### PR TITLE
chore: assert deserialized types are correct

### DIFF
--- a/clients/client-accessanalyzer/protocols/Aws_restJson1.ts
+++ b/clients/client-accessanalyzer/protocols/Aws_restJson1.ts
@@ -112,6 +112,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -1165,7 +1168,7 @@ export const deserializeAws_restJson1CreateAccessPreviewCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   return Promise.resolve(contents);
 };
@@ -1268,7 +1271,7 @@ export const deserializeAws_restJson1CreateAnalyzerCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   return Promise.resolve(contents);
 };
@@ -2150,7 +2153,7 @@ export const deserializeAws_restJson1ListAccessPreviewFindingsCommand = async (
     contents.findings = deserializeAws_restJson1AccessPreviewFindingsList(data.findings, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2249,7 +2252,7 @@ export const deserializeAws_restJson1ListAccessPreviewsCommand = async (
     contents.accessPreviews = deserializeAws_restJson1AccessPreviewsList(data.accessPreviews, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2340,7 +2343,7 @@ export const deserializeAws_restJson1ListAnalyzedResourcesCommand = async (
     contents.analyzedResources = deserializeAws_restJson1AnalyzedResourcesList(data.analyzedResources, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2431,7 +2434,7 @@ export const deserializeAws_restJson1ListAnalyzersCommand = async (
     contents.analyzers = deserializeAws_restJson1AnalyzersList(data.analyzers, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2514,7 +2517,7 @@ export const deserializeAws_restJson1ListArchiveRulesCommand = async (
     contents.archiveRules = deserializeAws_restJson1ArchiveRulesList(data.archiveRules, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2597,7 +2600,7 @@ export const deserializeAws_restJson1ListFindingsCommand = async (
     contents.findings = deserializeAws_restJson1FindingsList(data.findings, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2685,7 +2688,7 @@ export const deserializeAws_restJson1ListPolicyGenerationsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.policyGenerations !== undefined && data.policyGenerations !== null) {
     contents.policyGenerations = deserializeAws_restJson1PolicyGenerationList(data.policyGenerations, context);
@@ -2854,7 +2857,7 @@ export const deserializeAws_restJson1StartPolicyGenerationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.jobId !== undefined && data.jobId !== null) {
-    contents.jobId = data.jobId;
+    contents.jobId = __expectString(data.jobId);
   }
   return Promise.resolve(contents);
 };
@@ -3368,7 +3371,7 @@ export const deserializeAws_restJson1ValidatePolicyCommand = async (
     contents.findings = deserializeAws_restJson1ValidatePolicyFindingList(data.findings, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3446,7 +3449,7 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -3465,13 +3468,13 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.resourceId !== undefined && data.resourceId !== null) {
-    contents.resourceId = data.resourceId;
+    contents.resourceId = __expectString(data.resourceId);
   }
   if (data.resourceType !== undefined && data.resourceType !== null) {
-    contents.resourceType = data.resourceType;
+    contents.resourceType = __expectString(data.resourceType);
   }
   return contents;
 };
@@ -3493,7 +3496,7 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   }
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -3512,13 +3515,13 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.resourceId !== undefined && data.resourceId !== null) {
-    contents.resourceId = data.resourceId;
+    contents.resourceId = __expectString(data.resourceId);
   }
   if (data.resourceType !== undefined && data.resourceType !== null) {
-    contents.resourceType = data.resourceType;
+    contents.resourceType = __expectString(data.resourceType);
   }
   return contents;
 };
@@ -3537,13 +3540,13 @@ const deserializeAws_restJson1ServiceQuotaExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.resourceId !== undefined && data.resourceId !== null) {
-    contents.resourceId = data.resourceId;
+    contents.resourceId = __expectString(data.resourceId);
   }
   if (data.resourceType !== undefined && data.resourceType !== null) {
-    contents.resourceType = data.resourceType;
+    contents.resourceType = __expectString(data.resourceType);
   }
   return contents;
 };
@@ -3567,7 +3570,7 @@ const deserializeAws_restJson1ThrottlingExceptionResponse = async (
   }
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -3589,10 +3592,10 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
     contents.fieldList = deserializeAws_restJson1ValidationExceptionFieldList(data.fieldList, context);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.reason !== undefined && data.reason !== null) {
-    contents.reason = data.reason;
+    contents.reason = __expectString(data.reason);
   }
   return contents;
 };
@@ -4003,14 +4006,14 @@ const serializeAws_restJson1VpcConfiguration = (input: VpcConfiguration, context
 
 const deserializeAws_restJson1AccessPreview = (output: any, context: __SerdeContext): AccessPreview => {
   return {
-    analyzerArn: output.analyzerArn !== undefined && output.analyzerArn !== null ? output.analyzerArn : undefined,
+    analyzerArn: __expectString(output.analyzerArn),
     configurations:
       output.configurations !== undefined && output.configurations !== null
         ? deserializeAws_restJson1ConfigurationsMap(output.configurations, context)
         : undefined,
     createdAt: output.createdAt !== undefined && output.createdAt !== null ? new Date(output.createdAt) : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    id: __expectString(output.id),
+    status: __expectString(output.status),
     statusReason:
       output.statusReason !== undefined && output.statusReason !== null
         ? deserializeAws_restJson1AccessPreviewStatusReason(output.statusReason, context)
@@ -4024,38 +4027,29 @@ const deserializeAws_restJson1AccessPreviewFinding = (output: any, context: __Se
       output.action !== undefined && output.action !== null
         ? deserializeAws_restJson1ActionList(output.action, context)
         : undefined,
-    changeType: output.changeType !== undefined && output.changeType !== null ? output.changeType : undefined,
+    changeType: __expectString(output.changeType),
     condition:
       output.condition !== undefined && output.condition !== null
         ? deserializeAws_restJson1ConditionKeyMap(output.condition, context)
         : undefined,
     createdAt: output.createdAt !== undefined && output.createdAt !== null ? new Date(output.createdAt) : undefined,
-    error: output.error !== undefined && output.error !== null ? output.error : undefined,
-    existingFindingId:
-      output.existingFindingId !== undefined && output.existingFindingId !== null
-        ? output.existingFindingId
-        : undefined,
-    existingFindingStatus:
-      output.existingFindingStatus !== undefined && output.existingFindingStatus !== null
-        ? output.existingFindingStatus
-        : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    isPublic: output.isPublic !== undefined && output.isPublic !== null ? output.isPublic : undefined,
+    error: __expectString(output.error),
+    existingFindingId: __expectString(output.existingFindingId),
+    existingFindingStatus: __expectString(output.existingFindingStatus),
+    id: __expectString(output.id),
+    isPublic: __expectBoolean(output.isPublic),
     principal:
       output.principal !== undefined && output.principal !== null
         ? deserializeAws_restJson1PrincipalMap(output.principal, context)
         : undefined,
-    resource: output.resource !== undefined && output.resource !== null ? output.resource : undefined,
-    resourceOwnerAccount:
-      output.resourceOwnerAccount !== undefined && output.resourceOwnerAccount !== null
-        ? output.resourceOwnerAccount
-        : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
+    resource: __expectString(output.resource),
+    resourceOwnerAccount: __expectString(output.resourceOwnerAccount),
+    resourceType: __expectString(output.resourceType),
     sources:
       output.sources !== undefined && output.sources !== null
         ? deserializeAws_restJson1FindingSourceList(output.sources, context)
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -4089,16 +4083,16 @@ const deserializeAws_restJson1AccessPreviewStatusReason = (
   context: __SerdeContext
 ): AccessPreviewStatusReason => {
   return {
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
+    code: __expectString(output.code),
   } as any;
 };
 
 const deserializeAws_restJson1AccessPreviewSummary = (output: any, context: __SerdeContext): AccessPreviewSummary => {
   return {
-    analyzerArn: output.analyzerArn !== undefined && output.analyzerArn !== null ? output.analyzerArn : undefined,
+    analyzerArn: __expectString(output.analyzerArn),
     createdAt: output.createdAt !== undefined && output.createdAt !== null ? new Date(output.createdAt) : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    id: __expectString(output.id),
+    status: __expectString(output.status),
     statusReason:
       output.statusReason !== undefined && output.statusReason !== null
         ? deserializeAws_restJson1AccessPreviewStatusReason(output.statusReason, context)
@@ -4107,15 +4101,11 @@ const deserializeAws_restJson1AccessPreviewSummary = (output: any, context: __Se
 };
 
 const deserializeAws_restJson1AclGrantee = (output: any, context: __SerdeContext): AclGrantee => {
-  if (output.id !== undefined && output.id !== null) {
-    return {
-      id: output.id,
-    };
+  if (__expectString(output.id) !== undefined) {
+    return { id: __expectString(output.id) as any };
   }
-  if (output.uri !== undefined && output.uri !== null) {
-    return {
-      uri: output.uri,
-    };
+  if (__expectString(output.uri) !== undefined) {
+    return { uri: __expectString(output.uri) as any };
   }
   return { $unknown: Object.entries(output)[0] };
 };
@@ -4127,7 +4117,7 @@ const deserializeAws_restJson1ActionList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4139,19 +4129,16 @@ const deserializeAws_restJson1AnalyzedResource = (output: any, context: __SerdeC
         : undefined,
     analyzedAt: output.analyzedAt !== undefined && output.analyzedAt !== null ? new Date(output.analyzedAt) : undefined,
     createdAt: output.createdAt !== undefined && output.createdAt !== null ? new Date(output.createdAt) : undefined,
-    error: output.error !== undefined && output.error !== null ? output.error : undefined,
-    isPublic: output.isPublic !== undefined && output.isPublic !== null ? output.isPublic : undefined,
-    resourceArn: output.resourceArn !== undefined && output.resourceArn !== null ? output.resourceArn : undefined,
-    resourceOwnerAccount:
-      output.resourceOwnerAccount !== undefined && output.resourceOwnerAccount !== null
-        ? output.resourceOwnerAccount
-        : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
+    error: __expectString(output.error),
+    isPublic: __expectBoolean(output.isPublic),
+    resourceArn: __expectString(output.resourceArn),
+    resourceOwnerAccount: __expectString(output.resourceOwnerAccount),
+    resourceType: __expectString(output.resourceType),
     sharedVia:
       output.sharedVia !== undefined && output.sharedVia !== null
         ? deserializeAws_restJson1SharedViaList(output.sharedVia, context)
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
     updatedAt: output.updatedAt !== undefined && output.updatedAt !== null ? new Date(output.updatedAt) : undefined,
   } as any;
 };
@@ -4175,12 +4162,9 @@ const deserializeAws_restJson1AnalyzedResourceSummary = (
   context: __SerdeContext
 ): AnalyzedResourceSummary => {
   return {
-    resourceArn: output.resourceArn !== undefined && output.resourceArn !== null ? output.resourceArn : undefined,
-    resourceOwnerAccount:
-      output.resourceOwnerAccount !== undefined && output.resourceOwnerAccount !== null
-        ? output.resourceOwnerAccount
-        : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
+    resourceArn: __expectString(output.resourceArn),
+    resourceOwnerAccount: __expectString(output.resourceOwnerAccount),
+    resourceType: __expectString(output.resourceType),
   } as any;
 };
 
@@ -4197,18 +4181,15 @@ const deserializeAws_restJson1AnalyzersList = (output: any, context: __SerdeCont
 
 const deserializeAws_restJson1AnalyzerSummary = (output: any, context: __SerdeContext): AnalyzerSummary => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt: output.createdAt !== undefined && output.createdAt !== null ? new Date(output.createdAt) : undefined,
-    lastResourceAnalyzed:
-      output.lastResourceAnalyzed !== undefined && output.lastResourceAnalyzed !== null
-        ? output.lastResourceAnalyzed
-        : undefined,
+    lastResourceAnalyzed: __expectString(output.lastResourceAnalyzed),
     lastResourceAnalyzedAt:
       output.lastResourceAnalyzedAt !== undefined && output.lastResourceAnalyzedAt !== null
         ? new Date(output.lastResourceAnalyzedAt)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    name: __expectString(output.name),
+    status: __expectString(output.status),
     statusReason:
       output.statusReason !== undefined && output.statusReason !== null
         ? deserializeAws_restJson1StatusReason(output.statusReason, context)
@@ -4217,7 +4198,7 @@ const deserializeAws_restJson1AnalyzerSummary = (output: any, context: __SerdeCo
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1TagsMap(output.tags, context)
         : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -4239,7 +4220,7 @@ const deserializeAws_restJson1ArchiveRuleSummary = (output: any, context: __Serd
       output.filter !== undefined && output.filter !== null
         ? deserializeAws_restJson1FilterCriteriaMap(output.filter, context)
         : undefined,
-    ruleName: output.ruleName !== undefined && output.ruleName !== null ? output.ruleName : undefined,
+    ruleName: __expectString(output.ruleName),
     updatedAt: output.updatedAt !== undefined && output.updatedAt !== null ? new Date(output.updatedAt) : undefined,
   } as any;
 };
@@ -4262,7 +4243,7 @@ const deserializeAws_restJson1ConditionKeyMap = (output: any, context: __SerdeCo
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -4322,7 +4303,7 @@ const deserializeAws_restJson1Criterion = (output: any, context: __SerdeContext)
         : undefined,
     eq:
       output.eq !== undefined && output.eq !== null ? deserializeAws_restJson1ValueList(output.eq, context) : undefined,
-    exists: output.exists !== undefined && output.exists !== null ? output.exists : undefined,
+    exists: __expectBoolean(output.exists),
     neq:
       output.neq !== undefined && output.neq !== null
         ? deserializeAws_restJson1ValueList(output.neq, context)
@@ -4357,24 +4338,21 @@ const deserializeAws_restJson1Finding = (output: any, context: __SerdeContext): 
         ? deserializeAws_restJson1ConditionKeyMap(output.condition, context)
         : undefined,
     createdAt: output.createdAt !== undefined && output.createdAt !== null ? new Date(output.createdAt) : undefined,
-    error: output.error !== undefined && output.error !== null ? output.error : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    isPublic: output.isPublic !== undefined && output.isPublic !== null ? output.isPublic : undefined,
+    error: __expectString(output.error),
+    id: __expectString(output.id),
+    isPublic: __expectBoolean(output.isPublic),
     principal:
       output.principal !== undefined && output.principal !== null
         ? deserializeAws_restJson1PrincipalMap(output.principal, context)
         : undefined,
-    resource: output.resource !== undefined && output.resource !== null ? output.resource : undefined,
-    resourceOwnerAccount:
-      output.resourceOwnerAccount !== undefined && output.resourceOwnerAccount !== null
-        ? output.resourceOwnerAccount
-        : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
+    resource: __expectString(output.resource),
+    resourceOwnerAccount: __expectString(output.resourceOwnerAccount),
+    resourceType: __expectString(output.resourceType),
     sources:
       output.sources !== undefined && output.sources !== null
         ? deserializeAws_restJson1FindingSourceList(output.sources, context)
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
     updatedAt: output.updatedAt !== undefined && output.updatedAt !== null ? new Date(output.updatedAt) : undefined,
   } as any;
 };
@@ -4396,14 +4374,13 @@ const deserializeAws_restJson1FindingSource = (output: any, context: __SerdeCont
       output.detail !== undefined && output.detail !== null
         ? deserializeAws_restJson1FindingSourceDetail(output.detail, context)
         : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    type: __expectString(output.type),
   } as any;
 };
 
 const deserializeAws_restJson1FindingSourceDetail = (output: any, context: __SerdeContext): FindingSourceDetail => {
   return {
-    accessPointArn:
-      output.accessPointArn !== undefined && output.accessPointArn !== null ? output.accessPointArn : undefined,
+    accessPointArn: __expectString(output.accessPointArn),
   } as any;
 };
 
@@ -4430,31 +4407,28 @@ const deserializeAws_restJson1FindingSummary = (output: any, context: __SerdeCon
         ? deserializeAws_restJson1ConditionKeyMap(output.condition, context)
         : undefined,
     createdAt: output.createdAt !== undefined && output.createdAt !== null ? new Date(output.createdAt) : undefined,
-    error: output.error !== undefined && output.error !== null ? output.error : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    isPublic: output.isPublic !== undefined && output.isPublic !== null ? output.isPublic : undefined,
+    error: __expectString(output.error),
+    id: __expectString(output.id),
+    isPublic: __expectBoolean(output.isPublic),
     principal:
       output.principal !== undefined && output.principal !== null
         ? deserializeAws_restJson1PrincipalMap(output.principal, context)
         : undefined,
-    resource: output.resource !== undefined && output.resource !== null ? output.resource : undefined,
-    resourceOwnerAccount:
-      output.resourceOwnerAccount !== undefined && output.resourceOwnerAccount !== null
-        ? output.resourceOwnerAccount
-        : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
+    resource: __expectString(output.resource),
+    resourceOwnerAccount: __expectString(output.resourceOwnerAccount),
+    resourceType: __expectString(output.resourceType),
     sources:
       output.sources !== undefined && output.sources !== null
         ? deserializeAws_restJson1FindingSourceList(output.sources, context)
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
     updatedAt: output.updatedAt !== undefined && output.updatedAt !== null ? new Date(output.updatedAt) : undefined,
   } as any;
 };
 
 const deserializeAws_restJson1GeneratedPolicy = (output: any, context: __SerdeContext): GeneratedPolicy => {
   return {
-    policy: output.policy !== undefined && output.policy !== null ? output.policy : undefined,
+    policy: __expectString(output.policy),
   } as any;
 };
 
@@ -4478,8 +4452,8 @@ const deserializeAws_restJson1GeneratedPolicyProperties = (
       output.cloudTrailProperties !== undefined && output.cloudTrailProperties !== null
         ? deserializeAws_restJson1CloudTrailProperties(output.cloudTrailProperties, context)
         : undefined,
-    isComplete: output.isComplete !== undefined && output.isComplete !== null ? output.isComplete : undefined,
-    principalArn: output.principalArn !== undefined && output.principalArn !== null ? output.principalArn : undefined,
+    isComplete: __expectBoolean(output.isComplete),
+    principalArn: __expectString(output.principalArn),
   } as any;
 };
 
@@ -4498,7 +4472,7 @@ const deserializeAws_restJson1GeneratedPolicyResult = (output: any, context: __S
 
 const deserializeAws_restJson1IamRoleConfiguration = (output: any, context: __SerdeContext): IamRoleConfiguration => {
   return {
-    trustPolicy: output.trustPolicy !== undefined && output.trustPolicy !== null ? output.trustPolicy : undefined,
+    trustPolicy: __expectString(output.trustPolicy),
   } as any;
 };
 
@@ -4514,16 +4488,16 @@ const deserializeAws_restJson1JobDetails = (output: any, context: __SerdeContext
       output.jobError !== undefined && output.jobError !== null
         ? deserializeAws_restJson1JobError(output.jobError, context)
         : undefined,
-    jobId: output.jobId !== undefined && output.jobId !== null ? output.jobId : undefined,
+    jobId: __expectString(output.jobId),
     startedOn: output.startedOn !== undefined && output.startedOn !== null ? new Date(output.startedOn) : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
   } as any;
 };
 
 const deserializeAws_restJson1JobError = (output: any, context: __SerdeContext): JobError => {
   return {
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    code: __expectString(output.code),
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -4534,7 +4508,7 @@ const deserializeAws_restJson1KmsConstraintsMap = (output: any, context: __Serde
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -4545,18 +4519,13 @@ const deserializeAws_restJson1KmsGrantConfiguration = (output: any, context: __S
       output.constraints !== undefined && output.constraints !== null
         ? deserializeAws_restJson1KmsGrantConstraints(output.constraints, context)
         : undefined,
-    granteePrincipal:
-      output.granteePrincipal !== undefined && output.granteePrincipal !== null ? output.granteePrincipal : undefined,
-    issuingAccount:
-      output.issuingAccount !== undefined && output.issuingAccount !== null ? output.issuingAccount : undefined,
+    granteePrincipal: __expectString(output.granteePrincipal),
+    issuingAccount: __expectString(output.issuingAccount),
     operations:
       output.operations !== undefined && output.operations !== null
         ? deserializeAws_restJson1KmsGrantOperationsList(output.operations, context)
         : undefined,
-    retiringPrincipal:
-      output.retiringPrincipal !== undefined && output.retiringPrincipal !== null
-        ? output.retiringPrincipal
-        : undefined,
+    retiringPrincipal: __expectString(output.retiringPrincipal),
   } as any;
 };
 
@@ -4597,7 +4566,7 @@ const deserializeAws_restJson1KmsGrantOperationsList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4621,7 +4590,7 @@ const deserializeAws_restJson1KmsKeyPoliciesMap = (output: any, context: __Serde
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -4668,25 +4637,19 @@ const deserializeAws_restJson1NetworkOriginConfiguration = (
 };
 
 const deserializeAws_restJson1PathElement = (output: any, context: __SerdeContext): PathElement => {
-  if (output.index !== undefined && output.index !== null) {
-    return {
-      index: output.index,
-    };
+  if (__expectNumber(output.index) !== undefined) {
+    return { index: __expectNumber(output.index) as any };
   }
-  if (output.key !== undefined && output.key !== null) {
-    return {
-      key: output.key,
-    };
+  if (__expectString(output.key) !== undefined) {
+    return { key: __expectString(output.key) as any };
   }
   if (output.substring !== undefined && output.substring !== null) {
     return {
       substring: deserializeAws_restJson1Substring(output.substring, context),
     };
   }
-  if (output.value !== undefined && output.value !== null) {
-    return {
-      value: output.value,
-    };
+  if (__expectString(output.value) !== undefined) {
+    return { value: __expectString(output.value) as any };
   }
   return { $unknown: Object.entries(output)[0] };
 };
@@ -4706,10 +4669,10 @@ const deserializeAws_restJson1PolicyGeneration = (output: any, context: __SerdeC
   return {
     completedOn:
       output.completedOn !== undefined && output.completedOn !== null ? new Date(output.completedOn) : undefined,
-    jobId: output.jobId !== undefined && output.jobId !== null ? output.jobId : undefined,
-    principalArn: output.principalArn !== undefined && output.principalArn !== null ? output.principalArn : undefined,
+    jobId: __expectString(output.jobId),
+    principalArn: __expectString(output.principalArn),
     startedOn: output.startedOn !== undefined && output.startedOn !== null ? new Date(output.startedOn) : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -4726,9 +4689,9 @@ const deserializeAws_restJson1PolicyGenerationList = (output: any, context: __Se
 
 const deserializeAws_restJson1Position = (output: any, context: __SerdeContext): Position => {
   return {
-    column: output.column !== undefined && output.column !== null ? output.column : undefined,
-    line: output.line !== undefined && output.line !== null ? output.line : undefined,
-    offset: output.offset !== undefined && output.offset !== null ? output.offset : undefined,
+    column: __expectNumber(output.column),
+    line: __expectNumber(output.line),
+    offset: __expectNumber(output.offset),
   } as any;
 };
 
@@ -4739,7 +4702,7 @@ const deserializeAws_restJson1PrincipalMap = (output: any, context: __SerdeConte
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -4751,7 +4714,7 @@ const deserializeAws_restJson1RegionList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4760,10 +4723,7 @@ const deserializeAws_restJson1S3AccessPointConfiguration = (
   context: __SerdeContext
 ): S3AccessPointConfiguration => {
   return {
-    accessPointPolicy:
-      output.accessPointPolicy !== undefined && output.accessPointPolicy !== null
-        ? output.accessPointPolicy
-        : undefined,
+    accessPointPolicy: __expectString(output.accessPointPolicy),
     networkOrigin:
       output.networkOrigin !== undefined && output.networkOrigin !== null
         ? deserializeAws_restJson1NetworkOriginConfiguration(output.networkOrigin, context)
@@ -4802,7 +4762,7 @@ const deserializeAws_restJson1S3BucketAclGrantConfiguration = (
       output.grantee !== undefined && output.grantee !== null
         ? deserializeAws_restJson1AclGrantee(output.grantee, context)
         : undefined,
-    permission: output.permission !== undefined && output.permission !== null ? output.permission : undefined,
+    permission: __expectString(output.permission),
   } as any;
 };
 
@@ -4830,7 +4790,7 @@ const deserializeAws_restJson1S3BucketConfiguration = (output: any, context: __S
       output.bucketAclGrants !== undefined && output.bucketAclGrants !== null
         ? deserializeAws_restJson1S3BucketAclGrantConfigurationsList(output.bucketAclGrants, context)
         : undefined,
-    bucketPolicy: output.bucketPolicy !== undefined && output.bucketPolicy !== null ? output.bucketPolicy : undefined,
+    bucketPolicy: __expectString(output.bucketPolicy),
     bucketPublicAccessBlock:
       output.bucketPublicAccessBlock !== undefined && output.bucketPublicAccessBlock !== null
         ? deserializeAws_restJson1S3PublicAccessBlockConfiguration(output.bucketPublicAccessBlock, context)
@@ -4843,12 +4803,8 @@ const deserializeAws_restJson1S3PublicAccessBlockConfiguration = (
   context: __SerdeContext
 ): S3PublicAccessBlockConfiguration => {
   return {
-    ignorePublicAcls:
-      output.ignorePublicAcls !== undefined && output.ignorePublicAcls !== null ? output.ignorePublicAcls : undefined,
-    restrictPublicBuckets:
-      output.restrictPublicBuckets !== undefined && output.restrictPublicBuckets !== null
-        ? output.restrictPublicBuckets
-        : undefined,
+    ignorePublicAcls: __expectBoolean(output.ignorePublicAcls),
+    restrictPublicBuckets: __expectBoolean(output.restrictPublicBuckets),
   } as any;
 };
 
@@ -4857,8 +4813,8 @@ const deserializeAws_restJson1SecretsManagerSecretConfiguration = (
   context: __SerdeContext
 ): SecretsManagerSecretConfiguration => {
   return {
-    kmsKeyId: output.kmsKeyId !== undefined && output.kmsKeyId !== null ? output.kmsKeyId : undefined,
-    secretPolicy: output.secretPolicy !== undefined && output.secretPolicy !== null ? output.secretPolicy : undefined,
+    kmsKeyId: __expectString(output.kmsKeyId),
+    secretPolicy: __expectString(output.secretPolicy),
   } as any;
 };
 
@@ -4869,7 +4825,7 @@ const deserializeAws_restJson1SharedViaList = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4888,20 +4844,20 @@ const deserializeAws_restJson1Span = (output: any, context: __SerdeContext): Spa
 
 const deserializeAws_restJson1SqsQueueConfiguration = (output: any, context: __SerdeContext): SqsQueueConfiguration => {
   return {
-    queuePolicy: output.queuePolicy !== undefined && output.queuePolicy !== null ? output.queuePolicy : undefined,
+    queuePolicy: __expectString(output.queuePolicy),
   } as any;
 };
 
 const deserializeAws_restJson1StatusReason = (output: any, context: __SerdeContext): StatusReason => {
   return {
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
+    code: __expectString(output.code),
   } as any;
 };
 
 const deserializeAws_restJson1Substring = (output: any, context: __SerdeContext): Substring => {
   return {
-    length: output.length !== undefined && output.length !== null ? output.length : undefined,
-    start: output.start !== undefined && output.start !== null ? output.start : undefined,
+    length: __expectNumber(output.length),
+    start: __expectNumber(output.start),
   } as any;
 };
 
@@ -4912,16 +4868,15 @@ const deserializeAws_restJson1TagsMap = (output: any, context: __SerdeContext): 
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1TrailProperties = (output: any, context: __SerdeContext): TrailProperties => {
   return {
-    allRegions: output.allRegions !== undefined && output.allRegions !== null ? output.allRegions : undefined,
-    cloudTrailArn:
-      output.cloudTrailArn !== undefined && output.cloudTrailArn !== null ? output.cloudTrailArn : undefined,
+    allRegions: __expectBoolean(output.allRegions),
+    cloudTrailArn: __expectString(output.cloudTrailArn),
     regions:
       output.regions !== undefined && output.regions !== null
         ? deserializeAws_restJson1RegionList(output.regions, context)
@@ -4942,12 +4897,10 @@ const deserializeAws_restJson1TrailPropertiesList = (output: any, context: __Ser
 
 const deserializeAws_restJson1ValidatePolicyFinding = (output: any, context: __SerdeContext): ValidatePolicyFinding => {
   return {
-    findingDetails:
-      output.findingDetails !== undefined && output.findingDetails !== null ? output.findingDetails : undefined,
-    findingType: output.findingType !== undefined && output.findingType !== null ? output.findingType : undefined,
-    issueCode: output.issueCode !== undefined && output.issueCode !== null ? output.issueCode : undefined,
-    learnMoreLink:
-      output.learnMoreLink !== undefined && output.learnMoreLink !== null ? output.learnMoreLink : undefined,
+    findingDetails: __expectString(output.findingDetails),
+    findingType: __expectString(output.findingType),
+    issueCode: __expectString(output.issueCode),
+    learnMoreLink: __expectString(output.learnMoreLink),
     locations:
       output.locations !== undefined && output.locations !== null
         ? deserializeAws_restJson1LocationList(output.locations, context)
@@ -4974,8 +4927,8 @@ const deserializeAws_restJson1ValidationExceptionField = (
   context: __SerdeContext
 ): ValidationExceptionField => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    message: __expectString(output.message),
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -5000,13 +4953,13 @@ const deserializeAws_restJson1ValueList = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1VpcConfiguration = (output: any, context: __SerdeContext): VpcConfiguration => {
   return {
-    vpcId: output.vpcId !== undefined && output.vpcId !== null ? output.vpcId : undefined,
+    vpcId: __expectString(output.vpcId),
   } as any;
 };
 

--- a/clients/client-acm-pca/protocols/Aws_json1_1.ts
+++ b/clients/client-acm-pca/protocols/Aws_json1_1.ts
@@ -139,7 +139,12 @@ import {
   Validity,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -3224,12 +3229,8 @@ const deserializeAws_json1_1AccessDescriptionList = (output: any, context: __Ser
 
 const deserializeAws_json1_1AccessMethod = (output: any, context: __SerdeContext): AccessMethod => {
   return {
-    AccessMethodType:
-      output.AccessMethodType !== undefined && output.AccessMethodType !== null ? output.AccessMethodType : undefined,
-    CustomObjectIdentifier:
-      output.CustomObjectIdentifier !== undefined && output.CustomObjectIdentifier !== null
-        ? output.CustomObjectIdentifier
-        : undefined,
+    AccessMethodType: __expectString(output.AccessMethodType),
+    CustomObjectIdentifier: __expectString(output.CustomObjectIdentifier),
   } as any;
 };
 
@@ -3240,35 +3241,26 @@ const deserializeAws_json1_1ActionList = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1ASN1Subject = (output: any, context: __SerdeContext): ASN1Subject => {
   return {
-    CommonName: output.CommonName !== undefined && output.CommonName !== null ? output.CommonName : undefined,
-    Country: output.Country !== undefined && output.Country !== null ? output.Country : undefined,
-    DistinguishedNameQualifier:
-      output.DistinguishedNameQualifier !== undefined && output.DistinguishedNameQualifier !== null
-        ? output.DistinguishedNameQualifier
-        : undefined,
-    GenerationQualifier:
-      output.GenerationQualifier !== undefined && output.GenerationQualifier !== null
-        ? output.GenerationQualifier
-        : undefined,
-    GivenName: output.GivenName !== undefined && output.GivenName !== null ? output.GivenName : undefined,
-    Initials: output.Initials !== undefined && output.Initials !== null ? output.Initials : undefined,
-    Locality: output.Locality !== undefined && output.Locality !== null ? output.Locality : undefined,
-    Organization: output.Organization !== undefined && output.Organization !== null ? output.Organization : undefined,
-    OrganizationalUnit:
-      output.OrganizationalUnit !== undefined && output.OrganizationalUnit !== null
-        ? output.OrganizationalUnit
-        : undefined,
-    Pseudonym: output.Pseudonym !== undefined && output.Pseudonym !== null ? output.Pseudonym : undefined,
-    SerialNumber: output.SerialNumber !== undefined && output.SerialNumber !== null ? output.SerialNumber : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    Surname: output.Surname !== undefined && output.Surname !== null ? output.Surname : undefined,
-    Title: output.Title !== undefined && output.Title !== null ? output.Title : undefined,
+    CommonName: __expectString(output.CommonName),
+    Country: __expectString(output.Country),
+    DistinguishedNameQualifier: __expectString(output.DistinguishedNameQualifier),
+    GenerationQualifier: __expectString(output.GenerationQualifier),
+    GivenName: __expectString(output.GivenName),
+    Initials: __expectString(output.Initials),
+    Locality: __expectString(output.Locality),
+    Organization: __expectString(output.Organization),
+    OrganizationalUnit: __expectString(output.OrganizationalUnit),
+    Pseudonym: __expectString(output.Pseudonym),
+    SerialNumber: __expectString(output.SerialNumber),
+    State: __expectString(output.State),
+    Surname: __expectString(output.Surname),
+    Title: __expectString(output.Title),
   } as any;
 };
 
@@ -3285,7 +3277,7 @@ const deserializeAws_json1_1CertificateAuthorities = (output: any, context: __Se
 
 const deserializeAws_json1_1CertificateAuthority = (output: any, context: __SerdeContext): CertificateAuthority => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     CertificateAuthorityConfiguration:
       output.CertificateAuthorityConfiguration !== undefined && output.CertificateAuthorityConfiguration !== null
         ? deserializeAws_json1_1CertificateAuthorityConfiguration(output.CertificateAuthorityConfiguration, context)
@@ -3294,12 +3286,8 @@ const deserializeAws_json1_1CertificateAuthority = (output: any, context: __Serd
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
-    KeyStorageSecurityStandard:
-      output.KeyStorageSecurityStandard !== undefined && output.KeyStorageSecurityStandard !== null
-        ? output.KeyStorageSecurityStandard
-        : undefined,
+    FailureReason: __expectString(output.FailureReason),
+    KeyStorageSecurityStandard: __expectString(output.KeyStorageSecurityStandard),
     LastStateChangeAt:
       output.LastStateChangeAt !== undefined && output.LastStateChangeAt !== null
         ? new Date(Math.round(output.LastStateChangeAt * 1000))
@@ -3312,7 +3300,7 @@ const deserializeAws_json1_1CertificateAuthority = (output: any, context: __Serd
       output.NotBefore !== undefined && output.NotBefore !== null
         ? new Date(Math.round(output.NotBefore * 1000))
         : undefined,
-    OwnerAccount: output.OwnerAccount !== undefined && output.OwnerAccount !== null ? output.OwnerAccount : undefined,
+    OwnerAccount: __expectString(output.OwnerAccount),
     RestorableUntil:
       output.RestorableUntil !== undefined && output.RestorableUntil !== null
         ? new Date(Math.round(output.RestorableUntil * 1000))
@@ -3321,9 +3309,9 @@ const deserializeAws_json1_1CertificateAuthority = (output: any, context: __Serd
       output.RevocationConfiguration !== undefined && output.RevocationConfiguration !== null
         ? deserializeAws_json1_1RevocationConfiguration(output.RevocationConfiguration, context)
         : undefined,
-    Serial: output.Serial !== undefined && output.Serial !== null ? output.Serial : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Serial: __expectString(output.Serial),
+    Status: __expectString(output.Status),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -3336,9 +3324,8 @@ const deserializeAws_json1_1CertificateAuthorityConfiguration = (
       output.CsrExtensions !== undefined && output.CsrExtensions !== null
         ? deserializeAws_json1_1CsrExtensions(output.CsrExtensions, context)
         : undefined,
-    KeyAlgorithm: output.KeyAlgorithm !== undefined && output.KeyAlgorithm !== null ? output.KeyAlgorithm : undefined,
-    SigningAlgorithm:
-      output.SigningAlgorithm !== undefined && output.SigningAlgorithm !== null ? output.SigningAlgorithm : undefined,
+    KeyAlgorithm: __expectString(output.KeyAlgorithm),
+    SigningAlgorithm: __expectString(output.SigningAlgorithm),
     Subject:
       output.Subject !== undefined && output.Subject !== null
         ? deserializeAws_json1_1ASN1Subject(output.Subject, context)
@@ -3351,7 +3338,7 @@ const deserializeAws_json1_1CertificateMismatchException = (
   context: __SerdeContext
 ): CertificateMismatchException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3360,7 +3347,7 @@ const deserializeAws_json1_1ConcurrentModificationException = (
   context: __SerdeContext
 ): ConcurrentModificationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3369,9 +3356,8 @@ const deserializeAws_json1_1CreateCertificateAuthorityAuditReportResponse = (
   context: __SerdeContext
 ): CreateCertificateAuthorityAuditReportResponse => {
   return {
-    AuditReportId:
-      output.AuditReportId !== undefined && output.AuditReportId !== null ? output.AuditReportId : undefined,
-    S3Key: output.S3Key !== undefined && output.S3Key !== null ? output.S3Key : undefined,
+    AuditReportId: __expectString(output.AuditReportId),
+    S3Key: __expectString(output.S3Key),
   } as any;
 };
 
@@ -3380,21 +3366,17 @@ const deserializeAws_json1_1CreateCertificateAuthorityResponse = (
   context: __SerdeContext
 ): CreateCertificateAuthorityResponse => {
   return {
-    CertificateAuthorityArn:
-      output.CertificateAuthorityArn !== undefined && output.CertificateAuthorityArn !== null
-        ? output.CertificateAuthorityArn
-        : undefined,
+    CertificateAuthorityArn: __expectString(output.CertificateAuthorityArn),
   } as any;
 };
 
 const deserializeAws_json1_1CrlConfiguration = (output: any, context: __SerdeContext): CrlConfiguration => {
   return {
-    CustomCname: output.CustomCname !== undefined && output.CustomCname !== null ? output.CustomCname : undefined,
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
-    ExpirationInDays:
-      output.ExpirationInDays !== undefined && output.ExpirationInDays !== null ? output.ExpirationInDays : undefined,
-    S3BucketName: output.S3BucketName !== undefined && output.S3BucketName !== null ? output.S3BucketName : undefined,
-    S3ObjectAcl: output.S3ObjectAcl !== undefined && output.S3ObjectAcl !== null ? output.S3ObjectAcl : undefined,
+    CustomCname: __expectString(output.CustomCname),
+    Enabled: __expectBoolean(output.Enabled),
+    ExpirationInDays: __expectNumber(output.ExpirationInDays),
+    S3BucketName: __expectString(output.S3BucketName),
+    S3ObjectAcl: __expectString(output.S3ObjectAcl),
   } as any;
 };
 
@@ -3416,16 +3398,13 @@ const deserializeAws_json1_1DescribeCertificateAuthorityAuditReportResponse = (
   context: __SerdeContext
 ): DescribeCertificateAuthorityAuditReportResponse => {
   return {
-    AuditReportStatus:
-      output.AuditReportStatus !== undefined && output.AuditReportStatus !== null
-        ? output.AuditReportStatus
-        : undefined,
+    AuditReportStatus: __expectString(output.AuditReportStatus),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    S3BucketName: output.S3BucketName !== undefined && output.S3BucketName !== null ? output.S3BucketName : undefined,
-    S3Key: output.S3Key !== undefined && output.S3Key !== null ? output.S3Key : undefined,
+    S3BucketName: __expectString(output.S3BucketName),
+    S3Key: __expectString(output.S3Key),
   } as any;
 };
 
@@ -3443,8 +3422,8 @@ const deserializeAws_json1_1DescribeCertificateAuthorityResponse = (
 
 const deserializeAws_json1_1EdiPartyName = (output: any, context: __SerdeContext): EdiPartyName => {
   return {
-    NameAssigner: output.NameAssigner !== undefined && output.NameAssigner !== null ? output.NameAssigner : undefined,
-    PartyName: output.PartyName !== undefined && output.PartyName !== null ? output.PartyName : undefined,
+    NameAssigner: __expectString(output.NameAssigner),
+    PartyName: __expectString(output.PartyName),
   } as any;
 };
 
@@ -3454,22 +3433,19 @@ const deserializeAws_json1_1GeneralName = (output: any, context: __SerdeContext)
       output.DirectoryName !== undefined && output.DirectoryName !== null
         ? deserializeAws_json1_1ASN1Subject(output.DirectoryName, context)
         : undefined,
-    DnsName: output.DnsName !== undefined && output.DnsName !== null ? output.DnsName : undefined,
+    DnsName: __expectString(output.DnsName),
     EdiPartyName:
       output.EdiPartyName !== undefined && output.EdiPartyName !== null
         ? deserializeAws_json1_1EdiPartyName(output.EdiPartyName, context)
         : undefined,
-    IpAddress: output.IpAddress !== undefined && output.IpAddress !== null ? output.IpAddress : undefined,
+    IpAddress: __expectString(output.IpAddress),
     OtherName:
       output.OtherName !== undefined && output.OtherName !== null
         ? deserializeAws_json1_1OtherName(output.OtherName, context)
         : undefined,
-    RegisteredId: output.RegisteredId !== undefined && output.RegisteredId !== null ? output.RegisteredId : undefined,
-    Rfc822Name: output.Rfc822Name !== undefined && output.Rfc822Name !== null ? output.Rfc822Name : undefined,
-    UniformResourceIdentifier:
-      output.UniformResourceIdentifier !== undefined && output.UniformResourceIdentifier !== null
-        ? output.UniformResourceIdentifier
-        : undefined,
+    RegisteredId: __expectString(output.RegisteredId),
+    Rfc822Name: __expectString(output.Rfc822Name),
+    UniformResourceIdentifier: __expectString(output.UniformResourceIdentifier),
   } as any;
 };
 
@@ -3478,9 +3454,8 @@ const deserializeAws_json1_1GetCertificateAuthorityCertificateResponse = (
   context: __SerdeContext
 ): GetCertificateAuthorityCertificateResponse => {
   return {
-    Certificate: output.Certificate !== undefined && output.Certificate !== null ? output.Certificate : undefined,
-    CertificateChain:
-      output.CertificateChain !== undefined && output.CertificateChain !== null ? output.CertificateChain : undefined,
+    Certificate: __expectString(output.Certificate),
+    CertificateChain: __expectString(output.CertificateChain),
   } as any;
 };
 
@@ -3489,33 +3464,32 @@ const deserializeAws_json1_1GetCertificateAuthorityCsrResponse = (
   context: __SerdeContext
 ): GetCertificateAuthorityCsrResponse => {
   return {
-    Csr: output.Csr !== undefined && output.Csr !== null ? output.Csr : undefined,
+    Csr: __expectString(output.Csr),
   } as any;
 };
 
 const deserializeAws_json1_1GetCertificateResponse = (output: any, context: __SerdeContext): GetCertificateResponse => {
   return {
-    Certificate: output.Certificate !== undefined && output.Certificate !== null ? output.Certificate : undefined,
-    CertificateChain:
-      output.CertificateChain !== undefined && output.CertificateChain !== null ? output.CertificateChain : undefined,
+    Certificate: __expectString(output.Certificate),
+    CertificateChain: __expectString(output.CertificateChain),
   } as any;
 };
 
 const deserializeAws_json1_1GetPolicyResponse = (output: any, context: __SerdeContext): GetPolicyResponse => {
   return {
-    Policy: output.Policy !== undefined && output.Policy !== null ? output.Policy : undefined,
+    Policy: __expectString(output.Policy),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidArgsException = (output: any, context: __SerdeContext): InvalidArgsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidArnException = (output: any, context: __SerdeContext): InvalidArnException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3524,13 +3498,13 @@ const deserializeAws_json1_1InvalidNextTokenException = (
   context: __SerdeContext
 ): InvalidNextTokenException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidPolicyException = (output: any, context: __SerdeContext): InvalidPolicyException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3539,19 +3513,19 @@ const deserializeAws_json1_1InvalidRequestException = (
   context: __SerdeContext
 ): InvalidRequestException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidStateException = (output: any, context: __SerdeContext): InvalidStateException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidTagException = (output: any, context: __SerdeContext): InvalidTagException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3560,32 +3534,27 @@ const deserializeAws_json1_1IssueCertificateResponse = (
   context: __SerdeContext
 ): IssueCertificateResponse => {
   return {
-    CertificateArn:
-      output.CertificateArn !== undefined && output.CertificateArn !== null ? output.CertificateArn : undefined,
+    CertificateArn: __expectString(output.CertificateArn),
   } as any;
 };
 
 const deserializeAws_json1_1KeyUsage = (output: any, context: __SerdeContext): KeyUsage => {
   return {
-    CRLSign: output.CRLSign !== undefined && output.CRLSign !== null ? output.CRLSign : undefined,
-    DataEncipherment:
-      output.DataEncipherment !== undefined && output.DataEncipherment !== null ? output.DataEncipherment : undefined,
-    DecipherOnly: output.DecipherOnly !== undefined && output.DecipherOnly !== null ? output.DecipherOnly : undefined,
-    DigitalSignature:
-      output.DigitalSignature !== undefined && output.DigitalSignature !== null ? output.DigitalSignature : undefined,
-    EncipherOnly: output.EncipherOnly !== undefined && output.EncipherOnly !== null ? output.EncipherOnly : undefined,
-    KeyAgreement: output.KeyAgreement !== undefined && output.KeyAgreement !== null ? output.KeyAgreement : undefined,
-    KeyCertSign: output.KeyCertSign !== undefined && output.KeyCertSign !== null ? output.KeyCertSign : undefined,
-    KeyEncipherment:
-      output.KeyEncipherment !== undefined && output.KeyEncipherment !== null ? output.KeyEncipherment : undefined,
-    NonRepudiation:
-      output.NonRepudiation !== undefined && output.NonRepudiation !== null ? output.NonRepudiation : undefined,
+    CRLSign: __expectBoolean(output.CRLSign),
+    DataEncipherment: __expectBoolean(output.DataEncipherment),
+    DecipherOnly: __expectBoolean(output.DecipherOnly),
+    DigitalSignature: __expectBoolean(output.DigitalSignature),
+    EncipherOnly: __expectBoolean(output.EncipherOnly),
+    KeyAgreement: __expectBoolean(output.KeyAgreement),
+    KeyCertSign: __expectBoolean(output.KeyCertSign),
+    KeyEncipherment: __expectBoolean(output.KeyEncipherment),
+    NonRepudiation: __expectBoolean(output.NonRepudiation),
   } as any;
 };
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3598,7 +3567,7 @@ const deserializeAws_json1_1ListCertificateAuthoritiesResponse = (
       output.CertificateAuthorities !== undefined && output.CertificateAuthorities !== null
         ? deserializeAws_json1_1CertificateAuthorities(output.CertificateAuthorities, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -3607,7 +3576,7 @@ const deserializeAws_json1_1ListPermissionsResponse = (
   context: __SerdeContext
 ): ListPermissionsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Permissions:
       output.Permissions !== undefined && output.Permissions !== null
         ? deserializeAws_json1_1PermissionList(output.Permissions, context)
@@ -3617,7 +3586,7 @@ const deserializeAws_json1_1ListPermissionsResponse = (
 
 const deserializeAws_json1_1ListTagsResponse = (output: any, context: __SerdeContext): ListTagsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_1TagList(output.Tags, context)
@@ -3630,7 +3599,7 @@ const deserializeAws_json1_1LockoutPreventedException = (
   context: __SerdeContext
 ): LockoutPreventedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3639,20 +3608,20 @@ const deserializeAws_json1_1MalformedCertificateException = (
   context: __SerdeContext
 ): MalformedCertificateException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1MalformedCSRException = (output: any, context: __SerdeContext): MalformedCSRException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1OtherName = (output: any, context: __SerdeContext): OtherName => {
   return {
-    TypeId: output.TypeId !== undefined && output.TypeId !== null ? output.TypeId : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    TypeId: __expectString(output.TypeId),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -3662,18 +3631,14 @@ const deserializeAws_json1_1Permission = (output: any, context: __SerdeContext):
       output.Actions !== undefined && output.Actions !== null
         ? deserializeAws_json1_1ActionList(output.Actions, context)
         : undefined,
-    CertificateAuthorityArn:
-      output.CertificateAuthorityArn !== undefined && output.CertificateAuthorityArn !== null
-        ? output.CertificateAuthorityArn
-        : undefined,
+    CertificateAuthorityArn: __expectString(output.CertificateAuthorityArn),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    Policy: output.Policy !== undefined && output.Policy !== null ? output.Policy : undefined,
-    Principal: output.Principal !== undefined && output.Principal !== null ? output.Principal : undefined,
-    SourceAccount:
-      output.SourceAccount !== undefined && output.SourceAccount !== null ? output.SourceAccount : undefined,
+    Policy: __expectString(output.Policy),
+    Principal: __expectString(output.Principal),
+    SourceAccount: __expectString(output.SourceAccount),
   } as any;
 };
 
@@ -3682,7 +3647,7 @@ const deserializeAws_json1_1PermissionAlreadyExistsException = (
   context: __SerdeContext
 ): PermissionAlreadyExistsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3702,13 +3667,13 @@ const deserializeAws_json1_1RequestAlreadyProcessedException = (
   context: __SerdeContext
 ): RequestAlreadyProcessedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1RequestFailedException = (output: any, context: __SerdeContext): RequestFailedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3717,7 +3682,7 @@ const deserializeAws_json1_1RequestInProgressException = (
   context: __SerdeContext
 ): RequestInProgressException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3726,7 +3691,7 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3744,8 +3709,8 @@ const deserializeAws_json1_1RevocationConfiguration = (
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -3762,7 +3727,7 @@ const deserializeAws_json1_1TagList = (output: any, context: __SerdeContext): Ta
 
 const deserializeAws_json1_1TooManyTagsException = (output: any, context: __SerdeContext): TooManyTagsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 

--- a/clients/client-acm/protocols/Aws_json1_1.ts
+++ b/clients/client-acm/protocols/Aws_json1_1.ts
@@ -94,7 +94,11 @@ import {
   ValidationException,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -1970,23 +1974,19 @@ const serializeAws_json1_1UpdateCertificateOptionsRequest = (
 
 const deserializeAws_json1_1AccessDeniedException = (output: any, context: __SerdeContext): AccessDeniedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1CertificateDetail = (output: any, context: __SerdeContext): CertificateDetail => {
   return {
-    CertificateArn:
-      output.CertificateArn !== undefined && output.CertificateArn !== null ? output.CertificateArn : undefined,
-    CertificateAuthorityArn:
-      output.CertificateAuthorityArn !== undefined && output.CertificateAuthorityArn !== null
-        ? output.CertificateAuthorityArn
-        : undefined,
+    CertificateArn: __expectString(output.CertificateArn),
+    CertificateAuthorityArn: __expectString(output.CertificateAuthorityArn),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    DomainName: output.DomainName !== undefined && output.DomainName !== null ? output.DomainName : undefined,
+    DomainName: __expectString(output.DomainName),
     DomainValidationOptions:
       output.DomainValidationOptions !== undefined && output.DomainValidationOptions !== null
         ? deserializeAws_json1_1DomainValidationList(output.DomainValidationOptions, context)
@@ -1995,8 +1995,7 @@ const deserializeAws_json1_1CertificateDetail = (output: any, context: __SerdeCo
       output.ExtendedKeyUsages !== undefined && output.ExtendedKeyUsages !== null
         ? deserializeAws_json1_1ExtendedKeyUsageList(output.ExtendedKeyUsages, context)
         : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
+    FailureReason: __expectString(output.FailureReason),
     ImportedAt:
       output.ImportedAt !== undefined && output.ImportedAt !== null
         ? new Date(Math.round(output.ImportedAt * 1000))
@@ -2009,8 +2008,8 @@ const deserializeAws_json1_1CertificateDetail = (output: any, context: __SerdeCo
       output.IssuedAt !== undefined && output.IssuedAt !== null
         ? new Date(Math.round(output.IssuedAt * 1000))
         : undefined,
-    Issuer: output.Issuer !== undefined && output.Issuer !== null ? output.Issuer : undefined,
-    KeyAlgorithm: output.KeyAlgorithm !== undefined && output.KeyAlgorithm !== null ? output.KeyAlgorithm : undefined,
+    Issuer: __expectString(output.Issuer),
+    KeyAlgorithm: __expectString(output.KeyAlgorithm),
     KeyUsages:
       output.KeyUsages !== undefined && output.KeyUsages !== null
         ? deserializeAws_json1_1KeyUsageList(output.KeyUsages, context)
@@ -2027,50 +2026,38 @@ const deserializeAws_json1_1CertificateDetail = (output: any, context: __SerdeCo
       output.Options !== undefined && output.Options !== null
         ? deserializeAws_json1_1CertificateOptions(output.Options, context)
         : undefined,
-    RenewalEligibility:
-      output.RenewalEligibility !== undefined && output.RenewalEligibility !== null
-        ? output.RenewalEligibility
-        : undefined,
+    RenewalEligibility: __expectString(output.RenewalEligibility),
     RenewalSummary:
       output.RenewalSummary !== undefined && output.RenewalSummary !== null
         ? deserializeAws_json1_1RenewalSummary(output.RenewalSummary, context)
         : undefined,
-    RevocationReason:
-      output.RevocationReason !== undefined && output.RevocationReason !== null ? output.RevocationReason : undefined,
+    RevocationReason: __expectString(output.RevocationReason),
     RevokedAt:
       output.RevokedAt !== undefined && output.RevokedAt !== null
         ? new Date(Math.round(output.RevokedAt * 1000))
         : undefined,
-    Serial: output.Serial !== undefined && output.Serial !== null ? output.Serial : undefined,
-    SignatureAlgorithm:
-      output.SignatureAlgorithm !== undefined && output.SignatureAlgorithm !== null
-        ? output.SignatureAlgorithm
-        : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    Subject: output.Subject !== undefined && output.Subject !== null ? output.Subject : undefined,
+    Serial: __expectString(output.Serial),
+    SignatureAlgorithm: __expectString(output.SignatureAlgorithm),
+    Status: __expectString(output.Status),
+    Subject: __expectString(output.Subject),
     SubjectAlternativeNames:
       output.SubjectAlternativeNames !== undefined && output.SubjectAlternativeNames !== null
         ? deserializeAws_json1_1DomainList(output.SubjectAlternativeNames, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
 const deserializeAws_json1_1CertificateOptions = (output: any, context: __SerdeContext): CertificateOptions => {
   return {
-    CertificateTransparencyLoggingPreference:
-      output.CertificateTransparencyLoggingPreference !== undefined &&
-      output.CertificateTransparencyLoggingPreference !== null
-        ? output.CertificateTransparencyLoggingPreference
-        : undefined,
+    CertificateTransparencyLoggingPreference: __expectString(output.CertificateTransparencyLoggingPreference),
   } as any;
 };
 
 const deserializeAws_json1_1CertificateSummary = (output: any, context: __SerdeContext): CertificateSummary => {
   return {
-    CertificateArn:
-      output.CertificateArn !== undefined && output.CertificateArn !== null ? output.CertificateArn : undefined,
-    DomainName: output.DomainName !== undefined && output.DomainName !== null ? output.DomainName : undefined,
+    CertificateArn: __expectString(output.CertificateArn),
+    DomainName: __expectString(output.DomainName),
   } as any;
 };
 
@@ -2087,7 +2074,7 @@ const deserializeAws_json1_1CertificateSummaryList = (output: any, context: __Se
 
 const deserializeAws_json1_1ConflictException = (output: any, context: __SerdeContext): ConflictException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -2110,27 +2097,24 @@ const deserializeAws_json1_1DomainList = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1DomainValidation = (output: any, context: __SerdeContext): DomainValidation => {
   return {
-    DomainName: output.DomainName !== undefined && output.DomainName !== null ? output.DomainName : undefined,
+    DomainName: __expectString(output.DomainName),
     ResourceRecord:
       output.ResourceRecord !== undefined && output.ResourceRecord !== null
         ? deserializeAws_json1_1ResourceRecord(output.ResourceRecord, context)
         : undefined,
-    ValidationDomain:
-      output.ValidationDomain !== undefined && output.ValidationDomain !== null ? output.ValidationDomain : undefined,
+    ValidationDomain: __expectString(output.ValidationDomain),
     ValidationEmails:
       output.ValidationEmails !== undefined && output.ValidationEmails !== null
         ? deserializeAws_json1_1ValidationEmailList(output.ValidationEmails, context)
         : undefined,
-    ValidationMethod:
-      output.ValidationMethod !== undefined && output.ValidationMethod !== null ? output.ValidationMethod : undefined,
-    ValidationStatus:
-      output.ValidationStatus !== undefined && output.ValidationStatus !== null ? output.ValidationStatus : undefined,
+    ValidationMethod: __expectString(output.ValidationMethod),
+    ValidationStatus: __expectString(output.ValidationStatus),
   } as any;
 };
 
@@ -2150,8 +2134,7 @@ const deserializeAws_json1_1ExpiryEventsConfiguration = (
   context: __SerdeContext
 ): ExpiryEventsConfiguration => {
   return {
-    DaysBeforeExpiry:
-      output.DaysBeforeExpiry !== undefined && output.DaysBeforeExpiry !== null ? output.DaysBeforeExpiry : undefined,
+    DaysBeforeExpiry: __expectNumber(output.DaysBeforeExpiry),
   } as any;
 };
 
@@ -2160,17 +2143,16 @@ const deserializeAws_json1_1ExportCertificateResponse = (
   context: __SerdeContext
 ): ExportCertificateResponse => {
   return {
-    Certificate: output.Certificate !== undefined && output.Certificate !== null ? output.Certificate : undefined,
-    CertificateChain:
-      output.CertificateChain !== undefined && output.CertificateChain !== null ? output.CertificateChain : undefined,
-    PrivateKey: output.PrivateKey !== undefined && output.PrivateKey !== null ? output.PrivateKey : undefined,
+    Certificate: __expectString(output.Certificate),
+    CertificateChain: __expectString(output.CertificateChain),
+    PrivateKey: __expectString(output.PrivateKey),
   } as any;
 };
 
 const deserializeAws_json1_1ExtendedKeyUsage = (output: any, context: __SerdeContext): ExtendedKeyUsage => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    OID: output.OID !== undefined && output.OID !== null ? output.OID : undefined,
+    Name: __expectString(output.Name),
+    OID: __expectString(output.OID),
   } as any;
 };
 
@@ -2199,9 +2181,8 @@ const deserializeAws_json1_1GetAccountConfigurationResponse = (
 
 const deserializeAws_json1_1GetCertificateResponse = (output: any, context: __SerdeContext): GetCertificateResponse => {
   return {
-    Certificate: output.Certificate !== undefined && output.Certificate !== null ? output.Certificate : undefined,
-    CertificateChain:
-      output.CertificateChain !== undefined && output.CertificateChain !== null ? output.CertificateChain : undefined,
+    Certificate: __expectString(output.Certificate),
+    CertificateChain: __expectString(output.CertificateChain),
   } as any;
 };
 
@@ -2210,8 +2191,7 @@ const deserializeAws_json1_1ImportCertificateResponse = (
   context: __SerdeContext
 ): ImportCertificateResponse => {
   return {
-    CertificateArn:
-      output.CertificateArn !== undefined && output.CertificateArn !== null ? output.CertificateArn : undefined,
+    CertificateArn: __expectString(output.CertificateArn),
   } as any;
 };
 
@@ -2222,19 +2202,19 @@ const deserializeAws_json1_1InUseList = (output: any, context: __SerdeContext): 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1InvalidArgsException = (output: any, context: __SerdeContext): InvalidArgsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidArnException = (output: any, context: __SerdeContext): InvalidArnException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -2243,7 +2223,7 @@ const deserializeAws_json1_1InvalidDomainValidationOptionsException = (
   context: __SerdeContext
 ): InvalidDomainValidationOptionsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -2252,25 +2232,25 @@ const deserializeAws_json1_1InvalidParameterException = (
   context: __SerdeContext
 ): InvalidParameterException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidStateException = (output: any, context: __SerdeContext): InvalidStateException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidTagException = (output: any, context: __SerdeContext): InvalidTagException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1KeyUsage = (output: any, context: __SerdeContext): KeyUsage => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -2287,7 +2267,7 @@ const deserializeAws_json1_1KeyUsageList = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -2300,7 +2280,7 @@ const deserializeAws_json1_1ListCertificatesResponse = (
       output.CertificateSummaryList !== undefined && output.CertificateSummaryList !== null
         ? deserializeAws_json1_1CertificateSummaryList(output.CertificateSummaryList, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -2322,12 +2302,8 @@ const deserializeAws_json1_1RenewalSummary = (output: any, context: __SerdeConte
       output.DomainValidationOptions !== undefined && output.DomainValidationOptions !== null
         ? deserializeAws_json1_1DomainValidationList(output.DomainValidationOptions, context)
         : undefined,
-    RenewalStatus:
-      output.RenewalStatus !== undefined && output.RenewalStatus !== null ? output.RenewalStatus : undefined,
-    RenewalStatusReason:
-      output.RenewalStatusReason !== undefined && output.RenewalStatusReason !== null
-        ? output.RenewalStatusReason
-        : undefined,
+    RenewalStatus: __expectString(output.RenewalStatus),
+    RenewalStatusReason: __expectString(output.RenewalStatusReason),
     UpdatedAt:
       output.UpdatedAt !== undefined && output.UpdatedAt !== null
         ? new Date(Math.round(output.UpdatedAt * 1000))
@@ -2340,8 +2316,7 @@ const deserializeAws_json1_1RequestCertificateResponse = (
   context: __SerdeContext
 ): RequestCertificateResponse => {
   return {
-    CertificateArn:
-      output.CertificateArn !== undefined && output.CertificateArn !== null ? output.CertificateArn : undefined,
+    CertificateArn: __expectString(output.CertificateArn),
   } as any;
 };
 
@@ -2350,13 +2325,13 @@ const deserializeAws_json1_1RequestInProgressException = (
   context: __SerdeContext
 ): RequestInProgressException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1ResourceInUseException = (output: any, context: __SerdeContext): ResourceInUseException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -2365,22 +2340,22 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1ResourceRecord = (output: any, context: __SerdeContext): ResourceRecord => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Name: __expectString(output.Name),
+    Type: __expectString(output.Type),
+    Value: __expectString(output.Value),
   } as any;
 };
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -2397,19 +2372,19 @@ const deserializeAws_json1_1TagList = (output: any, context: __SerdeContext): Ta
 
 const deserializeAws_json1_1TagPolicyException = (output: any, context: __SerdeContext): TagPolicyException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1ThrottlingException = (output: any, context: __SerdeContext): ThrottlingException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1TooManyTagsException = (output: any, context: __SerdeContext): TooManyTagsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -2420,13 +2395,13 @@ const deserializeAws_json1_1ValidationEmailList = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1ValidationException = (output: any, context: __SerdeContext): ValidationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 

--- a/clients/client-alexa-for-business/protocols/Aws_json1_1.ts
+++ b/clients/client-alexa-for-business/protocols/Aws_json1_1.ts
@@ -474,7 +474,12 @@ import {
   UserData,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -8772,19 +8777,17 @@ const serializeAws_json1_1UpdateSkillGroupRequest = (input: UpdateSkillGroupRequ
 
 const deserializeAws_json1_1AddressBook = (output: any, context: __SerdeContext): AddressBook => {
   return {
-    AddressBookArn:
-      output.AddressBookArn !== undefined && output.AddressBookArn !== null ? output.AddressBookArn : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    AddressBookArn: __expectString(output.AddressBookArn),
+    Description: __expectString(output.Description),
+    Name: __expectString(output.Name),
   } as any;
 };
 
 const deserializeAws_json1_1AddressBookData = (output: any, context: __SerdeContext): AddressBookData => {
   return {
-    AddressBookArn:
-      output.AddressBookArn !== undefined && output.AddressBookArn !== null ? output.AddressBookArn : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    AddressBookArn: __expectString(output.AddressBookArn),
+    Description: __expectString(output.Description),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -8801,7 +8804,7 @@ const deserializeAws_json1_1AddressBookDataList = (output: any, context: __Serde
 
 const deserializeAws_json1_1AlreadyExistsException = (output: any, context: __SerdeContext): AlreadyExistsException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -8858,7 +8861,7 @@ const deserializeAws_json1_1BulletPoints = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -8868,13 +8871,13 @@ const deserializeAws_json1_1BusinessReport = (output: any, context: __SerdeConte
       output.DeliveryTime !== undefined && output.DeliveryTime !== null
         ? new Date(Math.round(output.DeliveryTime * 1000))
         : undefined,
-    DownloadUrl: output.DownloadUrl !== undefined && output.DownloadUrl !== null ? output.DownloadUrl : undefined,
-    FailureCode: output.FailureCode !== undefined && output.FailureCode !== null ? output.FailureCode : undefined,
+    DownloadUrl: __expectString(output.DownloadUrl),
+    FailureCode: __expectString(output.FailureCode),
     S3Location:
       output.S3Location !== undefined && output.S3Location !== null
         ? deserializeAws_json1_1BusinessReportS3Location(output.S3Location, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -8883,7 +8886,7 @@ const deserializeAws_json1_1BusinessReportContentRange = (
   context: __SerdeContext
 ): BusinessReportContentRange => {
   return {
-    Interval: output.Interval !== undefined && output.Interval !== null ? output.Interval : undefined,
+    Interval: __expectString(output.Interval),
   } as any;
 };
 
@@ -8892,7 +8895,7 @@ const deserializeAws_json1_1BusinessReportRecurrence = (
   context: __SerdeContext
 ): BusinessReportRecurrence => {
   return {
-    StartDate: output.StartDate !== undefined && output.StartDate !== null ? output.StartDate : undefined,
+    StartDate: __expectString(output.StartDate),
   } as any;
 };
 
@@ -8901,8 +8904,8 @@ const deserializeAws_json1_1BusinessReportS3Location = (
   context: __SerdeContext
 ): BusinessReportS3Location => {
   return {
-    BucketName: output.BucketName !== undefined && output.BucketName !== null ? output.BucketName : undefined,
-    Path: output.Path !== undefined && output.Path !== null ? output.Path : undefined,
+    BucketName: __expectString(output.BucketName),
+    Path: __expectString(output.Path),
   } as any;
 };
 
@@ -8912,7 +8915,7 @@ const deserializeAws_json1_1BusinessReportSchedule = (output: any, context: __Se
       output.ContentRange !== undefined && output.ContentRange !== null
         ? deserializeAws_json1_1BusinessReportContentRange(output.ContentRange, context)
         : undefined,
-    Format: output.Format !== undefined && output.Format !== null ? output.Format : undefined,
+    Format: __expectString(output.Format),
     LastBusinessReport:
       output.LastBusinessReport !== undefined && output.LastBusinessReport !== null
         ? deserializeAws_json1_1BusinessReport(output.LastBusinessReport, context)
@@ -8921,10 +8924,10 @@ const deserializeAws_json1_1BusinessReportSchedule = (output: any, context: __Se
       output.Recurrence !== undefined && output.Recurrence !== null
         ? deserializeAws_json1_1BusinessReportRecurrence(output.Recurrence, context)
         : undefined,
-    S3BucketName: output.S3BucketName !== undefined && output.S3BucketName !== null ? output.S3BucketName : undefined,
-    S3KeyPrefix: output.S3KeyPrefix !== undefined && output.S3KeyPrefix !== null ? output.S3KeyPrefix : undefined,
-    ScheduleArn: output.ScheduleArn !== undefined && output.ScheduleArn !== null ? output.ScheduleArn : undefined,
-    ScheduleName: output.ScheduleName !== undefined && output.ScheduleName !== null ? output.ScheduleName : undefined,
+    S3BucketName: __expectString(output.S3BucketName),
+    S3KeyPrefix: __expectString(output.S3KeyPrefix),
+    ScheduleArn: __expectString(output.ScheduleArn),
+    ScheduleName: __expectString(output.ScheduleName),
   } as any;
 };
 
@@ -8944,8 +8947,8 @@ const deserializeAws_json1_1BusinessReportScheduleList = (
 
 const deserializeAws_json1_1Category = (output: any, context: __SerdeContext): Category => {
   return {
-    CategoryId: output.CategoryId !== undefined && output.CategoryId !== null ? output.CategoryId : undefined,
-    CategoryName: output.CategoryName !== undefined && output.CategoryName !== null ? output.CategoryName : undefined,
+    CategoryId: __expectNumber(output.CategoryId),
+    CategoryName: __expectString(output.CategoryName),
   } as any;
 };
 
@@ -8965,22 +8968,19 @@ const deserializeAws_json1_1ConcurrentModificationException = (
   context: __SerdeContext
 ): ConcurrentModificationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1ConferencePreference = (output: any, context: __SerdeContext): ConferencePreference => {
   return {
-    DefaultConferenceProviderArn:
-      output.DefaultConferenceProviderArn !== undefined && output.DefaultConferenceProviderArn !== null
-        ? output.DefaultConferenceProviderArn
-        : undefined,
+    DefaultConferenceProviderArn: __expectString(output.DefaultConferenceProviderArn),
   } as any;
 };
 
 const deserializeAws_json1_1ConferenceProvider = (output: any, context: __SerdeContext): ConferenceProvider => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     IPDialIn:
       output.IPDialIn !== undefined && output.IPDialIn !== null
         ? deserializeAws_json1_1IPDialIn(output.IPDialIn, context)
@@ -8989,12 +8989,12 @@ const deserializeAws_json1_1ConferenceProvider = (output: any, context: __SerdeC
       output.MeetingSetting !== undefined && output.MeetingSetting !== null
         ? deserializeAws_json1_1MeetingSetting(output.MeetingSetting, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     PSTNDialIn:
       output.PSTNDialIn !== undefined && output.PSTNDialIn !== null
         ? deserializeAws_json1_1PSTNDialIn(output.PSTNDialIn, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -9011,11 +9011,11 @@ const deserializeAws_json1_1ConferenceProvidersList = (output: any, context: __S
 
 const deserializeAws_json1_1Contact = (output: any, context: __SerdeContext): Contact => {
   return {
-    ContactArn: output.ContactArn !== undefined && output.ContactArn !== null ? output.ContactArn : undefined,
-    DisplayName: output.DisplayName !== undefined && output.DisplayName !== null ? output.DisplayName : undefined,
-    FirstName: output.FirstName !== undefined && output.FirstName !== null ? output.FirstName : undefined,
-    LastName: output.LastName !== undefined && output.LastName !== null ? output.LastName : undefined,
-    PhoneNumber: output.PhoneNumber !== undefined && output.PhoneNumber !== null ? output.PhoneNumber : undefined,
+    ContactArn: __expectString(output.ContactArn),
+    DisplayName: __expectString(output.DisplayName),
+    FirstName: __expectString(output.FirstName),
+    LastName: __expectString(output.LastName),
+    PhoneNumber: __expectString(output.PhoneNumber),
     PhoneNumbers:
       output.PhoneNumbers !== undefined && output.PhoneNumbers !== null
         ? deserializeAws_json1_1PhoneNumberList(output.PhoneNumbers, context)
@@ -9029,11 +9029,11 @@ const deserializeAws_json1_1Contact = (output: any, context: __SerdeContext): Co
 
 const deserializeAws_json1_1ContactData = (output: any, context: __SerdeContext): ContactData => {
   return {
-    ContactArn: output.ContactArn !== undefined && output.ContactArn !== null ? output.ContactArn : undefined,
-    DisplayName: output.DisplayName !== undefined && output.DisplayName !== null ? output.DisplayName : undefined,
-    FirstName: output.FirstName !== undefined && output.FirstName !== null ? output.FirstName : undefined,
-    LastName: output.LastName !== undefined && output.LastName !== null ? output.LastName : undefined,
-    PhoneNumber: output.PhoneNumber !== undefined && output.PhoneNumber !== null ? output.PhoneNumber : undefined,
+    ContactArn: __expectString(output.ContactArn),
+    DisplayName: __expectString(output.DisplayName),
+    FirstName: __expectString(output.FirstName),
+    LastName: __expectString(output.LastName),
+    PhoneNumber: __expectString(output.PhoneNumber),
     PhoneNumbers:
       output.PhoneNumbers !== undefined && output.PhoneNumbers !== null
         ? deserializeAws_json1_1PhoneNumberList(output.PhoneNumbers, context)
@@ -9061,8 +9061,7 @@ const deserializeAws_json1_1CreateAddressBookResponse = (
   context: __SerdeContext
 ): CreateAddressBookResponse => {
   return {
-    AddressBookArn:
-      output.AddressBookArn !== undefined && output.AddressBookArn !== null ? output.AddressBookArn : undefined,
+    AddressBookArn: __expectString(output.AddressBookArn),
   } as any;
 };
 
@@ -9071,7 +9070,7 @@ const deserializeAws_json1_1CreateBusinessReportScheduleResponse = (
   context: __SerdeContext
 ): CreateBusinessReportScheduleResponse => {
   return {
-    ScheduleArn: output.ScheduleArn !== undefined && output.ScheduleArn !== null ? output.ScheduleArn : undefined,
+    ScheduleArn: __expectString(output.ScheduleArn),
   } as any;
 };
 
@@ -9080,16 +9079,13 @@ const deserializeAws_json1_1CreateConferenceProviderResponse = (
   context: __SerdeContext
 ): CreateConferenceProviderResponse => {
   return {
-    ConferenceProviderArn:
-      output.ConferenceProviderArn !== undefined && output.ConferenceProviderArn !== null
-        ? output.ConferenceProviderArn
-        : undefined,
+    ConferenceProviderArn: __expectString(output.ConferenceProviderArn),
   } as any;
 };
 
 const deserializeAws_json1_1CreateContactResponse = (output: any, context: __SerdeContext): CreateContactResponse => {
   return {
-    ContactArn: output.ContactArn !== undefined && output.ContactArn !== null ? output.ContactArn : undefined,
+    ContactArn: __expectString(output.ContactArn),
   } as any;
 };
 
@@ -9098,8 +9094,7 @@ const deserializeAws_json1_1CreateGatewayGroupResponse = (
   context: __SerdeContext
 ): CreateGatewayGroupResponse => {
   return {
-    GatewayGroupArn:
-      output.GatewayGroupArn !== undefined && output.GatewayGroupArn !== null ? output.GatewayGroupArn : undefined,
+    GatewayGroupArn: __expectString(output.GatewayGroupArn),
   } as any;
 };
 
@@ -9108,22 +9103,19 @@ const deserializeAws_json1_1CreateNetworkProfileResponse = (
   context: __SerdeContext
 ): CreateNetworkProfileResponse => {
   return {
-    NetworkProfileArn:
-      output.NetworkProfileArn !== undefined && output.NetworkProfileArn !== null
-        ? output.NetworkProfileArn
-        : undefined,
+    NetworkProfileArn: __expectString(output.NetworkProfileArn),
   } as any;
 };
 
 const deserializeAws_json1_1CreateProfileResponse = (output: any, context: __SerdeContext): CreateProfileResponse => {
   return {
-    ProfileArn: output.ProfileArn !== undefined && output.ProfileArn !== null ? output.ProfileArn : undefined,
+    ProfileArn: __expectString(output.ProfileArn),
   } as any;
 };
 
 const deserializeAws_json1_1CreateRoomResponse = (output: any, context: __SerdeContext): CreateRoomResponse => {
   return {
-    RoomArn: output.RoomArn !== undefined && output.RoomArn !== null ? output.RoomArn : undefined,
+    RoomArn: __expectString(output.RoomArn),
   } as any;
 };
 
@@ -9132,14 +9124,13 @@ const deserializeAws_json1_1CreateSkillGroupResponse = (
   context: __SerdeContext
 ): CreateSkillGroupResponse => {
   return {
-    SkillGroupArn:
-      output.SkillGroupArn !== undefined && output.SkillGroupArn !== null ? output.SkillGroupArn : undefined,
+    SkillGroupArn: __expectString(output.SkillGroupArn),
   } as any;
 };
 
 const deserializeAws_json1_1CreateUserResponse = (output: any, context: __SerdeContext): CreateUserResponse => {
   return {
-    UserArn: output.UserArn !== undefined && output.UserArn !== null ? output.UserArn : undefined,
+    UserArn: __expectString(output.UserArn),
   } as any;
 };
 
@@ -9228,37 +9219,31 @@ const deserializeAws_json1_1DeleteUserResponse = (output: any, context: __SerdeC
 
 const deserializeAws_json1_1DeveloperInfo = (output: any, context: __SerdeContext): DeveloperInfo => {
   return {
-    DeveloperName:
-      output.DeveloperName !== undefined && output.DeveloperName !== null ? output.DeveloperName : undefined,
-    Email: output.Email !== undefined && output.Email !== null ? output.Email : undefined,
-    PrivacyPolicy:
-      output.PrivacyPolicy !== undefined && output.PrivacyPolicy !== null ? output.PrivacyPolicy : undefined,
-    Url: output.Url !== undefined && output.Url !== null ? output.Url : undefined,
+    DeveloperName: __expectString(output.DeveloperName),
+    Email: __expectString(output.Email),
+    PrivacyPolicy: __expectString(output.PrivacyPolicy),
+    Url: __expectString(output.Url),
   } as any;
 };
 
 const deserializeAws_json1_1Device = (output: any, context: __SerdeContext): Device => {
   return {
-    DeviceArn: output.DeviceArn !== undefined && output.DeviceArn !== null ? output.DeviceArn : undefined,
-    DeviceName: output.DeviceName !== undefined && output.DeviceName !== null ? output.DeviceName : undefined,
-    DeviceSerialNumber:
-      output.DeviceSerialNumber !== undefined && output.DeviceSerialNumber !== null
-        ? output.DeviceSerialNumber
-        : undefined,
-    DeviceStatus: output.DeviceStatus !== undefined && output.DeviceStatus !== null ? output.DeviceStatus : undefined,
+    DeviceArn: __expectString(output.DeviceArn),
+    DeviceName: __expectString(output.DeviceName),
+    DeviceSerialNumber: __expectString(output.DeviceSerialNumber),
+    DeviceStatus: __expectString(output.DeviceStatus),
     DeviceStatusInfo:
       output.DeviceStatusInfo !== undefined && output.DeviceStatusInfo !== null
         ? deserializeAws_json1_1DeviceStatusInfo(output.DeviceStatusInfo, context)
         : undefined,
-    DeviceType: output.DeviceType !== undefined && output.DeviceType !== null ? output.DeviceType : undefined,
-    MacAddress: output.MacAddress !== undefined && output.MacAddress !== null ? output.MacAddress : undefined,
+    DeviceType: __expectString(output.DeviceType),
+    MacAddress: __expectString(output.MacAddress),
     NetworkProfileInfo:
       output.NetworkProfileInfo !== undefined && output.NetworkProfileInfo !== null
         ? deserializeAws_json1_1DeviceNetworkProfileInfo(output.NetworkProfileInfo, context)
         : undefined,
-    RoomArn: output.RoomArn !== undefined && output.RoomArn !== null ? output.RoomArn : undefined,
-    SoftwareVersion:
-      output.SoftwareVersion !== undefined && output.SoftwareVersion !== null ? output.SoftwareVersion : undefined,
+    RoomArn: __expectString(output.RoomArn),
+    SoftwareVersion: __expectString(output.SoftwareVersion),
   } as any;
 };
 
@@ -9268,31 +9253,21 @@ const deserializeAws_json1_1DeviceData = (output: any, context: __SerdeContext):
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
         : undefined,
-    DeviceArn: output.DeviceArn !== undefined && output.DeviceArn !== null ? output.DeviceArn : undefined,
-    DeviceName: output.DeviceName !== undefined && output.DeviceName !== null ? output.DeviceName : undefined,
-    DeviceSerialNumber:
-      output.DeviceSerialNumber !== undefined && output.DeviceSerialNumber !== null
-        ? output.DeviceSerialNumber
-        : undefined,
-    DeviceStatus: output.DeviceStatus !== undefined && output.DeviceStatus !== null ? output.DeviceStatus : undefined,
+    DeviceArn: __expectString(output.DeviceArn),
+    DeviceName: __expectString(output.DeviceName),
+    DeviceSerialNumber: __expectString(output.DeviceSerialNumber),
+    DeviceStatus: __expectString(output.DeviceStatus),
     DeviceStatusInfo:
       output.DeviceStatusInfo !== undefined && output.DeviceStatusInfo !== null
         ? deserializeAws_json1_1DeviceStatusInfo(output.DeviceStatusInfo, context)
         : undefined,
-    DeviceType: output.DeviceType !== undefined && output.DeviceType !== null ? output.DeviceType : undefined,
-    MacAddress: output.MacAddress !== undefined && output.MacAddress !== null ? output.MacAddress : undefined,
-    NetworkProfileArn:
-      output.NetworkProfileArn !== undefined && output.NetworkProfileArn !== null
-        ? output.NetworkProfileArn
-        : undefined,
-    NetworkProfileName:
-      output.NetworkProfileName !== undefined && output.NetworkProfileName !== null
-        ? output.NetworkProfileName
-        : undefined,
-    RoomArn: output.RoomArn !== undefined && output.RoomArn !== null ? output.RoomArn : undefined,
-    RoomName: output.RoomName !== undefined && output.RoomName !== null ? output.RoomName : undefined,
-    SoftwareVersion:
-      output.SoftwareVersion !== undefined && output.SoftwareVersion !== null ? output.SoftwareVersion : undefined,
+    DeviceType: __expectString(output.DeviceType),
+    MacAddress: __expectString(output.MacAddress),
+    NetworkProfileArn: __expectString(output.NetworkProfileArn),
+    NetworkProfileName: __expectString(output.NetworkProfileName),
+    RoomArn: __expectString(output.RoomArn),
+    RoomName: __expectString(output.RoomName),
+    SoftwareVersion: __expectString(output.SoftwareVersion),
   } as any;
 };
 
@@ -9313,8 +9288,8 @@ const deserializeAws_json1_1DeviceEvent = (output: any, context: __SerdeContext)
       output.Timestamp !== undefined && output.Timestamp !== null
         ? new Date(Math.round(output.Timestamp * 1000))
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Type: __expectString(output.Type),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -9334,16 +9309,12 @@ const deserializeAws_json1_1DeviceNetworkProfileInfo = (
   context: __SerdeContext
 ): DeviceNetworkProfileInfo => {
   return {
-    CertificateArn:
-      output.CertificateArn !== undefined && output.CertificateArn !== null ? output.CertificateArn : undefined,
+    CertificateArn: __expectString(output.CertificateArn),
     CertificateExpirationTime:
       output.CertificateExpirationTime !== undefined && output.CertificateExpirationTime !== null
         ? new Date(Math.round(output.CertificateExpirationTime * 1000))
         : undefined,
-    NetworkProfileArn:
-      output.NetworkProfileArn !== undefined && output.NetworkProfileArn !== null
-        ? output.NetworkProfileArn
-        : undefined,
+    NetworkProfileArn: __expectString(output.NetworkProfileArn),
   } as any;
 };
 
@@ -9352,14 +9323,14 @@ const deserializeAws_json1_1DeviceNotRegisteredException = (
   context: __SerdeContext
 ): DeviceNotRegisteredException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1DeviceStatusDetail = (output: any, context: __SerdeContext): DeviceStatusDetail => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Feature: output.Feature !== undefined && output.Feature !== null ? output.Feature : undefined,
+    Code: __expectString(output.Code),
+    Feature: __expectString(output.Feature),
   } as any;
 };
 
@@ -9376,8 +9347,7 @@ const deserializeAws_json1_1DeviceStatusDetails = (output: any, context: __Serde
 
 const deserializeAws_json1_1DeviceStatusInfo = (output: any, context: __SerdeContext): DeviceStatusInfo => {
   return {
-    ConnectionStatus:
-      output.ConnectionStatus !== undefined && output.ConnectionStatus !== null ? output.ConnectionStatus : undefined,
+    ConnectionStatus: __expectString(output.ConnectionStatus),
     ConnectionStatusUpdatedTime:
       output.ConnectionStatusUpdatedTime !== undefined && output.ConnectionStatusUpdatedTime !== null
         ? new Date(Math.round(output.ConnectionStatusUpdatedTime * 1000))
@@ -9426,12 +9396,12 @@ const deserializeAws_json1_1DisassociateSkillGroupFromRoomResponse = (
 
 const deserializeAws_json1_1EndOfMeetingReminder = (output: any, context: __SerdeContext): EndOfMeetingReminder => {
   return {
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
+    Enabled: __expectBoolean(output.Enabled),
     ReminderAtMinutes:
       output.ReminderAtMinutes !== undefined && output.ReminderAtMinutes !== null
         ? deserializeAws_json1_1EndOfMeetingReminderMinutesList(output.ReminderAtMinutes, context)
         : undefined,
-    ReminderType: output.ReminderType !== undefined && output.ReminderType !== null ? output.ReminderType : undefined,
+    ReminderType: __expectString(output.ReminderType),
   } as any;
 };
 
@@ -9442,7 +9412,7 @@ const deserializeAws_json1_1EndOfMeetingReminderMinutesList = (output: any, cont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectNumber(entry) as any;
     });
 };
 
@@ -9455,21 +9425,19 @@ const deserializeAws_json1_1ForgetSmartHomeAppliancesResponse = (
 
 const deserializeAws_json1_1Gateway = (output: any, context: __SerdeContext): Gateway => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    GatewayGroupArn:
-      output.GatewayGroupArn !== undefined && output.GatewayGroupArn !== null ? output.GatewayGroupArn : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    SoftwareVersion:
-      output.SoftwareVersion !== undefined && output.SoftwareVersion !== null ? output.SoftwareVersion : undefined,
+    Arn: __expectString(output.Arn),
+    Description: __expectString(output.Description),
+    GatewayGroupArn: __expectString(output.GatewayGroupArn),
+    Name: __expectString(output.Name),
+    SoftwareVersion: __expectString(output.SoftwareVersion),
   } as any;
 };
 
 const deserializeAws_json1_1GatewayGroup = (output: any, context: __SerdeContext): GatewayGroup => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Arn: __expectString(output.Arn),
+    Description: __expectString(output.Description),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -9486,9 +9454,9 @@ const deserializeAws_json1_1GatewayGroupSummaries = (output: any, context: __Ser
 
 const deserializeAws_json1_1GatewayGroupSummary = (output: any, context: __SerdeContext): GatewayGroupSummary => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Arn: __expectString(output.Arn),
+    Description: __expectString(output.Description),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -9505,13 +9473,11 @@ const deserializeAws_json1_1GatewaySummaries = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1GatewaySummary = (output: any, context: __SerdeContext): GatewaySummary => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    GatewayGroupArn:
-      output.GatewayGroupArn !== undefined && output.GatewayGroupArn !== null ? output.GatewayGroupArn : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    SoftwareVersion:
-      output.SoftwareVersion !== undefined && output.SoftwareVersion !== null ? output.SoftwareVersion : undefined,
+    Arn: __expectString(output.Arn),
+    Description: __expectString(output.Description),
+    GatewayGroupArn: __expectString(output.GatewayGroupArn),
+    Name: __expectString(output.Name),
+    SoftwareVersion: __expectString(output.SoftwareVersion),
   } as any;
 };
 
@@ -9522,7 +9488,7 @@ const deserializeAws_json1_1GenericKeywords = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -9603,9 +9569,8 @@ const deserializeAws_json1_1GetInvitationConfigurationResponse = (
   context: __SerdeContext
 ): GetInvitationConfigurationResponse => {
   return {
-    ContactEmail: output.ContactEmail !== undefined && output.ContactEmail !== null ? output.ContactEmail : undefined,
-    OrganizationName:
-      output.OrganizationName !== undefined && output.OrganizationName !== null ? output.OrganizationName : undefined,
+    ContactEmail: __expectString(output.ContactEmail),
+    OrganizationName: __expectString(output.OrganizationName),
     PrivateSkillIds:
       output.PrivateSkillIds !== undefined && output.PrivateSkillIds !== null
         ? deserializeAws_json1_1ShortSkillIdList(output.PrivateSkillIds, context)
@@ -9664,11 +9629,8 @@ const deserializeAws_json1_1GetSkillGroupResponse = (output: any, context: __Ser
 
 const deserializeAws_json1_1InstantBooking = (output: any, context: __SerdeContext): InstantBooking => {
   return {
-    DurationInMinutes:
-      output.DurationInMinutes !== undefined && output.DurationInMinutes !== null
-        ? output.DurationInMinutes
-        : undefined,
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
+    DurationInMinutes: __expectNumber(output.DurationInMinutes),
+    Enabled: __expectBoolean(output.Enabled),
   } as any;
 };
 
@@ -9677,13 +9639,13 @@ const deserializeAws_json1_1InvalidCertificateAuthorityException = (
   context: __SerdeContext
 ): InvalidCertificateAuthorityException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidDeviceException = (output: any, context: __SerdeContext): InvalidDeviceException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -9692,7 +9654,7 @@ const deserializeAws_json1_1InvalidSecretsManagerResourceException = (
   context: __SerdeContext
 ): InvalidSecretsManagerResourceException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -9701,7 +9663,7 @@ const deserializeAws_json1_1InvalidServiceLinkedRoleStateException = (
   context: __SerdeContext
 ): InvalidServiceLinkedRoleStateException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -9710,21 +9672,20 @@ const deserializeAws_json1_1InvalidUserStatusException = (
   context: __SerdeContext
 ): InvalidUserStatusException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1IPDialIn = (output: any, context: __SerdeContext): IPDialIn => {
   return {
-    CommsProtocol:
-      output.CommsProtocol !== undefined && output.CommsProtocol !== null ? output.CommsProtocol : undefined,
-    Endpoint: output.Endpoint !== undefined && output.Endpoint !== null ? output.Endpoint : undefined,
+    CommsProtocol: __expectString(output.CommsProtocol),
+    Endpoint: __expectString(output.Endpoint),
   } as any;
 };
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -9737,7 +9698,7 @@ const deserializeAws_json1_1ListBusinessReportSchedulesResponse = (
       output.BusinessReportSchedules !== undefined && output.BusinessReportSchedules !== null
         ? deserializeAws_json1_1BusinessReportScheduleList(output.BusinessReportSchedules, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -9750,7 +9711,7 @@ const deserializeAws_json1_1ListConferenceProvidersResponse = (
       output.ConferenceProviders !== undefined && output.ConferenceProviders !== null
         ? deserializeAws_json1_1ConferenceProvidersList(output.ConferenceProviders, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -9763,7 +9724,7 @@ const deserializeAws_json1_1ListDeviceEventsResponse = (
       output.DeviceEvents !== undefined && output.DeviceEvents !== null
         ? deserializeAws_json1_1DeviceEventList(output.DeviceEvents, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -9776,7 +9737,7 @@ const deserializeAws_json1_1ListGatewayGroupsResponse = (
       output.GatewayGroups !== undefined && output.GatewayGroups !== null
         ? deserializeAws_json1_1GatewayGroupSummaries(output.GatewayGroups, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -9786,13 +9747,13 @@ const deserializeAws_json1_1ListGatewaysResponse = (output: any, context: __Serd
       output.Gateways !== undefined && output.Gateways !== null
         ? deserializeAws_json1_1GatewaySummaries(output.Gateways, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
 const deserializeAws_json1_1ListSkillsResponse = (output: any, context: __SerdeContext): ListSkillsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     SkillSummaries:
       output.SkillSummaries !== undefined && output.SkillSummaries !== null
         ? deserializeAws_json1_1SkillSummaryList(output.SkillSummaries, context)
@@ -9809,7 +9770,7 @@ const deserializeAws_json1_1ListSkillsStoreCategoriesResponse = (
       output.CategoryList !== undefined && output.CategoryList !== null
         ? deserializeAws_json1_1CategoryList(output.CategoryList, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -9818,7 +9779,7 @@ const deserializeAws_json1_1ListSkillsStoreSkillsByCategoryResponse = (
   context: __SerdeContext
 ): ListSkillsStoreSkillsByCategoryResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     SkillsStoreSkills:
       output.SkillsStoreSkills !== undefined && output.SkillsStoreSkills !== null
         ? deserializeAws_json1_1SkillsStoreSkillList(output.SkillsStoreSkills, context)
@@ -9831,7 +9792,7 @@ const deserializeAws_json1_1ListSmartHomeAppliancesResponse = (
   context: __SerdeContext
 ): ListSmartHomeAppliancesResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     SmartHomeAppliances:
       output.SmartHomeAppliances !== undefined && output.SmartHomeAppliances !== null
         ? deserializeAws_json1_1SmartHomeApplianceList(output.SmartHomeAppliances, context)
@@ -9841,7 +9802,7 @@ const deserializeAws_json1_1ListSmartHomeAppliancesResponse = (
 
 const deserializeAws_json1_1ListTagsResponse = (output: any, context: __SerdeContext): ListTagsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_1TagList(output.Tags, context)
@@ -9866,46 +9827,33 @@ const deserializeAws_json1_1MeetingRoomConfiguration = (
       output.RequireCheckIn !== undefined && output.RequireCheckIn !== null
         ? deserializeAws_json1_1RequireCheckIn(output.RequireCheckIn, context)
         : undefined,
-    RoomUtilizationMetricsEnabled:
-      output.RoomUtilizationMetricsEnabled !== undefined && output.RoomUtilizationMetricsEnabled !== null
-        ? output.RoomUtilizationMetricsEnabled
-        : undefined,
+    RoomUtilizationMetricsEnabled: __expectBoolean(output.RoomUtilizationMetricsEnabled),
   } as any;
 };
 
 const deserializeAws_json1_1MeetingSetting = (output: any, context: __SerdeContext): MeetingSetting => {
   return {
-    RequirePin: output.RequirePin !== undefined && output.RequirePin !== null ? output.RequirePin : undefined,
+    RequirePin: __expectString(output.RequirePin),
   } as any;
 };
 
 const deserializeAws_json1_1NameInUseException = (output: any, context: __SerdeContext): NameInUseException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1NetworkProfile = (output: any, context: __SerdeContext): NetworkProfile => {
   return {
-    CertificateAuthorityArn:
-      output.CertificateAuthorityArn !== undefined && output.CertificateAuthorityArn !== null
-        ? output.CertificateAuthorityArn
-        : undefined,
-    CurrentPassword:
-      output.CurrentPassword !== undefined && output.CurrentPassword !== null ? output.CurrentPassword : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    EapMethod: output.EapMethod !== undefined && output.EapMethod !== null ? output.EapMethod : undefined,
-    NetworkProfileArn:
-      output.NetworkProfileArn !== undefined && output.NetworkProfileArn !== null
-        ? output.NetworkProfileArn
-        : undefined,
-    NetworkProfileName:
-      output.NetworkProfileName !== undefined && output.NetworkProfileName !== null
-        ? output.NetworkProfileName
-        : undefined,
-    NextPassword: output.NextPassword !== undefined && output.NextPassword !== null ? output.NextPassword : undefined,
-    SecurityType: output.SecurityType !== undefined && output.SecurityType !== null ? output.SecurityType : undefined,
-    Ssid: output.Ssid !== undefined && output.Ssid !== null ? output.Ssid : undefined,
+    CertificateAuthorityArn: __expectString(output.CertificateAuthorityArn),
+    CurrentPassword: __expectString(output.CurrentPassword),
+    Description: __expectString(output.Description),
+    EapMethod: __expectString(output.EapMethod),
+    NetworkProfileArn: __expectString(output.NetworkProfileArn),
+    NetworkProfileName: __expectString(output.NetworkProfileName),
+    NextPassword: __expectString(output.NextPassword),
+    SecurityType: __expectString(output.SecurityType),
+    Ssid: __expectString(output.Ssid),
     TrustAnchors:
       output.TrustAnchors !== undefined && output.TrustAnchors !== null
         ? deserializeAws_json1_1TrustAnchorList(output.TrustAnchors, context)
@@ -9915,22 +9863,13 @@ const deserializeAws_json1_1NetworkProfile = (output: any, context: __SerdeConte
 
 const deserializeAws_json1_1NetworkProfileData = (output: any, context: __SerdeContext): NetworkProfileData => {
   return {
-    CertificateAuthorityArn:
-      output.CertificateAuthorityArn !== undefined && output.CertificateAuthorityArn !== null
-        ? output.CertificateAuthorityArn
-        : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    EapMethod: output.EapMethod !== undefined && output.EapMethod !== null ? output.EapMethod : undefined,
-    NetworkProfileArn:
-      output.NetworkProfileArn !== undefined && output.NetworkProfileArn !== null
-        ? output.NetworkProfileArn
-        : undefined,
-    NetworkProfileName:
-      output.NetworkProfileName !== undefined && output.NetworkProfileName !== null
-        ? output.NetworkProfileName
-        : undefined,
-    SecurityType: output.SecurityType !== undefined && output.SecurityType !== null ? output.SecurityType : undefined,
-    Ssid: output.Ssid !== undefined && output.Ssid !== null ? output.Ssid : undefined,
+    CertificateAuthorityArn: __expectString(output.CertificateAuthorityArn),
+    Description: __expectString(output.Description),
+    EapMethod: __expectString(output.EapMethod),
+    NetworkProfileArn: __expectString(output.NetworkProfileArn),
+    NetworkProfileName: __expectString(output.NetworkProfileName),
+    SecurityType: __expectString(output.SecurityType),
+    Ssid: __expectString(output.Ssid),
   } as any;
 };
 
@@ -9952,20 +9891,20 @@ const deserializeAws_json1_1NewInThisVersionBulletPoints = (output: any, context
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1NotFoundException = (output: any, context: __SerdeContext): NotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1PhoneNumber = (output: any, context: __SerdeContext): PhoneNumber => {
   return {
-    Number: output.Number !== undefined && output.Number !== null ? output.Number : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Number: __expectString(output.Number),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -9982,48 +9921,38 @@ const deserializeAws_json1_1PhoneNumberList = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_1Profile = (output: any, context: __SerdeContext): Profile => {
   return {
-    Address: output.Address !== undefined && output.Address !== null ? output.Address : undefined,
-    AddressBookArn:
-      output.AddressBookArn !== undefined && output.AddressBookArn !== null ? output.AddressBookArn : undefined,
-    DataRetentionOptIn:
-      output.DataRetentionOptIn !== undefined && output.DataRetentionOptIn !== null
-        ? output.DataRetentionOptIn
-        : undefined,
-    DistanceUnit: output.DistanceUnit !== undefined && output.DistanceUnit !== null ? output.DistanceUnit : undefined,
-    IsDefault: output.IsDefault !== undefined && output.IsDefault !== null ? output.IsDefault : undefined,
-    Locale: output.Locale !== undefined && output.Locale !== null ? output.Locale : undefined,
-    MaxVolumeLimit:
-      output.MaxVolumeLimit !== undefined && output.MaxVolumeLimit !== null ? output.MaxVolumeLimit : undefined,
+    Address: __expectString(output.Address),
+    AddressBookArn: __expectString(output.AddressBookArn),
+    DataRetentionOptIn: __expectBoolean(output.DataRetentionOptIn),
+    DistanceUnit: __expectString(output.DistanceUnit),
+    IsDefault: __expectBoolean(output.IsDefault),
+    Locale: __expectString(output.Locale),
+    MaxVolumeLimit: __expectNumber(output.MaxVolumeLimit),
     MeetingRoomConfiguration:
       output.MeetingRoomConfiguration !== undefined && output.MeetingRoomConfiguration !== null
         ? deserializeAws_json1_1MeetingRoomConfiguration(output.MeetingRoomConfiguration, context)
         : undefined,
-    PSTNEnabled: output.PSTNEnabled !== undefined && output.PSTNEnabled !== null ? output.PSTNEnabled : undefined,
-    ProfileArn: output.ProfileArn !== undefined && output.ProfileArn !== null ? output.ProfileArn : undefined,
-    ProfileName: output.ProfileName !== undefined && output.ProfileName !== null ? output.ProfileName : undefined,
-    SetupModeDisabled:
-      output.SetupModeDisabled !== undefined && output.SetupModeDisabled !== null
-        ? output.SetupModeDisabled
-        : undefined,
-    TemperatureUnit:
-      output.TemperatureUnit !== undefined && output.TemperatureUnit !== null ? output.TemperatureUnit : undefined,
-    Timezone: output.Timezone !== undefined && output.Timezone !== null ? output.Timezone : undefined,
-    WakeWord: output.WakeWord !== undefined && output.WakeWord !== null ? output.WakeWord : undefined,
+    PSTNEnabled: __expectBoolean(output.PSTNEnabled),
+    ProfileArn: __expectString(output.ProfileArn),
+    ProfileName: __expectString(output.ProfileName),
+    SetupModeDisabled: __expectBoolean(output.SetupModeDisabled),
+    TemperatureUnit: __expectString(output.TemperatureUnit),
+    Timezone: __expectString(output.Timezone),
+    WakeWord: __expectString(output.WakeWord),
   } as any;
 };
 
 const deserializeAws_json1_1ProfileData = (output: any, context: __SerdeContext): ProfileData => {
   return {
-    Address: output.Address !== undefined && output.Address !== null ? output.Address : undefined,
-    DistanceUnit: output.DistanceUnit !== undefined && output.DistanceUnit !== null ? output.DistanceUnit : undefined,
-    IsDefault: output.IsDefault !== undefined && output.IsDefault !== null ? output.IsDefault : undefined,
-    Locale: output.Locale !== undefined && output.Locale !== null ? output.Locale : undefined,
-    ProfileArn: output.ProfileArn !== undefined && output.ProfileArn !== null ? output.ProfileArn : undefined,
-    ProfileName: output.ProfileName !== undefined && output.ProfileName !== null ? output.ProfileName : undefined,
-    TemperatureUnit:
-      output.TemperatureUnit !== undefined && output.TemperatureUnit !== null ? output.TemperatureUnit : undefined,
-    Timezone: output.Timezone !== undefined && output.Timezone !== null ? output.Timezone : undefined,
-    WakeWord: output.WakeWord !== undefined && output.WakeWord !== null ? output.WakeWord : undefined,
+    Address: __expectString(output.Address),
+    DistanceUnit: __expectString(output.DistanceUnit),
+    IsDefault: __expectBoolean(output.IsDefault),
+    Locale: __expectString(output.Locale),
+    ProfileArn: __expectString(output.ProfileArn),
+    ProfileName: __expectString(output.ProfileName),
+    TemperatureUnit: __expectString(output.TemperatureUnit),
+    Timezone: __expectString(output.Timezone),
+    WakeWord: __expectString(output.WakeWord),
   } as any;
 };
 
@@ -10040,12 +9969,10 @@ const deserializeAws_json1_1ProfileDataList = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_1PSTNDialIn = (output: any, context: __SerdeContext): PSTNDialIn => {
   return {
-    CountryCode: output.CountryCode !== undefined && output.CountryCode !== null ? output.CountryCode : undefined,
-    OneClickIdDelay:
-      output.OneClickIdDelay !== undefined && output.OneClickIdDelay !== null ? output.OneClickIdDelay : undefined,
-    OneClickPinDelay:
-      output.OneClickPinDelay !== undefined && output.OneClickPinDelay !== null ? output.OneClickPinDelay : undefined,
-    PhoneNumber: output.PhoneNumber !== undefined && output.PhoneNumber !== null ? output.PhoneNumber : undefined,
+    CountryCode: __expectString(output.CountryCode),
+    OneClickIdDelay: __expectString(output.OneClickIdDelay),
+    OneClickPinDelay: __expectString(output.OneClickPinDelay),
+    PhoneNumber: __expectString(output.PhoneNumber),
   } as any;
 };
 
@@ -10082,7 +10009,7 @@ const deserializeAws_json1_1RegisterAVSDeviceResponse = (
   context: __SerdeContext
 ): RegisterAVSDeviceResponse => {
   return {
-    DeviceArn: output.DeviceArn !== undefined && output.DeviceArn !== null ? output.DeviceArn : undefined,
+    DeviceArn: __expectString(output.DeviceArn),
   } as any;
 };
 
@@ -10092,18 +10019,15 @@ const deserializeAws_json1_1RejectSkillResponse = (output: any, context: __Serde
 
 const deserializeAws_json1_1RequireCheckIn = (output: any, context: __SerdeContext): RequireCheckIn => {
   return {
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
-    ReleaseAfterMinutes:
-      output.ReleaseAfterMinutes !== undefined && output.ReleaseAfterMinutes !== null
-        ? output.ReleaseAfterMinutes
-        : undefined,
+    Enabled: __expectBoolean(output.Enabled),
+    ReleaseAfterMinutes: __expectNumber(output.ReleaseAfterMinutes),
   } as any;
 };
 
 const deserializeAws_json1_1ResolveRoomResponse = (output: any, context: __SerdeContext): ResolveRoomResponse => {
   return {
-    RoomArn: output.RoomArn !== undefined && output.RoomArn !== null ? output.RoomArn : undefined,
-    RoomName: output.RoomName !== undefined && output.RoomName !== null ? output.RoomName : undefined,
+    RoomArn: __expectString(output.RoomArn),
+    RoomName: __expectString(output.RoomName),
     RoomSkillParameters:
       output.RoomSkillParameters !== undefined && output.RoomSkillParameters !== null
         ? deserializeAws_json1_1RoomSkillParameters(output.RoomSkillParameters, context)
@@ -10116,17 +10040,14 @@ const deserializeAws_json1_1ResourceAssociatedException = (
   context: __SerdeContext
 ): ResourceAssociatedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1ResourceInUseException = (output: any, context: __SerdeContext): ResourceInUseException => {
   return {
-    ClientRequestToken:
-      output.ClientRequestToken !== undefined && output.ClientRequestToken !== null
-        ? output.ClientRequestToken
-        : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    ClientRequestToken: __expectString(output.ClientRequestToken),
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -10137,7 +10058,7 @@ const deserializeAws_json1_1Reviews = (output: any, context: __SerdeContext): { 
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -10151,28 +10072,22 @@ const deserializeAws_json1_1RevokeInvitationResponse = (
 
 const deserializeAws_json1_1Room = (output: any, context: __SerdeContext): Room => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    ProfileArn: output.ProfileArn !== undefined && output.ProfileArn !== null ? output.ProfileArn : undefined,
-    ProviderCalendarId:
-      output.ProviderCalendarId !== undefined && output.ProviderCalendarId !== null
-        ? output.ProviderCalendarId
-        : undefined,
-    RoomArn: output.RoomArn !== undefined && output.RoomArn !== null ? output.RoomArn : undefined,
-    RoomName: output.RoomName !== undefined && output.RoomName !== null ? output.RoomName : undefined,
+    Description: __expectString(output.Description),
+    ProfileArn: __expectString(output.ProfileArn),
+    ProviderCalendarId: __expectString(output.ProviderCalendarId),
+    RoomArn: __expectString(output.RoomArn),
+    RoomName: __expectString(output.RoomName),
   } as any;
 };
 
 const deserializeAws_json1_1RoomData = (output: any, context: __SerdeContext): RoomData => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    ProfileArn: output.ProfileArn !== undefined && output.ProfileArn !== null ? output.ProfileArn : undefined,
-    ProfileName: output.ProfileName !== undefined && output.ProfileName !== null ? output.ProfileName : undefined,
-    ProviderCalendarId:
-      output.ProviderCalendarId !== undefined && output.ProviderCalendarId !== null
-        ? output.ProviderCalendarId
-        : undefined,
-    RoomArn: output.RoomArn !== undefined && output.RoomArn !== null ? output.RoomArn : undefined,
-    RoomName: output.RoomName !== undefined && output.RoomName !== null ? output.RoomName : undefined,
+    Description: __expectString(output.Description),
+    ProfileArn: __expectString(output.ProfileArn),
+    ProfileName: __expectString(output.ProfileName),
+    ProviderCalendarId: __expectString(output.ProviderCalendarId),
+    RoomArn: __expectString(output.RoomArn),
+    RoomName: __expectString(output.RoomName),
   } as any;
 };
 
@@ -10189,9 +10104,8 @@ const deserializeAws_json1_1RoomDataList = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_1RoomSkillParameter = (output: any, context: __SerdeContext): RoomSkillParameter => {
   return {
-    ParameterKey: output.ParameterKey !== undefined && output.ParameterKey !== null ? output.ParameterKey : undefined,
-    ParameterValue:
-      output.ParameterValue !== undefined && output.ParameterValue !== null ? output.ParameterValue : undefined,
+    ParameterKey: __expectString(output.ParameterKey),
+    ParameterValue: __expectString(output.ParameterValue),
   } as any;
 };
 
@@ -10213,7 +10127,7 @@ const deserializeAws_json1_1SampleUtterances = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -10226,8 +10140,8 @@ const deserializeAws_json1_1SearchAddressBooksResponse = (
       output.AddressBooks !== undefined && output.AddressBooks !== null
         ? deserializeAws_json1_1AddressBookDataList(output.AddressBooks, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
-    TotalCount: output.TotalCount !== undefined && output.TotalCount !== null ? output.TotalCount : undefined,
+    NextToken: __expectString(output.NextToken),
+    TotalCount: __expectNumber(output.TotalCount),
   } as any;
 };
 
@@ -10237,8 +10151,8 @@ const deserializeAws_json1_1SearchContactsResponse = (output: any, context: __Se
       output.Contacts !== undefined && output.Contacts !== null
         ? deserializeAws_json1_1ContactDataList(output.Contacts, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
-    TotalCount: output.TotalCount !== undefined && output.TotalCount !== null ? output.TotalCount : undefined,
+    NextToken: __expectString(output.NextToken),
+    TotalCount: __expectNumber(output.TotalCount),
   } as any;
 };
 
@@ -10248,8 +10162,8 @@ const deserializeAws_json1_1SearchDevicesResponse = (output: any, context: __Ser
       output.Devices !== undefined && output.Devices !== null
         ? deserializeAws_json1_1DeviceDataList(output.Devices, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
-    TotalCount: output.TotalCount !== undefined && output.TotalCount !== null ? output.TotalCount : undefined,
+    NextToken: __expectString(output.NextToken),
+    TotalCount: __expectNumber(output.TotalCount),
   } as any;
 };
 
@@ -10262,30 +10176,30 @@ const deserializeAws_json1_1SearchNetworkProfilesResponse = (
       output.NetworkProfiles !== undefined && output.NetworkProfiles !== null
         ? deserializeAws_json1_1NetworkProfileDataList(output.NetworkProfiles, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
-    TotalCount: output.TotalCount !== undefined && output.TotalCount !== null ? output.TotalCount : undefined,
+    NextToken: __expectString(output.NextToken),
+    TotalCount: __expectNumber(output.TotalCount),
   } as any;
 };
 
 const deserializeAws_json1_1SearchProfilesResponse = (output: any, context: __SerdeContext): SearchProfilesResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Profiles:
       output.Profiles !== undefined && output.Profiles !== null
         ? deserializeAws_json1_1ProfileDataList(output.Profiles, context)
         : undefined,
-    TotalCount: output.TotalCount !== undefined && output.TotalCount !== null ? output.TotalCount : undefined,
+    TotalCount: __expectNumber(output.TotalCount),
   } as any;
 };
 
 const deserializeAws_json1_1SearchRoomsResponse = (output: any, context: __SerdeContext): SearchRoomsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Rooms:
       output.Rooms !== undefined && output.Rooms !== null
         ? deserializeAws_json1_1RoomDataList(output.Rooms, context)
         : undefined,
-    TotalCount: output.TotalCount !== undefined && output.TotalCount !== null ? output.TotalCount : undefined,
+    TotalCount: __expectNumber(output.TotalCount),
   } as any;
 };
 
@@ -10294,19 +10208,19 @@ const deserializeAws_json1_1SearchSkillGroupsResponse = (
   context: __SerdeContext
 ): SearchSkillGroupsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     SkillGroups:
       output.SkillGroups !== undefined && output.SkillGroups !== null
         ? deserializeAws_json1_1SkillGroupDataList(output.SkillGroups, context)
         : undefined,
-    TotalCount: output.TotalCount !== undefined && output.TotalCount !== null ? output.TotalCount : undefined,
+    TotalCount: __expectNumber(output.TotalCount),
   } as any;
 };
 
 const deserializeAws_json1_1SearchUsersResponse = (output: any, context: __SerdeContext): SearchUsersResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
-    TotalCount: output.TotalCount !== undefined && output.TotalCount !== null ? output.TotalCount : undefined,
+    NextToken: __expectString(output.NextToken),
+    TotalCount: __expectNumber(output.TotalCount),
     Users:
       output.Users !== undefined && output.Users !== null
         ? deserializeAws_json1_1UserDataList(output.Users, context)
@@ -10319,8 +10233,7 @@ const deserializeAws_json1_1SendAnnouncementResponse = (
   context: __SerdeContext
 ): SendAnnouncementResponse => {
   return {
-    AnnouncementArn:
-      output.AnnouncementArn !== undefined && output.AnnouncementArn !== null ? output.AnnouncementArn : undefined,
+    AnnouncementArn: __expectString(output.AnnouncementArn),
   } as any;
 };
 
@@ -10335,14 +10248,14 @@ const deserializeAws_json1_1ShortSkillIdList = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1SipAddress = (output: any, context: __SerdeContext): SipAddress => {
   return {
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    Uri: output.Uri !== undefined && output.Uri !== null ? output.Uri : undefined,
+    Type: __expectString(output.Type),
+    Uri: __expectString(output.Uri),
   } as any;
 };
 
@@ -10367,25 +10280,18 @@ const deserializeAws_json1_1SkillDetails = (output: any, context: __SerdeContext
       output.DeveloperInfo !== undefined && output.DeveloperInfo !== null
         ? deserializeAws_json1_1DeveloperInfo(output.DeveloperInfo, context)
         : undefined,
-    EndUserLicenseAgreement:
-      output.EndUserLicenseAgreement !== undefined && output.EndUserLicenseAgreement !== null
-        ? output.EndUserLicenseAgreement
-        : undefined,
+    EndUserLicenseAgreement: __expectString(output.EndUserLicenseAgreement),
     GenericKeywords:
       output.GenericKeywords !== undefined && output.GenericKeywords !== null
         ? deserializeAws_json1_1GenericKeywords(output.GenericKeywords, context)
         : undefined,
-    InvocationPhrase:
-      output.InvocationPhrase !== undefined && output.InvocationPhrase !== null ? output.InvocationPhrase : undefined,
+    InvocationPhrase: __expectString(output.InvocationPhrase),
     NewInThisVersionBulletPoints:
       output.NewInThisVersionBulletPoints !== undefined && output.NewInThisVersionBulletPoints !== null
         ? deserializeAws_json1_1NewInThisVersionBulletPoints(output.NewInThisVersionBulletPoints, context)
         : undefined,
-    ProductDescription:
-      output.ProductDescription !== undefined && output.ProductDescription !== null
-        ? output.ProductDescription
-        : undefined,
-    ReleaseDate: output.ReleaseDate !== undefined && output.ReleaseDate !== null ? output.ReleaseDate : undefined,
+    ProductDescription: __expectString(output.ProductDescription),
+    ReleaseDate: __expectString(output.ReleaseDate),
     Reviews:
       output.Reviews !== undefined && output.Reviews !== null
         ? deserializeAws_json1_1Reviews(output.Reviews, context)
@@ -10399,21 +10305,17 @@ const deserializeAws_json1_1SkillDetails = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_1SkillGroup = (output: any, context: __SerdeContext): SkillGroup => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    SkillGroupArn:
-      output.SkillGroupArn !== undefined && output.SkillGroupArn !== null ? output.SkillGroupArn : undefined,
-    SkillGroupName:
-      output.SkillGroupName !== undefined && output.SkillGroupName !== null ? output.SkillGroupName : undefined,
+    Description: __expectString(output.Description),
+    SkillGroupArn: __expectString(output.SkillGroupArn),
+    SkillGroupName: __expectString(output.SkillGroupName),
   } as any;
 };
 
 const deserializeAws_json1_1SkillGroupData = (output: any, context: __SerdeContext): SkillGroupData => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    SkillGroupArn:
-      output.SkillGroupArn !== undefined && output.SkillGroupArn !== null ? output.SkillGroupArn : undefined,
-    SkillGroupName:
-      output.SkillGroupName !== undefined && output.SkillGroupName !== null ? output.SkillGroupName : undefined,
+    Description: __expectString(output.Description),
+    SkillGroupArn: __expectString(output.SkillGroupArn),
+    SkillGroupName: __expectString(output.SkillGroupName),
   } as any;
 };
 
@@ -10433,27 +10335,25 @@ const deserializeAws_json1_1SkillNotLinkedException = (
   context: __SerdeContext
 ): SkillNotLinkedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1SkillsStoreSkill = (output: any, context: __SerdeContext): SkillsStoreSkill => {
   return {
-    IconUrl: output.IconUrl !== undefined && output.IconUrl !== null ? output.IconUrl : undefined,
+    IconUrl: __expectString(output.IconUrl),
     SampleUtterances:
       output.SampleUtterances !== undefined && output.SampleUtterances !== null
         ? deserializeAws_json1_1SampleUtterances(output.SampleUtterances, context)
         : undefined,
-    ShortDescription:
-      output.ShortDescription !== undefined && output.ShortDescription !== null ? output.ShortDescription : undefined,
+    ShortDescription: __expectString(output.ShortDescription),
     SkillDetails:
       output.SkillDetails !== undefined && output.SkillDetails !== null
         ? deserializeAws_json1_1SkillDetails(output.SkillDetails, context)
         : undefined,
-    SkillId: output.SkillId !== undefined && output.SkillId !== null ? output.SkillId : undefined,
-    SkillName: output.SkillName !== undefined && output.SkillName !== null ? output.SkillName : undefined,
-    SupportsLinking:
-      output.SupportsLinking !== undefined && output.SupportsLinking !== null ? output.SupportsLinking : undefined,
+    SkillId: __expectString(output.SkillId),
+    SkillName: __expectString(output.SkillName),
+    SupportsLinking: __expectBoolean(output.SupportsLinking),
   } as any;
 };
 
@@ -10470,13 +10370,11 @@ const deserializeAws_json1_1SkillsStoreSkillList = (output: any, context: __Serd
 
 const deserializeAws_json1_1SkillSummary = (output: any, context: __SerdeContext): SkillSummary => {
   return {
-    EnablementType:
-      output.EnablementType !== undefined && output.EnablementType !== null ? output.EnablementType : undefined,
-    SkillId: output.SkillId !== undefined && output.SkillId !== null ? output.SkillId : undefined,
-    SkillName: output.SkillName !== undefined && output.SkillName !== null ? output.SkillName : undefined,
-    SkillType: output.SkillType !== undefined && output.SkillType !== null ? output.SkillType : undefined,
-    SupportsLinking:
-      output.SupportsLinking !== undefined && output.SupportsLinking !== null ? output.SupportsLinking : undefined,
+    EnablementType: __expectString(output.EnablementType),
+    SkillId: __expectString(output.SkillId),
+    SkillName: __expectString(output.SkillName),
+    SkillType: __expectString(output.SkillType),
+    SupportsLinking: __expectBoolean(output.SupportsLinking),
   } as any;
 };
 
@@ -10498,16 +10396,15 @@ const deserializeAws_json1_1SkillTypes = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1SmartHomeAppliance = (output: any, context: __SerdeContext): SmartHomeAppliance => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    FriendlyName: output.FriendlyName !== undefined && output.FriendlyName !== null ? output.FriendlyName : undefined,
-    ManufacturerName:
-      output.ManufacturerName !== undefined && output.ManufacturerName !== null ? output.ManufacturerName : undefined,
+    Description: __expectString(output.Description),
+    FriendlyName: __expectString(output.FriendlyName),
+    ManufacturerName: __expectString(output.ManufacturerName),
   } as any;
 };
 
@@ -10538,8 +10435,8 @@ const deserializeAws_json1_1StartSmartHomeApplianceDiscoveryResponse = (
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -10565,13 +10462,13 @@ const deserializeAws_json1_1TrustAnchorList = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1UnauthorizedException = (output: any, context: __SerdeContext): UnauthorizedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -10643,13 +10540,12 @@ const deserializeAws_json1_1UpdateSkillGroupResponse = (
 
 const deserializeAws_json1_1UserData = (output: any, context: __SerdeContext): UserData => {
   return {
-    Email: output.Email !== undefined && output.Email !== null ? output.Email : undefined,
-    EnrollmentId: output.EnrollmentId !== undefined && output.EnrollmentId !== null ? output.EnrollmentId : undefined,
-    EnrollmentStatus:
-      output.EnrollmentStatus !== undefined && output.EnrollmentStatus !== null ? output.EnrollmentStatus : undefined,
-    FirstName: output.FirstName !== undefined && output.FirstName !== null ? output.FirstName : undefined,
-    LastName: output.LastName !== undefined && output.LastName !== null ? output.LastName : undefined,
-    UserArn: output.UserArn !== undefined && output.UserArn !== null ? output.UserArn : undefined,
+    Email: __expectString(output.Email),
+    EnrollmentId: __expectString(output.EnrollmentId),
+    EnrollmentStatus: __expectString(output.EnrollmentStatus),
+    FirstName: __expectString(output.FirstName),
+    LastName: __expectString(output.LastName),
+    UserArn: __expectString(output.UserArn),
   } as any;
 };
 

--- a/clients/client-amp/protocols/Aws_restJson1.ts
+++ b/clients/client-amp/protocols/Aws_restJson1.ts
@@ -22,6 +22,7 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -191,13 +192,13 @@ export const deserializeAws_restJson1CreateWorkspaceCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.status !== undefined && data.status !== null) {
     contents.status = deserializeAws_restJson1WorkspaceStatus(data.status, context);
   }
   if (data.workspaceId !== undefined && data.workspaceId !== null) {
-    contents.workspaceId = data.workspaceId;
+    contents.workspaceId = __expectString(data.workspaceId);
   }
   return Promise.resolve(contents);
 };
@@ -463,7 +464,7 @@ export const deserializeAws_restJson1ListWorkspacesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.workspaces !== undefined && data.workspaces !== null) {
     contents.workspaces = deserializeAws_restJson1WorkspaceSummaryList(data.workspaces, context);
@@ -643,7 +644,7 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -662,13 +663,13 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.resourceId !== undefined && data.resourceId !== null) {
-    contents.resourceId = data.resourceId;
+    contents.resourceId = __expectString(data.resourceId);
   }
   if (data.resourceType !== undefined && data.resourceType !== null) {
-    contents.resourceType = data.resourceType;
+    contents.resourceType = __expectString(data.resourceType);
   }
   return contents;
 };
@@ -690,7 +691,7 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   }
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -709,13 +710,13 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.resourceId !== undefined && data.resourceId !== null) {
-    contents.resourceId = data.resourceId;
+    contents.resourceId = __expectString(data.resourceId);
   }
   if (data.resourceType !== undefined && data.resourceType !== null) {
-    contents.resourceType = data.resourceType;
+    contents.resourceType = __expectString(data.resourceType);
   }
   return contents;
 };
@@ -736,19 +737,19 @@ const deserializeAws_restJson1ServiceQuotaExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.quotaCode !== undefined && data.quotaCode !== null) {
-    contents.quotaCode = data.quotaCode;
+    contents.quotaCode = __expectString(data.quotaCode);
   }
   if (data.resourceId !== undefined && data.resourceId !== null) {
-    contents.resourceId = data.resourceId;
+    contents.resourceId = __expectString(data.resourceId);
   }
   if (data.resourceType !== undefined && data.resourceType !== null) {
-    contents.resourceType = data.resourceType;
+    contents.resourceType = __expectString(data.resourceType);
   }
   if (data.serviceCode !== undefined && data.serviceCode !== null) {
-    contents.serviceCode = data.serviceCode;
+    contents.serviceCode = __expectString(data.serviceCode);
   }
   return contents;
 };
@@ -772,13 +773,13 @@ const deserializeAws_restJson1ThrottlingExceptionResponse = async (
   }
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.quotaCode !== undefined && data.quotaCode !== null) {
-    contents.quotaCode = data.quotaCode;
+    contents.quotaCode = __expectString(data.quotaCode);
   }
   if (data.serviceCode !== undefined && data.serviceCode !== null) {
-    contents.serviceCode = data.serviceCode;
+    contents.serviceCode = __expectString(data.serviceCode);
   }
   return contents;
 };
@@ -800,10 +801,10 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
     contents.fieldList = deserializeAws_restJson1ValidationExceptionFieldList(data.fieldList, context);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.reason !== undefined && data.reason !== null) {
-    contents.reason = data.reason;
+    contents.reason = __expectString(data.reason);
   }
   return contents;
 };
@@ -813,8 +814,8 @@ const deserializeAws_restJson1ValidationExceptionField = (
   context: __SerdeContext
 ): ValidationExceptionField => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    message: __expectString(output.message),
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -834,34 +835,31 @@ const deserializeAws_restJson1ValidationExceptionFieldList = (
 
 const deserializeAws_restJson1WorkspaceDescription = (output: any, context: __SerdeContext): WorkspaceDescription => {
   return {
-    alias: output.alias !== undefined && output.alias !== null ? output.alias : undefined,
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    alias: __expectString(output.alias),
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    prometheusEndpoint:
-      output.prometheusEndpoint !== undefined && output.prometheusEndpoint !== null
-        ? output.prometheusEndpoint
-        : undefined,
+    prometheusEndpoint: __expectString(output.prometheusEndpoint),
     status:
       output.status !== undefined && output.status !== null
         ? deserializeAws_restJson1WorkspaceStatus(output.status, context)
         : undefined,
-    workspaceId: output.workspaceId !== undefined && output.workspaceId !== null ? output.workspaceId : undefined,
+    workspaceId: __expectString(output.workspaceId),
   } as any;
 };
 
 const deserializeAws_restJson1WorkspaceStatus = (output: any, context: __SerdeContext): WorkspaceStatus => {
   return {
-    statusCode: output.statusCode !== undefined && output.statusCode !== null ? output.statusCode : undefined,
+    statusCode: __expectString(output.statusCode),
   } as any;
 };
 
 const deserializeAws_restJson1WorkspaceSummary = (output: any, context: __SerdeContext): WorkspaceSummary => {
   return {
-    alias: output.alias !== undefined && output.alias !== null ? output.alias : undefined,
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    alias: __expectString(output.alias),
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
@@ -870,7 +868,7 @@ const deserializeAws_restJson1WorkspaceSummary = (output: any, context: __SerdeC
       output.status !== undefined && output.status !== null
         ? deserializeAws_restJson1WorkspaceStatus(output.status, context)
         : undefined,
-    workspaceId: output.workspaceId !== undefined && output.workspaceId !== null ? output.workspaceId : undefined,
+    workspaceId: __expectString(output.workspaceId),
   } as any;
 };
 

--- a/clients/client-amplify/protocols/Aws_restJson1.ts
+++ b/clients/client-amplify/protocols/Aws_restJson1.ts
@@ -91,6 +91,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -1873,10 +1875,10 @@ export const deserializeAws_restJson1CreateDeploymentCommand = async (
     contents.fileUploadUrls = deserializeAws_restJson1FileUploadUrls(data.fileUploadUrls, context);
   }
   if (data.jobId !== undefined && data.jobId !== null) {
-    contents.jobId = data.jobId;
+    contents.jobId = __expectString(data.jobId);
   }
   if (data.zipUploadUrl !== undefined && data.zipUploadUrl !== null) {
-    contents.zipUploadUrl = data.zipUploadUrl;
+    contents.zipUploadUrl = __expectString(data.zipUploadUrl);
   }
   return Promise.resolve(contents);
 };
@@ -2667,7 +2669,7 @@ export const deserializeAws_restJson1GenerateAccessLogsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.logUrl !== undefined && data.logUrl !== null) {
-    contents.logUrl = data.logUrl;
+    contents.logUrl = __expectString(data.logUrl);
   }
   return Promise.resolve(contents);
 };
@@ -2826,10 +2828,10 @@ export const deserializeAws_restJson1GetArtifactUrlCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.artifactId !== undefined && data.artifactId !== null) {
-    contents.artifactId = data.artifactId;
+    contents.artifactId = __expectString(data.artifactId);
   }
   if (data.artifactUrl !== undefined && data.artifactUrl !== null) {
-    contents.artifactUrl = data.artifactUrl;
+    contents.artifactUrl = __expectString(data.artifactUrl);
   }
   return Promise.resolve(contents);
 };
@@ -3331,7 +3333,7 @@ export const deserializeAws_restJson1ListAppsCommand = async (
     contents.apps = deserializeAws_restJson1Apps(data.apps, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3406,7 +3408,7 @@ export const deserializeAws_restJson1ListArtifactsCommand = async (
     contents.artifacts = deserializeAws_restJson1Artifacts(data.artifacts, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3489,7 +3491,7 @@ export const deserializeAws_restJson1ListBackendEnvironmentsCommand = async (
     contents.backendEnvironments = deserializeAws_restJson1BackendEnvironments(data.backendEnvironments, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3564,7 +3566,7 @@ export const deserializeAws_restJson1ListBranchesCommand = async (
     contents.branches = deserializeAws_restJson1Branches(data.branches, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3639,7 +3641,7 @@ export const deserializeAws_restJson1ListDomainAssociationsCommand = async (
     contents.domainAssociations = deserializeAws_restJson1DomainAssociations(data.domainAssociations, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3714,7 +3716,7 @@ export const deserializeAws_restJson1ListJobsCommand = async (
     contents.jobSummaries = deserializeAws_restJson1JobSummaries(data.jobSummaries, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3865,7 +3867,7 @@ export const deserializeAws_restJson1ListWebhooksCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.webhooks !== undefined && data.webhooks !== null) {
     contents.webhooks = deserializeAws_restJson1Webhooks(data.webhooks, context);
@@ -4681,7 +4683,7 @@ const deserializeAws_restJson1BadRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -4698,7 +4700,7 @@ const deserializeAws_restJson1DependentServiceFailureExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -4715,7 +4717,7 @@ const deserializeAws_restJson1InternalFailureExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -4732,7 +4734,7 @@ const deserializeAws_restJson1LimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -4749,7 +4751,7 @@ const deserializeAws_restJson1NotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -4767,10 +4769,10 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.code !== undefined && data.code !== null) {
-    contents.code = data.code;
+    contents.code = __expectString(data.code);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -4787,7 +4789,7 @@ const deserializeAws_restJson1UnauthorizedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -4917,8 +4919,8 @@ const serializeAws_restJson1TagMap = (input: { [key: string]: string }, context:
 
 const deserializeAws_restJson1App = (output: any, context: __SerdeContext): App => {
   return {
-    appArn: output.appArn !== undefined && output.appArn !== null ? output.appArn : undefined,
-    appId: output.appId !== undefined && output.appId !== null ? output.appId : undefined,
+    appArn: __expectString(output.appArn),
+    appId: __expectString(output.appId),
     autoBranchCreationConfig:
       output.autoBranchCreationConfig !== undefined && output.autoBranchCreationConfig !== null
         ? deserializeAws_restJson1AutoBranchCreationConfig(output.autoBranchCreationConfig, context)
@@ -4927,53 +4929,35 @@ const deserializeAws_restJson1App = (output: any, context: __SerdeContext): App 
       output.autoBranchCreationPatterns !== undefined && output.autoBranchCreationPatterns !== null
         ? deserializeAws_restJson1AutoBranchCreationPatterns(output.autoBranchCreationPatterns, context)
         : undefined,
-    basicAuthCredentials:
-      output.basicAuthCredentials !== undefined && output.basicAuthCredentials !== null
-        ? output.basicAuthCredentials
-        : undefined,
-    buildSpec: output.buildSpec !== undefined && output.buildSpec !== null ? output.buildSpec : undefined,
+    basicAuthCredentials: __expectString(output.basicAuthCredentials),
+    buildSpec: __expectString(output.buildSpec),
     createTime:
       output.createTime !== undefined && output.createTime !== null
         ? new Date(Math.round(output.createTime * 1000))
         : undefined,
-    customHeaders:
-      output.customHeaders !== undefined && output.customHeaders !== null ? output.customHeaders : undefined,
+    customHeaders: __expectString(output.customHeaders),
     customRules:
       output.customRules !== undefined && output.customRules !== null
         ? deserializeAws_restJson1CustomRules(output.customRules, context)
         : undefined,
-    defaultDomain:
-      output.defaultDomain !== undefined && output.defaultDomain !== null ? output.defaultDomain : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    enableAutoBranchCreation:
-      output.enableAutoBranchCreation !== undefined && output.enableAutoBranchCreation !== null
-        ? output.enableAutoBranchCreation
-        : undefined,
-    enableBasicAuth:
-      output.enableBasicAuth !== undefined && output.enableBasicAuth !== null ? output.enableBasicAuth : undefined,
-    enableBranchAutoBuild:
-      output.enableBranchAutoBuild !== undefined && output.enableBranchAutoBuild !== null
-        ? output.enableBranchAutoBuild
-        : undefined,
-    enableBranchAutoDeletion:
-      output.enableBranchAutoDeletion !== undefined && output.enableBranchAutoDeletion !== null
-        ? output.enableBranchAutoDeletion
-        : undefined,
+    defaultDomain: __expectString(output.defaultDomain),
+    description: __expectString(output.description),
+    enableAutoBranchCreation: __expectBoolean(output.enableAutoBranchCreation),
+    enableBasicAuth: __expectBoolean(output.enableBasicAuth),
+    enableBranchAutoBuild: __expectBoolean(output.enableBranchAutoBuild),
+    enableBranchAutoDeletion: __expectBoolean(output.enableBranchAutoDeletion),
     environmentVariables:
       output.environmentVariables !== undefined && output.environmentVariables !== null
         ? deserializeAws_restJson1EnvironmentVariables(output.environmentVariables, context)
         : undefined,
-    iamServiceRoleArn:
-      output.iamServiceRoleArn !== undefined && output.iamServiceRoleArn !== null
-        ? output.iamServiceRoleArn
-        : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    platform: output.platform !== undefined && output.platform !== null ? output.platform : undefined,
+    iamServiceRoleArn: __expectString(output.iamServiceRoleArn),
+    name: __expectString(output.name),
+    platform: __expectString(output.platform),
     productionBranch:
       output.productionBranch !== undefined && output.productionBranch !== null
         ? deserializeAws_restJson1ProductionBranch(output.productionBranch, context)
         : undefined,
-    repository: output.repository !== undefined && output.repository !== null ? output.repository : undefined,
+    repository: __expectString(output.repository),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1TagMap(output.tags, context)
@@ -4998,9 +4982,8 @@ const deserializeAws_restJson1Apps = (output: any, context: __SerdeContext): App
 
 const deserializeAws_restJson1Artifact = (output: any, context: __SerdeContext): Artifact => {
   return {
-    artifactFileName:
-      output.artifactFileName !== undefined && output.artifactFileName !== null ? output.artifactFileName : undefined,
-    artifactId: output.artifactId !== undefined && output.artifactId !== null ? output.artifactId : undefined,
+    artifactFileName: __expectString(output.artifactFileName),
+    artifactId: __expectString(output.artifactId),
   } as any;
 };
 
@@ -5022,7 +5005,7 @@ const deserializeAws_restJson1AssociatedResources = (output: any, context: __Ser
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -5031,33 +5014,19 @@ const deserializeAws_restJson1AutoBranchCreationConfig = (
   context: __SerdeContext
 ): AutoBranchCreationConfig => {
   return {
-    basicAuthCredentials:
-      output.basicAuthCredentials !== undefined && output.basicAuthCredentials !== null
-        ? output.basicAuthCredentials
-        : undefined,
-    buildSpec: output.buildSpec !== undefined && output.buildSpec !== null ? output.buildSpec : undefined,
-    enableAutoBuild:
-      output.enableAutoBuild !== undefined && output.enableAutoBuild !== null ? output.enableAutoBuild : undefined,
-    enableBasicAuth:
-      output.enableBasicAuth !== undefined && output.enableBasicAuth !== null ? output.enableBasicAuth : undefined,
-    enablePerformanceMode:
-      output.enablePerformanceMode !== undefined && output.enablePerformanceMode !== null
-        ? output.enablePerformanceMode
-        : undefined,
-    enablePullRequestPreview:
-      output.enablePullRequestPreview !== undefined && output.enablePullRequestPreview !== null
-        ? output.enablePullRequestPreview
-        : undefined,
+    basicAuthCredentials: __expectString(output.basicAuthCredentials),
+    buildSpec: __expectString(output.buildSpec),
+    enableAutoBuild: __expectBoolean(output.enableAutoBuild),
+    enableBasicAuth: __expectBoolean(output.enableBasicAuth),
+    enablePerformanceMode: __expectBoolean(output.enablePerformanceMode),
+    enablePullRequestPreview: __expectBoolean(output.enablePullRequestPreview),
     environmentVariables:
       output.environmentVariables !== undefined && output.environmentVariables !== null
         ? deserializeAws_restJson1EnvironmentVariables(output.environmentVariables, context)
         : undefined,
-    framework: output.framework !== undefined && output.framework !== null ? output.framework : undefined,
-    pullRequestEnvironmentName:
-      output.pullRequestEnvironmentName !== undefined && output.pullRequestEnvironmentName !== null
-        ? output.pullRequestEnvironmentName
-        : undefined,
-    stage: output.stage !== undefined && output.stage !== null ? output.stage : undefined,
+    framework: __expectString(output.framework),
+    pullRequestEnvironmentName: __expectString(output.pullRequestEnvironmentName),
+    stage: __expectString(output.stage),
   } as any;
 };
 
@@ -5068,7 +5037,7 @@ const deserializeAws_restJson1AutoBranchCreationPatterns = (output: any, context
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -5079,27 +5048,20 @@ const deserializeAws_restJson1AutoSubDomainCreationPatterns = (output: any, cont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1BackendEnvironment = (output: any, context: __SerdeContext): BackendEnvironment => {
   return {
-    backendEnvironmentArn:
-      output.backendEnvironmentArn !== undefined && output.backendEnvironmentArn !== null
-        ? output.backendEnvironmentArn
-        : undefined,
+    backendEnvironmentArn: __expectString(output.backendEnvironmentArn),
     createTime:
       output.createTime !== undefined && output.createTime !== null
         ? new Date(Math.round(output.createTime * 1000))
         : undefined,
-    deploymentArtifacts:
-      output.deploymentArtifacts !== undefined && output.deploymentArtifacts !== null
-        ? output.deploymentArtifacts
-        : undefined,
-    environmentName:
-      output.environmentName !== undefined && output.environmentName !== null ? output.environmentName : undefined,
-    stackName: output.stackName !== undefined && output.stackName !== null ? output.stackName : undefined,
+    deploymentArtifacts: __expectString(output.deploymentArtifacts),
+    environmentName: __expectString(output.environmentName),
+    stackName: __expectString(output.stackName),
     updateTime:
       output.updateTime !== undefined && output.updateTime !== null
         ? new Date(Math.round(output.updateTime * 1000))
@@ -5120,22 +5082,16 @@ const deserializeAws_restJson1BackendEnvironments = (output: any, context: __Ser
 
 const deserializeAws_restJson1Branch = (output: any, context: __SerdeContext): Branch => {
   return {
-    activeJobId: output.activeJobId !== undefined && output.activeJobId !== null ? output.activeJobId : undefined,
+    activeJobId: __expectString(output.activeJobId),
     associatedResources:
       output.associatedResources !== undefined && output.associatedResources !== null
         ? deserializeAws_restJson1AssociatedResources(output.associatedResources, context)
         : undefined,
-    backendEnvironmentArn:
-      output.backendEnvironmentArn !== undefined && output.backendEnvironmentArn !== null
-        ? output.backendEnvironmentArn
-        : undefined,
-    basicAuthCredentials:
-      output.basicAuthCredentials !== undefined && output.basicAuthCredentials !== null
-        ? output.basicAuthCredentials
-        : undefined,
-    branchArn: output.branchArn !== undefined && output.branchArn !== null ? output.branchArn : undefined,
-    branchName: output.branchName !== undefined && output.branchName !== null ? output.branchName : undefined,
-    buildSpec: output.buildSpec !== undefined && output.buildSpec !== null ? output.buildSpec : undefined,
+    backendEnvironmentArn: __expectString(output.backendEnvironmentArn),
+    basicAuthCredentials: __expectString(output.basicAuthCredentials),
+    branchArn: __expectString(output.branchArn),
+    branchName: __expectString(output.branchName),
+    buildSpec: __expectString(output.buildSpec),
     createTime:
       output.createTime !== undefined && output.createTime !== null
         ? new Date(Math.round(output.createTime * 1000))
@@ -5144,49 +5100,29 @@ const deserializeAws_restJson1Branch = (output: any, context: __SerdeContext): B
       output.customDomains !== undefined && output.customDomains !== null
         ? deserializeAws_restJson1CustomDomains(output.customDomains, context)
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    destinationBranch:
-      output.destinationBranch !== undefined && output.destinationBranch !== null
-        ? output.destinationBranch
-        : undefined,
-    displayName: output.displayName !== undefined && output.displayName !== null ? output.displayName : undefined,
-    enableAutoBuild:
-      output.enableAutoBuild !== undefined && output.enableAutoBuild !== null ? output.enableAutoBuild : undefined,
-    enableBasicAuth:
-      output.enableBasicAuth !== undefined && output.enableBasicAuth !== null ? output.enableBasicAuth : undefined,
-    enableNotification:
-      output.enableNotification !== undefined && output.enableNotification !== null
-        ? output.enableNotification
-        : undefined,
-    enablePerformanceMode:
-      output.enablePerformanceMode !== undefined && output.enablePerformanceMode !== null
-        ? output.enablePerformanceMode
-        : undefined,
-    enablePullRequestPreview:
-      output.enablePullRequestPreview !== undefined && output.enablePullRequestPreview !== null
-        ? output.enablePullRequestPreview
-        : undefined,
+    description: __expectString(output.description),
+    destinationBranch: __expectString(output.destinationBranch),
+    displayName: __expectString(output.displayName),
+    enableAutoBuild: __expectBoolean(output.enableAutoBuild),
+    enableBasicAuth: __expectBoolean(output.enableBasicAuth),
+    enableNotification: __expectBoolean(output.enableNotification),
+    enablePerformanceMode: __expectBoolean(output.enablePerformanceMode),
+    enablePullRequestPreview: __expectBoolean(output.enablePullRequestPreview),
     environmentVariables:
       output.environmentVariables !== undefined && output.environmentVariables !== null
         ? deserializeAws_restJson1EnvironmentVariables(output.environmentVariables, context)
         : undefined,
-    framework: output.framework !== undefined && output.framework !== null ? output.framework : undefined,
-    pullRequestEnvironmentName:
-      output.pullRequestEnvironmentName !== undefined && output.pullRequestEnvironmentName !== null
-        ? output.pullRequestEnvironmentName
-        : undefined,
-    sourceBranch: output.sourceBranch !== undefined && output.sourceBranch !== null ? output.sourceBranch : undefined,
-    stage: output.stage !== undefined && output.stage !== null ? output.stage : undefined,
+    framework: __expectString(output.framework),
+    pullRequestEnvironmentName: __expectString(output.pullRequestEnvironmentName),
+    sourceBranch: __expectString(output.sourceBranch),
+    stage: __expectString(output.stage),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1TagMap(output.tags, context)
         : undefined,
-    thumbnailUrl: output.thumbnailUrl !== undefined && output.thumbnailUrl !== null ? output.thumbnailUrl : undefined,
-    totalNumberOfJobs:
-      output.totalNumberOfJobs !== undefined && output.totalNumberOfJobs !== null
-        ? output.totalNumberOfJobs
-        : undefined,
-    ttl: output.ttl !== undefined && output.ttl !== null ? output.ttl : undefined,
+    thumbnailUrl: __expectString(output.thumbnailUrl),
+    totalNumberOfJobs: __expectString(output.totalNumberOfJobs),
+    ttl: __expectString(output.ttl),
     updateTime:
       output.updateTime !== undefined && output.updateTime !== null
         ? new Date(Math.round(output.updateTime * 1000))
@@ -5212,16 +5148,16 @@ const deserializeAws_restJson1CustomDomains = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1CustomRule = (output: any, context: __SerdeContext): CustomRule => {
   return {
-    condition: output.condition !== undefined && output.condition !== null ? output.condition : undefined,
-    source: output.source !== undefined && output.source !== null ? output.source : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    target: output.target !== undefined && output.target !== null ? output.target : undefined,
+    condition: __expectString(output.condition),
+    source: __expectString(output.source),
+    status: __expectString(output.status),
+    target: __expectString(output.target),
   } as any;
 };
 
@@ -5242,25 +5178,13 @@ const deserializeAws_restJson1DomainAssociation = (output: any, context: __Serde
       output.autoSubDomainCreationPatterns !== undefined && output.autoSubDomainCreationPatterns !== null
         ? deserializeAws_restJson1AutoSubDomainCreationPatterns(output.autoSubDomainCreationPatterns, context)
         : undefined,
-    autoSubDomainIAMRole:
-      output.autoSubDomainIAMRole !== undefined && output.autoSubDomainIAMRole !== null
-        ? output.autoSubDomainIAMRole
-        : undefined,
-    certificateVerificationDNSRecord:
-      output.certificateVerificationDNSRecord !== undefined && output.certificateVerificationDNSRecord !== null
-        ? output.certificateVerificationDNSRecord
-        : undefined,
-    domainAssociationArn:
-      output.domainAssociationArn !== undefined && output.domainAssociationArn !== null
-        ? output.domainAssociationArn
-        : undefined,
-    domainName: output.domainName !== undefined && output.domainName !== null ? output.domainName : undefined,
-    domainStatus: output.domainStatus !== undefined && output.domainStatus !== null ? output.domainStatus : undefined,
-    enableAutoSubDomain:
-      output.enableAutoSubDomain !== undefined && output.enableAutoSubDomain !== null
-        ? output.enableAutoSubDomain
-        : undefined,
-    statusReason: output.statusReason !== undefined && output.statusReason !== null ? output.statusReason : undefined,
+    autoSubDomainIAMRole: __expectString(output.autoSubDomainIAMRole),
+    certificateVerificationDNSRecord: __expectString(output.certificateVerificationDNSRecord),
+    domainAssociationArn: __expectString(output.domainAssociationArn),
+    domainName: __expectString(output.domainName),
+    domainStatus: __expectString(output.domainStatus),
+    enableAutoSubDomain: __expectBoolean(output.enableAutoSubDomain),
+    statusReason: __expectString(output.statusReason),
     subDomains:
       output.subDomains !== undefined && output.subDomains !== null
         ? deserializeAws_restJson1SubDomains(output.subDomains, context)
@@ -5289,7 +5213,7 @@ const deserializeAws_restJson1EnvironmentVariables = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -5301,7 +5225,7 @@ const deserializeAws_restJson1FileUploadUrls = (output: any, context: __SerdeCon
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -5332,35 +5256,34 @@ const deserializeAws_restJson1JobSummaries = (output: any, context: __SerdeConte
 
 const deserializeAws_restJson1JobSummary = (output: any, context: __SerdeContext): JobSummary => {
   return {
-    commitId: output.commitId !== undefined && output.commitId !== null ? output.commitId : undefined,
-    commitMessage:
-      output.commitMessage !== undefined && output.commitMessage !== null ? output.commitMessage : undefined,
+    commitId: __expectString(output.commitId),
+    commitMessage: __expectString(output.commitMessage),
     commitTime:
       output.commitTime !== undefined && output.commitTime !== null
         ? new Date(Math.round(output.commitTime * 1000))
         : undefined,
     endTime:
       output.endTime !== undefined && output.endTime !== null ? new Date(Math.round(output.endTime * 1000)) : undefined,
-    jobArn: output.jobArn !== undefined && output.jobArn !== null ? output.jobArn : undefined,
-    jobId: output.jobId !== undefined && output.jobId !== null ? output.jobId : undefined,
-    jobType: output.jobType !== undefined && output.jobType !== null ? output.jobType : undefined,
+    jobArn: __expectString(output.jobArn),
+    jobId: __expectString(output.jobId),
+    jobType: __expectString(output.jobType),
     startTime:
       output.startTime !== undefined && output.startTime !== null
         ? new Date(Math.round(output.startTime * 1000))
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
   } as any;
 };
 
 const deserializeAws_restJson1ProductionBranch = (output: any, context: __SerdeContext): ProductionBranch => {
   return {
-    branchName: output.branchName !== undefined && output.branchName !== null ? output.branchName : undefined,
+    branchName: __expectString(output.branchName),
     lastDeployTime:
       output.lastDeployTime !== undefined && output.lastDeployTime !== null
         ? new Date(Math.round(output.lastDeployTime * 1000))
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    thumbnailUrl: output.thumbnailUrl !== undefined && output.thumbnailUrl !== null ? output.thumbnailUrl : undefined,
+    status: __expectString(output.status),
+    thumbnailUrl: __expectString(output.thumbnailUrl),
   } as any;
 };
 
@@ -5371,18 +5294,18 @@ const deserializeAws_restJson1Screenshots = (output: any, context: __SerdeContex
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1Step = (output: any, context: __SerdeContext): Step => {
   return {
-    artifactsUrl: output.artifactsUrl !== undefined && output.artifactsUrl !== null ? output.artifactsUrl : undefined,
-    context: output.context !== undefined && output.context !== null ? output.context : undefined,
+    artifactsUrl: __expectString(output.artifactsUrl),
+    context: __expectString(output.context),
     endTime:
       output.endTime !== undefined && output.endTime !== null ? new Date(Math.round(output.endTime * 1000)) : undefined,
-    logUrl: output.logUrl !== undefined && output.logUrl !== null ? output.logUrl : undefined,
+    logUrl: __expectString(output.logUrl),
     screenshots:
       output.screenshots !== undefined && output.screenshots !== null
         ? deserializeAws_restJson1Screenshots(output.screenshots, context)
@@ -5391,13 +5314,11 @@ const deserializeAws_restJson1Step = (output: any, context: __SerdeContext): Ste
       output.startTime !== undefined && output.startTime !== null
         ? new Date(Math.round(output.startTime * 1000))
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    statusReason: output.statusReason !== undefined && output.statusReason !== null ? output.statusReason : undefined,
-    stepName: output.stepName !== undefined && output.stepName !== null ? output.stepName : undefined,
-    testArtifactsUrl:
-      output.testArtifactsUrl !== undefined && output.testArtifactsUrl !== null ? output.testArtifactsUrl : undefined,
-    testConfigUrl:
-      output.testConfigUrl !== undefined && output.testConfigUrl !== null ? output.testConfigUrl : undefined,
+    status: __expectString(output.status),
+    statusReason: __expectString(output.statusReason),
+    stepName: __expectString(output.stepName),
+    testArtifactsUrl: __expectString(output.testArtifactsUrl),
+    testConfigUrl: __expectString(output.testConfigUrl),
   } as any;
 };
 
@@ -5414,12 +5335,12 @@ const deserializeAws_restJson1Steps = (output: any, context: __SerdeContext): St
 
 const deserializeAws_restJson1SubDomain = (output: any, context: __SerdeContext): SubDomain => {
   return {
-    dnsRecord: output.dnsRecord !== undefined && output.dnsRecord !== null ? output.dnsRecord : undefined,
+    dnsRecord: __expectString(output.dnsRecord),
     subDomainSetting:
       output.subDomainSetting !== undefined && output.subDomainSetting !== null
         ? deserializeAws_restJson1SubDomainSetting(output.subDomainSetting, context)
         : undefined,
-    verified: output.verified !== undefined && output.verified !== null ? output.verified : undefined,
+    verified: __expectBoolean(output.verified),
   } as any;
 };
 
@@ -5436,8 +5357,8 @@ const deserializeAws_restJson1SubDomains = (output: any, context: __SerdeContext
 
 const deserializeAws_restJson1SubDomainSetting = (output: any, context: __SerdeContext): SubDomainSetting => {
   return {
-    branchName: output.branchName !== undefined && output.branchName !== null ? output.branchName : undefined,
-    prefix: output.prefix !== undefined && output.prefix !== null ? output.prefix : undefined,
+    branchName: __expectString(output.branchName),
+    prefix: __expectString(output.prefix),
   } as any;
 };
 
@@ -5448,26 +5369,26 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1Webhook = (output: any, context: __SerdeContext): Webhook => {
   return {
-    branchName: output.branchName !== undefined && output.branchName !== null ? output.branchName : undefined,
+    branchName: __expectString(output.branchName),
     createTime:
       output.createTime !== undefined && output.createTime !== null
         ? new Date(Math.round(output.createTime * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    description: __expectString(output.description),
     updateTime:
       output.updateTime !== undefined && output.updateTime !== null
         ? new Date(Math.round(output.updateTime * 1000))
         : undefined,
-    webhookArn: output.webhookArn !== undefined && output.webhookArn !== null ? output.webhookArn : undefined,
-    webhookId: output.webhookId !== undefined && output.webhookId !== null ? output.webhookId : undefined,
-    webhookUrl: output.webhookUrl !== undefined && output.webhookUrl !== null ? output.webhookUrl : undefined,
+    webhookArn: __expectString(output.webhookArn),
+    webhookId: __expectString(output.webhookId),
+    webhookUrl: __expectString(output.webhookUrl),
   } as any;
 };
 

--- a/clients/client-amplifybackend/protocols/Aws_restJson1.ts
+++ b/clients/client-amplifybackend/protocols/Aws_restJson1.ts
@@ -76,6 +76,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -1057,22 +1060,22 @@ export const deserializeAws_restJson1CloneBackendCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.appId !== undefined && data.appId !== null) {
-    contents.AppId = data.appId;
+    contents.AppId = __expectString(data.appId);
   }
   if (data.backendEnvironmentName !== undefined && data.backendEnvironmentName !== null) {
-    contents.BackendEnvironmentName = data.backendEnvironmentName;
+    contents.BackendEnvironmentName = __expectString(data.backendEnvironmentName);
   }
   if (data.error !== undefined && data.error !== null) {
-    contents.Error = data.error;
+    contents.Error = __expectString(data.error);
   }
   if (data.jobId !== undefined && data.jobId !== null) {
-    contents.JobId = data.jobId;
+    contents.JobId = __expectString(data.jobId);
   }
   if (data.operation !== undefined && data.operation !== null) {
-    contents.Operation = data.operation;
+    contents.Operation = __expectString(data.operation);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.Status = data.status;
+    contents.Status = __expectString(data.status);
   }
   return Promise.resolve(contents);
 };
@@ -1156,22 +1159,22 @@ export const deserializeAws_restJson1CreateBackendCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.appId !== undefined && data.appId !== null) {
-    contents.AppId = data.appId;
+    contents.AppId = __expectString(data.appId);
   }
   if (data.backendEnvironmentName !== undefined && data.backendEnvironmentName !== null) {
-    contents.BackendEnvironmentName = data.backendEnvironmentName;
+    contents.BackendEnvironmentName = __expectString(data.backendEnvironmentName);
   }
   if (data.error !== undefined && data.error !== null) {
-    contents.Error = data.error;
+    contents.Error = __expectString(data.error);
   }
   if (data.jobId !== undefined && data.jobId !== null) {
-    contents.JobId = data.jobId;
+    contents.JobId = __expectString(data.jobId);
   }
   if (data.operation !== undefined && data.operation !== null) {
-    contents.Operation = data.operation;
+    contents.Operation = __expectString(data.operation);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.Status = data.status;
+    contents.Status = __expectString(data.status);
   }
   return Promise.resolve(contents);
 };
@@ -1255,22 +1258,22 @@ export const deserializeAws_restJson1CreateBackendAPICommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.appId !== undefined && data.appId !== null) {
-    contents.AppId = data.appId;
+    contents.AppId = __expectString(data.appId);
   }
   if (data.backendEnvironmentName !== undefined && data.backendEnvironmentName !== null) {
-    contents.BackendEnvironmentName = data.backendEnvironmentName;
+    contents.BackendEnvironmentName = __expectString(data.backendEnvironmentName);
   }
   if (data.error !== undefined && data.error !== null) {
-    contents.Error = data.error;
+    contents.Error = __expectString(data.error);
   }
   if (data.jobId !== undefined && data.jobId !== null) {
-    contents.JobId = data.jobId;
+    contents.JobId = __expectString(data.jobId);
   }
   if (data.operation !== undefined && data.operation !== null) {
-    contents.Operation = data.operation;
+    contents.Operation = __expectString(data.operation);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.Status = data.status;
+    contents.Status = __expectString(data.status);
   }
   return Promise.resolve(contents);
 };
@@ -1354,22 +1357,22 @@ export const deserializeAws_restJson1CreateBackendAuthCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.appId !== undefined && data.appId !== null) {
-    contents.AppId = data.appId;
+    contents.AppId = __expectString(data.appId);
   }
   if (data.backendEnvironmentName !== undefined && data.backendEnvironmentName !== null) {
-    contents.BackendEnvironmentName = data.backendEnvironmentName;
+    contents.BackendEnvironmentName = __expectString(data.backendEnvironmentName);
   }
   if (data.error !== undefined && data.error !== null) {
-    contents.Error = data.error;
+    contents.Error = __expectString(data.error);
   }
   if (data.jobId !== undefined && data.jobId !== null) {
-    contents.JobId = data.jobId;
+    contents.JobId = __expectString(data.jobId);
   }
   if (data.operation !== undefined && data.operation !== null) {
-    contents.Operation = data.operation;
+    contents.Operation = __expectString(data.operation);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.Status = data.status;
+    contents.Status = __expectString(data.status);
   }
   return Promise.resolve(contents);
 };
@@ -1451,16 +1454,16 @@ export const deserializeAws_restJson1CreateBackendConfigCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.appId !== undefined && data.appId !== null) {
-    contents.AppId = data.appId;
+    contents.AppId = __expectString(data.appId);
   }
   if (data.backendEnvironmentName !== undefined && data.backendEnvironmentName !== null) {
-    contents.BackendEnvironmentName = data.backendEnvironmentName;
+    contents.BackendEnvironmentName = __expectString(data.backendEnvironmentName);
   }
   if (data.jobId !== undefined && data.jobId !== null) {
-    contents.JobId = data.jobId;
+    contents.JobId = __expectString(data.jobId);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.Status = data.status;
+    contents.Status = __expectString(data.status);
   }
   return Promise.resolve(contents);
 };
@@ -1542,16 +1545,16 @@ export const deserializeAws_restJson1CreateTokenCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.appId !== undefined && data.appId !== null) {
-    contents.AppId = data.appId;
+    contents.AppId = __expectString(data.appId);
   }
   if (data.challengeCode !== undefined && data.challengeCode !== null) {
-    contents.ChallengeCode = data.challengeCode;
+    contents.ChallengeCode = __expectString(data.challengeCode);
   }
   if (data.sessionId !== undefined && data.sessionId !== null) {
-    contents.SessionId = data.sessionId;
+    contents.SessionId = __expectString(data.sessionId);
   }
   if (data.ttl !== undefined && data.ttl !== null) {
-    contents.Ttl = data.ttl;
+    contents.Ttl = __expectString(data.ttl);
   }
   return Promise.resolve(contents);
 };
@@ -1635,22 +1638,22 @@ export const deserializeAws_restJson1DeleteBackendCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.appId !== undefined && data.appId !== null) {
-    contents.AppId = data.appId;
+    contents.AppId = __expectString(data.appId);
   }
   if (data.backendEnvironmentName !== undefined && data.backendEnvironmentName !== null) {
-    contents.BackendEnvironmentName = data.backendEnvironmentName;
+    contents.BackendEnvironmentName = __expectString(data.backendEnvironmentName);
   }
   if (data.error !== undefined && data.error !== null) {
-    contents.Error = data.error;
+    contents.Error = __expectString(data.error);
   }
   if (data.jobId !== undefined && data.jobId !== null) {
-    contents.JobId = data.jobId;
+    contents.JobId = __expectString(data.jobId);
   }
   if (data.operation !== undefined && data.operation !== null) {
-    contents.Operation = data.operation;
+    contents.Operation = __expectString(data.operation);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.Status = data.status;
+    contents.Status = __expectString(data.status);
   }
   return Promise.resolve(contents);
 };
@@ -1734,22 +1737,22 @@ export const deserializeAws_restJson1DeleteBackendAPICommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.appId !== undefined && data.appId !== null) {
-    contents.AppId = data.appId;
+    contents.AppId = __expectString(data.appId);
   }
   if (data.backendEnvironmentName !== undefined && data.backendEnvironmentName !== null) {
-    contents.BackendEnvironmentName = data.backendEnvironmentName;
+    contents.BackendEnvironmentName = __expectString(data.backendEnvironmentName);
   }
   if (data.error !== undefined && data.error !== null) {
-    contents.Error = data.error;
+    contents.Error = __expectString(data.error);
   }
   if (data.jobId !== undefined && data.jobId !== null) {
-    contents.JobId = data.jobId;
+    contents.JobId = __expectString(data.jobId);
   }
   if (data.operation !== undefined && data.operation !== null) {
-    contents.Operation = data.operation;
+    contents.Operation = __expectString(data.operation);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.Status = data.status;
+    contents.Status = __expectString(data.status);
   }
   return Promise.resolve(contents);
 };
@@ -1833,22 +1836,22 @@ export const deserializeAws_restJson1DeleteBackendAuthCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.appId !== undefined && data.appId !== null) {
-    contents.AppId = data.appId;
+    contents.AppId = __expectString(data.appId);
   }
   if (data.backendEnvironmentName !== undefined && data.backendEnvironmentName !== null) {
-    contents.BackendEnvironmentName = data.backendEnvironmentName;
+    contents.BackendEnvironmentName = __expectString(data.backendEnvironmentName);
   }
   if (data.error !== undefined && data.error !== null) {
-    contents.Error = data.error;
+    contents.Error = __expectString(data.error);
   }
   if (data.jobId !== undefined && data.jobId !== null) {
-    contents.JobId = data.jobId;
+    contents.JobId = __expectString(data.jobId);
   }
   if (data.operation !== undefined && data.operation !== null) {
-    contents.Operation = data.operation;
+    contents.Operation = __expectString(data.operation);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.Status = data.status;
+    contents.Status = __expectString(data.status);
   }
   return Promise.resolve(contents);
 };
@@ -1927,7 +1930,7 @@ export const deserializeAws_restJson1DeleteTokenCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.isSuccess !== undefined && data.isSuccess !== null) {
-    contents.IsSuccess = data.isSuccess;
+    contents.IsSuccess = __expectBoolean(data.isSuccess);
   }
   return Promise.resolve(contents);
 };
@@ -2011,22 +2014,22 @@ export const deserializeAws_restJson1GenerateBackendAPIModelsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.appId !== undefined && data.appId !== null) {
-    contents.AppId = data.appId;
+    contents.AppId = __expectString(data.appId);
   }
   if (data.backendEnvironmentName !== undefined && data.backendEnvironmentName !== null) {
-    contents.BackendEnvironmentName = data.backendEnvironmentName;
+    contents.BackendEnvironmentName = __expectString(data.backendEnvironmentName);
   }
   if (data.error !== undefined && data.error !== null) {
-    contents.Error = data.error;
+    contents.Error = __expectString(data.error);
   }
   if (data.jobId !== undefined && data.jobId !== null) {
-    contents.JobId = data.jobId;
+    contents.JobId = __expectString(data.jobId);
   }
   if (data.operation !== undefined && data.operation !== null) {
-    contents.Operation = data.operation;
+    contents.Operation = __expectString(data.operation);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.Status = data.status;
+    contents.Status = __expectString(data.status);
   }
   return Promise.resolve(contents);
 };
@@ -2110,22 +2113,22 @@ export const deserializeAws_restJson1GetBackendCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.amplifyMetaConfig !== undefined && data.amplifyMetaConfig !== null) {
-    contents.AmplifyMetaConfig = data.amplifyMetaConfig;
+    contents.AmplifyMetaConfig = __expectString(data.amplifyMetaConfig);
   }
   if (data.appId !== undefined && data.appId !== null) {
-    contents.AppId = data.appId;
+    contents.AppId = __expectString(data.appId);
   }
   if (data.appName !== undefined && data.appName !== null) {
-    contents.AppName = data.appName;
+    contents.AppName = __expectString(data.appName);
   }
   if (data.backendEnvironmentList !== undefined && data.backendEnvironmentList !== null) {
     contents.BackendEnvironmentList = deserializeAws_restJson1ListOf__string(data.backendEnvironmentList, context);
   }
   if (data.backendEnvironmentName !== undefined && data.backendEnvironmentName !== null) {
-    contents.BackendEnvironmentName = data.backendEnvironmentName;
+    contents.BackendEnvironmentName = __expectString(data.backendEnvironmentName);
   }
   if (data.error !== undefined && data.error !== null) {
-    contents.Error = data.error;
+    contents.Error = __expectString(data.error);
   }
   return Promise.resolve(contents);
 };
@@ -2208,19 +2211,19 @@ export const deserializeAws_restJson1GetBackendAPICommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.appId !== undefined && data.appId !== null) {
-    contents.AppId = data.appId;
+    contents.AppId = __expectString(data.appId);
   }
   if (data.backendEnvironmentName !== undefined && data.backendEnvironmentName !== null) {
-    contents.BackendEnvironmentName = data.backendEnvironmentName;
+    contents.BackendEnvironmentName = __expectString(data.backendEnvironmentName);
   }
   if (data.error !== undefined && data.error !== null) {
-    contents.Error = data.error;
+    contents.Error = __expectString(data.error);
   }
   if (data.resourceConfig !== undefined && data.resourceConfig !== null) {
     contents.ResourceConfig = deserializeAws_restJson1BackendAPIResourceConfig(data.resourceConfig, context);
   }
   if (data.resourceName !== undefined && data.resourceName !== null) {
-    contents.ResourceName = data.resourceName;
+    contents.ResourceName = __expectString(data.resourceName);
   }
   return Promise.resolve(contents);
 };
@@ -2300,10 +2303,10 @@ export const deserializeAws_restJson1GetBackendAPIModelsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.models !== undefined && data.models !== null) {
-    contents.Models = data.models;
+    contents.Models = __expectString(data.models);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.Status = data.status;
+    contents.Status = __expectString(data.status);
   }
   return Promise.resolve(contents);
 };
@@ -2386,19 +2389,19 @@ export const deserializeAws_restJson1GetBackendAuthCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.appId !== undefined && data.appId !== null) {
-    contents.AppId = data.appId;
+    contents.AppId = __expectString(data.appId);
   }
   if (data.backendEnvironmentName !== undefined && data.backendEnvironmentName !== null) {
-    contents.BackendEnvironmentName = data.backendEnvironmentName;
+    contents.BackendEnvironmentName = __expectString(data.backendEnvironmentName);
   }
   if (data.error !== undefined && data.error !== null) {
-    contents.Error = data.error;
+    contents.Error = __expectString(data.error);
   }
   if (data.resourceConfig !== undefined && data.resourceConfig !== null) {
     contents.ResourceConfig = deserializeAws_restJson1CreateBackendAuthResourceConfig(data.resourceConfig, context);
   }
   if (data.resourceName !== undefined && data.resourceName !== null) {
-    contents.ResourceName = data.resourceName;
+    contents.ResourceName = __expectString(data.resourceName);
   }
   return Promise.resolve(contents);
 };
@@ -2484,28 +2487,28 @@ export const deserializeAws_restJson1GetBackendJobCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.appId !== undefined && data.appId !== null) {
-    contents.AppId = data.appId;
+    contents.AppId = __expectString(data.appId);
   }
   if (data.backendEnvironmentName !== undefined && data.backendEnvironmentName !== null) {
-    contents.BackendEnvironmentName = data.backendEnvironmentName;
+    contents.BackendEnvironmentName = __expectString(data.backendEnvironmentName);
   }
   if (data.createTime !== undefined && data.createTime !== null) {
-    contents.CreateTime = data.createTime;
+    contents.CreateTime = __expectString(data.createTime);
   }
   if (data.error !== undefined && data.error !== null) {
-    contents.Error = data.error;
+    contents.Error = __expectString(data.error);
   }
   if (data.jobId !== undefined && data.jobId !== null) {
-    contents.JobId = data.jobId;
+    contents.JobId = __expectString(data.jobId);
   }
   if (data.operation !== undefined && data.operation !== null) {
-    contents.Operation = data.operation;
+    contents.Operation = __expectString(data.operation);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.Status = data.status;
+    contents.Status = __expectString(data.status);
   }
   if (data.updateTime !== undefined && data.updateTime !== null) {
-    contents.UpdateTime = data.updateTime;
+    contents.UpdateTime = __expectString(data.updateTime);
   }
   return Promise.resolve(contents);
 };
@@ -2587,16 +2590,16 @@ export const deserializeAws_restJson1GetTokenCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.appId !== undefined && data.appId !== null) {
-    contents.AppId = data.appId;
+    contents.AppId = __expectString(data.appId);
   }
   if (data.challengeCode !== undefined && data.challengeCode !== null) {
-    contents.ChallengeCode = data.challengeCode;
+    contents.ChallengeCode = __expectString(data.challengeCode);
   }
   if (data.sessionId !== undefined && data.sessionId !== null) {
-    contents.SessionId = data.sessionId;
+    contents.SessionId = __expectString(data.sessionId);
   }
   if (data.ttl !== undefined && data.ttl !== null) {
-    contents.Ttl = data.ttl;
+    contents.Ttl = __expectString(data.ttl);
   }
   return Promise.resolve(contents);
 };
@@ -2679,7 +2682,7 @@ export const deserializeAws_restJson1ListBackendJobsCommand = async (
     contents.Jobs = deserializeAws_restJson1ListOfBackendJobRespObj(data.jobs, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2762,19 +2765,19 @@ export const deserializeAws_restJson1RemoveAllBackendsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.appId !== undefined && data.appId !== null) {
-    contents.AppId = data.appId;
+    contents.AppId = __expectString(data.appId);
   }
   if (data.error !== undefined && data.error !== null) {
-    contents.Error = data.error;
+    contents.Error = __expectString(data.error);
   }
   if (data.jobId !== undefined && data.jobId !== null) {
-    contents.JobId = data.jobId;
+    contents.JobId = __expectString(data.jobId);
   }
   if (data.operation !== undefined && data.operation !== null) {
-    contents.Operation = data.operation;
+    contents.Operation = __expectString(data.operation);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.Status = data.status;
+    contents.Status = __expectString(data.status);
   }
   return Promise.resolve(contents);
 };
@@ -2853,7 +2856,7 @@ export const deserializeAws_restJson1RemoveBackendConfigCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.error !== undefined && data.error !== null) {
-    contents.Error = data.error;
+    contents.Error = __expectString(data.error);
   }
   return Promise.resolve(contents);
 };
@@ -2937,22 +2940,22 @@ export const deserializeAws_restJson1UpdateBackendAPICommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.appId !== undefined && data.appId !== null) {
-    contents.AppId = data.appId;
+    contents.AppId = __expectString(data.appId);
   }
   if (data.backendEnvironmentName !== undefined && data.backendEnvironmentName !== null) {
-    contents.BackendEnvironmentName = data.backendEnvironmentName;
+    contents.BackendEnvironmentName = __expectString(data.backendEnvironmentName);
   }
   if (data.error !== undefined && data.error !== null) {
-    contents.Error = data.error;
+    contents.Error = __expectString(data.error);
   }
   if (data.jobId !== undefined && data.jobId !== null) {
-    contents.JobId = data.jobId;
+    contents.JobId = __expectString(data.jobId);
   }
   if (data.operation !== undefined && data.operation !== null) {
-    contents.Operation = data.operation;
+    contents.Operation = __expectString(data.operation);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.Status = data.status;
+    contents.Status = __expectString(data.status);
   }
   return Promise.resolve(contents);
 };
@@ -3036,22 +3039,22 @@ export const deserializeAws_restJson1UpdateBackendAuthCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.appId !== undefined && data.appId !== null) {
-    contents.AppId = data.appId;
+    contents.AppId = __expectString(data.appId);
   }
   if (data.backendEnvironmentName !== undefined && data.backendEnvironmentName !== null) {
-    contents.BackendEnvironmentName = data.backendEnvironmentName;
+    contents.BackendEnvironmentName = __expectString(data.backendEnvironmentName);
   }
   if (data.error !== undefined && data.error !== null) {
-    contents.Error = data.error;
+    contents.Error = __expectString(data.error);
   }
   if (data.jobId !== undefined && data.jobId !== null) {
-    contents.JobId = data.jobId;
+    contents.JobId = __expectString(data.jobId);
   }
   if (data.operation !== undefined && data.operation !== null) {
-    contents.Operation = data.operation;
+    contents.Operation = __expectString(data.operation);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.Status = data.status;
+    contents.Status = __expectString(data.status);
   }
   return Promise.resolve(contents);
 };
@@ -3133,13 +3136,13 @@ export const deserializeAws_restJson1UpdateBackendConfigCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.appId !== undefined && data.appId !== null) {
-    contents.AppId = data.appId;
+    contents.AppId = __expectString(data.appId);
   }
   if (data.backendManagerAppId !== undefined && data.backendManagerAppId !== null) {
-    contents.BackendManagerAppId = data.backendManagerAppId;
+    contents.BackendManagerAppId = __expectString(data.backendManagerAppId);
   }
   if (data.error !== undefined && data.error !== null) {
-    contents.Error = data.error;
+    contents.Error = __expectString(data.error);
   }
   if (data.loginAuthConfig !== undefined && data.loginAuthConfig !== null) {
     contents.LoginAuthConfig = deserializeAws_restJson1LoginAuthConfigReqObj(data.loginAuthConfig, context);
@@ -3228,28 +3231,28 @@ export const deserializeAws_restJson1UpdateBackendJobCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.appId !== undefined && data.appId !== null) {
-    contents.AppId = data.appId;
+    contents.AppId = __expectString(data.appId);
   }
   if (data.backendEnvironmentName !== undefined && data.backendEnvironmentName !== null) {
-    contents.BackendEnvironmentName = data.backendEnvironmentName;
+    contents.BackendEnvironmentName = __expectString(data.backendEnvironmentName);
   }
   if (data.createTime !== undefined && data.createTime !== null) {
-    contents.CreateTime = data.createTime;
+    contents.CreateTime = __expectString(data.createTime);
   }
   if (data.error !== undefined && data.error !== null) {
-    contents.Error = data.error;
+    contents.Error = __expectString(data.error);
   }
   if (data.jobId !== undefined && data.jobId !== null) {
-    contents.JobId = data.jobId;
+    contents.JobId = __expectString(data.jobId);
   }
   if (data.operation !== undefined && data.operation !== null) {
-    contents.Operation = data.operation;
+    contents.Operation = __expectString(data.operation);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.Status = data.status;
+    contents.Status = __expectString(data.status);
   }
   if (data.updateTime !== undefined && data.updateTime !== null) {
-    contents.UpdateTime = data.updateTime;
+    contents.UpdateTime = __expectString(data.updateTime);
   }
   return Promise.resolve(contents);
 };
@@ -3327,7 +3330,7 @@ const deserializeAws_restJson1BadRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -3344,7 +3347,7 @@ const deserializeAws_restJson1GatewayTimeoutExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -3362,10 +3365,10 @@ const deserializeAws_restJson1NotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   if (data.resourceType !== undefined && data.resourceType !== null) {
-    contents.ResourceType = data.resourceType;
+    contents.ResourceType = __expectString(data.resourceType);
   }
   return contents;
 };
@@ -3383,10 +3386,10 @@ const deserializeAws_restJson1TooManyRequestsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.limitType !== undefined && data.limitType !== null) {
-    contents.LimitType = data.limitType;
+    contents.LimitType = __expectString(data.limitType);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -3857,30 +3860,20 @@ const deserializeAws_restJson1BackendAPIAppSyncAuthSettings = (
   context: __SerdeContext
 ): BackendAPIAppSyncAuthSettings => {
   return {
-    CognitoUserPoolId:
-      output.cognitoUserPoolId !== undefined && output.cognitoUserPoolId !== null
-        ? output.cognitoUserPoolId
-        : undefined,
-    Description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    ExpirationTime:
-      output.expirationTime !== undefined && output.expirationTime !== null ? output.expirationTime : undefined,
-    OpenIDAuthTTL:
-      output.openIDAuthTTL !== undefined && output.openIDAuthTTL !== null ? output.openIDAuthTTL : undefined,
-    OpenIDClientId:
-      output.openIDClientId !== undefined && output.openIDClientId !== null ? output.openIDClientId : undefined,
-    OpenIDIatTTL: output.openIDIatTTL !== undefined && output.openIDIatTTL !== null ? output.openIDIatTTL : undefined,
-    OpenIDIssueURL:
-      output.openIDIssueURL !== undefined && output.openIDIssueURL !== null ? output.openIDIssueURL : undefined,
-    OpenIDProviderName:
-      output.openIDProviderName !== undefined && output.openIDProviderName !== null
-        ? output.openIDProviderName
-        : undefined,
+    CognitoUserPoolId: __expectString(output.cognitoUserPoolId),
+    Description: __expectString(output.description),
+    ExpirationTime: __expectNumber(output.expirationTime),
+    OpenIDAuthTTL: __expectString(output.openIDAuthTTL),
+    OpenIDClientId: __expectString(output.openIDClientId),
+    OpenIDIatTTL: __expectString(output.openIDIatTTL),
+    OpenIDIssueURL: __expectString(output.openIDIssueURL),
+    OpenIDProviderName: __expectString(output.openIDProviderName),
   } as any;
 };
 
 const deserializeAws_restJson1BackendAPIAuthType = (output: any, context: __SerdeContext): BackendAPIAuthType => {
   return {
-    Mode: output.mode !== undefined && output.mode !== null ? output.mode : undefined,
+    Mode: __expectString(output.mode),
     Settings:
       output.settings !== undefined && output.settings !== null
         ? deserializeAws_restJson1BackendAPIAppSyncAuthSettings(output.settings, context)
@@ -3893,10 +3886,7 @@ const deserializeAws_restJson1BackendAPIConflictResolution = (
   context: __SerdeContext
 ): BackendAPIConflictResolution => {
   return {
-    ResolutionStrategy:
-      output.resolutionStrategy !== undefined && output.resolutionStrategy !== null
-        ? output.resolutionStrategy
-        : undefined,
+    ResolutionStrategy: __expectString(output.resolutionStrategy),
   } as any;
 };
 
@@ -3909,7 +3899,7 @@ const deserializeAws_restJson1BackendAPIResourceConfig = (
       output.additionalAuthTypes !== undefined && output.additionalAuthTypes !== null
         ? deserializeAws_restJson1ListOfBackendAPIAuthType(output.additionalAuthTypes, context)
         : undefined,
-    ApiName: output.apiName !== undefined && output.apiName !== null ? output.apiName : undefined,
+    ApiName: __expectString(output.apiName),
     ConflictResolution:
       output.conflictResolution !== undefined && output.conflictResolution !== null
         ? deserializeAws_restJson1BackendAPIConflictResolution(output.conflictResolution, context)
@@ -3918,9 +3908,8 @@ const deserializeAws_restJson1BackendAPIResourceConfig = (
       output.defaultAuthType !== undefined && output.defaultAuthType !== null
         ? deserializeAws_restJson1BackendAPIAuthType(output.defaultAuthType, context)
         : undefined,
-    Service: output.service !== undefined && output.service !== null ? output.service : undefined,
-    TransformSchema:
-      output.transformSchema !== undefined && output.transformSchema !== null ? output.transformSchema : undefined,
+    Service: __expectString(output.service),
+    TransformSchema: __expectString(output.transformSchema),
   } as any;
 };
 
@@ -3929,25 +3918,21 @@ const deserializeAws_restJson1BackendAuthSocialProviderConfig = (
   context: __SerdeContext
 ): BackendAuthSocialProviderConfig => {
   return {
-    ClientId: output.client_id !== undefined && output.client_id !== null ? output.client_id : undefined,
-    ClientSecret:
-      output.client_secret !== undefined && output.client_secret !== null ? output.client_secret : undefined,
+    ClientId: __expectString(output.client_id),
+    ClientSecret: __expectString(output.client_secret),
   } as any;
 };
 
 const deserializeAws_restJson1BackendJobRespObj = (output: any, context: __SerdeContext): BackendJobRespObj => {
   return {
-    AppId: output.appId !== undefined && output.appId !== null ? output.appId : undefined,
-    BackendEnvironmentName:
-      output.backendEnvironmentName !== undefined && output.backendEnvironmentName !== null
-        ? output.backendEnvironmentName
-        : undefined,
-    CreateTime: output.createTime !== undefined && output.createTime !== null ? output.createTime : undefined,
-    Error: output.error !== undefined && output.error !== null ? output.error : undefined,
-    JobId: output.jobId !== undefined && output.jobId !== null ? output.jobId : undefined,
-    Operation: output.operation !== undefined && output.operation !== null ? output.operation : undefined,
-    Status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    UpdateTime: output.updateTime !== undefined && output.updateTime !== null ? output.updateTime : undefined,
+    AppId: __expectString(output.appId),
+    BackendEnvironmentName: __expectString(output.backendEnvironmentName),
+    CreateTime: __expectString(output.createTime),
+    Error: __expectString(output.error),
+    JobId: __expectString(output.jobId),
+    Operation: __expectString(output.operation),
+    Status: __expectString(output.status),
+    UpdateTime: __expectString(output.updateTime),
   } as any;
 };
 
@@ -3956,8 +3941,7 @@ const deserializeAws_restJson1CreateBackendAuthForgotPasswordConfig = (
   context: __SerdeContext
 ): CreateBackendAuthForgotPasswordConfig => {
   return {
-    DeliveryMethod:
-      output.deliveryMethod !== undefined && output.deliveryMethod !== null ? output.deliveryMethod : undefined,
+    DeliveryMethod: __expectString(output.deliveryMethod),
     EmailSettings:
       output.emailSettings !== undefined && output.emailSettings !== null
         ? deserializeAws_restJson1EmailSettings(output.emailSettings, context)
@@ -3974,12 +3958,8 @@ const deserializeAws_restJson1CreateBackendAuthIdentityPoolConfig = (
   context: __SerdeContext
 ): CreateBackendAuthIdentityPoolConfig => {
   return {
-    IdentityPoolName:
-      output.identityPoolName !== undefined && output.identityPoolName !== null ? output.identityPoolName : undefined,
-    UnauthenticatedLogin:
-      output.unauthenticatedLogin !== undefined && output.unauthenticatedLogin !== null
-        ? output.unauthenticatedLogin
-        : undefined,
+    IdentityPoolName: __expectString(output.identityPoolName),
+    UnauthenticatedLogin: __expectBoolean(output.unauthenticatedLogin),
   } as any;
 };
 
@@ -3988,7 +3968,7 @@ const deserializeAws_restJson1CreateBackendAuthMFAConfig = (
   context: __SerdeContext
 ): CreateBackendAuthMFAConfig => {
   return {
-    MFAMode: output.MFAMode !== undefined && output.MFAMode !== null ? output.MFAMode : undefined,
+    MFAMode: __expectString(output.MFAMode),
     Settings:
       output.settings !== undefined && output.settings !== null
         ? deserializeAws_restJson1Settings(output.settings, context)
@@ -4001,9 +3981,8 @@ const deserializeAws_restJson1CreateBackendAuthOAuthConfig = (
   context: __SerdeContext
 ): CreateBackendAuthOAuthConfig => {
   return {
-    DomainPrefix: output.domainPrefix !== undefined && output.domainPrefix !== null ? output.domainPrefix : undefined,
-    OAuthGrantType:
-      output.oAuthGrantType !== undefined && output.oAuthGrantType !== null ? output.oAuthGrantType : undefined,
+    DomainPrefix: __expectString(output.domainPrefix),
+    OAuthGrantType: __expectString(output.oAuthGrantType),
     OAuthScopes:
       output.oAuthScopes !== undefined && output.oAuthScopes !== null
         ? deserializeAws_restJson1ListOfOAuthScopesElement(output.oAuthScopes, context)
@@ -4032,8 +4011,7 @@ const deserializeAws_restJson1CreateBackendAuthPasswordPolicyConfig = (
       output.additionalConstraints !== undefined && output.additionalConstraints !== null
         ? deserializeAws_restJson1ListOfAdditionalConstraintsElement(output.additionalConstraints, context)
         : undefined,
-    MinimumLength:
-      output.minimumLength !== undefined && output.minimumLength !== null ? output.minimumLength : undefined,
+    MinimumLength: __expectNumber(output.minimumLength),
   } as any;
 };
 
@@ -4042,13 +4020,12 @@ const deserializeAws_restJson1CreateBackendAuthResourceConfig = (
   context: __SerdeContext
 ): CreateBackendAuthResourceConfig => {
   return {
-    AuthResources:
-      output.authResources !== undefined && output.authResources !== null ? output.authResources : undefined,
+    AuthResources: __expectString(output.authResources),
     IdentityPoolConfigs:
       output.identityPoolConfigs !== undefined && output.identityPoolConfigs !== null
         ? deserializeAws_restJson1CreateBackendAuthIdentityPoolConfig(output.identityPoolConfigs, context)
         : undefined,
-    Service: output.service !== undefined && output.service !== null ? output.service : undefined,
+    Service: __expectString(output.service),
     UserPoolConfigs:
       output.userPoolConfigs !== undefined && output.userPoolConfigs !== null
         ? deserializeAws_restJson1CreateBackendAuthUserPoolConfig(output.userPoolConfigs, context)
@@ -4081,15 +4058,15 @@ const deserializeAws_restJson1CreateBackendAuthUserPoolConfig = (
       output.requiredSignUpAttributes !== undefined && output.requiredSignUpAttributes !== null
         ? deserializeAws_restJson1ListOfRequiredSignUpAttributesElement(output.requiredSignUpAttributes, context)
         : undefined,
-    SignInMethod: output.signInMethod !== undefined && output.signInMethod !== null ? output.signInMethod : undefined,
-    UserPoolName: output.userPoolName !== undefined && output.userPoolName !== null ? output.userPoolName : undefined,
+    SignInMethod: __expectString(output.signInMethod),
+    UserPoolName: __expectString(output.userPoolName),
   } as any;
 };
 
 const deserializeAws_restJson1EmailSettings = (output: any, context: __SerdeContext): EmailSettings => {
   return {
-    EmailMessage: output.emailMessage !== undefined && output.emailMessage !== null ? output.emailMessage : undefined,
-    EmailSubject: output.emailSubject !== undefined && output.emailSubject !== null ? output.emailSubject : undefined,
+    EmailMessage: __expectString(output.emailMessage),
+    EmailSubject: __expectString(output.emailSubject),
   } as any;
 };
 
@@ -4100,7 +4077,7 @@ const deserializeAws_restJson1ListOf__string = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4114,7 +4091,7 @@ const deserializeAws_restJson1ListOfAdditionalConstraintsElement = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4153,7 +4130,7 @@ const deserializeAws_restJson1ListOfMfaTypesElement = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4167,7 +4144,7 @@ const deserializeAws_restJson1ListOfOAuthScopesElement = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4181,28 +4158,16 @@ const deserializeAws_restJson1ListOfRequiredSignUpAttributesElement = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1LoginAuthConfigReqObj = (output: any, context: __SerdeContext): LoginAuthConfigReqObj => {
   return {
-    AwsCognitoIdentityPoolId:
-      output.aws_cognito_identity_pool_id !== undefined && output.aws_cognito_identity_pool_id !== null
-        ? output.aws_cognito_identity_pool_id
-        : undefined,
-    AwsCognitoRegion:
-      output.aws_cognito_region !== undefined && output.aws_cognito_region !== null
-        ? output.aws_cognito_region
-        : undefined,
-    AwsUserPoolsId:
-      output.aws_user_pools_id !== undefined && output.aws_user_pools_id !== null
-        ? output.aws_user_pools_id
-        : undefined,
-    AwsUserPoolsWebClientId:
-      output.aws_user_pools_web_client_id !== undefined && output.aws_user_pools_web_client_id !== null
-        ? output.aws_user_pools_web_client_id
-        : undefined,
+    AwsCognitoIdentityPoolId: __expectString(output.aws_cognito_identity_pool_id),
+    AwsCognitoRegion: __expectString(output.aws_cognito_region),
+    AwsUserPoolsId: __expectString(output.aws_user_pools_id),
+    AwsUserPoolsWebClientId: __expectString(output.aws_user_pools_web_client_id),
   } as any;
 };
 
@@ -4212,13 +4177,13 @@ const deserializeAws_restJson1Settings = (output: any, context: __SerdeContext):
       output.mfaTypes !== undefined && output.mfaTypes !== null
         ? deserializeAws_restJson1ListOfMfaTypesElement(output.mfaTypes, context)
         : undefined,
-    SmsMessage: output.smsMessage !== undefined && output.smsMessage !== null ? output.smsMessage : undefined,
+    SmsMessage: __expectString(output.smsMessage),
   } as any;
 };
 
 const deserializeAws_restJson1SmsSettings = (output: any, context: __SerdeContext): SmsSettings => {
   return {
-    SmsMessage: output.smsMessage !== undefined && output.smsMessage !== null ? output.smsMessage : undefined,
+    SmsMessage: __expectString(output.smsMessage),
   } as any;
 };
 

--- a/clients/client-api-gateway/protocols/Aws_restJson1.ts
+++ b/clients/client-api-gateway/protocols/Aws_restJson1.ts
@@ -277,6 +277,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -5017,22 +5020,22 @@ export const deserializeAws_restJson1CreateApiKeyCommand = async (
     contents.createdDate = new Date(Math.round(data.createdDate * 1000));
   }
   if (data.customerId !== undefined && data.customerId !== null) {
-    contents.customerId = data.customerId;
+    contents.customerId = __expectString(data.customerId);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.enabled !== undefined && data.enabled !== null) {
-    contents.enabled = data.enabled;
+    contents.enabled = __expectBoolean(data.enabled);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   if (data.lastUpdatedDate !== undefined && data.lastUpdatedDate !== null) {
     contents.lastUpdatedDate = new Date(Math.round(data.lastUpdatedDate * 1000));
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.stageKeys !== undefined && data.stageKeys !== null) {
     contents.stageKeys = deserializeAws_restJson1ListOfString(data.stageKeys, context);
@@ -5041,7 +5044,7 @@ export const deserializeAws_restJson1CreateApiKeyCommand = async (
     contents.tags = deserializeAws_restJson1MapOfStringToString(data.tags, context);
   }
   if (data.value !== undefined && data.value !== null) {
-    contents.value = data.value;
+    contents.value = __expectString(data.value);
   }
   return Promise.resolve(contents);
 };
@@ -5145,34 +5148,34 @@ export const deserializeAws_restJson1CreateAuthorizerCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.authType !== undefined && data.authType !== null) {
-    contents.authType = data.authType;
+    contents.authType = __expectString(data.authType);
   }
   if (data.authorizerCredentials !== undefined && data.authorizerCredentials !== null) {
-    contents.authorizerCredentials = data.authorizerCredentials;
+    contents.authorizerCredentials = __expectString(data.authorizerCredentials);
   }
   if (data.authorizerResultTtlInSeconds !== undefined && data.authorizerResultTtlInSeconds !== null) {
-    contents.authorizerResultTtlInSeconds = data.authorizerResultTtlInSeconds;
+    contents.authorizerResultTtlInSeconds = __expectNumber(data.authorizerResultTtlInSeconds);
   }
   if (data.authorizerUri !== undefined && data.authorizerUri !== null) {
-    contents.authorizerUri = data.authorizerUri;
+    contents.authorizerUri = __expectString(data.authorizerUri);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   if (data.identitySource !== undefined && data.identitySource !== null) {
-    contents.identitySource = data.identitySource;
+    contents.identitySource = __expectString(data.identitySource);
   }
   if (data.identityValidationExpression !== undefined && data.identityValidationExpression !== null) {
-    contents.identityValidationExpression = data.identityValidationExpression;
+    contents.identityValidationExpression = __expectString(data.identityValidationExpression);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.providerARNs !== undefined && data.providerARNs !== null) {
     contents.providerARNs = deserializeAws_restJson1ListOfARNs(data.providerARNs, context);
   }
   if (data.type !== undefined && data.type !== null) {
-    contents.type = data.type;
+    contents.type = __expectString(data.type);
   }
   return Promise.resolve(contents);
 };
@@ -5261,13 +5264,13 @@ export const deserializeAws_restJson1CreateBasePathMappingCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.basePath !== undefined && data.basePath !== null) {
-    contents.basePath = data.basePath;
+    contents.basePath = __expectString(data.basePath);
   }
   if (data.restApiId !== undefined && data.restApiId !== null) {
-    contents.restApiId = data.restApiId;
+    contents.restApiId = __expectString(data.restApiId);
   }
   if (data.stage !== undefined && data.stage !== null) {
-    contents.stage = data.stage;
+    contents.stage = __expectString(data.stage);
   }
   return Promise.resolve(contents);
 };
@@ -5363,10 +5366,10 @@ export const deserializeAws_restJson1CreateDeploymentCommand = async (
     contents.createdDate = new Date(Math.round(data.createdDate * 1000));
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   return Promise.resolve(contents);
 };
@@ -5471,13 +5474,13 @@ export const deserializeAws_restJson1CreateDocumentationPartCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   if (data.location !== undefined && data.location !== null) {
     contents.location = deserializeAws_restJson1DocumentationPartLocation(data.location, context);
   }
   if (data.properties !== undefined && data.properties !== null) {
-    contents.properties = data.properties;
+    contents.properties = __expectString(data.properties);
   }
   return Promise.resolve(contents);
 };
@@ -5577,10 +5580,10 @@ export const deserializeAws_restJson1CreateDocumentationVersionCommand = async (
     contents.createdDate = new Date(Math.round(data.createdDate * 1000));
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.version !== undefined && data.version !== null) {
-    contents.version = data.version;
+    contents.version = __expectString(data.version);
   }
   return Promise.resolve(contents);
 };
@@ -5690,28 +5693,28 @@ export const deserializeAws_restJson1CreateDomainNameCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.certificateArn !== undefined && data.certificateArn !== null) {
-    contents.certificateArn = data.certificateArn;
+    contents.certificateArn = __expectString(data.certificateArn);
   }
   if (data.certificateName !== undefined && data.certificateName !== null) {
-    contents.certificateName = data.certificateName;
+    contents.certificateName = __expectString(data.certificateName);
   }
   if (data.certificateUploadDate !== undefined && data.certificateUploadDate !== null) {
     contents.certificateUploadDate = new Date(Math.round(data.certificateUploadDate * 1000));
   }
   if (data.distributionDomainName !== undefined && data.distributionDomainName !== null) {
-    contents.distributionDomainName = data.distributionDomainName;
+    contents.distributionDomainName = __expectString(data.distributionDomainName);
   }
   if (data.distributionHostedZoneId !== undefined && data.distributionHostedZoneId !== null) {
-    contents.distributionHostedZoneId = data.distributionHostedZoneId;
+    contents.distributionHostedZoneId = __expectString(data.distributionHostedZoneId);
   }
   if (data.domainName !== undefined && data.domainName !== null) {
-    contents.domainName = data.domainName;
+    contents.domainName = __expectString(data.domainName);
   }
   if (data.domainNameStatus !== undefined && data.domainNameStatus !== null) {
-    contents.domainNameStatus = data.domainNameStatus;
+    contents.domainNameStatus = __expectString(data.domainNameStatus);
   }
   if (data.domainNameStatusMessage !== undefined && data.domainNameStatusMessage !== null) {
-    contents.domainNameStatusMessage = data.domainNameStatusMessage;
+    contents.domainNameStatusMessage = __expectString(data.domainNameStatusMessage);
   }
   if (data.endpointConfiguration !== undefined && data.endpointConfiguration !== null) {
     contents.endpointConfiguration = deserializeAws_restJson1EndpointConfiguration(data.endpointConfiguration, context);
@@ -5723,19 +5726,19 @@ export const deserializeAws_restJson1CreateDomainNameCommand = async (
     );
   }
   if (data.regionalCertificateArn !== undefined && data.regionalCertificateArn !== null) {
-    contents.regionalCertificateArn = data.regionalCertificateArn;
+    contents.regionalCertificateArn = __expectString(data.regionalCertificateArn);
   }
   if (data.regionalCertificateName !== undefined && data.regionalCertificateName !== null) {
-    contents.regionalCertificateName = data.regionalCertificateName;
+    contents.regionalCertificateName = __expectString(data.regionalCertificateName);
   }
   if (data.regionalDomainName !== undefined && data.regionalDomainName !== null) {
-    contents.regionalDomainName = data.regionalDomainName;
+    contents.regionalDomainName = __expectString(data.regionalDomainName);
   }
   if (data.regionalHostedZoneId !== undefined && data.regionalHostedZoneId !== null) {
-    contents.regionalHostedZoneId = data.regionalHostedZoneId;
+    contents.regionalHostedZoneId = __expectString(data.regionalHostedZoneId);
   }
   if (data.securityPolicy !== undefined && data.securityPolicy !== null) {
-    contents.securityPolicy = data.securityPolicy;
+    contents.securityPolicy = __expectString(data.securityPolicy);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1MapOfStringToString(data.tags, context);
@@ -5821,19 +5824,19 @@ export const deserializeAws_restJson1CreateModelCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.contentType !== undefined && data.contentType !== null) {
-    contents.contentType = data.contentType;
+    contents.contentType = __expectString(data.contentType);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.schema !== undefined && data.schema !== null) {
-    contents.schema = data.schema;
+    contents.schema = __expectString(data.schema);
   }
   return Promise.resolve(contents);
 };
@@ -5931,16 +5934,16 @@ export const deserializeAws_restJson1CreateRequestValidatorCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.validateRequestBody !== undefined && data.validateRequestBody !== null) {
-    contents.validateRequestBody = data.validateRequestBody;
+    contents.validateRequestBody = __expectBoolean(data.validateRequestBody);
   }
   if (data.validateRequestParameters !== undefined && data.validateRequestParameters !== null) {
-    contents.validateRequestParameters = data.validateRequestParameters;
+    contents.validateRequestParameters = __expectBoolean(data.validateRequestParameters);
   }
   return Promise.resolve(contents);
 };
@@ -6031,16 +6034,16 @@ export const deserializeAws_restJson1CreateResourceCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   if (data.parentId !== undefined && data.parentId !== null) {
-    contents.parentId = data.parentId;
+    contents.parentId = __expectString(data.parentId);
   }
   if (data.path !== undefined && data.path !== null) {
-    contents.path = data.path;
+    contents.path = __expectString(data.path);
   }
   if (data.pathPart !== undefined && data.pathPart !== null) {
-    contents.pathPart = data.pathPart;
+    contents.pathPart = __expectString(data.pathPart);
   }
   if (data.resourceMethods !== undefined && data.resourceMethods !== null) {
     contents.resourceMethods = deserializeAws_restJson1MapOfMethod(data.resourceMethods, context);
@@ -6150,7 +6153,7 @@ export const deserializeAws_restJson1CreateRestApiCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.apiKeySource !== undefined && data.apiKeySource !== null) {
-    contents.apiKeySource = data.apiKeySource;
+    contents.apiKeySource = __expectString(data.apiKeySource);
   }
   if (data.binaryMediaTypes !== undefined && data.binaryMediaTypes !== null) {
     contents.binaryMediaTypes = deserializeAws_restJson1ListOfString(data.binaryMediaTypes, context);
@@ -6159,31 +6162,31 @@ export const deserializeAws_restJson1CreateRestApiCommand = async (
     contents.createdDate = new Date(Math.round(data.createdDate * 1000));
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.disableExecuteApiEndpoint !== undefined && data.disableExecuteApiEndpoint !== null) {
-    contents.disableExecuteApiEndpoint = data.disableExecuteApiEndpoint;
+    contents.disableExecuteApiEndpoint = __expectBoolean(data.disableExecuteApiEndpoint);
   }
   if (data.endpointConfiguration !== undefined && data.endpointConfiguration !== null) {
     contents.endpointConfiguration = deserializeAws_restJson1EndpointConfiguration(data.endpointConfiguration, context);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   if (data.minimumCompressionSize !== undefined && data.minimumCompressionSize !== null) {
-    contents.minimumCompressionSize = data.minimumCompressionSize;
+    contents.minimumCompressionSize = __expectNumber(data.minimumCompressionSize);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.policy !== undefined && data.policy !== null) {
-    contents.policy = data.policy;
+    contents.policy = __expectString(data.policy);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1MapOfStringToString(data.tags, context);
   }
   if (data.version !== undefined && data.version !== null) {
-    contents.version = data.version;
+    contents.version = __expectString(data.version);
   }
   if (data.warnings !== undefined && data.warnings !== null) {
     contents.warnings = deserializeAws_restJson1ListOfString(data.warnings, context);
@@ -6284,31 +6287,31 @@ export const deserializeAws_restJson1CreateStageCommand = async (
     contents.accessLogSettings = deserializeAws_restJson1AccessLogSettings(data.accessLogSettings, context);
   }
   if (data.cacheClusterEnabled !== undefined && data.cacheClusterEnabled !== null) {
-    contents.cacheClusterEnabled = data.cacheClusterEnabled;
+    contents.cacheClusterEnabled = __expectBoolean(data.cacheClusterEnabled);
   }
   if (data.cacheClusterSize !== undefined && data.cacheClusterSize !== null) {
-    contents.cacheClusterSize = data.cacheClusterSize;
+    contents.cacheClusterSize = __expectString(data.cacheClusterSize);
   }
   if (data.cacheClusterStatus !== undefined && data.cacheClusterStatus !== null) {
-    contents.cacheClusterStatus = data.cacheClusterStatus;
+    contents.cacheClusterStatus = __expectString(data.cacheClusterStatus);
   }
   if (data.canarySettings !== undefined && data.canarySettings !== null) {
     contents.canarySettings = deserializeAws_restJson1CanarySettings(data.canarySettings, context);
   }
   if (data.clientCertificateId !== undefined && data.clientCertificateId !== null) {
-    contents.clientCertificateId = data.clientCertificateId;
+    contents.clientCertificateId = __expectString(data.clientCertificateId);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
     contents.createdDate = new Date(Math.round(data.createdDate * 1000));
   }
   if (data.deploymentId !== undefined && data.deploymentId !== null) {
-    contents.deploymentId = data.deploymentId;
+    contents.deploymentId = __expectString(data.deploymentId);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.documentationVersion !== undefined && data.documentationVersion !== null) {
-    contents.documentationVersion = data.documentationVersion;
+    contents.documentationVersion = __expectString(data.documentationVersion);
   }
   if (data.lastUpdatedDate !== undefined && data.lastUpdatedDate !== null) {
     contents.lastUpdatedDate = new Date(Math.round(data.lastUpdatedDate * 1000));
@@ -6317,19 +6320,19 @@ export const deserializeAws_restJson1CreateStageCommand = async (
     contents.methodSettings = deserializeAws_restJson1MapOfMethodSettings(data.methodSettings, context);
   }
   if (data.stageName !== undefined && data.stageName !== null) {
-    contents.stageName = data.stageName;
+    contents.stageName = __expectString(data.stageName);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1MapOfStringToString(data.tags, context);
   }
   if (data.tracingEnabled !== undefined && data.tracingEnabled !== null) {
-    contents.tracingEnabled = data.tracingEnabled;
+    contents.tracingEnabled = __expectBoolean(data.tracingEnabled);
   }
   if (data.variables !== undefined && data.variables !== null) {
     contents.variables = deserializeAws_restJson1MapOfStringToString(data.variables, context);
   }
   if (data.webAclArn !== undefined && data.webAclArn !== null) {
-    contents.webAclArn = data.webAclArn;
+    contents.webAclArn = __expectString(data.webAclArn);
   }
   return Promise.resolve(contents);
 };
@@ -6434,16 +6437,16 @@ export const deserializeAws_restJson1CreateUsagePlanCommand = async (
     contents.apiStages = deserializeAws_restJson1ListOfApiStage(data.apiStages, context);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.productCode !== undefined && data.productCode !== null) {
-    contents.productCode = data.productCode;
+    contents.productCode = __expectString(data.productCode);
   }
   if (data.quota !== undefined && data.quota !== null) {
     contents.quota = deserializeAws_restJson1QuotaSettings(data.quota, context);
@@ -6550,16 +6553,16 @@ export const deserializeAws_restJson1CreateUsagePlanKeyCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.type !== undefined && data.type !== null) {
-    contents.type = data.type;
+    contents.type = __expectString(data.type);
   }
   if (data.value !== undefined && data.value !== null) {
-    contents.value = data.value;
+    contents.value = __expectString(data.value);
   }
   return Promise.resolve(contents);
 };
@@ -6652,19 +6655,19 @@ export const deserializeAws_restJson1CreateVpcLinkCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.status = data.status;
+    contents.status = __expectString(data.status);
   }
   if (data.statusMessage !== undefined && data.statusMessage !== null) {
-    contents.statusMessage = data.statusMessage;
+    contents.statusMessage = __expectString(data.statusMessage);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1MapOfStringToString(data.tags, context);
@@ -8551,19 +8554,19 @@ export const deserializeAws_restJson1GenerateClientCertificateCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.clientCertificateId !== undefined && data.clientCertificateId !== null) {
-    contents.clientCertificateId = data.clientCertificateId;
+    contents.clientCertificateId = __expectString(data.clientCertificateId);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
     contents.createdDate = new Date(Math.round(data.createdDate * 1000));
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.expirationDate !== undefined && data.expirationDate !== null) {
     contents.expirationDate = new Date(Math.round(data.expirationDate * 1000));
   }
   if (data.pemEncodedCertificate !== undefined && data.pemEncodedCertificate !== null) {
-    contents.pemEncodedCertificate = data.pemEncodedCertificate;
+    contents.pemEncodedCertificate = __expectString(data.pemEncodedCertificate);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1MapOfStringToString(data.tags, context);
@@ -8640,10 +8643,10 @@ export const deserializeAws_restJson1GetAccountCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.apiKeyVersion !== undefined && data.apiKeyVersion !== null) {
-    contents.apiKeyVersion = data.apiKeyVersion;
+    contents.apiKeyVersion = __expectString(data.apiKeyVersion);
   }
   if (data.cloudwatchRoleArn !== undefined && data.cloudwatchRoleArn !== null) {
-    contents.cloudwatchRoleArn = data.cloudwatchRoleArn;
+    contents.cloudwatchRoleArn = __expectString(data.cloudwatchRoleArn);
   }
   if (data.features !== undefined && data.features !== null) {
     contents.features = deserializeAws_restJson1ListOfString(data.features, context);
@@ -8732,22 +8735,22 @@ export const deserializeAws_restJson1GetApiKeyCommand = async (
     contents.createdDate = new Date(Math.round(data.createdDate * 1000));
   }
   if (data.customerId !== undefined && data.customerId !== null) {
-    contents.customerId = data.customerId;
+    contents.customerId = __expectString(data.customerId);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.enabled !== undefined && data.enabled !== null) {
-    contents.enabled = data.enabled;
+    contents.enabled = __expectBoolean(data.enabled);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   if (data.lastUpdatedDate !== undefined && data.lastUpdatedDate !== null) {
     contents.lastUpdatedDate = new Date(Math.round(data.lastUpdatedDate * 1000));
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.stageKeys !== undefined && data.stageKeys !== null) {
     contents.stageKeys = deserializeAws_restJson1ListOfString(data.stageKeys, context);
@@ -8756,7 +8759,7 @@ export const deserializeAws_restJson1GetApiKeyCommand = async (
     contents.tags = deserializeAws_restJson1MapOfStringToString(data.tags, context);
   }
   if (data.value !== undefined && data.value !== null) {
-    contents.value = data.value;
+    contents.value = __expectString(data.value);
   }
   return Promise.resolve(contents);
 };
@@ -8832,7 +8835,7 @@ export const deserializeAws_restJson1GetApiKeysCommand = async (
     contents.items = deserializeAws_restJson1ListOfApiKey(data.item, context);
   }
   if (data.position !== undefined && data.position !== null) {
-    contents.position = data.position;
+    contents.position = __expectString(data.position);
   }
   if (data.warnings !== undefined && data.warnings !== null) {
     contents.warnings = deserializeAws_restJson1ListOfString(data.warnings, context);
@@ -8915,34 +8918,34 @@ export const deserializeAws_restJson1GetAuthorizerCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.authType !== undefined && data.authType !== null) {
-    contents.authType = data.authType;
+    contents.authType = __expectString(data.authType);
   }
   if (data.authorizerCredentials !== undefined && data.authorizerCredentials !== null) {
-    contents.authorizerCredentials = data.authorizerCredentials;
+    contents.authorizerCredentials = __expectString(data.authorizerCredentials);
   }
   if (data.authorizerResultTtlInSeconds !== undefined && data.authorizerResultTtlInSeconds !== null) {
-    contents.authorizerResultTtlInSeconds = data.authorizerResultTtlInSeconds;
+    contents.authorizerResultTtlInSeconds = __expectNumber(data.authorizerResultTtlInSeconds);
   }
   if (data.authorizerUri !== undefined && data.authorizerUri !== null) {
-    contents.authorizerUri = data.authorizerUri;
+    contents.authorizerUri = __expectString(data.authorizerUri);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   if (data.identitySource !== undefined && data.identitySource !== null) {
-    contents.identitySource = data.identitySource;
+    contents.identitySource = __expectString(data.identitySource);
   }
   if (data.identityValidationExpression !== undefined && data.identityValidationExpression !== null) {
-    contents.identityValidationExpression = data.identityValidationExpression;
+    contents.identityValidationExpression = __expectString(data.identityValidationExpression);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.providerARNs !== undefined && data.providerARNs !== null) {
     contents.providerARNs = deserializeAws_restJson1ListOfARNs(data.providerARNs, context);
   }
   if (data.type !== undefined && data.type !== null) {
-    contents.type = data.type;
+    contents.type = __expectString(data.type);
   }
   return Promise.resolve(contents);
 };
@@ -9017,7 +9020,7 @@ export const deserializeAws_restJson1GetAuthorizersCommand = async (
     contents.items = deserializeAws_restJson1ListOfAuthorizer(data.item, context);
   }
   if (data.position !== undefined && data.position !== null) {
-    contents.position = data.position;
+    contents.position = __expectString(data.position);
   }
   return Promise.resolve(contents);
 };
@@ -9098,13 +9101,13 @@ export const deserializeAws_restJson1GetBasePathMappingCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.basePath !== undefined && data.basePath !== null) {
-    contents.basePath = data.basePath;
+    contents.basePath = __expectString(data.basePath);
   }
   if (data.restApiId !== undefined && data.restApiId !== null) {
-    contents.restApiId = data.restApiId;
+    contents.restApiId = __expectString(data.restApiId);
   }
   if (data.stage !== undefined && data.stage !== null) {
-    contents.stage = data.stage;
+    contents.stage = __expectString(data.stage);
   }
   return Promise.resolve(contents);
 };
@@ -9179,7 +9182,7 @@ export const deserializeAws_restJson1GetBasePathMappingsCommand = async (
     contents.items = deserializeAws_restJson1ListOfBasePathMapping(data.item, context);
   }
   if (data.position !== undefined && data.position !== null) {
-    contents.position = data.position;
+    contents.position = __expectString(data.position);
   }
   return Promise.resolve(contents);
 };
@@ -9255,19 +9258,19 @@ export const deserializeAws_restJson1GetClientCertificateCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.clientCertificateId !== undefined && data.clientCertificateId !== null) {
-    contents.clientCertificateId = data.clientCertificateId;
+    contents.clientCertificateId = __expectString(data.clientCertificateId);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
     contents.createdDate = new Date(Math.round(data.createdDate * 1000));
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.expirationDate !== undefined && data.expirationDate !== null) {
     contents.expirationDate = new Date(Math.round(data.expirationDate * 1000));
   }
   if (data.pemEncodedCertificate !== undefined && data.pemEncodedCertificate !== null) {
-    contents.pemEncodedCertificate = data.pemEncodedCertificate;
+    contents.pemEncodedCertificate = __expectString(data.pemEncodedCertificate);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1MapOfStringToString(data.tags, context);
@@ -9345,7 +9348,7 @@ export const deserializeAws_restJson1GetClientCertificatesCommand = async (
     contents.items = deserializeAws_restJson1ListOfClientCertificate(data.item, context);
   }
   if (data.position !== undefined && data.position !== null) {
-    contents.position = data.position;
+    contents.position = __expectString(data.position);
   }
   return Promise.resolve(contents);
 };
@@ -9425,10 +9428,10 @@ export const deserializeAws_restJson1GetDeploymentCommand = async (
     contents.createdDate = new Date(Math.round(data.createdDate * 1000));
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   return Promise.resolve(contents);
 };
@@ -9511,7 +9514,7 @@ export const deserializeAws_restJson1GetDeploymentsCommand = async (
     contents.items = deserializeAws_restJson1ListOfDeployment(data.item, context);
   }
   if (data.position !== undefined && data.position !== null) {
-    contents.position = data.position;
+    contents.position = __expectString(data.position);
   }
   return Promise.resolve(contents);
 };
@@ -9600,13 +9603,13 @@ export const deserializeAws_restJson1GetDocumentationPartCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   if (data.location !== undefined && data.location !== null) {
     contents.location = deserializeAws_restJson1DocumentationPartLocation(data.location, context);
   }
   if (data.properties !== undefined && data.properties !== null) {
-    contents.properties = data.properties;
+    contents.properties = __expectString(data.properties);
   }
   return Promise.resolve(contents);
 };
@@ -9681,7 +9684,7 @@ export const deserializeAws_restJson1GetDocumentationPartsCommand = async (
     contents.items = deserializeAws_restJson1ListOfDocumentationPart(data.item, context);
   }
   if (data.position !== undefined && data.position !== null) {
-    contents.position = data.position;
+    contents.position = __expectString(data.position);
   }
   return Promise.resolve(contents);
 };
@@ -9765,10 +9768,10 @@ export const deserializeAws_restJson1GetDocumentationVersionCommand = async (
     contents.createdDate = new Date(Math.round(data.createdDate * 1000));
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.version !== undefined && data.version !== null) {
-    contents.version = data.version;
+    contents.version = __expectString(data.version);
   }
   return Promise.resolve(contents);
 };
@@ -9843,7 +9846,7 @@ export const deserializeAws_restJson1GetDocumentationVersionsCommand = async (
     contents.items = deserializeAws_restJson1ListOfDocumentationVersion(data.item, context);
   }
   if (data.position !== undefined && data.position !== null) {
-    contents.position = data.position;
+    contents.position = __expectString(data.position);
   }
   return Promise.resolve(contents);
 };
@@ -9937,28 +9940,28 @@ export const deserializeAws_restJson1GetDomainNameCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.certificateArn !== undefined && data.certificateArn !== null) {
-    contents.certificateArn = data.certificateArn;
+    contents.certificateArn = __expectString(data.certificateArn);
   }
   if (data.certificateName !== undefined && data.certificateName !== null) {
-    contents.certificateName = data.certificateName;
+    contents.certificateName = __expectString(data.certificateName);
   }
   if (data.certificateUploadDate !== undefined && data.certificateUploadDate !== null) {
     contents.certificateUploadDate = new Date(Math.round(data.certificateUploadDate * 1000));
   }
   if (data.distributionDomainName !== undefined && data.distributionDomainName !== null) {
-    contents.distributionDomainName = data.distributionDomainName;
+    contents.distributionDomainName = __expectString(data.distributionDomainName);
   }
   if (data.distributionHostedZoneId !== undefined && data.distributionHostedZoneId !== null) {
-    contents.distributionHostedZoneId = data.distributionHostedZoneId;
+    contents.distributionHostedZoneId = __expectString(data.distributionHostedZoneId);
   }
   if (data.domainName !== undefined && data.domainName !== null) {
-    contents.domainName = data.domainName;
+    contents.domainName = __expectString(data.domainName);
   }
   if (data.domainNameStatus !== undefined && data.domainNameStatus !== null) {
-    contents.domainNameStatus = data.domainNameStatus;
+    contents.domainNameStatus = __expectString(data.domainNameStatus);
   }
   if (data.domainNameStatusMessage !== undefined && data.domainNameStatusMessage !== null) {
-    contents.domainNameStatusMessage = data.domainNameStatusMessage;
+    contents.domainNameStatusMessage = __expectString(data.domainNameStatusMessage);
   }
   if (data.endpointConfiguration !== undefined && data.endpointConfiguration !== null) {
     contents.endpointConfiguration = deserializeAws_restJson1EndpointConfiguration(data.endpointConfiguration, context);
@@ -9970,19 +9973,19 @@ export const deserializeAws_restJson1GetDomainNameCommand = async (
     );
   }
   if (data.regionalCertificateArn !== undefined && data.regionalCertificateArn !== null) {
-    contents.regionalCertificateArn = data.regionalCertificateArn;
+    contents.regionalCertificateArn = __expectString(data.regionalCertificateArn);
   }
   if (data.regionalCertificateName !== undefined && data.regionalCertificateName !== null) {
-    contents.regionalCertificateName = data.regionalCertificateName;
+    contents.regionalCertificateName = __expectString(data.regionalCertificateName);
   }
   if (data.regionalDomainName !== undefined && data.regionalDomainName !== null) {
-    contents.regionalDomainName = data.regionalDomainName;
+    contents.regionalDomainName = __expectString(data.regionalDomainName);
   }
   if (data.regionalHostedZoneId !== undefined && data.regionalHostedZoneId !== null) {
-    contents.regionalHostedZoneId = data.regionalHostedZoneId;
+    contents.regionalHostedZoneId = __expectString(data.regionalHostedZoneId);
   }
   if (data.securityPolicy !== undefined && data.securityPolicy !== null) {
-    contents.securityPolicy = data.securityPolicy;
+    contents.securityPolicy = __expectString(data.securityPolicy);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1MapOfStringToString(data.tags, context);
@@ -10068,7 +10071,7 @@ export const deserializeAws_restJson1GetDomainNamesCommand = async (
     contents.items = deserializeAws_restJson1ListOfDomainName(data.item, context);
   }
   if (data.position !== undefined && data.position !== null) {
-    contents.position = data.position;
+    contents.position = __expectString(data.position);
   }
   return Promise.resolve(contents);
 };
@@ -10236,7 +10239,7 @@ export const deserializeAws_restJson1GetGatewayResponseCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.defaultResponse !== undefined && data.defaultResponse !== null) {
-    contents.defaultResponse = data.defaultResponse;
+    contents.defaultResponse = __expectBoolean(data.defaultResponse);
   }
   if (data.responseParameters !== undefined && data.responseParameters !== null) {
     contents.responseParameters = deserializeAws_restJson1MapOfStringToString(data.responseParameters, context);
@@ -10245,10 +10248,10 @@ export const deserializeAws_restJson1GetGatewayResponseCommand = async (
     contents.responseTemplates = deserializeAws_restJson1MapOfStringToString(data.responseTemplates, context);
   }
   if (data.responseType !== undefined && data.responseType !== null) {
-    contents.responseType = data.responseType;
+    contents.responseType = __expectString(data.responseType);
   }
   if (data.statusCode !== undefined && data.statusCode !== null) {
-    contents.statusCode = data.statusCode;
+    contents.statusCode = __expectString(data.statusCode);
   }
   return Promise.resolve(contents);
 };
@@ -10323,7 +10326,7 @@ export const deserializeAws_restJson1GetGatewayResponsesCommand = async (
     contents.items = deserializeAws_restJson1ListOfGatewayResponse(data.item, context);
   }
   if (data.position !== undefined && data.position !== null) {
-    contents.position = data.position;
+    contents.position = __expectString(data.position);
   }
   return Promise.resolve(contents);
 };
@@ -10419,22 +10422,22 @@ export const deserializeAws_restJson1GetIntegrationCommand = async (
     contents.cacheKeyParameters = deserializeAws_restJson1ListOfString(data.cacheKeyParameters, context);
   }
   if (data.cacheNamespace !== undefined && data.cacheNamespace !== null) {
-    contents.cacheNamespace = data.cacheNamespace;
+    contents.cacheNamespace = __expectString(data.cacheNamespace);
   }
   if (data.connectionId !== undefined && data.connectionId !== null) {
-    contents.connectionId = data.connectionId;
+    contents.connectionId = __expectString(data.connectionId);
   }
   if (data.connectionType !== undefined && data.connectionType !== null) {
-    contents.connectionType = data.connectionType;
+    contents.connectionType = __expectString(data.connectionType);
   }
   if (data.contentHandling !== undefined && data.contentHandling !== null) {
-    contents.contentHandling = data.contentHandling;
+    contents.contentHandling = __expectString(data.contentHandling);
   }
   if (data.credentials !== undefined && data.credentials !== null) {
-    contents.credentials = data.credentials;
+    contents.credentials = __expectString(data.credentials);
   }
   if (data.httpMethod !== undefined && data.httpMethod !== null) {
-    contents.httpMethod = data.httpMethod;
+    contents.httpMethod = __expectString(data.httpMethod);
   }
   if (data.integrationResponses !== undefined && data.integrationResponses !== null) {
     contents.integrationResponses = deserializeAws_restJson1MapOfIntegrationResponse(
@@ -10443,7 +10446,7 @@ export const deserializeAws_restJson1GetIntegrationCommand = async (
     );
   }
   if (data.passthroughBehavior !== undefined && data.passthroughBehavior !== null) {
-    contents.passthroughBehavior = data.passthroughBehavior;
+    contents.passthroughBehavior = __expectString(data.passthroughBehavior);
   }
   if (data.requestParameters !== undefined && data.requestParameters !== null) {
     contents.requestParameters = deserializeAws_restJson1MapOfStringToString(data.requestParameters, context);
@@ -10452,16 +10455,16 @@ export const deserializeAws_restJson1GetIntegrationCommand = async (
     contents.requestTemplates = deserializeAws_restJson1MapOfStringToString(data.requestTemplates, context);
   }
   if (data.timeoutInMillis !== undefined && data.timeoutInMillis !== null) {
-    contents.timeoutInMillis = data.timeoutInMillis;
+    contents.timeoutInMillis = __expectNumber(data.timeoutInMillis);
   }
   if (data.tlsConfig !== undefined && data.tlsConfig !== null) {
     contents.tlsConfig = deserializeAws_restJson1TlsConfig(data.tlsConfig, context);
   }
   if (data.type !== undefined && data.type !== null) {
-    contents.type = data.type;
+    contents.type = __expectString(data.type);
   }
   if (data.uri !== undefined && data.uri !== null) {
-    contents.uri = data.uri;
+    contents.uri = __expectString(data.uri);
   }
   return Promise.resolve(contents);
 };
@@ -10536,7 +10539,7 @@ export const deserializeAws_restJson1GetIntegrationResponseCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.contentHandling !== undefined && data.contentHandling !== null) {
-    contents.contentHandling = data.contentHandling;
+    contents.contentHandling = __expectString(data.contentHandling);
   }
   if (data.responseParameters !== undefined && data.responseParameters !== null) {
     contents.responseParameters = deserializeAws_restJson1MapOfStringToString(data.responseParameters, context);
@@ -10545,10 +10548,10 @@ export const deserializeAws_restJson1GetIntegrationResponseCommand = async (
     contents.responseTemplates = deserializeAws_restJson1MapOfStringToString(data.responseTemplates, context);
   }
   if (data.selectionPattern !== undefined && data.selectionPattern !== null) {
-    contents.selectionPattern = data.selectionPattern;
+    contents.selectionPattern = __expectString(data.selectionPattern);
   }
   if (data.statusCode !== undefined && data.statusCode !== null) {
-    contents.statusCode = data.statusCode;
+    contents.statusCode = __expectString(data.statusCode);
   }
   return Promise.resolve(contents);
 };
@@ -10629,19 +10632,19 @@ export const deserializeAws_restJson1GetMethodCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.apiKeyRequired !== undefined && data.apiKeyRequired !== null) {
-    contents.apiKeyRequired = data.apiKeyRequired;
+    contents.apiKeyRequired = __expectBoolean(data.apiKeyRequired);
   }
   if (data.authorizationScopes !== undefined && data.authorizationScopes !== null) {
     contents.authorizationScopes = deserializeAws_restJson1ListOfString(data.authorizationScopes, context);
   }
   if (data.authorizationType !== undefined && data.authorizationType !== null) {
-    contents.authorizationType = data.authorizationType;
+    contents.authorizationType = __expectString(data.authorizationType);
   }
   if (data.authorizerId !== undefined && data.authorizerId !== null) {
-    contents.authorizerId = data.authorizerId;
+    contents.authorizerId = __expectString(data.authorizerId);
   }
   if (data.httpMethod !== undefined && data.httpMethod !== null) {
-    contents.httpMethod = data.httpMethod;
+    contents.httpMethod = __expectString(data.httpMethod);
   }
   if (data.methodIntegration !== undefined && data.methodIntegration !== null) {
     contents.methodIntegration = deserializeAws_restJson1Integration(data.methodIntegration, context);
@@ -10650,7 +10653,7 @@ export const deserializeAws_restJson1GetMethodCommand = async (
     contents.methodResponses = deserializeAws_restJson1MapOfMethodResponse(data.methodResponses, context);
   }
   if (data.operationName !== undefined && data.operationName !== null) {
-    contents.operationName = data.operationName;
+    contents.operationName = __expectString(data.operationName);
   }
   if (data.requestModels !== undefined && data.requestModels !== null) {
     contents.requestModels = deserializeAws_restJson1MapOfStringToString(data.requestModels, context);
@@ -10659,7 +10662,7 @@ export const deserializeAws_restJson1GetMethodCommand = async (
     contents.requestParameters = deserializeAws_restJson1MapOfStringToBoolean(data.requestParameters, context);
   }
   if (data.requestValidatorId !== undefined && data.requestValidatorId !== null) {
-    contents.requestValidatorId = data.requestValidatorId;
+    contents.requestValidatorId = __expectString(data.requestValidatorId);
   }
   return Promise.resolve(contents);
 };
@@ -10738,7 +10741,7 @@ export const deserializeAws_restJson1GetMethodResponseCommand = async (
     contents.responseParameters = deserializeAws_restJson1MapOfStringToBoolean(data.responseParameters, context);
   }
   if (data.statusCode !== undefined && data.statusCode !== null) {
-    contents.statusCode = data.statusCode;
+    contents.statusCode = __expectString(data.statusCode);
   }
   return Promise.resolve(contents);
 };
@@ -10813,19 +10816,19 @@ export const deserializeAws_restJson1GetModelCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.contentType !== undefined && data.contentType !== null) {
-    contents.contentType = data.contentType;
+    contents.contentType = __expectString(data.contentType);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.schema !== undefined && data.schema !== null) {
-    contents.schema = data.schema;
+    contents.schema = __expectString(data.schema);
   }
   return Promise.resolve(contents);
 };
@@ -10900,7 +10903,7 @@ export const deserializeAws_restJson1GetModelsCommand = async (
     contents.items = deserializeAws_restJson1ListOfModel(data.item, context);
   }
   if (data.position !== undefined && data.position !== null) {
-    contents.position = data.position;
+    contents.position = __expectString(data.position);
   }
   return Promise.resolve(contents);
 };
@@ -10979,7 +10982,7 @@ export const deserializeAws_restJson1GetModelTemplateCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.value !== undefined && data.value !== null) {
-    contents.value = data.value;
+    contents.value = __expectString(data.value);
   }
   return Promise.resolve(contents);
 };
@@ -11061,16 +11064,16 @@ export const deserializeAws_restJson1GetRequestValidatorCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.validateRequestBody !== undefined && data.validateRequestBody !== null) {
-    contents.validateRequestBody = data.validateRequestBody;
+    contents.validateRequestBody = __expectBoolean(data.validateRequestBody);
   }
   if (data.validateRequestParameters !== undefined && data.validateRequestParameters !== null) {
-    contents.validateRequestParameters = data.validateRequestParameters;
+    contents.validateRequestParameters = __expectBoolean(data.validateRequestParameters);
   }
   return Promise.resolve(contents);
 };
@@ -11145,7 +11148,7 @@ export const deserializeAws_restJson1GetRequestValidatorsCommand = async (
     contents.items = deserializeAws_restJson1ListOfRequestValidator(data.item, context);
   }
   if (data.position !== undefined && data.position !== null) {
-    contents.position = data.position;
+    contents.position = __expectString(data.position);
   }
   return Promise.resolve(contents);
 };
@@ -11228,16 +11231,16 @@ export const deserializeAws_restJson1GetResourceCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   if (data.parentId !== undefined && data.parentId !== null) {
-    contents.parentId = data.parentId;
+    contents.parentId = __expectString(data.parentId);
   }
   if (data.path !== undefined && data.path !== null) {
-    contents.path = data.path;
+    contents.path = __expectString(data.path);
   }
   if (data.pathPart !== undefined && data.pathPart !== null) {
-    contents.pathPart = data.pathPart;
+    contents.pathPart = __expectString(data.pathPart);
   }
   if (data.resourceMethods !== undefined && data.resourceMethods !== null) {
     contents.resourceMethods = deserializeAws_restJson1MapOfMethod(data.resourceMethods, context);
@@ -11315,7 +11318,7 @@ export const deserializeAws_restJson1GetResourcesCommand = async (
     contents.items = deserializeAws_restJson1ListOfResource(data.item, context);
   }
   if (data.position !== undefined && data.position !== null) {
-    contents.position = data.position;
+    contents.position = __expectString(data.position);
   }
   return Promise.resolve(contents);
 };
@@ -11406,7 +11409,7 @@ export const deserializeAws_restJson1GetRestApiCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.apiKeySource !== undefined && data.apiKeySource !== null) {
-    contents.apiKeySource = data.apiKeySource;
+    contents.apiKeySource = __expectString(data.apiKeySource);
   }
   if (data.binaryMediaTypes !== undefined && data.binaryMediaTypes !== null) {
     contents.binaryMediaTypes = deserializeAws_restJson1ListOfString(data.binaryMediaTypes, context);
@@ -11415,31 +11418,31 @@ export const deserializeAws_restJson1GetRestApiCommand = async (
     contents.createdDate = new Date(Math.round(data.createdDate * 1000));
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.disableExecuteApiEndpoint !== undefined && data.disableExecuteApiEndpoint !== null) {
-    contents.disableExecuteApiEndpoint = data.disableExecuteApiEndpoint;
+    contents.disableExecuteApiEndpoint = __expectBoolean(data.disableExecuteApiEndpoint);
   }
   if (data.endpointConfiguration !== undefined && data.endpointConfiguration !== null) {
     contents.endpointConfiguration = deserializeAws_restJson1EndpointConfiguration(data.endpointConfiguration, context);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   if (data.minimumCompressionSize !== undefined && data.minimumCompressionSize !== null) {
-    contents.minimumCompressionSize = data.minimumCompressionSize;
+    contents.minimumCompressionSize = __expectNumber(data.minimumCompressionSize);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.policy !== undefined && data.policy !== null) {
-    contents.policy = data.policy;
+    contents.policy = __expectString(data.policy);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1MapOfStringToString(data.tags, context);
   }
   if (data.version !== undefined && data.version !== null) {
-    contents.version = data.version;
+    contents.version = __expectString(data.version);
   }
   if (data.warnings !== undefined && data.warnings !== null) {
     contents.warnings = deserializeAws_restJson1ListOfString(data.warnings, context);
@@ -11517,7 +11520,7 @@ export const deserializeAws_restJson1GetRestApisCommand = async (
     contents.items = deserializeAws_restJson1ListOfRestApi(data.item, context);
   }
   if (data.position !== undefined && data.position !== null) {
-    contents.position = data.position;
+    contents.position = __expectString(data.position);
   }
   return Promise.resolve(contents);
 };
@@ -11690,13 +11693,13 @@ export const deserializeAws_restJson1GetSdkTypeCommand = async (
     );
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.friendlyName !== undefined && data.friendlyName !== null) {
-    contents.friendlyName = data.friendlyName;
+    contents.friendlyName = __expectString(data.friendlyName);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   return Promise.resolve(contents);
 };
@@ -11849,31 +11852,31 @@ export const deserializeAws_restJson1GetStageCommand = async (
     contents.accessLogSettings = deserializeAws_restJson1AccessLogSettings(data.accessLogSettings, context);
   }
   if (data.cacheClusterEnabled !== undefined && data.cacheClusterEnabled !== null) {
-    contents.cacheClusterEnabled = data.cacheClusterEnabled;
+    contents.cacheClusterEnabled = __expectBoolean(data.cacheClusterEnabled);
   }
   if (data.cacheClusterSize !== undefined && data.cacheClusterSize !== null) {
-    contents.cacheClusterSize = data.cacheClusterSize;
+    contents.cacheClusterSize = __expectString(data.cacheClusterSize);
   }
   if (data.cacheClusterStatus !== undefined && data.cacheClusterStatus !== null) {
-    contents.cacheClusterStatus = data.cacheClusterStatus;
+    contents.cacheClusterStatus = __expectString(data.cacheClusterStatus);
   }
   if (data.canarySettings !== undefined && data.canarySettings !== null) {
     contents.canarySettings = deserializeAws_restJson1CanarySettings(data.canarySettings, context);
   }
   if (data.clientCertificateId !== undefined && data.clientCertificateId !== null) {
-    contents.clientCertificateId = data.clientCertificateId;
+    contents.clientCertificateId = __expectString(data.clientCertificateId);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
     contents.createdDate = new Date(Math.round(data.createdDate * 1000));
   }
   if (data.deploymentId !== undefined && data.deploymentId !== null) {
-    contents.deploymentId = data.deploymentId;
+    contents.deploymentId = __expectString(data.deploymentId);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.documentationVersion !== undefined && data.documentationVersion !== null) {
-    contents.documentationVersion = data.documentationVersion;
+    contents.documentationVersion = __expectString(data.documentationVersion);
   }
   if (data.lastUpdatedDate !== undefined && data.lastUpdatedDate !== null) {
     contents.lastUpdatedDate = new Date(Math.round(data.lastUpdatedDate * 1000));
@@ -11882,19 +11885,19 @@ export const deserializeAws_restJson1GetStageCommand = async (
     contents.methodSettings = deserializeAws_restJson1MapOfMethodSettings(data.methodSettings, context);
   }
   if (data.stageName !== undefined && data.stageName !== null) {
-    contents.stageName = data.stageName;
+    contents.stageName = __expectString(data.stageName);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1MapOfStringToString(data.tags, context);
   }
   if (data.tracingEnabled !== undefined && data.tracingEnabled !== null) {
-    contents.tracingEnabled = data.tracingEnabled;
+    contents.tracingEnabled = __expectBoolean(data.tracingEnabled);
   }
   if (data.variables !== undefined && data.variables !== null) {
     contents.variables = deserializeAws_restJson1MapOfStringToString(data.variables, context);
   }
   if (data.webAclArn !== undefined && data.webAclArn !== null) {
-    contents.webAclArn = data.webAclArn;
+    contents.webAclArn = __expectString(data.webAclArn);
   }
   return Promise.resolve(contents);
 };
@@ -12127,19 +12130,19 @@ export const deserializeAws_restJson1GetUsageCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.endDate !== undefined && data.endDate !== null) {
-    contents.endDate = data.endDate;
+    contents.endDate = __expectString(data.endDate);
   }
   if (data.values !== undefined && data.values !== null) {
     contents.items = deserializeAws_restJson1MapOfKeyUsages(data.values, context);
   }
   if (data.position !== undefined && data.position !== null) {
-    contents.position = data.position;
+    contents.position = __expectString(data.position);
   }
   if (data.startDate !== undefined && data.startDate !== null) {
-    contents.startDate = data.startDate;
+    contents.startDate = __expectString(data.startDate);
   }
   if (data.usagePlanId !== undefined && data.usagePlanId !== null) {
-    contents.usagePlanId = data.usagePlanId;
+    contents.usagePlanId = __expectString(data.usagePlanId);
   }
   return Promise.resolve(contents);
 };
@@ -12228,16 +12231,16 @@ export const deserializeAws_restJson1GetUsagePlanCommand = async (
     contents.apiStages = deserializeAws_restJson1ListOfApiStage(data.apiStages, context);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.productCode !== undefined && data.productCode !== null) {
-    contents.productCode = data.productCode;
+    contents.productCode = __expectString(data.productCode);
   }
   if (data.quota !== undefined && data.quota !== null) {
     contents.quota = deserializeAws_restJson1QuotaSettings(data.quota, context);
@@ -12328,16 +12331,16 @@ export const deserializeAws_restJson1GetUsagePlanKeyCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.type !== undefined && data.type !== null) {
-    contents.type = data.type;
+    contents.type = __expectString(data.type);
   }
   if (data.value !== undefined && data.value !== null) {
-    contents.value = data.value;
+    contents.value = __expectString(data.value);
   }
   return Promise.resolve(contents);
 };
@@ -12420,7 +12423,7 @@ export const deserializeAws_restJson1GetUsagePlanKeysCommand = async (
     contents.items = deserializeAws_restJson1ListOfUsagePlanKey(data.item, context);
   }
   if (data.position !== undefined && data.position !== null) {
-    contents.position = data.position;
+    contents.position = __expectString(data.position);
   }
   return Promise.resolve(contents);
 };
@@ -12503,7 +12506,7 @@ export const deserializeAws_restJson1GetUsagePlansCommand = async (
     contents.items = deserializeAws_restJson1ListOfUsagePlan(data.item, context);
   }
   if (data.position !== undefined && data.position !== null) {
-    contents.position = data.position;
+    contents.position = __expectString(data.position);
   }
   return Promise.resolve(contents);
 };
@@ -12596,19 +12599,19 @@ export const deserializeAws_restJson1GetVpcLinkCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.status = data.status;
+    contents.status = __expectString(data.status);
   }
   if (data.statusMessage !== undefined && data.statusMessage !== null) {
-    contents.statusMessage = data.statusMessage;
+    contents.statusMessage = __expectString(data.statusMessage);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1MapOfStringToString(data.tags, context);
@@ -12689,7 +12692,7 @@ export const deserializeAws_restJson1GetVpcLinksCommand = async (
     contents.items = deserializeAws_restJson1ListOfVpcLink(data.item, context);
   }
   if (data.position !== undefined && data.position !== null) {
-    contents.position = data.position;
+    contents.position = __expectString(data.position);
   }
   return Promise.resolve(contents);
 };
@@ -12962,7 +12965,7 @@ export const deserializeAws_restJson1ImportRestApiCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.apiKeySource !== undefined && data.apiKeySource !== null) {
-    contents.apiKeySource = data.apiKeySource;
+    contents.apiKeySource = __expectString(data.apiKeySource);
   }
   if (data.binaryMediaTypes !== undefined && data.binaryMediaTypes !== null) {
     contents.binaryMediaTypes = deserializeAws_restJson1ListOfString(data.binaryMediaTypes, context);
@@ -12971,31 +12974,31 @@ export const deserializeAws_restJson1ImportRestApiCommand = async (
     contents.createdDate = new Date(Math.round(data.createdDate * 1000));
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.disableExecuteApiEndpoint !== undefined && data.disableExecuteApiEndpoint !== null) {
-    contents.disableExecuteApiEndpoint = data.disableExecuteApiEndpoint;
+    contents.disableExecuteApiEndpoint = __expectBoolean(data.disableExecuteApiEndpoint);
   }
   if (data.endpointConfiguration !== undefined && data.endpointConfiguration !== null) {
     contents.endpointConfiguration = deserializeAws_restJson1EndpointConfiguration(data.endpointConfiguration, context);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   if (data.minimumCompressionSize !== undefined && data.minimumCompressionSize !== null) {
-    contents.minimumCompressionSize = data.minimumCompressionSize;
+    contents.minimumCompressionSize = __expectNumber(data.minimumCompressionSize);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.policy !== undefined && data.policy !== null) {
-    contents.policy = data.policy;
+    contents.policy = __expectString(data.policy);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1MapOfStringToString(data.tags, context);
   }
   if (data.version !== undefined && data.version !== null) {
-    contents.version = data.version;
+    contents.version = __expectString(data.version);
   }
   if (data.warnings !== undefined && data.warnings !== null) {
     contents.warnings = deserializeAws_restJson1ListOfString(data.warnings, context);
@@ -13089,7 +13092,7 @@ export const deserializeAws_restJson1PutGatewayResponseCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.defaultResponse !== undefined && data.defaultResponse !== null) {
-    contents.defaultResponse = data.defaultResponse;
+    contents.defaultResponse = __expectBoolean(data.defaultResponse);
   }
   if (data.responseParameters !== undefined && data.responseParameters !== null) {
     contents.responseParameters = deserializeAws_restJson1MapOfStringToString(data.responseParameters, context);
@@ -13098,10 +13101,10 @@ export const deserializeAws_restJson1PutGatewayResponseCommand = async (
     contents.responseTemplates = deserializeAws_restJson1MapOfStringToString(data.responseTemplates, context);
   }
   if (data.responseType !== undefined && data.responseType !== null) {
-    contents.responseType = data.responseType;
+    contents.responseType = __expectString(data.responseType);
   }
   if (data.statusCode !== undefined && data.statusCode !== null) {
-    contents.statusCode = data.statusCode;
+    contents.statusCode = __expectString(data.statusCode);
   }
   return Promise.resolve(contents);
 };
@@ -13205,22 +13208,22 @@ export const deserializeAws_restJson1PutIntegrationCommand = async (
     contents.cacheKeyParameters = deserializeAws_restJson1ListOfString(data.cacheKeyParameters, context);
   }
   if (data.cacheNamespace !== undefined && data.cacheNamespace !== null) {
-    contents.cacheNamespace = data.cacheNamespace;
+    contents.cacheNamespace = __expectString(data.cacheNamespace);
   }
   if (data.connectionId !== undefined && data.connectionId !== null) {
-    contents.connectionId = data.connectionId;
+    contents.connectionId = __expectString(data.connectionId);
   }
   if (data.connectionType !== undefined && data.connectionType !== null) {
-    contents.connectionType = data.connectionType;
+    contents.connectionType = __expectString(data.connectionType);
   }
   if (data.contentHandling !== undefined && data.contentHandling !== null) {
-    contents.contentHandling = data.contentHandling;
+    contents.contentHandling = __expectString(data.contentHandling);
   }
   if (data.credentials !== undefined && data.credentials !== null) {
-    contents.credentials = data.credentials;
+    contents.credentials = __expectString(data.credentials);
   }
   if (data.httpMethod !== undefined && data.httpMethod !== null) {
-    contents.httpMethod = data.httpMethod;
+    contents.httpMethod = __expectString(data.httpMethod);
   }
   if (data.integrationResponses !== undefined && data.integrationResponses !== null) {
     contents.integrationResponses = deserializeAws_restJson1MapOfIntegrationResponse(
@@ -13229,7 +13232,7 @@ export const deserializeAws_restJson1PutIntegrationCommand = async (
     );
   }
   if (data.passthroughBehavior !== undefined && data.passthroughBehavior !== null) {
-    contents.passthroughBehavior = data.passthroughBehavior;
+    contents.passthroughBehavior = __expectString(data.passthroughBehavior);
   }
   if (data.requestParameters !== undefined && data.requestParameters !== null) {
     contents.requestParameters = deserializeAws_restJson1MapOfStringToString(data.requestParameters, context);
@@ -13238,16 +13241,16 @@ export const deserializeAws_restJson1PutIntegrationCommand = async (
     contents.requestTemplates = deserializeAws_restJson1MapOfStringToString(data.requestTemplates, context);
   }
   if (data.timeoutInMillis !== undefined && data.timeoutInMillis !== null) {
-    contents.timeoutInMillis = data.timeoutInMillis;
+    contents.timeoutInMillis = __expectNumber(data.timeoutInMillis);
   }
   if (data.tlsConfig !== undefined && data.tlsConfig !== null) {
     contents.tlsConfig = deserializeAws_restJson1TlsConfig(data.tlsConfig, context);
   }
   if (data.type !== undefined && data.type !== null) {
-    contents.type = data.type;
+    contents.type = __expectString(data.type);
   }
   if (data.uri !== undefined && data.uri !== null) {
-    contents.uri = data.uri;
+    contents.uri = __expectString(data.uri);
   }
   return Promise.resolve(contents);
 };
@@ -13338,7 +13341,7 @@ export const deserializeAws_restJson1PutIntegrationResponseCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.contentHandling !== undefined && data.contentHandling !== null) {
-    contents.contentHandling = data.contentHandling;
+    contents.contentHandling = __expectString(data.contentHandling);
   }
   if (data.responseParameters !== undefined && data.responseParameters !== null) {
     contents.responseParameters = deserializeAws_restJson1MapOfStringToString(data.responseParameters, context);
@@ -13347,10 +13350,10 @@ export const deserializeAws_restJson1PutIntegrationResponseCommand = async (
     contents.responseTemplates = deserializeAws_restJson1MapOfStringToString(data.responseTemplates, context);
   }
   if (data.selectionPattern !== undefined && data.selectionPattern !== null) {
-    contents.selectionPattern = data.selectionPattern;
+    contents.selectionPattern = __expectString(data.selectionPattern);
   }
   if (data.statusCode !== undefined && data.statusCode !== null) {
-    contents.statusCode = data.statusCode;
+    contents.statusCode = __expectString(data.statusCode);
   }
   return Promise.resolve(contents);
 };
@@ -13455,19 +13458,19 @@ export const deserializeAws_restJson1PutMethodCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.apiKeyRequired !== undefined && data.apiKeyRequired !== null) {
-    contents.apiKeyRequired = data.apiKeyRequired;
+    contents.apiKeyRequired = __expectBoolean(data.apiKeyRequired);
   }
   if (data.authorizationScopes !== undefined && data.authorizationScopes !== null) {
     contents.authorizationScopes = deserializeAws_restJson1ListOfString(data.authorizationScopes, context);
   }
   if (data.authorizationType !== undefined && data.authorizationType !== null) {
-    contents.authorizationType = data.authorizationType;
+    contents.authorizationType = __expectString(data.authorizationType);
   }
   if (data.authorizerId !== undefined && data.authorizerId !== null) {
-    contents.authorizerId = data.authorizerId;
+    contents.authorizerId = __expectString(data.authorizerId);
   }
   if (data.httpMethod !== undefined && data.httpMethod !== null) {
-    contents.httpMethod = data.httpMethod;
+    contents.httpMethod = __expectString(data.httpMethod);
   }
   if (data.methodIntegration !== undefined && data.methodIntegration !== null) {
     contents.methodIntegration = deserializeAws_restJson1Integration(data.methodIntegration, context);
@@ -13476,7 +13479,7 @@ export const deserializeAws_restJson1PutMethodCommand = async (
     contents.methodResponses = deserializeAws_restJson1MapOfMethodResponse(data.methodResponses, context);
   }
   if (data.operationName !== undefined && data.operationName !== null) {
-    contents.operationName = data.operationName;
+    contents.operationName = __expectString(data.operationName);
   }
   if (data.requestModels !== undefined && data.requestModels !== null) {
     contents.requestModels = deserializeAws_restJson1MapOfStringToString(data.requestModels, context);
@@ -13485,7 +13488,7 @@ export const deserializeAws_restJson1PutMethodCommand = async (
     contents.requestParameters = deserializeAws_restJson1MapOfStringToBoolean(data.requestParameters, context);
   }
   if (data.requestValidatorId !== undefined && data.requestValidatorId !== null) {
-    contents.requestValidatorId = data.requestValidatorId;
+    contents.requestValidatorId = __expectString(data.requestValidatorId);
   }
   return Promise.resolve(contents);
 };
@@ -13588,7 +13591,7 @@ export const deserializeAws_restJson1PutMethodResponseCommand = async (
     contents.responseParameters = deserializeAws_restJson1MapOfStringToBoolean(data.responseParameters, context);
   }
   if (data.statusCode !== undefined && data.statusCode !== null) {
-    contents.statusCode = data.statusCode;
+    contents.statusCode = __expectString(data.statusCode);
   }
   return Promise.resolve(contents);
 };
@@ -13695,7 +13698,7 @@ export const deserializeAws_restJson1PutRestApiCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.apiKeySource !== undefined && data.apiKeySource !== null) {
-    contents.apiKeySource = data.apiKeySource;
+    contents.apiKeySource = __expectString(data.apiKeySource);
   }
   if (data.binaryMediaTypes !== undefined && data.binaryMediaTypes !== null) {
     contents.binaryMediaTypes = deserializeAws_restJson1ListOfString(data.binaryMediaTypes, context);
@@ -13704,31 +13707,31 @@ export const deserializeAws_restJson1PutRestApiCommand = async (
     contents.createdDate = new Date(Math.round(data.createdDate * 1000));
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.disableExecuteApiEndpoint !== undefined && data.disableExecuteApiEndpoint !== null) {
-    contents.disableExecuteApiEndpoint = data.disableExecuteApiEndpoint;
+    contents.disableExecuteApiEndpoint = __expectBoolean(data.disableExecuteApiEndpoint);
   }
   if (data.endpointConfiguration !== undefined && data.endpointConfiguration !== null) {
     contents.endpointConfiguration = deserializeAws_restJson1EndpointConfiguration(data.endpointConfiguration, context);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   if (data.minimumCompressionSize !== undefined && data.minimumCompressionSize !== null) {
-    contents.minimumCompressionSize = data.minimumCompressionSize;
+    contents.minimumCompressionSize = __expectNumber(data.minimumCompressionSize);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.policy !== undefined && data.policy !== null) {
-    contents.policy = data.policy;
+    contents.policy = __expectString(data.policy);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1MapOfStringToString(data.tags, context);
   }
   if (data.version !== undefined && data.version !== null) {
-    contents.version = data.version;
+    contents.version = __expectString(data.version);
   }
   if (data.warnings !== undefined && data.warnings !== null) {
     contents.warnings = deserializeAws_restJson1ListOfString(data.warnings, context);
@@ -13929,19 +13932,19 @@ export const deserializeAws_restJson1TestInvokeAuthorizerCommand = async (
     contents.claims = deserializeAws_restJson1MapOfStringToString(data.claims, context);
   }
   if (data.clientStatus !== undefined && data.clientStatus !== null) {
-    contents.clientStatus = data.clientStatus;
+    contents.clientStatus = __expectNumber(data.clientStatus);
   }
   if (data.latency !== undefined && data.latency !== null) {
-    contents.latency = data.latency;
+    contents.latency = __expectNumber(data.latency);
   }
   if (data.log !== undefined && data.log !== null) {
-    contents.log = data.log;
+    contents.log = __expectString(data.log);
   }
   if (data.policy !== undefined && data.policy !== null) {
-    contents.policy = data.policy;
+    contents.policy = __expectString(data.policy);
   }
   if (data.principalId !== undefined && data.principalId !== null) {
-    contents.principalId = data.principalId;
+    contents.principalId = __expectString(data.principalId);
   }
   return Promise.resolve(contents);
 };
@@ -14025,22 +14028,22 @@ export const deserializeAws_restJson1TestInvokeMethodCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.body !== undefined && data.body !== null) {
-    contents.body = data.body;
+    contents.body = __expectString(data.body);
   }
   if (data.headers !== undefined && data.headers !== null) {
     contents.headers = deserializeAws_restJson1MapOfStringToString(data.headers, context);
   }
   if (data.latency !== undefined && data.latency !== null) {
-    contents.latency = data.latency;
+    contents.latency = __expectNumber(data.latency);
   }
   if (data.log !== undefined && data.log !== null) {
-    contents.log = data.log;
+    contents.log = __expectString(data.log);
   }
   if (data.multiValueHeaders !== undefined && data.multiValueHeaders !== null) {
     contents.multiValueHeaders = deserializeAws_restJson1MapOfStringToList(data.multiValueHeaders, context);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.status = data.status;
+    contents.status = __expectNumber(data.status);
   }
   return Promise.resolve(contents);
 };
@@ -14205,10 +14208,10 @@ export const deserializeAws_restJson1UpdateAccountCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.apiKeyVersion !== undefined && data.apiKeyVersion !== null) {
-    contents.apiKeyVersion = data.apiKeyVersion;
+    contents.apiKeyVersion = __expectString(data.apiKeyVersion);
   }
   if (data.cloudwatchRoleArn !== undefined && data.cloudwatchRoleArn !== null) {
-    contents.cloudwatchRoleArn = data.cloudwatchRoleArn;
+    contents.cloudwatchRoleArn = __expectString(data.cloudwatchRoleArn);
   }
   if (data.features !== undefined && data.features !== null) {
     contents.features = deserializeAws_restJson1ListOfString(data.features, context);
@@ -14305,22 +14308,22 @@ export const deserializeAws_restJson1UpdateApiKeyCommand = async (
     contents.createdDate = new Date(Math.round(data.createdDate * 1000));
   }
   if (data.customerId !== undefined && data.customerId !== null) {
-    contents.customerId = data.customerId;
+    contents.customerId = __expectString(data.customerId);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.enabled !== undefined && data.enabled !== null) {
-    contents.enabled = data.enabled;
+    contents.enabled = __expectBoolean(data.enabled);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   if (data.lastUpdatedDate !== undefined && data.lastUpdatedDate !== null) {
     contents.lastUpdatedDate = new Date(Math.round(data.lastUpdatedDate * 1000));
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.stageKeys !== undefined && data.stageKeys !== null) {
     contents.stageKeys = deserializeAws_restJson1ListOfString(data.stageKeys, context);
@@ -14329,7 +14332,7 @@ export const deserializeAws_restJson1UpdateApiKeyCommand = async (
     contents.tags = deserializeAws_restJson1MapOfStringToString(data.tags, context);
   }
   if (data.value !== undefined && data.value !== null) {
-    contents.value = data.value;
+    contents.value = __expectString(data.value);
   }
   return Promise.resolve(contents);
 };
@@ -14425,34 +14428,34 @@ export const deserializeAws_restJson1UpdateAuthorizerCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.authType !== undefined && data.authType !== null) {
-    contents.authType = data.authType;
+    contents.authType = __expectString(data.authType);
   }
   if (data.authorizerCredentials !== undefined && data.authorizerCredentials !== null) {
-    contents.authorizerCredentials = data.authorizerCredentials;
+    contents.authorizerCredentials = __expectString(data.authorizerCredentials);
   }
   if (data.authorizerResultTtlInSeconds !== undefined && data.authorizerResultTtlInSeconds !== null) {
-    contents.authorizerResultTtlInSeconds = data.authorizerResultTtlInSeconds;
+    contents.authorizerResultTtlInSeconds = __expectNumber(data.authorizerResultTtlInSeconds);
   }
   if (data.authorizerUri !== undefined && data.authorizerUri !== null) {
-    contents.authorizerUri = data.authorizerUri;
+    contents.authorizerUri = __expectString(data.authorizerUri);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   if (data.identitySource !== undefined && data.identitySource !== null) {
-    contents.identitySource = data.identitySource;
+    contents.identitySource = __expectString(data.identitySource);
   }
   if (data.identityValidationExpression !== undefined && data.identityValidationExpression !== null) {
-    contents.identityValidationExpression = data.identityValidationExpression;
+    contents.identityValidationExpression = __expectString(data.identityValidationExpression);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.providerARNs !== undefined && data.providerARNs !== null) {
     contents.providerARNs = deserializeAws_restJson1ListOfARNs(data.providerARNs, context);
   }
   if (data.type !== undefined && data.type !== null) {
-    contents.type = data.type;
+    contents.type = __expectString(data.type);
   }
   return Promise.resolve(contents);
 };
@@ -14533,13 +14536,13 @@ export const deserializeAws_restJson1UpdateBasePathMappingCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.basePath !== undefined && data.basePath !== null) {
-    contents.basePath = data.basePath;
+    contents.basePath = __expectString(data.basePath);
   }
   if (data.restApiId !== undefined && data.restApiId !== null) {
-    contents.restApiId = data.restApiId;
+    contents.restApiId = __expectString(data.restApiId);
   }
   if (data.stage !== undefined && data.stage !== null) {
-    contents.stage = data.stage;
+    contents.stage = __expectString(data.stage);
   }
   return Promise.resolve(contents);
 };
@@ -14631,19 +14634,19 @@ export const deserializeAws_restJson1UpdateClientCertificateCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.clientCertificateId !== undefined && data.clientCertificateId !== null) {
-    contents.clientCertificateId = data.clientCertificateId;
+    contents.clientCertificateId = __expectString(data.clientCertificateId);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
     contents.createdDate = new Date(Math.round(data.createdDate * 1000));
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.expirationDate !== undefined && data.expirationDate !== null) {
     contents.expirationDate = new Date(Math.round(data.expirationDate * 1000));
   }
   if (data.pemEncodedCertificate !== undefined && data.pemEncodedCertificate !== null) {
-    contents.pemEncodedCertificate = data.pemEncodedCertificate;
+    contents.pemEncodedCertificate = __expectString(data.pemEncodedCertificate);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1MapOfStringToString(data.tags, context);
@@ -14734,10 +14737,10 @@ export const deserializeAws_restJson1UpdateDeploymentCommand = async (
     contents.createdDate = new Date(Math.round(data.createdDate * 1000));
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   return Promise.resolve(contents);
 };
@@ -14826,13 +14829,13 @@ export const deserializeAws_restJson1UpdateDocumentationPartCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   if (data.location !== undefined && data.location !== null) {
     contents.location = deserializeAws_restJson1DocumentationPartLocation(data.location, context);
   }
   if (data.properties !== undefined && data.properties !== null) {
-    contents.properties = data.properties;
+    contents.properties = __expectString(data.properties);
   }
   return Promise.resolve(contents);
 };
@@ -14932,10 +14935,10 @@ export const deserializeAws_restJson1UpdateDocumentationVersionCommand = async (
     contents.createdDate = new Date(Math.round(data.createdDate * 1000));
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.version !== undefined && data.version !== null) {
-    contents.version = data.version;
+    contents.version = __expectString(data.version);
   }
   return Promise.resolve(contents);
 };
@@ -15037,28 +15040,28 @@ export const deserializeAws_restJson1UpdateDomainNameCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.certificateArn !== undefined && data.certificateArn !== null) {
-    contents.certificateArn = data.certificateArn;
+    contents.certificateArn = __expectString(data.certificateArn);
   }
   if (data.certificateName !== undefined && data.certificateName !== null) {
-    contents.certificateName = data.certificateName;
+    contents.certificateName = __expectString(data.certificateName);
   }
   if (data.certificateUploadDate !== undefined && data.certificateUploadDate !== null) {
     contents.certificateUploadDate = new Date(Math.round(data.certificateUploadDate * 1000));
   }
   if (data.distributionDomainName !== undefined && data.distributionDomainName !== null) {
-    contents.distributionDomainName = data.distributionDomainName;
+    contents.distributionDomainName = __expectString(data.distributionDomainName);
   }
   if (data.distributionHostedZoneId !== undefined && data.distributionHostedZoneId !== null) {
-    contents.distributionHostedZoneId = data.distributionHostedZoneId;
+    contents.distributionHostedZoneId = __expectString(data.distributionHostedZoneId);
   }
   if (data.domainName !== undefined && data.domainName !== null) {
-    contents.domainName = data.domainName;
+    contents.domainName = __expectString(data.domainName);
   }
   if (data.domainNameStatus !== undefined && data.domainNameStatus !== null) {
-    contents.domainNameStatus = data.domainNameStatus;
+    contents.domainNameStatus = __expectString(data.domainNameStatus);
   }
   if (data.domainNameStatusMessage !== undefined && data.domainNameStatusMessage !== null) {
-    contents.domainNameStatusMessage = data.domainNameStatusMessage;
+    contents.domainNameStatusMessage = __expectString(data.domainNameStatusMessage);
   }
   if (data.endpointConfiguration !== undefined && data.endpointConfiguration !== null) {
     contents.endpointConfiguration = deserializeAws_restJson1EndpointConfiguration(data.endpointConfiguration, context);
@@ -15070,19 +15073,19 @@ export const deserializeAws_restJson1UpdateDomainNameCommand = async (
     );
   }
   if (data.regionalCertificateArn !== undefined && data.regionalCertificateArn !== null) {
-    contents.regionalCertificateArn = data.regionalCertificateArn;
+    contents.regionalCertificateArn = __expectString(data.regionalCertificateArn);
   }
   if (data.regionalCertificateName !== undefined && data.regionalCertificateName !== null) {
-    contents.regionalCertificateName = data.regionalCertificateName;
+    contents.regionalCertificateName = __expectString(data.regionalCertificateName);
   }
   if (data.regionalDomainName !== undefined && data.regionalDomainName !== null) {
-    contents.regionalDomainName = data.regionalDomainName;
+    contents.regionalDomainName = __expectString(data.regionalDomainName);
   }
   if (data.regionalHostedZoneId !== undefined && data.regionalHostedZoneId !== null) {
-    contents.regionalHostedZoneId = data.regionalHostedZoneId;
+    contents.regionalHostedZoneId = __expectString(data.regionalHostedZoneId);
   }
   if (data.securityPolicy !== undefined && data.securityPolicy !== null) {
-    contents.securityPolicy = data.securityPolicy;
+    contents.securityPolicy = __expectString(data.securityPolicy);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1MapOfStringToString(data.tags, context);
@@ -15176,7 +15179,7 @@ export const deserializeAws_restJson1UpdateGatewayResponseCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.defaultResponse !== undefined && data.defaultResponse !== null) {
-    contents.defaultResponse = data.defaultResponse;
+    contents.defaultResponse = __expectBoolean(data.defaultResponse);
   }
   if (data.responseParameters !== undefined && data.responseParameters !== null) {
     contents.responseParameters = deserializeAws_restJson1MapOfStringToString(data.responseParameters, context);
@@ -15185,10 +15188,10 @@ export const deserializeAws_restJson1UpdateGatewayResponseCommand = async (
     contents.responseTemplates = deserializeAws_restJson1MapOfStringToString(data.responseTemplates, context);
   }
   if (data.responseType !== undefined && data.responseType !== null) {
-    contents.responseType = data.responseType;
+    contents.responseType = __expectString(data.responseType);
   }
   if (data.statusCode !== undefined && data.statusCode !== null) {
-    contents.statusCode = data.statusCode;
+    contents.statusCode = __expectString(data.statusCode);
   }
   return Promise.resolve(contents);
 };
@@ -15284,22 +15287,22 @@ export const deserializeAws_restJson1UpdateIntegrationCommand = async (
     contents.cacheKeyParameters = deserializeAws_restJson1ListOfString(data.cacheKeyParameters, context);
   }
   if (data.cacheNamespace !== undefined && data.cacheNamespace !== null) {
-    contents.cacheNamespace = data.cacheNamespace;
+    contents.cacheNamespace = __expectString(data.cacheNamespace);
   }
   if (data.connectionId !== undefined && data.connectionId !== null) {
-    contents.connectionId = data.connectionId;
+    contents.connectionId = __expectString(data.connectionId);
   }
   if (data.connectionType !== undefined && data.connectionType !== null) {
-    contents.connectionType = data.connectionType;
+    contents.connectionType = __expectString(data.connectionType);
   }
   if (data.contentHandling !== undefined && data.contentHandling !== null) {
-    contents.contentHandling = data.contentHandling;
+    contents.contentHandling = __expectString(data.contentHandling);
   }
   if (data.credentials !== undefined && data.credentials !== null) {
-    contents.credentials = data.credentials;
+    contents.credentials = __expectString(data.credentials);
   }
   if (data.httpMethod !== undefined && data.httpMethod !== null) {
-    contents.httpMethod = data.httpMethod;
+    contents.httpMethod = __expectString(data.httpMethod);
   }
   if (data.integrationResponses !== undefined && data.integrationResponses !== null) {
     contents.integrationResponses = deserializeAws_restJson1MapOfIntegrationResponse(
@@ -15308,7 +15311,7 @@ export const deserializeAws_restJson1UpdateIntegrationCommand = async (
     );
   }
   if (data.passthroughBehavior !== undefined && data.passthroughBehavior !== null) {
-    contents.passthroughBehavior = data.passthroughBehavior;
+    contents.passthroughBehavior = __expectString(data.passthroughBehavior);
   }
   if (data.requestParameters !== undefined && data.requestParameters !== null) {
     contents.requestParameters = deserializeAws_restJson1MapOfStringToString(data.requestParameters, context);
@@ -15317,16 +15320,16 @@ export const deserializeAws_restJson1UpdateIntegrationCommand = async (
     contents.requestTemplates = deserializeAws_restJson1MapOfStringToString(data.requestTemplates, context);
   }
   if (data.timeoutInMillis !== undefined && data.timeoutInMillis !== null) {
-    contents.timeoutInMillis = data.timeoutInMillis;
+    contents.timeoutInMillis = __expectNumber(data.timeoutInMillis);
   }
   if (data.tlsConfig !== undefined && data.tlsConfig !== null) {
     contents.tlsConfig = deserializeAws_restJson1TlsConfig(data.tlsConfig, context);
   }
   if (data.type !== undefined && data.type !== null) {
-    contents.type = data.type;
+    contents.type = __expectString(data.type);
   }
   if (data.uri !== undefined && data.uri !== null) {
-    contents.uri = data.uri;
+    contents.uri = __expectString(data.uri);
   }
   return Promise.resolve(contents);
 };
@@ -15417,7 +15420,7 @@ export const deserializeAws_restJson1UpdateIntegrationResponseCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.contentHandling !== undefined && data.contentHandling !== null) {
-    contents.contentHandling = data.contentHandling;
+    contents.contentHandling = __expectString(data.contentHandling);
   }
   if (data.responseParameters !== undefined && data.responseParameters !== null) {
     contents.responseParameters = deserializeAws_restJson1MapOfStringToString(data.responseParameters, context);
@@ -15426,10 +15429,10 @@ export const deserializeAws_restJson1UpdateIntegrationResponseCommand = async (
     contents.responseTemplates = deserializeAws_restJson1MapOfStringToString(data.responseTemplates, context);
   }
   if (data.selectionPattern !== undefined && data.selectionPattern !== null) {
-    contents.selectionPattern = data.selectionPattern;
+    contents.selectionPattern = __expectString(data.selectionPattern);
   }
   if (data.statusCode !== undefined && data.statusCode !== null) {
-    contents.statusCode = data.statusCode;
+    contents.statusCode = __expectString(data.statusCode);
   }
   return Promise.resolve(contents);
 };
@@ -15526,19 +15529,19 @@ export const deserializeAws_restJson1UpdateMethodCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.apiKeyRequired !== undefined && data.apiKeyRequired !== null) {
-    contents.apiKeyRequired = data.apiKeyRequired;
+    contents.apiKeyRequired = __expectBoolean(data.apiKeyRequired);
   }
   if (data.authorizationScopes !== undefined && data.authorizationScopes !== null) {
     contents.authorizationScopes = deserializeAws_restJson1ListOfString(data.authorizationScopes, context);
   }
   if (data.authorizationType !== undefined && data.authorizationType !== null) {
-    contents.authorizationType = data.authorizationType;
+    contents.authorizationType = __expectString(data.authorizationType);
   }
   if (data.authorizerId !== undefined && data.authorizerId !== null) {
-    contents.authorizerId = data.authorizerId;
+    contents.authorizerId = __expectString(data.authorizerId);
   }
   if (data.httpMethod !== undefined && data.httpMethod !== null) {
-    contents.httpMethod = data.httpMethod;
+    contents.httpMethod = __expectString(data.httpMethod);
   }
   if (data.methodIntegration !== undefined && data.methodIntegration !== null) {
     contents.methodIntegration = deserializeAws_restJson1Integration(data.methodIntegration, context);
@@ -15547,7 +15550,7 @@ export const deserializeAws_restJson1UpdateMethodCommand = async (
     contents.methodResponses = deserializeAws_restJson1MapOfMethodResponse(data.methodResponses, context);
   }
   if (data.operationName !== undefined && data.operationName !== null) {
-    contents.operationName = data.operationName;
+    contents.operationName = __expectString(data.operationName);
   }
   if (data.requestModels !== undefined && data.requestModels !== null) {
     contents.requestModels = deserializeAws_restJson1MapOfStringToString(data.requestModels, context);
@@ -15556,7 +15559,7 @@ export const deserializeAws_restJson1UpdateMethodCommand = async (
     contents.requestParameters = deserializeAws_restJson1MapOfStringToBoolean(data.requestParameters, context);
   }
   if (data.requestValidatorId !== undefined && data.requestValidatorId !== null) {
-    contents.requestValidatorId = data.requestValidatorId;
+    contents.requestValidatorId = __expectString(data.requestValidatorId);
   }
   return Promise.resolve(contents);
 };
@@ -15651,7 +15654,7 @@ export const deserializeAws_restJson1UpdateMethodResponseCommand = async (
     contents.responseParameters = deserializeAws_restJson1MapOfStringToBoolean(data.responseParameters, context);
   }
   if (data.statusCode !== undefined && data.statusCode !== null) {
-    contents.statusCode = data.statusCode;
+    contents.statusCode = __expectString(data.statusCode);
   }
   return Promise.resolve(contents);
 };
@@ -15750,19 +15753,19 @@ export const deserializeAws_restJson1UpdateModelCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.contentType !== undefined && data.contentType !== null) {
-    contents.contentType = data.contentType;
+    contents.contentType = __expectString(data.contentType);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.schema !== undefined && data.schema !== null) {
-    contents.schema = data.schema;
+    contents.schema = __expectString(data.schema);
   }
   return Promise.resolve(contents);
 };
@@ -15852,16 +15855,16 @@ export const deserializeAws_restJson1UpdateRequestValidatorCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.validateRequestBody !== undefined && data.validateRequestBody !== null) {
-    contents.validateRequestBody = data.validateRequestBody;
+    contents.validateRequestBody = __expectBoolean(data.validateRequestBody);
   }
   if (data.validateRequestParameters !== undefined && data.validateRequestParameters !== null) {
-    contents.validateRequestParameters = data.validateRequestParameters;
+    contents.validateRequestParameters = __expectBoolean(data.validateRequestParameters);
   }
   return Promise.resolve(contents);
 };
@@ -15944,16 +15947,16 @@ export const deserializeAws_restJson1UpdateResourceCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   if (data.parentId !== undefined && data.parentId !== null) {
-    contents.parentId = data.parentId;
+    contents.parentId = __expectString(data.parentId);
   }
   if (data.path !== undefined && data.path !== null) {
-    contents.path = data.path;
+    contents.path = __expectString(data.path);
   }
   if (data.pathPart !== undefined && data.pathPart !== null) {
-    contents.pathPart = data.pathPart;
+    contents.pathPart = __expectString(data.pathPart);
   }
   if (data.resourceMethods !== undefined && data.resourceMethods !== null) {
     contents.resourceMethods = deserializeAws_restJson1MapOfMethod(data.resourceMethods, context);
@@ -16055,7 +16058,7 @@ export const deserializeAws_restJson1UpdateRestApiCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.apiKeySource !== undefined && data.apiKeySource !== null) {
-    contents.apiKeySource = data.apiKeySource;
+    contents.apiKeySource = __expectString(data.apiKeySource);
   }
   if (data.binaryMediaTypes !== undefined && data.binaryMediaTypes !== null) {
     contents.binaryMediaTypes = deserializeAws_restJson1ListOfString(data.binaryMediaTypes, context);
@@ -16064,31 +16067,31 @@ export const deserializeAws_restJson1UpdateRestApiCommand = async (
     contents.createdDate = new Date(Math.round(data.createdDate * 1000));
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.disableExecuteApiEndpoint !== undefined && data.disableExecuteApiEndpoint !== null) {
-    contents.disableExecuteApiEndpoint = data.disableExecuteApiEndpoint;
+    contents.disableExecuteApiEndpoint = __expectBoolean(data.disableExecuteApiEndpoint);
   }
   if (data.endpointConfiguration !== undefined && data.endpointConfiguration !== null) {
     contents.endpointConfiguration = deserializeAws_restJson1EndpointConfiguration(data.endpointConfiguration, context);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   if (data.minimumCompressionSize !== undefined && data.minimumCompressionSize !== null) {
-    contents.minimumCompressionSize = data.minimumCompressionSize;
+    contents.minimumCompressionSize = __expectNumber(data.minimumCompressionSize);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.policy !== undefined && data.policy !== null) {
-    contents.policy = data.policy;
+    contents.policy = __expectString(data.policy);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1MapOfStringToString(data.tags, context);
   }
   if (data.version !== undefined && data.version !== null) {
-    contents.version = data.version;
+    contents.version = __expectString(data.version);
   }
   if (data.warnings !== undefined && data.warnings !== null) {
     contents.warnings = deserializeAws_restJson1ListOfString(data.warnings, context);
@@ -16197,31 +16200,31 @@ export const deserializeAws_restJson1UpdateStageCommand = async (
     contents.accessLogSettings = deserializeAws_restJson1AccessLogSettings(data.accessLogSettings, context);
   }
   if (data.cacheClusterEnabled !== undefined && data.cacheClusterEnabled !== null) {
-    contents.cacheClusterEnabled = data.cacheClusterEnabled;
+    contents.cacheClusterEnabled = __expectBoolean(data.cacheClusterEnabled);
   }
   if (data.cacheClusterSize !== undefined && data.cacheClusterSize !== null) {
-    contents.cacheClusterSize = data.cacheClusterSize;
+    contents.cacheClusterSize = __expectString(data.cacheClusterSize);
   }
   if (data.cacheClusterStatus !== undefined && data.cacheClusterStatus !== null) {
-    contents.cacheClusterStatus = data.cacheClusterStatus;
+    contents.cacheClusterStatus = __expectString(data.cacheClusterStatus);
   }
   if (data.canarySettings !== undefined && data.canarySettings !== null) {
     contents.canarySettings = deserializeAws_restJson1CanarySettings(data.canarySettings, context);
   }
   if (data.clientCertificateId !== undefined && data.clientCertificateId !== null) {
-    contents.clientCertificateId = data.clientCertificateId;
+    contents.clientCertificateId = __expectString(data.clientCertificateId);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
     contents.createdDate = new Date(Math.round(data.createdDate * 1000));
   }
   if (data.deploymentId !== undefined && data.deploymentId !== null) {
-    contents.deploymentId = data.deploymentId;
+    contents.deploymentId = __expectString(data.deploymentId);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.documentationVersion !== undefined && data.documentationVersion !== null) {
-    contents.documentationVersion = data.documentationVersion;
+    contents.documentationVersion = __expectString(data.documentationVersion);
   }
   if (data.lastUpdatedDate !== undefined && data.lastUpdatedDate !== null) {
     contents.lastUpdatedDate = new Date(Math.round(data.lastUpdatedDate * 1000));
@@ -16230,19 +16233,19 @@ export const deserializeAws_restJson1UpdateStageCommand = async (
     contents.methodSettings = deserializeAws_restJson1MapOfMethodSettings(data.methodSettings, context);
   }
   if (data.stageName !== undefined && data.stageName !== null) {
-    contents.stageName = data.stageName;
+    contents.stageName = __expectString(data.stageName);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1MapOfStringToString(data.tags, context);
   }
   if (data.tracingEnabled !== undefined && data.tracingEnabled !== null) {
-    contents.tracingEnabled = data.tracingEnabled;
+    contents.tracingEnabled = __expectBoolean(data.tracingEnabled);
   }
   if (data.variables !== undefined && data.variables !== null) {
     contents.variables = deserializeAws_restJson1MapOfStringToString(data.variables, context);
   }
   if (data.webAclArn !== undefined && data.webAclArn !== null) {
-    contents.webAclArn = data.webAclArn;
+    contents.webAclArn = __expectString(data.webAclArn);
   }
   return Promise.resolve(contents);
 };
@@ -16333,19 +16336,19 @@ export const deserializeAws_restJson1UpdateUsageCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.endDate !== undefined && data.endDate !== null) {
-    contents.endDate = data.endDate;
+    contents.endDate = __expectString(data.endDate);
   }
   if (data.values !== undefined && data.values !== null) {
     contents.items = deserializeAws_restJson1MapOfKeyUsages(data.values, context);
   }
   if (data.position !== undefined && data.position !== null) {
-    contents.position = data.position;
+    contents.position = __expectString(data.position);
   }
   if (data.startDate !== undefined && data.startDate !== null) {
-    contents.startDate = data.startDate;
+    contents.startDate = __expectString(data.startDate);
   }
   if (data.usagePlanId !== undefined && data.usagePlanId !== null) {
-    contents.usagePlanId = data.usagePlanId;
+    contents.usagePlanId = __expectString(data.usagePlanId);
   }
   return Promise.resolve(contents);
 };
@@ -16434,16 +16437,16 @@ export const deserializeAws_restJson1UpdateUsagePlanCommand = async (
     contents.apiStages = deserializeAws_restJson1ListOfApiStage(data.apiStages, context);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.productCode !== undefined && data.productCode !== null) {
-    contents.productCode = data.productCode;
+    contents.productCode = __expectString(data.productCode);
   }
   if (data.quota !== undefined && data.quota !== null) {
     contents.quota = deserializeAws_restJson1QuotaSettings(data.quota, context);
@@ -16545,19 +16548,19 @@ export const deserializeAws_restJson1UpdateVpcLinkCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.status = data.status;
+    contents.status = __expectString(data.status);
   }
   if (data.statusMessage !== undefined && data.statusMessage !== null) {
-    contents.statusMessage = data.statusMessage;
+    contents.statusMessage = __expectString(data.statusMessage);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1MapOfStringToString(data.tags, context);
@@ -16649,7 +16652,7 @@ const deserializeAws_restJson1BadRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -16666,7 +16669,7 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -16687,7 +16690,7 @@ const deserializeAws_restJson1LimitExceededExceptionResponse = async (
   }
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -16704,7 +16707,7 @@ const deserializeAws_restJson1NotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -16725,7 +16728,7 @@ const deserializeAws_restJson1ServiceUnavailableExceptionResponse = async (
   }
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -16746,7 +16749,7 @@ const deserializeAws_restJson1TooManyRequestsExceptionResponse = async (
   }
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -16763,7 +16766,7 @@ const deserializeAws_restJson1UnauthorizedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -17002,9 +17005,8 @@ const serializeAws_restJson1TlsConfig = (input: TlsConfig, context: __SerdeConte
 
 const deserializeAws_restJson1AccessLogSettings = (output: any, context: __SerdeContext): AccessLogSettings => {
   return {
-    destinationArn:
-      output.destinationArn !== undefined && output.destinationArn !== null ? output.destinationArn : undefined,
-    format: output.format !== undefined && output.format !== null ? output.format : undefined,
+    destinationArn: __expectString(output.destinationArn),
+    format: __expectString(output.format),
   } as any;
 };
 
@@ -17014,15 +17016,15 @@ const deserializeAws_restJson1ApiKey = (output: any, context: __SerdeContext): A
       output.createdDate !== undefined && output.createdDate !== null
         ? new Date(Math.round(output.createdDate * 1000))
         : undefined,
-    customerId: output.customerId !== undefined && output.customerId !== null ? output.customerId : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    enabled: output.enabled !== undefined && output.enabled !== null ? output.enabled : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    customerId: __expectString(output.customerId),
+    description: __expectString(output.description),
+    enabled: __expectBoolean(output.enabled),
+    id: __expectString(output.id),
     lastUpdatedDate:
       output.lastUpdatedDate !== undefined && output.lastUpdatedDate !== null
         ? new Date(Math.round(output.lastUpdatedDate * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
     stageKeys:
       output.stageKeys !== undefined && output.stageKeys !== null
         ? deserializeAws_restJson1ListOfString(output.stageKeys, context)
@@ -17031,14 +17033,14 @@ const deserializeAws_restJson1ApiKey = (output: any, context: __SerdeContext): A
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1MapOfStringToString(output.tags, context)
         : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    value: __expectString(output.value),
   } as any;
 };
 
 const deserializeAws_restJson1ApiStage = (output: any, context: __SerdeContext): ApiStage => {
   return {
-    apiId: output.apiId !== undefined && output.apiId !== null ? output.apiId : undefined,
-    stage: output.stage !== undefined && output.stage !== null ? output.stage : undefined,
+    apiId: __expectString(output.apiId),
+    stage: __expectString(output.stage),
     throttle:
       output.throttle !== undefined && output.throttle !== null
         ? deserializeAws_restJson1MapOfApiStageThrottleSettings(output.throttle, context)
@@ -17048,74 +17050,55 @@ const deserializeAws_restJson1ApiStage = (output: any, context: __SerdeContext):
 
 const deserializeAws_restJson1Authorizer = (output: any, context: __SerdeContext): Authorizer => {
   return {
-    authType: output.authType !== undefined && output.authType !== null ? output.authType : undefined,
-    authorizerCredentials:
-      output.authorizerCredentials !== undefined && output.authorizerCredentials !== null
-        ? output.authorizerCredentials
-        : undefined,
-    authorizerResultTtlInSeconds:
-      output.authorizerResultTtlInSeconds !== undefined && output.authorizerResultTtlInSeconds !== null
-        ? output.authorizerResultTtlInSeconds
-        : undefined,
-    authorizerUri:
-      output.authorizerUri !== undefined && output.authorizerUri !== null ? output.authorizerUri : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    identitySource:
-      output.identitySource !== undefined && output.identitySource !== null ? output.identitySource : undefined,
-    identityValidationExpression:
-      output.identityValidationExpression !== undefined && output.identityValidationExpression !== null
-        ? output.identityValidationExpression
-        : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    authType: __expectString(output.authType),
+    authorizerCredentials: __expectString(output.authorizerCredentials),
+    authorizerResultTtlInSeconds: __expectNumber(output.authorizerResultTtlInSeconds),
+    authorizerUri: __expectString(output.authorizerUri),
+    id: __expectString(output.id),
+    identitySource: __expectString(output.identitySource),
+    identityValidationExpression: __expectString(output.identityValidationExpression),
+    name: __expectString(output.name),
     providerARNs:
       output.providerARNs !== undefined && output.providerARNs !== null
         ? deserializeAws_restJson1ListOfARNs(output.providerARNs, context)
         : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    type: __expectString(output.type),
   } as any;
 };
 
 const deserializeAws_restJson1BasePathMapping = (output: any, context: __SerdeContext): BasePathMapping => {
   return {
-    basePath: output.basePath !== undefined && output.basePath !== null ? output.basePath : undefined,
-    restApiId: output.restApiId !== undefined && output.restApiId !== null ? output.restApiId : undefined,
-    stage: output.stage !== undefined && output.stage !== null ? output.stage : undefined,
+    basePath: __expectString(output.basePath),
+    restApiId: __expectString(output.restApiId),
+    stage: __expectString(output.stage),
   } as any;
 };
 
 const deserializeAws_restJson1CanarySettings = (output: any, context: __SerdeContext): CanarySettings => {
   return {
-    deploymentId: output.deploymentId !== undefined && output.deploymentId !== null ? output.deploymentId : undefined,
-    percentTraffic:
-      output.percentTraffic !== undefined && output.percentTraffic !== null ? output.percentTraffic : undefined,
+    deploymentId: __expectString(output.deploymentId),
+    percentTraffic: __expectNumber(output.percentTraffic),
     stageVariableOverrides:
       output.stageVariableOverrides !== undefined && output.stageVariableOverrides !== null
         ? deserializeAws_restJson1MapOfStringToString(output.stageVariableOverrides, context)
         : undefined,
-    useStageCache:
-      output.useStageCache !== undefined && output.useStageCache !== null ? output.useStageCache : undefined,
+    useStageCache: __expectBoolean(output.useStageCache),
   } as any;
 };
 
 const deserializeAws_restJson1ClientCertificate = (output: any, context: __SerdeContext): ClientCertificate => {
   return {
-    clientCertificateId:
-      output.clientCertificateId !== undefined && output.clientCertificateId !== null
-        ? output.clientCertificateId
-        : undefined,
+    clientCertificateId: __expectString(output.clientCertificateId),
     createdDate:
       output.createdDate !== undefined && output.createdDate !== null
         ? new Date(Math.round(output.createdDate * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    description: __expectString(output.description),
     expirationDate:
       output.expirationDate !== undefined && output.expirationDate !== null
         ? new Date(Math.round(output.expirationDate * 1000))
         : undefined,
-    pemEncodedCertificate:
-      output.pemEncodedCertificate !== undefined && output.pemEncodedCertificate !== null
-        ? output.pemEncodedCertificate
-        : undefined,
+    pemEncodedCertificate: __expectString(output.pemEncodedCertificate),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1MapOfStringToString(output.tags, context)
@@ -17133,19 +17116,19 @@ const deserializeAws_restJson1Deployment = (output: any, context: __SerdeContext
       output.createdDate !== undefined && output.createdDate !== null
         ? new Date(Math.round(output.createdDate * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    description: __expectString(output.description),
+    id: __expectString(output.id),
   } as any;
 };
 
 const deserializeAws_restJson1DocumentationPart = (output: any, context: __SerdeContext): DocumentationPart => {
   return {
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    id: __expectString(output.id),
     location:
       output.location !== undefined && output.location !== null
         ? deserializeAws_restJson1DocumentationPartLocation(output.location, context)
         : undefined,
-    properties: output.properties !== undefined && output.properties !== null ? output.properties : undefined,
+    properties: __expectString(output.properties),
   } as any;
 };
 
@@ -17154,11 +17137,11 @@ const deserializeAws_restJson1DocumentationPartLocation = (
   context: __SerdeContext
 ): DocumentationPartLocation => {
   return {
-    method: output.method !== undefined && output.method !== null ? output.method : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    path: output.path !== undefined && output.path !== null ? output.path : undefined,
-    statusCode: output.statusCode !== undefined && output.statusCode !== null ? output.statusCode : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    method: __expectString(output.method),
+    name: __expectString(output.name),
+    path: __expectString(output.path),
+    statusCode: __expectString(output.statusCode),
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -17168,36 +17151,24 @@ const deserializeAws_restJson1DocumentationVersion = (output: any, context: __Se
       output.createdDate !== undefined && output.createdDate !== null
         ? new Date(Math.round(output.createdDate * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    description: __expectString(output.description),
+    version: __expectString(output.version),
   } as any;
 };
 
 const deserializeAws_restJson1DomainName = (output: any, context: __SerdeContext): DomainName => {
   return {
-    certificateArn:
-      output.certificateArn !== undefined && output.certificateArn !== null ? output.certificateArn : undefined,
-    certificateName:
-      output.certificateName !== undefined && output.certificateName !== null ? output.certificateName : undefined,
+    certificateArn: __expectString(output.certificateArn),
+    certificateName: __expectString(output.certificateName),
     certificateUploadDate:
       output.certificateUploadDate !== undefined && output.certificateUploadDate !== null
         ? new Date(Math.round(output.certificateUploadDate * 1000))
         : undefined,
-    distributionDomainName:
-      output.distributionDomainName !== undefined && output.distributionDomainName !== null
-        ? output.distributionDomainName
-        : undefined,
-    distributionHostedZoneId:
-      output.distributionHostedZoneId !== undefined && output.distributionHostedZoneId !== null
-        ? output.distributionHostedZoneId
-        : undefined,
-    domainName: output.domainName !== undefined && output.domainName !== null ? output.domainName : undefined,
-    domainNameStatus:
-      output.domainNameStatus !== undefined && output.domainNameStatus !== null ? output.domainNameStatus : undefined,
-    domainNameStatusMessage:
-      output.domainNameStatusMessage !== undefined && output.domainNameStatusMessage !== null
-        ? output.domainNameStatusMessage
-        : undefined,
+    distributionDomainName: __expectString(output.distributionDomainName),
+    distributionHostedZoneId: __expectString(output.distributionHostedZoneId),
+    domainName: __expectString(output.domainName),
+    domainNameStatus: __expectString(output.domainNameStatus),
+    domainNameStatusMessage: __expectString(output.domainNameStatusMessage),
     endpointConfiguration:
       output.endpointConfiguration !== undefined && output.endpointConfiguration !== null
         ? deserializeAws_restJson1EndpointConfiguration(output.endpointConfiguration, context)
@@ -17206,24 +17177,11 @@ const deserializeAws_restJson1DomainName = (output: any, context: __SerdeContext
       output.mutualTlsAuthentication !== undefined && output.mutualTlsAuthentication !== null
         ? deserializeAws_restJson1MutualTlsAuthentication(output.mutualTlsAuthentication, context)
         : undefined,
-    regionalCertificateArn:
-      output.regionalCertificateArn !== undefined && output.regionalCertificateArn !== null
-        ? output.regionalCertificateArn
-        : undefined,
-    regionalCertificateName:
-      output.regionalCertificateName !== undefined && output.regionalCertificateName !== null
-        ? output.regionalCertificateName
-        : undefined,
-    regionalDomainName:
-      output.regionalDomainName !== undefined && output.regionalDomainName !== null
-        ? output.regionalDomainName
-        : undefined,
-    regionalHostedZoneId:
-      output.regionalHostedZoneId !== undefined && output.regionalHostedZoneId !== null
-        ? output.regionalHostedZoneId
-        : undefined,
-    securityPolicy:
-      output.securityPolicy !== undefined && output.securityPolicy !== null ? output.securityPolicy : undefined,
+    regionalCertificateArn: __expectString(output.regionalCertificateArn),
+    regionalCertificateName: __expectString(output.regionalCertificateName),
+    regionalDomainName: __expectString(output.regionalDomainName),
+    regionalHostedZoneId: __expectString(output.regionalHostedZoneId),
+    securityPolicy: __expectString(output.securityPolicy),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1MapOfStringToString(output.tags, context)
@@ -17246,8 +17204,7 @@ const deserializeAws_restJson1EndpointConfiguration = (output: any, context: __S
 
 const deserializeAws_restJson1GatewayResponse = (output: any, context: __SerdeContext): GatewayResponse => {
   return {
-    defaultResponse:
-      output.defaultResponse !== undefined && output.defaultResponse !== null ? output.defaultResponse : undefined,
+    defaultResponse: __expectBoolean(output.defaultResponse),
     responseParameters:
       output.responseParameters !== undefined && output.responseParameters !== null
         ? deserializeAws_restJson1MapOfStringToString(output.responseParameters, context)
@@ -17256,8 +17213,8 @@ const deserializeAws_restJson1GatewayResponse = (output: any, context: __SerdeCo
       output.responseTemplates !== undefined && output.responseTemplates !== null
         ? deserializeAws_restJson1MapOfStringToString(output.responseTemplates, context)
         : undefined,
-    responseType: output.responseType !== undefined && output.responseType !== null ? output.responseType : undefined,
-    statusCode: output.statusCode !== undefined && output.statusCode !== null ? output.statusCode : undefined,
+    responseType: __expectString(output.responseType),
+    statusCode: __expectString(output.statusCode),
   } as any;
 };
 
@@ -17267,23 +17224,17 @@ const deserializeAws_restJson1Integration = (output: any, context: __SerdeContex
       output.cacheKeyParameters !== undefined && output.cacheKeyParameters !== null
         ? deserializeAws_restJson1ListOfString(output.cacheKeyParameters, context)
         : undefined,
-    cacheNamespace:
-      output.cacheNamespace !== undefined && output.cacheNamespace !== null ? output.cacheNamespace : undefined,
-    connectionId: output.connectionId !== undefined && output.connectionId !== null ? output.connectionId : undefined,
-    connectionType:
-      output.connectionType !== undefined && output.connectionType !== null ? output.connectionType : undefined,
-    contentHandling:
-      output.contentHandling !== undefined && output.contentHandling !== null ? output.contentHandling : undefined,
-    credentials: output.credentials !== undefined && output.credentials !== null ? output.credentials : undefined,
-    httpMethod: output.httpMethod !== undefined && output.httpMethod !== null ? output.httpMethod : undefined,
+    cacheNamespace: __expectString(output.cacheNamespace),
+    connectionId: __expectString(output.connectionId),
+    connectionType: __expectString(output.connectionType),
+    contentHandling: __expectString(output.contentHandling),
+    credentials: __expectString(output.credentials),
+    httpMethod: __expectString(output.httpMethod),
     integrationResponses:
       output.integrationResponses !== undefined && output.integrationResponses !== null
         ? deserializeAws_restJson1MapOfIntegrationResponse(output.integrationResponses, context)
         : undefined,
-    passthroughBehavior:
-      output.passthroughBehavior !== undefined && output.passthroughBehavior !== null
-        ? output.passthroughBehavior
-        : undefined,
+    passthroughBehavior: __expectString(output.passthroughBehavior),
     requestParameters:
       output.requestParameters !== undefined && output.requestParameters !== null
         ? deserializeAws_restJson1MapOfStringToString(output.requestParameters, context)
@@ -17292,21 +17243,19 @@ const deserializeAws_restJson1Integration = (output: any, context: __SerdeContex
       output.requestTemplates !== undefined && output.requestTemplates !== null
         ? deserializeAws_restJson1MapOfStringToString(output.requestTemplates, context)
         : undefined,
-    timeoutInMillis:
-      output.timeoutInMillis !== undefined && output.timeoutInMillis !== null ? output.timeoutInMillis : undefined,
+    timeoutInMillis: __expectNumber(output.timeoutInMillis),
     tlsConfig:
       output.tlsConfig !== undefined && output.tlsConfig !== null
         ? deserializeAws_restJson1TlsConfig(output.tlsConfig, context)
         : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
-    uri: output.uri !== undefined && output.uri !== null ? output.uri : undefined,
+    type: __expectString(output.type),
+    uri: __expectString(output.uri),
   } as any;
 };
 
 const deserializeAws_restJson1IntegrationResponse = (output: any, context: __SerdeContext): IntegrationResponse => {
   return {
-    contentHandling:
-      output.contentHandling !== undefined && output.contentHandling !== null ? output.contentHandling : undefined,
+    contentHandling: __expectString(output.contentHandling),
     responseParameters:
       output.responseParameters !== undefined && output.responseParameters !== null
         ? deserializeAws_restJson1MapOfStringToString(output.responseParameters, context)
@@ -17315,9 +17264,8 @@ const deserializeAws_restJson1IntegrationResponse = (output: any, context: __Ser
       output.responseTemplates !== undefined && output.responseTemplates !== null
         ? deserializeAws_restJson1MapOfStringToString(output.responseTemplates, context)
         : undefined,
-    selectionPattern:
-      output.selectionPattern !== undefined && output.selectionPattern !== null ? output.selectionPattern : undefined,
-    statusCode: output.statusCode !== undefined && output.statusCode !== null ? output.statusCode : undefined,
+    selectionPattern: __expectString(output.selectionPattern),
+    statusCode: __expectString(output.statusCode),
   } as any;
 };
 
@@ -17350,7 +17298,7 @@ const deserializeAws_restJson1ListOfARNs = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -17444,7 +17392,7 @@ const deserializeAws_restJson1ListOfEndpointType = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -17466,7 +17414,7 @@ const deserializeAws_restJson1ListOfLong = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectNumber(entry) as any;
     });
 };
 
@@ -17557,7 +17505,7 @@ const deserializeAws_restJson1ListOfString = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -17717,7 +17665,7 @@ const deserializeAws_restJson1MapOfStringToBoolean = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectBoolean(value) as any,
     };
   }, {});
 };
@@ -17747,25 +17695,21 @@ const deserializeAws_restJson1MapOfStringToString = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1Method = (output: any, context: __SerdeContext): Method => {
   return {
-    apiKeyRequired:
-      output.apiKeyRequired !== undefined && output.apiKeyRequired !== null ? output.apiKeyRequired : undefined,
+    apiKeyRequired: __expectBoolean(output.apiKeyRequired),
     authorizationScopes:
       output.authorizationScopes !== undefined && output.authorizationScopes !== null
         ? deserializeAws_restJson1ListOfString(output.authorizationScopes, context)
         : undefined,
-    authorizationType:
-      output.authorizationType !== undefined && output.authorizationType !== null
-        ? output.authorizationType
-        : undefined,
-    authorizerId: output.authorizerId !== undefined && output.authorizerId !== null ? output.authorizerId : undefined,
-    httpMethod: output.httpMethod !== undefined && output.httpMethod !== null ? output.httpMethod : undefined,
+    authorizationType: __expectString(output.authorizationType),
+    authorizerId: __expectString(output.authorizerId),
+    httpMethod: __expectString(output.httpMethod),
     methodIntegration:
       output.methodIntegration !== undefined && output.methodIntegration !== null
         ? deserializeAws_restJson1Integration(output.methodIntegration, context)
@@ -17774,8 +17718,7 @@ const deserializeAws_restJson1Method = (output: any, context: __SerdeContext): M
       output.methodResponses !== undefined && output.methodResponses !== null
         ? deserializeAws_restJson1MapOfMethodResponse(output.methodResponses, context)
         : undefined,
-    operationName:
-      output.operationName !== undefined && output.operationName !== null ? output.operationName : undefined,
+    operationName: __expectString(output.operationName),
     requestModels:
       output.requestModels !== undefined && output.requestModels !== null
         ? deserializeAws_restJson1MapOfStringToString(output.requestModels, context)
@@ -17784,10 +17727,7 @@ const deserializeAws_restJson1Method = (output: any, context: __SerdeContext): M
       output.requestParameters !== undefined && output.requestParameters !== null
         ? deserializeAws_restJson1MapOfStringToBoolean(output.requestParameters, context)
         : undefined,
-    requestValidatorId:
-      output.requestValidatorId !== undefined && output.requestValidatorId !== null
-        ? output.requestValidatorId
-        : undefined,
+    requestValidatorId: __expectString(output.requestValidatorId),
   } as any;
 };
 
@@ -17801,65 +17741,39 @@ const deserializeAws_restJson1MethodResponse = (output: any, context: __SerdeCon
       output.responseParameters !== undefined && output.responseParameters !== null
         ? deserializeAws_restJson1MapOfStringToBoolean(output.responseParameters, context)
         : undefined,
-    statusCode: output.statusCode !== undefined && output.statusCode !== null ? output.statusCode : undefined,
+    statusCode: __expectString(output.statusCode),
   } as any;
 };
 
 const deserializeAws_restJson1MethodSetting = (output: any, context: __SerdeContext): MethodSetting => {
   return {
-    cacheDataEncrypted:
-      output.cacheDataEncrypted !== undefined && output.cacheDataEncrypted !== null
-        ? output.cacheDataEncrypted
-        : undefined,
-    cacheTtlInSeconds:
-      output.cacheTtlInSeconds !== undefined && output.cacheTtlInSeconds !== null
-        ? output.cacheTtlInSeconds
-        : undefined,
-    cachingEnabled:
-      output.cachingEnabled !== undefined && output.cachingEnabled !== null ? output.cachingEnabled : undefined,
-    dataTraceEnabled:
-      output.dataTraceEnabled !== undefined && output.dataTraceEnabled !== null ? output.dataTraceEnabled : undefined,
-    loggingLevel: output.loggingLevel !== undefined && output.loggingLevel !== null ? output.loggingLevel : undefined,
-    metricsEnabled:
-      output.metricsEnabled !== undefined && output.metricsEnabled !== null ? output.metricsEnabled : undefined,
-    requireAuthorizationForCacheControl:
-      output.requireAuthorizationForCacheControl !== undefined && output.requireAuthorizationForCacheControl !== null
-        ? output.requireAuthorizationForCacheControl
-        : undefined,
-    throttlingBurstLimit:
-      output.throttlingBurstLimit !== undefined && output.throttlingBurstLimit !== null
-        ? output.throttlingBurstLimit
-        : undefined,
-    throttlingRateLimit:
-      output.throttlingRateLimit !== undefined && output.throttlingRateLimit !== null
-        ? output.throttlingRateLimit
-        : undefined,
-    unauthorizedCacheControlHeaderStrategy:
-      output.unauthorizedCacheControlHeaderStrategy !== undefined &&
-      output.unauthorizedCacheControlHeaderStrategy !== null
-        ? output.unauthorizedCacheControlHeaderStrategy
-        : undefined,
+    cacheDataEncrypted: __expectBoolean(output.cacheDataEncrypted),
+    cacheTtlInSeconds: __expectNumber(output.cacheTtlInSeconds),
+    cachingEnabled: __expectBoolean(output.cachingEnabled),
+    dataTraceEnabled: __expectBoolean(output.dataTraceEnabled),
+    loggingLevel: __expectString(output.loggingLevel),
+    metricsEnabled: __expectBoolean(output.metricsEnabled),
+    requireAuthorizationForCacheControl: __expectBoolean(output.requireAuthorizationForCacheControl),
+    throttlingBurstLimit: __expectNumber(output.throttlingBurstLimit),
+    throttlingRateLimit: __expectNumber(output.throttlingRateLimit),
+    unauthorizedCacheControlHeaderStrategy: __expectString(output.unauthorizedCacheControlHeaderStrategy),
   } as any;
 };
 
 const deserializeAws_restJson1MethodSnapshot = (output: any, context: __SerdeContext): MethodSnapshot => {
   return {
-    apiKeyRequired:
-      output.apiKeyRequired !== undefined && output.apiKeyRequired !== null ? output.apiKeyRequired : undefined,
-    authorizationType:
-      output.authorizationType !== undefined && output.authorizationType !== null
-        ? output.authorizationType
-        : undefined,
+    apiKeyRequired: __expectBoolean(output.apiKeyRequired),
+    authorizationType: __expectString(output.authorizationType),
   } as any;
 };
 
 const deserializeAws_restJson1Model = (output: any, context: __SerdeContext): Model => {
   return {
-    contentType: output.contentType !== undefined && output.contentType !== null ? output.contentType : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    schema: output.schema !== undefined && output.schema !== null ? output.schema : undefined,
+    contentType: __expectString(output.contentType),
+    description: __expectString(output.description),
+    id: __expectString(output.id),
+    name: __expectString(output.name),
+    schema: __expectString(output.schema),
   } as any;
 };
 
@@ -17868,12 +17782,8 @@ const deserializeAws_restJson1MutualTlsAuthentication = (
   context: __SerdeContext
 ): MutualTlsAuthentication => {
   return {
-    truststoreUri:
-      output.truststoreUri !== undefined && output.truststoreUri !== null ? output.truststoreUri : undefined,
-    truststoreVersion:
-      output.truststoreVersion !== undefined && output.truststoreVersion !== null
-        ? output.truststoreVersion
-        : undefined,
+    truststoreUri: __expectString(output.truststoreUri),
+    truststoreVersion: __expectString(output.truststoreVersion),
     truststoreWarnings:
       output.truststoreWarnings !== undefined && output.truststoreWarnings !== null
         ? deserializeAws_restJson1ListOfString(output.truststoreWarnings, context)
@@ -17901,33 +17811,27 @@ const deserializeAws_restJson1PathToMapOfMethodSnapshot = (
 
 const deserializeAws_restJson1QuotaSettings = (output: any, context: __SerdeContext): QuotaSettings => {
   return {
-    limit: output.limit !== undefined && output.limit !== null ? output.limit : undefined,
-    offset: output.offset !== undefined && output.offset !== null ? output.offset : undefined,
-    period: output.period !== undefined && output.period !== null ? output.period : undefined,
+    limit: __expectNumber(output.limit),
+    offset: __expectNumber(output.offset),
+    period: __expectString(output.period),
   } as any;
 };
 
 const deserializeAws_restJson1RequestValidator = (output: any, context: __SerdeContext): RequestValidator => {
   return {
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    validateRequestBody:
-      output.validateRequestBody !== undefined && output.validateRequestBody !== null
-        ? output.validateRequestBody
-        : undefined,
-    validateRequestParameters:
-      output.validateRequestParameters !== undefined && output.validateRequestParameters !== null
-        ? output.validateRequestParameters
-        : undefined,
+    id: __expectString(output.id),
+    name: __expectString(output.name),
+    validateRequestBody: __expectBoolean(output.validateRequestBody),
+    validateRequestParameters: __expectBoolean(output.validateRequestParameters),
   } as any;
 };
 
 const deserializeAws_restJson1Resource = (output: any, context: __SerdeContext): Resource => {
   return {
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    parentId: output.parentId !== undefined && output.parentId !== null ? output.parentId : undefined,
-    path: output.path !== undefined && output.path !== null ? output.path : undefined,
-    pathPart: output.pathPart !== undefined && output.pathPart !== null ? output.pathPart : undefined,
+    id: __expectString(output.id),
+    parentId: __expectString(output.parentId),
+    path: __expectString(output.path),
+    pathPart: __expectString(output.pathPart),
     resourceMethods:
       output.resourceMethods !== undefined && output.resourceMethods !== null
         ? deserializeAws_restJson1MapOfMethod(output.resourceMethods, context)
@@ -17937,7 +17841,7 @@ const deserializeAws_restJson1Resource = (output: any, context: __SerdeContext):
 
 const deserializeAws_restJson1RestApi = (output: any, context: __SerdeContext): RestApi => {
   return {
-    apiKeySource: output.apiKeySource !== undefined && output.apiKeySource !== null ? output.apiKeySource : undefined,
+    apiKeySource: __expectString(output.apiKeySource),
     binaryMediaTypes:
       output.binaryMediaTypes !== undefined && output.binaryMediaTypes !== null
         ? deserializeAws_restJson1ListOfString(output.binaryMediaTypes, context)
@@ -17946,27 +17850,21 @@ const deserializeAws_restJson1RestApi = (output: any, context: __SerdeContext): 
       output.createdDate !== undefined && output.createdDate !== null
         ? new Date(Math.round(output.createdDate * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    disableExecuteApiEndpoint:
-      output.disableExecuteApiEndpoint !== undefined && output.disableExecuteApiEndpoint !== null
-        ? output.disableExecuteApiEndpoint
-        : undefined,
+    description: __expectString(output.description),
+    disableExecuteApiEndpoint: __expectBoolean(output.disableExecuteApiEndpoint),
     endpointConfiguration:
       output.endpointConfiguration !== undefined && output.endpointConfiguration !== null
         ? deserializeAws_restJson1EndpointConfiguration(output.endpointConfiguration, context)
         : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    minimumCompressionSize:
-      output.minimumCompressionSize !== undefined && output.minimumCompressionSize !== null
-        ? output.minimumCompressionSize
-        : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    policy: output.policy !== undefined && output.policy !== null ? output.policy : undefined,
+    id: __expectString(output.id),
+    minimumCompressionSize: __expectNumber(output.minimumCompressionSize),
+    name: __expectString(output.name),
+    policy: __expectString(output.policy),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1MapOfStringToString(output.tags, context)
         : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    version: __expectString(output.version),
     warnings:
       output.warnings !== undefined && output.warnings !== null
         ? deserializeAws_restJson1ListOfString(output.warnings, context)
@@ -17979,11 +17877,11 @@ const deserializeAws_restJson1SdkConfigurationProperty = (
   context: __SerdeContext
 ): SdkConfigurationProperty => {
   return {
-    defaultValue: output.defaultValue !== undefined && output.defaultValue !== null ? output.defaultValue : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    friendlyName: output.friendlyName !== undefined && output.friendlyName !== null ? output.friendlyName : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    required: output.required !== undefined && output.required !== null ? output.required : undefined,
+    defaultValue: __expectString(output.defaultValue),
+    description: __expectString(output.description),
+    friendlyName: __expectString(output.friendlyName),
+    name: __expectString(output.name),
+    required: __expectBoolean(output.required),
   } as any;
 };
 
@@ -17993,9 +17891,9 @@ const deserializeAws_restJson1SdkType = (output: any, context: __SerdeContext): 
       output.configurationProperties !== undefined && output.configurationProperties !== null
         ? deserializeAws_restJson1ListOfSdkConfigurationProperty(output.configurationProperties, context)
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    friendlyName: output.friendlyName !== undefined && output.friendlyName !== null ? output.friendlyName : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    description: __expectString(output.description),
+    friendlyName: __expectString(output.friendlyName),
+    id: __expectString(output.id),
   } as any;
 };
 
@@ -18005,34 +17903,21 @@ const deserializeAws_restJson1Stage = (output: any, context: __SerdeContext): St
       output.accessLogSettings !== undefined && output.accessLogSettings !== null
         ? deserializeAws_restJson1AccessLogSettings(output.accessLogSettings, context)
         : undefined,
-    cacheClusterEnabled:
-      output.cacheClusterEnabled !== undefined && output.cacheClusterEnabled !== null
-        ? output.cacheClusterEnabled
-        : undefined,
-    cacheClusterSize:
-      output.cacheClusterSize !== undefined && output.cacheClusterSize !== null ? output.cacheClusterSize : undefined,
-    cacheClusterStatus:
-      output.cacheClusterStatus !== undefined && output.cacheClusterStatus !== null
-        ? output.cacheClusterStatus
-        : undefined,
+    cacheClusterEnabled: __expectBoolean(output.cacheClusterEnabled),
+    cacheClusterSize: __expectString(output.cacheClusterSize),
+    cacheClusterStatus: __expectString(output.cacheClusterStatus),
     canarySettings:
       output.canarySettings !== undefined && output.canarySettings !== null
         ? deserializeAws_restJson1CanarySettings(output.canarySettings, context)
         : undefined,
-    clientCertificateId:
-      output.clientCertificateId !== undefined && output.clientCertificateId !== null
-        ? output.clientCertificateId
-        : undefined,
+    clientCertificateId: __expectString(output.clientCertificateId),
     createdDate:
       output.createdDate !== undefined && output.createdDate !== null
         ? new Date(Math.round(output.createdDate * 1000))
         : undefined,
-    deploymentId: output.deploymentId !== undefined && output.deploymentId !== null ? output.deploymentId : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    documentationVersion:
-      output.documentationVersion !== undefined && output.documentationVersion !== null
-        ? output.documentationVersion
-        : undefined,
+    deploymentId: __expectString(output.deploymentId),
+    description: __expectString(output.description),
+    documentationVersion: __expectString(output.documentationVersion),
     lastUpdatedDate:
       output.lastUpdatedDate !== undefined && output.lastUpdatedDate !== null
         ? new Date(Math.round(output.lastUpdatedDate * 1000))
@@ -18041,34 +17926,30 @@ const deserializeAws_restJson1Stage = (output: any, context: __SerdeContext): St
       output.methodSettings !== undefined && output.methodSettings !== null
         ? deserializeAws_restJson1MapOfMethodSettings(output.methodSettings, context)
         : undefined,
-    stageName: output.stageName !== undefined && output.stageName !== null ? output.stageName : undefined,
+    stageName: __expectString(output.stageName),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1MapOfStringToString(output.tags, context)
         : undefined,
-    tracingEnabled:
-      output.tracingEnabled !== undefined && output.tracingEnabled !== null ? output.tracingEnabled : undefined,
+    tracingEnabled: __expectBoolean(output.tracingEnabled),
     variables:
       output.variables !== undefined && output.variables !== null
         ? deserializeAws_restJson1MapOfStringToString(output.variables, context)
         : undefined,
-    webAclArn: output.webAclArn !== undefined && output.webAclArn !== null ? output.webAclArn : undefined,
+    webAclArn: __expectString(output.webAclArn),
   } as any;
 };
 
 const deserializeAws_restJson1ThrottleSettings = (output: any, context: __SerdeContext): ThrottleSettings => {
   return {
-    burstLimit: output.burstLimit !== undefined && output.burstLimit !== null ? output.burstLimit : undefined,
-    rateLimit: output.rateLimit !== undefined && output.rateLimit !== null ? output.rateLimit : undefined,
+    burstLimit: __expectNumber(output.burstLimit),
+    rateLimit: __expectNumber(output.rateLimit),
   } as any;
 };
 
 const deserializeAws_restJson1TlsConfig = (output: any, context: __SerdeContext): TlsConfig => {
   return {
-    insecureSkipVerification:
-      output.insecureSkipVerification !== undefined && output.insecureSkipVerification !== null
-        ? output.insecureSkipVerification
-        : undefined,
+    insecureSkipVerification: __expectBoolean(output.insecureSkipVerification),
   } as any;
 };
 
@@ -18078,10 +17959,10 @@ const deserializeAws_restJson1UsagePlan = (output: any, context: __SerdeContext)
       output.apiStages !== undefined && output.apiStages !== null
         ? deserializeAws_restJson1ListOfApiStage(output.apiStages, context)
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    productCode: output.productCode !== undefined && output.productCode !== null ? output.productCode : undefined,
+    description: __expectString(output.description),
+    id: __expectString(output.id),
+    name: __expectString(output.name),
+    productCode: __expectString(output.productCode),
     quota:
       output.quota !== undefined && output.quota !== null
         ? deserializeAws_restJson1QuotaSettings(output.quota, context)
@@ -18099,21 +17980,20 @@ const deserializeAws_restJson1UsagePlan = (output: any, context: __SerdeContext)
 
 const deserializeAws_restJson1UsagePlanKey = (output: any, context: __SerdeContext): UsagePlanKey => {
   return {
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    id: __expectString(output.id),
+    name: __expectString(output.name),
+    type: __expectString(output.type),
+    value: __expectString(output.value),
   } as any;
 };
 
 const deserializeAws_restJson1VpcLink = (output: any, context: __SerdeContext): VpcLink => {
   return {
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    statusMessage:
-      output.statusMessage !== undefined && output.statusMessage !== null ? output.statusMessage : undefined,
+    description: __expectString(output.description),
+    id: __expectString(output.id),
+    name: __expectString(output.name),
+    status: __expectString(output.status),
+    statusMessage: __expectString(output.statusMessage),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1MapOfStringToString(output.tags, context)

--- a/clients/client-apigatewaymanagementapi/protocols/Aws_restJson1.ts
+++ b/clients/client-apigatewaymanagementapi/protocols/Aws_restJson1.ts
@@ -11,6 +11,7 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -381,15 +382,15 @@ const deserializeAws_restJson1PayloadTooLargeExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
 
 const deserializeAws_restJson1Identity = (output: any, context: __SerdeContext): Identity => {
   return {
-    SourceIp: output.sourceIp !== undefined && output.sourceIp !== null ? output.sourceIp : undefined,
-    UserAgent: output.userAgent !== undefined && output.userAgent !== null ? output.userAgent : undefined,
+    SourceIp: __expectString(output.sourceIp),
+    UserAgent: __expectString(output.userAgent),
   } as any;
 };
 

--- a/clients/client-apigatewayv2/protocols/Aws_restJson1.ts
+++ b/clients/client-apigatewayv2/protocols/Aws_restJson1.ts
@@ -141,6 +141,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -3104,16 +3107,16 @@ export const deserializeAws_restJson1CreateApiCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.apiEndpoint !== undefined && data.apiEndpoint !== null) {
-    contents.ApiEndpoint = data.apiEndpoint;
+    contents.ApiEndpoint = __expectString(data.apiEndpoint);
   }
   if (data.apiGatewayManaged !== undefined && data.apiGatewayManaged !== null) {
-    contents.ApiGatewayManaged = data.apiGatewayManaged;
+    contents.ApiGatewayManaged = __expectBoolean(data.apiGatewayManaged);
   }
   if (data.apiId !== undefined && data.apiId !== null) {
-    contents.ApiId = data.apiId;
+    contents.ApiId = __expectString(data.apiId);
   }
   if (data.apiKeySelectionExpression !== undefined && data.apiKeySelectionExpression !== null) {
-    contents.ApiKeySelectionExpression = data.apiKeySelectionExpression;
+    contents.ApiKeySelectionExpression = __expectString(data.apiKeySelectionExpression);
   }
   if (data.corsConfiguration !== undefined && data.corsConfiguration !== null) {
     contents.CorsConfiguration = deserializeAws_restJson1Cors(data.corsConfiguration, context);
@@ -3122,31 +3125,31 @@ export const deserializeAws_restJson1CreateApiCommand = async (
     contents.CreatedDate = new Date(data.createdDate);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.Description = data.description;
+    contents.Description = __expectString(data.description);
   }
   if (data.disableExecuteApiEndpoint !== undefined && data.disableExecuteApiEndpoint !== null) {
-    contents.DisableExecuteApiEndpoint = data.disableExecuteApiEndpoint;
+    contents.DisableExecuteApiEndpoint = __expectBoolean(data.disableExecuteApiEndpoint);
   }
   if (data.disableSchemaValidation !== undefined && data.disableSchemaValidation !== null) {
-    contents.DisableSchemaValidation = data.disableSchemaValidation;
+    contents.DisableSchemaValidation = __expectBoolean(data.disableSchemaValidation);
   }
   if (data.importInfo !== undefined && data.importInfo !== null) {
     contents.ImportInfo = deserializeAws_restJson1__listOf__string(data.importInfo, context);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.Name = data.name;
+    contents.Name = __expectString(data.name);
   }
   if (data.protocolType !== undefined && data.protocolType !== null) {
-    contents.ProtocolType = data.protocolType;
+    contents.ProtocolType = __expectString(data.protocolType);
   }
   if (data.routeSelectionExpression !== undefined && data.routeSelectionExpression !== null) {
-    contents.RouteSelectionExpression = data.routeSelectionExpression;
+    contents.RouteSelectionExpression = __expectString(data.routeSelectionExpression);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
   }
   if (data.version !== undefined && data.version !== null) {
-    contents.Version = data.version;
+    contents.Version = __expectString(data.version);
   }
   if (data.warnings !== undefined && data.warnings !== null) {
     contents.Warnings = deserializeAws_restJson1__listOf__string(data.warnings, context);
@@ -3231,16 +3234,16 @@ export const deserializeAws_restJson1CreateApiMappingCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.apiId !== undefined && data.apiId !== null) {
-    contents.ApiId = data.apiId;
+    contents.ApiId = __expectString(data.apiId);
   }
   if (data.apiMappingId !== undefined && data.apiMappingId !== null) {
-    contents.ApiMappingId = data.apiMappingId;
+    contents.ApiMappingId = __expectString(data.apiMappingId);
   }
   if (data.apiMappingKey !== undefined && data.apiMappingKey !== null) {
-    contents.ApiMappingKey = data.apiMappingKey;
+    contents.ApiMappingKey = __expectString(data.apiMappingKey);
   }
   if (data.stage !== undefined && data.stage !== null) {
-    contents.Stage = data.stage;
+    contents.Stage = __expectString(data.stage);
   }
   return Promise.resolve(contents);
 };
@@ -3329,37 +3332,37 @@ export const deserializeAws_restJson1CreateAuthorizerCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.authorizerCredentialsArn !== undefined && data.authorizerCredentialsArn !== null) {
-    contents.AuthorizerCredentialsArn = data.authorizerCredentialsArn;
+    contents.AuthorizerCredentialsArn = __expectString(data.authorizerCredentialsArn);
   }
   if (data.authorizerId !== undefined && data.authorizerId !== null) {
-    contents.AuthorizerId = data.authorizerId;
+    contents.AuthorizerId = __expectString(data.authorizerId);
   }
   if (data.authorizerPayloadFormatVersion !== undefined && data.authorizerPayloadFormatVersion !== null) {
-    contents.AuthorizerPayloadFormatVersion = data.authorizerPayloadFormatVersion;
+    contents.AuthorizerPayloadFormatVersion = __expectString(data.authorizerPayloadFormatVersion);
   }
   if (data.authorizerResultTtlInSeconds !== undefined && data.authorizerResultTtlInSeconds !== null) {
-    contents.AuthorizerResultTtlInSeconds = data.authorizerResultTtlInSeconds;
+    contents.AuthorizerResultTtlInSeconds = __expectNumber(data.authorizerResultTtlInSeconds);
   }
   if (data.authorizerType !== undefined && data.authorizerType !== null) {
-    contents.AuthorizerType = data.authorizerType;
+    contents.AuthorizerType = __expectString(data.authorizerType);
   }
   if (data.authorizerUri !== undefined && data.authorizerUri !== null) {
-    contents.AuthorizerUri = data.authorizerUri;
+    contents.AuthorizerUri = __expectString(data.authorizerUri);
   }
   if (data.enableSimpleResponses !== undefined && data.enableSimpleResponses !== null) {
-    contents.EnableSimpleResponses = data.enableSimpleResponses;
+    contents.EnableSimpleResponses = __expectBoolean(data.enableSimpleResponses);
   }
   if (data.identitySource !== undefined && data.identitySource !== null) {
     contents.IdentitySource = deserializeAws_restJson1IdentitySourceList(data.identitySource, context);
   }
   if (data.identityValidationExpression !== undefined && data.identityValidationExpression !== null) {
-    contents.IdentityValidationExpression = data.identityValidationExpression;
+    contents.IdentityValidationExpression = __expectString(data.identityValidationExpression);
   }
   if (data.jwtConfiguration !== undefined && data.jwtConfiguration !== null) {
     contents.JwtConfiguration = deserializeAws_restJson1JWTConfiguration(data.jwtConfiguration, context);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.Name = data.name;
+    contents.Name = __expectString(data.name);
   }
   return Promise.resolve(contents);
 };
@@ -3443,22 +3446,22 @@ export const deserializeAws_restJson1CreateDeploymentCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.autoDeployed !== undefined && data.autoDeployed !== null) {
-    contents.AutoDeployed = data.autoDeployed;
+    contents.AutoDeployed = __expectBoolean(data.autoDeployed);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
     contents.CreatedDate = new Date(data.createdDate);
   }
   if (data.deploymentId !== undefined && data.deploymentId !== null) {
-    contents.DeploymentId = data.deploymentId;
+    contents.DeploymentId = __expectString(data.deploymentId);
   }
   if (data.deploymentStatus !== undefined && data.deploymentStatus !== null) {
-    contents.DeploymentStatus = data.deploymentStatus;
+    contents.DeploymentStatus = __expectString(data.deploymentStatus);
   }
   if (data.deploymentStatusMessage !== undefined && data.deploymentStatusMessage !== null) {
-    contents.DeploymentStatusMessage = data.deploymentStatusMessage;
+    contents.DeploymentStatusMessage = __expectString(data.deploymentStatusMessage);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.Description = data.description;
+    contents.Description = __expectString(data.description);
   }
   return Promise.resolve(contents);
 };
@@ -3541,10 +3544,10 @@ export const deserializeAws_restJson1CreateDomainNameCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.apiMappingSelectionExpression !== undefined && data.apiMappingSelectionExpression !== null) {
-    contents.ApiMappingSelectionExpression = data.apiMappingSelectionExpression;
+    contents.ApiMappingSelectionExpression = __expectString(data.apiMappingSelectionExpression);
   }
   if (data.domainName !== undefined && data.domainName !== null) {
-    contents.DomainName = data.domainName;
+    contents.DomainName = __expectString(data.domainName);
   }
   if (data.domainNameConfigurations !== undefined && data.domainNameConfigurations !== null) {
     contents.DomainNameConfigurations = deserializeAws_restJson1DomainNameConfigurations(
@@ -3665,49 +3668,49 @@ export const deserializeAws_restJson1CreateIntegrationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.apiGatewayManaged !== undefined && data.apiGatewayManaged !== null) {
-    contents.ApiGatewayManaged = data.apiGatewayManaged;
+    contents.ApiGatewayManaged = __expectBoolean(data.apiGatewayManaged);
   }
   if (data.connectionId !== undefined && data.connectionId !== null) {
-    contents.ConnectionId = data.connectionId;
+    contents.ConnectionId = __expectString(data.connectionId);
   }
   if (data.connectionType !== undefined && data.connectionType !== null) {
-    contents.ConnectionType = data.connectionType;
+    contents.ConnectionType = __expectString(data.connectionType);
   }
   if (data.contentHandlingStrategy !== undefined && data.contentHandlingStrategy !== null) {
-    contents.ContentHandlingStrategy = data.contentHandlingStrategy;
+    contents.ContentHandlingStrategy = __expectString(data.contentHandlingStrategy);
   }
   if (data.credentialsArn !== undefined && data.credentialsArn !== null) {
-    contents.CredentialsArn = data.credentialsArn;
+    contents.CredentialsArn = __expectString(data.credentialsArn);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.Description = data.description;
+    contents.Description = __expectString(data.description);
   }
   if (data.integrationId !== undefined && data.integrationId !== null) {
-    contents.IntegrationId = data.integrationId;
+    contents.IntegrationId = __expectString(data.integrationId);
   }
   if (data.integrationMethod !== undefined && data.integrationMethod !== null) {
-    contents.IntegrationMethod = data.integrationMethod;
+    contents.IntegrationMethod = __expectString(data.integrationMethod);
   }
   if (
     data.integrationResponseSelectionExpression !== undefined &&
     data.integrationResponseSelectionExpression !== null
   ) {
-    contents.IntegrationResponseSelectionExpression = data.integrationResponseSelectionExpression;
+    contents.IntegrationResponseSelectionExpression = __expectString(data.integrationResponseSelectionExpression);
   }
   if (data.integrationSubtype !== undefined && data.integrationSubtype !== null) {
-    contents.IntegrationSubtype = data.integrationSubtype;
+    contents.IntegrationSubtype = __expectString(data.integrationSubtype);
   }
   if (data.integrationType !== undefined && data.integrationType !== null) {
-    contents.IntegrationType = data.integrationType;
+    contents.IntegrationType = __expectString(data.integrationType);
   }
   if (data.integrationUri !== undefined && data.integrationUri !== null) {
-    contents.IntegrationUri = data.integrationUri;
+    contents.IntegrationUri = __expectString(data.integrationUri);
   }
   if (data.passthroughBehavior !== undefined && data.passthroughBehavior !== null) {
-    contents.PassthroughBehavior = data.passthroughBehavior;
+    contents.PassthroughBehavior = __expectString(data.passthroughBehavior);
   }
   if (data.payloadFormatVersion !== undefined && data.payloadFormatVersion !== null) {
-    contents.PayloadFormatVersion = data.payloadFormatVersion;
+    contents.PayloadFormatVersion = __expectString(data.payloadFormatVersion);
   }
   if (data.requestParameters !== undefined && data.requestParameters !== null) {
     contents.RequestParameters = deserializeAws_restJson1IntegrationParameters(data.requestParameters, context);
@@ -3719,10 +3722,10 @@ export const deserializeAws_restJson1CreateIntegrationCommand = async (
     contents.ResponseParameters = deserializeAws_restJson1ResponseParameters(data.responseParameters, context);
   }
   if (data.templateSelectionExpression !== undefined && data.templateSelectionExpression !== null) {
-    contents.TemplateSelectionExpression = data.templateSelectionExpression;
+    contents.TemplateSelectionExpression = __expectString(data.templateSelectionExpression);
   }
   if (data.timeoutInMillis !== undefined && data.timeoutInMillis !== null) {
-    contents.TimeoutInMillis = data.timeoutInMillis;
+    contents.TimeoutInMillis = __expectNumber(data.timeoutInMillis);
   }
   if (data.tlsConfig !== undefined && data.tlsConfig !== null) {
     contents.TlsConfig = deserializeAws_restJson1TlsConfig(data.tlsConfig, context);
@@ -3809,13 +3812,13 @@ export const deserializeAws_restJson1CreateIntegrationResponseCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.contentHandlingStrategy !== undefined && data.contentHandlingStrategy !== null) {
-    contents.ContentHandlingStrategy = data.contentHandlingStrategy;
+    contents.ContentHandlingStrategy = __expectString(data.contentHandlingStrategy);
   }
   if (data.integrationResponseId !== undefined && data.integrationResponseId !== null) {
-    contents.IntegrationResponseId = data.integrationResponseId;
+    contents.IntegrationResponseId = __expectString(data.integrationResponseId);
   }
   if (data.integrationResponseKey !== undefined && data.integrationResponseKey !== null) {
-    contents.IntegrationResponseKey = data.integrationResponseKey;
+    contents.IntegrationResponseKey = __expectString(data.integrationResponseKey);
   }
   if (data.responseParameters !== undefined && data.responseParameters !== null) {
     contents.ResponseParameters = deserializeAws_restJson1IntegrationParameters(data.responseParameters, context);
@@ -3824,7 +3827,7 @@ export const deserializeAws_restJson1CreateIntegrationResponseCommand = async (
     contents.ResponseTemplates = deserializeAws_restJson1TemplateMap(data.responseTemplates, context);
   }
   if (data.templateSelectionExpression !== undefined && data.templateSelectionExpression !== null) {
-    contents.TemplateSelectionExpression = data.templateSelectionExpression;
+    contents.TemplateSelectionExpression = __expectString(data.templateSelectionExpression);
   }
   return Promise.resolve(contents);
 };
@@ -3907,19 +3910,19 @@ export const deserializeAws_restJson1CreateModelCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.contentType !== undefined && data.contentType !== null) {
-    contents.ContentType = data.contentType;
+    contents.ContentType = __expectString(data.contentType);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.Description = data.description;
+    contents.Description = __expectString(data.description);
   }
   if (data.modelId !== undefined && data.modelId !== null) {
-    contents.ModelId = data.modelId;
+    contents.ModelId = __expectString(data.modelId);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.Name = data.name;
+    contents.Name = __expectString(data.name);
   }
   if (data.schema !== undefined && data.schema !== null) {
-    contents.Schema = data.schema;
+    contents.Schema = __expectString(data.schema);
   }
   return Promise.resolve(contents);
 };
@@ -4010,25 +4013,25 @@ export const deserializeAws_restJson1CreateRouteCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.apiGatewayManaged !== undefined && data.apiGatewayManaged !== null) {
-    contents.ApiGatewayManaged = data.apiGatewayManaged;
+    contents.ApiGatewayManaged = __expectBoolean(data.apiGatewayManaged);
   }
   if (data.apiKeyRequired !== undefined && data.apiKeyRequired !== null) {
-    contents.ApiKeyRequired = data.apiKeyRequired;
+    contents.ApiKeyRequired = __expectBoolean(data.apiKeyRequired);
   }
   if (data.authorizationScopes !== undefined && data.authorizationScopes !== null) {
     contents.AuthorizationScopes = deserializeAws_restJson1AuthorizationScopes(data.authorizationScopes, context);
   }
   if (data.authorizationType !== undefined && data.authorizationType !== null) {
-    contents.AuthorizationType = data.authorizationType;
+    contents.AuthorizationType = __expectString(data.authorizationType);
   }
   if (data.authorizerId !== undefined && data.authorizerId !== null) {
-    contents.AuthorizerId = data.authorizerId;
+    contents.AuthorizerId = __expectString(data.authorizerId);
   }
   if (data.modelSelectionExpression !== undefined && data.modelSelectionExpression !== null) {
-    contents.ModelSelectionExpression = data.modelSelectionExpression;
+    contents.ModelSelectionExpression = __expectString(data.modelSelectionExpression);
   }
   if (data.operationName !== undefined && data.operationName !== null) {
-    contents.OperationName = data.operationName;
+    contents.OperationName = __expectString(data.operationName);
   }
   if (data.requestModels !== undefined && data.requestModels !== null) {
     contents.RequestModels = deserializeAws_restJson1RouteModels(data.requestModels, context);
@@ -4037,16 +4040,16 @@ export const deserializeAws_restJson1CreateRouteCommand = async (
     contents.RequestParameters = deserializeAws_restJson1RouteParameters(data.requestParameters, context);
   }
   if (data.routeId !== undefined && data.routeId !== null) {
-    contents.RouteId = data.routeId;
+    contents.RouteId = __expectString(data.routeId);
   }
   if (data.routeKey !== undefined && data.routeKey !== null) {
-    contents.RouteKey = data.routeKey;
+    contents.RouteKey = __expectString(data.routeKey);
   }
   if (data.routeResponseSelectionExpression !== undefined && data.routeResponseSelectionExpression !== null) {
-    contents.RouteResponseSelectionExpression = data.routeResponseSelectionExpression;
+    contents.RouteResponseSelectionExpression = __expectString(data.routeResponseSelectionExpression);
   }
   if (data.target !== undefined && data.target !== null) {
-    contents.Target = data.target;
+    contents.Target = __expectString(data.target);
   }
   return Promise.resolve(contents);
 };
@@ -4129,7 +4132,7 @@ export const deserializeAws_restJson1CreateRouteResponseCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.modelSelectionExpression !== undefined && data.modelSelectionExpression !== null) {
-    contents.ModelSelectionExpression = data.modelSelectionExpression;
+    contents.ModelSelectionExpression = __expectString(data.modelSelectionExpression);
   }
   if (data.responseModels !== undefined && data.responseModels !== null) {
     contents.ResponseModels = deserializeAws_restJson1RouteModels(data.responseModels, context);
@@ -4138,10 +4141,10 @@ export const deserializeAws_restJson1CreateRouteResponseCommand = async (
     contents.ResponseParameters = deserializeAws_restJson1RouteParameters(data.responseParameters, context);
   }
   if (data.routeResponseId !== undefined && data.routeResponseId !== null) {
-    contents.RouteResponseId = data.routeResponseId;
+    contents.RouteResponseId = __expectString(data.routeResponseId);
   }
   if (data.routeResponseKey !== undefined && data.routeResponseKey !== null) {
-    contents.RouteResponseKey = data.routeResponseKey;
+    contents.RouteResponseKey = __expectString(data.routeResponseKey);
   }
   return Promise.resolve(contents);
 };
@@ -4236,13 +4239,13 @@ export const deserializeAws_restJson1CreateStageCommand = async (
     contents.AccessLogSettings = deserializeAws_restJson1AccessLogSettings(data.accessLogSettings, context);
   }
   if (data.apiGatewayManaged !== undefined && data.apiGatewayManaged !== null) {
-    contents.ApiGatewayManaged = data.apiGatewayManaged;
+    contents.ApiGatewayManaged = __expectBoolean(data.apiGatewayManaged);
   }
   if (data.autoDeploy !== undefined && data.autoDeploy !== null) {
-    contents.AutoDeploy = data.autoDeploy;
+    contents.AutoDeploy = __expectBoolean(data.autoDeploy);
   }
   if (data.clientCertificateId !== undefined && data.clientCertificateId !== null) {
-    contents.ClientCertificateId = data.clientCertificateId;
+    contents.ClientCertificateId = __expectString(data.clientCertificateId);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
     contents.CreatedDate = new Date(data.createdDate);
@@ -4251,13 +4254,13 @@ export const deserializeAws_restJson1CreateStageCommand = async (
     contents.DefaultRouteSettings = deserializeAws_restJson1RouteSettings(data.defaultRouteSettings, context);
   }
   if (data.deploymentId !== undefined && data.deploymentId !== null) {
-    contents.DeploymentId = data.deploymentId;
+    contents.DeploymentId = __expectString(data.deploymentId);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.Description = data.description;
+    contents.Description = __expectString(data.description);
   }
   if (data.lastDeploymentStatusMessage !== undefined && data.lastDeploymentStatusMessage !== null) {
-    contents.LastDeploymentStatusMessage = data.lastDeploymentStatusMessage;
+    contents.LastDeploymentStatusMessage = __expectString(data.lastDeploymentStatusMessage);
   }
   if (data.lastUpdatedDate !== undefined && data.lastUpdatedDate !== null) {
     contents.LastUpdatedDate = new Date(data.lastUpdatedDate);
@@ -4266,7 +4269,7 @@ export const deserializeAws_restJson1CreateStageCommand = async (
     contents.RouteSettings = deserializeAws_restJson1RouteSettingsMap(data.routeSettings, context);
   }
   if (data.stageName !== undefined && data.stageName !== null) {
-    contents.StageName = data.stageName;
+    contents.StageName = __expectString(data.stageName);
   }
   if (data.stageVariables !== undefined && data.stageVariables !== null) {
     contents.StageVariables = deserializeAws_restJson1StageVariablesMap(data.stageVariables, context);
@@ -4362,7 +4365,7 @@ export const deserializeAws_restJson1CreateVpcLinkCommand = async (
     contents.CreatedDate = new Date(data.createdDate);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.Name = data.name;
+    contents.Name = __expectString(data.name);
   }
   if (data.securityGroupIds !== undefined && data.securityGroupIds !== null) {
     contents.SecurityGroupIds = deserializeAws_restJson1SecurityGroupIdList(data.securityGroupIds, context);
@@ -4374,16 +4377,16 @@ export const deserializeAws_restJson1CreateVpcLinkCommand = async (
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
   }
   if (data.vpcLinkId !== undefined && data.vpcLinkId !== null) {
-    contents.VpcLinkId = data.vpcLinkId;
+    contents.VpcLinkId = __expectString(data.vpcLinkId);
   }
   if (data.vpcLinkStatus !== undefined && data.vpcLinkStatus !== null) {
-    contents.VpcLinkStatus = data.vpcLinkStatus;
+    contents.VpcLinkStatus = __expectString(data.vpcLinkStatus);
   }
   if (data.vpcLinkStatusMessage !== undefined && data.vpcLinkStatusMessage !== null) {
-    contents.VpcLinkStatusMessage = data.vpcLinkStatusMessage;
+    contents.VpcLinkStatusMessage = __expectString(data.vpcLinkStatusMessage);
   }
   if (data.vpcLinkVersion !== undefined && data.vpcLinkVersion !== null) {
-    contents.VpcLinkVersion = data.vpcLinkVersion;
+    contents.VpcLinkVersion = __expectString(data.vpcLinkVersion);
   }
   return Promise.resolve(contents);
 };
@@ -5482,16 +5485,16 @@ export const deserializeAws_restJson1GetApiCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.apiEndpoint !== undefined && data.apiEndpoint !== null) {
-    contents.ApiEndpoint = data.apiEndpoint;
+    contents.ApiEndpoint = __expectString(data.apiEndpoint);
   }
   if (data.apiGatewayManaged !== undefined && data.apiGatewayManaged !== null) {
-    contents.ApiGatewayManaged = data.apiGatewayManaged;
+    contents.ApiGatewayManaged = __expectBoolean(data.apiGatewayManaged);
   }
   if (data.apiId !== undefined && data.apiId !== null) {
-    contents.ApiId = data.apiId;
+    contents.ApiId = __expectString(data.apiId);
   }
   if (data.apiKeySelectionExpression !== undefined && data.apiKeySelectionExpression !== null) {
-    contents.ApiKeySelectionExpression = data.apiKeySelectionExpression;
+    contents.ApiKeySelectionExpression = __expectString(data.apiKeySelectionExpression);
   }
   if (data.corsConfiguration !== undefined && data.corsConfiguration !== null) {
     contents.CorsConfiguration = deserializeAws_restJson1Cors(data.corsConfiguration, context);
@@ -5500,31 +5503,31 @@ export const deserializeAws_restJson1GetApiCommand = async (
     contents.CreatedDate = new Date(data.createdDate);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.Description = data.description;
+    contents.Description = __expectString(data.description);
   }
   if (data.disableExecuteApiEndpoint !== undefined && data.disableExecuteApiEndpoint !== null) {
-    contents.DisableExecuteApiEndpoint = data.disableExecuteApiEndpoint;
+    contents.DisableExecuteApiEndpoint = __expectBoolean(data.disableExecuteApiEndpoint);
   }
   if (data.disableSchemaValidation !== undefined && data.disableSchemaValidation !== null) {
-    contents.DisableSchemaValidation = data.disableSchemaValidation;
+    contents.DisableSchemaValidation = __expectBoolean(data.disableSchemaValidation);
   }
   if (data.importInfo !== undefined && data.importInfo !== null) {
     contents.ImportInfo = deserializeAws_restJson1__listOf__string(data.importInfo, context);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.Name = data.name;
+    contents.Name = __expectString(data.name);
   }
   if (data.protocolType !== undefined && data.protocolType !== null) {
-    contents.ProtocolType = data.protocolType;
+    contents.ProtocolType = __expectString(data.protocolType);
   }
   if (data.routeSelectionExpression !== undefined && data.routeSelectionExpression !== null) {
-    contents.RouteSelectionExpression = data.routeSelectionExpression;
+    contents.RouteSelectionExpression = __expectString(data.routeSelectionExpression);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
   }
   if (data.version !== undefined && data.version !== null) {
-    contents.Version = data.version;
+    contents.Version = __expectString(data.version);
   }
   if (data.warnings !== undefined && data.warnings !== null) {
     contents.Warnings = deserializeAws_restJson1__listOf__string(data.warnings, context);
@@ -5593,16 +5596,16 @@ export const deserializeAws_restJson1GetApiMappingCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.apiId !== undefined && data.apiId !== null) {
-    contents.ApiId = data.apiId;
+    contents.ApiId = __expectString(data.apiId);
   }
   if (data.apiMappingId !== undefined && data.apiMappingId !== null) {
-    contents.ApiMappingId = data.apiMappingId;
+    contents.ApiMappingId = __expectString(data.apiMappingId);
   }
   if (data.apiMappingKey !== undefined && data.apiMappingKey !== null) {
-    contents.ApiMappingKey = data.apiMappingKey;
+    contents.ApiMappingKey = __expectString(data.apiMappingKey);
   }
   if (data.stage !== undefined && data.stage !== null) {
-    contents.Stage = data.stage;
+    contents.Stage = __expectString(data.stage);
   }
   return Promise.resolve(contents);
 };
@@ -5677,7 +5680,7 @@ export const deserializeAws_restJson1GetApiMappingsCommand = async (
     contents.Items = deserializeAws_restJson1__listOfApiMapping(data.items, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -5752,7 +5755,7 @@ export const deserializeAws_restJson1GetApisCommand = async (
     contents.Items = deserializeAws_restJson1__listOfApi(data.items, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -5833,37 +5836,37 @@ export const deserializeAws_restJson1GetAuthorizerCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.authorizerCredentialsArn !== undefined && data.authorizerCredentialsArn !== null) {
-    contents.AuthorizerCredentialsArn = data.authorizerCredentialsArn;
+    contents.AuthorizerCredentialsArn = __expectString(data.authorizerCredentialsArn);
   }
   if (data.authorizerId !== undefined && data.authorizerId !== null) {
-    contents.AuthorizerId = data.authorizerId;
+    contents.AuthorizerId = __expectString(data.authorizerId);
   }
   if (data.authorizerPayloadFormatVersion !== undefined && data.authorizerPayloadFormatVersion !== null) {
-    contents.AuthorizerPayloadFormatVersion = data.authorizerPayloadFormatVersion;
+    contents.AuthorizerPayloadFormatVersion = __expectString(data.authorizerPayloadFormatVersion);
   }
   if (data.authorizerResultTtlInSeconds !== undefined && data.authorizerResultTtlInSeconds !== null) {
-    contents.AuthorizerResultTtlInSeconds = data.authorizerResultTtlInSeconds;
+    contents.AuthorizerResultTtlInSeconds = __expectNumber(data.authorizerResultTtlInSeconds);
   }
   if (data.authorizerType !== undefined && data.authorizerType !== null) {
-    contents.AuthorizerType = data.authorizerType;
+    contents.AuthorizerType = __expectString(data.authorizerType);
   }
   if (data.authorizerUri !== undefined && data.authorizerUri !== null) {
-    contents.AuthorizerUri = data.authorizerUri;
+    contents.AuthorizerUri = __expectString(data.authorizerUri);
   }
   if (data.enableSimpleResponses !== undefined && data.enableSimpleResponses !== null) {
-    contents.EnableSimpleResponses = data.enableSimpleResponses;
+    contents.EnableSimpleResponses = __expectBoolean(data.enableSimpleResponses);
   }
   if (data.identitySource !== undefined && data.identitySource !== null) {
     contents.IdentitySource = deserializeAws_restJson1IdentitySourceList(data.identitySource, context);
   }
   if (data.identityValidationExpression !== undefined && data.identityValidationExpression !== null) {
-    contents.IdentityValidationExpression = data.identityValidationExpression;
+    contents.IdentityValidationExpression = __expectString(data.identityValidationExpression);
   }
   if (data.jwtConfiguration !== undefined && data.jwtConfiguration !== null) {
     contents.JwtConfiguration = deserializeAws_restJson1JWTConfiguration(data.jwtConfiguration, context);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.Name = data.name;
+    contents.Name = __expectString(data.name);
   }
   return Promise.resolve(contents);
 };
@@ -5930,7 +5933,7 @@ export const deserializeAws_restJson1GetAuthorizersCommand = async (
     contents.Items = deserializeAws_restJson1__listOfAuthorizer(data.items, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -6006,22 +6009,22 @@ export const deserializeAws_restJson1GetDeploymentCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.autoDeployed !== undefined && data.autoDeployed !== null) {
-    contents.AutoDeployed = data.autoDeployed;
+    contents.AutoDeployed = __expectBoolean(data.autoDeployed);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
     contents.CreatedDate = new Date(data.createdDate);
   }
   if (data.deploymentId !== undefined && data.deploymentId !== null) {
-    contents.DeploymentId = data.deploymentId;
+    contents.DeploymentId = __expectString(data.deploymentId);
   }
   if (data.deploymentStatus !== undefined && data.deploymentStatus !== null) {
-    contents.DeploymentStatus = data.deploymentStatus;
+    contents.DeploymentStatus = __expectString(data.deploymentStatus);
   }
   if (data.deploymentStatusMessage !== undefined && data.deploymentStatusMessage !== null) {
-    contents.DeploymentStatusMessage = data.deploymentStatusMessage;
+    contents.DeploymentStatusMessage = __expectString(data.deploymentStatusMessage);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.Description = data.description;
+    contents.Description = __expectString(data.description);
   }
   return Promise.resolve(contents);
 };
@@ -6088,7 +6091,7 @@ export const deserializeAws_restJson1GetDeploymentsCommand = async (
     contents.Items = deserializeAws_restJson1__listOfDeployment(data.items, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -6163,10 +6166,10 @@ export const deserializeAws_restJson1GetDomainNameCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.apiMappingSelectionExpression !== undefined && data.apiMappingSelectionExpression !== null) {
-    contents.ApiMappingSelectionExpression = data.apiMappingSelectionExpression;
+    contents.ApiMappingSelectionExpression = __expectString(data.apiMappingSelectionExpression);
   }
   if (data.domainName !== undefined && data.domainName !== null) {
-    contents.DomainName = data.domainName;
+    contents.DomainName = __expectString(data.domainName);
   }
   if (data.domainNameConfigurations !== undefined && data.domainNameConfigurations !== null) {
     contents.DomainNameConfigurations = deserializeAws_restJson1DomainNameConfigurations(
@@ -6248,7 +6251,7 @@ export const deserializeAws_restJson1GetDomainNamesCommand = async (
     contents.Items = deserializeAws_restJson1__listOfDomainName(data.items, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -6338,49 +6341,49 @@ export const deserializeAws_restJson1GetIntegrationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.apiGatewayManaged !== undefined && data.apiGatewayManaged !== null) {
-    contents.ApiGatewayManaged = data.apiGatewayManaged;
+    contents.ApiGatewayManaged = __expectBoolean(data.apiGatewayManaged);
   }
   if (data.connectionId !== undefined && data.connectionId !== null) {
-    contents.ConnectionId = data.connectionId;
+    contents.ConnectionId = __expectString(data.connectionId);
   }
   if (data.connectionType !== undefined && data.connectionType !== null) {
-    contents.ConnectionType = data.connectionType;
+    contents.ConnectionType = __expectString(data.connectionType);
   }
   if (data.contentHandlingStrategy !== undefined && data.contentHandlingStrategy !== null) {
-    contents.ContentHandlingStrategy = data.contentHandlingStrategy;
+    contents.ContentHandlingStrategy = __expectString(data.contentHandlingStrategy);
   }
   if (data.credentialsArn !== undefined && data.credentialsArn !== null) {
-    contents.CredentialsArn = data.credentialsArn;
+    contents.CredentialsArn = __expectString(data.credentialsArn);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.Description = data.description;
+    contents.Description = __expectString(data.description);
   }
   if (data.integrationId !== undefined && data.integrationId !== null) {
-    contents.IntegrationId = data.integrationId;
+    contents.IntegrationId = __expectString(data.integrationId);
   }
   if (data.integrationMethod !== undefined && data.integrationMethod !== null) {
-    contents.IntegrationMethod = data.integrationMethod;
+    contents.IntegrationMethod = __expectString(data.integrationMethod);
   }
   if (
     data.integrationResponseSelectionExpression !== undefined &&
     data.integrationResponseSelectionExpression !== null
   ) {
-    contents.IntegrationResponseSelectionExpression = data.integrationResponseSelectionExpression;
+    contents.IntegrationResponseSelectionExpression = __expectString(data.integrationResponseSelectionExpression);
   }
   if (data.integrationSubtype !== undefined && data.integrationSubtype !== null) {
-    contents.IntegrationSubtype = data.integrationSubtype;
+    contents.IntegrationSubtype = __expectString(data.integrationSubtype);
   }
   if (data.integrationType !== undefined && data.integrationType !== null) {
-    contents.IntegrationType = data.integrationType;
+    contents.IntegrationType = __expectString(data.integrationType);
   }
   if (data.integrationUri !== undefined && data.integrationUri !== null) {
-    contents.IntegrationUri = data.integrationUri;
+    contents.IntegrationUri = __expectString(data.integrationUri);
   }
   if (data.passthroughBehavior !== undefined && data.passthroughBehavior !== null) {
-    contents.PassthroughBehavior = data.passthroughBehavior;
+    contents.PassthroughBehavior = __expectString(data.passthroughBehavior);
   }
   if (data.payloadFormatVersion !== undefined && data.payloadFormatVersion !== null) {
-    contents.PayloadFormatVersion = data.payloadFormatVersion;
+    contents.PayloadFormatVersion = __expectString(data.payloadFormatVersion);
   }
   if (data.requestParameters !== undefined && data.requestParameters !== null) {
     contents.RequestParameters = deserializeAws_restJson1IntegrationParameters(data.requestParameters, context);
@@ -6392,10 +6395,10 @@ export const deserializeAws_restJson1GetIntegrationCommand = async (
     contents.ResponseParameters = deserializeAws_restJson1ResponseParameters(data.responseParameters, context);
   }
   if (data.templateSelectionExpression !== undefined && data.templateSelectionExpression !== null) {
-    contents.TemplateSelectionExpression = data.templateSelectionExpression;
+    contents.TemplateSelectionExpression = __expectString(data.templateSelectionExpression);
   }
   if (data.timeoutInMillis !== undefined && data.timeoutInMillis !== null) {
-    contents.TimeoutInMillis = data.timeoutInMillis;
+    contents.TimeoutInMillis = __expectNumber(data.timeoutInMillis);
   }
   if (data.tlsConfig !== undefined && data.tlsConfig !== null) {
     contents.TlsConfig = deserializeAws_restJson1TlsConfig(data.tlsConfig, context);
@@ -6466,13 +6469,13 @@ export const deserializeAws_restJson1GetIntegrationResponseCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.contentHandlingStrategy !== undefined && data.contentHandlingStrategy !== null) {
-    contents.ContentHandlingStrategy = data.contentHandlingStrategy;
+    contents.ContentHandlingStrategy = __expectString(data.contentHandlingStrategy);
   }
   if (data.integrationResponseId !== undefined && data.integrationResponseId !== null) {
-    contents.IntegrationResponseId = data.integrationResponseId;
+    contents.IntegrationResponseId = __expectString(data.integrationResponseId);
   }
   if (data.integrationResponseKey !== undefined && data.integrationResponseKey !== null) {
-    contents.IntegrationResponseKey = data.integrationResponseKey;
+    contents.IntegrationResponseKey = __expectString(data.integrationResponseKey);
   }
   if (data.responseParameters !== undefined && data.responseParameters !== null) {
     contents.ResponseParameters = deserializeAws_restJson1IntegrationParameters(data.responseParameters, context);
@@ -6481,7 +6484,7 @@ export const deserializeAws_restJson1GetIntegrationResponseCommand = async (
     contents.ResponseTemplates = deserializeAws_restJson1TemplateMap(data.responseTemplates, context);
   }
   if (data.templateSelectionExpression !== undefined && data.templateSelectionExpression !== null) {
-    contents.TemplateSelectionExpression = data.templateSelectionExpression;
+    contents.TemplateSelectionExpression = __expectString(data.templateSelectionExpression);
   }
   return Promise.resolve(contents);
 };
@@ -6548,7 +6551,7 @@ export const deserializeAws_restJson1GetIntegrationResponsesCommand = async (
     contents.Items = deserializeAws_restJson1__listOfIntegrationResponse(data.items, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -6623,7 +6626,7 @@ export const deserializeAws_restJson1GetIntegrationsCommand = async (
     contents.Items = deserializeAws_restJson1__listOfIntegration(data.items, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -6698,19 +6701,19 @@ export const deserializeAws_restJson1GetModelCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.contentType !== undefined && data.contentType !== null) {
-    contents.ContentType = data.contentType;
+    contents.ContentType = __expectString(data.contentType);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.Description = data.description;
+    contents.Description = __expectString(data.description);
   }
   if (data.modelId !== undefined && data.modelId !== null) {
-    contents.ModelId = data.modelId;
+    contents.ModelId = __expectString(data.modelId);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.Name = data.name;
+    contents.Name = __expectString(data.name);
   }
   if (data.schema !== undefined && data.schema !== null) {
-    contents.Schema = data.schema;
+    contents.Schema = __expectString(data.schema);
   }
   return Promise.resolve(contents);
 };
@@ -6777,7 +6780,7 @@ export const deserializeAws_restJson1GetModelsCommand = async (
     contents.Items = deserializeAws_restJson1__listOfModel(data.items, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -6848,7 +6851,7 @@ export const deserializeAws_restJson1GetModelTemplateCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.value !== undefined && data.value !== null) {
-    contents.Value = data.value;
+    contents.Value = __expectString(data.value);
   }
   return Promise.resolve(contents);
 };
@@ -6923,25 +6926,25 @@ export const deserializeAws_restJson1GetRouteCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.apiGatewayManaged !== undefined && data.apiGatewayManaged !== null) {
-    contents.ApiGatewayManaged = data.apiGatewayManaged;
+    contents.ApiGatewayManaged = __expectBoolean(data.apiGatewayManaged);
   }
   if (data.apiKeyRequired !== undefined && data.apiKeyRequired !== null) {
-    contents.ApiKeyRequired = data.apiKeyRequired;
+    contents.ApiKeyRequired = __expectBoolean(data.apiKeyRequired);
   }
   if (data.authorizationScopes !== undefined && data.authorizationScopes !== null) {
     contents.AuthorizationScopes = deserializeAws_restJson1AuthorizationScopes(data.authorizationScopes, context);
   }
   if (data.authorizationType !== undefined && data.authorizationType !== null) {
-    contents.AuthorizationType = data.authorizationType;
+    contents.AuthorizationType = __expectString(data.authorizationType);
   }
   if (data.authorizerId !== undefined && data.authorizerId !== null) {
-    contents.AuthorizerId = data.authorizerId;
+    contents.AuthorizerId = __expectString(data.authorizerId);
   }
   if (data.modelSelectionExpression !== undefined && data.modelSelectionExpression !== null) {
-    contents.ModelSelectionExpression = data.modelSelectionExpression;
+    contents.ModelSelectionExpression = __expectString(data.modelSelectionExpression);
   }
   if (data.operationName !== undefined && data.operationName !== null) {
-    contents.OperationName = data.operationName;
+    contents.OperationName = __expectString(data.operationName);
   }
   if (data.requestModels !== undefined && data.requestModels !== null) {
     contents.RequestModels = deserializeAws_restJson1RouteModels(data.requestModels, context);
@@ -6950,16 +6953,16 @@ export const deserializeAws_restJson1GetRouteCommand = async (
     contents.RequestParameters = deserializeAws_restJson1RouteParameters(data.requestParameters, context);
   }
   if (data.routeId !== undefined && data.routeId !== null) {
-    contents.RouteId = data.routeId;
+    contents.RouteId = __expectString(data.routeId);
   }
   if (data.routeKey !== undefined && data.routeKey !== null) {
-    contents.RouteKey = data.routeKey;
+    contents.RouteKey = __expectString(data.routeKey);
   }
   if (data.routeResponseSelectionExpression !== undefined && data.routeResponseSelectionExpression !== null) {
-    contents.RouteResponseSelectionExpression = data.routeResponseSelectionExpression;
+    contents.RouteResponseSelectionExpression = __expectString(data.routeResponseSelectionExpression);
   }
   if (data.target !== undefined && data.target !== null) {
-    contents.Target = data.target;
+    contents.Target = __expectString(data.target);
   }
   return Promise.resolve(contents);
 };
@@ -7026,7 +7029,7 @@ export const deserializeAws_restJson1GetRouteResponseCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.modelSelectionExpression !== undefined && data.modelSelectionExpression !== null) {
-    contents.ModelSelectionExpression = data.modelSelectionExpression;
+    contents.ModelSelectionExpression = __expectString(data.modelSelectionExpression);
   }
   if (data.responseModels !== undefined && data.responseModels !== null) {
     contents.ResponseModels = deserializeAws_restJson1RouteModels(data.responseModels, context);
@@ -7035,10 +7038,10 @@ export const deserializeAws_restJson1GetRouteResponseCommand = async (
     contents.ResponseParameters = deserializeAws_restJson1RouteParameters(data.responseParameters, context);
   }
   if (data.routeResponseId !== undefined && data.routeResponseId !== null) {
-    contents.RouteResponseId = data.routeResponseId;
+    contents.RouteResponseId = __expectString(data.routeResponseId);
   }
   if (data.routeResponseKey !== undefined && data.routeResponseKey !== null) {
-    contents.RouteResponseKey = data.routeResponseKey;
+    contents.RouteResponseKey = __expectString(data.routeResponseKey);
   }
   return Promise.resolve(contents);
 };
@@ -7105,7 +7108,7 @@ export const deserializeAws_restJson1GetRouteResponsesCommand = async (
     contents.Items = deserializeAws_restJson1__listOfRouteResponse(data.items, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -7180,7 +7183,7 @@ export const deserializeAws_restJson1GetRoutesCommand = async (
     contents.Items = deserializeAws_restJson1__listOfRoute(data.items, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -7267,13 +7270,13 @@ export const deserializeAws_restJson1GetStageCommand = async (
     contents.AccessLogSettings = deserializeAws_restJson1AccessLogSettings(data.accessLogSettings, context);
   }
   if (data.apiGatewayManaged !== undefined && data.apiGatewayManaged !== null) {
-    contents.ApiGatewayManaged = data.apiGatewayManaged;
+    contents.ApiGatewayManaged = __expectBoolean(data.apiGatewayManaged);
   }
   if (data.autoDeploy !== undefined && data.autoDeploy !== null) {
-    contents.AutoDeploy = data.autoDeploy;
+    contents.AutoDeploy = __expectBoolean(data.autoDeploy);
   }
   if (data.clientCertificateId !== undefined && data.clientCertificateId !== null) {
-    contents.ClientCertificateId = data.clientCertificateId;
+    contents.ClientCertificateId = __expectString(data.clientCertificateId);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
     contents.CreatedDate = new Date(data.createdDate);
@@ -7282,13 +7285,13 @@ export const deserializeAws_restJson1GetStageCommand = async (
     contents.DefaultRouteSettings = deserializeAws_restJson1RouteSettings(data.defaultRouteSettings, context);
   }
   if (data.deploymentId !== undefined && data.deploymentId !== null) {
-    contents.DeploymentId = data.deploymentId;
+    contents.DeploymentId = __expectString(data.deploymentId);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.Description = data.description;
+    contents.Description = __expectString(data.description);
   }
   if (data.lastDeploymentStatusMessage !== undefined && data.lastDeploymentStatusMessage !== null) {
-    contents.LastDeploymentStatusMessage = data.lastDeploymentStatusMessage;
+    contents.LastDeploymentStatusMessage = __expectString(data.lastDeploymentStatusMessage);
   }
   if (data.lastUpdatedDate !== undefined && data.lastUpdatedDate !== null) {
     contents.LastUpdatedDate = new Date(data.lastUpdatedDate);
@@ -7297,7 +7300,7 @@ export const deserializeAws_restJson1GetStageCommand = async (
     contents.RouteSettings = deserializeAws_restJson1RouteSettingsMap(data.routeSettings, context);
   }
   if (data.stageName !== undefined && data.stageName !== null) {
-    contents.StageName = data.stageName;
+    contents.StageName = __expectString(data.stageName);
   }
   if (data.stageVariables !== undefined && data.stageVariables !== null) {
     contents.StageVariables = deserializeAws_restJson1StageVariablesMap(data.stageVariables, context);
@@ -7370,7 +7373,7 @@ export const deserializeAws_restJson1GetStagesCommand = async (
     contents.Items = deserializeAws_restJson1__listOfStage(data.items, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -7531,7 +7534,7 @@ export const deserializeAws_restJson1GetVpcLinkCommand = async (
     contents.CreatedDate = new Date(data.createdDate);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.Name = data.name;
+    contents.Name = __expectString(data.name);
   }
   if (data.securityGroupIds !== undefined && data.securityGroupIds !== null) {
     contents.SecurityGroupIds = deserializeAws_restJson1SecurityGroupIdList(data.securityGroupIds, context);
@@ -7543,16 +7546,16 @@ export const deserializeAws_restJson1GetVpcLinkCommand = async (
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
   }
   if (data.vpcLinkId !== undefined && data.vpcLinkId !== null) {
-    contents.VpcLinkId = data.vpcLinkId;
+    contents.VpcLinkId = __expectString(data.vpcLinkId);
   }
   if (data.vpcLinkStatus !== undefined && data.vpcLinkStatus !== null) {
-    contents.VpcLinkStatus = data.vpcLinkStatus;
+    contents.VpcLinkStatus = __expectString(data.vpcLinkStatus);
   }
   if (data.vpcLinkStatusMessage !== undefined && data.vpcLinkStatusMessage !== null) {
-    contents.VpcLinkStatusMessage = data.vpcLinkStatusMessage;
+    contents.VpcLinkStatusMessage = __expectString(data.vpcLinkStatusMessage);
   }
   if (data.vpcLinkVersion !== undefined && data.vpcLinkVersion !== null) {
-    contents.VpcLinkVersion = data.vpcLinkVersion;
+    contents.VpcLinkVersion = __expectString(data.vpcLinkVersion);
   }
   return Promise.resolve(contents);
 };
@@ -7619,7 +7622,7 @@ export const deserializeAws_restJson1GetVpcLinksCommand = async (
     contents.Items = deserializeAws_restJson1__listOfVpcLink(data.items, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -7697,16 +7700,16 @@ export const deserializeAws_restJson1ImportApiCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.apiEndpoint !== undefined && data.apiEndpoint !== null) {
-    contents.ApiEndpoint = data.apiEndpoint;
+    contents.ApiEndpoint = __expectString(data.apiEndpoint);
   }
   if (data.apiGatewayManaged !== undefined && data.apiGatewayManaged !== null) {
-    contents.ApiGatewayManaged = data.apiGatewayManaged;
+    contents.ApiGatewayManaged = __expectBoolean(data.apiGatewayManaged);
   }
   if (data.apiId !== undefined && data.apiId !== null) {
-    contents.ApiId = data.apiId;
+    contents.ApiId = __expectString(data.apiId);
   }
   if (data.apiKeySelectionExpression !== undefined && data.apiKeySelectionExpression !== null) {
-    contents.ApiKeySelectionExpression = data.apiKeySelectionExpression;
+    contents.ApiKeySelectionExpression = __expectString(data.apiKeySelectionExpression);
   }
   if (data.corsConfiguration !== undefined && data.corsConfiguration !== null) {
     contents.CorsConfiguration = deserializeAws_restJson1Cors(data.corsConfiguration, context);
@@ -7715,31 +7718,31 @@ export const deserializeAws_restJson1ImportApiCommand = async (
     contents.CreatedDate = new Date(data.createdDate);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.Description = data.description;
+    contents.Description = __expectString(data.description);
   }
   if (data.disableExecuteApiEndpoint !== undefined && data.disableExecuteApiEndpoint !== null) {
-    contents.DisableExecuteApiEndpoint = data.disableExecuteApiEndpoint;
+    contents.DisableExecuteApiEndpoint = __expectBoolean(data.disableExecuteApiEndpoint);
   }
   if (data.disableSchemaValidation !== undefined && data.disableSchemaValidation !== null) {
-    contents.DisableSchemaValidation = data.disableSchemaValidation;
+    contents.DisableSchemaValidation = __expectBoolean(data.disableSchemaValidation);
   }
   if (data.importInfo !== undefined && data.importInfo !== null) {
     contents.ImportInfo = deserializeAws_restJson1__listOf__string(data.importInfo, context);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.Name = data.name;
+    contents.Name = __expectString(data.name);
   }
   if (data.protocolType !== undefined && data.protocolType !== null) {
-    contents.ProtocolType = data.protocolType;
+    contents.ProtocolType = __expectString(data.protocolType);
   }
   if (data.routeSelectionExpression !== undefined && data.routeSelectionExpression !== null) {
-    contents.RouteSelectionExpression = data.routeSelectionExpression;
+    contents.RouteSelectionExpression = __expectString(data.routeSelectionExpression);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
   }
   if (data.version !== undefined && data.version !== null) {
-    contents.Version = data.version;
+    contents.Version = __expectString(data.version);
   }
   if (data.warnings !== undefined && data.warnings !== null) {
     contents.Warnings = deserializeAws_restJson1__listOf__string(data.warnings, context);
@@ -7836,16 +7839,16 @@ export const deserializeAws_restJson1ReimportApiCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.apiEndpoint !== undefined && data.apiEndpoint !== null) {
-    contents.ApiEndpoint = data.apiEndpoint;
+    contents.ApiEndpoint = __expectString(data.apiEndpoint);
   }
   if (data.apiGatewayManaged !== undefined && data.apiGatewayManaged !== null) {
-    contents.ApiGatewayManaged = data.apiGatewayManaged;
+    contents.ApiGatewayManaged = __expectBoolean(data.apiGatewayManaged);
   }
   if (data.apiId !== undefined && data.apiId !== null) {
-    contents.ApiId = data.apiId;
+    contents.ApiId = __expectString(data.apiId);
   }
   if (data.apiKeySelectionExpression !== undefined && data.apiKeySelectionExpression !== null) {
-    contents.ApiKeySelectionExpression = data.apiKeySelectionExpression;
+    contents.ApiKeySelectionExpression = __expectString(data.apiKeySelectionExpression);
   }
   if (data.corsConfiguration !== undefined && data.corsConfiguration !== null) {
     contents.CorsConfiguration = deserializeAws_restJson1Cors(data.corsConfiguration, context);
@@ -7854,31 +7857,31 @@ export const deserializeAws_restJson1ReimportApiCommand = async (
     contents.CreatedDate = new Date(data.createdDate);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.Description = data.description;
+    contents.Description = __expectString(data.description);
   }
   if (data.disableExecuteApiEndpoint !== undefined && data.disableExecuteApiEndpoint !== null) {
-    contents.DisableExecuteApiEndpoint = data.disableExecuteApiEndpoint;
+    contents.DisableExecuteApiEndpoint = __expectBoolean(data.disableExecuteApiEndpoint);
   }
   if (data.disableSchemaValidation !== undefined && data.disableSchemaValidation !== null) {
-    contents.DisableSchemaValidation = data.disableSchemaValidation;
+    contents.DisableSchemaValidation = __expectBoolean(data.disableSchemaValidation);
   }
   if (data.importInfo !== undefined && data.importInfo !== null) {
     contents.ImportInfo = deserializeAws_restJson1__listOf__string(data.importInfo, context);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.Name = data.name;
+    contents.Name = __expectString(data.name);
   }
   if (data.protocolType !== undefined && data.protocolType !== null) {
-    contents.ProtocolType = data.protocolType;
+    contents.ProtocolType = __expectString(data.protocolType);
   }
   if (data.routeSelectionExpression !== undefined && data.routeSelectionExpression !== null) {
-    contents.RouteSelectionExpression = data.routeSelectionExpression;
+    contents.RouteSelectionExpression = __expectString(data.routeSelectionExpression);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
   }
   if (data.version !== undefined && data.version !== null) {
-    contents.Version = data.version;
+    contents.Version = __expectString(data.version);
   }
   if (data.warnings !== undefined && data.warnings !== null) {
     contents.Warnings = deserializeAws_restJson1__listOf__string(data.warnings, context);
@@ -8184,16 +8187,16 @@ export const deserializeAws_restJson1UpdateApiCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.apiEndpoint !== undefined && data.apiEndpoint !== null) {
-    contents.ApiEndpoint = data.apiEndpoint;
+    contents.ApiEndpoint = __expectString(data.apiEndpoint);
   }
   if (data.apiGatewayManaged !== undefined && data.apiGatewayManaged !== null) {
-    contents.ApiGatewayManaged = data.apiGatewayManaged;
+    contents.ApiGatewayManaged = __expectBoolean(data.apiGatewayManaged);
   }
   if (data.apiId !== undefined && data.apiId !== null) {
-    contents.ApiId = data.apiId;
+    contents.ApiId = __expectString(data.apiId);
   }
   if (data.apiKeySelectionExpression !== undefined && data.apiKeySelectionExpression !== null) {
-    contents.ApiKeySelectionExpression = data.apiKeySelectionExpression;
+    contents.ApiKeySelectionExpression = __expectString(data.apiKeySelectionExpression);
   }
   if (data.corsConfiguration !== undefined && data.corsConfiguration !== null) {
     contents.CorsConfiguration = deserializeAws_restJson1Cors(data.corsConfiguration, context);
@@ -8202,31 +8205,31 @@ export const deserializeAws_restJson1UpdateApiCommand = async (
     contents.CreatedDate = new Date(data.createdDate);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.Description = data.description;
+    contents.Description = __expectString(data.description);
   }
   if (data.disableExecuteApiEndpoint !== undefined && data.disableExecuteApiEndpoint !== null) {
-    contents.DisableExecuteApiEndpoint = data.disableExecuteApiEndpoint;
+    contents.DisableExecuteApiEndpoint = __expectBoolean(data.disableExecuteApiEndpoint);
   }
   if (data.disableSchemaValidation !== undefined && data.disableSchemaValidation !== null) {
-    contents.DisableSchemaValidation = data.disableSchemaValidation;
+    contents.DisableSchemaValidation = __expectBoolean(data.disableSchemaValidation);
   }
   if (data.importInfo !== undefined && data.importInfo !== null) {
     contents.ImportInfo = deserializeAws_restJson1__listOf__string(data.importInfo, context);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.Name = data.name;
+    contents.Name = __expectString(data.name);
   }
   if (data.protocolType !== undefined && data.protocolType !== null) {
-    contents.ProtocolType = data.protocolType;
+    contents.ProtocolType = __expectString(data.protocolType);
   }
   if (data.routeSelectionExpression !== undefined && data.routeSelectionExpression !== null) {
-    contents.RouteSelectionExpression = data.routeSelectionExpression;
+    contents.RouteSelectionExpression = __expectString(data.routeSelectionExpression);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
   }
   if (data.version !== undefined && data.version !== null) {
-    contents.Version = data.version;
+    contents.Version = __expectString(data.version);
   }
   if (data.warnings !== undefined && data.warnings !== null) {
     contents.Warnings = deserializeAws_restJson1__listOf__string(data.warnings, context);
@@ -8311,16 +8314,16 @@ export const deserializeAws_restJson1UpdateApiMappingCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.apiId !== undefined && data.apiId !== null) {
-    contents.ApiId = data.apiId;
+    contents.ApiId = __expectString(data.apiId);
   }
   if (data.apiMappingId !== undefined && data.apiMappingId !== null) {
-    contents.ApiMappingId = data.apiMappingId;
+    contents.ApiMappingId = __expectString(data.apiMappingId);
   }
   if (data.apiMappingKey !== undefined && data.apiMappingKey !== null) {
-    contents.ApiMappingKey = data.apiMappingKey;
+    contents.ApiMappingKey = __expectString(data.apiMappingKey);
   }
   if (data.stage !== undefined && data.stage !== null) {
-    contents.Stage = data.stage;
+    contents.Stage = __expectString(data.stage);
   }
   return Promise.resolve(contents);
 };
@@ -8409,37 +8412,37 @@ export const deserializeAws_restJson1UpdateAuthorizerCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.authorizerCredentialsArn !== undefined && data.authorizerCredentialsArn !== null) {
-    contents.AuthorizerCredentialsArn = data.authorizerCredentialsArn;
+    contents.AuthorizerCredentialsArn = __expectString(data.authorizerCredentialsArn);
   }
   if (data.authorizerId !== undefined && data.authorizerId !== null) {
-    contents.AuthorizerId = data.authorizerId;
+    contents.AuthorizerId = __expectString(data.authorizerId);
   }
   if (data.authorizerPayloadFormatVersion !== undefined && data.authorizerPayloadFormatVersion !== null) {
-    contents.AuthorizerPayloadFormatVersion = data.authorizerPayloadFormatVersion;
+    contents.AuthorizerPayloadFormatVersion = __expectString(data.authorizerPayloadFormatVersion);
   }
   if (data.authorizerResultTtlInSeconds !== undefined && data.authorizerResultTtlInSeconds !== null) {
-    contents.AuthorizerResultTtlInSeconds = data.authorizerResultTtlInSeconds;
+    contents.AuthorizerResultTtlInSeconds = __expectNumber(data.authorizerResultTtlInSeconds);
   }
   if (data.authorizerType !== undefined && data.authorizerType !== null) {
-    contents.AuthorizerType = data.authorizerType;
+    contents.AuthorizerType = __expectString(data.authorizerType);
   }
   if (data.authorizerUri !== undefined && data.authorizerUri !== null) {
-    contents.AuthorizerUri = data.authorizerUri;
+    contents.AuthorizerUri = __expectString(data.authorizerUri);
   }
   if (data.enableSimpleResponses !== undefined && data.enableSimpleResponses !== null) {
-    contents.EnableSimpleResponses = data.enableSimpleResponses;
+    contents.EnableSimpleResponses = __expectBoolean(data.enableSimpleResponses);
   }
   if (data.identitySource !== undefined && data.identitySource !== null) {
     contents.IdentitySource = deserializeAws_restJson1IdentitySourceList(data.identitySource, context);
   }
   if (data.identityValidationExpression !== undefined && data.identityValidationExpression !== null) {
-    contents.IdentityValidationExpression = data.identityValidationExpression;
+    contents.IdentityValidationExpression = __expectString(data.identityValidationExpression);
   }
   if (data.jwtConfiguration !== undefined && data.jwtConfiguration !== null) {
     contents.JwtConfiguration = deserializeAws_restJson1JWTConfiguration(data.jwtConfiguration, context);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.Name = data.name;
+    contents.Name = __expectString(data.name);
   }
   return Promise.resolve(contents);
 };
@@ -8523,22 +8526,22 @@ export const deserializeAws_restJson1UpdateDeploymentCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.autoDeployed !== undefined && data.autoDeployed !== null) {
-    contents.AutoDeployed = data.autoDeployed;
+    contents.AutoDeployed = __expectBoolean(data.autoDeployed);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
     contents.CreatedDate = new Date(data.createdDate);
   }
   if (data.deploymentId !== undefined && data.deploymentId !== null) {
-    contents.DeploymentId = data.deploymentId;
+    contents.DeploymentId = __expectString(data.deploymentId);
   }
   if (data.deploymentStatus !== undefined && data.deploymentStatus !== null) {
-    contents.DeploymentStatus = data.deploymentStatus;
+    contents.DeploymentStatus = __expectString(data.deploymentStatus);
   }
   if (data.deploymentStatusMessage !== undefined && data.deploymentStatusMessage !== null) {
-    contents.DeploymentStatusMessage = data.deploymentStatusMessage;
+    contents.DeploymentStatusMessage = __expectString(data.deploymentStatusMessage);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.Description = data.description;
+    contents.Description = __expectString(data.description);
   }
   return Promise.resolve(contents);
 };
@@ -8621,10 +8624,10 @@ export const deserializeAws_restJson1UpdateDomainNameCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.apiMappingSelectionExpression !== undefined && data.apiMappingSelectionExpression !== null) {
-    contents.ApiMappingSelectionExpression = data.apiMappingSelectionExpression;
+    contents.ApiMappingSelectionExpression = __expectString(data.apiMappingSelectionExpression);
   }
   if (data.domainName !== undefined && data.domainName !== null) {
-    contents.DomainName = data.domainName;
+    contents.DomainName = __expectString(data.domainName);
   }
   if (data.domainNameConfigurations !== undefined && data.domainNameConfigurations !== null) {
     contents.DomainNameConfigurations = deserializeAws_restJson1DomainNameConfigurations(
@@ -8737,49 +8740,49 @@ export const deserializeAws_restJson1UpdateIntegrationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.apiGatewayManaged !== undefined && data.apiGatewayManaged !== null) {
-    contents.ApiGatewayManaged = data.apiGatewayManaged;
+    contents.ApiGatewayManaged = __expectBoolean(data.apiGatewayManaged);
   }
   if (data.connectionId !== undefined && data.connectionId !== null) {
-    contents.ConnectionId = data.connectionId;
+    contents.ConnectionId = __expectString(data.connectionId);
   }
   if (data.connectionType !== undefined && data.connectionType !== null) {
-    contents.ConnectionType = data.connectionType;
+    contents.ConnectionType = __expectString(data.connectionType);
   }
   if (data.contentHandlingStrategy !== undefined && data.contentHandlingStrategy !== null) {
-    contents.ContentHandlingStrategy = data.contentHandlingStrategy;
+    contents.ContentHandlingStrategy = __expectString(data.contentHandlingStrategy);
   }
   if (data.credentialsArn !== undefined && data.credentialsArn !== null) {
-    contents.CredentialsArn = data.credentialsArn;
+    contents.CredentialsArn = __expectString(data.credentialsArn);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.Description = data.description;
+    contents.Description = __expectString(data.description);
   }
   if (data.integrationId !== undefined && data.integrationId !== null) {
-    contents.IntegrationId = data.integrationId;
+    contents.IntegrationId = __expectString(data.integrationId);
   }
   if (data.integrationMethod !== undefined && data.integrationMethod !== null) {
-    contents.IntegrationMethod = data.integrationMethod;
+    contents.IntegrationMethod = __expectString(data.integrationMethod);
   }
   if (
     data.integrationResponseSelectionExpression !== undefined &&
     data.integrationResponseSelectionExpression !== null
   ) {
-    contents.IntegrationResponseSelectionExpression = data.integrationResponseSelectionExpression;
+    contents.IntegrationResponseSelectionExpression = __expectString(data.integrationResponseSelectionExpression);
   }
   if (data.integrationSubtype !== undefined && data.integrationSubtype !== null) {
-    contents.IntegrationSubtype = data.integrationSubtype;
+    contents.IntegrationSubtype = __expectString(data.integrationSubtype);
   }
   if (data.integrationType !== undefined && data.integrationType !== null) {
-    contents.IntegrationType = data.integrationType;
+    contents.IntegrationType = __expectString(data.integrationType);
   }
   if (data.integrationUri !== undefined && data.integrationUri !== null) {
-    contents.IntegrationUri = data.integrationUri;
+    contents.IntegrationUri = __expectString(data.integrationUri);
   }
   if (data.passthroughBehavior !== undefined && data.passthroughBehavior !== null) {
-    contents.PassthroughBehavior = data.passthroughBehavior;
+    contents.PassthroughBehavior = __expectString(data.passthroughBehavior);
   }
   if (data.payloadFormatVersion !== undefined && data.payloadFormatVersion !== null) {
-    contents.PayloadFormatVersion = data.payloadFormatVersion;
+    contents.PayloadFormatVersion = __expectString(data.payloadFormatVersion);
   }
   if (data.requestParameters !== undefined && data.requestParameters !== null) {
     contents.RequestParameters = deserializeAws_restJson1IntegrationParameters(data.requestParameters, context);
@@ -8791,10 +8794,10 @@ export const deserializeAws_restJson1UpdateIntegrationCommand = async (
     contents.ResponseParameters = deserializeAws_restJson1ResponseParameters(data.responseParameters, context);
   }
   if (data.templateSelectionExpression !== undefined && data.templateSelectionExpression !== null) {
-    contents.TemplateSelectionExpression = data.templateSelectionExpression;
+    contents.TemplateSelectionExpression = __expectString(data.templateSelectionExpression);
   }
   if (data.timeoutInMillis !== undefined && data.timeoutInMillis !== null) {
-    contents.TimeoutInMillis = data.timeoutInMillis;
+    contents.TimeoutInMillis = __expectNumber(data.timeoutInMillis);
   }
   if (data.tlsConfig !== undefined && data.tlsConfig !== null) {
     contents.TlsConfig = deserializeAws_restJson1TlsConfig(data.tlsConfig, context);
@@ -8881,13 +8884,13 @@ export const deserializeAws_restJson1UpdateIntegrationResponseCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.contentHandlingStrategy !== undefined && data.contentHandlingStrategy !== null) {
-    contents.ContentHandlingStrategy = data.contentHandlingStrategy;
+    contents.ContentHandlingStrategy = __expectString(data.contentHandlingStrategy);
   }
   if (data.integrationResponseId !== undefined && data.integrationResponseId !== null) {
-    contents.IntegrationResponseId = data.integrationResponseId;
+    contents.IntegrationResponseId = __expectString(data.integrationResponseId);
   }
   if (data.integrationResponseKey !== undefined && data.integrationResponseKey !== null) {
-    contents.IntegrationResponseKey = data.integrationResponseKey;
+    contents.IntegrationResponseKey = __expectString(data.integrationResponseKey);
   }
   if (data.responseParameters !== undefined && data.responseParameters !== null) {
     contents.ResponseParameters = deserializeAws_restJson1IntegrationParameters(data.responseParameters, context);
@@ -8896,7 +8899,7 @@ export const deserializeAws_restJson1UpdateIntegrationResponseCommand = async (
     contents.ResponseTemplates = deserializeAws_restJson1TemplateMap(data.responseTemplates, context);
   }
   if (data.templateSelectionExpression !== undefined && data.templateSelectionExpression !== null) {
-    contents.TemplateSelectionExpression = data.templateSelectionExpression;
+    contents.TemplateSelectionExpression = __expectString(data.templateSelectionExpression);
   }
   return Promise.resolve(contents);
 };
@@ -8979,19 +8982,19 @@ export const deserializeAws_restJson1UpdateModelCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.contentType !== undefined && data.contentType !== null) {
-    contents.ContentType = data.contentType;
+    contents.ContentType = __expectString(data.contentType);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.Description = data.description;
+    contents.Description = __expectString(data.description);
   }
   if (data.modelId !== undefined && data.modelId !== null) {
-    contents.ModelId = data.modelId;
+    contents.ModelId = __expectString(data.modelId);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.Name = data.name;
+    contents.Name = __expectString(data.name);
   }
   if (data.schema !== undefined && data.schema !== null) {
-    contents.Schema = data.schema;
+    contents.Schema = __expectString(data.schema);
   }
   return Promise.resolve(contents);
 };
@@ -9082,25 +9085,25 @@ export const deserializeAws_restJson1UpdateRouteCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.apiGatewayManaged !== undefined && data.apiGatewayManaged !== null) {
-    contents.ApiGatewayManaged = data.apiGatewayManaged;
+    contents.ApiGatewayManaged = __expectBoolean(data.apiGatewayManaged);
   }
   if (data.apiKeyRequired !== undefined && data.apiKeyRequired !== null) {
-    contents.ApiKeyRequired = data.apiKeyRequired;
+    contents.ApiKeyRequired = __expectBoolean(data.apiKeyRequired);
   }
   if (data.authorizationScopes !== undefined && data.authorizationScopes !== null) {
     contents.AuthorizationScopes = deserializeAws_restJson1AuthorizationScopes(data.authorizationScopes, context);
   }
   if (data.authorizationType !== undefined && data.authorizationType !== null) {
-    contents.AuthorizationType = data.authorizationType;
+    contents.AuthorizationType = __expectString(data.authorizationType);
   }
   if (data.authorizerId !== undefined && data.authorizerId !== null) {
-    contents.AuthorizerId = data.authorizerId;
+    contents.AuthorizerId = __expectString(data.authorizerId);
   }
   if (data.modelSelectionExpression !== undefined && data.modelSelectionExpression !== null) {
-    contents.ModelSelectionExpression = data.modelSelectionExpression;
+    contents.ModelSelectionExpression = __expectString(data.modelSelectionExpression);
   }
   if (data.operationName !== undefined && data.operationName !== null) {
-    contents.OperationName = data.operationName;
+    contents.OperationName = __expectString(data.operationName);
   }
   if (data.requestModels !== undefined && data.requestModels !== null) {
     contents.RequestModels = deserializeAws_restJson1RouteModels(data.requestModels, context);
@@ -9109,16 +9112,16 @@ export const deserializeAws_restJson1UpdateRouteCommand = async (
     contents.RequestParameters = deserializeAws_restJson1RouteParameters(data.requestParameters, context);
   }
   if (data.routeId !== undefined && data.routeId !== null) {
-    contents.RouteId = data.routeId;
+    contents.RouteId = __expectString(data.routeId);
   }
   if (data.routeKey !== undefined && data.routeKey !== null) {
-    contents.RouteKey = data.routeKey;
+    contents.RouteKey = __expectString(data.routeKey);
   }
   if (data.routeResponseSelectionExpression !== undefined && data.routeResponseSelectionExpression !== null) {
-    contents.RouteResponseSelectionExpression = data.routeResponseSelectionExpression;
+    contents.RouteResponseSelectionExpression = __expectString(data.routeResponseSelectionExpression);
   }
   if (data.target !== undefined && data.target !== null) {
-    contents.Target = data.target;
+    contents.Target = __expectString(data.target);
   }
   return Promise.resolve(contents);
 };
@@ -9201,7 +9204,7 @@ export const deserializeAws_restJson1UpdateRouteResponseCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.modelSelectionExpression !== undefined && data.modelSelectionExpression !== null) {
-    contents.ModelSelectionExpression = data.modelSelectionExpression;
+    contents.ModelSelectionExpression = __expectString(data.modelSelectionExpression);
   }
   if (data.responseModels !== undefined && data.responseModels !== null) {
     contents.ResponseModels = deserializeAws_restJson1RouteModels(data.responseModels, context);
@@ -9210,10 +9213,10 @@ export const deserializeAws_restJson1UpdateRouteResponseCommand = async (
     contents.ResponseParameters = deserializeAws_restJson1RouteParameters(data.responseParameters, context);
   }
   if (data.routeResponseId !== undefined && data.routeResponseId !== null) {
-    contents.RouteResponseId = data.routeResponseId;
+    contents.RouteResponseId = __expectString(data.routeResponseId);
   }
   if (data.routeResponseKey !== undefined && data.routeResponseKey !== null) {
-    contents.RouteResponseKey = data.routeResponseKey;
+    contents.RouteResponseKey = __expectString(data.routeResponseKey);
   }
   return Promise.resolve(contents);
 };
@@ -9308,13 +9311,13 @@ export const deserializeAws_restJson1UpdateStageCommand = async (
     contents.AccessLogSettings = deserializeAws_restJson1AccessLogSettings(data.accessLogSettings, context);
   }
   if (data.apiGatewayManaged !== undefined && data.apiGatewayManaged !== null) {
-    contents.ApiGatewayManaged = data.apiGatewayManaged;
+    contents.ApiGatewayManaged = __expectBoolean(data.apiGatewayManaged);
   }
   if (data.autoDeploy !== undefined && data.autoDeploy !== null) {
-    contents.AutoDeploy = data.autoDeploy;
+    contents.AutoDeploy = __expectBoolean(data.autoDeploy);
   }
   if (data.clientCertificateId !== undefined && data.clientCertificateId !== null) {
-    contents.ClientCertificateId = data.clientCertificateId;
+    contents.ClientCertificateId = __expectString(data.clientCertificateId);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
     contents.CreatedDate = new Date(data.createdDate);
@@ -9323,13 +9326,13 @@ export const deserializeAws_restJson1UpdateStageCommand = async (
     contents.DefaultRouteSettings = deserializeAws_restJson1RouteSettings(data.defaultRouteSettings, context);
   }
   if (data.deploymentId !== undefined && data.deploymentId !== null) {
-    contents.DeploymentId = data.deploymentId;
+    contents.DeploymentId = __expectString(data.deploymentId);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.Description = data.description;
+    contents.Description = __expectString(data.description);
   }
   if (data.lastDeploymentStatusMessage !== undefined && data.lastDeploymentStatusMessage !== null) {
-    contents.LastDeploymentStatusMessage = data.lastDeploymentStatusMessage;
+    contents.LastDeploymentStatusMessage = __expectString(data.lastDeploymentStatusMessage);
   }
   if (data.lastUpdatedDate !== undefined && data.lastUpdatedDate !== null) {
     contents.LastUpdatedDate = new Date(data.lastUpdatedDate);
@@ -9338,7 +9341,7 @@ export const deserializeAws_restJson1UpdateStageCommand = async (
     contents.RouteSettings = deserializeAws_restJson1RouteSettingsMap(data.routeSettings, context);
   }
   if (data.stageName !== undefined && data.stageName !== null) {
-    contents.StageName = data.stageName;
+    contents.StageName = __expectString(data.stageName);
   }
   if (data.stageVariables !== undefined && data.stageVariables !== null) {
     contents.StageVariables = deserializeAws_restJson1StageVariablesMap(data.stageVariables, context);
@@ -9434,7 +9437,7 @@ export const deserializeAws_restJson1UpdateVpcLinkCommand = async (
     contents.CreatedDate = new Date(data.createdDate);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.Name = data.name;
+    contents.Name = __expectString(data.name);
   }
   if (data.securityGroupIds !== undefined && data.securityGroupIds !== null) {
     contents.SecurityGroupIds = deserializeAws_restJson1SecurityGroupIdList(data.securityGroupIds, context);
@@ -9446,16 +9449,16 @@ export const deserializeAws_restJson1UpdateVpcLinkCommand = async (
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
   }
   if (data.vpcLinkId !== undefined && data.vpcLinkId !== null) {
-    contents.VpcLinkId = data.vpcLinkId;
+    contents.VpcLinkId = __expectString(data.vpcLinkId);
   }
   if (data.vpcLinkStatus !== undefined && data.vpcLinkStatus !== null) {
-    contents.VpcLinkStatus = data.vpcLinkStatus;
+    contents.VpcLinkStatus = __expectString(data.vpcLinkStatus);
   }
   if (data.vpcLinkStatusMessage !== undefined && data.vpcLinkStatusMessage !== null) {
-    contents.VpcLinkStatusMessage = data.vpcLinkStatusMessage;
+    contents.VpcLinkStatusMessage = __expectString(data.vpcLinkStatusMessage);
   }
   if (data.vpcLinkVersion !== undefined && data.vpcLinkVersion !== null) {
-    contents.VpcLinkVersion = data.vpcLinkVersion;
+    contents.VpcLinkVersion = __expectString(data.vpcLinkVersion);
   }
   return Promise.resolve(contents);
 };
@@ -9525,7 +9528,7 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -9542,7 +9545,7 @@ const deserializeAws_restJson1BadRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -9559,7 +9562,7 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -9577,10 +9580,10 @@ const deserializeAws_restJson1NotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   if (data.resourceType !== undefined && data.resourceType !== null) {
-    contents.ResourceType = data.resourceType;
+    contents.ResourceType = __expectString(data.resourceType);
   }
   return contents;
 };
@@ -9598,10 +9601,10 @@ const deserializeAws_restJson1TooManyRequestsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.limitType !== undefined && data.limitType !== null) {
-    contents.LimitType = data.limitType;
+    contents.LimitType = __expectString(data.limitType);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -9930,7 +9933,7 @@ const deserializeAws_restJson1__listOf__string = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -10071,54 +10074,38 @@ const deserializeAws_restJson1__listOfVpcLink = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1AccessLogSettings = (output: any, context: __SerdeContext): AccessLogSettings => {
   return {
-    DestinationArn:
-      output.destinationArn !== undefined && output.destinationArn !== null ? output.destinationArn : undefined,
-    Format: output.format !== undefined && output.format !== null ? output.format : undefined,
+    DestinationArn: __expectString(output.destinationArn),
+    Format: __expectString(output.format),
   } as any;
 };
 
 const deserializeAws_restJson1Api = (output: any, context: __SerdeContext): Api => {
   return {
-    ApiEndpoint: output.apiEndpoint !== undefined && output.apiEndpoint !== null ? output.apiEndpoint : undefined,
-    ApiGatewayManaged:
-      output.apiGatewayManaged !== undefined && output.apiGatewayManaged !== null
-        ? output.apiGatewayManaged
-        : undefined,
-    ApiId: output.apiId !== undefined && output.apiId !== null ? output.apiId : undefined,
-    ApiKeySelectionExpression:
-      output.apiKeySelectionExpression !== undefined && output.apiKeySelectionExpression !== null
-        ? output.apiKeySelectionExpression
-        : undefined,
+    ApiEndpoint: __expectString(output.apiEndpoint),
+    ApiGatewayManaged: __expectBoolean(output.apiGatewayManaged),
+    ApiId: __expectString(output.apiId),
+    ApiKeySelectionExpression: __expectString(output.apiKeySelectionExpression),
     CorsConfiguration:
       output.corsConfiguration !== undefined && output.corsConfiguration !== null
         ? deserializeAws_restJson1Cors(output.corsConfiguration, context)
         : undefined,
     CreatedDate:
       output.createdDate !== undefined && output.createdDate !== null ? new Date(output.createdDate) : undefined,
-    Description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    DisableExecuteApiEndpoint:
-      output.disableExecuteApiEndpoint !== undefined && output.disableExecuteApiEndpoint !== null
-        ? output.disableExecuteApiEndpoint
-        : undefined,
-    DisableSchemaValidation:
-      output.disableSchemaValidation !== undefined && output.disableSchemaValidation !== null
-        ? output.disableSchemaValidation
-        : undefined,
+    Description: __expectString(output.description),
+    DisableExecuteApiEndpoint: __expectBoolean(output.disableExecuteApiEndpoint),
+    DisableSchemaValidation: __expectBoolean(output.disableSchemaValidation),
     ImportInfo:
       output.importInfo !== undefined && output.importInfo !== null
         ? deserializeAws_restJson1__listOf__string(output.importInfo, context)
         : undefined,
-    Name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    ProtocolType: output.protocolType !== undefined && output.protocolType !== null ? output.protocolType : undefined,
-    RouteSelectionExpression:
-      output.routeSelectionExpression !== undefined && output.routeSelectionExpression !== null
-        ? output.routeSelectionExpression
-        : undefined,
+    Name: __expectString(output.name),
+    ProtocolType: __expectString(output.protocolType),
+    RouteSelectionExpression: __expectString(output.routeSelectionExpression),
     Tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1Tags(output.tags, context)
         : undefined,
-    Version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    Version: __expectString(output.version),
     Warnings:
       output.warnings !== undefined && output.warnings !== null
         ? deserializeAws_restJson1__listOf__string(output.warnings, context)
@@ -10128,11 +10115,10 @@ const deserializeAws_restJson1Api = (output: any, context: __SerdeContext): Api 
 
 const deserializeAws_restJson1ApiMapping = (output: any, context: __SerdeContext): ApiMapping => {
   return {
-    ApiId: output.apiId !== undefined && output.apiId !== null ? output.apiId : undefined,
-    ApiMappingId: output.apiMappingId !== undefined && output.apiMappingId !== null ? output.apiMappingId : undefined,
-    ApiMappingKey:
-      output.apiMappingKey !== undefined && output.apiMappingKey !== null ? output.apiMappingKey : undefined,
-    Stage: output.stage !== undefined && output.stage !== null ? output.stage : undefined,
+    ApiId: __expectString(output.apiId),
+    ApiMappingId: __expectString(output.apiMappingId),
+    ApiMappingKey: __expectString(output.apiMappingKey),
+    Stage: __expectString(output.stage),
   } as any;
 };
 
@@ -10143,53 +10129,35 @@ const deserializeAws_restJson1AuthorizationScopes = (output: any, context: __Ser
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1Authorizer = (output: any, context: __SerdeContext): Authorizer => {
   return {
-    AuthorizerCredentialsArn:
-      output.authorizerCredentialsArn !== undefined && output.authorizerCredentialsArn !== null
-        ? output.authorizerCredentialsArn
-        : undefined,
-    AuthorizerId: output.authorizerId !== undefined && output.authorizerId !== null ? output.authorizerId : undefined,
-    AuthorizerPayloadFormatVersion:
-      output.authorizerPayloadFormatVersion !== undefined && output.authorizerPayloadFormatVersion !== null
-        ? output.authorizerPayloadFormatVersion
-        : undefined,
-    AuthorizerResultTtlInSeconds:
-      output.authorizerResultTtlInSeconds !== undefined && output.authorizerResultTtlInSeconds !== null
-        ? output.authorizerResultTtlInSeconds
-        : undefined,
-    AuthorizerType:
-      output.authorizerType !== undefined && output.authorizerType !== null ? output.authorizerType : undefined,
-    AuthorizerUri:
-      output.authorizerUri !== undefined && output.authorizerUri !== null ? output.authorizerUri : undefined,
-    EnableSimpleResponses:
-      output.enableSimpleResponses !== undefined && output.enableSimpleResponses !== null
-        ? output.enableSimpleResponses
-        : undefined,
+    AuthorizerCredentialsArn: __expectString(output.authorizerCredentialsArn),
+    AuthorizerId: __expectString(output.authorizerId),
+    AuthorizerPayloadFormatVersion: __expectString(output.authorizerPayloadFormatVersion),
+    AuthorizerResultTtlInSeconds: __expectNumber(output.authorizerResultTtlInSeconds),
+    AuthorizerType: __expectString(output.authorizerType),
+    AuthorizerUri: __expectString(output.authorizerUri),
+    EnableSimpleResponses: __expectBoolean(output.enableSimpleResponses),
     IdentitySource:
       output.identitySource !== undefined && output.identitySource !== null
         ? deserializeAws_restJson1IdentitySourceList(output.identitySource, context)
         : undefined,
-    IdentityValidationExpression:
-      output.identityValidationExpression !== undefined && output.identityValidationExpression !== null
-        ? output.identityValidationExpression
-        : undefined,
+    IdentityValidationExpression: __expectString(output.identityValidationExpression),
     JwtConfiguration:
       output.jwtConfiguration !== undefined && output.jwtConfiguration !== null
         ? deserializeAws_restJson1JWTConfiguration(output.jwtConfiguration, context)
         : undefined,
-    Name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    Name: __expectString(output.name),
   } as any;
 };
 
 const deserializeAws_restJson1Cors = (output: any, context: __SerdeContext): Cors => {
   return {
-    AllowCredentials:
-      output.allowCredentials !== undefined && output.allowCredentials !== null ? output.allowCredentials : undefined,
+    AllowCredentials: __expectBoolean(output.allowCredentials),
     AllowHeaders:
       output.allowHeaders !== undefined && output.allowHeaders !== null
         ? deserializeAws_restJson1CorsHeaderList(output.allowHeaders, context)
@@ -10206,7 +10174,7 @@ const deserializeAws_restJson1Cors = (output: any, context: __SerdeContext): Cor
       output.exposeHeaders !== undefined && output.exposeHeaders !== null
         ? deserializeAws_restJson1CorsHeaderList(output.exposeHeaders, context)
         : undefined,
-    MaxAge: output.maxAge !== undefined && output.maxAge !== null ? output.maxAge : undefined,
+    MaxAge: __expectNumber(output.maxAge),
   } as any;
 };
 
@@ -10217,7 +10185,7 @@ const deserializeAws_restJson1CorsHeaderList = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -10228,7 +10196,7 @@ const deserializeAws_restJson1CorsMethodList = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -10239,33 +10207,26 @@ const deserializeAws_restJson1CorsOriginList = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1Deployment = (output: any, context: __SerdeContext): Deployment => {
   return {
-    AutoDeployed: output.autoDeployed !== undefined && output.autoDeployed !== null ? output.autoDeployed : undefined,
+    AutoDeployed: __expectBoolean(output.autoDeployed),
     CreatedDate:
       output.createdDate !== undefined && output.createdDate !== null ? new Date(output.createdDate) : undefined,
-    DeploymentId: output.deploymentId !== undefined && output.deploymentId !== null ? output.deploymentId : undefined,
-    DeploymentStatus:
-      output.deploymentStatus !== undefined && output.deploymentStatus !== null ? output.deploymentStatus : undefined,
-    DeploymentStatusMessage:
-      output.deploymentStatusMessage !== undefined && output.deploymentStatusMessage !== null
-        ? output.deploymentStatusMessage
-        : undefined,
-    Description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    DeploymentId: __expectString(output.deploymentId),
+    DeploymentStatus: __expectString(output.deploymentStatus),
+    DeploymentStatusMessage: __expectString(output.deploymentStatusMessage),
+    Description: __expectString(output.description),
   } as any;
 };
 
 const deserializeAws_restJson1DomainName = (output: any, context: __SerdeContext): DomainName => {
   return {
-    ApiMappingSelectionExpression:
-      output.apiMappingSelectionExpression !== undefined && output.apiMappingSelectionExpression !== null
-        ? output.apiMappingSelectionExpression
-        : undefined,
-    DomainName: output.domainName !== undefined && output.domainName !== null ? output.domainName : undefined,
+    ApiMappingSelectionExpression: __expectString(output.apiMappingSelectionExpression),
+    DomainName: __expectString(output.domainName),
     DomainNameConfigurations:
       output.domainNameConfigurations !== undefined && output.domainNameConfigurations !== null
         ? deserializeAws_restJson1DomainNameConfigurations(output.domainNameConfigurations, context)
@@ -10286,28 +10247,18 @@ const deserializeAws_restJson1DomainNameConfiguration = (
   context: __SerdeContext
 ): DomainNameConfiguration => {
   return {
-    ApiGatewayDomainName:
-      output.apiGatewayDomainName !== undefined && output.apiGatewayDomainName !== null
-        ? output.apiGatewayDomainName
-        : undefined,
-    CertificateArn:
-      output.certificateArn !== undefined && output.certificateArn !== null ? output.certificateArn : undefined,
-    CertificateName:
-      output.certificateName !== undefined && output.certificateName !== null ? output.certificateName : undefined,
+    ApiGatewayDomainName: __expectString(output.apiGatewayDomainName),
+    CertificateArn: __expectString(output.certificateArn),
+    CertificateName: __expectString(output.certificateName),
     CertificateUploadDate:
       output.certificateUploadDate !== undefined && output.certificateUploadDate !== null
         ? new Date(output.certificateUploadDate)
         : undefined,
-    DomainNameStatus:
-      output.domainNameStatus !== undefined && output.domainNameStatus !== null ? output.domainNameStatus : undefined,
-    DomainNameStatusMessage:
-      output.domainNameStatusMessage !== undefined && output.domainNameStatusMessage !== null
-        ? output.domainNameStatusMessage
-        : undefined,
-    EndpointType: output.endpointType !== undefined && output.endpointType !== null ? output.endpointType : undefined,
-    HostedZoneId: output.hostedZoneId !== undefined && output.hostedZoneId !== null ? output.hostedZoneId : undefined,
-    SecurityPolicy:
-      output.securityPolicy !== undefined && output.securityPolicy !== null ? output.securityPolicy : undefined,
+    DomainNameStatus: __expectString(output.domainNameStatus),
+    DomainNameStatusMessage: __expectString(output.domainNameStatusMessage),
+    EndpointType: __expectString(output.endpointType),
+    HostedZoneId: __expectString(output.hostedZoneId),
+    SecurityPolicy: __expectString(output.securityPolicy),
   } as any;
 };
 
@@ -10332,53 +10283,26 @@ const deserializeAws_restJson1IdentitySourceList = (output: any, context: __Serd
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1Integration = (output: any, context: __SerdeContext): Integration => {
   return {
-    ApiGatewayManaged:
-      output.apiGatewayManaged !== undefined && output.apiGatewayManaged !== null
-        ? output.apiGatewayManaged
-        : undefined,
-    ConnectionId: output.connectionId !== undefined && output.connectionId !== null ? output.connectionId : undefined,
-    ConnectionType:
-      output.connectionType !== undefined && output.connectionType !== null ? output.connectionType : undefined,
-    ContentHandlingStrategy:
-      output.contentHandlingStrategy !== undefined && output.contentHandlingStrategy !== null
-        ? output.contentHandlingStrategy
-        : undefined,
-    CredentialsArn:
-      output.credentialsArn !== undefined && output.credentialsArn !== null ? output.credentialsArn : undefined,
-    Description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    IntegrationId:
-      output.integrationId !== undefined && output.integrationId !== null ? output.integrationId : undefined,
-    IntegrationMethod:
-      output.integrationMethod !== undefined && output.integrationMethod !== null
-        ? output.integrationMethod
-        : undefined,
-    IntegrationResponseSelectionExpression:
-      output.integrationResponseSelectionExpression !== undefined &&
-      output.integrationResponseSelectionExpression !== null
-        ? output.integrationResponseSelectionExpression
-        : undefined,
-    IntegrationSubtype:
-      output.integrationSubtype !== undefined && output.integrationSubtype !== null
-        ? output.integrationSubtype
-        : undefined,
-    IntegrationType:
-      output.integrationType !== undefined && output.integrationType !== null ? output.integrationType : undefined,
-    IntegrationUri:
-      output.integrationUri !== undefined && output.integrationUri !== null ? output.integrationUri : undefined,
-    PassthroughBehavior:
-      output.passthroughBehavior !== undefined && output.passthroughBehavior !== null
-        ? output.passthroughBehavior
-        : undefined,
-    PayloadFormatVersion:
-      output.payloadFormatVersion !== undefined && output.payloadFormatVersion !== null
-        ? output.payloadFormatVersion
-        : undefined,
+    ApiGatewayManaged: __expectBoolean(output.apiGatewayManaged),
+    ConnectionId: __expectString(output.connectionId),
+    ConnectionType: __expectString(output.connectionType),
+    ContentHandlingStrategy: __expectString(output.contentHandlingStrategy),
+    CredentialsArn: __expectString(output.credentialsArn),
+    Description: __expectString(output.description),
+    IntegrationId: __expectString(output.integrationId),
+    IntegrationMethod: __expectString(output.integrationMethod),
+    IntegrationResponseSelectionExpression: __expectString(output.integrationResponseSelectionExpression),
+    IntegrationSubtype: __expectString(output.integrationSubtype),
+    IntegrationType: __expectString(output.integrationType),
+    IntegrationUri: __expectString(output.integrationUri),
+    PassthroughBehavior: __expectString(output.passthroughBehavior),
+    PayloadFormatVersion: __expectString(output.payloadFormatVersion),
     RequestParameters:
       output.requestParameters !== undefined && output.requestParameters !== null
         ? deserializeAws_restJson1IntegrationParameters(output.requestParameters, context)
@@ -10391,12 +10315,8 @@ const deserializeAws_restJson1Integration = (output: any, context: __SerdeContex
       output.responseParameters !== undefined && output.responseParameters !== null
         ? deserializeAws_restJson1ResponseParameters(output.responseParameters, context)
         : undefined,
-    TemplateSelectionExpression:
-      output.templateSelectionExpression !== undefined && output.templateSelectionExpression !== null
-        ? output.templateSelectionExpression
-        : undefined,
-    TimeoutInMillis:
-      output.timeoutInMillis !== undefined && output.timeoutInMillis !== null ? output.timeoutInMillis : undefined,
+    TemplateSelectionExpression: __expectString(output.templateSelectionExpression),
+    TimeoutInMillis: __expectNumber(output.timeoutInMillis),
     TlsConfig:
       output.tlsConfig !== undefined && output.tlsConfig !== null
         ? deserializeAws_restJson1TlsConfig(output.tlsConfig, context)
@@ -10414,25 +10334,16 @@ const deserializeAws_restJson1IntegrationParameters = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1IntegrationResponse = (output: any, context: __SerdeContext): IntegrationResponse => {
   return {
-    ContentHandlingStrategy:
-      output.contentHandlingStrategy !== undefined && output.contentHandlingStrategy !== null
-        ? output.contentHandlingStrategy
-        : undefined,
-    IntegrationResponseId:
-      output.integrationResponseId !== undefined && output.integrationResponseId !== null
-        ? output.integrationResponseId
-        : undefined,
-    IntegrationResponseKey:
-      output.integrationResponseKey !== undefined && output.integrationResponseKey !== null
-        ? output.integrationResponseKey
-        : undefined,
+    ContentHandlingStrategy: __expectString(output.contentHandlingStrategy),
+    IntegrationResponseId: __expectString(output.integrationResponseId),
+    IntegrationResponseKey: __expectString(output.integrationResponseKey),
     ResponseParameters:
       output.responseParameters !== undefined && output.responseParameters !== null
         ? deserializeAws_restJson1IntegrationParameters(output.responseParameters, context)
@@ -10441,10 +10352,7 @@ const deserializeAws_restJson1IntegrationResponse = (output: any, context: __Ser
       output.responseTemplates !== undefined && output.responseTemplates !== null
         ? deserializeAws_restJson1TemplateMap(output.responseTemplates, context)
         : undefined,
-    TemplateSelectionExpression:
-      output.templateSelectionExpression !== undefined && output.templateSelectionExpression !== null
-        ? output.templateSelectionExpression
-        : undefined,
+    TemplateSelectionExpression: __expectString(output.templateSelectionExpression),
   } as any;
 };
 
@@ -10454,17 +10362,17 @@ const deserializeAws_restJson1JWTConfiguration = (output: any, context: __SerdeC
       output.audience !== undefined && output.audience !== null
         ? deserializeAws_restJson1__listOf__string(output.audience, context)
         : undefined,
-    Issuer: output.issuer !== undefined && output.issuer !== null ? output.issuer : undefined,
+    Issuer: __expectString(output.issuer),
   } as any;
 };
 
 const deserializeAws_restJson1Model = (output: any, context: __SerdeContext): Model => {
   return {
-    ContentType: output.contentType !== undefined && output.contentType !== null ? output.contentType : undefined,
-    Description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    ModelId: output.modelId !== undefined && output.modelId !== null ? output.modelId : undefined,
-    Name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    Schema: output.schema !== undefined && output.schema !== null ? output.schema : undefined,
+    ContentType: __expectString(output.contentType),
+    Description: __expectString(output.description),
+    ModelId: __expectString(output.modelId),
+    Name: __expectString(output.name),
+    Schema: __expectString(output.schema),
   } as any;
 };
 
@@ -10473,12 +10381,8 @@ const deserializeAws_restJson1MutualTlsAuthentication = (
   context: __SerdeContext
 ): MutualTlsAuthentication => {
   return {
-    TruststoreUri:
-      output.truststoreUri !== undefined && output.truststoreUri !== null ? output.truststoreUri : undefined,
-    TruststoreVersion:
-      output.truststoreVersion !== undefined && output.truststoreVersion !== null
-        ? output.truststoreVersion
-        : undefined,
+    TruststoreUri: __expectString(output.truststoreUri),
+    TruststoreVersion: __expectString(output.truststoreVersion),
     TruststoreWarnings:
       output.truststoreWarnings !== undefined && output.truststoreWarnings !== null
         ? deserializeAws_restJson1__listOf__string(output.truststoreWarnings, context)
@@ -10488,7 +10392,7 @@ const deserializeAws_restJson1MutualTlsAuthentication = (
 
 const deserializeAws_restJson1ParameterConstraints = (output: any, context: __SerdeContext): ParameterConstraints => {
   return {
-    Required: output.required !== undefined && output.required !== null ? output.required : undefined,
+    Required: __expectBoolean(output.required),
   } as any;
 };
 
@@ -10512,27 +10416,16 @@ const deserializeAws_restJson1ResponseParameters = (
 
 const deserializeAws_restJson1Route = (output: any, context: __SerdeContext): Route => {
   return {
-    ApiGatewayManaged:
-      output.apiGatewayManaged !== undefined && output.apiGatewayManaged !== null
-        ? output.apiGatewayManaged
-        : undefined,
-    ApiKeyRequired:
-      output.apiKeyRequired !== undefined && output.apiKeyRequired !== null ? output.apiKeyRequired : undefined,
+    ApiGatewayManaged: __expectBoolean(output.apiGatewayManaged),
+    ApiKeyRequired: __expectBoolean(output.apiKeyRequired),
     AuthorizationScopes:
       output.authorizationScopes !== undefined && output.authorizationScopes !== null
         ? deserializeAws_restJson1AuthorizationScopes(output.authorizationScopes, context)
         : undefined,
-    AuthorizationType:
-      output.authorizationType !== undefined && output.authorizationType !== null
-        ? output.authorizationType
-        : undefined,
-    AuthorizerId: output.authorizerId !== undefined && output.authorizerId !== null ? output.authorizerId : undefined,
-    ModelSelectionExpression:
-      output.modelSelectionExpression !== undefined && output.modelSelectionExpression !== null
-        ? output.modelSelectionExpression
-        : undefined,
-    OperationName:
-      output.operationName !== undefined && output.operationName !== null ? output.operationName : undefined,
+    AuthorizationType: __expectString(output.authorizationType),
+    AuthorizerId: __expectString(output.authorizerId),
+    ModelSelectionExpression: __expectString(output.modelSelectionExpression),
+    OperationName: __expectString(output.operationName),
     RequestModels:
       output.requestModels !== undefined && output.requestModels !== null
         ? deserializeAws_restJson1RouteModels(output.requestModels, context)
@@ -10541,13 +10434,10 @@ const deserializeAws_restJson1Route = (output: any, context: __SerdeContext): Ro
       output.requestParameters !== undefined && output.requestParameters !== null
         ? deserializeAws_restJson1RouteParameters(output.requestParameters, context)
         : undefined,
-    RouteId: output.routeId !== undefined && output.routeId !== null ? output.routeId : undefined,
-    RouteKey: output.routeKey !== undefined && output.routeKey !== null ? output.routeKey : undefined,
-    RouteResponseSelectionExpression:
-      output.routeResponseSelectionExpression !== undefined && output.routeResponseSelectionExpression !== null
-        ? output.routeResponseSelectionExpression
-        : undefined,
-    Target: output.target !== undefined && output.target !== null ? output.target : undefined,
+    RouteId: __expectString(output.routeId),
+    RouteKey: __expectString(output.routeKey),
+    RouteResponseSelectionExpression: __expectString(output.routeResponseSelectionExpression),
+    Target: __expectString(output.target),
   } as any;
 };
 
@@ -10558,7 +10448,7 @@ const deserializeAws_restJson1RouteModels = (output: any, context: __SerdeContex
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -10580,10 +10470,7 @@ const deserializeAws_restJson1RouteParameters = (
 
 const deserializeAws_restJson1RouteResponse = (output: any, context: __SerdeContext): RouteResponse => {
   return {
-    ModelSelectionExpression:
-      output.modelSelectionExpression !== undefined && output.modelSelectionExpression !== null
-        ? output.modelSelectionExpression
-        : undefined,
+    ModelSelectionExpression: __expectString(output.modelSelectionExpression),
     ResponseModels:
       output.responseModels !== undefined && output.responseModels !== null
         ? deserializeAws_restJson1RouteModels(output.responseModels, context)
@@ -10592,30 +10479,18 @@ const deserializeAws_restJson1RouteResponse = (output: any, context: __SerdeCont
       output.responseParameters !== undefined && output.responseParameters !== null
         ? deserializeAws_restJson1RouteParameters(output.responseParameters, context)
         : undefined,
-    RouteResponseId:
-      output.routeResponseId !== undefined && output.routeResponseId !== null ? output.routeResponseId : undefined,
-    RouteResponseKey:
-      output.routeResponseKey !== undefined && output.routeResponseKey !== null ? output.routeResponseKey : undefined,
+    RouteResponseId: __expectString(output.routeResponseId),
+    RouteResponseKey: __expectString(output.routeResponseKey),
   } as any;
 };
 
 const deserializeAws_restJson1RouteSettings = (output: any, context: __SerdeContext): RouteSettings => {
   return {
-    DataTraceEnabled:
-      output.dataTraceEnabled !== undefined && output.dataTraceEnabled !== null ? output.dataTraceEnabled : undefined,
-    DetailedMetricsEnabled:
-      output.detailedMetricsEnabled !== undefined && output.detailedMetricsEnabled !== null
-        ? output.detailedMetricsEnabled
-        : undefined,
-    LoggingLevel: output.loggingLevel !== undefined && output.loggingLevel !== null ? output.loggingLevel : undefined,
-    ThrottlingBurstLimit:
-      output.throttlingBurstLimit !== undefined && output.throttlingBurstLimit !== null
-        ? output.throttlingBurstLimit
-        : undefined,
-    ThrottlingRateLimit:
-      output.throttlingRateLimit !== undefined && output.throttlingRateLimit !== null
-        ? output.throttlingRateLimit
-        : undefined,
+    DataTraceEnabled: __expectBoolean(output.dataTraceEnabled),
+    DetailedMetricsEnabled: __expectBoolean(output.detailedMetricsEnabled),
+    LoggingLevel: __expectString(output.loggingLevel),
+    ThrottlingBurstLimit: __expectNumber(output.throttlingBurstLimit),
+    ThrottlingRateLimit: __expectNumber(output.throttlingRateLimit),
   } as any;
 };
 
@@ -10641,7 +10516,7 @@ const deserializeAws_restJson1SecurityGroupIdList = (output: any, context: __Ser
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -10651,27 +10526,18 @@ const deserializeAws_restJson1Stage = (output: any, context: __SerdeContext): St
       output.accessLogSettings !== undefined && output.accessLogSettings !== null
         ? deserializeAws_restJson1AccessLogSettings(output.accessLogSettings, context)
         : undefined,
-    ApiGatewayManaged:
-      output.apiGatewayManaged !== undefined && output.apiGatewayManaged !== null
-        ? output.apiGatewayManaged
-        : undefined,
-    AutoDeploy: output.autoDeploy !== undefined && output.autoDeploy !== null ? output.autoDeploy : undefined,
-    ClientCertificateId:
-      output.clientCertificateId !== undefined && output.clientCertificateId !== null
-        ? output.clientCertificateId
-        : undefined,
+    ApiGatewayManaged: __expectBoolean(output.apiGatewayManaged),
+    AutoDeploy: __expectBoolean(output.autoDeploy),
+    ClientCertificateId: __expectString(output.clientCertificateId),
     CreatedDate:
       output.createdDate !== undefined && output.createdDate !== null ? new Date(output.createdDate) : undefined,
     DefaultRouteSettings:
       output.defaultRouteSettings !== undefined && output.defaultRouteSettings !== null
         ? deserializeAws_restJson1RouteSettings(output.defaultRouteSettings, context)
         : undefined,
-    DeploymentId: output.deploymentId !== undefined && output.deploymentId !== null ? output.deploymentId : undefined,
-    Description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    LastDeploymentStatusMessage:
-      output.lastDeploymentStatusMessage !== undefined && output.lastDeploymentStatusMessage !== null
-        ? output.lastDeploymentStatusMessage
-        : undefined,
+    DeploymentId: __expectString(output.deploymentId),
+    Description: __expectString(output.description),
+    LastDeploymentStatusMessage: __expectString(output.lastDeploymentStatusMessage),
     LastUpdatedDate:
       output.lastUpdatedDate !== undefined && output.lastUpdatedDate !== null
         ? new Date(output.lastUpdatedDate)
@@ -10680,7 +10546,7 @@ const deserializeAws_restJson1Stage = (output: any, context: __SerdeContext): St
       output.routeSettings !== undefined && output.routeSettings !== null
         ? deserializeAws_restJson1RouteSettingsMap(output.routeSettings, context)
         : undefined,
-    StageName: output.stageName !== undefined && output.stageName !== null ? output.stageName : undefined,
+    StageName: __expectString(output.stageName),
     StageVariables:
       output.stageVariables !== undefined && output.stageVariables !== null
         ? deserializeAws_restJson1StageVariablesMap(output.stageVariables, context)
@@ -10699,7 +10565,7 @@ const deserializeAws_restJson1StageVariablesMap = (output: any, context: __Serde
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -10711,7 +10577,7 @@ const deserializeAws_restJson1SubnetIdList = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -10722,7 +10588,7 @@ const deserializeAws_restJson1Tags = (output: any, context: __SerdeContext): { [
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -10734,17 +10600,14 @@ const deserializeAws_restJson1TemplateMap = (output: any, context: __SerdeContex
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1TlsConfig = (output: any, context: __SerdeContext): TlsConfig => {
   return {
-    ServerNameToVerify:
-      output.serverNameToVerify !== undefined && output.serverNameToVerify !== null
-        ? output.serverNameToVerify
-        : undefined,
+    ServerNameToVerify: __expectString(output.serverNameToVerify),
   } as any;
 };
 
@@ -10752,7 +10615,7 @@ const deserializeAws_restJson1VpcLink = (output: any, context: __SerdeContext): 
   return {
     CreatedDate:
       output.createdDate !== undefined && output.createdDate !== null ? new Date(output.createdDate) : undefined,
-    Name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    Name: __expectString(output.name),
     SecurityGroupIds:
       output.securityGroupIds !== undefined && output.securityGroupIds !== null
         ? deserializeAws_restJson1SecurityGroupIdList(output.securityGroupIds, context)
@@ -10765,15 +10628,10 @@ const deserializeAws_restJson1VpcLink = (output: any, context: __SerdeContext): 
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1Tags(output.tags, context)
         : undefined,
-    VpcLinkId: output.vpcLinkId !== undefined && output.vpcLinkId !== null ? output.vpcLinkId : undefined,
-    VpcLinkStatus:
-      output.vpcLinkStatus !== undefined && output.vpcLinkStatus !== null ? output.vpcLinkStatus : undefined,
-    VpcLinkStatusMessage:
-      output.vpcLinkStatusMessage !== undefined && output.vpcLinkStatusMessage !== null
-        ? output.vpcLinkStatusMessage
-        : undefined,
-    VpcLinkVersion:
-      output.vpcLinkVersion !== undefined && output.vpcLinkVersion !== null ? output.vpcLinkVersion : undefined,
+    VpcLinkId: __expectString(output.vpcLinkId),
+    VpcLinkStatus: __expectString(output.vpcLinkStatus),
+    VpcLinkStatusMessage: __expectString(output.vpcLinkStatusMessage),
+    VpcLinkVersion: __expectString(output.vpcLinkVersion),
   } as any;
 };
 

--- a/clients/client-app-mesh/protocols/Aws_restJson1.ts
+++ b/clients/client-app-mesh/protocols/Aws_restJson1.ts
@@ -242,6 +242,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -3955,7 +3958,7 @@ export const deserializeAws_restJson1ListGatewayRoutesCommand = async (
     contents.gatewayRoutes = deserializeAws_restJson1GatewayRouteList(data.gatewayRoutes, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -4054,7 +4057,7 @@ export const deserializeAws_restJson1ListMeshesCommand = async (
     contents.meshes = deserializeAws_restJson1MeshList(data.meshes, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -4150,7 +4153,7 @@ export const deserializeAws_restJson1ListRoutesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.routes !== undefined && data.routes !== null) {
     contents.routes = deserializeAws_restJson1RouteList(data.routes, context);
@@ -4249,7 +4252,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagList(data.tags, context);
@@ -4348,7 +4351,7 @@ export const deserializeAws_restJson1ListVirtualGatewaysCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.virtualGateways !== undefined && data.virtualGateways !== null) {
     contents.virtualGateways = deserializeAws_restJson1VirtualGatewayList(data.virtualGateways, context);
@@ -4447,7 +4450,7 @@ export const deserializeAws_restJson1ListVirtualNodesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.virtualNodes !== undefined && data.virtualNodes !== null) {
     contents.virtualNodes = deserializeAws_restJson1VirtualNodeList(data.virtualNodes, context);
@@ -4546,7 +4549,7 @@ export const deserializeAws_restJson1ListVirtualRoutersCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.virtualRouters !== undefined && data.virtualRouters !== null) {
     contents.virtualRouters = deserializeAws_restJson1VirtualRouterList(data.virtualRouters, context);
@@ -4645,7 +4648,7 @@ export const deserializeAws_restJson1ListVirtualServicesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.virtualServices !== undefined && data.virtualServices !== null) {
     contents.virtualServices = deserializeAws_restJson1VirtualServiceList(data.virtualServices, context);
@@ -5687,7 +5690,7 @@ const deserializeAws_restJson1BadRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -5704,7 +5707,7 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -5721,7 +5724,7 @@ const deserializeAws_restJson1ForbiddenExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -5739,7 +5742,7 @@ const deserializeAws_restJson1InternalServerErrorExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -5756,7 +5759,7 @@ const deserializeAws_restJson1LimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -5773,7 +5776,7 @@ const deserializeAws_restJson1NotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -5790,7 +5793,7 @@ const deserializeAws_restJson1ResourceInUseExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -5808,7 +5811,7 @@ const deserializeAws_restJson1ServiceUnavailableExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -5828,7 +5831,7 @@ const deserializeAws_restJson1TooManyRequestsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -5845,7 +5848,7 @@ const deserializeAws_restJson1TooManyTagsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -7371,8 +7374,8 @@ const deserializeAws_restJson1AwsCloudMapInstanceAttribute = (
   context: __SerdeContext
 ): AwsCloudMapInstanceAttribute => {
   return {
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    key: __expectString(output.key),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -7399,9 +7402,8 @@ const deserializeAws_restJson1AwsCloudMapServiceDiscovery = (
       output.attributes !== undefined && output.attributes !== null
         ? deserializeAws_restJson1AwsCloudMapInstanceAttributes(output.attributes, context)
         : undefined,
-    namespaceName:
-      output.namespaceName !== undefined && output.namespaceName !== null ? output.namespaceName : undefined,
-    serviceName: output.serviceName !== undefined && output.serviceName !== null ? output.serviceName : undefined,
+    namespaceName: __expectString(output.namespaceName),
+    serviceName: __expectString(output.serviceName),
   } as any;
 };
 
@@ -7441,7 +7443,7 @@ const deserializeAws_restJson1CertificateAuthorityArns = (output: any, context: 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7460,7 +7462,7 @@ const deserializeAws_restJson1ClientPolicyTls = (output: any, context: __SerdeCo
       output.certificate !== undefined && output.certificate !== null
         ? deserializeAws_restJson1ClientTlsCertificate(output.certificate, context)
         : undefined,
-    enforce: output.enforce !== undefined && output.enforce !== null ? output.enforce : undefined,
+    enforce: __expectBoolean(output.enforce),
     ports:
       output.ports !== undefined && output.ports !== null
         ? deserializeAws_restJson1PortSet(output.ports, context)
@@ -7488,35 +7490,34 @@ const deserializeAws_restJson1ClientTlsCertificate = (output: any, context: __Se
 
 const deserializeAws_restJson1DnsServiceDiscovery = (output: any, context: __SerdeContext): DnsServiceDiscovery => {
   return {
-    hostname: output.hostname !== undefined && output.hostname !== null ? output.hostname : undefined,
-    responseType: output.responseType !== undefined && output.responseType !== null ? output.responseType : undefined,
+    hostname: __expectString(output.hostname),
+    responseType: __expectString(output.responseType),
   } as any;
 };
 
 const deserializeAws_restJson1Duration = (output: any, context: __SerdeContext): Duration => {
   return {
-    unit: output.unit !== undefined && output.unit !== null ? output.unit : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    unit: __expectString(output.unit),
+    value: __expectNumber(output.value),
   } as any;
 };
 
 const deserializeAws_restJson1EgressFilter = (output: any, context: __SerdeContext): EgressFilter => {
   return {
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    type: __expectString(output.type),
   } as any;
 };
 
 const deserializeAws_restJson1FileAccessLog = (output: any, context: __SerdeContext): FileAccessLog => {
   return {
-    path: output.path !== undefined && output.path !== null ? output.path : undefined,
+    path: __expectString(output.path),
   } as any;
 };
 
 const deserializeAws_restJson1GatewayRouteData = (output: any, context: __SerdeContext): GatewayRouteData => {
   return {
-    gatewayRouteName:
-      output.gatewayRouteName !== undefined && output.gatewayRouteName !== null ? output.gatewayRouteName : undefined,
-    meshName: output.meshName !== undefined && output.meshName !== null ? output.meshName : undefined,
+    gatewayRouteName: __expectString(output.gatewayRouteName),
+    meshName: __expectString(output.meshName),
     metadata:
       output.metadata !== undefined && output.metadata !== null
         ? deserializeAws_restJson1ResourceMetadata(output.metadata, context)
@@ -7529,10 +7530,7 @@ const deserializeAws_restJson1GatewayRouteData = (output: any, context: __SerdeC
       output.status !== undefined && output.status !== null
         ? deserializeAws_restJson1GatewayRouteStatus(output.status, context)
         : undefined,
-    virtualGatewayName:
-      output.virtualGatewayName !== undefined && output.virtualGatewayName !== null
-        ? output.virtualGatewayName
-        : undefined,
+    virtualGatewayName: __expectString(output.virtualGatewayName),
   } as any;
 };
 
@@ -7541,8 +7539,8 @@ const deserializeAws_restJson1GatewayRouteHostnameMatch = (
   context: __SerdeContext
 ): GatewayRouteHostnameMatch => {
   return {
-    exact: output.exact !== undefined && output.exact !== null ? output.exact : undefined,
-    suffix: output.suffix !== undefined && output.suffix !== null ? output.suffix : undefined,
+    exact: __expectString(output.exact),
+    suffix: __expectString(output.suffix),
   } as any;
 };
 
@@ -7551,10 +7549,7 @@ const deserializeAws_restJson1GatewayRouteHostnameRewrite = (
   context: __SerdeContext
 ): GatewayRouteHostnameRewrite => {
   return {
-    defaultTargetHostname:
-      output.defaultTargetHostname !== undefined && output.defaultTargetHostname !== null
-        ? output.defaultTargetHostname
-        : undefined,
+    defaultTargetHostname: __expectString(output.defaultTargetHostname),
   } as any;
 };
 
@@ -7571,26 +7566,21 @@ const deserializeAws_restJson1GatewayRouteList = (output: any, context: __SerdeC
 
 const deserializeAws_restJson1GatewayRouteRef = (output: any, context: __SerdeContext): GatewayRouteRef => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    gatewayRouteName:
-      output.gatewayRouteName !== undefined && output.gatewayRouteName !== null ? output.gatewayRouteName : undefined,
+    gatewayRouteName: __expectString(output.gatewayRouteName),
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
         ? new Date(Math.round(output.lastUpdatedAt * 1000))
         : undefined,
-    meshName: output.meshName !== undefined && output.meshName !== null ? output.meshName : undefined,
-    meshOwner: output.meshOwner !== undefined && output.meshOwner !== null ? output.meshOwner : undefined,
-    resourceOwner:
-      output.resourceOwner !== undefined && output.resourceOwner !== null ? output.resourceOwner : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
-    virtualGatewayName:
-      output.virtualGatewayName !== undefined && output.virtualGatewayName !== null
-        ? output.virtualGatewayName
-        : undefined,
+    meshName: __expectString(output.meshName),
+    meshOwner: __expectString(output.meshOwner),
+    resourceOwner: __expectString(output.resourceOwner),
+    version: __expectNumber(output.version),
+    virtualGatewayName: __expectString(output.virtualGatewayName),
   } as any;
 };
 
@@ -7608,13 +7598,13 @@ const deserializeAws_restJson1GatewayRouteSpec = (output: any, context: __SerdeC
       output.httpRoute !== undefined && output.httpRoute !== null
         ? deserializeAws_restJson1HttpGatewayRoute(output.httpRoute, context)
         : undefined,
-    priority: output.priority !== undefined && output.priority !== null ? output.priority : undefined,
+    priority: __expectNumber(output.priority),
   } as any;
 };
 
 const deserializeAws_restJson1GatewayRouteStatus = (output: any, context: __SerdeContext): GatewayRouteStatus => {
   return {
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -7632,10 +7622,7 @@ const deserializeAws_restJson1GatewayRouteVirtualService = (
   context: __SerdeContext
 ): GatewayRouteVirtualService => {
   return {
-    virtualServiceName:
-      output.virtualServiceName !== undefined && output.virtualServiceName !== null
-        ? output.virtualServiceName
-        : undefined,
+    virtualServiceName: __expectString(output.virtualServiceName),
   } as any;
 };
 
@@ -7678,7 +7665,7 @@ const deserializeAws_restJson1GrpcGatewayRouteMatch = (output: any, context: __S
       output.metadata !== undefined && output.metadata !== null
         ? deserializeAws_restJson1GrpcGatewayRouteMetadataList(output.metadata, context)
         : undefined,
-    serviceName: output.serviceName !== undefined && output.serviceName !== null ? output.serviceName : undefined,
+    serviceName: __expectString(output.serviceName),
   } as any;
 };
 
@@ -7687,12 +7674,12 @@ const deserializeAws_restJson1GrpcGatewayRouteMetadata = (
   context: __SerdeContext
 ): GrpcGatewayRouteMetadata => {
   return {
-    invert: output.invert !== undefined && output.invert !== null ? output.invert : undefined,
+    invert: __expectBoolean(output.invert),
     match:
       output.match !== undefined && output.match !== null
         ? deserializeAws_restJson1GrpcMetadataMatchMethod(output.match, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -7726,30 +7713,22 @@ const deserializeAws_restJson1GrpcMetadataMatchMethod = (
   output: any,
   context: __SerdeContext
 ): GrpcMetadataMatchMethod => {
-  if (output.exact !== undefined && output.exact !== null) {
-    return {
-      exact: output.exact,
-    };
+  if (__expectString(output.exact) !== undefined) {
+    return { exact: __expectString(output.exact) as any };
   }
-  if (output.prefix !== undefined && output.prefix !== null) {
-    return {
-      prefix: output.prefix,
-    };
+  if (__expectString(output.prefix) !== undefined) {
+    return { prefix: __expectString(output.prefix) as any };
   }
   if (output.range !== undefined && output.range !== null) {
     return {
       range: deserializeAws_restJson1MatchRange(output.range, context),
     };
   }
-  if (output.regex !== undefined && output.regex !== null) {
-    return {
-      regex: output.regex,
-    };
+  if (__expectString(output.regex) !== undefined) {
+    return { regex: __expectString(output.regex) as any };
   }
-  if (output.suffix !== undefined && output.suffix !== null) {
-    return {
-      suffix: output.suffix,
-    };
+  if (__expectString(output.suffix) !== undefined) {
+    return { suffix: __expectString(output.suffix) as any };
   }
   return { $unknown: Object.entries(output)[0] };
 };
@@ -7764,7 +7743,7 @@ const deserializeAws_restJson1GrpcRetryPolicy = (output: any, context: __SerdeCo
       output.httpRetryEvents !== undefined && output.httpRetryEvents !== null
         ? deserializeAws_restJson1HttpRetryPolicyEvents(output.httpRetryEvents, context)
         : undefined,
-    maxRetries: output.maxRetries !== undefined && output.maxRetries !== null ? output.maxRetries : undefined,
+    maxRetries: __expectNumber(output.maxRetries),
     perRetryTimeout:
       output.perRetryTimeout !== undefined && output.perRetryTimeout !== null
         ? deserializeAws_restJson1Duration(output.perRetryTimeout, context)
@@ -7786,7 +7765,7 @@ const deserializeAws_restJson1GrpcRetryPolicyEvents = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7826,19 +7805,19 @@ const deserializeAws_restJson1GrpcRouteMatch = (output: any, context: __SerdeCon
       output.metadata !== undefined && output.metadata !== null
         ? deserializeAws_restJson1GrpcRouteMetadataList(output.metadata, context)
         : undefined,
-    methodName: output.methodName !== undefined && output.methodName !== null ? output.methodName : undefined,
-    serviceName: output.serviceName !== undefined && output.serviceName !== null ? output.serviceName : undefined,
+    methodName: __expectString(output.methodName),
+    serviceName: __expectString(output.serviceName),
   } as any;
 };
 
 const deserializeAws_restJson1GrpcRouteMetadata = (output: any, context: __SerdeContext): GrpcRouteMetadata => {
   return {
-    invert: output.invert !== undefined && output.invert !== null ? output.invert : undefined,
+    invert: __expectBoolean(output.invert),
     match:
       output.match !== undefined && output.match !== null
         ? deserializeAws_restJson1GrpcRouteMetadataMatchMethod(output.match, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -7857,30 +7836,22 @@ const deserializeAws_restJson1GrpcRouteMetadataMatchMethod = (
   output: any,
   context: __SerdeContext
 ): GrpcRouteMetadataMatchMethod => {
-  if (output.exact !== undefined && output.exact !== null) {
-    return {
-      exact: output.exact,
-    };
+  if (__expectString(output.exact) !== undefined) {
+    return { exact: __expectString(output.exact) as any };
   }
-  if (output.prefix !== undefined && output.prefix !== null) {
-    return {
-      prefix: output.prefix,
-    };
+  if (__expectString(output.prefix) !== undefined) {
+    return { prefix: __expectString(output.prefix) as any };
   }
   if (output.range !== undefined && output.range !== null) {
     return {
       range: deserializeAws_restJson1MatchRange(output.range, context),
     };
   }
-  if (output.regex !== undefined && output.regex !== null) {
-    return {
-      regex: output.regex,
-    };
+  if (__expectString(output.regex) !== undefined) {
+    return { regex: __expectString(output.regex) as any };
   }
-  if (output.suffix !== undefined && output.suffix !== null) {
-    return {
-      suffix: output.suffix,
-    };
+  if (__expectString(output.suffix) !== undefined) {
+    return { suffix: __expectString(output.suffix) as any };
   }
   return { $unknown: Object.entries(output)[0] };
 };
@@ -7899,49 +7870,35 @@ const deserializeAws_restJson1GrpcTimeout = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_restJson1HeaderMatchMethod = (output: any, context: __SerdeContext): HeaderMatchMethod => {
-  if (output.exact !== undefined && output.exact !== null) {
-    return {
-      exact: output.exact,
-    };
+  if (__expectString(output.exact) !== undefined) {
+    return { exact: __expectString(output.exact) as any };
   }
-  if (output.prefix !== undefined && output.prefix !== null) {
-    return {
-      prefix: output.prefix,
-    };
+  if (__expectString(output.prefix) !== undefined) {
+    return { prefix: __expectString(output.prefix) as any };
   }
   if (output.range !== undefined && output.range !== null) {
     return {
       range: deserializeAws_restJson1MatchRange(output.range, context),
     };
   }
-  if (output.regex !== undefined && output.regex !== null) {
-    return {
-      regex: output.regex,
-    };
+  if (__expectString(output.regex) !== undefined) {
+    return { regex: __expectString(output.regex) as any };
   }
-  if (output.suffix !== undefined && output.suffix !== null) {
-    return {
-      suffix: output.suffix,
-    };
+  if (__expectString(output.suffix) !== undefined) {
+    return { suffix: __expectString(output.suffix) as any };
   }
   return { $unknown: Object.entries(output)[0] };
 };
 
 const deserializeAws_restJson1HealthCheckPolicy = (output: any, context: __SerdeContext): HealthCheckPolicy => {
   return {
-    healthyThreshold:
-      output.healthyThreshold !== undefined && output.healthyThreshold !== null ? output.healthyThreshold : undefined,
-    intervalMillis:
-      output.intervalMillis !== undefined && output.intervalMillis !== null ? output.intervalMillis : undefined,
-    path: output.path !== undefined && output.path !== null ? output.path : undefined,
-    port: output.port !== undefined && output.port !== null ? output.port : undefined,
-    protocol: output.protocol !== undefined && output.protocol !== null ? output.protocol : undefined,
-    timeoutMillis:
-      output.timeoutMillis !== undefined && output.timeoutMillis !== null ? output.timeoutMillis : undefined,
-    unhealthyThreshold:
-      output.unhealthyThreshold !== undefined && output.unhealthyThreshold !== null
-        ? output.unhealthyThreshold
-        : undefined,
+    healthyThreshold: __expectNumber(output.healthyThreshold),
+    intervalMillis: __expectNumber(output.intervalMillis),
+    path: __expectString(output.path),
+    port: __expectNumber(output.port),
+    protocol: __expectString(output.protocol),
+    timeoutMillis: __expectNumber(output.timeoutMillis),
+    unhealthyThreshold: __expectNumber(output.unhealthyThreshold),
   } as any;
 };
 
@@ -7979,12 +7936,12 @@ const deserializeAws_restJson1HttpGatewayRouteHeader = (
   context: __SerdeContext
 ): HttpGatewayRouteHeader => {
   return {
-    invert: output.invert !== undefined && output.invert !== null ? output.invert : undefined,
+    invert: __expectBoolean(output.invert),
     match:
       output.match !== undefined && output.match !== null
         ? deserializeAws_restJson1HeaderMatchMethod(output.match, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -8012,12 +7969,12 @@ const deserializeAws_restJson1HttpGatewayRouteMatch = (output: any, context: __S
       output.hostname !== undefined && output.hostname !== null
         ? deserializeAws_restJson1GatewayRouteHostnameMatch(output.hostname, context)
         : undefined,
-    method: output.method !== undefined && output.method !== null ? output.method : undefined,
+    method: __expectString(output.method),
     path:
       output.path !== undefined && output.path !== null
         ? deserializeAws_restJson1HttpPathMatch(output.path, context)
         : undefined,
-    prefix: output.prefix !== undefined && output.prefix !== null ? output.prefix : undefined,
+    prefix: __expectString(output.prefix),
     queryParameters:
       output.queryParameters !== undefined && output.queryParameters !== null
         ? deserializeAws_restJson1HttpQueryParameters(output.queryParameters, context)
@@ -8030,7 +7987,7 @@ const deserializeAws_restJson1HttpGatewayRoutePathRewrite = (
   context: __SerdeContext
 ): HttpGatewayRoutePathRewrite => {
   return {
-    exact: output.exact !== undefined && output.exact !== null ? output.exact : undefined,
+    exact: __expectString(output.exact),
   } as any;
 };
 
@@ -8039,9 +7996,8 @@ const deserializeAws_restJson1HttpGatewayRoutePrefixRewrite = (
   context: __SerdeContext
 ): HttpGatewayRoutePrefixRewrite => {
   return {
-    defaultPrefix:
-      output.defaultPrefix !== undefined && output.defaultPrefix !== null ? output.defaultPrefix : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    defaultPrefix: __expectString(output.defaultPrefix),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -8067,8 +8023,8 @@ const deserializeAws_restJson1HttpGatewayRouteRewrite = (
 
 const deserializeAws_restJson1HttpPathMatch = (output: any, context: __SerdeContext): HttpPathMatch => {
   return {
-    exact: output.exact !== undefined && output.exact !== null ? output.exact : undefined,
-    regex: output.regex !== undefined && output.regex !== null ? output.regex : undefined,
+    exact: __expectString(output.exact),
+    regex: __expectString(output.regex),
   } as any;
 };
 
@@ -8078,7 +8034,7 @@ const deserializeAws_restJson1HttpQueryParameter = (output: any, context: __Serd
       output.match !== undefined && output.match !== null
         ? deserializeAws_restJson1QueryParameterMatch(output.match, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -8099,7 +8055,7 @@ const deserializeAws_restJson1HttpRetryPolicy = (output: any, context: __SerdeCo
       output.httpRetryEvents !== undefined && output.httpRetryEvents !== null
         ? deserializeAws_restJson1HttpRetryPolicyEvents(output.httpRetryEvents, context)
         : undefined,
-    maxRetries: output.maxRetries !== undefined && output.maxRetries !== null ? output.maxRetries : undefined,
+    maxRetries: __expectNumber(output.maxRetries),
     perRetryTimeout:
       output.perRetryTimeout !== undefined && output.perRetryTimeout !== null
         ? deserializeAws_restJson1Duration(output.perRetryTimeout, context)
@@ -8118,7 +8074,7 @@ const deserializeAws_restJson1HttpRetryPolicyEvents = (output: any, context: __S
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -8154,12 +8110,12 @@ const deserializeAws_restJson1HttpRouteAction = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1HttpRouteHeader = (output: any, context: __SerdeContext): HttpRouteHeader => {
   return {
-    invert: output.invert !== undefined && output.invert !== null ? output.invert : undefined,
+    invert: __expectBoolean(output.invert),
     match:
       output.match !== undefined && output.match !== null
         ? deserializeAws_restJson1HeaderMatchMethod(output.match, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -8180,17 +8136,17 @@ const deserializeAws_restJson1HttpRouteMatch = (output: any, context: __SerdeCon
       output.headers !== undefined && output.headers !== null
         ? deserializeAws_restJson1HttpRouteHeaders(output.headers, context)
         : undefined,
-    method: output.method !== undefined && output.method !== null ? output.method : undefined,
+    method: __expectString(output.method),
     path:
       output.path !== undefined && output.path !== null
         ? deserializeAws_restJson1HttpPathMatch(output.path, context)
         : undefined,
-    prefix: output.prefix !== undefined && output.prefix !== null ? output.prefix : undefined,
+    prefix: __expectString(output.prefix),
     queryParameters:
       output.queryParameters !== undefined && output.queryParameters !== null
         ? deserializeAws_restJson1HttpQueryParameters(output.queryParameters, context)
         : undefined,
-    scheme: output.scheme !== undefined && output.scheme !== null ? output.scheme : undefined,
+    scheme: __expectString(output.scheme),
   } as any;
 };
 
@@ -8277,7 +8233,7 @@ const deserializeAws_restJson1ListenerTls = (output: any, context: __SerdeContex
       output.certificate !== undefined && output.certificate !== null
         ? deserializeAws_restJson1ListenerTlsCertificate(output.certificate, context)
         : undefined,
-    mode: output.mode !== undefined && output.mode !== null ? output.mode : undefined,
+    mode: __expectString(output.mode),
     validation:
       output.validation !== undefined && output.validation !== null
         ? deserializeAws_restJson1ListenerTlsValidationContext(output.validation, context)
@@ -8290,8 +8246,7 @@ const deserializeAws_restJson1ListenerTlsAcmCertificate = (
   context: __SerdeContext
 ): ListenerTlsAcmCertificate => {
   return {
-    certificateArn:
-      output.certificateArn !== undefined && output.certificateArn !== null ? output.certificateArn : undefined,
+    certificateArn: __expectString(output.certificateArn),
   } as any;
 };
 
@@ -8322,9 +8277,8 @@ const deserializeAws_restJson1ListenerTlsFileCertificate = (
   context: __SerdeContext
 ): ListenerTlsFileCertificate => {
   return {
-    certificateChain:
-      output.certificateChain !== undefined && output.certificateChain !== null ? output.certificateChain : undefined,
-    privateKey: output.privateKey !== undefined && output.privateKey !== null ? output.privateKey : undefined,
+    certificateChain: __expectString(output.certificateChain),
+    privateKey: __expectString(output.privateKey),
   } as any;
 };
 
@@ -8333,7 +8287,7 @@ const deserializeAws_restJson1ListenerTlsSdsCertificate = (
   context: __SerdeContext
 ): ListenerTlsSdsCertificate => {
   return {
-    secretName: output.secretName !== undefined && output.secretName !== null ? output.secretName : undefined,
+    secretName: __expectString(output.secretName),
   } as any;
 };
 
@@ -8381,14 +8335,14 @@ const deserializeAws_restJson1Logging = (output: any, context: __SerdeContext): 
 
 const deserializeAws_restJson1MatchRange = (output: any, context: __SerdeContext): MatchRange => {
   return {
-    end: output.end !== undefined && output.end !== null ? output.end : undefined,
-    start: output.start !== undefined && output.start !== null ? output.start : undefined,
+    end: __expectNumber(output.end),
+    start: __expectNumber(output.start),
   } as any;
 };
 
 const deserializeAws_restJson1MeshData = (output: any, context: __SerdeContext): MeshData => {
   return {
-    meshName: output.meshName !== undefined && output.meshName !== null ? output.meshName : undefined,
+    meshName: __expectString(output.meshName),
     metadata:
       output.metadata !== undefined && output.metadata !== null
         ? deserializeAws_restJson1ResourceMetadata(output.metadata, context)
@@ -8417,7 +8371,7 @@ const deserializeAws_restJson1MeshList = (output: any, context: __SerdeContext):
 
 const deserializeAws_restJson1MeshRef = (output: any, context: __SerdeContext): MeshRef => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
@@ -8426,11 +8380,10 @@ const deserializeAws_restJson1MeshRef = (output: any, context: __SerdeContext): 
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
         ? new Date(Math.round(output.lastUpdatedAt * 1000))
         : undefined,
-    meshName: output.meshName !== undefined && output.meshName !== null ? output.meshName : undefined,
-    meshOwner: output.meshOwner !== undefined && output.meshOwner !== null ? output.meshOwner : undefined,
-    resourceOwner:
-      output.resourceOwner !== undefined && output.resourceOwner !== null ? output.resourceOwner : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    meshName: __expectString(output.meshName),
+    meshOwner: __expectString(output.meshOwner),
+    resourceOwner: __expectString(output.resourceOwner),
+    version: __expectNumber(output.version),
   } as any;
 };
 
@@ -8445,7 +8398,7 @@ const deserializeAws_restJson1MeshSpec = (output: any, context: __SerdeContext):
 
 const deserializeAws_restJson1MeshStatus = (output: any, context: __SerdeContext): MeshStatus => {
   return {
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -8459,19 +8412,15 @@ const deserializeAws_restJson1OutlierDetection = (output: any, context: __SerdeC
       output.interval !== undefined && output.interval !== null
         ? deserializeAws_restJson1Duration(output.interval, context)
         : undefined,
-    maxEjectionPercent:
-      output.maxEjectionPercent !== undefined && output.maxEjectionPercent !== null
-        ? output.maxEjectionPercent
-        : undefined,
-    maxServerErrors:
-      output.maxServerErrors !== undefined && output.maxServerErrors !== null ? output.maxServerErrors : undefined,
+    maxEjectionPercent: __expectNumber(output.maxEjectionPercent),
+    maxServerErrors: __expectNumber(output.maxServerErrors),
   } as any;
 };
 
 const deserializeAws_restJson1PortMapping = (output: any, context: __SerdeContext): PortMapping => {
   return {
-    port: output.port !== undefined && output.port !== null ? output.port : undefined,
-    protocol: output.protocol !== undefined && output.protocol !== null ? output.protocol : undefined,
+    port: __expectNumber(output.port),
+    protocol: __expectString(output.protocol),
   } as any;
 };
 
@@ -8482,19 +8431,19 @@ const deserializeAws_restJson1PortSet = (output: any, context: __SerdeContext): 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectNumber(entry) as any;
     });
 };
 
 const deserializeAws_restJson1QueryParameterMatch = (output: any, context: __SerdeContext): QueryParameterMatch => {
   return {
-    exact: output.exact !== undefined && output.exact !== null ? output.exact : undefined,
+    exact: __expectString(output.exact),
   } as any;
 };
 
 const deserializeAws_restJson1ResourceMetadata = (output: any, context: __SerdeContext): ResourceMetadata => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
@@ -8503,22 +8452,21 @@ const deserializeAws_restJson1ResourceMetadata = (output: any, context: __SerdeC
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
         ? new Date(Math.round(output.lastUpdatedAt * 1000))
         : undefined,
-    meshOwner: output.meshOwner !== undefined && output.meshOwner !== null ? output.meshOwner : undefined,
-    resourceOwner:
-      output.resourceOwner !== undefined && output.resourceOwner !== null ? output.resourceOwner : undefined,
-    uid: output.uid !== undefined && output.uid !== null ? output.uid : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    meshOwner: __expectString(output.meshOwner),
+    resourceOwner: __expectString(output.resourceOwner),
+    uid: __expectString(output.uid),
+    version: __expectNumber(output.version),
   } as any;
 };
 
 const deserializeAws_restJson1RouteData = (output: any, context: __SerdeContext): RouteData => {
   return {
-    meshName: output.meshName !== undefined && output.meshName !== null ? output.meshName : undefined,
+    meshName: __expectString(output.meshName),
     metadata:
       output.metadata !== undefined && output.metadata !== null
         ? deserializeAws_restJson1ResourceMetadata(output.metadata, context)
         : undefined,
-    routeName: output.routeName !== undefined && output.routeName !== null ? output.routeName : undefined,
+    routeName: __expectString(output.routeName),
     spec:
       output.spec !== undefined && output.spec !== null
         ? deserializeAws_restJson1RouteSpec(output.spec, context)
@@ -8527,10 +8475,7 @@ const deserializeAws_restJson1RouteData = (output: any, context: __SerdeContext)
       output.status !== undefined && output.status !== null
         ? deserializeAws_restJson1RouteStatus(output.status, context)
         : undefined,
-    virtualRouterName:
-      output.virtualRouterName !== undefined && output.virtualRouterName !== null
-        ? output.virtualRouterName
-        : undefined,
+    virtualRouterName: __expectString(output.virtualRouterName),
   } as any;
 };
 
@@ -8547,7 +8492,7 @@ const deserializeAws_restJson1RouteList = (output: any, context: __SerdeContext)
 
 const deserializeAws_restJson1RouteRef = (output: any, context: __SerdeContext): RouteRef => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
@@ -8556,16 +8501,12 @@ const deserializeAws_restJson1RouteRef = (output: any, context: __SerdeContext):
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
         ? new Date(Math.round(output.lastUpdatedAt * 1000))
         : undefined,
-    meshName: output.meshName !== undefined && output.meshName !== null ? output.meshName : undefined,
-    meshOwner: output.meshOwner !== undefined && output.meshOwner !== null ? output.meshOwner : undefined,
-    resourceOwner:
-      output.resourceOwner !== undefined && output.resourceOwner !== null ? output.resourceOwner : undefined,
-    routeName: output.routeName !== undefined && output.routeName !== null ? output.routeName : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
-    virtualRouterName:
-      output.virtualRouterName !== undefined && output.virtualRouterName !== null
-        ? output.virtualRouterName
-        : undefined,
+    meshName: __expectString(output.meshName),
+    meshOwner: __expectString(output.meshOwner),
+    resourceOwner: __expectString(output.resourceOwner),
+    routeName: __expectString(output.routeName),
+    version: __expectNumber(output.version),
+    virtualRouterName: __expectString(output.virtualRouterName),
   } as any;
 };
 
@@ -8583,7 +8524,7 @@ const deserializeAws_restJson1RouteSpec = (output: any, context: __SerdeContext)
       output.httpRoute !== undefined && output.httpRoute !== null
         ? deserializeAws_restJson1HttpRoute(output.httpRoute, context)
         : undefined,
-    priority: output.priority !== undefined && output.priority !== null ? output.priority : undefined,
+    priority: __expectNumber(output.priority),
     tcpRoute:
       output.tcpRoute !== undefined && output.tcpRoute !== null
         ? deserializeAws_restJson1TcpRoute(output.tcpRoute, context)
@@ -8593,7 +8534,7 @@ const deserializeAws_restJson1RouteSpec = (output: any, context: __SerdeContext)
 
 const deserializeAws_restJson1RouteStatus = (output: any, context: __SerdeContext): RouteStatus => {
   return {
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -8618,7 +8559,7 @@ const deserializeAws_restJson1SubjectAlternativeNameList = (output: any, context
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -8659,8 +8600,8 @@ const deserializeAws_restJson1TagList = (output: any, context: __SerdeContext): 
 
 const deserializeAws_restJson1TagRef = (output: any, context: __SerdeContext): TagRef => {
   return {
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    key: __expectString(output.key),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -8674,7 +8615,7 @@ const deserializeAws_restJson1TcpRetryPolicyEvents = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -8739,8 +8680,7 @@ const deserializeAws_restJson1TlsValidationContextFileTrust = (
   context: __SerdeContext
 ): TlsValidationContextFileTrust => {
   return {
-    certificateChain:
-      output.certificateChain !== undefined && output.certificateChain !== null ? output.certificateChain : undefined,
+    certificateChain: __expectString(output.certificateChain),
   } as any;
 };
 
@@ -8749,7 +8689,7 @@ const deserializeAws_restJson1TlsValidationContextSdsTrust = (
   context: __SerdeContext
 ): TlsValidationContextSdsTrust => {
   return {
-    secretName: output.secretName !== undefined && output.secretName !== null ? output.secretName : undefined,
+    secretName: __expectString(output.secretName),
   } as any;
 };
 
@@ -8809,7 +8749,7 @@ const deserializeAws_restJson1VirtualGatewayCertificateAuthorityArns = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -8834,7 +8774,7 @@ const deserializeAws_restJson1VirtualGatewayClientPolicyTls = (
       output.certificate !== undefined && output.certificate !== null
         ? deserializeAws_restJson1VirtualGatewayClientTlsCertificate(output.certificate, context)
         : undefined,
-    enforce: output.enforce !== undefined && output.enforce !== null ? output.enforce : undefined,
+    enforce: __expectBoolean(output.enforce),
     ports:
       output.ports !== undefined && output.ports !== null
         ? deserializeAws_restJson1PortSet(output.ports, context)
@@ -8887,7 +8827,7 @@ const deserializeAws_restJson1VirtualGatewayConnectionPool = (
 
 const deserializeAws_restJson1VirtualGatewayData = (output: any, context: __SerdeContext): VirtualGatewayData => {
   return {
-    meshName: output.meshName !== undefined && output.meshName !== null ? output.meshName : undefined,
+    meshName: __expectString(output.meshName),
     metadata:
       output.metadata !== undefined && output.metadata !== null
         ? deserializeAws_restJson1ResourceMetadata(output.metadata, context)
@@ -8900,10 +8840,7 @@ const deserializeAws_restJson1VirtualGatewayData = (output: any, context: __Serd
       output.status !== undefined && output.status !== null
         ? deserializeAws_restJson1VirtualGatewayStatus(output.status, context)
         : undefined,
-    virtualGatewayName:
-      output.virtualGatewayName !== undefined && output.virtualGatewayName !== null
-        ? output.virtualGatewayName
-        : undefined,
+    virtualGatewayName: __expectString(output.virtualGatewayName),
   } as any;
 };
 
@@ -8912,7 +8849,7 @@ const deserializeAws_restJson1VirtualGatewayFileAccessLog = (
   context: __SerdeContext
 ): VirtualGatewayFileAccessLog => {
   return {
-    path: output.path !== undefined && output.path !== null ? output.path : undefined,
+    path: __expectString(output.path),
   } as any;
 };
 
@@ -8921,7 +8858,7 @@ const deserializeAws_restJson1VirtualGatewayGrpcConnectionPool = (
   context: __SerdeContext
 ): VirtualGatewayGrpcConnectionPool => {
   return {
-    maxRequests: output.maxRequests !== undefined && output.maxRequests !== null ? output.maxRequests : undefined,
+    maxRequests: __expectNumber(output.maxRequests),
   } as any;
 };
 
@@ -8930,19 +8867,13 @@ const deserializeAws_restJson1VirtualGatewayHealthCheckPolicy = (
   context: __SerdeContext
 ): VirtualGatewayHealthCheckPolicy => {
   return {
-    healthyThreshold:
-      output.healthyThreshold !== undefined && output.healthyThreshold !== null ? output.healthyThreshold : undefined,
-    intervalMillis:
-      output.intervalMillis !== undefined && output.intervalMillis !== null ? output.intervalMillis : undefined,
-    path: output.path !== undefined && output.path !== null ? output.path : undefined,
-    port: output.port !== undefined && output.port !== null ? output.port : undefined,
-    protocol: output.protocol !== undefined && output.protocol !== null ? output.protocol : undefined,
-    timeoutMillis:
-      output.timeoutMillis !== undefined && output.timeoutMillis !== null ? output.timeoutMillis : undefined,
-    unhealthyThreshold:
-      output.unhealthyThreshold !== undefined && output.unhealthyThreshold !== null
-        ? output.unhealthyThreshold
-        : undefined,
+    healthyThreshold: __expectNumber(output.healthyThreshold),
+    intervalMillis: __expectNumber(output.intervalMillis),
+    path: __expectString(output.path),
+    port: __expectNumber(output.port),
+    protocol: __expectString(output.protocol),
+    timeoutMillis: __expectNumber(output.timeoutMillis),
+    unhealthyThreshold: __expectNumber(output.unhealthyThreshold),
   } as any;
 };
 
@@ -8951,7 +8882,7 @@ const deserializeAws_restJson1VirtualGatewayHttp2ConnectionPool = (
   context: __SerdeContext
 ): VirtualGatewayHttp2ConnectionPool => {
   return {
-    maxRequests: output.maxRequests !== undefined && output.maxRequests !== null ? output.maxRequests : undefined,
+    maxRequests: __expectNumber(output.maxRequests),
   } as any;
 };
 
@@ -8960,12 +8891,8 @@ const deserializeAws_restJson1VirtualGatewayHttpConnectionPool = (
   context: __SerdeContext
 ): VirtualGatewayHttpConnectionPool => {
   return {
-    maxConnections:
-      output.maxConnections !== undefined && output.maxConnections !== null ? output.maxConnections : undefined,
-    maxPendingRequests:
-      output.maxPendingRequests !== undefined && output.maxPendingRequests !== null
-        ? output.maxPendingRequests
-        : undefined,
+    maxConnections: __expectNumber(output.maxConnections),
+    maxPendingRequests: __expectNumber(output.maxPendingRequests),
   } as any;
 };
 
@@ -9027,7 +8954,7 @@ const deserializeAws_restJson1VirtualGatewayListenerTls = (
       output.certificate !== undefined && output.certificate !== null
         ? deserializeAws_restJson1VirtualGatewayListenerTlsCertificate(output.certificate, context)
         : undefined,
-    mode: output.mode !== undefined && output.mode !== null ? output.mode : undefined,
+    mode: __expectString(output.mode),
     validation:
       output.validation !== undefined && output.validation !== null
         ? deserializeAws_restJson1VirtualGatewayListenerTlsValidationContext(output.validation, context)
@@ -9040,8 +8967,7 @@ const deserializeAws_restJson1VirtualGatewayListenerTlsAcmCertificate = (
   context: __SerdeContext
 ): VirtualGatewayListenerTlsAcmCertificate => {
   return {
-    certificateArn:
-      output.certificateArn !== undefined && output.certificateArn !== null ? output.certificateArn : undefined,
+    certificateArn: __expectString(output.certificateArn),
   } as any;
 };
 
@@ -9072,9 +8998,8 @@ const deserializeAws_restJson1VirtualGatewayListenerTlsFileCertificate = (
   context: __SerdeContext
 ): VirtualGatewayListenerTlsFileCertificate => {
   return {
-    certificateChain:
-      output.certificateChain !== undefined && output.certificateChain !== null ? output.certificateChain : undefined,
-    privateKey: output.privateKey !== undefined && output.privateKey !== null ? output.privateKey : undefined,
+    certificateChain: __expectString(output.certificateChain),
+    privateKey: __expectString(output.privateKey),
   } as any;
 };
 
@@ -9083,7 +9008,7 @@ const deserializeAws_restJson1VirtualGatewayListenerTlsSdsCertificate = (
   context: __SerdeContext
 ): VirtualGatewayListenerTlsSdsCertificate => {
   return {
-    secretName: output.secretName !== undefined && output.secretName !== null ? output.secretName : undefined,
+    secretName: __expectString(output.secretName),
   } as any;
 };
 
@@ -9134,14 +9059,14 @@ const deserializeAws_restJson1VirtualGatewayPortMapping = (
   context: __SerdeContext
 ): VirtualGatewayPortMapping => {
   return {
-    port: output.port !== undefined && output.port !== null ? output.port : undefined,
-    protocol: output.protocol !== undefined && output.protocol !== null ? output.protocol : undefined,
+    port: __expectNumber(output.port),
+    protocol: __expectString(output.protocol),
   } as any;
 };
 
 const deserializeAws_restJson1VirtualGatewayRef = (output: any, context: __SerdeContext): VirtualGatewayRef => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
@@ -9150,15 +9075,11 @@ const deserializeAws_restJson1VirtualGatewayRef = (output: any, context: __Serde
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
         ? new Date(Math.round(output.lastUpdatedAt * 1000))
         : undefined,
-    meshName: output.meshName !== undefined && output.meshName !== null ? output.meshName : undefined,
-    meshOwner: output.meshOwner !== undefined && output.meshOwner !== null ? output.meshOwner : undefined,
-    resourceOwner:
-      output.resourceOwner !== undefined && output.resourceOwner !== null ? output.resourceOwner : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
-    virtualGatewayName:
-      output.virtualGatewayName !== undefined && output.virtualGatewayName !== null
-        ? output.virtualGatewayName
-        : undefined,
+    meshName: __expectString(output.meshName),
+    meshOwner: __expectString(output.meshOwner),
+    resourceOwner: __expectString(output.resourceOwner),
+    version: __expectNumber(output.version),
+    virtualGatewayName: __expectString(output.virtualGatewayName),
   } as any;
 };
 
@@ -9181,7 +9102,7 @@ const deserializeAws_restJson1VirtualGatewaySpec = (output: any, context: __Serd
 
 const deserializeAws_restJson1VirtualGatewayStatus = (output: any, context: __SerdeContext): VirtualGatewayStatus => {
   return {
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -9218,8 +9139,7 @@ const deserializeAws_restJson1VirtualGatewayTlsValidationContextFileTrust = (
   context: __SerdeContext
 ): VirtualGatewayTlsValidationContextFileTrust => {
   return {
-    certificateChain:
-      output.certificateChain !== undefined && output.certificateChain !== null ? output.certificateChain : undefined,
+    certificateChain: __expectString(output.certificateChain),
   } as any;
 };
 
@@ -9228,7 +9148,7 @@ const deserializeAws_restJson1VirtualGatewayTlsValidationContextSdsTrust = (
   context: __SerdeContext
 ): VirtualGatewayTlsValidationContextSdsTrust => {
   return {
-    secretName: output.secretName !== undefined && output.secretName !== null ? output.secretName : undefined,
+    secretName: __expectString(output.secretName),
   } as any;
 };
 
@@ -9283,7 +9203,7 @@ const deserializeAws_restJson1VirtualNodeConnectionPool = (
 
 const deserializeAws_restJson1VirtualNodeData = (output: any, context: __SerdeContext): VirtualNodeData => {
   return {
-    meshName: output.meshName !== undefined && output.meshName !== null ? output.meshName : undefined,
+    meshName: __expectString(output.meshName),
     metadata:
       output.metadata !== undefined && output.metadata !== null
         ? deserializeAws_restJson1ResourceMetadata(output.metadata, context)
@@ -9296,8 +9216,7 @@ const deserializeAws_restJson1VirtualNodeData = (output: any, context: __SerdeCo
       output.status !== undefined && output.status !== null
         ? deserializeAws_restJson1VirtualNodeStatus(output.status, context)
         : undefined,
-    virtualNodeName:
-      output.virtualNodeName !== undefined && output.virtualNodeName !== null ? output.virtualNodeName : undefined,
+    virtualNodeName: __expectString(output.virtualNodeName),
   } as any;
 };
 
@@ -9306,7 +9225,7 @@ const deserializeAws_restJson1VirtualNodeGrpcConnectionPool = (
   context: __SerdeContext
 ): VirtualNodeGrpcConnectionPool => {
   return {
-    maxRequests: output.maxRequests !== undefined && output.maxRequests !== null ? output.maxRequests : undefined,
+    maxRequests: __expectNumber(output.maxRequests),
   } as any;
 };
 
@@ -9315,7 +9234,7 @@ const deserializeAws_restJson1VirtualNodeHttp2ConnectionPool = (
   context: __SerdeContext
 ): VirtualNodeHttp2ConnectionPool => {
   return {
-    maxRequests: output.maxRequests !== undefined && output.maxRequests !== null ? output.maxRequests : undefined,
+    maxRequests: __expectNumber(output.maxRequests),
   } as any;
 };
 
@@ -9324,12 +9243,8 @@ const deserializeAws_restJson1VirtualNodeHttpConnectionPool = (
   context: __SerdeContext
 ): VirtualNodeHttpConnectionPool => {
   return {
-    maxConnections:
-      output.maxConnections !== undefined && output.maxConnections !== null ? output.maxConnections : undefined,
-    maxPendingRequests:
-      output.maxPendingRequests !== undefined && output.maxPendingRequests !== null
-        ? output.maxPendingRequests
-        : undefined,
+    maxConnections: __expectNumber(output.maxConnections),
+    maxPendingRequests: __expectNumber(output.maxPendingRequests),
   } as any;
 };
 
@@ -9346,7 +9261,7 @@ const deserializeAws_restJson1VirtualNodeList = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1VirtualNodeRef = (output: any, context: __SerdeContext): VirtualNodeRef => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
@@ -9355,13 +9270,11 @@ const deserializeAws_restJson1VirtualNodeRef = (output: any, context: __SerdeCon
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
         ? new Date(Math.round(output.lastUpdatedAt * 1000))
         : undefined,
-    meshName: output.meshName !== undefined && output.meshName !== null ? output.meshName : undefined,
-    meshOwner: output.meshOwner !== undefined && output.meshOwner !== null ? output.meshOwner : undefined,
-    resourceOwner:
-      output.resourceOwner !== undefined && output.resourceOwner !== null ? output.resourceOwner : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
-    virtualNodeName:
-      output.virtualNodeName !== undefined && output.virtualNodeName !== null ? output.virtualNodeName : undefined,
+    meshName: __expectString(output.meshName),
+    meshOwner: __expectString(output.meshOwner),
+    resourceOwner: __expectString(output.resourceOwner),
+    version: __expectNumber(output.version),
+    virtualNodeName: __expectString(output.virtualNodeName),
   } as any;
 };
 
@@ -9370,8 +9283,7 @@ const deserializeAws_restJson1VirtualNodeServiceProvider = (
   context: __SerdeContext
 ): VirtualNodeServiceProvider => {
   return {
-    virtualNodeName:
-      output.virtualNodeName !== undefined && output.virtualNodeName !== null ? output.virtualNodeName : undefined,
+    virtualNodeName: __expectString(output.virtualNodeName),
   } as any;
 };
 
@@ -9402,7 +9314,7 @@ const deserializeAws_restJson1VirtualNodeSpec = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1VirtualNodeStatus = (output: any, context: __SerdeContext): VirtualNodeStatus => {
   return {
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -9411,14 +9323,13 @@ const deserializeAws_restJson1VirtualNodeTcpConnectionPool = (
   context: __SerdeContext
 ): VirtualNodeTcpConnectionPool => {
   return {
-    maxConnections:
-      output.maxConnections !== undefined && output.maxConnections !== null ? output.maxConnections : undefined,
+    maxConnections: __expectNumber(output.maxConnections),
   } as any;
 };
 
 const deserializeAws_restJson1VirtualRouterData = (output: any, context: __SerdeContext): VirtualRouterData => {
   return {
-    meshName: output.meshName !== undefined && output.meshName !== null ? output.meshName : undefined,
+    meshName: __expectString(output.meshName),
     metadata:
       output.metadata !== undefined && output.metadata !== null
         ? deserializeAws_restJson1ResourceMetadata(output.metadata, context)
@@ -9431,10 +9342,7 @@ const deserializeAws_restJson1VirtualRouterData = (output: any, context: __Serde
       output.status !== undefined && output.status !== null
         ? deserializeAws_restJson1VirtualRouterStatus(output.status, context)
         : undefined,
-    virtualRouterName:
-      output.virtualRouterName !== undefined && output.virtualRouterName !== null
-        ? output.virtualRouterName
-        : undefined,
+    virtualRouterName: __expectString(output.virtualRouterName),
   } as any;
 };
 
@@ -9474,7 +9382,7 @@ const deserializeAws_restJson1VirtualRouterListeners = (
 
 const deserializeAws_restJson1VirtualRouterRef = (output: any, context: __SerdeContext): VirtualRouterRef => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
@@ -9483,15 +9391,11 @@ const deserializeAws_restJson1VirtualRouterRef = (output: any, context: __SerdeC
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
         ? new Date(Math.round(output.lastUpdatedAt * 1000))
         : undefined,
-    meshName: output.meshName !== undefined && output.meshName !== null ? output.meshName : undefined,
-    meshOwner: output.meshOwner !== undefined && output.meshOwner !== null ? output.meshOwner : undefined,
-    resourceOwner:
-      output.resourceOwner !== undefined && output.resourceOwner !== null ? output.resourceOwner : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
-    virtualRouterName:
-      output.virtualRouterName !== undefined && output.virtualRouterName !== null
-        ? output.virtualRouterName
-        : undefined,
+    meshName: __expectString(output.meshName),
+    meshOwner: __expectString(output.meshOwner),
+    resourceOwner: __expectString(output.resourceOwner),
+    version: __expectNumber(output.version),
+    virtualRouterName: __expectString(output.virtualRouterName),
   } as any;
 };
 
@@ -9500,10 +9404,7 @@ const deserializeAws_restJson1VirtualRouterServiceProvider = (
   context: __SerdeContext
 ): VirtualRouterServiceProvider => {
   return {
-    virtualRouterName:
-      output.virtualRouterName !== undefined && output.virtualRouterName !== null
-        ? output.virtualRouterName
-        : undefined,
+    virtualRouterName: __expectString(output.virtualRouterName),
   } as any;
 };
 
@@ -9518,7 +9419,7 @@ const deserializeAws_restJson1VirtualRouterSpec = (output: any, context: __Serde
 
 const deserializeAws_restJson1VirtualRouterStatus = (output: any, context: __SerdeContext): VirtualRouterStatus => {
   return {
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -9528,16 +9429,13 @@ const deserializeAws_restJson1VirtualServiceBackend = (output: any, context: __S
       output.clientPolicy !== undefined && output.clientPolicy !== null
         ? deserializeAws_restJson1ClientPolicy(output.clientPolicy, context)
         : undefined,
-    virtualServiceName:
-      output.virtualServiceName !== undefined && output.virtualServiceName !== null
-        ? output.virtualServiceName
-        : undefined,
+    virtualServiceName: __expectString(output.virtualServiceName),
   } as any;
 };
 
 const deserializeAws_restJson1VirtualServiceData = (output: any, context: __SerdeContext): VirtualServiceData => {
   return {
-    meshName: output.meshName !== undefined && output.meshName !== null ? output.meshName : undefined,
+    meshName: __expectString(output.meshName),
     metadata:
       output.metadata !== undefined && output.metadata !== null
         ? deserializeAws_restJson1ResourceMetadata(output.metadata, context)
@@ -9550,10 +9448,7 @@ const deserializeAws_restJson1VirtualServiceData = (output: any, context: __Serd
       output.status !== undefined && output.status !== null
         ? deserializeAws_restJson1VirtualServiceStatus(output.status, context)
         : undefined,
-    virtualServiceName:
-      output.virtualServiceName !== undefined && output.virtualServiceName !== null
-        ? output.virtualServiceName
-        : undefined,
+    virtualServiceName: __expectString(output.virtualServiceName),
   } as any;
 };
 
@@ -9587,7 +9482,7 @@ const deserializeAws_restJson1VirtualServiceProvider = (
 
 const deserializeAws_restJson1VirtualServiceRef = (output: any, context: __SerdeContext): VirtualServiceRef => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
@@ -9596,15 +9491,11 @@ const deserializeAws_restJson1VirtualServiceRef = (output: any, context: __Serde
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
         ? new Date(Math.round(output.lastUpdatedAt * 1000))
         : undefined,
-    meshName: output.meshName !== undefined && output.meshName !== null ? output.meshName : undefined,
-    meshOwner: output.meshOwner !== undefined && output.meshOwner !== null ? output.meshOwner : undefined,
-    resourceOwner:
-      output.resourceOwner !== undefined && output.resourceOwner !== null ? output.resourceOwner : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
-    virtualServiceName:
-      output.virtualServiceName !== undefined && output.virtualServiceName !== null
-        ? output.virtualServiceName
-        : undefined,
+    meshName: __expectString(output.meshName),
+    meshOwner: __expectString(output.meshOwner),
+    resourceOwner: __expectString(output.resourceOwner),
+    version: __expectNumber(output.version),
+    virtualServiceName: __expectString(output.virtualServiceName),
   } as any;
 };
 
@@ -9619,14 +9510,14 @@ const deserializeAws_restJson1VirtualServiceSpec = (output: any, context: __Serd
 
 const deserializeAws_restJson1VirtualServiceStatus = (output: any, context: __SerdeContext): VirtualServiceStatus => {
   return {
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
   } as any;
 };
 
 const deserializeAws_restJson1WeightedTarget = (output: any, context: __SerdeContext): WeightedTarget => {
   return {
-    virtualNode: output.virtualNode !== undefined && output.virtualNode !== null ? output.virtualNode : undefined,
-    weight: output.weight !== undefined && output.weight !== null ? output.weight : undefined,
+    virtualNode: __expectString(output.virtualNode),
+    weight: __expectNumber(output.weight),
   } as any;
 };
 

--- a/clients/client-appconfig/protocols/Aws_restJson1.ts
+++ b/clients/client-appconfig/protocols/Aws_restJson1.ts
@@ -100,6 +100,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -1354,13 +1356,13 @@ export const deserializeAws_restJson1CreateApplicationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   return Promise.resolve(contents);
 };
@@ -1429,22 +1431,22 @@ export const deserializeAws_restJson1CreateConfigurationProfileCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ApplicationId !== undefined && data.ApplicationId !== null) {
-    contents.ApplicationId = data.ApplicationId;
+    contents.ApplicationId = __expectString(data.ApplicationId);
   }
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.LocationUri !== undefined && data.LocationUri !== null) {
-    contents.LocationUri = data.LocationUri;
+    contents.LocationUri = __expectString(data.LocationUri);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.RetrievalRoleArn !== undefined && data.RetrievalRoleArn !== null) {
-    contents.RetrievalRoleArn = data.RetrievalRoleArn;
+    contents.RetrievalRoleArn = __expectString(data.RetrievalRoleArn);
   }
   if (data.Validators !== undefined && data.Validators !== null) {
     contents.Validators = deserializeAws_restJson1ValidatorList(data.Validators, context);
@@ -1525,28 +1527,28 @@ export const deserializeAws_restJson1CreateDeploymentStrategyCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.DeploymentDurationInMinutes !== undefined && data.DeploymentDurationInMinutes !== null) {
-    contents.DeploymentDurationInMinutes = data.DeploymentDurationInMinutes;
+    contents.DeploymentDurationInMinutes = __expectNumber(data.DeploymentDurationInMinutes);
   }
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.FinalBakeTimeInMinutes !== undefined && data.FinalBakeTimeInMinutes !== null) {
-    contents.FinalBakeTimeInMinutes = data.FinalBakeTimeInMinutes;
+    contents.FinalBakeTimeInMinutes = __expectNumber(data.FinalBakeTimeInMinutes);
   }
   if (data.GrowthFactor !== undefined && data.GrowthFactor !== null) {
-    contents.GrowthFactor = data.GrowthFactor;
+    contents.GrowthFactor = __expectNumber(data.GrowthFactor);
   }
   if (data.GrowthType !== undefined && data.GrowthType !== null) {
-    contents.GrowthType = data.GrowthType;
+    contents.GrowthType = __expectString(data.GrowthType);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.ReplicateTo !== undefined && data.ReplicateTo !== null) {
-    contents.ReplicateTo = data.ReplicateTo;
+    contents.ReplicateTo = __expectString(data.ReplicateTo);
   }
   return Promise.resolve(contents);
 };
@@ -1614,22 +1616,22 @@ export const deserializeAws_restJson1CreateEnvironmentCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ApplicationId !== undefined && data.ApplicationId !== null) {
-    contents.ApplicationId = data.ApplicationId;
+    contents.ApplicationId = __expectString(data.ApplicationId);
   }
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.Monitors !== undefined && data.Monitors !== null) {
     contents.Monitors = deserializeAws_restJson1MonitorList(data.Monitors, context);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.State !== undefined && data.State !== null) {
-    contents.State = data.State;
+    contents.State = __expectString(data.State);
   }
   return Promise.resolve(contents);
 };
@@ -2166,13 +2168,13 @@ export const deserializeAws_restJson1GetApplicationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   return Promise.resolve(contents);
 };
@@ -2326,22 +2328,22 @@ export const deserializeAws_restJson1GetConfigurationProfileCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ApplicationId !== undefined && data.ApplicationId !== null) {
-    contents.ApplicationId = data.ApplicationId;
+    contents.ApplicationId = __expectString(data.ApplicationId);
   }
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.LocationUri !== undefined && data.LocationUri !== null) {
-    contents.LocationUri = data.LocationUri;
+    contents.LocationUri = __expectString(data.LocationUri);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.RetrievalRoleArn !== undefined && data.RetrievalRoleArn !== null) {
-    contents.RetrievalRoleArn = data.RetrievalRoleArn;
+    contents.RetrievalRoleArn = __expectString(data.RetrievalRoleArn);
   }
   if (data.Validators !== undefined && data.Validators !== null) {
     contents.Validators = deserializeAws_restJson1ValidatorList(data.Validators, context);
@@ -2432,58 +2434,58 @@ export const deserializeAws_restJson1GetDeploymentCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ApplicationId !== undefined && data.ApplicationId !== null) {
-    contents.ApplicationId = data.ApplicationId;
+    contents.ApplicationId = __expectString(data.ApplicationId);
   }
   if (data.CompletedAt !== undefined && data.CompletedAt !== null) {
     contents.CompletedAt = new Date(data.CompletedAt);
   }
   if (data.ConfigurationLocationUri !== undefined && data.ConfigurationLocationUri !== null) {
-    contents.ConfigurationLocationUri = data.ConfigurationLocationUri;
+    contents.ConfigurationLocationUri = __expectString(data.ConfigurationLocationUri);
   }
   if (data.ConfigurationName !== undefined && data.ConfigurationName !== null) {
-    contents.ConfigurationName = data.ConfigurationName;
+    contents.ConfigurationName = __expectString(data.ConfigurationName);
   }
   if (data.ConfigurationProfileId !== undefined && data.ConfigurationProfileId !== null) {
-    contents.ConfigurationProfileId = data.ConfigurationProfileId;
+    contents.ConfigurationProfileId = __expectString(data.ConfigurationProfileId);
   }
   if (data.ConfigurationVersion !== undefined && data.ConfigurationVersion !== null) {
-    contents.ConfigurationVersion = data.ConfigurationVersion;
+    contents.ConfigurationVersion = __expectString(data.ConfigurationVersion);
   }
   if (data.DeploymentDurationInMinutes !== undefined && data.DeploymentDurationInMinutes !== null) {
-    contents.DeploymentDurationInMinutes = data.DeploymentDurationInMinutes;
+    contents.DeploymentDurationInMinutes = __expectNumber(data.DeploymentDurationInMinutes);
   }
   if (data.DeploymentNumber !== undefined && data.DeploymentNumber !== null) {
-    contents.DeploymentNumber = data.DeploymentNumber;
+    contents.DeploymentNumber = __expectNumber(data.DeploymentNumber);
   }
   if (data.DeploymentStrategyId !== undefined && data.DeploymentStrategyId !== null) {
-    contents.DeploymentStrategyId = data.DeploymentStrategyId;
+    contents.DeploymentStrategyId = __expectString(data.DeploymentStrategyId);
   }
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.EnvironmentId !== undefined && data.EnvironmentId !== null) {
-    contents.EnvironmentId = data.EnvironmentId;
+    contents.EnvironmentId = __expectString(data.EnvironmentId);
   }
   if (data.EventLog !== undefined && data.EventLog !== null) {
     contents.EventLog = deserializeAws_restJson1DeploymentEvents(data.EventLog, context);
   }
   if (data.FinalBakeTimeInMinutes !== undefined && data.FinalBakeTimeInMinutes !== null) {
-    contents.FinalBakeTimeInMinutes = data.FinalBakeTimeInMinutes;
+    contents.FinalBakeTimeInMinutes = __expectNumber(data.FinalBakeTimeInMinutes);
   }
   if (data.GrowthFactor !== undefined && data.GrowthFactor !== null) {
-    contents.GrowthFactor = data.GrowthFactor;
+    contents.GrowthFactor = __expectNumber(data.GrowthFactor);
   }
   if (data.GrowthType !== undefined && data.GrowthType !== null) {
-    contents.GrowthType = data.GrowthType;
+    contents.GrowthType = __expectString(data.GrowthType);
   }
   if (data.PercentageComplete !== undefined && data.PercentageComplete !== null) {
-    contents.PercentageComplete = data.PercentageComplete;
+    contents.PercentageComplete = __expectNumber(data.PercentageComplete);
   }
   if (data.StartedAt !== undefined && data.StartedAt !== null) {
     contents.StartedAt = new Date(data.StartedAt);
   }
   if (data.State !== undefined && data.State !== null) {
-    contents.State = data.State;
+    contents.State = __expectString(data.State);
   }
   return Promise.resolve(contents);
 };
@@ -2561,28 +2563,28 @@ export const deserializeAws_restJson1GetDeploymentStrategyCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.DeploymentDurationInMinutes !== undefined && data.DeploymentDurationInMinutes !== null) {
-    contents.DeploymentDurationInMinutes = data.DeploymentDurationInMinutes;
+    contents.DeploymentDurationInMinutes = __expectNumber(data.DeploymentDurationInMinutes);
   }
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.FinalBakeTimeInMinutes !== undefined && data.FinalBakeTimeInMinutes !== null) {
-    contents.FinalBakeTimeInMinutes = data.FinalBakeTimeInMinutes;
+    contents.FinalBakeTimeInMinutes = __expectNumber(data.FinalBakeTimeInMinutes);
   }
   if (data.GrowthFactor !== undefined && data.GrowthFactor !== null) {
-    contents.GrowthFactor = data.GrowthFactor;
+    contents.GrowthFactor = __expectNumber(data.GrowthFactor);
   }
   if (data.GrowthType !== undefined && data.GrowthType !== null) {
-    contents.GrowthType = data.GrowthType;
+    contents.GrowthType = __expectString(data.GrowthType);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.ReplicateTo !== undefined && data.ReplicateTo !== null) {
-    contents.ReplicateTo = data.ReplicateTo;
+    contents.ReplicateTo = __expectString(data.ReplicateTo);
   }
   return Promise.resolve(contents);
 };
@@ -2658,22 +2660,22 @@ export const deserializeAws_restJson1GetEnvironmentCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ApplicationId !== undefined && data.ApplicationId !== null) {
-    contents.ApplicationId = data.ApplicationId;
+    contents.ApplicationId = __expectString(data.ApplicationId);
   }
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.Monitors !== undefined && data.Monitors !== null) {
     contents.Monitors = deserializeAws_restJson1MonitorList(data.Monitors, context);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.State !== undefined && data.State !== null) {
-    contents.State = data.State;
+    contents.State = __expectString(data.State);
   }
   return Promise.resolve(contents);
 };
@@ -2837,7 +2839,7 @@ export const deserializeAws_restJson1ListApplicationsCommand = async (
     contents.Items = deserializeAws_restJson1ApplicationList(data.Items, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2904,7 +2906,7 @@ export const deserializeAws_restJson1ListConfigurationProfilesCommand = async (
     contents.Items = deserializeAws_restJson1ConfigurationProfileSummaryList(data.Items, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2979,7 +2981,7 @@ export const deserializeAws_restJson1ListDeploymentsCommand = async (
     contents.Items = deserializeAws_restJson1DeploymentList(data.Items, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3054,7 +3056,7 @@ export const deserializeAws_restJson1ListDeploymentStrategiesCommand = async (
     contents.Items = deserializeAws_restJson1DeploymentStrategyList(data.Items, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3121,7 +3123,7 @@ export const deserializeAws_restJson1ListEnvironmentsCommand = async (
     contents.Items = deserializeAws_restJson1EnvironmentList(data.Items, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3196,7 +3198,7 @@ export const deserializeAws_restJson1ListHostedConfigurationVersionsCommand = as
     contents.Items = deserializeAws_restJson1HostedConfigurationVersionSummaryList(data.Items, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3355,58 +3357,58 @@ export const deserializeAws_restJson1StartDeploymentCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ApplicationId !== undefined && data.ApplicationId !== null) {
-    contents.ApplicationId = data.ApplicationId;
+    contents.ApplicationId = __expectString(data.ApplicationId);
   }
   if (data.CompletedAt !== undefined && data.CompletedAt !== null) {
     contents.CompletedAt = new Date(data.CompletedAt);
   }
   if (data.ConfigurationLocationUri !== undefined && data.ConfigurationLocationUri !== null) {
-    contents.ConfigurationLocationUri = data.ConfigurationLocationUri;
+    contents.ConfigurationLocationUri = __expectString(data.ConfigurationLocationUri);
   }
   if (data.ConfigurationName !== undefined && data.ConfigurationName !== null) {
-    contents.ConfigurationName = data.ConfigurationName;
+    contents.ConfigurationName = __expectString(data.ConfigurationName);
   }
   if (data.ConfigurationProfileId !== undefined && data.ConfigurationProfileId !== null) {
-    contents.ConfigurationProfileId = data.ConfigurationProfileId;
+    contents.ConfigurationProfileId = __expectString(data.ConfigurationProfileId);
   }
   if (data.ConfigurationVersion !== undefined && data.ConfigurationVersion !== null) {
-    contents.ConfigurationVersion = data.ConfigurationVersion;
+    contents.ConfigurationVersion = __expectString(data.ConfigurationVersion);
   }
   if (data.DeploymentDurationInMinutes !== undefined && data.DeploymentDurationInMinutes !== null) {
-    contents.DeploymentDurationInMinutes = data.DeploymentDurationInMinutes;
+    contents.DeploymentDurationInMinutes = __expectNumber(data.DeploymentDurationInMinutes);
   }
   if (data.DeploymentNumber !== undefined && data.DeploymentNumber !== null) {
-    contents.DeploymentNumber = data.DeploymentNumber;
+    contents.DeploymentNumber = __expectNumber(data.DeploymentNumber);
   }
   if (data.DeploymentStrategyId !== undefined && data.DeploymentStrategyId !== null) {
-    contents.DeploymentStrategyId = data.DeploymentStrategyId;
+    contents.DeploymentStrategyId = __expectString(data.DeploymentStrategyId);
   }
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.EnvironmentId !== undefined && data.EnvironmentId !== null) {
-    contents.EnvironmentId = data.EnvironmentId;
+    contents.EnvironmentId = __expectString(data.EnvironmentId);
   }
   if (data.EventLog !== undefined && data.EventLog !== null) {
     contents.EventLog = deserializeAws_restJson1DeploymentEvents(data.EventLog, context);
   }
   if (data.FinalBakeTimeInMinutes !== undefined && data.FinalBakeTimeInMinutes !== null) {
-    contents.FinalBakeTimeInMinutes = data.FinalBakeTimeInMinutes;
+    contents.FinalBakeTimeInMinutes = __expectNumber(data.FinalBakeTimeInMinutes);
   }
   if (data.GrowthFactor !== undefined && data.GrowthFactor !== null) {
-    contents.GrowthFactor = data.GrowthFactor;
+    contents.GrowthFactor = __expectNumber(data.GrowthFactor);
   }
   if (data.GrowthType !== undefined && data.GrowthType !== null) {
-    contents.GrowthType = data.GrowthType;
+    contents.GrowthType = __expectString(data.GrowthType);
   }
   if (data.PercentageComplete !== undefined && data.PercentageComplete !== null) {
-    contents.PercentageComplete = data.PercentageComplete;
+    contents.PercentageComplete = __expectNumber(data.PercentageComplete);
   }
   if (data.StartedAt !== undefined && data.StartedAt !== null) {
     contents.StartedAt = new Date(data.StartedAt);
   }
   if (data.State !== undefined && data.State !== null) {
-    contents.State = data.State;
+    contents.State = __expectString(data.State);
   }
   return Promise.resolve(contents);
 };
@@ -3502,58 +3504,58 @@ export const deserializeAws_restJson1StopDeploymentCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ApplicationId !== undefined && data.ApplicationId !== null) {
-    contents.ApplicationId = data.ApplicationId;
+    contents.ApplicationId = __expectString(data.ApplicationId);
   }
   if (data.CompletedAt !== undefined && data.CompletedAt !== null) {
     contents.CompletedAt = new Date(data.CompletedAt);
   }
   if (data.ConfigurationLocationUri !== undefined && data.ConfigurationLocationUri !== null) {
-    contents.ConfigurationLocationUri = data.ConfigurationLocationUri;
+    contents.ConfigurationLocationUri = __expectString(data.ConfigurationLocationUri);
   }
   if (data.ConfigurationName !== undefined && data.ConfigurationName !== null) {
-    contents.ConfigurationName = data.ConfigurationName;
+    contents.ConfigurationName = __expectString(data.ConfigurationName);
   }
   if (data.ConfigurationProfileId !== undefined && data.ConfigurationProfileId !== null) {
-    contents.ConfigurationProfileId = data.ConfigurationProfileId;
+    contents.ConfigurationProfileId = __expectString(data.ConfigurationProfileId);
   }
   if (data.ConfigurationVersion !== undefined && data.ConfigurationVersion !== null) {
-    contents.ConfigurationVersion = data.ConfigurationVersion;
+    contents.ConfigurationVersion = __expectString(data.ConfigurationVersion);
   }
   if (data.DeploymentDurationInMinutes !== undefined && data.DeploymentDurationInMinutes !== null) {
-    contents.DeploymentDurationInMinutes = data.DeploymentDurationInMinutes;
+    contents.DeploymentDurationInMinutes = __expectNumber(data.DeploymentDurationInMinutes);
   }
   if (data.DeploymentNumber !== undefined && data.DeploymentNumber !== null) {
-    contents.DeploymentNumber = data.DeploymentNumber;
+    contents.DeploymentNumber = __expectNumber(data.DeploymentNumber);
   }
   if (data.DeploymentStrategyId !== undefined && data.DeploymentStrategyId !== null) {
-    contents.DeploymentStrategyId = data.DeploymentStrategyId;
+    contents.DeploymentStrategyId = __expectString(data.DeploymentStrategyId);
   }
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.EnvironmentId !== undefined && data.EnvironmentId !== null) {
-    contents.EnvironmentId = data.EnvironmentId;
+    contents.EnvironmentId = __expectString(data.EnvironmentId);
   }
   if (data.EventLog !== undefined && data.EventLog !== null) {
     contents.EventLog = deserializeAws_restJson1DeploymentEvents(data.EventLog, context);
   }
   if (data.FinalBakeTimeInMinutes !== undefined && data.FinalBakeTimeInMinutes !== null) {
-    contents.FinalBakeTimeInMinutes = data.FinalBakeTimeInMinutes;
+    contents.FinalBakeTimeInMinutes = __expectNumber(data.FinalBakeTimeInMinutes);
   }
   if (data.GrowthFactor !== undefined && data.GrowthFactor !== null) {
-    contents.GrowthFactor = data.GrowthFactor;
+    contents.GrowthFactor = __expectNumber(data.GrowthFactor);
   }
   if (data.GrowthType !== undefined && data.GrowthType !== null) {
-    contents.GrowthType = data.GrowthType;
+    contents.GrowthType = __expectString(data.GrowthType);
   }
   if (data.PercentageComplete !== undefined && data.PercentageComplete !== null) {
-    contents.PercentageComplete = data.PercentageComplete;
+    contents.PercentageComplete = __expectNumber(data.PercentageComplete);
   }
   if (data.StartedAt !== undefined && data.StartedAt !== null) {
     contents.StartedAt = new Date(data.StartedAt);
   }
   if (data.State !== undefined && data.State !== null) {
-    contents.State = data.State;
+    contents.State = __expectString(data.State);
   }
   return Promise.resolve(contents);
 };
@@ -3760,13 +3762,13 @@ export const deserializeAws_restJson1UpdateApplicationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   return Promise.resolve(contents);
 };
@@ -3843,22 +3845,22 @@ export const deserializeAws_restJson1UpdateConfigurationProfileCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ApplicationId !== undefined && data.ApplicationId !== null) {
-    contents.ApplicationId = data.ApplicationId;
+    contents.ApplicationId = __expectString(data.ApplicationId);
   }
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.LocationUri !== undefined && data.LocationUri !== null) {
-    contents.LocationUri = data.LocationUri;
+    contents.LocationUri = __expectString(data.LocationUri);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.RetrievalRoleArn !== undefined && data.RetrievalRoleArn !== null) {
-    contents.RetrievalRoleArn = data.RetrievalRoleArn;
+    contents.RetrievalRoleArn = __expectString(data.RetrievalRoleArn);
   }
   if (data.Validators !== undefined && data.Validators !== null) {
     contents.Validators = deserializeAws_restJson1ValidatorList(data.Validators, context);
@@ -3939,28 +3941,28 @@ export const deserializeAws_restJson1UpdateDeploymentStrategyCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.DeploymentDurationInMinutes !== undefined && data.DeploymentDurationInMinutes !== null) {
-    contents.DeploymentDurationInMinutes = data.DeploymentDurationInMinutes;
+    contents.DeploymentDurationInMinutes = __expectNumber(data.DeploymentDurationInMinutes);
   }
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.FinalBakeTimeInMinutes !== undefined && data.FinalBakeTimeInMinutes !== null) {
-    contents.FinalBakeTimeInMinutes = data.FinalBakeTimeInMinutes;
+    contents.FinalBakeTimeInMinutes = __expectNumber(data.FinalBakeTimeInMinutes);
   }
   if (data.GrowthFactor !== undefined && data.GrowthFactor !== null) {
-    contents.GrowthFactor = data.GrowthFactor;
+    contents.GrowthFactor = __expectNumber(data.GrowthFactor);
   }
   if (data.GrowthType !== undefined && data.GrowthType !== null) {
-    contents.GrowthType = data.GrowthType;
+    contents.GrowthType = __expectString(data.GrowthType);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.ReplicateTo !== undefined && data.ReplicateTo !== null) {
-    contents.ReplicateTo = data.ReplicateTo;
+    contents.ReplicateTo = __expectString(data.ReplicateTo);
   }
   return Promise.resolve(contents);
 };
@@ -4036,22 +4038,22 @@ export const deserializeAws_restJson1UpdateEnvironmentCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ApplicationId !== undefined && data.ApplicationId !== null) {
-    contents.ApplicationId = data.ApplicationId;
+    contents.ApplicationId = __expectString(data.ApplicationId);
   }
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.Monitors !== undefined && data.Monitors !== null) {
     contents.Monitors = deserializeAws_restJson1MonitorList(data.Monitors, context);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.State !== undefined && data.State !== null) {
-    contents.State = data.State;
+    contents.State = __expectString(data.State);
   }
   return Promise.resolve(contents);
 };
@@ -4188,7 +4190,7 @@ const deserializeAws_restJson1BadRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -4205,7 +4207,7 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -4222,7 +4224,7 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -4242,16 +4244,16 @@ const deserializeAws_restJson1PayloadTooLargeExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Limit !== undefined && data.Limit !== null) {
-    contents.Limit = data.Limit;
+    contents.Limit = __expectNumber(data.Limit);
   }
   if (data.Measure !== undefined && data.Measure !== null) {
-    contents.Measure = data.Measure;
+    contents.Measure = __expectString(data.Measure);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.Size !== undefined && data.Size !== null) {
-    contents.Size = data.Size;
+    contents.Size = __expectNumber(data.Size);
   }
   return contents;
 };
@@ -4269,10 +4271,10 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.ResourceName !== undefined && data.ResourceName !== null) {
-    contents.ResourceName = data.ResourceName;
+    contents.ResourceName = __expectString(data.ResourceName);
   }
   return contents;
 };
@@ -4289,7 +4291,7 @@ const deserializeAws_restJson1ServiceQuotaExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -4344,9 +4346,9 @@ const serializeAws_restJson1ValidatorList = (input: Validator[], context: __Serd
 
 const deserializeAws_restJson1Application = (output: any, context: __SerdeContext): Application => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Description: __expectString(output.Description),
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -4366,11 +4368,10 @@ const deserializeAws_restJson1ConfigurationProfileSummary = (
   context: __SerdeContext
 ): ConfigurationProfileSummary => {
   return {
-    ApplicationId:
-      output.ApplicationId !== undefined && output.ApplicationId !== null ? output.ApplicationId : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    LocationUri: output.LocationUri !== undefined && output.LocationUri !== null ? output.LocationUri : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    ApplicationId: __expectString(output.ApplicationId),
+    Id: __expectString(output.Id),
+    LocationUri: __expectString(output.LocationUri),
+    Name: __expectString(output.Name),
     ValidatorTypes:
       output.ValidatorTypes !== undefined && output.ValidatorTypes !== null
         ? deserializeAws_restJson1ValidatorTypeList(output.ValidatorTypes, context)
@@ -4394,10 +4395,10 @@ const deserializeAws_restJson1ConfigurationProfileSummaryList = (
 
 const deserializeAws_restJson1DeploymentEvent = (output: any, context: __SerdeContext): DeploymentEvent => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    EventType: output.EventType !== undefined && output.EventType !== null ? output.EventType : undefined,
+    Description: __expectString(output.Description),
+    EventType: __expectString(output.EventType),
     OccurredAt: output.OccurredAt !== undefined && output.OccurredAt !== null ? new Date(output.OccurredAt) : undefined,
-    TriggeredBy: output.TriggeredBy !== undefined && output.TriggeredBy !== null ? output.TriggeredBy : undefined,
+    TriggeredBy: __expectString(output.TriggeredBy),
   } as any;
 };
 
@@ -4425,20 +4426,14 @@ const deserializeAws_restJson1DeploymentList = (output: any, context: __SerdeCon
 
 const deserializeAws_restJson1DeploymentStrategy = (output: any, context: __SerdeContext): DeploymentStrategy => {
   return {
-    DeploymentDurationInMinutes:
-      output.DeploymentDurationInMinutes !== undefined && output.DeploymentDurationInMinutes !== null
-        ? output.DeploymentDurationInMinutes
-        : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    FinalBakeTimeInMinutes:
-      output.FinalBakeTimeInMinutes !== undefined && output.FinalBakeTimeInMinutes !== null
-        ? output.FinalBakeTimeInMinutes
-        : undefined,
-    GrowthFactor: output.GrowthFactor !== undefined && output.GrowthFactor !== null ? output.GrowthFactor : undefined,
-    GrowthType: output.GrowthType !== undefined && output.GrowthType !== null ? output.GrowthType : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    ReplicateTo: output.ReplicateTo !== undefined && output.ReplicateTo !== null ? output.ReplicateTo : undefined,
+    DeploymentDurationInMinutes: __expectNumber(output.DeploymentDurationInMinutes),
+    Description: __expectString(output.Description),
+    FinalBakeTimeInMinutes: __expectNumber(output.FinalBakeTimeInMinutes),
+    GrowthFactor: __expectNumber(output.GrowthFactor),
+    GrowthType: __expectString(output.GrowthType),
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
+    ReplicateTo: __expectString(output.ReplicateTo),
   } as any;
 };
 
@@ -4457,47 +4452,30 @@ const deserializeAws_restJson1DeploymentSummary = (output: any, context: __Serde
   return {
     CompletedAt:
       output.CompletedAt !== undefined && output.CompletedAt !== null ? new Date(output.CompletedAt) : undefined,
-    ConfigurationName:
-      output.ConfigurationName !== undefined && output.ConfigurationName !== null
-        ? output.ConfigurationName
-        : undefined,
-    ConfigurationVersion:
-      output.ConfigurationVersion !== undefined && output.ConfigurationVersion !== null
-        ? output.ConfigurationVersion
-        : undefined,
-    DeploymentDurationInMinutes:
-      output.DeploymentDurationInMinutes !== undefined && output.DeploymentDurationInMinutes !== null
-        ? output.DeploymentDurationInMinutes
-        : undefined,
-    DeploymentNumber:
-      output.DeploymentNumber !== undefined && output.DeploymentNumber !== null ? output.DeploymentNumber : undefined,
-    FinalBakeTimeInMinutes:
-      output.FinalBakeTimeInMinutes !== undefined && output.FinalBakeTimeInMinutes !== null
-        ? output.FinalBakeTimeInMinutes
-        : undefined,
-    GrowthFactor: output.GrowthFactor !== undefined && output.GrowthFactor !== null ? output.GrowthFactor : undefined,
-    GrowthType: output.GrowthType !== undefined && output.GrowthType !== null ? output.GrowthType : undefined,
-    PercentageComplete:
-      output.PercentageComplete !== undefined && output.PercentageComplete !== null
-        ? output.PercentageComplete
-        : undefined,
+    ConfigurationName: __expectString(output.ConfigurationName),
+    ConfigurationVersion: __expectString(output.ConfigurationVersion),
+    DeploymentDurationInMinutes: __expectNumber(output.DeploymentDurationInMinutes),
+    DeploymentNumber: __expectNumber(output.DeploymentNumber),
+    FinalBakeTimeInMinutes: __expectNumber(output.FinalBakeTimeInMinutes),
+    GrowthFactor: __expectNumber(output.GrowthFactor),
+    GrowthType: __expectString(output.GrowthType),
+    PercentageComplete: __expectNumber(output.PercentageComplete),
     StartedAt: output.StartedAt !== undefined && output.StartedAt !== null ? new Date(output.StartedAt) : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    State: __expectString(output.State),
   } as any;
 };
 
 const deserializeAws_restJson1Environment = (output: any, context: __SerdeContext): Environment => {
   return {
-    ApplicationId:
-      output.ApplicationId !== undefined && output.ApplicationId !== null ? output.ApplicationId : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    ApplicationId: __expectString(output.ApplicationId),
+    Description: __expectString(output.Description),
+    Id: __expectString(output.Id),
     Monitors:
       output.Monitors !== undefined && output.Monitors !== null
         ? deserializeAws_restJson1MonitorList(output.Monitors, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    Name: __expectString(output.Name),
+    State: __expectString(output.State),
   } as any;
 };
 
@@ -4517,16 +4495,11 @@ const deserializeAws_restJson1HostedConfigurationVersionSummary = (
   context: __SerdeContext
 ): HostedConfigurationVersionSummary => {
   return {
-    ApplicationId:
-      output.ApplicationId !== undefined && output.ApplicationId !== null ? output.ApplicationId : undefined,
-    ConfigurationProfileId:
-      output.ConfigurationProfileId !== undefined && output.ConfigurationProfileId !== null
-        ? output.ConfigurationProfileId
-        : undefined,
-    ContentType: output.ContentType !== undefined && output.ContentType !== null ? output.ContentType : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    VersionNumber:
-      output.VersionNumber !== undefined && output.VersionNumber !== null ? output.VersionNumber : undefined,
+    ApplicationId: __expectString(output.ApplicationId),
+    ConfigurationProfileId: __expectString(output.ConfigurationProfileId),
+    ContentType: __expectString(output.ContentType),
+    Description: __expectString(output.Description),
+    VersionNumber: __expectNumber(output.VersionNumber),
   } as any;
 };
 
@@ -4546,8 +4519,8 @@ const deserializeAws_restJson1HostedConfigurationVersionSummaryList = (
 
 const deserializeAws_restJson1Monitor = (output: any, context: __SerdeContext): Monitor => {
   return {
-    AlarmArn: output.AlarmArn !== undefined && output.AlarmArn !== null ? output.AlarmArn : undefined,
-    AlarmRoleArn: output.AlarmRoleArn !== undefined && output.AlarmRoleArn !== null ? output.AlarmRoleArn : undefined,
+    AlarmArn: __expectString(output.AlarmArn),
+    AlarmRoleArn: __expectString(output.AlarmRoleArn),
   } as any;
 };
 
@@ -4569,15 +4542,15 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1Validator = (output: any, context: __SerdeContext): Validator => {
   return {
-    Content: output.Content !== undefined && output.Content !== null ? output.Content : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Content: __expectString(output.Content),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -4602,7 +4575,7 @@ const deserializeAws_restJson1ValidatorTypeList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 

--- a/clients/client-appflow/protocols/Aws_restJson1.ts
+++ b/clients/client-appflow/protocols/Aws_restJson1.ts
@@ -168,6 +168,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -720,7 +723,7 @@ export const deserializeAws_restJson1CreateConnectorProfileCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.connectorProfileArn !== undefined && data.connectorProfileArn !== null) {
-    contents.connectorProfileArn = data.connectorProfileArn;
+    contents.connectorProfileArn = __expectString(data.connectorProfileArn);
   }
   return Promise.resolve(contents);
 };
@@ -808,10 +811,10 @@ export const deserializeAws_restJson1CreateFlowCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.flowArn !== undefined && data.flowArn !== null) {
-    contents.flowArn = data.flowArn;
+    contents.flowArn = __expectString(data.flowArn);
   }
   if (data.flowStatus !== undefined && data.flowStatus !== null) {
-    contents.flowStatus = data.flowStatus;
+    contents.flowStatus = __expectString(data.flowStatus);
   }
   return Promise.resolve(contents);
 };
@@ -1145,7 +1148,7 @@ export const deserializeAws_restJson1DescribeConnectorProfilesCommand = async (
     );
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1215,7 +1218,7 @@ export const deserializeAws_restJson1DescribeConnectorsCommand = async (
     );
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1296,10 +1299,10 @@ export const deserializeAws_restJson1DescribeFlowCommand = async (
     contents.createdAt = new Date(Math.round(data.createdAt * 1000));
   }
   if (data.createdBy !== undefined && data.createdBy !== null) {
-    contents.createdBy = data.createdBy;
+    contents.createdBy = __expectString(data.createdBy);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.destinationFlowConfigList !== undefined && data.destinationFlowConfigList !== null) {
     contents.destinationFlowConfigList = deserializeAws_restJson1DestinationFlowConfigList(
@@ -1308,19 +1311,19 @@ export const deserializeAws_restJson1DescribeFlowCommand = async (
     );
   }
   if (data.flowArn !== undefined && data.flowArn !== null) {
-    contents.flowArn = data.flowArn;
+    contents.flowArn = __expectString(data.flowArn);
   }
   if (data.flowName !== undefined && data.flowName !== null) {
-    contents.flowName = data.flowName;
+    contents.flowName = __expectString(data.flowName);
   }
   if (data.flowStatus !== undefined && data.flowStatus !== null) {
-    contents.flowStatus = data.flowStatus;
+    contents.flowStatus = __expectString(data.flowStatus);
   }
   if (data.flowStatusMessage !== undefined && data.flowStatusMessage !== null) {
-    contents.flowStatusMessage = data.flowStatusMessage;
+    contents.flowStatusMessage = __expectString(data.flowStatusMessage);
   }
   if (data.kmsArn !== undefined && data.kmsArn !== null) {
-    contents.kmsArn = data.kmsArn;
+    contents.kmsArn = __expectString(data.kmsArn);
   }
   if (data.lastRunExecutionDetails !== undefined && data.lastRunExecutionDetails !== null) {
     contents.lastRunExecutionDetails = deserializeAws_restJson1ExecutionDetails(data.lastRunExecutionDetails, context);
@@ -1329,7 +1332,7 @@ export const deserializeAws_restJson1DescribeFlowCommand = async (
     contents.lastUpdatedAt = new Date(Math.round(data.lastUpdatedAt * 1000));
   }
   if (data.lastUpdatedBy !== undefined && data.lastUpdatedBy !== null) {
-    contents.lastUpdatedBy = data.lastUpdatedBy;
+    contents.lastUpdatedBy = __expectString(data.lastUpdatedBy);
   }
   if (data.sourceFlowConfig !== undefined && data.sourceFlowConfig !== null) {
     contents.sourceFlowConfig = deserializeAws_restJson1SourceFlowConfig(data.sourceFlowConfig, context);
@@ -1408,7 +1411,7 @@ export const deserializeAws_restJson1DescribeFlowExecutionRecordsCommand = async
     contents.flowExecutions = deserializeAws_restJson1FlowExecutionList(data.flowExecutions, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1570,7 +1573,7 @@ export const deserializeAws_restJson1ListFlowsCommand = async (
     contents.flows = deserializeAws_restJson1FlowList(data.flows, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1706,13 +1709,13 @@ export const deserializeAws_restJson1StartFlowCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.executionId !== undefined && data.executionId !== null) {
-    contents.executionId = data.executionId;
+    contents.executionId = __expectString(data.executionId);
   }
   if (data.flowArn !== undefined && data.flowArn !== null) {
-    contents.flowArn = data.flowArn;
+    contents.flowArn = __expectString(data.flowArn);
   }
   if (data.flowStatus !== undefined && data.flowStatus !== null) {
-    contents.flowStatus = data.flowStatus;
+    contents.flowStatus = __expectString(data.flowStatus);
   }
   return Promise.resolve(contents);
 };
@@ -1792,10 +1795,10 @@ export const deserializeAws_restJson1StopFlowCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.flowArn !== undefined && data.flowArn !== null) {
-    contents.flowArn = data.flowArn;
+    contents.flowArn = __expectString(data.flowArn);
   }
   if (data.flowStatus !== undefined && data.flowStatus !== null) {
-    contents.flowStatus = data.flowStatus;
+    contents.flowStatus = __expectString(data.flowStatus);
   }
   return Promise.resolve(contents);
 };
@@ -2008,7 +2011,7 @@ export const deserializeAws_restJson1UpdateConnectorProfileCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.connectorProfileArn !== undefined && data.connectorProfileArn !== null) {
-    contents.connectorProfileArn = data.connectorProfileArn;
+    contents.connectorProfileArn = __expectString(data.connectorProfileArn);
   }
   return Promise.resolve(contents);
 };
@@ -2095,7 +2098,7 @@ export const deserializeAws_restJson1UpdateFlowCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.flowStatus !== undefined && data.flowStatus !== null) {
-    contents.flowStatus = data.flowStatus;
+    contents.flowStatus = __expectString(data.flowStatus);
   }
   return Promise.resolve(contents);
 };
@@ -2197,7 +2200,7 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2214,7 +2217,7 @@ const deserializeAws_restJson1ConnectorAuthenticationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2231,7 +2234,7 @@ const deserializeAws_restJson1ConnectorServerExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2248,7 +2251,7 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2265,7 +2268,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2282,7 +2285,7 @@ const deserializeAws_restJson1ServiceQuotaExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2299,7 +2302,7 @@ const deserializeAws_restJson1UnsupportedOperationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2316,7 +2319,7 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -3455,8 +3458,7 @@ const serializeAws_restJson1ZendeskSourceProperties = (
 
 const deserializeAws_restJson1AggregationConfig = (output: any, context: __SerdeContext): AggregationConfig => {
   return {
-    aggregationType:
-      output.aggregationType !== undefined && output.aggregationType !== null ? output.aggregationType : undefined,
+    aggregationType: __expectString(output.aggregationType),
   } as any;
 };
 
@@ -3476,7 +3478,7 @@ const deserializeAws_restJson1AmplitudeSourceProperties = (
   context: __SerdeContext
 ): AmplitudeSourceProperties => {
   return {
-    object: output.object !== undefined && output.object !== null ? output.object : undefined,
+    object: __expectString(output.object),
   } as any;
 };
 
@@ -3485,24 +3487,14 @@ const deserializeAws_restJson1ConnectorConfiguration = (
   context: __SerdeContext
 ): ConnectorConfiguration => {
   return {
-    canUseAsDestination:
-      output.canUseAsDestination !== undefined && output.canUseAsDestination !== null
-        ? output.canUseAsDestination
-        : undefined,
-    canUseAsSource:
-      output.canUseAsSource !== undefined && output.canUseAsSource !== null ? output.canUseAsSource : undefined,
+    canUseAsDestination: __expectBoolean(output.canUseAsDestination),
+    canUseAsSource: __expectBoolean(output.canUseAsSource),
     connectorMetadata:
       output.connectorMetadata !== undefined && output.connectorMetadata !== null
         ? deserializeAws_restJson1ConnectorMetadata(output.connectorMetadata, context)
         : undefined,
-    isPrivateLinkEnabled:
-      output.isPrivateLinkEnabled !== undefined && output.isPrivateLinkEnabled !== null
-        ? output.isPrivateLinkEnabled
-        : undefined,
-    isPrivateLinkEndpointUrlRequired:
-      output.isPrivateLinkEndpointUrlRequired !== undefined && output.isPrivateLinkEndpointUrlRequired !== null
-        ? output.isPrivateLinkEndpointUrlRequired
-        : undefined,
+    isPrivateLinkEnabled: __expectBoolean(output.isPrivateLinkEnabled),
+    isPrivateLinkEndpointUrlRequired: __expectBoolean(output.isPrivateLinkEndpointUrlRequired),
     supportedDestinationConnectors:
       output.supportedDestinationConnectors !== undefined && output.supportedDestinationConnectors !== null
         ? deserializeAws_restJson1ConnectorTypeList(output.supportedDestinationConnectors, context)
@@ -3538,24 +3530,21 @@ const deserializeAws_restJson1ConnectorConfigurationsMap = (
 
 const deserializeAws_restJson1ConnectorEntity = (output: any, context: __SerdeContext): ConnectorEntity => {
   return {
-    hasNestedEntities:
-      output.hasNestedEntities !== undefined && output.hasNestedEntities !== null
-        ? output.hasNestedEntities
-        : undefined,
-    label: output.label !== undefined && output.label !== null ? output.label : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    hasNestedEntities: __expectBoolean(output.hasNestedEntities),
+    label: __expectString(output.label),
+    name: __expectString(output.name),
   } as any;
 };
 
 const deserializeAws_restJson1ConnectorEntityField = (output: any, context: __SerdeContext): ConnectorEntityField => {
   return {
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    description: __expectString(output.description),
     destinationProperties:
       output.destinationProperties !== undefined && output.destinationProperties !== null
         ? deserializeAws_restJson1DestinationFieldProperties(output.destinationProperties, context)
         : undefined,
-    identifier: output.identifier !== undefined && output.identifier !== null ? output.identifier : undefined,
-    label: output.label !== undefined && output.label !== null ? output.label : undefined,
+    identifier: __expectString(output.identifier),
+    label: __expectString(output.label),
     sourceProperties:
       output.sourceProperties !== undefined && output.sourceProperties !== null
         ? deserializeAws_restJson1SourceFieldProperties(output.sourceProperties, context)
@@ -3694,48 +3683,38 @@ const deserializeAws_restJson1ConnectorMetadata = (output: any, context: __Serde
 
 const deserializeAws_restJson1ConnectorOperator = (output: any, context: __SerdeContext): ConnectorOperator => {
   return {
-    Amplitude: output.Amplitude !== undefined && output.Amplitude !== null ? output.Amplitude : undefined,
-    Datadog: output.Datadog !== undefined && output.Datadog !== null ? output.Datadog : undefined,
-    Dynatrace: output.Dynatrace !== undefined && output.Dynatrace !== null ? output.Dynatrace : undefined,
-    GoogleAnalytics:
-      output.GoogleAnalytics !== undefined && output.GoogleAnalytics !== null ? output.GoogleAnalytics : undefined,
-    InforNexus: output.InforNexus !== undefined && output.InforNexus !== null ? output.InforNexus : undefined,
-    Marketo: output.Marketo !== undefined && output.Marketo !== null ? output.Marketo : undefined,
-    S3: output.S3 !== undefined && output.S3 !== null ? output.S3 : undefined,
-    Salesforce: output.Salesforce !== undefined && output.Salesforce !== null ? output.Salesforce : undefined,
-    ServiceNow: output.ServiceNow !== undefined && output.ServiceNow !== null ? output.ServiceNow : undefined,
-    Singular: output.Singular !== undefined && output.Singular !== null ? output.Singular : undefined,
-    Slack: output.Slack !== undefined && output.Slack !== null ? output.Slack : undefined,
-    Trendmicro: output.Trendmicro !== undefined && output.Trendmicro !== null ? output.Trendmicro : undefined,
-    Veeva: output.Veeva !== undefined && output.Veeva !== null ? output.Veeva : undefined,
-    Zendesk: output.Zendesk !== undefined && output.Zendesk !== null ? output.Zendesk : undefined,
+    Amplitude: __expectString(output.Amplitude),
+    Datadog: __expectString(output.Datadog),
+    Dynatrace: __expectString(output.Dynatrace),
+    GoogleAnalytics: __expectString(output.GoogleAnalytics),
+    InforNexus: __expectString(output.InforNexus),
+    Marketo: __expectString(output.Marketo),
+    S3: __expectString(output.S3),
+    Salesforce: __expectString(output.Salesforce),
+    ServiceNow: __expectString(output.ServiceNow),
+    Singular: __expectString(output.Singular),
+    Slack: __expectString(output.Slack),
+    Trendmicro: __expectString(output.Trendmicro),
+    Veeva: __expectString(output.Veeva),
+    Zendesk: __expectString(output.Zendesk),
   } as any;
 };
 
 const deserializeAws_restJson1ConnectorProfile = (output: any, context: __SerdeContext): ConnectorProfile => {
   return {
-    connectionMode:
-      output.connectionMode !== undefined && output.connectionMode !== null ? output.connectionMode : undefined,
-    connectorProfileArn:
-      output.connectorProfileArn !== undefined && output.connectorProfileArn !== null
-        ? output.connectorProfileArn
-        : undefined,
-    connectorProfileName:
-      output.connectorProfileName !== undefined && output.connectorProfileName !== null
-        ? output.connectorProfileName
-        : undefined,
+    connectionMode: __expectString(output.connectionMode),
+    connectorProfileArn: __expectString(output.connectorProfileArn),
+    connectorProfileName: __expectString(output.connectorProfileName),
     connectorProfileProperties:
       output.connectorProfileProperties !== undefined && output.connectorProfileProperties !== null
         ? deserializeAws_restJson1ConnectorProfileProperties(output.connectorProfileProperties, context)
         : undefined,
-    connectorType:
-      output.connectorType !== undefined && output.connectorType !== null ? output.connectorType : undefined,
+    connectorType: __expectString(output.connectorType),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    credentialsArn:
-      output.credentialsArn !== undefined && output.credentialsArn !== null ? output.credentialsArn : undefined,
+    credentialsArn: __expectString(output.credentialsArn),
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
         ? new Date(Math.round(output.lastUpdatedAt * 1000))
@@ -3839,7 +3818,7 @@ const deserializeAws_restJson1ConnectorTypeList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3848,9 +3827,8 @@ const deserializeAws_restJson1CustomerProfilesDestinationProperties = (
   context: __SerdeContext
 ): CustomerProfilesDestinationProperties => {
   return {
-    domainName: output.domainName !== undefined && output.domainName !== null ? output.domainName : undefined,
-    objectTypeName:
-      output.objectTypeName !== undefined && output.objectTypeName !== null ? output.objectTypeName : undefined,
+    domainName: __expectString(output.domainName),
+    objectTypeName: __expectString(output.objectTypeName),
   } as any;
 };
 
@@ -3866,7 +3844,7 @@ const deserializeAws_restJson1DatadogConnectorProfileProperties = (
   context: __SerdeContext
 ): DatadogConnectorProfileProperties => {
   return {
-    instanceUrl: output.instanceUrl !== undefined && output.instanceUrl !== null ? output.instanceUrl : undefined,
+    instanceUrl: __expectString(output.instanceUrl),
   } as any;
 };
 
@@ -3879,7 +3857,7 @@ const deserializeAws_restJson1DatadogSourceProperties = (
   context: __SerdeContext
 ): DatadogSourceProperties => {
   return {
-    object: output.object !== undefined && output.object !== null ? output.object : undefined,
+    object: __expectString(output.object),
   } as any;
 };
 
@@ -3936,10 +3914,10 @@ const deserializeAws_restJson1DestinationFieldProperties = (
   context: __SerdeContext
 ): DestinationFieldProperties => {
   return {
-    isCreatable: output.isCreatable !== undefined && output.isCreatable !== null ? output.isCreatable : undefined,
-    isNullable: output.isNullable !== undefined && output.isNullable !== null ? output.isNullable : undefined,
-    isUpdatable: output.isUpdatable !== undefined && output.isUpdatable !== null ? output.isUpdatable : undefined,
-    isUpsertable: output.isUpsertable !== undefined && output.isUpsertable !== null ? output.isUpsertable : undefined,
+    isCreatable: __expectBoolean(output.isCreatable),
+    isNullable: __expectBoolean(output.isNullable),
+    isUpdatable: __expectBoolean(output.isUpdatable),
+    isUpsertable: __expectBoolean(output.isUpsertable),
     supportedWriteOperations:
       output.supportedWriteOperations !== undefined && output.supportedWriteOperations !== null
         ? deserializeAws_restJson1SupportedWriteOperationList(output.supportedWriteOperations, context)
@@ -3949,12 +3927,8 @@ const deserializeAws_restJson1DestinationFieldProperties = (
 
 const deserializeAws_restJson1DestinationFlowConfig = (output: any, context: __SerdeContext): DestinationFlowConfig => {
   return {
-    connectorProfileName:
-      output.connectorProfileName !== undefined && output.connectorProfileName !== null
-        ? output.connectorProfileName
-        : undefined,
-    connectorType:
-      output.connectorType !== undefined && output.connectorType !== null ? output.connectorType : undefined,
+    connectorProfileName: __expectString(output.connectorProfileName),
+    connectorType: __expectString(output.connectorType),
     destinationConnectorProperties:
       output.destinationConnectorProperties !== undefined && output.destinationConnectorProperties !== null
         ? deserializeAws_restJson1DestinationConnectorProperties(output.destinationConnectorProperties, context)
@@ -3981,7 +3955,7 @@ const deserializeAws_restJson1DynatraceConnectorProfileProperties = (
   context: __SerdeContext
 ): DynatraceConnectorProfileProperties => {
   return {
-    instanceUrl: output.instanceUrl !== undefined && output.instanceUrl !== null ? output.instanceUrl : undefined,
+    instanceUrl: __expectString(output.instanceUrl),
   } as any;
 };
 
@@ -3994,27 +3968,22 @@ const deserializeAws_restJson1DynatraceSourceProperties = (
   context: __SerdeContext
 ): DynatraceSourceProperties => {
   return {
-    object: output.object !== undefined && output.object !== null ? output.object : undefined,
+    object: __expectString(output.object),
   } as any;
 };
 
 const deserializeAws_restJson1ErrorHandlingConfig = (output: any, context: __SerdeContext): ErrorHandlingConfig => {
   return {
-    bucketName: output.bucketName !== undefined && output.bucketName !== null ? output.bucketName : undefined,
-    bucketPrefix: output.bucketPrefix !== undefined && output.bucketPrefix !== null ? output.bucketPrefix : undefined,
-    failOnFirstDestinationError:
-      output.failOnFirstDestinationError !== undefined && output.failOnFirstDestinationError !== null
-        ? output.failOnFirstDestinationError
-        : undefined,
+    bucketName: __expectString(output.bucketName),
+    bucketPrefix: __expectString(output.bucketPrefix),
+    failOnFirstDestinationError: __expectBoolean(output.failOnFirstDestinationError),
   } as any;
 };
 
 const deserializeAws_restJson1ErrorInfo = (output: any, context: __SerdeContext): ErrorInfo => {
   return {
-    executionMessage:
-      output.executionMessage !== undefined && output.executionMessage !== null ? output.executionMessage : undefined,
-    putFailuresCount:
-      output.putFailuresCount !== undefined && output.putFailuresCount !== null ? output.putFailuresCount : undefined,
+    executionMessage: __expectString(output.executionMessage),
+    putFailuresCount: __expectNumber(output.putFailuresCount),
   } as any;
 };
 
@@ -4027,7 +3996,7 @@ const deserializeAws_restJson1EventBridgeDestinationProperties = (
       output.errorHandlingConfig !== undefined && output.errorHandlingConfig !== null
         ? deserializeAws_restJson1ErrorHandlingConfig(output.errorHandlingConfig, context)
         : undefined,
-    object: output.object !== undefined && output.object !== null ? output.object : undefined,
+    object: __expectString(output.object),
   } as any;
 };
 
@@ -4037,14 +4006,8 @@ const deserializeAws_restJson1EventBridgeMetadata = (output: any, context: __Ser
 
 const deserializeAws_restJson1ExecutionDetails = (output: any, context: __SerdeContext): ExecutionDetails => {
   return {
-    mostRecentExecutionMessage:
-      output.mostRecentExecutionMessage !== undefined && output.mostRecentExecutionMessage !== null
-        ? output.mostRecentExecutionMessage
-        : undefined,
-    mostRecentExecutionStatus:
-      output.mostRecentExecutionStatus !== undefined && output.mostRecentExecutionStatus !== null
-        ? output.mostRecentExecutionStatus
-        : undefined,
+    mostRecentExecutionMessage: __expectString(output.mostRecentExecutionMessage),
+    mostRecentExecutionStatus: __expectString(output.mostRecentExecutionStatus),
     mostRecentExecutionTime:
       output.mostRecentExecutionTime !== undefined && output.mostRecentExecutionTime !== null
         ? new Date(Math.round(output.mostRecentExecutionTime * 1000))
@@ -4062,13 +4025,12 @@ const deserializeAws_restJson1ExecutionRecord = (output: any, context: __SerdeCo
       output.dataPullStartTime !== undefined && output.dataPullStartTime !== null
         ? new Date(Math.round(output.dataPullStartTime * 1000))
         : undefined,
-    executionId: output.executionId !== undefined && output.executionId !== null ? output.executionId : undefined,
+    executionId: __expectString(output.executionId),
     executionResult:
       output.executionResult !== undefined && output.executionResult !== null
         ? deserializeAws_restJson1ExecutionResult(output.executionResult, context)
         : undefined,
-    executionStatus:
-      output.executionStatus !== undefined && output.executionStatus !== null ? output.executionStatus : undefined,
+    executionStatus: __expectString(output.executionStatus),
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
         ? new Date(Math.round(output.lastUpdatedAt * 1000))
@@ -4082,21 +4044,19 @@ const deserializeAws_restJson1ExecutionRecord = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1ExecutionResult = (output: any, context: __SerdeContext): ExecutionResult => {
   return {
-    bytesProcessed:
-      output.bytesProcessed !== undefined && output.bytesProcessed !== null ? output.bytesProcessed : undefined,
-    bytesWritten: output.bytesWritten !== undefined && output.bytesWritten !== null ? output.bytesWritten : undefined,
+    bytesProcessed: __expectNumber(output.bytesProcessed),
+    bytesWritten: __expectNumber(output.bytesWritten),
     errorInfo:
       output.errorInfo !== undefined && output.errorInfo !== null
         ? deserializeAws_restJson1ErrorInfo(output.errorInfo, context)
         : undefined,
-    recordsProcessed:
-      output.recordsProcessed !== undefined && output.recordsProcessed !== null ? output.recordsProcessed : undefined,
+    recordsProcessed: __expectNumber(output.recordsProcessed),
   } as any;
 };
 
 const deserializeAws_restJson1FieldTypeDetails = (output: any, context: __SerdeContext): FieldTypeDetails => {
   return {
-    fieldType: output.fieldType !== undefined && output.fieldType !== null ? output.fieldType : undefined,
+    fieldType: __expectString(output.fieldType),
     filterOperators:
       output.filterOperators !== undefined && output.filterOperators !== null
         ? deserializeAws_restJson1FilterOperatorList(output.filterOperators, context)
@@ -4115,7 +4075,7 @@ const deserializeAws_restJson1FilterOperatorList = (output: any, context: __Serd
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4125,15 +4085,12 @@ const deserializeAws_restJson1FlowDefinition = (output: any, context: __SerdeCon
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    createdBy: output.createdBy !== undefined && output.createdBy !== null ? output.createdBy : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    destinationConnectorType:
-      output.destinationConnectorType !== undefined && output.destinationConnectorType !== null
-        ? output.destinationConnectorType
-        : undefined,
-    flowArn: output.flowArn !== undefined && output.flowArn !== null ? output.flowArn : undefined,
-    flowName: output.flowName !== undefined && output.flowName !== null ? output.flowName : undefined,
-    flowStatus: output.flowStatus !== undefined && output.flowStatus !== null ? output.flowStatus : undefined,
+    createdBy: __expectString(output.createdBy),
+    description: __expectString(output.description),
+    destinationConnectorType: __expectString(output.destinationConnectorType),
+    flowArn: __expectString(output.flowArn),
+    flowName: __expectString(output.flowName),
+    flowStatus: __expectString(output.flowStatus),
     lastRunExecutionDetails:
       output.lastRunExecutionDetails !== undefined && output.lastRunExecutionDetails !== null
         ? deserializeAws_restJson1ExecutionDetails(output.lastRunExecutionDetails, context)
@@ -4142,17 +4099,13 @@ const deserializeAws_restJson1FlowDefinition = (output: any, context: __SerdeCon
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
         ? new Date(Math.round(output.lastUpdatedAt * 1000))
         : undefined,
-    lastUpdatedBy:
-      output.lastUpdatedBy !== undefined && output.lastUpdatedBy !== null ? output.lastUpdatedBy : undefined,
-    sourceConnectorType:
-      output.sourceConnectorType !== undefined && output.sourceConnectorType !== null
-        ? output.sourceConnectorType
-        : undefined,
+    lastUpdatedBy: __expectString(output.lastUpdatedBy),
+    sourceConnectorType: __expectString(output.sourceConnectorType),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1TagMap(output.tags, context)
         : undefined,
-    triggerType: output.triggerType !== undefined && output.triggerType !== null ? output.triggerType : undefined,
+    triggerType: __expectString(output.triggerType),
   } as any;
 };
 
@@ -4202,7 +4155,7 @@ const deserializeAws_restJson1GoogleAnalyticsSourceProperties = (
   context: __SerdeContext
 ): GoogleAnalyticsSourceProperties => {
   return {
-    object: output.object !== undefined && output.object !== null ? output.object : undefined,
+    object: __expectString(output.object),
   } as any;
 };
 
@@ -4222,7 +4175,7 @@ const deserializeAws_restJson1HoneycodeDestinationProperties = (
       output.errorHandlingConfig !== undefined && output.errorHandlingConfig !== null
         ? deserializeAws_restJson1ErrorHandlingConfig(output.errorHandlingConfig, context)
         : undefined,
-    object: output.object !== undefined && output.object !== null ? output.object : undefined,
+    object: __expectString(output.object),
   } as any;
 };
 
@@ -4242,16 +4195,13 @@ const deserializeAws_restJson1IdFieldNameList = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1IncrementalPullConfig = (output: any, context: __SerdeContext): IncrementalPullConfig => {
   return {
-    datetimeTypeFieldName:
-      output.datetimeTypeFieldName !== undefined && output.datetimeTypeFieldName !== null
-        ? output.datetimeTypeFieldName
-        : undefined,
+    datetimeTypeFieldName: __expectString(output.datetimeTypeFieldName),
   } as any;
 };
 
@@ -4260,7 +4210,7 @@ const deserializeAws_restJson1InforNexusConnectorProfileProperties = (
   context: __SerdeContext
 ): InforNexusConnectorProfileProperties => {
   return {
-    instanceUrl: output.instanceUrl !== undefined && output.instanceUrl !== null ? output.instanceUrl : undefined,
+    instanceUrl: __expectString(output.instanceUrl),
   } as any;
 };
 
@@ -4273,7 +4223,7 @@ const deserializeAws_restJson1InforNexusSourceProperties = (
   context: __SerdeContext
 ): InforNexusSourceProperties => {
   return {
-    object: output.object !== undefined && output.object !== null ? output.object : undefined,
+    object: __expectString(output.object),
   } as any;
 };
 
@@ -4289,7 +4239,7 @@ const deserializeAws_restJson1MarketoConnectorProfileProperties = (
   context: __SerdeContext
 ): MarketoConnectorProfileProperties => {
   return {
-    instanceUrl: output.instanceUrl !== undefined && output.instanceUrl !== null ? output.instanceUrl : undefined,
+    instanceUrl: __expectString(output.instanceUrl),
   } as any;
 };
 
@@ -4302,7 +4252,7 @@ const deserializeAws_restJson1MarketoSourceProperties = (
   context: __SerdeContext
 ): MarketoSourceProperties => {
   return {
-    object: output.object !== undefined && output.object !== null ? output.object : undefined,
+    object: __expectString(output.object),
   } as any;
 };
 
@@ -4313,14 +4263,14 @@ const deserializeAws_restJson1OAuthScopeList = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1PrefixConfig = (output: any, context: __SerdeContext): PrefixConfig => {
   return {
-    prefixFormat: output.prefixFormat !== undefined && output.prefixFormat !== null ? output.prefixFormat : undefined,
-    prefixType: output.prefixType !== undefined && output.prefixType !== null ? output.prefixType : undefined,
+    prefixFormat: __expectString(output.prefixFormat),
+    prefixType: __expectString(output.prefixType),
   } as any;
 };
 
@@ -4329,10 +4279,10 @@ const deserializeAws_restJson1RedshiftConnectorProfileProperties = (
   context: __SerdeContext
 ): RedshiftConnectorProfileProperties => {
   return {
-    bucketName: output.bucketName !== undefined && output.bucketName !== null ? output.bucketName : undefined,
-    bucketPrefix: output.bucketPrefix !== undefined && output.bucketPrefix !== null ? output.bucketPrefix : undefined,
-    databaseUrl: output.databaseUrl !== undefined && output.databaseUrl !== null ? output.databaseUrl : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
+    bucketName: __expectString(output.bucketName),
+    bucketPrefix: __expectString(output.bucketPrefix),
+    databaseUrl: __expectString(output.databaseUrl),
+    roleArn: __expectString(output.roleArn),
   } as any;
 };
 
@@ -4341,16 +4291,13 @@ const deserializeAws_restJson1RedshiftDestinationProperties = (
   context: __SerdeContext
 ): RedshiftDestinationProperties => {
   return {
-    bucketPrefix: output.bucketPrefix !== undefined && output.bucketPrefix !== null ? output.bucketPrefix : undefined,
+    bucketPrefix: __expectString(output.bucketPrefix),
     errorHandlingConfig:
       output.errorHandlingConfig !== undefined && output.errorHandlingConfig !== null
         ? deserializeAws_restJson1ErrorHandlingConfig(output.errorHandlingConfig, context)
         : undefined,
-    intermediateBucketName:
-      output.intermediateBucketName !== undefined && output.intermediateBucketName !== null
-        ? output.intermediateBucketName
-        : undefined,
-    object: output.object !== undefined && output.object !== null ? output.object : undefined,
+    intermediateBucketName: __expectString(output.intermediateBucketName),
+    object: __expectString(output.object),
   } as any;
 };
 
@@ -4365,7 +4312,7 @@ const deserializeAws_restJson1RegionList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4374,8 +4321,8 @@ const deserializeAws_restJson1S3DestinationProperties = (
   context: __SerdeContext
 ): S3DestinationProperties => {
   return {
-    bucketName: output.bucketName !== undefined && output.bucketName !== null ? output.bucketName : undefined,
-    bucketPrefix: output.bucketPrefix !== undefined && output.bucketPrefix !== null ? output.bucketPrefix : undefined,
+    bucketName: __expectString(output.bucketName),
+    bucketPrefix: __expectString(output.bucketPrefix),
     s3OutputFormatConfig:
       output.s3OutputFormatConfig !== undefined && output.s3OutputFormatConfig !== null
         ? deserializeAws_restJson1S3OutputFormatConfig(output.s3OutputFormatConfig, context)
@@ -4393,7 +4340,7 @@ const deserializeAws_restJson1S3OutputFormatConfig = (output: any, context: __Se
       output.aggregationConfig !== undefined && output.aggregationConfig !== null
         ? deserializeAws_restJson1AggregationConfig(output.aggregationConfig, context)
         : undefined,
-    fileType: output.fileType !== undefined && output.fileType !== null ? output.fileType : undefined,
+    fileType: __expectString(output.fileType),
     prefixConfig:
       output.prefixConfig !== undefined && output.prefixConfig !== null
         ? deserializeAws_restJson1PrefixConfig(output.prefixConfig, context)
@@ -4403,8 +4350,8 @@ const deserializeAws_restJson1S3OutputFormatConfig = (output: any, context: __Se
 
 const deserializeAws_restJson1S3SourceProperties = (output: any, context: __SerdeContext): S3SourceProperties => {
   return {
-    bucketName: output.bucketName !== undefined && output.bucketName !== null ? output.bucketName : undefined,
-    bucketPrefix: output.bucketPrefix !== undefined && output.bucketPrefix !== null ? output.bucketPrefix : undefined,
+    bucketName: __expectString(output.bucketName),
+    bucketPrefix: __expectString(output.bucketPrefix),
   } as any;
 };
 
@@ -4413,11 +4360,8 @@ const deserializeAws_restJson1SalesforceConnectorProfileProperties = (
   context: __SerdeContext
 ): SalesforceConnectorProfileProperties => {
   return {
-    instanceUrl: output.instanceUrl !== undefined && output.instanceUrl !== null ? output.instanceUrl : undefined,
-    isSandboxEnvironment:
-      output.isSandboxEnvironment !== undefined && output.isSandboxEnvironment !== null
-        ? output.isSandboxEnvironment
-        : undefined,
+    instanceUrl: __expectString(output.instanceUrl),
+    isSandboxEnvironment: __expectBoolean(output.isSandboxEnvironment),
   } as any;
 };
 
@@ -4434,11 +4378,8 @@ const deserializeAws_restJson1SalesforceDestinationProperties = (
       output.idFieldNames !== undefined && output.idFieldNames !== null
         ? deserializeAws_restJson1IdFieldNameList(output.idFieldNames, context)
         : undefined,
-    object: output.object !== undefined && output.object !== null ? output.object : undefined,
-    writeOperationType:
-      output.writeOperationType !== undefined && output.writeOperationType !== null
-        ? output.writeOperationType
-        : undefined,
+    object: __expectString(output.object),
+    writeOperationType: __expectString(output.writeOperationType),
   } as any;
 };
 
@@ -4456,15 +4397,9 @@ const deserializeAws_restJson1SalesforceSourceProperties = (
   context: __SerdeContext
 ): SalesforceSourceProperties => {
   return {
-    enableDynamicFieldUpdate:
-      output.enableDynamicFieldUpdate !== undefined && output.enableDynamicFieldUpdate !== null
-        ? output.enableDynamicFieldUpdate
-        : undefined,
-    includeDeletedRecords:
-      output.includeDeletedRecords !== undefined && output.includeDeletedRecords !== null
-        ? output.includeDeletedRecords
-        : undefined,
-    object: output.object !== undefined && output.object !== null ? output.object : undefined,
+    enableDynamicFieldUpdate: __expectBoolean(output.enableDynamicFieldUpdate),
+    includeDeletedRecords: __expectBoolean(output.includeDeletedRecords),
+    object: __expectString(output.object),
   } as any;
 };
 
@@ -4473,7 +4408,7 @@ const deserializeAws_restJson1ScheduledTriggerProperties = (
   context: __SerdeContext
 ): ScheduledTriggerProperties => {
   return {
-    dataPullMode: output.dataPullMode !== undefined && output.dataPullMode !== null ? output.dataPullMode : undefined,
+    dataPullMode: __expectString(output.dataPullMode),
     firstExecutionFrom:
       output.firstExecutionFrom !== undefined && output.firstExecutionFrom !== null
         ? new Date(Math.round(output.firstExecutionFrom * 1000))
@@ -4482,17 +4417,13 @@ const deserializeAws_restJson1ScheduledTriggerProperties = (
       output.scheduleEndTime !== undefined && output.scheduleEndTime !== null
         ? new Date(Math.round(output.scheduleEndTime * 1000))
         : undefined,
-    scheduleExpression:
-      output.scheduleExpression !== undefined && output.scheduleExpression !== null
-        ? output.scheduleExpression
-        : undefined,
-    scheduleOffset:
-      output.scheduleOffset !== undefined && output.scheduleOffset !== null ? output.scheduleOffset : undefined,
+    scheduleExpression: __expectString(output.scheduleExpression),
+    scheduleOffset: __expectNumber(output.scheduleOffset),
     scheduleStartTime:
       output.scheduleStartTime !== undefined && output.scheduleStartTime !== null
         ? new Date(Math.round(output.scheduleStartTime * 1000))
         : undefined,
-    timezone: output.timezone !== undefined && output.timezone !== null ? output.timezone : undefined,
+    timezone: __expectString(output.timezone),
   } as any;
 };
 
@@ -4506,7 +4437,7 @@ const deserializeAws_restJson1SchedulingFrequencyTypeList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4515,7 +4446,7 @@ const deserializeAws_restJson1ServiceNowConnectorProfileProperties = (
   context: __SerdeContext
 ): ServiceNowConnectorProfileProperties => {
   return {
-    instanceUrl: output.instanceUrl !== undefined && output.instanceUrl !== null ? output.instanceUrl : undefined,
+    instanceUrl: __expectString(output.instanceUrl),
   } as any;
 };
 
@@ -4528,7 +4459,7 @@ const deserializeAws_restJson1ServiceNowSourceProperties = (
   context: __SerdeContext
 ): ServiceNowSourceProperties => {
   return {
-    object: output.object !== undefined && output.object !== null ? output.object : undefined,
+    object: __expectString(output.object),
   } as any;
 };
 
@@ -4548,7 +4479,7 @@ const deserializeAws_restJson1SingularSourceProperties = (
   context: __SerdeContext
 ): SingularSourceProperties => {
   return {
-    object: output.object !== undefined && output.object !== null ? output.object : undefined,
+    object: __expectString(output.object),
   } as any;
 };
 
@@ -4557,7 +4488,7 @@ const deserializeAws_restJson1SlackConnectorProfileProperties = (
   context: __SerdeContext
 ): SlackConnectorProfileProperties => {
   return {
-    instanceUrl: output.instanceUrl !== undefined && output.instanceUrl !== null ? output.instanceUrl : undefined,
+    instanceUrl: __expectString(output.instanceUrl),
   } as any;
 };
 
@@ -4572,7 +4503,7 @@ const deserializeAws_restJson1SlackMetadata = (output: any, context: __SerdeCont
 
 const deserializeAws_restJson1SlackSourceProperties = (output: any, context: __SerdeContext): SlackSourceProperties => {
   return {
-    object: output.object !== undefined && output.object !== null ? output.object : undefined,
+    object: __expectString(output.object),
   } as any;
 };
 
@@ -4581,16 +4512,13 @@ const deserializeAws_restJson1SnowflakeConnectorProfileProperties = (
   context: __SerdeContext
 ): SnowflakeConnectorProfileProperties => {
   return {
-    accountName: output.accountName !== undefined && output.accountName !== null ? output.accountName : undefined,
-    bucketName: output.bucketName !== undefined && output.bucketName !== null ? output.bucketName : undefined,
-    bucketPrefix: output.bucketPrefix !== undefined && output.bucketPrefix !== null ? output.bucketPrefix : undefined,
-    privateLinkServiceName:
-      output.privateLinkServiceName !== undefined && output.privateLinkServiceName !== null
-        ? output.privateLinkServiceName
-        : undefined,
-    region: output.region !== undefined && output.region !== null ? output.region : undefined,
-    stage: output.stage !== undefined && output.stage !== null ? output.stage : undefined,
-    warehouse: output.warehouse !== undefined && output.warehouse !== null ? output.warehouse : undefined,
+    accountName: __expectString(output.accountName),
+    bucketName: __expectString(output.bucketName),
+    bucketPrefix: __expectString(output.bucketPrefix),
+    privateLinkServiceName: __expectString(output.privateLinkServiceName),
+    region: __expectString(output.region),
+    stage: __expectString(output.stage),
+    warehouse: __expectString(output.warehouse),
   } as any;
 };
 
@@ -4599,16 +4527,13 @@ const deserializeAws_restJson1SnowflakeDestinationProperties = (
   context: __SerdeContext
 ): SnowflakeDestinationProperties => {
   return {
-    bucketPrefix: output.bucketPrefix !== undefined && output.bucketPrefix !== null ? output.bucketPrefix : undefined,
+    bucketPrefix: __expectString(output.bucketPrefix),
     errorHandlingConfig:
       output.errorHandlingConfig !== undefined && output.errorHandlingConfig !== null
         ? deserializeAws_restJson1ErrorHandlingConfig(output.errorHandlingConfig, context)
         : undefined,
-    intermediateBucketName:
-      output.intermediateBucketName !== undefined && output.intermediateBucketName !== null
-        ? output.intermediateBucketName
-        : undefined,
-    object: output.object !== undefined && output.object !== null ? output.object : undefined,
+    intermediateBucketName: __expectString(output.intermediateBucketName),
+    object: __expectString(output.object),
   } as any;
 };
 
@@ -4687,9 +4612,8 @@ const deserializeAws_restJson1SourceConnectorProperties = (
 
 const deserializeAws_restJson1SourceFieldProperties = (output: any, context: __SerdeContext): SourceFieldProperties => {
   return {
-    isQueryable: output.isQueryable !== undefined && output.isQueryable !== null ? output.isQueryable : undefined,
-    isRetrievable:
-      output.isRetrievable !== undefined && output.isRetrievable !== null ? output.isRetrievable : undefined,
+    isQueryable: __expectBoolean(output.isQueryable),
+    isRetrievable: __expectBoolean(output.isRetrievable),
   } as any;
 };
 
@@ -4700,18 +4624,14 @@ const deserializeAws_restJson1SourceFields = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1SourceFlowConfig = (output: any, context: __SerdeContext): SourceFlowConfig => {
   return {
-    connectorProfileName:
-      output.connectorProfileName !== undefined && output.connectorProfileName !== null
-        ? output.connectorProfileName
-        : undefined,
-    connectorType:
-      output.connectorType !== undefined && output.connectorType !== null ? output.connectorType : undefined,
+    connectorProfileName: __expectString(output.connectorProfileName),
+    connectorType: __expectString(output.connectorType),
     incrementalPullConfig:
       output.incrementalPullConfig !== undefined && output.incrementalPullConfig !== null
         ? deserializeAws_restJson1IncrementalPullConfig(output.incrementalPullConfig, context)
@@ -4742,7 +4662,7 @@ const deserializeAws_restJson1SupportedValueList = (output: any, context: __Serd
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4756,7 +4676,7 @@ const deserializeAws_restJson1SupportedWriteOperationList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4767,7 +4687,7 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -4778,8 +4698,7 @@ const deserializeAws_restJson1Task = (output: any, context: __SerdeContext): Tas
       output.connectorOperator !== undefined && output.connectorOperator !== null
         ? deserializeAws_restJson1ConnectorOperator(output.connectorOperator, context)
         : undefined,
-    destinationField:
-      output.destinationField !== undefined && output.destinationField !== null ? output.destinationField : undefined,
+    destinationField: __expectString(output.destinationField),
     sourceFields:
       output.sourceFields !== undefined && output.sourceFields !== null
         ? deserializeAws_restJson1SourceFields(output.sourceFields, context)
@@ -4788,7 +4707,7 @@ const deserializeAws_restJson1Task = (output: any, context: __SerdeContext): Tas
       output.taskProperties !== undefined && output.taskProperties !== null
         ? deserializeAws_restJson1TaskPropertiesMap(output.taskProperties, context)
         : undefined,
-    taskType: output.taskType !== undefined && output.taskType !== null ? output.taskType : undefined,
+    taskType: __expectString(output.taskType),
   } as any;
 };
 
@@ -4800,7 +4719,7 @@ const deserializeAws_restJson1TaskPropertiesMap = (output: any, context: __Serde
       }
       return {
         ...acc,
-        [key]: value,
+        [key]: __expectString(value) as any,
       };
     },
     {}
@@ -4834,7 +4753,7 @@ const deserializeAws_restJson1TrendmicroSourceProperties = (
   context: __SerdeContext
 ): TrendmicroSourceProperties => {
   return {
-    object: output.object !== undefined && output.object !== null ? output.object : undefined,
+    object: __expectString(output.object),
   } as any;
 };
 
@@ -4844,7 +4763,7 @@ const deserializeAws_restJson1TriggerConfig = (output: any, context: __SerdeCont
       output.triggerProperties !== undefined && output.triggerProperties !== null
         ? deserializeAws_restJson1TriggerProperties(output.triggerProperties, context)
         : undefined,
-    triggerType: output.triggerType !== undefined && output.triggerType !== null ? output.triggerType : undefined,
+    triggerType: __expectString(output.triggerType),
   } as any;
 };
 
@@ -4864,7 +4783,7 @@ const deserializeAws_restJson1TriggerTypeList = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4873,8 +4792,8 @@ const deserializeAws_restJson1UpsolverDestinationProperties = (
   context: __SerdeContext
 ): UpsolverDestinationProperties => {
   return {
-    bucketName: output.bucketName !== undefined && output.bucketName !== null ? output.bucketName : undefined,
-    bucketPrefix: output.bucketPrefix !== undefined && output.bucketPrefix !== null ? output.bucketPrefix : undefined,
+    bucketName: __expectString(output.bucketName),
+    bucketPrefix: __expectString(output.bucketPrefix),
     s3OutputFormatConfig:
       output.s3OutputFormatConfig !== undefined && output.s3OutputFormatConfig !== null
         ? deserializeAws_restJson1UpsolverS3OutputFormatConfig(output.s3OutputFormatConfig, context)
@@ -4895,7 +4814,7 @@ const deserializeAws_restJson1UpsolverS3OutputFormatConfig = (
       output.aggregationConfig !== undefined && output.aggregationConfig !== null
         ? deserializeAws_restJson1AggregationConfig(output.aggregationConfig, context)
         : undefined,
-    fileType: output.fileType !== undefined && output.fileType !== null ? output.fileType : undefined,
+    fileType: __expectString(output.fileType),
     prefixConfig:
       output.prefixConfig !== undefined && output.prefixConfig !== null
         ? deserializeAws_restJson1PrefixConfig(output.prefixConfig, context)
@@ -4908,7 +4827,7 @@ const deserializeAws_restJson1VeevaConnectorProfileProperties = (
   context: __SerdeContext
 ): VeevaConnectorProfileProperties => {
   return {
-    instanceUrl: output.instanceUrl !== undefined && output.instanceUrl !== null ? output.instanceUrl : undefined,
+    instanceUrl: __expectString(output.instanceUrl),
   } as any;
 };
 
@@ -4918,7 +4837,7 @@ const deserializeAws_restJson1VeevaMetadata = (output: any, context: __SerdeCont
 
 const deserializeAws_restJson1VeevaSourceProperties = (output: any, context: __SerdeContext): VeevaSourceProperties => {
   return {
-    object: output.object !== undefined && output.object !== null ? output.object : undefined,
+    object: __expectString(output.object),
   } as any;
 };
 
@@ -4927,7 +4846,7 @@ const deserializeAws_restJson1ZendeskConnectorProfileProperties = (
   context: __SerdeContext
 ): ZendeskConnectorProfileProperties => {
   return {
-    instanceUrl: output.instanceUrl !== undefined && output.instanceUrl !== null ? output.instanceUrl : undefined,
+    instanceUrl: __expectString(output.instanceUrl),
   } as any;
 };
 
@@ -4944,11 +4863,8 @@ const deserializeAws_restJson1ZendeskDestinationProperties = (
       output.idFieldNames !== undefined && output.idFieldNames !== null
         ? deserializeAws_restJson1IdFieldNameList(output.idFieldNames, context)
         : undefined,
-    object: output.object !== undefined && output.object !== null ? output.object : undefined,
-    writeOperationType:
-      output.writeOperationType !== undefined && output.writeOperationType !== null
-        ? output.writeOperationType
-        : undefined,
+    object: __expectString(output.object),
+    writeOperationType: __expectString(output.writeOperationType),
   } as any;
 };
 
@@ -4966,7 +4882,7 @@ const deserializeAws_restJson1ZendeskSourceProperties = (
   context: __SerdeContext
 ): ZendeskSourceProperties => {
   return {
-    object: output.object !== undefined && output.object !== null ? output.object : undefined,
+    object: __expectString(output.object),
   } as any;
 };
 

--- a/clients/client-appintegrations/protocols/Aws_restJson1.ts
+++ b/clients/client-appintegrations/protocols/Aws_restJson1.ts
@@ -43,6 +43,7 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -336,7 +337,7 @@ export const deserializeAws_restJson1CreateEventIntegrationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.EventIntegrationArn !== undefined && data.EventIntegrationArn !== null) {
-    contents.EventIntegrationArn = data.EventIntegrationArn;
+    contents.EventIntegrationArn = __expectString(data.EventIntegrationArn);
   }
   return Promise.resolve(contents);
 };
@@ -519,19 +520,19 @@ export const deserializeAws_restJson1GetEventIntegrationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.EventBridgeBus !== undefined && data.EventBridgeBus !== null) {
-    contents.EventBridgeBus = data.EventBridgeBus;
+    contents.EventBridgeBus = __expectString(data.EventBridgeBus);
   }
   if (data.EventFilter !== undefined && data.EventFilter !== null) {
     contents.EventFilter = deserializeAws_restJson1EventFilter(data.EventFilter, context);
   }
   if (data.EventIntegrationArn !== undefined && data.EventIntegrationArn !== null) {
-    contents.EventIntegrationArn = data.EventIntegrationArn;
+    contents.EventIntegrationArn = __expectString(data.EventIntegrationArn);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
@@ -628,7 +629,7 @@ export const deserializeAws_restJson1ListEventIntegrationAssociationsCommand = a
     );
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -719,7 +720,7 @@ export const deserializeAws_restJson1ListEventIntegrationsCommand = async (
     contents.EventIntegrations = deserializeAws_restJson1EventIntegrationsList(data.EventIntegrations, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1109,7 +1110,7 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1126,7 +1127,7 @@ const deserializeAws_restJson1DuplicateResourceExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1143,7 +1144,7 @@ const deserializeAws_restJson1InternalServiceErrorResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1160,7 +1161,7 @@ const deserializeAws_restJson1InvalidRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1177,7 +1178,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1194,7 +1195,7 @@ const deserializeAws_restJson1ResourceQuotaExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1211,7 +1212,7 @@ const deserializeAws_restJson1ThrottlingExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1244,31 +1245,27 @@ const deserializeAws_restJson1ClientAssociationMetadata = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1EventFilter = (output: any, context: __SerdeContext): EventFilter => {
   return {
-    Source: output.Source !== undefined && output.Source !== null ? output.Source : undefined,
+    Source: __expectString(output.Source),
   } as any;
 };
 
 const deserializeAws_restJson1EventIntegration = (output: any, context: __SerdeContext): EventIntegration => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    EventBridgeBus:
-      output.EventBridgeBus !== undefined && output.EventBridgeBus !== null ? output.EventBridgeBus : undefined,
+    Description: __expectString(output.Description),
+    EventBridgeBus: __expectString(output.EventBridgeBus),
     EventFilter:
       output.EventFilter !== undefined && output.EventFilter !== null
         ? deserializeAws_restJson1EventFilter(output.EventFilter, context)
         : undefined,
-    EventIntegrationArn:
-      output.EventIntegrationArn !== undefined && output.EventIntegrationArn !== null
-        ? output.EventIntegrationArn
-        : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    EventIntegrationArn: __expectString(output.EventIntegrationArn),
+    Name: __expectString(output.Name),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_restJson1TagMap(output.Tags, context)
@@ -1285,23 +1282,11 @@ const deserializeAws_restJson1EventIntegrationAssociation = (
       output.ClientAssociationMetadata !== undefined && output.ClientAssociationMetadata !== null
         ? deserializeAws_restJson1ClientAssociationMetadata(output.ClientAssociationMetadata, context)
         : undefined,
-    ClientId: output.ClientId !== undefined && output.ClientId !== null ? output.ClientId : undefined,
-    EventBridgeRuleName:
-      output.EventBridgeRuleName !== undefined && output.EventBridgeRuleName !== null
-        ? output.EventBridgeRuleName
-        : undefined,
-    EventIntegrationAssociationArn:
-      output.EventIntegrationAssociationArn !== undefined && output.EventIntegrationAssociationArn !== null
-        ? output.EventIntegrationAssociationArn
-        : undefined,
-    EventIntegrationAssociationId:
-      output.EventIntegrationAssociationId !== undefined && output.EventIntegrationAssociationId !== null
-        ? output.EventIntegrationAssociationId
-        : undefined,
-    EventIntegrationName:
-      output.EventIntegrationName !== undefined && output.EventIntegrationName !== null
-        ? output.EventIntegrationName
-        : undefined,
+    ClientId: __expectString(output.ClientId),
+    EventBridgeRuleName: __expectString(output.EventBridgeRuleName),
+    EventIntegrationAssociationArn: __expectString(output.EventIntegrationAssociationArn),
+    EventIntegrationAssociationId: __expectString(output.EventIntegrationAssociationId),
+    EventIntegrationName: __expectString(output.EventIntegrationName),
   } as any;
 };
 
@@ -1337,7 +1322,7 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };

--- a/clients/client-application-auto-scaling/protocols/Aws_json1_1.ts
+++ b/clients/client-application-auto-scaling/protocols/Aws_json1_1.ts
@@ -75,7 +75,12 @@ import {
   ValidationException,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -1459,8 +1464,8 @@ const serializeAws_json1_1TargetTrackingScalingPolicyConfiguration = (
 
 const deserializeAws_json1_1Alarm = (output: any, context: __SerdeContext): Alarm => {
   return {
-    AlarmARN: output.AlarmARN !== undefined && output.AlarmARN !== null ? output.AlarmARN : undefined,
-    AlarmName: output.AlarmName !== undefined && output.AlarmName !== null ? output.AlarmName : undefined,
+    AlarmARN: __expectString(output.AlarmARN),
+    AlarmName: __expectString(output.AlarmName),
   } as any;
 };
 
@@ -1480,7 +1485,7 @@ const deserializeAws_json1_1ConcurrentUpdateException = (
   context: __SerdeContext
 ): ConcurrentUpdateException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -1493,10 +1498,10 @@ const deserializeAws_json1_1CustomizedMetricSpecification = (
       output.Dimensions !== undefined && output.Dimensions !== null
         ? deserializeAws_json1_1MetricDimensions(output.Dimensions, context)
         : undefined,
-    MetricName: output.MetricName !== undefined && output.MetricName !== null ? output.MetricName : undefined,
-    Namespace: output.Namespace !== undefined && output.Namespace !== null ? output.Namespace : undefined,
-    Statistic: output.Statistic !== undefined && output.Statistic !== null ? output.Statistic : undefined,
-    Unit: output.Unit !== undefined && output.Unit !== null ? output.Unit : undefined,
+    MetricName: __expectString(output.MetricName),
+    Namespace: __expectString(output.Namespace),
+    Statistic: __expectString(output.Statistic),
+    Unit: __expectString(output.Unit),
   } as any;
 };
 
@@ -1526,7 +1531,7 @@ const deserializeAws_json1_1DescribeScalableTargetsResponse = (
   context: __SerdeContext
 ): DescribeScalableTargetsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     ScalableTargets:
       output.ScalableTargets !== undefined && output.ScalableTargets !== null
         ? deserializeAws_json1_1ScalableTargets(output.ScalableTargets, context)
@@ -1539,7 +1544,7 @@ const deserializeAws_json1_1DescribeScalingActivitiesResponse = (
   context: __SerdeContext
 ): DescribeScalingActivitiesResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     ScalingActivities:
       output.ScalingActivities !== undefined && output.ScalingActivities !== null
         ? deserializeAws_json1_1ScalingActivities(output.ScalingActivities, context)
@@ -1552,7 +1557,7 @@ const deserializeAws_json1_1DescribeScalingPoliciesResponse = (
   context: __SerdeContext
 ): DescribeScalingPoliciesResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     ScalingPolicies:
       output.ScalingPolicies !== undefined && output.ScalingPolicies !== null
         ? deserializeAws_json1_1ScalingPolicies(output.ScalingPolicies, context)
@@ -1565,7 +1570,7 @@ const deserializeAws_json1_1DescribeScheduledActionsResponse = (
   context: __SerdeContext
 ): DescribeScheduledActionsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     ScheduledActions:
       output.ScheduledActions !== undefined && output.ScheduledActions !== null
         ? deserializeAws_json1_1ScheduledActions(output.ScheduledActions, context)
@@ -1578,7 +1583,7 @@ const deserializeAws_json1_1FailedResourceAccessException = (
   context: __SerdeContext
 ): FailedResourceAccessException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -1587,7 +1592,7 @@ const deserializeAws_json1_1InternalServiceException = (
   context: __SerdeContext
 ): InternalServiceException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -1596,20 +1601,20 @@ const deserializeAws_json1_1InvalidNextTokenException = (
   context: __SerdeContext
 ): InvalidNextTokenException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1MetricDimension = (output: any, context: __SerdeContext): MetricDimension => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Name: __expectString(output.Name),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -1629,7 +1634,7 @@ const deserializeAws_json1_1ObjectNotFoundException = (
   context: __SerdeContext
 ): ObjectNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -1638,12 +1643,8 @@ const deserializeAws_json1_1PredefinedMetricSpecification = (
   context: __SerdeContext
 ): PredefinedMetricSpecification => {
   return {
-    PredefinedMetricType:
-      output.PredefinedMetricType !== undefined && output.PredefinedMetricType !== null
-        ? output.PredefinedMetricType
-        : undefined,
-    ResourceLabel:
-      output.ResourceLabel !== undefined && output.ResourceLabel !== null ? output.ResourceLabel : undefined,
+    PredefinedMetricType: __expectString(output.PredefinedMetricType),
+    ResourceLabel: __expectString(output.ResourceLabel),
   } as any;
 };
 
@@ -1656,7 +1657,7 @@ const deserializeAws_json1_1PutScalingPolicyResponse = (
       output.Alarms !== undefined && output.Alarms !== null
         ? deserializeAws_json1_1Alarms(output.Alarms, context)
         : undefined,
-    PolicyARN: output.PolicyARN !== undefined && output.PolicyARN !== null ? output.PolicyARN : undefined,
+    PolicyARN: __expectString(output.PolicyARN),
   } as any;
 };
 
@@ -1680,16 +1681,12 @@ const deserializeAws_json1_1ScalableTarget = (output: any, context: __SerdeConte
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    MaxCapacity: output.MaxCapacity !== undefined && output.MaxCapacity !== null ? output.MaxCapacity : undefined,
-    MinCapacity: output.MinCapacity !== undefined && output.MinCapacity !== null ? output.MinCapacity : undefined,
-    ResourceId: output.ResourceId !== undefined && output.ResourceId !== null ? output.ResourceId : undefined,
-    RoleARN: output.RoleARN !== undefined && output.RoleARN !== null ? output.RoleARN : undefined,
-    ScalableDimension:
-      output.ScalableDimension !== undefined && output.ScalableDimension !== null
-        ? output.ScalableDimension
-        : undefined,
-    ServiceNamespace:
-      output.ServiceNamespace !== undefined && output.ServiceNamespace !== null ? output.ServiceNamespace : undefined,
+    MaxCapacity: __expectNumber(output.MaxCapacity),
+    MinCapacity: __expectNumber(output.MinCapacity),
+    ResourceId: __expectString(output.ResourceId),
+    RoleARN: __expectString(output.RoleARN),
+    ScalableDimension: __expectString(output.ScalableDimension),
+    ServiceNamespace: __expectString(output.ServiceNamespace),
     SuspendedState:
       output.SuspendedState !== undefined && output.SuspendedState !== null
         ? deserializeAws_json1_1SuspendedState(output.SuspendedState, context)
@@ -1699,8 +1696,8 @@ const deserializeAws_json1_1ScalableTarget = (output: any, context: __SerdeConte
 
 const deserializeAws_json1_1ScalableTargetAction = (output: any, context: __SerdeContext): ScalableTargetAction => {
   return {
-    MaxCapacity: output.MaxCapacity !== undefined && output.MaxCapacity !== null ? output.MaxCapacity : undefined,
-    MinCapacity: output.MinCapacity !== undefined && output.MinCapacity !== null ? output.MinCapacity : undefined,
+    MaxCapacity: __expectNumber(output.MaxCapacity),
+    MinCapacity: __expectNumber(output.MinCapacity),
   } as any;
 };
 
@@ -1728,26 +1725,21 @@ const deserializeAws_json1_1ScalingActivities = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1ScalingActivity = (output: any, context: __SerdeContext): ScalingActivity => {
   return {
-    ActivityId: output.ActivityId !== undefined && output.ActivityId !== null ? output.ActivityId : undefined,
-    Cause: output.Cause !== undefined && output.Cause !== null ? output.Cause : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Details: output.Details !== undefined && output.Details !== null ? output.Details : undefined,
+    ActivityId: __expectString(output.ActivityId),
+    Cause: __expectString(output.Cause),
+    Description: __expectString(output.Description),
+    Details: __expectString(output.Details),
     EndTime:
       output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
-    ResourceId: output.ResourceId !== undefined && output.ResourceId !== null ? output.ResourceId : undefined,
-    ScalableDimension:
-      output.ScalableDimension !== undefined && output.ScalableDimension !== null
-        ? output.ScalableDimension
-        : undefined,
-    ServiceNamespace:
-      output.ServiceNamespace !== undefined && output.ServiceNamespace !== null ? output.ServiceNamespace : undefined,
+    ResourceId: __expectString(output.ResourceId),
+    ScalableDimension: __expectString(output.ScalableDimension),
+    ServiceNamespace: __expectString(output.ServiceNamespace),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
         ? new Date(Math.round(output.StartTime * 1000))
         : undefined,
-    StatusCode: output.StatusCode !== undefined && output.StatusCode !== null ? output.StatusCode : undefined,
-    StatusMessage:
-      output.StatusMessage !== undefined && output.StatusMessage !== null ? output.StatusMessage : undefined,
+    StatusCode: __expectString(output.StatusCode),
+    StatusMessage: __expectString(output.StatusMessage),
   } as any;
 };
 
@@ -1772,16 +1764,12 @@ const deserializeAws_json1_1ScalingPolicy = (output: any, context: __SerdeContex
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    PolicyARN: output.PolicyARN !== undefined && output.PolicyARN !== null ? output.PolicyARN : undefined,
-    PolicyName: output.PolicyName !== undefined && output.PolicyName !== null ? output.PolicyName : undefined,
-    PolicyType: output.PolicyType !== undefined && output.PolicyType !== null ? output.PolicyType : undefined,
-    ResourceId: output.ResourceId !== undefined && output.ResourceId !== null ? output.ResourceId : undefined,
-    ScalableDimension:
-      output.ScalableDimension !== undefined && output.ScalableDimension !== null
-        ? output.ScalableDimension
-        : undefined,
-    ServiceNamespace:
-      output.ServiceNamespace !== undefined && output.ServiceNamespace !== null ? output.ServiceNamespace : undefined,
+    PolicyARN: __expectString(output.PolicyARN),
+    PolicyName: __expectString(output.PolicyName),
+    PolicyType: __expectString(output.PolicyType),
+    ResourceId: __expectString(output.ResourceId),
+    ScalableDimension: __expectString(output.ScalableDimension),
+    ServiceNamespace: __expectString(output.ServiceNamespace),
     StepScalingPolicyConfiguration:
       output.StepScalingPolicyConfiguration !== undefined && output.StepScalingPolicyConfiguration !== null
         ? deserializeAws_json1_1StepScalingPolicyConfiguration(output.StepScalingPolicyConfiguration, context)
@@ -1805,31 +1793,21 @@ const deserializeAws_json1_1ScheduledAction = (output: any, context: __SerdeCont
         : undefined,
     EndTime:
       output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
-    ResourceId: output.ResourceId !== undefined && output.ResourceId !== null ? output.ResourceId : undefined,
-    ScalableDimension:
-      output.ScalableDimension !== undefined && output.ScalableDimension !== null
-        ? output.ScalableDimension
-        : undefined,
+    ResourceId: __expectString(output.ResourceId),
+    ScalableDimension: __expectString(output.ScalableDimension),
     ScalableTargetAction:
       output.ScalableTargetAction !== undefined && output.ScalableTargetAction !== null
         ? deserializeAws_json1_1ScalableTargetAction(output.ScalableTargetAction, context)
         : undefined,
-    Schedule: output.Schedule !== undefined && output.Schedule !== null ? output.Schedule : undefined,
-    ScheduledActionARN:
-      output.ScheduledActionARN !== undefined && output.ScheduledActionARN !== null
-        ? output.ScheduledActionARN
-        : undefined,
-    ScheduledActionName:
-      output.ScheduledActionName !== undefined && output.ScheduledActionName !== null
-        ? output.ScheduledActionName
-        : undefined,
-    ServiceNamespace:
-      output.ServiceNamespace !== undefined && output.ServiceNamespace !== null ? output.ServiceNamespace : undefined,
+    Schedule: __expectString(output.Schedule),
+    ScheduledActionARN: __expectString(output.ScheduledActionARN),
+    ScheduledActionName: __expectString(output.ScheduledActionName),
+    ServiceNamespace: __expectString(output.ServiceNamespace),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
         ? new Date(Math.round(output.StartTime * 1000))
         : undefined,
-    Timezone: output.Timezone !== undefined && output.Timezone !== null ? output.Timezone : undefined,
+    Timezone: __expectString(output.Timezone),
   } as any;
 };
 
@@ -1846,18 +1824,9 @@ const deserializeAws_json1_1ScheduledActions = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1StepAdjustment = (output: any, context: __SerdeContext): StepAdjustment => {
   return {
-    MetricIntervalLowerBound:
-      output.MetricIntervalLowerBound !== undefined && output.MetricIntervalLowerBound !== null
-        ? output.MetricIntervalLowerBound
-        : undefined,
-    MetricIntervalUpperBound:
-      output.MetricIntervalUpperBound !== undefined && output.MetricIntervalUpperBound !== null
-        ? output.MetricIntervalUpperBound
-        : undefined,
-    ScalingAdjustment:
-      output.ScalingAdjustment !== undefined && output.ScalingAdjustment !== null
-        ? output.ScalingAdjustment
-        : undefined,
+    MetricIntervalLowerBound: __expectNumber(output.MetricIntervalLowerBound),
+    MetricIntervalUpperBound: __expectNumber(output.MetricIntervalUpperBound),
+    ScalingAdjustment: __expectNumber(output.ScalingAdjustment),
   } as any;
 };
 
@@ -1877,17 +1846,10 @@ const deserializeAws_json1_1StepScalingPolicyConfiguration = (
   context: __SerdeContext
 ): StepScalingPolicyConfiguration => {
   return {
-    AdjustmentType:
-      output.AdjustmentType !== undefined && output.AdjustmentType !== null ? output.AdjustmentType : undefined,
-    Cooldown: output.Cooldown !== undefined && output.Cooldown !== null ? output.Cooldown : undefined,
-    MetricAggregationType:
-      output.MetricAggregationType !== undefined && output.MetricAggregationType !== null
-        ? output.MetricAggregationType
-        : undefined,
-    MinAdjustmentMagnitude:
-      output.MinAdjustmentMagnitude !== undefined && output.MinAdjustmentMagnitude !== null
-        ? output.MinAdjustmentMagnitude
-        : undefined,
+    AdjustmentType: __expectString(output.AdjustmentType),
+    Cooldown: __expectNumber(output.Cooldown),
+    MetricAggregationType: __expectString(output.MetricAggregationType),
+    MinAdjustmentMagnitude: __expectNumber(output.MinAdjustmentMagnitude),
     StepAdjustments:
       output.StepAdjustments !== undefined && output.StepAdjustments !== null
         ? deserializeAws_json1_1StepAdjustments(output.StepAdjustments, context)
@@ -1897,18 +1859,9 @@ const deserializeAws_json1_1StepScalingPolicyConfiguration = (
 
 const deserializeAws_json1_1SuspendedState = (output: any, context: __SerdeContext): SuspendedState => {
   return {
-    DynamicScalingInSuspended:
-      output.DynamicScalingInSuspended !== undefined && output.DynamicScalingInSuspended !== null
-        ? output.DynamicScalingInSuspended
-        : undefined,
-    DynamicScalingOutSuspended:
-      output.DynamicScalingOutSuspended !== undefined && output.DynamicScalingOutSuspended !== null
-        ? output.DynamicScalingOutSuspended
-        : undefined,
-    ScheduledScalingSuspended:
-      output.ScheduledScalingSuspended !== undefined && output.ScheduledScalingSuspended !== null
-        ? output.ScheduledScalingSuspended
-        : undefined,
+    DynamicScalingInSuspended: __expectBoolean(output.DynamicScalingInSuspended),
+    DynamicScalingOutSuspended: __expectBoolean(output.DynamicScalingOutSuspended),
+    ScheduledScalingSuspended: __expectBoolean(output.ScheduledScalingSuspended),
   } as any;
 };
 
@@ -1921,23 +1874,20 @@ const deserializeAws_json1_1TargetTrackingScalingPolicyConfiguration = (
       output.CustomizedMetricSpecification !== undefined && output.CustomizedMetricSpecification !== null
         ? deserializeAws_json1_1CustomizedMetricSpecification(output.CustomizedMetricSpecification, context)
         : undefined,
-    DisableScaleIn:
-      output.DisableScaleIn !== undefined && output.DisableScaleIn !== null ? output.DisableScaleIn : undefined,
+    DisableScaleIn: __expectBoolean(output.DisableScaleIn),
     PredefinedMetricSpecification:
       output.PredefinedMetricSpecification !== undefined && output.PredefinedMetricSpecification !== null
         ? deserializeAws_json1_1PredefinedMetricSpecification(output.PredefinedMetricSpecification, context)
         : undefined,
-    ScaleInCooldown:
-      output.ScaleInCooldown !== undefined && output.ScaleInCooldown !== null ? output.ScaleInCooldown : undefined,
-    ScaleOutCooldown:
-      output.ScaleOutCooldown !== undefined && output.ScaleOutCooldown !== null ? output.ScaleOutCooldown : undefined,
-    TargetValue: output.TargetValue !== undefined && output.TargetValue !== null ? output.TargetValue : undefined,
+    ScaleInCooldown: __expectNumber(output.ScaleInCooldown),
+    ScaleOutCooldown: __expectNumber(output.ScaleOutCooldown),
+    TargetValue: __expectNumber(output.TargetValue),
   } as any;
 };
 
 const deserializeAws_json1_1ValidationException = (output: any, context: __SerdeContext): ValidationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 

--- a/clients/client-application-discovery-service/protocols/Aws_json1_1.ts
+++ b/clients/client-application-discovery-service/protocols/Aws_json1_1.ts
@@ -147,7 +147,12 @@ import {
   UpdateApplicationResponse,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -3388,12 +3393,9 @@ const deserializeAws_json1_1AgentConfigurationStatus = (
   context: __SerdeContext
 ): AgentConfigurationStatus => {
   return {
-    agentId: output.agentId !== undefined && output.agentId !== null ? output.agentId : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    operationSucceeded:
-      output.operationSucceeded !== undefined && output.operationSucceeded !== null
-        ? output.operationSucceeded
-        : undefined,
+    agentId: __expectString(output.agentId),
+    description: __expectString(output.description),
+    operationSucceeded: __expectBoolean(output.operationSucceeded),
   } as any;
 };
 
@@ -3413,31 +3415,26 @@ const deserializeAws_json1_1AgentConfigurationStatusList = (
 
 const deserializeAws_json1_1AgentInfo = (output: any, context: __SerdeContext): AgentInfo => {
   return {
-    agentId: output.agentId !== undefined && output.agentId !== null ? output.agentId : undefined,
+    agentId: __expectString(output.agentId),
     agentNetworkInfoList:
       output.agentNetworkInfoList !== undefined && output.agentNetworkInfoList !== null
         ? deserializeAws_json1_1AgentNetworkInfoList(output.agentNetworkInfoList, context)
         : undefined,
-    agentType: output.agentType !== undefined && output.agentType !== null ? output.agentType : undefined,
-    collectionStatus:
-      output.collectionStatus !== undefined && output.collectionStatus !== null ? output.collectionStatus : undefined,
-    connectorId: output.connectorId !== undefined && output.connectorId !== null ? output.connectorId : undefined,
-    health: output.health !== undefined && output.health !== null ? output.health : undefined,
-    hostName: output.hostName !== undefined && output.hostName !== null ? output.hostName : undefined,
-    lastHealthPingTime:
-      output.lastHealthPingTime !== undefined && output.lastHealthPingTime !== null
-        ? output.lastHealthPingTime
-        : undefined,
-    registeredTime:
-      output.registeredTime !== undefined && output.registeredTime !== null ? output.registeredTime : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    agentType: __expectString(output.agentType),
+    collectionStatus: __expectString(output.collectionStatus),
+    connectorId: __expectString(output.connectorId),
+    health: __expectString(output.health),
+    hostName: __expectString(output.hostName),
+    lastHealthPingTime: __expectString(output.lastHealthPingTime),
+    registeredTime: __expectString(output.registeredTime),
+    version: __expectString(output.version),
   } as any;
 };
 
 const deserializeAws_json1_1AgentNetworkInfo = (output: any, context: __SerdeContext): AgentNetworkInfo => {
   return {
-    ipAddress: output.ipAddress !== undefined && output.ipAddress !== null ? output.ipAddress : undefined,
-    macAddress: output.macAddress !== undefined && output.macAddress !== null ? output.macAddress : undefined,
+    ipAddress: __expectString(output.ipAddress),
+    macAddress: __expectString(output.macAddress),
   } as any;
 };
 
@@ -3475,7 +3472,7 @@ const deserializeAws_json1_1AuthorizationErrorException = (
   context: __SerdeContext
 ): AuthorizationErrorException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3484,10 +3481,9 @@ const deserializeAws_json1_1BatchDeleteImportDataError = (
   context: __SerdeContext
 ): BatchDeleteImportDataError => {
   return {
-    errorCode: output.errorCode !== undefined && output.errorCode !== null ? output.errorCode : undefined,
-    errorDescription:
-      output.errorDescription !== undefined && output.errorDescription !== null ? output.errorDescription : undefined,
-    importTaskId: output.importTaskId !== undefined && output.importTaskId !== null ? output.importTaskId : undefined,
+    errorCode: __expectString(output.errorCode),
+    errorDescription: __expectString(output.errorDescription),
+    importTaskId: __expectString(output.importTaskId),
   } as any;
 };
 
@@ -3524,7 +3520,7 @@ const deserializeAws_json1_1Configuration = (output: any, context: __SerdeContex
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -3542,18 +3538,14 @@ const deserializeAws_json1_1Configurations = (output: any, context: __SerdeConte
 
 const deserializeAws_json1_1ConfigurationTag = (output: any, context: __SerdeContext): ConfigurationTag => {
   return {
-    configurationId:
-      output.configurationId !== undefined && output.configurationId !== null ? output.configurationId : undefined,
-    configurationType:
-      output.configurationType !== undefined && output.configurationType !== null
-        ? output.configurationType
-        : undefined,
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
+    configurationId: __expectString(output.configurationId),
+    configurationType: __expectString(output.configurationType),
+    key: __expectString(output.key),
     timeOfCreation:
       output.timeOfCreation !== undefined && output.timeOfCreation !== null
         ? new Date(Math.round(output.timeOfCreation * 1000))
         : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -3570,7 +3562,7 @@ const deserializeAws_json1_1ConfigurationTagSet = (output: any, context: __Serde
 
 const deserializeAws_json1_1ConflictErrorException = (output: any, context: __SerdeContext): ConflictErrorException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3579,9 +3571,9 @@ const deserializeAws_json1_1ContinuousExportDescription = (
   context: __SerdeContext
 ): ContinuousExportDescription => {
   return {
-    dataSource: output.dataSource !== undefined && output.dataSource !== null ? output.dataSource : undefined,
-    exportId: output.exportId !== undefined && output.exportId !== null ? output.exportId : undefined,
-    s3Bucket: output.s3Bucket !== undefined && output.s3Bucket !== null ? output.s3Bucket : undefined,
+    dataSource: __expectString(output.dataSource),
+    exportId: __expectString(output.exportId),
+    s3Bucket: __expectString(output.s3Bucket),
     schemaStorageConfig:
       output.schemaStorageConfig !== undefined && output.schemaStorageConfig !== null
         ? deserializeAws_json1_1SchemaStorageConfig(output.schemaStorageConfig, context)
@@ -3590,8 +3582,8 @@ const deserializeAws_json1_1ContinuousExportDescription = (
       output.startTime !== undefined && output.startTime !== null
         ? new Date(Math.round(output.startTime * 1000))
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    statusDetail: output.statusDetail !== undefined && output.statusDetail !== null ? output.statusDetail : undefined,
+    status: __expectString(output.status),
+    statusDetail: __expectString(output.statusDetail),
     stopTime:
       output.stopTime !== undefined && output.stopTime !== null
         ? new Date(Math.round(output.stopTime * 1000))
@@ -3618,8 +3610,7 @@ const deserializeAws_json1_1CreateApplicationResponse = (
   context: __SerdeContext
 ): CreateApplicationResponse => {
   return {
-    configurationId:
-      output.configurationId !== undefined && output.configurationId !== null ? output.configurationId : undefined,
+    configurationId: __expectString(output.configurationId),
   } as any;
 };
 
@@ -3629,49 +3620,25 @@ const deserializeAws_json1_1CreateTagsResponse = (output: any, context: __SerdeC
 
 const deserializeAws_json1_1CustomerAgentInfo = (output: any, context: __SerdeContext): CustomerAgentInfo => {
   return {
-    activeAgents: output.activeAgents !== undefined && output.activeAgents !== null ? output.activeAgents : undefined,
-    blackListedAgents:
-      output.blackListedAgents !== undefined && output.blackListedAgents !== null
-        ? output.blackListedAgents
-        : undefined,
-    healthyAgents:
-      output.healthyAgents !== undefined && output.healthyAgents !== null ? output.healthyAgents : undefined,
-    shutdownAgents:
-      output.shutdownAgents !== undefined && output.shutdownAgents !== null ? output.shutdownAgents : undefined,
-    totalAgents: output.totalAgents !== undefined && output.totalAgents !== null ? output.totalAgents : undefined,
-    unhealthyAgents:
-      output.unhealthyAgents !== undefined && output.unhealthyAgents !== null ? output.unhealthyAgents : undefined,
-    unknownAgents:
-      output.unknownAgents !== undefined && output.unknownAgents !== null ? output.unknownAgents : undefined,
+    activeAgents: __expectNumber(output.activeAgents),
+    blackListedAgents: __expectNumber(output.blackListedAgents),
+    healthyAgents: __expectNumber(output.healthyAgents),
+    shutdownAgents: __expectNumber(output.shutdownAgents),
+    totalAgents: __expectNumber(output.totalAgents),
+    unhealthyAgents: __expectNumber(output.unhealthyAgents),
+    unknownAgents: __expectNumber(output.unknownAgents),
   } as any;
 };
 
 const deserializeAws_json1_1CustomerConnectorInfo = (output: any, context: __SerdeContext): CustomerConnectorInfo => {
   return {
-    activeConnectors:
-      output.activeConnectors !== undefined && output.activeConnectors !== null ? output.activeConnectors : undefined,
-    blackListedConnectors:
-      output.blackListedConnectors !== undefined && output.blackListedConnectors !== null
-        ? output.blackListedConnectors
-        : undefined,
-    healthyConnectors:
-      output.healthyConnectors !== undefined && output.healthyConnectors !== null
-        ? output.healthyConnectors
-        : undefined,
-    shutdownConnectors:
-      output.shutdownConnectors !== undefined && output.shutdownConnectors !== null
-        ? output.shutdownConnectors
-        : undefined,
-    totalConnectors:
-      output.totalConnectors !== undefined && output.totalConnectors !== null ? output.totalConnectors : undefined,
-    unhealthyConnectors:
-      output.unhealthyConnectors !== undefined && output.unhealthyConnectors !== null
-        ? output.unhealthyConnectors
-        : undefined,
-    unknownConnectors:
-      output.unknownConnectors !== undefined && output.unknownConnectors !== null
-        ? output.unknownConnectors
-        : undefined,
+    activeConnectors: __expectNumber(output.activeConnectors),
+    blackListedConnectors: __expectNumber(output.blackListedConnectors),
+    healthyConnectors: __expectNumber(output.healthyConnectors),
+    shutdownConnectors: __expectNumber(output.shutdownConnectors),
+    totalConnectors: __expectNumber(output.totalConnectors),
+    unhealthyConnectors: __expectNumber(output.unhealthyConnectors),
+    unknownConnectors: __expectNumber(output.unknownConnectors),
   } as any;
 };
 
@@ -3692,7 +3659,7 @@ const deserializeAws_json1_1DescribeAgentsResponse = (output: any, context: __Se
       output.agentsInfo !== undefined && output.agentsInfo !== null
         ? deserializeAws_json1_1AgentsInfo(output.agentsInfo, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -3706,7 +3673,7 @@ const deserializeAws_json1_1DescribeConfigurationsAttribute = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -3746,7 +3713,7 @@ const deserializeAws_json1_1DescribeContinuousExportsResponse = (
       output.descriptions !== undefined && output.descriptions !== null
         ? deserializeAws_json1_1ContinuousExportDescriptions(output.descriptions, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -3759,7 +3726,7 @@ const deserializeAws_json1_1DescribeExportConfigurationsResponse = (
       output.exportsInfo !== undefined && output.exportsInfo !== null
         ? deserializeAws_json1_1ExportsInfo(output.exportsInfo, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -3772,7 +3739,7 @@ const deserializeAws_json1_1DescribeExportTasksResponse = (
       output.exportsInfo !== undefined && output.exportsInfo !== null
         ? deserializeAws_json1_1ExportsInfo(output.exportsInfo, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -3781,7 +3748,7 @@ const deserializeAws_json1_1DescribeImportTasksResponse = (
   context: __SerdeContext
 ): DescribeImportTasksResponse => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     tasks:
       output.tasks !== undefined && output.tasks !== null
         ? deserializeAws_json1_1ImportTaskList(output.tasks, context)
@@ -3791,7 +3758,7 @@ const deserializeAws_json1_1DescribeImportTasksResponse = (
 
 const deserializeAws_json1_1DescribeTagsResponse = (output: any, context: __SerdeContext): DescribeTagsResponse => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_json1_1ConfigurationTagSet(output.tags, context)
@@ -3811,23 +3778,20 @@ const deserializeAws_json1_1ExportConfigurationsResponse = (
   context: __SerdeContext
 ): ExportConfigurationsResponse => {
   return {
-    exportId: output.exportId !== undefined && output.exportId !== null ? output.exportId : undefined,
+    exportId: __expectString(output.exportId),
   } as any;
 };
 
 const deserializeAws_json1_1ExportInfo = (output: any, context: __SerdeContext): ExportInfo => {
   return {
-    configurationsDownloadUrl:
-      output.configurationsDownloadUrl !== undefined && output.configurationsDownloadUrl !== null
-        ? output.configurationsDownloadUrl
-        : undefined,
-    exportId: output.exportId !== undefined && output.exportId !== null ? output.exportId : undefined,
+    configurationsDownloadUrl: __expectString(output.configurationsDownloadUrl),
+    exportId: __expectString(output.exportId),
     exportRequestTime:
       output.exportRequestTime !== undefined && output.exportRequestTime !== null
         ? new Date(Math.round(output.exportRequestTime * 1000))
         : undefined,
-    exportStatus: output.exportStatus !== undefined && output.exportStatus !== null ? output.exportStatus : undefined,
-    isTruncated: output.isTruncated !== undefined && output.isTruncated !== null ? output.isTruncated : undefined,
+    exportStatus: __expectString(output.exportStatus),
+    isTruncated: __expectBoolean(output.isTruncated),
     requestedEndTime:
       output.requestedEndTime !== undefined && output.requestedEndTime !== null
         ? new Date(Math.round(output.requestedEndTime * 1000))
@@ -3836,8 +3800,7 @@ const deserializeAws_json1_1ExportInfo = (output: any, context: __SerdeContext):
       output.requestedStartTime !== undefined && output.requestedStartTime !== null
         ? new Date(Math.round(output.requestedStartTime * 1000))
         : undefined,
-    statusMessage:
-      output.statusMessage !== undefined && output.statusMessage !== null ? output.statusMessage : undefined,
+    statusMessage: __expectString(output.statusMessage),
   } as any;
 };
 
@@ -3861,20 +3824,14 @@ const deserializeAws_json1_1GetDiscoverySummaryResponse = (
       output.agentSummary !== undefined && output.agentSummary !== null
         ? deserializeAws_json1_1CustomerAgentInfo(output.agentSummary, context)
         : undefined,
-    applications: output.applications !== undefined && output.applications !== null ? output.applications : undefined,
+    applications: __expectNumber(output.applications),
     connectorSummary:
       output.connectorSummary !== undefined && output.connectorSummary !== null
         ? deserializeAws_json1_1CustomerConnectorInfo(output.connectorSummary, context)
         : undefined,
-    servers: output.servers !== undefined && output.servers !== null ? output.servers : undefined,
-    serversMappedToApplications:
-      output.serversMappedToApplications !== undefined && output.serversMappedToApplications !== null
-        ? output.serversMappedToApplications
-        : undefined,
-    serversMappedtoTags:
-      output.serversMappedtoTags !== undefined && output.serversMappedtoTags !== null
-        ? output.serversMappedtoTags
-        : undefined,
+    servers: __expectNumber(output.servers),
+    serversMappedToApplications: __expectNumber(output.serversMappedToApplications),
+    serversMappedtoTags: __expectNumber(output.serversMappedtoTags),
   } as any;
 };
 
@@ -3883,28 +3840,16 @@ const deserializeAws_json1_1HomeRegionNotSetException = (
   context: __SerdeContext
 ): HomeRegionNotSetException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1ImportTask = (output: any, context: __SerdeContext): ImportTask => {
   return {
-    applicationImportFailure:
-      output.applicationImportFailure !== undefined && output.applicationImportFailure !== null
-        ? output.applicationImportFailure
-        : undefined,
-    applicationImportSuccess:
-      output.applicationImportSuccess !== undefined && output.applicationImportSuccess !== null
-        ? output.applicationImportSuccess
-        : undefined,
-    clientRequestToken:
-      output.clientRequestToken !== undefined && output.clientRequestToken !== null
-        ? output.clientRequestToken
-        : undefined,
-    errorsAndFailedEntriesZip:
-      output.errorsAndFailedEntriesZip !== undefined && output.errorsAndFailedEntriesZip !== null
-        ? output.errorsAndFailedEntriesZip
-        : undefined,
+    applicationImportFailure: __expectNumber(output.applicationImportFailure),
+    applicationImportSuccess: __expectNumber(output.applicationImportSuccess),
+    clientRequestToken: __expectString(output.clientRequestToken),
+    errorsAndFailedEntriesZip: __expectString(output.errorsAndFailedEntriesZip),
     importCompletionTime:
       output.importCompletionTime !== undefined && output.importCompletionTime !== null
         ? new Date(Math.round(output.importCompletionTime * 1000))
@@ -3917,18 +3862,12 @@ const deserializeAws_json1_1ImportTask = (output: any, context: __SerdeContext):
       output.importRequestTime !== undefined && output.importRequestTime !== null
         ? new Date(Math.round(output.importRequestTime * 1000))
         : undefined,
-    importTaskId: output.importTaskId !== undefined && output.importTaskId !== null ? output.importTaskId : undefined,
-    importUrl: output.importUrl !== undefined && output.importUrl !== null ? output.importUrl : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    serverImportFailure:
-      output.serverImportFailure !== undefined && output.serverImportFailure !== null
-        ? output.serverImportFailure
-        : undefined,
-    serverImportSuccess:
-      output.serverImportSuccess !== undefined && output.serverImportSuccess !== null
-        ? output.serverImportSuccess
-        : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    importTaskId: __expectString(output.importTaskId),
+    importUrl: __expectString(output.importUrl),
+    name: __expectString(output.name),
+    serverImportFailure: __expectNumber(output.serverImportFailure),
+    serverImportSuccess: __expectNumber(output.serverImportSuccess),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -3948,7 +3887,7 @@ const deserializeAws_json1_1InvalidParameterException = (
   context: __SerdeContext
 ): InvalidParameterException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3957,7 +3896,7 @@ const deserializeAws_json1_1InvalidParameterValueException = (
   context: __SerdeContext
 ): InvalidParameterValueException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3970,7 +3909,7 @@ const deserializeAws_json1_1ListConfigurationsResponse = (
       output.configurations !== undefined && output.configurations !== null
         ? deserializeAws_json1_1Configurations(output.configurations, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -3979,15 +3918,12 @@ const deserializeAws_json1_1ListServerNeighborsResponse = (
   context: __SerdeContext
 ): ListServerNeighborsResponse => {
   return {
-    knownDependencyCount:
-      output.knownDependencyCount !== undefined && output.knownDependencyCount !== null
-        ? output.knownDependencyCount
-        : undefined,
+    knownDependencyCount: __expectNumber(output.knownDependencyCount),
     neighbors:
       output.neighbors !== undefined && output.neighbors !== null
         ? deserializeAws_json1_1NeighborDetailsList(output.neighbors, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -3996,20 +3932,11 @@ const deserializeAws_json1_1NeighborConnectionDetail = (
   context: __SerdeContext
 ): NeighborConnectionDetail => {
   return {
-    connectionsCount:
-      output.connectionsCount !== undefined && output.connectionsCount !== null ? output.connectionsCount : undefined,
-    destinationPort:
-      output.destinationPort !== undefined && output.destinationPort !== null ? output.destinationPort : undefined,
-    destinationServerId:
-      output.destinationServerId !== undefined && output.destinationServerId !== null
-        ? output.destinationServerId
-        : undefined,
-    sourceServerId:
-      output.sourceServerId !== undefined && output.sourceServerId !== null ? output.sourceServerId : undefined,
-    transportProtocol:
-      output.transportProtocol !== undefined && output.transportProtocol !== null
-        ? output.transportProtocol
-        : undefined,
+    connectionsCount: __expectNumber(output.connectionsCount),
+    destinationPort: __expectNumber(output.destinationPort),
+    destinationServerId: __expectString(output.destinationServerId),
+    sourceServerId: __expectString(output.sourceServerId),
+    transportProtocol: __expectString(output.transportProtocol),
   } as any;
 };
 
@@ -4032,13 +3959,13 @@ const deserializeAws_json1_1OperationNotPermittedException = (
   context: __SerdeContext
 ): OperationNotPermittedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1ResourceInUseException = (output: any, context: __SerdeContext): ResourceInUseException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -4047,7 +3974,7 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -4058,7 +3985,7 @@ const deserializeAws_json1_1SchemaStorageConfig = (output: any, context: __Serde
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -4068,7 +3995,7 @@ const deserializeAws_json1_1ServerInternalErrorException = (
   context: __SerdeContext
 ): ServerInternalErrorException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -4077,9 +4004,9 @@ const deserializeAws_json1_1StartContinuousExportResponse = (
   context: __SerdeContext
 ): StartContinuousExportResponse => {
   return {
-    dataSource: output.dataSource !== undefined && output.dataSource !== null ? output.dataSource : undefined,
-    exportId: output.exportId !== undefined && output.exportId !== null ? output.exportId : undefined,
-    s3Bucket: output.s3Bucket !== undefined && output.s3Bucket !== null ? output.s3Bucket : undefined,
+    dataSource: __expectString(output.dataSource),
+    exportId: __expectString(output.exportId),
+    s3Bucket: __expectString(output.s3Bucket),
     schemaStorageConfig:
       output.schemaStorageConfig !== undefined && output.schemaStorageConfig !== null
         ? deserializeAws_json1_1SchemaStorageConfig(output.schemaStorageConfig, context)
@@ -4108,7 +4035,7 @@ const deserializeAws_json1_1StartExportTaskResponse = (
   context: __SerdeContext
 ): StartExportTaskResponse => {
   return {
-    exportId: output.exportId !== undefined && output.exportId !== null ? output.exportId : undefined,
+    exportId: __expectString(output.exportId),
   } as any;
 };
 

--- a/clients/client-application-insights/protocols/Aws_json1_1.ts
+++ b/clients/client-application-insights/protocols/Aws_json1_1.ts
@@ -125,7 +125,12 @@ import {
   ValidationException,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -2883,24 +2888,22 @@ const serializeAws_json1_1UpdateLogPatternRequest = (input: UpdateLogPatternRequ
 
 const deserializeAws_json1_1AccessDeniedException = (output: any, context: __SerdeContext): AccessDeniedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1ApplicationComponent = (output: any, context: __SerdeContext): ApplicationComponent => {
   return {
-    ComponentName:
-      output.ComponentName !== undefined && output.ComponentName !== null ? output.ComponentName : undefined,
-    ComponentRemarks:
-      output.ComponentRemarks !== undefined && output.ComponentRemarks !== null ? output.ComponentRemarks : undefined,
+    ComponentName: __expectString(output.ComponentName),
+    ComponentRemarks: __expectString(output.ComponentRemarks),
     DetectedWorkload:
       output.DetectedWorkload !== undefined && output.DetectedWorkload !== null
         ? deserializeAws_json1_1DetectedWorkload(output.DetectedWorkload, context)
         : undefined,
-    Monitor: output.Monitor !== undefined && output.Monitor !== null ? output.Monitor : undefined,
-    OsType: output.OsType !== undefined && output.OsType !== null ? output.OsType : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
-    Tier: output.Tier !== undefined && output.Tier !== null ? output.Tier : undefined,
+    Monitor: __expectBoolean(output.Monitor),
+    OsType: __expectString(output.OsType),
+    ResourceType: __expectString(output.ResourceType),
+    Tier: __expectString(output.Tier),
   } as any;
 };
 
@@ -2920,22 +2923,12 @@ const deserializeAws_json1_1ApplicationComponentList = (
 
 const deserializeAws_json1_1ApplicationInfo = (output: any, context: __SerdeContext): ApplicationInfo => {
   return {
-    CWEMonitorEnabled:
-      output.CWEMonitorEnabled !== undefined && output.CWEMonitorEnabled !== null
-        ? output.CWEMonitorEnabled
-        : undefined,
-    LifeCycle: output.LifeCycle !== undefined && output.LifeCycle !== null ? output.LifeCycle : undefined,
-    OpsCenterEnabled:
-      output.OpsCenterEnabled !== undefined && output.OpsCenterEnabled !== null ? output.OpsCenterEnabled : undefined,
-    OpsItemSNSTopicArn:
-      output.OpsItemSNSTopicArn !== undefined && output.OpsItemSNSTopicArn !== null
-        ? output.OpsItemSNSTopicArn
-        : undefined,
-    Remarks: output.Remarks !== undefined && output.Remarks !== null ? output.Remarks : undefined,
-    ResourceGroupName:
-      output.ResourceGroupName !== undefined && output.ResourceGroupName !== null
-        ? output.ResourceGroupName
-        : undefined,
+    CWEMonitorEnabled: __expectBoolean(output.CWEMonitorEnabled),
+    LifeCycle: __expectString(output.LifeCycle),
+    OpsCenterEnabled: __expectBoolean(output.OpsCenterEnabled),
+    OpsItemSNSTopicArn: __expectString(output.OpsItemSNSTopicArn),
+    Remarks: __expectString(output.Remarks),
+    ResourceGroupName: __expectString(output.ResourceGroupName),
   } as any;
 };
 
@@ -2952,30 +2945,21 @@ const deserializeAws_json1_1ApplicationInfoList = (output: any, context: __Serde
 
 const deserializeAws_json1_1BadRequestException = (output: any, context: __SerdeContext): BadRequestException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1ConfigurationEvent = (output: any, context: __SerdeContext): ConfigurationEvent => {
   return {
-    EventDetail: output.EventDetail !== undefined && output.EventDetail !== null ? output.EventDetail : undefined,
-    EventResourceName:
-      output.EventResourceName !== undefined && output.EventResourceName !== null
-        ? output.EventResourceName
-        : undefined,
-    EventResourceType:
-      output.EventResourceType !== undefined && output.EventResourceType !== null
-        ? output.EventResourceType
-        : undefined,
-    EventStatus: output.EventStatus !== undefined && output.EventStatus !== null ? output.EventStatus : undefined,
+    EventDetail: __expectString(output.EventDetail),
+    EventResourceName: __expectString(output.EventResourceName),
+    EventResourceType: __expectString(output.EventResourceType),
+    EventStatus: __expectString(output.EventStatus),
     EventTime:
       output.EventTime !== undefined && output.EventTime !== null
         ? new Date(Math.round(output.EventTime * 1000))
         : undefined,
-    MonitoredResourceARN:
-      output.MonitoredResourceARN !== undefined && output.MonitoredResourceARN !== null
-        ? output.MonitoredResourceARN
-        : undefined,
+    MonitoredResourceARN: __expectString(output.MonitoredResourceARN),
   } as any;
 };
 
@@ -3018,10 +3002,7 @@ const deserializeAws_json1_1CreateLogPatternResponse = (
       output.LogPattern !== undefined && output.LogPattern !== null
         ? deserializeAws_json1_1LogPattern(output.LogPattern, context)
         : undefined,
-    ResourceGroupName:
-      output.ResourceGroupName !== undefined && output.ResourceGroupName !== null
-        ? output.ResourceGroupName
-        : undefined,
+    ResourceGroupName: __expectString(output.ResourceGroupName),
   } as any;
 };
 
@@ -3063,10 +3044,7 @@ const deserializeAws_json1_1DescribeComponentConfigurationRecommendationResponse
   context: __SerdeContext
 ): DescribeComponentConfigurationRecommendationResponse => {
   return {
-    ComponentConfiguration:
-      output.ComponentConfiguration !== undefined && output.ComponentConfiguration !== null
-        ? output.ComponentConfiguration
-        : undefined,
+    ComponentConfiguration: __expectString(output.ComponentConfiguration),
   } as any;
 };
 
@@ -3075,12 +3053,9 @@ const deserializeAws_json1_1DescribeComponentConfigurationResponse = (
   context: __SerdeContext
 ): DescribeComponentConfigurationResponse => {
   return {
-    ComponentConfiguration:
-      output.ComponentConfiguration !== undefined && output.ComponentConfiguration !== null
-        ? output.ComponentConfiguration
-        : undefined,
-    Monitor: output.Monitor !== undefined && output.Monitor !== null ? output.Monitor : undefined,
-    Tier: output.Tier !== undefined && output.Tier !== null ? output.Tier : undefined,
+    ComponentConfiguration: __expectString(output.ComponentConfiguration),
+    Monitor: __expectBoolean(output.Monitor),
+    Tier: __expectString(output.Tier),
   } as any;
 };
 
@@ -3109,10 +3084,7 @@ const deserializeAws_json1_1DescribeLogPatternResponse = (
       output.LogPattern !== undefined && output.LogPattern !== null
         ? deserializeAws_json1_1LogPattern(output.LogPattern, context)
         : undefined,
-    ResourceGroupName:
-      output.ResourceGroupName !== undefined && output.ResourceGroupName !== null
-        ? output.ResourceGroupName
-        : undefined,
+    ResourceGroupName: __expectString(output.ResourceGroupName),
   } as any;
 };
 
@@ -3181,7 +3153,7 @@ const deserializeAws_json1_1Feedback = (
       }
       return {
         ...acc,
-        [key]: value,
+        [key]: __expectString(value) as any,
       };
     },
     {}
@@ -3193,7 +3165,7 @@ const deserializeAws_json1_1InternalServerException = (
   context: __SerdeContext
 ): InternalServerException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3206,7 +3178,7 @@ const deserializeAws_json1_1ListApplicationsResponse = (
       output.ApplicationInfoList !== undefined && output.ApplicationInfoList !== null
         ? deserializeAws_json1_1ApplicationInfoList(output.ApplicationInfoList, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -3216,7 +3188,7 @@ const deserializeAws_json1_1ListComponentsResponse = (output: any, context: __Se
       output.ApplicationComponentList !== undefined && output.ApplicationComponentList !== null
         ? deserializeAws_json1_1ApplicationComponentList(output.ApplicationComponentList, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -3229,7 +3201,7 @@ const deserializeAws_json1_1ListConfigurationHistoryResponse = (
       output.EventList !== undefined && output.EventList !== null
         ? deserializeAws_json1_1ConfigurationEventList(output.EventList, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -3242,11 +3214,8 @@ const deserializeAws_json1_1ListLogPatternSetsResponse = (
       output.LogPatternSets !== undefined && output.LogPatternSets !== null
         ? deserializeAws_json1_1LogPatternSetList(output.LogPatternSets, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
-    ResourceGroupName:
-      output.ResourceGroupName !== undefined && output.ResourceGroupName !== null
-        ? output.ResourceGroupName
-        : undefined,
+    NextToken: __expectString(output.NextToken),
+    ResourceGroupName: __expectString(output.ResourceGroupName),
   } as any;
 };
 
@@ -3259,17 +3228,14 @@ const deserializeAws_json1_1ListLogPatternsResponse = (
       output.LogPatterns !== undefined && output.LogPatterns !== null
         ? deserializeAws_json1_1LogPatternList(output.LogPatterns, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
-    ResourceGroupName:
-      output.ResourceGroupName !== undefined && output.ResourceGroupName !== null
-        ? output.ResourceGroupName
-        : undefined,
+    NextToken: __expectString(output.NextToken),
+    ResourceGroupName: __expectString(output.ResourceGroupName),
   } as any;
 };
 
 const deserializeAws_json1_1ListProblemsResponse = (output: any, context: __SerdeContext): ListProblemsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     ProblemList:
       output.ProblemList !== undefined && output.ProblemList !== null
         ? deserializeAws_json1_1ProblemList(output.ProblemList, context)
@@ -3291,11 +3257,10 @@ const deserializeAws_json1_1ListTagsForResourceResponse = (
 
 const deserializeAws_json1_1LogPattern = (output: any, context: __SerdeContext): LogPattern => {
   return {
-    Pattern: output.Pattern !== undefined && output.Pattern !== null ? output.Pattern : undefined,
-    PatternName: output.PatternName !== undefined && output.PatternName !== null ? output.PatternName : undefined,
-    PatternSetName:
-      output.PatternSetName !== undefined && output.PatternSetName !== null ? output.PatternSetName : undefined,
-    Rank: output.Rank !== undefined && output.Rank !== null ? output.Rank : undefined,
+    Pattern: __expectString(output.Pattern),
+    PatternName: __expectString(output.PatternName),
+    PatternSetName: __expectString(output.PatternSetName),
+    Rank: __expectNumber(output.Rank),
   } as any;
 };
 
@@ -3317,114 +3282,64 @@ const deserializeAws_json1_1LogPatternSetList = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1Observation = (output: any, context: __SerdeContext): Observation => {
   return {
-    CloudWatchEventDetailType:
-      output.CloudWatchEventDetailType !== undefined && output.CloudWatchEventDetailType !== null
-        ? output.CloudWatchEventDetailType
-        : undefined,
-    CloudWatchEventId:
-      output.CloudWatchEventId !== undefined && output.CloudWatchEventId !== null
-        ? output.CloudWatchEventId
-        : undefined,
-    CloudWatchEventSource:
-      output.CloudWatchEventSource !== undefined && output.CloudWatchEventSource !== null
-        ? output.CloudWatchEventSource
-        : undefined,
-    CodeDeployApplication:
-      output.CodeDeployApplication !== undefined && output.CodeDeployApplication !== null
-        ? output.CodeDeployApplication
-        : undefined,
-    CodeDeployDeploymentGroup:
-      output.CodeDeployDeploymentGroup !== undefined && output.CodeDeployDeploymentGroup !== null
-        ? output.CodeDeployDeploymentGroup
-        : undefined,
-    CodeDeployDeploymentId:
-      output.CodeDeployDeploymentId !== undefined && output.CodeDeployDeploymentId !== null
-        ? output.CodeDeployDeploymentId
-        : undefined,
-    CodeDeployInstanceGroupId:
-      output.CodeDeployInstanceGroupId !== undefined && output.CodeDeployInstanceGroupId !== null
-        ? output.CodeDeployInstanceGroupId
-        : undefined,
-    CodeDeployState:
-      output.CodeDeployState !== undefined && output.CodeDeployState !== null ? output.CodeDeployState : undefined,
-    EbsCause: output.EbsCause !== undefined && output.EbsCause !== null ? output.EbsCause : undefined,
-    EbsEvent: output.EbsEvent !== undefined && output.EbsEvent !== null ? output.EbsEvent : undefined,
-    EbsRequestId: output.EbsRequestId !== undefined && output.EbsRequestId !== null ? output.EbsRequestId : undefined,
-    EbsResult: output.EbsResult !== undefined && output.EbsResult !== null ? output.EbsResult : undefined,
-    Ec2State: output.Ec2State !== undefined && output.Ec2State !== null ? output.Ec2State : undefined,
+    CloudWatchEventDetailType: __expectString(output.CloudWatchEventDetailType),
+    CloudWatchEventId: __expectString(output.CloudWatchEventId),
+    CloudWatchEventSource: __expectString(output.CloudWatchEventSource),
+    CodeDeployApplication: __expectString(output.CodeDeployApplication),
+    CodeDeployDeploymentGroup: __expectString(output.CodeDeployDeploymentGroup),
+    CodeDeployDeploymentId: __expectString(output.CodeDeployDeploymentId),
+    CodeDeployInstanceGroupId: __expectString(output.CodeDeployInstanceGroupId),
+    CodeDeployState: __expectString(output.CodeDeployState),
+    EbsCause: __expectString(output.EbsCause),
+    EbsEvent: __expectString(output.EbsEvent),
+    EbsRequestId: __expectString(output.EbsRequestId),
+    EbsResult: __expectString(output.EbsResult),
+    Ec2State: __expectString(output.Ec2State),
     EndTime:
       output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
-    HealthEventArn:
-      output.HealthEventArn !== undefined && output.HealthEventArn !== null ? output.HealthEventArn : undefined,
-    HealthEventDescription:
-      output.HealthEventDescription !== undefined && output.HealthEventDescription !== null
-        ? output.HealthEventDescription
-        : undefined,
-    HealthEventTypeCategory:
-      output.HealthEventTypeCategory !== undefined && output.HealthEventTypeCategory !== null
-        ? output.HealthEventTypeCategory
-        : undefined,
-    HealthEventTypeCode:
-      output.HealthEventTypeCode !== undefined && output.HealthEventTypeCode !== null
-        ? output.HealthEventTypeCode
-        : undefined,
-    HealthService:
-      output.HealthService !== undefined && output.HealthService !== null ? output.HealthService : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    HealthEventArn: __expectString(output.HealthEventArn),
+    HealthEventDescription: __expectString(output.HealthEventDescription),
+    HealthEventTypeCategory: __expectString(output.HealthEventTypeCategory),
+    HealthEventTypeCode: __expectString(output.HealthEventTypeCode),
+    HealthService: __expectString(output.HealthService),
+    Id: __expectString(output.Id),
     LineTime:
       output.LineTime !== undefined && output.LineTime !== null
         ? new Date(Math.round(output.LineTime * 1000))
         : undefined,
-    LogFilter: output.LogFilter !== undefined && output.LogFilter !== null ? output.LogFilter : undefined,
-    LogGroup: output.LogGroup !== undefined && output.LogGroup !== null ? output.LogGroup : undefined,
-    LogText: output.LogText !== undefined && output.LogText !== null ? output.LogText : undefined,
-    MetricName: output.MetricName !== undefined && output.MetricName !== null ? output.MetricName : undefined,
-    MetricNamespace:
-      output.MetricNamespace !== undefined && output.MetricNamespace !== null ? output.MetricNamespace : undefined,
-    RdsEventCategories:
-      output.RdsEventCategories !== undefined && output.RdsEventCategories !== null
-        ? output.RdsEventCategories
-        : undefined,
-    RdsEventMessage:
-      output.RdsEventMessage !== undefined && output.RdsEventMessage !== null ? output.RdsEventMessage : undefined,
-    S3EventName: output.S3EventName !== undefined && output.S3EventName !== null ? output.S3EventName : undefined,
-    SourceARN: output.SourceARN !== undefined && output.SourceARN !== null ? output.SourceARN : undefined,
-    SourceType: output.SourceType !== undefined && output.SourceType !== null ? output.SourceType : undefined,
+    LogFilter: __expectString(output.LogFilter),
+    LogGroup: __expectString(output.LogGroup),
+    LogText: __expectString(output.LogText),
+    MetricName: __expectString(output.MetricName),
+    MetricNamespace: __expectString(output.MetricNamespace),
+    RdsEventCategories: __expectString(output.RdsEventCategories),
+    RdsEventMessage: __expectString(output.RdsEventMessage),
+    S3EventName: __expectString(output.S3EventName),
+    SourceARN: __expectString(output.SourceARN),
+    SourceType: __expectString(output.SourceType),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
         ? new Date(Math.round(output.StartTime * 1000))
         : undefined,
-    StatesArn: output.StatesArn !== undefined && output.StatesArn !== null ? output.StatesArn : undefined,
-    StatesExecutionArn:
-      output.StatesExecutionArn !== undefined && output.StatesExecutionArn !== null
-        ? output.StatesExecutionArn
-        : undefined,
-    StatesInput: output.StatesInput !== undefined && output.StatesInput !== null ? output.StatesInput : undefined,
-    StatesStatus: output.StatesStatus !== undefined && output.StatesStatus !== null ? output.StatesStatus : undefined,
-    Unit: output.Unit !== undefined && output.Unit !== null ? output.Unit : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
-    XRayErrorPercent:
-      output.XRayErrorPercent !== undefined && output.XRayErrorPercent !== null ? output.XRayErrorPercent : undefined,
-    XRayFaultPercent:
-      output.XRayFaultPercent !== undefined && output.XRayFaultPercent !== null ? output.XRayFaultPercent : undefined,
-    XRayNodeName: output.XRayNodeName !== undefined && output.XRayNodeName !== null ? output.XRayNodeName : undefined,
-    XRayNodeType: output.XRayNodeType !== undefined && output.XRayNodeType !== null ? output.XRayNodeType : undefined,
-    XRayRequestAverageLatency:
-      output.XRayRequestAverageLatency !== undefined && output.XRayRequestAverageLatency !== null
-        ? output.XRayRequestAverageLatency
-        : undefined,
-    XRayRequestCount:
-      output.XRayRequestCount !== undefined && output.XRayRequestCount !== null ? output.XRayRequestCount : undefined,
-    XRayThrottlePercent:
-      output.XRayThrottlePercent !== undefined && output.XRayThrottlePercent !== null
-        ? output.XRayThrottlePercent
-        : undefined,
+    StatesArn: __expectString(output.StatesArn),
+    StatesExecutionArn: __expectString(output.StatesExecutionArn),
+    StatesInput: __expectString(output.StatesInput),
+    StatesStatus: __expectString(output.StatesStatus),
+    Unit: __expectString(output.Unit),
+    Value: __expectNumber(output.Value),
+    XRayErrorPercent: __expectNumber(output.XRayErrorPercent),
+    XRayFaultPercent: __expectNumber(output.XRayFaultPercent),
+    XRayNodeName: __expectString(output.XRayNodeName),
+    XRayNodeType: __expectString(output.XRayNodeType),
+    XRayRequestAverageLatency: __expectNumber(output.XRayRequestAverageLatency),
+    XRayRequestCount: __expectNumber(output.XRayRequestCount),
+    XRayThrottlePercent: __expectNumber(output.XRayThrottlePercent),
   } as any;
 };
 
@@ -3441,28 +3356,23 @@ const deserializeAws_json1_1ObservationList = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_1Problem = (output: any, context: __SerdeContext): Problem => {
   return {
-    AffectedResource:
-      output.AffectedResource !== undefined && output.AffectedResource !== null ? output.AffectedResource : undefined,
+    AffectedResource: __expectString(output.AffectedResource),
     EndTime:
       output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
     Feedback:
       output.Feedback !== undefined && output.Feedback !== null
         ? deserializeAws_json1_1Feedback(output.Feedback, context)
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Insights: output.Insights !== undefined && output.Insights !== null ? output.Insights : undefined,
-    ResourceGroupName:
-      output.ResourceGroupName !== undefined && output.ResourceGroupName !== null
-        ? output.ResourceGroupName
-        : undefined,
-    SeverityLevel:
-      output.SeverityLevel !== undefined && output.SeverityLevel !== null ? output.SeverityLevel : undefined,
+    Id: __expectString(output.Id),
+    Insights: __expectString(output.Insights),
+    ResourceGroupName: __expectString(output.ResourceGroupName),
+    SeverityLevel: __expectString(output.SeverityLevel),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
         ? new Date(Math.round(output.StartTime * 1000))
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    Title: output.Title !== undefined && output.Title !== null ? output.Title : undefined,
+    Status: __expectString(output.Status),
+    Title: __expectString(output.Title),
   } as any;
 };
 
@@ -3488,7 +3398,7 @@ const deserializeAws_json1_1RelatedObservations = (output: any, context: __Serde
 
 const deserializeAws_json1_1ResourceInUseException = (output: any, context: __SerdeContext): ResourceInUseException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3499,7 +3409,7 @@ const deserializeAws_json1_1ResourceList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3508,14 +3418,14 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -3539,14 +3449,14 @@ const deserializeAws_json1_1TagsAlreadyExistException = (
   context: __SerdeContext
 ): TagsAlreadyExistException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1TooManyTagsException = (output: any, context: __SerdeContext): TooManyTagsException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    ResourceName: output.ResourceName !== undefined && output.ResourceName !== null ? output.ResourceName : undefined,
+    Message: __expectString(output.Message),
+    ResourceName: __expectString(output.ResourceName),
   } as any;
 };
 
@@ -3589,16 +3499,13 @@ const deserializeAws_json1_1UpdateLogPatternResponse = (
       output.LogPattern !== undefined && output.LogPattern !== null
         ? deserializeAws_json1_1LogPattern(output.LogPattern, context)
         : undefined,
-    ResourceGroupName:
-      output.ResourceGroupName !== undefined && output.ResourceGroupName !== null
-        ? output.ResourceGroupName
-        : undefined,
+    ResourceGroupName: __expectString(output.ResourceGroupName),
   } as any;
 };
 
 const deserializeAws_json1_1ValidationException = (output: any, context: __SerdeContext): ValidationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3609,7 +3516,7 @@ const deserializeAws_json1_1WorkloadMetaData = (output: any, context: __SerdeCon
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };

--- a/clients/client-applicationcostprofiler/protocols/Aws_restJson1.ts
+++ b/clients/client-applicationcostprofiler/protocols/Aws_restJson1.ts
@@ -35,6 +35,7 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -238,7 +239,7 @@ export const deserializeAws_restJson1DeleteReportDefinitionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.reportId !== undefined && data.reportId !== null) {
-    contents.reportId = data.reportId;
+    contents.reportId = __expectString(data.reportId);
   }
   return Promise.resolve(contents);
 };
@@ -329,19 +330,19 @@ export const deserializeAws_restJson1GetReportDefinitionCommand = async (
     contents.destinationS3Location = deserializeAws_restJson1S3Location(data.destinationS3Location, context);
   }
   if (data.format !== undefined && data.format !== null) {
-    contents.format = data.format;
+    contents.format = __expectString(data.format);
   }
   if (data.lastUpdated !== undefined && data.lastUpdated !== null) {
     contents.lastUpdated = new Date(Math.round(data.lastUpdated * 1000));
   }
   if (data.reportDescription !== undefined && data.reportDescription !== null) {
-    contents.reportDescription = data.reportDescription;
+    contents.reportDescription = __expectString(data.reportDescription);
   }
   if (data.reportFrequency !== undefined && data.reportFrequency !== null) {
-    contents.reportFrequency = data.reportFrequency;
+    contents.reportFrequency = __expectString(data.reportFrequency);
   }
   if (data.reportId !== undefined && data.reportId !== null) {
-    contents.reportId = data.reportId;
+    contents.reportId = __expectString(data.reportId);
   }
   return Promise.resolve(contents);
 };
@@ -420,7 +421,7 @@ export const deserializeAws_restJson1ImportApplicationUsageCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.importId !== undefined && data.importId !== null) {
-    contents.importId = data.importId;
+    contents.importId = __expectString(data.importId);
   }
   return Promise.resolve(contents);
 };
@@ -500,7 +501,7 @@ export const deserializeAws_restJson1ListReportDefinitionsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.reportDefinitions !== undefined && data.reportDefinitions !== null) {
     contents.reportDefinitions = deserializeAws_restJson1ReportDefinitionList(data.reportDefinitions, context);
@@ -582,7 +583,7 @@ export const deserializeAws_restJson1PutReportDefinitionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.reportId !== undefined && data.reportId !== null) {
-    contents.reportId = data.reportId;
+    contents.reportId = __expectString(data.reportId);
   }
   return Promise.resolve(contents);
 };
@@ -669,7 +670,7 @@ export const deserializeAws_restJson1UpdateReportDefinitionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.reportId !== undefined && data.reportId !== null) {
-    contents.reportId = data.reportId;
+    contents.reportId = __expectString(data.reportId);
   }
   return Promise.resolve(contents);
 };
@@ -747,7 +748,7 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -764,7 +765,7 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -781,7 +782,7 @@ const deserializeAws_restJson1ServiceQuotaExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -798,7 +799,7 @@ const deserializeAws_restJson1ThrottlingExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -815,7 +816,7 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -845,18 +846,14 @@ const deserializeAws_restJson1ReportDefinition = (output: any, context: __SerdeC
       output.destinationS3Location !== undefined && output.destinationS3Location !== null
         ? deserializeAws_restJson1S3Location(output.destinationS3Location, context)
         : undefined,
-    format: output.format !== undefined && output.format !== null ? output.format : undefined,
+    format: __expectString(output.format),
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
         ? new Date(Math.round(output.lastUpdatedAt * 1000))
         : undefined,
-    reportDescription:
-      output.reportDescription !== undefined && output.reportDescription !== null
-        ? output.reportDescription
-        : undefined,
-    reportFrequency:
-      output.reportFrequency !== undefined && output.reportFrequency !== null ? output.reportFrequency : undefined,
-    reportId: output.reportId !== undefined && output.reportId !== null ? output.reportId : undefined,
+    reportDescription: __expectString(output.reportDescription),
+    reportFrequency: __expectString(output.reportFrequency),
+    reportId: __expectString(output.reportId),
   } as any;
 };
 
@@ -873,8 +870,8 @@ const deserializeAws_restJson1ReportDefinitionList = (output: any, context: __Se
 
 const deserializeAws_restJson1S3Location = (output: any, context: __SerdeContext): S3Location => {
   return {
-    bucket: output.bucket !== undefined && output.bucket !== null ? output.bucket : undefined,
-    prefix: output.prefix !== undefined && output.prefix !== null ? output.prefix : undefined,
+    bucket: __expectString(output.bucket),
+    prefix: __expectString(output.prefix),
   } as any;
 };
 

--- a/clients/client-apprunner/protocols/Aws_json1_0.ts
+++ b/clients/client-apprunner/protocols/Aws_json1_0.ts
@@ -117,7 +117,12 @@ import {
   UpdateServiceResponse,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -2481,8 +2486,8 @@ const deserializeAws_json1_0AssociateCustomDomainResponse = (
       output.CustomDomain !== undefined && output.CustomDomain !== null
         ? deserializeAws_json1_0CustomDomain(output.CustomDomain, context)
         : undefined,
-    DNSTarget: output.DNSTarget !== undefined && output.DNSTarget !== null ? output.DNSTarget : undefined,
-    ServiceArn: output.ServiceArn !== undefined && output.ServiceArn !== null ? output.ServiceArn : undefined,
+    DNSTarget: __expectString(output.DNSTarget),
+    ServiceArn: __expectString(output.ServiceArn),
   } as any;
 };
 
@@ -2491,10 +2496,8 @@ const deserializeAws_json1_0AuthenticationConfiguration = (
   context: __SerdeContext
 ): AuthenticationConfiguration => {
   return {
-    AccessRoleArn:
-      output.AccessRoleArn !== undefined && output.AccessRoleArn !== null ? output.AccessRoleArn : undefined,
-    ConnectionArn:
-      output.ConnectionArn !== undefined && output.ConnectionArn !== null ? output.ConnectionArn : undefined,
+    AccessRoleArn: __expectString(output.AccessRoleArn),
+    ConnectionArn: __expectString(output.ConnectionArn),
   } as any;
 };
 
@@ -2503,18 +2506,9 @@ const deserializeAws_json1_0AutoScalingConfiguration = (
   context: __SerdeContext
 ): AutoScalingConfiguration => {
   return {
-    AutoScalingConfigurationArn:
-      output.AutoScalingConfigurationArn !== undefined && output.AutoScalingConfigurationArn !== null
-        ? output.AutoScalingConfigurationArn
-        : undefined,
-    AutoScalingConfigurationName:
-      output.AutoScalingConfigurationName !== undefined && output.AutoScalingConfigurationName !== null
-        ? output.AutoScalingConfigurationName
-        : undefined,
-    AutoScalingConfigurationRevision:
-      output.AutoScalingConfigurationRevision !== undefined && output.AutoScalingConfigurationRevision !== null
-        ? output.AutoScalingConfigurationRevision
-        : undefined,
+    AutoScalingConfigurationArn: __expectString(output.AutoScalingConfigurationArn),
+    AutoScalingConfigurationName: __expectString(output.AutoScalingConfigurationName),
+    AutoScalingConfigurationRevision: __expectNumber(output.AutoScalingConfigurationRevision),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
@@ -2523,12 +2517,11 @@ const deserializeAws_json1_0AutoScalingConfiguration = (
       output.DeletedAt !== undefined && output.DeletedAt !== null
         ? new Date(Math.round(output.DeletedAt * 1000))
         : undefined,
-    Latest: output.Latest !== undefined && output.Latest !== null ? output.Latest : undefined,
-    MaxConcurrency:
-      output.MaxConcurrency !== undefined && output.MaxConcurrency !== null ? output.MaxConcurrency : undefined,
-    MaxSize: output.MaxSize !== undefined && output.MaxSize !== null ? output.MaxSize : undefined,
-    MinSize: output.MinSize !== undefined && output.MinSize !== null ? output.MinSize : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Latest: __expectBoolean(output.Latest),
+    MaxConcurrency: __expectNumber(output.MaxConcurrency),
+    MaxSize: __expectNumber(output.MaxSize),
+    MinSize: __expectNumber(output.MinSize),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -2537,18 +2530,9 @@ const deserializeAws_json1_0AutoScalingConfigurationSummary = (
   context: __SerdeContext
 ): AutoScalingConfigurationSummary => {
   return {
-    AutoScalingConfigurationArn:
-      output.AutoScalingConfigurationArn !== undefined && output.AutoScalingConfigurationArn !== null
-        ? output.AutoScalingConfigurationArn
-        : undefined,
-    AutoScalingConfigurationName:
-      output.AutoScalingConfigurationName !== undefined && output.AutoScalingConfigurationName !== null
-        ? output.AutoScalingConfigurationName
-        : undefined,
-    AutoScalingConfigurationRevision:
-      output.AutoScalingConfigurationRevision !== undefined && output.AutoScalingConfigurationRevision !== null
-        ? output.AutoScalingConfigurationRevision
-        : undefined,
+    AutoScalingConfigurationArn: __expectString(output.AutoScalingConfigurationArn),
+    AutoScalingConfigurationName: __expectString(output.AutoScalingConfigurationName),
+    AutoScalingConfigurationRevision: __expectNumber(output.AutoScalingConfigurationRevision),
   } as any;
 };
 
@@ -2571,10 +2555,10 @@ const deserializeAws_json1_0CertificateValidationRecord = (
   context: __SerdeContext
 ): CertificateValidationRecord => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Name: __expectString(output.Name),
+    Status: __expectString(output.Status),
+    Type: __expectString(output.Type),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -2598,10 +2582,7 @@ const deserializeAws_json1_0CodeConfiguration = (output: any, context: __SerdeCo
       output.CodeConfigurationValues !== undefined && output.CodeConfigurationValues !== null
         ? deserializeAws_json1_0CodeConfigurationValues(output.CodeConfigurationValues, context)
         : undefined,
-    ConfigurationSource:
-      output.ConfigurationSource !== undefined && output.ConfigurationSource !== null
-        ? output.ConfigurationSource
-        : undefined,
+    ConfigurationSource: __expectString(output.ConfigurationSource),
   } as any;
 };
 
@@ -2610,14 +2591,14 @@ const deserializeAws_json1_0CodeConfigurationValues = (
   context: __SerdeContext
 ): CodeConfigurationValues => {
   return {
-    BuildCommand: output.BuildCommand !== undefined && output.BuildCommand !== null ? output.BuildCommand : undefined,
-    Port: output.Port !== undefined && output.Port !== null ? output.Port : undefined,
-    Runtime: output.Runtime !== undefined && output.Runtime !== null ? output.Runtime : undefined,
+    BuildCommand: __expectString(output.BuildCommand),
+    Port: __expectString(output.Port),
+    Runtime: __expectString(output.Runtime),
     RuntimeEnvironmentVariables:
       output.RuntimeEnvironmentVariables !== undefined && output.RuntimeEnvironmentVariables !== null
         ? deserializeAws_json1_0RuntimeEnvironmentVariables(output.RuntimeEnvironmentVariables, context)
         : undefined,
-    StartCommand: output.StartCommand !== undefined && output.StartCommand !== null ? output.StartCommand : undefined,
+    StartCommand: __expectString(output.StartCommand),
   } as any;
 };
 
@@ -2627,8 +2608,7 @@ const deserializeAws_json1_0CodeRepository = (output: any, context: __SerdeConte
       output.CodeConfiguration !== undefined && output.CodeConfiguration !== null
         ? deserializeAws_json1_0CodeConfiguration(output.CodeConfiguration, context)
         : undefined,
-    RepositoryUrl:
-      output.RepositoryUrl !== undefined && output.RepositoryUrl !== null ? output.RepositoryUrl : undefined,
+    RepositoryUrl: __expectString(output.RepositoryUrl),
     SourceCodeVersion:
       output.SourceCodeVersion !== undefined && output.SourceCodeVersion !== null
         ? deserializeAws_json1_0SourceCodeVersion(output.SourceCodeVersion, context)
@@ -2638,31 +2618,27 @@ const deserializeAws_json1_0CodeRepository = (output: any, context: __SerdeConte
 
 const deserializeAws_json1_0Connection = (output: any, context: __SerdeContext): Connection => {
   return {
-    ConnectionArn:
-      output.ConnectionArn !== undefined && output.ConnectionArn !== null ? output.ConnectionArn : undefined,
-    ConnectionName:
-      output.ConnectionName !== undefined && output.ConnectionName !== null ? output.ConnectionName : undefined,
+    ConnectionArn: __expectString(output.ConnectionArn),
+    ConnectionName: __expectString(output.ConnectionName),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    ProviderType: output.ProviderType !== undefined && output.ProviderType !== null ? output.ProviderType : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    ProviderType: __expectString(output.ProviderType),
+    Status: __expectString(output.Status),
   } as any;
 };
 
 const deserializeAws_json1_0ConnectionSummary = (output: any, context: __SerdeContext): ConnectionSummary => {
   return {
-    ConnectionArn:
-      output.ConnectionArn !== undefined && output.ConnectionArn !== null ? output.ConnectionArn : undefined,
-    ConnectionName:
-      output.ConnectionName !== undefined && output.ConnectionName !== null ? output.ConnectionName : undefined,
+    ConnectionArn: __expectString(output.ConnectionArn),
+    ConnectionName: __expectString(output.ConnectionName),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    ProviderType: output.ProviderType !== undefined && output.ProviderType !== null ? output.ProviderType : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    ProviderType: __expectString(output.ProviderType),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -2703,7 +2679,7 @@ const deserializeAws_json1_0CreateConnectionResponse = (
 
 const deserializeAws_json1_0CreateServiceResponse = (output: any, context: __SerdeContext): CreateServiceResponse => {
   return {
-    OperationId: output.OperationId !== undefined && output.OperationId !== null ? output.OperationId : undefined,
+    OperationId: __expectString(output.OperationId),
     Service:
       output.Service !== undefined && output.Service !== null
         ? deserializeAws_json1_0Service(output.Service, context)
@@ -2717,12 +2693,9 @@ const deserializeAws_json1_0CustomDomain = (output: any, context: __SerdeContext
       output.CertificateValidationRecords !== undefined && output.CertificateValidationRecords !== null
         ? deserializeAws_json1_0CertificateValidationRecordList(output.CertificateValidationRecords, context)
         : undefined,
-    DomainName: output.DomainName !== undefined && output.DomainName !== null ? output.DomainName : undefined,
-    EnableWWWSubdomain:
-      output.EnableWWWSubdomain !== undefined && output.EnableWWWSubdomain !== null
-        ? output.EnableWWWSubdomain
-        : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    DomainName: __expectString(output.DomainName),
+    EnableWWWSubdomain: __expectBoolean(output.EnableWWWSubdomain),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -2763,7 +2736,7 @@ const deserializeAws_json1_0DeleteConnectionResponse = (
 
 const deserializeAws_json1_0DeleteServiceResponse = (output: any, context: __SerdeContext): DeleteServiceResponse => {
   return {
-    OperationId: output.OperationId !== undefined && output.OperationId !== null ? output.OperationId : undefined,
+    OperationId: __expectString(output.OperationId),
     Service:
       output.Service !== undefined && output.Service !== null
         ? deserializeAws_json1_0Service(output.Service, context)
@@ -2792,9 +2765,9 @@ const deserializeAws_json1_0DescribeCustomDomainsResponse = (
       output.CustomDomains !== undefined && output.CustomDomains !== null
         ? deserializeAws_json1_0CustomDomainList(output.CustomDomains, context)
         : undefined,
-    DNSTarget: output.DNSTarget !== undefined && output.DNSTarget !== null ? output.DNSTarget : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
-    ServiceArn: output.ServiceArn !== undefined && output.ServiceArn !== null ? output.ServiceArn : undefined,
+    DNSTarget: __expectString(output.DNSTarget),
+    NextToken: __expectString(output.NextToken),
+    ServiceArn: __expectString(output.ServiceArn),
   } as any;
 };
 
@@ -2819,8 +2792,8 @@ const deserializeAws_json1_0DisassociateCustomDomainResponse = (
       output.CustomDomain !== undefined && output.CustomDomain !== null
         ? deserializeAws_json1_0CustomDomain(output.CustomDomain, context)
         : undefined,
-    DNSTarget: output.DNSTarget !== undefined && output.DNSTarget !== null ? output.DNSTarget : undefined,
-    ServiceArn: output.ServiceArn !== undefined && output.ServiceArn !== null ? output.ServiceArn : undefined,
+    DNSTarget: __expectString(output.DNSTarget),
+    ServiceArn: __expectString(output.ServiceArn),
   } as any;
 };
 
@@ -2829,7 +2802,7 @@ const deserializeAws_json1_0EncryptionConfiguration = (
   context: __SerdeContext
 ): EncryptionConfiguration => {
   return {
-    KmsKey: output.KmsKey !== undefined && output.KmsKey !== null ? output.KmsKey : undefined,
+    KmsKey: __expectString(output.KmsKey),
   } as any;
 };
 
@@ -2838,27 +2811,23 @@ const deserializeAws_json1_0HealthCheckConfiguration = (
   context: __SerdeContext
 ): HealthCheckConfiguration => {
   return {
-    HealthyThreshold:
-      output.HealthyThreshold !== undefined && output.HealthyThreshold !== null ? output.HealthyThreshold : undefined,
-    Interval: output.Interval !== undefined && output.Interval !== null ? output.Interval : undefined,
-    Path: output.Path !== undefined && output.Path !== null ? output.Path : undefined,
-    Protocol: output.Protocol !== undefined && output.Protocol !== null ? output.Protocol : undefined,
-    Timeout: output.Timeout !== undefined && output.Timeout !== null ? output.Timeout : undefined,
-    UnhealthyThreshold:
-      output.UnhealthyThreshold !== undefined && output.UnhealthyThreshold !== null
-        ? output.UnhealthyThreshold
-        : undefined,
+    HealthyThreshold: __expectNumber(output.HealthyThreshold),
+    Interval: __expectNumber(output.Interval),
+    Path: __expectString(output.Path),
+    Protocol: __expectString(output.Protocol),
+    Timeout: __expectNumber(output.Timeout),
+    UnhealthyThreshold: __expectNumber(output.UnhealthyThreshold),
   } as any;
 };
 
 const deserializeAws_json1_0ImageConfiguration = (output: any, context: __SerdeContext): ImageConfiguration => {
   return {
-    Port: output.Port !== undefined && output.Port !== null ? output.Port : undefined,
+    Port: __expectString(output.Port),
     RuntimeEnvironmentVariables:
       output.RuntimeEnvironmentVariables !== undefined && output.RuntimeEnvironmentVariables !== null
         ? deserializeAws_json1_0RuntimeEnvironmentVariables(output.RuntimeEnvironmentVariables, context)
         : undefined,
-    StartCommand: output.StartCommand !== undefined && output.StartCommand !== null ? output.StartCommand : undefined,
+    StartCommand: __expectString(output.StartCommand),
   } as any;
 };
 
@@ -2868,21 +2837,16 @@ const deserializeAws_json1_0ImageRepository = (output: any, context: __SerdeCont
       output.ImageConfiguration !== undefined && output.ImageConfiguration !== null
         ? deserializeAws_json1_0ImageConfiguration(output.ImageConfiguration, context)
         : undefined,
-    ImageIdentifier:
-      output.ImageIdentifier !== undefined && output.ImageIdentifier !== null ? output.ImageIdentifier : undefined,
-    ImageRepositoryType:
-      output.ImageRepositoryType !== undefined && output.ImageRepositoryType !== null
-        ? output.ImageRepositoryType
-        : undefined,
+    ImageIdentifier: __expectString(output.ImageIdentifier),
+    ImageRepositoryType: __expectString(output.ImageRepositoryType),
   } as any;
 };
 
 const deserializeAws_json1_0InstanceConfiguration = (output: any, context: __SerdeContext): InstanceConfiguration => {
   return {
-    Cpu: output.Cpu !== undefined && output.Cpu !== null ? output.Cpu : undefined,
-    InstanceRoleArn:
-      output.InstanceRoleArn !== undefined && output.InstanceRoleArn !== null ? output.InstanceRoleArn : undefined,
-    Memory: output.Memory !== undefined && output.Memory !== null ? output.Memory : undefined,
+    Cpu: __expectString(output.Cpu),
+    InstanceRoleArn: __expectString(output.InstanceRoleArn),
+    Memory: __expectString(output.Memory),
   } as any;
 };
 
@@ -2891,7 +2855,7 @@ const deserializeAws_json1_0InternalServiceErrorException = (
   context: __SerdeContext
 ): InternalServiceErrorException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2900,13 +2864,13 @@ const deserializeAws_json1_0InvalidRequestException = (
   context: __SerdeContext
 ): InvalidRequestException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_0InvalidStateException = (output: any, context: __SerdeContext): InvalidStateException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2919,7 +2883,7 @@ const deserializeAws_json1_0ListAutoScalingConfigurationsResponse = (
       output.AutoScalingConfigurationSummaryList !== undefined && output.AutoScalingConfigurationSummaryList !== null
         ? deserializeAws_json1_0AutoScalingConfigurationSummaryList(output.AutoScalingConfigurationSummaryList, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -2932,13 +2896,13 @@ const deserializeAws_json1_0ListConnectionsResponse = (
       output.ConnectionSummaryList !== undefined && output.ConnectionSummaryList !== null
         ? deserializeAws_json1_0ConnectionSummaryList(output.ConnectionSummaryList, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
 const deserializeAws_json1_0ListOperationsResponse = (output: any, context: __SerdeContext): ListOperationsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     OperationSummaryList:
       output.OperationSummaryList !== undefined && output.OperationSummaryList !== null
         ? deserializeAws_json1_0OperationSummaryList(output.OperationSummaryList, context)
@@ -2948,7 +2912,7 @@ const deserializeAws_json1_0ListOperationsResponse = (output: any, context: __Se
 
 const deserializeAws_json1_0ListServicesResponse = (output: any, context: __SerdeContext): ListServicesResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     ServiceSummaryList:
       output.ServiceSummaryList !== undefined && output.ServiceSummaryList !== null
         ? deserializeAws_json1_0ServiceSummaryList(output.ServiceSummaryList, context)
@@ -2972,14 +2936,14 @@ const deserializeAws_json1_0OperationSummary = (output: any, context: __SerdeCon
   return {
     EndedAt:
       output.EndedAt !== undefined && output.EndedAt !== null ? new Date(Math.round(output.EndedAt * 1000)) : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    Id: __expectString(output.Id),
     StartedAt:
       output.StartedAt !== undefined && output.StartedAt !== null
         ? new Date(Math.round(output.StartedAt * 1000))
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    TargetArn: output.TargetArn !== undefined && output.TargetArn !== null ? output.TargetArn : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Status: __expectString(output.Status),
+    TargetArn: __expectString(output.TargetArn),
+    Type: __expectString(output.Type),
     UpdatedAt:
       output.UpdatedAt !== undefined && output.UpdatedAt !== null
         ? new Date(Math.round(output.UpdatedAt * 1000))
@@ -3000,7 +2964,7 @@ const deserializeAws_json1_0OperationSummaryList = (output: any, context: __Serd
 
 const deserializeAws_json1_0PauseServiceResponse = (output: any, context: __SerdeContext): PauseServiceResponse => {
   return {
-    OperationId: output.OperationId !== undefined && output.OperationId !== null ? output.OperationId : undefined,
+    OperationId: __expectString(output.OperationId),
     Service:
       output.Service !== undefined && output.Service !== null
         ? deserializeAws_json1_0Service(output.Service, context)
@@ -3013,13 +2977,13 @@ const deserializeAws_json1_0ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_0ResumeServiceResponse = (output: any, context: __SerdeContext): ResumeServiceResponse => {
   return {
-    OperationId: output.OperationId !== undefined && output.OperationId !== null ? output.OperationId : undefined,
+    OperationId: __expectString(output.OperationId),
     Service:
       output.Service !== undefined && output.Service !== null
         ? deserializeAws_json1_0Service(output.Service, context)
@@ -3037,7 +3001,7 @@ const deserializeAws_json1_0RuntimeEnvironmentVariables = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -3068,15 +3032,15 @@ const deserializeAws_json1_0Service = (output: any, context: __SerdeContext): Se
       output.InstanceConfiguration !== undefined && output.InstanceConfiguration !== null
         ? deserializeAws_json1_0InstanceConfiguration(output.InstanceConfiguration, context)
         : undefined,
-    ServiceArn: output.ServiceArn !== undefined && output.ServiceArn !== null ? output.ServiceArn : undefined,
-    ServiceId: output.ServiceId !== undefined && output.ServiceId !== null ? output.ServiceId : undefined,
-    ServiceName: output.ServiceName !== undefined && output.ServiceName !== null ? output.ServiceName : undefined,
-    ServiceUrl: output.ServiceUrl !== undefined && output.ServiceUrl !== null ? output.ServiceUrl : undefined,
+    ServiceArn: __expectString(output.ServiceArn),
+    ServiceId: __expectString(output.ServiceId),
+    ServiceName: __expectString(output.ServiceName),
+    ServiceUrl: __expectString(output.ServiceUrl),
     SourceConfiguration:
       output.SourceConfiguration !== undefined && output.SourceConfiguration !== null
         ? deserializeAws_json1_0SourceConfiguration(output.SourceConfiguration, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
     UpdatedAt:
       output.UpdatedAt !== undefined && output.UpdatedAt !== null
         ? new Date(Math.round(output.UpdatedAt * 1000))
@@ -3089,7 +3053,7 @@ const deserializeAws_json1_0ServiceQuotaExceededException = (
   context: __SerdeContext
 ): ServiceQuotaExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3099,11 +3063,11 @@ const deserializeAws_json1_0ServiceSummary = (output: any, context: __SerdeConte
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    ServiceArn: output.ServiceArn !== undefined && output.ServiceArn !== null ? output.ServiceArn : undefined,
-    ServiceId: output.ServiceId !== undefined && output.ServiceId !== null ? output.ServiceId : undefined,
-    ServiceName: output.ServiceName !== undefined && output.ServiceName !== null ? output.ServiceName : undefined,
-    ServiceUrl: output.ServiceUrl !== undefined && output.ServiceUrl !== null ? output.ServiceUrl : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    ServiceArn: __expectString(output.ServiceArn),
+    ServiceId: __expectString(output.ServiceId),
+    ServiceName: __expectString(output.ServiceName),
+    ServiceUrl: __expectString(output.ServiceUrl),
+    Status: __expectString(output.Status),
     UpdatedAt:
       output.UpdatedAt !== undefined && output.UpdatedAt !== null
         ? new Date(Math.round(output.UpdatedAt * 1000))
@@ -3124,8 +3088,8 @@ const deserializeAws_json1_0ServiceSummaryList = (output: any, context: __SerdeC
 
 const deserializeAws_json1_0SourceCodeVersion = (output: any, context: __SerdeContext): SourceCodeVersion => {
   return {
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Type: __expectString(output.Type),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -3135,10 +3099,7 @@ const deserializeAws_json1_0SourceConfiguration = (output: any, context: __Serde
       output.AuthenticationConfiguration !== undefined && output.AuthenticationConfiguration !== null
         ? deserializeAws_json1_0AuthenticationConfiguration(output.AuthenticationConfiguration, context)
         : undefined,
-    AutoDeploymentsEnabled:
-      output.AutoDeploymentsEnabled !== undefined && output.AutoDeploymentsEnabled !== null
-        ? output.AutoDeploymentsEnabled
-        : undefined,
+    AutoDeploymentsEnabled: __expectBoolean(output.AutoDeploymentsEnabled),
     CodeRepository:
       output.CodeRepository !== undefined && output.CodeRepository !== null
         ? deserializeAws_json1_0CodeRepository(output.CodeRepository, context)
@@ -3155,14 +3116,14 @@ const deserializeAws_json1_0StartDeploymentResponse = (
   context: __SerdeContext
 ): StartDeploymentResponse => {
   return {
-    OperationId: output.OperationId !== undefined && output.OperationId !== null ? output.OperationId : undefined,
+    OperationId: __expectString(output.OperationId),
   } as any;
 };
 
 const deserializeAws_json1_0Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -3187,7 +3148,7 @@ const deserializeAws_json1_0UntagResourceResponse = (output: any, context: __Ser
 
 const deserializeAws_json1_0UpdateServiceResponse = (output: any, context: __SerdeContext): UpdateServiceResponse => {
   return {
-    OperationId: output.OperationId !== undefined && output.OperationId !== null ? output.OperationId : undefined,
+    OperationId: __expectString(output.OperationId),
     Service:
       output.Service !== undefined && output.Service !== null
         ? deserializeAws_json1_0Service(output.Service, context)

--- a/clients/client-appstream/protocols/Aws_json1_1.ts
+++ b/clients/client-appstream/protocols/Aws_json1_1.ts
@@ -243,7 +243,12 @@ import {
   VpcConfig,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -5475,8 +5480,8 @@ const serializeAws_json1_1VpcConfig = (input: VpcConfig, context: __SerdeContext
 
 const deserializeAws_json1_1AccessEndpoint = (output: any, context: __SerdeContext): AccessEndpoint => {
   return {
-    EndpointType: output.EndpointType !== undefined && output.EndpointType !== null ? output.EndpointType : undefined,
-    VpceId: output.VpceId !== undefined && output.VpceId !== null ? output.VpceId : undefined,
+    EndpointType: __expectString(output.EndpointType),
+    VpceId: __expectString(output.VpceId),
   } as any;
 };
 
@@ -5493,17 +5498,16 @@ const deserializeAws_json1_1AccessEndpointList = (output: any, context: __SerdeC
 
 const deserializeAws_json1_1Application = (output: any, context: __SerdeContext): Application => {
   return {
-    DisplayName: output.DisplayName !== undefined && output.DisplayName !== null ? output.DisplayName : undefined,
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
-    IconURL: output.IconURL !== undefined && output.IconURL !== null ? output.IconURL : undefined,
-    LaunchParameters:
-      output.LaunchParameters !== undefined && output.LaunchParameters !== null ? output.LaunchParameters : undefined,
-    LaunchPath: output.LaunchPath !== undefined && output.LaunchPath !== null ? output.LaunchPath : undefined,
+    DisplayName: __expectString(output.DisplayName),
+    Enabled: __expectBoolean(output.Enabled),
+    IconURL: __expectString(output.IconURL),
+    LaunchParameters: __expectString(output.LaunchParameters),
+    LaunchPath: __expectString(output.LaunchPath),
     Metadata:
       output.Metadata !== undefined && output.Metadata !== null
         ? deserializeAws_json1_1Metadata(output.Metadata, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -5523,10 +5527,9 @@ const deserializeAws_json1_1ApplicationSettingsResponse = (
   context: __SerdeContext
 ): ApplicationSettingsResponse => {
   return {
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
-    S3BucketName: output.S3BucketName !== undefined && output.S3BucketName !== null ? output.S3BucketName : undefined,
-    SettingsGroup:
-      output.SettingsGroup !== undefined && output.SettingsGroup !== null ? output.SettingsGroup : undefined,
+    Enabled: __expectBoolean(output.Enabled),
+    S3BucketName: __expectString(output.S3BucketName),
+    SettingsGroup: __expectString(output.SettingsGroup),
   } as any;
 };
 
@@ -5560,10 +5563,10 @@ const deserializeAws_json1_1BatchDisassociateUserStackResult = (
 
 const deserializeAws_json1_1ComputeCapacityStatus = (output: any, context: __SerdeContext): ComputeCapacityStatus => {
   return {
-    Available: output.Available !== undefined && output.Available !== null ? output.Available : undefined,
-    Desired: output.Desired !== undefined && output.Desired !== null ? output.Desired : undefined,
-    InUse: output.InUse !== undefined && output.InUse !== null ? output.InUse : undefined,
-    Running: output.Running !== undefined && output.Running !== null ? output.Running : undefined,
+    Available: __expectNumber(output.Available),
+    Desired: __expectNumber(output.Desired),
+    InUse: __expectNumber(output.InUse),
+    Running: __expectNumber(output.Running),
   } as any;
 };
 
@@ -5572,16 +5575,13 @@ const deserializeAws_json1_1ConcurrentModificationException = (
   context: __SerdeContext
 ): ConcurrentModificationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1CopyImageResponse = (output: any, context: __SerdeContext): CopyImageResponse => {
   return {
-    DestinationImageName:
-      output.DestinationImageName !== undefined && output.DestinationImageName !== null
-        ? output.DestinationImageName
-        : undefined,
+    DestinationImageName: __expectString(output.DestinationImageName),
   } as any;
 };
 
@@ -5625,7 +5625,7 @@ const deserializeAws_json1_1CreateImageBuilderStreamingURLResult = (
   return {
     Expires:
       output.Expires !== undefined && output.Expires !== null ? new Date(Math.round(output.Expires * 1000)) : undefined,
-    StreamingURL: output.StreamingURL !== undefined && output.StreamingURL !== null ? output.StreamingURL : undefined,
+    StreamingURL: __expectString(output.StreamingURL),
   } as any;
 };
 
@@ -5645,7 +5645,7 @@ const deserializeAws_json1_1CreateStreamingURLResult = (
   return {
     Expires:
       output.Expires !== undefined && output.Expires !== null ? new Date(Math.round(output.Expires * 1000)) : undefined,
-    StreamingURL: output.StreamingURL !== undefined && output.StreamingURL !== null ? output.StreamingURL : undefined,
+    StreamingURL: __expectString(output.StreamingURL),
   } as any;
 };
 
@@ -5654,8 +5654,7 @@ const deserializeAws_json1_1CreateUpdatedImageResult = (
   context: __SerdeContext
 ): CreateUpdatedImageResult => {
   return {
-    canUpdateImage:
-      output.canUpdateImage !== undefined && output.canUpdateImage !== null ? output.canUpdateImage : undefined,
+    canUpdateImage: __expectBoolean(output.canUpdateImage),
     image:
       output.image !== undefined && output.image !== null
         ? deserializeAws_json1_1Image(output.image, context)
@@ -5668,8 +5667,8 @@ const deserializeAws_json1_1CreateUsageReportSubscriptionResult = (
   context: __SerdeContext
 ): CreateUsageReportSubscriptionResult => {
   return {
-    S3BucketName: output.S3BucketName !== undefined && output.S3BucketName !== null ? output.S3BucketName : undefined,
-    Schedule: output.Schedule !== undefined && output.Schedule !== null ? output.Schedule : undefined,
+    S3BucketName: __expectString(output.S3BucketName),
+    Schedule: __expectString(output.Schedule),
   } as any;
 };
 
@@ -5740,7 +5739,7 @@ const deserializeAws_json1_1DescribeDirectoryConfigsResult = (
       output.DirectoryConfigs !== undefined && output.DirectoryConfigs !== null
         ? deserializeAws_json1_1DirectoryConfigList(output.DirectoryConfigs, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -5750,7 +5749,7 @@ const deserializeAws_json1_1DescribeFleetsResult = (output: any, context: __Serd
       output.Fleets !== undefined && output.Fleets !== null
         ? deserializeAws_json1_1FleetList(output.Fleets, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -5763,7 +5762,7 @@ const deserializeAws_json1_1DescribeImageBuildersResult = (
       output.ImageBuilders !== undefined && output.ImageBuilders !== null
         ? deserializeAws_json1_1ImageBuilderList(output.ImageBuilders, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -5772,8 +5771,8 @@ const deserializeAws_json1_1DescribeImagePermissionsResult = (
   context: __SerdeContext
 ): DescribeImagePermissionsResult => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    Name: __expectString(output.Name),
+    NextToken: __expectString(output.NextToken),
     SharedImagePermissionsList:
       output.SharedImagePermissionsList !== undefined && output.SharedImagePermissionsList !== null
         ? deserializeAws_json1_1SharedImagePermissionsList(output.SharedImagePermissionsList, context)
@@ -5787,13 +5786,13 @@ const deserializeAws_json1_1DescribeImagesResult = (output: any, context: __Serd
       output.Images !== undefined && output.Images !== null
         ? deserializeAws_json1_1ImageList(output.Images, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
 const deserializeAws_json1_1DescribeSessionsResult = (output: any, context: __SerdeContext): DescribeSessionsResult => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Sessions:
       output.Sessions !== undefined && output.Sessions !== null
         ? deserializeAws_json1_1SessionList(output.Sessions, context)
@@ -5803,7 +5802,7 @@ const deserializeAws_json1_1DescribeSessionsResult = (output: any, context: __Se
 
 const deserializeAws_json1_1DescribeStacksResult = (output: any, context: __SerdeContext): DescribeStacksResult => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Stacks:
       output.Stacks !== undefined && output.Stacks !== null
         ? deserializeAws_json1_1StackList(output.Stacks, context)
@@ -5816,7 +5815,7 @@ const deserializeAws_json1_1DescribeUsageReportSubscriptionsResult = (
   context: __SerdeContext
 ): DescribeUsageReportSubscriptionsResult => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     UsageReportSubscriptions:
       output.UsageReportSubscriptions !== undefined && output.UsageReportSubscriptions !== null
         ? deserializeAws_json1_1UsageReportSubscriptionList(output.UsageReportSubscriptions, context)
@@ -5826,7 +5825,7 @@ const deserializeAws_json1_1DescribeUsageReportSubscriptionsResult = (
 
 const deserializeAws_json1_1DescribeUsersResult = (output: any, context: __SerdeContext): DescribeUsersResult => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Users:
       output.Users !== undefined && output.Users !== null
         ? deserializeAws_json1_1UserList(output.Users, context)
@@ -5839,7 +5838,7 @@ const deserializeAws_json1_1DescribeUserStackAssociationsResult = (
   context: __SerdeContext
 ): DescribeUserStackAssociationsResult => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     UserStackAssociations:
       output.UserStackAssociations !== undefined && output.UserStackAssociations !== null
         ? deserializeAws_json1_1UserStackAssociationList(output.UserStackAssociations, context)
@@ -5853,8 +5852,7 @@ const deserializeAws_json1_1DirectoryConfig = (output: any, context: __SerdeCont
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
         : undefined,
-    DirectoryName:
-      output.DirectoryName !== undefined && output.DirectoryName !== null ? output.DirectoryName : undefined,
+    DirectoryName: __expectString(output.DirectoryName),
     OrganizationalUnitDistinguishedNames:
       output.OrganizationalUnitDistinguishedNames !== undefined && output.OrganizationalUnitDistinguishedNames !== null
         ? deserializeAws_json1_1OrganizationalUnitDistinguishedNamesList(
@@ -5893,12 +5891,8 @@ const deserializeAws_json1_1DisassociateFleetResult = (
 
 const deserializeAws_json1_1DomainJoinInfo = (output: any, context: __SerdeContext): DomainJoinInfo => {
   return {
-    DirectoryName:
-      output.DirectoryName !== undefined && output.DirectoryName !== null ? output.DirectoryName : undefined,
-    OrganizationalUnitDistinguishedName:
-      output.OrganizationalUnitDistinguishedName !== undefined && output.OrganizationalUnitDistinguishedName !== null
-        ? output.OrganizationalUnitDistinguishedName
-        : undefined,
+    DirectoryName: __expectString(output.DirectoryName),
+    OrganizationalUnitDistinguishedName: __expectString(output.OrganizationalUnitDistinguishedName),
   } as any;
 };
 
@@ -5909,7 +5903,7 @@ const deserializeAws_json1_1DomainList = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -5920,7 +5914,7 @@ const deserializeAws_json1_1EmbedHostDomains = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -5934,7 +5928,7 @@ const deserializeAws_json1_1ExpireSessionResult = (output: any, context: __Serde
 
 const deserializeAws_json1_1Fleet = (output: any, context: __SerdeContext): Fleet => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     ComputeCapacityStatus:
       output.ComputeCapacityStatus !== undefined && output.ComputeCapacityStatus !== null
         ? deserializeAws_json1_1ComputeCapacityStatus(output.ComputeCapacityStatus, context)
@@ -5943,40 +5937,28 @@ const deserializeAws_json1_1Fleet = (output: any, context: __SerdeContext): Flee
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    DisconnectTimeoutInSeconds:
-      output.DisconnectTimeoutInSeconds !== undefined && output.DisconnectTimeoutInSeconds !== null
-        ? output.DisconnectTimeoutInSeconds
-        : undefined,
-    DisplayName: output.DisplayName !== undefined && output.DisplayName !== null ? output.DisplayName : undefined,
+    Description: __expectString(output.Description),
+    DisconnectTimeoutInSeconds: __expectNumber(output.DisconnectTimeoutInSeconds),
+    DisplayName: __expectString(output.DisplayName),
     DomainJoinInfo:
       output.DomainJoinInfo !== undefined && output.DomainJoinInfo !== null
         ? deserializeAws_json1_1DomainJoinInfo(output.DomainJoinInfo, context)
         : undefined,
-    EnableDefaultInternetAccess:
-      output.EnableDefaultInternetAccess !== undefined && output.EnableDefaultInternetAccess !== null
-        ? output.EnableDefaultInternetAccess
-        : undefined,
+    EnableDefaultInternetAccess: __expectBoolean(output.EnableDefaultInternetAccess),
     FleetErrors:
       output.FleetErrors !== undefined && output.FleetErrors !== null
         ? deserializeAws_json1_1FleetErrors(output.FleetErrors, context)
         : undefined,
-    FleetType: output.FleetType !== undefined && output.FleetType !== null ? output.FleetType : undefined,
-    IamRoleArn: output.IamRoleArn !== undefined && output.IamRoleArn !== null ? output.IamRoleArn : undefined,
-    IdleDisconnectTimeoutInSeconds:
-      output.IdleDisconnectTimeoutInSeconds !== undefined && output.IdleDisconnectTimeoutInSeconds !== null
-        ? output.IdleDisconnectTimeoutInSeconds
-        : undefined,
-    ImageArn: output.ImageArn !== undefined && output.ImageArn !== null ? output.ImageArn : undefined,
-    ImageName: output.ImageName !== undefined && output.ImageName !== null ? output.ImageName : undefined,
-    InstanceType: output.InstanceType !== undefined && output.InstanceType !== null ? output.InstanceType : undefined,
-    MaxUserDurationInSeconds:
-      output.MaxUserDurationInSeconds !== undefined && output.MaxUserDurationInSeconds !== null
-        ? output.MaxUserDurationInSeconds
-        : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    StreamView: output.StreamView !== undefined && output.StreamView !== null ? output.StreamView : undefined,
+    FleetType: __expectString(output.FleetType),
+    IamRoleArn: __expectString(output.IamRoleArn),
+    IdleDisconnectTimeoutInSeconds: __expectNumber(output.IdleDisconnectTimeoutInSeconds),
+    ImageArn: __expectString(output.ImageArn),
+    ImageName: __expectString(output.ImageName),
+    InstanceType: __expectString(output.InstanceType),
+    MaxUserDurationInSeconds: __expectNumber(output.MaxUserDurationInSeconds),
+    Name: __expectString(output.Name),
+    State: __expectString(output.State),
+    StreamView: __expectString(output.StreamView),
     VpcConfig:
       output.VpcConfig !== undefined && output.VpcConfig !== null
         ? deserializeAws_json1_1VpcConfig(output.VpcConfig, context)
@@ -5986,8 +5968,8 @@ const deserializeAws_json1_1Fleet = (output: any, context: __SerdeContext): Flee
 
 const deserializeAws_json1_1FleetError = (output: any, context: __SerdeContext): FleetError => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
   } as any;
 };
 
@@ -6019,24 +6001,17 @@ const deserializeAws_json1_1Image = (output: any, context: __SerdeContext): Imag
       output.Applications !== undefined && output.Applications !== null
         ? deserializeAws_json1_1Applications(output.Applications, context)
         : undefined,
-    AppstreamAgentVersion:
-      output.AppstreamAgentVersion !== undefined && output.AppstreamAgentVersion !== null
-        ? output.AppstreamAgentVersion
-        : undefined,
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    BaseImageArn: output.BaseImageArn !== undefined && output.BaseImageArn !== null ? output.BaseImageArn : undefined,
+    AppstreamAgentVersion: __expectString(output.AppstreamAgentVersion),
+    Arn: __expectString(output.Arn),
+    BaseImageArn: __expectString(output.BaseImageArn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    DisplayName: output.DisplayName !== undefined && output.DisplayName !== null ? output.DisplayName : undefined,
-    ImageBuilderName:
-      output.ImageBuilderName !== undefined && output.ImageBuilderName !== null ? output.ImageBuilderName : undefined,
-    ImageBuilderSupported:
-      output.ImageBuilderSupported !== undefined && output.ImageBuilderSupported !== null
-        ? output.ImageBuilderSupported
-        : undefined,
+    Description: __expectString(output.Description),
+    DisplayName: __expectString(output.DisplayName),
+    ImageBuilderName: __expectString(output.ImageBuilderName),
+    ImageBuilderSupported: __expectBoolean(output.ImageBuilderSupported),
     ImageErrors:
       output.ImageErrors !== undefined && output.ImageErrors !== null
         ? deserializeAws_json1_1ResourceErrors(output.ImageErrors, context)
@@ -6045,18 +6020,18 @@ const deserializeAws_json1_1Image = (output: any, context: __SerdeContext): Imag
       output.ImagePermissions !== undefined && output.ImagePermissions !== null
         ? deserializeAws_json1_1ImagePermissions(output.ImagePermissions, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Platform: output.Platform !== undefined && output.Platform !== null ? output.Platform : undefined,
+    Name: __expectString(output.Name),
+    Platform: __expectString(output.Platform),
     PublicBaseImageReleasedDate:
       output.PublicBaseImageReleasedDate !== undefined && output.PublicBaseImageReleasedDate !== null
         ? new Date(Math.round(output.PublicBaseImageReleasedDate * 1000))
         : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    State: __expectString(output.State),
     StateChangeReason:
       output.StateChangeReason !== undefined && output.StateChangeReason !== null
         ? deserializeAws_json1_1ImageStateChangeReason(output.StateChangeReason, context)
         : undefined,
-    Visibility: output.Visibility !== undefined && output.Visibility !== null ? output.Visibility : undefined,
+    Visibility: __expectString(output.Visibility),
   } as any;
 };
 
@@ -6066,39 +6041,33 @@ const deserializeAws_json1_1ImageBuilder = (output: any, context: __SerdeContext
       output.AccessEndpoints !== undefined && output.AccessEndpoints !== null
         ? deserializeAws_json1_1AccessEndpointList(output.AccessEndpoints, context)
         : undefined,
-    AppstreamAgentVersion:
-      output.AppstreamAgentVersion !== undefined && output.AppstreamAgentVersion !== null
-        ? output.AppstreamAgentVersion
-        : undefined,
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    AppstreamAgentVersion: __expectString(output.AppstreamAgentVersion),
+    Arn: __expectString(output.Arn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    DisplayName: output.DisplayName !== undefined && output.DisplayName !== null ? output.DisplayName : undefined,
+    Description: __expectString(output.Description),
+    DisplayName: __expectString(output.DisplayName),
     DomainJoinInfo:
       output.DomainJoinInfo !== undefined && output.DomainJoinInfo !== null
         ? deserializeAws_json1_1DomainJoinInfo(output.DomainJoinInfo, context)
         : undefined,
-    EnableDefaultInternetAccess:
-      output.EnableDefaultInternetAccess !== undefined && output.EnableDefaultInternetAccess !== null
-        ? output.EnableDefaultInternetAccess
-        : undefined,
-    IamRoleArn: output.IamRoleArn !== undefined && output.IamRoleArn !== null ? output.IamRoleArn : undefined,
-    ImageArn: output.ImageArn !== undefined && output.ImageArn !== null ? output.ImageArn : undefined,
+    EnableDefaultInternetAccess: __expectBoolean(output.EnableDefaultInternetAccess),
+    IamRoleArn: __expectString(output.IamRoleArn),
+    ImageArn: __expectString(output.ImageArn),
     ImageBuilderErrors:
       output.ImageBuilderErrors !== undefined && output.ImageBuilderErrors !== null
         ? deserializeAws_json1_1ResourceErrors(output.ImageBuilderErrors, context)
         : undefined,
-    InstanceType: output.InstanceType !== undefined && output.InstanceType !== null ? output.InstanceType : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    InstanceType: __expectString(output.InstanceType),
+    Name: __expectString(output.Name),
     NetworkAccessConfiguration:
       output.NetworkAccessConfiguration !== undefined && output.NetworkAccessConfiguration !== null
         ? deserializeAws_json1_1NetworkAccessConfiguration(output.NetworkAccessConfiguration, context)
         : undefined,
-    Platform: output.Platform !== undefined && output.Platform !== null ? output.Platform : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    Platform: __expectString(output.Platform),
+    State: __expectString(output.State),
     StateChangeReason:
       output.StateChangeReason !== undefined && output.StateChangeReason !== null
         ? deserializeAws_json1_1ImageBuilderStateChangeReason(output.StateChangeReason, context)
@@ -6126,8 +6095,8 @@ const deserializeAws_json1_1ImageBuilderStateChangeReason = (
   context: __SerdeContext
 ): ImageBuilderStateChangeReason => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -6144,18 +6113,15 @@ const deserializeAws_json1_1ImageList = (output: any, context: __SerdeContext): 
 
 const deserializeAws_json1_1ImagePermissions = (output: any, context: __SerdeContext): ImagePermissions => {
   return {
-    allowFleet: output.allowFleet !== undefined && output.allowFleet !== null ? output.allowFleet : undefined,
-    allowImageBuilder:
-      output.allowImageBuilder !== undefined && output.allowImageBuilder !== null
-        ? output.allowImageBuilder
-        : undefined,
+    allowFleet: __expectBoolean(output.allowFleet),
+    allowImageBuilder: __expectBoolean(output.allowImageBuilder),
   } as any;
 };
 
 const deserializeAws_json1_1ImageStateChangeReason = (output: any, context: __SerdeContext): ImageStateChangeReason => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -6164,7 +6130,7 @@ const deserializeAws_json1_1IncompatibleImageException = (
   context: __SerdeContext
 ): IncompatibleImageException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -6173,7 +6139,7 @@ const deserializeAws_json1_1InvalidAccountStatusException = (
   context: __SerdeContext
 ): InvalidAccountStatusException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -6182,13 +6148,13 @@ const deserializeAws_json1_1InvalidParameterCombinationException = (
   context: __SerdeContext
 ): InvalidParameterCombinationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidRoleException = (output: any, context: __SerdeContext): InvalidRoleException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -6197,8 +6163,8 @@ const deserializeAws_json1_1LastReportGenerationExecutionError = (
   context: __SerdeContext
 ): LastReportGenerationExecutionError => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
   } as any;
 };
 
@@ -6218,7 +6184,7 @@ const deserializeAws_json1_1LastReportGenerationExecutionErrors = (
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -6231,7 +6197,7 @@ const deserializeAws_json1_1ListAssociatedFleetsResult = (
       output.Names !== undefined && output.Names !== null
         ? deserializeAws_json1_1StringList(output.Names, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -6244,7 +6210,7 @@ const deserializeAws_json1_1ListAssociatedStacksResult = (
       output.Names !== undefined && output.Names !== null
         ? deserializeAws_json1_1StringList(output.Names, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -6265,7 +6231,7 @@ const deserializeAws_json1_1Metadata = (output: any, context: __SerdeContext): {
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -6275,11 +6241,8 @@ const deserializeAws_json1_1NetworkAccessConfiguration = (
   context: __SerdeContext
 ): NetworkAccessConfiguration => {
   return {
-    EniId: output.EniId !== undefined && output.EniId !== null ? output.EniId : undefined,
-    EniPrivateIpAddress:
-      output.EniPrivateIpAddress !== undefined && output.EniPrivateIpAddress !== null
-        ? output.EniPrivateIpAddress
-        : undefined,
+    EniId: __expectString(output.EniId),
+    EniPrivateIpAddress: __expectString(output.EniPrivateIpAddress),
   } as any;
 };
 
@@ -6288,7 +6251,7 @@ const deserializeAws_json1_1OperationNotPermittedException = (
   context: __SerdeContext
 ): OperationNotPermittedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -6302,7 +6265,7 @@ const deserializeAws_json1_1OrganizationalUnitDistinguishedNamesList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6311,7 +6274,7 @@ const deserializeAws_json1_1RequestLimitExceededException = (
   context: __SerdeContext
 ): RequestLimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -6320,14 +6283,14 @@ const deserializeAws_json1_1ResourceAlreadyExistsException = (
   context: __SerdeContext
 ): ResourceAlreadyExistsException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1ResourceError = (output: any, context: __SerdeContext): ResourceError => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
     ErrorTimestamp:
       output.ErrorTimestamp !== undefined && output.ErrorTimestamp !== null
         ? new Date(Math.round(output.ErrorTimestamp * 1000))
@@ -6348,7 +6311,7 @@ const deserializeAws_json1_1ResourceErrors = (output: any, context: __SerdeConte
 
 const deserializeAws_json1_1ResourceInUseException = (output: any, context: __SerdeContext): ResourceInUseException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -6357,7 +6320,7 @@ const deserializeAws_json1_1ResourceNotAvailableException = (
   context: __SerdeContext
 ): ResourceNotAvailableException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -6366,7 +6329,7 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -6377,7 +6340,7 @@ const deserializeAws_json1_1SecurityGroupIdList = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6386,22 +6349,17 @@ const deserializeAws_json1_1ServiceAccountCredentials = (
   context: __SerdeContext
 ): ServiceAccountCredentials => {
   return {
-    AccountName: output.AccountName !== undefined && output.AccountName !== null ? output.AccountName : undefined,
-    AccountPassword:
-      output.AccountPassword !== undefined && output.AccountPassword !== null ? output.AccountPassword : undefined,
+    AccountName: __expectString(output.AccountName),
+    AccountPassword: __expectString(output.AccountPassword),
   } as any;
 };
 
 const deserializeAws_json1_1Session = (output: any, context: __SerdeContext): Session => {
   return {
-    AuthenticationType:
-      output.AuthenticationType !== undefined && output.AuthenticationType !== null
-        ? output.AuthenticationType
-        : undefined,
-    ConnectionState:
-      output.ConnectionState !== undefined && output.ConnectionState !== null ? output.ConnectionState : undefined,
-    FleetName: output.FleetName !== undefined && output.FleetName !== null ? output.FleetName : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    AuthenticationType: __expectString(output.AuthenticationType),
+    ConnectionState: __expectString(output.ConnectionState),
+    FleetName: __expectString(output.FleetName),
+    Id: __expectString(output.Id),
     MaxExpirationTime:
       output.MaxExpirationTime !== undefined && output.MaxExpirationTime !== null
         ? new Date(Math.round(output.MaxExpirationTime * 1000))
@@ -6410,13 +6368,13 @@ const deserializeAws_json1_1Session = (output: any, context: __SerdeContext): Se
       output.NetworkAccessConfiguration !== undefined && output.NetworkAccessConfiguration !== null
         ? deserializeAws_json1_1NetworkAccessConfiguration(output.NetworkAccessConfiguration, context)
         : undefined,
-    StackName: output.StackName !== undefined && output.StackName !== null ? output.StackName : undefined,
+    StackName: __expectString(output.StackName),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
         ? new Date(Math.round(output.StartTime * 1000))
         : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    UserId: output.UserId !== undefined && output.UserId !== null ? output.UserId : undefined,
+    State: __expectString(output.State),
+    UserId: __expectString(output.UserId),
   } as any;
 };
 
@@ -6437,8 +6395,7 @@ const deserializeAws_json1_1SharedImagePermissions = (output: any, context: __Se
       output.imagePermissions !== undefined && output.imagePermissions !== null
         ? deserializeAws_json1_1ImagePermissions(output.imagePermissions, context)
         : undefined,
-    sharedAccountId:
-      output.sharedAccountId !== undefined && output.sharedAccountId !== null ? output.sharedAccountId : undefined,
+    sharedAccountId: __expectString(output.sharedAccountId),
   } as any;
 };
 
@@ -6466,20 +6423,20 @@ const deserializeAws_json1_1Stack = (output: any, context: __SerdeContext): Stac
       output.ApplicationSettings !== undefined && output.ApplicationSettings !== null
         ? deserializeAws_json1_1ApplicationSettingsResponse(output.ApplicationSettings, context)
         : undefined,
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    DisplayName: output.DisplayName !== undefined && output.DisplayName !== null ? output.DisplayName : undefined,
+    Description: __expectString(output.Description),
+    DisplayName: __expectString(output.DisplayName),
     EmbedHostDomains:
       output.EmbedHostDomains !== undefined && output.EmbedHostDomains !== null
         ? deserializeAws_json1_1EmbedHostDomains(output.EmbedHostDomains, context)
         : undefined,
-    FeedbackURL: output.FeedbackURL !== undefined && output.FeedbackURL !== null ? output.FeedbackURL : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    RedirectURL: output.RedirectURL !== undefined && output.RedirectURL !== null ? output.RedirectURL : undefined,
+    FeedbackURL: __expectString(output.FeedbackURL),
+    Name: __expectString(output.Name),
+    RedirectURL: __expectString(output.RedirectURL),
     StackErrors:
       output.StackErrors !== undefined && output.StackErrors !== null
         ? deserializeAws_json1_1StackErrors(output.StackErrors, context)
@@ -6497,8 +6454,8 @@ const deserializeAws_json1_1Stack = (output: any, context: __SerdeContext): Stac
 
 const deserializeAws_json1_1StackError = (output: any, context: __SerdeContext): StackError => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
   } as any;
 };
 
@@ -6555,16 +6512,12 @@ const deserializeAws_json1_1StopImageBuilderResult = (output: any, context: __Se
 
 const deserializeAws_json1_1StorageConnector = (output: any, context: __SerdeContext): StorageConnector => {
   return {
-    ConnectorType:
-      output.ConnectorType !== undefined && output.ConnectorType !== null ? output.ConnectorType : undefined,
+    ConnectorType: __expectString(output.ConnectorType),
     Domains:
       output.Domains !== undefined && output.Domains !== null
         ? deserializeAws_json1_1DomainList(output.Domains, context)
         : undefined,
-    ResourceIdentifier:
-      output.ResourceIdentifier !== undefined && output.ResourceIdentifier !== null
-        ? output.ResourceIdentifier
-        : undefined,
+    ResourceIdentifier: __expectString(output.ResourceIdentifier),
   } as any;
 };
 
@@ -6586,7 +6539,7 @@ const deserializeAws_json1_1StringList = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6597,7 +6550,7 @@ const deserializeAws_json1_1SubnetIdList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6612,7 +6565,7 @@ const deserializeAws_json1_1Tags = (output: any, context: __SerdeContext): { [ke
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -6667,8 +6620,8 @@ const deserializeAws_json1_1UsageReportSubscription = (
       output.LastGeneratedReportDate !== undefined && output.LastGeneratedReportDate !== null
         ? new Date(Math.round(output.LastGeneratedReportDate * 1000))
         : undefined,
-    S3BucketName: output.S3BucketName !== undefined && output.S3BucketName !== null ? output.S3BucketName : undefined,
-    Schedule: output.Schedule !== undefined && output.Schedule !== null ? output.Schedule : undefined,
+    S3BucketName: __expectString(output.S3BucketName),
+    Schedule: __expectString(output.Schedule),
     SubscriptionErrors:
       output.SubscriptionErrors !== undefined && output.SubscriptionErrors !== null
         ? deserializeAws_json1_1LastReportGenerationExecutionErrors(output.SubscriptionErrors, context)
@@ -6692,20 +6645,17 @@ const deserializeAws_json1_1UsageReportSubscriptionList = (
 
 const deserializeAws_json1_1User = (output: any, context: __SerdeContext): User => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    AuthenticationType:
-      output.AuthenticationType !== undefined && output.AuthenticationType !== null
-        ? output.AuthenticationType
-        : undefined,
+    Arn: __expectString(output.Arn),
+    AuthenticationType: __expectString(output.AuthenticationType),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
         : undefined,
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
-    FirstName: output.FirstName !== undefined && output.FirstName !== null ? output.FirstName : undefined,
-    LastName: output.LastName !== undefined && output.LastName !== null ? output.LastName : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    UserName: output.UserName !== undefined && output.UserName !== null ? output.UserName : undefined,
+    Enabled: __expectBoolean(output.Enabled),
+    FirstName: __expectString(output.FirstName),
+    LastName: __expectString(output.LastName),
+    Status: __expectString(output.Status),
+    UserName: __expectString(output.UserName),
   } as any;
 };
 
@@ -6722,8 +6672,8 @@ const deserializeAws_json1_1UserList = (output: any, context: __SerdeContext): U
 
 const deserializeAws_json1_1UserSetting = (output: any, context: __SerdeContext): UserSetting => {
   return {
-    Action: output.Action !== undefined && output.Action !== null ? output.Action : undefined,
-    Permission: output.Permission !== undefined && output.Permission !== null ? output.Permission : undefined,
+    Action: __expectString(output.Action),
+    Permission: __expectString(output.Permission),
   } as any;
 };
 
@@ -6740,16 +6690,10 @@ const deserializeAws_json1_1UserSettingList = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_1UserStackAssociation = (output: any, context: __SerdeContext): UserStackAssociation => {
   return {
-    AuthenticationType:
-      output.AuthenticationType !== undefined && output.AuthenticationType !== null
-        ? output.AuthenticationType
-        : undefined,
-    SendEmailNotification:
-      output.SendEmailNotification !== undefined && output.SendEmailNotification !== null
-        ? output.SendEmailNotification
-        : undefined,
-    StackName: output.StackName !== undefined && output.StackName !== null ? output.StackName : undefined,
-    UserName: output.UserName !== undefined && output.UserName !== null ? output.UserName : undefined,
+    AuthenticationType: __expectString(output.AuthenticationType),
+    SendEmailNotification: __expectBoolean(output.SendEmailNotification),
+    StackName: __expectString(output.StackName),
+    UserName: __expectString(output.UserName),
   } as any;
 };
 
@@ -6758,8 +6702,8 @@ const deserializeAws_json1_1UserStackAssociationError = (
   context: __SerdeContext
 ): UserStackAssociationError => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
     UserStackAssociation:
       output.UserStackAssociation !== undefined && output.UserStackAssociation !== null
         ? deserializeAws_json1_1UserStackAssociation(output.UserStackAssociation, context)

--- a/clients/client-appsync/protocols/Aws_restJson1.ts
+++ b/clients/client-appsync/protocols/Aws_restJson1.ts
@@ -95,6 +95,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -3466,10 +3469,10 @@ export const deserializeAws_restJson1GetSchemaCreationStatusCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.details !== undefined && data.details !== null) {
-    contents.details = data.details;
+    contents.details = __expectString(data.details);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.status = data.status;
+    contents.status = __expectString(data.status);
   }
   return Promise.resolve(contents);
 };
@@ -3639,7 +3642,7 @@ export const deserializeAws_restJson1ListApiKeysCommand = async (
     contents.apiKeys = deserializeAws_restJson1ApiKeys(data.apiKeys, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3722,7 +3725,7 @@ export const deserializeAws_restJson1ListDataSourcesCommand = async (
     contents.dataSources = deserializeAws_restJson1DataSources(data.dataSources, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3805,7 +3808,7 @@ export const deserializeAws_restJson1ListFunctionsCommand = async (
     contents.functions = deserializeAws_restJson1Functions(data.functions, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3888,7 +3891,7 @@ export const deserializeAws_restJson1ListGraphqlApisCommand = async (
     contents.graphqlApis = deserializeAws_restJson1GraphqlApis(data.graphqlApis, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3960,7 +3963,7 @@ export const deserializeAws_restJson1ListResolversCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.resolvers !== undefined && data.resolvers !== null) {
     contents.resolvers = deserializeAws_restJson1Resolvers(data.resolvers, context);
@@ -4043,7 +4046,7 @@ export const deserializeAws_restJson1ListResolversByFunctionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.resolvers !== undefined && data.resolvers !== null) {
     contents.resolvers = deserializeAws_restJson1Resolvers(data.resolvers, context);
@@ -4221,7 +4224,7 @@ export const deserializeAws_restJson1ListTypesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.types !== undefined && data.types !== null) {
     contents.types = deserializeAws_restJson1TypeList(data.types, context);
@@ -4311,7 +4314,7 @@ export const deserializeAws_restJson1StartSchemaCreationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.status !== undefined && data.status !== null) {
-    contents.status = data.status;
+    contents.status = __expectString(data.status);
   }
   return Promise.resolve(contents);
 };
@@ -5188,7 +5191,7 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -5205,7 +5208,7 @@ const deserializeAws_restJson1ApiKeyLimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -5222,7 +5225,7 @@ const deserializeAws_restJson1ApiKeyValidityOutOfBoundsExceptionResponse = async
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -5239,7 +5242,7 @@ const deserializeAws_restJson1ApiLimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -5256,7 +5259,7 @@ const deserializeAws_restJson1BadRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -5273,7 +5276,7 @@ const deserializeAws_restJson1ConcurrentModificationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -5290,7 +5293,7 @@ const deserializeAws_restJson1GraphQLSchemaExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -5307,7 +5310,7 @@ const deserializeAws_restJson1InternalFailureExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -5324,7 +5327,7 @@ const deserializeAws_restJson1LimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -5341,7 +5344,7 @@ const deserializeAws_restJson1NotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -5358,7 +5361,7 @@ const deserializeAws_restJson1UnauthorizedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -5612,10 +5615,7 @@ const deserializeAws_restJson1AdditionalAuthenticationProvider = (
   context: __SerdeContext
 ): AdditionalAuthenticationProvider => {
   return {
-    authenticationType:
-      output.authenticationType !== undefined && output.authenticationType !== null
-        ? output.authenticationType
-        : undefined,
+    authenticationType: __expectString(output.authenticationType),
     openIDConnectConfig:
       output.openIDConnectConfig !== undefined && output.openIDConnectConfig !== null
         ? deserializeAws_restJson1OpenIDConnectConfig(output.openIDConnectConfig, context)
@@ -5643,30 +5643,21 @@ const deserializeAws_restJson1AdditionalAuthenticationProviders = (
 
 const deserializeAws_restJson1ApiCache = (output: any, context: __SerdeContext): ApiCache => {
   return {
-    apiCachingBehavior:
-      output.apiCachingBehavior !== undefined && output.apiCachingBehavior !== null
-        ? output.apiCachingBehavior
-        : undefined,
-    atRestEncryptionEnabled:
-      output.atRestEncryptionEnabled !== undefined && output.atRestEncryptionEnabled !== null
-        ? output.atRestEncryptionEnabled
-        : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    transitEncryptionEnabled:
-      output.transitEncryptionEnabled !== undefined && output.transitEncryptionEnabled !== null
-        ? output.transitEncryptionEnabled
-        : undefined,
-    ttl: output.ttl !== undefined && output.ttl !== null ? output.ttl : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    apiCachingBehavior: __expectString(output.apiCachingBehavior),
+    atRestEncryptionEnabled: __expectBoolean(output.atRestEncryptionEnabled),
+    status: __expectString(output.status),
+    transitEncryptionEnabled: __expectBoolean(output.transitEncryptionEnabled),
+    ttl: __expectNumber(output.ttl),
+    type: __expectString(output.type),
   } as any;
 };
 
 const deserializeAws_restJson1ApiKey = (output: any, context: __SerdeContext): ApiKey => {
   return {
-    deletes: output.deletes !== undefined && output.deletes !== null ? output.deletes : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    expires: output.expires !== undefined && output.expires !== null ? output.expires : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    deletes: __expectNumber(output.deletes),
+    description: __expectString(output.description),
+    expires: __expectNumber(output.expires),
+    id: __expectString(output.id),
   } as any;
 };
 
@@ -5683,10 +5674,7 @@ const deserializeAws_restJson1ApiKeys = (output: any, context: __SerdeContext): 
 
 const deserializeAws_restJson1AuthorizationConfig = (output: any, context: __SerdeContext): AuthorizationConfig => {
   return {
-    authorizationType:
-      output.authorizationType !== undefined && output.authorizationType !== null
-        ? output.authorizationType
-        : undefined,
+    authorizationType: __expectString(output.authorizationType),
     awsIamConfig:
       output.awsIamConfig !== undefined && output.awsIamConfig !== null
         ? deserializeAws_restJson1AwsIamConfig(output.awsIamConfig, context)
@@ -5696,12 +5684,8 @@ const deserializeAws_restJson1AuthorizationConfig = (output: any, context: __Ser
 
 const deserializeAws_restJson1AwsIamConfig = (output: any, context: __SerdeContext): AwsIamConfig => {
   return {
-    signingRegion:
-      output.signingRegion !== undefined && output.signingRegion !== null ? output.signingRegion : undefined,
-    signingServiceName:
-      output.signingServiceName !== undefined && output.signingServiceName !== null
-        ? output.signingServiceName
-        : undefined,
+    signingRegion: __expectString(output.signingRegion),
+    signingServiceName: __expectString(output.signingServiceName),
   } as any;
 };
 
@@ -5711,7 +5695,7 @@ const deserializeAws_restJson1CachingConfig = (output: any, context: __SerdeCont
       output.cachingKeys !== undefined && output.cachingKeys !== null
         ? deserializeAws_restJson1CachingKeys(output.cachingKeys, context)
         : undefined,
-    ttl: output.ttl !== undefined && output.ttl !== null ? output.ttl : undefined,
+    ttl: __expectNumber(output.ttl),
   } as any;
 };
 
@@ -5722,24 +5706,22 @@ const deserializeAws_restJson1CachingKeys = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1CognitoUserPoolConfig = (output: any, context: __SerdeContext): CognitoUserPoolConfig => {
   return {
-    appIdClientRegex:
-      output.appIdClientRegex !== undefined && output.appIdClientRegex !== null ? output.appIdClientRegex : undefined,
-    awsRegion: output.awsRegion !== undefined && output.awsRegion !== null ? output.awsRegion : undefined,
-    userPoolId: output.userPoolId !== undefined && output.userPoolId !== null ? output.userPoolId : undefined,
+    appIdClientRegex: __expectString(output.appIdClientRegex),
+    awsRegion: __expectString(output.awsRegion),
+    userPoolId: __expectString(output.userPoolId),
   } as any;
 };
 
 const deserializeAws_restJson1DataSource = (output: any, context: __SerdeContext): DataSource => {
   return {
-    dataSourceArn:
-      output.dataSourceArn !== undefined && output.dataSourceArn !== null ? output.dataSourceArn : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    dataSourceArn: __expectString(output.dataSourceArn),
+    description: __expectString(output.description),
     dynamodbConfig:
       output.dynamodbConfig !== undefined && output.dynamodbConfig !== null
         ? deserializeAws_restJson1DynamodbDataSourceConfig(output.dynamodbConfig, context)
@@ -5756,14 +5738,13 @@ const deserializeAws_restJson1DataSource = (output: any, context: __SerdeContext
       output.lambdaConfig !== undefined && output.lambdaConfig !== null
         ? deserializeAws_restJson1LambdaDataSourceConfig(output.lambdaConfig, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
     relationalDatabaseConfig:
       output.relationalDatabaseConfig !== undefined && output.relationalDatabaseConfig !== null
         ? deserializeAws_restJson1RelationalDatabaseDataSourceConfig(output.relationalDatabaseConfig, context)
         : undefined,
-    serviceRoleArn:
-      output.serviceRoleArn !== undefined && output.serviceRoleArn !== null ? output.serviceRoleArn : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    serviceRoleArn: __expectString(output.serviceRoleArn),
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -5780,15 +5761,9 @@ const deserializeAws_restJson1DataSources = (output: any, context: __SerdeContex
 
 const deserializeAws_restJson1DeltaSyncConfig = (output: any, context: __SerdeContext): DeltaSyncConfig => {
   return {
-    baseTableTTL: output.baseTableTTL !== undefined && output.baseTableTTL !== null ? output.baseTableTTL : undefined,
-    deltaSyncTableName:
-      output.deltaSyncTableName !== undefined && output.deltaSyncTableName !== null
-        ? output.deltaSyncTableName
-        : undefined,
-    deltaSyncTableTTL:
-      output.deltaSyncTableTTL !== undefined && output.deltaSyncTableTTL !== null
-        ? output.deltaSyncTableTTL
-        : undefined,
+    baseTableTTL: __expectNumber(output.baseTableTTL),
+    deltaSyncTableName: __expectString(output.deltaSyncTableName),
+    deltaSyncTableTTL: __expectNumber(output.deltaSyncTableTTL),
   } as any;
 };
 
@@ -5797,17 +5772,14 @@ const deserializeAws_restJson1DynamodbDataSourceConfig = (
   context: __SerdeContext
 ): DynamodbDataSourceConfig => {
   return {
-    awsRegion: output.awsRegion !== undefined && output.awsRegion !== null ? output.awsRegion : undefined,
+    awsRegion: __expectString(output.awsRegion),
     deltaSyncConfig:
       output.deltaSyncConfig !== undefined && output.deltaSyncConfig !== null
         ? deserializeAws_restJson1DeltaSyncConfig(output.deltaSyncConfig, context)
         : undefined,
-    tableName: output.tableName !== undefined && output.tableName !== null ? output.tableName : undefined,
-    useCallerCredentials:
-      output.useCallerCredentials !== undefined && output.useCallerCredentials !== null
-        ? output.useCallerCredentials
-        : undefined,
-    versioned: output.versioned !== undefined && output.versioned !== null ? output.versioned : undefined,
+    tableName: __expectString(output.tableName),
+    useCallerCredentials: __expectBoolean(output.useCallerCredentials),
+    versioned: __expectBoolean(output.versioned),
   } as any;
 };
 
@@ -5816,29 +5788,21 @@ const deserializeAws_restJson1ElasticsearchDataSourceConfig = (
   context: __SerdeContext
 ): ElasticsearchDataSourceConfig => {
   return {
-    awsRegion: output.awsRegion !== undefined && output.awsRegion !== null ? output.awsRegion : undefined,
-    endpoint: output.endpoint !== undefined && output.endpoint !== null ? output.endpoint : undefined,
+    awsRegion: __expectString(output.awsRegion),
+    endpoint: __expectString(output.endpoint),
   } as any;
 };
 
 const deserializeAws_restJson1FunctionConfiguration = (output: any, context: __SerdeContext): FunctionConfiguration => {
   return {
-    dataSourceName:
-      output.dataSourceName !== undefined && output.dataSourceName !== null ? output.dataSourceName : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    functionArn: output.functionArn !== undefined && output.functionArn !== null ? output.functionArn : undefined,
-    functionId: output.functionId !== undefined && output.functionId !== null ? output.functionId : undefined,
-    functionVersion:
-      output.functionVersion !== undefined && output.functionVersion !== null ? output.functionVersion : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    requestMappingTemplate:
-      output.requestMappingTemplate !== undefined && output.requestMappingTemplate !== null
-        ? output.requestMappingTemplate
-        : undefined,
-    responseMappingTemplate:
-      output.responseMappingTemplate !== undefined && output.responseMappingTemplate !== null
-        ? output.responseMappingTemplate
-        : undefined,
+    dataSourceName: __expectString(output.dataSourceName),
+    description: __expectString(output.description),
+    functionArn: __expectString(output.functionArn),
+    functionId: __expectString(output.functionId),
+    functionVersion: __expectString(output.functionVersion),
+    name: __expectString(output.name),
+    requestMappingTemplate: __expectString(output.requestMappingTemplate),
+    responseMappingTemplate: __expectString(output.responseMappingTemplate),
     syncConfig:
       output.syncConfig !== undefined && output.syncConfig !== null
         ? deserializeAws_restJson1SyncConfig(output.syncConfig, context)
@@ -5864,7 +5828,7 @@ const deserializeAws_restJson1FunctionsIds = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -5874,17 +5838,14 @@ const deserializeAws_restJson1GraphqlApi = (output: any, context: __SerdeContext
       output.additionalAuthenticationProviders !== undefined && output.additionalAuthenticationProviders !== null
         ? deserializeAws_restJson1AdditionalAuthenticationProviders(output.additionalAuthenticationProviders, context)
         : undefined,
-    apiId: output.apiId !== undefined && output.apiId !== null ? output.apiId : undefined,
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    authenticationType:
-      output.authenticationType !== undefined && output.authenticationType !== null
-        ? output.authenticationType
-        : undefined,
+    apiId: __expectString(output.apiId),
+    arn: __expectString(output.arn),
+    authenticationType: __expectString(output.authenticationType),
     logConfig:
       output.logConfig !== undefined && output.logConfig !== null
         ? deserializeAws_restJson1LogConfig(output.logConfig, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
     openIDConnectConfig:
       output.openIDConnectConfig !== undefined && output.openIDConnectConfig !== null
         ? deserializeAws_restJson1OpenIDConnectConfig(output.openIDConnectConfig, context)
@@ -5901,8 +5862,8 @@ const deserializeAws_restJson1GraphqlApi = (output: any, context: __SerdeContext
       output.userPoolConfig !== undefined && output.userPoolConfig !== null
         ? deserializeAws_restJson1UserPoolConfig(output.userPoolConfig, context)
         : undefined,
-    wafWebAclArn: output.wafWebAclArn !== undefined && output.wafWebAclArn !== null ? output.wafWebAclArn : undefined,
-    xrayEnabled: output.xrayEnabled !== undefined && output.xrayEnabled !== null ? output.xrayEnabled : undefined,
+    wafWebAclArn: __expectString(output.wafWebAclArn),
+    xrayEnabled: __expectBoolean(output.xrayEnabled),
   } as any;
 };
 
@@ -5923,7 +5884,7 @@ const deserializeAws_restJson1HttpDataSourceConfig = (output: any, context: __Se
       output.authorizationConfig !== undefined && output.authorizationConfig !== null
         ? deserializeAws_restJson1AuthorizationConfig(output.authorizationConfig, context)
         : undefined,
-    endpoint: output.endpoint !== undefined && output.endpoint !== null ? output.endpoint : undefined,
+    endpoint: __expectString(output.endpoint),
   } as any;
 };
 
@@ -5932,10 +5893,7 @@ const deserializeAws_restJson1LambdaConflictHandlerConfig = (
   context: __SerdeContext
 ): LambdaConflictHandlerConfig => {
   return {
-    lambdaConflictHandlerArn:
-      output.lambdaConflictHandlerArn !== undefined && output.lambdaConflictHandlerArn !== null
-        ? output.lambdaConflictHandlerArn
-        : undefined,
+    lambdaConflictHandlerArn: __expectString(output.lambdaConflictHandlerArn),
   } as any;
 };
 
@@ -5944,25 +5902,15 @@ const deserializeAws_restJson1LambdaDataSourceConfig = (
   context: __SerdeContext
 ): LambdaDataSourceConfig => {
   return {
-    lambdaFunctionArn:
-      output.lambdaFunctionArn !== undefined && output.lambdaFunctionArn !== null
-        ? output.lambdaFunctionArn
-        : undefined,
+    lambdaFunctionArn: __expectString(output.lambdaFunctionArn),
   } as any;
 };
 
 const deserializeAws_restJson1LogConfig = (output: any, context: __SerdeContext): LogConfig => {
   return {
-    cloudWatchLogsRoleArn:
-      output.cloudWatchLogsRoleArn !== undefined && output.cloudWatchLogsRoleArn !== null
-        ? output.cloudWatchLogsRoleArn
-        : undefined,
-    excludeVerboseContent:
-      output.excludeVerboseContent !== undefined && output.excludeVerboseContent !== null
-        ? output.excludeVerboseContent
-        : undefined,
-    fieldLogLevel:
-      output.fieldLogLevel !== undefined && output.fieldLogLevel !== null ? output.fieldLogLevel : undefined,
+    cloudWatchLogsRoleArn: __expectString(output.cloudWatchLogsRoleArn),
+    excludeVerboseContent: __expectBoolean(output.excludeVerboseContent),
+    fieldLogLevel: __expectString(output.fieldLogLevel),
   } as any;
 };
 
@@ -5976,17 +5924,17 @@ const deserializeAws_restJson1MapOfStringToString = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1OpenIDConnectConfig = (output: any, context: __SerdeContext): OpenIDConnectConfig => {
   return {
-    authTTL: output.authTTL !== undefined && output.authTTL !== null ? output.authTTL : undefined,
-    clientId: output.clientId !== undefined && output.clientId !== null ? output.clientId : undefined,
-    iatTTL: output.iatTTL !== undefined && output.iatTTL !== null ? output.iatTTL : undefined,
-    issuer: output.issuer !== undefined && output.issuer !== null ? output.issuer : undefined,
+    authTTL: __expectNumber(output.authTTL),
+    clientId: __expectString(output.clientId),
+    iatTTL: __expectNumber(output.iatTTL),
+    issuer: __expectString(output.issuer),
   } as any;
 };
 
@@ -6001,17 +5949,11 @@ const deserializeAws_restJson1PipelineConfig = (output: any, context: __SerdeCon
 
 const deserializeAws_restJson1RdsHttpEndpointConfig = (output: any, context: __SerdeContext): RdsHttpEndpointConfig => {
   return {
-    awsRegion: output.awsRegion !== undefined && output.awsRegion !== null ? output.awsRegion : undefined,
-    awsSecretStoreArn:
-      output.awsSecretStoreArn !== undefined && output.awsSecretStoreArn !== null
-        ? output.awsSecretStoreArn
-        : undefined,
-    databaseName: output.databaseName !== undefined && output.databaseName !== null ? output.databaseName : undefined,
-    dbClusterIdentifier:
-      output.dbClusterIdentifier !== undefined && output.dbClusterIdentifier !== null
-        ? output.dbClusterIdentifier
-        : undefined,
-    schema: output.schema !== undefined && output.schema !== null ? output.schema : undefined,
+    awsRegion: __expectString(output.awsRegion),
+    awsSecretStoreArn: __expectString(output.awsSecretStoreArn),
+    databaseName: __expectString(output.databaseName),
+    dbClusterIdentifier: __expectString(output.dbClusterIdentifier),
+    schema: __expectString(output.schema),
   } as any;
 };
 
@@ -6024,10 +5966,7 @@ const deserializeAws_restJson1RelationalDatabaseDataSourceConfig = (
       output.rdsHttpEndpointConfig !== undefined && output.rdsHttpEndpointConfig !== null
         ? deserializeAws_restJson1RdsHttpEndpointConfig(output.rdsHttpEndpointConfig, context)
         : undefined,
-    relationalDatabaseSourceType:
-      output.relationalDatabaseSourceType !== undefined && output.relationalDatabaseSourceType !== null
-        ? output.relationalDatabaseSourceType
-        : undefined,
+    relationalDatabaseSourceType: __expectString(output.relationalDatabaseSourceType),
   } as any;
 };
 
@@ -6037,28 +5976,21 @@ const deserializeAws_restJson1Resolver = (output: any, context: __SerdeContext):
       output.cachingConfig !== undefined && output.cachingConfig !== null
         ? deserializeAws_restJson1CachingConfig(output.cachingConfig, context)
         : undefined,
-    dataSourceName:
-      output.dataSourceName !== undefined && output.dataSourceName !== null ? output.dataSourceName : undefined,
-    fieldName: output.fieldName !== undefined && output.fieldName !== null ? output.fieldName : undefined,
-    kind: output.kind !== undefined && output.kind !== null ? output.kind : undefined,
+    dataSourceName: __expectString(output.dataSourceName),
+    fieldName: __expectString(output.fieldName),
+    kind: __expectString(output.kind),
     pipelineConfig:
       output.pipelineConfig !== undefined && output.pipelineConfig !== null
         ? deserializeAws_restJson1PipelineConfig(output.pipelineConfig, context)
         : undefined,
-    requestMappingTemplate:
-      output.requestMappingTemplate !== undefined && output.requestMappingTemplate !== null
-        ? output.requestMappingTemplate
-        : undefined,
-    resolverArn: output.resolverArn !== undefined && output.resolverArn !== null ? output.resolverArn : undefined,
-    responseMappingTemplate:
-      output.responseMappingTemplate !== undefined && output.responseMappingTemplate !== null
-        ? output.responseMappingTemplate
-        : undefined,
+    requestMappingTemplate: __expectString(output.requestMappingTemplate),
+    resolverArn: __expectString(output.resolverArn),
+    responseMappingTemplate: __expectString(output.responseMappingTemplate),
     syncConfig:
       output.syncConfig !== undefined && output.syncConfig !== null
         ? deserializeAws_restJson1SyncConfig(output.syncConfig, context)
         : undefined,
-    typeName: output.typeName !== undefined && output.typeName !== null ? output.typeName : undefined,
+    typeName: __expectString(output.typeName),
   } as any;
 };
 
@@ -6075,12 +6007,8 @@ const deserializeAws_restJson1Resolvers = (output: any, context: __SerdeContext)
 
 const deserializeAws_restJson1SyncConfig = (output: any, context: __SerdeContext): SyncConfig => {
   return {
-    conflictDetection:
-      output.conflictDetection !== undefined && output.conflictDetection !== null
-        ? output.conflictDetection
-        : undefined,
-    conflictHandler:
-      output.conflictHandler !== undefined && output.conflictHandler !== null ? output.conflictHandler : undefined,
+    conflictDetection: __expectString(output.conflictDetection),
+    conflictHandler: __expectString(output.conflictHandler),
     lambdaConflictHandlerConfig:
       output.lambdaConflictHandlerConfig !== undefined && output.lambdaConflictHandlerConfig !== null
         ? deserializeAws_restJson1LambdaConflictHandlerConfig(output.lambdaConflictHandlerConfig, context)
@@ -6095,18 +6023,18 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1Type = (output: any, context: __SerdeContext): Type => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    definition: output.definition !== undefined && output.definition !== null ? output.definition : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    format: output.format !== undefined && output.format !== null ? output.format : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    arn: __expectString(output.arn),
+    definition: __expectString(output.definition),
+    description: __expectString(output.description),
+    format: __expectString(output.format),
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -6123,12 +6051,10 @@ const deserializeAws_restJson1TypeList = (output: any, context: __SerdeContext):
 
 const deserializeAws_restJson1UserPoolConfig = (output: any, context: __SerdeContext): UserPoolConfig => {
   return {
-    appIdClientRegex:
-      output.appIdClientRegex !== undefined && output.appIdClientRegex !== null ? output.appIdClientRegex : undefined,
-    awsRegion: output.awsRegion !== undefined && output.awsRegion !== null ? output.awsRegion : undefined,
-    defaultAction:
-      output.defaultAction !== undefined && output.defaultAction !== null ? output.defaultAction : undefined,
-    userPoolId: output.userPoolId !== undefined && output.userPoolId !== null ? output.userPoolId : undefined,
+    appIdClientRegex: __expectString(output.appIdClientRegex),
+    awsRegion: __expectString(output.awsRegion),
+    defaultAction: __expectString(output.defaultAction),
+    userPoolId: __expectString(output.userPoolId),
   } as any;
 };
 

--- a/clients/client-athena/protocols/Aws_json1_1.ts
+++ b/clients/client-athena/protocols/Aws_json1_1.ts
@@ -163,7 +163,12 @@ import {
   WorkGroupSummary,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -3410,25 +3415,24 @@ const deserializeAws_json1_1BatchGetQueryExecutionOutput = (
 
 const deserializeAws_json1_1Column = (output: any, context: __SerdeContext): Column => {
   return {
-    Comment: output.Comment !== undefined && output.Comment !== null ? output.Comment : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Comment: __expectString(output.Comment),
+    Name: __expectString(output.Name),
+    Type: __expectString(output.Type),
   } as any;
 };
 
 const deserializeAws_json1_1ColumnInfo = (output: any, context: __SerdeContext): ColumnInfo => {
   return {
-    CaseSensitive:
-      output.CaseSensitive !== undefined && output.CaseSensitive !== null ? output.CaseSensitive : undefined,
-    CatalogName: output.CatalogName !== undefined && output.CatalogName !== null ? output.CatalogName : undefined,
-    Label: output.Label !== undefined && output.Label !== null ? output.Label : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Nullable: output.Nullable !== undefined && output.Nullable !== null ? output.Nullable : undefined,
-    Precision: output.Precision !== undefined && output.Precision !== null ? output.Precision : undefined,
-    Scale: output.Scale !== undefined && output.Scale !== null ? output.Scale : undefined,
-    SchemaName: output.SchemaName !== undefined && output.SchemaName !== null ? output.SchemaName : undefined,
-    TableName: output.TableName !== undefined && output.TableName !== null ? output.TableName : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    CaseSensitive: __expectBoolean(output.CaseSensitive),
+    CatalogName: __expectString(output.CatalogName),
+    Label: __expectString(output.Label),
+    Name: __expectString(output.Name),
+    Nullable: __expectString(output.Nullable),
+    Precision: __expectNumber(output.Precision),
+    Scale: __expectNumber(output.Scale),
+    SchemaName: __expectString(output.SchemaName),
+    TableName: __expectString(output.TableName),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -3463,7 +3467,7 @@ const deserializeAws_json1_1CreateDataCatalogOutput = (
 
 const deserializeAws_json1_1CreateNamedQueryOutput = (output: any, context: __SerdeContext): CreateNamedQueryOutput => {
   return {
-    NamedQueryId: output.NamedQueryId !== undefined && output.NamedQueryId !== null ? output.NamedQueryId : undefined,
+    NamedQueryId: __expectString(output.NamedQueryId),
   } as any;
 };
 
@@ -3480,8 +3484,8 @@ const deserializeAws_json1_1CreateWorkGroupOutput = (output: any, context: __Ser
 
 const deserializeAws_json1_1Database = (output: any, context: __SerdeContext): Database => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Description: __expectString(output.Description),
+    Name: __expectString(output.Name),
     Parameters:
       output.Parameters !== undefined && output.Parameters !== null
         ? deserializeAws_json1_1ParametersMap(output.Parameters, context)
@@ -3502,20 +3506,20 @@ const deserializeAws_json1_1DatabaseList = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_1DataCatalog = (output: any, context: __SerdeContext): DataCatalog => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Description: __expectString(output.Description),
+    Name: __expectString(output.Name),
     Parameters:
       output.Parameters !== undefined && output.Parameters !== null
         ? deserializeAws_json1_1ParametersMap(output.Parameters, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
 const deserializeAws_json1_1DataCatalogSummary = (output: any, context: __SerdeContext): DataCatalogSummary => {
   return {
-    CatalogName: output.CatalogName !== undefined && output.CatalogName !== null ? output.CatalogName : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    CatalogName: __expectString(output.CatalogName),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -3532,7 +3536,7 @@ const deserializeAws_json1_1DataCatalogSummaryList = (output: any, context: __Se
 
 const deserializeAws_json1_1Datum = (output: any, context: __SerdeContext): Datum => {
   return {
-    VarCharValue: output.VarCharValue !== undefined && output.VarCharValue !== null ? output.VarCharValue : undefined,
+    VarCharValue: __expectString(output.VarCharValue),
   } as any;
 };
 
@@ -3574,22 +3578,15 @@ const deserializeAws_json1_1EncryptionConfiguration = (
   context: __SerdeContext
 ): EncryptionConfiguration => {
   return {
-    EncryptionOption:
-      output.EncryptionOption !== undefined && output.EncryptionOption !== null ? output.EncryptionOption : undefined,
-    KmsKey: output.KmsKey !== undefined && output.KmsKey !== null ? output.KmsKey : undefined,
+    EncryptionOption: __expectString(output.EncryptionOption),
+    KmsKey: __expectString(output.KmsKey),
   } as any;
 };
 
 const deserializeAws_json1_1EngineVersion = (output: any, context: __SerdeContext): EngineVersion => {
   return {
-    EffectiveEngineVersion:
-      output.EffectiveEngineVersion !== undefined && output.EffectiveEngineVersion !== null
-        ? output.EffectiveEngineVersion
-        : undefined,
-    SelectedEngineVersion:
-      output.SelectedEngineVersion !== undefined && output.SelectedEngineVersion !== null
-        ? output.SelectedEngineVersion
-        : undefined,
+    EffectiveEngineVersion: __expectString(output.EffectiveEngineVersion),
+    SelectedEngineVersion: __expectString(output.SelectedEngineVersion),
   } as any;
 };
 
@@ -3657,12 +3654,12 @@ const deserializeAws_json1_1GetQueryExecutionOutput = (
 
 const deserializeAws_json1_1GetQueryResultsOutput = (output: any, context: __SerdeContext): GetQueryResultsOutput => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     ResultSet:
       output.ResultSet !== undefined && output.ResultSet !== null
         ? deserializeAws_json1_1ResultSet(output.ResultSet, context)
         : undefined,
-    UpdateCount: output.UpdateCount !== undefined && output.UpdateCount !== null ? output.UpdateCount : undefined,
+    UpdateCount: __expectNumber(output.UpdateCount),
   } as any;
 };
 
@@ -3689,7 +3686,7 @@ const deserializeAws_json1_1InternalServerException = (
   context: __SerdeContext
 ): InternalServerException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3698,9 +3695,8 @@ const deserializeAws_json1_1InvalidRequestException = (
   context: __SerdeContext
 ): InvalidRequestException => {
   return {
-    AthenaErrorCode:
-      output.AthenaErrorCode !== undefined && output.AthenaErrorCode !== null ? output.AthenaErrorCode : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    AthenaErrorCode: __expectString(output.AthenaErrorCode),
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3710,7 +3706,7 @@ const deserializeAws_json1_1ListDatabasesOutput = (output: any, context: __Serde
       output.DatabaseList !== undefined && output.DatabaseList !== null
         ? deserializeAws_json1_1DatabaseList(output.DatabaseList, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -3720,7 +3716,7 @@ const deserializeAws_json1_1ListDataCatalogsOutput = (output: any, context: __Se
       output.DataCatalogsSummary !== undefined && output.DataCatalogsSummary !== null
         ? deserializeAws_json1_1DataCatalogSummaryList(output.DataCatalogsSummary, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -3733,7 +3729,7 @@ const deserializeAws_json1_1ListEngineVersionsOutput = (
       output.EngineVersions !== undefined && output.EngineVersions !== null
         ? deserializeAws_json1_1EngineVersionsList(output.EngineVersions, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -3743,7 +3739,7 @@ const deserializeAws_json1_1ListNamedQueriesOutput = (output: any, context: __Se
       output.NamedQueryIds !== undefined && output.NamedQueryIds !== null
         ? deserializeAws_json1_1NamedQueryIdList(output.NamedQueryIds, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -3752,7 +3748,7 @@ const deserializeAws_json1_1ListPreparedStatementsOutput = (
   context: __SerdeContext
 ): ListPreparedStatementsOutput => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     PreparedStatements:
       output.PreparedStatements !== undefined && output.PreparedStatements !== null
         ? deserializeAws_json1_1PreparedStatementsList(output.PreparedStatements, context)
@@ -3765,7 +3761,7 @@ const deserializeAws_json1_1ListQueryExecutionsOutput = (
   context: __SerdeContext
 ): ListQueryExecutionsOutput => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     QueryExecutionIds:
       output.QueryExecutionIds !== undefined && output.QueryExecutionIds !== null
         ? deserializeAws_json1_1QueryExecutionIdList(output.QueryExecutionIds, context)
@@ -3778,7 +3774,7 @@ const deserializeAws_json1_1ListTableMetadataOutput = (
   context: __SerdeContext
 ): ListTableMetadataOutput => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     TableMetadataList:
       output.TableMetadataList !== undefined && output.TableMetadataList !== null
         ? deserializeAws_json1_1TableMetadataList(output.TableMetadataList, context)
@@ -3791,7 +3787,7 @@ const deserializeAws_json1_1ListTagsForResourceOutput = (
   context: __SerdeContext
 ): ListTagsForResourceOutput => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_1TagList(output.Tags, context)
@@ -3801,7 +3797,7 @@ const deserializeAws_json1_1ListTagsForResourceOutput = (
 
 const deserializeAws_json1_1ListWorkGroupsOutput = (output: any, context: __SerdeContext): ListWorkGroupsOutput => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     WorkGroups:
       output.WorkGroups !== undefined && output.WorkGroups !== null
         ? deserializeAws_json1_1WorkGroupsList(output.WorkGroups, context)
@@ -3811,18 +3807,18 @@ const deserializeAws_json1_1ListWorkGroupsOutput = (output: any, context: __Serd
 
 const deserializeAws_json1_1MetadataException = (output: any, context: __SerdeContext): MetadataException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1NamedQuery = (output: any, context: __SerdeContext): NamedQuery => {
   return {
-    Database: output.Database !== undefined && output.Database !== null ? output.Database : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    NamedQueryId: output.NamedQueryId !== undefined && output.NamedQueryId !== null ? output.NamedQueryId : undefined,
-    QueryString: output.QueryString !== undefined && output.QueryString !== null ? output.QueryString : undefined,
-    WorkGroup: output.WorkGroup !== undefined && output.WorkGroup !== null ? output.WorkGroup : undefined,
+    Database: __expectString(output.Database),
+    Description: __expectString(output.Description),
+    Name: __expectString(output.Name),
+    NamedQueryId: __expectString(output.NamedQueryId),
+    QueryString: __expectString(output.QueryString),
+    WorkGroup: __expectString(output.WorkGroup),
   } as any;
 };
 
@@ -3833,7 +3829,7 @@ const deserializeAws_json1_1NamedQueryIdList = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3855,24 +3851,21 @@ const deserializeAws_json1_1ParametersMap = (output: any, context: __SerdeContex
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_json1_1PreparedStatement = (output: any, context: __SerdeContext): PreparedStatement => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    QueryStatement:
-      output.QueryStatement !== undefined && output.QueryStatement !== null ? output.QueryStatement : undefined,
-    StatementName:
-      output.StatementName !== undefined && output.StatementName !== null ? output.StatementName : undefined,
-    WorkGroupName:
-      output.WorkGroupName !== undefined && output.WorkGroupName !== null ? output.WorkGroupName : undefined,
+    QueryStatement: __expectString(output.QueryStatement),
+    StatementName: __expectString(output.StatementName),
+    WorkGroupName: __expectString(output.WorkGroupName),
   } as any;
 };
 
@@ -3899,8 +3892,7 @@ const deserializeAws_json1_1PreparedStatementSummary = (
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    StatementName:
-      output.StatementName !== undefined && output.StatementName !== null ? output.StatementName : undefined,
+    StatementName: __expectString(output.StatementName),
   } as any;
 };
 
@@ -3910,19 +3902,17 @@ const deserializeAws_json1_1QueryExecution = (output: any, context: __SerdeConte
       output.EngineVersion !== undefined && output.EngineVersion !== null
         ? deserializeAws_json1_1EngineVersion(output.EngineVersion, context)
         : undefined,
-    Query: output.Query !== undefined && output.Query !== null ? output.Query : undefined,
+    Query: __expectString(output.Query),
     QueryExecutionContext:
       output.QueryExecutionContext !== undefined && output.QueryExecutionContext !== null
         ? deserializeAws_json1_1QueryExecutionContext(output.QueryExecutionContext, context)
         : undefined,
-    QueryExecutionId:
-      output.QueryExecutionId !== undefined && output.QueryExecutionId !== null ? output.QueryExecutionId : undefined,
+    QueryExecutionId: __expectString(output.QueryExecutionId),
     ResultConfiguration:
       output.ResultConfiguration !== undefined && output.ResultConfiguration !== null
         ? deserializeAws_json1_1ResultConfiguration(output.ResultConfiguration, context)
         : undefined,
-    StatementType:
-      output.StatementType !== undefined && output.StatementType !== null ? output.StatementType : undefined,
+    StatementType: __expectString(output.StatementType),
     Statistics:
       output.Statistics !== undefined && output.Statistics !== null
         ? deserializeAws_json1_1QueryExecutionStatistics(output.Statistics, context)
@@ -3931,14 +3921,14 @@ const deserializeAws_json1_1QueryExecution = (output: any, context: __SerdeConte
       output.Status !== undefined && output.Status !== null
         ? deserializeAws_json1_1QueryExecutionStatus(output.Status, context)
         : undefined,
-    WorkGroup: output.WorkGroup !== undefined && output.WorkGroup !== null ? output.WorkGroup : undefined,
+    WorkGroup: __expectString(output.WorkGroup),
   } as any;
 };
 
 const deserializeAws_json1_1QueryExecutionContext = (output: any, context: __SerdeContext): QueryExecutionContext => {
   return {
-    Catalog: output.Catalog !== undefined && output.Catalog !== null ? output.Catalog : undefined,
-    Database: output.Database !== undefined && output.Database !== null ? output.Database : undefined,
+    Catalog: __expectString(output.Catalog),
+    Database: __expectString(output.Database),
   } as any;
 };
 
@@ -3949,7 +3939,7 @@ const deserializeAws_json1_1QueryExecutionIdList = (output: any, context: __Serd
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3969,34 +3959,13 @@ const deserializeAws_json1_1QueryExecutionStatistics = (
   context: __SerdeContext
 ): QueryExecutionStatistics => {
   return {
-    DataManifestLocation:
-      output.DataManifestLocation !== undefined && output.DataManifestLocation !== null
-        ? output.DataManifestLocation
-        : undefined,
-    DataScannedInBytes:
-      output.DataScannedInBytes !== undefined && output.DataScannedInBytes !== null
-        ? output.DataScannedInBytes
-        : undefined,
-    EngineExecutionTimeInMillis:
-      output.EngineExecutionTimeInMillis !== undefined && output.EngineExecutionTimeInMillis !== null
-        ? output.EngineExecutionTimeInMillis
-        : undefined,
-    QueryPlanningTimeInMillis:
-      output.QueryPlanningTimeInMillis !== undefined && output.QueryPlanningTimeInMillis !== null
-        ? output.QueryPlanningTimeInMillis
-        : undefined,
-    QueryQueueTimeInMillis:
-      output.QueryQueueTimeInMillis !== undefined && output.QueryQueueTimeInMillis !== null
-        ? output.QueryQueueTimeInMillis
-        : undefined,
-    ServiceProcessingTimeInMillis:
-      output.ServiceProcessingTimeInMillis !== undefined && output.ServiceProcessingTimeInMillis !== null
-        ? output.ServiceProcessingTimeInMillis
-        : undefined,
-    TotalExecutionTimeInMillis:
-      output.TotalExecutionTimeInMillis !== undefined && output.TotalExecutionTimeInMillis !== null
-        ? output.TotalExecutionTimeInMillis
-        : undefined,
+    DataManifestLocation: __expectString(output.DataManifestLocation),
+    DataScannedInBytes: __expectNumber(output.DataScannedInBytes),
+    EngineExecutionTimeInMillis: __expectNumber(output.EngineExecutionTimeInMillis),
+    QueryPlanningTimeInMillis: __expectNumber(output.QueryPlanningTimeInMillis),
+    QueryQueueTimeInMillis: __expectNumber(output.QueryQueueTimeInMillis),
+    ServiceProcessingTimeInMillis: __expectNumber(output.ServiceProcessingTimeInMillis),
+    TotalExecutionTimeInMillis: __expectNumber(output.TotalExecutionTimeInMillis),
   } as any;
 };
 
@@ -4006,11 +3975,8 @@ const deserializeAws_json1_1QueryExecutionStatus = (output: any, context: __Serd
       output.CompletionDateTime !== undefined && output.CompletionDateTime !== null
         ? new Date(Math.round(output.CompletionDateTime * 1000))
         : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    StateChangeReason:
-      output.StateChangeReason !== undefined && output.StateChangeReason !== null
-        ? output.StateChangeReason
-        : undefined,
+    State: __expectString(output.State),
+    StateChangeReason: __expectString(output.StateChangeReason),
     SubmissionDateTime:
       output.SubmissionDateTime !== undefined && output.SubmissionDateTime !== null
         ? new Date(Math.round(output.SubmissionDateTime * 1000))
@@ -4023,8 +3989,8 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    ResourceName: output.ResourceName !== undefined && output.ResourceName !== null ? output.ResourceName : undefined,
+    Message: __expectString(output.Message),
+    ResourceName: __expectString(output.ResourceName),
   } as any;
 };
 
@@ -4034,8 +4000,7 @@ const deserializeAws_json1_1ResultConfiguration = (output: any, context: __Serde
       output.EncryptionConfiguration !== undefined && output.EncryptionConfiguration !== null
         ? deserializeAws_json1_1EncryptionConfiguration(output.EncryptionConfiguration, context)
         : undefined,
-    OutputLocation:
-      output.OutputLocation !== undefined && output.OutputLocation !== null ? output.OutputLocation : undefined,
+    OutputLocation: __expectString(output.OutputLocation),
   } as any;
 };
 
@@ -4086,8 +4051,7 @@ const deserializeAws_json1_1StartQueryExecutionOutput = (
   context: __SerdeContext
 ): StartQueryExecutionOutput => {
   return {
-    QueryExecutionId:
-      output.QueryExecutionId !== undefined && output.QueryExecutionId !== null ? output.QueryExecutionId : undefined,
+    QueryExecutionId: __expectString(output.QueryExecutionId),
   } as any;
 };
 
@@ -4112,7 +4076,7 @@ const deserializeAws_json1_1TableMetadata = (output: any, context: __SerdeContex
       output.LastAccessTime !== undefined && output.LastAccessTime !== null
         ? new Date(Math.round(output.LastAccessTime * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     Parameters:
       output.Parameters !== undefined && output.Parameters !== null
         ? deserializeAws_json1_1ParametersMap(output.Parameters, context)
@@ -4121,7 +4085,7 @@ const deserializeAws_json1_1TableMetadata = (output: any, context: __SerdeContex
       output.PartitionKeys !== undefined && output.PartitionKeys !== null
         ? deserializeAws_json1_1ColumnList(output.PartitionKeys, context)
         : undefined,
-    TableType: output.TableType !== undefined && output.TableType !== null ? output.TableType : undefined,
+    TableType: __expectString(output.TableType),
   } as any;
 };
 
@@ -4138,8 +4102,8 @@ const deserializeAws_json1_1TableMetadataList = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -4163,8 +4127,8 @@ const deserializeAws_json1_1TooManyRequestsException = (
   context: __SerdeContext
 ): TooManyRequestsException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Reason: output.Reason !== undefined && output.Reason !== null ? output.Reason : undefined,
+    Message: __expectString(output.Message),
+    Reason: __expectString(output.Reason),
   } as any;
 };
 
@@ -4173,9 +4137,9 @@ const deserializeAws_json1_1UnprocessedNamedQueryId = (
   context: __SerdeContext
 ): UnprocessedNamedQueryId => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    NamedQueryId: output.NamedQueryId !== undefined && output.NamedQueryId !== null ? output.NamedQueryId : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
+    NamedQueryId: __expectString(output.NamedQueryId),
   } as any;
 };
 
@@ -4198,10 +4162,9 @@ const deserializeAws_json1_1UnprocessedQueryExecutionId = (
   context: __SerdeContext
 ): UnprocessedQueryExecutionId => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    QueryExecutionId:
-      output.QueryExecutionId !== undefined && output.QueryExecutionId !== null ? output.QueryExecutionId : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
+    QueryExecutionId: __expectString(output.QueryExecutionId),
   } as any;
 };
 
@@ -4251,34 +4214,22 @@ const deserializeAws_json1_1WorkGroup = (output: any, context: __SerdeContext): 
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    Description: __expectString(output.Description),
+    Name: __expectString(output.Name),
+    State: __expectString(output.State),
   } as any;
 };
 
 const deserializeAws_json1_1WorkGroupConfiguration = (output: any, context: __SerdeContext): WorkGroupConfiguration => {
   return {
-    BytesScannedCutoffPerQuery:
-      output.BytesScannedCutoffPerQuery !== undefined && output.BytesScannedCutoffPerQuery !== null
-        ? output.BytesScannedCutoffPerQuery
-        : undefined,
-    EnforceWorkGroupConfiguration:
-      output.EnforceWorkGroupConfiguration !== undefined && output.EnforceWorkGroupConfiguration !== null
-        ? output.EnforceWorkGroupConfiguration
-        : undefined,
+    BytesScannedCutoffPerQuery: __expectNumber(output.BytesScannedCutoffPerQuery),
+    EnforceWorkGroupConfiguration: __expectBoolean(output.EnforceWorkGroupConfiguration),
     EngineVersion:
       output.EngineVersion !== undefined && output.EngineVersion !== null
         ? deserializeAws_json1_1EngineVersion(output.EngineVersion, context)
         : undefined,
-    PublishCloudWatchMetricsEnabled:
-      output.PublishCloudWatchMetricsEnabled !== undefined && output.PublishCloudWatchMetricsEnabled !== null
-        ? output.PublishCloudWatchMetricsEnabled
-        : undefined,
-    RequesterPaysEnabled:
-      output.RequesterPaysEnabled !== undefined && output.RequesterPaysEnabled !== null
-        ? output.RequesterPaysEnabled
-        : undefined,
+    PublishCloudWatchMetricsEnabled: __expectBoolean(output.PublishCloudWatchMetricsEnabled),
+    RequesterPaysEnabled: __expectBoolean(output.RequesterPaysEnabled),
     ResultConfiguration:
       output.ResultConfiguration !== undefined && output.ResultConfiguration !== null
         ? deserializeAws_json1_1ResultConfiguration(output.ResultConfiguration, context)
@@ -4303,13 +4254,13 @@ const deserializeAws_json1_1WorkGroupSummary = (output: any, context: __SerdeCon
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     EngineVersion:
       output.EngineVersion !== undefined && output.EngineVersion !== null
         ? deserializeAws_json1_1EngineVersion(output.EngineVersion, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    Name: __expectString(output.Name),
+    State: __expectString(output.State),
   } as any;
 };
 

--- a/clients/client-auditmanager/protocols/Aws_restJson1.ts
+++ b/clients/client-auditmanager/protocols/Aws_restJson1.ts
@@ -185,6 +185,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -3005,7 +3008,7 @@ export const deserializeAws_restJson1DeregisterAccountCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.status !== undefined && data.status !== null) {
-    contents.status = data.status;
+    contents.status = __expectString(data.status);
   }
   return Promise.resolve(contents);
 };
@@ -3234,7 +3237,7 @@ export const deserializeAws_restJson1GetAccountStatusCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.status !== undefined && data.status !== null) {
-    contents.status = data.status;
+    contents.status = __expectString(data.status);
   }
   return Promise.resolve(contents);
 };
@@ -3534,7 +3537,7 @@ export const deserializeAws_restJson1GetChangeLogsCommand = async (
     contents.changeLogs = deserializeAws_restJson1ChangeLogs(data.changeLogs, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3696,7 +3699,7 @@ export const deserializeAws_restJson1GetDelegationsCommand = async (
     contents.delegations = deserializeAws_restJson1DelegationMetadataList(data.delegations, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3850,7 +3853,7 @@ export const deserializeAws_restJson1GetEvidenceByEvidenceFolderCommand = async 
     contents.evidence = deserializeAws_restJson1EvidenceList(data.evidence, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -4012,7 +4015,7 @@ export const deserializeAws_restJson1GetEvidenceFoldersByAssessmentCommand = asy
     contents.evidenceFolders = deserializeAws_restJson1AssessmentEvidenceFolders(data.evidenceFolders, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -4095,7 +4098,7 @@ export const deserializeAws_restJson1GetEvidenceFoldersByAssessmentControlComman
     contents.evidenceFolders = deserializeAws_restJson1AssessmentEvidenceFolders(data.evidenceFolders, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -4175,10 +4178,10 @@ export const deserializeAws_restJson1GetOrganizationAdminAccountCommand = async 
   };
   const data: any = await parseBody(output.body, context);
   if (data.adminAccountId !== undefined && data.adminAccountId !== null) {
-    contents.adminAccountId = data.adminAccountId;
+    contents.adminAccountId = __expectString(data.adminAccountId);
   }
   if (data.organizationId !== undefined && data.organizationId !== null) {
-    contents.organizationId = data.organizationId;
+    contents.organizationId = __expectString(data.organizationId);
   }
   return Promise.resolve(contents);
 };
@@ -4395,7 +4398,7 @@ export const deserializeAws_restJson1ListAssessmentFrameworksCommand = async (
     contents.frameworkMetadataList = deserializeAws_restJson1FrameworkMetadataList(data.frameworkMetadataList, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -4470,7 +4473,7 @@ export const deserializeAws_restJson1ListAssessmentReportsCommand = async (
     contents.assessmentReports = deserializeAws_restJson1AssessmentReportsMetadata(data.assessmentReports, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -4545,7 +4548,7 @@ export const deserializeAws_restJson1ListAssessmentsCommand = async (
     contents.assessmentMetadata = deserializeAws_restJson1ListAssessmentMetadata(data.assessmentMetadata, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -4620,7 +4623,7 @@ export const deserializeAws_restJson1ListControlsCommand = async (
     contents.controlMetadataList = deserializeAws_restJson1ControlMetadataList(data.controlMetadataList, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -4695,7 +4698,7 @@ export const deserializeAws_restJson1ListKeywordsForDataSourceCommand = async (
     contents.keywords = deserializeAws_restJson1Keywords(data.keywords, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -4767,7 +4770,7 @@ export const deserializeAws_restJson1ListNotificationsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.notifications !== undefined && data.notifications !== null) {
     contents.notifications = deserializeAws_restJson1Notifications(data.notifications, context);
@@ -4912,7 +4915,7 @@ export const deserializeAws_restJson1RegisterAccountCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.status !== undefined && data.status !== null) {
-    contents.status = data.status;
+    contents.status = __expectString(data.status);
   }
   return Promise.resolve(contents);
 };
@@ -4992,10 +4995,10 @@ export const deserializeAws_restJson1RegisterOrganizationAdminAccountCommand = a
   };
   const data: any = await parseBody(output.body, context);
   if (data.adminAccountId !== undefined && data.adminAccountId !== null) {
-    contents.adminAccountId = data.adminAccountId;
+    contents.adminAccountId = __expectString(data.adminAccountId);
   }
   if (data.organizationId !== undefined && data.organizationId !== null) {
-    contents.organizationId = data.organizationId;
+    contents.organizationId = __expectString(data.organizationId);
   }
   return Promise.resolve(contents);
 };
@@ -5757,16 +5760,16 @@ export const deserializeAws_restJson1ValidateAssessmentReportIntegrityCommand = 
   };
   const data: any = await parseBody(output.body, context);
   if (data.signatureAlgorithm !== undefined && data.signatureAlgorithm !== null) {
-    contents.signatureAlgorithm = data.signatureAlgorithm;
+    contents.signatureAlgorithm = __expectString(data.signatureAlgorithm);
   }
   if (data.signatureDateTime !== undefined && data.signatureDateTime !== null) {
-    contents.signatureDateTime = data.signatureDateTime;
+    contents.signatureDateTime = __expectString(data.signatureDateTime);
   }
   if (data.signatureKeyId !== undefined && data.signatureKeyId !== null) {
-    contents.signatureKeyId = data.signatureKeyId;
+    contents.signatureKeyId = __expectString(data.signatureKeyId);
   }
   if (data.signatureValid !== undefined && data.signatureValid !== null) {
-    contents.signatureValid = data.signatureValid;
+    contents.signatureValid = __expectBoolean(data.signatureValid);
   }
   if (data.validationErrors !== undefined && data.validationErrors !== null) {
     contents.validationErrors = deserializeAws_restJson1ValidationErrors(data.validationErrors, context);
@@ -5847,7 +5850,7 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -5864,7 +5867,7 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -5883,13 +5886,13 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.resourceId !== undefined && data.resourceId !== null) {
-    contents.resourceId = data.resourceId;
+    contents.resourceId = __expectString(data.resourceId);
   }
   if (data.resourceType !== undefined && data.resourceType !== null) {
-    contents.resourceType = data.resourceType;
+    contents.resourceType = __expectString(data.resourceType);
   }
   return contents;
 };
@@ -5911,10 +5914,10 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
     contents.fields = deserializeAws_restJson1ValidationExceptionFieldList(data.fields, context);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.reason !== undefined && data.reason !== null) {
-    contents.reason = data.reason;
+    contents.reason = __expectString(data.reason);
   }
   return contents;
 };
@@ -6226,7 +6229,7 @@ const serializeAws_restJson1UpdateAssessmentFrameworkControlSets = (
 
 const deserializeAws_restJson1Assessment = (output: any, context: __SerdeContext): Assessment => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     awsAccount:
       output.awsAccount !== undefined && output.awsAccount !== null
         ? deserializeAws_restJson1AWSAccount(output.awsAccount, context)
@@ -6248,25 +6251,21 @@ const deserializeAws_restJson1Assessment = (output: any, context: __SerdeContext
 
 const deserializeAws_restJson1AssessmentControl = (output: any, context: __SerdeContext): AssessmentControl => {
   return {
-    assessmentReportEvidenceCount:
-      output.assessmentReportEvidenceCount !== undefined && output.assessmentReportEvidenceCount !== null
-        ? output.assessmentReportEvidenceCount
-        : undefined,
+    assessmentReportEvidenceCount: __expectNumber(output.assessmentReportEvidenceCount),
     comments:
       output.comments !== undefined && output.comments !== null
         ? deserializeAws_restJson1ControlComments(output.comments, context)
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    evidenceCount:
-      output.evidenceCount !== undefined && output.evidenceCount !== null ? output.evidenceCount : undefined,
+    description: __expectString(output.description),
+    evidenceCount: __expectNumber(output.evidenceCount),
     evidenceSources:
       output.evidenceSources !== undefined && output.evidenceSources !== null
         ? deserializeAws_restJson1EvidenceSources(output.evidenceSources, context)
         : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    response: output.response !== undefined && output.response !== null ? output.response : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    id: __expectString(output.id),
+    name: __expectString(output.name),
+    response: __expectString(output.response),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -6291,21 +6290,15 @@ const deserializeAws_restJson1AssessmentControlSet = (output: any, context: __Se
       output.delegations !== undefined && output.delegations !== null
         ? deserializeAws_restJson1Delegations(output.delegations, context)
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    manualEvidenceCount:
-      output.manualEvidenceCount !== undefined && output.manualEvidenceCount !== null
-        ? output.manualEvidenceCount
-        : undefined,
+    description: __expectString(output.description),
+    id: __expectString(output.id),
+    manualEvidenceCount: __expectNumber(output.manualEvidenceCount),
     roles:
       output.roles !== undefined && output.roles !== null
         ? deserializeAws_restJson1Roles(output.roles, context)
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    systemEvidenceCount:
-      output.systemEvidenceCount !== undefined && output.systemEvidenceCount !== null
-        ? output.systemEvidenceCount
-        : undefined,
+    status: __expectString(output.status),
+    systemEvidenceCount: __expectNumber(output.systemEvidenceCount),
   } as any;
 };
 
@@ -6328,50 +6321,24 @@ const deserializeAws_restJson1AssessmentEvidenceFolder = (
   context: __SerdeContext
 ): AssessmentEvidenceFolder => {
   return {
-    assessmentId: output.assessmentId !== undefined && output.assessmentId !== null ? output.assessmentId : undefined,
-    assessmentReportSelectionCount:
-      output.assessmentReportSelectionCount !== undefined && output.assessmentReportSelectionCount !== null
-        ? output.assessmentReportSelectionCount
-        : undefined,
-    author: output.author !== undefined && output.author !== null ? output.author : undefined,
-    controlId: output.controlId !== undefined && output.controlId !== null ? output.controlId : undefined,
-    controlName: output.controlName !== undefined && output.controlName !== null ? output.controlName : undefined,
-    controlSetId: output.controlSetId !== undefined && output.controlSetId !== null ? output.controlSetId : undefined,
-    dataSource: output.dataSource !== undefined && output.dataSource !== null ? output.dataSource : undefined,
+    assessmentId: __expectString(output.assessmentId),
+    assessmentReportSelectionCount: __expectNumber(output.assessmentReportSelectionCount),
+    author: __expectString(output.author),
+    controlId: __expectString(output.controlId),
+    controlName: __expectString(output.controlName),
+    controlSetId: __expectString(output.controlSetId),
+    dataSource: __expectString(output.dataSource),
     date: output.date !== undefined && output.date !== null ? new Date(Math.round(output.date * 1000)) : undefined,
-    evidenceAwsServiceSourceCount:
-      output.evidenceAwsServiceSourceCount !== undefined && output.evidenceAwsServiceSourceCount !== null
-        ? output.evidenceAwsServiceSourceCount
-        : undefined,
-    evidenceByTypeComplianceCheckCount:
-      output.evidenceByTypeComplianceCheckCount !== undefined && output.evidenceByTypeComplianceCheckCount !== null
-        ? output.evidenceByTypeComplianceCheckCount
-        : undefined,
-    evidenceByTypeComplianceCheckIssuesCount:
-      output.evidenceByTypeComplianceCheckIssuesCount !== undefined &&
-      output.evidenceByTypeComplianceCheckIssuesCount !== null
-        ? output.evidenceByTypeComplianceCheckIssuesCount
-        : undefined,
-    evidenceByTypeConfigurationDataCount:
-      output.evidenceByTypeConfigurationDataCount !== undefined && output.evidenceByTypeConfigurationDataCount !== null
-        ? output.evidenceByTypeConfigurationDataCount
-        : undefined,
-    evidenceByTypeManualCount:
-      output.evidenceByTypeManualCount !== undefined && output.evidenceByTypeManualCount !== null
-        ? output.evidenceByTypeManualCount
-        : undefined,
-    evidenceByTypeUserActivityCount:
-      output.evidenceByTypeUserActivityCount !== undefined && output.evidenceByTypeUserActivityCount !== null
-        ? output.evidenceByTypeUserActivityCount
-        : undefined,
-    evidenceResourcesIncludedCount:
-      output.evidenceResourcesIncludedCount !== undefined && output.evidenceResourcesIncludedCount !== null
-        ? output.evidenceResourcesIncludedCount
-        : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    totalEvidence:
-      output.totalEvidence !== undefined && output.totalEvidence !== null ? output.totalEvidence : undefined,
+    evidenceAwsServiceSourceCount: __expectNumber(output.evidenceAwsServiceSourceCount),
+    evidenceByTypeComplianceCheckCount: __expectNumber(output.evidenceByTypeComplianceCheckCount),
+    evidenceByTypeComplianceCheckIssuesCount: __expectNumber(output.evidenceByTypeComplianceCheckIssuesCount),
+    evidenceByTypeConfigurationDataCount: __expectNumber(output.evidenceByTypeConfigurationDataCount),
+    evidenceByTypeManualCount: __expectNumber(output.evidenceByTypeManualCount),
+    evidenceByTypeUserActivityCount: __expectNumber(output.evidenceByTypeUserActivityCount),
+    evidenceResourcesIncludedCount: __expectNumber(output.evidenceResourcesIncludedCount),
+    id: __expectString(output.id),
+    name: __expectString(output.name),
+    totalEvidence: __expectNumber(output.totalEvidence),
   } as any;
 };
 
@@ -6391,12 +6358,12 @@ const deserializeAws_restJson1AssessmentEvidenceFolders = (
 
 const deserializeAws_restJson1AssessmentFramework = (output: any, context: __SerdeContext): AssessmentFramework => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     controlSets:
       output.controlSets !== undefined && output.controlSets !== null
         ? deserializeAws_restJson1AssessmentControlSets(output.controlSets, context)
         : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    id: __expectString(output.id),
     metadata:
       output.metadata !== undefined && output.metadata !== null
         ? deserializeAws_restJson1FrameworkMetadata(output.metadata, context)
@@ -6409,26 +6376,23 @@ const deserializeAws_restJson1AssessmentFrameworkMetadata = (
   context: __SerdeContext
 ): AssessmentFrameworkMetadata => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    complianceType:
-      output.complianceType !== undefined && output.complianceType !== null ? output.complianceType : undefined,
-    controlSetsCount:
-      output.controlSetsCount !== undefined && output.controlSetsCount !== null ? output.controlSetsCount : undefined,
-    controlsCount:
-      output.controlsCount !== undefined && output.controlsCount !== null ? output.controlsCount : undefined,
+    arn: __expectString(output.arn),
+    complianceType: __expectString(output.complianceType),
+    controlSetsCount: __expectNumber(output.controlSetsCount),
+    controlsCount: __expectNumber(output.controlsCount),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    description: __expectString(output.description),
+    id: __expectString(output.id),
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
         ? new Date(Math.round(output.lastUpdatedAt * 1000))
         : undefined,
-    logo: output.logo !== undefined && output.logo !== null ? output.logo : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    logo: __expectString(output.logo),
+    name: __expectString(output.name),
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -6438,8 +6402,7 @@ const deserializeAws_restJson1AssessmentMetadata = (output: any, context: __Serd
       output.assessmentReportsDestination !== undefined && output.assessmentReportsDestination !== null
         ? deserializeAws_restJson1AssessmentReportsDestination(output.assessmentReportsDestination, context)
         : undefined,
-    complianceType:
-      output.complianceType !== undefined && output.complianceType !== null ? output.complianceType : undefined,
+    complianceType: __expectString(output.complianceType),
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
         ? new Date(Math.round(output.creationTime * 1000))
@@ -6448,13 +6411,13 @@ const deserializeAws_restJson1AssessmentMetadata = (output: any, context: __Serd
       output.delegations !== undefined && output.delegations !== null
         ? deserializeAws_restJson1Delegations(output.delegations, context)
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    description: __expectString(output.description),
+    id: __expectString(output.id),
     lastUpdated:
       output.lastUpdated !== undefined && output.lastUpdated !== null
         ? new Date(Math.round(output.lastUpdated * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
     roles:
       output.roles !== undefined && output.roles !== null
         ? deserializeAws_restJson1Roles(output.roles, context)
@@ -6463,7 +6426,7 @@ const deserializeAws_restJson1AssessmentMetadata = (output: any, context: __Serd
       output.scope !== undefined && output.scope !== null
         ? deserializeAws_restJson1Scope(output.scope, context)
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -6472,8 +6435,7 @@ const deserializeAws_restJson1AssessmentMetadataItem = (
   context: __SerdeContext
 ): AssessmentMetadataItem => {
   return {
-    complianceType:
-      output.complianceType !== undefined && output.complianceType !== null ? output.complianceType : undefined,
+    complianceType: __expectString(output.complianceType),
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
         ? new Date(Math.round(output.creationTime * 1000))
@@ -6482,35 +6444,34 @@ const deserializeAws_restJson1AssessmentMetadataItem = (
       output.delegations !== undefined && output.delegations !== null
         ? deserializeAws_restJson1Delegations(output.delegations, context)
         : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    id: __expectString(output.id),
     lastUpdated:
       output.lastUpdated !== undefined && output.lastUpdated !== null
         ? new Date(Math.round(output.lastUpdated * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
     roles:
       output.roles !== undefined && output.roles !== null
         ? deserializeAws_restJson1Roles(output.roles, context)
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
   } as any;
 };
 
 const deserializeAws_restJson1AssessmentReport = (output: any, context: __SerdeContext): AssessmentReport => {
   return {
-    assessmentId: output.assessmentId !== undefined && output.assessmentId !== null ? output.assessmentId : undefined,
-    assessmentName:
-      output.assessmentName !== undefined && output.assessmentName !== null ? output.assessmentName : undefined,
-    author: output.author !== undefined && output.author !== null ? output.author : undefined,
-    awsAccountId: output.awsAccountId !== undefined && output.awsAccountId !== null ? output.awsAccountId : undefined,
+    assessmentId: __expectString(output.assessmentId),
+    assessmentName: __expectString(output.assessmentName),
+    author: __expectString(output.author),
+    awsAccountId: __expectString(output.awsAccountId),
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
         ? new Date(Math.round(output.creationTime * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    description: __expectString(output.description),
+    id: __expectString(output.id),
+    name: __expectString(output.name),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -6519,9 +6480,9 @@ const deserializeAws_restJson1AssessmentReportEvidenceError = (
   context: __SerdeContext
 ): AssessmentReportEvidenceError => {
   return {
-    errorCode: output.errorCode !== undefined && output.errorCode !== null ? output.errorCode : undefined,
-    errorMessage: output.errorMessage !== undefined && output.errorMessage !== null ? output.errorMessage : undefined,
-    evidenceId: output.evidenceId !== undefined && output.evidenceId !== null ? output.evidenceId : undefined,
+    errorCode: __expectString(output.errorCode),
+    errorMessage: __expectString(output.errorMessage),
+    evidenceId: __expectString(output.evidenceId),
   } as any;
 };
 
@@ -6544,18 +6505,17 @@ const deserializeAws_restJson1AssessmentReportMetadata = (
   context: __SerdeContext
 ): AssessmentReportMetadata => {
   return {
-    assessmentId: output.assessmentId !== undefined && output.assessmentId !== null ? output.assessmentId : undefined,
-    assessmentName:
-      output.assessmentName !== undefined && output.assessmentName !== null ? output.assessmentName : undefined,
-    author: output.author !== undefined && output.author !== null ? output.author : undefined,
+    assessmentId: __expectString(output.assessmentId),
+    assessmentName: __expectString(output.assessmentName),
+    author: __expectString(output.author),
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
         ? new Date(Math.round(output.creationTime * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    description: __expectString(output.description),
+    id: __expectString(output.id),
+    name: __expectString(output.name),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -6564,9 +6524,8 @@ const deserializeAws_restJson1AssessmentReportsDestination = (
   context: __SerdeContext
 ): AssessmentReportsDestination => {
   return {
-    destination: output.destination !== undefined && output.destination !== null ? output.destination : undefined,
-    destinationType:
-      output.destinationType !== undefined && output.destinationType !== null ? output.destinationType : undefined,
+    destination: __expectString(output.destination),
+    destinationType: __expectString(output.destinationType),
   } as any;
 };
 
@@ -6586,9 +6545,9 @@ const deserializeAws_restJson1AssessmentReportsMetadata = (
 
 const deserializeAws_restJson1AWSAccount = (output: any, context: __SerdeContext): AWSAccount => {
   return {
-    emailAddress: output.emailAddress !== undefined && output.emailAddress !== null ? output.emailAddress : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    emailAddress: __expectString(output.emailAddress),
+    id: __expectString(output.id),
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -6605,7 +6564,7 @@ const deserializeAws_restJson1AWSAccounts = (output: any, context: __SerdeContex
 
 const deserializeAws_restJson1AWSService = (output: any, context: __SerdeContext): AWSService => {
   return {
-    serviceName: output.serviceName !== undefined && output.serviceName !== null ? output.serviceName : undefined,
+    serviceName: __expectString(output.serviceName),
   } as any;
 };
 
@@ -6629,8 +6588,8 @@ const deserializeAws_restJson1BatchCreateDelegationByAssessmentError = (
       output.createDelegationRequest !== undefined && output.createDelegationRequest !== null
         ? deserializeAws_restJson1CreateDelegationRequest(output.createDelegationRequest, context)
         : undefined,
-    errorCode: output.errorCode !== undefined && output.errorCode !== null ? output.errorCode : undefined,
-    errorMessage: output.errorMessage !== undefined && output.errorMessage !== null ? output.errorMessage : undefined,
+    errorCode: __expectString(output.errorCode),
+    errorMessage: __expectString(output.errorMessage),
   } as any;
 };
 
@@ -6653,9 +6612,9 @@ const deserializeAws_restJson1BatchDeleteDelegationByAssessmentError = (
   context: __SerdeContext
 ): BatchDeleteDelegationByAssessmentError => {
   return {
-    delegationId: output.delegationId !== undefined && output.delegationId !== null ? output.delegationId : undefined,
-    errorCode: output.errorCode !== undefined && output.errorCode !== null ? output.errorCode : undefined,
-    errorMessage: output.errorMessage !== undefined && output.errorMessage !== null ? output.errorMessage : undefined,
+    delegationId: __expectString(output.delegationId),
+    errorCode: __expectString(output.errorCode),
+    errorMessage: __expectString(output.errorMessage),
   } as any;
 };
 
@@ -6678,8 +6637,8 @@ const deserializeAws_restJson1BatchImportEvidenceToAssessmentControlError = (
   context: __SerdeContext
 ): BatchImportEvidenceToAssessmentControlError => {
   return {
-    errorCode: output.errorCode !== undefined && output.errorCode !== null ? output.errorCode : undefined,
-    errorMessage: output.errorMessage !== undefined && output.errorMessage !== null ? output.errorMessage : undefined,
+    errorCode: __expectString(output.errorCode),
+    errorMessage: __expectString(output.errorMessage),
     manualEvidence:
       output.manualEvidence !== undefined && output.manualEvidence !== null
         ? deserializeAws_restJson1ManualEvidence(output.manualEvidence, context)
@@ -6703,14 +6662,14 @@ const deserializeAws_restJson1BatchImportEvidenceToAssessmentControlErrors = (
 
 const deserializeAws_restJson1ChangeLog = (output: any, context: __SerdeContext): ChangeLog => {
   return {
-    action: output.action !== undefined && output.action !== null ? output.action : undefined,
+    action: __expectString(output.action),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    createdBy: output.createdBy !== undefined && output.createdBy !== null ? output.createdBy : undefined,
-    objectName: output.objectName !== undefined && output.objectName !== null ? output.objectName : undefined,
-    objectType: output.objectType !== undefined && output.objectType !== null ? output.objectType : undefined,
+    createdBy: __expectString(output.createdBy),
+    objectName: __expectString(output.objectName),
+    objectType: __expectString(output.objectType),
   } as any;
 };
 
@@ -6727,49 +6686,40 @@ const deserializeAws_restJson1ChangeLogs = (output: any, context: __SerdeContext
 
 const deserializeAws_restJson1Control = (output: any, context: __SerdeContext): Control => {
   return {
-    actionPlanInstructions:
-      output.actionPlanInstructions !== undefined && output.actionPlanInstructions !== null
-        ? output.actionPlanInstructions
-        : undefined,
-    actionPlanTitle:
-      output.actionPlanTitle !== undefined && output.actionPlanTitle !== null ? output.actionPlanTitle : undefined,
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    actionPlanInstructions: __expectString(output.actionPlanInstructions),
+    actionPlanTitle: __expectString(output.actionPlanTitle),
+    arn: __expectString(output.arn),
     controlMappingSources:
       output.controlMappingSources !== undefined && output.controlMappingSources !== null
         ? deserializeAws_restJson1ControlMappingSources(output.controlMappingSources, context)
         : undefined,
-    controlSources:
-      output.controlSources !== undefined && output.controlSources !== null ? output.controlSources : undefined,
+    controlSources: __expectString(output.controlSources),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    createdBy: output.createdBy !== undefined && output.createdBy !== null ? output.createdBy : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    createdBy: __expectString(output.createdBy),
+    description: __expectString(output.description),
+    id: __expectString(output.id),
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
         ? new Date(Math.round(output.lastUpdatedAt * 1000))
         : undefined,
-    lastUpdatedBy:
-      output.lastUpdatedBy !== undefined && output.lastUpdatedBy !== null ? output.lastUpdatedBy : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    lastUpdatedBy: __expectString(output.lastUpdatedBy),
+    name: __expectString(output.name),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1TagMap(output.tags, context)
         : undefined,
-    testingInformation:
-      output.testingInformation !== undefined && output.testingInformation !== null
-        ? output.testingInformation
-        : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    testingInformation: __expectString(output.testingInformation),
+    type: __expectString(output.type),
   } as any;
 };
 
 const deserializeAws_restJson1ControlComment = (output: any, context: __SerdeContext): ControlComment => {
   return {
-    authorName: output.authorName !== undefined && output.authorName !== null ? output.authorName : undefined,
-    commentBody: output.commentBody !== undefined && output.commentBody !== null ? output.commentBody : undefined,
+    authorName: __expectString(output.authorName),
+    commentBody: __expectString(output.commentBody),
     postedDate:
       output.postedDate !== undefined && output.postedDate !== null
         ? new Date(Math.round(output.postedDate * 1000))
@@ -6790,27 +6740,17 @@ const deserializeAws_restJson1ControlComments = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1ControlMappingSource = (output: any, context: __SerdeContext): ControlMappingSource => {
   return {
-    sourceDescription:
-      output.sourceDescription !== undefined && output.sourceDescription !== null
-        ? output.sourceDescription
-        : undefined,
-    sourceFrequency:
-      output.sourceFrequency !== undefined && output.sourceFrequency !== null ? output.sourceFrequency : undefined,
-    sourceId: output.sourceId !== undefined && output.sourceId !== null ? output.sourceId : undefined,
+    sourceDescription: __expectString(output.sourceDescription),
+    sourceFrequency: __expectString(output.sourceFrequency),
+    sourceId: __expectString(output.sourceId),
     sourceKeyword:
       output.sourceKeyword !== undefined && output.sourceKeyword !== null
         ? deserializeAws_restJson1SourceKeyword(output.sourceKeyword, context)
         : undefined,
-    sourceName: output.sourceName !== undefined && output.sourceName !== null ? output.sourceName : undefined,
-    sourceSetUpOption:
-      output.sourceSetUpOption !== undefined && output.sourceSetUpOption !== null
-        ? output.sourceSetUpOption
-        : undefined,
-    sourceType: output.sourceType !== undefined && output.sourceType !== null ? output.sourceType : undefined,
-    troubleshootingText:
-      output.troubleshootingText !== undefined && output.troubleshootingText !== null
-        ? output.troubleshootingText
-        : undefined,
+    sourceName: __expectString(output.sourceName),
+    sourceSetUpOption: __expectString(output.sourceSetUpOption),
+    sourceType: __expectString(output.sourceType),
+    troubleshootingText: __expectString(output.troubleshootingText),
   } as any;
 };
 
@@ -6830,19 +6770,18 @@ const deserializeAws_restJson1ControlMappingSources = (
 
 const deserializeAws_restJson1ControlMetadata = (output: any, context: __SerdeContext): ControlMetadata => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    controlSources:
-      output.controlSources !== undefined && output.controlSources !== null ? output.controlSources : undefined,
+    arn: __expectString(output.arn),
+    controlSources: __expectString(output.controlSources),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    id: __expectString(output.id),
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
         ? new Date(Math.round(output.lastUpdatedAt * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -6874,8 +6813,8 @@ const deserializeAws_restJson1ControlSet = (output: any, context: __SerdeContext
       output.controls !== undefined && output.controls !== null
         ? deserializeAws_restJson1Controls(output.controls, context)
         : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    id: __expectString(output.id),
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -6895,50 +6834,47 @@ const deserializeAws_restJson1CreateDelegationRequest = (
   context: __SerdeContext
 ): CreateDelegationRequest => {
   return {
-    comment: output.comment !== undefined && output.comment !== null ? output.comment : undefined,
-    controlSetId: output.controlSetId !== undefined && output.controlSetId !== null ? output.controlSetId : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
-    roleType: output.roleType !== undefined && output.roleType !== null ? output.roleType : undefined,
+    comment: __expectString(output.comment),
+    controlSetId: __expectString(output.controlSetId),
+    roleArn: __expectString(output.roleArn),
+    roleType: __expectString(output.roleType),
   } as any;
 };
 
 const deserializeAws_restJson1Delegation = (output: any, context: __SerdeContext): Delegation => {
   return {
-    assessmentId: output.assessmentId !== undefined && output.assessmentId !== null ? output.assessmentId : undefined,
-    assessmentName:
-      output.assessmentName !== undefined && output.assessmentName !== null ? output.assessmentName : undefined,
-    comment: output.comment !== undefined && output.comment !== null ? output.comment : undefined,
-    controlSetId: output.controlSetId !== undefined && output.controlSetId !== null ? output.controlSetId : undefined,
-    createdBy: output.createdBy !== undefined && output.createdBy !== null ? output.createdBy : undefined,
+    assessmentId: __expectString(output.assessmentId),
+    assessmentName: __expectString(output.assessmentName),
+    comment: __expectString(output.comment),
+    controlSetId: __expectString(output.controlSetId),
+    createdBy: __expectString(output.createdBy),
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
         ? new Date(Math.round(output.creationTime * 1000))
         : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    id: __expectString(output.id),
     lastUpdated:
       output.lastUpdated !== undefined && output.lastUpdated !== null
         ? new Date(Math.round(output.lastUpdated * 1000))
         : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
-    roleType: output.roleType !== undefined && output.roleType !== null ? output.roleType : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    roleArn: __expectString(output.roleArn),
+    roleType: __expectString(output.roleType),
+    status: __expectString(output.status),
   } as any;
 };
 
 const deserializeAws_restJson1DelegationMetadata = (output: any, context: __SerdeContext): DelegationMetadata => {
   return {
-    assessmentId: output.assessmentId !== undefined && output.assessmentId !== null ? output.assessmentId : undefined,
-    assessmentName:
-      output.assessmentName !== undefined && output.assessmentName !== null ? output.assessmentName : undefined,
-    controlSetName:
-      output.controlSetName !== undefined && output.controlSetName !== null ? output.controlSetName : undefined,
+    assessmentId: __expectString(output.assessmentId),
+    assessmentName: __expectString(output.assessmentName),
+    controlSetName: __expectString(output.controlSetName),
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
         ? new Date(Math.round(output.creationTime * 1000))
         : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    id: __expectString(output.id),
+    roleArn: __expectString(output.roleArn),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -6966,32 +6902,22 @@ const deserializeAws_restJson1Delegations = (output: any, context: __SerdeContex
 
 const deserializeAws_restJson1Evidence = (output: any, context: __SerdeContext): Evidence => {
   return {
-    assessmentReportSelection:
-      output.assessmentReportSelection !== undefined && output.assessmentReportSelection !== null
-        ? output.assessmentReportSelection
-        : undefined,
+    assessmentReportSelection: __expectString(output.assessmentReportSelection),
     attributes:
       output.attributes !== undefined && output.attributes !== null
         ? deserializeAws_restJson1EvidenceAttributes(output.attributes, context)
         : undefined,
-    awsAccountId: output.awsAccountId !== undefined && output.awsAccountId !== null ? output.awsAccountId : undefined,
-    awsOrganization:
-      output.awsOrganization !== undefined && output.awsOrganization !== null ? output.awsOrganization : undefined,
-    complianceCheck:
-      output.complianceCheck !== undefined && output.complianceCheck !== null ? output.complianceCheck : undefined,
-    dataSource: output.dataSource !== undefined && output.dataSource !== null ? output.dataSource : undefined,
-    eventName: output.eventName !== undefined && output.eventName !== null ? output.eventName : undefined,
-    eventSource: output.eventSource !== undefined && output.eventSource !== null ? output.eventSource : undefined,
-    evidenceAwsAccountId:
-      output.evidenceAwsAccountId !== undefined && output.evidenceAwsAccountId !== null
-        ? output.evidenceAwsAccountId
-        : undefined,
-    evidenceByType:
-      output.evidenceByType !== undefined && output.evidenceByType !== null ? output.evidenceByType : undefined,
-    evidenceFolderId:
-      output.evidenceFolderId !== undefined && output.evidenceFolderId !== null ? output.evidenceFolderId : undefined,
-    iamId: output.iamId !== undefined && output.iamId !== null ? output.iamId : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    awsAccountId: __expectString(output.awsAccountId),
+    awsOrganization: __expectString(output.awsOrganization),
+    complianceCheck: __expectString(output.complianceCheck),
+    dataSource: __expectString(output.dataSource),
+    eventName: __expectString(output.eventName),
+    eventSource: __expectString(output.eventSource),
+    evidenceAwsAccountId: __expectString(output.evidenceAwsAccountId),
+    evidenceByType: __expectString(output.evidenceByType),
+    evidenceFolderId: __expectString(output.evidenceFolderId),
+    iamId: __expectString(output.iamId),
+    id: __expectString(output.id),
     resourcesIncluded:
       output.resourcesIncluded !== undefined && output.resourcesIncluded !== null
         ? deserializeAws_restJson1Resources(output.resourcesIncluded, context)
@@ -7010,7 +6936,7 @@ const deserializeAws_restJson1EvidenceAttributes = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -7022,7 +6948,7 @@ const deserializeAws_restJson1EvidenceIds = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7044,51 +6970,47 @@ const deserializeAws_restJson1EvidenceSources = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1Framework = (output: any, context: __SerdeContext): Framework => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    complianceType:
-      output.complianceType !== undefined && output.complianceType !== null ? output.complianceType : undefined,
+    arn: __expectString(output.arn),
+    complianceType: __expectString(output.complianceType),
     controlSets:
       output.controlSets !== undefined && output.controlSets !== null
         ? deserializeAws_restJson1ControlSets(output.controlSets, context)
         : undefined,
-    controlSources:
-      output.controlSources !== undefined && output.controlSources !== null ? output.controlSources : undefined,
+    controlSources: __expectString(output.controlSources),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    createdBy: output.createdBy !== undefined && output.createdBy !== null ? output.createdBy : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    createdBy: __expectString(output.createdBy),
+    description: __expectString(output.description),
+    id: __expectString(output.id),
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
         ? new Date(Math.round(output.lastUpdatedAt * 1000))
         : undefined,
-    lastUpdatedBy:
-      output.lastUpdatedBy !== undefined && output.lastUpdatedBy !== null ? output.lastUpdatedBy : undefined,
-    logo: output.logo !== undefined && output.logo !== null ? output.logo : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    lastUpdatedBy: __expectString(output.lastUpdatedBy),
+    logo: __expectString(output.logo),
+    name: __expectString(output.name),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1TagMap(output.tags, context)
         : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    type: __expectString(output.type),
   } as any;
 };
 
 const deserializeAws_restJson1FrameworkMetadata = (output: any, context: __SerdeContext): FrameworkMetadata => {
   return {
-    complianceType:
-      output.complianceType !== undefined && output.complianceType !== null ? output.complianceType : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    logo: output.logo !== undefined && output.logo !== null ? output.logo : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    complianceType: __expectString(output.complianceType),
+    description: __expectString(output.description),
+    logo: __expectString(output.logo),
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -7113,7 +7035,7 @@ const deserializeAws_restJson1Keywords = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7133,26 +7055,23 @@ const deserializeAws_restJson1ListAssessmentMetadata = (
 
 const deserializeAws_restJson1ManualEvidence = (output: any, context: __SerdeContext): ManualEvidence => {
   return {
-    s3ResourcePath:
-      output.s3ResourcePath !== undefined && output.s3ResourcePath !== null ? output.s3ResourcePath : undefined,
+    s3ResourcePath: __expectString(output.s3ResourcePath),
   } as any;
 };
 
 const deserializeAws_restJson1Notification = (output: any, context: __SerdeContext): Notification => {
   return {
-    assessmentId: output.assessmentId !== undefined && output.assessmentId !== null ? output.assessmentId : undefined,
-    assessmentName:
-      output.assessmentName !== undefined && output.assessmentName !== null ? output.assessmentName : undefined,
-    controlSetId: output.controlSetId !== undefined && output.controlSetId !== null ? output.controlSetId : undefined,
-    controlSetName:
-      output.controlSetName !== undefined && output.controlSetName !== null ? output.controlSetName : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    assessmentId: __expectString(output.assessmentId),
+    assessmentName: __expectString(output.assessmentName),
+    controlSetId: __expectString(output.controlSetId),
+    controlSetName: __expectString(output.controlSetName),
+    description: __expectString(output.description),
     eventTime:
       output.eventTime !== undefined && output.eventTime !== null
         ? new Date(Math.round(output.eventTime * 1000))
         : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    source: output.source !== undefined && output.source !== null ? output.source : undefined,
+    id: __expectString(output.id),
+    source: __expectString(output.source),
   } as any;
 };
 
@@ -7169,8 +7088,8 @@ const deserializeAws_restJson1Notifications = (output: any, context: __SerdeCont
 
 const deserializeAws_restJson1Resource = (output: any, context: __SerdeContext): Resource => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    arn: __expectString(output.arn),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -7187,8 +7106,8 @@ const deserializeAws_restJson1Resources = (output: any, context: __SerdeContext)
 
 const deserializeAws_restJson1Role = (output: any, context: __SerdeContext): Role => {
   return {
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
-    roleType: output.roleType !== undefined && output.roleType !== null ? output.roleType : undefined,
+    roleArn: __expectString(output.roleArn),
+    roleType: __expectString(output.roleType),
   } as any;
 };
 
@@ -7218,10 +7137,10 @@ const deserializeAws_restJson1Scope = (output: any, context: __SerdeContext): Sc
 
 const deserializeAws_restJson1ServiceMetadata = (output: any, context: __SerdeContext): ServiceMetadata => {
   return {
-    category: output.category !== undefined && output.category !== null ? output.category : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    displayName: output.displayName !== undefined && output.displayName !== null ? output.displayName : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    category: __expectString(output.category),
+    description: __expectString(output.description),
+    displayName: __expectString(output.displayName),
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -7246,18 +7165,16 @@ const deserializeAws_restJson1Settings = (output: any, context: __SerdeContext):
       output.defaultProcessOwners !== undefined && output.defaultProcessOwners !== null
         ? deserializeAws_restJson1Roles(output.defaultProcessOwners, context)
         : undefined,
-    isAwsOrgEnabled:
-      output.isAwsOrgEnabled !== undefined && output.isAwsOrgEnabled !== null ? output.isAwsOrgEnabled : undefined,
-    kmsKey: output.kmsKey !== undefined && output.kmsKey !== null ? output.kmsKey : undefined,
-    snsTopic: output.snsTopic !== undefined && output.snsTopic !== null ? output.snsTopic : undefined,
+    isAwsOrgEnabled: __expectBoolean(output.isAwsOrgEnabled),
+    kmsKey: __expectString(output.kmsKey),
+    snsTopic: __expectString(output.snsTopic),
   } as any;
 };
 
 const deserializeAws_restJson1SourceKeyword = (output: any, context: __SerdeContext): SourceKeyword => {
   return {
-    keywordInputType:
-      output.keywordInputType !== undefined && output.keywordInputType !== null ? output.keywordInputType : undefined,
-    keywordValue: output.keywordValue !== undefined && output.keywordValue !== null ? output.keywordValue : undefined,
+    keywordInputType: __expectString(output.keywordInputType),
+    keywordValue: __expectString(output.keywordValue),
   } as any;
 };
 
@@ -7268,16 +7185,15 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1URL = (output: any, context: __SerdeContext): URL => {
   return {
-    hyperlinkName:
-      output.hyperlinkName !== undefined && output.hyperlinkName !== null ? output.hyperlinkName : undefined,
-    link: output.link !== undefined && output.link !== null ? output.link : undefined,
+    hyperlinkName: __expectString(output.hyperlinkName),
+    link: __expectString(output.link),
   } as any;
 };
 
@@ -7288,7 +7204,7 @@ const deserializeAws_restJson1ValidationErrors = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7297,8 +7213,8 @@ const deserializeAws_restJson1ValidationExceptionField = (
   context: __SerdeContext
 ): ValidationExceptionField => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    message: __expectString(output.message),
+    name: __expectString(output.name),
   } as any;
 };
 

--- a/clients/client-auto-scaling-plans/protocols/Aws_json1_1.ts
+++ b/clients/client-auto-scaling-plans/protocols/Aws_json1_1.ts
@@ -47,7 +47,12 @@ import {
   ValidationException,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -1019,10 +1024,7 @@ const serializeAws_json1_1UpdateScalingPlanRequest = (
 
 const deserializeAws_json1_1ApplicationSource = (output: any, context: __SerdeContext): ApplicationSource => {
   return {
-    CloudFormationStackARN:
-      output.CloudFormationStackARN !== undefined && output.CloudFormationStackARN !== null
-        ? output.CloudFormationStackARN
-        : undefined,
+    CloudFormationStackARN: __expectString(output.CloudFormationStackARN),
     TagFilters:
       output.TagFilters !== undefined && output.TagFilters !== null
         ? deserializeAws_json1_1TagFilters(output.TagFilters, context)
@@ -1035,7 +1037,7 @@ const deserializeAws_json1_1ConcurrentUpdateException = (
   context: __SerdeContext
 ): ConcurrentUpdateException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -1044,10 +1046,7 @@ const deserializeAws_json1_1CreateScalingPlanResponse = (
   context: __SerdeContext
 ): CreateScalingPlanResponse => {
   return {
-    ScalingPlanVersion:
-      output.ScalingPlanVersion !== undefined && output.ScalingPlanVersion !== null
-        ? output.ScalingPlanVersion
-        : undefined,
+    ScalingPlanVersion: __expectNumber(output.ScalingPlanVersion),
   } as any;
 };
 
@@ -1060,10 +1059,10 @@ const deserializeAws_json1_1CustomizedLoadMetricSpecification = (
       output.Dimensions !== undefined && output.Dimensions !== null
         ? deserializeAws_json1_1MetricDimensions(output.Dimensions, context)
         : undefined,
-    MetricName: output.MetricName !== undefined && output.MetricName !== null ? output.MetricName : undefined,
-    Namespace: output.Namespace !== undefined && output.Namespace !== null ? output.Namespace : undefined,
-    Statistic: output.Statistic !== undefined && output.Statistic !== null ? output.Statistic : undefined,
-    Unit: output.Unit !== undefined && output.Unit !== null ? output.Unit : undefined,
+    MetricName: __expectString(output.MetricName),
+    Namespace: __expectString(output.Namespace),
+    Statistic: __expectString(output.Statistic),
+    Unit: __expectString(output.Unit),
   } as any;
 };
 
@@ -1076,10 +1075,10 @@ const deserializeAws_json1_1CustomizedScalingMetricSpecification = (
       output.Dimensions !== undefined && output.Dimensions !== null
         ? deserializeAws_json1_1MetricDimensions(output.Dimensions, context)
         : undefined,
-    MetricName: output.MetricName !== undefined && output.MetricName !== null ? output.MetricName : undefined,
-    Namespace: output.Namespace !== undefined && output.Namespace !== null ? output.Namespace : undefined,
-    Statistic: output.Statistic !== undefined && output.Statistic !== null ? output.Statistic : undefined,
-    Unit: output.Unit !== undefined && output.Unit !== null ? output.Unit : undefined,
+    MetricName: __expectString(output.MetricName),
+    Namespace: __expectString(output.Namespace),
+    Statistic: __expectString(output.Statistic),
+    Unit: __expectString(output.Unit),
   } as any;
 };
 
@@ -1089,7 +1088,7 @@ const deserializeAws_json1_1Datapoint = (output: any, context: __SerdeContext): 
       output.Timestamp !== undefined && output.Timestamp !== null
         ? new Date(Math.round(output.Timestamp * 1000))
         : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Value: __expectNumber(output.Value),
   } as any;
 };
 
@@ -1116,7 +1115,7 @@ const deserializeAws_json1_1DescribeScalingPlanResourcesResponse = (
   context: __SerdeContext
 ): DescribeScalingPlanResourcesResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     ScalingPlanResources:
       output.ScalingPlanResources !== undefined && output.ScalingPlanResources !== null
         ? deserializeAws_json1_1ScalingPlanResources(output.ScalingPlanResources, context)
@@ -1129,7 +1128,7 @@ const deserializeAws_json1_1DescribeScalingPlansResponse = (
   context: __SerdeContext
 ): DescribeScalingPlansResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     ScalingPlans:
       output.ScalingPlans !== undefined && output.ScalingPlans !== null
         ? deserializeAws_json1_1ScalingPlans(output.ScalingPlans, context)
@@ -1154,7 +1153,7 @@ const deserializeAws_json1_1InternalServiceException = (
   context: __SerdeContext
 ): InternalServiceException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -1163,20 +1162,20 @@ const deserializeAws_json1_1InvalidNextTokenException = (
   context: __SerdeContext
 ): InvalidNextTokenException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1MetricDimension = (output: any, context: __SerdeContext): MetricDimension => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Name: __expectString(output.Name),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -1196,7 +1195,7 @@ const deserializeAws_json1_1ObjectNotFoundException = (
   context: __SerdeContext
 ): ObjectNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -1205,12 +1204,8 @@ const deserializeAws_json1_1PredefinedLoadMetricSpecification = (
   context: __SerdeContext
 ): PredefinedLoadMetricSpecification => {
   return {
-    PredefinedLoadMetricType:
-      output.PredefinedLoadMetricType !== undefined && output.PredefinedLoadMetricType !== null
-        ? output.PredefinedLoadMetricType
-        : undefined,
-    ResourceLabel:
-      output.ResourceLabel !== undefined && output.ResourceLabel !== null ? output.ResourceLabel : undefined,
+    PredefinedLoadMetricType: __expectString(output.PredefinedLoadMetricType),
+    ResourceLabel: __expectString(output.ResourceLabel),
   } as any;
 };
 
@@ -1219,12 +1214,8 @@ const deserializeAws_json1_1PredefinedScalingMetricSpecification = (
   context: __SerdeContext
 ): PredefinedScalingMetricSpecification => {
   return {
-    PredefinedScalingMetricType:
-      output.PredefinedScalingMetricType !== undefined && output.PredefinedScalingMetricType !== null
-        ? output.PredefinedScalingMetricType
-        : undefined,
-    ResourceLabel:
-      output.ResourceLabel !== undefined && output.ResourceLabel !== null ? output.ResourceLabel : undefined,
+    PredefinedScalingMetricType: __expectString(output.PredefinedScalingMetricType),
+    ResourceLabel: __expectString(output.ResourceLabel),
   } as any;
 };
 
@@ -1234,43 +1225,21 @@ const deserializeAws_json1_1ScalingInstruction = (output: any, context: __SerdeC
       output.CustomizedLoadMetricSpecification !== undefined && output.CustomizedLoadMetricSpecification !== null
         ? deserializeAws_json1_1CustomizedLoadMetricSpecification(output.CustomizedLoadMetricSpecification, context)
         : undefined,
-    DisableDynamicScaling:
-      output.DisableDynamicScaling !== undefined && output.DisableDynamicScaling !== null
-        ? output.DisableDynamicScaling
-        : undefined,
-    MaxCapacity: output.MaxCapacity !== undefined && output.MaxCapacity !== null ? output.MaxCapacity : undefined,
-    MinCapacity: output.MinCapacity !== undefined && output.MinCapacity !== null ? output.MinCapacity : undefined,
+    DisableDynamicScaling: __expectBoolean(output.DisableDynamicScaling),
+    MaxCapacity: __expectNumber(output.MaxCapacity),
+    MinCapacity: __expectNumber(output.MinCapacity),
     PredefinedLoadMetricSpecification:
       output.PredefinedLoadMetricSpecification !== undefined && output.PredefinedLoadMetricSpecification !== null
         ? deserializeAws_json1_1PredefinedLoadMetricSpecification(output.PredefinedLoadMetricSpecification, context)
         : undefined,
-    PredictiveScalingMaxCapacityBehavior:
-      output.PredictiveScalingMaxCapacityBehavior !== undefined && output.PredictiveScalingMaxCapacityBehavior !== null
-        ? output.PredictiveScalingMaxCapacityBehavior
-        : undefined,
-    PredictiveScalingMaxCapacityBuffer:
-      output.PredictiveScalingMaxCapacityBuffer !== undefined && output.PredictiveScalingMaxCapacityBuffer !== null
-        ? output.PredictiveScalingMaxCapacityBuffer
-        : undefined,
-    PredictiveScalingMode:
-      output.PredictiveScalingMode !== undefined && output.PredictiveScalingMode !== null
-        ? output.PredictiveScalingMode
-        : undefined,
-    ResourceId: output.ResourceId !== undefined && output.ResourceId !== null ? output.ResourceId : undefined,
-    ScalableDimension:
-      output.ScalableDimension !== undefined && output.ScalableDimension !== null
-        ? output.ScalableDimension
-        : undefined,
-    ScalingPolicyUpdateBehavior:
-      output.ScalingPolicyUpdateBehavior !== undefined && output.ScalingPolicyUpdateBehavior !== null
-        ? output.ScalingPolicyUpdateBehavior
-        : undefined,
-    ScheduledActionBufferTime:
-      output.ScheduledActionBufferTime !== undefined && output.ScheduledActionBufferTime !== null
-        ? output.ScheduledActionBufferTime
-        : undefined,
-    ServiceNamespace:
-      output.ServiceNamespace !== undefined && output.ServiceNamespace !== null ? output.ServiceNamespace : undefined,
+    PredictiveScalingMaxCapacityBehavior: __expectString(output.PredictiveScalingMaxCapacityBehavior),
+    PredictiveScalingMaxCapacityBuffer: __expectNumber(output.PredictiveScalingMaxCapacityBuffer),
+    PredictiveScalingMode: __expectString(output.PredictiveScalingMode),
+    ResourceId: __expectString(output.ResourceId),
+    ScalableDimension: __expectString(output.ScalableDimension),
+    ScalingPolicyUpdateBehavior: __expectString(output.ScalingPolicyUpdateBehavior),
+    ScheduledActionBufferTime: __expectNumber(output.ScheduledActionBufferTime),
+    ServiceNamespace: __expectString(output.ServiceNamespace),
     TargetTrackingConfigurations:
       output.TargetTrackingConfigurations !== undefined && output.TargetTrackingConfigurations !== null
         ? deserializeAws_json1_1TargetTrackingConfigurations(output.TargetTrackingConfigurations, context)
@@ -1303,15 +1272,10 @@ const deserializeAws_json1_1ScalingPlan = (output: any, context: __SerdeContext)
       output.ScalingInstructions !== undefined && output.ScalingInstructions !== null
         ? deserializeAws_json1_1ScalingInstructions(output.ScalingInstructions, context)
         : undefined,
-    ScalingPlanName:
-      output.ScalingPlanName !== undefined && output.ScalingPlanName !== null ? output.ScalingPlanName : undefined,
-    ScalingPlanVersion:
-      output.ScalingPlanVersion !== undefined && output.ScalingPlanVersion !== null
-        ? output.ScalingPlanVersion
-        : undefined,
-    StatusCode: output.StatusCode !== undefined && output.StatusCode !== null ? output.StatusCode : undefined,
-    StatusMessage:
-      output.StatusMessage !== undefined && output.StatusMessage !== null ? output.StatusMessage : undefined,
+    ScalingPlanName: __expectString(output.ScalingPlanName),
+    ScalingPlanVersion: __expectNumber(output.ScalingPlanVersion),
+    StatusCode: __expectString(output.StatusCode),
+    StatusMessage: __expectString(output.StatusMessage),
     StatusStartTime:
       output.StatusStartTime !== undefined && output.StatusStartTime !== null
         ? new Date(Math.round(output.StatusStartTime * 1000))
@@ -1321,31 +1285,17 @@ const deserializeAws_json1_1ScalingPlan = (output: any, context: __SerdeContext)
 
 const deserializeAws_json1_1ScalingPlanResource = (output: any, context: __SerdeContext): ScalingPlanResource => {
   return {
-    ResourceId: output.ResourceId !== undefined && output.ResourceId !== null ? output.ResourceId : undefined,
-    ScalableDimension:
-      output.ScalableDimension !== undefined && output.ScalableDimension !== null
-        ? output.ScalableDimension
-        : undefined,
-    ScalingPlanName:
-      output.ScalingPlanName !== undefined && output.ScalingPlanName !== null ? output.ScalingPlanName : undefined,
-    ScalingPlanVersion:
-      output.ScalingPlanVersion !== undefined && output.ScalingPlanVersion !== null
-        ? output.ScalingPlanVersion
-        : undefined,
+    ResourceId: __expectString(output.ResourceId),
+    ScalableDimension: __expectString(output.ScalableDimension),
+    ScalingPlanName: __expectString(output.ScalingPlanName),
+    ScalingPlanVersion: __expectNumber(output.ScalingPlanVersion),
     ScalingPolicies:
       output.ScalingPolicies !== undefined && output.ScalingPolicies !== null
         ? deserializeAws_json1_1ScalingPolicies(output.ScalingPolicies, context)
         : undefined,
-    ScalingStatusCode:
-      output.ScalingStatusCode !== undefined && output.ScalingStatusCode !== null
-        ? output.ScalingStatusCode
-        : undefined,
-    ScalingStatusMessage:
-      output.ScalingStatusMessage !== undefined && output.ScalingStatusMessage !== null
-        ? output.ScalingStatusMessage
-        : undefined,
-    ServiceNamespace:
-      output.ServiceNamespace !== undefined && output.ServiceNamespace !== null ? output.ServiceNamespace : undefined,
+    ScalingStatusCode: __expectString(output.ScalingStatusCode),
+    ScalingStatusMessage: __expectString(output.ScalingStatusMessage),
+    ServiceNamespace: __expectString(output.ServiceNamespace),
   } as any;
 };
 
@@ -1384,8 +1334,8 @@ const deserializeAws_json1_1ScalingPolicies = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_1ScalingPolicy = (output: any, context: __SerdeContext): ScalingPolicy => {
   return {
-    PolicyName: output.PolicyName !== undefined && output.PolicyName !== null ? output.PolicyName : undefined,
-    PolicyType: output.PolicyType !== undefined && output.PolicyType !== null ? output.PolicyType : undefined,
+    PolicyName: __expectString(output.PolicyName),
+    PolicyType: __expectString(output.PolicyType),
     TargetTrackingConfiguration:
       output.TargetTrackingConfiguration !== undefined && output.TargetTrackingConfiguration !== null
         ? deserializeAws_json1_1TargetTrackingConfiguration(output.TargetTrackingConfiguration, context)
@@ -1395,7 +1345,7 @@ const deserializeAws_json1_1ScalingPolicy = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1TagFilter = (output: any, context: __SerdeContext): TagFilter => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
+    Key: __expectString(output.Key),
     Values:
       output.Values !== undefined && output.Values !== null
         ? deserializeAws_json1_1TagValues(output.Values, context)
@@ -1421,7 +1371,7 @@ const deserializeAws_json1_1TagValues = (output: any, context: __SerdeContext): 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -1437,12 +1387,8 @@ const deserializeAws_json1_1TargetTrackingConfiguration = (
             context
           )
         : undefined,
-    DisableScaleIn:
-      output.DisableScaleIn !== undefined && output.DisableScaleIn !== null ? output.DisableScaleIn : undefined,
-    EstimatedInstanceWarmup:
-      output.EstimatedInstanceWarmup !== undefined && output.EstimatedInstanceWarmup !== null
-        ? output.EstimatedInstanceWarmup
-        : undefined,
+    DisableScaleIn: __expectBoolean(output.DisableScaleIn),
+    EstimatedInstanceWarmup: __expectNumber(output.EstimatedInstanceWarmup),
     PredefinedScalingMetricSpecification:
       output.PredefinedScalingMetricSpecification !== undefined && output.PredefinedScalingMetricSpecification !== null
         ? deserializeAws_json1_1PredefinedScalingMetricSpecification(
@@ -1450,11 +1396,9 @@ const deserializeAws_json1_1TargetTrackingConfiguration = (
             context
           )
         : undefined,
-    ScaleInCooldown:
-      output.ScaleInCooldown !== undefined && output.ScaleInCooldown !== null ? output.ScaleInCooldown : undefined,
-    ScaleOutCooldown:
-      output.ScaleOutCooldown !== undefined && output.ScaleOutCooldown !== null ? output.ScaleOutCooldown : undefined,
-    TargetValue: output.TargetValue !== undefined && output.TargetValue !== null ? output.TargetValue : undefined,
+    ScaleInCooldown: __expectNumber(output.ScaleInCooldown),
+    ScaleOutCooldown: __expectNumber(output.ScaleOutCooldown),
+    TargetValue: __expectNumber(output.TargetValue),
   } as any;
 };
 
@@ -1481,7 +1425,7 @@ const deserializeAws_json1_1UpdateScalingPlanResponse = (
 
 const deserializeAws_json1_1ValidationException = (output: any, context: __SerdeContext): ValidationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 

--- a/clients/client-auto-scaling/protocols/Aws_query.ts
+++ b/clients/client-auto-scaling/protocols/Aws_query.ts
@@ -344,6 +344,7 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
@@ -7271,7 +7272,7 @@ const deserializeAws_queryActiveInstanceRefreshNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -7302,7 +7303,7 @@ const deserializeAws_queryActivitiesType = (output: any, context: __SerdeContext
     );
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -7323,16 +7324,16 @@ const deserializeAws_queryActivity = (output: any, context: __SerdeContext): Act
     AutoScalingGroupARN: undefined,
   };
   if (output["ActivityId"] !== undefined) {
-    contents.ActivityId = output["ActivityId"];
+    contents.ActivityId = __expectString(output["ActivityId"]);
   }
   if (output["AutoScalingGroupName"] !== undefined) {
-    contents.AutoScalingGroupName = output["AutoScalingGroupName"];
+    contents.AutoScalingGroupName = __expectString(output["AutoScalingGroupName"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output["Cause"] !== undefined) {
-    contents.Cause = output["Cause"];
+    contents.Cause = __expectString(output["Cause"]);
   }
   if (output["StartTime"] !== undefined) {
     contents.StartTime = new Date(output["StartTime"]);
@@ -7341,22 +7342,22 @@ const deserializeAws_queryActivity = (output: any, context: __SerdeContext): Act
     contents.EndTime = new Date(output["EndTime"]);
   }
   if (output["StatusCode"] !== undefined) {
-    contents.StatusCode = output["StatusCode"];
+    contents.StatusCode = __expectString(output["StatusCode"]);
   }
   if (output["StatusMessage"] !== undefined) {
-    contents.StatusMessage = output["StatusMessage"];
+    contents.StatusMessage = __expectString(output["StatusMessage"]);
   }
   if (output["Progress"] !== undefined) {
     contents.Progress = parseInt(output["Progress"]);
   }
   if (output["Details"] !== undefined) {
-    contents.Details = output["Details"];
+    contents.Details = __expectString(output["Details"]);
   }
   if (output["AutoScalingGroupState"] !== undefined) {
-    contents.AutoScalingGroupState = output["AutoScalingGroupState"];
+    contents.AutoScalingGroupState = __expectString(output["AutoScalingGroupState"]);
   }
   if (output["AutoScalingGroupARN"] !== undefined) {
-    contents.AutoScalingGroupARN = output["AutoScalingGroupARN"];
+    contents.AutoScalingGroupARN = __expectString(output["AutoScalingGroupARN"]);
   }
   return contents;
 };
@@ -7376,7 +7377,7 @@ const deserializeAws_queryAdjustmentType = (output: any, context: __SerdeContext
     AdjustmentType: undefined,
   };
   if (output["AdjustmentType"] !== undefined) {
-    contents.AdjustmentType = output["AdjustmentType"];
+    contents.AdjustmentType = __expectString(output["AdjustmentType"]);
   }
   return contents;
 };
@@ -7398,10 +7399,10 @@ const deserializeAws_queryAlarm = (output: any, context: __SerdeContext): Alarm 
     AlarmARN: undefined,
   };
   if (output["AlarmName"] !== undefined) {
-    contents.AlarmName = output["AlarmName"];
+    contents.AlarmName = __expectString(output["AlarmName"]);
   }
   if (output["AlarmARN"] !== undefined) {
-    contents.AlarmARN = output["AlarmARN"];
+    contents.AlarmARN = __expectString(output["AlarmARN"]);
   }
   return contents;
 };
@@ -7422,7 +7423,7 @@ const deserializeAws_queryAlreadyExistsFault = (output: any, context: __SerdeCon
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -7477,13 +7478,13 @@ const deserializeAws_queryAutoScalingGroup = (output: any, context: __SerdeConte
     WarmPoolSize: undefined,
   };
   if (output["AutoScalingGroupName"] !== undefined) {
-    contents.AutoScalingGroupName = output["AutoScalingGroupName"];
+    contents.AutoScalingGroupName = __expectString(output["AutoScalingGroupName"]);
   }
   if (output["AutoScalingGroupARN"] !== undefined) {
-    contents.AutoScalingGroupARN = output["AutoScalingGroupARN"];
+    contents.AutoScalingGroupARN = __expectString(output["AutoScalingGroupARN"]);
   }
   if (output["LaunchConfigurationName"] !== undefined) {
-    contents.LaunchConfigurationName = output["LaunchConfigurationName"];
+    contents.LaunchConfigurationName = __expectString(output["LaunchConfigurationName"]);
   }
   if (output["LaunchTemplate"] !== undefined) {
     contents.LaunchTemplate = deserializeAws_queryLaunchTemplateSpecification(output["LaunchTemplate"], context);
@@ -7534,7 +7535,7 @@ const deserializeAws_queryAutoScalingGroup = (output: any, context: __SerdeConte
     );
   }
   if (output["HealthCheckType"] !== undefined) {
-    contents.HealthCheckType = output["HealthCheckType"];
+    contents.HealthCheckType = __expectString(output["HealthCheckType"]);
   }
   if (output["HealthCheckGracePeriod"] !== undefined) {
     contents.HealthCheckGracePeriod = parseInt(output["HealthCheckGracePeriod"]);
@@ -7558,10 +7559,10 @@ const deserializeAws_queryAutoScalingGroup = (output: any, context: __SerdeConte
     );
   }
   if (output["PlacementGroup"] !== undefined) {
-    contents.PlacementGroup = output["PlacementGroup"];
+    contents.PlacementGroup = __expectString(output["PlacementGroup"]);
   }
   if (output["VPCZoneIdentifier"] !== undefined) {
-    contents.VPCZoneIdentifier = output["VPCZoneIdentifier"];
+    contents.VPCZoneIdentifier = __expectString(output["VPCZoneIdentifier"]);
   }
   if (output.EnabledMetrics === "") {
     contents.EnabledMetrics = [];
@@ -7573,7 +7574,7 @@ const deserializeAws_queryAutoScalingGroup = (output: any, context: __SerdeConte
     );
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output.Tags === "") {
     contents.Tags = [];
@@ -7594,7 +7595,7 @@ const deserializeAws_queryAutoScalingGroup = (output: any, context: __SerdeConte
     contents.NewInstancesProtectedFromScaleIn = __parseBoolean(output["NewInstancesProtectedFromScaleIn"]);
   }
   if (output["ServiceLinkedRoleARN"] !== undefined) {
-    contents.ServiceLinkedRoleARN = output["ServiceLinkedRoleARN"];
+    contents.ServiceLinkedRoleARN = __expectString(output["ServiceLinkedRoleARN"]);
   }
   if (output["MaxInstanceLifetime"] !== undefined) {
     contents.MaxInstanceLifetime = parseInt(output["MaxInstanceLifetime"]);
@@ -7640,7 +7641,7 @@ const deserializeAws_queryAutoScalingGroupsType = (output: any, context: __Serde
     );
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -7662,25 +7663,25 @@ const deserializeAws_queryAutoScalingInstanceDetails = (
     WeightedCapacity: undefined,
   };
   if (output["InstanceId"] !== undefined) {
-    contents.InstanceId = output["InstanceId"];
+    contents.InstanceId = __expectString(output["InstanceId"]);
   }
   if (output["InstanceType"] !== undefined) {
-    contents.InstanceType = output["InstanceType"];
+    contents.InstanceType = __expectString(output["InstanceType"]);
   }
   if (output["AutoScalingGroupName"] !== undefined) {
-    contents.AutoScalingGroupName = output["AutoScalingGroupName"];
+    contents.AutoScalingGroupName = __expectString(output["AutoScalingGroupName"]);
   }
   if (output["AvailabilityZone"] !== undefined) {
-    contents.AvailabilityZone = output["AvailabilityZone"];
+    contents.AvailabilityZone = __expectString(output["AvailabilityZone"]);
   }
   if (output["LifecycleState"] !== undefined) {
-    contents.LifecycleState = output["LifecycleState"];
+    contents.LifecycleState = __expectString(output["LifecycleState"]);
   }
   if (output["HealthStatus"] !== undefined) {
-    contents.HealthStatus = output["HealthStatus"];
+    contents.HealthStatus = __expectString(output["HealthStatus"]);
   }
   if (output["LaunchConfigurationName"] !== undefined) {
-    contents.LaunchConfigurationName = output["LaunchConfigurationName"];
+    contents.LaunchConfigurationName = __expectString(output["LaunchConfigurationName"]);
   }
   if (output["LaunchTemplate"] !== undefined) {
     contents.LaunchTemplate = deserializeAws_queryLaunchTemplateSpecification(output["LaunchTemplate"], context);
@@ -7689,7 +7690,7 @@ const deserializeAws_queryAutoScalingInstanceDetails = (
     contents.ProtectedFromScaleIn = __parseBoolean(output["ProtectedFromScaleIn"]);
   }
   if (output["WeightedCapacity"] !== undefined) {
-    contents.WeightedCapacity = output["WeightedCapacity"];
+    contents.WeightedCapacity = __expectString(output["WeightedCapacity"]);
   }
   return contents;
 };
@@ -7726,7 +7727,7 @@ const deserializeAws_queryAutoScalingInstancesType = (
     );
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -7738,7 +7739,7 @@ const deserializeAws_queryAutoScalingNotificationTypes = (output: any, context: 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7749,7 +7750,7 @@ const deserializeAws_queryAvailabilityZones = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7802,10 +7803,10 @@ const deserializeAws_queryBlockDeviceMapping = (output: any, context: __SerdeCon
     NoDevice: undefined,
   };
   if (output["VirtualName"] !== undefined) {
-    contents.VirtualName = output["VirtualName"];
+    contents.VirtualName = __expectString(output["VirtualName"]);
   }
   if (output["DeviceName"] !== undefined) {
-    contents.DeviceName = output["DeviceName"];
+    contents.DeviceName = __expectString(output["DeviceName"]);
   }
   if (output["Ebs"] !== undefined) {
     contents.Ebs = deserializeAws_queryEbs(output["Ebs"], context);
@@ -7835,7 +7836,7 @@ const deserializeAws_queryCancelInstanceRefreshAnswer = (
     InstanceRefreshId: undefined,
   };
   if (output["InstanceRefreshId"] !== undefined) {
-    contents.InstanceRefreshId = output["InstanceRefreshId"];
+    contents.InstanceRefreshId = __expectString(output["InstanceRefreshId"]);
   }
   return contents;
 };
@@ -7873,7 +7874,7 @@ const deserializeAws_queryClassicLinkVPCSecurityGroups = (output: any, context: 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7897,10 +7898,10 @@ const deserializeAws_queryCustomizedMetricSpecification = (
     Unit: undefined,
   };
   if (output["MetricName"] !== undefined) {
-    contents.MetricName = output["MetricName"];
+    contents.MetricName = __expectString(output["MetricName"]);
   }
   if (output["Namespace"] !== undefined) {
-    contents.Namespace = output["Namespace"];
+    contents.Namespace = __expectString(output["Namespace"]);
   }
   if (output.Dimensions === "") {
     contents.Dimensions = [];
@@ -7912,10 +7913,10 @@ const deserializeAws_queryCustomizedMetricSpecification = (
     );
   }
   if (output["Statistic"] !== undefined) {
-    contents.Statistic = output["Statistic"];
+    contents.Statistic = __expectString(output["Statistic"]);
   }
   if (output["Unit"] !== undefined) {
-    contents.Unit = output["Unit"];
+    contents.Unit = __expectString(output["Unit"]);
   }
   return contents;
 };
@@ -8017,7 +8018,7 @@ const deserializeAws_queryDescribeInstanceRefreshesAnswer = (
     );
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -8078,7 +8079,7 @@ const deserializeAws_queryDescribeLoadBalancersResponse = (
     );
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -8101,7 +8102,7 @@ const deserializeAws_queryDescribeLoadBalancerTargetGroupsResponse = (
     );
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -8156,7 +8157,7 @@ const deserializeAws_queryDescribeNotificationConfigurationsAnswer = (
     );
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -8199,7 +8200,7 @@ const deserializeAws_queryDescribeWarmPoolAnswer = (output: any, context: __Serd
     contents.Instances = deserializeAws_queryInstances(__getArrayIfSingleItem(output["Instances"]["member"]), context);
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -8247,13 +8248,13 @@ const deserializeAws_queryEbs = (output: any, context: __SerdeContext): Ebs => {
     Throughput: undefined,
   };
   if (output["SnapshotId"] !== undefined) {
-    contents.SnapshotId = output["SnapshotId"];
+    contents.SnapshotId = __expectString(output["SnapshotId"]);
   }
   if (output["VolumeSize"] !== undefined) {
     contents.VolumeSize = parseInt(output["VolumeSize"]);
   }
   if (output["VolumeType"] !== undefined) {
-    contents.VolumeType = output["VolumeType"];
+    contents.VolumeType = __expectString(output["VolumeType"]);
   }
   if (output["DeleteOnTermination"] !== undefined) {
     contents.DeleteOnTermination = __parseBoolean(output["DeleteOnTermination"]);
@@ -8276,10 +8277,10 @@ const deserializeAws_queryEnabledMetric = (output: any, context: __SerdeContext)
     Granularity: undefined,
   };
   if (output["Metric"] !== undefined) {
-    contents.Metric = output["Metric"];
+    contents.Metric = __expectString(output["Metric"]);
   }
   if (output["Granularity"] !== undefined) {
-    contents.Granularity = output["Granularity"];
+    contents.Granularity = __expectString(output["Granularity"]);
   }
   return contents;
 };
@@ -8337,13 +8338,13 @@ const deserializeAws_queryFailedScheduledUpdateGroupActionRequest = (
     ErrorMessage: undefined,
   };
   if (output["ScheduledActionName"] !== undefined) {
-    contents.ScheduledActionName = output["ScheduledActionName"];
+    contents.ScheduledActionName = __expectString(output["ScheduledActionName"]);
   }
   if (output["ErrorCode"] !== undefined) {
-    contents.ErrorCode = output["ErrorCode"];
+    contents.ErrorCode = __expectString(output["ErrorCode"]);
   }
   if (output["ErrorMessage"] !== undefined) {
-    contents.ErrorMessage = output["ErrorMessage"];
+    contents.ErrorMessage = __expectString(output["ErrorMessage"]);
   }
   return contents;
 };
@@ -8402,22 +8403,22 @@ const deserializeAws_queryInstance = (output: any, context: __SerdeContext): Ins
     WeightedCapacity: undefined,
   };
   if (output["InstanceId"] !== undefined) {
-    contents.InstanceId = output["InstanceId"];
+    contents.InstanceId = __expectString(output["InstanceId"]);
   }
   if (output["InstanceType"] !== undefined) {
-    contents.InstanceType = output["InstanceType"];
+    contents.InstanceType = __expectString(output["InstanceType"]);
   }
   if (output["AvailabilityZone"] !== undefined) {
-    contents.AvailabilityZone = output["AvailabilityZone"];
+    contents.AvailabilityZone = __expectString(output["AvailabilityZone"]);
   }
   if (output["LifecycleState"] !== undefined) {
-    contents.LifecycleState = output["LifecycleState"];
+    contents.LifecycleState = __expectString(output["LifecycleState"]);
   }
   if (output["HealthStatus"] !== undefined) {
-    contents.HealthStatus = output["HealthStatus"];
+    contents.HealthStatus = __expectString(output["HealthStatus"]);
   }
   if (output["LaunchConfigurationName"] !== undefined) {
-    contents.LaunchConfigurationName = output["LaunchConfigurationName"];
+    contents.LaunchConfigurationName = __expectString(output["LaunchConfigurationName"]);
   }
   if (output["LaunchTemplate"] !== undefined) {
     contents.LaunchTemplate = deserializeAws_queryLaunchTemplateSpecification(output["LaunchTemplate"], context);
@@ -8426,7 +8427,7 @@ const deserializeAws_queryInstance = (output: any, context: __SerdeContext): Ins
     contents.ProtectedFromScaleIn = __parseBoolean(output["ProtectedFromScaleIn"]);
   }
   if (output["WeightedCapacity"] !== undefined) {
-    contents.WeightedCapacity = output["WeightedCapacity"];
+    contents.WeightedCapacity = __expectString(output["WeightedCapacity"]);
   }
   return contents;
 };
@@ -8438,13 +8439,13 @@ const deserializeAws_queryInstanceMetadataOptions = (output: any, context: __Ser
     HttpEndpoint: undefined,
   };
   if (output["HttpTokens"] !== undefined) {
-    contents.HttpTokens = output["HttpTokens"];
+    contents.HttpTokens = __expectString(output["HttpTokens"]);
   }
   if (output["HttpPutResponseHopLimit"] !== undefined) {
     contents.HttpPutResponseHopLimit = parseInt(output["HttpPutResponseHopLimit"]);
   }
   if (output["HttpEndpoint"] !== undefined) {
-    contents.HttpEndpoint = output["HttpEndpoint"];
+    contents.HttpEndpoint = __expectString(output["HttpEndpoint"]);
   }
   return contents;
 };
@@ -8472,16 +8473,16 @@ const deserializeAws_queryInstanceRefresh = (output: any, context: __SerdeContex
     ProgressDetails: undefined,
   };
   if (output["InstanceRefreshId"] !== undefined) {
-    contents.InstanceRefreshId = output["InstanceRefreshId"];
+    contents.InstanceRefreshId = __expectString(output["InstanceRefreshId"]);
   }
   if (output["AutoScalingGroupName"] !== undefined) {
-    contents.AutoScalingGroupName = output["AutoScalingGroupName"];
+    contents.AutoScalingGroupName = __expectString(output["AutoScalingGroupName"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["StatusReason"] !== undefined) {
-    contents.StatusReason = output["StatusReason"];
+    contents.StatusReason = __expectString(output["StatusReason"]);
   }
   if (output["StartTime"] !== undefined) {
     contents.StartTime = new Date(output["StartTime"]);
@@ -8520,7 +8521,7 @@ const deserializeAws_queryInstanceRefreshInProgressFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -8603,7 +8604,7 @@ const deserializeAws_queryInstancesDistribution = (output: any, context: __Serde
     SpotMaxPrice: undefined,
   };
   if (output["OnDemandAllocationStrategy"] !== undefined) {
-    contents.OnDemandAllocationStrategy = output["OnDemandAllocationStrategy"];
+    contents.OnDemandAllocationStrategy = __expectString(output["OnDemandAllocationStrategy"]);
   }
   if (output["OnDemandBaseCapacity"] !== undefined) {
     contents.OnDemandBaseCapacity = parseInt(output["OnDemandBaseCapacity"]);
@@ -8612,13 +8613,13 @@ const deserializeAws_queryInstancesDistribution = (output: any, context: __Serde
     contents.OnDemandPercentageAboveBaseCapacity = parseInt(output["OnDemandPercentageAboveBaseCapacity"]);
   }
   if (output["SpotAllocationStrategy"] !== undefined) {
-    contents.SpotAllocationStrategy = output["SpotAllocationStrategy"];
+    contents.SpotAllocationStrategy = __expectString(output["SpotAllocationStrategy"]);
   }
   if (output["SpotInstancePools"] !== undefined) {
     contents.SpotInstancePools = parseInt(output["SpotInstancePools"]);
   }
   if (output["SpotMaxPrice"] !== undefined) {
-    contents.SpotMaxPrice = output["SpotMaxPrice"];
+    contents.SpotMaxPrice = __expectString(output["SpotMaxPrice"]);
   }
   return contents;
 };
@@ -8628,7 +8629,7 @@ const deserializeAws_queryInvalidNextToken = (output: any, context: __SerdeConte
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -8657,16 +8658,16 @@ const deserializeAws_queryLaunchConfiguration = (output: any, context: __SerdeCo
     MetadataOptions: undefined,
   };
   if (output["LaunchConfigurationName"] !== undefined) {
-    contents.LaunchConfigurationName = output["LaunchConfigurationName"];
+    contents.LaunchConfigurationName = __expectString(output["LaunchConfigurationName"]);
   }
   if (output["LaunchConfigurationARN"] !== undefined) {
-    contents.LaunchConfigurationARN = output["LaunchConfigurationARN"];
+    contents.LaunchConfigurationARN = __expectString(output["LaunchConfigurationARN"]);
   }
   if (output["ImageId"] !== undefined) {
-    contents.ImageId = output["ImageId"];
+    contents.ImageId = __expectString(output["ImageId"]);
   }
   if (output["KeyName"] !== undefined) {
-    contents.KeyName = output["KeyName"];
+    contents.KeyName = __expectString(output["KeyName"]);
   }
   if (output.SecurityGroups === "") {
     contents.SecurityGroups = [];
@@ -8678,7 +8679,7 @@ const deserializeAws_queryLaunchConfiguration = (output: any, context: __SerdeCo
     );
   }
   if (output["ClassicLinkVPCId"] !== undefined) {
-    contents.ClassicLinkVPCId = output["ClassicLinkVPCId"];
+    contents.ClassicLinkVPCId = __expectString(output["ClassicLinkVPCId"]);
   }
   if (output.ClassicLinkVPCSecurityGroups === "") {
     contents.ClassicLinkVPCSecurityGroups = [];
@@ -8693,16 +8694,16 @@ const deserializeAws_queryLaunchConfiguration = (output: any, context: __SerdeCo
     );
   }
   if (output["UserData"] !== undefined) {
-    contents.UserData = output["UserData"];
+    contents.UserData = __expectString(output["UserData"]);
   }
   if (output["InstanceType"] !== undefined) {
-    contents.InstanceType = output["InstanceType"];
+    contents.InstanceType = __expectString(output["InstanceType"]);
   }
   if (output["KernelId"] !== undefined) {
-    contents.KernelId = output["KernelId"];
+    contents.KernelId = __expectString(output["KernelId"]);
   }
   if (output["RamdiskId"] !== undefined) {
-    contents.RamdiskId = output["RamdiskId"];
+    contents.RamdiskId = __expectString(output["RamdiskId"]);
   }
   if (output.BlockDeviceMappings === "") {
     contents.BlockDeviceMappings = [];
@@ -8717,10 +8718,10 @@ const deserializeAws_queryLaunchConfiguration = (output: any, context: __SerdeCo
     contents.InstanceMonitoring = deserializeAws_queryInstanceMonitoring(output["InstanceMonitoring"], context);
   }
   if (output["SpotPrice"] !== undefined) {
-    contents.SpotPrice = output["SpotPrice"];
+    contents.SpotPrice = __expectString(output["SpotPrice"]);
   }
   if (output["IamInstanceProfile"] !== undefined) {
-    contents.IamInstanceProfile = output["IamInstanceProfile"];
+    contents.IamInstanceProfile = __expectString(output["IamInstanceProfile"]);
   }
   if (output["CreatedTime"] !== undefined) {
     contents.CreatedTime = new Date(output["CreatedTime"]);
@@ -8732,7 +8733,7 @@ const deserializeAws_queryLaunchConfiguration = (output: any, context: __SerdeCo
     contents.AssociatePublicIpAddress = __parseBoolean(output["AssociatePublicIpAddress"]);
   }
   if (output["PlacementTenancy"] !== undefined) {
-    contents.PlacementTenancy = output["PlacementTenancy"];
+    contents.PlacementTenancy = __expectString(output["PlacementTenancy"]);
   }
   if (output["MetadataOptions"] !== undefined) {
     contents.MetadataOptions = deserializeAws_queryInstanceMetadataOptions(output["MetadataOptions"], context);
@@ -8769,7 +8770,7 @@ const deserializeAws_queryLaunchConfigurationsType = (
     );
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -8801,10 +8802,10 @@ const deserializeAws_queryLaunchTemplateOverrides = (output: any, context: __Ser
     LaunchTemplateSpecification: undefined,
   };
   if (output["InstanceType"] !== undefined) {
-    contents.InstanceType = output["InstanceType"];
+    contents.InstanceType = __expectString(output["InstanceType"]);
   }
   if (output["WeightedCapacity"] !== undefined) {
-    contents.WeightedCapacity = output["WeightedCapacity"];
+    contents.WeightedCapacity = __expectString(output["WeightedCapacity"]);
   }
   if (output["LaunchTemplateSpecification"] !== undefined) {
     contents.LaunchTemplateSpecification = deserializeAws_queryLaunchTemplateSpecification(
@@ -8825,13 +8826,13 @@ const deserializeAws_queryLaunchTemplateSpecification = (
     Version: undefined,
   };
   if (output["LaunchTemplateId"] !== undefined) {
-    contents.LaunchTemplateId = output["LaunchTemplateId"];
+    contents.LaunchTemplateId = __expectString(output["LaunchTemplateId"]);
   }
   if (output["LaunchTemplateName"] !== undefined) {
-    contents.LaunchTemplateName = output["LaunchTemplateName"];
+    contents.LaunchTemplateName = __expectString(output["LaunchTemplateName"]);
   }
   if (output["Version"] !== undefined) {
-    contents.Version = output["Version"];
+    contents.Version = __expectString(output["Version"]);
   }
   return contents;
 };
@@ -8849,22 +8850,22 @@ const deserializeAws_queryLifecycleHook = (output: any, context: __SerdeContext)
     DefaultResult: undefined,
   };
   if (output["LifecycleHookName"] !== undefined) {
-    contents.LifecycleHookName = output["LifecycleHookName"];
+    contents.LifecycleHookName = __expectString(output["LifecycleHookName"]);
   }
   if (output["AutoScalingGroupName"] !== undefined) {
-    contents.AutoScalingGroupName = output["AutoScalingGroupName"];
+    contents.AutoScalingGroupName = __expectString(output["AutoScalingGroupName"]);
   }
   if (output["LifecycleTransition"] !== undefined) {
-    contents.LifecycleTransition = output["LifecycleTransition"];
+    contents.LifecycleTransition = __expectString(output["LifecycleTransition"]);
   }
   if (output["NotificationTargetARN"] !== undefined) {
-    contents.NotificationTargetARN = output["NotificationTargetARN"];
+    contents.NotificationTargetARN = __expectString(output["NotificationTargetARN"]);
   }
   if (output["RoleARN"] !== undefined) {
-    contents.RoleARN = output["RoleARN"];
+    contents.RoleARN = __expectString(output["RoleARN"]);
   }
   if (output["NotificationMetadata"] !== undefined) {
-    contents.NotificationMetadata = output["NotificationMetadata"];
+    contents.NotificationMetadata = __expectString(output["NotificationMetadata"]);
   }
   if (output["HeartbeatTimeout"] !== undefined) {
     contents.HeartbeatTimeout = parseInt(output["HeartbeatTimeout"]);
@@ -8873,7 +8874,7 @@ const deserializeAws_queryLifecycleHook = (output: any, context: __SerdeContext)
     contents.GlobalTimeout = parseInt(output["GlobalTimeout"]);
   }
   if (output["DefaultResult"] !== undefined) {
-    contents.DefaultResult = output["DefaultResult"];
+    contents.DefaultResult = __expectString(output["DefaultResult"]);
   }
   return contents;
 };
@@ -8894,7 +8895,7 @@ const deserializeAws_queryLimitExceededFault = (output: any, context: __SerdeCon
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -8906,7 +8907,7 @@ const deserializeAws_queryLoadBalancerNames = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -8916,10 +8917,10 @@ const deserializeAws_queryLoadBalancerState = (output: any, context: __SerdeCont
     State: undefined,
   };
   if (output["LoadBalancerName"] !== undefined) {
-    contents.LoadBalancerName = output["LoadBalancerName"];
+    contents.LoadBalancerName = __expectString(output["LoadBalancerName"]);
   }
   if (output["State"] !== undefined) {
-    contents.State = output["State"];
+    contents.State = __expectString(output["State"]);
   }
   return contents;
 };
@@ -8944,10 +8945,10 @@ const deserializeAws_queryLoadBalancerTargetGroupState = (
     State: undefined,
   };
   if (output["LoadBalancerTargetGroupARN"] !== undefined) {
-    contents.LoadBalancerTargetGroupARN = output["LoadBalancerTargetGroupARN"];
+    contents.LoadBalancerTargetGroupARN = __expectString(output["LoadBalancerTargetGroupARN"]);
   }
   if (output["State"] !== undefined) {
-    contents.State = output["State"];
+    contents.State = __expectString(output["State"]);
   }
   return contents;
 };
@@ -9015,7 +9016,7 @@ const deserializeAws_queryMetricCollectionType = (output: any, context: __SerdeC
     Metric: undefined,
   };
   if (output["Metric"] !== undefined) {
-    contents.Metric = output["Metric"];
+    contents.Metric = __expectString(output["Metric"]);
   }
   return contents;
 };
@@ -9037,10 +9038,10 @@ const deserializeAws_queryMetricDimension = (output: any, context: __SerdeContex
     Value: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["Value"] !== undefined) {
-    contents.Value = output["Value"];
+    contents.Value = __expectString(output["Value"]);
   }
   return contents;
 };
@@ -9061,7 +9062,7 @@ const deserializeAws_queryMetricGranularityType = (output: any, context: __Serde
     Granularity: undefined,
   };
   if (output["Granularity"] !== undefined) {
-    contents.Granularity = output["Granularity"];
+    contents.Granularity = __expectString(output["Granularity"]);
   }
   return contents;
 };
@@ -9104,13 +9105,13 @@ const deserializeAws_queryNotificationConfiguration = (
     NotificationType: undefined,
   };
   if (output["AutoScalingGroupName"] !== undefined) {
-    contents.AutoScalingGroupName = output["AutoScalingGroupName"];
+    contents.AutoScalingGroupName = __expectString(output["AutoScalingGroupName"]);
   }
   if (output["TopicARN"] !== undefined) {
-    contents.TopicARN = output["TopicARN"];
+    contents.TopicARN = __expectString(output["TopicARN"]);
   }
   if (output["NotificationType"] !== undefined) {
-    contents.NotificationType = output["NotificationType"];
+    contents.NotificationType = __expectString(output["NotificationType"]);
   }
   return contents;
 };
@@ -9155,7 +9156,7 @@ const deserializeAws_queryPoliciesType = (output: any, context: __SerdeContext):
     );
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -9166,7 +9167,7 @@ const deserializeAws_queryPolicyARNType = (output: any, context: __SerdeContext)
     Alarms: undefined,
   };
   if (output["PolicyARN"] !== undefined) {
-    contents.PolicyARN = output["PolicyARN"];
+    contents.PolicyARN = __expectString(output["PolicyARN"]);
   }
   if (output.Alarms === "") {
     contents.Alarms = [];
@@ -9186,10 +9187,10 @@ const deserializeAws_queryPredefinedMetricSpecification = (
     ResourceLabel: undefined,
   };
   if (output["PredefinedMetricType"] !== undefined) {
-    contents.PredefinedMetricType = output["PredefinedMetricType"];
+    contents.PredefinedMetricType = __expectString(output["PredefinedMetricType"]);
   }
   if (output["ResourceLabel"] !== undefined) {
-    contents.ResourceLabel = output["ResourceLabel"];
+    contents.ResourceLabel = __expectString(output["ResourceLabel"]);
   }
   return contents;
 };
@@ -9215,13 +9216,13 @@ const deserializeAws_queryPredictiveScalingConfiguration = (
     );
   }
   if (output["Mode"] !== undefined) {
-    contents.Mode = output["Mode"];
+    contents.Mode = __expectString(output["Mode"]);
   }
   if (output["SchedulingBufferTime"] !== undefined) {
     contents.SchedulingBufferTime = parseInt(output["SchedulingBufferTime"]);
   }
   if (output["MaxCapacityBreachBehavior"] !== undefined) {
-    contents.MaxCapacityBreachBehavior = output["MaxCapacityBreachBehavior"];
+    contents.MaxCapacityBreachBehavior = __expectString(output["MaxCapacityBreachBehavior"]);
   }
   if (output["MaxCapacityBuffer"] !== undefined) {
     contents.MaxCapacityBuffer = parseInt(output["MaxCapacityBuffer"]);
@@ -9308,10 +9309,10 @@ const deserializeAws_queryPredictiveScalingPredefinedLoadMetric = (
     ResourceLabel: undefined,
   };
   if (output["PredefinedMetricType"] !== undefined) {
-    contents.PredefinedMetricType = output["PredefinedMetricType"];
+    contents.PredefinedMetricType = __expectString(output["PredefinedMetricType"]);
   }
   if (output["ResourceLabel"] !== undefined) {
-    contents.ResourceLabel = output["ResourceLabel"];
+    contents.ResourceLabel = __expectString(output["ResourceLabel"]);
   }
   return contents;
 };
@@ -9325,10 +9326,10 @@ const deserializeAws_queryPredictiveScalingPredefinedMetricPair = (
     ResourceLabel: undefined,
   };
   if (output["PredefinedMetricType"] !== undefined) {
-    contents.PredefinedMetricType = output["PredefinedMetricType"];
+    contents.PredefinedMetricType = __expectString(output["PredefinedMetricType"]);
   }
   if (output["ResourceLabel"] !== undefined) {
-    contents.ResourceLabel = output["ResourceLabel"];
+    contents.ResourceLabel = __expectString(output["ResourceLabel"]);
   }
   return contents;
 };
@@ -9342,10 +9343,10 @@ const deserializeAws_queryPredictiveScalingPredefinedScalingMetric = (
     ResourceLabel: undefined,
   };
   if (output["PredefinedMetricType"] !== undefined) {
-    contents.PredefinedMetricType = output["PredefinedMetricType"];
+    contents.PredefinedMetricType = __expectString(output["PredefinedMetricType"]);
   }
   if (output["ResourceLabel"] !== undefined) {
-    contents.ResourceLabel = output["ResourceLabel"];
+    contents.ResourceLabel = __expectString(output["ResourceLabel"]);
   }
   return contents;
 };
@@ -9379,7 +9380,7 @@ const deserializeAws_queryProcessType = (output: any, context: __SerdeContext): 
     ProcessName: undefined,
   };
   if (output["ProcessName"] !== undefined) {
-    contents.ProcessName = output["ProcessName"];
+    contents.ProcessName = __expectString(output["ProcessName"]);
   }
   return contents;
 };
@@ -9407,7 +9408,7 @@ const deserializeAws_queryResourceContentionFault = (output: any, context: __Ser
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -9417,7 +9418,7 @@ const deserializeAws_queryResourceInUseFault = (output: any, context: __SerdeCon
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -9430,7 +9431,7 @@ const deserializeAws_queryScalingActivityInProgressFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -9466,19 +9467,19 @@ const deserializeAws_queryScalingPolicy = (output: any, context: __SerdeContext)
     PredictiveScalingConfiguration: undefined,
   };
   if (output["AutoScalingGroupName"] !== undefined) {
-    contents.AutoScalingGroupName = output["AutoScalingGroupName"];
+    contents.AutoScalingGroupName = __expectString(output["AutoScalingGroupName"]);
   }
   if (output["PolicyName"] !== undefined) {
-    contents.PolicyName = output["PolicyName"];
+    contents.PolicyName = __expectString(output["PolicyName"]);
   }
   if (output["PolicyARN"] !== undefined) {
-    contents.PolicyARN = output["PolicyARN"];
+    contents.PolicyARN = __expectString(output["PolicyARN"]);
   }
   if (output["PolicyType"] !== undefined) {
-    contents.PolicyType = output["PolicyType"];
+    contents.PolicyType = __expectString(output["PolicyType"]);
   }
   if (output["AdjustmentType"] !== undefined) {
-    contents.AdjustmentType = output["AdjustmentType"];
+    contents.AdjustmentType = __expectString(output["AdjustmentType"]);
   }
   if (output["MinAdjustmentStep"] !== undefined) {
     contents.MinAdjustmentStep = parseInt(output["MinAdjustmentStep"]);
@@ -9502,7 +9503,7 @@ const deserializeAws_queryScalingPolicy = (output: any, context: __SerdeContext)
     );
   }
   if (output["MetricAggregationType"] !== undefined) {
-    contents.MetricAggregationType = output["MetricAggregationType"];
+    contents.MetricAggregationType = __expectString(output["MetricAggregationType"]);
   }
   if (output["EstimatedInstanceWarmup"] !== undefined) {
     contents.EstimatedInstanceWarmup = parseInt(output["EstimatedInstanceWarmup"]);
@@ -9549,7 +9550,7 @@ const deserializeAws_queryScheduledActionsType = (output: any, context: __SerdeC
     );
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -9572,13 +9573,13 @@ const deserializeAws_queryScheduledUpdateGroupAction = (
     TimeZone: undefined,
   };
   if (output["AutoScalingGroupName"] !== undefined) {
-    contents.AutoScalingGroupName = output["AutoScalingGroupName"];
+    contents.AutoScalingGroupName = __expectString(output["AutoScalingGroupName"]);
   }
   if (output["ScheduledActionName"] !== undefined) {
-    contents.ScheduledActionName = output["ScheduledActionName"];
+    contents.ScheduledActionName = __expectString(output["ScheduledActionName"]);
   }
   if (output["ScheduledActionARN"] !== undefined) {
-    contents.ScheduledActionARN = output["ScheduledActionARN"];
+    contents.ScheduledActionARN = __expectString(output["ScheduledActionARN"]);
   }
   if (output["Time"] !== undefined) {
     contents.Time = new Date(output["Time"]);
@@ -9590,7 +9591,7 @@ const deserializeAws_queryScheduledUpdateGroupAction = (
     contents.EndTime = new Date(output["EndTime"]);
   }
   if (output["Recurrence"] !== undefined) {
-    contents.Recurrence = output["Recurrence"];
+    contents.Recurrence = __expectString(output["Recurrence"]);
   }
   if (output["MinSize"] !== undefined) {
     contents.MinSize = parseInt(output["MinSize"]);
@@ -9602,7 +9603,7 @@ const deserializeAws_queryScheduledUpdateGroupAction = (
     contents.DesiredCapacity = parseInt(output["DesiredCapacity"]);
   }
   if (output["TimeZone"] !== undefined) {
-    contents.TimeZone = output["TimeZone"];
+    contents.TimeZone = __expectString(output["TimeZone"]);
   }
   return contents;
 };
@@ -9628,7 +9629,7 @@ const deserializeAws_querySecurityGroups = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -9640,7 +9641,7 @@ const deserializeAws_queryServiceLinkedRoleFailure = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -9661,7 +9662,7 @@ const deserializeAws_queryStartInstanceRefreshAnswer = (
     InstanceRefreshId: undefined,
   };
   if (output["InstanceRefreshId"] !== undefined) {
-    contents.InstanceRefreshId = output["InstanceRefreshId"];
+    contents.InstanceRefreshId = __expectString(output["InstanceRefreshId"]);
   }
   return contents;
 };
@@ -9701,10 +9702,10 @@ const deserializeAws_querySuspendedProcess = (output: any, context: __SerdeConte
     SuspensionReason: undefined,
   };
   if (output["ProcessName"] !== undefined) {
-    contents.ProcessName = output["ProcessName"];
+    contents.ProcessName = __expectString(output["ProcessName"]);
   }
   if (output["SuspensionReason"] !== undefined) {
-    contents.SuspensionReason = output["SuspensionReason"];
+    contents.SuspensionReason = __expectString(output["SuspensionReason"]);
   }
   return contents;
 };
@@ -9729,16 +9730,16 @@ const deserializeAws_queryTagDescription = (output: any, context: __SerdeContext
     PropagateAtLaunch: undefined,
   };
   if (output["ResourceId"] !== undefined) {
-    contents.ResourceId = output["ResourceId"];
+    contents.ResourceId = __expectString(output["ResourceId"]);
   }
   if (output["ResourceType"] !== undefined) {
-    contents.ResourceType = output["ResourceType"];
+    contents.ResourceType = __expectString(output["ResourceType"]);
   }
   if (output["Key"] !== undefined) {
-    contents.Key = output["Key"];
+    contents.Key = __expectString(output["Key"]);
   }
   if (output["Value"] !== undefined) {
-    contents.Value = output["Value"];
+    contents.Value = __expectString(output["Value"]);
   }
   if (output["PropagateAtLaunch"] !== undefined) {
     contents.PropagateAtLaunch = __parseBoolean(output["PropagateAtLaunch"]);
@@ -9769,7 +9770,7 @@ const deserializeAws_queryTagsType = (output: any, context: __SerdeContext): Tag
     contents.Tags = deserializeAws_queryTagDescriptionList(__getArrayIfSingleItem(output["Tags"]["member"]), context);
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -9781,7 +9782,7 @@ const deserializeAws_queryTargetGroupARNs = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -9823,7 +9824,7 @@ const deserializeAws_queryTerminationPolicies = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -9841,10 +9842,10 @@ const deserializeAws_queryWarmPoolConfiguration = (output: any, context: __Serde
     contents.MinSize = parseInt(output["MinSize"]);
   }
   if (output["PoolState"] !== undefined) {
-    contents.PoolState = output["PoolState"];
+    contents.PoolState = __expectString(output["PoolState"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   return contents;
 };

--- a/clients/client-backup/protocols/Aws_restJson1.ts
+++ b/clients/client-backup/protocols/Aws_restJson1.ts
@@ -172,6 +172,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -1800,16 +1803,16 @@ export const deserializeAws_restJson1CreateBackupPlanCommand = async (
     );
   }
   if (data.BackupPlanArn !== undefined && data.BackupPlanArn !== null) {
-    contents.BackupPlanArn = data.BackupPlanArn;
+    contents.BackupPlanArn = __expectString(data.BackupPlanArn);
   }
   if (data.BackupPlanId !== undefined && data.BackupPlanId !== null) {
-    contents.BackupPlanId = data.BackupPlanId;
+    contents.BackupPlanId = __expectString(data.BackupPlanId);
   }
   if (data.CreationDate !== undefined && data.CreationDate !== null) {
     contents.CreationDate = new Date(Math.round(data.CreationDate * 1000));
   }
   if (data.VersionId !== undefined && data.VersionId !== null) {
-    contents.VersionId = data.VersionId;
+    contents.VersionId = __expectString(data.VersionId);
   }
   return Promise.resolve(contents);
 };
@@ -1898,13 +1901,13 @@ export const deserializeAws_restJson1CreateBackupSelectionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.BackupPlanId !== undefined && data.BackupPlanId !== null) {
-    contents.BackupPlanId = data.BackupPlanId;
+    contents.BackupPlanId = __expectString(data.BackupPlanId);
   }
   if (data.CreationDate !== undefined && data.CreationDate !== null) {
     contents.CreationDate = new Date(Math.round(data.CreationDate * 1000));
   }
   if (data.SelectionId !== undefined && data.SelectionId !== null) {
-    contents.SelectionId = data.SelectionId;
+    contents.SelectionId = __expectString(data.SelectionId);
   }
   return Promise.resolve(contents);
 };
@@ -1993,10 +1996,10 @@ export const deserializeAws_restJson1CreateBackupVaultCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.BackupVaultArn !== undefined && data.BackupVaultArn !== null) {
-    contents.BackupVaultArn = data.BackupVaultArn;
+    contents.BackupVaultArn = __expectString(data.BackupVaultArn);
   }
   if (data.BackupVaultName !== undefined && data.BackupVaultName !== null) {
-    contents.BackupVaultName = data.BackupVaultName;
+    contents.BackupVaultName = __expectString(data.BackupVaultName);
   }
   if (data.CreationDate !== undefined && data.CreationDate !== null) {
     contents.CreationDate = new Date(Math.round(data.CreationDate * 1000));
@@ -2089,16 +2092,16 @@ export const deserializeAws_restJson1DeleteBackupPlanCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.BackupPlanArn !== undefined && data.BackupPlanArn !== null) {
-    contents.BackupPlanArn = data.BackupPlanArn;
+    contents.BackupPlanArn = __expectString(data.BackupPlanArn);
   }
   if (data.BackupPlanId !== undefined && data.BackupPlanId !== null) {
-    contents.BackupPlanId = data.BackupPlanId;
+    contents.BackupPlanId = __expectString(data.BackupPlanId);
   }
   if (data.DeletionDate !== undefined && data.DeletionDate !== null) {
     contents.DeletionDate = new Date(Math.round(data.DeletionDate * 1000));
   }
   if (data.VersionId !== undefined && data.VersionId !== null) {
-    contents.VersionId = data.VersionId;
+    contents.VersionId = __expectString(data.VersionId);
   }
   return Promise.resolve(contents);
 };
@@ -2603,28 +2606,28 @@ export const deserializeAws_restJson1DescribeBackupJobCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AccountId !== undefined && data.AccountId !== null) {
-    contents.AccountId = data.AccountId;
+    contents.AccountId = __expectString(data.AccountId);
   }
   if (data.BackupJobId !== undefined && data.BackupJobId !== null) {
-    contents.BackupJobId = data.BackupJobId;
+    contents.BackupJobId = __expectString(data.BackupJobId);
   }
   if (data.BackupOptions !== undefined && data.BackupOptions !== null) {
     contents.BackupOptions = deserializeAws_restJson1BackupOptions(data.BackupOptions, context);
   }
   if (data.BackupSizeInBytes !== undefined && data.BackupSizeInBytes !== null) {
-    contents.BackupSizeInBytes = data.BackupSizeInBytes;
+    contents.BackupSizeInBytes = __expectNumber(data.BackupSizeInBytes);
   }
   if (data.BackupType !== undefined && data.BackupType !== null) {
-    contents.BackupType = data.BackupType;
+    contents.BackupType = __expectString(data.BackupType);
   }
   if (data.BackupVaultArn !== undefined && data.BackupVaultArn !== null) {
-    contents.BackupVaultArn = data.BackupVaultArn;
+    contents.BackupVaultArn = __expectString(data.BackupVaultArn);
   }
   if (data.BackupVaultName !== undefined && data.BackupVaultName !== null) {
-    contents.BackupVaultName = data.BackupVaultName;
+    contents.BackupVaultName = __expectString(data.BackupVaultName);
   }
   if (data.BytesTransferred !== undefined && data.BytesTransferred !== null) {
-    contents.BytesTransferred = data.BytesTransferred;
+    contents.BytesTransferred = __expectNumber(data.BytesTransferred);
   }
   if (data.CompletionDate !== undefined && data.CompletionDate !== null) {
     contents.CompletionDate = new Date(Math.round(data.CompletionDate * 1000));
@@ -2639,28 +2642,28 @@ export const deserializeAws_restJson1DescribeBackupJobCommand = async (
     contents.ExpectedCompletionDate = new Date(Math.round(data.ExpectedCompletionDate * 1000));
   }
   if (data.IamRoleArn !== undefined && data.IamRoleArn !== null) {
-    contents.IamRoleArn = data.IamRoleArn;
+    contents.IamRoleArn = __expectString(data.IamRoleArn);
   }
   if (data.PercentDone !== undefined && data.PercentDone !== null) {
-    contents.PercentDone = data.PercentDone;
+    contents.PercentDone = __expectString(data.PercentDone);
   }
   if (data.RecoveryPointArn !== undefined && data.RecoveryPointArn !== null) {
-    contents.RecoveryPointArn = data.RecoveryPointArn;
+    contents.RecoveryPointArn = __expectString(data.RecoveryPointArn);
   }
   if (data.ResourceArn !== undefined && data.ResourceArn !== null) {
-    contents.ResourceArn = data.ResourceArn;
+    contents.ResourceArn = __expectString(data.ResourceArn);
   }
   if (data.ResourceType !== undefined && data.ResourceType !== null) {
-    contents.ResourceType = data.ResourceType;
+    contents.ResourceType = __expectString(data.ResourceType);
   }
   if (data.StartBy !== undefined && data.StartBy !== null) {
     contents.StartBy = new Date(Math.round(data.StartBy * 1000));
   }
   if (data.State !== undefined && data.State !== null) {
-    contents.State = data.State;
+    contents.State = __expectString(data.State);
   }
   if (data.StatusMessage !== undefined && data.StatusMessage !== null) {
-    contents.StatusMessage = data.StatusMessage;
+    contents.StatusMessage = __expectString(data.StatusMessage);
   }
   return Promise.resolve(contents);
 };
@@ -2752,22 +2755,22 @@ export const deserializeAws_restJson1DescribeBackupVaultCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.BackupVaultArn !== undefined && data.BackupVaultArn !== null) {
-    contents.BackupVaultArn = data.BackupVaultArn;
+    contents.BackupVaultArn = __expectString(data.BackupVaultArn);
   }
   if (data.BackupVaultName !== undefined && data.BackupVaultName !== null) {
-    contents.BackupVaultName = data.BackupVaultName;
+    contents.BackupVaultName = __expectString(data.BackupVaultName);
   }
   if (data.CreationDate !== undefined && data.CreationDate !== null) {
     contents.CreationDate = new Date(Math.round(data.CreationDate * 1000));
   }
   if (data.CreatorRequestId !== undefined && data.CreatorRequestId !== null) {
-    contents.CreatorRequestId = data.CreatorRequestId;
+    contents.CreatorRequestId = __expectString(data.CreatorRequestId);
   }
   if (data.EncryptionKeyArn !== undefined && data.EncryptionKeyArn !== null) {
-    contents.EncryptionKeyArn = data.EncryptionKeyArn;
+    contents.EncryptionKeyArn = __expectString(data.EncryptionKeyArn);
   }
   if (data.NumberOfRecoveryPoints !== undefined && data.NumberOfRecoveryPoints !== null) {
-    contents.NumberOfRecoveryPoints = data.NumberOfRecoveryPoints;
+    contents.NumberOfRecoveryPoints = __expectNumber(data.NumberOfRecoveryPoints);
   }
   return Promise.resolve(contents);
 };
@@ -2997,10 +3000,10 @@ export const deserializeAws_restJson1DescribeProtectedResourceCommand = async (
     contents.LastBackupTime = new Date(Math.round(data.LastBackupTime * 1000));
   }
   if (data.ResourceArn !== undefined && data.ResourceArn !== null) {
-    contents.ResourceArn = data.ResourceArn;
+    contents.ResourceArn = __expectString(data.ResourceArn);
   }
   if (data.ResourceType !== undefined && data.ResourceType !== null) {
-    contents.ResourceType = data.ResourceType;
+    contents.ResourceType = __expectString(data.ResourceType);
   }
   return Promise.resolve(contents);
 };
@@ -3096,13 +3099,13 @@ export const deserializeAws_restJson1DescribeRecoveryPointCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.BackupSizeInBytes !== undefined && data.BackupSizeInBytes !== null) {
-    contents.BackupSizeInBytes = data.BackupSizeInBytes;
+    contents.BackupSizeInBytes = __expectNumber(data.BackupSizeInBytes);
   }
   if (data.BackupVaultArn !== undefined && data.BackupVaultArn !== null) {
-    contents.BackupVaultArn = data.BackupVaultArn;
+    contents.BackupVaultArn = __expectString(data.BackupVaultArn);
   }
   if (data.BackupVaultName !== undefined && data.BackupVaultName !== null) {
-    contents.BackupVaultName = data.BackupVaultName;
+    contents.BackupVaultName = __expectString(data.BackupVaultName);
   }
   if (data.CalculatedLifecycle !== undefined && data.CalculatedLifecycle !== null) {
     contents.CalculatedLifecycle = deserializeAws_restJson1CalculatedLifecycle(data.CalculatedLifecycle, context);
@@ -3117,13 +3120,13 @@ export const deserializeAws_restJson1DescribeRecoveryPointCommand = async (
     contents.CreationDate = new Date(Math.round(data.CreationDate * 1000));
   }
   if (data.EncryptionKeyArn !== undefined && data.EncryptionKeyArn !== null) {
-    contents.EncryptionKeyArn = data.EncryptionKeyArn;
+    contents.EncryptionKeyArn = __expectString(data.EncryptionKeyArn);
   }
   if (data.IamRoleArn !== undefined && data.IamRoleArn !== null) {
-    contents.IamRoleArn = data.IamRoleArn;
+    contents.IamRoleArn = __expectString(data.IamRoleArn);
   }
   if (data.IsEncrypted !== undefined && data.IsEncrypted !== null) {
-    contents.IsEncrypted = data.IsEncrypted;
+    contents.IsEncrypted = __expectBoolean(data.IsEncrypted);
   }
   if (data.LastRestoreTime !== undefined && data.LastRestoreTime !== null) {
     contents.LastRestoreTime = new Date(Math.round(data.LastRestoreTime * 1000));
@@ -3132,22 +3135,22 @@ export const deserializeAws_restJson1DescribeRecoveryPointCommand = async (
     contents.Lifecycle = deserializeAws_restJson1Lifecycle(data.Lifecycle, context);
   }
   if (data.RecoveryPointArn !== undefined && data.RecoveryPointArn !== null) {
-    contents.RecoveryPointArn = data.RecoveryPointArn;
+    contents.RecoveryPointArn = __expectString(data.RecoveryPointArn);
   }
   if (data.ResourceArn !== undefined && data.ResourceArn !== null) {
-    contents.ResourceArn = data.ResourceArn;
+    contents.ResourceArn = __expectString(data.ResourceArn);
   }
   if (data.ResourceType !== undefined && data.ResourceType !== null) {
-    contents.ResourceType = data.ResourceType;
+    contents.ResourceType = __expectString(data.ResourceType);
   }
   if (data.SourceBackupVaultArn !== undefined && data.SourceBackupVaultArn !== null) {
-    contents.SourceBackupVaultArn = data.SourceBackupVaultArn;
+    contents.SourceBackupVaultArn = __expectString(data.SourceBackupVaultArn);
   }
   if (data.Status !== undefined && data.Status !== null) {
-    contents.Status = data.Status;
+    contents.Status = __expectString(data.Status);
   }
   if (data.StorageClass !== undefined && data.StorageClass !== null) {
-    contents.StorageClass = data.StorageClass;
+    contents.StorageClass = __expectString(data.StorageClass);
   }
   return Promise.resolve(contents);
 };
@@ -3296,43 +3299,43 @@ export const deserializeAws_restJson1DescribeRestoreJobCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AccountId !== undefined && data.AccountId !== null) {
-    contents.AccountId = data.AccountId;
+    contents.AccountId = __expectString(data.AccountId);
   }
   if (data.BackupSizeInBytes !== undefined && data.BackupSizeInBytes !== null) {
-    contents.BackupSizeInBytes = data.BackupSizeInBytes;
+    contents.BackupSizeInBytes = __expectNumber(data.BackupSizeInBytes);
   }
   if (data.CompletionDate !== undefined && data.CompletionDate !== null) {
     contents.CompletionDate = new Date(Math.round(data.CompletionDate * 1000));
   }
   if (data.CreatedResourceArn !== undefined && data.CreatedResourceArn !== null) {
-    contents.CreatedResourceArn = data.CreatedResourceArn;
+    contents.CreatedResourceArn = __expectString(data.CreatedResourceArn);
   }
   if (data.CreationDate !== undefined && data.CreationDate !== null) {
     contents.CreationDate = new Date(Math.round(data.CreationDate * 1000));
   }
   if (data.ExpectedCompletionTimeMinutes !== undefined && data.ExpectedCompletionTimeMinutes !== null) {
-    contents.ExpectedCompletionTimeMinutes = data.ExpectedCompletionTimeMinutes;
+    contents.ExpectedCompletionTimeMinutes = __expectNumber(data.ExpectedCompletionTimeMinutes);
   }
   if (data.IamRoleArn !== undefined && data.IamRoleArn !== null) {
-    contents.IamRoleArn = data.IamRoleArn;
+    contents.IamRoleArn = __expectString(data.IamRoleArn);
   }
   if (data.PercentDone !== undefined && data.PercentDone !== null) {
-    contents.PercentDone = data.PercentDone;
+    contents.PercentDone = __expectString(data.PercentDone);
   }
   if (data.RecoveryPointArn !== undefined && data.RecoveryPointArn !== null) {
-    contents.RecoveryPointArn = data.RecoveryPointArn;
+    contents.RecoveryPointArn = __expectString(data.RecoveryPointArn);
   }
   if (data.ResourceType !== undefined && data.ResourceType !== null) {
-    contents.ResourceType = data.ResourceType;
+    contents.ResourceType = __expectString(data.ResourceType);
   }
   if (data.RestoreJobId !== undefined && data.RestoreJobId !== null) {
-    contents.RestoreJobId = data.RestoreJobId;
+    contents.RestoreJobId = __expectString(data.RestoreJobId);
   }
   if (data.Status !== undefined && data.Status !== null) {
-    contents.Status = data.Status;
+    contents.Status = __expectString(data.Status);
   }
   if (data.StatusMessage !== undefined && data.StatusMessage !== null) {
-    contents.StatusMessage = data.StatusMessage;
+    contents.StatusMessage = __expectString(data.StatusMessage);
   }
   return Promise.resolve(contents);
 };
@@ -3510,7 +3513,7 @@ export const deserializeAws_restJson1ExportBackupPlanTemplateCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.BackupPlanTemplateJson !== undefined && data.BackupPlanTemplateJson !== null) {
-    contents.BackupPlanTemplateJson = data.BackupPlanTemplateJson;
+    contents.BackupPlanTemplateJson = __expectString(data.BackupPlanTemplateJson);
   }
   return Promise.resolve(contents);
 };
@@ -3606,16 +3609,16 @@ export const deserializeAws_restJson1GetBackupPlanCommand = async (
     contents.BackupPlan = deserializeAws_restJson1BackupPlan(data.BackupPlan, context);
   }
   if (data.BackupPlanArn !== undefined && data.BackupPlanArn !== null) {
-    contents.BackupPlanArn = data.BackupPlanArn;
+    contents.BackupPlanArn = __expectString(data.BackupPlanArn);
   }
   if (data.BackupPlanId !== undefined && data.BackupPlanId !== null) {
-    contents.BackupPlanId = data.BackupPlanId;
+    contents.BackupPlanId = __expectString(data.BackupPlanId);
   }
   if (data.CreationDate !== undefined && data.CreationDate !== null) {
     contents.CreationDate = new Date(Math.round(data.CreationDate * 1000));
   }
   if (data.CreatorRequestId !== undefined && data.CreatorRequestId !== null) {
-    contents.CreatorRequestId = data.CreatorRequestId;
+    contents.CreatorRequestId = __expectString(data.CreatorRequestId);
   }
   if (data.DeletionDate !== undefined && data.DeletionDate !== null) {
     contents.DeletionDate = new Date(Math.round(data.DeletionDate * 1000));
@@ -3624,7 +3627,7 @@ export const deserializeAws_restJson1GetBackupPlanCommand = async (
     contents.LastExecutionDate = new Date(Math.round(data.LastExecutionDate * 1000));
   }
   if (data.VersionId !== undefined && data.VersionId !== null) {
-    contents.VersionId = data.VersionId;
+    contents.VersionId = __expectString(data.VersionId);
   }
   return Promise.resolve(contents);
 };
@@ -3873,7 +3876,7 @@ export const deserializeAws_restJson1GetBackupSelectionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.BackupPlanId !== undefined && data.BackupPlanId !== null) {
-    contents.BackupPlanId = data.BackupPlanId;
+    contents.BackupPlanId = __expectString(data.BackupPlanId);
   }
   if (data.BackupSelection !== undefined && data.BackupSelection !== null) {
     contents.BackupSelection = deserializeAws_restJson1BackupSelection(data.BackupSelection, context);
@@ -3882,10 +3885,10 @@ export const deserializeAws_restJson1GetBackupSelectionCommand = async (
     contents.CreationDate = new Date(Math.round(data.CreationDate * 1000));
   }
   if (data.CreatorRequestId !== undefined && data.CreatorRequestId !== null) {
-    contents.CreatorRequestId = data.CreatorRequestId;
+    contents.CreatorRequestId = __expectString(data.CreatorRequestId);
   }
   if (data.SelectionId !== undefined && data.SelectionId !== null) {
-    contents.SelectionId = data.SelectionId;
+    contents.SelectionId = __expectString(data.SelectionId);
   }
   return Promise.resolve(contents);
 };
@@ -3966,13 +3969,13 @@ export const deserializeAws_restJson1GetBackupVaultAccessPolicyCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.BackupVaultArn !== undefined && data.BackupVaultArn !== null) {
-    contents.BackupVaultArn = data.BackupVaultArn;
+    contents.BackupVaultArn = __expectString(data.BackupVaultArn);
   }
   if (data.BackupVaultName !== undefined && data.BackupVaultName !== null) {
-    contents.BackupVaultName = data.BackupVaultName;
+    contents.BackupVaultName = __expectString(data.BackupVaultName);
   }
   if (data.Policy !== undefined && data.Policy !== null) {
-    contents.Policy = data.Policy;
+    contents.Policy = __expectString(data.Policy);
   }
   return Promise.resolve(contents);
 };
@@ -4054,16 +4057,16 @@ export const deserializeAws_restJson1GetBackupVaultNotificationsCommand = async 
   };
   const data: any = await parseBody(output.body, context);
   if (data.BackupVaultArn !== undefined && data.BackupVaultArn !== null) {
-    contents.BackupVaultArn = data.BackupVaultArn;
+    contents.BackupVaultArn = __expectString(data.BackupVaultArn);
   }
   if (data.BackupVaultEvents !== undefined && data.BackupVaultEvents !== null) {
     contents.BackupVaultEvents = deserializeAws_restJson1BackupVaultEvents(data.BackupVaultEvents, context);
   }
   if (data.BackupVaultName !== undefined && data.BackupVaultName !== null) {
-    contents.BackupVaultName = data.BackupVaultName;
+    contents.BackupVaultName = __expectString(data.BackupVaultName);
   }
   if (data.SNSTopicArn !== undefined && data.SNSTopicArn !== null) {
-    contents.SNSTopicArn = data.SNSTopicArn;
+    contents.SNSTopicArn = __expectString(data.SNSTopicArn);
   }
   return Promise.resolve(contents);
 };
@@ -4144,10 +4147,10 @@ export const deserializeAws_restJson1GetRecoveryPointRestoreMetadataCommand = as
   };
   const data: any = await parseBody(output.body, context);
   if (data.BackupVaultArn !== undefined && data.BackupVaultArn !== null) {
-    contents.BackupVaultArn = data.BackupVaultArn;
+    contents.BackupVaultArn = __expectString(data.BackupVaultArn);
   }
   if (data.RecoveryPointArn !== undefined && data.RecoveryPointArn !== null) {
-    contents.RecoveryPointArn = data.RecoveryPointArn;
+    contents.RecoveryPointArn = __expectString(data.RecoveryPointArn);
   }
   if (data.RestoreMetadata !== undefined && data.RestoreMetadata !== null) {
     contents.RestoreMetadata = deserializeAws_restJson1Metadata(data.RestoreMetadata, context);
@@ -4288,7 +4291,7 @@ export const deserializeAws_restJson1ListBackupJobsCommand = async (
     contents.BackupJobs = deserializeAws_restJson1BackupJobsList(data.BackupJobs, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -4355,7 +4358,7 @@ export const deserializeAws_restJson1ListBackupPlansCommand = async (
     contents.BackupPlansList = deserializeAws_restJson1BackupPlansList(data.BackupPlansList, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -4441,7 +4444,7 @@ export const deserializeAws_restJson1ListBackupPlanTemplatesCommand = async (
     );
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -4527,7 +4530,7 @@ export const deserializeAws_restJson1ListBackupPlanVersionsCommand = async (
     );
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -4610,7 +4613,7 @@ export const deserializeAws_restJson1ListBackupSelectionsCommand = async (
     contents.BackupSelectionsList = deserializeAws_restJson1BackupSelectionsList(data.BackupSelectionsList, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -4693,7 +4696,7 @@ export const deserializeAws_restJson1ListBackupVaultsCommand = async (
     contents.BackupVaultList = deserializeAws_restJson1BackupVaultList(data.BackupVaultList, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -4776,7 +4779,7 @@ export const deserializeAws_restJson1ListCopyJobsCommand = async (
     contents.CopyJobs = deserializeAws_restJson1CopyJobsList(data.CopyJobs, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -4840,7 +4843,7 @@ export const deserializeAws_restJson1ListProtectedResourcesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Results !== undefined && data.Results !== null) {
     contents.Results = deserializeAws_restJson1ProtectedResourcesList(data.Results, context);
@@ -4907,7 +4910,7 @@ export const deserializeAws_restJson1ListRecoveryPointsByBackupVaultCommand = as
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.RecoveryPoints !== undefined && data.RecoveryPoints !== null) {
     contents.RecoveryPoints = deserializeAws_restJson1RecoveryPointByBackupVaultList(data.RecoveryPoints, context);
@@ -4990,7 +4993,7 @@ export const deserializeAws_restJson1ListRecoveryPointsByResourceCommand = async
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.RecoveryPoints !== undefined && data.RecoveryPoints !== null) {
     contents.RecoveryPoints = deserializeAws_restJson1RecoveryPointByResourceList(data.RecoveryPoints, context);
@@ -5073,7 +5076,7 @@ export const deserializeAws_restJson1ListRestoreJobsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.RestoreJobs !== undefined && data.RestoreJobs !== null) {
     contents.RestoreJobs = deserializeAws_restJson1RestoreJobsList(data.RestoreJobs, context);
@@ -5156,7 +5159,7 @@ export const deserializeAws_restJson1ListTagsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.Tags, context);
@@ -5390,13 +5393,13 @@ export const deserializeAws_restJson1StartBackupJobCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.BackupJobId !== undefined && data.BackupJobId !== null) {
-    contents.BackupJobId = data.BackupJobId;
+    contents.BackupJobId = __expectString(data.BackupJobId);
   }
   if (data.CreationDate !== undefined && data.CreationDate !== null) {
     contents.CreationDate = new Date(Math.round(data.CreationDate * 1000));
   }
   if (data.RecoveryPointArn !== undefined && data.RecoveryPointArn !== null) {
-    contents.RecoveryPointArn = data.RecoveryPointArn;
+    contents.RecoveryPointArn = __expectString(data.RecoveryPointArn);
   }
   return Promise.resolve(contents);
 };
@@ -5492,7 +5495,7 @@ export const deserializeAws_restJson1StartCopyJobCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.CopyJobId !== undefined && data.CopyJobId !== null) {
-    contents.CopyJobId = data.CopyJobId;
+    contents.CopyJobId = __expectString(data.CopyJobId);
   }
   if (data.CreationDate !== undefined && data.CreationDate !== null) {
     contents.CreationDate = new Date(Math.round(data.CreationDate * 1000));
@@ -5590,7 +5593,7 @@ export const deserializeAws_restJson1StartRestoreJobCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.RestoreJobId !== undefined && data.RestoreJobId !== null) {
-    contents.RestoreJobId = data.RestoreJobId;
+    contents.RestoreJobId = __expectString(data.RestoreJobId);
   }
   return Promise.resolve(contents);
 };
@@ -5920,16 +5923,16 @@ export const deserializeAws_restJson1UpdateBackupPlanCommand = async (
     );
   }
   if (data.BackupPlanArn !== undefined && data.BackupPlanArn !== null) {
-    contents.BackupPlanArn = data.BackupPlanArn;
+    contents.BackupPlanArn = __expectString(data.BackupPlanArn);
   }
   if (data.BackupPlanId !== undefined && data.BackupPlanId !== null) {
-    contents.BackupPlanId = data.BackupPlanId;
+    contents.BackupPlanId = __expectString(data.BackupPlanId);
   }
   if (data.CreationDate !== undefined && data.CreationDate !== null) {
     contents.CreationDate = new Date(Math.round(data.CreationDate * 1000));
   }
   if (data.VersionId !== undefined && data.VersionId !== null) {
-    contents.VersionId = data.VersionId;
+    contents.VersionId = __expectString(data.VersionId);
   }
   return Promise.resolve(contents);
 };
@@ -6086,7 +6089,7 @@ export const deserializeAws_restJson1UpdateRecoveryPointLifecycleCommand = async
   };
   const data: any = await parseBody(output.body, context);
   if (data.BackupVaultArn !== undefined && data.BackupVaultArn !== null) {
-    contents.BackupVaultArn = data.BackupVaultArn;
+    contents.BackupVaultArn = __expectString(data.BackupVaultArn);
   }
   if (data.CalculatedLifecycle !== undefined && data.CalculatedLifecycle !== null) {
     contents.CalculatedLifecycle = deserializeAws_restJson1CalculatedLifecycle(data.CalculatedLifecycle, context);
@@ -6095,7 +6098,7 @@ export const deserializeAws_restJson1UpdateRecoveryPointLifecycleCommand = async
     contents.Lifecycle = deserializeAws_restJson1Lifecycle(data.Lifecycle, context);
   }
   if (data.RecoveryPointArn !== undefined && data.RecoveryPointArn !== null) {
-    contents.RecoveryPointArn = data.RecoveryPointArn;
+    contents.RecoveryPointArn = __expectString(data.RecoveryPointArn);
   }
   return Promise.resolve(contents);
 };
@@ -6245,22 +6248,22 @@ const deserializeAws_restJson1AlreadyExistsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.Code !== undefined && data.Code !== null) {
-    contents.Code = data.Code;
+    contents.Code = __expectString(data.Code);
   }
   if (data.Context !== undefined && data.Context !== null) {
-    contents.Context = data.Context;
+    contents.Context = __expectString(data.Context);
   }
   if (data.CreatorRequestId !== undefined && data.CreatorRequestId !== null) {
-    contents.CreatorRequestId = data.CreatorRequestId;
+    contents.CreatorRequestId = __expectString(data.CreatorRequestId);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   return contents;
 };
@@ -6280,16 +6283,16 @@ const deserializeAws_restJson1DependencyFailureExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Code !== undefined && data.Code !== null) {
-    contents.Code = data.Code;
+    contents.Code = __expectString(data.Code);
   }
   if (data.Context !== undefined && data.Context !== null) {
-    contents.Context = data.Context;
+    contents.Context = __expectString(data.Context);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   return contents;
 };
@@ -6309,16 +6312,16 @@ const deserializeAws_restJson1InvalidParameterValueExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Code !== undefined && data.Code !== null) {
-    contents.Code = data.Code;
+    contents.Code = __expectString(data.Code);
   }
   if (data.Context !== undefined && data.Context !== null) {
-    contents.Context = data.Context;
+    contents.Context = __expectString(data.Context);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   return contents;
 };
@@ -6338,16 +6341,16 @@ const deserializeAws_restJson1InvalidRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Code !== undefined && data.Code !== null) {
-    contents.Code = data.Code;
+    contents.Code = __expectString(data.Code);
   }
   if (data.Context !== undefined && data.Context !== null) {
-    contents.Context = data.Context;
+    contents.Context = __expectString(data.Context);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   return contents;
 };
@@ -6367,16 +6370,16 @@ const deserializeAws_restJson1InvalidResourceStateExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Code !== undefined && data.Code !== null) {
-    contents.Code = data.Code;
+    contents.Code = __expectString(data.Code);
   }
   if (data.Context !== undefined && data.Context !== null) {
-    contents.Context = data.Context;
+    contents.Context = __expectString(data.Context);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   return contents;
 };
@@ -6396,16 +6399,16 @@ const deserializeAws_restJson1LimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Code !== undefined && data.Code !== null) {
-    contents.Code = data.Code;
+    contents.Code = __expectString(data.Code);
   }
   if (data.Context !== undefined && data.Context !== null) {
-    contents.Context = data.Context;
+    contents.Context = __expectString(data.Context);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   return contents;
 };
@@ -6425,16 +6428,16 @@ const deserializeAws_restJson1MissingParameterValueExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Code !== undefined && data.Code !== null) {
-    contents.Code = data.Code;
+    contents.Code = __expectString(data.Code);
   }
   if (data.Context !== undefined && data.Context !== null) {
-    contents.Context = data.Context;
+    contents.Context = __expectString(data.Context);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   return contents;
 };
@@ -6454,16 +6457,16 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Code !== undefined && data.Code !== null) {
-    contents.Code = data.Code;
+    contents.Code = __expectString(data.Code);
   }
   if (data.Context !== undefined && data.Context !== null) {
-    contents.Context = data.Context;
+    contents.Context = __expectString(data.Context);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   return contents;
 };
@@ -6483,16 +6486,16 @@ const deserializeAws_restJson1ServiceUnavailableExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Code !== undefined && data.Code !== null) {
-    contents.Code = data.Code;
+    contents.Code = __expectString(data.Code);
   }
   if (data.Context !== undefined && data.Context !== null) {
-    contents.Context = data.Context;
+    contents.Context = __expectString(data.Context);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   return contents;
 };
@@ -6731,7 +6734,7 @@ const deserializeAws_restJson1AdvancedBackupSetting = (output: any, context: __S
       output.BackupOptions !== undefined && output.BackupOptions !== null
         ? deserializeAws_restJson1BackupOptions(output.BackupOptions, context)
         : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
+    ResourceType: __expectString(output.ResourceType),
   } as any;
 };
 
@@ -6751,23 +6754,17 @@ const deserializeAws_restJson1AdvancedBackupSettings = (
 
 const deserializeAws_restJson1BackupJob = (output: any, context: __SerdeContext): BackupJob => {
   return {
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
-    BackupJobId: output.BackupJobId !== undefined && output.BackupJobId !== null ? output.BackupJobId : undefined,
+    AccountId: __expectString(output.AccountId),
+    BackupJobId: __expectString(output.BackupJobId),
     BackupOptions:
       output.BackupOptions !== undefined && output.BackupOptions !== null
         ? deserializeAws_restJson1BackupOptions(output.BackupOptions, context)
         : undefined,
-    BackupSizeInBytes:
-      output.BackupSizeInBytes !== undefined && output.BackupSizeInBytes !== null
-        ? output.BackupSizeInBytes
-        : undefined,
-    BackupType: output.BackupType !== undefined && output.BackupType !== null ? output.BackupType : undefined,
-    BackupVaultArn:
-      output.BackupVaultArn !== undefined && output.BackupVaultArn !== null ? output.BackupVaultArn : undefined,
-    BackupVaultName:
-      output.BackupVaultName !== undefined && output.BackupVaultName !== null ? output.BackupVaultName : undefined,
-    BytesTransferred:
-      output.BytesTransferred !== undefined && output.BytesTransferred !== null ? output.BytesTransferred : undefined,
+    BackupSizeInBytes: __expectNumber(output.BackupSizeInBytes),
+    BackupType: __expectString(output.BackupType),
+    BackupVaultArn: __expectString(output.BackupVaultArn),
+    BackupVaultName: __expectString(output.BackupVaultName),
+    BytesTransferred: __expectNumber(output.BytesTransferred),
     CompletionDate:
       output.CompletionDate !== undefined && output.CompletionDate !== null
         ? new Date(Math.round(output.CompletionDate * 1000))
@@ -6784,17 +6781,15 @@ const deserializeAws_restJson1BackupJob = (output: any, context: __SerdeContext)
       output.ExpectedCompletionDate !== undefined && output.ExpectedCompletionDate !== null
         ? new Date(Math.round(output.ExpectedCompletionDate * 1000))
         : undefined,
-    IamRoleArn: output.IamRoleArn !== undefined && output.IamRoleArn !== null ? output.IamRoleArn : undefined,
-    PercentDone: output.PercentDone !== undefined && output.PercentDone !== null ? output.PercentDone : undefined,
-    RecoveryPointArn:
-      output.RecoveryPointArn !== undefined && output.RecoveryPointArn !== null ? output.RecoveryPointArn : undefined,
-    ResourceArn: output.ResourceArn !== undefined && output.ResourceArn !== null ? output.ResourceArn : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
+    IamRoleArn: __expectString(output.IamRoleArn),
+    PercentDone: __expectString(output.PercentDone),
+    RecoveryPointArn: __expectString(output.RecoveryPointArn),
+    ResourceArn: __expectString(output.ResourceArn),
+    ResourceType: __expectString(output.ResourceType),
     StartBy:
       output.StartBy !== undefined && output.StartBy !== null ? new Date(Math.round(output.StartBy * 1000)) : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    StatusMessage:
-      output.StatusMessage !== undefined && output.StatusMessage !== null ? output.StatusMessage : undefined,
+    State: __expectString(output.State),
+    StatusMessage: __expectString(output.StatusMessage),
   } as any;
 };
 
@@ -6816,7 +6811,7 @@ const deserializeAws_restJson1BackupOptions = (output: any, context: __SerdeCont
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -6827,8 +6822,7 @@ const deserializeAws_restJson1BackupPlan = (output: any, context: __SerdeContext
       output.AdvancedBackupSettings !== undefined && output.AdvancedBackupSettings !== null
         ? deserializeAws_restJson1AdvancedBackupSettings(output.AdvancedBackupSettings, context)
         : undefined,
-    BackupPlanName:
-      output.BackupPlanName !== undefined && output.BackupPlanName !== null ? output.BackupPlanName : undefined,
+    BackupPlanName: __expectString(output.BackupPlanName),
     Rules:
       output.Rules !== undefined && output.Rules !== null
         ? deserializeAws_restJson1BackupRules(output.Rules, context)
@@ -6853,17 +6847,14 @@ const deserializeAws_restJson1BackupPlansListMember = (output: any, context: __S
       output.AdvancedBackupSettings !== undefined && output.AdvancedBackupSettings !== null
         ? deserializeAws_restJson1AdvancedBackupSettings(output.AdvancedBackupSettings, context)
         : undefined,
-    BackupPlanArn:
-      output.BackupPlanArn !== undefined && output.BackupPlanArn !== null ? output.BackupPlanArn : undefined,
-    BackupPlanId: output.BackupPlanId !== undefined && output.BackupPlanId !== null ? output.BackupPlanId : undefined,
-    BackupPlanName:
-      output.BackupPlanName !== undefined && output.BackupPlanName !== null ? output.BackupPlanName : undefined,
+    BackupPlanArn: __expectString(output.BackupPlanArn),
+    BackupPlanId: __expectString(output.BackupPlanId),
+    BackupPlanName: __expectString(output.BackupPlanName),
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
         ? new Date(Math.round(output.CreationDate * 1000))
         : undefined,
-    CreatorRequestId:
-      output.CreatorRequestId !== undefined && output.CreatorRequestId !== null ? output.CreatorRequestId : undefined,
+    CreatorRequestId: __expectString(output.CreatorRequestId),
     DeletionDate:
       output.DeletionDate !== undefined && output.DeletionDate !== null
         ? new Date(Math.round(output.DeletionDate * 1000))
@@ -6872,7 +6863,7 @@ const deserializeAws_restJson1BackupPlansListMember = (output: any, context: __S
       output.LastExecutionDate !== undefined && output.LastExecutionDate !== null
         ? new Date(Math.round(output.LastExecutionDate * 1000))
         : undefined,
-    VersionId: output.VersionId !== undefined && output.VersionId !== null ? output.VersionId : undefined,
+    VersionId: __expectString(output.VersionId),
   } as any;
 };
 
@@ -6895,14 +6886,8 @@ const deserializeAws_restJson1BackupPlanTemplatesListMember = (
   context: __SerdeContext
 ): BackupPlanTemplatesListMember => {
   return {
-    BackupPlanTemplateId:
-      output.BackupPlanTemplateId !== undefined && output.BackupPlanTemplateId !== null
-        ? output.BackupPlanTemplateId
-        : undefined,
-    BackupPlanTemplateName:
-      output.BackupPlanTemplateName !== undefined && output.BackupPlanTemplateName !== null
-        ? output.BackupPlanTemplateName
-        : undefined,
+    BackupPlanTemplateId: __expectString(output.BackupPlanTemplateId),
+    BackupPlanTemplateName: __expectString(output.BackupPlanTemplateName),
   } as any;
 };
 
@@ -6922,18 +6907,12 @@ const deserializeAws_restJson1BackupPlanVersionsList = (
 
 const deserializeAws_restJson1BackupRule = (output: any, context: __SerdeContext): BackupRule => {
   return {
-    CompletionWindowMinutes:
-      output.CompletionWindowMinutes !== undefined && output.CompletionWindowMinutes !== null
-        ? output.CompletionWindowMinutes
-        : undefined,
+    CompletionWindowMinutes: __expectNumber(output.CompletionWindowMinutes),
     CopyActions:
       output.CopyActions !== undefined && output.CopyActions !== null
         ? deserializeAws_restJson1CopyActions(output.CopyActions, context)
         : undefined,
-    EnableContinuousBackup:
-      output.EnableContinuousBackup !== undefined && output.EnableContinuousBackup !== null
-        ? output.EnableContinuousBackup
-        : undefined,
+    EnableContinuousBackup: __expectBoolean(output.EnableContinuousBackup),
     Lifecycle:
       output.Lifecycle !== undefined && output.Lifecycle !== null
         ? deserializeAws_restJson1Lifecycle(output.Lifecycle, context)
@@ -6942,20 +6921,11 @@ const deserializeAws_restJson1BackupRule = (output: any, context: __SerdeContext
       output.RecoveryPointTags !== undefined && output.RecoveryPointTags !== null
         ? deserializeAws_restJson1Tags(output.RecoveryPointTags, context)
         : undefined,
-    RuleId: output.RuleId !== undefined && output.RuleId !== null ? output.RuleId : undefined,
-    RuleName: output.RuleName !== undefined && output.RuleName !== null ? output.RuleName : undefined,
-    ScheduleExpression:
-      output.ScheduleExpression !== undefined && output.ScheduleExpression !== null
-        ? output.ScheduleExpression
-        : undefined,
-    StartWindowMinutes:
-      output.StartWindowMinutes !== undefined && output.StartWindowMinutes !== null
-        ? output.StartWindowMinutes
-        : undefined,
-    TargetBackupVaultName:
-      output.TargetBackupVaultName !== undefined && output.TargetBackupVaultName !== null
-        ? output.TargetBackupVaultName
-        : undefined,
+    RuleId: __expectString(output.RuleId),
+    RuleName: __expectString(output.RuleName),
+    ScheduleExpression: __expectString(output.ScheduleExpression),
+    StartWindowMinutes: __expectNumber(output.StartWindowMinutes),
+    TargetBackupVaultName: __expectString(output.TargetBackupVaultName),
   } as any;
 };
 
@@ -6972,7 +6942,7 @@ const deserializeAws_restJson1BackupRules = (output: any, context: __SerdeContex
 
 const deserializeAws_restJson1BackupSelection = (output: any, context: __SerdeContext): BackupSelection => {
   return {
-    IamRoleArn: output.IamRoleArn !== undefined && output.IamRoleArn !== null ? output.IamRoleArn : undefined,
+    IamRoleArn: __expectString(output.IamRoleArn),
     ListOfTags:
       output.ListOfTags !== undefined && output.ListOfTags !== null
         ? deserializeAws_restJson1ListOfTags(output.ListOfTags, context)
@@ -6981,8 +6951,7 @@ const deserializeAws_restJson1BackupSelection = (output: any, context: __SerdeCo
       output.Resources !== undefined && output.Resources !== null
         ? deserializeAws_restJson1ResourceArns(output.Resources, context)
         : undefined,
-    SelectionName:
-      output.SelectionName !== undefined && output.SelectionName !== null ? output.SelectionName : undefined,
+    SelectionName: __expectString(output.SelectionName),
   } as any;
 };
 
@@ -7005,17 +6974,15 @@ const deserializeAws_restJson1BackupSelectionsListMember = (
   context: __SerdeContext
 ): BackupSelectionsListMember => {
   return {
-    BackupPlanId: output.BackupPlanId !== undefined && output.BackupPlanId !== null ? output.BackupPlanId : undefined,
+    BackupPlanId: __expectString(output.BackupPlanId),
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
         ? new Date(Math.round(output.CreationDate * 1000))
         : undefined,
-    CreatorRequestId:
-      output.CreatorRequestId !== undefined && output.CreatorRequestId !== null ? output.CreatorRequestId : undefined,
-    IamRoleArn: output.IamRoleArn !== undefined && output.IamRoleArn !== null ? output.IamRoleArn : undefined,
-    SelectionId: output.SelectionId !== undefined && output.SelectionId !== null ? output.SelectionId : undefined,
-    SelectionName:
-      output.SelectionName !== undefined && output.SelectionName !== null ? output.SelectionName : undefined,
+    CreatorRequestId: __expectString(output.CreatorRequestId),
+    IamRoleArn: __expectString(output.IamRoleArn),
+    SelectionId: __expectString(output.SelectionId),
+    SelectionName: __expectString(output.SelectionName),
   } as any;
 };
 
@@ -7029,7 +6996,7 @@ const deserializeAws_restJson1BackupVaultEvents = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7046,22 +7013,15 @@ const deserializeAws_restJson1BackupVaultList = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1BackupVaultListMember = (output: any, context: __SerdeContext): BackupVaultListMember => {
   return {
-    BackupVaultArn:
-      output.BackupVaultArn !== undefined && output.BackupVaultArn !== null ? output.BackupVaultArn : undefined,
-    BackupVaultName:
-      output.BackupVaultName !== undefined && output.BackupVaultName !== null ? output.BackupVaultName : undefined,
+    BackupVaultArn: __expectString(output.BackupVaultArn),
+    BackupVaultName: __expectString(output.BackupVaultName),
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
         ? new Date(Math.round(output.CreationDate * 1000))
         : undefined,
-    CreatorRequestId:
-      output.CreatorRequestId !== undefined && output.CreatorRequestId !== null ? output.CreatorRequestId : undefined,
-    EncryptionKeyArn:
-      output.EncryptionKeyArn !== undefined && output.EncryptionKeyArn !== null ? output.EncryptionKeyArn : undefined,
-    NumberOfRecoveryPoints:
-      output.NumberOfRecoveryPoints !== undefined && output.NumberOfRecoveryPoints !== null
-        ? output.NumberOfRecoveryPoints
-        : undefined,
+    CreatorRequestId: __expectString(output.CreatorRequestId),
+    EncryptionKeyArn: __expectString(output.EncryptionKeyArn),
+    NumberOfRecoveryPoints: __expectNumber(output.NumberOfRecoveryPoints),
   } as any;
 };
 
@@ -7080,20 +7040,15 @@ const deserializeAws_restJson1CalculatedLifecycle = (output: any, context: __Ser
 
 const deserializeAws_restJson1Condition = (output: any, context: __SerdeContext): Condition => {
   return {
-    ConditionKey: output.ConditionKey !== undefined && output.ConditionKey !== null ? output.ConditionKey : undefined,
-    ConditionType:
-      output.ConditionType !== undefined && output.ConditionType !== null ? output.ConditionType : undefined,
-    ConditionValue:
-      output.ConditionValue !== undefined && output.ConditionValue !== null ? output.ConditionValue : undefined,
+    ConditionKey: __expectString(output.ConditionKey),
+    ConditionType: __expectString(output.ConditionType),
+    ConditionValue: __expectString(output.ConditionValue),
   } as any;
 };
 
 const deserializeAws_restJson1CopyAction = (output: any, context: __SerdeContext): CopyAction => {
   return {
-    DestinationBackupVaultArn:
-      output.DestinationBackupVaultArn !== undefined && output.DestinationBackupVaultArn !== null
-        ? output.DestinationBackupVaultArn
-        : undefined,
+    DestinationBackupVaultArn: __expectString(output.DestinationBackupVaultArn),
     Lifecycle:
       output.Lifecycle !== undefined && output.Lifecycle !== null
         ? deserializeAws_restJson1Lifecycle(output.Lifecycle, context)
@@ -7114,16 +7069,13 @@ const deserializeAws_restJson1CopyActions = (output: any, context: __SerdeContex
 
 const deserializeAws_restJson1CopyJob = (output: any, context: __SerdeContext): CopyJob => {
   return {
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
-    BackupSizeInBytes:
-      output.BackupSizeInBytes !== undefined && output.BackupSizeInBytes !== null
-        ? output.BackupSizeInBytes
-        : undefined,
+    AccountId: __expectString(output.AccountId),
+    BackupSizeInBytes: __expectNumber(output.BackupSizeInBytes),
     CompletionDate:
       output.CompletionDate !== undefined && output.CompletionDate !== null
         ? new Date(Math.round(output.CompletionDate * 1000))
         : undefined,
-    CopyJobId: output.CopyJobId !== undefined && output.CopyJobId !== null ? output.CopyJobId : undefined,
+    CopyJobId: __expectString(output.CopyJobId),
     CreatedBy:
       output.CreatedBy !== undefined && output.CreatedBy !== null
         ? deserializeAws_restJson1RecoveryPointCreator(output.CreatedBy, context)
@@ -7132,28 +7084,15 @@ const deserializeAws_restJson1CopyJob = (output: any, context: __SerdeContext): 
       output.CreationDate !== undefined && output.CreationDate !== null
         ? new Date(Math.round(output.CreationDate * 1000))
         : undefined,
-    DestinationBackupVaultArn:
-      output.DestinationBackupVaultArn !== undefined && output.DestinationBackupVaultArn !== null
-        ? output.DestinationBackupVaultArn
-        : undefined,
-    DestinationRecoveryPointArn:
-      output.DestinationRecoveryPointArn !== undefined && output.DestinationRecoveryPointArn !== null
-        ? output.DestinationRecoveryPointArn
-        : undefined,
-    IamRoleArn: output.IamRoleArn !== undefined && output.IamRoleArn !== null ? output.IamRoleArn : undefined,
-    ResourceArn: output.ResourceArn !== undefined && output.ResourceArn !== null ? output.ResourceArn : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
-    SourceBackupVaultArn:
-      output.SourceBackupVaultArn !== undefined && output.SourceBackupVaultArn !== null
-        ? output.SourceBackupVaultArn
-        : undefined,
-    SourceRecoveryPointArn:
-      output.SourceRecoveryPointArn !== undefined && output.SourceRecoveryPointArn !== null
-        ? output.SourceRecoveryPointArn
-        : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    StatusMessage:
-      output.StatusMessage !== undefined && output.StatusMessage !== null ? output.StatusMessage : undefined,
+    DestinationBackupVaultArn: __expectString(output.DestinationBackupVaultArn),
+    DestinationRecoveryPointArn: __expectString(output.DestinationRecoveryPointArn),
+    IamRoleArn: __expectString(output.IamRoleArn),
+    ResourceArn: __expectString(output.ResourceArn),
+    ResourceType: __expectString(output.ResourceType),
+    SourceBackupVaultArn: __expectString(output.SourceBackupVaultArn),
+    SourceRecoveryPointArn: __expectString(output.SourceRecoveryPointArn),
+    State: __expectString(output.State),
+    StatusMessage: __expectString(output.StatusMessage),
   } as any;
 };
 
@@ -7175,19 +7114,15 @@ const deserializeAws_restJson1GlobalSettings = (output: any, context: __SerdeCon
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1Lifecycle = (output: any, context: __SerdeContext): Lifecycle => {
   return {
-    DeleteAfterDays:
-      output.DeleteAfterDays !== undefined && output.DeleteAfterDays !== null ? output.DeleteAfterDays : undefined,
-    MoveToColdStorageAfterDays:
-      output.MoveToColdStorageAfterDays !== undefined && output.MoveToColdStorageAfterDays !== null
-        ? output.MoveToColdStorageAfterDays
-        : undefined,
+    DeleteAfterDays: __expectNumber(output.DeleteAfterDays),
+    MoveToColdStorageAfterDays: __expectNumber(output.MoveToColdStorageAfterDays),
   } as any;
 };
 
@@ -7209,7 +7144,7 @@ const deserializeAws_restJson1Metadata = (output: any, context: __SerdeContext):
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -7220,8 +7155,8 @@ const deserializeAws_restJson1ProtectedResource = (output: any, context: __Serde
       output.LastBackupTime !== undefined && output.LastBackupTime !== null
         ? new Date(Math.round(output.LastBackupTime * 1000))
         : undefined,
-    ResourceArn: output.ResourceArn !== undefined && output.ResourceArn !== null ? output.ResourceArn : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
+    ResourceArn: __expectString(output.ResourceArn),
+    ResourceType: __expectString(output.ResourceType),
   } as any;
 };
 
@@ -7241,14 +7176,9 @@ const deserializeAws_restJson1RecoveryPointByBackupVault = (
   context: __SerdeContext
 ): RecoveryPointByBackupVault => {
   return {
-    BackupSizeInBytes:
-      output.BackupSizeInBytes !== undefined && output.BackupSizeInBytes !== null
-        ? output.BackupSizeInBytes
-        : undefined,
-    BackupVaultArn:
-      output.BackupVaultArn !== undefined && output.BackupVaultArn !== null ? output.BackupVaultArn : undefined,
-    BackupVaultName:
-      output.BackupVaultName !== undefined && output.BackupVaultName !== null ? output.BackupVaultName : undefined,
+    BackupSizeInBytes: __expectNumber(output.BackupSizeInBytes),
+    BackupVaultArn: __expectString(output.BackupVaultArn),
+    BackupVaultName: __expectString(output.BackupVaultName),
     CalculatedLifecycle:
       output.CalculatedLifecycle !== undefined && output.CalculatedLifecycle !== null
         ? deserializeAws_restJson1CalculatedLifecycle(output.CalculatedLifecycle, context)
@@ -7265,10 +7195,9 @@ const deserializeAws_restJson1RecoveryPointByBackupVault = (
       output.CreationDate !== undefined && output.CreationDate !== null
         ? new Date(Math.round(output.CreationDate * 1000))
         : undefined,
-    EncryptionKeyArn:
-      output.EncryptionKeyArn !== undefined && output.EncryptionKeyArn !== null ? output.EncryptionKeyArn : undefined,
-    IamRoleArn: output.IamRoleArn !== undefined && output.IamRoleArn !== null ? output.IamRoleArn : undefined,
-    IsEncrypted: output.IsEncrypted !== undefined && output.IsEncrypted !== null ? output.IsEncrypted : undefined,
+    EncryptionKeyArn: __expectString(output.EncryptionKeyArn),
+    IamRoleArn: __expectString(output.IamRoleArn),
+    IsEncrypted: __expectBoolean(output.IsEncrypted),
     LastRestoreTime:
       output.LastRestoreTime !== undefined && output.LastRestoreTime !== null
         ? new Date(Math.round(output.LastRestoreTime * 1000))
@@ -7277,15 +7206,11 @@ const deserializeAws_restJson1RecoveryPointByBackupVault = (
       output.Lifecycle !== undefined && output.Lifecycle !== null
         ? deserializeAws_restJson1Lifecycle(output.Lifecycle, context)
         : undefined,
-    RecoveryPointArn:
-      output.RecoveryPointArn !== undefined && output.RecoveryPointArn !== null ? output.RecoveryPointArn : undefined,
-    ResourceArn: output.ResourceArn !== undefined && output.ResourceArn !== null ? output.ResourceArn : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
-    SourceBackupVaultArn:
-      output.SourceBackupVaultArn !== undefined && output.SourceBackupVaultArn !== null
-        ? output.SourceBackupVaultArn
-        : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    RecoveryPointArn: __expectString(output.RecoveryPointArn),
+    ResourceArn: __expectString(output.ResourceArn),
+    ResourceType: __expectString(output.ResourceType),
+    SourceBackupVaultArn: __expectString(output.SourceBackupVaultArn),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -7308,19 +7233,15 @@ const deserializeAws_restJson1RecoveryPointByResource = (
   context: __SerdeContext
 ): RecoveryPointByResource => {
   return {
-    BackupSizeBytes:
-      output.BackupSizeBytes !== undefined && output.BackupSizeBytes !== null ? output.BackupSizeBytes : undefined,
-    BackupVaultName:
-      output.BackupVaultName !== undefined && output.BackupVaultName !== null ? output.BackupVaultName : undefined,
+    BackupSizeBytes: __expectNumber(output.BackupSizeBytes),
+    BackupVaultName: __expectString(output.BackupVaultName),
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
         ? new Date(Math.round(output.CreationDate * 1000))
         : undefined,
-    EncryptionKeyArn:
-      output.EncryptionKeyArn !== undefined && output.EncryptionKeyArn !== null ? output.EncryptionKeyArn : undefined,
-    RecoveryPointArn:
-      output.RecoveryPointArn !== undefined && output.RecoveryPointArn !== null ? output.RecoveryPointArn : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    EncryptionKeyArn: __expectString(output.EncryptionKeyArn),
+    RecoveryPointArn: __expectString(output.RecoveryPointArn),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -7340,14 +7261,10 @@ const deserializeAws_restJson1RecoveryPointByResourceList = (
 
 const deserializeAws_restJson1RecoveryPointCreator = (output: any, context: __SerdeContext): RecoveryPointCreator => {
   return {
-    BackupPlanArn:
-      output.BackupPlanArn !== undefined && output.BackupPlanArn !== null ? output.BackupPlanArn : undefined,
-    BackupPlanId: output.BackupPlanId !== undefined && output.BackupPlanId !== null ? output.BackupPlanId : undefined,
-    BackupPlanVersion:
-      output.BackupPlanVersion !== undefined && output.BackupPlanVersion !== null
-        ? output.BackupPlanVersion
-        : undefined,
-    BackupRuleId: output.BackupRuleId !== undefined && output.BackupRuleId !== null ? output.BackupRuleId : undefined,
+    BackupPlanArn: __expectString(output.BackupPlanArn),
+    BackupPlanId: __expectString(output.BackupPlanId),
+    BackupPlanVersion: __expectString(output.BackupPlanVersion),
+    BackupRuleId: __expectString(output.BackupRuleId),
   } as any;
 };
 
@@ -7358,7 +7275,7 @@ const deserializeAws_restJson1ResourceArns = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7372,7 +7289,7 @@ const deserializeAws_restJson1ResourceTypeOptInPreference = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectBoolean(value) as any,
     };
   }, {});
 };
@@ -7384,7 +7301,7 @@ const deserializeAws_restJson1ResourceTypes = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7401,36 +7318,25 @@ const deserializeAws_restJson1RestoreJobsList = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1RestoreJobsListMember = (output: any, context: __SerdeContext): RestoreJobsListMember => {
   return {
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
-    BackupSizeInBytes:
-      output.BackupSizeInBytes !== undefined && output.BackupSizeInBytes !== null
-        ? output.BackupSizeInBytes
-        : undefined,
+    AccountId: __expectString(output.AccountId),
+    BackupSizeInBytes: __expectNumber(output.BackupSizeInBytes),
     CompletionDate:
       output.CompletionDate !== undefined && output.CompletionDate !== null
         ? new Date(Math.round(output.CompletionDate * 1000))
         : undefined,
-    CreatedResourceArn:
-      output.CreatedResourceArn !== undefined && output.CreatedResourceArn !== null
-        ? output.CreatedResourceArn
-        : undefined,
+    CreatedResourceArn: __expectString(output.CreatedResourceArn),
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
         ? new Date(Math.round(output.CreationDate * 1000))
         : undefined,
-    ExpectedCompletionTimeMinutes:
-      output.ExpectedCompletionTimeMinutes !== undefined && output.ExpectedCompletionTimeMinutes !== null
-        ? output.ExpectedCompletionTimeMinutes
-        : undefined,
-    IamRoleArn: output.IamRoleArn !== undefined && output.IamRoleArn !== null ? output.IamRoleArn : undefined,
-    PercentDone: output.PercentDone !== undefined && output.PercentDone !== null ? output.PercentDone : undefined,
-    RecoveryPointArn:
-      output.RecoveryPointArn !== undefined && output.RecoveryPointArn !== null ? output.RecoveryPointArn : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
-    RestoreJobId: output.RestoreJobId !== undefined && output.RestoreJobId !== null ? output.RestoreJobId : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusMessage:
-      output.StatusMessage !== undefined && output.StatusMessage !== null ? output.StatusMessage : undefined,
+    ExpectedCompletionTimeMinutes: __expectNumber(output.ExpectedCompletionTimeMinutes),
+    IamRoleArn: __expectString(output.IamRoleArn),
+    PercentDone: __expectString(output.PercentDone),
+    RecoveryPointArn: __expectString(output.RecoveryPointArn),
+    ResourceType: __expectString(output.ResourceType),
+    RestoreJobId: __expectString(output.RestoreJobId),
+    Status: __expectString(output.Status),
+    StatusMessage: __expectString(output.StatusMessage),
   } as any;
 };
 
@@ -7441,7 +7347,7 @@ const deserializeAws_restJson1Tags = (output: any, context: __SerdeContext): { [
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };

--- a/clients/client-batch/protocols/Aws_restJson1.ts
+++ b/clients/client-batch/protocols/Aws_restJson1.ts
@@ -95,6 +95,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -764,10 +767,10 @@ export const deserializeAws_restJson1CreateComputeEnvironmentCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.computeEnvironmentArn !== undefined && data.computeEnvironmentArn !== null) {
-    contents.computeEnvironmentArn = data.computeEnvironmentArn;
+    contents.computeEnvironmentArn = __expectString(data.computeEnvironmentArn);
   }
   if (data.computeEnvironmentName !== undefined && data.computeEnvironmentName !== null) {
-    contents.computeEnvironmentName = data.computeEnvironmentName;
+    contents.computeEnvironmentName = __expectString(data.computeEnvironmentName);
   }
   return Promise.resolve(contents);
 };
@@ -831,10 +834,10 @@ export const deserializeAws_restJson1CreateJobQueueCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.jobQueueArn !== undefined && data.jobQueueArn !== null) {
-    contents.jobQueueArn = data.jobQueueArn;
+    contents.jobQueueArn = __expectString(data.jobQueueArn);
   }
   if (data.jobQueueName !== undefined && data.jobQueueName !== null) {
-    contents.jobQueueName = data.jobQueueName;
+    contents.jobQueueName = __expectString(data.jobQueueName);
   }
   return Promise.resolve(contents);
 };
@@ -1081,7 +1084,7 @@ export const deserializeAws_restJson1DescribeComputeEnvironmentsCommand = async 
     );
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1148,7 +1151,7 @@ export const deserializeAws_restJson1DescribeJobDefinitionsCommand = async (
     contents.jobDefinitions = deserializeAws_restJson1JobDefinitionList(data.jobDefinitions, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1215,7 +1218,7 @@ export const deserializeAws_restJson1DescribeJobQueuesCommand = async (
     contents.jobQueues = deserializeAws_restJson1JobQueueDetailList(data.jobQueues, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1345,7 +1348,7 @@ export const deserializeAws_restJson1ListJobsCommand = async (
     contents.jobSummaryList = deserializeAws_restJson1JobSummaryList(data.jobSummaryList, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1473,13 +1476,13 @@ export const deserializeAws_restJson1RegisterJobDefinitionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.jobDefinitionArn !== undefined && data.jobDefinitionArn !== null) {
-    contents.jobDefinitionArn = data.jobDefinitionArn;
+    contents.jobDefinitionArn = __expectString(data.jobDefinitionArn);
   }
   if (data.jobDefinitionName !== undefined && data.jobDefinitionName !== null) {
-    contents.jobDefinitionName = data.jobDefinitionName;
+    contents.jobDefinitionName = __expectString(data.jobDefinitionName);
   }
   if (data.revision !== undefined && data.revision !== null) {
-    contents.revision = data.revision;
+    contents.revision = __expectNumber(data.revision);
   }
   return Promise.resolve(contents);
 };
@@ -1544,13 +1547,13 @@ export const deserializeAws_restJson1SubmitJobCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.jobArn !== undefined && data.jobArn !== null) {
-    contents.jobArn = data.jobArn;
+    contents.jobArn = __expectString(data.jobArn);
   }
   if (data.jobId !== undefined && data.jobId !== null) {
-    contents.jobId = data.jobId;
+    contents.jobId = __expectString(data.jobId);
   }
   if (data.jobName !== undefined && data.jobName !== null) {
-    contents.jobName = data.jobName;
+    contents.jobName = __expectString(data.jobName);
   }
   return Promise.resolve(contents);
 };
@@ -1791,10 +1794,10 @@ export const deserializeAws_restJson1UpdateComputeEnvironmentCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.computeEnvironmentArn !== undefined && data.computeEnvironmentArn !== null) {
-    contents.computeEnvironmentArn = data.computeEnvironmentArn;
+    contents.computeEnvironmentArn = __expectString(data.computeEnvironmentArn);
   }
   if (data.computeEnvironmentName !== undefined && data.computeEnvironmentName !== null) {
-    contents.computeEnvironmentName = data.computeEnvironmentName;
+    contents.computeEnvironmentName = __expectString(data.computeEnvironmentName);
   }
   return Promise.resolve(contents);
 };
@@ -1858,10 +1861,10 @@ export const deserializeAws_restJson1UpdateJobQueueCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.jobQueueArn !== undefined && data.jobQueueArn !== null) {
-    contents.jobQueueArn = data.jobQueueArn;
+    contents.jobQueueArn = __expectString(data.jobQueueArn);
   }
   if (data.jobQueueName !== undefined && data.jobQueueName !== null) {
-    contents.jobQueueName = data.jobQueueName;
+    contents.jobQueueName = __expectString(data.jobQueueName);
   }
   return Promise.resolve(contents);
 };
@@ -1923,7 +1926,7 @@ const deserializeAws_restJson1ClientExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1940,7 +1943,7 @@ const deserializeAws_restJson1ServerExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2577,15 +2580,15 @@ const deserializeAws_restJson1ArrayJobStatusSummary = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectNumber(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1ArrayPropertiesDetail = (output: any, context: __SerdeContext): ArrayPropertiesDetail => {
   return {
-    index: output.index !== undefined && output.index !== null ? output.index : undefined,
-    size: output.size !== undefined && output.size !== null ? output.size : undefined,
+    index: __expectNumber(output.index),
+    size: __expectNumber(output.size),
     statusSummary:
       output.statusSummary !== undefined && output.statusSummary !== null
         ? deserializeAws_restJson1ArrayJobStatusSummary(output.statusSummary, context)
@@ -2598,8 +2601,8 @@ const deserializeAws_restJson1ArrayPropertiesSummary = (
   context: __SerdeContext
 ): ArrayPropertiesSummary => {
   return {
-    index: output.index !== undefined && output.index !== null ? output.index : undefined,
-    size: output.size !== undefined && output.size !== null ? output.size : undefined,
+    index: __expectNumber(output.index),
+    size: __expectNumber(output.size),
   } as any;
 };
 
@@ -2608,19 +2611,15 @@ const deserializeAws_restJson1AttemptContainerDetail = (
   context: __SerdeContext
 ): AttemptContainerDetail => {
   return {
-    containerInstanceArn:
-      output.containerInstanceArn !== undefined && output.containerInstanceArn !== null
-        ? output.containerInstanceArn
-        : undefined,
-    exitCode: output.exitCode !== undefined && output.exitCode !== null ? output.exitCode : undefined,
-    logStreamName:
-      output.logStreamName !== undefined && output.logStreamName !== null ? output.logStreamName : undefined,
+    containerInstanceArn: __expectString(output.containerInstanceArn),
+    exitCode: __expectNumber(output.exitCode),
+    logStreamName: __expectString(output.logStreamName),
     networkInterfaces:
       output.networkInterfaces !== undefined && output.networkInterfaces !== null
         ? deserializeAws_restJson1NetworkInterfaceList(output.networkInterfaces, context)
         : undefined,
-    reason: output.reason !== undefined && output.reason !== null ? output.reason : undefined,
-    taskArn: output.taskArn !== undefined && output.taskArn !== null ? output.taskArn : undefined,
+    reason: __expectString(output.reason),
+    taskArn: __expectString(output.taskArn),
   } as any;
 };
 
@@ -2630,9 +2629,9 @@ const deserializeAws_restJson1AttemptDetail = (output: any, context: __SerdeCont
       output.container !== undefined && output.container !== null
         ? deserializeAws_restJson1AttemptContainerDetail(output.container, context)
         : undefined,
-    startedAt: output.startedAt !== undefined && output.startedAt !== null ? output.startedAt : undefined,
-    statusReason: output.statusReason !== undefined && output.statusReason !== null ? output.statusReason : undefined,
-    stoppedAt: output.stoppedAt !== undefined && output.stoppedAt !== null ? output.stoppedAt : undefined,
+    startedAt: __expectNumber(output.startedAt),
+    statusReason: __expectString(output.statusReason),
+    stoppedAt: __expectNumber(output.stoppedAt),
   } as any;
 };
 
@@ -2652,29 +2651,22 @@ const deserializeAws_restJson1ComputeEnvironmentDetail = (
   context: __SerdeContext
 ): ComputeEnvironmentDetail => {
   return {
-    computeEnvironmentArn:
-      output.computeEnvironmentArn !== undefined && output.computeEnvironmentArn !== null
-        ? output.computeEnvironmentArn
-        : undefined,
-    computeEnvironmentName:
-      output.computeEnvironmentName !== undefined && output.computeEnvironmentName !== null
-        ? output.computeEnvironmentName
-        : undefined,
+    computeEnvironmentArn: __expectString(output.computeEnvironmentArn),
+    computeEnvironmentName: __expectString(output.computeEnvironmentName),
     computeResources:
       output.computeResources !== undefined && output.computeResources !== null
         ? deserializeAws_restJson1ComputeResource(output.computeResources, context)
         : undefined,
-    ecsClusterArn:
-      output.ecsClusterArn !== undefined && output.ecsClusterArn !== null ? output.ecsClusterArn : undefined,
-    serviceRole: output.serviceRole !== undefined && output.serviceRole !== null ? output.serviceRole : undefined,
-    state: output.state !== undefined && output.state !== null ? output.state : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    statusReason: output.statusReason !== undefined && output.statusReason !== null ? output.statusReason : undefined,
+    ecsClusterArn: __expectString(output.ecsClusterArn),
+    serviceRole: __expectString(output.serviceRole),
+    state: __expectString(output.state),
+    status: __expectString(output.status),
+    statusReason: __expectString(output.statusReason),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1TagrisTagsMap(output.tags, context)
         : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -2697,11 +2689,8 @@ const deserializeAws_restJson1ComputeEnvironmentOrder = (
   context: __SerdeContext
 ): ComputeEnvironmentOrder => {
   return {
-    computeEnvironment:
-      output.computeEnvironment !== undefined && output.computeEnvironment !== null
-        ? output.computeEnvironment
-        : undefined,
-    order: output.order !== undefined && output.order !== null ? output.order : undefined,
+    computeEnvironment: __expectString(output.computeEnvironment),
+    order: __expectNumber(output.order),
   } as any;
 };
 
@@ -2721,20 +2710,16 @@ const deserializeAws_restJson1ComputeEnvironmentOrders = (
 
 const deserializeAws_restJson1ComputeResource = (output: any, context: __SerdeContext): ComputeResource => {
   return {
-    allocationStrategy:
-      output.allocationStrategy !== undefined && output.allocationStrategy !== null
-        ? output.allocationStrategy
-        : undefined,
-    bidPercentage:
-      output.bidPercentage !== undefined && output.bidPercentage !== null ? output.bidPercentage : undefined,
-    desiredvCpus: output.desiredvCpus !== undefined && output.desiredvCpus !== null ? output.desiredvCpus : undefined,
+    allocationStrategy: __expectString(output.allocationStrategy),
+    bidPercentage: __expectNumber(output.bidPercentage),
+    desiredvCpus: __expectNumber(output.desiredvCpus),
     ec2Configuration:
       output.ec2Configuration !== undefined && output.ec2Configuration !== null
         ? deserializeAws_restJson1Ec2ConfigurationList(output.ec2Configuration, context)
         : undefined,
-    ec2KeyPair: output.ec2KeyPair !== undefined && output.ec2KeyPair !== null ? output.ec2KeyPair : undefined,
-    imageId: output.imageId !== undefined && output.imageId !== null ? output.imageId : undefined,
-    instanceRole: output.instanceRole !== undefined && output.instanceRole !== null ? output.instanceRole : undefined,
+    ec2KeyPair: __expectString(output.ec2KeyPair),
+    imageId: __expectString(output.imageId),
+    instanceRole: __expectString(output.instanceRole),
     instanceTypes:
       output.instanceTypes !== undefined && output.instanceTypes !== null
         ? deserializeAws_restJson1StringList(output.instanceTypes, context)
@@ -2743,16 +2728,14 @@ const deserializeAws_restJson1ComputeResource = (output: any, context: __SerdeCo
       output.launchTemplate !== undefined && output.launchTemplate !== null
         ? deserializeAws_restJson1LaunchTemplateSpecification(output.launchTemplate, context)
         : undefined,
-    maxvCpus: output.maxvCpus !== undefined && output.maxvCpus !== null ? output.maxvCpus : undefined,
-    minvCpus: output.minvCpus !== undefined && output.minvCpus !== null ? output.minvCpus : undefined,
-    placementGroup:
-      output.placementGroup !== undefined && output.placementGroup !== null ? output.placementGroup : undefined,
+    maxvCpus: __expectNumber(output.maxvCpus),
+    minvCpus: __expectNumber(output.minvCpus),
+    placementGroup: __expectString(output.placementGroup),
     securityGroupIds:
       output.securityGroupIds !== undefined && output.securityGroupIds !== null
         ? deserializeAws_restJson1StringList(output.securityGroupIds, context)
         : undefined,
-    spotIamFleetRole:
-      output.spotIamFleetRole !== undefined && output.spotIamFleetRole !== null ? output.spotIamFleetRole : undefined,
+    spotIamFleetRole: __expectString(output.spotIamFleetRole),
     subnets:
       output.subnets !== undefined && output.subnets !== null
         ? deserializeAws_restJson1StringList(output.subnets, context)
@@ -2761,7 +2744,7 @@ const deserializeAws_restJson1ComputeResource = (output: any, context: __SerdeCo
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1TagsMap(output.tags, context)
         : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -2771,24 +2754,20 @@ const deserializeAws_restJson1ContainerDetail = (output: any, context: __SerdeCo
       output.command !== undefined && output.command !== null
         ? deserializeAws_restJson1StringList(output.command, context)
         : undefined,
-    containerInstanceArn:
-      output.containerInstanceArn !== undefined && output.containerInstanceArn !== null
-        ? output.containerInstanceArn
-        : undefined,
+    containerInstanceArn: __expectString(output.containerInstanceArn),
     environment:
       output.environment !== undefined && output.environment !== null
         ? deserializeAws_restJson1EnvironmentVariables(output.environment, context)
         : undefined,
-    executionRoleArn:
-      output.executionRoleArn !== undefined && output.executionRoleArn !== null ? output.executionRoleArn : undefined,
-    exitCode: output.exitCode !== undefined && output.exitCode !== null ? output.exitCode : undefined,
+    executionRoleArn: __expectString(output.executionRoleArn),
+    exitCode: __expectNumber(output.exitCode),
     fargatePlatformConfiguration:
       output.fargatePlatformConfiguration !== undefined && output.fargatePlatformConfiguration !== null
         ? deserializeAws_restJson1FargatePlatformConfiguration(output.fargatePlatformConfiguration, context)
         : undefined,
-    image: output.image !== undefined && output.image !== null ? output.image : undefined,
-    instanceType: output.instanceType !== undefined && output.instanceType !== null ? output.instanceType : undefined,
-    jobRoleArn: output.jobRoleArn !== undefined && output.jobRoleArn !== null ? output.jobRoleArn : undefined,
+    image: __expectString(output.image),
+    instanceType: __expectString(output.instanceType),
+    jobRoleArn: __expectString(output.jobRoleArn),
     linuxParameters:
       output.linuxParameters !== undefined && output.linuxParameters !== null
         ? deserializeAws_restJson1LinuxParameters(output.linuxParameters, context)
@@ -2797,9 +2776,8 @@ const deserializeAws_restJson1ContainerDetail = (output: any, context: __SerdeCo
       output.logConfiguration !== undefined && output.logConfiguration !== null
         ? deserializeAws_restJson1LogConfiguration(output.logConfiguration, context)
         : undefined,
-    logStreamName:
-      output.logStreamName !== undefined && output.logStreamName !== null ? output.logStreamName : undefined,
-    memory: output.memory !== undefined && output.memory !== null ? output.memory : undefined,
+    logStreamName: __expectString(output.logStreamName),
+    memory: __expectNumber(output.memory),
     mountPoints:
       output.mountPoints !== undefined && output.mountPoints !== null
         ? deserializeAws_restJson1MountPoints(output.mountPoints, context)
@@ -2812,12 +2790,9 @@ const deserializeAws_restJson1ContainerDetail = (output: any, context: __SerdeCo
       output.networkInterfaces !== undefined && output.networkInterfaces !== null
         ? deserializeAws_restJson1NetworkInterfaceList(output.networkInterfaces, context)
         : undefined,
-    privileged: output.privileged !== undefined && output.privileged !== null ? output.privileged : undefined,
-    readonlyRootFilesystem:
-      output.readonlyRootFilesystem !== undefined && output.readonlyRootFilesystem !== null
-        ? output.readonlyRootFilesystem
-        : undefined,
-    reason: output.reason !== undefined && output.reason !== null ? output.reason : undefined,
+    privileged: __expectBoolean(output.privileged),
+    readonlyRootFilesystem: __expectBoolean(output.readonlyRootFilesystem),
+    reason: __expectString(output.reason),
     resourceRequirements:
       output.resourceRequirements !== undefined && output.resourceRequirements !== null
         ? deserializeAws_restJson1ResourceRequirements(output.resourceRequirements, context)
@@ -2826,13 +2801,13 @@ const deserializeAws_restJson1ContainerDetail = (output: any, context: __SerdeCo
       output.secrets !== undefined && output.secrets !== null
         ? deserializeAws_restJson1SecretList(output.secrets, context)
         : undefined,
-    taskArn: output.taskArn !== undefined && output.taskArn !== null ? output.taskArn : undefined,
+    taskArn: __expectString(output.taskArn),
     ulimits:
       output.ulimits !== undefined && output.ulimits !== null
         ? deserializeAws_restJson1Ulimits(output.ulimits, context)
         : undefined,
-    user: output.user !== undefined && output.user !== null ? output.user : undefined,
-    vcpus: output.vcpus !== undefined && output.vcpus !== null ? output.vcpus : undefined,
+    user: __expectString(output.user),
+    vcpus: __expectNumber(output.vcpus),
     volumes:
       output.volumes !== undefined && output.volumes !== null
         ? deserializeAws_restJson1Volumes(output.volumes, context)
@@ -2850,15 +2825,14 @@ const deserializeAws_restJson1ContainerProperties = (output: any, context: __Ser
       output.environment !== undefined && output.environment !== null
         ? deserializeAws_restJson1EnvironmentVariables(output.environment, context)
         : undefined,
-    executionRoleArn:
-      output.executionRoleArn !== undefined && output.executionRoleArn !== null ? output.executionRoleArn : undefined,
+    executionRoleArn: __expectString(output.executionRoleArn),
     fargatePlatformConfiguration:
       output.fargatePlatformConfiguration !== undefined && output.fargatePlatformConfiguration !== null
         ? deserializeAws_restJson1FargatePlatformConfiguration(output.fargatePlatformConfiguration, context)
         : undefined,
-    image: output.image !== undefined && output.image !== null ? output.image : undefined,
-    instanceType: output.instanceType !== undefined && output.instanceType !== null ? output.instanceType : undefined,
-    jobRoleArn: output.jobRoleArn !== undefined && output.jobRoleArn !== null ? output.jobRoleArn : undefined,
+    image: __expectString(output.image),
+    instanceType: __expectString(output.instanceType),
+    jobRoleArn: __expectString(output.jobRoleArn),
     linuxParameters:
       output.linuxParameters !== undefined && output.linuxParameters !== null
         ? deserializeAws_restJson1LinuxParameters(output.linuxParameters, context)
@@ -2867,7 +2841,7 @@ const deserializeAws_restJson1ContainerProperties = (output: any, context: __Ser
       output.logConfiguration !== undefined && output.logConfiguration !== null
         ? deserializeAws_restJson1LogConfiguration(output.logConfiguration, context)
         : undefined,
-    memory: output.memory !== undefined && output.memory !== null ? output.memory : undefined,
+    memory: __expectNumber(output.memory),
     mountPoints:
       output.mountPoints !== undefined && output.mountPoints !== null
         ? deserializeAws_restJson1MountPoints(output.mountPoints, context)
@@ -2876,11 +2850,8 @@ const deserializeAws_restJson1ContainerProperties = (output: any, context: __Ser
       output.networkConfiguration !== undefined && output.networkConfiguration !== null
         ? deserializeAws_restJson1NetworkConfiguration(output.networkConfiguration, context)
         : undefined,
-    privileged: output.privileged !== undefined && output.privileged !== null ? output.privileged : undefined,
-    readonlyRootFilesystem:
-      output.readonlyRootFilesystem !== undefined && output.readonlyRootFilesystem !== null
-        ? output.readonlyRootFilesystem
-        : undefined,
+    privileged: __expectBoolean(output.privileged),
+    readonlyRootFilesystem: __expectBoolean(output.readonlyRootFilesystem),
     resourceRequirements:
       output.resourceRequirements !== undefined && output.resourceRequirements !== null
         ? deserializeAws_restJson1ResourceRequirements(output.resourceRequirements, context)
@@ -2893,8 +2864,8 @@ const deserializeAws_restJson1ContainerProperties = (output: any, context: __Ser
       output.ulimits !== undefined && output.ulimits !== null
         ? deserializeAws_restJson1Ulimits(output.ulimits, context)
         : undefined,
-    user: output.user !== undefined && output.user !== null ? output.user : undefined,
-    vcpus: output.vcpus !== undefined && output.vcpus !== null ? output.vcpus : undefined,
+    user: __expectString(output.user),
+    vcpus: __expectNumber(output.vcpus),
     volumes:
       output.volumes !== undefined && output.volumes !== null
         ? deserializeAws_restJson1Volumes(output.volumes, context)
@@ -2904,16 +2875,15 @@ const deserializeAws_restJson1ContainerProperties = (output: any, context: __Ser
 
 const deserializeAws_restJson1ContainerSummary = (output: any, context: __SerdeContext): ContainerSummary => {
   return {
-    exitCode: output.exitCode !== undefined && output.exitCode !== null ? output.exitCode : undefined,
-    reason: output.reason !== undefined && output.reason !== null ? output.reason : undefined,
+    exitCode: __expectNumber(output.exitCode),
+    reason: __expectString(output.reason),
   } as any;
 };
 
 const deserializeAws_restJson1Device = (output: any, context: __SerdeContext): Device => {
   return {
-    containerPath:
-      output.containerPath !== undefined && output.containerPath !== null ? output.containerPath : undefined,
-    hostPath: output.hostPath !== undefined && output.hostPath !== null ? output.hostPath : undefined,
+    containerPath: __expectString(output.containerPath),
+    hostPath: __expectString(output.hostPath),
     permissions:
       output.permissions !== undefined && output.permissions !== null
         ? deserializeAws_restJson1DeviceCgroupPermissions(output.permissions, context)
@@ -2931,7 +2901,7 @@ const deserializeAws_restJson1DeviceCgroupPermissions = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2948,9 +2918,8 @@ const deserializeAws_restJson1DevicesList = (output: any, context: __SerdeContex
 
 const deserializeAws_restJson1Ec2Configuration = (output: any, context: __SerdeContext): Ec2Configuration => {
   return {
-    imageIdOverride:
-      output.imageIdOverride !== undefined && output.imageIdOverride !== null ? output.imageIdOverride : undefined,
-    imageType: output.imageType !== undefined && output.imageType !== null ? output.imageType : undefined,
+    imageIdOverride: __expectString(output.imageIdOverride),
+    imageType: __expectString(output.imageType),
   } as any;
 };
 
@@ -2970,9 +2939,8 @@ const deserializeAws_restJson1EFSAuthorizationConfig = (
   context: __SerdeContext
 ): EFSAuthorizationConfig => {
   return {
-    accessPointId:
-      output.accessPointId !== undefined && output.accessPointId !== null ? output.accessPointId : undefined,
-    iam: output.iam !== undefined && output.iam !== null ? output.iam : undefined,
+    accessPointId: __expectString(output.accessPointId),
+    iam: __expectString(output.iam),
   } as any;
 };
 
@@ -2985,17 +2953,10 @@ const deserializeAws_restJson1EFSVolumeConfiguration = (
       output.authorizationConfig !== undefined && output.authorizationConfig !== null
         ? deserializeAws_restJson1EFSAuthorizationConfig(output.authorizationConfig, context)
         : undefined,
-    fileSystemId: output.fileSystemId !== undefined && output.fileSystemId !== null ? output.fileSystemId : undefined,
-    rootDirectory:
-      output.rootDirectory !== undefined && output.rootDirectory !== null ? output.rootDirectory : undefined,
-    transitEncryption:
-      output.transitEncryption !== undefined && output.transitEncryption !== null
-        ? output.transitEncryption
-        : undefined,
-    transitEncryptionPort:
-      output.transitEncryptionPort !== undefined && output.transitEncryptionPort !== null
-        ? output.transitEncryptionPort
-        : undefined,
+    fileSystemId: __expectString(output.fileSystemId),
+    rootDirectory: __expectString(output.rootDirectory),
+    transitEncryption: __expectString(output.transitEncryption),
+    transitEncryptionPort: __expectNumber(output.transitEncryptionPort),
   } as any;
 };
 
@@ -3012,11 +2973,10 @@ const deserializeAws_restJson1EnvironmentVariables = (output: any, context: __Se
 
 const deserializeAws_restJson1EvaluateOnExit = (output: any, context: __SerdeContext): EvaluateOnExit => {
   return {
-    action: output.action !== undefined && output.action !== null ? output.action : undefined,
-    onExitCode: output.onExitCode !== undefined && output.onExitCode !== null ? output.onExitCode : undefined,
-    onReason: output.onReason !== undefined && output.onReason !== null ? output.onReason : undefined,
-    onStatusReason:
-      output.onStatusReason !== undefined && output.onStatusReason !== null ? output.onStatusReason : undefined,
+    action: __expectString(output.action),
+    onExitCode: __expectString(output.onExitCode),
+    onReason: __expectString(output.onReason),
+    onStatusReason: __expectString(output.onStatusReason),
   } as any;
 };
 
@@ -3036,14 +2996,13 @@ const deserializeAws_restJson1FargatePlatformConfiguration = (
   context: __SerdeContext
 ): FargatePlatformConfiguration => {
   return {
-    platformVersion:
-      output.platformVersion !== undefined && output.platformVersion !== null ? output.platformVersion : undefined,
+    platformVersion: __expectString(output.platformVersion),
   } as any;
 };
 
 const deserializeAws_restJson1Host = (output: any, context: __SerdeContext): Host => {
   return {
-    sourcePath: output.sourcePath !== undefined && output.sourcePath !== null ? output.sourcePath : undefined,
+    sourcePath: __expectString(output.sourcePath),
   } as any;
 };
 
@@ -3053,12 +3012,8 @@ const deserializeAws_restJson1JobDefinition = (output: any, context: __SerdeCont
       output.containerProperties !== undefined && output.containerProperties !== null
         ? deserializeAws_restJson1ContainerProperties(output.containerProperties, context)
         : undefined,
-    jobDefinitionArn:
-      output.jobDefinitionArn !== undefined && output.jobDefinitionArn !== null ? output.jobDefinitionArn : undefined,
-    jobDefinitionName:
-      output.jobDefinitionName !== undefined && output.jobDefinitionName !== null
-        ? output.jobDefinitionName
-        : undefined,
+    jobDefinitionArn: __expectString(output.jobDefinitionArn),
+    jobDefinitionName: __expectString(output.jobDefinitionName),
     nodeProperties:
       output.nodeProperties !== undefined && output.nodeProperties !== null
         ? deserializeAws_restJson1NodeProperties(output.nodeProperties, context)
@@ -3071,14 +3026,13 @@ const deserializeAws_restJson1JobDefinition = (output: any, context: __SerdeCont
       output.platformCapabilities !== undefined && output.platformCapabilities !== null
         ? deserializeAws_restJson1PlatformCapabilityList(output.platformCapabilities, context)
         : undefined,
-    propagateTags:
-      output.propagateTags !== undefined && output.propagateTags !== null ? output.propagateTags : undefined,
+    propagateTags: __expectBoolean(output.propagateTags),
     retryStrategy:
       output.retryStrategy !== undefined && output.retryStrategy !== null
         ? deserializeAws_restJson1RetryStrategy(output.retryStrategy, context)
         : undefined,
-    revision: output.revision !== undefined && output.revision !== null ? output.revision : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    revision: __expectNumber(output.revision),
+    status: __expectString(output.status),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1TagrisTagsMap(output.tags, context)
@@ -3087,7 +3041,7 @@ const deserializeAws_restJson1JobDefinition = (output: any, context: __SerdeCont
       output.timeout !== undefined && output.timeout !== null
         ? deserializeAws_restJson1JobTimeout(output.timeout, context)
         : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -3104,8 +3058,8 @@ const deserializeAws_restJson1JobDefinitionList = (output: any, context: __Serde
 
 const deserializeAws_restJson1JobDependency = (output: any, context: __SerdeContext): JobDependency => {
   return {
-    jobId: output.jobId !== undefined && output.jobId !== null ? output.jobId : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    jobId: __expectString(output.jobId),
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -3134,17 +3088,16 @@ const deserializeAws_restJson1JobDetail = (output: any, context: __SerdeContext)
       output.container !== undefined && output.container !== null
         ? deserializeAws_restJson1ContainerDetail(output.container, context)
         : undefined,
-    createdAt: output.createdAt !== undefined && output.createdAt !== null ? output.createdAt : undefined,
+    createdAt: __expectNumber(output.createdAt),
     dependsOn:
       output.dependsOn !== undefined && output.dependsOn !== null
         ? deserializeAws_restJson1JobDependencyList(output.dependsOn, context)
         : undefined,
-    jobArn: output.jobArn !== undefined && output.jobArn !== null ? output.jobArn : undefined,
-    jobDefinition:
-      output.jobDefinition !== undefined && output.jobDefinition !== null ? output.jobDefinition : undefined,
-    jobId: output.jobId !== undefined && output.jobId !== null ? output.jobId : undefined,
-    jobName: output.jobName !== undefined && output.jobName !== null ? output.jobName : undefined,
-    jobQueue: output.jobQueue !== undefined && output.jobQueue !== null ? output.jobQueue : undefined,
+    jobArn: __expectString(output.jobArn),
+    jobDefinition: __expectString(output.jobDefinition),
+    jobId: __expectString(output.jobId),
+    jobName: __expectString(output.jobName),
+    jobQueue: __expectString(output.jobQueue),
     nodeDetails:
       output.nodeDetails !== undefined && output.nodeDetails !== null
         ? deserializeAws_restJson1NodeDetails(output.nodeDetails, context)
@@ -3161,16 +3114,15 @@ const deserializeAws_restJson1JobDetail = (output: any, context: __SerdeContext)
       output.platformCapabilities !== undefined && output.platformCapabilities !== null
         ? deserializeAws_restJson1PlatformCapabilityList(output.platformCapabilities, context)
         : undefined,
-    propagateTags:
-      output.propagateTags !== undefined && output.propagateTags !== null ? output.propagateTags : undefined,
+    propagateTags: __expectBoolean(output.propagateTags),
     retryStrategy:
       output.retryStrategy !== undefined && output.retryStrategy !== null
         ? deserializeAws_restJson1RetryStrategy(output.retryStrategy, context)
         : undefined,
-    startedAt: output.startedAt !== undefined && output.startedAt !== null ? output.startedAt : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    statusReason: output.statusReason !== undefined && output.statusReason !== null ? output.statusReason : undefined,
-    stoppedAt: output.stoppedAt !== undefined && output.stoppedAt !== null ? output.stoppedAt : undefined,
+    startedAt: __expectNumber(output.startedAt),
+    status: __expectString(output.status),
+    statusReason: __expectString(output.statusReason),
+    stoppedAt: __expectNumber(output.stoppedAt),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1TagrisTagsMap(output.tags, context)
@@ -3199,12 +3151,12 @@ const deserializeAws_restJson1JobQueueDetail = (output: any, context: __SerdeCon
       output.computeEnvironmentOrder !== undefined && output.computeEnvironmentOrder !== null
         ? deserializeAws_restJson1ComputeEnvironmentOrders(output.computeEnvironmentOrder, context)
         : undefined,
-    jobQueueArn: output.jobQueueArn !== undefined && output.jobQueueArn !== null ? output.jobQueueArn : undefined,
-    jobQueueName: output.jobQueueName !== undefined && output.jobQueueName !== null ? output.jobQueueName : undefined,
-    priority: output.priority !== undefined && output.priority !== null ? output.priority : undefined,
-    state: output.state !== undefined && output.state !== null ? output.state : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    statusReason: output.statusReason !== undefined && output.statusReason !== null ? output.statusReason : undefined,
+    jobQueueArn: __expectString(output.jobQueueArn),
+    jobQueueName: __expectString(output.jobQueueName),
+    priority: __expectNumber(output.priority),
+    state: __expectString(output.state),
+    status: __expectString(output.status),
+    statusReason: __expectString(output.statusReason),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1TagrisTagsMap(output.tags, context)
@@ -3233,18 +3185,18 @@ const deserializeAws_restJson1JobSummary = (output: any, context: __SerdeContext
       output.container !== undefined && output.container !== null
         ? deserializeAws_restJson1ContainerSummary(output.container, context)
         : undefined,
-    createdAt: output.createdAt !== undefined && output.createdAt !== null ? output.createdAt : undefined,
-    jobArn: output.jobArn !== undefined && output.jobArn !== null ? output.jobArn : undefined,
-    jobId: output.jobId !== undefined && output.jobId !== null ? output.jobId : undefined,
-    jobName: output.jobName !== undefined && output.jobName !== null ? output.jobName : undefined,
+    createdAt: __expectNumber(output.createdAt),
+    jobArn: __expectString(output.jobArn),
+    jobId: __expectString(output.jobId),
+    jobName: __expectString(output.jobName),
     nodeProperties:
       output.nodeProperties !== undefined && output.nodeProperties !== null
         ? deserializeAws_restJson1NodePropertiesSummary(output.nodeProperties, context)
         : undefined,
-    startedAt: output.startedAt !== undefined && output.startedAt !== null ? output.startedAt : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    statusReason: output.statusReason !== undefined && output.statusReason !== null ? output.statusReason : undefined,
-    stoppedAt: output.stoppedAt !== undefined && output.stoppedAt !== null ? output.stoppedAt : undefined,
+    startedAt: __expectNumber(output.startedAt),
+    status: __expectString(output.status),
+    statusReason: __expectString(output.statusReason),
+    stoppedAt: __expectNumber(output.stoppedAt),
   } as any;
 };
 
@@ -3261,17 +3213,14 @@ const deserializeAws_restJson1JobSummaryList = (output: any, context: __SerdeCon
 
 const deserializeAws_restJson1JobTimeout = (output: any, context: __SerdeContext): JobTimeout => {
   return {
-    attemptDurationSeconds:
-      output.attemptDurationSeconds !== undefined && output.attemptDurationSeconds !== null
-        ? output.attemptDurationSeconds
-        : undefined,
+    attemptDurationSeconds: __expectNumber(output.attemptDurationSeconds),
   } as any;
 };
 
 const deserializeAws_restJson1KeyValuePair = (output: any, context: __SerdeContext): KeyValuePair => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    name: __expectString(output.name),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -3280,13 +3229,9 @@ const deserializeAws_restJson1LaunchTemplateSpecification = (
   context: __SerdeContext
 ): LaunchTemplateSpecification => {
   return {
-    launchTemplateId:
-      output.launchTemplateId !== undefined && output.launchTemplateId !== null ? output.launchTemplateId : undefined,
-    launchTemplateName:
-      output.launchTemplateName !== undefined && output.launchTemplateName !== null
-        ? output.launchTemplateName
-        : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    launchTemplateId: __expectString(output.launchTemplateId),
+    launchTemplateName: __expectString(output.launchTemplateName),
+    version: __expectString(output.version),
   } as any;
 };
 
@@ -3296,14 +3241,10 @@ const deserializeAws_restJson1LinuxParameters = (output: any, context: __SerdeCo
       output.devices !== undefined && output.devices !== null
         ? deserializeAws_restJson1DevicesList(output.devices, context)
         : undefined,
-    initProcessEnabled:
-      output.initProcessEnabled !== undefined && output.initProcessEnabled !== null
-        ? output.initProcessEnabled
-        : undefined,
-    maxSwap: output.maxSwap !== undefined && output.maxSwap !== null ? output.maxSwap : undefined,
-    sharedMemorySize:
-      output.sharedMemorySize !== undefined && output.sharedMemorySize !== null ? output.sharedMemorySize : undefined,
-    swappiness: output.swappiness !== undefined && output.swappiness !== null ? output.swappiness : undefined,
+    initProcessEnabled: __expectBoolean(output.initProcessEnabled),
+    maxSwap: __expectNumber(output.maxSwap),
+    sharedMemorySize: __expectNumber(output.sharedMemorySize),
+    swappiness: __expectNumber(output.swappiness),
     tmpfs:
       output.tmpfs !== undefined && output.tmpfs !== null
         ? deserializeAws_restJson1TmpfsList(output.tmpfs, context)
@@ -3313,7 +3254,7 @@ const deserializeAws_restJson1LinuxParameters = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1LogConfiguration = (output: any, context: __SerdeContext): LogConfiguration => {
   return {
-    logDriver: output.logDriver !== undefined && output.logDriver !== null ? output.logDriver : undefined,
+    logDriver: __expectString(output.logDriver),
     options:
       output.options !== undefined && output.options !== null
         ? deserializeAws_restJson1LogConfigurationOptionsMap(output.options, context)
@@ -3335,17 +3276,16 @@ const deserializeAws_restJson1LogConfigurationOptionsMap = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1MountPoint = (output: any, context: __SerdeContext): MountPoint => {
   return {
-    containerPath:
-      output.containerPath !== undefined && output.containerPath !== null ? output.containerPath : undefined,
-    readOnly: output.readOnly !== undefined && output.readOnly !== null ? output.readOnly : undefined,
-    sourceVolume: output.sourceVolume !== undefined && output.sourceVolume !== null ? output.sourceVolume : undefined,
+    containerPath: __expectString(output.containerPath),
+    readOnly: __expectBoolean(output.readOnly),
+    sourceVolume: __expectString(output.sourceVolume),
   } as any;
 };
 
@@ -3362,19 +3302,15 @@ const deserializeAws_restJson1MountPoints = (output: any, context: __SerdeContex
 
 const deserializeAws_restJson1NetworkConfiguration = (output: any, context: __SerdeContext): NetworkConfiguration => {
   return {
-    assignPublicIp:
-      output.assignPublicIp !== undefined && output.assignPublicIp !== null ? output.assignPublicIp : undefined,
+    assignPublicIp: __expectString(output.assignPublicIp),
   } as any;
 };
 
 const deserializeAws_restJson1NetworkInterface = (output: any, context: __SerdeContext): NetworkInterface => {
   return {
-    attachmentId: output.attachmentId !== undefined && output.attachmentId !== null ? output.attachmentId : undefined,
-    ipv6Address: output.ipv6Address !== undefined && output.ipv6Address !== null ? output.ipv6Address : undefined,
-    privateIpv4Address:
-      output.privateIpv4Address !== undefined && output.privateIpv4Address !== null
-        ? output.privateIpv4Address
-        : undefined,
+    attachmentId: __expectString(output.attachmentId),
+    ipv6Address: __expectString(output.ipv6Address),
+    privateIpv4Address: __expectString(output.privateIpv4Address),
   } as any;
 };
 
@@ -3391,27 +3327,27 @@ const deserializeAws_restJson1NetworkInterfaceList = (output: any, context: __Se
 
 const deserializeAws_restJson1NodeDetails = (output: any, context: __SerdeContext): NodeDetails => {
   return {
-    isMainNode: output.isMainNode !== undefined && output.isMainNode !== null ? output.isMainNode : undefined,
-    nodeIndex: output.nodeIndex !== undefined && output.nodeIndex !== null ? output.nodeIndex : undefined,
+    isMainNode: __expectBoolean(output.isMainNode),
+    nodeIndex: __expectNumber(output.nodeIndex),
   } as any;
 };
 
 const deserializeAws_restJson1NodeProperties = (output: any, context: __SerdeContext): NodeProperties => {
   return {
-    mainNode: output.mainNode !== undefined && output.mainNode !== null ? output.mainNode : undefined,
+    mainNode: __expectNumber(output.mainNode),
     nodeRangeProperties:
       output.nodeRangeProperties !== undefined && output.nodeRangeProperties !== null
         ? deserializeAws_restJson1NodeRangeProperties(output.nodeRangeProperties, context)
         : undefined,
-    numNodes: output.numNodes !== undefined && output.numNodes !== null ? output.numNodes : undefined,
+    numNodes: __expectNumber(output.numNodes),
   } as any;
 };
 
 const deserializeAws_restJson1NodePropertiesSummary = (output: any, context: __SerdeContext): NodePropertiesSummary => {
   return {
-    isMainNode: output.isMainNode !== undefined && output.isMainNode !== null ? output.isMainNode : undefined,
-    nodeIndex: output.nodeIndex !== undefined && output.nodeIndex !== null ? output.nodeIndex : undefined,
-    numNodes: output.numNodes !== undefined && output.numNodes !== null ? output.numNodes : undefined,
+    isMainNode: __expectBoolean(output.isMainNode),
+    nodeIndex: __expectNumber(output.nodeIndex),
+    numNodes: __expectNumber(output.numNodes),
   } as any;
 };
 
@@ -3432,7 +3368,7 @@ const deserializeAws_restJson1NodeRangeProperty = (output: any, context: __Serde
       output.container !== undefined && output.container !== null
         ? deserializeAws_restJson1ContainerProperties(output.container, context)
         : undefined,
-    targetNodes: output.targetNodes !== undefined && output.targetNodes !== null ? output.targetNodes : undefined,
+    targetNodes: __expectString(output.targetNodes),
   } as any;
 };
 
@@ -3443,7 +3379,7 @@ const deserializeAws_restJson1ParametersMap = (output: any, context: __SerdeCont
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -3458,14 +3394,14 @@ const deserializeAws_restJson1PlatformCapabilityList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1ResourceRequirement = (output: any, context: __SerdeContext): ResourceRequirement => {
   return {
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    type: __expectString(output.type),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -3482,7 +3418,7 @@ const deserializeAws_restJson1ResourceRequirements = (output: any, context: __Se
 
 const deserializeAws_restJson1RetryStrategy = (output: any, context: __SerdeContext): RetryStrategy => {
   return {
-    attempts: output.attempts !== undefined && output.attempts !== null ? output.attempts : undefined,
+    attempts: __expectNumber(output.attempts),
     evaluateOnExit:
       output.evaluateOnExit !== undefined && output.evaluateOnExit !== null
         ? deserializeAws_restJson1EvaluateOnExitList(output.evaluateOnExit, context)
@@ -3492,8 +3428,8 @@ const deserializeAws_restJson1RetryStrategy = (output: any, context: __SerdeCont
 
 const deserializeAws_restJson1Secret = (output: any, context: __SerdeContext): Secret => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    valueFrom: output.valueFrom !== undefined && output.valueFrom !== null ? output.valueFrom : undefined,
+    name: __expectString(output.name),
+    valueFrom: __expectString(output.valueFrom),
   } as any;
 };
 
@@ -3515,7 +3451,7 @@ const deserializeAws_restJson1StringList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3526,7 +3462,7 @@ const deserializeAws_restJson1TagrisTagsMap = (output: any, context: __SerdeCont
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -3538,20 +3474,19 @@ const deserializeAws_restJson1TagsMap = (output: any, context: __SerdeContext): 
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1Tmpfs = (output: any, context: __SerdeContext): Tmpfs => {
   return {
-    containerPath:
-      output.containerPath !== undefined && output.containerPath !== null ? output.containerPath : undefined,
+    containerPath: __expectString(output.containerPath),
     mountOptions:
       output.mountOptions !== undefined && output.mountOptions !== null
         ? deserializeAws_restJson1StringList(output.mountOptions, context)
         : undefined,
-    size: output.size !== undefined && output.size !== null ? output.size : undefined,
+    size: __expectNumber(output.size),
   } as any;
 };
 
@@ -3568,9 +3503,9 @@ const deserializeAws_restJson1TmpfsList = (output: any, context: __SerdeContext)
 
 const deserializeAws_restJson1Ulimit = (output: any, context: __SerdeContext): Ulimit => {
   return {
-    hardLimit: output.hardLimit !== undefined && output.hardLimit !== null ? output.hardLimit : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    softLimit: output.softLimit !== undefined && output.softLimit !== null ? output.softLimit : undefined,
+    hardLimit: __expectNumber(output.hardLimit),
+    name: __expectString(output.name),
+    softLimit: __expectNumber(output.softLimit),
   } as any;
 };
 
@@ -3595,7 +3530,7 @@ const deserializeAws_restJson1Volume = (output: any, context: __SerdeContext): V
       output.host !== undefined && output.host !== null
         ? deserializeAws_restJson1Host(output.host, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
   } as any;
 };
 

--- a/clients/client-braket/protocols/Aws_restJson1.ts
+++ b/clients/client-braket/protocols/Aws_restJson1.ts
@@ -29,6 +29,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   LazyJsonString as __LazyJsonString,
   SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -327,10 +329,10 @@ export const deserializeAws_restJson1CancelQuantumTaskCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.cancellationStatus !== undefined && data.cancellationStatus !== null) {
-    contents.cancellationStatus = data.cancellationStatus;
+    contents.cancellationStatus = __expectString(data.cancellationStatus);
   }
   if (data.quantumTaskArn !== undefined && data.quantumTaskArn !== null) {
-    contents.quantumTaskArn = data.quantumTaskArn;
+    contents.quantumTaskArn = __expectString(data.quantumTaskArn);
   }
   return Promise.resolve(contents);
 };
@@ -425,7 +427,7 @@ export const deserializeAws_restJson1CreateQuantumTaskCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.quantumTaskArn !== undefined && data.quantumTaskArn !== null) {
-    contents.quantumTaskArn = data.quantumTaskArn;
+    contents.quantumTaskArn = __expectString(data.quantumTaskArn);
   }
   return Promise.resolve(contents);
 };
@@ -525,22 +527,22 @@ export const deserializeAws_restJson1GetDeviceCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.deviceArn !== undefined && data.deviceArn !== null) {
-    contents.deviceArn = data.deviceArn;
+    contents.deviceArn = __expectString(data.deviceArn);
   }
   if (data.deviceCapabilities !== undefined && data.deviceCapabilities !== null) {
     contents.deviceCapabilities = new __LazyJsonString(data.deviceCapabilities);
   }
   if (data.deviceName !== undefined && data.deviceName !== null) {
-    contents.deviceName = data.deviceName;
+    contents.deviceName = __expectString(data.deviceName);
   }
   if (data.deviceStatus !== undefined && data.deviceStatus !== null) {
-    contents.deviceStatus = data.deviceStatus;
+    contents.deviceStatus = __expectString(data.deviceStatus);
   }
   if (data.deviceType !== undefined && data.deviceType !== null) {
-    contents.deviceType = data.deviceType;
+    contents.deviceType = __expectString(data.deviceType);
   }
   if (data.providerName !== undefined && data.providerName !== null) {
-    contents.providerName = data.providerName;
+    contents.providerName = __expectString(data.providerName);
   }
   return Promise.resolve(contents);
 };
@@ -656,7 +658,7 @@ export const deserializeAws_restJson1GetQuantumTaskCommand = async (
     contents.createdAt = new Date(Math.round(data.createdAt * 1000));
   }
   if (data.deviceArn !== undefined && data.deviceArn !== null) {
-    contents.deviceArn = data.deviceArn;
+    contents.deviceArn = __expectString(data.deviceArn);
   }
   if (data.deviceParameters !== undefined && data.deviceParameters !== null) {
     contents.deviceParameters = new __LazyJsonString(data.deviceParameters);
@@ -665,22 +667,22 @@ export const deserializeAws_restJson1GetQuantumTaskCommand = async (
     contents.endedAt = new Date(Math.round(data.endedAt * 1000));
   }
   if (data.failureReason !== undefined && data.failureReason !== null) {
-    contents.failureReason = data.failureReason;
+    contents.failureReason = __expectString(data.failureReason);
   }
   if (data.outputS3Bucket !== undefined && data.outputS3Bucket !== null) {
-    contents.outputS3Bucket = data.outputS3Bucket;
+    contents.outputS3Bucket = __expectString(data.outputS3Bucket);
   }
   if (data.outputS3Directory !== undefined && data.outputS3Directory !== null) {
-    contents.outputS3Directory = data.outputS3Directory;
+    contents.outputS3Directory = __expectString(data.outputS3Directory);
   }
   if (data.quantumTaskArn !== undefined && data.quantumTaskArn !== null) {
-    contents.quantumTaskArn = data.quantumTaskArn;
+    contents.quantumTaskArn = __expectString(data.quantumTaskArn);
   }
   if (data.shots !== undefined && data.shots !== null) {
-    contents.shots = data.shots;
+    contents.shots = __expectNumber(data.shots);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.status = data.status;
+    contents.status = __expectString(data.status);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagsMap(data.tags, context);
@@ -845,7 +847,7 @@ export const deserializeAws_restJson1SearchDevicesCommand = async (
     contents.devices = deserializeAws_restJson1DeviceSummaryList(data.devices, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -925,7 +927,7 @@ export const deserializeAws_restJson1SearchQuantumTasksCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.quantumTasks !== undefined && data.quantumTasks !== null) {
     contents.quantumTasks = deserializeAws_restJson1QuantumTaskSummaryList(data.quantumTasks, context);
@@ -1140,7 +1142,7 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1157,7 +1159,7 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1174,7 +1176,7 @@ const deserializeAws_restJson1DeviceOfflineExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1191,7 +1193,7 @@ const deserializeAws_restJson1DeviceRetiredExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1208,7 +1210,7 @@ const deserializeAws_restJson1InternalServiceExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1225,7 +1227,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1242,7 +1244,7 @@ const deserializeAws_restJson1ServiceQuotaExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1259,7 +1261,7 @@ const deserializeAws_restJson1ThrottlingExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1276,7 +1278,7 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1351,11 +1353,11 @@ const serializeAws_restJson1TagsMap = (input: { [key: string]: string }, context
 
 const deserializeAws_restJson1DeviceSummary = (output: any, context: __SerdeContext): DeviceSummary => {
   return {
-    deviceArn: output.deviceArn !== undefined && output.deviceArn !== null ? output.deviceArn : undefined,
-    deviceName: output.deviceName !== undefined && output.deviceName !== null ? output.deviceName : undefined,
-    deviceStatus: output.deviceStatus !== undefined && output.deviceStatus !== null ? output.deviceStatus : undefined,
-    deviceType: output.deviceType !== undefined && output.deviceType !== null ? output.deviceType : undefined,
-    providerName: output.providerName !== undefined && output.providerName !== null ? output.providerName : undefined,
+    deviceArn: __expectString(output.deviceArn),
+    deviceName: __expectString(output.deviceName),
+    deviceStatus: __expectString(output.deviceStatus),
+    deviceType: __expectString(output.deviceType),
+    providerName: __expectString(output.providerName),
   } as any;
 };
 
@@ -1376,19 +1378,14 @@ const deserializeAws_restJson1QuantumTaskSummary = (output: any, context: __Serd
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    deviceArn: output.deviceArn !== undefined && output.deviceArn !== null ? output.deviceArn : undefined,
+    deviceArn: __expectString(output.deviceArn),
     endedAt:
       output.endedAt !== undefined && output.endedAt !== null ? new Date(Math.round(output.endedAt * 1000)) : undefined,
-    outputS3Bucket:
-      output.outputS3Bucket !== undefined && output.outputS3Bucket !== null ? output.outputS3Bucket : undefined,
-    outputS3Directory:
-      output.outputS3Directory !== undefined && output.outputS3Directory !== null
-        ? output.outputS3Directory
-        : undefined,
-    quantumTaskArn:
-      output.quantumTaskArn !== undefined && output.quantumTaskArn !== null ? output.quantumTaskArn : undefined,
-    shots: output.shots !== undefined && output.shots !== null ? output.shots : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    outputS3Bucket: __expectString(output.outputS3Bucket),
+    outputS3Directory: __expectString(output.outputS3Directory),
+    quantumTaskArn: __expectString(output.quantumTaskArn),
+    shots: __expectNumber(output.shots),
+    status: __expectString(output.status),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1TagsMap(output.tags, context)
@@ -1414,7 +1411,7 @@ const deserializeAws_restJson1TagsMap = (output: any, context: __SerdeContext): 
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };

--- a/clients/client-budgets/protocols/Aws_json1_1.ts
+++ b/clients/client-budgets/protocols/Aws_json1_1.ts
@@ -118,7 +118,12 @@ import {
   UpdateSubscriberResponse,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -3000,30 +3005,27 @@ const serializeAws_json1_1Users = (input: string[], context: __SerdeContext): an
 
 const deserializeAws_json1_1AccessDeniedException = (output: any, context: __SerdeContext): AccessDeniedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1Action = (output: any, context: __SerdeContext): Action => {
   return {
-    ActionId: output.ActionId !== undefined && output.ActionId !== null ? output.ActionId : undefined,
+    ActionId: __expectString(output.ActionId),
     ActionThreshold:
       output.ActionThreshold !== undefined && output.ActionThreshold !== null
         ? deserializeAws_json1_1ActionThreshold(output.ActionThreshold, context)
         : undefined,
-    ActionType: output.ActionType !== undefined && output.ActionType !== null ? output.ActionType : undefined,
-    ApprovalModel:
-      output.ApprovalModel !== undefined && output.ApprovalModel !== null ? output.ApprovalModel : undefined,
-    BudgetName: output.BudgetName !== undefined && output.BudgetName !== null ? output.BudgetName : undefined,
+    ActionType: __expectString(output.ActionType),
+    ApprovalModel: __expectString(output.ApprovalModel),
+    BudgetName: __expectString(output.BudgetName),
     Definition:
       output.Definition !== undefined && output.Definition !== null
         ? deserializeAws_json1_1Definition(output.Definition, context)
         : undefined,
-    ExecutionRoleArn:
-      output.ExecutionRoleArn !== undefined && output.ExecutionRoleArn !== null ? output.ExecutionRoleArn : undefined,
-    NotificationType:
-      output.NotificationType !== undefined && output.NotificationType !== null ? output.NotificationType : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    ExecutionRoleArn: __expectString(output.ExecutionRoleArn),
+    NotificationType: __expectString(output.NotificationType),
+    Status: __expectString(output.Status),
     Subscribers:
       output.Subscribers !== undefined && output.Subscribers !== null
         ? deserializeAws_json1_1Subscribers(output.Subscribers, context)
@@ -3048,8 +3050,8 @@ const deserializeAws_json1_1ActionHistory = (output: any, context: __SerdeContex
       output.ActionHistoryDetails !== undefined && output.ActionHistoryDetails !== null
         ? deserializeAws_json1_1ActionHistoryDetails(output.ActionHistoryDetails, context)
         : undefined,
-    EventType: output.EventType !== undefined && output.EventType !== null ? output.EventType : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    EventType: __expectString(output.EventType),
+    Status: __expectString(output.Status),
     Timestamp:
       output.Timestamp !== undefined && output.Timestamp !== null
         ? new Date(Math.round(output.Timestamp * 1000))
@@ -3063,7 +3065,7 @@ const deserializeAws_json1_1ActionHistoryDetails = (output: any, context: __Serd
       output.Action !== undefined && output.Action !== null
         ? deserializeAws_json1_1Action(output.Action, context)
         : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3080,14 +3082,8 @@ const deserializeAws_json1_1Actions = (output: any, context: __SerdeContext): Ac
 
 const deserializeAws_json1_1ActionThreshold = (output: any, context: __SerdeContext): ActionThreshold => {
   return {
-    ActionThresholdType:
-      output.ActionThresholdType !== undefined && output.ActionThresholdType !== null
-        ? output.ActionThresholdType
-        : undefined,
-    ActionThresholdValue:
-      output.ActionThresholdValue !== undefined && output.ActionThresholdValue !== null
-        ? output.ActionThresholdValue
-        : undefined,
+    ActionThresholdType: __expectString(output.ActionThresholdType),
+    ActionThresholdValue: __expectNumber(output.ActionThresholdValue),
   } as any;
 };
 
@@ -3097,8 +3093,8 @@ const deserializeAws_json1_1Budget = (output: any, context: __SerdeContext): Bud
       output.BudgetLimit !== undefined && output.BudgetLimit !== null
         ? deserializeAws_json1_1Spend(output.BudgetLimit, context)
         : undefined,
-    BudgetName: output.BudgetName !== undefined && output.BudgetName !== null ? output.BudgetName : undefined,
-    BudgetType: output.BudgetType !== undefined && output.BudgetType !== null ? output.BudgetType : undefined,
+    BudgetName: __expectString(output.BudgetName),
+    BudgetType: __expectString(output.BudgetType),
     CalculatedSpend:
       output.CalculatedSpend !== undefined && output.CalculatedSpend !== null
         ? deserializeAws_json1_1CalculatedSpend(output.CalculatedSpend, context)
@@ -3123,7 +3119,7 @@ const deserializeAws_json1_1Budget = (output: any, context: __SerdeContext): Bud
       output.TimePeriod !== undefined && output.TimePeriod !== null
         ? deserializeAws_json1_1TimePeriod(output.TimePeriod, context)
         : undefined,
-    TimeUnit: output.TimeUnit !== undefined && output.TimeUnit !== null ? output.TimeUnit : undefined,
+    TimeUnit: __expectString(output.TimeUnit),
   } as any;
 };
 
@@ -3166,8 +3162,8 @@ const deserializeAws_json1_1BudgetPerformanceHistory = (
   context: __SerdeContext
 ): BudgetPerformanceHistory => {
   return {
-    BudgetName: output.BudgetName !== undefined && output.BudgetName !== null ? output.BudgetName : undefined,
-    BudgetType: output.BudgetType !== undefined && output.BudgetType !== null ? output.BudgetType : undefined,
+    BudgetName: __expectString(output.BudgetName),
+    BudgetType: __expectString(output.BudgetType),
     BudgetedAndActualAmountsList:
       output.BudgetedAndActualAmountsList !== undefined && output.BudgetedAndActualAmountsList !== null
         ? deserializeAws_json1_1BudgetedAndActualAmountsList(output.BudgetedAndActualAmountsList, context)
@@ -3180,7 +3176,7 @@ const deserializeAws_json1_1BudgetPerformanceHistory = (
       output.CostTypes !== undefined && output.CostTypes !== null
         ? deserializeAws_json1_1CostTypes(output.CostTypes, context)
         : undefined,
-    TimeUnit: output.TimeUnit !== undefined && output.TimeUnit !== null ? output.TimeUnit : undefined,
+    TimeUnit: __expectString(output.TimeUnit),
   } as any;
 };
 
@@ -3222,29 +3218,17 @@ const deserializeAws_json1_1CostFilters = (output: any, context: __SerdeContext)
 
 const deserializeAws_json1_1CostTypes = (output: any, context: __SerdeContext): CostTypes => {
   return {
-    IncludeCredit:
-      output.IncludeCredit !== undefined && output.IncludeCredit !== null ? output.IncludeCredit : undefined,
-    IncludeDiscount:
-      output.IncludeDiscount !== undefined && output.IncludeDiscount !== null ? output.IncludeDiscount : undefined,
-    IncludeOtherSubscription:
-      output.IncludeOtherSubscription !== undefined && output.IncludeOtherSubscription !== null
-        ? output.IncludeOtherSubscription
-        : undefined,
-    IncludeRecurring:
-      output.IncludeRecurring !== undefined && output.IncludeRecurring !== null ? output.IncludeRecurring : undefined,
-    IncludeRefund:
-      output.IncludeRefund !== undefined && output.IncludeRefund !== null ? output.IncludeRefund : undefined,
-    IncludeSubscription:
-      output.IncludeSubscription !== undefined && output.IncludeSubscription !== null
-        ? output.IncludeSubscription
-        : undefined,
-    IncludeSupport:
-      output.IncludeSupport !== undefined && output.IncludeSupport !== null ? output.IncludeSupport : undefined,
-    IncludeTax: output.IncludeTax !== undefined && output.IncludeTax !== null ? output.IncludeTax : undefined,
-    IncludeUpfront:
-      output.IncludeUpfront !== undefined && output.IncludeUpfront !== null ? output.IncludeUpfront : undefined,
-    UseAmortized: output.UseAmortized !== undefined && output.UseAmortized !== null ? output.UseAmortized : undefined,
-    UseBlended: output.UseBlended !== undefined && output.UseBlended !== null ? output.UseBlended : undefined,
+    IncludeCredit: __expectBoolean(output.IncludeCredit),
+    IncludeDiscount: __expectBoolean(output.IncludeDiscount),
+    IncludeOtherSubscription: __expectBoolean(output.IncludeOtherSubscription),
+    IncludeRecurring: __expectBoolean(output.IncludeRecurring),
+    IncludeRefund: __expectBoolean(output.IncludeRefund),
+    IncludeSubscription: __expectBoolean(output.IncludeSubscription),
+    IncludeSupport: __expectBoolean(output.IncludeSupport),
+    IncludeTax: __expectBoolean(output.IncludeTax),
+    IncludeUpfront: __expectBoolean(output.IncludeUpfront),
+    UseAmortized: __expectBoolean(output.UseAmortized),
+    UseBlended: __expectBoolean(output.UseBlended),
   } as any;
 };
 
@@ -3253,9 +3237,9 @@ const deserializeAws_json1_1CreateBudgetActionResponse = (
   context: __SerdeContext
 ): CreateBudgetActionResponse => {
   return {
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
-    ActionId: output.ActionId !== undefined && output.ActionId !== null ? output.ActionId : undefined,
-    BudgetName: output.BudgetName !== undefined && output.BudgetName !== null ? output.BudgetName : undefined,
+    AccountId: __expectString(output.AccountId),
+    ActionId: __expectString(output.ActionId),
+    BudgetName: __expectString(output.BudgetName),
   } as any;
 };
 
@@ -3282,7 +3266,7 @@ const deserializeAws_json1_1CreationLimitExceededException = (
   context: __SerdeContext
 ): CreationLimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3308,12 +3292,12 @@ const deserializeAws_json1_1DeleteBudgetActionResponse = (
   context: __SerdeContext
 ): DeleteBudgetActionResponse => {
   return {
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
+    AccountId: __expectString(output.AccountId),
     Action:
       output.Action !== undefined && output.Action !== null
         ? deserializeAws_json1_1Action(output.Action, context)
         : undefined,
-    BudgetName: output.BudgetName !== undefined && output.BudgetName !== null ? output.BudgetName : undefined,
+    BudgetName: __expectString(output.BudgetName),
   } as any;
 };
 
@@ -3344,7 +3328,7 @@ const deserializeAws_json1_1DescribeBudgetActionHistoriesResponse = (
       output.ActionHistories !== undefined && output.ActionHistories !== null
         ? deserializeAws_json1_1ActionHistories(output.ActionHistories, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -3353,12 +3337,12 @@ const deserializeAws_json1_1DescribeBudgetActionResponse = (
   context: __SerdeContext
 ): DescribeBudgetActionResponse => {
   return {
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
+    AccountId: __expectString(output.AccountId),
     Action:
       output.Action !== undefined && output.Action !== null
         ? deserializeAws_json1_1Action(output.Action, context)
         : undefined,
-    BudgetName: output.BudgetName !== undefined && output.BudgetName !== null ? output.BudgetName : undefined,
+    BudgetName: __expectString(output.BudgetName),
   } as any;
 };
 
@@ -3371,7 +3355,7 @@ const deserializeAws_json1_1DescribeBudgetActionsForAccountResponse = (
       output.Actions !== undefined && output.Actions !== null
         ? deserializeAws_json1_1Actions(output.Actions, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -3384,7 +3368,7 @@ const deserializeAws_json1_1DescribeBudgetActionsForBudgetResponse = (
       output.Actions !== undefined && output.Actions !== null
         ? deserializeAws_json1_1Actions(output.Actions, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -3397,7 +3381,7 @@ const deserializeAws_json1_1DescribeBudgetPerformanceHistoryResponse = (
       output.BudgetPerformanceHistory !== undefined && output.BudgetPerformanceHistory !== null
         ? deserializeAws_json1_1BudgetPerformanceHistory(output.BudgetPerformanceHistory, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -3419,7 +3403,7 @@ const deserializeAws_json1_1DescribeBudgetsResponse = (
       output.Budgets !== undefined && output.Budgets !== null
         ? deserializeAws_json1_1Budgets(output.Budgets, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -3428,7 +3412,7 @@ const deserializeAws_json1_1DescribeNotificationsForBudgetResponse = (
   context: __SerdeContext
 ): DescribeNotificationsForBudgetResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Notifications:
       output.Notifications !== undefined && output.Notifications !== null
         ? deserializeAws_json1_1Notifications(output.Notifications, context)
@@ -3441,7 +3425,7 @@ const deserializeAws_json1_1DescribeSubscribersForNotificationResponse = (
   context: __SerdeContext
 ): DescribeSubscribersForNotificationResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Subscribers:
       output.Subscribers !== undefined && output.Subscribers !== null
         ? deserializeAws_json1_1Subscribers(output.Subscribers, context)
@@ -3456,7 +3440,7 @@ const deserializeAws_json1_1DimensionValues = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3465,7 +3449,7 @@ const deserializeAws_json1_1DuplicateRecordException = (
   context: __SerdeContext
 ): DuplicateRecordException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3474,11 +3458,10 @@ const deserializeAws_json1_1ExecuteBudgetActionResponse = (
   context: __SerdeContext
 ): ExecuteBudgetActionResponse => {
   return {
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
-    ActionId: output.ActionId !== undefined && output.ActionId !== null ? output.ActionId : undefined,
-    BudgetName: output.BudgetName !== undefined && output.BudgetName !== null ? output.BudgetName : undefined,
-    ExecutionType:
-      output.ExecutionType !== undefined && output.ExecutionType !== null ? output.ExecutionType : undefined,
+    AccountId: __expectString(output.AccountId),
+    ActionId: __expectString(output.ActionId),
+    BudgetName: __expectString(output.BudgetName),
+    ExecutionType: __expectString(output.ExecutionType),
   } as any;
 };
 
@@ -3487,7 +3470,7 @@ const deserializeAws_json1_1ExpiredNextTokenException = (
   context: __SerdeContext
 ): ExpiredNextTokenException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3498,7 +3481,7 @@ const deserializeAws_json1_1Groups = (output: any, context: __SerdeContext): str
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3508,7 +3491,7 @@ const deserializeAws_json1_1IamActionDefinition = (output: any, context: __Serde
       output.Groups !== undefined && output.Groups !== null
         ? deserializeAws_json1_1Groups(output.Groups, context)
         : undefined,
-    PolicyArn: output.PolicyArn !== undefined && output.PolicyArn !== null ? output.PolicyArn : undefined,
+    PolicyArn: __expectString(output.PolicyArn),
     Roles:
       output.Roles !== undefined && output.Roles !== null
         ? deserializeAws_json1_1Roles(output.Roles, context)
@@ -3527,13 +3510,13 @@ const deserializeAws_json1_1InstanceIds = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1InternalErrorException = (output: any, context: __SerdeContext): InternalErrorException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3542,7 +3525,7 @@ const deserializeAws_json1_1InvalidNextTokenException = (
   context: __SerdeContext
 ): InvalidNextTokenException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3551,31 +3534,23 @@ const deserializeAws_json1_1InvalidParameterException = (
   context: __SerdeContext
 ): InvalidParameterException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1NotFoundException = (output: any, context: __SerdeContext): NotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1Notification = (output: any, context: __SerdeContext): Notification => {
   return {
-    ComparisonOperator:
-      output.ComparisonOperator !== undefined && output.ComparisonOperator !== null
-        ? output.ComparisonOperator
-        : undefined,
-    NotificationState:
-      output.NotificationState !== undefined && output.NotificationState !== null
-        ? output.NotificationState
-        : undefined,
-    NotificationType:
-      output.NotificationType !== undefined && output.NotificationType !== null ? output.NotificationType : undefined,
-    Threshold: output.Threshold !== undefined && output.Threshold !== null ? output.Threshold : undefined,
-    ThresholdType:
-      output.ThresholdType !== undefined && output.ThresholdType !== null ? output.ThresholdType : undefined,
+    ComparisonOperator: __expectString(output.ComparisonOperator),
+    NotificationState: __expectString(output.NotificationState),
+    NotificationType: __expectString(output.NotificationType),
+    Threshold: __expectNumber(output.Threshold),
+    ThresholdType: __expectString(output.ThresholdType),
   } as any;
 };
 
@@ -3607,7 +3582,7 @@ const deserializeAws_json1_1ResourceLockedException = (
   context: __SerdeContext
 ): ResourceLockedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3618,13 +3593,13 @@ const deserializeAws_json1_1Roles = (output: any, context: __SerdeContext): stri
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1ScpActionDefinition = (output: any, context: __SerdeContext): ScpActionDefinition => {
   return {
-    PolicyId: output.PolicyId !== undefined && output.PolicyId !== null ? output.PolicyId : undefined,
+    PolicyId: __expectString(output.PolicyId),
     TargetIds:
       output.TargetIds !== undefined && output.TargetIds !== null
         ? deserializeAws_json1_1TargetIds(output.TargetIds, context)
@@ -3634,28 +3609,26 @@ const deserializeAws_json1_1ScpActionDefinition = (output: any, context: __Serde
 
 const deserializeAws_json1_1Spend = (output: any, context: __SerdeContext): Spend => {
   return {
-    Amount: output.Amount !== undefined && output.Amount !== null ? output.Amount : undefined,
-    Unit: output.Unit !== undefined && output.Unit !== null ? output.Unit : undefined,
+    Amount: __expectString(output.Amount),
+    Unit: __expectString(output.Unit),
   } as any;
 };
 
 const deserializeAws_json1_1SsmActionDefinition = (output: any, context: __SerdeContext): SsmActionDefinition => {
   return {
-    ActionSubType:
-      output.ActionSubType !== undefined && output.ActionSubType !== null ? output.ActionSubType : undefined,
+    ActionSubType: __expectString(output.ActionSubType),
     InstanceIds:
       output.InstanceIds !== undefined && output.InstanceIds !== null
         ? deserializeAws_json1_1InstanceIds(output.InstanceIds, context)
         : undefined,
-    Region: output.Region !== undefined && output.Region !== null ? output.Region : undefined,
+    Region: __expectString(output.Region),
   } as any;
 };
 
 const deserializeAws_json1_1Subscriber = (output: any, context: __SerdeContext): Subscriber => {
   return {
-    Address: output.Address !== undefined && output.Address !== null ? output.Address : undefined,
-    SubscriptionType:
-      output.SubscriptionType !== undefined && output.SubscriptionType !== null ? output.SubscriptionType : undefined,
+    Address: __expectString(output.Address),
+    SubscriptionType: __expectString(output.SubscriptionType),
   } as any;
 };
 
@@ -3677,7 +3650,7 @@ const deserializeAws_json1_1TargetIds = (output: any, context: __SerdeContext): 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3693,8 +3666,8 @@ const deserializeAws_json1_1UpdateBudgetActionResponse = (
   context: __SerdeContext
 ): UpdateBudgetActionResponse => {
   return {
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
-    BudgetName: output.BudgetName !== undefined && output.BudgetName !== null ? output.BudgetName : undefined,
+    AccountId: __expectString(output.AccountId),
+    BudgetName: __expectString(output.BudgetName),
     NewAction:
       output.NewAction !== undefined && output.NewAction !== null
         ? deserializeAws_json1_1Action(output.NewAction, context)
@@ -3731,7 +3704,7 @@ const deserializeAws_json1_1Users = (output: any, context: __SerdeContext): stri
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 

--- a/clients/client-chime/protocols/Aws_restJson1.ts
+++ b/clients/client-chime/protocols/Aws_restJson1.ts
@@ -617,6 +617,9 @@ import {
 } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -8621,7 +8624,7 @@ export const deserializeAws_restJson1CreateAppInstanceCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AppInstanceArn !== undefined && data.AppInstanceArn !== null) {
-    contents.AppInstanceArn = data.AppInstanceArn;
+    contents.AppInstanceArn = __expectString(data.AppInstanceArn);
   }
   return Promise.resolve(contents);
 };
@@ -8736,7 +8739,7 @@ export const deserializeAws_restJson1CreateAppInstanceAdminCommand = async (
     contents.AppInstanceAdmin = deserializeAws_restJson1Identity(data.AppInstanceAdmin, context);
   }
   if (data.AppInstanceArn !== undefined && data.AppInstanceArn !== null) {
-    contents.AppInstanceArn = data.AppInstanceArn;
+    contents.AppInstanceArn = __expectString(data.AppInstanceArn);
   }
   return Promise.resolve(contents);
 };
@@ -8847,7 +8850,7 @@ export const deserializeAws_restJson1CreateAppInstanceUserCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AppInstanceUserArn !== undefined && data.AppInstanceUserArn !== null) {
-    contents.AppInstanceUserArn = data.AppInstanceUserArn;
+    contents.AppInstanceUserArn = __expectString(data.AppInstanceUserArn);
   }
   return Promise.resolve(contents);
 };
@@ -9180,7 +9183,7 @@ export const deserializeAws_restJson1CreateChannelCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
-    contents.ChannelArn = data.ChannelArn;
+    contents.ChannelArn = __expectString(data.ChannelArn);
   }
   return Promise.resolve(contents);
 };
@@ -9292,7 +9295,7 @@ export const deserializeAws_restJson1CreateChannelBanCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
-    contents.ChannelArn = data.ChannelArn;
+    contents.ChannelArn = __expectString(data.ChannelArn);
   }
   if (data.Member !== undefined && data.Member !== null) {
     contents.Member = deserializeAws_restJson1Identity(data.Member, context);
@@ -9407,7 +9410,7 @@ export const deserializeAws_restJson1CreateChannelMembershipCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
-    contents.ChannelArn = data.ChannelArn;
+    contents.ChannelArn = __expectString(data.ChannelArn);
   }
   if (data.Member !== undefined && data.Member !== null) {
     contents.Member = deserializeAws_restJson1Identity(data.Member, context);
@@ -9522,7 +9525,7 @@ export const deserializeAws_restJson1CreateChannelModeratorCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
-    contents.ChannelArn = data.ChannelArn;
+    contents.ChannelArn = __expectString(data.ChannelArn);
   }
   if (data.ChannelModerator !== undefined && data.ChannelModerator !== null) {
     contents.ChannelModerator = deserializeAws_restJson1Identity(data.ChannelModerator, context);
@@ -9739,7 +9742,7 @@ export const deserializeAws_restJson1CreateMeetingDialOutCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.TransactionId !== undefined && data.TransactionId !== null) {
-    contents.TransactionId = data.TransactionId;
+    contents.TransactionId = __expectString(data.TransactionId);
   }
   return Promise.resolve(contents);
 };
@@ -16347,7 +16350,7 @@ export const deserializeAws_restJson1GetPhoneNumberSettingsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.CallingName !== undefined && data.CallingName !== null) {
-    contents.CallingName = data.CallingName;
+    contents.CallingName = __expectString(data.CallingName);
   }
   if (data.CallingNameUpdatedTimestamp !== undefined && data.CallingNameUpdatedTimestamp !== null) {
     contents.CallingNameUpdatedTimestamp = new Date(data.CallingNameUpdatedTimestamp);
@@ -18319,7 +18322,7 @@ export const deserializeAws_restJson1ListAccountsCommand = async (
     contents.Accounts = deserializeAws_restJson1AccountList(data.Accounts, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -18427,10 +18430,10 @@ export const deserializeAws_restJson1ListAppInstanceAdminsCommand = async (
     contents.AppInstanceAdmins = deserializeAws_restJson1AppInstanceAdminList(data.AppInstanceAdmins, context);
   }
   if (data.AppInstanceArn !== undefined && data.AppInstanceArn !== null) {
-    contents.AppInstanceArn = data.AppInstanceArn;
+    contents.AppInstanceArn = __expectString(data.AppInstanceArn);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -18529,7 +18532,7 @@ export const deserializeAws_restJson1ListAppInstancesCommand = async (
     contents.AppInstances = deserializeAws_restJson1AppInstanceList(data.AppInstances, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -18626,13 +18629,13 @@ export const deserializeAws_restJson1ListAppInstanceUsersCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AppInstanceArn !== undefined && data.AppInstanceArn !== null) {
-    contents.AppInstanceArn = data.AppInstanceArn;
+    contents.AppInstanceArn = __expectString(data.AppInstanceArn);
   }
   if (data.AppInstanceUsers !== undefined && data.AppInstanceUsers !== null) {
     contents.AppInstanceUsers = deserializeAws_restJson1AppInstanceUserList(data.AppInstanceUsers, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -18731,7 +18734,7 @@ export const deserializeAws_restJson1ListAttendeesCommand = async (
     contents.Attendees = deserializeAws_restJson1AttendeeList(data.Attendees, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -18941,7 +18944,7 @@ export const deserializeAws_restJson1ListBotsCommand = async (
     contents.Bots = deserializeAws_restJson1BotList(data.Bots, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -19046,13 +19049,13 @@ export const deserializeAws_restJson1ListChannelBansCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
-    contents.ChannelArn = data.ChannelArn;
+    contents.ChannelArn = __expectString(data.ChannelArn);
   }
   if (data.ChannelBans !== undefined && data.ChannelBans !== null) {
     contents.ChannelBans = deserializeAws_restJson1ChannelBanSummaryList(data.ChannelBans, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -19149,7 +19152,7 @@ export const deserializeAws_restJson1ListChannelMembershipsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
-    contents.ChannelArn = data.ChannelArn;
+    contents.ChannelArn = __expectString(data.ChannelArn);
   }
   if (data.ChannelMemberships !== undefined && data.ChannelMemberships !== null) {
     contents.ChannelMemberships = deserializeAws_restJson1ChannelMembershipSummaryList(
@@ -19158,7 +19161,7 @@ export const deserializeAws_restJson1ListChannelMembershipsCommand = async (
     );
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -19260,7 +19263,7 @@ export const deserializeAws_restJson1ListChannelMembershipsForAppInstanceUserCom
     );
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -19357,13 +19360,13 @@ export const deserializeAws_restJson1ListChannelMessagesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
-    contents.ChannelArn = data.ChannelArn;
+    contents.ChannelArn = __expectString(data.ChannelArn);
   }
   if (data.ChannelMessages !== undefined && data.ChannelMessages !== null) {
     contents.ChannelMessages = deserializeAws_restJson1ChannelMessageSummaryList(data.ChannelMessages, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -19460,13 +19463,13 @@ export const deserializeAws_restJson1ListChannelModeratorsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
-    contents.ChannelArn = data.ChannelArn;
+    contents.ChannelArn = __expectString(data.ChannelArn);
   }
   if (data.ChannelModerators !== undefined && data.ChannelModerators !== null) {
     contents.ChannelModerators = deserializeAws_restJson1ChannelModeratorSummaryList(data.ChannelModerators, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -19565,7 +19568,7 @@ export const deserializeAws_restJson1ListChannelsCommand = async (
     contents.Channels = deserializeAws_restJson1ChannelSummaryList(data.Channels, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -19664,7 +19667,7 @@ export const deserializeAws_restJson1ListChannelsModeratedByAppInstanceUserComma
     contents.Channels = deserializeAws_restJson1ChannelModeratedByAppInstanceUserSummaryList(data.Channels, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -19763,7 +19766,7 @@ export const deserializeAws_restJson1ListMeetingsCommand = async (
     contents.Meetings = deserializeAws_restJson1MeetingList(data.Meetings, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -19962,7 +19965,7 @@ export const deserializeAws_restJson1ListPhoneNumberOrdersCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.PhoneNumberOrders !== undefined && data.PhoneNumberOrders !== null) {
     contents.PhoneNumberOrders = deserializeAws_restJson1PhoneNumberOrderList(data.PhoneNumberOrders, context);
@@ -20061,7 +20064,7 @@ export const deserializeAws_restJson1ListPhoneNumbersCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.PhoneNumbers !== undefined && data.PhoneNumbers !== null) {
     contents.PhoneNumbers = deserializeAws_restJson1PhoneNumberList(data.PhoneNumbers, context);
@@ -20168,7 +20171,7 @@ export const deserializeAws_restJson1ListProxySessionsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.ProxySessions !== undefined && data.ProxySessions !== null) {
     contents.ProxySessions = deserializeAws_restJson1ProxySessions(data.ProxySessions, context);
@@ -20275,7 +20278,7 @@ export const deserializeAws_restJson1ListRoomMembershipsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.RoomMemberships !== undefined && data.RoomMemberships !== null) {
     contents.RoomMemberships = deserializeAws_restJson1RoomMembershipList(data.RoomMemberships, context);
@@ -20382,7 +20385,7 @@ export const deserializeAws_restJson1ListRoomsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Rooms !== undefined && data.Rooms !== null) {
     contents.Rooms = deserializeAws_restJson1RoomList(data.Rooms, context);
@@ -20489,7 +20492,7 @@ export const deserializeAws_restJson1ListSipMediaApplicationsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.SipMediaApplications !== undefined && data.SipMediaApplications !== null) {
     contents.SipMediaApplications = deserializeAws_restJson1SipMediaApplicationList(data.SipMediaApplications, context);
@@ -20588,7 +20591,7 @@ export const deserializeAws_restJson1ListSipRulesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.SipRules !== undefined && data.SipRules !== null) {
     contents.SipRules = deserializeAws_restJson1SipRuleList(data.SipRules, context);
@@ -20888,7 +20891,7 @@ export const deserializeAws_restJson1ListUsersCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Users !== undefined && data.Users !== null) {
     contents.Users = deserializeAws_restJson1UserList(data.Users, context);
@@ -20995,7 +20998,7 @@ export const deserializeAws_restJson1ListVoiceConnectorGroupsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.VoiceConnectorGroups !== undefined && data.VoiceConnectorGroups !== null) {
     contents.VoiceConnectorGroups = deserializeAws_restJson1VoiceConnectorGroupList(data.VoiceConnectorGroups, context);
@@ -21094,7 +21097,7 @@ export const deserializeAws_restJson1ListVoiceConnectorsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.VoiceConnectors !== undefined && data.VoiceConnectors !== null) {
     contents.VoiceConnectors = deserializeAws_restJson1VoiceConnectorList(data.VoiceConnectors, context);
@@ -22685,10 +22688,10 @@ export const deserializeAws_restJson1RedactChannelMessageCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
-    contents.ChannelArn = data.ChannelArn;
+    contents.ChannelArn = __expectString(data.ChannelArn);
   }
   if (data.MessageId !== undefined && data.MessageId !== null) {
-    contents.MessageId = data.MessageId;
+    contents.MessageId = __expectString(data.MessageId);
   }
   return Promise.resolve(contents);
 };
@@ -23302,7 +23305,7 @@ export const deserializeAws_restJson1SearchAvailablePhoneNumbersCommand = async 
     contents.E164PhoneNumbers = deserializeAws_restJson1E164PhoneNumberList(data.E164PhoneNumbers, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -23406,10 +23409,10 @@ export const deserializeAws_restJson1SendChannelMessageCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
-    contents.ChannelArn = data.ChannelArn;
+    contents.ChannelArn = __expectString(data.ChannelArn);
   }
   if (data.MessageId !== undefined && data.MessageId !== null) {
-    contents.MessageId = data.MessageId;
+    contents.MessageId = __expectString(data.MessageId);
   }
   return Promise.resolve(contents);
 };
@@ -24316,7 +24319,7 @@ export const deserializeAws_restJson1UpdateAppInstanceCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AppInstanceArn !== undefined && data.AppInstanceArn !== null) {
-    contents.AppInstanceArn = data.AppInstanceArn;
+    contents.AppInstanceArn = __expectString(data.AppInstanceArn);
   }
   return Promise.resolve(contents);
 };
@@ -24419,7 +24422,7 @@ export const deserializeAws_restJson1UpdateAppInstanceUserCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AppInstanceUserArn !== undefined && data.AppInstanceUserArn !== null) {
-    contents.AppInstanceUserArn = data.AppInstanceUserArn;
+    contents.AppInstanceUserArn = __expectString(data.AppInstanceUserArn);
   }
   return Promise.resolve(contents);
 };
@@ -24625,7 +24628,7 @@ export const deserializeAws_restJson1UpdateChannelCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
-    contents.ChannelArn = data.ChannelArn;
+    contents.ChannelArn = __expectString(data.ChannelArn);
   }
   return Promise.resolve(contents);
 };
@@ -24729,10 +24732,10 @@ export const deserializeAws_restJson1UpdateChannelMessageCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
-    contents.ChannelArn = data.ChannelArn;
+    contents.ChannelArn = __expectString(data.ChannelArn);
   }
   if (data.MessageId !== undefined && data.MessageId !== null) {
-    contents.MessageId = data.MessageId;
+    contents.MessageId = __expectString(data.MessageId);
   }
   return Promise.resolve(contents);
 };
@@ -24835,7 +24838,7 @@ export const deserializeAws_restJson1UpdateChannelReadMarkerCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
-    contents.ChannelArn = data.ChannelArn;
+    contents.ChannelArn = __expectString(data.ChannelArn);
   }
   return Promise.resolve(contents);
 };
@@ -26292,10 +26295,10 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Code !== undefined && data.Code !== null) {
-    contents.Code = data.Code;
+    contents.Code = __expectString(data.Code);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -26313,10 +26316,10 @@ const deserializeAws_restJson1BadRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Code !== undefined && data.Code !== null) {
-    contents.Code = data.Code;
+    contents.Code = __expectString(data.Code);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -26334,10 +26337,10 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Code !== undefined && data.Code !== null) {
-    contents.Code = data.Code;
+    contents.Code = __expectString(data.Code);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -26355,10 +26358,10 @@ const deserializeAws_restJson1ForbiddenExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Code !== undefined && data.Code !== null) {
-    contents.Code = data.Code;
+    contents.Code = __expectString(data.Code);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -26376,10 +26379,10 @@ const deserializeAws_restJson1NotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Code !== undefined && data.Code !== null) {
-    contents.Code = data.Code;
+    contents.Code = __expectString(data.Code);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -26397,10 +26400,10 @@ const deserializeAws_restJson1ResourceLimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Code !== undefined && data.Code !== null) {
-    contents.Code = data.Code;
+    contents.Code = __expectString(data.Code);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -26418,10 +26421,10 @@ const deserializeAws_restJson1ServiceFailureExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Code !== undefined && data.Code !== null) {
-    contents.Code = data.Code;
+    contents.Code = __expectString(data.Code);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -26439,10 +26442,10 @@ const deserializeAws_restJson1ServiceUnavailableExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Code !== undefined && data.Code !== null) {
-    contents.Code = data.Code;
+    contents.Code = __expectString(data.Code);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -26460,10 +26463,10 @@ const deserializeAws_restJson1ThrottledClientExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Code !== undefined && data.Code !== null) {
-    contents.Code = data.Code;
+    contents.Code = __expectString(data.Code);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -26481,10 +26484,10 @@ const deserializeAws_restJson1UnauthorizedClientExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Code !== undefined && data.Code !== null) {
-    contents.Code = data.Code;
+    contents.Code = __expectString(data.Code);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -26502,10 +26505,10 @@ const deserializeAws_restJson1UnprocessableEntityExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Code !== undefined && data.Code !== null) {
-    contents.Code = data.Code;
+    contents.Code = __expectString(data.Code);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -27228,16 +27231,15 @@ const serializeAws_restJson1VoiceConnectorSettings = (input: VoiceConnectorSetti
 
 const deserializeAws_restJson1Account = (output: any, context: __SerdeContext): Account => {
   return {
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
-    AccountType: output.AccountType !== undefined && output.AccountType !== null ? output.AccountType : undefined,
-    AwsAccountId: output.AwsAccountId !== undefined && output.AwsAccountId !== null ? output.AwsAccountId : undefined,
+    AccountId: __expectString(output.AccountId),
+    AccountType: __expectString(output.AccountType),
+    AwsAccountId: __expectString(output.AwsAccountId),
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
         ? new Date(output.CreatedTimestamp)
         : undefined,
-    DefaultLicense:
-      output.DefaultLicense !== undefined && output.DefaultLicense !== null ? output.DefaultLicense : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    DefaultLicense: __expectString(output.DefaultLicense),
+    Name: __expectString(output.Name),
     SigninDelegateGroups:
       output.SigninDelegateGroups !== undefined && output.SigninDelegateGroups !== null
         ? deserializeAws_restJson1SigninDelegateGroupList(output.SigninDelegateGroups, context)
@@ -27262,12 +27264,8 @@ const deserializeAws_restJson1AccountList = (output: any, context: __SerdeContex
 
 const deserializeAws_restJson1AccountSettings = (output: any, context: __SerdeContext): AccountSettings => {
   return {
-    DisableRemoteControl:
-      output.DisableRemoteControl !== undefined && output.DisableRemoteControl !== null
-        ? output.DisableRemoteControl
-        : undefined,
-    EnableDialOut:
-      output.EnableDialOut !== undefined && output.EnableDialOut !== null ? output.EnableDialOut : undefined,
+    DisableRemoteControl: __expectBoolean(output.DisableRemoteControl),
+    EnableDialOut: __expectBoolean(output.EnableDialOut),
   } as any;
 };
 
@@ -27276,21 +27274,14 @@ const deserializeAws_restJson1AlexaForBusinessMetadata = (
   context: __SerdeContext
 ): AlexaForBusinessMetadata => {
   return {
-    AlexaForBusinessRoomArn:
-      output.AlexaForBusinessRoomArn !== undefined && output.AlexaForBusinessRoomArn !== null
-        ? output.AlexaForBusinessRoomArn
-        : undefined,
-    IsAlexaForBusinessEnabled:
-      output.IsAlexaForBusinessEnabled !== undefined && output.IsAlexaForBusinessEnabled !== null
-        ? output.IsAlexaForBusinessEnabled
-        : undefined,
+    AlexaForBusinessRoomArn: __expectString(output.AlexaForBusinessRoomArn),
+    IsAlexaForBusinessEnabled: __expectBoolean(output.IsAlexaForBusinessEnabled),
   } as any;
 };
 
 const deserializeAws_restJson1AppInstance = (output: any, context: __SerdeContext): AppInstance => {
   return {
-    AppInstanceArn:
-      output.AppInstanceArn !== undefined && output.AppInstanceArn !== null ? output.AppInstanceArn : undefined,
+    AppInstanceArn: __expectString(output.AppInstanceArn),
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
         ? new Date(Math.round(output.CreatedTimestamp * 1000))
@@ -27299,8 +27290,8 @@ const deserializeAws_restJson1AppInstance = (output: any, context: __SerdeContex
       output.LastUpdatedTimestamp !== undefined && output.LastUpdatedTimestamp !== null
         ? new Date(Math.round(output.LastUpdatedTimestamp * 1000))
         : undefined,
-    Metadata: output.Metadata !== undefined && output.Metadata !== null ? output.Metadata : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Metadata: __expectString(output.Metadata),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -27310,8 +27301,7 @@ const deserializeAws_restJson1AppInstanceAdmin = (output: any, context: __SerdeC
       output.Admin !== undefined && output.Admin !== null
         ? deserializeAws_restJson1Identity(output.Admin, context)
         : undefined,
-    AppInstanceArn:
-      output.AppInstanceArn !== undefined && output.AppInstanceArn !== null ? output.AppInstanceArn : undefined,
+    AppInstanceArn: __expectString(output.AppInstanceArn),
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
         ? new Date(Math.round(output.CreatedTimestamp * 1000))
@@ -27373,11 +27363,8 @@ const deserializeAws_restJson1AppInstanceStreamingConfiguration = (
   context: __SerdeContext
 ): AppInstanceStreamingConfiguration => {
   return {
-    AppInstanceDataType:
-      output.AppInstanceDataType !== undefined && output.AppInstanceDataType !== null
-        ? output.AppInstanceDataType
-        : undefined,
-    ResourceArn: output.ResourceArn !== undefined && output.ResourceArn !== null ? output.ResourceArn : undefined,
+    AppInstanceDataType: __expectString(output.AppInstanceDataType),
+    ResourceArn: __expectString(output.ResourceArn),
   } as any;
 };
 
@@ -27397,19 +27384,15 @@ const deserializeAws_restJson1AppInstanceStreamingConfigurationList = (
 
 const deserializeAws_restJson1AppInstanceSummary = (output: any, context: __SerdeContext): AppInstanceSummary => {
   return {
-    AppInstanceArn:
-      output.AppInstanceArn !== undefined && output.AppInstanceArn !== null ? output.AppInstanceArn : undefined,
-    Metadata: output.Metadata !== undefined && output.Metadata !== null ? output.Metadata : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    AppInstanceArn: __expectString(output.AppInstanceArn),
+    Metadata: __expectString(output.Metadata),
+    Name: __expectString(output.Name),
   } as any;
 };
 
 const deserializeAws_restJson1AppInstanceUser = (output: any, context: __SerdeContext): AppInstanceUser => {
   return {
-    AppInstanceUserArn:
-      output.AppInstanceUserArn !== undefined && output.AppInstanceUserArn !== null
-        ? output.AppInstanceUserArn
-        : undefined,
+    AppInstanceUserArn: __expectString(output.AppInstanceUserArn),
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
         ? new Date(Math.round(output.CreatedTimestamp * 1000))
@@ -27418,8 +27401,8 @@ const deserializeAws_restJson1AppInstanceUser = (output: any, context: __SerdeCo
       output.LastUpdatedTimestamp !== undefined && output.LastUpdatedTimestamp !== null
         ? new Date(Math.round(output.LastUpdatedTimestamp * 1000))
         : undefined,
-    Metadata: output.Metadata !== undefined && output.Metadata !== null ? output.Metadata : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Metadata: __expectString(output.Metadata),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -27446,7 +27429,7 @@ const deserializeAws_restJson1AppInstanceUserMembershipSummary = (
       output.ReadMarkerTimestamp !== undefined && output.ReadMarkerTimestamp !== null
         ? new Date(Math.round(output.ReadMarkerTimestamp * 1000))
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -27455,21 +27438,17 @@ const deserializeAws_restJson1AppInstanceUserSummary = (
   context: __SerdeContext
 ): AppInstanceUserSummary => {
   return {
-    AppInstanceUserArn:
-      output.AppInstanceUserArn !== undefined && output.AppInstanceUserArn !== null
-        ? output.AppInstanceUserArn
-        : undefined,
-    Metadata: output.Metadata !== undefined && output.Metadata !== null ? output.Metadata : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    AppInstanceUserArn: __expectString(output.AppInstanceUserArn),
+    Metadata: __expectString(output.Metadata),
+    Name: __expectString(output.Name),
   } as any;
 };
 
 const deserializeAws_restJson1Attendee = (output: any, context: __SerdeContext): Attendee => {
   return {
-    AttendeeId: output.AttendeeId !== undefined && output.AttendeeId !== null ? output.AttendeeId : undefined,
-    ExternalUserId:
-      output.ExternalUserId !== undefined && output.ExternalUserId !== null ? output.ExternalUserId : undefined,
-    JoinToken: output.JoinToken !== undefined && output.JoinToken !== null ? output.JoinToken : undefined,
+    AttendeeId: __expectString(output.AttendeeId),
+    ExternalUserId: __expectString(output.ExternalUserId),
+    JoinToken: __expectString(output.JoinToken),
   } as any;
 };
 
@@ -27489,7 +27468,7 @@ const deserializeAws_restJson1BatchChannelMemberships = (
   context: __SerdeContext
 ): BatchChannelMemberships => {
   return {
-    ChannelArn: output.ChannelArn !== undefined && output.ChannelArn !== null ? output.ChannelArn : undefined,
+    ChannelArn: __expectString(output.ChannelArn),
     InvitedBy:
       output.InvitedBy !== undefined && output.InvitedBy !== null
         ? deserializeAws_restJson1Identity(output.InvitedBy, context)
@@ -27498,7 +27477,7 @@ const deserializeAws_restJson1BatchChannelMemberships = (
       output.Members !== undefined && output.Members !== null
         ? deserializeAws_restJson1Members(output.Members, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -27521,9 +27500,9 @@ const deserializeAws_restJson1BatchCreateChannelMembershipError = (
   context: __SerdeContext
 ): BatchCreateChannelMembershipError => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    MemberArn: output.MemberArn !== undefined && output.MemberArn !== null ? output.MemberArn : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
+    MemberArn: __expectString(output.MemberArn),
   } as any;
 };
 
@@ -27543,22 +27522,21 @@ const deserializeAws_restJson1BatchCreateChannelMembershipErrors = (
 
 const deserializeAws_restJson1Bot = (output: any, context: __SerdeContext): Bot => {
   return {
-    BotEmail: output.BotEmail !== undefined && output.BotEmail !== null ? output.BotEmail : undefined,
-    BotId: output.BotId !== undefined && output.BotId !== null ? output.BotId : undefined,
-    BotType: output.BotType !== undefined && output.BotType !== null ? output.BotType : undefined,
+    BotEmail: __expectString(output.BotEmail),
+    BotId: __expectString(output.BotId),
+    BotType: __expectString(output.BotType),
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
         ? new Date(output.CreatedTimestamp)
         : undefined,
-    Disabled: output.Disabled !== undefined && output.Disabled !== null ? output.Disabled : undefined,
-    DisplayName: output.DisplayName !== undefined && output.DisplayName !== null ? output.DisplayName : undefined,
-    SecurityToken:
-      output.SecurityToken !== undefined && output.SecurityToken !== null ? output.SecurityToken : undefined,
+    Disabled: __expectBoolean(output.Disabled),
+    DisplayName: __expectString(output.DisplayName),
+    SecurityToken: __expectString(output.SecurityToken),
     UpdatedTimestamp:
       output.UpdatedTimestamp !== undefined && output.UpdatedTimestamp !== null
         ? new Date(output.UpdatedTimestamp)
         : undefined,
-    UserId: output.UserId !== undefined && output.UserId !== null ? output.UserId : undefined,
+    UserId: __expectString(output.UserId),
   } as any;
 };
 
@@ -27578,7 +27556,7 @@ const deserializeAws_restJson1BusinessCallingSettings = (
   context: __SerdeContext
 ): BusinessCallingSettings => {
   return {
-    CdrBucket: output.CdrBucket !== undefined && output.CdrBucket !== null ? output.CdrBucket : undefined,
+    CdrBucket: __expectString(output.CdrBucket),
   } as any;
 };
 
@@ -27589,7 +27567,7 @@ const deserializeAws_restJson1CallingRegionList = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -27600,13 +27578,13 @@ const deserializeAws_restJson1CapabilityList = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1Channel = (output: any, context: __SerdeContext): Channel => {
   return {
-    ChannelArn: output.ChannelArn !== undefined && output.ChannelArn !== null ? output.ChannelArn : undefined,
+    ChannelArn: __expectString(output.ChannelArn),
     CreatedBy:
       output.CreatedBy !== undefined && output.CreatedBy !== null
         ? deserializeAws_restJson1Identity(output.CreatedBy, context)
@@ -27623,16 +27601,16 @@ const deserializeAws_restJson1Channel = (output: any, context: __SerdeContext): 
       output.LastUpdatedTimestamp !== undefined && output.LastUpdatedTimestamp !== null
         ? new Date(Math.round(output.LastUpdatedTimestamp * 1000))
         : undefined,
-    Metadata: output.Metadata !== undefined && output.Metadata !== null ? output.Metadata : undefined,
-    Mode: output.Mode !== undefined && output.Mode !== null ? output.Mode : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Privacy: output.Privacy !== undefined && output.Privacy !== null ? output.Privacy : undefined,
+    Metadata: __expectString(output.Metadata),
+    Mode: __expectString(output.Mode),
+    Name: __expectString(output.Name),
+    Privacy: __expectString(output.Privacy),
   } as any;
 };
 
 const deserializeAws_restJson1ChannelBan = (output: any, context: __SerdeContext): ChannelBan => {
   return {
-    ChannelArn: output.ChannelArn !== undefined && output.ChannelArn !== null ? output.ChannelArn : undefined,
+    ChannelArn: __expectString(output.ChannelArn),
     CreatedBy:
       output.CreatedBy !== undefined && output.CreatedBy !== null
         ? deserializeAws_restJson1Identity(output.CreatedBy, context)
@@ -27670,7 +27648,7 @@ const deserializeAws_restJson1ChannelBanSummaryList = (output: any, context: __S
 
 const deserializeAws_restJson1ChannelMembership = (output: any, context: __SerdeContext): ChannelMembership => {
   return {
-    ChannelArn: output.ChannelArn !== undefined && output.ChannelArn !== null ? output.ChannelArn : undefined,
+    ChannelArn: __expectString(output.ChannelArn),
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
         ? new Date(Math.round(output.CreatedTimestamp * 1000))
@@ -27687,7 +27665,7 @@ const deserializeAws_restJson1ChannelMembership = (output: any, context: __Serde
       output.Member !== undefined && output.Member !== null
         ? deserializeAws_restJson1Identity(output.Member, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -27749,8 +27727,8 @@ const deserializeAws_restJson1ChannelMembershipSummaryList = (
 
 const deserializeAws_restJson1ChannelMessage = (output: any, context: __SerdeContext): ChannelMessage => {
   return {
-    ChannelArn: output.ChannelArn !== undefined && output.ChannelArn !== null ? output.ChannelArn : undefined,
-    Content: output.Content !== undefined && output.Content !== null ? output.Content : undefined,
+    ChannelArn: __expectString(output.ChannelArn),
+    Content: __expectString(output.Content),
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
         ? new Date(Math.round(output.CreatedTimestamp * 1000))
@@ -27763,21 +27741,21 @@ const deserializeAws_restJson1ChannelMessage = (output: any, context: __SerdeCon
       output.LastUpdatedTimestamp !== undefined && output.LastUpdatedTimestamp !== null
         ? new Date(Math.round(output.LastUpdatedTimestamp * 1000))
         : undefined,
-    MessageId: output.MessageId !== undefined && output.MessageId !== null ? output.MessageId : undefined,
-    Metadata: output.Metadata !== undefined && output.Metadata !== null ? output.Metadata : undefined,
-    Persistence: output.Persistence !== undefined && output.Persistence !== null ? output.Persistence : undefined,
-    Redacted: output.Redacted !== undefined && output.Redacted !== null ? output.Redacted : undefined,
+    MessageId: __expectString(output.MessageId),
+    Metadata: __expectString(output.Metadata),
+    Persistence: __expectString(output.Persistence),
+    Redacted: __expectBoolean(output.Redacted),
     Sender:
       output.Sender !== undefined && output.Sender !== null
         ? deserializeAws_restJson1Identity(output.Sender, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
 const deserializeAws_restJson1ChannelMessageSummary = (output: any, context: __SerdeContext): ChannelMessageSummary => {
   return {
-    Content: output.Content !== undefined && output.Content !== null ? output.Content : undefined,
+    Content: __expectString(output.Content),
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
         ? new Date(Math.round(output.CreatedTimestamp * 1000))
@@ -27790,14 +27768,14 @@ const deserializeAws_restJson1ChannelMessageSummary = (output: any, context: __S
       output.LastUpdatedTimestamp !== undefined && output.LastUpdatedTimestamp !== null
         ? new Date(Math.round(output.LastUpdatedTimestamp * 1000))
         : undefined,
-    MessageId: output.MessageId !== undefined && output.MessageId !== null ? output.MessageId : undefined,
-    Metadata: output.Metadata !== undefined && output.Metadata !== null ? output.Metadata : undefined,
-    Redacted: output.Redacted !== undefined && output.Redacted !== null ? output.Redacted : undefined,
+    MessageId: __expectString(output.MessageId),
+    Metadata: __expectString(output.Metadata),
+    Redacted: __expectBoolean(output.Redacted),
     Sender:
       output.Sender !== undefined && output.Sender !== null
         ? deserializeAws_restJson1Identity(output.Sender, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -27843,7 +27821,7 @@ const deserializeAws_restJson1ChannelModeratedByAppInstanceUserSummaryList = (
 
 const deserializeAws_restJson1ChannelModerator = (output: any, context: __SerdeContext): ChannelModerator => {
   return {
-    ChannelArn: output.ChannelArn !== undefined && output.ChannelArn !== null ? output.ChannelArn : undefined,
+    ChannelArn: __expectString(output.ChannelArn),
     CreatedBy:
       output.CreatedBy !== undefined && output.CreatedBy !== null
         ? deserializeAws_restJson1Identity(output.CreatedBy, context)
@@ -27890,22 +27868,21 @@ const deserializeAws_restJson1ChannelRetentionSettings = (
   context: __SerdeContext
 ): ChannelRetentionSettings => {
   return {
-    RetentionDays:
-      output.RetentionDays !== undefined && output.RetentionDays !== null ? output.RetentionDays : undefined,
+    RetentionDays: __expectNumber(output.RetentionDays),
   } as any;
 };
 
 const deserializeAws_restJson1ChannelSummary = (output: any, context: __SerdeContext): ChannelSummary => {
   return {
-    ChannelArn: output.ChannelArn !== undefined && output.ChannelArn !== null ? output.ChannelArn : undefined,
+    ChannelArn: __expectString(output.ChannelArn),
     LastMessageTimestamp:
       output.LastMessageTimestamp !== undefined && output.LastMessageTimestamp !== null
         ? new Date(Math.round(output.LastMessageTimestamp * 1000))
         : undefined,
-    Metadata: output.Metadata !== undefined && output.Metadata !== null ? output.Metadata : undefined,
-    Mode: output.Mode !== undefined && output.Mode !== null ? output.Mode : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Privacy: output.Privacy !== undefined && output.Privacy !== null ? output.Privacy : undefined,
+    Metadata: __expectString(output.Metadata),
+    Mode: __expectString(output.Mode),
+    Name: __expectString(output.Name),
+    Privacy: __expectString(output.Privacy),
   } as any;
 };
 
@@ -27925,17 +27902,15 @@ const deserializeAws_restJson1ConversationRetentionSettings = (
   context: __SerdeContext
 ): ConversationRetentionSettings => {
   return {
-    RetentionDays:
-      output.RetentionDays !== undefined && output.RetentionDays !== null ? output.RetentionDays : undefined,
+    RetentionDays: __expectNumber(output.RetentionDays),
   } as any;
 };
 
 const deserializeAws_restJson1CreateAttendeeError = (output: any, context: __SerdeContext): CreateAttendeeError => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    ExternalUserId:
-      output.ExternalUserId !== undefined && output.ExternalUserId !== null ? output.ExternalUserId : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
+    ExternalUserId: __expectString(output.ExternalUserId),
   } as any;
 };
 
@@ -27944,14 +27919,9 @@ const deserializeAws_restJson1DNISEmergencyCallingConfiguration = (
   context: __SerdeContext
 ): DNISEmergencyCallingConfiguration => {
   return {
-    CallingCountry:
-      output.CallingCountry !== undefined && output.CallingCountry !== null ? output.CallingCountry : undefined,
-    EmergencyPhoneNumber:
-      output.EmergencyPhoneNumber !== undefined && output.EmergencyPhoneNumber !== null
-        ? output.EmergencyPhoneNumber
-        : undefined,
-    TestPhoneNumber:
-      output.TestPhoneNumber !== undefined && output.TestPhoneNumber !== null ? output.TestPhoneNumber : undefined,
+    CallingCountry: __expectString(output.CallingCountry),
+    EmergencyPhoneNumber: __expectString(output.EmergencyPhoneNumber),
+    TestPhoneNumber: __expectString(output.TestPhoneNumber),
   } as any;
 };
 
@@ -27976,7 +27946,7 @@ const deserializeAws_restJson1E164PhoneNumberList = (output: any, context: __Ser
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -27994,38 +27964,32 @@ const deserializeAws_restJson1EmergencyCallingConfiguration = (
 
 const deserializeAws_restJson1EventsConfiguration = (output: any, context: __SerdeContext): EventsConfiguration => {
   return {
-    BotId: output.BotId !== undefined && output.BotId !== null ? output.BotId : undefined,
-    LambdaFunctionArn:
-      output.LambdaFunctionArn !== undefined && output.LambdaFunctionArn !== null
-        ? output.LambdaFunctionArn
-        : undefined,
-    OutboundEventsHTTPSEndpoint:
-      output.OutboundEventsHTTPSEndpoint !== undefined && output.OutboundEventsHTTPSEndpoint !== null
-        ? output.OutboundEventsHTTPSEndpoint
-        : undefined,
+    BotId: __expectString(output.BotId),
+    LambdaFunctionArn: __expectString(output.LambdaFunctionArn),
+    OutboundEventsHTTPSEndpoint: __expectString(output.OutboundEventsHTTPSEndpoint),
   } as any;
 };
 
 const deserializeAws_restJson1GeoMatchParams = (output: any, context: __SerdeContext): GeoMatchParams => {
   return {
-    AreaCode: output.AreaCode !== undefined && output.AreaCode !== null ? output.AreaCode : undefined,
-    Country: output.Country !== undefined && output.Country !== null ? output.Country : undefined,
+    AreaCode: __expectString(output.AreaCode),
+    Country: __expectString(output.Country),
   } as any;
 };
 
 const deserializeAws_restJson1Identity = (output: any, context: __SerdeContext): Identity => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Arn: __expectString(output.Arn),
+    Name: __expectString(output.Name),
   } as any;
 };
 
 const deserializeAws_restJson1Invite = (output: any, context: __SerdeContext): Invite => {
   return {
-    EmailAddress: output.EmailAddress !== undefined && output.EmailAddress !== null ? output.EmailAddress : undefined,
-    EmailStatus: output.EmailStatus !== undefined && output.EmailStatus !== null ? output.EmailStatus : undefined,
-    InviteId: output.InviteId !== undefined && output.InviteId !== null ? output.InviteId : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    EmailAddress: __expectString(output.EmailAddress),
+    EmailStatus: __expectString(output.EmailStatus),
+    InviteId: __expectString(output.InviteId),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -28047,46 +28011,37 @@ const deserializeAws_restJson1LicenseList = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1LoggingConfiguration = (output: any, context: __SerdeContext): LoggingConfiguration => {
   return {
-    EnableSIPLogs:
-      output.EnableSIPLogs !== undefined && output.EnableSIPLogs !== null ? output.EnableSIPLogs : undefined,
+    EnableSIPLogs: __expectBoolean(output.EnableSIPLogs),
   } as any;
 };
 
 const deserializeAws_restJson1MediaPlacement = (output: any, context: __SerdeContext): MediaPlacement => {
   return {
-    AudioFallbackUrl:
-      output.AudioFallbackUrl !== undefined && output.AudioFallbackUrl !== null ? output.AudioFallbackUrl : undefined,
-    AudioHostUrl: output.AudioHostUrl !== undefined && output.AudioHostUrl !== null ? output.AudioHostUrl : undefined,
-    ScreenDataUrl:
-      output.ScreenDataUrl !== undefined && output.ScreenDataUrl !== null ? output.ScreenDataUrl : undefined,
-    ScreenSharingUrl:
-      output.ScreenSharingUrl !== undefined && output.ScreenSharingUrl !== null ? output.ScreenSharingUrl : undefined,
-    ScreenViewingUrl:
-      output.ScreenViewingUrl !== undefined && output.ScreenViewingUrl !== null ? output.ScreenViewingUrl : undefined,
-    SignalingUrl: output.SignalingUrl !== undefined && output.SignalingUrl !== null ? output.SignalingUrl : undefined,
-    TurnControlUrl:
-      output.TurnControlUrl !== undefined && output.TurnControlUrl !== null ? output.TurnControlUrl : undefined,
+    AudioFallbackUrl: __expectString(output.AudioFallbackUrl),
+    AudioHostUrl: __expectString(output.AudioHostUrl),
+    ScreenDataUrl: __expectString(output.ScreenDataUrl),
+    ScreenSharingUrl: __expectString(output.ScreenSharingUrl),
+    ScreenViewingUrl: __expectString(output.ScreenViewingUrl),
+    SignalingUrl: __expectString(output.SignalingUrl),
+    TurnControlUrl: __expectString(output.TurnControlUrl),
   } as any;
 };
 
 const deserializeAws_restJson1Meeting = (output: any, context: __SerdeContext): Meeting => {
   return {
-    ExternalMeetingId:
-      output.ExternalMeetingId !== undefined && output.ExternalMeetingId !== null
-        ? output.ExternalMeetingId
-        : undefined,
+    ExternalMeetingId: __expectString(output.ExternalMeetingId),
     MediaPlacement:
       output.MediaPlacement !== undefined && output.MediaPlacement !== null
         ? deserializeAws_restJson1MediaPlacement(output.MediaPlacement, context)
         : undefined,
-    MediaRegion: output.MediaRegion !== undefined && output.MediaRegion !== null ? output.MediaRegion : undefined,
-    MeetingId: output.MeetingId !== undefined && output.MeetingId !== null ? output.MeetingId : undefined,
+    MediaRegion: __expectString(output.MediaRegion),
+    MeetingId: __expectString(output.MeetingId),
   } as any;
 };
 
@@ -28103,19 +28058,19 @@ const deserializeAws_restJson1MeetingList = (output: any, context: __SerdeContex
 
 const deserializeAws_restJson1Member = (output: any, context: __SerdeContext): Member => {
   return {
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
-    Email: output.Email !== undefined && output.Email !== null ? output.Email : undefined,
-    FullName: output.FullName !== undefined && output.FullName !== null ? output.FullName : undefined,
-    MemberId: output.MemberId !== undefined && output.MemberId !== null ? output.MemberId : undefined,
-    MemberType: output.MemberType !== undefined && output.MemberType !== null ? output.MemberType : undefined,
+    AccountId: __expectString(output.AccountId),
+    Email: __expectString(output.Email),
+    FullName: __expectString(output.FullName),
+    MemberId: __expectString(output.MemberId),
+    MemberType: __expectString(output.MemberType),
   } as any;
 };
 
 const deserializeAws_restJson1MemberError = (output: any, context: __SerdeContext): MemberError => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    MemberId: output.MemberId !== undefined && output.MemberId !== null ? output.MemberId : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
+    MemberId: __expectString(output.MemberId),
   } as any;
 };
 
@@ -28146,15 +28101,14 @@ const deserializeAws_restJson1MessagingSessionEndpoint = (
   context: __SerdeContext
 ): MessagingSessionEndpoint => {
   return {
-    Url: output.Url !== undefined && output.Url !== null ? output.Url : undefined,
+    Url: __expectString(output.Url),
   } as any;
 };
 
 const deserializeAws_restJson1OrderedPhoneNumber = (output: any, context: __SerdeContext): OrderedPhoneNumber => {
   return {
-    E164PhoneNumber:
-      output.E164PhoneNumber !== undefined && output.E164PhoneNumber !== null ? output.E164PhoneNumber : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    E164PhoneNumber: __expectString(output.E164PhoneNumber),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -28171,7 +28125,7 @@ const deserializeAws_restJson1OrderedPhoneNumberList = (output: any, context: __
 
 const deserializeAws_restJson1Origination = (output: any, context: __SerdeContext): Origination => {
   return {
-    Disabled: output.Disabled !== undefined && output.Disabled !== null ? output.Disabled : undefined,
+    Disabled: __expectBoolean(output.Disabled),
     Routes:
       output.Routes !== undefined && output.Routes !== null
         ? deserializeAws_restJson1OriginationRouteList(output.Routes, context)
@@ -28181,11 +28135,11 @@ const deserializeAws_restJson1Origination = (output: any, context: __SerdeContex
 
 const deserializeAws_restJson1OriginationRoute = (output: any, context: __SerdeContext): OriginationRoute => {
   return {
-    Host: output.Host !== undefined && output.Host !== null ? output.Host : undefined,
-    Port: output.Port !== undefined && output.Port !== null ? output.Port : undefined,
-    Priority: output.Priority !== undefined && output.Priority !== null ? output.Priority : undefined,
-    Protocol: output.Protocol !== undefined && output.Protocol !== null ? output.Protocol : undefined,
-    Weight: output.Weight !== undefined && output.Weight !== null ? output.Weight : undefined,
+    Host: __expectString(output.Host),
+    Port: __expectNumber(output.Port),
+    Priority: __expectNumber(output.Priority),
+    Protocol: __expectString(output.Protocol),
+    Weight: __expectNumber(output.Weight),
   } as any;
 };
 
@@ -28202,9 +28156,8 @@ const deserializeAws_restJson1OriginationRouteList = (output: any, context: __Se
 
 const deserializeAws_restJson1Participant = (output: any, context: __SerdeContext): Participant => {
   return {
-    PhoneNumber: output.PhoneNumber !== undefined && output.PhoneNumber !== null ? output.PhoneNumber : undefined,
-    ProxyPhoneNumber:
-      output.ProxyPhoneNumber !== undefined && output.ProxyPhoneNumber !== null ? output.ProxyPhoneNumber : undefined,
+    PhoneNumber: __expectString(output.PhoneNumber),
+    ProxyPhoneNumber: __expectString(output.ProxyPhoneNumber),
   } as any;
 };
 
@@ -28225,16 +28178,13 @@ const deserializeAws_restJson1PhoneNumber = (output: any, context: __SerdeContex
       output.Associations !== undefined && output.Associations !== null
         ? deserializeAws_restJson1PhoneNumberAssociationList(output.Associations, context)
         : undefined,
-    CallingName: output.CallingName !== undefined && output.CallingName !== null ? output.CallingName : undefined,
-    CallingNameStatus:
-      output.CallingNameStatus !== undefined && output.CallingNameStatus !== null
-        ? output.CallingNameStatus
-        : undefined,
+    CallingName: __expectString(output.CallingName),
+    CallingNameStatus: __expectString(output.CallingNameStatus),
     Capabilities:
       output.Capabilities !== undefined && output.Capabilities !== null
         ? deserializeAws_restJson1PhoneNumberCapabilities(output.Capabilities, context)
         : undefined,
-    Country: output.Country !== undefined && output.Country !== null ? output.Country : undefined,
+    Country: __expectString(output.Country),
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
         ? new Date(output.CreatedTimestamp)
@@ -28243,13 +28193,11 @@ const deserializeAws_restJson1PhoneNumber = (output: any, context: __SerdeContex
       output.DeletionTimestamp !== undefined && output.DeletionTimestamp !== null
         ? new Date(output.DeletionTimestamp)
         : undefined,
-    E164PhoneNumber:
-      output.E164PhoneNumber !== undefined && output.E164PhoneNumber !== null ? output.E164PhoneNumber : undefined,
-    PhoneNumberId:
-      output.PhoneNumberId !== undefined && output.PhoneNumberId !== null ? output.PhoneNumberId : undefined,
-    ProductType: output.ProductType !== undefined && output.ProductType !== null ? output.ProductType : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    E164PhoneNumber: __expectString(output.E164PhoneNumber),
+    PhoneNumberId: __expectString(output.PhoneNumberId),
+    ProductType: __expectString(output.ProductType),
+    Status: __expectString(output.Status),
+    Type: __expectString(output.Type),
     UpdatedTimestamp:
       output.UpdatedTimestamp !== undefined && output.UpdatedTimestamp !== null
         ? new Date(output.UpdatedTimestamp)
@@ -28266,8 +28214,8 @@ const deserializeAws_restJson1PhoneNumberAssociation = (
       output.AssociatedTimestamp !== undefined && output.AssociatedTimestamp !== null
         ? new Date(output.AssociatedTimestamp)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Name: __expectString(output.Name),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -28290,12 +28238,12 @@ const deserializeAws_restJson1PhoneNumberCapabilities = (
   context: __SerdeContext
 ): PhoneNumberCapabilities => {
   return {
-    InboundCall: output.InboundCall !== undefined && output.InboundCall !== null ? output.InboundCall : undefined,
-    InboundMMS: output.InboundMMS !== undefined && output.InboundMMS !== null ? output.InboundMMS : undefined,
-    InboundSMS: output.InboundSMS !== undefined && output.InboundSMS !== null ? output.InboundSMS : undefined,
-    OutboundCall: output.OutboundCall !== undefined && output.OutboundCall !== null ? output.OutboundCall : undefined,
-    OutboundMMS: output.OutboundMMS !== undefined && output.OutboundMMS !== null ? output.OutboundMMS : undefined,
-    OutboundSMS: output.OutboundSMS !== undefined && output.OutboundSMS !== null ? output.OutboundSMS : undefined,
+    InboundCall: __expectBoolean(output.InboundCall),
+    InboundMMS: __expectBoolean(output.InboundMMS),
+    InboundSMS: __expectBoolean(output.InboundSMS),
+    OutboundCall: __expectBoolean(output.OutboundCall),
+    OutboundMMS: __expectBoolean(output.OutboundMMS),
+    OutboundSMS: __expectBoolean(output.OutboundSMS),
   } as any;
 };
 
@@ -28315,7 +28263,7 @@ const deserializeAws_restJson1PhoneNumberCountriesList = (
 
 const deserializeAws_restJson1PhoneNumberCountry = (output: any, context: __SerdeContext): PhoneNumberCountry => {
   return {
-    CountryCode: output.CountryCode !== undefined && output.CountryCode !== null ? output.CountryCode : undefined,
+    CountryCode: __expectString(output.CountryCode),
     SupportedPhoneNumberTypes:
       output.SupportedPhoneNumberTypes !== undefined && output.SupportedPhoneNumberTypes !== null
         ? deserializeAws_restJson1PhoneNumberTypeList(output.SupportedPhoneNumberTypes, context)
@@ -28325,10 +28273,9 @@ const deserializeAws_restJson1PhoneNumberCountry = (output: any, context: __Serd
 
 const deserializeAws_restJson1PhoneNumberError = (output: any, context: __SerdeContext): PhoneNumberError => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    PhoneNumberId:
-      output.PhoneNumberId !== undefined && output.PhoneNumberId !== null ? output.PhoneNumberId : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
+    PhoneNumberId: __expectString(output.PhoneNumberId),
   } as any;
 };
 
@@ -28364,12 +28311,9 @@ const deserializeAws_restJson1PhoneNumberOrder = (output: any, context: __SerdeC
       output.OrderedPhoneNumbers !== undefined && output.OrderedPhoneNumbers !== null
         ? deserializeAws_restJson1OrderedPhoneNumberList(output.OrderedPhoneNumbers, context)
         : undefined,
-    PhoneNumberOrderId:
-      output.PhoneNumberOrderId !== undefined && output.PhoneNumberOrderId !== null
-        ? output.PhoneNumberOrderId
-        : undefined,
-    ProductType: output.ProductType !== undefined && output.ProductType !== null ? output.ProductType : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    PhoneNumberOrderId: __expectString(output.PhoneNumberOrderId),
+    ProductType: __expectString(output.ProductType),
+    Status: __expectString(output.Status),
     UpdatedTimestamp:
       output.UpdatedTimestamp !== undefined && output.UpdatedTimestamp !== null
         ? new Date(output.UpdatedTimestamp)
@@ -28398,21 +28342,15 @@ const deserializeAws_restJson1PhoneNumberTypeList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1Proxy = (output: any, context: __SerdeContext): Proxy => {
   return {
-    DefaultSessionExpiryMinutes:
-      output.DefaultSessionExpiryMinutes !== undefined && output.DefaultSessionExpiryMinutes !== null
-        ? output.DefaultSessionExpiryMinutes
-        : undefined,
-    Disabled: output.Disabled !== undefined && output.Disabled !== null ? output.Disabled : undefined,
-    FallBackPhoneNumber:
-      output.FallBackPhoneNumber !== undefined && output.FallBackPhoneNumber !== null
-        ? output.FallBackPhoneNumber
-        : undefined,
+    DefaultSessionExpiryMinutes: __expectNumber(output.DefaultSessionExpiryMinutes),
+    Disabled: __expectBoolean(output.Disabled),
+    FallBackPhoneNumber: __expectString(output.FallBackPhoneNumber),
     PhoneNumberCountries:
       output.PhoneNumberCountries !== undefined && output.PhoneNumberCountries !== null
         ? deserializeAws_restJson1StringList(output.PhoneNumberCountries, context)
@@ -28434,32 +28372,25 @@ const deserializeAws_restJson1ProxySession = (output: any, context: __SerdeConte
       output.EndedTimestamp !== undefined && output.EndedTimestamp !== null
         ? new Date(output.EndedTimestamp)
         : undefined,
-    ExpiryMinutes:
-      output.ExpiryMinutes !== undefined && output.ExpiryMinutes !== null ? output.ExpiryMinutes : undefined,
-    GeoMatchLevel:
-      output.GeoMatchLevel !== undefined && output.GeoMatchLevel !== null ? output.GeoMatchLevel : undefined,
+    ExpiryMinutes: __expectNumber(output.ExpiryMinutes),
+    GeoMatchLevel: __expectString(output.GeoMatchLevel),
     GeoMatchParams:
       output.GeoMatchParams !== undefined && output.GeoMatchParams !== null
         ? deserializeAws_restJson1GeoMatchParams(output.GeoMatchParams, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    NumberSelectionBehavior:
-      output.NumberSelectionBehavior !== undefined && output.NumberSelectionBehavior !== null
-        ? output.NumberSelectionBehavior
-        : undefined,
+    Name: __expectString(output.Name),
+    NumberSelectionBehavior: __expectString(output.NumberSelectionBehavior),
     Participants:
       output.Participants !== undefined && output.Participants !== null
         ? deserializeAws_restJson1Participants(output.Participants, context)
         : undefined,
-    ProxySessionId:
-      output.ProxySessionId !== undefined && output.ProxySessionId !== null ? output.ProxySessionId : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    ProxySessionId: __expectString(output.ProxySessionId),
+    Status: __expectString(output.Status),
     UpdatedTimestamp:
       output.UpdatedTimestamp !== undefined && output.UpdatedTimestamp !== null
         ? new Date(output.UpdatedTimestamp)
         : undefined,
-    VoiceConnectorId:
-      output.VoiceConnectorId !== undefined && output.VoiceConnectorId !== null ? output.VoiceConnectorId : undefined,
+    VoiceConnectorId: __expectString(output.VoiceConnectorId),
   } as any;
 };
 
@@ -28489,14 +28420,14 @@ const deserializeAws_restJson1RetentionSettings = (output: any, context: __Serde
 
 const deserializeAws_restJson1Room = (output: any, context: __SerdeContext): Room => {
   return {
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
-    CreatedBy: output.CreatedBy !== undefined && output.CreatedBy !== null ? output.CreatedBy : undefined,
+    AccountId: __expectString(output.AccountId),
+    CreatedBy: __expectString(output.CreatedBy),
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
         ? new Date(output.CreatedTimestamp)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    RoomId: output.RoomId !== undefined && output.RoomId !== null ? output.RoomId : undefined,
+    Name: __expectString(output.Name),
+    RoomId: __expectString(output.RoomId),
     UpdatedTimestamp:
       output.UpdatedTimestamp !== undefined && output.UpdatedTimestamp !== null
         ? new Date(output.UpdatedTimestamp)
@@ -28517,13 +28448,13 @@ const deserializeAws_restJson1RoomList = (output: any, context: __SerdeContext):
 
 const deserializeAws_restJson1RoomMembership = (output: any, context: __SerdeContext): RoomMembership => {
   return {
-    InvitedBy: output.InvitedBy !== undefined && output.InvitedBy !== null ? output.InvitedBy : undefined,
+    InvitedBy: __expectString(output.InvitedBy),
     Member:
       output.Member !== undefined && output.Member !== null
         ? deserializeAws_restJson1Member(output.Member, context)
         : undefined,
-    Role: output.Role !== undefined && output.Role !== null ? output.Role : undefined,
-    RoomId: output.RoomId !== undefined && output.RoomId !== null ? output.RoomId : undefined,
+    Role: __expectString(output.Role),
+    RoomId: __expectString(output.RoomId),
     UpdatedTimestamp:
       output.UpdatedTimestamp !== undefined && output.UpdatedTimestamp !== null
         ? new Date(output.UpdatedTimestamp)
@@ -28544,8 +28475,7 @@ const deserializeAws_restJson1RoomMembershipList = (output: any, context: __Serd
 
 const deserializeAws_restJson1RoomRetentionSettings = (output: any, context: __SerdeContext): RoomRetentionSettings => {
   return {
-    RetentionDays:
-      output.RetentionDays !== undefined && output.RetentionDays !== null ? output.RetentionDays : undefined,
+    RetentionDays: __expectNumber(output.RetentionDays),
   } as any;
 };
 
@@ -28556,13 +28486,13 @@ const deserializeAws_restJson1SensitiveStringList = (output: any, context: __Ser
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1SigninDelegateGroup = (output: any, context: __SerdeContext): SigninDelegateGroup => {
   return {
-    GroupName: output.GroupName !== undefined && output.GroupName !== null ? output.GroupName : undefined,
+    GroupName: __expectString(output.GroupName),
   } as any;
 };
 
@@ -28582,7 +28512,7 @@ const deserializeAws_restJson1SigninDelegateGroupList = (
 
 const deserializeAws_restJson1SipMediaApplication = (output: any, context: __SerdeContext): SipMediaApplication => {
   return {
-    AwsRegion: output.AwsRegion !== undefined && output.AwsRegion !== null ? output.AwsRegion : undefined,
+    AwsRegion: __expectString(output.AwsRegion),
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
         ? new Date(output.CreatedTimestamp)
@@ -28591,11 +28521,8 @@ const deserializeAws_restJson1SipMediaApplication = (output: any, context: __Ser
       output.Endpoints !== undefined && output.Endpoints !== null
         ? deserializeAws_restJson1SipMediaApplicationEndpointList(output.Endpoints, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    SipMediaApplicationId:
-      output.SipMediaApplicationId !== undefined && output.SipMediaApplicationId !== null
-        ? output.SipMediaApplicationId
-        : undefined,
+    Name: __expectString(output.Name),
+    SipMediaApplicationId: __expectString(output.SipMediaApplicationId),
     UpdatedTimestamp:
       output.UpdatedTimestamp !== undefined && output.UpdatedTimestamp !== null
         ? new Date(output.UpdatedTimestamp)
@@ -28608,8 +28535,7 @@ const deserializeAws_restJson1SipMediaApplicationCall = (
   context: __SerdeContext
 ): SipMediaApplicationCall => {
   return {
-    TransactionId:
-      output.TransactionId !== undefined && output.TransactionId !== null ? output.TransactionId : undefined,
+    TransactionId: __expectString(output.TransactionId),
   } as any;
 };
 
@@ -28618,7 +28544,7 @@ const deserializeAws_restJson1SipMediaApplicationEndpoint = (
   context: __SerdeContext
 ): SipMediaApplicationEndpoint => {
   return {
-    LambdaArn: output.LambdaArn !== undefined && output.LambdaArn !== null ? output.LambdaArn : undefined,
+    LambdaArn: __expectString(output.LambdaArn),
   } as any;
 };
 
@@ -28655,10 +28581,7 @@ const deserializeAws_restJson1SipMediaApplicationLoggingConfiguration = (
   context: __SerdeContext
 ): SipMediaApplicationLoggingConfiguration => {
   return {
-    EnableSipMediaApplicationMessageLogs:
-      output.EnableSipMediaApplicationMessageLogs !== undefined && output.EnableSipMediaApplicationMessageLogs !== null
-        ? output.EnableSipMediaApplicationMessageLogs
-        : undefined,
+    EnableSipMediaApplicationMessageLogs: __expectBoolean(output.EnableSipMediaApplicationMessageLogs),
   } as any;
 };
 
@@ -28668,15 +28591,15 @@ const deserializeAws_restJson1SipRule = (output: any, context: __SerdeContext): 
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
         ? new Date(output.CreatedTimestamp)
         : undefined,
-    Disabled: output.Disabled !== undefined && output.Disabled !== null ? output.Disabled : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    SipRuleId: output.SipRuleId !== undefined && output.SipRuleId !== null ? output.SipRuleId : undefined,
+    Disabled: __expectBoolean(output.Disabled),
+    Name: __expectString(output.Name),
+    SipRuleId: __expectString(output.SipRuleId),
     TargetApplications:
       output.TargetApplications !== undefined && output.TargetApplications !== null
         ? deserializeAws_restJson1SipRuleTargetApplicationList(output.TargetApplications, context)
         : undefined,
-    TriggerType: output.TriggerType !== undefined && output.TriggerType !== null ? output.TriggerType : undefined,
-    TriggerValue: output.TriggerValue !== undefined && output.TriggerValue !== null ? output.TriggerValue : undefined,
+    TriggerType: __expectString(output.TriggerType),
+    TriggerValue: __expectString(output.TriggerValue),
     UpdatedTimestamp:
       output.UpdatedTimestamp !== undefined && output.UpdatedTimestamp !== null
         ? new Date(output.UpdatedTimestamp)
@@ -28700,12 +28623,9 @@ const deserializeAws_restJson1SipRuleTargetApplication = (
   context: __SerdeContext
 ): SipRuleTargetApplication => {
   return {
-    AwsRegion: output.AwsRegion !== undefined && output.AwsRegion !== null ? output.AwsRegion : undefined,
-    Priority: output.Priority !== undefined && output.Priority !== null ? output.Priority : undefined,
-    SipMediaApplicationId:
-      output.SipMediaApplicationId !== undefined && output.SipMediaApplicationId !== null
-        ? output.SipMediaApplicationId
-        : undefined,
+    AwsRegion: __expectString(output.AwsRegion),
+    Priority: __expectNumber(output.Priority),
+    SipMediaApplicationId: __expectString(output.SipMediaApplicationId),
   } as any;
 };
 
@@ -28728,11 +28648,8 @@ const deserializeAws_restJson1StreamingConfiguration = (
   context: __SerdeContext
 ): StreamingConfiguration => {
   return {
-    DataRetentionInHours:
-      output.DataRetentionInHours !== undefined && output.DataRetentionInHours !== null
-        ? output.DataRetentionInHours
-        : undefined,
-    Disabled: output.Disabled !== undefined && output.Disabled !== null ? output.Disabled : undefined,
+    DataRetentionInHours: __expectNumber(output.DataRetentionInHours),
+    Disabled: __expectBoolean(output.Disabled),
     StreamingNotificationTargets:
       output.StreamingNotificationTargets !== undefined && output.StreamingNotificationTargets !== null
         ? deserializeAws_restJson1StreamingNotificationTargetList(output.StreamingNotificationTargets, context)
@@ -28745,10 +28662,7 @@ const deserializeAws_restJson1StreamingNotificationTarget = (
   context: __SerdeContext
 ): StreamingNotificationTarget => {
   return {
-    NotificationTarget:
-      output.NotificationTarget !== undefined && output.NotificationTarget !== null
-        ? output.NotificationTarget
-        : undefined,
+    NotificationTarget: __expectString(output.NotificationTarget),
   } as any;
 };
 
@@ -28773,14 +28687,14 @@ const deserializeAws_restJson1StringList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -28797,11 +28711,9 @@ const deserializeAws_restJson1TagList = (output: any, context: __SerdeContext): 
 
 const deserializeAws_restJson1TelephonySettings = (output: any, context: __SerdeContext): TelephonySettings => {
   return {
-    InboundCalling:
-      output.InboundCalling !== undefined && output.InboundCalling !== null ? output.InboundCalling : undefined,
-    OutboundCalling:
-      output.OutboundCalling !== undefined && output.OutboundCalling !== null ? output.OutboundCalling : undefined,
-    SMS: output.SMS !== undefined && output.SMS !== null ? output.SMS : undefined,
+    InboundCalling: __expectBoolean(output.InboundCalling),
+    OutboundCalling: __expectBoolean(output.OutboundCalling),
+    SMS: __expectBoolean(output.SMS),
   } as any;
 };
 
@@ -28815,58 +28727,46 @@ const deserializeAws_restJson1Termination = (output: any, context: __SerdeContex
       output.CidrAllowedList !== undefined && output.CidrAllowedList !== null
         ? deserializeAws_restJson1StringList(output.CidrAllowedList, context)
         : undefined,
-    CpsLimit: output.CpsLimit !== undefined && output.CpsLimit !== null ? output.CpsLimit : undefined,
-    DefaultPhoneNumber:
-      output.DefaultPhoneNumber !== undefined && output.DefaultPhoneNumber !== null
-        ? output.DefaultPhoneNumber
-        : undefined,
-    Disabled: output.Disabled !== undefined && output.Disabled !== null ? output.Disabled : undefined,
+    CpsLimit: __expectNumber(output.CpsLimit),
+    DefaultPhoneNumber: __expectString(output.DefaultPhoneNumber),
+    Disabled: __expectBoolean(output.Disabled),
   } as any;
 };
 
 const deserializeAws_restJson1TerminationHealth = (output: any, context: __SerdeContext): TerminationHealth => {
   return {
-    Source: output.Source !== undefined && output.Source !== null ? output.Source : undefined,
+    Source: __expectString(output.Source),
     Timestamp: output.Timestamp !== undefined && output.Timestamp !== null ? new Date(output.Timestamp) : undefined,
   } as any;
 };
 
 const deserializeAws_restJson1User = (output: any, context: __SerdeContext): User => {
   return {
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
+    AccountId: __expectString(output.AccountId),
     AlexaForBusinessMetadata:
       output.AlexaForBusinessMetadata !== undefined && output.AlexaForBusinessMetadata !== null
         ? deserializeAws_restJson1AlexaForBusinessMetadata(output.AlexaForBusinessMetadata, context)
         : undefined,
-    DisplayName: output.DisplayName !== undefined && output.DisplayName !== null ? output.DisplayName : undefined,
+    DisplayName: __expectString(output.DisplayName),
     InvitedOn: output.InvitedOn !== undefined && output.InvitedOn !== null ? new Date(output.InvitedOn) : undefined,
-    LicenseType: output.LicenseType !== undefined && output.LicenseType !== null ? output.LicenseType : undefined,
-    PersonalPIN: output.PersonalPIN !== undefined && output.PersonalPIN !== null ? output.PersonalPIN : undefined,
-    PrimaryEmail: output.PrimaryEmail !== undefined && output.PrimaryEmail !== null ? output.PrimaryEmail : undefined,
-    PrimaryProvisionedNumber:
-      output.PrimaryProvisionedNumber !== undefined && output.PrimaryProvisionedNumber !== null
-        ? output.PrimaryProvisionedNumber
-        : undefined,
+    LicenseType: __expectString(output.LicenseType),
+    PersonalPIN: __expectString(output.PersonalPIN),
+    PrimaryEmail: __expectString(output.PrimaryEmail),
+    PrimaryProvisionedNumber: __expectString(output.PrimaryProvisionedNumber),
     RegisteredOn:
       output.RegisteredOn !== undefined && output.RegisteredOn !== null ? new Date(output.RegisteredOn) : undefined,
-    UserId: output.UserId !== undefined && output.UserId !== null ? output.UserId : undefined,
-    UserInvitationStatus:
-      output.UserInvitationStatus !== undefined && output.UserInvitationStatus !== null
-        ? output.UserInvitationStatus
-        : undefined,
-    UserRegistrationStatus:
-      output.UserRegistrationStatus !== undefined && output.UserRegistrationStatus !== null
-        ? output.UserRegistrationStatus
-        : undefined,
-    UserType: output.UserType !== undefined && output.UserType !== null ? output.UserType : undefined,
+    UserId: __expectString(output.UserId),
+    UserInvitationStatus: __expectString(output.UserInvitationStatus),
+    UserRegistrationStatus: __expectString(output.UserRegistrationStatus),
+    UserType: __expectString(output.UserType),
   } as any;
 };
 
 const deserializeAws_restJson1UserError = (output: any, context: __SerdeContext): UserError => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    UserId: output.UserId !== undefined && output.UserId !== null ? output.UserId : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
+    UserId: __expectString(output.UserId),
   } as any;
 };
 
@@ -28903,24 +28803,19 @@ const deserializeAws_restJson1UserSettings = (output: any, context: __SerdeConte
 
 const deserializeAws_restJson1VoiceConnector = (output: any, context: __SerdeContext): VoiceConnector => {
   return {
-    AwsRegion: output.AwsRegion !== undefined && output.AwsRegion !== null ? output.AwsRegion : undefined,
+    AwsRegion: __expectString(output.AwsRegion),
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
         ? new Date(output.CreatedTimestamp)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    OutboundHostName:
-      output.OutboundHostName !== undefined && output.OutboundHostName !== null ? output.OutboundHostName : undefined,
-    RequireEncryption:
-      output.RequireEncryption !== undefined && output.RequireEncryption !== null
-        ? output.RequireEncryption
-        : undefined,
+    Name: __expectString(output.Name),
+    OutboundHostName: __expectString(output.OutboundHostName),
+    RequireEncryption: __expectBoolean(output.RequireEncryption),
     UpdatedTimestamp:
       output.UpdatedTimestamp !== undefined && output.UpdatedTimestamp !== null
         ? new Date(output.UpdatedTimestamp)
         : undefined,
-    VoiceConnectorId:
-      output.VoiceConnectorId !== undefined && output.VoiceConnectorId !== null ? output.VoiceConnectorId : undefined,
+    VoiceConnectorId: __expectString(output.VoiceConnectorId),
   } as any;
 };
 
@@ -28930,15 +28825,12 @@ const deserializeAws_restJson1VoiceConnectorGroup = (output: any, context: __Ser
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
         ? new Date(output.CreatedTimestamp)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     UpdatedTimestamp:
       output.UpdatedTimestamp !== undefined && output.UpdatedTimestamp !== null
         ? new Date(output.UpdatedTimestamp)
         : undefined,
-    VoiceConnectorGroupId:
-      output.VoiceConnectorGroupId !== undefined && output.VoiceConnectorGroupId !== null
-        ? output.VoiceConnectorGroupId
-        : undefined,
+    VoiceConnectorGroupId: __expectString(output.VoiceConnectorGroupId),
     VoiceConnectorItems:
       output.VoiceConnectorItems !== undefined && output.VoiceConnectorItems !== null
         ? deserializeAws_restJson1VoiceConnectorItemList(output.VoiceConnectorItems, context)
@@ -28962,9 +28854,8 @@ const deserializeAws_restJson1VoiceConnectorGroupList = (
 
 const deserializeAws_restJson1VoiceConnectorItem = (output: any, context: __SerdeContext): VoiceConnectorItem => {
   return {
-    Priority: output.Priority !== undefined && output.Priority !== null ? output.Priority : undefined,
-    VoiceConnectorId:
-      output.VoiceConnectorId !== undefined && output.VoiceConnectorId !== null ? output.VoiceConnectorId : undefined,
+    Priority: __expectNumber(output.Priority),
+    VoiceConnectorId: __expectString(output.VoiceConnectorId),
   } as any;
 };
 
@@ -28995,7 +28886,7 @@ const deserializeAws_restJson1VoiceConnectorSettings = (
   context: __SerdeContext
 ): VoiceConnectorSettings => {
   return {
-    CdrBucket: output.CdrBucket !== undefined && output.CdrBucket !== null ? output.CdrBucket : undefined,
+    CdrBucket: __expectString(output.CdrBucket),
   } as any;
 };
 

--- a/clients/client-cloud9/protocols/Aws_json1_1.ts
+++ b/clients/client-cloud9/protocols/Aws_json1_1.ts
@@ -77,7 +77,11 @@ import {
   UpdateEnvironmentResult,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -1813,9 +1817,9 @@ const serializeAws_json1_1UpdateEnvironmentRequest = (
 
 const deserializeAws_json1_1BadRequestException = (output: any, context: __SerdeContext): BadRequestException => {
   return {
-    className: output.className !== undefined && output.className !== null ? output.className : undefined,
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    className: __expectString(output.className),
+    code: __expectNumber(output.code),
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -1824,17 +1828,17 @@ const deserializeAws_json1_1ConcurrentAccessException = (
   context: __SerdeContext
 ): ConcurrentAccessException => {
   return {
-    className: output.className !== undefined && output.className !== null ? output.className : undefined,
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    className: __expectString(output.className),
+    code: __expectNumber(output.code),
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1ConflictException = (output: any, context: __SerdeContext): ConflictException => {
   return {
-    className: output.className !== undefined && output.className !== null ? output.className : undefined,
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    className: __expectString(output.className),
+    code: __expectNumber(output.code),
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -1843,8 +1847,7 @@ const deserializeAws_json1_1CreateEnvironmentEC2Result = (
   context: __SerdeContext
 ): CreateEnvironmentEC2Result => {
   return {
-    environmentId:
-      output.environmentId !== undefined && output.environmentId !== null ? output.environmentId : undefined,
+    environmentId: __expectString(output.environmentId),
   } as any;
 };
 
@@ -1883,7 +1886,7 @@ const deserializeAws_json1_1DescribeEnvironmentMembershipsResult = (
       output.memberships !== undefined && output.memberships !== null
         ? deserializeAws_json1_1EnvironmentMembersList(output.memberships, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -1904,29 +1907,25 @@ const deserializeAws_json1_1DescribeEnvironmentStatusResult = (
   context: __SerdeContext
 ): DescribeEnvironmentStatusResult => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    message: __expectString(output.message),
+    status: __expectString(output.status),
   } as any;
 };
 
 const deserializeAws_json1_1Environment = (output: any, context: __SerdeContext): Environment => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    connectionType:
-      output.connectionType !== undefined && output.connectionType !== null ? output.connectionType : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    arn: __expectString(output.arn),
+    connectionType: __expectString(output.connectionType),
+    description: __expectString(output.description),
+    id: __expectString(output.id),
     lifecycle:
       output.lifecycle !== undefined && output.lifecycle !== null
         ? deserializeAws_json1_1EnvironmentLifecycle(output.lifecycle, context)
         : undefined,
-    managedCredentialsStatus:
-      output.managedCredentialsStatus !== undefined && output.managedCredentialsStatus !== null
-        ? output.managedCredentialsStatus
-        : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    ownerArn: output.ownerArn !== undefined && output.ownerArn !== null ? output.ownerArn : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    managedCredentialsStatus: __expectString(output.managedCredentialsStatus),
+    name: __expectString(output.name),
+    ownerArn: __expectString(output.ownerArn),
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -1937,16 +1936,15 @@ const deserializeAws_json1_1EnvironmentIdList = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1EnvironmentLifecycle = (output: any, context: __SerdeContext): EnvironmentLifecycle => {
   return {
-    failureResource:
-      output.failureResource !== undefined && output.failureResource !== null ? output.failureResource : undefined,
-    reason: output.reason !== undefined && output.reason !== null ? output.reason : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    failureResource: __expectString(output.failureResource),
+    reason: __expectString(output.reason),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -1963,15 +1961,14 @@ const deserializeAws_json1_1EnvironmentList = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_1EnvironmentMember = (output: any, context: __SerdeContext): EnvironmentMember => {
   return {
-    environmentId:
-      output.environmentId !== undefined && output.environmentId !== null ? output.environmentId : undefined,
+    environmentId: __expectString(output.environmentId),
     lastAccess:
       output.lastAccess !== undefined && output.lastAccess !== null
         ? new Date(Math.round(output.lastAccess * 1000))
         : undefined,
-    permissions: output.permissions !== undefined && output.permissions !== null ? output.permissions : undefined,
-    userArn: output.userArn !== undefined && output.userArn !== null ? output.userArn : undefined,
-    userId: output.userId !== undefined && output.userId !== null ? output.userId : undefined,
+    permissions: __expectString(output.permissions),
+    userArn: __expectString(output.userArn),
+    userId: __expectString(output.userId),
   } as any;
 };
 
@@ -1988,9 +1985,9 @@ const deserializeAws_json1_1EnvironmentMembersList = (output: any, context: __Se
 
 const deserializeAws_json1_1ForbiddenException = (output: any, context: __SerdeContext): ForbiddenException => {
   return {
-    className: output.className !== undefined && output.className !== null ? output.className : undefined,
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    className: __expectString(output.className),
+    code: __expectNumber(output.code),
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -1999,17 +1996,17 @@ const deserializeAws_json1_1InternalServerErrorException = (
   context: __SerdeContext
 ): InternalServerErrorException => {
   return {
-    className: output.className !== undefined && output.className !== null ? output.className : undefined,
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    className: __expectString(output.className),
+    code: __expectNumber(output.code),
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    className: output.className !== undefined && output.className !== null ? output.className : undefined,
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    className: __expectString(output.className),
+    code: __expectNumber(output.code),
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -2019,7 +2016,7 @@ const deserializeAws_json1_1ListEnvironmentsResult = (output: any, context: __Se
       output.environmentIds !== undefined && output.environmentIds !== null
         ? deserializeAws_json1_1EnvironmentIdList(output.environmentIds, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -2037,16 +2034,16 @@ const deserializeAws_json1_1ListTagsForResourceResponse = (
 
 const deserializeAws_json1_1NotFoundException = (output: any, context: __SerdeContext): NotFoundException => {
   return {
-    className: output.className !== undefined && output.className !== null ? output.className : undefined,
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    className: __expectString(output.className),
+    code: __expectNumber(output.code),
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -2070,9 +2067,9 @@ const deserializeAws_json1_1TooManyRequestsException = (
   context: __SerdeContext
 ): TooManyRequestsException => {
   return {
-    className: output.className !== undefined && output.className !== null ? output.className : undefined,
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    className: __expectString(output.className),
+    code: __expectNumber(output.code),
+    message: __expectString(output.message),
   } as any;
 };
 

--- a/clients/client-clouddirectory/protocols/Aws_restJson1.ts
+++ b/clients/client-clouddirectory/protocols/Aws_restJson1.ts
@@ -275,7 +275,12 @@ import {
   ValidationException,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -2309,10 +2314,10 @@ export const deserializeAws_restJson1ApplySchemaCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AppliedSchemaArn !== undefined && data.AppliedSchemaArn !== null) {
-    contents.AppliedSchemaArn = data.AppliedSchemaArn;
+    contents.AppliedSchemaArn = __expectString(data.AppliedSchemaArn);
   }
   if (data.DirectoryArn !== undefined && data.DirectoryArn !== null) {
-    contents.DirectoryArn = data.DirectoryArn;
+    contents.DirectoryArn = __expectString(data.DirectoryArn);
   }
   return Promise.resolve(contents);
 };
@@ -2431,7 +2436,7 @@ export const deserializeAws_restJson1AttachObjectCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AttachedObjectIdentifier !== undefined && data.AttachedObjectIdentifier !== null) {
-    contents.AttachedObjectIdentifier = data.AttachedObjectIdentifier;
+    contents.AttachedObjectIdentifier = __expectString(data.AttachedObjectIdentifier);
   }
   return Promise.resolve(contents);
 };
@@ -2681,7 +2686,7 @@ export const deserializeAws_restJson1AttachToIndexCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AttachedObjectIdentifier !== undefined && data.AttachedObjectIdentifier !== null) {
-    contents.AttachedObjectIdentifier = data.AttachedObjectIdentifier;
+    contents.AttachedObjectIdentifier = __expectString(data.AttachedObjectIdentifier);
   }
   return Promise.resolve(contents);
 };
@@ -3168,16 +3173,16 @@ export const deserializeAws_restJson1CreateDirectoryCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AppliedSchemaArn !== undefined && data.AppliedSchemaArn !== null) {
-    contents.AppliedSchemaArn = data.AppliedSchemaArn;
+    contents.AppliedSchemaArn = __expectString(data.AppliedSchemaArn);
   }
   if (data.DirectoryArn !== undefined && data.DirectoryArn !== null) {
-    contents.DirectoryArn = data.DirectoryArn;
+    contents.DirectoryArn = __expectString(data.DirectoryArn);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.ObjectIdentifier !== undefined && data.ObjectIdentifier !== null) {
-    contents.ObjectIdentifier = data.ObjectIdentifier;
+    contents.ObjectIdentifier = __expectString(data.ObjectIdentifier);
   }
   return Promise.resolve(contents);
 };
@@ -3411,7 +3416,7 @@ export const deserializeAws_restJson1CreateIndexCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ObjectIdentifier !== undefined && data.ObjectIdentifier !== null) {
-    contents.ObjectIdentifier = data.ObjectIdentifier;
+    contents.ObjectIdentifier = __expectString(data.ObjectIdentifier);
   }
   return Promise.resolve(contents);
 };
@@ -3546,7 +3551,7 @@ export const deserializeAws_restJson1CreateObjectCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ObjectIdentifier !== undefined && data.ObjectIdentifier !== null) {
-    contents.ObjectIdentifier = data.ObjectIdentifier;
+    contents.ObjectIdentifier = __expectString(data.ObjectIdentifier);
   }
   return Promise.resolve(contents);
 };
@@ -3681,7 +3686,7 @@ export const deserializeAws_restJson1CreateSchemaCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.SchemaArn !== undefined && data.SchemaArn !== null) {
-    contents.SchemaArn = data.SchemaArn;
+    contents.SchemaArn = __expectString(data.SchemaArn);
   }
   return Promise.resolve(contents);
 };
@@ -3907,7 +3912,7 @@ export const deserializeAws_restJson1DeleteDirectoryCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.DirectoryArn !== undefined && data.DirectoryArn !== null) {
-    contents.DirectoryArn = data.DirectoryArn;
+    contents.DirectoryArn = __expectString(data.DirectoryArn);
   }
   return Promise.resolve(contents);
 };
@@ -4256,7 +4261,7 @@ export const deserializeAws_restJson1DeleteSchemaCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.SchemaArn !== undefined && data.SchemaArn !== null) {
-    contents.SchemaArn = data.SchemaArn;
+    contents.SchemaArn = __expectString(data.SchemaArn);
   }
   return Promise.resolve(contents);
 };
@@ -4474,7 +4479,7 @@ export const deserializeAws_restJson1DetachFromIndexCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.DetachedObjectIdentifier !== undefined && data.DetachedObjectIdentifier !== null) {
-    contents.DetachedObjectIdentifier = data.DetachedObjectIdentifier;
+    contents.DetachedObjectIdentifier = __expectString(data.DetachedObjectIdentifier);
   }
   return Promise.resolve(contents);
 };
@@ -4601,7 +4606,7 @@ export const deserializeAws_restJson1DetachObjectCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.DetachedObjectIdentifier !== undefined && data.DetachedObjectIdentifier !== null) {
-    contents.DetachedObjectIdentifier = data.DetachedObjectIdentifier;
+    contents.DetachedObjectIdentifier = __expectString(data.DetachedObjectIdentifier);
   }
   return Promise.resolve(contents);
 };
@@ -4950,7 +4955,7 @@ export const deserializeAws_restJson1DisableDirectoryCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.DirectoryArn !== undefined && data.DirectoryArn !== null) {
-    contents.DirectoryArn = data.DirectoryArn;
+    contents.DirectoryArn = __expectString(data.DirectoryArn);
   }
   return Promise.resolve(contents);
 };
@@ -5061,7 +5066,7 @@ export const deserializeAws_restJson1EnableDirectoryCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.DirectoryArn !== undefined && data.DirectoryArn !== null) {
-    contents.DirectoryArn = data.DirectoryArn;
+    contents.DirectoryArn = __expectString(data.DirectoryArn);
   }
   return Promise.resolve(contents);
 };
@@ -5172,7 +5177,7 @@ export const deserializeAws_restJson1GetAppliedSchemaVersionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AppliedSchemaArn !== undefined && data.AppliedSchemaArn !== null) {
-    contents.AppliedSchemaArn = data.AppliedSchemaArn;
+    contents.AppliedSchemaArn = __expectString(data.AppliedSchemaArn);
   }
   return Promise.resolve(contents);
 };
@@ -5720,7 +5725,7 @@ export const deserializeAws_restJson1GetObjectInformationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ObjectIdentifier !== undefined && data.ObjectIdentifier !== null) {
-    contents.ObjectIdentifier = data.ObjectIdentifier;
+    contents.ObjectIdentifier = __expectString(data.ObjectIdentifier);
   }
   if (data.SchemaFacets !== undefined && data.SchemaFacets !== null) {
     contents.SchemaFacets = deserializeAws_restJson1SchemaFacetList(data.SchemaFacets, context);
@@ -5835,10 +5840,10 @@ export const deserializeAws_restJson1GetSchemaAsJsonCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Document !== undefined && data.Document !== null) {
-    contents.Document = data.Document;
+    contents.Document = __expectString(data.Document);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   return Promise.resolve(contents);
 };
@@ -6061,7 +6066,7 @@ export const deserializeAws_restJson1ListAppliedSchemaArnsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.SchemaArns !== undefined && data.SchemaArns !== null) {
     contents.SchemaArns = deserializeAws_restJson1Arns(data.SchemaArns, context);
@@ -6179,7 +6184,7 @@ export const deserializeAws_restJson1ListAttachedIndicesCommand = async (
     contents.IndexAttachments = deserializeAws_restJson1IndexAttachmentList(data.IndexAttachments, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -6291,7 +6296,7 @@ export const deserializeAws_restJson1ListDevelopmentSchemaArnsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.SchemaArns !== undefined && data.SchemaArns !== null) {
     contents.SchemaArns = deserializeAws_restJson1Arns(data.SchemaArns, context);
@@ -6409,7 +6414,7 @@ export const deserializeAws_restJson1ListDirectoriesCommand = async (
     contents.Directories = deserializeAws_restJson1DirectoryList(data.Directories, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -6516,7 +6521,7 @@ export const deserializeAws_restJson1ListFacetAttributesCommand = async (
     contents.Attributes = deserializeAws_restJson1FacetAttributeList(data.Attributes, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -6639,7 +6644,7 @@ export const deserializeAws_restJson1ListFacetNamesCommand = async (
     contents.FacetNames = deserializeAws_restJson1FacetNameList(data.FacetNames, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -6754,7 +6759,7 @@ export const deserializeAws_restJson1ListIncomingTypedLinksCommand = async (
     contents.LinkSpecifiers = deserializeAws_restJson1TypedLinkSpecifierList(data.LinkSpecifiers, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -6885,7 +6890,7 @@ export const deserializeAws_restJson1ListIndexCommand = async (
     contents.IndexAttachments = deserializeAws_restJson1IndexAttachmentList(data.IndexAttachments, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -7021,7 +7026,7 @@ export const deserializeAws_restJson1ListManagedSchemaArnsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.SchemaArns !== undefined && data.SchemaArns !== null) {
     contents.SchemaArns = deserializeAws_restJson1Arns(data.SchemaArns, context);
@@ -7123,7 +7128,7 @@ export const deserializeAws_restJson1ListObjectAttributesCommand = async (
     contents.Attributes = deserializeAws_restJson1AttributeKeyAndValueList(data.Attributes, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -7254,7 +7259,7 @@ export const deserializeAws_restJson1ListObjectChildrenCommand = async (
     contents.Children = deserializeAws_restJson1LinkNameToObjectIdentifierMap(data.Children, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -7382,7 +7387,7 @@ export const deserializeAws_restJson1ListObjectParentPathsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.PathToObjectIdentifiersList !== undefined && data.PathToObjectIdentifiersList !== null) {
     contents.PathToObjectIdentifiersList = deserializeAws_restJson1PathToObjectIdentifiersList(
@@ -7509,7 +7514,7 @@ export const deserializeAws_restJson1ListObjectParentsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.ParentLinks !== undefined && data.ParentLinks !== null) {
     contents.ParentLinks = deserializeAws_restJson1ObjectIdentifierAndLinkNameList(data.ParentLinks, context);
@@ -7646,7 +7651,7 @@ export const deserializeAws_restJson1ListObjectPoliciesCommand = async (
     contents.AttachedPolicyIds = deserializeAws_restJson1ObjectIdentifierList(data.AttachedPolicyIds, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -7766,7 +7771,7 @@ export const deserializeAws_restJson1ListOutgoingTypedLinksCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.TypedLinkSpecifiers !== undefined && data.TypedLinkSpecifiers !== null) {
     contents.TypedLinkSpecifiers = deserializeAws_restJson1TypedLinkSpecifierList(data.TypedLinkSpecifiers, context);
@@ -7897,7 +7902,7 @@ export const deserializeAws_restJson1ListPolicyAttachmentsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.ObjectIdentifiers !== undefined && data.ObjectIdentifiers !== null) {
     contents.ObjectIdentifiers = deserializeAws_restJson1ObjectIdentifierList(data.ObjectIdentifiers, context);
@@ -8028,7 +8033,7 @@ export const deserializeAws_restJson1ListPublishedSchemaArnsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.SchemaArns !== undefined && data.SchemaArns !== null) {
     contents.SchemaArns = deserializeAws_restJson1Arns(data.SchemaArns, context);
@@ -8143,7 +8148,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagList(data.Tags, context);
@@ -8261,7 +8266,7 @@ export const deserializeAws_restJson1ListTypedLinkFacetAttributesCommand = async
     contents.Attributes = deserializeAws_restJson1TypedLinkAttributeDefinitionList(data.Attributes, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -8384,7 +8389,7 @@ export const deserializeAws_restJson1ListTypedLinkFacetNamesCommand = async (
     contents.FacetNames = deserializeAws_restJson1TypedLinkNameList(data.FacetNames, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -8496,7 +8501,7 @@ export const deserializeAws_restJson1LookupPolicyCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.PolicyToPathList !== undefined && data.PolicyToPathList !== null) {
     contents.PolicyToPathList = deserializeAws_restJson1PolicyToPathList(data.PolicyToPathList, context);
@@ -8618,7 +8623,7 @@ export const deserializeAws_restJson1PublishSchemaCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.PublishedSchemaArn !== undefined && data.PublishedSchemaArn !== null) {
-    contents.PublishedSchemaArn = data.PublishedSchemaArn;
+    contents.PublishedSchemaArn = __expectString(data.PublishedSchemaArn);
   }
   return Promise.resolve(contents);
 };
@@ -8729,7 +8734,7 @@ export const deserializeAws_restJson1PutSchemaFromJsonCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   return Promise.resolve(contents);
 };
@@ -9415,7 +9420,7 @@ export const deserializeAws_restJson1UpdateObjectAttributesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ObjectIdentifier !== undefined && data.ObjectIdentifier !== null) {
-    contents.ObjectIdentifier = data.ObjectIdentifier;
+    contents.ObjectIdentifier = __expectString(data.ObjectIdentifier);
   }
   return Promise.resolve(contents);
 };
@@ -9542,7 +9547,7 @@ export const deserializeAws_restJson1UpdateSchemaCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.SchemaArn !== undefined && data.SchemaArn !== null) {
-    contents.SchemaArn = data.SchemaArn;
+    contents.SchemaArn = __expectString(data.SchemaArn);
   }
   return Promise.resolve(contents);
 };
@@ -9777,10 +9782,10 @@ export const deserializeAws_restJson1UpgradeAppliedSchemaCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.DirectoryArn !== undefined && data.DirectoryArn !== null) {
-    contents.DirectoryArn = data.DirectoryArn;
+    contents.DirectoryArn = __expectString(data.DirectoryArn);
   }
   if (data.UpgradedSchemaArn !== undefined && data.UpgradedSchemaArn !== null) {
-    contents.UpgradedSchemaArn = data.UpgradedSchemaArn;
+    contents.UpgradedSchemaArn = __expectString(data.UpgradedSchemaArn);
   }
   return Promise.resolve(contents);
 };
@@ -9899,7 +9904,7 @@ export const deserializeAws_restJson1UpgradePublishedSchemaCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.UpgradedSchemaArn !== undefined && data.UpgradedSchemaArn !== null) {
-    contents.UpgradedSchemaArn = data.UpgradedSchemaArn;
+    contents.UpgradedSchemaArn = __expectString(data.UpgradedSchemaArn);
   }
   return Promise.resolve(contents);
 };
@@ -10017,7 +10022,7 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -10036,13 +10041,13 @@ const deserializeAws_restJson1BatchWriteExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Index !== undefined && data.Index !== null) {
-    contents.Index = data.Index;
+    contents.Index = __expectNumber(data.Index);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   return contents;
 };
@@ -10059,7 +10064,7 @@ const deserializeAws_restJson1CannotListParentOfRootExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -10076,7 +10081,7 @@ const deserializeAws_restJson1DirectoryAlreadyExistsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -10093,7 +10098,7 @@ const deserializeAws_restJson1DirectoryDeletedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -10110,7 +10115,7 @@ const deserializeAws_restJson1DirectoryNotDisabledExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -10127,7 +10132,7 @@ const deserializeAws_restJson1DirectoryNotEnabledExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -10144,7 +10149,7 @@ const deserializeAws_restJson1FacetAlreadyExistsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -10161,7 +10166,7 @@ const deserializeAws_restJson1FacetInUseExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -10178,7 +10183,7 @@ const deserializeAws_restJson1FacetNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -10195,7 +10200,7 @@ const deserializeAws_restJson1FacetValidationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -10212,7 +10217,7 @@ const deserializeAws_restJson1IncompatibleSchemaExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -10229,7 +10234,7 @@ const deserializeAws_restJson1IndexedAttributeMissingExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -10246,7 +10251,7 @@ const deserializeAws_restJson1InternalServiceExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -10263,7 +10268,7 @@ const deserializeAws_restJson1InvalidArnExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -10280,7 +10285,7 @@ const deserializeAws_restJson1InvalidAttachmentExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -10297,7 +10302,7 @@ const deserializeAws_restJson1InvalidFacetUpdateExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -10314,7 +10319,7 @@ const deserializeAws_restJson1InvalidNextTokenExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -10331,7 +10336,7 @@ const deserializeAws_restJson1InvalidRuleExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -10348,7 +10353,7 @@ const deserializeAws_restJson1InvalidSchemaDocExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -10365,7 +10370,7 @@ const deserializeAws_restJson1InvalidTaggingRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -10382,7 +10387,7 @@ const deserializeAws_restJson1LimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -10399,7 +10404,7 @@ const deserializeAws_restJson1LinkNameAlreadyInUseExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -10416,7 +10421,7 @@ const deserializeAws_restJson1NotIndexExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -10433,7 +10438,7 @@ const deserializeAws_restJson1NotNodeExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -10450,7 +10455,7 @@ const deserializeAws_restJson1NotPolicyExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -10467,7 +10472,7 @@ const deserializeAws_restJson1ObjectAlreadyDetachedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -10484,7 +10489,7 @@ const deserializeAws_restJson1ObjectNotDetachedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -10501,7 +10506,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -10518,7 +10523,7 @@ const deserializeAws_restJson1RetryableConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -10535,7 +10540,7 @@ const deserializeAws_restJson1SchemaAlreadyExistsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -10552,7 +10557,7 @@ const deserializeAws_restJson1SchemaAlreadyPublishedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -10569,7 +10574,7 @@ const deserializeAws_restJson1StillContainsLinksExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -10586,7 +10591,7 @@ const deserializeAws_restJson1UnsupportedIndexTypeExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -10603,7 +10608,7 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -11687,15 +11692,15 @@ const deserializeAws_restJson1Arns = (output: any, context: __SerdeContext): str
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1AttributeKey = (output: any, context: __SerdeContext): AttributeKey => {
   return {
-    FacetName: output.FacetName !== undefined && output.FacetName !== null ? output.FacetName : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    SchemaArn: output.SchemaArn !== undefined && output.SchemaArn !== null ? output.SchemaArn : undefined,
+    FacetName: __expectString(output.FacetName),
+    Name: __expectString(output.Name),
+    SchemaArn: __expectString(output.SchemaArn),
   } as any;
 };
 
@@ -11728,8 +11733,7 @@ const deserializeAws_restJson1AttributeKeyAndValueList = (
 
 const deserializeAws_restJson1AttributeNameAndValue = (output: any, context: __SerdeContext): AttributeNameAndValue => {
   return {
-    AttributeName:
-      output.AttributeName !== undefined && output.AttributeName !== null ? output.AttributeName : undefined,
+    AttributeName: __expectString(output.AttributeName),
     Value:
       output.Value !== undefined && output.Value !== null
         ? deserializeAws_restJson1TypedAttributeValue(output.Value, context)
@@ -11758,7 +11762,7 @@ const deserializeAws_restJson1AttributeNameList = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -11774,10 +11778,7 @@ const deserializeAws_restJson1BatchAttachObjectResponse = (
   context: __SerdeContext
 ): BatchAttachObjectResponse => {
   return {
-    attachedObjectIdentifier:
-      output.attachedObjectIdentifier !== undefined && output.attachedObjectIdentifier !== null
-        ? output.attachedObjectIdentifier
-        : undefined,
+    attachedObjectIdentifier: __expectString(output.attachedObjectIdentifier),
   } as any;
 };
 
@@ -11793,10 +11794,7 @@ const deserializeAws_restJson1BatchAttachToIndexResponse = (
   context: __SerdeContext
 ): BatchAttachToIndexResponse => {
   return {
-    AttachedObjectIdentifier:
-      output.AttachedObjectIdentifier !== undefined && output.AttachedObjectIdentifier !== null
-        ? output.AttachedObjectIdentifier
-        : undefined,
+    AttachedObjectIdentifier: __expectString(output.AttachedObjectIdentifier),
   } as any;
 };
 
@@ -11817,8 +11815,7 @@ const deserializeAws_restJson1BatchCreateIndexResponse = (
   context: __SerdeContext
 ): BatchCreateIndexResponse => {
   return {
-    ObjectIdentifier:
-      output.ObjectIdentifier !== undefined && output.ObjectIdentifier !== null ? output.ObjectIdentifier : undefined,
+    ObjectIdentifier: __expectString(output.ObjectIdentifier),
   } as any;
 };
 
@@ -11827,8 +11824,7 @@ const deserializeAws_restJson1BatchCreateObjectResponse = (
   context: __SerdeContext
 ): BatchCreateObjectResponse => {
   return {
-    ObjectIdentifier:
-      output.ObjectIdentifier !== undefined && output.ObjectIdentifier !== null ? output.ObjectIdentifier : undefined,
+    ObjectIdentifier: __expectString(output.ObjectIdentifier),
   } as any;
 };
 
@@ -11844,10 +11840,7 @@ const deserializeAws_restJson1BatchDetachFromIndexResponse = (
   context: __SerdeContext
 ): BatchDetachFromIndexResponse => {
   return {
-    DetachedObjectIdentifier:
-      output.DetachedObjectIdentifier !== undefined && output.DetachedObjectIdentifier !== null
-        ? output.DetachedObjectIdentifier
-        : undefined,
+    DetachedObjectIdentifier: __expectString(output.DetachedObjectIdentifier),
   } as any;
 };
 
@@ -11856,10 +11849,7 @@ const deserializeAws_restJson1BatchDetachObjectResponse = (
   context: __SerdeContext
 ): BatchDetachObjectResponse => {
   return {
-    detachedObjectIdentifier:
-      output.detachedObjectIdentifier !== undefined && output.detachedObjectIdentifier !== null
-        ? output.detachedObjectIdentifier
-        : undefined,
+    detachedObjectIdentifier: __expectString(output.detachedObjectIdentifier),
   } as any;
 };
 
@@ -11906,8 +11896,7 @@ const deserializeAws_restJson1BatchGetObjectInformationResponse = (
   context: __SerdeContext
 ): BatchGetObjectInformationResponse => {
   return {
-    ObjectIdentifier:
-      output.ObjectIdentifier !== undefined && output.ObjectIdentifier !== null ? output.ObjectIdentifier : undefined,
+    ObjectIdentifier: __expectString(output.ObjectIdentifier),
     SchemaFacets:
       output.SchemaFacets !== undefined && output.SchemaFacets !== null
         ? deserializeAws_restJson1SchemaFacetList(output.SchemaFacets, context)
@@ -11924,7 +11913,7 @@ const deserializeAws_restJson1BatchListAttachedIndicesResponse = (
       output.IndexAttachments !== undefined && output.IndexAttachments !== null
         ? deserializeAws_restJson1IndexAttachmentList(output.IndexAttachments, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -11937,7 +11926,7 @@ const deserializeAws_restJson1BatchListIncomingTypedLinksResponse = (
       output.LinkSpecifiers !== undefined && output.LinkSpecifiers !== null
         ? deserializeAws_restJson1TypedLinkSpecifierList(output.LinkSpecifiers, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -11950,7 +11939,7 @@ const deserializeAws_restJson1BatchListIndexResponse = (
       output.IndexAttachments !== undefined && output.IndexAttachments !== null
         ? deserializeAws_restJson1IndexAttachmentList(output.IndexAttachments, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -11963,7 +11952,7 @@ const deserializeAws_restJson1BatchListObjectAttributesResponse = (
       output.Attributes !== undefined && output.Attributes !== null
         ? deserializeAws_restJson1AttributeKeyAndValueList(output.Attributes, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -11976,7 +11965,7 @@ const deserializeAws_restJson1BatchListObjectChildrenResponse = (
       output.Children !== undefined && output.Children !== null
         ? deserializeAws_restJson1LinkNameToObjectIdentifierMap(output.Children, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -11985,7 +11974,7 @@ const deserializeAws_restJson1BatchListObjectParentPathsResponse = (
   context: __SerdeContext
 ): BatchListObjectParentPathsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     PathToObjectIdentifiersList:
       output.PathToObjectIdentifiersList !== undefined && output.PathToObjectIdentifiersList !== null
         ? deserializeAws_restJson1PathToObjectIdentifiersList(output.PathToObjectIdentifiersList, context)
@@ -11998,7 +11987,7 @@ const deserializeAws_restJson1BatchListObjectParentsResponse = (
   context: __SerdeContext
 ): BatchListObjectParentsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     ParentLinks:
       output.ParentLinks !== undefined && output.ParentLinks !== null
         ? deserializeAws_restJson1ObjectIdentifierAndLinkNameList(output.ParentLinks, context)
@@ -12015,7 +12004,7 @@ const deserializeAws_restJson1BatchListObjectPoliciesResponse = (
       output.AttachedPolicyIds !== undefined && output.AttachedPolicyIds !== null
         ? deserializeAws_restJson1ObjectIdentifierList(output.AttachedPolicyIds, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -12024,7 +12013,7 @@ const deserializeAws_restJson1BatchListOutgoingTypedLinksResponse = (
   context: __SerdeContext
 ): BatchListOutgoingTypedLinksResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     TypedLinkSpecifiers:
       output.TypedLinkSpecifiers !== undefined && output.TypedLinkSpecifiers !== null
         ? deserializeAws_restJson1TypedLinkSpecifierList(output.TypedLinkSpecifiers, context)
@@ -12037,7 +12026,7 @@ const deserializeAws_restJson1BatchListPolicyAttachmentsResponse = (
   context: __SerdeContext
 ): BatchListPolicyAttachmentsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     ObjectIdentifiers:
       output.ObjectIdentifiers !== undefined && output.ObjectIdentifiers !== null
         ? deserializeAws_restJson1ObjectIdentifierList(output.ObjectIdentifiers, context)
@@ -12050,7 +12039,7 @@ const deserializeAws_restJson1BatchLookupPolicyResponse = (
   context: __SerdeContext
 ): BatchLookupPolicyResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     PolicyToPathList:
       output.PolicyToPathList !== undefined && output.PolicyToPathList !== null
         ? deserializeAws_restJson1PolicyToPathList(output.PolicyToPathList, context)
@@ -12060,8 +12049,8 @@ const deserializeAws_restJson1BatchLookupPolicyResponse = (
 
 const deserializeAws_restJson1BatchReadException = (output: any, context: __SerdeContext): BatchReadException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Message: __expectString(output.Message),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -12178,8 +12167,7 @@ const deserializeAws_restJson1BatchUpdateObjectAttributesResponse = (
   context: __SerdeContext
 ): BatchUpdateObjectAttributesResponse => {
   return {
-    ObjectIdentifier:
-      output.ObjectIdentifier !== undefined && output.ObjectIdentifier !== null ? output.ObjectIdentifier : undefined,
+    ObjectIdentifier: __expectString(output.ObjectIdentifier),
   } as any;
 };
 
@@ -12271,9 +12259,9 @@ const deserializeAws_restJson1Directory = (output: any, context: __SerdeContext)
       output.CreationDateTime !== undefined && output.CreationDateTime !== null
         ? new Date(Math.round(output.CreationDateTime * 1000))
         : undefined,
-    DirectoryArn: output.DirectoryArn !== undefined && output.DirectoryArn !== null ? output.DirectoryArn : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    DirectoryArn: __expectString(output.DirectoryArn),
+    Name: __expectString(output.Name),
+    State: __expectString(output.State),
   } as any;
 };
 
@@ -12290,9 +12278,9 @@ const deserializeAws_restJson1DirectoryList = (output: any, context: __SerdeCont
 
 const deserializeAws_restJson1Facet = (output: any, context: __SerdeContext): Facet => {
   return {
-    FacetStyle: output.FacetStyle !== undefined && output.FacetStyle !== null ? output.FacetStyle : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    ObjectType: output.ObjectType !== undefined && output.ObjectType !== null ? output.ObjectType : undefined,
+    FacetStyle: __expectString(output.FacetStyle),
+    Name: __expectString(output.Name),
+    ObjectType: __expectString(output.ObjectType),
   } as any;
 };
 
@@ -12306,9 +12294,8 @@ const deserializeAws_restJson1FacetAttribute = (output: any, context: __SerdeCon
       output.AttributeReference !== undefined && output.AttributeReference !== null
         ? deserializeAws_restJson1FacetAttributeReference(output.AttributeReference, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    RequiredBehavior:
-      output.RequiredBehavior !== undefined && output.RequiredBehavior !== null ? output.RequiredBehavior : undefined,
+    Name: __expectString(output.Name),
+    RequiredBehavior: __expectString(output.RequiredBehavior),
   } as any;
 };
 
@@ -12321,12 +12308,12 @@ const deserializeAws_restJson1FacetAttributeDefinition = (
       output.DefaultValue !== undefined && output.DefaultValue !== null
         ? deserializeAws_restJson1TypedAttributeValue(output.DefaultValue, context)
         : undefined,
-    IsImmutable: output.IsImmutable !== undefined && output.IsImmutable !== null ? output.IsImmutable : undefined,
+    IsImmutable: __expectBoolean(output.IsImmutable),
     Rules:
       output.Rules !== undefined && output.Rules !== null
         ? deserializeAws_restJson1RuleMap(output.Rules, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -12346,12 +12333,8 @@ const deserializeAws_restJson1FacetAttributeReference = (
   context: __SerdeContext
 ): FacetAttributeReference => {
   return {
-    TargetAttributeName:
-      output.TargetAttributeName !== undefined && output.TargetAttributeName !== null
-        ? output.TargetAttributeName
-        : undefined,
-    TargetFacetName:
-      output.TargetFacetName !== undefined && output.TargetFacetName !== null ? output.TargetFacetName : undefined,
+    TargetAttributeName: __expectString(output.TargetAttributeName),
+    TargetFacetName: __expectString(output.TargetFacetName),
   } as any;
 };
 
@@ -12362,7 +12345,7 @@ const deserializeAws_restJson1FacetNameList = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -12372,8 +12355,7 @@ const deserializeAws_restJson1IndexAttachment = (output: any, context: __SerdeCo
       output.IndexedAttributes !== undefined && output.IndexedAttributes !== null
         ? deserializeAws_restJson1AttributeKeyAndValueList(output.IndexedAttributes, context)
         : undefined,
-    ObjectIdentifier:
-      output.ObjectIdentifier !== undefined && output.ObjectIdentifier !== null ? output.ObjectIdentifier : undefined,
+    ObjectIdentifier: __expectString(output.ObjectIdentifier),
   } as any;
 };
 
@@ -12398,7 +12380,7 @@ const deserializeAws_restJson1LinkNameToObjectIdentifierMap = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -12422,9 +12404,8 @@ const deserializeAws_restJson1ObjectIdentifierAndLinkNameTuple = (
   context: __SerdeContext
 ): ObjectIdentifierAndLinkNameTuple => {
   return {
-    LinkName: output.LinkName !== undefined && output.LinkName !== null ? output.LinkName : undefined,
-    ObjectIdentifier:
-      output.ObjectIdentifier !== undefined && output.ObjectIdentifier !== null ? output.ObjectIdentifier : undefined,
+    LinkName: __expectString(output.LinkName),
+    ObjectIdentifier: __expectString(output.ObjectIdentifier),
   } as any;
 };
 
@@ -12435,7 +12416,7 @@ const deserializeAws_restJson1ObjectIdentifierList = (output: any, context: __Se
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -12449,14 +12430,14 @@ const deserializeAws_restJson1ObjectIdentifierToLinkNameMap = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1ObjectReference = (output: any, context: __SerdeContext): ObjectReference => {
   return {
-    Selector: output.Selector !== undefined && output.Selector !== null ? output.Selector : undefined,
+    Selector: __expectString(output.Selector),
   } as any;
 };
 
@@ -12469,7 +12450,7 @@ const deserializeAws_restJson1PathToObjectIdentifiers = (
       output.ObjectIdentifiers !== undefined && output.ObjectIdentifiers !== null
         ? deserializeAws_restJson1ObjectIdentifierList(output.ObjectIdentifiers, context)
         : undefined,
-    Path: output.Path !== undefined && output.Path !== null ? output.Path : undefined,
+    Path: __expectString(output.Path),
   } as any;
 };
 
@@ -12489,10 +12470,9 @@ const deserializeAws_restJson1PathToObjectIdentifiersList = (
 
 const deserializeAws_restJson1PolicyAttachment = (output: any, context: __SerdeContext): PolicyAttachment => {
   return {
-    ObjectIdentifier:
-      output.ObjectIdentifier !== undefined && output.ObjectIdentifier !== null ? output.ObjectIdentifier : undefined,
-    PolicyId: output.PolicyId !== undefined && output.PolicyId !== null ? output.PolicyId : undefined,
-    PolicyType: output.PolicyType !== undefined && output.PolicyType !== null ? output.PolicyType : undefined,
+    ObjectIdentifier: __expectString(output.ObjectIdentifier),
+    PolicyId: __expectString(output.PolicyId),
+    PolicyType: __expectString(output.PolicyType),
   } as any;
 };
 
@@ -12509,7 +12489,7 @@ const deserializeAws_restJson1PolicyAttachmentList = (output: any, context: __Se
 
 const deserializeAws_restJson1PolicyToPath = (output: any, context: __SerdeContext): PolicyToPath => {
   return {
-    Path: output.Path !== undefined && output.Path !== null ? output.Path : undefined,
+    Path: __expectString(output.Path),
     Policies:
       output.Policies !== undefined && output.Policies !== null
         ? deserializeAws_restJson1PolicyAttachmentList(output.Policies, context)
@@ -12534,7 +12514,7 @@ const deserializeAws_restJson1Rule = (output: any, context: __SerdeContext): Rul
       output.Parameters !== undefined && output.Parameters !== null
         ? deserializeAws_restJson1RuleParameterMap(output.Parameters, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -12557,15 +12537,15 @@ const deserializeAws_restJson1RuleParameterMap = (output: any, context: __SerdeC
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1SchemaFacet = (output: any, context: __SerdeContext): SchemaFacet => {
   return {
-    FacetName: output.FacetName !== undefined && output.FacetName !== null ? output.FacetName : undefined,
-    SchemaArn: output.SchemaArn !== undefined && output.SchemaArn !== null ? output.SchemaArn : undefined,
+    FacetName: __expectString(output.FacetName),
+    SchemaArn: __expectString(output.SchemaArn),
   } as any;
 };
 
@@ -12582,8 +12562,8 @@ const deserializeAws_restJson1SchemaFacetList = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -12604,25 +12584,19 @@ const deserializeAws_restJson1TypedAttributeValue = (output: any, context: __Ser
       BinaryValue: context.base64Decoder(output.BinaryValue),
     };
   }
-  if (output.BooleanValue !== undefined && output.BooleanValue !== null) {
-    return {
-      BooleanValue: output.BooleanValue,
-    };
+  if (__expectBoolean(output.BooleanValue) !== undefined) {
+    return { BooleanValue: __expectBoolean(output.BooleanValue) as any };
   }
   if (output.DatetimeValue !== undefined && output.DatetimeValue !== null) {
     return {
       DatetimeValue: new Date(Math.round(output.DatetimeValue * 1000)),
     };
   }
-  if (output.NumberValue !== undefined && output.NumberValue !== null) {
-    return {
-      NumberValue: output.NumberValue,
-    };
+  if (__expectString(output.NumberValue) !== undefined) {
+    return { NumberValue: __expectString(output.NumberValue) as any };
   }
-  if (output.StringValue !== undefined && output.StringValue !== null) {
-    return {
-      StringValue: output.StringValue,
-    };
+  if (__expectString(output.StringValue) !== undefined) {
+    return { StringValue: __expectString(output.StringValue) as any };
   }
   return { $unknown: Object.entries(output)[0] };
 };
@@ -12636,15 +12610,14 @@ const deserializeAws_restJson1TypedLinkAttributeDefinition = (
       output.DefaultValue !== undefined && output.DefaultValue !== null
         ? deserializeAws_restJson1TypedAttributeValue(output.DefaultValue, context)
         : undefined,
-    IsImmutable: output.IsImmutable !== undefined && output.IsImmutable !== null ? output.IsImmutable : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    RequiredBehavior:
-      output.RequiredBehavior !== undefined && output.RequiredBehavior !== null ? output.RequiredBehavior : undefined,
+    IsImmutable: __expectBoolean(output.IsImmutable),
+    Name: __expectString(output.Name),
+    RequiredBehavior: __expectString(output.RequiredBehavior),
     Rules:
       output.Rules !== undefined && output.Rules !== null
         ? deserializeAws_restJson1RuleMap(output.Rules, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -12669,7 +12642,7 @@ const deserializeAws_restJson1TypedLinkNameList = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -12678,9 +12651,8 @@ const deserializeAws_restJson1TypedLinkSchemaAndFacetName = (
   context: __SerdeContext
 ): TypedLinkSchemaAndFacetName => {
   return {
-    SchemaArn: output.SchemaArn !== undefined && output.SchemaArn !== null ? output.SchemaArn : undefined,
-    TypedLinkName:
-      output.TypedLinkName !== undefined && output.TypedLinkName !== null ? output.TypedLinkName : undefined,
+    SchemaArn: __expectString(output.SchemaArn),
+    TypedLinkName: __expectString(output.TypedLinkName),
   } as any;
 };
 

--- a/clients/client-cloudformation/protocols/Aws_query.ts
+++ b/clients/client-cloudformation/protocols/Aws_query.ts
@@ -306,6 +306,7 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
@@ -6379,10 +6380,10 @@ const deserializeAws_queryAccountGateResult = (output: any, context: __SerdeCont
     StatusReason: undefined,
   };
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["StatusReason"] !== undefined) {
-    contents.StatusReason = output["StatusReason"];
+    contents.StatusReason = __expectString(output["StatusReason"]);
   }
   return contents;
 };
@@ -6393,7 +6394,7 @@ const deserializeAws_queryAccountLimit = (output: any, context: __SerdeContext):
     Value: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["Value"] !== undefined) {
     contents.Value = parseInt(output["Value"]);
@@ -6419,7 +6420,7 @@ const deserializeAws_queryAccountList = (output: any, context: __SerdeContext): 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6430,7 +6431,7 @@ const deserializeAws_queryAllowedValues = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6439,7 +6440,7 @@ const deserializeAws_queryAlreadyExistsException = (output: any, context: __Serd
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -6465,7 +6466,7 @@ const deserializeAws_queryCapabilities = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6474,7 +6475,7 @@ const deserializeAws_queryCFNRegistryException = (output: any, context: __SerdeC
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -6485,7 +6486,7 @@ const deserializeAws_queryChange = (output: any, context: __SerdeContext): Chang
     ResourceChange: undefined,
   };
   if (output["Type"] !== undefined) {
-    contents.Type = output["Type"];
+    contents.Type = __expectString(output["Type"]);
   }
   if (output["ResourceChange"] !== undefined) {
     contents.ResourceChange = deserializeAws_queryResourceChange(output["ResourceChange"], context);
@@ -6512,7 +6513,7 @@ const deserializeAws_queryChangeSetNotFoundException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -6544,40 +6545,40 @@ const deserializeAws_queryChangeSetSummary = (output: any, context: __SerdeConte
     RootChangeSetId: undefined,
   };
   if (output["StackId"] !== undefined) {
-    contents.StackId = output["StackId"];
+    contents.StackId = __expectString(output["StackId"]);
   }
   if (output["StackName"] !== undefined) {
-    contents.StackName = output["StackName"];
+    contents.StackName = __expectString(output["StackName"]);
   }
   if (output["ChangeSetId"] !== undefined) {
-    contents.ChangeSetId = output["ChangeSetId"];
+    contents.ChangeSetId = __expectString(output["ChangeSetId"]);
   }
   if (output["ChangeSetName"] !== undefined) {
-    contents.ChangeSetName = output["ChangeSetName"];
+    contents.ChangeSetName = __expectString(output["ChangeSetName"]);
   }
   if (output["ExecutionStatus"] !== undefined) {
-    contents.ExecutionStatus = output["ExecutionStatus"];
+    contents.ExecutionStatus = __expectString(output["ExecutionStatus"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["StatusReason"] !== undefined) {
-    contents.StatusReason = output["StatusReason"];
+    contents.StatusReason = __expectString(output["StatusReason"]);
   }
   if (output["CreationTime"] !== undefined) {
     contents.CreationTime = new Date(output["CreationTime"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output["IncludeNestedStacks"] !== undefined) {
     contents.IncludeNestedStacks = __parseBoolean(output["IncludeNestedStacks"]);
   }
   if (output["ParentChangeSetId"] !== undefined) {
-    contents.ParentChangeSetId = output["ParentChangeSetId"];
+    contents.ParentChangeSetId = __expectString(output["ParentChangeSetId"]);
   }
   if (output["RootChangeSetId"] !== undefined) {
-    contents.RootChangeSetId = output["RootChangeSetId"];
+    contents.RootChangeSetId = __expectString(output["RootChangeSetId"]);
   }
   return contents;
 };
@@ -6596,10 +6597,10 @@ const deserializeAws_queryCreateChangeSetOutput = (output: any, context: __Serde
     StackId: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   if (output["StackId"] !== undefined) {
-    contents.StackId = output["StackId"];
+    contents.StackId = __expectString(output["StackId"]);
   }
   return contents;
 };
@@ -6612,7 +6613,7 @@ const deserializeAws_queryCreatedButModifiedException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -6625,7 +6626,7 @@ const deserializeAws_queryCreateStackInstancesOutput = (
     OperationId: undefined,
   };
   if (output["OperationId"] !== undefined) {
-    contents.OperationId = output["OperationId"];
+    contents.OperationId = __expectString(output["OperationId"]);
   }
   return contents;
 };
@@ -6635,7 +6636,7 @@ const deserializeAws_queryCreateStackOutput = (output: any, context: __SerdeCont
     StackId: undefined,
   };
   if (output["StackId"] !== undefined) {
-    contents.StackId = output["StackId"];
+    contents.StackId = __expectString(output["StackId"]);
   }
   return contents;
 };
@@ -6645,7 +6646,7 @@ const deserializeAws_queryCreateStackSetOutput = (output: any, context: __SerdeC
     StackSetId: undefined,
   };
   if (output["StackSetId"] !== undefined) {
-    contents.StackSetId = output["StackSetId"];
+    contents.StackSetId = __expectString(output["StackSetId"]);
   }
   return contents;
 };
@@ -6663,7 +6664,7 @@ const deserializeAws_queryDeleteStackInstancesOutput = (
     OperationId: undefined,
   };
   if (output["OperationId"] !== undefined) {
-    contents.OperationId = output["OperationId"];
+    contents.OperationId = __expectString(output["OperationId"]);
   }
   return contents;
 };
@@ -6686,7 +6687,7 @@ const deserializeAws_queryDeploymentTargets = (output: any, context: __SerdeCont
     contents.Accounts = deserializeAws_queryAccountList(__getArrayIfSingleItem(output["Accounts"]["member"]), context);
   }
   if (output["AccountsUrl"] !== undefined) {
-    contents.AccountsUrl = output["AccountsUrl"];
+    contents.AccountsUrl = __expectString(output["AccountsUrl"]);
   }
   if (output.OrganizationalUnitIds === "") {
     contents.OrganizationalUnitIds = [];
@@ -6723,7 +6724,7 @@ const deserializeAws_queryDescribeAccountLimitsOutput = (
     );
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -6751,19 +6752,19 @@ const deserializeAws_queryDescribeChangeSetOutput = (output: any, context: __Ser
     RootChangeSetId: undefined,
   };
   if (output["ChangeSetName"] !== undefined) {
-    contents.ChangeSetName = output["ChangeSetName"];
+    contents.ChangeSetName = __expectString(output["ChangeSetName"]);
   }
   if (output["ChangeSetId"] !== undefined) {
-    contents.ChangeSetId = output["ChangeSetId"];
+    contents.ChangeSetId = __expectString(output["ChangeSetId"]);
   }
   if (output["StackId"] !== undefined) {
-    contents.StackId = output["StackId"];
+    contents.StackId = __expectString(output["StackId"]);
   }
   if (output["StackName"] !== undefined) {
-    contents.StackName = output["StackName"];
+    contents.StackName = __expectString(output["StackName"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output.Parameters === "") {
     contents.Parameters = [];
@@ -6778,13 +6779,13 @@ const deserializeAws_queryDescribeChangeSetOutput = (output: any, context: __Ser
     contents.CreationTime = new Date(output["CreationTime"]);
   }
   if (output["ExecutionStatus"] !== undefined) {
-    contents.ExecutionStatus = output["ExecutionStatus"];
+    contents.ExecutionStatus = __expectString(output["ExecutionStatus"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["StatusReason"] !== undefined) {
-    contents.StatusReason = output["StatusReason"];
+    contents.StatusReason = __expectString(output["StatusReason"]);
   }
   if (output.NotificationARNs === "") {
     contents.NotificationARNs = [];
@@ -6823,16 +6824,16 @@ const deserializeAws_queryDescribeChangeSetOutput = (output: any, context: __Ser
     contents.Changes = deserializeAws_queryChanges(__getArrayIfSingleItem(output["Changes"]["member"]), context);
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   if (output["IncludeNestedStacks"] !== undefined) {
     contents.IncludeNestedStacks = __parseBoolean(output["IncludeNestedStacks"]);
   }
   if (output["ParentChangeSetId"] !== undefined) {
-    contents.ParentChangeSetId = output["ParentChangeSetId"];
+    contents.ParentChangeSetId = __expectString(output["ParentChangeSetId"]);
   }
   if (output["RootChangeSetId"] !== undefined) {
-    contents.RootChangeSetId = output["RootChangeSetId"];
+    contents.RootChangeSetId = __expectString(output["RootChangeSetId"]);
   }
   return contents;
 };
@@ -6851,19 +6852,19 @@ const deserializeAws_queryDescribeStackDriftDetectionStatusOutput = (
     Timestamp: undefined,
   };
   if (output["StackId"] !== undefined) {
-    contents.StackId = output["StackId"];
+    contents.StackId = __expectString(output["StackId"]);
   }
   if (output["StackDriftDetectionId"] !== undefined) {
-    contents.StackDriftDetectionId = output["StackDriftDetectionId"];
+    contents.StackDriftDetectionId = __expectString(output["StackDriftDetectionId"]);
   }
   if (output["StackDriftStatus"] !== undefined) {
-    contents.StackDriftStatus = output["StackDriftStatus"];
+    contents.StackDriftStatus = __expectString(output["StackDriftStatus"]);
   }
   if (output["DetectionStatus"] !== undefined) {
-    contents.DetectionStatus = output["DetectionStatus"];
+    contents.DetectionStatus = __expectString(output["DetectionStatus"]);
   }
   if (output["DetectionStatusReason"] !== undefined) {
-    contents.DetectionStatusReason = output["DetectionStatusReason"];
+    contents.DetectionStatusReason = __expectString(output["DetectionStatusReason"]);
   }
   if (output["DriftedStackResourceCount"] !== undefined) {
     contents.DriftedStackResourceCount = parseInt(output["DriftedStackResourceCount"]);
@@ -6892,7 +6893,7 @@ const deserializeAws_queryDescribeStackEventsOutput = (
     );
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -6928,7 +6929,7 @@ const deserializeAws_queryDescribeStackResourceDriftsOutput = (
     );
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -7000,7 +7001,7 @@ const deserializeAws_queryDescribeStacksOutput = (output: any, context: __SerdeC
     contents.Stacks = deserializeAws_queryStacks(__getArrayIfSingleItem(output["Stacks"]["member"]), context);
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -7025,46 +7026,46 @@ const deserializeAws_queryDescribeTypeOutput = (output: any, context: __SerdeCon
     TimeCreated: undefined,
   };
   if (output["Arn"] !== undefined) {
-    contents.Arn = output["Arn"];
+    contents.Arn = __expectString(output["Arn"]);
   }
   if (output["Type"] !== undefined) {
-    contents.Type = output["Type"];
+    contents.Type = __expectString(output["Type"]);
   }
   if (output["TypeName"] !== undefined) {
-    contents.TypeName = output["TypeName"];
+    contents.TypeName = __expectString(output["TypeName"]);
   }
   if (output["DefaultVersionId"] !== undefined) {
-    contents.DefaultVersionId = output["DefaultVersionId"];
+    contents.DefaultVersionId = __expectString(output["DefaultVersionId"]);
   }
   if (output["IsDefaultVersion"] !== undefined) {
     contents.IsDefaultVersion = __parseBoolean(output["IsDefaultVersion"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output["Schema"] !== undefined) {
-    contents.Schema = output["Schema"];
+    contents.Schema = __expectString(output["Schema"]);
   }
   if (output["ProvisioningType"] !== undefined) {
-    contents.ProvisioningType = output["ProvisioningType"];
+    contents.ProvisioningType = __expectString(output["ProvisioningType"]);
   }
   if (output["DeprecatedStatus"] !== undefined) {
-    contents.DeprecatedStatus = output["DeprecatedStatus"];
+    contents.DeprecatedStatus = __expectString(output["DeprecatedStatus"]);
   }
   if (output["LoggingConfig"] !== undefined) {
     contents.LoggingConfig = deserializeAws_queryLoggingConfig(output["LoggingConfig"], context);
   }
   if (output["ExecutionRoleArn"] !== undefined) {
-    contents.ExecutionRoleArn = output["ExecutionRoleArn"];
+    contents.ExecutionRoleArn = __expectString(output["ExecutionRoleArn"]);
   }
   if (output["Visibility"] !== undefined) {
-    contents.Visibility = output["Visibility"];
+    contents.Visibility = __expectString(output["Visibility"]);
   }
   if (output["SourceUrl"] !== undefined) {
-    contents.SourceUrl = output["SourceUrl"];
+    contents.SourceUrl = __expectString(output["SourceUrl"]);
   }
   if (output["DocumentationUrl"] !== undefined) {
-    contents.DocumentationUrl = output["DocumentationUrl"];
+    contents.DocumentationUrl = __expectString(output["DocumentationUrl"]);
   }
   if (output["LastUpdated"] !== undefined) {
     contents.LastUpdated = new Date(output["LastUpdated"]);
@@ -7086,16 +7087,16 @@ const deserializeAws_queryDescribeTypeRegistrationOutput = (
     TypeVersionArn: undefined,
   };
   if (output["ProgressStatus"] !== undefined) {
-    contents.ProgressStatus = output["ProgressStatus"];
+    contents.ProgressStatus = __expectString(output["ProgressStatus"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output["TypeArn"] !== undefined) {
-    contents.TypeArn = output["TypeArn"];
+    contents.TypeArn = __expectString(output["TypeArn"]);
   }
   if (output["TypeVersionArn"] !== undefined) {
-    contents.TypeVersionArn = output["TypeVersionArn"];
+    contents.TypeVersionArn = __expectString(output["TypeVersionArn"]);
   }
   return contents;
 };
@@ -7105,7 +7106,7 @@ const deserializeAws_queryDetectStackDriftOutput = (output: any, context: __Serd
     StackDriftDetectionId: undefined,
   };
   if (output["StackDriftDetectionId"] !== undefined) {
-    contents.StackDriftDetectionId = output["StackDriftDetectionId"];
+    contents.StackDriftDetectionId = __expectString(output["StackDriftDetectionId"]);
   }
   return contents;
 };
@@ -7131,7 +7132,7 @@ const deserializeAws_queryDetectStackSetDriftOutput = (
     OperationId: undefined,
   };
   if (output["OperationId"] !== undefined) {
-    contents.OperationId = output["OperationId"];
+    contents.OperationId = __expectString(output["OperationId"]);
   }
   return contents;
 };
@@ -7144,7 +7145,7 @@ const deserializeAws_queryEstimateTemplateCostOutput = (
     Url: undefined,
   };
   if (output["Url"] !== undefined) {
-    contents.Url = output["Url"];
+    contents.Url = __expectString(output["Url"]);
   }
   return contents;
 };
@@ -7161,13 +7162,13 @@ const deserializeAws_queryExport = (output: any, context: __SerdeContext): Expor
     Value: undefined,
   };
   if (output["ExportingStackId"] !== undefined) {
-    contents.ExportingStackId = output["ExportingStackId"];
+    contents.ExportingStackId = __expectString(output["ExportingStackId"]);
   }
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["Value"] !== undefined) {
-    contents.Value = output["Value"];
+    contents.Value = __expectString(output["Value"]);
   }
   return contents;
 };
@@ -7188,7 +7189,7 @@ const deserializeAws_queryGetStackPolicyOutput = (output: any, context: __SerdeC
     StackPolicyBody: undefined,
   };
   if (output["StackPolicyBody"] !== undefined) {
-    contents.StackPolicyBody = output["StackPolicyBody"];
+    contents.StackPolicyBody = __expectString(output["StackPolicyBody"]);
   }
   return contents;
 };
@@ -7199,7 +7200,7 @@ const deserializeAws_queryGetTemplateOutput = (output: any, context: __SerdeCont
     StagesAvailable: undefined,
   };
   if (output["TemplateBody"] !== undefined) {
-    contents.TemplateBody = output["TemplateBody"];
+    contents.TemplateBody = __expectString(output["TemplateBody"]);
   }
   if (output.StagesAvailable === "") {
     contents.StagesAvailable = [];
@@ -7238,7 +7239,7 @@ const deserializeAws_queryGetTemplateSummaryOutput = (
     );
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output.Capabilities === "") {
     contents.Capabilities = [];
@@ -7250,7 +7251,7 @@ const deserializeAws_queryGetTemplateSummaryOutput = (
     );
   }
   if (output["CapabilitiesReason"] !== undefined) {
-    contents.CapabilitiesReason = output["CapabilitiesReason"];
+    contents.CapabilitiesReason = __expectString(output["CapabilitiesReason"]);
   }
   if (output.ResourceTypes === "") {
     contents.ResourceTypes = [];
@@ -7262,10 +7263,10 @@ const deserializeAws_queryGetTemplateSummaryOutput = (
     );
   }
   if (output["Version"] !== undefined) {
-    contents.Version = output["Version"];
+    contents.Version = __expectString(output["Version"]);
   }
   if (output["Metadata"] !== undefined) {
-    contents.Metadata = output["Metadata"];
+    contents.Metadata = __expectString(output["Metadata"]);
   }
   if (output.DeclaredTransforms === "") {
     contents.DeclaredTransforms = [];
@@ -7298,7 +7299,7 @@ const deserializeAws_queryImports = (output: any, context: __SerdeContext): stri
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7310,7 +7311,7 @@ const deserializeAws_queryInsufficientCapabilitiesException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -7323,7 +7324,7 @@ const deserializeAws_queryInvalidChangeSetStatusException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -7336,7 +7337,7 @@ const deserializeAws_queryInvalidOperationException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -7349,7 +7350,7 @@ const deserializeAws_queryInvalidStateTransitionException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -7359,7 +7360,7 @@ const deserializeAws_queryLimitExceededException = (output: any, context: __Serd
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -7379,7 +7380,7 @@ const deserializeAws_queryListChangeSetsOutput = (output: any, context: __SerdeC
     );
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -7396,7 +7397,7 @@ const deserializeAws_queryListExportsOutput = (output: any, context: __SerdeCont
     contents.Exports = deserializeAws_queryExports(__getArrayIfSingleItem(output["Exports"]["member"]), context);
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -7413,7 +7414,7 @@ const deserializeAws_queryListImportsOutput = (output: any, context: __SerdeCont
     contents.Imports = deserializeAws_queryImports(__getArrayIfSingleItem(output["Imports"]["member"]), context);
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -7436,7 +7437,7 @@ const deserializeAws_queryListStackInstancesOutput = (
     );
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -7459,7 +7460,7 @@ const deserializeAws_queryListStackResourcesOutput = (
     );
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -7482,7 +7483,7 @@ const deserializeAws_queryListStackSetOperationResultsOutput = (
     );
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -7505,7 +7506,7 @@ const deserializeAws_queryListStackSetOperationsOutput = (
     );
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -7525,7 +7526,7 @@ const deserializeAws_queryListStackSetsOutput = (output: any, context: __SerdeCo
     );
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -7545,7 +7546,7 @@ const deserializeAws_queryListStacksOutput = (output: any, context: __SerdeConte
     );
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -7568,7 +7569,7 @@ const deserializeAws_queryListTypeRegistrationsOutput = (
     );
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -7588,7 +7589,7 @@ const deserializeAws_queryListTypesOutput = (output: any, context: __SerdeContex
     );
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -7608,7 +7609,7 @@ const deserializeAws_queryListTypeVersionsOutput = (output: any, context: __Serd
     );
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -7619,10 +7620,10 @@ const deserializeAws_queryLoggingConfig = (output: any, context: __SerdeContext)
     LogGroupName: undefined,
   };
   if (output["LogRoleArn"] !== undefined) {
-    contents.LogRoleArn = output["LogRoleArn"];
+    contents.LogRoleArn = __expectString(output["LogRoleArn"]);
   }
   if (output["LogGroupName"] !== undefined) {
-    contents.LogGroupName = output["LogGroupName"];
+    contents.LogGroupName = __expectString(output["LogGroupName"]);
   }
   return contents;
 };
@@ -7634,7 +7635,7 @@ const deserializeAws_queryLogicalResourceIds = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7644,10 +7645,10 @@ const deserializeAws_queryModuleInfo = (output: any, context: __SerdeContext): M
     LogicalIdHierarchy: undefined,
   };
   if (output["TypeHierarchy"] !== undefined) {
-    contents.TypeHierarchy = output["TypeHierarchy"];
+    contents.TypeHierarchy = __expectString(output["TypeHierarchy"]);
   }
   if (output["LogicalIdHierarchy"] !== undefined) {
-    contents.LogicalIdHierarchy = output["LogicalIdHierarchy"];
+    contents.LogicalIdHierarchy = __expectString(output["LogicalIdHierarchy"]);
   }
   return contents;
 };
@@ -7660,7 +7661,7 @@ const deserializeAws_queryNameAlreadyExistsException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -7672,7 +7673,7 @@ const deserializeAws_queryNotificationARNs = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7684,7 +7685,7 @@ const deserializeAws_queryOperationIdAlreadyExistsException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -7697,7 +7698,7 @@ const deserializeAws_queryOperationInProgressException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -7710,7 +7711,7 @@ const deserializeAws_queryOperationNotFoundException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -7723,7 +7724,7 @@ const deserializeAws_queryOperationStatusCheckFailedException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -7735,7 +7736,7 @@ const deserializeAws_queryOrganizationalUnitIdList = (output: any, context: __Se
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7747,16 +7748,16 @@ const deserializeAws_queryOutput = (output: any, context: __SerdeContext): Outpu
     ExportName: undefined,
   };
   if (output["OutputKey"] !== undefined) {
-    contents.OutputKey = output["OutputKey"];
+    contents.OutputKey = __expectString(output["OutputKey"]);
   }
   if (output["OutputValue"] !== undefined) {
-    contents.OutputValue = output["OutputValue"];
+    contents.OutputValue = __expectString(output["OutputValue"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output["ExportName"] !== undefined) {
-    contents.ExportName = output["ExportName"];
+    contents.ExportName = __expectString(output["ExportName"]);
   }
   return contents;
 };
@@ -7780,16 +7781,16 @@ const deserializeAws_queryParameter = (output: any, context: __SerdeContext): Pa
     ResolvedValue: undefined,
   };
   if (output["ParameterKey"] !== undefined) {
-    contents.ParameterKey = output["ParameterKey"];
+    contents.ParameterKey = __expectString(output["ParameterKey"]);
   }
   if (output["ParameterValue"] !== undefined) {
-    contents.ParameterValue = output["ParameterValue"];
+    contents.ParameterValue = __expectString(output["ParameterValue"]);
   }
   if (output["UsePreviousValue"] !== undefined) {
     contents.UsePreviousValue = __parseBoolean(output["UsePreviousValue"]);
   }
   if (output["ResolvedValue"] !== undefined) {
-    contents.ResolvedValue = output["ResolvedValue"];
+    contents.ResolvedValue = __expectString(output["ResolvedValue"]);
   }
   return contents;
 };
@@ -7820,19 +7821,19 @@ const deserializeAws_queryParameterDeclaration = (output: any, context: __SerdeC
     ParameterConstraints: undefined,
   };
   if (output["ParameterKey"] !== undefined) {
-    contents.ParameterKey = output["ParameterKey"];
+    contents.ParameterKey = __expectString(output["ParameterKey"]);
   }
   if (output["DefaultValue"] !== undefined) {
-    contents.DefaultValue = output["DefaultValue"];
+    contents.DefaultValue = __expectString(output["DefaultValue"]);
   }
   if (output["ParameterType"] !== undefined) {
-    contents.ParameterType = output["ParameterType"];
+    contents.ParameterType = __expectString(output["ParameterType"]);
   }
   if (output["NoEcho"] !== undefined) {
     contents.NoEcho = __parseBoolean(output["NoEcho"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output["ParameterConstraints"] !== undefined) {
     contents.ParameterConstraints = deserializeAws_queryParameterConstraints(output["ParameterConstraints"], context);
@@ -7885,10 +7886,10 @@ const deserializeAws_queryPhysicalResourceIdContextKeyValuePair = (
     Value: undefined,
   };
   if (output["Key"] !== undefined) {
-    contents.Key = output["Key"];
+    contents.Key = __expectString(output["Key"]);
   }
   if (output["Value"] !== undefined) {
-    contents.Value = output["Value"];
+    contents.Value = __expectString(output["Value"]);
   }
   return contents;
 };
@@ -7901,16 +7902,16 @@ const deserializeAws_queryPropertyDifference = (output: any, context: __SerdeCon
     DifferenceType: undefined,
   };
   if (output["PropertyPath"] !== undefined) {
-    contents.PropertyPath = output["PropertyPath"];
+    contents.PropertyPath = __expectString(output["PropertyPath"]);
   }
   if (output["ExpectedValue"] !== undefined) {
-    contents.ExpectedValue = output["ExpectedValue"];
+    contents.ExpectedValue = __expectString(output["ExpectedValue"]);
   }
   if (output["ActualValue"] !== undefined) {
-    contents.ActualValue = output["ActualValue"];
+    contents.ActualValue = __expectString(output["ActualValue"]);
   }
   if (output["DifferenceType"] !== undefined) {
-    contents.DifferenceType = output["DifferenceType"];
+    contents.DifferenceType = __expectString(output["DifferenceType"]);
   }
   return contents;
 };
@@ -7941,7 +7942,7 @@ const deserializeAws_queryRegionList = (output: any, context: __SerdeContext): s
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7950,7 +7951,7 @@ const deserializeAws_queryRegisterTypeOutput = (output: any, context: __SerdeCon
     RegistrationToken: undefined,
   };
   if (output["RegistrationToken"] !== undefined) {
-    contents.RegistrationToken = output["RegistrationToken"];
+    contents.RegistrationToken = __expectString(output["RegistrationToken"]);
   }
   return contents;
 };
@@ -7962,7 +7963,7 @@ const deserializeAws_queryRegistrationTokenList = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7979,19 +7980,19 @@ const deserializeAws_queryResourceChange = (output: any, context: __SerdeContext
     ModuleInfo: undefined,
   };
   if (output["Action"] !== undefined) {
-    contents.Action = output["Action"];
+    contents.Action = __expectString(output["Action"]);
   }
   if (output["LogicalResourceId"] !== undefined) {
-    contents.LogicalResourceId = output["LogicalResourceId"];
+    contents.LogicalResourceId = __expectString(output["LogicalResourceId"]);
   }
   if (output["PhysicalResourceId"] !== undefined) {
-    contents.PhysicalResourceId = output["PhysicalResourceId"];
+    contents.PhysicalResourceId = __expectString(output["PhysicalResourceId"]);
   }
   if (output["ResourceType"] !== undefined) {
-    contents.ResourceType = output["ResourceType"];
+    contents.ResourceType = __expectString(output["ResourceType"]);
   }
   if (output["Replacement"] !== undefined) {
-    contents.Replacement = output["Replacement"];
+    contents.Replacement = __expectString(output["Replacement"]);
   }
   if (output.Scope === "") {
     contents.Scope = [];
@@ -8009,7 +8010,7 @@ const deserializeAws_queryResourceChange = (output: any, context: __SerdeContext
     );
   }
   if (output["ChangeSetId"] !== undefined) {
-    contents.ChangeSetId = output["ChangeSetId"];
+    contents.ChangeSetId = __expectString(output["ChangeSetId"]);
   }
   if (output["ModuleInfo"] !== undefined) {
     contents.ModuleInfo = deserializeAws_queryModuleInfo(output["ModuleInfo"], context);
@@ -8028,13 +8029,13 @@ const deserializeAws_queryResourceChangeDetail = (output: any, context: __SerdeC
     contents.Target = deserializeAws_queryResourceTargetDefinition(output["Target"], context);
   }
   if (output["Evaluation"] !== undefined) {
-    contents.Evaluation = output["Evaluation"];
+    contents.Evaluation = __expectString(output["Evaluation"]);
   }
   if (output["ChangeSource"] !== undefined) {
-    contents.ChangeSource = output["ChangeSource"];
+    contents.ChangeSource = __expectString(output["ChangeSource"]);
   }
   if (output["CausingEntity"] !== undefined) {
-    contents.CausingEntity = output["CausingEntity"];
+    contents.CausingEntity = __expectString(output["CausingEntity"]);
   }
   return contents;
 };
@@ -8057,7 +8058,7 @@ const deserializeAws_queryResourceIdentifiers = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -8085,7 +8086,7 @@ const deserializeAws_queryResourceIdentifierSummary = (
     ResourceIdentifiers: undefined,
   };
   if (output["ResourceType"] !== undefined) {
-    contents.ResourceType = output["ResourceType"];
+    contents.ResourceType = __expectString(output["ResourceType"]);
   }
   if (output.LogicalResourceIds === "") {
     contents.LogicalResourceIds = [];
@@ -8118,13 +8119,13 @@ const deserializeAws_queryResourceTargetDefinition = (
     RequiresRecreation: undefined,
   };
   if (output["Attribute"] !== undefined) {
-    contents.Attribute = output["Attribute"];
+    contents.Attribute = __expectString(output["Attribute"]);
   }
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["RequiresRecreation"] !== undefined) {
-    contents.RequiresRecreation = output["RequiresRecreation"];
+    contents.RequiresRecreation = __expectString(output["RequiresRecreation"]);
   }
   return contents;
 };
@@ -8136,7 +8137,7 @@ const deserializeAws_queryResourceTypes = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -8166,10 +8167,10 @@ const deserializeAws_queryRollbackTrigger = (output: any, context: __SerdeContex
     Type: undefined,
   };
   if (output["Arn"] !== undefined) {
-    contents.Arn = output["Arn"];
+    contents.Arn = __expectString(output["Arn"]);
   }
   if (output["Type"] !== undefined) {
-    contents.Type = output["Type"];
+    contents.Type = __expectString(output["Type"]);
   }
   return contents;
 };
@@ -8192,7 +8193,7 @@ const deserializeAws_queryScope = (output: any, context: __SerdeContext): (Resou
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -8230,16 +8231,16 @@ const deserializeAws_queryStack = (output: any, context: __SerdeContext): Stack 
     DriftInformation: undefined,
   };
   if (output["StackId"] !== undefined) {
-    contents.StackId = output["StackId"];
+    contents.StackId = __expectString(output["StackId"]);
   }
   if (output["StackName"] !== undefined) {
-    contents.StackName = output["StackName"];
+    contents.StackName = __expectString(output["StackName"]);
   }
   if (output["ChangeSetId"] !== undefined) {
-    contents.ChangeSetId = output["ChangeSetId"];
+    contents.ChangeSetId = __expectString(output["ChangeSetId"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output.Parameters === "") {
     contents.Parameters = [];
@@ -8266,10 +8267,10 @@ const deserializeAws_queryStack = (output: any, context: __SerdeContext): Stack 
     );
   }
   if (output["StackStatus"] !== undefined) {
-    contents.StackStatus = output["StackStatus"];
+    contents.StackStatus = __expectString(output["StackStatus"]);
   }
   if (output["StackStatusReason"] !== undefined) {
-    contents.StackStatusReason = output["StackStatusReason"];
+    contents.StackStatusReason = __expectString(output["StackStatusReason"]);
   }
   if (output["DisableRollback"] !== undefined) {
     contents.DisableRollback = __parseBoolean(output["DisableRollback"]);
@@ -8302,7 +8303,7 @@ const deserializeAws_queryStack = (output: any, context: __SerdeContext): Stack 
     contents.Outputs = deserializeAws_queryOutputs(__getArrayIfSingleItem(output["Outputs"]["member"]), context);
   }
   if (output["RoleARN"] !== undefined) {
-    contents.RoleARN = output["RoleARN"];
+    contents.RoleARN = __expectString(output["RoleARN"]);
   }
   if (output.Tags === "") {
     contents.Tags = [];
@@ -8314,10 +8315,10 @@ const deserializeAws_queryStack = (output: any, context: __SerdeContext): Stack 
     contents.EnableTerminationProtection = __parseBoolean(output["EnableTerminationProtection"]);
   }
   if (output["ParentId"] !== undefined) {
-    contents.ParentId = output["ParentId"];
+    contents.ParentId = __expectString(output["ParentId"]);
   }
   if (output["RootId"] !== undefined) {
-    contents.RootId = output["RootId"];
+    contents.RootId = __expectString(output["RootId"]);
   }
   if (output["DriftInformation"] !== undefined) {
     contents.DriftInformation = deserializeAws_queryStackDriftInformation(output["DriftInformation"], context);
@@ -8331,7 +8332,7 @@ const deserializeAws_queryStackDriftInformation = (output: any, context: __Serde
     LastCheckTimestamp: undefined,
   };
   if (output["StackDriftStatus"] !== undefined) {
-    contents.StackDriftStatus = output["StackDriftStatus"];
+    contents.StackDriftStatus = __expectString(output["StackDriftStatus"]);
   }
   if (output["LastCheckTimestamp"] !== undefined) {
     contents.LastCheckTimestamp = new Date(output["LastCheckTimestamp"]);
@@ -8348,7 +8349,7 @@ const deserializeAws_queryStackDriftInformationSummary = (
     LastCheckTimestamp: undefined,
   };
   if (output["StackDriftStatus"] !== undefined) {
-    contents.StackDriftStatus = output["StackDriftStatus"];
+    contents.StackDriftStatus = __expectString(output["StackDriftStatus"]);
   }
   if (output["LastCheckTimestamp"] !== undefined) {
     contents.LastCheckTimestamp = new Date(output["LastCheckTimestamp"]);
@@ -8371,37 +8372,37 @@ const deserializeAws_queryStackEvent = (output: any, context: __SerdeContext): S
     ClientRequestToken: undefined,
   };
   if (output["StackId"] !== undefined) {
-    contents.StackId = output["StackId"];
+    contents.StackId = __expectString(output["StackId"]);
   }
   if (output["EventId"] !== undefined) {
-    contents.EventId = output["EventId"];
+    contents.EventId = __expectString(output["EventId"]);
   }
   if (output["StackName"] !== undefined) {
-    contents.StackName = output["StackName"];
+    contents.StackName = __expectString(output["StackName"]);
   }
   if (output["LogicalResourceId"] !== undefined) {
-    contents.LogicalResourceId = output["LogicalResourceId"];
+    contents.LogicalResourceId = __expectString(output["LogicalResourceId"]);
   }
   if (output["PhysicalResourceId"] !== undefined) {
-    contents.PhysicalResourceId = output["PhysicalResourceId"];
+    contents.PhysicalResourceId = __expectString(output["PhysicalResourceId"]);
   }
   if (output["ResourceType"] !== undefined) {
-    contents.ResourceType = output["ResourceType"];
+    contents.ResourceType = __expectString(output["ResourceType"]);
   }
   if (output["Timestamp"] !== undefined) {
     contents.Timestamp = new Date(output["Timestamp"]);
   }
   if (output["ResourceStatus"] !== undefined) {
-    contents.ResourceStatus = output["ResourceStatus"];
+    contents.ResourceStatus = __expectString(output["ResourceStatus"]);
   }
   if (output["ResourceStatusReason"] !== undefined) {
-    contents.ResourceStatusReason = output["ResourceStatusReason"];
+    contents.ResourceStatusReason = __expectString(output["ResourceStatusReason"]);
   }
   if (output["ResourceProperties"] !== undefined) {
-    contents.ResourceProperties = output["ResourceProperties"];
+    contents.ResourceProperties = __expectString(output["ResourceProperties"]);
   }
   if (output["ClientRequestToken"] !== undefined) {
-    contents.ClientRequestToken = output["ClientRequestToken"];
+    contents.ClientRequestToken = __expectString(output["ClientRequestToken"]);
   }
   return contents;
 };
@@ -8432,16 +8433,16 @@ const deserializeAws_queryStackInstance = (output: any, context: __SerdeContext)
     LastDriftCheckTimestamp: undefined,
   };
   if (output["StackSetId"] !== undefined) {
-    contents.StackSetId = output["StackSetId"];
+    contents.StackSetId = __expectString(output["StackSetId"]);
   }
   if (output["Region"] !== undefined) {
-    contents.Region = output["Region"];
+    contents.Region = __expectString(output["Region"]);
   }
   if (output["Account"] !== undefined) {
-    contents.Account = output["Account"];
+    contents.Account = __expectString(output["Account"]);
   }
   if (output["StackId"] !== undefined) {
-    contents.StackId = output["StackId"];
+    contents.StackId = __expectString(output["StackId"]);
   }
   if (output.ParameterOverrides === "") {
     contents.ParameterOverrides = [];
@@ -8453,7 +8454,7 @@ const deserializeAws_queryStackInstance = (output: any, context: __SerdeContext)
     );
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["StackInstanceStatus"] !== undefined) {
     contents.StackInstanceStatus = deserializeAws_queryStackInstanceComprehensiveStatus(
@@ -8462,13 +8463,13 @@ const deserializeAws_queryStackInstance = (output: any, context: __SerdeContext)
     );
   }
   if (output["StatusReason"] !== undefined) {
-    contents.StatusReason = output["StatusReason"];
+    contents.StatusReason = __expectString(output["StatusReason"]);
   }
   if (output["OrganizationalUnitId"] !== undefined) {
-    contents.OrganizationalUnitId = output["OrganizationalUnitId"];
+    contents.OrganizationalUnitId = __expectString(output["OrganizationalUnitId"]);
   }
   if (output["DriftStatus"] !== undefined) {
-    contents.DriftStatus = output["DriftStatus"];
+    contents.DriftStatus = __expectString(output["DriftStatus"]);
   }
   if (output["LastDriftCheckTimestamp"] !== undefined) {
     contents.LastDriftCheckTimestamp = new Date(output["LastDriftCheckTimestamp"]);
@@ -8484,7 +8485,7 @@ const deserializeAws_queryStackInstanceComprehensiveStatus = (
     DetailedStatus: undefined,
   };
   if (output["DetailedStatus"] !== undefined) {
-    contents.DetailedStatus = output["DetailedStatus"];
+    contents.DetailedStatus = __expectString(output["DetailedStatus"]);
   }
   return contents;
 };
@@ -8497,7 +8498,7 @@ const deserializeAws_queryStackInstanceNotFoundException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -8527,22 +8528,22 @@ const deserializeAws_queryStackInstanceSummary = (output: any, context: __SerdeC
     LastDriftCheckTimestamp: undefined,
   };
   if (output["StackSetId"] !== undefined) {
-    contents.StackSetId = output["StackSetId"];
+    contents.StackSetId = __expectString(output["StackSetId"]);
   }
   if (output["Region"] !== undefined) {
-    contents.Region = output["Region"];
+    contents.Region = __expectString(output["Region"]);
   }
   if (output["Account"] !== undefined) {
-    contents.Account = output["Account"];
+    contents.Account = __expectString(output["Account"]);
   }
   if (output["StackId"] !== undefined) {
-    contents.StackId = output["StackId"];
+    contents.StackId = __expectString(output["StackId"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["StatusReason"] !== undefined) {
-    contents.StatusReason = output["StatusReason"];
+    contents.StatusReason = __expectString(output["StatusReason"]);
   }
   if (output["StackInstanceStatus"] !== undefined) {
     contents.StackInstanceStatus = deserializeAws_queryStackInstanceComprehensiveStatus(
@@ -8551,10 +8552,10 @@ const deserializeAws_queryStackInstanceSummary = (output: any, context: __SerdeC
     );
   }
   if (output["OrganizationalUnitId"] !== undefined) {
-    contents.OrganizationalUnitId = output["OrganizationalUnitId"];
+    contents.OrganizationalUnitId = __expectString(output["OrganizationalUnitId"]);
   }
   if (output["DriftStatus"] !== undefined) {
-    contents.DriftStatus = output["DriftStatus"];
+    contents.DriftStatus = __expectString(output["DriftStatus"]);
   }
   if (output["LastDriftCheckTimestamp"] !== undefined) {
     contents.LastDriftCheckTimestamp = new Date(output["LastDriftCheckTimestamp"]);
@@ -8577,31 +8578,31 @@ const deserializeAws_queryStackResource = (output: any, context: __SerdeContext)
     ModuleInfo: undefined,
   };
   if (output["StackName"] !== undefined) {
-    contents.StackName = output["StackName"];
+    contents.StackName = __expectString(output["StackName"]);
   }
   if (output["StackId"] !== undefined) {
-    contents.StackId = output["StackId"];
+    contents.StackId = __expectString(output["StackId"]);
   }
   if (output["LogicalResourceId"] !== undefined) {
-    contents.LogicalResourceId = output["LogicalResourceId"];
+    contents.LogicalResourceId = __expectString(output["LogicalResourceId"]);
   }
   if (output["PhysicalResourceId"] !== undefined) {
-    contents.PhysicalResourceId = output["PhysicalResourceId"];
+    contents.PhysicalResourceId = __expectString(output["PhysicalResourceId"]);
   }
   if (output["ResourceType"] !== undefined) {
-    contents.ResourceType = output["ResourceType"];
+    contents.ResourceType = __expectString(output["ResourceType"]);
   }
   if (output["Timestamp"] !== undefined) {
     contents.Timestamp = new Date(output["Timestamp"]);
   }
   if (output["ResourceStatus"] !== undefined) {
-    contents.ResourceStatus = output["ResourceStatus"];
+    contents.ResourceStatus = __expectString(output["ResourceStatus"]);
   }
   if (output["ResourceStatusReason"] !== undefined) {
-    contents.ResourceStatusReason = output["ResourceStatusReason"];
+    contents.ResourceStatusReason = __expectString(output["ResourceStatusReason"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output["DriftInformation"] !== undefined) {
     contents.DriftInformation = deserializeAws_queryStackResourceDriftInformation(output["DriftInformation"], context);
@@ -8628,34 +8629,34 @@ const deserializeAws_queryStackResourceDetail = (output: any, context: __SerdeCo
     ModuleInfo: undefined,
   };
   if (output["StackName"] !== undefined) {
-    contents.StackName = output["StackName"];
+    contents.StackName = __expectString(output["StackName"]);
   }
   if (output["StackId"] !== undefined) {
-    contents.StackId = output["StackId"];
+    contents.StackId = __expectString(output["StackId"]);
   }
   if (output["LogicalResourceId"] !== undefined) {
-    contents.LogicalResourceId = output["LogicalResourceId"];
+    contents.LogicalResourceId = __expectString(output["LogicalResourceId"]);
   }
   if (output["PhysicalResourceId"] !== undefined) {
-    contents.PhysicalResourceId = output["PhysicalResourceId"];
+    contents.PhysicalResourceId = __expectString(output["PhysicalResourceId"]);
   }
   if (output["ResourceType"] !== undefined) {
-    contents.ResourceType = output["ResourceType"];
+    contents.ResourceType = __expectString(output["ResourceType"]);
   }
   if (output["LastUpdatedTimestamp"] !== undefined) {
     contents.LastUpdatedTimestamp = new Date(output["LastUpdatedTimestamp"]);
   }
   if (output["ResourceStatus"] !== undefined) {
-    contents.ResourceStatus = output["ResourceStatus"];
+    contents.ResourceStatus = __expectString(output["ResourceStatus"]);
   }
   if (output["ResourceStatusReason"] !== undefined) {
-    contents.ResourceStatusReason = output["ResourceStatusReason"];
+    contents.ResourceStatusReason = __expectString(output["ResourceStatusReason"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output["Metadata"] !== undefined) {
-    contents.Metadata = output["Metadata"];
+    contents.Metadata = __expectString(output["Metadata"]);
   }
   if (output["DriftInformation"] !== undefined) {
     contents.DriftInformation = deserializeAws_queryStackResourceDriftInformation(output["DriftInformation"], context);
@@ -8681,13 +8682,13 @@ const deserializeAws_queryStackResourceDrift = (output: any, context: __SerdeCon
     ModuleInfo: undefined,
   };
   if (output["StackId"] !== undefined) {
-    contents.StackId = output["StackId"];
+    contents.StackId = __expectString(output["StackId"]);
   }
   if (output["LogicalResourceId"] !== undefined) {
-    contents.LogicalResourceId = output["LogicalResourceId"];
+    contents.LogicalResourceId = __expectString(output["LogicalResourceId"]);
   }
   if (output["PhysicalResourceId"] !== undefined) {
-    contents.PhysicalResourceId = output["PhysicalResourceId"];
+    contents.PhysicalResourceId = __expectString(output["PhysicalResourceId"]);
   }
   if (output.PhysicalResourceIdContext === "") {
     contents.PhysicalResourceIdContext = [];
@@ -8702,13 +8703,13 @@ const deserializeAws_queryStackResourceDrift = (output: any, context: __SerdeCon
     );
   }
   if (output["ResourceType"] !== undefined) {
-    contents.ResourceType = output["ResourceType"];
+    contents.ResourceType = __expectString(output["ResourceType"]);
   }
   if (output["ExpectedProperties"] !== undefined) {
-    contents.ExpectedProperties = output["ExpectedProperties"];
+    contents.ExpectedProperties = __expectString(output["ExpectedProperties"]);
   }
   if (output["ActualProperties"] !== undefined) {
-    contents.ActualProperties = output["ActualProperties"];
+    contents.ActualProperties = __expectString(output["ActualProperties"]);
   }
   if (output.PropertyDifferences === "") {
     contents.PropertyDifferences = [];
@@ -8720,7 +8721,7 @@ const deserializeAws_queryStackResourceDrift = (output: any, context: __SerdeCon
     );
   }
   if (output["StackResourceDriftStatus"] !== undefined) {
-    contents.StackResourceDriftStatus = output["StackResourceDriftStatus"];
+    contents.StackResourceDriftStatus = __expectString(output["StackResourceDriftStatus"]);
   }
   if (output["Timestamp"] !== undefined) {
     contents.Timestamp = new Date(output["Timestamp"]);
@@ -8740,7 +8741,7 @@ const deserializeAws_queryStackResourceDriftInformation = (
     LastCheckTimestamp: undefined,
   };
   if (output["StackResourceDriftStatus"] !== undefined) {
-    contents.StackResourceDriftStatus = output["StackResourceDriftStatus"];
+    contents.StackResourceDriftStatus = __expectString(output["StackResourceDriftStatus"]);
   }
   if (output["LastCheckTimestamp"] !== undefined) {
     contents.LastCheckTimestamp = new Date(output["LastCheckTimestamp"]);
@@ -8757,7 +8758,7 @@ const deserializeAws_queryStackResourceDriftInformationSummary = (
     LastCheckTimestamp: undefined,
   };
   if (output["StackResourceDriftStatus"] !== undefined) {
-    contents.StackResourceDriftStatus = output["StackResourceDriftStatus"];
+    contents.StackResourceDriftStatus = __expectString(output["StackResourceDriftStatus"]);
   }
   if (output["LastCheckTimestamp"] !== undefined) {
     contents.LastCheckTimestamp = new Date(output["LastCheckTimestamp"]);
@@ -8810,22 +8811,22 @@ const deserializeAws_queryStackResourceSummary = (output: any, context: __SerdeC
     ModuleInfo: undefined,
   };
   if (output["LogicalResourceId"] !== undefined) {
-    contents.LogicalResourceId = output["LogicalResourceId"];
+    contents.LogicalResourceId = __expectString(output["LogicalResourceId"]);
   }
   if (output["PhysicalResourceId"] !== undefined) {
-    contents.PhysicalResourceId = output["PhysicalResourceId"];
+    contents.PhysicalResourceId = __expectString(output["PhysicalResourceId"]);
   }
   if (output["ResourceType"] !== undefined) {
-    contents.ResourceType = output["ResourceType"];
+    contents.ResourceType = __expectString(output["ResourceType"]);
   }
   if (output["LastUpdatedTimestamp"] !== undefined) {
     contents.LastUpdatedTimestamp = new Date(output["LastUpdatedTimestamp"]);
   }
   if (output["ResourceStatus"] !== undefined) {
-    contents.ResourceStatus = output["ResourceStatus"];
+    contents.ResourceStatus = __expectString(output["ResourceStatus"]);
   }
   if (output["ResourceStatusReason"] !== undefined) {
-    contents.ResourceStatusReason = output["ResourceStatusReason"];
+    contents.ResourceStatusReason = __expectString(output["ResourceStatusReason"]);
   }
   if (output["DriftInformation"] !== undefined) {
     contents.DriftInformation = deserializeAws_queryStackResourceDriftInformationSummary(
@@ -8869,19 +8870,19 @@ const deserializeAws_queryStackSet = (output: any, context: __SerdeContext): Sta
     OrganizationalUnitIds: undefined,
   };
   if (output["StackSetName"] !== undefined) {
-    contents.StackSetName = output["StackSetName"];
+    contents.StackSetName = __expectString(output["StackSetName"]);
   }
   if (output["StackSetId"] !== undefined) {
-    contents.StackSetId = output["StackSetId"];
+    contents.StackSetId = __expectString(output["StackSetId"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["TemplateBody"] !== undefined) {
-    contents.TemplateBody = output["TemplateBody"];
+    contents.TemplateBody = __expectString(output["TemplateBody"]);
   }
   if (output.Parameters === "") {
     contents.Parameters = [];
@@ -8908,13 +8909,13 @@ const deserializeAws_queryStackSet = (output: any, context: __SerdeContext): Sta
     contents.Tags = deserializeAws_queryTags(__getArrayIfSingleItem(output["Tags"]["member"]), context);
   }
   if (output["StackSetARN"] !== undefined) {
-    contents.StackSetARN = output["StackSetARN"];
+    contents.StackSetARN = __expectString(output["StackSetARN"]);
   }
   if (output["AdministrationRoleARN"] !== undefined) {
-    contents.AdministrationRoleARN = output["AdministrationRoleARN"];
+    contents.AdministrationRoleARN = __expectString(output["AdministrationRoleARN"]);
   }
   if (output["ExecutionRoleName"] !== undefined) {
-    contents.ExecutionRoleName = output["ExecutionRoleName"];
+    contents.ExecutionRoleName = __expectString(output["ExecutionRoleName"]);
   }
   if (output["StackSetDriftDetectionDetails"] !== undefined) {
     contents.StackSetDriftDetectionDetails = deserializeAws_queryStackSetDriftDetectionDetails(
@@ -8926,7 +8927,7 @@ const deserializeAws_queryStackSet = (output: any, context: __SerdeContext): Sta
     contents.AutoDeployment = deserializeAws_queryAutoDeployment(output["AutoDeployment"], context);
   }
   if (output["PermissionModel"] !== undefined) {
-    contents.PermissionModel = output["PermissionModel"];
+    contents.PermissionModel = __expectString(output["PermissionModel"]);
   }
   if (output.OrganizationalUnitIds === "") {
     contents.OrganizationalUnitIds = [];
@@ -8955,10 +8956,10 @@ const deserializeAws_queryStackSetDriftDetectionDetails = (
     FailedStackInstancesCount: undefined,
   };
   if (output["DriftStatus"] !== undefined) {
-    contents.DriftStatus = output["DriftStatus"];
+    contents.DriftStatus = __expectString(output["DriftStatus"]);
   }
   if (output["DriftDetectionStatus"] !== undefined) {
-    contents.DriftDetectionStatus = output["DriftDetectionStatus"];
+    contents.DriftDetectionStatus = __expectString(output["DriftDetectionStatus"]);
   }
   if (output["LastDriftCheckTimestamp"] !== undefined) {
     contents.LastDriftCheckTimestamp = new Date(output["LastDriftCheckTimestamp"]);
@@ -8989,7 +8990,7 @@ const deserializeAws_queryStackSetNotEmptyException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -9002,7 +9003,7 @@ const deserializeAws_queryStackSetNotFoundException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -9023,16 +9024,16 @@ const deserializeAws_queryStackSetOperation = (output: any, context: __SerdeCont
     StackSetDriftDetectionDetails: undefined,
   };
   if (output["OperationId"] !== undefined) {
-    contents.OperationId = output["OperationId"];
+    contents.OperationId = __expectString(output["OperationId"]);
   }
   if (output["StackSetId"] !== undefined) {
-    contents.StackSetId = output["StackSetId"];
+    contents.StackSetId = __expectString(output["StackSetId"]);
   }
   if (output["Action"] !== undefined) {
-    contents.Action = output["Action"];
+    contents.Action = __expectString(output["Action"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["OperationPreferences"] !== undefined) {
     contents.OperationPreferences = deserializeAws_queryStackSetOperationPreferences(
@@ -9044,10 +9045,10 @@ const deserializeAws_queryStackSetOperation = (output: any, context: __SerdeCont
     contents.RetainStacks = __parseBoolean(output["RetainStacks"]);
   }
   if (output["AdministrationRoleARN"] !== undefined) {
-    contents.AdministrationRoleARN = output["AdministrationRoleARN"];
+    contents.AdministrationRoleARN = __expectString(output["AdministrationRoleARN"]);
   }
   if (output["ExecutionRoleName"] !== undefined) {
-    contents.ExecutionRoleName = output["ExecutionRoleName"];
+    contents.ExecutionRoleName = __expectString(output["ExecutionRoleName"]);
   }
   if (output["CreationTimestamp"] !== undefined) {
     contents.CreationTimestamp = new Date(output["CreationTimestamp"]);
@@ -9080,7 +9081,7 @@ const deserializeAws_queryStackSetOperationPreferences = (
     MaxConcurrentPercentage: undefined,
   };
   if (output["RegionConcurrencyType"] !== undefined) {
-    contents.RegionConcurrencyType = output["RegionConcurrencyType"];
+    contents.RegionConcurrencyType = __expectString(output["RegionConcurrencyType"]);
   }
   if (output.RegionOrder === "") {
     contents.RegionOrder = [];
@@ -9133,22 +9134,22 @@ const deserializeAws_queryStackSetOperationResultSummary = (
     OrganizationalUnitId: undefined,
   };
   if (output["Account"] !== undefined) {
-    contents.Account = output["Account"];
+    contents.Account = __expectString(output["Account"]);
   }
   if (output["Region"] !== undefined) {
-    contents.Region = output["Region"];
+    contents.Region = __expectString(output["Region"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["StatusReason"] !== undefined) {
-    contents.StatusReason = output["StatusReason"];
+    contents.StatusReason = __expectString(output["StatusReason"]);
   }
   if (output["AccountGateResult"] !== undefined) {
     contents.AccountGateResult = deserializeAws_queryAccountGateResult(output["AccountGateResult"], context);
   }
   if (output["OrganizationalUnitId"] !== undefined) {
-    contents.OrganizationalUnitId = output["OrganizationalUnitId"];
+    contents.OrganizationalUnitId = __expectString(output["OrganizationalUnitId"]);
   }
   return contents;
 };
@@ -9179,13 +9180,13 @@ const deserializeAws_queryStackSetOperationSummary = (
     EndTimestamp: undefined,
   };
   if (output["OperationId"] !== undefined) {
-    contents.OperationId = output["OperationId"];
+    contents.OperationId = __expectString(output["OperationId"]);
   }
   if (output["Action"] !== undefined) {
-    contents.Action = output["Action"];
+    contents.Action = __expectString(output["Action"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["CreationTimestamp"] !== undefined) {
     contents.CreationTimestamp = new Date(output["CreationTimestamp"]);
@@ -9219,25 +9220,25 @@ const deserializeAws_queryStackSetSummary = (output: any, context: __SerdeContex
     LastDriftCheckTimestamp: undefined,
   };
   if (output["StackSetName"] !== undefined) {
-    contents.StackSetName = output["StackSetName"];
+    contents.StackSetName = __expectString(output["StackSetName"]);
   }
   if (output["StackSetId"] !== undefined) {
-    contents.StackSetId = output["StackSetId"];
+    contents.StackSetId = __expectString(output["StackSetId"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["AutoDeployment"] !== undefined) {
     contents.AutoDeployment = deserializeAws_queryAutoDeployment(output["AutoDeployment"], context);
   }
   if (output["PermissionModel"] !== undefined) {
-    contents.PermissionModel = output["PermissionModel"];
+    contents.PermissionModel = __expectString(output["PermissionModel"]);
   }
   if (output["DriftStatus"] !== undefined) {
-    contents.DriftStatus = output["DriftStatus"];
+    contents.DriftStatus = __expectString(output["DriftStatus"]);
   }
   if (output["LastDriftCheckTimestamp"] !== undefined) {
     contents.LastDriftCheckTimestamp = new Date(output["LastDriftCheckTimestamp"]);
@@ -9271,13 +9272,13 @@ const deserializeAws_queryStackSummary = (output: any, context: __SerdeContext):
     DriftInformation: undefined,
   };
   if (output["StackId"] !== undefined) {
-    contents.StackId = output["StackId"];
+    contents.StackId = __expectString(output["StackId"]);
   }
   if (output["StackName"] !== undefined) {
-    contents.StackName = output["StackName"];
+    contents.StackName = __expectString(output["StackName"]);
   }
   if (output["TemplateDescription"] !== undefined) {
-    contents.TemplateDescription = output["TemplateDescription"];
+    contents.TemplateDescription = __expectString(output["TemplateDescription"]);
   }
   if (output["CreationTime"] !== undefined) {
     contents.CreationTime = new Date(output["CreationTime"]);
@@ -9289,16 +9290,16 @@ const deserializeAws_queryStackSummary = (output: any, context: __SerdeContext):
     contents.DeletionTime = new Date(output["DeletionTime"]);
   }
   if (output["StackStatus"] !== undefined) {
-    contents.StackStatus = output["StackStatus"];
+    contents.StackStatus = __expectString(output["StackStatus"]);
   }
   if (output["StackStatusReason"] !== undefined) {
-    contents.StackStatusReason = output["StackStatusReason"];
+    contents.StackStatusReason = __expectString(output["StackStatusReason"]);
   }
   if (output["ParentId"] !== undefined) {
-    contents.ParentId = output["ParentId"];
+    contents.ParentId = __expectString(output["ParentId"]);
   }
   if (output["RootId"] !== undefined) {
-    contents.RootId = output["RootId"];
+    contents.RootId = __expectString(output["RootId"]);
   }
   if (output["DriftInformation"] !== undefined) {
     contents.DriftInformation = deserializeAws_queryStackDriftInformationSummary(output["DriftInformation"], context);
@@ -9313,7 +9314,7 @@ const deserializeAws_queryStageList = (output: any, context: __SerdeContext): (T
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -9322,7 +9323,7 @@ const deserializeAws_queryStaleRequestException = (output: any, context: __Serde
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -9341,10 +9342,10 @@ const deserializeAws_queryTag = (output: any, context: __SerdeContext): Tag => {
     Value: undefined,
   };
   if (output["Key"] !== undefined) {
-    contents.Key = output["Key"];
+    contents.Key = __expectString(output["Key"]);
   }
   if (output["Value"] !== undefined) {
-    contents.Value = output["Value"];
+    contents.Value = __expectString(output["Value"]);
   }
   return contents;
 };
@@ -9368,16 +9369,16 @@ const deserializeAws_queryTemplateParameter = (output: any, context: __SerdeCont
     Description: undefined,
   };
   if (output["ParameterKey"] !== undefined) {
-    contents.ParameterKey = output["ParameterKey"];
+    contents.ParameterKey = __expectString(output["ParameterKey"]);
   }
   if (output["DefaultValue"] !== undefined) {
-    contents.DefaultValue = output["DefaultValue"];
+    contents.DefaultValue = __expectString(output["DefaultValue"]);
   }
   if (output["NoEcho"] !== undefined) {
     contents.NoEcho = __parseBoolean(output["NoEcho"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   return contents;
 };
@@ -9401,7 +9402,7 @@ const deserializeAws_queryTokenAlreadyExistsException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -9413,7 +9414,7 @@ const deserializeAws_queryTransformsList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -9422,7 +9423,7 @@ const deserializeAws_queryTypeNotFoundException = (output: any, context: __Serde
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -9448,22 +9449,22 @@ const deserializeAws_queryTypeSummary = (output: any, context: __SerdeContext): 
     Description: undefined,
   };
   if (output["Type"] !== undefined) {
-    contents.Type = output["Type"];
+    contents.Type = __expectString(output["Type"]);
   }
   if (output["TypeName"] !== undefined) {
-    contents.TypeName = output["TypeName"];
+    contents.TypeName = __expectString(output["TypeName"]);
   }
   if (output["DefaultVersionId"] !== undefined) {
-    contents.DefaultVersionId = output["DefaultVersionId"];
+    contents.DefaultVersionId = __expectString(output["DefaultVersionId"]);
   }
   if (output["TypeArn"] !== undefined) {
-    contents.TypeArn = output["TypeArn"];
+    contents.TypeArn = __expectString(output["TypeArn"]);
   }
   if (output["LastUpdated"] !== undefined) {
     contents.LastUpdated = new Date(output["LastUpdated"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   return contents;
 };
@@ -9490,25 +9491,25 @@ const deserializeAws_queryTypeVersionSummary = (output: any, context: __SerdeCon
     Description: undefined,
   };
   if (output["Type"] !== undefined) {
-    contents.Type = output["Type"];
+    contents.Type = __expectString(output["Type"]);
   }
   if (output["TypeName"] !== undefined) {
-    contents.TypeName = output["TypeName"];
+    contents.TypeName = __expectString(output["TypeName"]);
   }
   if (output["VersionId"] !== undefined) {
-    contents.VersionId = output["VersionId"];
+    contents.VersionId = __expectString(output["VersionId"]);
   }
   if (output["IsDefaultVersion"] !== undefined) {
     contents.IsDefaultVersion = __parseBoolean(output["IsDefaultVersion"]);
   }
   if (output["Arn"] !== undefined) {
-    contents.Arn = output["Arn"];
+    contents.Arn = __expectString(output["Arn"]);
   }
   if (output["TimeCreated"] !== undefined) {
     contents.TimeCreated = new Date(output["TimeCreated"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   return contents;
 };
@@ -9521,7 +9522,7 @@ const deserializeAws_queryUpdateStackInstancesOutput = (
     OperationId: undefined,
   };
   if (output["OperationId"] !== undefined) {
-    contents.OperationId = output["OperationId"];
+    contents.OperationId = __expectString(output["OperationId"]);
   }
   return contents;
 };
@@ -9531,7 +9532,7 @@ const deserializeAws_queryUpdateStackOutput = (output: any, context: __SerdeCont
     StackId: undefined,
   };
   if (output["StackId"] !== undefined) {
-    contents.StackId = output["StackId"];
+    contents.StackId = __expectString(output["StackId"]);
   }
   return contents;
 };
@@ -9541,7 +9542,7 @@ const deserializeAws_queryUpdateStackSetOutput = (output: any, context: __SerdeC
     OperationId: undefined,
   };
   if (output["OperationId"] !== undefined) {
-    contents.OperationId = output["OperationId"];
+    contents.OperationId = __expectString(output["OperationId"]);
   }
   return contents;
 };
@@ -9554,7 +9555,7 @@ const deserializeAws_queryUpdateTerminationProtectionOutput = (
     StackId: undefined,
   };
   if (output["StackId"] !== undefined) {
-    contents.StackId = output["StackId"];
+    contents.StackId = __expectString(output["StackId"]);
   }
   return contents;
 };
@@ -9577,7 +9578,7 @@ const deserializeAws_queryValidateTemplateOutput = (output: any, context: __Serd
     );
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output.Capabilities === "") {
     contents.Capabilities = [];
@@ -9589,7 +9590,7 @@ const deserializeAws_queryValidateTemplateOutput = (output: any, context: __Serd
     );
   }
   if (output["CapabilitiesReason"] !== undefined) {
-    contents.CapabilitiesReason = output["CapabilitiesReason"];
+    contents.CapabilitiesReason = __expectString(output["CapabilitiesReason"]);
   }
   if (output.DeclaredTransforms === "") {
     contents.DeclaredTransforms = [];

--- a/clients/client-cloudfront/protocols/Aws_restXml.ts
+++ b/clients/client-cloudfront/protocols/Aws_restXml.ts
@@ -475,6 +475,7 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
@@ -11134,7 +11135,7 @@ const deserializeAws_restXmlAccessDeniedResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11151,7 +11152,7 @@ const deserializeAws_restXmlBatchTooLargeResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11168,7 +11169,7 @@ const deserializeAws_restXmlCachePolicyAlreadyExistsResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11185,7 +11186,7 @@ const deserializeAws_restXmlCachePolicyInUseResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11202,7 +11203,7 @@ const deserializeAws_restXmlCannotChangeImmutablePublicKeyFieldsResponse = async
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11219,7 +11220,7 @@ const deserializeAws_restXmlCloudFrontOriginAccessIdentityAlreadyExistsResponse 
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11236,7 +11237,7 @@ const deserializeAws_restXmlCloudFrontOriginAccessIdentityInUseResponse = async 
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11253,7 +11254,7 @@ const deserializeAws_restXmlCNAMEAlreadyExistsResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11270,7 +11271,7 @@ const deserializeAws_restXmlDistributionAlreadyExistsResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11287,7 +11288,7 @@ const deserializeAws_restXmlDistributionNotDisabledResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11304,7 +11305,7 @@ const deserializeAws_restXmlFieldLevelEncryptionConfigAlreadyExistsResponse = as
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11321,7 +11322,7 @@ const deserializeAws_restXmlFieldLevelEncryptionConfigInUseResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11338,7 +11339,7 @@ const deserializeAws_restXmlFieldLevelEncryptionProfileAlreadyExistsResponse = a
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11355,7 +11356,7 @@ const deserializeAws_restXmlFieldLevelEncryptionProfileInUseResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11372,7 +11373,7 @@ const deserializeAws_restXmlFieldLevelEncryptionProfileSizeExceededResponse = as
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11389,7 +11390,7 @@ const deserializeAws_restXmlFunctionAlreadyExistsResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11406,7 +11407,7 @@ const deserializeAws_restXmlFunctionInUseResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11423,7 +11424,7 @@ const deserializeAws_restXmlFunctionSizeLimitExceededResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11440,7 +11441,7 @@ const deserializeAws_restXmlIllegalDeleteResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11457,7 +11458,7 @@ const deserializeAws_restXmlIllegalFieldLevelEncryptionConfigAssociationWithCach
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11474,7 +11475,7 @@ const deserializeAws_restXmlIllegalUpdateResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11491,7 +11492,7 @@ const deserializeAws_restXmlInconsistentQuantitiesResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11508,7 +11509,7 @@ const deserializeAws_restXmlInvalidArgumentResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11525,7 +11526,7 @@ const deserializeAws_restXmlInvalidDefaultRootObjectResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11542,7 +11543,7 @@ const deserializeAws_restXmlInvalidErrorCodeResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11559,7 +11560,7 @@ const deserializeAws_restXmlInvalidForwardCookiesResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11576,7 +11577,7 @@ const deserializeAws_restXmlInvalidFunctionAssociationResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11593,7 +11594,7 @@ const deserializeAws_restXmlInvalidGeoRestrictionParameterResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11610,7 +11611,7 @@ const deserializeAws_restXmlInvalidHeadersForS3OriginResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11627,7 +11628,7 @@ const deserializeAws_restXmlInvalidIfMatchVersionResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11644,7 +11645,7 @@ const deserializeAws_restXmlInvalidLambdaFunctionAssociationResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11661,7 +11662,7 @@ const deserializeAws_restXmlInvalidLocationCodeResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11678,7 +11679,7 @@ const deserializeAws_restXmlInvalidMinimumProtocolVersionResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11695,7 +11696,7 @@ const deserializeAws_restXmlInvalidOriginResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11712,7 +11713,7 @@ const deserializeAws_restXmlInvalidOriginAccessIdentityResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11729,7 +11730,7 @@ const deserializeAws_restXmlInvalidOriginKeepaliveTimeoutResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11746,7 +11747,7 @@ const deserializeAws_restXmlInvalidOriginReadTimeoutResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11763,7 +11764,7 @@ const deserializeAws_restXmlInvalidProtocolSettingsResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11780,7 +11781,7 @@ const deserializeAws_restXmlInvalidQueryStringParametersResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11797,7 +11798,7 @@ const deserializeAws_restXmlInvalidRelativePathResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11814,7 +11815,7 @@ const deserializeAws_restXmlInvalidRequiredProtocolResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11831,7 +11832,7 @@ const deserializeAws_restXmlInvalidResponseCodeResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11848,7 +11849,7 @@ const deserializeAws_restXmlInvalidTaggingResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11865,7 +11866,7 @@ const deserializeAws_restXmlInvalidTTLOrderResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11882,7 +11883,7 @@ const deserializeAws_restXmlInvalidViewerCertificateResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11899,7 +11900,7 @@ const deserializeAws_restXmlInvalidWebACLIdResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11916,7 +11917,7 @@ const deserializeAws_restXmlKeyGroupAlreadyExistsResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11933,7 +11934,7 @@ const deserializeAws_restXmlMissingBodyResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11950,7 +11951,7 @@ const deserializeAws_restXmlNoSuchCachePolicyResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11967,7 +11968,7 @@ const deserializeAws_restXmlNoSuchCloudFrontOriginAccessIdentityResponse = async
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -11984,7 +11985,7 @@ const deserializeAws_restXmlNoSuchDistributionResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12001,7 +12002,7 @@ const deserializeAws_restXmlNoSuchFieldLevelEncryptionConfigResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12018,7 +12019,7 @@ const deserializeAws_restXmlNoSuchFieldLevelEncryptionProfileResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12035,7 +12036,7 @@ const deserializeAws_restXmlNoSuchFunctionExistsResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12052,7 +12053,7 @@ const deserializeAws_restXmlNoSuchInvalidationResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12069,7 +12070,7 @@ const deserializeAws_restXmlNoSuchOriginResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12086,7 +12087,7 @@ const deserializeAws_restXmlNoSuchOriginRequestPolicyResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12103,7 +12104,7 @@ const deserializeAws_restXmlNoSuchPublicKeyResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12120,7 +12121,7 @@ const deserializeAws_restXmlNoSuchRealtimeLogConfigResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12137,7 +12138,7 @@ const deserializeAws_restXmlNoSuchResourceResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12154,7 +12155,7 @@ const deserializeAws_restXmlNoSuchStreamingDistributionResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12171,7 +12172,7 @@ const deserializeAws_restXmlOriginRequestPolicyAlreadyExistsResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12188,7 +12189,7 @@ const deserializeAws_restXmlOriginRequestPolicyInUseResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12205,7 +12206,7 @@ const deserializeAws_restXmlPreconditionFailedResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12222,7 +12223,7 @@ const deserializeAws_restXmlPublicKeyAlreadyExistsResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12239,7 +12240,7 @@ const deserializeAws_restXmlPublicKeyInUseResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12256,7 +12257,7 @@ const deserializeAws_restXmlQueryArgProfileEmptyResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12273,7 +12274,7 @@ const deserializeAws_restXmlRealtimeLogConfigAlreadyExistsResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12290,7 +12291,7 @@ const deserializeAws_restXmlRealtimeLogConfigInUseResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12307,7 +12308,7 @@ const deserializeAws_restXmlRealtimeLogConfigOwnerMismatchResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12324,7 +12325,7 @@ const deserializeAws_restXmlResourceInUseResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12341,7 +12342,7 @@ const deserializeAws_restXmlStreamingDistributionAlreadyExistsResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12358,7 +12359,7 @@ const deserializeAws_restXmlStreamingDistributionNotDisabledResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12375,7 +12376,7 @@ const deserializeAws_restXmlTestFunctionFailedResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12392,7 +12393,7 @@ const deserializeAws_restXmlTooManyCacheBehaviorsResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12409,7 +12410,7 @@ const deserializeAws_restXmlTooManyCachePoliciesResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12426,7 +12427,7 @@ const deserializeAws_restXmlTooManyCertificatesResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12443,7 +12444,7 @@ const deserializeAws_restXmlTooManyCloudFrontOriginAccessIdentitiesResponse = as
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12460,7 +12461,7 @@ const deserializeAws_restXmlTooManyCookieNamesInWhiteListResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12477,7 +12478,7 @@ const deserializeAws_restXmlTooManyCookiesInCachePolicyResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12494,7 +12495,7 @@ const deserializeAws_restXmlTooManyCookiesInOriginRequestPolicyResponse = async 
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12511,7 +12512,7 @@ const deserializeAws_restXmlTooManyDistributionCNAMEsResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12528,7 +12529,7 @@ const deserializeAws_restXmlTooManyDistributionsResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12545,7 +12546,7 @@ const deserializeAws_restXmlTooManyDistributionsAssociatedToCachePolicyResponse 
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12562,7 +12563,7 @@ const deserializeAws_restXmlTooManyDistributionsAssociatedToFieldLevelEncryption
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12579,7 +12580,7 @@ const deserializeAws_restXmlTooManyDistributionsAssociatedToKeyGroupResponse = a
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12596,7 +12597,7 @@ const deserializeAws_restXmlTooManyDistributionsAssociatedToOriginRequestPolicyR
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12613,7 +12614,7 @@ const deserializeAws_restXmlTooManyDistributionsWithFunctionAssociationsResponse
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12630,7 +12631,7 @@ const deserializeAws_restXmlTooManyDistributionsWithLambdaAssociationsResponse =
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12647,7 +12648,7 @@ const deserializeAws_restXmlTooManyDistributionsWithSingleFunctionARNResponse = 
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12664,7 +12665,7 @@ const deserializeAws_restXmlTooManyFieldLevelEncryptionConfigsResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12681,7 +12682,7 @@ const deserializeAws_restXmlTooManyFieldLevelEncryptionContentTypeProfilesRespon
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12698,7 +12699,7 @@ const deserializeAws_restXmlTooManyFieldLevelEncryptionEncryptionEntitiesRespons
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12715,7 +12716,7 @@ const deserializeAws_restXmlTooManyFieldLevelEncryptionFieldPatternsResponse = a
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12732,7 +12733,7 @@ const deserializeAws_restXmlTooManyFieldLevelEncryptionProfilesResponse = async 
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12749,7 +12750,7 @@ const deserializeAws_restXmlTooManyFieldLevelEncryptionQueryArgProfilesResponse 
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12766,7 +12767,7 @@ const deserializeAws_restXmlTooManyFunctionAssociationsResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12783,7 +12784,7 @@ const deserializeAws_restXmlTooManyFunctionsResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12800,7 +12801,7 @@ const deserializeAws_restXmlTooManyHeadersInCachePolicyResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12817,7 +12818,7 @@ const deserializeAws_restXmlTooManyHeadersInForwardedValuesResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12834,7 +12835,7 @@ const deserializeAws_restXmlTooManyHeadersInOriginRequestPolicyResponse = async 
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12851,7 +12852,7 @@ const deserializeAws_restXmlTooManyInvalidationsInProgressResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12868,7 +12869,7 @@ const deserializeAws_restXmlTooManyKeyGroupsResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12885,7 +12886,7 @@ const deserializeAws_restXmlTooManyKeyGroupsAssociatedToDistributionResponse = a
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12902,7 +12903,7 @@ const deserializeAws_restXmlTooManyLambdaFunctionAssociationsResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12919,7 +12920,7 @@ const deserializeAws_restXmlTooManyOriginCustomHeadersResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12936,7 +12937,7 @@ const deserializeAws_restXmlTooManyOriginGroupsPerDistributionResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12953,7 +12954,7 @@ const deserializeAws_restXmlTooManyOriginRequestPoliciesResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12970,7 +12971,7 @@ const deserializeAws_restXmlTooManyOriginsResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -12987,7 +12988,7 @@ const deserializeAws_restXmlTooManyPublicKeysResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -13004,7 +13005,7 @@ const deserializeAws_restXmlTooManyPublicKeysInKeyGroupResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -13021,7 +13022,7 @@ const deserializeAws_restXmlTooManyQueryStringParametersResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -13038,7 +13039,7 @@ const deserializeAws_restXmlTooManyQueryStringsInCachePolicyResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -13055,7 +13056,7 @@ const deserializeAws_restXmlTooManyQueryStringsInOriginRequestPolicyResponse = a
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -13072,7 +13073,7 @@ const deserializeAws_restXmlTooManyRealtimeLogConfigsResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -13089,7 +13090,7 @@ const deserializeAws_restXmlTooManyStreamingDistributionCNAMEsResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -13106,7 +13107,7 @@ const deserializeAws_restXmlTooManyStreamingDistributionsResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -13123,7 +13124,7 @@ const deserializeAws_restXmlTooManyTrustedSignersResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -13140,7 +13141,7 @@ const deserializeAws_restXmlTrustedKeyGroupDoesNotExistResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -13157,7 +13158,7 @@ const deserializeAws_restXmlTrustedSignerDoesNotExistResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -13174,7 +13175,7 @@ const deserializeAws_restXmlUnsupportedOperationResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -15275,10 +15276,10 @@ const deserializeAws_restXmlAliasICPRecordal = (output: any, context: __SerdeCon
     ICPRecordalStatus: undefined,
   };
   if (output["CNAME"] !== undefined) {
-    contents.CNAME = output["CNAME"];
+    contents.CNAME = __expectString(output["CNAME"]);
   }
   if (output["ICPRecordalStatus"] !== undefined) {
-    contents.ICPRecordalStatus = output["ICPRecordalStatus"];
+    contents.ICPRecordalStatus = __expectString(output["ICPRecordalStatus"]);
   }
   return contents;
 };
@@ -15301,7 +15302,7 @@ const deserializeAws_restXmlAliasList = (output: any, context: __SerdeContext): 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -15333,7 +15334,7 @@ const deserializeAws_restXmlAwsAccountNumberList = (output: any, context: __Serd
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -15359,10 +15360,10 @@ const deserializeAws_restXmlCacheBehavior = (output: any, context: __SerdeContex
     MaxTTL: undefined,
   };
   if (output["PathPattern"] !== undefined) {
-    contents.PathPattern = output["PathPattern"];
+    contents.PathPattern = __expectString(output["PathPattern"]);
   }
   if (output["TargetOriginId"] !== undefined) {
-    contents.TargetOriginId = output["TargetOriginId"];
+    contents.TargetOriginId = __expectString(output["TargetOriginId"]);
   }
   if (output["TrustedSigners"] !== undefined) {
     contents.TrustedSigners = deserializeAws_restXmlTrustedSigners(output["TrustedSigners"], context);
@@ -15371,7 +15372,7 @@ const deserializeAws_restXmlCacheBehavior = (output: any, context: __SerdeContex
     contents.TrustedKeyGroups = deserializeAws_restXmlTrustedKeyGroups(output["TrustedKeyGroups"], context);
   }
   if (output["ViewerProtocolPolicy"] !== undefined) {
-    contents.ViewerProtocolPolicy = output["ViewerProtocolPolicy"];
+    contents.ViewerProtocolPolicy = __expectString(output["ViewerProtocolPolicy"]);
   }
   if (output["AllowedMethods"] !== undefined) {
     contents.AllowedMethods = deserializeAws_restXmlAllowedMethods(output["AllowedMethods"], context);
@@ -15392,16 +15393,16 @@ const deserializeAws_restXmlCacheBehavior = (output: any, context: __SerdeContex
     contents.FunctionAssociations = deserializeAws_restXmlFunctionAssociations(output["FunctionAssociations"], context);
   }
   if (output["FieldLevelEncryptionId"] !== undefined) {
-    contents.FieldLevelEncryptionId = output["FieldLevelEncryptionId"];
+    contents.FieldLevelEncryptionId = __expectString(output["FieldLevelEncryptionId"]);
   }
   if (output["RealtimeLogConfigArn"] !== undefined) {
-    contents.RealtimeLogConfigArn = output["RealtimeLogConfigArn"];
+    contents.RealtimeLogConfigArn = __expectString(output["RealtimeLogConfigArn"]);
   }
   if (output["CachePolicyId"] !== undefined) {
-    contents.CachePolicyId = output["CachePolicyId"];
+    contents.CachePolicyId = __expectString(output["CachePolicyId"]);
   }
   if (output["OriginRequestPolicyId"] !== undefined) {
-    contents.OriginRequestPolicyId = output["OriginRequestPolicyId"];
+    contents.OriginRequestPolicyId = __expectString(output["OriginRequestPolicyId"]);
   }
   if (output["ForwardedValues"] !== undefined) {
     contents.ForwardedValues = deserializeAws_restXmlForwardedValues(output["ForwardedValues"], context);
@@ -15473,7 +15474,7 @@ const deserializeAws_restXmlCachePolicy = (output: any, context: __SerdeContext)
     CachePolicyConfig: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   if (output["LastModifiedTime"] !== undefined) {
     contents.LastModifiedTime = new Date(output["LastModifiedTime"]);
@@ -15494,10 +15495,10 @@ const deserializeAws_restXmlCachePolicyConfig = (output: any, context: __SerdeCo
     ParametersInCacheKeyAndForwardedToOrigin: undefined,
   };
   if (output["Comment"] !== undefined) {
-    contents.Comment = output["Comment"];
+    contents.Comment = __expectString(output["Comment"]);
   }
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["DefaultTTL"] !== undefined) {
     contents.DefaultTTL = parseInt(output["DefaultTTL"]);
@@ -15526,7 +15527,7 @@ const deserializeAws_restXmlCachePolicyCookiesConfig = (
     Cookies: undefined,
   };
   if (output["CookieBehavior"] !== undefined) {
-    contents.CookieBehavior = output["CookieBehavior"];
+    contents.CookieBehavior = __expectString(output["CookieBehavior"]);
   }
   if (output["Cookies"] !== undefined) {
     contents.Cookies = deserializeAws_restXmlCookieNames(output["Cookies"], context);
@@ -15543,7 +15544,7 @@ const deserializeAws_restXmlCachePolicyHeadersConfig = (
     Headers: undefined,
   };
   if (output["HeaderBehavior"] !== undefined) {
-    contents.HeaderBehavior = output["HeaderBehavior"];
+    contents.HeaderBehavior = __expectString(output["HeaderBehavior"]);
   }
   if (output["Headers"] !== undefined) {
     contents.Headers = deserializeAws_restXmlHeaders(output["Headers"], context);
@@ -15559,7 +15560,7 @@ const deserializeAws_restXmlCachePolicyList = (output: any, context: __SerdeCont
     Items: undefined,
   };
   if (output["NextMarker"] !== undefined) {
-    contents.NextMarker = output["NextMarker"];
+    contents.NextMarker = __expectString(output["NextMarker"]);
   }
   if (output["MaxItems"] !== undefined) {
     contents.MaxItems = parseInt(output["MaxItems"]);
@@ -15588,7 +15589,7 @@ const deserializeAws_restXmlCachePolicyQueryStringsConfig = (
     QueryStrings: undefined,
   };
   if (output["QueryStringBehavior"] !== undefined) {
-    contents.QueryStringBehavior = output["QueryStringBehavior"];
+    contents.QueryStringBehavior = __expectString(output["QueryStringBehavior"]);
   }
   if (output["QueryStrings"] !== undefined) {
     contents.QueryStrings = deserializeAws_restXmlQueryStringNames(output["QueryStrings"], context);
@@ -15602,7 +15603,7 @@ const deserializeAws_restXmlCachePolicySummary = (output: any, context: __SerdeC
     CachePolicy: undefined,
   };
   if (output["Type"] !== undefined) {
-    contents.Type = output["Type"];
+    contents.Type = __expectString(output["Type"]);
   }
   if (output["CachePolicy"] !== undefined) {
     contents.CachePolicy = deserializeAws_restXmlCachePolicy(output["CachePolicy"], context);
@@ -15631,10 +15632,10 @@ const deserializeAws_restXmlCloudFrontOriginAccessIdentity = (
     CloudFrontOriginAccessIdentityConfig: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   if (output["S3CanonicalUserId"] !== undefined) {
-    contents.S3CanonicalUserId = output["S3CanonicalUserId"];
+    contents.S3CanonicalUserId = __expectString(output["S3CanonicalUserId"]);
   }
   if (output["CloudFrontOriginAccessIdentityConfig"] !== undefined) {
     contents.CloudFrontOriginAccessIdentityConfig = deserializeAws_restXmlCloudFrontOriginAccessIdentityConfig(
@@ -15654,10 +15655,10 @@ const deserializeAws_restXmlCloudFrontOriginAccessIdentityConfig = (
     Comment: undefined,
   };
   if (output["CallerReference"] !== undefined) {
-    contents.CallerReference = output["CallerReference"];
+    contents.CallerReference = __expectString(output["CallerReference"]);
   }
   if (output["Comment"] !== undefined) {
-    contents.Comment = output["Comment"];
+    contents.Comment = __expectString(output["Comment"]);
   }
   return contents;
 };
@@ -15675,10 +15676,10 @@ const deserializeAws_restXmlCloudFrontOriginAccessIdentityList = (
     Items: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output["NextMarker"] !== undefined) {
-    contents.NextMarker = output["NextMarker"];
+    contents.NextMarker = __expectString(output["NextMarker"]);
   }
   if (output["MaxItems"] !== undefined) {
     contents.MaxItems = parseInt(output["MaxItems"]);
@@ -15711,13 +15712,13 @@ const deserializeAws_restXmlCloudFrontOriginAccessIdentitySummary = (
     Comment: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   if (output["S3CanonicalUserId"] !== undefined) {
-    contents.S3CanonicalUserId = output["S3CanonicalUserId"];
+    contents.S3CanonicalUserId = __expectString(output["S3CanonicalUserId"]);
   }
   if (output["Comment"] !== undefined) {
-    contents.Comment = output["Comment"];
+    contents.Comment = __expectString(output["Comment"]);
   }
   return contents;
 };
@@ -15743,13 +15744,13 @@ const deserializeAws_restXmlContentTypeProfile = (output: any, context: __SerdeC
     ContentType: undefined,
   };
   if (output["Format"] !== undefined) {
-    contents.Format = output["Format"];
+    contents.Format = __expectString(output["Format"]);
   }
   if (output["ProfileId"] !== undefined) {
-    contents.ProfileId = output["ProfileId"];
+    contents.ProfileId = __expectString(output["ProfileId"]);
   }
   if (output["ContentType"] !== undefined) {
-    contents.ContentType = output["ContentType"];
+    contents.ContentType = __expectString(output["ContentType"]);
   }
   return contents;
 };
@@ -15809,7 +15810,7 @@ const deserializeAws_restXmlCookieNameList = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -15836,7 +15837,7 @@ const deserializeAws_restXmlCookiePreference = (output: any, context: __SerdeCon
     WhitelistedNames: undefined,
   };
   if (output["Forward"] !== undefined) {
-    contents.Forward = output["Forward"];
+    contents.Forward = __expectString(output["Forward"]);
   }
   if (output["WhitelistedNames"] !== undefined) {
     contents.WhitelistedNames = deserializeAws_restXmlCookieNames(output["WhitelistedNames"], context);
@@ -15855,10 +15856,10 @@ const deserializeAws_restXmlCustomErrorResponse = (output: any, context: __Serde
     contents.ErrorCode = parseInt(output["ErrorCode"]);
   }
   if (output["ResponsePagePath"] !== undefined) {
-    contents.ResponsePagePath = output["ResponsePagePath"];
+    contents.ResponsePagePath = __expectString(output["ResponsePagePath"]);
   }
   if (output["ResponseCode"] !== undefined) {
-    contents.ResponseCode = output["ResponseCode"];
+    contents.ResponseCode = __expectString(output["ResponseCode"]);
   }
   if (output["ErrorCachingMinTTL"] !== undefined) {
     contents.ErrorCachingMinTTL = parseInt(output["ErrorCachingMinTTL"]);
@@ -15933,7 +15934,7 @@ const deserializeAws_restXmlCustomOriginConfig = (output: any, context: __SerdeC
     contents.HTTPSPort = parseInt(output["HTTPSPort"]);
   }
   if (output["OriginProtocolPolicy"] !== undefined) {
-    contents.OriginProtocolPolicy = output["OriginProtocolPolicy"];
+    contents.OriginProtocolPolicy = __expectString(output["OriginProtocolPolicy"]);
   }
   if (output["OriginSslProtocols"] !== undefined) {
     contents.OriginSslProtocols = deserializeAws_restXmlOriginSslProtocols(output["OriginSslProtocols"], context);
@@ -15968,7 +15969,7 @@ const deserializeAws_restXmlDefaultCacheBehavior = (output: any, context: __Serd
     MaxTTL: undefined,
   };
   if (output["TargetOriginId"] !== undefined) {
-    contents.TargetOriginId = output["TargetOriginId"];
+    contents.TargetOriginId = __expectString(output["TargetOriginId"]);
   }
   if (output["TrustedSigners"] !== undefined) {
     contents.TrustedSigners = deserializeAws_restXmlTrustedSigners(output["TrustedSigners"], context);
@@ -15977,7 +15978,7 @@ const deserializeAws_restXmlDefaultCacheBehavior = (output: any, context: __Serd
     contents.TrustedKeyGroups = deserializeAws_restXmlTrustedKeyGroups(output["TrustedKeyGroups"], context);
   }
   if (output["ViewerProtocolPolicy"] !== undefined) {
-    contents.ViewerProtocolPolicy = output["ViewerProtocolPolicy"];
+    contents.ViewerProtocolPolicy = __expectString(output["ViewerProtocolPolicy"]);
   }
   if (output["AllowedMethods"] !== undefined) {
     contents.AllowedMethods = deserializeAws_restXmlAllowedMethods(output["AllowedMethods"], context);
@@ -15998,16 +15999,16 @@ const deserializeAws_restXmlDefaultCacheBehavior = (output: any, context: __Serd
     contents.FunctionAssociations = deserializeAws_restXmlFunctionAssociations(output["FunctionAssociations"], context);
   }
   if (output["FieldLevelEncryptionId"] !== undefined) {
-    contents.FieldLevelEncryptionId = output["FieldLevelEncryptionId"];
+    contents.FieldLevelEncryptionId = __expectString(output["FieldLevelEncryptionId"]);
   }
   if (output["RealtimeLogConfigArn"] !== undefined) {
-    contents.RealtimeLogConfigArn = output["RealtimeLogConfigArn"];
+    contents.RealtimeLogConfigArn = __expectString(output["RealtimeLogConfigArn"]);
   }
   if (output["CachePolicyId"] !== undefined) {
-    contents.CachePolicyId = output["CachePolicyId"];
+    contents.CachePolicyId = __expectString(output["CachePolicyId"]);
   }
   if (output["OriginRequestPolicyId"] !== undefined) {
-    contents.OriginRequestPolicyId = output["OriginRequestPolicyId"];
+    contents.OriginRequestPolicyId = __expectString(output["OriginRequestPolicyId"]);
   }
   if (output["ForwardedValues"] !== undefined) {
     contents.ForwardedValues = deserializeAws_restXmlForwardedValues(output["ForwardedValues"], context);
@@ -16038,13 +16039,13 @@ const deserializeAws_restXmlDistribution = (output: any, context: __SerdeContext
     AliasICPRecordals: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   if (output["ARN"] !== undefined) {
-    contents.ARN = output["ARN"];
+    contents.ARN = __expectString(output["ARN"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["LastModifiedTime"] !== undefined) {
     contents.LastModifiedTime = new Date(output["LastModifiedTime"]);
@@ -16053,7 +16054,7 @@ const deserializeAws_restXmlDistribution = (output: any, context: __SerdeContext
     contents.InProgressInvalidationBatches = parseInt(output["InProgressInvalidationBatches"]);
   }
   if (output["DomainName"] !== undefined) {
-    contents.DomainName = output["DomainName"];
+    contents.DomainName = __expectString(output["DomainName"]);
   }
   if (output["ActiveTrustedSigners"] !== undefined) {
     contents.ActiveTrustedSigners = deserializeAws_restXmlActiveTrustedSigners(output["ActiveTrustedSigners"], context);
@@ -16100,13 +16101,13 @@ const deserializeAws_restXmlDistributionConfig = (output: any, context: __SerdeC
     IsIPV6Enabled: undefined,
   };
   if (output["CallerReference"] !== undefined) {
-    contents.CallerReference = output["CallerReference"];
+    contents.CallerReference = __expectString(output["CallerReference"]);
   }
   if (output["Aliases"] !== undefined) {
     contents.Aliases = deserializeAws_restXmlAliases(output["Aliases"], context);
   }
   if (output["DefaultRootObject"] !== undefined) {
-    contents.DefaultRootObject = output["DefaultRootObject"];
+    contents.DefaultRootObject = __expectString(output["DefaultRootObject"]);
   }
   if (output["Origins"] !== undefined) {
     contents.Origins = deserializeAws_restXmlOrigins(output["Origins"], context);
@@ -16124,13 +16125,13 @@ const deserializeAws_restXmlDistributionConfig = (output: any, context: __SerdeC
     contents.CustomErrorResponses = deserializeAws_restXmlCustomErrorResponses(output["CustomErrorResponses"], context);
   }
   if (output["Comment"] !== undefined) {
-    contents.Comment = output["Comment"];
+    contents.Comment = __expectString(output["Comment"]);
   }
   if (output["Logging"] !== undefined) {
     contents.Logging = deserializeAws_restXmlLoggingConfig(output["Logging"], context);
   }
   if (output["PriceClass"] !== undefined) {
-    contents.PriceClass = output["PriceClass"];
+    contents.PriceClass = __expectString(output["PriceClass"]);
   }
   if (output["Enabled"] !== undefined) {
     contents.Enabled = __parseBoolean(output["Enabled"]);
@@ -16142,10 +16143,10 @@ const deserializeAws_restXmlDistributionConfig = (output: any, context: __SerdeC
     contents.Restrictions = deserializeAws_restXmlRestrictions(output["Restrictions"], context);
   }
   if (output["WebACLId"] !== undefined) {
-    contents.WebACLId = output["WebACLId"];
+    contents.WebACLId = __expectString(output["WebACLId"]);
   }
   if (output["HttpVersion"] !== undefined) {
-    contents.HttpVersion = output["HttpVersion"];
+    contents.HttpVersion = __expectString(output["HttpVersion"]);
   }
   if (output["IsIPV6Enabled"] !== undefined) {
     contents.IsIPV6Enabled = __parseBoolean(output["IsIPV6Enabled"]);
@@ -16163,10 +16164,10 @@ const deserializeAws_restXmlDistributionIdList = (output: any, context: __SerdeC
     Items: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output["NextMarker"] !== undefined) {
-    contents.NextMarker = output["NextMarker"];
+    contents.NextMarker = __expectString(output["NextMarker"]);
   }
   if (output["MaxItems"] !== undefined) {
     contents.MaxItems = parseInt(output["MaxItems"]);
@@ -16196,7 +16197,7 @@ const deserializeAws_restXmlDistributionIdListSummary = (output: any, context: _
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -16210,10 +16211,10 @@ const deserializeAws_restXmlDistributionList = (output: any, context: __SerdeCon
     Items: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output["NextMarker"] !== undefined) {
-    contents.NextMarker = output["NextMarker"];
+    contents.NextMarker = __expectString(output["NextMarker"]);
   }
   if (output["MaxItems"] !== undefined) {
     contents.MaxItems = parseInt(output["MaxItems"]);
@@ -16260,19 +16261,19 @@ const deserializeAws_restXmlDistributionSummary = (output: any, context: __Serde
     AliasICPRecordals: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   if (output["ARN"] !== undefined) {
-    contents.ARN = output["ARN"];
+    contents.ARN = __expectString(output["ARN"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["LastModifiedTime"] !== undefined) {
     contents.LastModifiedTime = new Date(output["LastModifiedTime"]);
   }
   if (output["DomainName"] !== undefined) {
-    contents.DomainName = output["DomainName"];
+    contents.DomainName = __expectString(output["DomainName"]);
   }
   if (output["Aliases"] !== undefined) {
     contents.Aliases = deserializeAws_restXmlAliases(output["Aliases"], context);
@@ -16293,10 +16294,10 @@ const deserializeAws_restXmlDistributionSummary = (output: any, context: __Serde
     contents.CustomErrorResponses = deserializeAws_restXmlCustomErrorResponses(output["CustomErrorResponses"], context);
   }
   if (output["Comment"] !== undefined) {
-    contents.Comment = output["Comment"];
+    contents.Comment = __expectString(output["Comment"]);
   }
   if (output["PriceClass"] !== undefined) {
-    contents.PriceClass = output["PriceClass"];
+    contents.PriceClass = __expectString(output["PriceClass"]);
   }
   if (output["Enabled"] !== undefined) {
     contents.Enabled = __parseBoolean(output["Enabled"]);
@@ -16308,10 +16309,10 @@ const deserializeAws_restXmlDistributionSummary = (output: any, context: __Serde
     contents.Restrictions = deserializeAws_restXmlRestrictions(output["Restrictions"], context);
   }
   if (output["WebACLId"] !== undefined) {
-    contents.WebACLId = output["WebACLId"];
+    contents.WebACLId = __expectString(output["WebACLId"]);
   }
   if (output["HttpVersion"] !== undefined) {
-    contents.HttpVersion = output["HttpVersion"];
+    contents.HttpVersion = __expectString(output["HttpVersion"]);
   }
   if (output["IsIPV6Enabled"] !== undefined) {
     contents.IsIPV6Enabled = __parseBoolean(output["IsIPV6Enabled"]);
@@ -16366,10 +16367,10 @@ const deserializeAws_restXmlEncryptionEntity = (output: any, context: __SerdeCon
     FieldPatterns: undefined,
   };
   if (output["PublicKeyId"] !== undefined) {
-    contents.PublicKeyId = output["PublicKeyId"];
+    contents.PublicKeyId = __expectString(output["PublicKeyId"]);
   }
   if (output["ProviderId"] !== undefined) {
-    contents.ProviderId = output["ProviderId"];
+    contents.ProviderId = __expectString(output["ProviderId"]);
   }
   if (output["FieldPatterns"] !== undefined) {
     contents.FieldPatterns = deserializeAws_restXmlFieldPatterns(output["FieldPatterns"], context);
@@ -16394,7 +16395,7 @@ const deserializeAws_restXmlEndPoint = (output: any, context: __SerdeContext): E
     KinesisStreamConfig: undefined,
   };
   if (output["StreamType"] !== undefined) {
-    contents.StreamType = output["StreamType"];
+    contents.StreamType = __expectString(output["StreamType"]);
   }
   if (output["KinesisStreamConfig"] !== undefined) {
     contents.KinesisStreamConfig = deserializeAws_restXmlKinesisStreamConfig(output["KinesisStreamConfig"], context);
@@ -16420,7 +16421,7 @@ const deserializeAws_restXmlFieldLevelEncryption = (output: any, context: __Serd
     FieldLevelEncryptionConfig: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   if (output["LastModifiedTime"] !== undefined) {
     contents.LastModifiedTime = new Date(output["LastModifiedTime"]);
@@ -16445,10 +16446,10 @@ const deserializeAws_restXmlFieldLevelEncryptionConfig = (
     ContentTypeProfileConfig: undefined,
   };
   if (output["CallerReference"] !== undefined) {
-    contents.CallerReference = output["CallerReference"];
+    contents.CallerReference = __expectString(output["CallerReference"]);
   }
   if (output["Comment"] !== undefined) {
-    contents.Comment = output["Comment"];
+    contents.Comment = __expectString(output["Comment"]);
   }
   if (output["QueryArgProfileConfig"] !== undefined) {
     contents.QueryArgProfileConfig = deserializeAws_restXmlQueryArgProfileConfig(
@@ -16476,7 +16477,7 @@ const deserializeAws_restXmlFieldLevelEncryptionList = (
     Items: undefined,
   };
   if (output["NextMarker"] !== undefined) {
-    contents.NextMarker = output["NextMarker"];
+    contents.NextMarker = __expectString(output["NextMarker"]);
   }
   if (output["MaxItems"] !== undefined) {
     contents.MaxItems = parseInt(output["MaxItems"]);
@@ -16506,7 +16507,7 @@ const deserializeAws_restXmlFieldLevelEncryptionProfile = (
     FieldLevelEncryptionProfileConfig: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   if (output["LastModifiedTime"] !== undefined) {
     contents.LastModifiedTime = new Date(output["LastModifiedTime"]);
@@ -16531,13 +16532,13 @@ const deserializeAws_restXmlFieldLevelEncryptionProfileConfig = (
     EncryptionEntities: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["CallerReference"] !== undefined) {
-    contents.CallerReference = output["CallerReference"];
+    contents.CallerReference = __expectString(output["CallerReference"]);
   }
   if (output["Comment"] !== undefined) {
-    contents.Comment = output["Comment"];
+    contents.Comment = __expectString(output["Comment"]);
   }
   if (output["EncryptionEntities"] !== undefined) {
     contents.EncryptionEntities = deserializeAws_restXmlEncryptionEntities(output["EncryptionEntities"], context);
@@ -16556,7 +16557,7 @@ const deserializeAws_restXmlFieldLevelEncryptionProfileList = (
     Items: undefined,
   };
   if (output["NextMarker"] !== undefined) {
-    contents.NextMarker = output["NextMarker"];
+    contents.NextMarker = __expectString(output["NextMarker"]);
   }
   if (output["MaxItems"] !== undefined) {
     contents.MaxItems = parseInt(output["MaxItems"]);
@@ -16588,19 +16589,19 @@ const deserializeAws_restXmlFieldLevelEncryptionProfileSummary = (
     Comment: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   if (output["LastModifiedTime"] !== undefined) {
     contents.LastModifiedTime = new Date(output["LastModifiedTime"]);
   }
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["EncryptionEntities"] !== undefined) {
     contents.EncryptionEntities = deserializeAws_restXmlEncryptionEntities(output["EncryptionEntities"], context);
   }
   if (output["Comment"] !== undefined) {
-    contents.Comment = output["Comment"];
+    contents.Comment = __expectString(output["Comment"]);
   }
   return contents;
 };
@@ -16631,13 +16632,13 @@ const deserializeAws_restXmlFieldLevelEncryptionSummary = (
     ContentTypeProfileConfig: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   if (output["LastModifiedTime"] !== undefined) {
     contents.LastModifiedTime = new Date(output["LastModifiedTime"]);
   }
   if (output["Comment"] !== undefined) {
-    contents.Comment = output["Comment"];
+    contents.Comment = __expectString(output["Comment"]);
   }
   if (output["QueryArgProfileConfig"] !== undefined) {
     contents.QueryArgProfileConfig = deserializeAws_restXmlQueryArgProfileConfig(
@@ -16675,7 +16676,7 @@ const deserializeAws_restXmlFieldList = (output: any, context: __SerdeContext): 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -16686,7 +16687,7 @@ const deserializeAws_restXmlFieldPatternList = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -16738,10 +16739,10 @@ const deserializeAws_restXmlFunctionAssociation = (output: any, context: __Serde
     EventType: undefined,
   };
   if (output["FunctionARN"] !== undefined) {
-    contents.FunctionARN = output["FunctionARN"];
+    contents.FunctionARN = __expectString(output["FunctionARN"]);
   }
   if (output["EventType"] !== undefined) {
-    contents.EventType = output["EventType"];
+    contents.EventType = __expectString(output["EventType"]);
   }
   return contents;
 };
@@ -16783,10 +16784,10 @@ const deserializeAws_restXmlFunctionConfig = (output: any, context: __SerdeConte
     Runtime: undefined,
   };
   if (output["Comment"] !== undefined) {
-    contents.Comment = output["Comment"];
+    contents.Comment = __expectString(output["Comment"]);
   }
   if (output["Runtime"] !== undefined) {
-    contents.Runtime = output["Runtime"];
+    contents.Runtime = __expectString(output["Runtime"]);
   }
   return contents;
 };
@@ -16798,7 +16799,7 @@ const deserializeAws_restXmlFunctionExecutionLogList = (output: any, context: __
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -16810,7 +16811,7 @@ const deserializeAws_restXmlFunctionList = (output: any, context: __SerdeContext
     Items: undefined,
   };
   if (output["NextMarker"] !== undefined) {
-    contents.NextMarker = output["NextMarker"];
+    contents.NextMarker = __expectString(output["NextMarker"]);
   }
   if (output["MaxItems"] !== undefined) {
     contents.MaxItems = parseInt(output["MaxItems"]);
@@ -16838,10 +16839,10 @@ const deserializeAws_restXmlFunctionMetadata = (output: any, context: __SerdeCon
     LastModifiedTime: undefined,
   };
   if (output["FunctionARN"] !== undefined) {
-    contents.FunctionARN = output["FunctionARN"];
+    contents.FunctionARN = __expectString(output["FunctionARN"]);
   }
   if (output["Stage"] !== undefined) {
-    contents.Stage = output["Stage"];
+    contents.Stage = __expectString(output["Stage"]);
   }
   if (output["CreatedTime"] !== undefined) {
     contents.CreatedTime = new Date(output["CreatedTime"]);
@@ -16860,10 +16861,10 @@ const deserializeAws_restXmlFunctionSummary = (output: any, context: __SerdeCont
     FunctionMetadata: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["FunctionConfig"] !== undefined) {
     contents.FunctionConfig = deserializeAws_restXmlFunctionConfig(output["FunctionConfig"], context);
@@ -16892,7 +16893,7 @@ const deserializeAws_restXmlGeoRestriction = (output: any, context: __SerdeConte
     Items: undefined,
   };
   if (output["RestrictionType"] !== undefined) {
-    contents.RestrictionType = output["RestrictionType"];
+    contents.RestrictionType = __expectString(output["RestrictionType"]);
   }
   if (output["Quantity"] !== undefined) {
     contents.Quantity = parseInt(output["Quantity"]);
@@ -16913,7 +16914,7 @@ const deserializeAws_restXmlHeaderList = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -16942,10 +16943,10 @@ const deserializeAws_restXmlInvalidation = (output: any, context: __SerdeContext
     InvalidationBatch: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["CreateTime"] !== undefined) {
     contents.CreateTime = new Date(output["CreateTime"]);
@@ -16965,7 +16966,7 @@ const deserializeAws_restXmlInvalidationBatch = (output: any, context: __SerdeCo
     contents.Paths = deserializeAws_restXmlPaths(output["Paths"], context);
   }
   if (output["CallerReference"] !== undefined) {
-    contents.CallerReference = output["CallerReference"];
+    contents.CallerReference = __expectString(output["CallerReference"]);
   }
   return contents;
 };
@@ -16980,10 +16981,10 @@ const deserializeAws_restXmlInvalidationList = (output: any, context: __SerdeCon
     Items: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output["NextMarker"] !== undefined) {
-    contents.NextMarker = output["NextMarker"];
+    contents.NextMarker = __expectString(output["NextMarker"]);
   }
   if (output["MaxItems"] !== undefined) {
     contents.MaxItems = parseInt(output["MaxItems"]);
@@ -17013,13 +17014,13 @@ const deserializeAws_restXmlInvalidationSummary = (output: any, context: __Serde
     Status: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   if (output["CreateTime"] !== undefined) {
     contents.CreateTime = new Date(output["CreateTime"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   return contents;
 };
@@ -17042,7 +17043,7 @@ const deserializeAws_restXmlKeyGroup = (output: any, context: __SerdeContext): K
     KeyGroupConfig: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   if (output["LastModifiedTime"] !== undefined) {
     contents.LastModifiedTime = new Date(output["LastModifiedTime"]);
@@ -17060,7 +17061,7 @@ const deserializeAws_restXmlKeyGroupConfig = (output: any, context: __SerdeConte
     Comment: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output.Items === "") {
     contents.Items = [];
@@ -17072,7 +17073,7 @@ const deserializeAws_restXmlKeyGroupConfig = (output: any, context: __SerdeConte
     );
   }
   if (output["Comment"] !== undefined) {
-    contents.Comment = output["Comment"];
+    contents.Comment = __expectString(output["Comment"]);
   }
   return contents;
 };
@@ -17085,7 +17086,7 @@ const deserializeAws_restXmlKeyGroupList = (output: any, context: __SerdeContext
     Items: undefined,
   };
   if (output["NextMarker"] !== undefined) {
-    contents.NextMarker = output["NextMarker"];
+    contents.NextMarker = __expectString(output["NextMarker"]);
   }
   if (output["MaxItems"] !== undefined) {
     contents.MaxItems = parseInt(output["MaxItems"]);
@@ -17133,7 +17134,7 @@ const deserializeAws_restXmlKeyPairIdList = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -17160,7 +17161,7 @@ const deserializeAws_restXmlKGKeyPairIds = (output: any, context: __SerdeContext
     KeyPairIds: undefined,
   };
   if (output["KeyGroupId"] !== undefined) {
-    contents.KeyGroupId = output["KeyGroupId"];
+    contents.KeyGroupId = __expectString(output["KeyGroupId"]);
   }
   if (output["KeyPairIds"] !== undefined) {
     contents.KeyPairIds = deserializeAws_restXmlKeyPairIds(output["KeyPairIds"], context);
@@ -17185,10 +17186,10 @@ const deserializeAws_restXmlKinesisStreamConfig = (output: any, context: __Serde
     StreamARN: undefined,
   };
   if (output["RoleARN"] !== undefined) {
-    contents.RoleARN = output["RoleARN"];
+    contents.RoleARN = __expectString(output["RoleARN"]);
   }
   if (output["StreamARN"] !== undefined) {
-    contents.StreamARN = output["StreamARN"];
+    contents.StreamARN = __expectString(output["StreamARN"]);
   }
   return contents;
 };
@@ -17203,10 +17204,10 @@ const deserializeAws_restXmlLambdaFunctionAssociation = (
     IncludeBody: undefined,
   };
   if (output["LambdaFunctionARN"] !== undefined) {
-    contents.LambdaFunctionARN = output["LambdaFunctionARN"];
+    contents.LambdaFunctionARN = __expectString(output["LambdaFunctionARN"]);
   }
   if (output["EventType"] !== undefined) {
-    contents.EventType = output["EventType"];
+    contents.EventType = __expectString(output["EventType"]);
   }
   if (output["IncludeBody"] !== undefined) {
     contents.IncludeBody = __parseBoolean(output["IncludeBody"]);
@@ -17258,7 +17259,7 @@ const deserializeAws_restXmlLocationList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -17276,10 +17277,10 @@ const deserializeAws_restXmlLoggingConfig = (output: any, context: __SerdeContex
     contents.IncludeCookies = __parseBoolean(output["IncludeCookies"]);
   }
   if (output["Bucket"] !== undefined) {
-    contents.Bucket = output["Bucket"];
+    contents.Bucket = __expectString(output["Bucket"]);
   }
   if (output["Prefix"] !== undefined) {
-    contents.Prefix = output["Prefix"];
+    contents.Prefix = __expectString(output["Prefix"]);
   }
   return contents;
 };
@@ -17291,7 +17292,7 @@ const deserializeAws_restXmlMethodsList = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -17321,13 +17322,13 @@ const deserializeAws_restXmlOrigin = (output: any, context: __SerdeContext): Ori
     OriginShield: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   if (output["DomainName"] !== undefined) {
-    contents.DomainName = output["DomainName"];
+    contents.DomainName = __expectString(output["DomainName"]);
   }
   if (output["OriginPath"] !== undefined) {
-    contents.OriginPath = output["OriginPath"];
+    contents.OriginPath = __expectString(output["OriginPath"]);
   }
   if (output["CustomHeaders"] !== undefined) {
     contents.CustomHeaders = deserializeAws_restXmlCustomHeaders(output["CustomHeaders"], context);
@@ -17356,10 +17357,10 @@ const deserializeAws_restXmlOriginCustomHeader = (output: any, context: __SerdeC
     HeaderValue: undefined,
   };
   if (output["HeaderName"] !== undefined) {
-    contents.HeaderName = output["HeaderName"];
+    contents.HeaderName = __expectString(output["HeaderName"]);
   }
   if (output["HeaderValue"] !== undefined) {
-    contents.HeaderValue = output["HeaderValue"];
+    contents.HeaderValue = __expectString(output["HeaderValue"]);
   }
   return contents;
 };
@@ -17382,7 +17383,7 @@ const deserializeAws_restXmlOriginGroup = (output: any, context: __SerdeContext)
     Members: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   if (output["FailoverCriteria"] !== undefined) {
     contents.FailoverCriteria = deserializeAws_restXmlOriginGroupFailoverCriteria(output["FailoverCriteria"], context);
@@ -17422,7 +17423,7 @@ const deserializeAws_restXmlOriginGroupMember = (output: any, context: __SerdeCo
     OriginId: undefined,
   };
   if (output["OriginId"] !== undefined) {
-    contents.OriginId = output["OriginId"];
+    contents.OriginId = __expectString(output["OriginId"]);
   }
   return contents;
 };
@@ -17496,7 +17497,7 @@ const deserializeAws_restXmlOriginRequestPolicy = (output: any, context: __Serde
     OriginRequestPolicyConfig: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   if (output["LastModifiedTime"] !== undefined) {
     contents.LastModifiedTime = new Date(output["LastModifiedTime"]);
@@ -17522,10 +17523,10 @@ const deserializeAws_restXmlOriginRequestPolicyConfig = (
     QueryStringsConfig: undefined,
   };
   if (output["Comment"] !== undefined) {
-    contents.Comment = output["Comment"];
+    contents.Comment = __expectString(output["Comment"]);
   }
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["HeadersConfig"] !== undefined) {
     contents.HeadersConfig = deserializeAws_restXmlOriginRequestPolicyHeadersConfig(output["HeadersConfig"], context);
@@ -17551,7 +17552,7 @@ const deserializeAws_restXmlOriginRequestPolicyCookiesConfig = (
     Cookies: undefined,
   };
   if (output["CookieBehavior"] !== undefined) {
-    contents.CookieBehavior = output["CookieBehavior"];
+    contents.CookieBehavior = __expectString(output["CookieBehavior"]);
   }
   if (output["Cookies"] !== undefined) {
     contents.Cookies = deserializeAws_restXmlCookieNames(output["Cookies"], context);
@@ -17568,7 +17569,7 @@ const deserializeAws_restXmlOriginRequestPolicyHeadersConfig = (
     Headers: undefined,
   };
   if (output["HeaderBehavior"] !== undefined) {
-    contents.HeaderBehavior = output["HeaderBehavior"];
+    contents.HeaderBehavior = __expectString(output["HeaderBehavior"]);
   }
   if (output["Headers"] !== undefined) {
     contents.Headers = deserializeAws_restXmlHeaders(output["Headers"], context);
@@ -17587,7 +17588,7 @@ const deserializeAws_restXmlOriginRequestPolicyList = (
     Items: undefined,
   };
   if (output["NextMarker"] !== undefined) {
-    contents.NextMarker = output["NextMarker"];
+    contents.NextMarker = __expectString(output["NextMarker"]);
   }
   if (output["MaxItems"] !== undefined) {
     contents.MaxItems = parseInt(output["MaxItems"]);
@@ -17616,7 +17617,7 @@ const deserializeAws_restXmlOriginRequestPolicyQueryStringsConfig = (
     QueryStrings: undefined,
   };
   if (output["QueryStringBehavior"] !== undefined) {
-    contents.QueryStringBehavior = output["QueryStringBehavior"];
+    contents.QueryStringBehavior = __expectString(output["QueryStringBehavior"]);
   }
   if (output["QueryStrings"] !== undefined) {
     contents.QueryStrings = deserializeAws_restXmlQueryStringNames(output["QueryStrings"], context);
@@ -17633,7 +17634,7 @@ const deserializeAws_restXmlOriginRequestPolicySummary = (
     OriginRequestPolicy: undefined,
   };
   if (output["Type"] !== undefined) {
-    contents.Type = output["Type"];
+    contents.Type = __expectString(output["Type"]);
   }
   if (output["OriginRequestPolicy"] !== undefined) {
     contents.OriginRequestPolicy = deserializeAws_restXmlOriginRequestPolicy(output["OriginRequestPolicy"], context);
@@ -17681,7 +17682,7 @@ const deserializeAws_restXmlOriginShield = (output: any, context: __SerdeContext
     contents.Enabled = __parseBoolean(output["Enabled"]);
   }
   if (output["OriginShieldRegion"] !== undefined) {
-    contents.OriginShieldRegion = output["OriginShieldRegion"];
+    contents.OriginShieldRegion = __expectString(output["OriginShieldRegion"]);
   }
   return contents;
 };
@@ -17745,7 +17746,7 @@ const deserializeAws_restXmlPathList = (output: any, context: __SerdeContext): s
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -17773,7 +17774,7 @@ const deserializeAws_restXmlPublicKey = (output: any, context: __SerdeContext): 
     PublicKeyConfig: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   if (output["CreatedTime"] !== undefined) {
     contents.CreatedTime = new Date(output["CreatedTime"]);
@@ -17792,16 +17793,16 @@ const deserializeAws_restXmlPublicKeyConfig = (output: any, context: __SerdeCont
     Comment: undefined,
   };
   if (output["CallerReference"] !== undefined) {
-    contents.CallerReference = output["CallerReference"];
+    contents.CallerReference = __expectString(output["CallerReference"]);
   }
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["EncodedKey"] !== undefined) {
-    contents.EncodedKey = output["EncodedKey"];
+    contents.EncodedKey = __expectString(output["EncodedKey"]);
   }
   if (output["Comment"] !== undefined) {
-    contents.Comment = output["Comment"];
+    contents.Comment = __expectString(output["Comment"]);
   }
   return contents;
 };
@@ -17813,7 +17814,7 @@ const deserializeAws_restXmlPublicKeyIdList = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -17825,7 +17826,7 @@ const deserializeAws_restXmlPublicKeyList = (output: any, context: __SerdeContex
     Items: undefined,
   };
   if (output["NextMarker"] !== undefined) {
-    contents.NextMarker = output["NextMarker"];
+    contents.NextMarker = __expectString(output["NextMarker"]);
   }
   if (output["MaxItems"] !== undefined) {
     contents.MaxItems = parseInt(output["MaxItems"]);
@@ -17854,19 +17855,19 @@ const deserializeAws_restXmlPublicKeySummary = (output: any, context: __SerdeCon
     Comment: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["CreatedTime"] !== undefined) {
     contents.CreatedTime = new Date(output["CreatedTime"]);
   }
   if (output["EncodedKey"] !== undefined) {
-    contents.EncodedKey = output["EncodedKey"];
+    contents.EncodedKey = __expectString(output["EncodedKey"]);
   }
   if (output["Comment"] !== undefined) {
-    contents.Comment = output["Comment"];
+    contents.Comment = __expectString(output["Comment"]);
   }
   return contents;
 };
@@ -17888,10 +17889,10 @@ const deserializeAws_restXmlQueryArgProfile = (output: any, context: __SerdeCont
     ProfileId: undefined,
   };
   if (output["QueryArg"] !== undefined) {
-    contents.QueryArg = output["QueryArg"];
+    contents.QueryArg = __expectString(output["QueryArg"]);
   }
   if (output["ProfileId"] !== undefined) {
-    contents.ProfileId = output["ProfileId"];
+    contents.ProfileId = __expectString(output["ProfileId"]);
   }
   return contents;
 };
@@ -17968,7 +17969,7 @@ const deserializeAws_restXmlQueryStringCacheKeysList = (output: any, context: __
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -17999,7 +18000,7 @@ const deserializeAws_restXmlQueryStringNamesList = (output: any, context: __Serd
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -18012,10 +18013,10 @@ const deserializeAws_restXmlRealtimeLogConfig = (output: any, context: __SerdeCo
     Fields: undefined,
   };
   if (output["ARN"] !== undefined) {
-    contents.ARN = output["ARN"];
+    contents.ARN = __expectString(output["ARN"]);
   }
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["SamplingRate"] !== undefined) {
     contents.SamplingRate = parseInt(output["SamplingRate"]);
@@ -18073,10 +18074,10 @@ const deserializeAws_restXmlRealtimeLogConfigs = (output: any, context: __SerdeC
     contents.IsTruncated = __parseBoolean(output["IsTruncated"]);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output["NextMarker"] !== undefined) {
-    contents.NextMarker = output["NextMarker"];
+    contents.NextMarker = __expectString(output["NextMarker"]);
   }
   return contents;
 };
@@ -18089,7 +18090,7 @@ const deserializeAws_restXmlRealtimeMetricsSubscriptionConfig = (
     RealtimeMetricsSubscriptionStatus: undefined,
   };
   if (output["RealtimeMetricsSubscriptionStatus"] !== undefined) {
-    contents.RealtimeMetricsSubscriptionStatus = output["RealtimeMetricsSubscriptionStatus"];
+    contents.RealtimeMetricsSubscriptionStatus = __expectString(output["RealtimeMetricsSubscriptionStatus"]);
   }
   return contents;
 };
@@ -18110,10 +18111,10 @@ const deserializeAws_restXmlS3Origin = (output: any, context: __SerdeContext): S
     OriginAccessIdentity: undefined,
   };
   if (output["DomainName"] !== undefined) {
-    contents.DomainName = output["DomainName"];
+    contents.DomainName = __expectString(output["DomainName"]);
   }
   if (output["OriginAccessIdentity"] !== undefined) {
-    contents.OriginAccessIdentity = output["OriginAccessIdentity"];
+    contents.OriginAccessIdentity = __expectString(output["OriginAccessIdentity"]);
   }
   return contents;
 };
@@ -18123,7 +18124,7 @@ const deserializeAws_restXmlS3OriginConfig = (output: any, context: __SerdeConte
     OriginAccessIdentity: undefined,
   };
   if (output["OriginAccessIdentity"] !== undefined) {
-    contents.OriginAccessIdentity = output["OriginAccessIdentity"];
+    contents.OriginAccessIdentity = __expectString(output["OriginAccessIdentity"]);
   }
   return contents;
 };
@@ -18134,7 +18135,7 @@ const deserializeAws_restXmlSigner = (output: any, context: __SerdeContext): Sig
     KeyPairIds: undefined,
   };
   if (output["AwsAccountNumber"] !== undefined) {
-    contents.AwsAccountNumber = output["AwsAccountNumber"];
+    contents.AwsAccountNumber = __expectString(output["AwsAccountNumber"]);
   }
   if (output["KeyPairIds"] !== undefined) {
     contents.KeyPairIds = deserializeAws_restXmlKeyPairIds(output["KeyPairIds"], context);
@@ -18160,7 +18161,7 @@ const deserializeAws_restXmlSslProtocolsList = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -18206,19 +18207,19 @@ const deserializeAws_restXmlStreamingDistribution = (output: any, context: __Ser
     StreamingDistributionConfig: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   if (output["ARN"] !== undefined) {
-    contents.ARN = output["ARN"];
+    contents.ARN = __expectString(output["ARN"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["LastModifiedTime"] !== undefined) {
     contents.LastModifiedTime = new Date(output["LastModifiedTime"]);
   }
   if (output["DomainName"] !== undefined) {
-    contents.DomainName = output["DomainName"];
+    contents.DomainName = __expectString(output["DomainName"]);
   }
   if (output["ActiveTrustedSigners"] !== undefined) {
     contents.ActiveTrustedSigners = deserializeAws_restXmlActiveTrustedSigners(output["ActiveTrustedSigners"], context);
@@ -18247,7 +18248,7 @@ const deserializeAws_restXmlStreamingDistributionConfig = (
     Enabled: undefined,
   };
   if (output["CallerReference"] !== undefined) {
-    contents.CallerReference = output["CallerReference"];
+    contents.CallerReference = __expectString(output["CallerReference"]);
   }
   if (output["S3Origin"] !== undefined) {
     contents.S3Origin = deserializeAws_restXmlS3Origin(output["S3Origin"], context);
@@ -18256,7 +18257,7 @@ const deserializeAws_restXmlStreamingDistributionConfig = (
     contents.Aliases = deserializeAws_restXmlAliases(output["Aliases"], context);
   }
   if (output["Comment"] !== undefined) {
-    contents.Comment = output["Comment"];
+    contents.Comment = __expectString(output["Comment"]);
   }
   if (output["Logging"] !== undefined) {
     contents.Logging = deserializeAws_restXmlStreamingLoggingConfig(output["Logging"], context);
@@ -18265,7 +18266,7 @@ const deserializeAws_restXmlStreamingDistributionConfig = (
     contents.TrustedSigners = deserializeAws_restXmlTrustedSigners(output["TrustedSigners"], context);
   }
   if (output["PriceClass"] !== undefined) {
-    contents.PriceClass = output["PriceClass"];
+    contents.PriceClass = __expectString(output["PriceClass"]);
   }
   if (output["Enabled"] !== undefined) {
     contents.Enabled = __parseBoolean(output["Enabled"]);
@@ -18286,10 +18287,10 @@ const deserializeAws_restXmlStreamingDistributionList = (
     Items: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output["NextMarker"] !== undefined) {
-    contents.NextMarker = output["NextMarker"];
+    contents.NextMarker = __expectString(output["NextMarker"]);
   }
   if (output["MaxItems"] !== undefined) {
     contents.MaxItems = parseInt(output["MaxItems"]);
@@ -18330,19 +18331,19 @@ const deserializeAws_restXmlStreamingDistributionSummary = (
     Enabled: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   if (output["ARN"] !== undefined) {
-    contents.ARN = output["ARN"];
+    contents.ARN = __expectString(output["ARN"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["LastModifiedTime"] !== undefined) {
     contents.LastModifiedTime = new Date(output["LastModifiedTime"]);
   }
   if (output["DomainName"] !== undefined) {
-    contents.DomainName = output["DomainName"];
+    contents.DomainName = __expectString(output["DomainName"]);
   }
   if (output["S3Origin"] !== undefined) {
     contents.S3Origin = deserializeAws_restXmlS3Origin(output["S3Origin"], context);
@@ -18354,10 +18355,10 @@ const deserializeAws_restXmlStreamingDistributionSummary = (
     contents.TrustedSigners = deserializeAws_restXmlTrustedSigners(output["TrustedSigners"], context);
   }
   if (output["Comment"] !== undefined) {
-    contents.Comment = output["Comment"];
+    contents.Comment = __expectString(output["Comment"]);
   }
   if (output["PriceClass"] !== undefined) {
-    contents.PriceClass = output["PriceClass"];
+    contents.PriceClass = __expectString(output["PriceClass"]);
   }
   if (output["Enabled"] !== undefined) {
     contents.Enabled = __parseBoolean(output["Enabled"]);
@@ -18389,10 +18390,10 @@ const deserializeAws_restXmlStreamingLoggingConfig = (output: any, context: __Se
     contents.Enabled = __parseBoolean(output["Enabled"]);
   }
   if (output["Bucket"] !== undefined) {
-    contents.Bucket = output["Bucket"];
+    contents.Bucket = __expectString(output["Bucket"]);
   }
   if (output["Prefix"] !== undefined) {
-    contents.Prefix = output["Prefix"];
+    contents.Prefix = __expectString(output["Prefix"]);
   }
   return contents;
 };
@@ -18403,10 +18404,10 @@ const deserializeAws_restXmlTag = (output: any, context: __SerdeContext): Tag =>
     Value: undefined,
   };
   if (output["Key"] !== undefined) {
-    contents.Key = output["Key"];
+    contents.Key = __expectString(output["Key"]);
   }
   if (output["Value"] !== undefined) {
-    contents.Value = output["Value"];
+    contents.Value = __expectString(output["Value"]);
   }
   return contents;
 };
@@ -18447,7 +18448,7 @@ const deserializeAws_restXmlTestResult = (output: any, context: __SerdeContext):
     contents.FunctionSummary = deserializeAws_restXmlFunctionSummary(output["FunctionSummary"], context);
   }
   if (output["ComputeUtilization"] !== undefined) {
-    contents.ComputeUtilization = output["ComputeUtilization"];
+    contents.ComputeUtilization = __expectString(output["ComputeUtilization"]);
   }
   if (output.FunctionExecutionLogs === "") {
     contents.FunctionExecutionLogs = [];
@@ -18459,10 +18460,10 @@ const deserializeAws_restXmlTestResult = (output: any, context: __SerdeContext):
     );
   }
   if (output["FunctionErrorMessage"] !== undefined) {
-    contents.FunctionErrorMessage = output["FunctionErrorMessage"];
+    contents.FunctionErrorMessage = __expectString(output["FunctionErrorMessage"]);
   }
   if (output["FunctionOutput"] !== undefined) {
-    contents.FunctionOutput = output["FunctionOutput"];
+    contents.FunctionOutput = __expectString(output["FunctionOutput"]);
   }
   return contents;
 };
@@ -18474,7 +18475,7 @@ const deserializeAws_restXmlTrustedKeyGroupIdList = (output: any, context: __Ser
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -18540,22 +18541,22 @@ const deserializeAws_restXmlViewerCertificate = (output: any, context: __SerdeCo
     contents.CloudFrontDefaultCertificate = __parseBoolean(output["CloudFrontDefaultCertificate"]);
   }
   if (output["IAMCertificateId"] !== undefined) {
-    contents.IAMCertificateId = output["IAMCertificateId"];
+    contents.IAMCertificateId = __expectString(output["IAMCertificateId"]);
   }
   if (output["ACMCertificateArn"] !== undefined) {
-    contents.ACMCertificateArn = output["ACMCertificateArn"];
+    contents.ACMCertificateArn = __expectString(output["ACMCertificateArn"]);
   }
   if (output["SSLSupportMethod"] !== undefined) {
-    contents.SSLSupportMethod = output["SSLSupportMethod"];
+    contents.SSLSupportMethod = __expectString(output["SSLSupportMethod"]);
   }
   if (output["MinimumProtocolVersion"] !== undefined) {
-    contents.MinimumProtocolVersion = output["MinimumProtocolVersion"];
+    contents.MinimumProtocolVersion = __expectString(output["MinimumProtocolVersion"]);
   }
   if (output["Certificate"] !== undefined) {
-    contents.Certificate = output["Certificate"];
+    contents.Certificate = __expectString(output["Certificate"]);
   }
   if (output["CertificateSource"] !== undefined) {
-    contents.CertificateSource = output["CertificateSource"];
+    contents.CertificateSource = __expectString(output["CertificateSource"]);
   }
   return contents;
 };

--- a/clients/client-cloudhsm-v2/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudhsm-v2/protocols/Aws_json1_1.ts
@@ -62,7 +62,11 @@ import {
   UntagResourceResponse,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -1913,9 +1917,9 @@ const serializeAws_json1_1UntagResourceRequest = (input: UntagResourceRequest, c
 
 const deserializeAws_json1_1Backup = (output: any, context: __SerdeContext): Backup => {
   return {
-    BackupId: output.BackupId !== undefined && output.BackupId !== null ? output.BackupId : undefined,
-    BackupState: output.BackupState !== undefined && output.BackupState !== null ? output.BackupState : undefined,
-    ClusterId: output.ClusterId !== undefined && output.ClusterId !== null ? output.ClusterId : undefined,
+    BackupId: __expectString(output.BackupId),
+    BackupState: __expectString(output.BackupState),
+    ClusterId: __expectString(output.ClusterId),
     CopyTimestamp:
       output.CopyTimestamp !== undefined && output.CopyTimestamp !== null
         ? new Date(Math.round(output.CopyTimestamp * 1000))
@@ -1928,11 +1932,10 @@ const deserializeAws_json1_1Backup = (output: any, context: __SerdeContext): Bac
       output.DeleteTimestamp !== undefined && output.DeleteTimestamp !== null
         ? new Date(Math.round(output.DeleteTimestamp * 1000))
         : undefined,
-    NeverExpires: output.NeverExpires !== undefined && output.NeverExpires !== null ? output.NeverExpires : undefined,
-    SourceBackup: output.SourceBackup !== undefined && output.SourceBackup !== null ? output.SourceBackup : undefined,
-    SourceCluster:
-      output.SourceCluster !== undefined && output.SourceCluster !== null ? output.SourceCluster : undefined,
-    SourceRegion: output.SourceRegion !== undefined && output.SourceRegion !== null ? output.SourceRegion : undefined,
+    NeverExpires: __expectBoolean(output.NeverExpires),
+    SourceBackup: __expectString(output.SourceBackup),
+    SourceCluster: __expectString(output.SourceCluster),
+    SourceRegion: __expectString(output.SourceRegion),
     TagList:
       output.TagList !== undefined && output.TagList !== null
         ? deserializeAws_json1_1TagList(output.TagList, context)
@@ -1942,8 +1945,8 @@ const deserializeAws_json1_1Backup = (output: any, context: __SerdeContext): Bac
 
 const deserializeAws_json1_1BackupRetentionPolicy = (output: any, context: __SerdeContext): BackupRetentionPolicy => {
   return {
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Type: __expectString(output.Type),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -1960,21 +1963,11 @@ const deserializeAws_json1_1Backups = (output: any, context: __SerdeContext): Ba
 
 const deserializeAws_json1_1Certificates = (output: any, context: __SerdeContext): Certificates => {
   return {
-    AwsHardwareCertificate:
-      output.AwsHardwareCertificate !== undefined && output.AwsHardwareCertificate !== null
-        ? output.AwsHardwareCertificate
-        : undefined,
-    ClusterCertificate:
-      output.ClusterCertificate !== undefined && output.ClusterCertificate !== null
-        ? output.ClusterCertificate
-        : undefined,
-    ClusterCsr: output.ClusterCsr !== undefined && output.ClusterCsr !== null ? output.ClusterCsr : undefined,
-    HsmCertificate:
-      output.HsmCertificate !== undefined && output.HsmCertificate !== null ? output.HsmCertificate : undefined,
-    ManufacturerHardwareCertificate:
-      output.ManufacturerHardwareCertificate !== undefined && output.ManufacturerHardwareCertificate !== null
-        ? output.ManufacturerHardwareCertificate
-        : undefined,
+    AwsHardwareCertificate: __expectString(output.AwsHardwareCertificate),
+    ClusterCertificate: __expectString(output.ClusterCertificate),
+    ClusterCsr: __expectString(output.ClusterCsr),
+    HsmCertificate: __expectString(output.HsmCertificate),
+    ManufacturerHardwareCertificate: __expectString(output.ManufacturerHardwareCertificate),
   } as any;
 };
 
@@ -1983,7 +1976,7 @@ const deserializeAws_json1_1CloudHsmAccessDeniedException = (
   context: __SerdeContext
 ): CloudHsmAccessDeniedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -1992,7 +1985,7 @@ const deserializeAws_json1_1CloudHsmInternalFailureException = (
   context: __SerdeContext
 ): CloudHsmInternalFailureException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2001,7 +1994,7 @@ const deserializeAws_json1_1CloudHsmInvalidRequestException = (
   context: __SerdeContext
 ): CloudHsmInvalidRequestException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2010,7 +2003,7 @@ const deserializeAws_json1_1CloudHsmResourceNotFoundException = (
   context: __SerdeContext
 ): CloudHsmResourceNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2019,19 +2012,19 @@ const deserializeAws_json1_1CloudHsmServiceException = (
   context: __SerdeContext
 ): CloudHsmServiceException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1CloudHsmTagException = (output: any, context: __SerdeContext): CloudHsmTagException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1Cluster = (output: any, context: __SerdeContext): Cluster => {
   return {
-    BackupPolicy: output.BackupPolicy !== undefined && output.BackupPolicy !== null ? output.BackupPolicy : undefined,
+    BackupPolicy: __expectString(output.BackupPolicy),
     BackupRetentionPolicy:
       output.BackupRetentionPolicy !== undefined && output.BackupRetentionPolicy !== null
         ? deserializeAws_json1_1BackupRetentionPolicy(output.BackupRetentionPolicy, context)
@@ -2040,22 +2033,19 @@ const deserializeAws_json1_1Cluster = (output: any, context: __SerdeContext): Cl
       output.Certificates !== undefined && output.Certificates !== null
         ? deserializeAws_json1_1Certificates(output.Certificates, context)
         : undefined,
-    ClusterId: output.ClusterId !== undefined && output.ClusterId !== null ? output.ClusterId : undefined,
+    ClusterId: __expectString(output.ClusterId),
     CreateTimestamp:
       output.CreateTimestamp !== undefined && output.CreateTimestamp !== null
         ? new Date(Math.round(output.CreateTimestamp * 1000))
         : undefined,
-    HsmType: output.HsmType !== undefined && output.HsmType !== null ? output.HsmType : undefined,
+    HsmType: __expectString(output.HsmType),
     Hsms:
       output.Hsms !== undefined && output.Hsms !== null ? deserializeAws_json1_1Hsms(output.Hsms, context) : undefined,
-    PreCoPassword:
-      output.PreCoPassword !== undefined && output.PreCoPassword !== null ? output.PreCoPassword : undefined,
-    SecurityGroup:
-      output.SecurityGroup !== undefined && output.SecurityGroup !== null ? output.SecurityGroup : undefined,
-    SourceBackupId:
-      output.SourceBackupId !== undefined && output.SourceBackupId !== null ? output.SourceBackupId : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    StateMessage: output.StateMessage !== undefined && output.StateMessage !== null ? output.StateMessage : undefined,
+    PreCoPassword: __expectString(output.PreCoPassword),
+    SecurityGroup: __expectString(output.SecurityGroup),
+    SourceBackupId: __expectString(output.SourceBackupId),
+    State: __expectString(output.State),
+    StateMessage: __expectString(output.StateMessage),
     SubnetMapping:
       output.SubnetMapping !== undefined && output.SubnetMapping !== null
         ? deserializeAws_json1_1ExternalSubnetMapping(output.SubnetMapping, context)
@@ -2064,7 +2054,7 @@ const deserializeAws_json1_1Cluster = (output: any, context: __SerdeContext): Cl
       output.TagList !== undefined && output.TagList !== null
         ? deserializeAws_json1_1TagList(output.TagList, context)
         : undefined,
-    VpcId: output.VpcId !== undefined && output.VpcId !== null ? output.VpcId : undefined,
+    VpcId: __expectString(output.VpcId),
   } as any;
 };
 
@@ -2126,7 +2116,7 @@ const deserializeAws_json1_1DeleteClusterResponse = (output: any, context: __Ser
 
 const deserializeAws_json1_1DeleteHsmResponse = (output: any, context: __SerdeContext): DeleteHsmResponse => {
   return {
-    HsmId: output.HsmId !== undefined && output.HsmId !== null ? output.HsmId : undefined,
+    HsmId: __expectString(output.HsmId),
   } as any;
 };
 
@@ -2139,7 +2129,7 @@ const deserializeAws_json1_1DescribeBackupsResponse = (
       output.Backups !== undefined && output.Backups !== null
         ? deserializeAws_json1_1Backups(output.Backups, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -2152,7 +2142,7 @@ const deserializeAws_json1_1DescribeClustersResponse = (
       output.Clusters !== undefined && output.Clusters !== null
         ? deserializeAws_json1_1Clusters(output.Clusters, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -2162,10 +2152,9 @@ const deserializeAws_json1_1DestinationBackup = (output: any, context: __SerdeCo
       output.CreateTimestamp !== undefined && output.CreateTimestamp !== null
         ? new Date(Math.round(output.CreateTimestamp * 1000))
         : undefined,
-    SourceBackup: output.SourceBackup !== undefined && output.SourceBackup !== null ? output.SourceBackup : undefined,
-    SourceCluster:
-      output.SourceCluster !== undefined && output.SourceCluster !== null ? output.SourceCluster : undefined,
-    SourceRegion: output.SourceRegion !== undefined && output.SourceRegion !== null ? output.SourceRegion : undefined,
+    SourceBackup: __expectString(output.SourceBackup),
+    SourceCluster: __expectString(output.SourceCluster),
+    SourceRegion: __expectString(output.SourceRegion),
   } as any;
 };
 
@@ -2179,22 +2168,21 @@ const deserializeAws_json1_1ExternalSubnetMapping = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_json1_1Hsm = (output: any, context: __SerdeContext): Hsm => {
   return {
-    AvailabilityZone:
-      output.AvailabilityZone !== undefined && output.AvailabilityZone !== null ? output.AvailabilityZone : undefined,
-    ClusterId: output.ClusterId !== undefined && output.ClusterId !== null ? output.ClusterId : undefined,
-    EniId: output.EniId !== undefined && output.EniId !== null ? output.EniId : undefined,
-    EniIp: output.EniIp !== undefined && output.EniIp !== null ? output.EniIp : undefined,
-    HsmId: output.HsmId !== undefined && output.HsmId !== null ? output.HsmId : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    StateMessage: output.StateMessage !== undefined && output.StateMessage !== null ? output.StateMessage : undefined,
-    SubnetId: output.SubnetId !== undefined && output.SubnetId !== null ? output.SubnetId : undefined,
+    AvailabilityZone: __expectString(output.AvailabilityZone),
+    ClusterId: __expectString(output.ClusterId),
+    EniId: __expectString(output.EniId),
+    EniIp: __expectString(output.EniIp),
+    HsmId: __expectString(output.HsmId),
+    State: __expectString(output.State),
+    StateMessage: __expectString(output.StateMessage),
+    SubnetId: __expectString(output.SubnetId),
   } as any;
 };
 
@@ -2214,14 +2202,14 @@ const deserializeAws_json1_1InitializeClusterResponse = (
   context: __SerdeContext
 ): InitializeClusterResponse => {
   return {
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    StateMessage: output.StateMessage !== undefined && output.StateMessage !== null ? output.StateMessage : undefined,
+    State: __expectString(output.State),
+    StateMessage: __expectString(output.StateMessage),
   } as any;
 };
 
 const deserializeAws_json1_1ListTagsResponse = (output: any, context: __SerdeContext): ListTagsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     TagList:
       output.TagList !== undefined && output.TagList !== null
         ? deserializeAws_json1_1TagList(output.TagList, context)
@@ -2261,8 +2249,8 @@ const deserializeAws_json1_1RestoreBackupResponse = (output: any, context: __Ser
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 

--- a/clients/client-cloudhsm/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudhsm/protocols/Aws_json1_1.ts
@@ -71,7 +71,11 @@ import {
   Tag,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -1989,7 +1993,7 @@ const deserializeAws_json1_1AddTagsToResourceResponse = (
   context: __SerdeContext
 ): AddTagsToResourceResponse => {
   return {
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -2000,7 +2004,7 @@ const deserializeAws_json1_1AZList = (output: any, context: __SerdeContext): str
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2011,7 +2015,7 @@ const deserializeAws_json1_1ClientList = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2020,8 +2024,8 @@ const deserializeAws_json1_1CloudHsmInternalException = (
   context: __SerdeContext
 ): CloudHsmInternalException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    retryable: output.retryable !== undefined && output.retryable !== null ? output.retryable : undefined,
+    message: __expectString(output.message),
+    retryable: __expectBoolean(output.retryable),
   } as any;
 };
 
@@ -2030,20 +2034,20 @@ const deserializeAws_json1_1CloudHsmServiceException = (
   context: __SerdeContext
 ): CloudHsmServiceException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    retryable: output.retryable !== undefined && output.retryable !== null ? output.retryable : undefined,
+    message: __expectString(output.message),
+    retryable: __expectBoolean(output.retryable),
   } as any;
 };
 
 const deserializeAws_json1_1CreateHapgResponse = (output: any, context: __SerdeContext): CreateHapgResponse => {
   return {
-    HapgArn: output.HapgArn !== undefined && output.HapgArn !== null ? output.HapgArn : undefined,
+    HapgArn: __expectString(output.HapgArn),
   } as any;
 };
 
 const deserializeAws_json1_1CreateHsmResponse = (output: any, context: __SerdeContext): CreateHsmResponse => {
   return {
-    HsmArn: output.HsmArn !== undefined && output.HsmArn !== null ? output.HsmArn : undefined,
+    HsmArn: __expectString(output.HsmArn),
   } as any;
 };
 
@@ -2052,19 +2056,19 @@ const deserializeAws_json1_1CreateLunaClientResponse = (
   context: __SerdeContext
 ): CreateLunaClientResponse => {
   return {
-    ClientArn: output.ClientArn !== undefined && output.ClientArn !== null ? output.ClientArn : undefined,
+    ClientArn: __expectString(output.ClientArn),
   } as any;
 };
 
 const deserializeAws_json1_1DeleteHapgResponse = (output: any, context: __SerdeContext): DeleteHapgResponse => {
   return {
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
 const deserializeAws_json1_1DeleteHsmResponse = (output: any, context: __SerdeContext): DeleteHsmResponse => {
   return {
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -2073,14 +2077,14 @@ const deserializeAws_json1_1DeleteLunaClientResponse = (
   context: __SerdeContext
 ): DeleteLunaClientResponse => {
   return {
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
 const deserializeAws_json1_1DescribeHapgResponse = (output: any, context: __SerdeContext): DescribeHapgResponse => {
   return {
-    HapgArn: output.HapgArn !== undefined && output.HapgArn !== null ? output.HapgArn : undefined,
-    HapgSerial: output.HapgSerial !== undefined && output.HapgSerial !== null ? output.HapgSerial : undefined,
+    HapgArn: __expectString(output.HapgArn),
+    HapgSerial: __expectString(output.HapgSerial),
     HsmsLastActionFailed:
       output.HsmsLastActionFailed !== undefined && output.HsmsLastActionFailed !== null
         ? deserializeAws_json1_1HsmList(output.HsmsLastActionFailed, context)
@@ -2093,62 +2097,42 @@ const deserializeAws_json1_1DescribeHapgResponse = (output: any, context: __Serd
       output.HsmsPendingRegistration !== undefined && output.HsmsPendingRegistration !== null
         ? deserializeAws_json1_1HsmList(output.HsmsPendingRegistration, context)
         : undefined,
-    Label: output.Label !== undefined && output.Label !== null ? output.Label : undefined,
-    LastModifiedTimestamp:
-      output.LastModifiedTimestamp !== undefined && output.LastModifiedTimestamp !== null
-        ? output.LastModifiedTimestamp
-        : undefined,
+    Label: __expectString(output.Label),
+    LastModifiedTimestamp: __expectString(output.LastModifiedTimestamp),
     PartitionSerialList:
       output.PartitionSerialList !== undefined && output.PartitionSerialList !== null
         ? deserializeAws_json1_1PartitionSerialList(output.PartitionSerialList, context)
         : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    State: __expectString(output.State),
   } as any;
 };
 
 const deserializeAws_json1_1DescribeHsmResponse = (output: any, context: __SerdeContext): DescribeHsmResponse => {
   return {
-    AvailabilityZone:
-      output.AvailabilityZone !== undefined && output.AvailabilityZone !== null ? output.AvailabilityZone : undefined,
-    EniId: output.EniId !== undefined && output.EniId !== null ? output.EniId : undefined,
-    EniIp: output.EniIp !== undefined && output.EniIp !== null ? output.EniIp : undefined,
-    HsmArn: output.HsmArn !== undefined && output.HsmArn !== null ? output.HsmArn : undefined,
-    HsmType: output.HsmType !== undefined && output.HsmType !== null ? output.HsmType : undefined,
-    IamRoleArn: output.IamRoleArn !== undefined && output.IamRoleArn !== null ? output.IamRoleArn : undefined,
+    AvailabilityZone: __expectString(output.AvailabilityZone),
+    EniId: __expectString(output.EniId),
+    EniIp: __expectString(output.EniIp),
+    HsmArn: __expectString(output.HsmArn),
+    HsmType: __expectString(output.HsmType),
+    IamRoleArn: __expectString(output.IamRoleArn),
     Partitions:
       output.Partitions !== undefined && output.Partitions !== null
         ? deserializeAws_json1_1PartitionList(output.Partitions, context)
         : undefined,
-    SerialNumber: output.SerialNumber !== undefined && output.SerialNumber !== null ? output.SerialNumber : undefined,
-    ServerCertLastUpdated:
-      output.ServerCertLastUpdated !== undefined && output.ServerCertLastUpdated !== null
-        ? output.ServerCertLastUpdated
-        : undefined,
-    ServerCertUri:
-      output.ServerCertUri !== undefined && output.ServerCertUri !== null ? output.ServerCertUri : undefined,
-    SoftwareVersion:
-      output.SoftwareVersion !== undefined && output.SoftwareVersion !== null ? output.SoftwareVersion : undefined,
-    SshKeyLastUpdated:
-      output.SshKeyLastUpdated !== undefined && output.SshKeyLastUpdated !== null
-        ? output.SshKeyLastUpdated
-        : undefined,
-    SshPublicKey: output.SshPublicKey !== undefined && output.SshPublicKey !== null ? output.SshPublicKey : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusDetails:
-      output.StatusDetails !== undefined && output.StatusDetails !== null ? output.StatusDetails : undefined,
-    SubnetId: output.SubnetId !== undefined && output.SubnetId !== null ? output.SubnetId : undefined,
-    SubscriptionEndDate:
-      output.SubscriptionEndDate !== undefined && output.SubscriptionEndDate !== null
-        ? output.SubscriptionEndDate
-        : undefined,
-    SubscriptionStartDate:
-      output.SubscriptionStartDate !== undefined && output.SubscriptionStartDate !== null
-        ? output.SubscriptionStartDate
-        : undefined,
-    SubscriptionType:
-      output.SubscriptionType !== undefined && output.SubscriptionType !== null ? output.SubscriptionType : undefined,
-    VendorName: output.VendorName !== undefined && output.VendorName !== null ? output.VendorName : undefined,
-    VpcId: output.VpcId !== undefined && output.VpcId !== null ? output.VpcId : undefined,
+    SerialNumber: __expectString(output.SerialNumber),
+    ServerCertLastUpdated: __expectString(output.ServerCertLastUpdated),
+    ServerCertUri: __expectString(output.ServerCertUri),
+    SoftwareVersion: __expectString(output.SoftwareVersion),
+    SshKeyLastUpdated: __expectString(output.SshKeyLastUpdated),
+    SshPublicKey: __expectString(output.SshPublicKey),
+    Status: __expectString(output.Status),
+    StatusDetails: __expectString(output.StatusDetails),
+    SubnetId: __expectString(output.SubnetId),
+    SubscriptionEndDate: __expectString(output.SubscriptionEndDate),
+    SubscriptionStartDate: __expectString(output.SubscriptionStartDate),
+    SubscriptionType: __expectString(output.SubscriptionType),
+    VendorName: __expectString(output.VendorName),
+    VpcId: __expectString(output.VpcId),
   } as any;
 };
 
@@ -2157,25 +2141,19 @@ const deserializeAws_json1_1DescribeLunaClientResponse = (
   context: __SerdeContext
 ): DescribeLunaClientResponse => {
   return {
-    Certificate: output.Certificate !== undefined && output.Certificate !== null ? output.Certificate : undefined,
-    CertificateFingerprint:
-      output.CertificateFingerprint !== undefined && output.CertificateFingerprint !== null
-        ? output.CertificateFingerprint
-        : undefined,
-    ClientArn: output.ClientArn !== undefined && output.ClientArn !== null ? output.ClientArn : undefined,
-    Label: output.Label !== undefined && output.Label !== null ? output.Label : undefined,
-    LastModifiedTimestamp:
-      output.LastModifiedTimestamp !== undefined && output.LastModifiedTimestamp !== null
-        ? output.LastModifiedTimestamp
-        : undefined,
+    Certificate: __expectString(output.Certificate),
+    CertificateFingerprint: __expectString(output.CertificateFingerprint),
+    ClientArn: __expectString(output.ClientArn),
+    Label: __expectString(output.Label),
+    LastModifiedTimestamp: __expectString(output.LastModifiedTimestamp),
   } as any;
 };
 
 const deserializeAws_json1_1GetConfigResponse = (output: any, context: __SerdeContext): GetConfigResponse => {
   return {
-    ConfigCred: output.ConfigCred !== undefined && output.ConfigCred !== null ? output.ConfigCred : undefined,
-    ConfigFile: output.ConfigFile !== undefined && output.ConfigFile !== null ? output.ConfigFile : undefined,
-    ConfigType: output.ConfigType !== undefined && output.ConfigType !== null ? output.ConfigType : undefined,
+    ConfigCred: __expectString(output.ConfigCred),
+    ConfigFile: __expectString(output.ConfigFile),
+    ConfigType: __expectString(output.ConfigType),
   } as any;
 };
 
@@ -2186,7 +2164,7 @@ const deserializeAws_json1_1HapgList = (output: any, context: __SerdeContext): s
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2197,7 +2175,7 @@ const deserializeAws_json1_1HsmList = (output: any, context: __SerdeContext): st
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2206,8 +2184,8 @@ const deserializeAws_json1_1InvalidRequestException = (
   context: __SerdeContext
 ): InvalidRequestException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    retryable: output.retryable !== undefined && output.retryable !== null ? output.retryable : undefined,
+    message: __expectString(output.message),
+    retryable: __expectBoolean(output.retryable),
   } as any;
 };
 
@@ -2229,7 +2207,7 @@ const deserializeAws_json1_1ListHapgsResponse = (output: any, context: __SerdeCo
       output.HapgList !== undefined && output.HapgList !== null
         ? deserializeAws_json1_1HapgList(output.HapgList, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -2239,7 +2217,7 @@ const deserializeAws_json1_1ListHsmsResponse = (output: any, context: __SerdeCon
       output.HsmList !== undefined && output.HsmList !== null
         ? deserializeAws_json1_1HsmList(output.HsmList, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -2252,7 +2230,7 @@ const deserializeAws_json1_1ListLunaClientsResponse = (
       output.ClientList !== undefined && output.ClientList !== null
         ? deserializeAws_json1_1ClientList(output.ClientList, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -2270,13 +2248,13 @@ const deserializeAws_json1_1ListTagsForResourceResponse = (
 
 const deserializeAws_json1_1ModifyHapgResponse = (output: any, context: __SerdeContext): ModifyHapgResponse => {
   return {
-    HapgArn: output.HapgArn !== undefined && output.HapgArn !== null ? output.HapgArn : undefined,
+    HapgArn: __expectString(output.HapgArn),
   } as any;
 };
 
 const deserializeAws_json1_1ModifyHsmResponse = (output: any, context: __SerdeContext): ModifyHsmResponse => {
   return {
-    HsmArn: output.HsmArn !== undefined && output.HsmArn !== null ? output.HsmArn : undefined,
+    HsmArn: __expectString(output.HsmArn),
   } as any;
 };
 
@@ -2285,7 +2263,7 @@ const deserializeAws_json1_1ModifyLunaClientResponse = (
   context: __SerdeContext
 ): ModifyLunaClientResponse => {
   return {
-    ClientArn: output.ClientArn !== undefined && output.ClientArn !== null ? output.ClientArn : undefined,
+    ClientArn: __expectString(output.ClientArn),
   } as any;
 };
 
@@ -2296,7 +2274,7 @@ const deserializeAws_json1_1PartitionList = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2307,7 +2285,7 @@ const deserializeAws_json1_1PartitionSerialList = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2316,14 +2294,14 @@ const deserializeAws_json1_1RemoveTagsFromResourceResponse = (
   context: __SerdeContext
 ): RemoveTagsFromResourceResponse => {
   return {
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 

--- a/clients/client-cloudsearch-domain/protocols/Aws_restJson1.ts
+++ b/clients/client-cloudsearch-domain/protocols/Aws_restJson1.ts
@@ -18,6 +18,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -263,13 +265,13 @@ export const deserializeAws_restJson1UploadDocumentsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.adds !== undefined && data.adds !== null) {
-    contents.adds = data.adds;
+    contents.adds = __expectNumber(data.adds);
   }
   if (data.deletes !== undefined && data.deletes !== null) {
-    contents.deletes = data.deletes;
+    contents.deletes = __expectNumber(data.deletes);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.status = data.status;
+    contents.status = __expectString(data.status);
   }
   if (data.warnings !== undefined && data.warnings !== null) {
     contents.warnings = deserializeAws_restJson1DocumentServiceWarnings(data.warnings, context);
@@ -327,10 +329,10 @@ const deserializeAws_restJson1DocumentServiceExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.status = data.status;
+    contents.status = __expectString(data.status);
   }
   return contents;
 };
@@ -347,15 +349,15 @@ const deserializeAws_restJson1SearchExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
 
 const deserializeAws_restJson1Bucket = (output: any, context: __SerdeContext): Bucket => {
   return {
-    count: output.count !== undefined && output.count !== null ? output.count : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    count: __expectNumber(output.count),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -384,7 +386,7 @@ const deserializeAws_restJson1DocumentServiceWarning = (
   context: __SerdeContext
 ): DocumentServiceWarning => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -409,7 +411,7 @@ const deserializeAws_restJson1Exprs = (output: any, context: __SerdeContext): { 
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -440,14 +442,14 @@ const deserializeAws_restJson1Fields = (output: any, context: __SerdeContext): {
 
 const deserializeAws_restJson1FieldStats = (output: any, context: __SerdeContext): FieldStats => {
   return {
-    count: output.count !== undefined && output.count !== null ? output.count : undefined,
-    max: output.max !== undefined && output.max !== null ? output.max : undefined,
-    mean: output.mean !== undefined && output.mean !== null ? output.mean : undefined,
-    min: output.min !== undefined && output.min !== null ? output.min : undefined,
-    missing: output.missing !== undefined && output.missing !== null ? output.missing : undefined,
-    stddev: output.stddev !== undefined && output.stddev !== null ? output.stddev : undefined,
-    sum: output.sum !== undefined && output.sum !== null ? output.sum : undefined,
-    sumOfSquares: output.sumOfSquares !== undefined && output.sumOfSquares !== null ? output.sumOfSquares : undefined,
+    count: __expectNumber(output.count),
+    max: __expectString(output.max),
+    mean: __expectString(output.mean),
+    min: __expectString(output.min),
+    missing: __expectNumber(output.missing),
+    stddev: __expectNumber(output.stddev),
+    sum: __expectNumber(output.sum),
+    sumOfSquares: __expectNumber(output.sumOfSquares),
   } as any;
 };
 
@@ -458,7 +460,7 @@ const deserializeAws_restJson1FieldValue = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -469,7 +471,7 @@ const deserializeAws_restJson1Highlights = (output: any, context: __SerdeContext
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -488,7 +490,7 @@ const deserializeAws_restJson1Hit = (output: any, context: __SerdeContext): Hit 
       output.highlights !== undefined && output.highlights !== null
         ? deserializeAws_restJson1Highlights(output.highlights, context)
         : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    id: __expectString(output.id),
   } as any;
 };
 
@@ -505,20 +507,20 @@ const deserializeAws_restJson1HitList = (output: any, context: __SerdeContext): 
 
 const deserializeAws_restJson1Hits = (output: any, context: __SerdeContext): Hits => {
   return {
-    cursor: output.cursor !== undefined && output.cursor !== null ? output.cursor : undefined,
-    found: output.found !== undefined && output.found !== null ? output.found : undefined,
+    cursor: __expectString(output.cursor),
+    found: __expectNumber(output.found),
     hit:
       output.hit !== undefined && output.hit !== null
         ? deserializeAws_restJson1HitList(output.hit, context)
         : undefined,
-    start: output.start !== undefined && output.start !== null ? output.start : undefined,
+    start: __expectNumber(output.start),
   } as any;
 };
 
 const deserializeAws_restJson1SearchStatus = (output: any, context: __SerdeContext): SearchStatus => {
   return {
-    rid: output.rid !== undefined && output.rid !== null ? output.rid : undefined,
-    timems: output.timems !== undefined && output.timems !== null ? output.timems : undefined,
+    rid: __expectString(output.rid),
+    timems: __expectNumber(output.timems),
   } as any;
 };
 
@@ -536,9 +538,9 @@ const deserializeAws_restJson1Stats = (output: any, context: __SerdeContext): { 
 
 const deserializeAws_restJson1SuggestionMatch = (output: any, context: __SerdeContext): SuggestionMatch => {
   return {
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    score: output.score !== undefined && output.score !== null ? output.score : undefined,
-    suggestion: output.suggestion !== undefined && output.suggestion !== null ? output.suggestion : undefined,
+    id: __expectString(output.id),
+    score: __expectNumber(output.score),
+    suggestion: __expectString(output.suggestion),
   } as any;
 };
 
@@ -555,8 +557,8 @@ const deserializeAws_restJson1Suggestions = (output: any, context: __SerdeContex
 
 const deserializeAws_restJson1SuggestModel = (output: any, context: __SerdeContext): SuggestModel => {
   return {
-    found: output.found !== undefined && output.found !== null ? output.found : undefined,
-    query: output.query !== undefined && output.query !== null ? output.query : undefined,
+    found: __expectNumber(output.found),
+    query: __expectString(output.query),
     suggestions:
       output.suggestions !== undefined && output.suggestions !== null
         ? deserializeAws_restJson1Suggestions(output.suggestions, context)
@@ -566,8 +568,8 @@ const deserializeAws_restJson1SuggestModel = (output: any, context: __SerdeConte
 
 const deserializeAws_restJson1SuggestStatus = (output: any, context: __SerdeContext): SuggestStatus => {
   return {
-    rid: output.rid !== undefined && output.rid !== null ? output.rid : undefined,
-    timems: output.timems !== undefined && output.timems !== null ? output.timems : undefined,
+    rid: __expectString(output.rid),
+    timems: __expectNumber(output.timems),
   } as any;
 };
 

--- a/clients/client-cloudsearch/protocols/Aws_query.ts
+++ b/clients/client-cloudsearch/protocols/Aws_query.ts
@@ -157,6 +157,7 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
@@ -3546,7 +3547,7 @@ const deserializeAws_queryAccessPoliciesStatus = (output: any, context: __SerdeC
     Status: undefined,
   };
   if (output["Options"] !== undefined) {
-    contents.Options = output["Options"];
+    contents.Options = __expectString(output["Options"]);
   }
   if (output["Status"] !== undefined) {
     contents.Status = deserializeAws_queryOptionStatus(output["Status"], context);
@@ -3563,19 +3564,19 @@ const deserializeAws_queryAnalysisOptions = (output: any, context: __SerdeContex
     AlgorithmicStemming: undefined,
   };
   if (output["Synonyms"] !== undefined) {
-    contents.Synonyms = output["Synonyms"];
+    contents.Synonyms = __expectString(output["Synonyms"]);
   }
   if (output["Stopwords"] !== undefined) {
-    contents.Stopwords = output["Stopwords"];
+    contents.Stopwords = __expectString(output["Stopwords"]);
   }
   if (output["StemmingDictionary"] !== undefined) {
-    contents.StemmingDictionary = output["StemmingDictionary"];
+    contents.StemmingDictionary = __expectString(output["StemmingDictionary"]);
   }
   if (output["JapaneseTokenizationDictionary"] !== undefined) {
-    contents.JapaneseTokenizationDictionary = output["JapaneseTokenizationDictionary"];
+    contents.JapaneseTokenizationDictionary = __expectString(output["JapaneseTokenizationDictionary"]);
   }
   if (output["AlgorithmicStemming"] !== undefined) {
-    contents.AlgorithmicStemming = output["AlgorithmicStemming"];
+    contents.AlgorithmicStemming = __expectString(output["AlgorithmicStemming"]);
   }
   return contents;
 };
@@ -3587,10 +3588,10 @@ const deserializeAws_queryAnalysisScheme = (output: any, context: __SerdeContext
     AnalysisOptions: undefined,
   };
   if (output["AnalysisSchemeName"] !== undefined) {
-    contents.AnalysisSchemeName = output["AnalysisSchemeName"];
+    contents.AnalysisSchemeName = __expectString(output["AnalysisSchemeName"]);
   }
   if (output["AnalysisSchemeLanguage"] !== undefined) {
-    contents.AnalysisSchemeLanguage = output["AnalysisSchemeLanguage"];
+    contents.AnalysisSchemeLanguage = __expectString(output["AnalysisSchemeLanguage"]);
   }
   if (output["AnalysisOptions"] !== undefined) {
     contents.AnalysisOptions = deserializeAws_queryAnalysisOptions(output["AnalysisOptions"], context);
@@ -3646,10 +3647,10 @@ const deserializeAws_queryBaseException = (output: any, context: __SerdeContext)
     Message: undefined,
   };
   if (output["Code"] !== undefined) {
-    contents.Code = output["Code"];
+    contents.Code = __expectString(output["Code"]);
   }
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -3689,10 +3690,10 @@ const deserializeAws_queryDateArrayOptions = (output: any, context: __SerdeConte
     ReturnEnabled: undefined,
   };
   if (output["DefaultValue"] !== undefined) {
-    contents.DefaultValue = output["DefaultValue"];
+    contents.DefaultValue = __expectString(output["DefaultValue"]);
   }
   if (output["SourceFields"] !== undefined) {
-    contents.SourceFields = output["SourceFields"];
+    contents.SourceFields = __expectString(output["SourceFields"]);
   }
   if (output["FacetEnabled"] !== undefined) {
     contents.FacetEnabled = __parseBoolean(output["FacetEnabled"]);
@@ -3716,10 +3717,10 @@ const deserializeAws_queryDateOptions = (output: any, context: __SerdeContext): 
     SortEnabled: undefined,
   };
   if (output["DefaultValue"] !== undefined) {
-    contents.DefaultValue = output["DefaultValue"];
+    contents.DefaultValue = __expectString(output["DefaultValue"]);
   }
   if (output["SourceField"] !== undefined) {
-    contents.SourceField = output["SourceField"];
+    contents.SourceField = __expectString(output["SourceField"]);
   }
   if (output["FacetEnabled"] !== undefined) {
     contents.FacetEnabled = __parseBoolean(output["FacetEnabled"]);
@@ -4003,10 +4004,10 @@ const deserializeAws_queryDisabledOperationException = (
     Message: undefined,
   };
   if (output["Code"] !== undefined) {
-    contents.Code = output["Code"];
+    contents.Code = __expectString(output["Code"]);
   }
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -4021,13 +4022,13 @@ const deserializeAws_queryDocumentSuggesterOptions = (
     SortExpression: undefined,
   };
   if (output["SourceField"] !== undefined) {
-    contents.SourceField = output["SourceField"];
+    contents.SourceField = __expectString(output["SourceField"]);
   }
   if (output["FuzzyMatching"] !== undefined) {
-    contents.FuzzyMatching = output["FuzzyMatching"];
+    contents.FuzzyMatching = __expectString(output["FuzzyMatching"]);
   }
   if (output["SortExpression"] !== undefined) {
-    contents.SortExpression = output["SortExpression"];
+    contents.SortExpression = __expectString(output["SortExpression"]);
   }
   return contents;
 };
@@ -4041,7 +4042,7 @@ const deserializeAws_queryDomainEndpointOptions = (output: any, context: __Serde
     contents.EnforceHTTPS = __parseBoolean(output["EnforceHTTPS"]);
   }
   if (output["TLSSecurityPolicy"] !== undefined) {
-    contents.TLSSecurityPolicy = output["TLSSecurityPolicy"];
+    contents.TLSSecurityPolicy = __expectString(output["TLSSecurityPolicy"]);
   }
   return contents;
 };
@@ -4070,7 +4071,7 @@ const deserializeAws_queryDomainNameMap = (output: any, context: __SerdeContext)
     }
     return {
       ...acc,
-      [pair["key"]]: pair["value"],
+      [pair["key"]]: __expectString(pair["value"]) as any,
     };
   }, {});
 };
@@ -4092,13 +4093,13 @@ const deserializeAws_queryDomainStatus = (output: any, context: __SerdeContext):
     Limits: undefined,
   };
   if (output["DomainId"] !== undefined) {
-    contents.DomainId = output["DomainId"];
+    contents.DomainId = __expectString(output["DomainId"]);
   }
   if (output["DomainName"] !== undefined) {
-    contents.DomainName = output["DomainName"];
+    contents.DomainName = __expectString(output["DomainName"]);
   }
   if (output["ARN"] !== undefined) {
-    contents.ARN = output["ARN"];
+    contents.ARN = __expectString(output["ARN"]);
   }
   if (output["Created"] !== undefined) {
     contents.Created = __parseBoolean(output["Created"]);
@@ -4119,7 +4120,7 @@ const deserializeAws_queryDomainStatus = (output: any, context: __SerdeContext):
     contents.Processing = __parseBoolean(output["Processing"]);
   }
   if (output["SearchInstanceType"] !== undefined) {
-    contents.SearchInstanceType = output["SearchInstanceType"];
+    contents.SearchInstanceType = __expectString(output["SearchInstanceType"]);
   }
   if (output["SearchPartitionCount"] !== undefined) {
     contents.SearchPartitionCount = parseInt(output["SearchPartitionCount"]);
@@ -4156,7 +4157,7 @@ const deserializeAws_queryDoubleArrayOptions = (output: any, context: __SerdeCon
     contents.DefaultValue = parseFloat(output["DefaultValue"]);
   }
   if (output["SourceFields"] !== undefined) {
-    contents.SourceFields = output["SourceFields"];
+    contents.SourceFields = __expectString(output["SourceFields"]);
   }
   if (output["FacetEnabled"] !== undefined) {
     contents.FacetEnabled = __parseBoolean(output["FacetEnabled"]);
@@ -4183,7 +4184,7 @@ const deserializeAws_queryDoubleOptions = (output: any, context: __SerdeContext)
     contents.DefaultValue = parseFloat(output["DefaultValue"]);
   }
   if (output["SourceField"] !== undefined) {
-    contents.SourceField = output["SourceField"];
+    contents.SourceField = __expectString(output["SourceField"]);
   }
   if (output["FacetEnabled"] !== undefined) {
     contents.FacetEnabled = __parseBoolean(output["FacetEnabled"]);
@@ -4206,10 +4207,10 @@ const deserializeAws_queryExpression = (output: any, context: __SerdeContext): E
     ExpressionValue: undefined,
   };
   if (output["ExpressionName"] !== undefined) {
-    contents.ExpressionName = output["ExpressionName"];
+    contents.ExpressionName = __expectString(output["ExpressionName"]);
   }
   if (output["ExpressionValue"] !== undefined) {
-    contents.ExpressionValue = output["ExpressionValue"];
+    contents.ExpressionValue = __expectString(output["ExpressionValue"]);
   }
   return contents;
 };
@@ -4246,7 +4247,7 @@ const deserializeAws_queryFieldNameList = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4283,10 +4284,10 @@ const deserializeAws_queryIndexField = (output: any, context: __SerdeContext): I
     DateArrayOptions: undefined,
   };
   if (output["IndexFieldName"] !== undefined) {
-    contents.IndexFieldName = output["IndexFieldName"];
+    contents.IndexFieldName = __expectString(output["IndexFieldName"]);
   }
   if (output["IndexFieldType"] !== undefined) {
-    contents.IndexFieldType = output["IndexFieldType"];
+    contents.IndexFieldType = __expectString(output["IndexFieldType"]);
   }
   if (output["IntOptions"] !== undefined) {
     contents.IntOptions = deserializeAws_queryIntOptions(output["IntOptions"], context);
@@ -4361,7 +4362,7 @@ const deserializeAws_queryIntArrayOptions = (output: any, context: __SerdeContex
     contents.DefaultValue = parseInt(output["DefaultValue"]);
   }
   if (output["SourceFields"] !== undefined) {
-    contents.SourceFields = output["SourceFields"];
+    contents.SourceFields = __expectString(output["SourceFields"]);
   }
   if (output["FacetEnabled"] !== undefined) {
     contents.FacetEnabled = __parseBoolean(output["FacetEnabled"]);
@@ -4381,10 +4382,10 @@ const deserializeAws_queryInternalException = (output: any, context: __SerdeCont
     Message: undefined,
   };
   if (output["Code"] !== undefined) {
-    contents.Code = output["Code"];
+    contents.Code = __expectString(output["Code"]);
   }
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -4402,7 +4403,7 @@ const deserializeAws_queryIntOptions = (output: any, context: __SerdeContext): I
     contents.DefaultValue = parseInt(output["DefaultValue"]);
   }
   if (output["SourceField"] !== undefined) {
-    contents.SourceField = output["SourceField"];
+    contents.SourceField = __expectString(output["SourceField"]);
   }
   if (output["FacetEnabled"] !== undefined) {
     contents.FacetEnabled = __parseBoolean(output["FacetEnabled"]);
@@ -4425,10 +4426,10 @@ const deserializeAws_queryInvalidTypeException = (output: any, context: __SerdeC
     Message: undefined,
   };
   if (output["Code"] !== undefined) {
-    contents.Code = output["Code"];
+    contents.Code = __expectString(output["Code"]);
   }
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -4443,10 +4444,10 @@ const deserializeAws_queryLatLonOptions = (output: any, context: __SerdeContext)
     SortEnabled: undefined,
   };
   if (output["DefaultValue"] !== undefined) {
-    contents.DefaultValue = output["DefaultValue"];
+    contents.DefaultValue = __expectString(output["DefaultValue"]);
   }
   if (output["SourceField"] !== undefined) {
-    contents.SourceField = output["SourceField"];
+    contents.SourceField = __expectString(output["SourceField"]);
   }
   if (output["FacetEnabled"] !== undefined) {
     contents.FacetEnabled = __parseBoolean(output["FacetEnabled"]);
@@ -4469,10 +4470,10 @@ const deserializeAws_queryLimitExceededException = (output: any, context: __Serd
     Message: undefined,
   };
   if (output["Code"] !== undefined) {
-    contents.Code = output["Code"];
+    contents.Code = __expectString(output["Code"]);
   }
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -4516,10 +4517,10 @@ const deserializeAws_queryLiteralArrayOptions = (output: any, context: __SerdeCo
     ReturnEnabled: undefined,
   };
   if (output["DefaultValue"] !== undefined) {
-    contents.DefaultValue = output["DefaultValue"];
+    contents.DefaultValue = __expectString(output["DefaultValue"]);
   }
   if (output["SourceFields"] !== undefined) {
-    contents.SourceFields = output["SourceFields"];
+    contents.SourceFields = __expectString(output["SourceFields"]);
   }
   if (output["FacetEnabled"] !== undefined) {
     contents.FacetEnabled = __parseBoolean(output["FacetEnabled"]);
@@ -4543,10 +4544,10 @@ const deserializeAws_queryLiteralOptions = (output: any, context: __SerdeContext
     SortEnabled: undefined,
   };
   if (output["DefaultValue"] !== undefined) {
-    contents.DefaultValue = output["DefaultValue"];
+    contents.DefaultValue = __expectString(output["DefaultValue"]);
   }
   if (output["SourceField"] !== undefined) {
-    contents.SourceField = output["SourceField"];
+    contents.SourceField = __expectString(output["SourceField"]);
   }
   if (output["FacetEnabled"] !== undefined) {
     contents.FacetEnabled = __parseBoolean(output["FacetEnabled"]);
@@ -4581,7 +4582,7 @@ const deserializeAws_queryOptionStatus = (output: any, context: __SerdeContext):
     contents.UpdateVersion = parseInt(output["UpdateVersion"]);
   }
   if (output["State"] !== undefined) {
-    contents.State = output["State"];
+    contents.State = __expectString(output["State"]);
   }
   if (output["PendingDeletion"] !== undefined) {
     contents.PendingDeletion = __parseBoolean(output["PendingDeletion"]);
@@ -4598,10 +4599,10 @@ const deserializeAws_queryResourceNotFoundException = (
     Message: undefined,
   };
   if (output["Code"] !== undefined) {
-    contents.Code = output["Code"];
+    contents.Code = __expectString(output["Code"]);
   }
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -4613,7 +4614,7 @@ const deserializeAws_queryScalingParameters = (output: any, context: __SerdeCont
     DesiredPartitionCount: undefined,
   };
   if (output["DesiredInstanceType"] !== undefined) {
-    contents.DesiredInstanceType = output["DesiredInstanceType"];
+    contents.DesiredInstanceType = __expectString(output["DesiredInstanceType"]);
   }
   if (output["DesiredReplicationCount"] !== undefined) {
     contents.DesiredReplicationCount = parseInt(output["DesiredReplicationCount"]);
@@ -4643,7 +4644,7 @@ const deserializeAws_queryServiceEndpoint = (output: any, context: __SerdeContex
     Endpoint: undefined,
   };
   if (output["Endpoint"] !== undefined) {
-    contents.Endpoint = output["Endpoint"];
+    contents.Endpoint = __expectString(output["Endpoint"]);
   }
   return contents;
 };
@@ -4654,7 +4655,7 @@ const deserializeAws_querySuggester = (output: any, context: __SerdeContext): Su
     DocumentSuggesterOptions: undefined,
   };
   if (output["SuggesterName"] !== undefined) {
-    contents.SuggesterName = output["SuggesterName"];
+    contents.SuggesterName = __expectString(output["SuggesterName"]);
   }
   if (output["DocumentSuggesterOptions"] !== undefined) {
     contents.DocumentSuggesterOptions = deserializeAws_queryDocumentSuggesterOptions(
@@ -4699,10 +4700,10 @@ const deserializeAws_queryTextArrayOptions = (output: any, context: __SerdeConte
     AnalysisScheme: undefined,
   };
   if (output["DefaultValue"] !== undefined) {
-    contents.DefaultValue = output["DefaultValue"];
+    contents.DefaultValue = __expectString(output["DefaultValue"]);
   }
   if (output["SourceFields"] !== undefined) {
-    contents.SourceFields = output["SourceFields"];
+    contents.SourceFields = __expectString(output["SourceFields"]);
   }
   if (output["ReturnEnabled"] !== undefined) {
     contents.ReturnEnabled = __parseBoolean(output["ReturnEnabled"]);
@@ -4711,7 +4712,7 @@ const deserializeAws_queryTextArrayOptions = (output: any, context: __SerdeConte
     contents.HighlightEnabled = __parseBoolean(output["HighlightEnabled"]);
   }
   if (output["AnalysisScheme"] !== undefined) {
-    contents.AnalysisScheme = output["AnalysisScheme"];
+    contents.AnalysisScheme = __expectString(output["AnalysisScheme"]);
   }
   return contents;
 };
@@ -4726,10 +4727,10 @@ const deserializeAws_queryTextOptions = (output: any, context: __SerdeContext): 
     AnalysisScheme: undefined,
   };
   if (output["DefaultValue"] !== undefined) {
-    contents.DefaultValue = output["DefaultValue"];
+    contents.DefaultValue = __expectString(output["DefaultValue"]);
   }
   if (output["SourceField"] !== undefined) {
-    contents.SourceField = output["SourceField"];
+    contents.SourceField = __expectString(output["SourceField"]);
   }
   if (output["ReturnEnabled"] !== undefined) {
     contents.ReturnEnabled = __parseBoolean(output["ReturnEnabled"]);
@@ -4741,7 +4742,7 @@ const deserializeAws_queryTextOptions = (output: any, context: __SerdeContext): 
     contents.HighlightEnabled = __parseBoolean(output["HighlightEnabled"]);
   }
   if (output["AnalysisScheme"] !== undefined) {
-    contents.AnalysisScheme = output["AnalysisScheme"];
+    contents.AnalysisScheme = __expectString(output["AnalysisScheme"]);
   }
   return contents;
 };
@@ -4810,10 +4811,10 @@ const deserializeAws_queryValidationException = (output: any, context: __SerdeCo
     Message: undefined,
   };
   if (output["Code"] !== undefined) {
-    contents.Code = output["Code"];
+    contents.Code = __expectString(output["Code"]);
   }
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };

--- a/clients/client-cloudtrail/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudtrail/protocols/Aws_json1_1.ts
@@ -118,7 +118,11 @@ import {
   UpdateTrailResponse,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -3510,7 +3514,7 @@ const deserializeAws_json1_1AdvancedEventSelector = (output: any, context: __Ser
       output.FieldSelectors !== undefined && output.FieldSelectors !== null
         ? deserializeAws_json1_1AdvancedFieldSelectors(output.FieldSelectors, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -3538,7 +3542,7 @@ const deserializeAws_json1_1AdvancedFieldSelector = (output: any, context: __Ser
       output.Equals !== undefined && output.Equals !== null
         ? deserializeAws_json1_1Operator(output.Equals, context)
         : undefined,
-    Field: output.Field !== undefined && output.Field !== null ? output.Field : undefined,
+    Field: __expectString(output.Field),
     NotEndsWith:
       output.NotEndsWith !== undefined && output.NotEndsWith !== null
         ? deserializeAws_json1_1Operator(output.NotEndsWith, context)
@@ -3577,7 +3581,7 @@ const deserializeAws_json1_1CloudTrailAccessNotEnabledException = (
   context: __SerdeContext
 ): CloudTrailAccessNotEnabledException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3586,7 +3590,7 @@ const deserializeAws_json1_1CloudTrailARNInvalidException = (
   context: __SerdeContext
 ): CloudTrailARNInvalidException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3595,7 +3599,7 @@ const deserializeAws_json1_1CloudTrailInvalidClientTokenIdException = (
   context: __SerdeContext
 ): CloudTrailInvalidClientTokenIdException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3604,55 +3608,37 @@ const deserializeAws_json1_1CloudWatchLogsDeliveryUnavailableException = (
   context: __SerdeContext
 ): CloudWatchLogsDeliveryUnavailableException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1ConflictException = (output: any, context: __SerdeContext): ConflictException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1CreateTrailResponse = (output: any, context: __SerdeContext): CreateTrailResponse => {
   return {
-    CloudWatchLogsLogGroupArn:
-      output.CloudWatchLogsLogGroupArn !== undefined && output.CloudWatchLogsLogGroupArn !== null
-        ? output.CloudWatchLogsLogGroupArn
-        : undefined,
-    CloudWatchLogsRoleArn:
-      output.CloudWatchLogsRoleArn !== undefined && output.CloudWatchLogsRoleArn !== null
-        ? output.CloudWatchLogsRoleArn
-        : undefined,
-    IncludeGlobalServiceEvents:
-      output.IncludeGlobalServiceEvents !== undefined && output.IncludeGlobalServiceEvents !== null
-        ? output.IncludeGlobalServiceEvents
-        : undefined,
-    IsMultiRegionTrail:
-      output.IsMultiRegionTrail !== undefined && output.IsMultiRegionTrail !== null
-        ? output.IsMultiRegionTrail
-        : undefined,
-    IsOrganizationTrail:
-      output.IsOrganizationTrail !== undefined && output.IsOrganizationTrail !== null
-        ? output.IsOrganizationTrail
-        : undefined,
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
-    LogFileValidationEnabled:
-      output.LogFileValidationEnabled !== undefined && output.LogFileValidationEnabled !== null
-        ? output.LogFileValidationEnabled
-        : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    S3BucketName: output.S3BucketName !== undefined && output.S3BucketName !== null ? output.S3BucketName : undefined,
-    S3KeyPrefix: output.S3KeyPrefix !== undefined && output.S3KeyPrefix !== null ? output.S3KeyPrefix : undefined,
-    SnsTopicARN: output.SnsTopicARN !== undefined && output.SnsTopicARN !== null ? output.SnsTopicARN : undefined,
-    SnsTopicName: output.SnsTopicName !== undefined && output.SnsTopicName !== null ? output.SnsTopicName : undefined,
-    TrailARN: output.TrailARN !== undefined && output.TrailARN !== null ? output.TrailARN : undefined,
+    CloudWatchLogsLogGroupArn: __expectString(output.CloudWatchLogsLogGroupArn),
+    CloudWatchLogsRoleArn: __expectString(output.CloudWatchLogsRoleArn),
+    IncludeGlobalServiceEvents: __expectBoolean(output.IncludeGlobalServiceEvents),
+    IsMultiRegionTrail: __expectBoolean(output.IsMultiRegionTrail),
+    IsOrganizationTrail: __expectBoolean(output.IsOrganizationTrail),
+    KmsKeyId: __expectString(output.KmsKeyId),
+    LogFileValidationEnabled: __expectBoolean(output.LogFileValidationEnabled),
+    Name: __expectString(output.Name),
+    S3BucketName: __expectString(output.S3BucketName),
+    S3KeyPrefix: __expectString(output.S3KeyPrefix),
+    SnsTopicARN: __expectString(output.SnsTopicARN),
+    SnsTopicName: __expectString(output.SnsTopicName),
+    TrailARN: __expectString(output.TrailARN),
   } as any;
 };
 
 const deserializeAws_json1_1DataResource = (output: any, context: __SerdeContext): DataResource => {
   return {
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
     Values:
       output.Values !== undefined && output.Values !== null
         ? deserializeAws_json1_1DataResourceValues(output.Values, context)
@@ -3678,7 +3664,7 @@ const deserializeAws_json1_1DataResourceValues = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3697,22 +3683,21 @@ const deserializeAws_json1_1DescribeTrailsResponse = (output: any, context: __Se
 
 const deserializeAws_json1_1Event = (output: any, context: __SerdeContext): Event => {
   return {
-    AccessKeyId: output.AccessKeyId !== undefined && output.AccessKeyId !== null ? output.AccessKeyId : undefined,
-    CloudTrailEvent:
-      output.CloudTrailEvent !== undefined && output.CloudTrailEvent !== null ? output.CloudTrailEvent : undefined,
-    EventId: output.EventId !== undefined && output.EventId !== null ? output.EventId : undefined,
-    EventName: output.EventName !== undefined && output.EventName !== null ? output.EventName : undefined,
-    EventSource: output.EventSource !== undefined && output.EventSource !== null ? output.EventSource : undefined,
+    AccessKeyId: __expectString(output.AccessKeyId),
+    CloudTrailEvent: __expectString(output.CloudTrailEvent),
+    EventId: __expectString(output.EventId),
+    EventName: __expectString(output.EventName),
+    EventSource: __expectString(output.EventSource),
     EventTime:
       output.EventTime !== undefined && output.EventTime !== null
         ? new Date(Math.round(output.EventTime * 1000))
         : undefined,
-    ReadOnly: output.ReadOnly !== undefined && output.ReadOnly !== null ? output.ReadOnly : undefined,
+    ReadOnly: __expectString(output.ReadOnly),
     Resources:
       output.Resources !== undefined && output.Resources !== null
         ? deserializeAws_json1_1ResourceList(output.Resources, context)
         : undefined,
-    Username: output.Username !== undefined && output.Username !== null ? output.Username : undefined,
+    Username: __expectString(output.Username),
   } as any;
 };
 
@@ -3726,12 +3711,8 @@ const deserializeAws_json1_1EventSelector = (output: any, context: __SerdeContex
       output.ExcludeManagementEventSources !== undefined && output.ExcludeManagementEventSources !== null
         ? deserializeAws_json1_1ExcludeManagementEventSources(output.ExcludeManagementEventSources, context)
         : undefined,
-    IncludeManagementEvents:
-      output.IncludeManagementEvents !== undefined && output.IncludeManagementEvents !== null
-        ? output.IncludeManagementEvents
-        : undefined,
-    ReadWriteType:
-      output.ReadWriteType !== undefined && output.ReadWriteType !== null ? output.ReadWriteType : undefined,
+    IncludeManagementEvents: __expectBoolean(output.IncludeManagementEvents),
+    ReadWriteType: __expectString(output.ReadWriteType),
   } as any;
 };
 
@@ -3764,7 +3745,7 @@ const deserializeAws_json1_1ExcludeManagementEventSources = (output: any, contex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3781,7 +3762,7 @@ const deserializeAws_json1_1GetEventSelectorsResponse = (
       output.EventSelectors !== undefined && output.EventSelectors !== null
         ? deserializeAws_json1_1EventSelectors(output.EventSelectors, context)
         : undefined,
-    TrailARN: output.TrailARN !== undefined && output.TrailARN !== null ? output.TrailARN : undefined,
+    TrailARN: __expectString(output.TrailARN),
   } as any;
 };
 
@@ -3794,7 +3775,7 @@ const deserializeAws_json1_1GetInsightSelectorsResponse = (
       output.InsightSelectors !== undefined && output.InsightSelectors !== null
         ? deserializeAws_json1_1InsightSelectors(output.InsightSelectors, context)
         : undefined,
-    TrailARN: output.TrailARN !== undefined && output.TrailARN !== null ? output.TrailARN : undefined,
+    TrailARN: __expectString(output.TrailARN),
   } as any;
 };
 
@@ -3809,51 +3790,27 @@ const deserializeAws_json1_1GetTrailResponse = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1GetTrailStatusResponse = (output: any, context: __SerdeContext): GetTrailStatusResponse => {
   return {
-    IsLogging: output.IsLogging !== undefined && output.IsLogging !== null ? output.IsLogging : undefined,
-    LatestCloudWatchLogsDeliveryError:
-      output.LatestCloudWatchLogsDeliveryError !== undefined && output.LatestCloudWatchLogsDeliveryError !== null
-        ? output.LatestCloudWatchLogsDeliveryError
-        : undefined,
+    IsLogging: __expectBoolean(output.IsLogging),
+    LatestCloudWatchLogsDeliveryError: __expectString(output.LatestCloudWatchLogsDeliveryError),
     LatestCloudWatchLogsDeliveryTime:
       output.LatestCloudWatchLogsDeliveryTime !== undefined && output.LatestCloudWatchLogsDeliveryTime !== null
         ? new Date(Math.round(output.LatestCloudWatchLogsDeliveryTime * 1000))
         : undefined,
-    LatestDeliveryAttemptSucceeded:
-      output.LatestDeliveryAttemptSucceeded !== undefined && output.LatestDeliveryAttemptSucceeded !== null
-        ? output.LatestDeliveryAttemptSucceeded
-        : undefined,
-    LatestDeliveryAttemptTime:
-      output.LatestDeliveryAttemptTime !== undefined && output.LatestDeliveryAttemptTime !== null
-        ? output.LatestDeliveryAttemptTime
-        : undefined,
-    LatestDeliveryError:
-      output.LatestDeliveryError !== undefined && output.LatestDeliveryError !== null
-        ? output.LatestDeliveryError
-        : undefined,
+    LatestDeliveryAttemptSucceeded: __expectString(output.LatestDeliveryAttemptSucceeded),
+    LatestDeliveryAttemptTime: __expectString(output.LatestDeliveryAttemptTime),
+    LatestDeliveryError: __expectString(output.LatestDeliveryError),
     LatestDeliveryTime:
       output.LatestDeliveryTime !== undefined && output.LatestDeliveryTime !== null
         ? new Date(Math.round(output.LatestDeliveryTime * 1000))
         : undefined,
-    LatestDigestDeliveryError:
-      output.LatestDigestDeliveryError !== undefined && output.LatestDigestDeliveryError !== null
-        ? output.LatestDigestDeliveryError
-        : undefined,
+    LatestDigestDeliveryError: __expectString(output.LatestDigestDeliveryError),
     LatestDigestDeliveryTime:
       output.LatestDigestDeliveryTime !== undefined && output.LatestDigestDeliveryTime !== null
         ? new Date(Math.round(output.LatestDigestDeliveryTime * 1000))
         : undefined,
-    LatestNotificationAttemptSucceeded:
-      output.LatestNotificationAttemptSucceeded !== undefined && output.LatestNotificationAttemptSucceeded !== null
-        ? output.LatestNotificationAttemptSucceeded
-        : undefined,
-    LatestNotificationAttemptTime:
-      output.LatestNotificationAttemptTime !== undefined && output.LatestNotificationAttemptTime !== null
-        ? output.LatestNotificationAttemptTime
-        : undefined,
-    LatestNotificationError:
-      output.LatestNotificationError !== undefined && output.LatestNotificationError !== null
-        ? output.LatestNotificationError
-        : undefined,
+    LatestNotificationAttemptSucceeded: __expectString(output.LatestNotificationAttemptSucceeded),
+    LatestNotificationAttemptTime: __expectString(output.LatestNotificationAttemptTime),
+    LatestNotificationError: __expectString(output.LatestNotificationError),
     LatestNotificationTime:
       output.LatestNotificationTime !== undefined && output.LatestNotificationTime !== null
         ? new Date(Math.round(output.LatestNotificationTime * 1000))
@@ -3866,14 +3823,8 @@ const deserializeAws_json1_1GetTrailStatusResponse = (output: any, context: __Se
       output.StopLoggingTime !== undefined && output.StopLoggingTime !== null
         ? new Date(Math.round(output.StopLoggingTime * 1000))
         : undefined,
-    TimeLoggingStarted:
-      output.TimeLoggingStarted !== undefined && output.TimeLoggingStarted !== null
-        ? output.TimeLoggingStarted
-        : undefined,
-    TimeLoggingStopped:
-      output.TimeLoggingStopped !== undefined && output.TimeLoggingStopped !== null
-        ? output.TimeLoggingStopped
-        : undefined,
+    TimeLoggingStarted: __expectString(output.TimeLoggingStarted),
+    TimeLoggingStopped: __expectString(output.TimeLoggingStopped),
   } as any;
 };
 
@@ -3882,13 +3833,13 @@ const deserializeAws_json1_1InsightNotEnabledException = (
   context: __SerdeContext
 ): InsightNotEnabledException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1InsightSelector = (output: any, context: __SerdeContext): InsightSelector => {
   return {
-    InsightType: output.InsightType !== undefined && output.InsightType !== null ? output.InsightType : undefined,
+    InsightType: __expectString(output.InsightType),
   } as any;
 };
 
@@ -3908,7 +3859,7 @@ const deserializeAws_json1_1InsufficientDependencyServiceAccessPermissionExcepti
   context: __SerdeContext
 ): InsufficientDependencyServiceAccessPermissionException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3917,7 +3868,7 @@ const deserializeAws_json1_1InsufficientEncryptionPolicyException = (
   context: __SerdeContext
 ): InsufficientEncryptionPolicyException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3926,7 +3877,7 @@ const deserializeAws_json1_1InsufficientS3BucketPolicyException = (
   context: __SerdeContext
 ): InsufficientS3BucketPolicyException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3935,7 +3886,7 @@ const deserializeAws_json1_1InsufficientSnsTopicPolicyException = (
   context: __SerdeContext
 ): InsufficientSnsTopicPolicyException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3944,7 +3895,7 @@ const deserializeAws_json1_1InvalidCloudWatchLogsLogGroupArnException = (
   context: __SerdeContext
 ): InvalidCloudWatchLogsLogGroupArnException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3953,7 +3904,7 @@ const deserializeAws_json1_1InvalidCloudWatchLogsRoleArnException = (
   context: __SerdeContext
 ): InvalidCloudWatchLogsRoleArnException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3962,7 +3913,7 @@ const deserializeAws_json1_1InvalidEventCategoryException = (
   context: __SerdeContext
 ): InvalidEventCategoryException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3971,7 +3922,7 @@ const deserializeAws_json1_1InvalidEventSelectorsException = (
   context: __SerdeContext
 ): InvalidEventSelectorsException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3980,7 +3931,7 @@ const deserializeAws_json1_1InvalidHomeRegionException = (
   context: __SerdeContext
 ): InvalidHomeRegionException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3989,7 +3940,7 @@ const deserializeAws_json1_1InvalidInsightSelectorsException = (
   context: __SerdeContext
 ): InvalidInsightSelectorsException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3998,7 +3949,7 @@ const deserializeAws_json1_1InvalidKmsKeyIdException = (
   context: __SerdeContext
 ): InvalidKmsKeyIdException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -4007,7 +3958,7 @@ const deserializeAws_json1_1InvalidLookupAttributesException = (
   context: __SerdeContext
 ): InvalidLookupAttributesException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -4016,7 +3967,7 @@ const deserializeAws_json1_1InvalidMaxResultsException = (
   context: __SerdeContext
 ): InvalidMaxResultsException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -4025,7 +3976,7 @@ const deserializeAws_json1_1InvalidNextTokenException = (
   context: __SerdeContext
 ): InvalidNextTokenException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -4034,7 +3985,7 @@ const deserializeAws_json1_1InvalidParameterCombinationException = (
   context: __SerdeContext
 ): InvalidParameterCombinationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -4043,7 +3994,7 @@ const deserializeAws_json1_1InvalidS3BucketNameException = (
   context: __SerdeContext
 ): InvalidS3BucketNameException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -4052,7 +4003,7 @@ const deserializeAws_json1_1InvalidS3PrefixException = (
   context: __SerdeContext
 ): InvalidS3PrefixException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -4061,7 +4012,7 @@ const deserializeAws_json1_1InvalidSnsTopicNameException = (
   context: __SerdeContext
 ): InvalidSnsTopicNameException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -4070,7 +4021,7 @@ const deserializeAws_json1_1InvalidTagParameterException = (
   context: __SerdeContext
 ): InvalidTagParameterException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -4079,13 +4030,13 @@ const deserializeAws_json1_1InvalidTimeRangeException = (
   context: __SerdeContext
 ): InvalidTimeRangeException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidTokenException = (output: any, context: __SerdeContext): InvalidTokenException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -4094,13 +4045,13 @@ const deserializeAws_json1_1InvalidTrailNameException = (
   context: __SerdeContext
 ): InvalidTrailNameException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1KmsException = (output: any, context: __SerdeContext): KmsException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -4109,7 +4060,7 @@ const deserializeAws_json1_1KmsKeyDisabledException = (
   context: __SerdeContext
 ): KmsKeyDisabledException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -4118,13 +4069,13 @@ const deserializeAws_json1_1KmsKeyNotFoundException = (
   context: __SerdeContext
 ): KmsKeyNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1ListPublicKeysResponse = (output: any, context: __SerdeContext): ListPublicKeysResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     PublicKeyList:
       output.PublicKeyList !== undefined && output.PublicKeyList !== null
         ? deserializeAws_json1_1PublicKeyList(output.PublicKeyList, context)
@@ -4134,7 +4085,7 @@ const deserializeAws_json1_1ListPublicKeysResponse = (output: any, context: __Se
 
 const deserializeAws_json1_1ListTagsResponse = (output: any, context: __SerdeContext): ListTagsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     ResourceTagList:
       output.ResourceTagList !== undefined && output.ResourceTagList !== null
         ? deserializeAws_json1_1ResourceTagList(output.ResourceTagList, context)
@@ -4144,7 +4095,7 @@ const deserializeAws_json1_1ListTagsResponse = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1ListTrailsResponse = (output: any, context: __SerdeContext): ListTrailsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Trails:
       output.Trails !== undefined && output.Trails !== null
         ? deserializeAws_json1_1Trails(output.Trails, context)
@@ -4158,7 +4109,7 @@ const deserializeAws_json1_1LookupEventsResponse = (output: any, context: __Serd
       output.Events !== undefined && output.Events !== null
         ? deserializeAws_json1_1EventsList(output.Events, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -4167,7 +4118,7 @@ const deserializeAws_json1_1MaximumNumberOfTrailsExceededException = (
   context: __SerdeContext
 ): MaximumNumberOfTrailsExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -4176,7 +4127,7 @@ const deserializeAws_json1_1NotOrganizationMasterAccountException = (
   context: __SerdeContext
 ): NotOrganizationMasterAccountException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -4185,7 +4136,7 @@ const deserializeAws_json1_1OperationNotPermittedException = (
   context: __SerdeContext
 ): OperationNotPermittedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -4196,7 +4147,7 @@ const deserializeAws_json1_1Operator = (output: any, context: __SerdeContext): s
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4205,7 +4156,7 @@ const deserializeAws_json1_1OrganizationNotInAllFeaturesModeException = (
   context: __SerdeContext
 ): OrganizationNotInAllFeaturesModeException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -4214,13 +4165,13 @@ const deserializeAws_json1_1OrganizationsNotInUseException = (
   context: __SerdeContext
 ): OrganizationsNotInUseException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1PublicKey = (output: any, context: __SerdeContext): PublicKey => {
   return {
-    Fingerprint: output.Fingerprint !== undefined && output.Fingerprint !== null ? output.Fingerprint : undefined,
+    Fingerprint: __expectString(output.Fingerprint),
     ValidityEndTime:
       output.ValidityEndTime !== undefined && output.ValidityEndTime !== null
         ? new Date(Math.round(output.ValidityEndTime * 1000))
@@ -4257,7 +4208,7 @@ const deserializeAws_json1_1PutEventSelectorsResponse = (
       output.EventSelectors !== undefined && output.EventSelectors !== null
         ? deserializeAws_json1_1EventSelectors(output.EventSelectors, context)
         : undefined,
-    TrailARN: output.TrailARN !== undefined && output.TrailARN !== null ? output.TrailARN : undefined,
+    TrailARN: __expectString(output.TrailARN),
   } as any;
 };
 
@@ -4270,7 +4221,7 @@ const deserializeAws_json1_1PutInsightSelectorsResponse = (
       output.InsightSelectors !== undefined && output.InsightSelectors !== null
         ? deserializeAws_json1_1InsightSelectors(output.InsightSelectors, context)
         : undefined,
-    TrailARN: output.TrailARN !== undefined && output.TrailARN !== null ? output.TrailARN : undefined,
+    TrailARN: __expectString(output.TrailARN),
   } as any;
 };
 
@@ -4280,8 +4231,8 @@ const deserializeAws_json1_1RemoveTagsResponse = (output: any, context: __SerdeC
 
 const deserializeAws_json1_1Resource = (output: any, context: __SerdeContext): Resource => {
   return {
-    ResourceName: output.ResourceName !== undefined && output.ResourceName !== null ? output.ResourceName : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
+    ResourceName: __expectString(output.ResourceName),
+    ResourceType: __expectString(output.ResourceType),
   } as any;
 };
 
@@ -4301,13 +4252,13 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1ResourceTag = (output: any, context: __SerdeContext): ResourceTag => {
   return {
-    ResourceId: output.ResourceId !== undefined && output.ResourceId !== null ? output.ResourceId : undefined,
+    ResourceId: __expectString(output.ResourceId),
     TagsList:
       output.TagsList !== undefined && output.TagsList !== null
         ? deserializeAws_json1_1TagsList(output.TagsList, context)
@@ -4331,7 +4282,7 @@ const deserializeAws_json1_1ResourceTypeNotSupportedException = (
   context: __SerdeContext
 ): ResourceTypeNotSupportedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -4340,7 +4291,7 @@ const deserializeAws_json1_1S3BucketDoesNotExistException = (
   context: __SerdeContext
 ): S3BucketDoesNotExistException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -4354,8 +4305,8 @@ const deserializeAws_json1_1StopLoggingResponse = (output: any, context: __Serde
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -4364,7 +4315,7 @@ const deserializeAws_json1_1TagsLimitExceededException = (
   context: __SerdeContext
 ): TagsLimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -4381,46 +4332,22 @@ const deserializeAws_json1_1TagsList = (output: any, context: __SerdeContext): T
 
 const deserializeAws_json1_1Trail = (output: any, context: __SerdeContext): Trail => {
   return {
-    CloudWatchLogsLogGroupArn:
-      output.CloudWatchLogsLogGroupArn !== undefined && output.CloudWatchLogsLogGroupArn !== null
-        ? output.CloudWatchLogsLogGroupArn
-        : undefined,
-    CloudWatchLogsRoleArn:
-      output.CloudWatchLogsRoleArn !== undefined && output.CloudWatchLogsRoleArn !== null
-        ? output.CloudWatchLogsRoleArn
-        : undefined,
-    HasCustomEventSelectors:
-      output.HasCustomEventSelectors !== undefined && output.HasCustomEventSelectors !== null
-        ? output.HasCustomEventSelectors
-        : undefined,
-    HasInsightSelectors:
-      output.HasInsightSelectors !== undefined && output.HasInsightSelectors !== null
-        ? output.HasInsightSelectors
-        : undefined,
-    HomeRegion: output.HomeRegion !== undefined && output.HomeRegion !== null ? output.HomeRegion : undefined,
-    IncludeGlobalServiceEvents:
-      output.IncludeGlobalServiceEvents !== undefined && output.IncludeGlobalServiceEvents !== null
-        ? output.IncludeGlobalServiceEvents
-        : undefined,
-    IsMultiRegionTrail:
-      output.IsMultiRegionTrail !== undefined && output.IsMultiRegionTrail !== null
-        ? output.IsMultiRegionTrail
-        : undefined,
-    IsOrganizationTrail:
-      output.IsOrganizationTrail !== undefined && output.IsOrganizationTrail !== null
-        ? output.IsOrganizationTrail
-        : undefined,
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
-    LogFileValidationEnabled:
-      output.LogFileValidationEnabled !== undefined && output.LogFileValidationEnabled !== null
-        ? output.LogFileValidationEnabled
-        : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    S3BucketName: output.S3BucketName !== undefined && output.S3BucketName !== null ? output.S3BucketName : undefined,
-    S3KeyPrefix: output.S3KeyPrefix !== undefined && output.S3KeyPrefix !== null ? output.S3KeyPrefix : undefined,
-    SnsTopicARN: output.SnsTopicARN !== undefined && output.SnsTopicARN !== null ? output.SnsTopicARN : undefined,
-    SnsTopicName: output.SnsTopicName !== undefined && output.SnsTopicName !== null ? output.SnsTopicName : undefined,
-    TrailARN: output.TrailARN !== undefined && output.TrailARN !== null ? output.TrailARN : undefined,
+    CloudWatchLogsLogGroupArn: __expectString(output.CloudWatchLogsLogGroupArn),
+    CloudWatchLogsRoleArn: __expectString(output.CloudWatchLogsRoleArn),
+    HasCustomEventSelectors: __expectBoolean(output.HasCustomEventSelectors),
+    HasInsightSelectors: __expectBoolean(output.HasInsightSelectors),
+    HomeRegion: __expectString(output.HomeRegion),
+    IncludeGlobalServiceEvents: __expectBoolean(output.IncludeGlobalServiceEvents),
+    IsMultiRegionTrail: __expectBoolean(output.IsMultiRegionTrail),
+    IsOrganizationTrail: __expectBoolean(output.IsOrganizationTrail),
+    KmsKeyId: __expectString(output.KmsKeyId),
+    LogFileValidationEnabled: __expectBoolean(output.LogFileValidationEnabled),
+    Name: __expectString(output.Name),
+    S3BucketName: __expectString(output.S3BucketName),
+    S3KeyPrefix: __expectString(output.S3KeyPrefix),
+    SnsTopicARN: __expectString(output.SnsTopicARN),
+    SnsTopicName: __expectString(output.SnsTopicName),
+    TrailARN: __expectString(output.TrailARN),
   } as any;
 };
 
@@ -4429,15 +4356,15 @@ const deserializeAws_json1_1TrailAlreadyExistsException = (
   context: __SerdeContext
 ): TrailAlreadyExistsException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1TrailInfo = (output: any, context: __SerdeContext): TrailInfo => {
   return {
-    HomeRegion: output.HomeRegion !== undefined && output.HomeRegion !== null ? output.HomeRegion : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    TrailARN: output.TrailARN !== undefined && output.TrailARN !== null ? output.TrailARN : undefined,
+    HomeRegion: __expectString(output.HomeRegion),
+    Name: __expectString(output.Name),
+    TrailARN: __expectString(output.TrailARN),
   } as any;
 };
 
@@ -4454,7 +4381,7 @@ const deserializeAws_json1_1TrailList = (output: any, context: __SerdeContext): 
 
 const deserializeAws_json1_1TrailNotFoundException = (output: any, context: __SerdeContext): TrailNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -4463,7 +4390,7 @@ const deserializeAws_json1_1TrailNotProvidedException = (
   context: __SerdeContext
 ): TrailNotProvidedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -4483,43 +4410,25 @@ const deserializeAws_json1_1UnsupportedOperationException = (
   context: __SerdeContext
 ): UnsupportedOperationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1UpdateTrailResponse = (output: any, context: __SerdeContext): UpdateTrailResponse => {
   return {
-    CloudWatchLogsLogGroupArn:
-      output.CloudWatchLogsLogGroupArn !== undefined && output.CloudWatchLogsLogGroupArn !== null
-        ? output.CloudWatchLogsLogGroupArn
-        : undefined,
-    CloudWatchLogsRoleArn:
-      output.CloudWatchLogsRoleArn !== undefined && output.CloudWatchLogsRoleArn !== null
-        ? output.CloudWatchLogsRoleArn
-        : undefined,
-    IncludeGlobalServiceEvents:
-      output.IncludeGlobalServiceEvents !== undefined && output.IncludeGlobalServiceEvents !== null
-        ? output.IncludeGlobalServiceEvents
-        : undefined,
-    IsMultiRegionTrail:
-      output.IsMultiRegionTrail !== undefined && output.IsMultiRegionTrail !== null
-        ? output.IsMultiRegionTrail
-        : undefined,
-    IsOrganizationTrail:
-      output.IsOrganizationTrail !== undefined && output.IsOrganizationTrail !== null
-        ? output.IsOrganizationTrail
-        : undefined,
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
-    LogFileValidationEnabled:
-      output.LogFileValidationEnabled !== undefined && output.LogFileValidationEnabled !== null
-        ? output.LogFileValidationEnabled
-        : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    S3BucketName: output.S3BucketName !== undefined && output.S3BucketName !== null ? output.S3BucketName : undefined,
-    S3KeyPrefix: output.S3KeyPrefix !== undefined && output.S3KeyPrefix !== null ? output.S3KeyPrefix : undefined,
-    SnsTopicARN: output.SnsTopicARN !== undefined && output.SnsTopicARN !== null ? output.SnsTopicARN : undefined,
-    SnsTopicName: output.SnsTopicName !== undefined && output.SnsTopicName !== null ? output.SnsTopicName : undefined,
-    TrailARN: output.TrailARN !== undefined && output.TrailARN !== null ? output.TrailARN : undefined,
+    CloudWatchLogsLogGroupArn: __expectString(output.CloudWatchLogsLogGroupArn),
+    CloudWatchLogsRoleArn: __expectString(output.CloudWatchLogsRoleArn),
+    IncludeGlobalServiceEvents: __expectBoolean(output.IncludeGlobalServiceEvents),
+    IsMultiRegionTrail: __expectBoolean(output.IsMultiRegionTrail),
+    IsOrganizationTrail: __expectBoolean(output.IsOrganizationTrail),
+    KmsKeyId: __expectString(output.KmsKeyId),
+    LogFileValidationEnabled: __expectBoolean(output.LogFileValidationEnabled),
+    Name: __expectString(output.Name),
+    S3BucketName: __expectString(output.S3BucketName),
+    S3KeyPrefix: __expectString(output.S3KeyPrefix),
+    SnsTopicARN: __expectString(output.SnsTopicARN),
+    SnsTopicName: __expectString(output.SnsTopicName),
+    TrailARN: __expectString(output.TrailARN),
   } as any;
 };
 

--- a/clients/client-cloudwatch-events/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudwatch-events/protocols/Aws_json1_1.ts
@@ -259,7 +259,12 @@ import {
   UpdateConnectionResponse,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -5935,34 +5940,21 @@ const serializeAws_json1_1UpdateConnectionRequest = (input: UpdateConnectionRequ
 
 const deserializeAws_json1_1ApiDestination = (output: any, context: __SerdeContext): ApiDestination => {
   return {
-    ApiDestinationArn:
-      output.ApiDestinationArn !== undefined && output.ApiDestinationArn !== null
-        ? output.ApiDestinationArn
-        : undefined,
-    ApiDestinationState:
-      output.ApiDestinationState !== undefined && output.ApiDestinationState !== null
-        ? output.ApiDestinationState
-        : undefined,
-    ConnectionArn:
-      output.ConnectionArn !== undefined && output.ConnectionArn !== null ? output.ConnectionArn : undefined,
+    ApiDestinationArn: __expectString(output.ApiDestinationArn),
+    ApiDestinationState: __expectString(output.ApiDestinationState),
+    ConnectionArn: __expectString(output.ConnectionArn),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    HttpMethod: output.HttpMethod !== undefined && output.HttpMethod !== null ? output.HttpMethod : undefined,
-    InvocationEndpoint:
-      output.InvocationEndpoint !== undefined && output.InvocationEndpoint !== null
-        ? output.InvocationEndpoint
-        : undefined,
-    InvocationRateLimitPerSecond:
-      output.InvocationRateLimitPerSecond !== undefined && output.InvocationRateLimitPerSecond !== null
-        ? output.InvocationRateLimitPerSecond
-        : undefined,
+    HttpMethod: __expectString(output.HttpMethod),
+    InvocationEndpoint: __expectString(output.InvocationEndpoint),
+    InvocationRateLimitPerSecond: __expectNumber(output.InvocationRateLimitPerSecond),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -5979,19 +5971,17 @@ const deserializeAws_json1_1ApiDestinationResponseList = (output: any, context: 
 
 const deserializeAws_json1_1Archive = (output: any, context: __SerdeContext): Archive => {
   return {
-    ArchiveName: output.ArchiveName !== undefined && output.ArchiveName !== null ? output.ArchiveName : undefined,
+    ArchiveName: __expectString(output.ArchiveName),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    EventCount: output.EventCount !== undefined && output.EventCount !== null ? output.EventCount : undefined,
-    EventSourceArn:
-      output.EventSourceArn !== undefined && output.EventSourceArn !== null ? output.EventSourceArn : undefined,
-    RetentionDays:
-      output.RetentionDays !== undefined && output.RetentionDays !== null ? output.RetentionDays : undefined,
-    SizeBytes: output.SizeBytes !== undefined && output.SizeBytes !== null ? output.SizeBytes : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    StateReason: output.StateReason !== undefined && output.StateReason !== null ? output.StateReason : undefined,
+    EventCount: __expectNumber(output.EventCount),
+    EventSourceArn: __expectString(output.EventSourceArn),
+    RetentionDays: __expectNumber(output.RetentionDays),
+    SizeBytes: __expectNumber(output.SizeBytes),
+    State: __expectString(output.State),
+    StateReason: __expectString(output.StateReason),
   } as any;
 };
 
@@ -6008,8 +5998,7 @@ const deserializeAws_json1_1ArchiveResponseList = (output: any, context: __Serde
 
 const deserializeAws_json1_1AwsVpcConfiguration = (output: any, context: __SerdeContext): AwsVpcConfiguration => {
   return {
-    AssignPublicIp:
-      output.AssignPublicIp !== undefined && output.AssignPublicIp !== null ? output.AssignPublicIp : undefined,
+    AssignPublicIp: __expectString(output.AssignPublicIp),
     SecurityGroups:
       output.SecurityGroups !== undefined && output.SecurityGroups !== null
         ? deserializeAws_json1_1StringList(output.SecurityGroups, context)
@@ -6023,7 +6012,7 @@ const deserializeAws_json1_1AwsVpcConfiguration = (output: any, context: __Serde
 
 const deserializeAws_json1_1BatchArrayProperties = (output: any, context: __SerdeContext): BatchArrayProperties => {
   return {
-    Size: output.Size !== undefined && output.Size !== null ? output.Size : undefined,
+    Size: __expectNumber(output.Size),
   } as any;
 };
 
@@ -6033,9 +6022,8 @@ const deserializeAws_json1_1BatchParameters = (output: any, context: __SerdeCont
       output.ArrayProperties !== undefined && output.ArrayProperties !== null
         ? deserializeAws_json1_1BatchArrayProperties(output.ArrayProperties, context)
         : undefined,
-    JobDefinition:
-      output.JobDefinition !== undefined && output.JobDefinition !== null ? output.JobDefinition : undefined,
-    JobName: output.JobName !== undefined && output.JobName !== null ? output.JobName : undefined,
+    JobDefinition: __expectString(output.JobDefinition),
+    JobName: __expectString(output.JobName),
     RetryStrategy:
       output.RetryStrategy !== undefined && output.RetryStrategy !== null
         ? deserializeAws_json1_1BatchRetryStrategy(output.RetryStrategy, context)
@@ -6045,15 +6033,15 @@ const deserializeAws_json1_1BatchParameters = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_1BatchRetryStrategy = (output: any, context: __SerdeContext): BatchRetryStrategy => {
   return {
-    Attempts: output.Attempts !== undefined && output.Attempts !== null ? output.Attempts : undefined,
+    Attempts: __expectNumber(output.Attempts),
   } as any;
 };
 
 const deserializeAws_json1_1CancelReplayResponse = (output: any, context: __SerdeContext): CancelReplayResponse => {
   return {
-    ReplayArn: output.ReplayArn !== undefined && output.ReplayArn !== null ? output.ReplayArn : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    StateReason: output.StateReason !== undefined && output.StateReason !== null ? output.StateReason : undefined,
+    ReplayArn: __expectString(output.ReplayArn),
+    State: __expectString(output.State),
+    StateReason: __expectString(output.StateReason),
   } as any;
 };
 
@@ -6062,20 +6050,15 @@ const deserializeAws_json1_1ConcurrentModificationException = (
   context: __SerdeContext
 ): ConcurrentModificationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1Connection = (output: any, context: __SerdeContext): Connection => {
   return {
-    AuthorizationType:
-      output.AuthorizationType !== undefined && output.AuthorizationType !== null
-        ? output.AuthorizationType
-        : undefined,
-    ConnectionArn:
-      output.ConnectionArn !== undefined && output.ConnectionArn !== null ? output.ConnectionArn : undefined,
-    ConnectionState:
-      output.ConnectionState !== undefined && output.ConnectionState !== null ? output.ConnectionState : undefined,
+    AuthorizationType: __expectString(output.AuthorizationType),
+    ConnectionArn: __expectString(output.ConnectionArn),
+    ConnectionState: __expectString(output.ConnectionState),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -6088,8 +6071,8 @@ const deserializeAws_json1_1Connection = (output: any, context: __SerdeContext):
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    StateReason: output.StateReason !== undefined && output.StateReason !== null ? output.StateReason : undefined,
+    Name: __expectString(output.Name),
+    StateReason: __expectString(output.StateReason),
   } as any;
 };
 
@@ -6098,7 +6081,7 @@ const deserializeAws_json1_1ConnectionApiKeyAuthResponseParameters = (
   context: __SerdeContext
 ): ConnectionApiKeyAuthResponseParameters => {
   return {
-    ApiKeyName: output.ApiKeyName !== undefined && output.ApiKeyName !== null ? output.ApiKeyName : undefined,
+    ApiKeyName: __expectString(output.ApiKeyName),
   } as any;
 };
 
@@ -6131,7 +6114,7 @@ const deserializeAws_json1_1ConnectionBasicAuthResponseParameters = (
   context: __SerdeContext
 ): ConnectionBasicAuthResponseParameters => {
   return {
-    Username: output.Username !== undefined && output.Username !== null ? output.Username : undefined,
+    Username: __expectString(output.Username),
   } as any;
 };
 
@@ -6140,10 +6123,9 @@ const deserializeAws_json1_1ConnectionBodyParameter = (
   context: __SerdeContext
 ): ConnectionBodyParameter => {
   return {
-    IsValueSecret:
-      output.IsValueSecret !== undefined && output.IsValueSecret !== null ? output.IsValueSecret : undefined,
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    IsValueSecret: __expectBoolean(output.IsValueSecret),
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -6166,10 +6148,9 @@ const deserializeAws_json1_1ConnectionHeaderParameter = (
   context: __SerdeContext
 ): ConnectionHeaderParameter => {
   return {
-    IsValueSecret:
-      output.IsValueSecret !== undefined && output.IsValueSecret !== null ? output.IsValueSecret : undefined,
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    IsValueSecret: __expectBoolean(output.IsValueSecret),
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -6212,7 +6193,7 @@ const deserializeAws_json1_1ConnectionOAuthClientResponseParameters = (
   context: __SerdeContext
 ): ConnectionOAuthClientResponseParameters => {
   return {
-    ClientID: output.ClientID !== undefined && output.ClientID !== null ? output.ClientID : undefined,
+    ClientID: __expectString(output.ClientID),
   } as any;
 };
 
@@ -6221,15 +6202,12 @@ const deserializeAws_json1_1ConnectionOAuthResponseParameters = (
   context: __SerdeContext
 ): ConnectionOAuthResponseParameters => {
   return {
-    AuthorizationEndpoint:
-      output.AuthorizationEndpoint !== undefined && output.AuthorizationEndpoint !== null
-        ? output.AuthorizationEndpoint
-        : undefined,
+    AuthorizationEndpoint: __expectString(output.AuthorizationEndpoint),
     ClientParameters:
       output.ClientParameters !== undefined && output.ClientParameters !== null
         ? deserializeAws_json1_1ConnectionOAuthClientResponseParameters(output.ClientParameters, context)
         : undefined,
-    HttpMethod: output.HttpMethod !== undefined && output.HttpMethod !== null ? output.HttpMethod : undefined,
+    HttpMethod: __expectString(output.HttpMethod),
     OAuthHttpParameters:
       output.OAuthHttpParameters !== undefined && output.OAuthHttpParameters !== null
         ? deserializeAws_json1_1ConnectionHttpParameters(output.OAuthHttpParameters, context)
@@ -6242,10 +6220,9 @@ const deserializeAws_json1_1ConnectionQueryStringParameter = (
   context: __SerdeContext
 ): ConnectionQueryStringParameter => {
   return {
-    IsValueSecret:
-      output.IsValueSecret !== undefined && output.IsValueSecret !== null ? output.IsValueSecret : undefined,
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    IsValueSecret: __expectBoolean(output.IsValueSecret),
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -6279,14 +6256,8 @@ const deserializeAws_json1_1CreateApiDestinationResponse = (
   context: __SerdeContext
 ): CreateApiDestinationResponse => {
   return {
-    ApiDestinationArn:
-      output.ApiDestinationArn !== undefined && output.ApiDestinationArn !== null
-        ? output.ApiDestinationArn
-        : undefined,
-    ApiDestinationState:
-      output.ApiDestinationState !== undefined && output.ApiDestinationState !== null
-        ? output.ApiDestinationState
-        : undefined,
+    ApiDestinationArn: __expectString(output.ApiDestinationArn),
+    ApiDestinationState: __expectString(output.ApiDestinationState),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -6300,13 +6271,13 @@ const deserializeAws_json1_1CreateApiDestinationResponse = (
 
 const deserializeAws_json1_1CreateArchiveResponse = (output: any, context: __SerdeContext): CreateArchiveResponse => {
   return {
-    ArchiveArn: output.ArchiveArn !== undefined && output.ArchiveArn !== null ? output.ArchiveArn : undefined,
+    ArchiveArn: __expectString(output.ArchiveArn),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    StateReason: output.StateReason !== undefined && output.StateReason !== null ? output.StateReason : undefined,
+    State: __expectString(output.State),
+    StateReason: __expectString(output.StateReason),
   } as any;
 };
 
@@ -6315,10 +6286,8 @@ const deserializeAws_json1_1CreateConnectionResponse = (
   context: __SerdeContext
 ): CreateConnectionResponse => {
   return {
-    ConnectionArn:
-      output.ConnectionArn !== undefined && output.ConnectionArn !== null ? output.ConnectionArn : undefined,
-    ConnectionState:
-      output.ConnectionState !== undefined && output.ConnectionState !== null ? output.ConnectionState : undefined,
+    ConnectionArn: __expectString(output.ConnectionArn),
+    ConnectionState: __expectString(output.ConnectionState),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -6332,7 +6301,7 @@ const deserializeAws_json1_1CreateConnectionResponse = (
 
 const deserializeAws_json1_1CreateEventBusResponse = (output: any, context: __SerdeContext): CreateEventBusResponse => {
   return {
-    EventBusArn: output.EventBusArn !== undefined && output.EventBusArn !== null ? output.EventBusArn : undefined,
+    EventBusArn: __expectString(output.EventBusArn),
   } as any;
 };
 
@@ -6341,14 +6310,13 @@ const deserializeAws_json1_1CreatePartnerEventSourceResponse = (
   context: __SerdeContext
 ): CreatePartnerEventSourceResponse => {
   return {
-    EventSourceArn:
-      output.EventSourceArn !== undefined && output.EventSourceArn !== null ? output.EventSourceArn : undefined,
+    EventSourceArn: __expectString(output.EventSourceArn),
   } as any;
 };
 
 const deserializeAws_json1_1DeadLetterConfig = (output: any, context: __SerdeContext): DeadLetterConfig => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
   } as any;
 };
 
@@ -6357,10 +6325,8 @@ const deserializeAws_json1_1DeauthorizeConnectionResponse = (
   context: __SerdeContext
 ): DeauthorizeConnectionResponse => {
   return {
-    ConnectionArn:
-      output.ConnectionArn !== undefined && output.ConnectionArn !== null ? output.ConnectionArn : undefined,
-    ConnectionState:
-      output.ConnectionState !== undefined && output.ConnectionState !== null ? output.ConnectionState : undefined,
+    ConnectionArn: __expectString(output.ConnectionArn),
+    ConnectionState: __expectString(output.ConnectionState),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -6392,10 +6358,8 @@ const deserializeAws_json1_1DeleteConnectionResponse = (
   context: __SerdeContext
 ): DeleteConnectionResponse => {
   return {
-    ConnectionArn:
-      output.ConnectionArn !== undefined && output.ConnectionArn !== null ? output.ConnectionArn : undefined,
-    ConnectionState:
-      output.ConnectionState !== undefined && output.ConnectionState !== null ? output.ConnectionState : undefined,
+    ConnectionArn: __expectString(output.ConnectionArn),
+    ConnectionState: __expectString(output.ConnectionState),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -6416,35 +6380,22 @@ const deserializeAws_json1_1DescribeApiDestinationResponse = (
   context: __SerdeContext
 ): DescribeApiDestinationResponse => {
   return {
-    ApiDestinationArn:
-      output.ApiDestinationArn !== undefined && output.ApiDestinationArn !== null
-        ? output.ApiDestinationArn
-        : undefined,
-    ApiDestinationState:
-      output.ApiDestinationState !== undefined && output.ApiDestinationState !== null
-        ? output.ApiDestinationState
-        : undefined,
-    ConnectionArn:
-      output.ConnectionArn !== undefined && output.ConnectionArn !== null ? output.ConnectionArn : undefined,
+    ApiDestinationArn: __expectString(output.ApiDestinationArn),
+    ApiDestinationState: __expectString(output.ApiDestinationState),
+    ConnectionArn: __expectString(output.ConnectionArn),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    HttpMethod: output.HttpMethod !== undefined && output.HttpMethod !== null ? output.HttpMethod : undefined,
-    InvocationEndpoint:
-      output.InvocationEndpoint !== undefined && output.InvocationEndpoint !== null
-        ? output.InvocationEndpoint
-        : undefined,
-    InvocationRateLimitPerSecond:
-      output.InvocationRateLimitPerSecond !== undefined && output.InvocationRateLimitPerSecond !== null
-        ? output.InvocationRateLimitPerSecond
-        : undefined,
+    Description: __expectString(output.Description),
+    HttpMethod: __expectString(output.HttpMethod),
+    InvocationEndpoint: __expectString(output.InvocationEndpoint),
+    InvocationRateLimitPerSecond: __expectNumber(output.InvocationRateLimitPerSecond),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -6453,22 +6404,20 @@ const deserializeAws_json1_1DescribeArchiveResponse = (
   context: __SerdeContext
 ): DescribeArchiveResponse => {
   return {
-    ArchiveArn: output.ArchiveArn !== undefined && output.ArchiveArn !== null ? output.ArchiveArn : undefined,
-    ArchiveName: output.ArchiveName !== undefined && output.ArchiveName !== null ? output.ArchiveName : undefined,
+    ArchiveArn: __expectString(output.ArchiveArn),
+    ArchiveName: __expectString(output.ArchiveName),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    EventCount: output.EventCount !== undefined && output.EventCount !== null ? output.EventCount : undefined,
-    EventPattern: output.EventPattern !== undefined && output.EventPattern !== null ? output.EventPattern : undefined,
-    EventSourceArn:
-      output.EventSourceArn !== undefined && output.EventSourceArn !== null ? output.EventSourceArn : undefined,
-    RetentionDays:
-      output.RetentionDays !== undefined && output.RetentionDays !== null ? output.RetentionDays : undefined,
-    SizeBytes: output.SizeBytes !== undefined && output.SizeBytes !== null ? output.SizeBytes : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    StateReason: output.StateReason !== undefined && output.StateReason !== null ? output.StateReason : undefined,
+    Description: __expectString(output.Description),
+    EventCount: __expectNumber(output.EventCount),
+    EventPattern: __expectString(output.EventPattern),
+    EventSourceArn: __expectString(output.EventSourceArn),
+    RetentionDays: __expectNumber(output.RetentionDays),
+    SizeBytes: __expectNumber(output.SizeBytes),
+    State: __expectString(output.State),
+    StateReason: __expectString(output.StateReason),
   } as any;
 };
 
@@ -6481,19 +6430,14 @@ const deserializeAws_json1_1DescribeConnectionResponse = (
       output.AuthParameters !== undefined && output.AuthParameters !== null
         ? deserializeAws_json1_1ConnectionAuthResponseParameters(output.AuthParameters, context)
         : undefined,
-    AuthorizationType:
-      output.AuthorizationType !== undefined && output.AuthorizationType !== null
-        ? output.AuthorizationType
-        : undefined,
-    ConnectionArn:
-      output.ConnectionArn !== undefined && output.ConnectionArn !== null ? output.ConnectionArn : undefined,
-    ConnectionState:
-      output.ConnectionState !== undefined && output.ConnectionState !== null ? output.ConnectionState : undefined,
+    AuthorizationType: __expectString(output.AuthorizationType),
+    ConnectionArn: __expectString(output.ConnectionArn),
+    ConnectionState: __expectString(output.ConnectionState),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     LastAuthorizedTime:
       output.LastAuthorizedTime !== undefined && output.LastAuthorizedTime !== null
         ? new Date(Math.round(output.LastAuthorizedTime * 1000))
@@ -6502,9 +6446,9 @@ const deserializeAws_json1_1DescribeConnectionResponse = (
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    SecretArn: output.SecretArn !== undefined && output.SecretArn !== null ? output.SecretArn : undefined,
-    StateReason: output.StateReason !== undefined && output.StateReason !== null ? output.StateReason : undefined,
+    Name: __expectString(output.Name),
+    SecretArn: __expectString(output.SecretArn),
+    StateReason: __expectString(output.StateReason),
   } as any;
 };
 
@@ -6513,9 +6457,9 @@ const deserializeAws_json1_1DescribeEventBusResponse = (
   context: __SerdeContext
 ): DescribeEventBusResponse => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Policy: output.Policy !== undefined && output.Policy !== null ? output.Policy : undefined,
+    Arn: __expectString(output.Arn),
+    Name: __expectString(output.Name),
+    Policy: __expectString(output.Policy),
   } as any;
 };
 
@@ -6524,8 +6468,8 @@ const deserializeAws_json1_1DescribeEventSourceResponse = (
   context: __SerdeContext
 ): DescribeEventSourceResponse => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    CreatedBy: output.CreatedBy !== undefined && output.CreatedBy !== null ? output.CreatedBy : undefined,
+    Arn: __expectString(output.Arn),
+    CreatedBy: __expectString(output.CreatedBy),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -6534,8 +6478,8 @@ const deserializeAws_json1_1DescribeEventSourceResponse = (
       output.ExpirationTime !== undefined && output.ExpirationTime !== null
         ? new Date(Math.round(output.ExpirationTime * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    Name: __expectString(output.Name),
+    State: __expectString(output.State),
   } as any;
 };
 
@@ -6544,14 +6488,14 @@ const deserializeAws_json1_1DescribePartnerEventSourceResponse = (
   context: __SerdeContext
 ): DescribePartnerEventSourceResponse => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Arn: __expectString(output.Arn),
+    Name: __expectString(output.Name),
   } as any;
 };
 
 const deserializeAws_json1_1DescribeReplayResponse = (output: any, context: __SerdeContext): DescribeReplayResponse => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     Destination:
       output.Destination !== undefined && output.Destination !== null
         ? deserializeAws_json1_1ReplayDestination(output.Destination, context)
@@ -6564,68 +6508,60 @@ const deserializeAws_json1_1DescribeReplayResponse = (output: any, context: __Se
       output.EventLastReplayedTime !== undefined && output.EventLastReplayedTime !== null
         ? new Date(Math.round(output.EventLastReplayedTime * 1000))
         : undefined,
-    EventSourceArn:
-      output.EventSourceArn !== undefined && output.EventSourceArn !== null ? output.EventSourceArn : undefined,
+    EventSourceArn: __expectString(output.EventSourceArn),
     EventStartTime:
       output.EventStartTime !== undefined && output.EventStartTime !== null
         ? new Date(Math.round(output.EventStartTime * 1000))
         : undefined,
-    ReplayArn: output.ReplayArn !== undefined && output.ReplayArn !== null ? output.ReplayArn : undefined,
+    ReplayArn: __expectString(output.ReplayArn),
     ReplayEndTime:
       output.ReplayEndTime !== undefined && output.ReplayEndTime !== null
         ? new Date(Math.round(output.ReplayEndTime * 1000))
         : undefined,
-    ReplayName: output.ReplayName !== undefined && output.ReplayName !== null ? output.ReplayName : undefined,
+    ReplayName: __expectString(output.ReplayName),
     ReplayStartTime:
       output.ReplayStartTime !== undefined && output.ReplayStartTime !== null
         ? new Date(Math.round(output.ReplayStartTime * 1000))
         : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    StateReason: output.StateReason !== undefined && output.StateReason !== null ? output.StateReason : undefined,
+    State: __expectString(output.State),
+    StateReason: __expectString(output.StateReason),
   } as any;
 };
 
 const deserializeAws_json1_1DescribeRuleResponse = (output: any, context: __SerdeContext): DescribeRuleResponse => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    CreatedBy: output.CreatedBy !== undefined && output.CreatedBy !== null ? output.CreatedBy : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    EventBusName: output.EventBusName !== undefined && output.EventBusName !== null ? output.EventBusName : undefined,
-    EventPattern: output.EventPattern !== undefined && output.EventPattern !== null ? output.EventPattern : undefined,
-    ManagedBy: output.ManagedBy !== undefined && output.ManagedBy !== null ? output.ManagedBy : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
-    ScheduleExpression:
-      output.ScheduleExpression !== undefined && output.ScheduleExpression !== null
-        ? output.ScheduleExpression
-        : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    Arn: __expectString(output.Arn),
+    CreatedBy: __expectString(output.CreatedBy),
+    Description: __expectString(output.Description),
+    EventBusName: __expectString(output.EventBusName),
+    EventPattern: __expectString(output.EventPattern),
+    ManagedBy: __expectString(output.ManagedBy),
+    Name: __expectString(output.Name),
+    RoleArn: __expectString(output.RoleArn),
+    ScheduleExpression: __expectString(output.ScheduleExpression),
+    State: __expectString(output.State),
   } as any;
 };
 
 const deserializeAws_json1_1EcsParameters = (output: any, context: __SerdeContext): EcsParameters => {
   return {
-    Group: output.Group !== undefined && output.Group !== null ? output.Group : undefined,
-    LaunchType: output.LaunchType !== undefined && output.LaunchType !== null ? output.LaunchType : undefined,
+    Group: __expectString(output.Group),
+    LaunchType: __expectString(output.LaunchType),
     NetworkConfiguration:
       output.NetworkConfiguration !== undefined && output.NetworkConfiguration !== null
         ? deserializeAws_json1_1NetworkConfiguration(output.NetworkConfiguration, context)
         : undefined,
-    PlatformVersion:
-      output.PlatformVersion !== undefined && output.PlatformVersion !== null ? output.PlatformVersion : undefined,
-    TaskCount: output.TaskCount !== undefined && output.TaskCount !== null ? output.TaskCount : undefined,
-    TaskDefinitionArn:
-      output.TaskDefinitionArn !== undefined && output.TaskDefinitionArn !== null
-        ? output.TaskDefinitionArn
-        : undefined,
+    PlatformVersion: __expectString(output.PlatformVersion),
+    TaskCount: __expectNumber(output.TaskCount),
+    TaskDefinitionArn: __expectString(output.TaskDefinitionArn),
   } as any;
 };
 
 const deserializeAws_json1_1EventBus = (output: any, context: __SerdeContext): EventBus => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Policy: output.Policy !== undefined && output.Policy !== null ? output.Policy : undefined,
+    Arn: __expectString(output.Arn),
+    Name: __expectString(output.Name),
+    Policy: __expectString(output.Policy),
   } as any;
 };
 
@@ -6642,8 +6578,8 @@ const deserializeAws_json1_1EventBusList = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_1EventSource = (output: any, context: __SerdeContext): EventSource => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    CreatedBy: output.CreatedBy !== undefined && output.CreatedBy !== null ? output.CreatedBy : undefined,
+    Arn: __expectString(output.Arn),
+    CreatedBy: __expectString(output.CreatedBy),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -6652,8 +6588,8 @@ const deserializeAws_json1_1EventSource = (output: any, context: __SerdeContext)
       output.ExpirationTime !== undefined && output.ExpirationTime !== null
         ? new Date(Math.round(output.ExpirationTime * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    Name: __expectString(output.Name),
+    State: __expectString(output.State),
   } as any;
 };
 
@@ -6675,7 +6611,7 @@ const deserializeAws_json1_1HeaderParametersMap = (output: any, context: __Serde
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -6699,7 +6635,7 @@ const deserializeAws_json1_1HttpParameters = (output: any, context: __SerdeConte
 
 const deserializeAws_json1_1IllegalStatusException = (output: any, context: __SerdeContext): IllegalStatusException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6709,14 +6645,13 @@ const deserializeAws_json1_1InputTransformer = (output: any, context: __SerdeCon
       output.InputPathsMap !== undefined && output.InputPathsMap !== null
         ? deserializeAws_json1_1TransformerPaths(output.InputPathsMap, context)
         : undefined,
-    InputTemplate:
-      output.InputTemplate !== undefined && output.InputTemplate !== null ? output.InputTemplate : undefined,
+    InputTemplate: __expectString(output.InputTemplate),
   } as any;
 };
 
 const deserializeAws_json1_1InternalException = (output: any, context: __SerdeContext): InternalException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6725,26 +6660,25 @@ const deserializeAws_json1_1InvalidEventPatternException = (
   context: __SerdeContext
 ): InvalidEventPatternException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidStateException = (output: any, context: __SerdeContext): InvalidStateException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1KinesisParameters = (output: any, context: __SerdeContext): KinesisParameters => {
   return {
-    PartitionKeyPath:
-      output.PartitionKeyPath !== undefined && output.PartitionKeyPath !== null ? output.PartitionKeyPath : undefined,
+    PartitionKeyPath: __expectString(output.PartitionKeyPath),
   } as any;
 };
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6757,7 +6691,7 @@ const deserializeAws_json1_1ListApiDestinationsResponse = (
       output.ApiDestinations !== undefined && output.ApiDestinations !== null
         ? deserializeAws_json1_1ApiDestinationResponseList(output.ApiDestinations, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -6767,7 +6701,7 @@ const deserializeAws_json1_1ListArchivesResponse = (output: any, context: __Serd
       output.Archives !== undefined && output.Archives !== null
         ? deserializeAws_json1_1ArchiveResponseList(output.Archives, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -6780,7 +6714,7 @@ const deserializeAws_json1_1ListConnectionsResponse = (
       output.Connections !== undefined && output.Connections !== null
         ? deserializeAws_json1_1ConnectionResponseList(output.Connections, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -6790,7 +6724,7 @@ const deserializeAws_json1_1ListEventBusesResponse = (output: any, context: __Se
       output.EventBuses !== undefined && output.EventBuses !== null
         ? deserializeAws_json1_1EventBusList(output.EventBuses, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -6803,7 +6737,7 @@ const deserializeAws_json1_1ListEventSourcesResponse = (
       output.EventSources !== undefined && output.EventSources !== null
         ? deserializeAws_json1_1EventSourceList(output.EventSources, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -6812,7 +6746,7 @@ const deserializeAws_json1_1ListPartnerEventSourceAccountsResponse = (
   context: __SerdeContext
 ): ListPartnerEventSourceAccountsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     PartnerEventSourceAccounts:
       output.PartnerEventSourceAccounts !== undefined && output.PartnerEventSourceAccounts !== null
         ? deserializeAws_json1_1PartnerEventSourceAccountList(output.PartnerEventSourceAccounts, context)
@@ -6825,7 +6759,7 @@ const deserializeAws_json1_1ListPartnerEventSourcesResponse = (
   context: __SerdeContext
 ): ListPartnerEventSourcesResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     PartnerEventSources:
       output.PartnerEventSources !== undefined && output.PartnerEventSources !== null
         ? deserializeAws_json1_1PartnerEventSourceList(output.PartnerEventSources, context)
@@ -6835,7 +6769,7 @@ const deserializeAws_json1_1ListPartnerEventSourcesResponse = (
 
 const deserializeAws_json1_1ListReplaysResponse = (output: any, context: __SerdeContext): ListReplaysResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Replays:
       output.Replays !== undefined && output.Replays !== null
         ? deserializeAws_json1_1ReplayList(output.Replays, context)
@@ -6848,7 +6782,7 @@ const deserializeAws_json1_1ListRuleNamesByTargetResponse = (
   context: __SerdeContext
 ): ListRuleNamesByTargetResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     RuleNames:
       output.RuleNames !== undefined && output.RuleNames !== null
         ? deserializeAws_json1_1RuleNameList(output.RuleNames, context)
@@ -6858,7 +6792,7 @@ const deserializeAws_json1_1ListRuleNamesByTargetResponse = (
 
 const deserializeAws_json1_1ListRulesResponse = (output: any, context: __SerdeContext): ListRulesResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Rules:
       output.Rules !== undefined && output.Rules !== null
         ? deserializeAws_json1_1RuleResponseList(output.Rules, context)
@@ -6883,7 +6817,7 @@ const deserializeAws_json1_1ListTargetsByRuleResponse = (
   context: __SerdeContext
 ): ListTargetsByRuleResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Targets:
       output.Targets !== undefined && output.Targets !== null
         ? deserializeAws_json1_1TargetList(output.Targets, context)
@@ -6893,7 +6827,7 @@ const deserializeAws_json1_1ListTargetsByRuleResponse = (
 
 const deserializeAws_json1_1ManagedRuleException = (output: any, context: __SerdeContext): ManagedRuleException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6911,14 +6845,14 @@ const deserializeAws_json1_1OperationDisabledException = (
   context: __SerdeContext
 ): OperationDisabledException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1PartnerEventSource = (output: any, context: __SerdeContext): PartnerEventSource => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Arn: __expectString(output.Arn),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -6927,7 +6861,7 @@ const deserializeAws_json1_1PartnerEventSourceAccount = (
   context: __SerdeContext
 ): PartnerEventSourceAccount => {
   return {
-    Account: output.Account !== undefined && output.Account !== null ? output.Account : undefined,
+    Account: __expectString(output.Account),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -6936,7 +6870,7 @@ const deserializeAws_json1_1PartnerEventSourceAccount = (
       output.ExpirationTime !== undefined && output.ExpirationTime !== null
         ? new Date(Math.round(output.ExpirationTime * 1000))
         : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    State: __expectString(output.State),
   } as any;
 };
 
@@ -6972,7 +6906,7 @@ const deserializeAws_json1_1PathParameterList = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6981,7 +6915,7 @@ const deserializeAws_json1_1PolicyLengthExceededException = (
   context: __SerdeContext
 ): PolicyLengthExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6991,16 +6925,15 @@ const deserializeAws_json1_1PutEventsResponse = (output: any, context: __SerdeCo
       output.Entries !== undefined && output.Entries !== null
         ? deserializeAws_json1_1PutEventsResultEntryList(output.Entries, context)
         : undefined,
-    FailedEntryCount:
-      output.FailedEntryCount !== undefined && output.FailedEntryCount !== null ? output.FailedEntryCount : undefined,
+    FailedEntryCount: __expectNumber(output.FailedEntryCount),
   } as any;
 };
 
 const deserializeAws_json1_1PutEventsResultEntry = (output: any, context: __SerdeContext): PutEventsResultEntry => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    EventId: output.EventId !== undefined && output.EventId !== null ? output.EventId : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
+    EventId: __expectString(output.EventId),
   } as any;
 };
 
@@ -7027,8 +6960,7 @@ const deserializeAws_json1_1PutPartnerEventsResponse = (
       output.Entries !== undefined && output.Entries !== null
         ? deserializeAws_json1_1PutPartnerEventsResultEntryList(output.Entries, context)
         : undefined,
-    FailedEntryCount:
-      output.FailedEntryCount !== undefined && output.FailedEntryCount !== null ? output.FailedEntryCount : undefined,
+    FailedEntryCount: __expectNumber(output.FailedEntryCount),
   } as any;
 };
 
@@ -7037,9 +6969,9 @@ const deserializeAws_json1_1PutPartnerEventsResultEntry = (
   context: __SerdeContext
 ): PutPartnerEventsResultEntry => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    EventId: output.EventId !== undefined && output.EventId !== null ? output.EventId : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
+    EventId: __expectString(output.EventId),
   } as any;
 };
 
@@ -7059,7 +6991,7 @@ const deserializeAws_json1_1PutPartnerEventsResultEntryList = (
 
 const deserializeAws_json1_1PutRuleResponse = (output: any, context: __SerdeContext): PutRuleResponse => {
   return {
-    RuleArn: output.RuleArn !== undefined && output.RuleArn !== null ? output.RuleArn : undefined,
+    RuleArn: __expectString(output.RuleArn),
   } as any;
 };
 
@@ -7069,16 +7001,15 @@ const deserializeAws_json1_1PutTargetsResponse = (output: any, context: __SerdeC
       output.FailedEntries !== undefined && output.FailedEntries !== null
         ? deserializeAws_json1_1PutTargetsResultEntryList(output.FailedEntries, context)
         : undefined,
-    FailedEntryCount:
-      output.FailedEntryCount !== undefined && output.FailedEntryCount !== null ? output.FailedEntryCount : undefined,
+    FailedEntryCount: __expectNumber(output.FailedEntryCount),
   } as any;
 };
 
 const deserializeAws_json1_1PutTargetsResultEntry = (output: any, context: __SerdeContext): PutTargetsResultEntry => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    TargetId: output.TargetId !== undefined && output.TargetId !== null ? output.TargetId : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
+    TargetId: __expectString(output.TargetId),
   } as any;
 };
 
@@ -7106,21 +7037,19 @@ const deserializeAws_json1_1QueryStringParametersMap = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_json1_1RedshiftDataParameters = (output: any, context: __SerdeContext): RedshiftDataParameters => {
   return {
-    Database: output.Database !== undefined && output.Database !== null ? output.Database : undefined,
-    DbUser: output.DbUser !== undefined && output.DbUser !== null ? output.DbUser : undefined,
-    SecretManagerArn:
-      output.SecretManagerArn !== undefined && output.SecretManagerArn !== null ? output.SecretManagerArn : undefined,
-    Sql: output.Sql !== undefined && output.Sql !== null ? output.Sql : undefined,
-    StatementName:
-      output.StatementName !== undefined && output.StatementName !== null ? output.StatementName : undefined,
-    WithEvent: output.WithEvent !== undefined && output.WithEvent !== null ? output.WithEvent : undefined,
+    Database: __expectString(output.Database),
+    DbUser: __expectString(output.DbUser),
+    SecretManagerArn: __expectString(output.SecretManagerArn),
+    Sql: __expectString(output.Sql),
+    StatementName: __expectString(output.StatementName),
+    WithEvent: __expectBoolean(output.WithEvent),
   } as any;
 };
 
@@ -7130,8 +7059,7 @@ const deserializeAws_json1_1RemoveTargetsResponse = (output: any, context: __Ser
       output.FailedEntries !== undefined && output.FailedEntries !== null
         ? deserializeAws_json1_1RemoveTargetsResultEntryList(output.FailedEntries, context)
         : undefined,
-    FailedEntryCount:
-      output.FailedEntryCount !== undefined && output.FailedEntryCount !== null ? output.FailedEntryCount : undefined,
+    FailedEntryCount: __expectNumber(output.FailedEntryCount),
   } as any;
 };
 
@@ -7140,9 +7068,9 @@ const deserializeAws_json1_1RemoveTargetsResultEntry = (
   context: __SerdeContext
 ): RemoveTargetsResultEntry => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    TargetId: output.TargetId !== undefined && output.TargetId !== null ? output.TargetId : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
+    TargetId: __expectString(output.TargetId),
   } as any;
 };
 
@@ -7170,8 +7098,7 @@ const deserializeAws_json1_1Replay = (output: any, context: __SerdeContext): Rep
       output.EventLastReplayedTime !== undefined && output.EventLastReplayedTime !== null
         ? new Date(Math.round(output.EventLastReplayedTime * 1000))
         : undefined,
-    EventSourceArn:
-      output.EventSourceArn !== undefined && output.EventSourceArn !== null ? output.EventSourceArn : undefined,
+    EventSourceArn: __expectString(output.EventSourceArn),
     EventStartTime:
       output.EventStartTime !== undefined && output.EventStartTime !== null
         ? new Date(Math.round(output.EventStartTime * 1000))
@@ -7180,19 +7107,19 @@ const deserializeAws_json1_1Replay = (output: any, context: __SerdeContext): Rep
       output.ReplayEndTime !== undefined && output.ReplayEndTime !== null
         ? new Date(Math.round(output.ReplayEndTime * 1000))
         : undefined,
-    ReplayName: output.ReplayName !== undefined && output.ReplayName !== null ? output.ReplayName : undefined,
+    ReplayName: __expectString(output.ReplayName),
     ReplayStartTime:
       output.ReplayStartTime !== undefined && output.ReplayStartTime !== null
         ? new Date(Math.round(output.ReplayStartTime * 1000))
         : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    StateReason: output.StateReason !== undefined && output.StateReason !== null ? output.StateReason : undefined,
+    State: __expectString(output.State),
+    StateReason: __expectString(output.StateReason),
   } as any;
 };
 
 const deserializeAws_json1_1ReplayDestination = (output: any, context: __SerdeContext): ReplayDestination => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     FilterArns:
       output.FilterArns !== undefined && output.FilterArns !== null
         ? deserializeAws_json1_1ReplayDestinationFilters(output.FilterArns, context)
@@ -7207,7 +7134,7 @@ const deserializeAws_json1_1ReplayDestinationFilters = (output: any, context: __
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7227,7 +7154,7 @@ const deserializeAws_json1_1ResourceAlreadyExistsException = (
   context: __SerdeContext
 ): ResourceAlreadyExistsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -7236,37 +7163,28 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1RetryPolicy = (output: any, context: __SerdeContext): RetryPolicy => {
   return {
-    MaximumEventAgeInSeconds:
-      output.MaximumEventAgeInSeconds !== undefined && output.MaximumEventAgeInSeconds !== null
-        ? output.MaximumEventAgeInSeconds
-        : undefined,
-    MaximumRetryAttempts:
-      output.MaximumRetryAttempts !== undefined && output.MaximumRetryAttempts !== null
-        ? output.MaximumRetryAttempts
-        : undefined,
+    MaximumEventAgeInSeconds: __expectNumber(output.MaximumEventAgeInSeconds),
+    MaximumRetryAttempts: __expectNumber(output.MaximumRetryAttempts),
   } as any;
 };
 
 const deserializeAws_json1_1Rule = (output: any, context: __SerdeContext): Rule => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    EventBusName: output.EventBusName !== undefined && output.EventBusName !== null ? output.EventBusName : undefined,
-    EventPattern: output.EventPattern !== undefined && output.EventPattern !== null ? output.EventPattern : undefined,
-    ManagedBy: output.ManagedBy !== undefined && output.ManagedBy !== null ? output.ManagedBy : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
-    ScheduleExpression:
-      output.ScheduleExpression !== undefined && output.ScheduleExpression !== null
-        ? output.ScheduleExpression
-        : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    Arn: __expectString(output.Arn),
+    Description: __expectString(output.Description),
+    EventBusName: __expectString(output.EventBusName),
+    EventPattern: __expectString(output.EventPattern),
+    ManagedBy: __expectString(output.ManagedBy),
+    Name: __expectString(output.Name),
+    RoleArn: __expectString(output.RoleArn),
+    ScheduleExpression: __expectString(output.ScheduleExpression),
+    State: __expectString(output.State),
   } as any;
 };
 
@@ -7277,7 +7195,7 @@ const deserializeAws_json1_1RuleNameList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7303,7 +7221,7 @@ const deserializeAws_json1_1RunCommandParameters = (output: any, context: __Serd
 
 const deserializeAws_json1_1RunCommandTarget = (output: any, context: __SerdeContext): RunCommandTarget => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
+    Key: __expectString(output.Key),
     Values:
       output.Values !== undefined && output.Values !== null
         ? deserializeAws_json1_1RunCommandTargetValues(output.Values, context)
@@ -7329,7 +7247,7 @@ const deserializeAws_json1_1RunCommandTargetValues = (output: any, context: __Se
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7338,8 +7256,8 @@ const deserializeAws_json1_1SageMakerPipelineParameter = (
   context: __SerdeContext
 ): SageMakerPipelineParameter => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Name: __expectString(output.Name),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -7371,20 +7289,19 @@ const deserializeAws_json1_1SageMakerPipelineParameters = (
 
 const deserializeAws_json1_1SqsParameters = (output: any, context: __SerdeContext): SqsParameters => {
   return {
-    MessageGroupId:
-      output.MessageGroupId !== undefined && output.MessageGroupId !== null ? output.MessageGroupId : undefined,
+    MessageGroupId: __expectString(output.MessageGroupId),
   } as any;
 };
 
 const deserializeAws_json1_1StartReplayResponse = (output: any, context: __SerdeContext): StartReplayResponse => {
   return {
-    ReplayArn: output.ReplayArn !== undefined && output.ReplayArn !== null ? output.ReplayArn : undefined,
+    ReplayArn: __expectString(output.ReplayArn),
     ReplayStartTime:
       output.ReplayStartTime !== undefined && output.ReplayStartTime !== null
         ? new Date(Math.round(output.ReplayStartTime * 1000))
         : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    StateReason: output.StateReason !== undefined && output.StateReason !== null ? output.StateReason : undefined,
+    State: __expectString(output.State),
+    StateReason: __expectString(output.StateReason),
   } as any;
 };
 
@@ -7395,14 +7312,14 @@ const deserializeAws_json1_1StringList = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -7423,7 +7340,7 @@ const deserializeAws_json1_1TagResourceResponse = (output: any, context: __Serde
 
 const deserializeAws_json1_1Target = (output: any, context: __SerdeContext): Target => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     BatchParameters:
       output.BatchParameters !== undefined && output.BatchParameters !== null
         ? deserializeAws_json1_1BatchParameters(output.BatchParameters, context)
@@ -7440,9 +7357,9 @@ const deserializeAws_json1_1Target = (output: any, context: __SerdeContext): Tar
       output.HttpParameters !== undefined && output.HttpParameters !== null
         ? deserializeAws_json1_1HttpParameters(output.HttpParameters, context)
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Input: output.Input !== undefined && output.Input !== null ? output.Input : undefined,
-    InputPath: output.InputPath !== undefined && output.InputPath !== null ? output.InputPath : undefined,
+    Id: __expectString(output.Id),
+    Input: __expectString(output.Input),
+    InputPath: __expectString(output.InputPath),
     InputTransformer:
       output.InputTransformer !== undefined && output.InputTransformer !== null
         ? deserializeAws_json1_1InputTransformer(output.InputTransformer, context)
@@ -7459,7 +7376,7 @@ const deserializeAws_json1_1Target = (output: any, context: __SerdeContext): Tar
       output.RetryPolicy !== undefined && output.RetryPolicy !== null
         ? deserializeAws_json1_1RetryPolicy(output.RetryPolicy, context)
         : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
+    RoleArn: __expectString(output.RoleArn),
     RunCommandParameters:
       output.RunCommandParameters !== undefined && output.RunCommandParameters !== null
         ? deserializeAws_json1_1RunCommandParameters(output.RunCommandParameters, context)
@@ -7491,7 +7408,7 @@ const deserializeAws_json1_1TestEventPatternResponse = (
   context: __SerdeContext
 ): TestEventPatternResponse => {
   return {
-    Result: output.Result !== undefined && output.Result !== null ? output.Result : undefined,
+    Result: __expectBoolean(output.Result),
   } as any;
 };
 
@@ -7502,7 +7419,7 @@ const deserializeAws_json1_1TransformerPaths = (output: any, context: __SerdeCon
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -7516,14 +7433,8 @@ const deserializeAws_json1_1UpdateApiDestinationResponse = (
   context: __SerdeContext
 ): UpdateApiDestinationResponse => {
   return {
-    ApiDestinationArn:
-      output.ApiDestinationArn !== undefined && output.ApiDestinationArn !== null
-        ? output.ApiDestinationArn
-        : undefined,
-    ApiDestinationState:
-      output.ApiDestinationState !== undefined && output.ApiDestinationState !== null
-        ? output.ApiDestinationState
-        : undefined,
+    ApiDestinationArn: __expectString(output.ApiDestinationArn),
+    ApiDestinationState: __expectString(output.ApiDestinationState),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -7537,13 +7448,13 @@ const deserializeAws_json1_1UpdateApiDestinationResponse = (
 
 const deserializeAws_json1_1UpdateArchiveResponse = (output: any, context: __SerdeContext): UpdateArchiveResponse => {
   return {
-    ArchiveArn: output.ArchiveArn !== undefined && output.ArchiveArn !== null ? output.ArchiveArn : undefined,
+    ArchiveArn: __expectString(output.ArchiveArn),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    StateReason: output.StateReason !== undefined && output.StateReason !== null ? output.StateReason : undefined,
+    State: __expectString(output.State),
+    StateReason: __expectString(output.StateReason),
   } as any;
 };
 
@@ -7552,10 +7463,8 @@ const deserializeAws_json1_1UpdateConnectionResponse = (
   context: __SerdeContext
 ): UpdateConnectionResponse => {
   return {
-    ConnectionArn:
-      output.ConnectionArn !== undefined && output.ConnectionArn !== null ? output.ConnectionArn : undefined,
-    ConnectionState:
-      output.ConnectionState !== undefined && output.ConnectionState !== null ? output.ConnectionState : undefined,
+    ConnectionArn: __expectString(output.ConnectionArn),
+    ConnectionState: __expectString(output.ConnectionState),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))

--- a/clients/client-cloudwatch-logs/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudwatch-logs/protocols/Aws_json1_1.ts
@@ -179,7 +179,12 @@ import {
   UntagLogGroupRequest,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -4467,7 +4472,7 @@ const deserializeAws_json1_1CreateExportTaskResponse = (
   context: __SerdeContext
 ): CreateExportTaskResponse => {
   return {
-    taskId: output.taskId !== undefined && output.taskId !== null ? output.taskId : undefined,
+    taskId: __expectString(output.taskId),
   } as any;
 };
 
@@ -4476,11 +4481,8 @@ const deserializeAws_json1_1DataAlreadyAcceptedException = (
   context: __SerdeContext
 ): DataAlreadyAcceptedException => {
   return {
-    expectedSequenceToken:
-      output.expectedSequenceToken !== undefined && output.expectedSequenceToken !== null
-        ? output.expectedSequenceToken
-        : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    expectedSequenceToken: __expectString(output.expectedSequenceToken),
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -4489,7 +4491,7 @@ const deserializeAws_json1_1DeleteQueryDefinitionResponse = (
   context: __SerdeContext
 ): DeleteQueryDefinitionResponse => {
   return {
-    success: output.success !== undefined && output.success !== null ? output.success : undefined,
+    success: __expectBoolean(output.success),
   } as any;
 };
 
@@ -4502,7 +4504,7 @@ const deserializeAws_json1_1DescribeDestinationsResponse = (
       output.destinations !== undefined && output.destinations !== null
         ? deserializeAws_json1_1Destinations(output.destinations, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -4515,7 +4517,7 @@ const deserializeAws_json1_1DescribeExportTasksResponse = (
       output.exportTasks !== undefined && output.exportTasks !== null
         ? deserializeAws_json1_1ExportTasks(output.exportTasks, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -4528,7 +4530,7 @@ const deserializeAws_json1_1DescribeLogGroupsResponse = (
       output.logGroups !== undefined && output.logGroups !== null
         ? deserializeAws_json1_1LogGroups(output.logGroups, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -4541,7 +4543,7 @@ const deserializeAws_json1_1DescribeLogStreamsResponse = (
       output.logStreams !== undefined && output.logStreams !== null
         ? deserializeAws_json1_1LogStreams(output.logStreams, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -4554,7 +4556,7 @@ const deserializeAws_json1_1DescribeMetricFiltersResponse = (
       output.metricFilters !== undefined && output.metricFilters !== null
         ? deserializeAws_json1_1MetricFilters(output.metricFilters, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -4563,7 +4565,7 @@ const deserializeAws_json1_1DescribeQueriesResponse = (
   context: __SerdeContext
 ): DescribeQueriesResponse => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     queries:
       output.queries !== undefined && output.queries !== null
         ? deserializeAws_json1_1QueryInfoList(output.queries, context)
@@ -4576,7 +4578,7 @@ const deserializeAws_json1_1DescribeQueryDefinitionsResponse = (
   context: __SerdeContext
 ): DescribeQueryDefinitionsResponse => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     queryDefinitions:
       output.queryDefinitions !== undefined && output.queryDefinitions !== null
         ? deserializeAws_json1_1QueryDefinitionList(output.queryDefinitions, context)
@@ -4589,7 +4591,7 @@ const deserializeAws_json1_1DescribeResourcePoliciesResponse = (
   context: __SerdeContext
 ): DescribeResourcePoliciesResponse => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     resourcePolicies:
       output.resourcePolicies !== undefined && output.resourcePolicies !== null
         ? deserializeAws_json1_1ResourcePolicies(output.resourcePolicies, context)
@@ -4602,7 +4604,7 @@ const deserializeAws_json1_1DescribeSubscriptionFiltersResponse = (
   context: __SerdeContext
 ): DescribeSubscriptionFiltersResponse => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     subscriptionFilters:
       output.subscriptionFilters !== undefined && output.subscriptionFilters !== null
         ? deserializeAws_json1_1SubscriptionFilters(output.subscriptionFilters, context)
@@ -4612,13 +4614,12 @@ const deserializeAws_json1_1DescribeSubscriptionFiltersResponse = (
 
 const deserializeAws_json1_1Destination = (output: any, context: __SerdeContext): Destination => {
   return {
-    accessPolicy: output.accessPolicy !== undefined && output.accessPolicy !== null ? output.accessPolicy : undefined,
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    creationTime: output.creationTime !== undefined && output.creationTime !== null ? output.creationTime : undefined,
-    destinationName:
-      output.destinationName !== undefined && output.destinationName !== null ? output.destinationName : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
-    targetArn: output.targetArn !== undefined && output.targetArn !== null ? output.targetArn : undefined,
+    accessPolicy: __expectString(output.accessPolicy),
+    arn: __expectString(output.arn),
+    creationTime: __expectNumber(output.creationTime),
+    destinationName: __expectString(output.destinationName),
+    roleArn: __expectString(output.roleArn),
+    targetArn: __expectString(output.targetArn),
   } as any;
 };
 
@@ -4640,31 +4641,28 @@ const deserializeAws_json1_1Dimensions = (output: any, context: __SerdeContext):
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_json1_1ExportTask = (output: any, context: __SerdeContext): ExportTask => {
   return {
-    destination: output.destination !== undefined && output.destination !== null ? output.destination : undefined,
-    destinationPrefix:
-      output.destinationPrefix !== undefined && output.destinationPrefix !== null
-        ? output.destinationPrefix
-        : undefined,
+    destination: __expectString(output.destination),
+    destinationPrefix: __expectString(output.destinationPrefix),
     executionInfo:
       output.executionInfo !== undefined && output.executionInfo !== null
         ? deserializeAws_json1_1ExportTaskExecutionInfo(output.executionInfo, context)
         : undefined,
-    from: output.from !== undefined && output.from !== null ? output.from : undefined,
-    logGroupName: output.logGroupName !== undefined && output.logGroupName !== null ? output.logGroupName : undefined,
+    from: __expectNumber(output.from),
+    logGroupName: __expectString(output.logGroupName),
     status:
       output.status !== undefined && output.status !== null
         ? deserializeAws_json1_1ExportTaskStatus(output.status, context)
         : undefined,
-    taskId: output.taskId !== undefined && output.taskId !== null ? output.taskId : undefined,
-    taskName: output.taskName !== undefined && output.taskName !== null ? output.taskName : undefined,
-    to: output.to !== undefined && output.to !== null ? output.to : undefined,
+    taskId: __expectString(output.taskId),
+    taskName: __expectString(output.taskName),
+    to: __expectNumber(output.to),
   } as any;
 };
 
@@ -4673,9 +4671,8 @@ const deserializeAws_json1_1ExportTaskExecutionInfo = (
   context: __SerdeContext
 ): ExportTaskExecutionInfo => {
   return {
-    completionTime:
-      output.completionTime !== undefined && output.completionTime !== null ? output.completionTime : undefined,
-    creationTime: output.creationTime !== undefined && output.creationTime !== null ? output.creationTime : undefined,
+    completionTime: __expectNumber(output.completionTime),
+    creationTime: __expectNumber(output.creationTime),
   } as any;
 };
 
@@ -4692,8 +4689,8 @@ const deserializeAws_json1_1ExportTasks = (output: any, context: __SerdeContext)
 
 const deserializeAws_json1_1ExportTaskStatus = (output: any, context: __SerdeContext): ExportTaskStatus => {
   return {
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    code: __expectString(output.code),
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -4704,20 +4701,18 @@ const deserializeAws_json1_1ExtractedValues = (output: any, context: __SerdeCont
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_json1_1FilteredLogEvent = (output: any, context: __SerdeContext): FilteredLogEvent => {
   return {
-    eventId: output.eventId !== undefined && output.eventId !== null ? output.eventId : undefined,
-    ingestionTime:
-      output.ingestionTime !== undefined && output.ingestionTime !== null ? output.ingestionTime : undefined,
-    logStreamName:
-      output.logStreamName !== undefined && output.logStreamName !== null ? output.logStreamName : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    timestamp: output.timestamp !== undefined && output.timestamp !== null ? output.timestamp : undefined,
+    eventId: __expectString(output.eventId),
+    ingestionTime: __expectNumber(output.ingestionTime),
+    logStreamName: __expectString(output.logStreamName),
+    message: __expectString(output.message),
+    timestamp: __expectNumber(output.timestamp),
   } as any;
 };
 
@@ -4741,7 +4736,7 @@ const deserializeAws_json1_1FilterLogEventsResponse = (
       output.events !== undefined && output.events !== null
         ? deserializeAws_json1_1FilteredLogEvents(output.events, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     searchedLogStreams:
       output.searchedLogStreams !== undefined && output.searchedLogStreams !== null
         ? deserializeAws_json1_1SearchedLogStreams(output.searchedLogStreams, context)
@@ -4755,12 +4750,8 @@ const deserializeAws_json1_1GetLogEventsResponse = (output: any, context: __Serd
       output.events !== undefined && output.events !== null
         ? deserializeAws_json1_1OutputLogEvents(output.events, context)
         : undefined,
-    nextBackwardToken:
-      output.nextBackwardToken !== undefined && output.nextBackwardToken !== null
-        ? output.nextBackwardToken
-        : undefined,
-    nextForwardToken:
-      output.nextForwardToken !== undefined && output.nextForwardToken !== null ? output.nextForwardToken : undefined,
+    nextBackwardToken: __expectString(output.nextBackwardToken),
+    nextForwardToken: __expectString(output.nextForwardToken),
   } as any;
 };
 
@@ -4798,7 +4789,7 @@ const deserializeAws_json1_1GetQueryResultsResponse = (
       output.statistics !== undefined && output.statistics !== null
         ? deserializeAws_json1_1QueryStatistics(output.statistics, context)
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -4807,7 +4798,7 @@ const deserializeAws_json1_1InvalidOperationException = (
   context: __SerdeContext
 ): InvalidOperationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -4816,7 +4807,7 @@ const deserializeAws_json1_1InvalidParameterException = (
   context: __SerdeContext
 ): InvalidParameterException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -4825,17 +4816,14 @@ const deserializeAws_json1_1InvalidSequenceTokenException = (
   context: __SerdeContext
 ): InvalidSequenceTokenException => {
   return {
-    expectedSequenceToken:
-      output.expectedSequenceToken !== undefined && output.expectedSequenceToken !== null
-        ? output.expectedSequenceToken
-        : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    expectedSequenceToken: __expectString(output.expectedSequenceToken),
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -4851,24 +4839,20 @@ const deserializeAws_json1_1ListTagsLogGroupResponse = (
 
 const deserializeAws_json1_1LogGroup = (output: any, context: __SerdeContext): LogGroup => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    creationTime: output.creationTime !== undefined && output.creationTime !== null ? output.creationTime : undefined,
-    kmsKeyId: output.kmsKeyId !== undefined && output.kmsKeyId !== null ? output.kmsKeyId : undefined,
-    logGroupName: output.logGroupName !== undefined && output.logGroupName !== null ? output.logGroupName : undefined,
-    metricFilterCount:
-      output.metricFilterCount !== undefined && output.metricFilterCount !== null
-        ? output.metricFilterCount
-        : undefined,
-    retentionInDays:
-      output.retentionInDays !== undefined && output.retentionInDays !== null ? output.retentionInDays : undefined,
-    storedBytes: output.storedBytes !== undefined && output.storedBytes !== null ? output.storedBytes : undefined,
+    arn: __expectString(output.arn),
+    creationTime: __expectNumber(output.creationTime),
+    kmsKeyId: __expectString(output.kmsKeyId),
+    logGroupName: __expectString(output.logGroupName),
+    metricFilterCount: __expectNumber(output.metricFilterCount),
+    retentionInDays: __expectNumber(output.retentionInDays),
+    storedBytes: __expectNumber(output.storedBytes),
   } as any;
 };
 
 const deserializeAws_json1_1LogGroupField = (output: any, context: __SerdeContext): LogGroupField => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    percent: output.percent !== undefined && output.percent !== null ? output.percent : undefined,
+    name: __expectString(output.name),
+    percent: __expectNumber(output.percent),
   } as any;
 };
 
@@ -4890,7 +4874,7 @@ const deserializeAws_json1_1LogGroupNames = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4912,34 +4896,21 @@ const deserializeAws_json1_1LogRecord = (output: any, context: __SerdeContext): 
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_json1_1LogStream = (output: any, context: __SerdeContext): LogStream => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    creationTime: output.creationTime !== undefined && output.creationTime !== null ? output.creationTime : undefined,
-    firstEventTimestamp:
-      output.firstEventTimestamp !== undefined && output.firstEventTimestamp !== null
-        ? output.firstEventTimestamp
-        : undefined,
-    lastEventTimestamp:
-      output.lastEventTimestamp !== undefined && output.lastEventTimestamp !== null
-        ? output.lastEventTimestamp
-        : undefined,
-    lastIngestionTime:
-      output.lastIngestionTime !== undefined && output.lastIngestionTime !== null
-        ? output.lastIngestionTime
-        : undefined,
-    logStreamName:
-      output.logStreamName !== undefined && output.logStreamName !== null ? output.logStreamName : undefined,
-    storedBytes: output.storedBytes !== undefined && output.storedBytes !== null ? output.storedBytes : undefined,
-    uploadSequenceToken:
-      output.uploadSequenceToken !== undefined && output.uploadSequenceToken !== null
-        ? output.uploadSequenceToken
-        : undefined,
+    arn: __expectString(output.arn),
+    creationTime: __expectNumber(output.creationTime),
+    firstEventTimestamp: __expectNumber(output.firstEventTimestamp),
+    lastEventTimestamp: __expectNumber(output.lastEventTimestamp),
+    lastIngestionTime: __expectNumber(output.lastIngestionTime),
+    logStreamName: __expectString(output.logStreamName),
+    storedBytes: __expectNumber(output.storedBytes),
+    uploadSequenceToken: __expectString(output.uploadSequenceToken),
   } as any;
 };
 
@@ -4959,7 +4930,7 @@ const deserializeAws_json1_1MalformedQueryException = (
   context: __SerdeContext
 ): MalformedQueryException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
     queryCompileError:
       output.queryCompileError !== undefined && output.queryCompileError !== null
         ? deserializeAws_json1_1QueryCompileError(output.queryCompileError, context)
@@ -4969,11 +4940,10 @@ const deserializeAws_json1_1MalformedQueryException = (
 
 const deserializeAws_json1_1MetricFilter = (output: any, context: __SerdeContext): MetricFilter => {
   return {
-    creationTime: output.creationTime !== undefined && output.creationTime !== null ? output.creationTime : undefined,
-    filterName: output.filterName !== undefined && output.filterName !== null ? output.filterName : undefined,
-    filterPattern:
-      output.filterPattern !== undefined && output.filterPattern !== null ? output.filterPattern : undefined,
-    logGroupName: output.logGroupName !== undefined && output.logGroupName !== null ? output.logGroupName : undefined,
+    creationTime: __expectNumber(output.creationTime),
+    filterName: __expectString(output.filterName),
+    filterPattern: __expectString(output.filterPattern),
+    logGroupName: __expectString(output.logGroupName),
     metricTransformations:
       output.metricTransformations !== undefined && output.metricTransformations !== null
         ? deserializeAws_json1_1MetricTransformations(output.metricTransformations, context)
@@ -4997,8 +4967,8 @@ const deserializeAws_json1_1MetricFilterMatchRecord = (
   context: __SerdeContext
 ): MetricFilterMatchRecord => {
   return {
-    eventMessage: output.eventMessage !== undefined && output.eventMessage !== null ? output.eventMessage : undefined,
-    eventNumber: output.eventNumber !== undefined && output.eventNumber !== null ? output.eventNumber : undefined,
+    eventMessage: __expectString(output.eventMessage),
+    eventNumber: __expectNumber(output.eventNumber),
     extractedValues:
       output.extractedValues !== undefined && output.extractedValues !== null
         ? deserializeAws_json1_1ExtractedValues(output.extractedValues, context)
@@ -5019,16 +4989,15 @@ const deserializeAws_json1_1MetricFilters = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1MetricTransformation = (output: any, context: __SerdeContext): MetricTransformation => {
   return {
-    defaultValue: output.defaultValue !== undefined && output.defaultValue !== null ? output.defaultValue : undefined,
+    defaultValue: __expectNumber(output.defaultValue),
     dimensions:
       output.dimensions !== undefined && output.dimensions !== null
         ? deserializeAws_json1_1Dimensions(output.dimensions, context)
         : undefined,
-    metricName: output.metricName !== undefined && output.metricName !== null ? output.metricName : undefined,
-    metricNamespace:
-      output.metricNamespace !== undefined && output.metricNamespace !== null ? output.metricNamespace : undefined,
-    metricValue: output.metricValue !== undefined && output.metricValue !== null ? output.metricValue : undefined,
-    unit: output.unit !== undefined && output.unit !== null ? output.unit : undefined,
+    metricName: __expectString(output.metricName),
+    metricNamespace: __expectString(output.metricNamespace),
+    metricValue: __expectString(output.metricValue),
+    unit: __expectString(output.unit),
   } as any;
 };
 
@@ -5048,16 +5017,15 @@ const deserializeAws_json1_1OperationAbortedException = (
   context: __SerdeContext
 ): OperationAbortedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1OutputLogEvent = (output: any, context: __SerdeContext): OutputLogEvent => {
   return {
-    ingestionTime:
-      output.ingestionTime !== undefined && output.ingestionTime !== null ? output.ingestionTime : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    timestamp: output.timestamp !== undefined && output.timestamp !== null ? output.timestamp : undefined,
+    ingestionTime: __expectNumber(output.ingestionTime),
+    message: __expectString(output.message),
+    timestamp: __expectNumber(output.timestamp),
   } as any;
 };
 
@@ -5083,10 +5051,7 @@ const deserializeAws_json1_1PutDestinationResponse = (output: any, context: __Se
 
 const deserializeAws_json1_1PutLogEventsResponse = (output: any, context: __SerdeContext): PutLogEventsResponse => {
   return {
-    nextSequenceToken:
-      output.nextSequenceToken !== undefined && output.nextSequenceToken !== null
-        ? output.nextSequenceToken
-        : undefined,
+    nextSequenceToken: __expectString(output.nextSequenceToken),
     rejectedLogEventsInfo:
       output.rejectedLogEventsInfo !== undefined && output.rejectedLogEventsInfo !== null
         ? deserializeAws_json1_1RejectedLogEventsInfo(output.rejectedLogEventsInfo, context)
@@ -5099,10 +5064,7 @@ const deserializeAws_json1_1PutQueryDefinitionResponse = (
   context: __SerdeContext
 ): PutQueryDefinitionResponse => {
   return {
-    queryDefinitionId:
-      output.queryDefinitionId !== undefined && output.queryDefinitionId !== null
-        ? output.queryDefinitionId
-        : undefined,
+    queryDefinitionId: __expectString(output.queryDefinitionId),
   } as any;
 };
 
@@ -5124,7 +5086,7 @@ const deserializeAws_json1_1QueryCompileError = (output: any, context: __SerdeCo
       output.location !== undefined && output.location !== null
         ? deserializeAws_json1_1QueryCompileErrorLocation(output.location, context)
         : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -5133,26 +5095,21 @@ const deserializeAws_json1_1QueryCompileErrorLocation = (
   context: __SerdeContext
 ): QueryCompileErrorLocation => {
   return {
-    endCharOffset:
-      output.endCharOffset !== undefined && output.endCharOffset !== null ? output.endCharOffset : undefined,
-    startCharOffset:
-      output.startCharOffset !== undefined && output.startCharOffset !== null ? output.startCharOffset : undefined,
+    endCharOffset: __expectNumber(output.endCharOffset),
+    startCharOffset: __expectNumber(output.startCharOffset),
   } as any;
 };
 
 const deserializeAws_json1_1QueryDefinition = (output: any, context: __SerdeContext): QueryDefinition => {
   return {
-    lastModified: output.lastModified !== undefined && output.lastModified !== null ? output.lastModified : undefined,
+    lastModified: __expectNumber(output.lastModified),
     logGroupNames:
       output.logGroupNames !== undefined && output.logGroupNames !== null
         ? deserializeAws_json1_1LogGroupNames(output.logGroupNames, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    queryDefinitionId:
-      output.queryDefinitionId !== undefined && output.queryDefinitionId !== null
-        ? output.queryDefinitionId
-        : undefined,
-    queryString: output.queryString !== undefined && output.queryString !== null ? output.queryString : undefined,
+    name: __expectString(output.name),
+    queryDefinitionId: __expectString(output.queryDefinitionId),
+    queryString: __expectString(output.queryString),
   } as any;
 };
 
@@ -5169,11 +5126,11 @@ const deserializeAws_json1_1QueryDefinitionList = (output: any, context: __Serde
 
 const deserializeAws_json1_1QueryInfo = (output: any, context: __SerdeContext): QueryInfo => {
   return {
-    createTime: output.createTime !== undefined && output.createTime !== null ? output.createTime : undefined,
-    logGroupName: output.logGroupName !== undefined && output.logGroupName !== null ? output.logGroupName : undefined,
-    queryId: output.queryId !== undefined && output.queryId !== null ? output.queryId : undefined,
-    queryString: output.queryString !== undefined && output.queryString !== null ? output.queryString : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    createTime: __expectNumber(output.createTime),
+    logGroupName: __expectString(output.logGroupName),
+    queryId: __expectString(output.queryId),
+    queryString: __expectString(output.queryString),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -5201,28 +5158,17 @@ const deserializeAws_json1_1QueryResults = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_1QueryStatistics = (output: any, context: __SerdeContext): QueryStatistics => {
   return {
-    bytesScanned: output.bytesScanned !== undefined && output.bytesScanned !== null ? output.bytesScanned : undefined,
-    recordsMatched:
-      output.recordsMatched !== undefined && output.recordsMatched !== null ? output.recordsMatched : undefined,
-    recordsScanned:
-      output.recordsScanned !== undefined && output.recordsScanned !== null ? output.recordsScanned : undefined,
+    bytesScanned: __expectNumber(output.bytesScanned),
+    recordsMatched: __expectNumber(output.recordsMatched),
+    recordsScanned: __expectNumber(output.recordsScanned),
   } as any;
 };
 
 const deserializeAws_json1_1RejectedLogEventsInfo = (output: any, context: __SerdeContext): RejectedLogEventsInfo => {
   return {
-    expiredLogEventEndIndex:
-      output.expiredLogEventEndIndex !== undefined && output.expiredLogEventEndIndex !== null
-        ? output.expiredLogEventEndIndex
-        : undefined,
-    tooNewLogEventStartIndex:
-      output.tooNewLogEventStartIndex !== undefined && output.tooNewLogEventStartIndex !== null
-        ? output.tooNewLogEventStartIndex
-        : undefined,
-    tooOldLogEventEndIndex:
-      output.tooOldLogEventEndIndex !== undefined && output.tooOldLogEventEndIndex !== null
-        ? output.tooOldLogEventEndIndex
-        : undefined,
+    expiredLogEventEndIndex: __expectNumber(output.expiredLogEventEndIndex),
+    tooNewLogEventStartIndex: __expectNumber(output.tooNewLogEventStartIndex),
+    tooOldLogEventEndIndex: __expectNumber(output.tooOldLogEventEndIndex),
   } as any;
 };
 
@@ -5231,7 +5177,7 @@ const deserializeAws_json1_1ResourceAlreadyExistsException = (
   context: __SerdeContext
 ): ResourceAlreadyExistsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -5240,7 +5186,7 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -5257,18 +5203,16 @@ const deserializeAws_json1_1ResourcePolicies = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1ResourcePolicy = (output: any, context: __SerdeContext): ResourcePolicy => {
   return {
-    lastUpdatedTime:
-      output.lastUpdatedTime !== undefined && output.lastUpdatedTime !== null ? output.lastUpdatedTime : undefined,
-    policyDocument:
-      output.policyDocument !== undefined && output.policyDocument !== null ? output.policyDocument : undefined,
-    policyName: output.policyName !== undefined && output.policyName !== null ? output.policyName : undefined,
+    lastUpdatedTime: __expectNumber(output.lastUpdatedTime),
+    policyDocument: __expectString(output.policyDocument),
+    policyName: __expectString(output.policyName),
   } as any;
 };
 
 const deserializeAws_json1_1ResultField = (output: any, context: __SerdeContext): ResultField => {
   return {
-    field: output.field !== undefined && output.field !== null ? output.field : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    field: __expectString(output.field),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -5285,12 +5229,8 @@ const deserializeAws_json1_1ResultRows = (output: any, context: __SerdeContext):
 
 const deserializeAws_json1_1SearchedLogStream = (output: any, context: __SerdeContext): SearchedLogStream => {
   return {
-    logStreamName:
-      output.logStreamName !== undefined && output.logStreamName !== null ? output.logStreamName : undefined,
-    searchedCompletely:
-      output.searchedCompletely !== undefined && output.searchedCompletely !== null
-        ? output.searchedCompletely
-        : undefined,
+    logStreamName: __expectString(output.logStreamName),
+    searchedCompletely: __expectBoolean(output.searchedCompletely),
   } as any;
 };
 
@@ -5310,33 +5250,31 @@ const deserializeAws_json1_1ServiceUnavailableException = (
   context: __SerdeContext
 ): ServiceUnavailableException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1StartQueryResponse = (output: any, context: __SerdeContext): StartQueryResponse => {
   return {
-    queryId: output.queryId !== undefined && output.queryId !== null ? output.queryId : undefined,
+    queryId: __expectString(output.queryId),
   } as any;
 };
 
 const deserializeAws_json1_1StopQueryResponse = (output: any, context: __SerdeContext): StopQueryResponse => {
   return {
-    success: output.success !== undefined && output.success !== null ? output.success : undefined,
+    success: __expectBoolean(output.success),
   } as any;
 };
 
 const deserializeAws_json1_1SubscriptionFilter = (output: any, context: __SerdeContext): SubscriptionFilter => {
   return {
-    creationTime: output.creationTime !== undefined && output.creationTime !== null ? output.creationTime : undefined,
-    destinationArn:
-      output.destinationArn !== undefined && output.destinationArn !== null ? output.destinationArn : undefined,
-    distribution: output.distribution !== undefined && output.distribution !== null ? output.distribution : undefined,
-    filterName: output.filterName !== undefined && output.filterName !== null ? output.filterName : undefined,
-    filterPattern:
-      output.filterPattern !== undefined && output.filterPattern !== null ? output.filterPattern : undefined,
-    logGroupName: output.logGroupName !== undefined && output.logGroupName !== null ? output.logGroupName : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
+    creationTime: __expectNumber(output.creationTime),
+    destinationArn: __expectString(output.destinationArn),
+    distribution: __expectString(output.distribution),
+    filterName: __expectString(output.filterName),
+    filterPattern: __expectString(output.filterPattern),
+    logGroupName: __expectString(output.logGroupName),
+    roleArn: __expectString(output.roleArn),
   } as any;
 };
 
@@ -5358,7 +5296,7 @@ const deserializeAws_json1_1Tags = (output: any, context: __SerdeContext): { [ke
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -5380,7 +5318,7 @@ const deserializeAws_json1_1UnrecognizedClientException = (
   context: __SerdeContext
 ): UnrecognizedClientException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 

--- a/clients/client-cloudwatch/protocols/Aws_query.ts
+++ b/clients/client-cloudwatch/protocols/Aws_query.ts
@@ -179,6 +179,7 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
@@ -4568,22 +4569,22 @@ const deserializeAws_queryAlarmHistoryItem = (output: any, context: __SerdeConte
     HistoryData: undefined,
   };
   if (output["AlarmName"] !== undefined) {
-    contents.AlarmName = output["AlarmName"];
+    contents.AlarmName = __expectString(output["AlarmName"]);
   }
   if (output["AlarmType"] !== undefined) {
-    contents.AlarmType = output["AlarmType"];
+    contents.AlarmType = __expectString(output["AlarmType"]);
   }
   if (output["Timestamp"] !== undefined) {
     contents.Timestamp = new Date(output["Timestamp"]);
   }
   if (output["HistoryItemType"] !== undefined) {
-    contents.HistoryItemType = output["HistoryItemType"];
+    contents.HistoryItemType = __expectString(output["HistoryItemType"]);
   }
   if (output["HistorySummary"] !== undefined) {
-    contents.HistorySummary = output["HistorySummary"];
+    contents.HistorySummary = __expectString(output["HistorySummary"]);
   }
   if (output["HistoryData"] !== undefined) {
-    contents.HistoryData = output["HistoryData"];
+    contents.HistoryData = __expectString(output["HistoryData"]);
   }
   return contents;
 };
@@ -4609,10 +4610,10 @@ const deserializeAws_queryAnomalyDetector = (output: any, context: __SerdeContex
     StateValue: undefined,
   };
   if (output["Namespace"] !== undefined) {
-    contents.Namespace = output["Namespace"];
+    contents.Namespace = __expectString(output["Namespace"]);
   }
   if (output["MetricName"] !== undefined) {
-    contents.MetricName = output["MetricName"];
+    contents.MetricName = __expectString(output["MetricName"]);
   }
   if (output.Dimensions === "") {
     contents.Dimensions = [];
@@ -4624,13 +4625,13 @@ const deserializeAws_queryAnomalyDetector = (output: any, context: __SerdeContex
     );
   }
   if (output["Stat"] !== undefined) {
-    contents.Stat = output["Stat"];
+    contents.Stat = __expectString(output["Stat"]);
   }
   if (output["Configuration"] !== undefined) {
     contents.Configuration = deserializeAws_queryAnomalyDetectorConfiguration(output["Configuration"], context);
   }
   if (output["StateValue"] !== undefined) {
-    contents.StateValue = output["StateValue"];
+    contents.StateValue = __expectString(output["StateValue"]);
   }
   return contents;
 };
@@ -4653,7 +4654,7 @@ const deserializeAws_queryAnomalyDetectorConfiguration = (
     );
   }
   if (output["MetricTimezone"] !== undefined) {
-    contents.MetricTimezone = output["MetricTimezone"];
+    contents.MetricTimezone = __expectString(output["MetricTimezone"]);
   }
   return contents;
 };
@@ -4720,19 +4721,19 @@ const deserializeAws_queryCompositeAlarm = (output: any, context: __SerdeContext
     );
   }
   if (output["AlarmArn"] !== undefined) {
-    contents.AlarmArn = output["AlarmArn"];
+    contents.AlarmArn = __expectString(output["AlarmArn"]);
   }
   if (output["AlarmConfigurationUpdatedTimestamp"] !== undefined) {
     contents.AlarmConfigurationUpdatedTimestamp = new Date(output["AlarmConfigurationUpdatedTimestamp"]);
   }
   if (output["AlarmDescription"] !== undefined) {
-    contents.AlarmDescription = output["AlarmDescription"];
+    contents.AlarmDescription = __expectString(output["AlarmDescription"]);
   }
   if (output["AlarmName"] !== undefined) {
-    contents.AlarmName = output["AlarmName"];
+    contents.AlarmName = __expectString(output["AlarmName"]);
   }
   if (output["AlarmRule"] !== undefined) {
-    contents.AlarmRule = output["AlarmRule"];
+    contents.AlarmRule = __expectString(output["AlarmRule"]);
   }
   if (output.InsufficientDataActions === "") {
     contents.InsufficientDataActions = [];
@@ -4753,16 +4754,16 @@ const deserializeAws_queryCompositeAlarm = (output: any, context: __SerdeContext
     );
   }
   if (output["StateReason"] !== undefined) {
-    contents.StateReason = output["StateReason"];
+    contents.StateReason = __expectString(output["StateReason"]);
   }
   if (output["StateReasonData"] !== undefined) {
-    contents.StateReasonData = output["StateReasonData"];
+    contents.StateReasonData = __expectString(output["StateReasonData"]);
   }
   if (output["StateUpdatedTimestamp"] !== undefined) {
     contents.StateUpdatedTimestamp = new Date(output["StateUpdatedTimestamp"]);
   }
   if (output["StateValue"] !== undefined) {
-    contents.StateValue = output["StateValue"];
+    contents.StateValue = __expectString(output["StateValue"]);
   }
   return contents;
 };
@@ -4786,7 +4787,7 @@ const deserializeAws_queryConcurrentModificationException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -4810,10 +4811,10 @@ const deserializeAws_queryDashboardEntry = (output: any, context: __SerdeContext
     Size: undefined,
   };
   if (output["DashboardName"] !== undefined) {
-    contents.DashboardName = output["DashboardName"];
+    contents.DashboardName = __expectString(output["DashboardName"]);
   }
   if (output["DashboardArn"] !== undefined) {
-    contents.DashboardArn = output["DashboardArn"];
+    contents.DashboardArn = __expectString(output["DashboardArn"]);
   }
   if (output["LastModified"] !== undefined) {
     contents.LastModified = new Date(output["LastModified"]);
@@ -4833,7 +4834,7 @@ const deserializeAws_queryDashboardInvalidInputError = (
     dashboardValidationMessages: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   if (output.dashboardValidationMessages === "") {
     contents.dashboardValidationMessages = [];
@@ -4855,7 +4856,7 @@ const deserializeAws_queryDashboardNotFoundError = (output: any, context: __Serd
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -4869,10 +4870,10 @@ const deserializeAws_queryDashboardValidationMessage = (
     Message: undefined,
   };
   if (output["DataPath"] !== undefined) {
-    contents.DataPath = output["DataPath"];
+    contents.DataPath = __expectString(output["DataPath"]);
   }
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -4921,7 +4922,7 @@ const deserializeAws_queryDatapoint = (output: any, context: __SerdeContext): Da
     contents.Maximum = parseFloat(output["Maximum"]);
   }
   if (output["Unit"] !== undefined) {
-    contents.Unit = output["Unit"];
+    contents.Unit = __expectString(output["Unit"]);
   }
   if (output.ExtendedStatistics === "") {
     contents.ExtendedStatistics = {};
@@ -5027,7 +5028,7 @@ const deserializeAws_queryDescribeAlarmHistoryOutput = (
     );
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -5076,7 +5077,7 @@ const deserializeAws_queryDescribeAlarmsOutput = (output: any, context: __SerdeC
     );
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -5099,7 +5100,7 @@ const deserializeAws_queryDescribeAnomalyDetectorsOutput = (
     );
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -5113,7 +5114,7 @@ const deserializeAws_queryDescribeInsightRulesOutput = (
     InsightRules: undefined,
   };
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   if (output.InsightRules === "") {
     contents.InsightRules = [];
@@ -5133,10 +5134,10 @@ const deserializeAws_queryDimension = (output: any, context: __SerdeContext): Di
     Value: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["Value"] !== undefined) {
-    contents.Value = output["Value"];
+    contents.Value = __expectString(output["Value"]);
   }
   return contents;
 };
@@ -5197,13 +5198,13 @@ const deserializeAws_queryGetDashboardOutput = (output: any, context: __SerdeCon
     DashboardName: undefined,
   };
   if (output["DashboardArn"] !== undefined) {
-    contents.DashboardArn = output["DashboardArn"];
+    contents.DashboardArn = __expectString(output["DashboardArn"]);
   }
   if (output["DashboardBody"] !== undefined) {
-    contents.DashboardBody = output["DashboardBody"];
+    contents.DashboardBody = __expectString(output["DashboardBody"]);
   }
   if (output["DashboardName"] !== undefined) {
-    contents.DashboardName = output["DashboardName"];
+    contents.DashboardName = __expectString(output["DashboardName"]);
   }
   return contents;
 };
@@ -5230,7 +5231,7 @@ const deserializeAws_queryGetInsightRuleReportOutput = (
     );
   }
   if (output["AggregationStatistic"] !== undefined) {
-    contents.AggregationStatistic = output["AggregationStatistic"];
+    contents.AggregationStatistic = __expectString(output["AggregationStatistic"]);
   }
   if (output["AggregateValue"] !== undefined) {
     contents.AggregateValue = parseFloat(output["AggregateValue"]);
@@ -5275,7 +5276,7 @@ const deserializeAws_queryGetMetricDataOutput = (output: any, context: __SerdeCo
     );
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   if (output.Messages === "") {
     contents.Messages = [];
@@ -5298,7 +5299,7 @@ const deserializeAws_queryGetMetricStatisticsOutput = (
     Datapoints: undefined,
   };
   if (output["Label"] !== undefined) {
-    contents.Label = output["Label"];
+    contents.Label = __expectString(output["Label"]);
   }
   if (output.Datapoints === "") {
     contents.Datapoints = [];
@@ -5326,10 +5327,10 @@ const deserializeAws_queryGetMetricStreamOutput = (output: any, context: __Serde
     OutputFormat: undefined,
   };
   if (output["Arn"] !== undefined) {
-    contents.Arn = output["Arn"];
+    contents.Arn = __expectString(output["Arn"]);
   }
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output.IncludeFilters === "") {
     contents.IncludeFilters = [];
@@ -5350,13 +5351,13 @@ const deserializeAws_queryGetMetricStreamOutput = (output: any, context: __Serde
     );
   }
   if (output["FirehoseArn"] !== undefined) {
-    contents.FirehoseArn = output["FirehoseArn"];
+    contents.FirehoseArn = __expectString(output["FirehoseArn"]);
   }
   if (output["RoleArn"] !== undefined) {
-    contents.RoleArn = output["RoleArn"];
+    contents.RoleArn = __expectString(output["RoleArn"]);
   }
   if (output["State"] !== undefined) {
-    contents.State = output["State"];
+    contents.State = __expectString(output["State"]);
   }
   if (output["CreationDate"] !== undefined) {
     contents.CreationDate = new Date(output["CreationDate"]);
@@ -5365,7 +5366,7 @@ const deserializeAws_queryGetMetricStreamOutput = (output: any, context: __Serde
     contents.LastUpdateDate = new Date(output["LastUpdateDate"]);
   }
   if (output["OutputFormat"] !== undefined) {
-    contents.OutputFormat = output["OutputFormat"];
+    contents.OutputFormat = __expectString(output["OutputFormat"]);
   }
   return contents;
 };
@@ -5391,16 +5392,16 @@ const deserializeAws_queryInsightRule = (output: any, context: __SerdeContext): 
     Definition: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["State"] !== undefined) {
-    contents.State = output["State"];
+    contents.State = __expectString(output["State"]);
   }
   if (output["Schema"] !== undefined) {
-    contents.Schema = output["Schema"];
+    contents.Schema = __expectString(output["Schema"]);
   }
   if (output["Definition"] !== undefined) {
-    contents.Definition = output["Definition"];
+    contents.Definition = __expectString(output["Definition"]);
   }
   return contents;
 };
@@ -5473,7 +5474,7 @@ const deserializeAws_queryInsightRuleContributorKeyLabels = (output: any, contex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -5484,7 +5485,7 @@ const deserializeAws_queryInsightRuleContributorKeys = (output: any, context: __
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -5573,7 +5574,7 @@ const deserializeAws_queryInternalServiceFault = (output: any, context: __SerdeC
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -5583,7 +5584,7 @@ const deserializeAws_queryInvalidFormatFault = (output: any, context: __SerdeCon
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -5593,7 +5594,7 @@ const deserializeAws_queryInvalidNextToken = (output: any, context: __SerdeConte
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -5606,7 +5607,7 @@ const deserializeAws_queryInvalidParameterCombinationException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -5619,7 +5620,7 @@ const deserializeAws_queryInvalidParameterValueException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -5629,7 +5630,7 @@ const deserializeAws_queryLimitExceededException = (output: any, context: __Serd
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -5639,7 +5640,7 @@ const deserializeAws_queryLimitExceededFault = (output: any, context: __SerdeCon
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -5659,7 +5660,7 @@ const deserializeAws_queryListDashboardsOutput = (output: any, context: __SerdeC
     );
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -5676,7 +5677,7 @@ const deserializeAws_queryListMetricsOutput = (output: any, context: __SerdeCont
     contents.Metrics = deserializeAws_queryMetrics(__getArrayIfSingleItem(output["Metrics"]["member"]), context);
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -5687,7 +5688,7 @@ const deserializeAws_queryListMetricStreamsOutput = (output: any, context: __Ser
     Entries: undefined,
   };
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   if (output.Entries === "") {
     contents.Entries = [];
@@ -5723,10 +5724,10 @@ const deserializeAws_queryMessageData = (output: any, context: __SerdeContext): 
     Value: undefined,
   };
   if (output["Code"] !== undefined) {
-    contents.Code = output["Code"];
+    contents.Code = __expectString(output["Code"]);
   }
   if (output["Value"] !== undefined) {
-    contents.Value = output["Value"];
+    contents.Value = __expectString(output["Value"]);
   }
   return contents;
 };
@@ -5738,10 +5739,10 @@ const deserializeAws_queryMetric = (output: any, context: __SerdeContext): Metri
     Dimensions: undefined,
   };
   if (output["Namespace"] !== undefined) {
-    contents.Namespace = output["Namespace"];
+    contents.Namespace = __expectString(output["Namespace"]);
   }
   if (output["MetricName"] !== undefined) {
-    contents.MetricName = output["MetricName"];
+    contents.MetricName = __expectString(output["MetricName"]);
   }
   if (output.Dimensions === "") {
     contents.Dimensions = [];
@@ -5786,13 +5787,13 @@ const deserializeAws_queryMetricAlarm = (output: any, context: __SerdeContext): 
     ThresholdMetricId: undefined,
   };
   if (output["AlarmName"] !== undefined) {
-    contents.AlarmName = output["AlarmName"];
+    contents.AlarmName = __expectString(output["AlarmName"]);
   }
   if (output["AlarmArn"] !== undefined) {
-    contents.AlarmArn = output["AlarmArn"];
+    contents.AlarmArn = __expectString(output["AlarmArn"]);
   }
   if (output["AlarmDescription"] !== undefined) {
-    contents.AlarmDescription = output["AlarmDescription"];
+    contents.AlarmDescription = __expectString(output["AlarmDescription"]);
   }
   if (output["AlarmConfigurationUpdatedTimestamp"] !== undefined) {
     contents.AlarmConfigurationUpdatedTimestamp = new Date(output["AlarmConfigurationUpdatedTimestamp"]);
@@ -5828,28 +5829,28 @@ const deserializeAws_queryMetricAlarm = (output: any, context: __SerdeContext): 
     );
   }
   if (output["StateValue"] !== undefined) {
-    contents.StateValue = output["StateValue"];
+    contents.StateValue = __expectString(output["StateValue"]);
   }
   if (output["StateReason"] !== undefined) {
-    contents.StateReason = output["StateReason"];
+    contents.StateReason = __expectString(output["StateReason"]);
   }
   if (output["StateReasonData"] !== undefined) {
-    contents.StateReasonData = output["StateReasonData"];
+    contents.StateReasonData = __expectString(output["StateReasonData"]);
   }
   if (output["StateUpdatedTimestamp"] !== undefined) {
     contents.StateUpdatedTimestamp = new Date(output["StateUpdatedTimestamp"]);
   }
   if (output["MetricName"] !== undefined) {
-    contents.MetricName = output["MetricName"];
+    contents.MetricName = __expectString(output["MetricName"]);
   }
   if (output["Namespace"] !== undefined) {
-    contents.Namespace = output["Namespace"];
+    contents.Namespace = __expectString(output["Namespace"]);
   }
   if (output["Statistic"] !== undefined) {
-    contents.Statistic = output["Statistic"];
+    contents.Statistic = __expectString(output["Statistic"]);
   }
   if (output["ExtendedStatistic"] !== undefined) {
-    contents.ExtendedStatistic = output["ExtendedStatistic"];
+    contents.ExtendedStatistic = __expectString(output["ExtendedStatistic"]);
   }
   if (output.Dimensions === "") {
     contents.Dimensions = [];
@@ -5864,7 +5865,7 @@ const deserializeAws_queryMetricAlarm = (output: any, context: __SerdeContext): 
     contents.Period = parseInt(output["Period"]);
   }
   if (output["Unit"] !== undefined) {
-    contents.Unit = output["Unit"];
+    contents.Unit = __expectString(output["Unit"]);
   }
   if (output["EvaluationPeriods"] !== undefined) {
     contents.EvaluationPeriods = parseInt(output["EvaluationPeriods"]);
@@ -5876,13 +5877,13 @@ const deserializeAws_queryMetricAlarm = (output: any, context: __SerdeContext): 
     contents.Threshold = parseFloat(output["Threshold"]);
   }
   if (output["ComparisonOperator"] !== undefined) {
-    contents.ComparisonOperator = output["ComparisonOperator"];
+    contents.ComparisonOperator = __expectString(output["ComparisonOperator"]);
   }
   if (output["TreatMissingData"] !== undefined) {
-    contents.TreatMissingData = output["TreatMissingData"];
+    contents.TreatMissingData = __expectString(output["TreatMissingData"]);
   }
   if (output["EvaluateLowSampleCountPercentile"] !== undefined) {
-    contents.EvaluateLowSampleCountPercentile = output["EvaluateLowSampleCountPercentile"];
+    contents.EvaluateLowSampleCountPercentile = __expectString(output["EvaluateLowSampleCountPercentile"]);
   }
   if (output.Metrics === "") {
     contents.Metrics = [];
@@ -5894,7 +5895,7 @@ const deserializeAws_queryMetricAlarm = (output: any, context: __SerdeContext): 
     );
   }
   if (output["ThresholdMetricId"] !== undefined) {
-    contents.ThresholdMetricId = output["ThresholdMetricId"];
+    contents.ThresholdMetricId = __expectString(output["ThresholdMetricId"]);
   }
   return contents;
 };
@@ -5931,16 +5932,16 @@ const deserializeAws_queryMetricDataQuery = (output: any, context: __SerdeContex
     Period: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   if (output["MetricStat"] !== undefined) {
     contents.MetricStat = deserializeAws_queryMetricStat(output["MetricStat"], context);
   }
   if (output["Expression"] !== undefined) {
-    contents.Expression = output["Expression"];
+    contents.Expression = __expectString(output["Expression"]);
   }
   if (output["Label"] !== undefined) {
-    contents.Label = output["Label"];
+    contents.Label = __expectString(output["Label"]);
   }
   if (output["ReturnData"] !== undefined) {
     contents.ReturnData = __parseBoolean(output["ReturnData"]);
@@ -5961,10 +5962,10 @@ const deserializeAws_queryMetricDataResult = (output: any, context: __SerdeConte
     Messages: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   if (output["Label"] !== undefined) {
-    contents.Label = output["Label"];
+    contents.Label = __expectString(output["Label"]);
   }
   if (output.Timestamps === "") {
     contents.Timestamps = [];
@@ -5982,7 +5983,7 @@ const deserializeAws_queryMetricDataResult = (output: any, context: __SerdeConte
     contents.Values = deserializeAws_queryDatapointValues(__getArrayIfSingleItem(output["Values"]["member"]), context);
   }
   if (output["StatusCode"] !== undefined) {
-    contents.StatusCode = output["StatusCode"];
+    contents.StatusCode = __expectString(output["StatusCode"]);
   }
   if (output.Messages === "") {
     contents.Messages = [];
@@ -6043,10 +6044,10 @@ const deserializeAws_queryMetricStat = (output: any, context: __SerdeContext): M
     contents.Period = parseInt(output["Period"]);
   }
   if (output["Stat"] !== undefined) {
-    contents.Stat = output["Stat"];
+    contents.Stat = __expectString(output["Stat"]);
   }
   if (output["Unit"] !== undefined) {
-    contents.Unit = output["Unit"];
+    contents.Unit = __expectString(output["Unit"]);
   }
   return contents;
 };
@@ -6073,7 +6074,7 @@ const deserializeAws_queryMetricStreamEntry = (output: any, context: __SerdeCont
     OutputFormat: undefined,
   };
   if (output["Arn"] !== undefined) {
-    contents.Arn = output["Arn"];
+    contents.Arn = __expectString(output["Arn"]);
   }
   if (output["CreationDate"] !== undefined) {
     contents.CreationDate = new Date(output["CreationDate"]);
@@ -6082,16 +6083,16 @@ const deserializeAws_queryMetricStreamEntry = (output: any, context: __SerdeCont
     contents.LastUpdateDate = new Date(output["LastUpdateDate"]);
   }
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["FirehoseArn"] !== undefined) {
-    contents.FirehoseArn = output["FirehoseArn"];
+    contents.FirehoseArn = __expectString(output["FirehoseArn"]);
   }
   if (output["State"] !== undefined) {
-    contents.State = output["State"];
+    contents.State = __expectString(output["State"]);
   }
   if (output["OutputFormat"] !== undefined) {
-    contents.OutputFormat = output["OutputFormat"];
+    contents.OutputFormat = __expectString(output["OutputFormat"]);
   }
   return contents;
 };
@@ -6101,7 +6102,7 @@ const deserializeAws_queryMetricStreamFilter = (output: any, context: __SerdeCon
     Namespace: undefined,
   };
   if (output["Namespace"] !== undefined) {
-    contents.Namespace = output["Namespace"];
+    contents.Namespace = __expectString(output["Namespace"]);
   }
   return contents;
 };
@@ -6125,7 +6126,7 @@ const deserializeAws_queryMissingRequiredParameterException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -6138,16 +6139,16 @@ const deserializeAws_queryPartialFailure = (output: any, context: __SerdeContext
     FailureDescription: undefined,
   };
   if (output["FailureResource"] !== undefined) {
-    contents.FailureResource = output["FailureResource"];
+    contents.FailureResource = __expectString(output["FailureResource"]);
   }
   if (output["ExceptionType"] !== undefined) {
-    contents.ExceptionType = output["ExceptionType"];
+    contents.ExceptionType = __expectString(output["ExceptionType"]);
   }
   if (output["FailureCode"] !== undefined) {
-    contents.FailureCode = output["FailureCode"];
+    contents.FailureCode = __expectString(output["FailureCode"]);
   }
   if (output["FailureDescription"] !== undefined) {
-    contents.FailureDescription = output["FailureDescription"];
+    contents.FailureDescription = __expectString(output["FailureDescription"]);
   }
   return contents;
 };
@@ -6189,7 +6190,7 @@ const deserializeAws_queryPutMetricStreamOutput = (output: any, context: __Serde
     Arn: undefined,
   };
   if (output["Arn"] !== undefined) {
-    contents.Arn = output["Arn"];
+    contents.Arn = __expectString(output["Arn"]);
   }
   return contents;
 };
@@ -6215,7 +6216,7 @@ const deserializeAws_queryResourceList = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6224,7 +6225,7 @@ const deserializeAws_queryResourceNotFound = (output: any, context: __SerdeConte
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -6239,13 +6240,13 @@ const deserializeAws_queryResourceNotFoundException = (
     Message: undefined,
   };
   if (output["ResourceType"] !== undefined) {
-    contents.ResourceType = output["ResourceType"];
+    contents.ResourceType = __expectString(output["ResourceType"]);
   }
   if (output["ResourceId"] !== undefined) {
-    contents.ResourceId = output["ResourceId"];
+    contents.ResourceId = __expectString(output["ResourceId"]);
   }
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -6269,10 +6270,10 @@ const deserializeAws_queryTag = (output: any, context: __SerdeContext): Tag => {
     Value: undefined,
   };
   if (output["Key"] !== undefined) {
-    contents.Key = output["Key"];
+    contents.Key = __expectString(output["Key"]);
   }
   if (output["Value"] !== undefined) {
-    contents.Value = output["Value"];
+    contents.Value = __expectString(output["Value"]);
   }
   return contents;
 };

--- a/clients/client-codeartifact/protocols/Aws_restJson1.ts
+++ b/clients/client-codeartifact/protocols/Aws_restJson1.ts
@@ -128,6 +128,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -2512,7 +2514,7 @@ export const deserializeAws_restJson1GetAuthorizationTokenCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.authorizationToken !== undefined && data.authorizationToken !== null) {
-    contents.authorizationToken = data.authorizationToken;
+    contents.authorizationToken = __expectString(data.authorizationToken);
   }
   if (data.expiration !== undefined && data.expiration !== null) {
     contents.expiration = new Date(Math.round(data.expiration * 1000));
@@ -2799,22 +2801,22 @@ export const deserializeAws_restJson1GetPackageVersionReadmeCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.format !== undefined && data.format !== null) {
-    contents.format = data.format;
+    contents.format = __expectString(data.format);
   }
   if (data.namespace !== undefined && data.namespace !== null) {
-    contents.namespace = data.namespace;
+    contents.namespace = __expectString(data.namespace);
   }
   if (data.package !== undefined && data.package !== null) {
-    contents.package = data.package;
+    contents.package = __expectString(data.package);
   }
   if (data.readme !== undefined && data.readme !== null) {
-    contents.readme = data.readme;
+    contents.readme = __expectString(data.readme);
   }
   if (data.version !== undefined && data.version !== null) {
-    contents.version = data.version;
+    contents.version = __expectString(data.version);
   }
   if (data.versionRevision !== undefined && data.versionRevision !== null) {
-    contents.versionRevision = data.versionRevision;
+    contents.versionRevision = __expectString(data.versionRevision);
   }
   return Promise.resolve(contents);
 };
@@ -2901,7 +2903,7 @@ export const deserializeAws_restJson1GetRepositoryEndpointCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.repositoryEndpoint !== undefined && data.repositoryEndpoint !== null) {
-    contents.repositoryEndpoint = data.repositoryEndpoint;
+    contents.repositoryEndpoint = __expectString(data.repositoryEndpoint);
   }
   return Promise.resolve(contents);
 };
@@ -3079,7 +3081,7 @@ export const deserializeAws_restJson1ListDomainsCommand = async (
     contents.domains = deserializeAws_restJson1DomainSummaryList(data.domains, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3159,7 +3161,7 @@ export const deserializeAws_restJson1ListPackagesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.packages !== undefined && data.packages !== null) {
     contents.packages = deserializeAws_restJson1PackageSummaryList(data.packages, context);
@@ -3258,22 +3260,22 @@ export const deserializeAws_restJson1ListPackageVersionAssetsCommand = async (
     contents.assets = deserializeAws_restJson1AssetSummaryList(data.assets, context);
   }
   if (data.format !== undefined && data.format !== null) {
-    contents.format = data.format;
+    contents.format = __expectString(data.format);
   }
   if (data.namespace !== undefined && data.namespace !== null) {
-    contents.namespace = data.namespace;
+    contents.namespace = __expectString(data.namespace);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.package !== undefined && data.package !== null) {
-    contents.package = data.package;
+    contents.package = __expectString(data.package);
   }
   if (data.version !== undefined && data.version !== null) {
-    contents.version = data.version;
+    contents.version = __expectString(data.version);
   }
   if (data.versionRevision !== undefined && data.versionRevision !== null) {
-    contents.versionRevision = data.versionRevision;
+    contents.versionRevision = __expectString(data.versionRevision);
   }
   return Promise.resolve(contents);
 };
@@ -3369,22 +3371,22 @@ export const deserializeAws_restJson1ListPackageVersionDependenciesCommand = asy
     contents.dependencies = deserializeAws_restJson1PackageDependencyList(data.dependencies, context);
   }
   if (data.format !== undefined && data.format !== null) {
-    contents.format = data.format;
+    contents.format = __expectString(data.format);
   }
   if (data.namespace !== undefined && data.namespace !== null) {
-    contents.namespace = data.namespace;
+    contents.namespace = __expectString(data.namespace);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.package !== undefined && data.package !== null) {
-    contents.package = data.package;
+    contents.package = __expectString(data.package);
   }
   if (data.version !== undefined && data.version !== null) {
-    contents.version = data.version;
+    contents.version = __expectString(data.version);
   }
   if (data.versionRevision !== undefined && data.versionRevision !== null) {
-    contents.versionRevision = data.versionRevision;
+    contents.versionRevision = __expectString(data.versionRevision);
   }
   return Promise.resolve(contents);
 };
@@ -3476,19 +3478,19 @@ export const deserializeAws_restJson1ListPackageVersionsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.defaultDisplayVersion !== undefined && data.defaultDisplayVersion !== null) {
-    contents.defaultDisplayVersion = data.defaultDisplayVersion;
+    contents.defaultDisplayVersion = __expectString(data.defaultDisplayVersion);
   }
   if (data.format !== undefined && data.format !== null) {
-    contents.format = data.format;
+    contents.format = __expectString(data.format);
   }
   if (data.namespace !== undefined && data.namespace !== null) {
-    contents.namespace = data.namespace;
+    contents.namespace = __expectString(data.namespace);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.package !== undefined && data.package !== null) {
-    contents.package = data.package;
+    contents.package = __expectString(data.package);
   }
   if (data.versions !== undefined && data.versions !== null) {
     contents.versions = deserializeAws_restJson1PackageVersionSummaryList(data.versions, context);
@@ -3579,7 +3581,7 @@ export const deserializeAws_restJson1ListRepositoriesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.repositories !== undefined && data.repositories !== null) {
     contents.repositories = deserializeAws_restJson1RepositorySummaryList(data.repositories, context);
@@ -3662,7 +3664,7 @@ export const deserializeAws_restJson1ListRepositoriesInDomainCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.repositories !== undefined && data.repositories !== null) {
     contents.repositories = deserializeAws_restJson1RepositorySummaryList(data.repositories, context);
@@ -4399,7 +4401,7 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -4418,13 +4420,13 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.resourceId !== undefined && data.resourceId !== null) {
-    contents.resourceId = data.resourceId;
+    contents.resourceId = __expectString(data.resourceId);
   }
   if (data.resourceType !== undefined && data.resourceType !== null) {
-    contents.resourceType = data.resourceType;
+    contents.resourceType = __expectString(data.resourceType);
   }
   return contents;
 };
@@ -4441,7 +4443,7 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -4460,13 +4462,13 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.resourceId !== undefined && data.resourceId !== null) {
-    contents.resourceId = data.resourceId;
+    contents.resourceId = __expectString(data.resourceId);
   }
   if (data.resourceType !== undefined && data.resourceType !== null) {
-    contents.resourceType = data.resourceType;
+    contents.resourceType = __expectString(data.resourceType);
   }
   return contents;
 };
@@ -4485,13 +4487,13 @@ const deserializeAws_restJson1ServiceQuotaExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.resourceId !== undefined && data.resourceId !== null) {
-    contents.resourceId = data.resourceId;
+    contents.resourceId = __expectString(data.resourceId);
   }
   if (data.resourceType !== undefined && data.resourceType !== null) {
-    contents.resourceType = data.resourceType;
+    contents.resourceType = __expectString(data.resourceType);
   }
   return contents;
 };
@@ -4512,7 +4514,7 @@ const deserializeAws_restJson1ThrottlingExceptionResponse = async (
   }
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -4530,10 +4532,10 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.reason !== undefined && data.reason !== null) {
-    contents.reason = data.reason;
+    contents.reason = __expectString(data.reason);
   }
   return contents;
 };
@@ -4619,7 +4621,7 @@ const deserializeAws_restJson1AssetHashes = (output: any, context: __SerdeContex
       }
       return {
         ...acc,
-        [key]: value,
+        [key]: __expectString(value) as any,
       };
     },
     {}
@@ -4632,8 +4634,8 @@ const deserializeAws_restJson1AssetSummary = (output: any, context: __SerdeConte
       output.hashes !== undefined && output.hashes !== null
         ? deserializeAws_restJson1AssetHashes(output.hashes, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    size: output.size !== undefined && output.size !== null ? output.size : undefined,
+    name: __expectString(output.name),
+    size: __expectNumber(output.size),
   } as any;
 };
 
@@ -4650,36 +4652,32 @@ const deserializeAws_restJson1AssetSummaryList = (output: any, context: __SerdeC
 
 const deserializeAws_restJson1DomainDescription = (output: any, context: __SerdeContext): DomainDescription => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    assetSizeBytes:
-      output.assetSizeBytes !== undefined && output.assetSizeBytes !== null ? output.assetSizeBytes : undefined,
+    arn: __expectString(output.arn),
+    assetSizeBytes: __expectNumber(output.assetSizeBytes),
     createdTime:
       output.createdTime !== undefined && output.createdTime !== null
         ? new Date(Math.round(output.createdTime * 1000))
         : undefined,
-    encryptionKey:
-      output.encryptionKey !== undefined && output.encryptionKey !== null ? output.encryptionKey : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    owner: output.owner !== undefined && output.owner !== null ? output.owner : undefined,
-    repositoryCount:
-      output.repositoryCount !== undefined && output.repositoryCount !== null ? output.repositoryCount : undefined,
-    s3BucketArn: output.s3BucketArn !== undefined && output.s3BucketArn !== null ? output.s3BucketArn : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    encryptionKey: __expectString(output.encryptionKey),
+    name: __expectString(output.name),
+    owner: __expectString(output.owner),
+    repositoryCount: __expectNumber(output.repositoryCount),
+    s3BucketArn: __expectString(output.s3BucketArn),
+    status: __expectString(output.status),
   } as any;
 };
 
 const deserializeAws_restJson1DomainSummary = (output: any, context: __SerdeContext): DomainSummary => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdTime:
       output.createdTime !== undefined && output.createdTime !== null
         ? new Date(Math.round(output.createdTime * 1000))
         : undefined,
-    encryptionKey:
-      output.encryptionKey !== undefined && output.encryptionKey !== null ? output.encryptionKey : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    owner: output.owner !== undefined && output.owner !== null ? output.owner : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    encryptionKey: __expectString(output.encryptionKey),
+    name: __expectString(output.name),
+    owner: __expectString(output.owner),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -4696,8 +4694,8 @@ const deserializeAws_restJson1DomainSummaryList = (output: any, context: __Serde
 
 const deserializeAws_restJson1LicenseInfo = (output: any, context: __SerdeContext): LicenseInfo => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    url: output.url !== undefined && output.url !== null ? output.url : undefined,
+    name: __expectString(output.name),
+    url: __expectString(output.url),
   } as any;
 };
 
@@ -4714,14 +4712,10 @@ const deserializeAws_restJson1LicenseInfoList = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1PackageDependency = (output: any, context: __SerdeContext): PackageDependency => {
   return {
-    dependencyType:
-      output.dependencyType !== undefined && output.dependencyType !== null ? output.dependencyType : undefined,
-    namespace: output.namespace !== undefined && output.namespace !== null ? output.namespace : undefined,
-    package: output.package !== undefined && output.package !== null ? output.package : undefined,
-    versionRequirement:
-      output.versionRequirement !== undefined && output.versionRequirement !== null
-        ? output.versionRequirement
-        : undefined,
+    dependencyType: __expectString(output.dependencyType),
+    namespace: __expectString(output.namespace),
+    package: __expectString(output.package),
+    versionRequirement: __expectString(output.versionRequirement),
   } as any;
 };
 
@@ -4738,9 +4732,9 @@ const deserializeAws_restJson1PackageDependencyList = (output: any, context: __S
 
 const deserializeAws_restJson1PackageSummary = (output: any, context: __SerdeContext): PackageSummary => {
   return {
-    format: output.format !== undefined && output.format !== null ? output.format : undefined,
-    namespace: output.namespace !== undefined && output.namespace !== null ? output.namespace : undefined,
-    package: output.package !== undefined && output.package !== null ? output.package : undefined,
+    format: __expectString(output.format),
+    namespace: __expectString(output.namespace),
+    package: __expectString(output.package),
   } as any;
 };
 
@@ -4760,34 +4754,31 @@ const deserializeAws_restJson1PackageVersionDescription = (
   context: __SerdeContext
 ): PackageVersionDescription => {
   return {
-    displayName: output.displayName !== undefined && output.displayName !== null ? output.displayName : undefined,
-    format: output.format !== undefined && output.format !== null ? output.format : undefined,
-    homePage: output.homePage !== undefined && output.homePage !== null ? output.homePage : undefined,
+    displayName: __expectString(output.displayName),
+    format: __expectString(output.format),
+    homePage: __expectString(output.homePage),
     licenses:
       output.licenses !== undefined && output.licenses !== null
         ? deserializeAws_restJson1LicenseInfoList(output.licenses, context)
         : undefined,
-    namespace: output.namespace !== undefined && output.namespace !== null ? output.namespace : undefined,
-    packageName: output.packageName !== undefined && output.packageName !== null ? output.packageName : undefined,
+    namespace: __expectString(output.namespace),
+    packageName: __expectString(output.packageName),
     publishedTime:
       output.publishedTime !== undefined && output.publishedTime !== null
         ? new Date(Math.round(output.publishedTime * 1000))
         : undefined,
-    revision: output.revision !== undefined && output.revision !== null ? output.revision : undefined,
-    sourceCodeRepository:
-      output.sourceCodeRepository !== undefined && output.sourceCodeRepository !== null
-        ? output.sourceCodeRepository
-        : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    summary: output.summary !== undefined && output.summary !== null ? output.summary : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    revision: __expectString(output.revision),
+    sourceCodeRepository: __expectString(output.sourceCodeRepository),
+    status: __expectString(output.status),
+    summary: __expectString(output.summary),
+    version: __expectString(output.version),
   } as any;
 };
 
 const deserializeAws_restJson1PackageVersionError = (output: any, context: __SerdeContext): PackageVersionError => {
   return {
-    errorCode: output.errorCode !== undefined && output.errorCode !== null ? output.errorCode : undefined,
-    errorMessage: output.errorMessage !== undefined && output.errorMessage !== null ? output.errorMessage : undefined,
+    errorCode: __expectString(output.errorCode),
+    errorMessage: __expectString(output.errorMessage),
   } as any;
 };
 
@@ -4808,9 +4799,9 @@ const deserializeAws_restJson1PackageVersionErrorMap = (
 
 const deserializeAws_restJson1PackageVersionSummary = (output: any, context: __SerdeContext): PackageVersionSummary => {
   return {
-    revision: output.revision !== undefined && output.revision !== null ? output.revision : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    revision: __expectString(output.revision),
+    status: __expectString(output.status),
+    version: __expectString(output.version),
   } as any;
 };
 
@@ -4830,19 +4821,16 @@ const deserializeAws_restJson1PackageVersionSummaryList = (
 
 const deserializeAws_restJson1RepositoryDescription = (output: any, context: __SerdeContext): RepositoryDescription => {
   return {
-    administratorAccount:
-      output.administratorAccount !== undefined && output.administratorAccount !== null
-        ? output.administratorAccount
-        : undefined,
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    domainName: output.domainName !== undefined && output.domainName !== null ? output.domainName : undefined,
-    domainOwner: output.domainOwner !== undefined && output.domainOwner !== null ? output.domainOwner : undefined,
+    administratorAccount: __expectString(output.administratorAccount),
+    arn: __expectString(output.arn),
+    description: __expectString(output.description),
+    domainName: __expectString(output.domainName),
+    domainOwner: __expectString(output.domainOwner),
     externalConnections:
       output.externalConnections !== undefined && output.externalConnections !== null
         ? deserializeAws_restJson1RepositoryExternalConnectionInfoList(output.externalConnections, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
     upstreams:
       output.upstreams !== undefined && output.upstreams !== null
         ? deserializeAws_restJson1UpstreamRepositoryInfoList(output.upstreams, context)
@@ -4855,13 +4843,9 @@ const deserializeAws_restJson1RepositoryExternalConnectionInfo = (
   context: __SerdeContext
 ): RepositoryExternalConnectionInfo => {
   return {
-    externalConnectionName:
-      output.externalConnectionName !== undefined && output.externalConnectionName !== null
-        ? output.externalConnectionName
-        : undefined,
-    packageFormat:
-      output.packageFormat !== undefined && output.packageFormat !== null ? output.packageFormat : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    externalConnectionName: __expectString(output.externalConnectionName),
+    packageFormat: __expectString(output.packageFormat),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -4881,15 +4865,12 @@ const deserializeAws_restJson1RepositoryExternalConnectionInfoList = (
 
 const deserializeAws_restJson1RepositorySummary = (output: any, context: __SerdeContext): RepositorySummary => {
   return {
-    administratorAccount:
-      output.administratorAccount !== undefined && output.administratorAccount !== null
-        ? output.administratorAccount
-        : undefined,
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    domainName: output.domainName !== undefined && output.domainName !== null ? output.domainName : undefined,
-    domainOwner: output.domainOwner !== undefined && output.domainOwner !== null ? output.domainOwner : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    administratorAccount: __expectString(output.administratorAccount),
+    arn: __expectString(output.arn),
+    description: __expectString(output.description),
+    domainName: __expectString(output.domainName),
+    domainOwner: __expectString(output.domainOwner),
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -4906,9 +4887,9 @@ const deserializeAws_restJson1RepositorySummaryList = (output: any, context: __S
 
 const deserializeAws_restJson1ResourcePolicy = (output: any, context: __SerdeContext): ResourcePolicy => {
   return {
-    document: output.document !== undefined && output.document !== null ? output.document : undefined,
-    resourceArn: output.resourceArn !== undefined && output.resourceArn !== null ? output.resourceArn : undefined,
-    revision: output.revision !== undefined && output.revision !== null ? output.revision : undefined,
+    document: __expectString(output.document),
+    resourceArn: __expectString(output.resourceArn),
+    revision: __expectString(output.revision),
   } as any;
 };
 
@@ -4917,8 +4898,8 @@ const deserializeAws_restJson1SuccessfulPackageVersionInfo = (
   context: __SerdeContext
 ): SuccessfulPackageVersionInfo => {
   return {
-    revision: output.revision !== undefined && output.revision !== null ? output.revision : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    revision: __expectString(output.revision),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -4942,8 +4923,8 @@ const deserializeAws_restJson1SuccessfulPackageVersionInfoMap = (
 
 const deserializeAws_restJson1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    key: __expectString(output.key),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -4963,8 +4944,7 @@ const deserializeAws_restJson1UpstreamRepositoryInfo = (
   context: __SerdeContext
 ): UpstreamRepositoryInfo => {
   return {
-    repositoryName:
-      output.repositoryName !== undefined && output.repositoryName !== null ? output.repositoryName : undefined,
+    repositoryName: __expectString(output.repositoryName),
   } as any;
 };
 

--- a/clients/client-codebuild/protocols/Aws_json1_1.ts
+++ b/clients/client-codebuild/protocols/Aws_json1_1.ts
@@ -234,7 +234,12 @@ import {
   WebhookFilter,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -4643,7 +4648,7 @@ const deserializeAws_json1_1AccountLimitExceededException = (
   context: __SerdeContext
 ): AccountLimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -4740,37 +4745,31 @@ const deserializeAws_json1_1BatchRestrictions = (output: any, context: __SerdeCo
       output.computeTypesAllowed !== undefined && output.computeTypesAllowed !== null
         ? deserializeAws_json1_1ComputeTypesAllowed(output.computeTypesAllowed, context)
         : undefined,
-    maximumBuildsAllowed:
-      output.maximumBuildsAllowed !== undefined && output.maximumBuildsAllowed !== null
-        ? output.maximumBuildsAllowed
-        : undefined,
+    maximumBuildsAllowed: __expectNumber(output.maximumBuildsAllowed),
   } as any;
 };
 
 const deserializeAws_json1_1Build = (output: any, context: __SerdeContext): Build => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     artifacts:
       output.artifacts !== undefined && output.artifacts !== null
         ? deserializeAws_json1_1BuildArtifacts(output.artifacts, context)
         : undefined,
-    buildBatchArn:
-      output.buildBatchArn !== undefined && output.buildBatchArn !== null ? output.buildBatchArn : undefined,
-    buildComplete:
-      output.buildComplete !== undefined && output.buildComplete !== null ? output.buildComplete : undefined,
-    buildNumber: output.buildNumber !== undefined && output.buildNumber !== null ? output.buildNumber : undefined,
-    buildStatus: output.buildStatus !== undefined && output.buildStatus !== null ? output.buildStatus : undefined,
+    buildBatchArn: __expectString(output.buildBatchArn),
+    buildComplete: __expectBoolean(output.buildComplete),
+    buildNumber: __expectNumber(output.buildNumber),
+    buildStatus: __expectString(output.buildStatus),
     cache:
       output.cache !== undefined && output.cache !== null
         ? deserializeAws_json1_1ProjectCache(output.cache, context)
         : undefined,
-    currentPhase: output.currentPhase !== undefined && output.currentPhase !== null ? output.currentPhase : undefined,
+    currentPhase: __expectString(output.currentPhase),
     debugSession:
       output.debugSession !== undefined && output.debugSession !== null
         ? deserializeAws_json1_1DebugSession(output.debugSession, context)
         : undefined,
-    encryptionKey:
-      output.encryptionKey !== undefined && output.encryptionKey !== null ? output.encryptionKey : undefined,
+    encryptionKey: __expectString(output.encryptionKey),
     endTime:
       output.endTime !== undefined && output.endTime !== null ? new Date(Math.round(output.endTime * 1000)) : undefined,
     environment:
@@ -4785,8 +4784,8 @@ const deserializeAws_json1_1Build = (output: any, context: __SerdeContext): Buil
       output.fileSystemLocations !== undefined && output.fileSystemLocations !== null
         ? deserializeAws_json1_1ProjectFileSystemLocations(output.fileSystemLocations, context)
         : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    initiator: output.initiator !== undefined && output.initiator !== null ? output.initiator : undefined,
+    id: __expectString(output.id),
+    initiator: __expectString(output.initiator),
     logs:
       output.logs !== undefined && output.logs !== null
         ? deserializeAws_json1_1LogsLocation(output.logs, context)
@@ -4799,19 +4798,13 @@ const deserializeAws_json1_1Build = (output: any, context: __SerdeContext): Buil
       output.phases !== undefined && output.phases !== null
         ? deserializeAws_json1_1BuildPhases(output.phases, context)
         : undefined,
-    projectName: output.projectName !== undefined && output.projectName !== null ? output.projectName : undefined,
-    queuedTimeoutInMinutes:
-      output.queuedTimeoutInMinutes !== undefined && output.queuedTimeoutInMinutes !== null
-        ? output.queuedTimeoutInMinutes
-        : undefined,
+    projectName: __expectString(output.projectName),
+    queuedTimeoutInMinutes: __expectNumber(output.queuedTimeoutInMinutes),
     reportArns:
       output.reportArns !== undefined && output.reportArns !== null
         ? deserializeAws_json1_1BuildReportArns(output.reportArns, context)
         : undefined,
-    resolvedSourceVersion:
-      output.resolvedSourceVersion !== undefined && output.resolvedSourceVersion !== null
-        ? output.resolvedSourceVersion
-        : undefined,
+    resolvedSourceVersion: __expectString(output.resolvedSourceVersion),
     secondaryArtifacts:
       output.secondaryArtifacts !== undefined && output.secondaryArtifacts !== null
         ? deserializeAws_json1_1BuildArtifactsList(output.secondaryArtifacts, context)
@@ -4824,19 +4817,17 @@ const deserializeAws_json1_1Build = (output: any, context: __SerdeContext): Buil
       output.secondarySources !== undefined && output.secondarySources !== null
         ? deserializeAws_json1_1ProjectSources(output.secondarySources, context)
         : undefined,
-    serviceRole: output.serviceRole !== undefined && output.serviceRole !== null ? output.serviceRole : undefined,
+    serviceRole: __expectString(output.serviceRole),
     source:
       output.source !== undefined && output.source !== null
         ? deserializeAws_json1_1ProjectSource(output.source, context)
         : undefined,
-    sourceVersion:
-      output.sourceVersion !== undefined && output.sourceVersion !== null ? output.sourceVersion : undefined,
+    sourceVersion: __expectString(output.sourceVersion),
     startTime:
       output.startTime !== undefined && output.startTime !== null
         ? new Date(Math.round(output.startTime * 1000))
         : undefined,
-    timeoutInMinutes:
-      output.timeoutInMinutes !== undefined && output.timeoutInMinutes !== null ? output.timeoutInMinutes : undefined,
+    timeoutInMinutes: __expectNumber(output.timeoutInMinutes),
     vpcConfig:
       output.vpcConfig !== undefined && output.vpcConfig !== null
         ? deserializeAws_json1_1VpcConfig(output.vpcConfig, context)
@@ -4846,25 +4837,13 @@ const deserializeAws_json1_1Build = (output: any, context: __SerdeContext): Buil
 
 const deserializeAws_json1_1BuildArtifacts = (output: any, context: __SerdeContext): BuildArtifacts => {
   return {
-    artifactIdentifier:
-      output.artifactIdentifier !== undefined && output.artifactIdentifier !== null
-        ? output.artifactIdentifier
-        : undefined,
-    bucketOwnerAccess:
-      output.bucketOwnerAccess !== undefined && output.bucketOwnerAccess !== null
-        ? output.bucketOwnerAccess
-        : undefined,
-    encryptionDisabled:
-      output.encryptionDisabled !== undefined && output.encryptionDisabled !== null
-        ? output.encryptionDisabled
-        : undefined,
-    location: output.location !== undefined && output.location !== null ? output.location : undefined,
-    md5sum: output.md5sum !== undefined && output.md5sum !== null ? output.md5sum : undefined,
-    overrideArtifactName:
-      output.overrideArtifactName !== undefined && output.overrideArtifactName !== null
-        ? output.overrideArtifactName
-        : undefined,
-    sha256sum: output.sha256sum !== undefined && output.sha256sum !== null ? output.sha256sum : undefined,
+    artifactIdentifier: __expectString(output.artifactIdentifier),
+    bucketOwnerAccess: __expectString(output.bucketOwnerAccess),
+    encryptionDisabled: __expectBoolean(output.encryptionDisabled),
+    location: __expectString(output.location),
+    md5sum: __expectString(output.md5sum),
+    overrideArtifactName: __expectBoolean(output.overrideArtifactName),
+    sha256sum: __expectString(output.sha256sum),
   } as any;
 };
 
@@ -4881,7 +4860,7 @@ const deserializeAws_json1_1BuildArtifactsList = (output: any, context: __SerdeC
 
 const deserializeAws_json1_1BuildBatch = (output: any, context: __SerdeContext): BuildBatch => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     artifacts:
       output.artifacts !== undefined && output.artifacts !== null
         ? deserializeAws_json1_1BuildArtifacts(output.artifacts, context)
@@ -4890,30 +4869,21 @@ const deserializeAws_json1_1BuildBatch = (output: any, context: __SerdeContext):
       output.buildBatchConfig !== undefined && output.buildBatchConfig !== null
         ? deserializeAws_json1_1ProjectBuildBatchConfig(output.buildBatchConfig, context)
         : undefined,
-    buildBatchNumber:
-      output.buildBatchNumber !== undefined && output.buildBatchNumber !== null ? output.buildBatchNumber : undefined,
-    buildBatchStatus:
-      output.buildBatchStatus !== undefined && output.buildBatchStatus !== null ? output.buildBatchStatus : undefined,
+    buildBatchNumber: __expectNumber(output.buildBatchNumber),
+    buildBatchStatus: __expectString(output.buildBatchStatus),
     buildGroups:
       output.buildGroups !== undefined && output.buildGroups !== null
         ? deserializeAws_json1_1BuildGroups(output.buildGroups, context)
         : undefined,
-    buildTimeoutInMinutes:
-      output.buildTimeoutInMinutes !== undefined && output.buildTimeoutInMinutes !== null
-        ? output.buildTimeoutInMinutes
-        : undefined,
+    buildTimeoutInMinutes: __expectNumber(output.buildTimeoutInMinutes),
     cache:
       output.cache !== undefined && output.cache !== null
         ? deserializeAws_json1_1ProjectCache(output.cache, context)
         : undefined,
-    complete: output.complete !== undefined && output.complete !== null ? output.complete : undefined,
-    currentPhase: output.currentPhase !== undefined && output.currentPhase !== null ? output.currentPhase : undefined,
-    debugSessionEnabled:
-      output.debugSessionEnabled !== undefined && output.debugSessionEnabled !== null
-        ? output.debugSessionEnabled
-        : undefined,
-    encryptionKey:
-      output.encryptionKey !== undefined && output.encryptionKey !== null ? output.encryptionKey : undefined,
+    complete: __expectBoolean(output.complete),
+    currentPhase: __expectString(output.currentPhase),
+    debugSessionEnabled: __expectBoolean(output.debugSessionEnabled),
+    encryptionKey: __expectString(output.encryptionKey),
     endTime:
       output.endTime !== undefined && output.endTime !== null ? new Date(Math.round(output.endTime * 1000)) : undefined,
     environment:
@@ -4924,8 +4894,8 @@ const deserializeAws_json1_1BuildBatch = (output: any, context: __SerdeContext):
       output.fileSystemLocations !== undefined && output.fileSystemLocations !== null
         ? deserializeAws_json1_1ProjectFileSystemLocations(output.fileSystemLocations, context)
         : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    initiator: output.initiator !== undefined && output.initiator !== null ? output.initiator : undefined,
+    id: __expectString(output.id),
+    initiator: __expectString(output.initiator),
     logConfig:
       output.logConfig !== undefined && output.logConfig !== null
         ? deserializeAws_json1_1LogsConfig(output.logConfig, context)
@@ -4934,15 +4904,9 @@ const deserializeAws_json1_1BuildBatch = (output: any, context: __SerdeContext):
       output.phases !== undefined && output.phases !== null
         ? deserializeAws_json1_1BuildBatchPhases(output.phases, context)
         : undefined,
-    projectName: output.projectName !== undefined && output.projectName !== null ? output.projectName : undefined,
-    queuedTimeoutInMinutes:
-      output.queuedTimeoutInMinutes !== undefined && output.queuedTimeoutInMinutes !== null
-        ? output.queuedTimeoutInMinutes
-        : undefined,
-    resolvedSourceVersion:
-      output.resolvedSourceVersion !== undefined && output.resolvedSourceVersion !== null
-        ? output.resolvedSourceVersion
-        : undefined,
+    projectName: __expectString(output.projectName),
+    queuedTimeoutInMinutes: __expectNumber(output.queuedTimeoutInMinutes),
+    resolvedSourceVersion: __expectString(output.resolvedSourceVersion),
     secondaryArtifacts:
       output.secondaryArtifacts !== undefined && output.secondaryArtifacts !== null
         ? deserializeAws_json1_1BuildArtifactsList(output.secondaryArtifacts, context)
@@ -4955,13 +4919,12 @@ const deserializeAws_json1_1BuildBatch = (output: any, context: __SerdeContext):
       output.secondarySources !== undefined && output.secondarySources !== null
         ? deserializeAws_json1_1ProjectSources(output.secondarySources, context)
         : undefined,
-    serviceRole: output.serviceRole !== undefined && output.serviceRole !== null ? output.serviceRole : undefined,
+    serviceRole: __expectString(output.serviceRole),
     source:
       output.source !== undefined && output.source !== null
         ? deserializeAws_json1_1ProjectSource(output.source, context)
         : undefined,
-    sourceVersion:
-      output.sourceVersion !== undefined && output.sourceVersion !== null ? output.sourceVersion : undefined,
+    sourceVersion: __expectString(output.sourceVersion),
     startTime:
       output.startTime !== undefined && output.startTime !== null
         ? new Date(Math.round(output.startTime * 1000))
@@ -4991,7 +4954,7 @@ const deserializeAws_json1_1BuildBatchIds = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -5001,14 +4964,11 @@ const deserializeAws_json1_1BuildBatchPhase = (output: any, context: __SerdeCont
       output.contexts !== undefined && output.contexts !== null
         ? deserializeAws_json1_1PhaseContexts(output.contexts, context)
         : undefined,
-    durationInSeconds:
-      output.durationInSeconds !== undefined && output.durationInSeconds !== null
-        ? output.durationInSeconds
-        : undefined,
+    durationInSeconds: __expectNumber(output.durationInSeconds),
     endTime:
       output.endTime !== undefined && output.endTime !== null ? new Date(Math.round(output.endTime * 1000)) : undefined,
-    phaseStatus: output.phaseStatus !== undefined && output.phaseStatus !== null ? output.phaseStatus : undefined,
-    phaseType: output.phaseType !== undefined && output.phaseType !== null ? output.phaseType : undefined,
+    phaseStatus: __expectString(output.phaseStatus),
+    phaseType: __expectString(output.phaseType),
     startTime:
       output.startTime !== undefined && output.startTime !== null
         ? new Date(Math.round(output.startTime * 1000))
@@ -5037,9 +4997,8 @@ const deserializeAws_json1_1BuildGroup = (output: any, context: __SerdeContext):
       output.dependsOn !== undefined && output.dependsOn !== null
         ? deserializeAws_json1_1Identifiers(output.dependsOn, context)
         : undefined,
-    identifier: output.identifier !== undefined && output.identifier !== null ? output.identifier : undefined,
-    ignoreFailure:
-      output.ignoreFailure !== undefined && output.ignoreFailure !== null ? output.ignoreFailure : undefined,
+    identifier: __expectString(output.identifier),
+    ignoreFailure: __expectBoolean(output.ignoreFailure),
     priorBuildSummaryList:
       output.priorBuildSummaryList !== undefined && output.priorBuildSummaryList !== null
         ? deserializeAws_json1_1BuildSummaries(output.priorBuildSummaryList, context)
@@ -5065,14 +5024,14 @@ const deserializeAws_json1_1BuildIds = (output: any, context: __SerdeContext): s
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1BuildNotDeleted = (output: any, context: __SerdeContext): BuildNotDeleted => {
   return {
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    statusCode: output.statusCode !== undefined && output.statusCode !== null ? output.statusCode : undefined,
+    id: __expectString(output.id),
+    statusCode: __expectString(output.statusCode),
   } as any;
 };
 
@@ -5082,14 +5041,11 @@ const deserializeAws_json1_1BuildPhase = (output: any, context: __SerdeContext):
       output.contexts !== undefined && output.contexts !== null
         ? deserializeAws_json1_1PhaseContexts(output.contexts, context)
         : undefined,
-    durationInSeconds:
-      output.durationInSeconds !== undefined && output.durationInSeconds !== null
-        ? output.durationInSeconds
-        : undefined,
+    durationInSeconds: __expectNumber(output.durationInSeconds),
     endTime:
       output.endTime !== undefined && output.endTime !== null ? new Date(Math.round(output.endTime * 1000)) : undefined,
-    phaseStatus: output.phaseStatus !== undefined && output.phaseStatus !== null ? output.phaseStatus : undefined,
-    phaseType: output.phaseType !== undefined && output.phaseType !== null ? output.phaseType : undefined,
+    phaseStatus: __expectString(output.phaseStatus),
+    phaseType: __expectString(output.phaseType),
     startTime:
       output.startTime !== undefined && output.startTime !== null
         ? new Date(Math.round(output.startTime * 1000))
@@ -5115,7 +5071,7 @@ const deserializeAws_json1_1BuildReportArns = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -5143,8 +5099,8 @@ const deserializeAws_json1_1BuildsNotDeleted = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1BuildStatusConfig = (output: any, context: __SerdeContext): BuildStatusConfig => {
   return {
-    context: output.context !== undefined && output.context !== null ? output.context : undefined,
-    targetUrl: output.targetUrl !== undefined && output.targetUrl !== null ? output.targetUrl : undefined,
+    context: __expectString(output.context),
+    targetUrl: __expectString(output.targetUrl),
   } as any;
 };
 
@@ -5161,8 +5117,8 @@ const deserializeAws_json1_1BuildSummaries = (output: any, context: __SerdeConte
 
 const deserializeAws_json1_1BuildSummary = (output: any, context: __SerdeContext): BuildSummary => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    buildStatus: output.buildStatus !== undefined && output.buildStatus !== null ? output.buildStatus : undefined,
+    arn: __expectString(output.arn),
+    buildStatus: __expectString(output.buildStatus),
     primaryArtifact:
       output.primaryArtifact !== undefined && output.primaryArtifact !== null
         ? deserializeAws_json1_1ResolvedArtifact(output.primaryArtifact, context)
@@ -5180,33 +5136,25 @@ const deserializeAws_json1_1BuildSummary = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_1CloudWatchLogsConfig = (output: any, context: __SerdeContext): CloudWatchLogsConfig => {
   return {
-    groupName: output.groupName !== undefined && output.groupName !== null ? output.groupName : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    streamName: output.streamName !== undefined && output.streamName !== null ? output.streamName : undefined,
+    groupName: __expectString(output.groupName),
+    status: __expectString(output.status),
+    streamName: __expectString(output.streamName),
   } as any;
 };
 
 const deserializeAws_json1_1CodeCoverage = (output: any, context: __SerdeContext): CodeCoverage => {
   return {
-    branchCoveragePercentage:
-      output.branchCoveragePercentage !== undefined && output.branchCoveragePercentage !== null
-        ? output.branchCoveragePercentage
-        : undefined,
-    branchesCovered:
-      output.branchesCovered !== undefined && output.branchesCovered !== null ? output.branchesCovered : undefined,
-    branchesMissed:
-      output.branchesMissed !== undefined && output.branchesMissed !== null ? output.branchesMissed : undefined,
+    branchCoveragePercentage: __expectNumber(output.branchCoveragePercentage),
+    branchesCovered: __expectNumber(output.branchesCovered),
+    branchesMissed: __expectNumber(output.branchesMissed),
     expired:
       output.expired !== undefined && output.expired !== null ? new Date(Math.round(output.expired * 1000)) : undefined,
-    filePath: output.filePath !== undefined && output.filePath !== null ? output.filePath : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    lineCoveragePercentage:
-      output.lineCoveragePercentage !== undefined && output.lineCoveragePercentage !== null
-        ? output.lineCoveragePercentage
-        : undefined,
-    linesCovered: output.linesCovered !== undefined && output.linesCovered !== null ? output.linesCovered : undefined,
-    linesMissed: output.linesMissed !== undefined && output.linesMissed !== null ? output.linesMissed : undefined,
-    reportARN: output.reportARN !== undefined && output.reportARN !== null ? output.reportARN : undefined,
+    filePath: __expectString(output.filePath),
+    id: __expectString(output.id),
+    lineCoveragePercentage: __expectNumber(output.lineCoveragePercentage),
+    linesCovered: __expectNumber(output.linesCovered),
+    linesMissed: __expectNumber(output.linesMissed),
+    reportARN: __expectString(output.reportARN),
   } as any;
 };
 
@@ -5215,20 +5163,12 @@ const deserializeAws_json1_1CodeCoverageReportSummary = (
   context: __SerdeContext
 ): CodeCoverageReportSummary => {
   return {
-    branchCoveragePercentage:
-      output.branchCoveragePercentage !== undefined && output.branchCoveragePercentage !== null
-        ? output.branchCoveragePercentage
-        : undefined,
-    branchesCovered:
-      output.branchesCovered !== undefined && output.branchesCovered !== null ? output.branchesCovered : undefined,
-    branchesMissed:
-      output.branchesMissed !== undefined && output.branchesMissed !== null ? output.branchesMissed : undefined,
-    lineCoveragePercentage:
-      output.lineCoveragePercentage !== undefined && output.lineCoveragePercentage !== null
-        ? output.lineCoveragePercentage
-        : undefined,
-    linesCovered: output.linesCovered !== undefined && output.linesCovered !== null ? output.linesCovered : undefined,
-    linesMissed: output.linesMissed !== undefined && output.linesMissed !== null ? output.linesMissed : undefined,
+    branchCoveragePercentage: __expectNumber(output.branchCoveragePercentage),
+    branchesCovered: __expectNumber(output.branchesCovered),
+    branchesMissed: __expectNumber(output.branchesMissed),
+    lineCoveragePercentage: __expectNumber(output.lineCoveragePercentage),
+    linesCovered: __expectNumber(output.linesCovered),
+    linesMissed: __expectNumber(output.linesMissed),
   } as any;
 };
 
@@ -5250,7 +5190,7 @@ const deserializeAws_json1_1ComputeTypesAllowed = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -5286,10 +5226,8 @@ const deserializeAws_json1_1CreateWebhookOutput = (output: any, context: __Serde
 
 const deserializeAws_json1_1DebugSession = (output: any, context: __SerdeContext): DebugSession => {
   return {
-    sessionEnabled:
-      output.sessionEnabled !== undefined && output.sessionEnabled !== null ? output.sessionEnabled : undefined,
-    sessionTarget:
-      output.sessionTarget !== undefined && output.sessionTarget !== null ? output.sessionTarget : undefined,
+    sessionEnabled: __expectBoolean(output.sessionEnabled),
+    sessionTarget: __expectString(output.sessionTarget),
   } as any;
 };
 
@@ -5303,7 +5241,7 @@ const deserializeAws_json1_1DeleteBuildBatchOutput = (output: any, context: __Se
       output.buildsNotDeleted !== undefined && output.buildsNotDeleted !== null
         ? deserializeAws_json1_1BuildsNotDeleted(output.buildsNotDeleted, context)
         : undefined,
-    statusCode: output.statusCode !== undefined && output.statusCode !== null ? output.statusCode : undefined,
+    statusCode: __expectString(output.statusCode),
   } as any;
 };
 
@@ -5334,7 +5272,7 @@ const deserializeAws_json1_1DeleteSourceCredentialsOutput = (
   context: __SerdeContext
 ): DeleteSourceCredentialsOutput => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
   } as any;
 };
 
@@ -5351,7 +5289,7 @@ const deserializeAws_json1_1DescribeCodeCoveragesOutput = (
       output.codeCoverages !== undefined && output.codeCoverages !== null
         ? deserializeAws_json1_1CodeCoverages(output.codeCoverages, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -5360,7 +5298,7 @@ const deserializeAws_json1_1DescribeTestCasesOutput = (
   context: __SerdeContext
 ): DescribeTestCasesOutput => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     testCases:
       output.testCases !== undefined && output.testCases !== null
         ? deserializeAws_json1_1TestCases(output.testCases, context)
@@ -5370,8 +5308,8 @@ const deserializeAws_json1_1DescribeTestCasesOutput = (
 
 const deserializeAws_json1_1EnvironmentImage = (output: any, context: __SerdeContext): EnvironmentImage => {
   return {
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    description: __expectString(output.description),
+    name: __expectString(output.name),
     versions:
       output.versions !== undefined && output.versions !== null
         ? deserializeAws_json1_1ImageVersions(output.versions, context)
@@ -5396,7 +5334,7 @@ const deserializeAws_json1_1EnvironmentLanguage = (output: any, context: __Serde
       output.images !== undefined && output.images !== null
         ? deserializeAws_json1_1EnvironmentImages(output.images, context)
         : undefined,
-    language: output.language !== undefined && output.language !== null ? output.language : undefined,
+    language: __expectString(output.language),
   } as any;
 };
 
@@ -5417,7 +5355,7 @@ const deserializeAws_json1_1EnvironmentPlatform = (output: any, context: __Serde
       output.languages !== undefined && output.languages !== null
         ? deserializeAws_json1_1EnvironmentLanguages(output.languages, context)
         : undefined,
-    platform: output.platform !== undefined && output.platform !== null ? output.platform : undefined,
+    platform: __expectString(output.platform),
   } as any;
 };
 
@@ -5434,9 +5372,9 @@ const deserializeAws_json1_1EnvironmentPlatforms = (output: any, context: __Serd
 
 const deserializeAws_json1_1EnvironmentVariable = (output: any, context: __SerdeContext): EnvironmentVariable => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    name: __expectString(output.name),
+    type: __expectString(output.type),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -5456,8 +5394,8 @@ const deserializeAws_json1_1ExportedEnvironmentVariable = (
   context: __SerdeContext
 ): ExportedEnvironmentVariable => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    name: __expectString(output.name),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -5518,14 +5456,13 @@ const deserializeAws_json1_1GetResourcePolicyOutput = (
   context: __SerdeContext
 ): GetResourcePolicyOutput => {
   return {
-    policy: output.policy !== undefined && output.policy !== null ? output.policy : undefined,
+    policy: __expectString(output.policy),
   } as any;
 };
 
 const deserializeAws_json1_1GitSubmodulesConfig = (output: any, context: __SerdeContext): GitSubmodulesConfig => {
   return {
-    fetchSubmodules:
-      output.fetchSubmodules !== undefined && output.fetchSubmodules !== null ? output.fetchSubmodules : undefined,
+    fetchSubmodules: __expectBoolean(output.fetchSubmodules),
   } as any;
 };
 
@@ -5536,7 +5473,7 @@ const deserializeAws_json1_1Identifiers = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -5547,7 +5484,7 @@ const deserializeAws_json1_1ImageVersions = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -5556,7 +5493,7 @@ const deserializeAws_json1_1ImportSourceCredentialsOutput = (
   context: __SerdeContext
 ): ImportSourceCredentialsOutput => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
   } as any;
 };
 
@@ -5569,7 +5506,7 @@ const deserializeAws_json1_1InvalidateProjectCacheOutput = (
 
 const deserializeAws_json1_1InvalidInputException = (output: any, context: __SerdeContext): InvalidInputException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -5582,7 +5519,7 @@ const deserializeAws_json1_1ListBuildBatchesForProjectOutput = (
       output.ids !== undefined && output.ids !== null
         ? deserializeAws_json1_1BuildBatchIds(output.ids, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -5592,7 +5529,7 @@ const deserializeAws_json1_1ListBuildBatchesOutput = (output: any, context: __Se
       output.ids !== undefined && output.ids !== null
         ? deserializeAws_json1_1BuildBatchIds(output.ids, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -5603,7 +5540,7 @@ const deserializeAws_json1_1ListBuildsForProjectOutput = (
   return {
     ids:
       output.ids !== undefined && output.ids !== null ? deserializeAws_json1_1BuildIds(output.ids, context) : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -5611,7 +5548,7 @@ const deserializeAws_json1_1ListBuildsOutput = (output: any, context: __SerdeCon
   return {
     ids:
       output.ids !== undefined && output.ids !== null ? deserializeAws_json1_1BuildIds(output.ids, context) : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -5629,7 +5566,7 @@ const deserializeAws_json1_1ListCuratedEnvironmentImagesOutput = (
 
 const deserializeAws_json1_1ListProjectsOutput = (output: any, context: __SerdeContext): ListProjectsOutput => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     projects:
       output.projects !== undefined && output.projects !== null
         ? deserializeAws_json1_1ProjectNames(output.projects, context)
@@ -5639,7 +5576,7 @@ const deserializeAws_json1_1ListProjectsOutput = (output: any, context: __SerdeC
 
 const deserializeAws_json1_1ListReportGroupsOutput = (output: any, context: __SerdeContext): ListReportGroupsOutput => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     reportGroups:
       output.reportGroups !== undefined && output.reportGroups !== null
         ? deserializeAws_json1_1ReportGroupArns(output.reportGroups, context)
@@ -5652,7 +5589,7 @@ const deserializeAws_json1_1ListReportsForReportGroupOutput = (
   context: __SerdeContext
 ): ListReportsForReportGroupOutput => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     reports:
       output.reports !== undefined && output.reports !== null
         ? deserializeAws_json1_1ReportArns(output.reports, context)
@@ -5662,7 +5599,7 @@ const deserializeAws_json1_1ListReportsForReportGroupOutput = (
 
 const deserializeAws_json1_1ListReportsOutput = (output: any, context: __SerdeContext): ListReportsOutput => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     reports:
       output.reports !== undefined && output.reports !== null
         ? deserializeAws_json1_1ReportArns(output.reports, context)
@@ -5675,7 +5612,7 @@ const deserializeAws_json1_1ListSharedProjectsOutput = (
   context: __SerdeContext
 ): ListSharedProjectsOutput => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     projects:
       output.projects !== undefined && output.projects !== null
         ? deserializeAws_json1_1ProjectArns(output.projects, context)
@@ -5688,7 +5625,7 @@ const deserializeAws_json1_1ListSharedReportGroupsOutput = (
   context: __SerdeContext
 ): ListSharedReportGroupsOutput => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     reportGroups:
       output.reportGroups !== undefined && output.reportGroups !== null
         ? deserializeAws_json1_1ReportGroupArns(output.reportGroups, context)
@@ -5727,42 +5664,36 @@ const deserializeAws_json1_1LogsLocation = (output: any, context: __SerdeContext
       output.cloudWatchLogs !== undefined && output.cloudWatchLogs !== null
         ? deserializeAws_json1_1CloudWatchLogsConfig(output.cloudWatchLogs, context)
         : undefined,
-    cloudWatchLogsArn:
-      output.cloudWatchLogsArn !== undefined && output.cloudWatchLogsArn !== null
-        ? output.cloudWatchLogsArn
-        : undefined,
-    deepLink: output.deepLink !== undefined && output.deepLink !== null ? output.deepLink : undefined,
-    groupName: output.groupName !== undefined && output.groupName !== null ? output.groupName : undefined,
-    s3DeepLink: output.s3DeepLink !== undefined && output.s3DeepLink !== null ? output.s3DeepLink : undefined,
+    cloudWatchLogsArn: __expectString(output.cloudWatchLogsArn),
+    deepLink: __expectString(output.deepLink),
+    groupName: __expectString(output.groupName),
+    s3DeepLink: __expectString(output.s3DeepLink),
     s3Logs:
       output.s3Logs !== undefined && output.s3Logs !== null
         ? deserializeAws_json1_1S3LogsConfig(output.s3Logs, context)
         : undefined,
-    s3LogsArn: output.s3LogsArn !== undefined && output.s3LogsArn !== null ? output.s3LogsArn : undefined,
-    streamName: output.streamName !== undefined && output.streamName !== null ? output.streamName : undefined,
+    s3LogsArn: __expectString(output.s3LogsArn),
+    streamName: __expectString(output.streamName),
   } as any;
 };
 
 const deserializeAws_json1_1NetworkInterface = (output: any, context: __SerdeContext): NetworkInterface => {
   return {
-    networkInterfaceId:
-      output.networkInterfaceId !== undefined && output.networkInterfaceId !== null
-        ? output.networkInterfaceId
-        : undefined,
-    subnetId: output.subnetId !== undefined && output.subnetId !== null ? output.subnetId : undefined,
+    networkInterfaceId: __expectString(output.networkInterfaceId),
+    subnetId: __expectString(output.subnetId),
   } as any;
 };
 
 const deserializeAws_json1_1OAuthProviderException = (output: any, context: __SerdeContext): OAuthProviderException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1PhaseContext = (output: any, context: __SerdeContext): PhaseContext => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    statusCode: output.statusCode !== undefined && output.statusCode !== null ? output.statusCode : undefined,
+    message: __expectString(output.message),
+    statusCode: __expectString(output.statusCode),
   } as any;
 };
 
@@ -5779,7 +5710,7 @@ const deserializeAws_json1_1PhaseContexts = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1Project = (output: any, context: __SerdeContext): Project => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     artifacts:
       output.artifacts !== undefined && output.artifacts !== null
         ? deserializeAws_json1_1ProjectArtifacts(output.artifacts, context)
@@ -5796,15 +5727,11 @@ const deserializeAws_json1_1Project = (output: any, context: __SerdeContext): Pr
       output.cache !== undefined && output.cache !== null
         ? deserializeAws_json1_1ProjectCache(output.cache, context)
         : undefined,
-    concurrentBuildLimit:
-      output.concurrentBuildLimit !== undefined && output.concurrentBuildLimit !== null
-        ? output.concurrentBuildLimit
-        : undefined,
+    concurrentBuildLimit: __expectNumber(output.concurrentBuildLimit),
     created:
       output.created !== undefined && output.created !== null ? new Date(Math.round(output.created * 1000)) : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    encryptionKey:
-      output.encryptionKey !== undefined && output.encryptionKey !== null ? output.encryptionKey : undefined,
+    description: __expectString(output.description),
+    encryptionKey: __expectString(output.encryptionKey),
     environment:
       output.environment !== undefined && output.environment !== null
         ? deserializeAws_json1_1ProjectEnvironment(output.environment, context)
@@ -5821,11 +5748,8 @@ const deserializeAws_json1_1Project = (output: any, context: __SerdeContext): Pr
       output.logsConfig !== undefined && output.logsConfig !== null
         ? deserializeAws_json1_1LogsConfig(output.logsConfig, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    queuedTimeoutInMinutes:
-      output.queuedTimeoutInMinutes !== undefined && output.queuedTimeoutInMinutes !== null
-        ? output.queuedTimeoutInMinutes
-        : undefined,
+    name: __expectString(output.name),
+    queuedTimeoutInMinutes: __expectNumber(output.queuedTimeoutInMinutes),
     secondaryArtifacts:
       output.secondaryArtifacts !== undefined && output.secondaryArtifacts !== null
         ? deserializeAws_json1_1ProjectArtifactsList(output.secondaryArtifacts, context)
@@ -5838,19 +5762,17 @@ const deserializeAws_json1_1Project = (output: any, context: __SerdeContext): Pr
       output.secondarySources !== undefined && output.secondarySources !== null
         ? deserializeAws_json1_1ProjectSources(output.secondarySources, context)
         : undefined,
-    serviceRole: output.serviceRole !== undefined && output.serviceRole !== null ? output.serviceRole : undefined,
+    serviceRole: __expectString(output.serviceRole),
     source:
       output.source !== undefined && output.source !== null
         ? deserializeAws_json1_1ProjectSource(output.source, context)
         : undefined,
-    sourceVersion:
-      output.sourceVersion !== undefined && output.sourceVersion !== null ? output.sourceVersion : undefined,
+    sourceVersion: __expectString(output.sourceVersion),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_json1_1TagList(output.tags, context)
         : undefined,
-    timeoutInMinutes:
-      output.timeoutInMinutes !== undefined && output.timeoutInMinutes !== null ? output.timeoutInMinutes : undefined,
+    timeoutInMinutes: __expectNumber(output.timeoutInMinutes),
     vpcConfig:
       output.vpcConfig !== undefined && output.vpcConfig !== null
         ? deserializeAws_json1_1VpcConfig(output.vpcConfig, context)
@@ -5869,35 +5791,22 @@ const deserializeAws_json1_1ProjectArns = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1ProjectArtifacts = (output: any, context: __SerdeContext): ProjectArtifacts => {
   return {
-    artifactIdentifier:
-      output.artifactIdentifier !== undefined && output.artifactIdentifier !== null
-        ? output.artifactIdentifier
-        : undefined,
-    bucketOwnerAccess:
-      output.bucketOwnerAccess !== undefined && output.bucketOwnerAccess !== null
-        ? output.bucketOwnerAccess
-        : undefined,
-    encryptionDisabled:
-      output.encryptionDisabled !== undefined && output.encryptionDisabled !== null
-        ? output.encryptionDisabled
-        : undefined,
-    location: output.location !== undefined && output.location !== null ? output.location : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    namespaceType:
-      output.namespaceType !== undefined && output.namespaceType !== null ? output.namespaceType : undefined,
-    overrideArtifactName:
-      output.overrideArtifactName !== undefined && output.overrideArtifactName !== null
-        ? output.overrideArtifactName
-        : undefined,
-    packaging: output.packaging !== undefined && output.packaging !== null ? output.packaging : undefined,
-    path: output.path !== undefined && output.path !== null ? output.path : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    artifactIdentifier: __expectString(output.artifactIdentifier),
+    bucketOwnerAccess: __expectString(output.bucketOwnerAccess),
+    encryptionDisabled: __expectBoolean(output.encryptionDisabled),
+    location: __expectString(output.location),
+    name: __expectString(output.name),
+    namespaceType: __expectString(output.namespaceType),
+    overrideArtifactName: __expectBoolean(output.overrideArtifactName),
+    packaging: __expectString(output.packaging),
+    path: __expectString(output.path),
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -5914,9 +5823,8 @@ const deserializeAws_json1_1ProjectArtifactsList = (output: any, context: __Serd
 
 const deserializeAws_json1_1ProjectBadge = (output: any, context: __SerdeContext): ProjectBadge => {
   return {
-    badgeEnabled: output.badgeEnabled !== undefined && output.badgeEnabled !== null ? output.badgeEnabled : undefined,
-    badgeRequestUrl:
-      output.badgeRequestUrl !== undefined && output.badgeRequestUrl !== null ? output.badgeRequestUrl : undefined,
+    badgeEnabled: __expectBoolean(output.badgeEnabled),
+    badgeRequestUrl: __expectString(output.badgeRequestUrl),
   } as any;
 };
 
@@ -5925,26 +5833,24 @@ const deserializeAws_json1_1ProjectBuildBatchConfig = (
   context: __SerdeContext
 ): ProjectBuildBatchConfig => {
   return {
-    combineArtifacts:
-      output.combineArtifacts !== undefined && output.combineArtifacts !== null ? output.combineArtifacts : undefined,
+    combineArtifacts: __expectBoolean(output.combineArtifacts),
     restrictions:
       output.restrictions !== undefined && output.restrictions !== null
         ? deserializeAws_json1_1BatchRestrictions(output.restrictions, context)
         : undefined,
-    serviceRole: output.serviceRole !== undefined && output.serviceRole !== null ? output.serviceRole : undefined,
-    timeoutInMins:
-      output.timeoutInMins !== undefined && output.timeoutInMins !== null ? output.timeoutInMins : undefined,
+    serviceRole: __expectString(output.serviceRole),
+    timeoutInMins: __expectNumber(output.timeoutInMins),
   } as any;
 };
 
 const deserializeAws_json1_1ProjectCache = (output: any, context: __SerdeContext): ProjectCache => {
   return {
-    location: output.location !== undefined && output.location !== null ? output.location : undefined,
+    location: __expectString(output.location),
     modes:
       output.modes !== undefined && output.modes !== null
         ? deserializeAws_json1_1ProjectCacheModes(output.modes, context)
         : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -5955,30 +5861,26 @@ const deserializeAws_json1_1ProjectCacheModes = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1ProjectEnvironment = (output: any, context: __SerdeContext): ProjectEnvironment => {
   return {
-    certificate: output.certificate !== undefined && output.certificate !== null ? output.certificate : undefined,
-    computeType: output.computeType !== undefined && output.computeType !== null ? output.computeType : undefined,
+    certificate: __expectString(output.certificate),
+    computeType: __expectString(output.computeType),
     environmentVariables:
       output.environmentVariables !== undefined && output.environmentVariables !== null
         ? deserializeAws_json1_1EnvironmentVariables(output.environmentVariables, context)
         : undefined,
-    image: output.image !== undefined && output.image !== null ? output.image : undefined,
-    imagePullCredentialsType:
-      output.imagePullCredentialsType !== undefined && output.imagePullCredentialsType !== null
-        ? output.imagePullCredentialsType
-        : undefined,
-    privilegedMode:
-      output.privilegedMode !== undefined && output.privilegedMode !== null ? output.privilegedMode : undefined,
+    image: __expectString(output.image),
+    imagePullCredentialsType: __expectString(output.imagePullCredentialsType),
+    privilegedMode: __expectBoolean(output.privilegedMode),
     registryCredential:
       output.registryCredential !== undefined && output.registryCredential !== null
         ? deserializeAws_json1_1RegistryCredential(output.registryCredential, context)
         : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -5987,11 +5889,11 @@ const deserializeAws_json1_1ProjectFileSystemLocation = (
   context: __SerdeContext
 ): ProjectFileSystemLocation => {
   return {
-    identifier: output.identifier !== undefined && output.identifier !== null ? output.identifier : undefined,
-    location: output.location !== undefined && output.location !== null ? output.location : undefined,
-    mountOptions: output.mountOptions !== undefined && output.mountOptions !== null ? output.mountOptions : undefined,
-    mountPoint: output.mountPoint !== undefined && output.mountPoint !== null ? output.mountPoint : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    identifier: __expectString(output.identifier),
+    location: __expectString(output.location),
+    mountOptions: __expectString(output.mountOptions),
+    mountPoint: __expectString(output.mountPoint),
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -6016,7 +5918,7 @@ const deserializeAws_json1_1ProjectNames = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6055,22 +5957,17 @@ const deserializeAws_json1_1ProjectSource = (output: any, context: __SerdeContex
       output.buildStatusConfig !== undefined && output.buildStatusConfig !== null
         ? deserializeAws_json1_1BuildStatusConfig(output.buildStatusConfig, context)
         : undefined,
-    buildspec: output.buildspec !== undefined && output.buildspec !== null ? output.buildspec : undefined,
-    gitCloneDepth:
-      output.gitCloneDepth !== undefined && output.gitCloneDepth !== null ? output.gitCloneDepth : undefined,
+    buildspec: __expectString(output.buildspec),
+    gitCloneDepth: __expectNumber(output.gitCloneDepth),
     gitSubmodulesConfig:
       output.gitSubmodulesConfig !== undefined && output.gitSubmodulesConfig !== null
         ? deserializeAws_json1_1GitSubmodulesConfig(output.gitSubmodulesConfig, context)
         : undefined,
-    insecureSsl: output.insecureSsl !== undefined && output.insecureSsl !== null ? output.insecureSsl : undefined,
-    location: output.location !== undefined && output.location !== null ? output.location : undefined,
-    reportBuildStatus:
-      output.reportBuildStatus !== undefined && output.reportBuildStatus !== null
-        ? output.reportBuildStatus
-        : undefined,
-    sourceIdentifier:
-      output.sourceIdentifier !== undefined && output.sourceIdentifier !== null ? output.sourceIdentifier : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    insecureSsl: __expectBoolean(output.insecureSsl),
+    location: __expectString(output.location),
+    reportBuildStatus: __expectBoolean(output.reportBuildStatus),
+    sourceIdentifier: __expectString(output.sourceIdentifier),
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -6087,10 +5984,8 @@ const deserializeAws_json1_1ProjectSources = (output: any, context: __SerdeConte
 
 const deserializeAws_json1_1ProjectSourceVersion = (output: any, context: __SerdeContext): ProjectSourceVersion => {
   return {
-    sourceIdentifier:
-      output.sourceIdentifier !== undefined && output.sourceIdentifier !== null ? output.sourceIdentifier : undefined,
-    sourceVersion:
-      output.sourceVersion !== undefined && output.sourceVersion !== null ? output.sourceVersion : undefined,
+    sourceIdentifier: __expectString(output.sourceIdentifier),
+    sourceVersion: __expectString(output.sourceVersion),
   } as any;
 };
 
@@ -6099,46 +5994,42 @@ const deserializeAws_json1_1PutResourcePolicyOutput = (
   context: __SerdeContext
 ): PutResourcePolicyOutput => {
   return {
-    resourceArn: output.resourceArn !== undefined && output.resourceArn !== null ? output.resourceArn : undefined,
+    resourceArn: __expectString(output.resourceArn),
   } as any;
 };
 
 const deserializeAws_json1_1RegistryCredential = (output: any, context: __SerdeContext): RegistryCredential => {
   return {
-    credential: output.credential !== undefined && output.credential !== null ? output.credential : undefined,
-    credentialProvider:
-      output.credentialProvider !== undefined && output.credentialProvider !== null
-        ? output.credentialProvider
-        : undefined,
+    credential: __expectString(output.credential),
+    credentialProvider: __expectString(output.credentialProvider),
   } as any;
 };
 
 const deserializeAws_json1_1Report = (output: any, context: __SerdeContext): Report => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     codeCoverageSummary:
       output.codeCoverageSummary !== undefined && output.codeCoverageSummary !== null
         ? deserializeAws_json1_1CodeCoverageReportSummary(output.codeCoverageSummary, context)
         : undefined,
     created:
       output.created !== undefined && output.created !== null ? new Date(Math.round(output.created * 1000)) : undefined,
-    executionId: output.executionId !== undefined && output.executionId !== null ? output.executionId : undefined,
+    executionId: __expectString(output.executionId),
     expired:
       output.expired !== undefined && output.expired !== null ? new Date(Math.round(output.expired * 1000)) : undefined,
     exportConfig:
       output.exportConfig !== undefined && output.exportConfig !== null
         ? deserializeAws_json1_1ReportExportConfig(output.exportConfig, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    reportGroupArn:
-      output.reportGroupArn !== undefined && output.reportGroupArn !== null ? output.reportGroupArn : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    name: __expectString(output.name),
+    reportGroupArn: __expectString(output.reportGroupArn),
+    status: __expectString(output.status),
     testSummary:
       output.testSummary !== undefined && output.testSummary !== null
         ? deserializeAws_json1_1TestReportSummary(output.testSummary, context)
         : undefined,
-    truncated: output.truncated !== undefined && output.truncated !== null ? output.truncated : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    truncated: __expectBoolean(output.truncated),
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -6149,14 +6040,13 @@ const deserializeAws_json1_1ReportArns = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1ReportExportConfig = (output: any, context: __SerdeContext): ReportExportConfig => {
   return {
-    exportConfigType:
-      output.exportConfigType !== undefined && output.exportConfigType !== null ? output.exportConfigType : undefined,
+    exportConfigType: __expectString(output.exportConfigType),
     s3Destination:
       output.s3Destination !== undefined && output.s3Destination !== null
         ? deserializeAws_json1_1S3ReportExportConfig(output.s3Destination, context)
@@ -6166,7 +6056,7 @@ const deserializeAws_json1_1ReportExportConfig = (output: any, context: __SerdeC
 
 const deserializeAws_json1_1ReportGroup = (output: any, context: __SerdeContext): ReportGroup => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     created:
       output.created !== undefined && output.created !== null ? new Date(Math.round(output.created * 1000)) : undefined,
     exportConfig:
@@ -6177,13 +6067,13 @@ const deserializeAws_json1_1ReportGroup = (output: any, context: __SerdeContext)
       output.lastModified !== undefined && output.lastModified !== null
         ? new Date(Math.round(output.lastModified * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    name: __expectString(output.name),
+    status: __expectString(output.status),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_json1_1TagList(output.tags, context)
         : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -6194,7 +6084,7 @@ const deserializeAws_json1_1ReportGroupArns = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6225,9 +6115,9 @@ const deserializeAws_json1_1ReportGroupTrendRawDataList = (
 
 const deserializeAws_json1_1ReportGroupTrendStats = (output: any, context: __SerdeContext): ReportGroupTrendStats => {
   return {
-    average: output.average !== undefined && output.average !== null ? output.average : undefined,
-    max: output.max !== undefined && output.max !== null ? output.max : undefined,
-    min: output.min !== undefined && output.min !== null ? output.min : undefined,
+    average: __expectString(output.average),
+    max: __expectString(output.max),
+    min: __expectString(output.min),
   } as any;
 };
 
@@ -6249,23 +6139,23 @@ const deserializeAws_json1_1ReportStatusCounts = (output: any, context: __SerdeC
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectNumber(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_json1_1ReportWithRawData = (output: any, context: __SerdeContext): ReportWithRawData => {
   return {
-    data: output.data !== undefined && output.data !== null ? output.data : undefined,
-    reportArn: output.reportArn !== undefined && output.reportArn !== null ? output.reportArn : undefined,
+    data: __expectString(output.data),
+    reportArn: __expectString(output.reportArn),
   } as any;
 };
 
 const deserializeAws_json1_1ResolvedArtifact = (output: any, context: __SerdeContext): ResolvedArtifact => {
   return {
-    identifier: output.identifier !== undefined && output.identifier !== null ? output.identifier : undefined,
-    location: output.location !== undefined && output.location !== null ? output.location : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    identifier: __expectString(output.identifier),
+    location: __expectString(output.location),
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -6285,7 +6175,7 @@ const deserializeAws_json1_1ResourceAlreadyExistsException = (
   context: __SerdeContext
 ): ResourceAlreadyExistsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6294,7 +6184,7 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6318,31 +6208,21 @@ const deserializeAws_json1_1RetryBuildOutput = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1S3LogsConfig = (output: any, context: __SerdeContext): S3LogsConfig => {
   return {
-    bucketOwnerAccess:
-      output.bucketOwnerAccess !== undefined && output.bucketOwnerAccess !== null
-        ? output.bucketOwnerAccess
-        : undefined,
-    encryptionDisabled:
-      output.encryptionDisabled !== undefined && output.encryptionDisabled !== null
-        ? output.encryptionDisabled
-        : undefined,
-    location: output.location !== undefined && output.location !== null ? output.location : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    bucketOwnerAccess: __expectString(output.bucketOwnerAccess),
+    encryptionDisabled: __expectBoolean(output.encryptionDisabled),
+    location: __expectString(output.location),
+    status: __expectString(output.status),
   } as any;
 };
 
 const deserializeAws_json1_1S3ReportExportConfig = (output: any, context: __SerdeContext): S3ReportExportConfig => {
   return {
-    bucket: output.bucket !== undefined && output.bucket !== null ? output.bucket : undefined,
-    bucketOwner: output.bucketOwner !== undefined && output.bucketOwner !== null ? output.bucketOwner : undefined,
-    encryptionDisabled:
-      output.encryptionDisabled !== undefined && output.encryptionDisabled !== null
-        ? output.encryptionDisabled
-        : undefined,
-    encryptionKey:
-      output.encryptionKey !== undefined && output.encryptionKey !== null ? output.encryptionKey : undefined,
-    packaging: output.packaging !== undefined && output.packaging !== null ? output.packaging : undefined,
-    path: output.path !== undefined && output.path !== null ? output.path : undefined,
+    bucket: __expectString(output.bucket),
+    bucketOwner: __expectString(output.bucketOwner),
+    encryptionDisabled: __expectBoolean(output.encryptionDisabled),
+    encryptionKey: __expectString(output.encryptionKey),
+    packaging: __expectString(output.packaging),
+    path: __expectString(output.path),
   } as any;
 };
 
@@ -6353,22 +6233,22 @@ const deserializeAws_json1_1SecurityGroupIds = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1SourceAuth = (output: any, context: __SerdeContext): SourceAuth => {
   return {
-    resource: output.resource !== undefined && output.resource !== null ? output.resource : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    resource: __expectString(output.resource),
+    type: __expectString(output.type),
   } as any;
 };
 
 const deserializeAws_json1_1SourceCredentialsInfo = (output: any, context: __SerdeContext): SourceCredentialsInfo => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    authType: output.authType !== undefined && output.authType !== null ? output.authType : undefined,
-    serverType: output.serverType !== undefined && output.serverType !== null ? output.serverType : undefined,
+    arn: __expectString(output.arn),
+    authType: __expectString(output.authType),
+    serverType: __expectString(output.serverType),
   } as any;
 };
 
@@ -6429,14 +6309,14 @@ const deserializeAws_json1_1Subnets = (output: any, context: __SerdeContext): st
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    key: __expectString(output.key),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -6453,19 +6333,15 @@ const deserializeAws_json1_1TagList = (output: any, context: __SerdeContext): Ta
 
 const deserializeAws_json1_1TestCase = (output: any, context: __SerdeContext): TestCase => {
   return {
-    durationInNanoSeconds:
-      output.durationInNanoSeconds !== undefined && output.durationInNanoSeconds !== null
-        ? output.durationInNanoSeconds
-        : undefined,
+    durationInNanoSeconds: __expectNumber(output.durationInNanoSeconds),
     expired:
       output.expired !== undefined && output.expired !== null ? new Date(Math.round(output.expired * 1000)) : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    prefix: output.prefix !== undefined && output.prefix !== null ? output.prefix : undefined,
-    reportArn: output.reportArn !== undefined && output.reportArn !== null ? output.reportArn : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    testRawDataPath:
-      output.testRawDataPath !== undefined && output.testRawDataPath !== null ? output.testRawDataPath : undefined,
+    message: __expectString(output.message),
+    name: __expectString(output.name),
+    prefix: __expectString(output.prefix),
+    reportArn: __expectString(output.reportArn),
+    status: __expectString(output.status),
+    testRawDataPath: __expectString(output.testRawDataPath),
   } as any;
 };
 
@@ -6482,15 +6358,12 @@ const deserializeAws_json1_1TestCases = (output: any, context: __SerdeContext): 
 
 const deserializeAws_json1_1TestReportSummary = (output: any, context: __SerdeContext): TestReportSummary => {
   return {
-    durationInNanoSeconds:
-      output.durationInNanoSeconds !== undefined && output.durationInNanoSeconds !== null
-        ? output.durationInNanoSeconds
-        : undefined,
+    durationInNanoSeconds: __expectNumber(output.durationInNanoSeconds),
     statusCounts:
       output.statusCounts !== undefined && output.statusCounts !== null
         ? deserializeAws_json1_1ReportStatusCounts(output.statusCounts, context)
         : undefined,
-    total: output.total !== undefined && output.total !== null ? output.total : undefined,
+    total: __expectNumber(output.total),
   } as any;
 };
 
@@ -6534,14 +6407,14 @@ const deserializeAws_json1_1VpcConfig = (output: any, context: __SerdeContext): 
       output.subnets !== undefined && output.subnets !== null
         ? deserializeAws_json1_1Subnets(output.subnets, context)
         : undefined,
-    vpcId: output.vpcId !== undefined && output.vpcId !== null ? output.vpcId : undefined,
+    vpcId: __expectString(output.vpcId),
   } as any;
 };
 
 const deserializeAws_json1_1Webhook = (output: any, context: __SerdeContext): Webhook => {
   return {
-    branchFilter: output.branchFilter !== undefined && output.branchFilter !== null ? output.branchFilter : undefined,
-    buildType: output.buildType !== undefined && output.buildType !== null ? output.buildType : undefined,
+    branchFilter: __expectString(output.branchFilter),
+    buildType: __expectString(output.buildType),
     filterGroups:
       output.filterGroups !== undefined && output.filterGroups !== null
         ? deserializeAws_json1_1FilterGroups(output.filterGroups, context)
@@ -6550,20 +6423,17 @@ const deserializeAws_json1_1Webhook = (output: any, context: __SerdeContext): We
       output.lastModifiedSecret !== undefined && output.lastModifiedSecret !== null
         ? new Date(Math.round(output.lastModifiedSecret * 1000))
         : undefined,
-    payloadUrl: output.payloadUrl !== undefined && output.payloadUrl !== null ? output.payloadUrl : undefined,
-    secret: output.secret !== undefined && output.secret !== null ? output.secret : undefined,
-    url: output.url !== undefined && output.url !== null ? output.url : undefined,
+    payloadUrl: __expectString(output.payloadUrl),
+    secret: __expectString(output.secret),
+    url: __expectString(output.url),
   } as any;
 };
 
 const deserializeAws_json1_1WebhookFilter = (output: any, context: __SerdeContext): WebhookFilter => {
   return {
-    excludeMatchedPattern:
-      output.excludeMatchedPattern !== undefined && output.excludeMatchedPattern !== null
-        ? output.excludeMatchedPattern
-        : undefined,
-    pattern: output.pattern !== undefined && output.pattern !== null ? output.pattern : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    excludeMatchedPattern: __expectBoolean(output.excludeMatchedPattern),
+    pattern: __expectString(output.pattern),
+    type: __expectString(output.type),
   } as any;
 };
 

--- a/clients/client-codecommit/protocols/Aws_json1_1.ts
+++ b/clients/client-codecommit/protocols/Aws_json1_1.ts
@@ -610,7 +610,12 @@ import {
   UpdateRepositoryNameInput,
 } from "../models/models_1";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -17725,15 +17730,14 @@ const deserializeAws_json1_1ActorDoesNotExistException = (
   context: __SerdeContext
 ): ActorDoesNotExistException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1Approval = (output: any, context: __SerdeContext): Approval => {
   return {
-    approvalState:
-      output.approvalState !== undefined && output.approvalState !== null ? output.approvalState : undefined,
-    userArn: output.userArn !== undefined && output.userArn !== null ? output.userArn : undefined,
+    approvalState: __expectString(output.approvalState),
+    userArn: __expectString(output.userArn),
   } as any;
 };
 
@@ -17750,14 +17754,9 @@ const deserializeAws_json1_1ApprovalList = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_1ApprovalRule = (output: any, context: __SerdeContext): ApprovalRule => {
   return {
-    approvalRuleContent:
-      output.approvalRuleContent !== undefined && output.approvalRuleContent !== null
-        ? output.approvalRuleContent
-        : undefined,
-    approvalRuleId:
-      output.approvalRuleId !== undefined && output.approvalRuleId !== null ? output.approvalRuleId : undefined,
-    approvalRuleName:
-      output.approvalRuleName !== undefined && output.approvalRuleName !== null ? output.approvalRuleName : undefined,
+    approvalRuleContent: __expectString(output.approvalRuleContent),
+    approvalRuleId: __expectString(output.approvalRuleId),
+    approvalRuleName: __expectString(output.approvalRuleName),
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
         ? new Date(Math.round(output.creationDate * 1000))
@@ -17766,16 +17765,12 @@ const deserializeAws_json1_1ApprovalRule = (output: any, context: __SerdeContext
       output.lastModifiedDate !== undefined && output.lastModifiedDate !== null
         ? new Date(Math.round(output.lastModifiedDate * 1000))
         : undefined,
-    lastModifiedUser:
-      output.lastModifiedUser !== undefined && output.lastModifiedUser !== null ? output.lastModifiedUser : undefined,
+    lastModifiedUser: __expectString(output.lastModifiedUser),
     originApprovalRuleTemplate:
       output.originApprovalRuleTemplate !== undefined && output.originApprovalRuleTemplate !== null
         ? deserializeAws_json1_1OriginApprovalRuleTemplate(output.originApprovalRuleTemplate, context)
         : undefined,
-    ruleContentSha256:
-      output.ruleContentSha256 !== undefined && output.ruleContentSha256 !== null
-        ? output.ruleContentSha256
-        : undefined,
+    ruleContentSha256: __expectString(output.ruleContentSha256),
   } as any;
 };
 
@@ -17784,7 +17779,7 @@ const deserializeAws_json1_1ApprovalRuleContentRequiredException = (
   context: __SerdeContext
 ): ApprovalRuleContentRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -17793,7 +17788,7 @@ const deserializeAws_json1_1ApprovalRuleDoesNotExistException = (
   context: __SerdeContext
 ): ApprovalRuleDoesNotExistException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -17802,14 +17797,9 @@ const deserializeAws_json1_1ApprovalRuleEventMetadata = (
   context: __SerdeContext
 ): ApprovalRuleEventMetadata => {
   return {
-    approvalRuleContent:
-      output.approvalRuleContent !== undefined && output.approvalRuleContent !== null
-        ? output.approvalRuleContent
-        : undefined,
-    approvalRuleId:
-      output.approvalRuleId !== undefined && output.approvalRuleId !== null ? output.approvalRuleId : undefined,
-    approvalRuleName:
-      output.approvalRuleName !== undefined && output.approvalRuleName !== null ? output.approvalRuleName : undefined,
+    approvalRuleContent: __expectString(output.approvalRuleContent),
+    approvalRuleId: __expectString(output.approvalRuleId),
+    approvalRuleName: __expectString(output.approvalRuleName),
   } as any;
 };
 
@@ -17818,7 +17808,7 @@ const deserializeAws_json1_1ApprovalRuleNameAlreadyExistsException = (
   context: __SerdeContext
 ): ApprovalRuleNameAlreadyExistsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -17827,7 +17817,7 @@ const deserializeAws_json1_1ApprovalRuleNameRequiredException = (
   context: __SerdeContext
 ): ApprovalRuleNameRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -17836,9 +17826,8 @@ const deserializeAws_json1_1ApprovalRuleOverriddenEventMetadata = (
   context: __SerdeContext
 ): ApprovalRuleOverriddenEventMetadata => {
   return {
-    overrideStatus:
-      output.overrideStatus !== undefined && output.overrideStatus !== null ? output.overrideStatus : undefined,
-    revisionId: output.revisionId !== undefined && output.revisionId !== null ? output.revisionId : undefined,
+    overrideStatus: __expectString(output.overrideStatus),
+    revisionId: __expectString(output.revisionId),
   } as any;
 };
 
@@ -17860,7 +17849,7 @@ const deserializeAws_json1_1ApprovalRulesNotSatisfiedList = (output: any, contex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -17871,28 +17860,16 @@ const deserializeAws_json1_1ApprovalRulesSatisfiedList = (output: any, context: 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1ApprovalRuleTemplate = (output: any, context: __SerdeContext): ApprovalRuleTemplate => {
   return {
-    approvalRuleTemplateContent:
-      output.approvalRuleTemplateContent !== undefined && output.approvalRuleTemplateContent !== null
-        ? output.approvalRuleTemplateContent
-        : undefined,
-    approvalRuleTemplateDescription:
-      output.approvalRuleTemplateDescription !== undefined && output.approvalRuleTemplateDescription !== null
-        ? output.approvalRuleTemplateDescription
-        : undefined,
-    approvalRuleTemplateId:
-      output.approvalRuleTemplateId !== undefined && output.approvalRuleTemplateId !== null
-        ? output.approvalRuleTemplateId
-        : undefined,
-    approvalRuleTemplateName:
-      output.approvalRuleTemplateName !== undefined && output.approvalRuleTemplateName !== null
-        ? output.approvalRuleTemplateName
-        : undefined,
+    approvalRuleTemplateContent: __expectString(output.approvalRuleTemplateContent),
+    approvalRuleTemplateDescription: __expectString(output.approvalRuleTemplateDescription),
+    approvalRuleTemplateId: __expectString(output.approvalRuleTemplateId),
+    approvalRuleTemplateName: __expectString(output.approvalRuleTemplateName),
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
         ? new Date(Math.round(output.creationDate * 1000))
@@ -17901,12 +17878,8 @@ const deserializeAws_json1_1ApprovalRuleTemplate = (output: any, context: __Serd
       output.lastModifiedDate !== undefined && output.lastModifiedDate !== null
         ? new Date(Math.round(output.lastModifiedDate * 1000))
         : undefined,
-    lastModifiedUser:
-      output.lastModifiedUser !== undefined && output.lastModifiedUser !== null ? output.lastModifiedUser : undefined,
-    ruleContentSha256:
-      output.ruleContentSha256 !== undefined && output.ruleContentSha256 !== null
-        ? output.ruleContentSha256
-        : undefined,
+    lastModifiedUser: __expectString(output.lastModifiedUser),
+    ruleContentSha256: __expectString(output.ruleContentSha256),
   } as any;
 };
 
@@ -17915,7 +17888,7 @@ const deserializeAws_json1_1ApprovalRuleTemplateContentRequiredException = (
   context: __SerdeContext
 ): ApprovalRuleTemplateContentRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -17924,7 +17897,7 @@ const deserializeAws_json1_1ApprovalRuleTemplateDoesNotExistException = (
   context: __SerdeContext
 ): ApprovalRuleTemplateDoesNotExistException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -17933,7 +17906,7 @@ const deserializeAws_json1_1ApprovalRuleTemplateInUseException = (
   context: __SerdeContext
 ): ApprovalRuleTemplateInUseException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -17942,7 +17915,7 @@ const deserializeAws_json1_1ApprovalRuleTemplateNameAlreadyExistsException = (
   context: __SerdeContext
 ): ApprovalRuleTemplateNameAlreadyExistsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -17953,7 +17926,7 @@ const deserializeAws_json1_1ApprovalRuleTemplateNameList = (output: any, context
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -17962,7 +17935,7 @@ const deserializeAws_json1_1ApprovalRuleTemplateNameRequiredException = (
   context: __SerdeContext
 ): ApprovalRuleTemplateNameRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -17971,9 +17944,8 @@ const deserializeAws_json1_1ApprovalStateChangedEventMetadata = (
   context: __SerdeContext
 ): ApprovalStateChangedEventMetadata => {
   return {
-    approvalStatus:
-      output.approvalStatus !== undefined && output.approvalStatus !== null ? output.approvalStatus : undefined,
-    revisionId: output.revisionId !== undefined && output.revisionId !== null ? output.revisionId : undefined,
+    approvalStatus: __expectString(output.approvalStatus),
+    revisionId: __expectString(output.revisionId),
   } as any;
 };
 
@@ -17982,7 +17954,7 @@ const deserializeAws_json1_1ApprovalStateRequiredException = (
   context: __SerdeContext
 ): ApprovalStateRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -17991,7 +17963,7 @@ const deserializeAws_json1_1AuthorDoesNotExistException = (
   context: __SerdeContext
 ): AuthorDoesNotExistException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -18000,10 +17972,9 @@ const deserializeAws_json1_1BatchAssociateApprovalRuleTemplateWithRepositoriesEr
   context: __SerdeContext
 ): BatchAssociateApprovalRuleTemplateWithRepositoriesError => {
   return {
-    errorCode: output.errorCode !== undefined && output.errorCode !== null ? output.errorCode : undefined,
-    errorMessage: output.errorMessage !== undefined && output.errorMessage !== null ? output.errorMessage : undefined,
-    repositoryName:
-      output.repositoryName !== undefined && output.repositoryName !== null ? output.repositoryName : undefined,
+    errorCode: __expectString(output.errorCode),
+    errorMessage: __expectString(output.errorMessage),
+    repositoryName: __expectString(output.repositoryName),
   } as any;
 };
 
@@ -18042,10 +18013,9 @@ const deserializeAws_json1_1BatchDescribeMergeConflictsError = (
   context: __SerdeContext
 ): BatchDescribeMergeConflictsError => {
   return {
-    exceptionName:
-      output.exceptionName !== undefined && output.exceptionName !== null ? output.exceptionName : undefined,
-    filePath: output.filePath !== undefined && output.filePath !== null ? output.filePath : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    exceptionName: __expectString(output.exceptionName),
+    filePath: __expectString(output.filePath),
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -18068,22 +18038,18 @@ const deserializeAws_json1_1BatchDescribeMergeConflictsOutput = (
   context: __SerdeContext
 ): BatchDescribeMergeConflictsOutput => {
   return {
-    baseCommitId: output.baseCommitId !== undefined && output.baseCommitId !== null ? output.baseCommitId : undefined,
+    baseCommitId: __expectString(output.baseCommitId),
     conflicts:
       output.conflicts !== undefined && output.conflicts !== null
         ? deserializeAws_json1_1Conflicts(output.conflicts, context)
         : undefined,
-    destinationCommitId:
-      output.destinationCommitId !== undefined && output.destinationCommitId !== null
-        ? output.destinationCommitId
-        : undefined,
+    destinationCommitId: __expectString(output.destinationCommitId),
     errors:
       output.errors !== undefined && output.errors !== null
         ? deserializeAws_json1_1BatchDescribeMergeConflictsErrors(output.errors, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
-    sourceCommitId:
-      output.sourceCommitId !== undefined && output.sourceCommitId !== null ? output.sourceCommitId : undefined,
+    nextToken: __expectString(output.nextToken),
+    sourceCommitId: __expectString(output.sourceCommitId),
   } as any;
 };
 
@@ -18092,10 +18058,9 @@ const deserializeAws_json1_1BatchDisassociateApprovalRuleTemplateFromRepositorie
   context: __SerdeContext
 ): BatchDisassociateApprovalRuleTemplateFromRepositoriesError => {
   return {
-    errorCode: output.errorCode !== undefined && output.errorCode !== null ? output.errorCode : undefined,
-    errorMessage: output.errorMessage !== undefined && output.errorMessage !== null ? output.errorMessage : undefined,
-    repositoryName:
-      output.repositoryName !== undefined && output.repositoryName !== null ? output.repositoryName : undefined,
+    errorCode: __expectString(output.errorCode),
+    errorMessage: __expectString(output.errorMessage),
+    repositoryName: __expectString(output.repositoryName),
   } as any;
 };
 
@@ -18131,9 +18096,9 @@ const deserializeAws_json1_1BatchDisassociateApprovalRuleTemplateFromRepositorie
 
 const deserializeAws_json1_1BatchGetCommitsError = (output: any, context: __SerdeContext): BatchGetCommitsError => {
   return {
-    commitId: output.commitId !== undefined && output.commitId !== null ? output.commitId : undefined,
-    errorCode: output.errorCode !== undefined && output.errorCode !== null ? output.errorCode : undefined,
-    errorMessage: output.errorMessage !== undefined && output.errorMessage !== null ? output.errorMessage : undefined,
+    commitId: __expectString(output.commitId),
+    errorCode: __expectString(output.errorCode),
+    errorMessage: __expectString(output.errorMessage),
   } as any;
 };
 
@@ -18185,7 +18150,7 @@ const deserializeAws_json1_1BeforeCommitIdAndAfterCommitIdAreSameException = (
   context: __SerdeContext
 ): BeforeCommitIdAndAfterCommitIdAreSameException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -18194,7 +18159,7 @@ const deserializeAws_json1_1BlobIdDoesNotExistException = (
   context: __SerdeContext
 ): BlobIdDoesNotExistException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -18203,15 +18168,15 @@ const deserializeAws_json1_1BlobIdRequiredException = (
   context: __SerdeContext
 ): BlobIdRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1BlobMetadata = (output: any, context: __SerdeContext): BlobMetadata => {
   return {
-    blobId: output.blobId !== undefined && output.blobId !== null ? output.blobId : undefined,
-    mode: output.mode !== undefined && output.mode !== null ? output.mode : undefined,
-    path: output.path !== undefined && output.path !== null ? output.path : undefined,
+    blobId: __expectString(output.blobId),
+    mode: __expectString(output.mode),
+    path: __expectString(output.path),
   } as any;
 };
 
@@ -18220,14 +18185,14 @@ const deserializeAws_json1_1BranchDoesNotExistException = (
   context: __SerdeContext
 ): BranchDoesNotExistException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1BranchInfo = (output: any, context: __SerdeContext): BranchInfo => {
   return {
-    branchName: output.branchName !== undefined && output.branchName !== null ? output.branchName : undefined,
-    commitId: output.commitId !== undefined && output.commitId !== null ? output.commitId : undefined,
+    branchName: __expectString(output.branchName),
+    commitId: __expectString(output.commitId),
   } as any;
 };
 
@@ -18236,7 +18201,7 @@ const deserializeAws_json1_1BranchNameExistsException = (
   context: __SerdeContext
 ): BranchNameExistsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -18245,7 +18210,7 @@ const deserializeAws_json1_1BranchNameIsTagNameException = (
   context: __SerdeContext
 ): BranchNameIsTagNameException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -18256,7 +18221,7 @@ const deserializeAws_json1_1BranchNameList = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -18265,7 +18230,7 @@ const deserializeAws_json1_1BranchNameRequiredException = (
   context: __SerdeContext
 ): BranchNameRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -18276,7 +18241,7 @@ const deserializeAws_json1_1CallerReactions = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -18285,7 +18250,7 @@ const deserializeAws_json1_1CannotDeleteApprovalRuleFromTemplateException = (
   context: __SerdeContext
 ): CannotDeleteApprovalRuleFromTemplateException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -18294,7 +18259,7 @@ const deserializeAws_json1_1CannotModifyApprovalRuleFromTemplateException = (
   context: __SerdeContext
 ): CannotModifyApprovalRuleFromTemplateException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -18303,29 +18268,26 @@ const deserializeAws_json1_1ClientRequestTokenRequiredException = (
   context: __SerdeContext
 ): ClientRequestTokenRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1Comment = (output: any, context: __SerdeContext): Comment => {
   return {
-    authorArn: output.authorArn !== undefined && output.authorArn !== null ? output.authorArn : undefined,
+    authorArn: __expectString(output.authorArn),
     callerReactions:
       output.callerReactions !== undefined && output.callerReactions !== null
         ? deserializeAws_json1_1CallerReactions(output.callerReactions, context)
         : undefined,
-    clientRequestToken:
-      output.clientRequestToken !== undefined && output.clientRequestToken !== null
-        ? output.clientRequestToken
-        : undefined,
-    commentId: output.commentId !== undefined && output.commentId !== null ? output.commentId : undefined,
-    content: output.content !== undefined && output.content !== null ? output.content : undefined,
+    clientRequestToken: __expectString(output.clientRequestToken),
+    commentId: __expectString(output.commentId),
+    content: __expectString(output.content),
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
         ? new Date(Math.round(output.creationDate * 1000))
         : undefined,
-    deleted: output.deleted !== undefined && output.deleted !== null ? output.deleted : undefined,
-    inReplyTo: output.inReplyTo !== undefined && output.inReplyTo !== null ? output.inReplyTo : undefined,
+    deleted: __expectBoolean(output.deleted),
+    inReplyTo: __expectString(output.inReplyTo),
     lastModifiedDate:
       output.lastModifiedDate !== undefined && output.lastModifiedDate !== null
         ? new Date(Math.round(output.lastModifiedDate * 1000))
@@ -18342,7 +18304,7 @@ const deserializeAws_json1_1CommentContentRequiredException = (
   context: __SerdeContext
 ): CommentContentRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -18351,7 +18313,7 @@ const deserializeAws_json1_1CommentContentSizeLimitExceededException = (
   context: __SerdeContext
 ): CommentContentSizeLimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -18360,7 +18322,7 @@ const deserializeAws_json1_1CommentDeletedException = (
   context: __SerdeContext
 ): CommentDeletedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -18369,7 +18331,7 @@ const deserializeAws_json1_1CommentDoesNotExistException = (
   context: __SerdeContext
 ): CommentDoesNotExistException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -18378,7 +18340,7 @@ const deserializeAws_json1_1CommentIdRequiredException = (
   context: __SerdeContext
 ): CommentIdRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -18387,7 +18349,7 @@ const deserializeAws_json1_1CommentNotCreatedByCallerException = (
   context: __SerdeContext
 ): CommentNotCreatedByCallerException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -18407,12 +18369,10 @@ const deserializeAws_json1_1CommentsForComparedCommit = (
   context: __SerdeContext
 ): CommentsForComparedCommit => {
   return {
-    afterBlobId: output.afterBlobId !== undefined && output.afterBlobId !== null ? output.afterBlobId : undefined,
-    afterCommitId:
-      output.afterCommitId !== undefined && output.afterCommitId !== null ? output.afterCommitId : undefined,
-    beforeBlobId: output.beforeBlobId !== undefined && output.beforeBlobId !== null ? output.beforeBlobId : undefined,
-    beforeCommitId:
-      output.beforeCommitId !== undefined && output.beforeCommitId !== null ? output.beforeCommitId : undefined,
+    afterBlobId: __expectString(output.afterBlobId),
+    afterCommitId: __expectString(output.afterCommitId),
+    beforeBlobId: __expectString(output.beforeBlobId),
+    beforeCommitId: __expectString(output.beforeCommitId),
     comments:
       output.comments !== undefined && output.comments !== null
         ? deserializeAws_json1_1Comments(output.comments, context)
@@ -18421,8 +18381,7 @@ const deserializeAws_json1_1CommentsForComparedCommit = (
       output.location !== undefined && output.location !== null
         ? deserializeAws_json1_1Location(output.location, context)
         : undefined,
-    repositoryName:
-      output.repositoryName !== undefined && output.repositoryName !== null ? output.repositoryName : undefined,
+    repositoryName: __expectString(output.repositoryName),
   } as any;
 };
 
@@ -18442,12 +18401,10 @@ const deserializeAws_json1_1CommentsForComparedCommitData = (
 
 const deserializeAws_json1_1CommentsForPullRequest = (output: any, context: __SerdeContext): CommentsForPullRequest => {
   return {
-    afterBlobId: output.afterBlobId !== undefined && output.afterBlobId !== null ? output.afterBlobId : undefined,
-    afterCommitId:
-      output.afterCommitId !== undefined && output.afterCommitId !== null ? output.afterCommitId : undefined,
-    beforeBlobId: output.beforeBlobId !== undefined && output.beforeBlobId !== null ? output.beforeBlobId : undefined,
-    beforeCommitId:
-      output.beforeCommitId !== undefined && output.beforeCommitId !== null ? output.beforeCommitId : undefined,
+    afterBlobId: __expectString(output.afterBlobId),
+    afterCommitId: __expectString(output.afterCommitId),
+    beforeBlobId: __expectString(output.beforeBlobId),
+    beforeCommitId: __expectString(output.beforeCommitId),
     comments:
       output.comments !== undefined && output.comments !== null
         ? deserializeAws_json1_1Comments(output.comments, context)
@@ -18456,10 +18413,8 @@ const deserializeAws_json1_1CommentsForPullRequest = (output: any, context: __Se
       output.location !== undefined && output.location !== null
         ? deserializeAws_json1_1Location(output.location, context)
         : undefined,
-    pullRequestId:
-      output.pullRequestId !== undefined && output.pullRequestId !== null ? output.pullRequestId : undefined,
-    repositoryName:
-      output.repositoryName !== undefined && output.repositoryName !== null ? output.repositoryName : undefined,
+    pullRequestId: __expectString(output.pullRequestId),
+    repositoryName: __expectString(output.repositoryName),
   } as any;
 };
 
@@ -18479,23 +18434,22 @@ const deserializeAws_json1_1CommentsForPullRequestData = (
 
 const deserializeAws_json1_1Commit = (output: any, context: __SerdeContext): Commit => {
   return {
-    additionalData:
-      output.additionalData !== undefined && output.additionalData !== null ? output.additionalData : undefined,
+    additionalData: __expectString(output.additionalData),
     author:
       output.author !== undefined && output.author !== null
         ? deserializeAws_json1_1UserInfo(output.author, context)
         : undefined,
-    commitId: output.commitId !== undefined && output.commitId !== null ? output.commitId : undefined,
+    commitId: __expectString(output.commitId),
     committer:
       output.committer !== undefined && output.committer !== null
         ? deserializeAws_json1_1UserInfo(output.committer, context)
         : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
     parents:
       output.parents !== undefined && output.parents !== null
         ? deserializeAws_json1_1ParentList(output.parents, context)
         : undefined,
-    treeId: output.treeId !== undefined && output.treeId !== null ? output.treeId : undefined,
+    treeId: __expectString(output.treeId),
   } as any;
 };
 
@@ -18504,7 +18458,7 @@ const deserializeAws_json1_1CommitDoesNotExistException = (
   context: __SerdeContext
 ): CommitDoesNotExistException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -18513,7 +18467,7 @@ const deserializeAws_json1_1CommitIdDoesNotExistException = (
   context: __SerdeContext
 ): CommitIdDoesNotExistException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -18522,7 +18476,7 @@ const deserializeAws_json1_1CommitIdRequiredException = (
   context: __SerdeContext
 ): CommitIdRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -18531,7 +18485,7 @@ const deserializeAws_json1_1CommitIdsLimitExceededException = (
   context: __SerdeContext
 ): CommitIdsLimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -18540,7 +18494,7 @@ const deserializeAws_json1_1CommitIdsListRequiredException = (
   context: __SerdeContext
 ): CommitIdsListRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -18549,7 +18503,7 @@ const deserializeAws_json1_1CommitMessageLengthExceededException = (
   context: __SerdeContext
 ): CommitMessageLengthExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -18569,7 +18523,7 @@ const deserializeAws_json1_1CommitRequiredException = (
   context: __SerdeContext
 ): CommitRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -18578,7 +18532,7 @@ const deserializeAws_json1_1ConcurrentReferenceUpdateException = (
   context: __SerdeContext
 ): ConcurrentReferenceUpdateException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -18597,15 +18551,13 @@ const deserializeAws_json1_1Conflict = (output: any, context: __SerdeContext): C
 
 const deserializeAws_json1_1ConflictMetadata = (output: any, context: __SerdeContext): ConflictMetadata => {
   return {
-    contentConflict:
-      output.contentConflict !== undefined && output.contentConflict !== null ? output.contentConflict : undefined,
-    fileModeConflict:
-      output.fileModeConflict !== undefined && output.fileModeConflict !== null ? output.fileModeConflict : undefined,
+    contentConflict: __expectBoolean(output.contentConflict),
+    fileModeConflict: __expectBoolean(output.fileModeConflict),
     fileModes:
       output.fileModes !== undefined && output.fileModes !== null
         ? deserializeAws_json1_1FileModes(output.fileModes, context)
         : undefined,
-    filePath: output.filePath !== undefined && output.filePath !== null ? output.filePath : undefined,
+    filePath: __expectString(output.filePath),
     fileSizes:
       output.fileSizes !== undefined && output.fileSizes !== null
         ? deserializeAws_json1_1FileSizes(output.fileSizes, context)
@@ -18618,14 +18570,8 @@ const deserializeAws_json1_1ConflictMetadata = (output: any, context: __SerdeCon
       output.mergeOperations !== undefined && output.mergeOperations !== null
         ? deserializeAws_json1_1MergeOperations(output.mergeOperations, context)
         : undefined,
-    numberOfConflicts:
-      output.numberOfConflicts !== undefined && output.numberOfConflicts !== null
-        ? output.numberOfConflicts
-        : undefined,
-    objectTypeConflict:
-      output.objectTypeConflict !== undefined && output.objectTypeConflict !== null
-        ? output.objectTypeConflict
-        : undefined,
+    numberOfConflicts: __expectNumber(output.numberOfConflicts),
+    objectTypeConflict: __expectBoolean(output.objectTypeConflict),
     objectTypes:
       output.objectTypes !== undefined && output.objectTypes !== null
         ? deserializeAws_json1_1ObjectTypes(output.objectTypes, context)
@@ -18669,7 +18615,7 @@ const deserializeAws_json1_1CreateApprovalRuleTemplateOutput = (
 
 const deserializeAws_json1_1CreateCommitOutput = (output: any, context: __SerdeContext): CreateCommitOutput => {
   return {
-    commitId: output.commitId !== undefined && output.commitId !== null ? output.commitId : undefined,
+    commitId: __expectString(output.commitId),
     filesAdded:
       output.filesAdded !== undefined && output.filesAdded !== null
         ? deserializeAws_json1_1FilesMetadata(output.filesAdded, context)
@@ -18682,7 +18628,7 @@ const deserializeAws_json1_1CreateCommitOutput = (output: any, context: __SerdeC
       output.filesUpdated !== undefined && output.filesUpdated !== null
         ? deserializeAws_json1_1FilesMetadata(output.filesUpdated, context)
         : undefined,
-    treeId: output.treeId !== undefined && output.treeId !== null ? output.treeId : undefined,
+    treeId: __expectString(output.treeId),
   } as any;
 };
 
@@ -18724,8 +18670,8 @@ const deserializeAws_json1_1CreateUnreferencedMergeCommitOutput = (
   context: __SerdeContext
 ): CreateUnreferencedMergeCommitOutput => {
   return {
-    commitId: output.commitId !== undefined && output.commitId !== null ? output.commitId : undefined,
-    treeId: output.treeId !== undefined && output.treeId !== null ? output.treeId : undefined,
+    commitId: __expectString(output.commitId),
+    treeId: __expectString(output.treeId),
   } as any;
 };
 
@@ -18734,7 +18680,7 @@ const deserializeAws_json1_1DefaultBranchCannotBeDeletedException = (
   context: __SerdeContext
 ): DefaultBranchCannotBeDeletedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -18743,10 +18689,7 @@ const deserializeAws_json1_1DeleteApprovalRuleTemplateOutput = (
   context: __SerdeContext
 ): DeleteApprovalRuleTemplateOutput => {
   return {
-    approvalRuleTemplateId:
-      output.approvalRuleTemplateId !== undefined && output.approvalRuleTemplateId !== null
-        ? output.approvalRuleTemplateId
-        : undefined,
+    approvalRuleTemplateId: __expectString(output.approvalRuleTemplateId),
   } as any;
 };
 
@@ -18773,10 +18716,10 @@ const deserializeAws_json1_1DeleteCommentContentOutput = (
 
 const deserializeAws_json1_1DeleteFileOutput = (output: any, context: __SerdeContext): DeleteFileOutput => {
   return {
-    blobId: output.blobId !== undefined && output.blobId !== null ? output.blobId : undefined,
-    commitId: output.commitId !== undefined && output.commitId !== null ? output.commitId : undefined,
-    filePath: output.filePath !== undefined && output.filePath !== null ? output.filePath : undefined,
-    treeId: output.treeId !== undefined && output.treeId !== null ? output.treeId : undefined,
+    blobId: __expectString(output.blobId),
+    commitId: __expectString(output.commitId),
+    filePath: __expectString(output.filePath),
+    treeId: __expectString(output.treeId),
   } as any;
 };
 
@@ -18785,14 +18728,13 @@ const deserializeAws_json1_1DeletePullRequestApprovalRuleOutput = (
   context: __SerdeContext
 ): DeletePullRequestApprovalRuleOutput => {
   return {
-    approvalRuleId:
-      output.approvalRuleId !== undefined && output.approvalRuleId !== null ? output.approvalRuleId : undefined,
+    approvalRuleId: __expectString(output.approvalRuleId),
   } as any;
 };
 
 const deserializeAws_json1_1DeleteRepositoryOutput = (output: any, context: __SerdeContext): DeleteRepositoryOutput => {
   return {
-    repositoryId: output.repositoryId !== undefined && output.repositoryId !== null ? output.repositoryId : undefined,
+    repositoryId: __expectString(output.repositoryId),
   } as any;
 };
 
@@ -18801,22 +18743,18 @@ const deserializeAws_json1_1DescribeMergeConflictsOutput = (
   context: __SerdeContext
 ): DescribeMergeConflictsOutput => {
   return {
-    baseCommitId: output.baseCommitId !== undefined && output.baseCommitId !== null ? output.baseCommitId : undefined,
+    baseCommitId: __expectString(output.baseCommitId),
     conflictMetadata:
       output.conflictMetadata !== undefined && output.conflictMetadata !== null
         ? deserializeAws_json1_1ConflictMetadata(output.conflictMetadata, context)
         : undefined,
-    destinationCommitId:
-      output.destinationCommitId !== undefined && output.destinationCommitId !== null
-        ? output.destinationCommitId
-        : undefined,
+    destinationCommitId: __expectString(output.destinationCommitId),
     mergeHunks:
       output.mergeHunks !== undefined && output.mergeHunks !== null
         ? deserializeAws_json1_1MergeHunks(output.mergeHunks, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
-    sourceCommitId:
-      output.sourceCommitId !== undefined && output.sourceCommitId !== null ? output.sourceCommitId : undefined,
+    nextToken: __expectString(output.nextToken),
+    sourceCommitId: __expectString(output.sourceCommitId),
   } as any;
 };
 
@@ -18825,7 +18763,7 @@ const deserializeAws_json1_1DescribePullRequestEventsOutput = (
   context: __SerdeContext
 ): DescribePullRequestEventsOutput => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     pullRequestEvents:
       output.pullRequestEvents !== undefined && output.pullRequestEvents !== null
         ? deserializeAws_json1_1PullRequestEventList(output.pullRequestEvents, context)
@@ -18843,7 +18781,7 @@ const deserializeAws_json1_1Difference = (output: any, context: __SerdeContext):
       output.beforeBlob !== undefined && output.beforeBlob !== null
         ? deserializeAws_json1_1BlobMetadata(output.beforeBlob, context)
         : undefined,
-    changeType: output.changeType !== undefined && output.changeType !== null ? output.changeType : undefined,
+    changeType: __expectString(output.changeType),
   } as any;
 };
 
@@ -18863,7 +18801,7 @@ const deserializeAws_json1_1DirectoryNameConflictsWithFileNameException = (
   context: __SerdeContext
 ): DirectoryNameConflictsWithFileNameException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -18872,7 +18810,7 @@ const deserializeAws_json1_1EncryptionIntegrityChecksFailedException = (
   context: __SerdeContext
 ): EncryptionIntegrityChecksFailedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -18881,7 +18819,7 @@ const deserializeAws_json1_1EncryptionKeyAccessDeniedException = (
   context: __SerdeContext
 ): EncryptionKeyAccessDeniedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -18890,7 +18828,7 @@ const deserializeAws_json1_1EncryptionKeyDisabledException = (
   context: __SerdeContext
 ): EncryptionKeyDisabledException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -18899,7 +18837,7 @@ const deserializeAws_json1_1EncryptionKeyNotFoundException = (
   context: __SerdeContext
 ): EncryptionKeyNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -18908,7 +18846,7 @@ const deserializeAws_json1_1EncryptionKeyUnavailableException = (
   context: __SerdeContext
 ): EncryptionKeyUnavailableException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -18934,17 +18872,17 @@ const deserializeAws_json1_1Evaluation = (output: any, context: __SerdeContext):
       output.approvalRulesSatisfied !== undefined && output.approvalRulesSatisfied !== null
         ? deserializeAws_json1_1ApprovalRulesSatisfiedList(output.approvalRulesSatisfied, context)
         : undefined,
-    approved: output.approved !== undefined && output.approved !== null ? output.approved : undefined,
-    overridden: output.overridden !== undefined && output.overridden !== null ? output.overridden : undefined,
+    approved: __expectBoolean(output.approved),
+    overridden: __expectBoolean(output.overridden),
   } as any;
 };
 
 const deserializeAws_json1_1File = (output: any, context: __SerdeContext): File => {
   return {
-    absolutePath: output.absolutePath !== undefined && output.absolutePath !== null ? output.absolutePath : undefined,
-    blobId: output.blobId !== undefined && output.blobId !== null ? output.blobId : undefined,
-    fileMode: output.fileMode !== undefined && output.fileMode !== null ? output.fileMode : undefined,
-    relativePath: output.relativePath !== undefined && output.relativePath !== null ? output.relativePath : undefined,
+    absolutePath: __expectString(output.absolutePath),
+    blobId: __expectString(output.blobId),
+    fileMode: __expectString(output.fileMode),
+    relativePath: __expectString(output.relativePath),
   } as any;
 };
 
@@ -18953,7 +18891,7 @@ const deserializeAws_json1_1FileContentAndSourceFileSpecifiedException = (
   context: __SerdeContext
 ): FileContentAndSourceFileSpecifiedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -18962,7 +18900,7 @@ const deserializeAws_json1_1FileContentRequiredException = (
   context: __SerdeContext
 ): FileContentRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -18971,7 +18909,7 @@ const deserializeAws_json1_1FileContentSizeLimitExceededException = (
   context: __SerdeContext
 ): FileContentSizeLimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -18980,7 +18918,7 @@ const deserializeAws_json1_1FileDoesNotExistException = (
   context: __SerdeContext
 ): FileDoesNotExistException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -18989,7 +18927,7 @@ const deserializeAws_json1_1FileEntryRequiredException = (
   context: __SerdeContext
 ): FileEntryRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19006,9 +18944,9 @@ const deserializeAws_json1_1FileList = (output: any, context: __SerdeContext): F
 
 const deserializeAws_json1_1FileMetadata = (output: any, context: __SerdeContext): FileMetadata => {
   return {
-    absolutePath: output.absolutePath !== undefined && output.absolutePath !== null ? output.absolutePath : undefined,
-    blobId: output.blobId !== undefined && output.blobId !== null ? output.blobId : undefined,
-    fileMode: output.fileMode !== undefined && output.fileMode !== null ? output.fileMode : undefined,
+    absolutePath: __expectString(output.absolutePath),
+    blobId: __expectString(output.blobId),
+    fileMode: __expectString(output.fileMode),
   } as any;
 };
 
@@ -19017,15 +18955,15 @@ const deserializeAws_json1_1FileModeRequiredException = (
   context: __SerdeContext
 ): FileModeRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1FileModes = (output: any, context: __SerdeContext): FileModes => {
   return {
-    base: output.base !== undefined && output.base !== null ? output.base : undefined,
-    destination: output.destination !== undefined && output.destination !== null ? output.destination : undefined,
-    source: output.source !== undefined && output.source !== null ? output.source : undefined,
+    base: __expectString(output.base),
+    destination: __expectString(output.destination),
+    source: __expectString(output.source),
   } as any;
 };
 
@@ -19034,7 +18972,7 @@ const deserializeAws_json1_1FileNameConflictsWithDirectoryNameException = (
   context: __SerdeContext
 ): FileNameConflictsWithDirectoryNameException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19043,15 +18981,15 @@ const deserializeAws_json1_1FilePathConflictsWithSubmodulePathException = (
   context: __SerdeContext
 ): FilePathConflictsWithSubmodulePathException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1FileSizes = (output: any, context: __SerdeContext): FileSizes => {
   return {
-    base: output.base !== undefined && output.base !== null ? output.base : undefined,
-    destination: output.destination !== undefined && output.destination !== null ? output.destination : undefined,
-    source: output.source !== undefined && output.source !== null ? output.source : undefined,
+    base: __expectNumber(output.base),
+    destination: __expectNumber(output.destination),
+    source: __expectNumber(output.source),
   } as any;
 };
 
@@ -19068,15 +19006,15 @@ const deserializeAws_json1_1FilesMetadata = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1FileTooLargeException = (output: any, context: __SerdeContext): FileTooLargeException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1Folder = (output: any, context: __SerdeContext): Folder => {
   return {
-    absolutePath: output.absolutePath !== undefined && output.absolutePath !== null ? output.absolutePath : undefined,
-    relativePath: output.relativePath !== undefined && output.relativePath !== null ? output.relativePath : undefined,
-    treeId: output.treeId !== undefined && output.treeId !== null ? output.treeId : undefined,
+    absolutePath: __expectString(output.absolutePath),
+    relativePath: __expectString(output.relativePath),
+    treeId: __expectString(output.treeId),
   } as any;
 };
 
@@ -19085,7 +19023,7 @@ const deserializeAws_json1_1FolderContentSizeLimitExceededException = (
   context: __SerdeContext
 ): FolderContentSizeLimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19094,7 +19032,7 @@ const deserializeAws_json1_1FolderDoesNotExistException = (
   context: __SerdeContext
 ): FolderDoesNotExistException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19151,7 +19089,7 @@ const deserializeAws_json1_1GetCommentReactionsOutput = (
   context: __SerdeContext
 ): GetCommentReactionsOutput => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     reactionsForComment:
       output.reactionsForComment !== undefined && output.reactionsForComment !== null
         ? deserializeAws_json1_1ReactionsForCommentList(output.reactionsForComment, context)
@@ -19168,7 +19106,7 @@ const deserializeAws_json1_1GetCommentsForComparedCommitOutput = (
       output.commentsForComparedCommitData !== undefined && output.commentsForComparedCommitData !== null
         ? deserializeAws_json1_1CommentsForComparedCommitData(output.commentsForComparedCommitData, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -19181,7 +19119,7 @@ const deserializeAws_json1_1GetCommentsForPullRequestOutput = (
       output.commentsForPullRequestData !== undefined && output.commentsForPullRequestData !== null
         ? deserializeAws_json1_1CommentsForPullRequestData(output.commentsForPullRequestData, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -19196,7 +19134,7 @@ const deserializeAws_json1_1GetCommitOutput = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_1GetDifferencesOutput = (output: any, context: __SerdeContext): GetDifferencesOutput => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     differences:
       output.differences !== undefined && output.differences !== null
         ? deserializeAws_json1_1DifferenceList(output.differences, context)
@@ -19206,26 +19144,26 @@ const deserializeAws_json1_1GetDifferencesOutput = (output: any, context: __Serd
 
 const deserializeAws_json1_1GetFileOutput = (output: any, context: __SerdeContext): GetFileOutput => {
   return {
-    blobId: output.blobId !== undefined && output.blobId !== null ? output.blobId : undefined,
-    commitId: output.commitId !== undefined && output.commitId !== null ? output.commitId : undefined,
+    blobId: __expectString(output.blobId),
+    commitId: __expectString(output.commitId),
     fileContent:
       output.fileContent !== undefined && output.fileContent !== null
         ? context.base64Decoder(output.fileContent)
         : undefined,
-    fileMode: output.fileMode !== undefined && output.fileMode !== null ? output.fileMode : undefined,
-    filePath: output.filePath !== undefined && output.filePath !== null ? output.filePath : undefined,
-    fileSize: output.fileSize !== undefined && output.fileSize !== null ? output.fileSize : undefined,
+    fileMode: __expectString(output.fileMode),
+    filePath: __expectString(output.filePath),
+    fileSize: __expectNumber(output.fileSize),
   } as any;
 };
 
 const deserializeAws_json1_1GetFolderOutput = (output: any, context: __SerdeContext): GetFolderOutput => {
   return {
-    commitId: output.commitId !== undefined && output.commitId !== null ? output.commitId : undefined,
+    commitId: __expectString(output.commitId),
     files:
       output.files !== undefined && output.files !== null
         ? deserializeAws_json1_1FileList(output.files, context)
         : undefined,
-    folderPath: output.folderPath !== undefined && output.folderPath !== null ? output.folderPath : undefined,
+    folderPath: __expectString(output.folderPath),
     subFolders:
       output.subFolders !== undefined && output.subFolders !== null
         ? deserializeAws_json1_1FolderList(output.subFolders, context)
@@ -19238,21 +19176,16 @@ const deserializeAws_json1_1GetFolderOutput = (output: any, context: __SerdeCont
       output.symbolicLinks !== undefined && output.symbolicLinks !== null
         ? deserializeAws_json1_1SymbolicLinkList(output.symbolicLinks, context)
         : undefined,
-    treeId: output.treeId !== undefined && output.treeId !== null ? output.treeId : undefined,
+    treeId: __expectString(output.treeId),
   } as any;
 };
 
 const deserializeAws_json1_1GetMergeCommitOutput = (output: any, context: __SerdeContext): GetMergeCommitOutput => {
   return {
-    baseCommitId: output.baseCommitId !== undefined && output.baseCommitId !== null ? output.baseCommitId : undefined,
-    destinationCommitId:
-      output.destinationCommitId !== undefined && output.destinationCommitId !== null
-        ? output.destinationCommitId
-        : undefined,
-    mergedCommitId:
-      output.mergedCommitId !== undefined && output.mergedCommitId !== null ? output.mergedCommitId : undefined,
-    sourceCommitId:
-      output.sourceCommitId !== undefined && output.sourceCommitId !== null ? output.sourceCommitId : undefined,
+    baseCommitId: __expectString(output.baseCommitId),
+    destinationCommitId: __expectString(output.destinationCommitId),
+    mergedCommitId: __expectString(output.mergedCommitId),
+    sourceCommitId: __expectString(output.sourceCommitId),
   } as any;
 };
 
@@ -19261,35 +19194,27 @@ const deserializeAws_json1_1GetMergeConflictsOutput = (
   context: __SerdeContext
 ): GetMergeConflictsOutput => {
   return {
-    baseCommitId: output.baseCommitId !== undefined && output.baseCommitId !== null ? output.baseCommitId : undefined,
+    baseCommitId: __expectString(output.baseCommitId),
     conflictMetadataList:
       output.conflictMetadataList !== undefined && output.conflictMetadataList !== null
         ? deserializeAws_json1_1ConflictMetadataList(output.conflictMetadataList, context)
         : undefined,
-    destinationCommitId:
-      output.destinationCommitId !== undefined && output.destinationCommitId !== null
-        ? output.destinationCommitId
-        : undefined,
-    mergeable: output.mergeable !== undefined && output.mergeable !== null ? output.mergeable : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
-    sourceCommitId:
-      output.sourceCommitId !== undefined && output.sourceCommitId !== null ? output.sourceCommitId : undefined,
+    destinationCommitId: __expectString(output.destinationCommitId),
+    mergeable: __expectBoolean(output.mergeable),
+    nextToken: __expectString(output.nextToken),
+    sourceCommitId: __expectString(output.sourceCommitId),
   } as any;
 };
 
 const deserializeAws_json1_1GetMergeOptionsOutput = (output: any, context: __SerdeContext): GetMergeOptionsOutput => {
   return {
-    baseCommitId: output.baseCommitId !== undefined && output.baseCommitId !== null ? output.baseCommitId : undefined,
-    destinationCommitId:
-      output.destinationCommitId !== undefined && output.destinationCommitId !== null
-        ? output.destinationCommitId
-        : undefined,
+    baseCommitId: __expectString(output.baseCommitId),
+    destinationCommitId: __expectString(output.destinationCommitId),
     mergeOptions:
       output.mergeOptions !== undefined && output.mergeOptions !== null
         ? deserializeAws_json1_1MergeOptions(output.mergeOptions, context)
         : undefined,
-    sourceCommitId:
-      output.sourceCommitId !== undefined && output.sourceCommitId !== null ? output.sourceCommitId : undefined,
+    sourceCommitId: __expectString(output.sourceCommitId),
   } as any;
 };
 
@@ -19319,8 +19244,8 @@ const deserializeAws_json1_1GetPullRequestOverrideStateOutput = (
   context: __SerdeContext
 ): GetPullRequestOverrideStateOutput => {
   return {
-    overridden: output.overridden !== undefined && output.overridden !== null ? output.overridden : undefined,
-    overrider: output.overrider !== undefined && output.overrider !== null ? output.overrider : undefined,
+    overridden: __expectBoolean(output.overridden),
+    overrider: __expectString(output.overrider),
   } as any;
 };
 
@@ -19338,8 +19263,7 @@ const deserializeAws_json1_1GetRepositoryTriggersOutput = (
   context: __SerdeContext
 ): GetRepositoryTriggersOutput => {
   return {
-    configurationId:
-      output.configurationId !== undefined && output.configurationId !== null ? output.configurationId : undefined,
+    configurationId: __expectString(output.configurationId),
     triggers:
       output.triggers !== undefined && output.triggers !== null
         ? deserializeAws_json1_1RepositoryTriggersList(output.triggers, context)
@@ -19352,7 +19276,7 @@ const deserializeAws_json1_1IdempotencyParameterMismatchException = (
   context: __SerdeContext
 ): IdempotencyParameterMismatchException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19361,7 +19285,7 @@ const deserializeAws_json1_1InvalidActorArnException = (
   context: __SerdeContext
 ): InvalidActorArnException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19370,7 +19294,7 @@ const deserializeAws_json1_1InvalidApprovalRuleContentException = (
   context: __SerdeContext
 ): InvalidApprovalRuleContentException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19379,7 +19303,7 @@ const deserializeAws_json1_1InvalidApprovalRuleNameException = (
   context: __SerdeContext
 ): InvalidApprovalRuleNameException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19388,7 +19312,7 @@ const deserializeAws_json1_1InvalidApprovalRuleTemplateContentException = (
   context: __SerdeContext
 ): InvalidApprovalRuleTemplateContentException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19397,7 +19321,7 @@ const deserializeAws_json1_1InvalidApprovalRuleTemplateDescriptionException = (
   context: __SerdeContext
 ): InvalidApprovalRuleTemplateDescriptionException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19406,7 +19330,7 @@ const deserializeAws_json1_1InvalidApprovalRuleTemplateNameException = (
   context: __SerdeContext
 ): InvalidApprovalRuleTemplateNameException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19415,7 +19339,7 @@ const deserializeAws_json1_1InvalidApprovalStateException = (
   context: __SerdeContext
 ): InvalidApprovalStateException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19424,13 +19348,13 @@ const deserializeAws_json1_1InvalidAuthorArnException = (
   context: __SerdeContext
 ): InvalidAuthorArnException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidBlobIdException = (output: any, context: __SerdeContext): InvalidBlobIdException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19439,7 +19363,7 @@ const deserializeAws_json1_1InvalidBranchNameException = (
   context: __SerdeContext
 ): InvalidBranchNameException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19448,7 +19372,7 @@ const deserializeAws_json1_1InvalidClientRequestTokenException = (
   context: __SerdeContext
 ): InvalidClientRequestTokenException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19457,13 +19381,13 @@ const deserializeAws_json1_1InvalidCommentIdException = (
   context: __SerdeContext
 ): InvalidCommentIdException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidCommitException = (output: any, context: __SerdeContext): InvalidCommitException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19472,7 +19396,7 @@ const deserializeAws_json1_1InvalidCommitIdException = (
   context: __SerdeContext
 ): InvalidCommitIdException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19481,7 +19405,7 @@ const deserializeAws_json1_1InvalidConflictDetailLevelException = (
   context: __SerdeContext
 ): InvalidConflictDetailLevelException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19490,7 +19414,7 @@ const deserializeAws_json1_1InvalidConflictResolutionException = (
   context: __SerdeContext
 ): InvalidConflictResolutionException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19499,7 +19423,7 @@ const deserializeAws_json1_1InvalidConflictResolutionStrategyException = (
   context: __SerdeContext
 ): InvalidConflictResolutionStrategyException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19508,7 +19432,7 @@ const deserializeAws_json1_1InvalidContinuationTokenException = (
   context: __SerdeContext
 ): InvalidContinuationTokenException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19517,7 +19441,7 @@ const deserializeAws_json1_1InvalidDeletionParameterException = (
   context: __SerdeContext
 ): InvalidDeletionParameterException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19526,7 +19450,7 @@ const deserializeAws_json1_1InvalidDescriptionException = (
   context: __SerdeContext
 ): InvalidDescriptionException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19535,13 +19459,13 @@ const deserializeAws_json1_1InvalidDestinationCommitSpecifierException = (
   context: __SerdeContext
 ): InvalidDestinationCommitSpecifierException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidEmailException = (output: any, context: __SerdeContext): InvalidEmailException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19550,7 +19474,7 @@ const deserializeAws_json1_1InvalidFileLocationException = (
   context: __SerdeContext
 ): InvalidFileLocationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19559,7 +19483,7 @@ const deserializeAws_json1_1InvalidFileModeException = (
   context: __SerdeContext
 ): InvalidFileModeException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19568,7 +19492,7 @@ const deserializeAws_json1_1InvalidFilePositionException = (
   context: __SerdeContext
 ): InvalidFilePositionException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19577,7 +19501,7 @@ const deserializeAws_json1_1InvalidMaxConflictFilesException = (
   context: __SerdeContext
 ): InvalidMaxConflictFilesException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19586,7 +19510,7 @@ const deserializeAws_json1_1InvalidMaxMergeHunksException = (
   context: __SerdeContext
 ): InvalidMaxMergeHunksException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19595,7 +19519,7 @@ const deserializeAws_json1_1InvalidMaxResultsException = (
   context: __SerdeContext
 ): InvalidMaxResultsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19604,13 +19528,13 @@ const deserializeAws_json1_1InvalidMergeOptionException = (
   context: __SerdeContext
 ): InvalidMergeOptionException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidOrderException = (output: any, context: __SerdeContext): InvalidOrderException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19619,7 +19543,7 @@ const deserializeAws_json1_1InvalidOverrideStatusException = (
   context: __SerdeContext
 ): InvalidOverrideStatusException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19628,13 +19552,13 @@ const deserializeAws_json1_1InvalidParentCommitIdException = (
   context: __SerdeContext
 ): InvalidParentCommitIdException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidPathException = (output: any, context: __SerdeContext): InvalidPathException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19643,7 +19567,7 @@ const deserializeAws_json1_1InvalidPullRequestEventTypeException = (
   context: __SerdeContext
 ): InvalidPullRequestEventTypeException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19652,7 +19576,7 @@ const deserializeAws_json1_1InvalidPullRequestIdException = (
   context: __SerdeContext
 ): InvalidPullRequestIdException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19661,7 +19585,7 @@ const deserializeAws_json1_1InvalidPullRequestStatusException = (
   context: __SerdeContext
 ): InvalidPullRequestStatusException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19670,7 +19594,7 @@ const deserializeAws_json1_1InvalidPullRequestStatusUpdateException = (
   context: __SerdeContext
 ): InvalidPullRequestStatusUpdateException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19679,7 +19603,7 @@ const deserializeAws_json1_1InvalidReactionUserArnException = (
   context: __SerdeContext
 ): InvalidReactionUserArnException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19688,7 +19612,7 @@ const deserializeAws_json1_1InvalidReactionValueException = (
   context: __SerdeContext
 ): InvalidReactionValueException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19697,7 +19621,7 @@ const deserializeAws_json1_1InvalidReferenceNameException = (
   context: __SerdeContext
 ): InvalidReferenceNameException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19706,7 +19630,7 @@ const deserializeAws_json1_1InvalidRelativeFileVersionEnumException = (
   context: __SerdeContext
 ): InvalidRelativeFileVersionEnumException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19715,7 +19639,7 @@ const deserializeAws_json1_1InvalidReplacementContentException = (
   context: __SerdeContext
 ): InvalidReplacementContentException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19724,7 +19648,7 @@ const deserializeAws_json1_1InvalidReplacementTypeException = (
   context: __SerdeContext
 ): InvalidReplacementTypeException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19733,7 +19657,7 @@ const deserializeAws_json1_1InvalidRepositoryDescriptionException = (
   context: __SerdeContext
 ): InvalidRepositoryDescriptionException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19742,7 +19666,7 @@ const deserializeAws_json1_1InvalidRepositoryNameException = (
   context: __SerdeContext
 ): InvalidRepositoryNameException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19751,7 +19675,7 @@ const deserializeAws_json1_1InvalidRepositoryTriggerBranchNameException = (
   context: __SerdeContext
 ): InvalidRepositoryTriggerBranchNameException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19760,7 +19684,7 @@ const deserializeAws_json1_1InvalidRepositoryTriggerCustomDataException = (
   context: __SerdeContext
 ): InvalidRepositoryTriggerCustomDataException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19769,7 +19693,7 @@ const deserializeAws_json1_1InvalidRepositoryTriggerDestinationArnException = (
   context: __SerdeContext
 ): InvalidRepositoryTriggerDestinationArnException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19778,7 +19702,7 @@ const deserializeAws_json1_1InvalidRepositoryTriggerEventsException = (
   context: __SerdeContext
 ): InvalidRepositoryTriggerEventsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19787,7 +19711,7 @@ const deserializeAws_json1_1InvalidRepositoryTriggerNameException = (
   context: __SerdeContext
 ): InvalidRepositoryTriggerNameException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19796,7 +19720,7 @@ const deserializeAws_json1_1InvalidRepositoryTriggerRegionException = (
   context: __SerdeContext
 ): InvalidRepositoryTriggerRegionException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19805,7 +19729,7 @@ const deserializeAws_json1_1InvalidResourceArnException = (
   context: __SerdeContext
 ): InvalidResourceArnException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19814,7 +19738,7 @@ const deserializeAws_json1_1InvalidRevisionIdException = (
   context: __SerdeContext
 ): InvalidRevisionIdException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19823,13 +19747,13 @@ const deserializeAws_json1_1InvalidRuleContentSha256Exception = (
   context: __SerdeContext
 ): InvalidRuleContentSha256Exception => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidSortByException = (output: any, context: __SerdeContext): InvalidSortByException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19838,7 +19762,7 @@ const deserializeAws_json1_1InvalidSourceCommitSpecifierException = (
   context: __SerdeContext
 ): InvalidSourceCommitSpecifierException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19847,7 +19771,7 @@ const deserializeAws_json1_1InvalidSystemTagUsageException = (
   context: __SerdeContext
 ): InvalidSystemTagUsageException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19856,7 +19780,7 @@ const deserializeAws_json1_1InvalidTagKeysListException = (
   context: __SerdeContext
 ): InvalidTagKeysListException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19865,7 +19789,7 @@ const deserializeAws_json1_1InvalidTagsMapException = (
   context: __SerdeContext
 ): InvalidTagsMapException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19874,13 +19798,13 @@ const deserializeAws_json1_1InvalidTargetBranchException = (
   context: __SerdeContext
 ): InvalidTargetBranchException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidTargetException = (output: any, context: __SerdeContext): InvalidTargetException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19889,21 +19813,21 @@ const deserializeAws_json1_1InvalidTargetsException = (
   context: __SerdeContext
 ): InvalidTargetsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidTitleException = (output: any, context: __SerdeContext): InvalidTitleException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1IsBinaryFile = (output: any, context: __SerdeContext): IsBinaryFile => {
   return {
-    base: output.base !== undefined && output.base !== null ? output.base : undefined,
-    destination: output.destination !== undefined && output.destination !== null ? output.destination : undefined,
-    source: output.source !== undefined && output.source !== null ? output.source : undefined,
+    base: __expectBoolean(output.base),
+    destination: __expectBoolean(output.destination),
+    source: __expectBoolean(output.source),
   } as any;
 };
 
@@ -19916,7 +19840,7 @@ const deserializeAws_json1_1ListApprovalRuleTemplatesOutput = (
       output.approvalRuleTemplateNames !== undefined && output.approvalRuleTemplateNames !== null
         ? deserializeAws_json1_1ApprovalRuleTemplateNameList(output.approvalRuleTemplateNames, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -19929,7 +19853,7 @@ const deserializeAws_json1_1ListAssociatedApprovalRuleTemplatesForRepositoryOutp
       output.approvalRuleTemplateNames !== undefined && output.approvalRuleTemplateNames !== null
         ? deserializeAws_json1_1ApprovalRuleTemplateNameList(output.approvalRuleTemplateNames, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -19939,13 +19863,13 @@ const deserializeAws_json1_1ListBranchesOutput = (output: any, context: __SerdeC
       output.branches !== undefined && output.branches !== null
         ? deserializeAws_json1_1BranchNameList(output.branches, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
 const deserializeAws_json1_1ListPullRequestsOutput = (output: any, context: __SerdeContext): ListPullRequestsOutput => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     pullRequestIds:
       output.pullRequestIds !== undefined && output.pullRequestIds !== null
         ? deserializeAws_json1_1PullRequestIdList(output.pullRequestIds, context)
@@ -19958,7 +19882,7 @@ const deserializeAws_json1_1ListRepositoriesForApprovalRuleTemplateOutput = (
   context: __SerdeContext
 ): ListRepositoriesForApprovalRuleTemplateOutput => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     repositoryNames:
       output.repositoryNames !== undefined && output.repositoryNames !== null
         ? deserializeAws_json1_1RepositoryNameList(output.repositoryNames, context)
@@ -19968,7 +19892,7 @@ const deserializeAws_json1_1ListRepositoriesForApprovalRuleTemplateOutput = (
 
 const deserializeAws_json1_1ListRepositoriesOutput = (output: any, context: __SerdeContext): ListRepositoriesOutput => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     repositories:
       output.repositories !== undefined && output.repositories !== null
         ? deserializeAws_json1_1RepositoryNameIdPairList(output.repositories, context)
@@ -19981,7 +19905,7 @@ const deserializeAws_json1_1ListTagsForResourceOutput = (
   context: __SerdeContext
 ): ListTagsForResourceOutput => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_json1_1TagsMap(output.tags, context)
@@ -19991,12 +19915,9 @@ const deserializeAws_json1_1ListTagsForResourceOutput = (
 
 const deserializeAws_json1_1Location = (output: any, context: __SerdeContext): Location => {
   return {
-    filePath: output.filePath !== undefined && output.filePath !== null ? output.filePath : undefined,
-    filePosition: output.filePosition !== undefined && output.filePosition !== null ? output.filePosition : undefined,
-    relativeFileVersion:
-      output.relativeFileVersion !== undefined && output.relativeFileVersion !== null
-        ? output.relativeFileVersion
-        : undefined,
+    filePath: __expectString(output.filePath),
+    filePosition: __expectNumber(output.filePosition),
+    relativeFileVersion: __expectString(output.relativeFileVersion),
   } as any;
 };
 
@@ -20005,7 +19926,7 @@ const deserializeAws_json1_1ManualMergeRequiredException = (
   context: __SerdeContext
 ): ManualMergeRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -20014,7 +19935,7 @@ const deserializeAws_json1_1MaximumBranchesExceededException = (
   context: __SerdeContext
 ): MaximumBranchesExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -20023,7 +19944,7 @@ const deserializeAws_json1_1MaximumConflictResolutionEntriesExceededException = 
   context: __SerdeContext
 ): MaximumConflictResolutionEntriesExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -20032,7 +19953,7 @@ const deserializeAws_json1_1MaximumFileContentToLoadExceededException = (
   context: __SerdeContext
 ): MaximumFileContentToLoadExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -20041,7 +19962,7 @@ const deserializeAws_json1_1MaximumFileEntriesExceededException = (
   context: __SerdeContext
 ): MaximumFileEntriesExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -20050,7 +19971,7 @@ const deserializeAws_json1_1MaximumItemsToCompareExceededException = (
   context: __SerdeContext
 ): MaximumItemsToCompareExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -20059,7 +19980,7 @@ const deserializeAws_json1_1MaximumNumberOfApprovalsExceededException = (
   context: __SerdeContext
 ): MaximumNumberOfApprovalsExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -20068,7 +19989,7 @@ const deserializeAws_json1_1MaximumOpenPullRequestsExceededException = (
   context: __SerdeContext
 ): MaximumOpenPullRequestsExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -20077,7 +19998,7 @@ const deserializeAws_json1_1MaximumRepositoryNamesExceededException = (
   context: __SerdeContext
 ): MaximumRepositoryNamesExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -20086,7 +20007,7 @@ const deserializeAws_json1_1MaximumRepositoryTriggersExceededException = (
   context: __SerdeContext
 ): MaximumRepositoryTriggersExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -20095,7 +20016,7 @@ const deserializeAws_json1_1MaximumRuleTemplatesAssociatedWithRepositoryExceptio
   context: __SerdeContext
 ): MaximumRuleTemplatesAssociatedWithRepositoryException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -20104,8 +20025,8 @@ const deserializeAws_json1_1MergeBranchesByFastForwardOutput = (
   context: __SerdeContext
 ): MergeBranchesByFastForwardOutput => {
   return {
-    commitId: output.commitId !== undefined && output.commitId !== null ? output.commitId : undefined,
-    treeId: output.treeId !== undefined && output.treeId !== null ? output.treeId : undefined,
+    commitId: __expectString(output.commitId),
+    treeId: __expectString(output.treeId),
   } as any;
 };
 
@@ -20114,8 +20035,8 @@ const deserializeAws_json1_1MergeBranchesBySquashOutput = (
   context: __SerdeContext
 ): MergeBranchesBySquashOutput => {
   return {
-    commitId: output.commitId !== undefined && output.commitId !== null ? output.commitId : undefined,
-    treeId: output.treeId !== undefined && output.treeId !== null ? output.treeId : undefined,
+    commitId: __expectString(output.commitId),
+    treeId: __expectString(output.treeId),
   } as any;
 };
 
@@ -20124,8 +20045,8 @@ const deserializeAws_json1_1MergeBranchesByThreeWayOutput = (
   context: __SerdeContext
 ): MergeBranchesByThreeWayOutput => {
   return {
-    commitId: output.commitId !== undefined && output.commitId !== null ? output.commitId : undefined,
-    treeId: output.treeId !== undefined && output.treeId !== null ? output.treeId : undefined,
+    commitId: __expectString(output.commitId),
+    treeId: __expectString(output.treeId),
   } as any;
 };
 
@@ -20139,7 +20060,7 @@ const deserializeAws_json1_1MergeHunk = (output: any, context: __SerdeContext): 
       output.destination !== undefined && output.destination !== null
         ? deserializeAws_json1_1MergeHunkDetail(output.destination, context)
         : undefined,
-    isConflict: output.isConflict !== undefined && output.isConflict !== null ? output.isConflict : undefined,
+    isConflict: __expectBoolean(output.isConflict),
     source:
       output.source !== undefined && output.source !== null
         ? deserializeAws_json1_1MergeHunkDetail(output.source, context)
@@ -20149,9 +20070,9 @@ const deserializeAws_json1_1MergeHunk = (output: any, context: __SerdeContext): 
 
 const deserializeAws_json1_1MergeHunkDetail = (output: any, context: __SerdeContext): MergeHunkDetail => {
   return {
-    endLine: output.endLine !== undefined && output.endLine !== null ? output.endLine : undefined,
-    hunkContent: output.hunkContent !== undefined && output.hunkContent !== null ? output.hunkContent : undefined,
-    startLine: output.startLine !== undefined && output.startLine !== null ? output.startLine : undefined,
+    endLine: __expectNumber(output.endLine),
+    hunkContent: __expectString(output.hunkContent),
+    startLine: __expectNumber(output.startLine),
   } as any;
 };
 
@@ -20168,18 +20089,17 @@ const deserializeAws_json1_1MergeHunks = (output: any, context: __SerdeContext):
 
 const deserializeAws_json1_1MergeMetadata = (output: any, context: __SerdeContext): MergeMetadata => {
   return {
-    isMerged: output.isMerged !== undefined && output.isMerged !== null ? output.isMerged : undefined,
-    mergeCommitId:
-      output.mergeCommitId !== undefined && output.mergeCommitId !== null ? output.mergeCommitId : undefined,
-    mergeOption: output.mergeOption !== undefined && output.mergeOption !== null ? output.mergeOption : undefined,
-    mergedBy: output.mergedBy !== undefined && output.mergedBy !== null ? output.mergedBy : undefined,
+    isMerged: __expectBoolean(output.isMerged),
+    mergeCommitId: __expectString(output.mergeCommitId),
+    mergeOption: __expectString(output.mergeOption),
+    mergedBy: __expectString(output.mergedBy),
   } as any;
 };
 
 const deserializeAws_json1_1MergeOperations = (output: any, context: __SerdeContext): MergeOperations => {
   return {
-    destination: output.destination !== undefined && output.destination !== null ? output.destination : undefined,
-    source: output.source !== undefined && output.source !== null ? output.source : undefined,
+    destination: __expectString(output.destination),
+    source: __expectString(output.source),
   } as any;
 };
 
@@ -20188,7 +20108,7 @@ const deserializeAws_json1_1MergeOptionRequiredException = (
   context: __SerdeContext
 ): MergeOptionRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -20199,7 +20119,7 @@ const deserializeAws_json1_1MergeOptions = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -20244,7 +20164,7 @@ const deserializeAws_json1_1MultipleConflictResolutionEntriesException = (
   context: __SerdeContext
 ): MultipleConflictResolutionEntriesException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -20253,7 +20173,7 @@ const deserializeAws_json1_1MultipleRepositoriesInPullRequestException = (
   context: __SerdeContext
 ): MultipleRepositoriesInPullRequestException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -20262,13 +20182,13 @@ const deserializeAws_json1_1NameLengthExceededException = (
   context: __SerdeContext
 ): NameLengthExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1NoChangeException = (output: any, context: __SerdeContext): NoChangeException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -20277,7 +20197,7 @@ const deserializeAws_json1_1NumberOfRulesExceededException = (
   context: __SerdeContext
 ): NumberOfRulesExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -20286,15 +20206,15 @@ const deserializeAws_json1_1NumberOfRuleTemplatesExceededException = (
   context: __SerdeContext
 ): NumberOfRuleTemplatesExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1ObjectTypes = (output: any, context: __SerdeContext): ObjectTypes => {
   return {
-    base: output.base !== undefined && output.base !== null ? output.base : undefined,
-    destination: output.destination !== undefined && output.destination !== null ? output.destination : undefined,
-    source: output.source !== undefined && output.source !== null ? output.source : undefined,
+    base: __expectString(output.base),
+    destination: __expectString(output.destination),
+    source: __expectString(output.source),
   } as any;
 };
 
@@ -20303,14 +20223,8 @@ const deserializeAws_json1_1OriginApprovalRuleTemplate = (
   context: __SerdeContext
 ): OriginApprovalRuleTemplate => {
   return {
-    approvalRuleTemplateId:
-      output.approvalRuleTemplateId !== undefined && output.approvalRuleTemplateId !== null
-        ? output.approvalRuleTemplateId
-        : undefined,
-    approvalRuleTemplateName:
-      output.approvalRuleTemplateName !== undefined && output.approvalRuleTemplateName !== null
-        ? output.approvalRuleTemplateName
-        : undefined,
+    approvalRuleTemplateId: __expectString(output.approvalRuleTemplateId),
+    approvalRuleTemplateName: __expectString(output.approvalRuleTemplateName),
   } as any;
 };
 
@@ -20319,7 +20233,7 @@ const deserializeAws_json1_1OverrideAlreadySetException = (
   context: __SerdeContext
 ): OverrideAlreadySetException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -20328,7 +20242,7 @@ const deserializeAws_json1_1OverrideStatusRequiredException = (
   context: __SerdeContext
 ): OverrideStatusRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -20337,7 +20251,7 @@ const deserializeAws_json1_1ParentCommitDoesNotExistException = (
   context: __SerdeContext
 ): ParentCommitDoesNotExistException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -20346,7 +20260,7 @@ const deserializeAws_json1_1ParentCommitIdOutdatedException = (
   context: __SerdeContext
 ): ParentCommitIdOutdatedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -20355,7 +20269,7 @@ const deserializeAws_json1_1ParentCommitIdRequiredException = (
   context: __SerdeContext
 ): ParentCommitIdRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -20366,7 +20280,7 @@ const deserializeAws_json1_1ParentList = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -20375,13 +20289,13 @@ const deserializeAws_json1_1PathDoesNotExistException = (
   context: __SerdeContext
 ): PathDoesNotExistException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1PathRequiredException = (output: any, context: __SerdeContext): PathRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -20390,12 +20304,10 @@ const deserializeAws_json1_1PostCommentForComparedCommitOutput = (
   context: __SerdeContext
 ): PostCommentForComparedCommitOutput => {
   return {
-    afterBlobId: output.afterBlobId !== undefined && output.afterBlobId !== null ? output.afterBlobId : undefined,
-    afterCommitId:
-      output.afterCommitId !== undefined && output.afterCommitId !== null ? output.afterCommitId : undefined,
-    beforeBlobId: output.beforeBlobId !== undefined && output.beforeBlobId !== null ? output.beforeBlobId : undefined,
-    beforeCommitId:
-      output.beforeCommitId !== undefined && output.beforeCommitId !== null ? output.beforeCommitId : undefined,
+    afterBlobId: __expectString(output.afterBlobId),
+    afterCommitId: __expectString(output.afterCommitId),
+    beforeBlobId: __expectString(output.beforeBlobId),
+    beforeCommitId: __expectString(output.beforeCommitId),
     comment:
       output.comment !== undefined && output.comment !== null
         ? deserializeAws_json1_1Comment(output.comment, context)
@@ -20404,8 +20316,7 @@ const deserializeAws_json1_1PostCommentForComparedCommitOutput = (
       output.location !== undefined && output.location !== null
         ? deserializeAws_json1_1Location(output.location, context)
         : undefined,
-    repositoryName:
-      output.repositoryName !== undefined && output.repositoryName !== null ? output.repositoryName : undefined,
+    repositoryName: __expectString(output.repositoryName),
   } as any;
 };
 
@@ -20414,12 +20325,10 @@ const deserializeAws_json1_1PostCommentForPullRequestOutput = (
   context: __SerdeContext
 ): PostCommentForPullRequestOutput => {
   return {
-    afterBlobId: output.afterBlobId !== undefined && output.afterBlobId !== null ? output.afterBlobId : undefined,
-    afterCommitId:
-      output.afterCommitId !== undefined && output.afterCommitId !== null ? output.afterCommitId : undefined,
-    beforeBlobId: output.beforeBlobId !== undefined && output.beforeBlobId !== null ? output.beforeBlobId : undefined,
-    beforeCommitId:
-      output.beforeCommitId !== undefined && output.beforeCommitId !== null ? output.beforeCommitId : undefined,
+    afterBlobId: __expectString(output.afterBlobId),
+    afterCommitId: __expectString(output.afterCommitId),
+    beforeBlobId: __expectString(output.beforeBlobId),
+    beforeCommitId: __expectString(output.beforeCommitId),
     comment:
       output.comment !== undefined && output.comment !== null
         ? deserializeAws_json1_1Comment(output.comment, context)
@@ -20428,10 +20337,8 @@ const deserializeAws_json1_1PostCommentForPullRequestOutput = (
       output.location !== undefined && output.location !== null
         ? deserializeAws_json1_1Location(output.location, context)
         : undefined,
-    pullRequestId:
-      output.pullRequestId !== undefined && output.pullRequestId !== null ? output.pullRequestId : undefined,
-    repositoryName:
-      output.repositoryName !== undefined && output.repositoryName !== null ? output.repositoryName : undefined,
+    pullRequestId: __expectString(output.pullRequestId),
+    repositoryName: __expectString(output.repositoryName),
   } as any;
 };
 
@@ -20450,32 +20357,25 @@ const deserializeAws_json1_1PullRequest = (output: any, context: __SerdeContext)
       output.approvalRules !== undefined && output.approvalRules !== null
         ? deserializeAws_json1_1ApprovalRulesList(output.approvalRules, context)
         : undefined,
-    authorArn: output.authorArn !== undefined && output.authorArn !== null ? output.authorArn : undefined,
-    clientRequestToken:
-      output.clientRequestToken !== undefined && output.clientRequestToken !== null
-        ? output.clientRequestToken
-        : undefined,
+    authorArn: __expectString(output.authorArn),
+    clientRequestToken: __expectString(output.clientRequestToken),
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
         ? new Date(Math.round(output.creationDate * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    description: __expectString(output.description),
     lastActivityDate:
       output.lastActivityDate !== undefined && output.lastActivityDate !== null
         ? new Date(Math.round(output.lastActivityDate * 1000))
         : undefined,
-    pullRequestId:
-      output.pullRequestId !== undefined && output.pullRequestId !== null ? output.pullRequestId : undefined,
-    pullRequestStatus:
-      output.pullRequestStatus !== undefined && output.pullRequestStatus !== null
-        ? output.pullRequestStatus
-        : undefined,
+    pullRequestId: __expectString(output.pullRequestId),
+    pullRequestStatus: __expectString(output.pullRequestStatus),
     pullRequestTargets:
       output.pullRequestTargets !== undefined && output.pullRequestTargets !== null
         ? deserializeAws_json1_1PullRequestTargetList(output.pullRequestTargets, context)
         : undefined,
-    revisionId: output.revisionId !== undefined && output.revisionId !== null ? output.revisionId : undefined,
-    title: output.title !== undefined && output.title !== null ? output.title : undefined,
+    revisionId: __expectString(output.revisionId),
+    title: __expectString(output.title),
   } as any;
 };
 
@@ -20484,7 +20384,7 @@ const deserializeAws_json1_1PullRequestAlreadyClosedException = (
   context: __SerdeContext
 ): PullRequestAlreadyClosedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -20493,7 +20393,7 @@ const deserializeAws_json1_1PullRequestApprovalRulesNotSatisfiedException = (
   context: __SerdeContext
 ): PullRequestApprovalRulesNotSatisfiedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -20502,7 +20402,7 @@ const deserializeAws_json1_1PullRequestCannotBeApprovedByAuthorException = (
   context: __SerdeContext
 ): PullRequestCannotBeApprovedByAuthorException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -20511,15 +20411,10 @@ const deserializeAws_json1_1PullRequestCreatedEventMetadata = (
   context: __SerdeContext
 ): PullRequestCreatedEventMetadata => {
   return {
-    destinationCommitId:
-      output.destinationCommitId !== undefined && output.destinationCommitId !== null
-        ? output.destinationCommitId
-        : undefined,
-    mergeBase: output.mergeBase !== undefined && output.mergeBase !== null ? output.mergeBase : undefined,
-    repositoryName:
-      output.repositoryName !== undefined && output.repositoryName !== null ? output.repositoryName : undefined,
-    sourceCommitId:
-      output.sourceCommitId !== undefined && output.sourceCommitId !== null ? output.sourceCommitId : undefined,
+    destinationCommitId: __expectString(output.destinationCommitId),
+    mergeBase: __expectString(output.mergeBase),
+    repositoryName: __expectString(output.repositoryName),
+    sourceCommitId: __expectString(output.sourceCommitId),
   } as any;
 };
 
@@ -20528,13 +20423,13 @@ const deserializeAws_json1_1PullRequestDoesNotExistException = (
   context: __SerdeContext
 ): PullRequestDoesNotExistException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1PullRequestEvent = (output: any, context: __SerdeContext): PullRequestEvent => {
   return {
-    actorArn: output.actorArn !== undefined && output.actorArn !== null ? output.actorArn : undefined,
+    actorArn: __expectString(output.actorArn),
     approvalRuleEventMetadata:
       output.approvalRuleEventMetadata !== undefined && output.approvalRuleEventMetadata !== null
         ? deserializeAws_json1_1ApprovalRuleEventMetadata(output.approvalRuleEventMetadata, context)
@@ -20555,12 +20450,8 @@ const deserializeAws_json1_1PullRequestEvent = (output: any, context: __SerdeCon
       output.pullRequestCreatedEventMetadata !== undefined && output.pullRequestCreatedEventMetadata !== null
         ? deserializeAws_json1_1PullRequestCreatedEventMetadata(output.pullRequestCreatedEventMetadata, context)
         : undefined,
-    pullRequestEventType:
-      output.pullRequestEventType !== undefined && output.pullRequestEventType !== null
-        ? output.pullRequestEventType
-        : undefined,
-    pullRequestId:
-      output.pullRequestId !== undefined && output.pullRequestId !== null ? output.pullRequestId : undefined,
+    pullRequestEventType: __expectString(output.pullRequestEventType),
+    pullRequestId: __expectString(output.pullRequestId),
     pullRequestMergedStateChangedEventMetadata:
       output.pullRequestMergedStateChangedEventMetadata !== undefined &&
       output.pullRequestMergedStateChangedEventMetadata !== null
@@ -20606,7 +20497,7 @@ const deserializeAws_json1_1PullRequestIdList = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -20615,7 +20506,7 @@ const deserializeAws_json1_1PullRequestIdRequiredException = (
   context: __SerdeContext
 ): PullRequestIdRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -20624,16 +20515,12 @@ const deserializeAws_json1_1PullRequestMergedStateChangedEventMetadata = (
   context: __SerdeContext
 ): PullRequestMergedStateChangedEventMetadata => {
   return {
-    destinationReference:
-      output.destinationReference !== undefined && output.destinationReference !== null
-        ? output.destinationReference
-        : undefined,
+    destinationReference: __expectString(output.destinationReference),
     mergeMetadata:
       output.mergeMetadata !== undefined && output.mergeMetadata !== null
         ? deserializeAws_json1_1MergeMetadata(output.mergeMetadata, context)
         : undefined,
-    repositoryName:
-      output.repositoryName !== undefined && output.repositoryName !== null ? output.repositoryName : undefined,
+    repositoryName: __expectString(output.repositoryName),
   } as any;
 };
 
@@ -20642,13 +20529,10 @@ const deserializeAws_json1_1PullRequestSourceReferenceUpdatedEventMetadata = (
   context: __SerdeContext
 ): PullRequestSourceReferenceUpdatedEventMetadata => {
   return {
-    afterCommitId:
-      output.afterCommitId !== undefined && output.afterCommitId !== null ? output.afterCommitId : undefined,
-    beforeCommitId:
-      output.beforeCommitId !== undefined && output.beforeCommitId !== null ? output.beforeCommitId : undefined,
-    mergeBase: output.mergeBase !== undefined && output.mergeBase !== null ? output.mergeBase : undefined,
-    repositoryName:
-      output.repositoryName !== undefined && output.repositoryName !== null ? output.repositoryName : undefined,
+    afterCommitId: __expectString(output.afterCommitId),
+    beforeCommitId: __expectString(output.beforeCommitId),
+    mergeBase: __expectString(output.mergeBase),
+    repositoryName: __expectString(output.repositoryName),
   } as any;
 };
 
@@ -20657,10 +20541,7 @@ const deserializeAws_json1_1PullRequestStatusChangedEventMetadata = (
   context: __SerdeContext
 ): PullRequestStatusChangedEventMetadata => {
   return {
-    pullRequestStatus:
-      output.pullRequestStatus !== undefined && output.pullRequestStatus !== null
-        ? output.pullRequestStatus
-        : undefined,
+    pullRequestStatus: __expectString(output.pullRequestStatus),
   } as any;
 };
 
@@ -20669,30 +20550,22 @@ const deserializeAws_json1_1PullRequestStatusRequiredException = (
   context: __SerdeContext
 ): PullRequestStatusRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1PullRequestTarget = (output: any, context: __SerdeContext): PullRequestTarget => {
   return {
-    destinationCommit:
-      output.destinationCommit !== undefined && output.destinationCommit !== null
-        ? output.destinationCommit
-        : undefined,
-    destinationReference:
-      output.destinationReference !== undefined && output.destinationReference !== null
-        ? output.destinationReference
-        : undefined,
-    mergeBase: output.mergeBase !== undefined && output.mergeBase !== null ? output.mergeBase : undefined,
+    destinationCommit: __expectString(output.destinationCommit),
+    destinationReference: __expectString(output.destinationReference),
+    mergeBase: __expectString(output.mergeBase),
     mergeMetadata:
       output.mergeMetadata !== undefined && output.mergeMetadata !== null
         ? deserializeAws_json1_1MergeMetadata(output.mergeMetadata, context)
         : undefined,
-    repositoryName:
-      output.repositoryName !== undefined && output.repositoryName !== null ? output.repositoryName : undefined,
-    sourceCommit: output.sourceCommit !== undefined && output.sourceCommit !== null ? output.sourceCommit : undefined,
-    sourceReference:
-      output.sourceReference !== undefined && output.sourceReference !== null ? output.sourceReference : undefined,
+    repositoryName: __expectString(output.repositoryName),
+    sourceCommit: __expectString(output.sourceCommit),
+    sourceReference: __expectString(output.sourceReference),
   } as any;
 };
 
@@ -20712,15 +20585,15 @@ const deserializeAws_json1_1PutFileEntryConflictException = (
   context: __SerdeContext
 ): PutFileEntryConflictException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1PutFileOutput = (output: any, context: __SerdeContext): PutFileOutput => {
   return {
-    blobId: output.blobId !== undefined && output.blobId !== null ? output.blobId : undefined,
-    commitId: output.commitId !== undefined && output.commitId !== null ? output.commitId : undefined,
-    treeId: output.treeId !== undefined && output.treeId !== null ? output.treeId : undefined,
+    blobId: __expectString(output.blobId),
+    commitId: __expectString(output.commitId),
+    treeId: __expectString(output.treeId),
   } as any;
 };
 
@@ -20729,8 +20602,7 @@ const deserializeAws_json1_1PutRepositoryTriggersOutput = (
   context: __SerdeContext
 ): PutRepositoryTriggersOutput => {
   return {
-    configurationId:
-      output.configurationId !== undefined && output.configurationId !== null ? output.configurationId : undefined,
+    configurationId: __expectString(output.configurationId),
   } as any;
 };
 
@@ -20741,7 +20613,7 @@ const deserializeAws_json1_1ReactionCountsMap = (output: any, context: __SerdeCo
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectNumber(value) as any,
     };
   }, {});
 };
@@ -20756,10 +20628,7 @@ const deserializeAws_json1_1ReactionForComment = (output: any, context: __SerdeC
       output.reactionUsers !== undefined && output.reactionUsers !== null
         ? deserializeAws_json1_1ReactionUsersList(output.reactionUsers, context)
         : undefined,
-    reactionsFromDeletedUsersCount:
-      output.reactionsFromDeletedUsersCount !== undefined && output.reactionsFromDeletedUsersCount !== null
-        ? output.reactionsFromDeletedUsersCount
-        : undefined,
+    reactionsFromDeletedUsersCount: __expectNumber(output.reactionsFromDeletedUsersCount),
   } as any;
 };
 
@@ -20768,7 +20637,7 @@ const deserializeAws_json1_1ReactionLimitExceededException = (
   context: __SerdeContext
 ): ReactionLimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -20790,15 +20659,15 @@ const deserializeAws_json1_1ReactionUsersList = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1ReactionValueFormats = (output: any, context: __SerdeContext): ReactionValueFormats => {
   return {
-    emoji: output.emoji !== undefined && output.emoji !== null ? output.emoji : undefined,
-    shortCode: output.shortCode !== undefined && output.shortCode !== null ? output.shortCode : undefined,
-    unicode: output.unicode !== undefined && output.unicode !== null ? output.unicode : undefined,
+    emoji: __expectString(output.emoji),
+    shortCode: __expectString(output.shortCode),
+    unicode: __expectString(output.unicode),
   } as any;
 };
 
@@ -20807,7 +20676,7 @@ const deserializeAws_json1_1ReactionValueRequiredException = (
   context: __SerdeContext
 ): ReactionValueRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -20816,7 +20685,7 @@ const deserializeAws_json1_1ReferenceDoesNotExistException = (
   context: __SerdeContext
 ): ReferenceDoesNotExistException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -20825,7 +20694,7 @@ const deserializeAws_json1_1ReferenceNameRequiredException = (
   context: __SerdeContext
 ): ReferenceNameRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -20834,7 +20703,7 @@ const deserializeAws_json1_1ReferenceTypeNotSupportedException = (
   context: __SerdeContext
 ): ReferenceTypeNotSupportedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -20843,7 +20712,7 @@ const deserializeAws_json1_1ReplacementContentRequiredException = (
   context: __SerdeContext
 ): ReplacementContentRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -20852,7 +20721,7 @@ const deserializeAws_json1_1ReplacementTypeRequiredException = (
   context: __SerdeContext
 ): ReplacementTypeRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -20861,7 +20730,7 @@ const deserializeAws_json1_1RepositoryDoesNotExistException = (
   context: __SerdeContext
 ): RepositoryDoesNotExistException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -20870,33 +20739,28 @@ const deserializeAws_json1_1RepositoryLimitExceededException = (
   context: __SerdeContext
 ): RepositoryLimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1RepositoryMetadata = (output: any, context: __SerdeContext): RepositoryMetadata => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    accountId: output.accountId !== undefined && output.accountId !== null ? output.accountId : undefined,
-    cloneUrlHttp: output.cloneUrlHttp !== undefined && output.cloneUrlHttp !== null ? output.cloneUrlHttp : undefined,
-    cloneUrlSsh: output.cloneUrlSsh !== undefined && output.cloneUrlSsh !== null ? output.cloneUrlSsh : undefined,
+    Arn: __expectString(output.Arn),
+    accountId: __expectString(output.accountId),
+    cloneUrlHttp: __expectString(output.cloneUrlHttp),
+    cloneUrlSsh: __expectString(output.cloneUrlSsh),
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
         ? new Date(Math.round(output.creationDate * 1000))
         : undefined,
-    defaultBranch:
-      output.defaultBranch !== undefined && output.defaultBranch !== null ? output.defaultBranch : undefined,
+    defaultBranch: __expectString(output.defaultBranch),
     lastModifiedDate:
       output.lastModifiedDate !== undefined && output.lastModifiedDate !== null
         ? new Date(Math.round(output.lastModifiedDate * 1000))
         : undefined,
-    repositoryDescription:
-      output.repositoryDescription !== undefined && output.repositoryDescription !== null
-        ? output.repositoryDescription
-        : undefined,
-    repositoryId: output.repositoryId !== undefined && output.repositoryId !== null ? output.repositoryId : undefined,
-    repositoryName:
-      output.repositoryName !== undefined && output.repositoryName !== null ? output.repositoryName : undefined,
+    repositoryDescription: __expectString(output.repositoryDescription),
+    repositoryId: __expectString(output.repositoryId),
+    repositoryName: __expectString(output.repositoryName),
   } as any;
 };
 
@@ -20916,15 +20780,14 @@ const deserializeAws_json1_1RepositoryNameExistsException = (
   context: __SerdeContext
 ): RepositoryNameExistsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1RepositoryNameIdPair = (output: any, context: __SerdeContext): RepositoryNameIdPair => {
   return {
-    repositoryId: output.repositoryId !== undefined && output.repositoryId !== null ? output.repositoryId : undefined,
-    repositoryName:
-      output.repositoryName !== undefined && output.repositoryName !== null ? output.repositoryName : undefined,
+    repositoryId: __expectString(output.repositoryId),
+    repositoryName: __expectString(output.repositoryName),
   } as any;
 };
 
@@ -20949,7 +20812,7 @@ const deserializeAws_json1_1RepositoryNameList = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -20958,7 +20821,7 @@ const deserializeAws_json1_1RepositoryNameRequiredException = (
   context: __SerdeContext
 ): RepositoryNameRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -20967,7 +20830,7 @@ const deserializeAws_json1_1RepositoryNamesRequiredException = (
   context: __SerdeContext
 ): RepositoryNamesRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -20976,7 +20839,7 @@ const deserializeAws_json1_1RepositoryNotAssociatedWithPullRequestException = (
   context: __SerdeContext
 ): RepositoryNotAssociatedWithPullRequestException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -20987,7 +20850,7 @@ const deserializeAws_json1_1RepositoryNotFoundList = (output: any, context: __Se
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -20997,14 +20860,13 @@ const deserializeAws_json1_1RepositoryTrigger = (output: any, context: __SerdeCo
       output.branches !== undefined && output.branches !== null
         ? deserializeAws_json1_1BranchNameList(output.branches, context)
         : undefined,
-    customData: output.customData !== undefined && output.customData !== null ? output.customData : undefined,
-    destinationArn:
-      output.destinationArn !== undefined && output.destinationArn !== null ? output.destinationArn : undefined,
+    customData: __expectString(output.customData),
+    destinationArn: __expectString(output.destinationArn),
     events:
       output.events !== undefined && output.events !== null
         ? deserializeAws_json1_1RepositoryTriggerEventList(output.events, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -21013,7 +20875,7 @@ const deserializeAws_json1_1RepositoryTriggerBranchNameListRequiredException = (
   context: __SerdeContext
 ): RepositoryTriggerBranchNameListRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -21022,7 +20884,7 @@ const deserializeAws_json1_1RepositoryTriggerDestinationArnRequiredException = (
   context: __SerdeContext
 ): RepositoryTriggerDestinationArnRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -21036,7 +20898,7 @@ const deserializeAws_json1_1RepositoryTriggerEventList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -21045,7 +20907,7 @@ const deserializeAws_json1_1RepositoryTriggerEventsListRequiredException = (
   context: __SerdeContext
 ): RepositoryTriggerEventsListRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -21054,9 +20916,8 @@ const deserializeAws_json1_1RepositoryTriggerExecutionFailure = (
   context: __SerdeContext
 ): RepositoryTriggerExecutionFailure => {
   return {
-    failureMessage:
-      output.failureMessage !== undefined && output.failureMessage !== null ? output.failureMessage : undefined,
-    trigger: output.trigger !== undefined && output.trigger !== null ? output.trigger : undefined,
+    failureMessage: __expectString(output.failureMessage),
+    trigger: __expectString(output.trigger),
   } as any;
 };
 
@@ -21081,7 +20942,7 @@ const deserializeAws_json1_1RepositoryTriggerNameList = (output: any, context: _
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -21090,7 +20951,7 @@ const deserializeAws_json1_1RepositoryTriggerNameRequiredException = (
   context: __SerdeContext
 ): RepositoryTriggerNameRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -21110,7 +20971,7 @@ const deserializeAws_json1_1RepositoryTriggersListRequiredException = (
   context: __SerdeContext
 ): RepositoryTriggersListRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -21119,7 +20980,7 @@ const deserializeAws_json1_1ResourceArnRequiredException = (
   context: __SerdeContext
 ): ResourceArnRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -21128,7 +20989,7 @@ const deserializeAws_json1_1RestrictedSourceFileException = (
   context: __SerdeContext
 ): RestrictedSourceFileException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -21137,7 +20998,7 @@ const deserializeAws_json1_1RevisionIdRequiredException = (
   context: __SerdeContext
 ): RevisionIdRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -21146,7 +21007,7 @@ const deserializeAws_json1_1RevisionNotCurrentException = (
   context: __SerdeContext
 ): RevisionNotCurrentException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -21155,7 +21016,7 @@ const deserializeAws_json1_1SameFileContentException = (
   context: __SerdeContext
 ): SameFileContentException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -21164,7 +21025,7 @@ const deserializeAws_json1_1SamePathRequestException = (
   context: __SerdeContext
 ): SamePathRequestException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -21173,7 +21034,7 @@ const deserializeAws_json1_1SourceAndDestinationAreSameException = (
   context: __SerdeContext
 ): SourceAndDestinationAreSameException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -21182,15 +21043,15 @@ const deserializeAws_json1_1SourceFileOrContentRequiredException = (
   context: __SerdeContext
 ): SourceFileOrContentRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1SubModule = (output: any, context: __SerdeContext): SubModule => {
   return {
-    absolutePath: output.absolutePath !== undefined && output.absolutePath !== null ? output.absolutePath : undefined,
-    commitId: output.commitId !== undefined && output.commitId !== null ? output.commitId : undefined,
-    relativePath: output.relativePath !== undefined && output.relativePath !== null ? output.relativePath : undefined,
+    absolutePath: __expectString(output.absolutePath),
+    commitId: __expectString(output.commitId),
+    relativePath: __expectString(output.relativePath),
   } as any;
 };
 
@@ -21207,10 +21068,10 @@ const deserializeAws_json1_1SubModuleList = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1SymbolicLink = (output: any, context: __SerdeContext): SymbolicLink => {
   return {
-    absolutePath: output.absolutePath !== undefined && output.absolutePath !== null ? output.absolutePath : undefined,
-    blobId: output.blobId !== undefined && output.blobId !== null ? output.blobId : undefined,
-    fileMode: output.fileMode !== undefined && output.fileMode !== null ? output.fileMode : undefined,
-    relativePath: output.relativePath !== undefined && output.relativePath !== null ? output.relativePath : undefined,
+    absolutePath: __expectString(output.absolutePath),
+    blobId: __expectString(output.blobId),
+    fileMode: __expectString(output.fileMode),
+    relativePath: __expectString(output.relativePath),
   } as any;
 };
 
@@ -21230,13 +21091,13 @@ const deserializeAws_json1_1TagKeysListRequiredException = (
   context: __SerdeContext
 ): TagKeysListRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1TagPolicyException = (output: any, context: __SerdeContext): TagPolicyException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -21247,7 +21108,7 @@ const deserializeAws_json1_1TagsMap = (output: any, context: __SerdeContext): { 
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -21257,7 +21118,7 @@ const deserializeAws_json1_1TagsMapRequiredException = (
   context: __SerdeContext
 ): TagsMapRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -21266,7 +21127,7 @@ const deserializeAws_json1_1TargetRequiredException = (
   context: __SerdeContext
 ): TargetRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -21275,7 +21136,7 @@ const deserializeAws_json1_1TargetsRequiredException = (
   context: __SerdeContext
 ): TargetsRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -21300,7 +21161,7 @@ const deserializeAws_json1_1TipOfSourceReferenceIsDifferentException = (
   context: __SerdeContext
 ): TipOfSourceReferenceIsDifferentException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -21309,19 +21170,19 @@ const deserializeAws_json1_1TipsDivergenceExceededException = (
   context: __SerdeContext
 ): TipsDivergenceExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1TitleRequiredException = (output: any, context: __SerdeContext): TitleRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1TooManyTagsException = (output: any, context: __SerdeContext): TooManyTagsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -21420,9 +21281,9 @@ const deserializeAws_json1_1UpdatePullRequestTitleOutput = (
 
 const deserializeAws_json1_1UserInfo = (output: any, context: __SerdeContext): UserInfo => {
   return {
-    date: output.date !== undefined && output.date !== null ? output.date : undefined,
-    email: output.email !== undefined && output.email !== null ? output.email : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    date: __expectString(output.date),
+    email: __expectString(output.email),
+    name: __expectString(output.name),
   } as any;
 };
 

--- a/clients/client-codedeploy/protocols/Aws_json1_1.ts
+++ b/clients/client-codedeploy/protocols/Aws_json1_1.ts
@@ -403,7 +403,12 @@ import {
   _InstanceType,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -8743,7 +8748,7 @@ const serializeAws_json1_1UpdateDeploymentGroupInput = (
 
 const deserializeAws_json1_1Alarm = (output: any, context: __SerdeContext): Alarm => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -8753,11 +8758,8 @@ const deserializeAws_json1_1AlarmConfiguration = (output: any, context: __SerdeC
       output.alarms !== undefined && output.alarms !== null
         ? deserializeAws_json1_1AlarmList(output.alarms, context)
         : undefined,
-    enabled: output.enabled !== undefined && output.enabled !== null ? output.enabled : undefined,
-    ignorePollAlarmFailure:
-      output.ignorePollAlarmFailure !== undefined && output.ignorePollAlarmFailure !== null
-        ? output.ignorePollAlarmFailure
-        : undefined,
+    enabled: __expectBoolean(output.enabled),
+    ignorePollAlarmFailure: __expectBoolean(output.ignorePollAlarmFailure),
   } as any;
 };
 
@@ -8777,7 +8779,7 @@ const deserializeAws_json1_1AlarmsLimitExceededException = (
   context: __SerdeContext
 ): AlarmsLimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -8786,7 +8788,7 @@ const deserializeAws_json1_1ApplicationAlreadyExistsException = (
   context: __SerdeContext
 ): ApplicationAlreadyExistsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -8795,28 +8797,21 @@ const deserializeAws_json1_1ApplicationDoesNotExistException = (
   context: __SerdeContext
 ): ApplicationDoesNotExistException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1ApplicationInfo = (output: any, context: __SerdeContext): ApplicationInfo => {
   return {
-    applicationId:
-      output.applicationId !== undefined && output.applicationId !== null ? output.applicationId : undefined,
-    applicationName:
-      output.applicationName !== undefined && output.applicationName !== null ? output.applicationName : undefined,
-    computePlatform:
-      output.computePlatform !== undefined && output.computePlatform !== null ? output.computePlatform : undefined,
+    applicationId: __expectString(output.applicationId),
+    applicationName: __expectString(output.applicationName),
+    computePlatform: __expectString(output.computePlatform),
     createTime:
       output.createTime !== undefined && output.createTime !== null
         ? new Date(Math.round(output.createTime * 1000))
         : undefined,
-    gitHubAccountName:
-      output.gitHubAccountName !== undefined && output.gitHubAccountName !== null
-        ? output.gitHubAccountName
-        : undefined,
-    linkedToGitHub:
-      output.linkedToGitHub !== undefined && output.linkedToGitHub !== null ? output.linkedToGitHub : undefined,
+    gitHubAccountName: __expectString(output.gitHubAccountName),
+    linkedToGitHub: __expectBoolean(output.linkedToGitHub),
   } as any;
 };
 
@@ -8825,7 +8820,7 @@ const deserializeAws_json1_1ApplicationLimitExceededException = (
   context: __SerdeContext
 ): ApplicationLimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -8834,7 +8829,7 @@ const deserializeAws_json1_1ApplicationNameRequiredException = (
   context: __SerdeContext
 ): ApplicationNameRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -8856,14 +8851,14 @@ const deserializeAws_json1_1ApplicationsList = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1AppSpecContent = (output: any, context: __SerdeContext): AppSpecContent => {
   return {
-    content: output.content !== undefined && output.content !== null ? output.content : undefined,
-    sha256: output.sha256 !== undefined && output.sha256 !== null ? output.sha256 : undefined,
+    content: __expectString(output.content),
+    sha256: __expectString(output.sha256),
   } as any;
 };
 
@@ -8872,7 +8867,7 @@ const deserializeAws_json1_1ArnNotSupportedException = (
   context: __SerdeContext
 ): ArnNotSupportedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -8881,7 +8876,7 @@ const deserializeAws_json1_1AutoRollbackConfiguration = (
   context: __SerdeContext
 ): AutoRollbackConfiguration => {
   return {
-    enabled: output.enabled !== undefined && output.enabled !== null ? output.enabled : undefined,
+    enabled: __expectBoolean(output.enabled),
     events:
       output.events !== undefined && output.events !== null
         ? deserializeAws_json1_1AutoRollbackEventsList(output.events, context)
@@ -8899,14 +8894,14 @@ const deserializeAws_json1_1AutoRollbackEventsList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1AutoScalingGroup = (output: any, context: __SerdeContext): AutoScalingGroup => {
   return {
-    hook: output.hook !== undefined && output.hook !== null ? output.hook : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    hook: __expectString(output.hook),
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -8928,7 +8923,7 @@ const deserializeAws_json1_1AutoScalingGroupNameList = (output: any, context: __
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -8937,9 +8932,8 @@ const deserializeAws_json1_1BatchGetApplicationRevisionsOutput = (
   context: __SerdeContext
 ): BatchGetApplicationRevisionsOutput => {
   return {
-    applicationName:
-      output.applicationName !== undefined && output.applicationName !== null ? output.applicationName : undefined,
-    errorMessage: output.errorMessage !== undefined && output.errorMessage !== null ? output.errorMessage : undefined,
+    applicationName: __expectString(output.applicationName),
+    errorMessage: __expectString(output.errorMessage),
     revisions:
       output.revisions !== undefined && output.revisions !== null
         ? deserializeAws_json1_1RevisionInfoList(output.revisions, context)
@@ -8968,7 +8962,7 @@ const deserializeAws_json1_1BatchGetDeploymentGroupsOutput = (
       output.deploymentGroupsInfo !== undefined && output.deploymentGroupsInfo !== null
         ? deserializeAws_json1_1DeploymentGroupInfoList(output.deploymentGroupsInfo, context)
         : undefined,
-    errorMessage: output.errorMessage !== undefined && output.errorMessage !== null ? output.errorMessage : undefined,
+    errorMessage: __expectString(output.errorMessage),
   } as any;
 };
 
@@ -8977,7 +8971,7 @@ const deserializeAws_json1_1BatchGetDeploymentInstancesOutput = (
   context: __SerdeContext
 ): BatchGetDeploymentInstancesOutput => {
   return {
-    errorMessage: output.errorMessage !== undefined && output.errorMessage !== null ? output.errorMessage : undefined,
+    errorMessage: __expectString(output.errorMessage),
     instancesSummary:
       output.instancesSummary !== undefined && output.instancesSummary !== null
         ? deserializeAws_json1_1InstanceSummaryList(output.instancesSummary, context)
@@ -9026,7 +9020,7 @@ const deserializeAws_json1_1BatchLimitExceededException = (
   context: __SerdeContext
 ): BatchLimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9056,11 +9050,8 @@ const deserializeAws_json1_1BlueInstanceTerminationOption = (
   context: __SerdeContext
 ): BlueInstanceTerminationOption => {
   return {
-    action: output.action !== undefined && output.action !== null ? output.action : undefined,
-    terminationWaitTimeInMinutes:
-      output.terminationWaitTimeInMinutes !== undefined && output.terminationWaitTimeInMinutes !== null
-        ? output.terminationWaitTimeInMinutes
-        : undefined,
+    action: __expectString(output.action),
+    terminationWaitTimeInMinutes: __expectNumber(output.terminationWaitTimeInMinutes),
   } as any;
 };
 
@@ -9069,13 +9060,13 @@ const deserializeAws_json1_1BucketNameFilterRequiredException = (
   context: __SerdeContext
 ): BucketNameFilterRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1CloudFormationTarget = (output: any, context: __SerdeContext): CloudFormationTarget => {
   return {
-    deploymentId: output.deploymentId !== undefined && output.deploymentId !== null ? output.deploymentId : undefined,
+    deploymentId: __expectString(output.deploymentId),
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
         ? new Date(Math.round(output.lastUpdatedAt * 1000))
@@ -9084,13 +9075,10 @@ const deserializeAws_json1_1CloudFormationTarget = (output: any, context: __Serd
       output.lifecycleEvents !== undefined && output.lifecycleEvents !== null
         ? deserializeAws_json1_1LifecycleEventList(output.lifecycleEvents, context)
         : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    targetId: output.targetId !== undefined && output.targetId !== null ? output.targetId : undefined,
-    targetVersionWeight:
-      output.targetVersionWeight !== undefined && output.targetVersionWeight !== null
-        ? output.targetVersionWeight
-        : undefined,
+    resourceType: __expectString(output.resourceType),
+    status: __expectString(output.status),
+    targetId: __expectString(output.targetId),
+    targetVersionWeight: __expectNumber(output.targetVersionWeight),
   } as any;
 };
 
@@ -9099,8 +9087,7 @@ const deserializeAws_json1_1CreateApplicationOutput = (
   context: __SerdeContext
 ): CreateApplicationOutput => {
   return {
-    applicationId:
-      output.applicationId !== undefined && output.applicationId !== null ? output.applicationId : undefined,
+    applicationId: __expectString(output.applicationId),
   } as any;
 };
 
@@ -9109,10 +9096,7 @@ const deserializeAws_json1_1CreateDeploymentConfigOutput = (
   context: __SerdeContext
 ): CreateDeploymentConfigOutput => {
   return {
-    deploymentConfigId:
-      output.deploymentConfigId !== undefined && output.deploymentConfigId !== null
-        ? output.deploymentConfigId
-        : undefined,
+    deploymentConfigId: __expectString(output.deploymentConfigId),
   } as any;
 };
 
@@ -9121,16 +9105,13 @@ const deserializeAws_json1_1CreateDeploymentGroupOutput = (
   context: __SerdeContext
 ): CreateDeploymentGroupOutput => {
   return {
-    deploymentGroupId:
-      output.deploymentGroupId !== undefined && output.deploymentGroupId !== null
-        ? output.deploymentGroupId
-        : undefined,
+    deploymentGroupId: __expectString(output.deploymentGroupId),
   } as any;
 };
 
 const deserializeAws_json1_1CreateDeploymentOutput = (output: any, context: __SerdeContext): CreateDeploymentOutput => {
   return {
-    deploymentId: output.deploymentId !== undefined && output.deploymentId !== null ? output.deploymentId : undefined,
+    deploymentId: __expectString(output.deploymentId),
   } as any;
 };
 
@@ -9151,7 +9132,7 @@ const deserializeAws_json1_1DeleteGitHubAccountTokenOutput = (
   context: __SerdeContext
 ): DeleteGitHubAccountTokenOutput => {
   return {
-    tokenName: output.tokenName !== undefined && output.tokenName !== null ? output.tokenName : undefined,
+    tokenName: __expectString(output.tokenName),
   } as any;
 };
 
@@ -9167,7 +9148,7 @@ const deserializeAws_json1_1DeploymentAlreadyCompletedException = (
   context: __SerdeContext
 ): DeploymentAlreadyCompletedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9176,7 +9157,7 @@ const deserializeAws_json1_1DeploymentConfigAlreadyExistsException = (
   context: __SerdeContext
 ): DeploymentConfigAlreadyExistsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9185,26 +9166,19 @@ const deserializeAws_json1_1DeploymentConfigDoesNotExistException = (
   context: __SerdeContext
 ): DeploymentConfigDoesNotExistException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1DeploymentConfigInfo = (output: any, context: __SerdeContext): DeploymentConfigInfo => {
   return {
-    computePlatform:
-      output.computePlatform !== undefined && output.computePlatform !== null ? output.computePlatform : undefined,
+    computePlatform: __expectString(output.computePlatform),
     createTime:
       output.createTime !== undefined && output.createTime !== null
         ? new Date(Math.round(output.createTime * 1000))
         : undefined,
-    deploymentConfigId:
-      output.deploymentConfigId !== undefined && output.deploymentConfigId !== null
-        ? output.deploymentConfigId
-        : undefined,
-    deploymentConfigName:
-      output.deploymentConfigName !== undefined && output.deploymentConfigName !== null
-        ? output.deploymentConfigName
-        : undefined,
+    deploymentConfigId: __expectString(output.deploymentConfigId),
+    deploymentConfigName: __expectString(output.deploymentConfigName),
     minimumHealthyHosts:
       output.minimumHealthyHosts !== undefined && output.minimumHealthyHosts !== null
         ? deserializeAws_json1_1MinimumHealthyHosts(output.minimumHealthyHosts, context)
@@ -9221,7 +9195,7 @@ const deserializeAws_json1_1DeploymentConfigInUseException = (
   context: __SerdeContext
 ): DeploymentConfigInUseException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9230,7 +9204,7 @@ const deserializeAws_json1_1DeploymentConfigLimitExceededException = (
   context: __SerdeContext
 ): DeploymentConfigLimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9239,7 +9213,7 @@ const deserializeAws_json1_1DeploymentConfigNameRequiredException = (
   context: __SerdeContext
 ): DeploymentConfigNameRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9250,7 +9224,7 @@ const deserializeAws_json1_1DeploymentConfigsList = (output: any, context: __Ser
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -9259,7 +9233,7 @@ const deserializeAws_json1_1DeploymentDoesNotExistException = (
   context: __SerdeContext
 ): DeploymentDoesNotExistException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9268,7 +9242,7 @@ const deserializeAws_json1_1DeploymentGroupAlreadyExistsException = (
   context: __SerdeContext
 ): DeploymentGroupAlreadyExistsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9277,7 +9251,7 @@ const deserializeAws_json1_1DeploymentGroupDoesNotExistException = (
   context: __SerdeContext
 ): DeploymentGroupDoesNotExistException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9287,8 +9261,7 @@ const deserializeAws_json1_1DeploymentGroupInfo = (output: any, context: __Serde
       output.alarmConfiguration !== undefined && output.alarmConfiguration !== null
         ? deserializeAws_json1_1AlarmConfiguration(output.alarmConfiguration, context)
         : undefined,
-    applicationName:
-      output.applicationName !== undefined && output.applicationName !== null ? output.applicationName : undefined,
+    applicationName: __expectString(output.applicationName),
     autoRollbackConfiguration:
       output.autoRollbackConfiguration !== undefined && output.autoRollbackConfiguration !== null
         ? deserializeAws_json1_1AutoRollbackConfiguration(output.autoRollbackConfiguration, context)
@@ -9301,20 +9274,10 @@ const deserializeAws_json1_1DeploymentGroupInfo = (output: any, context: __Serde
       output.blueGreenDeploymentConfiguration !== undefined && output.blueGreenDeploymentConfiguration !== null
         ? deserializeAws_json1_1BlueGreenDeploymentConfiguration(output.blueGreenDeploymentConfiguration, context)
         : undefined,
-    computePlatform:
-      output.computePlatform !== undefined && output.computePlatform !== null ? output.computePlatform : undefined,
-    deploymentConfigName:
-      output.deploymentConfigName !== undefined && output.deploymentConfigName !== null
-        ? output.deploymentConfigName
-        : undefined,
-    deploymentGroupId:
-      output.deploymentGroupId !== undefined && output.deploymentGroupId !== null
-        ? output.deploymentGroupId
-        : undefined,
-    deploymentGroupName:
-      output.deploymentGroupName !== undefined && output.deploymentGroupName !== null
-        ? output.deploymentGroupName
-        : undefined,
+    computePlatform: __expectString(output.computePlatform),
+    deploymentConfigName: __expectString(output.deploymentConfigName),
+    deploymentGroupId: __expectString(output.deploymentGroupId),
+    deploymentGroupName: __expectString(output.deploymentGroupName),
     deploymentStyle:
       output.deploymentStyle !== undefined && output.deploymentStyle !== null
         ? deserializeAws_json1_1DeploymentStyle(output.deploymentStyle, context)
@@ -9351,12 +9314,8 @@ const deserializeAws_json1_1DeploymentGroupInfo = (output: any, context: __Serde
       output.onPremisesTagSet !== undefined && output.onPremisesTagSet !== null
         ? deserializeAws_json1_1OnPremisesTagSet(output.onPremisesTagSet, context)
         : undefined,
-    outdatedInstancesStrategy:
-      output.outdatedInstancesStrategy !== undefined && output.outdatedInstancesStrategy !== null
-        ? output.outdatedInstancesStrategy
-        : undefined,
-    serviceRoleArn:
-      output.serviceRoleArn !== undefined && output.serviceRoleArn !== null ? output.serviceRoleArn : undefined,
+    outdatedInstancesStrategy: __expectString(output.outdatedInstancesStrategy),
+    serviceRoleArn: __expectString(output.serviceRoleArn),
     targetRevision:
       output.targetRevision !== undefined && output.targetRevision !== null
         ? deserializeAws_json1_1RevisionLocation(output.targetRevision, context)
@@ -9384,7 +9343,7 @@ const deserializeAws_json1_1DeploymentGroupLimitExceededException = (
   context: __SerdeContext
 ): DeploymentGroupLimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9393,7 +9352,7 @@ const deserializeAws_json1_1DeploymentGroupNameRequiredException = (
   context: __SerdeContext
 ): DeploymentGroupNameRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9404,7 +9363,7 @@ const deserializeAws_json1_1DeploymentGroupsList = (output: any, context: __Serd
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -9413,18 +9372,14 @@ const deserializeAws_json1_1DeploymentIdRequiredException = (
   context: __SerdeContext
 ): DeploymentIdRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1DeploymentInfo = (output: any, context: __SerdeContext): DeploymentInfo => {
   return {
-    additionalDeploymentStatusInfo:
-      output.additionalDeploymentStatusInfo !== undefined && output.additionalDeploymentStatusInfo !== null
-        ? output.additionalDeploymentStatusInfo
-        : undefined,
-    applicationName:
-      output.applicationName !== undefined && output.applicationName !== null ? output.applicationName : undefined,
+    additionalDeploymentStatusInfo: __expectString(output.additionalDeploymentStatusInfo),
+    applicationName: __expectString(output.applicationName),
     autoRollbackConfiguration:
       output.autoRollbackConfiguration !== undefined && output.autoRollbackConfiguration !== null
         ? deserializeAws_json1_1AutoRollbackConfiguration(output.autoRollbackConfiguration, context)
@@ -9437,22 +9392,15 @@ const deserializeAws_json1_1DeploymentInfo = (output: any, context: __SerdeConte
       output.completeTime !== undefined && output.completeTime !== null
         ? new Date(Math.round(output.completeTime * 1000))
         : undefined,
-    computePlatform:
-      output.computePlatform !== undefined && output.computePlatform !== null ? output.computePlatform : undefined,
+    computePlatform: __expectString(output.computePlatform),
     createTime:
       output.createTime !== undefined && output.createTime !== null
         ? new Date(Math.round(output.createTime * 1000))
         : undefined,
-    creator: output.creator !== undefined && output.creator !== null ? output.creator : undefined,
-    deploymentConfigName:
-      output.deploymentConfigName !== undefined && output.deploymentConfigName !== null
-        ? output.deploymentConfigName
-        : undefined,
-    deploymentGroupName:
-      output.deploymentGroupName !== undefined && output.deploymentGroupName !== null
-        ? output.deploymentGroupName
-        : undefined,
-    deploymentId: output.deploymentId !== undefined && output.deploymentId !== null ? output.deploymentId : undefined,
+    creator: __expectString(output.creator),
+    deploymentConfigName: __expectString(output.deploymentConfigName),
+    deploymentGroupName: __expectString(output.deploymentGroupName),
+    deploymentId: __expectString(output.deploymentId),
     deploymentOverview:
       output.deploymentOverview !== undefined && output.deploymentOverview !== null
         ? deserializeAws_json1_1DeploymentOverview(output.deploymentOverview, context)
@@ -9465,24 +9413,15 @@ const deserializeAws_json1_1DeploymentInfo = (output: any, context: __SerdeConte
       output.deploymentStyle !== undefined && output.deploymentStyle !== null
         ? deserializeAws_json1_1DeploymentStyle(output.deploymentStyle, context)
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    description: __expectString(output.description),
     errorInformation:
       output.errorInformation !== undefined && output.errorInformation !== null
         ? deserializeAws_json1_1ErrorInformation(output.errorInformation, context)
         : undefined,
-    externalId: output.externalId !== undefined && output.externalId !== null ? output.externalId : undefined,
-    fileExistsBehavior:
-      output.fileExistsBehavior !== undefined && output.fileExistsBehavior !== null
-        ? output.fileExistsBehavior
-        : undefined,
-    ignoreApplicationStopFailures:
-      output.ignoreApplicationStopFailures !== undefined && output.ignoreApplicationStopFailures !== null
-        ? output.ignoreApplicationStopFailures
-        : undefined,
-    instanceTerminationWaitTimeStarted:
-      output.instanceTerminationWaitTimeStarted !== undefined && output.instanceTerminationWaitTimeStarted !== null
-        ? output.instanceTerminationWaitTimeStarted
-        : undefined,
+    externalId: __expectString(output.externalId),
+    fileExistsBehavior: __expectString(output.fileExistsBehavior),
+    ignoreApplicationStopFailures: __expectBoolean(output.ignoreApplicationStopFailures),
+    instanceTerminationWaitTimeStarted: __expectBoolean(output.instanceTerminationWaitTimeStarted),
     loadBalancerInfo:
       output.loadBalancerInfo !== undefined && output.loadBalancerInfo !== null
         ? deserializeAws_json1_1LoadBalancerInfo(output.loadBalancerInfo, context)
@@ -9507,15 +9446,12 @@ const deserializeAws_json1_1DeploymentInfo = (output: any, context: __SerdeConte
       output.startTime !== undefined && output.startTime !== null
         ? new Date(Math.round(output.startTime * 1000))
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
     targetInstances:
       output.targetInstances !== undefined && output.targetInstances !== null
         ? deserializeAws_json1_1TargetInstances(output.targetInstances, context)
         : undefined,
-    updateOutdatedInstancesOnly:
-      output.updateOutdatedInstancesOnly !== undefined && output.updateOutdatedInstancesOnly !== null
-        ? output.updateOutdatedInstancesOnly
-        : undefined,
+    updateOutdatedInstancesOnly: __expectBoolean(output.updateOutdatedInstancesOnly),
   } as any;
 };
 
@@ -9524,7 +9460,7 @@ const deserializeAws_json1_1DeploymentIsNotInReadyStateException = (
   context: __SerdeContext
 ): DeploymentIsNotInReadyStateException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9533,7 +9469,7 @@ const deserializeAws_json1_1DeploymentLimitExceededException = (
   context: __SerdeContext
 ): DeploymentLimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9542,29 +9478,25 @@ const deserializeAws_json1_1DeploymentNotStartedException = (
   context: __SerdeContext
 ): DeploymentNotStartedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1DeploymentOverview = (output: any, context: __SerdeContext): DeploymentOverview => {
   return {
-    Failed: output.Failed !== undefined && output.Failed !== null ? output.Failed : undefined,
-    InProgress: output.InProgress !== undefined && output.InProgress !== null ? output.InProgress : undefined,
-    Pending: output.Pending !== undefined && output.Pending !== null ? output.Pending : undefined,
-    Ready: output.Ready !== undefined && output.Ready !== null ? output.Ready : undefined,
-    Skipped: output.Skipped !== undefined && output.Skipped !== null ? output.Skipped : undefined,
-    Succeeded: output.Succeeded !== undefined && output.Succeeded !== null ? output.Succeeded : undefined,
+    Failed: __expectNumber(output.Failed),
+    InProgress: __expectNumber(output.InProgress),
+    Pending: __expectNumber(output.Pending),
+    Ready: __expectNumber(output.Ready),
+    Skipped: __expectNumber(output.Skipped),
+    Succeeded: __expectNumber(output.Succeeded),
   } as any;
 };
 
 const deserializeAws_json1_1DeploymentReadyOption = (output: any, context: __SerdeContext): DeploymentReadyOption => {
   return {
-    actionOnTimeout:
-      output.actionOnTimeout !== undefined && output.actionOnTimeout !== null ? output.actionOnTimeout : undefined,
-    waitTimeInMinutes:
-      output.waitTimeInMinutes !== undefined && output.waitTimeInMinutes !== null
-        ? output.waitTimeInMinutes
-        : undefined,
+    actionOnTimeout: __expectString(output.actionOnTimeout),
+    waitTimeInMinutes: __expectNumber(output.waitTimeInMinutes),
   } as any;
 };
 
@@ -9586,7 +9518,7 @@ const deserializeAws_json1_1DeploymentsList = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -9597,16 +9529,14 @@ const deserializeAws_json1_1DeploymentStatusMessageList = (output: any, context:
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1DeploymentStyle = (output: any, context: __SerdeContext): DeploymentStyle => {
   return {
-    deploymentOption:
-      output.deploymentOption !== undefined && output.deploymentOption !== null ? output.deploymentOption : undefined,
-    deploymentType:
-      output.deploymentType !== undefined && output.deploymentType !== null ? output.deploymentType : undefined,
+    deploymentOption: __expectString(output.deploymentOption),
+    deploymentType: __expectString(output.deploymentType),
   } as any;
 };
 
@@ -9616,10 +9546,7 @@ const deserializeAws_json1_1DeploymentTarget = (output: any, context: __SerdeCon
       output.cloudFormationTarget !== undefined && output.cloudFormationTarget !== null
         ? deserializeAws_json1_1CloudFormationTarget(output.cloudFormationTarget, context)
         : undefined,
-    deploymentTargetType:
-      output.deploymentTargetType !== undefined && output.deploymentTargetType !== null
-        ? output.deploymentTargetType
-        : undefined,
+    deploymentTargetType: __expectString(output.deploymentTargetType),
     ecsTarget:
       output.ecsTarget !== undefined && output.ecsTarget !== null
         ? deserializeAws_json1_1ECSTarget(output.ecsTarget, context)
@@ -9640,7 +9567,7 @@ const deserializeAws_json1_1DeploymentTargetDoesNotExistException = (
   context: __SerdeContext
 ): DeploymentTargetDoesNotExistException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9649,7 +9576,7 @@ const deserializeAws_json1_1DeploymentTargetIdRequiredException = (
   context: __SerdeContext
 ): DeploymentTargetIdRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9669,7 +9596,7 @@ const deserializeAws_json1_1DeploymentTargetListSizeExceededException = (
   context: __SerdeContext
 ): DeploymentTargetListSizeExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9678,24 +9605,24 @@ const deserializeAws_json1_1DescriptionTooLongException = (
   context: __SerdeContext
 ): DescriptionTooLongException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1Diagnostics = (output: any, context: __SerdeContext): Diagnostics => {
   return {
-    errorCode: output.errorCode !== undefined && output.errorCode !== null ? output.errorCode : undefined,
-    logTail: output.logTail !== undefined && output.logTail !== null ? output.logTail : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    scriptName: output.scriptName !== undefined && output.scriptName !== null ? output.scriptName : undefined,
+    errorCode: __expectString(output.errorCode),
+    logTail: __expectString(output.logTail),
+    message: __expectString(output.message),
+    scriptName: __expectString(output.scriptName),
   } as any;
 };
 
 const deserializeAws_json1_1EC2TagFilter = (output: any, context: __SerdeContext): EC2TagFilter => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Type: __expectString(output.Type),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -9732,8 +9659,8 @@ const deserializeAws_json1_1EC2TagSetList = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1ECSService = (output: any, context: __SerdeContext): ECSService => {
   return {
-    clusterName: output.clusterName !== undefined && output.clusterName !== null ? output.clusterName : undefined,
-    serviceName: output.serviceName !== undefined && output.serviceName !== null ? output.serviceName : undefined,
+    clusterName: __expectString(output.clusterName),
+    serviceName: __expectString(output.serviceName),
   } as any;
 };
 
@@ -9753,13 +9680,13 @@ const deserializeAws_json1_1ECSServiceMappingLimitExceededException = (
   context: __SerdeContext
 ): ECSServiceMappingLimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1ECSTarget = (output: any, context: __SerdeContext): ECSTarget => {
   return {
-    deploymentId: output.deploymentId !== undefined && output.deploymentId !== null ? output.deploymentId : undefined,
+    deploymentId: __expectString(output.deploymentId),
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
         ? new Date(Math.round(output.lastUpdatedAt * 1000))
@@ -9768,9 +9695,9 @@ const deserializeAws_json1_1ECSTarget = (output: any, context: __SerdeContext): 
       output.lifecycleEvents !== undefined && output.lifecycleEvents !== null
         ? deserializeAws_json1_1LifecycleEventList(output.lifecycleEvents, context)
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    targetArn: output.targetArn !== undefined && output.targetArn !== null ? output.targetArn : undefined,
-    targetId: output.targetId !== undefined && output.targetId !== null ? output.targetId : undefined,
+    status: __expectString(output.status),
+    targetArn: __expectString(output.targetArn),
+    targetId: __expectString(output.targetId),
     taskSetsInfo:
       output.taskSetsInfo !== undefined && output.taskSetsInfo !== null
         ? deserializeAws_json1_1ECSTaskSetList(output.taskSetsInfo, context)
@@ -9780,18 +9707,17 @@ const deserializeAws_json1_1ECSTarget = (output: any, context: __SerdeContext): 
 
 const deserializeAws_json1_1ECSTaskSet = (output: any, context: __SerdeContext): ECSTaskSet => {
   return {
-    desiredCount: output.desiredCount !== undefined && output.desiredCount !== null ? output.desiredCount : undefined,
-    identifer: output.identifer !== undefined && output.identifer !== null ? output.identifer : undefined,
-    pendingCount: output.pendingCount !== undefined && output.pendingCount !== null ? output.pendingCount : undefined,
-    runningCount: output.runningCount !== undefined && output.runningCount !== null ? output.runningCount : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    desiredCount: __expectNumber(output.desiredCount),
+    identifer: __expectString(output.identifer),
+    pendingCount: __expectNumber(output.pendingCount),
+    runningCount: __expectNumber(output.runningCount),
+    status: __expectString(output.status),
     targetGroup:
       output.targetGroup !== undefined && output.targetGroup !== null
         ? deserializeAws_json1_1TargetGroupInfo(output.targetGroup, context)
         : undefined,
-    taskSetLabel: output.taskSetLabel !== undefined && output.taskSetLabel !== null ? output.taskSetLabel : undefined,
-    trafficWeight:
-      output.trafficWeight !== undefined && output.trafficWeight !== null ? output.trafficWeight : undefined,
+    taskSetLabel: __expectString(output.taskSetLabel),
+    trafficWeight: __expectNumber(output.trafficWeight),
   } as any;
 };
 
@@ -9808,7 +9734,7 @@ const deserializeAws_json1_1ECSTaskSetList = (output: any, context: __SerdeConte
 
 const deserializeAws_json1_1ELBInfo = (output: any, context: __SerdeContext): ELBInfo => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -9825,8 +9751,8 @@ const deserializeAws_json1_1ELBInfoList = (output: any, context: __SerdeContext)
 
 const deserializeAws_json1_1ErrorInformation = (output: any, context: __SerdeContext): ErrorInformation => {
   return {
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    code: __expectString(output.code),
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9836,7 +9762,7 @@ const deserializeAws_json1_1GenericRevisionInfo = (output: any, context: __Serde
       output.deploymentGroups !== undefined && output.deploymentGroups !== null
         ? deserializeAws_json1_1DeploymentGroupsList(output.deploymentGroups, context)
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    description: __expectString(output.description),
     firstUsedTime:
       output.firstUsedTime !== undefined && output.firstUsedTime !== null
         ? new Date(Math.round(output.firstUsedTime * 1000))
@@ -9866,8 +9792,7 @@ const deserializeAws_json1_1GetApplicationRevisionOutput = (
   context: __SerdeContext
 ): GetApplicationRevisionOutput => {
   return {
-    applicationName:
-      output.applicationName !== undefined && output.applicationName !== null ? output.applicationName : undefined,
+    applicationName: __expectString(output.applicationName),
     revision:
       output.revision !== undefined && output.revision !== null
         ? deserializeAws_json1_1RevisionLocation(output.revision, context)
@@ -9953,7 +9878,7 @@ const deserializeAws_json1_1GitHubAccountTokenDoesNotExistException = (
   context: __SerdeContext
 ): GitHubAccountTokenDoesNotExistException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9964,7 +9889,7 @@ const deserializeAws_json1_1GitHubAccountTokenNameList = (output: any, context: 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -9973,14 +9898,14 @@ const deserializeAws_json1_1GitHubAccountTokenNameRequiredException = (
   context: __SerdeContext
 ): GitHubAccountTokenNameRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1GitHubLocation = (output: any, context: __SerdeContext): GitHubLocation => {
   return {
-    commitId: output.commitId !== undefined && output.commitId !== null ? output.commitId : undefined,
-    repository: output.repository !== undefined && output.repository !== null ? output.repository : undefined,
+    commitId: __expectString(output.commitId),
+    repository: __expectString(output.repository),
   } as any;
 };
 
@@ -9989,7 +9914,7 @@ const deserializeAws_json1_1GreenFleetProvisioningOption = (
   context: __SerdeContext
 ): GreenFleetProvisioningOption => {
   return {
-    action: output.action !== undefined && output.action !== null ? output.action : undefined,
+    action: __expectString(output.action),
   } as any;
 };
 
@@ -9998,7 +9923,7 @@ const deserializeAws_json1_1IamArnRequiredException = (
   context: __SerdeContext
 ): IamArnRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10007,7 +9932,7 @@ const deserializeAws_json1_1IamSessionArnAlreadyRegisteredException = (
   context: __SerdeContext
 ): IamSessionArnAlreadyRegisteredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10016,7 +9941,7 @@ const deserializeAws_json1_1IamUserArnAlreadyRegisteredException = (
   context: __SerdeContext
 ): IamUserArnAlreadyRegisteredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10025,7 +9950,7 @@ const deserializeAws_json1_1IamUserArnRequiredException = (
   context: __SerdeContext
 ): IamUserArnRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10034,7 +9959,7 @@ const deserializeAws_json1_1InstanceDoesNotExistException = (
   context: __SerdeContext
 ): InstanceDoesNotExistException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10043,7 +9968,7 @@ const deserializeAws_json1_1InstanceIdRequiredException = (
   context: __SerdeContext
 ): InstanceIdRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10053,11 +9978,10 @@ const deserializeAws_json1_1InstanceInfo = (output: any, context: __SerdeContext
       output.deregisterTime !== undefined && output.deregisterTime !== null
         ? new Date(Math.round(output.deregisterTime * 1000))
         : undefined,
-    iamSessionArn:
-      output.iamSessionArn !== undefined && output.iamSessionArn !== null ? output.iamSessionArn : undefined,
-    iamUserArn: output.iamUserArn !== undefined && output.iamUserArn !== null ? output.iamUserArn : undefined,
-    instanceArn: output.instanceArn !== undefined && output.instanceArn !== null ? output.instanceArn : undefined,
-    instanceName: output.instanceName !== undefined && output.instanceName !== null ? output.instanceName : undefined,
+    iamSessionArn: __expectString(output.iamSessionArn),
+    iamUserArn: __expectString(output.iamUserArn),
+    instanceArn: __expectString(output.instanceArn),
+    instanceName: __expectString(output.instanceName),
     registerTime:
       output.registerTime !== undefined && output.registerTime !== null
         ? new Date(Math.round(output.registerTime * 1000))
@@ -10085,7 +10009,7 @@ const deserializeAws_json1_1InstanceLimitExceededException = (
   context: __SerdeContext
 ): InstanceLimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10094,7 +10018,7 @@ const deserializeAws_json1_1InstanceNameAlreadyRegisteredException = (
   context: __SerdeContext
 ): InstanceNameAlreadyRegisteredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10105,7 +10029,7 @@ const deserializeAws_json1_1InstanceNameList = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -10114,7 +10038,7 @@ const deserializeAws_json1_1InstanceNameRequiredException = (
   context: __SerdeContext
 ): InstanceNameRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10123,7 +10047,7 @@ const deserializeAws_json1_1InstanceNotRegisteredException = (
   context: __SerdeContext
 ): InstanceNotRegisteredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10134,15 +10058,15 @@ const deserializeAws_json1_1InstancesList = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1InstanceSummary = (output: any, context: __SerdeContext): InstanceSummary => {
   return {
-    deploymentId: output.deploymentId !== undefined && output.deploymentId !== null ? output.deploymentId : undefined,
-    instanceId: output.instanceId !== undefined && output.instanceId !== null ? output.instanceId : undefined,
-    instanceType: output.instanceType !== undefined && output.instanceType !== null ? output.instanceType : undefined,
+    deploymentId: __expectString(output.deploymentId),
+    instanceId: __expectString(output.instanceId),
+    instanceType: __expectString(output.instanceType),
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
         ? new Date(Math.round(output.lastUpdatedAt * 1000))
@@ -10151,7 +10075,7 @@ const deserializeAws_json1_1InstanceSummary = (output: any, context: __SerdeCont
       output.lifecycleEvents !== undefined && output.lifecycleEvents !== null
         ? deserializeAws_json1_1LifecycleEventList(output.lifecycleEvents, context)
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -10168,9 +10092,8 @@ const deserializeAws_json1_1InstanceSummaryList = (output: any, context: __Serde
 
 const deserializeAws_json1_1InstanceTarget = (output: any, context: __SerdeContext): InstanceTarget => {
   return {
-    deploymentId: output.deploymentId !== undefined && output.deploymentId !== null ? output.deploymentId : undefined,
-    instanceLabel:
-      output.instanceLabel !== undefined && output.instanceLabel !== null ? output.instanceLabel : undefined,
+    deploymentId: __expectString(output.deploymentId),
+    instanceLabel: __expectString(output.instanceLabel),
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
         ? new Date(Math.round(output.lastUpdatedAt * 1000))
@@ -10179,9 +10102,9 @@ const deserializeAws_json1_1InstanceTarget = (output: any, context: __SerdeConte
       output.lifecycleEvents !== undefined && output.lifecycleEvents !== null
         ? deserializeAws_json1_1LifecycleEventList(output.lifecycleEvents, context)
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    targetArn: output.targetArn !== undefined && output.targetArn !== null ? output.targetArn : undefined,
-    targetId: output.targetId !== undefined && output.targetId !== null ? output.targetId : undefined,
+    status: __expectString(output.status),
+    targetArn: __expectString(output.targetArn),
+    targetId: __expectString(output.targetId),
   } as any;
 };
 
@@ -10190,7 +10113,7 @@ const deserializeAws_json1_1InvalidAlarmConfigException = (
   context: __SerdeContext
 ): InvalidAlarmConfigException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10199,13 +10122,13 @@ const deserializeAws_json1_1InvalidApplicationNameException = (
   context: __SerdeContext
 ): InvalidApplicationNameException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidArnException = (output: any, context: __SerdeContext): InvalidArnException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10214,7 +10137,7 @@ const deserializeAws_json1_1InvalidAutoRollbackConfigException = (
   context: __SerdeContext
 ): InvalidAutoRollbackConfigException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10223,7 +10146,7 @@ const deserializeAws_json1_1InvalidAutoScalingGroupException = (
   context: __SerdeContext
 ): InvalidAutoScalingGroupException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10232,7 +10155,7 @@ const deserializeAws_json1_1InvalidBlueGreenDeploymentConfigurationException = (
   context: __SerdeContext
 ): InvalidBlueGreenDeploymentConfigurationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10241,7 +10164,7 @@ const deserializeAws_json1_1InvalidBucketNameFilterException = (
   context: __SerdeContext
 ): InvalidBucketNameFilterException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10250,7 +10173,7 @@ const deserializeAws_json1_1InvalidComputePlatformException = (
   context: __SerdeContext
 ): InvalidComputePlatformException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10259,7 +10182,7 @@ const deserializeAws_json1_1InvalidDeployedStateFilterException = (
   context: __SerdeContext
 ): InvalidDeployedStateFilterException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10268,7 +10191,7 @@ const deserializeAws_json1_1InvalidDeploymentConfigNameException = (
   context: __SerdeContext
 ): InvalidDeploymentConfigNameException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10277,7 +10200,7 @@ const deserializeAws_json1_1InvalidDeploymentGroupNameException = (
   context: __SerdeContext
 ): InvalidDeploymentGroupNameException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10286,7 +10209,7 @@ const deserializeAws_json1_1InvalidDeploymentIdException = (
   context: __SerdeContext
 ): InvalidDeploymentIdException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10295,7 +10218,7 @@ const deserializeAws_json1_1InvalidDeploymentInstanceTypeException = (
   context: __SerdeContext
 ): InvalidDeploymentInstanceTypeException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10304,7 +10227,7 @@ const deserializeAws_json1_1InvalidDeploymentStatusException = (
   context: __SerdeContext
 ): InvalidDeploymentStatusException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10313,7 +10236,7 @@ const deserializeAws_json1_1InvalidDeploymentStyleException = (
   context: __SerdeContext
 ): InvalidDeploymentStyleException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10322,7 +10245,7 @@ const deserializeAws_json1_1InvalidDeploymentTargetIdException = (
   context: __SerdeContext
 ): InvalidDeploymentTargetIdException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10331,7 +10254,7 @@ const deserializeAws_json1_1InvalidDeploymentWaitTypeException = (
   context: __SerdeContext
 ): InvalidDeploymentWaitTypeException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10340,13 +10263,13 @@ const deserializeAws_json1_1InvalidEC2TagCombinationException = (
   context: __SerdeContext
 ): InvalidEC2TagCombinationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidEC2TagException = (output: any, context: __SerdeContext): InvalidEC2TagException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10355,7 +10278,7 @@ const deserializeAws_json1_1InvalidECSServiceException = (
   context: __SerdeContext
 ): InvalidECSServiceException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10364,7 +10287,7 @@ const deserializeAws_json1_1InvalidExternalIdException = (
   context: __SerdeContext
 ): InvalidExternalIdException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10373,7 +10296,7 @@ const deserializeAws_json1_1InvalidFileExistsBehaviorException = (
   context: __SerdeContext
 ): InvalidFileExistsBehaviorException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10382,7 +10305,7 @@ const deserializeAws_json1_1InvalidGitHubAccountTokenException = (
   context: __SerdeContext
 ): InvalidGitHubAccountTokenException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10391,7 +10314,7 @@ const deserializeAws_json1_1InvalidGitHubAccountTokenNameException = (
   context: __SerdeContext
 ): InvalidGitHubAccountTokenNameException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10400,7 +10323,7 @@ const deserializeAws_json1_1InvalidIamSessionArnException = (
   context: __SerdeContext
 ): InvalidIamSessionArnException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10409,7 +10332,7 @@ const deserializeAws_json1_1InvalidIamUserArnException = (
   context: __SerdeContext
 ): InvalidIamUserArnException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10418,13 +10341,13 @@ const deserializeAws_json1_1InvalidIgnoreApplicationStopFailuresValueException =
   context: __SerdeContext
 ): InvalidIgnoreApplicationStopFailuresValueException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidInputException = (output: any, context: __SerdeContext): InvalidInputException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10433,7 +10356,7 @@ const deserializeAws_json1_1InvalidInstanceNameException = (
   context: __SerdeContext
 ): InvalidInstanceNameException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10442,7 +10365,7 @@ const deserializeAws_json1_1InvalidInstanceStatusException = (
   context: __SerdeContext
 ): InvalidInstanceStatusException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10451,7 +10374,7 @@ const deserializeAws_json1_1InvalidInstanceTypeException = (
   context: __SerdeContext
 ): InvalidInstanceTypeException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10460,7 +10383,7 @@ const deserializeAws_json1_1InvalidKeyPrefixFilterException = (
   context: __SerdeContext
 ): InvalidKeyPrefixFilterException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10469,7 +10392,7 @@ const deserializeAws_json1_1InvalidLifecycleEventHookExecutionIdException = (
   context: __SerdeContext
 ): InvalidLifecycleEventHookExecutionIdException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10478,7 +10401,7 @@ const deserializeAws_json1_1InvalidLifecycleEventHookExecutionStatusException = 
   context: __SerdeContext
 ): InvalidLifecycleEventHookExecutionStatusException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10487,7 +10410,7 @@ const deserializeAws_json1_1InvalidLoadBalancerInfoException = (
   context: __SerdeContext
 ): InvalidLoadBalancerInfoException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10496,7 +10419,7 @@ const deserializeAws_json1_1InvalidMinimumHealthyHostValueException = (
   context: __SerdeContext
 ): InvalidMinimumHealthyHostValueException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10505,7 +10428,7 @@ const deserializeAws_json1_1InvalidNextTokenException = (
   context: __SerdeContext
 ): InvalidNextTokenException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10514,7 +10437,7 @@ const deserializeAws_json1_1InvalidOnPremisesTagCombinationException = (
   context: __SerdeContext
 ): InvalidOnPremisesTagCombinationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10523,7 +10446,7 @@ const deserializeAws_json1_1InvalidOperationException = (
   context: __SerdeContext
 ): InvalidOperationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10532,7 +10455,7 @@ const deserializeAws_json1_1InvalidRegistrationStatusException = (
   context: __SerdeContext
 ): InvalidRegistrationStatusException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10541,19 +10464,19 @@ const deserializeAws_json1_1InvalidRevisionException = (
   context: __SerdeContext
 ): InvalidRevisionException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidRoleException = (output: any, context: __SerdeContext): InvalidRoleException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidSortByException = (output: any, context: __SerdeContext): InvalidSortByException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10562,13 +10485,13 @@ const deserializeAws_json1_1InvalidSortOrderException = (
   context: __SerdeContext
 ): InvalidSortOrderException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidTagException = (output: any, context: __SerdeContext): InvalidTagException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10577,7 +10500,7 @@ const deserializeAws_json1_1InvalidTagFilterException = (
   context: __SerdeContext
 ): InvalidTagFilterException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10586,7 +10509,7 @@ const deserializeAws_json1_1InvalidTagsToAddException = (
   context: __SerdeContext
 ): InvalidTagsToAddException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10595,7 +10518,7 @@ const deserializeAws_json1_1InvalidTargetFilterNameException = (
   context: __SerdeContext
 ): InvalidTargetFilterNameException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10604,7 +10527,7 @@ const deserializeAws_json1_1InvalidTargetGroupPairException = (
   context: __SerdeContext
 ): InvalidTargetGroupPairException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10613,7 +10536,7 @@ const deserializeAws_json1_1InvalidTargetInstancesException = (
   context: __SerdeContext
 ): InvalidTargetInstancesException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10622,7 +10545,7 @@ const deserializeAws_json1_1InvalidTimeRangeException = (
   context: __SerdeContext
 ): InvalidTimeRangeException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10631,7 +10554,7 @@ const deserializeAws_json1_1InvalidTrafficRoutingConfigurationException = (
   context: __SerdeContext
 ): InvalidTrafficRoutingConfigurationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10640,7 +10563,7 @@ const deserializeAws_json1_1InvalidTriggerConfigException = (
   context: __SerdeContext
 ): InvalidTriggerConfigException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10649,29 +10572,23 @@ const deserializeAws_json1_1InvalidUpdateOutdatedInstancesOnlyValueException = (
   context: __SerdeContext
 ): InvalidUpdateOutdatedInstancesOnlyValueException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1LambdaFunctionInfo = (output: any, context: __SerdeContext): LambdaFunctionInfo => {
   return {
-    currentVersion:
-      output.currentVersion !== undefined && output.currentVersion !== null ? output.currentVersion : undefined,
-    functionAlias:
-      output.functionAlias !== undefined && output.functionAlias !== null ? output.functionAlias : undefined,
-    functionName: output.functionName !== undefined && output.functionName !== null ? output.functionName : undefined,
-    targetVersion:
-      output.targetVersion !== undefined && output.targetVersion !== null ? output.targetVersion : undefined,
-    targetVersionWeight:
-      output.targetVersionWeight !== undefined && output.targetVersionWeight !== null
-        ? output.targetVersionWeight
-        : undefined,
+    currentVersion: __expectString(output.currentVersion),
+    functionAlias: __expectString(output.functionAlias),
+    functionName: __expectString(output.functionName),
+    targetVersion: __expectString(output.targetVersion),
+    targetVersionWeight: __expectNumber(output.targetVersionWeight),
   } as any;
 };
 
 const deserializeAws_json1_1LambdaTarget = (output: any, context: __SerdeContext): LambdaTarget => {
   return {
-    deploymentId: output.deploymentId !== undefined && output.deploymentId !== null ? output.deploymentId : undefined,
+    deploymentId: __expectString(output.deploymentId),
     lambdaFunctionInfo:
       output.lambdaFunctionInfo !== undefined && output.lambdaFunctionInfo !== null
         ? deserializeAws_json1_1LambdaFunctionInfo(output.lambdaFunctionInfo, context)
@@ -10684,9 +10601,9 @@ const deserializeAws_json1_1LambdaTarget = (output: any, context: __SerdeContext
       output.lifecycleEvents !== undefined && output.lifecycleEvents !== null
         ? deserializeAws_json1_1LifecycleEventList(output.lifecycleEvents, context)
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    targetArn: output.targetArn !== undefined && output.targetArn !== null ? output.targetArn : undefined,
-    targetId: output.targetId !== undefined && output.targetId !== null ? output.targetId : undefined,
+    status: __expectString(output.status),
+    targetArn: __expectString(output.targetArn),
+    targetId: __expectString(output.targetId),
   } as any;
 };
 
@@ -10696,10 +10613,10 @@ const deserializeAws_json1_1LastDeploymentInfo = (output: any, context: __SerdeC
       output.createTime !== undefined && output.createTime !== null
         ? new Date(Math.round(output.createTime * 1000))
         : undefined,
-    deploymentId: output.deploymentId !== undefined && output.deploymentId !== null ? output.deploymentId : undefined,
+    deploymentId: __expectString(output.deploymentId),
     endTime:
       output.endTime !== undefined && output.endTime !== null ? new Date(Math.round(output.endTime * 1000)) : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -10711,15 +10628,12 @@ const deserializeAws_json1_1LifecycleEvent = (output: any, context: __SerdeConte
         : undefined,
     endTime:
       output.endTime !== undefined && output.endTime !== null ? new Date(Math.round(output.endTime * 1000)) : undefined,
-    lifecycleEventName:
-      output.lifecycleEventName !== undefined && output.lifecycleEventName !== null
-        ? output.lifecycleEventName
-        : undefined,
+    lifecycleEventName: __expectString(output.lifecycleEventName),
     startTime:
       output.startTime !== undefined && output.startTime !== null
         ? new Date(Math.round(output.startTime * 1000))
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -10728,7 +10642,7 @@ const deserializeAws_json1_1LifecycleEventAlreadyCompletedException = (
   context: __SerdeContext
 ): LifecycleEventAlreadyCompletedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10748,7 +10662,7 @@ const deserializeAws_json1_1LifecycleHookLimitExceededException = (
   context: __SerdeContext
 ): LifecycleHookLimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10757,7 +10671,7 @@ const deserializeAws_json1_1ListApplicationRevisionsOutput = (
   context: __SerdeContext
 ): ListApplicationRevisionsOutput => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     revisions:
       output.revisions !== undefined && output.revisions !== null
         ? deserializeAws_json1_1RevisionLocationList(output.revisions, context)
@@ -10771,7 +10685,7 @@ const deserializeAws_json1_1ListApplicationsOutput = (output: any, context: __Se
       output.applications !== undefined && output.applications !== null
         ? deserializeAws_json1_1ApplicationsList(output.applications, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -10784,7 +10698,7 @@ const deserializeAws_json1_1ListDeploymentConfigsOutput = (
       output.deploymentConfigsList !== undefined && output.deploymentConfigsList !== null
         ? deserializeAws_json1_1DeploymentConfigsList(output.deploymentConfigsList, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -10793,13 +10707,12 @@ const deserializeAws_json1_1ListDeploymentGroupsOutput = (
   context: __SerdeContext
 ): ListDeploymentGroupsOutput => {
   return {
-    applicationName:
-      output.applicationName !== undefined && output.applicationName !== null ? output.applicationName : undefined,
+    applicationName: __expectString(output.applicationName),
     deploymentGroups:
       output.deploymentGroups !== undefined && output.deploymentGroups !== null
         ? deserializeAws_json1_1DeploymentGroupsList(output.deploymentGroups, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -10812,7 +10725,7 @@ const deserializeAws_json1_1ListDeploymentInstancesOutput = (
       output.instancesList !== undefined && output.instancesList !== null
         ? deserializeAws_json1_1InstancesList(output.instancesList, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -10822,7 +10735,7 @@ const deserializeAws_json1_1ListDeploymentsOutput = (output: any, context: __Ser
       output.deployments !== undefined && output.deployments !== null
         ? deserializeAws_json1_1DeploymentsList(output.deployments, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -10831,7 +10744,7 @@ const deserializeAws_json1_1ListDeploymentTargetsOutput = (
   context: __SerdeContext
 ): ListDeploymentTargetsOutput => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     targetIds:
       output.targetIds !== undefined && output.targetIds !== null
         ? deserializeAws_json1_1TargetIdList(output.targetIds, context)
@@ -10846,7 +10759,7 @@ const deserializeAws_json1_1ListenerArnList = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -10855,7 +10768,7 @@ const deserializeAws_json1_1ListGitHubAccountTokenNamesOutput = (
   context: __SerdeContext
 ): ListGitHubAccountTokenNamesOutput => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     tokenNameList:
       output.tokenNameList !== undefined && output.tokenNameList !== null
         ? deserializeAws_json1_1GitHubAccountTokenNameList(output.tokenNameList, context)
@@ -10872,7 +10785,7 @@ const deserializeAws_json1_1ListOnPremisesInstancesOutput = (
       output.instanceNames !== undefined && output.instanceNames !== null
         ? deserializeAws_json1_1InstanceNameList(output.instanceNames, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -10881,7 +10794,7 @@ const deserializeAws_json1_1ListTagsForResourceOutput = (
   context: __SerdeContext
 ): ListTagsForResourceOutput => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_1TagList(output.Tags, context)
@@ -10908,8 +10821,8 @@ const deserializeAws_json1_1LoadBalancerInfo = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1MinimumHealthyHosts = (output: any, context: __SerdeContext): MinimumHealthyHosts => {
   return {
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    type: __expectString(output.type),
+    value: __expectNumber(output.value),
   } as any;
 };
 
@@ -10918,7 +10831,7 @@ const deserializeAws_json1_1MultipleIamArnsProvidedException = (
   context: __SerdeContext
 ): MultipleIamArnsProvidedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10947,7 +10860,7 @@ const deserializeAws_json1_1OperationNotSupportedException = (
   context: __SerdeContext
 ): OperationNotSupportedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10956,17 +10869,14 @@ const deserializeAws_json1_1PutLifecycleEventHookExecutionStatusOutput = (
   context: __SerdeContext
 ): PutLifecycleEventHookExecutionStatusOutput => {
   return {
-    lifecycleEventHookExecutionId:
-      output.lifecycleEventHookExecutionId !== undefined && output.lifecycleEventHookExecutionId !== null
-        ? output.lifecycleEventHookExecutionId
-        : undefined,
+    lifecycleEventHookExecutionId: __expectString(output.lifecycleEventHookExecutionId),
   } as any;
 };
 
 const deserializeAws_json1_1RawString = (output: any, context: __SerdeContext): RawString => {
   return {
-    content: output.content !== undefined && output.content !== null ? output.content : undefined,
-    sha256: output.sha256 !== undefined && output.sha256 !== null ? output.sha256 : undefined,
+    content: __expectString(output.content),
+    sha256: __expectString(output.sha256),
   } as any;
 };
 
@@ -10977,11 +10887,7 @@ const deserializeAws_json1_1RelatedDeployments = (output: any, context: __SerdeC
       output.autoUpdateOutdatedInstancesDeploymentIds !== null
         ? deserializeAws_json1_1DeploymentsList(output.autoUpdateOutdatedInstancesDeploymentIds, context)
         : undefined,
-    autoUpdateOutdatedInstancesRootDeploymentId:
-      output.autoUpdateOutdatedInstancesRootDeploymentId !== undefined &&
-      output.autoUpdateOutdatedInstancesRootDeploymentId !== null
-        ? output.autoUpdateOutdatedInstancesRootDeploymentId
-        : undefined,
+    autoUpdateOutdatedInstancesRootDeploymentId: __expectString(output.autoUpdateOutdatedInstancesRootDeploymentId),
   } as any;
 };
 
@@ -10990,7 +10896,7 @@ const deserializeAws_json1_1ResourceArnRequiredException = (
   context: __SerdeContext
 ): ResourceArnRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10999,7 +10905,7 @@ const deserializeAws_json1_1ResourceValidationException = (
   context: __SerdeContext
 ): ResourceValidationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -11008,7 +10914,7 @@ const deserializeAws_json1_1RevisionDoesNotExistException = (
   context: __SerdeContext
 ): RevisionDoesNotExistException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -11046,7 +10952,7 @@ const deserializeAws_json1_1RevisionLocation = (output: any, context: __SerdeCon
       output.gitHubLocation !== undefined && output.gitHubLocation !== null
         ? deserializeAws_json1_1GitHubLocation(output.gitHubLocation, context)
         : undefined,
-    revisionType: output.revisionType !== undefined && output.revisionType !== null ? output.revisionType : undefined,
+    revisionType: __expectString(output.revisionType),
     s3Location:
       output.s3Location !== undefined && output.s3Location !== null
         ? deserializeAws_json1_1S3Location(output.s3Location, context)
@@ -11074,61 +10980,53 @@ const deserializeAws_json1_1RevisionRequiredException = (
   context: __SerdeContext
 ): RevisionRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1RoleRequiredException = (output: any, context: __SerdeContext): RoleRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1RollbackInfo = (output: any, context: __SerdeContext): RollbackInfo => {
   return {
-    rollbackDeploymentId:
-      output.rollbackDeploymentId !== undefined && output.rollbackDeploymentId !== null
-        ? output.rollbackDeploymentId
-        : undefined,
-    rollbackMessage:
-      output.rollbackMessage !== undefined && output.rollbackMessage !== null ? output.rollbackMessage : undefined,
-    rollbackTriggeringDeploymentId:
-      output.rollbackTriggeringDeploymentId !== undefined && output.rollbackTriggeringDeploymentId !== null
-        ? output.rollbackTriggeringDeploymentId
-        : undefined,
+    rollbackDeploymentId: __expectString(output.rollbackDeploymentId),
+    rollbackMessage: __expectString(output.rollbackMessage),
+    rollbackTriggeringDeploymentId: __expectString(output.rollbackTriggeringDeploymentId),
   } as any;
 };
 
 const deserializeAws_json1_1S3Location = (output: any, context: __SerdeContext): S3Location => {
   return {
-    bucket: output.bucket !== undefined && output.bucket !== null ? output.bucket : undefined,
-    bundleType: output.bundleType !== undefined && output.bundleType !== null ? output.bundleType : undefined,
-    eTag: output.eTag !== undefined && output.eTag !== null ? output.eTag : undefined,
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    bucket: __expectString(output.bucket),
+    bundleType: __expectString(output.bundleType),
+    eTag: __expectString(output.eTag),
+    key: __expectString(output.key),
+    version: __expectString(output.version),
   } as any;
 };
 
 const deserializeAws_json1_1StopDeploymentOutput = (output: any, context: __SerdeContext): StopDeploymentOutput => {
   return {
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    statusMessage:
-      output.statusMessage !== undefined && output.statusMessage !== null ? output.statusMessage : undefined,
+    status: __expectString(output.status),
+    statusMessage: __expectString(output.statusMessage),
   } as any;
 };
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
 const deserializeAws_json1_1TagFilter = (output: any, context: __SerdeContext): TagFilter => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Type: __expectString(output.Type),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -11148,7 +11046,7 @@ const deserializeAws_json1_1TagLimitExceededException = (
   context: __SerdeContext
 ): TagLimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -11165,7 +11063,7 @@ const deserializeAws_json1_1TagList = (output: any, context: __SerdeContext): Ta
 
 const deserializeAws_json1_1TagRequiredException = (output: any, context: __SerdeContext): TagRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -11178,13 +11076,13 @@ const deserializeAws_json1_1TagSetListLimitExceededException = (
   context: __SerdeContext
 ): TagSetListLimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1TargetGroupInfo = (output: any, context: __SerdeContext): TargetGroupInfo => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -11234,7 +11132,7 @@ const deserializeAws_json1_1TargetIdList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -11257,25 +11155,21 @@ const deserializeAws_json1_1TargetInstances = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_1ThrottlingException = (output: any, context: __SerdeContext): ThrottlingException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1TimeBasedCanary = (output: any, context: __SerdeContext): TimeBasedCanary => {
   return {
-    canaryInterval:
-      output.canaryInterval !== undefined && output.canaryInterval !== null ? output.canaryInterval : undefined,
-    canaryPercentage:
-      output.canaryPercentage !== undefined && output.canaryPercentage !== null ? output.canaryPercentage : undefined,
+    canaryInterval: __expectNumber(output.canaryInterval),
+    canaryPercentage: __expectNumber(output.canaryPercentage),
   } as any;
 };
 
 const deserializeAws_json1_1TimeBasedLinear = (output: any, context: __SerdeContext): TimeBasedLinear => {
   return {
-    linearInterval:
-      output.linearInterval !== undefined && output.linearInterval !== null ? output.linearInterval : undefined,
-    linearPercentage:
-      output.linearPercentage !== undefined && output.linearPercentage !== null ? output.linearPercentage : undefined,
+    linearInterval: __expectNumber(output.linearInterval),
+    linearPercentage: __expectNumber(output.linearPercentage),
   } as any;
 };
 
@@ -11298,7 +11192,7 @@ const deserializeAws_json1_1TrafficRoutingConfig = (output: any, context: __Serd
       output.timeBasedLinear !== undefined && output.timeBasedLinear !== null
         ? deserializeAws_json1_1TimeBasedLinear(output.timeBasedLinear, context)
         : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -11308,9 +11202,8 @@ const deserializeAws_json1_1TriggerConfig = (output: any, context: __SerdeContex
       output.triggerEvents !== undefined && output.triggerEvents !== null
         ? deserializeAws_json1_1TriggerEventTypeList(output.triggerEvents, context)
         : undefined,
-    triggerName: output.triggerName !== undefined && output.triggerName !== null ? output.triggerName : undefined,
-    triggerTargetArn:
-      output.triggerTargetArn !== undefined && output.triggerTargetArn !== null ? output.triggerTargetArn : undefined,
+    triggerName: __expectString(output.triggerName),
+    triggerTargetArn: __expectString(output.triggerTargetArn),
   } as any;
 };
 
@@ -11335,7 +11228,7 @@ const deserializeAws_json1_1TriggerEventTypeList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -11344,7 +11237,7 @@ const deserializeAws_json1_1TriggerTargetsLimitExceededException = (
   context: __SerdeContext
 ): TriggerTargetsLimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -11353,7 +11246,7 @@ const deserializeAws_json1_1UnsupportedActionForDeploymentTypeException = (
   context: __SerdeContext
 ): UnsupportedActionForDeploymentTypeException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 

--- a/clients/client-codeguru-reviewer/protocols/Aws_restJson1.ts
+++ b/clients/client-codeguru-reviewer/protocols/Aws_restJson1.ts
@@ -70,6 +70,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -1076,7 +1078,7 @@ export const deserializeAws_restJson1ListCodeReviewsCommand = async (
     contents.CodeReviewSummaries = deserializeAws_restJson1CodeReviewSummaries(data.CodeReviewSummaries, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1156,7 +1158,7 @@ export const deserializeAws_restJson1ListRecommendationFeedbackCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.RecommendationFeedbackSummaries !== undefined && data.RecommendationFeedbackSummaries !== null) {
     contents.RecommendationFeedbackSummaries = deserializeAws_restJson1RecommendationFeedbackSummaries(
@@ -1250,7 +1252,7 @@ export const deserializeAws_restJson1ListRecommendationsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.RecommendationSummaries !== undefined && data.RecommendationSummaries !== null) {
     contents.RecommendationSummaries = deserializeAws_restJson1RecommendationSummaries(
@@ -1344,7 +1346,7 @@ export const deserializeAws_restJson1ListRepositoryAssociationsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.RepositoryAssociationSummaries !== undefined && data.RepositoryAssociationSummaries !== null) {
     contents.RepositoryAssociationSummaries = deserializeAws_restJson1RepositoryAssociationSummaries(
@@ -1708,7 +1710,7 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1725,7 +1727,7 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1742,7 +1744,7 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1759,7 +1761,7 @@ const deserializeAws_restJson1NotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1776,7 +1778,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1793,7 +1795,7 @@ const deserializeAws_restJson1ThrottlingExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1810,7 +1812,7 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1909,10 +1911,8 @@ const serializeAws_restJson1ThirdPartySourceRepository = (
 
 const deserializeAws_restJson1CodeReview = (output: any, context: __SerdeContext): CodeReview => {
   return {
-    AssociationArn:
-      output.AssociationArn !== undefined && output.AssociationArn !== null ? output.AssociationArn : undefined,
-    CodeReviewArn:
-      output.CodeReviewArn !== undefined && output.CodeReviewArn !== null ? output.CodeReviewArn : undefined,
+    AssociationArn: __expectString(output.AssociationArn),
+    CodeReviewArn: __expectString(output.CodeReviewArn),
     CreatedTimeStamp:
       output.CreatedTimeStamp !== undefined && output.CreatedTimeStamp !== null
         ? new Date(Math.round(output.CreatedTimeStamp * 1000))
@@ -1925,20 +1925,18 @@ const deserializeAws_restJson1CodeReview = (output: any, context: __SerdeContext
       output.Metrics !== undefined && output.Metrics !== null
         ? deserializeAws_restJson1Metrics(output.Metrics, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Owner: output.Owner !== undefined && output.Owner !== null ? output.Owner : undefined,
-    ProviderType: output.ProviderType !== undefined && output.ProviderType !== null ? output.ProviderType : undefined,
-    PullRequestId:
-      output.PullRequestId !== undefined && output.PullRequestId !== null ? output.PullRequestId : undefined,
-    RepositoryName:
-      output.RepositoryName !== undefined && output.RepositoryName !== null ? output.RepositoryName : undefined,
+    Name: __expectString(output.Name),
+    Owner: __expectString(output.Owner),
+    ProviderType: __expectString(output.ProviderType),
+    PullRequestId: __expectString(output.PullRequestId),
+    RepositoryName: __expectString(output.RepositoryName),
     SourceCodeType:
       output.SourceCodeType !== undefined && output.SourceCodeType !== null
         ? deserializeAws_restJson1SourceCodeType(output.SourceCodeType, context)
         : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    StateReason: output.StateReason !== undefined && output.StateReason !== null ? output.StateReason : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    State: __expectString(output.State),
+    StateReason: __expectString(output.StateReason),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -1955,8 +1953,7 @@ const deserializeAws_restJson1CodeReviewSummaries = (output: any, context: __Ser
 
 const deserializeAws_restJson1CodeReviewSummary = (output: any, context: __SerdeContext): CodeReviewSummary => {
   return {
-    CodeReviewArn:
-      output.CodeReviewArn !== undefined && output.CodeReviewArn !== null ? output.CodeReviewArn : undefined,
+    CodeReviewArn: __expectString(output.CodeReviewArn),
     CreatedTimeStamp:
       output.CreatedTimeStamp !== undefined && output.CreatedTimeStamp !== null
         ? new Date(Math.round(output.CreatedTimeStamp * 1000))
@@ -1969,15 +1966,13 @@ const deserializeAws_restJson1CodeReviewSummary = (output: any, context: __Serde
       output.MetricsSummary !== undefined && output.MetricsSummary !== null
         ? deserializeAws_restJson1MetricsSummary(output.MetricsSummary, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Owner: output.Owner !== undefined && output.Owner !== null ? output.Owner : undefined,
-    ProviderType: output.ProviderType !== undefined && output.ProviderType !== null ? output.ProviderType : undefined,
-    PullRequestId:
-      output.PullRequestId !== undefined && output.PullRequestId !== null ? output.PullRequestId : undefined,
-    RepositoryName:
-      output.RepositoryName !== undefined && output.RepositoryName !== null ? output.RepositoryName : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Name: __expectString(output.Name),
+    Owner: __expectString(output.Owner),
+    ProviderType: __expectString(output.ProviderType),
+    PullRequestId: __expectString(output.PullRequestId),
+    RepositoryName: __expectString(output.RepositoryName),
+    State: __expectString(output.State),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -1986,41 +1981,29 @@ const deserializeAws_restJson1CommitDiffSourceCodeType = (
   context: __SerdeContext
 ): CommitDiffSourceCodeType => {
   return {
-    DestinationCommit:
-      output.DestinationCommit !== undefined && output.DestinationCommit !== null
-        ? output.DestinationCommit
-        : undefined,
-    SourceCommit: output.SourceCommit !== undefined && output.SourceCommit !== null ? output.SourceCommit : undefined,
+    DestinationCommit: __expectString(output.DestinationCommit),
+    SourceCommit: __expectString(output.SourceCommit),
   } as any;
 };
 
 const deserializeAws_restJson1KMSKeyDetails = (output: any, context: __SerdeContext): KMSKeyDetails => {
   return {
-    EncryptionOption:
-      output.EncryptionOption !== undefined && output.EncryptionOption !== null ? output.EncryptionOption : undefined,
-    KMSKeyId: output.KMSKeyId !== undefined && output.KMSKeyId !== null ? output.KMSKeyId : undefined,
+    EncryptionOption: __expectString(output.EncryptionOption),
+    KMSKeyId: __expectString(output.KMSKeyId),
   } as any;
 };
 
 const deserializeAws_restJson1Metrics = (output: any, context: __SerdeContext): Metrics => {
   return {
-    FindingsCount:
-      output.FindingsCount !== undefined && output.FindingsCount !== null ? output.FindingsCount : undefined,
-    MeteredLinesOfCodeCount:
-      output.MeteredLinesOfCodeCount !== undefined && output.MeteredLinesOfCodeCount !== null
-        ? output.MeteredLinesOfCodeCount
-        : undefined,
+    FindingsCount: __expectNumber(output.FindingsCount),
+    MeteredLinesOfCodeCount: __expectNumber(output.MeteredLinesOfCodeCount),
   } as any;
 };
 
 const deserializeAws_restJson1MetricsSummary = (output: any, context: __SerdeContext): MetricsSummary => {
   return {
-    FindingsCount:
-      output.FindingsCount !== undefined && output.FindingsCount !== null ? output.FindingsCount : undefined,
-    MeteredLinesOfCodeCount:
-      output.MeteredLinesOfCodeCount !== undefined && output.MeteredLinesOfCodeCount !== null
-        ? output.MeteredLinesOfCodeCount
-        : undefined,
+    FindingsCount: __expectNumber(output.FindingsCount),
+    MeteredLinesOfCodeCount: __expectNumber(output.MeteredLinesOfCodeCount),
   } as any;
 };
 
@@ -2031,7 +2014,7 @@ const deserializeAws_restJson1Reactions = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2040,8 +2023,7 @@ const deserializeAws_restJson1RecommendationFeedback = (
   context: __SerdeContext
 ): RecommendationFeedback => {
   return {
-    CodeReviewArn:
-      output.CodeReviewArn !== undefined && output.CodeReviewArn !== null ? output.CodeReviewArn : undefined,
+    CodeReviewArn: __expectString(output.CodeReviewArn),
     CreatedTimeStamp:
       output.CreatedTimeStamp !== undefined && output.CreatedTimeStamp !== null
         ? new Date(Math.round(output.CreatedTimeStamp * 1000))
@@ -2054,9 +2036,8 @@ const deserializeAws_restJson1RecommendationFeedback = (
       output.Reactions !== undefined && output.Reactions !== null
         ? deserializeAws_restJson1Reactions(output.Reactions, context)
         : undefined,
-    RecommendationId:
-      output.RecommendationId !== undefined && output.RecommendationId !== null ? output.RecommendationId : undefined,
-    UserId: output.UserId !== undefined && output.UserId !== null ? output.UserId : undefined,
+    RecommendationId: __expectString(output.RecommendationId),
+    UserId: __expectString(output.UserId),
   } as any;
 };
 
@@ -2083,9 +2064,8 @@ const deserializeAws_restJson1RecommendationFeedbackSummary = (
       output.Reactions !== undefined && output.Reactions !== null
         ? deserializeAws_restJson1Reactions(output.Reactions, context)
         : undefined,
-    RecommendationId:
-      output.RecommendationId !== undefined && output.RecommendationId !== null ? output.RecommendationId : undefined,
-    UserId: output.UserId !== undefined && output.UserId !== null ? output.UserId : undefined,
+    RecommendationId: __expectString(output.RecommendationId),
+    UserId: __expectString(output.UserId),
   } as any;
 };
 
@@ -2105,23 +2085,19 @@ const deserializeAws_restJson1RecommendationSummaries = (
 
 const deserializeAws_restJson1RecommendationSummary = (output: any, context: __SerdeContext): RecommendationSummary => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    EndLine: output.EndLine !== undefined && output.EndLine !== null ? output.EndLine : undefined,
-    FilePath: output.FilePath !== undefined && output.FilePath !== null ? output.FilePath : undefined,
-    RecommendationId:
-      output.RecommendationId !== undefined && output.RecommendationId !== null ? output.RecommendationId : undefined,
-    StartLine: output.StartLine !== undefined && output.StartLine !== null ? output.StartLine : undefined,
+    Description: __expectString(output.Description),
+    EndLine: __expectNumber(output.EndLine),
+    FilePath: __expectString(output.FilePath),
+    RecommendationId: __expectString(output.RecommendationId),
+    StartLine: __expectNumber(output.StartLine),
   } as any;
 };
 
 const deserializeAws_restJson1RepositoryAssociation = (output: any, context: __SerdeContext): RepositoryAssociation => {
   return {
-    AssociationArn:
-      output.AssociationArn !== undefined && output.AssociationArn !== null ? output.AssociationArn : undefined,
-    AssociationId:
-      output.AssociationId !== undefined && output.AssociationId !== null ? output.AssociationId : undefined,
-    ConnectionArn:
-      output.ConnectionArn !== undefined && output.ConnectionArn !== null ? output.ConnectionArn : undefined,
+    AssociationArn: __expectString(output.AssociationArn),
+    AssociationId: __expectString(output.AssociationId),
+    ConnectionArn: __expectString(output.ConnectionArn),
     CreatedTimeStamp:
       output.CreatedTimeStamp !== undefined && output.CreatedTimeStamp !== null
         ? new Date(Math.round(output.CreatedTimeStamp * 1000))
@@ -2134,11 +2110,11 @@ const deserializeAws_restJson1RepositoryAssociation = (output: any, context: __S
       output.LastUpdatedTimeStamp !== undefined && output.LastUpdatedTimeStamp !== null
         ? new Date(Math.round(output.LastUpdatedTimeStamp * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Owner: output.Owner !== undefined && output.Owner !== null ? output.Owner : undefined,
-    ProviderType: output.ProviderType !== undefined && output.ProviderType !== null ? output.ProviderType : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    StateReason: output.StateReason !== undefined && output.StateReason !== null ? output.StateReason : undefined,
+    Name: __expectString(output.Name),
+    Owner: __expectString(output.Owner),
+    ProviderType: __expectString(output.ProviderType),
+    State: __expectString(output.State),
+    StateReason: __expectString(output.StateReason),
   } as any;
 };
 
@@ -2161,20 +2137,17 @@ const deserializeAws_restJson1RepositoryAssociationSummary = (
   context: __SerdeContext
 ): RepositoryAssociationSummary => {
   return {
-    AssociationArn:
-      output.AssociationArn !== undefined && output.AssociationArn !== null ? output.AssociationArn : undefined,
-    AssociationId:
-      output.AssociationId !== undefined && output.AssociationId !== null ? output.AssociationId : undefined,
-    ConnectionArn:
-      output.ConnectionArn !== undefined && output.ConnectionArn !== null ? output.ConnectionArn : undefined,
+    AssociationArn: __expectString(output.AssociationArn),
+    AssociationId: __expectString(output.AssociationId),
+    ConnectionArn: __expectString(output.ConnectionArn),
     LastUpdatedTimeStamp:
       output.LastUpdatedTimeStamp !== undefined && output.LastUpdatedTimeStamp !== null
         ? new Date(Math.round(output.LastUpdatedTimeStamp * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Owner: output.Owner !== undefined && output.Owner !== null ? output.Owner : undefined,
-    ProviderType: output.ProviderType !== undefined && output.ProviderType !== null ? output.ProviderType : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    Name: __expectString(output.Name),
+    Owner: __expectString(output.Owner),
+    ProviderType: __expectString(output.ProviderType),
+    State: __expectString(output.State),
   } as any;
 };
 
@@ -2183,7 +2156,7 @@ const deserializeAws_restJson1RepositoryHeadSourceCodeType = (
   context: __SerdeContext
 ): RepositoryHeadSourceCodeType => {
   return {
-    BranchName: output.BranchName !== undefined && output.BranchName !== null ? output.BranchName : undefined,
+    BranchName: __expectString(output.BranchName),
   } as any;
 };
 
@@ -2207,7 +2180,7 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };

--- a/clients/client-codeguruprofiler/protocols/Aws_restJson1.ts
+++ b/clients/client-codeguruprofiler/protocols/Aws_restJson1.ts
@@ -90,6 +90,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -1018,7 +1021,7 @@ export const deserializeAws_restJson1BatchGetFrameMetricDataCommand = async (
     contents.frameMetricData = deserializeAws_restJson1FrameMetricData(data.frameMetricData, context);
   }
   if (data.resolution !== undefined && data.resolution !== null) {
-    contents.resolution = data.resolution;
+    contents.resolution = __expectString(data.resolution);
   }
   if (data.startTime !== undefined && data.startTime !== null) {
     contents.startTime = new Date(data.startTime);
@@ -1426,7 +1429,7 @@ export const deserializeAws_restJson1GetFindingsReportAccountSummaryCommand = as
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.reportSummaries !== undefined && data.reportSummaries !== null) {
     contents.reportSummaries = deserializeAws_restJson1FindingsReportSummaries(data.reportSummaries, context);
@@ -1583,10 +1586,10 @@ export const deserializeAws_restJson1GetPolicyCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.policy !== undefined && data.policy !== null) {
-    contents.policy = data.policy;
+    contents.policy = __expectString(data.policy);
   }
   if (data.revisionId !== undefined && data.revisionId !== null) {
-    contents.revisionId = data.revisionId;
+    contents.revisionId = __expectString(data.revisionId);
   }
   return Promise.resolve(contents);
 };
@@ -1755,7 +1758,7 @@ export const deserializeAws_restJson1GetRecommendationsCommand = async (
     contents.profileStartTime = new Date(data.profileStartTime);
   }
   if (data.profilingGroupName !== undefined && data.profilingGroupName !== null) {
-    contents.profilingGroupName = data.profilingGroupName;
+    contents.profilingGroupName = __expectString(data.profilingGroupName);
   }
   if (data.recommendations !== undefined && data.recommendations !== null) {
     contents.recommendations = deserializeAws_restJson1Recommendations(data.recommendations, context);
@@ -1844,7 +1847,7 @@ export const deserializeAws_restJson1ListFindingsReportsCommand = async (
     );
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1924,7 +1927,7 @@ export const deserializeAws_restJson1ListProfileTimesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.profileTimes !== undefined && data.profileTimes !== null) {
     contents.profileTimes = deserializeAws_restJson1ProfileTimes(data.profileTimes, context);
@@ -2008,7 +2011,7 @@ export const deserializeAws_restJson1ListProfilingGroupsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.profilingGroupNames !== undefined && data.profilingGroupNames !== null) {
     contents.profilingGroupNames = deserializeAws_restJson1ProfilingGroupNames(data.profilingGroupNames, context);
@@ -2224,10 +2227,10 @@ export const deserializeAws_restJson1PutPermissionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.policy !== undefined && data.policy !== null) {
-    contents.policy = data.policy;
+    contents.policy = __expectString(data.policy);
   }
   if (data.revisionId !== undefined && data.revisionId !== null) {
-    contents.revisionId = data.revisionId;
+    contents.revisionId = __expectString(data.revisionId);
   }
   return Promise.resolve(contents);
 };
@@ -2397,10 +2400,10 @@ export const deserializeAws_restJson1RemovePermissionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.policy !== undefined && data.policy !== null) {
-    contents.policy = data.policy;
+    contents.policy = __expectString(data.policy);
   }
   if (data.revisionId !== undefined && data.revisionId !== null) {
-    contents.revisionId = data.revisionId;
+    contents.revisionId = __expectString(data.revisionId);
   }
   return Promise.resolve(contents);
 };
@@ -2780,7 +2783,7 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2798,7 +2801,7 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2815,7 +2818,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2833,7 +2836,7 @@ const deserializeAws_restJson1ServiceQuotaExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2851,7 +2854,7 @@ const deserializeAws_restJson1ThrottlingExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2868,7 +2871,7 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2988,10 +2991,8 @@ const deserializeAws_restJson1AgentConfiguration = (output: any, context: __Serd
       output.agentParameters !== undefined && output.agentParameters !== null
         ? deserializeAws_restJson1AgentParameters(output.agentParameters, context)
         : undefined,
-    periodInSeconds:
-      output.periodInSeconds !== undefined && output.periodInSeconds !== null ? output.periodInSeconds : undefined,
-    shouldProfile:
-      output.shouldProfile !== undefined && output.shouldProfile !== null ? output.shouldProfile : undefined,
+    periodInSeconds: __expectNumber(output.periodInSeconds),
+    shouldProfile: __expectBoolean(output.shouldProfile),
   } as any;
 };
 
@@ -3000,8 +3001,7 @@ const deserializeAws_restJson1AgentOrchestrationConfig = (
   context: __SerdeContext
 ): AgentOrchestrationConfig => {
   return {
-    profilingEnabled:
-      output.profilingEnabled !== undefined && output.profilingEnabled !== null ? output.profilingEnabled : undefined,
+    profilingEnabled: __expectBoolean(output.profilingEnabled),
   } as any;
 };
 
@@ -3013,7 +3013,7 @@ const deserializeAws_restJson1AgentParameters = (output: any, context: __SerdeCo
       }
       return {
         ...acc,
-        [key]: value,
+        [key]: __expectString(value) as any,
       };
     },
     {}
@@ -3022,7 +3022,7 @@ const deserializeAws_restJson1AgentParameters = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1AggregatedProfileTime = (output: any, context: __SerdeContext): AggregatedProfileTime => {
   return {
-    period: output.period !== undefined && output.period !== null ? output.period : undefined,
+    period: __expectString(output.period),
     start: output.start !== undefined && output.start !== null ? new Date(output.start) : undefined,
   } as any;
 };
@@ -3048,14 +3048,14 @@ const deserializeAws_restJson1Anomaly = (output: any, context: __SerdeContext): 
       output.metric !== undefined && output.metric !== null
         ? deserializeAws_restJson1Metric(output.metric, context)
         : undefined,
-    reason: output.reason !== undefined && output.reason !== null ? output.reason : undefined,
+    reason: __expectString(output.reason),
   } as any;
 };
 
 const deserializeAws_restJson1AnomalyInstance = (output: any, context: __SerdeContext): AnomalyInstance => {
   return {
     endTime: output.endTime !== undefined && output.endTime !== null ? new Date(output.endTime) : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    id: __expectString(output.id),
     startTime: output.startTime !== undefined && output.startTime !== null ? new Date(output.startTime) : undefined,
     userFeedback:
       output.userFeedback !== undefined && output.userFeedback !== null
@@ -3081,8 +3081,8 @@ const deserializeAws_restJson1Channel = (output: any, context: __SerdeContext): 
       output.eventPublishers !== undefined && output.eventPublishers !== null
         ? deserializeAws_restJson1EventPublishers(output.eventPublishers, context)
         : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    uri: output.uri !== undefined && output.uri !== null ? output.uri : undefined,
+    id: __expectString(output.id),
+    uri: __expectString(output.uri),
   } as any;
 };
 
@@ -3104,7 +3104,7 @@ const deserializeAws_restJson1EventPublishers = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3124,7 +3124,7 @@ const deserializeAws_restJson1FindingsReportSummaries = (
 
 const deserializeAws_restJson1FindingsReportSummary = (output: any, context: __SerdeContext): FindingsReportSummary => {
   return {
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    id: __expectString(output.id),
     profileEndTime:
       output.profileEndTime !== undefined && output.profileEndTime !== null
         ? new Date(output.profileEndTime)
@@ -3133,25 +3133,19 @@ const deserializeAws_restJson1FindingsReportSummary = (output: any, context: __S
       output.profileStartTime !== undefined && output.profileStartTime !== null
         ? new Date(output.profileStartTime)
         : undefined,
-    profilingGroupName:
-      output.profilingGroupName !== undefined && output.profilingGroupName !== null
-        ? output.profilingGroupName
-        : undefined,
-    totalNumberOfFindings:
-      output.totalNumberOfFindings !== undefined && output.totalNumberOfFindings !== null
-        ? output.totalNumberOfFindings
-        : undefined,
+    profilingGroupName: __expectString(output.profilingGroupName),
+    totalNumberOfFindings: __expectNumber(output.totalNumberOfFindings),
   } as any;
 };
 
 const deserializeAws_restJson1FrameMetric = (output: any, context: __SerdeContext): FrameMetric => {
   return {
-    frameName: output.frameName !== undefined && output.frameName !== null ? output.frameName : undefined,
+    frameName: __expectString(output.frameName),
     threadStates:
       output.threadStates !== undefined && output.threadStates !== null
         ? deserializeAws_restJson1ThreadStates(output.threadStates, context)
         : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -3186,7 +3180,7 @@ const deserializeAws_restJson1FrameMetricValues = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectNumber(entry) as any;
     });
 };
 
@@ -3203,15 +3197,9 @@ const deserializeAws_restJson1ListOfTimestamps = (output: any, context: __SerdeC
 
 const deserializeAws_restJson1Match = (output: any, context: __SerdeContext): Match => {
   return {
-    frameAddress: output.frameAddress !== undefined && output.frameAddress !== null ? output.frameAddress : undefined,
-    targetFramesIndex:
-      output.targetFramesIndex !== undefined && output.targetFramesIndex !== null
-        ? output.targetFramesIndex
-        : undefined,
-    thresholdBreachValue:
-      output.thresholdBreachValue !== undefined && output.thresholdBreachValue !== null
-        ? output.thresholdBreachValue
-        : undefined,
+    frameAddress: __expectString(output.frameAddress),
+    targetFramesIndex: __expectNumber(output.targetFramesIndex),
+    thresholdBreachValue: __expectNumber(output.thresholdBreachValue),
   } as any;
 };
 
@@ -3228,12 +3216,12 @@ const deserializeAws_restJson1Matches = (output: any, context: __SerdeContext): 
 
 const deserializeAws_restJson1Metric = (output: any, context: __SerdeContext): Metric => {
   return {
-    frameName: output.frameName !== undefined && output.frameName !== null ? output.frameName : undefined,
+    frameName: __expectString(output.frameName),
     threadStates:
       output.threadStates !== undefined && output.threadStates !== null
         ? deserializeAws_restJson1Strings(output.threadStates, context)
         : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -3255,17 +3243,15 @@ const deserializeAws_restJson1Pattern = (output: any, context: __SerdeContext): 
       output.countersToAggregate !== undefined && output.countersToAggregate !== null
         ? deserializeAws_restJson1Strings(output.countersToAggregate, context)
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    resolutionSteps:
-      output.resolutionSteps !== undefined && output.resolutionSteps !== null ? output.resolutionSteps : undefined,
+    description: __expectString(output.description),
+    id: __expectString(output.id),
+    name: __expectString(output.name),
+    resolutionSteps: __expectString(output.resolutionSteps),
     targetFrames:
       output.targetFrames !== undefined && output.targetFrames !== null
         ? deserializeAws_restJson1TargetFrames(output.targetFrames, context)
         : undefined,
-    thresholdPercent:
-      output.thresholdPercent !== undefined && output.thresholdPercent !== null ? output.thresholdPercent : undefined,
+    thresholdPercent: __expectNumber(output.thresholdPercent),
   } as any;
 };
 
@@ -3295,11 +3281,10 @@ const deserializeAws_restJson1ProfilingGroupDescription = (
       output.agentOrchestrationConfig !== undefined && output.agentOrchestrationConfig !== null
         ? deserializeAws_restJson1AgentOrchestrationConfig(output.agentOrchestrationConfig, context)
         : undefined,
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    computePlatform:
-      output.computePlatform !== undefined && output.computePlatform !== null ? output.computePlatform : undefined,
+    arn: __expectString(output.arn),
+    computePlatform: __expectString(output.computePlatform),
     createdAt: output.createdAt !== undefined && output.createdAt !== null ? new Date(output.createdAt) : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
     profilingStatus:
       output.profilingStatus !== undefined && output.profilingStatus !== null
         ? deserializeAws_restJson1ProfilingStatus(output.profilingStatus, context)
@@ -3333,7 +3318,7 @@ const deserializeAws_restJson1ProfilingGroupNames = (output: any, context: __Ser
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3356,10 +3341,8 @@ const deserializeAws_restJson1ProfilingStatus = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1Recommendation = (output: any, context: __SerdeContext): Recommendation => {
   return {
-    allMatchesCount:
-      output.allMatchesCount !== undefined && output.allMatchesCount !== null ? output.allMatchesCount : undefined,
-    allMatchesSum:
-      output.allMatchesSum !== undefined && output.allMatchesSum !== null ? output.allMatchesSum : undefined,
+    allMatchesCount: __expectNumber(output.allMatchesCount),
+    allMatchesSum: __expectNumber(output.allMatchesSum),
     endTime: output.endTime !== undefined && output.endTime !== null ? new Date(output.endTime) : undefined,
     pattern:
       output.pattern !== undefined && output.pattern !== null
@@ -3391,7 +3374,7 @@ const deserializeAws_restJson1Strings = (output: any, context: __SerdeContext): 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3402,7 +3385,7 @@ const deserializeAws_restJson1TagsMap = (output: any, context: __SerdeContext): 
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -3414,7 +3397,7 @@ const deserializeAws_restJson1TargetFrame = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3436,7 +3419,7 @@ const deserializeAws_restJson1ThreadStates = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3463,7 +3446,7 @@ const deserializeAws_restJson1UnprocessedEndTimeMap = (
 
 const deserializeAws_restJson1UserFeedback = (output: any, context: __SerdeContext): UserFeedback => {
   return {
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    type: __expectString(output.type),
   } as any;
 };
 

--- a/clients/client-codepipeline/protocols/Aws_json1_1.ts
+++ b/clients/client-codepipeline/protocols/Aws_json1_1.ts
@@ -273,7 +273,12 @@ import {
   WebhookNotFoundException,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -5223,7 +5228,7 @@ const serializeAws_json1_1WebhookFilters = (input: WebhookFilterRule[], context:
 
 const deserializeAws_json1_1AcknowledgeJobOutput = (output: any, context: __SerdeContext): AcknowledgeJobOutput => {
   return {
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -5232,7 +5237,7 @@ const deserializeAws_json1_1AcknowledgeThirdPartyJobOutput = (
   context: __SerdeContext
 ): AcknowledgeThirdPartyJobOutput => {
   return {
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -5255,7 +5260,7 @@ const deserializeAws_json1_1ActionConfigurationMap = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -5265,13 +5270,13 @@ const deserializeAws_json1_1ActionConfigurationProperty = (
   context: __SerdeContext
 ): ActionConfigurationProperty => {
   return {
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    queryable: output.queryable !== undefined && output.queryable !== null ? output.queryable : undefined,
-    required: output.required !== undefined && output.required !== null ? output.required : undefined,
-    secret: output.secret !== undefined && output.secret !== null ? output.secret : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    description: __expectString(output.description),
+    key: __expectBoolean(output.key),
+    name: __expectString(output.name),
+    queryable: __expectBoolean(output.queryable),
+    required: __expectBoolean(output.required),
+    secret: __expectBoolean(output.secret),
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -5291,11 +5296,8 @@ const deserializeAws_json1_1ActionConfigurationPropertyList = (
 
 const deserializeAws_json1_1ActionContext = (output: any, context: __SerdeContext): ActionContext => {
   return {
-    actionExecutionId:
-      output.actionExecutionId !== undefined && output.actionExecutionId !== null
-        ? output.actionExecutionId
-        : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    actionExecutionId: __expectString(output.actionExecutionId),
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -5313,57 +5315,43 @@ const deserializeAws_json1_1ActionDeclaration = (output: any, context: __SerdeCo
       output.inputArtifacts !== undefined && output.inputArtifacts !== null
         ? deserializeAws_json1_1InputArtifactList(output.inputArtifacts, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    namespace: output.namespace !== undefined && output.namespace !== null ? output.namespace : undefined,
+    name: __expectString(output.name),
+    namespace: __expectString(output.namespace),
     outputArtifacts:
       output.outputArtifacts !== undefined && output.outputArtifacts !== null
         ? deserializeAws_json1_1OutputArtifactList(output.outputArtifacts, context)
         : undefined,
-    region: output.region !== undefined && output.region !== null ? output.region : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
-    runOrder: output.runOrder !== undefined && output.runOrder !== null ? output.runOrder : undefined,
+    region: __expectString(output.region),
+    roleArn: __expectString(output.roleArn),
+    runOrder: __expectNumber(output.runOrder),
   } as any;
 };
 
 const deserializeAws_json1_1ActionExecution = (output: any, context: __SerdeContext): ActionExecution => {
   return {
-    actionExecutionId:
-      output.actionExecutionId !== undefined && output.actionExecutionId !== null
-        ? output.actionExecutionId
-        : undefined,
+    actionExecutionId: __expectString(output.actionExecutionId),
     errorDetails:
       output.errorDetails !== undefined && output.errorDetails !== null
         ? deserializeAws_json1_1ErrorDetails(output.errorDetails, context)
         : undefined,
-    externalExecutionId:
-      output.externalExecutionId !== undefined && output.externalExecutionId !== null
-        ? output.externalExecutionId
-        : undefined,
-    externalExecutionUrl:
-      output.externalExecutionUrl !== undefined && output.externalExecutionUrl !== null
-        ? output.externalExecutionUrl
-        : undefined,
+    externalExecutionId: __expectString(output.externalExecutionId),
+    externalExecutionUrl: __expectString(output.externalExecutionUrl),
     lastStatusChange:
       output.lastStatusChange !== undefined && output.lastStatusChange !== null
         ? new Date(Math.round(output.lastStatusChange * 1000))
         : undefined,
-    lastUpdatedBy:
-      output.lastUpdatedBy !== undefined && output.lastUpdatedBy !== null ? output.lastUpdatedBy : undefined,
-    percentComplete:
-      output.percentComplete !== undefined && output.percentComplete !== null ? output.percentComplete : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    summary: output.summary !== undefined && output.summary !== null ? output.summary : undefined,
-    token: output.token !== undefined && output.token !== null ? output.token : undefined,
+    lastUpdatedBy: __expectString(output.lastUpdatedBy),
+    percentComplete: __expectNumber(output.percentComplete),
+    status: __expectString(output.status),
+    summary: __expectString(output.summary),
+    token: __expectString(output.token),
   } as any;
 };
 
 const deserializeAws_json1_1ActionExecutionDetail = (output: any, context: __SerdeContext): ActionExecutionDetail => {
   return {
-    actionExecutionId:
-      output.actionExecutionId !== undefined && output.actionExecutionId !== null
-        ? output.actionExecutionId
-        : undefined,
-    actionName: output.actionName !== undefined && output.actionName !== null ? output.actionName : undefined,
+    actionExecutionId: __expectString(output.actionExecutionId),
+    actionName: __expectString(output.actionName),
     input:
       output.input !== undefined && output.input !== null
         ? deserializeAws_json1_1ActionExecutionInput(output.input, context)
@@ -5376,18 +5364,14 @@ const deserializeAws_json1_1ActionExecutionDetail = (output: any, context: __Ser
       output.output !== undefined && output.output !== null
         ? deserializeAws_json1_1ActionExecutionOutput(output.output, context)
         : undefined,
-    pipelineExecutionId:
-      output.pipelineExecutionId !== undefined && output.pipelineExecutionId !== null
-        ? output.pipelineExecutionId
-        : undefined,
-    pipelineVersion:
-      output.pipelineVersion !== undefined && output.pipelineVersion !== null ? output.pipelineVersion : undefined,
-    stageName: output.stageName !== undefined && output.stageName !== null ? output.stageName : undefined,
+    pipelineExecutionId: __expectString(output.pipelineExecutionId),
+    pipelineVersion: __expectNumber(output.pipelineVersion),
+    stageName: __expectString(output.stageName),
     startTime:
       output.startTime !== undefined && output.startTime !== null
         ? new Date(Math.round(output.startTime * 1000))
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -5419,13 +5403,13 @@ const deserializeAws_json1_1ActionExecutionInput = (output: any, context: __Serd
       output.inputArtifacts !== undefined && output.inputArtifacts !== null
         ? deserializeAws_json1_1ArtifactDetailList(output.inputArtifacts, context)
         : undefined,
-    namespace: output.namespace !== undefined && output.namespace !== null ? output.namespace : undefined,
-    region: output.region !== undefined && output.region !== null ? output.region : undefined,
+    namespace: __expectString(output.namespace),
+    region: __expectString(output.region),
     resolvedConfiguration:
       output.resolvedConfiguration !== undefined && output.resolvedConfiguration !== null
         ? deserializeAws_json1_1ResolvedActionConfigurationMap(output.resolvedConfiguration, context)
         : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
+    roleArn: __expectString(output.roleArn),
   } as any;
 };
 
@@ -5448,18 +5432,9 @@ const deserializeAws_json1_1ActionExecutionOutput = (output: any, context: __Ser
 
 const deserializeAws_json1_1ActionExecutionResult = (output: any, context: __SerdeContext): ActionExecutionResult => {
   return {
-    externalExecutionId:
-      output.externalExecutionId !== undefined && output.externalExecutionId !== null
-        ? output.externalExecutionId
-        : undefined,
-    externalExecutionSummary:
-      output.externalExecutionSummary !== undefined && output.externalExecutionSummary !== null
-        ? output.externalExecutionSummary
-        : undefined,
-    externalExecutionUrl:
-      output.externalExecutionUrl !== undefined && output.externalExecutionUrl !== null
-        ? output.externalExecutionUrl
-        : undefined,
+    externalExecutionId: __expectString(output.externalExecutionId),
+    externalExecutionSummary: __expectString(output.externalExecutionSummary),
+    externalExecutionUrl: __expectString(output.externalExecutionUrl),
   } as any;
 };
 
@@ -5468,7 +5443,7 @@ const deserializeAws_json1_1ActionNotFoundException = (
   context: __SerdeContext
 ): ActionNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -5476,25 +5451,24 @@ const deserializeAws_json1_1ActionRevision = (output: any, context: __SerdeConte
   return {
     created:
       output.created !== undefined && output.created !== null ? new Date(Math.round(output.created * 1000)) : undefined,
-    revisionChangeId:
-      output.revisionChangeId !== undefined && output.revisionChangeId !== null ? output.revisionChangeId : undefined,
-    revisionId: output.revisionId !== undefined && output.revisionId !== null ? output.revisionId : undefined,
+    revisionChangeId: __expectString(output.revisionChangeId),
+    revisionId: __expectString(output.revisionId),
   } as any;
 };
 
 const deserializeAws_json1_1ActionState = (output: any, context: __SerdeContext): ActionState => {
   return {
-    actionName: output.actionName !== undefined && output.actionName !== null ? output.actionName : undefined,
+    actionName: __expectString(output.actionName),
     currentRevision:
       output.currentRevision !== undefined && output.currentRevision !== null
         ? deserializeAws_json1_1ActionRevision(output.currentRevision, context)
         : undefined,
-    entityUrl: output.entityUrl !== undefined && output.entityUrl !== null ? output.entityUrl : undefined,
+    entityUrl: __expectString(output.entityUrl),
     latestExecution:
       output.latestExecution !== undefined && output.latestExecution !== null
         ? deserializeAws_json1_1ActionExecution(output.latestExecution, context)
         : undefined,
-    revisionUrl: output.revisionUrl !== undefined && output.revisionUrl !== null ? output.revisionUrl : undefined,
+    revisionUrl: __expectString(output.revisionUrl),
   } as any;
 };
 
@@ -5539,14 +5513,14 @@ const deserializeAws_json1_1ActionTypeArtifactDetails = (
   context: __SerdeContext
 ): ActionTypeArtifactDetails => {
   return {
-    maximumCount: output.maximumCount !== undefined && output.maximumCount !== null ? output.maximumCount : undefined,
-    minimumCount: output.minimumCount !== undefined && output.minimumCount !== null ? output.minimumCount : undefined,
+    maximumCount: __expectNumber(output.maximumCount),
+    minimumCount: __expectNumber(output.minimumCount),
   } as any;
 };
 
 const deserializeAws_json1_1ActionTypeDeclaration = (output: any, context: __SerdeContext): ActionTypeDeclaration => {
   return {
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    description: __expectString(output.description),
     executor:
       output.executor !== undefined && output.executor !== null
         ? deserializeAws_json1_1ActionTypeExecutor(output.executor, context)
@@ -5584,30 +5558,27 @@ const deserializeAws_json1_1ActionTypeExecutor = (output: any, context: __SerdeC
       output.configuration !== undefined && output.configuration !== null
         ? deserializeAws_json1_1ExecutorConfiguration(output.configuration, context)
         : undefined,
-    jobTimeout: output.jobTimeout !== undefined && output.jobTimeout !== null ? output.jobTimeout : undefined,
-    policyStatementsTemplate:
-      output.policyStatementsTemplate !== undefined && output.policyStatementsTemplate !== null
-        ? output.policyStatementsTemplate
-        : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    jobTimeout: __expectNumber(output.jobTimeout),
+    policyStatementsTemplate: __expectString(output.policyStatementsTemplate),
+    type: __expectString(output.type),
   } as any;
 };
 
 const deserializeAws_json1_1ActionTypeId = (output: any, context: __SerdeContext): ActionTypeId => {
   return {
-    category: output.category !== undefined && output.category !== null ? output.category : undefined,
-    owner: output.owner !== undefined && output.owner !== null ? output.owner : undefined,
-    provider: output.provider !== undefined && output.provider !== null ? output.provider : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    category: __expectString(output.category),
+    owner: __expectString(output.owner),
+    provider: __expectString(output.provider),
+    version: __expectString(output.version),
   } as any;
 };
 
 const deserializeAws_json1_1ActionTypeIdentifier = (output: any, context: __SerdeContext): ActionTypeIdentifier => {
   return {
-    category: output.category !== undefined && output.category !== null ? output.category : undefined,
-    owner: output.owner !== undefined && output.owner !== null ? output.owner : undefined,
-    provider: output.provider !== undefined && output.provider !== null ? output.provider : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    category: __expectString(output.category),
+    owner: __expectString(output.owner),
+    provider: __expectString(output.provider),
+    version: __expectString(output.version),
   } as any;
 };
 
@@ -5627,7 +5598,7 @@ const deserializeAws_json1_1ActionTypeNotFoundException = (
   context: __SerdeContext
 ): ActionTypeNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -5653,52 +5624,30 @@ const deserializeAws_json1_1ActionTypeProperties = (output: any, context: __Serd
 
 const deserializeAws_json1_1ActionTypeProperty = (output: any, context: __SerdeContext): ActionTypeProperty => {
   return {
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    noEcho: output.noEcho !== undefined && output.noEcho !== null ? output.noEcho : undefined,
-    optional: output.optional !== undefined && output.optional !== null ? output.optional : undefined,
-    queryable: output.queryable !== undefined && output.queryable !== null ? output.queryable : undefined,
+    description: __expectString(output.description),
+    key: __expectBoolean(output.key),
+    name: __expectString(output.name),
+    noEcho: __expectBoolean(output.noEcho),
+    optional: __expectBoolean(output.optional),
+    queryable: __expectBoolean(output.queryable),
   } as any;
 };
 
 const deserializeAws_json1_1ActionTypeSettings = (output: any, context: __SerdeContext): ActionTypeSettings => {
   return {
-    entityUrlTemplate:
-      output.entityUrlTemplate !== undefined && output.entityUrlTemplate !== null
-        ? output.entityUrlTemplate
-        : undefined,
-    executionUrlTemplate:
-      output.executionUrlTemplate !== undefined && output.executionUrlTemplate !== null
-        ? output.executionUrlTemplate
-        : undefined,
-    revisionUrlTemplate:
-      output.revisionUrlTemplate !== undefined && output.revisionUrlTemplate !== null
-        ? output.revisionUrlTemplate
-        : undefined,
-    thirdPartyConfigurationUrl:
-      output.thirdPartyConfigurationUrl !== undefined && output.thirdPartyConfigurationUrl !== null
-        ? output.thirdPartyConfigurationUrl
-        : undefined,
+    entityUrlTemplate: __expectString(output.entityUrlTemplate),
+    executionUrlTemplate: __expectString(output.executionUrlTemplate),
+    revisionUrlTemplate: __expectString(output.revisionUrlTemplate),
+    thirdPartyConfigurationUrl: __expectString(output.thirdPartyConfigurationUrl),
   } as any;
 };
 
 const deserializeAws_json1_1ActionTypeUrls = (output: any, context: __SerdeContext): ActionTypeUrls => {
   return {
-    configurationUrl:
-      output.configurationUrl !== undefined && output.configurationUrl !== null ? output.configurationUrl : undefined,
-    entityUrlTemplate:
-      output.entityUrlTemplate !== undefined && output.entityUrlTemplate !== null
-        ? output.entityUrlTemplate
-        : undefined,
-    executionUrlTemplate:
-      output.executionUrlTemplate !== undefined && output.executionUrlTemplate !== null
-        ? output.executionUrlTemplate
-        : undefined,
-    revisionUrlTemplate:
-      output.revisionUrlTemplate !== undefined && output.revisionUrlTemplate !== null
-        ? output.revisionUrlTemplate
-        : undefined,
+    configurationUrl: __expectString(output.configurationUrl),
+    entityUrlTemplate: __expectString(output.entityUrlTemplate),
+    executionUrlTemplate: __expectString(output.executionUrlTemplate),
+    revisionUrlTemplate: __expectString(output.revisionUrlTemplate),
   } as any;
 };
 
@@ -5709,7 +5658,7 @@ const deserializeAws_json1_1AllowedAccounts = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -5718,7 +5667,7 @@ const deserializeAws_json1_1ApprovalAlreadyCompletedException = (
   context: __SerdeContext
 ): ApprovalAlreadyCompletedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -5728,14 +5677,14 @@ const deserializeAws_json1_1Artifact = (output: any, context: __SerdeContext): A
       output.location !== undefined && output.location !== null
         ? deserializeAws_json1_1ArtifactLocation(output.location, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    revision: output.revision !== undefined && output.revision !== null ? output.revision : undefined,
+    name: __expectString(output.name),
+    revision: __expectString(output.revision),
   } as any;
 };
 
 const deserializeAws_json1_1ArtifactDetail = (output: any, context: __SerdeContext): ArtifactDetail => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
     s3location:
       output.s3location !== undefined && output.s3location !== null
         ? deserializeAws_json1_1S3Location(output.s3location, context)
@@ -5756,8 +5705,8 @@ const deserializeAws_json1_1ArtifactDetailList = (output: any, context: __SerdeC
 
 const deserializeAws_json1_1ArtifactDetails = (output: any, context: __SerdeContext): ArtifactDetails => {
   return {
-    maximumCount: output.maximumCount !== undefined && output.maximumCount !== null ? output.maximumCount : undefined,
-    minimumCount: output.minimumCount !== undefined && output.minimumCount !== null ? output.minimumCount : undefined,
+    maximumCount: __expectNumber(output.maximumCount),
+    minimumCount: __expectNumber(output.minimumCount),
   } as any;
 };
 
@@ -5778,7 +5727,7 @@ const deserializeAws_json1_1ArtifactLocation = (output: any, context: __SerdeCon
       output.s3Location !== undefined && output.s3Location !== null
         ? deserializeAws_json1_1S3ArtifactLocation(output.s3Location, context)
         : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -5786,15 +5735,11 @@ const deserializeAws_json1_1ArtifactRevision = (output: any, context: __SerdeCon
   return {
     created:
       output.created !== undefined && output.created !== null ? new Date(Math.round(output.created * 1000)) : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    revisionChangeIdentifier:
-      output.revisionChangeIdentifier !== undefined && output.revisionChangeIdentifier !== null
-        ? output.revisionChangeIdentifier
-        : undefined,
-    revisionId: output.revisionId !== undefined && output.revisionId !== null ? output.revisionId : undefined,
-    revisionSummary:
-      output.revisionSummary !== undefined && output.revisionSummary !== null ? output.revisionSummary : undefined,
-    revisionUrl: output.revisionUrl !== undefined && output.revisionUrl !== null ? output.revisionUrl : undefined,
+    name: __expectString(output.name),
+    revisionChangeIdentifier: __expectString(output.revisionChangeIdentifier),
+    revisionId: __expectString(output.revisionId),
+    revisionSummary: __expectString(output.revisionSummary),
+    revisionUrl: __expectString(output.revisionUrl),
   } as any;
 };
 
@@ -5815,8 +5760,8 @@ const deserializeAws_json1_1ArtifactStore = (output: any, context: __SerdeContex
       output.encryptionKey !== undefined && output.encryptionKey !== null
         ? deserializeAws_json1_1EncryptionKey(output.encryptionKey, context)
         : undefined,
-    location: output.location !== undefined && output.location !== null ? output.location : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    location: __expectString(output.location),
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -5837,17 +5782,16 @@ const deserializeAws_json1_1ArtifactStoreMap = (
 
 const deserializeAws_json1_1AWSSessionCredentials = (output: any, context: __SerdeContext): AWSSessionCredentials => {
   return {
-    accessKeyId: output.accessKeyId !== undefined && output.accessKeyId !== null ? output.accessKeyId : undefined,
-    secretAccessKey:
-      output.secretAccessKey !== undefined && output.secretAccessKey !== null ? output.secretAccessKey : undefined,
-    sessionToken: output.sessionToken !== undefined && output.sessionToken !== null ? output.sessionToken : undefined,
+    accessKeyId: __expectString(output.accessKeyId),
+    secretAccessKey: __expectString(output.secretAccessKey),
+    sessionToken: __expectString(output.sessionToken),
   } as any;
 };
 
 const deserializeAws_json1_1BlockerDeclaration = (output: any, context: __SerdeContext): BlockerDeclaration => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    name: __expectString(output.name),
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -5856,13 +5800,13 @@ const deserializeAws_json1_1ConcurrentModificationException = (
   context: __SerdeContext
 ): ConcurrentModificationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1ConflictException = (output: any, context: __SerdeContext): ConflictException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -5911,29 +5855,28 @@ const deserializeAws_json1_1DuplicatedStopRequestException = (
   context: __SerdeContext
 ): DuplicatedStopRequestException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1EncryptionKey = (output: any, context: __SerdeContext): EncryptionKey => {
   return {
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    id: __expectString(output.id),
+    type: __expectString(output.type),
   } as any;
 };
 
 const deserializeAws_json1_1ErrorDetails = (output: any, context: __SerdeContext): ErrorDetails => {
   return {
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    code: __expectString(output.code),
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1ExecutionTrigger = (output: any, context: __SerdeContext): ExecutionTrigger => {
   return {
-    triggerDetail:
-      output.triggerDetail !== undefined && output.triggerDetail !== null ? output.triggerDetail : undefined,
-    triggerType: output.triggerType !== undefined && output.triggerType !== null ? output.triggerType : undefined,
+    triggerDetail: __expectString(output.triggerDetail),
+    triggerType: __expectString(output.triggerType),
   } as any;
 };
 
@@ -5997,9 +5940,8 @@ const deserializeAws_json1_1GetPipelineStateOutput = (output: any, context: __Se
   return {
     created:
       output.created !== undefined && output.created !== null ? new Date(Math.round(output.created * 1000)) : undefined,
-    pipelineName: output.pipelineName !== undefined && output.pipelineName !== null ? output.pipelineName : undefined,
-    pipelineVersion:
-      output.pipelineVersion !== undefined && output.pipelineVersion !== null ? output.pipelineVersion : undefined,
+    pipelineName: __expectString(output.pipelineName),
+    pipelineVersion: __expectNumber(output.pipelineVersion),
     stageStates:
       output.stageStates !== undefined && output.stageStates !== null
         ? deserializeAws_json1_1StageStateList(output.stageStates, context)
@@ -6023,7 +5965,7 @@ const deserializeAws_json1_1GetThirdPartyJobDetailsOutput = (
 
 const deserializeAws_json1_1InputArtifact = (output: any, context: __SerdeContext): InputArtifact => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -6043,7 +5985,7 @@ const deserializeAws_json1_1InvalidActionDeclarationException = (
   context: __SerdeContext
 ): InvalidActionDeclarationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6052,13 +5994,13 @@ const deserializeAws_json1_1InvalidApprovalTokenException = (
   context: __SerdeContext
 ): InvalidApprovalTokenException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidArnException = (output: any, context: __SerdeContext): InvalidArnException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6067,7 +6009,7 @@ const deserializeAws_json1_1InvalidBlockerDeclarationException = (
   context: __SerdeContext
 ): InvalidBlockerDeclarationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6076,13 +6018,13 @@ const deserializeAws_json1_1InvalidClientTokenException = (
   context: __SerdeContext
 ): InvalidClientTokenException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidJobException = (output: any, context: __SerdeContext): InvalidJobException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6091,7 +6033,7 @@ const deserializeAws_json1_1InvalidJobStateException = (
   context: __SerdeContext
 ): InvalidJobStateException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6100,13 +6042,13 @@ const deserializeAws_json1_1InvalidNextTokenException = (
   context: __SerdeContext
 ): InvalidNextTokenException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidNonceException = (output: any, context: __SerdeContext): InvalidNonceException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6115,7 +6057,7 @@ const deserializeAws_json1_1InvalidStageDeclarationException = (
   context: __SerdeContext
 ): InvalidStageDeclarationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6124,13 +6066,13 @@ const deserializeAws_json1_1InvalidStructureException = (
   context: __SerdeContext
 ): InvalidStructureException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidTagsException = (output: any, context: __SerdeContext): InvalidTagsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6139,7 +6081,7 @@ const deserializeAws_json1_1InvalidWebhookAuthenticationParametersException = (
   context: __SerdeContext
 ): InvalidWebhookAuthenticationParametersException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6148,19 +6090,19 @@ const deserializeAws_json1_1InvalidWebhookFilterPatternException = (
   context: __SerdeContext
 ): InvalidWebhookFilterPatternException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1Job = (output: any, context: __SerdeContext): Job => {
   return {
-    accountId: output.accountId !== undefined && output.accountId !== null ? output.accountId : undefined,
+    accountId: __expectString(output.accountId),
     data:
       output.data !== undefined && output.data !== null
         ? deserializeAws_json1_1JobData(output.data, context)
         : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    nonce: output.nonce !== undefined && output.nonce !== null ? output.nonce : undefined,
+    id: __expectString(output.id),
+    nonce: __expectString(output.nonce),
   } as any;
 };
 
@@ -6178,10 +6120,7 @@ const deserializeAws_json1_1JobData = (output: any, context: __SerdeContext): Jo
       output.artifactCredentials !== undefined && output.artifactCredentials !== null
         ? deserializeAws_json1_1AWSSessionCredentials(output.artifactCredentials, context)
         : undefined,
-    continuationToken:
-      output.continuationToken !== undefined && output.continuationToken !== null
-        ? output.continuationToken
-        : undefined,
+    continuationToken: __expectString(output.continuationToken),
     encryptionKey:
       output.encryptionKey !== undefined && output.encryptionKey !== null
         ? deserializeAws_json1_1EncryptionKey(output.encryptionKey, context)
@@ -6203,12 +6142,12 @@ const deserializeAws_json1_1JobData = (output: any, context: __SerdeContext): Jo
 
 const deserializeAws_json1_1JobDetails = (output: any, context: __SerdeContext): JobDetails => {
   return {
-    accountId: output.accountId !== undefined && output.accountId !== null ? output.accountId : undefined,
+    accountId: __expectString(output.accountId),
     data:
       output.data !== undefined && output.data !== null
         ? deserializeAws_json1_1JobData(output.data, context)
         : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    id: __expectString(output.id),
   } as any;
 };
 
@@ -6225,7 +6164,7 @@ const deserializeAws_json1_1JobList = (output: any, context: __SerdeContext): Jo
 
 const deserializeAws_json1_1JobNotFoundException = (output: any, context: __SerdeContext): JobNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6250,16 +6189,13 @@ const deserializeAws_json1_1LambdaExecutorConfiguration = (
   context: __SerdeContext
 ): LambdaExecutorConfiguration => {
   return {
-    lambdaFunctionArn:
-      output.lambdaFunctionArn !== undefined && output.lambdaFunctionArn !== null
-        ? output.lambdaFunctionArn
-        : undefined,
+    lambdaFunctionArn: __expectString(output.lambdaFunctionArn),
   } as any;
 };
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6272,7 +6208,7 @@ const deserializeAws_json1_1ListActionExecutionsOutput = (
       output.actionExecutionDetails !== undefined && output.actionExecutionDetails !== null
         ? deserializeAws_json1_1ActionExecutionDetailList(output.actionExecutionDetails, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -6282,7 +6218,7 @@ const deserializeAws_json1_1ListActionTypesOutput = (output: any, context: __Ser
       output.actionTypes !== undefined && output.actionTypes !== null
         ? deserializeAws_json1_1ActionTypeList(output.actionTypes, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -6291,7 +6227,7 @@ const deserializeAws_json1_1ListPipelineExecutionsOutput = (
   context: __SerdeContext
 ): ListPipelineExecutionsOutput => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     pipelineExecutionSummaries:
       output.pipelineExecutionSummaries !== undefined && output.pipelineExecutionSummaries !== null
         ? deserializeAws_json1_1PipelineExecutionSummaryList(output.pipelineExecutionSummaries, context)
@@ -6301,7 +6237,7 @@ const deserializeAws_json1_1ListPipelineExecutionsOutput = (
 
 const deserializeAws_json1_1ListPipelinesOutput = (output: any, context: __SerdeContext): ListPipelinesOutput => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     pipelines:
       output.pipelines !== undefined && output.pipelines !== null
         ? deserializeAws_json1_1PipelineList(output.pipelines, context)
@@ -6314,7 +6250,7 @@ const deserializeAws_json1_1ListTagsForResourceOutput = (
   context: __SerdeContext
 ): ListTagsForResourceOutput => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_json1_1TagList(output.tags, context)
@@ -6324,13 +6260,13 @@ const deserializeAws_json1_1ListTagsForResourceOutput = (
 
 const deserializeAws_json1_1ListWebhookItem = (output: any, context: __SerdeContext): ListWebhookItem => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     definition:
       output.definition !== undefined && output.definition !== null
         ? deserializeAws_json1_1WebhookDefinition(output.definition, context)
         : undefined,
-    errorCode: output.errorCode !== undefined && output.errorCode !== null ? output.errorCode : undefined,
-    errorMessage: output.errorMessage !== undefined && output.errorMessage !== null ? output.errorMessage : undefined,
+    errorCode: __expectString(output.errorCode),
+    errorMessage: __expectString(output.errorMessage),
     lastTriggered:
       output.lastTriggered !== undefined && output.lastTriggered !== null
         ? new Date(Math.round(output.lastTriggered * 1000))
@@ -6339,13 +6275,13 @@ const deserializeAws_json1_1ListWebhookItem = (output: any, context: __SerdeCont
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_json1_1TagList(output.tags, context)
         : undefined,
-    url: output.url !== undefined && output.url !== null ? output.url : undefined,
+    url: __expectString(output.url),
   } as any;
 };
 
 const deserializeAws_json1_1ListWebhooksOutput = (output: any, context: __SerdeContext): ListWebhooksOutput => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     webhooks:
       output.webhooks !== undefined && output.webhooks !== null
         ? deserializeAws_json1_1WebhookList(output.webhooks, context)
@@ -6358,13 +6294,13 @@ const deserializeAws_json1_1NotLatestPipelineExecutionException = (
   context: __SerdeContext
 ): NotLatestPipelineExecutionException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1OutputArtifact = (output: any, context: __SerdeContext): OutputArtifact => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -6386,7 +6322,7 @@ const deserializeAws_json1_1OutputVariablesMap = (output: any, context: __SerdeC
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -6396,7 +6332,7 @@ const deserializeAws_json1_1OutputVariablesSizeExceededException = (
   context: __SerdeContext
 ): OutputVariablesSizeExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6406,12 +6342,9 @@ const deserializeAws_json1_1PipelineContext = (output: any, context: __SerdeCont
       output.action !== undefined && output.action !== null
         ? deserializeAws_json1_1ActionContext(output.action, context)
         : undefined,
-    pipelineArn: output.pipelineArn !== undefined && output.pipelineArn !== null ? output.pipelineArn : undefined,
-    pipelineExecutionId:
-      output.pipelineExecutionId !== undefined && output.pipelineExecutionId !== null
-        ? output.pipelineExecutionId
-        : undefined,
-    pipelineName: output.pipelineName !== undefined && output.pipelineName !== null ? output.pipelineName : undefined,
+    pipelineArn: __expectString(output.pipelineArn),
+    pipelineExecutionId: __expectString(output.pipelineExecutionId),
+    pipelineName: __expectString(output.pipelineName),
     stage:
       output.stage !== undefined && output.stage !== null
         ? deserializeAws_json1_1StageContext(output.stage, context)
@@ -6429,13 +6362,13 @@ const deserializeAws_json1_1PipelineDeclaration = (output: any, context: __Serde
       output.artifactStores !== undefined && output.artifactStores !== null
         ? deserializeAws_json1_1ArtifactStoreMap(output.artifactStores, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
+    name: __expectString(output.name),
+    roleArn: __expectString(output.roleArn),
     stages:
       output.stages !== undefined && output.stages !== null
         ? deserializeAws_json1_1PipelineStageDeclarationList(output.stages, context)
         : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    version: __expectNumber(output.version),
   } as any;
 };
 
@@ -6445,16 +6378,11 @@ const deserializeAws_json1_1PipelineExecution = (output: any, context: __SerdeCo
       output.artifactRevisions !== undefined && output.artifactRevisions !== null
         ? deserializeAws_json1_1ArtifactRevisionList(output.artifactRevisions, context)
         : undefined,
-    pipelineExecutionId:
-      output.pipelineExecutionId !== undefined && output.pipelineExecutionId !== null
-        ? output.pipelineExecutionId
-        : undefined,
-    pipelineName: output.pipelineName !== undefined && output.pipelineName !== null ? output.pipelineName : undefined,
-    pipelineVersion:
-      output.pipelineVersion !== undefined && output.pipelineVersion !== null ? output.pipelineVersion : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    statusSummary:
-      output.statusSummary !== undefined && output.statusSummary !== null ? output.statusSummary : undefined,
+    pipelineExecutionId: __expectString(output.pipelineExecutionId),
+    pipelineName: __expectString(output.pipelineName),
+    pipelineVersion: __expectNumber(output.pipelineVersion),
+    status: __expectString(output.status),
+    statusSummary: __expectString(output.statusSummary),
   } as any;
 };
 
@@ -6463,7 +6391,7 @@ const deserializeAws_json1_1PipelineExecutionNotFoundException = (
   context: __SerdeContext
 ): PipelineExecutionNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6472,7 +6400,7 @@ const deserializeAws_json1_1PipelineExecutionNotStoppableException = (
   context: __SerdeContext
 ): PipelineExecutionNotStoppableException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6485,10 +6413,7 @@ const deserializeAws_json1_1PipelineExecutionSummary = (
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
         ? new Date(Math.round(output.lastUpdateTime * 1000))
         : undefined,
-    pipelineExecutionId:
-      output.pipelineExecutionId !== undefined && output.pipelineExecutionId !== null
-        ? output.pipelineExecutionId
-        : undefined,
+    pipelineExecutionId: __expectString(output.pipelineExecutionId),
     sourceRevisions:
       output.sourceRevisions !== undefined && output.sourceRevisions !== null
         ? deserializeAws_json1_1SourceRevisionList(output.sourceRevisions, context)
@@ -6497,7 +6422,7 @@ const deserializeAws_json1_1PipelineExecutionSummary = (
       output.startTime !== undefined && output.startTime !== null
         ? new Date(Math.round(output.startTime * 1000))
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
     stopTrigger:
       output.stopTrigger !== undefined && output.stopTrigger !== null
         ? deserializeAws_json1_1StopExecutionTrigger(output.stopTrigger, context)
@@ -6538,7 +6463,7 @@ const deserializeAws_json1_1PipelineMetadata = (output: any, context: __SerdeCon
   return {
     created:
       output.created !== undefined && output.created !== null ? new Date(Math.round(output.created * 1000)) : undefined,
-    pipelineArn: output.pipelineArn !== undefined && output.pipelineArn !== null ? output.pipelineArn : undefined,
+    pipelineArn: __expectString(output.pipelineArn),
     updated:
       output.updated !== undefined && output.updated !== null ? new Date(Math.round(output.updated * 1000)) : undefined,
   } as any;
@@ -6549,7 +6474,7 @@ const deserializeAws_json1_1PipelineNameInUseException = (
   context: __SerdeContext
 ): PipelineNameInUseException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6558,7 +6483,7 @@ const deserializeAws_json1_1PipelineNotFoundException = (
   context: __SerdeContext
 ): PipelineNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6580,10 +6505,10 @@ const deserializeAws_json1_1PipelineSummary = (output: any, context: __SerdeCont
   return {
     created:
       output.created !== undefined && output.created !== null ? new Date(Math.round(output.created * 1000)) : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
     updated:
       output.updated !== undefined && output.updated !== null ? new Date(Math.round(output.updated * 1000)) : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    version: __expectNumber(output.version),
   } as any;
 };
 
@@ -6592,7 +6517,7 @@ const deserializeAws_json1_1PipelineVersionNotFoundException = (
   context: __SerdeContext
 ): PipelineVersionNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6624,7 +6549,7 @@ const deserializeAws_json1_1PollingAccountList = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6635,7 +6560,7 @@ const deserializeAws_json1_1PollingServicePrincipalList = (output: any, context:
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6644,11 +6569,8 @@ const deserializeAws_json1_1PutActionRevisionOutput = (
   context: __SerdeContext
 ): PutActionRevisionOutput => {
   return {
-    newRevision: output.newRevision !== undefined && output.newRevision !== null ? output.newRevision : undefined,
-    pipelineExecutionId:
-      output.pipelineExecutionId !== undefined && output.pipelineExecutionId !== null
-        ? output.pipelineExecutionId
-        : undefined,
+    newRevision: __expectBoolean(output.newRevision),
+    pipelineExecutionId: __expectString(output.pipelineExecutionId),
   } as any;
 };
 
@@ -6682,7 +6604,7 @@ const deserializeAws_json1_1RegisterWebhookWithThirdPartyOutput = (
 
 const deserializeAws_json1_1RequestFailedException = (output: any, context: __SerdeContext): RequestFailedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6696,7 +6618,7 @@ const deserializeAws_json1_1ResolvedActionConfigurationMap = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -6706,7 +6628,7 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6715,34 +6637,30 @@ const deserializeAws_json1_1RetryStageExecutionOutput = (
   context: __SerdeContext
 ): RetryStageExecutionOutput => {
   return {
-    pipelineExecutionId:
-      output.pipelineExecutionId !== undefined && output.pipelineExecutionId !== null
-        ? output.pipelineExecutionId
-        : undefined,
+    pipelineExecutionId: __expectString(output.pipelineExecutionId),
   } as any;
 };
 
 const deserializeAws_json1_1S3ArtifactLocation = (output: any, context: __SerdeContext): S3ArtifactLocation => {
   return {
-    bucketName: output.bucketName !== undefined && output.bucketName !== null ? output.bucketName : undefined,
-    objectKey: output.objectKey !== undefined && output.objectKey !== null ? output.objectKey : undefined,
+    bucketName: __expectString(output.bucketName),
+    objectKey: __expectString(output.objectKey),
   } as any;
 };
 
 const deserializeAws_json1_1S3Location = (output: any, context: __SerdeContext): S3Location => {
   return {
-    bucket: output.bucket !== undefined && output.bucket !== null ? output.bucket : undefined,
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
+    bucket: __expectString(output.bucket),
+    key: __expectString(output.key),
   } as any;
 };
 
 const deserializeAws_json1_1SourceRevision = (output: any, context: __SerdeContext): SourceRevision => {
   return {
-    actionName: output.actionName !== undefined && output.actionName !== null ? output.actionName : undefined,
-    revisionId: output.revisionId !== undefined && output.revisionId !== null ? output.revisionId : undefined,
-    revisionSummary:
-      output.revisionSummary !== undefined && output.revisionSummary !== null ? output.revisionSummary : undefined,
-    revisionUrl: output.revisionUrl !== undefined && output.revisionUrl !== null ? output.revisionUrl : undefined,
+    actionName: __expectString(output.actionName),
+    revisionId: __expectString(output.revisionId),
+    revisionSummary: __expectString(output.revisionSummary),
+    revisionUrl: __expectString(output.revisionUrl),
   } as any;
 };
 
@@ -6787,7 +6705,7 @@ const deserializeAws_json1_1StageBlockerDeclarationList = (
 
 const deserializeAws_json1_1StageContext = (output: any, context: __SerdeContext): StageContext => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -6801,23 +6719,20 @@ const deserializeAws_json1_1StageDeclaration = (output: any, context: __SerdeCon
       output.blockers !== undefined && output.blockers !== null
         ? deserializeAws_json1_1StageBlockerDeclarationList(output.blockers, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
   } as any;
 };
 
 const deserializeAws_json1_1StageExecution = (output: any, context: __SerdeContext): StageExecution => {
   return {
-    pipelineExecutionId:
-      output.pipelineExecutionId !== undefined && output.pipelineExecutionId !== null
-        ? output.pipelineExecutionId
-        : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    pipelineExecutionId: __expectString(output.pipelineExecutionId),
+    status: __expectString(output.status),
   } as any;
 };
 
 const deserializeAws_json1_1StageNotFoundException = (output: any, context: __SerdeContext): StageNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6826,7 +6741,7 @@ const deserializeAws_json1_1StageNotRetryableException = (
   context: __SerdeContext
 ): StageNotRetryableException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6848,7 +6763,7 @@ const deserializeAws_json1_1StageState = (output: any, context: __SerdeContext):
       output.latestExecution !== undefined && output.latestExecution !== null
         ? deserializeAws_json1_1StageExecution(output.latestExecution, context)
         : undefined,
-    stageName: output.stageName !== undefined && output.stageName !== null ? output.stageName : undefined,
+    stageName: __expectString(output.stageName),
   } as any;
 };
 
@@ -6868,16 +6783,13 @@ const deserializeAws_json1_1StartPipelineExecutionOutput = (
   context: __SerdeContext
 ): StartPipelineExecutionOutput => {
   return {
-    pipelineExecutionId:
-      output.pipelineExecutionId !== undefined && output.pipelineExecutionId !== null
-        ? output.pipelineExecutionId
-        : undefined,
+    pipelineExecutionId: __expectString(output.pipelineExecutionId),
   } as any;
 };
 
 const deserializeAws_json1_1StopExecutionTrigger = (output: any, context: __SerdeContext): StopExecutionTrigger => {
   return {
-    reason: output.reason !== undefined && output.reason !== null ? output.reason : undefined,
+    reason: __expectString(output.reason),
   } as any;
 };
 
@@ -6886,17 +6798,14 @@ const deserializeAws_json1_1StopPipelineExecutionOutput = (
   context: __SerdeContext
 ): StopPipelineExecutionOutput => {
   return {
-    pipelineExecutionId:
-      output.pipelineExecutionId !== undefined && output.pipelineExecutionId !== null
-        ? output.pipelineExecutionId
-        : undefined,
+    pipelineExecutionId: __expectString(output.pipelineExecutionId),
   } as any;
 };
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    key: __expectString(output.key),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -6917,8 +6826,8 @@ const deserializeAws_json1_1TagResourceOutput = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1ThirdPartyJob = (output: any, context: __SerdeContext): ThirdPartyJob => {
   return {
-    clientId: output.clientId !== undefined && output.clientId !== null ? output.clientId : undefined,
-    jobId: output.jobId !== undefined && output.jobId !== null ? output.jobId : undefined,
+    clientId: __expectString(output.clientId),
+    jobId: __expectString(output.jobId),
   } as any;
 };
 
@@ -6936,10 +6845,7 @@ const deserializeAws_json1_1ThirdPartyJobData = (output: any, context: __SerdeCo
       output.artifactCredentials !== undefined && output.artifactCredentials !== null
         ? deserializeAws_json1_1AWSSessionCredentials(output.artifactCredentials, context)
         : undefined,
-    continuationToken:
-      output.continuationToken !== undefined && output.continuationToken !== null
-        ? output.continuationToken
-        : undefined,
+    continuationToken: __expectString(output.continuationToken),
     encryptionKey:
       output.encryptionKey !== undefined && output.encryptionKey !== null
         ? deserializeAws_json1_1EncryptionKey(output.encryptionKey, context)
@@ -6965,8 +6871,8 @@ const deserializeAws_json1_1ThirdPartyJobDetails = (output: any, context: __Serd
       output.data !== undefined && output.data !== null
         ? deserializeAws_json1_1ThirdPartyJobData(output.data, context)
         : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    nonce: output.nonce !== undefined && output.nonce !== null ? output.nonce : undefined,
+    id: __expectString(output.id),
+    nonce: __expectString(output.nonce),
   } as any;
 };
 
@@ -6983,21 +6889,19 @@ const deserializeAws_json1_1ThirdPartyJobList = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1TooManyTagsException = (output: any, context: __SerdeContext): TooManyTagsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1TransitionState = (output: any, context: __SerdeContext): TransitionState => {
   return {
-    disabledReason:
-      output.disabledReason !== undefined && output.disabledReason !== null ? output.disabledReason : undefined,
-    enabled: output.enabled !== undefined && output.enabled !== null ? output.enabled : undefined,
+    disabledReason: __expectString(output.disabledReason),
+    enabled: __expectBoolean(output.enabled),
     lastChangedAt:
       output.lastChangedAt !== undefined && output.lastChangedAt !== null
         ? new Date(Math.round(output.lastChangedAt * 1000))
         : undefined,
-    lastChangedBy:
-      output.lastChangedBy !== undefined && output.lastChangedBy !== null ? output.lastChangedBy : undefined,
+    lastChangedBy: __expectString(output.lastChangedBy),
   } as any;
 };
 
@@ -7016,7 +6920,7 @@ const deserializeAws_json1_1UpdatePipelineOutput = (output: any, context: __Serd
 
 const deserializeAws_json1_1ValidationException = (output: any, context: __SerdeContext): ValidationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -7025,16 +6929,14 @@ const deserializeAws_json1_1WebhookAuthConfiguration = (
   context: __SerdeContext
 ): WebhookAuthConfiguration => {
   return {
-    AllowedIPRange:
-      output.AllowedIPRange !== undefined && output.AllowedIPRange !== null ? output.AllowedIPRange : undefined,
-    SecretToken: output.SecretToken !== undefined && output.SecretToken !== null ? output.SecretToken : undefined,
+    AllowedIPRange: __expectString(output.AllowedIPRange),
+    SecretToken: __expectString(output.SecretToken),
   } as any;
 };
 
 const deserializeAws_json1_1WebhookDefinition = (output: any, context: __SerdeContext): WebhookDefinition => {
   return {
-    authentication:
-      output.authentication !== undefined && output.authentication !== null ? output.authentication : undefined,
+    authentication: __expectString(output.authentication),
     authenticationConfiguration:
       output.authenticationConfiguration !== undefined && output.authenticationConfiguration !== null
         ? deserializeAws_json1_1WebhookAuthConfiguration(output.authenticationConfiguration, context)
@@ -7043,17 +6945,16 @@ const deserializeAws_json1_1WebhookDefinition = (output: any, context: __SerdeCo
       output.filters !== undefined && output.filters !== null
         ? deserializeAws_json1_1WebhookFilters(output.filters, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    targetAction: output.targetAction !== undefined && output.targetAction !== null ? output.targetAction : undefined,
-    targetPipeline:
-      output.targetPipeline !== undefined && output.targetPipeline !== null ? output.targetPipeline : undefined,
+    name: __expectString(output.name),
+    targetAction: __expectString(output.targetAction),
+    targetPipeline: __expectString(output.targetPipeline),
   } as any;
 };
 
 const deserializeAws_json1_1WebhookFilterRule = (output: any, context: __SerdeContext): WebhookFilterRule => {
   return {
-    jsonPath: output.jsonPath !== undefined && output.jsonPath !== null ? output.jsonPath : undefined,
-    matchEquals: output.matchEquals !== undefined && output.matchEquals !== null ? output.matchEquals : undefined,
+    jsonPath: __expectString(output.jsonPath),
+    matchEquals: __expectString(output.matchEquals),
   } as any;
 };
 

--- a/clients/client-codestar-connections/protocols/Aws_json1_0.ts
+++ b/clients/client-codestar-connections/protocols/Aws_json1_0.ts
@@ -49,7 +49,7 @@ import {
   VpcConfiguration,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException, expectString as __expectString } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -1161,22 +1161,18 @@ const serializeAws_json1_0VpcConfiguration = (input: VpcConfiguration, context: 
 
 const deserializeAws_json1_0ConflictException = (output: any, context: __SerdeContext): ConflictException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_0Connection = (output: any, context: __SerdeContext): Connection => {
   return {
-    ConnectionArn:
-      output.ConnectionArn !== undefined && output.ConnectionArn !== null ? output.ConnectionArn : undefined,
-    ConnectionName:
-      output.ConnectionName !== undefined && output.ConnectionName !== null ? output.ConnectionName : undefined,
-    ConnectionStatus:
-      output.ConnectionStatus !== undefined && output.ConnectionStatus !== null ? output.ConnectionStatus : undefined,
-    HostArn: output.HostArn !== undefined && output.HostArn !== null ? output.HostArn : undefined,
-    OwnerAccountId:
-      output.OwnerAccountId !== undefined && output.OwnerAccountId !== null ? output.OwnerAccountId : undefined,
-    ProviderType: output.ProviderType !== undefined && output.ProviderType !== null ? output.ProviderType : undefined,
+    ConnectionArn: __expectString(output.ConnectionArn),
+    ConnectionName: __expectString(output.ConnectionName),
+    ConnectionStatus: __expectString(output.ConnectionStatus),
+    HostArn: __expectString(output.HostArn),
+    OwnerAccountId: __expectString(output.OwnerAccountId),
+    ProviderType: __expectString(output.ProviderType),
   } as any;
 };
 
@@ -1193,8 +1189,7 @@ const deserializeAws_json1_0ConnectionList = (output: any, context: __SerdeConte
 
 const deserializeAws_json1_0CreateConnectionOutput = (output: any, context: __SerdeContext): CreateConnectionOutput => {
   return {
-    ConnectionArn:
-      output.ConnectionArn !== undefined && output.ConnectionArn !== null ? output.ConnectionArn : undefined,
+    ConnectionArn: __expectString(output.ConnectionArn),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_0TagList(output.Tags, context)
@@ -1204,7 +1199,7 @@ const deserializeAws_json1_0CreateConnectionOutput = (output: any, context: __Se
 
 const deserializeAws_json1_0CreateHostOutput = (output: any, context: __SerdeContext): CreateHostOutput => {
   return {
-    HostArn: output.HostArn !== undefined && output.HostArn !== null ? output.HostArn : undefined,
+    HostArn: __expectString(output.HostArn),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_0TagList(output.Tags, context)
@@ -1231,11 +1226,10 @@ const deserializeAws_json1_0GetConnectionOutput = (output: any, context: __Serde
 
 const deserializeAws_json1_0GetHostOutput = (output: any, context: __SerdeContext): GetHostOutput => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    ProviderEndpoint:
-      output.ProviderEndpoint !== undefined && output.ProviderEndpoint !== null ? output.ProviderEndpoint : undefined,
-    ProviderType: output.ProviderType !== undefined && output.ProviderType !== null ? output.ProviderType : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Name: __expectString(output.Name),
+    ProviderEndpoint: __expectString(output.ProviderEndpoint),
+    ProviderType: __expectString(output.ProviderType),
+    Status: __expectString(output.Status),
     VpcConfiguration:
       output.VpcConfiguration !== undefined && output.VpcConfiguration !== null
         ? deserializeAws_json1_0VpcConfiguration(output.VpcConfiguration, context)
@@ -1245,14 +1239,12 @@ const deserializeAws_json1_0GetHostOutput = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_0Host = (output: any, context: __SerdeContext): Host => {
   return {
-    HostArn: output.HostArn !== undefined && output.HostArn !== null ? output.HostArn : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    ProviderEndpoint:
-      output.ProviderEndpoint !== undefined && output.ProviderEndpoint !== null ? output.ProviderEndpoint : undefined,
-    ProviderType: output.ProviderType !== undefined && output.ProviderType !== null ? output.ProviderType : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusMessage:
-      output.StatusMessage !== undefined && output.StatusMessage !== null ? output.StatusMessage : undefined,
+    HostArn: __expectString(output.HostArn),
+    Name: __expectString(output.Name),
+    ProviderEndpoint: __expectString(output.ProviderEndpoint),
+    ProviderType: __expectString(output.ProviderType),
+    Status: __expectString(output.Status),
+    StatusMessage: __expectString(output.StatusMessage),
     VpcConfiguration:
       output.VpcConfiguration !== undefined && output.VpcConfiguration !== null
         ? deserializeAws_json1_0VpcConfiguration(output.VpcConfiguration, context)
@@ -1273,7 +1265,7 @@ const deserializeAws_json1_0HostList = (output: any, context: __SerdeContext): H
 
 const deserializeAws_json1_0LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -1283,7 +1275,7 @@ const deserializeAws_json1_0ListConnectionsOutput = (output: any, context: __Ser
       output.Connections !== undefined && output.Connections !== null
         ? deserializeAws_json1_0ConnectionList(output.Connections, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -1293,7 +1285,7 @@ const deserializeAws_json1_0ListHostsOutput = (output: any, context: __SerdeCont
       output.Hosts !== undefined && output.Hosts !== null
         ? deserializeAws_json1_0HostList(output.Hosts, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -1314,7 +1306,7 @@ const deserializeAws_json1_0ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -1323,7 +1315,7 @@ const deserializeAws_json1_0ResourceUnavailableException = (
   context: __SerdeContext
 ): ResourceUnavailableException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -1334,7 +1326,7 @@ const deserializeAws_json1_0SecurityGroupIds = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -1345,14 +1337,14 @@ const deserializeAws_json1_0SubnetIds = (output: any, context: __SerdeContext): 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_0Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -1376,7 +1368,7 @@ const deserializeAws_json1_0UnsupportedOperationException = (
   context: __SerdeContext
 ): UnsupportedOperationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -1398,9 +1390,8 @@ const deserializeAws_json1_0VpcConfiguration = (output: any, context: __SerdeCon
       output.SubnetIds !== undefined && output.SubnetIds !== null
         ? deserializeAws_json1_0SubnetIds(output.SubnetIds, context)
         : undefined,
-    TlsCertificate:
-      output.TlsCertificate !== undefined && output.TlsCertificate !== null ? output.TlsCertificate : undefined,
-    VpcId: output.VpcId !== undefined && output.VpcId !== null ? output.VpcId : undefined,
+    TlsCertificate: __expectString(output.TlsCertificate),
+    VpcId: __expectString(output.VpcId),
   } as any;
 };
 

--- a/clients/client-codestar-notifications/protocols/Aws_restJson1.ts
+++ b/clients/client-codestar-notifications/protocols/Aws_restJson1.ts
@@ -47,7 +47,7 @@ import {
   ValidationException,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException, expectString as __expectString } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -418,7 +418,7 @@ export const deserializeAws_restJson1CreateNotificationRuleCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   return Promise.resolve(contents);
 };
@@ -513,7 +513,7 @@ export const deserializeAws_restJson1DeleteNotificationRuleCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   return Promise.resolve(contents);
 };
@@ -645,16 +645,16 @@ export const deserializeAws_restJson1DescribeNotificationRuleCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreatedBy !== undefined && data.CreatedBy !== null) {
-    contents.CreatedBy = data.CreatedBy;
+    contents.CreatedBy = __expectString(data.CreatedBy);
   }
   if (data.CreatedTimestamp !== undefined && data.CreatedTimestamp !== null) {
     contents.CreatedTimestamp = new Date(Math.round(data.CreatedTimestamp * 1000));
   }
   if (data.DetailType !== undefined && data.DetailType !== null) {
-    contents.DetailType = data.DetailType;
+    contents.DetailType = __expectString(data.DetailType);
   }
   if (data.EventTypes !== undefined && data.EventTypes !== null) {
     contents.EventTypes = deserializeAws_restJson1EventTypeBatch(data.EventTypes, context);
@@ -663,13 +663,13 @@ export const deserializeAws_restJson1DescribeNotificationRuleCommand = async (
     contents.LastModifiedTimestamp = new Date(Math.round(data.LastModifiedTimestamp * 1000));
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.Resource !== undefined && data.Resource !== null) {
-    contents.Resource = data.Resource;
+    contents.Resource = __expectString(data.Resource);
   }
   if (data.Status !== undefined && data.Status !== null) {
-    contents.Status = data.Status;
+    contents.Status = __expectString(data.Status);
   }
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.Tags, context);
@@ -742,7 +742,7 @@ export const deserializeAws_restJson1ListEventTypesCommand = async (
     contents.EventTypes = deserializeAws_restJson1EventTypeBatch(data.EventTypes, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -806,7 +806,7 @@ export const deserializeAws_restJson1ListNotificationRulesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.NotificationRules !== undefined && data.NotificationRules !== null) {
     contents.NotificationRules = deserializeAws_restJson1NotificationRuleBatch(data.NotificationRules, context);
@@ -936,7 +936,7 @@ export const deserializeAws_restJson1ListTargetsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Targets !== undefined && data.Targets !== null) {
     contents.Targets = deserializeAws_restJson1TargetsBatch(data.Targets, context);
@@ -1002,7 +1002,7 @@ export const deserializeAws_restJson1SubscribeCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   return Promise.resolve(contents);
 };
@@ -1136,7 +1136,7 @@ export const deserializeAws_restJson1UnsubscribeCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   return Promise.resolve(contents);
 };
@@ -1316,7 +1316,7 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1333,7 +1333,7 @@ const deserializeAws_restJson1ConcurrentModificationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1350,7 +1350,7 @@ const deserializeAws_restJson1ConfigurationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1367,7 +1367,7 @@ const deserializeAws_restJson1InvalidNextTokenExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1384,7 +1384,7 @@ const deserializeAws_restJson1LimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1401,7 +1401,7 @@ const deserializeAws_restJson1ResourceAlreadyExistsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1418,7 +1418,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1435,7 +1435,7 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1565,11 +1565,10 @@ const deserializeAws_restJson1EventTypeBatch = (output: any, context: __SerdeCon
 
 const deserializeAws_restJson1EventTypeSummary = (output: any, context: __SerdeContext): EventTypeSummary => {
   return {
-    EventTypeId: output.EventTypeId !== undefined && output.EventTypeId !== null ? output.EventTypeId : undefined,
-    EventTypeName:
-      output.EventTypeName !== undefined && output.EventTypeName !== null ? output.EventTypeName : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
-    ServiceName: output.ServiceName !== undefined && output.ServiceName !== null ? output.ServiceName : undefined,
+    EventTypeId: __expectString(output.EventTypeId),
+    EventTypeName: __expectString(output.EventTypeName),
+    ResourceType: __expectString(output.ResourceType),
+    ServiceName: __expectString(output.ServiceName),
   } as any;
 };
 
@@ -1592,8 +1591,8 @@ const deserializeAws_restJson1NotificationRuleSummary = (
   context: __SerdeContext
 ): NotificationRuleSummary => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    Arn: __expectString(output.Arn),
+    Id: __expectString(output.Id),
   } as any;
 };
 
@@ -1604,7 +1603,7 @@ const deserializeAws_restJson1Tags = (output: any, context: __SerdeContext): { [
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -1622,10 +1621,9 @@ const deserializeAws_restJson1TargetsBatch = (output: any, context: __SerdeConte
 
 const deserializeAws_restJson1TargetSummary = (output: any, context: __SerdeContext): TargetSummary => {
   return {
-    TargetAddress:
-      output.TargetAddress !== undefined && output.TargetAddress !== null ? output.TargetAddress : undefined,
-    TargetStatus: output.TargetStatus !== undefined && output.TargetStatus !== null ? output.TargetStatus : undefined,
-    TargetType: output.TargetType !== undefined && output.TargetType !== null ? output.TargetType : undefined,
+    TargetAddress: __expectString(output.TargetAddress),
+    TargetStatus: __expectString(output.TargetStatus),
+    TargetType: __expectString(output.TargetType),
   } as any;
 };
 

--- a/clients/client-codestar/protocols/Aws_json1_1.ts
+++ b/clients/client-codestar/protocols/Aws_json1_1.ts
@@ -90,7 +90,11 @@ import {
   ValidationException,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -2154,10 +2158,7 @@ const deserializeAws_json1_1AssociateTeamMemberResult = (
   context: __SerdeContext
 ): AssociateTeamMemberResult => {
   return {
-    clientRequestToken:
-      output.clientRequestToken !== undefined && output.clientRequestToken !== null
-        ? output.clientRequestToken
-        : undefined,
+    clientRequestToken: __expectString(output.clientRequestToken),
   } as any;
 };
 
@@ -2166,22 +2167,16 @@ const deserializeAws_json1_1ConcurrentModificationException = (
   context: __SerdeContext
 ): ConcurrentModificationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1CreateProjectResult = (output: any, context: __SerdeContext): CreateProjectResult => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    clientRequestToken:
-      output.clientRequestToken !== undefined && output.clientRequestToken !== null
-        ? output.clientRequestToken
-        : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    projectTemplateId:
-      output.projectTemplateId !== undefined && output.projectTemplateId !== null
-        ? output.projectTemplateId
-        : undefined,
+    arn: __expectString(output.arn),
+    clientRequestToken: __expectString(output.clientRequestToken),
+    id: __expectString(output.id),
+    projectTemplateId: __expectString(output.projectTemplateId),
   } as any;
 };
 
@@ -2194,21 +2189,21 @@ const deserializeAws_json1_1CreateUserProfileResult = (
       output.createdTimestamp !== undefined && output.createdTimestamp !== null
         ? new Date(Math.round(output.createdTimestamp * 1000))
         : undefined,
-    displayName: output.displayName !== undefined && output.displayName !== null ? output.displayName : undefined,
-    emailAddress: output.emailAddress !== undefined && output.emailAddress !== null ? output.emailAddress : undefined,
+    displayName: __expectString(output.displayName),
+    emailAddress: __expectString(output.emailAddress),
     lastModifiedTimestamp:
       output.lastModifiedTimestamp !== undefined && output.lastModifiedTimestamp !== null
         ? new Date(Math.round(output.lastModifiedTimestamp * 1000))
         : undefined,
-    sshPublicKey: output.sshPublicKey !== undefined && output.sshPublicKey !== null ? output.sshPublicKey : undefined,
-    userArn: output.userArn !== undefined && output.userArn !== null ? output.userArn : undefined,
+    sshPublicKey: __expectString(output.sshPublicKey),
+    userArn: __expectString(output.userArn),
   } as any;
 };
 
 const deserializeAws_json1_1DeleteProjectResult = (output: any, context: __SerdeContext): DeleteProjectResult => {
   return {
-    projectArn: output.projectArn !== undefined && output.projectArn !== null ? output.projectArn : undefined,
-    stackId: output.stackId !== undefined && output.stackId !== null ? output.stackId : undefined,
+    projectArn: __expectString(output.projectArn),
+    stackId: __expectString(output.stackId),
   } as any;
 };
 
@@ -2217,29 +2212,23 @@ const deserializeAws_json1_1DeleteUserProfileResult = (
   context: __SerdeContext
 ): DeleteUserProfileResult => {
   return {
-    userArn: output.userArn !== undefined && output.userArn !== null ? output.userArn : undefined,
+    userArn: __expectString(output.userArn),
   } as any;
 };
 
 const deserializeAws_json1_1DescribeProjectResult = (output: any, context: __SerdeContext): DescribeProjectResult => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    clientRequestToken:
-      output.clientRequestToken !== undefined && output.clientRequestToken !== null
-        ? output.clientRequestToken
-        : undefined,
+    arn: __expectString(output.arn),
+    clientRequestToken: __expectString(output.clientRequestToken),
     createdTimeStamp:
       output.createdTimeStamp !== undefined && output.createdTimeStamp !== null
         ? new Date(Math.round(output.createdTimeStamp * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    projectTemplateId:
-      output.projectTemplateId !== undefined && output.projectTemplateId !== null
-        ? output.projectTemplateId
-        : undefined,
-    stackId: output.stackId !== undefined && output.stackId !== null ? output.stackId : undefined,
+    description: __expectString(output.description),
+    id: __expectString(output.id),
+    name: __expectString(output.name),
+    projectTemplateId: __expectString(output.projectTemplateId),
+    stackId: __expectString(output.stackId),
     status:
       output.status !== undefined && output.status !== null
         ? deserializeAws_json1_1ProjectStatus(output.status, context)
@@ -2256,14 +2245,14 @@ const deserializeAws_json1_1DescribeUserProfileResult = (
       output.createdTimestamp !== undefined && output.createdTimestamp !== null
         ? new Date(Math.round(output.createdTimestamp * 1000))
         : undefined,
-    displayName: output.displayName !== undefined && output.displayName !== null ? output.displayName : undefined,
-    emailAddress: output.emailAddress !== undefined && output.emailAddress !== null ? output.emailAddress : undefined,
+    displayName: __expectString(output.displayName),
+    emailAddress: __expectString(output.emailAddress),
     lastModifiedTimestamp:
       output.lastModifiedTimestamp !== undefined && output.lastModifiedTimestamp !== null
         ? new Date(Math.round(output.lastModifiedTimestamp * 1000))
         : undefined,
-    sshPublicKey: output.sshPublicKey !== undefined && output.sshPublicKey !== null ? output.sshPublicKey : undefined,
-    userArn: output.userArn !== undefined && output.userArn !== null ? output.userArn : undefined,
+    sshPublicKey: __expectString(output.sshPublicKey),
+    userArn: __expectString(output.userArn),
   } as any;
 };
 
@@ -2279,7 +2268,7 @@ const deserializeAws_json1_1InvalidNextTokenException = (
   context: __SerdeContext
 ): InvalidNextTokenException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -2288,19 +2277,19 @@ const deserializeAws_json1_1InvalidServiceRoleException = (
   context: __SerdeContext
 ): InvalidServiceRoleException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1ListProjectsResult = (output: any, context: __SerdeContext): ListProjectsResult => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     projects:
       output.projects !== undefined && output.projects !== null
         ? deserializeAws_json1_1ProjectsList(output.projects, context)
@@ -2310,7 +2299,7 @@ const deserializeAws_json1_1ListProjectsResult = (output: any, context: __SerdeC
 
 const deserializeAws_json1_1ListResourcesResult = (output: any, context: __SerdeContext): ListResourcesResult => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     resources:
       output.resources !== undefined && output.resources !== null
         ? deserializeAws_json1_1ResourcesResult(output.resources, context)
@@ -2323,7 +2312,7 @@ const deserializeAws_json1_1ListTagsForProjectResult = (
   context: __SerdeContext
 ): ListTagsForProjectResult => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     tags:
       output.tags !== undefined && output.tags !== null ? deserializeAws_json1_1Tags(output.tags, context) : undefined,
   } as any;
@@ -2331,7 +2320,7 @@ const deserializeAws_json1_1ListTagsForProjectResult = (
 
 const deserializeAws_json1_1ListTeamMembersResult = (output: any, context: __SerdeContext): ListTeamMembersResult => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     teamMembers:
       output.teamMembers !== undefined && output.teamMembers !== null
         ? deserializeAws_json1_1TeamMemberResult(output.teamMembers, context)
@@ -2341,7 +2330,7 @@ const deserializeAws_json1_1ListTeamMembersResult = (output: any, context: __Ser
 
 const deserializeAws_json1_1ListUserProfilesResult = (output: any, context: __SerdeContext): ListUserProfilesResult => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     userProfiles:
       output.userProfiles !== undefined && output.userProfiles !== null
         ? deserializeAws_json1_1UserProfilesList(output.userProfiles, context)
@@ -2354,7 +2343,7 @@ const deserializeAws_json1_1ProjectAlreadyExistsException = (
   context: __SerdeContext
 ): ProjectAlreadyExistsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -2363,7 +2352,7 @@ const deserializeAws_json1_1ProjectConfigurationException = (
   context: __SerdeContext
 ): ProjectConfigurationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -2372,7 +2361,7 @@ const deserializeAws_json1_1ProjectCreationFailedException = (
   context: __SerdeContext
 ): ProjectCreationFailedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -2381,7 +2370,7 @@ const deserializeAws_json1_1ProjectNotFoundException = (
   context: __SerdeContext
 ): ProjectNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -2398,21 +2387,21 @@ const deserializeAws_json1_1ProjectsList = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_1ProjectStatus = (output: any, context: __SerdeContext): ProjectStatus => {
   return {
-    reason: output.reason !== undefined && output.reason !== null ? output.reason : undefined,
-    state: output.state !== undefined && output.state !== null ? output.state : undefined,
+    reason: __expectString(output.reason),
+    state: __expectString(output.state),
   } as any;
 };
 
 const deserializeAws_json1_1ProjectSummary = (output: any, context: __SerdeContext): ProjectSummary => {
   return {
-    projectArn: output.projectArn !== undefined && output.projectArn !== null ? output.projectArn : undefined,
-    projectId: output.projectId !== undefined && output.projectId !== null ? output.projectId : undefined,
+    projectArn: __expectString(output.projectArn),
+    projectId: __expectString(output.projectId),
   } as any;
 };
 
 const deserializeAws_json1_1Resource = (output: any, context: __SerdeContext): Resource => {
   return {
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    id: __expectString(output.id),
   } as any;
 };
 
@@ -2441,19 +2430,16 @@ const deserializeAws_json1_1Tags = (output: any, context: __SerdeContext): { [ke
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_json1_1TeamMember = (output: any, context: __SerdeContext): TeamMember => {
   return {
-    projectRole: output.projectRole !== undefined && output.projectRole !== null ? output.projectRole : undefined,
-    remoteAccessAllowed:
-      output.remoteAccessAllowed !== undefined && output.remoteAccessAllowed !== null
-        ? output.remoteAccessAllowed
-        : undefined,
-    userArn: output.userArn !== undefined && output.userArn !== null ? output.userArn : undefined,
+    projectRole: __expectString(output.projectRole),
+    remoteAccessAllowed: __expectBoolean(output.remoteAccessAllowed),
+    userArn: __expectString(output.userArn),
   } as any;
 };
 
@@ -2462,7 +2448,7 @@ const deserializeAws_json1_1TeamMemberAlreadyAssociatedException = (
   context: __SerdeContext
 ): TeamMemberAlreadyAssociatedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -2471,7 +2457,7 @@ const deserializeAws_json1_1TeamMemberNotFoundException = (
   context: __SerdeContext
 ): TeamMemberNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -2496,12 +2482,9 @@ const deserializeAws_json1_1UpdateProjectResult = (output: any, context: __Serde
 
 const deserializeAws_json1_1UpdateTeamMemberResult = (output: any, context: __SerdeContext): UpdateTeamMemberResult => {
   return {
-    projectRole: output.projectRole !== undefined && output.projectRole !== null ? output.projectRole : undefined,
-    remoteAccessAllowed:
-      output.remoteAccessAllowed !== undefined && output.remoteAccessAllowed !== null
-        ? output.remoteAccessAllowed
-        : undefined,
-    userArn: output.userArn !== undefined && output.userArn !== null ? output.userArn : undefined,
+    projectRole: __expectString(output.projectRole),
+    remoteAccessAllowed: __expectBoolean(output.remoteAccessAllowed),
+    userArn: __expectString(output.userArn),
   } as any;
 };
 
@@ -2514,14 +2497,14 @@ const deserializeAws_json1_1UpdateUserProfileResult = (
       output.createdTimestamp !== undefined && output.createdTimestamp !== null
         ? new Date(Math.round(output.createdTimestamp * 1000))
         : undefined,
-    displayName: output.displayName !== undefined && output.displayName !== null ? output.displayName : undefined,
-    emailAddress: output.emailAddress !== undefined && output.emailAddress !== null ? output.emailAddress : undefined,
+    displayName: __expectString(output.displayName),
+    emailAddress: __expectString(output.emailAddress),
     lastModifiedTimestamp:
       output.lastModifiedTimestamp !== undefined && output.lastModifiedTimestamp !== null
         ? new Date(Math.round(output.lastModifiedTimestamp * 1000))
         : undefined,
-    sshPublicKey: output.sshPublicKey !== undefined && output.sshPublicKey !== null ? output.sshPublicKey : undefined,
-    userArn: output.userArn !== undefined && output.userArn !== null ? output.userArn : undefined,
+    sshPublicKey: __expectString(output.sshPublicKey),
+    userArn: __expectString(output.userArn),
   } as any;
 };
 
@@ -2530,7 +2513,7 @@ const deserializeAws_json1_1UserProfileAlreadyExistsException = (
   context: __SerdeContext
 ): UserProfileAlreadyExistsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -2539,7 +2522,7 @@ const deserializeAws_json1_1UserProfileNotFoundException = (
   context: __SerdeContext
 ): UserProfileNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -2556,16 +2539,16 @@ const deserializeAws_json1_1UserProfilesList = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1UserProfileSummary = (output: any, context: __SerdeContext): UserProfileSummary => {
   return {
-    displayName: output.displayName !== undefined && output.displayName !== null ? output.displayName : undefined,
-    emailAddress: output.emailAddress !== undefined && output.emailAddress !== null ? output.emailAddress : undefined,
-    sshPublicKey: output.sshPublicKey !== undefined && output.sshPublicKey !== null ? output.sshPublicKey : undefined,
-    userArn: output.userArn !== undefined && output.userArn !== null ? output.userArn : undefined,
+    displayName: __expectString(output.displayName),
+    emailAddress: __expectString(output.emailAddress),
+    sshPublicKey: __expectString(output.sshPublicKey),
+    userArn: __expectString(output.userArn),
   } as any;
 };
 
 const deserializeAws_json1_1ValidationException = (output: any, context: __SerdeContext): ValidationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 

--- a/clients/client-cognito-identity-provider/protocols/Aws_json1_1.ts
+++ b/clients/client-cognito-identity-provider/protocols/Aws_json1_1.ts
@@ -574,7 +574,12 @@ import {
   VerifyUserAttributeResponse,
 } from "../models/models_1";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -15719,8 +15724,8 @@ const deserializeAws_json1_1AccountTakeoverActionType = (
   context: __SerdeContext
 ): AccountTakeoverActionType => {
   return {
-    EventAction: output.EventAction !== undefined && output.EventAction !== null ? output.EventAction : undefined,
-    Notify: output.Notify !== undefined && output.Notify !== null ? output.Notify : undefined,
+    EventAction: __expectString(output.EventAction),
+    Notify: __expectBoolean(output.Notify),
   } as any;
 };
 
@@ -15759,18 +15764,12 @@ const deserializeAws_json1_1AdminCreateUserConfigType = (
   context: __SerdeContext
 ): AdminCreateUserConfigType => {
   return {
-    AllowAdminCreateUserOnly:
-      output.AllowAdminCreateUserOnly !== undefined && output.AllowAdminCreateUserOnly !== null
-        ? output.AllowAdminCreateUserOnly
-        : undefined,
+    AllowAdminCreateUserOnly: __expectBoolean(output.AllowAdminCreateUserOnly),
     InviteMessageTemplate:
       output.InviteMessageTemplate !== undefined && output.InviteMessageTemplate !== null
         ? deserializeAws_json1_1MessageTemplateType(output.InviteMessageTemplate, context)
         : undefined,
-    UnusedAccountValidityDays:
-      output.UnusedAccountValidityDays !== undefined && output.UnusedAccountValidityDays !== null
-        ? output.UnusedAccountValidityDays
-        : undefined,
+    UnusedAccountValidityDays: __expectNumber(output.UnusedAccountValidityDays),
   } as any;
 };
 
@@ -15825,15 +15824,12 @@ const deserializeAws_json1_1AdminGetDeviceResponse = (output: any, context: __Se
 
 const deserializeAws_json1_1AdminGetUserResponse = (output: any, context: __SerdeContext): AdminGetUserResponse => {
   return {
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
+    Enabled: __expectBoolean(output.Enabled),
     MFAOptions:
       output.MFAOptions !== undefined && output.MFAOptions !== null
         ? deserializeAws_json1_1MFAOptionListType(output.MFAOptions, context)
         : undefined,
-    PreferredMfaSetting:
-      output.PreferredMfaSetting !== undefined && output.PreferredMfaSetting !== null
-        ? output.PreferredMfaSetting
-        : undefined,
+    PreferredMfaSetting: __expectString(output.PreferredMfaSetting),
     UserAttributes:
       output.UserAttributes !== undefined && output.UserAttributes !== null
         ? deserializeAws_json1_1AttributeListType(output.UserAttributes, context)
@@ -15850,8 +15846,8 @@ const deserializeAws_json1_1AdminGetUserResponse = (output: any, context: __Serd
       output.UserMFASettingList !== undefined && output.UserMFASettingList !== null
         ? deserializeAws_json1_1UserMFASettingListType(output.UserMFASettingList, context)
         : undefined,
-    UserStatus: output.UserStatus !== undefined && output.UserStatus !== null ? output.UserStatus : undefined,
-    Username: output.Username !== undefined && output.Username !== null ? output.Username : undefined,
+    UserStatus: __expectString(output.UserStatus),
+    Username: __expectString(output.Username),
   } as any;
 };
 
@@ -15864,13 +15860,12 @@ const deserializeAws_json1_1AdminInitiateAuthResponse = (
       output.AuthenticationResult !== undefined && output.AuthenticationResult !== null
         ? deserializeAws_json1_1AuthenticationResultType(output.AuthenticationResult, context)
         : undefined,
-    ChallengeName:
-      output.ChallengeName !== undefined && output.ChallengeName !== null ? output.ChallengeName : undefined,
+    ChallengeName: __expectString(output.ChallengeName),
     ChallengeParameters:
       output.ChallengeParameters !== undefined && output.ChallengeParameters !== null
         ? deserializeAws_json1_1ChallengeParametersType(output.ChallengeParameters, context)
         : undefined,
-    Session: output.Session !== undefined && output.Session !== null ? output.Session : undefined,
+    Session: __expectString(output.Session),
   } as any;
 };
 
@@ -15890,8 +15885,7 @@ const deserializeAws_json1_1AdminListDevicesResponse = (
       output.Devices !== undefined && output.Devices !== null
         ? deserializeAws_json1_1DeviceListType(output.Devices, context)
         : undefined,
-    PaginationToken:
-      output.PaginationToken !== undefined && output.PaginationToken !== null ? output.PaginationToken : undefined,
+    PaginationToken: __expectString(output.PaginationToken),
   } as any;
 };
 
@@ -15904,7 +15898,7 @@ const deserializeAws_json1_1AdminListGroupsForUserResponse = (
       output.Groups !== undefined && output.Groups !== null
         ? deserializeAws_json1_1GroupListType(output.Groups, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -15917,7 +15911,7 @@ const deserializeAws_json1_1AdminListUserAuthEventsResponse = (
       output.AuthEvents !== undefined && output.AuthEvents !== null
         ? deserializeAws_json1_1AuthEventsType(output.AuthEvents, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -15937,13 +15931,12 @@ const deserializeAws_json1_1AdminRespondToAuthChallengeResponse = (
       output.AuthenticationResult !== undefined && output.AuthenticationResult !== null
         ? deserializeAws_json1_1AuthenticationResultType(output.AuthenticationResult, context)
         : undefined,
-    ChallengeName:
-      output.ChallengeName !== undefined && output.ChallengeName !== null ? output.ChallengeName : undefined,
+    ChallengeName: __expectString(output.ChallengeName),
     ChallengeParameters:
       output.ChallengeParameters !== undefined && output.ChallengeParameters !== null
         ? deserializeAws_json1_1ChallengeParametersType(output.ChallengeParameters, context)
         : undefined,
-    Session: output.Session !== undefined && output.Session !== null ? output.Session : undefined,
+    Session: __expectString(output.Session),
   } as any;
 };
 
@@ -16006,13 +15999,13 @@ const deserializeAws_json1_1AliasAttributesListType = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1AliasExistsException = (output: any, context: __SerdeContext): AliasExistsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -16021,14 +16014,11 @@ const deserializeAws_json1_1AnalyticsConfigurationType = (
   context: __SerdeContext
 ): AnalyticsConfigurationType => {
   return {
-    ApplicationArn:
-      output.ApplicationArn !== undefined && output.ApplicationArn !== null ? output.ApplicationArn : undefined,
-    ApplicationId:
-      output.ApplicationId !== undefined && output.ApplicationId !== null ? output.ApplicationId : undefined,
-    ExternalId: output.ExternalId !== undefined && output.ExternalId !== null ? output.ExternalId : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
-    UserDataShared:
-      output.UserDataShared !== undefined && output.UserDataShared !== null ? output.UserDataShared : undefined,
+    ApplicationArn: __expectString(output.ApplicationArn),
+    ApplicationId: __expectString(output.ApplicationId),
+    ExternalId: __expectString(output.ExternalId),
+    RoleArn: __expectString(output.RoleArn),
+    UserDataShared: __expectBoolean(output.UserDataShared),
   } as any;
 };
 
@@ -16037,8 +16027,8 @@ const deserializeAws_json1_1AssociateSoftwareTokenResponse = (
   context: __SerdeContext
 ): AssociateSoftwareTokenResponse => {
   return {
-    SecretCode: output.SecretCode !== undefined && output.SecretCode !== null ? output.SecretCode : undefined,
-    Session: output.Session !== undefined && output.Session !== null ? output.Session : undefined,
+    SecretCode: __expectString(output.SecretCode),
+    Session: __expectString(output.Session),
   } as any;
 };
 
@@ -16063,15 +16053,15 @@ const deserializeAws_json1_1AttributeMappingType = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_json1_1AttributeType = (output: any, context: __SerdeContext): AttributeType => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Name: __expectString(output.Name),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -16080,15 +16070,15 @@ const deserializeAws_json1_1AuthenticationResultType = (
   context: __SerdeContext
 ): AuthenticationResultType => {
   return {
-    AccessToken: output.AccessToken !== undefined && output.AccessToken !== null ? output.AccessToken : undefined,
-    ExpiresIn: output.ExpiresIn !== undefined && output.ExpiresIn !== null ? output.ExpiresIn : undefined,
-    IdToken: output.IdToken !== undefined && output.IdToken !== null ? output.IdToken : undefined,
+    AccessToken: __expectString(output.AccessToken),
+    ExpiresIn: __expectNumber(output.ExpiresIn),
+    IdToken: __expectString(output.IdToken),
     NewDeviceMetadata:
       output.NewDeviceMetadata !== undefined && output.NewDeviceMetadata !== null
         ? deserializeAws_json1_1NewDeviceMetadataType(output.NewDeviceMetadata, context)
         : undefined,
-    RefreshToken: output.RefreshToken !== undefined && output.RefreshToken !== null ? output.RefreshToken : undefined,
-    TokenType: output.TokenType !== undefined && output.TokenType !== null ? output.TokenType : undefined,
+    RefreshToken: __expectString(output.RefreshToken),
+    TokenType: __expectString(output.TokenType),
   } as any;
 };
 
@@ -16121,14 +16111,13 @@ const deserializeAws_json1_1AuthEventType = (output: any, context: __SerdeContex
       output.EventFeedback !== undefined && output.EventFeedback !== null
         ? deserializeAws_json1_1EventFeedbackType(output.EventFeedback, context)
         : undefined,
-    EventId: output.EventId !== undefined && output.EventId !== null ? output.EventId : undefined,
-    EventResponse:
-      output.EventResponse !== undefined && output.EventResponse !== null ? output.EventResponse : undefined,
+    EventId: __expectString(output.EventId),
+    EventResponse: __expectString(output.EventResponse),
     EventRisk:
       output.EventRisk !== undefined && output.EventRisk !== null
         ? deserializeAws_json1_1EventRiskType(output.EventRisk, context)
         : undefined,
-    EventType: output.EventType !== undefined && output.EventType !== null ? output.EventType : undefined,
+    EventType: __expectString(output.EventType),
   } as any;
 };
 
@@ -16139,7 +16128,7 @@ const deserializeAws_json1_1BlockedIPRangeListType = (output: any, context: __Se
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -16150,7 +16139,7 @@ const deserializeAws_json1_1CallbackURLsListType = (output: any, context: __Serd
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -16164,7 +16153,7 @@ const deserializeAws_json1_1ChallengeParametersType = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -16185,12 +16174,8 @@ const deserializeAws_json1_1ChallengeResponseListType = (
 
 const deserializeAws_json1_1ChallengeResponseType = (output: any, context: __SerdeContext): ChallengeResponseType => {
   return {
-    ChallengeName:
-      output.ChallengeName !== undefined && output.ChallengeName !== null ? output.ChallengeName : undefined,
-    ChallengeResponse:
-      output.ChallengeResponse !== undefined && output.ChallengeResponse !== null
-        ? output.ChallengeResponse
-        : undefined,
+    ChallengeName: __expectString(output.ChallengeName),
+    ChallengeResponse: __expectString(output.ChallengeResponse),
   } as any;
 };
 
@@ -16205,7 +16190,7 @@ const deserializeAws_json1_1ClientPermissionListType = (output: any, context: __
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -16228,11 +16213,9 @@ const deserializeAws_json1_1CodeDeliveryDetailsType = (
   context: __SerdeContext
 ): CodeDeliveryDetailsType => {
   return {
-    AttributeName:
-      output.AttributeName !== undefined && output.AttributeName !== null ? output.AttributeName : undefined,
-    DeliveryMedium:
-      output.DeliveryMedium !== undefined && output.DeliveryMedium !== null ? output.DeliveryMedium : undefined,
-    Destination: output.Destination !== undefined && output.Destination !== null ? output.Destination : undefined,
+    AttributeName: __expectString(output.AttributeName),
+    DeliveryMedium: __expectString(output.DeliveryMedium),
+    Destination: __expectString(output.Destination),
   } as any;
 };
 
@@ -16241,13 +16224,13 @@ const deserializeAws_json1_1CodeDeliveryFailureException = (
   context: __SerdeContext
 ): CodeDeliveryFailureException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1CodeMismatchException = (output: any, context: __SerdeContext): CodeMismatchException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -16256,7 +16239,7 @@ const deserializeAws_json1_1CompromisedCredentialsActionsType = (
   context: __SerdeContext
 ): CompromisedCredentialsActionsType => {
   return {
-    EventAction: output.EventAction !== undefined && output.EventAction !== null ? output.EventAction : undefined,
+    EventAction: __expectString(output.EventAction),
   } as any;
 };
 
@@ -16281,16 +16264,13 @@ const deserializeAws_json1_1ConcurrentModificationException = (
   context: __SerdeContext
 ): ConcurrentModificationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1ConfirmDeviceResponse = (output: any, context: __SerdeContext): ConfirmDeviceResponse => {
   return {
-    UserConfirmationNecessary:
-      output.UserConfirmationNecessary !== undefined && output.UserConfirmationNecessary !== null
-        ? output.UserConfirmationNecessary
-        : undefined,
+    UserConfirmationNecessary: __expectBoolean(output.UserConfirmationNecessary),
   } as any;
 };
 
@@ -16367,8 +16347,7 @@ const deserializeAws_json1_1CreateUserPoolDomainResponse = (
   context: __SerdeContext
 ): CreateUserPoolDomainResponse => {
   return {
-    CloudFrontDomain:
-      output.CloudFrontDomain !== undefined && output.CloudFrontDomain !== null ? output.CloudFrontDomain : undefined,
+    CloudFrontDomain: __expectString(output.CloudFrontDomain),
   } as any;
 };
 
@@ -16383,8 +16362,7 @@ const deserializeAws_json1_1CreateUserPoolResponse = (output: any, context: __Se
 
 const deserializeAws_json1_1CustomDomainConfigType = (output: any, context: __SerdeContext): CustomDomainConfigType => {
   return {
-    CertificateArn:
-      output.CertificateArn !== undefined && output.CertificateArn !== null ? output.CertificateArn : undefined,
+    CertificateArn: __expectString(output.CertificateArn),
   } as any;
 };
 
@@ -16393,9 +16371,8 @@ const deserializeAws_json1_1CustomEmailLambdaVersionConfigType = (
   context: __SerdeContext
 ): CustomEmailLambdaVersionConfigType => {
   return {
-    LambdaArn: output.LambdaArn !== undefined && output.LambdaArn !== null ? output.LambdaArn : undefined,
-    LambdaVersion:
-      output.LambdaVersion !== undefined && output.LambdaVersion !== null ? output.LambdaVersion : undefined,
+    LambdaArn: __expectString(output.LambdaArn),
+    LambdaVersion: __expectString(output.LambdaVersion),
   } as any;
 };
 
@@ -16404,9 +16381,8 @@ const deserializeAws_json1_1CustomSMSLambdaVersionConfigType = (
   context: __SerdeContext
 ): CustomSMSLambdaVersionConfigType => {
   return {
-    LambdaArn: output.LambdaArn !== undefined && output.LambdaArn !== null ? output.LambdaArn : undefined,
-    LambdaVersion:
-      output.LambdaVersion !== undefined && output.LambdaVersion !== null ? output.LambdaVersion : undefined,
+    LambdaArn: __expectString(output.LambdaArn),
+    LambdaVersion: __expectString(output.LambdaVersion),
   } as any;
 };
 
@@ -16513,14 +16489,8 @@ const deserializeAws_json1_1DeviceConfigurationType = (
   context: __SerdeContext
 ): DeviceConfigurationType => {
   return {
-    ChallengeRequiredOnNewDevice:
-      output.ChallengeRequiredOnNewDevice !== undefined && output.ChallengeRequiredOnNewDevice !== null
-        ? output.ChallengeRequiredOnNewDevice
-        : undefined,
-    DeviceOnlyRememberedOnUserPrompt:
-      output.DeviceOnlyRememberedOnUserPrompt !== undefined && output.DeviceOnlyRememberedOnUserPrompt !== null
-        ? output.DeviceOnlyRememberedOnUserPrompt
-        : undefined,
+    ChallengeRequiredOnNewDevice: __expectBoolean(output.ChallengeRequiredOnNewDevice),
+    DeviceOnlyRememberedOnUserPrompt: __expectBoolean(output.DeviceOnlyRememberedOnUserPrompt),
   } as any;
 };
 
@@ -16545,7 +16515,7 @@ const deserializeAws_json1_1DeviceType = (output: any, context: __SerdeContext):
       output.DeviceCreateDate !== undefined && output.DeviceCreateDate !== null
         ? new Date(Math.round(output.DeviceCreateDate * 1000))
         : undefined,
-    DeviceKey: output.DeviceKey !== undefined && output.DeviceKey !== null ? output.DeviceKey : undefined,
+    DeviceKey: __expectString(output.DeviceKey),
     DeviceLastAuthenticatedDate:
       output.DeviceLastAuthenticatedDate !== undefined && output.DeviceLastAuthenticatedDate !== null
         ? new Date(Math.round(output.DeviceLastAuthenticatedDate * 1000))
@@ -16559,20 +16529,17 @@ const deserializeAws_json1_1DeviceType = (output: any, context: __SerdeContext):
 
 const deserializeAws_json1_1DomainDescriptionType = (output: any, context: __SerdeContext): DomainDescriptionType => {
   return {
-    AWSAccountId: output.AWSAccountId !== undefined && output.AWSAccountId !== null ? output.AWSAccountId : undefined,
-    CloudFrontDistribution:
-      output.CloudFrontDistribution !== undefined && output.CloudFrontDistribution !== null
-        ? output.CloudFrontDistribution
-        : undefined,
+    AWSAccountId: __expectString(output.AWSAccountId),
+    CloudFrontDistribution: __expectString(output.CloudFrontDistribution),
     CustomDomainConfig:
       output.CustomDomainConfig !== undefined && output.CustomDomainConfig !== null
         ? deserializeAws_json1_1CustomDomainConfigType(output.CustomDomainConfig, context)
         : undefined,
-    Domain: output.Domain !== undefined && output.Domain !== null ? output.Domain : undefined,
-    S3Bucket: output.S3Bucket !== undefined && output.S3Bucket !== null ? output.S3Bucket : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    UserPoolId: output.UserPoolId !== undefined && output.UserPoolId !== null ? output.UserPoolId : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    Domain: __expectString(output.Domain),
+    S3Bucket: __expectString(output.S3Bucket),
+    Status: __expectString(output.Status),
+    UserPoolId: __expectString(output.UserPoolId),
+    Version: __expectString(output.Version),
   } as any;
 };
 
@@ -16581,24 +16548,17 @@ const deserializeAws_json1_1DuplicateProviderException = (
   context: __SerdeContext
 ): DuplicateProviderException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1EmailConfigurationType = (output: any, context: __SerdeContext): EmailConfigurationType => {
   return {
-    ConfigurationSet:
-      output.ConfigurationSet !== undefined && output.ConfigurationSet !== null ? output.ConfigurationSet : undefined,
-    EmailSendingAccount:
-      output.EmailSendingAccount !== undefined && output.EmailSendingAccount !== null
-        ? output.EmailSendingAccount
-        : undefined,
-    From: output.From !== undefined && output.From !== null ? output.From : undefined,
-    ReplyToEmailAddress:
-      output.ReplyToEmailAddress !== undefined && output.ReplyToEmailAddress !== null
-        ? output.ReplyToEmailAddress
-        : undefined,
-    SourceArn: output.SourceArn !== undefined && output.SourceArn !== null ? output.SourceArn : undefined,
+    ConfigurationSet: __expectString(output.ConfigurationSet),
+    EmailSendingAccount: __expectString(output.EmailSendingAccount),
+    From: __expectString(output.From),
+    ReplyToEmailAddress: __expectString(output.ReplyToEmailAddress),
+    SourceArn: __expectString(output.SourceArn),
   } as any;
 };
 
@@ -16607,17 +16567,17 @@ const deserializeAws_json1_1EnableSoftwareTokenMFAException = (
   context: __SerdeContext
 ): EnableSoftwareTokenMFAException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1EventContextDataType = (output: any, context: __SerdeContext): EventContextDataType => {
   return {
-    City: output.City !== undefined && output.City !== null ? output.City : undefined,
-    Country: output.Country !== undefined && output.Country !== null ? output.Country : undefined,
-    DeviceName: output.DeviceName !== undefined && output.DeviceName !== null ? output.DeviceName : undefined,
-    IpAddress: output.IpAddress !== undefined && output.IpAddress !== null ? output.IpAddress : undefined,
-    Timezone: output.Timezone !== undefined && output.Timezone !== null ? output.Timezone : undefined,
+    City: __expectString(output.City),
+    Country: __expectString(output.Country),
+    DeviceName: __expectString(output.DeviceName),
+    IpAddress: __expectString(output.IpAddress),
+    Timezone: __expectString(output.Timezone),
   } as any;
 };
 
@@ -16627,9 +16587,8 @@ const deserializeAws_json1_1EventFeedbackType = (output: any, context: __SerdeCo
       output.FeedbackDate !== undefined && output.FeedbackDate !== null
         ? new Date(Math.round(output.FeedbackDate * 1000))
         : undefined,
-    FeedbackValue:
-      output.FeedbackValue !== undefined && output.FeedbackValue !== null ? output.FeedbackValue : undefined,
-    Provider: output.Provider !== undefined && output.Provider !== null ? output.Provider : undefined,
+    FeedbackValue: __expectString(output.FeedbackValue),
+    Provider: __expectString(output.Provider),
   } as any;
 };
 
@@ -16640,24 +16599,21 @@ const deserializeAws_json1_1EventFiltersType = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1EventRiskType = (output: any, context: __SerdeContext): EventRiskType => {
   return {
-    CompromisedCredentialsDetected:
-      output.CompromisedCredentialsDetected !== undefined && output.CompromisedCredentialsDetected !== null
-        ? output.CompromisedCredentialsDetected
-        : undefined,
-    RiskDecision: output.RiskDecision !== undefined && output.RiskDecision !== null ? output.RiskDecision : undefined,
-    RiskLevel: output.RiskLevel !== undefined && output.RiskLevel !== null ? output.RiskLevel : undefined,
+    CompromisedCredentialsDetected: __expectBoolean(output.CompromisedCredentialsDetected),
+    RiskDecision: __expectString(output.RiskDecision),
+    RiskLevel: __expectString(output.RiskLevel),
   } as any;
 };
 
 const deserializeAws_json1_1ExpiredCodeException = (output: any, context: __SerdeContext): ExpiredCodeException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -16671,7 +16627,7 @@ const deserializeAws_json1_1ExplicitAuthFlowsListType = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -16690,7 +16646,7 @@ const deserializeAws_json1_1GetCSVHeaderResponse = (output: any, context: __Serd
       output.CSVHeader !== undefined && output.CSVHeader !== null
         ? deserializeAws_json1_1ListOfStringTypes(output.CSVHeader, context)
         : undefined,
-    UserPoolId: output.UserPoolId !== undefined && output.UserPoolId !== null ? output.UserPoolId : undefined,
+    UserPoolId: __expectString(output.UserPoolId),
   } as any;
 };
 
@@ -16729,7 +16685,7 @@ const deserializeAws_json1_1GetSigningCertificateResponse = (
   context: __SerdeContext
 ): GetSigningCertificateResponse => {
   return {
-    Certificate: output.Certificate !== undefined && output.Certificate !== null ? output.Certificate : undefined,
+    Certificate: __expectString(output.Certificate),
   } as any;
 };
 
@@ -16762,8 +16718,7 @@ const deserializeAws_json1_1GetUserPoolMfaConfigResponse = (
   context: __SerdeContext
 ): GetUserPoolMfaConfigResponse => {
   return {
-    MfaConfiguration:
-      output.MfaConfiguration !== undefined && output.MfaConfiguration !== null ? output.MfaConfiguration : undefined,
+    MfaConfiguration: __expectString(output.MfaConfiguration),
     SmsMfaConfiguration:
       output.SmsMfaConfiguration !== undefined && output.SmsMfaConfiguration !== null
         ? deserializeAws_json1_1SmsMfaConfigType(output.SmsMfaConfiguration, context)
@@ -16781,10 +16736,7 @@ const deserializeAws_json1_1GetUserResponse = (output: any, context: __SerdeCont
       output.MFAOptions !== undefined && output.MFAOptions !== null
         ? deserializeAws_json1_1MFAOptionListType(output.MFAOptions, context)
         : undefined,
-    PreferredMfaSetting:
-      output.PreferredMfaSetting !== undefined && output.PreferredMfaSetting !== null
-        ? output.PreferredMfaSetting
-        : undefined,
+    PreferredMfaSetting: __expectString(output.PreferredMfaSetting),
     UserAttributes:
       output.UserAttributes !== undefined && output.UserAttributes !== null
         ? deserializeAws_json1_1AttributeListType(output.UserAttributes, context)
@@ -16793,7 +16745,7 @@ const deserializeAws_json1_1GetUserResponse = (output: any, context: __SerdeCont
       output.UserMFASettingList !== undefined && output.UserMFASettingList !== null
         ? deserializeAws_json1_1UserMFASettingListType(output.UserMFASettingList, context)
         : undefined,
-    Username: output.Username !== undefined && output.Username !== null ? output.Username : undefined,
+    Username: __expectString(output.Username),
   } as any;
 };
 
@@ -16803,7 +16755,7 @@ const deserializeAws_json1_1GlobalSignOutResponse = (output: any, context: __Ser
 
 const deserializeAws_json1_1GroupExistsException = (output: any, context: __SerdeContext): GroupExistsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -16824,15 +16776,15 @@ const deserializeAws_json1_1GroupType = (output: any, context: __SerdeContext): 
       output.CreationDate !== undefined && output.CreationDate !== null
         ? new Date(Math.round(output.CreationDate * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    GroupName: output.GroupName !== undefined && output.GroupName !== null ? output.GroupName : undefined,
+    Description: __expectString(output.Description),
+    GroupName: __expectString(output.GroupName),
     LastModifiedDate:
       output.LastModifiedDate !== undefined && output.LastModifiedDate !== null
         ? new Date(Math.round(output.LastModifiedDate * 1000))
         : undefined,
-    Precedence: output.Precedence !== undefined && output.Precedence !== null ? output.Precedence : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
-    UserPoolId: output.UserPoolId !== undefined && output.UserPoolId !== null ? output.UserPoolId : undefined,
+    Precedence: __expectNumber(output.Precedence),
+    RoleArn: __expectString(output.RoleArn),
+    UserPoolId: __expectString(output.UserPoolId),
   } as any;
 };
 
@@ -16858,9 +16810,9 @@ const deserializeAws_json1_1IdentityProviderType = (output: any, context: __Serd
       output.ProviderDetails !== undefined && output.ProviderDetails !== null
         ? deserializeAws_json1_1ProviderDetailsType(output.ProviderDetails, context)
         : undefined,
-    ProviderName: output.ProviderName !== undefined && output.ProviderName !== null ? output.ProviderName : undefined,
-    ProviderType: output.ProviderType !== undefined && output.ProviderType !== null ? output.ProviderType : undefined,
-    UserPoolId: output.UserPoolId !== undefined && output.UserPoolId !== null ? output.UserPoolId : undefined,
+    ProviderName: __expectString(output.ProviderName),
+    ProviderType: __expectString(output.ProviderType),
+    UserPoolId: __expectString(output.UserPoolId),
   } as any;
 };
 
@@ -16871,7 +16823,7 @@ const deserializeAws_json1_1IdpIdentifiersListType = (output: any, context: __Se
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -16881,19 +16833,18 @@ const deserializeAws_json1_1InitiateAuthResponse = (output: any, context: __Serd
       output.AuthenticationResult !== undefined && output.AuthenticationResult !== null
         ? deserializeAws_json1_1AuthenticationResultType(output.AuthenticationResult, context)
         : undefined,
-    ChallengeName:
-      output.ChallengeName !== undefined && output.ChallengeName !== null ? output.ChallengeName : undefined,
+    ChallengeName: __expectString(output.ChallengeName),
     ChallengeParameters:
       output.ChallengeParameters !== undefined && output.ChallengeParameters !== null
         ? deserializeAws_json1_1ChallengeParametersType(output.ChallengeParameters, context)
         : undefined,
-    Session: output.Session !== undefined && output.Session !== null ? output.Session : undefined,
+    Session: __expectString(output.Session),
   } as any;
 };
 
 const deserializeAws_json1_1InternalErrorException = (output: any, context: __SerdeContext): InternalErrorException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -16902,7 +16853,7 @@ const deserializeAws_json1_1InvalidEmailRoleAccessPolicyException = (
   context: __SerdeContext
 ): InvalidEmailRoleAccessPolicyException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -16911,7 +16862,7 @@ const deserializeAws_json1_1InvalidLambdaResponseException = (
   context: __SerdeContext
 ): InvalidLambdaResponseException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -16920,7 +16871,7 @@ const deserializeAws_json1_1InvalidOAuthFlowException = (
   context: __SerdeContext
 ): InvalidOAuthFlowException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -16929,7 +16880,7 @@ const deserializeAws_json1_1InvalidParameterException = (
   context: __SerdeContext
 ): InvalidParameterException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -16938,7 +16889,7 @@ const deserializeAws_json1_1InvalidPasswordException = (
   context: __SerdeContext
 ): InvalidPasswordException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -16947,7 +16898,7 @@ const deserializeAws_json1_1InvalidSmsRoleAccessPolicyException = (
   context: __SerdeContext
 ): InvalidSmsRoleAccessPolicyException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -16956,7 +16907,7 @@ const deserializeAws_json1_1InvalidSmsRoleTrustRelationshipException = (
   context: __SerdeContext
 ): InvalidSmsRoleTrustRelationshipException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -16965,58 +16916,37 @@ const deserializeAws_json1_1InvalidUserPoolConfigurationException = (
   context: __SerdeContext
 ): InvalidUserPoolConfigurationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1LambdaConfigType = (output: any, context: __SerdeContext): LambdaConfigType => {
   return {
-    CreateAuthChallenge:
-      output.CreateAuthChallenge !== undefined && output.CreateAuthChallenge !== null
-        ? output.CreateAuthChallenge
-        : undefined,
+    CreateAuthChallenge: __expectString(output.CreateAuthChallenge),
     CustomEmailSender:
       output.CustomEmailSender !== undefined && output.CustomEmailSender !== null
         ? deserializeAws_json1_1CustomEmailLambdaVersionConfigType(output.CustomEmailSender, context)
         : undefined,
-    CustomMessage:
-      output.CustomMessage !== undefined && output.CustomMessage !== null ? output.CustomMessage : undefined,
+    CustomMessage: __expectString(output.CustomMessage),
     CustomSMSSender:
       output.CustomSMSSender !== undefined && output.CustomSMSSender !== null
         ? deserializeAws_json1_1CustomSMSLambdaVersionConfigType(output.CustomSMSSender, context)
         : undefined,
-    DefineAuthChallenge:
-      output.DefineAuthChallenge !== undefined && output.DefineAuthChallenge !== null
-        ? output.DefineAuthChallenge
-        : undefined,
-    KMSKeyID: output.KMSKeyID !== undefined && output.KMSKeyID !== null ? output.KMSKeyID : undefined,
-    PostAuthentication:
-      output.PostAuthentication !== undefined && output.PostAuthentication !== null
-        ? output.PostAuthentication
-        : undefined,
-    PostConfirmation:
-      output.PostConfirmation !== undefined && output.PostConfirmation !== null ? output.PostConfirmation : undefined,
-    PreAuthentication:
-      output.PreAuthentication !== undefined && output.PreAuthentication !== null
-        ? output.PreAuthentication
-        : undefined,
-    PreSignUp: output.PreSignUp !== undefined && output.PreSignUp !== null ? output.PreSignUp : undefined,
-    PreTokenGeneration:
-      output.PreTokenGeneration !== undefined && output.PreTokenGeneration !== null
-        ? output.PreTokenGeneration
-        : undefined,
-    UserMigration:
-      output.UserMigration !== undefined && output.UserMigration !== null ? output.UserMigration : undefined,
-    VerifyAuthChallengeResponse:
-      output.VerifyAuthChallengeResponse !== undefined && output.VerifyAuthChallengeResponse !== null
-        ? output.VerifyAuthChallengeResponse
-        : undefined,
+    DefineAuthChallenge: __expectString(output.DefineAuthChallenge),
+    KMSKeyID: __expectString(output.KMSKeyID),
+    PostAuthentication: __expectString(output.PostAuthentication),
+    PostConfirmation: __expectString(output.PostConfirmation),
+    PreAuthentication: __expectString(output.PreAuthentication),
+    PreSignUp: __expectString(output.PreSignUp),
+    PreTokenGeneration: __expectString(output.PreTokenGeneration),
+    UserMigration: __expectString(output.UserMigration),
+    VerifyAuthChallengeResponse: __expectString(output.VerifyAuthChallengeResponse),
   } as any;
 };
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -17026,8 +16956,7 @@ const deserializeAws_json1_1ListDevicesResponse = (output: any, context: __Serde
       output.Devices !== undefined && output.Devices !== null
         ? deserializeAws_json1_1DeviceListType(output.Devices, context)
         : undefined,
-    PaginationToken:
-      output.PaginationToken !== undefined && output.PaginationToken !== null ? output.PaginationToken : undefined,
+    PaginationToken: __expectString(output.PaginationToken),
   } as any;
 };
 
@@ -17037,7 +16966,7 @@ const deserializeAws_json1_1ListGroupsResponse = (output: any, context: __SerdeC
       output.Groups !== undefined && output.Groups !== null
         ? deserializeAws_json1_1GroupListType(output.Groups, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -17046,7 +16975,7 @@ const deserializeAws_json1_1ListIdentityProvidersResponse = (
   context: __SerdeContext
 ): ListIdentityProvidersResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Providers:
       output.Providers !== undefined && output.Providers !== null
         ? deserializeAws_json1_1ProvidersListType(output.Providers, context)
@@ -17061,7 +16990,7 @@ const deserializeAws_json1_1ListOfStringTypes = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -17070,7 +16999,7 @@ const deserializeAws_json1_1ListResourceServersResponse = (
   context: __SerdeContext
 ): ListResourceServersResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     ResourceServers:
       output.ResourceServers !== undefined && output.ResourceServers !== null
         ? deserializeAws_json1_1ResourceServersListType(output.ResourceServers, context)
@@ -17095,8 +17024,7 @@ const deserializeAws_json1_1ListUserImportJobsResponse = (
   context: __SerdeContext
 ): ListUserImportJobsResponse => {
   return {
-    PaginationToken:
-      output.PaginationToken !== undefined && output.PaginationToken !== null ? output.PaginationToken : undefined,
+    PaginationToken: __expectString(output.PaginationToken),
     UserImportJobs:
       output.UserImportJobs !== undefined && output.UserImportJobs !== null
         ? deserializeAws_json1_1UserImportJobsListType(output.UserImportJobs, context)
@@ -17109,7 +17037,7 @@ const deserializeAws_json1_1ListUserPoolClientsResponse = (
   context: __SerdeContext
 ): ListUserPoolClientsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     UserPoolClients:
       output.UserPoolClients !== undefined && output.UserPoolClients !== null
         ? deserializeAws_json1_1UserPoolClientListType(output.UserPoolClients, context)
@@ -17119,7 +17047,7 @@ const deserializeAws_json1_1ListUserPoolClientsResponse = (
 
 const deserializeAws_json1_1ListUserPoolsResponse = (output: any, context: __SerdeContext): ListUserPoolsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     UserPools:
       output.UserPools !== undefined && output.UserPools !== null
         ? deserializeAws_json1_1UserPoolListType(output.UserPools, context)
@@ -17132,7 +17060,7 @@ const deserializeAws_json1_1ListUsersInGroupResponse = (
   context: __SerdeContext
 ): ListUsersInGroupResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Users:
       output.Users !== undefined && output.Users !== null
         ? deserializeAws_json1_1UsersListType(output.Users, context)
@@ -17142,8 +17070,7 @@ const deserializeAws_json1_1ListUsersInGroupResponse = (
 
 const deserializeAws_json1_1ListUsersResponse = (output: any, context: __SerdeContext): ListUsersResponse => {
   return {
-    PaginationToken:
-      output.PaginationToken !== undefined && output.PaginationToken !== null ? output.PaginationToken : undefined,
+    PaginationToken: __expectString(output.PaginationToken),
     Users:
       output.Users !== undefined && output.Users !== null
         ? deserializeAws_json1_1UsersListType(output.Users, context)
@@ -17158,15 +17085,15 @@ const deserializeAws_json1_1LogoutURLsListType = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1MessageTemplateType = (output: any, context: __SerdeContext): MessageTemplateType => {
   return {
-    EmailMessage: output.EmailMessage !== undefined && output.EmailMessage !== null ? output.EmailMessage : undefined,
-    EmailSubject: output.EmailSubject !== undefined && output.EmailSubject !== null ? output.EmailSubject : undefined,
-    SMSMessage: output.SMSMessage !== undefined && output.SMSMessage !== null ? output.SMSMessage : undefined,
+    EmailMessage: __expectString(output.EmailMessage),
+    EmailSubject: __expectString(output.EmailSubject),
+    SMSMessage: __expectString(output.SMSMessage),
   } as any;
 };
 
@@ -17175,7 +17102,7 @@ const deserializeAws_json1_1MFAMethodNotFoundException = (
   context: __SerdeContext
 ): MFAMethodNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -17192,24 +17119,21 @@ const deserializeAws_json1_1MFAOptionListType = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1MFAOptionType = (output: any, context: __SerdeContext): MFAOptionType => {
   return {
-    AttributeName:
-      output.AttributeName !== undefined && output.AttributeName !== null ? output.AttributeName : undefined,
-    DeliveryMedium:
-      output.DeliveryMedium !== undefined && output.DeliveryMedium !== null ? output.DeliveryMedium : undefined,
+    AttributeName: __expectString(output.AttributeName),
+    DeliveryMedium: __expectString(output.DeliveryMedium),
   } as any;
 };
 
 const deserializeAws_json1_1NewDeviceMetadataType = (output: any, context: __SerdeContext): NewDeviceMetadataType => {
   return {
-    DeviceGroupKey:
-      output.DeviceGroupKey !== undefined && output.DeviceGroupKey !== null ? output.DeviceGroupKey : undefined,
-    DeviceKey: output.DeviceKey !== undefined && output.DeviceKey !== null ? output.DeviceKey : undefined,
+    DeviceGroupKey: __expectString(output.DeviceGroupKey),
+    DeviceKey: __expectString(output.DeviceKey),
   } as any;
 };
 
 const deserializeAws_json1_1NotAuthorizedException = (output: any, context: __SerdeContext): NotAuthorizedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -17222,7 +17146,7 @@ const deserializeAws_json1_1NotifyConfigurationType = (
       output.BlockEmail !== undefined && output.BlockEmail !== null
         ? deserializeAws_json1_1NotifyEmailType(output.BlockEmail, context)
         : undefined,
-    From: output.From !== undefined && output.From !== null ? output.From : undefined,
+    From: __expectString(output.From),
     MfaEmail:
       output.MfaEmail !== undefined && output.MfaEmail !== null
         ? deserializeAws_json1_1NotifyEmailType(output.MfaEmail, context)
@@ -17231,16 +17155,16 @@ const deserializeAws_json1_1NotifyConfigurationType = (
       output.NoActionEmail !== undefined && output.NoActionEmail !== null
         ? deserializeAws_json1_1NotifyEmailType(output.NoActionEmail, context)
         : undefined,
-    ReplyTo: output.ReplyTo !== undefined && output.ReplyTo !== null ? output.ReplyTo : undefined,
-    SourceArn: output.SourceArn !== undefined && output.SourceArn !== null ? output.SourceArn : undefined,
+    ReplyTo: __expectString(output.ReplyTo),
+    SourceArn: __expectString(output.SourceArn),
   } as any;
 };
 
 const deserializeAws_json1_1NotifyEmailType = (output: any, context: __SerdeContext): NotifyEmailType => {
   return {
-    HtmlBody: output.HtmlBody !== undefined && output.HtmlBody !== null ? output.HtmlBody : undefined,
-    Subject: output.Subject !== undefined && output.Subject !== null ? output.Subject : undefined,
-    TextBody: output.TextBody !== undefined && output.TextBody !== null ? output.TextBody : undefined,
+    HtmlBody: __expectString(output.HtmlBody),
+    Subject: __expectString(output.Subject),
+    TextBody: __expectString(output.TextBody),
   } as any;
 };
 
@@ -17249,8 +17173,8 @@ const deserializeAws_json1_1NumberAttributeConstraintsType = (
   context: __SerdeContext
 ): NumberAttributeConstraintsType => {
   return {
-    MaxValue: output.MaxValue !== undefined && output.MaxValue !== null ? output.MaxValue : undefined,
-    MinValue: output.MinValue !== undefined && output.MinValue !== null ? output.MinValue : undefined,
+    MaxValue: __expectString(output.MaxValue),
+    MinValue: __expectString(output.MinValue),
   } as any;
 };
 
@@ -17261,26 +17185,18 @@ const deserializeAws_json1_1OAuthFlowsType = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1PasswordPolicyType = (output: any, context: __SerdeContext): PasswordPolicyType => {
   return {
-    MinimumLength:
-      output.MinimumLength !== undefined && output.MinimumLength !== null ? output.MinimumLength : undefined,
-    RequireLowercase:
-      output.RequireLowercase !== undefined && output.RequireLowercase !== null ? output.RequireLowercase : undefined,
-    RequireNumbers:
-      output.RequireNumbers !== undefined && output.RequireNumbers !== null ? output.RequireNumbers : undefined,
-    RequireSymbols:
-      output.RequireSymbols !== undefined && output.RequireSymbols !== null ? output.RequireSymbols : undefined,
-    RequireUppercase:
-      output.RequireUppercase !== undefined && output.RequireUppercase !== null ? output.RequireUppercase : undefined,
-    TemporaryPasswordValidityDays:
-      output.TemporaryPasswordValidityDays !== undefined && output.TemporaryPasswordValidityDays !== null
-        ? output.TemporaryPasswordValidityDays
-        : undefined,
+    MinimumLength: __expectNumber(output.MinimumLength),
+    RequireLowercase: __expectBoolean(output.RequireLowercase),
+    RequireNumbers: __expectBoolean(output.RequireNumbers),
+    RequireSymbols: __expectBoolean(output.RequireSymbols),
+    RequireUppercase: __expectBoolean(output.RequireUppercase),
+    TemporaryPasswordValidityDays: __expectNumber(output.TemporaryPasswordValidityDays),
   } as any;
 };
 
@@ -17289,7 +17205,7 @@ const deserializeAws_json1_1PasswordResetRequiredException = (
   context: __SerdeContext
 ): PasswordResetRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -17298,7 +17214,7 @@ const deserializeAws_json1_1PreconditionNotMetException = (
   context: __SerdeContext
 ): PreconditionNotMetException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -17312,8 +17228,8 @@ const deserializeAws_json1_1ProviderDescription = (output: any, context: __Serde
       output.LastModifiedDate !== undefined && output.LastModifiedDate !== null
         ? new Date(Math.round(output.LastModifiedDate * 1000))
         : undefined,
-    ProviderName: output.ProviderName !== undefined && output.ProviderName !== null ? output.ProviderName : undefined,
-    ProviderType: output.ProviderType !== undefined && output.ProviderType !== null ? output.ProviderType : undefined,
+    ProviderName: __expectString(output.ProviderName),
+    ProviderType: __expectString(output.ProviderType),
   } as any;
 };
 
@@ -17324,7 +17240,7 @@ const deserializeAws_json1_1ProviderDetailsType = (output: any, context: __Serde
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -17353,8 +17269,8 @@ const deserializeAws_json1_1RecoveryMechanismsType = (output: any, context: __Se
 
 const deserializeAws_json1_1RecoveryOptionType = (output: any, context: __SerdeContext): RecoveryOptionType => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Priority: output.Priority !== undefined && output.Priority !== null ? output.Priority : undefined,
+    Name: __expectString(output.Name),
+    Priority: __expectNumber(output.Priority),
   } as any;
 };
 
@@ -17375,7 +17291,7 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -17398,9 +17314,8 @@ const deserializeAws_json1_1ResourceServerScopeType = (
   context: __SerdeContext
 ): ResourceServerScopeType => {
   return {
-    ScopeDescription:
-      output.ScopeDescription !== undefined && output.ScopeDescription !== null ? output.ScopeDescription : undefined,
-    ScopeName: output.ScopeName !== undefined && output.ScopeName !== null ? output.ScopeName : undefined,
+    ScopeDescription: __expectString(output.ScopeDescription),
+    ScopeName: __expectString(output.ScopeName),
   } as any;
 };
 
@@ -17417,13 +17332,13 @@ const deserializeAws_json1_1ResourceServersListType = (output: any, context: __S
 
 const deserializeAws_json1_1ResourceServerType = (output: any, context: __SerdeContext): ResourceServerType => {
   return {
-    Identifier: output.Identifier !== undefined && output.Identifier !== null ? output.Identifier : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Identifier: __expectString(output.Identifier),
+    Name: __expectString(output.Name),
     Scopes:
       output.Scopes !== undefined && output.Scopes !== null
         ? deserializeAws_json1_1ResourceServerScopeListType(output.Scopes, context)
         : undefined,
-    UserPoolId: output.UserPoolId !== undefined && output.UserPoolId !== null ? output.UserPoolId : undefined,
+    UserPoolId: __expectString(output.UserPoolId),
   } as any;
 };
 
@@ -17436,13 +17351,12 @@ const deserializeAws_json1_1RespondToAuthChallengeResponse = (
       output.AuthenticationResult !== undefined && output.AuthenticationResult !== null
         ? deserializeAws_json1_1AuthenticationResultType(output.AuthenticationResult, context)
         : undefined,
-    ChallengeName:
-      output.ChallengeName !== undefined && output.ChallengeName !== null ? output.ChallengeName : undefined,
+    ChallengeName: __expectString(output.ChallengeName),
     ChallengeParameters:
       output.ChallengeParameters !== undefined && output.ChallengeParameters !== null
         ? deserializeAws_json1_1ChallengeParametersType(output.ChallengeParameters, context)
         : undefined,
-    Session: output.Session !== undefined && output.Session !== null ? output.Session : undefined,
+    Session: __expectString(output.Session),
   } as any;
 };
 
@@ -17456,7 +17370,7 @@ const deserializeAws_json1_1RiskConfigurationType = (output: any, context: __Ser
       output.AccountTakeoverRiskConfiguration !== undefined && output.AccountTakeoverRiskConfiguration !== null
         ? deserializeAws_json1_1AccountTakeoverRiskConfigurationType(output.AccountTakeoverRiskConfiguration, context)
         : undefined,
-    ClientId: output.ClientId !== undefined && output.ClientId !== null ? output.ClientId : undefined,
+    ClientId: __expectString(output.ClientId),
     CompromisedCredentialsRiskConfiguration:
       output.CompromisedCredentialsRiskConfiguration !== undefined &&
       output.CompromisedCredentialsRiskConfiguration !== null
@@ -17473,7 +17387,7 @@ const deserializeAws_json1_1RiskConfigurationType = (output: any, context: __Ser
       output.RiskExceptionConfiguration !== undefined && output.RiskExceptionConfiguration !== null
         ? deserializeAws_json1_1RiskExceptionConfigurationType(output.RiskExceptionConfiguration, context)
         : undefined,
-    UserPoolId: output.UserPoolId !== undefined && output.UserPoolId !== null ? output.UserPoolId : undefined,
+    UserPoolId: __expectString(output.UserPoolId),
   } as any;
 };
 
@@ -17509,21 +17423,15 @@ const deserializeAws_json1_1SchemaAttributesListType = (
 
 const deserializeAws_json1_1SchemaAttributeType = (output: any, context: __SerdeContext): SchemaAttributeType => {
   return {
-    AttributeDataType:
-      output.AttributeDataType !== undefined && output.AttributeDataType !== null
-        ? output.AttributeDataType
-        : undefined,
-    DeveloperOnlyAttribute:
-      output.DeveloperOnlyAttribute !== undefined && output.DeveloperOnlyAttribute !== null
-        ? output.DeveloperOnlyAttribute
-        : undefined,
-    Mutable: output.Mutable !== undefined && output.Mutable !== null ? output.Mutable : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    AttributeDataType: __expectString(output.AttributeDataType),
+    DeveloperOnlyAttribute: __expectBoolean(output.DeveloperOnlyAttribute),
+    Mutable: __expectBoolean(output.Mutable),
+    Name: __expectString(output.Name),
     NumberAttributeConstraints:
       output.NumberAttributeConstraints !== undefined && output.NumberAttributeConstraints !== null
         ? deserializeAws_json1_1NumberAttributeConstraintsType(output.NumberAttributeConstraints, context)
         : undefined,
-    Required: output.Required !== undefined && output.Required !== null ? output.Required : undefined,
+    Required: __expectBoolean(output.Required),
     StringAttributeConstraints:
       output.StringAttributeConstraints !== undefined && output.StringAttributeConstraints !== null
         ? deserializeAws_json1_1StringAttributeConstraintsType(output.StringAttributeConstraints, context)
@@ -17536,7 +17444,7 @@ const deserializeAws_json1_1ScopeDoesNotExistException = (
   context: __SerdeContext
 ): ScopeDoesNotExistException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -17547,7 +17455,7 @@ const deserializeAws_json1_1ScopeListType = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -17587,8 +17495,7 @@ const deserializeAws_json1_1SetUserPoolMfaConfigResponse = (
   context: __SerdeContext
 ): SetUserPoolMfaConfigResponse => {
   return {
-    MfaConfiguration:
-      output.MfaConfiguration !== undefined && output.MfaConfiguration !== null ? output.MfaConfiguration : undefined,
+    MfaConfiguration: __expectString(output.MfaConfiguration),
     SmsMfaConfiguration:
       output.SmsMfaConfiguration !== undefined && output.SmsMfaConfiguration !== null
         ? deserializeAws_json1_1SmsMfaConfigType(output.SmsMfaConfiguration, context)
@@ -17613,9 +17520,8 @@ const deserializeAws_json1_1SignUpResponse = (output: any, context: __SerdeConte
       output.CodeDeliveryDetails !== undefined && output.CodeDeliveryDetails !== null
         ? deserializeAws_json1_1CodeDeliveryDetailsType(output.CodeDeliveryDetails, context)
         : undefined,
-    UserConfirmed:
-      output.UserConfirmed !== undefined && output.UserConfirmed !== null ? output.UserConfirmed : undefined,
-    UserSub: output.UserSub !== undefined && output.UserSub !== null ? output.UserSub : undefined,
+    UserConfirmed: __expectBoolean(output.UserConfirmed),
+    UserSub: __expectString(output.UserSub),
   } as any;
 };
 
@@ -17626,23 +17532,20 @@ const deserializeAws_json1_1SkippedIPRangeListType = (output: any, context: __Se
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1SmsConfigurationType = (output: any, context: __SerdeContext): SmsConfigurationType => {
   return {
-    ExternalId: output.ExternalId !== undefined && output.ExternalId !== null ? output.ExternalId : undefined,
-    SnsCallerArn: output.SnsCallerArn !== undefined && output.SnsCallerArn !== null ? output.SnsCallerArn : undefined,
+    ExternalId: __expectString(output.ExternalId),
+    SnsCallerArn: __expectString(output.SnsCallerArn),
   } as any;
 };
 
 const deserializeAws_json1_1SmsMfaConfigType = (output: any, context: __SerdeContext): SmsMfaConfigType => {
   return {
-    SmsAuthenticationMessage:
-      output.SmsAuthenticationMessage !== undefined && output.SmsAuthenticationMessage !== null
-        ? output.SmsAuthenticationMessage
-        : undefined,
+    SmsAuthenticationMessage: __expectString(output.SmsAuthenticationMessage),
     SmsConfiguration:
       output.SmsConfiguration !== undefined && output.SmsConfiguration !== null
         ? deserializeAws_json1_1SmsConfigurationType(output.SmsConfiguration, context)
@@ -17655,7 +17558,7 @@ const deserializeAws_json1_1SoftwareTokenMfaConfigType = (
   context: __SerdeContext
 ): SoftwareTokenMfaConfigType => {
   return {
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
+    Enabled: __expectBoolean(output.Enabled),
   } as any;
 };
 
@@ -17664,7 +17567,7 @@ const deserializeAws_json1_1SoftwareTokenMFANotFoundException = (
   context: __SerdeContext
 ): SoftwareTokenMFANotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -17697,8 +17600,8 @@ const deserializeAws_json1_1StringAttributeConstraintsType = (
   context: __SerdeContext
 ): StringAttributeConstraintsType => {
   return {
-    MaxLength: output.MaxLength !== undefined && output.MaxLength !== null ? output.MaxLength : undefined,
-    MinLength: output.MinLength !== undefined && output.MinLength !== null ? output.MinLength : undefined,
+    MaxLength: __expectString(output.MaxLength),
+    MinLength: __expectString(output.MinLength),
   } as any;
 };
 
@@ -17709,7 +17612,7 @@ const deserializeAws_json1_1SupportedIdentityProvidersListType = (output: any, c
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -17719,9 +17622,9 @@ const deserializeAws_json1_1TagResourceResponse = (output: any, context: __Serde
 
 const deserializeAws_json1_1TokenValidityUnitsType = (output: any, context: __SerdeContext): TokenValidityUnitsType => {
   return {
-    AccessToken: output.AccessToken !== undefined && output.AccessToken !== null ? output.AccessToken : undefined,
-    IdToken: output.IdToken !== undefined && output.IdToken !== null ? output.IdToken : undefined,
-    RefreshToken: output.RefreshToken !== undefined && output.RefreshToken !== null ? output.RefreshToken : undefined,
+    AccessToken: __expectString(output.AccessToken),
+    IdToken: __expectString(output.IdToken),
+    RefreshToken: __expectString(output.RefreshToken),
   } as any;
 };
 
@@ -17730,7 +17633,7 @@ const deserializeAws_json1_1TooManyFailedAttemptsException = (
   context: __SerdeContext
 ): TooManyFailedAttemptsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -17739,31 +17642,31 @@ const deserializeAws_json1_1TooManyRequestsException = (
   context: __SerdeContext
 ): TooManyRequestsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1UICustomizationType = (output: any, context: __SerdeContext): UICustomizationType => {
   return {
-    CSS: output.CSS !== undefined && output.CSS !== null ? output.CSS : undefined,
-    CSSVersion: output.CSSVersion !== undefined && output.CSSVersion !== null ? output.CSSVersion : undefined,
-    ClientId: output.ClientId !== undefined && output.ClientId !== null ? output.ClientId : undefined,
+    CSS: __expectString(output.CSS),
+    CSSVersion: __expectString(output.CSSVersion),
+    ClientId: __expectString(output.ClientId),
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
         ? new Date(Math.round(output.CreationDate * 1000))
         : undefined,
-    ImageUrl: output.ImageUrl !== undefined && output.ImageUrl !== null ? output.ImageUrl : undefined,
+    ImageUrl: __expectString(output.ImageUrl),
     LastModifiedDate:
       output.LastModifiedDate !== undefined && output.LastModifiedDate !== null
         ? new Date(Math.round(output.LastModifiedDate * 1000))
         : undefined,
-    UserPoolId: output.UserPoolId !== undefined && output.UserPoolId !== null ? output.UserPoolId : undefined,
+    UserPoolId: __expectString(output.UserPoolId),
   } as any;
 };
 
 const deserializeAws_json1_1UnauthorizedException = (output: any, context: __SerdeContext): UnauthorizedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -17772,7 +17675,7 @@ const deserializeAws_json1_1UnexpectedLambdaException = (
   context: __SerdeContext
 ): UnexpectedLambdaException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -17781,7 +17684,7 @@ const deserializeAws_json1_1UnsupportedIdentityProviderException = (
   context: __SerdeContext
 ): UnsupportedIdentityProviderException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -17790,7 +17693,7 @@ const deserializeAws_json1_1UnsupportedOperationException = (
   context: __SerdeContext
 ): UnsupportedOperationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -17799,7 +17702,7 @@ const deserializeAws_json1_1UnsupportedTokenTypeException = (
   context: __SerdeContext
 ): UnsupportedTokenTypeException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -17808,7 +17711,7 @@ const deserializeAws_json1_1UnsupportedUserStateException = (
   context: __SerdeContext
 ): UnsupportedUserStateException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -17892,8 +17795,7 @@ const deserializeAws_json1_1UpdateUserPoolDomainResponse = (
   context: __SerdeContext
 ): UpdateUserPoolDomainResponse => {
   return {
-    CloudFrontDomain:
-      output.CloudFrontDomain !== undefined && output.CloudFrontDomain !== null ? output.CloudFrontDomain : undefined,
+    CloudFrontDomain: __expectString(output.CloudFrontDomain),
   } as any;
 };
 
@@ -17906,7 +17808,7 @@ const deserializeAws_json1_1UserImportInProgressException = (
   context: __SerdeContext
 ): UserImportInProgressException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -17923,35 +17825,28 @@ const deserializeAws_json1_1UserImportJobsListType = (output: any, context: __Se
 
 const deserializeAws_json1_1UserImportJobType = (output: any, context: __SerdeContext): UserImportJobType => {
   return {
-    CloudWatchLogsRoleArn:
-      output.CloudWatchLogsRoleArn !== undefined && output.CloudWatchLogsRoleArn !== null
-        ? output.CloudWatchLogsRoleArn
-        : undefined,
+    CloudWatchLogsRoleArn: __expectString(output.CloudWatchLogsRoleArn),
     CompletionDate:
       output.CompletionDate !== undefined && output.CompletionDate !== null
         ? new Date(Math.round(output.CompletionDate * 1000))
         : undefined,
-    CompletionMessage:
-      output.CompletionMessage !== undefined && output.CompletionMessage !== null
-        ? output.CompletionMessage
-        : undefined,
+    CompletionMessage: __expectString(output.CompletionMessage),
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
         ? new Date(Math.round(output.CreationDate * 1000))
         : undefined,
-    FailedUsers: output.FailedUsers !== undefined && output.FailedUsers !== null ? output.FailedUsers : undefined,
-    ImportedUsers:
-      output.ImportedUsers !== undefined && output.ImportedUsers !== null ? output.ImportedUsers : undefined,
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
-    JobName: output.JobName !== undefined && output.JobName !== null ? output.JobName : undefined,
-    PreSignedUrl: output.PreSignedUrl !== undefined && output.PreSignedUrl !== null ? output.PreSignedUrl : undefined,
-    SkippedUsers: output.SkippedUsers !== undefined && output.SkippedUsers !== null ? output.SkippedUsers : undefined,
+    FailedUsers: __expectNumber(output.FailedUsers),
+    ImportedUsers: __expectNumber(output.ImportedUsers),
+    JobId: __expectString(output.JobId),
+    JobName: __expectString(output.JobName),
+    PreSignedUrl: __expectString(output.PreSignedUrl),
+    SkippedUsers: __expectNumber(output.SkippedUsers),
     StartDate:
       output.StartDate !== undefined && output.StartDate !== null
         ? new Date(Math.round(output.StartDate * 1000))
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    UserPoolId: output.UserPoolId !== undefined && output.UserPoolId !== null ? output.UserPoolId : undefined,
+    Status: __expectString(output.Status),
+    UserPoolId: __expectString(output.UserPoolId),
   } as any;
 };
 
@@ -17960,7 +17855,7 @@ const deserializeAws_json1_1UserLambdaValidationException = (
   context: __SerdeContext
 ): UserLambdaValidationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -17971,7 +17866,7 @@ const deserializeAws_json1_1UserMFASettingListType = (output: any, context: __Se
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -17985,7 +17880,7 @@ const deserializeAws_json1_1UsernameAttributesListType = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -17994,8 +17889,7 @@ const deserializeAws_json1_1UsernameConfigurationType = (
   context: __SerdeContext
 ): UsernameConfigurationType => {
   return {
-    CaseSensitive:
-      output.CaseSensitive !== undefined && output.CaseSensitive !== null ? output.CaseSensitive : undefined,
+    CaseSensitive: __expectBoolean(output.CaseSensitive),
   } as any;
 };
 
@@ -18004,7 +17898,7 @@ const deserializeAws_json1_1UsernameExistsException = (
   context: __SerdeContext
 ): UsernameExistsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -18013,13 +17907,13 @@ const deserializeAws_json1_1UserNotConfirmedException = (
   context: __SerdeContext
 ): UserNotConfirmedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1UserNotFoundException = (output: any, context: __SerdeContext): UserNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -18028,16 +17922,13 @@ const deserializeAws_json1_1UserPoolAddOnNotEnabledException = (
   context: __SerdeContext
 ): UserPoolAddOnNotEnabledException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1UserPoolAddOnsType = (output: any, context: __SerdeContext): UserPoolAddOnsType => {
   return {
-    AdvancedSecurityMode:
-      output.AdvancedSecurityMode !== undefined && output.AdvancedSecurityMode !== null
-        ? output.AdvancedSecurityMode
-        : undefined,
+    AdvancedSecurityMode: __expectString(output.AdvancedSecurityMode),
   } as any;
 };
 
@@ -18046,9 +17937,9 @@ const deserializeAws_json1_1UserPoolClientDescription = (
   context: __SerdeContext
 ): UserPoolClientDescription => {
   return {
-    ClientId: output.ClientId !== undefined && output.ClientId !== null ? output.ClientId : undefined,
-    ClientName: output.ClientName !== undefined && output.ClientName !== null ? output.ClientName : undefined,
-    UserPoolId: output.UserPoolId !== undefined && output.UserPoolId !== null ? output.UserPoolId : undefined,
+    ClientId: __expectString(output.ClientId),
+    ClientName: __expectString(output.ClientName),
+    UserPoolId: __expectString(output.UserPoolId),
   } as any;
 };
 
@@ -18068,18 +17959,12 @@ const deserializeAws_json1_1UserPoolClientListType = (
 
 const deserializeAws_json1_1UserPoolClientType = (output: any, context: __SerdeContext): UserPoolClientType => {
   return {
-    AccessTokenValidity:
-      output.AccessTokenValidity !== undefined && output.AccessTokenValidity !== null
-        ? output.AccessTokenValidity
-        : undefined,
+    AccessTokenValidity: __expectNumber(output.AccessTokenValidity),
     AllowedOAuthFlows:
       output.AllowedOAuthFlows !== undefined && output.AllowedOAuthFlows !== null
         ? deserializeAws_json1_1OAuthFlowsType(output.AllowedOAuthFlows, context)
         : undefined,
-    AllowedOAuthFlowsUserPoolClient:
-      output.AllowedOAuthFlowsUserPoolClient !== undefined && output.AllowedOAuthFlowsUserPoolClient !== null
-        ? output.AllowedOAuthFlowsUserPoolClient
-        : undefined,
+    AllowedOAuthFlowsUserPoolClient: __expectBoolean(output.AllowedOAuthFlowsUserPoolClient),
     AllowedOAuthScopes:
       output.AllowedOAuthScopes !== undefined && output.AllowedOAuthScopes !== null
         ? deserializeAws_json1_1ScopeListType(output.AllowedOAuthScopes, context)
@@ -18092,27 +17977,20 @@ const deserializeAws_json1_1UserPoolClientType = (output: any, context: __SerdeC
       output.CallbackURLs !== undefined && output.CallbackURLs !== null
         ? deserializeAws_json1_1CallbackURLsListType(output.CallbackURLs, context)
         : undefined,
-    ClientId: output.ClientId !== undefined && output.ClientId !== null ? output.ClientId : undefined,
-    ClientName: output.ClientName !== undefined && output.ClientName !== null ? output.ClientName : undefined,
-    ClientSecret: output.ClientSecret !== undefined && output.ClientSecret !== null ? output.ClientSecret : undefined,
+    ClientId: __expectString(output.ClientId),
+    ClientName: __expectString(output.ClientName),
+    ClientSecret: __expectString(output.ClientSecret),
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
         ? new Date(Math.round(output.CreationDate * 1000))
         : undefined,
-    DefaultRedirectURI:
-      output.DefaultRedirectURI !== undefined && output.DefaultRedirectURI !== null
-        ? output.DefaultRedirectURI
-        : undefined,
-    EnableTokenRevocation:
-      output.EnableTokenRevocation !== undefined && output.EnableTokenRevocation !== null
-        ? output.EnableTokenRevocation
-        : undefined,
+    DefaultRedirectURI: __expectString(output.DefaultRedirectURI),
+    EnableTokenRevocation: __expectBoolean(output.EnableTokenRevocation),
     ExplicitAuthFlows:
       output.ExplicitAuthFlows !== undefined && output.ExplicitAuthFlows !== null
         ? deserializeAws_json1_1ExplicitAuthFlowsListType(output.ExplicitAuthFlows, context)
         : undefined,
-    IdTokenValidity:
-      output.IdTokenValidity !== undefined && output.IdTokenValidity !== null ? output.IdTokenValidity : undefined,
+    IdTokenValidity: __expectNumber(output.IdTokenValidity),
     LastModifiedDate:
       output.LastModifiedDate !== undefined && output.LastModifiedDate !== null
         ? new Date(Math.round(output.LastModifiedDate * 1000))
@@ -18121,18 +17999,12 @@ const deserializeAws_json1_1UserPoolClientType = (output: any, context: __SerdeC
       output.LogoutURLs !== undefined && output.LogoutURLs !== null
         ? deserializeAws_json1_1LogoutURLsListType(output.LogoutURLs, context)
         : undefined,
-    PreventUserExistenceErrors:
-      output.PreventUserExistenceErrors !== undefined && output.PreventUserExistenceErrors !== null
-        ? output.PreventUserExistenceErrors
-        : undefined,
+    PreventUserExistenceErrors: __expectString(output.PreventUserExistenceErrors),
     ReadAttributes:
       output.ReadAttributes !== undefined && output.ReadAttributes !== null
         ? deserializeAws_json1_1ClientPermissionListType(output.ReadAttributes, context)
         : undefined,
-    RefreshTokenValidity:
-      output.RefreshTokenValidity !== undefined && output.RefreshTokenValidity !== null
-        ? output.RefreshTokenValidity
-        : undefined,
+    RefreshTokenValidity: __expectNumber(output.RefreshTokenValidity),
     SupportedIdentityProviders:
       output.SupportedIdentityProviders !== undefined && output.SupportedIdentityProviders !== null
         ? deserializeAws_json1_1SupportedIdentityProvidersListType(output.SupportedIdentityProviders, context)
@@ -18141,7 +18013,7 @@ const deserializeAws_json1_1UserPoolClientType = (output: any, context: __SerdeC
       output.TokenValidityUnits !== undefined && output.TokenValidityUnits !== null
         ? deserializeAws_json1_1TokenValidityUnitsType(output.TokenValidityUnits, context)
         : undefined,
-    UserPoolId: output.UserPoolId !== undefined && output.UserPoolId !== null ? output.UserPoolId : undefined,
+    UserPoolId: __expectString(output.UserPoolId),
     WriteAttributes:
       output.WriteAttributes !== undefined && output.WriteAttributes !== null
         ? deserializeAws_json1_1ClientPermissionListType(output.WriteAttributes, context)
@@ -18158,7 +18030,7 @@ const deserializeAws_json1_1UserPoolDescriptionType = (
       output.CreationDate !== undefined && output.CreationDate !== null
         ? new Date(Math.round(output.CreationDate * 1000))
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    Id: __expectString(output.Id),
     LambdaConfig:
       output.LambdaConfig !== undefined && output.LambdaConfig !== null
         ? deserializeAws_json1_1LambdaConfigType(output.LambdaConfig, context)
@@ -18167,8 +18039,8 @@ const deserializeAws_json1_1UserPoolDescriptionType = (
       output.LastModifiedDate !== undefined && output.LastModifiedDate !== null
         ? new Date(Math.round(output.LastModifiedDate * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Name: __expectString(output.Name),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -18197,7 +18069,7 @@ const deserializeAws_json1_1UserPoolTaggingException = (
   context: __SerdeContext
 ): UserPoolTaggingException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -18208,7 +18080,7 @@ const deserializeAws_json1_1UserPoolTagsType = (output: any, context: __SerdeCon
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -18227,7 +18099,7 @@ const deserializeAws_json1_1UserPoolType = (output: any, context: __SerdeContext
       output.AliasAttributes !== undefined && output.AliasAttributes !== null
         ? deserializeAws_json1_1AliasAttributesListType(output.AliasAttributes, context)
         : undefined,
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     AutoVerifiedAttributes:
       output.AutoVerifiedAttributes !== undefined && output.AutoVerifiedAttributes !== null
         ? deserializeAws_json1_1VerifiedAttributesListType(output.AutoVerifiedAttributes, context)
@@ -18236,33 +18108,21 @@ const deserializeAws_json1_1UserPoolType = (output: any, context: __SerdeContext
       output.CreationDate !== undefined && output.CreationDate !== null
         ? new Date(Math.round(output.CreationDate * 1000))
         : undefined,
-    CustomDomain: output.CustomDomain !== undefined && output.CustomDomain !== null ? output.CustomDomain : undefined,
+    CustomDomain: __expectString(output.CustomDomain),
     DeviceConfiguration:
       output.DeviceConfiguration !== undefined && output.DeviceConfiguration !== null
         ? deserializeAws_json1_1DeviceConfigurationType(output.DeviceConfiguration, context)
         : undefined,
-    Domain: output.Domain !== undefined && output.Domain !== null ? output.Domain : undefined,
+    Domain: __expectString(output.Domain),
     EmailConfiguration:
       output.EmailConfiguration !== undefined && output.EmailConfiguration !== null
         ? deserializeAws_json1_1EmailConfigurationType(output.EmailConfiguration, context)
         : undefined,
-    EmailConfigurationFailure:
-      output.EmailConfigurationFailure !== undefined && output.EmailConfigurationFailure !== null
-        ? output.EmailConfigurationFailure
-        : undefined,
-    EmailVerificationMessage:
-      output.EmailVerificationMessage !== undefined && output.EmailVerificationMessage !== null
-        ? output.EmailVerificationMessage
-        : undefined,
-    EmailVerificationSubject:
-      output.EmailVerificationSubject !== undefined && output.EmailVerificationSubject !== null
-        ? output.EmailVerificationSubject
-        : undefined,
-    EstimatedNumberOfUsers:
-      output.EstimatedNumberOfUsers !== undefined && output.EstimatedNumberOfUsers !== null
-        ? output.EstimatedNumberOfUsers
-        : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    EmailConfigurationFailure: __expectString(output.EmailConfigurationFailure),
+    EmailVerificationMessage: __expectString(output.EmailVerificationMessage),
+    EmailVerificationSubject: __expectString(output.EmailVerificationSubject),
+    EstimatedNumberOfUsers: __expectNumber(output.EstimatedNumberOfUsers),
+    Id: __expectString(output.Id),
     LambdaConfig:
       output.LambdaConfig !== undefined && output.LambdaConfig !== null
         ? deserializeAws_json1_1LambdaConfigType(output.LambdaConfig, context)
@@ -18271,9 +18131,8 @@ const deserializeAws_json1_1UserPoolType = (output: any, context: __SerdeContext
       output.LastModifiedDate !== undefined && output.LastModifiedDate !== null
         ? new Date(Math.round(output.LastModifiedDate * 1000))
         : undefined,
-    MfaConfiguration:
-      output.MfaConfiguration !== undefined && output.MfaConfiguration !== null ? output.MfaConfiguration : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    MfaConfiguration: __expectString(output.MfaConfiguration),
+    Name: __expectString(output.Name),
     Policies:
       output.Policies !== undefined && output.Policies !== null
         ? deserializeAws_json1_1UserPoolPolicyType(output.Policies, context)
@@ -18282,23 +18141,14 @@ const deserializeAws_json1_1UserPoolType = (output: any, context: __SerdeContext
       output.SchemaAttributes !== undefined && output.SchemaAttributes !== null
         ? deserializeAws_json1_1SchemaAttributesListType(output.SchemaAttributes, context)
         : undefined,
-    SmsAuthenticationMessage:
-      output.SmsAuthenticationMessage !== undefined && output.SmsAuthenticationMessage !== null
-        ? output.SmsAuthenticationMessage
-        : undefined,
+    SmsAuthenticationMessage: __expectString(output.SmsAuthenticationMessage),
     SmsConfiguration:
       output.SmsConfiguration !== undefined && output.SmsConfiguration !== null
         ? deserializeAws_json1_1SmsConfigurationType(output.SmsConfiguration, context)
         : undefined,
-    SmsConfigurationFailure:
-      output.SmsConfigurationFailure !== undefined && output.SmsConfigurationFailure !== null
-        ? output.SmsConfigurationFailure
-        : undefined,
-    SmsVerificationMessage:
-      output.SmsVerificationMessage !== undefined && output.SmsVerificationMessage !== null
-        ? output.SmsVerificationMessage
-        : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    SmsConfigurationFailure: __expectString(output.SmsConfigurationFailure),
+    SmsVerificationMessage: __expectString(output.SmsVerificationMessage),
+    Status: __expectString(output.Status),
     UserPoolAddOns:
       output.UserPoolAddOns !== undefined && output.UserPoolAddOns !== null
         ? deserializeAws_json1_1UserPoolAddOnsType(output.UserPoolAddOns, context)
@@ -18339,7 +18189,7 @@ const deserializeAws_json1_1UserType = (output: any, context: __SerdeContext): U
       output.Attributes !== undefined && output.Attributes !== null
         ? deserializeAws_json1_1AttributeListType(output.Attributes, context)
         : undefined,
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
+    Enabled: __expectBoolean(output.Enabled),
     MFAOptions:
       output.MFAOptions !== undefined && output.MFAOptions !== null
         ? deserializeAws_json1_1MFAOptionListType(output.MFAOptions, context)
@@ -18352,8 +18202,8 @@ const deserializeAws_json1_1UserType = (output: any, context: __SerdeContext): U
       output.UserLastModifiedDate !== undefined && output.UserLastModifiedDate !== null
         ? new Date(Math.round(output.UserLastModifiedDate * 1000))
         : undefined,
-    UserStatus: output.UserStatus !== undefined && output.UserStatus !== null ? output.UserStatus : undefined,
-    Username: output.Username !== undefined && output.Username !== null ? output.Username : undefined,
+    UserStatus: __expectString(output.UserStatus),
+    Username: __expectString(output.Username),
   } as any;
 };
 
@@ -18362,21 +18212,12 @@ const deserializeAws_json1_1VerificationMessageTemplateType = (
   context: __SerdeContext
 ): VerificationMessageTemplateType => {
   return {
-    DefaultEmailOption:
-      output.DefaultEmailOption !== undefined && output.DefaultEmailOption !== null
-        ? output.DefaultEmailOption
-        : undefined,
-    EmailMessage: output.EmailMessage !== undefined && output.EmailMessage !== null ? output.EmailMessage : undefined,
-    EmailMessageByLink:
-      output.EmailMessageByLink !== undefined && output.EmailMessageByLink !== null
-        ? output.EmailMessageByLink
-        : undefined,
-    EmailSubject: output.EmailSubject !== undefined && output.EmailSubject !== null ? output.EmailSubject : undefined,
-    EmailSubjectByLink:
-      output.EmailSubjectByLink !== undefined && output.EmailSubjectByLink !== null
-        ? output.EmailSubjectByLink
-        : undefined,
-    SmsMessage: output.SmsMessage !== undefined && output.SmsMessage !== null ? output.SmsMessage : undefined,
+    DefaultEmailOption: __expectString(output.DefaultEmailOption),
+    EmailMessage: __expectString(output.EmailMessage),
+    EmailMessageByLink: __expectString(output.EmailMessageByLink),
+    EmailSubject: __expectString(output.EmailSubject),
+    EmailSubjectByLink: __expectString(output.EmailSubjectByLink),
+    SmsMessage: __expectString(output.SmsMessage),
   } as any;
 };
 
@@ -18390,7 +18231,7 @@ const deserializeAws_json1_1VerifiedAttributesListType = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -18399,8 +18240,8 @@ const deserializeAws_json1_1VerifySoftwareTokenResponse = (
   context: __SerdeContext
 ): VerifySoftwareTokenResponse => {
   return {
-    Session: output.Session !== undefined && output.Session !== null ? output.Session : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Session: __expectString(output.Session),
+    Status: __expectString(output.Status),
   } as any;
 };
 

--- a/clients/client-cognito-identity/protocols/Aws_json1_1.ts
+++ b/clients/client-cognito-identity/protocols/Aws_json1_1.ts
@@ -114,7 +114,11 @@ import {
   UntagResourceResponse,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -3218,12 +3222,9 @@ const deserializeAws_json1_1CognitoIdentityProvider = (
   context: __SerdeContext
 ): CognitoIdentityProvider => {
   return {
-    ClientId: output.ClientId !== undefined && output.ClientId !== null ? output.ClientId : undefined,
-    ProviderName: output.ProviderName !== undefined && output.ProviderName !== null ? output.ProviderName : undefined,
-    ServerSideTokenCheck:
-      output.ServerSideTokenCheck !== undefined && output.ServerSideTokenCheck !== null
-        ? output.ServerSideTokenCheck
-        : undefined,
+    ClientId: __expectString(output.ClientId),
+    ProviderName: __expectString(output.ProviderName),
+    ServerSideTokenCheck: __expectBoolean(output.ServerSideTokenCheck),
   } as any;
 };
 
@@ -3246,19 +3247,19 @@ const deserializeAws_json1_1ConcurrentModificationException = (
   context: __SerdeContext
 ): ConcurrentModificationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1Credentials = (output: any, context: __SerdeContext): Credentials => {
   return {
-    AccessKeyId: output.AccessKeyId !== undefined && output.AccessKeyId !== null ? output.AccessKeyId : undefined,
+    AccessKeyId: __expectString(output.AccessKeyId),
     Expiration:
       output.Expiration !== undefined && output.Expiration !== null
         ? new Date(Math.round(output.Expiration * 1000))
         : undefined,
-    SecretKey: output.SecretKey !== undefined && output.SecretKey !== null ? output.SecretKey : undefined,
-    SessionToken: output.SessionToken !== undefined && output.SessionToken !== null ? output.SessionToken : undefined,
+    SecretKey: __expectString(output.SecretKey),
+    SessionToken: __expectString(output.SessionToken),
   } as any;
 };
 
@@ -3279,7 +3280,7 @@ const deserializeAws_json1_1DeveloperUserAlreadyRegisteredException = (
   context: __SerdeContext
 ): DeveloperUserAlreadyRegisteredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3290,7 +3291,7 @@ const deserializeAws_json1_1DeveloperUserIdentifierList = (output: any, context:
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3299,7 +3300,7 @@ const deserializeAws_json1_1ExternalServiceException = (
   context: __SerdeContext
 ): ExternalServiceException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3312,7 +3313,7 @@ const deserializeAws_json1_1GetCredentialsForIdentityResponse = (
       output.Credentials !== undefined && output.Credentials !== null
         ? deserializeAws_json1_1Credentials(output.Credentials, context)
         : undefined,
-    IdentityId: output.IdentityId !== undefined && output.IdentityId !== null ? output.IdentityId : undefined,
+    IdentityId: __expectString(output.IdentityId),
   } as any;
 };
 
@@ -3321,8 +3322,7 @@ const deserializeAws_json1_1GetIdentityPoolRolesResponse = (
   context: __SerdeContext
 ): GetIdentityPoolRolesResponse => {
   return {
-    IdentityPoolId:
-      output.IdentityPoolId !== undefined && output.IdentityPoolId !== null ? output.IdentityPoolId : undefined,
+    IdentityPoolId: __expectString(output.IdentityPoolId),
     RoleMappings:
       output.RoleMappings !== undefined && output.RoleMappings !== null
         ? deserializeAws_json1_1RoleMappingMap(output.RoleMappings, context)
@@ -3336,7 +3336,7 @@ const deserializeAws_json1_1GetIdentityPoolRolesResponse = (
 
 const deserializeAws_json1_1GetIdResponse = (output: any, context: __SerdeContext): GetIdResponse => {
   return {
-    IdentityId: output.IdentityId !== undefined && output.IdentityId !== null ? output.IdentityId : undefined,
+    IdentityId: __expectString(output.IdentityId),
   } as any;
 };
 
@@ -3345,15 +3345,15 @@ const deserializeAws_json1_1GetOpenIdTokenForDeveloperIdentityResponse = (
   context: __SerdeContext
 ): GetOpenIdTokenForDeveloperIdentityResponse => {
   return {
-    IdentityId: output.IdentityId !== undefined && output.IdentityId !== null ? output.IdentityId : undefined,
-    Token: output.Token !== undefined && output.Token !== null ? output.Token : undefined,
+    IdentityId: __expectString(output.IdentityId),
+    Token: __expectString(output.Token),
   } as any;
 };
 
 const deserializeAws_json1_1GetOpenIdTokenResponse = (output: any, context: __SerdeContext): GetOpenIdTokenResponse => {
   return {
-    IdentityId: output.IdentityId !== undefined && output.IdentityId !== null ? output.IdentityId : undefined,
-    Token: output.Token !== undefined && output.Token !== null ? output.Token : undefined,
+    IdentityId: __expectString(output.IdentityId),
+    Token: __expectString(output.Token),
   } as any;
 };
 
@@ -3362,17 +3362,13 @@ const deserializeAws_json1_1GetPrincipalTagAttributeMapResponse = (
   context: __SerdeContext
 ): GetPrincipalTagAttributeMapResponse => {
   return {
-    IdentityPoolId:
-      output.IdentityPoolId !== undefined && output.IdentityPoolId !== null ? output.IdentityPoolId : undefined,
-    IdentityProviderName:
-      output.IdentityProviderName !== undefined && output.IdentityProviderName !== null
-        ? output.IdentityProviderName
-        : undefined,
+    IdentityPoolId: __expectString(output.IdentityPoolId),
+    IdentityProviderName: __expectString(output.IdentityProviderName),
     PrincipalTags:
       output.PrincipalTags !== undefined && output.PrincipalTags !== null
         ? deserializeAws_json1_1PrincipalTags(output.PrincipalTags, context)
         : undefined,
-    UseDefaults: output.UseDefaults !== undefined && output.UseDefaults !== null ? output.UseDefaults : undefined,
+    UseDefaults: __expectBoolean(output.UseDefaults),
   } as any;
 };
 
@@ -3393,7 +3389,7 @@ const deserializeAws_json1_1IdentityDescription = (output: any, context: __Serde
       output.CreationDate !== undefined && output.CreationDate !== null
         ? new Date(Math.round(output.CreationDate * 1000))
         : undefined,
-    IdentityId: output.IdentityId !== undefined && output.IdentityId !== null ? output.IdentityId : undefined,
+    IdentityId: __expectString(output.IdentityId),
     LastModifiedDate:
       output.LastModifiedDate !== undefined && output.LastModifiedDate !== null
         ? new Date(Math.round(output.LastModifiedDate * 1000))
@@ -3407,24 +3403,15 @@ const deserializeAws_json1_1IdentityDescription = (output: any, context: __Serde
 
 const deserializeAws_json1_1IdentityPool = (output: any, context: __SerdeContext): IdentityPool => {
   return {
-    AllowClassicFlow:
-      output.AllowClassicFlow !== undefined && output.AllowClassicFlow !== null ? output.AllowClassicFlow : undefined,
-    AllowUnauthenticatedIdentities:
-      output.AllowUnauthenticatedIdentities !== undefined && output.AllowUnauthenticatedIdentities !== null
-        ? output.AllowUnauthenticatedIdentities
-        : undefined,
+    AllowClassicFlow: __expectBoolean(output.AllowClassicFlow),
+    AllowUnauthenticatedIdentities: __expectBoolean(output.AllowUnauthenticatedIdentities),
     CognitoIdentityProviders:
       output.CognitoIdentityProviders !== undefined && output.CognitoIdentityProviders !== null
         ? deserializeAws_json1_1CognitoIdentityProviderList(output.CognitoIdentityProviders, context)
         : undefined,
-    DeveloperProviderName:
-      output.DeveloperProviderName !== undefined && output.DeveloperProviderName !== null
-        ? output.DeveloperProviderName
-        : undefined,
-    IdentityPoolId:
-      output.IdentityPoolId !== undefined && output.IdentityPoolId !== null ? output.IdentityPoolId : undefined,
-    IdentityPoolName:
-      output.IdentityPoolName !== undefined && output.IdentityPoolName !== null ? output.IdentityPoolName : undefined,
+    DeveloperProviderName: __expectString(output.DeveloperProviderName),
+    IdentityPoolId: __expectString(output.IdentityPoolId),
+    IdentityPoolName: __expectString(output.IdentityPoolName),
     IdentityPoolTags:
       output.IdentityPoolTags !== undefined && output.IdentityPoolTags !== null
         ? deserializeAws_json1_1IdentityPoolTagsType(output.IdentityPoolTags, context)
@@ -3449,10 +3436,8 @@ const deserializeAws_json1_1IdentityPoolShortDescription = (
   context: __SerdeContext
 ): IdentityPoolShortDescription => {
   return {
-    IdentityPoolId:
-      output.IdentityPoolId !== undefined && output.IdentityPoolId !== null ? output.IdentityPoolId : undefined,
-    IdentityPoolName:
-      output.IdentityPoolName !== undefined && output.IdentityPoolName !== null ? output.IdentityPoolName : undefined,
+    IdentityPoolId: __expectString(output.IdentityPoolId),
+    IdentityPoolName: __expectString(output.IdentityPoolName),
   } as any;
 };
 
@@ -3480,7 +3465,7 @@ const deserializeAws_json1_1IdentityPoolTagsType = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -3492,14 +3477,14 @@ const deserializeAws_json1_1IdentityProviders = (output: any, context: __SerdeCo
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_json1_1InternalErrorException = (output: any, context: __SerdeContext): InternalErrorException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3508,7 +3493,7 @@ const deserializeAws_json1_1InvalidIdentityPoolConfigurationException = (
   context: __SerdeContext
 ): InvalidIdentityPoolConfigurationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3517,13 +3502,13 @@ const deserializeAws_json1_1InvalidParameterException = (
   context: __SerdeContext
 ): InvalidParameterException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3533,9 +3518,8 @@ const deserializeAws_json1_1ListIdentitiesResponse = (output: any, context: __Se
       output.Identities !== undefined && output.Identities !== null
         ? deserializeAws_json1_1IdentitiesList(output.Identities, context)
         : undefined,
-    IdentityPoolId:
-      output.IdentityPoolId !== undefined && output.IdentityPoolId !== null ? output.IdentityPoolId : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    IdentityPoolId: __expectString(output.IdentityPoolId),
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -3548,7 +3532,7 @@ const deserializeAws_json1_1ListIdentityPoolsResponse = (
       output.IdentityPools !== undefined && output.IdentityPools !== null
         ? deserializeAws_json1_1IdentityPoolsList(output.IdentityPools, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -3571,7 +3555,7 @@ const deserializeAws_json1_1LoginsList = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3584,17 +3568,17 @@ const deserializeAws_json1_1LookupDeveloperIdentityResponse = (
       output.DeveloperUserIdentifierList !== undefined && output.DeveloperUserIdentifierList !== null
         ? deserializeAws_json1_1DeveloperUserIdentifierList(output.DeveloperUserIdentifierList, context)
         : undefined,
-    IdentityId: output.IdentityId !== undefined && output.IdentityId !== null ? output.IdentityId : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    IdentityId: __expectString(output.IdentityId),
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
 const deserializeAws_json1_1MappingRule = (output: any, context: __SerdeContext): MappingRule => {
   return {
-    Claim: output.Claim !== undefined && output.Claim !== null ? output.Claim : undefined,
-    MatchType: output.MatchType !== undefined && output.MatchType !== null ? output.MatchType : undefined,
-    RoleARN: output.RoleARN !== undefined && output.RoleARN !== null ? output.RoleARN : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Claim: __expectString(output.Claim),
+    MatchType: __expectString(output.MatchType),
+    RoleARN: __expectString(output.RoleARN),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -3614,13 +3598,13 @@ const deserializeAws_json1_1MergeDeveloperIdentitiesResponse = (
   context: __SerdeContext
 ): MergeDeveloperIdentitiesResponse => {
   return {
-    IdentityId: output.IdentityId !== undefined && output.IdentityId !== null ? output.IdentityId : undefined,
+    IdentityId: __expectString(output.IdentityId),
   } as any;
 };
 
 const deserializeAws_json1_1NotAuthorizedException = (output: any, context: __SerdeContext): NotAuthorizedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3631,7 +3615,7 @@ const deserializeAws_json1_1OIDCProviderList = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3642,7 +3626,7 @@ const deserializeAws_json1_1PrincipalTags = (output: any, context: __SerdeContex
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -3652,7 +3636,7 @@ const deserializeAws_json1_1ResourceConflictException = (
   context: __SerdeContext
 ): ResourceConflictException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3661,21 +3645,18 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1RoleMapping = (output: any, context: __SerdeContext): RoleMapping => {
   return {
-    AmbiguousRoleResolution:
-      output.AmbiguousRoleResolution !== undefined && output.AmbiguousRoleResolution !== null
-        ? output.AmbiguousRoleResolution
-        : undefined,
+    AmbiguousRoleResolution: __expectString(output.AmbiguousRoleResolution),
     RulesConfiguration:
       output.RulesConfiguration !== undefined && output.RulesConfiguration !== null
         ? deserializeAws_json1_1RulesConfigurationType(output.RulesConfiguration, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -3698,7 +3679,7 @@ const deserializeAws_json1_1RolesMap = (output: any, context: __SerdeContext): {
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -3719,7 +3700,7 @@ const deserializeAws_json1_1SAMLProviderList = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3728,17 +3709,13 @@ const deserializeAws_json1_1SetPrincipalTagAttributeMapResponse = (
   context: __SerdeContext
 ): SetPrincipalTagAttributeMapResponse => {
   return {
-    IdentityPoolId:
-      output.IdentityPoolId !== undefined && output.IdentityPoolId !== null ? output.IdentityPoolId : undefined,
-    IdentityProviderName:
-      output.IdentityProviderName !== undefined && output.IdentityProviderName !== null
-        ? output.IdentityProviderName
-        : undefined,
+    IdentityPoolId: __expectString(output.IdentityPoolId),
+    IdentityProviderName: __expectString(output.IdentityProviderName),
     PrincipalTags:
       output.PrincipalTags !== undefined && output.PrincipalTags !== null
         ? deserializeAws_json1_1PrincipalTags(output.PrincipalTags, context)
         : undefined,
-    UseDefaults: output.UseDefaults !== undefined && output.UseDefaults !== null ? output.UseDefaults : undefined,
+    UseDefaults: __expectBoolean(output.UseDefaults),
   } as any;
 };
 
@@ -3751,14 +3728,14 @@ const deserializeAws_json1_1TooManyRequestsException = (
   context: __SerdeContext
 ): TooManyRequestsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1UnprocessedIdentityId = (output: any, context: __SerdeContext): UnprocessedIdentityId => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    IdentityId: output.IdentityId !== undefined && output.IdentityId !== null ? output.IdentityId : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    IdentityId: __expectString(output.IdentityId),
   } as any;
 };
 

--- a/clients/client-cognito-sync/protocols/Aws_restJson1.ts
+++ b/clients/client-cognito-sync/protocols/Aws_restJson1.ts
@@ -61,6 +61,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -756,7 +759,7 @@ export const deserializeAws_restJson1BulkPublishCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.IdentityPoolId !== undefined && data.IdentityPoolId !== null) {
-    contents.IdentityPoolId = data.IdentityPoolId;
+    contents.IdentityPoolId = __expectString(data.IdentityPoolId);
   }
   return Promise.resolve(contents);
 };
@@ -1217,13 +1220,13 @@ export const deserializeAws_restJson1GetBulkPublishDetailsCommand = async (
     contents.BulkPublishStartTime = new Date(Math.round(data.BulkPublishStartTime * 1000));
   }
   if (data.BulkPublishStatus !== undefined && data.BulkPublishStatus !== null) {
-    contents.BulkPublishStatus = data.BulkPublishStatus;
+    contents.BulkPublishStatus = __expectString(data.BulkPublishStatus);
   }
   if (data.FailureMessage !== undefined && data.FailureMessage !== null) {
-    contents.FailureMessage = data.FailureMessage;
+    contents.FailureMessage = __expectString(data.FailureMessage);
   }
   if (data.IdentityPoolId !== undefined && data.IdentityPoolId !== null) {
-    contents.IdentityPoolId = data.IdentityPoolId;
+    contents.IdentityPoolId = __expectString(data.IdentityPoolId);
   }
   return Promise.resolve(contents);
 };
@@ -1394,7 +1397,7 @@ export const deserializeAws_restJson1GetIdentityPoolConfigurationCommand = async
     contents.CognitoStreams = deserializeAws_restJson1CognitoStreams(data.CognitoStreams, context);
   }
   if (data.IdentityPoolId !== undefined && data.IdentityPoolId !== null) {
-    contents.IdentityPoolId = data.IdentityPoolId;
+    contents.IdentityPoolId = __expectString(data.IdentityPoolId);
   }
   if (data.PushSync !== undefined && data.PushSync !== null) {
     contents.PushSync = deserializeAws_restJson1PushSync(data.PushSync, context);
@@ -1486,13 +1489,13 @@ export const deserializeAws_restJson1ListDatasetsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Count !== undefined && data.Count !== null) {
-    contents.Count = data.Count;
+    contents.Count = __expectNumber(data.Count);
   }
   if (data.Datasets !== undefined && data.Datasets !== null) {
     contents.Datasets = deserializeAws_restJson1DatasetList(data.Datasets, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1574,16 +1577,16 @@ export const deserializeAws_restJson1ListIdentityPoolUsageCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Count !== undefined && data.Count !== null) {
-    contents.Count = data.Count;
+    contents.Count = __expectNumber(data.Count);
   }
   if (data.IdentityPoolUsages !== undefined && data.IdentityPoolUsages !== null) {
     contents.IdentityPoolUsages = deserializeAws_restJson1IdentityPoolUsageList(data.IdentityPoolUsages, context);
   }
   if (data.MaxResults !== undefined && data.MaxResults !== null) {
-    contents.MaxResults = data.MaxResults;
+    contents.MaxResults = __expectNumber(data.MaxResults);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1670,31 +1673,31 @@ export const deserializeAws_restJson1ListRecordsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Count !== undefined && data.Count !== null) {
-    contents.Count = data.Count;
+    contents.Count = __expectNumber(data.Count);
   }
   if (data.DatasetDeletedAfterRequestedSyncCount !== undefined && data.DatasetDeletedAfterRequestedSyncCount !== null) {
-    contents.DatasetDeletedAfterRequestedSyncCount = data.DatasetDeletedAfterRequestedSyncCount;
+    contents.DatasetDeletedAfterRequestedSyncCount = __expectBoolean(data.DatasetDeletedAfterRequestedSyncCount);
   }
   if (data.DatasetExists !== undefined && data.DatasetExists !== null) {
-    contents.DatasetExists = data.DatasetExists;
+    contents.DatasetExists = __expectBoolean(data.DatasetExists);
   }
   if (data.DatasetSyncCount !== undefined && data.DatasetSyncCount !== null) {
-    contents.DatasetSyncCount = data.DatasetSyncCount;
+    contents.DatasetSyncCount = __expectNumber(data.DatasetSyncCount);
   }
   if (data.LastModifiedBy !== undefined && data.LastModifiedBy !== null) {
-    contents.LastModifiedBy = data.LastModifiedBy;
+    contents.LastModifiedBy = __expectString(data.LastModifiedBy);
   }
   if (data.MergedDatasetNames !== undefined && data.MergedDatasetNames !== null) {
     contents.MergedDatasetNames = deserializeAws_restJson1MergedDatasetNameList(data.MergedDatasetNames, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Records !== undefined && data.Records !== null) {
     contents.Records = deserializeAws_restJson1RecordList(data.Records, context);
   }
   if (data.SyncSessionToken !== undefined && data.SyncSessionToken !== null) {
-    contents.SyncSessionToken = data.SyncSessionToken;
+    contents.SyncSessionToken = __expectString(data.SyncSessionToken);
   }
   return Promise.resolve(contents);
 };
@@ -1773,7 +1776,7 @@ export const deserializeAws_restJson1RegisterDeviceCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.DeviceId !== undefined && data.DeviceId !== null) {
-    contents.DeviceId = data.DeviceId;
+    contents.DeviceId = __expectString(data.DeviceId);
   }
   return Promise.resolve(contents);
 };
@@ -1956,7 +1959,7 @@ export const deserializeAws_restJson1SetIdentityPoolConfigurationCommand = async
     contents.CognitoStreams = deserializeAws_restJson1CognitoStreams(data.CognitoStreams, context);
   }
   if (data.IdentityPoolId !== undefined && data.IdentityPoolId !== null) {
-    contents.IdentityPoolId = data.IdentityPoolId;
+    contents.IdentityPoolId = __expectString(data.IdentityPoolId);
   }
   if (data.PushSync !== undefined && data.PushSync !== null) {
     contents.PushSync = deserializeAws_restJson1PushSync(data.PushSync, context);
@@ -2354,7 +2357,7 @@ const deserializeAws_restJson1AlreadyStreamedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2371,7 +2374,7 @@ const deserializeAws_restJson1ConcurrentModificationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2388,7 +2391,7 @@ const deserializeAws_restJson1DuplicateRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2405,7 +2408,7 @@ const deserializeAws_restJson1InternalErrorExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2422,7 +2425,7 @@ const deserializeAws_restJson1InvalidConfigurationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2439,7 +2442,7 @@ const deserializeAws_restJson1InvalidLambdaFunctionOutputExceptionResponse = asy
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2456,7 +2459,7 @@ const deserializeAws_restJson1InvalidParameterExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2473,7 +2476,7 @@ const deserializeAws_restJson1LambdaThrottledExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2490,7 +2493,7 @@ const deserializeAws_restJson1LimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2507,7 +2510,7 @@ const deserializeAws_restJson1NotAuthorizedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2524,7 +2527,7 @@ const deserializeAws_restJson1ResourceConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2541,7 +2544,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2558,7 +2561,7 @@ const deserializeAws_restJson1TooManyRequestsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2636,16 +2639,15 @@ const deserializeAws_restJson1ApplicationArnList = (output: any, context: __Serd
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1CognitoStreams = (output: any, context: __SerdeContext): CognitoStreams => {
   return {
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
-    StreamName: output.StreamName !== undefined && output.StreamName !== null ? output.StreamName : undefined,
-    StreamingStatus:
-      output.StreamingStatus !== undefined && output.StreamingStatus !== null ? output.StreamingStatus : undefined,
+    RoleArn: __expectString(output.RoleArn),
+    StreamName: __expectString(output.StreamName),
+    StreamingStatus: __expectString(output.StreamingStatus),
   } as any;
 };
 
@@ -2655,16 +2657,15 @@ const deserializeAws_restJson1Dataset = (output: any, context: __SerdeContext): 
       output.CreationDate !== undefined && output.CreationDate !== null
         ? new Date(Math.round(output.CreationDate * 1000))
         : undefined,
-    DataStorage: output.DataStorage !== undefined && output.DataStorage !== null ? output.DataStorage : undefined,
-    DatasetName: output.DatasetName !== undefined && output.DatasetName !== null ? output.DatasetName : undefined,
-    IdentityId: output.IdentityId !== undefined && output.IdentityId !== null ? output.IdentityId : undefined,
-    LastModifiedBy:
-      output.LastModifiedBy !== undefined && output.LastModifiedBy !== null ? output.LastModifiedBy : undefined,
+    DataStorage: __expectNumber(output.DataStorage),
+    DatasetName: __expectString(output.DatasetName),
+    IdentityId: __expectString(output.IdentityId),
+    LastModifiedBy: __expectString(output.LastModifiedBy),
     LastModifiedDate:
       output.LastModifiedDate !== undefined && output.LastModifiedDate !== null
         ? new Date(Math.round(output.LastModifiedDate * 1000))
         : undefined,
-    NumRecords: output.NumRecords !== undefined && output.NumRecords !== null ? output.NumRecords : undefined,
+    NumRecords: __expectNumber(output.NumRecords),
   } as any;
 };
 
@@ -2686,24 +2687,20 @@ const deserializeAws_restJson1Events = (output: any, context: __SerdeContext): {
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1IdentityPoolUsage = (output: any, context: __SerdeContext): IdentityPoolUsage => {
   return {
-    DataStorage: output.DataStorage !== undefined && output.DataStorage !== null ? output.DataStorage : undefined,
-    IdentityPoolId:
-      output.IdentityPoolId !== undefined && output.IdentityPoolId !== null ? output.IdentityPoolId : undefined,
+    DataStorage: __expectNumber(output.DataStorage),
+    IdentityPoolId: __expectString(output.IdentityPoolId),
     LastModifiedDate:
       output.LastModifiedDate !== undefined && output.LastModifiedDate !== null
         ? new Date(Math.round(output.LastModifiedDate * 1000))
         : undefined,
-    SyncSessionsCount:
-      output.SyncSessionsCount !== undefined && output.SyncSessionsCount !== null
-        ? output.SyncSessionsCount
-        : undefined,
+    SyncSessionsCount: __expectNumber(output.SyncSessionsCount),
   } as any;
 };
 
@@ -2720,11 +2717,10 @@ const deserializeAws_restJson1IdentityPoolUsageList = (output: any, context: __S
 
 const deserializeAws_restJson1IdentityUsage = (output: any, context: __SerdeContext): IdentityUsage => {
   return {
-    DataStorage: output.DataStorage !== undefined && output.DataStorage !== null ? output.DataStorage : undefined,
-    DatasetCount: output.DatasetCount !== undefined && output.DatasetCount !== null ? output.DatasetCount : undefined,
-    IdentityId: output.IdentityId !== undefined && output.IdentityId !== null ? output.IdentityId : undefined,
-    IdentityPoolId:
-      output.IdentityPoolId !== undefined && output.IdentityPoolId !== null ? output.IdentityPoolId : undefined,
+    DataStorage: __expectNumber(output.DataStorage),
+    DatasetCount: __expectNumber(output.DatasetCount),
+    IdentityId: __expectString(output.IdentityId),
+    IdentityPoolId: __expectString(output.IdentityPoolId),
     LastModifiedDate:
       output.LastModifiedDate !== undefined && output.LastModifiedDate !== null
         ? new Date(Math.round(output.LastModifiedDate * 1000))
@@ -2739,7 +2735,7 @@ const deserializeAws_restJson1MergedDatasetNameList = (output: any, context: __S
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2749,7 +2745,7 @@ const deserializeAws_restJson1PushSync = (output: any, context: __SerdeContext):
       output.ApplicationArns !== undefined && output.ApplicationArns !== null
         ? deserializeAws_restJson1ApplicationArnList(output.ApplicationArns, context)
         : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
+    RoleArn: __expectString(output.RoleArn),
   } as any;
 };
 
@@ -2759,15 +2755,14 @@ const deserializeAws_restJson1_Record = (output: any, context: __SerdeContext): 
       output.DeviceLastModifiedDate !== undefined && output.DeviceLastModifiedDate !== null
         ? new Date(Math.round(output.DeviceLastModifiedDate * 1000))
         : undefined,
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    LastModifiedBy:
-      output.LastModifiedBy !== undefined && output.LastModifiedBy !== null ? output.LastModifiedBy : undefined,
+    Key: __expectString(output.Key),
+    LastModifiedBy: __expectString(output.LastModifiedBy),
     LastModifiedDate:
       output.LastModifiedDate !== undefined && output.LastModifiedDate !== null
         ? new Date(Math.round(output.LastModifiedDate * 1000))
         : undefined,
-    SyncCount: output.SyncCount !== undefined && output.SyncCount !== null ? output.SyncCount : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    SyncCount: __expectNumber(output.SyncCount),
+    Value: __expectString(output.Value),
   } as any;
 };
 

--- a/clients/client-comprehend/protocols/Aws_json1_1.ts
+++ b/clients/client-comprehend/protocols/Aws_json1_1.ts
@@ -400,7 +400,11 @@ import {
   VpcConfig,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -7557,7 +7561,7 @@ const deserializeAws_json1_1AttributeNamesList = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7570,7 +7574,7 @@ const deserializeAws_json1_1AugmentedManifestsListItem = (
       output.AttributeNames !== undefined && output.AttributeNames !== null
         ? deserializeAws_json1_1AttributeNamesList(output.AttributeNames, context)
         : undefined,
-    S3Uri: output.S3Uri !== undefined && output.S3Uri !== null ? output.S3Uri : undefined,
+    S3Uri: __expectString(output.S3Uri),
   } as any;
 };
 
@@ -7579,7 +7583,7 @@ const deserializeAws_json1_1BatchDetectDominantLanguageItemResult = (
   context: __SerdeContext
 ): BatchDetectDominantLanguageItemResult => {
   return {
-    Index: output.Index !== undefined && output.Index !== null ? output.Index : undefined,
+    Index: __expectNumber(output.Index),
     Languages:
       output.Languages !== undefined && output.Languages !== null
         ? deserializeAws_json1_1ListOfDominantLanguages(output.Languages, context)
@@ -7612,7 +7616,7 @@ const deserializeAws_json1_1BatchDetectEntitiesItemResult = (
       output.Entities !== undefined && output.Entities !== null
         ? deserializeAws_json1_1ListOfEntities(output.Entities, context)
         : undefined,
-    Index: output.Index !== undefined && output.Index !== null ? output.Index : undefined,
+    Index: __expectNumber(output.Index),
   } as any;
 };
 
@@ -7637,7 +7641,7 @@ const deserializeAws_json1_1BatchDetectKeyPhrasesItemResult = (
   context: __SerdeContext
 ): BatchDetectKeyPhrasesItemResult => {
   return {
-    Index: output.Index !== undefined && output.Index !== null ? output.Index : undefined,
+    Index: __expectNumber(output.Index),
     KeyPhrases:
       output.KeyPhrases !== undefined && output.KeyPhrases !== null
         ? deserializeAws_json1_1ListOfKeyPhrases(output.KeyPhrases, context)
@@ -7666,8 +7670,8 @@ const deserializeAws_json1_1BatchDetectSentimentItemResult = (
   context: __SerdeContext
 ): BatchDetectSentimentItemResult => {
   return {
-    Index: output.Index !== undefined && output.Index !== null ? output.Index : undefined,
-    Sentiment: output.Sentiment !== undefined && output.Sentiment !== null ? output.Sentiment : undefined,
+    Index: __expectNumber(output.Index),
+    Sentiment: __expectString(output.Sentiment),
     SentimentScore:
       output.SentimentScore !== undefined && output.SentimentScore !== null
         ? deserializeAws_json1_1SentimentScore(output.SentimentScore, context)
@@ -7696,7 +7700,7 @@ const deserializeAws_json1_1BatchDetectSyntaxItemResult = (
   context: __SerdeContext
 ): BatchDetectSyntaxItemResult => {
   return {
-    Index: output.Index !== undefined && output.Index !== null ? output.Index : undefined,
+    Index: __expectNumber(output.Index),
     SyntaxTokens:
       output.SyntaxTokens !== undefined && output.SyntaxTokens !== null
         ? deserializeAws_json1_1ListOfSyntaxTokens(output.SyntaxTokens, context)
@@ -7722,9 +7726,9 @@ const deserializeAws_json1_1BatchDetectSyntaxResponse = (
 
 const deserializeAws_json1_1BatchItemError = (output: any, context: __SerdeContext): BatchItemError => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    Index: output.Index !== undefined && output.Index !== null ? output.Index : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
+    Index: __expectNumber(output.Index),
   } as any;
 };
 
@@ -7744,7 +7748,7 @@ const deserializeAws_json1_1BatchSizeLimitExceededException = (
   context: __SerdeContext
 ): BatchSizeLimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7753,15 +7757,14 @@ const deserializeAws_json1_1ClassifierEvaluationMetrics = (
   context: __SerdeContext
 ): ClassifierEvaluationMetrics => {
   return {
-    Accuracy: output.Accuracy !== undefined && output.Accuracy !== null ? output.Accuracy : undefined,
-    F1Score: output.F1Score !== undefined && output.F1Score !== null ? output.F1Score : undefined,
-    HammingLoss: output.HammingLoss !== undefined && output.HammingLoss !== null ? output.HammingLoss : undefined,
-    MicroF1Score: output.MicroF1Score !== undefined && output.MicroF1Score !== null ? output.MicroF1Score : undefined,
-    MicroPrecision:
-      output.MicroPrecision !== undefined && output.MicroPrecision !== null ? output.MicroPrecision : undefined,
-    MicroRecall: output.MicroRecall !== undefined && output.MicroRecall !== null ? output.MicroRecall : undefined,
-    Precision: output.Precision !== undefined && output.Precision !== null ? output.Precision : undefined,
-    Recall: output.Recall !== undefined && output.Recall !== null ? output.Recall : undefined,
+    Accuracy: __expectNumber(output.Accuracy),
+    F1Score: __expectNumber(output.F1Score),
+    HammingLoss: __expectNumber(output.HammingLoss),
+    MicroF1Score: __expectNumber(output.MicroF1Score),
+    MicroPrecision: __expectNumber(output.MicroPrecision),
+    MicroRecall: __expectNumber(output.MicroRecall),
+    Precision: __expectNumber(output.Precision),
+    Recall: __expectNumber(output.Recall),
   } as any;
 };
 
@@ -7771,16 +7774,9 @@ const deserializeAws_json1_1ClassifierMetadata = (output: any, context: __SerdeC
       output.EvaluationMetrics !== undefined && output.EvaluationMetrics !== null
         ? deserializeAws_json1_1ClassifierEvaluationMetrics(output.EvaluationMetrics, context)
         : undefined,
-    NumberOfLabels:
-      output.NumberOfLabels !== undefined && output.NumberOfLabels !== null ? output.NumberOfLabels : undefined,
-    NumberOfTestDocuments:
-      output.NumberOfTestDocuments !== undefined && output.NumberOfTestDocuments !== null
-        ? output.NumberOfTestDocuments
-        : undefined,
-    NumberOfTrainedDocuments:
-      output.NumberOfTrainedDocuments !== undefined && output.NumberOfTrainedDocuments !== null
-        ? output.NumberOfTrainedDocuments
-        : undefined,
+    NumberOfLabels: __expectNumber(output.NumberOfLabels),
+    NumberOfTestDocuments: __expectNumber(output.NumberOfTestDocuments),
+    NumberOfTrainedDocuments: __expectNumber(output.NumberOfTrainedDocuments),
   } as any;
 };
 
@@ -7805,7 +7801,7 @@ const deserializeAws_json1_1ConcurrentModificationException = (
   context: __SerdeContext
 ): ConcurrentModificationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7826,16 +7822,13 @@ const deserializeAws_json1_1CreateDocumentClassifierResponse = (
   context: __SerdeContext
 ): CreateDocumentClassifierResponse => {
   return {
-    DocumentClassifierArn:
-      output.DocumentClassifierArn !== undefined && output.DocumentClassifierArn !== null
-        ? output.DocumentClassifierArn
-        : undefined,
+    DocumentClassifierArn: __expectString(output.DocumentClassifierArn),
   } as any;
 };
 
 const deserializeAws_json1_1CreateEndpointResponse = (output: any, context: __SerdeContext): CreateEndpointResponse => {
   return {
-    EndpointArn: output.EndpointArn !== undefined && output.EndpointArn !== null ? output.EndpointArn : undefined,
+    EndpointArn: __expectString(output.EndpointArn),
   } as any;
 };
 
@@ -7844,10 +7837,7 @@ const deserializeAws_json1_1CreateEntityRecognizerResponse = (
   context: __SerdeContext
 ): CreateEntityRecognizerResponse => {
   return {
-    EntityRecognizerArn:
-      output.EntityRecognizerArn !== undefined && output.EntityRecognizerArn !== null
-        ? output.EntityRecognizerArn
-        : undefined,
+    EntityRecognizerArn: __expectString(output.EntityRecognizerArn),
   } as any;
 };
 
@@ -8055,7 +8045,7 @@ const deserializeAws_json1_1DetectSentimentResponse = (
   context: __SerdeContext
 ): DetectSentimentResponse => {
   return {
-    Sentiment: output.Sentiment !== undefined && output.Sentiment !== null ? output.Sentiment : undefined,
+    Sentiment: __expectString(output.Sentiment),
     SentimentScore:
       output.SentimentScore !== undefined && output.SentimentScore !== null
         ? deserializeAws_json1_1SentimentScore(output.SentimentScore, context)
@@ -8074,8 +8064,8 @@ const deserializeAws_json1_1DetectSyntaxResponse = (output: any, context: __Serd
 
 const deserializeAws_json1_1DocumentClass = (output: any, context: __SerdeContext): DocumentClass => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Score: output.Score !== undefined && output.Score !== null ? output.Score : undefined,
+    Name: __expectString(output.Name),
+    Score: __expectNumber(output.Score),
   } as any;
 };
 
@@ -8084,24 +8074,18 @@ const deserializeAws_json1_1DocumentClassificationJobProperties = (
   context: __SerdeContext
 ): DocumentClassificationJobProperties => {
   return {
-    DataAccessRoleArn:
-      output.DataAccessRoleArn !== undefined && output.DataAccessRoleArn !== null
-        ? output.DataAccessRoleArn
-        : undefined,
-    DocumentClassifierArn:
-      output.DocumentClassifierArn !== undefined && output.DocumentClassifierArn !== null
-        ? output.DocumentClassifierArn
-        : undefined,
+    DataAccessRoleArn: __expectString(output.DataAccessRoleArn),
+    DocumentClassifierArn: __expectString(output.DocumentClassifierArn),
     EndTime:
       output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
     InputDataConfig:
       output.InputDataConfig !== undefined && output.InputDataConfig !== null
         ? deserializeAws_json1_1InputDataConfig(output.InputDataConfig, context)
         : undefined,
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
-    JobName: output.JobName !== undefined && output.JobName !== null ? output.JobName : undefined,
-    JobStatus: output.JobStatus !== undefined && output.JobStatus !== null ? output.JobStatus : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    JobId: __expectString(output.JobId),
+    JobName: __expectString(output.JobName),
+    JobStatus: __expectString(output.JobStatus),
+    Message: __expectString(output.Message),
     OutputDataConfig:
       output.OutputDataConfig !== undefined && output.OutputDataConfig !== null
         ? deserializeAws_json1_1OutputDataConfig(output.OutputDataConfig, context)
@@ -8110,8 +8094,7 @@ const deserializeAws_json1_1DocumentClassificationJobProperties = (
       output.SubmitTime !== undefined && output.SubmitTime !== null
         ? new Date(Math.round(output.SubmitTime * 1000))
         : undefined,
-    VolumeKmsKeyId:
-      output.VolumeKmsKeyId !== undefined && output.VolumeKmsKeyId !== null ? output.VolumeKmsKeyId : undefined,
+    VolumeKmsKeyId: __expectString(output.VolumeKmsKeyId),
     VpcConfig:
       output.VpcConfig !== undefined && output.VpcConfig !== null
         ? deserializeAws_json1_1VpcConfig(output.VpcConfig, context)
@@ -8156,10 +8139,9 @@ const deserializeAws_json1_1DocumentClassifierInputDataConfig = (
       output.AugmentedManifests !== undefined && output.AugmentedManifests !== null
         ? deserializeAws_json1_1DocumentClassifierAugmentedManifestsList(output.AugmentedManifests, context)
         : undefined,
-    DataFormat: output.DataFormat !== undefined && output.DataFormat !== null ? output.DataFormat : undefined,
-    LabelDelimiter:
-      output.LabelDelimiter !== undefined && output.LabelDelimiter !== null ? output.LabelDelimiter : undefined,
-    S3Uri: output.S3Uri !== undefined && output.S3Uri !== null ? output.S3Uri : undefined,
+    DataFormat: __expectString(output.DataFormat),
+    LabelDelimiter: __expectString(output.LabelDelimiter),
+    S3Uri: __expectString(output.S3Uri),
   } as any;
 };
 
@@ -8168,8 +8150,8 @@ const deserializeAws_json1_1DocumentClassifierOutputDataConfig = (
   context: __SerdeContext
 ): DocumentClassifierOutputDataConfig => {
   return {
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
-    S3Uri: output.S3Uri !== undefined && output.S3Uri !== null ? output.S3Uri : undefined,
+    KmsKeyId: __expectString(output.KmsKeyId),
+    S3Uri: __expectString(output.S3Uri),
   } as any;
 };
 
@@ -8182,30 +8164,23 @@ const deserializeAws_json1_1DocumentClassifierProperties = (
       output.ClassifierMetadata !== undefined && output.ClassifierMetadata !== null
         ? deserializeAws_json1_1ClassifierMetadata(output.ClassifierMetadata, context)
         : undefined,
-    DataAccessRoleArn:
-      output.DataAccessRoleArn !== undefined && output.DataAccessRoleArn !== null
-        ? output.DataAccessRoleArn
-        : undefined,
-    DocumentClassifierArn:
-      output.DocumentClassifierArn !== undefined && output.DocumentClassifierArn !== null
-        ? output.DocumentClassifierArn
-        : undefined,
+    DataAccessRoleArn: __expectString(output.DataAccessRoleArn),
+    DocumentClassifierArn: __expectString(output.DocumentClassifierArn),
     EndTime:
       output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
     InputDataConfig:
       output.InputDataConfig !== undefined && output.InputDataConfig !== null
         ? deserializeAws_json1_1DocumentClassifierInputDataConfig(output.InputDataConfig, context)
         : undefined,
-    LanguageCode: output.LanguageCode !== undefined && output.LanguageCode !== null ? output.LanguageCode : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Mode: output.Mode !== undefined && output.Mode !== null ? output.Mode : undefined,
-    ModelKmsKeyId:
-      output.ModelKmsKeyId !== undefined && output.ModelKmsKeyId !== null ? output.ModelKmsKeyId : undefined,
+    LanguageCode: __expectString(output.LanguageCode),
+    Message: __expectString(output.Message),
+    Mode: __expectString(output.Mode),
+    ModelKmsKeyId: __expectString(output.ModelKmsKeyId),
     OutputDataConfig:
       output.OutputDataConfig !== undefined && output.OutputDataConfig !== null
         ? deserializeAws_json1_1DocumentClassifierOutputDataConfig(output.OutputDataConfig, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
     SubmitTime:
       output.SubmitTime !== undefined && output.SubmitTime !== null
         ? new Date(Math.round(output.SubmitTime * 1000))
@@ -8218,8 +8193,7 @@ const deserializeAws_json1_1DocumentClassifierProperties = (
       output.TrainingStartTime !== undefined && output.TrainingStartTime !== null
         ? new Date(Math.round(output.TrainingStartTime * 1000))
         : undefined,
-    VolumeKmsKeyId:
-      output.VolumeKmsKeyId !== undefined && output.VolumeKmsKeyId !== null ? output.VolumeKmsKeyId : undefined,
+    VolumeKmsKeyId: __expectString(output.VolumeKmsKeyId),
     VpcConfig:
       output.VpcConfig !== undefined && output.VpcConfig !== null
         ? deserializeAws_json1_1VpcConfig(output.VpcConfig, context)
@@ -8243,15 +8217,15 @@ const deserializeAws_json1_1DocumentClassifierPropertiesList = (
 
 const deserializeAws_json1_1DocumentLabel = (output: any, context: __SerdeContext): DocumentLabel => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Score: output.Score !== undefined && output.Score !== null ? output.Score : undefined,
+    Name: __expectString(output.Name),
+    Score: __expectNumber(output.Score),
   } as any;
 };
 
 const deserializeAws_json1_1DominantLanguage = (output: any, context: __SerdeContext): DominantLanguage => {
   return {
-    LanguageCode: output.LanguageCode !== undefined && output.LanguageCode !== null ? output.LanguageCode : undefined,
-    Score: output.Score !== undefined && output.Score !== null ? output.Score : undefined,
+    LanguageCode: __expectString(output.LanguageCode),
+    Score: __expectNumber(output.Score),
   } as any;
 };
 
@@ -8260,20 +8234,17 @@ const deserializeAws_json1_1DominantLanguageDetectionJobProperties = (
   context: __SerdeContext
 ): DominantLanguageDetectionJobProperties => {
   return {
-    DataAccessRoleArn:
-      output.DataAccessRoleArn !== undefined && output.DataAccessRoleArn !== null
-        ? output.DataAccessRoleArn
-        : undefined,
+    DataAccessRoleArn: __expectString(output.DataAccessRoleArn),
     EndTime:
       output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
     InputDataConfig:
       output.InputDataConfig !== undefined && output.InputDataConfig !== null
         ? deserializeAws_json1_1InputDataConfig(output.InputDataConfig, context)
         : undefined,
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
-    JobName: output.JobName !== undefined && output.JobName !== null ? output.JobName : undefined,
-    JobStatus: output.JobStatus !== undefined && output.JobStatus !== null ? output.JobStatus : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    JobId: __expectString(output.JobId),
+    JobName: __expectString(output.JobName),
+    JobStatus: __expectString(output.JobStatus),
+    Message: __expectString(output.Message),
     OutputDataConfig:
       output.OutputDataConfig !== undefined && output.OutputDataConfig !== null
         ? deserializeAws_json1_1OutputDataConfig(output.OutputDataConfig, context)
@@ -8282,8 +8253,7 @@ const deserializeAws_json1_1DominantLanguageDetectionJobProperties = (
       output.SubmitTime !== undefined && output.SubmitTime !== null
         ? new Date(Math.round(output.SubmitTime * 1000))
         : undefined,
-    VolumeKmsKeyId:
-      output.VolumeKmsKeyId !== undefined && output.VolumeKmsKeyId !== null ? output.VolumeKmsKeyId : undefined,
+    VolumeKmsKeyId: __expectString(output.VolumeKmsKeyId),
     VpcConfig:
       output.VpcConfig !== undefined && output.VpcConfig !== null
         ? deserializeAws_json1_1VpcConfig(output.VpcConfig, context)
@@ -8311,26 +8281,17 @@ const deserializeAws_json1_1EndpointProperties = (output: any, context: __SerdeC
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    CurrentInferenceUnits:
-      output.CurrentInferenceUnits !== undefined && output.CurrentInferenceUnits !== null
-        ? output.CurrentInferenceUnits
-        : undefined,
-    DataAccessRoleArn:
-      output.DataAccessRoleArn !== undefined && output.DataAccessRoleArn !== null
-        ? output.DataAccessRoleArn
-        : undefined,
-    DesiredInferenceUnits:
-      output.DesiredInferenceUnits !== undefined && output.DesiredInferenceUnits !== null
-        ? output.DesiredInferenceUnits
-        : undefined,
-    EndpointArn: output.EndpointArn !== undefined && output.EndpointArn !== null ? output.EndpointArn : undefined,
+    CurrentInferenceUnits: __expectNumber(output.CurrentInferenceUnits),
+    DataAccessRoleArn: __expectString(output.DataAccessRoleArn),
+    DesiredInferenceUnits: __expectNumber(output.DesiredInferenceUnits),
+    EndpointArn: __expectString(output.EndpointArn),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    ModelArn: output.ModelArn !== undefined && output.ModelArn !== null ? output.ModelArn : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Message: __expectString(output.Message),
+    ModelArn: __expectString(output.ModelArn),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -8350,25 +8311,19 @@ const deserializeAws_json1_1EntitiesDetectionJobProperties = (
   context: __SerdeContext
 ): EntitiesDetectionJobProperties => {
   return {
-    DataAccessRoleArn:
-      output.DataAccessRoleArn !== undefined && output.DataAccessRoleArn !== null
-        ? output.DataAccessRoleArn
-        : undefined,
+    DataAccessRoleArn: __expectString(output.DataAccessRoleArn),
     EndTime:
       output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
-    EntityRecognizerArn:
-      output.EntityRecognizerArn !== undefined && output.EntityRecognizerArn !== null
-        ? output.EntityRecognizerArn
-        : undefined,
+    EntityRecognizerArn: __expectString(output.EntityRecognizerArn),
     InputDataConfig:
       output.InputDataConfig !== undefined && output.InputDataConfig !== null
         ? deserializeAws_json1_1InputDataConfig(output.InputDataConfig, context)
         : undefined,
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
-    JobName: output.JobName !== undefined && output.JobName !== null ? output.JobName : undefined,
-    JobStatus: output.JobStatus !== undefined && output.JobStatus !== null ? output.JobStatus : undefined,
-    LanguageCode: output.LanguageCode !== undefined && output.LanguageCode !== null ? output.LanguageCode : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    JobId: __expectString(output.JobId),
+    JobName: __expectString(output.JobName),
+    JobStatus: __expectString(output.JobStatus),
+    LanguageCode: __expectString(output.LanguageCode),
+    Message: __expectString(output.Message),
     OutputDataConfig:
       output.OutputDataConfig !== undefined && output.OutputDataConfig !== null
         ? deserializeAws_json1_1OutputDataConfig(output.OutputDataConfig, context)
@@ -8377,8 +8332,7 @@ const deserializeAws_json1_1EntitiesDetectionJobProperties = (
       output.SubmitTime !== undefined && output.SubmitTime !== null
         ? new Date(Math.round(output.SubmitTime * 1000))
         : undefined,
-    VolumeKmsKeyId:
-      output.VolumeKmsKeyId !== undefined && output.VolumeKmsKeyId !== null ? output.VolumeKmsKeyId : undefined,
+    VolumeKmsKeyId: __expectString(output.VolumeKmsKeyId),
     VpcConfig:
       output.VpcConfig !== undefined && output.VpcConfig !== null
         ? deserializeAws_json1_1VpcConfig(output.VpcConfig, context)
@@ -8402,18 +8356,18 @@ const deserializeAws_json1_1EntitiesDetectionJobPropertiesList = (
 
 const deserializeAws_json1_1Entity = (output: any, context: __SerdeContext): Entity => {
   return {
-    BeginOffset: output.BeginOffset !== undefined && output.BeginOffset !== null ? output.BeginOffset : undefined,
-    EndOffset: output.EndOffset !== undefined && output.EndOffset !== null ? output.EndOffset : undefined,
-    Score: output.Score !== undefined && output.Score !== null ? output.Score : undefined,
-    Text: output.Text !== undefined && output.Text !== null ? output.Text : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    BeginOffset: __expectNumber(output.BeginOffset),
+    EndOffset: __expectNumber(output.EndOffset),
+    Score: __expectNumber(output.Score),
+    Text: __expectString(output.Text),
+    Type: __expectString(output.Type),
   } as any;
 };
 
 const deserializeAws_json1_1EntityLabel = (output: any, context: __SerdeContext): EntityLabel => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Score: output.Score !== undefined && output.Score !== null ? output.Score : undefined,
+    Name: __expectString(output.Name),
+    Score: __expectNumber(output.Score),
   } as any;
 };
 
@@ -8422,7 +8376,7 @@ const deserializeAws_json1_1EntityRecognizerAnnotations = (
   context: __SerdeContext
 ): EntityRecognizerAnnotations => {
   return {
-    S3Uri: output.S3Uri !== undefined && output.S3Uri !== null ? output.S3Uri : undefined,
+    S3Uri: __expectString(output.S3Uri),
   } as any;
 };
 
@@ -8445,7 +8399,7 @@ const deserializeAws_json1_1EntityRecognizerDocuments = (
   context: __SerdeContext
 ): EntityRecognizerDocuments => {
   return {
-    S3Uri: output.S3Uri !== undefined && output.S3Uri !== null ? output.S3Uri : undefined,
+    S3Uri: __expectString(output.S3Uri),
   } as any;
 };
 
@@ -8454,7 +8408,7 @@ const deserializeAws_json1_1EntityRecognizerEntityList = (
   context: __SerdeContext
 ): EntityRecognizerEntityList => {
   return {
-    S3Uri: output.S3Uri !== undefined && output.S3Uri !== null ? output.S3Uri : undefined,
+    S3Uri: __expectString(output.S3Uri),
   } as any;
 };
 
@@ -8463,9 +8417,9 @@ const deserializeAws_json1_1EntityRecognizerEvaluationMetrics = (
   context: __SerdeContext
 ): EntityRecognizerEvaluationMetrics => {
   return {
-    F1Score: output.F1Score !== undefined && output.F1Score !== null ? output.F1Score : undefined,
-    Precision: output.Precision !== undefined && output.Precision !== null ? output.Precision : undefined,
-    Recall: output.Recall !== undefined && output.Recall !== null ? output.Recall : undefined,
+    F1Score: __expectNumber(output.F1Score),
+    Precision: __expectNumber(output.Precision),
+    Recall: __expectNumber(output.Recall),
   } as any;
 };
 
@@ -8482,7 +8436,7 @@ const deserializeAws_json1_1EntityRecognizerInputDataConfig = (
       output.AugmentedManifests !== undefined && output.AugmentedManifests !== null
         ? deserializeAws_json1_1EntityRecognizerAugmentedManifestsList(output.AugmentedManifests, context)
         : undefined,
-    DataFormat: output.DataFormat !== undefined && output.DataFormat !== null ? output.DataFormat : undefined,
+    DataFormat: __expectString(output.DataFormat),
     Documents:
       output.Documents !== undefined && output.Documents !== null
         ? deserializeAws_json1_1EntityRecognizerDocuments(output.Documents, context)
@@ -8511,14 +8465,8 @@ const deserializeAws_json1_1EntityRecognizerMetadata = (
       output.EvaluationMetrics !== undefined && output.EvaluationMetrics !== null
         ? deserializeAws_json1_1EntityRecognizerEvaluationMetrics(output.EvaluationMetrics, context)
         : undefined,
-    NumberOfTestDocuments:
-      output.NumberOfTestDocuments !== undefined && output.NumberOfTestDocuments !== null
-        ? output.NumberOfTestDocuments
-        : undefined,
-    NumberOfTrainedDocuments:
-      output.NumberOfTrainedDocuments !== undefined && output.NumberOfTrainedDocuments !== null
-        ? output.NumberOfTrainedDocuments
-        : undefined,
+    NumberOfTestDocuments: __expectNumber(output.NumberOfTestDocuments),
+    NumberOfTrainedDocuments: __expectNumber(output.NumberOfTrainedDocuments),
   } as any;
 };
 
@@ -8545,11 +8493,8 @@ const deserializeAws_json1_1EntityRecognizerMetadataEntityTypesListItem = (
       output.EvaluationMetrics !== undefined && output.EvaluationMetrics !== null
         ? deserializeAws_json1_1EntityTypesEvaluationMetrics(output.EvaluationMetrics, context)
         : undefined,
-    NumberOfTrainMentions:
-      output.NumberOfTrainMentions !== undefined && output.NumberOfTrainMentions !== null
-        ? output.NumberOfTrainMentions
-        : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    NumberOfTrainMentions: __expectNumber(output.NumberOfTrainMentions),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -8558,29 +8503,22 @@ const deserializeAws_json1_1EntityRecognizerProperties = (
   context: __SerdeContext
 ): EntityRecognizerProperties => {
   return {
-    DataAccessRoleArn:
-      output.DataAccessRoleArn !== undefined && output.DataAccessRoleArn !== null
-        ? output.DataAccessRoleArn
-        : undefined,
+    DataAccessRoleArn: __expectString(output.DataAccessRoleArn),
     EndTime:
       output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
-    EntityRecognizerArn:
-      output.EntityRecognizerArn !== undefined && output.EntityRecognizerArn !== null
-        ? output.EntityRecognizerArn
-        : undefined,
+    EntityRecognizerArn: __expectString(output.EntityRecognizerArn),
     InputDataConfig:
       output.InputDataConfig !== undefined && output.InputDataConfig !== null
         ? deserializeAws_json1_1EntityRecognizerInputDataConfig(output.InputDataConfig, context)
         : undefined,
-    LanguageCode: output.LanguageCode !== undefined && output.LanguageCode !== null ? output.LanguageCode : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    ModelKmsKeyId:
-      output.ModelKmsKeyId !== undefined && output.ModelKmsKeyId !== null ? output.ModelKmsKeyId : undefined,
+    LanguageCode: __expectString(output.LanguageCode),
+    Message: __expectString(output.Message),
+    ModelKmsKeyId: __expectString(output.ModelKmsKeyId),
     RecognizerMetadata:
       output.RecognizerMetadata !== undefined && output.RecognizerMetadata !== null
         ? deserializeAws_json1_1EntityRecognizerMetadata(output.RecognizerMetadata, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
     SubmitTime:
       output.SubmitTime !== undefined && output.SubmitTime !== null
         ? new Date(Math.round(output.SubmitTime * 1000))
@@ -8593,8 +8531,7 @@ const deserializeAws_json1_1EntityRecognizerProperties = (
       output.TrainingStartTime !== undefined && output.TrainingStartTime !== null
         ? new Date(Math.round(output.TrainingStartTime * 1000))
         : undefined,
-    VolumeKmsKeyId:
-      output.VolumeKmsKeyId !== undefined && output.VolumeKmsKeyId !== null ? output.VolumeKmsKeyId : undefined,
+    VolumeKmsKeyId: __expectString(output.VolumeKmsKeyId),
     VpcConfig:
       output.VpcConfig !== undefined && output.VpcConfig !== null
         ? deserializeAws_json1_1VpcConfig(output.VpcConfig, context)
@@ -8621,9 +8558,9 @@ const deserializeAws_json1_1EntityTypesEvaluationMetrics = (
   context: __SerdeContext
 ): EntityTypesEvaluationMetrics => {
   return {
-    F1Score: output.F1Score !== undefined && output.F1Score !== null ? output.F1Score : undefined,
-    Precision: output.Precision !== undefined && output.Precision !== null ? output.Precision : undefined,
-    Recall: output.Recall !== undefined && output.Recall !== null ? output.Recall : undefined,
+    F1Score: __expectNumber(output.F1Score),
+    Precision: __expectNumber(output.Precision),
+    Recall: __expectNumber(output.Recall),
   } as any;
 };
 
@@ -8640,7 +8577,7 @@ const deserializeAws_json1_1EntityTypesList = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_1EntityTypesListItem = (output: any, context: __SerdeContext): EntityTypesListItem => {
   return {
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -8649,21 +8586,18 @@ const deserializeAws_json1_1EventsDetectionJobProperties = (
   context: __SerdeContext
 ): EventsDetectionJobProperties => {
   return {
-    DataAccessRoleArn:
-      output.DataAccessRoleArn !== undefined && output.DataAccessRoleArn !== null
-        ? output.DataAccessRoleArn
-        : undefined,
+    DataAccessRoleArn: __expectString(output.DataAccessRoleArn),
     EndTime:
       output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
     InputDataConfig:
       output.InputDataConfig !== undefined && output.InputDataConfig !== null
         ? deserializeAws_json1_1InputDataConfig(output.InputDataConfig, context)
         : undefined,
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
-    JobName: output.JobName !== undefined && output.JobName !== null ? output.JobName : undefined,
-    JobStatus: output.JobStatus !== undefined && output.JobStatus !== null ? output.JobStatus : undefined,
-    LanguageCode: output.LanguageCode !== undefined && output.LanguageCode !== null ? output.LanguageCode : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    JobId: __expectString(output.JobId),
+    JobName: __expectString(output.JobName),
+    JobStatus: __expectString(output.JobStatus),
+    LanguageCode: __expectString(output.LanguageCode),
+    Message: __expectString(output.Message),
     OutputDataConfig:
       output.OutputDataConfig !== undefined && output.OutputDataConfig !== null
         ? deserializeAws_json1_1OutputDataConfig(output.OutputDataConfig, context)
@@ -8695,8 +8629,8 @@ const deserializeAws_json1_1EventsDetectionJobPropertiesList = (
 
 const deserializeAws_json1_1InputDataConfig = (output: any, context: __SerdeContext): InputDataConfig => {
   return {
-    InputFormat: output.InputFormat !== undefined && output.InputFormat !== null ? output.InputFormat : undefined,
-    S3Uri: output.S3Uri !== undefined && output.S3Uri !== null ? output.S3Uri : undefined,
+    InputFormat: __expectString(output.InputFormat),
+    S3Uri: __expectString(output.S3Uri),
   } as any;
 };
 
@@ -8705,13 +8639,13 @@ const deserializeAws_json1_1InternalServerException = (
   context: __SerdeContext
 ): InternalServerException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidFilterException = (output: any, context: __SerdeContext): InvalidFilterException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -8720,22 +8654,22 @@ const deserializeAws_json1_1InvalidRequestException = (
   context: __SerdeContext
 ): InvalidRequestException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1JobNotFoundException = (output: any, context: __SerdeContext): JobNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1KeyPhrase = (output: any, context: __SerdeContext): KeyPhrase => {
   return {
-    BeginOffset: output.BeginOffset !== undefined && output.BeginOffset !== null ? output.BeginOffset : undefined,
-    EndOffset: output.EndOffset !== undefined && output.EndOffset !== null ? output.EndOffset : undefined,
-    Score: output.Score !== undefined && output.Score !== null ? output.Score : undefined,
-    Text: output.Text !== undefined && output.Text !== null ? output.Text : undefined,
+    BeginOffset: __expectNumber(output.BeginOffset),
+    EndOffset: __expectNumber(output.EndOffset),
+    Score: __expectNumber(output.Score),
+    Text: __expectString(output.Text),
   } as any;
 };
 
@@ -8744,21 +8678,18 @@ const deserializeAws_json1_1KeyPhrasesDetectionJobProperties = (
   context: __SerdeContext
 ): KeyPhrasesDetectionJobProperties => {
   return {
-    DataAccessRoleArn:
-      output.DataAccessRoleArn !== undefined && output.DataAccessRoleArn !== null
-        ? output.DataAccessRoleArn
-        : undefined,
+    DataAccessRoleArn: __expectString(output.DataAccessRoleArn),
     EndTime:
       output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
     InputDataConfig:
       output.InputDataConfig !== undefined && output.InputDataConfig !== null
         ? deserializeAws_json1_1InputDataConfig(output.InputDataConfig, context)
         : undefined,
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
-    JobName: output.JobName !== undefined && output.JobName !== null ? output.JobName : undefined,
-    JobStatus: output.JobStatus !== undefined && output.JobStatus !== null ? output.JobStatus : undefined,
-    LanguageCode: output.LanguageCode !== undefined && output.LanguageCode !== null ? output.LanguageCode : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    JobId: __expectString(output.JobId),
+    JobName: __expectString(output.JobName),
+    JobStatus: __expectString(output.JobStatus),
+    LanguageCode: __expectString(output.LanguageCode),
+    Message: __expectString(output.Message),
     OutputDataConfig:
       output.OutputDataConfig !== undefined && output.OutputDataConfig !== null
         ? deserializeAws_json1_1OutputDataConfig(output.OutputDataConfig, context)
@@ -8767,8 +8698,7 @@ const deserializeAws_json1_1KeyPhrasesDetectionJobProperties = (
       output.SubmitTime !== undefined && output.SubmitTime !== null
         ? new Date(Math.round(output.SubmitTime * 1000))
         : undefined,
-    VolumeKmsKeyId:
-      output.VolumeKmsKeyId !== undefined && output.VolumeKmsKeyId !== null ? output.VolumeKmsKeyId : undefined,
+    VolumeKmsKeyId: __expectString(output.VolumeKmsKeyId),
     VpcConfig:
       output.VpcConfig !== undefined && output.VpcConfig !== null
         ? deserializeAws_json1_1VpcConfig(output.VpcConfig, context)
@@ -8795,7 +8725,7 @@ const deserializeAws_json1_1KmsKeyValidationException = (
   context: __SerdeContext
 ): KmsKeyValidationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -8812,7 +8742,7 @@ const deserializeAws_json1_1ListDocumentClassificationJobsResponse = (
             context
           )
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -8825,7 +8755,7 @@ const deserializeAws_json1_1ListDocumentClassifiersResponse = (
       output.DocumentClassifierPropertiesList !== undefined && output.DocumentClassifierPropertiesList !== null
         ? deserializeAws_json1_1DocumentClassifierPropertiesList(output.DocumentClassifierPropertiesList, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -8842,7 +8772,7 @@ const deserializeAws_json1_1ListDominantLanguageDetectionJobsResponse = (
             context
           )
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -8852,7 +8782,7 @@ const deserializeAws_json1_1ListEndpointsResponse = (output: any, context: __Ser
       output.EndpointPropertiesList !== undefined && output.EndpointPropertiesList !== null
         ? deserializeAws_json1_1EndpointPropertiesList(output.EndpointPropertiesList, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -8865,7 +8795,7 @@ const deserializeAws_json1_1ListEntitiesDetectionJobsResponse = (
       output.EntitiesDetectionJobPropertiesList !== undefined && output.EntitiesDetectionJobPropertiesList !== null
         ? deserializeAws_json1_1EntitiesDetectionJobPropertiesList(output.EntitiesDetectionJobPropertiesList, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -8878,7 +8808,7 @@ const deserializeAws_json1_1ListEntityRecognizersResponse = (
       output.EntityRecognizerPropertiesList !== undefined && output.EntityRecognizerPropertiesList !== null
         ? deserializeAws_json1_1EntityRecognizerPropertiesList(output.EntityRecognizerPropertiesList, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -8891,7 +8821,7 @@ const deserializeAws_json1_1ListEventsDetectionJobsResponse = (
       output.EventsDetectionJobPropertiesList !== undefined && output.EventsDetectionJobPropertiesList !== null
         ? deserializeAws_json1_1EventsDetectionJobPropertiesList(output.EventsDetectionJobPropertiesList, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -8907,7 +8837,7 @@ const deserializeAws_json1_1ListKeyPhrasesDetectionJobsResponse = (
             context
           )
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -9068,7 +8998,7 @@ const deserializeAws_json1_1ListOfPiiEntityTypes = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -9088,7 +9018,7 @@ const deserializeAws_json1_1ListPiiEntitiesDetectionJobsResponse = (
   context: __SerdeContext
 ): ListPiiEntitiesDetectionJobsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     PiiEntitiesDetectionJobPropertiesList:
       output.PiiEntitiesDetectionJobPropertiesList !== undefined &&
       output.PiiEntitiesDetectionJobPropertiesList !== null
@@ -9105,7 +9035,7 @@ const deserializeAws_json1_1ListSentimentDetectionJobsResponse = (
   context: __SerdeContext
 ): ListSentimentDetectionJobsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     SentimentDetectionJobPropertiesList:
       output.SentimentDetectionJobPropertiesList !== undefined && output.SentimentDetectionJobPropertiesList !== null
         ? deserializeAws_json1_1SentimentDetectionJobPropertiesList(output.SentimentDetectionJobPropertiesList, context)
@@ -9118,7 +9048,7 @@ const deserializeAws_json1_1ListTagsForResourceResponse = (
   context: __SerdeContext
 ): ListTagsForResourceResponse => {
   return {
-    ResourceArn: output.ResourceArn !== undefined && output.ResourceArn !== null ? output.ResourceArn : undefined,
+    ResourceArn: __expectString(output.ResourceArn),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_1TagList(output.Tags, context)
@@ -9131,7 +9061,7 @@ const deserializeAws_json1_1ListTopicsDetectionJobsResponse = (
   context: __SerdeContext
 ): ListTopicsDetectionJobsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     TopicsDetectionJobPropertiesList:
       output.TopicsDetectionJobPropertiesList !== undefined && output.TopicsDetectionJobPropertiesList !== null
         ? deserializeAws_json1_1TopicsDetectionJobPropertiesList(output.TopicsDetectionJobPropertiesList, context)
@@ -9141,15 +9071,15 @@ const deserializeAws_json1_1ListTopicsDetectionJobsResponse = (
 
 const deserializeAws_json1_1OutputDataConfig = (output: any, context: __SerdeContext): OutputDataConfig => {
   return {
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
-    S3Uri: output.S3Uri !== undefined && output.S3Uri !== null ? output.S3Uri : undefined,
+    KmsKeyId: __expectString(output.KmsKeyId),
+    S3Uri: __expectString(output.S3Uri),
   } as any;
 };
 
 const deserializeAws_json1_1PartOfSpeechTag = (output: any, context: __SerdeContext): PartOfSpeechTag => {
   return {
-    Score: output.Score !== undefined && output.Score !== null ? output.Score : undefined,
-    Tag: output.Tag !== undefined && output.Tag !== null ? output.Tag : undefined,
+    Score: __expectNumber(output.Score),
+    Tag: __expectString(output.Tag),
   } as any;
 };
 
@@ -9158,22 +9088,19 @@ const deserializeAws_json1_1PiiEntitiesDetectionJobProperties = (
   context: __SerdeContext
 ): PiiEntitiesDetectionJobProperties => {
   return {
-    DataAccessRoleArn:
-      output.DataAccessRoleArn !== undefined && output.DataAccessRoleArn !== null
-        ? output.DataAccessRoleArn
-        : undefined,
+    DataAccessRoleArn: __expectString(output.DataAccessRoleArn),
     EndTime:
       output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
     InputDataConfig:
       output.InputDataConfig !== undefined && output.InputDataConfig !== null
         ? deserializeAws_json1_1InputDataConfig(output.InputDataConfig, context)
         : undefined,
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
-    JobName: output.JobName !== undefined && output.JobName !== null ? output.JobName : undefined,
-    JobStatus: output.JobStatus !== undefined && output.JobStatus !== null ? output.JobStatus : undefined,
-    LanguageCode: output.LanguageCode !== undefined && output.LanguageCode !== null ? output.LanguageCode : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Mode: output.Mode !== undefined && output.Mode !== null ? output.Mode : undefined,
+    JobId: __expectString(output.JobId),
+    JobName: __expectString(output.JobName),
+    JobStatus: __expectString(output.JobStatus),
+    LanguageCode: __expectString(output.LanguageCode),
+    Message: __expectString(output.Message),
+    Mode: __expectString(output.Mode),
     OutputDataConfig:
       output.OutputDataConfig !== undefined && output.OutputDataConfig !== null
         ? deserializeAws_json1_1PiiOutputDataConfig(output.OutputDataConfig, context)
@@ -9205,25 +9132,24 @@ const deserializeAws_json1_1PiiEntitiesDetectionJobPropertiesList = (
 
 const deserializeAws_json1_1PiiEntity = (output: any, context: __SerdeContext): PiiEntity => {
   return {
-    BeginOffset: output.BeginOffset !== undefined && output.BeginOffset !== null ? output.BeginOffset : undefined,
-    EndOffset: output.EndOffset !== undefined && output.EndOffset !== null ? output.EndOffset : undefined,
-    Score: output.Score !== undefined && output.Score !== null ? output.Score : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    BeginOffset: __expectNumber(output.BeginOffset),
+    EndOffset: __expectNumber(output.EndOffset),
+    Score: __expectNumber(output.Score),
+    Type: __expectString(output.Type),
   } as any;
 };
 
 const deserializeAws_json1_1PiiOutputDataConfig = (output: any, context: __SerdeContext): PiiOutputDataConfig => {
   return {
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
-    S3Uri: output.S3Uri !== undefined && output.S3Uri !== null ? output.S3Uri : undefined,
+    KmsKeyId: __expectString(output.KmsKeyId),
+    S3Uri: __expectString(output.S3Uri),
   } as any;
 };
 
 const deserializeAws_json1_1RedactionConfig = (output: any, context: __SerdeContext): RedactionConfig => {
   return {
-    MaskCharacter:
-      output.MaskCharacter !== undefined && output.MaskCharacter !== null ? output.MaskCharacter : undefined,
-    MaskMode: output.MaskMode !== undefined && output.MaskMode !== null ? output.MaskMode : undefined,
+    MaskCharacter: __expectString(output.MaskCharacter),
+    MaskMode: __expectString(output.MaskMode),
     PiiEntityTypes:
       output.PiiEntityTypes !== undefined && output.PiiEntityTypes !== null
         ? deserializeAws_json1_1ListOfPiiEntityTypes(output.PiiEntityTypes, context)
@@ -9233,7 +9159,7 @@ const deserializeAws_json1_1RedactionConfig = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_1ResourceInUseException = (output: any, context: __SerdeContext): ResourceInUseException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -9242,7 +9168,7 @@ const deserializeAws_json1_1ResourceLimitExceededException = (
   context: __SerdeContext
 ): ResourceLimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -9251,7 +9177,7 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -9260,7 +9186,7 @@ const deserializeAws_json1_1ResourceUnavailableException = (
   context: __SerdeContext
 ): ResourceUnavailableException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -9271,7 +9197,7 @@ const deserializeAws_json1_1SecurityGroupIds = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -9280,21 +9206,18 @@ const deserializeAws_json1_1SentimentDetectionJobProperties = (
   context: __SerdeContext
 ): SentimentDetectionJobProperties => {
   return {
-    DataAccessRoleArn:
-      output.DataAccessRoleArn !== undefined && output.DataAccessRoleArn !== null
-        ? output.DataAccessRoleArn
-        : undefined,
+    DataAccessRoleArn: __expectString(output.DataAccessRoleArn),
     EndTime:
       output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
     InputDataConfig:
       output.InputDataConfig !== undefined && output.InputDataConfig !== null
         ? deserializeAws_json1_1InputDataConfig(output.InputDataConfig, context)
         : undefined,
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
-    JobName: output.JobName !== undefined && output.JobName !== null ? output.JobName : undefined,
-    JobStatus: output.JobStatus !== undefined && output.JobStatus !== null ? output.JobStatus : undefined,
-    LanguageCode: output.LanguageCode !== undefined && output.LanguageCode !== null ? output.LanguageCode : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    JobId: __expectString(output.JobId),
+    JobName: __expectString(output.JobName),
+    JobStatus: __expectString(output.JobStatus),
+    LanguageCode: __expectString(output.LanguageCode),
+    Message: __expectString(output.Message),
     OutputDataConfig:
       output.OutputDataConfig !== undefined && output.OutputDataConfig !== null
         ? deserializeAws_json1_1OutputDataConfig(output.OutputDataConfig, context)
@@ -9303,8 +9226,7 @@ const deserializeAws_json1_1SentimentDetectionJobProperties = (
       output.SubmitTime !== undefined && output.SubmitTime !== null
         ? new Date(Math.round(output.SubmitTime * 1000))
         : undefined,
-    VolumeKmsKeyId:
-      output.VolumeKmsKeyId !== undefined && output.VolumeKmsKeyId !== null ? output.VolumeKmsKeyId : undefined,
+    VolumeKmsKeyId: __expectString(output.VolumeKmsKeyId),
     VpcConfig:
       output.VpcConfig !== undefined && output.VpcConfig !== null
         ? deserializeAws_json1_1VpcConfig(output.VpcConfig, context)
@@ -9328,10 +9250,10 @@ const deserializeAws_json1_1SentimentDetectionJobPropertiesList = (
 
 const deserializeAws_json1_1SentimentScore = (output: any, context: __SerdeContext): SentimentScore => {
   return {
-    Mixed: output.Mixed !== undefined && output.Mixed !== null ? output.Mixed : undefined,
-    Negative: output.Negative !== undefined && output.Negative !== null ? output.Negative : undefined,
-    Neutral: output.Neutral !== undefined && output.Neutral !== null ? output.Neutral : undefined,
-    Positive: output.Positive !== undefined && output.Positive !== null ? output.Positive : undefined,
+    Mixed: __expectNumber(output.Mixed),
+    Negative: __expectNumber(output.Negative),
+    Neutral: __expectNumber(output.Neutral),
+    Positive: __expectNumber(output.Positive),
   } as any;
 };
 
@@ -9340,8 +9262,8 @@ const deserializeAws_json1_1StartDocumentClassificationJobResponse = (
   context: __SerdeContext
 ): StartDocumentClassificationJobResponse => {
   return {
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
-    JobStatus: output.JobStatus !== undefined && output.JobStatus !== null ? output.JobStatus : undefined,
+    JobId: __expectString(output.JobId),
+    JobStatus: __expectString(output.JobStatus),
   } as any;
 };
 
@@ -9350,8 +9272,8 @@ const deserializeAws_json1_1StartDominantLanguageDetectionJobResponse = (
   context: __SerdeContext
 ): StartDominantLanguageDetectionJobResponse => {
   return {
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
-    JobStatus: output.JobStatus !== undefined && output.JobStatus !== null ? output.JobStatus : undefined,
+    JobId: __expectString(output.JobId),
+    JobStatus: __expectString(output.JobStatus),
   } as any;
 };
 
@@ -9360,8 +9282,8 @@ const deserializeAws_json1_1StartEntitiesDetectionJobResponse = (
   context: __SerdeContext
 ): StartEntitiesDetectionJobResponse => {
   return {
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
-    JobStatus: output.JobStatus !== undefined && output.JobStatus !== null ? output.JobStatus : undefined,
+    JobId: __expectString(output.JobId),
+    JobStatus: __expectString(output.JobStatus),
   } as any;
 };
 
@@ -9370,8 +9292,8 @@ const deserializeAws_json1_1StartEventsDetectionJobResponse = (
   context: __SerdeContext
 ): StartEventsDetectionJobResponse => {
   return {
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
-    JobStatus: output.JobStatus !== undefined && output.JobStatus !== null ? output.JobStatus : undefined,
+    JobId: __expectString(output.JobId),
+    JobStatus: __expectString(output.JobStatus),
   } as any;
 };
 
@@ -9380,8 +9302,8 @@ const deserializeAws_json1_1StartKeyPhrasesDetectionJobResponse = (
   context: __SerdeContext
 ): StartKeyPhrasesDetectionJobResponse => {
   return {
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
-    JobStatus: output.JobStatus !== undefined && output.JobStatus !== null ? output.JobStatus : undefined,
+    JobId: __expectString(output.JobId),
+    JobStatus: __expectString(output.JobStatus),
   } as any;
 };
 
@@ -9390,8 +9312,8 @@ const deserializeAws_json1_1StartPiiEntitiesDetectionJobResponse = (
   context: __SerdeContext
 ): StartPiiEntitiesDetectionJobResponse => {
   return {
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
-    JobStatus: output.JobStatus !== undefined && output.JobStatus !== null ? output.JobStatus : undefined,
+    JobId: __expectString(output.JobId),
+    JobStatus: __expectString(output.JobStatus),
   } as any;
 };
 
@@ -9400,8 +9322,8 @@ const deserializeAws_json1_1StartSentimentDetectionJobResponse = (
   context: __SerdeContext
 ): StartSentimentDetectionJobResponse => {
   return {
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
-    JobStatus: output.JobStatus !== undefined && output.JobStatus !== null ? output.JobStatus : undefined,
+    JobId: __expectString(output.JobId),
+    JobStatus: __expectString(output.JobStatus),
   } as any;
 };
 
@@ -9410,8 +9332,8 @@ const deserializeAws_json1_1StartTopicsDetectionJobResponse = (
   context: __SerdeContext
 ): StartTopicsDetectionJobResponse => {
   return {
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
-    JobStatus: output.JobStatus !== undefined && output.JobStatus !== null ? output.JobStatus : undefined,
+    JobId: __expectString(output.JobId),
+    JobStatus: __expectString(output.JobStatus),
   } as any;
 };
 
@@ -9420,8 +9342,8 @@ const deserializeAws_json1_1StopDominantLanguageDetectionJobResponse = (
   context: __SerdeContext
 ): StopDominantLanguageDetectionJobResponse => {
   return {
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
-    JobStatus: output.JobStatus !== undefined && output.JobStatus !== null ? output.JobStatus : undefined,
+    JobId: __expectString(output.JobId),
+    JobStatus: __expectString(output.JobStatus),
   } as any;
 };
 
@@ -9430,8 +9352,8 @@ const deserializeAws_json1_1StopEntitiesDetectionJobResponse = (
   context: __SerdeContext
 ): StopEntitiesDetectionJobResponse => {
   return {
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
-    JobStatus: output.JobStatus !== undefined && output.JobStatus !== null ? output.JobStatus : undefined,
+    JobId: __expectString(output.JobId),
+    JobStatus: __expectString(output.JobStatus),
   } as any;
 };
 
@@ -9440,8 +9362,8 @@ const deserializeAws_json1_1StopEventsDetectionJobResponse = (
   context: __SerdeContext
 ): StopEventsDetectionJobResponse => {
   return {
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
-    JobStatus: output.JobStatus !== undefined && output.JobStatus !== null ? output.JobStatus : undefined,
+    JobId: __expectString(output.JobId),
+    JobStatus: __expectString(output.JobStatus),
   } as any;
 };
 
@@ -9450,8 +9372,8 @@ const deserializeAws_json1_1StopKeyPhrasesDetectionJobResponse = (
   context: __SerdeContext
 ): StopKeyPhrasesDetectionJobResponse => {
   return {
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
-    JobStatus: output.JobStatus !== undefined && output.JobStatus !== null ? output.JobStatus : undefined,
+    JobId: __expectString(output.JobId),
+    JobStatus: __expectString(output.JobStatus),
   } as any;
 };
 
@@ -9460,8 +9382,8 @@ const deserializeAws_json1_1StopPiiEntitiesDetectionJobResponse = (
   context: __SerdeContext
 ): StopPiiEntitiesDetectionJobResponse => {
   return {
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
-    JobStatus: output.JobStatus !== undefined && output.JobStatus !== null ? output.JobStatus : undefined,
+    JobId: __expectString(output.JobId),
+    JobStatus: __expectString(output.JobStatus),
   } as any;
 };
 
@@ -9470,8 +9392,8 @@ const deserializeAws_json1_1StopSentimentDetectionJobResponse = (
   context: __SerdeContext
 ): StopSentimentDetectionJobResponse => {
   return {
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
-    JobStatus: output.JobStatus !== undefined && output.JobStatus !== null ? output.JobStatus : undefined,
+    JobId: __expectString(output.JobId),
+    JobStatus: __expectString(output.JobStatus),
   } as any;
 };
 
@@ -9496,27 +9418,27 @@ const deserializeAws_json1_1Subnets = (output: any, context: __SerdeContext): st
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1SyntaxToken = (output: any, context: __SerdeContext): SyntaxToken => {
   return {
-    BeginOffset: output.BeginOffset !== undefined && output.BeginOffset !== null ? output.BeginOffset : undefined,
-    EndOffset: output.EndOffset !== undefined && output.EndOffset !== null ? output.EndOffset : undefined,
+    BeginOffset: __expectNumber(output.BeginOffset),
+    EndOffset: __expectNumber(output.EndOffset),
     PartOfSpeech:
       output.PartOfSpeech !== undefined && output.PartOfSpeech !== null
         ? deserializeAws_json1_1PartOfSpeechTag(output.PartOfSpeech, context)
         : undefined,
-    Text: output.Text !== undefined && output.Text !== null ? output.Text : undefined,
-    TokenId: output.TokenId !== undefined && output.TokenId !== null ? output.TokenId : undefined,
+    Text: __expectString(output.Text),
+    TokenId: __expectNumber(output.TokenId),
   } as any;
 };
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -9542,7 +9464,7 @@ const deserializeAws_json1_1TargetEventTypes = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -9551,7 +9473,7 @@ const deserializeAws_json1_1TextSizeLimitExceededException = (
   context: __SerdeContext
 ): TextSizeLimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -9560,7 +9482,7 @@ const deserializeAws_json1_1TooManyRequestsException = (
   context: __SerdeContext
 ): TooManyRequestsException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -9569,13 +9491,13 @@ const deserializeAws_json1_1TooManyTagKeysException = (
   context: __SerdeContext
 ): TooManyTagKeysException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1TooManyTagsException = (output: any, context: __SerdeContext): TooManyTagsException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -9584,22 +9506,18 @@ const deserializeAws_json1_1TopicsDetectionJobProperties = (
   context: __SerdeContext
 ): TopicsDetectionJobProperties => {
   return {
-    DataAccessRoleArn:
-      output.DataAccessRoleArn !== undefined && output.DataAccessRoleArn !== null
-        ? output.DataAccessRoleArn
-        : undefined,
+    DataAccessRoleArn: __expectString(output.DataAccessRoleArn),
     EndTime:
       output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
     InputDataConfig:
       output.InputDataConfig !== undefined && output.InputDataConfig !== null
         ? deserializeAws_json1_1InputDataConfig(output.InputDataConfig, context)
         : undefined,
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
-    JobName: output.JobName !== undefined && output.JobName !== null ? output.JobName : undefined,
-    JobStatus: output.JobStatus !== undefined && output.JobStatus !== null ? output.JobStatus : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    NumberOfTopics:
-      output.NumberOfTopics !== undefined && output.NumberOfTopics !== null ? output.NumberOfTopics : undefined,
+    JobId: __expectString(output.JobId),
+    JobName: __expectString(output.JobName),
+    JobStatus: __expectString(output.JobStatus),
+    Message: __expectString(output.Message),
+    NumberOfTopics: __expectNumber(output.NumberOfTopics),
     OutputDataConfig:
       output.OutputDataConfig !== undefined && output.OutputDataConfig !== null
         ? deserializeAws_json1_1OutputDataConfig(output.OutputDataConfig, context)
@@ -9608,8 +9526,7 @@ const deserializeAws_json1_1TopicsDetectionJobProperties = (
       output.SubmitTime !== undefined && output.SubmitTime !== null
         ? new Date(Math.round(output.SubmitTime * 1000))
         : undefined,
-    VolumeKmsKeyId:
-      output.VolumeKmsKeyId !== undefined && output.VolumeKmsKeyId !== null ? output.VolumeKmsKeyId : undefined,
+    VolumeKmsKeyId: __expectString(output.VolumeKmsKeyId),
     VpcConfig:
       output.VpcConfig !== undefined && output.VpcConfig !== null
         ? deserializeAws_json1_1VpcConfig(output.VpcConfig, context)
@@ -9636,7 +9553,7 @@ const deserializeAws_json1_1UnsupportedLanguageException = (
   context: __SerdeContext
 ): UnsupportedLanguageException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 

--- a/clients/client-comprehendmedical/protocols/Aws_json1_1.ts
+++ b/clients/client-comprehendmedical/protocols/Aws_json1_1.ts
@@ -136,7 +136,11 @@ import {
   ValidationException,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -2493,23 +2497,19 @@ const serializeAws_json1_1StopRxNormInferenceJobRequest = (
 
 const deserializeAws_json1_1Attribute = (output: any, context: __SerdeContext): Attribute => {
   return {
-    BeginOffset: output.BeginOffset !== undefined && output.BeginOffset !== null ? output.BeginOffset : undefined,
-    Category: output.Category !== undefined && output.Category !== null ? output.Category : undefined,
-    EndOffset: output.EndOffset !== undefined && output.EndOffset !== null ? output.EndOffset : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    RelationshipScore:
-      output.RelationshipScore !== undefined && output.RelationshipScore !== null
-        ? output.RelationshipScore
-        : undefined,
-    RelationshipType:
-      output.RelationshipType !== undefined && output.RelationshipType !== null ? output.RelationshipType : undefined,
-    Score: output.Score !== undefined && output.Score !== null ? output.Score : undefined,
-    Text: output.Text !== undefined && output.Text !== null ? output.Text : undefined,
+    BeginOffset: __expectNumber(output.BeginOffset),
+    Category: __expectString(output.Category),
+    EndOffset: __expectNumber(output.EndOffset),
+    Id: __expectNumber(output.Id),
+    RelationshipScore: __expectNumber(output.RelationshipScore),
+    RelationshipType: __expectString(output.RelationshipType),
+    Score: __expectNumber(output.Score),
+    Text: __expectString(output.Text),
     Traits:
       output.Traits !== undefined && output.Traits !== null
         ? deserializeAws_json1_1TraitList(output.Traits, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -2529,10 +2529,7 @@ const deserializeAws_json1_1ComprehendMedicalAsyncJobProperties = (
   context: __SerdeContext
 ): ComprehendMedicalAsyncJobProperties => {
   return {
-    DataAccessRoleArn:
-      output.DataAccessRoleArn !== undefined && output.DataAccessRoleArn !== null
-        ? output.DataAccessRoleArn
-        : undefined,
+    DataAccessRoleArn: __expectString(output.DataAccessRoleArn),
     EndTime:
       output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
     ExpirationTime:
@@ -2543,15 +2540,14 @@ const deserializeAws_json1_1ComprehendMedicalAsyncJobProperties = (
       output.InputDataConfig !== undefined && output.InputDataConfig !== null
         ? deserializeAws_json1_1InputDataConfig(output.InputDataConfig, context)
         : undefined,
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
-    JobName: output.JobName !== undefined && output.JobName !== null ? output.JobName : undefined,
-    JobStatus: output.JobStatus !== undefined && output.JobStatus !== null ? output.JobStatus : undefined,
-    KMSKey: output.KMSKey !== undefined && output.KMSKey !== null ? output.KMSKey : undefined,
-    LanguageCode: output.LanguageCode !== undefined && output.LanguageCode !== null ? output.LanguageCode : undefined,
-    ManifestFilePath:
-      output.ManifestFilePath !== undefined && output.ManifestFilePath !== null ? output.ManifestFilePath : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    ModelVersion: output.ModelVersion !== undefined && output.ModelVersion !== null ? output.ModelVersion : undefined,
+    JobId: __expectString(output.JobId),
+    JobName: __expectString(output.JobName),
+    JobStatus: __expectString(output.JobStatus),
+    KMSKey: __expectString(output.KMSKey),
+    LanguageCode: __expectString(output.LanguageCode),
+    ManifestFilePath: __expectString(output.ManifestFilePath),
+    Message: __expectString(output.Message),
+    ModelVersion: __expectString(output.ModelVersion),
     OutputDataConfig:
       output.OutputDataConfig !== undefined && output.OutputDataConfig !== null
         ? deserializeAws_json1_1OutputDataConfig(output.OutputDataConfig, context)
@@ -2631,9 +2627,8 @@ const deserializeAws_json1_1DetectEntitiesResponse = (output: any, context: __Se
       output.Entities !== undefined && output.Entities !== null
         ? deserializeAws_json1_1EntityList(output.Entities, context)
         : undefined,
-    ModelVersion: output.ModelVersion !== undefined && output.ModelVersion !== null ? output.ModelVersion : undefined,
-    PaginationToken:
-      output.PaginationToken !== undefined && output.PaginationToken !== null ? output.PaginationToken : undefined,
+    ModelVersion: __expectString(output.ModelVersion),
+    PaginationToken: __expectString(output.PaginationToken),
     UnmappedAttributes:
       output.UnmappedAttributes !== undefined && output.UnmappedAttributes !== null
         ? deserializeAws_json1_1UnmappedAttributeList(output.UnmappedAttributes, context)
@@ -2650,9 +2645,8 @@ const deserializeAws_json1_1DetectEntitiesV2Response = (
       output.Entities !== undefined && output.Entities !== null
         ? deserializeAws_json1_1EntityList(output.Entities, context)
         : undefined,
-    ModelVersion: output.ModelVersion !== undefined && output.ModelVersion !== null ? output.ModelVersion : undefined,
-    PaginationToken:
-      output.PaginationToken !== undefined && output.PaginationToken !== null ? output.PaginationToken : undefined,
+    ModelVersion: __expectString(output.ModelVersion),
+    PaginationToken: __expectString(output.PaginationToken),
     UnmappedAttributes:
       output.UnmappedAttributes !== undefined && output.UnmappedAttributes !== null
         ? deserializeAws_json1_1UnmappedAttributeList(output.UnmappedAttributes, context)
@@ -2666,9 +2660,8 @@ const deserializeAws_json1_1DetectPHIResponse = (output: any, context: __SerdeCo
       output.Entities !== undefined && output.Entities !== null
         ? deserializeAws_json1_1EntityList(output.Entities, context)
         : undefined,
-    ModelVersion: output.ModelVersion !== undefined && output.ModelVersion !== null ? output.ModelVersion : undefined,
-    PaginationToken:
-      output.PaginationToken !== undefined && output.PaginationToken !== null ? output.PaginationToken : undefined,
+    ModelVersion: __expectString(output.ModelVersion),
+    PaginationToken: __expectString(output.PaginationToken),
   } as any;
 };
 
@@ -2678,17 +2671,17 @@ const deserializeAws_json1_1Entity = (output: any, context: __SerdeContext): Ent
       output.Attributes !== undefined && output.Attributes !== null
         ? deserializeAws_json1_1AttributeList(output.Attributes, context)
         : undefined,
-    BeginOffset: output.BeginOffset !== undefined && output.BeginOffset !== null ? output.BeginOffset : undefined,
-    Category: output.Category !== undefined && output.Category !== null ? output.Category : undefined,
-    EndOffset: output.EndOffset !== undefined && output.EndOffset !== null ? output.EndOffset : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Score: output.Score !== undefined && output.Score !== null ? output.Score : undefined,
-    Text: output.Text !== undefined && output.Text !== null ? output.Text : undefined,
+    BeginOffset: __expectNumber(output.BeginOffset),
+    Category: __expectString(output.Category),
+    EndOffset: __expectNumber(output.EndOffset),
+    Id: __expectNumber(output.Id),
+    Score: __expectNumber(output.Score),
+    Text: __expectString(output.Text),
     Traits:
       output.Traits !== undefined && output.Traits !== null
         ? deserializeAws_json1_1TraitList(output.Traits, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -2705,23 +2698,19 @@ const deserializeAws_json1_1EntityList = (output: any, context: __SerdeContext):
 
 const deserializeAws_json1_1ICD10CMAttribute = (output: any, context: __SerdeContext): ICD10CMAttribute => {
   return {
-    BeginOffset: output.BeginOffset !== undefined && output.BeginOffset !== null ? output.BeginOffset : undefined,
-    Category: output.Category !== undefined && output.Category !== null ? output.Category : undefined,
-    EndOffset: output.EndOffset !== undefined && output.EndOffset !== null ? output.EndOffset : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    RelationshipScore:
-      output.RelationshipScore !== undefined && output.RelationshipScore !== null
-        ? output.RelationshipScore
-        : undefined,
-    RelationshipType:
-      output.RelationshipType !== undefined && output.RelationshipType !== null ? output.RelationshipType : undefined,
-    Score: output.Score !== undefined && output.Score !== null ? output.Score : undefined,
-    Text: output.Text !== undefined && output.Text !== null ? output.Text : undefined,
+    BeginOffset: __expectNumber(output.BeginOffset),
+    Category: __expectString(output.Category),
+    EndOffset: __expectNumber(output.EndOffset),
+    Id: __expectNumber(output.Id),
+    RelationshipScore: __expectNumber(output.RelationshipScore),
+    RelationshipType: __expectString(output.RelationshipType),
+    Score: __expectNumber(output.Score),
+    Text: __expectString(output.Text),
     Traits:
       output.Traits !== undefined && output.Traits !== null
         ? deserializeAws_json1_1ICD10CMTraitList(output.Traits, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -2738,9 +2727,9 @@ const deserializeAws_json1_1ICD10CMAttributeList = (output: any, context: __Serd
 
 const deserializeAws_json1_1ICD10CMConcept = (output: any, context: __SerdeContext): ICD10CMConcept => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Score: output.Score !== undefined && output.Score !== null ? output.Score : undefined,
+    Code: __expectString(output.Code),
+    Description: __expectString(output.Description),
+    Score: __expectNumber(output.Score),
   } as any;
 };
 
@@ -2761,21 +2750,21 @@ const deserializeAws_json1_1ICD10CMEntity = (output: any, context: __SerdeContex
       output.Attributes !== undefined && output.Attributes !== null
         ? deserializeAws_json1_1ICD10CMAttributeList(output.Attributes, context)
         : undefined,
-    BeginOffset: output.BeginOffset !== undefined && output.BeginOffset !== null ? output.BeginOffset : undefined,
-    Category: output.Category !== undefined && output.Category !== null ? output.Category : undefined,
-    EndOffset: output.EndOffset !== undefined && output.EndOffset !== null ? output.EndOffset : undefined,
+    BeginOffset: __expectNumber(output.BeginOffset),
+    Category: __expectString(output.Category),
+    EndOffset: __expectNumber(output.EndOffset),
     ICD10CMConcepts:
       output.ICD10CMConcepts !== undefined && output.ICD10CMConcepts !== null
         ? deserializeAws_json1_1ICD10CMConceptList(output.ICD10CMConcepts, context)
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Score: output.Score !== undefined && output.Score !== null ? output.Score : undefined,
-    Text: output.Text !== undefined && output.Text !== null ? output.Text : undefined,
+    Id: __expectNumber(output.Id),
+    Score: __expectNumber(output.Score),
+    Text: __expectString(output.Text),
     Traits:
       output.Traits !== undefined && output.Traits !== null
         ? deserializeAws_json1_1ICD10CMTraitList(output.Traits, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -2792,8 +2781,8 @@ const deserializeAws_json1_1ICD10CMEntityList = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1ICD10CMTrait = (output: any, context: __SerdeContext): ICD10CMTrait => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Score: output.Score !== undefined && output.Score !== null ? output.Score : undefined,
+    Name: __expectString(output.Name),
+    Score: __expectNumber(output.Score),
   } as any;
 };
 
@@ -2814,9 +2803,8 @@ const deserializeAws_json1_1InferICD10CMResponse = (output: any, context: __Serd
       output.Entities !== undefined && output.Entities !== null
         ? deserializeAws_json1_1ICD10CMEntityList(output.Entities, context)
         : undefined,
-    ModelVersion: output.ModelVersion !== undefined && output.ModelVersion !== null ? output.ModelVersion : undefined,
-    PaginationToken:
-      output.PaginationToken !== undefined && output.PaginationToken !== null ? output.PaginationToken : undefined,
+    ModelVersion: __expectString(output.ModelVersion),
+    PaginationToken: __expectString(output.PaginationToken),
   } as any;
 };
 
@@ -2826,16 +2814,15 @@ const deserializeAws_json1_1InferRxNormResponse = (output: any, context: __Serde
       output.Entities !== undefined && output.Entities !== null
         ? deserializeAws_json1_1RxNormEntityList(output.Entities, context)
         : undefined,
-    ModelVersion: output.ModelVersion !== undefined && output.ModelVersion !== null ? output.ModelVersion : undefined,
-    PaginationToken:
-      output.PaginationToken !== undefined && output.PaginationToken !== null ? output.PaginationToken : undefined,
+    ModelVersion: __expectString(output.ModelVersion),
+    PaginationToken: __expectString(output.PaginationToken),
   } as any;
 };
 
 const deserializeAws_json1_1InputDataConfig = (output: any, context: __SerdeContext): InputDataConfig => {
   return {
-    S3Bucket: output.S3Bucket !== undefined && output.S3Bucket !== null ? output.S3Bucket : undefined,
-    S3Key: output.S3Key !== undefined && output.S3Key !== null ? output.S3Key : undefined,
+    S3Bucket: __expectString(output.S3Bucket),
+    S3Key: __expectString(output.S3Key),
   } as any;
 };
 
@@ -2844,7 +2831,7 @@ const deserializeAws_json1_1InternalServerException = (
   context: __SerdeContext
 ): InternalServerException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2853,7 +2840,7 @@ const deserializeAws_json1_1InvalidEncodingException = (
   context: __SerdeContext
 ): InvalidEncodingException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2862,7 +2849,7 @@ const deserializeAws_json1_1InvalidRequestException = (
   context: __SerdeContext
 ): InvalidRequestException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2879,7 +2866,7 @@ const deserializeAws_json1_1ListEntitiesDetectionV2JobsResponse = (
             context
           )
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -2896,7 +2883,7 @@ const deserializeAws_json1_1ListICD10CMInferenceJobsResponse = (
             context
           )
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -2913,7 +2900,7 @@ const deserializeAws_json1_1ListPHIDetectionJobsResponse = (
             context
           )
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -2930,14 +2917,14 @@ const deserializeAws_json1_1ListRxNormInferenceJobsResponse = (
             context
           )
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
 const deserializeAws_json1_1OutputDataConfig = (output: any, context: __SerdeContext): OutputDataConfig => {
   return {
-    S3Bucket: output.S3Bucket !== undefined && output.S3Bucket !== null ? output.S3Bucket : undefined,
-    S3Key: output.S3Key !== undefined && output.S3Key !== null ? output.S3Key : undefined,
+    S3Bucket: __expectString(output.S3Bucket),
+    S3Key: __expectString(output.S3Key),
   } as any;
 };
 
@@ -2946,26 +2933,23 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1RxNormAttribute = (output: any, context: __SerdeContext): RxNormAttribute => {
   return {
-    BeginOffset: output.BeginOffset !== undefined && output.BeginOffset !== null ? output.BeginOffset : undefined,
-    EndOffset: output.EndOffset !== undefined && output.EndOffset !== null ? output.EndOffset : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    RelationshipScore:
-      output.RelationshipScore !== undefined && output.RelationshipScore !== null
-        ? output.RelationshipScore
-        : undefined,
-    Score: output.Score !== undefined && output.Score !== null ? output.Score : undefined,
-    Text: output.Text !== undefined && output.Text !== null ? output.Text : undefined,
+    BeginOffset: __expectNumber(output.BeginOffset),
+    EndOffset: __expectNumber(output.EndOffset),
+    Id: __expectNumber(output.Id),
+    RelationshipScore: __expectNumber(output.RelationshipScore),
+    Score: __expectNumber(output.Score),
+    Text: __expectString(output.Text),
     Traits:
       output.Traits !== undefined && output.Traits !== null
         ? deserializeAws_json1_1RxNormTraitList(output.Traits, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -2982,9 +2966,9 @@ const deserializeAws_json1_1RxNormAttributeList = (output: any, context: __Serde
 
 const deserializeAws_json1_1RxNormConcept = (output: any, context: __SerdeContext): RxNormConcept => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Score: output.Score !== undefined && output.Score !== null ? output.Score : undefined,
+    Code: __expectString(output.Code),
+    Description: __expectString(output.Description),
+    Score: __expectNumber(output.Score),
   } as any;
 };
 
@@ -3005,21 +2989,21 @@ const deserializeAws_json1_1RxNormEntity = (output: any, context: __SerdeContext
       output.Attributes !== undefined && output.Attributes !== null
         ? deserializeAws_json1_1RxNormAttributeList(output.Attributes, context)
         : undefined,
-    BeginOffset: output.BeginOffset !== undefined && output.BeginOffset !== null ? output.BeginOffset : undefined,
-    Category: output.Category !== undefined && output.Category !== null ? output.Category : undefined,
-    EndOffset: output.EndOffset !== undefined && output.EndOffset !== null ? output.EndOffset : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    BeginOffset: __expectNumber(output.BeginOffset),
+    Category: __expectString(output.Category),
+    EndOffset: __expectNumber(output.EndOffset),
+    Id: __expectNumber(output.Id),
     RxNormConcepts:
       output.RxNormConcepts !== undefined && output.RxNormConcepts !== null
         ? deserializeAws_json1_1RxNormConceptList(output.RxNormConcepts, context)
         : undefined,
-    Score: output.Score !== undefined && output.Score !== null ? output.Score : undefined,
-    Text: output.Text !== undefined && output.Text !== null ? output.Text : undefined,
+    Score: __expectNumber(output.Score),
+    Text: __expectString(output.Text),
     Traits:
       output.Traits !== undefined && output.Traits !== null
         ? deserializeAws_json1_1RxNormTraitList(output.Traits, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -3036,8 +3020,8 @@ const deserializeAws_json1_1RxNormEntityList = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1RxNormTrait = (output: any, context: __SerdeContext): RxNormTrait => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Score: output.Score !== undefined && output.Score !== null ? output.Score : undefined,
+    Name: __expectString(output.Name),
+    Score: __expectNumber(output.Score),
   } as any;
 };
 
@@ -3057,7 +3041,7 @@ const deserializeAws_json1_1ServiceUnavailableException = (
   context: __SerdeContext
 ): ServiceUnavailableException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3066,7 +3050,7 @@ const deserializeAws_json1_1StartEntitiesDetectionV2JobResponse = (
   context: __SerdeContext
 ): StartEntitiesDetectionV2JobResponse => {
   return {
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
+    JobId: __expectString(output.JobId),
   } as any;
 };
 
@@ -3075,7 +3059,7 @@ const deserializeAws_json1_1StartICD10CMInferenceJobResponse = (
   context: __SerdeContext
 ): StartICD10CMInferenceJobResponse => {
   return {
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
+    JobId: __expectString(output.JobId),
   } as any;
 };
 
@@ -3084,7 +3068,7 @@ const deserializeAws_json1_1StartPHIDetectionJobResponse = (
   context: __SerdeContext
 ): StartPHIDetectionJobResponse => {
   return {
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
+    JobId: __expectString(output.JobId),
   } as any;
 };
 
@@ -3093,7 +3077,7 @@ const deserializeAws_json1_1StartRxNormInferenceJobResponse = (
   context: __SerdeContext
 ): StartRxNormInferenceJobResponse => {
   return {
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
+    JobId: __expectString(output.JobId),
   } as any;
 };
 
@@ -3102,7 +3086,7 @@ const deserializeAws_json1_1StopEntitiesDetectionV2JobResponse = (
   context: __SerdeContext
 ): StopEntitiesDetectionV2JobResponse => {
   return {
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
+    JobId: __expectString(output.JobId),
   } as any;
 };
 
@@ -3111,7 +3095,7 @@ const deserializeAws_json1_1StopICD10CMInferenceJobResponse = (
   context: __SerdeContext
 ): StopICD10CMInferenceJobResponse => {
   return {
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
+    JobId: __expectString(output.JobId),
   } as any;
 };
 
@@ -3120,7 +3104,7 @@ const deserializeAws_json1_1StopPHIDetectionJobResponse = (
   context: __SerdeContext
 ): StopPHIDetectionJobResponse => {
   return {
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
+    JobId: __expectString(output.JobId),
   } as any;
 };
 
@@ -3129,7 +3113,7 @@ const deserializeAws_json1_1StopRxNormInferenceJobResponse = (
   context: __SerdeContext
 ): StopRxNormInferenceJobResponse => {
   return {
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
+    JobId: __expectString(output.JobId),
   } as any;
 };
 
@@ -3138,7 +3122,7 @@ const deserializeAws_json1_1TextSizeLimitExceededException = (
   context: __SerdeContext
 ): TextSizeLimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3147,14 +3131,14 @@ const deserializeAws_json1_1TooManyRequestsException = (
   context: __SerdeContext
 ): TooManyRequestsException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1Trait = (output: any, context: __SerdeContext): Trait => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Score: output.Score !== undefined && output.Score !== null ? output.Score : undefined,
+    Name: __expectString(output.Name),
+    Score: __expectNumber(output.Score),
   } as any;
 };
 
@@ -3175,7 +3159,7 @@ const deserializeAws_json1_1UnmappedAttribute = (output: any, context: __SerdeCo
       output.Attribute !== undefined && output.Attribute !== null
         ? deserializeAws_json1_1Attribute(output.Attribute, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -3192,7 +3176,7 @@ const deserializeAws_json1_1UnmappedAttributeList = (output: any, context: __Ser
 
 const deserializeAws_json1_1ValidationException = (output: any, context: __SerdeContext): ValidationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 

--- a/clients/client-compute-optimizer/protocols/Aws_json1_0.ts
+++ b/clients/client-compute-optimizer/protocols/Aws_json1_0.ts
@@ -124,7 +124,12 @@ import {
   VolumeRecommendationOption,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -2272,7 +2277,7 @@ const serializeAws_json1_0VolumeArns = (input: string[], context: __SerdeContext
 
 const deserializeAws_json1_0AccessDeniedException = (output: any, context: __SerdeContext): AccessDeniedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -2281,11 +2286,10 @@ const deserializeAws_json1_0AutoScalingGroupConfiguration = (
   context: __SerdeContext
 ): AutoScalingGroupConfiguration => {
   return {
-    desiredCapacity:
-      output.desiredCapacity !== undefined && output.desiredCapacity !== null ? output.desiredCapacity : undefined,
-    instanceType: output.instanceType !== undefined && output.instanceType !== null ? output.instanceType : undefined,
-    maxSize: output.maxSize !== undefined && output.maxSize !== null ? output.maxSize : undefined,
-    minSize: output.minSize !== undefined && output.minSize !== null ? output.minSize : undefined,
+    desiredCapacity: __expectNumber(output.desiredCapacity),
+    instanceType: __expectString(output.instanceType),
+    maxSize: __expectNumber(output.maxSize),
+    minSize: __expectNumber(output.minSize),
   } as any;
 };
 
@@ -2294,28 +2298,19 @@ const deserializeAws_json1_0AutoScalingGroupRecommendation = (
   context: __SerdeContext
 ): AutoScalingGroupRecommendation => {
   return {
-    accountId: output.accountId !== undefined && output.accountId !== null ? output.accountId : undefined,
-    autoScalingGroupArn:
-      output.autoScalingGroupArn !== undefined && output.autoScalingGroupArn !== null
-        ? output.autoScalingGroupArn
-        : undefined,
-    autoScalingGroupName:
-      output.autoScalingGroupName !== undefined && output.autoScalingGroupName !== null
-        ? output.autoScalingGroupName
-        : undefined,
+    accountId: __expectString(output.accountId),
+    autoScalingGroupArn: __expectString(output.autoScalingGroupArn),
+    autoScalingGroupName: __expectString(output.autoScalingGroupName),
     currentConfiguration:
       output.currentConfiguration !== undefined && output.currentConfiguration !== null
         ? deserializeAws_json1_0AutoScalingGroupConfiguration(output.currentConfiguration, context)
         : undefined,
-    finding: output.finding !== undefined && output.finding !== null ? output.finding : undefined,
+    finding: __expectString(output.finding),
     lastRefreshTimestamp:
       output.lastRefreshTimestamp !== undefined && output.lastRefreshTimestamp !== null
         ? new Date(Math.round(output.lastRefreshTimestamp * 1000))
         : undefined,
-    lookBackPeriodInDays:
-      output.lookBackPeriodInDays !== undefined && output.lookBackPeriodInDays !== null
-        ? output.lookBackPeriodInDays
-        : undefined,
+    lookBackPeriodInDays: __expectNumber(output.lookBackPeriodInDays),
     recommendationOptions:
       output.recommendationOptions !== undefined && output.recommendationOptions !== null
         ? deserializeAws_json1_0AutoScalingGroupRecommendationOptions(output.recommendationOptions, context)
@@ -2336,13 +2331,12 @@ const deserializeAws_json1_0AutoScalingGroupRecommendationOption = (
       output.configuration !== undefined && output.configuration !== null
         ? deserializeAws_json1_0AutoScalingGroupConfiguration(output.configuration, context)
         : undefined,
-    performanceRisk:
-      output.performanceRisk !== undefined && output.performanceRisk !== null ? output.performanceRisk : undefined,
+    performanceRisk: __expectNumber(output.performanceRisk),
     projectedUtilizationMetrics:
       output.projectedUtilizationMetrics !== undefined && output.projectedUtilizationMetrics !== null
         ? deserializeAws_json1_0ProjectedUtilizationMetrics(output.projectedUtilizationMetrics, context)
         : undefined,
-    rank: output.rank !== undefined && output.rank !== null ? output.rank : undefined,
+    rank: __expectNumber(output.rank),
   } as any;
 };
 
@@ -2379,7 +2373,7 @@ const deserializeAws_json1_0DescribeRecommendationExportJobsResponse = (
   context: __SerdeContext
 ): DescribeRecommendationExportJobsResponse => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     recommendationExportJobs:
       output.recommendationExportJobs !== undefined && output.recommendationExportJobs !== null
         ? deserializeAws_json1_0RecommendationExportJobs(output.recommendationExportJobs, context)
@@ -2389,9 +2383,9 @@ const deserializeAws_json1_0DescribeRecommendationExportJobsResponse = (
 
 const deserializeAws_json1_0EBSUtilizationMetric = (output: any, context: __SerdeContext): EBSUtilizationMetric => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    statistic: output.statistic !== undefined && output.statistic !== null ? output.statistic : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    name: __expectString(output.name),
+    statistic: __expectString(output.statistic),
+    value: __expectNumber(output.value),
   } as any;
 };
 
@@ -2411,7 +2405,7 @@ const deserializeAws_json1_0ExportAutoScalingGroupRecommendationsResponse = (
   context: __SerdeContext
 ): ExportAutoScalingGroupRecommendationsResponse => {
   return {
-    jobId: output.jobId !== undefined && output.jobId !== null ? output.jobId : undefined,
+    jobId: __expectString(output.jobId),
     s3Destination:
       output.s3Destination !== undefined && output.s3Destination !== null
         ? deserializeAws_json1_0S3Destination(output.s3Destination, context)
@@ -2433,7 +2427,7 @@ const deserializeAws_json1_0ExportEBSVolumeRecommendationsResponse = (
   context: __SerdeContext
 ): ExportEBSVolumeRecommendationsResponse => {
   return {
-    jobId: output.jobId !== undefined && output.jobId !== null ? output.jobId : undefined,
+    jobId: __expectString(output.jobId),
     s3Destination:
       output.s3Destination !== undefined && output.s3Destination !== null
         ? deserializeAws_json1_0S3Destination(output.s3Destination, context)
@@ -2446,7 +2440,7 @@ const deserializeAws_json1_0ExportEC2InstanceRecommendationsResponse = (
   context: __SerdeContext
 ): ExportEC2InstanceRecommendationsResponse => {
   return {
-    jobId: output.jobId !== undefined && output.jobId !== null ? output.jobId : undefined,
+    jobId: __expectString(output.jobId),
     s3Destination:
       output.s3Destination !== undefined && output.s3Destination !== null
         ? deserializeAws_json1_0S3Destination(output.s3Destination, context)
@@ -2459,7 +2453,7 @@ const deserializeAws_json1_0ExportLambdaFunctionRecommendationsResponse = (
   context: __SerdeContext
 ): ExportLambdaFunctionRecommendationsResponse => {
   return {
-    jobId: output.jobId !== undefined && output.jobId !== null ? output.jobId : undefined,
+    jobId: __expectString(output.jobId),
     s3Destination:
       output.s3Destination !== undefined && output.s3Destination !== null
         ? deserializeAws_json1_0S3Destination(output.s3Destination, context)
@@ -2480,7 +2474,7 @@ const deserializeAws_json1_0GetAutoScalingGroupRecommendationsResponse = (
       output.errors !== undefined && output.errors !== null
         ? deserializeAws_json1_0GetRecommendationErrors(output.errors, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -2493,7 +2487,7 @@ const deserializeAws_json1_0GetEBSVolumeRecommendationsResponse = (
       output.errors !== undefined && output.errors !== null
         ? deserializeAws_json1_0GetRecommendationErrors(output.errors, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     volumeRecommendations:
       output.volumeRecommendations !== undefined && output.volumeRecommendations !== null
         ? deserializeAws_json1_0VolumeRecommendations(output.volumeRecommendations, context)
@@ -2514,7 +2508,7 @@ const deserializeAws_json1_0GetEC2InstanceRecommendationsResponse = (
       output.instanceRecommendations !== undefined && output.instanceRecommendations !== null
         ? deserializeAws_json1_0InstanceRecommendations(output.instanceRecommendations, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -2535,12 +2529,9 @@ const deserializeAws_json1_0GetEnrollmentStatusResponse = (
   context: __SerdeContext
 ): GetEnrollmentStatusResponse => {
   return {
-    memberAccountsEnrolled:
-      output.memberAccountsEnrolled !== undefined && output.memberAccountsEnrolled !== null
-        ? output.memberAccountsEnrolled
-        : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    statusReason: output.statusReason !== undefined && output.statusReason !== null ? output.statusReason : undefined,
+    memberAccountsEnrolled: __expectBoolean(output.memberAccountsEnrolled),
+    status: __expectString(output.status),
+    statusReason: __expectString(output.statusReason),
   } as any;
 };
 
@@ -2553,15 +2544,15 @@ const deserializeAws_json1_0GetLambdaFunctionRecommendationsResponse = (
       output.lambdaFunctionRecommendations !== undefined && output.lambdaFunctionRecommendations !== null
         ? deserializeAws_json1_0LambdaFunctionRecommendations(output.lambdaFunctionRecommendations, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
 const deserializeAws_json1_0GetRecommendationError = (output: any, context: __SerdeContext): GetRecommendationError => {
   return {
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    identifier: output.identifier !== undefined && output.identifier !== null ? output.identifier : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    code: __expectString(output.code),
+    identifier: __expectString(output.identifier),
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -2584,7 +2575,7 @@ const deserializeAws_json1_0GetRecommendationSummariesResponse = (
   context: __SerdeContext
 ): GetRecommendationSummariesResponse => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     recommendationSummaries:
       output.recommendationSummaries !== undefined && output.recommendationSummaries !== null
         ? deserializeAws_json1_0RecommendationSummaries(output.recommendationSummaries, context)
@@ -2594,26 +2585,20 @@ const deserializeAws_json1_0GetRecommendationSummariesResponse = (
 
 const deserializeAws_json1_0InstanceRecommendation = (output: any, context: __SerdeContext): InstanceRecommendation => {
   return {
-    accountId: output.accountId !== undefined && output.accountId !== null ? output.accountId : undefined,
-    currentInstanceType:
-      output.currentInstanceType !== undefined && output.currentInstanceType !== null
-        ? output.currentInstanceType
-        : undefined,
-    finding: output.finding !== undefined && output.finding !== null ? output.finding : undefined,
+    accountId: __expectString(output.accountId),
+    currentInstanceType: __expectString(output.currentInstanceType),
+    finding: __expectString(output.finding),
     findingReasonCodes:
       output.findingReasonCodes !== undefined && output.findingReasonCodes !== null
         ? deserializeAws_json1_0InstanceRecommendationFindingReasonCodes(output.findingReasonCodes, context)
         : undefined,
-    instanceArn: output.instanceArn !== undefined && output.instanceArn !== null ? output.instanceArn : undefined,
-    instanceName: output.instanceName !== undefined && output.instanceName !== null ? output.instanceName : undefined,
+    instanceArn: __expectString(output.instanceArn),
+    instanceName: __expectString(output.instanceName),
     lastRefreshTimestamp:
       output.lastRefreshTimestamp !== undefined && output.lastRefreshTimestamp !== null
         ? new Date(Math.round(output.lastRefreshTimestamp * 1000))
         : undefined,
-    lookBackPeriodInDays:
-      output.lookBackPeriodInDays !== undefined && output.lookBackPeriodInDays !== null
-        ? output.lookBackPeriodInDays
-        : undefined,
+    lookBackPeriodInDays: __expectNumber(output.lookBackPeriodInDays),
     recommendationOptions:
       output.recommendationOptions !== undefined && output.recommendationOptions !== null
         ? deserializeAws_json1_0RecommendationOptions(output.recommendationOptions, context)
@@ -2639,7 +2624,7 @@ const deserializeAws_json1_0InstanceRecommendationFindingReasonCodes = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2648,9 +2633,8 @@ const deserializeAws_json1_0InstanceRecommendationOption = (
   context: __SerdeContext
 ): InstanceRecommendationOption => {
   return {
-    instanceType: output.instanceType !== undefined && output.instanceType !== null ? output.instanceType : undefined,
-    performanceRisk:
-      output.performanceRisk !== undefined && output.performanceRisk !== null ? output.performanceRisk : undefined,
+    instanceType: __expectString(output.instanceType),
+    performanceRisk: __expectNumber(output.performanceRisk),
     platformDifferences:
       output.platformDifferences !== undefined && output.platformDifferences !== null
         ? deserializeAws_json1_0PlatformDifferences(output.platformDifferences, context)
@@ -2659,7 +2643,7 @@ const deserializeAws_json1_0InstanceRecommendationOption = (
       output.projectedUtilizationMetrics !== undefined && output.projectedUtilizationMetrics !== null
         ? deserializeAws_json1_0ProjectedUtilizationMetrics(output.projectedUtilizationMetrics, context)
         : undefined,
-    rank: output.rank !== undefined && output.rank !== null ? output.rank : undefined,
+    rank: __expectNumber(output.rank),
   } as any;
 };
 
@@ -2682,7 +2666,7 @@ const deserializeAws_json1_0InternalServerException = (
   context: __SerdeContext
 ): InternalServerException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -2691,7 +2675,7 @@ const deserializeAws_json1_0InvalidParameterValueException = (
   context: __SerdeContext
 ): InvalidParameterValueException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -2700,9 +2684,9 @@ const deserializeAws_json1_0LambdaFunctionMemoryProjectedMetric = (
   context: __SerdeContext
 ): LambdaFunctionMemoryProjectedMetric => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    statistic: output.statistic !== undefined && output.statistic !== null ? output.statistic : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    name: __expectString(output.name),
+    statistic: __expectString(output.statistic),
+    value: __expectNumber(output.value),
   } as any;
 };
 
@@ -2725,12 +2709,12 @@ const deserializeAws_json1_0LambdaFunctionMemoryRecommendationOption = (
   context: __SerdeContext
 ): LambdaFunctionMemoryRecommendationOption => {
   return {
-    memorySize: output.memorySize !== undefined && output.memorySize !== null ? output.memorySize : undefined,
+    memorySize: __expectNumber(output.memorySize),
     projectedUtilizationMetrics:
       output.projectedUtilizationMetrics !== undefined && output.projectedUtilizationMetrics !== null
         ? deserializeAws_json1_0LambdaFunctionMemoryProjectedMetrics(output.projectedUtilizationMetrics, context)
         : undefined,
-    rank: output.rank !== undefined && output.rank !== null ? output.rank : undefined,
+    rank: __expectNumber(output.rank),
   } as any;
 };
 
@@ -2753,27 +2737,20 @@ const deserializeAws_json1_0LambdaFunctionRecommendation = (
   context: __SerdeContext
 ): LambdaFunctionRecommendation => {
   return {
-    accountId: output.accountId !== undefined && output.accountId !== null ? output.accountId : undefined,
-    currentMemorySize:
-      output.currentMemorySize !== undefined && output.currentMemorySize !== null
-        ? output.currentMemorySize
-        : undefined,
-    finding: output.finding !== undefined && output.finding !== null ? output.finding : undefined,
+    accountId: __expectString(output.accountId),
+    currentMemorySize: __expectNumber(output.currentMemorySize),
+    finding: __expectString(output.finding),
     findingReasonCodes:
       output.findingReasonCodes !== undefined && output.findingReasonCodes !== null
         ? deserializeAws_json1_0LambdaFunctionRecommendationFindingReasonCodes(output.findingReasonCodes, context)
         : undefined,
-    functionArn: output.functionArn !== undefined && output.functionArn !== null ? output.functionArn : undefined,
-    functionVersion:
-      output.functionVersion !== undefined && output.functionVersion !== null ? output.functionVersion : undefined,
+    functionArn: __expectString(output.functionArn),
+    functionVersion: __expectString(output.functionVersion),
     lastRefreshTimestamp:
       output.lastRefreshTimestamp !== undefined && output.lastRefreshTimestamp !== null
         ? new Date(Math.round(output.lastRefreshTimestamp * 1000))
         : undefined,
-    lookbackPeriodInDays:
-      output.lookbackPeriodInDays !== undefined && output.lookbackPeriodInDays !== null
-        ? output.lookbackPeriodInDays
-        : undefined,
+    lookbackPeriodInDays: __expectNumber(output.lookbackPeriodInDays),
     memorySizeRecommendationOptions:
       output.memorySizeRecommendationOptions !== undefined && output.memorySizeRecommendationOptions !== null
         ? deserializeAws_json1_0LambdaFunctionMemoryRecommendationOptions(
@@ -2781,10 +2758,7 @@ const deserializeAws_json1_0LambdaFunctionRecommendation = (
             context
           )
         : undefined,
-    numberOfInvocations:
-      output.numberOfInvocations !== undefined && output.numberOfInvocations !== null
-        ? output.numberOfInvocations
-        : undefined,
+    numberOfInvocations: __expectNumber(output.numberOfInvocations),
     utilizationMetrics:
       output.utilizationMetrics !== undefined && output.utilizationMetrics !== null
         ? deserializeAws_json1_0LambdaFunctionUtilizationMetrics(output.utilizationMetrics, context)
@@ -2802,7 +2776,7 @@ const deserializeAws_json1_0LambdaFunctionRecommendationFindingReasonCodes = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2825,9 +2799,9 @@ const deserializeAws_json1_0LambdaFunctionUtilizationMetric = (
   context: __SerdeContext
 ): LambdaFunctionUtilizationMetric => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    statistic: output.statistic !== undefined && output.statistic !== null ? output.statistic : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    name: __expectString(output.name),
+    statistic: __expectString(output.statistic),
+    value: __expectNumber(output.value),
   } as any;
 };
 
@@ -2847,7 +2821,7 @@ const deserializeAws_json1_0LambdaFunctionUtilizationMetrics = (
 
 const deserializeAws_json1_0LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -2858,7 +2832,7 @@ const deserializeAws_json1_0MetricValues = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectNumber(entry) as any;
     });
 };
 
@@ -2867,13 +2841,13 @@ const deserializeAws_json1_0MissingAuthenticationToken = (
   context: __SerdeContext
 ): MissingAuthenticationToken => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_0OptInRequiredException = (output: any, context: __SerdeContext): OptInRequiredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -2887,13 +2861,13 @@ const deserializeAws_json1_0PlatformDifferences = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_0ProjectedMetric = (output: any, context: __SerdeContext): ProjectedMetric => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
     timestamps:
       output.timestamps !== undefined && output.timestamps !== null
         ? deserializeAws_json1_0Timestamps(output.timestamps, context)
@@ -2943,8 +2917,8 @@ const deserializeAws_json1_0ReasonCodeSummaries = (output: any, context: __Serde
 
 const deserializeAws_json1_0ReasonCodeSummary = (output: any, context: __SerdeContext): ReasonCodeSummary => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    name: __expectString(output.name),
+    value: __expectNumber(output.value),
   } as any;
 };
 
@@ -2961,15 +2935,14 @@ const deserializeAws_json1_0RecommendationExportJob = (
       output.destination !== undefined && output.destination !== null
         ? deserializeAws_json1_0ExportDestination(output.destination, context)
         : undefined,
-    failureReason:
-      output.failureReason !== undefined && output.failureReason !== null ? output.failureReason : undefined,
-    jobId: output.jobId !== undefined && output.jobId !== null ? output.jobId : undefined,
+    failureReason: __expectString(output.failureReason),
+    jobId: __expectString(output.jobId),
     lastUpdatedTimestamp:
       output.lastUpdatedTimestamp !== undefined && output.lastUpdatedTimestamp !== null
         ? new Date(Math.round(output.lastUpdatedTimestamp * 1000))
         : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    resourceType: __expectString(output.resourceType),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -3003,14 +2976,8 @@ const deserializeAws_json1_0RecommendationOptions = (
 
 const deserializeAws_json1_0RecommendationSource = (output: any, context: __SerdeContext): RecommendationSource => {
   return {
-    recommendationSourceArn:
-      output.recommendationSourceArn !== undefined && output.recommendationSourceArn !== null
-        ? output.recommendationSourceArn
-        : undefined,
-    recommendationSourceType:
-      output.recommendationSourceType !== undefined && output.recommendationSourceType !== null
-        ? output.recommendationSourceType
-        : undefined,
+    recommendationSourceArn: __expectString(output.recommendationSourceArn),
+    recommendationSourceType: __expectString(output.recommendationSourceType),
   } as any;
 };
 
@@ -3041,11 +3008,8 @@ const deserializeAws_json1_0RecommendationSummaries = (
 
 const deserializeAws_json1_0RecommendationSummary = (output: any, context: __SerdeContext): RecommendationSummary => {
   return {
-    accountId: output.accountId !== undefined && output.accountId !== null ? output.accountId : undefined,
-    recommendationResourceType:
-      output.recommendationResourceType !== undefined && output.recommendationResourceType !== null
-        ? output.recommendationResourceType
-        : undefined,
+    accountId: __expectString(output.accountId),
+    recommendationResourceType: __expectString(output.recommendationResourceType),
     summaries:
       output.summaries !== undefined && output.summaries !== null
         ? deserializeAws_json1_0Summaries(output.summaries, context)
@@ -3062,11 +3026,8 @@ const deserializeAws_json1_0RecommendedOptionProjectedMetric = (
       output.projectedMetrics !== undefined && output.projectedMetrics !== null
         ? deserializeAws_json1_0ProjectedMetrics(output.projectedMetrics, context)
         : undefined,
-    rank: output.rank !== undefined && output.rank !== null ? output.rank : undefined,
-    recommendedInstanceType:
-      output.recommendedInstanceType !== undefined && output.recommendedInstanceType !== null
-        ? output.recommendedInstanceType
-        : undefined,
+    rank: __expectNumber(output.rank),
+    recommendedInstanceType: __expectString(output.recommendedInstanceType),
   } as any;
 };
 
@@ -3089,15 +3050,15 @@ const deserializeAws_json1_0ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_0S3Destination = (output: any, context: __SerdeContext): S3Destination => {
   return {
-    bucket: output.bucket !== undefined && output.bucket !== null ? output.bucket : undefined,
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
-    metadataKey: output.metadataKey !== undefined && output.metadataKey !== null ? output.metadataKey : undefined,
+    bucket: __expectString(output.bucket),
+    key: __expectString(output.key),
+    metadataKey: __expectString(output.metadataKey),
   } as any;
 };
 
@@ -3106,7 +3067,7 @@ const deserializeAws_json1_0ServiceUnavailableException = (
   context: __SerdeContext
 ): ServiceUnavailableException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3123,18 +3084,18 @@ const deserializeAws_json1_0Summaries = (output: any, context: __SerdeContext): 
 
 const deserializeAws_json1_0Summary = (output: any, context: __SerdeContext): Summary => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
     reasonCodeSummaries:
       output.reasonCodeSummaries !== undefined && output.reasonCodeSummaries !== null
         ? deserializeAws_json1_0ReasonCodeSummaries(output.reasonCodeSummaries, context)
         : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    value: __expectNumber(output.value),
   } as any;
 };
 
 const deserializeAws_json1_0ThrottlingException = (output: any, context: __SerdeContext): ThrottlingException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3154,16 +3115,16 @@ const deserializeAws_json1_0UpdateEnrollmentStatusResponse = (
   context: __SerdeContext
 ): UpdateEnrollmentStatusResponse => {
   return {
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    statusReason: output.statusReason !== undefined && output.statusReason !== null ? output.statusReason : undefined,
+    status: __expectString(output.status),
+    statusReason: __expectString(output.statusReason),
   } as any;
 };
 
 const deserializeAws_json1_0UtilizationMetric = (output: any, context: __SerdeContext): UtilizationMetric => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    statistic: output.statistic !== undefined && output.statistic !== null ? output.statistic : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    name: __expectString(output.name),
+    statistic: __expectString(output.statistic),
+    value: __expectNumber(output.value),
   } as any;
 };
 
@@ -3180,46 +3141,33 @@ const deserializeAws_json1_0UtilizationMetrics = (output: any, context: __SerdeC
 
 const deserializeAws_json1_0VolumeConfiguration = (output: any, context: __SerdeContext): VolumeConfiguration => {
   return {
-    volumeBaselineIOPS:
-      output.volumeBaselineIOPS !== undefined && output.volumeBaselineIOPS !== null
-        ? output.volumeBaselineIOPS
-        : undefined,
-    volumeBaselineThroughput:
-      output.volumeBaselineThroughput !== undefined && output.volumeBaselineThroughput !== null
-        ? output.volumeBaselineThroughput
-        : undefined,
-    volumeBurstIOPS:
-      output.volumeBurstIOPS !== undefined && output.volumeBurstIOPS !== null ? output.volumeBurstIOPS : undefined,
-    volumeBurstThroughput:
-      output.volumeBurstThroughput !== undefined && output.volumeBurstThroughput !== null
-        ? output.volumeBurstThroughput
-        : undefined,
-    volumeSize: output.volumeSize !== undefined && output.volumeSize !== null ? output.volumeSize : undefined,
-    volumeType: output.volumeType !== undefined && output.volumeType !== null ? output.volumeType : undefined,
+    volumeBaselineIOPS: __expectNumber(output.volumeBaselineIOPS),
+    volumeBaselineThroughput: __expectNumber(output.volumeBaselineThroughput),
+    volumeBurstIOPS: __expectNumber(output.volumeBurstIOPS),
+    volumeBurstThroughput: __expectNumber(output.volumeBurstThroughput),
+    volumeSize: __expectNumber(output.volumeSize),
+    volumeType: __expectString(output.volumeType),
   } as any;
 };
 
 const deserializeAws_json1_0VolumeRecommendation = (output: any, context: __SerdeContext): VolumeRecommendation => {
   return {
-    accountId: output.accountId !== undefined && output.accountId !== null ? output.accountId : undefined,
+    accountId: __expectString(output.accountId),
     currentConfiguration:
       output.currentConfiguration !== undefined && output.currentConfiguration !== null
         ? deserializeAws_json1_0VolumeConfiguration(output.currentConfiguration, context)
         : undefined,
-    finding: output.finding !== undefined && output.finding !== null ? output.finding : undefined,
+    finding: __expectString(output.finding),
     lastRefreshTimestamp:
       output.lastRefreshTimestamp !== undefined && output.lastRefreshTimestamp !== null
         ? new Date(Math.round(output.lastRefreshTimestamp * 1000))
         : undefined,
-    lookBackPeriodInDays:
-      output.lookBackPeriodInDays !== undefined && output.lookBackPeriodInDays !== null
-        ? output.lookBackPeriodInDays
-        : undefined,
+    lookBackPeriodInDays: __expectNumber(output.lookBackPeriodInDays),
     utilizationMetrics:
       output.utilizationMetrics !== undefined && output.utilizationMetrics !== null
         ? deserializeAws_json1_0EBSUtilizationMetrics(output.utilizationMetrics, context)
         : undefined,
-    volumeArn: output.volumeArn !== undefined && output.volumeArn !== null ? output.volumeArn : undefined,
+    volumeArn: __expectString(output.volumeArn),
     volumeRecommendationOptions:
       output.volumeRecommendationOptions !== undefined && output.volumeRecommendationOptions !== null
         ? deserializeAws_json1_0VolumeRecommendationOptions(output.volumeRecommendationOptions, context)
@@ -3236,9 +3184,8 @@ const deserializeAws_json1_0VolumeRecommendationOption = (
       output.configuration !== undefined && output.configuration !== null
         ? deserializeAws_json1_0VolumeConfiguration(output.configuration, context)
         : undefined,
-    performanceRisk:
-      output.performanceRisk !== undefined && output.performanceRisk !== null ? output.performanceRisk : undefined,
-    rank: output.rank !== undefined && output.rank !== null ? output.rank : undefined,
+    performanceRisk: __expectNumber(output.performanceRisk),
+    rank: __expectNumber(output.rank),
   } as any;
 };
 

--- a/clients/client-config-service/protocols/Aws_json1_1.ts
+++ b/clients/client-config-service/protocols/Aws_json1_1.ts
@@ -608,7 +608,12 @@ import {
   UntagResourceRequest,
 } from "../models/models_1";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -10585,8 +10590,7 @@ const deserializeAws_json1_1AccountAggregationSource = (
       output.AccountIds !== undefined && output.AccountIds !== null
         ? deserializeAws_json1_1AccountAggregationSourceAccountList(output.AccountIds, context)
         : undefined,
-    AllAwsRegions:
-      output.AllAwsRegions !== undefined && output.AllAwsRegions !== null ? output.AllAwsRegions : undefined,
+    AllAwsRegions: __expectBoolean(output.AllAwsRegions),
     AwsRegions:
       output.AwsRegions !== undefined && output.AwsRegions !== null
         ? deserializeAws_json1_1AggregatorRegionList(output.AwsRegions, context)
@@ -10601,7 +10605,7 @@ const deserializeAws_json1_1AccountAggregationSourceAccountList = (output: any, 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -10624,14 +10628,13 @@ const deserializeAws_json1_1AggregateComplianceByConfigRule = (
   context: __SerdeContext
 ): AggregateComplianceByConfigRule => {
   return {
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
-    AwsRegion: output.AwsRegion !== undefined && output.AwsRegion !== null ? output.AwsRegion : undefined,
+    AccountId: __expectString(output.AccountId),
+    AwsRegion: __expectString(output.AwsRegion),
     Compliance:
       output.Compliance !== undefined && output.Compliance !== null
         ? deserializeAws_json1_1Compliance(output.Compliance, context)
         : undefined,
-    ConfigRuleName:
-      output.ConfigRuleName !== undefined && output.ConfigRuleName !== null ? output.ConfigRuleName : undefined,
+    ConfigRuleName: __expectString(output.ConfigRuleName),
   } as any;
 };
 
@@ -10654,16 +10657,13 @@ const deserializeAws_json1_1AggregateComplianceByConformancePack = (
   context: __SerdeContext
 ): AggregateComplianceByConformancePack => {
   return {
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
-    AwsRegion: output.AwsRegion !== undefined && output.AwsRegion !== null ? output.AwsRegion : undefined,
+    AccountId: __expectString(output.AccountId),
+    AwsRegion: __expectString(output.AwsRegion),
     Compliance:
       output.Compliance !== undefined && output.Compliance !== null
         ? deserializeAws_json1_1AggregateConformancePackCompliance(output.Compliance, context)
         : undefined,
-    ConformancePackName:
-      output.ConformancePackName !== undefined && output.ConformancePackName !== null
-        ? output.ConformancePackName
-        : undefined,
+    ConformancePackName: __expectString(output.ConformancePackName),
   } as any;
 };
 
@@ -10690,7 +10690,7 @@ const deserializeAws_json1_1AggregateComplianceCount = (
       output.ComplianceSummary !== undefined && output.ComplianceSummary !== null
         ? deserializeAws_json1_1ComplianceSummary(output.ComplianceSummary, context)
         : undefined,
-    GroupName: output.GroupName !== undefined && output.GroupName !== null ? output.GroupName : undefined,
+    GroupName: __expectString(output.GroupName),
   } as any;
 };
 
@@ -10713,18 +10713,10 @@ const deserializeAws_json1_1AggregateConformancePackCompliance = (
   context: __SerdeContext
 ): AggregateConformancePackCompliance => {
   return {
-    ComplianceType:
-      output.ComplianceType !== undefined && output.ComplianceType !== null ? output.ComplianceType : undefined,
-    CompliantRuleCount:
-      output.CompliantRuleCount !== undefined && output.CompliantRuleCount !== null
-        ? output.CompliantRuleCount
-        : undefined,
-    NonCompliantRuleCount:
-      output.NonCompliantRuleCount !== undefined && output.NonCompliantRuleCount !== null
-        ? output.NonCompliantRuleCount
-        : undefined,
-    TotalRuleCount:
-      output.TotalRuleCount !== undefined && output.TotalRuleCount !== null ? output.TotalRuleCount : undefined,
+    ComplianceType: __expectString(output.ComplianceType),
+    CompliantRuleCount: __expectNumber(output.CompliantRuleCount),
+    NonCompliantRuleCount: __expectNumber(output.NonCompliantRuleCount),
+    TotalRuleCount: __expectNumber(output.TotalRuleCount),
   } as any;
 };
 
@@ -10733,14 +10725,8 @@ const deserializeAws_json1_1AggregateConformancePackComplianceCount = (
   context: __SerdeContext
 ): AggregateConformancePackComplianceCount => {
   return {
-    CompliantConformancePackCount:
-      output.CompliantConformancePackCount !== undefined && output.CompliantConformancePackCount !== null
-        ? output.CompliantConformancePackCount
-        : undefined,
-    NonCompliantConformancePackCount:
-      output.NonCompliantConformancePackCount !== undefined && output.NonCompliantConformancePackCount !== null
-        ? output.NonCompliantConformancePackCount
-        : undefined,
+    CompliantConformancePackCount: __expectNumber(output.CompliantConformancePackCount),
+    NonCompliantConformancePackCount: __expectNumber(output.NonCompliantConformancePackCount),
   } as any;
 };
 
@@ -10753,7 +10739,7 @@ const deserializeAws_json1_1AggregateConformancePackComplianceSummary = (
       output.ComplianceSummary !== undefined && output.ComplianceSummary !== null
         ? deserializeAws_json1_1AggregateConformancePackComplianceCount(output.ComplianceSummary, context)
         : undefined,
-    GroupName: output.GroupName !== undefined && output.GroupName !== null ? output.GroupName : undefined,
+    GroupName: __expectString(output.GroupName),
   } as any;
 };
 
@@ -10773,19 +10759,16 @@ const deserializeAws_json1_1AggregateConformancePackComplianceSummaryList = (
 
 const deserializeAws_json1_1AggregatedSourceStatus = (output: any, context: __SerdeContext): AggregatedSourceStatus => {
   return {
-    AwsRegion: output.AwsRegion !== undefined && output.AwsRegion !== null ? output.AwsRegion : undefined,
-    LastErrorCode:
-      output.LastErrorCode !== undefined && output.LastErrorCode !== null ? output.LastErrorCode : undefined,
-    LastErrorMessage:
-      output.LastErrorMessage !== undefined && output.LastErrorMessage !== null ? output.LastErrorMessage : undefined,
-    LastUpdateStatus:
-      output.LastUpdateStatus !== undefined && output.LastUpdateStatus !== null ? output.LastUpdateStatus : undefined,
+    AwsRegion: __expectString(output.AwsRegion),
+    LastErrorCode: __expectString(output.LastErrorCode),
+    LastErrorMessage: __expectString(output.LastErrorMessage),
+    LastUpdateStatus: __expectString(output.LastUpdateStatus),
     LastUpdateTime:
       output.LastUpdateTime !== undefined && output.LastUpdateTime !== null
         ? new Date(Math.round(output.LastUpdateTime * 1000))
         : undefined,
-    SourceId: output.SourceId !== undefined && output.SourceId !== null ? output.SourceId : undefined,
-    SourceType: output.SourceType !== undefined && output.SourceType !== null ? output.SourceType : undefined,
+    SourceId: __expectString(output.SourceId),
+    SourceType: __expectString(output.SourceType),
   } as any;
 };
 
@@ -10808,11 +10791,10 @@ const deserializeAws_json1_1AggregateEvaluationResult = (
   context: __SerdeContext
 ): AggregateEvaluationResult => {
   return {
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
-    Annotation: output.Annotation !== undefined && output.Annotation !== null ? output.Annotation : undefined,
-    AwsRegion: output.AwsRegion !== undefined && output.AwsRegion !== null ? output.AwsRegion : undefined,
-    ComplianceType:
-      output.ComplianceType !== undefined && output.ComplianceType !== null ? output.ComplianceType : undefined,
+    AccountId: __expectString(output.AccountId),
+    Annotation: __expectString(output.Annotation),
+    AwsRegion: __expectString(output.AwsRegion),
+    ComplianceType: __expectString(output.ComplianceType),
     ConfigRuleInvokedTime:
       output.ConfigRuleInvokedTime !== undefined && output.ConfigRuleInvokedTime !== null
         ? new Date(Math.round(output.ConfigRuleInvokedTime * 1000))
@@ -10847,12 +10829,11 @@ const deserializeAws_json1_1AggregateResourceIdentifier = (
   context: __SerdeContext
 ): AggregateResourceIdentifier => {
   return {
-    ResourceId: output.ResourceId !== undefined && output.ResourceId !== null ? output.ResourceId : undefined,
-    ResourceName: output.ResourceName !== undefined && output.ResourceName !== null ? output.ResourceName : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
-    SourceAccountId:
-      output.SourceAccountId !== undefined && output.SourceAccountId !== null ? output.SourceAccountId : undefined,
-    SourceRegion: output.SourceRegion !== undefined && output.SourceRegion !== null ? output.SourceRegion : undefined,
+    ResourceId: __expectString(output.ResourceId),
+    ResourceName: __expectString(output.ResourceName),
+    ResourceType: __expectString(output.ResourceType),
+    SourceAccountId: __expectString(output.SourceAccountId),
+    SourceRegion: __expectString(output.SourceRegion),
   } as any;
 };
 
@@ -10861,18 +10842,9 @@ const deserializeAws_json1_1AggregationAuthorization = (
   context: __SerdeContext
 ): AggregationAuthorization => {
   return {
-    AggregationAuthorizationArn:
-      output.AggregationAuthorizationArn !== undefined && output.AggregationAuthorizationArn !== null
-        ? output.AggregationAuthorizationArn
-        : undefined,
-    AuthorizedAccountId:
-      output.AuthorizedAccountId !== undefined && output.AuthorizedAccountId !== null
-        ? output.AuthorizedAccountId
-        : undefined,
-    AuthorizedAwsRegion:
-      output.AuthorizedAwsRegion !== undefined && output.AuthorizedAwsRegion !== null
-        ? output.AuthorizedAwsRegion
-        : undefined,
+    AggregationAuthorizationArn: __expectString(output.AggregationAuthorizationArn),
+    AuthorizedAccountId: __expectString(output.AuthorizedAccountId),
+    AuthorizedAwsRegion: __expectString(output.AuthorizedAwsRegion),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -10901,43 +10873,35 @@ const deserializeAws_json1_1AggregatorRegionList = (output: any, context: __Serd
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1BaseConfigurationItem = (output: any, context: __SerdeContext): BaseConfigurationItem => {
   return {
-    accountId: output.accountId !== undefined && output.accountId !== null ? output.accountId : undefined,
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    availabilityZone:
-      output.availabilityZone !== undefined && output.availabilityZone !== null ? output.availabilityZone : undefined,
-    awsRegion: output.awsRegion !== undefined && output.awsRegion !== null ? output.awsRegion : undefined,
-    configuration:
-      output.configuration !== undefined && output.configuration !== null ? output.configuration : undefined,
+    accountId: __expectString(output.accountId),
+    arn: __expectString(output.arn),
+    availabilityZone: __expectString(output.availabilityZone),
+    awsRegion: __expectString(output.awsRegion),
+    configuration: __expectString(output.configuration),
     configurationItemCaptureTime:
       output.configurationItemCaptureTime !== undefined && output.configurationItemCaptureTime !== null
         ? new Date(Math.round(output.configurationItemCaptureTime * 1000))
         : undefined,
-    configurationItemStatus:
-      output.configurationItemStatus !== undefined && output.configurationItemStatus !== null
-        ? output.configurationItemStatus
-        : undefined,
-    configurationStateId:
-      output.configurationStateId !== undefined && output.configurationStateId !== null
-        ? output.configurationStateId
-        : undefined,
+    configurationItemStatus: __expectString(output.configurationItemStatus),
+    configurationStateId: __expectString(output.configurationStateId),
     resourceCreationTime:
       output.resourceCreationTime !== undefined && output.resourceCreationTime !== null
         ? new Date(Math.round(output.resourceCreationTime * 1000))
         : undefined,
-    resourceId: output.resourceId !== undefined && output.resourceId !== null ? output.resourceId : undefined,
-    resourceName: output.resourceName !== undefined && output.resourceName !== null ? output.resourceName : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
+    resourceId: __expectString(output.resourceId),
+    resourceName: __expectString(output.resourceName),
+    resourceType: __expectString(output.resourceType),
     supplementaryConfiguration:
       output.supplementaryConfiguration !== undefined && output.supplementaryConfiguration !== null
         ? deserializeAws_json1_1SupplementaryConfiguration(output.supplementaryConfiguration, context)
         : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    version: __expectString(output.version),
   } as any;
 };
 
@@ -10993,8 +10957,7 @@ const deserializeAws_json1_1Compliance = (output: any, context: __SerdeContext):
       output.ComplianceContributorCount !== undefined && output.ComplianceContributorCount !== null
         ? deserializeAws_json1_1ComplianceContributorCount(output.ComplianceContributorCount, context)
         : undefined,
-    ComplianceType:
-      output.ComplianceType !== undefined && output.ComplianceType !== null ? output.ComplianceType : undefined,
+    ComplianceType: __expectString(output.ComplianceType),
   } as any;
 };
 
@@ -11004,8 +10967,7 @@ const deserializeAws_json1_1ComplianceByConfigRule = (output: any, context: __Se
       output.Compliance !== undefined && output.Compliance !== null
         ? deserializeAws_json1_1Compliance(output.Compliance, context)
         : undefined,
-    ConfigRuleName:
-      output.ConfigRuleName !== undefined && output.ConfigRuleName !== null ? output.ConfigRuleName : undefined,
+    ConfigRuleName: __expectString(output.ConfigRuleName),
   } as any;
 };
 
@@ -11029,8 +10991,8 @@ const deserializeAws_json1_1ComplianceByResource = (output: any, context: __Serd
       output.Compliance !== undefined && output.Compliance !== null
         ? deserializeAws_json1_1Compliance(output.Compliance, context)
         : undefined,
-    ResourceId: output.ResourceId !== undefined && output.ResourceId !== null ? output.ResourceId : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
+    ResourceId: __expectString(output.ResourceId),
+    ResourceType: __expectString(output.ResourceType),
   } as any;
 };
 
@@ -11050,8 +11012,8 @@ const deserializeAws_json1_1ComplianceContributorCount = (
   context: __SerdeContext
 ): ComplianceContributorCount => {
   return {
-    CapExceeded: output.CapExceeded !== undefined && output.CapExceeded !== null ? output.CapExceeded : undefined,
-    CappedCount: output.CappedCount !== undefined && output.CappedCount !== null ? output.CappedCount : undefined,
+    CapExceeded: __expectBoolean(output.CapExceeded),
+    CappedCount: __expectNumber(output.CappedCount),
   } as any;
 };
 
@@ -11062,7 +11024,7 @@ const deserializeAws_json1_1ComplianceResourceTypes = (output: any, context: __S
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -11106,7 +11068,7 @@ const deserializeAws_json1_1ComplianceSummaryByResourceType = (
       output.ComplianceSummary !== undefined && output.ComplianceSummary !== null
         ? deserializeAws_json1_1ComplianceSummary(output.ComplianceSummary, context)
         : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
+    ResourceType: __expectString(output.ResourceType),
   } as any;
 };
 
@@ -11119,11 +11081,9 @@ const deserializeAws_json1_1ConfigExportDeliveryInfo = (
       output.lastAttemptTime !== undefined && output.lastAttemptTime !== null
         ? new Date(Math.round(output.lastAttemptTime * 1000))
         : undefined,
-    lastErrorCode:
-      output.lastErrorCode !== undefined && output.lastErrorCode !== null ? output.lastErrorCode : undefined,
-    lastErrorMessage:
-      output.lastErrorMessage !== undefined && output.lastErrorMessage !== null ? output.lastErrorMessage : undefined,
-    lastStatus: output.lastStatus !== undefined && output.lastStatus !== null ? output.lastStatus : undefined,
+    lastErrorCode: __expectString(output.lastErrorCode),
+    lastErrorMessage: __expectString(output.lastErrorMessage),
+    lastStatus: __expectString(output.lastStatus),
     lastSuccessfulTime:
       output.lastSuccessfulTime !== undefined && output.lastSuccessfulTime !== null
         ? new Date(Math.round(output.lastSuccessfulTime * 1000))
@@ -11137,21 +11097,14 @@ const deserializeAws_json1_1ConfigExportDeliveryInfo = (
 
 const deserializeAws_json1_1ConfigRule = (output: any, context: __SerdeContext): ConfigRule => {
   return {
-    ConfigRuleArn:
-      output.ConfigRuleArn !== undefined && output.ConfigRuleArn !== null ? output.ConfigRuleArn : undefined,
-    ConfigRuleId: output.ConfigRuleId !== undefined && output.ConfigRuleId !== null ? output.ConfigRuleId : undefined,
-    ConfigRuleName:
-      output.ConfigRuleName !== undefined && output.ConfigRuleName !== null ? output.ConfigRuleName : undefined,
-    ConfigRuleState:
-      output.ConfigRuleState !== undefined && output.ConfigRuleState !== null ? output.ConfigRuleState : undefined,
-    CreatedBy: output.CreatedBy !== undefined && output.CreatedBy !== null ? output.CreatedBy : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    InputParameters:
-      output.InputParameters !== undefined && output.InputParameters !== null ? output.InputParameters : undefined,
-    MaximumExecutionFrequency:
-      output.MaximumExecutionFrequency !== undefined && output.MaximumExecutionFrequency !== null
-        ? output.MaximumExecutionFrequency
-        : undefined,
+    ConfigRuleArn: __expectString(output.ConfigRuleArn),
+    ConfigRuleId: __expectString(output.ConfigRuleId),
+    ConfigRuleName: __expectString(output.ConfigRuleName),
+    ConfigRuleState: __expectString(output.ConfigRuleState),
+    CreatedBy: __expectString(output.CreatedBy),
+    Description: __expectString(output.Description),
+    InputParameters: __expectString(output.InputParameters),
+    MaximumExecutionFrequency: __expectString(output.MaximumExecutionFrequency),
     Scope:
       output.Scope !== undefined && output.Scope !== null
         ? deserializeAws_json1_1Scope(output.Scope, context)
@@ -11168,27 +11121,20 @@ const deserializeAws_json1_1ConfigRuleEvaluationStatus = (
   context: __SerdeContext
 ): ConfigRuleEvaluationStatus => {
   return {
-    ConfigRuleArn:
-      output.ConfigRuleArn !== undefined && output.ConfigRuleArn !== null ? output.ConfigRuleArn : undefined,
-    ConfigRuleId: output.ConfigRuleId !== undefined && output.ConfigRuleId !== null ? output.ConfigRuleId : undefined,
-    ConfigRuleName:
-      output.ConfigRuleName !== undefined && output.ConfigRuleName !== null ? output.ConfigRuleName : undefined,
+    ConfigRuleArn: __expectString(output.ConfigRuleArn),
+    ConfigRuleId: __expectString(output.ConfigRuleId),
+    ConfigRuleName: __expectString(output.ConfigRuleName),
     FirstActivatedTime:
       output.FirstActivatedTime !== undefined && output.FirstActivatedTime !== null
         ? new Date(Math.round(output.FirstActivatedTime * 1000))
         : undefined,
-    FirstEvaluationStarted:
-      output.FirstEvaluationStarted !== undefined && output.FirstEvaluationStarted !== null
-        ? output.FirstEvaluationStarted
-        : undefined,
+    FirstEvaluationStarted: __expectBoolean(output.FirstEvaluationStarted),
     LastDeactivatedTime:
       output.LastDeactivatedTime !== undefined && output.LastDeactivatedTime !== null
         ? new Date(Math.round(output.LastDeactivatedTime * 1000))
         : undefined,
-    LastErrorCode:
-      output.LastErrorCode !== undefined && output.LastErrorCode !== null ? output.LastErrorCode : undefined,
-    LastErrorMessage:
-      output.LastErrorMessage !== undefined && output.LastErrorMessage !== null ? output.LastErrorMessage : undefined,
+    LastErrorCode: __expectString(output.LastErrorCode),
+    LastErrorMessage: __expectString(output.LastErrorMessage),
     LastFailedEvaluationTime:
       output.LastFailedEvaluationTime !== undefined && output.LastFailedEvaluationTime !== null
         ? new Date(Math.round(output.LastFailedEvaluationTime * 1000))
@@ -11238,10 +11184,7 @@ const deserializeAws_json1_1ConfigSnapshotDeliveryProperties = (
   context: __SerdeContext
 ): ConfigSnapshotDeliveryProperties => {
   return {
-    deliveryFrequency:
-      output.deliveryFrequency !== undefined && output.deliveryFrequency !== null
-        ? output.deliveryFrequency
-        : undefined,
+    deliveryFrequency: __expectString(output.deliveryFrequency),
   } as any;
 };
 
@@ -11250,11 +11193,9 @@ const deserializeAws_json1_1ConfigStreamDeliveryInfo = (
   context: __SerdeContext
 ): ConfigStreamDeliveryInfo => {
   return {
-    lastErrorCode:
-      output.lastErrorCode !== undefined && output.lastErrorCode !== null ? output.lastErrorCode : undefined,
-    lastErrorMessage:
-      output.lastErrorMessage !== undefined && output.lastErrorMessage !== null ? output.lastErrorMessage : undefined,
-    lastStatus: output.lastStatus !== undefined && output.lastStatus !== null ? output.lastStatus : undefined,
+    lastErrorCode: __expectString(output.lastErrorCode),
+    lastErrorMessage: __expectString(output.lastErrorMessage),
+    lastStatus: __expectString(output.lastStatus),
     lastStatusChangeTime:
       output.lastStatusChangeTime !== undefined && output.lastStatusChangeTime !== null
         ? new Date(Math.round(output.lastStatusChangeTime * 1000))
@@ -11271,15 +11212,9 @@ const deserializeAws_json1_1ConfigurationAggregator = (
       output.AccountAggregationSources !== undefined && output.AccountAggregationSources !== null
         ? deserializeAws_json1_1AccountAggregationSourceList(output.AccountAggregationSources, context)
         : undefined,
-    ConfigurationAggregatorArn:
-      output.ConfigurationAggregatorArn !== undefined && output.ConfigurationAggregatorArn !== null
-        ? output.ConfigurationAggregatorArn
-        : undefined,
-    ConfigurationAggregatorName:
-      output.ConfigurationAggregatorName !== undefined && output.ConfigurationAggregatorName !== null
-        ? output.ConfigurationAggregatorName
-        : undefined,
-    CreatedBy: output.CreatedBy !== undefined && output.CreatedBy !== null ? output.CreatedBy : undefined,
+    ConfigurationAggregatorArn: __expectString(output.ConfigurationAggregatorArn),
+    ConfigurationAggregatorName: __expectString(output.ConfigurationAggregatorName),
+    CreatedBy: __expectString(output.CreatedBy),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -11311,29 +11246,18 @@ const deserializeAws_json1_1ConfigurationAggregatorList = (
 
 const deserializeAws_json1_1ConfigurationItem = (output: any, context: __SerdeContext): ConfigurationItem => {
   return {
-    accountId: output.accountId !== undefined && output.accountId !== null ? output.accountId : undefined,
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    availabilityZone:
-      output.availabilityZone !== undefined && output.availabilityZone !== null ? output.availabilityZone : undefined,
-    awsRegion: output.awsRegion !== undefined && output.awsRegion !== null ? output.awsRegion : undefined,
-    configuration:
-      output.configuration !== undefined && output.configuration !== null ? output.configuration : undefined,
+    accountId: __expectString(output.accountId),
+    arn: __expectString(output.arn),
+    availabilityZone: __expectString(output.availabilityZone),
+    awsRegion: __expectString(output.awsRegion),
+    configuration: __expectString(output.configuration),
     configurationItemCaptureTime:
       output.configurationItemCaptureTime !== undefined && output.configurationItemCaptureTime !== null
         ? new Date(Math.round(output.configurationItemCaptureTime * 1000))
         : undefined,
-    configurationItemMD5Hash:
-      output.configurationItemMD5Hash !== undefined && output.configurationItemMD5Hash !== null
-        ? output.configurationItemMD5Hash
-        : undefined,
-    configurationItemStatus:
-      output.configurationItemStatus !== undefined && output.configurationItemStatus !== null
-        ? output.configurationItemStatus
-        : undefined,
-    configurationStateId:
-      output.configurationStateId !== undefined && output.configurationStateId !== null
-        ? output.configurationStateId
-        : undefined,
+    configurationItemMD5Hash: __expectString(output.configurationItemMD5Hash),
+    configurationItemStatus: __expectString(output.configurationItemStatus),
+    configurationStateId: __expectString(output.configurationStateId),
     relatedEvents:
       output.relatedEvents !== undefined && output.relatedEvents !== null
         ? deserializeAws_json1_1RelatedEventList(output.relatedEvents, context)
@@ -11346,16 +11270,16 @@ const deserializeAws_json1_1ConfigurationItem = (output: any, context: __SerdeCo
       output.resourceCreationTime !== undefined && output.resourceCreationTime !== null
         ? new Date(Math.round(output.resourceCreationTime * 1000))
         : undefined,
-    resourceId: output.resourceId !== undefined && output.resourceId !== null ? output.resourceId : undefined,
-    resourceName: output.resourceName !== undefined && output.resourceName !== null ? output.resourceName : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
+    resourceId: __expectString(output.resourceId),
+    resourceName: __expectString(output.resourceName),
+    resourceType: __expectString(output.resourceType),
     supplementaryConfiguration:
       output.supplementaryConfiguration !== undefined && output.supplementaryConfiguration !== null
         ? deserializeAws_json1_1SupplementaryConfiguration(output.supplementaryConfiguration, context)
         : undefined,
     tags:
       output.tags !== undefined && output.tags !== null ? deserializeAws_json1_1Tags(output.tags, context) : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    version: __expectString(output.version),
   } as any;
 };
 
@@ -11372,12 +11296,12 @@ const deserializeAws_json1_1ConfigurationItemList = (output: any, context: __Ser
 
 const deserializeAws_json1_1ConfigurationRecorder = (output: any, context: __SerdeContext): ConfigurationRecorder => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
     recordingGroup:
       output.recordingGroup !== undefined && output.recordingGroup !== null
         ? deserializeAws_json1_1RecordingGroup(output.recordingGroup, context)
         : undefined,
-    roleARN: output.roleARN !== undefined && output.roleARN !== null ? output.roleARN : undefined,
+    roleARN: __expectString(output.roleARN),
   } as any;
 };
 
@@ -11400,15 +11324,13 @@ const deserializeAws_json1_1ConfigurationRecorderStatus = (
   context: __SerdeContext
 ): ConfigurationRecorderStatus => {
   return {
-    lastErrorCode:
-      output.lastErrorCode !== undefined && output.lastErrorCode !== null ? output.lastErrorCode : undefined,
-    lastErrorMessage:
-      output.lastErrorMessage !== undefined && output.lastErrorMessage !== null ? output.lastErrorMessage : undefined,
+    lastErrorCode: __expectString(output.lastErrorCode),
+    lastErrorMessage: __expectString(output.lastErrorMessage),
     lastStartTime:
       output.lastStartTime !== undefined && output.lastStartTime !== null
         ? new Date(Math.round(output.lastStartTime * 1000))
         : undefined,
-    lastStatus: output.lastStatus !== undefined && output.lastStatus !== null ? output.lastStatus : undefined,
+    lastStatus: __expectString(output.lastStatus),
     lastStatusChangeTime:
       output.lastStatusChangeTime !== undefined && output.lastStatusChangeTime !== null
         ? new Date(Math.round(output.lastStatusChangeTime * 1000))
@@ -11417,8 +11339,8 @@ const deserializeAws_json1_1ConfigurationRecorderStatus = (
       output.lastStopTime !== undefined && output.lastStopTime !== null
         ? new Date(Math.round(output.lastStopTime * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    recording: output.recording !== undefined && output.recording !== null ? output.recording : undefined,
+    name: __expectString(output.name),
+    recording: __expectBoolean(output.recording),
   } as any;
 };
 
@@ -11441,14 +11363,8 @@ const deserializeAws_json1_1ConformancePackComplianceSummary = (
   context: __SerdeContext
 ): ConformancePackComplianceSummary => {
   return {
-    ConformancePackComplianceStatus:
-      output.ConformancePackComplianceStatus !== undefined && output.ConformancePackComplianceStatus !== null
-        ? output.ConformancePackComplianceStatus
-        : undefined,
-    ConformancePackName:
-      output.ConformancePackName !== undefined && output.ConformancePackName !== null
-        ? output.ConformancePackName
-        : undefined,
+    ConformancePackComplianceStatus: __expectString(output.ConformancePackComplianceStatus),
+    ConformancePackName: __expectString(output.ConformancePackName),
   } as any;
 };
 
@@ -11468,29 +11384,16 @@ const deserializeAws_json1_1ConformancePackComplianceSummaryList = (
 
 const deserializeAws_json1_1ConformancePackDetail = (output: any, context: __SerdeContext): ConformancePackDetail => {
   return {
-    ConformancePackArn:
-      output.ConformancePackArn !== undefined && output.ConformancePackArn !== null
-        ? output.ConformancePackArn
-        : undefined,
-    ConformancePackId:
-      output.ConformancePackId !== undefined && output.ConformancePackId !== null
-        ? output.ConformancePackId
-        : undefined,
+    ConformancePackArn: __expectString(output.ConformancePackArn),
+    ConformancePackId: __expectString(output.ConformancePackId),
     ConformancePackInputParameters:
       output.ConformancePackInputParameters !== undefined && output.ConformancePackInputParameters !== null
         ? deserializeAws_json1_1ConformancePackInputParameters(output.ConformancePackInputParameters, context)
         : undefined,
-    ConformancePackName:
-      output.ConformancePackName !== undefined && output.ConformancePackName !== null
-        ? output.ConformancePackName
-        : undefined,
-    CreatedBy: output.CreatedBy !== undefined && output.CreatedBy !== null ? output.CreatedBy : undefined,
-    DeliveryS3Bucket:
-      output.DeliveryS3Bucket !== undefined && output.DeliveryS3Bucket !== null ? output.DeliveryS3Bucket : undefined,
-    DeliveryS3KeyPrefix:
-      output.DeliveryS3KeyPrefix !== undefined && output.DeliveryS3KeyPrefix !== null
-        ? output.DeliveryS3KeyPrefix
-        : undefined,
+    ConformancePackName: __expectString(output.ConformancePackName),
+    CreatedBy: __expectString(output.CreatedBy),
+    DeliveryS3Bucket: __expectString(output.DeliveryS3Bucket),
+    DeliveryS3KeyPrefix: __expectString(output.DeliveryS3KeyPrefix),
     LastUpdateRequestedTime:
       output.LastUpdateRequestedTime !== undefined && output.LastUpdateRequestedTime !== null
         ? new Date(Math.round(output.LastUpdateRequestedTime * 1000))
@@ -11517,9 +11420,8 @@ const deserializeAws_json1_1ConformancePackEvaluationResult = (
   context: __SerdeContext
 ): ConformancePackEvaluationResult => {
   return {
-    Annotation: output.Annotation !== undefined && output.Annotation !== null ? output.Annotation : undefined,
-    ComplianceType:
-      output.ComplianceType !== undefined && output.ComplianceType !== null ? output.ComplianceType : undefined,
+    Annotation: __expectString(output.Annotation),
+    ComplianceType: __expectString(output.ComplianceType),
     ConfigRuleInvokedTime:
       output.ConfigRuleInvokedTime !== undefined && output.ConfigRuleInvokedTime !== null
         ? new Date(Math.round(output.ConfigRuleInvokedTime * 1000))
@@ -11540,10 +11442,8 @@ const deserializeAws_json1_1ConformancePackInputParameter = (
   context: __SerdeContext
 ): ConformancePackInputParameter => {
   return {
-    ParameterName:
-      output.ParameterName !== undefined && output.ParameterName !== null ? output.ParameterName : undefined,
-    ParameterValue:
-      output.ParameterValue !== undefined && output.ParameterValue !== null ? output.ParameterValue : undefined,
+    ParameterName: __expectString(output.ParameterName),
+    ParameterValue: __expectString(output.ParameterValue),
   } as any;
 };
 
@@ -11566,10 +11466,8 @@ const deserializeAws_json1_1ConformancePackRuleCompliance = (
   context: __SerdeContext
 ): ConformancePackRuleCompliance => {
   return {
-    ComplianceType:
-      output.ComplianceType !== undefined && output.ComplianceType !== null ? output.ComplianceType : undefined,
-    ConfigRuleName:
-      output.ConfigRuleName !== undefined && output.ConfigRuleName !== null ? output.ConfigRuleName : undefined,
+    ComplianceType: __expectString(output.ComplianceType),
+    ConfigRuleName: __expectString(output.ConfigRuleName),
     Controls:
       output.Controls !== undefined && output.Controls !== null
         ? deserializeAws_json1_1ControlsList(output.Controls, context)
@@ -11610,26 +11508,11 @@ const deserializeAws_json1_1ConformancePackStatusDetail = (
   context: __SerdeContext
 ): ConformancePackStatusDetail => {
   return {
-    ConformancePackArn:
-      output.ConformancePackArn !== undefined && output.ConformancePackArn !== null
-        ? output.ConformancePackArn
-        : undefined,
-    ConformancePackId:
-      output.ConformancePackId !== undefined && output.ConformancePackId !== null
-        ? output.ConformancePackId
-        : undefined,
-    ConformancePackName:
-      output.ConformancePackName !== undefined && output.ConformancePackName !== null
-        ? output.ConformancePackName
-        : undefined,
-    ConformancePackState:
-      output.ConformancePackState !== undefined && output.ConformancePackState !== null
-        ? output.ConformancePackState
-        : undefined,
-    ConformancePackStatusReason:
-      output.ConformancePackStatusReason !== undefined && output.ConformancePackStatusReason !== null
-        ? output.ConformancePackStatusReason
-        : undefined,
+    ConformancePackArn: __expectString(output.ConformancePackArn),
+    ConformancePackId: __expectString(output.ConformancePackId),
+    ConformancePackName: __expectString(output.ConformancePackName),
+    ConformancePackState: __expectString(output.ConformancePackState),
+    ConformancePackStatusReason: __expectString(output.ConformancePackStatusReason),
     LastUpdateCompletedTime:
       output.LastUpdateCompletedTime !== undefined && output.LastUpdateCompletedTime !== null
         ? new Date(Math.round(output.LastUpdateCompletedTime * 1000))
@@ -11638,7 +11521,7 @@ const deserializeAws_json1_1ConformancePackStatusDetail = (
       output.LastUpdateRequestedTime !== undefined && output.LastUpdateRequestedTime !== null
         ? new Date(Math.round(output.LastUpdateRequestedTime * 1000))
         : undefined,
-    StackArn: output.StackArn !== undefined && output.StackArn !== null ? output.StackArn : undefined,
+    StackArn: __expectString(output.StackArn),
   } as any;
 };
 
@@ -11661,7 +11544,7 @@ const deserializeAws_json1_1ConformancePackTemplateValidationException = (
   context: __SerdeContext
 ): ConformancePackTemplateValidationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -11672,7 +11555,7 @@ const deserializeAws_json1_1ControlsList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -11714,8 +11597,7 @@ const deserializeAws_json1_1DeliverConfigSnapshotResponse = (
   context: __SerdeContext
 ): DeliverConfigSnapshotResponse => {
   return {
-    configSnapshotId:
-      output.configSnapshotId !== undefined && output.configSnapshotId !== null ? output.configSnapshotId : undefined,
+    configSnapshotId: __expectString(output.configSnapshotId),
   } as any;
 };
 
@@ -11725,11 +11607,11 @@ const deserializeAws_json1_1DeliveryChannel = (output: any, context: __SerdeCont
       output.configSnapshotDeliveryProperties !== undefined && output.configSnapshotDeliveryProperties !== null
         ? deserializeAws_json1_1ConfigSnapshotDeliveryProperties(output.configSnapshotDeliveryProperties, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    s3BucketName: output.s3BucketName !== undefined && output.s3BucketName !== null ? output.s3BucketName : undefined,
-    s3KeyPrefix: output.s3KeyPrefix !== undefined && output.s3KeyPrefix !== null ? output.s3KeyPrefix : undefined,
-    s3KmsKeyArn: output.s3KmsKeyArn !== undefined && output.s3KmsKeyArn !== null ? output.s3KmsKeyArn : undefined,
-    snsTopicARN: output.snsTopicARN !== undefined && output.snsTopicARN !== null ? output.snsTopicARN : undefined,
+    name: __expectString(output.name),
+    s3BucketName: __expectString(output.s3BucketName),
+    s3KeyPrefix: __expectString(output.s3KeyPrefix),
+    s3KmsKeyArn: __expectString(output.s3KmsKeyArn),
+    snsTopicARN: __expectString(output.snsTopicARN),
   } as any;
 };
 
@@ -11758,7 +11640,7 @@ const deserializeAws_json1_1DeliveryChannelStatus = (output: any, context: __Ser
       output.configStreamDeliveryInfo !== undefined && output.configStreamDeliveryInfo !== null
         ? deserializeAws_json1_1ConfigStreamDeliveryInfo(output.configStreamDeliveryInfo, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -11785,7 +11667,7 @@ const deserializeAws_json1_1DescribeAggregateComplianceByConfigRulesResponse = (
       output.AggregateComplianceByConfigRules !== undefined && output.AggregateComplianceByConfigRules !== null
         ? deserializeAws_json1_1AggregateComplianceByConfigRuleList(output.AggregateComplianceByConfigRules, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -11802,7 +11684,7 @@ const deserializeAws_json1_1DescribeAggregateComplianceByConformancePacksRespons
             context
           )
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -11815,7 +11697,7 @@ const deserializeAws_json1_1DescribeAggregationAuthorizationsResponse = (
       output.AggregationAuthorizations !== undefined && output.AggregationAuthorizations !== null
         ? deserializeAws_json1_1AggregationAuthorizationList(output.AggregationAuthorizations, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -11828,7 +11710,7 @@ const deserializeAws_json1_1DescribeComplianceByConfigRuleResponse = (
       output.ComplianceByConfigRules !== undefined && output.ComplianceByConfigRules !== null
         ? deserializeAws_json1_1ComplianceByConfigRules(output.ComplianceByConfigRules, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -11841,7 +11723,7 @@ const deserializeAws_json1_1DescribeComplianceByResourceResponse = (
       output.ComplianceByResources !== undefined && output.ComplianceByResources !== null
         ? deserializeAws_json1_1ComplianceByResources(output.ComplianceByResources, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -11854,7 +11736,7 @@ const deserializeAws_json1_1DescribeConfigRuleEvaluationStatusResponse = (
       output.ConfigRulesEvaluationStatus !== undefined && output.ConfigRulesEvaluationStatus !== null
         ? deserializeAws_json1_1ConfigRuleEvaluationStatusList(output.ConfigRulesEvaluationStatus, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -11867,7 +11749,7 @@ const deserializeAws_json1_1DescribeConfigRulesResponse = (
       output.ConfigRules !== undefined && output.ConfigRules !== null
         ? deserializeAws_json1_1ConfigRules(output.ConfigRules, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -11880,7 +11762,7 @@ const deserializeAws_json1_1DescribeConfigurationAggregatorSourcesStatusResponse
       output.AggregatedSourceStatusList !== undefined && output.AggregatedSourceStatusList !== null
         ? deserializeAws_json1_1AggregatedSourceStatusList(output.AggregatedSourceStatusList, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -11893,7 +11775,7 @@ const deserializeAws_json1_1DescribeConfigurationAggregatorsResponse = (
       output.ConfigurationAggregators !== undefined && output.ConfigurationAggregators !== null
         ? deserializeAws_json1_1ConfigurationAggregatorList(output.ConfigurationAggregators, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -11926,15 +11808,12 @@ const deserializeAws_json1_1DescribeConformancePackComplianceResponse = (
   context: __SerdeContext
 ): DescribeConformancePackComplianceResponse => {
   return {
-    ConformancePackName:
-      output.ConformancePackName !== undefined && output.ConformancePackName !== null
-        ? output.ConformancePackName
-        : undefined,
+    ConformancePackName: __expectString(output.ConformancePackName),
     ConformancePackRuleComplianceList:
       output.ConformancePackRuleComplianceList !== undefined && output.ConformancePackRuleComplianceList !== null
         ? deserializeAws_json1_1ConformancePackRuleComplianceList(output.ConformancePackRuleComplianceList, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -11947,7 +11826,7 @@ const deserializeAws_json1_1DescribeConformancePacksResponse = (
       output.ConformancePackDetails !== undefined && output.ConformancePackDetails !== null
         ? deserializeAws_json1_1ConformancePackDetailList(output.ConformancePackDetails, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -11960,7 +11839,7 @@ const deserializeAws_json1_1DescribeConformancePackStatusResponse = (
       output.ConformancePackStatusDetails !== undefined && output.ConformancePackStatusDetails !== null
         ? deserializeAws_json1_1ConformancePackStatusDetailsList(output.ConformancePackStatusDetails, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -11993,7 +11872,7 @@ const deserializeAws_json1_1DescribeOrganizationConfigRulesResponse = (
   context: __SerdeContext
 ): DescribeOrganizationConfigRulesResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     OrganizationConfigRules:
       output.OrganizationConfigRules !== undefined && output.OrganizationConfigRules !== null
         ? deserializeAws_json1_1OrganizationConfigRules(output.OrganizationConfigRules, context)
@@ -12006,7 +11885,7 @@ const deserializeAws_json1_1DescribeOrganizationConfigRuleStatusesResponse = (
   context: __SerdeContext
 ): DescribeOrganizationConfigRuleStatusesResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     OrganizationConfigRuleStatuses:
       output.OrganizationConfigRuleStatuses !== undefined && output.OrganizationConfigRuleStatuses !== null
         ? deserializeAws_json1_1OrganizationConfigRuleStatuses(output.OrganizationConfigRuleStatuses, context)
@@ -12019,7 +11898,7 @@ const deserializeAws_json1_1DescribeOrganizationConformancePacksResponse = (
   context: __SerdeContext
 ): DescribeOrganizationConformancePacksResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     OrganizationConformancePacks:
       output.OrganizationConformancePacks !== undefined && output.OrganizationConformancePacks !== null
         ? deserializeAws_json1_1OrganizationConformancePacks(output.OrganizationConformancePacks, context)
@@ -12032,7 +11911,7 @@ const deserializeAws_json1_1DescribeOrganizationConformancePackStatusesResponse 
   context: __SerdeContext
 ): DescribeOrganizationConformancePackStatusesResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     OrganizationConformancePackStatuses:
       output.OrganizationConformancePackStatuses !== undefined && output.OrganizationConformancePackStatuses !== null
         ? deserializeAws_json1_1OrganizationConformancePackStatuses(output.OrganizationConformancePackStatuses, context)
@@ -12045,7 +11924,7 @@ const deserializeAws_json1_1DescribePendingAggregationRequestsResponse = (
   context: __SerdeContext
 ): DescribePendingAggregationRequestsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     PendingAggregationRequests:
       output.PendingAggregationRequests !== undefined && output.PendingAggregationRequests !== null
         ? deserializeAws_json1_1PendingAggregationRequestList(output.PendingAggregationRequests, context)
@@ -12070,7 +11949,7 @@ const deserializeAws_json1_1DescribeRemediationExceptionsResponse = (
   context: __SerdeContext
 ): DescribeRemediationExceptionsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     RemediationExceptions:
       output.RemediationExceptions !== undefined && output.RemediationExceptions !== null
         ? deserializeAws_json1_1RemediationExceptions(output.RemediationExceptions, context)
@@ -12083,7 +11962,7 @@ const deserializeAws_json1_1DescribeRemediationExecutionStatusResponse = (
   context: __SerdeContext
 ): DescribeRemediationExecutionStatusResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     RemediationExecutionStatuses:
       output.RemediationExecutionStatuses !== undefined && output.RemediationExecutionStatuses !== null
         ? deserializeAws_json1_1RemediationExecutionStatuses(output.RemediationExecutionStatuses, context)
@@ -12096,7 +11975,7 @@ const deserializeAws_json1_1DescribeRetentionConfigurationsResponse = (
   context: __SerdeContext
 ): DescribeRetentionConfigurationsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     RetentionConfigurations:
       output.RetentionConfigurations !== undefined && output.RetentionConfigurations !== null
         ? deserializeAws_json1_1RetentionConfigurationList(output.RetentionConfigurations, context)
@@ -12120,17 +11999,10 @@ const deserializeAws_json1_1DiscoveredResourceIdentifierList = (
 
 const deserializeAws_json1_1Evaluation = (output: any, context: __SerdeContext): Evaluation => {
   return {
-    Annotation: output.Annotation !== undefined && output.Annotation !== null ? output.Annotation : undefined,
-    ComplianceResourceId:
-      output.ComplianceResourceId !== undefined && output.ComplianceResourceId !== null
-        ? output.ComplianceResourceId
-        : undefined,
-    ComplianceResourceType:
-      output.ComplianceResourceType !== undefined && output.ComplianceResourceType !== null
-        ? output.ComplianceResourceType
-        : undefined,
-    ComplianceType:
-      output.ComplianceType !== undefined && output.ComplianceType !== null ? output.ComplianceType : undefined,
+    Annotation: __expectString(output.Annotation),
+    ComplianceResourceId: __expectString(output.ComplianceResourceId),
+    ComplianceResourceType: __expectString(output.ComplianceResourceType),
+    ComplianceType: __expectString(output.ComplianceType),
     OrderingTimestamp:
       output.OrderingTimestamp !== undefined && output.OrderingTimestamp !== null
         ? new Date(Math.round(output.OrderingTimestamp * 1000))
@@ -12140,9 +12012,8 @@ const deserializeAws_json1_1Evaluation = (output: any, context: __SerdeContext):
 
 const deserializeAws_json1_1EvaluationResult = (output: any, context: __SerdeContext): EvaluationResult => {
   return {
-    Annotation: output.Annotation !== undefined && output.Annotation !== null ? output.Annotation : undefined,
-    ComplianceType:
-      output.ComplianceType !== undefined && output.ComplianceType !== null ? output.ComplianceType : undefined,
+    Annotation: __expectString(output.Annotation),
+    ComplianceType: __expectString(output.ComplianceType),
     ConfigRuleInvokedTime:
       output.ConfigRuleInvokedTime !== undefined && output.ConfigRuleInvokedTime !== null
         ? new Date(Math.round(output.ConfigRuleInvokedTime * 1000))
@@ -12155,7 +12026,7 @@ const deserializeAws_json1_1EvaluationResult = (output: any, context: __SerdeCon
       output.ResultRecordedTime !== undefined && output.ResultRecordedTime !== null
         ? new Date(Math.round(output.ResultRecordedTime * 1000))
         : undefined,
-    ResultToken: output.ResultToken !== undefined && output.ResultToken !== null ? output.ResultToken : undefined,
+    ResultToken: __expectString(output.ResultToken),
   } as any;
 };
 
@@ -12180,10 +12051,9 @@ const deserializeAws_json1_1EvaluationResultQualifier = (
   context: __SerdeContext
 ): EvaluationResultQualifier => {
   return {
-    ConfigRuleName:
-      output.ConfigRuleName !== undefined && output.ConfigRuleName !== null ? output.ConfigRuleName : undefined,
-    ResourceId: output.ResourceId !== undefined && output.ResourceId !== null ? output.ResourceId : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
+    ConfigRuleName: __expectString(output.ConfigRuleName),
+    ResourceId: __expectString(output.ResourceId),
+    ResourceType: __expectString(output.ResourceType),
   } as any;
 };
 
@@ -12216,7 +12086,7 @@ const deserializeAws_json1_1ExcludedAccounts = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -12238,8 +12108,7 @@ const deserializeAws_json1_1FailedDeleteRemediationExceptionsBatch = (
       output.FailedItems !== undefined && output.FailedItems !== null
         ? deserializeAws_json1_1RemediationExceptionResourceKeys(output.FailedItems, context)
         : undefined,
-    FailureMessage:
-      output.FailureMessage !== undefined && output.FailureMessage !== null ? output.FailureMessage : undefined,
+    FailureMessage: __expectString(output.FailureMessage),
   } as any;
 };
 
@@ -12263,8 +12132,7 @@ const deserializeAws_json1_1FailedRemediationBatch = (output: any, context: __Se
       output.FailedItems !== undefined && output.FailedItems !== null
         ? deserializeAws_json1_1RemediationConfigurations(output.FailedItems, context)
         : undefined,
-    FailureMessage:
-      output.FailureMessage !== undefined && output.FailureMessage !== null ? output.FailureMessage : undefined,
+    FailureMessage: __expectString(output.FailureMessage),
   } as any;
 };
 
@@ -12291,8 +12159,7 @@ const deserializeAws_json1_1FailedRemediationExceptionBatch = (
       output.FailedItems !== undefined && output.FailedItems !== null
         ? deserializeAws_json1_1RemediationExceptions(output.FailedItems, context)
         : undefined,
-    FailureMessage:
-      output.FailureMessage !== undefined && output.FailureMessage !== null ? output.FailureMessage : undefined,
+    FailureMessage: __expectString(output.FailureMessage),
   } as any;
 };
 
@@ -12312,7 +12179,7 @@ const deserializeAws_json1_1FailedRemediationExceptionBatches = (
 
 const deserializeAws_json1_1FieldInfo = (output: any, context: __SerdeContext): FieldInfo => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -12336,7 +12203,7 @@ const deserializeAws_json1_1GetAggregateComplianceDetailsByConfigRuleResponse = 
       output.AggregateEvaluationResults !== undefined && output.AggregateEvaluationResults !== null
         ? deserializeAws_json1_1AggregateEvaluationResultList(output.AggregateEvaluationResults, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -12349,8 +12216,8 @@ const deserializeAws_json1_1GetAggregateConfigRuleComplianceSummaryResponse = (
       output.AggregateComplianceCounts !== undefined && output.AggregateComplianceCounts !== null
         ? deserializeAws_json1_1AggregateComplianceCountList(output.AggregateComplianceCounts, context)
         : undefined,
-    GroupByKey: output.GroupByKey !== undefined && output.GroupByKey !== null ? output.GroupByKey : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    GroupByKey: __expectString(output.GroupByKey),
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -12367,8 +12234,8 @@ const deserializeAws_json1_1GetAggregateConformancePackComplianceSummaryResponse
             context
           )
         : undefined,
-    GroupByKey: output.GroupByKey !== undefined && output.GroupByKey !== null ? output.GroupByKey : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    GroupByKey: __expectString(output.GroupByKey),
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -12377,16 +12244,13 @@ const deserializeAws_json1_1GetAggregateDiscoveredResourceCountsResponse = (
   context: __SerdeContext
 ): GetAggregateDiscoveredResourceCountsResponse => {
   return {
-    GroupByKey: output.GroupByKey !== undefined && output.GroupByKey !== null ? output.GroupByKey : undefined,
+    GroupByKey: __expectString(output.GroupByKey),
     GroupedResourceCounts:
       output.GroupedResourceCounts !== undefined && output.GroupedResourceCounts !== null
         ? deserializeAws_json1_1GroupedResourceCountList(output.GroupedResourceCounts, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
-    TotalDiscoveredResources:
-      output.TotalDiscoveredResources !== undefined && output.TotalDiscoveredResources !== null
-        ? output.TotalDiscoveredResources
-        : undefined,
+    NextToken: __expectString(output.NextToken),
+    TotalDiscoveredResources: __expectNumber(output.TotalDiscoveredResources),
   } as any;
 };
 
@@ -12411,7 +12275,7 @@ const deserializeAws_json1_1GetComplianceDetailsByConfigRuleResponse = (
       output.EvaluationResults !== undefined && output.EvaluationResults !== null
         ? deserializeAws_json1_1EvaluationResults(output.EvaluationResults, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -12424,7 +12288,7 @@ const deserializeAws_json1_1GetComplianceDetailsByResourceResponse = (
       output.EvaluationResults !== undefined && output.EvaluationResults !== null
         ? deserializeAws_json1_1EvaluationResults(output.EvaluationResults, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -12457,10 +12321,7 @@ const deserializeAws_json1_1GetConformancePackComplianceDetailsResponse = (
   context: __SerdeContext
 ): GetConformancePackComplianceDetailsResponse => {
   return {
-    ConformancePackName:
-      output.ConformancePackName !== undefined && output.ConformancePackName !== null
-        ? output.ConformancePackName
-        : undefined,
+    ConformancePackName: __expectString(output.ConformancePackName),
     ConformancePackRuleEvaluationResults:
       output.ConformancePackRuleEvaluationResults !== undefined && output.ConformancePackRuleEvaluationResults !== null
         ? deserializeAws_json1_1ConformancePackRuleEvaluationResultsList(
@@ -12468,7 +12329,7 @@ const deserializeAws_json1_1GetConformancePackComplianceDetailsResponse = (
             context
           )
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -12484,7 +12345,7 @@ const deserializeAws_json1_1GetConformancePackComplianceSummaryResponse = (
             context
           )
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -12493,15 +12354,12 @@ const deserializeAws_json1_1GetDiscoveredResourceCountsResponse = (
   context: __SerdeContext
 ): GetDiscoveredResourceCountsResponse => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     resourceCounts:
       output.resourceCounts !== undefined && output.resourceCounts !== null
         ? deserializeAws_json1_1ResourceCounts(output.resourceCounts, context)
         : undefined,
-    totalDiscoveredResources:
-      output.totalDiscoveredResources !== undefined && output.totalDiscoveredResources !== null
-        ? output.totalDiscoveredResources
-        : undefined,
+    totalDiscoveredResources: __expectNumber(output.totalDiscoveredResources),
   } as any;
 };
 
@@ -12510,7 +12368,7 @@ const deserializeAws_json1_1GetOrganizationConfigRuleDetailedStatusResponse = (
   context: __SerdeContext
 ): GetOrganizationConfigRuleDetailedStatusResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     OrganizationConfigRuleDetailedStatus:
       output.OrganizationConfigRuleDetailedStatus !== undefined && output.OrganizationConfigRuleDetailedStatus !== null
         ? deserializeAws_json1_1OrganizationConfigRuleDetailedStatus(
@@ -12526,7 +12384,7 @@ const deserializeAws_json1_1GetOrganizationConformancePackDetailedStatusResponse
   context: __SerdeContext
 ): GetOrganizationConformancePackDetailedStatusResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     OrganizationConformancePackDetailedStatuses:
       output.OrganizationConformancePackDetailedStatuses !== undefined &&
       output.OrganizationConformancePackDetailedStatuses !== null
@@ -12547,7 +12405,7 @@ const deserializeAws_json1_1GetResourceConfigHistoryResponse = (
       output.configurationItems !== undefined && output.configurationItems !== null
         ? deserializeAws_json1_1ConfigurationItemList(output.configurationItems, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -12562,9 +12420,8 @@ const deserializeAws_json1_1GetStoredQueryResponse = (output: any, context: __Se
 
 const deserializeAws_json1_1GroupedResourceCount = (output: any, context: __SerdeContext): GroupedResourceCount => {
   return {
-    GroupName: output.GroupName !== undefined && output.GroupName !== null ? output.GroupName : undefined,
-    ResourceCount:
-      output.ResourceCount !== undefined && output.ResourceCount !== null ? output.ResourceCount : undefined,
+    GroupName: __expectString(output.GroupName),
+    ResourceCount: __expectNumber(output.ResourceCount),
   } as any;
 };
 
@@ -12587,7 +12444,7 @@ const deserializeAws_json1_1InsufficientDeliveryPolicyException = (
   context: __SerdeContext
 ): InsufficientDeliveryPolicyException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -12596,7 +12453,7 @@ const deserializeAws_json1_1InsufficientPermissionsException = (
   context: __SerdeContext
 ): InsufficientPermissionsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -12605,7 +12462,7 @@ const deserializeAws_json1_1InvalidConfigurationRecorderNameException = (
   context: __SerdeContext
 ): InvalidConfigurationRecorderNameException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -12614,7 +12471,7 @@ const deserializeAws_json1_1InvalidDeliveryChannelNameException = (
   context: __SerdeContext
 ): InvalidDeliveryChannelNameException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -12623,13 +12480,13 @@ const deserializeAws_json1_1InvalidExpressionException = (
   context: __SerdeContext
 ): InvalidExpressionException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidLimitException = (output: any, context: __SerdeContext): InvalidLimitException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -12638,7 +12495,7 @@ const deserializeAws_json1_1InvalidNextTokenException = (
   context: __SerdeContext
 ): InvalidNextTokenException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -12647,7 +12504,7 @@ const deserializeAws_json1_1InvalidParameterValueException = (
   context: __SerdeContext
 ): InvalidParameterValueException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -12656,7 +12513,7 @@ const deserializeAws_json1_1InvalidRecordingGroupException = (
   context: __SerdeContext
 ): InvalidRecordingGroupException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -12665,13 +12522,13 @@ const deserializeAws_json1_1InvalidResultTokenException = (
   context: __SerdeContext
 ): InvalidResultTokenException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidRoleException = (output: any, context: __SerdeContext): InvalidRoleException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -12680,7 +12537,7 @@ const deserializeAws_json1_1InvalidS3KeyPrefixException = (
   context: __SerdeContext
 ): InvalidS3KeyPrefixException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -12689,7 +12546,7 @@ const deserializeAws_json1_1InvalidS3KmsKeyArnException = (
   context: __SerdeContext
 ): InvalidS3KmsKeyArnException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -12698,7 +12555,7 @@ const deserializeAws_json1_1InvalidSNSTopicARNException = (
   context: __SerdeContext
 ): InvalidSNSTopicARNException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -12707,7 +12564,7 @@ const deserializeAws_json1_1InvalidTimeRangeException = (
   context: __SerdeContext
 ): InvalidTimeRangeException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -12716,13 +12573,13 @@ const deserializeAws_json1_1LastDeliveryChannelDeleteFailedException = (
   context: __SerdeContext
 ): LastDeliveryChannelDeleteFailedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -12731,7 +12588,7 @@ const deserializeAws_json1_1ListAggregateDiscoveredResourcesResponse = (
   context: __SerdeContext
 ): ListAggregateDiscoveredResourcesResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     ResourceIdentifiers:
       output.ResourceIdentifiers !== undefined && output.ResourceIdentifiers !== null
         ? deserializeAws_json1_1DiscoveredResourceIdentifierList(output.ResourceIdentifiers, context)
@@ -12744,7 +12601,7 @@ const deserializeAws_json1_1ListDiscoveredResourcesResponse = (
   context: __SerdeContext
 ): ListDiscoveredResourcesResponse => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     resourceIdentifiers:
       output.resourceIdentifiers !== undefined && output.resourceIdentifiers !== null
         ? deserializeAws_json1_1ResourceIdentifierList(output.resourceIdentifiers, context)
@@ -12757,7 +12614,7 @@ const deserializeAws_json1_1ListStoredQueriesResponse = (
   context: __SerdeContext
 ): ListStoredQueriesResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     StoredQueryMetadata:
       output.StoredQueryMetadata !== undefined && output.StoredQueryMetadata !== null
         ? deserializeAws_json1_1StoredQueryMetadataList(output.StoredQueryMetadata, context)
@@ -12770,7 +12627,7 @@ const deserializeAws_json1_1ListTagsForResourceResponse = (
   context: __SerdeContext
 ): ListTagsForResourceResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_1TagList(output.Tags, context)
@@ -12783,7 +12640,7 @@ const deserializeAws_json1_1MaxActiveResourcesExceededException = (
   context: __SerdeContext
 ): MaxActiveResourcesExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -12792,7 +12649,7 @@ const deserializeAws_json1_1MaxNumberOfConfigRulesExceededException = (
   context: __SerdeContext
 ): MaxNumberOfConfigRulesExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -12801,7 +12658,7 @@ const deserializeAws_json1_1MaxNumberOfConfigurationRecordersExceededException =
   context: __SerdeContext
 ): MaxNumberOfConfigurationRecordersExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -12810,7 +12667,7 @@ const deserializeAws_json1_1MaxNumberOfConformancePacksExceededException = (
   context: __SerdeContext
 ): MaxNumberOfConformancePacksExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -12819,7 +12676,7 @@ const deserializeAws_json1_1MaxNumberOfDeliveryChannelsExceededException = (
   context: __SerdeContext
 ): MaxNumberOfDeliveryChannelsExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -12828,7 +12685,7 @@ const deserializeAws_json1_1MaxNumberOfOrganizationConfigRulesExceededException 
   context: __SerdeContext
 ): MaxNumberOfOrganizationConfigRulesExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -12837,7 +12694,7 @@ const deserializeAws_json1_1MaxNumberOfOrganizationConformancePacksExceededExcep
   context: __SerdeContext
 ): MaxNumberOfOrganizationConformancePacksExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -12846,25 +12703,21 @@ const deserializeAws_json1_1MaxNumberOfRetentionConfigurationsExceededException 
   context: __SerdeContext
 ): MaxNumberOfRetentionConfigurationsExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1MemberAccountStatus = (output: any, context: __SerdeContext): MemberAccountStatus => {
   return {
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
-    ConfigRuleName:
-      output.ConfigRuleName !== undefined && output.ConfigRuleName !== null ? output.ConfigRuleName : undefined,
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
+    AccountId: __expectString(output.AccountId),
+    ConfigRuleName: __expectString(output.ConfigRuleName),
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
     LastUpdateTime:
       output.LastUpdateTime !== undefined && output.LastUpdateTime !== null
         ? new Date(Math.round(output.LastUpdateTime * 1000))
         : undefined,
-    MemberAccountRuleStatus:
-      output.MemberAccountRuleStatus !== undefined && output.MemberAccountRuleStatus !== null
-        ? output.MemberAccountRuleStatus
-        : undefined,
+    MemberAccountRuleStatus: __expectString(output.MemberAccountRuleStatus),
   } as any;
 };
 
@@ -12873,7 +12726,7 @@ const deserializeAws_json1_1NoAvailableConfigurationRecorderException = (
   context: __SerdeContext
 ): NoAvailableConfigurationRecorderException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -12882,7 +12735,7 @@ const deserializeAws_json1_1NoAvailableDeliveryChannelException = (
   context: __SerdeContext
 ): NoAvailableDeliveryChannelException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -12891,7 +12744,7 @@ const deserializeAws_json1_1NoAvailableOrganizationException = (
   context: __SerdeContext
 ): NoAvailableOrganizationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -12900,13 +12753,13 @@ const deserializeAws_json1_1NoRunningConfigurationRecorderException = (
   context: __SerdeContext
 ): NoRunningConfigurationRecorderException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1NoSuchBucketException = (output: any, context: __SerdeContext): NoSuchBucketException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -12915,7 +12768,7 @@ const deserializeAws_json1_1NoSuchConfigRuleException = (
   context: __SerdeContext
 ): NoSuchConfigRuleException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -12924,7 +12777,7 @@ const deserializeAws_json1_1NoSuchConfigRuleInConformancePackException = (
   context: __SerdeContext
 ): NoSuchConfigRuleInConformancePackException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -12933,7 +12786,7 @@ const deserializeAws_json1_1NoSuchConfigurationAggregatorException = (
   context: __SerdeContext
 ): NoSuchConfigurationAggregatorException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -12942,7 +12795,7 @@ const deserializeAws_json1_1NoSuchConfigurationRecorderException = (
   context: __SerdeContext
 ): NoSuchConfigurationRecorderException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -12951,7 +12804,7 @@ const deserializeAws_json1_1NoSuchConformancePackException = (
   context: __SerdeContext
 ): NoSuchConformancePackException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -12960,7 +12813,7 @@ const deserializeAws_json1_1NoSuchDeliveryChannelException = (
   context: __SerdeContext
 ): NoSuchDeliveryChannelException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -12969,7 +12822,7 @@ const deserializeAws_json1_1NoSuchOrganizationConfigRuleException = (
   context: __SerdeContext
 ): NoSuchOrganizationConfigRuleException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -12978,7 +12831,7 @@ const deserializeAws_json1_1NoSuchOrganizationConformancePackException = (
   context: __SerdeContext
 ): NoSuchOrganizationConformancePackException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -12987,7 +12840,7 @@ const deserializeAws_json1_1NoSuchRemediationConfigurationException = (
   context: __SerdeContext
 ): NoSuchRemediationConfigurationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -12996,7 +12849,7 @@ const deserializeAws_json1_1NoSuchRemediationExceptionException = (
   context: __SerdeContext
 ): NoSuchRemediationExceptionException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -13005,7 +12858,7 @@ const deserializeAws_json1_1NoSuchRetentionConfigurationException = (
   context: __SerdeContext
 ): NoSuchRetentionConfigurationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -13014,7 +12867,7 @@ const deserializeAws_json1_1OrganizationAccessDeniedException = (
   context: __SerdeContext
 ): OrganizationAccessDeniedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -13023,13 +12876,12 @@ const deserializeAws_json1_1OrganizationAggregationSource = (
   context: __SerdeContext
 ): OrganizationAggregationSource => {
   return {
-    AllAwsRegions:
-      output.AllAwsRegions !== undefined && output.AllAwsRegions !== null ? output.AllAwsRegions : undefined,
+    AllAwsRegions: __expectBoolean(output.AllAwsRegions),
     AwsRegions:
       output.AwsRegions !== undefined && output.AwsRegions !== null
         ? deserializeAws_json1_1AggregatorRegionList(output.AwsRegions, context)
         : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
+    RoleArn: __expectString(output.RoleArn),
   } as any;
 };
 
@@ -13038,7 +12890,7 @@ const deserializeAws_json1_1OrganizationAllFeaturesNotEnabledException = (
   context: __SerdeContext
 ): OrganizationAllFeaturesNotEnabledException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -13052,14 +12904,8 @@ const deserializeAws_json1_1OrganizationConfigRule = (output: any, context: __Se
       output.LastUpdateTime !== undefined && output.LastUpdateTime !== null
         ? new Date(Math.round(output.LastUpdateTime * 1000))
         : undefined,
-    OrganizationConfigRuleArn:
-      output.OrganizationConfigRuleArn !== undefined && output.OrganizationConfigRuleArn !== null
-        ? output.OrganizationConfigRuleArn
-        : undefined,
-    OrganizationConfigRuleName:
-      output.OrganizationConfigRuleName !== undefined && output.OrganizationConfigRuleName !== null
-        ? output.OrganizationConfigRuleName
-        : undefined,
+    OrganizationConfigRuleArn: __expectString(output.OrganizationConfigRuleArn),
+    OrganizationConfigRuleName: __expectString(output.OrganizationConfigRuleName),
     OrganizationCustomRuleMetadata:
       output.OrganizationCustomRuleMetadata !== undefined && output.OrganizationCustomRuleMetadata !== null
         ? deserializeAws_json1_1OrganizationCustomRuleMetadata(output.OrganizationCustomRuleMetadata, context)
@@ -13104,20 +12950,14 @@ const deserializeAws_json1_1OrganizationConfigRuleStatus = (
   context: __SerdeContext
 ): OrganizationConfigRuleStatus => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
     LastUpdateTime:
       output.LastUpdateTime !== undefined && output.LastUpdateTime !== null
         ? new Date(Math.round(output.LastUpdateTime * 1000))
         : undefined,
-    OrganizationConfigRuleName:
-      output.OrganizationConfigRuleName !== undefined && output.OrganizationConfigRuleName !== null
-        ? output.OrganizationConfigRuleName
-        : undefined,
-    OrganizationRuleStatus:
-      output.OrganizationRuleStatus !== undefined && output.OrganizationRuleStatus !== null
-        ? output.OrganizationRuleStatus
-        : undefined,
+    OrganizationConfigRuleName: __expectString(output.OrganizationConfigRuleName),
+    OrganizationRuleStatus: __expectString(output.OrganizationRuleStatus),
   } as any;
 };
 
@@ -13145,7 +12985,7 @@ const deserializeAws_json1_1OrganizationConfigRuleTriggerTypes = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -13158,12 +12998,8 @@ const deserializeAws_json1_1OrganizationConformancePack = (
       output.ConformancePackInputParameters !== undefined && output.ConformancePackInputParameters !== null
         ? deserializeAws_json1_1ConformancePackInputParameters(output.ConformancePackInputParameters, context)
         : undefined,
-    DeliveryS3Bucket:
-      output.DeliveryS3Bucket !== undefined && output.DeliveryS3Bucket !== null ? output.DeliveryS3Bucket : undefined,
-    DeliveryS3KeyPrefix:
-      output.DeliveryS3KeyPrefix !== undefined && output.DeliveryS3KeyPrefix !== null
-        ? output.DeliveryS3KeyPrefix
-        : undefined,
+    DeliveryS3Bucket: __expectString(output.DeliveryS3Bucket),
+    DeliveryS3KeyPrefix: __expectString(output.DeliveryS3KeyPrefix),
     ExcludedAccounts:
       output.ExcludedAccounts !== undefined && output.ExcludedAccounts !== null
         ? deserializeAws_json1_1ExcludedAccounts(output.ExcludedAccounts, context)
@@ -13172,14 +13008,8 @@ const deserializeAws_json1_1OrganizationConformancePack = (
       output.LastUpdateTime !== undefined && output.LastUpdateTime !== null
         ? new Date(Math.round(output.LastUpdateTime * 1000))
         : undefined,
-    OrganizationConformancePackArn:
-      output.OrganizationConformancePackArn !== undefined && output.OrganizationConformancePackArn !== null
-        ? output.OrganizationConformancePackArn
-        : undefined,
-    OrganizationConformancePackName:
-      output.OrganizationConformancePackName !== undefined && output.OrganizationConformancePackName !== null
-        ? output.OrganizationConformancePackName
-        : undefined,
+    OrganizationConformancePackArn: __expectString(output.OrganizationConformancePackArn),
+    OrganizationConformancePackName: __expectString(output.OrganizationConformancePackName),
   } as any;
 };
 
@@ -13188,18 +13018,15 @@ const deserializeAws_json1_1OrganizationConformancePackDetailedStatus = (
   context: __SerdeContext
 ): OrganizationConformancePackDetailedStatus => {
   return {
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
-    ConformancePackName:
-      output.ConformancePackName !== undefined && output.ConformancePackName !== null
-        ? output.ConformancePackName
-        : undefined,
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
+    AccountId: __expectString(output.AccountId),
+    ConformancePackName: __expectString(output.ConformancePackName),
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
     LastUpdateTime:
       output.LastUpdateTime !== undefined && output.LastUpdateTime !== null
         ? new Date(Math.round(output.LastUpdateTime * 1000))
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -13236,17 +13063,14 @@ const deserializeAws_json1_1OrganizationConformancePackStatus = (
   context: __SerdeContext
 ): OrganizationConformancePackStatus => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
     LastUpdateTime:
       output.LastUpdateTime !== undefined && output.LastUpdateTime !== null
         ? new Date(Math.round(output.LastUpdateTime * 1000))
         : undefined,
-    OrganizationConformancePackName:
-      output.OrganizationConformancePackName !== undefined && output.OrganizationConformancePackName !== null
-        ? output.OrganizationConformancePackName
-        : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    OrganizationConformancePackName: __expectString(output.OrganizationConformancePackName),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -13269,7 +13093,7 @@ const deserializeAws_json1_1OrganizationConformancePackTemplateValidationExcepti
   context: __SerdeContext
 ): OrganizationConformancePackTemplateValidationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -13278,30 +13102,21 @@ const deserializeAws_json1_1OrganizationCustomRuleMetadata = (
   context: __SerdeContext
 ): OrganizationCustomRuleMetadata => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    InputParameters:
-      output.InputParameters !== undefined && output.InputParameters !== null ? output.InputParameters : undefined,
-    LambdaFunctionArn:
-      output.LambdaFunctionArn !== undefined && output.LambdaFunctionArn !== null
-        ? output.LambdaFunctionArn
-        : undefined,
-    MaximumExecutionFrequency:
-      output.MaximumExecutionFrequency !== undefined && output.MaximumExecutionFrequency !== null
-        ? output.MaximumExecutionFrequency
-        : undefined,
+    Description: __expectString(output.Description),
+    InputParameters: __expectString(output.InputParameters),
+    LambdaFunctionArn: __expectString(output.LambdaFunctionArn),
+    MaximumExecutionFrequency: __expectString(output.MaximumExecutionFrequency),
     OrganizationConfigRuleTriggerTypes:
       output.OrganizationConfigRuleTriggerTypes !== undefined && output.OrganizationConfigRuleTriggerTypes !== null
         ? deserializeAws_json1_1OrganizationConfigRuleTriggerTypes(output.OrganizationConfigRuleTriggerTypes, context)
         : undefined,
-    ResourceIdScope:
-      output.ResourceIdScope !== undefined && output.ResourceIdScope !== null ? output.ResourceIdScope : undefined,
+    ResourceIdScope: __expectString(output.ResourceIdScope),
     ResourceTypesScope:
       output.ResourceTypesScope !== undefined && output.ResourceTypesScope !== null
         ? deserializeAws_json1_1ResourceTypesScope(output.ResourceTypesScope, context)
         : undefined,
-    TagKeyScope: output.TagKeyScope !== undefined && output.TagKeyScope !== null ? output.TagKeyScope : undefined,
-    TagValueScope:
-      output.TagValueScope !== undefined && output.TagValueScope !== null ? output.TagValueScope : undefined,
+    TagKeyScope: __expectString(output.TagKeyScope),
+    TagValueScope: __expectString(output.TagValueScope),
   } as any;
 };
 
@@ -13310,24 +13125,17 @@ const deserializeAws_json1_1OrganizationManagedRuleMetadata = (
   context: __SerdeContext
 ): OrganizationManagedRuleMetadata => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    InputParameters:
-      output.InputParameters !== undefined && output.InputParameters !== null ? output.InputParameters : undefined,
-    MaximumExecutionFrequency:
-      output.MaximumExecutionFrequency !== undefined && output.MaximumExecutionFrequency !== null
-        ? output.MaximumExecutionFrequency
-        : undefined,
-    ResourceIdScope:
-      output.ResourceIdScope !== undefined && output.ResourceIdScope !== null ? output.ResourceIdScope : undefined,
+    Description: __expectString(output.Description),
+    InputParameters: __expectString(output.InputParameters),
+    MaximumExecutionFrequency: __expectString(output.MaximumExecutionFrequency),
+    ResourceIdScope: __expectString(output.ResourceIdScope),
     ResourceTypesScope:
       output.ResourceTypesScope !== undefined && output.ResourceTypesScope !== null
         ? deserializeAws_json1_1ResourceTypesScope(output.ResourceTypesScope, context)
         : undefined,
-    RuleIdentifier:
-      output.RuleIdentifier !== undefined && output.RuleIdentifier !== null ? output.RuleIdentifier : undefined,
-    TagKeyScope: output.TagKeyScope !== undefined && output.TagKeyScope !== null ? output.TagKeyScope : undefined,
-    TagValueScope:
-      output.TagValueScope !== undefined && output.TagValueScope !== null ? output.TagValueScope : undefined,
+    RuleIdentifier: __expectString(output.RuleIdentifier),
+    TagKeyScope: __expectString(output.TagKeyScope),
+    TagValueScope: __expectString(output.TagValueScope),
   } as any;
 };
 
@@ -13336,7 +13144,7 @@ const deserializeAws_json1_1OversizedConfigurationItemException = (
   context: __SerdeContext
 ): OversizedConfigurationItemException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -13345,14 +13153,8 @@ const deserializeAws_json1_1PendingAggregationRequest = (
   context: __SerdeContext
 ): PendingAggregationRequest => {
   return {
-    RequesterAccountId:
-      output.RequesterAccountId !== undefined && output.RequesterAccountId !== null
-        ? output.RequesterAccountId
-        : undefined,
-    RequesterAwsRegion:
-      output.RequesterAwsRegion !== undefined && output.RequesterAwsRegion !== null
-        ? output.RequesterAwsRegion
-        : undefined,
+    RequesterAccountId: __expectString(output.RequesterAccountId),
+    RequesterAwsRegion: __expectString(output.RequesterAwsRegion),
   } as any;
 };
 
@@ -13399,10 +13201,7 @@ const deserializeAws_json1_1PutConformancePackResponse = (
   context: __SerdeContext
 ): PutConformancePackResponse => {
   return {
-    ConformancePackArn:
-      output.ConformancePackArn !== undefined && output.ConformancePackArn !== null
-        ? output.ConformancePackArn
-        : undefined,
+    ConformancePackArn: __expectString(output.ConformancePackArn),
   } as any;
 };
 
@@ -13427,10 +13226,7 @@ const deserializeAws_json1_1PutOrganizationConfigRuleResponse = (
   context: __SerdeContext
 ): PutOrganizationConfigRuleResponse => {
   return {
-    OrganizationConfigRuleArn:
-      output.OrganizationConfigRuleArn !== undefined && output.OrganizationConfigRuleArn !== null
-        ? output.OrganizationConfigRuleArn
-        : undefined,
+    OrganizationConfigRuleArn: __expectString(output.OrganizationConfigRuleArn),
   } as any;
 };
 
@@ -13439,10 +13235,7 @@ const deserializeAws_json1_1PutOrganizationConformancePackResponse = (
   context: __SerdeContext
 ): PutOrganizationConformancePackResponse => {
   return {
-    OrganizationConformancePackArn:
-      output.OrganizationConformancePackArn !== undefined && output.OrganizationConformancePackArn !== null
-        ? output.OrganizationConformancePackArn
-        : undefined,
+    OrganizationConformancePackArn: __expectString(output.OrganizationConformancePackArn),
   } as any;
 };
 
@@ -13484,7 +13277,7 @@ const deserializeAws_json1_1PutRetentionConfigurationResponse = (
 
 const deserializeAws_json1_1PutStoredQueryResponse = (output: any, context: __SerdeContext): PutStoredQueryResponse => {
   return {
-    QueryArn: output.QueryArn !== undefined && output.QueryArn !== null ? output.QueryArn : undefined,
+    QueryArn: __expectString(output.QueryArn),
   } as any;
 };
 
@@ -13499,11 +13292,8 @@ const deserializeAws_json1_1QueryInfo = (output: any, context: __SerdeContext): 
 
 const deserializeAws_json1_1RecordingGroup = (output: any, context: __SerdeContext): RecordingGroup => {
   return {
-    allSupported: output.allSupported !== undefined && output.allSupported !== null ? output.allSupported : undefined,
-    includeGlobalResourceTypes:
-      output.includeGlobalResourceTypes !== undefined && output.includeGlobalResourceTypes !== null
-        ? output.includeGlobalResourceTypes
-        : undefined,
+    allSupported: __expectBoolean(output.allSupported),
+    includeGlobalResourceTypes: __expectBoolean(output.includeGlobalResourceTypes),
     resourceTypes:
       output.resourceTypes !== undefined && output.resourceTypes !== null
         ? deserializeAws_json1_1ResourceTypeList(output.resourceTypes, context)
@@ -13518,17 +13308,16 @@ const deserializeAws_json1_1RelatedEventList = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1Relationship = (output: any, context: __SerdeContext): Relationship => {
   return {
-    relationshipName:
-      output.relationshipName !== undefined && output.relationshipName !== null ? output.relationshipName : undefined,
-    resourceId: output.resourceId !== undefined && output.resourceId !== null ? output.resourceId : undefined,
-    resourceName: output.resourceName !== undefined && output.resourceName !== null ? output.resourceName : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
+    relationshipName: __expectString(output.relationshipName),
+    resourceId: __expectString(output.resourceId),
+    resourceName: __expectString(output.resourceName),
+    resourceType: __expectString(output.resourceType),
   } as any;
 };
 
@@ -13548,33 +13337,24 @@ const deserializeAws_json1_1RemediationConfiguration = (
   context: __SerdeContext
 ): RemediationConfiguration => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Automatic: output.Automatic !== undefined && output.Automatic !== null ? output.Automatic : undefined,
-    ConfigRuleName:
-      output.ConfigRuleName !== undefined && output.ConfigRuleName !== null ? output.ConfigRuleName : undefined,
-    CreatedByService:
-      output.CreatedByService !== undefined && output.CreatedByService !== null ? output.CreatedByService : undefined,
+    Arn: __expectString(output.Arn),
+    Automatic: __expectBoolean(output.Automatic),
+    ConfigRuleName: __expectString(output.ConfigRuleName),
+    CreatedByService: __expectString(output.CreatedByService),
     ExecutionControls:
       output.ExecutionControls !== undefined && output.ExecutionControls !== null
         ? deserializeAws_json1_1ExecutionControls(output.ExecutionControls, context)
         : undefined,
-    MaximumAutomaticAttempts:
-      output.MaximumAutomaticAttempts !== undefined && output.MaximumAutomaticAttempts !== null
-        ? output.MaximumAutomaticAttempts
-        : undefined,
+    MaximumAutomaticAttempts: __expectNumber(output.MaximumAutomaticAttempts),
     Parameters:
       output.Parameters !== undefined && output.Parameters !== null
         ? deserializeAws_json1_1RemediationParameters(output.Parameters, context)
         : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
-    RetryAttemptSeconds:
-      output.RetryAttemptSeconds !== undefined && output.RetryAttemptSeconds !== null
-        ? output.RetryAttemptSeconds
-        : undefined,
-    TargetId: output.TargetId !== undefined && output.TargetId !== null ? output.TargetId : undefined,
-    TargetType: output.TargetType !== undefined && output.TargetType !== null ? output.TargetType : undefined,
-    TargetVersion:
-      output.TargetVersion !== undefined && output.TargetVersion !== null ? output.TargetVersion : undefined,
+    ResourceType: __expectString(output.ResourceType),
+    RetryAttemptSeconds: __expectNumber(output.RetryAttemptSeconds),
+    TargetId: __expectString(output.TargetId),
+    TargetType: __expectString(output.TargetType),
+    TargetVersion: __expectString(output.TargetVersion),
   } as any;
 };
 
@@ -13594,15 +13374,14 @@ const deserializeAws_json1_1RemediationConfigurations = (
 
 const deserializeAws_json1_1RemediationException = (output: any, context: __SerdeContext): RemediationException => {
   return {
-    ConfigRuleName:
-      output.ConfigRuleName !== undefined && output.ConfigRuleName !== null ? output.ConfigRuleName : undefined,
+    ConfigRuleName: __expectString(output.ConfigRuleName),
     ExpirationTime:
       output.ExpirationTime !== undefined && output.ExpirationTime !== null
         ? new Date(Math.round(output.ExpirationTime * 1000))
         : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    ResourceId: output.ResourceId !== undefined && output.ResourceId !== null ? output.ResourceId : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
+    Message: __expectString(output.Message),
+    ResourceId: __expectString(output.ResourceId),
+    ResourceType: __expectString(output.ResourceType),
   } as any;
 };
 
@@ -13611,8 +13390,8 @@ const deserializeAws_json1_1RemediationExceptionResourceKey = (
   context: __SerdeContext
 ): RemediationExceptionResourceKey => {
   return {
-    ResourceId: output.ResourceId !== undefined && output.ResourceId !== null ? output.ResourceId : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
+    ResourceId: __expectString(output.ResourceId),
+    ResourceType: __expectString(output.ResourceType),
   } as any;
 };
 
@@ -13658,7 +13437,7 @@ const deserializeAws_json1_1RemediationExecutionStatus = (
       output.ResourceKey !== undefined && output.ResourceKey !== null
         ? deserializeAws_json1_1ResourceKey(output.ResourceKey, context)
         : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    State: __expectString(output.State),
     StepDetails:
       output.StepDetails !== undefined && output.StepDetails !== null
         ? deserializeAws_json1_1RemediationExecutionSteps(output.StepDetails, context)
@@ -13685,13 +13464,13 @@ const deserializeAws_json1_1RemediationExecutionStep = (
   context: __SerdeContext
 ): RemediationExecutionStep => {
   return {
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    ErrorMessage: __expectString(output.ErrorMessage),
+    Name: __expectString(output.Name),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
         ? new Date(Math.round(output.StartTime * 1000))
         : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    State: __expectString(output.State),
     StopTime:
       output.StopTime !== undefined && output.StopTime !== null
         ? new Date(Math.round(output.StopTime * 1000))
@@ -13718,7 +13497,7 @@ const deserializeAws_json1_1RemediationInProgressException = (
   context: __SerdeContext
 ): RemediationInProgressException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -13761,14 +13540,14 @@ const deserializeAws_json1_1ResourceConcurrentModificationException = (
   context: __SerdeContext
 ): ResourceConcurrentModificationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1ResourceCount = (output: any, context: __SerdeContext): ResourceCount => {
   return {
-    count: output.count !== undefined && output.count !== null ? output.count : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
+    count: __expectNumber(output.count),
+    resourceType: __expectString(output.resourceType),
   } as any;
 };
 
@@ -13789,9 +13568,9 @@ const deserializeAws_json1_1ResourceIdentifier = (output: any, context: __SerdeC
       output.resourceDeletionTime !== undefined && output.resourceDeletionTime !== null
         ? new Date(Math.round(output.resourceDeletionTime * 1000))
         : undefined,
-    resourceId: output.resourceId !== undefined && output.resourceId !== null ? output.resourceId : undefined,
-    resourceName: output.resourceName !== undefined && output.resourceName !== null ? output.resourceName : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
+    resourceId: __expectString(output.resourceId),
+    resourceName: __expectString(output.resourceName),
+    resourceType: __expectString(output.resourceType),
   } as any;
 };
 
@@ -13808,14 +13587,14 @@ const deserializeAws_json1_1ResourceIdentifierList = (output: any, context: __Se
 
 const deserializeAws_json1_1ResourceInUseException = (output: any, context: __SerdeContext): ResourceInUseException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1ResourceKey = (output: any, context: __SerdeContext): ResourceKey => {
   return {
-    resourceId: output.resourceId !== undefined && output.resourceId !== null ? output.resourceId : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
+    resourceId: __expectString(output.resourceId),
+    resourceType: __expectString(output.resourceType),
   } as any;
 };
 
@@ -13835,7 +13614,7 @@ const deserializeAws_json1_1ResourceNotDiscoveredException = (
   context: __SerdeContext
 ): ResourceNotDiscoveredException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -13844,7 +13623,7 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -13855,7 +13634,7 @@ const deserializeAws_json1_1ResourceTypeList = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -13866,13 +13645,13 @@ const deserializeAws_json1_1ResourceTypesScope = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1ResourceValue = (output: any, context: __SerdeContext): ResourceValue => {
   return {
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -13883,17 +13662,14 @@ const deserializeAws_json1_1Results = (output: any, context: __SerdeContext): st
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1RetentionConfiguration = (output: any, context: __SerdeContext): RetentionConfiguration => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    RetentionPeriodInDays:
-      output.RetentionPeriodInDays !== undefined && output.RetentionPeriodInDays !== null
-        ? output.RetentionPeriodInDays
-        : undefined,
+    Name: __expectString(output.Name),
+    RetentionPeriodInDays: __expectNumber(output.RetentionPeriodInDays),
   } as any;
 };
 
@@ -13913,16 +13689,13 @@ const deserializeAws_json1_1RetentionConfigurationList = (
 
 const deserializeAws_json1_1Scope = (output: any, context: __SerdeContext): Scope => {
   return {
-    ComplianceResourceId:
-      output.ComplianceResourceId !== undefined && output.ComplianceResourceId !== null
-        ? output.ComplianceResourceId
-        : undefined,
+    ComplianceResourceId: __expectString(output.ComplianceResourceId),
     ComplianceResourceTypes:
       output.ComplianceResourceTypes !== undefined && output.ComplianceResourceTypes !== null
         ? deserializeAws_json1_1ComplianceResourceTypes(output.ComplianceResourceTypes, context)
         : undefined,
-    TagKey: output.TagKey !== undefined && output.TagKey !== null ? output.TagKey : undefined,
-    TagValue: output.TagValue !== undefined && output.TagValue !== null ? output.TagValue : undefined,
+    TagKey: __expectString(output.TagKey),
+    TagValue: __expectString(output.TagValue),
   } as any;
 };
 
@@ -13931,7 +13704,7 @@ const deserializeAws_json1_1SelectAggregateResourceConfigResponse = (
   context: __SerdeContext
 ): SelectAggregateResourceConfigResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     QueryInfo:
       output.QueryInfo !== undefined && output.QueryInfo !== null
         ? deserializeAws_json1_1QueryInfo(output.QueryInfo, context)
@@ -13948,7 +13721,7 @@ const deserializeAws_json1_1SelectResourceConfigResponse = (
   context: __SerdeContext
 ): SelectResourceConfigResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     QueryInfo:
       output.QueryInfo !== undefined && output.QueryInfo !== null
         ? deserializeAws_json1_1QueryInfo(output.QueryInfo, context)
@@ -13962,24 +13735,20 @@ const deserializeAws_json1_1SelectResourceConfigResponse = (
 
 const deserializeAws_json1_1Source = (output: any, context: __SerdeContext): Source => {
   return {
-    Owner: output.Owner !== undefined && output.Owner !== null ? output.Owner : undefined,
+    Owner: __expectString(output.Owner),
     SourceDetails:
       output.SourceDetails !== undefined && output.SourceDetails !== null
         ? deserializeAws_json1_1SourceDetails(output.SourceDetails, context)
         : undefined,
-    SourceIdentifier:
-      output.SourceIdentifier !== undefined && output.SourceIdentifier !== null ? output.SourceIdentifier : undefined,
+    SourceIdentifier: __expectString(output.SourceIdentifier),
   } as any;
 };
 
 const deserializeAws_json1_1SourceDetail = (output: any, context: __SerdeContext): SourceDetail => {
   return {
-    EventSource: output.EventSource !== undefined && output.EventSource !== null ? output.EventSource : undefined,
-    MaximumExecutionFrequency:
-      output.MaximumExecutionFrequency !== undefined && output.MaximumExecutionFrequency !== null
-        ? output.MaximumExecutionFrequency
-        : undefined,
-    MessageType: output.MessageType !== undefined && output.MessageType !== null ? output.MessageType : undefined,
+    EventSource: __expectString(output.EventSource),
+    MaximumExecutionFrequency: __expectString(output.MaximumExecutionFrequency),
+    MessageType: __expectString(output.MessageType),
   } as any;
 };
 
@@ -13996,12 +13765,8 @@ const deserializeAws_json1_1SourceDetails = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1SsmControls = (output: any, context: __SerdeContext): SsmControls => {
   return {
-    ConcurrentExecutionRatePercentage:
-      output.ConcurrentExecutionRatePercentage !== undefined && output.ConcurrentExecutionRatePercentage !== null
-        ? output.ConcurrentExecutionRatePercentage
-        : undefined,
-    ErrorPercentage:
-      output.ErrorPercentage !== undefined && output.ErrorPercentage !== null ? output.ErrorPercentage : undefined,
+    ConcurrentExecutionRatePercentage: __expectNumber(output.ConcurrentExecutionRatePercentage),
+    ErrorPercentage: __expectNumber(output.ErrorPercentage),
   } as any;
 };
 
@@ -14021,8 +13786,7 @@ const deserializeAws_json1_1StartRemediationExecutionResponse = (
       output.FailedItems !== undefined && output.FailedItems !== null
         ? deserializeAws_json1_1ResourceKeys(output.FailedItems, context)
         : undefined,
-    FailureMessage:
-      output.FailureMessage !== undefined && output.FailureMessage !== null ? output.FailureMessage : undefined,
+    FailureMessage: __expectString(output.FailureMessage),
   } as any;
 };
 
@@ -14033,7 +13797,7 @@ const deserializeAws_json1_1StaticParameterValues = (output: any, context: __Ser
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -14048,20 +13812,20 @@ const deserializeAws_json1_1StaticValue = (output: any, context: __SerdeContext)
 
 const deserializeAws_json1_1StoredQuery = (output: any, context: __SerdeContext): StoredQuery => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Expression: output.Expression !== undefined && output.Expression !== null ? output.Expression : undefined,
-    QueryArn: output.QueryArn !== undefined && output.QueryArn !== null ? output.QueryArn : undefined,
-    QueryId: output.QueryId !== undefined && output.QueryId !== null ? output.QueryId : undefined,
-    QueryName: output.QueryName !== undefined && output.QueryName !== null ? output.QueryName : undefined,
+    Description: __expectString(output.Description),
+    Expression: __expectString(output.Expression),
+    QueryArn: __expectString(output.QueryArn),
+    QueryId: __expectString(output.QueryId),
+    QueryName: __expectString(output.QueryName),
   } as any;
 };
 
 const deserializeAws_json1_1StoredQueryMetadata = (output: any, context: __SerdeContext): StoredQueryMetadata => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    QueryArn: output.QueryArn !== undefined && output.QueryArn !== null ? output.QueryArn : undefined,
-    QueryId: output.QueryId !== undefined && output.QueryId !== null ? output.QueryId : undefined,
-    QueryName: output.QueryName !== undefined && output.QueryName !== null ? output.QueryName : undefined,
+    Description: __expectString(output.Description),
+    QueryArn: __expectString(output.QueryArn),
+    QueryId: __expectString(output.QueryId),
+    QueryName: __expectString(output.QueryName),
   } as any;
 };
 
@@ -14086,15 +13850,15 @@ const deserializeAws_json1_1SupplementaryConfiguration = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -14116,14 +13880,14 @@ const deserializeAws_json1_1Tags = (output: any, context: __SerdeContext): { [ke
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_json1_1TooManyTagsException = (output: any, context: __SerdeContext): TooManyTagsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -14143,7 +13907,7 @@ const deserializeAws_json1_1UnprocessedResourceIdentifierList = (
 
 const deserializeAws_json1_1ValidationException = (output: any, context: __SerdeContext): ValidationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 

--- a/clients/client-connect-contact-lens/protocols/Aws_restJson1.ts
+++ b/clients/client-connect-contact-lens/protocols/Aws_restJson1.ts
@@ -17,7 +17,11 @@ import {
   Transcript,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -66,7 +70,7 @@ export const deserializeAws_restJson1ListRealtimeContactAnalysisSegmentsCommand 
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Segments !== undefined && data.Segments !== null) {
     contents.Segments = deserializeAws_restJson1RealtimeContactAnalysisSegments(data.Segments, context);
@@ -155,7 +159,7 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -172,7 +176,7 @@ const deserializeAws_restJson1InternalServiceExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -189,7 +193,7 @@ const deserializeAws_restJson1InvalidRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -206,7 +210,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -223,7 +227,7 @@ const deserializeAws_restJson1ThrottlingExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -252,10 +256,8 @@ const deserializeAws_restJson1CategoryDetails = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1CharacterOffsets = (output: any, context: __SerdeContext): CharacterOffsets => {
   return {
-    BeginOffsetChar:
-      output.BeginOffsetChar !== undefined && output.BeginOffsetChar !== null ? output.BeginOffsetChar : undefined,
-    EndOffsetChar:
-      output.EndOffsetChar !== undefined && output.EndOffsetChar !== null ? output.EndOffsetChar : undefined,
+    BeginOffsetChar: __expectNumber(output.BeginOffsetChar),
+    EndOffsetChar: __expectNumber(output.EndOffsetChar),
   } as any;
 };
 
@@ -286,7 +288,7 @@ const deserializeAws_restJson1MatchedCategories = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -307,12 +309,8 @@ const deserializeAws_restJson1MatchedDetails = (
 
 const deserializeAws_restJson1PointOfInterest = (output: any, context: __SerdeContext): PointOfInterest => {
   return {
-    BeginOffsetMillis:
-      output.BeginOffsetMillis !== undefined && output.BeginOffsetMillis !== null
-        ? output.BeginOffsetMillis
-        : undefined,
-    EndOffsetMillis:
-      output.EndOffsetMillis !== undefined && output.EndOffsetMillis !== null ? output.EndOffsetMillis : undefined,
+    BeginOffsetMillis: __expectNumber(output.BeginOffsetMillis),
+    EndOffsetMillis: __expectNumber(output.EndOffsetMillis),
   } as any;
 };
 
@@ -359,23 +357,17 @@ const deserializeAws_restJson1RealtimeContactAnalysisSegments = (
 
 const deserializeAws_restJson1Transcript = (output: any, context: __SerdeContext): Transcript => {
   return {
-    BeginOffsetMillis:
-      output.BeginOffsetMillis !== undefined && output.BeginOffsetMillis !== null
-        ? output.BeginOffsetMillis
-        : undefined,
-    Content: output.Content !== undefined && output.Content !== null ? output.Content : undefined,
-    EndOffsetMillis:
-      output.EndOffsetMillis !== undefined && output.EndOffsetMillis !== null ? output.EndOffsetMillis : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    BeginOffsetMillis: __expectNumber(output.BeginOffsetMillis),
+    Content: __expectString(output.Content),
+    EndOffsetMillis: __expectNumber(output.EndOffsetMillis),
+    Id: __expectString(output.Id),
     IssuesDetected:
       output.IssuesDetected !== undefined && output.IssuesDetected !== null
         ? deserializeAws_restJson1IssuesDetected(output.IssuesDetected, context)
         : undefined,
-    ParticipantId:
-      output.ParticipantId !== undefined && output.ParticipantId !== null ? output.ParticipantId : undefined,
-    ParticipantRole:
-      output.ParticipantRole !== undefined && output.ParticipantRole !== null ? output.ParticipantRole : undefined,
-    Sentiment: output.Sentiment !== undefined && output.Sentiment !== null ? output.Sentiment : undefined,
+    ParticipantId: __expectString(output.ParticipantId),
+    ParticipantRole: __expectString(output.ParticipantRole),
+    Sentiment: __expectString(output.Sentiment),
   } as any;
 };
 

--- a/clients/client-connect/protocols/Aws_restJson1.ts
+++ b/clients/client-connect/protocols/Aws_restJson1.ts
@@ -385,6 +385,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -4415,7 +4418,7 @@ export const deserializeAws_restJson1AssociateInstanceStorageConfigCommand = asy
   };
   const data: any = await parseBody(output.body, context);
   if (data.AssociationId !== undefined && data.AssociationId !== null) {
-    contents.AssociationId = data.AssociationId;
+    contents.AssociationId = __expectString(data.AssociationId);
   }
   return Promise.resolve(contents);
 };
@@ -4882,7 +4885,7 @@ export const deserializeAws_restJson1AssociateSecurityKeyCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AssociationId !== undefined && data.AssociationId !== null) {
-    contents.AssociationId = data.AssociationId;
+    contents.AssociationId = __expectString(data.AssociationId);
   }
   return Promise.resolve(contents);
 };
@@ -4986,10 +4989,10 @@ export const deserializeAws_restJson1CreateContactFlowCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ContactFlowArn !== undefined && data.ContactFlowArn !== null) {
-    contents.ContactFlowArn = data.ContactFlowArn;
+    contents.ContactFlowArn = __expectString(data.ContactFlowArn);
   }
   if (data.ContactFlowId !== undefined && data.ContactFlowId !== null) {
-    contents.ContactFlowId = data.ContactFlowId;
+    contents.ContactFlowId = __expectString(data.ContactFlowId);
   }
   return Promise.resolve(contents);
 };
@@ -5101,10 +5104,10 @@ export const deserializeAws_restJson1CreateInstanceCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   return Promise.resolve(contents);
 };
@@ -5192,10 +5195,10 @@ export const deserializeAws_restJson1CreateIntegrationAssociationCommand = async
   };
   const data: any = await parseBody(output.body, context);
   if (data.IntegrationAssociationArn !== undefined && data.IntegrationAssociationArn !== null) {
-    contents.IntegrationAssociationArn = data.IntegrationAssociationArn;
+    contents.IntegrationAssociationArn = __expectString(data.IntegrationAssociationArn);
   }
   if (data.IntegrationAssociationId !== undefined && data.IntegrationAssociationId !== null) {
-    contents.IntegrationAssociationId = data.IntegrationAssociationId;
+    contents.IntegrationAssociationId = __expectString(data.IntegrationAssociationId);
   }
   return Promise.resolve(contents);
 };
@@ -5283,10 +5286,10 @@ export const deserializeAws_restJson1CreateQueueCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.QueueArn !== undefined && data.QueueArn !== null) {
-    contents.QueueArn = data.QueueArn;
+    contents.QueueArn = __expectString(data.QueueArn);
   }
   if (data.QueueId !== undefined && data.QueueId !== null) {
-    contents.QueueId = data.QueueId;
+    contents.QueueId = __expectString(data.QueueId);
   }
   return Promise.resolve(contents);
 };
@@ -5390,10 +5393,10 @@ export const deserializeAws_restJson1CreateQuickConnectCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.QuickConnectARN !== undefined && data.QuickConnectARN !== null) {
-    contents.QuickConnectARN = data.QuickConnectARN;
+    contents.QuickConnectARN = __expectString(data.QuickConnectARN);
   }
   if (data.QuickConnectId !== undefined && data.QuickConnectId !== null) {
-    contents.QuickConnectId = data.QuickConnectId;
+    contents.QuickConnectId = __expectString(data.QuickConnectId);
   }
   return Promise.resolve(contents);
 };
@@ -5497,10 +5500,10 @@ export const deserializeAws_restJson1CreateRoutingProfileCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.RoutingProfileArn !== undefined && data.RoutingProfileArn !== null) {
-    contents.RoutingProfileArn = data.RoutingProfileArn;
+    contents.RoutingProfileArn = __expectString(data.RoutingProfileArn);
   }
   if (data.RoutingProfileId !== undefined && data.RoutingProfileId !== null) {
-    contents.RoutingProfileId = data.RoutingProfileId;
+    contents.RoutingProfileId = __expectString(data.RoutingProfileId);
   }
   return Promise.resolve(contents);
 };
@@ -5604,10 +5607,10 @@ export const deserializeAws_restJson1CreateUseCaseCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.UseCaseArn !== undefined && data.UseCaseArn !== null) {
-    contents.UseCaseArn = data.UseCaseArn;
+    contents.UseCaseArn = __expectString(data.UseCaseArn);
   }
   if (data.UseCaseId !== undefined && data.UseCaseId !== null) {
-    contents.UseCaseId = data.UseCaseId;
+    contents.UseCaseId = __expectString(data.UseCaseId);
   }
   return Promise.resolve(contents);
 };
@@ -5695,10 +5698,10 @@ export const deserializeAws_restJson1CreateUserCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.UserArn !== undefined && data.UserArn !== null) {
-    contents.UserArn = data.UserArn;
+    contents.UserArn = __expectString(data.UserArn);
   }
   if (data.UserId !== undefined && data.UserId !== null) {
-    contents.UserId = data.UserId;
+    contents.UserId = __expectString(data.UserId);
   }
   return Promise.resolve(contents);
 };
@@ -5802,10 +5805,10 @@ export const deserializeAws_restJson1CreateUserHierarchyGroupCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.HierarchyGroupArn !== undefined && data.HierarchyGroupArn !== null) {
-    contents.HierarchyGroupArn = data.HierarchyGroupArn;
+    contents.HierarchyGroupArn = __expectString(data.HierarchyGroupArn);
   }
   if (data.HierarchyGroupId !== undefined && data.HierarchyGroupId !== null) {
-    contents.HierarchyGroupId = data.HierarchyGroupId;
+    contents.HierarchyGroupId = __expectString(data.HierarchyGroupId);
   }
   return Promise.resolve(contents);
 };
@@ -8066,7 +8069,7 @@ export const deserializeAws_restJson1GetCurrentMetricDataCommand = async (
     contents.MetricResults = deserializeAws_restJson1CurrentMetricResults(data.MetricResults, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -8252,7 +8255,7 @@ export const deserializeAws_restJson1GetMetricDataCommand = async (
     contents.MetricResults = deserializeAws_restJson1HistoricalMetricResults(data.MetricResults, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -8340,7 +8343,7 @@ export const deserializeAws_restJson1ListApprovedOriginsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Origins !== undefined && data.Origins !== null) {
     contents.Origins = deserializeAws_restJson1OriginsList(data.Origins, context);
@@ -8434,7 +8437,7 @@ export const deserializeAws_restJson1ListBotsCommand = async (
     contents.LexBots = deserializeAws_restJson1LexBotConfigList(data.LexBots, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -8520,7 +8523,7 @@ export const deserializeAws_restJson1ListContactFlowsCommand = async (
     );
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -8614,7 +8617,7 @@ export const deserializeAws_restJson1ListHoursOfOperationsCommand = async (
     );
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -8705,7 +8708,7 @@ export const deserializeAws_restJson1ListInstanceAttributesCommand = async (
     contents.Attributes = deserializeAws_restJson1AttributesList(data.Attributes, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -8796,7 +8799,7 @@ export const deserializeAws_restJson1ListInstancesCommand = async (
     contents.InstanceSummaryList = deserializeAws_restJson1InstanceSummaryList(data.InstanceSummaryList, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -8860,7 +8863,7 @@ export const deserializeAws_restJson1ListInstanceStorageConfigsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.StorageConfigs !== undefined && data.StorageConfigs !== null) {
     contents.StorageConfigs = deserializeAws_restJson1InstanceStorageConfigs(data.StorageConfigs, context);
@@ -8957,7 +8960,7 @@ export const deserializeAws_restJson1ListIntegrationAssociationsCommand = async 
     );
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -9040,7 +9043,7 @@ export const deserializeAws_restJson1ListLambdaFunctionsCommand = async (
     contents.LambdaFunctions = deserializeAws_restJson1FunctionArnsList(data.LambdaFunctions, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -9131,7 +9134,7 @@ export const deserializeAws_restJson1ListLexBotsCommand = async (
     contents.LexBots = deserializeAws_restJson1LexBotsList(data.LexBots, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -9219,7 +9222,7 @@ export const deserializeAws_restJson1ListPhoneNumbersCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.PhoneNumberSummaryList !== undefined && data.PhoneNumberSummaryList !== null) {
     contents.PhoneNumberSummaryList = deserializeAws_restJson1PhoneNumberSummaryList(
@@ -9313,7 +9316,7 @@ export const deserializeAws_restJson1ListPromptsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.PromptSummaryList !== undefined && data.PromptSummaryList !== null) {
     contents.PromptSummaryList = deserializeAws_restJson1PromptSummaryList(data.PromptSummaryList, context);
@@ -9404,7 +9407,7 @@ export const deserializeAws_restJson1ListQueueQuickConnectsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.QuickConnectSummaryList !== undefined && data.QuickConnectSummaryList !== null) {
     contents.QuickConnectSummaryList = deserializeAws_restJson1QuickConnectSummaryList(
@@ -9498,7 +9501,7 @@ export const deserializeAws_restJson1ListQueuesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.QueueSummaryList !== undefined && data.QueueSummaryList !== null) {
     contents.QueueSummaryList = deserializeAws_restJson1QueueSummaryList(data.QueueSummaryList, context);
@@ -9589,7 +9592,7 @@ export const deserializeAws_restJson1ListQuickConnectsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.QuickConnectSummaryList !== undefined && data.QuickConnectSummaryList !== null) {
     contents.QuickConnectSummaryList = deserializeAws_restJson1QuickConnectSummaryList(
@@ -9683,7 +9686,7 @@ export const deserializeAws_restJson1ListRoutingProfileQueuesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.RoutingProfileQueueConfigSummaryList !== undefined && data.RoutingProfileQueueConfigSummaryList !== null) {
     contents.RoutingProfileQueueConfigSummaryList = deserializeAws_restJson1RoutingProfileQueueConfigSummaryList(
@@ -9777,7 +9780,7 @@ export const deserializeAws_restJson1ListRoutingProfilesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.RoutingProfileSummaryList !== undefined && data.RoutingProfileSummaryList !== null) {
     contents.RoutingProfileSummaryList = deserializeAws_restJson1RoutingProfileSummaryList(
@@ -9871,7 +9874,7 @@ export const deserializeAws_restJson1ListSecurityKeysCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.SecurityKeys !== undefined && data.SecurityKeys !== null) {
     contents.SecurityKeys = deserializeAws_restJson1SecurityKeysList(data.SecurityKeys, context);
@@ -9962,7 +9965,7 @@ export const deserializeAws_restJson1ListSecurityProfilesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.SecurityProfileSummaryList !== undefined && data.SecurityProfileSummaryList !== null) {
     contents.SecurityProfileSummaryList = deserializeAws_restJson1SecurityProfileSummaryList(
@@ -10143,7 +10146,7 @@ export const deserializeAws_restJson1ListUseCasesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.UseCaseSummaryList !== undefined && data.UseCaseSummaryList !== null) {
     contents.UseCaseSummaryList = deserializeAws_restJson1UseCaseSummaryList(data.UseCaseSummaryList, context);
@@ -10226,7 +10229,7 @@ export const deserializeAws_restJson1ListUserHierarchyGroupsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.UserHierarchyGroupSummaryList !== undefined && data.UserHierarchyGroupSummaryList !== null) {
     contents.UserHierarchyGroupSummaryList = deserializeAws_restJson1HierarchyGroupSummaryList(
@@ -10320,7 +10323,7 @@ export const deserializeAws_restJson1ListUsersCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.UserSummaryList !== undefined && data.UserSummaryList !== null) {
     contents.UserSummaryList = deserializeAws_restJson1UserSummaryList(data.UserSummaryList, context);
@@ -10479,13 +10482,13 @@ export const deserializeAws_restJson1StartChatContactCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ContactId !== undefined && data.ContactId !== null) {
-    contents.ContactId = data.ContactId;
+    contents.ContactId = __expectString(data.ContactId);
   }
   if (data.ParticipantId !== undefined && data.ParticipantId !== null) {
-    contents.ParticipantId = data.ParticipantId;
+    contents.ParticipantId = __expectString(data.ParticipantId);
   }
   if (data.ParticipantToken !== undefined && data.ParticipantToken !== null) {
-    contents.ParticipantToken = data.ParticipantToken;
+    contents.ParticipantToken = __expectString(data.ParticipantToken);
   }
   return Promise.resolve(contents);
 };
@@ -10647,7 +10650,7 @@ export const deserializeAws_restJson1StartOutboundVoiceContactCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ContactId !== undefined && data.ContactId !== null) {
-    contents.ContactId = data.ContactId;
+    contents.ContactId = __expectString(data.ContactId);
   }
   return Promise.resolve(contents);
 };
@@ -10750,7 +10753,7 @@ export const deserializeAws_restJson1StartTaskContactCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ContactId !== undefined && data.ContactId !== null) {
-    contents.ContactId = data.ContactId;
+    contents.ContactId = __expectString(data.ContactId);
   }
   return Promise.resolve(contents);
 };
@@ -13176,7 +13179,7 @@ const deserializeAws_restJson1ContactFlowNotPublishedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -13193,7 +13196,7 @@ const deserializeAws_restJson1ContactNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -13210,7 +13213,7 @@ const deserializeAws_restJson1DestinationNotAllowedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -13227,7 +13230,7 @@ const deserializeAws_restJson1DuplicateResourceExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -13244,7 +13247,7 @@ const deserializeAws_restJson1InternalServiceExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -13278,7 +13281,7 @@ const deserializeAws_restJson1InvalidParameterExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -13295,7 +13298,7 @@ const deserializeAws_restJson1InvalidRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -13312,7 +13315,7 @@ const deserializeAws_restJson1LimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -13329,7 +13332,7 @@ const deserializeAws_restJson1OutboundContactNotPermittedExceptionResponse = asy
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -13346,7 +13349,7 @@ const deserializeAws_restJson1ResourceConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -13365,13 +13368,13 @@ const deserializeAws_restJson1ResourceInUseExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.ResourceId !== undefined && data.ResourceId !== null) {
-    contents.ResourceId = data.ResourceId;
+    contents.ResourceId = __expectString(data.ResourceId);
   }
   if (data.ResourceType !== undefined && data.ResourceType !== null) {
-    contents.ResourceType = data.ResourceType;
+    contents.ResourceType = __expectString(data.ResourceType);
   }
   return contents;
 };
@@ -13388,7 +13391,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -13405,7 +13408,7 @@ const deserializeAws_restJson1ServiceQuotaExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -13422,7 +13425,7 @@ const deserializeAws_restJson1ThrottlingExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -13439,7 +13442,7 @@ const deserializeAws_restJson1UserNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -13877,9 +13880,8 @@ const serializeAws_restJson1VoiceRecordingConfiguration = (
 
 const deserializeAws_restJson1Attribute = (output: any, context: __SerdeContext): Attribute => {
   return {
-    AttributeType:
-      output.AttributeType !== undefined && output.AttributeType !== null ? output.AttributeType : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    AttributeType: __expectString(output.AttributeType),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -13890,7 +13892,7 @@ const deserializeAws_restJson1Attributes = (output: any, context: __SerdeContext
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -13908,26 +13910,25 @@ const deserializeAws_restJson1AttributesList = (output: any, context: __SerdeCon
 
 const deserializeAws_restJson1ContactFlow = (output: any, context: __SerdeContext): ContactFlow => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Content: output.Content !== undefined && output.Content !== null ? output.Content : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Arn: __expectString(output.Arn),
+    Content: __expectString(output.Content),
+    Description: __expectString(output.Description),
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_restJson1TagMap(output.Tags, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
 const deserializeAws_restJson1ContactFlowSummary = (output: any, context: __SerdeContext): ContactFlowSummary => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    ContactFlowType:
-      output.ContactFlowType !== undefined && output.ContactFlowType !== null ? output.ContactFlowType : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Arn: __expectString(output.Arn),
+    ContactFlowType: __expectString(output.ContactFlowType),
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -13944,12 +13945,12 @@ const deserializeAws_restJson1ContactFlowSummaryList = (output: any, context: __
 
 const deserializeAws_restJson1Credentials = (output: any, context: __SerdeContext): Credentials => {
   return {
-    AccessToken: output.AccessToken !== undefined && output.AccessToken !== null ? output.AccessToken : undefined,
+    AccessToken: __expectString(output.AccessToken),
     AccessTokenExpiration:
       output.AccessTokenExpiration !== undefined && output.AccessTokenExpiration !== null
         ? new Date(Math.round(output.AccessTokenExpiration * 1000))
         : undefined,
-    RefreshToken: output.RefreshToken !== undefined && output.RefreshToken !== null ? output.RefreshToken : undefined,
+    RefreshToken: __expectString(output.RefreshToken),
     RefreshTokenExpiration:
       output.RefreshTokenExpiration !== undefined && output.RefreshTokenExpiration !== null
         ? new Date(Math.round(output.RefreshTokenExpiration * 1000))
@@ -13959,8 +13960,8 @@ const deserializeAws_restJson1Credentials = (output: any, context: __SerdeContex
 
 const deserializeAws_restJson1CurrentMetric = (output: any, context: __SerdeContext): CurrentMetric => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Unit: output.Unit !== undefined && output.Unit !== null ? output.Unit : undefined,
+    Name: __expectString(output.Name),
+    Unit: __expectString(output.Unit),
   } as any;
 };
 
@@ -13970,7 +13971,7 @@ const deserializeAws_restJson1CurrentMetricData = (output: any, context: __Serde
       output.Metric !== undefined && output.Metric !== null
         ? deserializeAws_restJson1CurrentMetric(output.Metric, context)
         : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Value: __expectNumber(output.Value),
   } as any;
 };
 
@@ -14014,7 +14015,7 @@ const deserializeAws_restJson1CurrentMetricResults = (output: any, context: __Se
 
 const deserializeAws_restJson1Dimensions = (output: any, context: __SerdeContext): Dimensions => {
   return {
-    Channel: output.Channel !== undefined && output.Channel !== null ? output.Channel : undefined,
+    Channel: __expectString(output.Channel),
     Queue:
       output.Queue !== undefined && output.Queue !== null
         ? deserializeAws_restJson1QueueReference(output.Queue, context)
@@ -14024,9 +14025,8 @@ const deserializeAws_restJson1Dimensions = (output: any, context: __SerdeContext
 
 const deserializeAws_restJson1EncryptionConfig = (output: any, context: __SerdeContext): EncryptionConfig => {
   return {
-    EncryptionType:
-      output.EncryptionType !== undefined && output.EncryptionType !== null ? output.EncryptionType : undefined,
-    KeyId: output.KeyId !== undefined && output.KeyId !== null ? output.KeyId : undefined,
+    EncryptionType: __expectString(output.EncryptionType),
+    KeyId: __expectString(output.KeyId),
   } as any;
 };
 
@@ -14037,28 +14037,28 @@ const deserializeAws_restJson1FunctionArnsList = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1HierarchyGroup = (output: any, context: __SerdeContext): HierarchyGroup => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     HierarchyPath:
       output.HierarchyPath !== undefined && output.HierarchyPath !== null
         ? deserializeAws_restJson1HierarchyPath(output.HierarchyPath, context)
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    LevelId: output.LevelId !== undefined && output.LevelId !== null ? output.LevelId : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Id: __expectString(output.Id),
+    LevelId: __expectString(output.LevelId),
+    Name: __expectString(output.Name),
   } as any;
 };
 
 const deserializeAws_restJson1HierarchyGroupSummary = (output: any, context: __SerdeContext): HierarchyGroupSummary => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Arn: __expectString(output.Arn),
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -14078,9 +14078,9 @@ const deserializeAws_restJson1HierarchyGroupSummaryList = (
 
 const deserializeAws_restJson1HierarchyLevel = (output: any, context: __SerdeContext): HierarchyLevel => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Arn: __expectString(output.Arn),
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -14136,13 +14136,13 @@ const deserializeAws_restJson1HierarchyStructure = (output: any, context: __Serd
 
 const deserializeAws_restJson1HistoricalMetric = (output: any, context: __SerdeContext): HistoricalMetric => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Statistic: output.Statistic !== undefined && output.Statistic !== null ? output.Statistic : undefined,
+    Name: __expectString(output.Name),
+    Statistic: __expectString(output.Statistic),
     Threshold:
       output.Threshold !== undefined && output.Threshold !== null
         ? deserializeAws_restJson1Threshold(output.Threshold, context)
         : undefined,
-    Unit: output.Unit !== undefined && output.Unit !== null ? output.Unit : undefined,
+    Unit: __expectString(output.Unit),
   } as any;
 };
 
@@ -14152,7 +14152,7 @@ const deserializeAws_restJson1HistoricalMetricData = (output: any, context: __Se
       output.Metric !== undefined && output.Metric !== null
         ? deserializeAws_restJson1HistoricalMetric(output.Metric, context)
         : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Value: __expectNumber(output.Value),
   } as any;
 };
 
@@ -14206,21 +14206,15 @@ const deserializeAws_restJson1HoursOfOperation = (output: any, context: __SerdeC
       output.Config !== undefined && output.Config !== null
         ? deserializeAws_restJson1HoursOfOperationConfigList(output.Config, context)
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    HoursOfOperationArn:
-      output.HoursOfOperationArn !== undefined && output.HoursOfOperationArn !== null
-        ? output.HoursOfOperationArn
-        : undefined,
-    HoursOfOperationId:
-      output.HoursOfOperationId !== undefined && output.HoursOfOperationId !== null
-        ? output.HoursOfOperationId
-        : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Description: __expectString(output.Description),
+    HoursOfOperationArn: __expectString(output.HoursOfOperationArn),
+    HoursOfOperationId: __expectString(output.HoursOfOperationId),
+    Name: __expectString(output.Name),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_restJson1TagMap(output.Tags, context)
         : undefined,
-    TimeZone: output.TimeZone !== undefined && output.TimeZone !== null ? output.TimeZone : undefined,
+    TimeZone: __expectString(output.TimeZone),
   } as any;
 };
 
@@ -14229,7 +14223,7 @@ const deserializeAws_restJson1HoursOfOperationConfig = (
   context: __SerdeContext
 ): HoursOfOperationConfig => {
   return {
-    Day: output.Day !== undefined && output.Day !== null ? output.Day : undefined,
+    Day: __expectString(output.Day),
     EndTime:
       output.EndTime !== undefined && output.EndTime !== null
         ? deserializeAws_restJson1HoursOfOperationTimeSlice(output.EndTime, context)
@@ -14260,9 +14254,9 @@ const deserializeAws_restJson1HoursOfOperationSummary = (
   context: __SerdeContext
 ): HoursOfOperationSummary => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Arn: __expectString(output.Arn),
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -14285,36 +14279,25 @@ const deserializeAws_restJson1HoursOfOperationTimeSlice = (
   context: __SerdeContext
 ): HoursOfOperationTimeSlice => {
   return {
-    Hours: output.Hours !== undefined && output.Hours !== null ? output.Hours : undefined,
-    Minutes: output.Minutes !== undefined && output.Minutes !== null ? output.Minutes : undefined,
+    Hours: __expectNumber(output.Hours),
+    Minutes: __expectNumber(output.Minutes),
   } as any;
 };
 
 const deserializeAws_restJson1Instance = (output: any, context: __SerdeContext): Instance => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    IdentityManagementType:
-      output.IdentityManagementType !== undefined && output.IdentityManagementType !== null
-        ? output.IdentityManagementType
-        : undefined,
-    InboundCallsEnabled:
-      output.InboundCallsEnabled !== undefined && output.InboundCallsEnabled !== null
-        ? output.InboundCallsEnabled
-        : undefined,
-    InstanceAlias:
-      output.InstanceAlias !== undefined && output.InstanceAlias !== null ? output.InstanceAlias : undefined,
-    InstanceStatus:
-      output.InstanceStatus !== undefined && output.InstanceStatus !== null ? output.InstanceStatus : undefined,
-    OutboundCallsEnabled:
-      output.OutboundCallsEnabled !== undefined && output.OutboundCallsEnabled !== null
-        ? output.OutboundCallsEnabled
-        : undefined,
-    ServiceRole: output.ServiceRole !== undefined && output.ServiceRole !== null ? output.ServiceRole : undefined,
+    Id: __expectString(output.Id),
+    IdentityManagementType: __expectString(output.IdentityManagementType),
+    InboundCallsEnabled: __expectBoolean(output.InboundCallsEnabled),
+    InstanceAlias: __expectString(output.InstanceAlias),
+    InstanceStatus: __expectString(output.InstanceStatus),
+    OutboundCallsEnabled: __expectBoolean(output.OutboundCallsEnabled),
+    ServiceRole: __expectString(output.ServiceRole),
     StatusReason:
       output.StatusReason !== undefined && output.StatusReason !== null
         ? deserializeAws_restJson1InstanceStatusReason(output.StatusReason, context)
@@ -14324,14 +14307,13 @@ const deserializeAws_restJson1Instance = (output: any, context: __SerdeContext):
 
 const deserializeAws_restJson1InstanceStatusReason = (output: any, context: __SerdeContext): InstanceStatusReason => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_restJson1InstanceStorageConfig = (output: any, context: __SerdeContext): InstanceStorageConfig => {
   return {
-    AssociationId:
-      output.AssociationId !== undefined && output.AssociationId !== null ? output.AssociationId : undefined,
+    AssociationId: __expectString(output.AssociationId),
     KinesisFirehoseConfig:
       output.KinesisFirehoseConfig !== undefined && output.KinesisFirehoseConfig !== null
         ? deserializeAws_restJson1KinesisFirehoseConfig(output.KinesisFirehoseConfig, context)
@@ -14348,7 +14330,7 @@ const deserializeAws_restJson1InstanceStorageConfig = (output: any, context: __S
       output.S3Config !== undefined && output.S3Config !== null
         ? deserializeAws_restJson1S3Config(output.S3Config, context)
         : undefined,
-    StorageType: output.StorageType !== undefined && output.StorageType !== null ? output.StorageType : undefined,
+    StorageType: __expectString(output.StorageType),
   } as any;
 };
 
@@ -14368,29 +14350,18 @@ const deserializeAws_restJson1InstanceStorageConfigs = (
 
 const deserializeAws_restJson1InstanceSummary = (output: any, context: __SerdeContext): InstanceSummary => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    IdentityManagementType:
-      output.IdentityManagementType !== undefined && output.IdentityManagementType !== null
-        ? output.IdentityManagementType
-        : undefined,
-    InboundCallsEnabled:
-      output.InboundCallsEnabled !== undefined && output.InboundCallsEnabled !== null
-        ? output.InboundCallsEnabled
-        : undefined,
-    InstanceAlias:
-      output.InstanceAlias !== undefined && output.InstanceAlias !== null ? output.InstanceAlias : undefined,
-    InstanceStatus:
-      output.InstanceStatus !== undefined && output.InstanceStatus !== null ? output.InstanceStatus : undefined,
-    OutboundCallsEnabled:
-      output.OutboundCallsEnabled !== undefined && output.OutboundCallsEnabled !== null
-        ? output.OutboundCallsEnabled
-        : undefined,
-    ServiceRole: output.ServiceRole !== undefined && output.ServiceRole !== null ? output.ServiceRole : undefined,
+    Id: __expectString(output.Id),
+    IdentityManagementType: __expectString(output.IdentityManagementType),
+    InboundCallsEnabled: __expectBoolean(output.InboundCallsEnabled),
+    InstanceAlias: __expectString(output.InstanceAlias),
+    InstanceStatus: __expectString(output.InstanceStatus),
+    OutboundCallsEnabled: __expectBoolean(output.OutboundCallsEnabled),
+    ServiceRole: __expectString(output.ServiceRole),
   } as any;
 };
 
@@ -14410,28 +14381,14 @@ const deserializeAws_restJson1IntegrationAssociationSummary = (
   context: __SerdeContext
 ): IntegrationAssociationSummary => {
   return {
-    InstanceId: output.InstanceId !== undefined && output.InstanceId !== null ? output.InstanceId : undefined,
-    IntegrationArn:
-      output.IntegrationArn !== undefined && output.IntegrationArn !== null ? output.IntegrationArn : undefined,
-    IntegrationAssociationArn:
-      output.IntegrationAssociationArn !== undefined && output.IntegrationAssociationArn !== null
-        ? output.IntegrationAssociationArn
-        : undefined,
-    IntegrationAssociationId:
-      output.IntegrationAssociationId !== undefined && output.IntegrationAssociationId !== null
-        ? output.IntegrationAssociationId
-        : undefined,
-    IntegrationType:
-      output.IntegrationType !== undefined && output.IntegrationType !== null ? output.IntegrationType : undefined,
-    SourceApplicationName:
-      output.SourceApplicationName !== undefined && output.SourceApplicationName !== null
-        ? output.SourceApplicationName
-        : undefined,
-    SourceApplicationUrl:
-      output.SourceApplicationUrl !== undefined && output.SourceApplicationUrl !== null
-        ? output.SourceApplicationUrl
-        : undefined,
-    SourceType: output.SourceType !== undefined && output.SourceType !== null ? output.SourceType : undefined,
+    InstanceId: __expectString(output.InstanceId),
+    IntegrationArn: __expectString(output.IntegrationArn),
+    IntegrationAssociationArn: __expectString(output.IntegrationAssociationArn),
+    IntegrationAssociationId: __expectString(output.IntegrationAssociationId),
+    IntegrationType: __expectString(output.IntegrationType),
+    SourceApplicationName: __expectString(output.SourceApplicationName),
+    SourceApplicationUrl: __expectString(output.SourceApplicationUrl),
+    SourceType: __expectString(output.SourceType),
   } as any;
 };
 
@@ -14451,13 +14408,13 @@ const deserializeAws_restJson1IntegrationAssociationSummaryList = (
 
 const deserializeAws_restJson1KinesisFirehoseConfig = (output: any, context: __SerdeContext): KinesisFirehoseConfig => {
   return {
-    FirehoseArn: output.FirehoseArn !== undefined && output.FirehoseArn !== null ? output.FirehoseArn : undefined,
+    FirehoseArn: __expectString(output.FirehoseArn),
   } as any;
 };
 
 const deserializeAws_restJson1KinesisStreamConfig = (output: any, context: __SerdeContext): KinesisStreamConfig => {
   return {
-    StreamArn: output.StreamArn !== undefined && output.StreamArn !== null ? output.StreamArn : undefined,
+    StreamArn: __expectString(output.StreamArn),
   } as any;
 };
 
@@ -14470,18 +14427,15 @@ const deserializeAws_restJson1KinesisVideoStreamConfig = (
       output.EncryptionConfig !== undefined && output.EncryptionConfig !== null
         ? deserializeAws_restJson1EncryptionConfig(output.EncryptionConfig, context)
         : undefined,
-    Prefix: output.Prefix !== undefined && output.Prefix !== null ? output.Prefix : undefined,
-    RetentionPeriodHours:
-      output.RetentionPeriodHours !== undefined && output.RetentionPeriodHours !== null
-        ? output.RetentionPeriodHours
-        : undefined,
+    Prefix: __expectString(output.Prefix),
+    RetentionPeriodHours: __expectNumber(output.RetentionPeriodHours),
   } as any;
 };
 
 const deserializeAws_restJson1LexBot = (output: any, context: __SerdeContext): LexBot => {
   return {
-    LexRegion: output.LexRegion !== undefined && output.LexRegion !== null ? output.LexRegion : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    LexRegion: __expectString(output.LexRegion),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -14522,7 +14476,7 @@ const deserializeAws_restJson1LexBotsList = (output: any, context: __SerdeContex
 
 const deserializeAws_restJson1LexV2Bot = (output: any, context: __SerdeContext): LexV2Bot => {
   return {
-    AliasArn: output.AliasArn !== undefined && output.AliasArn !== null ? output.AliasArn : undefined,
+    AliasArn: __expectString(output.AliasArn),
   } as any;
 };
 
@@ -14539,8 +14493,8 @@ const deserializeAws_restJson1MediaConcurrencies = (output: any, context: __Serd
 
 const deserializeAws_restJson1MediaConcurrency = (output: any, context: __SerdeContext): MediaConcurrency => {
   return {
-    Channel: output.Channel !== undefined && output.Channel !== null ? output.Channel : undefined,
-    Concurrency: output.Concurrency !== undefined && output.Concurrency !== null ? output.Concurrency : undefined,
+    Channel: __expectString(output.Channel),
+    Concurrency: __expectNumber(output.Concurrency),
   } as any;
 };
 
@@ -14551,22 +14505,15 @@ const deserializeAws_restJson1OriginsList = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1OutboundCallerConfig = (output: any, context: __SerdeContext): OutboundCallerConfig => {
   return {
-    OutboundCallerIdName:
-      output.OutboundCallerIdName !== undefined && output.OutboundCallerIdName !== null
-        ? output.OutboundCallerIdName
-        : undefined,
-    OutboundCallerIdNumberId:
-      output.OutboundCallerIdNumberId !== undefined && output.OutboundCallerIdNumberId !== null
-        ? output.OutboundCallerIdNumberId
-        : undefined,
-    OutboundFlowId:
-      output.OutboundFlowId !== undefined && output.OutboundFlowId !== null ? output.OutboundFlowId : undefined,
+    OutboundCallerIdName: __expectString(output.OutboundCallerIdName),
+    OutboundCallerIdNumberId: __expectString(output.OutboundCallerIdNumberId),
+    OutboundFlowId: __expectString(output.OutboundFlowId),
   } as any;
 };
 
@@ -14575,21 +14522,17 @@ const deserializeAws_restJson1PhoneNumberQuickConnectConfig = (
   context: __SerdeContext
 ): PhoneNumberQuickConnectConfig => {
   return {
-    PhoneNumber: output.PhoneNumber !== undefined && output.PhoneNumber !== null ? output.PhoneNumber : undefined,
+    PhoneNumber: __expectString(output.PhoneNumber),
   } as any;
 };
 
 const deserializeAws_restJson1PhoneNumberSummary = (output: any, context: __SerdeContext): PhoneNumberSummary => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    PhoneNumber: output.PhoneNumber !== undefined && output.PhoneNumber !== null ? output.PhoneNumber : undefined,
-    PhoneNumberCountryCode:
-      output.PhoneNumberCountryCode !== undefined && output.PhoneNumberCountryCode !== null
-        ? output.PhoneNumberCountryCode
-        : undefined,
-    PhoneNumberType:
-      output.PhoneNumberType !== undefined && output.PhoneNumberType !== null ? output.PhoneNumberType : undefined,
+    Arn: __expectString(output.Arn),
+    Id: __expectString(output.Id),
+    PhoneNumber: __expectString(output.PhoneNumber),
+    PhoneNumberCountryCode: __expectString(output.PhoneNumberCountryCode),
+    PhoneNumberType: __expectString(output.PhoneNumberType),
   } as any;
 };
 
@@ -14606,7 +14549,7 @@ const deserializeAws_restJson1PhoneNumberSummaryList = (output: any, context: __
 
 const deserializeAws_restJson1ProblemDetail = (output: any, context: __SerdeContext): ProblemDetail => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -14623,9 +14566,9 @@ const deserializeAws_restJson1Problems = (output: any, context: __SerdeContext):
 
 const deserializeAws_restJson1PromptSummary = (output: any, context: __SerdeContext): PromptSummary => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Arn: __expectString(output.Arn),
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -14642,20 +14585,17 @@ const deserializeAws_restJson1PromptSummaryList = (output: any, context: __Serde
 
 const deserializeAws_restJson1Queue = (output: any, context: __SerdeContext): Queue => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    HoursOfOperationId:
-      output.HoursOfOperationId !== undefined && output.HoursOfOperationId !== null
-        ? output.HoursOfOperationId
-        : undefined,
-    MaxContacts: output.MaxContacts !== undefined && output.MaxContacts !== null ? output.MaxContacts : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Description: __expectString(output.Description),
+    HoursOfOperationId: __expectString(output.HoursOfOperationId),
+    MaxContacts: __expectNumber(output.MaxContacts),
+    Name: __expectString(output.Name),
     OutboundCallerConfig:
       output.OutboundCallerConfig !== undefined && output.OutboundCallerConfig !== null
         ? deserializeAws_restJson1OutboundCallerConfig(output.OutboundCallerConfig, context)
         : undefined,
-    QueueArn: output.QueueArn !== undefined && output.QueueArn !== null ? output.QueueArn : undefined,
-    QueueId: output.QueueId !== undefined && output.QueueId !== null ? output.QueueId : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    QueueArn: __expectString(output.QueueArn),
+    QueueId: __expectString(output.QueueId),
+    Status: __expectString(output.Status),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_restJson1TagMap(output.Tags, context)
@@ -14668,25 +14608,24 @@ const deserializeAws_restJson1QueueQuickConnectConfig = (
   context: __SerdeContext
 ): QueueQuickConnectConfig => {
   return {
-    ContactFlowId:
-      output.ContactFlowId !== undefined && output.ContactFlowId !== null ? output.ContactFlowId : undefined,
-    QueueId: output.QueueId !== undefined && output.QueueId !== null ? output.QueueId : undefined,
+    ContactFlowId: __expectString(output.ContactFlowId),
+    QueueId: __expectString(output.QueueId),
   } as any;
 };
 
 const deserializeAws_restJson1QueueReference = (output: any, context: __SerdeContext): QueueReference => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    Arn: __expectString(output.Arn),
+    Id: __expectString(output.Id),
   } as any;
 };
 
 const deserializeAws_restJson1QueueSummary = (output: any, context: __SerdeContext): QueueSummary => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    QueueType: output.QueueType !== undefined && output.QueueType !== null ? output.QueueType : undefined,
+    Arn: __expectString(output.Arn),
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
+    QueueType: __expectString(output.QueueType),
   } as any;
 };
 
@@ -14703,16 +14642,14 @@ const deserializeAws_restJson1QueueSummaryList = (output: any, context: __SerdeC
 
 const deserializeAws_restJson1QuickConnect = (output: any, context: __SerdeContext): QuickConnect => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    QuickConnectARN:
-      output.QuickConnectARN !== undefined && output.QuickConnectARN !== null ? output.QuickConnectARN : undefined,
+    Description: __expectString(output.Description),
+    Name: __expectString(output.Name),
+    QuickConnectARN: __expectString(output.QuickConnectARN),
     QuickConnectConfig:
       output.QuickConnectConfig !== undefined && output.QuickConnectConfig !== null
         ? deserializeAws_restJson1QuickConnectConfig(output.QuickConnectConfig, context)
         : undefined,
-    QuickConnectId:
-      output.QuickConnectId !== undefined && output.QuickConnectId !== null ? output.QuickConnectId : undefined,
+    QuickConnectId: __expectString(output.QuickConnectId),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_restJson1TagMap(output.Tags, context)
@@ -14730,8 +14667,7 @@ const deserializeAws_restJson1QuickConnectConfig = (output: any, context: __Serd
       output.QueueConfig !== undefined && output.QueueConfig !== null
         ? deserializeAws_restJson1QueueQuickConnectConfig(output.QueueConfig, context)
         : undefined,
-    QuickConnectType:
-      output.QuickConnectType !== undefined && output.QuickConnectType !== null ? output.QuickConnectType : undefined,
+    QuickConnectType: __expectString(output.QuickConnectType),
     UserConfig:
       output.UserConfig !== undefined && output.UserConfig !== null
         ? deserializeAws_restJson1UserQuickConnectConfig(output.UserConfig, context)
@@ -14741,11 +14677,10 @@ const deserializeAws_restJson1QuickConnectConfig = (output: any, context: __Serd
 
 const deserializeAws_restJson1QuickConnectSummary = (output: any, context: __SerdeContext): QuickConnectSummary => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    QuickConnectType:
-      output.QuickConnectType !== undefined && output.QuickConnectType !== null ? output.QuickConnectType : undefined,
+    Arn: __expectString(output.Arn),
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
+    QuickConnectType: __expectString(output.QuickConnectType),
   } as any;
 };
 
@@ -14765,23 +14700,16 @@ const deserializeAws_restJson1QuickConnectSummaryList = (
 
 const deserializeAws_restJson1RoutingProfile = (output: any, context: __SerdeContext): RoutingProfile => {
   return {
-    DefaultOutboundQueueId:
-      output.DefaultOutboundQueueId !== undefined && output.DefaultOutboundQueueId !== null
-        ? output.DefaultOutboundQueueId
-        : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    InstanceId: output.InstanceId !== undefined && output.InstanceId !== null ? output.InstanceId : undefined,
+    DefaultOutboundQueueId: __expectString(output.DefaultOutboundQueueId),
+    Description: __expectString(output.Description),
+    InstanceId: __expectString(output.InstanceId),
     MediaConcurrencies:
       output.MediaConcurrencies !== undefined && output.MediaConcurrencies !== null
         ? deserializeAws_restJson1MediaConcurrencies(output.MediaConcurrencies, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    RoutingProfileArn:
-      output.RoutingProfileArn !== undefined && output.RoutingProfileArn !== null
-        ? output.RoutingProfileArn
-        : undefined,
-    RoutingProfileId:
-      output.RoutingProfileId !== undefined && output.RoutingProfileId !== null ? output.RoutingProfileId : undefined,
+    Name: __expectString(output.Name),
+    RoutingProfileArn: __expectString(output.RoutingProfileArn),
+    RoutingProfileId: __expectString(output.RoutingProfileId),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_restJson1TagMap(output.Tags, context)
@@ -14794,12 +14722,12 @@ const deserializeAws_restJson1RoutingProfileQueueConfigSummary = (
   context: __SerdeContext
 ): RoutingProfileQueueConfigSummary => {
   return {
-    Channel: output.Channel !== undefined && output.Channel !== null ? output.Channel : undefined,
-    Delay: output.Delay !== undefined && output.Delay !== null ? output.Delay : undefined,
-    Priority: output.Priority !== undefined && output.Priority !== null ? output.Priority : undefined,
-    QueueArn: output.QueueArn !== undefined && output.QueueArn !== null ? output.QueueArn : undefined,
-    QueueId: output.QueueId !== undefined && output.QueueId !== null ? output.QueueId : undefined,
-    QueueName: output.QueueName !== undefined && output.QueueName !== null ? output.QueueName : undefined,
+    Channel: __expectString(output.Channel),
+    Delay: __expectNumber(output.Delay),
+    Priority: __expectNumber(output.Priority),
+    QueueArn: __expectString(output.QueueArn),
+    QueueId: __expectString(output.QueueId),
+    QueueName: __expectString(output.QueueName),
   } as any;
 };
 
@@ -14819,9 +14747,9 @@ const deserializeAws_restJson1RoutingProfileQueueConfigSummaryList = (
 
 const deserializeAws_restJson1RoutingProfileSummary = (output: any, context: __SerdeContext): RoutingProfileSummary => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Arn: __expectString(output.Arn),
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -14841,8 +14769,8 @@ const deserializeAws_restJson1RoutingProfileSummaryList = (
 
 const deserializeAws_restJson1S3Config = (output: any, context: __SerdeContext): S3Config => {
   return {
-    BucketName: output.BucketName !== undefined && output.BucketName !== null ? output.BucketName : undefined,
-    BucketPrefix: output.BucketPrefix !== undefined && output.BucketPrefix !== null ? output.BucketPrefix : undefined,
+    BucketName: __expectString(output.BucketName),
+    BucketPrefix: __expectString(output.BucketPrefix),
     EncryptionConfig:
       output.EncryptionConfig !== undefined && output.EncryptionConfig !== null
         ? deserializeAws_restJson1EncryptionConfig(output.EncryptionConfig, context)
@@ -14852,13 +14780,12 @@ const deserializeAws_restJson1S3Config = (output: any, context: __SerdeContext):
 
 const deserializeAws_restJson1SecurityKey = (output: any, context: __SerdeContext): SecurityKey => {
   return {
-    AssociationId:
-      output.AssociationId !== undefined && output.AssociationId !== null ? output.AssociationId : undefined,
+    AssociationId: __expectString(output.AssociationId),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
+    Key: __expectString(output.Key),
   } as any;
 };
 
@@ -14880,7 +14807,7 @@ const deserializeAws_restJson1SecurityProfileIds = (output: any, context: __Serd
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -14889,9 +14816,9 @@ const deserializeAws_restJson1SecurityProfileSummary = (
   context: __SerdeContext
 ): SecurityProfileSummary => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Arn: __expectString(output.Arn),
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -14916,24 +14843,23 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1Threshold = (output: any, context: __SerdeContext): Threshold => {
   return {
-    Comparison: output.Comparison !== undefined && output.Comparison !== null ? output.Comparison : undefined,
-    ThresholdValue:
-      output.ThresholdValue !== undefined && output.ThresholdValue !== null ? output.ThresholdValue : undefined,
+    Comparison: __expectString(output.Comparison),
+    ThresholdValue: __expectNumber(output.ThresholdValue),
   } as any;
 };
 
 const deserializeAws_restJson1UseCase = (output: any, context: __SerdeContext): UseCase => {
   return {
-    UseCaseArn: output.UseCaseArn !== undefined && output.UseCaseArn !== null ? output.UseCaseArn : undefined,
-    UseCaseId: output.UseCaseId !== undefined && output.UseCaseId !== null ? output.UseCaseId : undefined,
-    UseCaseType: output.UseCaseType !== undefined && output.UseCaseType !== null ? output.UseCaseType : undefined,
+    UseCaseArn: __expectString(output.UseCaseArn),
+    UseCaseId: __expectString(output.UseCaseId),
+    UseCaseType: __expectString(output.UseCaseType),
   } as any;
 };
 
@@ -14950,12 +14876,10 @@ const deserializeAws_restJson1UseCaseSummaryList = (output: any, context: __Serd
 
 const deserializeAws_restJson1User = (output: any, context: __SerdeContext): User => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    DirectoryUserId:
-      output.DirectoryUserId !== undefined && output.DirectoryUserId !== null ? output.DirectoryUserId : undefined,
-    HierarchyGroupId:
-      output.HierarchyGroupId !== undefined && output.HierarchyGroupId !== null ? output.HierarchyGroupId : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    Arn: __expectString(output.Arn),
+    DirectoryUserId: __expectString(output.DirectoryUserId),
+    HierarchyGroupId: __expectString(output.HierarchyGroupId),
+    Id: __expectString(output.Id),
     IdentityInfo:
       output.IdentityInfo !== undefined && output.IdentityInfo !== null
         ? deserializeAws_restJson1UserIdentityInfo(output.IdentityInfo, context)
@@ -14964,8 +14888,7 @@ const deserializeAws_restJson1User = (output: any, context: __SerdeContext): Use
       output.PhoneConfig !== undefined && output.PhoneConfig !== null
         ? deserializeAws_restJson1UserPhoneConfig(output.PhoneConfig, context)
         : undefined,
-    RoutingProfileId:
-      output.RoutingProfileId !== undefined && output.RoutingProfileId !== null ? output.RoutingProfileId : undefined,
+    RoutingProfileId: __expectString(output.RoutingProfileId),
     SecurityProfileIds:
       output.SecurityProfileIds !== undefined && output.SecurityProfileIds !== null
         ? deserializeAws_restJson1SecurityProfileIds(output.SecurityProfileIds, context)
@@ -14974,28 +14897,24 @@ const deserializeAws_restJson1User = (output: any, context: __SerdeContext): Use
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_restJson1TagMap(output.Tags, context)
         : undefined,
-    Username: output.Username !== undefined && output.Username !== null ? output.Username : undefined,
+    Username: __expectString(output.Username),
   } as any;
 };
 
 const deserializeAws_restJson1UserIdentityInfo = (output: any, context: __SerdeContext): UserIdentityInfo => {
   return {
-    Email: output.Email !== undefined && output.Email !== null ? output.Email : undefined,
-    FirstName: output.FirstName !== undefined && output.FirstName !== null ? output.FirstName : undefined,
-    LastName: output.LastName !== undefined && output.LastName !== null ? output.LastName : undefined,
+    Email: __expectString(output.Email),
+    FirstName: __expectString(output.FirstName),
+    LastName: __expectString(output.LastName),
   } as any;
 };
 
 const deserializeAws_restJson1UserPhoneConfig = (output: any, context: __SerdeContext): UserPhoneConfig => {
   return {
-    AfterContactWorkTimeLimit:
-      output.AfterContactWorkTimeLimit !== undefined && output.AfterContactWorkTimeLimit !== null
-        ? output.AfterContactWorkTimeLimit
-        : undefined,
-    AutoAccept: output.AutoAccept !== undefined && output.AutoAccept !== null ? output.AutoAccept : undefined,
-    DeskPhoneNumber:
-      output.DeskPhoneNumber !== undefined && output.DeskPhoneNumber !== null ? output.DeskPhoneNumber : undefined,
-    PhoneType: output.PhoneType !== undefined && output.PhoneType !== null ? output.PhoneType : undefined,
+    AfterContactWorkTimeLimit: __expectNumber(output.AfterContactWorkTimeLimit),
+    AutoAccept: __expectBoolean(output.AutoAccept),
+    DeskPhoneNumber: __expectString(output.DeskPhoneNumber),
+    PhoneType: __expectString(output.PhoneType),
   } as any;
 };
 
@@ -15004,17 +14923,16 @@ const deserializeAws_restJson1UserQuickConnectConfig = (
   context: __SerdeContext
 ): UserQuickConnectConfig => {
   return {
-    ContactFlowId:
-      output.ContactFlowId !== undefined && output.ContactFlowId !== null ? output.ContactFlowId : undefined,
-    UserId: output.UserId !== undefined && output.UserId !== null ? output.UserId : undefined,
+    ContactFlowId: __expectString(output.ContactFlowId),
+    UserId: __expectString(output.UserId),
   } as any;
 };
 
 const deserializeAws_restJson1UserSummary = (output: any, context: __SerdeContext): UserSummary => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Username: output.Username !== undefined && output.Username !== null ? output.Username : undefined,
+    Arn: __expectString(output.Arn),
+    Id: __expectString(output.Id),
+    Username: __expectString(output.Username),
   } as any;
 };
 

--- a/clients/client-connectparticipant/protocols/Aws_restJson1.ts
+++ b/clients/client-connectparticipant/protocols/Aws_restJson1.ts
@@ -34,7 +34,7 @@ import {
   Websocket,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException, expectString as __expectString } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -528,10 +528,10 @@ export const deserializeAws_restJson1GetAttachmentCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Url !== undefined && data.Url !== null) {
-    contents.Url = data.Url;
+    contents.Url = __expectString(data.Url);
   }
   if (data.UrlExpiry !== undefined && data.UrlExpiry !== null) {
-    contents.UrlExpiry = data.UrlExpiry;
+    contents.UrlExpiry = __expectString(data.UrlExpiry);
   }
   return Promise.resolve(contents);
 };
@@ -612,10 +612,10 @@ export const deserializeAws_restJson1GetTranscriptCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.InitialContactId !== undefined && data.InitialContactId !== null) {
-    contents.InitialContactId = data.InitialContactId;
+    contents.InitialContactId = __expectString(data.InitialContactId);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Transcript !== undefined && data.Transcript !== null) {
     contents.Transcript = deserializeAws_restJson1Transcript(data.Transcript, context);
@@ -698,10 +698,10 @@ export const deserializeAws_restJson1SendEventCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AbsoluteTime !== undefined && data.AbsoluteTime !== null) {
-    contents.AbsoluteTime = data.AbsoluteTime;
+    contents.AbsoluteTime = __expectString(data.AbsoluteTime);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   return Promise.resolve(contents);
 };
@@ -781,10 +781,10 @@ export const deserializeAws_restJson1SendMessageCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AbsoluteTime !== undefined && data.AbsoluteTime !== null) {
-    contents.AbsoluteTime = data.AbsoluteTime;
+    contents.AbsoluteTime = __expectString(data.AbsoluteTime);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   return Promise.resolve(contents);
 };
@@ -864,7 +864,7 @@ export const deserializeAws_restJson1StartAttachmentUploadCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AttachmentId !== undefined && data.AttachmentId !== null) {
-    contents.AttachmentId = data.AttachmentId;
+    contents.AttachmentId = __expectString(data.AttachmentId);
   }
   if (data.UploadMetadata !== undefined && data.UploadMetadata !== null) {
     contents.UploadMetadata = deserializeAws_restJson1UploadMetadata(data.UploadMetadata, context);
@@ -953,7 +953,7 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -970,7 +970,7 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -987,7 +987,7 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1004,7 +1004,7 @@ const deserializeAws_restJson1ServiceQuotaExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1021,7 +1021,7 @@ const deserializeAws_restJson1ThrottlingExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1038,7 +1038,7 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1075,11 +1075,10 @@ const serializeAws_restJson1StartPosition = (input: StartPosition, context: __Se
 
 const deserializeAws_restJson1AttachmentItem = (output: any, context: __SerdeContext): AttachmentItem => {
   return {
-    AttachmentId: output.AttachmentId !== undefined && output.AttachmentId !== null ? output.AttachmentId : undefined,
-    AttachmentName:
-      output.AttachmentName !== undefined && output.AttachmentName !== null ? output.AttachmentName : undefined,
-    ContentType: output.ContentType !== undefined && output.ContentType !== null ? output.ContentType : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    AttachmentId: __expectString(output.AttachmentId),
+    AttachmentName: __expectString(output.AttachmentName),
+    ContentType: __expectString(output.ContentType),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -1096,28 +1095,25 @@ const deserializeAws_restJson1Attachments = (output: any, context: __SerdeContex
 
 const deserializeAws_restJson1ConnectionCredentials = (output: any, context: __SerdeContext): ConnectionCredentials => {
   return {
-    ConnectionToken:
-      output.ConnectionToken !== undefined && output.ConnectionToken !== null ? output.ConnectionToken : undefined,
-    Expiry: output.Expiry !== undefined && output.Expiry !== null ? output.Expiry : undefined,
+    ConnectionToken: __expectString(output.ConnectionToken),
+    Expiry: __expectString(output.Expiry),
   } as any;
 };
 
 const deserializeAws_restJson1Item = (output: any, context: __SerdeContext): Item => {
   return {
-    AbsoluteTime: output.AbsoluteTime !== undefined && output.AbsoluteTime !== null ? output.AbsoluteTime : undefined,
+    AbsoluteTime: __expectString(output.AbsoluteTime),
     Attachments:
       output.Attachments !== undefined && output.Attachments !== null
         ? deserializeAws_restJson1Attachments(output.Attachments, context)
         : undefined,
-    Content: output.Content !== undefined && output.Content !== null ? output.Content : undefined,
-    ContentType: output.ContentType !== undefined && output.ContentType !== null ? output.ContentType : undefined,
-    DisplayName: output.DisplayName !== undefined && output.DisplayName !== null ? output.DisplayName : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    ParticipantId:
-      output.ParticipantId !== undefined && output.ParticipantId !== null ? output.ParticipantId : undefined,
-    ParticipantRole:
-      output.ParticipantRole !== undefined && output.ParticipantRole !== null ? output.ParticipantRole : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Content: __expectString(output.Content),
+    ContentType: __expectString(output.ContentType),
+    DisplayName: __expectString(output.DisplayName),
+    Id: __expectString(output.Id),
+    ParticipantId: __expectString(output.ParticipantId),
+    ParticipantRole: __expectString(output.ParticipantRole),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -1138,8 +1134,8 @@ const deserializeAws_restJson1UploadMetadata = (output: any, context: __SerdeCon
       output.HeadersToInclude !== undefined && output.HeadersToInclude !== null
         ? deserializeAws_restJson1UploadMetadataSignedHeaders(output.HeadersToInclude, context)
         : undefined,
-    Url: output.Url !== undefined && output.Url !== null ? output.Url : undefined,
-    UrlExpiry: output.UrlExpiry !== undefined && output.UrlExpiry !== null ? output.UrlExpiry : undefined,
+    Url: __expectString(output.Url),
+    UrlExpiry: __expectString(output.UrlExpiry),
   } as any;
 };
 
@@ -1153,16 +1149,15 @@ const deserializeAws_restJson1UploadMetadataSignedHeaders = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1Websocket = (output: any, context: __SerdeContext): Websocket => {
   return {
-    ConnectionExpiry:
-      output.ConnectionExpiry !== undefined && output.ConnectionExpiry !== null ? output.ConnectionExpiry : undefined,
-    Url: output.Url !== undefined && output.Url !== null ? output.Url : undefined,
+    ConnectionExpiry: __expectString(output.ConnectionExpiry),
+    Url: __expectString(output.Url),
   } as any;
 };
 

--- a/clients/client-cost-and-usage-report-service/protocols/Aws_json1_1.ts
+++ b/clients/client-cost-and-usage-report-service/protocols/Aws_json1_1.ts
@@ -32,7 +32,11 @@ import {
   ValidationException,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -514,7 +518,7 @@ const deserializeAws_json1_1AdditionalArtifactList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -523,8 +527,7 @@ const deserializeAws_json1_1DeleteReportDefinitionResponse = (
   context: __SerdeContext
 ): DeleteReportDefinitionResponse => {
   return {
-    ResponseMessage:
-      output.ResponseMessage !== undefined && output.ResponseMessage !== null ? output.ResponseMessage : undefined,
+    ResponseMessage: __expectString(output.ResponseMessage),
   } as any;
 };
 
@@ -533,7 +536,7 @@ const deserializeAws_json1_1DescribeReportDefinitionsResponse = (
   context: __SerdeContext
 ): DescribeReportDefinitionsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     ReportDefinitions:
       output.ReportDefinitions !== undefined && output.ReportDefinitions !== null
         ? deserializeAws_json1_1ReportDefinitionList(output.ReportDefinitions, context)
@@ -546,13 +549,13 @@ const deserializeAws_json1_1DuplicateReportNameException = (
   context: __SerdeContext
 ): DuplicateReportNameException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1InternalErrorException = (output: any, context: __SerdeContext): InternalErrorException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -580,21 +583,16 @@ const deserializeAws_json1_1ReportDefinition = (output: any, context: __SerdeCon
       output.AdditionalSchemaElements !== undefined && output.AdditionalSchemaElements !== null
         ? deserializeAws_json1_1SchemaElementList(output.AdditionalSchemaElements, context)
         : undefined,
-    BillingViewArn:
-      output.BillingViewArn !== undefined && output.BillingViewArn !== null ? output.BillingViewArn : undefined,
-    Compression: output.Compression !== undefined && output.Compression !== null ? output.Compression : undefined,
-    Format: output.Format !== undefined && output.Format !== null ? output.Format : undefined,
-    RefreshClosedReports:
-      output.RefreshClosedReports !== undefined && output.RefreshClosedReports !== null
-        ? output.RefreshClosedReports
-        : undefined,
-    ReportName: output.ReportName !== undefined && output.ReportName !== null ? output.ReportName : undefined,
-    ReportVersioning:
-      output.ReportVersioning !== undefined && output.ReportVersioning !== null ? output.ReportVersioning : undefined,
-    S3Bucket: output.S3Bucket !== undefined && output.S3Bucket !== null ? output.S3Bucket : undefined,
-    S3Prefix: output.S3Prefix !== undefined && output.S3Prefix !== null ? output.S3Prefix : undefined,
-    S3Region: output.S3Region !== undefined && output.S3Region !== null ? output.S3Region : undefined,
-    TimeUnit: output.TimeUnit !== undefined && output.TimeUnit !== null ? output.TimeUnit : undefined,
+    BillingViewArn: __expectString(output.BillingViewArn),
+    Compression: __expectString(output.Compression),
+    Format: __expectString(output.Format),
+    RefreshClosedReports: __expectBoolean(output.RefreshClosedReports),
+    ReportName: __expectString(output.ReportName),
+    ReportVersioning: __expectString(output.ReportVersioning),
+    S3Bucket: __expectString(output.S3Bucket),
+    S3Prefix: __expectString(output.S3Prefix),
+    S3Region: __expectString(output.S3Region),
+    TimeUnit: __expectString(output.TimeUnit),
   } as any;
 };
 
@@ -614,7 +612,7 @@ const deserializeAws_json1_1ReportLimitReachedException = (
   context: __SerdeContext
 ): ReportLimitReachedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -625,13 +623,13 @@ const deserializeAws_json1_1SchemaElementList = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1ValidationException = (output: any, context: __SerdeContext): ValidationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 

--- a/clients/client-cost-explorer/protocols/Aws_json1_1.ts
+++ b/clients/client-cost-explorer/protocols/Aws_json1_1.ts
@@ -246,7 +246,12 @@ import {
   UtilizationByTime,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -3586,23 +3591,20 @@ const deserializeAws_json1_1Anomalies = (output: any, context: __SerdeContext): 
 
 const deserializeAws_json1_1Anomaly = (output: any, context: __SerdeContext): Anomaly => {
   return {
-    AnomalyEndDate:
-      output.AnomalyEndDate !== undefined && output.AnomalyEndDate !== null ? output.AnomalyEndDate : undefined,
-    AnomalyId: output.AnomalyId !== undefined && output.AnomalyId !== null ? output.AnomalyId : undefined,
+    AnomalyEndDate: __expectString(output.AnomalyEndDate),
+    AnomalyId: __expectString(output.AnomalyId),
     AnomalyScore:
       output.AnomalyScore !== undefined && output.AnomalyScore !== null
         ? deserializeAws_json1_1AnomalyScore(output.AnomalyScore, context)
         : undefined,
-    AnomalyStartDate:
-      output.AnomalyStartDate !== undefined && output.AnomalyStartDate !== null ? output.AnomalyStartDate : undefined,
-    DimensionValue:
-      output.DimensionValue !== undefined && output.DimensionValue !== null ? output.DimensionValue : undefined,
-    Feedback: output.Feedback !== undefined && output.Feedback !== null ? output.Feedback : undefined,
+    AnomalyStartDate: __expectString(output.AnomalyStartDate),
+    DimensionValue: __expectString(output.DimensionValue),
+    Feedback: __expectString(output.Feedback),
     Impact:
       output.Impact !== undefined && output.Impact !== null
         ? deserializeAws_json1_1Impact(output.Impact, context)
         : undefined,
-    MonitorArn: output.MonitorArn !== undefined && output.MonitorArn !== null ? output.MonitorArn : undefined,
+    MonitorArn: __expectString(output.MonitorArn),
     RootCauses:
       output.RootCauses !== undefined && output.RootCauses !== null
         ? deserializeAws_json1_1RootCauses(output.RootCauses, context)
@@ -3612,26 +3614,18 @@ const deserializeAws_json1_1Anomaly = (output: any, context: __SerdeContext): An
 
 const deserializeAws_json1_1AnomalyMonitor = (output: any, context: __SerdeContext): AnomalyMonitor => {
   return {
-    CreationDate: output.CreationDate !== undefined && output.CreationDate !== null ? output.CreationDate : undefined,
-    DimensionalValueCount:
-      output.DimensionalValueCount !== undefined && output.DimensionalValueCount !== null
-        ? output.DimensionalValueCount
-        : undefined,
-    LastEvaluatedDate:
-      output.LastEvaluatedDate !== undefined && output.LastEvaluatedDate !== null
-        ? output.LastEvaluatedDate
-        : undefined,
-    LastUpdatedDate:
-      output.LastUpdatedDate !== undefined && output.LastUpdatedDate !== null ? output.LastUpdatedDate : undefined,
-    MonitorArn: output.MonitorArn !== undefined && output.MonitorArn !== null ? output.MonitorArn : undefined,
-    MonitorDimension:
-      output.MonitorDimension !== undefined && output.MonitorDimension !== null ? output.MonitorDimension : undefined,
-    MonitorName: output.MonitorName !== undefined && output.MonitorName !== null ? output.MonitorName : undefined,
+    CreationDate: __expectString(output.CreationDate),
+    DimensionalValueCount: __expectNumber(output.DimensionalValueCount),
+    LastEvaluatedDate: __expectString(output.LastEvaluatedDate),
+    LastUpdatedDate: __expectString(output.LastUpdatedDate),
+    MonitorArn: __expectString(output.MonitorArn),
+    MonitorDimension: __expectString(output.MonitorDimension),
+    MonitorName: __expectString(output.MonitorName),
     MonitorSpecification:
       output.MonitorSpecification !== undefined && output.MonitorSpecification !== null
         ? deserializeAws_json1_1Expression(output.MonitorSpecification, context)
         : undefined,
-    MonitorType: output.MonitorType !== undefined && output.MonitorType !== null ? output.MonitorType : undefined,
+    MonitorType: __expectString(output.MonitorType),
   } as any;
 };
 
@@ -3648,15 +3642,15 @@ const deserializeAws_json1_1AnomalyMonitors = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_1AnomalyScore = (output: any, context: __SerdeContext): AnomalyScore => {
   return {
-    CurrentScore: output.CurrentScore !== undefined && output.CurrentScore !== null ? output.CurrentScore : undefined,
-    MaxScore: output.MaxScore !== undefined && output.MaxScore !== null ? output.MaxScore : undefined,
+    CurrentScore: __expectNumber(output.CurrentScore),
+    MaxScore: __expectNumber(output.MaxScore),
   } as any;
 };
 
 const deserializeAws_json1_1AnomalySubscription = (output: any, context: __SerdeContext): AnomalySubscription => {
   return {
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
-    Frequency: output.Frequency !== undefined && output.Frequency !== null ? output.Frequency : undefined,
+    AccountId: __expectString(output.AccountId),
+    Frequency: __expectString(output.Frequency),
     MonitorArnList:
       output.MonitorArnList !== undefined && output.MonitorArnList !== null
         ? deserializeAws_json1_1MonitorArnList(output.MonitorArnList, context)
@@ -3665,11 +3659,9 @@ const deserializeAws_json1_1AnomalySubscription = (output: any, context: __Serde
       output.Subscribers !== undefined && output.Subscribers !== null
         ? deserializeAws_json1_1Subscribers(output.Subscribers, context)
         : undefined,
-    SubscriptionArn:
-      output.SubscriptionArn !== undefined && output.SubscriptionArn !== null ? output.SubscriptionArn : undefined,
-    SubscriptionName:
-      output.SubscriptionName !== undefined && output.SubscriptionName !== null ? output.SubscriptionName : undefined,
-    Threshold: output.Threshold !== undefined && output.Threshold !== null ? output.Threshold : undefined,
+    SubscriptionArn: __expectString(output.SubscriptionArn),
+    SubscriptionName: __expectString(output.SubscriptionName),
+    Threshold: __expectNumber(output.Threshold),
   } as any;
 };
 
@@ -3691,7 +3683,7 @@ const deserializeAws_json1_1Attributes = (output: any, context: __SerdeContext):
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -3701,24 +3693,22 @@ const deserializeAws_json1_1BillExpirationException = (
   context: __SerdeContext
 ): BillExpirationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1CostCategory = (output: any, context: __SerdeContext): CostCategory => {
   return {
-    CostCategoryArn:
-      output.CostCategoryArn !== undefined && output.CostCategoryArn !== null ? output.CostCategoryArn : undefined,
-    DefaultValue: output.DefaultValue !== undefined && output.DefaultValue !== null ? output.DefaultValue : undefined,
-    EffectiveEnd: output.EffectiveEnd !== undefined && output.EffectiveEnd !== null ? output.EffectiveEnd : undefined,
-    EffectiveStart:
-      output.EffectiveStart !== undefined && output.EffectiveStart !== null ? output.EffectiveStart : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    CostCategoryArn: __expectString(output.CostCategoryArn),
+    DefaultValue: __expectString(output.DefaultValue),
+    EffectiveEnd: __expectString(output.EffectiveEnd),
+    EffectiveStart: __expectString(output.EffectiveStart),
+    Name: __expectString(output.Name),
     ProcessingStatus:
       output.ProcessingStatus !== undefined && output.ProcessingStatus !== null
         ? deserializeAws_json1_1CostCategoryProcessingStatusList(output.ProcessingStatus, context)
         : undefined,
-    RuleVersion: output.RuleVersion !== undefined && output.RuleVersion !== null ? output.RuleVersion : undefined,
+    RuleVersion: __expectString(output.RuleVersion),
     Rules:
       output.Rules !== undefined && output.Rules !== null
         ? deserializeAws_json1_1CostCategoryRulesList(output.Rules, context)
@@ -3731,9 +3721,8 @@ const deserializeAws_json1_1CostCategoryInheritedValueDimension = (
   context: __SerdeContext
 ): CostCategoryInheritedValueDimension => {
   return {
-    DimensionKey: output.DimensionKey !== undefined && output.DimensionKey !== null ? output.DimensionKey : undefined,
-    DimensionName:
-      output.DimensionName !== undefined && output.DimensionName !== null ? output.DimensionName : undefined,
+    DimensionKey: __expectString(output.DimensionKey),
+    DimensionName: __expectString(output.DimensionName),
   } as any;
 };
 
@@ -3744,7 +3733,7 @@ const deserializeAws_json1_1CostCategoryNamesList = (output: any, context: __Ser
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3753,8 +3742,8 @@ const deserializeAws_json1_1CostCategoryProcessingStatus = (
   context: __SerdeContext
 ): CostCategoryProcessingStatus => {
   return {
-    Component: output.Component !== undefined && output.Component !== null ? output.Component : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Component: __expectString(output.Component),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -3774,15 +3763,12 @@ const deserializeAws_json1_1CostCategoryProcessingStatusList = (
 
 const deserializeAws_json1_1CostCategoryReference = (output: any, context: __SerdeContext): CostCategoryReference => {
   return {
-    CostCategoryArn:
-      output.CostCategoryArn !== undefined && output.CostCategoryArn !== null ? output.CostCategoryArn : undefined,
-    DefaultValue: output.DefaultValue !== undefined && output.DefaultValue !== null ? output.DefaultValue : undefined,
-    EffectiveEnd: output.EffectiveEnd !== undefined && output.EffectiveEnd !== null ? output.EffectiveEnd : undefined,
-    EffectiveStart:
-      output.EffectiveStart !== undefined && output.EffectiveStart !== null ? output.EffectiveStart : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    NumberOfRules:
-      output.NumberOfRules !== undefined && output.NumberOfRules !== null ? output.NumberOfRules : undefined,
+    CostCategoryArn: __expectString(output.CostCategoryArn),
+    DefaultValue: __expectString(output.DefaultValue),
+    EffectiveEnd: __expectString(output.EffectiveEnd),
+    EffectiveStart: __expectString(output.EffectiveStart),
+    Name: __expectString(output.Name),
+    NumberOfRules: __expectNumber(output.NumberOfRules),
     ProcessingStatus:
       output.ProcessingStatus !== undefined && output.ProcessingStatus !== null
         ? deserializeAws_json1_1CostCategoryProcessingStatusList(output.ProcessingStatus, context)
@@ -3818,8 +3804,8 @@ const deserializeAws_json1_1CostCategoryRule = (output: any, context: __SerdeCon
       output.Rule !== undefined && output.Rule !== null
         ? deserializeAws_json1_1Expression(output.Rule, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Type: __expectString(output.Type),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -3836,7 +3822,7 @@ const deserializeAws_json1_1CostCategoryRulesList = (output: any, context: __Ser
 
 const deserializeAws_json1_1CostCategoryValues = (output: any, context: __SerdeContext): CostCategoryValues => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
+    Key: __expectString(output.Key),
     MatchOptions:
       output.MatchOptions !== undefined && output.MatchOptions !== null
         ? deserializeAws_json1_1MatchOptions(output.MatchOptions, context)
@@ -3855,7 +3841,7 @@ const deserializeAws_json1_1CostCategoryValuesList = (output: any, context: __Se
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3895,24 +3881,16 @@ const deserializeAws_json1_1CoverageByTime = (output: any, context: __SerdeConte
 
 const deserializeAws_json1_1CoverageCost = (output: any, context: __SerdeContext): CoverageCost => {
   return {
-    OnDemandCost: output.OnDemandCost !== undefined && output.OnDemandCost !== null ? output.OnDemandCost : undefined,
+    OnDemandCost: __expectString(output.OnDemandCost),
   } as any;
 };
 
 const deserializeAws_json1_1CoverageHours = (output: any, context: __SerdeContext): CoverageHours => {
   return {
-    CoverageHoursPercentage:
-      output.CoverageHoursPercentage !== undefined && output.CoverageHoursPercentage !== null
-        ? output.CoverageHoursPercentage
-        : undefined,
-    OnDemandHours:
-      output.OnDemandHours !== undefined && output.OnDemandHours !== null ? output.OnDemandHours : undefined,
-    ReservedHours:
-      output.ReservedHours !== undefined && output.ReservedHours !== null ? output.ReservedHours : undefined,
-    TotalRunningHours:
-      output.TotalRunningHours !== undefined && output.TotalRunningHours !== null
-        ? output.TotalRunningHours
-        : undefined,
+    CoverageHoursPercentage: __expectString(output.CoverageHoursPercentage),
+    OnDemandHours: __expectString(output.OnDemandHours),
+    ReservedHours: __expectString(output.ReservedHours),
+    TotalRunningHours: __expectString(output.TotalRunningHours),
   } as any;
 };
 
@@ -3921,22 +3899,10 @@ const deserializeAws_json1_1CoverageNormalizedUnits = (
   context: __SerdeContext
 ): CoverageNormalizedUnits => {
   return {
-    CoverageNormalizedUnitsPercentage:
-      output.CoverageNormalizedUnitsPercentage !== undefined && output.CoverageNormalizedUnitsPercentage !== null
-        ? output.CoverageNormalizedUnitsPercentage
-        : undefined,
-    OnDemandNormalizedUnits:
-      output.OnDemandNormalizedUnits !== undefined && output.OnDemandNormalizedUnits !== null
-        ? output.OnDemandNormalizedUnits
-        : undefined,
-    ReservedNormalizedUnits:
-      output.ReservedNormalizedUnits !== undefined && output.ReservedNormalizedUnits !== null
-        ? output.ReservedNormalizedUnits
-        : undefined,
-    TotalRunningNormalizedUnits:
-      output.TotalRunningNormalizedUnits !== undefined && output.TotalRunningNormalizedUnits !== null
-        ? output.TotalRunningNormalizedUnits
-        : undefined,
+    CoverageNormalizedUnitsPercentage: __expectString(output.CoverageNormalizedUnitsPercentage),
+    OnDemandNormalizedUnits: __expectString(output.OnDemandNormalizedUnits),
+    ReservedNormalizedUnits: __expectString(output.ReservedNormalizedUnits),
+    TotalRunningNormalizedUnits: __expectString(output.TotalRunningNormalizedUnits),
   } as any;
 };
 
@@ -3956,7 +3922,7 @@ const deserializeAws_json1_1CreateAnomalyMonitorResponse = (
   context: __SerdeContext
 ): CreateAnomalyMonitorResponse => {
   return {
-    MonitorArn: output.MonitorArn !== undefined && output.MonitorArn !== null ? output.MonitorArn : undefined,
+    MonitorArn: __expectString(output.MonitorArn),
   } as any;
 };
 
@@ -3965,8 +3931,7 @@ const deserializeAws_json1_1CreateAnomalySubscriptionResponse = (
   context: __SerdeContext
 ): CreateAnomalySubscriptionResponse => {
   return {
-    SubscriptionArn:
-      output.SubscriptionArn !== undefined && output.SubscriptionArn !== null ? output.SubscriptionArn : undefined,
+    SubscriptionArn: __expectString(output.SubscriptionArn),
   } as any;
 };
 
@@ -3975,49 +3940,33 @@ const deserializeAws_json1_1CreateCostCategoryDefinitionResponse = (
   context: __SerdeContext
 ): CreateCostCategoryDefinitionResponse => {
   return {
-    CostCategoryArn:
-      output.CostCategoryArn !== undefined && output.CostCategoryArn !== null ? output.CostCategoryArn : undefined,
-    EffectiveStart:
-      output.EffectiveStart !== undefined && output.EffectiveStart !== null ? output.EffectiveStart : undefined,
+    CostCategoryArn: __expectString(output.CostCategoryArn),
+    EffectiveStart: __expectString(output.EffectiveStart),
   } as any;
 };
 
 const deserializeAws_json1_1CurrentInstance = (output: any, context: __SerdeContext): CurrentInstance => {
   return {
-    CurrencyCode: output.CurrencyCode !== undefined && output.CurrencyCode !== null ? output.CurrencyCode : undefined,
-    InstanceName: output.InstanceName !== undefined && output.InstanceName !== null ? output.InstanceName : undefined,
-    MonthlyCost: output.MonthlyCost !== undefined && output.MonthlyCost !== null ? output.MonthlyCost : undefined,
-    OnDemandHoursInLookbackPeriod:
-      output.OnDemandHoursInLookbackPeriod !== undefined && output.OnDemandHoursInLookbackPeriod !== null
-        ? output.OnDemandHoursInLookbackPeriod
-        : undefined,
-    ReservationCoveredHoursInLookbackPeriod:
-      output.ReservationCoveredHoursInLookbackPeriod !== undefined &&
-      output.ReservationCoveredHoursInLookbackPeriod !== null
-        ? output.ReservationCoveredHoursInLookbackPeriod
-        : undefined,
+    CurrencyCode: __expectString(output.CurrencyCode),
+    InstanceName: __expectString(output.InstanceName),
+    MonthlyCost: __expectString(output.MonthlyCost),
+    OnDemandHoursInLookbackPeriod: __expectString(output.OnDemandHoursInLookbackPeriod),
+    ReservationCoveredHoursInLookbackPeriod: __expectString(output.ReservationCoveredHoursInLookbackPeriod),
     ResourceDetails:
       output.ResourceDetails !== undefined && output.ResourceDetails !== null
         ? deserializeAws_json1_1ResourceDetails(output.ResourceDetails, context)
         : undefined,
-    ResourceId: output.ResourceId !== undefined && output.ResourceId !== null ? output.ResourceId : undefined,
+    ResourceId: __expectString(output.ResourceId),
     ResourceUtilization:
       output.ResourceUtilization !== undefined && output.ResourceUtilization !== null
         ? deserializeAws_json1_1ResourceUtilization(output.ResourceUtilization, context)
         : undefined,
-    SavingsPlansCoveredHoursInLookbackPeriod:
-      output.SavingsPlansCoveredHoursInLookbackPeriod !== undefined &&
-      output.SavingsPlansCoveredHoursInLookbackPeriod !== null
-        ? output.SavingsPlansCoveredHoursInLookbackPeriod
-        : undefined,
+    SavingsPlansCoveredHoursInLookbackPeriod: __expectString(output.SavingsPlansCoveredHoursInLookbackPeriod),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_1TagValuesList(output.Tags, context)
         : undefined,
-    TotalRunningHoursInLookbackPeriod:
-      output.TotalRunningHoursInLookbackPeriod !== undefined && output.TotalRunningHoursInLookbackPeriod !== null
-        ? output.TotalRunningHoursInLookbackPeriod
-        : undefined,
+    TotalRunningHoursInLookbackPeriod: __expectString(output.TotalRunningHoursInLookbackPeriod),
   } as any;
 };
 
@@ -4026,14 +3975,14 @@ const deserializeAws_json1_1DataUnavailableException = (
   context: __SerdeContext
 ): DataUnavailableException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1DateInterval = (output: any, context: __SerdeContext): DateInterval => {
   return {
-    End: output.End !== undefined && output.End !== null ? output.End : undefined,
-    Start: output.Start !== undefined && output.Start !== null ? output.Start : undefined,
+    End: __expectString(output.End),
+    Start: __expectString(output.Start),
   } as any;
 };
 
@@ -4056,9 +4005,8 @@ const deserializeAws_json1_1DeleteCostCategoryDefinitionResponse = (
   context: __SerdeContext
 ): DeleteCostCategoryDefinitionResponse => {
   return {
-    CostCategoryArn:
-      output.CostCategoryArn !== undefined && output.CostCategoryArn !== null ? output.CostCategoryArn : undefined,
-    EffectiveEnd: output.EffectiveEnd !== undefined && output.EffectiveEnd !== null ? output.EffectiveEnd : undefined,
+    CostCategoryArn: __expectString(output.CostCategoryArn),
+    EffectiveEnd: __expectString(output.EffectiveEnd),
   } as any;
 };
 
@@ -4076,7 +4024,7 @@ const deserializeAws_json1_1DescribeCostCategoryDefinitionResponse = (
 
 const deserializeAws_json1_1DimensionValues = (output: any, context: __SerdeContext): DimensionValues => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
+    Key: __expectString(output.Key),
     MatchOptions:
       output.MatchOptions !== undefined && output.MatchOptions !== null
         ? deserializeAws_json1_1MatchOptions(output.MatchOptions, context)
@@ -4097,7 +4045,7 @@ const deserializeAws_json1_1DimensionValuesWithAttributes = (
       output.Attributes !== undefined && output.Attributes !== null
         ? deserializeAws_json1_1Attributes(output.Attributes, context)
         : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -4120,81 +4068,46 @@ const deserializeAws_json1_1DiskResourceUtilization = (
   context: __SerdeContext
 ): DiskResourceUtilization => {
   return {
-    DiskReadBytesPerSecond:
-      output.DiskReadBytesPerSecond !== undefined && output.DiskReadBytesPerSecond !== null
-        ? output.DiskReadBytesPerSecond
-        : undefined,
-    DiskReadOpsPerSecond:
-      output.DiskReadOpsPerSecond !== undefined && output.DiskReadOpsPerSecond !== null
-        ? output.DiskReadOpsPerSecond
-        : undefined,
-    DiskWriteBytesPerSecond:
-      output.DiskWriteBytesPerSecond !== undefined && output.DiskWriteBytesPerSecond !== null
-        ? output.DiskWriteBytesPerSecond
-        : undefined,
-    DiskWriteOpsPerSecond:
-      output.DiskWriteOpsPerSecond !== undefined && output.DiskWriteOpsPerSecond !== null
-        ? output.DiskWriteOpsPerSecond
-        : undefined,
+    DiskReadBytesPerSecond: __expectString(output.DiskReadBytesPerSecond),
+    DiskReadOpsPerSecond: __expectString(output.DiskReadOpsPerSecond),
+    DiskWriteBytesPerSecond: __expectString(output.DiskWriteBytesPerSecond),
+    DiskWriteOpsPerSecond: __expectString(output.DiskWriteOpsPerSecond),
   } as any;
 };
 
 const deserializeAws_json1_1EBSResourceUtilization = (output: any, context: __SerdeContext): EBSResourceUtilization => {
   return {
-    EbsReadBytesPerSecond:
-      output.EbsReadBytesPerSecond !== undefined && output.EbsReadBytesPerSecond !== null
-        ? output.EbsReadBytesPerSecond
-        : undefined,
-    EbsReadOpsPerSecond:
-      output.EbsReadOpsPerSecond !== undefined && output.EbsReadOpsPerSecond !== null
-        ? output.EbsReadOpsPerSecond
-        : undefined,
-    EbsWriteBytesPerSecond:
-      output.EbsWriteBytesPerSecond !== undefined && output.EbsWriteBytesPerSecond !== null
-        ? output.EbsWriteBytesPerSecond
-        : undefined,
-    EbsWriteOpsPerSecond:
-      output.EbsWriteOpsPerSecond !== undefined && output.EbsWriteOpsPerSecond !== null
-        ? output.EbsWriteOpsPerSecond
-        : undefined,
+    EbsReadBytesPerSecond: __expectString(output.EbsReadBytesPerSecond),
+    EbsReadOpsPerSecond: __expectString(output.EbsReadOpsPerSecond),
+    EbsWriteBytesPerSecond: __expectString(output.EbsWriteBytesPerSecond),
+    EbsWriteOpsPerSecond: __expectString(output.EbsWriteOpsPerSecond),
   } as any;
 };
 
 const deserializeAws_json1_1EC2InstanceDetails = (output: any, context: __SerdeContext): EC2InstanceDetails => {
   return {
-    AvailabilityZone:
-      output.AvailabilityZone !== undefined && output.AvailabilityZone !== null ? output.AvailabilityZone : undefined,
-    CurrentGeneration:
-      output.CurrentGeneration !== undefined && output.CurrentGeneration !== null
-        ? output.CurrentGeneration
-        : undefined,
-    Family: output.Family !== undefined && output.Family !== null ? output.Family : undefined,
-    InstanceType: output.InstanceType !== undefined && output.InstanceType !== null ? output.InstanceType : undefined,
-    Platform: output.Platform !== undefined && output.Platform !== null ? output.Platform : undefined,
-    Region: output.Region !== undefined && output.Region !== null ? output.Region : undefined,
-    SizeFlexEligible:
-      output.SizeFlexEligible !== undefined && output.SizeFlexEligible !== null ? output.SizeFlexEligible : undefined,
-    Tenancy: output.Tenancy !== undefined && output.Tenancy !== null ? output.Tenancy : undefined,
+    AvailabilityZone: __expectString(output.AvailabilityZone),
+    CurrentGeneration: __expectBoolean(output.CurrentGeneration),
+    Family: __expectString(output.Family),
+    InstanceType: __expectString(output.InstanceType),
+    Platform: __expectString(output.Platform),
+    Region: __expectString(output.Region),
+    SizeFlexEligible: __expectBoolean(output.SizeFlexEligible),
+    Tenancy: __expectString(output.Tenancy),
   } as any;
 };
 
 const deserializeAws_json1_1EC2ResourceDetails = (output: any, context: __SerdeContext): EC2ResourceDetails => {
   return {
-    HourlyOnDemandRate:
-      output.HourlyOnDemandRate !== undefined && output.HourlyOnDemandRate !== null
-        ? output.HourlyOnDemandRate
-        : undefined,
-    InstanceType: output.InstanceType !== undefined && output.InstanceType !== null ? output.InstanceType : undefined,
-    Memory: output.Memory !== undefined && output.Memory !== null ? output.Memory : undefined,
-    NetworkPerformance:
-      output.NetworkPerformance !== undefined && output.NetworkPerformance !== null
-        ? output.NetworkPerformance
-        : undefined,
-    Platform: output.Platform !== undefined && output.Platform !== null ? output.Platform : undefined,
-    Region: output.Region !== undefined && output.Region !== null ? output.Region : undefined,
-    Sku: output.Sku !== undefined && output.Sku !== null ? output.Sku : undefined,
-    Storage: output.Storage !== undefined && output.Storage !== null ? output.Storage : undefined,
-    Vcpu: output.Vcpu !== undefined && output.Vcpu !== null ? output.Vcpu : undefined,
+    HourlyOnDemandRate: __expectString(output.HourlyOnDemandRate),
+    InstanceType: __expectString(output.InstanceType),
+    Memory: __expectString(output.Memory),
+    NetworkPerformance: __expectString(output.NetworkPerformance),
+    Platform: __expectString(output.Platform),
+    Region: __expectString(output.Region),
+    Sku: __expectString(output.Sku),
+    Storage: __expectString(output.Storage),
+    Vcpu: __expectString(output.Vcpu),
   } as any;
 };
 
@@ -4208,18 +4121,9 @@ const deserializeAws_json1_1EC2ResourceUtilization = (output: any, context: __Se
       output.EBSResourceUtilization !== undefined && output.EBSResourceUtilization !== null
         ? deserializeAws_json1_1EBSResourceUtilization(output.EBSResourceUtilization, context)
         : undefined,
-    MaxCpuUtilizationPercentage:
-      output.MaxCpuUtilizationPercentage !== undefined && output.MaxCpuUtilizationPercentage !== null
-        ? output.MaxCpuUtilizationPercentage
-        : undefined,
-    MaxMemoryUtilizationPercentage:
-      output.MaxMemoryUtilizationPercentage !== undefined && output.MaxMemoryUtilizationPercentage !== null
-        ? output.MaxMemoryUtilizationPercentage
-        : undefined,
-    MaxStorageUtilizationPercentage:
-      output.MaxStorageUtilizationPercentage !== undefined && output.MaxStorageUtilizationPercentage !== null
-        ? output.MaxStorageUtilizationPercentage
-        : undefined,
+    MaxCpuUtilizationPercentage: __expectString(output.MaxCpuUtilizationPercentage),
+    MaxMemoryUtilizationPercentage: __expectString(output.MaxMemoryUtilizationPercentage),
+    MaxStorageUtilizationPercentage: __expectString(output.MaxStorageUtilizationPercentage),
     NetworkResourceUtilization:
       output.NetworkResourceUtilization !== undefined && output.NetworkResourceUtilization !== null
         ? deserializeAws_json1_1NetworkResourceUtilization(output.NetworkResourceUtilization, context)
@@ -4229,8 +4133,7 @@ const deserializeAws_json1_1EC2ResourceUtilization = (output: any, context: __Se
 
 const deserializeAws_json1_1EC2Specification = (output: any, context: __SerdeContext): EC2Specification => {
   return {
-    OfferingClass:
-      output.OfferingClass !== undefined && output.OfferingClass !== null ? output.OfferingClass : undefined,
+    OfferingClass: __expectString(output.OfferingClass),
   } as any;
 };
 
@@ -4239,34 +4142,22 @@ const deserializeAws_json1_1ElastiCacheInstanceDetails = (
   context: __SerdeContext
 ): ElastiCacheInstanceDetails => {
   return {
-    CurrentGeneration:
-      output.CurrentGeneration !== undefined && output.CurrentGeneration !== null
-        ? output.CurrentGeneration
-        : undefined,
-    Family: output.Family !== undefined && output.Family !== null ? output.Family : undefined,
-    NodeType: output.NodeType !== undefined && output.NodeType !== null ? output.NodeType : undefined,
-    ProductDescription:
-      output.ProductDescription !== undefined && output.ProductDescription !== null
-        ? output.ProductDescription
-        : undefined,
-    Region: output.Region !== undefined && output.Region !== null ? output.Region : undefined,
-    SizeFlexEligible:
-      output.SizeFlexEligible !== undefined && output.SizeFlexEligible !== null ? output.SizeFlexEligible : undefined,
+    CurrentGeneration: __expectBoolean(output.CurrentGeneration),
+    Family: __expectString(output.Family),
+    NodeType: __expectString(output.NodeType),
+    ProductDescription: __expectString(output.ProductDescription),
+    Region: __expectString(output.Region),
+    SizeFlexEligible: __expectBoolean(output.SizeFlexEligible),
   } as any;
 };
 
 const deserializeAws_json1_1ESInstanceDetails = (output: any, context: __SerdeContext): ESInstanceDetails => {
   return {
-    CurrentGeneration:
-      output.CurrentGeneration !== undefined && output.CurrentGeneration !== null
-        ? output.CurrentGeneration
-        : undefined,
-    InstanceClass:
-      output.InstanceClass !== undefined && output.InstanceClass !== null ? output.InstanceClass : undefined,
-    InstanceSize: output.InstanceSize !== undefined && output.InstanceSize !== null ? output.InstanceSize : undefined,
-    Region: output.Region !== undefined && output.Region !== null ? output.Region : undefined,
-    SizeFlexEligible:
-      output.SizeFlexEligible !== undefined && output.SizeFlexEligible !== null ? output.SizeFlexEligible : undefined,
+    CurrentGeneration: __expectBoolean(output.CurrentGeneration),
+    InstanceClass: __expectString(output.InstanceClass),
+    InstanceSize: __expectString(output.InstanceSize),
+    Region: __expectString(output.Region),
+    SizeFlexEligible: __expectBoolean(output.SizeFlexEligible),
   } as any;
 };
 
@@ -4318,21 +4209,15 @@ const deserializeAws_json1_1FindingReasonCodes = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1ForecastResult = (output: any, context: __SerdeContext): ForecastResult => {
   return {
-    MeanValue: output.MeanValue !== undefined && output.MeanValue !== null ? output.MeanValue : undefined,
-    PredictionIntervalLowerBound:
-      output.PredictionIntervalLowerBound !== undefined && output.PredictionIntervalLowerBound !== null
-        ? output.PredictionIntervalLowerBound
-        : undefined,
-    PredictionIntervalUpperBound:
-      output.PredictionIntervalUpperBound !== undefined && output.PredictionIntervalUpperBound !== null
-        ? output.PredictionIntervalUpperBound
-        : undefined,
+    MeanValue: __expectString(output.MeanValue),
+    PredictionIntervalLowerBound: __expectString(output.PredictionIntervalLowerBound),
+    PredictionIntervalUpperBound: __expectString(output.PredictionIntervalUpperBound),
     TimePeriod:
       output.TimePeriod !== undefined && output.TimePeriod !== null
         ? deserializeAws_json1_1DateInterval(output.TimePeriod, context)
@@ -4357,8 +4242,7 @@ const deserializeAws_json1_1GetAnomaliesResponse = (output: any, context: __Serd
       output.Anomalies !== undefined && output.Anomalies !== null
         ? deserializeAws_json1_1Anomalies(output.Anomalies, context)
         : undefined,
-    NextPageToken:
-      output.NextPageToken !== undefined && output.NextPageToken !== null ? output.NextPageToken : undefined,
+    NextPageToken: __expectString(output.NextPageToken),
   } as any;
 };
 
@@ -4371,8 +4255,7 @@ const deserializeAws_json1_1GetAnomalyMonitorsResponse = (
       output.AnomalyMonitors !== undefined && output.AnomalyMonitors !== null
         ? deserializeAws_json1_1AnomalyMonitors(output.AnomalyMonitors, context)
         : undefined,
-    NextPageToken:
-      output.NextPageToken !== undefined && output.NextPageToken !== null ? output.NextPageToken : undefined,
+    NextPageToken: __expectString(output.NextPageToken),
   } as any;
 };
 
@@ -4385,8 +4268,7 @@ const deserializeAws_json1_1GetAnomalySubscriptionsResponse = (
       output.AnomalySubscriptions !== undefined && output.AnomalySubscriptions !== null
         ? deserializeAws_json1_1AnomalySubscriptions(output.AnomalySubscriptions, context)
         : undefined,
-    NextPageToken:
-      output.NextPageToken !== undefined && output.NextPageToken !== null ? output.NextPageToken : undefined,
+    NextPageToken: __expectString(output.NextPageToken),
   } as any;
 };
 
@@ -4403,8 +4285,7 @@ const deserializeAws_json1_1GetCostAndUsageResponse = (
       output.GroupDefinitions !== undefined && output.GroupDefinitions !== null
         ? deserializeAws_json1_1GroupDefinitions(output.GroupDefinitions, context)
         : undefined,
-    NextPageToken:
-      output.NextPageToken !== undefined && output.NextPageToken !== null ? output.NextPageToken : undefined,
+    NextPageToken: __expectString(output.NextPageToken),
     ResultsByTime:
       output.ResultsByTime !== undefined && output.ResultsByTime !== null
         ? deserializeAws_json1_1ResultsByTime(output.ResultsByTime, context)
@@ -4425,8 +4306,7 @@ const deserializeAws_json1_1GetCostAndUsageWithResourcesResponse = (
       output.GroupDefinitions !== undefined && output.GroupDefinitions !== null
         ? deserializeAws_json1_1GroupDefinitions(output.GroupDefinitions, context)
         : undefined,
-    NextPageToken:
-      output.NextPageToken !== undefined && output.NextPageToken !== null ? output.NextPageToken : undefined,
+    NextPageToken: __expectString(output.NextPageToken),
     ResultsByTime:
       output.ResultsByTime !== undefined && output.ResultsByTime !== null
         ? deserializeAws_json1_1ResultsByTime(output.ResultsByTime, context)
@@ -4447,10 +4327,9 @@ const deserializeAws_json1_1GetCostCategoriesResponse = (
       output.CostCategoryValues !== undefined && output.CostCategoryValues !== null
         ? deserializeAws_json1_1CostCategoryValuesList(output.CostCategoryValues, context)
         : undefined,
-    NextPageToken:
-      output.NextPageToken !== undefined && output.NextPageToken !== null ? output.NextPageToken : undefined,
-    ReturnSize: output.ReturnSize !== undefined && output.ReturnSize !== null ? output.ReturnSize : undefined,
-    TotalSize: output.TotalSize !== undefined && output.TotalSize !== null ? output.TotalSize : undefined,
+    NextPageToken: __expectString(output.NextPageToken),
+    ReturnSize: __expectNumber(output.ReturnSize),
+    TotalSize: __expectNumber(output.TotalSize),
   } as any;
 };
 
@@ -4479,10 +4358,9 @@ const deserializeAws_json1_1GetDimensionValuesResponse = (
       output.DimensionValues !== undefined && output.DimensionValues !== null
         ? deserializeAws_json1_1DimensionValuesWithAttributesList(output.DimensionValues, context)
         : undefined,
-    NextPageToken:
-      output.NextPageToken !== undefined && output.NextPageToken !== null ? output.NextPageToken : undefined,
-    ReturnSize: output.ReturnSize !== undefined && output.ReturnSize !== null ? output.ReturnSize : undefined,
-    TotalSize: output.TotalSize !== undefined && output.TotalSize !== null ? output.TotalSize : undefined,
+    NextPageToken: __expectString(output.NextPageToken),
+    ReturnSize: __expectNumber(output.ReturnSize),
+    TotalSize: __expectNumber(output.TotalSize),
   } as any;
 };
 
@@ -4495,8 +4373,7 @@ const deserializeAws_json1_1GetReservationCoverageResponse = (
       output.CoveragesByTime !== undefined && output.CoveragesByTime !== null
         ? deserializeAws_json1_1CoveragesByTime(output.CoveragesByTime, context)
         : undefined,
-    NextPageToken:
-      output.NextPageToken !== undefined && output.NextPageToken !== null ? output.NextPageToken : undefined,
+    NextPageToken: __expectString(output.NextPageToken),
     Total:
       output.Total !== undefined && output.Total !== null
         ? deserializeAws_json1_1Coverage(output.Total, context)
@@ -4513,8 +4390,7 @@ const deserializeAws_json1_1GetReservationPurchaseRecommendationResponse = (
       output.Metadata !== undefined && output.Metadata !== null
         ? deserializeAws_json1_1ReservationPurchaseRecommendationMetadata(output.Metadata, context)
         : undefined,
-    NextPageToken:
-      output.NextPageToken !== undefined && output.NextPageToken !== null ? output.NextPageToken : undefined,
+    NextPageToken: __expectString(output.NextPageToken),
     Recommendations:
       output.Recommendations !== undefined && output.Recommendations !== null
         ? deserializeAws_json1_1ReservationPurchaseRecommendations(output.Recommendations, context)
@@ -4527,8 +4403,7 @@ const deserializeAws_json1_1GetReservationUtilizationResponse = (
   context: __SerdeContext
 ): GetReservationUtilizationResponse => {
   return {
-    NextPageToken:
-      output.NextPageToken !== undefined && output.NextPageToken !== null ? output.NextPageToken : undefined,
+    NextPageToken: __expectString(output.NextPageToken),
     Total:
       output.Total !== undefined && output.Total !== null
         ? deserializeAws_json1_1ReservationAggregates(output.Total, context)
@@ -4553,8 +4428,7 @@ const deserializeAws_json1_1GetRightsizingRecommendationResponse = (
       output.Metadata !== undefined && output.Metadata !== null
         ? deserializeAws_json1_1RightsizingRecommendationMetadata(output.Metadata, context)
         : undefined,
-    NextPageToken:
-      output.NextPageToken !== undefined && output.NextPageToken !== null ? output.NextPageToken : undefined,
+    NextPageToken: __expectString(output.NextPageToken),
     RightsizingRecommendations:
       output.RightsizingRecommendations !== undefined && output.RightsizingRecommendations !== null
         ? deserializeAws_json1_1RightsizingRecommendationList(output.RightsizingRecommendations, context)
@@ -4571,7 +4445,7 @@ const deserializeAws_json1_1GetSavingsPlansCoverageResponse = (
   context: __SerdeContext
 ): GetSavingsPlansCoverageResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     SavingsPlansCoverages:
       output.SavingsPlansCoverages !== undefined && output.SavingsPlansCoverages !== null
         ? deserializeAws_json1_1SavingsPlansCoverages(output.SavingsPlansCoverages, context)
@@ -4588,8 +4462,7 @@ const deserializeAws_json1_1GetSavingsPlansPurchaseRecommendationResponse = (
       output.Metadata !== undefined && output.Metadata !== null
         ? deserializeAws_json1_1SavingsPlansPurchaseRecommendationMetadata(output.Metadata, context)
         : undefined,
-    NextPageToken:
-      output.NextPageToken !== undefined && output.NextPageToken !== null ? output.NextPageToken : undefined,
+    NextPageToken: __expectString(output.NextPageToken),
     SavingsPlansPurchaseRecommendation:
       output.SavingsPlansPurchaseRecommendation !== undefined && output.SavingsPlansPurchaseRecommendation !== null
         ? deserializeAws_json1_1SavingsPlansPurchaseRecommendation(output.SavingsPlansPurchaseRecommendation, context)
@@ -4602,7 +4475,7 @@ const deserializeAws_json1_1GetSavingsPlansUtilizationDetailsResponse = (
   context: __SerdeContext
 ): GetSavingsPlansUtilizationDetailsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     SavingsPlansUtilizationDetails:
       output.SavingsPlansUtilizationDetails !== undefined && output.SavingsPlansUtilizationDetails !== null
         ? deserializeAws_json1_1SavingsPlansUtilizationDetails(output.SavingsPlansUtilizationDetails, context)
@@ -4636,14 +4509,13 @@ const deserializeAws_json1_1GetSavingsPlansUtilizationResponse = (
 
 const deserializeAws_json1_1GetTagsResponse = (output: any, context: __SerdeContext): GetTagsResponse => {
   return {
-    NextPageToken:
-      output.NextPageToken !== undefined && output.NextPageToken !== null ? output.NextPageToken : undefined,
-    ReturnSize: output.ReturnSize !== undefined && output.ReturnSize !== null ? output.ReturnSize : undefined,
+    NextPageToken: __expectString(output.NextPageToken),
+    ReturnSize: __expectNumber(output.ReturnSize),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_1TagList(output.Tags, context)
         : undefined,
-    TotalSize: output.TotalSize !== undefined && output.TotalSize !== null ? output.TotalSize : undefined,
+    TotalSize: __expectNumber(output.TotalSize),
   } as any;
 };
 
@@ -4676,8 +4548,8 @@ const deserializeAws_json1_1Group = (output: any, context: __SerdeContext): Grou
 
 const deserializeAws_json1_1GroupDefinition = (output: any, context: __SerdeContext): GroupDefinition => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Key: __expectString(output.Key),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -4705,8 +4577,8 @@ const deserializeAws_json1_1Groups = (output: any, context: __SerdeContext): Gro
 
 const deserializeAws_json1_1Impact = (output: any, context: __SerdeContext): Impact => {
   return {
-    MaxImpact: output.MaxImpact !== undefined && output.MaxImpact !== null ? output.MaxImpact : undefined,
-    TotalImpact: output.TotalImpact !== undefined && output.TotalImpact !== null ? output.TotalImpact : undefined,
+    MaxImpact: __expectNumber(output.MaxImpact),
+    TotalImpact: __expectNumber(output.TotalImpact),
   } as any;
 };
 
@@ -4740,7 +4612,7 @@ const deserializeAws_json1_1InvalidNextTokenException = (
   context: __SerdeContext
 ): InvalidNextTokenException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -4751,13 +4623,13 @@ const deserializeAws_json1_1Keys = (output: any, context: __SerdeContext): strin
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -4770,7 +4642,7 @@ const deserializeAws_json1_1ListCostCategoryDefinitionsResponse = (
       output.CostCategoryReferences !== undefined && output.CostCategoryReferences !== null
         ? deserializeAws_json1_1CostCategoryReferencesList(output.CostCategoryReferences, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -4781,7 +4653,7 @@ const deserializeAws_json1_1MatchOptions = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4799,8 +4671,8 @@ const deserializeAws_json1_1Metrics = (output: any, context: __SerdeContext): { 
 
 const deserializeAws_json1_1MetricValue = (output: any, context: __SerdeContext): MetricValue => {
   return {
-    Amount: output.Amount !== undefined && output.Amount !== null ? output.Amount : undefined,
-    Unit: output.Unit !== undefined && output.Unit !== null ? output.Unit : undefined,
+    Amount: __expectString(output.Amount),
+    Unit: __expectString(output.Unit),
   } as any;
 };
 
@@ -4823,7 +4695,7 @@ const deserializeAws_json1_1MonitorArnList = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4832,22 +4704,10 @@ const deserializeAws_json1_1NetworkResourceUtilization = (
   context: __SerdeContext
 ): NetworkResourceUtilization => {
   return {
-    NetworkInBytesPerSecond:
-      output.NetworkInBytesPerSecond !== undefined && output.NetworkInBytesPerSecond !== null
-        ? output.NetworkInBytesPerSecond
-        : undefined,
-    NetworkOutBytesPerSecond:
-      output.NetworkOutBytesPerSecond !== undefined && output.NetworkOutBytesPerSecond !== null
-        ? output.NetworkOutBytesPerSecond
-        : undefined,
-    NetworkPacketsInPerSecond:
-      output.NetworkPacketsInPerSecond !== undefined && output.NetworkPacketsInPerSecond !== null
-        ? output.NetworkPacketsInPerSecond
-        : undefined,
-    NetworkPacketsOutPerSecond:
-      output.NetworkPacketsOutPerSecond !== undefined && output.NetworkPacketsOutPerSecond !== null
-        ? output.NetworkPacketsOutPerSecond
-        : undefined,
+    NetworkInBytesPerSecond: __expectString(output.NetworkInBytesPerSecond),
+    NetworkOutBytesPerSecond: __expectString(output.NetworkOutBytesPerSecond),
+    NetworkPacketsInPerSecond: __expectString(output.NetworkPacketsInPerSecond),
+    NetworkPacketsOutPerSecond: __expectString(output.NetworkPacketsOutPerSecond),
   } as any;
 };
 
@@ -4861,7 +4721,7 @@ const deserializeAws_json1_1PlatformDifferences = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4870,28 +4730,21 @@ const deserializeAws_json1_1ProvideAnomalyFeedbackResponse = (
   context: __SerdeContext
 ): ProvideAnomalyFeedbackResponse => {
   return {
-    AnomalyId: output.AnomalyId !== undefined && output.AnomalyId !== null ? output.AnomalyId : undefined,
+    AnomalyId: __expectString(output.AnomalyId),
   } as any;
 };
 
 const deserializeAws_json1_1RDSInstanceDetails = (output: any, context: __SerdeContext): RDSInstanceDetails => {
   return {
-    CurrentGeneration:
-      output.CurrentGeneration !== undefined && output.CurrentGeneration !== null
-        ? output.CurrentGeneration
-        : undefined,
-    DatabaseEdition:
-      output.DatabaseEdition !== undefined && output.DatabaseEdition !== null ? output.DatabaseEdition : undefined,
-    DatabaseEngine:
-      output.DatabaseEngine !== undefined && output.DatabaseEngine !== null ? output.DatabaseEngine : undefined,
-    DeploymentOption:
-      output.DeploymentOption !== undefined && output.DeploymentOption !== null ? output.DeploymentOption : undefined,
-    Family: output.Family !== undefined && output.Family !== null ? output.Family : undefined,
-    InstanceType: output.InstanceType !== undefined && output.InstanceType !== null ? output.InstanceType : undefined,
-    LicenseModel: output.LicenseModel !== undefined && output.LicenseModel !== null ? output.LicenseModel : undefined,
-    Region: output.Region !== undefined && output.Region !== null ? output.Region : undefined,
-    SizeFlexEligible:
-      output.SizeFlexEligible !== undefined && output.SizeFlexEligible !== null ? output.SizeFlexEligible : undefined,
+    CurrentGeneration: __expectBoolean(output.CurrentGeneration),
+    DatabaseEdition: __expectString(output.DatabaseEdition),
+    DatabaseEngine: __expectString(output.DatabaseEngine),
+    DeploymentOption: __expectString(output.DeploymentOption),
+    Family: __expectString(output.Family),
+    InstanceType: __expectString(output.InstanceType),
+    LicenseModel: __expectString(output.LicenseModel),
+    Region: __expectString(output.Region),
+    SizeFlexEligible: __expectBoolean(output.SizeFlexEligible),
   } as any;
 };
 
@@ -4900,15 +4753,11 @@ const deserializeAws_json1_1RedshiftInstanceDetails = (
   context: __SerdeContext
 ): RedshiftInstanceDetails => {
   return {
-    CurrentGeneration:
-      output.CurrentGeneration !== undefined && output.CurrentGeneration !== null
-        ? output.CurrentGeneration
-        : undefined,
-    Family: output.Family !== undefined && output.Family !== null ? output.Family : undefined,
-    NodeType: output.NodeType !== undefined && output.NodeType !== null ? output.NodeType : undefined,
-    Region: output.Region !== undefined && output.Region !== null ? output.Region : undefined,
-    SizeFlexEligible:
-      output.SizeFlexEligible !== undefined && output.SizeFlexEligible !== null ? output.SizeFlexEligible : undefined,
+    CurrentGeneration: __expectBoolean(output.CurrentGeneration),
+    Family: __expectString(output.Family),
+    NodeType: __expectString(output.NodeType),
+    Region: __expectString(output.Region),
+    SizeFlexEligible: __expectBoolean(output.SizeFlexEligible),
   } as any;
 };
 
@@ -4917,61 +4766,29 @@ const deserializeAws_json1_1RequestChangedException = (
   context: __SerdeContext
 ): RequestChangedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1ReservationAggregates = (output: any, context: __SerdeContext): ReservationAggregates => {
   return {
-    AmortizedRecurringFee:
-      output.AmortizedRecurringFee !== undefined && output.AmortizedRecurringFee !== null
-        ? output.AmortizedRecurringFee
-        : undefined,
-    AmortizedUpfrontFee:
-      output.AmortizedUpfrontFee !== undefined && output.AmortizedUpfrontFee !== null
-        ? output.AmortizedUpfrontFee
-        : undefined,
-    NetRISavings: output.NetRISavings !== undefined && output.NetRISavings !== null ? output.NetRISavings : undefined,
-    OnDemandCostOfRIHoursUsed:
-      output.OnDemandCostOfRIHoursUsed !== undefined && output.OnDemandCostOfRIHoursUsed !== null
-        ? output.OnDemandCostOfRIHoursUsed
-        : undefined,
-    PurchasedHours:
-      output.PurchasedHours !== undefined && output.PurchasedHours !== null ? output.PurchasedHours : undefined,
-    PurchasedUnits:
-      output.PurchasedUnits !== undefined && output.PurchasedUnits !== null ? output.PurchasedUnits : undefined,
-    RICostForUnusedHours:
-      output.RICostForUnusedHours !== undefined && output.RICostForUnusedHours !== null
-        ? output.RICostForUnusedHours
-        : undefined,
-    RealizedSavings:
-      output.RealizedSavings !== undefined && output.RealizedSavings !== null ? output.RealizedSavings : undefined,
-    TotalActualHours:
-      output.TotalActualHours !== undefined && output.TotalActualHours !== null ? output.TotalActualHours : undefined,
-    TotalActualUnits:
-      output.TotalActualUnits !== undefined && output.TotalActualUnits !== null ? output.TotalActualUnits : undefined,
-    TotalAmortizedFee:
-      output.TotalAmortizedFee !== undefined && output.TotalAmortizedFee !== null
-        ? output.TotalAmortizedFee
-        : undefined,
-    TotalPotentialRISavings:
-      output.TotalPotentialRISavings !== undefined && output.TotalPotentialRISavings !== null
-        ? output.TotalPotentialRISavings
-        : undefined,
-    UnrealizedSavings:
-      output.UnrealizedSavings !== undefined && output.UnrealizedSavings !== null
-        ? output.UnrealizedSavings
-        : undefined,
-    UnusedHours: output.UnusedHours !== undefined && output.UnusedHours !== null ? output.UnusedHours : undefined,
-    UnusedUnits: output.UnusedUnits !== undefined && output.UnusedUnits !== null ? output.UnusedUnits : undefined,
-    UtilizationPercentage:
-      output.UtilizationPercentage !== undefined && output.UtilizationPercentage !== null
-        ? output.UtilizationPercentage
-        : undefined,
-    UtilizationPercentageInUnits:
-      output.UtilizationPercentageInUnits !== undefined && output.UtilizationPercentageInUnits !== null
-        ? output.UtilizationPercentageInUnits
-        : undefined,
+    AmortizedRecurringFee: __expectString(output.AmortizedRecurringFee),
+    AmortizedUpfrontFee: __expectString(output.AmortizedUpfrontFee),
+    NetRISavings: __expectString(output.NetRISavings),
+    OnDemandCostOfRIHoursUsed: __expectString(output.OnDemandCostOfRIHoursUsed),
+    PurchasedHours: __expectString(output.PurchasedHours),
+    PurchasedUnits: __expectString(output.PurchasedUnits),
+    RICostForUnusedHours: __expectString(output.RICostForUnusedHours),
+    RealizedSavings: __expectString(output.RealizedSavings),
+    TotalActualHours: __expectString(output.TotalActualHours),
+    TotalActualUnits: __expectString(output.TotalActualUnits),
+    TotalAmortizedFee: __expectString(output.TotalAmortizedFee),
+    TotalPotentialRISavings: __expectString(output.TotalPotentialRISavings),
+    UnrealizedSavings: __expectString(output.UnrealizedSavings),
+    UnusedHours: __expectString(output.UnusedHours),
+    UnusedUnits: __expectString(output.UnusedUnits),
+    UtilizationPercentage: __expectString(output.UtilizationPercentage),
+    UtilizationPercentageInUnits: __expectString(output.UtilizationPercentageInUnits),
   } as any;
 };
 
@@ -5010,13 +4827,9 @@ const deserializeAws_json1_1ReservationPurchaseRecommendation = (
   context: __SerdeContext
 ): ReservationPurchaseRecommendation => {
   return {
-    AccountScope: output.AccountScope !== undefined && output.AccountScope !== null ? output.AccountScope : undefined,
-    LookbackPeriodInDays:
-      output.LookbackPeriodInDays !== undefined && output.LookbackPeriodInDays !== null
-        ? output.LookbackPeriodInDays
-        : undefined,
-    PaymentOption:
-      output.PaymentOption !== undefined && output.PaymentOption !== null ? output.PaymentOption : undefined,
+    AccountScope: __expectString(output.AccountScope),
+    LookbackPeriodInDays: __expectString(output.LookbackPeriodInDays),
+    PaymentOption: __expectString(output.PaymentOption),
     RecommendationDetails:
       output.RecommendationDetails !== undefined && output.RecommendationDetails !== null
         ? deserializeAws_json1_1ReservationPurchaseRecommendationDetails(output.RecommendationDetails, context)
@@ -5029,7 +4842,7 @@ const deserializeAws_json1_1ReservationPurchaseRecommendation = (
       output.ServiceSpecification !== undefined && output.ServiceSpecification !== null
         ? deserializeAws_json1_1ServiceSpecification(output.ServiceSpecification, context)
         : undefined,
-    TermInYears: output.TermInYears !== undefined && output.TermInYears !== null ? output.TermInYears : undefined,
+    TermInYears: __expectString(output.TermInYears),
   } as any;
 };
 
@@ -5038,75 +4851,28 @@ const deserializeAws_json1_1ReservationPurchaseRecommendationDetail = (
   context: __SerdeContext
 ): ReservationPurchaseRecommendationDetail => {
   return {
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
-    AverageNormalizedUnitsUsedPerHour:
-      output.AverageNormalizedUnitsUsedPerHour !== undefined && output.AverageNormalizedUnitsUsedPerHour !== null
-        ? output.AverageNormalizedUnitsUsedPerHour
-        : undefined,
-    AverageNumberOfInstancesUsedPerHour:
-      output.AverageNumberOfInstancesUsedPerHour !== undefined && output.AverageNumberOfInstancesUsedPerHour !== null
-        ? output.AverageNumberOfInstancesUsedPerHour
-        : undefined,
-    AverageUtilization:
-      output.AverageUtilization !== undefined && output.AverageUtilization !== null
-        ? output.AverageUtilization
-        : undefined,
-    CurrencyCode: output.CurrencyCode !== undefined && output.CurrencyCode !== null ? output.CurrencyCode : undefined,
-    EstimatedBreakEvenInMonths:
-      output.EstimatedBreakEvenInMonths !== undefined && output.EstimatedBreakEvenInMonths !== null
-        ? output.EstimatedBreakEvenInMonths
-        : undefined,
-    EstimatedMonthlyOnDemandCost:
-      output.EstimatedMonthlyOnDemandCost !== undefined && output.EstimatedMonthlyOnDemandCost !== null
-        ? output.EstimatedMonthlyOnDemandCost
-        : undefined,
-    EstimatedMonthlySavingsAmount:
-      output.EstimatedMonthlySavingsAmount !== undefined && output.EstimatedMonthlySavingsAmount !== null
-        ? output.EstimatedMonthlySavingsAmount
-        : undefined,
-    EstimatedMonthlySavingsPercentage:
-      output.EstimatedMonthlySavingsPercentage !== undefined && output.EstimatedMonthlySavingsPercentage !== null
-        ? output.EstimatedMonthlySavingsPercentage
-        : undefined,
-    EstimatedReservationCostForLookbackPeriod:
-      output.EstimatedReservationCostForLookbackPeriod !== undefined &&
-      output.EstimatedReservationCostForLookbackPeriod !== null
-        ? output.EstimatedReservationCostForLookbackPeriod
-        : undefined,
+    AccountId: __expectString(output.AccountId),
+    AverageNormalizedUnitsUsedPerHour: __expectString(output.AverageNormalizedUnitsUsedPerHour),
+    AverageNumberOfInstancesUsedPerHour: __expectString(output.AverageNumberOfInstancesUsedPerHour),
+    AverageUtilization: __expectString(output.AverageUtilization),
+    CurrencyCode: __expectString(output.CurrencyCode),
+    EstimatedBreakEvenInMonths: __expectString(output.EstimatedBreakEvenInMonths),
+    EstimatedMonthlyOnDemandCost: __expectString(output.EstimatedMonthlyOnDemandCost),
+    EstimatedMonthlySavingsAmount: __expectString(output.EstimatedMonthlySavingsAmount),
+    EstimatedMonthlySavingsPercentage: __expectString(output.EstimatedMonthlySavingsPercentage),
+    EstimatedReservationCostForLookbackPeriod: __expectString(output.EstimatedReservationCostForLookbackPeriod),
     InstanceDetails:
       output.InstanceDetails !== undefined && output.InstanceDetails !== null
         ? deserializeAws_json1_1InstanceDetails(output.InstanceDetails, context)
         : undefined,
-    MaximumNormalizedUnitsUsedPerHour:
-      output.MaximumNormalizedUnitsUsedPerHour !== undefined && output.MaximumNormalizedUnitsUsedPerHour !== null
-        ? output.MaximumNormalizedUnitsUsedPerHour
-        : undefined,
-    MaximumNumberOfInstancesUsedPerHour:
-      output.MaximumNumberOfInstancesUsedPerHour !== undefined && output.MaximumNumberOfInstancesUsedPerHour !== null
-        ? output.MaximumNumberOfInstancesUsedPerHour
-        : undefined,
-    MinimumNormalizedUnitsUsedPerHour:
-      output.MinimumNormalizedUnitsUsedPerHour !== undefined && output.MinimumNormalizedUnitsUsedPerHour !== null
-        ? output.MinimumNormalizedUnitsUsedPerHour
-        : undefined,
-    MinimumNumberOfInstancesUsedPerHour:
-      output.MinimumNumberOfInstancesUsedPerHour !== undefined && output.MinimumNumberOfInstancesUsedPerHour !== null
-        ? output.MinimumNumberOfInstancesUsedPerHour
-        : undefined,
-    RecommendedNormalizedUnitsToPurchase:
-      output.RecommendedNormalizedUnitsToPurchase !== undefined && output.RecommendedNormalizedUnitsToPurchase !== null
-        ? output.RecommendedNormalizedUnitsToPurchase
-        : undefined,
-    RecommendedNumberOfInstancesToPurchase:
-      output.RecommendedNumberOfInstancesToPurchase !== undefined &&
-      output.RecommendedNumberOfInstancesToPurchase !== null
-        ? output.RecommendedNumberOfInstancesToPurchase
-        : undefined,
-    RecurringStandardMonthlyCost:
-      output.RecurringStandardMonthlyCost !== undefined && output.RecurringStandardMonthlyCost !== null
-        ? output.RecurringStandardMonthlyCost
-        : undefined,
-    UpfrontCost: output.UpfrontCost !== undefined && output.UpfrontCost !== null ? output.UpfrontCost : undefined,
+    MaximumNormalizedUnitsUsedPerHour: __expectString(output.MaximumNormalizedUnitsUsedPerHour),
+    MaximumNumberOfInstancesUsedPerHour: __expectString(output.MaximumNumberOfInstancesUsedPerHour),
+    MinimumNormalizedUnitsUsedPerHour: __expectString(output.MinimumNormalizedUnitsUsedPerHour),
+    MinimumNumberOfInstancesUsedPerHour: __expectString(output.MinimumNumberOfInstancesUsedPerHour),
+    RecommendedNormalizedUnitsToPurchase: __expectString(output.RecommendedNormalizedUnitsToPurchase),
+    RecommendedNumberOfInstancesToPurchase: __expectString(output.RecommendedNumberOfInstancesToPurchase),
+    RecurringStandardMonthlyCost: __expectString(output.RecurringStandardMonthlyCost),
+    UpfrontCost: __expectString(output.UpfrontCost),
   } as any;
 };
 
@@ -5129,12 +4895,8 @@ const deserializeAws_json1_1ReservationPurchaseRecommendationMetadata = (
   context: __SerdeContext
 ): ReservationPurchaseRecommendationMetadata => {
   return {
-    GenerationTimestamp:
-      output.GenerationTimestamp !== undefined && output.GenerationTimestamp !== null
-        ? output.GenerationTimestamp
-        : undefined,
-    RecommendationId:
-      output.RecommendationId !== undefined && output.RecommendationId !== null ? output.RecommendationId : undefined,
+    GenerationTimestamp: __expectString(output.GenerationTimestamp),
+    RecommendationId: __expectString(output.RecommendationId),
   } as any;
 };
 
@@ -5157,16 +4919,9 @@ const deserializeAws_json1_1ReservationPurchaseRecommendationSummary = (
   context: __SerdeContext
 ): ReservationPurchaseRecommendationSummary => {
   return {
-    CurrencyCode: output.CurrencyCode !== undefined && output.CurrencyCode !== null ? output.CurrencyCode : undefined,
-    TotalEstimatedMonthlySavingsAmount:
-      output.TotalEstimatedMonthlySavingsAmount !== undefined && output.TotalEstimatedMonthlySavingsAmount !== null
-        ? output.TotalEstimatedMonthlySavingsAmount
-        : undefined,
-    TotalEstimatedMonthlySavingsPercentage:
-      output.TotalEstimatedMonthlySavingsPercentage !== undefined &&
-      output.TotalEstimatedMonthlySavingsPercentage !== null
-        ? output.TotalEstimatedMonthlySavingsPercentage
-        : undefined,
+    CurrencyCode: __expectString(output.CurrencyCode),
+    TotalEstimatedMonthlySavingsAmount: __expectString(output.TotalEstimatedMonthlySavingsAmount),
+    TotalEstimatedMonthlySavingsPercentage: __expectString(output.TotalEstimatedMonthlySavingsPercentage),
   } as any;
 };
 
@@ -5179,12 +4934,12 @@ const deserializeAws_json1_1ReservationUtilizationGroup = (
       output.Attributes !== undefined && output.Attributes !== null
         ? deserializeAws_json1_1Attributes(output.Attributes, context)
         : undefined,
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
+    Key: __expectString(output.Key),
     Utilization:
       output.Utilization !== undefined && output.Utilization !== null
         ? deserializeAws_json1_1ReservationAggregates(output.Utilization, context)
         : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -5216,7 +4971,7 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -5231,7 +4986,7 @@ const deserializeAws_json1_1ResourceUtilization = (output: any, context: __Serde
 
 const deserializeAws_json1_1ResultByTime = (output: any, context: __SerdeContext): ResultByTime => {
   return {
-    Estimated: output.Estimated !== undefined && output.Estimated !== null ? output.Estimated : undefined,
+    Estimated: __expectBoolean(output.Estimated),
     Groups:
       output.Groups !== undefined && output.Groups !== null
         ? deserializeAws_json1_1Groups(output.Groups, context)
@@ -5263,7 +5018,7 @@ const deserializeAws_json1_1RightsizingRecommendation = (
   context: __SerdeContext
 ): RightsizingRecommendation => {
   return {
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
+    AccountId: __expectString(output.AccountId),
     CurrentInstance:
       output.CurrentInstance !== undefined && output.CurrentInstance !== null
         ? deserializeAws_json1_1CurrentInstance(output.CurrentInstance, context)
@@ -5276,8 +5031,7 @@ const deserializeAws_json1_1RightsizingRecommendation = (
       output.ModifyRecommendationDetail !== undefined && output.ModifyRecommendationDetail !== null
         ? deserializeAws_json1_1ModifyRecommendationDetail(output.ModifyRecommendationDetail, context)
         : undefined,
-    RightsizingType:
-      output.RightsizingType !== undefined && output.RightsizingType !== null ? output.RightsizingType : undefined,
+    RightsizingType: __expectString(output.RightsizingType),
     TerminateRecommendationDetail:
       output.TerminateRecommendationDetail !== undefined && output.TerminateRecommendationDetail !== null
         ? deserializeAws_json1_1TerminateRecommendationDetail(output.TerminateRecommendationDetail, context)
@@ -5290,14 +5044,8 @@ const deserializeAws_json1_1RightsizingRecommendationConfiguration = (
   context: __SerdeContext
 ): RightsizingRecommendationConfiguration => {
   return {
-    BenefitsConsidered:
-      output.BenefitsConsidered !== undefined && output.BenefitsConsidered !== null
-        ? output.BenefitsConsidered
-        : undefined,
-    RecommendationTarget:
-      output.RecommendationTarget !== undefined && output.RecommendationTarget !== null
-        ? output.RecommendationTarget
-        : undefined,
+    BenefitsConsidered: __expectBoolean(output.BenefitsConsidered),
+    RecommendationTarget: __expectString(output.RecommendationTarget),
   } as any;
 };
 
@@ -5320,20 +5068,10 @@ const deserializeAws_json1_1RightsizingRecommendationMetadata = (
   context: __SerdeContext
 ): RightsizingRecommendationMetadata => {
   return {
-    AdditionalMetadata:
-      output.AdditionalMetadata !== undefined && output.AdditionalMetadata !== null
-        ? output.AdditionalMetadata
-        : undefined,
-    GenerationTimestamp:
-      output.GenerationTimestamp !== undefined && output.GenerationTimestamp !== null
-        ? output.GenerationTimestamp
-        : undefined,
-    LookbackPeriodInDays:
-      output.LookbackPeriodInDays !== undefined && output.LookbackPeriodInDays !== null
-        ? output.LookbackPeriodInDays
-        : undefined,
-    RecommendationId:
-      output.RecommendationId !== undefined && output.RecommendationId !== null ? output.RecommendationId : undefined,
+    AdditionalMetadata: __expectString(output.AdditionalMetadata),
+    GenerationTimestamp: __expectString(output.GenerationTimestamp),
+    LookbackPeriodInDays: __expectString(output.LookbackPeriodInDays),
+    RecommendationId: __expectString(output.RecommendationId),
   } as any;
 };
 
@@ -5342,32 +5080,19 @@ const deserializeAws_json1_1RightsizingRecommendationSummary = (
   context: __SerdeContext
 ): RightsizingRecommendationSummary => {
   return {
-    EstimatedTotalMonthlySavingsAmount:
-      output.EstimatedTotalMonthlySavingsAmount !== undefined && output.EstimatedTotalMonthlySavingsAmount !== null
-        ? output.EstimatedTotalMonthlySavingsAmount
-        : undefined,
-    SavingsCurrencyCode:
-      output.SavingsCurrencyCode !== undefined && output.SavingsCurrencyCode !== null
-        ? output.SavingsCurrencyCode
-        : undefined,
-    SavingsPercentage:
-      output.SavingsPercentage !== undefined && output.SavingsPercentage !== null
-        ? output.SavingsPercentage
-        : undefined,
-    TotalRecommendationCount:
-      output.TotalRecommendationCount !== undefined && output.TotalRecommendationCount !== null
-        ? output.TotalRecommendationCount
-        : undefined,
+    EstimatedTotalMonthlySavingsAmount: __expectString(output.EstimatedTotalMonthlySavingsAmount),
+    SavingsCurrencyCode: __expectString(output.SavingsCurrencyCode),
+    SavingsPercentage: __expectString(output.SavingsPercentage),
+    TotalRecommendationCount: __expectString(output.TotalRecommendationCount),
   } as any;
 };
 
 const deserializeAws_json1_1RootCause = (output: any, context: __SerdeContext): RootCause => {
   return {
-    LinkedAccount:
-      output.LinkedAccount !== undefined && output.LinkedAccount !== null ? output.LinkedAccount : undefined,
-    Region: output.Region !== undefined && output.Region !== null ? output.Region : undefined,
-    Service: output.Service !== undefined && output.Service !== null ? output.Service : undefined,
-    UsageType: output.UsageType !== undefined && output.UsageType !== null ? output.UsageType : undefined,
+    LinkedAccount: __expectString(output.LinkedAccount),
+    Region: __expectString(output.Region),
+    Service: __expectString(output.Service),
+    UsageType: __expectString(output.UsageType),
   } as any;
 };
 
@@ -5387,18 +5112,9 @@ const deserializeAws_json1_1SavingsPlansAmortizedCommitment = (
   context: __SerdeContext
 ): SavingsPlansAmortizedCommitment => {
   return {
-    AmortizedRecurringCommitment:
-      output.AmortizedRecurringCommitment !== undefined && output.AmortizedRecurringCommitment !== null
-        ? output.AmortizedRecurringCommitment
-        : undefined,
-    AmortizedUpfrontCommitment:
-      output.AmortizedUpfrontCommitment !== undefined && output.AmortizedUpfrontCommitment !== null
-        ? output.AmortizedUpfrontCommitment
-        : undefined,
-    TotalAmortizedCommitment:
-      output.TotalAmortizedCommitment !== undefined && output.TotalAmortizedCommitment !== null
-        ? output.TotalAmortizedCommitment
-        : undefined,
+    AmortizedRecurringCommitment: __expectString(output.AmortizedRecurringCommitment),
+    AmortizedUpfrontCommitment: __expectString(output.AmortizedUpfrontCommitment),
+    TotalAmortizedCommitment: __expectString(output.TotalAmortizedCommitment),
   } as any;
 };
 
@@ -5424,16 +5140,10 @@ const deserializeAws_json1_1SavingsPlansCoverageData = (
   context: __SerdeContext
 ): SavingsPlansCoverageData => {
   return {
-    CoveragePercentage:
-      output.CoveragePercentage !== undefined && output.CoveragePercentage !== null
-        ? output.CoveragePercentage
-        : undefined,
-    OnDemandCost: output.OnDemandCost !== undefined && output.OnDemandCost !== null ? output.OnDemandCost : undefined,
-    SpendCoveredBySavingsPlans:
-      output.SpendCoveredBySavingsPlans !== undefined && output.SpendCoveredBySavingsPlans !== null
-        ? output.SpendCoveredBySavingsPlans
-        : undefined,
-    TotalCost: output.TotalCost !== undefined && output.TotalCost !== null ? output.TotalCost : undefined,
+    CoveragePercentage: __expectString(output.CoveragePercentage),
+    OnDemandCost: __expectString(output.OnDemandCost),
+    SpendCoveredBySavingsPlans: __expectString(output.SpendCoveredBySavingsPlans),
+    TotalCost: __expectString(output.TotalCost),
   } as any;
 };
 
@@ -5450,10 +5160,9 @@ const deserializeAws_json1_1SavingsPlansCoverages = (output: any, context: __Ser
 
 const deserializeAws_json1_1SavingsPlansDetails = (output: any, context: __SerdeContext): SavingsPlansDetails => {
   return {
-    InstanceFamily:
-      output.InstanceFamily !== undefined && output.InstanceFamily !== null ? output.InstanceFamily : undefined,
-    OfferingId: output.OfferingId !== undefined && output.OfferingId !== null ? output.OfferingId : undefined,
-    Region: output.Region !== undefined && output.Region !== null ? output.Region : undefined,
+    InstanceFamily: __expectString(output.InstanceFamily),
+    OfferingId: __expectString(output.OfferingId),
+    Region: __expectString(output.Region),
   } as any;
 };
 
@@ -5462,13 +5171,9 @@ const deserializeAws_json1_1SavingsPlansPurchaseRecommendation = (
   context: __SerdeContext
 ): SavingsPlansPurchaseRecommendation => {
   return {
-    AccountScope: output.AccountScope !== undefined && output.AccountScope !== null ? output.AccountScope : undefined,
-    LookbackPeriodInDays:
-      output.LookbackPeriodInDays !== undefined && output.LookbackPeriodInDays !== null
-        ? output.LookbackPeriodInDays
-        : undefined,
-    PaymentOption:
-      output.PaymentOption !== undefined && output.PaymentOption !== null ? output.PaymentOption : undefined,
+    AccountScope: __expectString(output.AccountScope),
+    LookbackPeriodInDays: __expectString(output.LookbackPeriodInDays),
+    PaymentOption: __expectString(output.PaymentOption),
     SavingsPlansPurchaseRecommendationDetails:
       output.SavingsPlansPurchaseRecommendationDetails !== undefined &&
       output.SavingsPlansPurchaseRecommendationDetails !== null
@@ -5485,9 +5190,8 @@ const deserializeAws_json1_1SavingsPlansPurchaseRecommendation = (
             context
           )
         : undefined,
-    SavingsPlansType:
-      output.SavingsPlansType !== undefined && output.SavingsPlansType !== null ? output.SavingsPlansType : undefined,
-    TermInYears: output.TermInYears !== undefined && output.TermInYears !== null ? output.TermInYears : undefined,
+    SavingsPlansType: __expectString(output.SavingsPlansType),
+    TermInYears: __expectString(output.TermInYears),
   } as any;
 };
 
@@ -5496,57 +5200,25 @@ const deserializeAws_json1_1SavingsPlansPurchaseRecommendationDetail = (
   context: __SerdeContext
 ): SavingsPlansPurchaseRecommendationDetail => {
   return {
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
-    CurrencyCode: output.CurrencyCode !== undefined && output.CurrencyCode !== null ? output.CurrencyCode : undefined,
-    CurrentAverageHourlyOnDemandSpend:
-      output.CurrentAverageHourlyOnDemandSpend !== undefined && output.CurrentAverageHourlyOnDemandSpend !== null
-        ? output.CurrentAverageHourlyOnDemandSpend
-        : undefined,
-    CurrentMaximumHourlyOnDemandSpend:
-      output.CurrentMaximumHourlyOnDemandSpend !== undefined && output.CurrentMaximumHourlyOnDemandSpend !== null
-        ? output.CurrentMaximumHourlyOnDemandSpend
-        : undefined,
-    CurrentMinimumHourlyOnDemandSpend:
-      output.CurrentMinimumHourlyOnDemandSpend !== undefined && output.CurrentMinimumHourlyOnDemandSpend !== null
-        ? output.CurrentMinimumHourlyOnDemandSpend
-        : undefined,
-    EstimatedAverageUtilization:
-      output.EstimatedAverageUtilization !== undefined && output.EstimatedAverageUtilization !== null
-        ? output.EstimatedAverageUtilization
-        : undefined,
-    EstimatedMonthlySavingsAmount:
-      output.EstimatedMonthlySavingsAmount !== undefined && output.EstimatedMonthlySavingsAmount !== null
-        ? output.EstimatedMonthlySavingsAmount
-        : undefined,
-    EstimatedOnDemandCost:
-      output.EstimatedOnDemandCost !== undefined && output.EstimatedOnDemandCost !== null
-        ? output.EstimatedOnDemandCost
-        : undefined,
-    EstimatedOnDemandCostWithCurrentCommitment:
-      output.EstimatedOnDemandCostWithCurrentCommitment !== undefined &&
-      output.EstimatedOnDemandCostWithCurrentCommitment !== null
-        ? output.EstimatedOnDemandCostWithCurrentCommitment
-        : undefined,
-    EstimatedROI: output.EstimatedROI !== undefined && output.EstimatedROI !== null ? output.EstimatedROI : undefined,
-    EstimatedSPCost:
-      output.EstimatedSPCost !== undefined && output.EstimatedSPCost !== null ? output.EstimatedSPCost : undefined,
-    EstimatedSavingsAmount:
-      output.EstimatedSavingsAmount !== undefined && output.EstimatedSavingsAmount !== null
-        ? output.EstimatedSavingsAmount
-        : undefined,
-    EstimatedSavingsPercentage:
-      output.EstimatedSavingsPercentage !== undefined && output.EstimatedSavingsPercentage !== null
-        ? output.EstimatedSavingsPercentage
-        : undefined,
-    HourlyCommitmentToPurchase:
-      output.HourlyCommitmentToPurchase !== undefined && output.HourlyCommitmentToPurchase !== null
-        ? output.HourlyCommitmentToPurchase
-        : undefined,
+    AccountId: __expectString(output.AccountId),
+    CurrencyCode: __expectString(output.CurrencyCode),
+    CurrentAverageHourlyOnDemandSpend: __expectString(output.CurrentAverageHourlyOnDemandSpend),
+    CurrentMaximumHourlyOnDemandSpend: __expectString(output.CurrentMaximumHourlyOnDemandSpend),
+    CurrentMinimumHourlyOnDemandSpend: __expectString(output.CurrentMinimumHourlyOnDemandSpend),
+    EstimatedAverageUtilization: __expectString(output.EstimatedAverageUtilization),
+    EstimatedMonthlySavingsAmount: __expectString(output.EstimatedMonthlySavingsAmount),
+    EstimatedOnDemandCost: __expectString(output.EstimatedOnDemandCost),
+    EstimatedOnDemandCostWithCurrentCommitment: __expectString(output.EstimatedOnDemandCostWithCurrentCommitment),
+    EstimatedROI: __expectString(output.EstimatedROI),
+    EstimatedSPCost: __expectString(output.EstimatedSPCost),
+    EstimatedSavingsAmount: __expectString(output.EstimatedSavingsAmount),
+    EstimatedSavingsPercentage: __expectString(output.EstimatedSavingsPercentage),
+    HourlyCommitmentToPurchase: __expectString(output.HourlyCommitmentToPurchase),
     SavingsPlansDetails:
       output.SavingsPlansDetails !== undefined && output.SavingsPlansDetails !== null
         ? deserializeAws_json1_1SavingsPlansDetails(output.SavingsPlansDetails, context)
         : undefined,
-    UpfrontCost: output.UpfrontCost !== undefined && output.UpfrontCost !== null ? output.UpfrontCost : undefined,
+    UpfrontCost: __expectString(output.UpfrontCost),
   } as any;
 };
 
@@ -5569,16 +5241,9 @@ const deserializeAws_json1_1SavingsPlansPurchaseRecommendationMetadata = (
   context: __SerdeContext
 ): SavingsPlansPurchaseRecommendationMetadata => {
   return {
-    AdditionalMetadata:
-      output.AdditionalMetadata !== undefined && output.AdditionalMetadata !== null
-        ? output.AdditionalMetadata
-        : undefined,
-    GenerationTimestamp:
-      output.GenerationTimestamp !== undefined && output.GenerationTimestamp !== null
-        ? output.GenerationTimestamp
-        : undefined,
-    RecommendationId:
-      output.RecommendationId !== undefined && output.RecommendationId !== null ? output.RecommendationId : undefined,
+    AdditionalMetadata: __expectString(output.AdditionalMetadata),
+    GenerationTimestamp: __expectString(output.GenerationTimestamp),
+    RecommendationId: __expectString(output.RecommendationId),
   } as any;
 };
 
@@ -5587,55 +5252,24 @@ const deserializeAws_json1_1SavingsPlansPurchaseRecommendationSummary = (
   context: __SerdeContext
 ): SavingsPlansPurchaseRecommendationSummary => {
   return {
-    CurrencyCode: output.CurrencyCode !== undefined && output.CurrencyCode !== null ? output.CurrencyCode : undefined,
-    CurrentOnDemandSpend:
-      output.CurrentOnDemandSpend !== undefined && output.CurrentOnDemandSpend !== null
-        ? output.CurrentOnDemandSpend
-        : undefined,
-    DailyCommitmentToPurchase:
-      output.DailyCommitmentToPurchase !== undefined && output.DailyCommitmentToPurchase !== null
-        ? output.DailyCommitmentToPurchase
-        : undefined,
-    EstimatedMonthlySavingsAmount:
-      output.EstimatedMonthlySavingsAmount !== undefined && output.EstimatedMonthlySavingsAmount !== null
-        ? output.EstimatedMonthlySavingsAmount
-        : undefined,
-    EstimatedOnDemandCostWithCurrentCommitment:
-      output.EstimatedOnDemandCostWithCurrentCommitment !== undefined &&
-      output.EstimatedOnDemandCostWithCurrentCommitment !== null
-        ? output.EstimatedOnDemandCostWithCurrentCommitment
-        : undefined,
-    EstimatedROI: output.EstimatedROI !== undefined && output.EstimatedROI !== null ? output.EstimatedROI : undefined,
-    EstimatedSavingsAmount:
-      output.EstimatedSavingsAmount !== undefined && output.EstimatedSavingsAmount !== null
-        ? output.EstimatedSavingsAmount
-        : undefined,
-    EstimatedSavingsPercentage:
-      output.EstimatedSavingsPercentage !== undefined && output.EstimatedSavingsPercentage !== null
-        ? output.EstimatedSavingsPercentage
-        : undefined,
-    EstimatedTotalCost:
-      output.EstimatedTotalCost !== undefined && output.EstimatedTotalCost !== null
-        ? output.EstimatedTotalCost
-        : undefined,
-    HourlyCommitmentToPurchase:
-      output.HourlyCommitmentToPurchase !== undefined && output.HourlyCommitmentToPurchase !== null
-        ? output.HourlyCommitmentToPurchase
-        : undefined,
-    TotalRecommendationCount:
-      output.TotalRecommendationCount !== undefined && output.TotalRecommendationCount !== null
-        ? output.TotalRecommendationCount
-        : undefined,
+    CurrencyCode: __expectString(output.CurrencyCode),
+    CurrentOnDemandSpend: __expectString(output.CurrentOnDemandSpend),
+    DailyCommitmentToPurchase: __expectString(output.DailyCommitmentToPurchase),
+    EstimatedMonthlySavingsAmount: __expectString(output.EstimatedMonthlySavingsAmount),
+    EstimatedOnDemandCostWithCurrentCommitment: __expectString(output.EstimatedOnDemandCostWithCurrentCommitment),
+    EstimatedROI: __expectString(output.EstimatedROI),
+    EstimatedSavingsAmount: __expectString(output.EstimatedSavingsAmount),
+    EstimatedSavingsPercentage: __expectString(output.EstimatedSavingsPercentage),
+    EstimatedTotalCost: __expectString(output.EstimatedTotalCost),
+    HourlyCommitmentToPurchase: __expectString(output.HourlyCommitmentToPurchase),
+    TotalRecommendationCount: __expectString(output.TotalRecommendationCount),
   } as any;
 };
 
 const deserializeAws_json1_1SavingsPlansSavings = (output: any, context: __SerdeContext): SavingsPlansSavings => {
   return {
-    NetSavings: output.NetSavings !== undefined && output.NetSavings !== null ? output.NetSavings : undefined,
-    OnDemandCostEquivalent:
-      output.OnDemandCostEquivalent !== undefined && output.OnDemandCostEquivalent !== null
-        ? output.OnDemandCostEquivalent
-        : undefined,
+    NetSavings: __expectString(output.NetSavings),
+    OnDemandCostEquivalent: __expectString(output.OnDemandCostEquivalent),
   } as any;
 };
 
@@ -5644,16 +5278,10 @@ const deserializeAws_json1_1SavingsPlansUtilization = (
   context: __SerdeContext
 ): SavingsPlansUtilization => {
   return {
-    TotalCommitment:
-      output.TotalCommitment !== undefined && output.TotalCommitment !== null ? output.TotalCommitment : undefined,
-    UnusedCommitment:
-      output.UnusedCommitment !== undefined && output.UnusedCommitment !== null ? output.UnusedCommitment : undefined,
-    UsedCommitment:
-      output.UsedCommitment !== undefined && output.UsedCommitment !== null ? output.UsedCommitment : undefined,
-    UtilizationPercentage:
-      output.UtilizationPercentage !== undefined && output.UtilizationPercentage !== null
-        ? output.UtilizationPercentage
-        : undefined,
+    TotalCommitment: __expectString(output.TotalCommitment),
+    UnusedCommitment: __expectString(output.UnusedCommitment),
+    UsedCommitment: __expectString(output.UsedCommitment),
+    UtilizationPercentage: __expectString(output.UtilizationPercentage),
   } as any;
 };
 
@@ -5718,8 +5346,7 @@ const deserializeAws_json1_1SavingsPlansUtilizationDetail = (
       output.Savings !== undefined && output.Savings !== null
         ? deserializeAws_json1_1SavingsPlansSavings(output.Savings, context)
         : undefined,
-    SavingsPlanArn:
-      output.SavingsPlanArn !== undefined && output.SavingsPlanArn !== null ? output.SavingsPlanArn : undefined,
+    SavingsPlanArn: __expectString(output.SavingsPlanArn),
     Utilization:
       output.Utilization !== undefined && output.Utilization !== null
         ? deserializeAws_json1_1SavingsPlansUtilization(output.Utilization, context)
@@ -5760,7 +5387,7 @@ const deserializeAws_json1_1ServiceQuotaExceededException = (
   context: __SerdeContext
 ): ServiceQuotaExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -5775,9 +5402,9 @@ const deserializeAws_json1_1ServiceSpecification = (output: any, context: __Serd
 
 const deserializeAws_json1_1Subscriber = (output: any, context: __SerdeContext): Subscriber => {
   return {
-    Address: output.Address !== undefined && output.Address !== null ? output.Address : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Address: __expectString(output.Address),
+    Status: __expectString(output.Status),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -5799,13 +5426,13 @@ const deserializeAws_json1_1TagList = (output: any, context: __SerdeContext): st
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1TagValues = (output: any, context: __SerdeContext): TagValues => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
+    Key: __expectString(output.Key),
     MatchOptions:
       output.MatchOptions !== undefined && output.MatchOptions !== null
         ? deserializeAws_json1_1MatchOptions(output.MatchOptions, context)
@@ -5830,19 +5457,10 @@ const deserializeAws_json1_1TagValuesList = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1TargetInstance = (output: any, context: __SerdeContext): TargetInstance => {
   return {
-    CurrencyCode: output.CurrencyCode !== undefined && output.CurrencyCode !== null ? output.CurrencyCode : undefined,
-    DefaultTargetInstance:
-      output.DefaultTargetInstance !== undefined && output.DefaultTargetInstance !== null
-        ? output.DefaultTargetInstance
-        : undefined,
-    EstimatedMonthlyCost:
-      output.EstimatedMonthlyCost !== undefined && output.EstimatedMonthlyCost !== null
-        ? output.EstimatedMonthlyCost
-        : undefined,
-    EstimatedMonthlySavings:
-      output.EstimatedMonthlySavings !== undefined && output.EstimatedMonthlySavings !== null
-        ? output.EstimatedMonthlySavings
-        : undefined,
+    CurrencyCode: __expectString(output.CurrencyCode),
+    DefaultTargetInstance: __expectBoolean(output.DefaultTargetInstance),
+    EstimatedMonthlyCost: __expectString(output.EstimatedMonthlyCost),
+    EstimatedMonthlySavings: __expectString(output.EstimatedMonthlySavings),
     ExpectedResourceUtilization:
       output.ExpectedResourceUtilization !== undefined && output.ExpectedResourceUtilization !== null
         ? deserializeAws_json1_1ResourceUtilization(output.ExpectedResourceUtilization, context)
@@ -5874,11 +5492,8 @@ const deserializeAws_json1_1TerminateRecommendationDetail = (
   context: __SerdeContext
 ): TerminateRecommendationDetail => {
   return {
-    CurrencyCode: output.CurrencyCode !== undefined && output.CurrencyCode !== null ? output.CurrencyCode : undefined,
-    EstimatedMonthlySavings:
-      output.EstimatedMonthlySavings !== undefined && output.EstimatedMonthlySavings !== null
-        ? output.EstimatedMonthlySavings
-        : undefined,
+    CurrencyCode: __expectString(output.CurrencyCode),
+    EstimatedMonthlySavings: __expectString(output.EstimatedMonthlySavings),
   } as any;
 };
 
@@ -5887,7 +5502,7 @@ const deserializeAws_json1_1UnknownMonitorException = (
   context: __SerdeContext
 ): UnknownMonitorException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -5896,7 +5511,7 @@ const deserializeAws_json1_1UnknownSubscriptionException = (
   context: __SerdeContext
 ): UnknownSubscriptionException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -5905,7 +5520,7 @@ const deserializeAws_json1_1UnresolvableUsageUnitException = (
   context: __SerdeContext
 ): UnresolvableUsageUnitException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -5914,7 +5529,7 @@ const deserializeAws_json1_1UpdateAnomalyMonitorResponse = (
   context: __SerdeContext
 ): UpdateAnomalyMonitorResponse => {
   return {
-    MonitorArn: output.MonitorArn !== undefined && output.MonitorArn !== null ? output.MonitorArn : undefined,
+    MonitorArn: __expectString(output.MonitorArn),
   } as any;
 };
 
@@ -5923,8 +5538,7 @@ const deserializeAws_json1_1UpdateAnomalySubscriptionResponse = (
   context: __SerdeContext
 ): UpdateAnomalySubscriptionResponse => {
   return {
-    SubscriptionArn:
-      output.SubscriptionArn !== undefined && output.SubscriptionArn !== null ? output.SubscriptionArn : undefined,
+    SubscriptionArn: __expectString(output.SubscriptionArn),
   } as any;
 };
 
@@ -5933,10 +5547,8 @@ const deserializeAws_json1_1UpdateCostCategoryDefinitionResponse = (
   context: __SerdeContext
 ): UpdateCostCategoryDefinitionResponse => {
   return {
-    CostCategoryArn:
-      output.CostCategoryArn !== undefined && output.CostCategoryArn !== null ? output.CostCategoryArn : undefined,
-    EffectiveStart:
-      output.EffectiveStart !== undefined && output.EffectiveStart !== null ? output.EffectiveStart : undefined,
+    CostCategoryArn: __expectString(output.CostCategoryArn),
+    EffectiveStart: __expectString(output.EffectiveStart),
   } as any;
 };
 
@@ -5975,7 +5587,7 @@ const deserializeAws_json1_1Values = (output: any, context: __SerdeContext): str
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 

--- a/clients/client-customer-profiles/protocols/Aws_restJson1.ts
+++ b/clients/client-customer-profiles/protocols/Aws_restJson1.ts
@@ -96,6 +96,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -1225,7 +1228,7 @@ export const deserializeAws_restJson1AddProfileKeyCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.KeyName !== undefined && data.KeyName !== null) {
-    contents.KeyName = data.KeyName;
+    contents.KeyName = __expectString(data.KeyName);
   }
   if (data.Values !== undefined && data.Values !== null) {
     contents.Values = deserializeAws_restJson1requestValueList(data.Values, context);
@@ -1325,16 +1328,16 @@ export const deserializeAws_restJson1CreateDomainCommand = async (
     contents.CreatedAt = new Date(Math.round(data.CreatedAt * 1000));
   }
   if (data.DeadLetterQueueUrl !== undefined && data.DeadLetterQueueUrl !== null) {
-    contents.DeadLetterQueueUrl = data.DeadLetterQueueUrl;
+    contents.DeadLetterQueueUrl = __expectString(data.DeadLetterQueueUrl);
   }
   if (data.DefaultEncryptionKey !== undefined && data.DefaultEncryptionKey !== null) {
-    contents.DefaultEncryptionKey = data.DefaultEncryptionKey;
+    contents.DefaultEncryptionKey = __expectString(data.DefaultEncryptionKey);
   }
   if (data.DefaultExpirationDays !== undefined && data.DefaultExpirationDays !== null) {
-    contents.DefaultExpirationDays = data.DefaultExpirationDays;
+    contents.DefaultExpirationDays = __expectNumber(data.DefaultExpirationDays);
   }
   if (data.DomainName !== undefined && data.DomainName !== null) {
-    contents.DomainName = data.DomainName;
+    contents.DomainName = __expectString(data.DomainName);
   }
   if (data.LastUpdatedAt !== undefined && data.LastUpdatedAt !== null) {
     contents.LastUpdatedAt = new Date(Math.round(data.LastUpdatedAt * 1000));
@@ -1430,7 +1433,7 @@ export const deserializeAws_restJson1CreateProfileCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ProfileId !== undefined && data.ProfileId !== null) {
-    contents.ProfileId = data.ProfileId;
+    contents.ProfileId = __expectString(data.ProfileId);
   }
   return Promise.resolve(contents);
 };
@@ -1517,7 +1520,7 @@ export const deserializeAws_restJson1DeleteDomainCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return Promise.resolve(contents);
 };
@@ -1604,7 +1607,7 @@ export const deserializeAws_restJson1DeleteIntegrationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return Promise.resolve(contents);
 };
@@ -1691,7 +1694,7 @@ export const deserializeAws_restJson1DeleteProfileCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return Promise.resolve(contents);
 };
@@ -1778,7 +1781,7 @@ export const deserializeAws_restJson1DeleteProfileKeyCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return Promise.resolve(contents);
 };
@@ -1865,7 +1868,7 @@ export const deserializeAws_restJson1DeleteProfileObjectCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return Promise.resolve(contents);
 };
@@ -1952,7 +1955,7 @@ export const deserializeAws_restJson1DeleteProfileObjectTypeCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return Promise.resolve(contents);
 };
@@ -2050,16 +2053,16 @@ export const deserializeAws_restJson1GetDomainCommand = async (
     contents.CreatedAt = new Date(Math.round(data.CreatedAt * 1000));
   }
   if (data.DeadLetterQueueUrl !== undefined && data.DeadLetterQueueUrl !== null) {
-    contents.DeadLetterQueueUrl = data.DeadLetterQueueUrl;
+    contents.DeadLetterQueueUrl = __expectString(data.DeadLetterQueueUrl);
   }
   if (data.DefaultEncryptionKey !== undefined && data.DefaultEncryptionKey !== null) {
-    contents.DefaultEncryptionKey = data.DefaultEncryptionKey;
+    contents.DefaultEncryptionKey = __expectString(data.DefaultEncryptionKey);
   }
   if (data.DefaultExpirationDays !== undefined && data.DefaultExpirationDays !== null) {
-    contents.DefaultExpirationDays = data.DefaultExpirationDays;
+    contents.DefaultExpirationDays = __expectNumber(data.DefaultExpirationDays);
   }
   if (data.DomainName !== undefined && data.DomainName !== null) {
-    contents.DomainName = data.DomainName;
+    contents.DomainName = __expectString(data.DomainName);
   }
   if (data.LastUpdatedAt !== undefined && data.LastUpdatedAt !== null) {
     contents.LastUpdatedAt = new Date(Math.round(data.LastUpdatedAt * 1000));
@@ -2166,19 +2169,19 @@ export const deserializeAws_restJson1GetIntegrationCommand = async (
     contents.CreatedAt = new Date(Math.round(data.CreatedAt * 1000));
   }
   if (data.DomainName !== undefined && data.DomainName !== null) {
-    contents.DomainName = data.DomainName;
+    contents.DomainName = __expectString(data.DomainName);
   }
   if (data.LastUpdatedAt !== undefined && data.LastUpdatedAt !== null) {
     contents.LastUpdatedAt = new Date(Math.round(data.LastUpdatedAt * 1000));
   }
   if (data.ObjectTypeName !== undefined && data.ObjectTypeName !== null) {
-    contents.ObjectTypeName = data.ObjectTypeName;
+    contents.ObjectTypeName = __expectString(data.ObjectTypeName);
   }
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }
   if (data.Uri !== undefined && data.Uri !== null) {
-    contents.Uri = data.Uri;
+    contents.Uri = __expectString(data.Uri);
   }
   return Promise.resolve(contents);
 };
@@ -2274,10 +2277,10 @@ export const deserializeAws_restJson1GetMatchesCommand = async (
     contents.Matches = deserializeAws_restJson1MatchesList(data.Matches, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.PotentialMatches !== undefined && data.PotentialMatches !== null) {
-    contents.PotentialMatches = data.PotentialMatches;
+    contents.PotentialMatches = __expectNumber(data.PotentialMatches);
   }
   return Promise.resolve(contents);
 };
@@ -2374,19 +2377,19 @@ export const deserializeAws_restJson1GetProfileObjectTypeCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AllowProfileCreation !== undefined && data.AllowProfileCreation !== null) {
-    contents.AllowProfileCreation = data.AllowProfileCreation;
+    contents.AllowProfileCreation = __expectBoolean(data.AllowProfileCreation);
   }
   if (data.CreatedAt !== undefined && data.CreatedAt !== null) {
     contents.CreatedAt = new Date(Math.round(data.CreatedAt * 1000));
   }
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.EncryptionKey !== undefined && data.EncryptionKey !== null) {
-    contents.EncryptionKey = data.EncryptionKey;
+    contents.EncryptionKey = __expectString(data.EncryptionKey);
   }
   if (data.ExpirationDays !== undefined && data.ExpirationDays !== null) {
-    contents.ExpirationDays = data.ExpirationDays;
+    contents.ExpirationDays = __expectNumber(data.ExpirationDays);
   }
   if (data.Fields !== undefined && data.Fields !== null) {
     contents.Fields = deserializeAws_restJson1FieldMap(data.Fields, context);
@@ -2398,13 +2401,13 @@ export const deserializeAws_restJson1GetProfileObjectTypeCommand = async (
     contents.LastUpdatedAt = new Date(Math.round(data.LastUpdatedAt * 1000));
   }
   if (data.ObjectTypeName !== undefined && data.ObjectTypeName !== null) {
-    contents.ObjectTypeName = data.ObjectTypeName;
+    contents.ObjectTypeName = __expectString(data.ObjectTypeName);
   }
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }
   if (data.TemplateId !== undefined && data.TemplateId !== null) {
-    contents.TemplateId = data.TemplateId;
+    contents.TemplateId = __expectString(data.TemplateId);
   }
   return Promise.resolve(contents);
 };
@@ -2496,7 +2499,7 @@ export const deserializeAws_restJson1GetProfileObjectTypeTemplateCommand = async
   };
   const data: any = await parseBody(output.body, context);
   if (data.AllowProfileCreation !== undefined && data.AllowProfileCreation !== null) {
-    contents.AllowProfileCreation = data.AllowProfileCreation;
+    contents.AllowProfileCreation = __expectBoolean(data.AllowProfileCreation);
   }
   if (data.Fields !== undefined && data.Fields !== null) {
     contents.Fields = deserializeAws_restJson1FieldMap(data.Fields, context);
@@ -2505,13 +2508,13 @@ export const deserializeAws_restJson1GetProfileObjectTypeTemplateCommand = async
     contents.Keys = deserializeAws_restJson1KeyMap(data.Keys, context);
   }
   if (data.SourceName !== undefined && data.SourceName !== null) {
-    contents.SourceName = data.SourceName;
+    contents.SourceName = __expectString(data.SourceName);
   }
   if (data.SourceObject !== undefined && data.SourceObject !== null) {
-    contents.SourceObject = data.SourceObject;
+    contents.SourceObject = __expectString(data.SourceObject);
   }
   if (data.TemplateId !== undefined && data.TemplateId !== null) {
-    contents.TemplateId = data.TemplateId;
+    contents.TemplateId = __expectString(data.TemplateId);
   }
   return Promise.resolve(contents);
 };
@@ -2602,7 +2605,7 @@ export const deserializeAws_restJson1ListAccountIntegrationsCommand = async (
     contents.Items = deserializeAws_restJson1IntegrationList(data.Items, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2693,7 +2696,7 @@ export const deserializeAws_restJson1ListDomainsCommand = async (
     contents.Items = deserializeAws_restJson1DomainList(data.Items, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2784,7 +2787,7 @@ export const deserializeAws_restJson1ListIntegrationsCommand = async (
     contents.Items = deserializeAws_restJson1IntegrationList(data.Items, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2875,7 +2878,7 @@ export const deserializeAws_restJson1ListProfileObjectsCommand = async (
     contents.Items = deserializeAws_restJson1ProfileObjectList(data.Items, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2966,7 +2969,7 @@ export const deserializeAws_restJson1ListProfileObjectTypesCommand = async (
     contents.Items = deserializeAws_restJson1ProfileObjectTypeList(data.Items, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3057,7 +3060,7 @@ export const deserializeAws_restJson1ListProfileObjectTypeTemplatesCommand = asy
     contents.Items = deserializeAws_restJson1ProfileObjectTypeTemplateList(data.Items, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3215,7 +3218,7 @@ export const deserializeAws_restJson1MergeProfilesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return Promise.resolve(contents);
 };
@@ -3302,19 +3305,19 @@ export const deserializeAws_restJson1PutIntegrationCommand = async (
     contents.CreatedAt = new Date(Math.round(data.CreatedAt * 1000));
   }
   if (data.DomainName !== undefined && data.DomainName !== null) {
-    contents.DomainName = data.DomainName;
+    contents.DomainName = __expectString(data.DomainName);
   }
   if (data.LastUpdatedAt !== undefined && data.LastUpdatedAt !== null) {
     contents.LastUpdatedAt = new Date(Math.round(data.LastUpdatedAt * 1000));
   }
   if (data.ObjectTypeName !== undefined && data.ObjectTypeName !== null) {
-    contents.ObjectTypeName = data.ObjectTypeName;
+    contents.ObjectTypeName = __expectString(data.ObjectTypeName);
   }
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }
   if (data.Uri !== undefined && data.Uri !== null) {
-    contents.Uri = data.Uri;
+    contents.Uri = __expectString(data.Uri);
   }
   return Promise.resolve(contents);
 };
@@ -3401,7 +3404,7 @@ export const deserializeAws_restJson1PutProfileObjectCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ProfileObjectUniqueKey !== undefined && data.ProfileObjectUniqueKey !== null) {
-    contents.ProfileObjectUniqueKey = data.ProfileObjectUniqueKey;
+    contents.ProfileObjectUniqueKey = __expectString(data.ProfileObjectUniqueKey);
   }
   return Promise.resolve(contents);
 };
@@ -3498,19 +3501,19 @@ export const deserializeAws_restJson1PutProfileObjectTypeCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AllowProfileCreation !== undefined && data.AllowProfileCreation !== null) {
-    contents.AllowProfileCreation = data.AllowProfileCreation;
+    contents.AllowProfileCreation = __expectBoolean(data.AllowProfileCreation);
   }
   if (data.CreatedAt !== undefined && data.CreatedAt !== null) {
     contents.CreatedAt = new Date(Math.round(data.CreatedAt * 1000));
   }
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.EncryptionKey !== undefined && data.EncryptionKey !== null) {
-    contents.EncryptionKey = data.EncryptionKey;
+    contents.EncryptionKey = __expectString(data.EncryptionKey);
   }
   if (data.ExpirationDays !== undefined && data.ExpirationDays !== null) {
-    contents.ExpirationDays = data.ExpirationDays;
+    contents.ExpirationDays = __expectNumber(data.ExpirationDays);
   }
   if (data.Fields !== undefined && data.Fields !== null) {
     contents.Fields = deserializeAws_restJson1FieldMap(data.Fields, context);
@@ -3522,13 +3525,13 @@ export const deserializeAws_restJson1PutProfileObjectTypeCommand = async (
     contents.LastUpdatedAt = new Date(Math.round(data.LastUpdatedAt * 1000));
   }
   if (data.ObjectTypeName !== undefined && data.ObjectTypeName !== null) {
-    contents.ObjectTypeName = data.ObjectTypeName;
+    contents.ObjectTypeName = __expectString(data.ObjectTypeName);
   }
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }
   if (data.TemplateId !== undefined && data.TemplateId !== null) {
-    contents.TemplateId = data.TemplateId;
+    contents.TemplateId = __expectString(data.TemplateId);
   }
   return Promise.resolve(contents);
 };
@@ -3619,7 +3622,7 @@ export const deserializeAws_restJson1SearchProfilesCommand = async (
     contents.Items = deserializeAws_restJson1ProfileList(data.Items, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3850,16 +3853,16 @@ export const deserializeAws_restJson1UpdateDomainCommand = async (
     contents.CreatedAt = new Date(Math.round(data.CreatedAt * 1000));
   }
   if (data.DeadLetterQueueUrl !== undefined && data.DeadLetterQueueUrl !== null) {
-    contents.DeadLetterQueueUrl = data.DeadLetterQueueUrl;
+    contents.DeadLetterQueueUrl = __expectString(data.DeadLetterQueueUrl);
   }
   if (data.DefaultEncryptionKey !== undefined && data.DefaultEncryptionKey !== null) {
-    contents.DefaultEncryptionKey = data.DefaultEncryptionKey;
+    contents.DefaultEncryptionKey = __expectString(data.DefaultEncryptionKey);
   }
   if (data.DefaultExpirationDays !== undefined && data.DefaultExpirationDays !== null) {
-    contents.DefaultExpirationDays = data.DefaultExpirationDays;
+    contents.DefaultExpirationDays = __expectNumber(data.DefaultExpirationDays);
   }
   if (data.DomainName !== undefined && data.DomainName !== null) {
-    contents.DomainName = data.DomainName;
+    contents.DomainName = __expectString(data.DomainName);
   }
   if (data.LastUpdatedAt !== undefined && data.LastUpdatedAt !== null) {
     contents.LastUpdatedAt = new Date(Math.round(data.LastUpdatedAt * 1000));
@@ -3955,7 +3958,7 @@ export const deserializeAws_restJson1UpdateProfileCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ProfileId !== undefined && data.ProfileId !== null) {
-    contents.ProfileId = data.ProfileId;
+    contents.ProfileId = __expectString(data.ProfileId);
   }
   return Promise.resolve(contents);
 };
@@ -4041,7 +4044,7 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -4058,7 +4061,7 @@ const deserializeAws_restJson1BadRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -4075,7 +4078,7 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -4092,7 +4095,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -4109,7 +4112,7 @@ const deserializeAws_restJson1ThrottlingExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -4558,16 +4561,16 @@ const serializeAws_restJson1ZendeskSourceProperties = (
 
 const deserializeAws_restJson1Address = (output: any, context: __SerdeContext): Address => {
   return {
-    Address1: output.Address1 !== undefined && output.Address1 !== null ? output.Address1 : undefined,
-    Address2: output.Address2 !== undefined && output.Address2 !== null ? output.Address2 : undefined,
-    Address3: output.Address3 !== undefined && output.Address3 !== null ? output.Address3 : undefined,
-    Address4: output.Address4 !== undefined && output.Address4 !== null ? output.Address4 : undefined,
-    City: output.City !== undefined && output.City !== null ? output.City : undefined,
-    Country: output.Country !== undefined && output.Country !== null ? output.Country : undefined,
-    County: output.County !== undefined && output.County !== null ? output.County : undefined,
-    PostalCode: output.PostalCode !== undefined && output.PostalCode !== null ? output.PostalCode : undefined,
-    Province: output.Province !== undefined && output.Province !== null ? output.Province : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    Address1: __expectString(output.Address1),
+    Address2: __expectString(output.Address2),
+    Address3: __expectString(output.Address3),
+    Address4: __expectString(output.Address4),
+    City: __expectString(output.City),
+    Country: __expectString(output.Country),
+    County: __expectString(output.County),
+    PostalCode: __expectString(output.PostalCode),
+    Province: __expectString(output.Province),
+    State: __expectString(output.State),
   } as any;
 };
 
@@ -4578,7 +4581,7 @@ const deserializeAws_restJson1Attributes = (output: any, context: __SerdeContext
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -4596,13 +4599,10 @@ const deserializeAws_restJson1DomainList = (output: any, context: __SerdeContext
 
 const deserializeAws_restJson1DomainStats = (output: any, context: __SerdeContext): DomainStats => {
   return {
-    MeteringProfileCount:
-      output.MeteringProfileCount !== undefined && output.MeteringProfileCount !== null
-        ? output.MeteringProfileCount
-        : undefined,
-    ObjectCount: output.ObjectCount !== undefined && output.ObjectCount !== null ? output.ObjectCount : undefined,
-    ProfileCount: output.ProfileCount !== undefined && output.ProfileCount !== null ? output.ProfileCount : undefined,
-    TotalSize: output.TotalSize !== undefined && output.TotalSize !== null ? output.TotalSize : undefined,
+    MeteringProfileCount: __expectNumber(output.MeteringProfileCount),
+    ObjectCount: __expectNumber(output.ObjectCount),
+    ProfileCount: __expectNumber(output.ProfileCount),
+    TotalSize: __expectNumber(output.TotalSize),
   } as any;
 };
 
@@ -4625,7 +4625,7 @@ const deserializeAws_restJson1FieldNameList = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4658,7 +4658,7 @@ const deserializeAws_restJson1ListDomainItem = (output: any, context: __SerdeCon
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    DomainName: output.DomainName !== undefined && output.DomainName !== null ? output.DomainName : undefined,
+    DomainName: __expectString(output.DomainName),
     LastUpdatedAt:
       output.LastUpdatedAt !== undefined && output.LastUpdatedAt !== null
         ? new Date(Math.round(output.LastUpdatedAt * 1000))
@@ -4676,18 +4676,17 @@ const deserializeAws_restJson1ListIntegrationItem = (output: any, context: __Ser
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    DomainName: output.DomainName !== undefined && output.DomainName !== null ? output.DomainName : undefined,
+    DomainName: __expectString(output.DomainName),
     LastUpdatedAt:
       output.LastUpdatedAt !== undefined && output.LastUpdatedAt !== null
         ? new Date(Math.round(output.LastUpdatedAt * 1000))
         : undefined,
-    ObjectTypeName:
-      output.ObjectTypeName !== undefined && output.ObjectTypeName !== null ? output.ObjectTypeName : undefined,
+    ObjectTypeName: __expectString(output.ObjectTypeName),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_restJson1TagMap(output.Tags, context)
         : undefined,
-    Uri: output.Uri !== undefined && output.Uri !== null ? output.Uri : undefined,
+    Uri: __expectString(output.Uri),
   } as any;
 };
 
@@ -4696,13 +4695,9 @@ const deserializeAws_restJson1ListProfileObjectsItem = (
   context: __SerdeContext
 ): ListProfileObjectsItem => {
   return {
-    Object: output.Object !== undefined && output.Object !== null ? output.Object : undefined,
-    ObjectTypeName:
-      output.ObjectTypeName !== undefined && output.ObjectTypeName !== null ? output.ObjectTypeName : undefined,
-    ProfileObjectUniqueKey:
-      output.ProfileObjectUniqueKey !== undefined && output.ProfileObjectUniqueKey !== null
-        ? output.ProfileObjectUniqueKey
-        : undefined,
+    Object: __expectString(output.Object),
+    ObjectTypeName: __expectString(output.ObjectTypeName),
+    ProfileObjectUniqueKey: __expectString(output.ProfileObjectUniqueKey),
   } as any;
 };
 
@@ -4715,13 +4710,12 @@ const deserializeAws_restJson1ListProfileObjectTypeItem = (
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     LastUpdatedAt:
       output.LastUpdatedAt !== undefined && output.LastUpdatedAt !== null
         ? new Date(Math.round(output.LastUpdatedAt * 1000))
         : undefined,
-    ObjectTypeName:
-      output.ObjectTypeName !== undefined && output.ObjectTypeName !== null ? output.ObjectTypeName : undefined,
+    ObjectTypeName: __expectString(output.ObjectTypeName),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_restJson1TagMap(output.Tags, context)
@@ -4734,9 +4728,9 @@ const deserializeAws_restJson1ListProfileObjectTypeTemplateItem = (
   context: __SerdeContext
 ): ListProfileObjectTypeTemplateItem => {
   return {
-    SourceName: output.SourceName !== undefined && output.SourceName !== null ? output.SourceName : undefined,
-    SourceObject: output.SourceObject !== undefined && output.SourceObject !== null ? output.SourceObject : undefined,
-    TemplateId: output.TemplateId !== undefined && output.TemplateId !== null ? output.TemplateId : undefined,
+    SourceName: __expectString(output.SourceName),
+    SourceObject: __expectString(output.SourceObject),
+    TemplateId: __expectString(output.TemplateId),
   } as any;
 };
 
@@ -4753,13 +4747,13 @@ const deserializeAws_restJson1MatchesList = (output: any, context: __SerdeContex
 
 const deserializeAws_restJson1MatchingResponse = (output: any, context: __SerdeContext): MatchingResponse => {
   return {
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
+    Enabled: __expectBoolean(output.Enabled),
   } as any;
 };
 
 const deserializeAws_restJson1MatchItem = (output: any, context: __SerdeContext): MatchItem => {
   return {
-    MatchId: output.MatchId !== undefined && output.MatchId !== null ? output.MatchId : undefined,
+    MatchId: __expectString(output.MatchId),
     ProfileIds:
       output.ProfileIds !== undefined && output.ProfileIds !== null
         ? deserializeAws_restJson1ProfileIdList(output.ProfileIds, context)
@@ -4769,9 +4763,9 @@ const deserializeAws_restJson1MatchItem = (output: any, context: __SerdeContext)
 
 const deserializeAws_restJson1ObjectTypeField = (output: any, context: __SerdeContext): ObjectTypeField => {
   return {
-    ContentType: output.ContentType !== undefined && output.ContentType !== null ? output.ContentType : undefined,
-    Source: output.Source !== undefined && output.Source !== null ? output.Source : undefined,
-    Target: output.Target !== undefined && output.Target !== null ? output.Target : undefined,
+    ContentType: __expectString(output.ContentType),
+    Source: __expectString(output.Source),
+    Target: __expectString(output.Target),
   } as any;
 };
 
@@ -4801,12 +4795,8 @@ const deserializeAws_restJson1ObjectTypeKeyList = (output: any, context: __Serde
 
 const deserializeAws_restJson1Profile = (output: any, context: __SerdeContext): Profile => {
   return {
-    AccountNumber:
-      output.AccountNumber !== undefined && output.AccountNumber !== null ? output.AccountNumber : undefined,
-    AdditionalInformation:
-      output.AdditionalInformation !== undefined && output.AdditionalInformation !== null
-        ? output.AdditionalInformation
-        : undefined,
+    AccountNumber: __expectString(output.AccountNumber),
+    AdditionalInformation: __expectString(output.AdditionalInformation),
     Address:
       output.Address !== undefined && output.Address !== null
         ? deserializeAws_restJson1Address(output.Address, context)
@@ -4819,38 +4809,25 @@ const deserializeAws_restJson1Profile = (output: any, context: __SerdeContext): 
       output.BillingAddress !== undefined && output.BillingAddress !== null
         ? deserializeAws_restJson1Address(output.BillingAddress, context)
         : undefined,
-    BirthDate: output.BirthDate !== undefined && output.BirthDate !== null ? output.BirthDate : undefined,
-    BusinessEmailAddress:
-      output.BusinessEmailAddress !== undefined && output.BusinessEmailAddress !== null
-        ? output.BusinessEmailAddress
-        : undefined,
-    BusinessName: output.BusinessName !== undefined && output.BusinessName !== null ? output.BusinessName : undefined,
-    BusinessPhoneNumber:
-      output.BusinessPhoneNumber !== undefined && output.BusinessPhoneNumber !== null
-        ? output.BusinessPhoneNumber
-        : undefined,
-    EmailAddress: output.EmailAddress !== undefined && output.EmailAddress !== null ? output.EmailAddress : undefined,
-    FirstName: output.FirstName !== undefined && output.FirstName !== null ? output.FirstName : undefined,
-    Gender: output.Gender !== undefined && output.Gender !== null ? output.Gender : undefined,
-    HomePhoneNumber:
-      output.HomePhoneNumber !== undefined && output.HomePhoneNumber !== null ? output.HomePhoneNumber : undefined,
-    LastName: output.LastName !== undefined && output.LastName !== null ? output.LastName : undefined,
+    BirthDate: __expectString(output.BirthDate),
+    BusinessEmailAddress: __expectString(output.BusinessEmailAddress),
+    BusinessName: __expectString(output.BusinessName),
+    BusinessPhoneNumber: __expectString(output.BusinessPhoneNumber),
+    EmailAddress: __expectString(output.EmailAddress),
+    FirstName: __expectString(output.FirstName),
+    Gender: __expectString(output.Gender),
+    HomePhoneNumber: __expectString(output.HomePhoneNumber),
+    LastName: __expectString(output.LastName),
     MailingAddress:
       output.MailingAddress !== undefined && output.MailingAddress !== null
         ? deserializeAws_restJson1Address(output.MailingAddress, context)
         : undefined,
-    MiddleName: output.MiddleName !== undefined && output.MiddleName !== null ? output.MiddleName : undefined,
-    MobilePhoneNumber:
-      output.MobilePhoneNumber !== undefined && output.MobilePhoneNumber !== null
-        ? output.MobilePhoneNumber
-        : undefined,
-    PartyType: output.PartyType !== undefined && output.PartyType !== null ? output.PartyType : undefined,
-    PersonalEmailAddress:
-      output.PersonalEmailAddress !== undefined && output.PersonalEmailAddress !== null
-        ? output.PersonalEmailAddress
-        : undefined,
-    PhoneNumber: output.PhoneNumber !== undefined && output.PhoneNumber !== null ? output.PhoneNumber : undefined,
-    ProfileId: output.ProfileId !== undefined && output.ProfileId !== null ? output.ProfileId : undefined,
+    MiddleName: __expectString(output.MiddleName),
+    MobilePhoneNumber: __expectString(output.MobilePhoneNumber),
+    PartyType: __expectString(output.PartyType),
+    PersonalEmailAddress: __expectString(output.PersonalEmailAddress),
+    PhoneNumber: __expectString(output.PhoneNumber),
+    ProfileId: __expectString(output.ProfileId),
     ShippingAddress:
       output.ShippingAddress !== undefined && output.ShippingAddress !== null
         ? deserializeAws_restJson1Address(output.ShippingAddress, context)
@@ -4865,7 +4842,7 @@ const deserializeAws_restJson1ProfileIdList = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4926,7 +4903,7 @@ const deserializeAws_restJson1requestValueList = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4940,7 +4917,7 @@ const deserializeAws_restJson1StandardIdentifierList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4951,7 +4928,7 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };

--- a/clients/client-data-pipeline/protocols/Aws_json1_1.ts
+++ b/clients/client-data-pipeline/protocols/Aws_json1_1.ts
@@ -88,7 +88,11 @@ import {
   ValidationWarning,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -2236,7 +2240,7 @@ const deserializeAws_json1_1AddTagsOutput = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1CreatePipelineOutput = (output: any, context: __SerdeContext): CreatePipelineOutput => {
   return {
-    pipelineId: output.pipelineId !== undefined && output.pipelineId !== null ? output.pipelineId : undefined,
+    pipelineId: __expectString(output.pipelineId),
   } as any;
 };
 
@@ -2249,9 +2253,8 @@ const deserializeAws_json1_1DeactivatePipelineOutput = (
 
 const deserializeAws_json1_1DescribeObjectsOutput = (output: any, context: __SerdeContext): DescribeObjectsOutput => {
   return {
-    hasMoreResults:
-      output.hasMoreResults !== undefined && output.hasMoreResults !== null ? output.hasMoreResults : undefined,
-    marker: output.marker !== undefined && output.marker !== null ? output.marker : undefined,
+    hasMoreResults: __expectBoolean(output.hasMoreResults),
+    marker: __expectString(output.marker),
     pipelineObjects:
       output.pipelineObjects !== undefined && output.pipelineObjects !== null
         ? deserializeAws_json1_1PipelineObjectList(output.pipelineObjects, context)
@@ -2276,18 +2279,15 @@ const deserializeAws_json1_1EvaluateExpressionOutput = (
   context: __SerdeContext
 ): EvaluateExpressionOutput => {
   return {
-    evaluatedExpression:
-      output.evaluatedExpression !== undefined && output.evaluatedExpression !== null
-        ? output.evaluatedExpression
-        : undefined,
+    evaluatedExpression: __expectString(output.evaluatedExpression),
   } as any;
 };
 
 const deserializeAws_json1_1Field = (output: any, context: __SerdeContext): Field => {
   return {
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
-    refValue: output.refValue !== undefined && output.refValue !== null ? output.refValue : undefined,
-    stringValue: output.stringValue !== undefined && output.stringValue !== null ? output.stringValue : undefined,
+    key: __expectString(output.key),
+    refValue: __expectString(output.refValue),
+    stringValue: __expectString(output.stringValue),
   } as any;
 };
 
@@ -2329,13 +2329,13 @@ const deserializeAws_json1_1idList = (output: any, context: __SerdeContext): str
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1InternalServiceError = (output: any, context: __SerdeContext): InternalServiceError => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -2344,15 +2344,14 @@ const deserializeAws_json1_1InvalidRequestException = (
   context: __SerdeContext
 ): InvalidRequestException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1ListPipelinesOutput = (output: any, context: __SerdeContext): ListPipelinesOutput => {
   return {
-    hasMoreResults:
-      output.hasMoreResults !== undefined && output.hasMoreResults !== null ? output.hasMoreResults : undefined,
-    marker: output.marker !== undefined && output.marker !== null ? output.marker : undefined,
+    hasMoreResults: __expectBoolean(output.hasMoreResults),
+    marker: __expectString(output.marker),
     pipelineIdList:
       output.pipelineIdList !== undefined && output.pipelineIdList !== null
         ? deserializeAws_json1_1pipelineList(output.pipelineIdList, context)
@@ -2362,8 +2361,8 @@ const deserializeAws_json1_1ListPipelinesOutput = (output: any, context: __Serde
 
 const deserializeAws_json1_1ParameterAttribute = (output: any, context: __SerdeContext): ParameterAttribute => {
   return {
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
-    stringValue: output.stringValue !== undefined && output.stringValue !== null ? output.stringValue : undefined,
+    key: __expectString(output.key),
+    stringValue: __expectString(output.stringValue),
   } as any;
 };
 
@@ -2384,7 +2383,7 @@ const deserializeAws_json1_1ParameterObject = (output: any, context: __SerdeCont
       output.attributes !== undefined && output.attributes !== null
         ? deserializeAws_json1_1ParameterAttributeList(output.attributes, context)
         : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    id: __expectString(output.id),
   } as any;
 };
 
@@ -2401,8 +2400,8 @@ const deserializeAws_json1_1ParameterObjectList = (output: any, context: __Serde
 
 const deserializeAws_json1_1ParameterValue = (output: any, context: __SerdeContext): ParameterValue => {
   return {
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    stringValue: output.stringValue !== undefined && output.stringValue !== null ? output.stringValue : undefined,
+    id: __expectString(output.id),
+    stringValue: __expectString(output.stringValue),
   } as any;
 };
 
@@ -2422,19 +2421,19 @@ const deserializeAws_json1_1PipelineDeletedException = (
   context: __SerdeContext
 ): PipelineDeletedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1PipelineDescription = (output: any, context: __SerdeContext): PipelineDescription => {
   return {
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    description: __expectString(output.description),
     fields:
       output.fields !== undefined && output.fields !== null
         ? deserializeAws_json1_1fieldList(output.fields, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    pipelineId: output.pipelineId !== undefined && output.pipelineId !== null ? output.pipelineId : undefined,
+    name: __expectString(output.name),
+    pipelineId: __expectString(output.pipelineId),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_json1_1tagList(output.tags, context)
@@ -2455,8 +2454,8 @@ const deserializeAws_json1_1PipelineDescriptionList = (output: any, context: __S
 
 const deserializeAws_json1_1PipelineIdName = (output: any, context: __SerdeContext): PipelineIdName => {
   return {
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    id: __expectString(output.id),
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -2476,7 +2475,7 @@ const deserializeAws_json1_1PipelineNotFoundException = (
   context: __SerdeContext
 ): PipelineNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -2486,8 +2485,8 @@ const deserializeAws_json1_1PipelineObject = (output: any, context: __SerdeConte
       output.fields !== undefined && output.fields !== null
         ? deserializeAws_json1_1fieldList(output.fields, context)
         : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    id: __expectString(output.id),
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -2531,7 +2530,7 @@ const deserializeAws_json1_1PutPipelineDefinitionOutput = (
   context: __SerdeContext
 ): PutPipelineDefinitionOutput => {
   return {
-    errored: output.errored !== undefined && output.errored !== null ? output.errored : undefined,
+    errored: __expectBoolean(output.errored),
     validationErrors:
       output.validationErrors !== undefined && output.validationErrors !== null
         ? deserializeAws_json1_1ValidationErrors(output.validationErrors, context)
@@ -2545,11 +2544,10 @@ const deserializeAws_json1_1PutPipelineDefinitionOutput = (
 
 const deserializeAws_json1_1QueryObjectsOutput = (output: any, context: __SerdeContext): QueryObjectsOutput => {
   return {
-    hasMoreResults:
-      output.hasMoreResults !== undefined && output.hasMoreResults !== null ? output.hasMoreResults : undefined,
+    hasMoreResults: __expectBoolean(output.hasMoreResults),
     ids:
       output.ids !== undefined && output.ids !== null ? deserializeAws_json1_1idList(output.ids, context) : undefined,
-    marker: output.marker !== undefined && output.marker !== null ? output.marker : undefined,
+    marker: __expectString(output.marker),
   } as any;
 };
 
@@ -2562,7 +2560,7 @@ const deserializeAws_json1_1ReportTaskProgressOutput = (
   context: __SerdeContext
 ): ReportTaskProgressOutput => {
   return {
-    canceled: output.canceled !== undefined && output.canceled !== null ? output.canceled : undefined,
+    canceled: __expectBoolean(output.canceled),
   } as any;
 };
 
@@ -2571,7 +2569,7 @@ const deserializeAws_json1_1ReportTaskRunnerHeartbeatOutput = (
   context: __SerdeContext
 ): ReportTaskRunnerHeartbeatOutput => {
   return {
-    terminate: output.terminate !== undefined && output.terminate !== null ? output.terminate : undefined,
+    terminate: __expectBoolean(output.terminate),
   } as any;
 };
 
@@ -2581,8 +2579,8 @@ const deserializeAws_json1_1SetTaskStatusOutput = (output: any, context: __Serde
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    key: __expectString(output.key),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -2599,19 +2597,19 @@ const deserializeAws_json1_1tagList = (output: any, context: __SerdeContext): Ta
 
 const deserializeAws_json1_1TaskNotFoundException = (output: any, context: __SerdeContext): TaskNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1TaskObject = (output: any, context: __SerdeContext): TaskObject => {
   return {
-    attemptId: output.attemptId !== undefined && output.attemptId !== null ? output.attemptId : undefined,
+    attemptId: __expectString(output.attemptId),
     objects:
       output.objects !== undefined && output.objects !== null
         ? deserializeAws_json1_1PipelineObjectMap(output.objects, context)
         : undefined,
-    pipelineId: output.pipelineId !== undefined && output.pipelineId !== null ? output.pipelineId : undefined,
-    taskId: output.taskId !== undefined && output.taskId !== null ? output.taskId : undefined,
+    pipelineId: __expectString(output.pipelineId),
+    taskId: __expectString(output.taskId),
   } as any;
 };
 
@@ -2620,7 +2618,7 @@ const deserializeAws_json1_1ValidatePipelineDefinitionOutput = (
   context: __SerdeContext
 ): ValidatePipelineDefinitionOutput => {
   return {
-    errored: output.errored !== undefined && output.errored !== null ? output.errored : undefined,
+    errored: __expectBoolean(output.errored),
     validationErrors:
       output.validationErrors !== undefined && output.validationErrors !== null
         ? deserializeAws_json1_1ValidationErrors(output.validationErrors, context)
@@ -2638,7 +2636,7 @@ const deserializeAws_json1_1ValidationError = (output: any, context: __SerdeCont
       output.errors !== undefined && output.errors !== null
         ? deserializeAws_json1_1validationMessages(output.errors, context)
         : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    id: __expectString(output.id),
   } as any;
 };
 
@@ -2660,13 +2658,13 @@ const deserializeAws_json1_1validationMessages = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1ValidationWarning = (output: any, context: __SerdeContext): ValidationWarning => {
   return {
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    id: __expectString(output.id),
     warnings:
       output.warnings !== undefined && output.warnings !== null
         ? deserializeAws_json1_1validationMessages(output.warnings, context)

--- a/clients/client-database-migration-service/protocols/Aws_json1_1.ts
+++ b/clients/client-database-migration-service/protocols/Aws_json1_1.ts
@@ -361,7 +361,12 @@ import {
   VpcSecurityGroupMembership,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -6701,16 +6706,15 @@ const serializeAws_json1_1VpcSecurityGroupIdList = (input: string[], context: __
 
 const deserializeAws_json1_1AccessDeniedFault = (output: any, context: __SerdeContext): AccessDeniedFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1AccountQuota = (output: any, context: __SerdeContext): AccountQuota => {
   return {
-    AccountQuotaName:
-      output.AccountQuotaName !== undefined && output.AccountQuotaName !== null ? output.AccountQuotaName : undefined,
-    Max: output.Max !== undefined && output.Max !== null ? output.Max : undefined,
-    Used: output.Used !== undefined && output.Used !== null ? output.Used : undefined,
+    AccountQuotaName: __expectString(output.AccountQuotaName),
+    Max: __expectNumber(output.Max),
+    Used: __expectNumber(output.Used),
   } as any;
 };
 
@@ -6746,7 +6750,7 @@ const deserializeAws_json1_1ApplyPendingMaintenanceActionResponse = (
 
 const deserializeAws_json1_1AvailabilityZone = (output: any, context: __SerdeContext): AvailabilityZone => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -6757,7 +6761,7 @@ const deserializeAws_json1_1AvailabilityZonesList = (output: any, context: __Ser
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6775,27 +6779,20 @@ const deserializeAws_json1_1CancelReplicationTaskAssessmentRunResponse = (
 
 const deserializeAws_json1_1Certificate = (output: any, context: __SerdeContext): Certificate => {
   return {
-    CertificateArn:
-      output.CertificateArn !== undefined && output.CertificateArn !== null ? output.CertificateArn : undefined,
+    CertificateArn: __expectString(output.CertificateArn),
     CertificateCreationDate:
       output.CertificateCreationDate !== undefined && output.CertificateCreationDate !== null
         ? new Date(Math.round(output.CertificateCreationDate * 1000))
         : undefined,
-    CertificateIdentifier:
-      output.CertificateIdentifier !== undefined && output.CertificateIdentifier !== null
-        ? output.CertificateIdentifier
-        : undefined,
-    CertificateOwner:
-      output.CertificateOwner !== undefined && output.CertificateOwner !== null ? output.CertificateOwner : undefined,
-    CertificatePem:
-      output.CertificatePem !== undefined && output.CertificatePem !== null ? output.CertificatePem : undefined,
+    CertificateIdentifier: __expectString(output.CertificateIdentifier),
+    CertificateOwner: __expectString(output.CertificateOwner),
+    CertificatePem: __expectString(output.CertificatePem),
     CertificateWallet:
       output.CertificateWallet !== undefined && output.CertificateWallet !== null
         ? context.base64Decoder(output.CertificateWallet)
         : undefined,
-    KeyLength: output.KeyLength !== undefined && output.KeyLength !== null ? output.KeyLength : undefined,
-    SigningAlgorithm:
-      output.SigningAlgorithm !== undefined && output.SigningAlgorithm !== null ? output.SigningAlgorithm : undefined,
+    KeyLength: __expectNumber(output.KeyLength),
+    SigningAlgorithm: __expectString(output.SigningAlgorithm),
     ValidFromDate:
       output.ValidFromDate !== undefined && output.ValidFromDate !== null
         ? new Date(Math.round(output.ValidFromDate * 1000))
@@ -6820,24 +6817,12 @@ const deserializeAws_json1_1CertificateList = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_1Connection = (output: any, context: __SerdeContext): Connection => {
   return {
-    EndpointArn: output.EndpointArn !== undefined && output.EndpointArn !== null ? output.EndpointArn : undefined,
-    EndpointIdentifier:
-      output.EndpointIdentifier !== undefined && output.EndpointIdentifier !== null
-        ? output.EndpointIdentifier
-        : undefined,
-    LastFailureMessage:
-      output.LastFailureMessage !== undefined && output.LastFailureMessage !== null
-        ? output.LastFailureMessage
-        : undefined,
-    ReplicationInstanceArn:
-      output.ReplicationInstanceArn !== undefined && output.ReplicationInstanceArn !== null
-        ? output.ReplicationInstanceArn
-        : undefined,
-    ReplicationInstanceIdentifier:
-      output.ReplicationInstanceIdentifier !== undefined && output.ReplicationInstanceIdentifier !== null
-        ? output.ReplicationInstanceIdentifier
-        : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    EndpointArn: __expectString(output.EndpointArn),
+    EndpointIdentifier: __expectString(output.EndpointIdentifier),
+    LastFailureMessage: __expectString(output.LastFailureMessage),
+    ReplicationInstanceArn: __expectString(output.ReplicationInstanceArn),
+    ReplicationInstanceIdentifier: __expectString(output.ReplicationInstanceIdentifier),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -7006,10 +6991,7 @@ const deserializeAws_json1_1DescribeAccountAttributesResponse = (
       output.AccountQuotas !== undefined && output.AccountQuotas !== null
         ? deserializeAws_json1_1AccountQuotaList(output.AccountQuotas, context)
         : undefined,
-    UniqueAccountIdentifier:
-      output.UniqueAccountIdentifier !== undefined && output.UniqueAccountIdentifier !== null
-        ? output.UniqueAccountIdentifier
-        : undefined,
+    UniqueAccountIdentifier: __expectString(output.UniqueAccountIdentifier),
   } as any;
 };
 
@@ -7022,7 +7004,7 @@ const deserializeAws_json1_1DescribeApplicableIndividualAssessmentsResponse = (
       output.IndividualAssessmentNames !== undefined && output.IndividualAssessmentNames !== null
         ? deserializeAws_json1_1IndividualAssessmentNameList(output.IndividualAssessmentNames, context)
         : undefined,
-    Marker: output.Marker !== undefined && output.Marker !== null ? output.Marker : undefined,
+    Marker: __expectString(output.Marker),
   } as any;
 };
 
@@ -7035,7 +7017,7 @@ const deserializeAws_json1_1DescribeCertificatesResponse = (
       output.Certificates !== undefined && output.Certificates !== null
         ? deserializeAws_json1_1CertificateList(output.Certificates, context)
         : undefined,
-    Marker: output.Marker !== undefined && output.Marker !== null ? output.Marker : undefined,
+    Marker: __expectString(output.Marker),
   } as any;
 };
 
@@ -7048,7 +7030,7 @@ const deserializeAws_json1_1DescribeConnectionsResponse = (
       output.Connections !== undefined && output.Connections !== null
         ? deserializeAws_json1_1ConnectionList(output.Connections, context)
         : undefined,
-    Marker: output.Marker !== undefined && output.Marker !== null ? output.Marker : undefined,
+    Marker: __expectString(output.Marker),
   } as any;
 };
 
@@ -7061,7 +7043,7 @@ const deserializeAws_json1_1DescribeEndpointSettingsResponse = (
       output.EndpointSettings !== undefined && output.EndpointSettings !== null
         ? deserializeAws_json1_1EndpointSettingsList(output.EndpointSettings, context)
         : undefined,
-    Marker: output.Marker !== undefined && output.Marker !== null ? output.Marker : undefined,
+    Marker: __expectString(output.Marker),
   } as any;
 };
 
@@ -7074,7 +7056,7 @@ const deserializeAws_json1_1DescribeEndpointsResponse = (
       output.Endpoints !== undefined && output.Endpoints !== null
         ? deserializeAws_json1_1EndpointList(output.Endpoints, context)
         : undefined,
-    Marker: output.Marker !== undefined && output.Marker !== null ? output.Marker : undefined,
+    Marker: __expectString(output.Marker),
   } as any;
 };
 
@@ -7083,7 +7065,7 @@ const deserializeAws_json1_1DescribeEndpointTypesResponse = (
   context: __SerdeContext
 ): DescribeEndpointTypesResponse => {
   return {
-    Marker: output.Marker !== undefined && output.Marker !== null ? output.Marker : undefined,
+    Marker: __expectString(output.Marker),
     SupportedEndpointTypes:
       output.SupportedEndpointTypes !== undefined && output.SupportedEndpointTypes !== null
         ? deserializeAws_json1_1SupportedEndpointTypeList(output.SupportedEndpointTypes, context)
@@ -7109,7 +7091,7 @@ const deserializeAws_json1_1DescribeEventsResponse = (output: any, context: __Se
       output.Events !== undefined && output.Events !== null
         ? deserializeAws_json1_1EventList(output.Events, context)
         : undefined,
-    Marker: output.Marker !== undefined && output.Marker !== null ? output.Marker : undefined,
+    Marker: __expectString(output.Marker),
   } as any;
 };
 
@@ -7122,7 +7104,7 @@ const deserializeAws_json1_1DescribeEventSubscriptionsResponse = (
       output.EventSubscriptionsList !== undefined && output.EventSubscriptionsList !== null
         ? deserializeAws_json1_1EventSubscriptionsList(output.EventSubscriptionsList, context)
         : undefined,
-    Marker: output.Marker !== undefined && output.Marker !== null ? output.Marker : undefined,
+    Marker: __expectString(output.Marker),
   } as any;
 };
 
@@ -7131,7 +7113,7 @@ const deserializeAws_json1_1DescribeOrderableReplicationInstancesResponse = (
   context: __SerdeContext
 ): DescribeOrderableReplicationInstancesResponse => {
   return {
-    Marker: output.Marker !== undefined && output.Marker !== null ? output.Marker : undefined,
+    Marker: __expectString(output.Marker),
     OrderableReplicationInstances:
       output.OrderableReplicationInstances !== undefined && output.OrderableReplicationInstances !== null
         ? deserializeAws_json1_1OrderableReplicationInstanceList(output.OrderableReplicationInstances, context)
@@ -7144,7 +7126,7 @@ const deserializeAws_json1_1DescribePendingMaintenanceActionsResponse = (
   context: __SerdeContext
 ): DescribePendingMaintenanceActionsResponse => {
   return {
-    Marker: output.Marker !== undefined && output.Marker !== null ? output.Marker : undefined,
+    Marker: __expectString(output.Marker),
     PendingMaintenanceActions:
       output.PendingMaintenanceActions !== undefined && output.PendingMaintenanceActions !== null
         ? deserializeAws_json1_1PendingMaintenanceActions(output.PendingMaintenanceActions, context)
@@ -7169,7 +7151,7 @@ const deserializeAws_json1_1DescribeReplicationInstancesResponse = (
   context: __SerdeContext
 ): DescribeReplicationInstancesResponse => {
   return {
-    Marker: output.Marker !== undefined && output.Marker !== null ? output.Marker : undefined,
+    Marker: __expectString(output.Marker),
     ReplicationInstances:
       output.ReplicationInstances !== undefined && output.ReplicationInstances !== null
         ? deserializeAws_json1_1ReplicationInstanceList(output.ReplicationInstances, context)
@@ -7182,11 +7164,8 @@ const deserializeAws_json1_1DescribeReplicationInstanceTaskLogsResponse = (
   context: __SerdeContext
 ): DescribeReplicationInstanceTaskLogsResponse => {
   return {
-    Marker: output.Marker !== undefined && output.Marker !== null ? output.Marker : undefined,
-    ReplicationInstanceArn:
-      output.ReplicationInstanceArn !== undefined && output.ReplicationInstanceArn !== null
-        ? output.ReplicationInstanceArn
-        : undefined,
+    Marker: __expectString(output.Marker),
+    ReplicationInstanceArn: __expectString(output.ReplicationInstanceArn),
     ReplicationInstanceTaskLogs:
       output.ReplicationInstanceTaskLogs !== undefined && output.ReplicationInstanceTaskLogs !== null
         ? deserializeAws_json1_1ReplicationInstanceTaskLogsList(output.ReplicationInstanceTaskLogs, context)
@@ -7199,7 +7178,7 @@ const deserializeAws_json1_1DescribeReplicationSubnetGroupsResponse = (
   context: __SerdeContext
 ): DescribeReplicationSubnetGroupsResponse => {
   return {
-    Marker: output.Marker !== undefined && output.Marker !== null ? output.Marker : undefined,
+    Marker: __expectString(output.Marker),
     ReplicationSubnetGroups:
       output.ReplicationSubnetGroups !== undefined && output.ReplicationSubnetGroups !== null
         ? deserializeAws_json1_1ReplicationSubnetGroups(output.ReplicationSubnetGroups, context)
@@ -7212,8 +7191,8 @@ const deserializeAws_json1_1DescribeReplicationTaskAssessmentResultsResponse = (
   context: __SerdeContext
 ): DescribeReplicationTaskAssessmentResultsResponse => {
   return {
-    BucketName: output.BucketName !== undefined && output.BucketName !== null ? output.BucketName : undefined,
-    Marker: output.Marker !== undefined && output.Marker !== null ? output.Marker : undefined,
+    BucketName: __expectString(output.BucketName),
+    Marker: __expectString(output.Marker),
     ReplicationTaskAssessmentResults:
       output.ReplicationTaskAssessmentResults !== undefined && output.ReplicationTaskAssessmentResults !== null
         ? deserializeAws_json1_1ReplicationTaskAssessmentResultList(output.ReplicationTaskAssessmentResults, context)
@@ -7226,7 +7205,7 @@ const deserializeAws_json1_1DescribeReplicationTaskAssessmentRunsResponse = (
   context: __SerdeContext
 ): DescribeReplicationTaskAssessmentRunsResponse => {
   return {
-    Marker: output.Marker !== undefined && output.Marker !== null ? output.Marker : undefined,
+    Marker: __expectString(output.Marker),
     ReplicationTaskAssessmentRuns:
       output.ReplicationTaskAssessmentRuns !== undefined && output.ReplicationTaskAssessmentRuns !== null
         ? deserializeAws_json1_1ReplicationTaskAssessmentRunList(output.ReplicationTaskAssessmentRuns, context)
@@ -7239,7 +7218,7 @@ const deserializeAws_json1_1DescribeReplicationTaskIndividualAssessmentsResponse
   context: __SerdeContext
 ): DescribeReplicationTaskIndividualAssessmentsResponse => {
   return {
-    Marker: output.Marker !== undefined && output.Marker !== null ? output.Marker : undefined,
+    Marker: __expectString(output.Marker),
     ReplicationTaskIndividualAssessments:
       output.ReplicationTaskIndividualAssessments !== undefined && output.ReplicationTaskIndividualAssessments !== null
         ? deserializeAws_json1_1ReplicationTaskIndividualAssessmentList(
@@ -7255,7 +7234,7 @@ const deserializeAws_json1_1DescribeReplicationTasksResponse = (
   context: __SerdeContext
 ): DescribeReplicationTasksResponse => {
   return {
-    Marker: output.Marker !== undefined && output.Marker !== null ? output.Marker : undefined,
+    Marker: __expectString(output.Marker),
     ReplicationTasks:
       output.ReplicationTasks !== undefined && output.ReplicationTasks !== null
         ? deserializeAws_json1_1ReplicationTaskList(output.ReplicationTasks, context)
@@ -7268,7 +7247,7 @@ const deserializeAws_json1_1DescribeSchemasResponse = (
   context: __SerdeContext
 ): DescribeSchemasResponse => {
   return {
-    Marker: output.Marker !== undefined && output.Marker !== null ? output.Marker : undefined,
+    Marker: __expectString(output.Marker),
     Schemas:
       output.Schemas !== undefined && output.Schemas !== null
         ? deserializeAws_json1_1SchemaList(output.Schemas, context)
@@ -7281,11 +7260,8 @@ const deserializeAws_json1_1DescribeTableStatisticsResponse = (
   context: __SerdeContext
 ): DescribeTableStatisticsResponse => {
   return {
-    Marker: output.Marker !== undefined && output.Marker !== null ? output.Marker : undefined,
-    ReplicationTaskArn:
-      output.ReplicationTaskArn !== undefined && output.ReplicationTaskArn !== null
-        ? output.ReplicationTaskArn
-        : undefined,
+    Marker: __expectString(output.Marker),
+    ReplicationTaskArn: __expectString(output.ReplicationTaskArn),
     TableStatistics:
       output.TableStatistics !== undefined && output.TableStatistics !== null
         ? deserializeAws_json1_1TableStatisticsList(output.TableStatistics, context)
@@ -7295,71 +7271,46 @@ const deserializeAws_json1_1DescribeTableStatisticsResponse = (
 
 const deserializeAws_json1_1DmsTransferSettings = (output: any, context: __SerdeContext): DmsTransferSettings => {
   return {
-    BucketName: output.BucketName !== undefined && output.BucketName !== null ? output.BucketName : undefined,
-    ServiceAccessRoleArn:
-      output.ServiceAccessRoleArn !== undefined && output.ServiceAccessRoleArn !== null
-        ? output.ServiceAccessRoleArn
-        : undefined,
+    BucketName: __expectString(output.BucketName),
+    ServiceAccessRoleArn: __expectString(output.ServiceAccessRoleArn),
   } as any;
 };
 
 const deserializeAws_json1_1DocDbSettings = (output: any, context: __SerdeContext): DocDbSettings => {
   return {
-    DatabaseName: output.DatabaseName !== undefined && output.DatabaseName !== null ? output.DatabaseName : undefined,
-    DocsToInvestigate:
-      output.DocsToInvestigate !== undefined && output.DocsToInvestigate !== null
-        ? output.DocsToInvestigate
-        : undefined,
-    ExtractDocId: output.ExtractDocId !== undefined && output.ExtractDocId !== null ? output.ExtractDocId : undefined,
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
-    NestingLevel: output.NestingLevel !== undefined && output.NestingLevel !== null ? output.NestingLevel : undefined,
-    Password: output.Password !== undefined && output.Password !== null ? output.Password : undefined,
-    Port: output.Port !== undefined && output.Port !== null ? output.Port : undefined,
-    SecretsManagerAccessRoleArn:
-      output.SecretsManagerAccessRoleArn !== undefined && output.SecretsManagerAccessRoleArn !== null
-        ? output.SecretsManagerAccessRoleArn
-        : undefined,
-    SecretsManagerSecretId:
-      output.SecretsManagerSecretId !== undefined && output.SecretsManagerSecretId !== null
-        ? output.SecretsManagerSecretId
-        : undefined,
-    ServerName: output.ServerName !== undefined && output.ServerName !== null ? output.ServerName : undefined,
-    Username: output.Username !== undefined && output.Username !== null ? output.Username : undefined,
+    DatabaseName: __expectString(output.DatabaseName),
+    DocsToInvestigate: __expectNumber(output.DocsToInvestigate),
+    ExtractDocId: __expectBoolean(output.ExtractDocId),
+    KmsKeyId: __expectString(output.KmsKeyId),
+    NestingLevel: __expectString(output.NestingLevel),
+    Password: __expectString(output.Password),
+    Port: __expectNumber(output.Port),
+    SecretsManagerAccessRoleArn: __expectString(output.SecretsManagerAccessRoleArn),
+    SecretsManagerSecretId: __expectString(output.SecretsManagerSecretId),
+    ServerName: __expectString(output.ServerName),
+    Username: __expectString(output.Username),
   } as any;
 };
 
 const deserializeAws_json1_1DynamoDbSettings = (output: any, context: __SerdeContext): DynamoDbSettings => {
   return {
-    ServiceAccessRoleArn:
-      output.ServiceAccessRoleArn !== undefined && output.ServiceAccessRoleArn !== null
-        ? output.ServiceAccessRoleArn
-        : undefined,
+    ServiceAccessRoleArn: __expectString(output.ServiceAccessRoleArn),
   } as any;
 };
 
 const deserializeAws_json1_1ElasticsearchSettings = (output: any, context: __SerdeContext): ElasticsearchSettings => {
   return {
-    EndpointUri: output.EndpointUri !== undefined && output.EndpointUri !== null ? output.EndpointUri : undefined,
-    ErrorRetryDuration:
-      output.ErrorRetryDuration !== undefined && output.ErrorRetryDuration !== null
-        ? output.ErrorRetryDuration
-        : undefined,
-    FullLoadErrorPercentage:
-      output.FullLoadErrorPercentage !== undefined && output.FullLoadErrorPercentage !== null
-        ? output.FullLoadErrorPercentage
-        : undefined,
-    ServiceAccessRoleArn:
-      output.ServiceAccessRoleArn !== undefined && output.ServiceAccessRoleArn !== null
-        ? output.ServiceAccessRoleArn
-        : undefined,
+    EndpointUri: __expectString(output.EndpointUri),
+    ErrorRetryDuration: __expectNumber(output.ErrorRetryDuration),
+    FullLoadErrorPercentage: __expectNumber(output.FullLoadErrorPercentage),
+    ServiceAccessRoleArn: __expectString(output.ServiceAccessRoleArn),
   } as any;
 };
 
 const deserializeAws_json1_1Endpoint = (output: any, context: __SerdeContext): Endpoint => {
   return {
-    CertificateArn:
-      output.CertificateArn !== undefined && output.CertificateArn !== null ? output.CertificateArn : undefined,
-    DatabaseName: output.DatabaseName !== undefined && output.DatabaseName !== null ? output.DatabaseName : undefined,
+    CertificateArn: __expectString(output.CertificateArn),
+    DatabaseName: __expectString(output.DatabaseName),
     DmsTransferSettings:
       output.DmsTransferSettings !== undefined && output.DmsTransferSettings !== null
         ? deserializeAws_json1_1DmsTransferSettings(output.DmsTransferSettings, context)
@@ -7376,26 +7327,14 @@ const deserializeAws_json1_1Endpoint = (output: any, context: __SerdeContext): E
       output.ElasticsearchSettings !== undefined && output.ElasticsearchSettings !== null
         ? deserializeAws_json1_1ElasticsearchSettings(output.ElasticsearchSettings, context)
         : undefined,
-    EndpointArn: output.EndpointArn !== undefined && output.EndpointArn !== null ? output.EndpointArn : undefined,
-    EndpointIdentifier:
-      output.EndpointIdentifier !== undefined && output.EndpointIdentifier !== null
-        ? output.EndpointIdentifier
-        : undefined,
-    EndpointType: output.EndpointType !== undefined && output.EndpointType !== null ? output.EndpointType : undefined,
-    EngineDisplayName:
-      output.EngineDisplayName !== undefined && output.EngineDisplayName !== null
-        ? output.EngineDisplayName
-        : undefined,
-    EngineName: output.EngineName !== undefined && output.EngineName !== null ? output.EngineName : undefined,
-    ExternalId: output.ExternalId !== undefined && output.ExternalId !== null ? output.ExternalId : undefined,
-    ExternalTableDefinition:
-      output.ExternalTableDefinition !== undefined && output.ExternalTableDefinition !== null
-        ? output.ExternalTableDefinition
-        : undefined,
-    ExtraConnectionAttributes:
-      output.ExtraConnectionAttributes !== undefined && output.ExtraConnectionAttributes !== null
-        ? output.ExtraConnectionAttributes
-        : undefined,
+    EndpointArn: __expectString(output.EndpointArn),
+    EndpointIdentifier: __expectString(output.EndpointIdentifier),
+    EndpointType: __expectString(output.EndpointType),
+    EngineDisplayName: __expectString(output.EngineDisplayName),
+    EngineName: __expectString(output.EngineName),
+    ExternalId: __expectString(output.ExternalId),
+    ExternalTableDefinition: __expectString(output.ExternalTableDefinition),
+    ExtraConnectionAttributes: __expectString(output.ExtraConnectionAttributes),
     IBMDb2Settings:
       output.IBMDb2Settings !== undefined && output.IBMDb2Settings !== null
         ? deserializeAws_json1_1IBMDb2Settings(output.IBMDb2Settings, context)
@@ -7408,7 +7347,7 @@ const deserializeAws_json1_1Endpoint = (output: any, context: __SerdeContext): E
       output.KinesisSettings !== undefined && output.KinesisSettings !== null
         ? deserializeAws_json1_1KinesisSettings(output.KinesisSettings, context)
         : undefined,
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
+    KmsKeyId: __expectString(output.KmsKeyId),
     MicrosoftSQLServerSettings:
       output.MicrosoftSQLServerSettings !== undefined && output.MicrosoftSQLServerSettings !== null
         ? deserializeAws_json1_1MicrosoftSQLServerSettings(output.MicrosoftSQLServerSettings, context)
@@ -7429,7 +7368,7 @@ const deserializeAws_json1_1Endpoint = (output: any, context: __SerdeContext): E
       output.OracleSettings !== undefined && output.OracleSettings !== null
         ? deserializeAws_json1_1OracleSettings(output.OracleSettings, context)
         : undefined,
-    Port: output.Port !== undefined && output.Port !== null ? output.Port : undefined,
+    Port: __expectNumber(output.Port),
     PostgreSQLSettings:
       output.PostgreSQLSettings !== undefined && output.PostgreSQLSettings !== null
         ? deserializeAws_json1_1PostgreSQLSettings(output.PostgreSQLSettings, context)
@@ -7442,18 +7381,15 @@ const deserializeAws_json1_1Endpoint = (output: any, context: __SerdeContext): E
       output.S3Settings !== undefined && output.S3Settings !== null
         ? deserializeAws_json1_1S3Settings(output.S3Settings, context)
         : undefined,
-    ServerName: output.ServerName !== undefined && output.ServerName !== null ? output.ServerName : undefined,
-    ServiceAccessRoleArn:
-      output.ServiceAccessRoleArn !== undefined && output.ServiceAccessRoleArn !== null
-        ? output.ServiceAccessRoleArn
-        : undefined,
-    SslMode: output.SslMode !== undefined && output.SslMode !== null ? output.SslMode : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    ServerName: __expectString(output.ServerName),
+    ServiceAccessRoleArn: __expectString(output.ServiceAccessRoleArn),
+    SslMode: __expectString(output.SslMode),
+    Status: __expectString(output.Status),
     SybaseSettings:
       output.SybaseSettings !== undefined && output.SybaseSettings !== null
         ? deserializeAws_json1_1SybaseSettings(output.SybaseSettings, context)
         : undefined,
-    Username: output.Username !== undefined && output.Username !== null ? output.Username : undefined,
+    Username: __expectString(output.Username),
   } as any;
 };
 
@@ -7470,18 +7406,17 @@ const deserializeAws_json1_1EndpointList = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_1EndpointSetting = (output: any, context: __SerdeContext): EndpointSetting => {
   return {
-    Applicability:
-      output.Applicability !== undefined && output.Applicability !== null ? output.Applicability : undefined,
+    Applicability: __expectString(output.Applicability),
     EnumValues:
       output.EnumValues !== undefined && output.EnumValues !== null
         ? deserializeAws_json1_1EndpointSettingEnumValues(output.EnumValues, context)
         : undefined,
-    IntValueMax: output.IntValueMax !== undefined && output.IntValueMax !== null ? output.IntValueMax : undefined,
-    IntValueMin: output.IntValueMin !== undefined && output.IntValueMin !== null ? output.IntValueMin : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Sensitive: output.Sensitive !== undefined && output.Sensitive !== null ? output.Sensitive : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    Units: output.Units !== undefined && output.Units !== null ? output.Units : undefined,
+    IntValueMax: __expectNumber(output.IntValueMax),
+    IntValueMin: __expectNumber(output.IntValueMin),
+    Name: __expectString(output.Name),
+    Sensitive: __expectBoolean(output.Sensitive),
+    Type: __expectString(output.Type),
+    Units: __expectString(output.Units),
   } as any;
 };
 
@@ -7492,7 +7427,7 @@ const deserializeAws_json1_1EndpointSettingEnumValues = (output: any, context: _
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7514,10 +7449,9 @@ const deserializeAws_json1_1Event = (output: any, context: __SerdeContext): Even
       output.EventCategories !== undefined && output.EventCategories !== null
         ? deserializeAws_json1_1EventCategoriesList(output.EventCategories, context)
         : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    SourceIdentifier:
-      output.SourceIdentifier !== undefined && output.SourceIdentifier !== null ? output.SourceIdentifier : undefined,
-    SourceType: output.SourceType !== undefined && output.SourceType !== null ? output.SourceType : undefined,
+    Message: __expectString(output.Message),
+    SourceIdentifier: __expectString(output.SourceIdentifier),
+    SourceType: __expectString(output.SourceType),
   } as any;
 };
 
@@ -7528,7 +7462,7 @@ const deserializeAws_json1_1EventCategoriesList = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7538,7 +7472,7 @@ const deserializeAws_json1_1EventCategoryGroup = (output: any, context: __SerdeC
       output.EventCategories !== undefined && output.EventCategories !== null
         ? deserializeAws_json1_1EventCategoriesList(output.EventCategories, context)
         : undefined,
-    SourceType: output.SourceType !== undefined && output.SourceType !== null ? output.SourceType : undefined,
+    SourceType: __expectString(output.SourceType),
   } as any;
 };
 
@@ -7566,28 +7500,21 @@ const deserializeAws_json1_1EventList = (output: any, context: __SerdeContext): 
 
 const deserializeAws_json1_1EventSubscription = (output: any, context: __SerdeContext): EventSubscription => {
   return {
-    CustSubscriptionId:
-      output.CustSubscriptionId !== undefined && output.CustSubscriptionId !== null
-        ? output.CustSubscriptionId
-        : undefined,
-    CustomerAwsId:
-      output.CustomerAwsId !== undefined && output.CustomerAwsId !== null ? output.CustomerAwsId : undefined,
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
+    CustSubscriptionId: __expectString(output.CustSubscriptionId),
+    CustomerAwsId: __expectString(output.CustomerAwsId),
+    Enabled: __expectBoolean(output.Enabled),
     EventCategoriesList:
       output.EventCategoriesList !== undefined && output.EventCategoriesList !== null
         ? deserializeAws_json1_1EventCategoriesList(output.EventCategoriesList, context)
         : undefined,
-    SnsTopicArn: output.SnsTopicArn !== undefined && output.SnsTopicArn !== null ? output.SnsTopicArn : undefined,
+    SnsTopicArn: __expectString(output.SnsTopicArn),
     SourceIdsList:
       output.SourceIdsList !== undefined && output.SourceIdsList !== null
         ? deserializeAws_json1_1SourceIdsList(output.SourceIdsList, context)
         : undefined,
-    SourceType: output.SourceType !== undefined && output.SourceType !== null ? output.SourceType : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    SubscriptionCreationTime:
-      output.SubscriptionCreationTime !== undefined && output.SubscriptionCreationTime !== null
-        ? output.SubscriptionCreationTime
-        : undefined,
+    SourceType: __expectString(output.SourceType),
+    Status: __expectString(output.Status),
+    SubscriptionCreationTime: __expectString(output.SubscriptionCreationTime),
   } as any;
 };
 
@@ -7604,26 +7531,16 @@ const deserializeAws_json1_1EventSubscriptionsList = (output: any, context: __Se
 
 const deserializeAws_json1_1IBMDb2Settings = (output: any, context: __SerdeContext): IBMDb2Settings => {
   return {
-    CurrentLsn: output.CurrentLsn !== undefined && output.CurrentLsn !== null ? output.CurrentLsn : undefined,
-    DatabaseName: output.DatabaseName !== undefined && output.DatabaseName !== null ? output.DatabaseName : undefined,
-    MaxKBytesPerRead:
-      output.MaxKBytesPerRead !== undefined && output.MaxKBytesPerRead !== null ? output.MaxKBytesPerRead : undefined,
-    Password: output.Password !== undefined && output.Password !== null ? output.Password : undefined,
-    Port: output.Port !== undefined && output.Port !== null ? output.Port : undefined,
-    SecretsManagerAccessRoleArn:
-      output.SecretsManagerAccessRoleArn !== undefined && output.SecretsManagerAccessRoleArn !== null
-        ? output.SecretsManagerAccessRoleArn
-        : undefined,
-    SecretsManagerSecretId:
-      output.SecretsManagerSecretId !== undefined && output.SecretsManagerSecretId !== null
-        ? output.SecretsManagerSecretId
-        : undefined,
-    ServerName: output.ServerName !== undefined && output.ServerName !== null ? output.ServerName : undefined,
-    SetDataCaptureChanges:
-      output.SetDataCaptureChanges !== undefined && output.SetDataCaptureChanges !== null
-        ? output.SetDataCaptureChanges
-        : undefined,
-    Username: output.Username !== undefined && output.Username !== null ? output.Username : undefined,
+    CurrentLsn: __expectString(output.CurrentLsn),
+    DatabaseName: __expectString(output.DatabaseName),
+    MaxKBytesPerRead: __expectNumber(output.MaxKBytesPerRead),
+    Password: __expectString(output.Password),
+    Port: __expectNumber(output.Port),
+    SecretsManagerAccessRoleArn: __expectString(output.SecretsManagerAccessRoleArn),
+    SecretsManagerSecretId: __expectString(output.SecretsManagerSecretId),
+    ServerName: __expectString(output.ServerName),
+    SetDataCaptureChanges: __expectBoolean(output.SetDataCaptureChanges),
+    Username: __expectString(output.Username),
   } as any;
 };
 
@@ -7646,7 +7563,7 @@ const deserializeAws_json1_1IndividualAssessmentNameList = (output: any, context
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7655,7 +7572,7 @@ const deserializeAws_json1_1InsufficientResourceCapacityFault = (
   context: __SerdeContext
 ): InsufficientResourceCapacityFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -7664,7 +7581,7 @@ const deserializeAws_json1_1InvalidCertificateFault = (
   context: __SerdeContext
 ): InvalidCertificateFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -7673,126 +7590,73 @@ const deserializeAws_json1_1InvalidResourceStateFault = (
   context: __SerdeContext
 ): InvalidResourceStateFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidSubnet = (output: any, context: __SerdeContext): InvalidSubnet => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1KafkaSettings = (output: any, context: __SerdeContext): KafkaSettings => {
   return {
-    Broker: output.Broker !== undefined && output.Broker !== null ? output.Broker : undefined,
-    IncludeControlDetails:
-      output.IncludeControlDetails !== undefined && output.IncludeControlDetails !== null
-        ? output.IncludeControlDetails
-        : undefined,
-    IncludeNullAndEmpty:
-      output.IncludeNullAndEmpty !== undefined && output.IncludeNullAndEmpty !== null
-        ? output.IncludeNullAndEmpty
-        : undefined,
-    IncludePartitionValue:
-      output.IncludePartitionValue !== undefined && output.IncludePartitionValue !== null
-        ? output.IncludePartitionValue
-        : undefined,
-    IncludeTableAlterOperations:
-      output.IncludeTableAlterOperations !== undefined && output.IncludeTableAlterOperations !== null
-        ? output.IncludeTableAlterOperations
-        : undefined,
-    IncludeTransactionDetails:
-      output.IncludeTransactionDetails !== undefined && output.IncludeTransactionDetails !== null
-        ? output.IncludeTransactionDetails
-        : undefined,
-    MessageFormat:
-      output.MessageFormat !== undefined && output.MessageFormat !== null ? output.MessageFormat : undefined,
-    MessageMaxBytes:
-      output.MessageMaxBytes !== undefined && output.MessageMaxBytes !== null ? output.MessageMaxBytes : undefined,
-    PartitionIncludeSchemaTable:
-      output.PartitionIncludeSchemaTable !== undefined && output.PartitionIncludeSchemaTable !== null
-        ? output.PartitionIncludeSchemaTable
-        : undefined,
-    SaslPassword: output.SaslPassword !== undefined && output.SaslPassword !== null ? output.SaslPassword : undefined,
-    SaslUsername: output.SaslUsername !== undefined && output.SaslUsername !== null ? output.SaslUsername : undefined,
-    SecurityProtocol:
-      output.SecurityProtocol !== undefined && output.SecurityProtocol !== null ? output.SecurityProtocol : undefined,
-    SslCaCertificateArn:
-      output.SslCaCertificateArn !== undefined && output.SslCaCertificateArn !== null
-        ? output.SslCaCertificateArn
-        : undefined,
-    SslClientCertificateArn:
-      output.SslClientCertificateArn !== undefined && output.SslClientCertificateArn !== null
-        ? output.SslClientCertificateArn
-        : undefined,
-    SslClientKeyArn:
-      output.SslClientKeyArn !== undefined && output.SslClientKeyArn !== null ? output.SslClientKeyArn : undefined,
-    SslClientKeyPassword:
-      output.SslClientKeyPassword !== undefined && output.SslClientKeyPassword !== null
-        ? output.SslClientKeyPassword
-        : undefined,
-    Topic: output.Topic !== undefined && output.Topic !== null ? output.Topic : undefined,
+    Broker: __expectString(output.Broker),
+    IncludeControlDetails: __expectBoolean(output.IncludeControlDetails),
+    IncludeNullAndEmpty: __expectBoolean(output.IncludeNullAndEmpty),
+    IncludePartitionValue: __expectBoolean(output.IncludePartitionValue),
+    IncludeTableAlterOperations: __expectBoolean(output.IncludeTableAlterOperations),
+    IncludeTransactionDetails: __expectBoolean(output.IncludeTransactionDetails),
+    MessageFormat: __expectString(output.MessageFormat),
+    MessageMaxBytes: __expectNumber(output.MessageMaxBytes),
+    PartitionIncludeSchemaTable: __expectBoolean(output.PartitionIncludeSchemaTable),
+    SaslPassword: __expectString(output.SaslPassword),
+    SaslUsername: __expectString(output.SaslUsername),
+    SecurityProtocol: __expectString(output.SecurityProtocol),
+    SslCaCertificateArn: __expectString(output.SslCaCertificateArn),
+    SslClientCertificateArn: __expectString(output.SslClientCertificateArn),
+    SslClientKeyArn: __expectString(output.SslClientKeyArn),
+    SslClientKeyPassword: __expectString(output.SslClientKeyPassword),
+    Topic: __expectString(output.Topic),
   } as any;
 };
 
 const deserializeAws_json1_1KinesisSettings = (output: any, context: __SerdeContext): KinesisSettings => {
   return {
-    IncludeControlDetails:
-      output.IncludeControlDetails !== undefined && output.IncludeControlDetails !== null
-        ? output.IncludeControlDetails
-        : undefined,
-    IncludeNullAndEmpty:
-      output.IncludeNullAndEmpty !== undefined && output.IncludeNullAndEmpty !== null
-        ? output.IncludeNullAndEmpty
-        : undefined,
-    IncludePartitionValue:
-      output.IncludePartitionValue !== undefined && output.IncludePartitionValue !== null
-        ? output.IncludePartitionValue
-        : undefined,
-    IncludeTableAlterOperations:
-      output.IncludeTableAlterOperations !== undefined && output.IncludeTableAlterOperations !== null
-        ? output.IncludeTableAlterOperations
-        : undefined,
-    IncludeTransactionDetails:
-      output.IncludeTransactionDetails !== undefined && output.IncludeTransactionDetails !== null
-        ? output.IncludeTransactionDetails
-        : undefined,
-    MessageFormat:
-      output.MessageFormat !== undefined && output.MessageFormat !== null ? output.MessageFormat : undefined,
-    PartitionIncludeSchemaTable:
-      output.PartitionIncludeSchemaTable !== undefined && output.PartitionIncludeSchemaTable !== null
-        ? output.PartitionIncludeSchemaTable
-        : undefined,
-    ServiceAccessRoleArn:
-      output.ServiceAccessRoleArn !== undefined && output.ServiceAccessRoleArn !== null
-        ? output.ServiceAccessRoleArn
-        : undefined,
-    StreamArn: output.StreamArn !== undefined && output.StreamArn !== null ? output.StreamArn : undefined,
+    IncludeControlDetails: __expectBoolean(output.IncludeControlDetails),
+    IncludeNullAndEmpty: __expectBoolean(output.IncludeNullAndEmpty),
+    IncludePartitionValue: __expectBoolean(output.IncludePartitionValue),
+    IncludeTableAlterOperations: __expectBoolean(output.IncludeTableAlterOperations),
+    IncludeTransactionDetails: __expectBoolean(output.IncludeTransactionDetails),
+    MessageFormat: __expectString(output.MessageFormat),
+    PartitionIncludeSchemaTable: __expectBoolean(output.PartitionIncludeSchemaTable),
+    ServiceAccessRoleArn: __expectString(output.ServiceAccessRoleArn),
+    StreamArn: __expectString(output.StreamArn),
   } as any;
 };
 
 const deserializeAws_json1_1KMSAccessDeniedFault = (output: any, context: __SerdeContext): KMSAccessDeniedFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1KMSDisabledFault = (output: any, context: __SerdeContext): KMSDisabledFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1KMSFault = (output: any, context: __SerdeContext): KMSFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1KMSInvalidStateFault = (output: any, context: __SerdeContext): KMSInvalidStateFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -7801,19 +7665,19 @@ const deserializeAws_json1_1KMSKeyNotAccessibleFault = (
   context: __SerdeContext
 ): KMSKeyNotAccessibleFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1KMSNotFoundFault = (output: any, context: __SerdeContext): KMSNotFoundFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1KMSThrottlingFault = (output: any, context: __SerdeContext): KMSThrottlingFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -7834,39 +7698,20 @@ const deserializeAws_json1_1MicrosoftSQLServerSettings = (
   context: __SerdeContext
 ): MicrosoftSQLServerSettings => {
   return {
-    BcpPacketSize:
-      output.BcpPacketSize !== undefined && output.BcpPacketSize !== null ? output.BcpPacketSize : undefined,
-    ControlTablesFileGroup:
-      output.ControlTablesFileGroup !== undefined && output.ControlTablesFileGroup !== null
-        ? output.ControlTablesFileGroup
-        : undefined,
-    DatabaseName: output.DatabaseName !== undefined && output.DatabaseName !== null ? output.DatabaseName : undefined,
-    Password: output.Password !== undefined && output.Password !== null ? output.Password : undefined,
-    Port: output.Port !== undefined && output.Port !== null ? output.Port : undefined,
-    QuerySingleAlwaysOnNode:
-      output.QuerySingleAlwaysOnNode !== undefined && output.QuerySingleAlwaysOnNode !== null
-        ? output.QuerySingleAlwaysOnNode
-        : undefined,
-    ReadBackupOnly:
-      output.ReadBackupOnly !== undefined && output.ReadBackupOnly !== null ? output.ReadBackupOnly : undefined,
-    SafeguardPolicy:
-      output.SafeguardPolicy !== undefined && output.SafeguardPolicy !== null ? output.SafeguardPolicy : undefined,
-    SecretsManagerAccessRoleArn:
-      output.SecretsManagerAccessRoleArn !== undefined && output.SecretsManagerAccessRoleArn !== null
-        ? output.SecretsManagerAccessRoleArn
-        : undefined,
-    SecretsManagerSecretId:
-      output.SecretsManagerSecretId !== undefined && output.SecretsManagerSecretId !== null
-        ? output.SecretsManagerSecretId
-        : undefined,
-    ServerName: output.ServerName !== undefined && output.ServerName !== null ? output.ServerName : undefined,
-    UseBcpFullLoad:
-      output.UseBcpFullLoad !== undefined && output.UseBcpFullLoad !== null ? output.UseBcpFullLoad : undefined,
-    UseThirdPartyBackupDevice:
-      output.UseThirdPartyBackupDevice !== undefined && output.UseThirdPartyBackupDevice !== null
-        ? output.UseThirdPartyBackupDevice
-        : undefined,
-    Username: output.Username !== undefined && output.Username !== null ? output.Username : undefined,
+    BcpPacketSize: __expectNumber(output.BcpPacketSize),
+    ControlTablesFileGroup: __expectString(output.ControlTablesFileGroup),
+    DatabaseName: __expectString(output.DatabaseName),
+    Password: __expectString(output.Password),
+    Port: __expectNumber(output.Port),
+    QuerySingleAlwaysOnNode: __expectBoolean(output.QuerySingleAlwaysOnNode),
+    ReadBackupOnly: __expectBoolean(output.ReadBackupOnly),
+    SafeguardPolicy: __expectString(output.SafeguardPolicy),
+    SecretsManagerAccessRoleArn: __expectString(output.SecretsManagerAccessRoleArn),
+    SecretsManagerSecretId: __expectString(output.SecretsManagerSecretId),
+    ServerName: __expectString(output.ServerName),
+    UseBcpFullLoad: __expectBoolean(output.UseBcpFullLoad),
+    UseThirdPartyBackupDevice: __expectBoolean(output.UseThirdPartyBackupDevice),
+    Username: __expectString(output.Username),
   } as any;
 };
 
@@ -7929,30 +7774,20 @@ const deserializeAws_json1_1ModifyReplicationTaskResponse = (
 
 const deserializeAws_json1_1MongoDbSettings = (output: any, context: __SerdeContext): MongoDbSettings => {
   return {
-    AuthMechanism:
-      output.AuthMechanism !== undefined && output.AuthMechanism !== null ? output.AuthMechanism : undefined,
-    AuthSource: output.AuthSource !== undefined && output.AuthSource !== null ? output.AuthSource : undefined,
-    AuthType: output.AuthType !== undefined && output.AuthType !== null ? output.AuthType : undefined,
-    DatabaseName: output.DatabaseName !== undefined && output.DatabaseName !== null ? output.DatabaseName : undefined,
-    DocsToInvestigate:
-      output.DocsToInvestigate !== undefined && output.DocsToInvestigate !== null
-        ? output.DocsToInvestigate
-        : undefined,
-    ExtractDocId: output.ExtractDocId !== undefined && output.ExtractDocId !== null ? output.ExtractDocId : undefined,
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
-    NestingLevel: output.NestingLevel !== undefined && output.NestingLevel !== null ? output.NestingLevel : undefined,
-    Password: output.Password !== undefined && output.Password !== null ? output.Password : undefined,
-    Port: output.Port !== undefined && output.Port !== null ? output.Port : undefined,
-    SecretsManagerAccessRoleArn:
-      output.SecretsManagerAccessRoleArn !== undefined && output.SecretsManagerAccessRoleArn !== null
-        ? output.SecretsManagerAccessRoleArn
-        : undefined,
-    SecretsManagerSecretId:
-      output.SecretsManagerSecretId !== undefined && output.SecretsManagerSecretId !== null
-        ? output.SecretsManagerSecretId
-        : undefined,
-    ServerName: output.ServerName !== undefined && output.ServerName !== null ? output.ServerName : undefined,
-    Username: output.Username !== undefined && output.Username !== null ? output.Username : undefined,
+    AuthMechanism: __expectString(output.AuthMechanism),
+    AuthSource: __expectString(output.AuthSource),
+    AuthType: __expectString(output.AuthType),
+    DatabaseName: __expectString(output.DatabaseName),
+    DocsToInvestigate: __expectString(output.DocsToInvestigate),
+    ExtractDocId: __expectString(output.ExtractDocId),
+    KmsKeyId: __expectString(output.KmsKeyId),
+    NestingLevel: __expectString(output.NestingLevel),
+    Password: __expectString(output.Password),
+    Port: __expectNumber(output.Port),
+    SecretsManagerAccessRoleArn: __expectString(output.SecretsManagerAccessRoleArn),
+    SecretsManagerSecretId: __expectString(output.SecretsManagerSecretId),
+    ServerName: __expectString(output.ServerName),
+    Username: __expectString(output.Username),
   } as any;
 };
 
@@ -7970,170 +7805,72 @@ const deserializeAws_json1_1MoveReplicationTaskResponse = (
 
 const deserializeAws_json1_1MySQLSettings = (output: any, context: __SerdeContext): MySQLSettings => {
   return {
-    AfterConnectScript:
-      output.AfterConnectScript !== undefined && output.AfterConnectScript !== null
-        ? output.AfterConnectScript
-        : undefined,
-    CleanSourceMetadataOnMismatch:
-      output.CleanSourceMetadataOnMismatch !== undefined && output.CleanSourceMetadataOnMismatch !== null
-        ? output.CleanSourceMetadataOnMismatch
-        : undefined,
-    DatabaseName: output.DatabaseName !== undefined && output.DatabaseName !== null ? output.DatabaseName : undefined,
-    EventsPollInterval:
-      output.EventsPollInterval !== undefined && output.EventsPollInterval !== null
-        ? output.EventsPollInterval
-        : undefined,
-    MaxFileSize: output.MaxFileSize !== undefined && output.MaxFileSize !== null ? output.MaxFileSize : undefined,
-    ParallelLoadThreads:
-      output.ParallelLoadThreads !== undefined && output.ParallelLoadThreads !== null
-        ? output.ParallelLoadThreads
-        : undefined,
-    Password: output.Password !== undefined && output.Password !== null ? output.Password : undefined,
-    Port: output.Port !== undefined && output.Port !== null ? output.Port : undefined,
-    SecretsManagerAccessRoleArn:
-      output.SecretsManagerAccessRoleArn !== undefined && output.SecretsManagerAccessRoleArn !== null
-        ? output.SecretsManagerAccessRoleArn
-        : undefined,
-    SecretsManagerSecretId:
-      output.SecretsManagerSecretId !== undefined && output.SecretsManagerSecretId !== null
-        ? output.SecretsManagerSecretId
-        : undefined,
-    ServerName: output.ServerName !== undefined && output.ServerName !== null ? output.ServerName : undefined,
-    ServerTimezone:
-      output.ServerTimezone !== undefined && output.ServerTimezone !== null ? output.ServerTimezone : undefined,
-    TargetDbType: output.TargetDbType !== undefined && output.TargetDbType !== null ? output.TargetDbType : undefined,
-    Username: output.Username !== undefined && output.Username !== null ? output.Username : undefined,
+    AfterConnectScript: __expectString(output.AfterConnectScript),
+    CleanSourceMetadataOnMismatch: __expectBoolean(output.CleanSourceMetadataOnMismatch),
+    DatabaseName: __expectString(output.DatabaseName),
+    EventsPollInterval: __expectNumber(output.EventsPollInterval),
+    MaxFileSize: __expectNumber(output.MaxFileSize),
+    ParallelLoadThreads: __expectNumber(output.ParallelLoadThreads),
+    Password: __expectString(output.Password),
+    Port: __expectNumber(output.Port),
+    SecretsManagerAccessRoleArn: __expectString(output.SecretsManagerAccessRoleArn),
+    SecretsManagerSecretId: __expectString(output.SecretsManagerSecretId),
+    ServerName: __expectString(output.ServerName),
+    ServerTimezone: __expectString(output.ServerTimezone),
+    TargetDbType: __expectString(output.TargetDbType),
+    Username: __expectString(output.Username),
   } as any;
 };
 
 const deserializeAws_json1_1NeptuneSettings = (output: any, context: __SerdeContext): NeptuneSettings => {
   return {
-    ErrorRetryDuration:
-      output.ErrorRetryDuration !== undefined && output.ErrorRetryDuration !== null
-        ? output.ErrorRetryDuration
-        : undefined,
-    IamAuthEnabled:
-      output.IamAuthEnabled !== undefined && output.IamAuthEnabled !== null ? output.IamAuthEnabled : undefined,
-    MaxFileSize: output.MaxFileSize !== undefined && output.MaxFileSize !== null ? output.MaxFileSize : undefined,
-    MaxRetryCount:
-      output.MaxRetryCount !== undefined && output.MaxRetryCount !== null ? output.MaxRetryCount : undefined,
-    S3BucketFolder:
-      output.S3BucketFolder !== undefined && output.S3BucketFolder !== null ? output.S3BucketFolder : undefined,
-    S3BucketName: output.S3BucketName !== undefined && output.S3BucketName !== null ? output.S3BucketName : undefined,
-    ServiceAccessRoleArn:
-      output.ServiceAccessRoleArn !== undefined && output.ServiceAccessRoleArn !== null
-        ? output.ServiceAccessRoleArn
-        : undefined,
+    ErrorRetryDuration: __expectNumber(output.ErrorRetryDuration),
+    IamAuthEnabled: __expectBoolean(output.IamAuthEnabled),
+    MaxFileSize: __expectNumber(output.MaxFileSize),
+    MaxRetryCount: __expectNumber(output.MaxRetryCount),
+    S3BucketFolder: __expectString(output.S3BucketFolder),
+    S3BucketName: __expectString(output.S3BucketName),
+    ServiceAccessRoleArn: __expectString(output.ServiceAccessRoleArn),
   } as any;
 };
 
 const deserializeAws_json1_1OracleSettings = (output: any, context: __SerdeContext): OracleSettings => {
   return {
-    AccessAlternateDirectly:
-      output.AccessAlternateDirectly !== undefined && output.AccessAlternateDirectly !== null
-        ? output.AccessAlternateDirectly
-        : undefined,
-    AddSupplementalLogging:
-      output.AddSupplementalLogging !== undefined && output.AddSupplementalLogging !== null
-        ? output.AddSupplementalLogging
-        : undefined,
-    AdditionalArchivedLogDestId:
-      output.AdditionalArchivedLogDestId !== undefined && output.AdditionalArchivedLogDestId !== null
-        ? output.AdditionalArchivedLogDestId
-        : undefined,
-    AllowSelectNestedTables:
-      output.AllowSelectNestedTables !== undefined && output.AllowSelectNestedTables !== null
-        ? output.AllowSelectNestedTables
-        : undefined,
-    ArchivedLogDestId:
-      output.ArchivedLogDestId !== undefined && output.ArchivedLogDestId !== null
-        ? output.ArchivedLogDestId
-        : undefined,
-    ArchivedLogsOnly:
-      output.ArchivedLogsOnly !== undefined && output.ArchivedLogsOnly !== null ? output.ArchivedLogsOnly : undefined,
-    AsmPassword: output.AsmPassword !== undefined && output.AsmPassword !== null ? output.AsmPassword : undefined,
-    AsmServer: output.AsmServer !== undefined && output.AsmServer !== null ? output.AsmServer : undefined,
-    AsmUser: output.AsmUser !== undefined && output.AsmUser !== null ? output.AsmUser : undefined,
-    CharLengthSemantics:
-      output.CharLengthSemantics !== undefined && output.CharLengthSemantics !== null
-        ? output.CharLengthSemantics
-        : undefined,
-    DatabaseName: output.DatabaseName !== undefined && output.DatabaseName !== null ? output.DatabaseName : undefined,
-    DirectPathNoLog:
-      output.DirectPathNoLog !== undefined && output.DirectPathNoLog !== null ? output.DirectPathNoLog : undefined,
-    DirectPathParallelLoad:
-      output.DirectPathParallelLoad !== undefined && output.DirectPathParallelLoad !== null
-        ? output.DirectPathParallelLoad
-        : undefined,
-    EnableHomogenousTablespace:
-      output.EnableHomogenousTablespace !== undefined && output.EnableHomogenousTablespace !== null
-        ? output.EnableHomogenousTablespace
-        : undefined,
-    FailTasksOnLobTruncation:
-      output.FailTasksOnLobTruncation !== undefined && output.FailTasksOnLobTruncation !== null
-        ? output.FailTasksOnLobTruncation
-        : undefined,
-    NumberDatatypeScale:
-      output.NumberDatatypeScale !== undefined && output.NumberDatatypeScale !== null
-        ? output.NumberDatatypeScale
-        : undefined,
-    OraclePathPrefix:
-      output.OraclePathPrefix !== undefined && output.OraclePathPrefix !== null ? output.OraclePathPrefix : undefined,
-    ParallelAsmReadThreads:
-      output.ParallelAsmReadThreads !== undefined && output.ParallelAsmReadThreads !== null
-        ? output.ParallelAsmReadThreads
-        : undefined,
-    Password: output.Password !== undefined && output.Password !== null ? output.Password : undefined,
-    Port: output.Port !== undefined && output.Port !== null ? output.Port : undefined,
-    ReadAheadBlocks:
-      output.ReadAheadBlocks !== undefined && output.ReadAheadBlocks !== null ? output.ReadAheadBlocks : undefined,
-    ReadTableSpaceName:
-      output.ReadTableSpaceName !== undefined && output.ReadTableSpaceName !== null
-        ? output.ReadTableSpaceName
-        : undefined,
-    ReplacePathPrefix:
-      output.ReplacePathPrefix !== undefined && output.ReplacePathPrefix !== null
-        ? output.ReplacePathPrefix
-        : undefined,
-    RetryInterval:
-      output.RetryInterval !== undefined && output.RetryInterval !== null ? output.RetryInterval : undefined,
-    SecretsManagerAccessRoleArn:
-      output.SecretsManagerAccessRoleArn !== undefined && output.SecretsManagerAccessRoleArn !== null
-        ? output.SecretsManagerAccessRoleArn
-        : undefined,
-    SecretsManagerOracleAsmAccessRoleArn:
-      output.SecretsManagerOracleAsmAccessRoleArn !== undefined && output.SecretsManagerOracleAsmAccessRoleArn !== null
-        ? output.SecretsManagerOracleAsmAccessRoleArn
-        : undefined,
-    SecretsManagerOracleAsmSecretId:
-      output.SecretsManagerOracleAsmSecretId !== undefined && output.SecretsManagerOracleAsmSecretId !== null
-        ? output.SecretsManagerOracleAsmSecretId
-        : undefined,
-    SecretsManagerSecretId:
-      output.SecretsManagerSecretId !== undefined && output.SecretsManagerSecretId !== null
-        ? output.SecretsManagerSecretId
-        : undefined,
-    SecurityDbEncryption:
-      output.SecurityDbEncryption !== undefined && output.SecurityDbEncryption !== null
-        ? output.SecurityDbEncryption
-        : undefined,
-    SecurityDbEncryptionName:
-      output.SecurityDbEncryptionName !== undefined && output.SecurityDbEncryptionName !== null
-        ? output.SecurityDbEncryptionName
-        : undefined,
-    ServerName: output.ServerName !== undefined && output.ServerName !== null ? output.ServerName : undefined,
-    SpatialDataOptionToGeoJsonFunctionName:
-      output.SpatialDataOptionToGeoJsonFunctionName !== undefined &&
-      output.SpatialDataOptionToGeoJsonFunctionName !== null
-        ? output.SpatialDataOptionToGeoJsonFunctionName
-        : undefined,
-    UseAlternateFolderForOnline:
-      output.UseAlternateFolderForOnline !== undefined && output.UseAlternateFolderForOnline !== null
-        ? output.UseAlternateFolderForOnline
-        : undefined,
-    UsePathPrefix:
-      output.UsePathPrefix !== undefined && output.UsePathPrefix !== null ? output.UsePathPrefix : undefined,
-    Username: output.Username !== undefined && output.Username !== null ? output.Username : undefined,
+    AccessAlternateDirectly: __expectBoolean(output.AccessAlternateDirectly),
+    AddSupplementalLogging: __expectBoolean(output.AddSupplementalLogging),
+    AdditionalArchivedLogDestId: __expectNumber(output.AdditionalArchivedLogDestId),
+    AllowSelectNestedTables: __expectBoolean(output.AllowSelectNestedTables),
+    ArchivedLogDestId: __expectNumber(output.ArchivedLogDestId),
+    ArchivedLogsOnly: __expectBoolean(output.ArchivedLogsOnly),
+    AsmPassword: __expectString(output.AsmPassword),
+    AsmServer: __expectString(output.AsmServer),
+    AsmUser: __expectString(output.AsmUser),
+    CharLengthSemantics: __expectString(output.CharLengthSemantics),
+    DatabaseName: __expectString(output.DatabaseName),
+    DirectPathNoLog: __expectBoolean(output.DirectPathNoLog),
+    DirectPathParallelLoad: __expectBoolean(output.DirectPathParallelLoad),
+    EnableHomogenousTablespace: __expectBoolean(output.EnableHomogenousTablespace),
+    FailTasksOnLobTruncation: __expectBoolean(output.FailTasksOnLobTruncation),
+    NumberDatatypeScale: __expectNumber(output.NumberDatatypeScale),
+    OraclePathPrefix: __expectString(output.OraclePathPrefix),
+    ParallelAsmReadThreads: __expectNumber(output.ParallelAsmReadThreads),
+    Password: __expectString(output.Password),
+    Port: __expectNumber(output.Port),
+    ReadAheadBlocks: __expectNumber(output.ReadAheadBlocks),
+    ReadTableSpaceName: __expectBoolean(output.ReadTableSpaceName),
+    ReplacePathPrefix: __expectBoolean(output.ReplacePathPrefix),
+    RetryInterval: __expectNumber(output.RetryInterval),
+    SecretsManagerAccessRoleArn: __expectString(output.SecretsManagerAccessRoleArn),
+    SecretsManagerOracleAsmAccessRoleArn: __expectString(output.SecretsManagerOracleAsmAccessRoleArn),
+    SecretsManagerOracleAsmSecretId: __expectString(output.SecretsManagerOracleAsmSecretId),
+    SecretsManagerSecretId: __expectString(output.SecretsManagerSecretId),
+    SecurityDbEncryption: __expectString(output.SecurityDbEncryption),
+    SecurityDbEncryptionName: __expectString(output.SecurityDbEncryptionName),
+    ServerName: __expectString(output.ServerName),
+    SpatialDataOptionToGeoJsonFunctionName: __expectString(output.SpatialDataOptionToGeoJsonFunctionName),
+    UseAlternateFolderForOnline: __expectBoolean(output.UseAlternateFolderForOnline),
+    UsePathPrefix: __expectString(output.UsePathPrefix),
+    Username: __expectString(output.Username),
   } as any;
 };
 
@@ -8146,31 +7883,14 @@ const deserializeAws_json1_1OrderableReplicationInstance = (
       output.AvailabilityZones !== undefined && output.AvailabilityZones !== null
         ? deserializeAws_json1_1AvailabilityZonesList(output.AvailabilityZones, context)
         : undefined,
-    DefaultAllocatedStorage:
-      output.DefaultAllocatedStorage !== undefined && output.DefaultAllocatedStorage !== null
-        ? output.DefaultAllocatedStorage
-        : undefined,
-    EngineVersion:
-      output.EngineVersion !== undefined && output.EngineVersion !== null ? output.EngineVersion : undefined,
-    IncludedAllocatedStorage:
-      output.IncludedAllocatedStorage !== undefined && output.IncludedAllocatedStorage !== null
-        ? output.IncludedAllocatedStorage
-        : undefined,
-    MaxAllocatedStorage:
-      output.MaxAllocatedStorage !== undefined && output.MaxAllocatedStorage !== null
-        ? output.MaxAllocatedStorage
-        : undefined,
-    MinAllocatedStorage:
-      output.MinAllocatedStorage !== undefined && output.MinAllocatedStorage !== null
-        ? output.MinAllocatedStorage
-        : undefined,
-    ReleaseStatus:
-      output.ReleaseStatus !== undefined && output.ReleaseStatus !== null ? output.ReleaseStatus : undefined,
-    ReplicationInstanceClass:
-      output.ReplicationInstanceClass !== undefined && output.ReplicationInstanceClass !== null
-        ? output.ReplicationInstanceClass
-        : undefined,
-    StorageType: output.StorageType !== undefined && output.StorageType !== null ? output.StorageType : undefined,
+    DefaultAllocatedStorage: __expectNumber(output.DefaultAllocatedStorage),
+    EngineVersion: __expectString(output.EngineVersion),
+    IncludedAllocatedStorage: __expectNumber(output.IncludedAllocatedStorage),
+    MaxAllocatedStorage: __expectNumber(output.MaxAllocatedStorage),
+    MinAllocatedStorage: __expectNumber(output.MinAllocatedStorage),
+    ReleaseStatus: __expectString(output.ReleaseStatus),
+    ReplicationInstanceClass: __expectString(output.ReplicationInstanceClass),
+    StorageType: __expectString(output.StorageType),
   } as any;
 };
 
@@ -8193,7 +7913,7 @@ const deserializeAws_json1_1PendingMaintenanceAction = (
   context: __SerdeContext
 ): PendingMaintenanceAction => {
   return {
-    Action: output.Action !== undefined && output.Action !== null ? output.Action : undefined,
+    Action: __expectString(output.Action),
     AutoAppliedAfterDate:
       output.AutoAppliedAfterDate !== undefined && output.AutoAppliedAfterDate !== null
         ? new Date(Math.round(output.AutoAppliedAfterDate * 1000))
@@ -8202,12 +7922,12 @@ const deserializeAws_json1_1PendingMaintenanceAction = (
       output.CurrentApplyDate !== undefined && output.CurrentApplyDate !== null
         ? new Date(Math.round(output.CurrentApplyDate * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     ForcedApplyDate:
       output.ForcedApplyDate !== undefined && output.ForcedApplyDate !== null
         ? new Date(Math.round(output.ForcedApplyDate * 1000))
         : undefined,
-    OptInStatus: output.OptInStatus !== undefined && output.OptInStatus !== null ? output.OptInStatus : undefined,
+    OptInStatus: __expectString(output.OptInStatus),
   } as any;
 };
 
@@ -8241,36 +7961,20 @@ const deserializeAws_json1_1PendingMaintenanceActions = (
 
 const deserializeAws_json1_1PostgreSQLSettings = (output: any, context: __SerdeContext): PostgreSQLSettings => {
   return {
-    AfterConnectScript:
-      output.AfterConnectScript !== undefined && output.AfterConnectScript !== null
-        ? output.AfterConnectScript
-        : undefined,
-    CaptureDdls: output.CaptureDdls !== undefined && output.CaptureDdls !== null ? output.CaptureDdls : undefined,
-    DatabaseName: output.DatabaseName !== undefined && output.DatabaseName !== null ? output.DatabaseName : undefined,
-    DdlArtifactsSchema:
-      output.DdlArtifactsSchema !== undefined && output.DdlArtifactsSchema !== null
-        ? output.DdlArtifactsSchema
-        : undefined,
-    ExecuteTimeout:
-      output.ExecuteTimeout !== undefined && output.ExecuteTimeout !== null ? output.ExecuteTimeout : undefined,
-    FailTasksOnLobTruncation:
-      output.FailTasksOnLobTruncation !== undefined && output.FailTasksOnLobTruncation !== null
-        ? output.FailTasksOnLobTruncation
-        : undefined,
-    MaxFileSize: output.MaxFileSize !== undefined && output.MaxFileSize !== null ? output.MaxFileSize : undefined,
-    Password: output.Password !== undefined && output.Password !== null ? output.Password : undefined,
-    Port: output.Port !== undefined && output.Port !== null ? output.Port : undefined,
-    SecretsManagerAccessRoleArn:
-      output.SecretsManagerAccessRoleArn !== undefined && output.SecretsManagerAccessRoleArn !== null
-        ? output.SecretsManagerAccessRoleArn
-        : undefined,
-    SecretsManagerSecretId:
-      output.SecretsManagerSecretId !== undefined && output.SecretsManagerSecretId !== null
-        ? output.SecretsManagerSecretId
-        : undefined,
-    ServerName: output.ServerName !== undefined && output.ServerName !== null ? output.ServerName : undefined,
-    SlotName: output.SlotName !== undefined && output.SlotName !== null ? output.SlotName : undefined,
-    Username: output.Username !== undefined && output.Username !== null ? output.Username : undefined,
+    AfterConnectScript: __expectString(output.AfterConnectScript),
+    CaptureDdls: __expectBoolean(output.CaptureDdls),
+    DatabaseName: __expectString(output.DatabaseName),
+    DdlArtifactsSchema: __expectString(output.DdlArtifactsSchema),
+    ExecuteTimeout: __expectNumber(output.ExecuteTimeout),
+    FailTasksOnLobTruncation: __expectBoolean(output.FailTasksOnLobTruncation),
+    MaxFileSize: __expectNumber(output.MaxFileSize),
+    Password: __expectString(output.Password),
+    Port: __expectNumber(output.Port),
+    SecretsManagerAccessRoleArn: __expectString(output.SecretsManagerAccessRoleArn),
+    SecretsManagerSecretId: __expectString(output.SecretsManagerSecretId),
+    ServerName: __expectString(output.ServerName),
+    SlotName: __expectString(output.SlotName),
+    Username: __expectString(output.Username),
   } as any;
 };
 
@@ -8288,67 +7992,36 @@ const deserializeAws_json1_1RebootReplicationInstanceResponse = (
 
 const deserializeAws_json1_1RedshiftSettings = (output: any, context: __SerdeContext): RedshiftSettings => {
   return {
-    AcceptAnyDate:
-      output.AcceptAnyDate !== undefined && output.AcceptAnyDate !== null ? output.AcceptAnyDate : undefined,
-    AfterConnectScript:
-      output.AfterConnectScript !== undefined && output.AfterConnectScript !== null
-        ? output.AfterConnectScript
-        : undefined,
-    BucketFolder: output.BucketFolder !== undefined && output.BucketFolder !== null ? output.BucketFolder : undefined,
-    BucketName: output.BucketName !== undefined && output.BucketName !== null ? output.BucketName : undefined,
-    CaseSensitiveNames:
-      output.CaseSensitiveNames !== undefined && output.CaseSensitiveNames !== null
-        ? output.CaseSensitiveNames
-        : undefined,
-    CompUpdate: output.CompUpdate !== undefined && output.CompUpdate !== null ? output.CompUpdate : undefined,
-    ConnectionTimeout:
-      output.ConnectionTimeout !== undefined && output.ConnectionTimeout !== null
-        ? output.ConnectionTimeout
-        : undefined,
-    DatabaseName: output.DatabaseName !== undefined && output.DatabaseName !== null ? output.DatabaseName : undefined,
-    DateFormat: output.DateFormat !== undefined && output.DateFormat !== null ? output.DateFormat : undefined,
-    EmptyAsNull: output.EmptyAsNull !== undefined && output.EmptyAsNull !== null ? output.EmptyAsNull : undefined,
-    EncryptionMode:
-      output.EncryptionMode !== undefined && output.EncryptionMode !== null ? output.EncryptionMode : undefined,
-    ExplicitIds: output.ExplicitIds !== undefined && output.ExplicitIds !== null ? output.ExplicitIds : undefined,
-    FileTransferUploadStreams:
-      output.FileTransferUploadStreams !== undefined && output.FileTransferUploadStreams !== null
-        ? output.FileTransferUploadStreams
-        : undefined,
-    LoadTimeout: output.LoadTimeout !== undefined && output.LoadTimeout !== null ? output.LoadTimeout : undefined,
-    MaxFileSize: output.MaxFileSize !== undefined && output.MaxFileSize !== null ? output.MaxFileSize : undefined,
-    Password: output.Password !== undefined && output.Password !== null ? output.Password : undefined,
-    Port: output.Port !== undefined && output.Port !== null ? output.Port : undefined,
-    RemoveQuotes: output.RemoveQuotes !== undefined && output.RemoveQuotes !== null ? output.RemoveQuotes : undefined,
-    ReplaceChars: output.ReplaceChars !== undefined && output.ReplaceChars !== null ? output.ReplaceChars : undefined,
-    ReplaceInvalidChars:
-      output.ReplaceInvalidChars !== undefined && output.ReplaceInvalidChars !== null
-        ? output.ReplaceInvalidChars
-        : undefined,
-    SecretsManagerAccessRoleArn:
-      output.SecretsManagerAccessRoleArn !== undefined && output.SecretsManagerAccessRoleArn !== null
-        ? output.SecretsManagerAccessRoleArn
-        : undefined,
-    SecretsManagerSecretId:
-      output.SecretsManagerSecretId !== undefined && output.SecretsManagerSecretId !== null
-        ? output.SecretsManagerSecretId
-        : undefined,
-    ServerName: output.ServerName !== undefined && output.ServerName !== null ? output.ServerName : undefined,
-    ServerSideEncryptionKmsKeyId:
-      output.ServerSideEncryptionKmsKeyId !== undefined && output.ServerSideEncryptionKmsKeyId !== null
-        ? output.ServerSideEncryptionKmsKeyId
-        : undefined,
-    ServiceAccessRoleArn:
-      output.ServiceAccessRoleArn !== undefined && output.ServiceAccessRoleArn !== null
-        ? output.ServiceAccessRoleArn
-        : undefined,
-    TimeFormat: output.TimeFormat !== undefined && output.TimeFormat !== null ? output.TimeFormat : undefined,
-    TrimBlanks: output.TrimBlanks !== undefined && output.TrimBlanks !== null ? output.TrimBlanks : undefined,
-    TruncateColumns:
-      output.TruncateColumns !== undefined && output.TruncateColumns !== null ? output.TruncateColumns : undefined,
-    Username: output.Username !== undefined && output.Username !== null ? output.Username : undefined,
-    WriteBufferSize:
-      output.WriteBufferSize !== undefined && output.WriteBufferSize !== null ? output.WriteBufferSize : undefined,
+    AcceptAnyDate: __expectBoolean(output.AcceptAnyDate),
+    AfterConnectScript: __expectString(output.AfterConnectScript),
+    BucketFolder: __expectString(output.BucketFolder),
+    BucketName: __expectString(output.BucketName),
+    CaseSensitiveNames: __expectBoolean(output.CaseSensitiveNames),
+    CompUpdate: __expectBoolean(output.CompUpdate),
+    ConnectionTimeout: __expectNumber(output.ConnectionTimeout),
+    DatabaseName: __expectString(output.DatabaseName),
+    DateFormat: __expectString(output.DateFormat),
+    EmptyAsNull: __expectBoolean(output.EmptyAsNull),
+    EncryptionMode: __expectString(output.EncryptionMode),
+    ExplicitIds: __expectBoolean(output.ExplicitIds),
+    FileTransferUploadStreams: __expectNumber(output.FileTransferUploadStreams),
+    LoadTimeout: __expectNumber(output.LoadTimeout),
+    MaxFileSize: __expectNumber(output.MaxFileSize),
+    Password: __expectString(output.Password),
+    Port: __expectNumber(output.Port),
+    RemoveQuotes: __expectBoolean(output.RemoveQuotes),
+    ReplaceChars: __expectString(output.ReplaceChars),
+    ReplaceInvalidChars: __expectString(output.ReplaceInvalidChars),
+    SecretsManagerAccessRoleArn: __expectString(output.SecretsManagerAccessRoleArn),
+    SecretsManagerSecretId: __expectString(output.SecretsManagerSecretId),
+    ServerName: __expectString(output.ServerName),
+    ServerSideEncryptionKmsKeyId: __expectString(output.ServerSideEncryptionKmsKeyId),
+    ServiceAccessRoleArn: __expectString(output.ServiceAccessRoleArn),
+    TimeFormat: __expectString(output.TimeFormat),
+    TrimBlanks: __expectBoolean(output.TrimBlanks),
+    TruncateColumns: __expectBoolean(output.TruncateColumns),
+    Username: __expectString(output.Username),
+    WriteBufferSize: __expectNumber(output.WriteBufferSize),
   } as any;
 };
 
@@ -8363,29 +8036,20 @@ const deserializeAws_json1_1RefreshSchemasResponse = (output: any, context: __Se
 
 const deserializeAws_json1_1RefreshSchemasStatus = (output: any, context: __SerdeContext): RefreshSchemasStatus => {
   return {
-    EndpointArn: output.EndpointArn !== undefined && output.EndpointArn !== null ? output.EndpointArn : undefined,
-    LastFailureMessage:
-      output.LastFailureMessage !== undefined && output.LastFailureMessage !== null
-        ? output.LastFailureMessage
-        : undefined,
+    EndpointArn: __expectString(output.EndpointArn),
+    LastFailureMessage: __expectString(output.LastFailureMessage),
     LastRefreshDate:
       output.LastRefreshDate !== undefined && output.LastRefreshDate !== null
         ? new Date(Math.round(output.LastRefreshDate * 1000))
         : undefined,
-    ReplicationInstanceArn:
-      output.ReplicationInstanceArn !== undefined && output.ReplicationInstanceArn !== null
-        ? output.ReplicationInstanceArn
-        : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    ReplicationInstanceArn: __expectString(output.ReplicationInstanceArn),
+    Status: __expectString(output.Status),
   } as any;
 };
 
 const deserializeAws_json1_1ReloadTablesResponse = (output: any, context: __SerdeContext): ReloadTablesResponse => {
   return {
-    ReplicationTaskArn:
-      output.ReplicationTaskArn !== undefined && output.ReplicationTaskArn !== null
-        ? output.ReplicationTaskArn
-        : undefined,
+    ReplicationTaskArn: __expectString(output.ReplicationTaskArn),
   } as any;
 };
 
@@ -8398,18 +8062,11 @@ const deserializeAws_json1_1RemoveTagsFromResourceResponse = (
 
 const deserializeAws_json1_1ReplicationInstance = (output: any, context: __SerdeContext): ReplicationInstance => {
   return {
-    AllocatedStorage:
-      output.AllocatedStorage !== undefined && output.AllocatedStorage !== null ? output.AllocatedStorage : undefined,
-    AutoMinorVersionUpgrade:
-      output.AutoMinorVersionUpgrade !== undefined && output.AutoMinorVersionUpgrade !== null
-        ? output.AutoMinorVersionUpgrade
-        : undefined,
-    AvailabilityZone:
-      output.AvailabilityZone !== undefined && output.AvailabilityZone !== null ? output.AvailabilityZone : undefined,
-    DnsNameServers:
-      output.DnsNameServers !== undefined && output.DnsNameServers !== null ? output.DnsNameServers : undefined,
-    EngineVersion:
-      output.EngineVersion !== undefined && output.EngineVersion !== null ? output.EngineVersion : undefined,
+    AllocatedStorage: __expectNumber(output.AllocatedStorage),
+    AutoMinorVersionUpgrade: __expectBoolean(output.AutoMinorVersionUpgrade),
+    AvailabilityZone: __expectString(output.AvailabilityZone),
+    DnsNameServers: __expectString(output.DnsNameServers),
+    EngineVersion: __expectString(output.EngineVersion),
     FreeUntil:
       output.FreeUntil !== undefined && output.FreeUntil !== null
         ? new Date(Math.round(output.FreeUntil * 1000))
@@ -8418,36 +8075,18 @@ const deserializeAws_json1_1ReplicationInstance = (output: any, context: __Serde
       output.InstanceCreateTime !== undefined && output.InstanceCreateTime !== null
         ? new Date(Math.round(output.InstanceCreateTime * 1000))
         : undefined,
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
-    MultiAZ: output.MultiAZ !== undefined && output.MultiAZ !== null ? output.MultiAZ : undefined,
+    KmsKeyId: __expectString(output.KmsKeyId),
+    MultiAZ: __expectBoolean(output.MultiAZ),
     PendingModifiedValues:
       output.PendingModifiedValues !== undefined && output.PendingModifiedValues !== null
         ? deserializeAws_json1_1ReplicationPendingModifiedValues(output.PendingModifiedValues, context)
         : undefined,
-    PreferredMaintenanceWindow:
-      output.PreferredMaintenanceWindow !== undefined && output.PreferredMaintenanceWindow !== null
-        ? output.PreferredMaintenanceWindow
-        : undefined,
-    PubliclyAccessible:
-      output.PubliclyAccessible !== undefined && output.PubliclyAccessible !== null
-        ? output.PubliclyAccessible
-        : undefined,
-    ReplicationInstanceArn:
-      output.ReplicationInstanceArn !== undefined && output.ReplicationInstanceArn !== null
-        ? output.ReplicationInstanceArn
-        : undefined,
-    ReplicationInstanceClass:
-      output.ReplicationInstanceClass !== undefined && output.ReplicationInstanceClass !== null
-        ? output.ReplicationInstanceClass
-        : undefined,
-    ReplicationInstanceIdentifier:
-      output.ReplicationInstanceIdentifier !== undefined && output.ReplicationInstanceIdentifier !== null
-        ? output.ReplicationInstanceIdentifier
-        : undefined,
-    ReplicationInstancePrivateIpAddress:
-      output.ReplicationInstancePrivateIpAddress !== undefined && output.ReplicationInstancePrivateIpAddress !== null
-        ? output.ReplicationInstancePrivateIpAddress
-        : undefined,
+    PreferredMaintenanceWindow: __expectString(output.PreferredMaintenanceWindow),
+    PubliclyAccessible: __expectBoolean(output.PubliclyAccessible),
+    ReplicationInstanceArn: __expectString(output.ReplicationInstanceArn),
+    ReplicationInstanceClass: __expectString(output.ReplicationInstanceClass),
+    ReplicationInstanceIdentifier: __expectString(output.ReplicationInstanceIdentifier),
+    ReplicationInstancePrivateIpAddress: __expectString(output.ReplicationInstancePrivateIpAddress),
     ReplicationInstancePrivateIpAddresses:
       output.ReplicationInstancePrivateIpAddresses !== undefined &&
       output.ReplicationInstancePrivateIpAddresses !== null
@@ -8456,10 +8095,7 @@ const deserializeAws_json1_1ReplicationInstance = (output: any, context: __Serde
             context
           )
         : undefined,
-    ReplicationInstancePublicIpAddress:
-      output.ReplicationInstancePublicIpAddress !== undefined && output.ReplicationInstancePublicIpAddress !== null
-        ? output.ReplicationInstancePublicIpAddress
-        : undefined,
+    ReplicationInstancePublicIpAddress: __expectString(output.ReplicationInstancePublicIpAddress),
     ReplicationInstancePublicIpAddresses:
       output.ReplicationInstancePublicIpAddresses !== undefined && output.ReplicationInstancePublicIpAddresses !== null
         ? deserializeAws_json1_1ReplicationInstancePublicIpAddressList(
@@ -8467,18 +8103,12 @@ const deserializeAws_json1_1ReplicationInstance = (output: any, context: __Serde
             context
           )
         : undefined,
-    ReplicationInstanceStatus:
-      output.ReplicationInstanceStatus !== undefined && output.ReplicationInstanceStatus !== null
-        ? output.ReplicationInstanceStatus
-        : undefined,
+    ReplicationInstanceStatus: __expectString(output.ReplicationInstanceStatus),
     ReplicationSubnetGroup:
       output.ReplicationSubnetGroup !== undefined && output.ReplicationSubnetGroup !== null
         ? deserializeAws_json1_1ReplicationSubnetGroup(output.ReplicationSubnetGroup, context)
         : undefined,
-    SecondaryAvailabilityZone:
-      output.SecondaryAvailabilityZone !== undefined && output.SecondaryAvailabilityZone !== null
-        ? output.SecondaryAvailabilityZone
-        : undefined,
+    SecondaryAvailabilityZone: __expectString(output.SecondaryAvailabilityZone),
     VpcSecurityGroups:
       output.VpcSecurityGroups !== undefined && output.VpcSecurityGroups !== null
         ? deserializeAws_json1_1VpcSecurityGroupMembershipList(output.VpcSecurityGroups, context)
@@ -8507,7 +8137,7 @@ const deserializeAws_json1_1ReplicationInstancePrivateIpAddressList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -8521,7 +8151,7 @@ const deserializeAws_json1_1ReplicationInstancePublicIpAddressList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -8530,18 +8160,9 @@ const deserializeAws_json1_1ReplicationInstanceTaskLog = (
   context: __SerdeContext
 ): ReplicationInstanceTaskLog => {
   return {
-    ReplicationInstanceTaskLogSize:
-      output.ReplicationInstanceTaskLogSize !== undefined && output.ReplicationInstanceTaskLogSize !== null
-        ? output.ReplicationInstanceTaskLogSize
-        : undefined,
-    ReplicationTaskArn:
-      output.ReplicationTaskArn !== undefined && output.ReplicationTaskArn !== null
-        ? output.ReplicationTaskArn
-        : undefined,
-    ReplicationTaskName:
-      output.ReplicationTaskName !== undefined && output.ReplicationTaskName !== null
-        ? output.ReplicationTaskName
-        : undefined,
+    ReplicationInstanceTaskLogSize: __expectNumber(output.ReplicationInstanceTaskLogSize),
+    ReplicationTaskArn: __expectString(output.ReplicationTaskArn),
+    ReplicationTaskName: __expectString(output.ReplicationTaskName),
   } as any;
 };
 
@@ -8564,37 +8185,23 @@ const deserializeAws_json1_1ReplicationPendingModifiedValues = (
   context: __SerdeContext
 ): ReplicationPendingModifiedValues => {
   return {
-    AllocatedStorage:
-      output.AllocatedStorage !== undefined && output.AllocatedStorage !== null ? output.AllocatedStorage : undefined,
-    EngineVersion:
-      output.EngineVersion !== undefined && output.EngineVersion !== null ? output.EngineVersion : undefined,
-    MultiAZ: output.MultiAZ !== undefined && output.MultiAZ !== null ? output.MultiAZ : undefined,
-    ReplicationInstanceClass:
-      output.ReplicationInstanceClass !== undefined && output.ReplicationInstanceClass !== null
-        ? output.ReplicationInstanceClass
-        : undefined,
+    AllocatedStorage: __expectNumber(output.AllocatedStorage),
+    EngineVersion: __expectString(output.EngineVersion),
+    MultiAZ: __expectBoolean(output.MultiAZ),
+    ReplicationInstanceClass: __expectString(output.ReplicationInstanceClass),
   } as any;
 };
 
 const deserializeAws_json1_1ReplicationSubnetGroup = (output: any, context: __SerdeContext): ReplicationSubnetGroup => {
   return {
-    ReplicationSubnetGroupDescription:
-      output.ReplicationSubnetGroupDescription !== undefined && output.ReplicationSubnetGroupDescription !== null
-        ? output.ReplicationSubnetGroupDescription
-        : undefined,
-    ReplicationSubnetGroupIdentifier:
-      output.ReplicationSubnetGroupIdentifier !== undefined && output.ReplicationSubnetGroupIdentifier !== null
-        ? output.ReplicationSubnetGroupIdentifier
-        : undefined,
-    SubnetGroupStatus:
-      output.SubnetGroupStatus !== undefined && output.SubnetGroupStatus !== null
-        ? output.SubnetGroupStatus
-        : undefined,
+    ReplicationSubnetGroupDescription: __expectString(output.ReplicationSubnetGroupDescription),
+    ReplicationSubnetGroupIdentifier: __expectString(output.ReplicationSubnetGroupIdentifier),
+    SubnetGroupStatus: __expectString(output.SubnetGroupStatus),
     Subnets:
       output.Subnets !== undefined && output.Subnets !== null
         ? deserializeAws_json1_1SubnetList(output.Subnets, context)
         : undefined,
-    VpcId: output.VpcId !== undefined && output.VpcId !== null ? output.VpcId : undefined,
+    VpcId: __expectString(output.VpcId),
   } as any;
 };
 
@@ -8603,7 +8210,7 @@ const deserializeAws_json1_1ReplicationSubnetGroupDoesNotCoverEnoughAZs = (
   context: __SerdeContext
 ): ReplicationSubnetGroupDoesNotCoverEnoughAZs => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -8623,40 +8230,19 @@ const deserializeAws_json1_1ReplicationSubnetGroups = (
 
 const deserializeAws_json1_1ReplicationTask = (output: any, context: __SerdeContext): ReplicationTask => {
   return {
-    CdcStartPosition:
-      output.CdcStartPosition !== undefined && output.CdcStartPosition !== null ? output.CdcStartPosition : undefined,
-    CdcStopPosition:
-      output.CdcStopPosition !== undefined && output.CdcStopPosition !== null ? output.CdcStopPosition : undefined,
-    LastFailureMessage:
-      output.LastFailureMessage !== undefined && output.LastFailureMessage !== null
-        ? output.LastFailureMessage
-        : undefined,
-    MigrationType:
-      output.MigrationType !== undefined && output.MigrationType !== null ? output.MigrationType : undefined,
-    RecoveryCheckpoint:
-      output.RecoveryCheckpoint !== undefined && output.RecoveryCheckpoint !== null
-        ? output.RecoveryCheckpoint
-        : undefined,
-    ReplicationInstanceArn:
-      output.ReplicationInstanceArn !== undefined && output.ReplicationInstanceArn !== null
-        ? output.ReplicationInstanceArn
-        : undefined,
-    ReplicationTaskArn:
-      output.ReplicationTaskArn !== undefined && output.ReplicationTaskArn !== null
-        ? output.ReplicationTaskArn
-        : undefined,
+    CdcStartPosition: __expectString(output.CdcStartPosition),
+    CdcStopPosition: __expectString(output.CdcStopPosition),
+    LastFailureMessage: __expectString(output.LastFailureMessage),
+    MigrationType: __expectString(output.MigrationType),
+    RecoveryCheckpoint: __expectString(output.RecoveryCheckpoint),
+    ReplicationInstanceArn: __expectString(output.ReplicationInstanceArn),
+    ReplicationTaskArn: __expectString(output.ReplicationTaskArn),
     ReplicationTaskCreationDate:
       output.ReplicationTaskCreationDate !== undefined && output.ReplicationTaskCreationDate !== null
         ? new Date(Math.round(output.ReplicationTaskCreationDate * 1000))
         : undefined,
-    ReplicationTaskIdentifier:
-      output.ReplicationTaskIdentifier !== undefined && output.ReplicationTaskIdentifier !== null
-        ? output.ReplicationTaskIdentifier
-        : undefined,
-    ReplicationTaskSettings:
-      output.ReplicationTaskSettings !== undefined && output.ReplicationTaskSettings !== null
-        ? output.ReplicationTaskSettings
-        : undefined,
+    ReplicationTaskIdentifier: __expectString(output.ReplicationTaskIdentifier),
+    ReplicationTaskSettings: __expectString(output.ReplicationTaskSettings),
     ReplicationTaskStartDate:
       output.ReplicationTaskStartDate !== undefined && output.ReplicationTaskStartDate !== null
         ? new Date(Math.round(output.ReplicationTaskStartDate * 1000))
@@ -8665,23 +8251,13 @@ const deserializeAws_json1_1ReplicationTask = (output: any, context: __SerdeCont
       output.ReplicationTaskStats !== undefined && output.ReplicationTaskStats !== null
         ? deserializeAws_json1_1ReplicationTaskStats(output.ReplicationTaskStats, context)
         : undefined,
-    SourceEndpointArn:
-      output.SourceEndpointArn !== undefined && output.SourceEndpointArn !== null
-        ? output.SourceEndpointArn
-        : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StopReason: output.StopReason !== undefined && output.StopReason !== null ? output.StopReason : undefined,
-    TableMappings:
-      output.TableMappings !== undefined && output.TableMappings !== null ? output.TableMappings : undefined,
-    TargetEndpointArn:
-      output.TargetEndpointArn !== undefined && output.TargetEndpointArn !== null
-        ? output.TargetEndpointArn
-        : undefined,
-    TargetReplicationInstanceArn:
-      output.TargetReplicationInstanceArn !== undefined && output.TargetReplicationInstanceArn !== null
-        ? output.TargetReplicationInstanceArn
-        : undefined,
-    TaskData: output.TaskData !== undefined && output.TaskData !== null ? output.TaskData : undefined,
+    SourceEndpointArn: __expectString(output.SourceEndpointArn),
+    Status: __expectString(output.Status),
+    StopReason: __expectString(output.StopReason),
+    TableMappings: __expectString(output.TableMappings),
+    TargetEndpointArn: __expectString(output.TargetEndpointArn),
+    TargetReplicationInstanceArn: __expectString(output.TargetReplicationInstanceArn),
+    TaskData: __expectString(output.TaskData),
   } as any;
 };
 
@@ -8690,29 +8266,16 @@ const deserializeAws_json1_1ReplicationTaskAssessmentResult = (
   context: __SerdeContext
 ): ReplicationTaskAssessmentResult => {
   return {
-    AssessmentResults:
-      output.AssessmentResults !== undefined && output.AssessmentResults !== null
-        ? output.AssessmentResults
-        : undefined,
-    AssessmentResultsFile:
-      output.AssessmentResultsFile !== undefined && output.AssessmentResultsFile !== null
-        ? output.AssessmentResultsFile
-        : undefined,
-    AssessmentStatus:
-      output.AssessmentStatus !== undefined && output.AssessmentStatus !== null ? output.AssessmentStatus : undefined,
-    ReplicationTaskArn:
-      output.ReplicationTaskArn !== undefined && output.ReplicationTaskArn !== null
-        ? output.ReplicationTaskArn
-        : undefined,
-    ReplicationTaskIdentifier:
-      output.ReplicationTaskIdentifier !== undefined && output.ReplicationTaskIdentifier !== null
-        ? output.ReplicationTaskIdentifier
-        : undefined,
+    AssessmentResults: __expectString(output.AssessmentResults),
+    AssessmentResultsFile: __expectString(output.AssessmentResultsFile),
+    AssessmentStatus: __expectString(output.AssessmentStatus),
+    ReplicationTaskArn: __expectString(output.ReplicationTaskArn),
+    ReplicationTaskIdentifier: __expectString(output.ReplicationTaskIdentifier),
     ReplicationTaskLastAssessmentDate:
       output.ReplicationTaskLastAssessmentDate !== undefined && output.ReplicationTaskLastAssessmentDate !== null
         ? new Date(Math.round(output.ReplicationTaskLastAssessmentDate * 1000))
         : undefined,
-    S3ObjectUrl: output.S3ObjectUrl !== undefined && output.S3ObjectUrl !== null ? output.S3ObjectUrl : undefined,
+    S3ObjectUrl: __expectString(output.S3ObjectUrl),
   } as any;
 };
 
@@ -8739,46 +8302,21 @@ const deserializeAws_json1_1ReplicationTaskAssessmentRun = (
       output.AssessmentProgress !== undefined && output.AssessmentProgress !== null
         ? deserializeAws_json1_1ReplicationTaskAssessmentRunProgress(output.AssessmentProgress, context)
         : undefined,
-    AssessmentRunName:
-      output.AssessmentRunName !== undefined && output.AssessmentRunName !== null
-        ? output.AssessmentRunName
-        : undefined,
-    LastFailureMessage:
-      output.LastFailureMessage !== undefined && output.LastFailureMessage !== null
-        ? output.LastFailureMessage
-        : undefined,
-    ReplicationTaskArn:
-      output.ReplicationTaskArn !== undefined && output.ReplicationTaskArn !== null
-        ? output.ReplicationTaskArn
-        : undefined,
-    ReplicationTaskAssessmentRunArn:
-      output.ReplicationTaskAssessmentRunArn !== undefined && output.ReplicationTaskAssessmentRunArn !== null
-        ? output.ReplicationTaskAssessmentRunArn
-        : undefined,
+    AssessmentRunName: __expectString(output.AssessmentRunName),
+    LastFailureMessage: __expectString(output.LastFailureMessage),
+    ReplicationTaskArn: __expectString(output.ReplicationTaskArn),
+    ReplicationTaskAssessmentRunArn: __expectString(output.ReplicationTaskAssessmentRunArn),
     ReplicationTaskAssessmentRunCreationDate:
       output.ReplicationTaskAssessmentRunCreationDate !== undefined &&
       output.ReplicationTaskAssessmentRunCreationDate !== null
         ? new Date(Math.round(output.ReplicationTaskAssessmentRunCreationDate * 1000))
         : undefined,
-    ResultEncryptionMode:
-      output.ResultEncryptionMode !== undefined && output.ResultEncryptionMode !== null
-        ? output.ResultEncryptionMode
-        : undefined,
-    ResultKmsKeyArn:
-      output.ResultKmsKeyArn !== undefined && output.ResultKmsKeyArn !== null ? output.ResultKmsKeyArn : undefined,
-    ResultLocationBucket:
-      output.ResultLocationBucket !== undefined && output.ResultLocationBucket !== null
-        ? output.ResultLocationBucket
-        : undefined,
-    ResultLocationFolder:
-      output.ResultLocationFolder !== undefined && output.ResultLocationFolder !== null
-        ? output.ResultLocationFolder
-        : undefined,
-    ServiceAccessRoleArn:
-      output.ServiceAccessRoleArn !== undefined && output.ServiceAccessRoleArn !== null
-        ? output.ServiceAccessRoleArn
-        : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    ResultEncryptionMode: __expectString(output.ResultEncryptionMode),
+    ResultKmsKeyArn: __expectString(output.ResultKmsKeyArn),
+    ResultLocationBucket: __expectString(output.ResultLocationBucket),
+    ResultLocationFolder: __expectString(output.ResultLocationFolder),
+    ServiceAccessRoleArn: __expectString(output.ServiceAccessRoleArn),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -8801,14 +8339,8 @@ const deserializeAws_json1_1ReplicationTaskAssessmentRunProgress = (
   context: __SerdeContext
 ): ReplicationTaskAssessmentRunProgress => {
   return {
-    IndividualAssessmentCompletedCount:
-      output.IndividualAssessmentCompletedCount !== undefined && output.IndividualAssessmentCompletedCount !== null
-        ? output.IndividualAssessmentCompletedCount
-        : undefined,
-    IndividualAssessmentCount:
-      output.IndividualAssessmentCount !== undefined && output.IndividualAssessmentCount !== null
-        ? output.IndividualAssessmentCount
-        : undefined,
+    IndividualAssessmentCompletedCount: __expectNumber(output.IndividualAssessmentCompletedCount),
+    IndividualAssessmentCount: __expectNumber(output.IndividualAssessmentCount),
   } as any;
 };
 
@@ -8817,25 +8349,15 @@ const deserializeAws_json1_1ReplicationTaskIndividualAssessment = (
   context: __SerdeContext
 ): ReplicationTaskIndividualAssessment => {
   return {
-    IndividualAssessmentName:
-      output.IndividualAssessmentName !== undefined && output.IndividualAssessmentName !== null
-        ? output.IndividualAssessmentName
-        : undefined,
-    ReplicationTaskAssessmentRunArn:
-      output.ReplicationTaskAssessmentRunArn !== undefined && output.ReplicationTaskAssessmentRunArn !== null
-        ? output.ReplicationTaskAssessmentRunArn
-        : undefined,
-    ReplicationTaskIndividualAssessmentArn:
-      output.ReplicationTaskIndividualAssessmentArn !== undefined &&
-      output.ReplicationTaskIndividualAssessmentArn !== null
-        ? output.ReplicationTaskIndividualAssessmentArn
-        : undefined,
+    IndividualAssessmentName: __expectString(output.IndividualAssessmentName),
+    ReplicationTaskAssessmentRunArn: __expectString(output.ReplicationTaskAssessmentRunArn),
+    ReplicationTaskIndividualAssessmentArn: __expectString(output.ReplicationTaskIndividualAssessmentArn),
     ReplicationTaskIndividualAssessmentStartDate:
       output.ReplicationTaskIndividualAssessmentStartDate !== undefined &&
       output.ReplicationTaskIndividualAssessmentStartDate !== null
         ? new Date(Math.round(output.ReplicationTaskIndividualAssessmentStartDate * 1000))
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -8866,10 +8388,7 @@ const deserializeAws_json1_1ReplicationTaskList = (output: any, context: __Serde
 
 const deserializeAws_json1_1ReplicationTaskStats = (output: any, context: __SerdeContext): ReplicationTaskStats => {
   return {
-    ElapsedTimeMillis:
-      output.ElapsedTimeMillis !== undefined && output.ElapsedTimeMillis !== null
-        ? output.ElapsedTimeMillis
-        : undefined,
+    ElapsedTimeMillis: __expectNumber(output.ElapsedTimeMillis),
     FreshStartDate:
       output.FreshStartDate !== undefined && output.FreshStartDate !== null
         ? new Date(Math.round(output.FreshStartDate * 1000))
@@ -8878,10 +8397,7 @@ const deserializeAws_json1_1ReplicationTaskStats = (output: any, context: __Serd
       output.FullLoadFinishDate !== undefined && output.FullLoadFinishDate !== null
         ? new Date(Math.round(output.FullLoadFinishDate * 1000))
         : undefined,
-    FullLoadProgressPercent:
-      output.FullLoadProgressPercent !== undefined && output.FullLoadProgressPercent !== null
-        ? output.FullLoadProgressPercent
-        : undefined,
+    FullLoadProgressPercent: __expectNumber(output.FullLoadProgressPercent),
     FullLoadStartDate:
       output.FullLoadStartDate !== undefined && output.FullLoadStartDate !== null
         ? new Date(Math.round(output.FullLoadStartDate * 1000))
@@ -8894,12 +8410,10 @@ const deserializeAws_json1_1ReplicationTaskStats = (output: any, context: __Serd
       output.StopDate !== undefined && output.StopDate !== null
         ? new Date(Math.round(output.StopDate * 1000))
         : undefined,
-    TablesErrored:
-      output.TablesErrored !== undefined && output.TablesErrored !== null ? output.TablesErrored : undefined,
-    TablesLoaded: output.TablesLoaded !== undefined && output.TablesLoaded !== null ? output.TablesLoaded : undefined,
-    TablesLoading:
-      output.TablesLoading !== undefined && output.TablesLoading !== null ? output.TablesLoading : undefined,
-    TablesQueued: output.TablesQueued !== undefined && output.TablesQueued !== null ? output.TablesQueued : undefined,
+    TablesErrored: __expectNumber(output.TablesErrored),
+    TablesLoaded: __expectNumber(output.TablesLoaded),
+    TablesLoading: __expectNumber(output.TablesLoading),
+    TablesQueued: __expectNumber(output.TablesQueued),
   } as any;
 };
 
@@ -8908,14 +8422,14 @@ const deserializeAws_json1_1ResourceAlreadyExistsFault = (
   context: __SerdeContext
 ): ResourceAlreadyExistsFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    resourceArn: output.resourceArn !== undefined && output.resourceArn !== null ? output.resourceArn : undefined,
+    message: __expectString(output.message),
+    resourceArn: __expectString(output.resourceArn),
   } as any;
 };
 
 const deserializeAws_json1_1ResourceNotFoundFault = (output: any, context: __SerdeContext): ResourceNotFoundFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -8928,10 +8442,7 @@ const deserializeAws_json1_1ResourcePendingMaintenanceActions = (
       output.PendingMaintenanceActionDetails !== undefined && output.PendingMaintenanceActionDetails !== null
         ? deserializeAws_json1_1PendingMaintenanceActionDetails(output.PendingMaintenanceActionDetails, context)
         : undefined,
-    ResourceIdentifier:
-      output.ResourceIdentifier !== undefined && output.ResourceIdentifier !== null
-        ? output.ResourceIdentifier
-        : undefined,
+    ResourceIdentifier: __expectString(output.ResourceIdentifier),
   } as any;
 };
 
@@ -8940,13 +8451,13 @@ const deserializeAws_json1_1ResourceQuotaExceededFault = (
   context: __SerdeContext
 ): ResourceQuotaExceededFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1S3AccessDeniedFault = (output: any, context: __SerdeContext): S3AccessDeniedFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -8955,85 +8466,40 @@ const deserializeAws_json1_1S3ResourceNotFoundFault = (
   context: __SerdeContext
 ): S3ResourceNotFoundFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1S3Settings = (output: any, context: __SerdeContext): S3Settings => {
   return {
-    BucketFolder: output.BucketFolder !== undefined && output.BucketFolder !== null ? output.BucketFolder : undefined,
-    BucketName: output.BucketName !== undefined && output.BucketName !== null ? output.BucketName : undefined,
-    CdcInsertsAndUpdates:
-      output.CdcInsertsAndUpdates !== undefined && output.CdcInsertsAndUpdates !== null
-        ? output.CdcInsertsAndUpdates
-        : undefined,
-    CdcInsertsOnly:
-      output.CdcInsertsOnly !== undefined && output.CdcInsertsOnly !== null ? output.CdcInsertsOnly : undefined,
-    CdcPath: output.CdcPath !== undefined && output.CdcPath !== null ? output.CdcPath : undefined,
-    CompressionType:
-      output.CompressionType !== undefined && output.CompressionType !== null ? output.CompressionType : undefined,
-    CsvDelimiter: output.CsvDelimiter !== undefined && output.CsvDelimiter !== null ? output.CsvDelimiter : undefined,
-    CsvNoSupValue:
-      output.CsvNoSupValue !== undefined && output.CsvNoSupValue !== null ? output.CsvNoSupValue : undefined,
-    CsvRowDelimiter:
-      output.CsvRowDelimiter !== undefined && output.CsvRowDelimiter !== null ? output.CsvRowDelimiter : undefined,
-    DataFormat: output.DataFormat !== undefined && output.DataFormat !== null ? output.DataFormat : undefined,
-    DataPageSize: output.DataPageSize !== undefined && output.DataPageSize !== null ? output.DataPageSize : undefined,
-    DatePartitionDelimiter:
-      output.DatePartitionDelimiter !== undefined && output.DatePartitionDelimiter !== null
-        ? output.DatePartitionDelimiter
-        : undefined,
-    DatePartitionEnabled:
-      output.DatePartitionEnabled !== undefined && output.DatePartitionEnabled !== null
-        ? output.DatePartitionEnabled
-        : undefined,
-    DatePartitionSequence:
-      output.DatePartitionSequence !== undefined && output.DatePartitionSequence !== null
-        ? output.DatePartitionSequence
-        : undefined,
-    DictPageSizeLimit:
-      output.DictPageSizeLimit !== undefined && output.DictPageSizeLimit !== null
-        ? output.DictPageSizeLimit
-        : undefined,
-    EnableStatistics:
-      output.EnableStatistics !== undefined && output.EnableStatistics !== null ? output.EnableStatistics : undefined,
-    EncodingType: output.EncodingType !== undefined && output.EncodingType !== null ? output.EncodingType : undefined,
-    EncryptionMode:
-      output.EncryptionMode !== undefined && output.EncryptionMode !== null ? output.EncryptionMode : undefined,
-    ExternalTableDefinition:
-      output.ExternalTableDefinition !== undefined && output.ExternalTableDefinition !== null
-        ? output.ExternalTableDefinition
-        : undefined,
-    IncludeOpForFullLoad:
-      output.IncludeOpForFullLoad !== undefined && output.IncludeOpForFullLoad !== null
-        ? output.IncludeOpForFullLoad
-        : undefined,
-    ParquetTimestampInMillisecond:
-      output.ParquetTimestampInMillisecond !== undefined && output.ParquetTimestampInMillisecond !== null
-        ? output.ParquetTimestampInMillisecond
-        : undefined,
-    ParquetVersion:
-      output.ParquetVersion !== undefined && output.ParquetVersion !== null ? output.ParquetVersion : undefined,
-    PreserveTransactions:
-      output.PreserveTransactions !== undefined && output.PreserveTransactions !== null
-        ? output.PreserveTransactions
-        : undefined,
-    RowGroupLength:
-      output.RowGroupLength !== undefined && output.RowGroupLength !== null ? output.RowGroupLength : undefined,
-    ServerSideEncryptionKmsKeyId:
-      output.ServerSideEncryptionKmsKeyId !== undefined && output.ServerSideEncryptionKmsKeyId !== null
-        ? output.ServerSideEncryptionKmsKeyId
-        : undefined,
-    ServiceAccessRoleArn:
-      output.ServiceAccessRoleArn !== undefined && output.ServiceAccessRoleArn !== null
-        ? output.ServiceAccessRoleArn
-        : undefined,
-    TimestampColumnName:
-      output.TimestampColumnName !== undefined && output.TimestampColumnName !== null
-        ? output.TimestampColumnName
-        : undefined,
-    UseCsvNoSupValue:
-      output.UseCsvNoSupValue !== undefined && output.UseCsvNoSupValue !== null ? output.UseCsvNoSupValue : undefined,
+    BucketFolder: __expectString(output.BucketFolder),
+    BucketName: __expectString(output.BucketName),
+    CdcInsertsAndUpdates: __expectBoolean(output.CdcInsertsAndUpdates),
+    CdcInsertsOnly: __expectBoolean(output.CdcInsertsOnly),
+    CdcPath: __expectString(output.CdcPath),
+    CompressionType: __expectString(output.CompressionType),
+    CsvDelimiter: __expectString(output.CsvDelimiter),
+    CsvNoSupValue: __expectString(output.CsvNoSupValue),
+    CsvRowDelimiter: __expectString(output.CsvRowDelimiter),
+    DataFormat: __expectString(output.DataFormat),
+    DataPageSize: __expectNumber(output.DataPageSize),
+    DatePartitionDelimiter: __expectString(output.DatePartitionDelimiter),
+    DatePartitionEnabled: __expectBoolean(output.DatePartitionEnabled),
+    DatePartitionSequence: __expectString(output.DatePartitionSequence),
+    DictPageSizeLimit: __expectNumber(output.DictPageSizeLimit),
+    EnableStatistics: __expectBoolean(output.EnableStatistics),
+    EncodingType: __expectString(output.EncodingType),
+    EncryptionMode: __expectString(output.EncryptionMode),
+    ExternalTableDefinition: __expectString(output.ExternalTableDefinition),
+    IncludeOpForFullLoad: __expectBoolean(output.IncludeOpForFullLoad),
+    ParquetTimestampInMillisecond: __expectBoolean(output.ParquetTimestampInMillisecond),
+    ParquetVersion: __expectString(output.ParquetVersion),
+    PreserveTransactions: __expectBoolean(output.PreserveTransactions),
+    RowGroupLength: __expectNumber(output.RowGroupLength),
+    ServerSideEncryptionKmsKeyId: __expectString(output.ServerSideEncryptionKmsKeyId),
+    ServiceAccessRoleArn: __expectString(output.ServiceAccessRoleArn),
+    TimestampColumnName: __expectString(output.TimestampColumnName),
+    UseCsvNoSupValue: __expectBoolean(output.UseCsvNoSupValue),
   } as any;
 };
 
@@ -9044,13 +8510,13 @@ const deserializeAws_json1_1SchemaList = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1SNSInvalidTopicFault = (output: any, context: __SerdeContext): SNSInvalidTopicFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9059,7 +8525,7 @@ const deserializeAws_json1_1SNSNoAuthorizationFault = (
   context: __SerdeContext
 ): SNSNoAuthorizationFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9070,7 +8536,7 @@ const deserializeAws_json1_1SourceIdsList = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -9127,7 +8593,7 @@ const deserializeAws_json1_1StorageQuotaExceededFault = (
   context: __SerdeContext
 ): StorageQuotaExceededFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9137,15 +8603,14 @@ const deserializeAws_json1_1Subnet = (output: any, context: __SerdeContext): Sub
       output.SubnetAvailabilityZone !== undefined && output.SubnetAvailabilityZone !== null
         ? deserializeAws_json1_1AvailabilityZone(output.SubnetAvailabilityZone, context)
         : undefined,
-    SubnetIdentifier:
-      output.SubnetIdentifier !== undefined && output.SubnetIdentifier !== null ? output.SubnetIdentifier : undefined,
-    SubnetStatus: output.SubnetStatus !== undefined && output.SubnetStatus !== null ? output.SubnetStatus : undefined,
+    SubnetIdentifier: __expectString(output.SubnetIdentifier),
+    SubnetStatus: __expectString(output.SubnetStatus),
   } as any;
 };
 
 const deserializeAws_json1_1SubnetAlreadyInUse = (output: any, context: __SerdeContext): SubnetAlreadyInUse => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9162,18 +8627,11 @@ const deserializeAws_json1_1SubnetList = (output: any, context: __SerdeContext):
 
 const deserializeAws_json1_1SupportedEndpointType = (output: any, context: __SerdeContext): SupportedEndpointType => {
   return {
-    EndpointType: output.EndpointType !== undefined && output.EndpointType !== null ? output.EndpointType : undefined,
-    EngineDisplayName:
-      output.EngineDisplayName !== undefined && output.EngineDisplayName !== null
-        ? output.EngineDisplayName
-        : undefined,
-    EngineName: output.EngineName !== undefined && output.EngineName !== null ? output.EngineName : undefined,
-    ReplicationInstanceEngineMinimumVersion:
-      output.ReplicationInstanceEngineMinimumVersion !== undefined &&
-      output.ReplicationInstanceEngineMinimumVersion !== null
-        ? output.ReplicationInstanceEngineMinimumVersion
-        : undefined,
-    SupportsCDC: output.SupportsCDC !== undefined && output.SupportsCDC !== null ? output.SupportsCDC : undefined,
+    EndpointType: __expectString(output.EndpointType),
+    EngineDisplayName: __expectString(output.EngineDisplayName),
+    EngineName: __expectString(output.EngineName),
+    ReplicationInstanceEngineMinimumVersion: __expectString(output.ReplicationInstanceEngineMinimumVersion),
+    SupportsCDC: __expectBoolean(output.SupportsCDC),
   } as any;
 };
 
@@ -9193,72 +8651,46 @@ const deserializeAws_json1_1SupportedEndpointTypeList = (
 
 const deserializeAws_json1_1SybaseSettings = (output: any, context: __SerdeContext): SybaseSettings => {
   return {
-    DatabaseName: output.DatabaseName !== undefined && output.DatabaseName !== null ? output.DatabaseName : undefined,
-    Password: output.Password !== undefined && output.Password !== null ? output.Password : undefined,
-    Port: output.Port !== undefined && output.Port !== null ? output.Port : undefined,
-    SecretsManagerAccessRoleArn:
-      output.SecretsManagerAccessRoleArn !== undefined && output.SecretsManagerAccessRoleArn !== null
-        ? output.SecretsManagerAccessRoleArn
-        : undefined,
-    SecretsManagerSecretId:
-      output.SecretsManagerSecretId !== undefined && output.SecretsManagerSecretId !== null
-        ? output.SecretsManagerSecretId
-        : undefined,
-    ServerName: output.ServerName !== undefined && output.ServerName !== null ? output.ServerName : undefined,
-    Username: output.Username !== undefined && output.Username !== null ? output.Username : undefined,
+    DatabaseName: __expectString(output.DatabaseName),
+    Password: __expectString(output.Password),
+    Port: __expectNumber(output.Port),
+    SecretsManagerAccessRoleArn: __expectString(output.SecretsManagerAccessRoleArn),
+    SecretsManagerSecretId: __expectString(output.SecretsManagerSecretId),
+    ServerName: __expectString(output.ServerName),
+    Username: __expectString(output.Username),
   } as any;
 };
 
 const deserializeAws_json1_1TableStatistics = (output: any, context: __SerdeContext): TableStatistics => {
   return {
-    Ddls: output.Ddls !== undefined && output.Ddls !== null ? output.Ddls : undefined,
-    Deletes: output.Deletes !== undefined && output.Deletes !== null ? output.Deletes : undefined,
-    FullLoadCondtnlChkFailedRows:
-      output.FullLoadCondtnlChkFailedRows !== undefined && output.FullLoadCondtnlChkFailedRows !== null
-        ? output.FullLoadCondtnlChkFailedRows
-        : undefined,
+    Ddls: __expectNumber(output.Ddls),
+    Deletes: __expectNumber(output.Deletes),
+    FullLoadCondtnlChkFailedRows: __expectNumber(output.FullLoadCondtnlChkFailedRows),
     FullLoadEndTime:
       output.FullLoadEndTime !== undefined && output.FullLoadEndTime !== null
         ? new Date(Math.round(output.FullLoadEndTime * 1000))
         : undefined,
-    FullLoadErrorRows:
-      output.FullLoadErrorRows !== undefined && output.FullLoadErrorRows !== null
-        ? output.FullLoadErrorRows
-        : undefined,
-    FullLoadReloaded:
-      output.FullLoadReloaded !== undefined && output.FullLoadReloaded !== null ? output.FullLoadReloaded : undefined,
-    FullLoadRows: output.FullLoadRows !== undefined && output.FullLoadRows !== null ? output.FullLoadRows : undefined,
+    FullLoadErrorRows: __expectNumber(output.FullLoadErrorRows),
+    FullLoadReloaded: __expectBoolean(output.FullLoadReloaded),
+    FullLoadRows: __expectNumber(output.FullLoadRows),
     FullLoadStartTime:
       output.FullLoadStartTime !== undefined && output.FullLoadStartTime !== null
         ? new Date(Math.round(output.FullLoadStartTime * 1000))
         : undefined,
-    Inserts: output.Inserts !== undefined && output.Inserts !== null ? output.Inserts : undefined,
+    Inserts: __expectNumber(output.Inserts),
     LastUpdateTime:
       output.LastUpdateTime !== undefined && output.LastUpdateTime !== null
         ? new Date(Math.round(output.LastUpdateTime * 1000))
         : undefined,
-    SchemaName: output.SchemaName !== undefined && output.SchemaName !== null ? output.SchemaName : undefined,
-    TableName: output.TableName !== undefined && output.TableName !== null ? output.TableName : undefined,
-    TableState: output.TableState !== undefined && output.TableState !== null ? output.TableState : undefined,
-    Updates: output.Updates !== undefined && output.Updates !== null ? output.Updates : undefined,
-    ValidationFailedRecords:
-      output.ValidationFailedRecords !== undefined && output.ValidationFailedRecords !== null
-        ? output.ValidationFailedRecords
-        : undefined,
-    ValidationPendingRecords:
-      output.ValidationPendingRecords !== undefined && output.ValidationPendingRecords !== null
-        ? output.ValidationPendingRecords
-        : undefined,
-    ValidationState:
-      output.ValidationState !== undefined && output.ValidationState !== null ? output.ValidationState : undefined,
-    ValidationStateDetails:
-      output.ValidationStateDetails !== undefined && output.ValidationStateDetails !== null
-        ? output.ValidationStateDetails
-        : undefined,
-    ValidationSuspendedRecords:
-      output.ValidationSuspendedRecords !== undefined && output.ValidationSuspendedRecords !== null
-        ? output.ValidationSuspendedRecords
-        : undefined,
+    SchemaName: __expectString(output.SchemaName),
+    TableName: __expectString(output.TableName),
+    TableState: __expectString(output.TableState),
+    Updates: __expectNumber(output.Updates),
+    ValidationFailedRecords: __expectNumber(output.ValidationFailedRecords),
+    ValidationPendingRecords: __expectNumber(output.ValidationPendingRecords),
+    ValidationState: __expectString(output.ValidationState),
+    ValidationStateDetails: __expectString(output.ValidationStateDetails),
+    ValidationSuspendedRecords: __expectNumber(output.ValidationSuspendedRecords),
   } as any;
 };
 
@@ -9275,8 +8707,8 @@ const deserializeAws_json1_1TableStatisticsList = (output: any, context: __Serde
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -9305,7 +8737,7 @@ const deserializeAws_json1_1UpgradeDependencyFailureFault = (
   context: __SerdeContext
 ): UpgradeDependencyFailureFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9314,11 +8746,8 @@ const deserializeAws_json1_1VpcSecurityGroupMembership = (
   context: __SerdeContext
 ): VpcSecurityGroupMembership => {
   return {
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    VpcSecurityGroupId:
-      output.VpcSecurityGroupId !== undefined && output.VpcSecurityGroupId !== null
-        ? output.VpcSecurityGroupId
-        : undefined,
+    Status: __expectString(output.Status),
+    VpcSecurityGroupId: __expectString(output.VpcSecurityGroupId),
   } as any;
 };
 

--- a/clients/client-databrew/protocols/Aws_restJson1.ts
+++ b/clients/client-databrew/protocols/Aws_restJson1.ts
@@ -93,6 +93,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -1376,7 +1379,7 @@ export const deserializeAws_restJson1BatchDeleteRecipeVersionCommand = async (
     contents.Errors = deserializeAws_restJson1RecipeErrorList(data.Errors, context);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   return Promise.resolve(contents);
 };
@@ -1447,7 +1450,7 @@ export const deserializeAws_restJson1CreateDatasetCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   return Promise.resolve(contents);
 };
@@ -1526,7 +1529,7 @@ export const deserializeAws_restJson1CreateProfileJobCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   return Promise.resolve(contents);
 };
@@ -1613,7 +1616,7 @@ export const deserializeAws_restJson1CreateProjectCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   return Promise.resolve(contents);
 };
@@ -1692,7 +1695,7 @@ export const deserializeAws_restJson1CreateRecipeCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   return Promise.resolve(contents);
 };
@@ -1763,7 +1766,7 @@ export const deserializeAws_restJson1CreateRecipeJobCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   return Promise.resolve(contents);
 };
@@ -1850,7 +1853,7 @@ export const deserializeAws_restJson1CreateScheduleCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   return Promise.resolve(contents);
 };
@@ -1921,7 +1924,7 @@ export const deserializeAws_restJson1DeleteDatasetCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   return Promise.resolve(contents);
 };
@@ -1992,7 +1995,7 @@ export const deserializeAws_restJson1DeleteJobCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   return Promise.resolve(contents);
 };
@@ -2063,7 +2066,7 @@ export const deserializeAws_restJson1DeleteProjectCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   return Promise.resolve(contents);
 };
@@ -2135,10 +2138,10 @@ export const deserializeAws_restJson1DeleteRecipeVersionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.RecipeVersion !== undefined && data.RecipeVersion !== null) {
-    contents.RecipeVersion = data.RecipeVersion;
+    contents.RecipeVersion = __expectString(data.RecipeVersion);
   }
   return Promise.resolve(contents);
 };
@@ -2209,7 +2212,7 @@ export const deserializeAws_restJson1DeleteScheduleCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   return Promise.resolve(contents);
 };
@@ -2286,10 +2289,10 @@ export const deserializeAws_restJson1DescribeDatasetCommand = async (
     contents.CreateDate = new Date(Math.round(data.CreateDate * 1000));
   }
   if (data.CreatedBy !== undefined && data.CreatedBy !== null) {
-    contents.CreatedBy = data.CreatedBy;
+    contents.CreatedBy = __expectString(data.CreatedBy);
   }
   if (data.Format !== undefined && data.Format !== null) {
-    contents.Format = data.Format;
+    contents.Format = __expectString(data.Format);
   }
   if (data.FormatOptions !== undefined && data.FormatOptions !== null) {
     contents.FormatOptions = deserializeAws_restJson1FormatOptions(data.FormatOptions, context);
@@ -2298,22 +2301,22 @@ export const deserializeAws_restJson1DescribeDatasetCommand = async (
     contents.Input = deserializeAws_restJson1Input(data.Input, context);
   }
   if (data.LastModifiedBy !== undefined && data.LastModifiedBy !== null) {
-    contents.LastModifiedBy = data.LastModifiedBy;
+    contents.LastModifiedBy = __expectString(data.LastModifiedBy);
   }
   if (data.LastModifiedDate !== undefined && data.LastModifiedDate !== null) {
     contents.LastModifiedDate = new Date(Math.round(data.LastModifiedDate * 1000));
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.PathOptions !== undefined && data.PathOptions !== null) {
     contents.PathOptions = deserializeAws_restJson1PathOptions(data.PathOptions, context);
   }
   if (data.ResourceArn !== undefined && data.ResourceArn !== null) {
-    contents.ResourceArn = data.ResourceArn;
+    contents.ResourceArn = __expectString(data.ResourceArn);
   }
   if (data.Source !== undefined && data.Source !== null) {
-    contents.Source = data.Source;
+    contents.Source = __expectString(data.Source);
   }
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
@@ -2401,61 +2404,61 @@ export const deserializeAws_restJson1DescribeJobCommand = async (
     contents.CreateDate = new Date(Math.round(data.CreateDate * 1000));
   }
   if (data.CreatedBy !== undefined && data.CreatedBy !== null) {
-    contents.CreatedBy = data.CreatedBy;
+    contents.CreatedBy = __expectString(data.CreatedBy);
   }
   if (data.DatasetName !== undefined && data.DatasetName !== null) {
-    contents.DatasetName = data.DatasetName;
+    contents.DatasetName = __expectString(data.DatasetName);
   }
   if (data.EncryptionKeyArn !== undefined && data.EncryptionKeyArn !== null) {
-    contents.EncryptionKeyArn = data.EncryptionKeyArn;
+    contents.EncryptionKeyArn = __expectString(data.EncryptionKeyArn);
   }
   if (data.EncryptionMode !== undefined && data.EncryptionMode !== null) {
-    contents.EncryptionMode = data.EncryptionMode;
+    contents.EncryptionMode = __expectString(data.EncryptionMode);
   }
   if (data.JobSample !== undefined && data.JobSample !== null) {
     contents.JobSample = deserializeAws_restJson1JobSample(data.JobSample, context);
   }
   if (data.LastModifiedBy !== undefined && data.LastModifiedBy !== null) {
-    contents.LastModifiedBy = data.LastModifiedBy;
+    contents.LastModifiedBy = __expectString(data.LastModifiedBy);
   }
   if (data.LastModifiedDate !== undefined && data.LastModifiedDate !== null) {
     contents.LastModifiedDate = new Date(Math.round(data.LastModifiedDate * 1000));
   }
   if (data.LogSubscription !== undefined && data.LogSubscription !== null) {
-    contents.LogSubscription = data.LogSubscription;
+    contents.LogSubscription = __expectString(data.LogSubscription);
   }
   if (data.MaxCapacity !== undefined && data.MaxCapacity !== null) {
-    contents.MaxCapacity = data.MaxCapacity;
+    contents.MaxCapacity = __expectNumber(data.MaxCapacity);
   }
   if (data.MaxRetries !== undefined && data.MaxRetries !== null) {
-    contents.MaxRetries = data.MaxRetries;
+    contents.MaxRetries = __expectNumber(data.MaxRetries);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.Outputs !== undefined && data.Outputs !== null) {
     contents.Outputs = deserializeAws_restJson1OutputList(data.Outputs, context);
   }
   if (data.ProjectName !== undefined && data.ProjectName !== null) {
-    contents.ProjectName = data.ProjectName;
+    contents.ProjectName = __expectString(data.ProjectName);
   }
   if (data.RecipeReference !== undefined && data.RecipeReference !== null) {
     contents.RecipeReference = deserializeAws_restJson1RecipeReference(data.RecipeReference, context);
   }
   if (data.ResourceArn !== undefined && data.ResourceArn !== null) {
-    contents.ResourceArn = data.ResourceArn;
+    contents.ResourceArn = __expectString(data.ResourceArn);
   }
   if (data.RoleArn !== undefined && data.RoleArn !== null) {
-    contents.RoleArn = data.RoleArn;
+    contents.RoleArn = __expectString(data.RoleArn);
   }
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }
   if (data.Timeout !== undefined && data.Timeout !== null) {
-    contents.Timeout = data.Timeout;
+    contents.Timeout = __expectNumber(data.Timeout);
   }
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   return Promise.resolve(contents);
 };
@@ -2532,31 +2535,31 @@ export const deserializeAws_restJson1DescribeJobRunCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Attempt !== undefined && data.Attempt !== null) {
-    contents.Attempt = data.Attempt;
+    contents.Attempt = __expectNumber(data.Attempt);
   }
   if (data.CompletedOn !== undefined && data.CompletedOn !== null) {
     contents.CompletedOn = new Date(Math.round(data.CompletedOn * 1000));
   }
   if (data.DatasetName !== undefined && data.DatasetName !== null) {
-    contents.DatasetName = data.DatasetName;
+    contents.DatasetName = __expectString(data.DatasetName);
   }
   if (data.ErrorMessage !== undefined && data.ErrorMessage !== null) {
-    contents.ErrorMessage = data.ErrorMessage;
+    contents.ErrorMessage = __expectString(data.ErrorMessage);
   }
   if (data.ExecutionTime !== undefined && data.ExecutionTime !== null) {
-    contents.ExecutionTime = data.ExecutionTime;
+    contents.ExecutionTime = __expectNumber(data.ExecutionTime);
   }
   if (data.JobName !== undefined && data.JobName !== null) {
-    contents.JobName = data.JobName;
+    contents.JobName = __expectString(data.JobName);
   }
   if (data.JobSample !== undefined && data.JobSample !== null) {
     contents.JobSample = deserializeAws_restJson1JobSample(data.JobSample, context);
   }
   if (data.LogGroupName !== undefined && data.LogGroupName !== null) {
-    contents.LogGroupName = data.LogGroupName;
+    contents.LogGroupName = __expectString(data.LogGroupName);
   }
   if (data.LogSubscription !== undefined && data.LogSubscription !== null) {
-    contents.LogSubscription = data.LogSubscription;
+    contents.LogSubscription = __expectString(data.LogSubscription);
   }
   if (data.Outputs !== undefined && data.Outputs !== null) {
     contents.Outputs = deserializeAws_restJson1OutputList(data.Outputs, context);
@@ -2565,16 +2568,16 @@ export const deserializeAws_restJson1DescribeJobRunCommand = async (
     contents.RecipeReference = deserializeAws_restJson1RecipeReference(data.RecipeReference, context);
   }
   if (data.RunId !== undefined && data.RunId !== null) {
-    contents.RunId = data.RunId;
+    contents.RunId = __expectString(data.RunId);
   }
   if (data.StartedBy !== undefined && data.StartedBy !== null) {
-    contents.StartedBy = data.StartedBy;
+    contents.StartedBy = __expectString(data.StartedBy);
   }
   if (data.StartedOn !== undefined && data.StartedOn !== null) {
     contents.StartedOn = new Date(Math.round(data.StartedOn * 1000));
   }
   if (data.State !== undefined && data.State !== null) {
-    contents.State = data.State;
+    contents.State = __expectString(data.State);
   }
   return Promise.resolve(contents);
 };
@@ -2653,40 +2656,40 @@ export const deserializeAws_restJson1DescribeProjectCommand = async (
     contents.CreateDate = new Date(Math.round(data.CreateDate * 1000));
   }
   if (data.CreatedBy !== undefined && data.CreatedBy !== null) {
-    contents.CreatedBy = data.CreatedBy;
+    contents.CreatedBy = __expectString(data.CreatedBy);
   }
   if (data.DatasetName !== undefined && data.DatasetName !== null) {
-    contents.DatasetName = data.DatasetName;
+    contents.DatasetName = __expectString(data.DatasetName);
   }
   if (data.LastModifiedBy !== undefined && data.LastModifiedBy !== null) {
-    contents.LastModifiedBy = data.LastModifiedBy;
+    contents.LastModifiedBy = __expectString(data.LastModifiedBy);
   }
   if (data.LastModifiedDate !== undefined && data.LastModifiedDate !== null) {
     contents.LastModifiedDate = new Date(Math.round(data.LastModifiedDate * 1000));
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.OpenDate !== undefined && data.OpenDate !== null) {
     contents.OpenDate = new Date(Math.round(data.OpenDate * 1000));
   }
   if (data.OpenedBy !== undefined && data.OpenedBy !== null) {
-    contents.OpenedBy = data.OpenedBy;
+    contents.OpenedBy = __expectString(data.OpenedBy);
   }
   if (data.RecipeName !== undefined && data.RecipeName !== null) {
-    contents.RecipeName = data.RecipeName;
+    contents.RecipeName = __expectString(data.RecipeName);
   }
   if (data.ResourceArn !== undefined && data.ResourceArn !== null) {
-    contents.ResourceArn = data.ResourceArn;
+    contents.ResourceArn = __expectString(data.ResourceArn);
   }
   if (data.RoleArn !== undefined && data.RoleArn !== null) {
-    contents.RoleArn = data.RoleArn;
+    contents.RoleArn = __expectString(data.RoleArn);
   }
   if (data.Sample !== undefined && data.Sample !== null) {
     contents.Sample = deserializeAws_restJson1Sample(data.Sample, context);
   }
   if (data.SessionStatus !== undefined && data.SessionStatus !== null) {
-    contents.SessionStatus = data.SessionStatus;
+    contents.SessionStatus = __expectString(data.SessionStatus);
   }
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
@@ -2767,34 +2770,34 @@ export const deserializeAws_restJson1DescribeRecipeCommand = async (
     contents.CreateDate = new Date(Math.round(data.CreateDate * 1000));
   }
   if (data.CreatedBy !== undefined && data.CreatedBy !== null) {
-    contents.CreatedBy = data.CreatedBy;
+    contents.CreatedBy = __expectString(data.CreatedBy);
   }
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.LastModifiedBy !== undefined && data.LastModifiedBy !== null) {
-    contents.LastModifiedBy = data.LastModifiedBy;
+    contents.LastModifiedBy = __expectString(data.LastModifiedBy);
   }
   if (data.LastModifiedDate !== undefined && data.LastModifiedDate !== null) {
     contents.LastModifiedDate = new Date(Math.round(data.LastModifiedDate * 1000));
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.ProjectName !== undefined && data.ProjectName !== null) {
-    contents.ProjectName = data.ProjectName;
+    contents.ProjectName = __expectString(data.ProjectName);
   }
   if (data.PublishedBy !== undefined && data.PublishedBy !== null) {
-    contents.PublishedBy = data.PublishedBy;
+    contents.PublishedBy = __expectString(data.PublishedBy);
   }
   if (data.PublishedDate !== undefined && data.PublishedDate !== null) {
     contents.PublishedDate = new Date(Math.round(data.PublishedDate * 1000));
   }
   if (data.RecipeVersion !== undefined && data.RecipeVersion !== null) {
-    contents.RecipeVersion = data.RecipeVersion;
+    contents.RecipeVersion = __expectString(data.RecipeVersion);
   }
   if (data.ResourceArn !== undefined && data.ResourceArn !== null) {
-    contents.ResourceArn = data.ResourceArn;
+    contents.ResourceArn = __expectString(data.ResourceArn);
   }
   if (data.Steps !== undefined && data.Steps !== null) {
     contents.Steps = deserializeAws_restJson1RecipeStepList(data.Steps, context);
@@ -2874,25 +2877,25 @@ export const deserializeAws_restJson1DescribeScheduleCommand = async (
     contents.CreateDate = new Date(Math.round(data.CreateDate * 1000));
   }
   if (data.CreatedBy !== undefined && data.CreatedBy !== null) {
-    contents.CreatedBy = data.CreatedBy;
+    contents.CreatedBy = __expectString(data.CreatedBy);
   }
   if (data.CronExpression !== undefined && data.CronExpression !== null) {
-    contents.CronExpression = data.CronExpression;
+    contents.CronExpression = __expectString(data.CronExpression);
   }
   if (data.JobNames !== undefined && data.JobNames !== null) {
     contents.JobNames = deserializeAws_restJson1JobNameList(data.JobNames, context);
   }
   if (data.LastModifiedBy !== undefined && data.LastModifiedBy !== null) {
-    contents.LastModifiedBy = data.LastModifiedBy;
+    contents.LastModifiedBy = __expectString(data.LastModifiedBy);
   }
   if (data.LastModifiedDate !== undefined && data.LastModifiedDate !== null) {
     contents.LastModifiedDate = new Date(Math.round(data.LastModifiedDate * 1000));
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.ResourceArn !== undefined && data.ResourceArn !== null) {
-    contents.ResourceArn = data.ResourceArn;
+    contents.ResourceArn = __expectString(data.ResourceArn);
   }
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
@@ -2962,7 +2965,7 @@ export const deserializeAws_restJson1ListDatasetsCommand = async (
     contents.Datasets = deserializeAws_restJson1DatasetList(data.Datasets, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3021,7 +3024,7 @@ export const deserializeAws_restJson1ListJobRunsCommand = async (
     contents.JobRuns = deserializeAws_restJson1JobRunList(data.JobRuns, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3088,7 +3091,7 @@ export const deserializeAws_restJson1ListJobsCommand = async (
     contents.Jobs = deserializeAws_restJson1JobList(data.Jobs, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3144,7 +3147,7 @@ export const deserializeAws_restJson1ListProjectsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Projects !== undefined && data.Projects !== null) {
     contents.Projects = deserializeAws_restJson1ProjectList(data.Projects, context);
@@ -3203,7 +3206,7 @@ export const deserializeAws_restJson1ListRecipesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Recipes !== undefined && data.Recipes !== null) {
     contents.Recipes = deserializeAws_restJson1RecipeList(data.Recipes, context);
@@ -3262,7 +3265,7 @@ export const deserializeAws_restJson1ListRecipeVersionsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Recipes !== undefined && data.Recipes !== null) {
     contents.Recipes = deserializeAws_restJson1RecipeList(data.Recipes, context);
@@ -3321,7 +3324,7 @@ export const deserializeAws_restJson1ListSchedulesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Schedules !== undefined && data.Schedules !== null) {
     contents.Schedules = deserializeAws_restJson1ScheduleList(data.Schedules, context);
@@ -3450,7 +3453,7 @@ export const deserializeAws_restJson1PublishRecipeCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   return Promise.resolve(contents);
 };
@@ -3523,13 +3526,13 @@ export const deserializeAws_restJson1SendProjectSessionActionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ActionId !== undefined && data.ActionId !== null) {
-    contents.ActionId = data.ActionId;
+    contents.ActionId = __expectNumber(data.ActionId);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.Result !== undefined && data.Result !== null) {
-    contents.Result = data.Result;
+    contents.Result = __expectString(data.Result);
   }
   return Promise.resolve(contents);
 };
@@ -3600,7 +3603,7 @@ export const deserializeAws_restJson1StartJobRunCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.RunId !== undefined && data.RunId !== null) {
-    contents.RunId = data.RunId;
+    contents.RunId = __expectString(data.RunId);
   }
   return Promise.resolve(contents);
 };
@@ -3680,10 +3683,10 @@ export const deserializeAws_restJson1StartProjectSessionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ClientSessionId !== undefined && data.ClientSessionId !== null) {
-    contents.ClientSessionId = data.ClientSessionId;
+    contents.ClientSessionId = __expectString(data.ClientSessionId);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   return Promise.resolve(contents);
 };
@@ -3762,7 +3765,7 @@ export const deserializeAws_restJson1StopJobRunCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.RunId !== undefined && data.RunId !== null) {
-    contents.RunId = data.RunId;
+    contents.RunId = __expectString(data.RunId);
   }
   return Promise.resolve(contents);
 };
@@ -3959,7 +3962,7 @@ export const deserializeAws_restJson1UpdateDatasetCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   return Promise.resolve(contents);
 };
@@ -4030,7 +4033,7 @@ export const deserializeAws_restJson1UpdateProfileJobCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   return Promise.resolve(contents);
 };
@@ -4105,7 +4108,7 @@ export const deserializeAws_restJson1UpdateProjectCommand = async (
     contents.LastModifiedDate = new Date(Math.round(data.LastModifiedDate * 1000));
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   return Promise.resolve(contents);
 };
@@ -4168,7 +4171,7 @@ export const deserializeAws_restJson1UpdateRecipeCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   return Promise.resolve(contents);
 };
@@ -4231,7 +4234,7 @@ export const deserializeAws_restJson1UpdateRecipeJobCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   return Promise.resolve(contents);
 };
@@ -4302,7 +4305,7 @@ export const deserializeAws_restJson1UpdateScheduleCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   return Promise.resolve(contents);
 };
@@ -4372,7 +4375,7 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -4389,7 +4392,7 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -4406,7 +4409,7 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -4423,7 +4426,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -4440,7 +4443,7 @@ const deserializeAws_restJson1ServiceQuotaExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -4457,7 +4460,7 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -4856,15 +4859,15 @@ const deserializeAws_restJson1ColumnNameList = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1ConditionExpression = (output: any, context: __SerdeContext): ConditionExpression => {
   return {
-    Condition: output.Condition !== undefined && output.Condition !== null ? output.Condition : undefined,
-    TargetColumn: output.TargetColumn !== undefined && output.TargetColumn !== null ? output.TargetColumn : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Condition: __expectString(output.Condition),
+    TargetColumn: __expectString(output.TargetColumn),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -4884,14 +4887,14 @@ const deserializeAws_restJson1ConditionExpressionList = (
 
 const deserializeAws_restJson1CsvOptions = (output: any, context: __SerdeContext): CsvOptions => {
   return {
-    Delimiter: output.Delimiter !== undefined && output.Delimiter !== null ? output.Delimiter : undefined,
-    HeaderRow: output.HeaderRow !== undefined && output.HeaderRow !== null ? output.HeaderRow : undefined,
+    Delimiter: __expectString(output.Delimiter),
+    HeaderRow: __expectBoolean(output.HeaderRow),
   } as any;
 };
 
 const deserializeAws_restJson1CsvOutputOptions = (output: any, context: __SerdeContext): CsvOutputOptions => {
   return {
-    Delimiter: output.Delimiter !== undefined && output.Delimiter !== null ? output.Delimiter : undefined,
+    Delimiter: __expectString(output.Delimiter),
   } as any;
 };
 
@@ -4900,14 +4903,8 @@ const deserializeAws_restJson1DatabaseInputDefinition = (
   context: __SerdeContext
 ): DatabaseInputDefinition => {
   return {
-    DatabaseTableName:
-      output.DatabaseTableName !== undefined && output.DatabaseTableName !== null
-        ? output.DatabaseTableName
-        : undefined,
-    GlueConnectionName:
-      output.GlueConnectionName !== undefined && output.GlueConnectionName !== null
-        ? output.GlueConnectionName
-        : undefined,
+    DatabaseTableName: __expectString(output.DatabaseTableName),
+    GlueConnectionName: __expectString(output.GlueConnectionName),
     TempDirectory:
       output.TempDirectory !== undefined && output.TempDirectory !== null
         ? deserializeAws_restJson1S3Location(output.TempDirectory, context)
@@ -4920,9 +4917,9 @@ const deserializeAws_restJson1DataCatalogInputDefinition = (
   context: __SerdeContext
 ): DataCatalogInputDefinition => {
   return {
-    CatalogId: output.CatalogId !== undefined && output.CatalogId !== null ? output.CatalogId : undefined,
-    DatabaseName: output.DatabaseName !== undefined && output.DatabaseName !== null ? output.DatabaseName : undefined,
-    TableName: output.TableName !== undefined && output.TableName !== null ? output.TableName : undefined,
+    CatalogId: __expectString(output.CatalogId),
+    DatabaseName: __expectString(output.DatabaseName),
+    TableName: __expectString(output.TableName),
     TempDirectory:
       output.TempDirectory !== undefined && output.TempDirectory !== null
         ? deserializeAws_restJson1S3Location(output.TempDirectory, context)
@@ -4932,13 +4929,13 @@ const deserializeAws_restJson1DataCatalogInputDefinition = (
 
 const deserializeAws_restJson1Dataset = (output: any, context: __SerdeContext): Dataset => {
   return {
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
+    AccountId: __expectString(output.AccountId),
     CreateDate:
       output.CreateDate !== undefined && output.CreateDate !== null
         ? new Date(Math.round(output.CreateDate * 1000))
         : undefined,
-    CreatedBy: output.CreatedBy !== undefined && output.CreatedBy !== null ? output.CreatedBy : undefined,
-    Format: output.Format !== undefined && output.Format !== null ? output.Format : undefined,
+    CreatedBy: __expectString(output.CreatedBy),
+    Format: __expectString(output.Format),
     FormatOptions:
       output.FormatOptions !== undefined && output.FormatOptions !== null
         ? deserializeAws_restJson1FormatOptions(output.FormatOptions, context)
@@ -4947,19 +4944,18 @@ const deserializeAws_restJson1Dataset = (output: any, context: __SerdeContext): 
       output.Input !== undefined && output.Input !== null
         ? deserializeAws_restJson1Input(output.Input, context)
         : undefined,
-    LastModifiedBy:
-      output.LastModifiedBy !== undefined && output.LastModifiedBy !== null ? output.LastModifiedBy : undefined,
+    LastModifiedBy: __expectString(output.LastModifiedBy),
     LastModifiedDate:
       output.LastModifiedDate !== undefined && output.LastModifiedDate !== null
         ? new Date(Math.round(output.LastModifiedDate * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     PathOptions:
       output.PathOptions !== undefined && output.PathOptions !== null
         ? deserializeAws_restJson1PathOptions(output.PathOptions, context)
         : undefined,
-    ResourceArn: output.ResourceArn !== undefined && output.ResourceArn !== null ? output.ResourceArn : undefined,
-    Source: output.Source !== undefined && output.Source !== null ? output.Source : undefined,
+    ResourceArn: __expectString(output.ResourceArn),
+    Source: __expectString(output.Source),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_restJson1TagMap(output.Tags, context)
@@ -4980,7 +4976,7 @@ const deserializeAws_restJson1DatasetList = (output: any, context: __SerdeContex
 
 const deserializeAws_restJson1DatasetParameter = (output: any, context: __SerdeContext): DatasetParameter => {
   return {
-    CreateColumn: output.CreateColumn !== undefined && output.CreateColumn !== null ? output.CreateColumn : undefined,
+    CreateColumn: __expectBoolean(output.CreateColumn),
     DatetimeOptions:
       output.DatetimeOptions !== undefined && output.DatetimeOptions !== null
         ? deserializeAws_restJson1DatetimeOptions(output.DatetimeOptions, context)
@@ -4989,23 +4985,22 @@ const deserializeAws_restJson1DatasetParameter = (output: any, context: __SerdeC
       output.Filter !== undefined && output.Filter !== null
         ? deserializeAws_restJson1FilterExpression(output.Filter, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Name: __expectString(output.Name),
+    Type: __expectString(output.Type),
   } as any;
 };
 
 const deserializeAws_restJson1DatetimeOptions = (output: any, context: __SerdeContext): DatetimeOptions => {
   return {
-    Format: output.Format !== undefined && output.Format !== null ? output.Format : undefined,
-    LocaleCode: output.LocaleCode !== undefined && output.LocaleCode !== null ? output.LocaleCode : undefined,
-    TimezoneOffset:
-      output.TimezoneOffset !== undefined && output.TimezoneOffset !== null ? output.TimezoneOffset : undefined,
+    Format: __expectString(output.Format),
+    LocaleCode: __expectString(output.LocaleCode),
+    TimezoneOffset: __expectString(output.TimezoneOffset),
   } as any;
 };
 
 const deserializeAws_restJson1ExcelOptions = (output: any, context: __SerdeContext): ExcelOptions => {
   return {
-    HeaderRow: output.HeaderRow !== undefined && output.HeaderRow !== null ? output.HeaderRow : undefined,
+    HeaderRow: __expectBoolean(output.HeaderRow),
     SheetIndexes:
       output.SheetIndexes !== undefined && output.SheetIndexes !== null
         ? deserializeAws_restJson1SheetIndexList(output.SheetIndexes, context)
@@ -5019,15 +5014,15 @@ const deserializeAws_restJson1ExcelOptions = (output: any, context: __SerdeConte
 
 const deserializeAws_restJson1FilesLimit = (output: any, context: __SerdeContext): FilesLimit => {
   return {
-    MaxFiles: output.MaxFiles !== undefined && output.MaxFiles !== null ? output.MaxFiles : undefined,
-    Order: output.Order !== undefined && output.Order !== null ? output.Order : undefined,
-    OrderedBy: output.OrderedBy !== undefined && output.OrderedBy !== null ? output.OrderedBy : undefined,
+    MaxFiles: __expectNumber(output.MaxFiles),
+    Order: __expectString(output.Order),
+    OrderedBy: __expectString(output.OrderedBy),
   } as any;
 };
 
 const deserializeAws_restJson1FilterExpression = (output: any, context: __SerdeContext): FilterExpression => {
   return {
-    Expression: output.Expression !== undefined && output.Expression !== null ? output.Expression : undefined,
+    Expression: __expectString(output.Expression),
     ValuesMap:
       output.ValuesMap !== undefined && output.ValuesMap !== null
         ? deserializeAws_restJson1ValuesMap(output.ValuesMap, context)
@@ -5071,49 +5066,45 @@ const deserializeAws_restJson1Input = (output: any, context: __SerdeContext): In
 
 const deserializeAws_restJson1Job = (output: any, context: __SerdeContext): Job => {
   return {
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
+    AccountId: __expectString(output.AccountId),
     CreateDate:
       output.CreateDate !== undefined && output.CreateDate !== null
         ? new Date(Math.round(output.CreateDate * 1000))
         : undefined,
-    CreatedBy: output.CreatedBy !== undefined && output.CreatedBy !== null ? output.CreatedBy : undefined,
-    DatasetName: output.DatasetName !== undefined && output.DatasetName !== null ? output.DatasetName : undefined,
-    EncryptionKeyArn:
-      output.EncryptionKeyArn !== undefined && output.EncryptionKeyArn !== null ? output.EncryptionKeyArn : undefined,
-    EncryptionMode:
-      output.EncryptionMode !== undefined && output.EncryptionMode !== null ? output.EncryptionMode : undefined,
+    CreatedBy: __expectString(output.CreatedBy),
+    DatasetName: __expectString(output.DatasetName),
+    EncryptionKeyArn: __expectString(output.EncryptionKeyArn),
+    EncryptionMode: __expectString(output.EncryptionMode),
     JobSample:
       output.JobSample !== undefined && output.JobSample !== null
         ? deserializeAws_restJson1JobSample(output.JobSample, context)
         : undefined,
-    LastModifiedBy:
-      output.LastModifiedBy !== undefined && output.LastModifiedBy !== null ? output.LastModifiedBy : undefined,
+    LastModifiedBy: __expectString(output.LastModifiedBy),
     LastModifiedDate:
       output.LastModifiedDate !== undefined && output.LastModifiedDate !== null
         ? new Date(Math.round(output.LastModifiedDate * 1000))
         : undefined,
-    LogSubscription:
-      output.LogSubscription !== undefined && output.LogSubscription !== null ? output.LogSubscription : undefined,
-    MaxCapacity: output.MaxCapacity !== undefined && output.MaxCapacity !== null ? output.MaxCapacity : undefined,
-    MaxRetries: output.MaxRetries !== undefined && output.MaxRetries !== null ? output.MaxRetries : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    LogSubscription: __expectString(output.LogSubscription),
+    MaxCapacity: __expectNumber(output.MaxCapacity),
+    MaxRetries: __expectNumber(output.MaxRetries),
+    Name: __expectString(output.Name),
     Outputs:
       output.Outputs !== undefined && output.Outputs !== null
         ? deserializeAws_restJson1OutputList(output.Outputs, context)
         : undefined,
-    ProjectName: output.ProjectName !== undefined && output.ProjectName !== null ? output.ProjectName : undefined,
+    ProjectName: __expectString(output.ProjectName),
     RecipeReference:
       output.RecipeReference !== undefined && output.RecipeReference !== null
         ? deserializeAws_restJson1RecipeReference(output.RecipeReference, context)
         : undefined,
-    ResourceArn: output.ResourceArn !== undefined && output.ResourceArn !== null ? output.ResourceArn : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
+    ResourceArn: __expectString(output.ResourceArn),
+    RoleArn: __expectString(output.RoleArn),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_restJson1TagMap(output.Tags, context)
         : undefined,
-    Timeout: output.Timeout !== undefined && output.Timeout !== null ? output.Timeout : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Timeout: __expectNumber(output.Timeout),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -5135,29 +5126,27 @@ const deserializeAws_restJson1JobNameList = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1JobRun = (output: any, context: __SerdeContext): JobRun => {
   return {
-    Attempt: output.Attempt !== undefined && output.Attempt !== null ? output.Attempt : undefined,
+    Attempt: __expectNumber(output.Attempt),
     CompletedOn:
       output.CompletedOn !== undefined && output.CompletedOn !== null
         ? new Date(Math.round(output.CompletedOn * 1000))
         : undefined,
-    DatasetName: output.DatasetName !== undefined && output.DatasetName !== null ? output.DatasetName : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    ExecutionTime:
-      output.ExecutionTime !== undefined && output.ExecutionTime !== null ? output.ExecutionTime : undefined,
-    JobName: output.JobName !== undefined && output.JobName !== null ? output.JobName : undefined,
+    DatasetName: __expectString(output.DatasetName),
+    ErrorMessage: __expectString(output.ErrorMessage),
+    ExecutionTime: __expectNumber(output.ExecutionTime),
+    JobName: __expectString(output.JobName),
     JobSample:
       output.JobSample !== undefined && output.JobSample !== null
         ? deserializeAws_restJson1JobSample(output.JobSample, context)
         : undefined,
-    LogGroupName: output.LogGroupName !== undefined && output.LogGroupName !== null ? output.LogGroupName : undefined,
-    LogSubscription:
-      output.LogSubscription !== undefined && output.LogSubscription !== null ? output.LogSubscription : undefined,
+    LogGroupName: __expectString(output.LogGroupName),
+    LogSubscription: __expectString(output.LogSubscription),
     Outputs:
       output.Outputs !== undefined && output.Outputs !== null
         ? deserializeAws_restJson1OutputList(output.Outputs, context)
@@ -5166,13 +5155,13 @@ const deserializeAws_restJson1JobRun = (output: any, context: __SerdeContext): J
       output.RecipeReference !== undefined && output.RecipeReference !== null
         ? deserializeAws_restJson1RecipeReference(output.RecipeReference, context)
         : undefined,
-    RunId: output.RunId !== undefined && output.RunId !== null ? output.RunId : undefined,
-    StartedBy: output.StartedBy !== undefined && output.StartedBy !== null ? output.StartedBy : undefined,
+    RunId: __expectString(output.RunId),
+    StartedBy: __expectString(output.StartedBy),
     StartedOn:
       output.StartedOn !== undefined && output.StartedOn !== null
         ? new Date(Math.round(output.StartedOn * 1000))
         : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    State: __expectString(output.State),
   } as any;
 };
 
@@ -5189,24 +5178,21 @@ const deserializeAws_restJson1JobRunList = (output: any, context: __SerdeContext
 
 const deserializeAws_restJson1JobSample = (output: any, context: __SerdeContext): JobSample => {
   return {
-    Mode: output.Mode !== undefined && output.Mode !== null ? output.Mode : undefined,
-    Size: output.Size !== undefined && output.Size !== null ? output.Size : undefined,
+    Mode: __expectString(output.Mode),
+    Size: __expectNumber(output.Size),
   } as any;
 };
 
 const deserializeAws_restJson1JsonOptions = (output: any, context: __SerdeContext): JsonOptions => {
   return {
-    MultiLine: output.MultiLine !== undefined && output.MultiLine !== null ? output.MultiLine : undefined,
+    MultiLine: __expectBoolean(output.MultiLine),
   } as any;
 };
 
 const deserializeAws_restJson1Output = (output: any, context: __SerdeContext): Output => {
   return {
-    CompressionFormat:
-      output.CompressionFormat !== undefined && output.CompressionFormat !== null
-        ? output.CompressionFormat
-        : undefined,
-    Format: output.Format !== undefined && output.Format !== null ? output.Format : undefined,
+    CompressionFormat: __expectString(output.CompressionFormat),
+    Format: __expectString(output.Format),
     FormatOptions:
       output.FormatOptions !== undefined && output.FormatOptions !== null
         ? deserializeAws_restJson1OutputFormatOptions(output.FormatOptions, context)
@@ -5215,7 +5201,7 @@ const deserializeAws_restJson1Output = (output: any, context: __SerdeContext): O
       output.Location !== undefined && output.Location !== null
         ? deserializeAws_restJson1S3Location(output.Location, context)
         : undefined,
-    Overwrite: output.Overwrite !== undefined && output.Overwrite !== null ? output.Overwrite : undefined,
+    Overwrite: __expectBoolean(output.Overwrite),
     PartitionColumns:
       output.PartitionColumns !== undefined && output.PartitionColumns !== null
         ? deserializeAws_restJson1ColumnNameList(output.PartitionColumns, context)
@@ -5250,7 +5236,7 @@ const deserializeAws_restJson1ParameterMap = (output: any, context: __SerdeConte
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -5289,28 +5275,27 @@ const deserializeAws_restJson1PathParametersMap = (
 
 const deserializeAws_restJson1Project = (output: any, context: __SerdeContext): Project => {
   return {
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
+    AccountId: __expectString(output.AccountId),
     CreateDate:
       output.CreateDate !== undefined && output.CreateDate !== null
         ? new Date(Math.round(output.CreateDate * 1000))
         : undefined,
-    CreatedBy: output.CreatedBy !== undefined && output.CreatedBy !== null ? output.CreatedBy : undefined,
-    DatasetName: output.DatasetName !== undefined && output.DatasetName !== null ? output.DatasetName : undefined,
-    LastModifiedBy:
-      output.LastModifiedBy !== undefined && output.LastModifiedBy !== null ? output.LastModifiedBy : undefined,
+    CreatedBy: __expectString(output.CreatedBy),
+    DatasetName: __expectString(output.DatasetName),
+    LastModifiedBy: __expectString(output.LastModifiedBy),
     LastModifiedDate:
       output.LastModifiedDate !== undefined && output.LastModifiedDate !== null
         ? new Date(Math.round(output.LastModifiedDate * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     OpenDate:
       output.OpenDate !== undefined && output.OpenDate !== null
         ? new Date(Math.round(output.OpenDate * 1000))
         : undefined,
-    OpenedBy: output.OpenedBy !== undefined && output.OpenedBy !== null ? output.OpenedBy : undefined,
-    RecipeName: output.RecipeName !== undefined && output.RecipeName !== null ? output.RecipeName : undefined,
-    ResourceArn: output.ResourceArn !== undefined && output.ResourceArn !== null ? output.ResourceArn : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
+    OpenedBy: __expectString(output.OpenedBy),
+    RecipeName: __expectString(output.RecipeName),
+    ResourceArn: __expectString(output.ResourceArn),
+    RoleArn: __expectString(output.RoleArn),
     Sample:
       output.Sample !== undefined && output.Sample !== null
         ? deserializeAws_restJson1Sample(output.Sample, context)
@@ -5339,24 +5324,22 @@ const deserializeAws_restJson1Recipe = (output: any, context: __SerdeContext): R
       output.CreateDate !== undefined && output.CreateDate !== null
         ? new Date(Math.round(output.CreateDate * 1000))
         : undefined,
-    CreatedBy: output.CreatedBy !== undefined && output.CreatedBy !== null ? output.CreatedBy : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    LastModifiedBy:
-      output.LastModifiedBy !== undefined && output.LastModifiedBy !== null ? output.LastModifiedBy : undefined,
+    CreatedBy: __expectString(output.CreatedBy),
+    Description: __expectString(output.Description),
+    LastModifiedBy: __expectString(output.LastModifiedBy),
     LastModifiedDate:
       output.LastModifiedDate !== undefined && output.LastModifiedDate !== null
         ? new Date(Math.round(output.LastModifiedDate * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    ProjectName: output.ProjectName !== undefined && output.ProjectName !== null ? output.ProjectName : undefined,
-    PublishedBy: output.PublishedBy !== undefined && output.PublishedBy !== null ? output.PublishedBy : undefined,
+    Name: __expectString(output.Name),
+    ProjectName: __expectString(output.ProjectName),
+    PublishedBy: __expectString(output.PublishedBy),
     PublishedDate:
       output.PublishedDate !== undefined && output.PublishedDate !== null
         ? new Date(Math.round(output.PublishedDate * 1000))
         : undefined,
-    RecipeVersion:
-      output.RecipeVersion !== undefined && output.RecipeVersion !== null ? output.RecipeVersion : undefined,
-    ResourceArn: output.ResourceArn !== undefined && output.ResourceArn !== null ? output.ResourceArn : undefined,
+    RecipeVersion: __expectString(output.RecipeVersion),
+    ResourceArn: __expectString(output.ResourceArn),
     Steps:
       output.Steps !== undefined && output.Steps !== null
         ? deserializeAws_restJson1RecipeStepList(output.Steps, context)
@@ -5370,7 +5353,7 @@ const deserializeAws_restJson1Recipe = (output: any, context: __SerdeContext): R
 
 const deserializeAws_restJson1RecipeAction = (output: any, context: __SerdeContext): RecipeAction => {
   return {
-    Operation: output.Operation !== undefined && output.Operation !== null ? output.Operation : undefined,
+    Operation: __expectString(output.Operation),
     Parameters:
       output.Parameters !== undefined && output.Parameters !== null
         ? deserializeAws_restJson1ParameterMap(output.Parameters, context)
@@ -5402,9 +5385,8 @@ const deserializeAws_restJson1RecipeList = (output: any, context: __SerdeContext
 
 const deserializeAws_restJson1RecipeReference = (output: any, context: __SerdeContext): RecipeReference => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    RecipeVersion:
-      output.RecipeVersion !== undefined && output.RecipeVersion !== null ? output.RecipeVersion : undefined,
+    Name: __expectString(output.Name),
+    RecipeVersion: __expectString(output.RecipeVersion),
   } as any;
 };
 
@@ -5437,49 +5419,46 @@ const deserializeAws_restJson1RecipeVersionErrorDetail = (
   context: __SerdeContext
 ): RecipeVersionErrorDetail => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    RecipeVersion:
-      output.RecipeVersion !== undefined && output.RecipeVersion !== null ? output.RecipeVersion : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
+    RecipeVersion: __expectString(output.RecipeVersion),
   } as any;
 };
 
 const deserializeAws_restJson1S3Location = (output: any, context: __SerdeContext): S3Location => {
   return {
-    Bucket: output.Bucket !== undefined && output.Bucket !== null ? output.Bucket : undefined,
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
+    Bucket: __expectString(output.Bucket),
+    Key: __expectString(output.Key),
   } as any;
 };
 
 const deserializeAws_restJson1Sample = (output: any, context: __SerdeContext): Sample => {
   return {
-    Size: output.Size !== undefined && output.Size !== null ? output.Size : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Size: __expectNumber(output.Size),
+    Type: __expectString(output.Type),
   } as any;
 };
 
 const deserializeAws_restJson1Schedule = (output: any, context: __SerdeContext): Schedule => {
   return {
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
+    AccountId: __expectString(output.AccountId),
     CreateDate:
       output.CreateDate !== undefined && output.CreateDate !== null
         ? new Date(Math.round(output.CreateDate * 1000))
         : undefined,
-    CreatedBy: output.CreatedBy !== undefined && output.CreatedBy !== null ? output.CreatedBy : undefined,
-    CronExpression:
-      output.CronExpression !== undefined && output.CronExpression !== null ? output.CronExpression : undefined,
+    CreatedBy: __expectString(output.CreatedBy),
+    CronExpression: __expectString(output.CronExpression),
     JobNames:
       output.JobNames !== undefined && output.JobNames !== null
         ? deserializeAws_restJson1JobNameList(output.JobNames, context)
         : undefined,
-    LastModifiedBy:
-      output.LastModifiedBy !== undefined && output.LastModifiedBy !== null ? output.LastModifiedBy : undefined,
+    LastModifiedBy: __expectString(output.LastModifiedBy),
     LastModifiedDate:
       output.LastModifiedDate !== undefined && output.LastModifiedDate !== null
         ? new Date(Math.round(output.LastModifiedDate * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    ResourceArn: output.ResourceArn !== undefined && output.ResourceArn !== null ? output.ResourceArn : undefined,
+    Name: __expectString(output.Name),
+    ResourceArn: __expectString(output.ResourceArn),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_restJson1TagMap(output.Tags, context)
@@ -5505,7 +5484,7 @@ const deserializeAws_restJson1SheetIndexList = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectNumber(entry) as any;
     });
 };
 
@@ -5516,7 +5495,7 @@ const deserializeAws_restJson1SheetNameList = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -5527,7 +5506,7 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -5539,7 +5518,7 @@ const deserializeAws_restJson1ValuesMap = (output: any, context: __SerdeContext)
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };

--- a/clients/client-dataexchange/protocols/Aws_restJson1.ts
+++ b/clients/client-dataexchange/protocols/Aws_restJson1.ts
@@ -64,6 +64,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -922,31 +925,31 @@ export const deserializeAws_restJson1CreateDataSetCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.AssetType !== undefined && data.AssetType !== null) {
-    contents.AssetType = data.AssetType;
+    contents.AssetType = __expectString(data.AssetType);
   }
   if (data.CreatedAt !== undefined && data.CreatedAt !== null) {
     contents.CreatedAt = new Date(data.CreatedAt);
   }
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.Origin !== undefined && data.Origin !== null) {
-    contents.Origin = data.Origin;
+    contents.Origin = __expectString(data.Origin);
   }
   if (data.OriginDetails !== undefined && data.OriginDetails !== null) {
     contents.OriginDetails = deserializeAws_restJson1OriginDetails(data.OriginDetails, context);
   }
   if (data.SourceId !== undefined && data.SourceId !== null) {
-    contents.SourceId = data.SourceId;
+    contents.SourceId = __expectString(data.SourceId);
   }
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1MapOf__string(data.Tags, context);
@@ -1046,7 +1049,7 @@ export const deserializeAws_restJson1CreateJobCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreatedAt !== undefined && data.CreatedAt !== null) {
     contents.CreatedAt = new Date(data.CreatedAt);
@@ -1058,13 +1061,13 @@ export const deserializeAws_restJson1CreateJobCommand = async (
     contents.Errors = deserializeAws_restJson1ListOfJobError(data.Errors, context);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.State !== undefined && data.State !== null) {
-    contents.State = data.State;
+    contents.State = __expectString(data.State);
   }
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   if (data.UpdatedAt !== undefined && data.UpdatedAt !== null) {
     contents.UpdatedAt = new Date(data.UpdatedAt);
@@ -1162,25 +1165,25 @@ export const deserializeAws_restJson1CreateRevisionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.Comment !== undefined && data.Comment !== null) {
-    contents.Comment = data.Comment;
+    contents.Comment = __expectString(data.Comment);
   }
   if (data.CreatedAt !== undefined && data.CreatedAt !== null) {
     contents.CreatedAt = new Date(data.CreatedAt);
   }
   if (data.DataSetId !== undefined && data.DataSetId !== null) {
-    contents.DataSetId = data.DataSetId;
+    contents.DataSetId = __expectString(data.DataSetId);
   }
   if (data.Finalized !== undefined && data.Finalized !== null) {
-    contents.Finalized = data.Finalized;
+    contents.Finalized = __expectBoolean(data.Finalized);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.SourceId !== undefined && data.SourceId !== null) {
-    contents.SourceId = data.SourceId;
+    contents.SourceId = __expectString(data.SourceId);
   }
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1MapOf__string(data.Tags, context);
@@ -1555,31 +1558,31 @@ export const deserializeAws_restJson1GetAssetCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.AssetDetails !== undefined && data.AssetDetails !== null) {
     contents.AssetDetails = deserializeAws_restJson1AssetDetails(data.AssetDetails, context);
   }
   if (data.AssetType !== undefined && data.AssetType !== null) {
-    contents.AssetType = data.AssetType;
+    contents.AssetType = __expectString(data.AssetType);
   }
   if (data.CreatedAt !== undefined && data.CreatedAt !== null) {
     contents.CreatedAt = new Date(data.CreatedAt);
   }
   if (data.DataSetId !== undefined && data.DataSetId !== null) {
-    contents.DataSetId = data.DataSetId;
+    contents.DataSetId = __expectString(data.DataSetId);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.RevisionId !== undefined && data.RevisionId !== null) {
-    contents.RevisionId = data.RevisionId;
+    contents.RevisionId = __expectString(data.RevisionId);
   }
   if (data.SourceId !== undefined && data.SourceId !== null) {
-    contents.SourceId = data.SourceId;
+    contents.SourceId = __expectString(data.SourceId);
   }
   if (data.UpdatedAt !== undefined && data.UpdatedAt !== null) {
     contents.UpdatedAt = new Date(data.UpdatedAt);
@@ -1671,31 +1674,31 @@ export const deserializeAws_restJson1GetDataSetCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.AssetType !== undefined && data.AssetType !== null) {
-    contents.AssetType = data.AssetType;
+    contents.AssetType = __expectString(data.AssetType);
   }
   if (data.CreatedAt !== undefined && data.CreatedAt !== null) {
     contents.CreatedAt = new Date(data.CreatedAt);
   }
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.Origin !== undefined && data.Origin !== null) {
-    contents.Origin = data.Origin;
+    contents.Origin = __expectString(data.Origin);
   }
   if (data.OriginDetails !== undefined && data.OriginDetails !== null) {
     contents.OriginDetails = deserializeAws_restJson1OriginDetails(data.OriginDetails, context);
   }
   if (data.SourceId !== undefined && data.SourceId !== null) {
-    contents.SourceId = data.SourceId;
+    contents.SourceId = __expectString(data.SourceId);
   }
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1MapOf__string(data.Tags, context);
@@ -1787,7 +1790,7 @@ export const deserializeAws_restJson1GetJobCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreatedAt !== undefined && data.CreatedAt !== null) {
     contents.CreatedAt = new Date(data.CreatedAt);
@@ -1799,13 +1802,13 @@ export const deserializeAws_restJson1GetJobCommand = async (
     contents.Errors = deserializeAws_restJson1ListOfJobError(data.Errors, context);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.State !== undefined && data.State !== null) {
-    contents.State = data.State;
+    contents.State = __expectString(data.State);
   }
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   if (data.UpdatedAt !== undefined && data.UpdatedAt !== null) {
     contents.UpdatedAt = new Date(data.UpdatedAt);
@@ -1895,25 +1898,25 @@ export const deserializeAws_restJson1GetRevisionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.Comment !== undefined && data.Comment !== null) {
-    contents.Comment = data.Comment;
+    contents.Comment = __expectString(data.Comment);
   }
   if (data.CreatedAt !== undefined && data.CreatedAt !== null) {
     contents.CreatedAt = new Date(data.CreatedAt);
   }
   if (data.DataSetId !== undefined && data.DataSetId !== null) {
-    contents.DataSetId = data.DataSetId;
+    contents.DataSetId = __expectString(data.DataSetId);
   }
   if (data.Finalized !== undefined && data.Finalized !== null) {
-    contents.Finalized = data.Finalized;
+    contents.Finalized = __expectBoolean(data.Finalized);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.SourceId !== undefined && data.SourceId !== null) {
-    contents.SourceId = data.SourceId;
+    contents.SourceId = __expectString(data.SourceId);
   }
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1MapOf__string(data.Tags, context);
@@ -1999,7 +2002,7 @@ export const deserializeAws_restJson1ListDataSetRevisionsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Revisions !== undefined && data.Revisions !== null) {
     contents.Revisions = deserializeAws_restJson1ListOfRevisionEntry(data.Revisions, context);
@@ -2085,7 +2088,7 @@ export const deserializeAws_restJson1ListDataSetsCommand = async (
     contents.DataSets = deserializeAws_restJson1ListOfDataSetEntry(data.DataSets, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2168,7 +2171,7 @@ export const deserializeAws_restJson1ListJobsCommand = async (
     contents.Jobs = deserializeAws_restJson1ListOfJobEntry(data.Jobs, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2251,7 +2254,7 @@ export const deserializeAws_restJson1ListRevisionAssetsCommand = async (
     contents.Assets = deserializeAws_restJson1ListOfAssetEntry(data.Assets, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2563,31 +2566,31 @@ export const deserializeAws_restJson1UpdateAssetCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.AssetDetails !== undefined && data.AssetDetails !== null) {
     contents.AssetDetails = deserializeAws_restJson1AssetDetails(data.AssetDetails, context);
   }
   if (data.AssetType !== undefined && data.AssetType !== null) {
-    contents.AssetType = data.AssetType;
+    contents.AssetType = __expectString(data.AssetType);
   }
   if (data.CreatedAt !== undefined && data.CreatedAt !== null) {
     contents.CreatedAt = new Date(data.CreatedAt);
   }
   if (data.DataSetId !== undefined && data.DataSetId !== null) {
-    contents.DataSetId = data.DataSetId;
+    contents.DataSetId = __expectString(data.DataSetId);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.RevisionId !== undefined && data.RevisionId !== null) {
-    contents.RevisionId = data.RevisionId;
+    contents.RevisionId = __expectString(data.RevisionId);
   }
   if (data.SourceId !== undefined && data.SourceId !== null) {
-    contents.SourceId = data.SourceId;
+    contents.SourceId = __expectString(data.SourceId);
   }
   if (data.UpdatedAt !== undefined && data.UpdatedAt !== null) {
     contents.UpdatedAt = new Date(data.UpdatedAt);
@@ -2694,31 +2697,31 @@ export const deserializeAws_restJson1UpdateDataSetCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.AssetType !== undefined && data.AssetType !== null) {
-    contents.AssetType = data.AssetType;
+    contents.AssetType = __expectString(data.AssetType);
   }
   if (data.CreatedAt !== undefined && data.CreatedAt !== null) {
     contents.CreatedAt = new Date(data.CreatedAt);
   }
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.Origin !== undefined && data.Origin !== null) {
-    contents.Origin = data.Origin;
+    contents.Origin = __expectString(data.Origin);
   }
   if (data.OriginDetails !== undefined && data.OriginDetails !== null) {
     contents.OriginDetails = deserializeAws_restJson1OriginDetails(data.OriginDetails, context);
   }
   if (data.SourceId !== undefined && data.SourceId !== null) {
-    contents.SourceId = data.SourceId;
+    contents.SourceId = __expectString(data.SourceId);
   }
   if (data.UpdatedAt !== undefined && data.UpdatedAt !== null) {
     contents.UpdatedAt = new Date(data.UpdatedAt);
@@ -2815,25 +2818,25 @@ export const deserializeAws_restJson1UpdateRevisionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.Comment !== undefined && data.Comment !== null) {
-    contents.Comment = data.Comment;
+    contents.Comment = __expectString(data.Comment);
   }
   if (data.CreatedAt !== undefined && data.CreatedAt !== null) {
     contents.CreatedAt = new Date(data.CreatedAt);
   }
   if (data.DataSetId !== undefined && data.DataSetId !== null) {
-    contents.DataSetId = data.DataSetId;
+    contents.DataSetId = __expectString(data.DataSetId);
   }
   if (data.Finalized !== undefined && data.Finalized !== null) {
-    contents.Finalized = data.Finalized;
+    contents.Finalized = __expectBoolean(data.Finalized);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.SourceId !== undefined && data.SourceId !== null) {
-    contents.SourceId = data.SourceId;
+    contents.SourceId = __expectString(data.SourceId);
   }
   if (data.UpdatedAt !== undefined && data.UpdatedAt !== null) {
     contents.UpdatedAt = new Date(data.UpdatedAt);
@@ -2930,7 +2933,7 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -2949,13 +2952,13 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.ResourceId !== undefined && data.ResourceId !== null) {
-    contents.ResourceId = data.ResourceId;
+    contents.ResourceId = __expectString(data.ResourceId);
   }
   if (data.ResourceType !== undefined && data.ResourceType !== null) {
-    contents.ResourceType = data.ResourceType;
+    contents.ResourceType = __expectString(data.ResourceType);
   }
   return contents;
 };
@@ -2972,7 +2975,7 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -2991,13 +2994,13 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.ResourceId !== undefined && data.ResourceId !== null) {
-    contents.ResourceId = data.ResourceId;
+    contents.ResourceId = __expectString(data.ResourceId);
   }
   if (data.ResourceType !== undefined && data.ResourceType !== null) {
-    contents.ResourceType = data.ResourceType;
+    contents.ResourceType = __expectString(data.ResourceType);
   }
   return contents;
 };
@@ -3016,13 +3019,13 @@ const deserializeAws_restJson1ServiceLimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.LimitName !== undefined && data.LimitName !== null) {
-    contents.LimitName = data.LimitName;
+    contents.LimitName = __expectString(data.LimitName);
   }
   if (data.LimitValue !== undefined && data.LimitValue !== null) {
-    contents.LimitValue = data.LimitValue;
+    contents.LimitValue = __expectNumber(data.LimitValue);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3039,7 +3042,7 @@ const deserializeAws_restJson1ThrottlingExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3056,7 +3059,7 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3256,9 +3259,9 @@ const serializeAws_restJson1RevisionDestinationEntry = (
 
 const deserializeAws_restJson1AssetDestinationEntry = (output: any, context: __SerdeContext): AssetDestinationEntry => {
   return {
-    AssetId: output.AssetId !== undefined && output.AssetId !== null ? output.AssetId : undefined,
-    Bucket: output.Bucket !== undefined && output.Bucket !== null ? output.Bucket : undefined,
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
+    AssetId: __expectString(output.AssetId),
+    Bucket: __expectString(output.Bucket),
+    Key: __expectString(output.Key),
   } as any;
 };
 
@@ -3273,43 +3276,43 @@ const deserializeAws_restJson1AssetDetails = (output: any, context: __SerdeConte
 
 const deserializeAws_restJson1AssetEntry = (output: any, context: __SerdeContext): AssetEntry => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     AssetDetails:
       output.AssetDetails !== undefined && output.AssetDetails !== null
         ? deserializeAws_restJson1AssetDetails(output.AssetDetails, context)
         : undefined,
-    AssetType: output.AssetType !== undefined && output.AssetType !== null ? output.AssetType : undefined,
+    AssetType: __expectString(output.AssetType),
     CreatedAt: output.CreatedAt !== undefined && output.CreatedAt !== null ? new Date(output.CreatedAt) : undefined,
-    DataSetId: output.DataSetId !== undefined && output.DataSetId !== null ? output.DataSetId : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    RevisionId: output.RevisionId !== undefined && output.RevisionId !== null ? output.RevisionId : undefined,
-    SourceId: output.SourceId !== undefined && output.SourceId !== null ? output.SourceId : undefined,
+    DataSetId: __expectString(output.DataSetId),
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
+    RevisionId: __expectString(output.RevisionId),
+    SourceId: __expectString(output.SourceId),
     UpdatedAt: output.UpdatedAt !== undefined && output.UpdatedAt !== null ? new Date(output.UpdatedAt) : undefined,
   } as any;
 };
 
 const deserializeAws_restJson1AssetSourceEntry = (output: any, context: __SerdeContext): AssetSourceEntry => {
   return {
-    Bucket: output.Bucket !== undefined && output.Bucket !== null ? output.Bucket : undefined,
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
+    Bucket: __expectString(output.Bucket),
+    Key: __expectString(output.Key),
   } as any;
 };
 
 const deserializeAws_restJson1DataSetEntry = (output: any, context: __SerdeContext): DataSetEntry => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    AssetType: output.AssetType !== undefined && output.AssetType !== null ? output.AssetType : undefined,
+    Arn: __expectString(output.Arn),
+    AssetType: __expectString(output.AssetType),
     CreatedAt: output.CreatedAt !== undefined && output.CreatedAt !== null ? new Date(output.CreatedAt) : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Origin: output.Origin !== undefined && output.Origin !== null ? output.Origin : undefined,
+    Description: __expectString(output.Description),
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
+    Origin: __expectString(output.Origin),
     OriginDetails:
       output.OriginDetails !== undefined && output.OriginDetails !== null
         ? deserializeAws_restJson1OriginDetails(output.OriginDetails, context)
         : undefined,
-    SourceId: output.SourceId !== undefined && output.SourceId !== null ? output.SourceId : undefined,
+    SourceId: __expectString(output.SourceId),
     UpdatedAt: output.UpdatedAt !== undefined && output.UpdatedAt !== null ? new Date(output.UpdatedAt) : undefined,
   } as any;
 };
@@ -3340,12 +3343,12 @@ const deserializeAws_restJson1ExportAssetsToS3ResponseDetails = (
       output.AssetDestinations !== undefined && output.AssetDestinations !== null
         ? deserializeAws_restJson1ListOfAssetDestinationEntry(output.AssetDestinations, context)
         : undefined,
-    DataSetId: output.DataSetId !== undefined && output.DataSetId !== null ? output.DataSetId : undefined,
+    DataSetId: __expectString(output.DataSetId),
     Encryption:
       output.Encryption !== undefined && output.Encryption !== null
         ? deserializeAws_restJson1ExportServerSideEncryption(output.Encryption, context)
         : undefined,
-    RevisionId: output.RevisionId !== undefined && output.RevisionId !== null ? output.RevisionId : undefined,
+    RevisionId: __expectString(output.RevisionId),
   } as any;
 };
 
@@ -3354,10 +3357,10 @@ const deserializeAws_restJson1ExportAssetToSignedUrlResponseDetails = (
   context: __SerdeContext
 ): ExportAssetToSignedUrlResponseDetails => {
   return {
-    AssetId: output.AssetId !== undefined && output.AssetId !== null ? output.AssetId : undefined,
-    DataSetId: output.DataSetId !== undefined && output.DataSetId !== null ? output.DataSetId : undefined,
-    RevisionId: output.RevisionId !== undefined && output.RevisionId !== null ? output.RevisionId : undefined,
-    SignedUrl: output.SignedUrl !== undefined && output.SignedUrl !== null ? output.SignedUrl : undefined,
+    AssetId: __expectString(output.AssetId),
+    DataSetId: __expectString(output.DataSetId),
+    RevisionId: __expectString(output.RevisionId),
+    SignedUrl: __expectString(output.SignedUrl),
     SignedUrlExpiresAt:
       output.SignedUrlExpiresAt !== undefined && output.SignedUrlExpiresAt !== null
         ? new Date(output.SignedUrlExpiresAt)
@@ -3370,7 +3373,7 @@ const deserializeAws_restJson1ExportRevisionsToS3ResponseDetails = (
   context: __SerdeContext
 ): ExportRevisionsToS3ResponseDetails => {
   return {
-    DataSetId: output.DataSetId !== undefined && output.DataSetId !== null ? output.DataSetId : undefined,
+    DataSetId: __expectString(output.DataSetId),
     Encryption:
       output.Encryption !== undefined && output.Encryption !== null
         ? deserializeAws_restJson1ExportServerSideEncryption(output.Encryption, context)
@@ -3387,8 +3390,8 @@ const deserializeAws_restJson1ExportServerSideEncryption = (
   context: __SerdeContext
 ): ExportServerSideEncryption => {
   return {
-    KmsKeyArn: output.KmsKeyArn !== undefined && output.KmsKeyArn !== null ? output.KmsKeyArn : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    KmsKeyArn: __expectString(output.KmsKeyArn),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -3397,7 +3400,7 @@ const deserializeAws_restJson1ImportAssetFromSignedUrlJobErrorDetails = (
   context: __SerdeContext
 ): ImportAssetFromSignedUrlJobErrorDetails => {
   return {
-    AssetName: output.AssetName !== undefined && output.AssetName !== null ? output.AssetName : undefined,
+    AssetName: __expectString(output.AssetName),
   } as any;
 };
 
@@ -3406,11 +3409,11 @@ const deserializeAws_restJson1ImportAssetFromSignedUrlResponseDetails = (
   context: __SerdeContext
 ): ImportAssetFromSignedUrlResponseDetails => {
   return {
-    AssetName: output.AssetName !== undefined && output.AssetName !== null ? output.AssetName : undefined,
-    DataSetId: output.DataSetId !== undefined && output.DataSetId !== null ? output.DataSetId : undefined,
-    Md5Hash: output.Md5Hash !== undefined && output.Md5Hash !== null ? output.Md5Hash : undefined,
-    RevisionId: output.RevisionId !== undefined && output.RevisionId !== null ? output.RevisionId : undefined,
-    SignedUrl: output.SignedUrl !== undefined && output.SignedUrl !== null ? output.SignedUrl : undefined,
+    AssetName: __expectString(output.AssetName),
+    DataSetId: __expectString(output.DataSetId),
+    Md5Hash: __expectString(output.Md5Hash),
+    RevisionId: __expectString(output.RevisionId),
+    SignedUrl: __expectString(output.SignedUrl),
     SignedUrlExpiresAt:
       output.SignedUrlExpiresAt !== undefined && output.SignedUrlExpiresAt !== null
         ? new Date(output.SignedUrlExpiresAt)
@@ -3427,14 +3430,14 @@ const deserializeAws_restJson1ImportAssetsFromS3ResponseDetails = (
       output.AssetSources !== undefined && output.AssetSources !== null
         ? deserializeAws_restJson1ListOfAssetSourceEntry(output.AssetSources, context)
         : undefined,
-    DataSetId: output.DataSetId !== undefined && output.DataSetId !== null ? output.DataSetId : undefined,
-    RevisionId: output.RevisionId !== undefined && output.RevisionId !== null ? output.RevisionId : undefined,
+    DataSetId: __expectString(output.DataSetId),
+    RevisionId: __expectString(output.RevisionId),
   } as any;
 };
 
 const deserializeAws_restJson1JobEntry = (output: any, context: __SerdeContext): JobEntry => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     CreatedAt: output.CreatedAt !== undefined && output.CreatedAt !== null ? new Date(output.CreatedAt) : undefined,
     Details:
       output.Details !== undefined && output.Details !== null
@@ -3444,25 +3447,25 @@ const deserializeAws_restJson1JobEntry = (output: any, context: __SerdeContext):
       output.Errors !== undefined && output.Errors !== null
         ? deserializeAws_restJson1ListOfJobError(output.Errors, context)
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Id: __expectString(output.Id),
+    State: __expectString(output.State),
+    Type: __expectString(output.Type),
     UpdatedAt: output.UpdatedAt !== undefined && output.UpdatedAt !== null ? new Date(output.UpdatedAt) : undefined,
   } as any;
 };
 
 const deserializeAws_restJson1JobError = (output: any, context: __SerdeContext): JobError => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
+    Code: __expectString(output.Code),
     Details:
       output.Details !== undefined && output.Details !== null
         ? deserializeAws_restJson1Details(output.Details, context)
         : undefined,
-    LimitName: output.LimitName !== undefined && output.LimitName !== null ? output.LimitName : undefined,
-    LimitValue: output.LimitValue !== undefined && output.LimitValue !== null ? output.LimitValue : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    ResourceId: output.ResourceId !== undefined && output.ResourceId !== null ? output.ResourceId : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
+    LimitName: __expectString(output.LimitName),
+    LimitValue: __expectNumber(output.LimitValue),
+    Message: __expectString(output.Message),
+    ResourceId: __expectString(output.ResourceId),
+    ResourceType: __expectString(output.ResourceType),
   } as any;
 };
 
@@ -3567,14 +3570,14 @@ const deserializeAws_restJson1MapOf__string = (output: any, context: __SerdeCont
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1OriginDetails = (output: any, context: __SerdeContext): OriginDetails => {
   return {
-    ProductId: output.ProductId !== undefined && output.ProductId !== null ? output.ProductId : undefined,
+    ProductId: __expectString(output.ProductId),
   } as any;
 };
 
@@ -3608,28 +3611,28 @@ const deserializeAws_restJson1RevisionDestinationEntry = (
   context: __SerdeContext
 ): RevisionDestinationEntry => {
   return {
-    Bucket: output.Bucket !== undefined && output.Bucket !== null ? output.Bucket : undefined,
-    KeyPattern: output.KeyPattern !== undefined && output.KeyPattern !== null ? output.KeyPattern : undefined,
-    RevisionId: output.RevisionId !== undefined && output.RevisionId !== null ? output.RevisionId : undefined,
+    Bucket: __expectString(output.Bucket),
+    KeyPattern: __expectString(output.KeyPattern),
+    RevisionId: __expectString(output.RevisionId),
   } as any;
 };
 
 const deserializeAws_restJson1RevisionEntry = (output: any, context: __SerdeContext): RevisionEntry => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Comment: output.Comment !== undefined && output.Comment !== null ? output.Comment : undefined,
+    Arn: __expectString(output.Arn),
+    Comment: __expectString(output.Comment),
     CreatedAt: output.CreatedAt !== undefined && output.CreatedAt !== null ? new Date(output.CreatedAt) : undefined,
-    DataSetId: output.DataSetId !== undefined && output.DataSetId !== null ? output.DataSetId : undefined,
-    Finalized: output.Finalized !== undefined && output.Finalized !== null ? output.Finalized : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    SourceId: output.SourceId !== undefined && output.SourceId !== null ? output.SourceId : undefined,
+    DataSetId: __expectString(output.DataSetId),
+    Finalized: __expectBoolean(output.Finalized),
+    Id: __expectString(output.Id),
+    SourceId: __expectString(output.SourceId),
     UpdatedAt: output.UpdatedAt !== undefined && output.UpdatedAt !== null ? new Date(output.UpdatedAt) : undefined,
   } as any;
 };
 
 const deserializeAws_restJson1S3SnapshotAsset = (output: any, context: __SerdeContext): S3SnapshotAsset => {
   return {
-    Size: output.Size !== undefined && output.Size !== null ? output.Size : undefined,
+    Size: __expectNumber(output.Size),
   } as any;
 };
 

--- a/clients/client-datasync/protocols/Aws_json1_1.ts
+++ b/clients/client-datasync/protocols/Aws_json1_1.ts
@@ -161,7 +161,11 @@ import {
   UpdateTaskResponse,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -3457,7 +3461,7 @@ const deserializeAws_json1_1AgentArnList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3474,9 +3478,9 @@ const deserializeAws_json1_1AgentList = (output: any, context: __SerdeContext): 
 
 const deserializeAws_json1_1AgentListEntry = (output: any, context: __SerdeContext): AgentListEntry => {
   return {
-    AgentArn: output.AgentArn !== undefined && output.AgentArn !== null ? output.AgentArn : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    AgentArn: __expectString(output.AgentArn),
+    Name: __expectString(output.Name),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -3489,7 +3493,7 @@ const deserializeAws_json1_1CancelTaskExecutionResponse = (
 
 const deserializeAws_json1_1CreateAgentResponse = (output: any, context: __SerdeContext): CreateAgentResponse => {
   return {
-    AgentArn: output.AgentArn !== undefined && output.AgentArn !== null ? output.AgentArn : undefined,
+    AgentArn: __expectString(output.AgentArn),
   } as any;
 };
 
@@ -3498,7 +3502,7 @@ const deserializeAws_json1_1CreateLocationEfsResponse = (
   context: __SerdeContext
 ): CreateLocationEfsResponse => {
   return {
-    LocationArn: output.LocationArn !== undefined && output.LocationArn !== null ? output.LocationArn : undefined,
+    LocationArn: __expectString(output.LocationArn),
   } as any;
 };
 
@@ -3507,7 +3511,7 @@ const deserializeAws_json1_1CreateLocationFsxWindowsResponse = (
   context: __SerdeContext
 ): CreateLocationFsxWindowsResponse => {
   return {
-    LocationArn: output.LocationArn !== undefined && output.LocationArn !== null ? output.LocationArn : undefined,
+    LocationArn: __expectString(output.LocationArn),
   } as any;
 };
 
@@ -3516,7 +3520,7 @@ const deserializeAws_json1_1CreateLocationNfsResponse = (
   context: __SerdeContext
 ): CreateLocationNfsResponse => {
   return {
-    LocationArn: output.LocationArn !== undefined && output.LocationArn !== null ? output.LocationArn : undefined,
+    LocationArn: __expectString(output.LocationArn),
   } as any;
 };
 
@@ -3525,7 +3529,7 @@ const deserializeAws_json1_1CreateLocationObjectStorageResponse = (
   context: __SerdeContext
 ): CreateLocationObjectStorageResponse => {
   return {
-    LocationArn: output.LocationArn !== undefined && output.LocationArn !== null ? output.LocationArn : undefined,
+    LocationArn: __expectString(output.LocationArn),
   } as any;
 };
 
@@ -3534,7 +3538,7 @@ const deserializeAws_json1_1CreateLocationS3Response = (
   context: __SerdeContext
 ): CreateLocationS3Response => {
   return {
-    LocationArn: output.LocationArn !== undefined && output.LocationArn !== null ? output.LocationArn : undefined,
+    LocationArn: __expectString(output.LocationArn),
   } as any;
 };
 
@@ -3543,13 +3547,13 @@ const deserializeAws_json1_1CreateLocationSmbResponse = (
   context: __SerdeContext
 ): CreateLocationSmbResponse => {
   return {
-    LocationArn: output.LocationArn !== undefined && output.LocationArn !== null ? output.LocationArn : undefined,
+    LocationArn: __expectString(output.LocationArn),
   } as any;
 };
 
 const deserializeAws_json1_1CreateTaskResponse = (output: any, context: __SerdeContext): CreateTaskResponse => {
   return {
-    TaskArn: output.TaskArn !== undefined && output.TaskArn !== null ? output.TaskArn : undefined,
+    TaskArn: __expectString(output.TaskArn),
   } as any;
 };
 
@@ -3567,22 +3571,22 @@ const deserializeAws_json1_1DeleteTaskResponse = (output: any, context: __SerdeC
 
 const deserializeAws_json1_1DescribeAgentResponse = (output: any, context: __SerdeContext): DescribeAgentResponse => {
   return {
-    AgentArn: output.AgentArn !== undefined && output.AgentArn !== null ? output.AgentArn : undefined,
+    AgentArn: __expectString(output.AgentArn),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    EndpointType: output.EndpointType !== undefined && output.EndpointType !== null ? output.EndpointType : undefined,
+    EndpointType: __expectString(output.EndpointType),
     LastConnectionTime:
       output.LastConnectionTime !== undefined && output.LastConnectionTime !== null
         ? new Date(Math.round(output.LastConnectionTime * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     PrivateLinkConfig:
       output.PrivateLinkConfig !== undefined && output.PrivateLinkConfig !== null
         ? deserializeAws_json1_1PrivateLinkConfig(output.PrivateLinkConfig, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -3599,8 +3603,8 @@ const deserializeAws_json1_1DescribeLocationEfsResponse = (
       output.Ec2Config !== undefined && output.Ec2Config !== null
         ? deserializeAws_json1_1Ec2Config(output.Ec2Config, context)
         : undefined,
-    LocationArn: output.LocationArn !== undefined && output.LocationArn !== null ? output.LocationArn : undefined,
-    LocationUri: output.LocationUri !== undefined && output.LocationUri !== null ? output.LocationUri : undefined,
+    LocationArn: __expectString(output.LocationArn),
+    LocationUri: __expectString(output.LocationUri),
   } as any;
 };
 
@@ -3613,14 +3617,14 @@ const deserializeAws_json1_1DescribeLocationFsxWindowsResponse = (
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    Domain: output.Domain !== undefined && output.Domain !== null ? output.Domain : undefined,
-    LocationArn: output.LocationArn !== undefined && output.LocationArn !== null ? output.LocationArn : undefined,
-    LocationUri: output.LocationUri !== undefined && output.LocationUri !== null ? output.LocationUri : undefined,
+    Domain: __expectString(output.Domain),
+    LocationArn: __expectString(output.LocationArn),
+    LocationUri: __expectString(output.LocationUri),
     SecurityGroupArns:
       output.SecurityGroupArns !== undefined && output.SecurityGroupArns !== null
         ? deserializeAws_json1_1Ec2SecurityGroupArnList(output.SecurityGroupArns, context)
         : undefined,
-    User: output.User !== undefined && output.User !== null ? output.User : undefined,
+    User: __expectString(output.User),
   } as any;
 };
 
@@ -3633,8 +3637,8 @@ const deserializeAws_json1_1DescribeLocationNfsResponse = (
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    LocationArn: output.LocationArn !== undefined && output.LocationArn !== null ? output.LocationArn : undefined,
-    LocationUri: output.LocationUri !== undefined && output.LocationUri !== null ? output.LocationUri : undefined,
+    LocationArn: __expectString(output.LocationArn),
+    LocationUri: __expectString(output.LocationUri),
     MountOptions:
       output.MountOptions !== undefined && output.MountOptions !== null
         ? deserializeAws_json1_1NfsMountOptions(output.MountOptions, context)
@@ -3651,7 +3655,7 @@ const deserializeAws_json1_1DescribeLocationObjectStorageResponse = (
   context: __SerdeContext
 ): DescribeLocationObjectStorageResponse => {
   return {
-    AccessKey: output.AccessKey !== undefined && output.AccessKey !== null ? output.AccessKey : undefined,
+    AccessKey: __expectString(output.AccessKey),
     AgentArns:
       output.AgentArns !== undefined && output.AgentArns !== null
         ? deserializeAws_json1_1AgentArnList(output.AgentArns, context)
@@ -3660,11 +3664,10 @@ const deserializeAws_json1_1DescribeLocationObjectStorageResponse = (
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    LocationArn: output.LocationArn !== undefined && output.LocationArn !== null ? output.LocationArn : undefined,
-    LocationUri: output.LocationUri !== undefined && output.LocationUri !== null ? output.LocationUri : undefined,
-    ServerPort: output.ServerPort !== undefined && output.ServerPort !== null ? output.ServerPort : undefined,
-    ServerProtocol:
-      output.ServerProtocol !== undefined && output.ServerProtocol !== null ? output.ServerProtocol : undefined,
+    LocationArn: __expectString(output.LocationArn),
+    LocationUri: __expectString(output.LocationUri),
+    ServerPort: __expectNumber(output.ServerPort),
+    ServerProtocol: __expectString(output.ServerProtocol),
   } as any;
 };
 
@@ -3681,14 +3684,13 @@ const deserializeAws_json1_1DescribeLocationS3Response = (
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    LocationArn: output.LocationArn !== undefined && output.LocationArn !== null ? output.LocationArn : undefined,
-    LocationUri: output.LocationUri !== undefined && output.LocationUri !== null ? output.LocationUri : undefined,
+    LocationArn: __expectString(output.LocationArn),
+    LocationUri: __expectString(output.LocationUri),
     S3Config:
       output.S3Config !== undefined && output.S3Config !== null
         ? deserializeAws_json1_1S3Config(output.S3Config, context)
         : undefined,
-    S3StorageClass:
-      output.S3StorageClass !== undefined && output.S3StorageClass !== null ? output.S3StorageClass : undefined,
+    S3StorageClass: __expectString(output.S3StorageClass),
   } as any;
 };
 
@@ -3705,14 +3707,14 @@ const deserializeAws_json1_1DescribeLocationSmbResponse = (
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    Domain: output.Domain !== undefined && output.Domain !== null ? output.Domain : undefined,
-    LocationArn: output.LocationArn !== undefined && output.LocationArn !== null ? output.LocationArn : undefined,
-    LocationUri: output.LocationUri !== undefined && output.LocationUri !== null ? output.LocationUri : undefined,
+    Domain: __expectString(output.Domain),
+    LocationArn: __expectString(output.LocationArn),
+    LocationUri: __expectString(output.LocationUri),
     MountOptions:
       output.MountOptions !== undefined && output.MountOptions !== null
         ? deserializeAws_json1_1SmbMountOptions(output.MountOptions, context)
         : undefined,
-    User: output.User !== undefined && output.User !== null ? output.User : undefined,
+    User: __expectString(output.User),
   } as any;
 };
 
@@ -3721,23 +3723,15 @@ const deserializeAws_json1_1DescribeTaskExecutionResponse = (
   context: __SerdeContext
 ): DescribeTaskExecutionResponse => {
   return {
-    BytesTransferred:
-      output.BytesTransferred !== undefined && output.BytesTransferred !== null ? output.BytesTransferred : undefined,
-    BytesWritten: output.BytesWritten !== undefined && output.BytesWritten !== null ? output.BytesWritten : undefined,
-    EstimatedBytesToTransfer:
-      output.EstimatedBytesToTransfer !== undefined && output.EstimatedBytesToTransfer !== null
-        ? output.EstimatedBytesToTransfer
-        : undefined,
-    EstimatedFilesToTransfer:
-      output.EstimatedFilesToTransfer !== undefined && output.EstimatedFilesToTransfer !== null
-        ? output.EstimatedFilesToTransfer
-        : undefined,
+    BytesTransferred: __expectNumber(output.BytesTransferred),
+    BytesWritten: __expectNumber(output.BytesWritten),
+    EstimatedBytesToTransfer: __expectNumber(output.EstimatedBytesToTransfer),
+    EstimatedFilesToTransfer: __expectNumber(output.EstimatedFilesToTransfer),
     Excludes:
       output.Excludes !== undefined && output.Excludes !== null
         ? deserializeAws_json1_1FilterList(output.Excludes, context)
         : undefined,
-    FilesTransferred:
-      output.FilesTransferred !== undefined && output.FilesTransferred !== null ? output.FilesTransferred : undefined,
+    FilesTransferred: __expectNumber(output.FilesTransferred),
     Includes:
       output.Includes !== undefined && output.Includes !== null
         ? deserializeAws_json1_1FilterList(output.Includes, context)
@@ -3754,41 +3748,31 @@ const deserializeAws_json1_1DescribeTaskExecutionResponse = (
       output.StartTime !== undefined && output.StartTime !== null
         ? new Date(Math.round(output.StartTime * 1000))
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    TaskExecutionArn:
-      output.TaskExecutionArn !== undefined && output.TaskExecutionArn !== null ? output.TaskExecutionArn : undefined,
+    Status: __expectString(output.Status),
+    TaskExecutionArn: __expectString(output.TaskExecutionArn),
   } as any;
 };
 
 const deserializeAws_json1_1DescribeTaskResponse = (output: any, context: __SerdeContext): DescribeTaskResponse => {
   return {
-    CloudWatchLogGroupArn:
-      output.CloudWatchLogGroupArn !== undefined && output.CloudWatchLogGroupArn !== null
-        ? output.CloudWatchLogGroupArn
-        : undefined,
+    CloudWatchLogGroupArn: __expectString(output.CloudWatchLogGroupArn),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    CurrentTaskExecutionArn:
-      output.CurrentTaskExecutionArn !== undefined && output.CurrentTaskExecutionArn !== null
-        ? output.CurrentTaskExecutionArn
-        : undefined,
-    DestinationLocationArn:
-      output.DestinationLocationArn !== undefined && output.DestinationLocationArn !== null
-        ? output.DestinationLocationArn
-        : undefined,
+    CurrentTaskExecutionArn: __expectString(output.CurrentTaskExecutionArn),
+    DestinationLocationArn: __expectString(output.DestinationLocationArn),
     DestinationNetworkInterfaceArns:
       output.DestinationNetworkInterfaceArns !== undefined && output.DestinationNetworkInterfaceArns !== null
         ? deserializeAws_json1_1DestinationNetworkInterfaceArns(output.DestinationNetworkInterfaceArns, context)
         : undefined,
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorDetail: output.ErrorDetail !== undefined && output.ErrorDetail !== null ? output.ErrorDetail : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorDetail: __expectString(output.ErrorDetail),
     Excludes:
       output.Excludes !== undefined && output.Excludes !== null
         ? deserializeAws_json1_1FilterList(output.Excludes, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     Options:
       output.Options !== undefined && output.Options !== null
         ? deserializeAws_json1_1Options(output.Options, context)
@@ -3797,16 +3781,13 @@ const deserializeAws_json1_1DescribeTaskResponse = (output: any, context: __Serd
       output.Schedule !== undefined && output.Schedule !== null
         ? deserializeAws_json1_1TaskSchedule(output.Schedule, context)
         : undefined,
-    SourceLocationArn:
-      output.SourceLocationArn !== undefined && output.SourceLocationArn !== null
-        ? output.SourceLocationArn
-        : undefined,
+    SourceLocationArn: __expectString(output.SourceLocationArn),
     SourceNetworkInterfaceArns:
       output.SourceNetworkInterfaceArns !== undefined && output.SourceNetworkInterfaceArns !== null
         ? deserializeAws_json1_1SourceNetworkInterfaceArns(output.SourceNetworkInterfaceArns, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    TaskArn: output.TaskArn !== undefined && output.TaskArn !== null ? output.TaskArn : undefined,
+    Status: __expectString(output.Status),
+    TaskArn: __expectString(output.TaskArn),
   } as any;
 };
 
@@ -3817,7 +3798,7 @@ const deserializeAws_json1_1DestinationNetworkInterfaceArns = (output: any, cont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3827,7 +3808,7 @@ const deserializeAws_json1_1Ec2Config = (output: any, context: __SerdeContext): 
       output.SecurityGroupArns !== undefined && output.SecurityGroupArns !== null
         ? deserializeAws_json1_1Ec2SecurityGroupArnList(output.SecurityGroupArns, context)
         : undefined,
-    SubnetArn: output.SubnetArn !== undefined && output.SubnetArn !== null ? output.SubnetArn : undefined,
+    SubnetArn: __expectString(output.SubnetArn),
   } as any;
 };
 
@@ -3838,7 +3819,7 @@ const deserializeAws_json1_1Ec2SecurityGroupArnList = (output: any, context: __S
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3855,15 +3836,15 @@ const deserializeAws_json1_1FilterList = (output: any, context: __SerdeContext):
 
 const deserializeAws_json1_1FilterRule = (output: any, context: __SerdeContext): FilterRule => {
   return {
-    FilterType: output.FilterType !== undefined && output.FilterType !== null ? output.FilterType : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    FilterType: __expectString(output.FilterType),
+    Value: __expectString(output.Value),
   } as any;
 };
 
 const deserializeAws_json1_1InternalException = (output: any, context: __SerdeContext): InternalException => {
   return {
-    errorCode: output.errorCode !== undefined && output.errorCode !== null ? output.errorCode : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    errorCode: __expectString(output.errorCode),
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3872,8 +3853,8 @@ const deserializeAws_json1_1InvalidRequestException = (
   context: __SerdeContext
 ): InvalidRequestException => {
   return {
-    errorCode: output.errorCode !== undefined && output.errorCode !== null ? output.errorCode : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    errorCode: __expectString(output.errorCode),
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3883,7 +3864,7 @@ const deserializeAws_json1_1ListAgentsResponse = (output: any, context: __SerdeC
       output.Agents !== undefined && output.Agents !== null
         ? deserializeAws_json1_1AgentList(output.Agents, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -3893,7 +3874,7 @@ const deserializeAws_json1_1ListLocationsResponse = (output: any, context: __Ser
       output.Locations !== undefined && output.Locations !== null
         ? deserializeAws_json1_1LocationList(output.Locations, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -3902,7 +3883,7 @@ const deserializeAws_json1_1ListTagsForResourceResponse = (
   context: __SerdeContext
 ): ListTagsForResourceResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_1OutputTagList(output.Tags, context)
@@ -3915,7 +3896,7 @@ const deserializeAws_json1_1ListTaskExecutionsResponse = (
   context: __SerdeContext
 ): ListTaskExecutionsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     TaskExecutions:
       output.TaskExecutions !== undefined && output.TaskExecutions !== null
         ? deserializeAws_json1_1TaskExecutionList(output.TaskExecutions, context)
@@ -3925,7 +3906,7 @@ const deserializeAws_json1_1ListTaskExecutionsResponse = (
 
 const deserializeAws_json1_1ListTasksResponse = (output: any, context: __SerdeContext): ListTasksResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Tasks:
       output.Tasks !== undefined && output.Tasks !== null
         ? deserializeAws_json1_1TaskList(output.Tasks, context)
@@ -3946,14 +3927,14 @@ const deserializeAws_json1_1LocationList = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_1LocationListEntry = (output: any, context: __SerdeContext): LocationListEntry => {
   return {
-    LocationArn: output.LocationArn !== undefined && output.LocationArn !== null ? output.LocationArn : undefined,
-    LocationUri: output.LocationUri !== undefined && output.LocationUri !== null ? output.LocationUri : undefined,
+    LocationArn: __expectString(output.LocationArn),
+    LocationUri: __expectString(output.LocationUri),
   } as any;
 };
 
 const deserializeAws_json1_1NfsMountOptions = (output: any, context: __SerdeContext): NfsMountOptions => {
   return {
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    Version: __expectString(output.Version),
   } as any;
 };
 
@@ -3968,30 +3949,20 @@ const deserializeAws_json1_1OnPremConfig = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_1Options = (output: any, context: __SerdeContext): Options => {
   return {
-    Atime: output.Atime !== undefined && output.Atime !== null ? output.Atime : undefined,
-    BytesPerSecond:
-      output.BytesPerSecond !== undefined && output.BytesPerSecond !== null ? output.BytesPerSecond : undefined,
-    Gid: output.Gid !== undefined && output.Gid !== null ? output.Gid : undefined,
-    LogLevel: output.LogLevel !== undefined && output.LogLevel !== null ? output.LogLevel : undefined,
-    Mtime: output.Mtime !== undefined && output.Mtime !== null ? output.Mtime : undefined,
-    OverwriteMode:
-      output.OverwriteMode !== undefined && output.OverwriteMode !== null ? output.OverwriteMode : undefined,
-    PosixPermissions:
-      output.PosixPermissions !== undefined && output.PosixPermissions !== null ? output.PosixPermissions : undefined,
-    PreserveDeletedFiles:
-      output.PreserveDeletedFiles !== undefined && output.PreserveDeletedFiles !== null
-        ? output.PreserveDeletedFiles
-        : undefined,
-    PreserveDevices:
-      output.PreserveDevices !== undefined && output.PreserveDevices !== null ? output.PreserveDevices : undefined,
-    SecurityDescriptorCopyFlags:
-      output.SecurityDescriptorCopyFlags !== undefined && output.SecurityDescriptorCopyFlags !== null
-        ? output.SecurityDescriptorCopyFlags
-        : undefined,
-    TaskQueueing: output.TaskQueueing !== undefined && output.TaskQueueing !== null ? output.TaskQueueing : undefined,
-    TransferMode: output.TransferMode !== undefined && output.TransferMode !== null ? output.TransferMode : undefined,
-    Uid: output.Uid !== undefined && output.Uid !== null ? output.Uid : undefined,
-    VerifyMode: output.VerifyMode !== undefined && output.VerifyMode !== null ? output.VerifyMode : undefined,
+    Atime: __expectString(output.Atime),
+    BytesPerSecond: __expectNumber(output.BytesPerSecond),
+    Gid: __expectString(output.Gid),
+    LogLevel: __expectString(output.LogLevel),
+    Mtime: __expectString(output.Mtime),
+    OverwriteMode: __expectString(output.OverwriteMode),
+    PosixPermissions: __expectString(output.PosixPermissions),
+    PreserveDeletedFiles: __expectString(output.PreserveDeletedFiles),
+    PreserveDevices: __expectString(output.PreserveDevices),
+    SecurityDescriptorCopyFlags: __expectString(output.SecurityDescriptorCopyFlags),
+    TaskQueueing: __expectString(output.TaskQueueing),
+    TransferMode: __expectString(output.TransferMode),
+    Uid: __expectString(output.Uid),
+    VerifyMode: __expectString(output.VerifyMode),
   } as any;
 };
 
@@ -4013,7 +3984,7 @@ const deserializeAws_json1_1PLSecurityGroupArnList = (output: any, context: __Se
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4024,16 +3995,13 @@ const deserializeAws_json1_1PLSubnetArnList = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1PrivateLinkConfig = (output: any, context: __SerdeContext): PrivateLinkConfig => {
   return {
-    PrivateLinkEndpoint:
-      output.PrivateLinkEndpoint !== undefined && output.PrivateLinkEndpoint !== null
-        ? output.PrivateLinkEndpoint
-        : undefined,
+    PrivateLinkEndpoint: __expectString(output.PrivateLinkEndpoint),
     SecurityGroupArns:
       output.SecurityGroupArns !== undefined && output.SecurityGroupArns !== null
         ? deserializeAws_json1_1PLSecurityGroupArnList(output.SecurityGroupArns, context)
@@ -4042,23 +4010,19 @@ const deserializeAws_json1_1PrivateLinkConfig = (output: any, context: __SerdeCo
       output.SubnetArns !== undefined && output.SubnetArns !== null
         ? deserializeAws_json1_1PLSubnetArnList(output.SubnetArns, context)
         : undefined,
-    VpcEndpointId:
-      output.VpcEndpointId !== undefined && output.VpcEndpointId !== null ? output.VpcEndpointId : undefined,
+    VpcEndpointId: __expectString(output.VpcEndpointId),
   } as any;
 };
 
 const deserializeAws_json1_1S3Config = (output: any, context: __SerdeContext): S3Config => {
   return {
-    BucketAccessRoleArn:
-      output.BucketAccessRoleArn !== undefined && output.BucketAccessRoleArn !== null
-        ? output.BucketAccessRoleArn
-        : undefined,
+    BucketAccessRoleArn: __expectString(output.BucketAccessRoleArn),
   } as any;
 };
 
 const deserializeAws_json1_1SmbMountOptions = (output: any, context: __SerdeContext): SmbMountOptions => {
   return {
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    Version: __expectString(output.Version),
   } as any;
 };
 
@@ -4069,7 +4033,7 @@ const deserializeAws_json1_1SourceNetworkInterfaceArns = (output: any, context: 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4078,15 +4042,14 @@ const deserializeAws_json1_1StartTaskExecutionResponse = (
   context: __SerdeContext
 ): StartTaskExecutionResponse => {
   return {
-    TaskExecutionArn:
-      output.TaskExecutionArn !== undefined && output.TaskExecutionArn !== null ? output.TaskExecutionArn : undefined,
+    TaskExecutionArn: __expectString(output.TaskExecutionArn),
   } as any;
 };
 
 const deserializeAws_json1_1TagListEntry = (output: any, context: __SerdeContext): TagListEntry => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -4107,9 +4070,8 @@ const deserializeAws_json1_1TaskExecutionList = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1TaskExecutionListEntry = (output: any, context: __SerdeContext): TaskExecutionListEntry => {
   return {
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    TaskExecutionArn:
-      output.TaskExecutionArn !== undefined && output.TaskExecutionArn !== null ? output.TaskExecutionArn : undefined,
+    Status: __expectString(output.Status),
+    TaskExecutionArn: __expectString(output.TaskExecutionArn),
   } as any;
 };
 
@@ -4118,21 +4080,15 @@ const deserializeAws_json1_1TaskExecutionResultDetail = (
   context: __SerdeContext
 ): TaskExecutionResultDetail => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorDetail: output.ErrorDetail !== undefined && output.ErrorDetail !== null ? output.ErrorDetail : undefined,
-    PrepareDuration:
-      output.PrepareDuration !== undefined && output.PrepareDuration !== null ? output.PrepareDuration : undefined,
-    PrepareStatus:
-      output.PrepareStatus !== undefined && output.PrepareStatus !== null ? output.PrepareStatus : undefined,
-    TotalDuration:
-      output.TotalDuration !== undefined && output.TotalDuration !== null ? output.TotalDuration : undefined,
-    TransferDuration:
-      output.TransferDuration !== undefined && output.TransferDuration !== null ? output.TransferDuration : undefined,
-    TransferStatus:
-      output.TransferStatus !== undefined && output.TransferStatus !== null ? output.TransferStatus : undefined,
-    VerifyDuration:
-      output.VerifyDuration !== undefined && output.VerifyDuration !== null ? output.VerifyDuration : undefined,
-    VerifyStatus: output.VerifyStatus !== undefined && output.VerifyStatus !== null ? output.VerifyStatus : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorDetail: __expectString(output.ErrorDetail),
+    PrepareDuration: __expectNumber(output.PrepareDuration),
+    PrepareStatus: __expectString(output.PrepareStatus),
+    TotalDuration: __expectNumber(output.TotalDuration),
+    TransferDuration: __expectNumber(output.TransferDuration),
+    TransferStatus: __expectString(output.TransferStatus),
+    VerifyDuration: __expectNumber(output.VerifyDuration),
+    VerifyStatus: __expectString(output.VerifyStatus),
   } as any;
 };
 
@@ -4149,18 +4105,15 @@ const deserializeAws_json1_1TaskList = (output: any, context: __SerdeContext): T
 
 const deserializeAws_json1_1TaskListEntry = (output: any, context: __SerdeContext): TaskListEntry => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    TaskArn: output.TaskArn !== undefined && output.TaskArn !== null ? output.TaskArn : undefined,
+    Name: __expectString(output.Name),
+    Status: __expectString(output.Status),
+    TaskArn: __expectString(output.TaskArn),
   } as any;
 };
 
 const deserializeAws_json1_1TaskSchedule = (output: any, context: __SerdeContext): TaskSchedule => {
   return {
-    ScheduleExpression:
-      output.ScheduleExpression !== undefined && output.ScheduleExpression !== null
-        ? output.ScheduleExpression
-        : undefined,
+    ScheduleExpression: __expectString(output.ScheduleExpression),
   } as any;
 };
 

--- a/clients/client-dax/protocols/Aws_json1_1.ts
+++ b/clients/client-dax/protocols/Aws_json1_1.ts
@@ -130,7 +130,11 @@ import {
   UpdateSubnetGroupResponse,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -3096,20 +3100,20 @@ const serializeAws_json1_1UpdateSubnetGroupRequest = (
 
 const deserializeAws_json1_1Cluster = (output: any, context: __SerdeContext): Cluster => {
   return {
-    ActiveNodes: output.ActiveNodes !== undefined && output.ActiveNodes !== null ? output.ActiveNodes : undefined,
-    ClusterArn: output.ClusterArn !== undefined && output.ClusterArn !== null ? output.ClusterArn : undefined,
+    ActiveNodes: __expectNumber(output.ActiveNodes),
+    ClusterArn: __expectString(output.ClusterArn),
     ClusterDiscoveryEndpoint:
       output.ClusterDiscoveryEndpoint !== undefined && output.ClusterDiscoveryEndpoint !== null
         ? deserializeAws_json1_1Endpoint(output.ClusterDiscoveryEndpoint, context)
         : undefined,
-    ClusterName: output.ClusterName !== undefined && output.ClusterName !== null ? output.ClusterName : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    IamRoleArn: output.IamRoleArn !== undefined && output.IamRoleArn !== null ? output.IamRoleArn : undefined,
+    ClusterName: __expectString(output.ClusterName),
+    Description: __expectString(output.Description),
+    IamRoleArn: __expectString(output.IamRoleArn),
     NodeIdsToRemove:
       output.NodeIdsToRemove !== undefined && output.NodeIdsToRemove !== null
         ? deserializeAws_json1_1NodeIdentifierList(output.NodeIdsToRemove, context)
         : undefined,
-    NodeType: output.NodeType !== undefined && output.NodeType !== null ? output.NodeType : undefined,
+    NodeType: __expectString(output.NodeType),
     Nodes:
       output.Nodes !== undefined && output.Nodes !== null
         ? deserializeAws_json1_1NodeList(output.Nodes, context)
@@ -3122,10 +3126,7 @@ const deserializeAws_json1_1Cluster = (output: any, context: __SerdeContext): Cl
       output.ParameterGroup !== undefined && output.ParameterGroup !== null
         ? deserializeAws_json1_1ParameterGroupStatus(output.ParameterGroup, context)
         : undefined,
-    PreferredMaintenanceWindow:
-      output.PreferredMaintenanceWindow !== undefined && output.PreferredMaintenanceWindow !== null
-        ? output.PreferredMaintenanceWindow
-        : undefined,
+    PreferredMaintenanceWindow: __expectString(output.PreferredMaintenanceWindow),
     SSEDescription:
       output.SSEDescription !== undefined && output.SSEDescription !== null
         ? deserializeAws_json1_1SSEDescription(output.SSEDescription, context)
@@ -3134,9 +3135,9 @@ const deserializeAws_json1_1Cluster = (output: any, context: __SerdeContext): Cl
       output.SecurityGroups !== undefined && output.SecurityGroups !== null
         ? deserializeAws_json1_1SecurityGroupMembershipList(output.SecurityGroups, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    SubnetGroup: output.SubnetGroup !== undefined && output.SubnetGroup !== null ? output.SubnetGroup : undefined,
-    TotalNodes: output.TotalNodes !== undefined && output.TotalNodes !== null ? output.TotalNodes : undefined,
+    Status: __expectString(output.Status),
+    SubnetGroup: __expectString(output.SubnetGroup),
+    TotalNodes: __expectNumber(output.TotalNodes),
   } as any;
 };
 
@@ -3145,7 +3146,7 @@ const deserializeAws_json1_1ClusterAlreadyExistsFault = (
   context: __SerdeContext
 ): ClusterAlreadyExistsFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3162,7 +3163,7 @@ const deserializeAws_json1_1ClusterList = (output: any, context: __SerdeContext)
 
 const deserializeAws_json1_1ClusterNotFoundFault = (output: any, context: __SerdeContext): ClusterNotFoundFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3171,7 +3172,7 @@ const deserializeAws_json1_1ClusterQuotaForCustomerExceededFault = (
   context: __SerdeContext
 ): ClusterQuotaForCustomerExceededFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3234,8 +3235,7 @@ const deserializeAws_json1_1DeleteParameterGroupResponse = (
   context: __SerdeContext
 ): DeleteParameterGroupResponse => {
   return {
-    DeletionMessage:
-      output.DeletionMessage !== undefined && output.DeletionMessage !== null ? output.DeletionMessage : undefined,
+    DeletionMessage: __expectString(output.DeletionMessage),
   } as any;
 };
 
@@ -3244,8 +3244,7 @@ const deserializeAws_json1_1DeleteSubnetGroupResponse = (
   context: __SerdeContext
 ): DeleteSubnetGroupResponse => {
   return {
-    DeletionMessage:
-      output.DeletionMessage !== undefined && output.DeletionMessage !== null ? output.DeletionMessage : undefined,
+    DeletionMessage: __expectString(output.DeletionMessage),
   } as any;
 };
 
@@ -3258,7 +3257,7 @@ const deserializeAws_json1_1DescribeClustersResponse = (
       output.Clusters !== undefined && output.Clusters !== null
         ? deserializeAws_json1_1ClusterList(output.Clusters, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -3267,7 +3266,7 @@ const deserializeAws_json1_1DescribeDefaultParametersResponse = (
   context: __SerdeContext
 ): DescribeDefaultParametersResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Parameters:
       output.Parameters !== undefined && output.Parameters !== null
         ? deserializeAws_json1_1ParameterList(output.Parameters, context)
@@ -3281,7 +3280,7 @@ const deserializeAws_json1_1DescribeEventsResponse = (output: any, context: __Se
       output.Events !== undefined && output.Events !== null
         ? deserializeAws_json1_1EventList(output.Events, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -3290,7 +3289,7 @@ const deserializeAws_json1_1DescribeParameterGroupsResponse = (
   context: __SerdeContext
 ): DescribeParameterGroupsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     ParameterGroups:
       output.ParameterGroups !== undefined && output.ParameterGroups !== null
         ? deserializeAws_json1_1ParameterGroupList(output.ParameterGroups, context)
@@ -3303,7 +3302,7 @@ const deserializeAws_json1_1DescribeParametersResponse = (
   context: __SerdeContext
 ): DescribeParametersResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Parameters:
       output.Parameters !== undefined && output.Parameters !== null
         ? deserializeAws_json1_1ParameterList(output.Parameters, context)
@@ -3316,7 +3315,7 @@ const deserializeAws_json1_1DescribeSubnetGroupsResponse = (
   context: __SerdeContext
 ): DescribeSubnetGroupsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     SubnetGroups:
       output.SubnetGroups !== undefined && output.SubnetGroups !== null
         ? deserializeAws_json1_1SubnetGroupList(output.SubnetGroups, context)
@@ -3326,17 +3325,17 @@ const deserializeAws_json1_1DescribeSubnetGroupsResponse = (
 
 const deserializeAws_json1_1Endpoint = (output: any, context: __SerdeContext): Endpoint => {
   return {
-    Address: output.Address !== undefined && output.Address !== null ? output.Address : undefined,
-    Port: output.Port !== undefined && output.Port !== null ? output.Port : undefined,
+    Address: __expectString(output.Address),
+    Port: __expectNumber(output.Port),
   } as any;
 };
 
 const deserializeAws_json1_1Event = (output: any, context: __SerdeContext): Event => {
   return {
     Date: output.Date !== undefined && output.Date !== null ? new Date(Math.round(output.Date * 1000)) : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    SourceName: output.SourceName !== undefined && output.SourceName !== null ? output.SourceName : undefined,
-    SourceType: output.SourceType !== undefined && output.SourceType !== null ? output.SourceType : undefined,
+    Message: __expectString(output.Message),
+    SourceName: __expectString(output.SourceName),
+    SourceType: __expectString(output.SourceType),
   } as any;
 };
 
@@ -3368,13 +3367,13 @@ const deserializeAws_json1_1InsufficientClusterCapacityFault = (
   context: __SerdeContext
 ): InsufficientClusterCapacityFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidARNFault = (output: any, context: __SerdeContext): InvalidARNFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3383,7 +3382,7 @@ const deserializeAws_json1_1InvalidClusterStateFault = (
   context: __SerdeContext
 ): InvalidClusterStateFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3392,7 +3391,7 @@ const deserializeAws_json1_1InvalidParameterCombinationException = (
   context: __SerdeContext
 ): InvalidParameterCombinationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3401,7 +3400,7 @@ const deserializeAws_json1_1InvalidParameterGroupStateFault = (
   context: __SerdeContext
 ): InvalidParameterGroupStateFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3410,13 +3409,13 @@ const deserializeAws_json1_1InvalidParameterValueException = (
   context: __SerdeContext
 ): InvalidParameterValueException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidSubnet = (output: any, context: __SerdeContext): InvalidSubnet => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3425,13 +3424,13 @@ const deserializeAws_json1_1InvalidVPCNetworkStateFault = (
   context: __SerdeContext
 ): InvalidVPCNetworkStateFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1ListTagsResponse = (output: any, context: __SerdeContext): ListTagsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_1TagList(output.Tags, context)
@@ -3441,8 +3440,7 @@ const deserializeAws_json1_1ListTagsResponse = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1Node = (output: any, context: __SerdeContext): Node => {
   return {
-    AvailabilityZone:
-      output.AvailabilityZone !== undefined && output.AvailabilityZone !== null ? output.AvailabilityZone : undefined,
+    AvailabilityZone: __expectString(output.AvailabilityZone),
     Endpoint:
       output.Endpoint !== undefined && output.Endpoint !== null
         ? deserializeAws_json1_1Endpoint(output.Endpoint, context)
@@ -3451,12 +3449,9 @@ const deserializeAws_json1_1Node = (output: any, context: __SerdeContext): Node 
       output.NodeCreateTime !== undefined && output.NodeCreateTime !== null
         ? new Date(Math.round(output.NodeCreateTime * 1000))
         : undefined,
-    NodeId: output.NodeId !== undefined && output.NodeId !== null ? output.NodeId : undefined,
-    NodeStatus: output.NodeStatus !== undefined && output.NodeStatus !== null ? output.NodeStatus : undefined,
-    ParameterGroupStatus:
-      output.ParameterGroupStatus !== undefined && output.ParameterGroupStatus !== null
-        ? output.ParameterGroupStatus
-        : undefined,
+    NodeId: __expectString(output.NodeId),
+    NodeStatus: __expectString(output.NodeStatus),
+    ParameterGroupStatus: __expectString(output.ParameterGroupStatus),
   } as any;
 };
 
@@ -3467,7 +3462,7 @@ const deserializeAws_json1_1NodeIdentifierList = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3484,7 +3479,7 @@ const deserializeAws_json1_1NodeList = (output: any, context: __SerdeContext): N
 
 const deserializeAws_json1_1NodeNotFoundFault = (output: any, context: __SerdeContext): NodeNotFoundFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3493,7 +3488,7 @@ const deserializeAws_json1_1NodeQuotaForClusterExceededFault = (
   context: __SerdeContext
 ): NodeQuotaForClusterExceededFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3502,14 +3497,14 @@ const deserializeAws_json1_1NodeQuotaForCustomerExceededFault = (
   context: __SerdeContext
 ): NodeQuotaForCustomerExceededFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1NodeTypeSpecificValue = (output: any, context: __SerdeContext): NodeTypeSpecificValue => {
   return {
-    NodeType: output.NodeType !== undefined && output.NodeType !== null ? output.NodeType : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    NodeType: __expectString(output.NodeType),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -3532,40 +3527,33 @@ const deserializeAws_json1_1NotificationConfiguration = (
   context: __SerdeContext
 ): NotificationConfiguration => {
   return {
-    TopicArn: output.TopicArn !== undefined && output.TopicArn !== null ? output.TopicArn : undefined,
-    TopicStatus: output.TopicStatus !== undefined && output.TopicStatus !== null ? output.TopicStatus : undefined,
+    TopicArn: __expectString(output.TopicArn),
+    TopicStatus: __expectString(output.TopicStatus),
   } as any;
 };
 
 const deserializeAws_json1_1Parameter = (output: any, context: __SerdeContext): Parameter => {
   return {
-    AllowedValues:
-      output.AllowedValues !== undefined && output.AllowedValues !== null ? output.AllowedValues : undefined,
-    ChangeType: output.ChangeType !== undefined && output.ChangeType !== null ? output.ChangeType : undefined,
-    DataType: output.DataType !== undefined && output.DataType !== null ? output.DataType : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    IsModifiable: output.IsModifiable !== undefined && output.IsModifiable !== null ? output.IsModifiable : undefined,
+    AllowedValues: __expectString(output.AllowedValues),
+    ChangeType: __expectString(output.ChangeType),
+    DataType: __expectString(output.DataType),
+    Description: __expectString(output.Description),
+    IsModifiable: __expectString(output.IsModifiable),
     NodeTypeSpecificValues:
       output.NodeTypeSpecificValues !== undefined && output.NodeTypeSpecificValues !== null
         ? deserializeAws_json1_1NodeTypeSpecificValueList(output.NodeTypeSpecificValues, context)
         : undefined,
-    ParameterName:
-      output.ParameterName !== undefined && output.ParameterName !== null ? output.ParameterName : undefined,
-    ParameterType:
-      output.ParameterType !== undefined && output.ParameterType !== null ? output.ParameterType : undefined,
-    ParameterValue:
-      output.ParameterValue !== undefined && output.ParameterValue !== null ? output.ParameterValue : undefined,
-    Source: output.Source !== undefined && output.Source !== null ? output.Source : undefined,
+    ParameterName: __expectString(output.ParameterName),
+    ParameterType: __expectString(output.ParameterType),
+    ParameterValue: __expectString(output.ParameterValue),
+    Source: __expectString(output.Source),
   } as any;
 };
 
 const deserializeAws_json1_1ParameterGroup = (output: any, context: __SerdeContext): ParameterGroup => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    ParameterGroupName:
-      output.ParameterGroupName !== undefined && output.ParameterGroupName !== null
-        ? output.ParameterGroupName
-        : undefined,
+    Description: __expectString(output.Description),
+    ParameterGroupName: __expectString(output.ParameterGroupName),
   } as any;
 };
 
@@ -3574,7 +3562,7 @@ const deserializeAws_json1_1ParameterGroupAlreadyExistsFault = (
   context: __SerdeContext
 ): ParameterGroupAlreadyExistsFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3594,7 +3582,7 @@ const deserializeAws_json1_1ParameterGroupNotFoundFault = (
   context: __SerdeContext
 ): ParameterGroupNotFoundFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3603,7 +3591,7 @@ const deserializeAws_json1_1ParameterGroupQuotaExceededFault = (
   context: __SerdeContext
 ): ParameterGroupQuotaExceededFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3613,14 +3601,8 @@ const deserializeAws_json1_1ParameterGroupStatus = (output: any, context: __Serd
       output.NodeIdsToReboot !== undefined && output.NodeIdsToReboot !== null
         ? deserializeAws_json1_1NodeIdentifierList(output.NodeIdsToReboot, context)
         : undefined,
-    ParameterApplyStatus:
-      output.ParameterApplyStatus !== undefined && output.ParameterApplyStatus !== null
-        ? output.ParameterApplyStatus
-        : undefined,
-    ParameterGroupName:
-      output.ParameterGroupName !== undefined && output.ParameterGroupName !== null
-        ? output.ParameterGroupName
-        : undefined,
+    ParameterApplyStatus: __expectString(output.ParameterApplyStatus),
+    ParameterGroupName: __expectString(output.ParameterGroupName),
   } as any;
 };
 
@@ -3649,11 +3631,8 @@ const deserializeAws_json1_1SecurityGroupMembership = (
   context: __SerdeContext
 ): SecurityGroupMembership => {
   return {
-    SecurityGroupIdentifier:
-      output.SecurityGroupIdentifier !== undefined && output.SecurityGroupIdentifier !== null
-        ? output.SecurityGroupIdentifier
-        : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    SecurityGroupIdentifier: __expectString(output.SecurityGroupIdentifier),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -3676,37 +3655,32 @@ const deserializeAws_json1_1ServiceLinkedRoleNotFoundFault = (
   context: __SerdeContext
 ): ServiceLinkedRoleNotFoundFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1SSEDescription = (output: any, context: __SerdeContext): SSEDescription => {
   return {
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
 const deserializeAws_json1_1Subnet = (output: any, context: __SerdeContext): Subnet => {
   return {
-    SubnetAvailabilityZone:
-      output.SubnetAvailabilityZone !== undefined && output.SubnetAvailabilityZone !== null
-        ? output.SubnetAvailabilityZone
-        : undefined,
-    SubnetIdentifier:
-      output.SubnetIdentifier !== undefined && output.SubnetIdentifier !== null ? output.SubnetIdentifier : undefined,
+    SubnetAvailabilityZone: __expectString(output.SubnetAvailabilityZone),
+    SubnetIdentifier: __expectString(output.SubnetIdentifier),
   } as any;
 };
 
 const deserializeAws_json1_1SubnetGroup = (output: any, context: __SerdeContext): SubnetGroup => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    SubnetGroupName:
-      output.SubnetGroupName !== undefined && output.SubnetGroupName !== null ? output.SubnetGroupName : undefined,
+    Description: __expectString(output.Description),
+    SubnetGroupName: __expectString(output.SubnetGroupName),
     Subnets:
       output.Subnets !== undefined && output.Subnets !== null
         ? deserializeAws_json1_1SubnetList(output.Subnets, context)
         : undefined,
-    VpcId: output.VpcId !== undefined && output.VpcId !== null ? output.VpcId : undefined,
+    VpcId: __expectString(output.VpcId),
   } as any;
 };
 
@@ -3715,13 +3689,13 @@ const deserializeAws_json1_1SubnetGroupAlreadyExistsFault = (
   context: __SerdeContext
 ): SubnetGroupAlreadyExistsFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1SubnetGroupInUseFault = (output: any, context: __SerdeContext): SubnetGroupInUseFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3741,7 +3715,7 @@ const deserializeAws_json1_1SubnetGroupNotFoundFault = (
   context: __SerdeContext
 ): SubnetGroupNotFoundFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3750,13 +3724,13 @@ const deserializeAws_json1_1SubnetGroupQuotaExceededFault = (
   context: __SerdeContext
 ): SubnetGroupQuotaExceededFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1SubnetInUse = (output: any, context: __SerdeContext): SubnetInUse => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3776,14 +3750,14 @@ const deserializeAws_json1_1SubnetQuotaExceededFault = (
   context: __SerdeContext
 ): SubnetQuotaExceededFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -3800,7 +3774,7 @@ const deserializeAws_json1_1TagList = (output: any, context: __SerdeContext): Ta
 
 const deserializeAws_json1_1TagNotFoundFault = (output: any, context: __SerdeContext): TagNotFoundFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3809,7 +3783,7 @@ const deserializeAws_json1_1TagQuotaPerResourceExceeded = (
   context: __SerdeContext
 ): TagQuotaPerResourceExceeded => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 

--- a/clients/client-detective/protocols/Aws_restJson1.ts
+++ b/clients/client-detective/protocols/Aws_restJson1.ts
@@ -36,6 +36,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -528,7 +530,7 @@ export const deserializeAws_restJson1CreateGraphCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.GraphArn !== undefined && data.GraphArn !== null) {
-    contents.GraphArn = data.GraphArn;
+    contents.GraphArn = __expectString(data.GraphArn);
   }
   return Promise.resolve(contents);
 };
@@ -986,7 +988,7 @@ export const deserializeAws_restJson1ListGraphsCommand = async (
     contents.GraphList = deserializeAws_restJson1GraphList(data.GraphList, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1053,7 +1055,7 @@ export const deserializeAws_restJson1ListInvitationsCommand = async (
     contents.Invitations = deserializeAws_restJson1MemberDetailList(data.Invitations, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1120,7 +1122,7 @@ export const deserializeAws_restJson1ListMembersCommand = async (
     contents.MemberDetails = deserializeAws_restJson1MemberDetailList(data.MemberDetails, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1553,7 +1555,7 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1570,7 +1572,7 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1587,7 +1589,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1604,7 +1606,7 @@ const deserializeAws_restJson1ServiceQuotaExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1621,7 +1623,7 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1674,13 +1676,13 @@ const deserializeAws_restJson1AccountIdList = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1Graph = (output: any, context: __SerdeContext): Graph => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null ? new Date(output.CreatedTime) : undefined,
   } as any;
@@ -1699,31 +1701,23 @@ const deserializeAws_restJson1GraphList = (output: any, context: __SerdeContext)
 
 const deserializeAws_restJson1MemberDetail = (output: any, context: __SerdeContext): MemberDetail => {
   return {
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
-    AdministratorId:
-      output.AdministratorId !== undefined && output.AdministratorId !== null ? output.AdministratorId : undefined,
-    DisabledReason:
-      output.DisabledReason !== undefined && output.DisabledReason !== null ? output.DisabledReason : undefined,
-    EmailAddress: output.EmailAddress !== undefined && output.EmailAddress !== null ? output.EmailAddress : undefined,
-    GraphArn: output.GraphArn !== undefined && output.GraphArn !== null ? output.GraphArn : undefined,
+    AccountId: __expectString(output.AccountId),
+    AdministratorId: __expectString(output.AdministratorId),
+    DisabledReason: __expectString(output.DisabledReason),
+    EmailAddress: __expectString(output.EmailAddress),
+    GraphArn: __expectString(output.GraphArn),
     InvitedTime:
       output.InvitedTime !== undefined && output.InvitedTime !== null ? new Date(output.InvitedTime) : undefined,
-    MasterId: output.MasterId !== undefined && output.MasterId !== null ? output.MasterId : undefined,
-    PercentOfGraphUtilization:
-      output.PercentOfGraphUtilization !== undefined && output.PercentOfGraphUtilization !== null
-        ? output.PercentOfGraphUtilization
-        : undefined,
+    MasterId: __expectString(output.MasterId),
+    PercentOfGraphUtilization: __expectNumber(output.PercentOfGraphUtilization),
     PercentOfGraphUtilizationUpdatedTime:
       output.PercentOfGraphUtilizationUpdatedTime !== undefined && output.PercentOfGraphUtilizationUpdatedTime !== null
         ? new Date(output.PercentOfGraphUtilizationUpdatedTime)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
     UpdatedTime:
       output.UpdatedTime !== undefined && output.UpdatedTime !== null ? new Date(output.UpdatedTime) : undefined,
-    VolumeUsageInBytes:
-      output.VolumeUsageInBytes !== undefined && output.VolumeUsageInBytes !== null
-        ? output.VolumeUsageInBytes
-        : undefined,
+    VolumeUsageInBytes: __expectNumber(output.VolumeUsageInBytes),
     VolumeUsageUpdatedTime:
       output.VolumeUsageUpdatedTime !== undefined && output.VolumeUsageUpdatedTime !== null
         ? new Date(output.VolumeUsageUpdatedTime)
@@ -1749,15 +1743,15 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1UnprocessedAccount = (output: any, context: __SerdeContext): UnprocessedAccount => {
   return {
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
-    Reason: output.Reason !== undefined && output.Reason !== null ? output.Reason : undefined,
+    AccountId: __expectString(output.AccountId),
+    Reason: __expectString(output.Reason),
   } as any;
 };
 

--- a/clients/client-device-farm/protocols/Aws_json1_1.ts
+++ b/clients/client-device-farm/protocols/Aws_json1_1.ts
@@ -391,7 +391,12 @@ import {
   VPCEConfiguration,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -8630,22 +8635,14 @@ const serializeAws_json1_1UpdateVPCEConfigurationRequest = (
 
 const deserializeAws_json1_1AccountSettings = (output: any, context: __SerdeContext): AccountSettings => {
   return {
-    awsAccountNumber:
-      output.awsAccountNumber !== undefined && output.awsAccountNumber !== null ? output.awsAccountNumber : undefined,
-    defaultJobTimeoutMinutes:
-      output.defaultJobTimeoutMinutes !== undefined && output.defaultJobTimeoutMinutes !== null
-        ? output.defaultJobTimeoutMinutes
-        : undefined,
-    maxJobTimeoutMinutes:
-      output.maxJobTimeoutMinutes !== undefined && output.maxJobTimeoutMinutes !== null
-        ? output.maxJobTimeoutMinutes
-        : undefined,
+    awsAccountNumber: __expectString(output.awsAccountNumber),
+    defaultJobTimeoutMinutes: __expectNumber(output.defaultJobTimeoutMinutes),
+    maxJobTimeoutMinutes: __expectNumber(output.maxJobTimeoutMinutes),
     maxSlots:
       output.maxSlots !== undefined && output.maxSlots !== null
         ? deserializeAws_json1_1MaxSlotMap(output.maxSlots, context)
         : undefined,
-    skipAppResign:
-      output.skipAppResign !== undefined && output.skipAppResign !== null ? output.skipAppResign : undefined,
+    skipAppResign: __expectBoolean(output.skipAppResign),
     trialMinutes:
       output.trialMinutes !== undefined && output.trialMinutes !== null
         ? deserializeAws_json1_1TrialMinutes(output.trialMinutes, context)
@@ -8668,23 +8665,23 @@ const deserializeAws_json1_1AndroidPaths = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1ArgumentException = (output: any, context: __SerdeContext): ArgumentException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1Artifact = (output: any, context: __SerdeContext): Artifact => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    extension: output.extension !== undefined && output.extension !== null ? output.extension : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
-    url: output.url !== undefined && output.url !== null ? output.url : undefined,
+    arn: __expectString(output.arn),
+    extension: __expectString(output.extension),
+    name: __expectString(output.name),
+    type: __expectString(output.type),
+    url: __expectString(output.url),
   } as any;
 };
 
@@ -8701,27 +8698,27 @@ const deserializeAws_json1_1Artifacts = (output: any, context: __SerdeContext): 
 
 const deserializeAws_json1_1CannotDeleteException = (output: any, context: __SerdeContext): CannotDeleteException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1Counters = (output: any, context: __SerdeContext): Counters => {
   return {
-    errored: output.errored !== undefined && output.errored !== null ? output.errored : undefined,
-    failed: output.failed !== undefined && output.failed !== null ? output.failed : undefined,
-    passed: output.passed !== undefined && output.passed !== null ? output.passed : undefined,
-    skipped: output.skipped !== undefined && output.skipped !== null ? output.skipped : undefined,
-    stopped: output.stopped !== undefined && output.stopped !== null ? output.stopped : undefined,
-    total: output.total !== undefined && output.total !== null ? output.total : undefined,
-    warned: output.warned !== undefined && output.warned !== null ? output.warned : undefined,
+    errored: __expectNumber(output.errored),
+    failed: __expectNumber(output.failed),
+    passed: __expectNumber(output.passed),
+    skipped: __expectNumber(output.skipped),
+    stopped: __expectNumber(output.stopped),
+    total: __expectNumber(output.total),
+    warned: __expectNumber(output.warned),
   } as any;
 };
 
 const deserializeAws_json1_1CPU = (output: any, context: __SerdeContext): CPU => {
   return {
-    architecture: output.architecture !== undefined && output.architecture !== null ? output.architecture : undefined,
-    clock: output.clock !== undefined && output.clock !== null ? output.clock : undefined,
-    frequency: output.frequency !== undefined && output.frequency !== null ? output.frequency : undefined,
+    architecture: __expectString(output.architecture),
+    clock: __expectNumber(output.clock),
+    frequency: __expectString(output.frequency),
   } as any;
 };
 
@@ -8798,7 +8795,7 @@ const deserializeAws_json1_1CreateTestGridUrlResult = (
   return {
     expires:
       output.expires !== undefined && output.expires !== null ? new Date(Math.round(output.expires * 1000)) : undefined,
-    url: output.url !== undefined && output.url !== null ? output.url : undefined,
+    url: __expectString(output.url),
   } as any;
 };
 
@@ -8893,35 +8890,29 @@ const deserializeAws_json1_1DeleteVPCEConfigurationResult = (
 
 const deserializeAws_json1_1Device = (output: any, context: __SerdeContext): Device => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    availability: output.availability !== undefined && output.availability !== null ? output.availability : undefined,
-    carrier: output.carrier !== undefined && output.carrier !== null ? output.carrier : undefined,
+    arn: __expectString(output.arn),
+    availability: __expectString(output.availability),
+    carrier: __expectString(output.carrier),
     cpu: output.cpu !== undefined && output.cpu !== null ? deserializeAws_json1_1CPU(output.cpu, context) : undefined,
-    fleetName: output.fleetName !== undefined && output.fleetName !== null ? output.fleetName : undefined,
-    fleetType: output.fleetType !== undefined && output.fleetType !== null ? output.fleetType : undefined,
-    formFactor: output.formFactor !== undefined && output.formFactor !== null ? output.formFactor : undefined,
-    heapSize: output.heapSize !== undefined && output.heapSize !== null ? output.heapSize : undefined,
-    image: output.image !== undefined && output.image !== null ? output.image : undefined,
+    fleetName: __expectString(output.fleetName),
+    fleetType: __expectString(output.fleetType),
+    formFactor: __expectString(output.formFactor),
+    heapSize: __expectNumber(output.heapSize),
+    image: __expectString(output.image),
     instances:
       output.instances !== undefined && output.instances !== null
         ? deserializeAws_json1_1DeviceInstances(output.instances, context)
         : undefined,
-    manufacturer: output.manufacturer !== undefined && output.manufacturer !== null ? output.manufacturer : undefined,
-    memory: output.memory !== undefined && output.memory !== null ? output.memory : undefined,
-    model: output.model !== undefined && output.model !== null ? output.model : undefined,
-    modelId: output.modelId !== undefined && output.modelId !== null ? output.modelId : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    os: output.os !== undefined && output.os !== null ? output.os : undefined,
-    platform: output.platform !== undefined && output.platform !== null ? output.platform : undefined,
-    radio: output.radio !== undefined && output.radio !== null ? output.radio : undefined,
-    remoteAccessEnabled:
-      output.remoteAccessEnabled !== undefined && output.remoteAccessEnabled !== null
-        ? output.remoteAccessEnabled
-        : undefined,
-    remoteDebugEnabled:
-      output.remoteDebugEnabled !== undefined && output.remoteDebugEnabled !== null
-        ? output.remoteDebugEnabled
-        : undefined,
+    manufacturer: __expectString(output.manufacturer),
+    memory: __expectNumber(output.memory),
+    model: __expectString(output.model),
+    modelId: __expectString(output.modelId),
+    name: __expectString(output.name),
+    os: __expectString(output.os),
+    platform: __expectString(output.platform),
+    radio: __expectString(output.radio),
+    remoteAccessEnabled: __expectBoolean(output.remoteAccessEnabled),
+    remoteDebugEnabled: __expectBoolean(output.remoteDebugEnabled),
     resolution:
       output.resolution !== undefined && output.resolution !== null
         ? deserializeAws_json1_1Resolution(output.resolution, context)
@@ -8931,8 +8922,8 @@ const deserializeAws_json1_1Device = (output: any, context: __SerdeContext): Dev
 
 const deserializeAws_json1_1DeviceFilter = (output: any, context: __SerdeContext): DeviceFilter => {
   return {
-    attribute: output.attribute !== undefined && output.attribute !== null ? output.attribute : undefined,
-    operator: output.operator !== undefined && output.operator !== null ? output.operator : undefined,
+    attribute: __expectString(output.attribute),
+    operator: __expectString(output.operator),
     values:
       output.values !== undefined && output.values !== null
         ? deserializeAws_json1_1DeviceFilterValues(output.values, context)
@@ -8958,7 +8949,7 @@ const deserializeAws_json1_1DeviceFilterValues = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -8969,14 +8960,14 @@ const deserializeAws_json1_1DeviceHostPaths = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1DeviceInstance = (output: any, context: __SerdeContext): DeviceInstance => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    deviceArn: output.deviceArn !== undefined && output.deviceArn !== null ? output.deviceArn : undefined,
+    arn: __expectString(output.arn),
+    deviceArn: __expectString(output.deviceArn),
     instanceProfile:
       output.instanceProfile !== undefined && output.instanceProfile !== null
         ? deserializeAws_json1_1InstanceProfile(output.instanceProfile, context)
@@ -8985,8 +8976,8 @@ const deserializeAws_json1_1DeviceInstance = (output: any, context: __SerdeConte
       output.labels !== undefined && output.labels !== null
         ? deserializeAws_json1_1InstanceLabels(output.labels, context)
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    udid: output.udid !== undefined && output.udid !== null ? output.udid : undefined,
+    status: __expectString(output.status),
+    udid: __expectString(output.udid),
   } as any;
 };
 
@@ -9003,23 +8994,23 @@ const deserializeAws_json1_1DeviceInstances = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_1DeviceMinutes = (output: any, context: __SerdeContext): DeviceMinutes => {
   return {
-    metered: output.metered !== undefined && output.metered !== null ? output.metered : undefined,
-    total: output.total !== undefined && output.total !== null ? output.total : undefined,
-    unmetered: output.unmetered !== undefined && output.unmetered !== null ? output.unmetered : undefined,
+    metered: __expectNumber(output.metered),
+    total: __expectNumber(output.total),
+    unmetered: __expectNumber(output.unmetered),
   } as any;
 };
 
 const deserializeAws_json1_1DevicePool = (output: any, context: __SerdeContext): DevicePool => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    maxDevices: output.maxDevices !== undefined && output.maxDevices !== null ? output.maxDevices : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    arn: __expectString(output.arn),
+    description: __expectString(output.description),
+    maxDevices: __expectNumber(output.maxDevices),
+    name: __expectString(output.name),
     rules:
       output.rules !== undefined && output.rules !== null
         ? deserializeAws_json1_1Rules(output.rules, context)
         : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -9028,7 +9019,7 @@ const deserializeAws_json1_1DevicePoolCompatibilityResult = (
   context: __SerdeContext
 ): DevicePoolCompatibilityResult => {
   return {
-    compatible: output.compatible !== undefined && output.compatible !== null ? output.compatible : undefined,
+    compatible: __expectBoolean(output.compatible),
     device:
       output.device !== undefined && output.device !== null
         ? deserializeAws_json1_1Device(output.device, context)
@@ -9082,11 +9073,8 @@ const deserializeAws_json1_1DeviceSelectionResult = (output: any, context: __Ser
       output.filters !== undefined && output.filters !== null
         ? deserializeAws_json1_1DeviceFilters(output.filters, context)
         : undefined,
-    matchedDevicesCount:
-      output.matchedDevicesCount !== undefined && output.matchedDevicesCount !== null
-        ? output.matchedDevicesCount
-        : undefined,
-    maxDevices: output.maxDevices !== undefined && output.maxDevices !== null ? output.maxDevices : undefined,
+    matchedDevicesCount: __expectNumber(output.matchedDevicesCount),
+    maxDevices: __expectNumber(output.maxDevices),
   } as any;
 };
 
@@ -9191,7 +9179,7 @@ const deserializeAws_json1_1GetOfferingStatusResult = (
       output.nextPeriod !== undefined && output.nextPeriod !== null
         ? deserializeAws_json1_1OfferingStatusMap(output.nextPeriod, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -9285,14 +9273,14 @@ const deserializeAws_json1_1GetVPCEConfigurationResult = (
 
 const deserializeAws_json1_1IdempotencyException = (output: any, context: __SerdeContext): IdempotencyException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1IncompatibilityMessage = (output: any, context: __SerdeContext): IncompatibilityMessage => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    message: __expectString(output.message),
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -9329,23 +9317,21 @@ const deserializeAws_json1_1InstanceLabels = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1InstanceProfile = (output: any, context: __SerdeContext): InstanceProfile => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    arn: __expectString(output.arn),
+    description: __expectString(output.description),
     excludeAppPackagesFromCleanup:
       output.excludeAppPackagesFromCleanup !== undefined && output.excludeAppPackagesFromCleanup !== null
         ? deserializeAws_json1_1PackageIds(output.excludeAppPackagesFromCleanup, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    packageCleanup:
-      output.packageCleanup !== undefined && output.packageCleanup !== null ? output.packageCleanup : undefined,
-    rebootAfterUse:
-      output.rebootAfterUse !== undefined && output.rebootAfterUse !== null ? output.rebootAfterUse : undefined,
+    name: __expectString(output.name),
+    packageCleanup: __expectBoolean(output.packageCleanup),
+    rebootAfterUse: __expectBoolean(output.rebootAfterUse),
   } as any;
 };
 
@@ -9365,7 +9351,7 @@ const deserializeAws_json1_1InternalServiceException = (
   context: __SerdeContext
 ): InternalServiceException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9374,7 +9360,7 @@ const deserializeAws_json1_1InvalidOperationException = (
   context: __SerdeContext
 ): InvalidOperationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9385,13 +9371,13 @@ const deserializeAws_json1_1IosPaths = (output: any, context: __SerdeContext): s
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1Job = (output: any, context: __SerdeContext): Job => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     counters:
       output.counters !== undefined && output.counters !== null
         ? deserializeAws_json1_1Counters(output.counters, context)
@@ -9406,19 +9392,18 @@ const deserializeAws_json1_1Job = (output: any, context: __SerdeContext): Job =>
       output.deviceMinutes !== undefined && output.deviceMinutes !== null
         ? deserializeAws_json1_1DeviceMinutes(output.deviceMinutes, context)
         : undefined,
-    instanceArn: output.instanceArn !== undefined && output.instanceArn !== null ? output.instanceArn : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    result: output.result !== undefined && output.result !== null ? output.result : undefined,
+    instanceArn: __expectString(output.instanceArn),
+    message: __expectString(output.message),
+    name: __expectString(output.name),
+    result: __expectString(output.result),
     started:
       output.started !== undefined && output.started !== null ? new Date(Math.round(output.started * 1000)) : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
     stopped:
       output.stopped !== undefined && output.stopped !== null ? new Date(Math.round(output.stopped * 1000)) : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
-    videoCapture: output.videoCapture !== undefined && output.videoCapture !== null ? output.videoCapture : undefined,
-    videoEndpoint:
-      output.videoEndpoint !== undefined && output.videoEndpoint !== null ? output.videoEndpoint : undefined,
+    type: __expectString(output.type),
+    videoCapture: __expectBoolean(output.videoCapture),
+    videoEndpoint: __expectString(output.videoEndpoint),
   } as any;
 };
 
@@ -9435,7 +9420,7 @@ const deserializeAws_json1_1Jobs = (output: any, context: __SerdeContext): Job[]
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9445,7 +9430,7 @@ const deserializeAws_json1_1ListArtifactsResult = (output: any, context: __Serde
       output.artifacts !== undefined && output.artifacts !== null
         ? deserializeAws_json1_1Artifacts(output.artifacts, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -9458,7 +9443,7 @@ const deserializeAws_json1_1ListDeviceInstancesResult = (
       output.deviceInstances !== undefined && output.deviceInstances !== null
         ? deserializeAws_json1_1DeviceInstances(output.deviceInstances, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -9468,7 +9453,7 @@ const deserializeAws_json1_1ListDevicePoolsResult = (output: any, context: __Ser
       output.devicePools !== undefined && output.devicePools !== null
         ? deserializeAws_json1_1DevicePools(output.devicePools, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -9478,7 +9463,7 @@ const deserializeAws_json1_1ListDevicesResult = (output: any, context: __SerdeCo
       output.devices !== undefined && output.devices !== null
         ? deserializeAws_json1_1Devices(output.devices, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -9491,7 +9476,7 @@ const deserializeAws_json1_1ListInstanceProfilesResult = (
       output.instanceProfiles !== undefined && output.instanceProfiles !== null
         ? deserializeAws_json1_1InstanceProfiles(output.instanceProfiles, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -9499,7 +9484,7 @@ const deserializeAws_json1_1ListJobsResult = (output: any, context: __SerdeConte
   return {
     jobs:
       output.jobs !== undefined && output.jobs !== null ? deserializeAws_json1_1Jobs(output.jobs, context) : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -9512,7 +9497,7 @@ const deserializeAws_json1_1ListNetworkProfilesResult = (
       output.networkProfiles !== undefined && output.networkProfiles !== null
         ? deserializeAws_json1_1NetworkProfiles(output.networkProfiles, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -9521,7 +9506,7 @@ const deserializeAws_json1_1ListOfferingPromotionsResult = (
   context: __SerdeContext
 ): ListOfferingPromotionsResult => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     offeringPromotions:
       output.offeringPromotions !== undefined && output.offeringPromotions !== null
         ? deserializeAws_json1_1OfferingPromotions(output.offeringPromotions, context)
@@ -9531,7 +9516,7 @@ const deserializeAws_json1_1ListOfferingPromotionsResult = (
 
 const deserializeAws_json1_1ListOfferingsResult = (output: any, context: __SerdeContext): ListOfferingsResult => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     offerings:
       output.offerings !== undefined && output.offerings !== null
         ? deserializeAws_json1_1Offerings(output.offerings, context)
@@ -9544,7 +9529,7 @@ const deserializeAws_json1_1ListOfferingTransactionsResult = (
   context: __SerdeContext
 ): ListOfferingTransactionsResult => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     offeringTransactions:
       output.offeringTransactions !== undefined && output.offeringTransactions !== null
         ? deserializeAws_json1_1OfferingTransactions(output.offeringTransactions, context)
@@ -9554,7 +9539,7 @@ const deserializeAws_json1_1ListOfferingTransactionsResult = (
 
 const deserializeAws_json1_1ListProjectsResult = (output: any, context: __SerdeContext): ListProjectsResult => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     projects:
       output.projects !== undefined && output.projects !== null
         ? deserializeAws_json1_1Projects(output.projects, context)
@@ -9567,7 +9552,7 @@ const deserializeAws_json1_1ListRemoteAccessSessionsResult = (
   context: __SerdeContext
 ): ListRemoteAccessSessionsResult => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     remoteAccessSessions:
       output.remoteAccessSessions !== undefined && output.remoteAccessSessions !== null
         ? deserializeAws_json1_1RemoteAccessSessions(output.remoteAccessSessions, context)
@@ -9577,7 +9562,7 @@ const deserializeAws_json1_1ListRemoteAccessSessionsResult = (
 
 const deserializeAws_json1_1ListRunsResult = (output: any, context: __SerdeContext): ListRunsResult => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     runs:
       output.runs !== undefined && output.runs !== null ? deserializeAws_json1_1Runs(output.runs, context) : undefined,
   } as any;
@@ -9585,7 +9570,7 @@ const deserializeAws_json1_1ListRunsResult = (output: any, context: __SerdeConte
 
 const deserializeAws_json1_1ListSamplesResult = (output: any, context: __SerdeContext): ListSamplesResult => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     samples:
       output.samples !== undefined && output.samples !== null
         ? deserializeAws_json1_1Samples(output.samples, context)
@@ -9595,7 +9580,7 @@ const deserializeAws_json1_1ListSamplesResult = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1ListSuitesResult = (output: any, context: __SerdeContext): ListSuitesResult => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     suites:
       output.suites !== undefined && output.suites !== null
         ? deserializeAws_json1_1Suites(output.suites, context)
@@ -9620,7 +9605,7 @@ const deserializeAws_json1_1ListTestGridProjectsResult = (
   context: __SerdeContext
 ): ListTestGridProjectsResult => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     testGridProjects:
       output.testGridProjects !== undefined && output.testGridProjects !== null
         ? deserializeAws_json1_1TestGridProjects(output.testGridProjects, context)
@@ -9637,7 +9622,7 @@ const deserializeAws_json1_1ListTestGridSessionActionsResult = (
       output.actions !== undefined && output.actions !== null
         ? deserializeAws_json1_1TestGridSessionActions(output.actions, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -9650,7 +9635,7 @@ const deserializeAws_json1_1ListTestGridSessionArtifactsResult = (
       output.artifacts !== undefined && output.artifacts !== null
         ? deserializeAws_json1_1TestGridSessionArtifacts(output.artifacts, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -9659,7 +9644,7 @@ const deserializeAws_json1_1ListTestGridSessionsResult = (
   context: __SerdeContext
 ): ListTestGridSessionsResult => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     testGridSessions:
       output.testGridSessions !== undefined && output.testGridSessions !== null
         ? deserializeAws_json1_1TestGridSessions(output.testGridSessions, context)
@@ -9669,7 +9654,7 @@ const deserializeAws_json1_1ListTestGridSessionsResult = (
 
 const deserializeAws_json1_1ListTestsResult = (output: any, context: __SerdeContext): ListTestsResult => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     tests:
       output.tests !== undefined && output.tests !== null
         ? deserializeAws_json1_1Tests(output.tests, context)
@@ -9682,7 +9667,7 @@ const deserializeAws_json1_1ListUniqueProblemsResult = (
   context: __SerdeContext
 ): ListUniqueProblemsResult => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     uniqueProblems:
       output.uniqueProblems !== undefined && output.uniqueProblems !== null
         ? deserializeAws_json1_1UniqueProblemsByExecutionResultMap(output.uniqueProblems, context)
@@ -9692,7 +9677,7 @@ const deserializeAws_json1_1ListUniqueProblemsResult = (
 
 const deserializeAws_json1_1ListUploadsResult = (output: any, context: __SerdeContext): ListUploadsResult => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     uploads:
       output.uploads !== undefined && output.uploads !== null
         ? deserializeAws_json1_1Uploads(output.uploads, context)
@@ -9705,7 +9690,7 @@ const deserializeAws_json1_1ListVPCEConfigurationsResult = (
   context: __SerdeContext
 ): ListVPCEConfigurationsResult => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     vpceConfigurations:
       output.vpceConfigurations !== undefined && output.vpceConfigurations !== null
         ? deserializeAws_json1_1VPCEConfigurations(output.vpceConfigurations, context)
@@ -9715,8 +9700,8 @@ const deserializeAws_json1_1ListVPCEConfigurationsResult = (
 
 const deserializeAws_json1_1Location = (output: any, context: __SerdeContext): Location => {
   return {
-    latitude: output.latitude !== undefined && output.latitude !== null ? output.latitude : undefined,
-    longitude: output.longitude !== undefined && output.longitude !== null ? output.longitude : undefined,
+    latitude: __expectNumber(output.latitude),
+    longitude: __expectNumber(output.longitude),
   } as any;
 };
 
@@ -9727,48 +9712,32 @@ const deserializeAws_json1_1MaxSlotMap = (output: any, context: __SerdeContext):
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectNumber(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_json1_1MonetaryAmount = (output: any, context: __SerdeContext): MonetaryAmount => {
   return {
-    amount: output.amount !== undefined && output.amount !== null ? output.amount : undefined,
-    currencyCode: output.currencyCode !== undefined && output.currencyCode !== null ? output.currencyCode : undefined,
+    amount: __expectNumber(output.amount),
+    currencyCode: __expectString(output.currencyCode),
   } as any;
 };
 
 const deserializeAws_json1_1NetworkProfile = (output: any, context: __SerdeContext): NetworkProfile => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    downlinkBandwidthBits:
-      output.downlinkBandwidthBits !== undefined && output.downlinkBandwidthBits !== null
-        ? output.downlinkBandwidthBits
-        : undefined,
-    downlinkDelayMs:
-      output.downlinkDelayMs !== undefined && output.downlinkDelayMs !== null ? output.downlinkDelayMs : undefined,
-    downlinkJitterMs:
-      output.downlinkJitterMs !== undefined && output.downlinkJitterMs !== null ? output.downlinkJitterMs : undefined,
-    downlinkLossPercent:
-      output.downlinkLossPercent !== undefined && output.downlinkLossPercent !== null
-        ? output.downlinkLossPercent
-        : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
-    uplinkBandwidthBits:
-      output.uplinkBandwidthBits !== undefined && output.uplinkBandwidthBits !== null
-        ? output.uplinkBandwidthBits
-        : undefined,
-    uplinkDelayMs:
-      output.uplinkDelayMs !== undefined && output.uplinkDelayMs !== null ? output.uplinkDelayMs : undefined,
-    uplinkJitterMs:
-      output.uplinkJitterMs !== undefined && output.uplinkJitterMs !== null ? output.uplinkJitterMs : undefined,
-    uplinkLossPercent:
-      output.uplinkLossPercent !== undefined && output.uplinkLossPercent !== null
-        ? output.uplinkLossPercent
-        : undefined,
+    arn: __expectString(output.arn),
+    description: __expectString(output.description),
+    downlinkBandwidthBits: __expectNumber(output.downlinkBandwidthBits),
+    downlinkDelayMs: __expectNumber(output.downlinkDelayMs),
+    downlinkJitterMs: __expectNumber(output.downlinkJitterMs),
+    downlinkLossPercent: __expectNumber(output.downlinkLossPercent),
+    name: __expectString(output.name),
+    type: __expectString(output.type),
+    uplinkBandwidthBits: __expectNumber(output.uplinkBandwidthBits),
+    uplinkDelayMs: __expectNumber(output.uplinkDelayMs),
+    uplinkJitterMs: __expectNumber(output.uplinkJitterMs),
+    uplinkLossPercent: __expectNumber(output.uplinkLossPercent),
   } as any;
 };
 
@@ -9785,33 +9754,33 @@ const deserializeAws_json1_1NetworkProfiles = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_1NotEligibleException = (output: any, context: __SerdeContext): NotEligibleException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1NotFoundException = (output: any, context: __SerdeContext): NotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1Offering = (output: any, context: __SerdeContext): Offering => {
   return {
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    platform: output.platform !== undefined && output.platform !== null ? output.platform : undefined,
+    description: __expectString(output.description),
+    id: __expectString(output.id),
+    platform: __expectString(output.platform),
     recurringCharges:
       output.recurringCharges !== undefined && output.recurringCharges !== null
         ? deserializeAws_json1_1RecurringCharges(output.recurringCharges, context)
         : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    type: __expectString(output.type),
   } as any;
 };
 
 const deserializeAws_json1_1OfferingPromotion = (output: any, context: __SerdeContext): OfferingPromotion => {
   return {
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    description: __expectString(output.description),
+    id: __expectString(output.id),
   } as any;
 };
 
@@ -9847,8 +9816,8 @@ const deserializeAws_json1_1OfferingStatus = (output: any, context: __SerdeConte
       output.offering !== undefined && output.offering !== null
         ? deserializeAws_json1_1Offering(output.offering, context)
         : undefined,
-    quantity: output.quantity !== undefined && output.quantity !== null ? output.quantity : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    quantity: __expectNumber(output.quantity),
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -9877,16 +9846,12 @@ const deserializeAws_json1_1OfferingTransaction = (output: any, context: __Serde
       output.createdOn !== undefined && output.createdOn !== null
         ? new Date(Math.round(output.createdOn * 1000))
         : undefined,
-    offeringPromotionId:
-      output.offeringPromotionId !== undefined && output.offeringPromotionId !== null
-        ? output.offeringPromotionId
-        : undefined,
+    offeringPromotionId: __expectString(output.offeringPromotionId),
     offeringStatus:
       output.offeringStatus !== undefined && output.offeringStatus !== null
         ? deserializeAws_json1_1OfferingStatus(output.offeringStatus, context)
         : undefined,
-    transactionId:
-      output.transactionId !== undefined && output.transactionId !== null ? output.transactionId : undefined,
+    transactionId: __expectString(output.transactionId),
   } as any;
 };
 
@@ -9908,7 +9873,7 @@ const deserializeAws_json1_1PackageIds = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -9922,8 +9887,8 @@ const deserializeAws_json1_1Problem = (output: any, context: __SerdeContext): Pr
       output.job !== undefined && output.job !== null
         ? deserializeAws_json1_1ProblemDetail(output.job, context)
         : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    result: output.result !== undefined && output.result !== null ? output.result : undefined,
+    message: __expectString(output.message),
+    result: __expectString(output.result),
     run:
       output.run !== undefined && output.run !== null
         ? deserializeAws_json1_1ProblemDetail(output.run, context)
@@ -9941,8 +9906,8 @@ const deserializeAws_json1_1Problem = (output: any, context: __SerdeContext): Pr
 
 const deserializeAws_json1_1ProblemDetail = (output: any, context: __SerdeContext): ProblemDetail => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    arn: __expectString(output.arn),
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -9959,14 +9924,11 @@ const deserializeAws_json1_1Problems = (output: any, context: __SerdeContext): P
 
 const deserializeAws_json1_1Project = (output: any, context: __SerdeContext): Project => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     created:
       output.created !== undefined && output.created !== null ? new Date(Math.round(output.created * 1000)) : undefined,
-    defaultJobTimeoutMinutes:
-      output.defaultJobTimeoutMinutes !== undefined && output.defaultJobTimeoutMinutes !== null
-        ? output.defaultJobTimeoutMinutes
-        : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    defaultJobTimeoutMinutes: __expectNumber(output.defaultJobTimeoutMinutes),
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -9989,7 +9951,7 @@ const deserializeAws_json1_1PurchasedDevicesMap = (output: any, context: __Serde
       }
       return {
         ...acc,
-        [key]: value,
+        [key]: __expectNumber(value) as any,
       };
     },
     {}
@@ -10007,10 +9969,10 @@ const deserializeAws_json1_1PurchaseOfferingResult = (output: any, context: __Se
 
 const deserializeAws_json1_1Radios = (output: any, context: __SerdeContext): Radios => {
   return {
-    bluetooth: output.bluetooth !== undefined && output.bluetooth !== null ? output.bluetooth : undefined,
-    gps: output.gps !== undefined && output.gps !== null ? output.gps : undefined,
-    nfc: output.nfc !== undefined && output.nfc !== null ? output.nfc : undefined,
-    wifi: output.wifi !== undefined && output.wifi !== null ? output.wifi : undefined,
+    bluetooth: __expectBoolean(output.bluetooth),
+    gps: __expectBoolean(output.gps),
+    nfc: __expectBoolean(output.nfc),
+    wifi: __expectBoolean(output.wifi),
   } as any;
 };
 
@@ -10020,7 +9982,7 @@ const deserializeAws_json1_1RecurringCharge = (output: any, context: __SerdeCont
       output.cost !== undefined && output.cost !== null
         ? deserializeAws_json1_1MonetaryAmount(output.cost, context)
         : undefined,
-    frequency: output.frequency !== undefined && output.frequency !== null ? output.frequency : undefined,
+    frequency: __expectString(output.frequency),
   } as any;
 };
 
@@ -10037,10 +9999,9 @@ const deserializeAws_json1_1RecurringCharges = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1RemoteAccessSession = (output: any, context: __SerdeContext): RemoteAccessSession => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    billingMethod:
-      output.billingMethod !== undefined && output.billingMethod !== null ? output.billingMethod : undefined,
-    clientId: output.clientId !== undefined && output.clientId !== null ? output.clientId : undefined,
+    arn: __expectString(output.arn),
+    billingMethod: __expectString(output.billingMethod),
+    clientId: __expectString(output.clientId),
     created:
       output.created !== undefined && output.created !== null ? new Date(Math.round(output.created * 1000)) : undefined,
     device:
@@ -10051,32 +10012,21 @@ const deserializeAws_json1_1RemoteAccessSession = (output: any, context: __Serde
       output.deviceMinutes !== undefined && output.deviceMinutes !== null
         ? deserializeAws_json1_1DeviceMinutes(output.deviceMinutes, context)
         : undefined,
-    deviceUdid: output.deviceUdid !== undefined && output.deviceUdid !== null ? output.deviceUdid : undefined,
-    endpoint: output.endpoint !== undefined && output.endpoint !== null ? output.endpoint : undefined,
-    hostAddress: output.hostAddress !== undefined && output.hostAddress !== null ? output.hostAddress : undefined,
-    instanceArn: output.instanceArn !== undefined && output.instanceArn !== null ? output.instanceArn : undefined,
-    interactionMode:
-      output.interactionMode !== undefined && output.interactionMode !== null ? output.interactionMode : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    remoteDebugEnabled:
-      output.remoteDebugEnabled !== undefined && output.remoteDebugEnabled !== null
-        ? output.remoteDebugEnabled
-        : undefined,
-    remoteRecordAppArn:
-      output.remoteRecordAppArn !== undefined && output.remoteRecordAppArn !== null
-        ? output.remoteRecordAppArn
-        : undefined,
-    remoteRecordEnabled:
-      output.remoteRecordEnabled !== undefined && output.remoteRecordEnabled !== null
-        ? output.remoteRecordEnabled
-        : undefined,
-    result: output.result !== undefined && output.result !== null ? output.result : undefined,
-    skipAppResign:
-      output.skipAppResign !== undefined && output.skipAppResign !== null ? output.skipAppResign : undefined,
+    deviceUdid: __expectString(output.deviceUdid),
+    endpoint: __expectString(output.endpoint),
+    hostAddress: __expectString(output.hostAddress),
+    instanceArn: __expectString(output.instanceArn),
+    interactionMode: __expectString(output.interactionMode),
+    message: __expectString(output.message),
+    name: __expectString(output.name),
+    remoteDebugEnabled: __expectBoolean(output.remoteDebugEnabled),
+    remoteRecordAppArn: __expectString(output.remoteRecordAppArn),
+    remoteRecordEnabled: __expectBoolean(output.remoteRecordEnabled),
+    result: __expectString(output.result),
+    skipAppResign: __expectBoolean(output.skipAppResign),
     started:
       output.started !== undefined && output.started !== null ? new Date(Math.round(output.started * 1000)) : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
     stopped:
       output.stopped !== undefined && output.stopped !== null ? new Date(Math.round(output.stopped * 1000)) : undefined,
   } as any;
@@ -10104,16 +10054,16 @@ const deserializeAws_json1_1RenewOfferingResult = (output: any, context: __Serde
 
 const deserializeAws_json1_1Resolution = (output: any, context: __SerdeContext): Resolution => {
   return {
-    height: output.height !== undefined && output.height !== null ? output.height : undefined,
-    width: output.width !== undefined && output.width !== null ? output.width : undefined,
+    height: __expectNumber(output.height),
+    width: __expectNumber(output.width),
   } as any;
 };
 
 const deserializeAws_json1_1Rule = (output: any, context: __SerdeContext): Rule => {
   return {
-    attribute: output.attribute !== undefined && output.attribute !== null ? output.attribute : undefined,
-    operator: output.operator !== undefined && output.operator !== null ? output.operator : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    attribute: __expectString(output.attribute),
+    operator: __expectString(output.operator),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -10130,12 +10080,10 @@ const deserializeAws_json1_1Rules = (output: any, context: __SerdeContext): Rule
 
 const deserializeAws_json1_1Run = (output: any, context: __SerdeContext): Run => {
   return {
-    appUpload: output.appUpload !== undefined && output.appUpload !== null ? output.appUpload : undefined,
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    billingMethod:
-      output.billingMethod !== undefined && output.billingMethod !== null ? output.billingMethod : undefined,
-    completedJobs:
-      output.completedJobs !== undefined && output.completedJobs !== null ? output.completedJobs : undefined,
+    appUpload: __expectString(output.appUpload),
+    arn: __expectString(output.arn),
+    billingMethod: __expectString(output.billingMethod),
+    completedJobs: __expectNumber(output.completedJobs),
     counters:
       output.counters !== undefined && output.counters !== null
         ? deserializeAws_json1_1Counters(output.counters, context)
@@ -10150,49 +10098,43 @@ const deserializeAws_json1_1Run = (output: any, context: __SerdeContext): Run =>
       output.deviceMinutes !== undefined && output.deviceMinutes !== null
         ? deserializeAws_json1_1DeviceMinutes(output.deviceMinutes, context)
         : undefined,
-    devicePoolArn:
-      output.devicePoolArn !== undefined && output.devicePoolArn !== null ? output.devicePoolArn : undefined,
+    devicePoolArn: __expectString(output.devicePoolArn),
     deviceSelectionResult:
       output.deviceSelectionResult !== undefined && output.deviceSelectionResult !== null
         ? deserializeAws_json1_1DeviceSelectionResult(output.deviceSelectionResult, context)
         : undefined,
-    eventCount: output.eventCount !== undefined && output.eventCount !== null ? output.eventCount : undefined,
-    jobTimeoutMinutes:
-      output.jobTimeoutMinutes !== undefined && output.jobTimeoutMinutes !== null
-        ? output.jobTimeoutMinutes
-        : undefined,
-    locale: output.locale !== undefined && output.locale !== null ? output.locale : undefined,
+    eventCount: __expectNumber(output.eventCount),
+    jobTimeoutMinutes: __expectNumber(output.jobTimeoutMinutes),
+    locale: __expectString(output.locale),
     location:
       output.location !== undefined && output.location !== null
         ? deserializeAws_json1_1Location(output.location, context)
         : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    message: __expectString(output.message),
+    name: __expectString(output.name),
     networkProfile:
       output.networkProfile !== undefined && output.networkProfile !== null
         ? deserializeAws_json1_1NetworkProfile(output.networkProfile, context)
         : undefined,
-    parsingResultUrl:
-      output.parsingResultUrl !== undefined && output.parsingResultUrl !== null ? output.parsingResultUrl : undefined,
-    platform: output.platform !== undefined && output.platform !== null ? output.platform : undefined,
+    parsingResultUrl: __expectString(output.parsingResultUrl),
+    platform: __expectString(output.platform),
     radios:
       output.radios !== undefined && output.radios !== null
         ? deserializeAws_json1_1Radios(output.radios, context)
         : undefined,
-    result: output.result !== undefined && output.result !== null ? output.result : undefined,
-    resultCode: output.resultCode !== undefined && output.resultCode !== null ? output.resultCode : undefined,
-    seed: output.seed !== undefined && output.seed !== null ? output.seed : undefined,
-    skipAppResign:
-      output.skipAppResign !== undefined && output.skipAppResign !== null ? output.skipAppResign : undefined,
+    result: __expectString(output.result),
+    resultCode: __expectString(output.resultCode),
+    seed: __expectNumber(output.seed),
+    skipAppResign: __expectBoolean(output.skipAppResign),
     started:
       output.started !== undefined && output.started !== null ? new Date(Math.round(output.started * 1000)) : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
     stopped:
       output.stopped !== undefined && output.stopped !== null ? new Date(Math.round(output.stopped * 1000)) : undefined,
-    testSpecArn: output.testSpecArn !== undefined && output.testSpecArn !== null ? output.testSpecArn : undefined,
-    totalJobs: output.totalJobs !== undefined && output.totalJobs !== null ? output.totalJobs : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
-    webUrl: output.webUrl !== undefined && output.webUrl !== null ? output.webUrl : undefined,
+    testSpecArn: __expectString(output.testSpecArn),
+    totalJobs: __expectNumber(output.totalJobs),
+    type: __expectString(output.type),
+    webUrl: __expectString(output.webUrl),
   } as any;
 };
 
@@ -10209,9 +10151,9 @@ const deserializeAws_json1_1Runs = (output: any, context: __SerdeContext): Run[]
 
 const deserializeAws_json1_1Sample = (output: any, context: __SerdeContext): Sample => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
-    url: output.url !== undefined && output.url !== null ? output.url : undefined,
+    arn: __expectString(output.arn),
+    type: __expectString(output.type),
+    url: __expectString(output.url),
   } as any;
 };
 
@@ -10239,7 +10181,7 @@ const deserializeAws_json1_1SecurityGroupIds = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -10248,7 +10190,7 @@ const deserializeAws_json1_1ServiceAccountException = (
   context: __SerdeContext
 ): ServiceAccountException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10283,13 +10225,13 @@ const deserializeAws_json1_1SubnetIds = (output: any, context: __SerdeContext): 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1Suite = (output: any, context: __SerdeContext): Suite => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     counters:
       output.counters !== undefined && output.counters !== null
         ? deserializeAws_json1_1Counters(output.counters, context)
@@ -10300,15 +10242,15 @@ const deserializeAws_json1_1Suite = (output: any, context: __SerdeContext): Suit
       output.deviceMinutes !== undefined && output.deviceMinutes !== null
         ? deserializeAws_json1_1DeviceMinutes(output.deviceMinutes, context)
         : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    result: output.result !== undefined && output.result !== null ? output.result : undefined,
+    message: __expectString(output.message),
+    name: __expectString(output.name),
+    result: __expectString(output.result),
     started:
       output.started !== undefined && output.started !== null ? new Date(Math.round(output.started * 1000)) : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
     stopped:
       output.stopped !== undefined && output.stopped !== null ? new Date(Math.round(output.stopped * 1000)) : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -10325,8 +10267,8 @@ const deserializeAws_json1_1Suites = (output: any, context: __SerdeContext): Sui
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -10343,15 +10285,15 @@ const deserializeAws_json1_1TagList = (output: any, context: __SerdeContext): Ta
 
 const deserializeAws_json1_1TagOperationException = (output: any, context: __SerdeContext): TagOperationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    resourceName: output.resourceName !== undefined && output.resourceName !== null ? output.resourceName : undefined,
+    message: __expectString(output.message),
+    resourceName: __expectString(output.resourceName),
   } as any;
 };
 
 const deserializeAws_json1_1TagPolicyException = (output: any, context: __SerdeContext): TagPolicyException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    resourceName: output.resourceName !== undefined && output.resourceName !== null ? output.resourceName : undefined,
+    message: __expectString(output.message),
+    resourceName: __expectString(output.resourceName),
   } as any;
 };
 
@@ -10361,7 +10303,7 @@ const deserializeAws_json1_1TagResourceResponse = (output: any, context: __Serde
 
 const deserializeAws_json1_1Test = (output: any, context: __SerdeContext): Test => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     counters:
       output.counters !== undefined && output.counters !== null
         ? deserializeAws_json1_1Counters(output.counters, context)
@@ -10372,25 +10314,25 @@ const deserializeAws_json1_1Test = (output: any, context: __SerdeContext): Test 
       output.deviceMinutes !== undefined && output.deviceMinutes !== null
         ? deserializeAws_json1_1DeviceMinutes(output.deviceMinutes, context)
         : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    result: output.result !== undefined && output.result !== null ? output.result : undefined,
+    message: __expectString(output.message),
+    name: __expectString(output.name),
+    result: __expectString(output.result),
     started:
       output.started !== undefined && output.started !== null ? new Date(Math.round(output.started * 1000)) : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
     stopped:
       output.stopped !== undefined && output.stopped !== null ? new Date(Math.round(output.stopped * 1000)) : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    type: __expectString(output.type),
   } as any;
 };
 
 const deserializeAws_json1_1TestGridProject = (output: any, context: __SerdeContext): TestGridProject => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     created:
       output.created !== undefined && output.created !== null ? new Date(Math.round(output.created * 1000)) : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    description: __expectString(output.description),
+    name: __expectString(output.name),
     vpcConfig:
       output.vpcConfig !== undefined && output.vpcConfig !== null
         ? deserializeAws_json1_1TestGridVpcConfig(output.vpcConfig, context)
@@ -10411,29 +10353,24 @@ const deserializeAws_json1_1TestGridProjects = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1TestGridSession = (output: any, context: __SerdeContext): TestGridSession => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    billingMinutes:
-      output.billingMinutes !== undefined && output.billingMinutes !== null ? output.billingMinutes : undefined,
+    arn: __expectString(output.arn),
+    billingMinutes: __expectNumber(output.billingMinutes),
     created:
       output.created !== undefined && output.created !== null ? new Date(Math.round(output.created * 1000)) : undefined,
     ended: output.ended !== undefined && output.ended !== null ? new Date(Math.round(output.ended * 1000)) : undefined,
-    seleniumProperties:
-      output.seleniumProperties !== undefined && output.seleniumProperties !== null
-        ? output.seleniumProperties
-        : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    seleniumProperties: __expectString(output.seleniumProperties),
+    status: __expectString(output.status),
   } as any;
 };
 
 const deserializeAws_json1_1TestGridSessionAction = (output: any, context: __SerdeContext): TestGridSessionAction => {
   return {
-    action: output.action !== undefined && output.action !== null ? output.action : undefined,
-    duration: output.duration !== undefined && output.duration !== null ? output.duration : undefined,
-    requestMethod:
-      output.requestMethod !== undefined && output.requestMethod !== null ? output.requestMethod : undefined,
+    action: __expectString(output.action),
+    duration: __expectNumber(output.duration),
+    requestMethod: __expectString(output.requestMethod),
     started:
       output.started !== undefined && output.started !== null ? new Date(Math.round(output.started * 1000)) : undefined,
-    statusCode: output.statusCode !== undefined && output.statusCode !== null ? output.statusCode : undefined,
+    statusCode: __expectString(output.statusCode),
   } as any;
 };
 
@@ -10456,9 +10393,9 @@ const deserializeAws_json1_1TestGridSessionArtifact = (
   context: __SerdeContext
 ): TestGridSessionArtifact => {
   return {
-    filename: output.filename !== undefined && output.filename !== null ? output.filename : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
-    url: output.url !== undefined && output.url !== null ? output.url : undefined,
+    filename: __expectString(output.filename),
+    type: __expectString(output.type),
+    url: __expectString(output.url),
   } as any;
 };
 
@@ -10497,7 +10434,7 @@ const deserializeAws_json1_1TestGridVpcConfig = (output: any, context: __SerdeCo
       output.subnetIds !== undefined && output.subnetIds !== null
         ? deserializeAws_json1_1SubnetIds(output.subnetIds, context)
         : undefined,
-    vpcId: output.vpcId !== undefined && output.vpcId !== null ? output.vpcId : undefined,
+    vpcId: __expectString(output.vpcId),
   } as any;
 };
 
@@ -10514,21 +10451,21 @@ const deserializeAws_json1_1Tests = (output: any, context: __SerdeContext): Test
 
 const deserializeAws_json1_1TooManyTagsException = (output: any, context: __SerdeContext): TooManyTagsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    resourceName: output.resourceName !== undefined && output.resourceName !== null ? output.resourceName : undefined,
+    message: __expectString(output.message),
+    resourceName: __expectString(output.resourceName),
   } as any;
 };
 
 const deserializeAws_json1_1TrialMinutes = (output: any, context: __SerdeContext): TrialMinutes => {
   return {
-    remaining: output.remaining !== undefined && output.remaining !== null ? output.remaining : undefined,
-    total: output.total !== undefined && output.total !== null ? output.total : undefined,
+    remaining: __expectNumber(output.remaining),
+    total: __expectNumber(output.total),
   } as any;
 };
 
 const deserializeAws_json1_1UniqueProblem = (output: any, context: __SerdeContext): UniqueProblem => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
     problems:
       output.problems !== undefined && output.problems !== null
         ? deserializeAws_json1_1Problems(output.problems, context)
@@ -10658,17 +10595,17 @@ const deserializeAws_json1_1UpdateVPCEConfigurationResult = (
 
 const deserializeAws_json1_1Upload = (output: any, context: __SerdeContext): Upload => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    category: output.category !== undefined && output.category !== null ? output.category : undefined,
-    contentType: output.contentType !== undefined && output.contentType !== null ? output.contentType : undefined,
+    arn: __expectString(output.arn),
+    category: __expectString(output.category),
+    contentType: __expectString(output.contentType),
     created:
       output.created !== undefined && output.created !== null ? new Date(Math.round(output.created * 1000)) : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    metadata: output.metadata !== undefined && output.metadata !== null ? output.metadata : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
-    url: output.url !== undefined && output.url !== null ? output.url : undefined,
+    message: __expectString(output.message),
+    metadata: __expectString(output.metadata),
+    name: __expectString(output.name),
+    status: __expectString(output.status),
+    type: __expectString(output.type),
+    url: __expectString(output.url),
   } as any;
 };
 
@@ -10685,19 +10622,11 @@ const deserializeAws_json1_1Uploads = (output: any, context: __SerdeContext): Up
 
 const deserializeAws_json1_1VPCEConfiguration = (output: any, context: __SerdeContext): VPCEConfiguration => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    serviceDnsName:
-      output.serviceDnsName !== undefined && output.serviceDnsName !== null ? output.serviceDnsName : undefined,
-    vpceConfigurationDescription:
-      output.vpceConfigurationDescription !== undefined && output.vpceConfigurationDescription !== null
-        ? output.vpceConfigurationDescription
-        : undefined,
-    vpceConfigurationName:
-      output.vpceConfigurationName !== undefined && output.vpceConfigurationName !== null
-        ? output.vpceConfigurationName
-        : undefined,
-    vpceServiceName:
-      output.vpceServiceName !== undefined && output.vpceServiceName !== null ? output.vpceServiceName : undefined,
+    arn: __expectString(output.arn),
+    serviceDnsName: __expectString(output.serviceDnsName),
+    vpceConfigurationDescription: __expectString(output.vpceConfigurationDescription),
+    vpceConfigurationName: __expectString(output.vpceConfigurationName),
+    vpceServiceName: __expectString(output.vpceServiceName),
   } as any;
 };
 

--- a/clients/client-devops-guru/protocols/Aws_restJson1.ts
+++ b/clients/client-devops-guru/protocols/Aws_restJson1.ts
@@ -129,6 +129,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -731,7 +733,7 @@ export const deserializeAws_restJson1AddNotificationChannelCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   return Promise.resolve(contents);
 };
@@ -837,16 +839,16 @@ export const deserializeAws_restJson1DescribeAccountHealthCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.MetricsAnalyzed !== undefined && data.MetricsAnalyzed !== null) {
-    contents.MetricsAnalyzed = data.MetricsAnalyzed;
+    contents.MetricsAnalyzed = __expectNumber(data.MetricsAnalyzed);
   }
   if (data.OpenProactiveInsights !== undefined && data.OpenProactiveInsights !== null) {
-    contents.OpenProactiveInsights = data.OpenProactiveInsights;
+    contents.OpenProactiveInsights = __expectNumber(data.OpenProactiveInsights);
   }
   if (data.OpenReactiveInsights !== undefined && data.OpenReactiveInsights !== null) {
-    contents.OpenReactiveInsights = data.OpenReactiveInsights;
+    contents.OpenReactiveInsights = __expectNumber(data.OpenReactiveInsights);
   }
   if (data.ResourceHours !== undefined && data.ResourceHours !== null) {
-    contents.ResourceHours = data.ResourceHours;
+    contents.ResourceHours = __expectNumber(data.ResourceHours);
   }
   return Promise.resolve(contents);
 };
@@ -927,13 +929,13 @@ export const deserializeAws_restJson1DescribeAccountOverviewCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.MeanTimeToRecoverInMilliseconds !== undefined && data.MeanTimeToRecoverInMilliseconds !== null) {
-    contents.MeanTimeToRecoverInMilliseconds = data.MeanTimeToRecoverInMilliseconds;
+    contents.MeanTimeToRecoverInMilliseconds = __expectNumber(data.MeanTimeToRecoverInMilliseconds);
   }
   if (data.ProactiveInsights !== undefined && data.ProactiveInsights !== null) {
-    contents.ProactiveInsights = data.ProactiveInsights;
+    contents.ProactiveInsights = __expectNumber(data.ProactiveInsights);
   }
   if (data.ReactiveInsights !== undefined && data.ReactiveInsights !== null) {
-    contents.ReactiveInsights = data.ReactiveInsights;
+    contents.ReactiveInsights = __expectNumber(data.ReactiveInsights);
   }
   return Promise.resolve(contents);
 };
@@ -1286,7 +1288,7 @@ export const deserializeAws_restJson1DescribeResourceCollectionHealthCommand = a
     contents.CloudFormation = deserializeAws_restJson1CloudFormationHealths(data.CloudFormation, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Service !== undefined && data.Service !== null) {
     contents.Service = deserializeAws_restJson1ServiceHealths(data.Service, context);
@@ -1455,7 +1457,7 @@ export const deserializeAws_restJson1GetCostEstimationCommand = async (
     contents.Costs = deserializeAws_restJson1ServiceResourceCosts(data.Costs, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.ResourceCollection !== undefined && data.ResourceCollection !== null) {
     contents.ResourceCollection = deserializeAws_restJson1CostEstimationResourceCollectionFilter(
@@ -1464,13 +1466,13 @@ export const deserializeAws_restJson1GetCostEstimationCommand = async (
     );
   }
   if (data.Status !== undefined && data.Status !== null) {
-    contents.Status = data.Status;
+    contents.Status = __expectString(data.Status);
   }
   if (data.TimeRange !== undefined && data.TimeRange !== null) {
     contents.TimeRange = deserializeAws_restJson1CostEstimationTimeRange(data.TimeRange, context);
   }
   if (data.TotalCost !== undefined && data.TotalCost !== null) {
-    contents.TotalCost = data.TotalCost;
+    contents.TotalCost = __expectNumber(data.TotalCost);
   }
   return Promise.resolve(contents);
 };
@@ -1558,7 +1560,7 @@ export const deserializeAws_restJson1GetResourceCollectionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.ResourceCollection !== undefined && data.ResourceCollection !== null) {
     contents.ResourceCollection = deserializeAws_restJson1ResourceCollectionFilter(data.ResourceCollection, context);
@@ -1650,7 +1652,7 @@ export const deserializeAws_restJson1ListAnomaliesForInsightCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.ProactiveAnomalies !== undefined && data.ProactiveAnomalies !== null) {
     contents.ProactiveAnomalies = deserializeAws_restJson1ProactiveAnomalies(data.ProactiveAnomalies, context);
@@ -1747,7 +1749,7 @@ export const deserializeAws_restJson1ListEventsCommand = async (
     contents.Events = deserializeAws_restJson1Events(data.Events, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1836,7 +1838,7 @@ export const deserializeAws_restJson1ListInsightsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.ProactiveInsights !== undefined && data.ProactiveInsights !== null) {
     contents.ProactiveInsights = deserializeAws_restJson1ProactiveInsights(data.ProactiveInsights, context);
@@ -1925,7 +1927,7 @@ export const deserializeAws_restJson1ListNotificationChannelsCommand = async (
     contents.Channels = deserializeAws_restJson1Channels(data.Channels, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2005,7 +2007,7 @@ export const deserializeAws_restJson1ListRecommendationsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Recommendations !== undefined && data.Recommendations !== null) {
     contents.Recommendations = deserializeAws_restJson1Recommendations(data.Recommendations, context);
@@ -2279,7 +2281,7 @@ export const deserializeAws_restJson1SearchInsightsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.ProactiveInsights !== undefined && data.ProactiveInsights !== null) {
     contents.ProactiveInsights = deserializeAws_restJson1ProactiveInsights(data.ProactiveInsights, context);
@@ -2620,7 +2622,7 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -2639,13 +2641,13 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.ResourceId !== undefined && data.ResourceId !== null) {
-    contents.ResourceId = data.ResourceId;
+    contents.ResourceId = __expectString(data.ResourceId);
   }
   if (data.ResourceType !== undefined && data.ResourceType !== null) {
-    contents.ResourceType = data.ResourceType;
+    contents.ResourceType = __expectString(data.ResourceType);
   }
   return contents;
 };
@@ -2666,7 +2668,7 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   }
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -2685,13 +2687,13 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.ResourceId !== undefined && data.ResourceId !== null) {
-    contents.ResourceId = data.ResourceId;
+    contents.ResourceId = __expectString(data.ResourceId);
   }
   if (data.ResourceType !== undefined && data.ResourceType !== null) {
-    contents.ResourceType = data.ResourceType;
+    contents.ResourceType = __expectString(data.ResourceType);
   }
   return contents;
 };
@@ -2708,7 +2710,7 @@ const deserializeAws_restJson1ServiceQuotaExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -2731,13 +2733,13 @@ const deserializeAws_restJson1ThrottlingExceptionResponse = async (
   }
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.QuotaCode !== undefined && data.QuotaCode !== null) {
-    contents.QuotaCode = data.QuotaCode;
+    contents.QuotaCode = __expectString(data.QuotaCode);
   }
   if (data.ServiceCode !== undefined && data.ServiceCode !== null) {
-    contents.ServiceCode = data.ServiceCode;
+    contents.ServiceCode = __expectString(data.ServiceCode);
   }
   return contents;
 };
@@ -2759,10 +2761,10 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
     contents.Fields = deserializeAws_restJson1ValidationExceptionFields(data.Fields, context);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.Reason !== undefined && data.Reason !== null) {
-    contents.Reason = data.Reason;
+    contents.Reason = __expectString(data.Reason);
   }
   return contents;
 };
@@ -3132,7 +3134,7 @@ const deserializeAws_restJson1CloudFormationHealth = (output: any, context: __Se
       output.Insight !== undefined && output.Insight !== null
         ? deserializeAws_restJson1InsightHealth(output.Insight, context)
         : undefined,
-    StackName: output.StackName !== undefined && output.StackName !== null ? output.StackName : undefined,
+    StackName: __expectString(output.StackName),
   } as any;
 };
 
@@ -3159,11 +3161,11 @@ const deserializeAws_restJson1CloudWatchMetricsDetail = (
       output.Dimensions !== undefined && output.Dimensions !== null
         ? deserializeAws_restJson1CloudWatchMetricsDimensions(output.Dimensions, context)
         : undefined,
-    MetricName: output.MetricName !== undefined && output.MetricName !== null ? output.MetricName : undefined,
-    Namespace: output.Namespace !== undefined && output.Namespace !== null ? output.Namespace : undefined,
-    Period: output.Period !== undefined && output.Period !== null ? output.Period : undefined,
-    Stat: output.Stat !== undefined && output.Stat !== null ? output.Stat : undefined,
-    Unit: output.Unit !== undefined && output.Unit !== null ? output.Unit : undefined,
+    MetricName: __expectString(output.MetricName),
+    Namespace: __expectString(output.Namespace),
+    Period: __expectNumber(output.Period),
+    Stat: __expectString(output.Stat),
+    Unit: __expectString(output.Unit),
   } as any;
 };
 
@@ -3186,8 +3188,8 @@ const deserializeAws_restJson1CloudWatchMetricsDimension = (
   context: __SerdeContext
 ): CloudWatchMetricsDimension => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Name: __expectString(output.Name),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -3224,7 +3226,7 @@ const deserializeAws_restJson1CostEstimationStackNames = (output: any, context: 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3244,11 +3246,11 @@ const deserializeAws_restJson1CostEstimationTimeRange = (
 
 const deserializeAws_restJson1Event = (output: any, context: __SerdeContext): Event => {
   return {
-    DataSource: output.DataSource !== undefined && output.DataSource !== null ? output.DataSource : undefined,
-    EventClass: output.EventClass !== undefined && output.EventClass !== null ? output.EventClass : undefined,
-    EventSource: output.EventSource !== undefined && output.EventSource !== null ? output.EventSource : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    DataSource: __expectString(output.DataSource),
+    EventClass: __expectString(output.EventClass),
+    EventSource: __expectString(output.EventSource),
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
     ResourceCollection:
       output.ResourceCollection !== undefined && output.ResourceCollection !== null
         ? deserializeAws_restJson1ResourceCollection(output.ResourceCollection, context)
@@ -3263,9 +3265,9 @@ const deserializeAws_restJson1Event = (output: any, context: __SerdeContext): Ev
 
 const deserializeAws_restJson1EventResource = (output: any, context: __SerdeContext): EventResource => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Arn: __expectString(output.Arn),
+    Name: __expectString(output.Name),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -3293,25 +3295,16 @@ const deserializeAws_restJson1Events = (output: any, context: __SerdeContext): E
 
 const deserializeAws_restJson1InsightFeedback = (output: any, context: __SerdeContext): InsightFeedback => {
   return {
-    Feedback: output.Feedback !== undefined && output.Feedback !== null ? output.Feedback : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    Feedback: __expectString(output.Feedback),
+    Id: __expectString(output.Id),
   } as any;
 };
 
 const deserializeAws_restJson1InsightHealth = (output: any, context: __SerdeContext): InsightHealth => {
   return {
-    MeanTimeToRecoverInMilliseconds:
-      output.MeanTimeToRecoverInMilliseconds !== undefined && output.MeanTimeToRecoverInMilliseconds !== null
-        ? output.MeanTimeToRecoverInMilliseconds
-        : undefined,
-    OpenProactiveInsights:
-      output.OpenProactiveInsights !== undefined && output.OpenProactiveInsights !== null
-        ? output.OpenProactiveInsights
-        : undefined,
-    OpenReactiveInsights:
-      output.OpenReactiveInsights !== undefined && output.OpenReactiveInsights !== null
-        ? output.OpenReactiveInsights
-        : undefined,
+    MeanTimeToRecoverInMilliseconds: __expectNumber(output.MeanTimeToRecoverInMilliseconds),
+    OpenProactiveInsights: __expectNumber(output.OpenProactiveInsights),
+    OpenReactiveInsights: __expectNumber(output.OpenReactiveInsights),
   } as any;
 };
 
@@ -3332,7 +3325,7 @@ const deserializeAws_restJson1NotificationChannel = (output: any, context: __Ser
       output.Config !== undefined && output.Config !== null
         ? deserializeAws_restJson1NotificationChannelConfig(output.Config, context)
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    Id: __expectString(output.Id),
   } as any;
 };
 
@@ -3350,7 +3343,7 @@ const deserializeAws_restJson1NotificationChannelConfig = (
 
 const deserializeAws_restJson1OpsCenterIntegration = (output: any, context: __SerdeContext): OpsCenterIntegration => {
   return {
-    OptInStatus: output.OptInStatus !== undefined && output.OptInStatus !== null ? output.OptInStatus : undefined,
+    OptInStatus: __expectString(output.OptInStatus),
   } as any;
 };
 
@@ -3385,12 +3378,9 @@ const deserializeAws_restJson1ProactiveAnomaly = (output: any, context: __SerdeC
       output.AnomalyTimeRange !== undefined && output.AnomalyTimeRange !== null
         ? deserializeAws_restJson1AnomalyTimeRange(output.AnomalyTimeRange, context)
         : undefined,
-    AssociatedInsightId:
-      output.AssociatedInsightId !== undefined && output.AssociatedInsightId !== null
-        ? output.AssociatedInsightId
-        : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Limit: output.Limit !== undefined && output.Limit !== null ? output.Limit : undefined,
+    AssociatedInsightId: __expectString(output.AssociatedInsightId),
+    Id: __expectString(output.Id),
+    Limit: __expectNumber(output.Limit),
     PredictionTimeRange:
       output.PredictionTimeRange !== undefined && output.PredictionTimeRange !== null
         ? deserializeAws_restJson1PredictionTimeRange(output.PredictionTimeRange, context)
@@ -3399,12 +3389,12 @@ const deserializeAws_restJson1ProactiveAnomaly = (output: any, context: __SerdeC
       output.ResourceCollection !== undefined && output.ResourceCollection !== null
         ? deserializeAws_restJson1ResourceCollection(output.ResourceCollection, context)
         : undefined,
-    Severity: output.Severity !== undefined && output.Severity !== null ? output.Severity : undefined,
+    Severity: __expectString(output.Severity),
     SourceDetails:
       output.SourceDetails !== undefined && output.SourceDetails !== null
         ? deserializeAws_restJson1AnomalySourceDetails(output.SourceDetails, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
     UpdateTime:
       output.UpdateTime !== undefined && output.UpdateTime !== null
         ? new Date(Math.round(output.UpdateTime * 1000))
@@ -3421,12 +3411,9 @@ const deserializeAws_restJson1ProactiveAnomalySummary = (
       output.AnomalyTimeRange !== undefined && output.AnomalyTimeRange !== null
         ? deserializeAws_restJson1AnomalyTimeRange(output.AnomalyTimeRange, context)
         : undefined,
-    AssociatedInsightId:
-      output.AssociatedInsightId !== undefined && output.AssociatedInsightId !== null
-        ? output.AssociatedInsightId
-        : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Limit: output.Limit !== undefined && output.Limit !== null ? output.Limit : undefined,
+    AssociatedInsightId: __expectString(output.AssociatedInsightId),
+    Id: __expectString(output.Id),
+    Limit: __expectNumber(output.Limit),
     PredictionTimeRange:
       output.PredictionTimeRange !== undefined && output.PredictionTimeRange !== null
         ? deserializeAws_restJson1PredictionTimeRange(output.PredictionTimeRange, context)
@@ -3435,12 +3422,12 @@ const deserializeAws_restJson1ProactiveAnomalySummary = (
       output.ResourceCollection !== undefined && output.ResourceCollection !== null
         ? deserializeAws_restJson1ResourceCollection(output.ResourceCollection, context)
         : undefined,
-    Severity: output.Severity !== undefined && output.Severity !== null ? output.Severity : undefined,
+    Severity: __expectString(output.Severity),
     SourceDetails:
       output.SourceDetails !== undefined && output.SourceDetails !== null
         ? deserializeAws_restJson1AnomalySourceDetails(output.SourceDetails, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
     UpdateTime:
       output.UpdateTime !== undefined && output.UpdateTime !== null
         ? new Date(Math.round(output.UpdateTime * 1000))
@@ -3450,12 +3437,12 @@ const deserializeAws_restJson1ProactiveAnomalySummary = (
 
 const deserializeAws_restJson1ProactiveInsight = (output: any, context: __SerdeContext): ProactiveInsight => {
   return {
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    Id: __expectString(output.Id),
     InsightTimeRange:
       output.InsightTimeRange !== undefined && output.InsightTimeRange !== null
         ? deserializeAws_restJson1InsightTimeRange(output.InsightTimeRange, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     PredictionTimeRange:
       output.PredictionTimeRange !== undefined && output.PredictionTimeRange !== null
         ? deserializeAws_restJson1PredictionTimeRange(output.PredictionTimeRange, context)
@@ -3464,9 +3451,9 @@ const deserializeAws_restJson1ProactiveInsight = (output: any, context: __SerdeC
       output.ResourceCollection !== undefined && output.ResourceCollection !== null
         ? deserializeAws_restJson1ResourceCollection(output.ResourceCollection, context)
         : undefined,
-    Severity: output.Severity !== undefined && output.Severity !== null ? output.Severity : undefined,
-    SsmOpsItemId: output.SsmOpsItemId !== undefined && output.SsmOpsItemId !== null ? output.SsmOpsItemId : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Severity: __expectString(output.Severity),
+    SsmOpsItemId: __expectString(output.SsmOpsItemId),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -3486,12 +3473,12 @@ const deserializeAws_restJson1ProactiveInsightSummary = (
   context: __SerdeContext
 ): ProactiveInsightSummary => {
   return {
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    Id: __expectString(output.Id),
     InsightTimeRange:
       output.InsightTimeRange !== undefined && output.InsightTimeRange !== null
         ? deserializeAws_restJson1InsightTimeRange(output.InsightTimeRange, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     PredictionTimeRange:
       output.PredictionTimeRange !== undefined && output.PredictionTimeRange !== null
         ? deserializeAws_restJson1PredictionTimeRange(output.PredictionTimeRange, context)
@@ -3504,8 +3491,8 @@ const deserializeAws_restJson1ProactiveInsightSummary = (
       output.ServiceCollection !== undefined && output.ServiceCollection !== null
         ? deserializeAws_restJson1ServiceCollection(output.ServiceCollection, context)
         : undefined,
-    Severity: output.Severity !== undefined && output.Severity !== null ? output.Severity : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Severity: __expectString(output.Severity),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -3526,21 +3513,18 @@ const deserializeAws_restJson1ReactiveAnomaly = (output: any, context: __SerdeCo
       output.AnomalyTimeRange !== undefined && output.AnomalyTimeRange !== null
         ? deserializeAws_restJson1AnomalyTimeRange(output.AnomalyTimeRange, context)
         : undefined,
-    AssociatedInsightId:
-      output.AssociatedInsightId !== undefined && output.AssociatedInsightId !== null
-        ? output.AssociatedInsightId
-        : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    AssociatedInsightId: __expectString(output.AssociatedInsightId),
+    Id: __expectString(output.Id),
     ResourceCollection:
       output.ResourceCollection !== undefined && output.ResourceCollection !== null
         ? deserializeAws_restJson1ResourceCollection(output.ResourceCollection, context)
         : undefined,
-    Severity: output.Severity !== undefined && output.Severity !== null ? output.Severity : undefined,
+    Severity: __expectString(output.Severity),
     SourceDetails:
       output.SourceDetails !== undefined && output.SourceDetails !== null
         ? deserializeAws_restJson1AnomalySourceDetails(output.SourceDetails, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -3553,39 +3537,36 @@ const deserializeAws_restJson1ReactiveAnomalySummary = (
       output.AnomalyTimeRange !== undefined && output.AnomalyTimeRange !== null
         ? deserializeAws_restJson1AnomalyTimeRange(output.AnomalyTimeRange, context)
         : undefined,
-    AssociatedInsightId:
-      output.AssociatedInsightId !== undefined && output.AssociatedInsightId !== null
-        ? output.AssociatedInsightId
-        : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    AssociatedInsightId: __expectString(output.AssociatedInsightId),
+    Id: __expectString(output.Id),
     ResourceCollection:
       output.ResourceCollection !== undefined && output.ResourceCollection !== null
         ? deserializeAws_restJson1ResourceCollection(output.ResourceCollection, context)
         : undefined,
-    Severity: output.Severity !== undefined && output.Severity !== null ? output.Severity : undefined,
+    Severity: __expectString(output.Severity),
     SourceDetails:
       output.SourceDetails !== undefined && output.SourceDetails !== null
         ? deserializeAws_restJson1AnomalySourceDetails(output.SourceDetails, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
 const deserializeAws_restJson1ReactiveInsight = (output: any, context: __SerdeContext): ReactiveInsight => {
   return {
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    Id: __expectString(output.Id),
     InsightTimeRange:
       output.InsightTimeRange !== undefined && output.InsightTimeRange !== null
         ? deserializeAws_restJson1InsightTimeRange(output.InsightTimeRange, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     ResourceCollection:
       output.ResourceCollection !== undefined && output.ResourceCollection !== null
         ? deserializeAws_restJson1ResourceCollection(output.ResourceCollection, context)
         : undefined,
-    Severity: output.Severity !== undefined && output.Severity !== null ? output.Severity : undefined,
-    SsmOpsItemId: output.SsmOpsItemId !== undefined && output.SsmOpsItemId !== null ? output.SsmOpsItemId : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Severity: __expectString(output.Severity),
+    SsmOpsItemId: __expectString(output.SsmOpsItemId),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -3605,12 +3586,12 @@ const deserializeAws_restJson1ReactiveInsightSummary = (
   context: __SerdeContext
 ): ReactiveInsightSummary => {
   return {
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    Id: __expectString(output.Id),
     InsightTimeRange:
       output.InsightTimeRange !== undefined && output.InsightTimeRange !== null
         ? deserializeAws_restJson1InsightTimeRange(output.InsightTimeRange, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     ResourceCollection:
       output.ResourceCollection !== undefined && output.ResourceCollection !== null
         ? deserializeAws_restJson1ResourceCollection(output.ResourceCollection, context)
@@ -3619,17 +3600,17 @@ const deserializeAws_restJson1ReactiveInsightSummary = (
       output.ServiceCollection !== undefined && output.ServiceCollection !== null
         ? deserializeAws_restJson1ServiceCollection(output.ServiceCollection, context)
         : undefined,
-    Severity: output.Severity !== undefined && output.Severity !== null ? output.Severity : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Severity: __expectString(output.Severity),
+    Status: __expectString(output.Status),
   } as any;
 };
 
 const deserializeAws_restJson1Recommendation = (output: any, context: __SerdeContext): Recommendation => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Link: output.Link !== undefined && output.Link !== null ? output.Link : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Reason: output.Reason !== undefined && output.Reason !== null ? output.Reason : undefined,
+    Description: __expectString(output.Description),
+    Link: __expectString(output.Link),
+    Name: __expectString(output.Name),
+    Reason: __expectString(output.Reason),
     RelatedAnomalies:
       output.RelatedAnomalies !== undefined && output.RelatedAnomalies !== null
         ? deserializeAws_restJson1RecommendationRelatedAnomalies(output.RelatedAnomalies, context)
@@ -3676,8 +3657,8 @@ const deserializeAws_restJson1RecommendationRelatedAnomalyResource = (
   context: __SerdeContext
 ): RecommendationRelatedAnomalyResource => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Name: __expectString(output.Name),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -3712,8 +3693,8 @@ const deserializeAws_restJson1RecommendationRelatedCloudWatchMetricsSourceDetail
   context: __SerdeContext
 ): RecommendationRelatedCloudWatchMetricsSourceDetail => {
   return {
-    MetricName: output.MetricName !== undefined && output.MetricName !== null ? output.MetricName : undefined,
-    Namespace: output.Namespace !== undefined && output.Namespace !== null ? output.Namespace : undefined,
+    MetricName: __expectString(output.MetricName),
+    Namespace: __expectString(output.Namespace),
   } as any;
 };
 
@@ -3736,7 +3717,7 @@ const deserializeAws_restJson1RecommendationRelatedEvent = (
   context: __SerdeContext
 ): RecommendationRelatedEvent => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     Resources:
       output.Resources !== undefined && output.Resources !== null
         ? deserializeAws_restJson1RecommendationRelatedEventResources(output.Resources, context)
@@ -3749,8 +3730,8 @@ const deserializeAws_restJson1RecommendationRelatedEventResource = (
   context: __SerdeContext
 ): RecommendationRelatedEventResource => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Name: __expectString(output.Name),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -3843,7 +3824,7 @@ const deserializeAws_restJson1ServiceHealth = (output: any, context: __SerdeCont
       output.Insight !== undefined && output.Insight !== null
         ? deserializeAws_restJson1ServiceInsightHealth(output.Insight, context)
         : undefined,
-    ServiceName: output.ServiceName !== undefined && output.ServiceName !== null ? output.ServiceName : undefined,
+    ServiceName: __expectString(output.ServiceName),
   } as any;
 };
 
@@ -3860,14 +3841,8 @@ const deserializeAws_restJson1ServiceHealths = (output: any, context: __SerdeCon
 
 const deserializeAws_restJson1ServiceInsightHealth = (output: any, context: __SerdeContext): ServiceInsightHealth => {
   return {
-    OpenProactiveInsights:
-      output.OpenProactiveInsights !== undefined && output.OpenProactiveInsights !== null
-        ? output.OpenProactiveInsights
-        : undefined,
-    OpenReactiveInsights:
-      output.OpenReactiveInsights !== undefined && output.OpenReactiveInsights !== null
-        ? output.OpenReactiveInsights
-        : undefined,
+    OpenProactiveInsights: __expectNumber(output.OpenProactiveInsights),
+    OpenReactiveInsights: __expectNumber(output.OpenReactiveInsights),
   } as any;
 };
 
@@ -3890,17 +3865,17 @@ const deserializeAws_restJson1ServiceNames = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1ServiceResourceCost = (output: any, context: __SerdeContext): ServiceResourceCost => {
   return {
-    Cost: output.Cost !== undefined && output.Cost !== null ? output.Cost : undefined,
-    Count: output.Count !== undefined && output.Count !== null ? output.Count : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    UnitCost: output.UnitCost !== undefined && output.UnitCost !== null ? output.UnitCost : undefined,
+    Cost: __expectNumber(output.Cost),
+    Count: __expectNumber(output.Count),
+    State: __expectString(output.State),
+    Type: __expectString(output.Type),
+    UnitCost: __expectNumber(output.UnitCost),
   } as any;
 };
 
@@ -3917,7 +3892,7 @@ const deserializeAws_restJson1ServiceResourceCosts = (output: any, context: __Se
 
 const deserializeAws_restJson1SnsChannelConfig = (output: any, context: __SerdeContext): SnsChannelConfig => {
   return {
-    TopicArn: output.TopicArn !== undefined && output.TopicArn !== null ? output.TopicArn : undefined,
+    TopicArn: __expectString(output.TopicArn),
   } as any;
 };
 
@@ -3928,7 +3903,7 @@ const deserializeAws_restJson1StackNames = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3937,8 +3912,8 @@ const deserializeAws_restJson1ValidationExceptionField = (
   context: __SerdeContext
 ): ValidationExceptionField => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Message: __expectString(output.Message),
+    Name: __expectString(output.Name),
   } as any;
 };
 

--- a/clients/client-direct-connect/protocols/Aws_json1_1.ts
+++ b/clients/client-direct-connect/protocols/Aws_json1_1.ts
@@ -307,7 +307,12 @@ import {
   VirtualInterfaces,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -5922,10 +5927,10 @@ const deserializeAws_json1_1AllocateTransitVirtualInterfaceResult = (
 
 const deserializeAws_json1_1AssociatedGateway = (output: any, context: __SerdeContext): AssociatedGateway => {
   return {
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    ownerAccount: output.ownerAccount !== undefined && output.ownerAccount !== null ? output.ownerAccount : undefined,
-    region: output.region !== undefined && output.region !== null ? output.region : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    id: __expectString(output.id),
+    ownerAccount: __expectString(output.ownerAccount),
+    region: __expectString(output.region),
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -5934,7 +5939,7 @@ const deserializeAws_json1_1AssociateMacSecKeyResponse = (
   context: __SerdeContext
 ): AssociateMacSecKeyResponse => {
   return {
-    connectionId: output.connectionId !== undefined && output.connectionId !== null ? output.connectionId : undefined,
+    connectionId: __expectString(output.connectionId),
     macSecKeys:
       output.macSecKeys !== undefined && output.macSecKeys !== null
         ? deserializeAws_json1_1MacSecKeyList(output.macSecKeys, context)
@@ -5949,7 +5954,7 @@ const deserializeAws_json1_1AvailableMacSecPortSpeeds = (output: any, context: _
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -5960,24 +5965,21 @@ const deserializeAws_json1_1AvailablePortSpeeds = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1BGPPeer = (output: any, context: __SerdeContext): BGPPeer => {
   return {
-    addressFamily:
-      output.addressFamily !== undefined && output.addressFamily !== null ? output.addressFamily : undefined,
-    amazonAddress:
-      output.amazonAddress !== undefined && output.amazonAddress !== null ? output.amazonAddress : undefined,
-    asn: output.asn !== undefined && output.asn !== null ? output.asn : undefined,
-    authKey: output.authKey !== undefined && output.authKey !== null ? output.authKey : undefined,
-    awsDeviceV2: output.awsDeviceV2 !== undefined && output.awsDeviceV2 !== null ? output.awsDeviceV2 : undefined,
-    bgpPeerId: output.bgpPeerId !== undefined && output.bgpPeerId !== null ? output.bgpPeerId : undefined,
-    bgpPeerState: output.bgpPeerState !== undefined && output.bgpPeerState !== null ? output.bgpPeerState : undefined,
-    bgpStatus: output.bgpStatus !== undefined && output.bgpStatus !== null ? output.bgpStatus : undefined,
-    customerAddress:
-      output.customerAddress !== undefined && output.customerAddress !== null ? output.customerAddress : undefined,
+    addressFamily: __expectString(output.addressFamily),
+    amazonAddress: __expectString(output.amazonAddress),
+    asn: __expectNumber(output.asn),
+    authKey: __expectString(output.authKey),
+    awsDeviceV2: __expectString(output.awsDeviceV2),
+    bgpPeerId: __expectString(output.bgpPeerId),
+    bgpPeerState: __expectString(output.bgpPeerState),
+    bgpStatus: __expectString(output.bgpStatus),
+    customerAddress: __expectString(output.customerAddress),
   } as any;
 };
 
@@ -5988,7 +5990,7 @@ const deserializeAws_json1_1BGPPeerIdList = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6008,8 +6010,7 @@ const deserializeAws_json1_1ConfirmConnectionResponse = (
   context: __SerdeContext
 ): ConfirmConnectionResponse => {
   return {
-    connectionState:
-      output.connectionState !== undefined && output.connectionState !== null ? output.connectionState : undefined,
+    connectionState: __expectString(output.connectionState),
   } as any;
 };
 
@@ -6018,10 +6019,7 @@ const deserializeAws_json1_1ConfirmPrivateVirtualInterfaceResponse = (
   context: __SerdeContext
 ): ConfirmPrivateVirtualInterfaceResponse => {
   return {
-    virtualInterfaceState:
-      output.virtualInterfaceState !== undefined && output.virtualInterfaceState !== null
-        ? output.virtualInterfaceState
-        : undefined,
+    virtualInterfaceState: __expectString(output.virtualInterfaceState),
   } as any;
 };
 
@@ -6030,10 +6028,7 @@ const deserializeAws_json1_1ConfirmPublicVirtualInterfaceResponse = (
   context: __SerdeContext
 ): ConfirmPublicVirtualInterfaceResponse => {
   return {
-    virtualInterfaceState:
-      output.virtualInterfaceState !== undefined && output.virtualInterfaceState !== null
-        ? output.virtualInterfaceState
-        : undefined,
+    virtualInterfaceState: __expectString(output.virtualInterfaceState),
   } as any;
 };
 
@@ -6042,58 +6037,42 @@ const deserializeAws_json1_1ConfirmTransitVirtualInterfaceResponse = (
   context: __SerdeContext
 ): ConfirmTransitVirtualInterfaceResponse => {
   return {
-    virtualInterfaceState:
-      output.virtualInterfaceState !== undefined && output.virtualInterfaceState !== null
-        ? output.virtualInterfaceState
-        : undefined,
+    virtualInterfaceState: __expectString(output.virtualInterfaceState),
   } as any;
 };
 
 const deserializeAws_json1_1Connection = (output: any, context: __SerdeContext): Connection => {
   return {
-    awsDevice: output.awsDevice !== undefined && output.awsDevice !== null ? output.awsDevice : undefined,
-    awsDeviceV2: output.awsDeviceV2 !== undefined && output.awsDeviceV2 !== null ? output.awsDeviceV2 : undefined,
-    bandwidth: output.bandwidth !== undefined && output.bandwidth !== null ? output.bandwidth : undefined,
-    connectionId: output.connectionId !== undefined && output.connectionId !== null ? output.connectionId : undefined,
-    connectionName:
-      output.connectionName !== undefined && output.connectionName !== null ? output.connectionName : undefined,
-    connectionState:
-      output.connectionState !== undefined && output.connectionState !== null ? output.connectionState : undefined,
-    encryptionMode:
-      output.encryptionMode !== undefined && output.encryptionMode !== null ? output.encryptionMode : undefined,
-    hasLogicalRedundancy:
-      output.hasLogicalRedundancy !== undefined && output.hasLogicalRedundancy !== null
-        ? output.hasLogicalRedundancy
-        : undefined,
-    jumboFrameCapable:
-      output.jumboFrameCapable !== undefined && output.jumboFrameCapable !== null
-        ? output.jumboFrameCapable
-        : undefined,
-    lagId: output.lagId !== undefined && output.lagId !== null ? output.lagId : undefined,
+    awsDevice: __expectString(output.awsDevice),
+    awsDeviceV2: __expectString(output.awsDeviceV2),
+    bandwidth: __expectString(output.bandwidth),
+    connectionId: __expectString(output.connectionId),
+    connectionName: __expectString(output.connectionName),
+    connectionState: __expectString(output.connectionState),
+    encryptionMode: __expectString(output.encryptionMode),
+    hasLogicalRedundancy: __expectString(output.hasLogicalRedundancy),
+    jumboFrameCapable: __expectBoolean(output.jumboFrameCapable),
+    lagId: __expectString(output.lagId),
     loaIssueTime:
       output.loaIssueTime !== undefined && output.loaIssueTime !== null
         ? new Date(Math.round(output.loaIssueTime * 1000))
         : undefined,
-    location: output.location !== undefined && output.location !== null ? output.location : undefined,
-    macSecCapable:
-      output.macSecCapable !== undefined && output.macSecCapable !== null ? output.macSecCapable : undefined,
+    location: __expectString(output.location),
+    macSecCapable: __expectBoolean(output.macSecCapable),
     macSecKeys:
       output.macSecKeys !== undefined && output.macSecKeys !== null
         ? deserializeAws_json1_1MacSecKeyList(output.macSecKeys, context)
         : undefined,
-    ownerAccount: output.ownerAccount !== undefined && output.ownerAccount !== null ? output.ownerAccount : undefined,
-    partnerName: output.partnerName !== undefined && output.partnerName !== null ? output.partnerName : undefined,
-    portEncryptionStatus:
-      output.portEncryptionStatus !== undefined && output.portEncryptionStatus !== null
-        ? output.portEncryptionStatus
-        : undefined,
-    providerName: output.providerName !== undefined && output.providerName !== null ? output.providerName : undefined,
-    region: output.region !== undefined && output.region !== null ? output.region : undefined,
+    ownerAccount: __expectString(output.ownerAccount),
+    partnerName: __expectString(output.partnerName),
+    portEncryptionStatus: __expectString(output.portEncryptionStatus),
+    providerName: __expectString(output.providerName),
+    region: __expectString(output.region),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_json1_1TagList(output.tags, context)
         : undefined,
-    vlan: output.vlan !== undefined && output.vlan !== null ? output.vlan : undefined,
+    vlan: __expectNumber(output.vlan),
   } as any;
 };
 
@@ -6232,10 +6211,7 @@ const deserializeAws_json1_1DeleteInterconnectResponse = (
   context: __SerdeContext
 ): DeleteInterconnectResponse => {
   return {
-    interconnectState:
-      output.interconnectState !== undefined && output.interconnectState !== null
-        ? output.interconnectState
-        : undefined,
+    interconnectState: __expectString(output.interconnectState),
   } as any;
 };
 
@@ -6244,10 +6220,7 @@ const deserializeAws_json1_1DeleteVirtualInterfaceResponse = (
   context: __SerdeContext
 ): DeleteVirtualInterfaceResponse => {
   return {
-    virtualInterfaceState:
-      output.virtualInterfaceState !== undefined && output.virtualInterfaceState !== null
-        ? output.virtualInterfaceState
-        : undefined,
+    virtualInterfaceState: __expectString(output.virtualInterfaceState),
   } as any;
 };
 
@@ -6273,7 +6246,7 @@ const deserializeAws_json1_1DescribeDirectConnectGatewayAssociationProposalsResu
             context
           )
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -6286,7 +6259,7 @@ const deserializeAws_json1_1DescribeDirectConnectGatewayAssociationsResult = (
       output.directConnectGatewayAssociations !== undefined && output.directConnectGatewayAssociations !== null
         ? deserializeAws_json1_1DirectConnectGatewayAssociationList(output.directConnectGatewayAssociations, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -6299,7 +6272,7 @@ const deserializeAws_json1_1DescribeDirectConnectGatewayAttachmentsResult = (
       output.directConnectGatewayAttachments !== undefined && output.directConnectGatewayAttachments !== null
         ? deserializeAws_json1_1DirectConnectGatewayAttachmentList(output.directConnectGatewayAttachments, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -6312,7 +6285,7 @@ const deserializeAws_json1_1DescribeDirectConnectGatewaysResult = (
       output.directConnectGateways !== undefined && output.directConnectGateways !== null
         ? deserializeAws_json1_1DirectConnectGatewayList(output.directConnectGateways, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -6339,29 +6312,18 @@ const deserializeAws_json1_1DirectConnectClientException = (
   context: __SerdeContext
 ): DirectConnectClientException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1DirectConnectGateway = (output: any, context: __SerdeContext): DirectConnectGateway => {
   return {
-    amazonSideAsn:
-      output.amazonSideAsn !== undefined && output.amazonSideAsn !== null ? output.amazonSideAsn : undefined,
-    directConnectGatewayId:
-      output.directConnectGatewayId !== undefined && output.directConnectGatewayId !== null
-        ? output.directConnectGatewayId
-        : undefined,
-    directConnectGatewayName:
-      output.directConnectGatewayName !== undefined && output.directConnectGatewayName !== null
-        ? output.directConnectGatewayName
-        : undefined,
-    directConnectGatewayState:
-      output.directConnectGatewayState !== undefined && output.directConnectGatewayState !== null
-        ? output.directConnectGatewayState
-        : undefined,
-    ownerAccount: output.ownerAccount !== undefined && output.ownerAccount !== null ? output.ownerAccount : undefined,
-    stateChangeError:
-      output.stateChangeError !== undefined && output.stateChangeError !== null ? output.stateChangeError : undefined,
+    amazonSideAsn: __expectNumber(output.amazonSideAsn),
+    directConnectGatewayId: __expectString(output.directConnectGatewayId),
+    directConnectGatewayName: __expectString(output.directConnectGatewayName),
+    directConnectGatewayState: __expectString(output.directConnectGatewayState),
+    ownerAccount: __expectString(output.ownerAccount),
+    stateChangeError: __expectString(output.stateChangeError),
   } as any;
 };
 
@@ -6379,30 +6341,14 @@ const deserializeAws_json1_1DirectConnectGatewayAssociation = (
       output.associatedGateway !== undefined && output.associatedGateway !== null
         ? deserializeAws_json1_1AssociatedGateway(output.associatedGateway, context)
         : undefined,
-    associationId:
-      output.associationId !== undefined && output.associationId !== null ? output.associationId : undefined,
-    associationState:
-      output.associationState !== undefined && output.associationState !== null ? output.associationState : undefined,
-    directConnectGatewayId:
-      output.directConnectGatewayId !== undefined && output.directConnectGatewayId !== null
-        ? output.directConnectGatewayId
-        : undefined,
-    directConnectGatewayOwnerAccount:
-      output.directConnectGatewayOwnerAccount !== undefined && output.directConnectGatewayOwnerAccount !== null
-        ? output.directConnectGatewayOwnerAccount
-        : undefined,
-    stateChangeError:
-      output.stateChangeError !== undefined && output.stateChangeError !== null ? output.stateChangeError : undefined,
-    virtualGatewayId:
-      output.virtualGatewayId !== undefined && output.virtualGatewayId !== null ? output.virtualGatewayId : undefined,
-    virtualGatewayOwnerAccount:
-      output.virtualGatewayOwnerAccount !== undefined && output.virtualGatewayOwnerAccount !== null
-        ? output.virtualGatewayOwnerAccount
-        : undefined,
-    virtualGatewayRegion:
-      output.virtualGatewayRegion !== undefined && output.virtualGatewayRegion !== null
-        ? output.virtualGatewayRegion
-        : undefined,
+    associationId: __expectString(output.associationId),
+    associationState: __expectString(output.associationState),
+    directConnectGatewayId: __expectString(output.directConnectGatewayId),
+    directConnectGatewayOwnerAccount: __expectString(output.directConnectGatewayOwnerAccount),
+    stateChangeError: __expectString(output.stateChangeError),
+    virtualGatewayId: __expectString(output.virtualGatewayId),
+    virtualGatewayOwnerAccount: __expectString(output.virtualGatewayOwnerAccount),
+    virtualGatewayRegion: __expectString(output.virtualGatewayRegion),
   } as any;
 };
 
@@ -6429,22 +6375,15 @@ const deserializeAws_json1_1DirectConnectGatewayAssociationProposal = (
       output.associatedGateway !== undefined && output.associatedGateway !== null
         ? deserializeAws_json1_1AssociatedGateway(output.associatedGateway, context)
         : undefined,
-    directConnectGatewayId:
-      output.directConnectGatewayId !== undefined && output.directConnectGatewayId !== null
-        ? output.directConnectGatewayId
-        : undefined,
-    directConnectGatewayOwnerAccount:
-      output.directConnectGatewayOwnerAccount !== undefined && output.directConnectGatewayOwnerAccount !== null
-        ? output.directConnectGatewayOwnerAccount
-        : undefined,
+    directConnectGatewayId: __expectString(output.directConnectGatewayId),
+    directConnectGatewayOwnerAccount: __expectString(output.directConnectGatewayOwnerAccount),
     existingAllowedPrefixesToDirectConnectGateway:
       output.existingAllowedPrefixesToDirectConnectGateway !== undefined &&
       output.existingAllowedPrefixesToDirectConnectGateway !== null
         ? deserializeAws_json1_1RouteFilterPrefixList(output.existingAllowedPrefixesToDirectConnectGateway, context)
         : undefined,
-    proposalId: output.proposalId !== undefined && output.proposalId !== null ? output.proposalId : undefined,
-    proposalState:
-      output.proposalState !== undefined && output.proposalState !== null ? output.proposalState : undefined,
+    proposalId: __expectString(output.proposalId),
+    proposalState: __expectString(output.proposalState),
     requestedAllowedPrefixesToDirectConnectGateway:
       output.requestedAllowedPrefixesToDirectConnectGateway !== undefined &&
       output.requestedAllowedPrefixesToDirectConnectGateway !== null
@@ -6472,28 +6411,13 @@ const deserializeAws_json1_1DirectConnectGatewayAttachment = (
   context: __SerdeContext
 ): DirectConnectGatewayAttachment => {
   return {
-    attachmentState:
-      output.attachmentState !== undefined && output.attachmentState !== null ? output.attachmentState : undefined,
-    attachmentType:
-      output.attachmentType !== undefined && output.attachmentType !== null ? output.attachmentType : undefined,
-    directConnectGatewayId:
-      output.directConnectGatewayId !== undefined && output.directConnectGatewayId !== null
-        ? output.directConnectGatewayId
-        : undefined,
-    stateChangeError:
-      output.stateChangeError !== undefined && output.stateChangeError !== null ? output.stateChangeError : undefined,
-    virtualInterfaceId:
-      output.virtualInterfaceId !== undefined && output.virtualInterfaceId !== null
-        ? output.virtualInterfaceId
-        : undefined,
-    virtualInterfaceOwnerAccount:
-      output.virtualInterfaceOwnerAccount !== undefined && output.virtualInterfaceOwnerAccount !== null
-        ? output.virtualInterfaceOwnerAccount
-        : undefined,
-    virtualInterfaceRegion:
-      output.virtualInterfaceRegion !== undefined && output.virtualInterfaceRegion !== null
-        ? output.virtualInterfaceRegion
-        : undefined,
+    attachmentState: __expectString(output.attachmentState),
+    attachmentType: __expectString(output.attachmentType),
+    directConnectGatewayId: __expectString(output.directConnectGatewayId),
+    stateChangeError: __expectString(output.stateChangeError),
+    virtualInterfaceId: __expectString(output.virtualInterfaceId),
+    virtualInterfaceOwnerAccount: __expectString(output.virtualInterfaceOwnerAccount),
+    virtualInterfaceRegion: __expectString(output.virtualInterfaceRegion),
   } as any;
 };
 
@@ -6530,7 +6454,7 @@ const deserializeAws_json1_1DirectConnectServerException = (
   context: __SerdeContext
 ): DirectConnectServerException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6539,7 +6463,7 @@ const deserializeAws_json1_1DisassociateMacSecKeyResponse = (
   context: __SerdeContext
 ): DisassociateMacSecKeyResponse => {
   return {
-    connectionId: output.connectionId !== undefined && output.connectionId !== null ? output.connectionId : undefined,
+    connectionId: __expectString(output.connectionId),
     macSecKeys:
       output.macSecKeys !== undefined && output.macSecKeys !== null
         ? deserializeAws_json1_1MacSecKeyList(output.macSecKeys, context)
@@ -6552,39 +6476,28 @@ const deserializeAws_json1_1DuplicateTagKeysException = (
   context: __SerdeContext
 ): DuplicateTagKeysException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1Interconnect = (output: any, context: __SerdeContext): Interconnect => {
   return {
-    awsDevice: output.awsDevice !== undefined && output.awsDevice !== null ? output.awsDevice : undefined,
-    awsDeviceV2: output.awsDeviceV2 !== undefined && output.awsDeviceV2 !== null ? output.awsDeviceV2 : undefined,
-    bandwidth: output.bandwidth !== undefined && output.bandwidth !== null ? output.bandwidth : undefined,
-    hasLogicalRedundancy:
-      output.hasLogicalRedundancy !== undefined && output.hasLogicalRedundancy !== null
-        ? output.hasLogicalRedundancy
-        : undefined,
-    interconnectId:
-      output.interconnectId !== undefined && output.interconnectId !== null ? output.interconnectId : undefined,
-    interconnectName:
-      output.interconnectName !== undefined && output.interconnectName !== null ? output.interconnectName : undefined,
-    interconnectState:
-      output.interconnectState !== undefined && output.interconnectState !== null
-        ? output.interconnectState
-        : undefined,
-    jumboFrameCapable:
-      output.jumboFrameCapable !== undefined && output.jumboFrameCapable !== null
-        ? output.jumboFrameCapable
-        : undefined,
-    lagId: output.lagId !== undefined && output.lagId !== null ? output.lagId : undefined,
+    awsDevice: __expectString(output.awsDevice),
+    awsDeviceV2: __expectString(output.awsDeviceV2),
+    bandwidth: __expectString(output.bandwidth),
+    hasLogicalRedundancy: __expectString(output.hasLogicalRedundancy),
+    interconnectId: __expectString(output.interconnectId),
+    interconnectName: __expectString(output.interconnectName),
+    interconnectState: __expectString(output.interconnectState),
+    jumboFrameCapable: __expectBoolean(output.jumboFrameCapable),
+    lagId: __expectString(output.lagId),
     loaIssueTime:
       output.loaIssueTime !== undefined && output.loaIssueTime !== null
         ? new Date(Math.round(output.loaIssueTime * 1000))
         : undefined,
-    location: output.location !== undefined && output.location !== null ? output.location : undefined,
-    providerName: output.providerName !== undefined && output.providerName !== null ? output.providerName : undefined,
-    region: output.region !== undefined && output.region !== null ? output.region : undefined,
+    location: __expectString(output.location),
+    providerName: __expectString(output.providerName),
+    region: __expectString(output.region),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_json1_1TagList(output.tags, context)
@@ -6614,48 +6527,31 @@ const deserializeAws_json1_1Interconnects = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1Lag = (output: any, context: __SerdeContext): Lag => {
   return {
-    allowsHostedConnections:
-      output.allowsHostedConnections !== undefined && output.allowsHostedConnections !== null
-        ? output.allowsHostedConnections
-        : undefined,
-    awsDevice: output.awsDevice !== undefined && output.awsDevice !== null ? output.awsDevice : undefined,
-    awsDeviceV2: output.awsDeviceV2 !== undefined && output.awsDeviceV2 !== null ? output.awsDeviceV2 : undefined,
+    allowsHostedConnections: __expectBoolean(output.allowsHostedConnections),
+    awsDevice: __expectString(output.awsDevice),
+    awsDeviceV2: __expectString(output.awsDeviceV2),
     connections:
       output.connections !== undefined && output.connections !== null
         ? deserializeAws_json1_1ConnectionList(output.connections, context)
         : undefined,
-    connectionsBandwidth:
-      output.connectionsBandwidth !== undefined && output.connectionsBandwidth !== null
-        ? output.connectionsBandwidth
-        : undefined,
-    encryptionMode:
-      output.encryptionMode !== undefined && output.encryptionMode !== null ? output.encryptionMode : undefined,
-    hasLogicalRedundancy:
-      output.hasLogicalRedundancy !== undefined && output.hasLogicalRedundancy !== null
-        ? output.hasLogicalRedundancy
-        : undefined,
-    jumboFrameCapable:
-      output.jumboFrameCapable !== undefined && output.jumboFrameCapable !== null
-        ? output.jumboFrameCapable
-        : undefined,
-    lagId: output.lagId !== undefined && output.lagId !== null ? output.lagId : undefined,
-    lagName: output.lagName !== undefined && output.lagName !== null ? output.lagName : undefined,
-    lagState: output.lagState !== undefined && output.lagState !== null ? output.lagState : undefined,
-    location: output.location !== undefined && output.location !== null ? output.location : undefined,
-    macSecCapable:
-      output.macSecCapable !== undefined && output.macSecCapable !== null ? output.macSecCapable : undefined,
+    connectionsBandwidth: __expectString(output.connectionsBandwidth),
+    encryptionMode: __expectString(output.encryptionMode),
+    hasLogicalRedundancy: __expectString(output.hasLogicalRedundancy),
+    jumboFrameCapable: __expectBoolean(output.jumboFrameCapable),
+    lagId: __expectString(output.lagId),
+    lagName: __expectString(output.lagName),
+    lagState: __expectString(output.lagState),
+    location: __expectString(output.location),
+    macSecCapable: __expectBoolean(output.macSecCapable),
     macSecKeys:
       output.macSecKeys !== undefined && output.macSecKeys !== null
         ? deserializeAws_json1_1MacSecKeyList(output.macSecKeys, context)
         : undefined,
-    minimumLinks: output.minimumLinks !== undefined && output.minimumLinks !== null ? output.minimumLinks : undefined,
-    numberOfConnections:
-      output.numberOfConnections !== undefined && output.numberOfConnections !== null
-        ? output.numberOfConnections
-        : undefined,
-    ownerAccount: output.ownerAccount !== undefined && output.ownerAccount !== null ? output.ownerAccount : undefined,
-    providerName: output.providerName !== undefined && output.providerName !== null ? output.providerName : undefined,
-    region: output.region !== undefined && output.region !== null ? output.region : undefined,
+    minimumLinks: __expectNumber(output.minimumLinks),
+    numberOfConnections: __expectNumber(output.numberOfConnections),
+    ownerAccount: __expectString(output.ownerAccount),
+    providerName: __expectString(output.providerName),
+    region: __expectString(output.region),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_json1_1TagList(output.tags, context)
@@ -6688,7 +6584,7 @@ const deserializeAws_json1_1ListVirtualInterfaceTestHistoryResponse = (
   context: __SerdeContext
 ): ListVirtualInterfaceTestHistoryResponse => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     virtualInterfaceTestHistory:
       output.virtualInterfaceTestHistory !== undefined && output.virtualInterfaceTestHistory !== null
         ? deserializeAws_json1_1VirtualInterfaceTestHistoryList(output.virtualInterfaceTestHistory, context)
@@ -6702,8 +6598,7 @@ const deserializeAws_json1_1Loa = (output: any, context: __SerdeContext): Loa =>
       output.loaContent !== undefined && output.loaContent !== null
         ? context.base64Decoder(output.loaContent)
         : undefined,
-    loaContentType:
-      output.loaContentType !== undefined && output.loaContentType !== null ? output.loaContentType : undefined,
+    loaContentType: __expectString(output.loaContentType),
   } as any;
 };
 
@@ -6721,9 +6616,9 @@ const deserializeAws_json1_1Location = (output: any, context: __SerdeContext): L
       output.availableProviders !== undefined && output.availableProviders !== null
         ? deserializeAws_json1_1ProviderList(output.availableProviders, context)
         : undefined,
-    locationCode: output.locationCode !== undefined && output.locationCode !== null ? output.locationCode : undefined,
-    locationName: output.locationName !== undefined && output.locationName !== null ? output.locationName : undefined,
-    region: output.region !== undefined && output.region !== null ? output.region : undefined,
+    locationCode: __expectString(output.locationCode),
+    locationName: __expectString(output.locationName),
+    region: __expectString(output.region),
   } as any;
 };
 
@@ -6749,10 +6644,10 @@ const deserializeAws_json1_1Locations = (output: any, context: __SerdeContext): 
 
 const deserializeAws_json1_1MacSecKey = (output: any, context: __SerdeContext): MacSecKey => {
   return {
-    ckn: output.ckn !== undefined && output.ckn !== null ? output.ckn : undefined,
-    secretARN: output.secretARN !== undefined && output.secretARN !== null ? output.secretARN : undefined,
-    startOn: output.startOn !== undefined && output.startOn !== null ? output.startOn : undefined,
-    state: output.state !== undefined && output.state !== null ? output.state : undefined,
+    ckn: __expectString(output.ckn),
+    secretARN: __expectString(output.secretARN),
+    startOn: __expectString(output.startOn),
+    state: __expectString(output.state),
   } as any;
 };
 
@@ -6774,13 +6669,13 @@ const deserializeAws_json1_1ProviderList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1ResourceTag = (output: any, context: __SerdeContext): ResourceTag => {
   return {
-    resourceArn: output.resourceArn !== undefined && output.resourceArn !== null ? output.resourceArn : undefined,
+    resourceArn: __expectString(output.resourceArn),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_json1_1TagList(output.tags, context)
@@ -6801,7 +6696,7 @@ const deserializeAws_json1_1ResourceTagList = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_1RouteFilterPrefix = (output: any, context: __SerdeContext): RouteFilterPrefix => {
   return {
-    cidr: output.cidr !== undefined && output.cidr !== null ? output.cidr : undefined,
+    cidr: __expectString(output.cidr),
   } as any;
 };
 
@@ -6842,8 +6737,8 @@ const deserializeAws_json1_1StopBgpFailoverTestResponse = (
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    key: __expectString(output.key),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -6864,7 +6759,7 @@ const deserializeAws_json1_1TagResourceResponse = (output: any, context: __Serde
 
 const deserializeAws_json1_1TooManyTagsException = (output: any, context: __SerdeContext): TooManyTagsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6886,12 +6781,8 @@ const deserializeAws_json1_1UpdateDirectConnectGatewayAssociationResult = (
 
 const deserializeAws_json1_1VirtualGateway = (output: any, context: __SerdeContext): VirtualGateway => {
   return {
-    virtualGatewayId:
-      output.virtualGatewayId !== undefined && output.virtualGatewayId !== null ? output.virtualGatewayId : undefined,
-    virtualGatewayState:
-      output.virtualGatewayState !== undefined && output.virtualGatewayState !== null
-        ? output.virtualGatewayState
-        : undefined,
+    virtualGatewayId: __expectString(output.virtualGatewayId),
+    virtualGatewayState: __expectString(output.virtualGatewayState),
   } as any;
 };
 
@@ -6917,38 +6808,25 @@ const deserializeAws_json1_1VirtualGateways = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_1VirtualInterface = (output: any, context: __SerdeContext): VirtualInterface => {
   return {
-    addressFamily:
-      output.addressFamily !== undefined && output.addressFamily !== null ? output.addressFamily : undefined,
-    amazonAddress:
-      output.amazonAddress !== undefined && output.amazonAddress !== null ? output.amazonAddress : undefined,
-    amazonSideAsn:
-      output.amazonSideAsn !== undefined && output.amazonSideAsn !== null ? output.amazonSideAsn : undefined,
-    asn: output.asn !== undefined && output.asn !== null ? output.asn : undefined,
-    authKey: output.authKey !== undefined && output.authKey !== null ? output.authKey : undefined,
-    awsDeviceV2: output.awsDeviceV2 !== undefined && output.awsDeviceV2 !== null ? output.awsDeviceV2 : undefined,
+    addressFamily: __expectString(output.addressFamily),
+    amazonAddress: __expectString(output.amazonAddress),
+    amazonSideAsn: __expectNumber(output.amazonSideAsn),
+    asn: __expectNumber(output.asn),
+    authKey: __expectString(output.authKey),
+    awsDeviceV2: __expectString(output.awsDeviceV2),
     bgpPeers:
       output.bgpPeers !== undefined && output.bgpPeers !== null
         ? deserializeAws_json1_1BGPPeerList(output.bgpPeers, context)
         : undefined,
-    connectionId: output.connectionId !== undefined && output.connectionId !== null ? output.connectionId : undefined,
-    customerAddress:
-      output.customerAddress !== undefined && output.customerAddress !== null ? output.customerAddress : undefined,
-    customerRouterConfig:
-      output.customerRouterConfig !== undefined && output.customerRouterConfig !== null
-        ? output.customerRouterConfig
-        : undefined,
-    directConnectGatewayId:
-      output.directConnectGatewayId !== undefined && output.directConnectGatewayId !== null
-        ? output.directConnectGatewayId
-        : undefined,
-    jumboFrameCapable:
-      output.jumboFrameCapable !== undefined && output.jumboFrameCapable !== null
-        ? output.jumboFrameCapable
-        : undefined,
-    location: output.location !== undefined && output.location !== null ? output.location : undefined,
-    mtu: output.mtu !== undefined && output.mtu !== null ? output.mtu : undefined,
-    ownerAccount: output.ownerAccount !== undefined && output.ownerAccount !== null ? output.ownerAccount : undefined,
-    region: output.region !== undefined && output.region !== null ? output.region : undefined,
+    connectionId: __expectString(output.connectionId),
+    customerAddress: __expectString(output.customerAddress),
+    customerRouterConfig: __expectString(output.customerRouterConfig),
+    directConnectGatewayId: __expectString(output.directConnectGatewayId),
+    jumboFrameCapable: __expectBoolean(output.jumboFrameCapable),
+    location: __expectString(output.location),
+    mtu: __expectNumber(output.mtu),
+    ownerAccount: __expectString(output.ownerAccount),
+    region: __expectString(output.region),
     routeFilterPrefixes:
       output.routeFilterPrefixes !== undefined && output.routeFilterPrefixes !== null
         ? deserializeAws_json1_1RouteFilterPrefixList(output.routeFilterPrefixes, context)
@@ -6957,25 +6835,12 @@ const deserializeAws_json1_1VirtualInterface = (output: any, context: __SerdeCon
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_json1_1TagList(output.tags, context)
         : undefined,
-    virtualGatewayId:
-      output.virtualGatewayId !== undefined && output.virtualGatewayId !== null ? output.virtualGatewayId : undefined,
-    virtualInterfaceId:
-      output.virtualInterfaceId !== undefined && output.virtualInterfaceId !== null
-        ? output.virtualInterfaceId
-        : undefined,
-    virtualInterfaceName:
-      output.virtualInterfaceName !== undefined && output.virtualInterfaceName !== null
-        ? output.virtualInterfaceName
-        : undefined,
-    virtualInterfaceState:
-      output.virtualInterfaceState !== undefined && output.virtualInterfaceState !== null
-        ? output.virtualInterfaceState
-        : undefined,
-    virtualInterfaceType:
-      output.virtualInterfaceType !== undefined && output.virtualInterfaceType !== null
-        ? output.virtualInterfaceType
-        : undefined,
-    vlan: output.vlan !== undefined && output.vlan !== null ? output.vlan : undefined,
+    virtualGatewayId: __expectString(output.virtualGatewayId),
+    virtualInterfaceId: __expectString(output.virtualInterfaceId),
+    virtualInterfaceName: __expectString(output.virtualInterfaceName),
+    virtualInterfaceState: __expectString(output.virtualInterfaceState),
+    virtualInterfaceType: __expectString(output.virtualInterfaceType),
+    vlan: __expectNumber(output.vlan),
   } as any;
 };
 
@@ -7010,21 +6875,15 @@ const deserializeAws_json1_1VirtualInterfaceTestHistory = (
         : undefined,
     endTime:
       output.endTime !== undefined && output.endTime !== null ? new Date(Math.round(output.endTime * 1000)) : undefined,
-    ownerAccount: output.ownerAccount !== undefined && output.ownerAccount !== null ? output.ownerAccount : undefined,
+    ownerAccount: __expectString(output.ownerAccount),
     startTime:
       output.startTime !== undefined && output.startTime !== null
         ? new Date(Math.round(output.startTime * 1000))
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    testDurationInMinutes:
-      output.testDurationInMinutes !== undefined && output.testDurationInMinutes !== null
-        ? output.testDurationInMinutes
-        : undefined,
-    testId: output.testId !== undefined && output.testId !== null ? output.testId : undefined,
-    virtualInterfaceId:
-      output.virtualInterfaceId !== undefined && output.virtualInterfaceId !== null
-        ? output.virtualInterfaceId
-        : undefined,
+    status: __expectString(output.status),
+    testDurationInMinutes: __expectNumber(output.testDurationInMinutes),
+    testId: __expectString(output.testId),
+    virtualInterfaceId: __expectString(output.virtualInterfaceId),
   } as any;
 };
 

--- a/clients/client-directory-service/protocols/Aws_json1_1.ts
+++ b/clients/client-directory-service/protocols/Aws_json1_1.ts
@@ -332,7 +332,12 @@ import {
   VerifyTrustResult,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -8110,8 +8115,8 @@ const deserializeAws_json1_1AcceptSharedDirectoryResult = (
 
 const deserializeAws_json1_1AccessDeniedException = (output: any, context: __SerdeContext): AccessDeniedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
+    Message: __expectString(output.Message),
+    RequestId: __expectString(output.RequestId),
   } as any;
 };
 
@@ -8126,7 +8131,7 @@ const deserializeAws_json1_1AdditionalRegions = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -8143,8 +8148,8 @@ const deserializeAws_json1_1AddTagsToResourceResult = (
 
 const deserializeAws_json1_1Attribute = (output: any, context: __SerdeContext): Attribute => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Name: __expectString(output.Name),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -8164,8 +8169,8 @@ const deserializeAws_json1_1AuthenticationFailedException = (
   context: __SerdeContext
 ): AuthenticationFailedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
+    Message: __expectString(output.Message),
+    RequestId: __expectString(output.RequestId),
   } as any;
 };
 
@@ -8176,7 +8181,7 @@ const deserializeAws_json1_1AvailabilityZones = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -8189,13 +8194,12 @@ const deserializeAws_json1_1CancelSchemaExtensionResult = (
 
 const deserializeAws_json1_1Certificate = (output: any, context: __SerdeContext): Certificate => {
   return {
-    CertificateId:
-      output.CertificateId !== undefined && output.CertificateId !== null ? output.CertificateId : undefined,
+    CertificateId: __expectString(output.CertificateId),
     ClientCertAuthSettings:
       output.ClientCertAuthSettings !== undefined && output.ClientCertAuthSettings !== null
         ? deserializeAws_json1_1ClientCertAuthSettings(output.ClientCertAuthSettings, context)
         : undefined,
-    CommonName: output.CommonName !== undefined && output.CommonName !== null ? output.CommonName : undefined,
+    CommonName: __expectString(output.CommonName),
     ExpiryDateTime:
       output.ExpiryDateTime !== undefined && output.ExpiryDateTime !== null
         ? new Date(Math.round(output.ExpiryDateTime * 1000))
@@ -8204,9 +8208,9 @@ const deserializeAws_json1_1Certificate = (output: any, context: __SerdeContext)
       output.RegisteredDateTime !== undefined && output.RegisteredDateTime !== null
         ? new Date(Math.round(output.RegisteredDateTime * 1000))
         : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    StateReason: output.StateReason !== undefined && output.StateReason !== null ? output.StateReason : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    State: __expectString(output.State),
+    StateReason: __expectString(output.StateReason),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -8215,8 +8219,8 @@ const deserializeAws_json1_1CertificateAlreadyExistsException = (
   context: __SerdeContext
 ): CertificateAlreadyExistsException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
+    Message: __expectString(output.Message),
+    RequestId: __expectString(output.RequestId),
   } as any;
 };
 
@@ -8225,22 +8229,21 @@ const deserializeAws_json1_1CertificateDoesNotExistException = (
   context: __SerdeContext
 ): CertificateDoesNotExistException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
+    Message: __expectString(output.Message),
+    RequestId: __expectString(output.RequestId),
   } as any;
 };
 
 const deserializeAws_json1_1CertificateInfo = (output: any, context: __SerdeContext): CertificateInfo => {
   return {
-    CertificateId:
-      output.CertificateId !== undefined && output.CertificateId !== null ? output.CertificateId : undefined,
-    CommonName: output.CommonName !== undefined && output.CommonName !== null ? output.CommonName : undefined,
+    CertificateId: __expectString(output.CertificateId),
+    CommonName: __expectString(output.CommonName),
     ExpiryDateTime:
       output.ExpiryDateTime !== undefined && output.ExpiryDateTime !== null
         ? new Date(Math.round(output.ExpiryDateTime * 1000))
         : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    State: __expectString(output.State),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -8249,8 +8252,8 @@ const deserializeAws_json1_1CertificateInUseException = (
   context: __SerdeContext
 ): CertificateInUseException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
+    Message: __expectString(output.Message),
+    RequestId: __expectString(output.RequestId),
   } as any;
 };
 
@@ -8259,8 +8262,8 @@ const deserializeAws_json1_1CertificateLimitExceededException = (
   context: __SerdeContext
 ): CertificateLimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
+    Message: __expectString(output.Message),
+    RequestId: __expectString(output.RequestId),
   } as any;
 };
 
@@ -8277,14 +8280,14 @@ const deserializeAws_json1_1CertificatesInfo = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1ClientCertAuthSettings = (output: any, context: __SerdeContext): ClientCertAuthSettings => {
   return {
-    OCSPUrl: output.OCSPUrl !== undefined && output.OCSPUrl !== null ? output.OCSPUrl : undefined,
+    OCSPUrl: __expectString(output.OCSPUrl),
   } as any;
 };
 
 const deserializeAws_json1_1ClientException = (output: any, context: __SerdeContext): ClientException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
+    Message: __expectString(output.Message),
+    RequestId: __expectString(output.RequestId),
   } as any;
 };
 
@@ -8294,8 +8297,8 @@ const deserializeAws_json1_1Computer = (output: any, context: __SerdeContext): C
       output.ComputerAttributes !== undefined && output.ComputerAttributes !== null
         ? deserializeAws_json1_1Attributes(output.ComputerAttributes, context)
         : undefined,
-    ComputerId: output.ComputerId !== undefined && output.ComputerId !== null ? output.ComputerId : undefined,
-    ComputerName: output.ComputerName !== undefined && output.ComputerName !== null ? output.ComputerName : undefined,
+    ComputerId: __expectString(output.ComputerId),
+    ComputerName: __expectString(output.ComputerName),
   } as any;
 };
 
@@ -8305,10 +8308,8 @@ const deserializeAws_json1_1ConditionalForwarder = (output: any, context: __Serd
       output.DnsIpAddrs !== undefined && output.DnsIpAddrs !== null
         ? deserializeAws_json1_1DnsIpAddrs(output.DnsIpAddrs, context)
         : undefined,
-    RemoteDomainName:
-      output.RemoteDomainName !== undefined && output.RemoteDomainName !== null ? output.RemoteDomainName : undefined,
-    ReplicationScope:
-      output.ReplicationScope !== undefined && output.ReplicationScope !== null ? output.ReplicationScope : undefined,
+    RemoteDomainName: __expectString(output.RemoteDomainName),
+    ReplicationScope: __expectString(output.ReplicationScope),
   } as any;
 };
 
@@ -8325,14 +8326,14 @@ const deserializeAws_json1_1ConditionalForwarders = (output: any, context: __Ser
 
 const deserializeAws_json1_1ConnectDirectoryResult = (output: any, context: __SerdeContext): ConnectDirectoryResult => {
   return {
-    DirectoryId: output.DirectoryId !== undefined && output.DirectoryId !== null ? output.DirectoryId : undefined,
+    DirectoryId: __expectString(output.DirectoryId),
   } as any;
 };
 
 const deserializeAws_json1_1CreateAliasResult = (output: any, context: __SerdeContext): CreateAliasResult => {
   return {
-    Alias: output.Alias !== undefined && output.Alias !== null ? output.Alias : undefined,
-    DirectoryId: output.DirectoryId !== undefined && output.DirectoryId !== null ? output.DirectoryId : undefined,
+    Alias: __expectString(output.Alias),
+    DirectoryId: __expectString(output.DirectoryId),
   } as any;
 };
 
@@ -8354,7 +8355,7 @@ const deserializeAws_json1_1CreateConditionalForwarderResult = (
 
 const deserializeAws_json1_1CreateDirectoryResult = (output: any, context: __SerdeContext): CreateDirectoryResult => {
   return {
-    DirectoryId: output.DirectoryId !== undefined && output.DirectoryId !== null ? output.DirectoryId : undefined,
+    DirectoryId: __expectString(output.DirectoryId),
   } as any;
 };
 
@@ -8370,19 +8371,19 @@ const deserializeAws_json1_1CreateMicrosoftADResult = (
   context: __SerdeContext
 ): CreateMicrosoftADResult => {
   return {
-    DirectoryId: output.DirectoryId !== undefined && output.DirectoryId !== null ? output.DirectoryId : undefined,
+    DirectoryId: __expectString(output.DirectoryId),
   } as any;
 };
 
 const deserializeAws_json1_1CreateSnapshotResult = (output: any, context: __SerdeContext): CreateSnapshotResult => {
   return {
-    SnapshotId: output.SnapshotId !== undefined && output.SnapshotId !== null ? output.SnapshotId : undefined,
+    SnapshotId: __expectString(output.SnapshotId),
   } as any;
 };
 
 const deserializeAws_json1_1CreateTrustResult = (output: any, context: __SerdeContext): CreateTrustResult => {
   return {
-    TrustId: output.TrustId !== undefined && output.TrustId !== null ? output.TrustId : undefined,
+    TrustId: __expectString(output.TrustId),
   } as any;
 };
 
@@ -8395,7 +8396,7 @@ const deserializeAws_json1_1DeleteConditionalForwarderResult = (
 
 const deserializeAws_json1_1DeleteDirectoryResult = (output: any, context: __SerdeContext): DeleteDirectoryResult => {
   return {
-    DirectoryId: output.DirectoryId !== undefined && output.DirectoryId !== null ? output.DirectoryId : undefined,
+    DirectoryId: __expectString(output.DirectoryId),
   } as any;
 };
 
@@ -8408,13 +8409,13 @@ const deserializeAws_json1_1DeleteLogSubscriptionResult = (
 
 const deserializeAws_json1_1DeleteSnapshotResult = (output: any, context: __SerdeContext): DeleteSnapshotResult => {
   return {
-    SnapshotId: output.SnapshotId !== undefined && output.SnapshotId !== null ? output.SnapshotId : undefined,
+    SnapshotId: __expectString(output.SnapshotId),
   } as any;
 };
 
 const deserializeAws_json1_1DeleteTrustResult = (output: any, context: __SerdeContext): DeleteTrustResult => {
   return {
-    TrustId: output.TrustId !== undefined && output.TrustId !== null ? output.TrustId : undefined,
+    TrustId: __expectString(output.TrustId),
   } as any;
 };
 
@@ -8465,7 +8466,7 @@ const deserializeAws_json1_1DescribeDirectoriesResult = (
       output.DirectoryDescriptions !== undefined && output.DirectoryDescriptions !== null
         ? deserializeAws_json1_1DirectoryDescriptions(output.DirectoryDescriptions, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -8478,7 +8479,7 @@ const deserializeAws_json1_1DescribeDomainControllersResult = (
       output.DomainControllers !== undefined && output.DomainControllers !== null
         ? deserializeAws_json1_1DomainControllers(output.DomainControllers, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -8503,13 +8504,13 @@ const deserializeAws_json1_1DescribeLDAPSSettingsResult = (
       output.LDAPSSettingsInfo !== undefined && output.LDAPSSettingsInfo !== null
         ? deserializeAws_json1_1LDAPSSettingsInfo(output.LDAPSSettingsInfo, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
 const deserializeAws_json1_1DescribeRegionsResult = (output: any, context: __SerdeContext): DescribeRegionsResult => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     RegionsDescription:
       output.RegionsDescription !== undefined && output.RegionsDescription !== null
         ? deserializeAws_json1_1RegionsDescription(output.RegionsDescription, context)
@@ -8522,7 +8523,7 @@ const deserializeAws_json1_1DescribeSharedDirectoriesResult = (
   context: __SerdeContext
 ): DescribeSharedDirectoriesResult => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     SharedDirectories:
       output.SharedDirectories !== undefined && output.SharedDirectories !== null
         ? deserializeAws_json1_1SharedDirectories(output.SharedDirectories, context)
@@ -8535,7 +8536,7 @@ const deserializeAws_json1_1DescribeSnapshotsResult = (
   context: __SerdeContext
 ): DescribeSnapshotsResult => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Snapshots:
       output.Snapshots !== undefined && output.Snapshots !== null
         ? deserializeAws_json1_1Snapshots(output.Snapshots, context)
@@ -8545,7 +8546,7 @@ const deserializeAws_json1_1DescribeSnapshotsResult = (
 
 const deserializeAws_json1_1DescribeTrustsResult = (output: any, context: __SerdeContext): DescribeTrustsResult => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Trusts:
       output.Trusts !== undefined && output.Trusts !== null
         ? deserializeAws_json1_1Trusts(output.Trusts, context)
@@ -8558,8 +8559,8 @@ const deserializeAws_json1_1DirectoryAlreadyInRegionException = (
   context: __SerdeContext
 ): DirectoryAlreadyInRegionException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
+    Message: __expectString(output.Message),
+    RequestId: __expectString(output.RequestId),
   } as any;
 };
 
@@ -8568,8 +8569,8 @@ const deserializeAws_json1_1DirectoryAlreadySharedException = (
   context: __SerdeContext
 ): DirectoryAlreadySharedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
+    Message: __expectString(output.Message),
+    RequestId: __expectString(output.RequestId),
   } as any;
 };
 
@@ -8586,42 +8587,37 @@ const deserializeAws_json1_1DirectoryConnectSettingsDescription = (
       output.ConnectIps !== undefined && output.ConnectIps !== null
         ? deserializeAws_json1_1IpAddrs(output.ConnectIps, context)
         : undefined,
-    CustomerUserName:
-      output.CustomerUserName !== undefined && output.CustomerUserName !== null ? output.CustomerUserName : undefined,
-    SecurityGroupId:
-      output.SecurityGroupId !== undefined && output.SecurityGroupId !== null ? output.SecurityGroupId : undefined,
+    CustomerUserName: __expectString(output.CustomerUserName),
+    SecurityGroupId: __expectString(output.SecurityGroupId),
     SubnetIds:
       output.SubnetIds !== undefined && output.SubnetIds !== null
         ? deserializeAws_json1_1SubnetIds(output.SubnetIds, context)
         : undefined,
-    VpcId: output.VpcId !== undefined && output.VpcId !== null ? output.VpcId : undefined,
+    VpcId: __expectString(output.VpcId),
   } as any;
 };
 
 const deserializeAws_json1_1DirectoryDescription = (output: any, context: __SerdeContext): DirectoryDescription => {
   return {
-    AccessUrl: output.AccessUrl !== undefined && output.AccessUrl !== null ? output.AccessUrl : undefined,
-    Alias: output.Alias !== undefined && output.Alias !== null ? output.Alias : undefined,
+    AccessUrl: __expectString(output.AccessUrl),
+    Alias: __expectString(output.Alias),
     ConnectSettings:
       output.ConnectSettings !== undefined && output.ConnectSettings !== null
         ? deserializeAws_json1_1DirectoryConnectSettingsDescription(output.ConnectSettings, context)
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    DesiredNumberOfDomainControllers:
-      output.DesiredNumberOfDomainControllers !== undefined && output.DesiredNumberOfDomainControllers !== null
-        ? output.DesiredNumberOfDomainControllers
-        : undefined,
-    DirectoryId: output.DirectoryId !== undefined && output.DirectoryId !== null ? output.DirectoryId : undefined,
+    Description: __expectString(output.Description),
+    DesiredNumberOfDomainControllers: __expectNumber(output.DesiredNumberOfDomainControllers),
+    DirectoryId: __expectString(output.DirectoryId),
     DnsIpAddrs:
       output.DnsIpAddrs !== undefined && output.DnsIpAddrs !== null
         ? deserializeAws_json1_1DnsIpAddrs(output.DnsIpAddrs, context)
         : undefined,
-    Edition: output.Edition !== undefined && output.Edition !== null ? output.Edition : undefined,
+    Edition: __expectString(output.Edition),
     LaunchTime:
       output.LaunchTime !== undefined && output.LaunchTime !== null
         ? new Date(Math.round(output.LaunchTime * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     OwnerDirectoryDescription:
       output.OwnerDirectoryDescription !== undefined && output.OwnerDirectoryDescription !== null
         ? deserializeAws_json1_1OwnerDirectoryDescription(output.OwnerDirectoryDescription, context)
@@ -8630,24 +8626,24 @@ const deserializeAws_json1_1DirectoryDescription = (output: any, context: __Serd
       output.RadiusSettings !== undefined && output.RadiusSettings !== null
         ? deserializeAws_json1_1RadiusSettings(output.RadiusSettings, context)
         : undefined,
-    RadiusStatus: output.RadiusStatus !== undefined && output.RadiusStatus !== null ? output.RadiusStatus : undefined,
+    RadiusStatus: __expectString(output.RadiusStatus),
     RegionsInfo:
       output.RegionsInfo !== undefined && output.RegionsInfo !== null
         ? deserializeAws_json1_1RegionsInfo(output.RegionsInfo, context)
         : undefined,
-    ShareMethod: output.ShareMethod !== undefined && output.ShareMethod !== null ? output.ShareMethod : undefined,
-    ShareNotes: output.ShareNotes !== undefined && output.ShareNotes !== null ? output.ShareNotes : undefined,
-    ShareStatus: output.ShareStatus !== undefined && output.ShareStatus !== null ? output.ShareStatus : undefined,
-    ShortName: output.ShortName !== undefined && output.ShortName !== null ? output.ShortName : undefined,
-    Size: output.Size !== undefined && output.Size !== null ? output.Size : undefined,
-    SsoEnabled: output.SsoEnabled !== undefined && output.SsoEnabled !== null ? output.SsoEnabled : undefined,
-    Stage: output.Stage !== undefined && output.Stage !== null ? output.Stage : undefined,
+    ShareMethod: __expectString(output.ShareMethod),
+    ShareNotes: __expectString(output.ShareNotes),
+    ShareStatus: __expectString(output.ShareStatus),
+    ShortName: __expectString(output.ShortName),
+    Size: __expectString(output.Size),
+    SsoEnabled: __expectBoolean(output.SsoEnabled),
+    Stage: __expectString(output.Stage),
     StageLastUpdatedDateTime:
       output.StageLastUpdatedDateTime !== undefined && output.StageLastUpdatedDateTime !== null
         ? new Date(Math.round(output.StageLastUpdatedDateTime * 1000))
         : undefined,
-    StageReason: output.StageReason !== undefined && output.StageReason !== null ? output.StageReason : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    StageReason: __expectString(output.StageReason),
+    Type: __expectString(output.Type),
     VpcSettings:
       output.VpcSettings !== undefined && output.VpcSettings !== null
         ? deserializeAws_json1_1DirectoryVpcSettingsDescription(output.VpcSettings, context)
@@ -8671,8 +8667,8 @@ const deserializeAws_json1_1DirectoryDoesNotExistException = (
   context: __SerdeContext
 ): DirectoryDoesNotExistException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
+    Message: __expectString(output.Message),
+    RequestId: __expectString(output.RequestId),
   } as any;
 };
 
@@ -8681,49 +8677,22 @@ const deserializeAws_json1_1DirectoryLimitExceededException = (
   context: __SerdeContext
 ): DirectoryLimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
+    Message: __expectString(output.Message),
+    RequestId: __expectString(output.RequestId),
   } as any;
 };
 
 const deserializeAws_json1_1DirectoryLimits = (output: any, context: __SerdeContext): DirectoryLimits => {
   return {
-    CloudOnlyDirectoriesCurrentCount:
-      output.CloudOnlyDirectoriesCurrentCount !== undefined && output.CloudOnlyDirectoriesCurrentCount !== null
-        ? output.CloudOnlyDirectoriesCurrentCount
-        : undefined,
-    CloudOnlyDirectoriesLimit:
-      output.CloudOnlyDirectoriesLimit !== undefined && output.CloudOnlyDirectoriesLimit !== null
-        ? output.CloudOnlyDirectoriesLimit
-        : undefined,
-    CloudOnlyDirectoriesLimitReached:
-      output.CloudOnlyDirectoriesLimitReached !== undefined && output.CloudOnlyDirectoriesLimitReached !== null
-        ? output.CloudOnlyDirectoriesLimitReached
-        : undefined,
-    CloudOnlyMicrosoftADCurrentCount:
-      output.CloudOnlyMicrosoftADCurrentCount !== undefined && output.CloudOnlyMicrosoftADCurrentCount !== null
-        ? output.CloudOnlyMicrosoftADCurrentCount
-        : undefined,
-    CloudOnlyMicrosoftADLimit:
-      output.CloudOnlyMicrosoftADLimit !== undefined && output.CloudOnlyMicrosoftADLimit !== null
-        ? output.CloudOnlyMicrosoftADLimit
-        : undefined,
-    CloudOnlyMicrosoftADLimitReached:
-      output.CloudOnlyMicrosoftADLimitReached !== undefined && output.CloudOnlyMicrosoftADLimitReached !== null
-        ? output.CloudOnlyMicrosoftADLimitReached
-        : undefined,
-    ConnectedDirectoriesCurrentCount:
-      output.ConnectedDirectoriesCurrentCount !== undefined && output.ConnectedDirectoriesCurrentCount !== null
-        ? output.ConnectedDirectoriesCurrentCount
-        : undefined,
-    ConnectedDirectoriesLimit:
-      output.ConnectedDirectoriesLimit !== undefined && output.ConnectedDirectoriesLimit !== null
-        ? output.ConnectedDirectoriesLimit
-        : undefined,
-    ConnectedDirectoriesLimitReached:
-      output.ConnectedDirectoriesLimitReached !== undefined && output.ConnectedDirectoriesLimitReached !== null
-        ? output.ConnectedDirectoriesLimitReached
-        : undefined,
+    CloudOnlyDirectoriesCurrentCount: __expectNumber(output.CloudOnlyDirectoriesCurrentCount),
+    CloudOnlyDirectoriesLimit: __expectNumber(output.CloudOnlyDirectoriesLimit),
+    CloudOnlyDirectoriesLimitReached: __expectBoolean(output.CloudOnlyDirectoriesLimitReached),
+    CloudOnlyMicrosoftADCurrentCount: __expectNumber(output.CloudOnlyMicrosoftADCurrentCount),
+    CloudOnlyMicrosoftADLimit: __expectNumber(output.CloudOnlyMicrosoftADLimit),
+    CloudOnlyMicrosoftADLimitReached: __expectBoolean(output.CloudOnlyMicrosoftADLimitReached),
+    ConnectedDirectoriesCurrentCount: __expectNumber(output.ConnectedDirectoriesCurrentCount),
+    ConnectedDirectoriesLimit: __expectNumber(output.ConnectedDirectoriesLimit),
+    ConnectedDirectoriesLimitReached: __expectBoolean(output.ConnectedDirectoriesLimitReached),
   } as any;
 };
 
@@ -8732,8 +8701,8 @@ const deserializeAws_json1_1DirectoryNotSharedException = (
   context: __SerdeContext
 ): DirectoryNotSharedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
+    Message: __expectString(output.Message),
+    RequestId: __expectString(output.RequestId),
   } as any;
 };
 
@@ -8742,8 +8711,8 @@ const deserializeAws_json1_1DirectoryUnavailableException = (
   context: __SerdeContext
 ): DirectoryUnavailableException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
+    Message: __expectString(output.Message),
+    RequestId: __expectString(output.RequestId),
   } as any;
 };
 
@@ -8753,7 +8722,7 @@ const deserializeAws_json1_1DirectoryVpcSettings = (output: any, context: __Serd
       output.SubnetIds !== undefined && output.SubnetIds !== null
         ? deserializeAws_json1_1SubnetIds(output.SubnetIds, context)
         : undefined,
-    VpcId: output.VpcId !== undefined && output.VpcId !== null ? output.VpcId : undefined,
+    VpcId: __expectString(output.VpcId),
   } as any;
 };
 
@@ -8766,13 +8735,12 @@ const deserializeAws_json1_1DirectoryVpcSettingsDescription = (
       output.AvailabilityZones !== undefined && output.AvailabilityZones !== null
         ? deserializeAws_json1_1AvailabilityZones(output.AvailabilityZones, context)
         : undefined,
-    SecurityGroupId:
-      output.SecurityGroupId !== undefined && output.SecurityGroupId !== null ? output.SecurityGroupId : undefined,
+    SecurityGroupId: __expectString(output.SecurityGroupId),
     SubnetIds:
       output.SubnetIds !== undefined && output.SubnetIds !== null
         ? deserializeAws_json1_1SubnetIds(output.SubnetIds, context)
         : undefined,
-    VpcId: output.VpcId !== undefined && output.VpcId !== null ? output.VpcId : undefined,
+    VpcId: __expectString(output.VpcId),
   } as any;
 };
 
@@ -8802,32 +8770,28 @@ const deserializeAws_json1_1DnsIpAddrs = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1DomainController = (output: any, context: __SerdeContext): DomainController => {
   return {
-    AvailabilityZone:
-      output.AvailabilityZone !== undefined && output.AvailabilityZone !== null ? output.AvailabilityZone : undefined,
-    DirectoryId: output.DirectoryId !== undefined && output.DirectoryId !== null ? output.DirectoryId : undefined,
-    DnsIpAddr: output.DnsIpAddr !== undefined && output.DnsIpAddr !== null ? output.DnsIpAddr : undefined,
-    DomainControllerId:
-      output.DomainControllerId !== undefined && output.DomainControllerId !== null
-        ? output.DomainControllerId
-        : undefined,
+    AvailabilityZone: __expectString(output.AvailabilityZone),
+    DirectoryId: __expectString(output.DirectoryId),
+    DnsIpAddr: __expectString(output.DnsIpAddr),
+    DomainControllerId: __expectString(output.DomainControllerId),
     LaunchTime:
       output.LaunchTime !== undefined && output.LaunchTime !== null
         ? new Date(Math.round(output.LaunchTime * 1000))
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
     StatusLastUpdatedDateTime:
       output.StatusLastUpdatedDateTime !== undefined && output.StatusLastUpdatedDateTime !== null
         ? new Date(Math.round(output.StatusLastUpdatedDateTime * 1000))
         : undefined,
-    StatusReason: output.StatusReason !== undefined && output.StatusReason !== null ? output.StatusReason : undefined,
-    SubnetId: output.SubnetId !== undefined && output.SubnetId !== null ? output.SubnetId : undefined,
-    VpcId: output.VpcId !== undefined && output.VpcId !== null ? output.VpcId : undefined,
+    StatusReason: __expectString(output.StatusReason),
+    SubnetId: __expectString(output.SubnetId),
+    VpcId: __expectString(output.VpcId),
   } as any;
 };
 
@@ -8836,8 +8800,8 @@ const deserializeAws_json1_1DomainControllerLimitExceededException = (
   context: __SerdeContext
 ): DomainControllerLimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
+    Message: __expectString(output.Message),
+    RequestId: __expectString(output.RequestId),
   } as any;
 };
 
@@ -8876,8 +8840,8 @@ const deserializeAws_json1_1EntityAlreadyExistsException = (
   context: __SerdeContext
 ): EntityAlreadyExistsException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
+    Message: __expectString(output.Message),
+    RequestId: __expectString(output.RequestId),
   } as any;
 };
 
@@ -8886,8 +8850,8 @@ const deserializeAws_json1_1EntityDoesNotExistException = (
   context: __SerdeContext
 ): EntityDoesNotExistException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
+    Message: __expectString(output.Message),
+    RequestId: __expectString(output.RequestId),
   } as any;
 };
 
@@ -8897,10 +8861,10 @@ const deserializeAws_json1_1EventTopic = (output: any, context: __SerdeContext):
       output.CreatedDateTime !== undefined && output.CreatedDateTime !== null
         ? new Date(Math.round(output.CreatedDateTime * 1000))
         : undefined,
-    DirectoryId: output.DirectoryId !== undefined && output.DirectoryId !== null ? output.DirectoryId : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    TopicArn: output.TopicArn !== undefined && output.TopicArn !== null ? output.TopicArn : undefined,
-    TopicName: output.TopicName !== undefined && output.TopicName !== null ? output.TopicName : undefined,
+    DirectoryId: __expectString(output.DirectoryId),
+    Status: __expectString(output.Status),
+    TopicArn: __expectString(output.TopicArn),
+    TopicName: __expectString(output.TopicName),
   } as any;
 };
 
@@ -8944,8 +8908,8 @@ const deserializeAws_json1_1InsufficientPermissionsException = (
   context: __SerdeContext
 ): InsufficientPermissionsException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
+    Message: __expectString(output.Message),
+    RequestId: __expectString(output.RequestId),
   } as any;
 };
 
@@ -8954,8 +8918,8 @@ const deserializeAws_json1_1InvalidCertificateException = (
   context: __SerdeContext
 ): InvalidCertificateException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
+    Message: __expectString(output.Message),
+    RequestId: __expectString(output.RequestId),
   } as any;
 };
 
@@ -8964,8 +8928,8 @@ const deserializeAws_json1_1InvalidClientAuthStatusException = (
   context: __SerdeContext
 ): InvalidClientAuthStatusException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
+    Message: __expectString(output.Message),
+    RequestId: __expectString(output.RequestId),
   } as any;
 };
 
@@ -8974,8 +8938,8 @@ const deserializeAws_json1_1InvalidLDAPSStatusException = (
   context: __SerdeContext
 ): InvalidLDAPSStatusException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
+    Message: __expectString(output.Message),
+    RequestId: __expectString(output.RequestId),
   } as any;
 };
 
@@ -8984,8 +8948,8 @@ const deserializeAws_json1_1InvalidNextTokenException = (
   context: __SerdeContext
 ): InvalidNextTokenException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
+    Message: __expectString(output.Message),
+    RequestId: __expectString(output.RequestId),
   } as any;
 };
 
@@ -8994,8 +8958,8 @@ const deserializeAws_json1_1InvalidParameterException = (
   context: __SerdeContext
 ): InvalidParameterException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
+    Message: __expectString(output.Message),
+    RequestId: __expectString(output.RequestId),
   } as any;
 };
 
@@ -9004,15 +8968,15 @@ const deserializeAws_json1_1InvalidPasswordException = (
   context: __SerdeContext
 ): InvalidPasswordException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
+    Message: __expectString(output.Message),
+    RequestId: __expectString(output.RequestId),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidTargetException = (output: any, context: __SerdeContext): InvalidTargetException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
+    Message: __expectString(output.Message),
+    RequestId: __expectString(output.RequestId),
   } as any;
 };
 
@@ -9023,7 +8987,7 @@ const deserializeAws_json1_1IpAddrs = (output: any, context: __SerdeContext): st
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -9033,15 +8997,11 @@ const deserializeAws_json1_1IpRouteInfo = (output: any, context: __SerdeContext)
       output.AddedDateTime !== undefined && output.AddedDateTime !== null
         ? new Date(Math.round(output.AddedDateTime * 1000))
         : undefined,
-    CidrIp: output.CidrIp !== undefined && output.CidrIp !== null ? output.CidrIp : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    DirectoryId: output.DirectoryId !== undefined && output.DirectoryId !== null ? output.DirectoryId : undefined,
-    IpRouteStatusMsg:
-      output.IpRouteStatusMsg !== undefined && output.IpRouteStatusMsg !== null ? output.IpRouteStatusMsg : undefined,
-    IpRouteStatusReason:
-      output.IpRouteStatusReason !== undefined && output.IpRouteStatusReason !== null
-        ? output.IpRouteStatusReason
-        : undefined,
+    CidrIp: __expectString(output.CidrIp),
+    Description: __expectString(output.Description),
+    DirectoryId: __expectString(output.DirectoryId),
+    IpRouteStatusMsg: __expectString(output.IpRouteStatusMsg),
+    IpRouteStatusReason: __expectString(output.IpRouteStatusReason),
   } as any;
 };
 
@@ -9050,8 +9010,8 @@ const deserializeAws_json1_1IpRouteLimitExceededException = (
   context: __SerdeContext
 ): IpRouteLimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
+    Message: __expectString(output.Message),
+    RequestId: __expectString(output.RequestId),
   } as any;
 };
 
@@ -9068,11 +9028,8 @@ const deserializeAws_json1_1IpRoutesInfo = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_1LDAPSSettingInfo = (output: any, context: __SerdeContext): LDAPSSettingInfo => {
   return {
-    LDAPSStatus: output.LDAPSStatus !== undefined && output.LDAPSStatus !== null ? output.LDAPSStatus : undefined,
-    LDAPSStatusReason:
-      output.LDAPSStatusReason !== undefined && output.LDAPSStatusReason !== null
-        ? output.LDAPSStatusReason
-        : undefined,
+    LDAPSStatus: __expectString(output.LDAPSStatus),
+    LDAPSStatusReason: __expectString(output.LDAPSStatusReason),
     LastUpdatedDateTime:
       output.LastUpdatedDateTime !== undefined && output.LastUpdatedDateTime !== null
         ? new Date(Math.round(output.LastUpdatedDateTime * 1000))
@@ -9097,7 +9054,7 @@ const deserializeAws_json1_1ListCertificatesResult = (output: any, context: __Se
       output.CertificatesInfo !== undefined && output.CertificatesInfo !== null
         ? deserializeAws_json1_1CertificatesInfo(output.CertificatesInfo, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -9107,7 +9064,7 @@ const deserializeAws_json1_1ListIpRoutesResult = (output: any, context: __SerdeC
       output.IpRoutesInfo !== undefined && output.IpRoutesInfo !== null
         ? deserializeAws_json1_1IpRoutesInfo(output.IpRoutesInfo, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -9120,7 +9077,7 @@ const deserializeAws_json1_1ListLogSubscriptionsResult = (
       output.LogSubscriptions !== undefined && output.LogSubscriptions !== null
         ? deserializeAws_json1_1LogSubscriptions(output.LogSubscriptions, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -9129,7 +9086,7 @@ const deserializeAws_json1_1ListSchemaExtensionsResult = (
   context: __SerdeContext
 ): ListSchemaExtensionsResult => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     SchemaExtensionsInfo:
       output.SchemaExtensionsInfo !== undefined && output.SchemaExtensionsInfo !== null
         ? deserializeAws_json1_1SchemaExtensionsInfo(output.SchemaExtensionsInfo, context)
@@ -9142,7 +9099,7 @@ const deserializeAws_json1_1ListTagsForResourceResult = (
   context: __SerdeContext
 ): ListTagsForResourceResult => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Tags:
       output.Tags !== undefined && output.Tags !== null ? deserializeAws_json1_1Tags(output.Tags, context) : undefined,
   } as any;
@@ -9150,8 +9107,8 @@ const deserializeAws_json1_1ListTagsForResourceResult = (
 
 const deserializeAws_json1_1LogSubscription = (output: any, context: __SerdeContext): LogSubscription => {
   return {
-    DirectoryId: output.DirectoryId !== undefined && output.DirectoryId !== null ? output.DirectoryId : undefined,
-    LogGroupName: output.LogGroupName !== undefined && output.LogGroupName !== null ? output.LogGroupName : undefined,
+    DirectoryId: __expectString(output.DirectoryId),
+    LogGroupName: __expectString(output.LogGroupName),
     SubscriptionCreatedDateTime:
       output.SubscriptionCreatedDateTime !== undefined && output.SubscriptionCreatedDateTime !== null
         ? new Date(Math.round(output.SubscriptionCreatedDateTime * 1000))
@@ -9175,15 +9132,15 @@ const deserializeAws_json1_1NoAvailableCertificateException = (
   context: __SerdeContext
 ): NoAvailableCertificateException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
+    Message: __expectString(output.Message),
+    RequestId: __expectString(output.RequestId),
   } as any;
 };
 
 const deserializeAws_json1_1OrganizationsException = (output: any, context: __SerdeContext): OrganizationsException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
+    Message: __expectString(output.Message),
+    RequestId: __expectString(output.RequestId),
   } as any;
 };
 
@@ -9192,8 +9149,8 @@ const deserializeAws_json1_1OwnerDirectoryDescription = (
   context: __SerdeContext
 ): OwnerDirectoryDescription => {
   return {
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
-    DirectoryId: output.DirectoryId !== undefined && output.DirectoryId !== null ? output.DirectoryId : undefined,
+    AccountId: __expectString(output.AccountId),
+    DirectoryId: __expectString(output.DirectoryId),
     DnsIpAddrs:
       output.DnsIpAddrs !== undefined && output.DnsIpAddrs !== null
         ? deserializeAws_json1_1DnsIpAddrs(output.DnsIpAddrs, context)
@@ -9202,7 +9159,7 @@ const deserializeAws_json1_1OwnerDirectoryDescription = (
       output.RadiusSettings !== undefined && output.RadiusSettings !== null
         ? deserializeAws_json1_1RadiusSettings(output.RadiusSettings, context)
         : undefined,
-    RadiusStatus: output.RadiusStatus !== undefined && output.RadiusStatus !== null ? output.RadiusStatus : undefined,
+    RadiusStatus: __expectString(output.RadiusStatus),
     VpcSettings:
       output.VpcSettings !== undefined && output.VpcSettings !== null
         ? deserializeAws_json1_1DirectoryVpcSettingsDescription(output.VpcSettings, context)
@@ -9212,33 +9169,24 @@ const deserializeAws_json1_1OwnerDirectoryDescription = (
 
 const deserializeAws_json1_1RadiusSettings = (output: any, context: __SerdeContext): RadiusSettings => {
   return {
-    AuthenticationProtocol:
-      output.AuthenticationProtocol !== undefined && output.AuthenticationProtocol !== null
-        ? output.AuthenticationProtocol
-        : undefined,
-    DisplayLabel: output.DisplayLabel !== undefined && output.DisplayLabel !== null ? output.DisplayLabel : undefined,
-    RadiusPort: output.RadiusPort !== undefined && output.RadiusPort !== null ? output.RadiusPort : undefined,
-    RadiusRetries:
-      output.RadiusRetries !== undefined && output.RadiusRetries !== null ? output.RadiusRetries : undefined,
+    AuthenticationProtocol: __expectString(output.AuthenticationProtocol),
+    DisplayLabel: __expectString(output.DisplayLabel),
+    RadiusPort: __expectNumber(output.RadiusPort),
+    RadiusRetries: __expectNumber(output.RadiusRetries),
     RadiusServers:
       output.RadiusServers !== undefined && output.RadiusServers !== null
         ? deserializeAws_json1_1Servers(output.RadiusServers, context)
         : undefined,
-    RadiusTimeout:
-      output.RadiusTimeout !== undefined && output.RadiusTimeout !== null ? output.RadiusTimeout : undefined,
-    SharedSecret: output.SharedSecret !== undefined && output.SharedSecret !== null ? output.SharedSecret : undefined,
-    UseSameUsername:
-      output.UseSameUsername !== undefined && output.UseSameUsername !== null ? output.UseSameUsername : undefined,
+    RadiusTimeout: __expectNumber(output.RadiusTimeout),
+    SharedSecret: __expectString(output.SharedSecret),
+    UseSameUsername: __expectBoolean(output.UseSameUsername),
   } as any;
 };
 
 const deserializeAws_json1_1RegionDescription = (output: any, context: __SerdeContext): RegionDescription => {
   return {
-    DesiredNumberOfDomainControllers:
-      output.DesiredNumberOfDomainControllers !== undefined && output.DesiredNumberOfDomainControllers !== null
-        ? output.DesiredNumberOfDomainControllers
-        : undefined,
-    DirectoryId: output.DirectoryId !== undefined && output.DirectoryId !== null ? output.DirectoryId : undefined,
+    DesiredNumberOfDomainControllers: __expectNumber(output.DesiredNumberOfDomainControllers),
+    DirectoryId: __expectString(output.DirectoryId),
     LastUpdatedDateTime:
       output.LastUpdatedDateTime !== undefined && output.LastUpdatedDateTime !== null
         ? new Date(Math.round(output.LastUpdatedDateTime * 1000))
@@ -9247,9 +9195,9 @@ const deserializeAws_json1_1RegionDescription = (output: any, context: __SerdeCo
       output.LaunchTime !== undefined && output.LaunchTime !== null
         ? new Date(Math.round(output.LaunchTime * 1000))
         : undefined,
-    RegionName: output.RegionName !== undefined && output.RegionName !== null ? output.RegionName : undefined,
-    RegionType: output.RegionType !== undefined && output.RegionType !== null ? output.RegionType : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    RegionName: __expectString(output.RegionName),
+    RegionType: __expectString(output.RegionType),
+    Status: __expectString(output.Status),
     StatusLastUpdatedDateTime:
       output.StatusLastUpdatedDateTime !== undefined && output.StatusLastUpdatedDateTime !== null
         ? new Date(Math.round(output.StatusLastUpdatedDateTime * 1000))
@@ -9266,8 +9214,8 @@ const deserializeAws_json1_1RegionLimitExceededException = (
   context: __SerdeContext
 ): RegionLimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
+    Message: __expectString(output.Message),
+    RequestId: __expectString(output.RequestId),
   } as any;
 };
 
@@ -9288,8 +9236,7 @@ const deserializeAws_json1_1RegionsInfo = (output: any, context: __SerdeContext)
       output.AdditionalRegions !== undefined && output.AdditionalRegions !== null
         ? deserializeAws_json1_1AdditionalRegions(output.AdditionalRegions, context)
         : undefined,
-    PrimaryRegion:
-      output.PrimaryRegion !== undefined && output.PrimaryRegion !== null ? output.PrimaryRegion : undefined,
+    PrimaryRegion: __expectString(output.PrimaryRegion),
   } as any;
 };
 
@@ -9298,8 +9245,7 @@ const deserializeAws_json1_1RegisterCertificateResult = (
   context: __SerdeContext
 ): RegisterCertificateResult => {
   return {
-    CertificateId:
-      output.CertificateId !== undefined && output.CertificateId !== null ? output.CertificateId : undefined,
+    CertificateId: __expectString(output.CertificateId),
   } as any;
 };
 
@@ -9315,10 +9261,7 @@ const deserializeAws_json1_1RejectSharedDirectoryResult = (
   context: __SerdeContext
 ): RejectSharedDirectoryResult => {
   return {
-    SharedDirectoryId:
-      output.SharedDirectoryId !== undefined && output.SharedDirectoryId !== null
-        ? output.SharedDirectoryId
-        : undefined,
+    SharedDirectoryId: __expectString(output.SharedDirectoryId),
   } as any;
 };
 
@@ -9353,24 +9296,15 @@ const deserializeAws_json1_1RestoreFromSnapshotResult = (
 
 const deserializeAws_json1_1SchemaExtensionInfo = (output: any, context: __SerdeContext): SchemaExtensionInfo => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    DirectoryId: output.DirectoryId !== undefined && output.DirectoryId !== null ? output.DirectoryId : undefined,
+    Description: __expectString(output.Description),
+    DirectoryId: __expectString(output.DirectoryId),
     EndDateTime:
       output.EndDateTime !== undefined && output.EndDateTime !== null
         ? new Date(Math.round(output.EndDateTime * 1000))
         : undefined,
-    SchemaExtensionId:
-      output.SchemaExtensionId !== undefined && output.SchemaExtensionId !== null
-        ? output.SchemaExtensionId
-        : undefined,
-    SchemaExtensionStatus:
-      output.SchemaExtensionStatus !== undefined && output.SchemaExtensionStatus !== null
-        ? output.SchemaExtensionStatus
-        : undefined,
-    SchemaExtensionStatusReason:
-      output.SchemaExtensionStatusReason !== undefined && output.SchemaExtensionStatusReason !== null
-        ? output.SchemaExtensionStatusReason
-        : undefined,
+    SchemaExtensionId: __expectString(output.SchemaExtensionId),
+    SchemaExtensionStatus: __expectString(output.SchemaExtensionStatus),
+    SchemaExtensionStatusReason: __expectString(output.SchemaExtensionStatusReason),
     StartDateTime:
       output.StartDateTime !== undefined && output.StartDateTime !== null
         ? new Date(Math.round(output.StartDateTime * 1000))
@@ -9396,14 +9330,14 @@ const deserializeAws_json1_1Servers = (output: any, context: __SerdeContext): st
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1ServiceException = (output: any, context: __SerdeContext): ServiceException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
+    Message: __expectString(output.Message),
+    RequestId: __expectString(output.RequestId),
   } as any;
 };
 
@@ -9428,28 +9362,19 @@ const deserializeAws_json1_1SharedDirectory = (output: any, context: __SerdeCont
       output.LastUpdatedDateTime !== undefined && output.LastUpdatedDateTime !== null
         ? new Date(Math.round(output.LastUpdatedDateTime * 1000))
         : undefined,
-    OwnerAccountId:
-      output.OwnerAccountId !== undefined && output.OwnerAccountId !== null ? output.OwnerAccountId : undefined,
-    OwnerDirectoryId:
-      output.OwnerDirectoryId !== undefined && output.OwnerDirectoryId !== null ? output.OwnerDirectoryId : undefined,
-    ShareMethod: output.ShareMethod !== undefined && output.ShareMethod !== null ? output.ShareMethod : undefined,
-    ShareNotes: output.ShareNotes !== undefined && output.ShareNotes !== null ? output.ShareNotes : undefined,
-    ShareStatus: output.ShareStatus !== undefined && output.ShareStatus !== null ? output.ShareStatus : undefined,
-    SharedAccountId:
-      output.SharedAccountId !== undefined && output.SharedAccountId !== null ? output.SharedAccountId : undefined,
-    SharedDirectoryId:
-      output.SharedDirectoryId !== undefined && output.SharedDirectoryId !== null
-        ? output.SharedDirectoryId
-        : undefined,
+    OwnerAccountId: __expectString(output.OwnerAccountId),
+    OwnerDirectoryId: __expectString(output.OwnerDirectoryId),
+    ShareMethod: __expectString(output.ShareMethod),
+    ShareNotes: __expectString(output.ShareNotes),
+    ShareStatus: __expectString(output.ShareStatus),
+    SharedAccountId: __expectString(output.SharedAccountId),
+    SharedDirectoryId: __expectString(output.SharedDirectoryId),
   } as any;
 };
 
 const deserializeAws_json1_1ShareDirectoryResult = (output: any, context: __SerdeContext): ShareDirectoryResult => {
   return {
-    SharedDirectoryId:
-      output.SharedDirectoryId !== undefined && output.SharedDirectoryId !== null
-        ? output.SharedDirectoryId
-        : undefined,
+    SharedDirectoryId: __expectString(output.SharedDirectoryId),
   } as any;
 };
 
@@ -9458,22 +9383,22 @@ const deserializeAws_json1_1ShareLimitExceededException = (
   context: __SerdeContext
 ): ShareLimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
+    Message: __expectString(output.Message),
+    RequestId: __expectString(output.RequestId),
   } as any;
 };
 
 const deserializeAws_json1_1Snapshot = (output: any, context: __SerdeContext): Snapshot => {
   return {
-    DirectoryId: output.DirectoryId !== undefined && output.DirectoryId !== null ? output.DirectoryId : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    SnapshotId: output.SnapshotId !== undefined && output.SnapshotId !== null ? output.SnapshotId : undefined,
+    DirectoryId: __expectString(output.DirectoryId),
+    Name: __expectString(output.Name),
+    SnapshotId: __expectString(output.SnapshotId),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
         ? new Date(Math.round(output.StartTime * 1000))
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Status: __expectString(output.Status),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -9482,25 +9407,16 @@ const deserializeAws_json1_1SnapshotLimitExceededException = (
   context: __SerdeContext
 ): SnapshotLimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
+    Message: __expectString(output.Message),
+    RequestId: __expectString(output.RequestId),
   } as any;
 };
 
 const deserializeAws_json1_1SnapshotLimits = (output: any, context: __SerdeContext): SnapshotLimits => {
   return {
-    ManualSnapshotsCurrentCount:
-      output.ManualSnapshotsCurrentCount !== undefined && output.ManualSnapshotsCurrentCount !== null
-        ? output.ManualSnapshotsCurrentCount
-        : undefined,
-    ManualSnapshotsLimit:
-      output.ManualSnapshotsLimit !== undefined && output.ManualSnapshotsLimit !== null
-        ? output.ManualSnapshotsLimit
-        : undefined,
-    ManualSnapshotsLimitReached:
-      output.ManualSnapshotsLimitReached !== undefined && output.ManualSnapshotsLimitReached !== null
-        ? output.ManualSnapshotsLimitReached
-        : undefined,
+    ManualSnapshotsCurrentCount: __expectNumber(output.ManualSnapshotsCurrentCount),
+    ManualSnapshotsLimit: __expectNumber(output.ManualSnapshotsLimit),
+    ManualSnapshotsLimitReached: __expectBoolean(output.ManualSnapshotsLimitReached),
   } as any;
 };
 
@@ -9520,10 +9436,7 @@ const deserializeAws_json1_1StartSchemaExtensionResult = (
   context: __SerdeContext
 ): StartSchemaExtensionResult => {
   return {
-    SchemaExtensionId:
-      output.SchemaExtensionId !== undefined && output.SchemaExtensionId !== null
-        ? output.SchemaExtensionId
-        : undefined,
+    SchemaExtensionId: __expectString(output.SchemaExtensionId),
   } as any;
 };
 
@@ -9534,14 +9447,14 @@ const deserializeAws_json1_1SubnetIds = (output: any, context: __SerdeContext): 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -9550,8 +9463,8 @@ const deserializeAws_json1_1TagLimitExceededException = (
   context: __SerdeContext
 ): TagLimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
+    Message: __expectString(output.Message),
+    RequestId: __expectString(output.RequestId),
   } as any;
 };
 
@@ -9572,26 +9485,22 @@ const deserializeAws_json1_1Trust = (output: any, context: __SerdeContext): Trus
       output.CreatedDateTime !== undefined && output.CreatedDateTime !== null
         ? new Date(Math.round(output.CreatedDateTime * 1000))
         : undefined,
-    DirectoryId: output.DirectoryId !== undefined && output.DirectoryId !== null ? output.DirectoryId : undefined,
+    DirectoryId: __expectString(output.DirectoryId),
     LastUpdatedDateTime:
       output.LastUpdatedDateTime !== undefined && output.LastUpdatedDateTime !== null
         ? new Date(Math.round(output.LastUpdatedDateTime * 1000))
         : undefined,
-    RemoteDomainName:
-      output.RemoteDomainName !== undefined && output.RemoteDomainName !== null ? output.RemoteDomainName : undefined,
-    SelectiveAuth:
-      output.SelectiveAuth !== undefined && output.SelectiveAuth !== null ? output.SelectiveAuth : undefined,
+    RemoteDomainName: __expectString(output.RemoteDomainName),
+    SelectiveAuth: __expectString(output.SelectiveAuth),
     StateLastUpdatedDateTime:
       output.StateLastUpdatedDateTime !== undefined && output.StateLastUpdatedDateTime !== null
         ? new Date(Math.round(output.StateLastUpdatedDateTime * 1000))
         : undefined,
-    TrustDirection:
-      output.TrustDirection !== undefined && output.TrustDirection !== null ? output.TrustDirection : undefined,
-    TrustId: output.TrustId !== undefined && output.TrustId !== null ? output.TrustId : undefined,
-    TrustState: output.TrustState !== undefined && output.TrustState !== null ? output.TrustState : undefined,
-    TrustStateReason:
-      output.TrustStateReason !== undefined && output.TrustStateReason !== null ? output.TrustStateReason : undefined,
-    TrustType: output.TrustType !== undefined && output.TrustType !== null ? output.TrustType : undefined,
+    TrustDirection: __expectString(output.TrustDirection),
+    TrustId: __expectString(output.TrustId),
+    TrustState: __expectString(output.TrustState),
+    TrustStateReason: __expectString(output.TrustStateReason),
+    TrustType: __expectString(output.TrustType),
   } as any;
 };
 
@@ -9608,10 +9517,7 @@ const deserializeAws_json1_1Trusts = (output: any, context: __SerdeContext): Tru
 
 const deserializeAws_json1_1UnshareDirectoryResult = (output: any, context: __SerdeContext): UnshareDirectoryResult => {
   return {
-    SharedDirectoryId:
-      output.SharedDirectoryId !== undefined && output.SharedDirectoryId !== null
-        ? output.SharedDirectoryId
-        : undefined,
+    SharedDirectoryId: __expectString(output.SharedDirectoryId),
   } as any;
 };
 
@@ -9620,8 +9526,8 @@ const deserializeAws_json1_1UnsupportedOperationException = (
   context: __SerdeContext
 ): UnsupportedOperationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
+    Message: __expectString(output.Message),
+    RequestId: __expectString(output.RequestId),
   } as any;
 };
 
@@ -9645,8 +9551,8 @@ const deserializeAws_json1_1UpdateRadiusResult = (output: any, context: __SerdeC
 
 const deserializeAws_json1_1UpdateTrustResult = (output: any, context: __SerdeContext): UpdateTrustResult => {
   return {
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
-    TrustId: output.TrustId !== undefined && output.TrustId !== null ? output.TrustId : undefined,
+    RequestId: __expectString(output.RequestId),
+    TrustId: __expectString(output.TrustId),
   } as any;
 };
 
@@ -9655,14 +9561,14 @@ const deserializeAws_json1_1UserDoesNotExistException = (
   context: __SerdeContext
 ): UserDoesNotExistException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
+    Message: __expectString(output.Message),
+    RequestId: __expectString(output.RequestId),
   } as any;
 };
 
 const deserializeAws_json1_1VerifyTrustResult = (output: any, context: __SerdeContext): VerifyTrustResult => {
   return {
-    TrustId: output.TrustId !== undefined && output.TrustId !== null ? output.TrustId : undefined,
+    TrustId: __expectString(output.TrustId),
   } as any;
 };
 

--- a/clients/client-dlm/protocols/Aws_restJson1.ts
+++ b/clients/client-dlm/protocols/Aws_restJson1.ts
@@ -49,6 +49,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -319,7 +322,7 @@ export const deserializeAws_restJson1CreateLifecyclePolicyCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.PolicyId !== undefined && data.PolicyId !== null) {
-    contents.PolicyId = data.PolicyId;
+    contents.PolicyId = __expectString(data.PolicyId);
   }
   return Promise.resolve(contents);
 };
@@ -887,10 +890,10 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Code !== undefined && data.Code !== null) {
-    contents.Code = data.Code;
+    contents.Code = __expectString(data.Code);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -910,10 +913,10 @@ const deserializeAws_restJson1InvalidRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Code !== undefined && data.Code !== null) {
-    contents.Code = data.Code;
+    contents.Code = __expectString(data.Code);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.MutuallyExclusiveParameters !== undefined && data.MutuallyExclusiveParameters !== null) {
     contents.MutuallyExclusiveParameters = deserializeAws_restJson1ParameterList(
@@ -941,13 +944,13 @@ const deserializeAws_restJson1LimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Code !== undefined && data.Code !== null) {
-    contents.Code = data.Code;
+    contents.Code = __expectString(data.Code);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.ResourceType !== undefined && data.ResourceType !== null) {
-    contents.ResourceType = data.ResourceType;
+    contents.ResourceType = __expectString(data.ResourceType);
   }
   return contents;
 };
@@ -967,16 +970,16 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Code !== undefined && data.Code !== null) {
-    contents.Code = data.Code;
+    contents.Code = __expectString(data.Code);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.ResourceIds !== undefined && data.ResourceIds !== null) {
     contents.ResourceIds = deserializeAws_restJson1PolicyIdList(data.ResourceIds, context);
   }
   if (data.ResourceType !== undefined && data.ResourceType !== null) {
-    contents.ResourceType = data.ResourceType;
+    contents.ResourceType = __expectString(data.ResourceType);
   }
   return contents;
 };
@@ -1351,7 +1354,7 @@ const deserializeAws_restJson1Action = (output: any, context: __SerdeContext): A
       output.CrossRegionCopy !== undefined && output.CrossRegionCopy !== null
         ? deserializeAws_restJson1CrossRegionCopyActionList(output.CrossRegionCopy, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -1373,17 +1376,16 @@ const deserializeAws_restJson1AvailabilityZoneList = (output: any, context: __Se
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1CreateRule = (output: any, context: __SerdeContext): CreateRule => {
   return {
-    CronExpression:
-      output.CronExpression !== undefined && output.CronExpression !== null ? output.CronExpression : undefined,
-    Interval: output.Interval !== undefined && output.Interval !== null ? output.Interval : undefined,
-    IntervalUnit: output.IntervalUnit !== undefined && output.IntervalUnit !== null ? output.IntervalUnit : undefined,
-    Location: output.Location !== undefined && output.Location !== null ? output.Location : undefined,
+    CronExpression: __expectString(output.CronExpression),
+    Interval: __expectNumber(output.Interval),
+    IntervalUnit: __expectString(output.IntervalUnit),
+    Location: __expectString(output.Location),
     Times:
       output.Times !== undefined && output.Times !== null
         ? deserializeAws_restJson1TimesList(output.Times, context)
@@ -1401,7 +1403,7 @@ const deserializeAws_restJson1CrossRegionCopyAction = (output: any, context: __S
       output.RetainRule !== undefined && output.RetainRule !== null
         ? deserializeAws_restJson1CrossRegionCopyRetainRule(output.RetainRule, context)
         : undefined,
-    Target: output.Target !== undefined && output.Target !== null ? output.Target : undefined,
+    Target: __expectString(output.Target),
   } as any;
 };
 
@@ -1424,22 +1426,22 @@ const deserializeAws_restJson1CrossRegionCopyRetainRule = (
   context: __SerdeContext
 ): CrossRegionCopyRetainRule => {
   return {
-    Interval: output.Interval !== undefined && output.Interval !== null ? output.Interval : undefined,
-    IntervalUnit: output.IntervalUnit !== undefined && output.IntervalUnit !== null ? output.IntervalUnit : undefined,
+    Interval: __expectNumber(output.Interval),
+    IntervalUnit: __expectString(output.IntervalUnit),
   } as any;
 };
 
 const deserializeAws_restJson1CrossRegionCopyRule = (output: any, context: __SerdeContext): CrossRegionCopyRule => {
   return {
-    CmkArn: output.CmkArn !== undefined && output.CmkArn !== null ? output.CmkArn : undefined,
-    CopyTags: output.CopyTags !== undefined && output.CopyTags !== null ? output.CopyTags : undefined,
-    Encrypted: output.Encrypted !== undefined && output.Encrypted !== null ? output.Encrypted : undefined,
+    CmkArn: __expectString(output.CmkArn),
+    CopyTags: __expectBoolean(output.CopyTags),
+    Encrypted: __expectBoolean(output.Encrypted),
     RetainRule:
       output.RetainRule !== undefined && output.RetainRule !== null
         ? deserializeAws_restJson1CrossRegionCopyRetainRule(output.RetainRule, context)
         : undefined,
-    Target: output.Target !== undefined && output.Target !== null ? output.Target : undefined,
-    TargetRegion: output.TargetRegion !== undefined && output.TargetRegion !== null ? output.TargetRegion : undefined,
+    Target: __expectString(output.Target),
+    TargetRegion: __expectString(output.TargetRegion),
   } as any;
 };
 
@@ -1459,16 +1461,15 @@ const deserializeAws_restJson1EncryptionConfiguration = (
   context: __SerdeContext
 ): EncryptionConfiguration => {
   return {
-    CmkArn: output.CmkArn !== undefined && output.CmkArn !== null ? output.CmkArn : undefined,
-    Encrypted: output.Encrypted !== undefined && output.Encrypted !== null ? output.Encrypted : undefined,
+    CmkArn: __expectString(output.CmkArn),
+    Encrypted: __expectBoolean(output.Encrypted),
   } as any;
 };
 
 const deserializeAws_restJson1EventParameters = (output: any, context: __SerdeContext): EventParameters => {
   return {
-    DescriptionRegex:
-      output.DescriptionRegex !== undefined && output.DescriptionRegex !== null ? output.DescriptionRegex : undefined,
-    EventType: output.EventType !== undefined && output.EventType !== null ? output.EventType : undefined,
+    DescriptionRegex: __expectString(output.DescriptionRegex),
+    EventType: __expectString(output.EventType),
     SnapshotOwner:
       output.SnapshotOwner !== undefined && output.SnapshotOwner !== null
         ? deserializeAws_restJson1SnapshotOwnerList(output.SnapshotOwner, context)
@@ -1482,7 +1483,7 @@ const deserializeAws_restJson1EventSource = (output: any, context: __SerdeContex
       output.Parameters !== undefined && output.Parameters !== null
         ? deserializeAws_restJson1EventParameters(output.Parameters, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -1492,9 +1493,9 @@ const deserializeAws_restJson1FastRestoreRule = (output: any, context: __SerdeCo
       output.AvailabilityZones !== undefined && output.AvailabilityZones !== null
         ? deserializeAws_restJson1AvailabilityZoneList(output.AvailabilityZones, context)
         : undefined,
-    Count: output.Count !== undefined && output.Count !== null ? output.Count : undefined,
-    Interval: output.Interval !== undefined && output.Interval !== null ? output.Interval : undefined,
-    IntervalUnit: output.IntervalUnit !== undefined && output.IntervalUnit !== null ? output.IntervalUnit : undefined,
+    Count: __expectNumber(output.Count),
+    Interval: __expectNumber(output.Interval),
+    IntervalUnit: __expectString(output.IntervalUnit),
   } as any;
 };
 
@@ -1508,18 +1509,16 @@ const deserializeAws_restJson1LifecyclePolicy = (output: any, context: __SerdeCo
       output.DateModified !== undefined && output.DateModified !== null
         ? new Date(Math.round(output.DateModified * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    ExecutionRoleArn:
-      output.ExecutionRoleArn !== undefined && output.ExecutionRoleArn !== null ? output.ExecutionRoleArn : undefined,
-    PolicyArn: output.PolicyArn !== undefined && output.PolicyArn !== null ? output.PolicyArn : undefined,
+    Description: __expectString(output.Description),
+    ExecutionRoleArn: __expectString(output.ExecutionRoleArn),
+    PolicyArn: __expectString(output.PolicyArn),
     PolicyDetails:
       output.PolicyDetails !== undefined && output.PolicyDetails !== null
         ? deserializeAws_restJson1PolicyDetails(output.PolicyDetails, context)
         : undefined,
-    PolicyId: output.PolicyId !== undefined && output.PolicyId !== null ? output.PolicyId : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    StatusMessage:
-      output.StatusMessage !== undefined && output.StatusMessage !== null ? output.StatusMessage : undefined,
+    PolicyId: __expectString(output.PolicyId),
+    State: __expectString(output.State),
+    StatusMessage: __expectString(output.StatusMessage),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_restJson1TagMap(output.Tags, context)
@@ -1532,10 +1531,10 @@ const deserializeAws_restJson1LifecyclePolicySummary = (
   context: __SerdeContext
 ): LifecyclePolicySummary => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    PolicyId: output.PolicyId !== undefined && output.PolicyId !== null ? output.PolicyId : undefined,
-    PolicyType: output.PolicyType !== undefined && output.PolicyType !== null ? output.PolicyType : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    Description: __expectString(output.Description),
+    PolicyId: __expectString(output.PolicyId),
+    PolicyType: __expectString(output.PolicyType),
+    State: __expectString(output.State),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_restJson1TagMap(output.Tags, context)
@@ -1564,17 +1563,14 @@ const deserializeAws_restJson1ParameterList = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1_Parameters = (output: any, context: __SerdeContext): _Parameters => {
   return {
-    ExcludeBootVolume:
-      output.ExcludeBootVolume !== undefined && output.ExcludeBootVolume !== null
-        ? output.ExcludeBootVolume
-        : undefined,
-    NoReboot: output.NoReboot !== undefined && output.NoReboot !== null ? output.NoReboot : undefined,
+    ExcludeBootVolume: __expectBoolean(output.ExcludeBootVolume),
+    NoReboot: __expectBoolean(output.NoReboot),
   } as any;
 };
 
@@ -1592,7 +1588,7 @@ const deserializeAws_restJson1PolicyDetails = (output: any, context: __SerdeCont
       output.Parameters !== undefined && output.Parameters !== null
         ? deserializeAws_restJson1_Parameters(output.Parameters, context)
         : undefined,
-    PolicyType: output.PolicyType !== undefined && output.PolicyType !== null ? output.PolicyType : undefined,
+    PolicyType: __expectString(output.PolicyType),
     ResourceLocations:
       output.ResourceLocations !== undefined && output.ResourceLocations !== null
         ? deserializeAws_restJson1ResourceLocationList(output.ResourceLocations, context)
@@ -1619,7 +1615,7 @@ const deserializeAws_restJson1PolicyIdList = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -1633,7 +1629,7 @@ const deserializeAws_restJson1ResourceLocationList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -1647,21 +1643,21 @@ const deserializeAws_restJson1ResourceTypeValuesList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1RetainRule = (output: any, context: __SerdeContext): RetainRule => {
   return {
-    Count: output.Count !== undefined && output.Count !== null ? output.Count : undefined,
-    Interval: output.Interval !== undefined && output.Interval !== null ? output.Interval : undefined,
-    IntervalUnit: output.IntervalUnit !== undefined && output.IntervalUnit !== null ? output.IntervalUnit : undefined,
+    Count: __expectNumber(output.Count),
+    Interval: __expectNumber(output.Interval),
+    IntervalUnit: __expectString(output.IntervalUnit),
   } as any;
 };
 
 const deserializeAws_restJson1Schedule = (output: any, context: __SerdeContext): Schedule => {
   return {
-    CopyTags: output.CopyTags !== undefined && output.CopyTags !== null ? output.CopyTags : undefined,
+    CopyTags: __expectBoolean(output.CopyTags),
     CreateRule:
       output.CreateRule !== undefined && output.CreateRule !== null
         ? deserializeAws_restJson1CreateRule(output.CreateRule, context)
@@ -1674,7 +1670,7 @@ const deserializeAws_restJson1Schedule = (output: any, context: __SerdeContext):
       output.FastRestoreRule !== undefined && output.FastRestoreRule !== null
         ? deserializeAws_restJson1FastRestoreRule(output.FastRestoreRule, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     RetainRule:
       output.RetainRule !== undefined && output.RetainRule !== null
         ? deserializeAws_restJson1RetainRule(output.RetainRule, context)
@@ -1711,12 +1707,8 @@ const deserializeAws_restJson1ShareRule = (output: any, context: __SerdeContext)
       output.TargetAccounts !== undefined && output.TargetAccounts !== null
         ? deserializeAws_restJson1ShareTargetAccountList(output.TargetAccounts, context)
         : undefined,
-    UnshareInterval:
-      output.UnshareInterval !== undefined && output.UnshareInterval !== null ? output.UnshareInterval : undefined,
-    UnshareIntervalUnit:
-      output.UnshareIntervalUnit !== undefined && output.UnshareIntervalUnit !== null
-        ? output.UnshareIntervalUnit
-        : undefined,
+    UnshareInterval: __expectNumber(output.UnshareInterval),
+    UnshareIntervalUnit: __expectString(output.UnshareIntervalUnit),
   } as any;
 };
 
@@ -1738,7 +1730,7 @@ const deserializeAws_restJson1ShareTargetAccountList = (output: any, context: __
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -1749,14 +1741,14 @@ const deserializeAws_restJson1SnapshotOwnerList = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -1767,7 +1759,7 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -1801,7 +1793,7 @@ const deserializeAws_restJson1TimesList = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 

--- a/clients/client-docdb/protocols/Aws_query.ts
+++ b/clients/client-docdb/protocols/Aws_query.ts
@@ -284,6 +284,7 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
@@ -6215,7 +6216,7 @@ const deserializeAws_queryAttributeValueList = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6227,7 +6228,7 @@ const deserializeAws_queryAuthorizationNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -6237,7 +6238,7 @@ const deserializeAws_queryAvailabilityZone = (output: any, context: __SerdeConte
     Name: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   return contents;
 };
@@ -6260,7 +6261,7 @@ const deserializeAws_queryAvailabilityZones = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6274,13 +6275,13 @@ const deserializeAws_queryCertificate = (output: any, context: __SerdeContext): 
     CertificateArn: undefined,
   };
   if (output["CertificateIdentifier"] !== undefined) {
-    contents.CertificateIdentifier = output["CertificateIdentifier"];
+    contents.CertificateIdentifier = __expectString(output["CertificateIdentifier"]);
   }
   if (output["CertificateType"] !== undefined) {
-    contents.CertificateType = output["CertificateType"];
+    contents.CertificateType = __expectString(output["CertificateType"]);
   }
   if (output["Thumbprint"] !== undefined) {
-    contents.Thumbprint = output["Thumbprint"];
+    contents.Thumbprint = __expectString(output["Thumbprint"]);
   }
   if (output["ValidFrom"] !== undefined) {
     contents.ValidFrom = new Date(output["ValidFrom"]);
@@ -6289,7 +6290,7 @@ const deserializeAws_queryCertificate = (output: any, context: __SerdeContext): 
     contents.ValidTill = new Date(output["ValidTill"]);
   }
   if (output["CertificateArn"] !== undefined) {
-    contents.CertificateArn = output["CertificateArn"];
+    contents.CertificateArn = __expectString(output["CertificateArn"]);
   }
   return contents;
 };
@@ -6320,7 +6321,7 @@ const deserializeAws_queryCertificateMessage = (output: any, context: __SerdeCon
     );
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -6333,7 +6334,7 @@ const deserializeAws_queryCertificateNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -6474,37 +6475,37 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
     contents.BackupRetentionPeriod = parseInt(output["BackupRetentionPeriod"]);
   }
   if (output["DBClusterIdentifier"] !== undefined) {
-    contents.DBClusterIdentifier = output["DBClusterIdentifier"];
+    contents.DBClusterIdentifier = __expectString(output["DBClusterIdentifier"]);
   }
   if (output["DBClusterParameterGroup"] !== undefined) {
-    contents.DBClusterParameterGroup = output["DBClusterParameterGroup"];
+    contents.DBClusterParameterGroup = __expectString(output["DBClusterParameterGroup"]);
   }
   if (output["DBSubnetGroup"] !== undefined) {
-    contents.DBSubnetGroup = output["DBSubnetGroup"];
+    contents.DBSubnetGroup = __expectString(output["DBSubnetGroup"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["PercentProgress"] !== undefined) {
-    contents.PercentProgress = output["PercentProgress"];
+    contents.PercentProgress = __expectString(output["PercentProgress"]);
   }
   if (output["EarliestRestorableTime"] !== undefined) {
     contents.EarliestRestorableTime = new Date(output["EarliestRestorableTime"]);
   }
   if (output["Endpoint"] !== undefined) {
-    contents.Endpoint = output["Endpoint"];
+    contents.Endpoint = __expectString(output["Endpoint"]);
   }
   if (output["ReaderEndpoint"] !== undefined) {
-    contents.ReaderEndpoint = output["ReaderEndpoint"];
+    contents.ReaderEndpoint = __expectString(output["ReaderEndpoint"]);
   }
   if (output["MultiAZ"] !== undefined) {
     contents.MultiAZ = __parseBoolean(output["MultiAZ"]);
   }
   if (output["Engine"] !== undefined) {
-    contents.Engine = output["Engine"];
+    contents.Engine = __expectString(output["Engine"]);
   }
   if (output["EngineVersion"] !== undefined) {
-    contents.EngineVersion = output["EngineVersion"];
+    contents.EngineVersion = __expectString(output["EngineVersion"]);
   }
   if (output["LatestRestorableTime"] !== undefined) {
     contents.LatestRestorableTime = new Date(output["LatestRestorableTime"]);
@@ -6513,13 +6514,13 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
     contents.Port = parseInt(output["Port"]);
   }
   if (output["MasterUsername"] !== undefined) {
-    contents.MasterUsername = output["MasterUsername"];
+    contents.MasterUsername = __expectString(output["MasterUsername"]);
   }
   if (output["PreferredBackupWindow"] !== undefined) {
-    contents.PreferredBackupWindow = output["PreferredBackupWindow"];
+    contents.PreferredBackupWindow = __expectString(output["PreferredBackupWindow"]);
   }
   if (output["PreferredMaintenanceWindow"] !== undefined) {
-    contents.PreferredMaintenanceWindow = output["PreferredMaintenanceWindow"];
+    contents.PreferredMaintenanceWindow = __expectString(output["PreferredMaintenanceWindow"]);
   }
   if (output.DBClusterMembers === "") {
     contents.DBClusterMembers = [];
@@ -6543,19 +6544,19 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
     );
   }
   if (output["HostedZoneId"] !== undefined) {
-    contents.HostedZoneId = output["HostedZoneId"];
+    contents.HostedZoneId = __expectString(output["HostedZoneId"]);
   }
   if (output["StorageEncrypted"] !== undefined) {
     contents.StorageEncrypted = __parseBoolean(output["StorageEncrypted"]);
   }
   if (output["KmsKeyId"] !== undefined) {
-    contents.KmsKeyId = output["KmsKeyId"];
+    contents.KmsKeyId = __expectString(output["KmsKeyId"]);
   }
   if (output["DbClusterResourceId"] !== undefined) {
-    contents.DbClusterResourceId = output["DbClusterResourceId"];
+    contents.DbClusterResourceId = __expectString(output["DbClusterResourceId"]);
   }
   if (output["DBClusterArn"] !== undefined) {
-    contents.DBClusterArn = output["DBClusterArn"];
+    contents.DBClusterArn = __expectString(output["DBClusterArn"]);
   }
   if (output.AssociatedRoles === "") {
     contents.AssociatedRoles = [];
@@ -6595,7 +6596,7 @@ const deserializeAws_queryDBClusterAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -6619,13 +6620,13 @@ const deserializeAws_queryDBClusterMember = (output: any, context: __SerdeContex
     PromotionTier: undefined,
   };
   if (output["DBInstanceIdentifier"] !== undefined) {
-    contents.DBInstanceIdentifier = output["DBInstanceIdentifier"];
+    contents.DBInstanceIdentifier = __expectString(output["DBInstanceIdentifier"]);
   }
   if (output["IsClusterWriter"] !== undefined) {
     contents.IsClusterWriter = __parseBoolean(output["IsClusterWriter"]);
   }
   if (output["DBClusterParameterGroupStatus"] !== undefined) {
-    contents.DBClusterParameterGroupStatus = output["DBClusterParameterGroupStatus"];
+    contents.DBClusterParameterGroupStatus = __expectString(output["DBClusterParameterGroupStatus"]);
   }
   if (output["PromotionTier"] !== undefined) {
     contents.PromotionTier = parseInt(output["PromotionTier"]);
@@ -6650,7 +6651,7 @@ const deserializeAws_queryDBClusterMessage = (output: any, context: __SerdeConte
     DBClusters: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.DBClusters === "") {
     contents.DBClusters = [];
@@ -6669,7 +6670,7 @@ const deserializeAws_queryDBClusterNotFoundFault = (output: any, context: __Serd
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -6682,16 +6683,16 @@ const deserializeAws_queryDBClusterParameterGroup = (output: any, context: __Ser
     DBClusterParameterGroupArn: undefined,
   };
   if (output["DBClusterParameterGroupName"] !== undefined) {
-    contents.DBClusterParameterGroupName = output["DBClusterParameterGroupName"];
+    contents.DBClusterParameterGroupName = __expectString(output["DBClusterParameterGroupName"]);
   }
   if (output["DBParameterGroupFamily"] !== undefined) {
-    contents.DBParameterGroupFamily = output["DBParameterGroupFamily"];
+    contents.DBParameterGroupFamily = __expectString(output["DBParameterGroupFamily"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output["DBClusterParameterGroupArn"] !== undefined) {
-    contents.DBClusterParameterGroupArn = output["DBClusterParameterGroupArn"];
+    contents.DBClusterParameterGroupArn = __expectString(output["DBClusterParameterGroupArn"]);
   }
   return contents;
 };
@@ -6714,7 +6715,7 @@ const deserializeAws_queryDBClusterParameterGroupDetails = (
     );
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -6741,7 +6742,7 @@ const deserializeAws_queryDBClusterParameterGroupNameMessage = (
     DBClusterParameterGroupName: undefined,
   };
   if (output["DBClusterParameterGroupName"] !== undefined) {
-    contents.DBClusterParameterGroupName = output["DBClusterParameterGroupName"];
+    contents.DBClusterParameterGroupName = __expectString(output["DBClusterParameterGroupName"]);
   }
   return contents;
 };
@@ -6754,7 +6755,7 @@ const deserializeAws_queryDBClusterParameterGroupNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -6768,7 +6769,7 @@ const deserializeAws_queryDBClusterParameterGroupsMessage = (
     DBClusterParameterGroups: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.DBClusterParameterGroups === "") {
     contents.DBClusterParameterGroups = [];
@@ -6793,7 +6794,7 @@ const deserializeAws_queryDBClusterQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -6804,10 +6805,10 @@ const deserializeAws_queryDBClusterRole = (output: any, context: __SerdeContext)
     Status: undefined,
   };
   if (output["RoleArn"] !== undefined) {
-    contents.RoleArn = output["RoleArn"];
+    contents.RoleArn = __expectString(output["RoleArn"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   return contents;
 };
@@ -6853,37 +6854,37 @@ const deserializeAws_queryDBClusterSnapshot = (output: any, context: __SerdeCont
     );
   }
   if (output["DBClusterSnapshotIdentifier"] !== undefined) {
-    contents.DBClusterSnapshotIdentifier = output["DBClusterSnapshotIdentifier"];
+    contents.DBClusterSnapshotIdentifier = __expectString(output["DBClusterSnapshotIdentifier"]);
   }
   if (output["DBClusterIdentifier"] !== undefined) {
-    contents.DBClusterIdentifier = output["DBClusterIdentifier"];
+    contents.DBClusterIdentifier = __expectString(output["DBClusterIdentifier"]);
   }
   if (output["SnapshotCreateTime"] !== undefined) {
     contents.SnapshotCreateTime = new Date(output["SnapshotCreateTime"]);
   }
   if (output["Engine"] !== undefined) {
-    contents.Engine = output["Engine"];
+    contents.Engine = __expectString(output["Engine"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["Port"] !== undefined) {
     contents.Port = parseInt(output["Port"]);
   }
   if (output["VpcId"] !== undefined) {
-    contents.VpcId = output["VpcId"];
+    contents.VpcId = __expectString(output["VpcId"]);
   }
   if (output["ClusterCreateTime"] !== undefined) {
     contents.ClusterCreateTime = new Date(output["ClusterCreateTime"]);
   }
   if (output["MasterUsername"] !== undefined) {
-    contents.MasterUsername = output["MasterUsername"];
+    contents.MasterUsername = __expectString(output["MasterUsername"]);
   }
   if (output["EngineVersion"] !== undefined) {
-    contents.EngineVersion = output["EngineVersion"];
+    contents.EngineVersion = __expectString(output["EngineVersion"]);
   }
   if (output["SnapshotType"] !== undefined) {
-    contents.SnapshotType = output["SnapshotType"];
+    contents.SnapshotType = __expectString(output["SnapshotType"]);
   }
   if (output["PercentProgress"] !== undefined) {
     contents.PercentProgress = parseInt(output["PercentProgress"]);
@@ -6892,13 +6893,13 @@ const deserializeAws_queryDBClusterSnapshot = (output: any, context: __SerdeCont
     contents.StorageEncrypted = __parseBoolean(output["StorageEncrypted"]);
   }
   if (output["KmsKeyId"] !== undefined) {
-    contents.KmsKeyId = output["KmsKeyId"];
+    contents.KmsKeyId = __expectString(output["KmsKeyId"]);
   }
   if (output["DBClusterSnapshotArn"] !== undefined) {
-    contents.DBClusterSnapshotArn = output["DBClusterSnapshotArn"];
+    contents.DBClusterSnapshotArn = __expectString(output["DBClusterSnapshotArn"]);
   }
   if (output["SourceDBClusterSnapshotArn"] !== undefined) {
-    contents.SourceDBClusterSnapshotArn = output["SourceDBClusterSnapshotArn"];
+    contents.SourceDBClusterSnapshotArn = __expectString(output["SourceDBClusterSnapshotArn"]);
   }
   return contents;
 };
@@ -6911,7 +6912,7 @@ const deserializeAws_queryDBClusterSnapshotAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -6925,7 +6926,7 @@ const deserializeAws_queryDBClusterSnapshotAttribute = (
     AttributeValues: undefined,
   };
   if (output["AttributeName"] !== undefined) {
-    contents.AttributeName = output["AttributeName"];
+    contents.AttributeName = __expectString(output["AttributeName"]);
   }
   if (output.AttributeValues === "") {
     contents.AttributeValues = [];
@@ -6962,7 +6963,7 @@ const deserializeAws_queryDBClusterSnapshotAttributesResult = (
     DBClusterSnapshotAttributes: undefined,
   };
   if (output["DBClusterSnapshotIdentifier"] !== undefined) {
-    contents.DBClusterSnapshotIdentifier = output["DBClusterSnapshotIdentifier"];
+    contents.DBClusterSnapshotIdentifier = __expectString(output["DBClusterSnapshotIdentifier"]);
   }
   if (output.DBClusterSnapshotAttributes === "") {
     contents.DBClusterSnapshotAttributes = [];
@@ -6999,7 +7000,7 @@ const deserializeAws_queryDBClusterSnapshotMessage = (
     DBClusterSnapshots: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.DBClusterSnapshots === "") {
     contents.DBClusterSnapshots = [];
@@ -7021,7 +7022,7 @@ const deserializeAws_queryDBClusterSnapshotNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -7038,19 +7039,19 @@ const deserializeAws_queryDBEngineVersion = (output: any, context: __SerdeContex
     SupportsLogExportsToCloudwatchLogs: undefined,
   };
   if (output["Engine"] !== undefined) {
-    contents.Engine = output["Engine"];
+    contents.Engine = __expectString(output["Engine"]);
   }
   if (output["EngineVersion"] !== undefined) {
-    contents.EngineVersion = output["EngineVersion"];
+    contents.EngineVersion = __expectString(output["EngineVersion"]);
   }
   if (output["DBParameterGroupFamily"] !== undefined) {
-    contents.DBParameterGroupFamily = output["DBParameterGroupFamily"];
+    contents.DBParameterGroupFamily = __expectString(output["DBParameterGroupFamily"]);
   }
   if (output["DBEngineDescription"] !== undefined) {
-    contents.DBEngineDescription = output["DBEngineDescription"];
+    contents.DBEngineDescription = __expectString(output["DBEngineDescription"]);
   }
   if (output["DBEngineVersionDescription"] !== undefined) {
-    contents.DBEngineVersionDescription = output["DBEngineVersionDescription"];
+    contents.DBEngineVersionDescription = __expectString(output["DBEngineVersionDescription"]);
   }
   if (output.ValidUpgradeTarget === "") {
     contents.ValidUpgradeTarget = [];
@@ -7093,7 +7094,7 @@ const deserializeAws_queryDBEngineVersionMessage = (output: any, context: __Serd
     DBEngineVersions: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.DBEngineVersions === "") {
     contents.DBEngineVersions = [];
@@ -7137,16 +7138,16 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
     EnabledCloudwatchLogsExports: undefined,
   };
   if (output["DBInstanceIdentifier"] !== undefined) {
-    contents.DBInstanceIdentifier = output["DBInstanceIdentifier"];
+    contents.DBInstanceIdentifier = __expectString(output["DBInstanceIdentifier"]);
   }
   if (output["DBInstanceClass"] !== undefined) {
-    contents.DBInstanceClass = output["DBInstanceClass"];
+    contents.DBInstanceClass = __expectString(output["DBInstanceClass"]);
   }
   if (output["Engine"] !== undefined) {
-    contents.Engine = output["Engine"];
+    contents.Engine = __expectString(output["Engine"]);
   }
   if (output["DBInstanceStatus"] !== undefined) {
-    contents.DBInstanceStatus = output["DBInstanceStatus"];
+    contents.DBInstanceStatus = __expectString(output["DBInstanceStatus"]);
   }
   if (output["Endpoint"] !== undefined) {
     contents.Endpoint = deserializeAws_queryEndpoint(output["Endpoint"], context);
@@ -7155,7 +7156,7 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
     contents.InstanceCreateTime = new Date(output["InstanceCreateTime"]);
   }
   if (output["PreferredBackupWindow"] !== undefined) {
-    contents.PreferredBackupWindow = output["PreferredBackupWindow"];
+    contents.PreferredBackupWindow = __expectString(output["PreferredBackupWindow"]);
   }
   if (output["BackupRetentionPeriod"] !== undefined) {
     contents.BackupRetentionPeriod = parseInt(output["BackupRetentionPeriod"]);
@@ -7173,13 +7174,13 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
     );
   }
   if (output["AvailabilityZone"] !== undefined) {
-    contents.AvailabilityZone = output["AvailabilityZone"];
+    contents.AvailabilityZone = __expectString(output["AvailabilityZone"]);
   }
   if (output["DBSubnetGroup"] !== undefined) {
     contents.DBSubnetGroup = deserializeAws_queryDBSubnetGroup(output["DBSubnetGroup"], context);
   }
   if (output["PreferredMaintenanceWindow"] !== undefined) {
-    contents.PreferredMaintenanceWindow = output["PreferredMaintenanceWindow"];
+    contents.PreferredMaintenanceWindow = __expectString(output["PreferredMaintenanceWindow"]);
   }
   if (output["PendingModifiedValues"] !== undefined) {
     contents.PendingModifiedValues = deserializeAws_queryPendingModifiedValues(
@@ -7191,7 +7192,7 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
     contents.LatestRestorableTime = new Date(output["LatestRestorableTime"]);
   }
   if (output["EngineVersion"] !== undefined) {
-    contents.EngineVersion = output["EngineVersion"];
+    contents.EngineVersion = __expectString(output["EngineVersion"]);
   }
   if (output["AutoMinorVersionUpgrade"] !== undefined) {
     contents.AutoMinorVersionUpgrade = __parseBoolean(output["AutoMinorVersionUpgrade"]);
@@ -7209,25 +7210,25 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
     );
   }
   if (output["DBClusterIdentifier"] !== undefined) {
-    contents.DBClusterIdentifier = output["DBClusterIdentifier"];
+    contents.DBClusterIdentifier = __expectString(output["DBClusterIdentifier"]);
   }
   if (output["StorageEncrypted"] !== undefined) {
     contents.StorageEncrypted = __parseBoolean(output["StorageEncrypted"]);
   }
   if (output["KmsKeyId"] !== undefined) {
-    contents.KmsKeyId = output["KmsKeyId"];
+    contents.KmsKeyId = __expectString(output["KmsKeyId"]);
   }
   if (output["DbiResourceId"] !== undefined) {
-    contents.DbiResourceId = output["DbiResourceId"];
+    contents.DbiResourceId = __expectString(output["DbiResourceId"]);
   }
   if (output["CACertificateIdentifier"] !== undefined) {
-    contents.CACertificateIdentifier = output["CACertificateIdentifier"];
+    contents.CACertificateIdentifier = __expectString(output["CACertificateIdentifier"]);
   }
   if (output["PromotionTier"] !== undefined) {
     contents.PromotionTier = parseInt(output["PromotionTier"]);
   }
   if (output["DBInstanceArn"] !== undefined) {
-    contents.DBInstanceArn = output["DBInstanceArn"];
+    contents.DBInstanceArn = __expectString(output["DBInstanceArn"]);
   }
   if (output.EnabledCloudwatchLogsExports === "") {
     contents.EnabledCloudwatchLogsExports = [];
@@ -7252,7 +7253,7 @@ const deserializeAws_queryDBInstanceAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -7274,7 +7275,7 @@ const deserializeAws_queryDBInstanceMessage = (output: any, context: __SerdeCont
     DBInstances: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.DBInstances === "") {
     contents.DBInstances = [];
@@ -7293,7 +7294,7 @@ const deserializeAws_queryDBInstanceNotFoundFault = (output: any, context: __Ser
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -7306,16 +7307,16 @@ const deserializeAws_queryDBInstanceStatusInfo = (output: any, context: __SerdeC
     Message: undefined,
   };
   if (output["StatusType"] !== undefined) {
-    contents.StatusType = output["StatusType"];
+    contents.StatusType = __expectString(output["StatusType"]);
   }
   if (output["Normal"] !== undefined) {
     contents.Normal = __parseBoolean(output["Normal"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -7339,7 +7340,7 @@ const deserializeAws_queryDBParameterGroupAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -7352,7 +7353,7 @@ const deserializeAws_queryDBParameterGroupNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -7365,7 +7366,7 @@ const deserializeAws_queryDBParameterGroupQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -7378,7 +7379,7 @@ const deserializeAws_queryDBSecurityGroupNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -7391,7 +7392,7 @@ const deserializeAws_queryDBSnapshotAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -7401,7 +7402,7 @@ const deserializeAws_queryDBSnapshotNotFoundFault = (output: any, context: __Ser
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -7416,16 +7417,16 @@ const deserializeAws_queryDBSubnetGroup = (output: any, context: __SerdeContext)
     DBSubnetGroupArn: undefined,
   };
   if (output["DBSubnetGroupName"] !== undefined) {
-    contents.DBSubnetGroupName = output["DBSubnetGroupName"];
+    contents.DBSubnetGroupName = __expectString(output["DBSubnetGroupName"]);
   }
   if (output["DBSubnetGroupDescription"] !== undefined) {
-    contents.DBSubnetGroupDescription = output["DBSubnetGroupDescription"];
+    contents.DBSubnetGroupDescription = __expectString(output["DBSubnetGroupDescription"]);
   }
   if (output["VpcId"] !== undefined) {
-    contents.VpcId = output["VpcId"];
+    contents.VpcId = __expectString(output["VpcId"]);
   }
   if (output["SubnetGroupStatus"] !== undefined) {
-    contents.SubnetGroupStatus = output["SubnetGroupStatus"];
+    contents.SubnetGroupStatus = __expectString(output["SubnetGroupStatus"]);
   }
   if (output.Subnets === "") {
     contents.Subnets = [];
@@ -7434,7 +7435,7 @@ const deserializeAws_queryDBSubnetGroup = (output: any, context: __SerdeContext)
     contents.Subnets = deserializeAws_querySubnetList(__getArrayIfSingleItem(output["Subnets"]["Subnet"]), context);
   }
   if (output["DBSubnetGroupArn"] !== undefined) {
-    contents.DBSubnetGroupArn = output["DBSubnetGroupArn"];
+    contents.DBSubnetGroupArn = __expectString(output["DBSubnetGroupArn"]);
   }
   return contents;
 };
@@ -7447,7 +7448,7 @@ const deserializeAws_queryDBSubnetGroupAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -7460,7 +7461,7 @@ const deserializeAws_queryDBSubnetGroupDoesNotCoverEnoughAZs = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -7471,7 +7472,7 @@ const deserializeAws_queryDBSubnetGroupMessage = (output: any, context: __SerdeC
     DBSubnetGroups: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.DBSubnetGroups === "") {
     contents.DBSubnetGroups = [];
@@ -7493,7 +7494,7 @@ const deserializeAws_queryDBSubnetGroupNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -7506,7 +7507,7 @@ const deserializeAws_queryDBSubnetGroupQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -7530,7 +7531,7 @@ const deserializeAws_queryDBSubnetQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -7543,7 +7544,7 @@ const deserializeAws_queryDBUpgradeDependencyFailureFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -7617,13 +7618,13 @@ const deserializeAws_queryEndpoint = (output: any, context: __SerdeContext): End
     HostedZoneId: undefined,
   };
   if (output["Address"] !== undefined) {
-    contents.Address = output["Address"];
+    contents.Address = __expectString(output["Address"]);
   }
   if (output["Port"] !== undefined) {
     contents.Port = parseInt(output["Port"]);
   }
   if (output["HostedZoneId"] !== undefined) {
-    contents.HostedZoneId = output["HostedZoneId"];
+    contents.HostedZoneId = __expectString(output["HostedZoneId"]);
   }
   return contents;
 };
@@ -7635,10 +7636,10 @@ const deserializeAws_queryEngineDefaults = (output: any, context: __SerdeContext
     Parameters: undefined,
   };
   if (output["DBParameterGroupFamily"] !== undefined) {
-    contents.DBParameterGroupFamily = output["DBParameterGroupFamily"];
+    contents.DBParameterGroupFamily = __expectString(output["DBParameterGroupFamily"]);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.Parameters === "") {
     contents.Parameters = [];
@@ -7662,13 +7663,13 @@ const deserializeAws_queryEvent = (output: any, context: __SerdeContext): Event 
     SourceArn: undefined,
   };
   if (output["SourceIdentifier"] !== undefined) {
-    contents.SourceIdentifier = output["SourceIdentifier"];
+    contents.SourceIdentifier = __expectString(output["SourceIdentifier"]);
   }
   if (output["SourceType"] !== undefined) {
-    contents.SourceType = output["SourceType"];
+    contents.SourceType = __expectString(output["SourceType"]);
   }
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   if (output.EventCategories === "") {
     contents.EventCategories = [];
@@ -7683,7 +7684,7 @@ const deserializeAws_queryEvent = (output: any, context: __SerdeContext): Event 
     contents.Date = new Date(output["Date"]);
   }
   if (output["SourceArn"] !== undefined) {
-    contents.SourceArn = output["SourceArn"];
+    contents.SourceArn = __expectString(output["SourceArn"]);
   }
   return contents;
 };
@@ -7695,7 +7696,7 @@ const deserializeAws_queryEventCategoriesList = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7705,7 +7706,7 @@ const deserializeAws_queryEventCategoriesMap = (output: any, context: __SerdeCon
     EventCategories: undefined,
   };
   if (output["SourceType"] !== undefined) {
-    contents.SourceType = output["SourceType"];
+    contents.SourceType = __expectString(output["SourceType"]);
   }
   if (output.EventCategories === "") {
     contents.EventCategories = [];
@@ -7766,7 +7767,7 @@ const deserializeAws_queryEventsMessage = (output: any, context: __SerdeContext)
     Events: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.Events === "") {
     contents.Events = [];
@@ -7795,7 +7796,7 @@ const deserializeAws_queryInstanceQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -7808,7 +7809,7 @@ const deserializeAws_queryInsufficientDBClusterCapacityFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -7821,7 +7822,7 @@ const deserializeAws_queryInsufficientDBInstanceCapacityFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -7834,7 +7835,7 @@ const deserializeAws_queryInsufficientStorageClusterCapacityFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -7847,7 +7848,7 @@ const deserializeAws_queryInvalidDBClusterSnapshotStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -7860,7 +7861,7 @@ const deserializeAws_queryInvalidDBClusterStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -7873,7 +7874,7 @@ const deserializeAws_queryInvalidDBInstanceStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -7886,7 +7887,7 @@ const deserializeAws_queryInvalidDBParameterGroupStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -7899,7 +7900,7 @@ const deserializeAws_queryInvalidDBSecurityGroupStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -7912,7 +7913,7 @@ const deserializeAws_queryInvalidDBSnapshotStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -7925,7 +7926,7 @@ const deserializeAws_queryInvalidDBSubnetGroupStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -7938,7 +7939,7 @@ const deserializeAws_queryInvalidDBSubnetStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -7948,7 +7949,7 @@ const deserializeAws_queryInvalidRestoreFault = (output: any, context: __SerdeCo
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -7958,7 +7959,7 @@ const deserializeAws_queryInvalidSubnet = (output: any, context: __SerdeContext)
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -7971,7 +7972,7 @@ const deserializeAws_queryInvalidVPCNetworkStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -7984,7 +7985,7 @@ const deserializeAws_queryKMSKeyNotAccessibleFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -7996,7 +7997,7 @@ const deserializeAws_queryLogTypeList = (output: any, context: __SerdeContext): 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -8062,16 +8063,16 @@ const deserializeAws_queryOrderableDBInstanceOption = (
     Vpc: undefined,
   };
   if (output["Engine"] !== undefined) {
-    contents.Engine = output["Engine"];
+    contents.Engine = __expectString(output["Engine"]);
   }
   if (output["EngineVersion"] !== undefined) {
-    contents.EngineVersion = output["EngineVersion"];
+    contents.EngineVersion = __expectString(output["EngineVersion"]);
   }
   if (output["DBInstanceClass"] !== undefined) {
-    contents.DBInstanceClass = output["DBInstanceClass"];
+    contents.DBInstanceClass = __expectString(output["DBInstanceClass"]);
   }
   if (output["LicenseModel"] !== undefined) {
-    contents.LicenseModel = output["LicenseModel"];
+    contents.LicenseModel = __expectString(output["LicenseModel"]);
   }
   if (output.AvailabilityZones === "") {
     contents.AvailabilityZones = [];
@@ -8123,7 +8124,7 @@ const deserializeAws_queryOrderableDBInstanceOptionsMessage = (
     );
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -8142,34 +8143,34 @@ const deserializeAws_queryParameter = (output: any, context: __SerdeContext): Pa
     ApplyMethod: undefined,
   };
   if (output["ParameterName"] !== undefined) {
-    contents.ParameterName = output["ParameterName"];
+    contents.ParameterName = __expectString(output["ParameterName"]);
   }
   if (output["ParameterValue"] !== undefined) {
-    contents.ParameterValue = output["ParameterValue"];
+    contents.ParameterValue = __expectString(output["ParameterValue"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output["Source"] !== undefined) {
-    contents.Source = output["Source"];
+    contents.Source = __expectString(output["Source"]);
   }
   if (output["ApplyType"] !== undefined) {
-    contents.ApplyType = output["ApplyType"];
+    contents.ApplyType = __expectString(output["ApplyType"]);
   }
   if (output["DataType"] !== undefined) {
-    contents.DataType = output["DataType"];
+    contents.DataType = __expectString(output["DataType"]);
   }
   if (output["AllowedValues"] !== undefined) {
-    contents.AllowedValues = output["AllowedValues"];
+    contents.AllowedValues = __expectString(output["AllowedValues"]);
   }
   if (output["IsModifiable"] !== undefined) {
     contents.IsModifiable = __parseBoolean(output["IsModifiable"]);
   }
   if (output["MinimumEngineVersion"] !== undefined) {
-    contents.MinimumEngineVersion = output["MinimumEngineVersion"];
+    contents.MinimumEngineVersion = __expectString(output["MinimumEngineVersion"]);
   }
   if (output["ApplyMethod"] !== undefined) {
-    contents.ApplyMethod = output["ApplyMethod"];
+    contents.ApplyMethod = __expectString(output["ApplyMethod"]);
   }
   return contents;
 };
@@ -8227,7 +8228,7 @@ const deserializeAws_queryPendingMaintenanceAction = (
     Description: undefined,
   };
   if (output["Action"] !== undefined) {
-    contents.Action = output["Action"];
+    contents.Action = __expectString(output["Action"]);
   }
   if (output["AutoAppliedAfterDate"] !== undefined) {
     contents.AutoAppliedAfterDate = new Date(output["AutoAppliedAfterDate"]);
@@ -8236,13 +8237,13 @@ const deserializeAws_queryPendingMaintenanceAction = (
     contents.ForcedApplyDate = new Date(output["ForcedApplyDate"]);
   }
   if (output["OptInStatus"] !== undefined) {
-    contents.OptInStatus = output["OptInStatus"];
+    contents.OptInStatus = __expectString(output["OptInStatus"]);
   }
   if (output["CurrentApplyDate"] !== undefined) {
     contents.CurrentApplyDate = new Date(output["CurrentApplyDate"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   return contents;
 };
@@ -8296,7 +8297,7 @@ const deserializeAws_queryPendingMaintenanceActionsMessage = (
     );
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -8319,13 +8320,13 @@ const deserializeAws_queryPendingModifiedValues = (output: any, context: __Serde
     PendingCloudwatchLogsExports: undefined,
   };
   if (output["DBInstanceClass"] !== undefined) {
-    contents.DBInstanceClass = output["DBInstanceClass"];
+    contents.DBInstanceClass = __expectString(output["DBInstanceClass"]);
   }
   if (output["AllocatedStorage"] !== undefined) {
     contents.AllocatedStorage = parseInt(output["AllocatedStorage"]);
   }
   if (output["MasterUserPassword"] !== undefined) {
-    contents.MasterUserPassword = output["MasterUserPassword"];
+    contents.MasterUserPassword = __expectString(output["MasterUserPassword"]);
   }
   if (output["Port"] !== undefined) {
     contents.Port = parseInt(output["Port"]);
@@ -8337,25 +8338,25 @@ const deserializeAws_queryPendingModifiedValues = (output: any, context: __Serde
     contents.MultiAZ = __parseBoolean(output["MultiAZ"]);
   }
   if (output["EngineVersion"] !== undefined) {
-    contents.EngineVersion = output["EngineVersion"];
+    contents.EngineVersion = __expectString(output["EngineVersion"]);
   }
   if (output["LicenseModel"] !== undefined) {
-    contents.LicenseModel = output["LicenseModel"];
+    contents.LicenseModel = __expectString(output["LicenseModel"]);
   }
   if (output["Iops"] !== undefined) {
     contents.Iops = parseInt(output["Iops"]);
   }
   if (output["DBInstanceIdentifier"] !== undefined) {
-    contents.DBInstanceIdentifier = output["DBInstanceIdentifier"];
+    contents.DBInstanceIdentifier = __expectString(output["DBInstanceIdentifier"]);
   }
   if (output["StorageType"] !== undefined) {
-    contents.StorageType = output["StorageType"];
+    contents.StorageType = __expectString(output["StorageType"]);
   }
   if (output["CACertificateIdentifier"] !== undefined) {
-    contents.CACertificateIdentifier = output["CACertificateIdentifier"];
+    contents.CACertificateIdentifier = __expectString(output["CACertificateIdentifier"]);
   }
   if (output["DBSubnetGroupName"] !== undefined) {
-    contents.DBSubnetGroupName = output["DBSubnetGroupName"];
+    contents.DBSubnetGroupName = __expectString(output["DBSubnetGroupName"]);
   }
   if (output["PendingCloudwatchLogsExports"] !== undefined) {
     contents.PendingCloudwatchLogsExports = deserializeAws_queryPendingCloudwatchLogsExports(
@@ -8381,7 +8382,7 @@ const deserializeAws_queryResourceNotFoundFault = (output: any, context: __Serde
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -8395,7 +8396,7 @@ const deserializeAws_queryResourcePendingMaintenanceActions = (
     PendingMaintenanceActionDetails: undefined,
   };
   if (output["ResourceIdentifier"] !== undefined) {
-    contents.ResourceIdentifier = output["ResourceIdentifier"];
+    contents.ResourceIdentifier = __expectString(output["ResourceIdentifier"]);
   }
   if (output.PendingMaintenanceActionDetails === "") {
     contents.PendingMaintenanceActionDetails = [];
@@ -8446,7 +8447,7 @@ const deserializeAws_querySharedSnapshotQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -8459,7 +8460,7 @@ const deserializeAws_querySnapshotQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -8492,7 +8493,7 @@ const deserializeAws_queryStorageQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -8505,7 +8506,7 @@ const deserializeAws_queryStorageTypeNotSupportedFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -8517,13 +8518,13 @@ const deserializeAws_querySubnet = (output: any, context: __SerdeContext): Subne
     SubnetStatus: undefined,
   };
   if (output["SubnetIdentifier"] !== undefined) {
-    contents.SubnetIdentifier = output["SubnetIdentifier"];
+    contents.SubnetIdentifier = __expectString(output["SubnetIdentifier"]);
   }
   if (output["SubnetAvailabilityZone"] !== undefined) {
     contents.SubnetAvailabilityZone = deserializeAws_queryAvailabilityZone(output["SubnetAvailabilityZone"], context);
   }
   if (output["SubnetStatus"] !== undefined) {
-    contents.SubnetStatus = output["SubnetStatus"];
+    contents.SubnetStatus = __expectString(output["SubnetStatus"]);
   }
   return contents;
 };
@@ -8533,7 +8534,7 @@ const deserializeAws_querySubnetAlreadyInUse = (output: any, context: __SerdeCon
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -8555,10 +8556,10 @@ const deserializeAws_queryTag = (output: any, context: __SerdeContext): Tag => {
     Value: undefined,
   };
   if (output["Key"] !== undefined) {
-    contents.Key = output["Key"];
+    contents.Key = __expectString(output["Key"]);
   }
   if (output["Value"] !== undefined) {
-    contents.Value = output["Value"];
+    contents.Value = __expectString(output["Value"]);
   }
   return contents;
 };
@@ -8596,13 +8597,13 @@ const deserializeAws_queryUpgradeTarget = (output: any, context: __SerdeContext)
     IsMajorVersionUpgrade: undefined,
   };
   if (output["Engine"] !== undefined) {
-    contents.Engine = output["Engine"];
+    contents.Engine = __expectString(output["Engine"]);
   }
   if (output["EngineVersion"] !== undefined) {
-    contents.EngineVersion = output["EngineVersion"];
+    contents.EngineVersion = __expectString(output["EngineVersion"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output["AutoUpgrade"] !== undefined) {
     contents.AutoUpgrade = __parseBoolean(output["AutoUpgrade"]);
@@ -8633,10 +8634,10 @@ const deserializeAws_queryVpcSecurityGroupMembership = (
     Status: undefined,
   };
   if (output["VpcSecurityGroupId"] !== undefined) {
-    contents.VpcSecurityGroupId = output["VpcSecurityGroupId"];
+    contents.VpcSecurityGroupId = __expectString(output["VpcSecurityGroupId"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   return contents;
 };

--- a/clients/client-dynamodb-streams/protocols/Aws_json1_0.ts
+++ b/clients/client-dynamodb-streams/protocols/Aws_json1_0.ts
@@ -27,7 +27,12 @@ import {
   _Stream,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -500,10 +505,8 @@ const deserializeAws_json1_0AttributeValue = (output: any, context: __SerdeConte
       B: context.base64Decoder(output.B),
     };
   }
-  if (output.BOOL !== undefined && output.BOOL !== null) {
-    return {
-      BOOL: output.BOOL,
-    };
+  if (__expectBoolean(output.BOOL) !== undefined) {
+    return { BOOL: __expectBoolean(output.BOOL) as any };
   }
   if (output.BS !== undefined && output.BS !== null) {
     return {
@@ -520,25 +523,19 @@ const deserializeAws_json1_0AttributeValue = (output: any, context: __SerdeConte
       M: deserializeAws_json1_0MapAttributeValue(output.M, context),
     };
   }
-  if (output.N !== undefined && output.N !== null) {
-    return {
-      N: output.N,
-    };
+  if (__expectString(output.N) !== undefined) {
+    return { N: __expectString(output.N) as any };
   }
   if (output.NS !== undefined && output.NS !== null) {
     return {
       NS: deserializeAws_json1_0NumberSetAttributeValue(output.NS, context),
     };
   }
-  if (output.NULL !== undefined && output.NULL !== null) {
-    return {
-      NULL: output.NULL,
-    };
+  if (__expectBoolean(output.NULL) !== undefined) {
+    return { NULL: __expectBoolean(output.NULL) as any };
   }
-  if (output.S !== undefined && output.S !== null) {
-    return {
-      S: output.S,
-    };
+  if (__expectString(output.S) !== undefined) {
+    return { S: __expectString(output.S) as any };
   }
   if (output.SS !== undefined && output.SS !== null) {
     return {
@@ -573,16 +570,13 @@ const deserializeAws_json1_0ExpiredIteratorException = (
   context: __SerdeContext
 ): ExpiredIteratorException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_0GetRecordsOutput = (output: any, context: __SerdeContext): GetRecordsOutput => {
   return {
-    NextShardIterator:
-      output.NextShardIterator !== undefined && output.NextShardIterator !== null
-        ? output.NextShardIterator
-        : undefined,
+    NextShardIterator: __expectString(output.NextShardIterator),
     Records:
       output.Records !== undefined && output.Records !== null
         ? deserializeAws_json1_0RecordList(output.Records, context)
@@ -592,21 +586,20 @@ const deserializeAws_json1_0GetRecordsOutput = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_0GetShardIteratorOutput = (output: any, context: __SerdeContext): GetShardIteratorOutput => {
   return {
-    ShardIterator:
-      output.ShardIterator !== undefined && output.ShardIterator !== null ? output.ShardIterator : undefined,
+    ShardIterator: __expectString(output.ShardIterator),
   } as any;
 };
 
 const deserializeAws_json1_0Identity = (output: any, context: __SerdeContext): Identity => {
   return {
-    PrincipalId: output.PrincipalId !== undefined && output.PrincipalId !== null ? output.PrincipalId : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    PrincipalId: __expectString(output.PrincipalId),
+    Type: __expectString(output.Type),
   } as any;
 };
 
 const deserializeAws_json1_0InternalServerError = (output: any, context: __SerdeContext): InternalServerError => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -623,15 +616,14 @@ const deserializeAws_json1_0KeySchema = (output: any, context: __SerdeContext): 
 
 const deserializeAws_json1_0KeySchemaElement = (output: any, context: __SerdeContext): KeySchemaElement => {
   return {
-    AttributeName:
-      output.AttributeName !== undefined && output.AttributeName !== null ? output.AttributeName : undefined,
-    KeyType: output.KeyType !== undefined && output.KeyType !== null ? output.KeyType : undefined,
+    AttributeName: __expectString(output.AttributeName),
+    KeyType: __expectString(output.KeyType),
   } as any;
 };
 
 const deserializeAws_json1_0LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -648,10 +640,7 @@ const deserializeAws_json1_0ListAttributeValue = (output: any, context: __SerdeC
 
 const deserializeAws_json1_0ListStreamsOutput = (output: any, context: __SerdeContext): ListStreamsOutput => {
   return {
-    LastEvaluatedStreamArn:
-      output.LastEvaluatedStreamArn !== undefined && output.LastEvaluatedStreamArn !== null
-        ? output.LastEvaluatedStreamArn
-        : undefined,
+    LastEvaluatedStreamArn: __expectString(output.LastEvaluatedStreamArn),
     Streams:
       output.Streams !== undefined && output.Streams !== null
         ? deserializeAws_json1_0StreamList(output.Streams, context)
@@ -681,21 +670,21 @@ const deserializeAws_json1_0NumberSetAttributeValue = (output: any, context: __S
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_0_Record = (output: any, context: __SerdeContext): _Record => {
   return {
-    awsRegion: output.awsRegion !== undefined && output.awsRegion !== null ? output.awsRegion : undefined,
+    awsRegion: __expectString(output.awsRegion),
     dynamodb:
       output.dynamodb !== undefined && output.dynamodb !== null
         ? deserializeAws_json1_0StreamRecord(output.dynamodb, context)
         : undefined,
-    eventID: output.eventID !== undefined && output.eventID !== null ? output.eventID : undefined,
-    eventName: output.eventName !== undefined && output.eventName !== null ? output.eventName : undefined,
-    eventSource: output.eventSource !== undefined && output.eventSource !== null ? output.eventSource : undefined,
-    eventVersion: output.eventVersion !== undefined && output.eventVersion !== null ? output.eventVersion : undefined,
+    eventID: __expectString(output.eventID),
+    eventName: __expectString(output.eventName),
+    eventSource: __expectString(output.eventSource),
+    eventVersion: __expectString(output.eventVersion),
     userIdentity:
       output.userIdentity !== undefined && output.userIdentity !== null
         ? deserializeAws_json1_0Identity(output.userIdentity, context)
@@ -719,32 +708,25 @@ const deserializeAws_json1_0ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_0SequenceNumberRange = (output: any, context: __SerdeContext): SequenceNumberRange => {
   return {
-    EndingSequenceNumber:
-      output.EndingSequenceNumber !== undefined && output.EndingSequenceNumber !== null
-        ? output.EndingSequenceNumber
-        : undefined,
-    StartingSequenceNumber:
-      output.StartingSequenceNumber !== undefined && output.StartingSequenceNumber !== null
-        ? output.StartingSequenceNumber
-        : undefined,
+    EndingSequenceNumber: __expectString(output.EndingSequenceNumber),
+    StartingSequenceNumber: __expectString(output.StartingSequenceNumber),
   } as any;
 };
 
 const deserializeAws_json1_0Shard = (output: any, context: __SerdeContext): Shard => {
   return {
-    ParentShardId:
-      output.ParentShardId !== undefined && output.ParentShardId !== null ? output.ParentShardId : undefined,
+    ParentShardId: __expectString(output.ParentShardId),
     SequenceNumberRange:
       output.SequenceNumberRange !== undefined && output.SequenceNumberRange !== null
         ? deserializeAws_json1_0SequenceNumberRange(output.SequenceNumberRange, context)
         : undefined,
-    ShardId: output.ShardId !== undefined && output.ShardId !== null ? output.ShardId : undefined,
+    ShardId: __expectString(output.ShardId),
   } as any;
 };
 
@@ -761,9 +743,9 @@ const deserializeAws_json1_0ShardDescriptionList = (output: any, context: __Serd
 
 const deserializeAws_json1_0_Stream = (output: any, context: __SerdeContext): _Stream => {
   return {
-    StreamArn: output.StreamArn !== undefined && output.StreamArn !== null ? output.StreamArn : undefined,
-    StreamLabel: output.StreamLabel !== undefined && output.StreamLabel !== null ? output.StreamLabel : undefined,
-    TableName: output.TableName !== undefined && output.TableName !== null ? output.TableName : undefined,
+    StreamArn: __expectString(output.StreamArn),
+    StreamLabel: __expectString(output.StreamLabel),
+    TableName: __expectString(output.TableName),
   } as any;
 };
 
@@ -777,20 +759,16 @@ const deserializeAws_json1_0StreamDescription = (output: any, context: __SerdeCo
       output.KeySchema !== undefined && output.KeySchema !== null
         ? deserializeAws_json1_0KeySchema(output.KeySchema, context)
         : undefined,
-    LastEvaluatedShardId:
-      output.LastEvaluatedShardId !== undefined && output.LastEvaluatedShardId !== null
-        ? output.LastEvaluatedShardId
-        : undefined,
+    LastEvaluatedShardId: __expectString(output.LastEvaluatedShardId),
     Shards:
       output.Shards !== undefined && output.Shards !== null
         ? deserializeAws_json1_0ShardDescriptionList(output.Shards, context)
         : undefined,
-    StreamArn: output.StreamArn !== undefined && output.StreamArn !== null ? output.StreamArn : undefined,
-    StreamLabel: output.StreamLabel !== undefined && output.StreamLabel !== null ? output.StreamLabel : undefined,
-    StreamStatus: output.StreamStatus !== undefined && output.StreamStatus !== null ? output.StreamStatus : undefined,
-    StreamViewType:
-      output.StreamViewType !== undefined && output.StreamViewType !== null ? output.StreamViewType : undefined,
-    TableName: output.TableName !== undefined && output.TableName !== null ? output.TableName : undefined,
+    StreamArn: __expectString(output.StreamArn),
+    StreamLabel: __expectString(output.StreamLabel),
+    StreamStatus: __expectString(output.StreamStatus),
+    StreamViewType: __expectString(output.StreamViewType),
+    TableName: __expectString(output.TableName),
   } as any;
 };
 
@@ -823,11 +801,9 @@ const deserializeAws_json1_0StreamRecord = (output: any, context: __SerdeContext
       output.OldImage !== undefined && output.OldImage !== null
         ? deserializeAws_json1_0AttributeMap(output.OldImage, context)
         : undefined,
-    SequenceNumber:
-      output.SequenceNumber !== undefined && output.SequenceNumber !== null ? output.SequenceNumber : undefined,
-    SizeBytes: output.SizeBytes !== undefined && output.SizeBytes !== null ? output.SizeBytes : undefined,
-    StreamViewType:
-      output.StreamViewType !== undefined && output.StreamViewType !== null ? output.StreamViewType : undefined,
+    SequenceNumber: __expectString(output.SequenceNumber),
+    SizeBytes: __expectNumber(output.SizeBytes),
+    StreamViewType: __expectString(output.StreamViewType),
   } as any;
 };
 
@@ -838,7 +814,7 @@ const deserializeAws_json1_0StringSetAttributeValue = (output: any, context: __S
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -847,7 +823,7 @@ const deserializeAws_json1_0TrimmedDataAccessException = (
   context: __SerdeContext
 ): TrimmedDataAccessException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 

--- a/clients/client-dynamodb/protocols/Aws_json1_0.ts
+++ b/clients/client-dynamodb/protocols/Aws_json1_0.ts
@@ -322,7 +322,12 @@ import {
   WriteRequest,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -7552,25 +7557,19 @@ const serializeAws_json1_0WriteRequests = (input: WriteRequest[], context: __Ser
 
 const deserializeAws_json1_0ArchivalSummary = (output: any, context: __SerdeContext): ArchivalSummary => {
   return {
-    ArchivalBackupArn:
-      output.ArchivalBackupArn !== undefined && output.ArchivalBackupArn !== null
-        ? output.ArchivalBackupArn
-        : undefined,
+    ArchivalBackupArn: __expectString(output.ArchivalBackupArn),
     ArchivalDateTime:
       output.ArchivalDateTime !== undefined && output.ArchivalDateTime !== null
         ? new Date(Math.round(output.ArchivalDateTime * 1000))
         : undefined,
-    ArchivalReason:
-      output.ArchivalReason !== undefined && output.ArchivalReason !== null ? output.ArchivalReason : undefined,
+    ArchivalReason: __expectString(output.ArchivalReason),
   } as any;
 };
 
 const deserializeAws_json1_0AttributeDefinition = (output: any, context: __SerdeContext): AttributeDefinition => {
   return {
-    AttributeName:
-      output.AttributeName !== undefined && output.AttributeName !== null ? output.AttributeName : undefined,
-    AttributeType:
-      output.AttributeType !== undefined && output.AttributeType !== null ? output.AttributeType : undefined,
+    AttributeName: __expectString(output.AttributeName),
+    AttributeType: __expectString(output.AttributeType),
   } as any;
 };
 
@@ -7607,7 +7606,7 @@ const deserializeAws_json1_0AttributeNameList = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7617,10 +7616,8 @@ const deserializeAws_json1_0AttributeValue = (output: any, context: __SerdeConte
       B: context.base64Decoder(output.B),
     };
   }
-  if (output.BOOL !== undefined && output.BOOL !== null) {
-    return {
-      BOOL: output.BOOL,
-    };
+  if (__expectBoolean(output.BOOL) !== undefined) {
+    return { BOOL: __expectBoolean(output.BOOL) as any };
   }
   if (output.BS !== undefined && output.BS !== null) {
     return {
@@ -7637,25 +7634,19 @@ const deserializeAws_json1_0AttributeValue = (output: any, context: __SerdeConte
       M: deserializeAws_json1_0MapAttributeValue(output.M, context),
     };
   }
-  if (output.N !== undefined && output.N !== null) {
-    return {
-      N: output.N,
-    };
+  if (__expectString(output.N) !== undefined) {
+    return { N: __expectString(output.N) as any };
   }
   if (output.NS !== undefined && output.NS !== null) {
     return {
       NS: deserializeAws_json1_0NumberSetAttributeValue(output.NS, context),
     };
   }
-  if (output.NULL !== undefined && output.NULL !== null) {
-    return {
-      NULL: output.NULL,
-    };
+  if (__expectBoolean(output.NULL) !== undefined) {
+    return { NULL: __expectBoolean(output.NULL) as any };
   }
-  if (output.S !== undefined && output.S !== null) {
-    return {
-      S: output.S,
-    };
+  if (__expectString(output.S) !== undefined) {
+    return { S: __expectString(output.S) as any };
   }
   if (output.SS !== undefined && output.SS !== null) {
     return {
@@ -7670,7 +7661,7 @@ const deserializeAws_json1_0AutoScalingPolicyDescription = (
   context: __SerdeContext
 ): AutoScalingPolicyDescription => {
   return {
-    PolicyName: output.PolicyName !== undefined && output.PolicyName !== null ? output.PolicyName : undefined,
+    PolicyName: __expectString(output.PolicyName),
     TargetTrackingScalingPolicyConfiguration:
       output.TargetTrackingScalingPolicyConfiguration !== undefined &&
       output.TargetTrackingScalingPolicyConfiguration !== null
@@ -7701,16 +7692,10 @@ const deserializeAws_json1_0AutoScalingSettingsDescription = (
   context: __SerdeContext
 ): AutoScalingSettingsDescription => {
   return {
-    AutoScalingDisabled:
-      output.AutoScalingDisabled !== undefined && output.AutoScalingDisabled !== null
-        ? output.AutoScalingDisabled
-        : undefined,
-    AutoScalingRoleArn:
-      output.AutoScalingRoleArn !== undefined && output.AutoScalingRoleArn !== null
-        ? output.AutoScalingRoleArn
-        : undefined,
-    MaximumUnits: output.MaximumUnits !== undefined && output.MaximumUnits !== null ? output.MaximumUnits : undefined,
-    MinimumUnits: output.MinimumUnits !== undefined && output.MinimumUnits !== null ? output.MinimumUnits : undefined,
+    AutoScalingDisabled: __expectBoolean(output.AutoScalingDisabled),
+    AutoScalingRoleArn: __expectString(output.AutoScalingRoleArn),
+    MaximumUnits: __expectNumber(output.MaximumUnits),
+    MinimumUnits: __expectNumber(output.MinimumUnits),
     ScalingPolicies:
       output.ScalingPolicies !== undefined && output.ScalingPolicies !== null
         ? deserializeAws_json1_0AutoScalingPolicyDescriptionList(output.ScalingPolicies, context)
@@ -7723,13 +7708,10 @@ const deserializeAws_json1_0AutoScalingTargetTrackingScalingPolicyConfigurationD
   context: __SerdeContext
 ): AutoScalingTargetTrackingScalingPolicyConfigurationDescription => {
   return {
-    DisableScaleIn:
-      output.DisableScaleIn !== undefined && output.DisableScaleIn !== null ? output.DisableScaleIn : undefined,
-    ScaleInCooldown:
-      output.ScaleInCooldown !== undefined && output.ScaleInCooldown !== null ? output.ScaleInCooldown : undefined,
-    ScaleOutCooldown:
-      output.ScaleOutCooldown !== undefined && output.ScaleOutCooldown !== null ? output.ScaleOutCooldown : undefined,
-    TargetValue: output.TargetValue !== undefined && output.TargetValue !== null ? output.TargetValue : undefined,
+    DisableScaleIn: __expectBoolean(output.DisableScaleIn),
+    ScaleInCooldown: __expectNumber(output.ScaleInCooldown),
+    ScaleOutCooldown: __expectNumber(output.ScaleOutCooldown),
+    TargetValue: __expectNumber(output.TargetValue),
   } as any;
 };
 
@@ -7752,7 +7734,7 @@ const deserializeAws_json1_0BackupDescription = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_0BackupDetails = (output: any, context: __SerdeContext): BackupDetails => {
   return {
-    BackupArn: output.BackupArn !== undefined && output.BackupArn !== null ? output.BackupArn : undefined,
+    BackupArn: __expectString(output.BackupArn),
     BackupCreationDateTime:
       output.BackupCreationDateTime !== undefined && output.BackupCreationDateTime !== null
         ? new Date(Math.round(output.BackupCreationDateTime * 1000))
@@ -7761,17 +7743,16 @@ const deserializeAws_json1_0BackupDetails = (output: any, context: __SerdeContex
       output.BackupExpiryDateTime !== undefined && output.BackupExpiryDateTime !== null
         ? new Date(Math.round(output.BackupExpiryDateTime * 1000))
         : undefined,
-    BackupName: output.BackupName !== undefined && output.BackupName !== null ? output.BackupName : undefined,
-    BackupSizeBytes:
-      output.BackupSizeBytes !== undefined && output.BackupSizeBytes !== null ? output.BackupSizeBytes : undefined,
-    BackupStatus: output.BackupStatus !== undefined && output.BackupStatus !== null ? output.BackupStatus : undefined,
-    BackupType: output.BackupType !== undefined && output.BackupType !== null ? output.BackupType : undefined,
+    BackupName: __expectString(output.BackupName),
+    BackupSizeBytes: __expectNumber(output.BackupSizeBytes),
+    BackupStatus: __expectString(output.BackupStatus),
+    BackupType: __expectString(output.BackupType),
   } as any;
 };
 
 const deserializeAws_json1_0BackupInUseException = (output: any, context: __SerdeContext): BackupInUseException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -7780,7 +7761,7 @@ const deserializeAws_json1_0BackupNotFoundException = (
   context: __SerdeContext
 ): BackupNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -7797,7 +7778,7 @@ const deserializeAws_json1_0BackupSummaries = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_0BackupSummary = (output: any, context: __SerdeContext): BackupSummary => {
   return {
-    BackupArn: output.BackupArn !== undefined && output.BackupArn !== null ? output.BackupArn : undefined,
+    BackupArn: __expectString(output.BackupArn),
     BackupCreationDateTime:
       output.BackupCreationDateTime !== undefined && output.BackupCreationDateTime !== null
         ? new Date(Math.round(output.BackupCreationDateTime * 1000))
@@ -7806,14 +7787,13 @@ const deserializeAws_json1_0BackupSummary = (output: any, context: __SerdeContex
       output.BackupExpiryDateTime !== undefined && output.BackupExpiryDateTime !== null
         ? new Date(Math.round(output.BackupExpiryDateTime * 1000))
         : undefined,
-    BackupName: output.BackupName !== undefined && output.BackupName !== null ? output.BackupName : undefined,
-    BackupSizeBytes:
-      output.BackupSizeBytes !== undefined && output.BackupSizeBytes !== null ? output.BackupSizeBytes : undefined,
-    BackupStatus: output.BackupStatus !== undefined && output.BackupStatus !== null ? output.BackupStatus : undefined,
-    BackupType: output.BackupType !== undefined && output.BackupType !== null ? output.BackupType : undefined,
-    TableArn: output.TableArn !== undefined && output.TableArn !== null ? output.TableArn : undefined,
-    TableId: output.TableId !== undefined && output.TableId !== null ? output.TableId : undefined,
-    TableName: output.TableName !== undefined && output.TableName !== null ? output.TableName : undefined,
+    BackupName: __expectString(output.BackupName),
+    BackupSizeBytes: __expectNumber(output.BackupSizeBytes),
+    BackupStatus: __expectString(output.BackupStatus),
+    BackupType: __expectString(output.BackupType),
+    TableArn: __expectString(output.TableArn),
+    TableId: __expectString(output.TableId),
+    TableName: __expectString(output.TableName),
   } as any;
 };
 
@@ -7881,8 +7861,8 @@ const deserializeAws_json1_0BatchGetResponseMap = (
 
 const deserializeAws_json1_0BatchStatementError = (output: any, context: __SerdeContext): BatchStatementError => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7896,7 +7876,7 @@ const deserializeAws_json1_0BatchStatementResponse = (output: any, context: __Se
       output.Item !== undefined && output.Item !== null
         ? deserializeAws_json1_0AttributeMap(output.Item, context)
         : undefined,
-    TableName: output.TableName !== undefined && output.TableName !== null ? output.TableName : undefined,
+    TableName: __expectString(output.TableName),
   } as any;
 };
 
@@ -7934,7 +7914,7 @@ const deserializeAws_json1_0BatchWriteItemRequestMap = (
 
 const deserializeAws_json1_0BillingModeSummary = (output: any, context: __SerdeContext): BillingModeSummary => {
   return {
-    BillingMode: output.BillingMode !== undefined && output.BillingMode !== null ? output.BillingMode : undefined,
+    BillingMode: __expectString(output.BillingMode),
     LastUpdateToPayPerRequestDateTime:
       output.LastUpdateToPayPerRequestDateTime !== undefined && output.LastUpdateToPayPerRequestDateTime !== null
         ? new Date(Math.round(output.LastUpdateToPayPerRequestDateTime * 1000))
@@ -7955,12 +7935,12 @@ const deserializeAws_json1_0BinarySetAttributeValue = (output: any, context: __S
 
 const deserializeAws_json1_0CancellationReason = (output: any, context: __SerdeContext): CancellationReason => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
+    Code: __expectString(output.Code),
     Item:
       output.Item !== undefined && output.Item !== null
         ? deserializeAws_json1_0AttributeMap(output.Item, context)
         : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7977,16 +7957,9 @@ const deserializeAws_json1_0CancellationReasonList = (output: any, context: __Se
 
 const deserializeAws_json1_0Capacity = (output: any, context: __SerdeContext): Capacity => {
   return {
-    CapacityUnits:
-      output.CapacityUnits !== undefined && output.CapacityUnits !== null ? output.CapacityUnits : undefined,
-    ReadCapacityUnits:
-      output.ReadCapacityUnits !== undefined && output.ReadCapacityUnits !== null
-        ? output.ReadCapacityUnits
-        : undefined,
-    WriteCapacityUnits:
-      output.WriteCapacityUnits !== undefined && output.WriteCapacityUnits !== null
-        ? output.WriteCapacityUnits
-        : undefined,
+    CapacityUnits: __expectNumber(output.CapacityUnits),
+    ReadCapacityUnits: __expectNumber(output.ReadCapacityUnits),
+    WriteCapacityUnits: __expectNumber(output.WriteCapacityUnits),
   } as any;
 };
 
@@ -7995,14 +7968,13 @@ const deserializeAws_json1_0ConditionalCheckFailedException = (
   context: __SerdeContext
 ): ConditionalCheckFailedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_0ConsumedCapacity = (output: any, context: __SerdeContext): ConsumedCapacity => {
   return {
-    CapacityUnits:
-      output.CapacityUnits !== undefined && output.CapacityUnits !== null ? output.CapacityUnits : undefined,
+    CapacityUnits: __expectNumber(output.CapacityUnits),
     GlobalSecondaryIndexes:
       output.GlobalSecondaryIndexes !== undefined && output.GlobalSecondaryIndexes !== null
         ? deserializeAws_json1_0SecondaryIndexesCapacityMap(output.GlobalSecondaryIndexes, context)
@@ -8011,19 +7983,13 @@ const deserializeAws_json1_0ConsumedCapacity = (output: any, context: __SerdeCon
       output.LocalSecondaryIndexes !== undefined && output.LocalSecondaryIndexes !== null
         ? deserializeAws_json1_0SecondaryIndexesCapacityMap(output.LocalSecondaryIndexes, context)
         : undefined,
-    ReadCapacityUnits:
-      output.ReadCapacityUnits !== undefined && output.ReadCapacityUnits !== null
-        ? output.ReadCapacityUnits
-        : undefined,
+    ReadCapacityUnits: __expectNumber(output.ReadCapacityUnits),
     Table:
       output.Table !== undefined && output.Table !== null
         ? deserializeAws_json1_0Capacity(output.Table, context)
         : undefined,
-    TableName: output.TableName !== undefined && output.TableName !== null ? output.TableName : undefined,
-    WriteCapacityUnits:
-      output.WriteCapacityUnits !== undefined && output.WriteCapacityUnits !== null
-        ? output.WriteCapacityUnits
-        : undefined,
+    TableName: __expectString(output.TableName),
+    WriteCapacityUnits: __expectNumber(output.WriteCapacityUnits),
   } as any;
 };
 
@@ -8043,10 +8009,7 @@ const deserializeAws_json1_0ContinuousBackupsDescription = (
   context: __SerdeContext
 ): ContinuousBackupsDescription => {
   return {
-    ContinuousBackupsStatus:
-      output.ContinuousBackupsStatus !== undefined && output.ContinuousBackupsStatus !== null
-        ? output.ContinuousBackupsStatus
-        : undefined,
+    ContinuousBackupsStatus: __expectString(output.ContinuousBackupsStatus),
     PointInTimeRecoveryDescription:
       output.PointInTimeRecoveryDescription !== undefined && output.PointInTimeRecoveryDescription !== null
         ? deserializeAws_json1_0PointInTimeRecoveryDescription(output.PointInTimeRecoveryDescription, context)
@@ -8059,7 +8022,7 @@ const deserializeAws_json1_0ContinuousBackupsUnavailableException = (
   context: __SerdeContext
 ): ContinuousBackupsUnavailableException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -8070,7 +8033,7 @@ const deserializeAws_json1_0ContributorInsightsRuleList = (output: any, context:
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -8093,12 +8056,9 @@ const deserializeAws_json1_0ContributorInsightsSummary = (
   context: __SerdeContext
 ): ContributorInsightsSummary => {
   return {
-    ContributorInsightsStatus:
-      output.ContributorInsightsStatus !== undefined && output.ContributorInsightsStatus !== null
-        ? output.ContributorInsightsStatus
-        : undefined,
-    IndexName: output.IndexName !== undefined && output.IndexName !== null ? output.IndexName : undefined,
-    TableName: output.TableName !== undefined && output.TableName !== null ? output.TableName : undefined,
+    ContributorInsightsStatus: __expectString(output.ContributorInsightsStatus),
+    IndexName: __expectString(output.IndexName),
+    TableName: __expectString(output.TableName),
   } as any;
 };
 
@@ -8203,20 +8163,17 @@ const deserializeAws_json1_0DescribeContributorInsightsOutput = (
       output.ContributorInsightsRuleList !== undefined && output.ContributorInsightsRuleList !== null
         ? deserializeAws_json1_0ContributorInsightsRuleList(output.ContributorInsightsRuleList, context)
         : undefined,
-    ContributorInsightsStatus:
-      output.ContributorInsightsStatus !== undefined && output.ContributorInsightsStatus !== null
-        ? output.ContributorInsightsStatus
-        : undefined,
+    ContributorInsightsStatus: __expectString(output.ContributorInsightsStatus),
     FailureException:
       output.FailureException !== undefined && output.FailureException !== null
         ? deserializeAws_json1_0FailureException(output.FailureException, context)
         : undefined,
-    IndexName: output.IndexName !== undefined && output.IndexName !== null ? output.IndexName : undefined,
+    IndexName: __expectString(output.IndexName),
     LastUpdateDateTime:
       output.LastUpdateDateTime !== undefined && output.LastUpdateDateTime !== null
         ? new Date(Math.round(output.LastUpdateDateTime * 1000))
         : undefined,
-    TableName: output.TableName !== undefined && output.TableName !== null ? output.TableName : undefined,
+    TableName: __expectString(output.TableName),
   } as any;
 };
 
@@ -8258,8 +8215,7 @@ const deserializeAws_json1_0DescribeGlobalTableSettingsOutput = (
   context: __SerdeContext
 ): DescribeGlobalTableSettingsOutput => {
   return {
-    GlobalTableName:
-      output.GlobalTableName !== undefined && output.GlobalTableName !== null ? output.GlobalTableName : undefined,
+    GlobalTableName: __expectString(output.GlobalTableName),
     ReplicaSettings:
       output.ReplicaSettings !== undefined && output.ReplicaSettings !== null
         ? deserializeAws_json1_0ReplicaSettingsDescriptionList(output.ReplicaSettings, context)
@@ -8276,28 +8232,16 @@ const deserializeAws_json1_0DescribeKinesisStreamingDestinationOutput = (
       output.KinesisDataStreamDestinations !== undefined && output.KinesisDataStreamDestinations !== null
         ? deserializeAws_json1_0KinesisDataStreamDestinations(output.KinesisDataStreamDestinations, context)
         : undefined,
-    TableName: output.TableName !== undefined && output.TableName !== null ? output.TableName : undefined,
+    TableName: __expectString(output.TableName),
   } as any;
 };
 
 const deserializeAws_json1_0DescribeLimitsOutput = (output: any, context: __SerdeContext): DescribeLimitsOutput => {
   return {
-    AccountMaxReadCapacityUnits:
-      output.AccountMaxReadCapacityUnits !== undefined && output.AccountMaxReadCapacityUnits !== null
-        ? output.AccountMaxReadCapacityUnits
-        : undefined,
-    AccountMaxWriteCapacityUnits:
-      output.AccountMaxWriteCapacityUnits !== undefined && output.AccountMaxWriteCapacityUnits !== null
-        ? output.AccountMaxWriteCapacityUnits
-        : undefined,
-    TableMaxReadCapacityUnits:
-      output.TableMaxReadCapacityUnits !== undefined && output.TableMaxReadCapacityUnits !== null
-        ? output.TableMaxReadCapacityUnits
-        : undefined,
-    TableMaxWriteCapacityUnits:
-      output.TableMaxWriteCapacityUnits !== undefined && output.TableMaxWriteCapacityUnits !== null
-        ? output.TableMaxWriteCapacityUnits
-        : undefined,
+    AccountMaxReadCapacityUnits: __expectNumber(output.AccountMaxReadCapacityUnits),
+    AccountMaxWriteCapacityUnits: __expectNumber(output.AccountMaxWriteCapacityUnits),
+    TableMaxReadCapacityUnits: __expectNumber(output.TableMaxReadCapacityUnits),
+    TableMaxWriteCapacityUnits: __expectNumber(output.TableMaxWriteCapacityUnits),
   } as any;
 };
 
@@ -8336,17 +8280,14 @@ const deserializeAws_json1_0DescribeTimeToLiveOutput = (
 
 const deserializeAws_json1_0DuplicateItemException = (output: any, context: __SerdeContext): DuplicateItemException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_0Endpoint = (output: any, context: __SerdeContext): Endpoint => {
   return {
-    Address: output.Address !== undefined && output.Address !== null ? output.Address : undefined,
-    CachePeriodInMinutes:
-      output.CachePeriodInMinutes !== undefined && output.CachePeriodInMinutes !== null
-        ? output.CachePeriodInMinutes
-        : undefined,
+    Address: __expectString(output.Address),
+    CachePeriodInMinutes: __expectNumber(output.CachePeriodInMinutes),
   } as any;
 };
 
@@ -8367,7 +8308,7 @@ const deserializeAws_json1_0ExecuteStatementOutput = (output: any, context: __Se
       output.Items !== undefined && output.Items !== null
         ? deserializeAws_json1_0ItemList(output.Items, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -8388,44 +8329,38 @@ const deserializeAws_json1_0ExportConflictException = (
   context: __SerdeContext
 ): ExportConflictException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_0ExportDescription = (output: any, context: __SerdeContext): ExportDescription => {
   return {
-    BilledSizeBytes:
-      output.BilledSizeBytes !== undefined && output.BilledSizeBytes !== null ? output.BilledSizeBytes : undefined,
-    ClientToken: output.ClientToken !== undefined && output.ClientToken !== null ? output.ClientToken : undefined,
+    BilledSizeBytes: __expectNumber(output.BilledSizeBytes),
+    ClientToken: __expectString(output.ClientToken),
     EndTime:
       output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
-    ExportArn: output.ExportArn !== undefined && output.ExportArn !== null ? output.ExportArn : undefined,
-    ExportFormat: output.ExportFormat !== undefined && output.ExportFormat !== null ? output.ExportFormat : undefined,
-    ExportManifest:
-      output.ExportManifest !== undefined && output.ExportManifest !== null ? output.ExportManifest : undefined,
-    ExportStatus: output.ExportStatus !== undefined && output.ExportStatus !== null ? output.ExportStatus : undefined,
+    ExportArn: __expectString(output.ExportArn),
+    ExportFormat: __expectString(output.ExportFormat),
+    ExportManifest: __expectString(output.ExportManifest),
+    ExportStatus: __expectString(output.ExportStatus),
     ExportTime:
       output.ExportTime !== undefined && output.ExportTime !== null
         ? new Date(Math.round(output.ExportTime * 1000))
         : undefined,
-    FailureCode: output.FailureCode !== undefined && output.FailureCode !== null ? output.FailureCode : undefined,
-    FailureMessage:
-      output.FailureMessage !== undefined && output.FailureMessage !== null ? output.FailureMessage : undefined,
-    ItemCount: output.ItemCount !== undefined && output.ItemCount !== null ? output.ItemCount : undefined,
-    S3Bucket: output.S3Bucket !== undefined && output.S3Bucket !== null ? output.S3Bucket : undefined,
-    S3BucketOwner:
-      output.S3BucketOwner !== undefined && output.S3BucketOwner !== null ? output.S3BucketOwner : undefined,
-    S3Prefix: output.S3Prefix !== undefined && output.S3Prefix !== null ? output.S3Prefix : undefined,
-    S3SseAlgorithm:
-      output.S3SseAlgorithm !== undefined && output.S3SseAlgorithm !== null ? output.S3SseAlgorithm : undefined,
-    S3SseKmsKeyId:
-      output.S3SseKmsKeyId !== undefined && output.S3SseKmsKeyId !== null ? output.S3SseKmsKeyId : undefined,
+    FailureCode: __expectString(output.FailureCode),
+    FailureMessage: __expectString(output.FailureMessage),
+    ItemCount: __expectNumber(output.ItemCount),
+    S3Bucket: __expectString(output.S3Bucket),
+    S3BucketOwner: __expectString(output.S3BucketOwner),
+    S3Prefix: __expectString(output.S3Prefix),
+    S3SseAlgorithm: __expectString(output.S3SseAlgorithm),
+    S3SseKmsKeyId: __expectString(output.S3SseKmsKeyId),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
         ? new Date(Math.round(output.StartTime * 1000))
         : undefined,
-    TableArn: output.TableArn !== undefined && output.TableArn !== null ? output.TableArn : undefined,
-    TableId: output.TableId !== undefined && output.TableId !== null ? output.TableId : undefined,
+    TableArn: __expectString(output.TableArn),
+    TableId: __expectString(output.TableId),
   } as any;
 };
 
@@ -8434,7 +8369,7 @@ const deserializeAws_json1_0ExportNotFoundException = (
   context: __SerdeContext
 ): ExportNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -8451,8 +8386,8 @@ const deserializeAws_json1_0ExportSummaries = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_0ExportSummary = (output: any, context: __SerdeContext): ExportSummary => {
   return {
-    ExportArn: output.ExportArn !== undefined && output.ExportArn !== null ? output.ExportArn : undefined,
-    ExportStatus: output.ExportStatus !== undefined && output.ExportStatus !== null ? output.ExportStatus : undefined,
+    ExportArn: __expectString(output.ExportArn),
+    ExportStatus: __expectString(output.ExportStatus),
   } as any;
 };
 
@@ -8478,19 +8413,15 @@ const deserializeAws_json1_0ExpressionAttributeNameMap = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_json1_0FailureException = (output: any, context: __SerdeContext): FailureException => {
   return {
-    ExceptionDescription:
-      output.ExceptionDescription !== undefined && output.ExceptionDescription !== null
-        ? output.ExceptionDescription
-        : undefined,
-    ExceptionName:
-      output.ExceptionName !== undefined && output.ExceptionName !== null ? output.ExceptionName : undefined,
+    ExceptionDescription: __expectString(output.ExceptionDescription),
+    ExceptionName: __expectString(output.ExceptionName),
   } as any;
 };
 
@@ -8512,13 +8443,12 @@ const deserializeAws_json1_0GlobalSecondaryIndexDescription = (
   context: __SerdeContext
 ): GlobalSecondaryIndexDescription => {
   return {
-    Backfilling: output.Backfilling !== undefined && output.Backfilling !== null ? output.Backfilling : undefined,
-    IndexArn: output.IndexArn !== undefined && output.IndexArn !== null ? output.IndexArn : undefined,
-    IndexName: output.IndexName !== undefined && output.IndexName !== null ? output.IndexName : undefined,
-    IndexSizeBytes:
-      output.IndexSizeBytes !== undefined && output.IndexSizeBytes !== null ? output.IndexSizeBytes : undefined,
-    IndexStatus: output.IndexStatus !== undefined && output.IndexStatus !== null ? output.IndexStatus : undefined,
-    ItemCount: output.ItemCount !== undefined && output.ItemCount !== null ? output.ItemCount : undefined,
+    Backfilling: __expectBoolean(output.Backfilling),
+    IndexArn: __expectString(output.IndexArn),
+    IndexName: __expectString(output.IndexName),
+    IndexSizeBytes: __expectNumber(output.IndexSizeBytes),
+    IndexStatus: __expectString(output.IndexStatus),
+    ItemCount: __expectNumber(output.ItemCount),
     KeySchema:
       output.KeySchema !== undefined && output.KeySchema !== null
         ? deserializeAws_json1_0KeySchema(output.KeySchema, context)
@@ -8567,7 +8497,7 @@ const deserializeAws_json1_0GlobalSecondaryIndexInfo = (
   context: __SerdeContext
 ): GlobalSecondaryIndexInfo => {
   return {
-    IndexName: output.IndexName !== undefined && output.IndexName !== null ? output.IndexName : undefined,
+    IndexName: __expectString(output.IndexName),
     KeySchema:
       output.KeySchema !== undefined && output.KeySchema !== null
         ? deserializeAws_json1_0KeySchema(output.KeySchema, context)
@@ -8585,8 +8515,7 @@ const deserializeAws_json1_0GlobalSecondaryIndexInfo = (
 
 const deserializeAws_json1_0GlobalTable = (output: any, context: __SerdeContext): GlobalTable => {
   return {
-    GlobalTableName:
-      output.GlobalTableName !== undefined && output.GlobalTableName !== null ? output.GlobalTableName : undefined,
+    GlobalTableName: __expectString(output.GlobalTableName),
     ReplicationGroup:
       output.ReplicationGroup !== undefined && output.ReplicationGroup !== null
         ? deserializeAws_json1_0ReplicaList(output.ReplicationGroup, context)
@@ -8599,7 +8528,7 @@ const deserializeAws_json1_0GlobalTableAlreadyExistsException = (
   context: __SerdeContext
 ): GlobalTableAlreadyExistsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -8609,14 +8538,9 @@ const deserializeAws_json1_0GlobalTableDescription = (output: any, context: __Se
       output.CreationDateTime !== undefined && output.CreationDateTime !== null
         ? new Date(Math.round(output.CreationDateTime * 1000))
         : undefined,
-    GlobalTableArn:
-      output.GlobalTableArn !== undefined && output.GlobalTableArn !== null ? output.GlobalTableArn : undefined,
-    GlobalTableName:
-      output.GlobalTableName !== undefined && output.GlobalTableName !== null ? output.GlobalTableName : undefined,
-    GlobalTableStatus:
-      output.GlobalTableStatus !== undefined && output.GlobalTableStatus !== null
-        ? output.GlobalTableStatus
-        : undefined,
+    GlobalTableArn: __expectString(output.GlobalTableArn),
+    GlobalTableName: __expectString(output.GlobalTableName),
+    GlobalTableStatus: __expectString(output.GlobalTableStatus),
     ReplicationGroup:
       output.ReplicationGroup !== undefined && output.ReplicationGroup !== null
         ? deserializeAws_json1_0ReplicaDescriptionList(output.ReplicationGroup, context)
@@ -8640,7 +8564,7 @@ const deserializeAws_json1_0GlobalTableNotFoundException = (
   context: __SerdeContext
 ): GlobalTableNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -8649,19 +8573,19 @@ const deserializeAws_json1_0IdempotentParameterMismatchException = (
   context: __SerdeContext
 ): IdempotentParameterMismatchException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_0IndexNotFoundException = (output: any, context: __SerdeContext): IndexNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_0InternalServerError = (output: any, context: __SerdeContext): InternalServerError => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -8670,7 +8594,7 @@ const deserializeAws_json1_0InvalidEndpointException = (
   context: __SerdeContext
 ): InvalidEndpointException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -8679,7 +8603,7 @@ const deserializeAws_json1_0InvalidExportTimeException = (
   context: __SerdeContext
 ): InvalidExportTimeException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -8688,7 +8612,7 @@ const deserializeAws_json1_0InvalidRestoreTimeException = (
   context: __SerdeContext
 ): InvalidRestoreTimeException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -8759,7 +8683,7 @@ const deserializeAws_json1_0ItemCollectionSizeEstimateRange = (output: any, cont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectNumber(entry) as any;
     });
 };
 
@@ -8768,7 +8692,7 @@ const deserializeAws_json1_0ItemCollectionSizeLimitExceededException = (
   context: __SerdeContext
 ): ItemCollectionSizeLimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -8832,8 +8756,7 @@ const deserializeAws_json1_0KeysAndAttributes = (output: any, context: __SerdeCo
       output.AttributesToGet !== undefined && output.AttributesToGet !== null
         ? deserializeAws_json1_0AttributeNameList(output.AttributesToGet, context)
         : undefined,
-    ConsistentRead:
-      output.ConsistentRead !== undefined && output.ConsistentRead !== null ? output.ConsistentRead : undefined,
+    ConsistentRead: __expectBoolean(output.ConsistentRead),
     ExpressionAttributeNames:
       output.ExpressionAttributeNames !== undefined && output.ExpressionAttributeNames !== null
         ? deserializeAws_json1_0ExpressionAttributeNameMap(output.ExpressionAttributeNames, context)
@@ -8842,10 +8765,7 @@ const deserializeAws_json1_0KeysAndAttributes = (output: any, context: __SerdeCo
       output.Keys !== undefined && output.Keys !== null
         ? deserializeAws_json1_0KeyList(output.Keys, context)
         : undefined,
-    ProjectionExpression:
-      output.ProjectionExpression !== undefined && output.ProjectionExpression !== null
-        ? output.ProjectionExpression
-        : undefined,
+    ProjectionExpression: __expectString(output.ProjectionExpression),
   } as any;
 };
 
@@ -8862,9 +8782,8 @@ const deserializeAws_json1_0KeySchema = (output: any, context: __SerdeContext): 
 
 const deserializeAws_json1_0KeySchemaElement = (output: any, context: __SerdeContext): KeySchemaElement => {
   return {
-    AttributeName:
-      output.AttributeName !== undefined && output.AttributeName !== null ? output.AttributeName : undefined,
-    KeyType: output.KeyType !== undefined && output.KeyType !== null ? output.KeyType : undefined,
+    AttributeName: __expectString(output.AttributeName),
+    KeyType: __expectString(output.KeyType),
   } as any;
 };
 
@@ -8873,15 +8792,9 @@ const deserializeAws_json1_0KinesisDataStreamDestination = (
   context: __SerdeContext
 ): KinesisDataStreamDestination => {
   return {
-    DestinationStatus:
-      output.DestinationStatus !== undefined && output.DestinationStatus !== null
-        ? output.DestinationStatus
-        : undefined,
-    DestinationStatusDescription:
-      output.DestinationStatusDescription !== undefined && output.DestinationStatusDescription !== null
-        ? output.DestinationStatusDescription
-        : undefined,
-    StreamArn: output.StreamArn !== undefined && output.StreamArn !== null ? output.StreamArn : undefined,
+    DestinationStatus: __expectString(output.DestinationStatus),
+    DestinationStatusDescription: __expectString(output.DestinationStatusDescription),
+    StreamArn: __expectString(output.StreamArn),
   } as any;
 };
 
@@ -8904,18 +8817,15 @@ const deserializeAws_json1_0KinesisStreamingDestinationOutput = (
   context: __SerdeContext
 ): KinesisStreamingDestinationOutput => {
   return {
-    DestinationStatus:
-      output.DestinationStatus !== undefined && output.DestinationStatus !== null
-        ? output.DestinationStatus
-        : undefined,
-    StreamArn: output.StreamArn !== undefined && output.StreamArn !== null ? output.StreamArn : undefined,
-    TableName: output.TableName !== undefined && output.TableName !== null ? output.TableName : undefined,
+    DestinationStatus: __expectString(output.DestinationStatus),
+    StreamArn: __expectString(output.StreamArn),
+    TableName: __expectString(output.TableName),
   } as any;
 };
 
 const deserializeAws_json1_0LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -8936,10 +8846,7 @@ const deserializeAws_json1_0ListBackupsOutput = (output: any, context: __SerdeCo
       output.BackupSummaries !== undefined && output.BackupSummaries !== null
         ? deserializeAws_json1_0BackupSummaries(output.BackupSummaries, context)
         : undefined,
-    LastEvaluatedBackupArn:
-      output.LastEvaluatedBackupArn !== undefined && output.LastEvaluatedBackupArn !== null
-        ? output.LastEvaluatedBackupArn
-        : undefined,
+    LastEvaluatedBackupArn: __expectString(output.LastEvaluatedBackupArn),
   } as any;
 };
 
@@ -8952,7 +8859,7 @@ const deserializeAws_json1_0ListContributorInsightsOutput = (
       output.ContributorInsightsSummaries !== undefined && output.ContributorInsightsSummaries !== null
         ? deserializeAws_json1_0ContributorInsightsSummaries(output.ContributorInsightsSummaries, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -8962,7 +8869,7 @@ const deserializeAws_json1_0ListExportsOutput = (output: any, context: __SerdeCo
       output.ExportSummaries !== undefined && output.ExportSummaries !== null
         ? deserializeAws_json1_0ExportSummaries(output.ExportSummaries, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -8972,19 +8879,13 @@ const deserializeAws_json1_0ListGlobalTablesOutput = (output: any, context: __Se
       output.GlobalTables !== undefined && output.GlobalTables !== null
         ? deserializeAws_json1_0GlobalTableList(output.GlobalTables, context)
         : undefined,
-    LastEvaluatedGlobalTableName:
-      output.LastEvaluatedGlobalTableName !== undefined && output.LastEvaluatedGlobalTableName !== null
-        ? output.LastEvaluatedGlobalTableName
-        : undefined,
+    LastEvaluatedGlobalTableName: __expectString(output.LastEvaluatedGlobalTableName),
   } as any;
 };
 
 const deserializeAws_json1_0ListTablesOutput = (output: any, context: __SerdeContext): ListTablesOutput => {
   return {
-    LastEvaluatedTableName:
-      output.LastEvaluatedTableName !== undefined && output.LastEvaluatedTableName !== null
-        ? output.LastEvaluatedTableName
-        : undefined,
+    LastEvaluatedTableName: __expectString(output.LastEvaluatedTableName),
     TableNames:
       output.TableNames !== undefined && output.TableNames !== null
         ? deserializeAws_json1_0TableNameList(output.TableNames, context)
@@ -8997,7 +8898,7 @@ const deserializeAws_json1_0ListTagsOfResourceOutput = (
   context: __SerdeContext
 ): ListTagsOfResourceOutput => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_0TagList(output.Tags, context)
@@ -9010,11 +8911,10 @@ const deserializeAws_json1_0LocalSecondaryIndexDescription = (
   context: __SerdeContext
 ): LocalSecondaryIndexDescription => {
   return {
-    IndexArn: output.IndexArn !== undefined && output.IndexArn !== null ? output.IndexArn : undefined,
-    IndexName: output.IndexName !== undefined && output.IndexName !== null ? output.IndexName : undefined,
-    IndexSizeBytes:
-      output.IndexSizeBytes !== undefined && output.IndexSizeBytes !== null ? output.IndexSizeBytes : undefined,
-    ItemCount: output.ItemCount !== undefined && output.ItemCount !== null ? output.ItemCount : undefined,
+    IndexArn: __expectString(output.IndexArn),
+    IndexName: __expectString(output.IndexName),
+    IndexSizeBytes: __expectNumber(output.IndexSizeBytes),
+    ItemCount: __expectNumber(output.ItemCount),
     KeySchema:
       output.KeySchema !== undefined && output.KeySchema !== null
         ? deserializeAws_json1_0KeySchema(output.KeySchema, context)
@@ -9059,7 +8959,7 @@ const deserializeAws_json1_0LocalSecondaryIndexInfo = (
   context: __SerdeContext
 ): LocalSecondaryIndexInfo => {
   return {
-    IndexName: output.IndexName !== undefined && output.IndexName !== null ? output.IndexName : undefined,
+    IndexName: __expectString(output.IndexName),
     KeySchema:
       output.KeySchema !== undefined && output.KeySchema !== null
         ? deserializeAws_json1_0KeySchema(output.KeySchema, context)
@@ -9093,7 +8993,7 @@ const deserializeAws_json1_0NonKeyAttributeNameList = (output: any, context: __S
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -9104,7 +9004,7 @@ const deserializeAws_json1_0NumberSetAttributeValue = (output: any, context: __S
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -9132,10 +9032,7 @@ const deserializeAws_json1_0PointInTimeRecoveryDescription = (
       output.LatestRestorableDateTime !== undefined && output.LatestRestorableDateTime !== null
         ? new Date(Math.round(output.LatestRestorableDateTime * 1000))
         : undefined,
-    PointInTimeRecoveryStatus:
-      output.PointInTimeRecoveryStatus !== undefined && output.PointInTimeRecoveryStatus !== null
-        ? output.PointInTimeRecoveryStatus
-        : undefined,
+    PointInTimeRecoveryStatus: __expectString(output.PointInTimeRecoveryStatus),
   } as any;
 };
 
@@ -9144,7 +9041,7 @@ const deserializeAws_json1_0PointInTimeRecoveryUnavailableException = (
   context: __SerdeContext
 ): PointInTimeRecoveryUnavailableException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9154,21 +9051,14 @@ const deserializeAws_json1_0Projection = (output: any, context: __SerdeContext):
       output.NonKeyAttributes !== undefined && output.NonKeyAttributes !== null
         ? deserializeAws_json1_0NonKeyAttributeNameList(output.NonKeyAttributes, context)
         : undefined,
-    ProjectionType:
-      output.ProjectionType !== undefined && output.ProjectionType !== null ? output.ProjectionType : undefined,
+    ProjectionType: __expectString(output.ProjectionType),
   } as any;
 };
 
 const deserializeAws_json1_0ProvisionedThroughput = (output: any, context: __SerdeContext): ProvisionedThroughput => {
   return {
-    ReadCapacityUnits:
-      output.ReadCapacityUnits !== undefined && output.ReadCapacityUnits !== null
-        ? output.ReadCapacityUnits
-        : undefined,
-    WriteCapacityUnits:
-      output.WriteCapacityUnits !== undefined && output.WriteCapacityUnits !== null
-        ? output.WriteCapacityUnits
-        : undefined,
+    ReadCapacityUnits: __expectNumber(output.ReadCapacityUnits),
+    WriteCapacityUnits: __expectNumber(output.WriteCapacityUnits),
   } as any;
 };
 
@@ -9185,18 +9075,9 @@ const deserializeAws_json1_0ProvisionedThroughputDescription = (
       output.LastIncreaseDateTime !== undefined && output.LastIncreaseDateTime !== null
         ? new Date(Math.round(output.LastIncreaseDateTime * 1000))
         : undefined,
-    NumberOfDecreasesToday:
-      output.NumberOfDecreasesToday !== undefined && output.NumberOfDecreasesToday !== null
-        ? output.NumberOfDecreasesToday
-        : undefined,
-    ReadCapacityUnits:
-      output.ReadCapacityUnits !== undefined && output.ReadCapacityUnits !== null
-        ? output.ReadCapacityUnits
-        : undefined,
-    WriteCapacityUnits:
-      output.WriteCapacityUnits !== undefined && output.WriteCapacityUnits !== null
-        ? output.WriteCapacityUnits
-        : undefined,
+    NumberOfDecreasesToday: __expectNumber(output.NumberOfDecreasesToday),
+    ReadCapacityUnits: __expectNumber(output.ReadCapacityUnits),
+    WriteCapacityUnits: __expectNumber(output.WriteCapacityUnits),
   } as any;
 };
 
@@ -9205,7 +9086,7 @@ const deserializeAws_json1_0ProvisionedThroughputExceededException = (
   context: __SerdeContext
 ): ProvisionedThroughputExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9214,10 +9095,7 @@ const deserializeAws_json1_0ProvisionedThroughputOverride = (
   context: __SerdeContext
 ): ProvisionedThroughputOverride => {
   return {
-    ReadCapacityUnits:
-      output.ReadCapacityUnits !== undefined && output.ReadCapacityUnits !== null
-        ? output.ReadCapacityUnits
-        : undefined,
+    ReadCapacityUnits: __expectNumber(output.ReadCapacityUnits),
   } as any;
 };
 
@@ -9268,7 +9146,7 @@ const deserializeAws_json1_0QueryOutput = (output: any, context: __SerdeContext)
       output.ConsumedCapacity !== undefined && output.ConsumedCapacity !== null
         ? deserializeAws_json1_0ConsumedCapacity(output.ConsumedCapacity, context)
         : undefined,
-    Count: output.Count !== undefined && output.Count !== null ? output.Count : undefined,
+    Count: __expectNumber(output.Count),
     Items:
       output.Items !== undefined && output.Items !== null
         ? deserializeAws_json1_0ItemList(output.Items, context)
@@ -9277,13 +9155,13 @@ const deserializeAws_json1_0QueryOutput = (output: any, context: __SerdeContext)
       output.LastEvaluatedKey !== undefined && output.LastEvaluatedKey !== null
         ? deserializeAws_json1_0Key(output.LastEvaluatedKey, context)
         : undefined,
-    ScannedCount: output.ScannedCount !== undefined && output.ScannedCount !== null ? output.ScannedCount : undefined,
+    ScannedCount: __expectNumber(output.ScannedCount),
   } as any;
 };
 
 const deserializeAws_json1_0Replica = (output: any, context: __SerdeContext): Replica => {
   return {
-    RegionName: output.RegionName !== undefined && output.RegionName !== null ? output.RegionName : undefined,
+    RegionName: __expectString(output.RegionName),
   } as any;
 };
 
@@ -9292,7 +9170,7 @@ const deserializeAws_json1_0ReplicaAlreadyExistsException = (
   context: __SerdeContext
 ): ReplicaAlreadyExistsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9308,7 +9186,7 @@ const deserializeAws_json1_0ReplicaAutoScalingDescription = (
             context
           )
         : undefined,
-    RegionName: output.RegionName !== undefined && output.RegionName !== null ? output.RegionName : undefined,
+    RegionName: __expectString(output.RegionName),
     ReplicaProvisionedReadCapacityAutoScalingSettings:
       output.ReplicaProvisionedReadCapacityAutoScalingSettings !== undefined &&
       output.ReplicaProvisionedReadCapacityAutoScalingSettings !== null
@@ -9325,8 +9203,7 @@ const deserializeAws_json1_0ReplicaAutoScalingDescription = (
             context
           )
         : undefined,
-    ReplicaStatus:
-      output.ReplicaStatus !== undefined && output.ReplicaStatus !== null ? output.ReplicaStatus : undefined,
+    ReplicaStatus: __expectString(output.ReplicaStatus),
   } as any;
 };
 
@@ -9350,27 +9227,19 @@ const deserializeAws_json1_0ReplicaDescription = (output: any, context: __SerdeC
       output.GlobalSecondaryIndexes !== undefined && output.GlobalSecondaryIndexes !== null
         ? deserializeAws_json1_0ReplicaGlobalSecondaryIndexDescriptionList(output.GlobalSecondaryIndexes, context)
         : undefined,
-    KMSMasterKeyId:
-      output.KMSMasterKeyId !== undefined && output.KMSMasterKeyId !== null ? output.KMSMasterKeyId : undefined,
+    KMSMasterKeyId: __expectString(output.KMSMasterKeyId),
     ProvisionedThroughputOverride:
       output.ProvisionedThroughputOverride !== undefined && output.ProvisionedThroughputOverride !== null
         ? deserializeAws_json1_0ProvisionedThroughputOverride(output.ProvisionedThroughputOverride, context)
         : undefined,
-    RegionName: output.RegionName !== undefined && output.RegionName !== null ? output.RegionName : undefined,
+    RegionName: __expectString(output.RegionName),
     ReplicaInaccessibleDateTime:
       output.ReplicaInaccessibleDateTime !== undefined && output.ReplicaInaccessibleDateTime !== null
         ? new Date(Math.round(output.ReplicaInaccessibleDateTime * 1000))
         : undefined,
-    ReplicaStatus:
-      output.ReplicaStatus !== undefined && output.ReplicaStatus !== null ? output.ReplicaStatus : undefined,
-    ReplicaStatusDescription:
-      output.ReplicaStatusDescription !== undefined && output.ReplicaStatusDescription !== null
-        ? output.ReplicaStatusDescription
-        : undefined,
-    ReplicaStatusPercentProgress:
-      output.ReplicaStatusPercentProgress !== undefined && output.ReplicaStatusPercentProgress !== null
-        ? output.ReplicaStatusPercentProgress
-        : undefined,
+    ReplicaStatus: __expectString(output.ReplicaStatus),
+    ReplicaStatusDescription: __expectString(output.ReplicaStatusDescription),
+    ReplicaStatusPercentProgress: __expectString(output.ReplicaStatusPercentProgress),
   } as any;
 };
 
@@ -9390,8 +9259,8 @@ const deserializeAws_json1_0ReplicaGlobalSecondaryIndexAutoScalingDescription = 
   context: __SerdeContext
 ): ReplicaGlobalSecondaryIndexAutoScalingDescription => {
   return {
-    IndexName: output.IndexName !== undefined && output.IndexName !== null ? output.IndexName : undefined,
-    IndexStatus: output.IndexStatus !== undefined && output.IndexStatus !== null ? output.IndexStatus : undefined,
+    IndexName: __expectString(output.IndexName),
+    IndexStatus: __expectString(output.IndexStatus),
     ProvisionedReadCapacityAutoScalingSettings:
       output.ProvisionedReadCapacityAutoScalingSettings !== undefined &&
       output.ProvisionedReadCapacityAutoScalingSettings !== null
@@ -9430,7 +9299,7 @@ const deserializeAws_json1_0ReplicaGlobalSecondaryIndexDescription = (
   context: __SerdeContext
 ): ReplicaGlobalSecondaryIndexDescription => {
   return {
-    IndexName: output.IndexName !== undefined && output.IndexName !== null ? output.IndexName : undefined,
+    IndexName: __expectString(output.IndexName),
     ProvisionedThroughputOverride:
       output.ProvisionedThroughputOverride !== undefined && output.ProvisionedThroughputOverride !== null
         ? deserializeAws_json1_0ProvisionedThroughputOverride(output.ProvisionedThroughputOverride, context)
@@ -9457,8 +9326,8 @@ const deserializeAws_json1_0ReplicaGlobalSecondaryIndexSettingsDescription = (
   context: __SerdeContext
 ): ReplicaGlobalSecondaryIndexSettingsDescription => {
   return {
-    IndexName: output.IndexName !== undefined && output.IndexName !== null ? output.IndexName : undefined,
-    IndexStatus: output.IndexStatus !== undefined && output.IndexStatus !== null ? output.IndexStatus : undefined,
+    IndexName: __expectString(output.IndexName),
+    IndexStatus: __expectString(output.IndexStatus),
     ProvisionedReadCapacityAutoScalingSettings:
       output.ProvisionedReadCapacityAutoScalingSettings !== undefined &&
       output.ProvisionedReadCapacityAutoScalingSettings !== null
@@ -9467,10 +9336,7 @@ const deserializeAws_json1_0ReplicaGlobalSecondaryIndexSettingsDescription = (
             context
           )
         : undefined,
-    ProvisionedReadCapacityUnits:
-      output.ProvisionedReadCapacityUnits !== undefined && output.ProvisionedReadCapacityUnits !== null
-        ? output.ProvisionedReadCapacityUnits
-        : undefined,
+    ProvisionedReadCapacityUnits: __expectNumber(output.ProvisionedReadCapacityUnits),
     ProvisionedWriteCapacityAutoScalingSettings:
       output.ProvisionedWriteCapacityAutoScalingSettings !== undefined &&
       output.ProvisionedWriteCapacityAutoScalingSettings !== null
@@ -9479,10 +9345,7 @@ const deserializeAws_json1_0ReplicaGlobalSecondaryIndexSettingsDescription = (
             context
           )
         : undefined,
-    ProvisionedWriteCapacityUnits:
-      output.ProvisionedWriteCapacityUnits !== undefined && output.ProvisionedWriteCapacityUnits !== null
-        ? output.ProvisionedWriteCapacityUnits
-        : undefined,
+    ProvisionedWriteCapacityUnits: __expectNumber(output.ProvisionedWriteCapacityUnits),
   } as any;
 };
 
@@ -9516,7 +9379,7 @@ const deserializeAws_json1_0ReplicaNotFoundException = (
   context: __SerdeContext
 ): ReplicaNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9525,7 +9388,7 @@ const deserializeAws_json1_0ReplicaSettingsDescription = (
   context: __SerdeContext
 ): ReplicaSettingsDescription => {
   return {
-    RegionName: output.RegionName !== undefined && output.RegionName !== null ? output.RegionName : undefined,
+    RegionName: __expectString(output.RegionName),
     ReplicaBillingModeSummary:
       output.ReplicaBillingModeSummary !== undefined && output.ReplicaBillingModeSummary !== null
         ? deserializeAws_json1_0BillingModeSummary(output.ReplicaBillingModeSummary, context)
@@ -9545,10 +9408,7 @@ const deserializeAws_json1_0ReplicaSettingsDescription = (
             context
           )
         : undefined,
-    ReplicaProvisionedReadCapacityUnits:
-      output.ReplicaProvisionedReadCapacityUnits !== undefined && output.ReplicaProvisionedReadCapacityUnits !== null
-        ? output.ReplicaProvisionedReadCapacityUnits
-        : undefined,
+    ReplicaProvisionedReadCapacityUnits: __expectNumber(output.ReplicaProvisionedReadCapacityUnits),
     ReplicaProvisionedWriteCapacityAutoScalingSettings:
       output.ReplicaProvisionedWriteCapacityAutoScalingSettings !== undefined &&
       output.ReplicaProvisionedWriteCapacityAutoScalingSettings !== null
@@ -9557,12 +9417,8 @@ const deserializeAws_json1_0ReplicaSettingsDescription = (
             context
           )
         : undefined,
-    ReplicaProvisionedWriteCapacityUnits:
-      output.ReplicaProvisionedWriteCapacityUnits !== undefined && output.ReplicaProvisionedWriteCapacityUnits !== null
-        ? output.ReplicaProvisionedWriteCapacityUnits
-        : undefined,
-    ReplicaStatus:
-      output.ReplicaStatus !== undefined && output.ReplicaStatus !== null ? output.ReplicaStatus : undefined,
+    ReplicaProvisionedWriteCapacityUnits: __expectNumber(output.ReplicaProvisionedWriteCapacityUnits),
+    ReplicaStatus: __expectString(output.ReplicaStatus),
   } as any;
 };
 
@@ -9582,13 +9438,13 @@ const deserializeAws_json1_0ReplicaSettingsDescriptionList = (
 
 const deserializeAws_json1_0RequestLimitExceeded = (output: any, context: __SerdeContext): RequestLimitExceeded => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_0ResourceInUseException = (output: any, context: __SerdeContext): ResourceInUseException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9597,7 +9453,7 @@ const deserializeAws_json1_0ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9607,14 +9463,9 @@ const deserializeAws_json1_0RestoreSummary = (output: any, context: __SerdeConte
       output.RestoreDateTime !== undefined && output.RestoreDateTime !== null
         ? new Date(Math.round(output.RestoreDateTime * 1000))
         : undefined,
-    RestoreInProgress:
-      output.RestoreInProgress !== undefined && output.RestoreInProgress !== null
-        ? output.RestoreInProgress
-        : undefined,
-    SourceBackupArn:
-      output.SourceBackupArn !== undefined && output.SourceBackupArn !== null ? output.SourceBackupArn : undefined,
-    SourceTableArn:
-      output.SourceTableArn !== undefined && output.SourceTableArn !== null ? output.SourceTableArn : undefined,
+    RestoreInProgress: __expectBoolean(output.RestoreInProgress),
+    SourceBackupArn: __expectString(output.SourceBackupArn),
+    SourceTableArn: __expectString(output.SourceTableArn),
   } as any;
 };
 
@@ -9648,7 +9499,7 @@ const deserializeAws_json1_0ScanOutput = (output: any, context: __SerdeContext):
       output.ConsumedCapacity !== undefined && output.ConsumedCapacity !== null
         ? deserializeAws_json1_0ConsumedCapacity(output.ConsumedCapacity, context)
         : undefined,
-    Count: output.Count !== undefined && output.Count !== null ? output.Count : undefined,
+    Count: __expectNumber(output.Count),
     Items:
       output.Items !== undefined && output.Items !== null
         ? deserializeAws_json1_0ItemList(output.Items, context)
@@ -9657,7 +9508,7 @@ const deserializeAws_json1_0ScanOutput = (output: any, context: __SerdeContext):
       output.LastEvaluatedKey !== undefined && output.LastEvaluatedKey !== null
         ? deserializeAws_json1_0Key(output.LastEvaluatedKey, context)
         : undefined,
-    ScannedCount: output.ScannedCount !== undefined && output.ScannedCount !== null ? output.ScannedCount : undefined,
+    ScannedCount: __expectNumber(output.ScannedCount),
   } as any;
 };
 
@@ -9678,8 +9529,8 @@ const deserializeAws_json1_0SecondaryIndexesCapacityMap = (
 
 const deserializeAws_json1_0SourceTableDetails = (output: any, context: __SerdeContext): SourceTableDetails => {
   return {
-    BillingMode: output.BillingMode !== undefined && output.BillingMode !== null ? output.BillingMode : undefined,
-    ItemCount: output.ItemCount !== undefined && output.ItemCount !== null ? output.ItemCount : undefined,
+    BillingMode: __expectString(output.BillingMode),
+    ItemCount: __expectNumber(output.ItemCount),
     KeySchema:
       output.KeySchema !== undefined && output.KeySchema !== null
         ? deserializeAws_json1_0KeySchema(output.KeySchema, context)
@@ -9688,15 +9539,14 @@ const deserializeAws_json1_0SourceTableDetails = (output: any, context: __SerdeC
       output.ProvisionedThroughput !== undefined && output.ProvisionedThroughput !== null
         ? deserializeAws_json1_0ProvisionedThroughput(output.ProvisionedThroughput, context)
         : undefined,
-    TableArn: output.TableArn !== undefined && output.TableArn !== null ? output.TableArn : undefined,
+    TableArn: __expectString(output.TableArn),
     TableCreationDateTime:
       output.TableCreationDateTime !== undefined && output.TableCreationDateTime !== null
         ? new Date(Math.round(output.TableCreationDateTime * 1000))
         : undefined,
-    TableId: output.TableId !== undefined && output.TableId !== null ? output.TableId : undefined,
-    TableName: output.TableName !== undefined && output.TableName !== null ? output.TableName : undefined,
-    TableSizeBytes:
-      output.TableSizeBytes !== undefined && output.TableSizeBytes !== null ? output.TableSizeBytes : undefined,
+    TableId: __expectString(output.TableId),
+    TableName: __expectString(output.TableName),
+    TableSizeBytes: __expectNumber(output.TableSizeBytes),
   } as any;
 };
 
@@ -9734,19 +9584,16 @@ const deserializeAws_json1_0SSEDescription = (output: any, context: __SerdeConte
       output.InaccessibleEncryptionDateTime !== undefined && output.InaccessibleEncryptionDateTime !== null
         ? new Date(Math.round(output.InaccessibleEncryptionDateTime * 1000))
         : undefined,
-    KMSMasterKeyArn:
-      output.KMSMasterKeyArn !== undefined && output.KMSMasterKeyArn !== null ? output.KMSMasterKeyArn : undefined,
-    SSEType: output.SSEType !== undefined && output.SSEType !== null ? output.SSEType : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    KMSMasterKeyArn: __expectString(output.KMSMasterKeyArn),
+    SSEType: __expectString(output.SSEType),
+    Status: __expectString(output.Status),
   } as any;
 };
 
 const deserializeAws_json1_0StreamSpecification = (output: any, context: __SerdeContext): StreamSpecification => {
   return {
-    StreamEnabled:
-      output.StreamEnabled !== undefined && output.StreamEnabled !== null ? output.StreamEnabled : undefined,
-    StreamViewType:
-      output.StreamViewType !== undefined && output.StreamViewType !== null ? output.StreamViewType : undefined,
+    StreamEnabled: __expectBoolean(output.StreamEnabled),
+    StreamViewType: __expectString(output.StreamViewType),
   } as any;
 };
 
@@ -9757,7 +9604,7 @@ const deserializeAws_json1_0StringSetAttributeValue = (output: any, context: __S
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -9766,7 +9613,7 @@ const deserializeAws_json1_0TableAlreadyExistsException = (
   context: __SerdeContext
 ): TableAlreadyExistsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9779,8 +9626,8 @@ const deserializeAws_json1_0TableAutoScalingDescription = (
       output.Replicas !== undefined && output.Replicas !== null
         ? deserializeAws_json1_0ReplicaAutoScalingDescriptionList(output.Replicas, context)
         : undefined,
-    TableName: output.TableName !== undefined && output.TableName !== null ? output.TableName : undefined,
-    TableStatus: output.TableStatus !== undefined && output.TableStatus !== null ? output.TableStatus : undefined,
+    TableName: __expectString(output.TableName),
+    TableStatus: __expectString(output.TableStatus),
   } as any;
 };
 
@@ -9806,21 +9653,14 @@ const deserializeAws_json1_0TableDescription = (output: any, context: __SerdeCon
       output.GlobalSecondaryIndexes !== undefined && output.GlobalSecondaryIndexes !== null
         ? deserializeAws_json1_0GlobalSecondaryIndexDescriptionList(output.GlobalSecondaryIndexes, context)
         : undefined,
-    GlobalTableVersion:
-      output.GlobalTableVersion !== undefined && output.GlobalTableVersion !== null
-        ? output.GlobalTableVersion
-        : undefined,
-    ItemCount: output.ItemCount !== undefined && output.ItemCount !== null ? output.ItemCount : undefined,
+    GlobalTableVersion: __expectString(output.GlobalTableVersion),
+    ItemCount: __expectNumber(output.ItemCount),
     KeySchema:
       output.KeySchema !== undefined && output.KeySchema !== null
         ? deserializeAws_json1_0KeySchema(output.KeySchema, context)
         : undefined,
-    LatestStreamArn:
-      output.LatestStreamArn !== undefined && output.LatestStreamArn !== null ? output.LatestStreamArn : undefined,
-    LatestStreamLabel:
-      output.LatestStreamLabel !== undefined && output.LatestStreamLabel !== null
-        ? output.LatestStreamLabel
-        : undefined,
+    LatestStreamArn: __expectString(output.LatestStreamArn),
+    LatestStreamLabel: __expectString(output.LatestStreamLabel),
     LocalSecondaryIndexes:
       output.LocalSecondaryIndexes !== undefined && output.LocalSecondaryIndexes !== null
         ? deserializeAws_json1_0LocalSecondaryIndexDescriptionList(output.LocalSecondaryIndexes, context)
@@ -9845,18 +9685,17 @@ const deserializeAws_json1_0TableDescription = (output: any, context: __SerdeCon
       output.StreamSpecification !== undefined && output.StreamSpecification !== null
         ? deserializeAws_json1_0StreamSpecification(output.StreamSpecification, context)
         : undefined,
-    TableArn: output.TableArn !== undefined && output.TableArn !== null ? output.TableArn : undefined,
-    TableId: output.TableId !== undefined && output.TableId !== null ? output.TableId : undefined,
-    TableName: output.TableName !== undefined && output.TableName !== null ? output.TableName : undefined,
-    TableSizeBytes:
-      output.TableSizeBytes !== undefined && output.TableSizeBytes !== null ? output.TableSizeBytes : undefined,
-    TableStatus: output.TableStatus !== undefined && output.TableStatus !== null ? output.TableStatus : undefined,
+    TableArn: __expectString(output.TableArn),
+    TableId: __expectString(output.TableId),
+    TableName: __expectString(output.TableName),
+    TableSizeBytes: __expectNumber(output.TableSizeBytes),
+    TableStatus: __expectString(output.TableStatus),
   } as any;
 };
 
 const deserializeAws_json1_0TableInUseException = (output: any, context: __SerdeContext): TableInUseException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9867,20 +9706,20 @@ const deserializeAws_json1_0TableNameList = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_0TableNotFoundException = (output: any, context: __SerdeContext): TableNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_0Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -9897,10 +9736,8 @@ const deserializeAws_json1_0TagList = (output: any, context: __SerdeContext): Ta
 
 const deserializeAws_json1_0TimeToLiveDescription = (output: any, context: __SerdeContext): TimeToLiveDescription => {
   return {
-    AttributeName:
-      output.AttributeName !== undefined && output.AttributeName !== null ? output.AttributeName : undefined,
-    TimeToLiveStatus:
-      output.TimeToLiveStatus !== undefined && output.TimeToLiveStatus !== null ? output.TimeToLiveStatus : undefined,
+    AttributeName: __expectString(output.AttributeName),
+    TimeToLiveStatus: __expectString(output.TimeToLiveStatus),
   } as any;
 };
 
@@ -9909,9 +9746,8 @@ const deserializeAws_json1_0TimeToLiveSpecification = (
   context: __SerdeContext
 ): TimeToLiveSpecification => {
   return {
-    AttributeName:
-      output.AttributeName !== undefined && output.AttributeName !== null ? output.AttributeName : undefined,
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
+    AttributeName: __expectString(output.AttributeName),
+    Enabled: __expectBoolean(output.Enabled),
   } as any;
 };
 
@@ -9937,7 +9773,7 @@ const deserializeAws_json1_0TransactionCanceledException = (
       output.CancellationReasons !== undefined && output.CancellationReasons !== null
         ? deserializeAws_json1_0CancellationReasonList(output.CancellationReasons, context)
         : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -9946,7 +9782,7 @@ const deserializeAws_json1_0TransactionConflictException = (
   context: __SerdeContext
 ): TransactionConflictException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9955,7 +9791,7 @@ const deserializeAws_json1_0TransactionInProgressException = (
   context: __SerdeContext
 ): TransactionInProgressException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -9992,12 +9828,9 @@ const deserializeAws_json1_0UpdateContributorInsightsOutput = (
   context: __SerdeContext
 ): UpdateContributorInsightsOutput => {
   return {
-    ContributorInsightsStatus:
-      output.ContributorInsightsStatus !== undefined && output.ContributorInsightsStatus !== null
-        ? output.ContributorInsightsStatus
-        : undefined,
-    IndexName: output.IndexName !== undefined && output.IndexName !== null ? output.IndexName : undefined,
-    TableName: output.TableName !== undefined && output.TableName !== null ? output.TableName : undefined,
+    ContributorInsightsStatus: __expectString(output.ContributorInsightsStatus),
+    IndexName: __expectString(output.IndexName),
+    TableName: __expectString(output.TableName),
   } as any;
 };
 
@@ -10018,8 +9851,7 @@ const deserializeAws_json1_0UpdateGlobalTableSettingsOutput = (
   context: __SerdeContext
 ): UpdateGlobalTableSettingsOutput => {
   return {
-    GlobalTableName:
-      output.GlobalTableName !== undefined && output.GlobalTableName !== null ? output.GlobalTableName : undefined,
+    GlobalTableName: __expectString(output.GlobalTableName),
     ReplicaSettings:
       output.ReplicaSettings !== undefined && output.ReplicaSettings !== null
         ? deserializeAws_json1_0ReplicaSettingsDescriptionList(output.ReplicaSettings, context)

--- a/clients/client-ebs/protocols/Aws_restJson1.ts
+++ b/clients/client-ebs/protocols/Aws_restJson1.ts
@@ -20,6 +20,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -269,7 +271,7 @@ export const deserializeAws_restJson1CompleteSnapshotCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Status !== undefined && data.Status !== null) {
-    contents.Status = data.Status;
+    contents.Status = __expectString(data.Status);
   }
   return Promise.resolve(contents);
 };
@@ -473,7 +475,7 @@ export const deserializeAws_restJson1ListChangedBlocksCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.BlockSize !== undefined && data.BlockSize !== null) {
-    contents.BlockSize = data.BlockSize;
+    contents.BlockSize = __expectNumber(data.BlockSize);
   }
   if (data.ChangedBlocks !== undefined && data.ChangedBlocks !== null) {
     contents.ChangedBlocks = deserializeAws_restJson1ChangedBlocks(data.ChangedBlocks, context);
@@ -482,10 +484,10 @@ export const deserializeAws_restJson1ListChangedBlocksCommand = async (
     contents.ExpiryTime = new Date(Math.round(data.ExpiryTime * 1000));
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.VolumeSize !== undefined && data.VolumeSize !== null) {
-    contents.VolumeSize = data.VolumeSize;
+    contents.VolumeSize = __expectNumber(data.VolumeSize);
   }
   return Promise.resolve(contents);
 };
@@ -584,7 +586,7 @@ export const deserializeAws_restJson1ListSnapshotBlocksCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.BlockSize !== undefined && data.BlockSize !== null) {
-    contents.BlockSize = data.BlockSize;
+    contents.BlockSize = __expectNumber(data.BlockSize);
   }
   if (data.Blocks !== undefined && data.Blocks !== null) {
     contents.Blocks = deserializeAws_restJson1Blocks(data.Blocks, context);
@@ -593,10 +595,10 @@ export const deserializeAws_restJson1ListSnapshotBlocksCommand = async (
     contents.ExpiryTime = new Date(Math.round(data.ExpiryTime * 1000));
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.VolumeSize !== undefined && data.VolumeSize !== null) {
-    contents.VolumeSize = data.VolumeSize;
+    contents.VolumeSize = __expectNumber(data.VolumeSize);
   }
   return Promise.resolve(contents);
 };
@@ -799,34 +801,34 @@ export const deserializeAws_restJson1StartSnapshotCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.BlockSize !== undefined && data.BlockSize !== null) {
-    contents.BlockSize = data.BlockSize;
+    contents.BlockSize = __expectNumber(data.BlockSize);
   }
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.KmsKeyArn !== undefined && data.KmsKeyArn !== null) {
-    contents.KmsKeyArn = data.KmsKeyArn;
+    contents.KmsKeyArn = __expectString(data.KmsKeyArn);
   }
   if (data.OwnerId !== undefined && data.OwnerId !== null) {
-    contents.OwnerId = data.OwnerId;
+    contents.OwnerId = __expectString(data.OwnerId);
   }
   if (data.ParentSnapshotId !== undefined && data.ParentSnapshotId !== null) {
-    contents.ParentSnapshotId = data.ParentSnapshotId;
+    contents.ParentSnapshotId = __expectString(data.ParentSnapshotId);
   }
   if (data.SnapshotId !== undefined && data.SnapshotId !== null) {
-    contents.SnapshotId = data.SnapshotId;
+    contents.SnapshotId = __expectString(data.SnapshotId);
   }
   if (data.StartTime !== undefined && data.StartTime !== null) {
     contents.StartTime = new Date(Math.round(data.StartTime * 1000));
   }
   if (data.Status !== undefined && data.Status !== null) {
-    contents.Status = data.Status;
+    contents.Status = __expectString(data.Status);
   }
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.Tags, context);
   }
   if (data.VolumeSize !== undefined && data.VolumeSize !== null) {
-    contents.VolumeSize = data.VolumeSize;
+    contents.VolumeSize = __expectNumber(data.VolumeSize);
   }
   return Promise.resolve(contents);
 };
@@ -937,10 +939,10 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.Reason !== undefined && data.Reason !== null) {
-    contents.Reason = data.Reason;
+    contents.Reason = __expectString(data.Reason);
   }
   return contents;
 };
@@ -957,7 +959,7 @@ const deserializeAws_restJson1ConcurrentLimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -974,7 +976,7 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -991,7 +993,7 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1009,10 +1011,10 @@ const deserializeAws_restJson1RequestThrottledExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.Reason !== undefined && data.Reason !== null) {
-    contents.Reason = data.Reason;
+    contents.Reason = __expectString(data.Reason);
   }
   return contents;
 };
@@ -1030,10 +1032,10 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.Reason !== undefined && data.Reason !== null) {
-    contents.Reason = data.Reason;
+    contents.Reason = __expectString(data.Reason);
   }
   return contents;
 };
@@ -1051,10 +1053,10 @@ const deserializeAws_restJson1ServiceQuotaExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.Reason !== undefined && data.Reason !== null) {
-    contents.Reason = data.Reason;
+    contents.Reason = __expectString(data.Reason);
   }
   return contents;
 };
@@ -1072,10 +1074,10 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.Reason !== undefined && data.Reason !== null) {
-    contents.Reason = data.Reason;
+    contents.Reason = __expectString(data.Reason);
   }
   return contents;
 };
@@ -1100,8 +1102,8 @@ const serializeAws_restJson1Tags = (input: Tag[], context: __SerdeContext): any 
 
 const deserializeAws_restJson1Block = (output: any, context: __SerdeContext): Block => {
   return {
-    BlockIndex: output.BlockIndex !== undefined && output.BlockIndex !== null ? output.BlockIndex : undefined,
-    BlockToken: output.BlockToken !== undefined && output.BlockToken !== null ? output.BlockToken : undefined,
+    BlockIndex: __expectNumber(output.BlockIndex),
+    BlockToken: __expectString(output.BlockToken),
   } as any;
 };
 
@@ -1118,11 +1120,9 @@ const deserializeAws_restJson1Blocks = (output: any, context: __SerdeContext): B
 
 const deserializeAws_restJson1ChangedBlock = (output: any, context: __SerdeContext): ChangedBlock => {
   return {
-    BlockIndex: output.BlockIndex !== undefined && output.BlockIndex !== null ? output.BlockIndex : undefined,
-    FirstBlockToken:
-      output.FirstBlockToken !== undefined && output.FirstBlockToken !== null ? output.FirstBlockToken : undefined,
-    SecondBlockToken:
-      output.SecondBlockToken !== undefined && output.SecondBlockToken !== null ? output.SecondBlockToken : undefined,
+    BlockIndex: __expectNumber(output.BlockIndex),
+    FirstBlockToken: __expectString(output.FirstBlockToken),
+    SecondBlockToken: __expectString(output.SecondBlockToken),
   } as any;
 };
 
@@ -1139,8 +1139,8 @@ const deserializeAws_restJson1ChangedBlocks = (output: any, context: __SerdeCont
 
 const deserializeAws_restJson1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 

--- a/clients/client-ec2-instance-connect/protocols/Aws_json1_1.ts
+++ b/clients/client-ec2-instance-connect/protocols/Aws_json1_1.ts
@@ -19,7 +19,11 @@ import {
   ThrottlingException,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -417,7 +421,7 @@ const serializeAws_json1_1SendSSHPublicKeyRequest = (input: SendSSHPublicKeyRequ
 
 const deserializeAws_json1_1AuthException = (output: any, context: __SerdeContext): AuthException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -426,7 +430,7 @@ const deserializeAws_json1_1EC2InstanceNotFoundException = (
   context: __SerdeContext
 ): EC2InstanceNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -435,13 +439,13 @@ const deserializeAws_json1_1EC2InstanceTypeInvalidException = (
   context: __SerdeContext
 ): EC2InstanceTypeInvalidException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidArgsException = (output: any, context: __SerdeContext): InvalidArgsException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -450,8 +454,8 @@ const deserializeAws_json1_1SendSerialConsoleSSHPublicKeyResponse = (
   context: __SerdeContext
 ): SendSerialConsoleSSHPublicKeyResponse => {
   return {
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
-    Success: output.Success !== undefined && output.Success !== null ? output.Success : undefined,
+    RequestId: __expectString(output.RequestId),
+    Success: __expectBoolean(output.Success),
   } as any;
 };
 
@@ -460,8 +464,8 @@ const deserializeAws_json1_1SendSSHPublicKeyResponse = (
   context: __SerdeContext
 ): SendSSHPublicKeyResponse => {
   return {
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
-    Success: output.Success !== undefined && output.Success !== null ? output.Success : undefined,
+    RequestId: __expectString(output.RequestId),
+    Success: __expectBoolean(output.Success),
   } as any;
 };
 
@@ -470,7 +474,7 @@ const deserializeAws_json1_1SerialConsoleAccessDisabledException = (
   context: __SerdeContext
 ): SerialConsoleAccessDisabledException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -479,7 +483,7 @@ const deserializeAws_json1_1SerialConsoleSessionLimitExceededException = (
   context: __SerdeContext
 ): SerialConsoleSessionLimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -488,19 +492,19 @@ const deserializeAws_json1_1SerialConsoleSessionUnavailableException = (
   context: __SerdeContext
 ): SerialConsoleSessionUnavailableException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1ServiceException = (output: any, context: __SerdeContext): ServiceException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1ThrottlingException = (output: any, context: __SerdeContext): ThrottlingException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 

--- a/clients/client-ec2/protocols/Aws_ec2.ts
+++ b/clients/client-ec2/protocols/Aws_ec2.ts
@@ -2916,6 +2916,7 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
@@ -48392,7 +48393,7 @@ const deserializeAws_ec2AcceptReservedInstancesExchangeQuoteResult = (
     ExchangeId: undefined,
   };
   if (output["exchangeId"] !== undefined) {
-    contents.ExchangeId = output["exchangeId"];
+    contents.ExchangeId = __expectString(output["exchangeId"]);
   }
   return contents;
 };
@@ -48483,7 +48484,7 @@ const deserializeAws_ec2AccountAttribute = (output: any, context: __SerdeContext
     AttributeValues: undefined,
   };
   if (output["attributeName"] !== undefined) {
-    contents.AttributeName = output["attributeName"];
+    contents.AttributeName = __expectString(output["attributeName"]);
   }
   if (output.attributeValueSet === "") {
     contents.AttributeValues = [];
@@ -48513,7 +48514,7 @@ const deserializeAws_ec2AccountAttributeValue = (output: any, context: __SerdeCo
     AttributeValue: undefined,
   };
   if (output["attributeValue"] !== undefined) {
-    contents.AttributeValue = output["attributeValue"];
+    contents.AttributeValue = __expectString(output["attributeValue"]);
   }
   return contents;
 };
@@ -48537,16 +48538,16 @@ const deserializeAws_ec2ActiveInstance = (output: any, context: __SerdeContext):
     InstanceHealth: undefined,
   };
   if (output["instanceId"] !== undefined) {
-    contents.InstanceId = output["instanceId"];
+    contents.InstanceId = __expectString(output["instanceId"]);
   }
   if (output["instanceType"] !== undefined) {
-    contents.InstanceType = output["instanceType"];
+    contents.InstanceType = __expectString(output["instanceType"]);
   }
   if (output["spotInstanceRequestId"] !== undefined) {
-    contents.SpotInstanceRequestId = output["spotInstanceRequestId"];
+    contents.SpotInstanceRequestId = __expectString(output["spotInstanceRequestId"]);
   }
   if (output["instanceHealth"] !== undefined) {
-    contents.InstanceHealth = output["instanceHealth"];
+    contents.InstanceHealth = __expectString(output["instanceHealth"]);
   }
   return contents;
 };
@@ -48580,28 +48581,28 @@ const deserializeAws_ec2Address = (output: any, context: __SerdeContext): Addres
     CarrierIp: undefined,
   };
   if (output["instanceId"] !== undefined) {
-    contents.InstanceId = output["instanceId"];
+    contents.InstanceId = __expectString(output["instanceId"]);
   }
   if (output["publicIp"] !== undefined) {
-    contents.PublicIp = output["publicIp"];
+    contents.PublicIp = __expectString(output["publicIp"]);
   }
   if (output["allocationId"] !== undefined) {
-    contents.AllocationId = output["allocationId"];
+    contents.AllocationId = __expectString(output["allocationId"]);
   }
   if (output["associationId"] !== undefined) {
-    contents.AssociationId = output["associationId"];
+    contents.AssociationId = __expectString(output["associationId"]);
   }
   if (output["domain"] !== undefined) {
-    contents.Domain = output["domain"];
+    contents.Domain = __expectString(output["domain"]);
   }
   if (output["networkInterfaceId"] !== undefined) {
-    contents.NetworkInterfaceId = output["networkInterfaceId"];
+    contents.NetworkInterfaceId = __expectString(output["networkInterfaceId"]);
   }
   if (output["networkInterfaceOwnerId"] !== undefined) {
-    contents.NetworkInterfaceOwnerId = output["networkInterfaceOwnerId"];
+    contents.NetworkInterfaceOwnerId = __expectString(output["networkInterfaceOwnerId"]);
   }
   if (output["privateIpAddress"] !== undefined) {
-    contents.PrivateIpAddress = output["privateIpAddress"];
+    contents.PrivateIpAddress = __expectString(output["privateIpAddress"]);
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -48610,19 +48611,19 @@ const deserializeAws_ec2Address = (output: any, context: __SerdeContext): Addres
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["publicIpv4Pool"] !== undefined) {
-    contents.PublicIpv4Pool = output["publicIpv4Pool"];
+    contents.PublicIpv4Pool = __expectString(output["publicIpv4Pool"]);
   }
   if (output["networkBorderGroup"] !== undefined) {
-    contents.NetworkBorderGroup = output["networkBorderGroup"];
+    contents.NetworkBorderGroup = __expectString(output["networkBorderGroup"]);
   }
   if (output["customerOwnedIp"] !== undefined) {
-    contents.CustomerOwnedIp = output["customerOwnedIp"];
+    contents.CustomerOwnedIp = __expectString(output["customerOwnedIp"]);
   }
   if (output["customerOwnedIpv4Pool"] !== undefined) {
-    contents.CustomerOwnedIpv4Pool = output["customerOwnedIpv4Pool"];
+    contents.CustomerOwnedIpv4Pool = __expectString(output["customerOwnedIpv4Pool"]);
   }
   if (output["carrierIp"] !== undefined) {
-    contents.CarrierIp = output["carrierIp"];
+    contents.CarrierIp = __expectString(output["carrierIp"]);
   }
   return contents;
 };
@@ -48635,13 +48636,13 @@ const deserializeAws_ec2AddressAttribute = (output: any, context: __SerdeContext
     PtrRecordUpdate: undefined,
   };
   if (output["publicIp"] !== undefined) {
-    contents.PublicIp = output["publicIp"];
+    contents.PublicIp = __expectString(output["publicIp"]);
   }
   if (output["allocationId"] !== undefined) {
-    contents.AllocationId = output["allocationId"];
+    contents.AllocationId = __expectString(output["allocationId"]);
   }
   if (output["ptrRecord"] !== undefined) {
-    contents.PtrRecord = output["ptrRecord"];
+    contents.PtrRecord = __expectString(output["ptrRecord"]);
   }
   if (output["ptrRecordUpdate"] !== undefined) {
     contents.PtrRecordUpdate = deserializeAws_ec2PtrUpdateStatus(output["ptrRecordUpdate"], context);
@@ -48693,28 +48694,28 @@ const deserializeAws_ec2AllocateAddressResult = (output: any, context: __SerdeCo
     CarrierIp: undefined,
   };
   if (output["publicIp"] !== undefined) {
-    contents.PublicIp = output["publicIp"];
+    contents.PublicIp = __expectString(output["publicIp"]);
   }
   if (output["allocationId"] !== undefined) {
-    contents.AllocationId = output["allocationId"];
+    contents.AllocationId = __expectString(output["allocationId"]);
   }
   if (output["publicIpv4Pool"] !== undefined) {
-    contents.PublicIpv4Pool = output["publicIpv4Pool"];
+    contents.PublicIpv4Pool = __expectString(output["publicIpv4Pool"]);
   }
   if (output["networkBorderGroup"] !== undefined) {
-    contents.NetworkBorderGroup = output["networkBorderGroup"];
+    contents.NetworkBorderGroup = __expectString(output["networkBorderGroup"]);
   }
   if (output["domain"] !== undefined) {
-    contents.Domain = output["domain"];
+    contents.Domain = __expectString(output["domain"]);
   }
   if (output["customerOwnedIp"] !== undefined) {
-    contents.CustomerOwnedIp = output["customerOwnedIp"];
+    contents.CustomerOwnedIp = __expectString(output["customerOwnedIp"]);
   }
   if (output["customerOwnedIpv4Pool"] !== undefined) {
-    contents.CustomerOwnedIpv4Pool = output["customerOwnedIpv4Pool"];
+    contents.CustomerOwnedIpv4Pool = __expectString(output["customerOwnedIpv4Pool"]);
   }
   if (output["carrierIp"] !== undefined) {
-    contents.CarrierIp = output["carrierIp"];
+    contents.CarrierIp = __expectString(output["carrierIp"]);
   }
   return contents;
 };
@@ -48741,10 +48742,10 @@ const deserializeAws_ec2AllowedPrincipal = (output: any, context: __SerdeContext
     Principal: undefined,
   };
   if (output["principalType"] !== undefined) {
-    contents.PrincipalType = output["principalType"];
+    contents.PrincipalType = __expectString(output["principalType"]);
   }
   if (output["principal"] !== undefined) {
-    contents.Principal = output["principal"];
+    contents.Principal = __expectString(output["principal"]);
   }
   return contents;
 };
@@ -48766,10 +48767,10 @@ const deserializeAws_ec2AlternatePathHint = (output: any, context: __SerdeContex
     ComponentArn: undefined,
   };
   if (output["componentId"] !== undefined) {
-    contents.ComponentId = output["componentId"];
+    contents.ComponentId = __expectString(output["componentId"]);
   }
   if (output["componentArn"] !== undefined) {
-    contents.ComponentArn = output["componentArn"];
+    contents.ComponentArn = __expectString(output["componentArn"]);
   }
   return contents;
 };
@@ -48795,7 +48796,7 @@ const deserializeAws_ec2AnalysisAclRule = (output: any, context: __SerdeContext)
     RuleNumber: undefined,
   };
   if (output["cidr"] !== undefined) {
-    contents.Cidr = output["cidr"];
+    contents.Cidr = __expectString(output["cidr"]);
   }
   if (output["egress"] !== undefined) {
     contents.Egress = __parseBoolean(output["egress"]);
@@ -48804,10 +48805,10 @@ const deserializeAws_ec2AnalysisAclRule = (output: any, context: __SerdeContext)
     contents.PortRange = deserializeAws_ec2PortRange(output["portRange"], context);
   }
   if (output["protocol"] !== undefined) {
-    contents.Protocol = output["protocol"];
+    contents.Protocol = __expectString(output["protocol"]);
   }
   if (output["ruleAction"] !== undefined) {
-    contents.RuleAction = output["ruleAction"];
+    contents.RuleAction = __expectString(output["ruleAction"]);
   }
   if (output["ruleNumber"] !== undefined) {
     contents.RuleNumber = parseInt(output["ruleNumber"]);
@@ -48821,10 +48822,10 @@ const deserializeAws_ec2AnalysisComponent = (output: any, context: __SerdeContex
     Arn: undefined,
   };
   if (output["id"] !== undefined) {
-    contents.Id = output["id"];
+    contents.Id = __expectString(output["id"]);
   }
   if (output["arn"] !== undefined) {
-    contents.Arn = output["arn"];
+    contents.Arn = __expectString(output["arn"]);
   }
   return contents;
 };
@@ -48868,10 +48869,10 @@ const deserializeAws_ec2AnalysisLoadBalancerTarget = (
     Port: undefined,
   };
   if (output["address"] !== undefined) {
-    contents.Address = output["address"];
+    contents.Address = __expectString(output["address"]);
   }
   if (output["availabilityZone"] !== undefined) {
-    contents.AvailabilityZone = output["availabilityZone"];
+    contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
   if (output["instance"] !== undefined) {
     contents.Instance = deserializeAws_ec2AnalysisComponent(output["instance"], context);
@@ -48909,7 +48910,7 @@ const deserializeAws_ec2AnalysisPacketHeader = (output: any, context: __SerdeCon
     );
   }
   if (output["protocol"] !== undefined) {
-    contents.Protocol = output["protocol"];
+    contents.Protocol = __expectString(output["protocol"]);
   }
   if (output.sourceAddressSet === "") {
     contents.SourceAddresses = [];
@@ -48946,34 +48947,34 @@ const deserializeAws_ec2AnalysisRouteTableRoute = (output: any, context: __Serde
     VpcPeeringConnectionId: undefined,
   };
   if (output["destinationCidr"] !== undefined) {
-    contents.DestinationCidr = output["destinationCidr"];
+    contents.DestinationCidr = __expectString(output["destinationCidr"]);
   }
   if (output["destinationPrefixListId"] !== undefined) {
-    contents.DestinationPrefixListId = output["destinationPrefixListId"];
+    contents.DestinationPrefixListId = __expectString(output["destinationPrefixListId"]);
   }
   if (output["egressOnlyInternetGatewayId"] !== undefined) {
-    contents.EgressOnlyInternetGatewayId = output["egressOnlyInternetGatewayId"];
+    contents.EgressOnlyInternetGatewayId = __expectString(output["egressOnlyInternetGatewayId"]);
   }
   if (output["gatewayId"] !== undefined) {
-    contents.GatewayId = output["gatewayId"];
+    contents.GatewayId = __expectString(output["gatewayId"]);
   }
   if (output["instanceId"] !== undefined) {
-    contents.InstanceId = output["instanceId"];
+    contents.InstanceId = __expectString(output["instanceId"]);
   }
   if (output["natGatewayId"] !== undefined) {
-    contents.NatGatewayId = output["natGatewayId"];
+    contents.NatGatewayId = __expectString(output["natGatewayId"]);
   }
   if (output["networkInterfaceId"] !== undefined) {
-    contents.NetworkInterfaceId = output["networkInterfaceId"];
+    contents.NetworkInterfaceId = __expectString(output["networkInterfaceId"]);
   }
   if (output["origin"] !== undefined) {
-    contents.Origin = output["origin"];
+    contents.Origin = __expectString(output["origin"]);
   }
   if (output["transitGatewayId"] !== undefined) {
-    contents.TransitGatewayId = output["transitGatewayId"];
+    contents.TransitGatewayId = __expectString(output["transitGatewayId"]);
   }
   if (output["vpcPeeringConnectionId"] !== undefined) {
-    contents.VpcPeeringConnectionId = output["vpcPeeringConnectionId"];
+    contents.VpcPeeringConnectionId = __expectString(output["vpcPeeringConnectionId"]);
   }
   return contents;
 };
@@ -48991,22 +48992,22 @@ const deserializeAws_ec2AnalysisSecurityGroupRule = (
     Protocol: undefined,
   };
   if (output["cidr"] !== undefined) {
-    contents.Cidr = output["cidr"];
+    contents.Cidr = __expectString(output["cidr"]);
   }
   if (output["direction"] !== undefined) {
-    contents.Direction = output["direction"];
+    contents.Direction = __expectString(output["direction"]);
   }
   if (output["securityGroupId"] !== undefined) {
-    contents.SecurityGroupId = output["securityGroupId"];
+    contents.SecurityGroupId = __expectString(output["securityGroupId"]);
   }
   if (output["portRange"] !== undefined) {
     contents.PortRange = deserializeAws_ec2PortRange(output["portRange"], context);
   }
   if (output["prefixListId"] !== undefined) {
-    contents.PrefixListId = output["prefixListId"];
+    contents.PrefixListId = __expectString(output["prefixListId"]);
   }
   if (output["protocol"] !== undefined) {
-    contents.Protocol = output["protocol"];
+    contents.Protocol = __expectString(output["protocol"]);
   }
   return contents;
 };
@@ -49040,7 +49041,7 @@ const deserializeAws_ec2ArchitectureTypeList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -49051,7 +49052,7 @@ const deserializeAws_ec2ArnList = (output: any, context: __SerdeContext): string
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -49060,7 +49061,7 @@ const deserializeAws_ec2AssignedPrivateIpAddress = (output: any, context: __Serd
     PrivateIpAddress: undefined,
   };
   if (output["privateIpAddress"] !== undefined) {
-    contents.PrivateIpAddress = output["privateIpAddress"];
+    contents.PrivateIpAddress = __expectString(output["privateIpAddress"]);
   }
   return contents;
 };
@@ -49097,7 +49098,7 @@ const deserializeAws_ec2AssignIpv6AddressesResult = (
     );
   }
   if (output["networkInterfaceId"] !== undefined) {
-    contents.NetworkInterfaceId = output["networkInterfaceId"];
+    contents.NetworkInterfaceId = __expectString(output["networkInterfaceId"]);
   }
   return contents;
 };
@@ -49111,7 +49112,7 @@ const deserializeAws_ec2AssignPrivateIpAddressesResult = (
     AssignedPrivateIpAddresses: undefined,
   };
   if (output["networkInterfaceId"] !== undefined) {
-    contents.NetworkInterfaceId = output["networkInterfaceId"];
+    contents.NetworkInterfaceId = __expectString(output["networkInterfaceId"]);
   }
   if (output.assignedPrivateIpAddressesSet === "") {
     contents.AssignedPrivateIpAddresses = [];
@@ -49133,7 +49134,7 @@ const deserializeAws_ec2AssociateAddressResult = (output: any, context: __SerdeC
     AssociationId: undefined,
   };
   if (output["associationId"] !== undefined) {
-    contents.AssociationId = output["associationId"];
+    contents.AssociationId = __expectString(output["associationId"]);
   }
   return contents;
 };
@@ -49147,7 +49148,7 @@ const deserializeAws_ec2AssociateClientVpnTargetNetworkResult = (
     Status: undefined,
   };
   if (output["associationId"] !== undefined) {
-    contents.AssociationId = output["associationId"];
+    contents.AssociationId = __expectString(output["associationId"]);
   }
   if (output["status"] !== undefined) {
     contents.Status = deserializeAws_ec2AssociationStatus(output["status"], context);
@@ -49163,16 +49164,16 @@ const deserializeAws_ec2AssociatedRole = (output: any, context: __SerdeContext):
     EncryptionKmsKeyId: undefined,
   };
   if (output["associatedRoleArn"] !== undefined) {
-    contents.AssociatedRoleArn = output["associatedRoleArn"];
+    contents.AssociatedRoleArn = __expectString(output["associatedRoleArn"]);
   }
   if (output["certificateS3BucketName"] !== undefined) {
-    contents.CertificateS3BucketName = output["certificateS3BucketName"];
+    contents.CertificateS3BucketName = __expectString(output["certificateS3BucketName"]);
   }
   if (output["certificateS3ObjectKey"] !== undefined) {
-    contents.CertificateS3ObjectKey = output["certificateS3ObjectKey"];
+    contents.CertificateS3ObjectKey = __expectString(output["certificateS3ObjectKey"]);
   }
   if (output["encryptionKmsKeyId"] !== undefined) {
-    contents.EncryptionKmsKeyId = output["encryptionKmsKeyId"];
+    contents.EncryptionKmsKeyId = __expectString(output["encryptionKmsKeyId"]);
   }
   return contents;
 };
@@ -49194,10 +49195,10 @@ const deserializeAws_ec2AssociatedTargetNetwork = (output: any, context: __Serde
     NetworkType: undefined,
   };
   if (output["networkId"] !== undefined) {
-    contents.NetworkId = output["networkId"];
+    contents.NetworkId = __expectString(output["networkId"]);
   }
   if (output["networkType"] !== undefined) {
-    contents.NetworkType = output["networkType"];
+    contents.NetworkType = __expectString(output["networkType"]);
   }
   return contents;
 };
@@ -49226,13 +49227,13 @@ const deserializeAws_ec2AssociateEnclaveCertificateIamRoleResult = (
     EncryptionKmsKeyId: undefined,
   };
   if (output["certificateS3BucketName"] !== undefined) {
-    contents.CertificateS3BucketName = output["certificateS3BucketName"];
+    contents.CertificateS3BucketName = __expectString(output["certificateS3BucketName"]);
   }
   if (output["certificateS3ObjectKey"] !== undefined) {
-    contents.CertificateS3ObjectKey = output["certificateS3ObjectKey"];
+    contents.CertificateS3ObjectKey = __expectString(output["certificateS3ObjectKey"]);
   }
   if (output["encryptionKmsKeyId"] !== undefined) {
-    contents.EncryptionKmsKeyId = output["encryptionKmsKeyId"];
+    contents.EncryptionKmsKeyId = __expectString(output["encryptionKmsKeyId"]);
   }
   return contents;
 };
@@ -49262,7 +49263,7 @@ const deserializeAws_ec2AssociateRouteTableResult = (
     AssociationState: undefined,
   };
   if (output["associationId"] !== undefined) {
-    contents.AssociationId = output["associationId"];
+    contents.AssociationId = __expectString(output["associationId"]);
   }
   if (output["associationState"] !== undefined) {
     contents.AssociationState = deserializeAws_ec2RouteTableAssociationState(output["associationState"], context);
@@ -49285,7 +49286,7 @@ const deserializeAws_ec2AssociateSubnetCidrBlockResult = (
     );
   }
   if (output["subnetId"] !== undefined) {
-    contents.SubnetId = output["subnetId"];
+    contents.SubnetId = __expectString(output["subnetId"]);
   }
   return contents;
 };
@@ -49334,7 +49335,7 @@ const deserializeAws_ec2AssociateTrunkInterfaceResult = (
     );
   }
   if (output["clientToken"] !== undefined) {
-    contents.ClientToken = output["clientToken"];
+    contents.ClientToken = __expectString(output["clientToken"]);
   }
   return contents;
 };
@@ -49358,7 +49359,7 @@ const deserializeAws_ec2AssociateVpcCidrBlockResult = (
     contents.CidrBlockAssociation = deserializeAws_ec2VpcCidrBlockAssociation(output["cidrBlockAssociation"], context);
   }
   if (output["vpcId"] !== undefined) {
-    contents.VpcId = output["vpcId"];
+    contents.VpcId = __expectString(output["vpcId"]);
   }
   return contents;
 };
@@ -49369,10 +49370,10 @@ const deserializeAws_ec2AssociationStatus = (output: any, context: __SerdeContex
     Message: undefined,
   };
   if (output["code"] !== undefined) {
-    contents.Code = output["code"];
+    contents.Code = __expectString(output["code"]);
   }
   if (output["message"] !== undefined) {
-    contents.Message = output["message"];
+    contents.Message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -49399,7 +49400,7 @@ const deserializeAws_ec2AttachNetworkInterfaceResult = (
     NetworkCardIndex: undefined,
   };
   if (output["attachmentId"] !== undefined) {
-    contents.AttachmentId = output["attachmentId"];
+    contents.AttachmentId = __expectString(output["attachmentId"]);
   }
   if (output["networkCardIndex"] !== undefined) {
     contents.NetworkCardIndex = parseInt(output["networkCardIndex"]);
@@ -49432,7 +49433,7 @@ const deserializeAws_ec2AttributeValue = (output: any, context: __SerdeContext):
     Value: undefined,
   };
   if (output["value"] !== undefined) {
-    contents.Value = output["value"];
+    contents.Value = __expectString(output["value"]);
   }
   return contents;
 };
@@ -49447,19 +49448,19 @@ const deserializeAws_ec2AuthorizationRule = (output: any, context: __SerdeContex
     Status: undefined,
   };
   if (output["clientVpnEndpointId"] !== undefined) {
-    contents.ClientVpnEndpointId = output["clientVpnEndpointId"];
+    contents.ClientVpnEndpointId = __expectString(output["clientVpnEndpointId"]);
   }
   if (output["description"] !== undefined) {
-    contents.Description = output["description"];
+    contents.Description = __expectString(output["description"]);
   }
   if (output["groupId"] !== undefined) {
-    contents.GroupId = output["groupId"];
+    contents.GroupId = __expectString(output["groupId"]);
   }
   if (output["accessAll"] !== undefined) {
     contents.AccessAll = __parseBoolean(output["accessAll"]);
   }
   if (output["destinationCidr"] !== undefined) {
-    contents.DestinationCidr = output["destinationCidr"];
+    contents.DestinationCidr = __expectString(output["destinationCidr"]);
   }
   if (output["status"] !== undefined) {
     contents.Status = deserializeAws_ec2ClientVpnAuthorizationRuleStatus(output["status"], context);
@@ -49506,10 +49507,10 @@ const deserializeAws_ec2AvailabilityZone = (output: any, context: __SerdeContext
     ParentZoneId: undefined,
   };
   if (output["zoneState"] !== undefined) {
-    contents.State = output["zoneState"];
+    contents.State = __expectString(output["zoneState"]);
   }
   if (output["optInStatus"] !== undefined) {
-    contents.OptInStatus = output["optInStatus"];
+    contents.OptInStatus = __expectString(output["optInStatus"]);
   }
   if (output.messageSet === "") {
     contents.Messages = [];
@@ -49521,28 +49522,28 @@ const deserializeAws_ec2AvailabilityZone = (output: any, context: __SerdeContext
     );
   }
   if (output["regionName"] !== undefined) {
-    contents.RegionName = output["regionName"];
+    contents.RegionName = __expectString(output["regionName"]);
   }
   if (output["zoneName"] !== undefined) {
-    contents.ZoneName = output["zoneName"];
+    contents.ZoneName = __expectString(output["zoneName"]);
   }
   if (output["zoneId"] !== undefined) {
-    contents.ZoneId = output["zoneId"];
+    contents.ZoneId = __expectString(output["zoneId"]);
   }
   if (output["groupName"] !== undefined) {
-    contents.GroupName = output["groupName"];
+    contents.GroupName = __expectString(output["groupName"]);
   }
   if (output["networkBorderGroup"] !== undefined) {
-    contents.NetworkBorderGroup = output["networkBorderGroup"];
+    contents.NetworkBorderGroup = __expectString(output["networkBorderGroup"]);
   }
   if (output["zoneType"] !== undefined) {
-    contents.ZoneType = output["zoneType"];
+    contents.ZoneType = __expectString(output["zoneType"]);
   }
   if (output["parentZoneName"] !== undefined) {
-    contents.ParentZoneName = output["parentZoneName"];
+    contents.ParentZoneName = __expectString(output["parentZoneName"]);
   }
   if (output["parentZoneId"] !== undefined) {
-    contents.ParentZoneId = output["parentZoneId"];
+    contents.ParentZoneId = __expectString(output["parentZoneId"]);
   }
   return contents;
 };
@@ -49563,7 +49564,7 @@ const deserializeAws_ec2AvailabilityZoneMessage = (output: any, context: __Serde
     Message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.Message = output["message"];
+    contents.Message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -49621,16 +49622,16 @@ const deserializeAws_ec2BlockDeviceMapping = (output: any, context: __SerdeConte
     NoDevice: undefined,
   };
   if (output["deviceName"] !== undefined) {
-    contents.DeviceName = output["deviceName"];
+    contents.DeviceName = __expectString(output["deviceName"]);
   }
   if (output["virtualName"] !== undefined) {
-    contents.VirtualName = output["virtualName"];
+    contents.VirtualName = __expectString(output["virtualName"]);
   }
   if (output["ebs"] !== undefined) {
     contents.Ebs = deserializeAws_ec2EbsBlockDevice(output["ebs"], context);
   }
   if (output["noDevice"] !== undefined) {
-    contents.NoDevice = output["noDevice"];
+    contents.NoDevice = __expectString(output["noDevice"]);
   }
   return contents;
 };
@@ -49653,7 +49654,7 @@ const deserializeAws_ec2BootModeTypeList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -49679,22 +49680,22 @@ const deserializeAws_ec2BundleTask = (output: any, context: __SerdeContext): Bun
     UpdateTime: undefined,
   };
   if (output["bundleId"] !== undefined) {
-    contents.BundleId = output["bundleId"];
+    contents.BundleId = __expectString(output["bundleId"]);
   }
   if (output["error"] !== undefined) {
     contents.BundleTaskError = deserializeAws_ec2BundleTaskError(output["error"], context);
   }
   if (output["instanceId"] !== undefined) {
-    contents.InstanceId = output["instanceId"];
+    contents.InstanceId = __expectString(output["instanceId"]);
   }
   if (output["progress"] !== undefined) {
-    contents.Progress = output["progress"];
+    contents.Progress = __expectString(output["progress"]);
   }
   if (output["startTime"] !== undefined) {
     contents.StartTime = new Date(output["startTime"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output["storage"] !== undefined) {
     contents.Storage = deserializeAws_ec2Storage(output["storage"], context);
@@ -49711,10 +49712,10 @@ const deserializeAws_ec2BundleTaskError = (output: any, context: __SerdeContext)
     Message: undefined,
   };
   if (output["code"] !== undefined) {
-    contents.Code = output["code"];
+    contents.Code = __expectString(output["code"]);
   }
   if (output["message"] !== undefined) {
-    contents.Message = output["message"];
+    contents.Message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -49738,16 +49739,16 @@ const deserializeAws_ec2ByoipCidr = (output: any, context: __SerdeContext): Byoi
     State: undefined,
   };
   if (output["cidr"] !== undefined) {
-    contents.Cidr = output["cidr"];
+    contents.Cidr = __expectString(output["cidr"]);
   }
   if (output["description"] !== undefined) {
-    contents.Description = output["description"];
+    contents.Description = __expectString(output["description"]);
   }
   if (output["statusMessage"] !== undefined) {
-    contents.StatusMessage = output["statusMessage"];
+    contents.StatusMessage = __expectString(output["statusMessage"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   return contents;
 };
@@ -49793,13 +49794,13 @@ const deserializeAws_ec2CancelImportTaskResult = (output: any, context: __SerdeC
     State: undefined,
   };
   if (output["importTaskId"] !== undefined) {
-    contents.ImportTaskId = output["importTaskId"];
+    contents.ImportTaskId = __expectString(output["importTaskId"]);
   }
   if (output["previousState"] !== undefined) {
-    contents.PreviousState = output["previousState"];
+    contents.PreviousState = __expectString(output["previousState"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   return contents;
 };
@@ -49813,10 +49814,10 @@ const deserializeAws_ec2CancelledSpotInstanceRequest = (
     State: undefined,
   };
   if (output["spotInstanceRequestId"] !== undefined) {
-    contents.SpotInstanceRequestId = output["spotInstanceRequestId"];
+    contents.SpotInstanceRequestId = __expectString(output["spotInstanceRequestId"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   return contents;
 };
@@ -49866,10 +49867,10 @@ const deserializeAws_ec2CancelSpotFleetRequestsError = (
     Message: undefined,
   };
   if (output["code"] !== undefined) {
-    contents.Code = output["code"];
+    contents.Code = __expectString(output["code"]);
   }
   if (output["message"] !== undefined) {
-    contents.Message = output["message"];
+    contents.Message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -49886,7 +49887,7 @@ const deserializeAws_ec2CancelSpotFleetRequestsErrorItem = (
     contents.Error = deserializeAws_ec2CancelSpotFleetRequestsError(output["error"], context);
   }
   if (output["spotFleetRequestId"] !== undefined) {
-    contents.SpotFleetRequestId = output["spotFleetRequestId"];
+    contents.SpotFleetRequestId = __expectString(output["spotFleetRequestId"]);
   }
   return contents;
 };
@@ -49947,13 +49948,13 @@ const deserializeAws_ec2CancelSpotFleetRequestsSuccessItem = (
     SpotFleetRequestId: undefined,
   };
   if (output["currentSpotFleetRequestState"] !== undefined) {
-    contents.CurrentSpotFleetRequestState = output["currentSpotFleetRequestState"];
+    contents.CurrentSpotFleetRequestState = __expectString(output["currentSpotFleetRequestState"]);
   }
   if (output["previousSpotFleetRequestState"] !== undefined) {
-    contents.PreviousSpotFleetRequestState = output["previousSpotFleetRequestState"];
+    contents.PreviousSpotFleetRequestState = __expectString(output["previousSpotFleetRequestState"]);
   }
   if (output["spotFleetRequestId"] !== undefined) {
-    contents.SpotFleetRequestId = output["spotFleetRequestId"];
+    contents.SpotFleetRequestId = __expectString(output["spotFleetRequestId"]);
   }
   return contents;
 };
@@ -50015,28 +50016,28 @@ const deserializeAws_ec2CapacityReservation = (output: any, context: __SerdeCont
     OutpostArn: undefined,
   };
   if (output["capacityReservationId"] !== undefined) {
-    contents.CapacityReservationId = output["capacityReservationId"];
+    contents.CapacityReservationId = __expectString(output["capacityReservationId"]);
   }
   if (output["ownerId"] !== undefined) {
-    contents.OwnerId = output["ownerId"];
+    contents.OwnerId = __expectString(output["ownerId"]);
   }
   if (output["capacityReservationArn"] !== undefined) {
-    contents.CapacityReservationArn = output["capacityReservationArn"];
+    contents.CapacityReservationArn = __expectString(output["capacityReservationArn"]);
   }
   if (output["availabilityZoneId"] !== undefined) {
-    contents.AvailabilityZoneId = output["availabilityZoneId"];
+    contents.AvailabilityZoneId = __expectString(output["availabilityZoneId"]);
   }
   if (output["instanceType"] !== undefined) {
-    contents.InstanceType = output["instanceType"];
+    contents.InstanceType = __expectString(output["instanceType"]);
   }
   if (output["instancePlatform"] !== undefined) {
-    contents.InstancePlatform = output["instancePlatform"];
+    contents.InstancePlatform = __expectString(output["instancePlatform"]);
   }
   if (output["availabilityZone"] !== undefined) {
-    contents.AvailabilityZone = output["availabilityZone"];
+    contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
   if (output["tenancy"] !== undefined) {
-    contents.Tenancy = output["tenancy"];
+    contents.Tenancy = __expectString(output["tenancy"]);
   }
   if (output["totalInstanceCount"] !== undefined) {
     contents.TotalInstanceCount = parseInt(output["totalInstanceCount"]);
@@ -50051,7 +50052,7 @@ const deserializeAws_ec2CapacityReservation = (output: any, context: __SerdeCont
     contents.EphemeralStorage = __parseBoolean(output["ephemeralStorage"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output["startDate"] !== undefined) {
     contents.StartDate = new Date(output["startDate"]);
@@ -50060,10 +50061,10 @@ const deserializeAws_ec2CapacityReservation = (output: any, context: __SerdeCont
     contents.EndDate = new Date(output["endDate"]);
   }
   if (output["endDateType"] !== undefined) {
-    contents.EndDateType = output["endDateType"];
+    contents.EndDateType = __expectString(output["endDateType"]);
   }
   if (output["instanceMatchCriteria"] !== undefined) {
-    contents.InstanceMatchCriteria = output["instanceMatchCriteria"];
+    contents.InstanceMatchCriteria = __expectString(output["instanceMatchCriteria"]);
   }
   if (output["createDate"] !== undefined) {
     contents.CreateDate = new Date(output["createDate"]);
@@ -50075,7 +50076,7 @@ const deserializeAws_ec2CapacityReservation = (output: any, context: __SerdeCont
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["outpostArn"] !== undefined) {
-    contents.OutpostArn = output["outpostArn"];
+    contents.OutpostArn = __expectString(output["outpostArn"]);
   }
   return contents;
 };
@@ -50086,10 +50087,10 @@ const deserializeAws_ec2CapacityReservationGroup = (output: any, context: __Serd
     OwnerId: undefined,
   };
   if (output["groupArn"] !== undefined) {
-    contents.GroupArn = output["groupArn"];
+    contents.GroupArn = __expectString(output["groupArn"]);
   }
   if (output["ownerId"] !== undefined) {
-    contents.OwnerId = output["ownerId"];
+    contents.OwnerId = __expectString(output["ownerId"]);
   }
   return contents;
 };
@@ -50116,7 +50117,7 @@ const deserializeAws_ec2CapacityReservationOptions = (
     UsageStrategy: undefined,
   };
   if (output["usageStrategy"] !== undefined) {
-    contents.UsageStrategy = output["usageStrategy"];
+    contents.UsageStrategy = __expectString(output["usageStrategy"]);
   }
   return contents;
 };
@@ -50141,7 +50142,7 @@ const deserializeAws_ec2CapacityReservationSpecificationResponse = (
     CapacityReservationTarget: undefined,
   };
   if (output["capacityReservationPreference"] !== undefined) {
-    contents.CapacityReservationPreference = output["capacityReservationPreference"];
+    contents.CapacityReservationPreference = __expectString(output["capacityReservationPreference"]);
   }
   if (output["capacityReservationTarget"] !== undefined) {
     contents.CapacityReservationTarget = deserializeAws_ec2CapacityReservationTargetResponse(
@@ -50161,10 +50162,10 @@ const deserializeAws_ec2CapacityReservationTargetResponse = (
     CapacityReservationResourceGroupArn: undefined,
   };
   if (output["capacityReservationId"] !== undefined) {
-    contents.CapacityReservationId = output["capacityReservationId"];
+    contents.CapacityReservationId = __expectString(output["capacityReservationId"]);
   }
   if (output["capacityReservationResourceGroupArn"] !== undefined) {
-    contents.CapacityReservationResourceGroupArn = output["capacityReservationResourceGroupArn"];
+    contents.CapacityReservationResourceGroupArn = __expectString(output["capacityReservationResourceGroupArn"]);
   }
   return contents;
 };
@@ -50178,16 +50179,16 @@ const deserializeAws_ec2CarrierGateway = (output: any, context: __SerdeContext):
     Tags: undefined,
   };
   if (output["carrierGatewayId"] !== undefined) {
-    contents.CarrierGatewayId = output["carrierGatewayId"];
+    contents.CarrierGatewayId = __expectString(output["carrierGatewayId"]);
   }
   if (output["vpcId"] !== undefined) {
-    contents.VpcId = output["vpcId"];
+    contents.VpcId = __expectString(output["vpcId"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output["ownerId"] !== undefined) {
-    contents.OwnerId = output["ownerId"];
+    contents.OwnerId = __expectString(output["ownerId"]);
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -50217,7 +50218,7 @@ const deserializeAws_ec2CertificateAuthentication = (
     ClientRootCertificateChain: undefined,
   };
   if (output["clientRootCertificateChain"] !== undefined) {
-    contents.ClientRootCertificateChain = output["clientRootCertificateChain"];
+    contents.ClientRootCertificateChain = __expectString(output["clientRootCertificateChain"]);
   }
   return contents;
 };
@@ -50227,7 +50228,7 @@ const deserializeAws_ec2CidrBlock = (output: any, context: __SerdeContext): Cidr
     CidrBlock: undefined,
   };
   if (output["cidrBlock"] !== undefined) {
-    contents.CidrBlock = output["cidrBlock"];
+    contents.CidrBlock = __expectString(output["cidrBlock"]);
   }
   return contents;
 };
@@ -50252,7 +50253,7 @@ const deserializeAws_ec2ClassicLinkDnsSupport = (output: any, context: __SerdeCo
     contents.ClassicLinkDnsSupported = __parseBoolean(output["classicLinkDnsSupported"]);
   }
   if (output["vpcId"] !== undefined) {
-    contents.VpcId = output["vpcId"];
+    contents.VpcId = __expectString(output["vpcId"]);
   }
   return contents;
 };
@@ -50285,7 +50286,7 @@ const deserializeAws_ec2ClassicLinkInstance = (output: any, context: __SerdeCont
     );
   }
   if (output["instanceId"] !== undefined) {
-    contents.InstanceId = output["instanceId"];
+    contents.InstanceId = __expectString(output["instanceId"]);
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -50294,7 +50295,7 @@ const deserializeAws_ec2ClassicLinkInstance = (output: any, context: __SerdeCont
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["vpcId"] !== undefined) {
-    contents.VpcId = output["vpcId"];
+    contents.VpcId = __expectString(output["vpcId"]);
   }
   return contents;
 };
@@ -50315,7 +50316,7 @@ const deserializeAws_ec2ClassicLoadBalancer = (output: any, context: __SerdeCont
     Name: undefined,
   };
   if (output["name"] !== undefined) {
-    contents.Name = output["name"];
+    contents.Name = __expectString(output["name"]);
   }
   return contents;
 };
@@ -50359,10 +50360,10 @@ const deserializeAws_ec2ClientCertificateRevocationListStatus = (
     Message: undefined,
   };
   if (output["code"] !== undefined) {
-    contents.Code = output["code"];
+    contents.Code = __expectString(output["code"]);
   }
   if (output["message"] !== undefined) {
-    contents.Message = output["message"];
+    contents.Message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -50380,7 +50381,7 @@ const deserializeAws_ec2ClientConnectResponseOptions = (
     contents.Enabled = __parseBoolean(output["enabled"]);
   }
   if (output["lambdaFunctionArn"] !== undefined) {
-    contents.LambdaFunctionArn = output["lambdaFunctionArn"];
+    contents.LambdaFunctionArn = __expectString(output["lambdaFunctionArn"]);
   }
   if (output["status"] !== undefined) {
     contents.Status = deserializeAws_ec2ClientVpnEndpointAttributeStatus(output["status"], context);
@@ -50396,7 +50397,7 @@ const deserializeAws_ec2ClientVpnAuthentication = (output: any, context: __Serde
     FederatedAuthentication: undefined,
   };
   if (output["type"] !== undefined) {
-    contents.Type = output["type"];
+    contents.Type = __expectString(output["type"]);
   }
   if (output["activeDirectory"] !== undefined) {
     contents.ActiveDirectory = deserializeAws_ec2DirectoryServiceAuthentication(output["activeDirectory"], context);
@@ -50439,10 +50440,10 @@ const deserializeAws_ec2ClientVpnAuthorizationRuleStatus = (
     Message: undefined,
   };
   if (output["code"] !== undefined) {
-    contents.Code = output["code"];
+    contents.Code = __expectString(output["code"]);
   }
   if (output["message"] !== undefined) {
-    contents.Message = output["message"];
+    contents.Message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -50465,43 +50466,43 @@ const deserializeAws_ec2ClientVpnConnection = (output: any, context: __SerdeCont
     PostureComplianceStatuses: undefined,
   };
   if (output["clientVpnEndpointId"] !== undefined) {
-    contents.ClientVpnEndpointId = output["clientVpnEndpointId"];
+    contents.ClientVpnEndpointId = __expectString(output["clientVpnEndpointId"]);
   }
   if (output["timestamp"] !== undefined) {
-    contents.Timestamp = output["timestamp"];
+    contents.Timestamp = __expectString(output["timestamp"]);
   }
   if (output["connectionId"] !== undefined) {
-    contents.ConnectionId = output["connectionId"];
+    contents.ConnectionId = __expectString(output["connectionId"]);
   }
   if (output["username"] !== undefined) {
-    contents.Username = output["username"];
+    contents.Username = __expectString(output["username"]);
   }
   if (output["connectionEstablishedTime"] !== undefined) {
-    contents.ConnectionEstablishedTime = output["connectionEstablishedTime"];
+    contents.ConnectionEstablishedTime = __expectString(output["connectionEstablishedTime"]);
   }
   if (output["ingressBytes"] !== undefined) {
-    contents.IngressBytes = output["ingressBytes"];
+    contents.IngressBytes = __expectString(output["ingressBytes"]);
   }
   if (output["egressBytes"] !== undefined) {
-    contents.EgressBytes = output["egressBytes"];
+    contents.EgressBytes = __expectString(output["egressBytes"]);
   }
   if (output["ingressPackets"] !== undefined) {
-    contents.IngressPackets = output["ingressPackets"];
+    contents.IngressPackets = __expectString(output["ingressPackets"]);
   }
   if (output["egressPackets"] !== undefined) {
-    contents.EgressPackets = output["egressPackets"];
+    contents.EgressPackets = __expectString(output["egressPackets"]);
   }
   if (output["clientIp"] !== undefined) {
-    contents.ClientIp = output["clientIp"];
+    contents.ClientIp = __expectString(output["clientIp"]);
   }
   if (output["commonName"] !== undefined) {
-    contents.CommonName = output["commonName"];
+    contents.CommonName = __expectString(output["commonName"]);
   }
   if (output["status"] !== undefined) {
     contents.Status = deserializeAws_ec2ClientVpnConnectionStatus(output["status"], context);
   }
   if (output["connectionEndTime"] !== undefined) {
-    contents.ConnectionEndTime = output["connectionEndTime"];
+    contents.ConnectionEndTime = __expectString(output["connectionEndTime"]);
   }
   if (output.postureComplianceStatusSet === "") {
     contents.PostureComplianceStatuses = [];
@@ -50538,10 +50539,10 @@ const deserializeAws_ec2ClientVpnConnectionStatus = (
     Message: undefined,
   };
   if (output["code"] !== undefined) {
-    contents.Code = output["code"];
+    contents.Code = __expectString(output["code"]);
   }
   if (output["message"] !== undefined) {
-    contents.Message = output["message"];
+    contents.Message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -50571,25 +50572,25 @@ const deserializeAws_ec2ClientVpnEndpoint = (output: any, context: __SerdeContex
     ClientConnectOptions: undefined,
   };
   if (output["clientVpnEndpointId"] !== undefined) {
-    contents.ClientVpnEndpointId = output["clientVpnEndpointId"];
+    contents.ClientVpnEndpointId = __expectString(output["clientVpnEndpointId"]);
   }
   if (output["description"] !== undefined) {
-    contents.Description = output["description"];
+    contents.Description = __expectString(output["description"]);
   }
   if (output["status"] !== undefined) {
     contents.Status = deserializeAws_ec2ClientVpnEndpointStatus(output["status"], context);
   }
   if (output["creationTime"] !== undefined) {
-    contents.CreationTime = output["creationTime"];
+    contents.CreationTime = __expectString(output["creationTime"]);
   }
   if (output["deletionTime"] !== undefined) {
-    contents.DeletionTime = output["deletionTime"];
+    contents.DeletionTime = __expectString(output["deletionTime"]);
   }
   if (output["dnsName"] !== undefined) {
-    contents.DnsName = output["dnsName"];
+    contents.DnsName = __expectString(output["dnsName"]);
   }
   if (output["clientCidrBlock"] !== undefined) {
-    contents.ClientCidrBlock = output["clientCidrBlock"];
+    contents.ClientCidrBlock = __expectString(output["clientCidrBlock"]);
   }
   if (output.dnsServer === "") {
     contents.DnsServers = [];
@@ -50604,10 +50605,10 @@ const deserializeAws_ec2ClientVpnEndpoint = (output: any, context: __SerdeContex
     contents.SplitTunnel = __parseBoolean(output["splitTunnel"]);
   }
   if (output["vpnProtocol"] !== undefined) {
-    contents.VpnProtocol = output["vpnProtocol"];
+    contents.VpnProtocol = __expectString(output["vpnProtocol"]);
   }
   if (output["transportProtocol"] !== undefined) {
-    contents.TransportProtocol = output["transportProtocol"];
+    contents.TransportProtocol = __expectString(output["transportProtocol"]);
   }
   if (output["vpnPort"] !== undefined) {
     contents.VpnPort = parseInt(output["vpnPort"]);
@@ -50622,7 +50623,7 @@ const deserializeAws_ec2ClientVpnEndpoint = (output: any, context: __SerdeContex
     );
   }
   if (output["serverCertificateArn"] !== undefined) {
-    contents.ServerCertificateArn = output["serverCertificateArn"];
+    contents.ServerCertificateArn = __expectString(output["serverCertificateArn"]);
   }
   if (output.authenticationOptions === "") {
     contents.AuthenticationOptions = [];
@@ -50655,10 +50656,10 @@ const deserializeAws_ec2ClientVpnEndpoint = (output: any, context: __SerdeContex
     );
   }
   if (output["vpcId"] !== undefined) {
-    contents.VpcId = output["vpcId"];
+    contents.VpcId = __expectString(output["vpcId"]);
   }
   if (output["selfServicePortalUrl"] !== undefined) {
-    contents.SelfServicePortalUrl = output["selfServicePortalUrl"];
+    contents.SelfServicePortalUrl = __expectString(output["selfServicePortalUrl"]);
   }
   if (output["clientConnectOptions"] !== undefined) {
     contents.ClientConnectOptions = deserializeAws_ec2ClientConnectResponseOptions(
@@ -50678,10 +50679,10 @@ const deserializeAws_ec2ClientVpnEndpointAttributeStatus = (
     Message: undefined,
   };
   if (output["code"] !== undefined) {
-    contents.Code = output["code"];
+    contents.Code = __expectString(output["code"]);
   }
   if (output["message"] !== undefined) {
-    contents.Message = output["message"];
+    contents.Message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -50692,10 +50693,10 @@ const deserializeAws_ec2ClientVpnEndpointStatus = (output: any, context: __Serde
     Message: undefined,
   };
   if (output["code"] !== undefined) {
-    contents.Code = output["code"];
+    contents.Code = __expectString(output["code"]);
   }
   if (output["message"] !== undefined) {
-    contents.Message = output["message"];
+    contents.Message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -50711,25 +50712,25 @@ const deserializeAws_ec2ClientVpnRoute = (output: any, context: __SerdeContext):
     Description: undefined,
   };
   if (output["clientVpnEndpointId"] !== undefined) {
-    contents.ClientVpnEndpointId = output["clientVpnEndpointId"];
+    contents.ClientVpnEndpointId = __expectString(output["clientVpnEndpointId"]);
   }
   if (output["destinationCidr"] !== undefined) {
-    contents.DestinationCidr = output["destinationCidr"];
+    contents.DestinationCidr = __expectString(output["destinationCidr"]);
   }
   if (output["targetSubnet"] !== undefined) {
-    contents.TargetSubnet = output["targetSubnet"];
+    contents.TargetSubnet = __expectString(output["targetSubnet"]);
   }
   if (output["type"] !== undefined) {
-    contents.Type = output["type"];
+    contents.Type = __expectString(output["type"]);
   }
   if (output["origin"] !== undefined) {
-    contents.Origin = output["origin"];
+    contents.Origin = __expectString(output["origin"]);
   }
   if (output["status"] !== undefined) {
     contents.Status = deserializeAws_ec2ClientVpnRouteStatus(output["status"], context);
   }
   if (output["description"] !== undefined) {
-    contents.Description = output["description"];
+    contents.Description = __expectString(output["description"]);
   }
   return contents;
 };
@@ -50751,10 +50752,10 @@ const deserializeAws_ec2ClientVpnRouteStatus = (output: any, context: __SerdeCon
     Message: undefined,
   };
   if (output["code"] !== undefined) {
-    contents.Code = output["code"];
+    contents.Code = __expectString(output["code"]);
   }
   if (output["message"] !== undefined) {
-    contents.Message = output["message"];
+    contents.Message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -50766,7 +50767,7 @@ const deserializeAws_ec2ClientVpnSecurityGroupIdSet = (output: any, context: __S
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -50778,16 +50779,16 @@ const deserializeAws_ec2CoipAddressUsage = (output: any, context: __SerdeContext
     CoIp: undefined,
   };
   if (output["allocationId"] !== undefined) {
-    contents.AllocationId = output["allocationId"];
+    contents.AllocationId = __expectString(output["allocationId"]);
   }
   if (output["awsAccountId"] !== undefined) {
-    contents.AwsAccountId = output["awsAccountId"];
+    contents.AwsAccountId = __expectString(output["awsAccountId"]);
   }
   if (output["awsService"] !== undefined) {
-    contents.AwsService = output["awsService"];
+    contents.AwsService = __expectString(output["awsService"]);
   }
   if (output["coIp"] !== undefined) {
-    contents.CoIp = output["coIp"];
+    contents.CoIp = __expectString(output["coIp"]);
   }
   return contents;
 };
@@ -50812,7 +50813,7 @@ const deserializeAws_ec2CoipPool = (output: any, context: __SerdeContext): CoipP
     PoolArn: undefined,
   };
   if (output["poolId"] !== undefined) {
-    contents.PoolId = output["poolId"];
+    contents.PoolId = __expectString(output["poolId"]);
   }
   if (output.poolCidrSet === "") {
     contents.PoolCidrs = [];
@@ -50824,7 +50825,7 @@ const deserializeAws_ec2CoipPool = (output: any, context: __SerdeContext): CoipP
     );
   }
   if (output["localGatewayRouteTableId"] !== undefined) {
-    contents.LocalGatewayRouteTableId = output["localGatewayRouteTableId"];
+    contents.LocalGatewayRouteTableId = __expectString(output["localGatewayRouteTableId"]);
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -50833,7 +50834,7 @@ const deserializeAws_ec2CoipPool = (output: any, context: __SerdeContext): CoipP
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["poolArn"] !== undefined) {
-    contents.PoolArn = output["poolArn"];
+    contents.PoolArn = __expectString(output["poolArn"]);
   }
   return contents;
 };
@@ -50858,7 +50859,7 @@ const deserializeAws_ec2ConfirmProductInstanceResult = (
     Return: undefined,
   };
   if (output["ownerId"] !== undefined) {
-    contents.OwnerId = output["ownerId"];
+    contents.OwnerId = __expectString(output["ownerId"]);
   }
   if (output["return"] !== undefined) {
     contents.Return = __parseBoolean(output["return"]);
@@ -50879,10 +50880,10 @@ const deserializeAws_ec2ConnectionLogResponseOptions = (
     contents.Enabled = __parseBoolean(output["Enabled"]);
   }
   if (output["CloudwatchLogGroup"] !== undefined) {
-    contents.CloudwatchLogGroup = output["CloudwatchLogGroup"];
+    contents.CloudwatchLogGroup = __expectString(output["CloudwatchLogGroup"]);
   }
   if (output["CloudwatchLogStream"] !== undefined) {
-    contents.CloudwatchLogStream = output["CloudwatchLogStream"];
+    contents.CloudwatchLogStream = __expectString(output["CloudwatchLogStream"]);
   }
   return contents;
 };
@@ -50898,19 +50899,19 @@ const deserializeAws_ec2ConnectionNotification = (output: any, context: __SerdeC
     ConnectionNotificationState: undefined,
   };
   if (output["connectionNotificationId"] !== undefined) {
-    contents.ConnectionNotificationId = output["connectionNotificationId"];
+    contents.ConnectionNotificationId = __expectString(output["connectionNotificationId"]);
   }
   if (output["serviceId"] !== undefined) {
-    contents.ServiceId = output["serviceId"];
+    contents.ServiceId = __expectString(output["serviceId"]);
   }
   if (output["vpcEndpointId"] !== undefined) {
-    contents.VpcEndpointId = output["vpcEndpointId"];
+    contents.VpcEndpointId = __expectString(output["vpcEndpointId"]);
   }
   if (output["connectionNotificationType"] !== undefined) {
-    contents.ConnectionNotificationType = output["connectionNotificationType"];
+    contents.ConnectionNotificationType = __expectString(output["connectionNotificationType"]);
   }
   if (output["connectionNotificationArn"] !== undefined) {
-    contents.ConnectionNotificationArn = output["connectionNotificationArn"];
+    contents.ConnectionNotificationArn = __expectString(output["connectionNotificationArn"]);
   }
   if (output.connectionEvents === "") {
     contents.ConnectionEvents = [];
@@ -50922,7 +50923,7 @@ const deserializeAws_ec2ConnectionNotification = (output: any, context: __SerdeC
     );
   }
   if (output["connectionNotificationState"] !== undefined) {
-    contents.ConnectionNotificationState = output["connectionNotificationState"];
+    contents.ConnectionNotificationState = __expectString(output["connectionNotificationState"]);
   }
   return contents;
 };
@@ -50952,10 +50953,10 @@ const deserializeAws_ec2ConversionTask = (output: any, context: __SerdeContext):
     Tags: undefined,
   };
   if (output["conversionTaskId"] !== undefined) {
-    contents.ConversionTaskId = output["conversionTaskId"];
+    contents.ConversionTaskId = __expectString(output["conversionTaskId"]);
   }
   if (output["expirationTime"] !== undefined) {
-    contents.ExpirationTime = output["expirationTime"];
+    contents.ExpirationTime = __expectString(output["expirationTime"]);
   }
   if (output["importInstance"] !== undefined) {
     contents.ImportInstance = deserializeAws_ec2ImportInstanceTaskDetails(output["importInstance"], context);
@@ -50964,10 +50965,10 @@ const deserializeAws_ec2ConversionTask = (output: any, context: __SerdeContext):
     contents.ImportVolume = deserializeAws_ec2ImportVolumeTaskDetails(output["importVolume"], context);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output["statusMessage"] !== undefined) {
-    contents.StatusMessage = output["statusMessage"];
+    contents.StatusMessage = __expectString(output["statusMessage"]);
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -50983,7 +50984,7 @@ const deserializeAws_ec2CopyFpgaImageResult = (output: any, context: __SerdeCont
     FpgaImageId: undefined,
   };
   if (output["fpgaImageId"] !== undefined) {
-    contents.FpgaImageId = output["fpgaImageId"];
+    contents.FpgaImageId = __expectString(output["fpgaImageId"]);
   }
   return contents;
 };
@@ -50993,7 +50994,7 @@ const deserializeAws_ec2CopyImageResult = (output: any, context: __SerdeContext)
     ImageId: undefined,
   };
   if (output["imageId"] !== undefined) {
-    contents.ImageId = output["imageId"];
+    contents.ImageId = __expectString(output["imageId"]);
   }
   return contents;
 };
@@ -51004,7 +51005,7 @@ const deserializeAws_ec2CopySnapshotResult = (output: any, context: __SerdeConte
     Tags: undefined,
   };
   if (output["snapshotId"] !== undefined) {
-    contents.SnapshotId = output["snapshotId"];
+    contents.SnapshotId = __expectString(output["snapshotId"]);
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -51076,13 +51077,13 @@ const deserializeAws_ec2CreateClientVpnEndpointResult = (
     DnsName: undefined,
   };
   if (output["clientVpnEndpointId"] !== undefined) {
-    contents.ClientVpnEndpointId = output["clientVpnEndpointId"];
+    contents.ClientVpnEndpointId = __expectString(output["clientVpnEndpointId"]);
   }
   if (output["status"] !== undefined) {
     contents.Status = deserializeAws_ec2ClientVpnEndpointStatus(output["status"], context);
   }
   if (output["dnsName"] !== undefined) {
-    contents.DnsName = output["dnsName"];
+    contents.DnsName = __expectString(output["dnsName"]);
   }
   return contents;
 };
@@ -51155,7 +51156,7 @@ const deserializeAws_ec2CreateEgressOnlyInternetGatewayResult = (
     EgressOnlyInternetGateway: undefined,
   };
   if (output["clientToken"] !== undefined) {
-    contents.ClientToken = output["clientToken"];
+    contents.ClientToken = __expectString(output["clientToken"]);
   }
   if (output["egressOnlyInternetGateway"] !== undefined) {
     contents.EgressOnlyInternetGateway = deserializeAws_ec2EgressOnlyInternetGateway(
@@ -51180,13 +51181,13 @@ const deserializeAws_ec2CreateFleetError = (output: any, context: __SerdeContext
     );
   }
   if (output["lifecycle"] !== undefined) {
-    contents.Lifecycle = output["lifecycle"];
+    contents.Lifecycle = __expectString(output["lifecycle"]);
   }
   if (output["errorCode"] !== undefined) {
-    contents.ErrorCode = output["errorCode"];
+    contents.ErrorCode = __expectString(output["errorCode"]);
   }
   if (output["errorMessage"] !== undefined) {
-    contents.ErrorMessage = output["errorMessage"];
+    contents.ErrorMessage = __expectString(output["errorMessage"]);
   }
   return contents;
 };
@@ -51217,7 +51218,7 @@ const deserializeAws_ec2CreateFleetInstance = (output: any, context: __SerdeCont
     );
   }
   if (output["lifecycle"] !== undefined) {
-    contents.Lifecycle = output["lifecycle"];
+    contents.Lifecycle = __expectString(output["lifecycle"]);
   }
   if (output.instanceIds === "") {
     contents.InstanceIds = [];
@@ -51229,10 +51230,10 @@ const deserializeAws_ec2CreateFleetInstance = (output: any, context: __SerdeCont
     );
   }
   if (output["instanceType"] !== undefined) {
-    contents.InstanceType = output["instanceType"];
+    contents.InstanceType = __expectString(output["instanceType"]);
   }
   if (output["platform"] !== undefined) {
-    contents.Platform = output["platform"];
+    contents.Platform = __expectString(output["platform"]);
   }
   return contents;
 };
@@ -51255,7 +51256,7 @@ const deserializeAws_ec2CreateFleetResult = (output: any, context: __SerdeContex
     Instances: undefined,
   };
   if (output["fleetId"] !== undefined) {
-    contents.FleetId = output["fleetId"];
+    contents.FleetId = __expectString(output["fleetId"]);
   }
   if (output.errorSet === "") {
     contents.Errors = [];
@@ -51285,7 +51286,7 @@ const deserializeAws_ec2CreateFlowLogsResult = (output: any, context: __SerdeCon
     Unsuccessful: undefined,
   };
   if (output["clientToken"] !== undefined) {
-    contents.ClientToken = output["clientToken"];
+    contents.ClientToken = __expectString(output["clientToken"]);
   }
   if (output.flowLogIdSet === "") {
     contents.FlowLogIds = [];
@@ -51314,10 +51315,10 @@ const deserializeAws_ec2CreateFpgaImageResult = (output: any, context: __SerdeCo
     FpgaImageGlobalId: undefined,
   };
   if (output["fpgaImageId"] !== undefined) {
-    contents.FpgaImageId = output["fpgaImageId"];
+    contents.FpgaImageId = __expectString(output["fpgaImageId"]);
   }
   if (output["fpgaImageGlobalId"] !== undefined) {
-    contents.FpgaImageGlobalId = output["fpgaImageGlobalId"];
+    contents.FpgaImageGlobalId = __expectString(output["fpgaImageGlobalId"]);
   }
   return contents;
 };
@@ -51327,7 +51328,7 @@ const deserializeAws_ec2CreateImageResult = (output: any, context: __SerdeContex
     ImageId: undefined,
   };
   if (output["imageId"] !== undefined) {
-    contents.ImageId = output["imageId"];
+    contents.ImageId = __expectString(output["imageId"]);
   }
   return contents;
 };
@@ -51440,7 +51441,7 @@ const deserializeAws_ec2CreateNatGatewayResult = (output: any, context: __SerdeC
     NatGateway: undefined,
   };
   if (output["clientToken"] !== undefined) {
-    contents.ClientToken = output["clientToken"];
+    contents.ClientToken = __expectString(output["clientToken"]);
   }
   if (output["natGateway"] !== undefined) {
     contents.NatGateway = deserializeAws_ec2NatGateway(output["natGateway"], context);
@@ -51496,7 +51497,7 @@ const deserializeAws_ec2CreateNetworkInterfaceResult = (
     contents.NetworkInterface = deserializeAws_ec2NetworkInterface(output["networkInterface"], context);
   }
   if (output["clientToken"] !== undefined) {
-    contents.ClientToken = output["clientToken"];
+    contents.ClientToken = __expectString(output["clientToken"]);
   }
   return contents;
 };
@@ -51557,7 +51558,7 @@ const deserializeAws_ec2CreateRestoreImageTaskResult = (
     ImageId: undefined,
   };
   if (output["imageId"] !== undefined) {
-    contents.ImageId = output["imageId"];
+    contents.ImageId = __expectString(output["imageId"]);
   }
   return contents;
 };
@@ -51591,7 +51592,7 @@ const deserializeAws_ec2CreateSecurityGroupResult = (
     Tags: undefined,
   };
   if (output["groupId"] !== undefined) {
-    contents.GroupId = output["groupId"];
+    contents.GroupId = __expectString(output["groupId"]);
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -51639,7 +51640,7 @@ const deserializeAws_ec2CreateStoreImageTaskResult = (
     ObjectKey: undefined,
   };
   if (output["objectKey"] !== undefined) {
-    contents.ObjectKey = output["objectKey"];
+    contents.ObjectKey = __expectString(output["objectKey"]);
   }
   return contents;
 };
@@ -51666,7 +51667,7 @@ const deserializeAws_ec2CreateTrafficMirrorFilterResult = (
     contents.TrafficMirrorFilter = deserializeAws_ec2TrafficMirrorFilter(output["trafficMirrorFilter"], context);
   }
   if (output["clientToken"] !== undefined) {
-    contents.ClientToken = output["clientToken"];
+    contents.ClientToken = __expectString(output["clientToken"]);
   }
   return contents;
 };
@@ -51686,7 +51687,7 @@ const deserializeAws_ec2CreateTrafficMirrorFilterRuleResult = (
     );
   }
   if (output["clientToken"] !== undefined) {
-    contents.ClientToken = output["clientToken"];
+    contents.ClientToken = __expectString(output["clientToken"]);
   }
   return contents;
 };
@@ -51703,7 +51704,7 @@ const deserializeAws_ec2CreateTrafficMirrorSessionResult = (
     contents.TrafficMirrorSession = deserializeAws_ec2TrafficMirrorSession(output["trafficMirrorSession"], context);
   }
   if (output["clientToken"] !== undefined) {
-    contents.ClientToken = output["clientToken"];
+    contents.ClientToken = __expectString(output["clientToken"]);
   }
   return contents;
 };
@@ -51720,7 +51721,7 @@ const deserializeAws_ec2CreateTrafficMirrorTargetResult = (
     contents.TrafficMirrorTarget = deserializeAws_ec2TrafficMirrorTarget(output["trafficMirrorTarget"], context);
   }
   if (output["clientToken"] !== undefined) {
-    contents.ClientToken = output["clientToken"];
+    contents.ClientToken = __expectString(output["clientToken"]);
   }
   return contents;
 };
@@ -51866,10 +51867,10 @@ const deserializeAws_ec2CreateVolumePermission = (output: any, context: __SerdeC
     UserId: undefined,
   };
   if (output["group"] !== undefined) {
-    contents.Group = output["group"];
+    contents.Group = __expectString(output["group"]);
   }
   if (output["userId"] !== undefined) {
-    contents.UserId = output["userId"];
+    contents.UserId = __expectString(output["userId"]);
   }
   return contents;
 };
@@ -51903,7 +51904,7 @@ const deserializeAws_ec2CreateVpcEndpointConnectionNotificationResult = (
     );
   }
   if (output["clientToken"] !== undefined) {
-    contents.ClientToken = output["clientToken"];
+    contents.ClientToken = __expectString(output["clientToken"]);
   }
   return contents;
 };
@@ -51917,7 +51918,7 @@ const deserializeAws_ec2CreateVpcEndpointResult = (output: any, context: __Serde
     contents.VpcEndpoint = deserializeAws_ec2VpcEndpoint(output["vpcEndpoint"], context);
   }
   if (output["clientToken"] !== undefined) {
-    contents.ClientToken = output["clientToken"];
+    contents.ClientToken = __expectString(output["clientToken"]);
   }
   return contents;
 };
@@ -51934,7 +51935,7 @@ const deserializeAws_ec2CreateVpcEndpointServiceConfigurationResult = (
     contents.ServiceConfiguration = deserializeAws_ec2ServiceConfiguration(output["serviceConfiguration"], context);
   }
   if (output["clientToken"] !== undefined) {
-    contents.ClientToken = output["clientToken"];
+    contents.ClientToken = __expectString(output["clientToken"]);
   }
   return contents;
 };
@@ -51990,7 +51991,7 @@ const deserializeAws_ec2CreditSpecification = (output: any, context: __SerdeCont
     CpuCredits: undefined,
   };
   if (output["cpuCredits"] !== undefined) {
-    contents.CpuCredits = output["cpuCredits"];
+    contents.CpuCredits = __expectString(output["cpuCredits"]);
   }
   return contents;
 };
@@ -52007,25 +52008,25 @@ const deserializeAws_ec2CustomerGateway = (output: any, context: __SerdeContext)
     Tags: undefined,
   };
   if (output["bgpAsn"] !== undefined) {
-    contents.BgpAsn = output["bgpAsn"];
+    contents.BgpAsn = __expectString(output["bgpAsn"]);
   }
   if (output["customerGatewayId"] !== undefined) {
-    contents.CustomerGatewayId = output["customerGatewayId"];
+    contents.CustomerGatewayId = __expectString(output["customerGatewayId"]);
   }
   if (output["ipAddress"] !== undefined) {
-    contents.IpAddress = output["ipAddress"];
+    contents.IpAddress = __expectString(output["ipAddress"]);
   }
   if (output["certificateArn"] !== undefined) {
-    contents.CertificateArn = output["certificateArn"];
+    contents.CertificateArn = __expectString(output["certificateArn"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output["type"] !== undefined) {
-    contents.Type = output["type"];
+    contents.Type = __expectString(output["type"]);
   }
   if (output["deviceName"] !== undefined) {
-    contents.DeviceName = output["deviceName"];
+    contents.DeviceName = __expectString(output["deviceName"]);
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -52105,10 +52106,10 @@ const deserializeAws_ec2DeleteFleetError = (output: any, context: __SerdeContext
     Message: undefined,
   };
   if (output["code"] !== undefined) {
-    contents.Code = output["code"];
+    contents.Code = __expectString(output["code"]);
   }
   if (output["message"] !== undefined) {
-    contents.Message = output["message"];
+    contents.Message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -52122,7 +52123,7 @@ const deserializeAws_ec2DeleteFleetErrorItem = (output: any, context: __SerdeCon
     contents.Error = deserializeAws_ec2DeleteFleetError(output["error"], context);
   }
   if (output["fleetId"] !== undefined) {
-    contents.FleetId = output["fleetId"];
+    contents.FleetId = __expectString(output["fleetId"]);
   }
   return contents;
 };
@@ -52177,13 +52178,13 @@ const deserializeAws_ec2DeleteFleetSuccessItem = (output: any, context: __SerdeC
     FleetId: undefined,
   };
   if (output["currentFleetState"] !== undefined) {
-    contents.CurrentFleetState = output["currentFleetState"];
+    contents.CurrentFleetState = __expectString(output["currentFleetState"]);
   }
   if (output["previousFleetState"] !== undefined) {
-    contents.PreviousFleetState = output["previousFleetState"];
+    contents.PreviousFleetState = __expectString(output["previousFleetState"]);
   }
   if (output["fleetId"] !== undefined) {
-    contents.FleetId = output["fleetId"];
+    contents.FleetId = __expectString(output["fleetId"]);
   }
   return contents;
 };
@@ -52249,10 +52250,10 @@ const deserializeAws_ec2DeleteLaunchTemplateVersionsResponseErrorItem = (
     ResponseError: undefined,
   };
   if (output["launchTemplateId"] !== undefined) {
-    contents.LaunchTemplateId = output["launchTemplateId"];
+    contents.LaunchTemplateId = __expectString(output["launchTemplateId"]);
   }
   if (output["launchTemplateName"] !== undefined) {
-    contents.LaunchTemplateName = output["launchTemplateName"];
+    contents.LaunchTemplateName = __expectString(output["launchTemplateName"]);
   }
   if (output["versionNumber"] !== undefined) {
     contents.VersionNumber = parseInt(output["versionNumber"]);
@@ -52287,10 +52288,10 @@ const deserializeAws_ec2DeleteLaunchTemplateVersionsResponseSuccessItem = (
     VersionNumber: undefined,
   };
   if (output["launchTemplateId"] !== undefined) {
-    contents.LaunchTemplateId = output["launchTemplateId"];
+    contents.LaunchTemplateId = __expectString(output["launchTemplateId"]);
   }
   if (output["launchTemplateName"] !== undefined) {
-    contents.LaunchTemplateName = output["launchTemplateName"];
+    contents.LaunchTemplateName = __expectString(output["launchTemplateName"]);
   }
   if (output["versionNumber"] !== undefined) {
     contents.VersionNumber = parseInt(output["versionNumber"]);
@@ -52396,7 +52397,7 @@ const deserializeAws_ec2DeleteNatGatewayResult = (output: any, context: __SerdeC
     NatGatewayId: undefined,
   };
   if (output["natGatewayId"] !== undefined) {
-    contents.NatGatewayId = output["natGatewayId"];
+    contents.NatGatewayId = __expectString(output["natGatewayId"]);
   }
   return contents;
 };
@@ -52409,7 +52410,7 @@ const deserializeAws_ec2DeleteNetworkInsightsAnalysisResult = (
     NetworkInsightsAnalysisId: undefined,
   };
   if (output["networkInsightsAnalysisId"] !== undefined) {
-    contents.NetworkInsightsAnalysisId = output["networkInsightsAnalysisId"];
+    contents.NetworkInsightsAnalysisId = __expectString(output["networkInsightsAnalysisId"]);
   }
   return contents;
 };
@@ -52422,7 +52423,7 @@ const deserializeAws_ec2DeleteNetworkInsightsPathResult = (
     NetworkInsightsPathId: undefined,
   };
   if (output["networkInsightsPathId"] !== undefined) {
-    contents.NetworkInsightsPathId = output["networkInsightsPathId"];
+    contents.NetworkInsightsPathId = __expectString(output["networkInsightsPathId"]);
   }
   return contents;
 };
@@ -52449,10 +52450,10 @@ const deserializeAws_ec2DeleteQueuedReservedInstancesError = (
     Message: undefined,
   };
   if (output["code"] !== undefined) {
-    contents.Code = output["code"];
+    contents.Code = __expectString(output["code"]);
   }
   if (output["message"] !== undefined) {
-    contents.Message = output["message"];
+    contents.Message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -52500,7 +52501,7 @@ const deserializeAws_ec2DeleteTrafficMirrorFilterResult = (
     TrafficMirrorFilterId: undefined,
   };
   if (output["trafficMirrorFilterId"] !== undefined) {
-    contents.TrafficMirrorFilterId = output["trafficMirrorFilterId"];
+    contents.TrafficMirrorFilterId = __expectString(output["trafficMirrorFilterId"]);
   }
   return contents;
 };
@@ -52513,7 +52514,7 @@ const deserializeAws_ec2DeleteTrafficMirrorFilterRuleResult = (
     TrafficMirrorFilterRuleId: undefined,
   };
   if (output["trafficMirrorFilterRuleId"] !== undefined) {
-    contents.TrafficMirrorFilterRuleId = output["trafficMirrorFilterRuleId"];
+    contents.TrafficMirrorFilterRuleId = __expectString(output["trafficMirrorFilterRuleId"]);
   }
   return contents;
 };
@@ -52526,7 +52527,7 @@ const deserializeAws_ec2DeleteTrafficMirrorSessionResult = (
     TrafficMirrorSessionId: undefined,
   };
   if (output["trafficMirrorSessionId"] !== undefined) {
-    contents.TrafficMirrorSessionId = output["trafficMirrorSessionId"];
+    contents.TrafficMirrorSessionId = __expectString(output["trafficMirrorSessionId"]);
   }
   return contents;
 };
@@ -52539,7 +52540,7 @@ const deserializeAws_ec2DeleteTrafficMirrorTargetResult = (
     TrafficMirrorTargetId: undefined,
   };
   if (output["trafficMirrorTargetId"] !== undefined) {
-    contents.TrafficMirrorTargetId = output["trafficMirrorTargetId"];
+    contents.TrafficMirrorTargetId = __expectString(output["trafficMirrorTargetId"]);
   }
   return contents;
 };
@@ -52841,7 +52842,7 @@ const deserializeAws_ec2DescribeAddressesAttributeResult = (
     contents.Addresses = deserializeAws_ec2AddressSet(__getArrayIfSingleItem(output["addressSet"]["item"]), context);
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -52932,7 +52933,7 @@ const deserializeAws_ec2DescribeByoipCidrsResult = (output: any, context: __Serd
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -52946,7 +52947,7 @@ const deserializeAws_ec2DescribeCapacityReservationsResult = (
     CapacityReservations: undefined,
   };
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   if (output.capacityReservationSet === "") {
     contents.CapacityReservations = [];
@@ -52978,7 +52979,7 @@ const deserializeAws_ec2DescribeCarrierGatewaysResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -53001,7 +53002,7 @@ const deserializeAws_ec2DescribeClassicLinkInstancesResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -53024,7 +53025,7 @@ const deserializeAws_ec2DescribeClientVpnAuthorizationRulesResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -53047,7 +53048,7 @@ const deserializeAws_ec2DescribeClientVpnConnectionsResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -53070,7 +53071,7 @@ const deserializeAws_ec2DescribeClientVpnEndpointsResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -53090,7 +53091,7 @@ const deserializeAws_ec2DescribeClientVpnRoutesResult = (
     contents.Routes = deserializeAws_ec2ClientVpnRouteSet(__getArrayIfSingleItem(output["routes"]["item"]), context);
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -53113,7 +53114,7 @@ const deserializeAws_ec2DescribeClientVpnTargetNetworksResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -53130,7 +53131,7 @@ const deserializeAws_ec2DescribeCoipPoolsResult = (output: any, context: __Serde
     contents.CoipPools = deserializeAws_ec2CoipPoolSet(__getArrayIfSingleItem(output["coipPoolSet"]["item"]), context);
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -53202,7 +53203,7 @@ const deserializeAws_ec2DescribeDhcpOptionsResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -53228,7 +53229,7 @@ const deserializeAws_ec2DescribeEgressOnlyInternetGatewaysResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -53255,7 +53256,7 @@ const deserializeAws_ec2DescribeElasticGpusResult = (
     contents.MaxResults = parseInt(output["maxResults"]);
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -53278,7 +53279,7 @@ const deserializeAws_ec2DescribeExportImageTasksResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -53320,7 +53321,7 @@ const deserializeAws_ec2DescribeFastSnapshotRestoresResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -53343,22 +53344,22 @@ const deserializeAws_ec2DescribeFastSnapshotRestoreSuccessItem = (
     DisabledTime: undefined,
   };
   if (output["snapshotId"] !== undefined) {
-    contents.SnapshotId = output["snapshotId"];
+    contents.SnapshotId = __expectString(output["snapshotId"]);
   }
   if (output["availabilityZone"] !== undefined) {
-    contents.AvailabilityZone = output["availabilityZone"];
+    contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output["stateTransitionReason"] !== undefined) {
-    contents.StateTransitionReason = output["stateTransitionReason"];
+    contents.StateTransitionReason = __expectString(output["stateTransitionReason"]);
   }
   if (output["ownerId"] !== undefined) {
-    contents.OwnerId = output["ownerId"];
+    contents.OwnerId = __expectString(output["ownerId"]);
   }
   if (output["ownerAlias"] !== undefined) {
-    contents.OwnerAlias = output["ownerAlias"];
+    contents.OwnerAlias = __expectString(output["ownerAlias"]);
   }
   if (output["enablingTime"] !== undefined) {
     contents.EnablingTime = new Date(output["enablingTime"]);
@@ -53406,13 +53407,13 @@ const deserializeAws_ec2DescribeFleetError = (output: any, context: __SerdeConte
     );
   }
   if (output["lifecycle"] !== undefined) {
-    contents.Lifecycle = output["lifecycle"];
+    contents.Lifecycle = __expectString(output["lifecycle"]);
   }
   if (output["errorCode"] !== undefined) {
-    contents.ErrorCode = output["errorCode"];
+    contents.ErrorCode = __expectString(output["errorCode"]);
   }
   if (output["errorMessage"] !== undefined) {
-    contents.ErrorMessage = output["errorMessage"];
+    contents.ErrorMessage = __expectString(output["errorMessage"]);
   }
   return contents;
 };
@@ -53441,10 +53442,10 @@ const deserializeAws_ec2DescribeFleetHistoryResult = (
     contents.LastEvaluatedTime = new Date(output["lastEvaluatedTime"]);
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   if (output["fleetId"] !== undefined) {
-    contents.FleetId = output["fleetId"];
+    contents.FleetId = __expectString(output["fleetId"]);
   }
   if (output["startTime"] !== undefined) {
     contents.StartTime = new Date(output["startTime"]);
@@ -53471,10 +53472,10 @@ const deserializeAws_ec2DescribeFleetInstancesResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   if (output["fleetId"] !== undefined) {
-    contents.FleetId = output["fleetId"];
+    contents.FleetId = __expectString(output["fleetId"]);
   }
   return contents;
 };
@@ -53505,7 +53506,7 @@ const deserializeAws_ec2DescribeFleetsInstances = (output: any, context: __Serde
     );
   }
   if (output["lifecycle"] !== undefined) {
-    contents.Lifecycle = output["lifecycle"];
+    contents.Lifecycle = __expectString(output["lifecycle"]);
   }
   if (output.instanceIds === "") {
     contents.InstanceIds = [];
@@ -53517,10 +53518,10 @@ const deserializeAws_ec2DescribeFleetsInstances = (output: any, context: __Serde
     );
   }
   if (output["instanceType"] !== undefined) {
-    contents.InstanceType = output["instanceType"];
+    contents.InstanceType = __expectString(output["instanceType"]);
   }
   if (output["platform"] !== undefined) {
-    contents.Platform = output["platform"];
+    contents.Platform = __expectString(output["platform"]);
   }
   return contents;
 };
@@ -53545,7 +53546,7 @@ const deserializeAws_ec2DescribeFleetsResult = (output: any, context: __SerdeCon
     Fleets: undefined,
   };
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   if (output.fleetSet === "") {
     contents.Fleets = [];
@@ -53568,7 +53569,7 @@ const deserializeAws_ec2DescribeFlowLogsResult = (output: any, context: __SerdeC
     contents.FlowLogs = deserializeAws_ec2FlowLogSet(__getArrayIfSingleItem(output["flowLogSet"]["item"]), context);
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -53601,7 +53602,7 @@ const deserializeAws_ec2DescribeFpgaImagesResult = (output: any, context: __Serd
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -53615,7 +53616,7 @@ const deserializeAws_ec2DescribeHostReservationOfferingsResult = (
     OfferingSet: undefined,
   };
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   if (output.offeringSet === "") {
     contents.OfferingSet = [];
@@ -53647,7 +53648,7 @@ const deserializeAws_ec2DescribeHostReservationsResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -53664,7 +53665,7 @@ const deserializeAws_ec2DescribeHostsResult = (output: any, context: __SerdeCont
     contents.Hosts = deserializeAws_ec2HostList(__getArrayIfSingleItem(output["hostSet"]["item"]), context);
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -53690,7 +53691,7 @@ const deserializeAws_ec2DescribeIamInstanceProfileAssociationsResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -53755,7 +53756,7 @@ const deserializeAws_ec2DescribeImportImageTasksResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -53778,7 +53779,7 @@ const deserializeAws_ec2DescribeImportSnapshotTasksResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -53804,7 +53805,7 @@ const deserializeAws_ec2DescribeInstanceCreditSpecificationsResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -53840,7 +53841,7 @@ const deserializeAws_ec2DescribeInstancesResult = (output: any, context: __Serde
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -53863,7 +53864,7 @@ const deserializeAws_ec2DescribeInstanceStatusResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -53886,7 +53887,7 @@ const deserializeAws_ec2DescribeInstanceTypeOfferingsResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -53909,7 +53910,7 @@ const deserializeAws_ec2DescribeInstanceTypesResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -53932,7 +53933,7 @@ const deserializeAws_ec2DescribeInternetGatewaysResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -53949,7 +53950,7 @@ const deserializeAws_ec2DescribeIpv6PoolsResult = (output: any, context: __Serde
     contents.Ipv6Pools = deserializeAws_ec2Ipv6PoolSet(__getArrayIfSingleItem(output["ipv6PoolSet"]["item"]), context);
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -53985,7 +53986,7 @@ const deserializeAws_ec2DescribeLaunchTemplatesResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -54008,7 +54009,7 @@ const deserializeAws_ec2DescribeLaunchTemplateVersionsResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -54031,7 +54032,7 @@ const deserializeAws_ec2DescribeLocalGatewayRouteTablesResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -54058,7 +54059,7 @@ const deserializeAws_ec2DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssoc
       );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -54084,7 +54085,7 @@ const deserializeAws_ec2DescribeLocalGatewayRouteTableVpcAssociationsResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -54107,7 +54108,7 @@ const deserializeAws_ec2DescribeLocalGatewaysResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -54133,7 +54134,7 @@ const deserializeAws_ec2DescribeLocalGatewayVirtualInterfaceGroupsResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -54159,7 +54160,7 @@ const deserializeAws_ec2DescribeLocalGatewayVirtualInterfacesResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -54173,7 +54174,7 @@ const deserializeAws_ec2DescribeManagedPrefixListsResult = (
     PrefixLists: undefined,
   };
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   if (output.prefixListSet === "") {
     contents.PrefixLists = [];
@@ -54205,7 +54206,7 @@ const deserializeAws_ec2DescribeMovingAddressesResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -54228,7 +54229,7 @@ const deserializeAws_ec2DescribeNatGatewaysResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -54251,7 +54252,7 @@ const deserializeAws_ec2DescribeNetworkAclsResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -54277,7 +54278,7 @@ const deserializeAws_ec2DescribeNetworkInsightsAnalysesResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -54300,7 +54301,7 @@ const deserializeAws_ec2DescribeNetworkInsightsPathsResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -54332,7 +54333,7 @@ const deserializeAws_ec2DescribeNetworkInterfaceAttributeResult = (
     );
   }
   if (output["networkInterfaceId"] !== undefined) {
-    contents.NetworkInterfaceId = output["networkInterfaceId"];
+    contents.NetworkInterfaceId = __expectString(output["networkInterfaceId"]);
   }
   if (output["sourceDestCheck"] !== undefined) {
     contents.SourceDestCheck = deserializeAws_ec2AttributeBooleanValue(output["sourceDestCheck"], context);
@@ -54361,7 +54362,7 @@ const deserializeAws_ec2DescribeNetworkInterfacePermissionsResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -54384,7 +54385,7 @@ const deserializeAws_ec2DescribeNetworkInterfacesResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -54417,7 +54418,7 @@ const deserializeAws_ec2DescribePrefixListsResult = (
     PrefixLists: undefined,
   };
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   if (output.prefixListSet === "") {
     contents.PrefixLists = [];
@@ -54449,7 +54450,7 @@ const deserializeAws_ec2DescribePrincipalIdFormatResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -54472,7 +54473,7 @@ const deserializeAws_ec2DescribePublicIpv4PoolsResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -54508,7 +54509,7 @@ const deserializeAws_ec2DescribeReplaceRootVolumeTasksResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -54544,7 +54545,7 @@ const deserializeAws_ec2DescribeReservedInstancesModificationsResult = (
     ReservedInstancesModifications: undefined,
   };
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   if (output.reservedInstancesModificationsSet === "") {
     contents.ReservedInstancesModifications = [];
@@ -54582,7 +54583,7 @@ const deserializeAws_ec2DescribeReservedInstancesOfferingsResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -54624,7 +54625,7 @@ const deserializeAws_ec2DescribeRouteTablesResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -54638,7 +54639,7 @@ const deserializeAws_ec2DescribeScheduledInstanceAvailabilityResult = (
     ScheduledInstanceAvailabilitySet: undefined,
   };
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   if (output.scheduledInstanceAvailabilitySet === "") {
     contents.ScheduledInstanceAvailabilitySet = [];
@@ -54664,7 +54665,7 @@ const deserializeAws_ec2DescribeScheduledInstancesResult = (
     ScheduledInstanceSet: undefined,
   };
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   if (output.scheduledInstanceSet === "") {
     contents.ScheduledInstanceSet = [];
@@ -54715,7 +54716,7 @@ const deserializeAws_ec2DescribeSecurityGroupsResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -54748,7 +54749,7 @@ const deserializeAws_ec2DescribeSnapshotAttributeResult = (
     );
   }
   if (output["snapshotId"] !== undefined) {
-    contents.SnapshotId = output["snapshotId"];
+    contents.SnapshotId = __expectString(output["snapshotId"]);
   }
   return contents;
 };
@@ -54765,7 +54766,7 @@ const deserializeAws_ec2DescribeSnapshotsResult = (output: any, context: __Serde
     contents.Snapshots = deserializeAws_ec2SnapshotList(__getArrayIfSingleItem(output["snapshotSet"]["item"]), context);
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -54805,10 +54806,10 @@ const deserializeAws_ec2DescribeSpotFleetInstancesResponse = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   if (output["spotFleetRequestId"] !== undefined) {
-    contents.SpotFleetRequestId = output["spotFleetRequestId"];
+    contents.SpotFleetRequestId = __expectString(output["spotFleetRequestId"]);
   }
   return contents;
 };
@@ -54837,10 +54838,10 @@ const deserializeAws_ec2DescribeSpotFleetRequestHistoryResponse = (
     contents.LastEvaluatedTime = new Date(output["lastEvaluatedTime"]);
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   if (output["spotFleetRequestId"] !== undefined) {
-    contents.SpotFleetRequestId = output["spotFleetRequestId"];
+    contents.SpotFleetRequestId = __expectString(output["spotFleetRequestId"]);
   }
   if (output["startTime"] !== undefined) {
     contents.StartTime = new Date(output["startTime"]);
@@ -54857,7 +54858,7 @@ const deserializeAws_ec2DescribeSpotFleetRequestsResponse = (
     SpotFleetRequestConfigs: undefined,
   };
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   if (output.spotFleetRequestConfigSet === "") {
     contents.SpotFleetRequestConfigs = [];
@@ -54889,7 +54890,7 @@ const deserializeAws_ec2DescribeSpotInstanceRequestsResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -54903,7 +54904,7 @@ const deserializeAws_ec2DescribeSpotPriceHistoryResult = (
     SpotPriceHistory: undefined,
   };
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   if (output.spotPriceHistorySet === "") {
     contents.SpotPriceHistory = [];
@@ -54926,7 +54927,7 @@ const deserializeAws_ec2DescribeStaleSecurityGroupsResult = (
     StaleSecurityGroupSet: undefined,
   };
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   if (output.staleSecurityGroupSet === "") {
     contents.StaleSecurityGroupSet = [];
@@ -54958,7 +54959,7 @@ const deserializeAws_ec2DescribeStoreImageTasksResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -54975,7 +54976,7 @@ const deserializeAws_ec2DescribeSubnetsResult = (output: any, context: __SerdeCo
     contents.Subnets = deserializeAws_ec2SubnetList(__getArrayIfSingleItem(output["subnetSet"]["item"]), context);
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -54986,7 +54987,7 @@ const deserializeAws_ec2DescribeTagsResult = (output: any, context: __SerdeConte
     Tags: undefined,
   };
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -55015,7 +55016,7 @@ const deserializeAws_ec2DescribeTrafficMirrorFiltersResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -55038,7 +55039,7 @@ const deserializeAws_ec2DescribeTrafficMirrorSessionsResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -55061,7 +55062,7 @@ const deserializeAws_ec2DescribeTrafficMirrorTargetsResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -55084,7 +55085,7 @@ const deserializeAws_ec2DescribeTransitGatewayAttachmentsResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -55110,7 +55111,7 @@ const deserializeAws_ec2DescribeTransitGatewayConnectPeersResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -55133,7 +55134,7 @@ const deserializeAws_ec2DescribeTransitGatewayConnectsResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -55159,7 +55160,7 @@ const deserializeAws_ec2DescribeTransitGatewayMulticastDomainsResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -55185,7 +55186,7 @@ const deserializeAws_ec2DescribeTransitGatewayPeeringAttachmentsResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -55208,7 +55209,7 @@ const deserializeAws_ec2DescribeTransitGatewayRouteTablesResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -55231,7 +55232,7 @@ const deserializeAws_ec2DescribeTransitGatewaysResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -55257,7 +55258,7 @@ const deserializeAws_ec2DescribeTransitGatewayVpcAttachmentsResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -55280,7 +55281,7 @@ const deserializeAws_ec2DescribeTrunkInterfaceAssociationsResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -55307,7 +55308,7 @@ const deserializeAws_ec2DescribeVolumeAttributeResult = (
     );
   }
   if (output["volumeId"] !== undefined) {
-    contents.VolumeId = output["volumeId"];
+    contents.VolumeId = __expectString(output["volumeId"]);
   }
   return contents;
 };
@@ -55330,7 +55331,7 @@ const deserializeAws_ec2DescribeVolumesModificationsResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -55347,7 +55348,7 @@ const deserializeAws_ec2DescribeVolumesResult = (output: any, context: __SerdeCo
     contents.Volumes = deserializeAws_ec2VolumeList(__getArrayIfSingleItem(output["volumeSet"]["item"]), context);
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -55361,7 +55362,7 @@ const deserializeAws_ec2DescribeVolumeStatusResult = (
     VolumeStatuses: undefined,
   };
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   if (output.volumeStatusSet === "") {
     contents.VolumeStatuses = [];
@@ -55385,7 +55386,7 @@ const deserializeAws_ec2DescribeVpcAttributeResult = (
     EnableDnsSupport: undefined,
   };
   if (output["vpcId"] !== undefined) {
-    contents.VpcId = output["vpcId"];
+    contents.VpcId = __expectString(output["vpcId"]);
   }
   if (output["enableDnsHostnames"] !== undefined) {
     contents.EnableDnsHostnames = deserializeAws_ec2AttributeBooleanValue(output["enableDnsHostnames"], context);
@@ -55405,7 +55406,7 @@ const deserializeAws_ec2DescribeVpcClassicLinkDnsSupportResult = (
     Vpcs: undefined,
   };
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   if (output.vpcs === "") {
     contents.Vpcs = [];
@@ -55453,7 +55454,7 @@ const deserializeAws_ec2DescribeVpcEndpointConnectionNotificationsResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -55476,7 +55477,7 @@ const deserializeAws_ec2DescribeVpcEndpointConnectionsResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -55499,7 +55500,7 @@ const deserializeAws_ec2DescribeVpcEndpointServiceConfigurationsResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -55522,7 +55523,7 @@ const deserializeAws_ec2DescribeVpcEndpointServicePermissionsResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -55555,7 +55556,7 @@ const deserializeAws_ec2DescribeVpcEndpointServicesResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -55578,7 +55579,7 @@ const deserializeAws_ec2DescribeVpcEndpointsResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -55601,7 +55602,7 @@ const deserializeAws_ec2DescribeVpcPeeringConnectionsResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -55618,7 +55619,7 @@ const deserializeAws_ec2DescribeVpcsResult = (output: any, context: __SerdeConte
     contents.Vpcs = deserializeAws_ec2VpcList(__getArrayIfSingleItem(output["vpcSet"]["item"]), context);
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -55680,7 +55681,7 @@ const deserializeAws_ec2DhcpConfiguration = (output: any, context: __SerdeContex
     Values: undefined,
   };
   if (output["key"] !== undefined) {
-    contents.Key = output["key"];
+    contents.Key = __expectString(output["key"]);
   }
   if (output.valueSet === "") {
     contents.Values = [];
@@ -55733,10 +55734,10 @@ const deserializeAws_ec2DhcpOptions = (output: any, context: __SerdeContext): Dh
     );
   }
   if (output["dhcpOptionsId"] !== undefined) {
-    contents.DhcpOptionsId = output["dhcpOptionsId"];
+    contents.DhcpOptionsId = __expectString(output["dhcpOptionsId"]);
   }
   if (output["ownerId"] !== undefined) {
-    contents.OwnerId = output["ownerId"];
+    contents.OwnerId = __expectString(output["ownerId"]);
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -55766,7 +55767,7 @@ const deserializeAws_ec2DirectoryServiceAuthentication = (
     DirectoryId: undefined,
   };
   if (output["directoryId"] !== undefined) {
-    contents.DirectoryId = output["directoryId"];
+    contents.DirectoryId = __expectString(output["directoryId"]);
   }
   return contents;
 };
@@ -55793,7 +55794,7 @@ const deserializeAws_ec2DisableFastSnapshotRestoreErrorItem = (
     FastSnapshotRestoreStateErrors: undefined,
   };
   if (output["snapshotId"] !== undefined) {
-    contents.SnapshotId = output["snapshotId"];
+    contents.SnapshotId = __expectString(output["snapshotId"]);
   }
   if (output.fastSnapshotRestoreStateErrorSet === "") {
     contents.FastSnapshotRestoreStateErrors = [];
@@ -55862,10 +55863,10 @@ const deserializeAws_ec2DisableFastSnapshotRestoreStateError = (
     Message: undefined,
   };
   if (output["code"] !== undefined) {
-    contents.Code = output["code"];
+    contents.Code = __expectString(output["code"]);
   }
   if (output["message"] !== undefined) {
-    contents.Message = output["message"];
+    contents.Message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -55879,7 +55880,7 @@ const deserializeAws_ec2DisableFastSnapshotRestoreStateErrorItem = (
     Error: undefined,
   };
   if (output["availabilityZone"] !== undefined) {
-    contents.AvailabilityZone = output["availabilityZone"];
+    contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
   if (output["error"] !== undefined) {
     contents.Error = deserializeAws_ec2DisableFastSnapshotRestoreStateError(output["error"], context);
@@ -55919,22 +55920,22 @@ const deserializeAws_ec2DisableFastSnapshotRestoreSuccessItem = (
     DisabledTime: undefined,
   };
   if (output["snapshotId"] !== undefined) {
-    contents.SnapshotId = output["snapshotId"];
+    contents.SnapshotId = __expectString(output["snapshotId"]);
   }
   if (output["availabilityZone"] !== undefined) {
-    contents.AvailabilityZone = output["availabilityZone"];
+    contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output["stateTransitionReason"] !== undefined) {
-    contents.StateTransitionReason = output["stateTransitionReason"];
+    contents.StateTransitionReason = __expectString(output["stateTransitionReason"]);
   }
   if (output["ownerId"] !== undefined) {
-    contents.OwnerId = output["ownerId"];
+    contents.OwnerId = __expectString(output["ownerId"]);
   }
   if (output["ownerAlias"] !== undefined) {
-    contents.OwnerAlias = output["ownerAlias"];
+    contents.OwnerAlias = __expectString(output["ownerAlias"]);
   }
   if (output["enablingTime"] !== undefined) {
     contents.EnablingTime = new Date(output["enablingTime"]);
@@ -56042,7 +56043,7 @@ const deserializeAws_ec2DisassociateClientVpnTargetNetworkResult = (
     Status: undefined,
   };
   if (output["associationId"] !== undefined) {
-    contents.AssociationId = output["associationId"];
+    contents.AssociationId = __expectString(output["associationId"]);
   }
   if (output["status"] !== undefined) {
     contents.Status = deserializeAws_ec2AssociationStatus(output["status"], context);
@@ -56094,7 +56095,7 @@ const deserializeAws_ec2DisassociateSubnetCidrBlockResult = (
     );
   }
   if (output["subnetId"] !== undefined) {
-    contents.SubnetId = output["subnetId"];
+    contents.SubnetId = __expectString(output["subnetId"]);
   }
   return contents;
 };
@@ -56140,7 +56141,7 @@ const deserializeAws_ec2DisassociateTrunkInterfaceResult = (
     contents.Return = __parseBoolean(output["return"]);
   }
   if (output["clientToken"] !== undefined) {
-    contents.ClientToken = output["clientToken"];
+    contents.ClientToken = __expectString(output["clientToken"]);
   }
   return contents;
 };
@@ -56164,7 +56165,7 @@ const deserializeAws_ec2DisassociateVpcCidrBlockResult = (
     contents.CidrBlockAssociation = deserializeAws_ec2VpcCidrBlockAssociation(output["cidrBlockAssociation"], context);
   }
   if (output["vpcId"] !== undefined) {
-    contents.VpcId = output["vpcId"];
+    contents.VpcId = __expectString(output["vpcId"]);
   }
   return contents;
 };
@@ -56177,13 +56178,13 @@ const deserializeAws_ec2DiskImageDescription = (output: any, context: __SerdeCon
     Size: undefined,
   };
   if (output["checksum"] !== undefined) {
-    contents.Checksum = output["checksum"];
+    contents.Checksum = __expectString(output["checksum"]);
   }
   if (output["format"] !== undefined) {
-    contents.Format = output["format"];
+    contents.Format = __expectString(output["format"]);
   }
   if (output["importManifestUrl"] !== undefined) {
-    contents.ImportManifestUrl = output["importManifestUrl"];
+    contents.ImportManifestUrl = __expectString(output["importManifestUrl"]);
   }
   if (output["size"] !== undefined) {
     contents.Size = parseInt(output["size"]);
@@ -56200,7 +56201,7 @@ const deserializeAws_ec2DiskImageVolumeDescription = (
     Size: undefined,
   };
   if (output["id"] !== undefined) {
-    contents.Id = output["id"];
+    contents.Id = __expectString(output["id"]);
   }
   if (output["size"] !== undefined) {
     contents.Size = parseInt(output["size"]);
@@ -56221,7 +56222,7 @@ const deserializeAws_ec2DiskInfo = (output: any, context: __SerdeContext): DiskI
     contents.Count = parseInt(output["count"]);
   }
   if (output["type"] !== undefined) {
-    contents.Type = output["type"];
+    contents.Type = __expectString(output["type"]);
   }
   return contents;
 };
@@ -56243,10 +56244,10 @@ const deserializeAws_ec2DnsEntry = (output: any, context: __SerdeContext): DnsEn
     HostedZoneId: undefined,
   };
   if (output["dnsName"] !== undefined) {
-    contents.DnsName = output["dnsName"];
+    contents.DnsName = __expectString(output["dnsName"]);
   }
   if (output["hostedZoneId"] !== undefined) {
-    contents.HostedZoneId = output["hostedZoneId"];
+    contents.HostedZoneId = __expectString(output["hostedZoneId"]);
   }
   return contents;
 };
@@ -56281,22 +56282,22 @@ const deserializeAws_ec2EbsBlockDevice = (output: any, context: __SerdeContext):
     contents.Iops = parseInt(output["iops"]);
   }
   if (output["snapshotId"] !== undefined) {
-    contents.SnapshotId = output["snapshotId"];
+    contents.SnapshotId = __expectString(output["snapshotId"]);
   }
   if (output["volumeSize"] !== undefined) {
     contents.VolumeSize = parseInt(output["volumeSize"]);
   }
   if (output["volumeType"] !== undefined) {
-    contents.VolumeType = output["volumeType"];
+    contents.VolumeType = __expectString(output["volumeType"]);
   }
   if (output["KmsKeyId"] !== undefined) {
-    contents.KmsKeyId = output["KmsKeyId"];
+    contents.KmsKeyId = __expectString(output["KmsKeyId"]);
   }
   if (output["throughput"] !== undefined) {
     contents.Throughput = parseInt(output["throughput"]);
   }
   if (output["outpostArn"] !== undefined) {
-    contents.OutpostArn = output["outpostArn"];
+    contents.OutpostArn = __expectString(output["outpostArn"]);
   }
   if (output["encrypted"] !== undefined) {
     contents.Encrypted = __parseBoolean(output["encrypted"]);
@@ -56312,16 +56313,16 @@ const deserializeAws_ec2EbsInfo = (output: any, context: __SerdeContext): EbsInf
     NvmeSupport: undefined,
   };
   if (output["ebsOptimizedSupport"] !== undefined) {
-    contents.EbsOptimizedSupport = output["ebsOptimizedSupport"];
+    contents.EbsOptimizedSupport = __expectString(output["ebsOptimizedSupport"]);
   }
   if (output["encryptionSupport"] !== undefined) {
-    contents.EncryptionSupport = output["encryptionSupport"];
+    contents.EncryptionSupport = __expectString(output["encryptionSupport"]);
   }
   if (output["ebsOptimizedInfo"] !== undefined) {
     contents.EbsOptimizedInfo = deserializeAws_ec2EbsOptimizedInfo(output["ebsOptimizedInfo"], context);
   }
   if (output["nvmeSupport"] !== undefined) {
-    contents.NvmeSupport = output["nvmeSupport"];
+    contents.NvmeSupport = __expectString(output["nvmeSupport"]);
   }
   return contents;
 };
@@ -56340,10 +56341,10 @@ const deserializeAws_ec2EbsInstanceBlockDevice = (output: any, context: __SerdeC
     contents.DeleteOnTermination = __parseBoolean(output["deleteOnTermination"]);
   }
   if (output["status"] !== undefined) {
-    contents.Status = output["status"];
+    contents.Status = __expectString(output["status"]);
   }
   if (output["volumeId"] !== undefined) {
-    contents.VolumeId = output["volumeId"];
+    contents.VolumeId = __expectString(output["volumeId"]);
   }
   return contents;
 };
@@ -56407,7 +56408,7 @@ const deserializeAws_ec2EgressOnlyInternetGateway = (
     );
   }
   if (output["egressOnlyInternetGatewayId"] !== undefined) {
-    contents.EgressOnlyInternetGatewayId = output["egressOnlyInternetGatewayId"];
+    contents.EgressOnlyInternetGatewayId = __expectString(output["egressOnlyInternetGatewayId"]);
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -56440,16 +56441,16 @@ const deserializeAws_ec2ElasticGpuAssociation = (output: any, context: __SerdeCo
     ElasticGpuAssociationTime: undefined,
   };
   if (output["elasticGpuId"] !== undefined) {
-    contents.ElasticGpuId = output["elasticGpuId"];
+    contents.ElasticGpuId = __expectString(output["elasticGpuId"]);
   }
   if (output["elasticGpuAssociationId"] !== undefined) {
-    contents.ElasticGpuAssociationId = output["elasticGpuAssociationId"];
+    contents.ElasticGpuAssociationId = __expectString(output["elasticGpuAssociationId"]);
   }
   if (output["elasticGpuAssociationState"] !== undefined) {
-    contents.ElasticGpuAssociationState = output["elasticGpuAssociationState"];
+    contents.ElasticGpuAssociationState = __expectString(output["elasticGpuAssociationState"]);
   }
   if (output["elasticGpuAssociationTime"] !== undefined) {
-    contents.ElasticGpuAssociationTime = output["elasticGpuAssociationTime"];
+    contents.ElasticGpuAssociationTime = __expectString(output["elasticGpuAssociationTime"]);
   }
   return contents;
 };
@@ -56470,7 +56471,7 @@ const deserializeAws_ec2ElasticGpuHealth = (output: any, context: __SerdeContext
     Status: undefined,
   };
   if (output["status"] !== undefined) {
-    contents.Status = output["status"];
+    contents.Status = __expectString(output["status"]);
   }
   return contents;
 };
@@ -56486,22 +56487,22 @@ const deserializeAws_ec2ElasticGpus = (output: any, context: __SerdeContext): El
     Tags: undefined,
   };
   if (output["elasticGpuId"] !== undefined) {
-    contents.ElasticGpuId = output["elasticGpuId"];
+    contents.ElasticGpuId = __expectString(output["elasticGpuId"]);
   }
   if (output["availabilityZone"] !== undefined) {
-    contents.AvailabilityZone = output["availabilityZone"];
+    contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
   if (output["elasticGpuType"] !== undefined) {
-    contents.ElasticGpuType = output["elasticGpuType"];
+    contents.ElasticGpuType = __expectString(output["elasticGpuType"]);
   }
   if (output["elasticGpuHealth"] !== undefined) {
     contents.ElasticGpuHealth = deserializeAws_ec2ElasticGpuHealth(output["elasticGpuHealth"], context);
   }
   if (output["elasticGpuState"] !== undefined) {
-    contents.ElasticGpuState = output["elasticGpuState"];
+    contents.ElasticGpuState = __expectString(output["elasticGpuState"]);
   }
   if (output["instanceId"] !== undefined) {
-    contents.InstanceId = output["instanceId"];
+    contents.InstanceId = __expectString(output["instanceId"]);
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -56531,7 +56532,7 @@ const deserializeAws_ec2ElasticGpuSpecificationResponse = (
     Type: undefined,
   };
   if (output["type"] !== undefined) {
-    contents.Type = output["type"];
+    contents.Type = __expectString(output["type"]);
   }
   return contents;
 };
@@ -56561,13 +56562,17 @@ const deserializeAws_ec2ElasticInferenceAcceleratorAssociation = (
     ElasticInferenceAcceleratorAssociationTime: undefined,
   };
   if (output["elasticInferenceAcceleratorArn"] !== undefined) {
-    contents.ElasticInferenceAcceleratorArn = output["elasticInferenceAcceleratorArn"];
+    contents.ElasticInferenceAcceleratorArn = __expectString(output["elasticInferenceAcceleratorArn"]);
   }
   if (output["elasticInferenceAcceleratorAssociationId"] !== undefined) {
-    contents.ElasticInferenceAcceleratorAssociationId = output["elasticInferenceAcceleratorAssociationId"];
+    contents.ElasticInferenceAcceleratorAssociationId = __expectString(
+      output["elasticInferenceAcceleratorAssociationId"]
+    );
   }
   if (output["elasticInferenceAcceleratorAssociationState"] !== undefined) {
-    contents.ElasticInferenceAcceleratorAssociationState = output["elasticInferenceAcceleratorAssociationState"];
+    contents.ElasticInferenceAcceleratorAssociationState = __expectString(
+      output["elasticInferenceAcceleratorAssociationState"]
+    );
   }
   if (output["elasticInferenceAcceleratorAssociationTime"] !== undefined) {
     contents.ElasticInferenceAcceleratorAssociationTime = new Date(
@@ -56613,7 +56618,7 @@ const deserializeAws_ec2EnableFastSnapshotRestoreErrorItem = (
     FastSnapshotRestoreStateErrors: undefined,
   };
   if (output["snapshotId"] !== undefined) {
-    contents.SnapshotId = output["snapshotId"];
+    contents.SnapshotId = __expectString(output["snapshotId"]);
   }
   if (output.fastSnapshotRestoreStateErrorSet === "") {
     contents.FastSnapshotRestoreStateErrors = [];
@@ -56682,10 +56687,10 @@ const deserializeAws_ec2EnableFastSnapshotRestoreStateError = (
     Message: undefined,
   };
   if (output["code"] !== undefined) {
-    contents.Code = output["code"];
+    contents.Code = __expectString(output["code"]);
   }
   if (output["message"] !== undefined) {
-    contents.Message = output["message"];
+    contents.Message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -56699,7 +56704,7 @@ const deserializeAws_ec2EnableFastSnapshotRestoreStateErrorItem = (
     Error: undefined,
   };
   if (output["availabilityZone"] !== undefined) {
-    contents.AvailabilityZone = output["availabilityZone"];
+    contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
   if (output["error"] !== undefined) {
     contents.Error = deserializeAws_ec2EnableFastSnapshotRestoreStateError(output["error"], context);
@@ -56739,22 +56744,22 @@ const deserializeAws_ec2EnableFastSnapshotRestoreSuccessItem = (
     DisabledTime: undefined,
   };
   if (output["snapshotId"] !== undefined) {
-    contents.SnapshotId = output["snapshotId"];
+    contents.SnapshotId = __expectString(output["snapshotId"]);
   }
   if (output["availabilityZone"] !== undefined) {
-    contents.AvailabilityZone = output["availabilityZone"];
+    contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output["stateTransitionReason"] !== undefined) {
-    contents.StateTransitionReason = output["stateTransitionReason"];
+    contents.StateTransitionReason = __expectString(output["stateTransitionReason"]);
   }
   if (output["ownerId"] !== undefined) {
-    contents.OwnerId = output["ownerId"];
+    contents.OwnerId = __expectString(output["ownerId"]);
   }
   if (output["ownerAlias"] !== undefined) {
-    contents.OwnerAlias = output["ownerAlias"];
+    contents.OwnerAlias = __expectString(output["ownerAlias"]);
   }
   if (output["enablingTime"] !== undefined) {
     contents.EnablingTime = new Date(output["enablingTime"]);
@@ -56892,13 +56897,13 @@ const deserializeAws_ec2EventInformation = (output: any, context: __SerdeContext
     InstanceId: undefined,
   };
   if (output["eventDescription"] !== undefined) {
-    contents.EventDescription = output["eventDescription"];
+    contents.EventDescription = __expectString(output["eventDescription"]);
   }
   if (output["eventSubType"] !== undefined) {
-    contents.EventSubType = output["eventSubType"];
+    contents.EventSubType = __expectString(output["eventSubType"]);
   }
   if (output["instanceId"] !== undefined) {
-    contents.InstanceId = output["instanceId"];
+    contents.InstanceId = __expectString(output["instanceId"]);
   }
   return contents;
 };
@@ -56958,7 +56963,7 @@ const deserializeAws_ec2Explanation = (output: any, context: __SerdeContext): Ex
     contents.AclRule = deserializeAws_ec2AnalysisAclRule(output["aclRule"], context);
   }
   if (output["address"] !== undefined) {
-    contents.Address = output["address"];
+    contents.Address = __expectString(output["address"]);
   }
   if (output.addressSet === "") {
     contents.Addresses = [];
@@ -56997,10 +57002,10 @@ const deserializeAws_ec2Explanation = (output: any, context: __SerdeContext): Ex
     contents.DestinationVpc = deserializeAws_ec2AnalysisComponent(output["destinationVpc"], context);
   }
   if (output["direction"] !== undefined) {
-    contents.Direction = output["direction"];
+    contents.Direction = __expectString(output["direction"]);
   }
   if (output["explanationCode"] !== undefined) {
-    contents.ExplanationCode = output["explanationCode"];
+    contents.ExplanationCode = __expectString(output["explanationCode"]);
   }
   if (output["ingressRouteTable"] !== undefined) {
     contents.IngressRouteTable = deserializeAws_ec2AnalysisComponent(output["ingressRouteTable"], context);
@@ -57009,7 +57014,7 @@ const deserializeAws_ec2Explanation = (output: any, context: __SerdeContext): Ex
     contents.InternetGateway = deserializeAws_ec2AnalysisComponent(output["internetGateway"], context);
   }
   if (output["loadBalancerArn"] !== undefined) {
-    contents.LoadBalancerArn = output["loadBalancerArn"];
+    contents.LoadBalancerArn = __expectString(output["loadBalancerArn"]);
   }
   if (output["classicLoadBalancerListener"] !== undefined) {
     contents.ClassicLoadBalancerListener = deserializeAws_ec2AnalysisLoadBalancerListener(
@@ -57048,7 +57053,7 @@ const deserializeAws_ec2Explanation = (output: any, context: __SerdeContext): Ex
     );
   }
   if (output["missingComponent"] !== undefined) {
-    contents.MissingComponent = output["missingComponent"];
+    contents.MissingComponent = __expectString(output["missingComponent"]);
   }
   if (output["natGateway"] !== undefined) {
     contents.NatGateway = deserializeAws_ec2AnalysisComponent(output["natGateway"], context);
@@ -57057,7 +57062,7 @@ const deserializeAws_ec2Explanation = (output: any, context: __SerdeContext): Ex
     contents.NetworkInterface = deserializeAws_ec2AnalysisComponent(output["networkInterface"], context);
   }
   if (output["packetField"] !== undefined) {
-    contents.PacketField = output["packetField"];
+    contents.PacketField = __expectString(output["packetField"]);
   }
   if (output["vpcPeeringConnection"] !== undefined) {
     contents.VpcPeeringConnection = deserializeAws_ec2AnalysisComponent(output["vpcPeeringConnection"], context);
@@ -57108,7 +57113,7 @@ const deserializeAws_ec2Explanation = (output: any, context: __SerdeContext): Ex
     contents.SourceVpc = deserializeAws_ec2AnalysisComponent(output["sourceVpc"], context);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output["subnet"] !== undefined) {
     contents.Subnet = deserializeAws_ec2AnalysisComponent(output["subnet"], context);
@@ -57151,7 +57156,7 @@ const deserializeAws_ec2ExportClientVpnClientCertificateRevocationListResult = (
     Status: undefined,
   };
   if (output["certificateRevocationList"] !== undefined) {
-    contents.CertificateRevocationList = output["certificateRevocationList"];
+    contents.CertificateRevocationList = __expectString(output["certificateRevocationList"]);
   }
   if (output["status"] !== undefined) {
     contents.Status = deserializeAws_ec2ClientCertificateRevocationListStatus(output["status"], context);
@@ -57167,7 +57172,7 @@ const deserializeAws_ec2ExportClientVpnClientConfigurationResult = (
     ClientConfiguration: undefined,
   };
   if (output["clientConfiguration"] !== undefined) {
-    contents.ClientConfiguration = output["clientConfiguration"];
+    contents.ClientConfiguration = __expectString(output["clientConfiguration"]);
   }
   return contents;
 };
@@ -57186,31 +57191,31 @@ const deserializeAws_ec2ExportImageResult = (output: any, context: __SerdeContex
     Tags: undefined,
   };
   if (output["description"] !== undefined) {
-    contents.Description = output["description"];
+    contents.Description = __expectString(output["description"]);
   }
   if (output["diskImageFormat"] !== undefined) {
-    contents.DiskImageFormat = output["diskImageFormat"];
+    contents.DiskImageFormat = __expectString(output["diskImageFormat"]);
   }
   if (output["exportImageTaskId"] !== undefined) {
-    contents.ExportImageTaskId = output["exportImageTaskId"];
+    contents.ExportImageTaskId = __expectString(output["exportImageTaskId"]);
   }
   if (output["imageId"] !== undefined) {
-    contents.ImageId = output["imageId"];
+    contents.ImageId = __expectString(output["imageId"]);
   }
   if (output["roleName"] !== undefined) {
-    contents.RoleName = output["roleName"];
+    contents.RoleName = __expectString(output["roleName"]);
   }
   if (output["progress"] !== undefined) {
-    contents.Progress = output["progress"];
+    contents.Progress = __expectString(output["progress"]);
   }
   if (output["s3ExportLocation"] !== undefined) {
     contents.S3ExportLocation = deserializeAws_ec2ExportTaskS3Location(output["s3ExportLocation"], context);
   }
   if (output["status"] !== undefined) {
-    contents.Status = output["status"];
+    contents.Status = __expectString(output["status"]);
   }
   if (output["statusMessage"] !== undefined) {
-    contents.StatusMessage = output["statusMessage"];
+    contents.StatusMessage = __expectString(output["statusMessage"]);
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -57233,25 +57238,25 @@ const deserializeAws_ec2ExportImageTask = (output: any, context: __SerdeContext)
     Tags: undefined,
   };
   if (output["description"] !== undefined) {
-    contents.Description = output["description"];
+    contents.Description = __expectString(output["description"]);
   }
   if (output["exportImageTaskId"] !== undefined) {
-    contents.ExportImageTaskId = output["exportImageTaskId"];
+    contents.ExportImageTaskId = __expectString(output["exportImageTaskId"]);
   }
   if (output["imageId"] !== undefined) {
-    contents.ImageId = output["imageId"];
+    contents.ImageId = __expectString(output["imageId"]);
   }
   if (output["progress"] !== undefined) {
-    contents.Progress = output["progress"];
+    contents.Progress = __expectString(output["progress"]);
   }
   if (output["s3ExportLocation"] !== undefined) {
     contents.S3ExportLocation = deserializeAws_ec2ExportTaskS3Location(output["s3ExportLocation"], context);
   }
   if (output["status"] !== undefined) {
-    contents.Status = output["status"];
+    contents.Status = __expectString(output["status"]);
   }
   if (output["statusMessage"] !== undefined) {
-    contents.StatusMessage = output["statusMessage"];
+    contents.StatusMessage = __expectString(output["statusMessage"]);
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -57284,10 +57289,10 @@ const deserializeAws_ec2ExportTask = (output: any, context: __SerdeContext): Exp
     Tags: undefined,
   };
   if (output["description"] !== undefined) {
-    contents.Description = output["description"];
+    contents.Description = __expectString(output["description"]);
   }
   if (output["exportTaskId"] !== undefined) {
-    contents.ExportTaskId = output["exportTaskId"];
+    contents.ExportTaskId = __expectString(output["exportTaskId"]);
   }
   if (output["exportToS3"] !== undefined) {
     contents.ExportToS3Task = deserializeAws_ec2ExportToS3Task(output["exportToS3"], context);
@@ -57296,10 +57301,10 @@ const deserializeAws_ec2ExportTask = (output: any, context: __SerdeContext): Exp
     contents.InstanceExportDetails = deserializeAws_ec2InstanceExportDetails(output["instanceExport"], context);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output["statusMessage"] !== undefined) {
-    contents.StatusMessage = output["statusMessage"];
+    contents.StatusMessage = __expectString(output["statusMessage"]);
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -57327,10 +57332,10 @@ const deserializeAws_ec2ExportTaskS3Location = (output: any, context: __SerdeCon
     S3Prefix: undefined,
   };
   if (output["s3Bucket"] !== undefined) {
-    contents.S3Bucket = output["s3Bucket"];
+    contents.S3Bucket = __expectString(output["s3Bucket"]);
   }
   if (output["s3Prefix"] !== undefined) {
-    contents.S3Prefix = output["s3Prefix"];
+    contents.S3Prefix = __expectString(output["s3Prefix"]);
   }
   return contents;
 };
@@ -57343,16 +57348,16 @@ const deserializeAws_ec2ExportToS3Task = (output: any, context: __SerdeContext):
     S3Key: undefined,
   };
   if (output["containerFormat"] !== undefined) {
-    contents.ContainerFormat = output["containerFormat"];
+    contents.ContainerFormat = __expectString(output["containerFormat"]);
   }
   if (output["diskImageFormat"] !== undefined) {
-    contents.DiskImageFormat = output["diskImageFormat"];
+    contents.DiskImageFormat = __expectString(output["diskImageFormat"]);
   }
   if (output["s3Bucket"] !== undefined) {
-    contents.S3Bucket = output["s3Bucket"];
+    contents.S3Bucket = __expectString(output["s3Bucket"]);
   }
   if (output["s3Key"] !== undefined) {
-    contents.S3Key = output["s3Key"];
+    contents.S3Key = __expectString(output["s3Key"]);
   }
   return contents;
 };
@@ -57365,7 +57370,7 @@ const deserializeAws_ec2ExportTransitGatewayRoutesResult = (
     S3Location: undefined,
   };
   if (output["s3Location"] !== undefined) {
-    contents.S3Location = output["s3Location"];
+    contents.S3Location = __expectString(output["s3Location"]);
   }
   return contents;
 };
@@ -57382,7 +57387,7 @@ const deserializeAws_ec2FailedQueuedPurchaseDeletion = (
     contents.Error = deserializeAws_ec2DeleteQueuedReservedInstancesError(output["error"], context);
   }
   if (output["reservedInstancesId"] !== undefined) {
-    contents.ReservedInstancesId = output["reservedInstancesId"];
+    contents.ReservedInstancesId = __expectString(output["reservedInstancesId"]);
   }
   return contents;
 };
@@ -57407,10 +57412,10 @@ const deserializeAws_ec2FederatedAuthentication = (output: any, context: __Serde
     SelfServiceSamlProviderArn: undefined,
   };
   if (output["samlProviderArn"] !== undefined) {
-    contents.SamlProviderArn = output["samlProviderArn"];
+    contents.SamlProviderArn = __expectString(output["samlProviderArn"]);
   }
   if (output["selfServiceSamlProviderArn"] !== undefined) {
-    contents.SelfServiceSamlProviderArn = output["selfServiceSamlProviderArn"];
+    contents.SelfServiceSamlProviderArn = __expectString(output["selfServiceSamlProviderArn"]);
   }
   return contents;
 };
@@ -57439,22 +57444,22 @@ const deserializeAws_ec2FleetData = (output: any, context: __SerdeContext): Flee
     Instances: undefined,
   };
   if (output["activityStatus"] !== undefined) {
-    contents.ActivityStatus = output["activityStatus"];
+    contents.ActivityStatus = __expectString(output["activityStatus"]);
   }
   if (output["createTime"] !== undefined) {
     contents.CreateTime = new Date(output["createTime"]);
   }
   if (output["fleetId"] !== undefined) {
-    contents.FleetId = output["fleetId"];
+    contents.FleetId = __expectString(output["fleetId"]);
   }
   if (output["fleetState"] !== undefined) {
-    contents.FleetState = output["fleetState"];
+    contents.FleetState = __expectString(output["fleetState"]);
   }
   if (output["clientToken"] !== undefined) {
-    contents.ClientToken = output["clientToken"];
+    contents.ClientToken = __expectString(output["clientToken"]);
   }
   if (output["excessCapacityTerminationPolicy"] !== undefined) {
-    contents.ExcessCapacityTerminationPolicy = output["excessCapacityTerminationPolicy"];
+    contents.ExcessCapacityTerminationPolicy = __expectString(output["excessCapacityTerminationPolicy"]);
   }
   if (output["fulfilledCapacity"] !== undefined) {
     contents.FulfilledCapacity = parseFloat(output["fulfilledCapacity"]);
@@ -57481,7 +57486,7 @@ const deserializeAws_ec2FleetData = (output: any, context: __SerdeContext): Flee
     contents.TerminateInstancesWithExpiration = __parseBoolean(output["terminateInstancesWithExpiration"]);
   }
   if (output["type"] !== undefined) {
-    contents.Type = output["type"];
+    contents.Type = __expectString(output["type"]);
   }
   if (output["validFrom"] !== undefined) {
     contents.ValidFrom = new Date(output["validFrom"]);
@@ -57579,16 +57584,16 @@ const deserializeAws_ec2FleetLaunchTemplateOverrides = (
     Placement: undefined,
   };
   if (output["instanceType"] !== undefined) {
-    contents.InstanceType = output["instanceType"];
+    contents.InstanceType = __expectString(output["instanceType"]);
   }
   if (output["maxPrice"] !== undefined) {
-    contents.MaxPrice = output["maxPrice"];
+    contents.MaxPrice = __expectString(output["maxPrice"]);
   }
   if (output["subnetId"] !== undefined) {
-    contents.SubnetId = output["subnetId"];
+    contents.SubnetId = __expectString(output["subnetId"]);
   }
   if (output["availabilityZone"] !== undefined) {
-    contents.AvailabilityZone = output["availabilityZone"];
+    contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
   if (output["weightedCapacity"] !== undefined) {
     contents.WeightedCapacity = parseFloat(output["weightedCapacity"]);
@@ -57626,13 +57631,13 @@ const deserializeAws_ec2FleetLaunchTemplateSpecification = (
     Version: undefined,
   };
   if (output["launchTemplateId"] !== undefined) {
-    contents.LaunchTemplateId = output["launchTemplateId"];
+    contents.LaunchTemplateId = __expectString(output["launchTemplateId"]);
   }
   if (output["launchTemplateName"] !== undefined) {
-    contents.LaunchTemplateName = output["launchTemplateName"];
+    contents.LaunchTemplateName = __expectString(output["launchTemplateName"]);
   }
   if (output["version"] !== undefined) {
-    contents.Version = output["version"];
+    contents.Version = __expectString(output["version"]);
   }
   return contents;
 };
@@ -57656,7 +57661,7 @@ const deserializeAws_ec2FleetSpotCapacityRebalance = (
     ReplacementStrategy: undefined,
   };
   if (output["replacementStrategy"] !== undefined) {
-    contents.ReplacementStrategy = output["replacementStrategy"];
+    contents.ReplacementStrategy = __expectString(output["replacementStrategy"]);
   }
   return contents;
 };
@@ -57695,37 +57700,37 @@ const deserializeAws_ec2FlowLog = (output: any, context: __SerdeContext): FlowLo
     contents.CreationTime = new Date(output["creationTime"]);
   }
   if (output["deliverLogsErrorMessage"] !== undefined) {
-    contents.DeliverLogsErrorMessage = output["deliverLogsErrorMessage"];
+    contents.DeliverLogsErrorMessage = __expectString(output["deliverLogsErrorMessage"]);
   }
   if (output["deliverLogsPermissionArn"] !== undefined) {
-    contents.DeliverLogsPermissionArn = output["deliverLogsPermissionArn"];
+    contents.DeliverLogsPermissionArn = __expectString(output["deliverLogsPermissionArn"]);
   }
   if (output["deliverLogsStatus"] !== undefined) {
-    contents.DeliverLogsStatus = output["deliverLogsStatus"];
+    contents.DeliverLogsStatus = __expectString(output["deliverLogsStatus"]);
   }
   if (output["flowLogId"] !== undefined) {
-    contents.FlowLogId = output["flowLogId"];
+    contents.FlowLogId = __expectString(output["flowLogId"]);
   }
   if (output["flowLogStatus"] !== undefined) {
-    contents.FlowLogStatus = output["flowLogStatus"];
+    contents.FlowLogStatus = __expectString(output["flowLogStatus"]);
   }
   if (output["logGroupName"] !== undefined) {
-    contents.LogGroupName = output["logGroupName"];
+    contents.LogGroupName = __expectString(output["logGroupName"]);
   }
   if (output["resourceId"] !== undefined) {
-    contents.ResourceId = output["resourceId"];
+    contents.ResourceId = __expectString(output["resourceId"]);
   }
   if (output["trafficType"] !== undefined) {
-    contents.TrafficType = output["trafficType"];
+    contents.TrafficType = __expectString(output["trafficType"]);
   }
   if (output["logDestinationType"] !== undefined) {
-    contents.LogDestinationType = output["logDestinationType"];
+    contents.LogDestinationType = __expectString(output["logDestinationType"]);
   }
   if (output["logDestination"] !== undefined) {
-    contents.LogDestination = output["logDestination"];
+    contents.LogDestination = __expectString(output["logDestination"]);
   }
   if (output["logFormat"] !== undefined) {
-    contents.LogFormat = output["logFormat"];
+    contents.LogFormat = __expectString(output["logFormat"]);
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -57758,10 +57763,10 @@ const deserializeAws_ec2FpgaDeviceInfo = (output: any, context: __SerdeContext):
     MemoryInfo: undefined,
   };
   if (output["name"] !== undefined) {
-    contents.Name = output["name"];
+    contents.Name = __expectString(output["name"]);
   }
   if (output["manufacturer"] !== undefined) {
-    contents.Manufacturer = output["manufacturer"];
+    contents.Manufacturer = __expectString(output["manufacturer"]);
   }
   if (output["count"] !== undefined) {
     contents.Count = parseInt(output["count"]);
@@ -57812,19 +57817,19 @@ const deserializeAws_ec2FpgaImage = (output: any, context: __SerdeContext): Fpga
     DataRetentionSupport: undefined,
   };
   if (output["fpgaImageId"] !== undefined) {
-    contents.FpgaImageId = output["fpgaImageId"];
+    contents.FpgaImageId = __expectString(output["fpgaImageId"]);
   }
   if (output["fpgaImageGlobalId"] !== undefined) {
-    contents.FpgaImageGlobalId = output["fpgaImageGlobalId"];
+    contents.FpgaImageGlobalId = __expectString(output["fpgaImageGlobalId"]);
   }
   if (output["name"] !== undefined) {
-    contents.Name = output["name"];
+    contents.Name = __expectString(output["name"]);
   }
   if (output["description"] !== undefined) {
-    contents.Description = output["description"];
+    contents.Description = __expectString(output["description"]);
   }
   if (output["shellVersion"] !== undefined) {
-    contents.ShellVersion = output["shellVersion"];
+    contents.ShellVersion = __expectString(output["shellVersion"]);
   }
   if (output["pciId"] !== undefined) {
     contents.PciId = deserializeAws_ec2PciId(output["pciId"], context);
@@ -57839,10 +57844,10 @@ const deserializeAws_ec2FpgaImage = (output: any, context: __SerdeContext): Fpga
     contents.UpdateTime = new Date(output["updateTime"]);
   }
   if (output["ownerId"] !== undefined) {
-    contents.OwnerId = output["ownerId"];
+    contents.OwnerId = __expectString(output["ownerId"]);
   }
   if (output["ownerAlias"] !== undefined) {
-    contents.OwnerAlias = output["ownerAlias"];
+    contents.OwnerAlias = __expectString(output["ownerAlias"]);
   }
   if (output.productCodes === "") {
     contents.ProductCodes = [];
@@ -57877,13 +57882,13 @@ const deserializeAws_ec2FpgaImageAttribute = (output: any, context: __SerdeConte
     ProductCodes: undefined,
   };
   if (output["fpgaImageId"] !== undefined) {
-    contents.FpgaImageId = output["fpgaImageId"];
+    contents.FpgaImageId = __expectString(output["fpgaImageId"]);
   }
   if (output["name"] !== undefined) {
-    contents.Name = output["name"];
+    contents.Name = __expectString(output["name"]);
   }
   if (output["description"] !== undefined) {
-    contents.Description = output["description"];
+    contents.Description = __expectString(output["description"]);
   }
   if (output.loadPermissions === "") {
     contents.LoadPermissions = [];
@@ -57923,10 +57928,10 @@ const deserializeAws_ec2FpgaImageState = (output: any, context: __SerdeContext):
     Message: undefined,
   };
   if (output["code"] !== undefined) {
-    contents.Code = output["code"];
+    contents.Code = __expectString(output["code"]);
   }
   if (output["message"] !== undefined) {
-    contents.Message = output["message"];
+    contents.Message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -57985,7 +57990,7 @@ const deserializeAws_ec2GetAssociatedIpv6PoolCidrsResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -58004,13 +58009,13 @@ const deserializeAws_ec2GetCapacityReservationUsageResult = (
     InstanceUsages: undefined,
   };
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   if (output["capacityReservationId"] !== undefined) {
-    contents.CapacityReservationId = output["capacityReservationId"];
+    contents.CapacityReservationId = __expectString(output["capacityReservationId"]);
   }
   if (output["instanceType"] !== undefined) {
-    contents.InstanceType = output["instanceType"];
+    contents.InstanceType = __expectString(output["instanceType"]);
   }
   if (output["totalInstanceCount"] !== undefined) {
     contents.TotalInstanceCount = parseInt(output["totalInstanceCount"]);
@@ -58019,7 +58024,7 @@ const deserializeAws_ec2GetCapacityReservationUsageResult = (
     contents.AvailableInstanceCount = parseInt(output["availableInstanceCount"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output.instanceUsageSet === "") {
     contents.InstanceUsages = [];
@@ -58040,7 +58045,7 @@ const deserializeAws_ec2GetCoipPoolUsageResult = (output: any, context: __SerdeC
     LocalGatewayRouteTableId: undefined,
   };
   if (output["coipPoolId"] !== undefined) {
-    contents.CoipPoolId = output["coipPoolId"];
+    contents.CoipPoolId = __expectString(output["coipPoolId"]);
   }
   if (output.coipAddressUsageSet === "") {
     contents.CoipAddressUsages = [];
@@ -58052,7 +58057,7 @@ const deserializeAws_ec2GetCoipPoolUsageResult = (output: any, context: __SerdeC
     );
   }
   if (output["localGatewayRouteTableId"] !== undefined) {
-    contents.LocalGatewayRouteTableId = output["localGatewayRouteTableId"];
+    contents.LocalGatewayRouteTableId = __expectString(output["localGatewayRouteTableId"]);
   }
   return contents;
 };
@@ -58064,10 +58069,10 @@ const deserializeAws_ec2GetConsoleOutputResult = (output: any, context: __SerdeC
     Timestamp: undefined,
   };
   if (output["instanceId"] !== undefined) {
-    contents.InstanceId = output["instanceId"];
+    contents.InstanceId = __expectString(output["instanceId"]);
   }
   if (output["output"] !== undefined) {
-    contents.Output = output["output"];
+    contents.Output = __expectString(output["output"]);
   }
   if (output["timestamp"] !== undefined) {
     contents.Timestamp = new Date(output["timestamp"]);
@@ -58084,10 +58089,10 @@ const deserializeAws_ec2GetConsoleScreenshotResult = (
     InstanceId: undefined,
   };
   if (output["imageData"] !== undefined) {
-    contents.ImageData = output["imageData"];
+    contents.ImageData = __expectString(output["imageData"]);
   }
   if (output["instanceId"] !== undefined) {
-    contents.InstanceId = output["instanceId"];
+    contents.InstanceId = __expectString(output["instanceId"]);
   }
   return contents;
 };
@@ -58116,7 +58121,7 @@ const deserializeAws_ec2GetEbsDefaultKmsKeyIdResult = (
     KmsKeyId: undefined,
   };
   if (output["kmsKeyId"] !== undefined) {
-    contents.KmsKeyId = output["kmsKeyId"];
+    contents.KmsKeyId = __expectString(output["kmsKeyId"]);
   }
   return contents;
 };
@@ -58142,7 +58147,7 @@ const deserializeAws_ec2GetFlowLogsIntegrationTemplateResult = (
     Result: undefined,
   };
   if (output["result"] !== undefined) {
-    contents.Result = output["result"];
+    contents.Result = __expectString(output["result"]);
   }
   return contents;
 };
@@ -58156,7 +58161,7 @@ const deserializeAws_ec2GetGroupsForCapacityReservationResult = (
     CapacityReservationGroups: undefined,
   };
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   if (output.capacityReservationGroupSet === "") {
     contents.CapacityReservationGroups = [];
@@ -58184,7 +58189,7 @@ const deserializeAws_ec2GetHostReservationPurchasePreviewResult = (
     TotalUpfrontPrice: undefined,
   };
   if (output["currencyCode"] !== undefined) {
-    contents.CurrencyCode = output["currencyCode"];
+    contents.CurrencyCode = __expectString(output["currencyCode"]);
   }
   if (output.purchase === "") {
     contents.Purchase = [];
@@ -58193,10 +58198,10 @@ const deserializeAws_ec2GetHostReservationPurchasePreviewResult = (
     contents.Purchase = deserializeAws_ec2PurchaseSet(__getArrayIfSingleItem(output["purchase"]["item"]), context);
   }
   if (output["totalHourlyPrice"] !== undefined) {
-    contents.TotalHourlyPrice = output["totalHourlyPrice"];
+    contents.TotalHourlyPrice = __expectString(output["totalHourlyPrice"]);
   }
   if (output["totalUpfrontPrice"] !== undefined) {
-    contents.TotalUpfrontPrice = output["totalUpfrontPrice"];
+    contents.TotalUpfrontPrice = __expectString(output["totalUpfrontPrice"]);
   }
   return contents;
 };
@@ -58232,7 +58237,7 @@ const deserializeAws_ec2GetManagedPrefixListAssociationsResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -58255,7 +58260,7 @@ const deserializeAws_ec2GetManagedPrefixListEntriesResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -58267,10 +58272,10 @@ const deserializeAws_ec2GetPasswordDataResult = (output: any, context: __SerdeCo
     Timestamp: undefined,
   };
   if (output["instanceId"] !== undefined) {
-    contents.InstanceId = output["instanceId"];
+    contents.InstanceId = __expectString(output["instanceId"]);
   }
   if (output["passwordData"] !== undefined) {
-    contents.PasswordData = output["passwordData"];
+    contents.PasswordData = __expectString(output["passwordData"]);
   }
   if (output["timestamp"] !== undefined) {
     contents.Timestamp = new Date(output["timestamp"]);
@@ -58294,7 +58299,7 @@ const deserializeAws_ec2GetReservedInstancesExchangeQuoteResult = (
     ValidationFailureReason: undefined,
   };
   if (output["currencyCode"] !== undefined) {
-    contents.CurrencyCode = output["currencyCode"];
+    contents.CurrencyCode = __expectString(output["currencyCode"]);
   }
   if (output["isValidExchange"] !== undefined) {
     contents.IsValidExchange = __parseBoolean(output["isValidExchange"]);
@@ -58303,7 +58308,7 @@ const deserializeAws_ec2GetReservedInstancesExchangeQuoteResult = (
     contents.OutputReservedInstancesWillExpireAt = new Date(output["outputReservedInstancesWillExpireAt"]);
   }
   if (output["paymentDue"] !== undefined) {
-    contents.PaymentDue = output["paymentDue"];
+    contents.PaymentDue = __expectString(output["paymentDue"]);
   }
   if (output["reservedInstanceValueRollup"] !== undefined) {
     contents.ReservedInstanceValueRollup = deserializeAws_ec2ReservationValue(
@@ -58339,7 +58344,7 @@ const deserializeAws_ec2GetReservedInstancesExchangeQuoteResult = (
     );
   }
   if (output["validationFailureReason"] !== undefined) {
-    contents.ValidationFailureReason = output["validationFailureReason"];
+    contents.ValidationFailureReason = __expectString(output["validationFailureReason"]);
   }
   return contents;
 };
@@ -58378,7 +58383,7 @@ const deserializeAws_ec2GetTransitGatewayAttachmentPropagationsResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -58404,7 +58409,7 @@ const deserializeAws_ec2GetTransitGatewayMulticastDomainAssociationsResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -58430,7 +58435,7 @@ const deserializeAws_ec2GetTransitGatewayPrefixListReferencesResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -58453,7 +58458,7 @@ const deserializeAws_ec2GetTransitGatewayRouteTableAssociationsResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -58479,7 +58484,7 @@ const deserializeAws_ec2GetTransitGatewayRouteTablePropagationsResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -58492,10 +58497,10 @@ const deserializeAws_ec2GpuDeviceInfo = (output: any, context: __SerdeContext): 
     MemoryInfo: undefined,
   };
   if (output["name"] !== undefined) {
-    contents.Name = output["name"];
+    contents.Name = __expectString(output["name"]);
   }
   if (output["manufacturer"] !== undefined) {
-    contents.Manufacturer = output["manufacturer"];
+    contents.Manufacturer = __expectString(output["manufacturer"]);
   }
   if (output["count"] !== undefined) {
     contents.Count = parseInt(output["count"]);
@@ -58550,10 +58555,10 @@ const deserializeAws_ec2GroupIdentifier = (output: any, context: __SerdeContext)
     GroupId: undefined,
   };
   if (output["groupName"] !== undefined) {
-    contents.GroupName = output["groupName"];
+    contents.GroupName = __expectString(output["groupName"]);
   }
   if (output["groupId"] !== undefined) {
-    contents.GroupId = output["groupId"];
+    contents.GroupId = __expectString(output["groupId"]);
   }
   return contents;
 };
@@ -58587,7 +58592,7 @@ const deserializeAws_ec2GroupIdStringList = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -58611,7 +58616,7 @@ const deserializeAws_ec2HistoryRecord = (output: any, context: __SerdeContext): 
     contents.EventInformation = deserializeAws_ec2EventInformation(output["eventInformation"], context);
   }
   if (output["eventType"] !== undefined) {
-    contents.EventType = output["eventType"];
+    contents.EventType = __expectString(output["eventType"]);
   }
   if (output["timestamp"] !== undefined) {
     contents.Timestamp = new Date(output["timestamp"]);
@@ -58629,7 +58634,7 @@ const deserializeAws_ec2HistoryRecordEntry = (output: any, context: __SerdeConte
     contents.EventInformation = deserializeAws_ec2EventInformation(output["eventInformation"], context);
   }
   if (output["eventType"] !== undefined) {
-    contents.EventType = output["eventType"];
+    contents.EventType = __expectString(output["eventType"]);
   }
   if (output["timestamp"] !== undefined) {
     contents.Timestamp = new Date(output["timestamp"]);
@@ -58680,25 +58685,25 @@ const deserializeAws_ec2Host = (output: any, context: __SerdeContext): Host => {
     MemberOfServiceLinkedResourceGroup: undefined,
   };
   if (output["autoPlacement"] !== undefined) {
-    contents.AutoPlacement = output["autoPlacement"];
+    contents.AutoPlacement = __expectString(output["autoPlacement"]);
   }
   if (output["availabilityZone"] !== undefined) {
-    contents.AvailabilityZone = output["availabilityZone"];
+    contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
   if (output["availableCapacity"] !== undefined) {
     contents.AvailableCapacity = deserializeAws_ec2AvailableCapacity(output["availableCapacity"], context);
   }
   if (output["clientToken"] !== undefined) {
-    contents.ClientToken = output["clientToken"];
+    contents.ClientToken = __expectString(output["clientToken"]);
   }
   if (output["hostId"] !== undefined) {
-    contents.HostId = output["hostId"];
+    contents.HostId = __expectString(output["hostId"]);
   }
   if (output["hostProperties"] !== undefined) {
     contents.HostProperties = deserializeAws_ec2HostProperties(output["hostProperties"], context);
   }
   if (output["hostReservationId"] !== undefined) {
-    contents.HostReservationId = output["hostReservationId"];
+    contents.HostReservationId = __expectString(output["hostReservationId"]);
   }
   if (output.instances === "") {
     contents.Instances = [];
@@ -58710,7 +58715,7 @@ const deserializeAws_ec2Host = (output: any, context: __SerdeContext): Host => {
     );
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output["allocationTime"] !== undefined) {
     contents.AllocationTime = new Date(output["allocationTime"]);
@@ -58725,16 +58730,16 @@ const deserializeAws_ec2Host = (output: any, context: __SerdeContext): Host => {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["hostRecovery"] !== undefined) {
-    contents.HostRecovery = output["hostRecovery"];
+    contents.HostRecovery = __expectString(output["hostRecovery"]);
   }
   if (output["allowsMultipleInstanceTypes"] !== undefined) {
-    contents.AllowsMultipleInstanceTypes = output["allowsMultipleInstanceTypes"];
+    contents.AllowsMultipleInstanceTypes = __expectString(output["allowsMultipleInstanceTypes"]);
   }
   if (output["ownerId"] !== undefined) {
-    contents.OwnerId = output["ownerId"];
+    contents.OwnerId = __expectString(output["ownerId"]);
   }
   if (output["availabilityZoneId"] !== undefined) {
-    contents.AvailabilityZoneId = output["availabilityZoneId"];
+    contents.AvailabilityZoneId = __expectString(output["availabilityZoneId"]);
   }
   if (output["memberOfServiceLinkedResourceGroup"] !== undefined) {
     contents.MemberOfServiceLinkedResourceGroup = __parseBoolean(output["memberOfServiceLinkedResourceGroup"]);
@@ -58749,13 +58754,13 @@ const deserializeAws_ec2HostInstance = (output: any, context: __SerdeContext): H
     OwnerId: undefined,
   };
   if (output["instanceId"] !== undefined) {
-    contents.InstanceId = output["instanceId"];
+    contents.InstanceId = __expectString(output["instanceId"]);
   }
   if (output["instanceType"] !== undefined) {
-    contents.InstanceType = output["instanceType"];
+    contents.InstanceType = __expectString(output["instanceType"]);
   }
   if (output["ownerId"] !== undefined) {
-    contents.OwnerId = output["ownerId"];
+    contents.OwnerId = __expectString(output["ownerId"]);
   }
   return contents;
 };
@@ -58793,25 +58798,25 @@ const deserializeAws_ec2HostOffering = (output: any, context: __SerdeContext): H
     UpfrontPrice: undefined,
   };
   if (output["currencyCode"] !== undefined) {
-    contents.CurrencyCode = output["currencyCode"];
+    contents.CurrencyCode = __expectString(output["currencyCode"]);
   }
   if (output["duration"] !== undefined) {
     contents.Duration = parseInt(output["duration"]);
   }
   if (output["hourlyPrice"] !== undefined) {
-    contents.HourlyPrice = output["hourlyPrice"];
+    contents.HourlyPrice = __expectString(output["hourlyPrice"]);
   }
   if (output["instanceFamily"] !== undefined) {
-    contents.InstanceFamily = output["instanceFamily"];
+    contents.InstanceFamily = __expectString(output["instanceFamily"]);
   }
   if (output["offeringId"] !== undefined) {
-    contents.OfferingId = output["offeringId"];
+    contents.OfferingId = __expectString(output["offeringId"]);
   }
   if (output["paymentOption"] !== undefined) {
-    contents.PaymentOption = output["paymentOption"];
+    contents.PaymentOption = __expectString(output["paymentOption"]);
   }
   if (output["upfrontPrice"] !== undefined) {
-    contents.UpfrontPrice = output["upfrontPrice"];
+    contents.UpfrontPrice = __expectString(output["upfrontPrice"]);
   }
   return contents;
 };
@@ -58839,10 +58844,10 @@ const deserializeAws_ec2HostProperties = (output: any, context: __SerdeContext):
     contents.Cores = parseInt(output["cores"]);
   }
   if (output["instanceType"] !== undefined) {
-    contents.InstanceType = output["instanceType"];
+    contents.InstanceType = __expectString(output["instanceType"]);
   }
   if (output["instanceFamily"] !== undefined) {
-    contents.InstanceFamily = output["instanceFamily"];
+    contents.InstanceFamily = __expectString(output["instanceFamily"]);
   }
   if (output["sockets"] !== undefined) {
     contents.Sockets = parseInt(output["sockets"]);
@@ -58874,7 +58879,7 @@ const deserializeAws_ec2HostReservation = (output: any, context: __SerdeContext)
     contents.Count = parseInt(output["count"]);
   }
   if (output["currencyCode"] !== undefined) {
-    contents.CurrencyCode = output["currencyCode"];
+    contents.CurrencyCode = __expectString(output["currencyCode"]);
   }
   if (output["duration"] !== undefined) {
     contents.Duration = parseInt(output["duration"]);
@@ -58892,28 +58897,28 @@ const deserializeAws_ec2HostReservation = (output: any, context: __SerdeContext)
     );
   }
   if (output["hostReservationId"] !== undefined) {
-    contents.HostReservationId = output["hostReservationId"];
+    contents.HostReservationId = __expectString(output["hostReservationId"]);
   }
   if (output["hourlyPrice"] !== undefined) {
-    contents.HourlyPrice = output["hourlyPrice"];
+    contents.HourlyPrice = __expectString(output["hourlyPrice"]);
   }
   if (output["instanceFamily"] !== undefined) {
-    contents.InstanceFamily = output["instanceFamily"];
+    contents.InstanceFamily = __expectString(output["instanceFamily"]);
   }
   if (output["offeringId"] !== undefined) {
-    contents.OfferingId = output["offeringId"];
+    contents.OfferingId = __expectString(output["offeringId"]);
   }
   if (output["paymentOption"] !== undefined) {
-    contents.PaymentOption = output["paymentOption"];
+    contents.PaymentOption = __expectString(output["paymentOption"]);
   }
   if (output["start"] !== undefined) {
     contents.Start = new Date(output["start"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output["upfrontPrice"] !== undefined) {
-    contents.UpfrontPrice = output["upfrontPrice"];
+    contents.UpfrontPrice = __expectString(output["upfrontPrice"]);
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -58941,10 +58946,10 @@ const deserializeAws_ec2IamInstanceProfile = (output: any, context: __SerdeConte
     Id: undefined,
   };
   if (output["arn"] !== undefined) {
-    contents.Arn = output["arn"];
+    contents.Arn = __expectString(output["arn"]);
   }
   if (output["id"] !== undefined) {
-    contents.Id = output["id"];
+    contents.Id = __expectString(output["id"]);
   }
   return contents;
 };
@@ -58961,16 +58966,16 @@ const deserializeAws_ec2IamInstanceProfileAssociation = (
     Timestamp: undefined,
   };
   if (output["associationId"] !== undefined) {
-    contents.AssociationId = output["associationId"];
+    contents.AssociationId = __expectString(output["associationId"]);
   }
   if (output["instanceId"] !== undefined) {
-    contents.InstanceId = output["instanceId"];
+    contents.InstanceId = __expectString(output["instanceId"]);
   }
   if (output["iamInstanceProfile"] !== undefined) {
     contents.IamInstanceProfile = deserializeAws_ec2IamInstanceProfile(output["iamInstanceProfile"], context);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output["timestamp"] !== undefined) {
     contents.Timestamp = new Date(output["timestamp"]);
@@ -59001,10 +59006,10 @@ const deserializeAws_ec2IamInstanceProfileSpecification = (
     Name: undefined,
   };
   if (output["arn"] !== undefined) {
-    contents.Arn = output["arn"];
+    contents.Arn = __expectString(output["arn"]);
   }
   if (output["name"] !== undefined) {
-    contents.Name = output["name"];
+    contents.Name = __expectString(output["name"]);
   }
   return contents;
 };
@@ -59033,7 +59038,7 @@ const deserializeAws_ec2IdFormat = (output: any, context: __SerdeContext): IdFor
     contents.Deadline = new Date(output["deadline"]);
   }
   if (output["resource"] !== undefined) {
-    contents.Resource = output["resource"];
+    contents.Resource = __expectString(output["resource"]);
   }
   if (output["useLongIds"] !== undefined) {
     contents.UseLongIds = __parseBoolean(output["useLongIds"]);
@@ -59068,7 +59073,7 @@ const deserializeAws_ec2IKEVersionsListValue = (output: any, context: __SerdeCon
     Value: undefined,
   };
   if (output["value"] !== undefined) {
-    contents.Value = output["value"];
+    contents.Value = __expectString(output["value"]);
   }
   return contents;
 };
@@ -59105,37 +59110,37 @@ const deserializeAws_ec2Image = (output: any, context: __SerdeContext): Image =>
     DeprecationTime: undefined,
   };
   if (output["architecture"] !== undefined) {
-    contents.Architecture = output["architecture"];
+    contents.Architecture = __expectString(output["architecture"]);
   }
   if (output["creationDate"] !== undefined) {
-    contents.CreationDate = output["creationDate"];
+    contents.CreationDate = __expectString(output["creationDate"]);
   }
   if (output["imageId"] !== undefined) {
-    contents.ImageId = output["imageId"];
+    contents.ImageId = __expectString(output["imageId"]);
   }
   if (output["imageLocation"] !== undefined) {
-    contents.ImageLocation = output["imageLocation"];
+    contents.ImageLocation = __expectString(output["imageLocation"]);
   }
   if (output["imageType"] !== undefined) {
-    contents.ImageType = output["imageType"];
+    contents.ImageType = __expectString(output["imageType"]);
   }
   if (output["isPublic"] !== undefined) {
     contents.Public = __parseBoolean(output["isPublic"]);
   }
   if (output["kernelId"] !== undefined) {
-    contents.KernelId = output["kernelId"];
+    contents.KernelId = __expectString(output["kernelId"]);
   }
   if (output["imageOwnerId"] !== undefined) {
-    contents.OwnerId = output["imageOwnerId"];
+    contents.OwnerId = __expectString(output["imageOwnerId"]);
   }
   if (output["platform"] !== undefined) {
-    contents.Platform = output["platform"];
+    contents.Platform = __expectString(output["platform"]);
   }
   if (output["platformDetails"] !== undefined) {
-    contents.PlatformDetails = output["platformDetails"];
+    contents.PlatformDetails = __expectString(output["platformDetails"]);
   }
   if (output["usageOperation"] !== undefined) {
-    contents.UsageOperation = output["usageOperation"];
+    contents.UsageOperation = __expectString(output["usageOperation"]);
   }
   if (output.productCodes === "") {
     contents.ProductCodes = [];
@@ -59147,10 +59152,10 @@ const deserializeAws_ec2Image = (output: any, context: __SerdeContext): Image =>
     );
   }
   if (output["ramdiskId"] !== undefined) {
-    contents.RamdiskId = output["ramdiskId"];
+    contents.RamdiskId = __expectString(output["ramdiskId"]);
   }
   if (output["imageState"] !== undefined) {
-    contents.State = output["imageState"];
+    contents.State = __expectString(output["imageState"]);
   }
   if (output.blockDeviceMapping === "") {
     contents.BlockDeviceMappings = [];
@@ -59162,28 +59167,28 @@ const deserializeAws_ec2Image = (output: any, context: __SerdeContext): Image =>
     );
   }
   if (output["description"] !== undefined) {
-    contents.Description = output["description"];
+    contents.Description = __expectString(output["description"]);
   }
   if (output["enaSupport"] !== undefined) {
     contents.EnaSupport = __parseBoolean(output["enaSupport"]);
   }
   if (output["hypervisor"] !== undefined) {
-    contents.Hypervisor = output["hypervisor"];
+    contents.Hypervisor = __expectString(output["hypervisor"]);
   }
   if (output["imageOwnerAlias"] !== undefined) {
-    contents.ImageOwnerAlias = output["imageOwnerAlias"];
+    contents.ImageOwnerAlias = __expectString(output["imageOwnerAlias"]);
   }
   if (output["name"] !== undefined) {
-    contents.Name = output["name"];
+    contents.Name = __expectString(output["name"]);
   }
   if (output["rootDeviceName"] !== undefined) {
-    contents.RootDeviceName = output["rootDeviceName"];
+    contents.RootDeviceName = __expectString(output["rootDeviceName"]);
   }
   if (output["rootDeviceType"] !== undefined) {
-    contents.RootDeviceType = output["rootDeviceType"];
+    contents.RootDeviceType = __expectString(output["rootDeviceType"]);
   }
   if (output["sriovNetSupport"] !== undefined) {
-    contents.SriovNetSupport = output["sriovNetSupport"];
+    contents.SriovNetSupport = __expectString(output["sriovNetSupport"]);
   }
   if (output["stateReason"] !== undefined) {
     contents.StateReason = deserializeAws_ec2StateReason(output["stateReason"], context);
@@ -59195,13 +59200,13 @@ const deserializeAws_ec2Image = (output: any, context: __SerdeContext): Image =>
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["virtualizationType"] !== undefined) {
-    contents.VirtualizationType = output["virtualizationType"];
+    contents.VirtualizationType = __expectString(output["virtualizationType"]);
   }
   if (output["bootMode"] !== undefined) {
-    contents.BootMode = output["bootMode"];
+    contents.BootMode = __expectString(output["bootMode"]);
   }
   if (output["deprecationTime"] !== undefined) {
-    contents.DeprecationTime = output["deprecationTime"];
+    contents.DeprecationTime = __expectString(output["deprecationTime"]);
   }
   return contents;
 };
@@ -59228,7 +59233,7 @@ const deserializeAws_ec2ImageAttribute = (output: any, context: __SerdeContext):
     );
   }
   if (output["imageId"] !== undefined) {
-    contents.ImageId = output["imageId"];
+    contents.ImageId = __expectString(output["imageId"]);
   }
   if (output.launchPermission === "") {
     contents.LaunchPermissions = [];
@@ -59298,7 +59303,7 @@ const deserializeAws_ec2ImportImageLicenseConfigurationResponse = (
     LicenseConfigurationArn: undefined,
   };
   if (output["licenseConfigurationArn"] !== undefined) {
-    contents.LicenseConfigurationArn = output["licenseConfigurationArn"];
+    contents.LicenseConfigurationArn = __expectString(output["licenseConfigurationArn"]);
   }
   return contents;
 };
@@ -59336,34 +59341,34 @@ const deserializeAws_ec2ImportImageResult = (output: any, context: __SerdeContex
     Tags: undefined,
   };
   if (output["architecture"] !== undefined) {
-    contents.Architecture = output["architecture"];
+    contents.Architecture = __expectString(output["architecture"]);
   }
   if (output["description"] !== undefined) {
-    contents.Description = output["description"];
+    contents.Description = __expectString(output["description"]);
   }
   if (output["encrypted"] !== undefined) {
     contents.Encrypted = __parseBoolean(output["encrypted"]);
   }
   if (output["hypervisor"] !== undefined) {
-    contents.Hypervisor = output["hypervisor"];
+    contents.Hypervisor = __expectString(output["hypervisor"]);
   }
   if (output["imageId"] !== undefined) {
-    contents.ImageId = output["imageId"];
+    contents.ImageId = __expectString(output["imageId"]);
   }
   if (output["importTaskId"] !== undefined) {
-    contents.ImportTaskId = output["importTaskId"];
+    contents.ImportTaskId = __expectString(output["importTaskId"]);
   }
   if (output["kmsKeyId"] !== undefined) {
-    contents.KmsKeyId = output["kmsKeyId"];
+    contents.KmsKeyId = __expectString(output["kmsKeyId"]);
   }
   if (output["licenseType"] !== undefined) {
-    contents.LicenseType = output["licenseType"];
+    contents.LicenseType = __expectString(output["licenseType"]);
   }
   if (output["platform"] !== undefined) {
-    contents.Platform = output["platform"];
+    contents.Platform = __expectString(output["platform"]);
   }
   if (output["progress"] !== undefined) {
-    contents.Progress = output["progress"];
+    contents.Progress = __expectString(output["progress"]);
   }
   if (output.snapshotDetailSet === "") {
     contents.SnapshotDetails = [];
@@ -59375,10 +59380,10 @@ const deserializeAws_ec2ImportImageResult = (output: any, context: __SerdeContex
     );
   }
   if (output["status"] !== undefined) {
-    contents.Status = output["status"];
+    contents.Status = __expectString(output["status"]);
   }
   if (output["statusMessage"] !== undefined) {
-    contents.StatusMessage = output["statusMessage"];
+    contents.StatusMessage = __expectString(output["statusMessage"]);
   }
   if (output.licenseSpecifications === "") {
     contents.LicenseSpecifications = [];
@@ -59417,34 +59422,34 @@ const deserializeAws_ec2ImportImageTask = (output: any, context: __SerdeContext)
     LicenseSpecifications: undefined,
   };
   if (output["architecture"] !== undefined) {
-    contents.Architecture = output["architecture"];
+    contents.Architecture = __expectString(output["architecture"]);
   }
   if (output["description"] !== undefined) {
-    contents.Description = output["description"];
+    contents.Description = __expectString(output["description"]);
   }
   if (output["encrypted"] !== undefined) {
     contents.Encrypted = __parseBoolean(output["encrypted"]);
   }
   if (output["hypervisor"] !== undefined) {
-    contents.Hypervisor = output["hypervisor"];
+    contents.Hypervisor = __expectString(output["hypervisor"]);
   }
   if (output["imageId"] !== undefined) {
-    contents.ImageId = output["imageId"];
+    contents.ImageId = __expectString(output["imageId"]);
   }
   if (output["importTaskId"] !== undefined) {
-    contents.ImportTaskId = output["importTaskId"];
+    contents.ImportTaskId = __expectString(output["importTaskId"]);
   }
   if (output["kmsKeyId"] !== undefined) {
-    contents.KmsKeyId = output["kmsKeyId"];
+    contents.KmsKeyId = __expectString(output["kmsKeyId"]);
   }
   if (output["licenseType"] !== undefined) {
-    contents.LicenseType = output["licenseType"];
+    contents.LicenseType = __expectString(output["licenseType"]);
   }
   if (output["platform"] !== undefined) {
-    contents.Platform = output["platform"];
+    contents.Platform = __expectString(output["platform"]);
   }
   if (output["progress"] !== undefined) {
-    contents.Progress = output["progress"];
+    contents.Progress = __expectString(output["progress"]);
   }
   if (output.snapshotDetailSet === "") {
     contents.SnapshotDetails = [];
@@ -59456,10 +59461,10 @@ const deserializeAws_ec2ImportImageTask = (output: any, context: __SerdeContext)
     );
   }
   if (output["status"] !== undefined) {
-    contents.Status = output["status"];
+    contents.Status = __expectString(output["status"]);
   }
   if (output["statusMessage"] !== undefined) {
-    contents.StatusMessage = output["statusMessage"];
+    contents.StatusMessage = __expectString(output["statusMessage"]);
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -59511,13 +59516,13 @@ const deserializeAws_ec2ImportInstanceTaskDetails = (
     Volumes: undefined,
   };
   if (output["description"] !== undefined) {
-    contents.Description = output["description"];
+    contents.Description = __expectString(output["description"]);
   }
   if (output["instanceId"] !== undefined) {
-    contents.InstanceId = output["instanceId"];
+    contents.InstanceId = __expectString(output["instanceId"]);
   }
   if (output["platform"] !== undefined) {
-    contents.Platform = output["platform"];
+    contents.Platform = __expectString(output["platform"]);
   }
   if (output.volumes === "") {
     contents.Volumes = [];
@@ -59545,22 +59550,22 @@ const deserializeAws_ec2ImportInstanceVolumeDetailItem = (
     Volume: undefined,
   };
   if (output["availabilityZone"] !== undefined) {
-    contents.AvailabilityZone = output["availabilityZone"];
+    contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
   if (output["bytesConverted"] !== undefined) {
     contents.BytesConverted = parseInt(output["bytesConverted"]);
   }
   if (output["description"] !== undefined) {
-    contents.Description = output["description"];
+    contents.Description = __expectString(output["description"]);
   }
   if (output["image"] !== undefined) {
     contents.Image = deserializeAws_ec2DiskImageDescription(output["image"], context);
   }
   if (output["status"] !== undefined) {
-    contents.Status = output["status"];
+    contents.Status = __expectString(output["status"]);
   }
   if (output["statusMessage"] !== undefined) {
-    contents.StatusMessage = output["statusMessage"];
+    contents.StatusMessage = __expectString(output["statusMessage"]);
   }
   if (output["volume"] !== undefined) {
     contents.Volume = deserializeAws_ec2DiskImageVolumeDescription(output["volume"], context);
@@ -59590,13 +59595,13 @@ const deserializeAws_ec2ImportKeyPairResult = (output: any, context: __SerdeCont
     Tags: undefined,
   };
   if (output["keyFingerprint"] !== undefined) {
-    contents.KeyFingerprint = output["keyFingerprint"];
+    contents.KeyFingerprint = __expectString(output["keyFingerprint"]);
   }
   if (output["keyName"] !== undefined) {
-    contents.KeyName = output["keyName"];
+    contents.KeyName = __expectString(output["keyName"]);
   }
   if (output["keyPairId"] !== undefined) {
-    contents.KeyPairId = output["keyPairId"];
+    contents.KeyPairId = __expectString(output["keyPairId"]);
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -59615,10 +59620,10 @@ const deserializeAws_ec2ImportSnapshotResult = (output: any, context: __SerdeCon
     Tags: undefined,
   };
   if (output["description"] !== undefined) {
-    contents.Description = output["description"];
+    contents.Description = __expectString(output["description"]);
   }
   if (output["importTaskId"] !== undefined) {
-    contents.ImportTaskId = output["importTaskId"];
+    contents.ImportTaskId = __expectString(output["importTaskId"]);
   }
   if (output["snapshotTaskDetail"] !== undefined) {
     contents.SnapshotTaskDetail = deserializeAws_ec2SnapshotTaskDetail(output["snapshotTaskDetail"], context);
@@ -59640,10 +59645,10 @@ const deserializeAws_ec2ImportSnapshotTask = (output: any, context: __SerdeConte
     Tags: undefined,
   };
   if (output["description"] !== undefined) {
-    contents.Description = output["description"];
+    contents.Description = __expectString(output["description"]);
   }
   if (output["importTaskId"] !== undefined) {
-    contents.ImportTaskId = output["importTaskId"];
+    contents.ImportTaskId = __expectString(output["importTaskId"]);
   }
   if (output["snapshotTaskDetail"] !== undefined) {
     contents.SnapshotTaskDetail = deserializeAws_ec2SnapshotTaskDetail(output["snapshotTaskDetail"], context);
@@ -59687,13 +59692,13 @@ const deserializeAws_ec2ImportVolumeTaskDetails = (output: any, context: __Serde
     Volume: undefined,
   };
   if (output["availabilityZone"] !== undefined) {
-    contents.AvailabilityZone = output["availabilityZone"];
+    contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
   if (output["bytesConverted"] !== undefined) {
     contents.BytesConverted = parseInt(output["bytesConverted"]);
   }
   if (output["description"] !== undefined) {
-    contents.Description = output["description"];
+    contents.Description = __expectString(output["description"]);
   }
   if (output["image"] !== undefined) {
     contents.Image = deserializeAws_ec2DiskImageDescription(output["image"], context);
@@ -59730,10 +59735,10 @@ const deserializeAws_ec2InferenceDeviceInfo = (output: any, context: __SerdeCont
     contents.Count = parseInt(output["count"]);
   }
   if (output["name"] !== undefined) {
-    contents.Name = output["name"];
+    contents.Name = __expectString(output["name"]);
   }
   if (output["manufacturer"] !== undefined) {
-    contents.Manufacturer = output["manufacturer"];
+    contents.Manufacturer = __expectString(output["manufacturer"]);
   }
   return contents;
 };
@@ -59756,7 +59761,7 @@ const deserializeAws_ec2InsideCidrBlocksStringList = (output: any, context: __Se
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -59816,19 +59821,19 @@ const deserializeAws_ec2Instance = (output: any, context: __SerdeContext): Insta
     contents.AmiLaunchIndex = parseInt(output["amiLaunchIndex"]);
   }
   if (output["imageId"] !== undefined) {
-    contents.ImageId = output["imageId"];
+    contents.ImageId = __expectString(output["imageId"]);
   }
   if (output["instanceId"] !== undefined) {
-    contents.InstanceId = output["instanceId"];
+    contents.InstanceId = __expectString(output["instanceId"]);
   }
   if (output["instanceType"] !== undefined) {
-    contents.InstanceType = output["instanceType"];
+    contents.InstanceType = __expectString(output["instanceType"]);
   }
   if (output["kernelId"] !== undefined) {
-    contents.KernelId = output["kernelId"];
+    contents.KernelId = __expectString(output["kernelId"]);
   }
   if (output["keyName"] !== undefined) {
-    contents.KeyName = output["keyName"];
+    contents.KeyName = __expectString(output["keyName"]);
   }
   if (output["launchTime"] !== undefined) {
     contents.LaunchTime = new Date(output["launchTime"]);
@@ -59840,13 +59845,13 @@ const deserializeAws_ec2Instance = (output: any, context: __SerdeContext): Insta
     contents.Placement = deserializeAws_ec2Placement(output["placement"], context);
   }
   if (output["platform"] !== undefined) {
-    contents.Platform = output["platform"];
+    contents.Platform = __expectString(output["platform"]);
   }
   if (output["privateDnsName"] !== undefined) {
-    contents.PrivateDnsName = output["privateDnsName"];
+    contents.PrivateDnsName = __expectString(output["privateDnsName"]);
   }
   if (output["privateIpAddress"] !== undefined) {
-    contents.PrivateIpAddress = output["privateIpAddress"];
+    contents.PrivateIpAddress = __expectString(output["privateIpAddress"]);
   }
   if (output.productCodes === "") {
     contents.ProductCodes = [];
@@ -59858,28 +59863,28 @@ const deserializeAws_ec2Instance = (output: any, context: __SerdeContext): Insta
     );
   }
   if (output["dnsName"] !== undefined) {
-    contents.PublicDnsName = output["dnsName"];
+    contents.PublicDnsName = __expectString(output["dnsName"]);
   }
   if (output["ipAddress"] !== undefined) {
-    contents.PublicIpAddress = output["ipAddress"];
+    contents.PublicIpAddress = __expectString(output["ipAddress"]);
   }
   if (output["ramdiskId"] !== undefined) {
-    contents.RamdiskId = output["ramdiskId"];
+    contents.RamdiskId = __expectString(output["ramdiskId"]);
   }
   if (output["instanceState"] !== undefined) {
     contents.State = deserializeAws_ec2InstanceState(output["instanceState"], context);
   }
   if (output["reason"] !== undefined) {
-    contents.StateTransitionReason = output["reason"];
+    contents.StateTransitionReason = __expectString(output["reason"]);
   }
   if (output["subnetId"] !== undefined) {
-    contents.SubnetId = output["subnetId"];
+    contents.SubnetId = __expectString(output["subnetId"]);
   }
   if (output["vpcId"] !== undefined) {
-    contents.VpcId = output["vpcId"];
+    contents.VpcId = __expectString(output["vpcId"]);
   }
   if (output["architecture"] !== undefined) {
-    contents.Architecture = output["architecture"];
+    contents.Architecture = __expectString(output["architecture"]);
   }
   if (output.blockDeviceMapping === "") {
     contents.BlockDeviceMappings = [];
@@ -59891,7 +59896,7 @@ const deserializeAws_ec2Instance = (output: any, context: __SerdeContext): Insta
     );
   }
   if (output["clientToken"] !== undefined) {
-    contents.ClientToken = output["clientToken"];
+    contents.ClientToken = __expectString(output["clientToken"]);
   }
   if (output["ebsOptimized"] !== undefined) {
     contents.EbsOptimized = __parseBoolean(output["ebsOptimized"]);
@@ -59900,13 +59905,13 @@ const deserializeAws_ec2Instance = (output: any, context: __SerdeContext): Insta
     contents.EnaSupport = __parseBoolean(output["enaSupport"]);
   }
   if (output["hypervisor"] !== undefined) {
-    contents.Hypervisor = output["hypervisor"];
+    contents.Hypervisor = __expectString(output["hypervisor"]);
   }
   if (output["iamInstanceProfile"] !== undefined) {
     contents.IamInstanceProfile = deserializeAws_ec2IamInstanceProfile(output["iamInstanceProfile"], context);
   }
   if (output["instanceLifecycle"] !== undefined) {
-    contents.InstanceLifecycle = output["instanceLifecycle"];
+    contents.InstanceLifecycle = __expectString(output["instanceLifecycle"]);
   }
   if (output.elasticGpuAssociationSet === "") {
     contents.ElasticGpuAssociations = [];
@@ -59939,13 +59944,13 @@ const deserializeAws_ec2Instance = (output: any, context: __SerdeContext): Insta
     );
   }
   if (output["outpostArn"] !== undefined) {
-    contents.OutpostArn = output["outpostArn"];
+    contents.OutpostArn = __expectString(output["outpostArn"]);
   }
   if (output["rootDeviceName"] !== undefined) {
-    contents.RootDeviceName = output["rootDeviceName"];
+    contents.RootDeviceName = __expectString(output["rootDeviceName"]);
   }
   if (output["rootDeviceType"] !== undefined) {
-    contents.RootDeviceType = output["rootDeviceType"];
+    contents.RootDeviceType = __expectString(output["rootDeviceType"]);
   }
   if (output.groupSet === "") {
     contents.SecurityGroups = [];
@@ -59960,10 +59965,10 @@ const deserializeAws_ec2Instance = (output: any, context: __SerdeContext): Insta
     contents.SourceDestCheck = __parseBoolean(output["sourceDestCheck"]);
   }
   if (output["spotInstanceRequestId"] !== undefined) {
-    contents.SpotInstanceRequestId = output["spotInstanceRequestId"];
+    contents.SpotInstanceRequestId = __expectString(output["spotInstanceRequestId"]);
   }
   if (output["sriovNetSupport"] !== undefined) {
-    contents.SriovNetSupport = output["sriovNetSupport"];
+    contents.SriovNetSupport = __expectString(output["sriovNetSupport"]);
   }
   if (output["stateReason"] !== undefined) {
     contents.StateReason = deserializeAws_ec2StateReason(output["stateReason"], context);
@@ -59975,13 +59980,13 @@ const deserializeAws_ec2Instance = (output: any, context: __SerdeContext): Insta
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["virtualizationType"] !== undefined) {
-    contents.VirtualizationType = output["virtualizationType"];
+    contents.VirtualizationType = __expectString(output["virtualizationType"]);
   }
   if (output["cpuOptions"] !== undefined) {
     contents.CpuOptions = deserializeAws_ec2CpuOptions(output["cpuOptions"], context);
   }
   if (output["capacityReservationId"] !== undefined) {
-    contents.CapacityReservationId = output["capacityReservationId"];
+    contents.CapacityReservationId = __expectString(output["capacityReservationId"]);
   }
   if (output["capacityReservationSpecification"] !== undefined) {
     contents.CapacityReservationSpecification = deserializeAws_ec2CapacityReservationSpecificationResponse(
@@ -60005,7 +60010,7 @@ const deserializeAws_ec2Instance = (output: any, context: __SerdeContext): Insta
     contents.EnclaveOptions = deserializeAws_ec2EnclaveOptions(output["enclaveOptions"], context);
   }
   if (output["bootMode"] !== undefined) {
-    contents.BootMode = output["bootMode"];
+    contents.BootMode = __expectString(output["bootMode"]);
   }
   return contents;
 };
@@ -60060,7 +60065,7 @@ const deserializeAws_ec2InstanceAttribute = (output: any, context: __SerdeContex
     contents.EbsOptimized = deserializeAws_ec2AttributeBooleanValue(output["ebsOptimized"], context);
   }
   if (output["instanceId"] !== undefined) {
-    contents.InstanceId = output["instanceId"];
+    contents.InstanceId = __expectString(output["instanceId"]);
   }
   if (output["instanceInitiatedShutdownBehavior"] !== undefined) {
     contents.InstanceInitiatedShutdownBehavior = deserializeAws_ec2AttributeValue(
@@ -60110,7 +60115,7 @@ const deserializeAws_ec2InstanceBlockDeviceMapping = (
     Ebs: undefined,
   };
   if (output["deviceName"] !== undefined) {
-    contents.DeviceName = output["deviceName"];
+    contents.DeviceName = __expectString(output["deviceName"]);
   }
   if (output["ebs"] !== undefined) {
     contents.Ebs = deserializeAws_ec2EbsInstanceBlockDevice(output["ebs"], context);
@@ -60142,7 +60147,7 @@ const deserializeAws_ec2InstanceCapacity = (output: any, context: __SerdeContext
     contents.AvailableCapacity = parseInt(output["availableCapacity"]);
   }
   if (output["instanceType"] !== undefined) {
-    contents.InstanceType = output["instanceType"];
+    contents.InstanceType = __expectString(output["instanceType"]);
   }
   if (output["totalCapacity"] !== undefined) {
     contents.TotalCapacity = parseInt(output["totalCapacity"]);
@@ -60159,7 +60164,7 @@ const deserializeAws_ec2InstanceCount = (output: any, context: __SerdeContext): 
     contents.InstanceCount = parseInt(output["instanceCount"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   return contents;
 };
@@ -60184,10 +60189,10 @@ const deserializeAws_ec2InstanceCreditSpecification = (
     CpuCredits: undefined,
   };
   if (output["instanceId"] !== undefined) {
-    contents.InstanceId = output["instanceId"];
+    contents.InstanceId = __expectString(output["instanceId"]);
   }
   if (output["cpuCredits"] !== undefined) {
-    contents.CpuCredits = output["cpuCredits"];
+    contents.CpuCredits = __expectString(output["cpuCredits"]);
   }
   return contents;
 };
@@ -60212,10 +60217,10 @@ const deserializeAws_ec2InstanceExportDetails = (output: any, context: __SerdeCo
     TargetEnvironment: undefined,
   };
   if (output["instanceId"] !== undefined) {
-    contents.InstanceId = output["instanceId"];
+    contents.InstanceId = __expectString(output["instanceId"]);
   }
   if (output["targetEnvironment"] !== undefined) {
-    contents.TargetEnvironment = output["targetEnvironment"];
+    contents.TargetEnvironment = __expectString(output["targetEnvironment"]);
   }
   return contents;
 };
@@ -60229,10 +60234,10 @@ const deserializeAws_ec2InstanceFamilyCreditSpecification = (
     CpuCredits: undefined,
   };
   if (output["instanceFamily"] !== undefined) {
-    contents.InstanceFamily = output["instanceFamily"];
+    contents.InstanceFamily = __expectString(output["instanceFamily"]);
   }
   if (output["cpuCredits"] !== undefined) {
-    contents.CpuCredits = output["cpuCredits"];
+    contents.CpuCredits = __expectString(output["cpuCredits"]);
   }
   return contents;
 };
@@ -60244,7 +60249,7 @@ const deserializeAws_ec2InstanceIdSet = (output: any, context: __SerdeContext): 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -60255,7 +60260,7 @@ const deserializeAws_ec2InstanceIdsSet = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -60264,7 +60269,7 @@ const deserializeAws_ec2InstanceIpv6Address = (output: any, context: __SerdeCont
     Ipv6Address: undefined,
   };
   if (output["ipv6Address"] !== undefined) {
-    contents.Ipv6Address = output["ipv6Address"];
+    contents.Ipv6Address = __expectString(output["ipv6Address"]);
   }
   return contents;
 };
@@ -60302,16 +60307,16 @@ const deserializeAws_ec2InstanceMetadataOptionsResponse = (
     HttpEndpoint: undefined,
   };
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output["httpTokens"] !== undefined) {
-    contents.HttpTokens = output["httpTokens"];
+    contents.HttpTokens = __expectString(output["httpTokens"]);
   }
   if (output["httpPutResponseHopLimit"] !== undefined) {
     contents.HttpPutResponseHopLimit = parseInt(output["httpPutResponseHopLimit"]);
   }
   if (output["httpEndpoint"] !== undefined) {
-    contents.HttpEndpoint = output["httpEndpoint"];
+    contents.HttpEndpoint = __expectString(output["httpEndpoint"]);
   }
   return contents;
 };
@@ -60322,7 +60327,7 @@ const deserializeAws_ec2InstanceMonitoring = (output: any, context: __SerdeConte
     Monitoring: undefined,
   };
   if (output["instanceId"] !== undefined) {
-    contents.InstanceId = output["instanceId"];
+    contents.InstanceId = __expectString(output["instanceId"]);
   }
   if (output["monitoring"] !== undefined) {
     contents.Monitoring = deserializeAws_ec2Monitoring(output["monitoring"], context);
@@ -60367,7 +60372,7 @@ const deserializeAws_ec2InstanceNetworkInterface = (output: any, context: __Serd
     contents.Attachment = deserializeAws_ec2InstanceNetworkInterfaceAttachment(output["attachment"], context);
   }
   if (output["description"] !== undefined) {
-    contents.Description = output["description"];
+    contents.Description = __expectString(output["description"]);
   }
   if (output.groupSet === "") {
     contents.Groups = [];
@@ -60388,19 +60393,19 @@ const deserializeAws_ec2InstanceNetworkInterface = (output: any, context: __Serd
     );
   }
   if (output["macAddress"] !== undefined) {
-    contents.MacAddress = output["macAddress"];
+    contents.MacAddress = __expectString(output["macAddress"]);
   }
   if (output["networkInterfaceId"] !== undefined) {
-    contents.NetworkInterfaceId = output["networkInterfaceId"];
+    contents.NetworkInterfaceId = __expectString(output["networkInterfaceId"]);
   }
   if (output["ownerId"] !== undefined) {
-    contents.OwnerId = output["ownerId"];
+    contents.OwnerId = __expectString(output["ownerId"]);
   }
   if (output["privateDnsName"] !== undefined) {
-    contents.PrivateDnsName = output["privateDnsName"];
+    contents.PrivateDnsName = __expectString(output["privateDnsName"]);
   }
   if (output["privateIpAddress"] !== undefined) {
-    contents.PrivateIpAddress = output["privateIpAddress"];
+    contents.PrivateIpAddress = __expectString(output["privateIpAddress"]);
   }
   if (output.privateIpAddressesSet === "") {
     contents.PrivateIpAddresses = [];
@@ -60415,16 +60420,16 @@ const deserializeAws_ec2InstanceNetworkInterface = (output: any, context: __Serd
     contents.SourceDestCheck = __parseBoolean(output["sourceDestCheck"]);
   }
   if (output["status"] !== undefined) {
-    contents.Status = output["status"];
+    contents.Status = __expectString(output["status"]);
   }
   if (output["subnetId"] !== undefined) {
-    contents.SubnetId = output["subnetId"];
+    contents.SubnetId = __expectString(output["subnetId"]);
   }
   if (output["vpcId"] !== undefined) {
-    contents.VpcId = output["vpcId"];
+    contents.VpcId = __expectString(output["vpcId"]);
   }
   if (output["interfaceType"] !== undefined) {
-    contents.InterfaceType = output["interfaceType"];
+    contents.InterfaceType = __expectString(output["interfaceType"]);
   }
   return contents;
 };
@@ -60440,16 +60445,16 @@ const deserializeAws_ec2InstanceNetworkInterfaceAssociation = (
     PublicIp: undefined,
   };
   if (output["carrierIp"] !== undefined) {
-    contents.CarrierIp = output["carrierIp"];
+    contents.CarrierIp = __expectString(output["carrierIp"]);
   }
   if (output["ipOwnerId"] !== undefined) {
-    contents.IpOwnerId = output["ipOwnerId"];
+    contents.IpOwnerId = __expectString(output["ipOwnerId"]);
   }
   if (output["publicDnsName"] !== undefined) {
-    contents.PublicDnsName = output["publicDnsName"];
+    contents.PublicDnsName = __expectString(output["publicDnsName"]);
   }
   if (output["publicIp"] !== undefined) {
-    contents.PublicIp = output["publicIp"];
+    contents.PublicIp = __expectString(output["publicIp"]);
   }
   return contents;
 };
@@ -60470,7 +60475,7 @@ const deserializeAws_ec2InstanceNetworkInterfaceAttachment = (
     contents.AttachTime = new Date(output["attachTime"]);
   }
   if (output["attachmentId"] !== undefined) {
-    contents.AttachmentId = output["attachmentId"];
+    contents.AttachmentId = __expectString(output["attachmentId"]);
   }
   if (output["deleteOnTermination"] !== undefined) {
     contents.DeleteOnTermination = __parseBoolean(output["deleteOnTermination"]);
@@ -60479,7 +60484,7 @@ const deserializeAws_ec2InstanceNetworkInterfaceAttachment = (
     contents.DeviceIndex = parseInt(output["deviceIndex"]);
   }
   if (output["status"] !== undefined) {
-    contents.Status = output["status"];
+    contents.Status = __expectString(output["status"]);
   }
   if (output["networkCardIndex"] !== undefined) {
     contents.NetworkCardIndex = parseInt(output["networkCardIndex"]);
@@ -60529,7 +60534,7 @@ const deserializeAws_ec2InstanceNetworkInterfaceSpecification = (
     contents.DeleteOnTermination = __parseBoolean(output["deleteOnTermination"]);
   }
   if (output["description"] !== undefined) {
-    contents.Description = output["description"];
+    contents.Description = __expectString(output["description"]);
   }
   if (output["deviceIndex"] !== undefined) {
     contents.DeviceIndex = parseInt(output["deviceIndex"]);
@@ -60556,10 +60561,10 @@ const deserializeAws_ec2InstanceNetworkInterfaceSpecification = (
     );
   }
   if (output["networkInterfaceId"] !== undefined) {
-    contents.NetworkInterfaceId = output["networkInterfaceId"];
+    contents.NetworkInterfaceId = __expectString(output["networkInterfaceId"]);
   }
   if (output["privateIpAddress"] !== undefined) {
-    contents.PrivateIpAddress = output["privateIpAddress"];
+    contents.PrivateIpAddress = __expectString(output["privateIpAddress"]);
   }
   if (output.privateIpAddressesSet === "") {
     contents.PrivateIpAddresses = [];
@@ -60574,13 +60579,13 @@ const deserializeAws_ec2InstanceNetworkInterfaceSpecification = (
     contents.SecondaryPrivateIpAddressCount = parseInt(output["secondaryPrivateIpAddressCount"]);
   }
   if (output["subnetId"] !== undefined) {
-    contents.SubnetId = output["subnetId"];
+    contents.SubnetId = __expectString(output["subnetId"]);
   }
   if (output["AssociateCarrierIpAddress"] !== undefined) {
     contents.AssociateCarrierIpAddress = __parseBoolean(output["AssociateCarrierIpAddress"]);
   }
   if (output["InterfaceType"] !== undefined) {
-    contents.InterfaceType = output["InterfaceType"];
+    contents.InterfaceType = __expectString(output["InterfaceType"]);
   }
   if (output["NetworkCardIndex"] !== undefined) {
     contents.NetworkCardIndex = parseInt(output["NetworkCardIndex"]);
@@ -60616,10 +60621,10 @@ const deserializeAws_ec2InstancePrivateIpAddress = (output: any, context: __Serd
     contents.Primary = __parseBoolean(output["primary"]);
   }
   if (output["privateDnsName"] !== undefined) {
-    contents.PrivateDnsName = output["privateDnsName"];
+    contents.PrivateDnsName = __expectString(output["privateDnsName"]);
   }
   if (output["privateIpAddress"] !== undefined) {
-    contents.PrivateIpAddress = output["privateIpAddress"];
+    contents.PrivateIpAddress = __expectString(output["privateIpAddress"]);
   }
   return contents;
 };
@@ -60647,7 +60652,7 @@ const deserializeAws_ec2InstanceState = (output: any, context: __SerdeContext): 
     contents.Code = parseInt(output["code"]);
   }
   if (output["name"] !== undefined) {
-    contents.Name = output["name"];
+    contents.Name = __expectString(output["name"]);
   }
   return contents;
 };
@@ -60662,7 +60667,7 @@ const deserializeAws_ec2InstanceStateChange = (output: any, context: __SerdeCont
     contents.CurrentState = deserializeAws_ec2InstanceState(output["currentState"], context);
   }
   if (output["instanceId"] !== undefined) {
-    contents.InstanceId = output["instanceId"];
+    contents.InstanceId = __expectString(output["instanceId"]);
   }
   if (output["previousState"] !== undefined) {
     contents.PreviousState = deserializeAws_ec2InstanceState(output["previousState"], context);
@@ -60692,10 +60697,10 @@ const deserializeAws_ec2InstanceStatus = (output: any, context: __SerdeContext):
     SystemStatus: undefined,
   };
   if (output["availabilityZone"] !== undefined) {
-    contents.AvailabilityZone = output["availabilityZone"];
+    contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
   if (output["outpostArn"] !== undefined) {
-    contents.OutpostArn = output["outpostArn"];
+    contents.OutpostArn = __expectString(output["outpostArn"]);
   }
   if (output.eventsSet === "") {
     contents.Events = [];
@@ -60707,7 +60712,7 @@ const deserializeAws_ec2InstanceStatus = (output: any, context: __SerdeContext):
     );
   }
   if (output["instanceId"] !== undefined) {
-    contents.InstanceId = output["instanceId"];
+    contents.InstanceId = __expectString(output["instanceId"]);
   }
   if (output["instanceState"] !== undefined) {
     contents.InstanceState = deserializeAws_ec2InstanceState(output["instanceState"], context);
@@ -60731,10 +60736,10 @@ const deserializeAws_ec2InstanceStatusDetails = (output: any, context: __SerdeCo
     contents.ImpairedSince = new Date(output["impairedSince"]);
   }
   if (output["name"] !== undefined) {
-    contents.Name = output["name"];
+    contents.Name = __expectString(output["name"]);
   }
   if (output["status"] !== undefined) {
-    contents.Status = output["status"];
+    contents.Status = __expectString(output["status"]);
   }
   return contents;
 };
@@ -60760,13 +60765,13 @@ const deserializeAws_ec2InstanceStatusEvent = (output: any, context: __SerdeCont
     NotBeforeDeadline: undefined,
   };
   if (output["instanceEventId"] !== undefined) {
-    contents.InstanceEventId = output["instanceEventId"];
+    contents.InstanceEventId = __expectString(output["instanceEventId"]);
   }
   if (output["code"] !== undefined) {
-    contents.Code = output["code"];
+    contents.Code = __expectString(output["code"]);
   }
   if (output["description"] !== undefined) {
-    contents.Description = output["description"];
+    contents.Description = __expectString(output["description"]);
   }
   if (output["notAfter"] !== undefined) {
     contents.NotAfter = new Date(output["notAfter"]);
@@ -60817,7 +60822,7 @@ const deserializeAws_ec2InstanceStatusSummary = (output: any, context: __SerdeCo
     );
   }
   if (output["status"] !== undefined) {
-    contents.Status = output["status"];
+    contents.Status = __expectString(output["status"]);
   }
   return contents;
 };
@@ -60838,7 +60843,7 @@ const deserializeAws_ec2InstanceStorageInfo = (output: any, context: __SerdeCont
     contents.Disks = deserializeAws_ec2DiskInfoList(__getArrayIfSingleItem(output["disks"]["item"]), context);
   }
   if (output["nvmeSupport"] !== undefined) {
-    contents.NvmeSupport = output["nvmeSupport"];
+    contents.NvmeSupport = __expectString(output["nvmeSupport"]);
   }
   return contents;
 };
@@ -60850,7 +60855,7 @@ const deserializeAws_ec2InstanceTagKeySet = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -60905,7 +60910,7 @@ const deserializeAws_ec2InstanceTypeInfo = (output: any, context: __SerdeContext
     SupportedBootModes: undefined,
   };
   if (output["instanceType"] !== undefined) {
-    contents.InstanceType = output["instanceType"];
+    contents.InstanceType = __expectString(output["instanceType"]);
   }
   if (output["currentGeneration"] !== undefined) {
     contents.CurrentGeneration = __parseBoolean(output["currentGeneration"]);
@@ -60947,7 +60952,7 @@ const deserializeAws_ec2InstanceTypeInfo = (output: any, context: __SerdeContext
     contents.BareMetal = __parseBoolean(output["bareMetal"]);
   }
   if (output["hypervisor"] !== undefined) {
-    contents.Hypervisor = output["hypervisor"];
+    contents.Hypervisor = __expectString(output["hypervisor"]);
   }
   if (output["processorInfo"] !== undefined) {
     contents.ProcessorInfo = deserializeAws_ec2ProcessorInfo(output["processorInfo"], context);
@@ -61027,13 +61032,13 @@ const deserializeAws_ec2InstanceTypeOffering = (output: any, context: __SerdeCon
     Location: undefined,
   };
   if (output["instanceType"] !== undefined) {
-    contents.InstanceType = output["instanceType"];
+    contents.InstanceType = __expectString(output["instanceType"]);
   }
   if (output["locationType"] !== undefined) {
-    contents.LocationType = output["locationType"];
+    contents.LocationType = __expectString(output["locationType"]);
   }
   if (output["location"] !== undefined) {
-    contents.Location = output["location"];
+    contents.Location = __expectString(output["location"]);
   }
   return contents;
 };
@@ -61055,7 +61060,7 @@ const deserializeAws_ec2InstanceUsage = (output: any, context: __SerdeContext): 
     UsedInstanceCount: undefined,
   };
   if (output["accountId"] !== undefined) {
-    contents.AccountId = output["accountId"];
+    contents.AccountId = __expectString(output["accountId"]);
   }
   if (output["usedInstanceCount"] !== undefined) {
     contents.UsedInstanceCount = parseInt(output["usedInstanceCount"]);
@@ -61091,10 +61096,10 @@ const deserializeAws_ec2InternetGateway = (output: any, context: __SerdeContext)
     );
   }
   if (output["internetGatewayId"] !== undefined) {
-    contents.InternetGatewayId = output["internetGatewayId"];
+    contents.InternetGatewayId = __expectString(output["internetGatewayId"]);
   }
   if (output["ownerId"] !== undefined) {
-    contents.OwnerId = output["ownerId"];
+    contents.OwnerId = __expectString(output["ownerId"]);
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -61114,10 +61119,10 @@ const deserializeAws_ec2InternetGatewayAttachment = (
     VpcId: undefined,
   };
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output["vpcId"] !== undefined) {
-    contents.VpcId = output["vpcId"];
+    contents.VpcId = __expectString(output["vpcId"]);
   }
   return contents;
 };
@@ -61154,7 +61159,7 @@ const deserializeAws_ec2IpAddressList = (output: any, context: __SerdeContext): 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -61172,7 +61177,7 @@ const deserializeAws_ec2IpPermission = (output: any, context: __SerdeContext): I
     contents.FromPort = parseInt(output["fromPort"]);
   }
   if (output["ipProtocol"] !== undefined) {
-    contents.IpProtocol = output["ipProtocol"];
+    contents.IpProtocol = __expectString(output["ipProtocol"]);
   }
   if (output.ipRanges === "") {
     contents.IpRanges = [];
@@ -61230,10 +61235,10 @@ const deserializeAws_ec2IpRange = (output: any, context: __SerdeContext): IpRang
     Description: undefined,
   };
   if (output["cidrIp"] !== undefined) {
-    contents.CidrIp = output["cidrIp"];
+    contents.CidrIp = __expectString(output["cidrIp"]);
   }
   if (output["description"] !== undefined) {
-    contents.Description = output["description"];
+    contents.Description = __expectString(output["description"]);
   }
   return contents;
 };
@@ -61256,7 +61261,7 @@ const deserializeAws_ec2IpRanges = (output: any, context: __SerdeContext): strin
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -61267,7 +61272,7 @@ const deserializeAws_ec2Ipv6AddressList = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -61277,10 +61282,10 @@ const deserializeAws_ec2Ipv6CidrAssociation = (output: any, context: __SerdeCont
     AssociatedResource: undefined,
   };
   if (output["ipv6Cidr"] !== undefined) {
-    contents.Ipv6Cidr = output["ipv6Cidr"];
+    contents.Ipv6Cidr = __expectString(output["ipv6Cidr"]);
   }
   if (output["associatedResource"] !== undefined) {
-    contents.AssociatedResource = output["associatedResource"];
+    contents.AssociatedResource = __expectString(output["associatedResource"]);
   }
   return contents;
 };
@@ -61301,7 +61306,7 @@ const deserializeAws_ec2Ipv6CidrBlock = (output: any, context: __SerdeContext): 
     Ipv6CidrBlock: undefined,
   };
   if (output["ipv6CidrBlock"] !== undefined) {
-    contents.Ipv6CidrBlock = output["ipv6CidrBlock"];
+    contents.Ipv6CidrBlock = __expectString(output["ipv6CidrBlock"]);
   }
   return contents;
 };
@@ -61325,10 +61330,10 @@ const deserializeAws_ec2Ipv6Pool = (output: any, context: __SerdeContext): Ipv6P
     Tags: undefined,
   };
   if (output["poolId"] !== undefined) {
-    contents.PoolId = output["poolId"];
+    contents.PoolId = __expectString(output["poolId"]);
   }
   if (output["description"] !== undefined) {
-    contents.Description = output["description"];
+    contents.Description = __expectString(output["description"]);
   }
   if (output.poolCidrBlockSet === "") {
     contents.PoolCidrBlocks = [];
@@ -61365,10 +61370,10 @@ const deserializeAws_ec2Ipv6Range = (output: any, context: __SerdeContext): Ipv6
     Description: undefined,
   };
   if (output["cidrIpv6"] !== undefined) {
-    contents.CidrIpv6 = output["cidrIpv6"];
+    contents.CidrIpv6 = __expectString(output["cidrIpv6"]);
   }
   if (output["description"] !== undefined) {
-    contents.Description = output["description"];
+    contents.Description = __expectString(output["description"]);
   }
   return contents;
 };
@@ -61393,16 +61398,16 @@ const deserializeAws_ec2KeyPair = (output: any, context: __SerdeContext): KeyPai
     Tags: undefined,
   };
   if (output["keyFingerprint"] !== undefined) {
-    contents.KeyFingerprint = output["keyFingerprint"];
+    contents.KeyFingerprint = __expectString(output["keyFingerprint"]);
   }
   if (output["keyMaterial"] !== undefined) {
-    contents.KeyMaterial = output["keyMaterial"];
+    contents.KeyMaterial = __expectString(output["keyMaterial"]);
   }
   if (output["keyName"] !== undefined) {
-    contents.KeyName = output["keyName"];
+    contents.KeyName = __expectString(output["keyName"]);
   }
   if (output["keyPairId"] !== undefined) {
-    contents.KeyPairId = output["keyPairId"];
+    contents.KeyPairId = __expectString(output["keyPairId"]);
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -61421,13 +61426,13 @@ const deserializeAws_ec2KeyPairInfo = (output: any, context: __SerdeContext): Ke
     Tags: undefined,
   };
   if (output["keyPairId"] !== undefined) {
-    contents.KeyPairId = output["keyPairId"];
+    contents.KeyPairId = __expectString(output["keyPairId"]);
   }
   if (output["keyFingerprint"] !== undefined) {
-    contents.KeyFingerprint = output["keyFingerprint"];
+    contents.KeyFingerprint = __expectString(output["keyFingerprint"]);
   }
   if (output["keyName"] !== undefined) {
-    contents.KeyName = output["keyName"];
+    contents.KeyName = __expectString(output["keyName"]);
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -61455,10 +61460,10 @@ const deserializeAws_ec2LastError = (output: any, context: __SerdeContext): Last
     Code: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.Message = output["message"];
+    contents.Message = __expectString(output["message"]);
   }
   if (output["code"] !== undefined) {
-    contents.Code = output["code"];
+    contents.Code = __expectString(output["code"]);
   }
   return contents;
 };
@@ -61469,10 +61474,10 @@ const deserializeAws_ec2LaunchPermission = (output: any, context: __SerdeContext
     UserId: undefined,
   };
   if (output["group"] !== undefined) {
-    contents.Group = output["group"];
+    contents.Group = __expectString(output["group"]);
   }
   if (output["userId"] !== undefined) {
-    contents.UserId = output["userId"];
+    contents.UserId = __expectString(output["userId"]);
   }
   return contents;
 };
@@ -61507,7 +61512,7 @@ const deserializeAws_ec2LaunchSpecification = (output: any, context: __SerdeCont
     Monitoring: undefined,
   };
   if (output["userData"] !== undefined) {
-    contents.UserData = output["userData"];
+    contents.UserData = __expectString(output["userData"]);
   }
   if (output.groupSet === "") {
     contents.SecurityGroups = [];
@@ -61519,7 +61524,7 @@ const deserializeAws_ec2LaunchSpecification = (output: any, context: __SerdeCont
     );
   }
   if (output["addressingType"] !== undefined) {
-    contents.AddressingType = output["addressingType"];
+    contents.AddressingType = __expectString(output["addressingType"]);
   }
   if (output.blockDeviceMapping === "") {
     contents.BlockDeviceMappings = [];
@@ -61540,16 +61545,16 @@ const deserializeAws_ec2LaunchSpecification = (output: any, context: __SerdeCont
     );
   }
   if (output["imageId"] !== undefined) {
-    contents.ImageId = output["imageId"];
+    contents.ImageId = __expectString(output["imageId"]);
   }
   if (output["instanceType"] !== undefined) {
-    contents.InstanceType = output["instanceType"];
+    contents.InstanceType = __expectString(output["instanceType"]);
   }
   if (output["kernelId"] !== undefined) {
-    contents.KernelId = output["kernelId"];
+    contents.KernelId = __expectString(output["kernelId"]);
   }
   if (output["keyName"] !== undefined) {
-    contents.KeyName = output["keyName"];
+    contents.KeyName = __expectString(output["keyName"]);
   }
   if (output.networkInterfaceSet === "") {
     contents.NetworkInterfaces = [];
@@ -61564,10 +61569,10 @@ const deserializeAws_ec2LaunchSpecification = (output: any, context: __SerdeCont
     contents.Placement = deserializeAws_ec2SpotPlacement(output["placement"], context);
   }
   if (output["ramdiskId"] !== undefined) {
-    contents.RamdiskId = output["ramdiskId"];
+    contents.RamdiskId = __expectString(output["ramdiskId"]);
   }
   if (output["subnetId"] !== undefined) {
-    contents.SubnetId = output["subnetId"];
+    contents.SubnetId = __expectString(output["subnetId"]);
   }
   if (output["monitoring"] !== undefined) {
     contents.Monitoring = deserializeAws_ec2RunInstancesMonitoringEnabled(output["monitoring"], context);
@@ -61597,16 +61602,16 @@ const deserializeAws_ec2LaunchTemplate = (output: any, context: __SerdeContext):
     Tags: undefined,
   };
   if (output["launchTemplateId"] !== undefined) {
-    contents.LaunchTemplateId = output["launchTemplateId"];
+    contents.LaunchTemplateId = __expectString(output["launchTemplateId"]);
   }
   if (output["launchTemplateName"] !== undefined) {
-    contents.LaunchTemplateName = output["launchTemplateName"];
+    contents.LaunchTemplateName = __expectString(output["launchTemplateName"]);
   }
   if (output["createTime"] !== undefined) {
     contents.CreateTime = new Date(output["createTime"]);
   }
   if (output["createdBy"] !== undefined) {
-    contents.CreatedBy = output["createdBy"];
+    contents.CreatedBy = __expectString(output["createdBy"]);
   }
   if (output["defaultVersionNumber"] !== undefined) {
     contents.DefaultVersionNumber = parseInt(output["defaultVersionNumber"]);
@@ -61654,16 +61659,16 @@ const deserializeAws_ec2LaunchTemplateBlockDeviceMapping = (
     NoDevice: undefined,
   };
   if (output["deviceName"] !== undefined) {
-    contents.DeviceName = output["deviceName"];
+    contents.DeviceName = __expectString(output["deviceName"]);
   }
   if (output["virtualName"] !== undefined) {
-    contents.VirtualName = output["virtualName"];
+    contents.VirtualName = __expectString(output["virtualName"]);
   }
   if (output["ebs"] !== undefined) {
     contents.Ebs = deserializeAws_ec2LaunchTemplateEbsBlockDevice(output["ebs"], context);
   }
   if (output["noDevice"] !== undefined) {
-    contents.NoDevice = output["noDevice"];
+    contents.NoDevice = __expectString(output["noDevice"]);
   }
   return contents;
 };
@@ -61691,7 +61696,7 @@ const deserializeAws_ec2LaunchTemplateCapacityReservationSpecificationResponse =
     CapacityReservationTarget: undefined,
   };
   if (output["capacityReservationPreference"] !== undefined) {
-    contents.CapacityReservationPreference = output["capacityReservationPreference"];
+    contents.CapacityReservationPreference = __expectString(output["capacityReservationPreference"]);
   }
   if (output["capacityReservationTarget"] !== undefined) {
     contents.CapacityReservationTarget = deserializeAws_ec2CapacityReservationTargetResponse(
@@ -61774,16 +61779,16 @@ const deserializeAws_ec2LaunchTemplateEbsBlockDevice = (
     contents.Iops = parseInt(output["iops"]);
   }
   if (output["kmsKeyId"] !== undefined) {
-    contents.KmsKeyId = output["kmsKeyId"];
+    contents.KmsKeyId = __expectString(output["kmsKeyId"]);
   }
   if (output["snapshotId"] !== undefined) {
-    contents.SnapshotId = output["snapshotId"];
+    contents.SnapshotId = __expectString(output["snapshotId"]);
   }
   if (output["volumeSize"] !== undefined) {
     contents.VolumeSize = parseInt(output["volumeSize"]);
   }
   if (output["volumeType"] !== undefined) {
-    contents.VolumeType = output["volumeType"];
+    contents.VolumeType = __expectString(output["volumeType"]);
   }
   if (output["throughput"] !== undefined) {
     contents.Throughput = parseInt(output["throughput"]);
@@ -61800,7 +61805,7 @@ const deserializeAws_ec2LaunchTemplateElasticInferenceAcceleratorResponse = (
     Count: undefined,
   };
   if (output["type"] !== undefined) {
-    contents.Type = output["type"];
+    contents.Type = __expectString(output["type"]);
   }
   if (output["count"] !== undefined) {
     contents.Count = parseInt(output["count"]);
@@ -61857,10 +61862,10 @@ const deserializeAws_ec2LaunchTemplateIamInstanceProfileSpecification = (
     Name: undefined,
   };
   if (output["arn"] !== undefined) {
-    contents.Arn = output["arn"];
+    contents.Arn = __expectString(output["arn"]);
   }
   if (output["name"] !== undefined) {
-    contents.Name = output["name"];
+    contents.Name = __expectString(output["name"]);
   }
   return contents;
 };
@@ -61874,7 +61879,7 @@ const deserializeAws_ec2LaunchTemplateInstanceMarketOptions = (
     SpotOptions: undefined,
   };
   if (output["marketType"] !== undefined) {
-    contents.MarketType = output["marketType"];
+    contents.MarketType = __expectString(output["marketType"]);
   }
   if (output["spotOptions"] !== undefined) {
     contents.SpotOptions = deserializeAws_ec2LaunchTemplateSpotMarketOptions(output["spotOptions"], context);
@@ -61893,16 +61898,16 @@ const deserializeAws_ec2LaunchTemplateInstanceMetadataOptions = (
     HttpEndpoint: undefined,
   };
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output["httpTokens"] !== undefined) {
-    contents.HttpTokens = output["httpTokens"];
+    contents.HttpTokens = __expectString(output["httpTokens"]);
   }
   if (output["httpPutResponseHopLimit"] !== undefined) {
     contents.HttpPutResponseHopLimit = parseInt(output["httpPutResponseHopLimit"]);
   }
   if (output["httpEndpoint"] !== undefined) {
-    contents.HttpEndpoint = output["httpEndpoint"];
+    contents.HttpEndpoint = __expectString(output["httpEndpoint"]);
   }
   return contents;
 };
@@ -61938,7 +61943,7 @@ const deserializeAws_ec2LaunchTemplateInstanceNetworkInterfaceSpecification = (
     contents.DeleteOnTermination = __parseBoolean(output["deleteOnTermination"]);
   }
   if (output["description"] !== undefined) {
-    contents.Description = output["description"];
+    contents.Description = __expectString(output["description"]);
   }
   if (output["deviceIndex"] !== undefined) {
     contents.DeviceIndex = parseInt(output["deviceIndex"]);
@@ -61953,7 +61958,7 @@ const deserializeAws_ec2LaunchTemplateInstanceNetworkInterfaceSpecification = (
     );
   }
   if (output["interfaceType"] !== undefined) {
-    contents.InterfaceType = output["interfaceType"];
+    contents.InterfaceType = __expectString(output["interfaceType"]);
   }
   if (output["ipv6AddressCount"] !== undefined) {
     contents.Ipv6AddressCount = parseInt(output["ipv6AddressCount"]);
@@ -61968,10 +61973,10 @@ const deserializeAws_ec2LaunchTemplateInstanceNetworkInterfaceSpecification = (
     );
   }
   if (output["networkInterfaceId"] !== undefined) {
-    contents.NetworkInterfaceId = output["networkInterfaceId"];
+    contents.NetworkInterfaceId = __expectString(output["networkInterfaceId"]);
   }
   if (output["privateIpAddress"] !== undefined) {
-    contents.PrivateIpAddress = output["privateIpAddress"];
+    contents.PrivateIpAddress = __expectString(output["privateIpAddress"]);
   }
   if (output.privateIpAddressesSet === "") {
     contents.PrivateIpAddresses = [];
@@ -61986,7 +61991,7 @@ const deserializeAws_ec2LaunchTemplateInstanceNetworkInterfaceSpecification = (
     contents.SecondaryPrivateIpAddressCount = parseInt(output["secondaryPrivateIpAddressCount"]);
   }
   if (output["subnetId"] !== undefined) {
-    contents.SubnetId = output["subnetId"];
+    contents.SubnetId = __expectString(output["subnetId"]);
   }
   if (output["networkCardIndex"] !== undefined) {
     contents.NetworkCardIndex = parseInt(output["networkCardIndex"]);
@@ -62016,7 +62021,7 @@ const deserializeAws_ec2LaunchTemplateLicenseConfiguration = (
     LicenseConfigurationArn: undefined,
   };
   if (output["licenseConfigurationArn"] !== undefined) {
-    contents.LicenseConfigurationArn = output["licenseConfigurationArn"];
+    contents.LicenseConfigurationArn = __expectString(output["licenseConfigurationArn"]);
   }
   return contents;
 };
@@ -62045,16 +62050,16 @@ const deserializeAws_ec2LaunchTemplateOverrides = (output: any, context: __Serde
     Priority: undefined,
   };
   if (output["instanceType"] !== undefined) {
-    contents.InstanceType = output["instanceType"];
+    contents.InstanceType = __expectString(output["instanceType"]);
   }
   if (output["spotPrice"] !== undefined) {
-    contents.SpotPrice = output["spotPrice"];
+    contents.SpotPrice = __expectString(output["spotPrice"]);
   }
   if (output["subnetId"] !== undefined) {
-    contents.SubnetId = output["subnetId"];
+    contents.SubnetId = __expectString(output["subnetId"]);
   }
   if (output["availabilityZone"] !== undefined) {
-    contents.AvailabilityZone = output["availabilityZone"];
+    contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
   if (output["weightedCapacity"] !== undefined) {
     contents.WeightedCapacity = parseFloat(output["weightedCapacity"]);
@@ -62091,25 +62096,25 @@ const deserializeAws_ec2LaunchTemplatePlacement = (output: any, context: __Serde
     PartitionNumber: undefined,
   };
   if (output["availabilityZone"] !== undefined) {
-    contents.AvailabilityZone = output["availabilityZone"];
+    contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
   if (output["affinity"] !== undefined) {
-    contents.Affinity = output["affinity"];
+    contents.Affinity = __expectString(output["affinity"]);
   }
   if (output["groupName"] !== undefined) {
-    contents.GroupName = output["groupName"];
+    contents.GroupName = __expectString(output["groupName"]);
   }
   if (output["hostId"] !== undefined) {
-    contents.HostId = output["hostId"];
+    contents.HostId = __expectString(output["hostId"]);
   }
   if (output["tenancy"] !== undefined) {
-    contents.Tenancy = output["tenancy"];
+    contents.Tenancy = __expectString(output["tenancy"]);
   }
   if (output["spreadDomain"] !== undefined) {
-    contents.SpreadDomain = output["spreadDomain"];
+    contents.SpreadDomain = __expectString(output["spreadDomain"]);
   }
   if (output["hostResourceGroupArn"] !== undefined) {
-    contents.HostResourceGroupArn = output["hostResourceGroupArn"];
+    contents.HostResourceGroupArn = __expectString(output["hostResourceGroupArn"]);
   }
   if (output["partitionNumber"] !== undefined) {
     contents.PartitionNumber = parseInt(output["partitionNumber"]);
@@ -62153,10 +62158,10 @@ const deserializeAws_ec2LaunchTemplateSpotMarketOptions = (
     InstanceInterruptionBehavior: undefined,
   };
   if (output["maxPrice"] !== undefined) {
-    contents.MaxPrice = output["maxPrice"];
+    contents.MaxPrice = __expectString(output["maxPrice"]);
   }
   if (output["spotInstanceType"] !== undefined) {
-    contents.SpotInstanceType = output["spotInstanceType"];
+    contents.SpotInstanceType = __expectString(output["spotInstanceType"]);
   }
   if (output["blockDurationMinutes"] !== undefined) {
     contents.BlockDurationMinutes = parseInt(output["blockDurationMinutes"]);
@@ -62165,7 +62170,7 @@ const deserializeAws_ec2LaunchTemplateSpotMarketOptions = (
     contents.ValidUntil = new Date(output["validUntil"]);
   }
   if (output["instanceInterruptionBehavior"] !== undefined) {
-    contents.InstanceInterruptionBehavior = output["instanceInterruptionBehavior"];
+    contents.InstanceInterruptionBehavior = __expectString(output["instanceInterruptionBehavior"]);
   }
   return contents;
 };
@@ -62179,7 +62184,7 @@ const deserializeAws_ec2LaunchTemplateTagSpecification = (
     Tags: undefined,
   };
   if (output["resourceType"] !== undefined) {
-    contents.ResourceType = output["resourceType"];
+    contents.ResourceType = __expectString(output["resourceType"]);
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -62216,22 +62221,22 @@ const deserializeAws_ec2LaunchTemplateVersion = (output: any, context: __SerdeCo
     LaunchTemplateData: undefined,
   };
   if (output["launchTemplateId"] !== undefined) {
-    contents.LaunchTemplateId = output["launchTemplateId"];
+    contents.LaunchTemplateId = __expectString(output["launchTemplateId"]);
   }
   if (output["launchTemplateName"] !== undefined) {
-    contents.LaunchTemplateName = output["launchTemplateName"];
+    contents.LaunchTemplateName = __expectString(output["launchTemplateName"]);
   }
   if (output["versionNumber"] !== undefined) {
     contents.VersionNumber = parseInt(output["versionNumber"]);
   }
   if (output["versionDescription"] !== undefined) {
-    contents.VersionDescription = output["versionDescription"];
+    contents.VersionDescription = __expectString(output["versionDescription"]);
   }
   if (output["createTime"] !== undefined) {
     contents.CreateTime = new Date(output["createTime"]);
   }
   if (output["createdBy"] !== undefined) {
-    contents.CreatedBy = output["createdBy"];
+    contents.CreatedBy = __expectString(output["createdBy"]);
   }
   if (output["defaultVersion"] !== undefined) {
     contents.DefaultVersion = __parseBoolean(output["defaultVersion"]);
@@ -62258,7 +62263,7 @@ const deserializeAws_ec2LicenseConfiguration = (output: any, context: __SerdeCon
     LicenseConfigurationArn: undefined,
   };
   if (output["licenseConfigurationArn"] !== undefined) {
-    contents.LicenseConfigurationArn = output["licenseConfigurationArn"];
+    contents.LicenseConfigurationArn = __expectString(output["licenseConfigurationArn"]);
   }
   return contents;
 };
@@ -62297,10 +62302,10 @@ const deserializeAws_ec2LoadPermission = (output: any, context: __SerdeContext):
     Group: undefined,
   };
   if (output["userId"] !== undefined) {
-    contents.UserId = output["userId"];
+    contents.UserId = __expectString(output["userId"]);
   }
   if (output["group"] !== undefined) {
-    contents.Group = output["group"];
+    contents.Group = __expectString(output["group"]);
   }
   return contents;
 };
@@ -62325,16 +62330,16 @@ const deserializeAws_ec2LocalGateway = (output: any, context: __SerdeContext): L
     Tags: undefined,
   };
   if (output["localGatewayId"] !== undefined) {
-    contents.LocalGatewayId = output["localGatewayId"];
+    contents.LocalGatewayId = __expectString(output["localGatewayId"]);
   }
   if (output["outpostArn"] !== undefined) {
-    contents.OutpostArn = output["outpostArn"];
+    contents.OutpostArn = __expectString(output["outpostArn"]);
   }
   if (output["ownerId"] !== undefined) {
-    contents.OwnerId = output["ownerId"];
+    contents.OwnerId = __expectString(output["ownerId"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -62356,25 +62361,25 @@ const deserializeAws_ec2LocalGatewayRoute = (output: any, context: __SerdeContex
     OwnerId: undefined,
   };
   if (output["destinationCidrBlock"] !== undefined) {
-    contents.DestinationCidrBlock = output["destinationCidrBlock"];
+    contents.DestinationCidrBlock = __expectString(output["destinationCidrBlock"]);
   }
   if (output["localGatewayVirtualInterfaceGroupId"] !== undefined) {
-    contents.LocalGatewayVirtualInterfaceGroupId = output["localGatewayVirtualInterfaceGroupId"];
+    contents.LocalGatewayVirtualInterfaceGroupId = __expectString(output["localGatewayVirtualInterfaceGroupId"]);
   }
   if (output["type"] !== undefined) {
-    contents.Type = output["type"];
+    contents.Type = __expectString(output["type"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output["localGatewayRouteTableId"] !== undefined) {
-    contents.LocalGatewayRouteTableId = output["localGatewayRouteTableId"];
+    contents.LocalGatewayRouteTableId = __expectString(output["localGatewayRouteTableId"]);
   }
   if (output["localGatewayRouteTableArn"] !== undefined) {
-    contents.LocalGatewayRouteTableArn = output["localGatewayRouteTableArn"];
+    contents.LocalGatewayRouteTableArn = __expectString(output["localGatewayRouteTableArn"]);
   }
   if (output["ownerId"] !== undefined) {
-    contents.OwnerId = output["ownerId"];
+    contents.OwnerId = __expectString(output["ownerId"]);
   }
   return contents;
 };
@@ -62401,22 +62406,22 @@ const deserializeAws_ec2LocalGatewayRouteTable = (output: any, context: __SerdeC
     Tags: undefined,
   };
   if (output["localGatewayRouteTableId"] !== undefined) {
-    contents.LocalGatewayRouteTableId = output["localGatewayRouteTableId"];
+    contents.LocalGatewayRouteTableId = __expectString(output["localGatewayRouteTableId"]);
   }
   if (output["localGatewayRouteTableArn"] !== undefined) {
-    contents.LocalGatewayRouteTableArn = output["localGatewayRouteTableArn"];
+    contents.LocalGatewayRouteTableArn = __expectString(output["localGatewayRouteTableArn"]);
   }
   if (output["localGatewayId"] !== undefined) {
-    contents.LocalGatewayId = output["localGatewayId"];
+    contents.LocalGatewayId = __expectString(output["localGatewayId"]);
   }
   if (output["outpostArn"] !== undefined) {
-    contents.OutpostArn = output["outpostArn"];
+    contents.OutpostArn = __expectString(output["outpostArn"]);
   }
   if (output["ownerId"] !== undefined) {
-    contents.OwnerId = output["ownerId"];
+    contents.OwnerId = __expectString(output["ownerId"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -62456,26 +62461,27 @@ const deserializeAws_ec2LocalGatewayRouteTableVirtualInterfaceGroupAssociation =
     Tags: undefined,
   };
   if (output["localGatewayRouteTableVirtualInterfaceGroupAssociationId"] !== undefined) {
-    contents.LocalGatewayRouteTableVirtualInterfaceGroupAssociationId =
-      output["localGatewayRouteTableVirtualInterfaceGroupAssociationId"];
+    contents.LocalGatewayRouteTableVirtualInterfaceGroupAssociationId = __expectString(
+      output["localGatewayRouteTableVirtualInterfaceGroupAssociationId"]
+    );
   }
   if (output["localGatewayVirtualInterfaceGroupId"] !== undefined) {
-    contents.LocalGatewayVirtualInterfaceGroupId = output["localGatewayVirtualInterfaceGroupId"];
+    contents.LocalGatewayVirtualInterfaceGroupId = __expectString(output["localGatewayVirtualInterfaceGroupId"]);
   }
   if (output["localGatewayId"] !== undefined) {
-    contents.LocalGatewayId = output["localGatewayId"];
+    contents.LocalGatewayId = __expectString(output["localGatewayId"]);
   }
   if (output["localGatewayRouteTableId"] !== undefined) {
-    contents.LocalGatewayRouteTableId = output["localGatewayRouteTableId"];
+    contents.LocalGatewayRouteTableId = __expectString(output["localGatewayRouteTableId"]);
   }
   if (output["localGatewayRouteTableArn"] !== undefined) {
-    contents.LocalGatewayRouteTableArn = output["localGatewayRouteTableArn"];
+    contents.LocalGatewayRouteTableArn = __expectString(output["localGatewayRouteTableArn"]);
   }
   if (output["ownerId"] !== undefined) {
-    contents.OwnerId = output["ownerId"];
+    contents.OwnerId = __expectString(output["ownerId"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -62515,25 +62521,25 @@ const deserializeAws_ec2LocalGatewayRouteTableVpcAssociation = (
     Tags: undefined,
   };
   if (output["localGatewayRouteTableVpcAssociationId"] !== undefined) {
-    contents.LocalGatewayRouteTableVpcAssociationId = output["localGatewayRouteTableVpcAssociationId"];
+    contents.LocalGatewayRouteTableVpcAssociationId = __expectString(output["localGatewayRouteTableVpcAssociationId"]);
   }
   if (output["localGatewayRouteTableId"] !== undefined) {
-    contents.LocalGatewayRouteTableId = output["localGatewayRouteTableId"];
+    contents.LocalGatewayRouteTableId = __expectString(output["localGatewayRouteTableId"]);
   }
   if (output["localGatewayRouteTableArn"] !== undefined) {
-    contents.LocalGatewayRouteTableArn = output["localGatewayRouteTableArn"];
+    contents.LocalGatewayRouteTableArn = __expectString(output["localGatewayRouteTableArn"]);
   }
   if (output["localGatewayId"] !== undefined) {
-    contents.LocalGatewayId = output["localGatewayId"];
+    contents.LocalGatewayId = __expectString(output["localGatewayId"]);
   }
   if (output["vpcId"] !== undefined) {
-    contents.VpcId = output["vpcId"];
+    contents.VpcId = __expectString(output["vpcId"]);
   }
   if (output["ownerId"] !== undefined) {
-    contents.OwnerId = output["ownerId"];
+    contents.OwnerId = __expectString(output["ownerId"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -62585,19 +62591,19 @@ const deserializeAws_ec2LocalGatewayVirtualInterface = (
     Tags: undefined,
   };
   if (output["localGatewayVirtualInterfaceId"] !== undefined) {
-    contents.LocalGatewayVirtualInterfaceId = output["localGatewayVirtualInterfaceId"];
+    contents.LocalGatewayVirtualInterfaceId = __expectString(output["localGatewayVirtualInterfaceId"]);
   }
   if (output["localGatewayId"] !== undefined) {
-    contents.LocalGatewayId = output["localGatewayId"];
+    contents.LocalGatewayId = __expectString(output["localGatewayId"]);
   }
   if (output["vlan"] !== undefined) {
     contents.Vlan = parseInt(output["vlan"]);
   }
   if (output["localAddress"] !== undefined) {
-    contents.LocalAddress = output["localAddress"];
+    contents.LocalAddress = __expectString(output["localAddress"]);
   }
   if (output["peerAddress"] !== undefined) {
-    contents.PeerAddress = output["peerAddress"];
+    contents.PeerAddress = __expectString(output["peerAddress"]);
   }
   if (output["localBgpAsn"] !== undefined) {
     contents.LocalBgpAsn = parseInt(output["localBgpAsn"]);
@@ -62606,7 +62612,7 @@ const deserializeAws_ec2LocalGatewayVirtualInterface = (
     contents.PeerBgpAsn = parseInt(output["peerBgpAsn"]);
   }
   if (output["ownerId"] !== undefined) {
-    contents.OwnerId = output["ownerId"];
+    contents.OwnerId = __expectString(output["ownerId"]);
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -62629,7 +62635,7 @@ const deserializeAws_ec2LocalGatewayVirtualInterfaceGroup = (
     Tags: undefined,
   };
   if (output["localGatewayVirtualInterfaceGroupId"] !== undefined) {
-    contents.LocalGatewayVirtualInterfaceGroupId = output["localGatewayVirtualInterfaceGroupId"];
+    contents.LocalGatewayVirtualInterfaceGroupId = __expectString(output["localGatewayVirtualInterfaceGroupId"]);
   }
   if (output.localGatewayVirtualInterfaceIdSet === "") {
     contents.LocalGatewayVirtualInterfaceIds = [];
@@ -62644,10 +62650,10 @@ const deserializeAws_ec2LocalGatewayVirtualInterfaceGroup = (
     );
   }
   if (output["localGatewayId"] !== undefined) {
-    contents.LocalGatewayId = output["localGatewayId"];
+    contents.LocalGatewayId = __expectString(output["localGatewayId"]);
   }
   if (output["ownerId"] !== undefined) {
-    contents.OwnerId = output["ownerId"];
+    contents.OwnerId = __expectString(output["ownerId"]);
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -62679,7 +62685,7 @@ const deserializeAws_ec2LocalGatewayVirtualInterfaceIdSet = (output: any, contex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -62711,22 +62717,22 @@ const deserializeAws_ec2ManagedPrefixList = (output: any, context: __SerdeContex
     OwnerId: undefined,
   };
   if (output["prefixListId"] !== undefined) {
-    contents.PrefixListId = output["prefixListId"];
+    contents.PrefixListId = __expectString(output["prefixListId"]);
   }
   if (output["addressFamily"] !== undefined) {
-    contents.AddressFamily = output["addressFamily"];
+    contents.AddressFamily = __expectString(output["addressFamily"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output["stateMessage"] !== undefined) {
-    contents.StateMessage = output["stateMessage"];
+    contents.StateMessage = __expectString(output["stateMessage"]);
   }
   if (output["prefixListArn"] !== undefined) {
-    contents.PrefixListArn = output["prefixListArn"];
+    contents.PrefixListArn = __expectString(output["prefixListArn"]);
   }
   if (output["prefixListName"] !== undefined) {
-    contents.PrefixListName = output["prefixListName"];
+    contents.PrefixListName = __expectString(output["prefixListName"]);
   }
   if (output["maxEntries"] !== undefined) {
     contents.MaxEntries = parseInt(output["maxEntries"]);
@@ -62741,7 +62747,7 @@ const deserializeAws_ec2ManagedPrefixList = (output: any, context: __SerdeContex
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["ownerId"] !== undefined) {
-    contents.OwnerId = output["ownerId"];
+    contents.OwnerId = __expectString(output["ownerId"]);
   }
   return contents;
 };
@@ -62843,7 +62849,7 @@ const deserializeAws_ec2ModifyEbsDefaultKmsKeyIdResult = (
     KmsKeyId: undefined,
   };
   if (output["kmsKeyId"] !== undefined) {
-    contents.KmsKeyId = output["kmsKeyId"];
+    contents.KmsKeyId = __expectString(output["kmsKeyId"]);
   }
   return contents;
 };
@@ -62967,7 +62973,7 @@ const deserializeAws_ec2ModifyInstanceMetadataOptionsResult = (
     InstanceMetadataOptions: undefined,
   };
   if (output["instanceId"] !== undefined) {
-    contents.InstanceId = output["instanceId"];
+    contents.InstanceId = __expectString(output["instanceId"]);
   }
   if (output["instanceMetadataOptions"] !== undefined) {
     contents.InstanceMetadataOptions = deserializeAws_ec2InstanceMetadataOptionsResponse(
@@ -63025,7 +63031,7 @@ const deserializeAws_ec2ModifyReservedInstancesResult = (
     ReservedInstancesModificationId: undefined,
   };
   if (output["reservedInstancesModificationId"] !== undefined) {
-    contents.ReservedInstancesModificationId = output["reservedInstancesModificationId"];
+    contents.ReservedInstancesModificationId = __expectString(output["reservedInstancesModificationId"]);
   }
   return contents;
 };
@@ -63279,7 +63285,7 @@ const deserializeAws_ec2Monitoring = (output: any, context: __SerdeContext): Mon
     State: undefined,
   };
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   return contents;
 };
@@ -63306,10 +63312,10 @@ const deserializeAws_ec2MoveAddressToVpcResult = (output: any, context: __SerdeC
     Status: undefined,
   };
   if (output["allocationId"] !== undefined) {
-    contents.AllocationId = output["allocationId"];
+    contents.AllocationId = __expectString(output["allocationId"]);
   }
   if (output["status"] !== undefined) {
-    contents.Status = output["status"];
+    contents.Status = __expectString(output["status"]);
   }
   return contents;
 };
@@ -63320,10 +63326,10 @@ const deserializeAws_ec2MovingAddressStatus = (output: any, context: __SerdeCont
     PublicIp: undefined,
   };
   if (output["moveStatus"] !== undefined) {
-    contents.MoveStatus = output["moveStatus"];
+    contents.MoveStatus = __expectString(output["moveStatus"]);
   }
   if (output["publicIp"] !== undefined) {
-    contents.PublicIp = output["publicIp"];
+    contents.PublicIp = __expectString(output["publicIp"]);
   }
   return contents;
 };
@@ -63361,10 +63367,10 @@ const deserializeAws_ec2NatGateway = (output: any, context: __SerdeContext): Nat
     contents.DeleteTime = new Date(output["deleteTime"]);
   }
   if (output["failureCode"] !== undefined) {
-    contents.FailureCode = output["failureCode"];
+    contents.FailureCode = __expectString(output["failureCode"]);
   }
   if (output["failureMessage"] !== undefined) {
-    contents.FailureMessage = output["failureMessage"];
+    contents.FailureMessage = __expectString(output["failureMessage"]);
   }
   if (output.natGatewayAddressSet === "") {
     contents.NatGatewayAddresses = [];
@@ -63376,19 +63382,19 @@ const deserializeAws_ec2NatGateway = (output: any, context: __SerdeContext): Nat
     );
   }
   if (output["natGatewayId"] !== undefined) {
-    contents.NatGatewayId = output["natGatewayId"];
+    contents.NatGatewayId = __expectString(output["natGatewayId"]);
   }
   if (output["provisionedBandwidth"] !== undefined) {
     contents.ProvisionedBandwidth = deserializeAws_ec2ProvisionedBandwidth(output["provisionedBandwidth"], context);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output["subnetId"] !== undefined) {
-    contents.SubnetId = output["subnetId"];
+    contents.SubnetId = __expectString(output["subnetId"]);
   }
   if (output["vpcId"] !== undefined) {
-    contents.VpcId = output["vpcId"];
+    contents.VpcId = __expectString(output["vpcId"]);
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -63397,7 +63403,7 @@ const deserializeAws_ec2NatGateway = (output: any, context: __SerdeContext): Nat
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["connectivityType"] !== undefined) {
-    contents.ConnectivityType = output["connectivityType"];
+    contents.ConnectivityType = __expectString(output["connectivityType"]);
   }
   return contents;
 };
@@ -63410,16 +63416,16 @@ const deserializeAws_ec2NatGatewayAddress = (output: any, context: __SerdeContex
     PublicIp: undefined,
   };
   if (output["allocationId"] !== undefined) {
-    contents.AllocationId = output["allocationId"];
+    contents.AllocationId = __expectString(output["allocationId"]);
   }
   if (output["networkInterfaceId"] !== undefined) {
-    contents.NetworkInterfaceId = output["networkInterfaceId"];
+    contents.NetworkInterfaceId = __expectString(output["networkInterfaceId"]);
   }
   if (output["privateIp"] !== undefined) {
-    contents.PrivateIp = output["privateIp"];
+    contents.PrivateIp = __expectString(output["privateIp"]);
   }
   if (output["publicIp"] !== undefined) {
-    contents.PublicIp = output["publicIp"];
+    contents.PublicIp = __expectString(output["publicIp"]);
   }
   return contents;
 };
@@ -63478,7 +63484,7 @@ const deserializeAws_ec2NetworkAcl = (output: any, context: __SerdeContext): Net
     contents.IsDefault = __parseBoolean(output["default"]);
   }
   if (output["networkAclId"] !== undefined) {
-    contents.NetworkAclId = output["networkAclId"];
+    contents.NetworkAclId = __expectString(output["networkAclId"]);
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -63487,10 +63493,10 @@ const deserializeAws_ec2NetworkAcl = (output: any, context: __SerdeContext): Net
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["vpcId"] !== undefined) {
-    contents.VpcId = output["vpcId"];
+    contents.VpcId = __expectString(output["vpcId"]);
   }
   if (output["ownerId"] !== undefined) {
-    contents.OwnerId = output["ownerId"];
+    contents.OwnerId = __expectString(output["ownerId"]);
   }
   return contents;
 };
@@ -63502,13 +63508,13 @@ const deserializeAws_ec2NetworkAclAssociation = (output: any, context: __SerdeCo
     SubnetId: undefined,
   };
   if (output["networkAclAssociationId"] !== undefined) {
-    contents.NetworkAclAssociationId = output["networkAclAssociationId"];
+    contents.NetworkAclAssociationId = __expectString(output["networkAclAssociationId"]);
   }
   if (output["networkAclId"] !== undefined) {
-    contents.NetworkAclId = output["networkAclId"];
+    contents.NetworkAclId = __expectString(output["networkAclId"]);
   }
   if (output["subnetId"] !== undefined) {
-    contents.SubnetId = output["subnetId"];
+    contents.SubnetId = __expectString(output["subnetId"]);
   }
   return contents;
 };
@@ -63536,7 +63542,7 @@ const deserializeAws_ec2NetworkAclEntry = (output: any, context: __SerdeContext)
     RuleNumber: undefined,
   };
   if (output["cidrBlock"] !== undefined) {
-    contents.CidrBlock = output["cidrBlock"];
+    contents.CidrBlock = __expectString(output["cidrBlock"]);
   }
   if (output["egress"] !== undefined) {
     contents.Egress = __parseBoolean(output["egress"]);
@@ -63545,16 +63551,16 @@ const deserializeAws_ec2NetworkAclEntry = (output: any, context: __SerdeContext)
     contents.IcmpTypeCode = deserializeAws_ec2IcmpTypeCode(output["icmpTypeCode"], context);
   }
   if (output["ipv6CidrBlock"] !== undefined) {
-    contents.Ipv6CidrBlock = output["ipv6CidrBlock"];
+    contents.Ipv6CidrBlock = __expectString(output["ipv6CidrBlock"]);
   }
   if (output["portRange"] !== undefined) {
     contents.PortRange = deserializeAws_ec2PortRange(output["portRange"], context);
   }
   if (output["protocol"] !== undefined) {
-    contents.Protocol = output["protocol"];
+    contents.Protocol = __expectString(output["protocol"]);
   }
   if (output["ruleAction"] !== undefined) {
-    contents.RuleAction = output["ruleAction"];
+    contents.RuleAction = __expectString(output["ruleAction"]);
   }
   if (output["ruleNumber"] !== undefined) {
     contents.RuleNumber = parseInt(output["ruleNumber"]);
@@ -63594,7 +63600,7 @@ const deserializeAws_ec2NetworkCardInfo = (output: any, context: __SerdeContext)
     contents.NetworkCardIndex = parseInt(output["networkCardIndex"]);
   }
   if (output["networkPerformance"] !== undefined) {
-    contents.NetworkPerformance = output["networkPerformance"];
+    contents.NetworkPerformance = __expectString(output["networkPerformance"]);
   }
   if (output["maximumNetworkInterfaces"] !== undefined) {
     contents.MaximumNetworkInterfaces = parseInt(output["maximumNetworkInterfaces"]);
@@ -63628,7 +63634,7 @@ const deserializeAws_ec2NetworkInfo = (output: any, context: __SerdeContext): Ne
     EfaInfo: undefined,
   };
   if (output["networkPerformance"] !== undefined) {
-    contents.NetworkPerformance = output["networkPerformance"];
+    contents.NetworkPerformance = __expectString(output["networkPerformance"]);
   }
   if (output["maximumNetworkInterfaces"] !== undefined) {
     contents.MaximumNetworkInterfaces = parseInt(output["maximumNetworkInterfaces"]);
@@ -63658,7 +63664,7 @@ const deserializeAws_ec2NetworkInfo = (output: any, context: __SerdeContext): Ne
     contents.Ipv6Supported = __parseBoolean(output["ipv6Supported"]);
   }
   if (output["enaSupport"] !== undefined) {
-    contents.EnaSupport = output["enaSupport"];
+    contents.EnaSupport = __expectString(output["enaSupport"]);
   }
   if (output["efaSupported"] !== undefined) {
     contents.EfaSupported = __parseBoolean(output["efaSupported"]);
@@ -63686,13 +63692,13 @@ const deserializeAws_ec2NetworkInsightsAnalysis = (output: any, context: __Serde
     Tags: undefined,
   };
   if (output["networkInsightsAnalysisId"] !== undefined) {
-    contents.NetworkInsightsAnalysisId = output["networkInsightsAnalysisId"];
+    contents.NetworkInsightsAnalysisId = __expectString(output["networkInsightsAnalysisId"]);
   }
   if (output["networkInsightsAnalysisArn"] !== undefined) {
-    contents.NetworkInsightsAnalysisArn = output["networkInsightsAnalysisArn"];
+    contents.NetworkInsightsAnalysisArn = __expectString(output["networkInsightsAnalysisArn"]);
   }
   if (output["networkInsightsPathId"] !== undefined) {
-    contents.NetworkInsightsPathId = output["networkInsightsPathId"];
+    contents.NetworkInsightsPathId = __expectString(output["networkInsightsPathId"]);
   }
   if (output.filterInArnSet === "") {
     contents.FilterInArns = [];
@@ -63707,10 +63713,10 @@ const deserializeAws_ec2NetworkInsightsAnalysis = (output: any, context: __Serde
     contents.StartDate = new Date(output["startDate"]);
   }
   if (output["status"] !== undefined) {
-    contents.Status = output["status"];
+    contents.Status = __expectString(output["status"]);
   }
   if (output["statusMessage"] !== undefined) {
-    contents.StatusMessage = output["statusMessage"];
+    contents.StatusMessage = __expectString(output["statusMessage"]);
   }
   if (output["networkPathFound"] !== undefined) {
     contents.NetworkPathFound = __parseBoolean(output["networkPathFound"]);
@@ -63788,28 +63794,28 @@ const deserializeAws_ec2NetworkInsightsPath = (output: any, context: __SerdeCont
     Tags: undefined,
   };
   if (output["networkInsightsPathId"] !== undefined) {
-    contents.NetworkInsightsPathId = output["networkInsightsPathId"];
+    contents.NetworkInsightsPathId = __expectString(output["networkInsightsPathId"]);
   }
   if (output["networkInsightsPathArn"] !== undefined) {
-    contents.NetworkInsightsPathArn = output["networkInsightsPathArn"];
+    contents.NetworkInsightsPathArn = __expectString(output["networkInsightsPathArn"]);
   }
   if (output["createdDate"] !== undefined) {
     contents.CreatedDate = new Date(output["createdDate"]);
   }
   if (output["source"] !== undefined) {
-    contents.Source = output["source"];
+    contents.Source = __expectString(output["source"]);
   }
   if (output["destination"] !== undefined) {
-    contents.Destination = output["destination"];
+    contents.Destination = __expectString(output["destination"]);
   }
   if (output["sourceIp"] !== undefined) {
-    contents.SourceIp = output["sourceIp"];
+    contents.SourceIp = __expectString(output["sourceIp"]);
   }
   if (output["destinationIp"] !== undefined) {
-    contents.DestinationIp = output["destinationIp"];
+    contents.DestinationIp = __expectString(output["destinationIp"]);
   }
   if (output["protocol"] !== undefined) {
-    contents.Protocol = output["protocol"];
+    contents.Protocol = __expectString(output["protocol"]);
   }
   if (output["destinationPort"] !== undefined) {
     contents.DestinationPort = parseInt(output["destinationPort"]);
@@ -63865,10 +63871,10 @@ const deserializeAws_ec2NetworkInterface = (output: any, context: __SerdeContext
     contents.Attachment = deserializeAws_ec2NetworkInterfaceAttachment(output["attachment"], context);
   }
   if (output["availabilityZone"] !== undefined) {
-    contents.AvailabilityZone = output["availabilityZone"];
+    contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
   if (output["description"] !== undefined) {
-    contents.Description = output["description"];
+    contents.Description = __expectString(output["description"]);
   }
   if (output.groupSet === "") {
     contents.Groups = [];
@@ -63880,7 +63886,7 @@ const deserializeAws_ec2NetworkInterface = (output: any, context: __SerdeContext
     );
   }
   if (output["interfaceType"] !== undefined) {
-    contents.InterfaceType = output["interfaceType"];
+    contents.InterfaceType = __expectString(output["interfaceType"]);
   }
   if (output.ipv6AddressesSet === "") {
     contents.Ipv6Addresses = [];
@@ -63892,22 +63898,22 @@ const deserializeAws_ec2NetworkInterface = (output: any, context: __SerdeContext
     );
   }
   if (output["macAddress"] !== undefined) {
-    contents.MacAddress = output["macAddress"];
+    contents.MacAddress = __expectString(output["macAddress"]);
   }
   if (output["networkInterfaceId"] !== undefined) {
-    contents.NetworkInterfaceId = output["networkInterfaceId"];
+    contents.NetworkInterfaceId = __expectString(output["networkInterfaceId"]);
   }
   if (output["outpostArn"] !== undefined) {
-    contents.OutpostArn = output["outpostArn"];
+    contents.OutpostArn = __expectString(output["outpostArn"]);
   }
   if (output["ownerId"] !== undefined) {
-    contents.OwnerId = output["ownerId"];
+    contents.OwnerId = __expectString(output["ownerId"]);
   }
   if (output["privateDnsName"] !== undefined) {
-    contents.PrivateDnsName = output["privateDnsName"];
+    contents.PrivateDnsName = __expectString(output["privateDnsName"]);
   }
   if (output["privateIpAddress"] !== undefined) {
-    contents.PrivateIpAddress = output["privateIpAddress"];
+    contents.PrivateIpAddress = __expectString(output["privateIpAddress"]);
   }
   if (output.privateIpAddressesSet === "") {
     contents.PrivateIpAddresses = [];
@@ -63919,7 +63925,7 @@ const deserializeAws_ec2NetworkInterface = (output: any, context: __SerdeContext
     );
   }
   if (output["requesterId"] !== undefined) {
-    contents.RequesterId = output["requesterId"];
+    contents.RequesterId = __expectString(output["requesterId"]);
   }
   if (output["requesterManaged"] !== undefined) {
     contents.RequesterManaged = __parseBoolean(output["requesterManaged"]);
@@ -63928,10 +63934,10 @@ const deserializeAws_ec2NetworkInterface = (output: any, context: __SerdeContext
     contents.SourceDestCheck = __parseBoolean(output["sourceDestCheck"]);
   }
   if (output["status"] !== undefined) {
-    contents.Status = output["status"];
+    contents.Status = __expectString(output["status"]);
   }
   if (output["subnetId"] !== undefined) {
-    contents.SubnetId = output["subnetId"];
+    contents.SubnetId = __expectString(output["subnetId"]);
   }
   if (output.tagSet === "") {
     contents.TagSet = [];
@@ -63940,7 +63946,7 @@ const deserializeAws_ec2NetworkInterface = (output: any, context: __SerdeContext
     contents.TagSet = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["vpcId"] !== undefined) {
-    contents.VpcId = output["vpcId"];
+    contents.VpcId = __expectString(output["vpcId"]);
   }
   return contents;
 };
@@ -63959,25 +63965,25 @@ const deserializeAws_ec2NetworkInterfaceAssociation = (
     CarrierIp: undefined,
   };
   if (output["allocationId"] !== undefined) {
-    contents.AllocationId = output["allocationId"];
+    contents.AllocationId = __expectString(output["allocationId"]);
   }
   if (output["associationId"] !== undefined) {
-    contents.AssociationId = output["associationId"];
+    contents.AssociationId = __expectString(output["associationId"]);
   }
   if (output["ipOwnerId"] !== undefined) {
-    contents.IpOwnerId = output["ipOwnerId"];
+    contents.IpOwnerId = __expectString(output["ipOwnerId"]);
   }
   if (output["publicDnsName"] !== undefined) {
-    contents.PublicDnsName = output["publicDnsName"];
+    contents.PublicDnsName = __expectString(output["publicDnsName"]);
   }
   if (output["publicIp"] !== undefined) {
-    contents.PublicIp = output["publicIp"];
+    contents.PublicIp = __expectString(output["publicIp"]);
   }
   if (output["customerOwnedIp"] !== undefined) {
-    contents.CustomerOwnedIp = output["customerOwnedIp"];
+    contents.CustomerOwnedIp = __expectString(output["customerOwnedIp"]);
   }
   if (output["carrierIp"] !== undefined) {
-    contents.CarrierIp = output["carrierIp"];
+    contents.CarrierIp = __expectString(output["carrierIp"]);
   }
   return contents;
 };
@@ -64000,7 +64006,7 @@ const deserializeAws_ec2NetworkInterfaceAttachment = (
     contents.AttachTime = new Date(output["attachTime"]);
   }
   if (output["attachmentId"] !== undefined) {
-    contents.AttachmentId = output["attachmentId"];
+    contents.AttachmentId = __expectString(output["attachmentId"]);
   }
   if (output["deleteOnTermination"] !== undefined) {
     contents.DeleteOnTermination = __parseBoolean(output["deleteOnTermination"]);
@@ -64012,13 +64018,13 @@ const deserializeAws_ec2NetworkInterfaceAttachment = (
     contents.NetworkCardIndex = parseInt(output["networkCardIndex"]);
   }
   if (output["instanceId"] !== undefined) {
-    contents.InstanceId = output["instanceId"];
+    contents.InstanceId = __expectString(output["instanceId"]);
   }
   if (output["instanceOwnerId"] !== undefined) {
-    contents.InstanceOwnerId = output["instanceOwnerId"];
+    contents.InstanceOwnerId = __expectString(output["instanceOwnerId"]);
   }
   if (output["status"] !== undefined) {
-    contents.Status = output["status"];
+    contents.Status = __expectString(output["status"]);
   }
   return contents;
 };
@@ -64031,7 +64037,7 @@ const deserializeAws_ec2NetworkInterfaceIpv6Address = (
     Ipv6Address: undefined,
   };
   if (output["ipv6Address"] !== undefined) {
-    contents.Ipv6Address = output["ipv6Address"];
+    contents.Ipv6Address = __expectString(output["ipv6Address"]);
   }
   return contents;
 };
@@ -64074,19 +64080,19 @@ const deserializeAws_ec2NetworkInterfacePermission = (
     PermissionState: undefined,
   };
   if (output["networkInterfacePermissionId"] !== undefined) {
-    contents.NetworkInterfacePermissionId = output["networkInterfacePermissionId"];
+    contents.NetworkInterfacePermissionId = __expectString(output["networkInterfacePermissionId"]);
   }
   if (output["networkInterfaceId"] !== undefined) {
-    contents.NetworkInterfaceId = output["networkInterfaceId"];
+    contents.NetworkInterfaceId = __expectString(output["networkInterfaceId"]);
   }
   if (output["awsAccountId"] !== undefined) {
-    contents.AwsAccountId = output["awsAccountId"];
+    contents.AwsAccountId = __expectString(output["awsAccountId"]);
   }
   if (output["awsService"] !== undefined) {
-    contents.AwsService = output["awsService"];
+    contents.AwsService = __expectString(output["awsService"]);
   }
   if (output["permission"] !== undefined) {
-    contents.Permission = output["permission"];
+    contents.Permission = __expectString(output["permission"]);
   }
   if (output["permissionState"] !== undefined) {
     contents.PermissionState = deserializeAws_ec2NetworkInterfacePermissionState(output["permissionState"], context);
@@ -64117,10 +64123,10 @@ const deserializeAws_ec2NetworkInterfacePermissionState = (
     StatusMessage: undefined,
   };
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output["statusMessage"] !== undefined) {
-    contents.StatusMessage = output["statusMessage"];
+    contents.StatusMessage = __expectString(output["statusMessage"]);
   }
   return contents;
 };
@@ -64142,10 +64148,10 @@ const deserializeAws_ec2NetworkInterfacePrivateIpAddress = (
     contents.Primary = __parseBoolean(output["primary"]);
   }
   if (output["privateDnsName"] !== undefined) {
-    contents.PrivateDnsName = output["privateDnsName"];
+    contents.PrivateDnsName = __expectString(output["privateDnsName"]);
   }
   if (output["privateIpAddress"] !== undefined) {
-    contents.PrivateIpAddress = output["privateIpAddress"];
+    contents.PrivateIpAddress = __expectString(output["privateIpAddress"]);
   }
   return contents;
 };
@@ -64185,7 +64191,7 @@ const deserializeAws_ec2OnDemandOptions = (output: any, context: __SerdeContext)
     MaxTotalPrice: undefined,
   };
   if (output["allocationStrategy"] !== undefined) {
-    contents.AllocationStrategy = output["allocationStrategy"];
+    contents.AllocationStrategy = __expectString(output["allocationStrategy"]);
   }
   if (output["capacityReservationOptions"] !== undefined) {
     contents.CapacityReservationOptions = deserializeAws_ec2CapacityReservationOptions(
@@ -64203,7 +64209,7 @@ const deserializeAws_ec2OnDemandOptions = (output: any, context: __SerdeContext)
     contents.MinTargetCapacity = parseInt(output["minTargetCapacity"]);
   }
   if (output["maxTotalPrice"] !== undefined) {
-    contents.MaxTotalPrice = output["maxTotalPrice"];
+    contents.MaxTotalPrice = __expectString(output["maxTotalPrice"]);
   }
   return contents;
 };
@@ -64277,16 +64283,16 @@ const deserializeAws_ec2PciId = (output: any, context: __SerdeContext): PciId =>
     SubsystemVendorId: undefined,
   };
   if (output["DeviceId"] !== undefined) {
-    contents.DeviceId = output["DeviceId"];
+    contents.DeviceId = __expectString(output["DeviceId"]);
   }
   if (output["VendorId"] !== undefined) {
-    contents.VendorId = output["VendorId"];
+    contents.VendorId = __expectString(output["VendorId"]);
   }
   if (output["SubsystemId"] !== undefined) {
-    contents.SubsystemId = output["SubsystemId"];
+    contents.SubsystemId = __expectString(output["SubsystemId"]);
   }
   if (output["SubsystemVendorId"] !== undefined) {
-    contents.SubsystemVendorId = output["SubsystemVendorId"];
+    contents.SubsystemVendorId = __expectString(output["SubsystemVendorId"]);
   }
   return contents;
 };
@@ -64297,10 +64303,10 @@ const deserializeAws_ec2PeeringAttachmentStatus = (output: any, context: __Serde
     Message: undefined,
   };
   if (output["code"] !== undefined) {
-    contents.Code = output["code"];
+    contents.Code = __expectString(output["code"]);
   }
   if (output["message"] !== undefined) {
-    contents.Message = output["message"];
+    contents.Message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -64334,13 +64340,13 @@ const deserializeAws_ec2PeeringTgwInfo = (output: any, context: __SerdeContext):
     Region: undefined,
   };
   if (output["transitGatewayId"] !== undefined) {
-    contents.TransitGatewayId = output["transitGatewayId"];
+    contents.TransitGatewayId = __expectString(output["transitGatewayId"]);
   }
   if (output["ownerId"] !== undefined) {
-    contents.OwnerId = output["ownerId"];
+    contents.OwnerId = __expectString(output["ownerId"]);
   }
   if (output["region"] !== undefined) {
-    contents.Region = output["region"];
+    contents.Region = __expectString(output["region"]);
   }
   return contents;
 };
@@ -64394,7 +64400,7 @@ const deserializeAws_ec2Phase1EncryptionAlgorithmsListValue = (
     Value: undefined,
   };
   if (output["value"] !== undefined) {
-    contents.Value = output["value"];
+    contents.Value = __expectString(output["value"]);
   }
   return contents;
 };
@@ -64421,7 +64427,7 @@ const deserializeAws_ec2Phase1IntegrityAlgorithmsListValue = (
     Value: undefined,
   };
   if (output["value"] !== undefined) {
-    contents.Value = output["value"];
+    contents.Value = __expectString(output["value"]);
   }
   return contents;
 };
@@ -64475,7 +64481,7 @@ const deserializeAws_ec2Phase2EncryptionAlgorithmsListValue = (
     Value: undefined,
   };
   if (output["value"] !== undefined) {
-    contents.Value = output["value"];
+    contents.Value = __expectString(output["value"]);
   }
   return contents;
 };
@@ -64502,7 +64508,7 @@ const deserializeAws_ec2Phase2IntegrityAlgorithmsListValue = (
     Value: undefined,
   };
   if (output["value"] !== undefined) {
-    contents.Value = output["value"];
+    contents.Value = __expectString(output["value"]);
   }
   return contents;
 };
@@ -64519,28 +64525,28 @@ const deserializeAws_ec2Placement = (output: any, context: __SerdeContext): Plac
     HostResourceGroupArn: undefined,
   };
   if (output["availabilityZone"] !== undefined) {
-    contents.AvailabilityZone = output["availabilityZone"];
+    contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
   if (output["affinity"] !== undefined) {
-    contents.Affinity = output["affinity"];
+    contents.Affinity = __expectString(output["affinity"]);
   }
   if (output["groupName"] !== undefined) {
-    contents.GroupName = output["groupName"];
+    contents.GroupName = __expectString(output["groupName"]);
   }
   if (output["partitionNumber"] !== undefined) {
     contents.PartitionNumber = parseInt(output["partitionNumber"]);
   }
   if (output["hostId"] !== undefined) {
-    contents.HostId = output["hostId"];
+    contents.HostId = __expectString(output["hostId"]);
   }
   if (output["tenancy"] !== undefined) {
-    contents.Tenancy = output["tenancy"];
+    contents.Tenancy = __expectString(output["tenancy"]);
   }
   if (output["spreadDomain"] !== undefined) {
-    contents.SpreadDomain = output["spreadDomain"];
+    contents.SpreadDomain = __expectString(output["spreadDomain"]);
   }
   if (output["hostResourceGroupArn"] !== undefined) {
-    contents.HostResourceGroupArn = output["hostResourceGroupArn"];
+    contents.HostResourceGroupArn = __expectString(output["hostResourceGroupArn"]);
   }
   return contents;
 };
@@ -64555,19 +64561,19 @@ const deserializeAws_ec2PlacementGroup = (output: any, context: __SerdeContext):
     Tags: undefined,
   };
   if (output["groupName"] !== undefined) {
-    contents.GroupName = output["groupName"];
+    contents.GroupName = __expectString(output["groupName"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output["strategy"] !== undefined) {
-    contents.Strategy = output["strategy"];
+    contents.Strategy = __expectString(output["strategy"]);
   }
   if (output["partitionCount"] !== undefined) {
     contents.PartitionCount = parseInt(output["partitionCount"]);
   }
   if (output["groupId"] !== undefined) {
-    contents.GroupId = output["groupId"];
+    contents.GroupId = __expectString(output["groupId"]);
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -64615,7 +64621,7 @@ const deserializeAws_ec2PlacementGroupStrategyList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -64624,7 +64630,7 @@ const deserializeAws_ec2PlacementResponse = (output: any, context: __SerdeContex
     GroupName: undefined,
   };
   if (output["groupName"] !== undefined) {
-    contents.GroupName = output["groupName"];
+    contents.GroupName = __expectString(output["groupName"]);
   }
   return contents;
 };
@@ -64634,7 +64640,7 @@ const deserializeAws_ec2PoolCidrBlock = (output: any, context: __SerdeContext): 
     Cidr: undefined,
   };
   if (output["poolCidrBlock"] !== undefined) {
-    contents.Cidr = output["poolCidrBlock"];
+    contents.Cidr = __expectString(output["poolCidrBlock"]);
   }
   return contents;
 };
@@ -64688,10 +64694,10 @@ const deserializeAws_ec2PrefixList = (output: any, context: __SerdeContext): Pre
     contents.Cidrs = deserializeAws_ec2ValueStringList(__getArrayIfSingleItem(output["cidrSet"]["item"]), context);
   }
   if (output["prefixListId"] !== undefined) {
-    contents.PrefixListId = output["prefixListId"];
+    contents.PrefixListId = __expectString(output["prefixListId"]);
   }
   if (output["prefixListName"] !== undefined) {
-    contents.PrefixListName = output["prefixListName"];
+    contents.PrefixListName = __expectString(output["prefixListName"]);
   }
   return contents;
 };
@@ -64702,10 +64708,10 @@ const deserializeAws_ec2PrefixListAssociation = (output: any, context: __SerdeCo
     ResourceOwner: undefined,
   };
   if (output["resourceId"] !== undefined) {
-    contents.ResourceId = output["resourceId"];
+    contents.ResourceId = __expectString(output["resourceId"]);
   }
   if (output["resourceOwner"] !== undefined) {
-    contents.ResourceOwner = output["resourceOwner"];
+    contents.ResourceOwner = __expectString(output["resourceOwner"]);
   }
   return contents;
 };
@@ -64727,10 +64733,10 @@ const deserializeAws_ec2PrefixListEntry = (output: any, context: __SerdeContext)
     Description: undefined,
   };
   if (output["cidr"] !== undefined) {
-    contents.Cidr = output["cidr"];
+    contents.Cidr = __expectString(output["cidr"]);
   }
   if (output["description"] !== undefined) {
-    contents.Description = output["description"];
+    contents.Description = __expectString(output["description"]);
   }
   return contents;
 };
@@ -64752,10 +64758,10 @@ const deserializeAws_ec2PrefixListId = (output: any, context: __SerdeContext): P
     PrefixListId: undefined,
   };
   if (output["description"] !== undefined) {
-    contents.Description = output["description"];
+    contents.Description = __expectString(output["description"]);
   }
   if (output["prefixListId"] !== undefined) {
-    contents.PrefixListId = output["prefixListId"];
+    contents.PrefixListId = __expectString(output["prefixListId"]);
   }
   return contents;
 };
@@ -64778,7 +64784,7 @@ const deserializeAws_ec2PrefixListIdSet = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -64804,7 +64810,7 @@ const deserializeAws_ec2PriceSchedule = (output: any, context: __SerdeContext): 
     contents.Active = __parseBoolean(output["active"]);
   }
   if (output["currencyCode"] !== undefined) {
-    contents.CurrencyCode = output["currencyCode"];
+    contents.CurrencyCode = __expectString(output["currencyCode"]);
   }
   if (output["price"] !== undefined) {
     contents.Price = parseFloat(output["price"]);
@@ -64857,7 +64863,7 @@ const deserializeAws_ec2PrincipalIdFormat = (output: any, context: __SerdeContex
     Statuses: undefined,
   };
   if (output["arn"] !== undefined) {
-    contents.Arn = output["arn"];
+    contents.Arn = __expectString(output["arn"]);
   }
   if (output.statusSet === "") {
     contents.Statuses = [];
@@ -64884,7 +64890,7 @@ const deserializeAws_ec2PrivateDnsDetails = (output: any, context: __SerdeContex
     PrivateDnsName: undefined,
   };
   if (output["privateDnsName"] !== undefined) {
-    contents.PrivateDnsName = output["privateDnsName"];
+    contents.PrivateDnsName = __expectString(output["privateDnsName"]);
   }
   return contents;
 };
@@ -64911,16 +64917,16 @@ const deserializeAws_ec2PrivateDnsNameConfiguration = (
     Name: undefined,
   };
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output["type"] !== undefined) {
-    contents.Type = output["type"];
+    contents.Type = __expectString(output["type"]);
   }
   if (output["value"] !== undefined) {
-    contents.Value = output["value"];
+    contents.Value = __expectString(output["value"]);
   }
   if (output["name"] !== undefined) {
-    contents.Name = output["name"];
+    contents.Name = __expectString(output["name"]);
   }
   return contents;
 };
@@ -64937,7 +64943,7 @@ const deserializeAws_ec2PrivateIpAddressSpecification = (
     contents.Primary = __parseBoolean(output["primary"]);
   }
   if (output["privateIpAddress"] !== undefined) {
-    contents.PrivateIpAddress = output["privateIpAddress"];
+    contents.PrivateIpAddress = __expectString(output["privateIpAddress"]);
   }
   return contents;
 };
@@ -64982,10 +64988,10 @@ const deserializeAws_ec2ProductCode = (output: any, context: __SerdeContext): Pr
     ProductCodeType: undefined,
   };
   if (output["productCode"] !== undefined) {
-    contents.ProductCodeId = output["productCode"];
+    contents.ProductCodeId = __expectString(output["productCode"]);
   }
   if (output["type"] !== undefined) {
-    contents.ProductCodeType = output["type"];
+    contents.ProductCodeType = __expectString(output["type"]);
   }
   return contents;
 };
@@ -65006,7 +65012,7 @@ const deserializeAws_ec2PropagatingVgw = (output: any, context: __SerdeContext):
     GatewayId: undefined,
   };
   if (output["gatewayId"] !== undefined) {
-    contents.GatewayId = output["gatewayId"];
+    contents.GatewayId = __expectString(output["gatewayId"]);
   }
   return contents;
 };
@@ -65044,16 +65050,16 @@ const deserializeAws_ec2ProvisionedBandwidth = (output: any, context: __SerdeCon
     contents.ProvisionTime = new Date(output["provisionTime"]);
   }
   if (output["provisioned"] !== undefined) {
-    contents.Provisioned = output["provisioned"];
+    contents.Provisioned = __expectString(output["provisioned"]);
   }
   if (output["requestTime"] !== undefined) {
     contents.RequestTime = new Date(output["requestTime"]);
   }
   if (output["requested"] !== undefined) {
-    contents.Requested = output["requested"];
+    contents.Requested = __expectString(output["requested"]);
   }
   if (output["status"] !== undefined) {
-    contents.Status = output["status"];
+    contents.Status = __expectString(output["status"]);
   }
   return contents;
 };
@@ -65065,13 +65071,13 @@ const deserializeAws_ec2PtrUpdateStatus = (output: any, context: __SerdeContext)
     Reason: undefined,
   };
   if (output["value"] !== undefined) {
-    contents.Value = output["value"];
+    contents.Value = __expectString(output["value"]);
   }
   if (output["status"] !== undefined) {
-    contents.Status = output["status"];
+    contents.Status = __expectString(output["status"]);
   }
   if (output["reason"] !== undefined) {
-    contents.Reason = output["reason"];
+    contents.Reason = __expectString(output["reason"]);
   }
   return contents;
 };
@@ -65087,10 +65093,10 @@ const deserializeAws_ec2PublicIpv4Pool = (output: any, context: __SerdeContext):
     Tags: undefined,
   };
   if (output["poolId"] !== undefined) {
-    contents.PoolId = output["poolId"];
+    contents.PoolId = __expectString(output["poolId"]);
   }
   if (output["description"] !== undefined) {
-    contents.Description = output["description"];
+    contents.Description = __expectString(output["description"]);
   }
   if (output.poolAddressRangeSet === "") {
     contents.PoolAddressRanges = [];
@@ -65108,7 +65114,7 @@ const deserializeAws_ec2PublicIpv4Pool = (output: any, context: __SerdeContext):
     contents.TotalAvailableAddressCount = parseInt(output["totalAvailableAddressCount"]);
   }
   if (output["networkBorderGroup"] !== undefined) {
-    contents.NetworkBorderGroup = output["networkBorderGroup"];
+    contents.NetworkBorderGroup = __expectString(output["networkBorderGroup"]);
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -65127,10 +65133,10 @@ const deserializeAws_ec2PublicIpv4PoolRange = (output: any, context: __SerdeCont
     AvailableAddressCount: undefined,
   };
   if (output["firstAddress"] !== undefined) {
-    contents.FirstAddress = output["firstAddress"];
+    contents.FirstAddress = __expectString(output["firstAddress"]);
   }
   if (output["lastAddress"] !== undefined) {
-    contents.LastAddress = output["lastAddress"];
+    contents.LastAddress = __expectString(output["lastAddress"]);
   }
   if (output["addressCount"] !== undefined) {
     contents.AddressCount = parseInt(output["addressCount"]);
@@ -65175,7 +65181,7 @@ const deserializeAws_ec2Purchase = (output: any, context: __SerdeContext): Purch
     UpfrontPrice: undefined,
   };
   if (output["currencyCode"] !== undefined) {
-    contents.CurrencyCode = output["currencyCode"];
+    contents.CurrencyCode = __expectString(output["currencyCode"]);
   }
   if (output["duration"] !== undefined) {
     contents.Duration = parseInt(output["duration"]);
@@ -65190,19 +65196,19 @@ const deserializeAws_ec2Purchase = (output: any, context: __SerdeContext): Purch
     );
   }
   if (output["hostReservationId"] !== undefined) {
-    contents.HostReservationId = output["hostReservationId"];
+    contents.HostReservationId = __expectString(output["hostReservationId"]);
   }
   if (output["hourlyPrice"] !== undefined) {
-    contents.HourlyPrice = output["hourlyPrice"];
+    contents.HourlyPrice = __expectString(output["hourlyPrice"]);
   }
   if (output["instanceFamily"] !== undefined) {
-    contents.InstanceFamily = output["instanceFamily"];
+    contents.InstanceFamily = __expectString(output["instanceFamily"]);
   }
   if (output["paymentOption"] !== undefined) {
-    contents.PaymentOption = output["paymentOption"];
+    contents.PaymentOption = __expectString(output["paymentOption"]);
   }
   if (output["upfrontPrice"] !== undefined) {
-    contents.UpfrontPrice = output["upfrontPrice"];
+    contents.UpfrontPrice = __expectString(output["upfrontPrice"]);
   }
   return contents;
 };
@@ -65230,10 +65236,10 @@ const deserializeAws_ec2PurchaseHostReservationResult = (
     TotalUpfrontPrice: undefined,
   };
   if (output["clientToken"] !== undefined) {
-    contents.ClientToken = output["clientToken"];
+    contents.ClientToken = __expectString(output["clientToken"]);
   }
   if (output["currencyCode"] !== undefined) {
-    contents.CurrencyCode = output["currencyCode"];
+    contents.CurrencyCode = __expectString(output["currencyCode"]);
   }
   if (output.purchase === "") {
     contents.Purchase = [];
@@ -65242,10 +65248,10 @@ const deserializeAws_ec2PurchaseHostReservationResult = (
     contents.Purchase = deserializeAws_ec2PurchaseSet(__getArrayIfSingleItem(output["purchase"]["item"]), context);
   }
   if (output["totalHourlyPrice"] !== undefined) {
-    contents.TotalHourlyPrice = output["totalHourlyPrice"];
+    contents.TotalHourlyPrice = __expectString(output["totalHourlyPrice"]);
   }
   if (output["totalUpfrontPrice"] !== undefined) {
-    contents.TotalUpfrontPrice = output["totalUpfrontPrice"];
+    contents.TotalUpfrontPrice = __expectString(output["totalUpfrontPrice"]);
   }
   return contents;
 };
@@ -65258,7 +65264,7 @@ const deserializeAws_ec2PurchaseReservedInstancesOfferingResult = (
     ReservedInstancesId: undefined,
   };
   if (output["reservedInstancesId"] !== undefined) {
-    contents.ReservedInstancesId = output["reservedInstancesId"];
+    contents.ReservedInstancesId = __expectString(output["reservedInstancesId"]);
   }
   return contents;
 };
@@ -65302,7 +65308,7 @@ const deserializeAws_ec2RecurringCharge = (output: any, context: __SerdeContext)
     contents.Amount = parseFloat(output["amount"]);
   }
   if (output["frequency"] !== undefined) {
-    contents.Frequency = output["frequency"];
+    contents.Frequency = __expectString(output["frequency"]);
   }
   return contents;
 };
@@ -65325,13 +65331,13 @@ const deserializeAws_ec2Region = (output: any, context: __SerdeContext): Region 
     OptInStatus: undefined,
   };
   if (output["regionEndpoint"] !== undefined) {
-    contents.Endpoint = output["regionEndpoint"];
+    contents.Endpoint = __expectString(output["regionEndpoint"]);
   }
   if (output["regionName"] !== undefined) {
-    contents.RegionName = output["regionName"];
+    contents.RegionName = __expectString(output["regionName"]);
   }
   if (output["optInStatus"] !== undefined) {
-    contents.OptInStatus = output["optInStatus"];
+    contents.OptInStatus = __expectString(output["optInStatus"]);
   }
   return contents;
 };
@@ -65352,7 +65358,7 @@ const deserializeAws_ec2RegisterImageResult = (output: any, context: __SerdeCont
     ImageId: undefined,
   };
   if (output["imageId"] !== undefined) {
-    contents.ImageId = output["imageId"];
+    contents.ImageId = __expectString(output["imageId"]);
   }
   return contents;
 };
@@ -65535,7 +65541,7 @@ const deserializeAws_ec2ReplaceNetworkAclAssociationResult = (
     NewAssociationId: undefined,
   };
   if (output["newAssociationId"] !== undefined) {
-    contents.NewAssociationId = output["newAssociationId"];
+    contents.NewAssociationId = __expectString(output["newAssociationId"]);
   }
   return contents;
 };
@@ -65550,19 +65556,19 @@ const deserializeAws_ec2ReplaceRootVolumeTask = (output: any, context: __SerdeCo
     Tags: undefined,
   };
   if (output["replaceRootVolumeTaskId"] !== undefined) {
-    contents.ReplaceRootVolumeTaskId = output["replaceRootVolumeTaskId"];
+    contents.ReplaceRootVolumeTaskId = __expectString(output["replaceRootVolumeTaskId"]);
   }
   if (output["instanceId"] !== undefined) {
-    contents.InstanceId = output["instanceId"];
+    contents.InstanceId = __expectString(output["instanceId"]);
   }
   if (output["taskState"] !== undefined) {
-    contents.TaskState = output["taskState"];
+    contents.TaskState = __expectString(output["taskState"]);
   }
   if (output["startTime"] !== undefined) {
-    contents.StartTime = output["startTime"];
+    contents.StartTime = __expectString(output["startTime"]);
   }
   if (output["completeTime"] !== undefined) {
-    contents.CompleteTime = output["completeTime"];
+    contents.CompleteTime = __expectString(output["completeTime"]);
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -65593,7 +65599,7 @@ const deserializeAws_ec2ReplaceRouteTableAssociationResult = (
     AssociationState: undefined,
   };
   if (output["newAssociationId"] !== undefined) {
-    contents.NewAssociationId = output["newAssociationId"];
+    contents.NewAssociationId = __expectString(output["newAssociationId"]);
   }
   if (output["associationState"] !== undefined) {
     contents.AssociationState = deserializeAws_ec2RouteTableAssociationState(output["associationState"], context);
@@ -65619,7 +65625,7 @@ const deserializeAws_ec2RequestSpotFleetResponse = (output: any, context: __Serd
     SpotFleetRequestId: undefined,
   };
   if (output["spotFleetRequestId"] !== undefined) {
-    contents.SpotFleetRequestId = output["spotFleetRequestId"];
+    contents.SpotFleetRequestId = __expectString(output["spotFleetRequestId"]);
   }
   return contents;
 };
@@ -65670,13 +65676,13 @@ const deserializeAws_ec2Reservation = (output: any, context: __SerdeContext): Re
     );
   }
   if (output["ownerId"] !== undefined) {
-    contents.OwnerId = output["ownerId"];
+    contents.OwnerId = __expectString(output["ownerId"]);
   }
   if (output["requesterId"] !== undefined) {
-    contents.RequesterId = output["requesterId"];
+    contents.RequesterId = __expectString(output["requesterId"]);
   }
   if (output["reservationId"] !== undefined) {
-    contents.ReservationId = output["reservationId"];
+    contents.ReservationId = __expectString(output["reservationId"]);
   }
   return contents;
 };
@@ -65699,13 +65705,13 @@ const deserializeAws_ec2ReservationValue = (output: any, context: __SerdeContext
     RemainingUpfrontValue: undefined,
   };
   if (output["hourlyPrice"] !== undefined) {
-    contents.HourlyPrice = output["hourlyPrice"];
+    contents.HourlyPrice = __expectString(output["hourlyPrice"]);
   }
   if (output["remainingTotalValue"] !== undefined) {
-    contents.RemainingTotalValue = output["remainingTotalValue"];
+    contents.RemainingTotalValue = __expectString(output["remainingTotalValue"]);
   }
   if (output["remainingUpfrontValue"] !== undefined) {
-    contents.RemainingUpfrontValue = output["remainingUpfrontValue"];
+    contents.RemainingUpfrontValue = __expectString(output["remainingUpfrontValue"]);
   }
   return contents;
 };
@@ -65722,7 +65728,7 @@ const deserializeAws_ec2ReservedInstanceReservationValue = (
     contents.ReservationValue = deserializeAws_ec2ReservationValue(output["reservationValue"], context);
   }
   if (output["reservedInstanceId"] !== undefined) {
-    contents.ReservedInstanceId = output["reservedInstanceId"];
+    contents.ReservedInstanceId = __expectString(output["reservedInstanceId"]);
   }
   return contents;
 };
@@ -65763,7 +65769,7 @@ const deserializeAws_ec2ReservedInstances = (output: any, context: __SerdeContex
     Tags: undefined,
   };
   if (output["availabilityZone"] !== undefined) {
-    contents.AvailabilityZone = output["availabilityZone"];
+    contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
   if (output["duration"] !== undefined) {
     contents.Duration = parseInt(output["duration"]);
@@ -65778,34 +65784,34 @@ const deserializeAws_ec2ReservedInstances = (output: any, context: __SerdeContex
     contents.InstanceCount = parseInt(output["instanceCount"]);
   }
   if (output["instanceType"] !== undefined) {
-    contents.InstanceType = output["instanceType"];
+    contents.InstanceType = __expectString(output["instanceType"]);
   }
   if (output["productDescription"] !== undefined) {
-    contents.ProductDescription = output["productDescription"];
+    contents.ProductDescription = __expectString(output["productDescription"]);
   }
   if (output["reservedInstancesId"] !== undefined) {
-    contents.ReservedInstancesId = output["reservedInstancesId"];
+    contents.ReservedInstancesId = __expectString(output["reservedInstancesId"]);
   }
   if (output["start"] !== undefined) {
     contents.Start = new Date(output["start"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output["usagePrice"] !== undefined) {
     contents.UsagePrice = parseFloat(output["usagePrice"]);
   }
   if (output["currencyCode"] !== undefined) {
-    contents.CurrencyCode = output["currencyCode"];
+    contents.CurrencyCode = __expectString(output["currencyCode"]);
   }
   if (output["instanceTenancy"] !== undefined) {
-    contents.InstanceTenancy = output["instanceTenancy"];
+    contents.InstanceTenancy = __expectString(output["instanceTenancy"]);
   }
   if (output["offeringClass"] !== undefined) {
-    contents.OfferingClass = output["offeringClass"];
+    contents.OfferingClass = __expectString(output["offeringClass"]);
   }
   if (output["offeringType"] !== undefined) {
-    contents.OfferingType = output["offeringType"];
+    contents.OfferingType = __expectString(output["offeringType"]);
   }
   if (output.recurringCharges === "") {
     contents.RecurringCharges = [];
@@ -65817,7 +65823,7 @@ const deserializeAws_ec2ReservedInstances = (output: any, context: __SerdeContex
     );
   }
   if (output["scope"] !== undefined) {
-    contents.Scope = output["scope"];
+    contents.Scope = __expectString(output["scope"]);
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -65840,19 +65846,19 @@ const deserializeAws_ec2ReservedInstancesConfiguration = (
     Scope: undefined,
   };
   if (output["availabilityZone"] !== undefined) {
-    contents.AvailabilityZone = output["availabilityZone"];
+    contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
   if (output["instanceCount"] !== undefined) {
     contents.InstanceCount = parseInt(output["instanceCount"]);
   }
   if (output["instanceType"] !== undefined) {
-    contents.InstanceType = output["instanceType"];
+    contents.InstanceType = __expectString(output["instanceType"]);
   }
   if (output["platform"] !== undefined) {
-    contents.Platform = output["platform"];
+    contents.Platform = __expectString(output["platform"]);
   }
   if (output["scope"] !== undefined) {
-    contents.Scope = output["scope"];
+    contents.Scope = __expectString(output["scope"]);
   }
   return contents;
 };
@@ -65862,7 +65868,7 @@ const deserializeAws_ec2ReservedInstancesId = (output: any, context: __SerdeCont
     ReservedInstancesId: undefined,
   };
   if (output["reservedInstancesId"] !== undefined) {
-    contents.ReservedInstancesId = output["reservedInstancesId"];
+    contents.ReservedInstancesId = __expectString(output["reservedInstancesId"]);
   }
   return contents;
 };
@@ -65892,7 +65898,7 @@ const deserializeAws_ec2ReservedInstancesListing = (output: any, context: __Serd
     UpdateDate: undefined,
   };
   if (output["clientToken"] !== undefined) {
-    contents.ClientToken = output["clientToken"];
+    contents.ClientToken = __expectString(output["clientToken"]);
   }
   if (output["createDate"] !== undefined) {
     contents.CreateDate = new Date(output["createDate"]);
@@ -65916,16 +65922,16 @@ const deserializeAws_ec2ReservedInstancesListing = (output: any, context: __Serd
     );
   }
   if (output["reservedInstancesId"] !== undefined) {
-    contents.ReservedInstancesId = output["reservedInstancesId"];
+    contents.ReservedInstancesId = __expectString(output["reservedInstancesId"]);
   }
   if (output["reservedInstancesListingId"] !== undefined) {
-    contents.ReservedInstancesListingId = output["reservedInstancesListingId"];
+    contents.ReservedInstancesListingId = __expectString(output["reservedInstancesListingId"]);
   }
   if (output["status"] !== undefined) {
-    contents.Status = output["status"];
+    contents.Status = __expectString(output["status"]);
   }
   if (output["statusMessage"] !== undefined) {
-    contents.StatusMessage = output["statusMessage"];
+    contents.StatusMessage = __expectString(output["statusMessage"]);
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -65969,7 +65975,7 @@ const deserializeAws_ec2ReservedInstancesModification = (
     UpdateDate: undefined,
   };
   if (output["clientToken"] !== undefined) {
-    contents.ClientToken = output["clientToken"];
+    contents.ClientToken = __expectString(output["clientToken"]);
   }
   if (output["createDate"] !== undefined) {
     contents.CreateDate = new Date(output["createDate"]);
@@ -65996,13 +66002,13 @@ const deserializeAws_ec2ReservedInstancesModification = (
     );
   }
   if (output["reservedInstancesModificationId"] !== undefined) {
-    contents.ReservedInstancesModificationId = output["reservedInstancesModificationId"];
+    contents.ReservedInstancesModificationId = __expectString(output["reservedInstancesModificationId"]);
   }
   if (output["status"] !== undefined) {
-    contents.Status = output["status"];
+    contents.Status = __expectString(output["status"]);
   }
   if (output["statusMessage"] !== undefined) {
-    contents.StatusMessage = output["statusMessage"];
+    contents.StatusMessage = __expectString(output["statusMessage"]);
   }
   if (output["updateDate"] !== undefined) {
     contents.UpdateDate = new Date(output["updateDate"]);
@@ -66033,7 +66039,7 @@ const deserializeAws_ec2ReservedInstancesModificationResult = (
     TargetConfiguration: undefined,
   };
   if (output["reservedInstancesId"] !== undefined) {
-    contents.ReservedInstancesId = output["reservedInstancesId"];
+    contents.ReservedInstancesId = __expectString(output["reservedInstancesId"]);
   }
   if (output["targetConfiguration"] !== undefined) {
     contents.TargetConfiguration = deserializeAws_ec2ReservedInstancesConfiguration(
@@ -66080,7 +66086,7 @@ const deserializeAws_ec2ReservedInstancesOffering = (
     Scope: undefined,
   };
   if (output["availabilityZone"] !== undefined) {
-    contents.AvailabilityZone = output["availabilityZone"];
+    contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
   if (output["duration"] !== undefined) {
     contents.Duration = parseInt(output["duration"]);
@@ -66089,31 +66095,31 @@ const deserializeAws_ec2ReservedInstancesOffering = (
     contents.FixedPrice = parseFloat(output["fixedPrice"]);
   }
   if (output["instanceType"] !== undefined) {
-    contents.InstanceType = output["instanceType"];
+    contents.InstanceType = __expectString(output["instanceType"]);
   }
   if (output["productDescription"] !== undefined) {
-    contents.ProductDescription = output["productDescription"];
+    contents.ProductDescription = __expectString(output["productDescription"]);
   }
   if (output["reservedInstancesOfferingId"] !== undefined) {
-    contents.ReservedInstancesOfferingId = output["reservedInstancesOfferingId"];
+    contents.ReservedInstancesOfferingId = __expectString(output["reservedInstancesOfferingId"]);
   }
   if (output["usagePrice"] !== undefined) {
     contents.UsagePrice = parseFloat(output["usagePrice"]);
   }
   if (output["currencyCode"] !== undefined) {
-    contents.CurrencyCode = output["currencyCode"];
+    contents.CurrencyCode = __expectString(output["currencyCode"]);
   }
   if (output["instanceTenancy"] !== undefined) {
-    contents.InstanceTenancy = output["instanceTenancy"];
+    contents.InstanceTenancy = __expectString(output["instanceTenancy"]);
   }
   if (output["marketplace"] !== undefined) {
     contents.Marketplace = __parseBoolean(output["marketplace"]);
   }
   if (output["offeringClass"] !== undefined) {
-    contents.OfferingClass = output["offeringClass"];
+    contents.OfferingClass = __expectString(output["offeringClass"]);
   }
   if (output["offeringType"] !== undefined) {
-    contents.OfferingType = output["offeringType"];
+    contents.OfferingType = __expectString(output["offeringType"]);
   }
   if (output.pricingDetailsSet === "") {
     contents.PricingDetails = [];
@@ -66134,7 +66140,7 @@ const deserializeAws_ec2ReservedInstancesOffering = (
     );
   }
   if (output["scope"] !== undefined) {
-    contents.Scope = output["scope"];
+    contents.Scope = __expectString(output["scope"]);
   }
   return contents;
 };
@@ -66185,7 +66191,7 @@ const deserializeAws_ec2ResetEbsDefaultKmsKeyIdResult = (
     KmsKeyId: undefined,
   };
   if (output["kmsKeyId"] !== undefined) {
-    contents.KmsKeyId = output["kmsKeyId"];
+    contents.KmsKeyId = __expectString(output["kmsKeyId"]);
   }
   return contents;
 };
@@ -66209,10 +66215,10 @@ const deserializeAws_ec2ResponseError = (output: any, context: __SerdeContext): 
     Message: undefined,
   };
   if (output["code"] !== undefined) {
-    contents.Code = output["code"];
+    contents.Code = __expectString(output["code"]);
   }
   if (output["message"] !== undefined) {
-    contents.Message = output["message"];
+    contents.Message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -66224,7 +66230,7 @@ const deserializeAws_ec2ResponseHostIdList = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -66235,7 +66241,7 @@ const deserializeAws_ec2ResponseHostIdSet = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -66273,7 +66279,7 @@ const deserializeAws_ec2ResponseLaunchTemplateData = (
     EnclaveOptions: undefined,
   };
   if (output["kernelId"] !== undefined) {
-    contents.KernelId = output["kernelId"];
+    contents.KernelId = __expectString(output["kernelId"]);
   }
   if (output["ebsOptimized"] !== undefined) {
     contents.EbsOptimized = __parseBoolean(output["ebsOptimized"]);
@@ -66303,13 +66309,13 @@ const deserializeAws_ec2ResponseLaunchTemplateData = (
     );
   }
   if (output["imageId"] !== undefined) {
-    contents.ImageId = output["imageId"];
+    contents.ImageId = __expectString(output["imageId"]);
   }
   if (output["instanceType"] !== undefined) {
-    contents.InstanceType = output["instanceType"];
+    contents.InstanceType = __expectString(output["instanceType"]);
   }
   if (output["keyName"] !== undefined) {
-    contents.KeyName = output["keyName"];
+    contents.KeyName = __expectString(output["keyName"]);
   }
   if (output["monitoring"] !== undefined) {
     contents.Monitoring = deserializeAws_ec2LaunchTemplatesMonitoring(output["monitoring"], context);
@@ -66318,16 +66324,16 @@ const deserializeAws_ec2ResponseLaunchTemplateData = (
     contents.Placement = deserializeAws_ec2LaunchTemplatePlacement(output["placement"], context);
   }
   if (output["ramDiskId"] !== undefined) {
-    contents.RamDiskId = output["ramDiskId"];
+    contents.RamDiskId = __expectString(output["ramDiskId"]);
   }
   if (output["disableApiTermination"] !== undefined) {
     contents.DisableApiTermination = __parseBoolean(output["disableApiTermination"]);
   }
   if (output["instanceInitiatedShutdownBehavior"] !== undefined) {
-    contents.InstanceInitiatedShutdownBehavior = output["instanceInitiatedShutdownBehavior"];
+    contents.InstanceInitiatedShutdownBehavior = __expectString(output["instanceInitiatedShutdownBehavior"]);
   }
   if (output["userData"] !== undefined) {
-    contents.UserData = output["userData"];
+    contents.UserData = __expectString(output["userData"]);
   }
   if (output.tagSpecificationSet === "") {
     contents.TagSpecifications = [];
@@ -66435,10 +66441,10 @@ const deserializeAws_ec2RestoreAddressToClassicResult = (
     Status: undefined,
   };
   if (output["publicIp"] !== undefined) {
-    contents.PublicIp = output["publicIp"];
+    contents.PublicIp = __expectString(output["publicIp"]);
   }
   if (output["status"] !== undefined) {
-    contents.Status = output["status"];
+    contents.Status = __expectString(output["status"]);
   }
   return contents;
 };
@@ -66522,7 +66528,7 @@ const deserializeAws_ec2RootDeviceTypeList = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -66545,49 +66551,49 @@ const deserializeAws_ec2Route = (output: any, context: __SerdeContext): Route =>
     VpcPeeringConnectionId: undefined,
   };
   if (output["destinationCidrBlock"] !== undefined) {
-    contents.DestinationCidrBlock = output["destinationCidrBlock"];
+    contents.DestinationCidrBlock = __expectString(output["destinationCidrBlock"]);
   }
   if (output["destinationIpv6CidrBlock"] !== undefined) {
-    contents.DestinationIpv6CidrBlock = output["destinationIpv6CidrBlock"];
+    contents.DestinationIpv6CidrBlock = __expectString(output["destinationIpv6CidrBlock"]);
   }
   if (output["destinationPrefixListId"] !== undefined) {
-    contents.DestinationPrefixListId = output["destinationPrefixListId"];
+    contents.DestinationPrefixListId = __expectString(output["destinationPrefixListId"]);
   }
   if (output["egressOnlyInternetGatewayId"] !== undefined) {
-    contents.EgressOnlyInternetGatewayId = output["egressOnlyInternetGatewayId"];
+    contents.EgressOnlyInternetGatewayId = __expectString(output["egressOnlyInternetGatewayId"]);
   }
   if (output["gatewayId"] !== undefined) {
-    contents.GatewayId = output["gatewayId"];
+    contents.GatewayId = __expectString(output["gatewayId"]);
   }
   if (output["instanceId"] !== undefined) {
-    contents.InstanceId = output["instanceId"];
+    contents.InstanceId = __expectString(output["instanceId"]);
   }
   if (output["instanceOwnerId"] !== undefined) {
-    contents.InstanceOwnerId = output["instanceOwnerId"];
+    contents.InstanceOwnerId = __expectString(output["instanceOwnerId"]);
   }
   if (output["natGatewayId"] !== undefined) {
-    contents.NatGatewayId = output["natGatewayId"];
+    contents.NatGatewayId = __expectString(output["natGatewayId"]);
   }
   if (output["transitGatewayId"] !== undefined) {
-    contents.TransitGatewayId = output["transitGatewayId"];
+    contents.TransitGatewayId = __expectString(output["transitGatewayId"]);
   }
   if (output["localGatewayId"] !== undefined) {
-    contents.LocalGatewayId = output["localGatewayId"];
+    contents.LocalGatewayId = __expectString(output["localGatewayId"]);
   }
   if (output["carrierGatewayId"] !== undefined) {
-    contents.CarrierGatewayId = output["carrierGatewayId"];
+    contents.CarrierGatewayId = __expectString(output["carrierGatewayId"]);
   }
   if (output["networkInterfaceId"] !== undefined) {
-    contents.NetworkInterfaceId = output["networkInterfaceId"];
+    contents.NetworkInterfaceId = __expectString(output["networkInterfaceId"]);
   }
   if (output["origin"] !== undefined) {
-    contents.Origin = output["origin"];
+    contents.Origin = __expectString(output["origin"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output["vpcPeeringConnectionId"] !== undefined) {
-    contents.VpcPeeringConnectionId = output["vpcPeeringConnectionId"];
+    contents.VpcPeeringConnectionId = __expectString(output["vpcPeeringConnectionId"]);
   }
   return contents;
 };
@@ -66632,7 +66638,7 @@ const deserializeAws_ec2RouteTable = (output: any, context: __SerdeContext): Rou
     );
   }
   if (output["routeTableId"] !== undefined) {
-    contents.RouteTableId = output["routeTableId"];
+    contents.RouteTableId = __expectString(output["routeTableId"]);
   }
   if (output.routeSet === "") {
     contents.Routes = [];
@@ -66647,10 +66653,10 @@ const deserializeAws_ec2RouteTable = (output: any, context: __SerdeContext): Rou
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["vpcId"] !== undefined) {
-    contents.VpcId = output["vpcId"];
+    contents.VpcId = __expectString(output["vpcId"]);
   }
   if (output["ownerId"] !== undefined) {
-    contents.OwnerId = output["ownerId"];
+    contents.OwnerId = __expectString(output["ownerId"]);
   }
   return contents;
 };
@@ -66668,16 +66674,16 @@ const deserializeAws_ec2RouteTableAssociation = (output: any, context: __SerdeCo
     contents.Main = __parseBoolean(output["main"]);
   }
   if (output["routeTableAssociationId"] !== undefined) {
-    contents.RouteTableAssociationId = output["routeTableAssociationId"];
+    contents.RouteTableAssociationId = __expectString(output["routeTableAssociationId"]);
   }
   if (output["routeTableId"] !== undefined) {
-    contents.RouteTableId = output["routeTableId"];
+    contents.RouteTableId = __expectString(output["routeTableId"]);
   }
   if (output["subnetId"] !== undefined) {
-    contents.SubnetId = output["subnetId"];
+    contents.SubnetId = __expectString(output["subnetId"]);
   }
   if (output["gatewayId"] !== undefined) {
-    contents.GatewayId = output["gatewayId"];
+    contents.GatewayId = __expectString(output["gatewayId"]);
   }
   if (output["associationState"] !== undefined) {
     contents.AssociationState = deserializeAws_ec2RouteTableAssociationState(output["associationState"], context);
@@ -66705,10 +66711,10 @@ const deserializeAws_ec2RouteTableAssociationState = (
     StatusMessage: undefined,
   };
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output["statusMessage"] !== undefined) {
-    contents.StatusMessage = output["statusMessage"];
+    contents.StatusMessage = __expectString(output["statusMessage"]);
   }
   return contents;
 };
@@ -66765,19 +66771,19 @@ const deserializeAws_ec2S3Storage = (output: any, context: __SerdeContext): S3St
     UploadPolicySignature: undefined,
   };
   if (output["AWSAccessKeyId"] !== undefined) {
-    contents.AWSAccessKeyId = output["AWSAccessKeyId"];
+    contents.AWSAccessKeyId = __expectString(output["AWSAccessKeyId"]);
   }
   if (output["bucket"] !== undefined) {
-    contents.Bucket = output["bucket"];
+    contents.Bucket = __expectString(output["bucket"]);
   }
   if (output["prefix"] !== undefined) {
-    contents.Prefix = output["prefix"];
+    contents.Prefix = __expectString(output["prefix"]);
   }
   if (output["uploadPolicy"] !== undefined) {
     contents.UploadPolicy = context.base64Decoder(output["uploadPolicy"]);
   }
   if (output["uploadPolicySignature"] !== undefined) {
-    contents.UploadPolicySignature = output["uploadPolicySignature"];
+    contents.UploadPolicySignature = __expectString(output["uploadPolicySignature"]);
   }
   return contents;
 };
@@ -66801,28 +66807,28 @@ const deserializeAws_ec2ScheduledInstance = (output: any, context: __SerdeContex
     TotalScheduledInstanceHours: undefined,
   };
   if (output["availabilityZone"] !== undefined) {
-    contents.AvailabilityZone = output["availabilityZone"];
+    contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
   if (output["createDate"] !== undefined) {
     contents.CreateDate = new Date(output["createDate"]);
   }
   if (output["hourlyPrice"] !== undefined) {
-    contents.HourlyPrice = output["hourlyPrice"];
+    contents.HourlyPrice = __expectString(output["hourlyPrice"]);
   }
   if (output["instanceCount"] !== undefined) {
     contents.InstanceCount = parseInt(output["instanceCount"]);
   }
   if (output["instanceType"] !== undefined) {
-    contents.InstanceType = output["instanceType"];
+    contents.InstanceType = __expectString(output["instanceType"]);
   }
   if (output["networkPlatform"] !== undefined) {
-    contents.NetworkPlatform = output["networkPlatform"];
+    contents.NetworkPlatform = __expectString(output["networkPlatform"]);
   }
   if (output["nextSlotStartTime"] !== undefined) {
     contents.NextSlotStartTime = new Date(output["nextSlotStartTime"]);
   }
   if (output["platform"] !== undefined) {
-    contents.Platform = output["platform"];
+    contents.Platform = __expectString(output["platform"]);
   }
   if (output["previousSlotEndTime"] !== undefined) {
     contents.PreviousSlotEndTime = new Date(output["previousSlotEndTime"]);
@@ -66831,7 +66837,7 @@ const deserializeAws_ec2ScheduledInstance = (output: any, context: __SerdeContex
     contents.Recurrence = deserializeAws_ec2ScheduledInstanceRecurrence(output["recurrence"], context);
   }
   if (output["scheduledInstanceId"] !== undefined) {
-    contents.ScheduledInstanceId = output["scheduledInstanceId"];
+    contents.ScheduledInstanceId = __expectString(output["scheduledInstanceId"]);
   }
   if (output["slotDurationInHours"] !== undefined) {
     contents.SlotDurationInHours = parseInt(output["slotDurationInHours"]);
@@ -66868,7 +66874,7 @@ const deserializeAws_ec2ScheduledInstanceAvailability = (
     TotalScheduledInstanceHours: undefined,
   };
   if (output["availabilityZone"] !== undefined) {
-    contents.AvailabilityZone = output["availabilityZone"];
+    contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
   if (output["availableInstanceCount"] !== undefined) {
     contents.AvailableInstanceCount = parseInt(output["availableInstanceCount"]);
@@ -66877,10 +66883,10 @@ const deserializeAws_ec2ScheduledInstanceAvailability = (
     contents.FirstSlotStartTime = new Date(output["firstSlotStartTime"]);
   }
   if (output["hourlyPrice"] !== undefined) {
-    contents.HourlyPrice = output["hourlyPrice"];
+    contents.HourlyPrice = __expectString(output["hourlyPrice"]);
   }
   if (output["instanceType"] !== undefined) {
-    contents.InstanceType = output["instanceType"];
+    contents.InstanceType = __expectString(output["instanceType"]);
   }
   if (output["maxTermDurationInDays"] !== undefined) {
     contents.MaxTermDurationInDays = parseInt(output["maxTermDurationInDays"]);
@@ -66889,13 +66895,13 @@ const deserializeAws_ec2ScheduledInstanceAvailability = (
     contents.MinTermDurationInDays = parseInt(output["minTermDurationInDays"]);
   }
   if (output["networkPlatform"] !== undefined) {
-    contents.NetworkPlatform = output["networkPlatform"];
+    contents.NetworkPlatform = __expectString(output["networkPlatform"]);
   }
   if (output["platform"] !== undefined) {
-    contents.Platform = output["platform"];
+    contents.Platform = __expectString(output["platform"]);
   }
   if (output["purchaseToken"] !== undefined) {
-    contents.PurchaseToken = output["purchaseToken"];
+    contents.PurchaseToken = __expectString(output["purchaseToken"]);
   }
   if (output["recurrence"] !== undefined) {
     contents.Recurrence = deserializeAws_ec2ScheduledInstanceRecurrence(output["recurrence"], context);
@@ -66935,7 +66941,7 @@ const deserializeAws_ec2ScheduledInstanceRecurrence = (
     OccurrenceUnit: undefined,
   };
   if (output["frequency"] !== undefined) {
-    contents.Frequency = output["frequency"];
+    contents.Frequency = __expectString(output["frequency"]);
   }
   if (output["interval"] !== undefined) {
     contents.Interval = parseInt(output["interval"]);
@@ -66953,7 +66959,7 @@ const deserializeAws_ec2ScheduledInstanceRecurrence = (
     contents.OccurrenceRelativeToEnd = __parseBoolean(output["occurrenceRelativeToEnd"]);
   }
   if (output["occurrenceUnit"] !== undefined) {
-    contents.OccurrenceUnit = output["occurrenceUnit"];
+    contents.OccurrenceUnit = __expectString(output["occurrenceUnit"]);
   }
   return contents;
 };
@@ -66987,7 +66993,7 @@ const deserializeAws_ec2SearchLocalGatewayRoutesResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -67010,7 +67016,7 @@ const deserializeAws_ec2SearchTransitGatewayMulticastGroupsResult = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.NextToken = output["nextToken"];
+    contents.NextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -67050,10 +67056,10 @@ const deserializeAws_ec2SecurityGroup = (output: any, context: __SerdeContext): 
     VpcId: undefined,
   };
   if (output["groupDescription"] !== undefined) {
-    contents.Description = output["groupDescription"];
+    contents.Description = __expectString(output["groupDescription"]);
   }
   if (output["groupName"] !== undefined) {
-    contents.GroupName = output["groupName"];
+    contents.GroupName = __expectString(output["groupName"]);
   }
   if (output.ipPermissions === "") {
     contents.IpPermissions = [];
@@ -67065,10 +67071,10 @@ const deserializeAws_ec2SecurityGroup = (output: any, context: __SerdeContext): 
     );
   }
   if (output["ownerId"] !== undefined) {
-    contents.OwnerId = output["ownerId"];
+    contents.OwnerId = __expectString(output["ownerId"]);
   }
   if (output["groupId"] !== undefined) {
-    contents.GroupId = output["groupId"];
+    contents.GroupId = __expectString(output["groupId"]);
   }
   if (output.ipPermissionsEgress === "") {
     contents.IpPermissionsEgress = [];
@@ -67086,7 +67092,7 @@ const deserializeAws_ec2SecurityGroup = (output: any, context: __SerdeContext): 
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["vpcId"] !== undefined) {
-    contents.VpcId = output["vpcId"];
+    contents.VpcId = __expectString(output["vpcId"]);
   }
   return contents;
 };
@@ -67097,10 +67103,10 @@ const deserializeAws_ec2SecurityGroupIdentifier = (output: any, context: __Serde
     GroupName: undefined,
   };
   if (output["groupId"] !== undefined) {
-    contents.GroupId = output["groupId"];
+    contents.GroupId = __expectString(output["groupId"]);
   }
   if (output["groupName"] !== undefined) {
-    contents.GroupName = output["groupName"];
+    contents.GroupName = __expectString(output["groupName"]);
   }
   return contents;
 };
@@ -67112,7 +67118,7 @@ const deserializeAws_ec2SecurityGroupIdStringList = (output: any, context: __Ser
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -67134,13 +67140,13 @@ const deserializeAws_ec2SecurityGroupReference = (output: any, context: __SerdeC
     VpcPeeringConnectionId: undefined,
   };
   if (output["groupId"] !== undefined) {
-    contents.GroupId = output["groupId"];
+    contents.GroupId = __expectString(output["groupId"]);
   }
   if (output["referencingVpcId"] !== undefined) {
-    contents.ReferencingVpcId = output["referencingVpcId"];
+    contents.ReferencingVpcId = __expectString(output["referencingVpcId"]);
   }
   if (output["vpcPeeringConnectionId"] !== undefined) {
-    contents.VpcPeeringConnectionId = output["vpcPeeringConnectionId"];
+    contents.VpcPeeringConnectionId = __expectString(output["vpcPeeringConnectionId"]);
   }
   return contents;
 };
@@ -67182,13 +67188,13 @@ const deserializeAws_ec2ServiceConfiguration = (output: any, context: __SerdeCon
     );
   }
   if (output["serviceId"] !== undefined) {
-    contents.ServiceId = output["serviceId"];
+    contents.ServiceId = __expectString(output["serviceId"]);
   }
   if (output["serviceName"] !== undefined) {
-    contents.ServiceName = output["serviceName"];
+    contents.ServiceName = __expectString(output["serviceName"]);
   }
   if (output["serviceState"] !== undefined) {
-    contents.ServiceState = output["serviceState"];
+    contents.ServiceState = __expectString(output["serviceState"]);
   }
   if (output.availabilityZoneSet === "") {
     contents.AvailabilityZones = [];
@@ -67233,7 +67239,7 @@ const deserializeAws_ec2ServiceConfiguration = (output: any, context: __SerdeCon
     );
   }
   if (output["privateDnsName"] !== undefined) {
-    contents.PrivateDnsName = output["privateDnsName"];
+    contents.PrivateDnsName = __expectString(output["privateDnsName"]);
   }
   if (output["privateDnsNameConfiguration"] !== undefined) {
     contents.PrivateDnsNameConfiguration = deserializeAws_ec2PrivateDnsNameConfiguration(
@@ -67278,10 +67284,10 @@ const deserializeAws_ec2ServiceDetail = (output: any, context: __SerdeContext): 
     PrivateDnsNameVerificationState: undefined,
   };
   if (output["serviceName"] !== undefined) {
-    contents.ServiceName = output["serviceName"];
+    contents.ServiceName = __expectString(output["serviceName"]);
   }
   if (output["serviceId"] !== undefined) {
-    contents.ServiceId = output["serviceId"];
+    contents.ServiceId = __expectString(output["serviceId"]);
   }
   if (output.serviceType === "") {
     contents.ServiceType = [];
@@ -67302,7 +67308,7 @@ const deserializeAws_ec2ServiceDetail = (output: any, context: __SerdeContext): 
     );
   }
   if (output["owner"] !== undefined) {
-    contents.Owner = output["owner"];
+    contents.Owner = __expectString(output["owner"]);
   }
   if (output.baseEndpointDnsNameSet === "") {
     contents.BaseEndpointDnsNames = [];
@@ -67314,7 +67320,7 @@ const deserializeAws_ec2ServiceDetail = (output: any, context: __SerdeContext): 
     );
   }
   if (output["privateDnsName"] !== undefined) {
-    contents.PrivateDnsName = output["privateDnsName"];
+    contents.PrivateDnsName = __expectString(output["privateDnsName"]);
   }
   if (output.privateDnsNameSet === "") {
     contents.PrivateDnsNames = [];
@@ -67341,7 +67347,7 @@ const deserializeAws_ec2ServiceDetail = (output: any, context: __SerdeContext): 
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["privateDnsNameVerificationState"] !== undefined) {
-    contents.PrivateDnsNameVerificationState = output["privateDnsNameVerificationState"];
+    contents.PrivateDnsNameVerificationState = __expectString(output["privateDnsNameVerificationState"]);
   }
   return contents;
 };
@@ -67362,7 +67368,7 @@ const deserializeAws_ec2ServiceTypeDetail = (output: any, context: __SerdeContex
     ServiceType: undefined,
   };
   if (output["serviceType"] !== undefined) {
-    contents.ServiceType = output["serviceType"];
+    contents.ServiceType = __expectString(output["serviceType"]);
   }
   return contents;
 };
@@ -67397,46 +67403,46 @@ const deserializeAws_ec2Snapshot = (output: any, context: __SerdeContext): Snaps
     Tags: undefined,
   };
   if (output["dataEncryptionKeyId"] !== undefined) {
-    contents.DataEncryptionKeyId = output["dataEncryptionKeyId"];
+    contents.DataEncryptionKeyId = __expectString(output["dataEncryptionKeyId"]);
   }
   if (output["description"] !== undefined) {
-    contents.Description = output["description"];
+    contents.Description = __expectString(output["description"]);
   }
   if (output["encrypted"] !== undefined) {
     contents.Encrypted = __parseBoolean(output["encrypted"]);
   }
   if (output["kmsKeyId"] !== undefined) {
-    contents.KmsKeyId = output["kmsKeyId"];
+    contents.KmsKeyId = __expectString(output["kmsKeyId"]);
   }
   if (output["ownerId"] !== undefined) {
-    contents.OwnerId = output["ownerId"];
+    contents.OwnerId = __expectString(output["ownerId"]);
   }
   if (output["progress"] !== undefined) {
-    contents.Progress = output["progress"];
+    contents.Progress = __expectString(output["progress"]);
   }
   if (output["snapshotId"] !== undefined) {
-    contents.SnapshotId = output["snapshotId"];
+    contents.SnapshotId = __expectString(output["snapshotId"]);
   }
   if (output["startTime"] !== undefined) {
     contents.StartTime = new Date(output["startTime"]);
   }
   if (output["status"] !== undefined) {
-    contents.State = output["status"];
+    contents.State = __expectString(output["status"]);
   }
   if (output["statusMessage"] !== undefined) {
-    contents.StateMessage = output["statusMessage"];
+    contents.StateMessage = __expectString(output["statusMessage"]);
   }
   if (output["volumeId"] !== undefined) {
-    contents.VolumeId = output["volumeId"];
+    contents.VolumeId = __expectString(output["volumeId"]);
   }
   if (output["volumeSize"] !== undefined) {
     contents.VolumeSize = parseInt(output["volumeSize"]);
   }
   if (output["ownerAlias"] !== undefined) {
-    contents.OwnerAlias = output["ownerAlias"];
+    contents.OwnerAlias = __expectString(output["ownerAlias"]);
   }
   if (output["outpostArn"] !== undefined) {
-    contents.OutpostArn = output["outpostArn"];
+    contents.OutpostArn = __expectString(output["outpostArn"]);
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -67461,31 +67467,31 @@ const deserializeAws_ec2SnapshotDetail = (output: any, context: __SerdeContext):
     UserBucket: undefined,
   };
   if (output["description"] !== undefined) {
-    contents.Description = output["description"];
+    contents.Description = __expectString(output["description"]);
   }
   if (output["deviceName"] !== undefined) {
-    contents.DeviceName = output["deviceName"];
+    contents.DeviceName = __expectString(output["deviceName"]);
   }
   if (output["diskImageSize"] !== undefined) {
     contents.DiskImageSize = parseFloat(output["diskImageSize"]);
   }
   if (output["format"] !== undefined) {
-    contents.Format = output["format"];
+    contents.Format = __expectString(output["format"]);
   }
   if (output["progress"] !== undefined) {
-    contents.Progress = output["progress"];
+    contents.Progress = __expectString(output["progress"]);
   }
   if (output["snapshotId"] !== undefined) {
-    contents.SnapshotId = output["snapshotId"];
+    contents.SnapshotId = __expectString(output["snapshotId"]);
   }
   if (output["status"] !== undefined) {
-    contents.Status = output["status"];
+    contents.Status = __expectString(output["status"]);
   }
   if (output["statusMessage"] !== undefined) {
-    contents.StatusMessage = output["statusMessage"];
+    contents.StatusMessage = __expectString(output["statusMessage"]);
   }
   if (output["url"] !== undefined) {
-    contents.Url = output["url"];
+    contents.Url = __expectString(output["url"]);
   }
   if (output["userBucket"] !== undefined) {
     contents.UserBucket = deserializeAws_ec2UserBucketDetails(output["userBucket"], context);
@@ -67519,7 +67525,7 @@ const deserializeAws_ec2SnapshotInfo = (output: any, context: __SerdeContext): S
     OutpostArn: undefined,
   };
   if (output["description"] !== undefined) {
-    contents.Description = output["description"];
+    contents.Description = __expectString(output["description"]);
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -67531,10 +67537,10 @@ const deserializeAws_ec2SnapshotInfo = (output: any, context: __SerdeContext): S
     contents.Encrypted = __parseBoolean(output["encrypted"]);
   }
   if (output["volumeId"] !== undefined) {
-    contents.VolumeId = output["volumeId"];
+    contents.VolumeId = __expectString(output["volumeId"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output["volumeSize"] !== undefined) {
     contents.VolumeSize = parseInt(output["volumeSize"]);
@@ -67543,16 +67549,16 @@ const deserializeAws_ec2SnapshotInfo = (output: any, context: __SerdeContext): S
     contents.StartTime = new Date(output["startTime"]);
   }
   if (output["progress"] !== undefined) {
-    contents.Progress = output["progress"];
+    contents.Progress = __expectString(output["progress"]);
   }
   if (output["ownerId"] !== undefined) {
-    contents.OwnerId = output["ownerId"];
+    contents.OwnerId = __expectString(output["ownerId"]);
   }
   if (output["snapshotId"] !== undefined) {
-    contents.SnapshotId = output["snapshotId"];
+    contents.SnapshotId = __expectString(output["snapshotId"]);
   }
   if (output["outpostArn"] !== undefined) {
-    contents.OutpostArn = output["outpostArn"];
+    contents.OutpostArn = __expectString(output["outpostArn"]);
   }
   return contents;
 };
@@ -67594,7 +67600,7 @@ const deserializeAws_ec2SnapshotTaskDetail = (output: any, context: __SerdeConte
     UserBucket: undefined,
   };
   if (output["description"] !== undefined) {
-    contents.Description = output["description"];
+    contents.Description = __expectString(output["description"]);
   }
   if (output["diskImageSize"] !== undefined) {
     contents.DiskImageSize = parseFloat(output["diskImageSize"]);
@@ -67603,25 +67609,25 @@ const deserializeAws_ec2SnapshotTaskDetail = (output: any, context: __SerdeConte
     contents.Encrypted = __parseBoolean(output["encrypted"]);
   }
   if (output["format"] !== undefined) {
-    contents.Format = output["format"];
+    contents.Format = __expectString(output["format"]);
   }
   if (output["kmsKeyId"] !== undefined) {
-    contents.KmsKeyId = output["kmsKeyId"];
+    contents.KmsKeyId = __expectString(output["kmsKeyId"]);
   }
   if (output["progress"] !== undefined) {
-    contents.Progress = output["progress"];
+    contents.Progress = __expectString(output["progress"]);
   }
   if (output["snapshotId"] !== undefined) {
-    contents.SnapshotId = output["snapshotId"];
+    contents.SnapshotId = __expectString(output["snapshotId"]);
   }
   if (output["status"] !== undefined) {
-    contents.Status = output["status"];
+    contents.Status = __expectString(output["status"]);
   }
   if (output["statusMessage"] !== undefined) {
-    contents.StatusMessage = output["statusMessage"];
+    contents.StatusMessage = __expectString(output["statusMessage"]);
   }
   if (output["url"] !== undefined) {
-    contents.Url = output["url"];
+    contents.Url = __expectString(output["url"]);
   }
   if (output["userBucket"] !== undefined) {
     contents.UserBucket = deserializeAws_ec2UserBucketDetails(output["userBucket"], context);
@@ -67634,7 +67640,7 @@ const deserializeAws_ec2SpotCapacityRebalance = (output: any, context: __SerdeCo
     ReplacementStrategy: undefined,
   };
   if (output["replacementStrategy"] !== undefined) {
-    contents.ReplacementStrategy = output["replacementStrategy"];
+    contents.ReplacementStrategy = __expectString(output["replacementStrategy"]);
   }
   return contents;
 };
@@ -67648,19 +67654,19 @@ const deserializeAws_ec2SpotDatafeedSubscription = (output: any, context: __Serd
     State: undefined,
   };
   if (output["bucket"] !== undefined) {
-    contents.Bucket = output["bucket"];
+    contents.Bucket = __expectString(output["bucket"]);
   }
   if (output["fault"] !== undefined) {
     contents.Fault = deserializeAws_ec2SpotInstanceStateFault(output["fault"], context);
   }
   if (output["ownerId"] !== undefined) {
-    contents.OwnerId = output["ownerId"];
+    contents.OwnerId = __expectString(output["ownerId"]);
   }
   if (output["prefix"] !== undefined) {
-    contents.Prefix = output["prefix"];
+    contents.Prefix = __expectString(output["prefix"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   return contents;
 };
@@ -67699,7 +67705,7 @@ const deserializeAws_ec2SpotFleetLaunchSpecification = (
     );
   }
   if (output["addressingType"] !== undefined) {
-    contents.AddressingType = output["addressingType"];
+    contents.AddressingType = __expectString(output["addressingType"]);
   }
   if (output.blockDeviceMapping === "") {
     contents.BlockDeviceMappings = [];
@@ -67720,16 +67726,16 @@ const deserializeAws_ec2SpotFleetLaunchSpecification = (
     );
   }
   if (output["imageId"] !== undefined) {
-    contents.ImageId = output["imageId"];
+    contents.ImageId = __expectString(output["imageId"]);
   }
   if (output["instanceType"] !== undefined) {
-    contents.InstanceType = output["instanceType"];
+    contents.InstanceType = __expectString(output["instanceType"]);
   }
   if (output["kernelId"] !== undefined) {
-    contents.KernelId = output["kernelId"];
+    contents.KernelId = __expectString(output["kernelId"]);
   }
   if (output["keyName"] !== undefined) {
-    contents.KeyName = output["keyName"];
+    contents.KeyName = __expectString(output["keyName"]);
   }
   if (output["monitoring"] !== undefined) {
     contents.Monitoring = deserializeAws_ec2SpotFleetMonitoring(output["monitoring"], context);
@@ -67747,16 +67753,16 @@ const deserializeAws_ec2SpotFleetLaunchSpecification = (
     contents.Placement = deserializeAws_ec2SpotPlacement(output["placement"], context);
   }
   if (output["ramdiskId"] !== undefined) {
-    contents.RamdiskId = output["ramdiskId"];
+    contents.RamdiskId = __expectString(output["ramdiskId"]);
   }
   if (output["spotPrice"] !== undefined) {
-    contents.SpotPrice = output["spotPrice"];
+    contents.SpotPrice = __expectString(output["spotPrice"]);
   }
   if (output["subnetId"] !== undefined) {
-    contents.SubnetId = output["subnetId"];
+    contents.SubnetId = __expectString(output["subnetId"]);
   }
   if (output["userData"] !== undefined) {
-    contents.UserData = output["userData"];
+    contents.UserData = __expectString(output["userData"]);
   }
   if (output["weightedCapacity"] !== undefined) {
     contents.WeightedCapacity = parseFloat(output["weightedCapacity"]);
@@ -67793,7 +67799,7 @@ const deserializeAws_ec2SpotFleetRequestConfig = (output: any, context: __SerdeC
     Tags: undefined,
   };
   if (output["activityStatus"] !== undefined) {
-    contents.ActivityStatus = output["activityStatus"];
+    contents.ActivityStatus = __expectString(output["activityStatus"]);
   }
   if (output["createTime"] !== undefined) {
     contents.CreateTime = new Date(output["createTime"]);
@@ -67805,10 +67811,10 @@ const deserializeAws_ec2SpotFleetRequestConfig = (output: any, context: __SerdeC
     );
   }
   if (output["spotFleetRequestId"] !== undefined) {
-    contents.SpotFleetRequestId = output["spotFleetRequestId"];
+    contents.SpotFleetRequestId = __expectString(output["spotFleetRequestId"]);
   }
   if (output["spotFleetRequestState"] !== undefined) {
-    contents.SpotFleetRequestState = output["spotFleetRequestState"];
+    contents.SpotFleetRequestState = __expectString(output["spotFleetRequestState"]);
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -67850,10 +67856,10 @@ const deserializeAws_ec2SpotFleetRequestConfigData = (
     TagSpecifications: undefined,
   };
   if (output["allocationStrategy"] !== undefined) {
-    contents.AllocationStrategy = output["allocationStrategy"];
+    contents.AllocationStrategy = __expectString(output["allocationStrategy"]);
   }
   if (output["onDemandAllocationStrategy"] !== undefined) {
-    contents.OnDemandAllocationStrategy = output["onDemandAllocationStrategy"];
+    contents.OnDemandAllocationStrategy = __expectString(output["onDemandAllocationStrategy"]);
   }
   if (output["spotMaintenanceStrategies"] !== undefined) {
     contents.SpotMaintenanceStrategies = deserializeAws_ec2SpotMaintenanceStrategies(
@@ -67862,10 +67868,10 @@ const deserializeAws_ec2SpotFleetRequestConfigData = (
     );
   }
   if (output["clientToken"] !== undefined) {
-    contents.ClientToken = output["clientToken"];
+    contents.ClientToken = __expectString(output["clientToken"]);
   }
   if (output["excessCapacityTerminationPolicy"] !== undefined) {
-    contents.ExcessCapacityTerminationPolicy = output["excessCapacityTerminationPolicy"];
+    contents.ExcessCapacityTerminationPolicy = __expectString(output["excessCapacityTerminationPolicy"]);
   }
   if (output["fulfilledCapacity"] !== undefined) {
     contents.FulfilledCapacity = parseFloat(output["fulfilledCapacity"]);
@@ -67874,7 +67880,7 @@ const deserializeAws_ec2SpotFleetRequestConfigData = (
     contents.OnDemandFulfilledCapacity = parseFloat(output["onDemandFulfilledCapacity"]);
   }
   if (output["iamFleetRole"] !== undefined) {
-    contents.IamFleetRole = output["iamFleetRole"];
+    contents.IamFleetRole = __expectString(output["iamFleetRole"]);
   }
   if (output.launchSpecifications === "") {
     contents.LaunchSpecifications = [];
@@ -67895,7 +67901,7 @@ const deserializeAws_ec2SpotFleetRequestConfigData = (
     );
   }
   if (output["spotPrice"] !== undefined) {
-    contents.SpotPrice = output["spotPrice"];
+    contents.SpotPrice = __expectString(output["spotPrice"]);
   }
   if (output["targetCapacity"] !== undefined) {
     contents.TargetCapacity = parseInt(output["targetCapacity"]);
@@ -67904,16 +67910,16 @@ const deserializeAws_ec2SpotFleetRequestConfigData = (
     contents.OnDemandTargetCapacity = parseInt(output["onDemandTargetCapacity"]);
   }
   if (output["onDemandMaxTotalPrice"] !== undefined) {
-    contents.OnDemandMaxTotalPrice = output["onDemandMaxTotalPrice"];
+    contents.OnDemandMaxTotalPrice = __expectString(output["onDemandMaxTotalPrice"]);
   }
   if (output["spotMaxTotalPrice"] !== undefined) {
-    contents.SpotMaxTotalPrice = output["spotMaxTotalPrice"];
+    contents.SpotMaxTotalPrice = __expectString(output["spotMaxTotalPrice"]);
   }
   if (output["terminateInstancesWithExpiration"] !== undefined) {
     contents.TerminateInstancesWithExpiration = __parseBoolean(output["terminateInstancesWithExpiration"]);
   }
   if (output["type"] !== undefined) {
-    contents.Type = output["type"];
+    contents.Type = __expectString(output["type"]);
   }
   if (output["validFrom"] !== undefined) {
     contents.ValidFrom = new Date(output["validFrom"]);
@@ -67925,7 +67931,7 @@ const deserializeAws_ec2SpotFleetRequestConfigData = (
     contents.ReplaceUnhealthyInstances = __parseBoolean(output["replaceUnhealthyInstances"]);
   }
   if (output["instanceInterruptionBehavior"] !== undefined) {
-    contents.InstanceInterruptionBehavior = output["instanceInterruptionBehavior"];
+    contents.InstanceInterruptionBehavior = __expectString(output["instanceInterruptionBehavior"]);
   }
   if (output["loadBalancersConfig"] !== undefined) {
     contents.LoadBalancersConfig = deserializeAws_ec2LoadBalancersConfig(output["loadBalancersConfig"], context);
@@ -67968,7 +67974,7 @@ const deserializeAws_ec2SpotFleetTagSpecification = (
     Tags: undefined,
   };
   if (output["resourceType"] !== undefined) {
-    contents.ResourceType = output["resourceType"];
+    contents.ResourceType = __expectString(output["resourceType"]);
   }
   if (output.tag === "") {
     contents.Tags = [];
@@ -68016,10 +68022,10 @@ const deserializeAws_ec2SpotInstanceRequest = (output: any, context: __SerdeCont
     InstanceInterruptionBehavior: undefined,
   };
   if (output["actualBlockHourlyPrice"] !== undefined) {
-    contents.ActualBlockHourlyPrice = output["actualBlockHourlyPrice"];
+    contents.ActualBlockHourlyPrice = __expectString(output["actualBlockHourlyPrice"]);
   }
   if (output["availabilityZoneGroup"] !== undefined) {
-    contents.AvailabilityZoneGroup = output["availabilityZoneGroup"];
+    contents.AvailabilityZoneGroup = __expectString(output["availabilityZoneGroup"]);
   }
   if (output["blockDurationMinutes"] !== undefined) {
     contents.BlockDurationMinutes = parseInt(output["blockDurationMinutes"]);
@@ -68031,28 +68037,28 @@ const deserializeAws_ec2SpotInstanceRequest = (output: any, context: __SerdeCont
     contents.Fault = deserializeAws_ec2SpotInstanceStateFault(output["fault"], context);
   }
   if (output["instanceId"] !== undefined) {
-    contents.InstanceId = output["instanceId"];
+    contents.InstanceId = __expectString(output["instanceId"]);
   }
   if (output["launchGroup"] !== undefined) {
-    contents.LaunchGroup = output["launchGroup"];
+    contents.LaunchGroup = __expectString(output["launchGroup"]);
   }
   if (output["launchSpecification"] !== undefined) {
     contents.LaunchSpecification = deserializeAws_ec2LaunchSpecification(output["launchSpecification"], context);
   }
   if (output["launchedAvailabilityZone"] !== undefined) {
-    contents.LaunchedAvailabilityZone = output["launchedAvailabilityZone"];
+    contents.LaunchedAvailabilityZone = __expectString(output["launchedAvailabilityZone"]);
   }
   if (output["productDescription"] !== undefined) {
-    contents.ProductDescription = output["productDescription"];
+    contents.ProductDescription = __expectString(output["productDescription"]);
   }
   if (output["spotInstanceRequestId"] !== undefined) {
-    contents.SpotInstanceRequestId = output["spotInstanceRequestId"];
+    contents.SpotInstanceRequestId = __expectString(output["spotInstanceRequestId"]);
   }
   if (output["spotPrice"] !== undefined) {
-    contents.SpotPrice = output["spotPrice"];
+    contents.SpotPrice = __expectString(output["spotPrice"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output["status"] !== undefined) {
     contents.Status = deserializeAws_ec2SpotInstanceStatus(output["status"], context);
@@ -68064,7 +68070,7 @@ const deserializeAws_ec2SpotInstanceRequest = (output: any, context: __SerdeCont
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["type"] !== undefined) {
-    contents.Type = output["type"];
+    contents.Type = __expectString(output["type"]);
   }
   if (output["validFrom"] !== undefined) {
     contents.ValidFrom = new Date(output["validFrom"]);
@@ -68073,7 +68079,7 @@ const deserializeAws_ec2SpotInstanceRequest = (output: any, context: __SerdeCont
     contents.ValidUntil = new Date(output["validUntil"]);
   }
   if (output["instanceInterruptionBehavior"] !== undefined) {
-    contents.InstanceInterruptionBehavior = output["instanceInterruptionBehavior"];
+    contents.InstanceInterruptionBehavior = __expectString(output["instanceInterruptionBehavior"]);
   }
   return contents;
 };
@@ -68095,10 +68101,10 @@ const deserializeAws_ec2SpotInstanceStateFault = (output: any, context: __SerdeC
     Message: undefined,
   };
   if (output["code"] !== undefined) {
-    contents.Code = output["code"];
+    contents.Code = __expectString(output["code"]);
   }
   if (output["message"] !== undefined) {
-    contents.Message = output["message"];
+    contents.Message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -68110,10 +68116,10 @@ const deserializeAws_ec2SpotInstanceStatus = (output: any, context: __SerdeConte
     UpdateTime: undefined,
   };
   if (output["code"] !== undefined) {
-    contents.Code = output["code"];
+    contents.Code = __expectString(output["code"]);
   }
   if (output["message"] !== undefined) {
-    contents.Message = output["message"];
+    contents.Message = __expectString(output["message"]);
   }
   if (output["updateTime"] !== undefined) {
     contents.UpdateTime = new Date(output["updateTime"]);
@@ -68146,7 +68152,7 @@ const deserializeAws_ec2SpotOptions = (output: any, context: __SerdeContext): Sp
     MaxTotalPrice: undefined,
   };
   if (output["allocationStrategy"] !== undefined) {
-    contents.AllocationStrategy = output["allocationStrategy"];
+    contents.AllocationStrategy = __expectString(output["allocationStrategy"]);
   }
   if (output["maintenanceStrategies"] !== undefined) {
     contents.MaintenanceStrategies = deserializeAws_ec2FleetSpotMaintenanceStrategies(
@@ -68155,7 +68161,7 @@ const deserializeAws_ec2SpotOptions = (output: any, context: __SerdeContext): Sp
     );
   }
   if (output["instanceInterruptionBehavior"] !== undefined) {
-    contents.InstanceInterruptionBehavior = output["instanceInterruptionBehavior"];
+    contents.InstanceInterruptionBehavior = __expectString(output["instanceInterruptionBehavior"]);
   }
   if (output["instancePoolsToUseCount"] !== undefined) {
     contents.InstancePoolsToUseCount = parseInt(output["instancePoolsToUseCount"]);
@@ -68170,7 +68176,7 @@ const deserializeAws_ec2SpotOptions = (output: any, context: __SerdeContext): Sp
     contents.MinTargetCapacity = parseInt(output["minTargetCapacity"]);
   }
   if (output["maxTotalPrice"] !== undefined) {
-    contents.MaxTotalPrice = output["maxTotalPrice"];
+    contents.MaxTotalPrice = __expectString(output["maxTotalPrice"]);
   }
   return contents;
 };
@@ -68182,13 +68188,13 @@ const deserializeAws_ec2SpotPlacement = (output: any, context: __SerdeContext): 
     Tenancy: undefined,
   };
   if (output["availabilityZone"] !== undefined) {
-    contents.AvailabilityZone = output["availabilityZone"];
+    contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
   if (output["groupName"] !== undefined) {
-    contents.GroupName = output["groupName"];
+    contents.GroupName = __expectString(output["groupName"]);
   }
   if (output["tenancy"] !== undefined) {
-    contents.Tenancy = output["tenancy"];
+    contents.Tenancy = __expectString(output["tenancy"]);
   }
   return contents;
 };
@@ -68202,16 +68208,16 @@ const deserializeAws_ec2SpotPrice = (output: any, context: __SerdeContext): Spot
     Timestamp: undefined,
   };
   if (output["availabilityZone"] !== undefined) {
-    contents.AvailabilityZone = output["availabilityZone"];
+    contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
   if (output["instanceType"] !== undefined) {
-    contents.InstanceType = output["instanceType"];
+    contents.InstanceType = __expectString(output["instanceType"]);
   }
   if (output["productDescription"] !== undefined) {
-    contents.ProductDescription = output["productDescription"];
+    contents.ProductDescription = __expectString(output["productDescription"]);
   }
   if (output["spotPrice"] !== undefined) {
-    contents.SpotPrice = output["spotPrice"];
+    contents.SpotPrice = __expectString(output["spotPrice"]);
   }
   if (output["timestamp"] !== undefined) {
     contents.Timestamp = new Date(output["timestamp"]);
@@ -68243,7 +68249,7 @@ const deserializeAws_ec2StaleIpPermission = (output: any, context: __SerdeContex
     contents.FromPort = parseInt(output["fromPort"]);
   }
   if (output["ipProtocol"] !== undefined) {
-    contents.IpProtocol = output["ipProtocol"];
+    contents.IpProtocol = __expectString(output["ipProtocol"]);
   }
   if (output.ipRanges === "") {
     contents.IpRanges = [];
@@ -68296,13 +68302,13 @@ const deserializeAws_ec2StaleSecurityGroup = (output: any, context: __SerdeConte
     VpcId: undefined,
   };
   if (output["description"] !== undefined) {
-    contents.Description = output["description"];
+    contents.Description = __expectString(output["description"]);
   }
   if (output["groupId"] !== undefined) {
-    contents.GroupId = output["groupId"];
+    contents.GroupId = __expectString(output["groupId"]);
   }
   if (output["groupName"] !== undefined) {
-    contents.GroupName = output["groupName"];
+    contents.GroupName = __expectString(output["groupName"]);
   }
   if (output.staleIpPermissions === "") {
     contents.StaleIpPermissions = [];
@@ -68323,7 +68329,7 @@ const deserializeAws_ec2StaleSecurityGroup = (output: any, context: __SerdeConte
     );
   }
   if (output["vpcId"] !== undefined) {
-    contents.VpcId = output["vpcId"];
+    contents.VpcId = __expectString(output["vpcId"]);
   }
   return contents;
 };
@@ -68390,10 +68396,10 @@ const deserializeAws_ec2StateReason = (output: any, context: __SerdeContext): St
     Message: undefined,
   };
   if (output["code"] !== undefined) {
-    contents.Code = output["code"];
+    contents.Code = __expectString(output["code"]);
   }
   if (output["message"] !== undefined) {
-    contents.Message = output["message"];
+    contents.Message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -68435,25 +68441,25 @@ const deserializeAws_ec2StoreImageTaskResult = (output: any, context: __SerdeCon
     StoreTaskFailureReason: undefined,
   };
   if (output["amiId"] !== undefined) {
-    contents.AmiId = output["amiId"];
+    contents.AmiId = __expectString(output["amiId"]);
   }
   if (output["taskStartTime"] !== undefined) {
     contents.TaskStartTime = new Date(output["taskStartTime"]);
   }
   if (output["bucket"] !== undefined) {
-    contents.Bucket = output["bucket"];
+    contents.Bucket = __expectString(output["bucket"]);
   }
   if (output["s3objectKey"] !== undefined) {
-    contents.S3objectKey = output["s3objectKey"];
+    contents.S3objectKey = __expectString(output["s3objectKey"]);
   }
   if (output["progressPercentage"] !== undefined) {
     contents.ProgressPercentage = parseInt(output["progressPercentage"]);
   }
   if (output["storeTaskState"] !== undefined) {
-    contents.StoreTaskState = output["storeTaskState"];
+    contents.StoreTaskState = __expectString(output["storeTaskState"]);
   }
   if (output["storeTaskFailureReason"] !== undefined) {
-    contents.StoreTaskFailureReason = output["storeTaskFailureReason"];
+    contents.StoreTaskFailureReason = __expectString(output["storeTaskFailureReason"]);
   }
   return contents;
 };
@@ -68476,7 +68482,7 @@ const deserializeAws_ec2StringList = (output: any, context: __SerdeContext): str
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -68501,16 +68507,16 @@ const deserializeAws_ec2Subnet = (output: any, context: __SerdeContext): Subnet 
     OutpostArn: undefined,
   };
   if (output["availabilityZone"] !== undefined) {
-    contents.AvailabilityZone = output["availabilityZone"];
+    contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
   if (output["availabilityZoneId"] !== undefined) {
-    contents.AvailabilityZoneId = output["availabilityZoneId"];
+    contents.AvailabilityZoneId = __expectString(output["availabilityZoneId"]);
   }
   if (output["availableIpAddressCount"] !== undefined) {
     contents.AvailableIpAddressCount = parseInt(output["availableIpAddressCount"]);
   }
   if (output["cidrBlock"] !== undefined) {
-    contents.CidrBlock = output["cidrBlock"];
+    contents.CidrBlock = __expectString(output["cidrBlock"]);
   }
   if (output["defaultForAz"] !== undefined) {
     contents.DefaultForAz = __parseBoolean(output["defaultForAz"]);
@@ -68522,19 +68528,19 @@ const deserializeAws_ec2Subnet = (output: any, context: __SerdeContext): Subnet 
     contents.MapCustomerOwnedIpOnLaunch = __parseBoolean(output["mapCustomerOwnedIpOnLaunch"]);
   }
   if (output["customerOwnedIpv4Pool"] !== undefined) {
-    contents.CustomerOwnedIpv4Pool = output["customerOwnedIpv4Pool"];
+    contents.CustomerOwnedIpv4Pool = __expectString(output["customerOwnedIpv4Pool"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output["subnetId"] !== undefined) {
-    contents.SubnetId = output["subnetId"];
+    contents.SubnetId = __expectString(output["subnetId"]);
   }
   if (output["vpcId"] !== undefined) {
-    contents.VpcId = output["vpcId"];
+    contents.VpcId = __expectString(output["vpcId"]);
   }
   if (output["ownerId"] !== undefined) {
-    contents.OwnerId = output["ownerId"];
+    contents.OwnerId = __expectString(output["ownerId"]);
   }
   if (output["assignIpv6AddressOnCreation"] !== undefined) {
     contents.AssignIpv6AddressOnCreation = __parseBoolean(output["assignIpv6AddressOnCreation"]);
@@ -68558,10 +68564,10 @@ const deserializeAws_ec2Subnet = (output: any, context: __SerdeContext): Subnet 
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["subnetArn"] !== undefined) {
-    contents.SubnetArn = output["subnetArn"];
+    contents.SubnetArn = __expectString(output["subnetArn"]);
   }
   if (output["outpostArn"] !== undefined) {
-    contents.OutpostArn = output["outpostArn"];
+    contents.OutpostArn = __expectString(output["outpostArn"]);
   }
   return contents;
 };
@@ -68572,10 +68578,10 @@ const deserializeAws_ec2SubnetAssociation = (output: any, context: __SerdeContex
     State: undefined,
   };
   if (output["subnetId"] !== undefined) {
-    contents.SubnetId = output["subnetId"];
+    contents.SubnetId = __expectString(output["subnetId"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   return contents;
 };
@@ -68597,10 +68603,10 @@ const deserializeAws_ec2SubnetCidrBlockState = (output: any, context: __SerdeCon
     StatusMessage: undefined,
   };
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output["statusMessage"] !== undefined) {
-    contents.StatusMessage = output["statusMessage"];
+    contents.StatusMessage = __expectString(output["statusMessage"]);
   }
   return contents;
 };
@@ -68615,10 +68621,10 @@ const deserializeAws_ec2SubnetIpv6CidrBlockAssociation = (
     Ipv6CidrBlockState: undefined,
   };
   if (output["associationId"] !== undefined) {
-    contents.AssociationId = output["associationId"];
+    contents.AssociationId = __expectString(output["associationId"]);
   }
   if (output["ipv6CidrBlock"] !== undefined) {
-    contents.Ipv6CidrBlock = output["ipv6CidrBlock"];
+    contents.Ipv6CidrBlock = __expectString(output["ipv6CidrBlock"]);
   }
   if (output["ipv6CidrBlockState"] !== undefined) {
     contents.Ipv6CidrBlockState = deserializeAws_ec2SubnetCidrBlockState(output["ipv6CidrBlockState"], context);
@@ -68659,7 +68665,7 @@ const deserializeAws_ec2SuccessfulInstanceCreditSpecificationItem = (
     InstanceId: undefined,
   };
   if (output["instanceId"] !== undefined) {
-    contents.InstanceId = output["instanceId"];
+    contents.InstanceId = __expectString(output["instanceId"]);
   }
   return contents;
 };
@@ -68686,7 +68692,7 @@ const deserializeAws_ec2SuccessfulQueuedPurchaseDeletion = (
     ReservedInstancesId: undefined,
   };
   if (output["reservedInstancesId"] !== undefined) {
-    contents.ReservedInstancesId = output["reservedInstancesId"];
+    contents.ReservedInstancesId = __expectString(output["reservedInstancesId"]);
   }
   return contents;
 };
@@ -68711,10 +68717,10 @@ const deserializeAws_ec2Tag = (output: any, context: __SerdeContext): Tag => {
     Value: undefined,
   };
   if (output["key"] !== undefined) {
-    contents.Key = output["key"];
+    contents.Key = __expectString(output["key"]);
   }
   if (output["value"] !== undefined) {
-    contents.Value = output["value"];
+    contents.Value = __expectString(output["value"]);
   }
   return contents;
 };
@@ -68727,16 +68733,16 @@ const deserializeAws_ec2TagDescription = (output: any, context: __SerdeContext):
     Value: undefined,
   };
   if (output["key"] !== undefined) {
-    contents.Key = output["key"];
+    contents.Key = __expectString(output["key"]);
   }
   if (output["resourceId"] !== undefined) {
-    contents.ResourceId = output["resourceId"];
+    contents.ResourceId = __expectString(output["resourceId"]);
   }
   if (output["resourceType"] !== undefined) {
-    contents.ResourceType = output["resourceType"];
+    contents.ResourceType = __expectString(output["resourceType"]);
   }
   if (output["value"] !== undefined) {
-    contents.Value = output["value"];
+    contents.Value = __expectString(output["value"]);
   }
   return contents;
 };
@@ -68769,7 +68775,7 @@ const deserializeAws_ec2TagSpecification = (output: any, context: __SerdeContext
     Tags: undefined,
   };
   if (output["resourceType"] !== undefined) {
-    contents.ResourceType = output["resourceType"];
+    contents.ResourceType = __expectString(output["resourceType"]);
   }
   if (output.Tag === "") {
     contents.Tags = [];
@@ -68811,7 +68817,7 @@ const deserializeAws_ec2TargetCapacitySpecification = (
     contents.SpotTargetCapacity = parseInt(output["spotTargetCapacity"]);
   }
   if (output["defaultTargetCapacityType"] !== undefined) {
-    contents.DefaultTargetCapacityType = output["defaultTargetCapacityType"];
+    contents.DefaultTargetCapacityType = __expectString(output["defaultTargetCapacityType"]);
   }
   return contents;
 };
@@ -68825,7 +68831,7 @@ const deserializeAws_ec2TargetConfiguration = (output: any, context: __SerdeCont
     contents.InstanceCount = parseInt(output["instanceCount"]);
   }
   if (output["offeringId"] !== undefined) {
-    contents.OfferingId = output["offeringId"];
+    contents.OfferingId = __expectString(output["offeringId"]);
   }
   return contents;
 };
@@ -68835,7 +68841,7 @@ const deserializeAws_ec2TargetGroup = (output: any, context: __SerdeContext): Ta
     Arn: undefined,
   };
   if (output["arn"] !== undefined) {
-    contents.Arn = output["arn"];
+    contents.Arn = __expectString(output["arn"]);
   }
   return contents;
 };
@@ -68877,16 +68883,16 @@ const deserializeAws_ec2TargetNetwork = (output: any, context: __SerdeContext): 
     SecurityGroups: undefined,
   };
   if (output["associationId"] !== undefined) {
-    contents.AssociationId = output["associationId"];
+    contents.AssociationId = __expectString(output["associationId"]);
   }
   if (output["vpcId"] !== undefined) {
-    contents.VpcId = output["vpcId"];
+    contents.VpcId = __expectString(output["vpcId"]);
   }
   if (output["targetNetworkId"] !== undefined) {
-    contents.TargetNetworkId = output["targetNetworkId"];
+    contents.TargetNetworkId = __expectString(output["targetNetworkId"]);
   }
   if (output["clientVpnEndpointId"] !== undefined) {
-    contents.ClientVpnEndpointId = output["clientVpnEndpointId"];
+    contents.ClientVpnEndpointId = __expectString(output["clientVpnEndpointId"]);
   }
   if (output["status"] !== undefined) {
     contents.Status = deserializeAws_ec2AssociationStatus(output["status"], context);
@@ -68952,10 +68958,10 @@ const deserializeAws_ec2TerminateClientVpnConnectionsResult = (
     ConnectionStatuses: undefined,
   };
   if (output["clientVpnEndpointId"] !== undefined) {
-    contents.ClientVpnEndpointId = output["clientVpnEndpointId"];
+    contents.ClientVpnEndpointId = __expectString(output["clientVpnEndpointId"]);
   }
   if (output["username"] !== undefined) {
-    contents.Username = output["username"];
+    contents.Username = __expectString(output["username"]);
   }
   if (output.connectionStatuses === "") {
     contents.ConnectionStatuses = [];
@@ -68979,7 +68985,7 @@ const deserializeAws_ec2TerminateConnectionStatus = (
     CurrentStatus: undefined,
   };
   if (output["connectionId"] !== undefined) {
-    contents.ConnectionId = output["connectionId"];
+    contents.ConnectionId = __expectString(output["connectionId"]);
   }
   if (output["previousStatus"] !== undefined) {
     contents.PreviousStatus = deserializeAws_ec2ClientVpnConnectionStatus(output["previousStatus"], context);
@@ -69041,7 +69047,7 @@ const deserializeAws_ec2TrafficMirrorFilter = (output: any, context: __SerdeCont
     Tags: undefined,
   };
   if (output["trafficMirrorFilterId"] !== undefined) {
-    contents.TrafficMirrorFilterId = output["trafficMirrorFilterId"];
+    contents.TrafficMirrorFilterId = __expectString(output["trafficMirrorFilterId"]);
   }
   if (output.ingressFilterRuleSet === "") {
     contents.IngressFilterRules = [];
@@ -69071,7 +69077,7 @@ const deserializeAws_ec2TrafficMirrorFilter = (output: any, context: __SerdeCont
     );
   }
   if (output["description"] !== undefined) {
-    contents.Description = output["description"];
+    contents.Description = __expectString(output["description"]);
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -69097,19 +69103,19 @@ const deserializeAws_ec2TrafficMirrorFilterRule = (output: any, context: __Serde
     Description: undefined,
   };
   if (output["trafficMirrorFilterRuleId"] !== undefined) {
-    contents.TrafficMirrorFilterRuleId = output["trafficMirrorFilterRuleId"];
+    contents.TrafficMirrorFilterRuleId = __expectString(output["trafficMirrorFilterRuleId"]);
   }
   if (output["trafficMirrorFilterId"] !== undefined) {
-    contents.TrafficMirrorFilterId = output["trafficMirrorFilterId"];
+    contents.TrafficMirrorFilterId = __expectString(output["trafficMirrorFilterId"]);
   }
   if (output["trafficDirection"] !== undefined) {
-    contents.TrafficDirection = output["trafficDirection"];
+    contents.TrafficDirection = __expectString(output["trafficDirection"]);
   }
   if (output["ruleNumber"] !== undefined) {
     contents.RuleNumber = parseInt(output["ruleNumber"]);
   }
   if (output["ruleAction"] !== undefined) {
-    contents.RuleAction = output["ruleAction"];
+    contents.RuleAction = __expectString(output["ruleAction"]);
   }
   if (output["protocol"] !== undefined) {
     contents.Protocol = parseInt(output["protocol"]);
@@ -69121,13 +69127,13 @@ const deserializeAws_ec2TrafficMirrorFilterRule = (output: any, context: __Serde
     contents.SourcePortRange = deserializeAws_ec2TrafficMirrorPortRange(output["sourcePortRange"], context);
   }
   if (output["destinationCidrBlock"] !== undefined) {
-    contents.DestinationCidrBlock = output["destinationCidrBlock"];
+    contents.DestinationCidrBlock = __expectString(output["destinationCidrBlock"]);
   }
   if (output["sourceCidrBlock"] !== undefined) {
-    contents.SourceCidrBlock = output["sourceCidrBlock"];
+    contents.SourceCidrBlock = __expectString(output["sourceCidrBlock"]);
   }
   if (output["description"] !== undefined) {
-    contents.Description = output["description"];
+    contents.Description = __expectString(output["description"]);
   }
   return contents;
 };
@@ -69167,7 +69173,7 @@ const deserializeAws_ec2TrafficMirrorNetworkServiceList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -69199,19 +69205,19 @@ const deserializeAws_ec2TrafficMirrorSession = (output: any, context: __SerdeCon
     Tags: undefined,
   };
   if (output["trafficMirrorSessionId"] !== undefined) {
-    contents.TrafficMirrorSessionId = output["trafficMirrorSessionId"];
+    contents.TrafficMirrorSessionId = __expectString(output["trafficMirrorSessionId"]);
   }
   if (output["trafficMirrorTargetId"] !== undefined) {
-    contents.TrafficMirrorTargetId = output["trafficMirrorTargetId"];
+    contents.TrafficMirrorTargetId = __expectString(output["trafficMirrorTargetId"]);
   }
   if (output["trafficMirrorFilterId"] !== undefined) {
-    contents.TrafficMirrorFilterId = output["trafficMirrorFilterId"];
+    contents.TrafficMirrorFilterId = __expectString(output["trafficMirrorFilterId"]);
   }
   if (output["networkInterfaceId"] !== undefined) {
-    contents.NetworkInterfaceId = output["networkInterfaceId"];
+    contents.NetworkInterfaceId = __expectString(output["networkInterfaceId"]);
   }
   if (output["ownerId"] !== undefined) {
-    contents.OwnerId = output["ownerId"];
+    contents.OwnerId = __expectString(output["ownerId"]);
   }
   if (output["packetLength"] !== undefined) {
     contents.PacketLength = parseInt(output["packetLength"]);
@@ -69223,7 +69229,7 @@ const deserializeAws_ec2TrafficMirrorSession = (output: any, context: __SerdeCon
     contents.VirtualNetworkId = parseInt(output["virtualNetworkId"]);
   }
   if (output["description"] !== undefined) {
-    contents.Description = output["description"];
+    contents.Description = __expectString(output["description"]);
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -69256,22 +69262,22 @@ const deserializeAws_ec2TrafficMirrorTarget = (output: any, context: __SerdeCont
     Tags: undefined,
   };
   if (output["trafficMirrorTargetId"] !== undefined) {
-    contents.TrafficMirrorTargetId = output["trafficMirrorTargetId"];
+    contents.TrafficMirrorTargetId = __expectString(output["trafficMirrorTargetId"]);
   }
   if (output["networkInterfaceId"] !== undefined) {
-    contents.NetworkInterfaceId = output["networkInterfaceId"];
+    contents.NetworkInterfaceId = __expectString(output["networkInterfaceId"]);
   }
   if (output["networkLoadBalancerArn"] !== undefined) {
-    contents.NetworkLoadBalancerArn = output["networkLoadBalancerArn"];
+    contents.NetworkLoadBalancerArn = __expectString(output["networkLoadBalancerArn"]);
   }
   if (output["type"] !== undefined) {
-    contents.Type = output["type"];
+    contents.Type = __expectString(output["type"]);
   }
   if (output["description"] !== undefined) {
-    contents.Description = output["description"];
+    contents.Description = __expectString(output["description"]);
   }
   if (output["ownerId"] !== undefined) {
-    contents.OwnerId = output["ownerId"];
+    contents.OwnerId = __expectString(output["ownerId"]);
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -69305,19 +69311,19 @@ const deserializeAws_ec2TransitGateway = (output: any, context: __SerdeContext):
     Tags: undefined,
   };
   if (output["transitGatewayId"] !== undefined) {
-    contents.TransitGatewayId = output["transitGatewayId"];
+    contents.TransitGatewayId = __expectString(output["transitGatewayId"]);
   }
   if (output["transitGatewayArn"] !== undefined) {
-    contents.TransitGatewayArn = output["transitGatewayArn"];
+    contents.TransitGatewayArn = __expectString(output["transitGatewayArn"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output["ownerId"] !== undefined) {
-    contents.OwnerId = output["ownerId"];
+    contents.OwnerId = __expectString(output["ownerId"]);
   }
   if (output["description"] !== undefined) {
-    contents.Description = output["description"];
+    contents.Description = __expectString(output["description"]);
   }
   if (output["creationTime"] !== undefined) {
     contents.CreationTime = new Date(output["creationTime"]);
@@ -69346,19 +69352,19 @@ const deserializeAws_ec2TransitGatewayAssociation = (
     State: undefined,
   };
   if (output["transitGatewayRouteTableId"] !== undefined) {
-    contents.TransitGatewayRouteTableId = output["transitGatewayRouteTableId"];
+    contents.TransitGatewayRouteTableId = __expectString(output["transitGatewayRouteTableId"]);
   }
   if (output["transitGatewayAttachmentId"] !== undefined) {
-    contents.TransitGatewayAttachmentId = output["transitGatewayAttachmentId"];
+    contents.TransitGatewayAttachmentId = __expectString(output["transitGatewayAttachmentId"]);
   }
   if (output["resourceId"] !== undefined) {
-    contents.ResourceId = output["resourceId"];
+    contents.ResourceId = __expectString(output["resourceId"]);
   }
   if (output["resourceType"] !== undefined) {
-    contents.ResourceType = output["resourceType"];
+    contents.ResourceType = __expectString(output["resourceType"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   return contents;
 };
@@ -69377,25 +69383,25 @@ const deserializeAws_ec2TransitGatewayAttachment = (output: any, context: __Serd
     Tags: undefined,
   };
   if (output["transitGatewayAttachmentId"] !== undefined) {
-    contents.TransitGatewayAttachmentId = output["transitGatewayAttachmentId"];
+    contents.TransitGatewayAttachmentId = __expectString(output["transitGatewayAttachmentId"]);
   }
   if (output["transitGatewayId"] !== undefined) {
-    contents.TransitGatewayId = output["transitGatewayId"];
+    contents.TransitGatewayId = __expectString(output["transitGatewayId"]);
   }
   if (output["transitGatewayOwnerId"] !== undefined) {
-    contents.TransitGatewayOwnerId = output["transitGatewayOwnerId"];
+    contents.TransitGatewayOwnerId = __expectString(output["transitGatewayOwnerId"]);
   }
   if (output["resourceOwnerId"] !== undefined) {
-    contents.ResourceOwnerId = output["resourceOwnerId"];
+    contents.ResourceOwnerId = __expectString(output["resourceOwnerId"]);
   }
   if (output["resourceType"] !== undefined) {
-    contents.ResourceType = output["resourceType"];
+    contents.ResourceType = __expectString(output["resourceType"]);
   }
   if (output["resourceId"] !== undefined) {
-    contents.ResourceId = output["resourceId"];
+    contents.ResourceId = __expectString(output["resourceId"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output["association"] !== undefined) {
     contents.Association = deserializeAws_ec2TransitGatewayAttachmentAssociation(output["association"], context);
@@ -69421,10 +69427,10 @@ const deserializeAws_ec2TransitGatewayAttachmentAssociation = (
     State: undefined,
   };
   if (output["transitGatewayRouteTableId"] !== undefined) {
-    contents.TransitGatewayRouteTableId = output["transitGatewayRouteTableId"];
+    contents.TransitGatewayRouteTableId = __expectString(output["transitGatewayRouteTableId"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   return contents;
 };
@@ -69447,13 +69453,13 @@ const deserializeAws_ec2TransitGatewayAttachmentBgpConfiguration = (
     contents.PeerAsn = parseInt(output["peerAsn"]);
   }
   if (output["transitGatewayAddress"] !== undefined) {
-    contents.TransitGatewayAddress = output["transitGatewayAddress"];
+    contents.TransitGatewayAddress = __expectString(output["transitGatewayAddress"]);
   }
   if (output["peerAddress"] !== undefined) {
-    contents.PeerAddress = output["peerAddress"];
+    contents.PeerAddress = __expectString(output["peerAddress"]);
   }
   if (output["bgpStatus"] !== undefined) {
-    contents.BgpStatus = output["bgpStatus"];
+    contents.BgpStatus = __expectString(output["bgpStatus"]);
   }
   return contents;
 };
@@ -69495,10 +69501,10 @@ const deserializeAws_ec2TransitGatewayAttachmentPropagation = (
     State: undefined,
   };
   if (output["transitGatewayRouteTableId"] !== undefined) {
-    contents.TransitGatewayRouteTableId = output["transitGatewayRouteTableId"];
+    contents.TransitGatewayRouteTableId = __expectString(output["transitGatewayRouteTableId"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   return contents;
 };
@@ -69528,16 +69534,16 @@ const deserializeAws_ec2TransitGatewayConnect = (output: any, context: __SerdeCo
     Tags: undefined,
   };
   if (output["transitGatewayAttachmentId"] !== undefined) {
-    contents.TransitGatewayAttachmentId = output["transitGatewayAttachmentId"];
+    contents.TransitGatewayAttachmentId = __expectString(output["transitGatewayAttachmentId"]);
   }
   if (output["transportTransitGatewayAttachmentId"] !== undefined) {
-    contents.TransportTransitGatewayAttachmentId = output["transportTransitGatewayAttachmentId"];
+    contents.TransportTransitGatewayAttachmentId = __expectString(output["transportTransitGatewayAttachmentId"]);
   }
   if (output["transitGatewayId"] !== undefined) {
-    contents.TransitGatewayId = output["transitGatewayId"];
+    contents.TransitGatewayId = __expectString(output["transitGatewayId"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output["creationTime"] !== undefined) {
     contents.CreationTime = new Date(output["creationTime"]);
@@ -69573,7 +69579,7 @@ const deserializeAws_ec2TransitGatewayConnectOptions = (
     Protocol: undefined,
   };
   if (output["protocol"] !== undefined) {
-    contents.Protocol = output["protocol"];
+    contents.Protocol = __expectString(output["protocol"]);
   }
   return contents;
 };
@@ -69591,13 +69597,13 @@ const deserializeAws_ec2TransitGatewayConnectPeer = (
     Tags: undefined,
   };
   if (output["transitGatewayAttachmentId"] !== undefined) {
-    contents.TransitGatewayAttachmentId = output["transitGatewayAttachmentId"];
+    contents.TransitGatewayAttachmentId = __expectString(output["transitGatewayAttachmentId"]);
   }
   if (output["transitGatewayConnectPeerId"] !== undefined) {
-    contents.TransitGatewayConnectPeerId = output["transitGatewayConnectPeerId"];
+    contents.TransitGatewayConnectPeerId = __expectString(output["transitGatewayConnectPeerId"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output["creationTime"] !== undefined) {
     contents.CreationTime = new Date(output["creationTime"]);
@@ -69629,10 +69635,10 @@ const deserializeAws_ec2TransitGatewayConnectPeerConfiguration = (
     BgpConfigurations: undefined,
   };
   if (output["transitGatewayAddress"] !== undefined) {
-    contents.TransitGatewayAddress = output["transitGatewayAddress"];
+    contents.TransitGatewayAddress = __expectString(output["transitGatewayAddress"]);
   }
   if (output["peerAddress"] !== undefined) {
-    contents.PeerAddress = output["peerAddress"];
+    contents.PeerAddress = __expectString(output["peerAddress"]);
   }
   if (output.insideCidrBlocks === "") {
     contents.InsideCidrBlocks = [];
@@ -69644,7 +69650,7 @@ const deserializeAws_ec2TransitGatewayConnectPeerConfiguration = (
     );
   }
   if (output["protocol"] !== undefined) {
-    contents.Protocol = output["protocol"];
+    contents.Protocol = __expectString(output["protocol"]);
   }
   if (output.bgpConfigurations === "") {
     contents.BgpConfigurations = [];
@@ -69693,7 +69699,7 @@ const deserializeAws_ec2TransitGatewayMulticastDeregisteredGroupMembers = (
     GroupIpAddress: undefined,
   };
   if (output["transitGatewayMulticastDomainId"] !== undefined) {
-    contents.TransitGatewayMulticastDomainId = output["transitGatewayMulticastDomainId"];
+    contents.TransitGatewayMulticastDomainId = __expectString(output["transitGatewayMulticastDomainId"]);
   }
   if (output.deregisteredNetworkInterfaceIds === "") {
     contents.DeregisteredNetworkInterfaceIds = [];
@@ -69708,7 +69714,7 @@ const deserializeAws_ec2TransitGatewayMulticastDeregisteredGroupMembers = (
     );
   }
   if (output["groupIpAddress"] !== undefined) {
-    contents.GroupIpAddress = output["groupIpAddress"];
+    contents.GroupIpAddress = __expectString(output["groupIpAddress"]);
   }
   return contents;
 };
@@ -69723,7 +69729,7 @@ const deserializeAws_ec2TransitGatewayMulticastDeregisteredGroupSources = (
     GroupIpAddress: undefined,
   };
   if (output["transitGatewayMulticastDomainId"] !== undefined) {
-    contents.TransitGatewayMulticastDomainId = output["transitGatewayMulticastDomainId"];
+    contents.TransitGatewayMulticastDomainId = __expectString(output["transitGatewayMulticastDomainId"]);
   }
   if (output.deregisteredNetworkInterfaceIds === "") {
     contents.DeregisteredNetworkInterfaceIds = [];
@@ -69738,7 +69744,7 @@ const deserializeAws_ec2TransitGatewayMulticastDeregisteredGroupSources = (
     );
   }
   if (output["groupIpAddress"] !== undefined) {
-    contents.GroupIpAddress = output["groupIpAddress"];
+    contents.GroupIpAddress = __expectString(output["groupIpAddress"]);
   }
   return contents;
 };
@@ -69758,22 +69764,22 @@ const deserializeAws_ec2TransitGatewayMulticastDomain = (
     Tags: undefined,
   };
   if (output["transitGatewayMulticastDomainId"] !== undefined) {
-    contents.TransitGatewayMulticastDomainId = output["transitGatewayMulticastDomainId"];
+    contents.TransitGatewayMulticastDomainId = __expectString(output["transitGatewayMulticastDomainId"]);
   }
   if (output["transitGatewayId"] !== undefined) {
-    contents.TransitGatewayId = output["transitGatewayId"];
+    contents.TransitGatewayId = __expectString(output["transitGatewayId"]);
   }
   if (output["transitGatewayMulticastDomainArn"] !== undefined) {
-    contents.TransitGatewayMulticastDomainArn = output["transitGatewayMulticastDomainArn"];
+    contents.TransitGatewayMulticastDomainArn = __expectString(output["transitGatewayMulticastDomainArn"]);
   }
   if (output["ownerId"] !== undefined) {
-    contents.OwnerId = output["ownerId"];
+    contents.OwnerId = __expectString(output["ownerId"]);
   }
   if (output["options"] !== undefined) {
     contents.Options = deserializeAws_ec2TransitGatewayMulticastDomainOptions(output["options"], context);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output["creationTime"] !== undefined) {
     contents.CreationTime = new Date(output["creationTime"]);
@@ -69799,16 +69805,16 @@ const deserializeAws_ec2TransitGatewayMulticastDomainAssociation = (
     Subnet: undefined,
   };
   if (output["transitGatewayAttachmentId"] !== undefined) {
-    contents.TransitGatewayAttachmentId = output["transitGatewayAttachmentId"];
+    contents.TransitGatewayAttachmentId = __expectString(output["transitGatewayAttachmentId"]);
   }
   if (output["resourceId"] !== undefined) {
-    contents.ResourceId = output["resourceId"];
+    contents.ResourceId = __expectString(output["resourceId"]);
   }
   if (output["resourceType"] !== undefined) {
-    contents.ResourceType = output["resourceType"];
+    contents.ResourceType = __expectString(output["resourceType"]);
   }
   if (output["resourceOwnerId"] !== undefined) {
-    contents.ResourceOwnerId = output["resourceOwnerId"];
+    contents.ResourceOwnerId = __expectString(output["resourceOwnerId"]);
   }
   if (output["subnet"] !== undefined) {
     contents.Subnet = deserializeAws_ec2SubnetAssociation(output["subnet"], context);
@@ -69843,19 +69849,19 @@ const deserializeAws_ec2TransitGatewayMulticastDomainAssociations = (
     Subnets: undefined,
   };
   if (output["transitGatewayMulticastDomainId"] !== undefined) {
-    contents.TransitGatewayMulticastDomainId = output["transitGatewayMulticastDomainId"];
+    contents.TransitGatewayMulticastDomainId = __expectString(output["transitGatewayMulticastDomainId"]);
   }
   if (output["transitGatewayAttachmentId"] !== undefined) {
-    contents.TransitGatewayAttachmentId = output["transitGatewayAttachmentId"];
+    contents.TransitGatewayAttachmentId = __expectString(output["transitGatewayAttachmentId"]);
   }
   if (output["resourceId"] !== undefined) {
-    contents.ResourceId = output["resourceId"];
+    contents.ResourceId = __expectString(output["resourceId"]);
   }
   if (output["resourceType"] !== undefined) {
-    contents.ResourceType = output["resourceType"];
+    contents.ResourceType = __expectString(output["resourceType"]);
   }
   if (output["resourceOwnerId"] !== undefined) {
-    contents.ResourceOwnerId = output["resourceOwnerId"];
+    contents.ResourceOwnerId = __expectString(output["resourceOwnerId"]);
   }
   if (output.subnets === "") {
     contents.Subnets = [];
@@ -69893,13 +69899,13 @@ const deserializeAws_ec2TransitGatewayMulticastDomainOptions = (
     AutoAcceptSharedAssociations: undefined,
   };
   if (output["igmpv2Support"] !== undefined) {
-    contents.Igmpv2Support = output["igmpv2Support"];
+    contents.Igmpv2Support = __expectString(output["igmpv2Support"]);
   }
   if (output["staticSourcesSupport"] !== undefined) {
-    contents.StaticSourcesSupport = output["staticSourcesSupport"];
+    contents.StaticSourcesSupport = __expectString(output["staticSourcesSupport"]);
   }
   if (output["autoAcceptSharedAssociations"] !== undefined) {
-    contents.AutoAcceptSharedAssociations = output["autoAcceptSharedAssociations"];
+    contents.AutoAcceptSharedAssociations = __expectString(output["autoAcceptSharedAssociations"]);
   }
   return contents;
 };
@@ -69922,25 +69928,25 @@ const deserializeAws_ec2TransitGatewayMulticastGroup = (
     SourceType: undefined,
   };
   if (output["groupIpAddress"] !== undefined) {
-    contents.GroupIpAddress = output["groupIpAddress"];
+    contents.GroupIpAddress = __expectString(output["groupIpAddress"]);
   }
   if (output["transitGatewayAttachmentId"] !== undefined) {
-    contents.TransitGatewayAttachmentId = output["transitGatewayAttachmentId"];
+    contents.TransitGatewayAttachmentId = __expectString(output["transitGatewayAttachmentId"]);
   }
   if (output["subnetId"] !== undefined) {
-    contents.SubnetId = output["subnetId"];
+    contents.SubnetId = __expectString(output["subnetId"]);
   }
   if (output["resourceId"] !== undefined) {
-    contents.ResourceId = output["resourceId"];
+    contents.ResourceId = __expectString(output["resourceId"]);
   }
   if (output["resourceType"] !== undefined) {
-    contents.ResourceType = output["resourceType"];
+    contents.ResourceType = __expectString(output["resourceType"]);
   }
   if (output["resourceOwnerId"] !== undefined) {
-    contents.ResourceOwnerId = output["resourceOwnerId"];
+    contents.ResourceOwnerId = __expectString(output["resourceOwnerId"]);
   }
   if (output["networkInterfaceId"] !== undefined) {
-    contents.NetworkInterfaceId = output["networkInterfaceId"];
+    contents.NetworkInterfaceId = __expectString(output["networkInterfaceId"]);
   }
   if (output["groupMember"] !== undefined) {
     contents.GroupMember = __parseBoolean(output["groupMember"]);
@@ -69949,10 +69955,10 @@ const deserializeAws_ec2TransitGatewayMulticastGroup = (
     contents.GroupSource = __parseBoolean(output["groupSource"]);
   }
   if (output["memberType"] !== undefined) {
-    contents.MemberType = output["memberType"];
+    contents.MemberType = __expectString(output["memberType"]);
   }
   if (output["sourceType"] !== undefined) {
-    contents.SourceType = output["sourceType"];
+    contents.SourceType = __expectString(output["sourceType"]);
   }
   return contents;
 };
@@ -69981,7 +69987,7 @@ const deserializeAws_ec2TransitGatewayMulticastRegisteredGroupMembers = (
     GroupIpAddress: undefined,
   };
   if (output["transitGatewayMulticastDomainId"] !== undefined) {
-    contents.TransitGatewayMulticastDomainId = output["transitGatewayMulticastDomainId"];
+    contents.TransitGatewayMulticastDomainId = __expectString(output["transitGatewayMulticastDomainId"]);
   }
   if (output.registeredNetworkInterfaceIds === "") {
     contents.RegisteredNetworkInterfaceIds = [];
@@ -69996,7 +70002,7 @@ const deserializeAws_ec2TransitGatewayMulticastRegisteredGroupMembers = (
     );
   }
   if (output["groupIpAddress"] !== undefined) {
-    contents.GroupIpAddress = output["groupIpAddress"];
+    contents.GroupIpAddress = __expectString(output["groupIpAddress"]);
   }
   return contents;
 };
@@ -70011,7 +70017,7 @@ const deserializeAws_ec2TransitGatewayMulticastRegisteredGroupSources = (
     GroupIpAddress: undefined,
   };
   if (output["transitGatewayMulticastDomainId"] !== undefined) {
-    contents.TransitGatewayMulticastDomainId = output["transitGatewayMulticastDomainId"];
+    contents.TransitGatewayMulticastDomainId = __expectString(output["transitGatewayMulticastDomainId"]);
   }
   if (output.registeredNetworkInterfaceIds === "") {
     contents.RegisteredNetworkInterfaceIds = [];
@@ -70026,7 +70032,7 @@ const deserializeAws_ec2TransitGatewayMulticastRegisteredGroupSources = (
     );
   }
   if (output["groupIpAddress"] !== undefined) {
-    contents.GroupIpAddress = output["groupIpAddress"];
+    contents.GroupIpAddress = __expectString(output["groupIpAddress"]);
   }
   return contents;
 };
@@ -70057,28 +70063,28 @@ const deserializeAws_ec2TransitGatewayOptions = (output: any, context: __SerdeCo
     );
   }
   if (output["autoAcceptSharedAttachments"] !== undefined) {
-    contents.AutoAcceptSharedAttachments = output["autoAcceptSharedAttachments"];
+    contents.AutoAcceptSharedAttachments = __expectString(output["autoAcceptSharedAttachments"]);
   }
   if (output["defaultRouteTableAssociation"] !== undefined) {
-    contents.DefaultRouteTableAssociation = output["defaultRouteTableAssociation"];
+    contents.DefaultRouteTableAssociation = __expectString(output["defaultRouteTableAssociation"]);
   }
   if (output["associationDefaultRouteTableId"] !== undefined) {
-    contents.AssociationDefaultRouteTableId = output["associationDefaultRouteTableId"];
+    contents.AssociationDefaultRouteTableId = __expectString(output["associationDefaultRouteTableId"]);
   }
   if (output["defaultRouteTablePropagation"] !== undefined) {
-    contents.DefaultRouteTablePropagation = output["defaultRouteTablePropagation"];
+    contents.DefaultRouteTablePropagation = __expectString(output["defaultRouteTablePropagation"]);
   }
   if (output["propagationDefaultRouteTableId"] !== undefined) {
-    contents.PropagationDefaultRouteTableId = output["propagationDefaultRouteTableId"];
+    contents.PropagationDefaultRouteTableId = __expectString(output["propagationDefaultRouteTableId"]);
   }
   if (output["vpnEcmpSupport"] !== undefined) {
-    contents.VpnEcmpSupport = output["vpnEcmpSupport"];
+    contents.VpnEcmpSupport = __expectString(output["vpnEcmpSupport"]);
   }
   if (output["dnsSupport"] !== undefined) {
-    contents.DnsSupport = output["dnsSupport"];
+    contents.DnsSupport = __expectString(output["dnsSupport"]);
   }
   if (output["multicastSupport"] !== undefined) {
-    contents.MulticastSupport = output["multicastSupport"];
+    contents.MulticastSupport = __expectString(output["multicastSupport"]);
   }
   return contents;
 };
@@ -70097,7 +70103,7 @@ const deserializeAws_ec2TransitGatewayPeeringAttachment = (
     Tags: undefined,
   };
   if (output["transitGatewayAttachmentId"] !== undefined) {
-    contents.TransitGatewayAttachmentId = output["transitGatewayAttachmentId"];
+    contents.TransitGatewayAttachmentId = __expectString(output["transitGatewayAttachmentId"]);
   }
   if (output["requesterTgwInfo"] !== undefined) {
     contents.RequesterTgwInfo = deserializeAws_ec2PeeringTgwInfo(output["requesterTgwInfo"], context);
@@ -70109,7 +70115,7 @@ const deserializeAws_ec2TransitGatewayPeeringAttachment = (
     contents.Status = deserializeAws_ec2PeeringAttachmentStatus(output["status"], context);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output["creationTime"] !== undefined) {
     contents.CreationTime = new Date(output["creationTime"]);
@@ -70147,13 +70153,13 @@ const deserializeAws_ec2TransitGatewayPrefixListAttachment = (
     ResourceId: undefined,
   };
   if (output["transitGatewayAttachmentId"] !== undefined) {
-    contents.TransitGatewayAttachmentId = output["transitGatewayAttachmentId"];
+    contents.TransitGatewayAttachmentId = __expectString(output["transitGatewayAttachmentId"]);
   }
   if (output["resourceType"] !== undefined) {
-    contents.ResourceType = output["resourceType"];
+    contents.ResourceType = __expectString(output["resourceType"]);
   }
   if (output["resourceId"] !== undefined) {
-    contents.ResourceId = output["resourceId"];
+    contents.ResourceId = __expectString(output["resourceId"]);
   }
   return contents;
 };
@@ -70171,16 +70177,16 @@ const deserializeAws_ec2TransitGatewayPrefixListReference = (
     TransitGatewayAttachment: undefined,
   };
   if (output["transitGatewayRouteTableId"] !== undefined) {
-    contents.TransitGatewayRouteTableId = output["transitGatewayRouteTableId"];
+    contents.TransitGatewayRouteTableId = __expectString(output["transitGatewayRouteTableId"]);
   }
   if (output["prefixListId"] !== undefined) {
-    contents.PrefixListId = output["prefixListId"];
+    contents.PrefixListId = __expectString(output["prefixListId"]);
   }
   if (output["prefixListOwnerId"] !== undefined) {
-    contents.PrefixListOwnerId = output["prefixListOwnerId"];
+    contents.PrefixListOwnerId = __expectString(output["prefixListOwnerId"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output["blackhole"] !== undefined) {
     contents.Blackhole = __parseBoolean(output["blackhole"]);
@@ -70220,19 +70226,19 @@ const deserializeAws_ec2TransitGatewayPropagation = (
     State: undefined,
   };
   if (output["transitGatewayAttachmentId"] !== undefined) {
-    contents.TransitGatewayAttachmentId = output["transitGatewayAttachmentId"];
+    contents.TransitGatewayAttachmentId = __expectString(output["transitGatewayAttachmentId"]);
   }
   if (output["resourceId"] !== undefined) {
-    contents.ResourceId = output["resourceId"];
+    contents.ResourceId = __expectString(output["resourceId"]);
   }
   if (output["resourceType"] !== undefined) {
-    contents.ResourceType = output["resourceType"];
+    contents.ResourceType = __expectString(output["resourceType"]);
   }
   if (output["transitGatewayRouteTableId"] !== undefined) {
-    contents.TransitGatewayRouteTableId = output["transitGatewayRouteTableId"];
+    contents.TransitGatewayRouteTableId = __expectString(output["transitGatewayRouteTableId"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   return contents;
 };
@@ -70246,10 +70252,10 @@ const deserializeAws_ec2TransitGatewayRoute = (output: any, context: __SerdeCont
     State: undefined,
   };
   if (output["destinationCidrBlock"] !== undefined) {
-    contents.DestinationCidrBlock = output["destinationCidrBlock"];
+    contents.DestinationCidrBlock = __expectString(output["destinationCidrBlock"]);
   }
   if (output["prefixListId"] !== undefined) {
-    contents.PrefixListId = output["prefixListId"];
+    contents.PrefixListId = __expectString(output["prefixListId"]);
   }
   if (output.transitGatewayAttachments === "") {
     contents.TransitGatewayAttachments = [];
@@ -70261,10 +70267,10 @@ const deserializeAws_ec2TransitGatewayRoute = (output: any, context: __SerdeCont
     );
   }
   if (output["type"] !== undefined) {
-    contents.Type = output["type"];
+    contents.Type = __expectString(output["type"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   return contents;
 };
@@ -70279,13 +70285,13 @@ const deserializeAws_ec2TransitGatewayRouteAttachment = (
     ResourceType: undefined,
   };
   if (output["resourceId"] !== undefined) {
-    contents.ResourceId = output["resourceId"];
+    contents.ResourceId = __expectString(output["resourceId"]);
   }
   if (output["transitGatewayAttachmentId"] !== undefined) {
-    contents.TransitGatewayAttachmentId = output["transitGatewayAttachmentId"];
+    contents.TransitGatewayAttachmentId = __expectString(output["transitGatewayAttachmentId"]);
   }
   if (output["resourceType"] !== undefined) {
-    contents.ResourceType = output["resourceType"];
+    contents.ResourceType = __expectString(output["resourceType"]);
   }
   return contents;
 };
@@ -70326,13 +70332,13 @@ const deserializeAws_ec2TransitGatewayRouteTable = (output: any, context: __Serd
     Tags: undefined,
   };
   if (output["transitGatewayRouteTableId"] !== undefined) {
-    contents.TransitGatewayRouteTableId = output["transitGatewayRouteTableId"];
+    contents.TransitGatewayRouteTableId = __expectString(output["transitGatewayRouteTableId"]);
   }
   if (output["transitGatewayId"] !== undefined) {
-    contents.TransitGatewayId = output["transitGatewayId"];
+    contents.TransitGatewayId = __expectString(output["transitGatewayId"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output["defaultAssociationRouteTable"] !== undefined) {
     contents.DefaultAssociationRouteTable = __parseBoolean(output["defaultAssociationRouteTable"]);
@@ -70363,16 +70369,16 @@ const deserializeAws_ec2TransitGatewayRouteTableAssociation = (
     State: undefined,
   };
   if (output["transitGatewayAttachmentId"] !== undefined) {
-    contents.TransitGatewayAttachmentId = output["transitGatewayAttachmentId"];
+    contents.TransitGatewayAttachmentId = __expectString(output["transitGatewayAttachmentId"]);
   }
   if (output["resourceId"] !== undefined) {
-    contents.ResourceId = output["resourceId"];
+    contents.ResourceId = __expectString(output["resourceId"]);
   }
   if (output["resourceType"] !== undefined) {
-    contents.ResourceType = output["resourceType"];
+    contents.ResourceType = __expectString(output["resourceType"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   return contents;
 };
@@ -70416,16 +70422,16 @@ const deserializeAws_ec2TransitGatewayRouteTablePropagation = (
     State: undefined,
   };
   if (output["transitGatewayAttachmentId"] !== undefined) {
-    contents.TransitGatewayAttachmentId = output["transitGatewayAttachmentId"];
+    contents.TransitGatewayAttachmentId = __expectString(output["transitGatewayAttachmentId"]);
   }
   if (output["resourceId"] !== undefined) {
-    contents.ResourceId = output["resourceId"];
+    contents.ResourceId = __expectString(output["resourceId"]);
   }
   if (output["resourceType"] !== undefined) {
-    contents.ResourceType = output["resourceType"];
+    contents.ResourceType = __expectString(output["resourceType"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   return contents;
 };
@@ -70460,19 +70466,19 @@ const deserializeAws_ec2TransitGatewayVpcAttachment = (
     Tags: undefined,
   };
   if (output["transitGatewayAttachmentId"] !== undefined) {
-    contents.TransitGatewayAttachmentId = output["transitGatewayAttachmentId"];
+    contents.TransitGatewayAttachmentId = __expectString(output["transitGatewayAttachmentId"]);
   }
   if (output["transitGatewayId"] !== undefined) {
-    contents.TransitGatewayId = output["transitGatewayId"];
+    contents.TransitGatewayId = __expectString(output["transitGatewayId"]);
   }
   if (output["vpcId"] !== undefined) {
-    contents.VpcId = output["vpcId"];
+    contents.VpcId = __expectString(output["vpcId"]);
   }
   if (output["vpcOwnerId"] !== undefined) {
-    contents.VpcOwnerId = output["vpcOwnerId"];
+    contents.VpcOwnerId = __expectString(output["vpcOwnerId"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output.subnetIds === "") {
     contents.SubnetIds = [];
@@ -70522,13 +70528,13 @@ const deserializeAws_ec2TransitGatewayVpcAttachmentOptions = (
     ApplianceModeSupport: undefined,
   };
   if (output["dnsSupport"] !== undefined) {
-    contents.DnsSupport = output["dnsSupport"];
+    contents.DnsSupport = __expectString(output["dnsSupport"]);
   }
   if (output["ipv6Support"] !== undefined) {
-    contents.Ipv6Support = output["ipv6Support"];
+    contents.Ipv6Support = __expectString(output["ipv6Support"]);
   }
   if (output["applianceModeSupport"] !== undefined) {
-    contents.ApplianceModeSupport = output["applianceModeSupport"];
+    contents.ApplianceModeSupport = __expectString(output["applianceModeSupport"]);
   }
   return contents;
 };
@@ -70547,16 +70553,16 @@ const deserializeAws_ec2TrunkInterfaceAssociation = (
     Tags: undefined,
   };
   if (output["associationId"] !== undefined) {
-    contents.AssociationId = output["associationId"];
+    contents.AssociationId = __expectString(output["associationId"]);
   }
   if (output["branchInterfaceId"] !== undefined) {
-    contents.BranchInterfaceId = output["branchInterfaceId"];
+    contents.BranchInterfaceId = __expectString(output["branchInterfaceId"]);
   }
   if (output["trunkInterfaceId"] !== undefined) {
-    contents.TrunkInterfaceId = output["trunkInterfaceId"];
+    contents.TrunkInterfaceId = __expectString(output["trunkInterfaceId"]);
   }
   if (output["interfaceProtocol"] !== undefined) {
-    contents.InterfaceProtocol = output["interfaceProtocol"];
+    contents.InterfaceProtocol = __expectString(output["interfaceProtocol"]);
   }
   if (output["vlanId"] !== undefined) {
     contents.VlanId = parseInt(output["vlanId"]);
@@ -70610,16 +70616,16 @@ const deserializeAws_ec2TunnelOption = (output: any, context: __SerdeContext): T
     StartupAction: undefined,
   };
   if (output["outsideIpAddress"] !== undefined) {
-    contents.OutsideIpAddress = output["outsideIpAddress"];
+    contents.OutsideIpAddress = __expectString(output["outsideIpAddress"]);
   }
   if (output["tunnelInsideCidr"] !== undefined) {
-    contents.TunnelInsideCidr = output["tunnelInsideCidr"];
+    contents.TunnelInsideCidr = __expectString(output["tunnelInsideCidr"]);
   }
   if (output["tunnelInsideIpv6Cidr"] !== undefined) {
-    contents.TunnelInsideIpv6Cidr = output["tunnelInsideIpv6Cidr"];
+    contents.TunnelInsideIpv6Cidr = __expectString(output["tunnelInsideIpv6Cidr"]);
   }
   if (output["preSharedKey"] !== undefined) {
-    contents.PreSharedKey = output["preSharedKey"];
+    contents.PreSharedKey = __expectString(output["preSharedKey"]);
   }
   if (output["phase1LifetimeSeconds"] !== undefined) {
     contents.Phase1LifetimeSeconds = parseInt(output["phase1LifetimeSeconds"]);
@@ -70640,7 +70646,7 @@ const deserializeAws_ec2TunnelOption = (output: any, context: __SerdeContext): T
     contents.DpdTimeoutSeconds = parseInt(output["dpdTimeoutSeconds"]);
   }
   if (output["dpdTimeoutAction"] !== undefined) {
-    contents.DpdTimeoutAction = output["dpdTimeoutAction"];
+    contents.DpdTimeoutAction = __expectString(output["dpdTimeoutAction"]);
   }
   if (output.phase1EncryptionAlgorithmSet === "") {
     contents.Phase1EncryptionAlgorithms = [];
@@ -70718,7 +70724,7 @@ const deserializeAws_ec2TunnelOption = (output: any, context: __SerdeContext): T
     );
   }
   if (output["startupAction"] !== undefined) {
-    contents.StartupAction = output["startupAction"];
+    contents.StartupAction = __expectString(output["startupAction"]);
   }
   return contents;
 };
@@ -70743,7 +70749,7 @@ const deserializeAws_ec2UnassignIpv6AddressesResult = (
     UnassignedIpv6Addresses: undefined,
   };
   if (output["networkInterfaceId"] !== undefined) {
-    contents.NetworkInterfaceId = output["networkInterfaceId"];
+    contents.NetworkInterfaceId = __expectString(output["networkInterfaceId"]);
   }
   if (output.unassignedIpv6Addresses === "") {
     contents.UnassignedIpv6Addresses = [];
@@ -70782,7 +70788,7 @@ const deserializeAws_ec2UnsuccessfulInstanceCreditSpecificationItem = (
     Error: undefined,
   };
   if (output["instanceId"] !== undefined) {
-    contents.InstanceId = output["instanceId"];
+    contents.InstanceId = __expectString(output["instanceId"]);
   }
   if (output["error"] !== undefined) {
     contents.Error = deserializeAws_ec2UnsuccessfulInstanceCreditSpecificationItemError(output["error"], context);
@@ -70799,10 +70805,10 @@ const deserializeAws_ec2UnsuccessfulInstanceCreditSpecificationItemError = (
     Message: undefined,
   };
   if (output["code"] !== undefined) {
-    contents.Code = output["code"];
+    contents.Code = __expectString(output["code"]);
   }
   if (output["message"] !== undefined) {
-    contents.Message = output["message"];
+    contents.Message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -70830,7 +70836,7 @@ const deserializeAws_ec2UnsuccessfulItem = (output: any, context: __SerdeContext
     contents.Error = deserializeAws_ec2UnsuccessfulItemError(output["error"], context);
   }
   if (output["resourceId"] !== undefined) {
-    contents.ResourceId = output["resourceId"];
+    contents.ResourceId = __expectString(output["resourceId"]);
   }
   return contents;
 };
@@ -70841,10 +70847,10 @@ const deserializeAws_ec2UnsuccessfulItemError = (output: any, context: __SerdeCo
     Message: undefined,
   };
   if (output["code"] !== undefined) {
-    contents.Code = output["code"];
+    contents.Code = __expectString(output["code"]);
   }
   if (output["message"] !== undefined) {
-    contents.Message = output["message"];
+    contents.Message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -70904,7 +70910,7 @@ const deserializeAws_ec2UsageClassTypeList = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -70914,10 +70920,10 @@ const deserializeAws_ec2UserBucketDetails = (output: any, context: __SerdeContex
     S3Key: undefined,
   };
   if (output["s3Bucket"] !== undefined) {
-    contents.S3Bucket = output["s3Bucket"];
+    contents.S3Bucket = __expectString(output["s3Bucket"]);
   }
   if (output["s3Key"] !== undefined) {
-    contents.S3Key = output["s3Key"];
+    contents.S3Key = __expectString(output["s3Key"]);
   }
   return contents;
 };
@@ -70933,25 +70939,25 @@ const deserializeAws_ec2UserIdGroupPair = (output: any, context: __SerdeContext)
     VpcPeeringConnectionId: undefined,
   };
   if (output["description"] !== undefined) {
-    contents.Description = output["description"];
+    contents.Description = __expectString(output["description"]);
   }
   if (output["groupId"] !== undefined) {
-    contents.GroupId = output["groupId"];
+    contents.GroupId = __expectString(output["groupId"]);
   }
   if (output["groupName"] !== undefined) {
-    contents.GroupName = output["groupName"];
+    contents.GroupName = __expectString(output["groupName"]);
   }
   if (output["peeringStatus"] !== undefined) {
-    contents.PeeringStatus = output["peeringStatus"];
+    contents.PeeringStatus = __expectString(output["peeringStatus"]);
   }
   if (output["userId"] !== undefined) {
-    contents.UserId = output["userId"];
+    contents.UserId = __expectString(output["userId"]);
   }
   if (output["vpcId"] !== undefined) {
-    contents.VpcId = output["vpcId"];
+    contents.VpcId = __expectString(output["vpcId"]);
   }
   if (output["vpcPeeringConnectionId"] !== undefined) {
-    contents.VpcPeeringConnectionId = output["vpcPeeringConnectionId"];
+    contents.VpcPeeringConnectionId = __expectString(output["vpcPeeringConnectionId"]);
   }
   return contents;
 };
@@ -70984,10 +70990,10 @@ const deserializeAws_ec2ValidationError = (output: any, context: __SerdeContext)
     Message: undefined,
   };
   if (output["code"] !== undefined) {
-    contents.Code = output["code"];
+    contents.Code = __expectString(output["code"]);
   }
   if (output["message"] !== undefined) {
-    contents.Message = output["message"];
+    contents.Message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -71012,7 +71018,7 @@ const deserializeAws_ec2ValueStringList = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -71070,16 +71076,16 @@ const deserializeAws_ec2VgwTelemetry = (output: any, context: __SerdeContext): V
     contents.LastStatusChange = new Date(output["lastStatusChange"]);
   }
   if (output["outsideIpAddress"] !== undefined) {
-    contents.OutsideIpAddress = output["outsideIpAddress"];
+    contents.OutsideIpAddress = __expectString(output["outsideIpAddress"]);
   }
   if (output["status"] !== undefined) {
-    contents.Status = output["status"];
+    contents.Status = __expectString(output["status"]);
   }
   if (output["statusMessage"] !== undefined) {
-    contents.StatusMessage = output["statusMessage"];
+    contents.StatusMessage = __expectString(output["statusMessage"]);
   }
   if (output["certificateArn"] !== undefined) {
-    contents.CertificateArn = output["certificateArn"];
+    contents.CertificateArn = __expectString(output["certificateArn"]);
   }
   return contents;
 };
@@ -71105,7 +71111,7 @@ const deserializeAws_ec2VirtualizationTypeList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -71138,7 +71144,7 @@ const deserializeAws_ec2Volume = (output: any, context: __SerdeContext): Volume 
     );
   }
   if (output["availabilityZone"] !== undefined) {
-    contents.AvailabilityZone = output["availabilityZone"];
+    contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
   if (output["createTime"] !== undefined) {
     contents.CreateTime = new Date(output["createTime"]);
@@ -71147,22 +71153,22 @@ const deserializeAws_ec2Volume = (output: any, context: __SerdeContext): Volume 
     contents.Encrypted = __parseBoolean(output["encrypted"]);
   }
   if (output["kmsKeyId"] !== undefined) {
-    contents.KmsKeyId = output["kmsKeyId"];
+    contents.KmsKeyId = __expectString(output["kmsKeyId"]);
   }
   if (output["outpostArn"] !== undefined) {
-    contents.OutpostArn = output["outpostArn"];
+    contents.OutpostArn = __expectString(output["outpostArn"]);
   }
   if (output["size"] !== undefined) {
     contents.Size = parseInt(output["size"]);
   }
   if (output["snapshotId"] !== undefined) {
-    contents.SnapshotId = output["snapshotId"];
+    contents.SnapshotId = __expectString(output["snapshotId"]);
   }
   if (output["status"] !== undefined) {
-    contents.State = output["status"];
+    contents.State = __expectString(output["status"]);
   }
   if (output["volumeId"] !== undefined) {
-    contents.VolumeId = output["volumeId"];
+    contents.VolumeId = __expectString(output["volumeId"]);
   }
   if (output["iops"] !== undefined) {
     contents.Iops = parseInt(output["iops"]);
@@ -71174,7 +71180,7 @@ const deserializeAws_ec2Volume = (output: any, context: __SerdeContext): Volume 
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["volumeType"] !== undefined) {
-    contents.VolumeType = output["volumeType"];
+    contents.VolumeType = __expectString(output["volumeType"]);
   }
   if (output["fastRestored"] !== undefined) {
     contents.FastRestored = __parseBoolean(output["fastRestored"]);
@@ -71201,16 +71207,16 @@ const deserializeAws_ec2VolumeAttachment = (output: any, context: __SerdeContext
     contents.AttachTime = new Date(output["attachTime"]);
   }
   if (output["device"] !== undefined) {
-    contents.Device = output["device"];
+    contents.Device = __expectString(output["device"]);
   }
   if (output["instanceId"] !== undefined) {
-    contents.InstanceId = output["instanceId"];
+    contents.InstanceId = __expectString(output["instanceId"]);
   }
   if (output["status"] !== undefined) {
-    contents.State = output["status"];
+    contents.State = __expectString(output["status"]);
   }
   if (output["volumeId"] !== undefined) {
-    contents.VolumeId = output["volumeId"];
+    contents.VolumeId = __expectString(output["volumeId"]);
   }
   if (output["deleteOnTermination"] !== undefined) {
     contents.DeleteOnTermination = __parseBoolean(output["deleteOnTermination"]);
@@ -71260,13 +71266,13 @@ const deserializeAws_ec2VolumeModification = (output: any, context: __SerdeConte
     EndTime: undefined,
   };
   if (output["volumeId"] !== undefined) {
-    contents.VolumeId = output["volumeId"];
+    contents.VolumeId = __expectString(output["volumeId"]);
   }
   if (output["modificationState"] !== undefined) {
-    contents.ModificationState = output["modificationState"];
+    contents.ModificationState = __expectString(output["modificationState"]);
   }
   if (output["statusMessage"] !== undefined) {
-    contents.StatusMessage = output["statusMessage"];
+    contents.StatusMessage = __expectString(output["statusMessage"]);
   }
   if (output["targetSize"] !== undefined) {
     contents.TargetSize = parseInt(output["targetSize"]);
@@ -71275,7 +71281,7 @@ const deserializeAws_ec2VolumeModification = (output: any, context: __SerdeConte
     contents.TargetIops = parseInt(output["targetIops"]);
   }
   if (output["targetVolumeType"] !== undefined) {
-    contents.TargetVolumeType = output["targetVolumeType"];
+    contents.TargetVolumeType = __expectString(output["targetVolumeType"]);
   }
   if (output["targetThroughput"] !== undefined) {
     contents.TargetThroughput = parseInt(output["targetThroughput"]);
@@ -71290,7 +71296,7 @@ const deserializeAws_ec2VolumeModification = (output: any, context: __SerdeConte
     contents.OriginalIops = parseInt(output["originalIops"]);
   }
   if (output["originalVolumeType"] !== undefined) {
-    contents.OriginalVolumeType = output["originalVolumeType"];
+    contents.OriginalVolumeType = __expectString(output["originalVolumeType"]);
   }
   if (output["originalThroughput"] !== undefined) {
     contents.OriginalThroughput = parseInt(output["originalThroughput"]);
@@ -71329,16 +71335,16 @@ const deserializeAws_ec2VolumeStatusAction = (output: any, context: __SerdeConte
     EventType: undefined,
   };
   if (output["code"] !== undefined) {
-    contents.Code = output["code"];
+    contents.Code = __expectString(output["code"]);
   }
   if (output["description"] !== undefined) {
-    contents.Description = output["description"];
+    contents.Description = __expectString(output["description"]);
   }
   if (output["eventId"] !== undefined) {
-    contents.EventId = output["eventId"];
+    contents.EventId = __expectString(output["eventId"]);
   }
   if (output["eventType"] !== undefined) {
-    contents.EventType = output["eventType"];
+    contents.EventType = __expectString(output["eventType"]);
   }
   return contents;
 };
@@ -71363,10 +71369,10 @@ const deserializeAws_ec2VolumeStatusAttachmentStatus = (
     InstanceId: undefined,
   };
   if (output["ioPerformance"] !== undefined) {
-    contents.IoPerformance = output["ioPerformance"];
+    contents.IoPerformance = __expectString(output["ioPerformance"]);
   }
   if (output["instanceId"] !== undefined) {
-    contents.InstanceId = output["instanceId"];
+    contents.InstanceId = __expectString(output["instanceId"]);
   }
   return contents;
 };
@@ -71391,10 +71397,10 @@ const deserializeAws_ec2VolumeStatusDetails = (output: any, context: __SerdeCont
     Status: undefined,
   };
   if (output["name"] !== undefined) {
-    contents.Name = output["name"];
+    contents.Name = __expectString(output["name"]);
   }
   if (output["status"] !== undefined) {
-    contents.Status = output["status"];
+    contents.Status = __expectString(output["status"]);
   }
   return contents;
 };
@@ -71420,13 +71426,13 @@ const deserializeAws_ec2VolumeStatusEvent = (output: any, context: __SerdeContex
     InstanceId: undefined,
   };
   if (output["description"] !== undefined) {
-    contents.Description = output["description"];
+    contents.Description = __expectString(output["description"]);
   }
   if (output["eventId"] !== undefined) {
-    contents.EventId = output["eventId"];
+    contents.EventId = __expectString(output["eventId"]);
   }
   if (output["eventType"] !== undefined) {
-    contents.EventType = output["eventType"];
+    contents.EventType = __expectString(output["eventType"]);
   }
   if (output["notAfter"] !== undefined) {
     contents.NotAfter = new Date(output["notAfter"]);
@@ -71435,7 +71441,7 @@ const deserializeAws_ec2VolumeStatusEvent = (output: any, context: __SerdeContex
     contents.NotBefore = new Date(output["notBefore"]);
   }
   if (output["instanceId"] !== undefined) {
-    contents.InstanceId = output["instanceId"];
+    contents.InstanceId = __expectString(output["instanceId"]);
   }
   return contents;
 };
@@ -71466,7 +71472,7 @@ const deserializeAws_ec2VolumeStatusInfo = (output: any, context: __SerdeContext
     );
   }
   if (output["status"] !== undefined) {
-    contents.Status = output["status"];
+    contents.Status = __expectString(output["status"]);
   }
   return contents;
 };
@@ -71491,10 +71497,10 @@ const deserializeAws_ec2VolumeStatusItem = (output: any, context: __SerdeContext
     );
   }
   if (output["availabilityZone"] !== undefined) {
-    contents.AvailabilityZone = output["availabilityZone"];
+    contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
   if (output["outpostArn"] !== undefined) {
-    contents.OutpostArn = output["outpostArn"];
+    contents.OutpostArn = __expectString(output["outpostArn"]);
   }
   if (output.eventsSet === "") {
     contents.Events = [];
@@ -71506,7 +71512,7 @@ const deserializeAws_ec2VolumeStatusItem = (output: any, context: __SerdeContext
     );
   }
   if (output["volumeId"] !== undefined) {
-    contents.VolumeId = output["volumeId"];
+    contents.VolumeId = __expectString(output["volumeId"]);
   }
   if (output["volumeStatus"] !== undefined) {
     contents.VolumeStatus = deserializeAws_ec2VolumeStatusInfo(output["volumeStatus"], context);
@@ -71548,22 +71554,22 @@ const deserializeAws_ec2Vpc = (output: any, context: __SerdeContext): Vpc => {
     Tags: undefined,
   };
   if (output["cidrBlock"] !== undefined) {
-    contents.CidrBlock = output["cidrBlock"];
+    contents.CidrBlock = __expectString(output["cidrBlock"]);
   }
   if (output["dhcpOptionsId"] !== undefined) {
-    contents.DhcpOptionsId = output["dhcpOptionsId"];
+    contents.DhcpOptionsId = __expectString(output["dhcpOptionsId"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output["vpcId"] !== undefined) {
-    contents.VpcId = output["vpcId"];
+    contents.VpcId = __expectString(output["vpcId"]);
   }
   if (output["ownerId"] !== undefined) {
-    contents.OwnerId = output["ownerId"];
+    contents.OwnerId = __expectString(output["ownerId"]);
   }
   if (output["instanceTenancy"] !== undefined) {
-    contents.InstanceTenancy = output["instanceTenancy"];
+    contents.InstanceTenancy = __expectString(output["instanceTenancy"]);
   }
   if (output.ipv6CidrBlockAssociationSet === "") {
     contents.Ipv6CidrBlockAssociationSet = [];
@@ -71604,10 +71610,10 @@ const deserializeAws_ec2VpcAttachment = (output: any, context: __SerdeContext): 
     VpcId: undefined,
   };
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output["vpcId"] !== undefined) {
-    contents.VpcId = output["vpcId"];
+    contents.VpcId = __expectString(output["vpcId"]);
   }
   return contents;
 };
@@ -71630,10 +71636,10 @@ const deserializeAws_ec2VpcCidrBlockAssociation = (output: any, context: __Serde
     CidrBlockState: undefined,
   };
   if (output["associationId"] !== undefined) {
-    contents.AssociationId = output["associationId"];
+    contents.AssociationId = __expectString(output["associationId"]);
   }
   if (output["cidrBlock"] !== undefined) {
-    contents.CidrBlock = output["cidrBlock"];
+    contents.CidrBlock = __expectString(output["cidrBlock"]);
   }
   if (output["cidrBlockState"] !== undefined) {
     contents.CidrBlockState = deserializeAws_ec2VpcCidrBlockState(output["cidrBlockState"], context);
@@ -71661,10 +71667,10 @@ const deserializeAws_ec2VpcCidrBlockState = (output: any, context: __SerdeContex
     StatusMessage: undefined,
   };
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output["statusMessage"] !== undefined) {
-    contents.StatusMessage = output["statusMessage"];
+    contents.StatusMessage = __expectString(output["statusMessage"]);
   }
   return contents;
 };
@@ -71685,7 +71691,7 @@ const deserializeAws_ec2VpcClassicLink = (output: any, context: __SerdeContext):
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["vpcId"] !== undefined) {
-    contents.VpcId = output["vpcId"];
+    contents.VpcId = __expectString(output["vpcId"]);
   }
   return contents;
 };
@@ -71722,22 +71728,22 @@ const deserializeAws_ec2VpcEndpoint = (output: any, context: __SerdeContext): Vp
     LastError: undefined,
   };
   if (output["vpcEndpointId"] !== undefined) {
-    contents.VpcEndpointId = output["vpcEndpointId"];
+    contents.VpcEndpointId = __expectString(output["vpcEndpointId"]);
   }
   if (output["vpcEndpointType"] !== undefined) {
-    contents.VpcEndpointType = output["vpcEndpointType"];
+    contents.VpcEndpointType = __expectString(output["vpcEndpointType"]);
   }
   if (output["vpcId"] !== undefined) {
-    contents.VpcId = output["vpcId"];
+    contents.VpcId = __expectString(output["vpcId"]);
   }
   if (output["serviceName"] !== undefined) {
-    contents.ServiceName = output["serviceName"];
+    contents.ServiceName = __expectString(output["serviceName"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output["policyDocument"] !== undefined) {
-    contents.PolicyDocument = output["policyDocument"];
+    contents.PolicyDocument = __expectString(output["policyDocument"]);
   }
   if (output.routeTableIdSet === "") {
     contents.RouteTableIds = [];
@@ -71794,7 +71800,7 @@ const deserializeAws_ec2VpcEndpoint = (output: any, context: __SerdeContext): Vp
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["ownerId"] !== undefined) {
-    contents.OwnerId = output["ownerId"];
+    contents.OwnerId = __expectString(output["ownerId"]);
   }
   if (output["lastError"] !== undefined) {
     contents.LastError = deserializeAws_ec2LastError(output["lastError"], context);
@@ -71814,16 +71820,16 @@ const deserializeAws_ec2VpcEndpointConnection = (output: any, context: __SerdeCo
     GatewayLoadBalancerArns: undefined,
   };
   if (output["serviceId"] !== undefined) {
-    contents.ServiceId = output["serviceId"];
+    contents.ServiceId = __expectString(output["serviceId"]);
   }
   if (output["vpcEndpointId"] !== undefined) {
-    contents.VpcEndpointId = output["vpcEndpointId"];
+    contents.VpcEndpointId = __expectString(output["vpcEndpointId"]);
   }
   if (output["vpcEndpointOwner"] !== undefined) {
-    contents.VpcEndpointOwner = output["vpcEndpointOwner"];
+    contents.VpcEndpointOwner = __expectString(output["vpcEndpointOwner"]);
   }
   if (output["vpcEndpointState"] !== undefined) {
-    contents.VpcEndpointState = output["vpcEndpointState"];
+    contents.VpcEndpointState = __expectString(output["vpcEndpointState"]);
   }
   if (output["creationTimestamp"] !== undefined) {
     contents.CreationTimestamp = new Date(output["creationTimestamp"]);
@@ -71889,19 +71895,19 @@ const deserializeAws_ec2VpcIpv6CidrBlockAssociation = (
     Ipv6Pool: undefined,
   };
   if (output["associationId"] !== undefined) {
-    contents.AssociationId = output["associationId"];
+    contents.AssociationId = __expectString(output["associationId"]);
   }
   if (output["ipv6CidrBlock"] !== undefined) {
-    contents.Ipv6CidrBlock = output["ipv6CidrBlock"];
+    contents.Ipv6CidrBlock = __expectString(output["ipv6CidrBlock"]);
   }
   if (output["ipv6CidrBlockState"] !== undefined) {
     contents.Ipv6CidrBlockState = deserializeAws_ec2VpcCidrBlockState(output["ipv6CidrBlockState"], context);
   }
   if (output["networkBorderGroup"] !== undefined) {
-    contents.NetworkBorderGroup = output["networkBorderGroup"];
+    contents.NetworkBorderGroup = __expectString(output["networkBorderGroup"]);
   }
   if (output["ipv6Pool"] !== undefined) {
-    contents.Ipv6Pool = output["ipv6Pool"];
+    contents.Ipv6Pool = __expectString(output["ipv6Pool"]);
   }
   return contents;
 };
@@ -71959,7 +71965,7 @@ const deserializeAws_ec2VpcPeeringConnection = (output: any, context: __SerdeCon
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["vpcPeeringConnectionId"] !== undefined) {
-    contents.VpcPeeringConnectionId = output["vpcPeeringConnectionId"];
+    contents.VpcPeeringConnectionId = __expectString(output["vpcPeeringConnectionId"]);
   }
   return contents;
 };
@@ -72009,10 +72015,10 @@ const deserializeAws_ec2VpcPeeringConnectionStateReason = (
     Message: undefined,
   };
   if (output["code"] !== undefined) {
-    contents.Code = output["code"];
+    contents.Code = __expectString(output["code"]);
   }
   if (output["message"] !== undefined) {
-    contents.Message = output["message"];
+    contents.Message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -72031,7 +72037,7 @@ const deserializeAws_ec2VpcPeeringConnectionVpcInfo = (
     Region: undefined,
   };
   if (output["cidrBlock"] !== undefined) {
-    contents.CidrBlock = output["cidrBlock"];
+    contents.CidrBlock = __expectString(output["cidrBlock"]);
   }
   if (output.ipv6CidrBlockSet === "") {
     contents.Ipv6CidrBlockSet = [];
@@ -72052,7 +72058,7 @@ const deserializeAws_ec2VpcPeeringConnectionVpcInfo = (
     );
   }
   if (output["ownerId"] !== undefined) {
-    contents.OwnerId = output["ownerId"];
+    contents.OwnerId = __expectString(output["ownerId"]);
   }
   if (output["peeringOptions"] !== undefined) {
     contents.PeeringOptions = deserializeAws_ec2VpcPeeringConnectionOptionsDescription(
@@ -72061,10 +72067,10 @@ const deserializeAws_ec2VpcPeeringConnectionVpcInfo = (
     );
   }
   if (output["vpcId"] !== undefined) {
-    contents.VpcId = output["vpcId"];
+    contents.VpcId = __expectString(output["vpcId"]);
   }
   if (output["region"] !== undefined) {
-    contents.Region = output["region"];
+    contents.Region = __expectString(output["region"]);
   }
   return contents;
 };
@@ -72085,28 +72091,28 @@ const deserializeAws_ec2VpnConnection = (output: any, context: __SerdeContext): 
     VgwTelemetry: undefined,
   };
   if (output["customerGatewayConfiguration"] !== undefined) {
-    contents.CustomerGatewayConfiguration = output["customerGatewayConfiguration"];
+    contents.CustomerGatewayConfiguration = __expectString(output["customerGatewayConfiguration"]);
   }
   if (output["customerGatewayId"] !== undefined) {
-    contents.CustomerGatewayId = output["customerGatewayId"];
+    contents.CustomerGatewayId = __expectString(output["customerGatewayId"]);
   }
   if (output["category"] !== undefined) {
-    contents.Category = output["category"];
+    contents.Category = __expectString(output["category"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output["type"] !== undefined) {
-    contents.Type = output["type"];
+    contents.Type = __expectString(output["type"]);
   }
   if (output["vpnConnectionId"] !== undefined) {
-    contents.VpnConnectionId = output["vpnConnectionId"];
+    contents.VpnConnectionId = __expectString(output["vpnConnectionId"]);
   }
   if (output["vpnGatewayId"] !== undefined) {
-    contents.VpnGatewayId = output["vpnGatewayId"];
+    contents.VpnGatewayId = __expectString(output["vpnGatewayId"]);
   }
   if (output["transitGatewayId"] !== undefined) {
-    contents.TransitGatewayId = output["transitGatewayId"];
+    contents.TransitGatewayId = __expectString(output["transitGatewayId"]);
   }
   if (output["options"] !== undefined) {
     contents.Options = deserializeAws_ec2VpnConnectionOptions(output["options"], context);
@@ -72164,19 +72170,19 @@ const deserializeAws_ec2VpnConnectionOptions = (output: any, context: __SerdeCon
     contents.StaticRoutesOnly = __parseBoolean(output["staticRoutesOnly"]);
   }
   if (output["localIpv4NetworkCidr"] !== undefined) {
-    contents.LocalIpv4NetworkCidr = output["localIpv4NetworkCidr"];
+    contents.LocalIpv4NetworkCidr = __expectString(output["localIpv4NetworkCidr"]);
   }
   if (output["remoteIpv4NetworkCidr"] !== undefined) {
-    contents.RemoteIpv4NetworkCidr = output["remoteIpv4NetworkCidr"];
+    contents.RemoteIpv4NetworkCidr = __expectString(output["remoteIpv4NetworkCidr"]);
   }
   if (output["localIpv6NetworkCidr"] !== undefined) {
-    contents.LocalIpv6NetworkCidr = output["localIpv6NetworkCidr"];
+    contents.LocalIpv6NetworkCidr = __expectString(output["localIpv6NetworkCidr"]);
   }
   if (output["remoteIpv6NetworkCidr"] !== undefined) {
-    contents.RemoteIpv6NetworkCidr = output["remoteIpv6NetworkCidr"];
+    contents.RemoteIpv6NetworkCidr = __expectString(output["remoteIpv6NetworkCidr"]);
   }
   if (output["tunnelInsideIpVersion"] !== undefined) {
-    contents.TunnelInsideIpVersion = output["tunnelInsideIpVersion"];
+    contents.TunnelInsideIpVersion = __expectString(output["tunnelInsideIpVersion"]);
   }
   if (output.tunnelOptionSet === "") {
     contents.TunnelOptions = [];
@@ -72201,13 +72207,13 @@ const deserializeAws_ec2VpnGateway = (output: any, context: __SerdeContext): Vpn
     Tags: undefined,
   };
   if (output["availabilityZone"] !== undefined) {
-    contents.AvailabilityZone = output["availabilityZone"];
+    contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   if (output["type"] !== undefined) {
-    contents.Type = output["type"];
+    contents.Type = __expectString(output["type"]);
   }
   if (output.attachments === "") {
     contents.VpcAttachments = [];
@@ -72219,7 +72225,7 @@ const deserializeAws_ec2VpnGateway = (output: any, context: __SerdeContext): Vpn
     );
   }
   if (output["vpnGatewayId"] !== undefined) {
-    contents.VpnGatewayId = output["vpnGatewayId"];
+    contents.VpnGatewayId = __expectString(output["vpnGatewayId"]);
   }
   if (output["amazonSideAsn"] !== undefined) {
     contents.AmazonSideAsn = parseInt(output["amazonSideAsn"]);
@@ -72251,13 +72257,13 @@ const deserializeAws_ec2VpnStaticRoute = (output: any, context: __SerdeContext):
     State: undefined,
   };
   if (output["destinationCidrBlock"] !== undefined) {
-    contents.DestinationCidrBlock = output["destinationCidrBlock"];
+    contents.DestinationCidrBlock = __expectString(output["destinationCidrBlock"]);
   }
   if (output["source"] !== undefined) {
-    contents.Source = output["source"];
+    contents.Source = __expectString(output["source"]);
   }
   if (output["state"] !== undefined) {
-    contents.State = output["state"];
+    contents.State = __expectString(output["state"]);
   }
   return contents;
 };

--- a/clients/client-ecr-public/protocols/Aws_json1_1.ts
+++ b/clients/client-ecr-public/protocols/Aws_json1_1.ts
@@ -148,7 +148,12 @@ import {
   UploadNotFoundException,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -3054,16 +3059,13 @@ const deserializeAws_json1_1ArchitectureList = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1AuthorizationData = (output: any, context: __SerdeContext): AuthorizationData => {
   return {
-    authorizationToken:
-      output.authorizationToken !== undefined && output.authorizationToken !== null
-        ? output.authorizationToken
-        : undefined,
+    authorizationToken: __expectString(output.authorizationToken),
     expiresAt:
       output.expiresAt !== undefined && output.expiresAt !== null
         ? new Date(Math.round(output.expiresAt * 1000))
@@ -3108,11 +3110,10 @@ const deserializeAws_json1_1CompleteLayerUploadResponse = (
   context: __SerdeContext
 ): CompleteLayerUploadResponse => {
   return {
-    layerDigest: output.layerDigest !== undefined && output.layerDigest !== null ? output.layerDigest : undefined,
-    registryId: output.registryId !== undefined && output.registryId !== null ? output.registryId : undefined,
-    repositoryName:
-      output.repositoryName !== undefined && output.repositoryName !== null ? output.repositoryName : undefined,
-    uploadId: output.uploadId !== undefined && output.uploadId !== null ? output.uploadId : undefined,
+    layerDigest: __expectString(output.layerDigest),
+    registryId: __expectString(output.registryId),
+    repositoryName: __expectString(output.repositoryName),
+    uploadId: __expectString(output.uploadId),
   } as any;
 };
 
@@ -3137,10 +3138,9 @@ const deserializeAws_json1_1DeleteRepositoryPolicyResponse = (
   context: __SerdeContext
 ): DeleteRepositoryPolicyResponse => {
   return {
-    policyText: output.policyText !== undefined && output.policyText !== null ? output.policyText : undefined,
-    registryId: output.registryId !== undefined && output.registryId !== null ? output.registryId : undefined,
-    repositoryName:
-      output.repositoryName !== undefined && output.repositoryName !== null ? output.repositoryName : undefined,
+    policyText: __expectString(output.policyText),
+    registryId: __expectString(output.registryId),
+    repositoryName: __expectString(output.repositoryName),
   } as any;
 };
 
@@ -3162,7 +3162,7 @@ const deserializeAws_json1_1DescribeImagesResponse = (output: any, context: __Se
       output.imageDetails !== undefined && output.imageDetails !== null
         ? deserializeAws_json1_1ImageDetailList(output.imageDetails, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -3175,7 +3175,7 @@ const deserializeAws_json1_1DescribeImageTagsResponse = (
       output.imageTagDetails !== undefined && output.imageTagDetails !== null
         ? deserializeAws_json1_1ImageTagDetailList(output.imageTagDetails, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -3184,7 +3184,7 @@ const deserializeAws_json1_1DescribeRegistriesResponse = (
   context: __SerdeContext
 ): DescribeRegistriesResponse => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     registries:
       output.registries !== undefined && output.registries !== null
         ? deserializeAws_json1_1RegistryList(output.registries, context)
@@ -3197,7 +3197,7 @@ const deserializeAws_json1_1DescribeRepositoriesResponse = (
   context: __SerdeContext
 ): DescribeRepositoriesResponse => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     repositories:
       output.repositories !== undefined && output.repositories !== null
         ? deserializeAws_json1_1RepositoryList(output.repositories, context)
@@ -3207,7 +3207,7 @@ const deserializeAws_json1_1DescribeRepositoriesResponse = (
 
 const deserializeAws_json1_1EmptyUploadException = (output: any, context: __SerdeContext): EmptyUploadException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3252,10 +3252,9 @@ const deserializeAws_json1_1GetRepositoryPolicyResponse = (
   context: __SerdeContext
 ): GetRepositoryPolicyResponse => {
   return {
-    policyText: output.policyText !== undefined && output.policyText !== null ? output.policyText : undefined,
-    registryId: output.registryId !== undefined && output.registryId !== null ? output.registryId : undefined,
-    repositoryName:
-      output.repositoryName !== undefined && output.repositoryName !== null ? output.repositoryName : undefined,
+    policyText: __expectString(output.policyText),
+    registryId: __expectString(output.registryId),
+    repositoryName: __expectString(output.repositoryName),
   } as any;
 };
 
@@ -3265,15 +3264,10 @@ const deserializeAws_json1_1Image = (output: any, context: __SerdeContext): Imag
       output.imageId !== undefined && output.imageId !== null
         ? deserializeAws_json1_1ImageIdentifier(output.imageId, context)
         : undefined,
-    imageManifest:
-      output.imageManifest !== undefined && output.imageManifest !== null ? output.imageManifest : undefined,
-    imageManifestMediaType:
-      output.imageManifestMediaType !== undefined && output.imageManifestMediaType !== null
-        ? output.imageManifestMediaType
-        : undefined,
-    registryId: output.registryId !== undefined && output.registryId !== null ? output.registryId : undefined,
-    repositoryName:
-      output.repositoryName !== undefined && output.repositoryName !== null ? output.repositoryName : undefined,
+    imageManifest: __expectString(output.imageManifest),
+    imageManifestMediaType: __expectString(output.imageManifestMediaType),
+    registryId: __expectString(output.registryId),
+    repositoryName: __expectString(output.repositoryName),
   } as any;
 };
 
@@ -3282,34 +3276,26 @@ const deserializeAws_json1_1ImageAlreadyExistsException = (
   context: __SerdeContext
 ): ImageAlreadyExistsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1ImageDetail = (output: any, context: __SerdeContext): ImageDetail => {
   return {
-    artifactMediaType:
-      output.artifactMediaType !== undefined && output.artifactMediaType !== null
-        ? output.artifactMediaType
-        : undefined,
-    imageDigest: output.imageDigest !== undefined && output.imageDigest !== null ? output.imageDigest : undefined,
-    imageManifestMediaType:
-      output.imageManifestMediaType !== undefined && output.imageManifestMediaType !== null
-        ? output.imageManifestMediaType
-        : undefined,
+    artifactMediaType: __expectString(output.artifactMediaType),
+    imageDigest: __expectString(output.imageDigest),
+    imageManifestMediaType: __expectString(output.imageManifestMediaType),
     imagePushedAt:
       output.imagePushedAt !== undefined && output.imagePushedAt !== null
         ? new Date(Math.round(output.imagePushedAt * 1000))
         : undefined,
-    imageSizeInBytes:
-      output.imageSizeInBytes !== undefined && output.imageSizeInBytes !== null ? output.imageSizeInBytes : undefined,
+    imageSizeInBytes: __expectNumber(output.imageSizeInBytes),
     imageTags:
       output.imageTags !== undefined && output.imageTags !== null
         ? deserializeAws_json1_1ImageTagList(output.imageTags, context)
         : undefined,
-    registryId: output.registryId !== undefined && output.registryId !== null ? output.registryId : undefined,
-    repositoryName:
-      output.repositoryName !== undefined && output.repositoryName !== null ? output.repositoryName : undefined,
+    registryId: __expectString(output.registryId),
+    repositoryName: __expectString(output.repositoryName),
   } as any;
 };
 
@@ -3329,15 +3315,14 @@ const deserializeAws_json1_1ImageDigestDoesNotMatchException = (
   context: __SerdeContext
 ): ImageDigestDoesNotMatchException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1ImageFailure = (output: any, context: __SerdeContext): ImageFailure => {
   return {
-    failureCode: output.failureCode !== undefined && output.failureCode !== null ? output.failureCode : undefined,
-    failureReason:
-      output.failureReason !== undefined && output.failureReason !== null ? output.failureReason : undefined,
+    failureCode: __expectString(output.failureCode),
+    failureReason: __expectString(output.failureReason),
     imageId:
       output.imageId !== undefined && output.imageId !== null
         ? deserializeAws_json1_1ImageIdentifier(output.imageId, context)
@@ -3358,8 +3343,8 @@ const deserializeAws_json1_1ImageFailureList = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1ImageIdentifier = (output: any, context: __SerdeContext): ImageIdentifier => {
   return {
-    imageDigest: output.imageDigest !== undefined && output.imageDigest !== null ? output.imageDigest : undefined,
-    imageTag: output.imageTag !== undefined && output.imageTag !== null ? output.imageTag : undefined,
+    imageDigest: __expectString(output.imageDigest),
+    imageTag: __expectString(output.imageTag),
   } as any;
 };
 
@@ -3376,7 +3361,7 @@ const deserializeAws_json1_1ImageIdentifierList = (output: any, context: __Serde
 
 const deserializeAws_json1_1ImageNotFoundException = (output: any, context: __SerdeContext): ImageNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3385,7 +3370,7 @@ const deserializeAws_json1_1ImageTagAlreadyExistsException = (
   context: __SerdeContext
 ): ImageTagAlreadyExistsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3399,7 +3384,7 @@ const deserializeAws_json1_1ImageTagDetail = (output: any, context: __SerdeConte
       output.imageDetail !== undefined && output.imageDetail !== null
         ? deserializeAws_json1_1ReferencedImageDetail(output.imageDetail, context)
         : undefined,
-    imageTag: output.imageTag !== undefined && output.imageTag !== null ? output.imageTag : undefined,
+    imageTag: __expectString(output.imageTag),
   } as any;
 };
 
@@ -3421,7 +3406,7 @@ const deserializeAws_json1_1ImageTagList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3430,14 +3415,14 @@ const deserializeAws_json1_1InitiateLayerUploadResponse = (
   context: __SerdeContext
 ): InitiateLayerUploadResponse => {
   return {
-    partSize: output.partSize !== undefined && output.partSize !== null ? output.partSize : undefined,
-    uploadId: output.uploadId !== undefined && output.uploadId !== null ? output.uploadId : undefined,
+    partSize: __expectNumber(output.partSize),
+    uploadId: __expectString(output.uploadId),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidLayerException = (output: any, context: __SerdeContext): InvalidLayerException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3446,15 +3431,11 @@ const deserializeAws_json1_1InvalidLayerPartException = (
   context: __SerdeContext
 ): InvalidLayerPartException => {
   return {
-    lastValidByteReceived:
-      output.lastValidByteReceived !== undefined && output.lastValidByteReceived !== null
-        ? output.lastValidByteReceived
-        : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    registryId: output.registryId !== undefined && output.registryId !== null ? output.registryId : undefined,
-    repositoryName:
-      output.repositoryName !== undefined && output.repositoryName !== null ? output.repositoryName : undefined,
-    uploadId: output.uploadId !== undefined && output.uploadId !== null ? output.uploadId : undefined,
+    lastValidByteReceived: __expectNumber(output.lastValidByteReceived),
+    message: __expectString(output.message),
+    registryId: __expectString(output.registryId),
+    repositoryName: __expectString(output.repositoryName),
+    uploadId: __expectString(output.uploadId),
   } as any;
 };
 
@@ -3463,7 +3444,7 @@ const deserializeAws_json1_1InvalidParameterException = (
   context: __SerdeContext
 ): InvalidParameterException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3472,19 +3453,16 @@ const deserializeAws_json1_1InvalidTagParameterException = (
   context: __SerdeContext
 ): InvalidTagParameterException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1Layer = (output: any, context: __SerdeContext): Layer => {
   return {
-    layerAvailability:
-      output.layerAvailability !== undefined && output.layerAvailability !== null
-        ? output.layerAvailability
-        : undefined,
-    layerDigest: output.layerDigest !== undefined && output.layerDigest !== null ? output.layerDigest : undefined,
-    layerSize: output.layerSize !== undefined && output.layerSize !== null ? output.layerSize : undefined,
-    mediaType: output.mediaType !== undefined && output.mediaType !== null ? output.mediaType : undefined,
+    layerAvailability: __expectString(output.layerAvailability),
+    layerDigest: __expectString(output.layerDigest),
+    layerSize: __expectNumber(output.layerSize),
+    mediaType: __expectString(output.mediaType),
   } as any;
 };
 
@@ -3493,16 +3471,15 @@ const deserializeAws_json1_1LayerAlreadyExistsException = (
   context: __SerdeContext
 ): LayerAlreadyExistsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1LayerFailure = (output: any, context: __SerdeContext): LayerFailure => {
   return {
-    failureCode: output.failureCode !== undefined && output.failureCode !== null ? output.failureCode : undefined,
-    failureReason:
-      output.failureReason !== undefined && output.failureReason !== null ? output.failureReason : undefined,
-    layerDigest: output.layerDigest !== undefined && output.layerDigest !== null ? output.layerDigest : undefined,
+    failureCode: __expectString(output.failureCode),
+    failureReason: __expectString(output.failureReason),
+    layerDigest: __expectString(output.layerDigest),
   } as any;
 };
 
@@ -3533,7 +3510,7 @@ const deserializeAws_json1_1LayerPartTooSmallException = (
   context: __SerdeContext
 ): LayerPartTooSmallException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3542,13 +3519,13 @@ const deserializeAws_json1_1LayersNotFoundException = (
   context: __SerdeContext
 ): LayersNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3571,7 +3548,7 @@ const deserializeAws_json1_1OperatingSystemList = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3610,21 +3587,14 @@ const deserializeAws_json1_1PutRepositoryCatalogDataResponse = (
 
 const deserializeAws_json1_1ReferencedImageDetail = (output: any, context: __SerdeContext): ReferencedImageDetail => {
   return {
-    artifactMediaType:
-      output.artifactMediaType !== undefined && output.artifactMediaType !== null
-        ? output.artifactMediaType
-        : undefined,
-    imageDigest: output.imageDigest !== undefined && output.imageDigest !== null ? output.imageDigest : undefined,
-    imageManifestMediaType:
-      output.imageManifestMediaType !== undefined && output.imageManifestMediaType !== null
-        ? output.imageManifestMediaType
-        : undefined,
+    artifactMediaType: __expectString(output.artifactMediaType),
+    imageDigest: __expectString(output.imageDigest),
+    imageManifestMediaType: __expectString(output.imageManifestMediaType),
     imagePushedAt:
       output.imagePushedAt !== undefined && output.imagePushedAt !== null
         ? new Date(Math.round(output.imagePushedAt * 1000))
         : undefined,
-    imageSizeInBytes:
-      output.imageSizeInBytes !== undefined && output.imageSizeInBytes !== null ? output.imageSizeInBytes : undefined,
+    imageSizeInBytes: __expectNumber(output.imageSizeInBytes),
   } as any;
 };
 
@@ -3633,7 +3603,7 @@ const deserializeAws_json1_1ReferencedImagesNotFoundException = (
   context: __SerdeContext
 ): ReferencedImagesNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3643,25 +3613,19 @@ const deserializeAws_json1_1Registry = (output: any, context: __SerdeContext): R
       output.aliases !== undefined && output.aliases !== null
         ? deserializeAws_json1_1RegistryAliasList(output.aliases, context)
         : undefined,
-    registryArn: output.registryArn !== undefined && output.registryArn !== null ? output.registryArn : undefined,
-    registryId: output.registryId !== undefined && output.registryId !== null ? output.registryId : undefined,
-    registryUri: output.registryUri !== undefined && output.registryUri !== null ? output.registryUri : undefined,
-    verified: output.verified !== undefined && output.verified !== null ? output.verified : undefined,
+    registryArn: __expectString(output.registryArn),
+    registryId: __expectString(output.registryId),
+    registryUri: __expectString(output.registryUri),
+    verified: __expectBoolean(output.verified),
   } as any;
 };
 
 const deserializeAws_json1_1RegistryAlias = (output: any, context: __SerdeContext): RegistryAlias => {
   return {
-    defaultRegistryAlias:
-      output.defaultRegistryAlias !== undefined && output.defaultRegistryAlias !== null
-        ? output.defaultRegistryAlias
-        : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    primaryRegistryAlias:
-      output.primaryRegistryAlias !== undefined && output.primaryRegistryAlias !== null
-        ? output.primaryRegistryAlias
-        : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    defaultRegistryAlias: __expectBoolean(output.defaultRegistryAlias),
+    name: __expectString(output.name),
+    primaryRegistryAlias: __expectBoolean(output.primaryRegistryAlias),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -3678,7 +3642,7 @@ const deserializeAws_json1_1RegistryAliasList = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1RegistryCatalogData = (output: any, context: __SerdeContext): RegistryCatalogData => {
   return {
-    displayName: output.displayName !== undefined && output.displayName !== null ? output.displayName : undefined,
+    displayName: __expectString(output.displayName),
   } as any;
 };
 
@@ -3698,7 +3662,7 @@ const deserializeAws_json1_1RegistryNotFoundException = (
   context: __SerdeContext
 ): RegistryNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3708,13 +3672,10 @@ const deserializeAws_json1_1Repository = (output: any, context: __SerdeContext):
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    registryId: output.registryId !== undefined && output.registryId !== null ? output.registryId : undefined,
-    repositoryArn:
-      output.repositoryArn !== undefined && output.repositoryArn !== null ? output.repositoryArn : undefined,
-    repositoryName:
-      output.repositoryName !== undefined && output.repositoryName !== null ? output.repositoryName : undefined,
-    repositoryUri:
-      output.repositoryUri !== undefined && output.repositoryUri !== null ? output.repositoryUri : undefined,
+    registryId: __expectString(output.registryId),
+    repositoryArn: __expectString(output.repositoryArn),
+    repositoryName: __expectString(output.repositoryName),
+    repositoryUri: __expectString(output.repositoryUri),
   } as any;
 };
 
@@ -3723,28 +3684,25 @@ const deserializeAws_json1_1RepositoryAlreadyExistsException = (
   context: __SerdeContext
 ): RepositoryAlreadyExistsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1RepositoryCatalogData = (output: any, context: __SerdeContext): RepositoryCatalogData => {
   return {
-    aboutText: output.aboutText !== undefined && output.aboutText !== null ? output.aboutText : undefined,
+    aboutText: __expectString(output.aboutText),
     architectures:
       output.architectures !== undefined && output.architectures !== null
         ? deserializeAws_json1_1ArchitectureList(output.architectures, context)
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    logoUrl: output.logoUrl !== undefined && output.logoUrl !== null ? output.logoUrl : undefined,
-    marketplaceCertified:
-      output.marketplaceCertified !== undefined && output.marketplaceCertified !== null
-        ? output.marketplaceCertified
-        : undefined,
+    description: __expectString(output.description),
+    logoUrl: __expectString(output.logoUrl),
+    marketplaceCertified: __expectBoolean(output.marketplaceCertified),
     operatingSystems:
       output.operatingSystems !== undefined && output.operatingSystems !== null
         ? deserializeAws_json1_1OperatingSystemList(output.operatingSystems, context)
         : undefined,
-    usageText: output.usageText !== undefined && output.usageText !== null ? output.usageText : undefined,
+    usageText: __expectString(output.usageText),
   } as any;
 };
 
@@ -3764,7 +3722,7 @@ const deserializeAws_json1_1RepositoryNotEmptyException = (
   context: __SerdeContext
 ): RepositoryNotEmptyException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3773,7 +3731,7 @@ const deserializeAws_json1_1RepositoryNotFoundException = (
   context: __SerdeContext
 ): RepositoryNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3782,13 +3740,13 @@ const deserializeAws_json1_1RepositoryPolicyNotFoundException = (
   context: __SerdeContext
 ): RepositoryPolicyNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1ServerException = (output: any, context: __SerdeContext): ServerException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3797,17 +3755,16 @@ const deserializeAws_json1_1SetRepositoryPolicyResponse = (
   context: __SerdeContext
 ): SetRepositoryPolicyResponse => {
   return {
-    policyText: output.policyText !== undefined && output.policyText !== null ? output.policyText : undefined,
-    registryId: output.registryId !== undefined && output.registryId !== null ? output.registryId : undefined,
-    repositoryName:
-      output.repositoryName !== undefined && output.repositoryName !== null ? output.repositoryName : undefined,
+    policyText: __expectString(output.policyText),
+    registryId: __expectString(output.registryId),
+    repositoryName: __expectString(output.repositoryName),
   } as any;
 };
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -3828,7 +3785,7 @@ const deserializeAws_json1_1TagResourceResponse = (output: any, context: __Serde
 
 const deserializeAws_json1_1TooManyTagsException = (output: any, context: __SerdeContext): TooManyTagsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3837,7 +3794,7 @@ const deserializeAws_json1_1UnsupportedCommandException = (
   context: __SerdeContext
 ): UnsupportedCommandException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3850,12 +3807,10 @@ const deserializeAws_json1_1UploadLayerPartResponse = (
   context: __SerdeContext
 ): UploadLayerPartResponse => {
   return {
-    lastByteReceived:
-      output.lastByteReceived !== undefined && output.lastByteReceived !== null ? output.lastByteReceived : undefined,
-    registryId: output.registryId !== undefined && output.registryId !== null ? output.registryId : undefined,
-    repositoryName:
-      output.repositoryName !== undefined && output.repositoryName !== null ? output.repositoryName : undefined,
-    uploadId: output.uploadId !== undefined && output.uploadId !== null ? output.uploadId : undefined,
+    lastByteReceived: __expectNumber(output.lastByteReceived),
+    registryId: __expectString(output.registryId),
+    repositoryName: __expectString(output.repositoryName),
+    uploadId: __expectString(output.uploadId),
   } as any;
 };
 
@@ -3864,7 +3819,7 @@ const deserializeAws_json1_1UploadNotFoundException = (
   context: __SerdeContext
 ): UploadNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 

--- a/clients/client-ecr/protocols/Aws_json1_1.ts
+++ b/clients/client-ecr/protocols/Aws_json1_1.ts
@@ -213,7 +213,12 @@ import {
   ValidationException,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -4421,8 +4426,8 @@ const serializeAws_json1_1UploadLayerPartRequest = (input: UploadLayerPartReques
 
 const deserializeAws_json1_1Attribute = (output: any, context: __SerdeContext): Attribute => {
   return {
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    key: __expectString(output.key),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -4439,16 +4444,12 @@ const deserializeAws_json1_1AttributeList = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1AuthorizationData = (output: any, context: __SerdeContext): AuthorizationData => {
   return {
-    authorizationToken:
-      output.authorizationToken !== undefined && output.authorizationToken !== null
-        ? output.authorizationToken
-        : undefined,
+    authorizationToken: __expectString(output.authorizationToken),
     expiresAt:
       output.expiresAt !== undefined && output.expiresAt !== null
         ? new Date(Math.round(output.expiresAt * 1000))
         : undefined,
-    proxyEndpoint:
-      output.proxyEndpoint !== undefined && output.proxyEndpoint !== null ? output.proxyEndpoint : undefined,
+    proxyEndpoint: __expectString(output.proxyEndpoint),
   } as any;
 };
 
@@ -4513,11 +4514,10 @@ const deserializeAws_json1_1CompleteLayerUploadResponse = (
   context: __SerdeContext
 ): CompleteLayerUploadResponse => {
   return {
-    layerDigest: output.layerDigest !== undefined && output.layerDigest !== null ? output.layerDigest : undefined,
-    registryId: output.registryId !== undefined && output.registryId !== null ? output.registryId : undefined,
-    repositoryName:
-      output.repositoryName !== undefined && output.repositoryName !== null ? output.repositoryName : undefined,
-    uploadId: output.uploadId !== undefined && output.uploadId !== null ? output.uploadId : undefined,
+    layerDigest: __expectString(output.layerDigest),
+    registryId: __expectString(output.registryId),
+    repositoryName: __expectString(output.repositoryName),
+    uploadId: __expectString(output.uploadId),
   } as any;
 };
 
@@ -4542,13 +4542,9 @@ const deserializeAws_json1_1DeleteLifecyclePolicyResponse = (
       output.lastEvaluatedAt !== undefined && output.lastEvaluatedAt !== null
         ? new Date(Math.round(output.lastEvaluatedAt * 1000))
         : undefined,
-    lifecyclePolicyText:
-      output.lifecyclePolicyText !== undefined && output.lifecyclePolicyText !== null
-        ? output.lifecyclePolicyText
-        : undefined,
-    registryId: output.registryId !== undefined && output.registryId !== null ? output.registryId : undefined,
-    repositoryName:
-      output.repositoryName !== undefined && output.repositoryName !== null ? output.repositoryName : undefined,
+    lifecyclePolicyText: __expectString(output.lifecyclePolicyText),
+    registryId: __expectString(output.registryId),
+    repositoryName: __expectString(output.repositoryName),
   } as any;
 };
 
@@ -4557,8 +4553,8 @@ const deserializeAws_json1_1DeleteRegistryPolicyResponse = (
   context: __SerdeContext
 ): DeleteRegistryPolicyResponse => {
   return {
-    policyText: output.policyText !== undefined && output.policyText !== null ? output.policyText : undefined,
-    registryId: output.registryId !== undefined && output.registryId !== null ? output.registryId : undefined,
+    policyText: __expectString(output.policyText),
+    registryId: __expectString(output.registryId),
   } as any;
 };
 
@@ -4567,10 +4563,9 @@ const deserializeAws_json1_1DeleteRepositoryPolicyResponse = (
   context: __SerdeContext
 ): DeleteRepositoryPolicyResponse => {
   return {
-    policyText: output.policyText !== undefined && output.policyText !== null ? output.policyText : undefined,
-    registryId: output.registryId !== undefined && output.registryId !== null ? output.registryId : undefined,
-    repositoryName:
-      output.repositoryName !== undefined && output.repositoryName !== null ? output.repositoryName : undefined,
+    policyText: __expectString(output.policyText),
+    registryId: __expectString(output.registryId),
+    repositoryName: __expectString(output.repositoryName),
   } as any;
 };
 
@@ -4603,10 +4598,9 @@ const deserializeAws_json1_1DescribeImageScanFindingsResponse = (
       output.imageScanStatus !== undefined && output.imageScanStatus !== null
         ? deserializeAws_json1_1ImageScanStatus(output.imageScanStatus, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
-    registryId: output.registryId !== undefined && output.registryId !== null ? output.registryId : undefined,
-    repositoryName:
-      output.repositoryName !== undefined && output.repositoryName !== null ? output.repositoryName : undefined,
+    nextToken: __expectString(output.nextToken),
+    registryId: __expectString(output.registryId),
+    repositoryName: __expectString(output.repositoryName),
   } as any;
 };
 
@@ -4616,7 +4610,7 @@ const deserializeAws_json1_1DescribeImagesResponse = (output: any, context: __Se
       output.imageDetails !== undefined && output.imageDetails !== null
         ? deserializeAws_json1_1ImageDetailList(output.imageDetails, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -4625,7 +4619,7 @@ const deserializeAws_json1_1DescribeRegistryResponse = (
   context: __SerdeContext
 ): DescribeRegistryResponse => {
   return {
-    registryId: output.registryId !== undefined && output.registryId !== null ? output.registryId : undefined,
+    registryId: __expectString(output.registryId),
     replicationConfiguration:
       output.replicationConfiguration !== undefined && output.replicationConfiguration !== null
         ? deserializeAws_json1_1ReplicationConfiguration(output.replicationConfiguration, context)
@@ -4638,7 +4632,7 @@ const deserializeAws_json1_1DescribeRepositoriesResponse = (
   context: __SerdeContext
 ): DescribeRepositoriesResponse => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     repositories:
       output.repositories !== undefined && output.repositories !== null
         ? deserializeAws_json1_1RepositoryList(output.repositories, context)
@@ -4648,7 +4642,7 @@ const deserializeAws_json1_1DescribeRepositoriesResponse = (
 
 const deserializeAws_json1_1EmptyUploadException = (output: any, context: __SerdeContext): EmptyUploadException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -4657,9 +4651,8 @@ const deserializeAws_json1_1EncryptionConfiguration = (
   context: __SerdeContext
 ): EncryptionConfiguration => {
   return {
-    encryptionType:
-      output.encryptionType !== undefined && output.encryptionType !== null ? output.encryptionType : undefined,
-    kmsKey: output.kmsKey !== undefined && output.kmsKey !== null ? output.kmsKey : undefined,
+    encryptionType: __expectString(output.encryptionType),
+    kmsKey: __expectString(output.kmsKey),
   } as any;
 };
 
@@ -4674,7 +4667,7 @@ const deserializeAws_json1_1FindingSeverityCounts = (
       }
       return {
         ...acc,
-        [key]: value,
+        [key]: __expectNumber(value) as any,
       };
     },
     {}
@@ -4698,8 +4691,8 @@ const deserializeAws_json1_1GetDownloadUrlForLayerResponse = (
   context: __SerdeContext
 ): GetDownloadUrlForLayerResponse => {
   return {
-    downloadUrl: output.downloadUrl !== undefined && output.downloadUrl !== null ? output.downloadUrl : undefined,
-    layerDigest: output.layerDigest !== undefined && output.layerDigest !== null ? output.layerDigest : undefined,
+    downloadUrl: __expectString(output.downloadUrl),
+    layerDigest: __expectString(output.layerDigest),
   } as any;
 };
 
@@ -4708,19 +4701,15 @@ const deserializeAws_json1_1GetLifecyclePolicyPreviewResponse = (
   context: __SerdeContext
 ): GetLifecyclePolicyPreviewResponse => {
   return {
-    lifecyclePolicyText:
-      output.lifecyclePolicyText !== undefined && output.lifecyclePolicyText !== null
-        ? output.lifecyclePolicyText
-        : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    lifecyclePolicyText: __expectString(output.lifecyclePolicyText),
+    nextToken: __expectString(output.nextToken),
     previewResults:
       output.previewResults !== undefined && output.previewResults !== null
         ? deserializeAws_json1_1LifecyclePolicyPreviewResultList(output.previewResults, context)
         : undefined,
-    registryId: output.registryId !== undefined && output.registryId !== null ? output.registryId : undefined,
-    repositoryName:
-      output.repositoryName !== undefined && output.repositoryName !== null ? output.repositoryName : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    registryId: __expectString(output.registryId),
+    repositoryName: __expectString(output.repositoryName),
+    status: __expectString(output.status),
     summary:
       output.summary !== undefined && output.summary !== null
         ? deserializeAws_json1_1LifecyclePolicyPreviewSummary(output.summary, context)
@@ -4737,13 +4726,9 @@ const deserializeAws_json1_1GetLifecyclePolicyResponse = (
       output.lastEvaluatedAt !== undefined && output.lastEvaluatedAt !== null
         ? new Date(Math.round(output.lastEvaluatedAt * 1000))
         : undefined,
-    lifecyclePolicyText:
-      output.lifecyclePolicyText !== undefined && output.lifecyclePolicyText !== null
-        ? output.lifecyclePolicyText
-        : undefined,
-    registryId: output.registryId !== undefined && output.registryId !== null ? output.registryId : undefined,
-    repositoryName:
-      output.repositoryName !== undefined && output.repositoryName !== null ? output.repositoryName : undefined,
+    lifecyclePolicyText: __expectString(output.lifecyclePolicyText),
+    registryId: __expectString(output.registryId),
+    repositoryName: __expectString(output.repositoryName),
   } as any;
 };
 
@@ -4752,8 +4737,8 @@ const deserializeAws_json1_1GetRegistryPolicyResponse = (
   context: __SerdeContext
 ): GetRegistryPolicyResponse => {
   return {
-    policyText: output.policyText !== undefined && output.policyText !== null ? output.policyText : undefined,
-    registryId: output.registryId !== undefined && output.registryId !== null ? output.registryId : undefined,
+    policyText: __expectString(output.policyText),
+    registryId: __expectString(output.registryId),
   } as any;
 };
 
@@ -4762,10 +4747,9 @@ const deserializeAws_json1_1GetRepositoryPolicyResponse = (
   context: __SerdeContext
 ): GetRepositoryPolicyResponse => {
   return {
-    policyText: output.policyText !== undefined && output.policyText !== null ? output.policyText : undefined,
-    registryId: output.registryId !== undefined && output.registryId !== null ? output.registryId : undefined,
-    repositoryName:
-      output.repositoryName !== undefined && output.repositoryName !== null ? output.repositoryName : undefined,
+    policyText: __expectString(output.policyText),
+    registryId: __expectString(output.registryId),
+    repositoryName: __expectString(output.repositoryName),
   } as any;
 };
 
@@ -4775,15 +4759,10 @@ const deserializeAws_json1_1Image = (output: any, context: __SerdeContext): Imag
       output.imageId !== undefined && output.imageId !== null
         ? deserializeAws_json1_1ImageIdentifier(output.imageId, context)
         : undefined,
-    imageManifest:
-      output.imageManifest !== undefined && output.imageManifest !== null ? output.imageManifest : undefined,
-    imageManifestMediaType:
-      output.imageManifestMediaType !== undefined && output.imageManifestMediaType !== null
-        ? output.imageManifestMediaType
-        : undefined,
-    registryId: output.registryId !== undefined && output.registryId !== null ? output.registryId : undefined,
-    repositoryName:
-      output.repositoryName !== undefined && output.repositoryName !== null ? output.repositoryName : undefined,
+    imageManifest: __expectString(output.imageManifest),
+    imageManifestMediaType: __expectString(output.imageManifestMediaType),
+    registryId: __expectString(output.registryId),
+    repositoryName: __expectString(output.repositoryName),
   } as any;
 };
 
@@ -4792,21 +4771,15 @@ const deserializeAws_json1_1ImageAlreadyExistsException = (
   context: __SerdeContext
 ): ImageAlreadyExistsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1ImageDetail = (output: any, context: __SerdeContext): ImageDetail => {
   return {
-    artifactMediaType:
-      output.artifactMediaType !== undefined && output.artifactMediaType !== null
-        ? output.artifactMediaType
-        : undefined,
-    imageDigest: output.imageDigest !== undefined && output.imageDigest !== null ? output.imageDigest : undefined,
-    imageManifestMediaType:
-      output.imageManifestMediaType !== undefined && output.imageManifestMediaType !== null
-        ? output.imageManifestMediaType
-        : undefined,
+    artifactMediaType: __expectString(output.artifactMediaType),
+    imageDigest: __expectString(output.imageDigest),
+    imageManifestMediaType: __expectString(output.imageManifestMediaType),
     imagePushedAt:
       output.imagePushedAt !== undefined && output.imagePushedAt !== null
         ? new Date(Math.round(output.imagePushedAt * 1000))
@@ -4819,15 +4792,13 @@ const deserializeAws_json1_1ImageDetail = (output: any, context: __SerdeContext)
       output.imageScanStatus !== undefined && output.imageScanStatus !== null
         ? deserializeAws_json1_1ImageScanStatus(output.imageScanStatus, context)
         : undefined,
-    imageSizeInBytes:
-      output.imageSizeInBytes !== undefined && output.imageSizeInBytes !== null ? output.imageSizeInBytes : undefined,
+    imageSizeInBytes: __expectNumber(output.imageSizeInBytes),
     imageTags:
       output.imageTags !== undefined && output.imageTags !== null
         ? deserializeAws_json1_1ImageTagList(output.imageTags, context)
         : undefined,
-    registryId: output.registryId !== undefined && output.registryId !== null ? output.registryId : undefined,
-    repositoryName:
-      output.repositoryName !== undefined && output.repositoryName !== null ? output.repositoryName : undefined,
+    registryId: __expectString(output.registryId),
+    repositoryName: __expectString(output.repositoryName),
   } as any;
 };
 
@@ -4847,15 +4818,14 @@ const deserializeAws_json1_1ImageDigestDoesNotMatchException = (
   context: __SerdeContext
 ): ImageDigestDoesNotMatchException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1ImageFailure = (output: any, context: __SerdeContext): ImageFailure => {
   return {
-    failureCode: output.failureCode !== undefined && output.failureCode !== null ? output.failureCode : undefined,
-    failureReason:
-      output.failureReason !== undefined && output.failureReason !== null ? output.failureReason : undefined,
+    failureCode: __expectString(output.failureCode),
+    failureReason: __expectString(output.failureReason),
     imageId:
       output.imageId !== undefined && output.imageId !== null
         ? deserializeAws_json1_1ImageIdentifier(output.imageId, context)
@@ -4876,8 +4846,8 @@ const deserializeAws_json1_1ImageFailureList = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1ImageIdentifier = (output: any, context: __SerdeContext): ImageIdentifier => {
   return {
-    imageDigest: output.imageDigest !== undefined && output.imageDigest !== null ? output.imageDigest : undefined,
-    imageTag: output.imageTag !== undefined && output.imageTag !== null ? output.imageTag : undefined,
+    imageDigest: __expectString(output.imageDigest),
+    imageTag: __expectString(output.imageTag),
   } as any;
 };
 
@@ -4905,7 +4875,7 @@ const deserializeAws_json1_1ImageList = (output: any, context: __SerdeContext): 
 
 const deserializeAws_json1_1ImageNotFoundException = (output: any, context: __SerdeContext): ImageNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -4915,10 +4885,10 @@ const deserializeAws_json1_1ImageScanFinding = (output: any, context: __SerdeCon
       output.attributes !== undefined && output.attributes !== null
         ? deserializeAws_json1_1AttributeList(output.attributes, context)
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    severity: output.severity !== undefined && output.severity !== null ? output.severity : undefined,
-    uri: output.uri !== undefined && output.uri !== null ? output.uri : undefined,
+    description: __expectString(output.description),
+    name: __expectString(output.name),
+    severity: __expectString(output.severity),
+    uri: __expectString(output.uri),
   } as any;
 };
 
@@ -4979,14 +4949,14 @@ const deserializeAws_json1_1ImageScanningConfiguration = (
   context: __SerdeContext
 ): ImageScanningConfiguration => {
   return {
-    scanOnPush: output.scanOnPush !== undefined && output.scanOnPush !== null ? output.scanOnPush : undefined,
+    scanOnPush: __expectBoolean(output.scanOnPush),
   } as any;
 };
 
 const deserializeAws_json1_1ImageScanStatus = (output: any, context: __SerdeContext): ImageScanStatus => {
   return {
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    description: __expectString(output.description),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -4995,7 +4965,7 @@ const deserializeAws_json1_1ImageTagAlreadyExistsException = (
   context: __SerdeContext
 ): ImageTagAlreadyExistsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -5006,7 +4976,7 @@ const deserializeAws_json1_1ImageTagList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -5015,14 +4985,14 @@ const deserializeAws_json1_1InitiateLayerUploadResponse = (
   context: __SerdeContext
 ): InitiateLayerUploadResponse => {
   return {
-    partSize: output.partSize !== undefined && output.partSize !== null ? output.partSize : undefined,
-    uploadId: output.uploadId !== undefined && output.uploadId !== null ? output.uploadId : undefined,
+    partSize: __expectNumber(output.partSize),
+    uploadId: __expectString(output.uploadId),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidLayerException = (output: any, context: __SerdeContext): InvalidLayerException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -5031,15 +5001,11 @@ const deserializeAws_json1_1InvalidLayerPartException = (
   context: __SerdeContext
 ): InvalidLayerPartException => {
   return {
-    lastValidByteReceived:
-      output.lastValidByteReceived !== undefined && output.lastValidByteReceived !== null
-        ? output.lastValidByteReceived
-        : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    registryId: output.registryId !== undefined && output.registryId !== null ? output.registryId : undefined,
-    repositoryName:
-      output.repositoryName !== undefined && output.repositoryName !== null ? output.repositoryName : undefined,
-    uploadId: output.uploadId !== undefined && output.uploadId !== null ? output.uploadId : undefined,
+    lastValidByteReceived: __expectNumber(output.lastValidByteReceived),
+    message: __expectString(output.message),
+    registryId: __expectString(output.registryId),
+    repositoryName: __expectString(output.repositoryName),
+    uploadId: __expectString(output.uploadId),
   } as any;
 };
 
@@ -5048,7 +5014,7 @@ const deserializeAws_json1_1InvalidParameterException = (
   context: __SerdeContext
 ): InvalidParameterException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -5057,26 +5023,23 @@ const deserializeAws_json1_1InvalidTagParameterException = (
   context: __SerdeContext
 ): InvalidTagParameterException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1KmsException = (output: any, context: __SerdeContext): KmsException => {
   return {
-    kmsError: output.kmsError !== undefined && output.kmsError !== null ? output.kmsError : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    kmsError: __expectString(output.kmsError),
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1Layer = (output: any, context: __SerdeContext): Layer => {
   return {
-    layerAvailability:
-      output.layerAvailability !== undefined && output.layerAvailability !== null
-        ? output.layerAvailability
-        : undefined,
-    layerDigest: output.layerDigest !== undefined && output.layerDigest !== null ? output.layerDigest : undefined,
-    layerSize: output.layerSize !== undefined && output.layerSize !== null ? output.layerSize : undefined,
-    mediaType: output.mediaType !== undefined && output.mediaType !== null ? output.mediaType : undefined,
+    layerAvailability: __expectString(output.layerAvailability),
+    layerDigest: __expectString(output.layerDigest),
+    layerSize: __expectNumber(output.layerSize),
+    mediaType: __expectString(output.mediaType),
   } as any;
 };
 
@@ -5085,16 +5048,15 @@ const deserializeAws_json1_1LayerAlreadyExistsException = (
   context: __SerdeContext
 ): LayerAlreadyExistsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1LayerFailure = (output: any, context: __SerdeContext): LayerFailure => {
   return {
-    failureCode: output.failureCode !== undefined && output.failureCode !== null ? output.failureCode : undefined,
-    failureReason:
-      output.failureReason !== undefined && output.failureReason !== null ? output.failureReason : undefined,
-    layerDigest: output.layerDigest !== undefined && output.layerDigest !== null ? output.layerDigest : undefined,
+    failureCode: __expectString(output.failureCode),
+    failureReason: __expectString(output.failureReason),
+    layerDigest: __expectString(output.layerDigest),
   } as any;
 };
 
@@ -5114,7 +5076,7 @@ const deserializeAws_json1_1LayerInaccessibleException = (
   context: __SerdeContext
 ): LayerInaccessibleException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -5134,7 +5096,7 @@ const deserializeAws_json1_1LayerPartTooSmallException = (
   context: __SerdeContext
 ): LayerPartTooSmallException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -5143,7 +5105,7 @@ const deserializeAws_json1_1LayersNotFoundException = (
   context: __SerdeContext
 ): LayersNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -5152,7 +5114,7 @@ const deserializeAws_json1_1LifecyclePolicyNotFoundException = (
   context: __SerdeContext
 ): LifecyclePolicyNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -5161,7 +5123,7 @@ const deserializeAws_json1_1LifecyclePolicyPreviewInProgressException = (
   context: __SerdeContext
 ): LifecyclePolicyPreviewInProgressException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -5170,7 +5132,7 @@ const deserializeAws_json1_1LifecyclePolicyPreviewNotFoundException = (
   context: __SerdeContext
 ): LifecyclePolicyPreviewNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -5183,11 +5145,8 @@ const deserializeAws_json1_1LifecyclePolicyPreviewResult = (
       output.action !== undefined && output.action !== null
         ? deserializeAws_json1_1LifecyclePolicyRuleAction(output.action, context)
         : undefined,
-    appliedRulePriority:
-      output.appliedRulePriority !== undefined && output.appliedRulePriority !== null
-        ? output.appliedRulePriority
-        : undefined,
-    imageDigest: output.imageDigest !== undefined && output.imageDigest !== null ? output.imageDigest : undefined,
+    appliedRulePriority: __expectNumber(output.appliedRulePriority),
+    imageDigest: __expectString(output.imageDigest),
     imagePushedAt:
       output.imagePushedAt !== undefined && output.imagePushedAt !== null
         ? new Date(Math.round(output.imagePushedAt * 1000))
@@ -5218,10 +5177,7 @@ const deserializeAws_json1_1LifecyclePolicyPreviewSummary = (
   context: __SerdeContext
 ): LifecyclePolicyPreviewSummary => {
   return {
-    expiringImageTotalCount:
-      output.expiringImageTotalCount !== undefined && output.expiringImageTotalCount !== null
-        ? output.expiringImageTotalCount
-        : undefined,
+    expiringImageTotalCount: __expectNumber(output.expiringImageTotalCount),
   } as any;
 };
 
@@ -5230,13 +5186,13 @@ const deserializeAws_json1_1LifecyclePolicyRuleAction = (
   context: __SerdeContext
 ): LifecyclePolicyRuleAction => {
   return {
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    type: __expectString(output.type),
   } as any;
 };
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -5246,7 +5202,7 @@ const deserializeAws_json1_1ListImagesResponse = (output: any, context: __SerdeC
       output.imageIds !== undefined && output.imageIds !== null
         ? deserializeAws_json1_1ImageIdentifierList(output.imageIds, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -5280,9 +5236,8 @@ const deserializeAws_json1_1PutImageScanningConfigurationResponse = (
       output.imageScanningConfiguration !== undefined && output.imageScanningConfiguration !== null
         ? deserializeAws_json1_1ImageScanningConfiguration(output.imageScanningConfiguration, context)
         : undefined,
-    registryId: output.registryId !== undefined && output.registryId !== null ? output.registryId : undefined,
-    repositoryName:
-      output.repositoryName !== undefined && output.repositoryName !== null ? output.repositoryName : undefined,
+    registryId: __expectString(output.registryId),
+    repositoryName: __expectString(output.repositoryName),
   } as any;
 };
 
@@ -5291,13 +5246,9 @@ const deserializeAws_json1_1PutImageTagMutabilityResponse = (
   context: __SerdeContext
 ): PutImageTagMutabilityResponse => {
   return {
-    imageTagMutability:
-      output.imageTagMutability !== undefined && output.imageTagMutability !== null
-        ? output.imageTagMutability
-        : undefined,
-    registryId: output.registryId !== undefined && output.registryId !== null ? output.registryId : undefined,
-    repositoryName:
-      output.repositoryName !== undefined && output.repositoryName !== null ? output.repositoryName : undefined,
+    imageTagMutability: __expectString(output.imageTagMutability),
+    registryId: __expectString(output.registryId),
+    repositoryName: __expectString(output.repositoryName),
   } as any;
 };
 
@@ -5306,13 +5257,9 @@ const deserializeAws_json1_1PutLifecyclePolicyResponse = (
   context: __SerdeContext
 ): PutLifecyclePolicyResponse => {
   return {
-    lifecyclePolicyText:
-      output.lifecyclePolicyText !== undefined && output.lifecyclePolicyText !== null
-        ? output.lifecyclePolicyText
-        : undefined,
-    registryId: output.registryId !== undefined && output.registryId !== null ? output.registryId : undefined,
-    repositoryName:
-      output.repositoryName !== undefined && output.repositoryName !== null ? output.repositoryName : undefined,
+    lifecyclePolicyText: __expectString(output.lifecyclePolicyText),
+    registryId: __expectString(output.registryId),
+    repositoryName: __expectString(output.repositoryName),
   } as any;
 };
 
@@ -5321,8 +5268,8 @@ const deserializeAws_json1_1PutRegistryPolicyResponse = (
   context: __SerdeContext
 ): PutRegistryPolicyResponse => {
   return {
-    policyText: output.policyText !== undefined && output.policyText !== null ? output.policyText : undefined,
-    registryId: output.registryId !== undefined && output.registryId !== null ? output.registryId : undefined,
+    policyText: __expectString(output.policyText),
+    registryId: __expectString(output.registryId),
   } as any;
 };
 
@@ -5343,7 +5290,7 @@ const deserializeAws_json1_1ReferencedImagesNotFoundException = (
   context: __SerdeContext
 ): ReferencedImagesNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -5352,7 +5299,7 @@ const deserializeAws_json1_1RegistryPolicyNotFoundException = (
   context: __SerdeContext
 ): RegistryPolicyNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -5370,8 +5317,8 @@ const deserializeAws_json1_1ReplicationConfiguration = (
 
 const deserializeAws_json1_1ReplicationDestination = (output: any, context: __SerdeContext): ReplicationDestination => {
   return {
-    region: output.region !== undefined && output.region !== null ? output.region : undefined,
-    registryId: output.registryId !== undefined && output.registryId !== null ? output.registryId : undefined,
+    region: __expectString(output.region),
+    registryId: __expectString(output.registryId),
   } as any;
 };
 
@@ -5423,17 +5370,11 @@ const deserializeAws_json1_1Repository = (output: any, context: __SerdeContext):
       output.imageScanningConfiguration !== undefined && output.imageScanningConfiguration !== null
         ? deserializeAws_json1_1ImageScanningConfiguration(output.imageScanningConfiguration, context)
         : undefined,
-    imageTagMutability:
-      output.imageTagMutability !== undefined && output.imageTagMutability !== null
-        ? output.imageTagMutability
-        : undefined,
-    registryId: output.registryId !== undefined && output.registryId !== null ? output.registryId : undefined,
-    repositoryArn:
-      output.repositoryArn !== undefined && output.repositoryArn !== null ? output.repositoryArn : undefined,
-    repositoryName:
-      output.repositoryName !== undefined && output.repositoryName !== null ? output.repositoryName : undefined,
-    repositoryUri:
-      output.repositoryUri !== undefined && output.repositoryUri !== null ? output.repositoryUri : undefined,
+    imageTagMutability: __expectString(output.imageTagMutability),
+    registryId: __expectString(output.registryId),
+    repositoryArn: __expectString(output.repositoryArn),
+    repositoryName: __expectString(output.repositoryName),
+    repositoryUri: __expectString(output.repositoryUri),
   } as any;
 };
 
@@ -5442,7 +5383,7 @@ const deserializeAws_json1_1RepositoryAlreadyExistsException = (
   context: __SerdeContext
 ): RepositoryAlreadyExistsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -5462,7 +5403,7 @@ const deserializeAws_json1_1RepositoryNotEmptyException = (
   context: __SerdeContext
 ): RepositoryNotEmptyException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -5471,7 +5412,7 @@ const deserializeAws_json1_1RepositoryNotFoundException = (
   context: __SerdeContext
 ): RepositoryNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -5480,19 +5421,19 @@ const deserializeAws_json1_1RepositoryPolicyNotFoundException = (
   context: __SerdeContext
 ): RepositoryPolicyNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1ScanNotFoundException = (output: any, context: __SerdeContext): ScanNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1ServerException = (output: any, context: __SerdeContext): ServerException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -5501,10 +5442,9 @@ const deserializeAws_json1_1SetRepositoryPolicyResponse = (
   context: __SerdeContext
 ): SetRepositoryPolicyResponse => {
   return {
-    policyText: output.policyText !== undefined && output.policyText !== null ? output.policyText : undefined,
-    registryId: output.registryId !== undefined && output.registryId !== null ? output.registryId : undefined,
-    repositoryName:
-      output.repositoryName !== undefined && output.repositoryName !== null ? output.repositoryName : undefined,
+    policyText: __expectString(output.policyText),
+    registryId: __expectString(output.registryId),
+    repositoryName: __expectString(output.repositoryName),
   } as any;
 };
 
@@ -5518,9 +5458,8 @@ const deserializeAws_json1_1StartImageScanResponse = (output: any, context: __Se
       output.imageScanStatus !== undefined && output.imageScanStatus !== null
         ? deserializeAws_json1_1ImageScanStatus(output.imageScanStatus, context)
         : undefined,
-    registryId: output.registryId !== undefined && output.registryId !== null ? output.registryId : undefined,
-    repositoryName:
-      output.repositoryName !== undefined && output.repositoryName !== null ? output.repositoryName : undefined,
+    registryId: __expectString(output.registryId),
+    repositoryName: __expectString(output.repositoryName),
   } as any;
 };
 
@@ -5529,21 +5468,17 @@ const deserializeAws_json1_1StartLifecyclePolicyPreviewResponse = (
   context: __SerdeContext
 ): StartLifecyclePolicyPreviewResponse => {
   return {
-    lifecyclePolicyText:
-      output.lifecyclePolicyText !== undefined && output.lifecyclePolicyText !== null
-        ? output.lifecyclePolicyText
-        : undefined,
-    registryId: output.registryId !== undefined && output.registryId !== null ? output.registryId : undefined,
-    repositoryName:
-      output.repositoryName !== undefined && output.repositoryName !== null ? output.repositoryName : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    lifecyclePolicyText: __expectString(output.lifecyclePolicyText),
+    registryId: __expectString(output.registryId),
+    repositoryName: __expectString(output.repositoryName),
+    status: __expectString(output.status),
   } as any;
 };
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -5564,7 +5499,7 @@ const deserializeAws_json1_1TagResourceResponse = (output: any, context: __Serde
 
 const deserializeAws_json1_1TooManyTagsException = (output: any, context: __SerdeContext): TooManyTagsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -5573,7 +5508,7 @@ const deserializeAws_json1_1UnsupportedImageTypeException = (
   context: __SerdeContext
 ): UnsupportedImageTypeException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -5586,12 +5521,10 @@ const deserializeAws_json1_1UploadLayerPartResponse = (
   context: __SerdeContext
 ): UploadLayerPartResponse => {
   return {
-    lastByteReceived:
-      output.lastByteReceived !== undefined && output.lastByteReceived !== null ? output.lastByteReceived : undefined,
-    registryId: output.registryId !== undefined && output.registryId !== null ? output.registryId : undefined,
-    repositoryName:
-      output.repositoryName !== undefined && output.repositoryName !== null ? output.repositoryName : undefined,
-    uploadId: output.uploadId !== undefined && output.uploadId !== null ? output.uploadId : undefined,
+    lastByteReceived: __expectNumber(output.lastByteReceived),
+    registryId: __expectString(output.registryId),
+    repositoryName: __expectString(output.repositoryName),
+    uploadId: __expectString(output.uploadId),
   } as any;
 };
 
@@ -5600,13 +5533,13 @@ const deserializeAws_json1_1UploadNotFoundException = (
   context: __SerdeContext
 ): UploadNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1ValidationException = (output: any, context: __SerdeContext): ValidationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 

--- a/clients/client-ecs/protocols/Aws_json1_1.ts
+++ b/clients/client-ecs/protocols/Aws_json1_1.ts
@@ -345,7 +345,12 @@ import {
   VolumeFrom,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -7843,7 +7848,7 @@ const serializeAws_json1_1VolumeList = (input: Volume[], context: __SerdeContext
 
 const deserializeAws_json1_1AccessDeniedException = (output: any, context: __SerdeContext): AccessDeniedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -7853,9 +7858,9 @@ const deserializeAws_json1_1Attachment = (output: any, context: __SerdeContext):
       output.details !== undefined && output.details !== null
         ? deserializeAws_json1_1AttachmentDetails(output.details, context)
         : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    id: __expectString(output.id),
+    status: __expectString(output.status),
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -7883,10 +7888,10 @@ const deserializeAws_json1_1Attachments = (output: any, context: __SerdeContext)
 
 const deserializeAws_json1_1Attribute = (output: any, context: __SerdeContext): Attribute => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    targetId: output.targetId !== undefined && output.targetId !== null ? output.targetId : undefined,
-    targetType: output.targetType !== undefined && output.targetType !== null ? output.targetType : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    name: __expectString(output.name),
+    targetId: __expectString(output.targetId),
+    targetType: __expectString(output.targetType),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -7895,7 +7900,7 @@ const deserializeAws_json1_1AttributeLimitExceededException = (
   context: __SerdeContext
 ): AttributeLimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -7915,25 +7920,18 @@ const deserializeAws_json1_1AutoScalingGroupProvider = (
   context: __SerdeContext
 ): AutoScalingGroupProvider => {
   return {
-    autoScalingGroupArn:
-      output.autoScalingGroupArn !== undefined && output.autoScalingGroupArn !== null
-        ? output.autoScalingGroupArn
-        : undefined,
+    autoScalingGroupArn: __expectString(output.autoScalingGroupArn),
     managedScaling:
       output.managedScaling !== undefined && output.managedScaling !== null
         ? deserializeAws_json1_1ManagedScaling(output.managedScaling, context)
         : undefined,
-    managedTerminationProtection:
-      output.managedTerminationProtection !== undefined && output.managedTerminationProtection !== null
-        ? output.managedTerminationProtection
-        : undefined,
+    managedTerminationProtection: __expectString(output.managedTerminationProtection),
   } as any;
 };
 
 const deserializeAws_json1_1AwsVpcConfiguration = (output: any, context: __SerdeContext): AwsVpcConfiguration => {
   return {
-    assignPublicIp:
-      output.assignPublicIp !== undefined && output.assignPublicIp !== null ? output.assignPublicIp : undefined,
+    assignPublicIp: __expectString(output.assignPublicIp),
     securityGroups:
       output.securityGroups !== undefined && output.securityGroups !== null
         ? deserializeAws_json1_1StringList(output.securityGroups, context)
@@ -7947,7 +7945,7 @@ const deserializeAws_json1_1AwsVpcConfiguration = (output: any, context: __Serde
 
 const deserializeAws_json1_1BlockedException = (output: any, context: __SerdeContext): BlockedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -7957,19 +7955,13 @@ const deserializeAws_json1_1CapacityProvider = (output: any, context: __SerdeCon
       output.autoScalingGroupProvider !== undefined && output.autoScalingGroupProvider !== null
         ? deserializeAws_json1_1AutoScalingGroupProvider(output.autoScalingGroupProvider, context)
         : undefined,
-    capacityProviderArn:
-      output.capacityProviderArn !== undefined && output.capacityProviderArn !== null
-        ? output.capacityProviderArn
-        : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    capacityProviderArn: __expectString(output.capacityProviderArn),
+    name: __expectString(output.name),
+    status: __expectString(output.status),
     tags:
       output.tags !== undefined && output.tags !== null ? deserializeAws_json1_1Tags(output.tags, context) : undefined,
-    updateStatus: output.updateStatus !== undefined && output.updateStatus !== null ? output.updateStatus : undefined,
-    updateStatusReason:
-      output.updateStatusReason !== undefined && output.updateStatusReason !== null
-        ? output.updateStatusReason
-        : undefined,
+    updateStatus: __expectString(output.updateStatus),
+    updateStatusReason: __expectString(output.updateStatusReason),
   } as any;
 };
 
@@ -8003,39 +7995,32 @@ const deserializeAws_json1_1CapacityProviderStrategyItem = (
   context: __SerdeContext
 ): CapacityProviderStrategyItem => {
   return {
-    base: output.base !== undefined && output.base !== null ? output.base : undefined,
-    capacityProvider:
-      output.capacityProvider !== undefined && output.capacityProvider !== null ? output.capacityProvider : undefined,
-    weight: output.weight !== undefined && output.weight !== null ? output.weight : undefined,
+    base: __expectNumber(output.base),
+    capacityProvider: __expectString(output.capacityProvider),
+    weight: __expectNumber(output.weight),
   } as any;
 };
 
 const deserializeAws_json1_1ClientException = (output: any, context: __SerdeContext): ClientException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1Cluster = (output: any, context: __SerdeContext): Cluster => {
   return {
-    activeServicesCount:
-      output.activeServicesCount !== undefined && output.activeServicesCount !== null
-        ? output.activeServicesCount
-        : undefined,
+    activeServicesCount: __expectNumber(output.activeServicesCount),
     attachments:
       output.attachments !== undefined && output.attachments !== null
         ? deserializeAws_json1_1Attachments(output.attachments, context)
         : undefined,
-    attachmentsStatus:
-      output.attachmentsStatus !== undefined && output.attachmentsStatus !== null
-        ? output.attachmentsStatus
-        : undefined,
+    attachmentsStatus: __expectString(output.attachmentsStatus),
     capacityProviders:
       output.capacityProviders !== undefined && output.capacityProviders !== null
         ? deserializeAws_json1_1StringList(output.capacityProviders, context)
         : undefined,
-    clusterArn: output.clusterArn !== undefined && output.clusterArn !== null ? output.clusterArn : undefined,
-    clusterName: output.clusterName !== undefined && output.clusterName !== null ? output.clusterName : undefined,
+    clusterArn: __expectString(output.clusterArn),
+    clusterName: __expectString(output.clusterName),
     configuration:
       output.configuration !== undefined && output.configuration !== null
         ? deserializeAws_json1_1ClusterConfiguration(output.configuration, context)
@@ -8044,18 +8029,9 @@ const deserializeAws_json1_1Cluster = (output: any, context: __SerdeContext): Cl
       output.defaultCapacityProviderStrategy !== undefined && output.defaultCapacityProviderStrategy !== null
         ? deserializeAws_json1_1CapacityProviderStrategy(output.defaultCapacityProviderStrategy, context)
         : undefined,
-    pendingTasksCount:
-      output.pendingTasksCount !== undefined && output.pendingTasksCount !== null
-        ? output.pendingTasksCount
-        : undefined,
-    registeredContainerInstancesCount:
-      output.registeredContainerInstancesCount !== undefined && output.registeredContainerInstancesCount !== null
-        ? output.registeredContainerInstancesCount
-        : undefined,
-    runningTasksCount:
-      output.runningTasksCount !== undefined && output.runningTasksCount !== null
-        ? output.runningTasksCount
-        : undefined,
+    pendingTasksCount: __expectNumber(output.pendingTasksCount),
+    registeredContainerInstancesCount: __expectNumber(output.registeredContainerInstancesCount),
+    runningTasksCount: __expectNumber(output.runningTasksCount),
     settings:
       output.settings !== undefined && output.settings !== null
         ? deserializeAws_json1_1ClusterSettings(output.settings, context)
@@ -8064,7 +8040,7 @@ const deserializeAws_json1_1Cluster = (output: any, context: __SerdeContext): Cl
       output.statistics !== undefined && output.statistics !== null
         ? deserializeAws_json1_1Statistics(output.statistics, context)
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
     tags:
       output.tags !== undefined && output.tags !== null ? deserializeAws_json1_1Tags(output.tags, context) : undefined,
   } as any;
@@ -8084,7 +8060,7 @@ const deserializeAws_json1_1ClusterContainsContainerInstancesException = (
   context: __SerdeContext
 ): ClusterContainsContainerInstancesException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -8093,7 +8069,7 @@ const deserializeAws_json1_1ClusterContainsServicesException = (
   context: __SerdeContext
 ): ClusterContainsServicesException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -8102,7 +8078,7 @@ const deserializeAws_json1_1ClusterContainsTasksException = (
   context: __SerdeContext
 ): ClusterContainsTasksException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -8111,7 +8087,7 @@ const deserializeAws_json1_1ClusterNotFoundException = (
   context: __SerdeContext
 ): ClusterNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -8128,8 +8104,8 @@ const deserializeAws_json1_1Clusters = (output: any, context: __SerdeContext): C
 
 const deserializeAws_json1_1ClusterSetting = (output: any, context: __SerdeContext): ClusterSetting => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    name: __expectString(output.name),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -8151,33 +8127,30 @@ const deserializeAws_json1_1CompatibilityList = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1Container = (output: any, context: __SerdeContext): Container => {
   return {
-    containerArn: output.containerArn !== undefined && output.containerArn !== null ? output.containerArn : undefined,
-    cpu: output.cpu !== undefined && output.cpu !== null ? output.cpu : undefined,
-    exitCode: output.exitCode !== undefined && output.exitCode !== null ? output.exitCode : undefined,
+    containerArn: __expectString(output.containerArn),
+    cpu: __expectString(output.cpu),
+    exitCode: __expectNumber(output.exitCode),
     gpuIds:
       output.gpuIds !== undefined && output.gpuIds !== null
         ? deserializeAws_json1_1GpuIds(output.gpuIds, context)
         : undefined,
-    healthStatus: output.healthStatus !== undefined && output.healthStatus !== null ? output.healthStatus : undefined,
-    image: output.image !== undefined && output.image !== null ? output.image : undefined,
-    imageDigest: output.imageDigest !== undefined && output.imageDigest !== null ? output.imageDigest : undefined,
-    lastStatus: output.lastStatus !== undefined && output.lastStatus !== null ? output.lastStatus : undefined,
+    healthStatus: __expectString(output.healthStatus),
+    image: __expectString(output.image),
+    imageDigest: __expectString(output.imageDigest),
+    lastStatus: __expectString(output.lastStatus),
     managedAgents:
       output.managedAgents !== undefined && output.managedAgents !== null
         ? deserializeAws_json1_1ManagedAgents(output.managedAgents, context)
         : undefined,
-    memory: output.memory !== undefined && output.memory !== null ? output.memory : undefined,
-    memoryReservation:
-      output.memoryReservation !== undefined && output.memoryReservation !== null
-        ? output.memoryReservation
-        : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    memory: __expectString(output.memory),
+    memoryReservation: __expectString(output.memoryReservation),
+    name: __expectString(output.name),
     networkBindings:
       output.networkBindings !== undefined && output.networkBindings !== null
         ? deserializeAws_json1_1NetworkBindings(output.networkBindings, context)
@@ -8186,9 +8159,9 @@ const deserializeAws_json1_1Container = (output: any, context: __SerdeContext): 
       output.networkInterfaces !== undefined && output.networkInterfaces !== null
         ? deserializeAws_json1_1NetworkInterfaces(output.networkInterfaces, context)
         : undefined,
-    reason: output.reason !== undefined && output.reason !== null ? output.reason : undefined,
-    runtimeId: output.runtimeId !== undefined && output.runtimeId !== null ? output.runtimeId : undefined,
-    taskArn: output.taskArn !== undefined && output.taskArn !== null ? output.taskArn : undefined,
+    reason: __expectString(output.reason),
+    runtimeId: __expectString(output.runtimeId),
+    taskArn: __expectString(output.taskArn),
   } as any;
 };
 
@@ -8198,15 +8171,12 @@ const deserializeAws_json1_1ContainerDefinition = (output: any, context: __Serde
       output.command !== undefined && output.command !== null
         ? deserializeAws_json1_1StringList(output.command, context)
         : undefined,
-    cpu: output.cpu !== undefined && output.cpu !== null ? output.cpu : undefined,
+    cpu: __expectNumber(output.cpu),
     dependsOn:
       output.dependsOn !== undefined && output.dependsOn !== null
         ? deserializeAws_json1_1ContainerDependencies(output.dependsOn, context)
         : undefined,
-    disableNetworking:
-      output.disableNetworking !== undefined && output.disableNetworking !== null
-        ? output.disableNetworking
-        : undefined,
+    disableNetworking: __expectBoolean(output.disableNetworking),
     dnsSearchDomains:
       output.dnsSearchDomains !== undefined && output.dnsSearchDomains !== null
         ? deserializeAws_json1_1StringList(output.dnsSearchDomains, context)
@@ -8235,7 +8205,7 @@ const deserializeAws_json1_1ContainerDefinition = (output: any, context: __Serde
       output.environmentFiles !== undefined && output.environmentFiles !== null
         ? deserializeAws_json1_1EnvironmentFiles(output.environmentFiles, context)
         : undefined,
-    essential: output.essential !== undefined && output.essential !== null ? output.essential : undefined,
+    essential: __expectBoolean(output.essential),
     extraHosts:
       output.extraHosts !== undefined && output.extraHosts !== null
         ? deserializeAws_json1_1HostEntryList(output.extraHosts, context)
@@ -8248,9 +8218,9 @@ const deserializeAws_json1_1ContainerDefinition = (output: any, context: __Serde
       output.healthCheck !== undefined && output.healthCheck !== null
         ? deserializeAws_json1_1HealthCheck(output.healthCheck, context)
         : undefined,
-    hostname: output.hostname !== undefined && output.hostname !== null ? output.hostname : undefined,
-    image: output.image !== undefined && output.image !== null ? output.image : undefined,
-    interactive: output.interactive !== undefined && output.interactive !== null ? output.interactive : undefined,
+    hostname: __expectString(output.hostname),
+    image: __expectString(output.image),
+    interactive: __expectBoolean(output.interactive),
     links:
       output.links !== undefined && output.links !== null
         ? deserializeAws_json1_1StringList(output.links, context)
@@ -8263,27 +8233,20 @@ const deserializeAws_json1_1ContainerDefinition = (output: any, context: __Serde
       output.logConfiguration !== undefined && output.logConfiguration !== null
         ? deserializeAws_json1_1LogConfiguration(output.logConfiguration, context)
         : undefined,
-    memory: output.memory !== undefined && output.memory !== null ? output.memory : undefined,
-    memoryReservation:
-      output.memoryReservation !== undefined && output.memoryReservation !== null
-        ? output.memoryReservation
-        : undefined,
+    memory: __expectNumber(output.memory),
+    memoryReservation: __expectNumber(output.memoryReservation),
     mountPoints:
       output.mountPoints !== undefined && output.mountPoints !== null
         ? deserializeAws_json1_1MountPointList(output.mountPoints, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
     portMappings:
       output.portMappings !== undefined && output.portMappings !== null
         ? deserializeAws_json1_1PortMappingList(output.portMappings, context)
         : undefined,
-    privileged: output.privileged !== undefined && output.privileged !== null ? output.privileged : undefined,
-    pseudoTerminal:
-      output.pseudoTerminal !== undefined && output.pseudoTerminal !== null ? output.pseudoTerminal : undefined,
-    readonlyRootFilesystem:
-      output.readonlyRootFilesystem !== undefined && output.readonlyRootFilesystem !== null
-        ? output.readonlyRootFilesystem
-        : undefined,
+    privileged: __expectBoolean(output.privileged),
+    pseudoTerminal: __expectBoolean(output.pseudoTerminal),
+    readonlyRootFilesystem: __expectBoolean(output.readonlyRootFilesystem),
     repositoryCredentials:
       output.repositoryCredentials !== undefined && output.repositoryCredentials !== null
         ? deserializeAws_json1_1RepositoryCredentials(output.repositoryCredentials, context)
@@ -8296,8 +8259,8 @@ const deserializeAws_json1_1ContainerDefinition = (output: any, context: __Serde
       output.secrets !== undefined && output.secrets !== null
         ? deserializeAws_json1_1SecretList(output.secrets, context)
         : undefined,
-    startTimeout: output.startTimeout !== undefined && output.startTimeout !== null ? output.startTimeout : undefined,
-    stopTimeout: output.stopTimeout !== undefined && output.stopTimeout !== null ? output.stopTimeout : undefined,
+    startTimeout: __expectNumber(output.startTimeout),
+    stopTimeout: __expectNumber(output.stopTimeout),
     systemControls:
       output.systemControls !== undefined && output.systemControls !== null
         ? deserializeAws_json1_1SystemControls(output.systemControls, context)
@@ -8306,13 +8269,12 @@ const deserializeAws_json1_1ContainerDefinition = (output: any, context: __Serde
       output.ulimits !== undefined && output.ulimits !== null
         ? deserializeAws_json1_1UlimitList(output.ulimits, context)
         : undefined,
-    user: output.user !== undefined && output.user !== null ? output.user : undefined,
+    user: __expectString(output.user),
     volumesFrom:
       output.volumesFrom !== undefined && output.volumesFrom !== null
         ? deserializeAws_json1_1VolumeFromList(output.volumesFrom, context)
         : undefined,
-    workingDirectory:
-      output.workingDirectory !== undefined && output.workingDirectory !== null ? output.workingDirectory : undefined,
+    workingDirectory: __expectString(output.workingDirectory),
   } as any;
 };
 
@@ -8340,20 +8302,15 @@ const deserializeAws_json1_1ContainerDependencies = (output: any, context: __Ser
 
 const deserializeAws_json1_1ContainerDependency = (output: any, context: __SerdeContext): ContainerDependency => {
   return {
-    condition: output.condition !== undefined && output.condition !== null ? output.condition : undefined,
-    containerName:
-      output.containerName !== undefined && output.containerName !== null ? output.containerName : undefined,
+    condition: __expectString(output.condition),
+    containerName: __expectString(output.containerName),
   } as any;
 };
 
 const deserializeAws_json1_1ContainerInstance = (output: any, context: __SerdeContext): ContainerInstance => {
   return {
-    agentConnected:
-      output.agentConnected !== undefined && output.agentConnected !== null ? output.agentConnected : undefined,
-    agentUpdateStatus:
-      output.agentUpdateStatus !== undefined && output.agentUpdateStatus !== null
-        ? output.agentUpdateStatus
-        : undefined,
+    agentConnected: __expectBoolean(output.agentConnected),
+    agentUpdateStatus: __expectString(output.agentUpdateStatus),
     attachments:
       output.attachments !== undefined && output.attachments !== null
         ? deserializeAws_json1_1Attachments(output.attachments, context)
@@ -8362,20 +8319,10 @@ const deserializeAws_json1_1ContainerInstance = (output: any, context: __SerdeCo
       output.attributes !== undefined && output.attributes !== null
         ? deserializeAws_json1_1Attributes(output.attributes, context)
         : undefined,
-    capacityProviderName:
-      output.capacityProviderName !== undefined && output.capacityProviderName !== null
-        ? output.capacityProviderName
-        : undefined,
-    containerInstanceArn:
-      output.containerInstanceArn !== undefined && output.containerInstanceArn !== null
-        ? output.containerInstanceArn
-        : undefined,
-    ec2InstanceId:
-      output.ec2InstanceId !== undefined && output.ec2InstanceId !== null ? output.ec2InstanceId : undefined,
-    pendingTasksCount:
-      output.pendingTasksCount !== undefined && output.pendingTasksCount !== null
-        ? output.pendingTasksCount
-        : undefined,
+    capacityProviderName: __expectString(output.capacityProviderName),
+    containerInstanceArn: __expectString(output.containerInstanceArn),
+    ec2InstanceId: __expectString(output.ec2InstanceId),
+    pendingTasksCount: __expectNumber(output.pendingTasksCount),
     registeredAt:
       output.registeredAt !== undefined && output.registeredAt !== null
         ? new Date(Math.round(output.registeredAt * 1000))
@@ -8388,15 +8335,12 @@ const deserializeAws_json1_1ContainerInstance = (output: any, context: __SerdeCo
       output.remainingResources !== undefined && output.remainingResources !== null
         ? deserializeAws_json1_1Resources(output.remainingResources, context)
         : undefined,
-    runningTasksCount:
-      output.runningTasksCount !== undefined && output.runningTasksCount !== null
-        ? output.runningTasksCount
-        : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    statusReason: output.statusReason !== undefined && output.statusReason !== null ? output.statusReason : undefined,
+    runningTasksCount: __expectNumber(output.runningTasksCount),
+    status: __expectString(output.status),
+    statusReason: __expectString(output.statusReason),
     tags:
       output.tags !== undefined && output.tags !== null ? deserializeAws_json1_1Tags(output.tags, context) : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    version: __expectNumber(output.version),
     versionInfo:
       output.versionInfo !== undefined && output.versionInfo !== null
         ? deserializeAws_json1_1VersionInfo(output.versionInfo, context)
@@ -8421,7 +8365,7 @@ const deserializeAws_json1_1ContainerOverride = (output: any, context: __SerdeCo
       output.command !== undefined && output.command !== null
         ? deserializeAws_json1_1StringList(output.command, context)
         : undefined,
-    cpu: output.cpu !== undefined && output.cpu !== null ? output.cpu : undefined,
+    cpu: __expectNumber(output.cpu),
     environment:
       output.environment !== undefined && output.environment !== null
         ? deserializeAws_json1_1EnvironmentVariables(output.environment, context)
@@ -8430,12 +8374,9 @@ const deserializeAws_json1_1ContainerOverride = (output: any, context: __SerdeCo
       output.environmentFiles !== undefined && output.environmentFiles !== null
         ? deserializeAws_json1_1EnvironmentFiles(output.environmentFiles, context)
         : undefined,
-    memory: output.memory !== undefined && output.memory !== null ? output.memory : undefined,
-    memoryReservation:
-      output.memoryReservation !== undefined && output.memoryReservation !== null
-        ? output.memoryReservation
-        : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    memory: __expectNumber(output.memory),
+    memoryReservation: __expectNumber(output.memoryReservation),
+    name: __expectString(output.name),
     resourceRequirements:
       output.resourceRequirements !== undefined && output.resourceRequirements !== null
         ? deserializeAws_json1_1ResourceRequirements(output.resourceRequirements, context)
@@ -8577,26 +8518,21 @@ const deserializeAws_json1_1Deployment = (output: any, context: __SerdeContext):
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    desiredCount: output.desiredCount !== undefined && output.desiredCount !== null ? output.desiredCount : undefined,
-    failedTasks: output.failedTasks !== undefined && output.failedTasks !== null ? output.failedTasks : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    launchType: output.launchType !== undefined && output.launchType !== null ? output.launchType : undefined,
+    desiredCount: __expectNumber(output.desiredCount),
+    failedTasks: __expectNumber(output.failedTasks),
+    id: __expectString(output.id),
+    launchType: __expectString(output.launchType),
     networkConfiguration:
       output.networkConfiguration !== undefined && output.networkConfiguration !== null
         ? deserializeAws_json1_1NetworkConfiguration(output.networkConfiguration, context)
         : undefined,
-    pendingCount: output.pendingCount !== undefined && output.pendingCount !== null ? output.pendingCount : undefined,
-    platformVersion:
-      output.platformVersion !== undefined && output.platformVersion !== null ? output.platformVersion : undefined,
-    rolloutState: output.rolloutState !== undefined && output.rolloutState !== null ? output.rolloutState : undefined,
-    rolloutStateReason:
-      output.rolloutStateReason !== undefined && output.rolloutStateReason !== null
-        ? output.rolloutStateReason
-        : undefined,
-    runningCount: output.runningCount !== undefined && output.runningCount !== null ? output.runningCount : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    taskDefinition:
-      output.taskDefinition !== undefined && output.taskDefinition !== null ? output.taskDefinition : undefined,
+    pendingCount: __expectNumber(output.pendingCount),
+    platformVersion: __expectString(output.platformVersion),
+    rolloutState: __expectString(output.rolloutState),
+    rolloutStateReason: __expectString(output.rolloutStateReason),
+    runningCount: __expectNumber(output.runningCount),
+    status: __expectString(output.status),
+    taskDefinition: __expectString(output.taskDefinition),
     updatedAt:
       output.updatedAt !== undefined && output.updatedAt !== null
         ? new Date(Math.round(output.updatedAt * 1000))
@@ -8609,8 +8545,8 @@ const deserializeAws_json1_1DeploymentCircuitBreaker = (
   context: __SerdeContext
 ): DeploymentCircuitBreaker => {
   return {
-    enable: output.enable !== undefined && output.enable !== null ? output.enable : undefined,
-    rollback: output.rollback !== undefined && output.rollback !== null ? output.rollback : undefined,
+    enable: __expectBoolean(output.enable),
+    rollback: __expectBoolean(output.rollback),
   } as any;
 };
 
@@ -8623,18 +8559,14 @@ const deserializeAws_json1_1DeploymentConfiguration = (
       output.deploymentCircuitBreaker !== undefined && output.deploymentCircuitBreaker !== null
         ? deserializeAws_json1_1DeploymentCircuitBreaker(output.deploymentCircuitBreaker, context)
         : undefined,
-    maximumPercent:
-      output.maximumPercent !== undefined && output.maximumPercent !== null ? output.maximumPercent : undefined,
-    minimumHealthyPercent:
-      output.minimumHealthyPercent !== undefined && output.minimumHealthyPercent !== null
-        ? output.minimumHealthyPercent
-        : undefined,
+    maximumPercent: __expectNumber(output.maximumPercent),
+    minimumHealthyPercent: __expectNumber(output.minimumHealthyPercent),
   } as any;
 };
 
 const deserializeAws_json1_1DeploymentController = (output: any, context: __SerdeContext): DeploymentController => {
   return {
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -8686,7 +8618,7 @@ const deserializeAws_json1_1DescribeCapacityProvidersResponse = (
       output.failures !== undefined && output.failures !== null
         ? deserializeAws_json1_1Failures(output.failures, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -8783,9 +8715,8 @@ const deserializeAws_json1_1DescribeTasksResponse = (output: any, context: __Ser
 
 const deserializeAws_json1_1Device = (output: any, context: __SerdeContext): Device => {
   return {
-    containerPath:
-      output.containerPath !== undefined && output.containerPath !== null ? output.containerPath : undefined,
-    hostPath: output.hostPath !== undefined && output.hostPath !== null ? output.hostPath : undefined,
+    containerPath: __expectString(output.containerPath),
+    hostPath: __expectString(output.hostPath),
     permissions:
       output.permissions !== undefined && output.permissions !== null
         ? deserializeAws_json1_1DeviceCgroupPermissions(output.permissions, context)
@@ -8803,7 +8734,7 @@ const deserializeAws_json1_1DeviceCgroupPermissions = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -8823,11 +8754,8 @@ const deserializeAws_json1_1DiscoverPollEndpointResponse = (
   context: __SerdeContext
 ): DiscoverPollEndpointResponse => {
   return {
-    endpoint: output.endpoint !== undefined && output.endpoint !== null ? output.endpoint : undefined,
-    telemetryEndpoint:
-      output.telemetryEndpoint !== undefined && output.telemetryEndpoint !== null
-        ? output.telemetryEndpoint
-        : undefined,
+    endpoint: __expectString(output.endpoint),
+    telemetryEndpoint: __expectString(output.telemetryEndpoint),
   } as any;
 };
 
@@ -8838,7 +8766,7 @@ const deserializeAws_json1_1DockerLabelsMap = (output: any, context: __SerdeCont
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -8848,9 +8776,8 @@ const deserializeAws_json1_1DockerVolumeConfiguration = (
   context: __SerdeContext
 ): DockerVolumeConfiguration => {
   return {
-    autoprovision:
-      output.autoprovision !== undefined && output.autoprovision !== null ? output.autoprovision : undefined,
-    driver: output.driver !== undefined && output.driver !== null ? output.driver : undefined,
+    autoprovision: __expectBoolean(output.autoprovision),
+    driver: __expectString(output.driver),
     driverOpts:
       output.driverOpts !== undefined && output.driverOpts !== null
         ? deserializeAws_json1_1StringMap(output.driverOpts, context)
@@ -8859,15 +8786,14 @@ const deserializeAws_json1_1DockerVolumeConfiguration = (
       output.labels !== undefined && output.labels !== null
         ? deserializeAws_json1_1StringMap(output.labels, context)
         : undefined,
-    scope: output.scope !== undefined && output.scope !== null ? output.scope : undefined,
+    scope: __expectString(output.scope),
   } as any;
 };
 
 const deserializeAws_json1_1EFSAuthorizationConfig = (output: any, context: __SerdeContext): EFSAuthorizationConfig => {
   return {
-    accessPointId:
-      output.accessPointId !== undefined && output.accessPointId !== null ? output.accessPointId : undefined,
-    iam: output.iam !== undefined && output.iam !== null ? output.iam : undefined,
+    accessPointId: __expectString(output.accessPointId),
+    iam: __expectString(output.iam),
   } as any;
 };
 
@@ -8877,24 +8803,17 @@ const deserializeAws_json1_1EFSVolumeConfiguration = (output: any, context: __Se
       output.authorizationConfig !== undefined && output.authorizationConfig !== null
         ? deserializeAws_json1_1EFSAuthorizationConfig(output.authorizationConfig, context)
         : undefined,
-    fileSystemId: output.fileSystemId !== undefined && output.fileSystemId !== null ? output.fileSystemId : undefined,
-    rootDirectory:
-      output.rootDirectory !== undefined && output.rootDirectory !== null ? output.rootDirectory : undefined,
-    transitEncryption:
-      output.transitEncryption !== undefined && output.transitEncryption !== null
-        ? output.transitEncryption
-        : undefined,
-    transitEncryptionPort:
-      output.transitEncryptionPort !== undefined && output.transitEncryptionPort !== null
-        ? output.transitEncryptionPort
-        : undefined,
+    fileSystemId: __expectString(output.fileSystemId),
+    rootDirectory: __expectString(output.rootDirectory),
+    transitEncryption: __expectString(output.transitEncryption),
+    transitEncryptionPort: __expectNumber(output.transitEncryptionPort),
   } as any;
 };
 
 const deserializeAws_json1_1EnvironmentFile = (output: any, context: __SerdeContext): EnvironmentFile => {
   return {
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    type: __expectString(output.type),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -8922,7 +8841,7 @@ const deserializeAws_json1_1EnvironmentVariables = (output: any, context: __Serd
 
 const deserializeAws_json1_1EphemeralStorage = (output: any, context: __SerdeContext): EphemeralStorage => {
   return {
-    sizeInGiB: output.sizeInGiB !== undefined && output.sizeInGiB !== null ? output.sizeInGiB : undefined,
+    sizeInGiB: __expectNumber(output.sizeInGiB),
   } as any;
 };
 
@@ -8931,12 +8850,12 @@ const deserializeAws_json1_1ExecuteCommandConfiguration = (
   context: __SerdeContext
 ): ExecuteCommandConfiguration => {
   return {
-    kmsKeyId: output.kmsKeyId !== undefined && output.kmsKeyId !== null ? output.kmsKeyId : undefined,
+    kmsKeyId: __expectString(output.kmsKeyId),
     logConfiguration:
       output.logConfiguration !== undefined && output.logConfiguration !== null
         ? deserializeAws_json1_1ExecuteCommandLogConfiguration(output.logConfiguration, context)
         : undefined,
-    logging: output.logging !== undefined && output.logging !== null ? output.logging : undefined,
+    logging: __expectString(output.logging),
   } as any;
 };
 
@@ -8945,43 +8864,33 @@ const deserializeAws_json1_1ExecuteCommandLogConfiguration = (
   context: __SerdeContext
 ): ExecuteCommandLogConfiguration => {
   return {
-    cloudWatchEncryptionEnabled:
-      output.cloudWatchEncryptionEnabled !== undefined && output.cloudWatchEncryptionEnabled !== null
-        ? output.cloudWatchEncryptionEnabled
-        : undefined,
-    cloudWatchLogGroupName:
-      output.cloudWatchLogGroupName !== undefined && output.cloudWatchLogGroupName !== null
-        ? output.cloudWatchLogGroupName
-        : undefined,
-    s3BucketName: output.s3BucketName !== undefined && output.s3BucketName !== null ? output.s3BucketName : undefined,
-    s3EncryptionEnabled:
-      output.s3EncryptionEnabled !== undefined && output.s3EncryptionEnabled !== null
-        ? output.s3EncryptionEnabled
-        : undefined,
-    s3KeyPrefix: output.s3KeyPrefix !== undefined && output.s3KeyPrefix !== null ? output.s3KeyPrefix : undefined,
+    cloudWatchEncryptionEnabled: __expectBoolean(output.cloudWatchEncryptionEnabled),
+    cloudWatchLogGroupName: __expectString(output.cloudWatchLogGroupName),
+    s3BucketName: __expectString(output.s3BucketName),
+    s3EncryptionEnabled: __expectBoolean(output.s3EncryptionEnabled),
+    s3KeyPrefix: __expectString(output.s3KeyPrefix),
   } as any;
 };
 
 const deserializeAws_json1_1ExecuteCommandResponse = (output: any, context: __SerdeContext): ExecuteCommandResponse => {
   return {
-    clusterArn: output.clusterArn !== undefined && output.clusterArn !== null ? output.clusterArn : undefined,
-    containerArn: output.containerArn !== undefined && output.containerArn !== null ? output.containerArn : undefined,
-    containerName:
-      output.containerName !== undefined && output.containerName !== null ? output.containerName : undefined,
-    interactive: output.interactive !== undefined && output.interactive !== null ? output.interactive : undefined,
+    clusterArn: __expectString(output.clusterArn),
+    containerArn: __expectString(output.containerArn),
+    containerName: __expectString(output.containerName),
+    interactive: __expectBoolean(output.interactive),
     session:
       output.session !== undefined && output.session !== null
         ? deserializeAws_json1_1Session(output.session, context)
         : undefined,
-    taskArn: output.taskArn !== undefined && output.taskArn !== null ? output.taskArn : undefined,
+    taskArn: __expectString(output.taskArn),
   } as any;
 };
 
 const deserializeAws_json1_1Failure = (output: any, context: __SerdeContext): Failure => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    detail: output.detail !== undefined && output.detail !== null ? output.detail : undefined,
-    reason: output.reason !== undefined && output.reason !== null ? output.reason : undefined,
+    arn: __expectString(output.arn),
+    detail: __expectString(output.detail),
+    reason: __expectString(output.reason),
   } as any;
 };
 
@@ -9002,7 +8911,7 @@ const deserializeAws_json1_1FirelensConfiguration = (output: any, context: __Ser
       output.options !== undefined && output.options !== null
         ? deserializeAws_json1_1FirelensConfigurationOptionsMap(output.options, context)
         : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -9016,7 +8925,7 @@ const deserializeAws_json1_1FirelensConfigurationOptionsMap = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -9026,11 +8935,8 @@ const deserializeAws_json1_1FSxWindowsFileServerAuthorizationConfig = (
   context: __SerdeContext
 ): FSxWindowsFileServerAuthorizationConfig => {
   return {
-    credentialsParameter:
-      output.credentialsParameter !== undefined && output.credentialsParameter !== null
-        ? output.credentialsParameter
-        : undefined,
-    domain: output.domain !== undefined && output.domain !== null ? output.domain : undefined,
+    credentialsParameter: __expectString(output.credentialsParameter),
+    domain: __expectString(output.domain),
   } as any;
 };
 
@@ -9043,9 +8949,8 @@ const deserializeAws_json1_1FSxWindowsFileServerVolumeConfiguration = (
       output.authorizationConfig !== undefined && output.authorizationConfig !== null
         ? deserializeAws_json1_1FSxWindowsFileServerAuthorizationConfig(output.authorizationConfig, context)
         : undefined,
-    fileSystemId: output.fileSystemId !== undefined && output.fileSystemId !== null ? output.fileSystemId : undefined,
-    rootDirectory:
-      output.rootDirectory !== undefined && output.rootDirectory !== null ? output.rootDirectory : undefined,
+    fileSystemId: __expectString(output.fileSystemId),
+    rootDirectory: __expectString(output.rootDirectory),
   } as any;
 };
 
@@ -9056,7 +8961,7 @@ const deserializeAws_json1_1GpuIds = (output: any, context: __SerdeContext): str
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -9066,17 +8971,17 @@ const deserializeAws_json1_1HealthCheck = (output: any, context: __SerdeContext)
       output.command !== undefined && output.command !== null
         ? deserializeAws_json1_1StringList(output.command, context)
         : undefined,
-    interval: output.interval !== undefined && output.interval !== null ? output.interval : undefined,
-    retries: output.retries !== undefined && output.retries !== null ? output.retries : undefined,
-    startPeriod: output.startPeriod !== undefined && output.startPeriod !== null ? output.startPeriod : undefined,
-    timeout: output.timeout !== undefined && output.timeout !== null ? output.timeout : undefined,
+    interval: __expectNumber(output.interval),
+    retries: __expectNumber(output.retries),
+    startPeriod: __expectNumber(output.startPeriod),
+    timeout: __expectNumber(output.timeout),
   } as any;
 };
 
 const deserializeAws_json1_1HostEntry = (output: any, context: __SerdeContext): HostEntry => {
   return {
-    hostname: output.hostname !== undefined && output.hostname !== null ? output.hostname : undefined,
-    ipAddress: output.ipAddress !== undefined && output.ipAddress !== null ? output.ipAddress : undefined,
+    hostname: __expectString(output.hostname),
+    ipAddress: __expectString(output.ipAddress),
   } as any;
 };
 
@@ -9093,14 +8998,14 @@ const deserializeAws_json1_1HostEntryList = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1HostVolumeProperties = (output: any, context: __SerdeContext): HostVolumeProperties => {
   return {
-    sourcePath: output.sourcePath !== undefined && output.sourcePath !== null ? output.sourcePath : undefined,
+    sourcePath: __expectString(output.sourcePath),
   } as any;
 };
 
 const deserializeAws_json1_1InferenceAccelerator = (output: any, context: __SerdeContext): InferenceAccelerator => {
   return {
-    deviceName: output.deviceName !== undefined && output.deviceName !== null ? output.deviceName : undefined,
-    deviceType: output.deviceType !== undefined && output.deviceType !== null ? output.deviceType : undefined,
+    deviceName: __expectString(output.deviceName),
+    deviceType: __expectString(output.deviceType),
   } as any;
 };
 
@@ -9109,8 +9014,8 @@ const deserializeAws_json1_1InferenceAcceleratorOverride = (
   context: __SerdeContext
 ): InferenceAcceleratorOverride => {
   return {
-    deviceName: output.deviceName !== undefined && output.deviceName !== null ? output.deviceName : undefined,
-    deviceType: output.deviceType !== undefined && output.deviceType !== null ? output.deviceType : undefined,
+    deviceName: __expectString(output.deviceName),
+    deviceType: __expectString(output.deviceType),
   } as any;
 };
 
@@ -9144,7 +9049,7 @@ const deserializeAws_json1_1InvalidParameterException = (
   context: __SerdeContext
 ): InvalidParameterException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9163,14 +9068,14 @@ const deserializeAws_json1_1KernelCapabilities = (output: any, context: __SerdeC
 
 const deserializeAws_json1_1KeyValuePair = (output: any, context: __SerdeContext): KeyValuePair => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    name: __expectString(output.name),
+    value: __expectString(output.value),
   } as any;
 };
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9184,14 +9089,10 @@ const deserializeAws_json1_1LinuxParameters = (output: any, context: __SerdeCont
       output.devices !== undefined && output.devices !== null
         ? deserializeAws_json1_1DevicesList(output.devices, context)
         : undefined,
-    initProcessEnabled:
-      output.initProcessEnabled !== undefined && output.initProcessEnabled !== null
-        ? output.initProcessEnabled
-        : undefined,
-    maxSwap: output.maxSwap !== undefined && output.maxSwap !== null ? output.maxSwap : undefined,
-    sharedMemorySize:
-      output.sharedMemorySize !== undefined && output.sharedMemorySize !== null ? output.sharedMemorySize : undefined,
-    swappiness: output.swappiness !== undefined && output.swappiness !== null ? output.swappiness : undefined,
+    initProcessEnabled: __expectBoolean(output.initProcessEnabled),
+    maxSwap: __expectNumber(output.maxSwap),
+    sharedMemorySize: __expectNumber(output.sharedMemorySize),
+    swappiness: __expectNumber(output.swappiness),
     tmpfs:
       output.tmpfs !== undefined && output.tmpfs !== null
         ? deserializeAws_json1_1TmpfsList(output.tmpfs, context)
@@ -9204,7 +9105,7 @@ const deserializeAws_json1_1ListAccountSettingsResponse = (
   context: __SerdeContext
 ): ListAccountSettingsResponse => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     settings:
       output.settings !== undefined && output.settings !== null
         ? deserializeAws_json1_1Settings(output.settings, context)
@@ -9218,7 +9119,7 @@ const deserializeAws_json1_1ListAttributesResponse = (output: any, context: __Se
       output.attributes !== undefined && output.attributes !== null
         ? deserializeAws_json1_1Attributes(output.attributes, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -9228,7 +9129,7 @@ const deserializeAws_json1_1ListClustersResponse = (output: any, context: __Serd
       output.clusterArns !== undefined && output.clusterArns !== null
         ? deserializeAws_json1_1StringList(output.clusterArns, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -9241,13 +9142,13 @@ const deserializeAws_json1_1ListContainerInstancesResponse = (
       output.containerInstanceArns !== undefined && output.containerInstanceArns !== null
         ? deserializeAws_json1_1StringList(output.containerInstanceArns, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
 const deserializeAws_json1_1ListServicesResponse = (output: any, context: __SerdeContext): ListServicesResponse => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     serviceArns:
       output.serviceArns !== undefined && output.serviceArns !== null
         ? deserializeAws_json1_1StringList(output.serviceArns, context)
@@ -9274,7 +9175,7 @@ const deserializeAws_json1_1ListTaskDefinitionFamiliesResponse = (
       output.families !== undefined && output.families !== null
         ? deserializeAws_json1_1StringList(output.families, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -9283,7 +9184,7 @@ const deserializeAws_json1_1ListTaskDefinitionsResponse = (
   context: __SerdeContext
 ): ListTaskDefinitionsResponse => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     taskDefinitionArns:
       output.taskDefinitionArns !== undefined && output.taskDefinitionArns !== null
         ? deserializeAws_json1_1StringList(output.taskDefinitionArns, context)
@@ -9293,7 +9194,7 @@ const deserializeAws_json1_1ListTaskDefinitionsResponse = (
 
 const deserializeAws_json1_1ListTasksResponse = (output: any, context: __SerdeContext): ListTasksResponse => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     taskArns:
       output.taskArns !== undefined && output.taskArns !== null
         ? deserializeAws_json1_1StringList(output.taskArns, context)
@@ -9303,14 +9204,10 @@ const deserializeAws_json1_1ListTasksResponse = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1LoadBalancer = (output: any, context: __SerdeContext): LoadBalancer => {
   return {
-    containerName:
-      output.containerName !== undefined && output.containerName !== null ? output.containerName : undefined,
-    containerPort:
-      output.containerPort !== undefined && output.containerPort !== null ? output.containerPort : undefined,
-    loadBalancerName:
-      output.loadBalancerName !== undefined && output.loadBalancerName !== null ? output.loadBalancerName : undefined,
-    targetGroupArn:
-      output.targetGroupArn !== undefined && output.targetGroupArn !== null ? output.targetGroupArn : undefined,
+    containerName: __expectString(output.containerName),
+    containerPort: __expectNumber(output.containerPort),
+    loadBalancerName: __expectString(output.loadBalancerName),
+    targetGroupArn: __expectString(output.targetGroupArn),
   } as any;
 };
 
@@ -9327,7 +9224,7 @@ const deserializeAws_json1_1LoadBalancers = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1LogConfiguration = (output: any, context: __SerdeContext): LogConfiguration => {
   return {
-    logDriver: output.logDriver !== undefined && output.logDriver !== null ? output.logDriver : undefined,
+    logDriver: __expectString(output.logDriver),
     options:
       output.options !== undefined && output.options !== null
         ? deserializeAws_json1_1LogConfigurationOptionsMap(output.options, context)
@@ -9349,7 +9246,7 @@ const deserializeAws_json1_1LogConfigurationOptionsMap = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -9360,9 +9257,9 @@ const deserializeAws_json1_1ManagedAgent = (output: any, context: __SerdeContext
       output.lastStartedAt !== undefined && output.lastStartedAt !== null
         ? new Date(Math.round(output.lastStartedAt * 1000))
         : undefined,
-    lastStatus: output.lastStatus !== undefined && output.lastStatus !== null ? output.lastStatus : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    reason: output.reason !== undefined && output.reason !== null ? output.reason : undefined,
+    lastStatus: __expectString(output.lastStatus),
+    name: __expectString(output.name),
+    reason: __expectString(output.reason),
   } as any;
 };
 
@@ -9379,21 +9276,11 @@ const deserializeAws_json1_1ManagedAgents = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1ManagedScaling = (output: any, context: __SerdeContext): ManagedScaling => {
   return {
-    instanceWarmupPeriod:
-      output.instanceWarmupPeriod !== undefined && output.instanceWarmupPeriod !== null
-        ? output.instanceWarmupPeriod
-        : undefined,
-    maximumScalingStepSize:
-      output.maximumScalingStepSize !== undefined && output.maximumScalingStepSize !== null
-        ? output.maximumScalingStepSize
-        : undefined,
-    minimumScalingStepSize:
-      output.minimumScalingStepSize !== undefined && output.minimumScalingStepSize !== null
-        ? output.minimumScalingStepSize
-        : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    targetCapacity:
-      output.targetCapacity !== undefined && output.targetCapacity !== null ? output.targetCapacity : undefined,
+    instanceWarmupPeriod: __expectNumber(output.instanceWarmupPeriod),
+    maximumScalingStepSize: __expectNumber(output.maximumScalingStepSize),
+    minimumScalingStepSize: __expectNumber(output.minimumScalingStepSize),
+    status: __expectString(output.status),
+    targetCapacity: __expectNumber(output.targetCapacity),
   } as any;
 };
 
@@ -9402,16 +9289,15 @@ const deserializeAws_json1_1MissingVersionException = (
   context: __SerdeContext
 ): MissingVersionException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1MountPoint = (output: any, context: __SerdeContext): MountPoint => {
   return {
-    containerPath:
-      output.containerPath !== undefined && output.containerPath !== null ? output.containerPath : undefined,
-    readOnly: output.readOnly !== undefined && output.readOnly !== null ? output.readOnly : undefined,
-    sourceVolume: output.sourceVolume !== undefined && output.sourceVolume !== null ? output.sourceVolume : undefined,
+    containerPath: __expectString(output.containerPath),
+    readOnly: __expectBoolean(output.readOnly),
+    sourceVolume: __expectString(output.sourceVolume),
   } as any;
 };
 
@@ -9428,11 +9314,10 @@ const deserializeAws_json1_1MountPointList = (output: any, context: __SerdeConte
 
 const deserializeAws_json1_1NetworkBinding = (output: any, context: __SerdeContext): NetworkBinding => {
   return {
-    bindIP: output.bindIP !== undefined && output.bindIP !== null ? output.bindIP : undefined,
-    containerPort:
-      output.containerPort !== undefined && output.containerPort !== null ? output.containerPort : undefined,
-    hostPort: output.hostPort !== undefined && output.hostPort !== null ? output.hostPort : undefined,
-    protocol: output.protocol !== undefined && output.protocol !== null ? output.protocol : undefined,
+    bindIP: __expectString(output.bindIP),
+    containerPort: __expectNumber(output.containerPort),
+    hostPort: __expectNumber(output.hostPort),
+    protocol: __expectString(output.protocol),
   } as any;
 };
 
@@ -9458,12 +9343,9 @@ const deserializeAws_json1_1NetworkConfiguration = (output: any, context: __Serd
 
 const deserializeAws_json1_1NetworkInterface = (output: any, context: __SerdeContext): NetworkInterface => {
   return {
-    attachmentId: output.attachmentId !== undefined && output.attachmentId !== null ? output.attachmentId : undefined,
-    ipv6Address: output.ipv6Address !== undefined && output.ipv6Address !== null ? output.ipv6Address : undefined,
-    privateIpv4Address:
-      output.privateIpv4Address !== undefined && output.privateIpv4Address !== null
-        ? output.privateIpv4Address
-        : undefined,
+    attachmentId: __expectString(output.attachmentId),
+    ipv6Address: __expectString(output.ipv6Address),
+    privateIpv4Address: __expectString(output.privateIpv4Address),
   } as any;
 };
 
@@ -9483,14 +9365,14 @@ const deserializeAws_json1_1NoUpdateAvailableException = (
   context: __SerdeContext
 ): NoUpdateAvailableException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1PlacementConstraint = (output: any, context: __SerdeContext): PlacementConstraint => {
   return {
-    expression: output.expression !== undefined && output.expression !== null ? output.expression : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    expression: __expectString(output.expression),
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -9518,8 +9400,8 @@ const deserializeAws_json1_1PlacementStrategies = (output: any, context: __Serde
 
 const deserializeAws_json1_1PlacementStrategy = (output: any, context: __SerdeContext): PlacementStrategy => {
   return {
-    field: output.field !== undefined && output.field !== null ? output.field : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    field: __expectString(output.field),
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -9528,7 +9410,7 @@ const deserializeAws_json1_1PlatformTaskDefinitionIncompatibilityException = (
   context: __SerdeContext
 ): PlatformTaskDefinitionIncompatibilityException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9537,16 +9419,15 @@ const deserializeAws_json1_1PlatformUnknownException = (
   context: __SerdeContext
 ): PlatformUnknownException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1PortMapping = (output: any, context: __SerdeContext): PortMapping => {
   return {
-    containerPort:
-      output.containerPort !== undefined && output.containerPort !== null ? output.containerPort : undefined,
-    hostPort: output.hostPort !== undefined && output.hostPort !== null ? output.hostPort : undefined,
-    protocol: output.protocol !== undefined && output.protocol !== null ? output.protocol : undefined,
+    containerPort: __expectNumber(output.containerPort),
+    hostPort: __expectNumber(output.hostPort),
+    protocol: __expectString(output.protocol),
   } as any;
 };
 
@@ -9563,13 +9444,12 @@ const deserializeAws_json1_1PortMappingList = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_1ProxyConfiguration = (output: any, context: __SerdeContext): ProxyConfiguration => {
   return {
-    containerName:
-      output.containerName !== undefined && output.containerName !== null ? output.containerName : undefined,
+    containerName: __expectString(output.containerName),
     properties:
       output.properties !== undefined && output.properties !== null
         ? deserializeAws_json1_1ProxyConfigurationProperties(output.properties, context)
         : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -9657,10 +9537,7 @@ const deserializeAws_json1_1RegisterTaskDefinitionResponse = (
 
 const deserializeAws_json1_1RepositoryCredentials = (output: any, context: __SerdeContext): RepositoryCredentials => {
   return {
-    credentialsParameter:
-      output.credentialsParameter !== undefined && output.credentialsParameter !== null
-        ? output.credentialsParameter
-        : undefined,
+    credentialsParameter: __expectString(output.credentialsParameter),
   } as any;
 };
 
@@ -9677,21 +9554,21 @@ const deserializeAws_json1_1RequiresAttributes = (output: any, context: __SerdeC
 
 const deserializeAws_json1_1Resource = (output: any, context: __SerdeContext): Resource => {
   return {
-    doubleValue: output.doubleValue !== undefined && output.doubleValue !== null ? output.doubleValue : undefined,
-    integerValue: output.integerValue !== undefined && output.integerValue !== null ? output.integerValue : undefined,
-    longValue: output.longValue !== undefined && output.longValue !== null ? output.longValue : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    doubleValue: __expectNumber(output.doubleValue),
+    integerValue: __expectNumber(output.integerValue),
+    longValue: __expectNumber(output.longValue),
+    name: __expectString(output.name),
     stringSetValue:
       output.stringSetValue !== undefined && output.stringSetValue !== null
         ? deserializeAws_json1_1StringList(output.stringSetValue, context)
         : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    type: __expectString(output.type),
   } as any;
 };
 
 const deserializeAws_json1_1ResourceInUseException = (output: any, context: __SerdeContext): ResourceInUseException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9700,14 +9577,14 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1ResourceRequirement = (output: any, context: __SerdeContext): ResourceRequirement => {
   return {
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    type: __expectString(output.type),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -9748,15 +9625,15 @@ const deserializeAws_json1_1RunTaskResponse = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_1Scale = (output: any, context: __SerdeContext): Scale => {
   return {
-    unit: output.unit !== undefined && output.unit !== null ? output.unit : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    unit: __expectString(output.unit),
+    value: __expectNumber(output.value),
   } as any;
 };
 
 const deserializeAws_json1_1Secret = (output: any, context: __SerdeContext): Secret => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    valueFrom: output.valueFrom !== undefined && output.valueFrom !== null ? output.valueFrom : undefined,
+    name: __expectString(output.name),
+    valueFrom: __expectString(output.valueFrom),
   } as any;
 };
 
@@ -9773,7 +9650,7 @@ const deserializeAws_json1_1SecretList = (output: any, context: __SerdeContext):
 
 const deserializeAws_json1_1ServerException = (output: any, context: __SerdeContext): ServerException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9783,12 +9660,12 @@ const deserializeAws_json1_1Service = (output: any, context: __SerdeContext): Se
       output.capacityProviderStrategy !== undefined && output.capacityProviderStrategy !== null
         ? deserializeAws_json1_1CapacityProviderStrategy(output.capacityProviderStrategy, context)
         : undefined,
-    clusterArn: output.clusterArn !== undefined && output.clusterArn !== null ? output.clusterArn : undefined,
+    clusterArn: __expectString(output.clusterArn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    createdBy: output.createdBy !== undefined && output.createdBy !== null ? output.createdBy : undefined,
+    createdBy: __expectString(output.createdBy),
     deploymentConfiguration:
       output.deploymentConfiguration !== undefined && output.deploymentConfiguration !== null
         ? deserializeAws_json1_1DeploymentConfiguration(output.deploymentConfiguration, context)
@@ -9801,24 +9678,15 @@ const deserializeAws_json1_1Service = (output: any, context: __SerdeContext): Se
       output.deployments !== undefined && output.deployments !== null
         ? deserializeAws_json1_1Deployments(output.deployments, context)
         : undefined,
-    desiredCount: output.desiredCount !== undefined && output.desiredCount !== null ? output.desiredCount : undefined,
-    enableECSManagedTags:
-      output.enableECSManagedTags !== undefined && output.enableECSManagedTags !== null
-        ? output.enableECSManagedTags
-        : undefined,
-    enableExecuteCommand:
-      output.enableExecuteCommand !== undefined && output.enableExecuteCommand !== null
-        ? output.enableExecuteCommand
-        : undefined,
+    desiredCount: __expectNumber(output.desiredCount),
+    enableECSManagedTags: __expectBoolean(output.enableECSManagedTags),
+    enableExecuteCommand: __expectBoolean(output.enableExecuteCommand),
     events:
       output.events !== undefined && output.events !== null
         ? deserializeAws_json1_1ServiceEvents(output.events, context)
         : undefined,
-    healthCheckGracePeriodSeconds:
-      output.healthCheckGracePeriodSeconds !== undefined && output.healthCheckGracePeriodSeconds !== null
-        ? output.healthCheckGracePeriodSeconds
-        : undefined,
-    launchType: output.launchType !== undefined && output.launchType !== null ? output.launchType : undefined,
+    healthCheckGracePeriodSeconds: __expectNumber(output.healthCheckGracePeriodSeconds),
+    launchType: __expectString(output.launchType),
     loadBalancers:
       output.loadBalancers !== undefined && output.loadBalancers !== null
         ? deserializeAws_json1_1LoadBalancers(output.loadBalancers, context)
@@ -9827,7 +9695,7 @@ const deserializeAws_json1_1Service = (output: any, context: __SerdeContext): Se
       output.networkConfiguration !== undefined && output.networkConfiguration !== null
         ? deserializeAws_json1_1NetworkConfiguration(output.networkConfiguration, context)
         : undefined,
-    pendingCount: output.pendingCount !== undefined && output.pendingCount !== null ? output.pendingCount : undefined,
+    pendingCount: __expectNumber(output.pendingCount),
     placementConstraints:
       output.placementConstraints !== undefined && output.placementConstraints !== null
         ? deserializeAws_json1_1PlacementConstraints(output.placementConstraints, context)
@@ -9836,27 +9704,21 @@ const deserializeAws_json1_1Service = (output: any, context: __SerdeContext): Se
       output.placementStrategy !== undefined && output.placementStrategy !== null
         ? deserializeAws_json1_1PlacementStrategies(output.placementStrategy, context)
         : undefined,
-    platformVersion:
-      output.platformVersion !== undefined && output.platformVersion !== null ? output.platformVersion : undefined,
-    propagateTags:
-      output.propagateTags !== undefined && output.propagateTags !== null ? output.propagateTags : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
-    runningCount: output.runningCount !== undefined && output.runningCount !== null ? output.runningCount : undefined,
-    schedulingStrategy:
-      output.schedulingStrategy !== undefined && output.schedulingStrategy !== null
-        ? output.schedulingStrategy
-        : undefined,
-    serviceArn: output.serviceArn !== undefined && output.serviceArn !== null ? output.serviceArn : undefined,
-    serviceName: output.serviceName !== undefined && output.serviceName !== null ? output.serviceName : undefined,
+    platformVersion: __expectString(output.platformVersion),
+    propagateTags: __expectString(output.propagateTags),
+    roleArn: __expectString(output.roleArn),
+    runningCount: __expectNumber(output.runningCount),
+    schedulingStrategy: __expectString(output.schedulingStrategy),
+    serviceArn: __expectString(output.serviceArn),
+    serviceName: __expectString(output.serviceName),
     serviceRegistries:
       output.serviceRegistries !== undefined && output.serviceRegistries !== null
         ? deserializeAws_json1_1ServiceRegistries(output.serviceRegistries, context)
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
     tags:
       output.tags !== undefined && output.tags !== null ? deserializeAws_json1_1Tags(output.tags, context) : undefined,
-    taskDefinition:
-      output.taskDefinition !== undefined && output.taskDefinition !== null ? output.taskDefinition : undefined,
+    taskDefinition: __expectString(output.taskDefinition),
     taskSets:
       output.taskSets !== undefined && output.taskSets !== null
         ? deserializeAws_json1_1TaskSets(output.taskSets, context)
@@ -9870,8 +9732,8 @@ const deserializeAws_json1_1ServiceEvent = (output: any, context: __SerdeContext
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    id: __expectString(output.id),
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9891,7 +9753,7 @@ const deserializeAws_json1_1ServiceNotActiveException = (
   context: __SerdeContext
 ): ServiceNotActiveException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9900,7 +9762,7 @@ const deserializeAws_json1_1ServiceNotFoundException = (
   context: __SerdeContext
 ): ServiceNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9917,12 +9779,10 @@ const deserializeAws_json1_1ServiceRegistries = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1ServiceRegistry = (output: any, context: __SerdeContext): ServiceRegistry => {
   return {
-    containerName:
-      output.containerName !== undefined && output.containerName !== null ? output.containerName : undefined,
-    containerPort:
-      output.containerPort !== undefined && output.containerPort !== null ? output.containerPort : undefined,
-    port: output.port !== undefined && output.port !== null ? output.port : undefined,
-    registryArn: output.registryArn !== undefined && output.registryArn !== null ? output.registryArn : undefined,
+    containerName: __expectString(output.containerName),
+    containerPort: __expectNumber(output.containerPort),
+    port: __expectNumber(output.port),
+    registryArn: __expectString(output.registryArn),
   } as any;
 };
 
@@ -9939,17 +9799,17 @@ const deserializeAws_json1_1Services = (output: any, context: __SerdeContext): S
 
 const deserializeAws_json1_1Session = (output: any, context: __SerdeContext): Session => {
   return {
-    sessionId: output.sessionId !== undefined && output.sessionId !== null ? output.sessionId : undefined,
-    streamUrl: output.streamUrl !== undefined && output.streamUrl !== null ? output.streamUrl : undefined,
-    tokenValue: output.tokenValue !== undefined && output.tokenValue !== null ? output.tokenValue : undefined,
+    sessionId: __expectString(output.sessionId),
+    streamUrl: __expectString(output.streamUrl),
+    tokenValue: __expectString(output.tokenValue),
   } as any;
 };
 
 const deserializeAws_json1_1Setting = (output: any, context: __SerdeContext): Setting => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    principalArn: output.principalArn !== undefined && output.principalArn !== null ? output.principalArn : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    name: __expectString(output.name),
+    principalArn: __expectString(output.principalArn),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -10002,7 +9862,7 @@ const deserializeAws_json1_1StringList = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -10013,7 +9873,7 @@ const deserializeAws_json1_1StringMap = (output: any, context: __SerdeContext): 
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -10023,8 +9883,7 @@ const deserializeAws_json1_1SubmitAttachmentStateChangesResponse = (
   context: __SerdeContext
 ): SubmitAttachmentStateChangesResponse => {
   return {
-    acknowledgment:
-      output.acknowledgment !== undefined && output.acknowledgment !== null ? output.acknowledgment : undefined,
+    acknowledgment: __expectString(output.acknowledgment),
   } as any;
 };
 
@@ -10033,8 +9892,7 @@ const deserializeAws_json1_1SubmitContainerStateChangeResponse = (
   context: __SerdeContext
 ): SubmitContainerStateChangeResponse => {
   return {
-    acknowledgment:
-      output.acknowledgment !== undefined && output.acknowledgment !== null ? output.acknowledgment : undefined,
+    acknowledgment: __expectString(output.acknowledgment),
   } as any;
 };
 
@@ -10043,15 +9901,14 @@ const deserializeAws_json1_1SubmitTaskStateChangeResponse = (
   context: __SerdeContext
 ): SubmitTaskStateChangeResponse => {
   return {
-    acknowledgment:
-      output.acknowledgment !== undefined && output.acknowledgment !== null ? output.acknowledgment : undefined,
+    acknowledgment: __expectString(output.acknowledgment),
   } as any;
 };
 
 const deserializeAws_json1_1SystemControl = (output: any, context: __SerdeContext): SystemControl => {
   return {
-    namespace: output.namespace !== undefined && output.namespace !== null ? output.namespace : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    namespace: __expectString(output.namespace),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -10068,8 +9925,8 @@ const deserializeAws_json1_1SystemControls = (output: any, context: __SerdeConte
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    key: __expectString(output.key),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -10093,7 +9950,7 @@ const deserializeAws_json1_1TargetNotConnectedException = (
   context: __SerdeContext
 ): TargetNotConnectedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10102,7 +9959,7 @@ const deserializeAws_json1_1TargetNotFoundException = (
   context: __SerdeContext
 ): TargetNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10116,37 +9973,26 @@ const deserializeAws_json1_1Task = (output: any, context: __SerdeContext): Task 
       output.attributes !== undefined && output.attributes !== null
         ? deserializeAws_json1_1Attributes(output.attributes, context)
         : undefined,
-    availabilityZone:
-      output.availabilityZone !== undefined && output.availabilityZone !== null ? output.availabilityZone : undefined,
-    capacityProviderName:
-      output.capacityProviderName !== undefined && output.capacityProviderName !== null
-        ? output.capacityProviderName
-        : undefined,
-    clusterArn: output.clusterArn !== undefined && output.clusterArn !== null ? output.clusterArn : undefined,
-    connectivity: output.connectivity !== undefined && output.connectivity !== null ? output.connectivity : undefined,
+    availabilityZone: __expectString(output.availabilityZone),
+    capacityProviderName: __expectString(output.capacityProviderName),
+    clusterArn: __expectString(output.clusterArn),
+    connectivity: __expectString(output.connectivity),
     connectivityAt:
       output.connectivityAt !== undefined && output.connectivityAt !== null
         ? new Date(Math.round(output.connectivityAt * 1000))
         : undefined,
-    containerInstanceArn:
-      output.containerInstanceArn !== undefined && output.containerInstanceArn !== null
-        ? output.containerInstanceArn
-        : undefined,
+    containerInstanceArn: __expectString(output.containerInstanceArn),
     containers:
       output.containers !== undefined && output.containers !== null
         ? deserializeAws_json1_1Containers(output.containers, context)
         : undefined,
-    cpu: output.cpu !== undefined && output.cpu !== null ? output.cpu : undefined,
+    cpu: __expectString(output.cpu),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    desiredStatus:
-      output.desiredStatus !== undefined && output.desiredStatus !== null ? output.desiredStatus : undefined,
-    enableExecuteCommand:
-      output.enableExecuteCommand !== undefined && output.enableExecuteCommand !== null
-        ? output.enableExecuteCommand
-        : undefined,
+    desiredStatus: __expectString(output.desiredStatus),
+    enableExecuteCommand: __expectBoolean(output.enableExecuteCommand),
     ephemeralStorage:
       output.ephemeralStorage !== undefined && output.ephemeralStorage !== null
         ? deserializeAws_json1_1EphemeralStorage(output.ephemeralStorage, context)
@@ -10155,21 +10001,20 @@ const deserializeAws_json1_1Task = (output: any, context: __SerdeContext): Task 
       output.executionStoppedAt !== undefined && output.executionStoppedAt !== null
         ? new Date(Math.round(output.executionStoppedAt * 1000))
         : undefined,
-    group: output.group !== undefined && output.group !== null ? output.group : undefined,
-    healthStatus: output.healthStatus !== undefined && output.healthStatus !== null ? output.healthStatus : undefined,
+    group: __expectString(output.group),
+    healthStatus: __expectString(output.healthStatus),
     inferenceAccelerators:
       output.inferenceAccelerators !== undefined && output.inferenceAccelerators !== null
         ? deserializeAws_json1_1InferenceAccelerators(output.inferenceAccelerators, context)
         : undefined,
-    lastStatus: output.lastStatus !== undefined && output.lastStatus !== null ? output.lastStatus : undefined,
-    launchType: output.launchType !== undefined && output.launchType !== null ? output.launchType : undefined,
-    memory: output.memory !== undefined && output.memory !== null ? output.memory : undefined,
+    lastStatus: __expectString(output.lastStatus),
+    launchType: __expectString(output.launchType),
+    memory: __expectString(output.memory),
     overrides:
       output.overrides !== undefined && output.overrides !== null
         ? deserializeAws_json1_1TaskOverride(output.overrides, context)
         : undefined,
-    platformVersion:
-      output.platformVersion !== undefined && output.platformVersion !== null ? output.platformVersion : undefined,
+    platformVersion: __expectString(output.platformVersion),
     pullStartedAt:
       output.pullStartedAt !== undefined && output.pullStartedAt !== null
         ? new Date(Math.round(output.pullStartedAt * 1000))
@@ -10182,26 +10027,22 @@ const deserializeAws_json1_1Task = (output: any, context: __SerdeContext): Task 
       output.startedAt !== undefined && output.startedAt !== null
         ? new Date(Math.round(output.startedAt * 1000))
         : undefined,
-    startedBy: output.startedBy !== undefined && output.startedBy !== null ? output.startedBy : undefined,
-    stopCode: output.stopCode !== undefined && output.stopCode !== null ? output.stopCode : undefined,
+    startedBy: __expectString(output.startedBy),
+    stopCode: __expectString(output.stopCode),
     stoppedAt:
       output.stoppedAt !== undefined && output.stoppedAt !== null
         ? new Date(Math.round(output.stoppedAt * 1000))
         : undefined,
-    stoppedReason:
-      output.stoppedReason !== undefined && output.stoppedReason !== null ? output.stoppedReason : undefined,
+    stoppedReason: __expectString(output.stoppedReason),
     stoppingAt:
       output.stoppingAt !== undefined && output.stoppingAt !== null
         ? new Date(Math.round(output.stoppingAt * 1000))
         : undefined,
     tags:
       output.tags !== undefined && output.tags !== null ? deserializeAws_json1_1Tags(output.tags, context) : undefined,
-    taskArn: output.taskArn !== undefined && output.taskArn !== null ? output.taskArn : undefined,
-    taskDefinitionArn:
-      output.taskDefinitionArn !== undefined && output.taskDefinitionArn !== null
-        ? output.taskDefinitionArn
-        : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    taskArn: __expectString(output.taskArn),
+    taskDefinitionArn: __expectString(output.taskDefinitionArn),
+    version: __expectNumber(output.version),
   } as any;
 };
 
@@ -10215,7 +10056,7 @@ const deserializeAws_json1_1TaskDefinition = (output: any, context: __SerdeConte
       output.containerDefinitions !== undefined && output.containerDefinitions !== null
         ? deserializeAws_json1_1ContainerDefinitions(output.containerDefinitions, context)
         : undefined,
-    cpu: output.cpu !== undefined && output.cpu !== null ? output.cpu : undefined,
+    cpu: __expectString(output.cpu),
     deregisteredAt:
       output.deregisteredAt !== undefined && output.deregisteredAt !== null
         ? new Date(Math.round(output.deregisteredAt * 1000))
@@ -10224,17 +10065,16 @@ const deserializeAws_json1_1TaskDefinition = (output: any, context: __SerdeConte
       output.ephemeralStorage !== undefined && output.ephemeralStorage !== null
         ? deserializeAws_json1_1EphemeralStorage(output.ephemeralStorage, context)
         : undefined,
-    executionRoleArn:
-      output.executionRoleArn !== undefined && output.executionRoleArn !== null ? output.executionRoleArn : undefined,
-    family: output.family !== undefined && output.family !== null ? output.family : undefined,
+    executionRoleArn: __expectString(output.executionRoleArn),
+    family: __expectString(output.family),
     inferenceAccelerators:
       output.inferenceAccelerators !== undefined && output.inferenceAccelerators !== null
         ? deserializeAws_json1_1InferenceAccelerators(output.inferenceAccelerators, context)
         : undefined,
-    ipcMode: output.ipcMode !== undefined && output.ipcMode !== null ? output.ipcMode : undefined,
-    memory: output.memory !== undefined && output.memory !== null ? output.memory : undefined,
-    networkMode: output.networkMode !== undefined && output.networkMode !== null ? output.networkMode : undefined,
-    pidMode: output.pidMode !== undefined && output.pidMode !== null ? output.pidMode : undefined,
+    ipcMode: __expectString(output.ipcMode),
+    memory: __expectString(output.memory),
+    networkMode: __expectString(output.networkMode),
+    pidMode: __expectString(output.pidMode),
     placementConstraints:
       output.placementConstraints !== undefined && output.placementConstraints !== null
         ? deserializeAws_json1_1TaskDefinitionPlacementConstraints(output.placementConstraints, context)
@@ -10247,7 +10087,7 @@ const deserializeAws_json1_1TaskDefinition = (output: any, context: __SerdeConte
       output.registeredAt !== undefined && output.registeredAt !== null
         ? new Date(Math.round(output.registeredAt * 1000))
         : undefined,
-    registeredBy: output.registeredBy !== undefined && output.registeredBy !== null ? output.registeredBy : undefined,
+    registeredBy: __expectString(output.registeredBy),
     requiresAttributes:
       output.requiresAttributes !== undefined && output.requiresAttributes !== null
         ? deserializeAws_json1_1RequiresAttributes(output.requiresAttributes, context)
@@ -10256,13 +10096,10 @@ const deserializeAws_json1_1TaskDefinition = (output: any, context: __SerdeConte
       output.requiresCompatibilities !== undefined && output.requiresCompatibilities !== null
         ? deserializeAws_json1_1CompatibilityList(output.requiresCompatibilities, context)
         : undefined,
-    revision: output.revision !== undefined && output.revision !== null ? output.revision : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    taskDefinitionArn:
-      output.taskDefinitionArn !== undefined && output.taskDefinitionArn !== null
-        ? output.taskDefinitionArn
-        : undefined,
-    taskRoleArn: output.taskRoleArn !== undefined && output.taskRoleArn !== null ? output.taskRoleArn : undefined,
+    revision: __expectNumber(output.revision),
+    status: __expectString(output.status),
+    taskDefinitionArn: __expectString(output.taskDefinitionArn),
+    taskRoleArn: __expectString(output.taskRoleArn),
     volumes:
       output.volumes !== undefined && output.volumes !== null
         ? deserializeAws_json1_1VolumeList(output.volumes, context)
@@ -10275,8 +10112,8 @@ const deserializeAws_json1_1TaskDefinitionPlacementConstraint = (
   context: __SerdeContext
 ): TaskDefinitionPlacementConstraint => {
   return {
-    expression: output.expression !== undefined && output.expression !== null ? output.expression : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    expression: __expectString(output.expression),
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -10300,19 +10137,18 @@ const deserializeAws_json1_1TaskOverride = (output: any, context: __SerdeContext
       output.containerOverrides !== undefined && output.containerOverrides !== null
         ? deserializeAws_json1_1ContainerOverrides(output.containerOverrides, context)
         : undefined,
-    cpu: output.cpu !== undefined && output.cpu !== null ? output.cpu : undefined,
+    cpu: __expectString(output.cpu),
     ephemeralStorage:
       output.ephemeralStorage !== undefined && output.ephemeralStorage !== null
         ? deserializeAws_json1_1EphemeralStorage(output.ephemeralStorage, context)
         : undefined,
-    executionRoleArn:
-      output.executionRoleArn !== undefined && output.executionRoleArn !== null ? output.executionRoleArn : undefined,
+    executionRoleArn: __expectString(output.executionRoleArn),
     inferenceAcceleratorOverrides:
       output.inferenceAcceleratorOverrides !== undefined && output.inferenceAcceleratorOverrides !== null
         ? deserializeAws_json1_1InferenceAcceleratorOverrides(output.inferenceAcceleratorOverrides, context)
         : undefined,
-    memory: output.memory !== undefined && output.memory !== null ? output.memory : undefined,
-    taskRoleArn: output.taskRoleArn !== undefined && output.taskRoleArn !== null ? output.taskRoleArn : undefined,
+    memory: __expectString(output.memory),
+    taskRoleArn: __expectString(output.taskRoleArn),
   } as any;
 };
 
@@ -10333,18 +10169,15 @@ const deserializeAws_json1_1TaskSet = (output: any, context: __SerdeContext): Ta
       output.capacityProviderStrategy !== undefined && output.capacityProviderStrategy !== null
         ? deserializeAws_json1_1CapacityProviderStrategy(output.capacityProviderStrategy, context)
         : undefined,
-    clusterArn: output.clusterArn !== undefined && output.clusterArn !== null ? output.clusterArn : undefined,
-    computedDesiredCount:
-      output.computedDesiredCount !== undefined && output.computedDesiredCount !== null
-        ? output.computedDesiredCount
-        : undefined,
+    clusterArn: __expectString(output.clusterArn),
+    computedDesiredCount: __expectNumber(output.computedDesiredCount),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    externalId: output.externalId !== undefined && output.externalId !== null ? output.externalId : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    launchType: output.launchType !== undefined && output.launchType !== null ? output.launchType : undefined,
+    externalId: __expectString(output.externalId),
+    id: __expectString(output.id),
+    launchType: __expectString(output.launchType),
     loadBalancers:
       output.loadBalancers !== undefined && output.loadBalancers !== null
         ? deserializeAws_json1_1LoadBalancers(output.loadBalancers, context)
@@ -10353,32 +10186,29 @@ const deserializeAws_json1_1TaskSet = (output: any, context: __SerdeContext): Ta
       output.networkConfiguration !== undefined && output.networkConfiguration !== null
         ? deserializeAws_json1_1NetworkConfiguration(output.networkConfiguration, context)
         : undefined,
-    pendingCount: output.pendingCount !== undefined && output.pendingCount !== null ? output.pendingCount : undefined,
-    platformVersion:
-      output.platformVersion !== undefined && output.platformVersion !== null ? output.platformVersion : undefined,
-    runningCount: output.runningCount !== undefined && output.runningCount !== null ? output.runningCount : undefined,
+    pendingCount: __expectNumber(output.pendingCount),
+    platformVersion: __expectString(output.platformVersion),
+    runningCount: __expectNumber(output.runningCount),
     scale:
       output.scale !== undefined && output.scale !== null
         ? deserializeAws_json1_1Scale(output.scale, context)
         : undefined,
-    serviceArn: output.serviceArn !== undefined && output.serviceArn !== null ? output.serviceArn : undefined,
+    serviceArn: __expectString(output.serviceArn),
     serviceRegistries:
       output.serviceRegistries !== undefined && output.serviceRegistries !== null
         ? deserializeAws_json1_1ServiceRegistries(output.serviceRegistries, context)
         : undefined,
-    stabilityStatus:
-      output.stabilityStatus !== undefined && output.stabilityStatus !== null ? output.stabilityStatus : undefined,
+    stabilityStatus: __expectString(output.stabilityStatus),
     stabilityStatusAt:
       output.stabilityStatusAt !== undefined && output.stabilityStatusAt !== null
         ? new Date(Math.round(output.stabilityStatusAt * 1000))
         : undefined,
-    startedBy: output.startedBy !== undefined && output.startedBy !== null ? output.startedBy : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    startedBy: __expectString(output.startedBy),
+    status: __expectString(output.status),
     tags:
       output.tags !== undefined && output.tags !== null ? deserializeAws_json1_1Tags(output.tags, context) : undefined,
-    taskDefinition:
-      output.taskDefinition !== undefined && output.taskDefinition !== null ? output.taskDefinition : undefined,
-    taskSetArn: output.taskSetArn !== undefined && output.taskSetArn !== null ? output.taskSetArn : undefined,
+    taskDefinition: __expectString(output.taskDefinition),
+    taskSetArn: __expectString(output.taskSetArn),
     updatedAt:
       output.updatedAt !== undefined && output.updatedAt !== null
         ? new Date(Math.round(output.updatedAt * 1000))
@@ -10391,7 +10221,7 @@ const deserializeAws_json1_1TaskSetNotFoundException = (
   context: __SerdeContext
 ): TaskSetNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10408,13 +10238,12 @@ const deserializeAws_json1_1TaskSets = (output: any, context: __SerdeContext): T
 
 const deserializeAws_json1_1Tmpfs = (output: any, context: __SerdeContext): Tmpfs => {
   return {
-    containerPath:
-      output.containerPath !== undefined && output.containerPath !== null ? output.containerPath : undefined,
+    containerPath: __expectString(output.containerPath),
     mountOptions:
       output.mountOptions !== undefined && output.mountOptions !== null
         ? deserializeAws_json1_1StringList(output.mountOptions, context)
         : undefined,
-    size: output.size !== undefined && output.size !== null ? output.size : undefined,
+    size: __expectNumber(output.size),
   } as any;
 };
 
@@ -10431,9 +10260,9 @@ const deserializeAws_json1_1TmpfsList = (output: any, context: __SerdeContext): 
 
 const deserializeAws_json1_1Ulimit = (output: any, context: __SerdeContext): Ulimit => {
   return {
-    hardLimit: output.hardLimit !== undefined && output.hardLimit !== null ? output.hardLimit : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    softLimit: output.softLimit !== undefined && output.softLimit !== null ? output.softLimit : undefined,
+    hardLimit: __expectNumber(output.hardLimit),
+    name: __expectString(output.name),
+    softLimit: __expectNumber(output.softLimit),
   } as any;
 };
 
@@ -10453,7 +10282,7 @@ const deserializeAws_json1_1UnsupportedFeatureException = (
   context: __SerdeContext
 ): UnsupportedFeatureException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10527,7 +10356,7 @@ const deserializeAws_json1_1UpdateInProgressException = (
   context: __SerdeContext
 ): UpdateInProgressException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10563,10 +10392,9 @@ const deserializeAws_json1_1UpdateTaskSetResponse = (output: any, context: __Ser
 
 const deserializeAws_json1_1VersionInfo = (output: any, context: __SerdeContext): VersionInfo => {
   return {
-    agentHash: output.agentHash !== undefined && output.agentHash !== null ? output.agentHash : undefined,
-    agentVersion: output.agentVersion !== undefined && output.agentVersion !== null ? output.agentVersion : undefined,
-    dockerVersion:
-      output.dockerVersion !== undefined && output.dockerVersion !== null ? output.dockerVersion : undefined,
+    agentHash: __expectString(output.agentHash),
+    agentVersion: __expectString(output.agentVersion),
+    dockerVersion: __expectString(output.dockerVersion),
   } as any;
 };
 
@@ -10592,15 +10420,14 @@ const deserializeAws_json1_1Volume = (output: any, context: __SerdeContext): Vol
       output.host !== undefined && output.host !== null
         ? deserializeAws_json1_1HostVolumeProperties(output.host, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
   } as any;
 };
 
 const deserializeAws_json1_1VolumeFrom = (output: any, context: __SerdeContext): VolumeFrom => {
   return {
-    readOnly: output.readOnly !== undefined && output.readOnly !== null ? output.readOnly : undefined,
-    sourceContainer:
-      output.sourceContainer !== undefined && output.sourceContainer !== null ? output.sourceContainer : undefined,
+    readOnly: __expectBoolean(output.readOnly),
+    sourceContainer: __expectString(output.sourceContainer),
   } as any;
 };
 

--- a/clients/client-efs/protocols/Aws_restJson1.ts
+++ b/clients/client-efs/protocols/Aws_restJson1.ts
@@ -112,6 +112,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -976,25 +979,25 @@ export const deserializeAws_restJson1CreateAccessPointCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AccessPointArn !== undefined && data.AccessPointArn !== null) {
-    contents.AccessPointArn = data.AccessPointArn;
+    contents.AccessPointArn = __expectString(data.AccessPointArn);
   }
   if (data.AccessPointId !== undefined && data.AccessPointId !== null) {
-    contents.AccessPointId = data.AccessPointId;
+    contents.AccessPointId = __expectString(data.AccessPointId);
   }
   if (data.ClientToken !== undefined && data.ClientToken !== null) {
-    contents.ClientToken = data.ClientToken;
+    contents.ClientToken = __expectString(data.ClientToken);
   }
   if (data.FileSystemId !== undefined && data.FileSystemId !== null) {
-    contents.FileSystemId = data.FileSystemId;
+    contents.FileSystemId = __expectString(data.FileSystemId);
   }
   if (data.LifeCycleState !== undefined && data.LifeCycleState !== null) {
-    contents.LifeCycleState = data.LifeCycleState;
+    contents.LifeCycleState = __expectString(data.LifeCycleState);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.OwnerId !== undefined && data.OwnerId !== null) {
-    contents.OwnerId = data.OwnerId;
+    contents.OwnerId = __expectString(data.OwnerId);
   }
   if (data.PosixUser !== undefined && data.PosixUser !== null) {
     contents.PosixUser = deserializeAws_restJson1PosixUser(data.PosixUser, context);
@@ -1114,46 +1117,46 @@ export const deserializeAws_restJson1CreateFileSystemCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AvailabilityZoneId !== undefined && data.AvailabilityZoneId !== null) {
-    contents.AvailabilityZoneId = data.AvailabilityZoneId;
+    contents.AvailabilityZoneId = __expectString(data.AvailabilityZoneId);
   }
   if (data.AvailabilityZoneName !== undefined && data.AvailabilityZoneName !== null) {
-    contents.AvailabilityZoneName = data.AvailabilityZoneName;
+    contents.AvailabilityZoneName = __expectString(data.AvailabilityZoneName);
   }
   if (data.CreationTime !== undefined && data.CreationTime !== null) {
     contents.CreationTime = new Date(Math.round(data.CreationTime * 1000));
   }
   if (data.CreationToken !== undefined && data.CreationToken !== null) {
-    contents.CreationToken = data.CreationToken;
+    contents.CreationToken = __expectString(data.CreationToken);
   }
   if (data.Encrypted !== undefined && data.Encrypted !== null) {
-    contents.Encrypted = data.Encrypted;
+    contents.Encrypted = __expectBoolean(data.Encrypted);
   }
   if (data.FileSystemArn !== undefined && data.FileSystemArn !== null) {
-    contents.FileSystemArn = data.FileSystemArn;
+    contents.FileSystemArn = __expectString(data.FileSystemArn);
   }
   if (data.FileSystemId !== undefined && data.FileSystemId !== null) {
-    contents.FileSystemId = data.FileSystemId;
+    contents.FileSystemId = __expectString(data.FileSystemId);
   }
   if (data.KmsKeyId !== undefined && data.KmsKeyId !== null) {
-    contents.KmsKeyId = data.KmsKeyId;
+    contents.KmsKeyId = __expectString(data.KmsKeyId);
   }
   if (data.LifeCycleState !== undefined && data.LifeCycleState !== null) {
-    contents.LifeCycleState = data.LifeCycleState;
+    contents.LifeCycleState = __expectString(data.LifeCycleState);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.NumberOfMountTargets !== undefined && data.NumberOfMountTargets !== null) {
-    contents.NumberOfMountTargets = data.NumberOfMountTargets;
+    contents.NumberOfMountTargets = __expectNumber(data.NumberOfMountTargets);
   }
   if (data.OwnerId !== undefined && data.OwnerId !== null) {
-    contents.OwnerId = data.OwnerId;
+    contents.OwnerId = __expectString(data.OwnerId);
   }
   if (data.PerformanceMode !== undefined && data.PerformanceMode !== null) {
-    contents.PerformanceMode = data.PerformanceMode;
+    contents.PerformanceMode = __expectString(data.PerformanceMode);
   }
   if (data.ProvisionedThroughputInMibps !== undefined && data.ProvisionedThroughputInMibps !== null) {
-    contents.ProvisionedThroughputInMibps = data.ProvisionedThroughputInMibps;
+    contents.ProvisionedThroughputInMibps = __expectNumber(data.ProvisionedThroughputInMibps);
   }
   if (data.SizeInBytes !== undefined && data.SizeInBytes !== null) {
     contents.SizeInBytes = deserializeAws_restJson1FileSystemSize(data.SizeInBytes, context);
@@ -1162,7 +1165,7 @@ export const deserializeAws_restJson1CreateFileSystemCommand = async (
     contents.Tags = deserializeAws_restJson1Tags(data.Tags, context);
   }
   if (data.ThroughputMode !== undefined && data.ThroughputMode !== null) {
-    contents.ThroughputMode = data.ThroughputMode;
+    contents.ThroughputMode = __expectString(data.ThroughputMode);
   }
   return Promise.resolve(contents);
 };
@@ -1274,34 +1277,34 @@ export const deserializeAws_restJson1CreateMountTargetCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AvailabilityZoneId !== undefined && data.AvailabilityZoneId !== null) {
-    contents.AvailabilityZoneId = data.AvailabilityZoneId;
+    contents.AvailabilityZoneId = __expectString(data.AvailabilityZoneId);
   }
   if (data.AvailabilityZoneName !== undefined && data.AvailabilityZoneName !== null) {
-    contents.AvailabilityZoneName = data.AvailabilityZoneName;
+    contents.AvailabilityZoneName = __expectString(data.AvailabilityZoneName);
   }
   if (data.FileSystemId !== undefined && data.FileSystemId !== null) {
-    contents.FileSystemId = data.FileSystemId;
+    contents.FileSystemId = __expectString(data.FileSystemId);
   }
   if (data.IpAddress !== undefined && data.IpAddress !== null) {
-    contents.IpAddress = data.IpAddress;
+    contents.IpAddress = __expectString(data.IpAddress);
   }
   if (data.LifeCycleState !== undefined && data.LifeCycleState !== null) {
-    contents.LifeCycleState = data.LifeCycleState;
+    contents.LifeCycleState = __expectString(data.LifeCycleState);
   }
   if (data.MountTargetId !== undefined && data.MountTargetId !== null) {
-    contents.MountTargetId = data.MountTargetId;
+    contents.MountTargetId = __expectString(data.MountTargetId);
   }
   if (data.NetworkInterfaceId !== undefined && data.NetworkInterfaceId !== null) {
-    contents.NetworkInterfaceId = data.NetworkInterfaceId;
+    contents.NetworkInterfaceId = __expectString(data.NetworkInterfaceId);
   }
   if (data.OwnerId !== undefined && data.OwnerId !== null) {
-    contents.OwnerId = data.OwnerId;
+    contents.OwnerId = __expectString(data.OwnerId);
   }
   if (data.SubnetId !== undefined && data.SubnetId !== null) {
-    contents.SubnetId = data.SubnetId;
+    contents.SubnetId = __expectString(data.SubnetId);
   }
   if (data.VpcId !== undefined && data.VpcId !== null) {
-    contents.VpcId = data.VpcId;
+    contents.VpcId = __expectString(data.VpcId);
   }
   return Promise.resolve(contents);
 };
@@ -1874,7 +1877,7 @@ export const deserializeAws_restJson1DescribeAccessPointsCommand = async (
     contents.AccessPoints = deserializeAws_restJson1AccessPointDescriptions(data.AccessPoints, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1954,7 +1957,7 @@ export const deserializeAws_restJson1DescribeAccountPreferencesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.ResourceIdPreference !== undefined && data.ResourceIdPreference !== null) {
     contents.ResourceIdPreference = deserializeAws_restJson1ResourceIdPreference(data.ResourceIdPreference, context);
@@ -2100,10 +2103,10 @@ export const deserializeAws_restJson1DescribeFileSystemPolicyCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.FileSystemId !== undefined && data.FileSystemId !== null) {
-    contents.FileSystemId = data.FileSystemId;
+    contents.FileSystemId = __expectString(data.FileSystemId);
   }
   if (data.Policy !== undefined && data.Policy !== null) {
-    contents.Policy = data.Policy;
+    contents.Policy = __expectString(data.Policy);
   }
   return Promise.resolve(contents);
 };
@@ -2179,10 +2182,10 @@ export const deserializeAws_restJson1DescribeFileSystemsCommand = async (
     contents.FileSystems = deserializeAws_restJson1FileSystemDescriptions(data.FileSystems, context);
   }
   if (data.Marker !== undefined && data.Marker !== null) {
-    contents.Marker = data.Marker;
+    contents.Marker = __expectString(data.Marker);
   }
   if (data.NextMarker !== undefined && data.NextMarker !== null) {
-    contents.NextMarker = data.NextMarker;
+    contents.NextMarker = __expectString(data.NextMarker);
   }
   return Promise.resolve(contents);
 };
@@ -2326,13 +2329,13 @@ export const deserializeAws_restJson1DescribeMountTargetsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Marker !== undefined && data.Marker !== null) {
-    contents.Marker = data.Marker;
+    contents.Marker = __expectString(data.Marker);
   }
   if (data.MountTargets !== undefined && data.MountTargets !== null) {
     contents.MountTargets = deserializeAws_restJson1MountTargetDescriptions(data.MountTargets, context);
   }
   if (data.NextMarker !== undefined && data.NextMarker !== null) {
-    contents.NextMarker = data.NextMarker;
+    contents.NextMarker = __expectString(data.NextMarker);
   }
   return Promise.resolve(contents);
 };
@@ -2500,10 +2503,10 @@ export const deserializeAws_restJson1DescribeTagsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Marker !== undefined && data.Marker !== null) {
-    contents.Marker = data.Marker;
+    contents.Marker = __expectString(data.Marker);
   }
   if (data.NextMarker !== undefined && data.NextMarker !== null) {
-    contents.NextMarker = data.NextMarker;
+    contents.NextMarker = __expectString(data.NextMarker);
   }
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.Tags, context);
@@ -2578,7 +2581,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.Tags, context);
@@ -2894,10 +2897,10 @@ export const deserializeAws_restJson1PutFileSystemPolicyCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.FileSystemId !== undefined && data.FileSystemId !== null) {
-    contents.FileSystemId = data.FileSystemId;
+    contents.FileSystemId = __expectString(data.FileSystemId);
   }
   if (data.Policy !== undefined && data.Policy !== null) {
-    contents.Policy = data.Policy;
+    contents.Policy = __expectString(data.Policy);
   }
   return Promise.resolve(contents);
 };
@@ -3221,46 +3224,46 @@ export const deserializeAws_restJson1UpdateFileSystemCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AvailabilityZoneId !== undefined && data.AvailabilityZoneId !== null) {
-    contents.AvailabilityZoneId = data.AvailabilityZoneId;
+    contents.AvailabilityZoneId = __expectString(data.AvailabilityZoneId);
   }
   if (data.AvailabilityZoneName !== undefined && data.AvailabilityZoneName !== null) {
-    contents.AvailabilityZoneName = data.AvailabilityZoneName;
+    contents.AvailabilityZoneName = __expectString(data.AvailabilityZoneName);
   }
   if (data.CreationTime !== undefined && data.CreationTime !== null) {
     contents.CreationTime = new Date(Math.round(data.CreationTime * 1000));
   }
   if (data.CreationToken !== undefined && data.CreationToken !== null) {
-    contents.CreationToken = data.CreationToken;
+    contents.CreationToken = __expectString(data.CreationToken);
   }
   if (data.Encrypted !== undefined && data.Encrypted !== null) {
-    contents.Encrypted = data.Encrypted;
+    contents.Encrypted = __expectBoolean(data.Encrypted);
   }
   if (data.FileSystemArn !== undefined && data.FileSystemArn !== null) {
-    contents.FileSystemArn = data.FileSystemArn;
+    contents.FileSystemArn = __expectString(data.FileSystemArn);
   }
   if (data.FileSystemId !== undefined && data.FileSystemId !== null) {
-    contents.FileSystemId = data.FileSystemId;
+    contents.FileSystemId = __expectString(data.FileSystemId);
   }
   if (data.KmsKeyId !== undefined && data.KmsKeyId !== null) {
-    contents.KmsKeyId = data.KmsKeyId;
+    contents.KmsKeyId = __expectString(data.KmsKeyId);
   }
   if (data.LifeCycleState !== undefined && data.LifeCycleState !== null) {
-    contents.LifeCycleState = data.LifeCycleState;
+    contents.LifeCycleState = __expectString(data.LifeCycleState);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.NumberOfMountTargets !== undefined && data.NumberOfMountTargets !== null) {
-    contents.NumberOfMountTargets = data.NumberOfMountTargets;
+    contents.NumberOfMountTargets = __expectNumber(data.NumberOfMountTargets);
   }
   if (data.OwnerId !== undefined && data.OwnerId !== null) {
-    contents.OwnerId = data.OwnerId;
+    contents.OwnerId = __expectString(data.OwnerId);
   }
   if (data.PerformanceMode !== undefined && data.PerformanceMode !== null) {
-    contents.PerformanceMode = data.PerformanceMode;
+    contents.PerformanceMode = __expectString(data.PerformanceMode);
   }
   if (data.ProvisionedThroughputInMibps !== undefined && data.ProvisionedThroughputInMibps !== null) {
-    contents.ProvisionedThroughputInMibps = data.ProvisionedThroughputInMibps;
+    contents.ProvisionedThroughputInMibps = __expectNumber(data.ProvisionedThroughputInMibps);
   }
   if (data.SizeInBytes !== undefined && data.SizeInBytes !== null) {
     contents.SizeInBytes = deserializeAws_restJson1FileSystemSize(data.SizeInBytes, context);
@@ -3269,7 +3272,7 @@ export const deserializeAws_restJson1UpdateFileSystemCommand = async (
     contents.Tags = deserializeAws_restJson1Tags(data.Tags, context);
   }
   if (data.ThroughputMode !== undefined && data.ThroughputMode !== null) {
-    contents.ThroughputMode = data.ThroughputMode;
+    contents.ThroughputMode = __expectString(data.ThroughputMode);
   }
   return Promise.resolve(contents);
 };
@@ -3373,13 +3376,13 @@ const deserializeAws_restJson1AccessPointAlreadyExistsResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.AccessPointId !== undefined && data.AccessPointId !== null) {
-    contents.AccessPointId = data.AccessPointId;
+    contents.AccessPointId = __expectString(data.AccessPointId);
   }
   if (data.ErrorCode !== undefined && data.ErrorCode !== null) {
-    contents.ErrorCode = data.ErrorCode;
+    contents.ErrorCode = __expectString(data.ErrorCode);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3397,10 +3400,10 @@ const deserializeAws_restJson1AccessPointLimitExceededResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.ErrorCode !== undefined && data.ErrorCode !== null) {
-    contents.ErrorCode = data.ErrorCode;
+    contents.ErrorCode = __expectString(data.ErrorCode);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3418,10 +3421,10 @@ const deserializeAws_restJson1AccessPointNotFoundResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.ErrorCode !== undefined && data.ErrorCode !== null) {
-    contents.ErrorCode = data.ErrorCode;
+    contents.ErrorCode = __expectString(data.ErrorCode);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3439,10 +3442,10 @@ const deserializeAws_restJson1AvailabilityZonesMismatchResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.ErrorCode !== undefined && data.ErrorCode !== null) {
-    contents.ErrorCode = data.ErrorCode;
+    contents.ErrorCode = __expectString(data.ErrorCode);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3460,10 +3463,10 @@ const deserializeAws_restJson1BadRequestResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.ErrorCode !== undefined && data.ErrorCode !== null) {
-    contents.ErrorCode = data.ErrorCode;
+    contents.ErrorCode = __expectString(data.ErrorCode);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3481,10 +3484,10 @@ const deserializeAws_restJson1DependencyTimeoutResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.ErrorCode !== undefined && data.ErrorCode !== null) {
-    contents.ErrorCode = data.ErrorCode;
+    contents.ErrorCode = __expectString(data.ErrorCode);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3503,13 +3506,13 @@ const deserializeAws_restJson1FileSystemAlreadyExistsResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.ErrorCode !== undefined && data.ErrorCode !== null) {
-    contents.ErrorCode = data.ErrorCode;
+    contents.ErrorCode = __expectString(data.ErrorCode);
   }
   if (data.FileSystemId !== undefined && data.FileSystemId !== null) {
-    contents.FileSystemId = data.FileSystemId;
+    contents.FileSystemId = __expectString(data.FileSystemId);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3527,10 +3530,10 @@ const deserializeAws_restJson1FileSystemInUseResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.ErrorCode !== undefined && data.ErrorCode !== null) {
-    contents.ErrorCode = data.ErrorCode;
+    contents.ErrorCode = __expectString(data.ErrorCode);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3548,10 +3551,10 @@ const deserializeAws_restJson1FileSystemLimitExceededResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.ErrorCode !== undefined && data.ErrorCode !== null) {
-    contents.ErrorCode = data.ErrorCode;
+    contents.ErrorCode = __expectString(data.ErrorCode);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3569,10 +3572,10 @@ const deserializeAws_restJson1FileSystemNotFoundResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.ErrorCode !== undefined && data.ErrorCode !== null) {
-    contents.ErrorCode = data.ErrorCode;
+    contents.ErrorCode = __expectString(data.ErrorCode);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3590,10 +3593,10 @@ const deserializeAws_restJson1IncorrectFileSystemLifeCycleStateResponse = async 
   };
   const data: any = parsedOutput.body;
   if (data.ErrorCode !== undefined && data.ErrorCode !== null) {
-    contents.ErrorCode = data.ErrorCode;
+    contents.ErrorCode = __expectString(data.ErrorCode);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3611,10 +3614,10 @@ const deserializeAws_restJson1IncorrectMountTargetStateResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.ErrorCode !== undefined && data.ErrorCode !== null) {
-    contents.ErrorCode = data.ErrorCode;
+    contents.ErrorCode = __expectString(data.ErrorCode);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3632,10 +3635,10 @@ const deserializeAws_restJson1InsufficientThroughputCapacityResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.ErrorCode !== undefined && data.ErrorCode !== null) {
-    contents.ErrorCode = data.ErrorCode;
+    contents.ErrorCode = __expectString(data.ErrorCode);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3653,10 +3656,10 @@ const deserializeAws_restJson1InternalServerErrorResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.ErrorCode !== undefined && data.ErrorCode !== null) {
-    contents.ErrorCode = data.ErrorCode;
+    contents.ErrorCode = __expectString(data.ErrorCode);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3674,10 +3677,10 @@ const deserializeAws_restJson1InvalidPolicyExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.ErrorCode !== undefined && data.ErrorCode !== null) {
-    contents.ErrorCode = data.ErrorCode;
+    contents.ErrorCode = __expectString(data.ErrorCode);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3695,10 +3698,10 @@ const deserializeAws_restJson1IpAddressInUseResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.ErrorCode !== undefined && data.ErrorCode !== null) {
-    contents.ErrorCode = data.ErrorCode;
+    contents.ErrorCode = __expectString(data.ErrorCode);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3716,10 +3719,10 @@ const deserializeAws_restJson1MountTargetConflictResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.ErrorCode !== undefined && data.ErrorCode !== null) {
-    contents.ErrorCode = data.ErrorCode;
+    contents.ErrorCode = __expectString(data.ErrorCode);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3737,10 +3740,10 @@ const deserializeAws_restJson1MountTargetNotFoundResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.ErrorCode !== undefined && data.ErrorCode !== null) {
-    contents.ErrorCode = data.ErrorCode;
+    contents.ErrorCode = __expectString(data.ErrorCode);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3758,10 +3761,10 @@ const deserializeAws_restJson1NetworkInterfaceLimitExceededResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.ErrorCode !== undefined && data.ErrorCode !== null) {
-    contents.ErrorCode = data.ErrorCode;
+    contents.ErrorCode = __expectString(data.ErrorCode);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3779,10 +3782,10 @@ const deserializeAws_restJson1NoFreeAddressesInSubnetResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.ErrorCode !== undefined && data.ErrorCode !== null) {
-    contents.ErrorCode = data.ErrorCode;
+    contents.ErrorCode = __expectString(data.ErrorCode);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3800,10 +3803,10 @@ const deserializeAws_restJson1PolicyNotFoundResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.ErrorCode !== undefined && data.ErrorCode !== null) {
-    contents.ErrorCode = data.ErrorCode;
+    contents.ErrorCode = __expectString(data.ErrorCode);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3821,10 +3824,10 @@ const deserializeAws_restJson1SecurityGroupLimitExceededResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.ErrorCode !== undefined && data.ErrorCode !== null) {
-    contents.ErrorCode = data.ErrorCode;
+    contents.ErrorCode = __expectString(data.ErrorCode);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3842,10 +3845,10 @@ const deserializeAws_restJson1SecurityGroupNotFoundResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.ErrorCode !== undefined && data.ErrorCode !== null) {
-    contents.ErrorCode = data.ErrorCode;
+    contents.ErrorCode = __expectString(data.ErrorCode);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3863,10 +3866,10 @@ const deserializeAws_restJson1SubnetNotFoundResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.ErrorCode !== undefined && data.ErrorCode !== null) {
-    contents.ErrorCode = data.ErrorCode;
+    contents.ErrorCode = __expectString(data.ErrorCode);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3884,10 +3887,10 @@ const deserializeAws_restJson1ThroughputLimitExceededResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.ErrorCode !== undefined && data.ErrorCode !== null) {
-    contents.ErrorCode = data.ErrorCode;
+    contents.ErrorCode = __expectString(data.ErrorCode);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3905,10 +3908,10 @@ const deserializeAws_restJson1TooManyRequestsResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.ErrorCode !== undefined && data.ErrorCode !== null) {
-    contents.ErrorCode = data.ErrorCode;
+    contents.ErrorCode = __expectString(data.ErrorCode);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3926,10 +3929,10 @@ const deserializeAws_restJson1UnsupportedAvailabilityZoneResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.ErrorCode !== undefined && data.ErrorCode !== null) {
-    contents.ErrorCode = data.ErrorCode;
+    contents.ErrorCode = __expectString(data.ErrorCode);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3947,10 +3950,10 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.ErrorCode !== undefined && data.ErrorCode !== null) {
-    contents.ErrorCode = data.ErrorCode;
+    contents.ErrorCode = __expectString(data.ErrorCode);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -4062,16 +4065,13 @@ const deserializeAws_restJson1AccessPointDescription = (
   context: __SerdeContext
 ): AccessPointDescription => {
   return {
-    AccessPointArn:
-      output.AccessPointArn !== undefined && output.AccessPointArn !== null ? output.AccessPointArn : undefined,
-    AccessPointId:
-      output.AccessPointId !== undefined && output.AccessPointId !== null ? output.AccessPointId : undefined,
-    ClientToken: output.ClientToken !== undefined && output.ClientToken !== null ? output.ClientToken : undefined,
-    FileSystemId: output.FileSystemId !== undefined && output.FileSystemId !== null ? output.FileSystemId : undefined,
-    LifeCycleState:
-      output.LifeCycleState !== undefined && output.LifeCycleState !== null ? output.LifeCycleState : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    OwnerId: output.OwnerId !== undefined && output.OwnerId !== null ? output.OwnerId : undefined,
+    AccessPointArn: __expectString(output.AccessPointArn),
+    AccessPointId: __expectString(output.AccessPointId),
+    ClientToken: __expectString(output.ClientToken),
+    FileSystemId: __expectString(output.FileSystemId),
+    LifeCycleState: __expectString(output.LifeCycleState),
+    Name: __expectString(output.Name),
+    OwnerId: __expectString(output.OwnerId),
     PosixUser:
       output.PosixUser !== undefined && output.PosixUser !== null
         ? deserializeAws_restJson1PosixUser(output.PosixUser, context)
@@ -4103,53 +4103,37 @@ const deserializeAws_restJson1AccessPointDescriptions = (
 
 const deserializeAws_restJson1BackupPolicy = (output: any, context: __SerdeContext): BackupPolicy => {
   return {
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
 const deserializeAws_restJson1CreationInfo = (output: any, context: __SerdeContext): CreationInfo => {
   return {
-    OwnerGid: output.OwnerGid !== undefined && output.OwnerGid !== null ? output.OwnerGid : undefined,
-    OwnerUid: output.OwnerUid !== undefined && output.OwnerUid !== null ? output.OwnerUid : undefined,
-    Permissions: output.Permissions !== undefined && output.Permissions !== null ? output.Permissions : undefined,
+    OwnerGid: __expectNumber(output.OwnerGid),
+    OwnerUid: __expectNumber(output.OwnerUid),
+    Permissions: __expectString(output.Permissions),
   } as any;
 };
 
 const deserializeAws_restJson1FileSystemDescription = (output: any, context: __SerdeContext): FileSystemDescription => {
   return {
-    AvailabilityZoneId:
-      output.AvailabilityZoneId !== undefined && output.AvailabilityZoneId !== null
-        ? output.AvailabilityZoneId
-        : undefined,
-    AvailabilityZoneName:
-      output.AvailabilityZoneName !== undefined && output.AvailabilityZoneName !== null
-        ? output.AvailabilityZoneName
-        : undefined,
+    AvailabilityZoneId: __expectString(output.AvailabilityZoneId),
+    AvailabilityZoneName: __expectString(output.AvailabilityZoneName),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    CreationToken:
-      output.CreationToken !== undefined && output.CreationToken !== null ? output.CreationToken : undefined,
-    Encrypted: output.Encrypted !== undefined && output.Encrypted !== null ? output.Encrypted : undefined,
-    FileSystemArn:
-      output.FileSystemArn !== undefined && output.FileSystemArn !== null ? output.FileSystemArn : undefined,
-    FileSystemId: output.FileSystemId !== undefined && output.FileSystemId !== null ? output.FileSystemId : undefined,
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
-    LifeCycleState:
-      output.LifeCycleState !== undefined && output.LifeCycleState !== null ? output.LifeCycleState : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    NumberOfMountTargets:
-      output.NumberOfMountTargets !== undefined && output.NumberOfMountTargets !== null
-        ? output.NumberOfMountTargets
-        : undefined,
-    OwnerId: output.OwnerId !== undefined && output.OwnerId !== null ? output.OwnerId : undefined,
-    PerformanceMode:
-      output.PerformanceMode !== undefined && output.PerformanceMode !== null ? output.PerformanceMode : undefined,
-    ProvisionedThroughputInMibps:
-      output.ProvisionedThroughputInMibps !== undefined && output.ProvisionedThroughputInMibps !== null
-        ? output.ProvisionedThroughputInMibps
-        : undefined,
+    CreationToken: __expectString(output.CreationToken),
+    Encrypted: __expectBoolean(output.Encrypted),
+    FileSystemArn: __expectString(output.FileSystemArn),
+    FileSystemId: __expectString(output.FileSystemId),
+    KmsKeyId: __expectString(output.KmsKeyId),
+    LifeCycleState: __expectString(output.LifeCycleState),
+    Name: __expectString(output.Name),
+    NumberOfMountTargets: __expectNumber(output.NumberOfMountTargets),
+    OwnerId: __expectString(output.OwnerId),
+    PerformanceMode: __expectString(output.PerformanceMode),
+    ProvisionedThroughputInMibps: __expectNumber(output.ProvisionedThroughputInMibps),
     SizeInBytes:
       output.SizeInBytes !== undefined && output.SizeInBytes !== null
         ? deserializeAws_restJson1FileSystemSize(output.SizeInBytes, context)
@@ -4158,8 +4142,7 @@ const deserializeAws_restJson1FileSystemDescription = (output: any, context: __S
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_restJson1Tags(output.Tags, context)
         : undefined,
-    ThroughputMode:
-      output.ThroughputMode !== undefined && output.ThroughputMode !== null ? output.ThroughputMode : undefined,
+    ThroughputMode: __expectString(output.ThroughputMode),
   } as any;
 };
 
@@ -4183,10 +4166,9 @@ const deserializeAws_restJson1FileSystemSize = (output: any, context: __SerdeCon
       output.Timestamp !== undefined && output.Timestamp !== null
         ? new Date(Math.round(output.Timestamp * 1000))
         : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
-    ValueInIA: output.ValueInIA !== undefined && output.ValueInIA !== null ? output.ValueInIA : undefined,
-    ValueInStandard:
-      output.ValueInStandard !== undefined && output.ValueInStandard !== null ? output.ValueInStandard : undefined,
+    Value: __expectNumber(output.Value),
+    ValueInIA: __expectNumber(output.ValueInIA),
+    ValueInStandard: __expectNumber(output.ValueInStandard),
   } as any;
 };
 
@@ -4203,8 +4185,7 @@ const deserializeAws_restJson1LifecyclePolicies = (output: any, context: __Serde
 
 const deserializeAws_restJson1LifecyclePolicy = (output: any, context: __SerdeContext): LifecyclePolicy => {
   return {
-    TransitionToIA:
-      output.TransitionToIA !== undefined && output.TransitionToIA !== null ? output.TransitionToIA : undefined,
+    TransitionToIA: __expectString(output.TransitionToIA),
   } as any;
 };
 
@@ -4213,27 +4194,16 @@ const deserializeAws_restJson1MountTargetDescription = (
   context: __SerdeContext
 ): MountTargetDescription => {
   return {
-    AvailabilityZoneId:
-      output.AvailabilityZoneId !== undefined && output.AvailabilityZoneId !== null
-        ? output.AvailabilityZoneId
-        : undefined,
-    AvailabilityZoneName:
-      output.AvailabilityZoneName !== undefined && output.AvailabilityZoneName !== null
-        ? output.AvailabilityZoneName
-        : undefined,
-    FileSystemId: output.FileSystemId !== undefined && output.FileSystemId !== null ? output.FileSystemId : undefined,
-    IpAddress: output.IpAddress !== undefined && output.IpAddress !== null ? output.IpAddress : undefined,
-    LifeCycleState:
-      output.LifeCycleState !== undefined && output.LifeCycleState !== null ? output.LifeCycleState : undefined,
-    MountTargetId:
-      output.MountTargetId !== undefined && output.MountTargetId !== null ? output.MountTargetId : undefined,
-    NetworkInterfaceId:
-      output.NetworkInterfaceId !== undefined && output.NetworkInterfaceId !== null
-        ? output.NetworkInterfaceId
-        : undefined,
-    OwnerId: output.OwnerId !== undefined && output.OwnerId !== null ? output.OwnerId : undefined,
-    SubnetId: output.SubnetId !== undefined && output.SubnetId !== null ? output.SubnetId : undefined,
-    VpcId: output.VpcId !== undefined && output.VpcId !== null ? output.VpcId : undefined,
+    AvailabilityZoneId: __expectString(output.AvailabilityZoneId),
+    AvailabilityZoneName: __expectString(output.AvailabilityZoneName),
+    FileSystemId: __expectString(output.FileSystemId),
+    IpAddress: __expectString(output.IpAddress),
+    LifeCycleState: __expectString(output.LifeCycleState),
+    MountTargetId: __expectString(output.MountTargetId),
+    NetworkInterfaceId: __expectString(output.NetworkInterfaceId),
+    OwnerId: __expectString(output.OwnerId),
+    SubnetId: __expectString(output.SubnetId),
+    VpcId: __expectString(output.VpcId),
   } as any;
 };
 
@@ -4253,19 +4223,18 @@ const deserializeAws_restJson1MountTargetDescriptions = (
 
 const deserializeAws_restJson1PosixUser = (output: any, context: __SerdeContext): PosixUser => {
   return {
-    Gid: output.Gid !== undefined && output.Gid !== null ? output.Gid : undefined,
+    Gid: __expectNumber(output.Gid),
     SecondaryGids:
       output.SecondaryGids !== undefined && output.SecondaryGids !== null
         ? deserializeAws_restJson1SecondaryGids(output.SecondaryGids, context)
         : undefined,
-    Uid: output.Uid !== undefined && output.Uid !== null ? output.Uid : undefined,
+    Uid: __expectNumber(output.Uid),
   } as any;
 };
 
 const deserializeAws_restJson1ResourceIdPreference = (output: any, context: __SerdeContext): ResourceIdPreference => {
   return {
-    ResourceIdType:
-      output.ResourceIdType !== undefined && output.ResourceIdType !== null ? output.ResourceIdType : undefined,
+    ResourceIdType: __expectString(output.ResourceIdType),
     Resources:
       output.Resources !== undefined && output.Resources !== null
         ? deserializeAws_restJson1Resources(output.Resources, context)
@@ -4280,7 +4249,7 @@ const deserializeAws_restJson1Resources = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4290,7 +4259,7 @@ const deserializeAws_restJson1RootDirectory = (output: any, context: __SerdeCont
       output.CreationInfo !== undefined && output.CreationInfo !== null
         ? deserializeAws_restJson1CreationInfo(output.CreationInfo, context)
         : undefined,
-    Path: output.Path !== undefined && output.Path !== null ? output.Path : undefined,
+    Path: __expectString(output.Path),
   } as any;
 };
 
@@ -4301,7 +4270,7 @@ const deserializeAws_restJson1SecondaryGids = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectNumber(entry) as any;
     });
 };
 
@@ -4312,14 +4281,14 @@ const deserializeAws_restJson1SecurityGroups = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 

--- a/clients/client-eks/protocols/Aws_restJson1.ts
+++ b/clients/client-eks/protocols/Aws_restJson1.ts
@@ -131,6 +131,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -2380,7 +2383,7 @@ export const deserializeAws_restJson1DescribeAddonVersionsCommand = async (
     contents.addons = deserializeAws_restJson1Addons(data.addons, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2964,7 +2967,7 @@ export const deserializeAws_restJson1ListAddonsCommand = async (
     contents.addons = deserializeAws_restJson1StringList(data.addons, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3055,7 +3058,7 @@ export const deserializeAws_restJson1ListClustersCommand = async (
     contents.clusters = deserializeAws_restJson1StringList(data.clusters, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3138,7 +3141,7 @@ export const deserializeAws_restJson1ListFargateProfilesCommand = async (
     contents.fargateProfileNames = deserializeAws_restJson1StringList(data.fargateProfileNames, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3224,7 +3227,7 @@ export const deserializeAws_restJson1ListIdentityProviderConfigsCommand = async 
     );
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3312,7 +3315,7 @@ export const deserializeAws_restJson1ListNodegroupsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.nodegroups !== undefined && data.nodegroups !== null) {
     contents.nodegroups = deserializeAws_restJson1StringList(data.nodegroups, context);
@@ -3466,7 +3469,7 @@ export const deserializeAws_restJson1ListUpdatesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.updateIds !== undefined && data.updateIds !== null) {
     contents.updateIds = deserializeAws_restJson1StringList(data.updateIds, context);
@@ -4140,7 +4143,7 @@ const deserializeAws_restJson1BadRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -4160,16 +4163,16 @@ const deserializeAws_restJson1ClientExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.addonName !== undefined && data.addonName !== null) {
-    contents.addonName = data.addonName;
+    contents.addonName = __expectString(data.addonName);
   }
   if (data.clusterName !== undefined && data.clusterName !== null) {
-    contents.clusterName = data.clusterName;
+    contents.clusterName = __expectString(data.clusterName);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.nodegroupName !== undefined && data.nodegroupName !== null) {
-    contents.nodegroupName = data.nodegroupName;
+    contents.nodegroupName = __expectString(data.nodegroupName);
   }
   return contents;
 };
@@ -4190,19 +4193,19 @@ const deserializeAws_restJson1InvalidParameterExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.addonName !== undefined && data.addonName !== null) {
-    contents.addonName = data.addonName;
+    contents.addonName = __expectString(data.addonName);
   }
   if (data.clusterName !== undefined && data.clusterName !== null) {
-    contents.clusterName = data.clusterName;
+    contents.clusterName = __expectString(data.clusterName);
   }
   if (data.fargateProfileName !== undefined && data.fargateProfileName !== null) {
-    contents.fargateProfileName = data.fargateProfileName;
+    contents.fargateProfileName = __expectString(data.fargateProfileName);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.nodegroupName !== undefined && data.nodegroupName !== null) {
-    contents.nodegroupName = data.nodegroupName;
+    contents.nodegroupName = __expectString(data.nodegroupName);
   }
   return contents;
 };
@@ -4222,16 +4225,16 @@ const deserializeAws_restJson1InvalidRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.addonName !== undefined && data.addonName !== null) {
-    contents.addonName = data.addonName;
+    contents.addonName = __expectString(data.addonName);
   }
   if (data.clusterName !== undefined && data.clusterName !== null) {
-    contents.clusterName = data.clusterName;
+    contents.clusterName = __expectString(data.clusterName);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.nodegroupName !== undefined && data.nodegroupName !== null) {
-    contents.nodegroupName = data.nodegroupName;
+    contents.nodegroupName = __expectString(data.nodegroupName);
   }
   return contents;
 };
@@ -4248,7 +4251,7 @@ const deserializeAws_restJson1NotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -4268,16 +4271,16 @@ const deserializeAws_restJson1ResourceInUseExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.addonName !== undefined && data.addonName !== null) {
-    contents.addonName = data.addonName;
+    contents.addonName = __expectString(data.addonName);
   }
   if (data.clusterName !== undefined && data.clusterName !== null) {
-    contents.clusterName = data.clusterName;
+    contents.clusterName = __expectString(data.clusterName);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.nodegroupName !== undefined && data.nodegroupName !== null) {
-    contents.nodegroupName = data.nodegroupName;
+    contents.nodegroupName = __expectString(data.nodegroupName);
   }
   return contents;
 };
@@ -4296,13 +4299,13 @@ const deserializeAws_restJson1ResourceLimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.clusterName !== undefined && data.clusterName !== null) {
-    contents.clusterName = data.clusterName;
+    contents.clusterName = __expectString(data.clusterName);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.nodegroupName !== undefined && data.nodegroupName !== null) {
-    contents.nodegroupName = data.nodegroupName;
+    contents.nodegroupName = __expectString(data.nodegroupName);
   }
   return contents;
 };
@@ -4323,19 +4326,19 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.addonName !== undefined && data.addonName !== null) {
-    contents.addonName = data.addonName;
+    contents.addonName = __expectString(data.addonName);
   }
   if (data.clusterName !== undefined && data.clusterName !== null) {
-    contents.clusterName = data.clusterName;
+    contents.clusterName = __expectString(data.clusterName);
   }
   if (data.fargateProfileName !== undefined && data.fargateProfileName !== null) {
-    contents.fargateProfileName = data.fargateProfileName;
+    contents.fargateProfileName = __expectString(data.fargateProfileName);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.nodegroupName !== undefined && data.nodegroupName !== null) {
-    contents.nodegroupName = data.nodegroupName;
+    contents.nodegroupName = __expectString(data.nodegroupName);
   }
   return contents;
 };
@@ -4355,16 +4358,16 @@ const deserializeAws_restJson1ServerExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.addonName !== undefined && data.addonName !== null) {
-    contents.addonName = data.addonName;
+    contents.addonName = __expectString(data.addonName);
   }
   if (data.clusterName !== undefined && data.clusterName !== null) {
-    contents.clusterName = data.clusterName;
+    contents.clusterName = __expectString(data.clusterName);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.nodegroupName !== undefined && data.nodegroupName !== null) {
-    contents.nodegroupName = data.nodegroupName;
+    contents.nodegroupName = __expectString(data.nodegroupName);
   }
   return contents;
 };
@@ -4381,7 +4384,7 @@ const deserializeAws_restJson1ServiceUnavailableExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -4401,13 +4404,13 @@ const deserializeAws_restJson1UnsupportedAvailabilityZoneExceptionResponse = asy
   };
   const data: any = parsedOutput.body;
   if (data.clusterName !== undefined && data.clusterName !== null) {
-    contents.clusterName = data.clusterName;
+    contents.clusterName = __expectString(data.clusterName);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.nodegroupName !== undefined && data.nodegroupName !== null) {
-    contents.nodegroupName = data.nodegroupName;
+    contents.nodegroupName = __expectString(data.nodegroupName);
   }
   if (data.validZones !== undefined && data.validZones !== null) {
     contents.validZones = deserializeAws_restJson1StringList(data.validZones, context);
@@ -4712,10 +4715,10 @@ const serializeAws_restJson1VpcConfigRequest = (input: VpcConfigRequest, context
 
 const deserializeAws_restJson1Addon = (output: any, context: __SerdeContext): Addon => {
   return {
-    addonArn: output.addonArn !== undefined && output.addonArn !== null ? output.addonArn : undefined,
-    addonName: output.addonName !== undefined && output.addonName !== null ? output.addonName : undefined,
-    addonVersion: output.addonVersion !== undefined && output.addonVersion !== null ? output.addonVersion : undefined,
-    clusterName: output.clusterName !== undefined && output.clusterName !== null ? output.clusterName : undefined,
+    addonArn: __expectString(output.addonArn),
+    addonName: __expectString(output.addonName),
+    addonVersion: __expectString(output.addonVersion),
+    clusterName: __expectString(output.clusterName),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
@@ -4728,11 +4731,8 @@ const deserializeAws_restJson1Addon = (output: any, context: __SerdeContext): Ad
       output.modifiedAt !== undefined && output.modifiedAt !== null
         ? new Date(Math.round(output.modifiedAt * 1000))
         : undefined,
-    serviceAccountRoleArn:
-      output.serviceAccountRoleArn !== undefined && output.serviceAccountRoleArn !== null
-        ? output.serviceAccountRoleArn
-        : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    serviceAccountRoleArn: __expectString(output.serviceAccountRoleArn),
+    status: __expectString(output.status),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1TagMap(output.tags, context)
@@ -4751,19 +4751,19 @@ const deserializeAws_restJson1AddonHealth = (output: any, context: __SerdeContex
 
 const deserializeAws_restJson1AddonInfo = (output: any, context: __SerdeContext): AddonInfo => {
   return {
-    addonName: output.addonName !== undefined && output.addonName !== null ? output.addonName : undefined,
+    addonName: __expectString(output.addonName),
     addonVersions:
       output.addonVersions !== undefined && output.addonVersions !== null
         ? deserializeAws_restJson1AddonVersionInfoList(output.addonVersions, context)
         : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    type: __expectString(output.type),
   } as any;
 };
 
 const deserializeAws_restJson1AddonIssue = (output: any, context: __SerdeContext): AddonIssue => {
   return {
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    code: __expectString(output.code),
+    message: __expectString(output.message),
     resourceIds:
       output.resourceIds !== undefined && output.resourceIds !== null
         ? deserializeAws_restJson1StringList(output.resourceIds, context)
@@ -4795,7 +4795,7 @@ const deserializeAws_restJson1Addons = (output: any, context: __SerdeContext): A
 
 const deserializeAws_restJson1AddonVersionInfo = (output: any, context: __SerdeContext): AddonVersionInfo => {
   return {
-    addonVersion: output.addonVersion !== undefined && output.addonVersion !== null ? output.addonVersion : undefined,
+    addonVersion: __expectString(output.addonVersion),
     architecture:
       output.architecture !== undefined && output.architecture !== null
         ? deserializeAws_restJson1StringList(output.architecture, context)
@@ -4820,7 +4820,7 @@ const deserializeAws_restJson1AddonVersionInfoList = (output: any, context: __Se
 
 const deserializeAws_restJson1AutoScalingGroup = (output: any, context: __SerdeContext): AutoScalingGroup => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -4837,21 +4837,18 @@ const deserializeAws_restJson1AutoScalingGroupList = (output: any, context: __Se
 
 const deserializeAws_restJson1Certificate = (output: any, context: __SerdeContext): Certificate => {
   return {
-    data: output.data !== undefined && output.data !== null ? output.data : undefined,
+    data: __expectString(output.data),
   } as any;
 };
 
 const deserializeAws_restJson1Cluster = (output: any, context: __SerdeContext): Cluster => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     certificateAuthority:
       output.certificateAuthority !== undefined && output.certificateAuthority !== null
         ? deserializeAws_restJson1Certificate(output.certificateAuthority, context)
         : undefined,
-    clientRequestToken:
-      output.clientRequestToken !== undefined && output.clientRequestToken !== null
-        ? output.clientRequestToken
-        : undefined,
+    clientRequestToken: __expectString(output.clientRequestToken),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
@@ -4860,7 +4857,7 @@ const deserializeAws_restJson1Cluster = (output: any, context: __SerdeContext): 
       output.encryptionConfig !== undefined && output.encryptionConfig !== null
         ? deserializeAws_restJson1EncryptionConfigList(output.encryptionConfig, context)
         : undefined,
-    endpoint: output.endpoint !== undefined && output.endpoint !== null ? output.endpoint : undefined,
+    endpoint: __expectString(output.endpoint),
     identity:
       output.identity !== undefined && output.identity !== null
         ? deserializeAws_restJson1Identity(output.identity, context)
@@ -4873,20 +4870,19 @@ const deserializeAws_restJson1Cluster = (output: any, context: __SerdeContext): 
       output.logging !== undefined && output.logging !== null
         ? deserializeAws_restJson1Logging(output.logging, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    platformVersion:
-      output.platformVersion !== undefined && output.platformVersion !== null ? output.platformVersion : undefined,
+    name: __expectString(output.name),
+    platformVersion: __expectString(output.platformVersion),
     resourcesVpcConfig:
       output.resourcesVpcConfig !== undefined && output.resourcesVpcConfig !== null
         ? deserializeAws_restJson1VpcConfigResponse(output.resourcesVpcConfig, context)
         : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    roleArn: __expectString(output.roleArn),
+    status: __expectString(output.status),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1TagMap(output.tags, context)
         : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    version: __expectString(output.version),
   } as any;
 };
 
@@ -4903,10 +4899,8 @@ const deserializeAws_restJson1Compatibilities = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1Compatibility = (output: any, context: __SerdeContext): Compatibility => {
   return {
-    clusterVersion:
-      output.clusterVersion !== undefined && output.clusterVersion !== null ? output.clusterVersion : undefined,
-    defaultVersion:
-      output.defaultVersion !== undefined && output.defaultVersion !== null ? output.defaultVersion : undefined,
+    clusterVersion: __expectString(output.clusterVersion),
+    defaultVersion: __expectBoolean(output.defaultVersion),
     platformVersions:
       output.platformVersions !== undefined && output.platformVersions !== null
         ? deserializeAws_restJson1StringList(output.platformVersions, context)
@@ -4940,8 +4934,8 @@ const deserializeAws_restJson1EncryptionConfigList = (output: any, context: __Se
 
 const deserializeAws_restJson1ErrorDetail = (output: any, context: __SerdeContext): ErrorDetail => {
   return {
-    errorCode: output.errorCode !== undefined && output.errorCode !== null ? output.errorCode : undefined,
-    errorMessage: output.errorMessage !== undefined && output.errorMessage !== null ? output.errorMessage : undefined,
+    errorCode: __expectString(output.errorCode),
+    errorMessage: __expectString(output.errorMessage),
     resourceIds:
       output.resourceIds !== undefined && output.resourceIds !== null
         ? deserializeAws_restJson1StringList(output.resourceIds, context)
@@ -4962,28 +4956,19 @@ const deserializeAws_restJson1ErrorDetails = (output: any, context: __SerdeConte
 
 const deserializeAws_restJson1FargateProfile = (output: any, context: __SerdeContext): FargateProfile => {
   return {
-    clusterName: output.clusterName !== undefined && output.clusterName !== null ? output.clusterName : undefined,
+    clusterName: __expectString(output.clusterName),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    fargateProfileArn:
-      output.fargateProfileArn !== undefined && output.fargateProfileArn !== null
-        ? output.fargateProfileArn
-        : undefined,
-    fargateProfileName:
-      output.fargateProfileName !== undefined && output.fargateProfileName !== null
-        ? output.fargateProfileName
-        : undefined,
-    podExecutionRoleArn:
-      output.podExecutionRoleArn !== undefined && output.podExecutionRoleArn !== null
-        ? output.podExecutionRoleArn
-        : undefined,
+    fargateProfileArn: __expectString(output.fargateProfileArn),
+    fargateProfileName: __expectString(output.fargateProfileName),
+    podExecutionRoleArn: __expectString(output.podExecutionRoleArn),
     selectors:
       output.selectors !== undefined && output.selectors !== null
         ? deserializeAws_restJson1FargateProfileSelectors(output.selectors, context)
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
     subnets:
       output.subnets !== undefined && output.subnets !== null
         ? deserializeAws_restJson1StringList(output.subnets, context)
@@ -5005,7 +4990,7 @@ const deserializeAws_restJson1FargateProfileLabel = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -5019,7 +5004,7 @@ const deserializeAws_restJson1FargateProfileSelector = (
       output.labels !== undefined && output.labels !== null
         ? deserializeAws_restJson1FargateProfileLabel(output.labels, context)
         : undefined,
-    namespace: output.namespace !== undefined && output.namespace !== null ? output.namespace : undefined,
+    namespace: __expectString(output.namespace),
   } as any;
 };
 
@@ -5051,8 +5036,8 @@ const deserializeAws_restJson1IdentityProviderConfig = (
   context: __SerdeContext
 ): IdentityProviderConfig => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    name: __expectString(output.name),
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -5084,8 +5069,8 @@ const deserializeAws_restJson1IdentityProviderConfigs = (
 
 const deserializeAws_restJson1Issue = (output: any, context: __SerdeContext): Issue => {
   return {
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    code: __expectString(output.code),
+    message: __expectString(output.message),
     resourceIds:
       output.resourceIds !== undefined && output.resourceIds !== null
         ? deserializeAws_restJson1StringList(output.resourceIds, context)
@@ -5109,8 +5094,7 @@ const deserializeAws_restJson1KubernetesNetworkConfigResponse = (
   context: __SerdeContext
 ): KubernetesNetworkConfigResponse => {
   return {
-    serviceIpv4Cidr:
-      output.serviceIpv4Cidr !== undefined && output.serviceIpv4Cidr !== null ? output.serviceIpv4Cidr : undefined,
+    serviceIpv4Cidr: __expectString(output.serviceIpv4Cidr),
   } as any;
 };
 
@@ -5121,7 +5105,7 @@ const deserializeAws_restJson1labelsMap = (output: any, context: __SerdeContext)
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -5131,9 +5115,9 @@ const deserializeAws_restJson1LaunchTemplateSpecification = (
   context: __SerdeContext
 ): LaunchTemplateSpecification => {
   return {
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    id: __expectString(output.id),
+    name: __expectString(output.name),
+    version: __expectString(output.version),
   } as any;
 };
 
@@ -5148,7 +5132,7 @@ const deserializeAws_restJson1Logging = (output: any, context: __SerdeContext): 
 
 const deserializeAws_restJson1LogSetup = (output: any, context: __SerdeContext): LogSetup => {
   return {
-    enabled: output.enabled !== undefined && output.enabled !== null ? output.enabled : undefined,
+    enabled: __expectBoolean(output.enabled),
     types:
       output.types !== undefined && output.types !== null
         ? deserializeAws_restJson1LogTypes(output.types, context)
@@ -5174,20 +5158,20 @@ const deserializeAws_restJson1LogTypes = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1Nodegroup = (output: any, context: __SerdeContext): Nodegroup => {
   return {
-    amiType: output.amiType !== undefined && output.amiType !== null ? output.amiType : undefined,
-    capacityType: output.capacityType !== undefined && output.capacityType !== null ? output.capacityType : undefined,
-    clusterName: output.clusterName !== undefined && output.clusterName !== null ? output.clusterName : undefined,
+    amiType: __expectString(output.amiType),
+    capacityType: __expectString(output.capacityType),
+    clusterName: __expectString(output.clusterName),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    diskSize: output.diskSize !== undefined && output.diskSize !== null ? output.diskSize : undefined,
+    diskSize: __expectNumber(output.diskSize),
     health:
       output.health !== undefined && output.health !== null
         ? deserializeAws_restJson1NodegroupHealth(output.health, context)
@@ -5208,12 +5192,10 @@ const deserializeAws_restJson1Nodegroup = (output: any, context: __SerdeContext)
       output.modifiedAt !== undefined && output.modifiedAt !== null
         ? new Date(Math.round(output.modifiedAt * 1000))
         : undefined,
-    nodeRole: output.nodeRole !== undefined && output.nodeRole !== null ? output.nodeRole : undefined,
-    nodegroupArn: output.nodegroupArn !== undefined && output.nodegroupArn !== null ? output.nodegroupArn : undefined,
-    nodegroupName:
-      output.nodegroupName !== undefined && output.nodegroupName !== null ? output.nodegroupName : undefined,
-    releaseVersion:
-      output.releaseVersion !== undefined && output.releaseVersion !== null ? output.releaseVersion : undefined,
+    nodeRole: __expectString(output.nodeRole),
+    nodegroupArn: __expectString(output.nodegroupArn),
+    nodegroupName: __expectString(output.nodegroupName),
+    releaseVersion: __expectString(output.releaseVersion),
     remoteAccess:
       output.remoteAccess !== undefined && output.remoteAccess !== null
         ? deserializeAws_restJson1RemoteAccessConfig(output.remoteAccess, context)
@@ -5226,7 +5208,7 @@ const deserializeAws_restJson1Nodegroup = (output: any, context: __SerdeContext)
       output.scalingConfig !== undefined && output.scalingConfig !== null
         ? deserializeAws_restJson1NodegroupScalingConfig(output.scalingConfig, context)
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
     subnets:
       output.subnets !== undefined && output.subnets !== null
         ? deserializeAws_restJson1StringList(output.subnets, context)
@@ -5243,7 +5225,7 @@ const deserializeAws_restJson1Nodegroup = (output: any, context: __SerdeContext)
       output.updateConfig !== undefined && output.updateConfig !== null
         ? deserializeAws_restJson1NodegroupUpdateConfig(output.updateConfig, context)
         : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    version: __expectString(output.version),
   } as any;
 };
 
@@ -5262,10 +5244,7 @@ const deserializeAws_restJson1NodegroupResources = (output: any, context: __Serd
       output.autoScalingGroups !== undefined && output.autoScalingGroups !== null
         ? deserializeAws_restJson1AutoScalingGroupList(output.autoScalingGroups, context)
         : undefined,
-    remoteAccessSecurityGroup:
-      output.remoteAccessSecurityGroup !== undefined && output.remoteAccessSecurityGroup !== null
-        ? output.remoteAccessSecurityGroup
-        : undefined,
+    remoteAccessSecurityGroup: __expectString(output.remoteAccessSecurityGroup),
   } as any;
 };
 
@@ -5274,26 +5253,22 @@ const deserializeAws_restJson1NodegroupScalingConfig = (
   context: __SerdeContext
 ): NodegroupScalingConfig => {
   return {
-    desiredSize: output.desiredSize !== undefined && output.desiredSize !== null ? output.desiredSize : undefined,
-    maxSize: output.maxSize !== undefined && output.maxSize !== null ? output.maxSize : undefined,
-    minSize: output.minSize !== undefined && output.minSize !== null ? output.minSize : undefined,
+    desiredSize: __expectNumber(output.desiredSize),
+    maxSize: __expectNumber(output.maxSize),
+    minSize: __expectNumber(output.minSize),
   } as any;
 };
 
 const deserializeAws_restJson1NodegroupUpdateConfig = (output: any, context: __SerdeContext): NodegroupUpdateConfig => {
   return {
-    maxUnavailable:
-      output.maxUnavailable !== undefined && output.maxUnavailable !== null ? output.maxUnavailable : undefined,
-    maxUnavailablePercentage:
-      output.maxUnavailablePercentage !== undefined && output.maxUnavailablePercentage !== null
-        ? output.maxUnavailablePercentage
-        : undefined,
+    maxUnavailable: __expectNumber(output.maxUnavailable),
+    maxUnavailablePercentage: __expectNumber(output.maxUnavailablePercentage),
   } as any;
 };
 
 const deserializeAws_restJson1OIDC = (output: any, context: __SerdeContext): OIDC => {
   return {
-    issuer: output.issuer !== undefined && output.issuer !== null ? output.issuer : undefined,
+    issuer: __expectString(output.issuer),
   } as any;
 };
 
@@ -5302,44 +5277,36 @@ const deserializeAws_restJson1OidcIdentityProviderConfig = (
   context: __SerdeContext
 ): OidcIdentityProviderConfig => {
   return {
-    clientId: output.clientId !== undefined && output.clientId !== null ? output.clientId : undefined,
-    clusterName: output.clusterName !== undefined && output.clusterName !== null ? output.clusterName : undefined,
-    groupsClaim: output.groupsClaim !== undefined && output.groupsClaim !== null ? output.groupsClaim : undefined,
-    groupsPrefix: output.groupsPrefix !== undefined && output.groupsPrefix !== null ? output.groupsPrefix : undefined,
-    identityProviderConfigArn:
-      output.identityProviderConfigArn !== undefined && output.identityProviderConfigArn !== null
-        ? output.identityProviderConfigArn
-        : undefined,
-    identityProviderConfigName:
-      output.identityProviderConfigName !== undefined && output.identityProviderConfigName !== null
-        ? output.identityProviderConfigName
-        : undefined,
-    issuerUrl: output.issuerUrl !== undefined && output.issuerUrl !== null ? output.issuerUrl : undefined,
+    clientId: __expectString(output.clientId),
+    clusterName: __expectString(output.clusterName),
+    groupsClaim: __expectString(output.groupsClaim),
+    groupsPrefix: __expectString(output.groupsPrefix),
+    identityProviderConfigArn: __expectString(output.identityProviderConfigArn),
+    identityProviderConfigName: __expectString(output.identityProviderConfigName),
+    issuerUrl: __expectString(output.issuerUrl),
     requiredClaims:
       output.requiredClaims !== undefined && output.requiredClaims !== null
         ? deserializeAws_restJson1requiredClaimsMap(output.requiredClaims, context)
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1TagMap(output.tags, context)
         : undefined,
-    usernameClaim:
-      output.usernameClaim !== undefined && output.usernameClaim !== null ? output.usernameClaim : undefined,
-    usernamePrefix:
-      output.usernamePrefix !== undefined && output.usernamePrefix !== null ? output.usernamePrefix : undefined,
+    usernameClaim: __expectString(output.usernameClaim),
+    usernamePrefix: __expectString(output.usernamePrefix),
   } as any;
 };
 
 const deserializeAws_restJson1Provider = (output: any, context: __SerdeContext): Provider => {
   return {
-    keyArn: output.keyArn !== undefined && output.keyArn !== null ? output.keyArn : undefined,
+    keyArn: __expectString(output.keyArn),
   } as any;
 };
 
 const deserializeAws_restJson1RemoteAccessConfig = (output: any, context: __SerdeContext): RemoteAccessConfig => {
   return {
-    ec2SshKey: output.ec2SshKey !== undefined && output.ec2SshKey !== null ? output.ec2SshKey : undefined,
+    ec2SshKey: __expectString(output.ec2SshKey),
     sourceSecurityGroups:
       output.sourceSecurityGroups !== undefined && output.sourceSecurityGroups !== null
         ? deserializeAws_restJson1StringList(output.sourceSecurityGroups, context)
@@ -5354,7 +5321,7 @@ const deserializeAws_restJson1requiredClaimsMap = (output: any, context: __Serde
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -5366,7 +5333,7 @@ const deserializeAws_restJson1StringList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -5377,16 +5344,16 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1Taint = (output: any, context: __SerdeContext): Taint => {
   return {
-    effect: output.effect !== undefined && output.effect !== null ? output.effect : undefined,
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    effect: __expectString(output.effect),
+    key: __expectString(output.key),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -5411,20 +5378,20 @@ const deserializeAws_restJson1Update = (output: any, context: __SerdeContext): U
       output.errors !== undefined && output.errors !== null
         ? deserializeAws_restJson1ErrorDetails(output.errors, context)
         : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    id: __expectString(output.id),
     params:
       output.params !== undefined && output.params !== null
         ? deserializeAws_restJson1UpdateParams(output.params, context)
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    status: __expectString(output.status),
+    type: __expectString(output.type),
   } as any;
 };
 
 const deserializeAws_restJson1UpdateParam = (output: any, context: __SerdeContext): UpdateParam => {
   return {
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    type: __expectString(output.type),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -5441,18 +5408,9 @@ const deserializeAws_restJson1UpdateParams = (output: any, context: __SerdeConte
 
 const deserializeAws_restJson1VpcConfigResponse = (output: any, context: __SerdeContext): VpcConfigResponse => {
   return {
-    clusterSecurityGroupId:
-      output.clusterSecurityGroupId !== undefined && output.clusterSecurityGroupId !== null
-        ? output.clusterSecurityGroupId
-        : undefined,
-    endpointPrivateAccess:
-      output.endpointPrivateAccess !== undefined && output.endpointPrivateAccess !== null
-        ? output.endpointPrivateAccess
-        : undefined,
-    endpointPublicAccess:
-      output.endpointPublicAccess !== undefined && output.endpointPublicAccess !== null
-        ? output.endpointPublicAccess
-        : undefined,
+    clusterSecurityGroupId: __expectString(output.clusterSecurityGroupId),
+    endpointPrivateAccess: __expectBoolean(output.endpointPrivateAccess),
+    endpointPublicAccess: __expectBoolean(output.endpointPublicAccess),
     publicAccessCidrs:
       output.publicAccessCidrs !== undefined && output.publicAccessCidrs !== null
         ? deserializeAws_restJson1StringList(output.publicAccessCidrs, context)
@@ -5465,7 +5423,7 @@ const deserializeAws_restJson1VpcConfigResponse = (output: any, context: __Serde
       output.subnetIds !== undefined && output.subnetIds !== null
         ? deserializeAws_restJson1StringList(output.subnetIds, context)
         : undefined,
-    vpcId: output.vpcId !== undefined && output.vpcId !== null ? output.vpcId : undefined,
+    vpcId: __expectString(output.vpcId),
   } as any;
 };
 

--- a/clients/client-elastic-beanstalk/protocols/Aws_query.ts
+++ b/clients/client-elastic-beanstalk/protocols/Aws_query.ts
@@ -314,6 +314,7 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
@@ -5474,13 +5475,13 @@ const deserializeAws_queryApplicationDescription = (output: any, context: __Serd
     ResourceLifecycleConfig: undefined,
   };
   if (output["ApplicationArn"] !== undefined) {
-    contents.ApplicationArn = output["ApplicationArn"];
+    contents.ApplicationArn = __expectString(output["ApplicationArn"]);
   }
   if (output["ApplicationName"] !== undefined) {
-    contents.ApplicationName = output["ApplicationName"];
+    contents.ApplicationName = __expectString(output["ApplicationName"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output["DateCreated"] !== undefined) {
     contents.DateCreated = new Date(output["DateCreated"]);
@@ -5592,7 +5593,7 @@ const deserializeAws_queryApplicationResourceLifecycleConfig = (
     VersionLifecycleConfig: undefined,
   };
   if (output["ServiceRole"] !== undefined) {
-    contents.ServiceRole = output["ServiceRole"];
+    contents.ServiceRole = __expectString(output["ServiceRole"]);
   }
   if (output["VersionLifecycleConfig"] !== undefined) {
     contents.VersionLifecycleConfig = deserializeAws_queryApplicationVersionLifecycleConfig(
@@ -5612,7 +5613,7 @@ const deserializeAws_queryApplicationResourceLifecycleDescriptionMessage = (
     ResourceLifecycleConfig: undefined,
   };
   if (output["ApplicationName"] !== undefined) {
-    contents.ApplicationName = output["ApplicationName"];
+    contents.ApplicationName = __expectString(output["ApplicationName"]);
   }
   if (output["ResourceLifecycleConfig"] !== undefined) {
     contents.ResourceLifecycleConfig = deserializeAws_queryApplicationResourceLifecycleConfig(
@@ -5640,16 +5641,16 @@ const deserializeAws_queryApplicationVersionDescription = (
     Status: undefined,
   };
   if (output["ApplicationVersionArn"] !== undefined) {
-    contents.ApplicationVersionArn = output["ApplicationVersionArn"];
+    contents.ApplicationVersionArn = __expectString(output["ApplicationVersionArn"]);
   }
   if (output["ApplicationName"] !== undefined) {
-    contents.ApplicationName = output["ApplicationName"];
+    contents.ApplicationName = __expectString(output["ApplicationName"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output["VersionLabel"] !== undefined) {
-    contents.VersionLabel = output["VersionLabel"];
+    contents.VersionLabel = __expectString(output["VersionLabel"]);
   }
   if (output["SourceBuildInformation"] !== undefined) {
     contents.SourceBuildInformation = deserializeAws_querySourceBuildInformation(
@@ -5658,7 +5659,7 @@ const deserializeAws_queryApplicationVersionDescription = (
     );
   }
   if (output["BuildArn"] !== undefined) {
-    contents.BuildArn = output["BuildArn"];
+    contents.BuildArn = __expectString(output["BuildArn"]);
   }
   if (output["SourceBundle"] !== undefined) {
     contents.SourceBundle = deserializeAws_queryS3Location(output["SourceBundle"], context);
@@ -5670,7 +5671,7 @@ const deserializeAws_queryApplicationVersionDescription = (
     contents.DateUpdated = new Date(output["DateUpdated"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   return contents;
 };
@@ -5723,7 +5724,7 @@ const deserializeAws_queryApplicationVersionDescriptionsMessage = (
     );
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -5756,16 +5757,16 @@ const deserializeAws_queryApplyEnvironmentManagedActionResult = (
     Status: undefined,
   };
   if (output["ActionId"] !== undefined) {
-    contents.ActionId = output["ActionId"];
+    contents.ActionId = __expectString(output["ActionId"]);
   }
   if (output["ActionDescription"] !== undefined) {
-    contents.ActionDescription = output["ActionDescription"];
+    contents.ActionDescription = __expectString(output["ActionDescription"]);
   }
   if (output["ActionType"] !== undefined) {
-    contents.ActionType = output["ActionType"];
+    contents.ActionType = __expectString(output["ActionType"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   return contents;
 };
@@ -5775,7 +5776,7 @@ const deserializeAws_queryAutoScalingGroup = (output: any, context: __SerdeConte
     Name: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   return contents;
 };
@@ -5812,7 +5813,7 @@ const deserializeAws_queryAvailableSolutionStackNamesList = (output: any, contex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -5821,7 +5822,7 @@ const deserializeAws_queryBuilder = (output: any, context: __SerdeContext): Buil
     ARN: undefined,
   };
   if (output["ARN"] !== undefined) {
-    contents.ARN = output["ARN"];
+    contents.ARN = __expectString(output["ARN"]);
   }
   return contents;
 };
@@ -5833,7 +5834,7 @@ const deserializeAws_queryCauses = (output: any, context: __SerdeContext): strin
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -5849,7 +5850,7 @@ const deserializeAws_queryCheckDNSAvailabilityResultMessage = (
     contents.Available = __parseBoolean(output["Available"]);
   }
   if (output["FullyQualifiedCNAME"] !== undefined) {
-    contents.FullyQualifiedCNAME = output["FullyQualifiedCNAME"];
+    contents.FullyQualifiedCNAME = __expectString(output["FullyQualifiedCNAME"]);
   }
   return contents;
 };
@@ -5862,7 +5863,7 @@ const deserializeAws_queryCodeBuildNotInServiceRegionException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -5885,22 +5886,22 @@ const deserializeAws_queryConfigurationOptionDescription = (
     Regex: undefined,
   };
   if (output["Namespace"] !== undefined) {
-    contents.Namespace = output["Namespace"];
+    contents.Namespace = __expectString(output["Namespace"]);
   }
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["DefaultValue"] !== undefined) {
-    contents.DefaultValue = output["DefaultValue"];
+    contents.DefaultValue = __expectString(output["DefaultValue"]);
   }
   if (output["ChangeSeverity"] !== undefined) {
-    contents.ChangeSeverity = output["ChangeSeverity"];
+    contents.ChangeSeverity = __expectString(output["ChangeSeverity"]);
   }
   if (output["UserDefined"] !== undefined) {
     contents.UserDefined = __parseBoolean(output["UserDefined"]);
   }
   if (output["ValueType"] !== undefined) {
-    contents.ValueType = output["ValueType"];
+    contents.ValueType = __expectString(output["ValueType"]);
   }
   if (output.ValueOptions === "") {
     contents.ValueOptions = [];
@@ -5947,7 +5948,7 @@ const deserializeAws_queryConfigurationOptionPossibleValues = (output: any, cont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -5961,10 +5962,10 @@ const deserializeAws_queryConfigurationOptionsDescription = (
     Options: undefined,
   };
   if (output["SolutionStackName"] !== undefined) {
-    contents.SolutionStackName = output["SolutionStackName"];
+    contents.SolutionStackName = __expectString(output["SolutionStackName"]);
   }
   if (output["PlatformArn"] !== undefined) {
-    contents.PlatformArn = output["PlatformArn"];
+    contents.PlatformArn = __expectString(output["PlatformArn"]);
   }
   if (output.Options === "") {
     contents.Options = [];
@@ -5989,16 +5990,16 @@ const deserializeAws_queryConfigurationOptionSetting = (
     Value: undefined,
   };
   if (output["ResourceName"] !== undefined) {
-    contents.ResourceName = output["ResourceName"];
+    contents.ResourceName = __expectString(output["ResourceName"]);
   }
   if (output["Namespace"] !== undefined) {
-    contents.Namespace = output["Namespace"];
+    contents.Namespace = __expectString(output["Namespace"]);
   }
   if (output["OptionName"] !== undefined) {
-    contents.OptionName = output["OptionName"];
+    contents.OptionName = __expectString(output["OptionName"]);
   }
   if (output["Value"] !== undefined) {
-    contents.Value = output["Value"];
+    contents.Value = __expectString(output["Value"]);
   }
   return contents;
 };
@@ -6034,25 +6035,25 @@ const deserializeAws_queryConfigurationSettingsDescription = (
     OptionSettings: undefined,
   };
   if (output["SolutionStackName"] !== undefined) {
-    contents.SolutionStackName = output["SolutionStackName"];
+    contents.SolutionStackName = __expectString(output["SolutionStackName"]);
   }
   if (output["PlatformArn"] !== undefined) {
-    contents.PlatformArn = output["PlatformArn"];
+    contents.PlatformArn = __expectString(output["PlatformArn"]);
   }
   if (output["ApplicationName"] !== undefined) {
-    contents.ApplicationName = output["ApplicationName"];
+    contents.ApplicationName = __expectString(output["ApplicationName"]);
   }
   if (output["TemplateName"] !== undefined) {
-    contents.TemplateName = output["TemplateName"];
+    contents.TemplateName = __expectString(output["TemplateName"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output["EnvironmentName"] !== undefined) {
-    contents.EnvironmentName = output["EnvironmentName"];
+    contents.EnvironmentName = __expectString(output["EnvironmentName"]);
   }
   if (output["DeploymentStatus"] !== undefined) {
-    contents.DeploymentStatus = output["DeploymentStatus"];
+    contents.DeploymentStatus = __expectString(output["DeploymentStatus"]);
   }
   if (output["DateCreated"] !== undefined) {
     contents.DateCreated = new Date(output["DateCreated"]);
@@ -6131,7 +6132,7 @@ const deserializeAws_queryConfigurationTemplateNamesList = (output: any, context
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6198,7 +6199,7 @@ const deserializeAws_queryCreateStorageLocationResultMessage = (
     S3Bucket: undefined,
   };
   if (output["S3Bucket"] !== undefined) {
-    contents.S3Bucket = output["S3Bucket"];
+    contents.S3Bucket = __expectString(output["S3Bucket"]);
   }
   return contents;
 };
@@ -6209,10 +6210,10 @@ const deserializeAws_queryCustomAmi = (output: any, context: __SerdeContext): Cu
     ImageId: undefined,
   };
   if (output["VirtualizationType"] !== undefined) {
-    contents.VirtualizationType = output["VirtualizationType"];
+    contents.VirtualizationType = __expectString(output["VirtualizationType"]);
   }
   if (output["ImageId"] !== undefined) {
-    contents.ImageId = output["ImageId"];
+    contents.ImageId = __expectString(output["ImageId"]);
   }
   return contents;
 };
@@ -6249,13 +6250,13 @@ const deserializeAws_queryDeployment = (output: any, context: __SerdeContext): D
     DeploymentTime: undefined,
   };
   if (output["VersionLabel"] !== undefined) {
-    contents.VersionLabel = output["VersionLabel"];
+    contents.VersionLabel = __expectString(output["VersionLabel"]);
   }
   if (output["DeploymentId"] !== undefined) {
     contents.DeploymentId = parseInt(output["DeploymentId"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["DeploymentTime"] !== undefined) {
     contents.DeploymentTime = new Date(output["DeploymentTime"]);
@@ -6291,16 +6292,16 @@ const deserializeAws_queryDescribeEnvironmentHealthResult = (
     RefreshedAt: undefined,
   };
   if (output["EnvironmentName"] !== undefined) {
-    contents.EnvironmentName = output["EnvironmentName"];
+    contents.EnvironmentName = __expectString(output["EnvironmentName"]);
   }
   if (output["HealthStatus"] !== undefined) {
-    contents.HealthStatus = output["HealthStatus"];
+    contents.HealthStatus = __expectString(output["HealthStatus"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["Color"] !== undefined) {
-    contents.Color = output["Color"];
+    contents.Color = __expectString(output["Color"]);
   }
   if (output.Causes === "") {
     contents.Causes = [];
@@ -6341,7 +6342,7 @@ const deserializeAws_queryDescribeEnvironmentManagedActionHistoryResult = (
     );
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -6387,7 +6388,7 @@ const deserializeAws_queryDescribeInstancesHealthResult = (
     contents.RefreshedAt = new Date(output["RefreshedAt"]);
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -6413,7 +6414,7 @@ const deserializeAws_queryElasticBeanstalkServiceException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -6443,34 +6444,34 @@ const deserializeAws_queryEnvironmentDescription = (output: any, context: __Serd
     OperationsRole: undefined,
   };
   if (output["EnvironmentName"] !== undefined) {
-    contents.EnvironmentName = output["EnvironmentName"];
+    contents.EnvironmentName = __expectString(output["EnvironmentName"]);
   }
   if (output["EnvironmentId"] !== undefined) {
-    contents.EnvironmentId = output["EnvironmentId"];
+    contents.EnvironmentId = __expectString(output["EnvironmentId"]);
   }
   if (output["ApplicationName"] !== undefined) {
-    contents.ApplicationName = output["ApplicationName"];
+    contents.ApplicationName = __expectString(output["ApplicationName"]);
   }
   if (output["VersionLabel"] !== undefined) {
-    contents.VersionLabel = output["VersionLabel"];
+    contents.VersionLabel = __expectString(output["VersionLabel"]);
   }
   if (output["SolutionStackName"] !== undefined) {
-    contents.SolutionStackName = output["SolutionStackName"];
+    contents.SolutionStackName = __expectString(output["SolutionStackName"]);
   }
   if (output["PlatformArn"] !== undefined) {
-    contents.PlatformArn = output["PlatformArn"];
+    contents.PlatformArn = __expectString(output["PlatformArn"]);
   }
   if (output["TemplateName"] !== undefined) {
-    contents.TemplateName = output["TemplateName"];
+    contents.TemplateName = __expectString(output["TemplateName"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output["EndpointURL"] !== undefined) {
-    contents.EndpointURL = output["EndpointURL"];
+    contents.EndpointURL = __expectString(output["EndpointURL"]);
   }
   if (output["CNAME"] !== undefined) {
-    contents.CNAME = output["CNAME"];
+    contents.CNAME = __expectString(output["CNAME"]);
   }
   if (output["DateCreated"] !== undefined) {
     contents.DateCreated = new Date(output["DateCreated"]);
@@ -6479,16 +6480,16 @@ const deserializeAws_queryEnvironmentDescription = (output: any, context: __Serd
     contents.DateUpdated = new Date(output["DateUpdated"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["AbortableOperationInProgress"] !== undefined) {
     contents.AbortableOperationInProgress = __parseBoolean(output["AbortableOperationInProgress"]);
   }
   if (output["Health"] !== undefined) {
-    contents.Health = output["Health"];
+    contents.Health = __expectString(output["Health"]);
   }
   if (output["HealthStatus"] !== undefined) {
-    contents.HealthStatus = output["HealthStatus"];
+    contents.HealthStatus = __expectString(output["HealthStatus"]);
   }
   if (output["Resources"] !== undefined) {
     contents.Resources = deserializeAws_queryEnvironmentResourcesDescription(output["Resources"], context);
@@ -6506,10 +6507,10 @@ const deserializeAws_queryEnvironmentDescription = (output: any, context: __Serd
     );
   }
   if (output["EnvironmentArn"] !== undefined) {
-    contents.EnvironmentArn = output["EnvironmentArn"];
+    contents.EnvironmentArn = __expectString(output["EnvironmentArn"]);
   }
   if (output["OperationsRole"] !== undefined) {
-    contents.OperationsRole = output["OperationsRole"];
+    contents.OperationsRole = __expectString(output["OperationsRole"]);
   }
   return contents;
 };
@@ -6546,7 +6547,7 @@ const deserializeAws_queryEnvironmentDescriptionsMessage = (
     );
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -6562,16 +6563,16 @@ const deserializeAws_queryEnvironmentInfoDescription = (
     Message: undefined,
   };
   if (output["InfoType"] !== undefined) {
-    contents.InfoType = output["InfoType"];
+    contents.InfoType = __expectString(output["InfoType"]);
   }
   if (output["Ec2InstanceId"] !== undefined) {
-    contents.Ec2InstanceId = output["Ec2InstanceId"];
+    contents.Ec2InstanceId = __expectString(output["Ec2InstanceId"]);
   }
   if (output["SampleTimestamp"] !== undefined) {
     contents.SampleTimestamp = new Date(output["SampleTimestamp"]);
   }
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -6596,10 +6597,10 @@ const deserializeAws_queryEnvironmentLink = (output: any, context: __SerdeContex
     EnvironmentName: undefined,
   };
   if (output["LinkName"] !== undefined) {
-    contents.LinkName = output["LinkName"];
+    contents.LinkName = __expectString(output["LinkName"]);
   }
   if (output["EnvironmentName"] !== undefined) {
-    contents.EnvironmentName = output["EnvironmentName"];
+    contents.EnvironmentName = __expectString(output["EnvironmentName"]);
   }
   return contents;
 };
@@ -6630,7 +6631,7 @@ const deserializeAws_queryEnvironmentResourceDescription = (
     Queues: undefined,
   };
   if (output["EnvironmentName"] !== undefined) {
-    contents.EnvironmentName = output["EnvironmentName"];
+    contents.EnvironmentName = __expectString(output["EnvironmentName"]);
   }
   if (output.AutoScalingGroups === "") {
     contents.AutoScalingGroups = [];
@@ -6728,13 +6729,13 @@ const deserializeAws_queryEnvironmentTier = (output: any, context: __SerdeContex
     Version: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["Type"] !== undefined) {
-    contents.Type = output["Type"];
+    contents.Type = __expectString(output["Type"]);
   }
   if (output["Version"] !== undefined) {
-    contents.Version = output["Version"];
+    contents.Version = __expectString(output["Version"]);
   }
   return contents;
 };
@@ -6755,28 +6756,28 @@ const deserializeAws_queryEventDescription = (output: any, context: __SerdeConte
     contents.EventDate = new Date(output["EventDate"]);
   }
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   if (output["ApplicationName"] !== undefined) {
-    contents.ApplicationName = output["ApplicationName"];
+    contents.ApplicationName = __expectString(output["ApplicationName"]);
   }
   if (output["VersionLabel"] !== undefined) {
-    contents.VersionLabel = output["VersionLabel"];
+    contents.VersionLabel = __expectString(output["VersionLabel"]);
   }
   if (output["TemplateName"] !== undefined) {
-    contents.TemplateName = output["TemplateName"];
+    contents.TemplateName = __expectString(output["TemplateName"]);
   }
   if (output["EnvironmentName"] !== undefined) {
-    contents.EnvironmentName = output["EnvironmentName"];
+    contents.EnvironmentName = __expectString(output["EnvironmentName"]);
   }
   if (output["PlatformArn"] !== undefined) {
-    contents.PlatformArn = output["PlatformArn"];
+    contents.PlatformArn = __expectString(output["PlatformArn"]);
   }
   if (output["RequestId"] !== undefined) {
-    contents.RequestId = output["RequestId"];
+    contents.RequestId = __expectString(output["RequestId"]);
   }
   if (output["Severity"] !== undefined) {
-    contents.Severity = output["Severity"];
+    contents.Severity = __expectString(output["Severity"]);
   }
   return contents;
 };
@@ -6810,7 +6811,7 @@ const deserializeAws_queryEventDescriptionsMessage = (
     );
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -6820,7 +6821,7 @@ const deserializeAws_queryInstance = (output: any, context: __SerdeContext): Ins
     Id: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   return contents;
 };
@@ -6893,7 +6894,7 @@ const deserializeAws_queryInsufficientPrivilegesException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -6903,7 +6904,7 @@ const deserializeAws_queryInvalidRequestException = (output: any, context: __Ser
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -6951,7 +6952,7 @@ const deserializeAws_queryLaunchConfiguration = (output: any, context: __SerdeCo
     Name: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   return contents;
 };
@@ -6972,7 +6973,7 @@ const deserializeAws_queryLaunchTemplate = (output: any, context: __SerdeContext
     Id: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   return contents;
 };
@@ -7023,7 +7024,7 @@ const deserializeAws_queryListener = (output: any, context: __SerdeContext): Lis
     Port: undefined,
   };
   if (output["Protocol"] !== undefined) {
-    contents.Protocol = output["Protocol"];
+    contents.Protocol = __expectString(output["Protocol"]);
   }
   if (output["Port"] !== undefined) {
     contents.Port = parseInt(output["Port"]);
@@ -7052,7 +7053,7 @@ const deserializeAws_queryListPlatformBranchesResult = (
     );
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -7075,7 +7076,7 @@ const deserializeAws_queryListPlatformVersionsResult = (
     );
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -7096,7 +7097,7 @@ const deserializeAws_queryLoadBalancer = (output: any, context: __SerdeContext):
     Name: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   return contents;
 };
@@ -7108,10 +7109,10 @@ const deserializeAws_queryLoadBalancerDescription = (output: any, context: __Ser
     Listeners: undefined,
   };
   if (output["LoadBalancerName"] !== undefined) {
-    contents.LoadBalancerName = output["LoadBalancerName"];
+    contents.LoadBalancerName = __expectString(output["LoadBalancerName"]);
   }
   if (output["Domain"] !== undefined) {
-    contents.Domain = output["Domain"];
+    contents.Domain = __expectString(output["Domain"]);
   }
   if (output.Listeners === "") {
     contents.Listeners = [];
@@ -7156,16 +7157,16 @@ const deserializeAws_queryManagedAction = (output: any, context: __SerdeContext)
     WindowStartTime: undefined,
   };
   if (output["ActionId"] !== undefined) {
-    contents.ActionId = output["ActionId"];
+    contents.ActionId = __expectString(output["ActionId"]);
   }
   if (output["ActionDescription"] !== undefined) {
-    contents.ActionDescription = output["ActionDescription"];
+    contents.ActionDescription = __expectString(output["ActionDescription"]);
   }
   if (output["ActionType"] !== undefined) {
-    contents.ActionType = output["ActionType"];
+    contents.ActionType = __expectString(output["ActionType"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["WindowStartTime"] !== undefined) {
     contents.WindowStartTime = new Date(output["WindowStartTime"]);
@@ -7188,22 +7189,22 @@ const deserializeAws_queryManagedActionHistoryItem = (
     FinishedTime: undefined,
   };
   if (output["ActionId"] !== undefined) {
-    contents.ActionId = output["ActionId"];
+    contents.ActionId = __expectString(output["ActionId"]);
   }
   if (output["ActionType"] !== undefined) {
-    contents.ActionType = output["ActionType"];
+    contents.ActionType = __expectString(output["ActionType"]);
   }
   if (output["ActionDescription"] !== undefined) {
-    contents.ActionDescription = output["ActionDescription"];
+    contents.ActionDescription = __expectString(output["ActionDescription"]);
   }
   if (output["FailureType"] !== undefined) {
-    contents.FailureType = output["FailureType"];
+    contents.FailureType = __expectString(output["FailureType"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["FailureDescription"] !== undefined) {
-    contents.FailureDescription = output["FailureDescription"];
+    contents.FailureDescription = __expectString(output["FailureDescription"]);
   }
   if (output["ExecutedTime"] !== undefined) {
     contents.ExecutedTime = new Date(output["ExecutedTime"]);
@@ -7236,7 +7237,7 @@ const deserializeAws_queryManagedActionInvalidStateException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -7296,7 +7297,7 @@ const deserializeAws_queryOperationInProgressException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -7307,10 +7308,10 @@ const deserializeAws_queryOptionRestrictionRegex = (output: any, context: __Serd
     Label: undefined,
   };
   if (output["Pattern"] !== undefined) {
-    contents.Pattern = output["Pattern"];
+    contents.Pattern = __expectString(output["Pattern"]);
   }
   if (output["Label"] !== undefined) {
-    contents.Label = output["Label"];
+    contents.Label = __expectString(output["Label"]);
   }
   return contents;
 };
@@ -7324,13 +7325,13 @@ const deserializeAws_queryPlatformBranchSummary = (output: any, context: __Serde
     SupportedTierList: undefined,
   };
   if (output["PlatformName"] !== undefined) {
-    contents.PlatformName = output["PlatformName"];
+    contents.PlatformName = __expectString(output["PlatformName"]);
   }
   if (output["BranchName"] !== undefined) {
-    contents.BranchName = output["BranchName"];
+    contents.BranchName = __expectString(output["BranchName"]);
   }
   if (output["LifecycleState"] !== undefined) {
-    contents.LifecycleState = output["LifecycleState"];
+    contents.LifecycleState = __expectString(output["LifecycleState"]);
   }
   if (output["BranchOrder"] !== undefined) {
     contents.BranchOrder = parseInt(output["BranchOrder"]);
@@ -7386,22 +7387,22 @@ const deserializeAws_queryPlatformDescription = (output: any, context: __SerdeCo
     PlatformBranchLifecycleState: undefined,
   };
   if (output["PlatformArn"] !== undefined) {
-    contents.PlatformArn = output["PlatformArn"];
+    contents.PlatformArn = __expectString(output["PlatformArn"]);
   }
   if (output["PlatformOwner"] !== undefined) {
-    contents.PlatformOwner = output["PlatformOwner"];
+    contents.PlatformOwner = __expectString(output["PlatformOwner"]);
   }
   if (output["PlatformName"] !== undefined) {
-    contents.PlatformName = output["PlatformName"];
+    contents.PlatformName = __expectString(output["PlatformName"]);
   }
   if (output["PlatformVersion"] !== undefined) {
-    contents.PlatformVersion = output["PlatformVersion"];
+    contents.PlatformVersion = __expectString(output["PlatformVersion"]);
   }
   if (output["SolutionStackName"] !== undefined) {
-    contents.SolutionStackName = output["SolutionStackName"];
+    contents.SolutionStackName = __expectString(output["SolutionStackName"]);
   }
   if (output["PlatformStatus"] !== undefined) {
-    contents.PlatformStatus = output["PlatformStatus"];
+    contents.PlatformStatus = __expectString(output["PlatformStatus"]);
   }
   if (output["DateCreated"] !== undefined) {
     contents.DateCreated = new Date(output["DateCreated"]);
@@ -7410,19 +7411,19 @@ const deserializeAws_queryPlatformDescription = (output: any, context: __SerdeCo
     contents.DateUpdated = new Date(output["DateUpdated"]);
   }
   if (output["PlatformCategory"] !== undefined) {
-    contents.PlatformCategory = output["PlatformCategory"];
+    contents.PlatformCategory = __expectString(output["PlatformCategory"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output["Maintainer"] !== undefined) {
-    contents.Maintainer = output["Maintainer"];
+    contents.Maintainer = __expectString(output["Maintainer"]);
   }
   if (output["OperatingSystemName"] !== undefined) {
-    contents.OperatingSystemName = output["OperatingSystemName"];
+    contents.OperatingSystemName = __expectString(output["OperatingSystemName"]);
   }
   if (output["OperatingSystemVersion"] !== undefined) {
-    contents.OperatingSystemVersion = output["OperatingSystemVersion"];
+    contents.OperatingSystemVersion = __expectString(output["OperatingSystemVersion"]);
   }
   if (output.ProgrammingLanguages === "") {
     contents.ProgrammingLanguages = [];
@@ -7470,13 +7471,13 @@ const deserializeAws_queryPlatformDescription = (output: any, context: __SerdeCo
     );
   }
   if (output["PlatformLifecycleState"] !== undefined) {
-    contents.PlatformLifecycleState = output["PlatformLifecycleState"];
+    contents.PlatformLifecycleState = __expectString(output["PlatformLifecycleState"]);
   }
   if (output["PlatformBranchName"] !== undefined) {
-    contents.PlatformBranchName = output["PlatformBranchName"];
+    contents.PlatformBranchName = __expectString(output["PlatformBranchName"]);
   }
   if (output["PlatformBranchLifecycleState"] !== undefined) {
-    contents.PlatformBranchLifecycleState = output["PlatformBranchLifecycleState"];
+    contents.PlatformBranchLifecycleState = __expectString(output["PlatformBranchLifecycleState"]);
   }
   return contents;
 };
@@ -7487,10 +7488,10 @@ const deserializeAws_queryPlatformFramework = (output: any, context: __SerdeCont
     Version: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["Version"] !== undefined) {
-    contents.Version = output["Version"];
+    contents.Version = __expectString(output["Version"]);
   }
   return contents;
 };
@@ -7515,10 +7516,10 @@ const deserializeAws_queryPlatformProgrammingLanguage = (
     Version: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["Version"] !== undefined) {
-    contents.Version = output["Version"];
+    contents.Version = __expectString(output["Version"]);
   }
   return contents;
 };
@@ -7553,22 +7554,22 @@ const deserializeAws_queryPlatformSummary = (output: any, context: __SerdeContex
     PlatformBranchLifecycleState: undefined,
   };
   if (output["PlatformArn"] !== undefined) {
-    contents.PlatformArn = output["PlatformArn"];
+    contents.PlatformArn = __expectString(output["PlatformArn"]);
   }
   if (output["PlatformOwner"] !== undefined) {
-    contents.PlatformOwner = output["PlatformOwner"];
+    contents.PlatformOwner = __expectString(output["PlatformOwner"]);
   }
   if (output["PlatformStatus"] !== undefined) {
-    contents.PlatformStatus = output["PlatformStatus"];
+    contents.PlatformStatus = __expectString(output["PlatformStatus"]);
   }
   if (output["PlatformCategory"] !== undefined) {
-    contents.PlatformCategory = output["PlatformCategory"];
+    contents.PlatformCategory = __expectString(output["PlatformCategory"]);
   }
   if (output["OperatingSystemName"] !== undefined) {
-    contents.OperatingSystemName = output["OperatingSystemName"];
+    contents.OperatingSystemName = __expectString(output["OperatingSystemName"]);
   }
   if (output["OperatingSystemVersion"] !== undefined) {
-    contents.OperatingSystemVersion = output["OperatingSystemVersion"];
+    contents.OperatingSystemVersion = __expectString(output["OperatingSystemVersion"]);
   }
   if (output.SupportedTierList === "") {
     contents.SupportedTierList = [];
@@ -7589,16 +7590,16 @@ const deserializeAws_queryPlatformSummary = (output: any, context: __SerdeContex
     );
   }
   if (output["PlatformLifecycleState"] !== undefined) {
-    contents.PlatformLifecycleState = output["PlatformLifecycleState"];
+    contents.PlatformLifecycleState = __expectString(output["PlatformLifecycleState"]);
   }
   if (output["PlatformVersion"] !== undefined) {
-    contents.PlatformVersion = output["PlatformVersion"];
+    contents.PlatformVersion = __expectString(output["PlatformVersion"]);
   }
   if (output["PlatformBranchName"] !== undefined) {
-    contents.PlatformBranchName = output["PlatformBranchName"];
+    contents.PlatformBranchName = __expectString(output["PlatformBranchName"]);
   }
   if (output["PlatformBranchLifecycleState"] !== undefined) {
-    contents.PlatformBranchLifecycleState = output["PlatformBranchLifecycleState"];
+    contents.PlatformBranchLifecycleState = __expectString(output["PlatformBranchLifecycleState"]);
   }
   return contents;
 };
@@ -7622,7 +7623,7 @@ const deserializeAws_queryPlatformVersionStillReferencedException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -7633,10 +7634,10 @@ const deserializeAws_queryQueue = (output: any, context: __SerdeContext): Queue 
     URL: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["URL"] !== undefined) {
-    contents.URL = output["URL"];
+    contents.URL = __expectString(output["URL"]);
   }
   return contents;
 };
@@ -7660,7 +7661,7 @@ const deserializeAws_queryResourceNotFoundException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -7713,7 +7714,7 @@ const deserializeAws_queryResourceTagsDescriptionMessage = (
     ResourceTags: undefined,
   };
   if (output["ResourceArn"] !== undefined) {
-    contents.ResourceArn = output["ResourceArn"];
+    contents.ResourceArn = __expectString(output["ResourceArn"]);
   }
   if (output.ResourceTags === "") {
     contents.ResourceTags = [];
@@ -7735,7 +7736,7 @@ const deserializeAws_queryResourceTypeNotSupportedException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -7765,10 +7766,10 @@ const deserializeAws_queryS3Location = (output: any, context: __SerdeContext): S
     S3Key: undefined,
   };
   if (output["S3Bucket"] !== undefined) {
-    contents.S3Bucket = output["S3Bucket"];
+    contents.S3Bucket = __expectString(output["S3Bucket"]);
   }
   if (output["S3Key"] !== undefined) {
-    contents.S3Key = output["S3Key"];
+    contents.S3Key = __expectString(output["S3Key"]);
   }
   return contents;
 };
@@ -7781,7 +7782,7 @@ const deserializeAws_queryS3LocationNotInServiceRegionException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -7794,7 +7795,7 @@ const deserializeAws_queryS3SubscriptionRequiredException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -7813,13 +7814,13 @@ const deserializeAws_querySingleInstanceHealth = (output: any, context: __SerdeC
     InstanceType: undefined,
   };
   if (output["InstanceId"] !== undefined) {
-    contents.InstanceId = output["InstanceId"];
+    contents.InstanceId = __expectString(output["InstanceId"]);
   }
   if (output["HealthStatus"] !== undefined) {
-    contents.HealthStatus = output["HealthStatus"];
+    contents.HealthStatus = __expectString(output["HealthStatus"]);
   }
   if (output["Color"] !== undefined) {
-    contents.Color = output["Color"];
+    contents.Color = __expectString(output["Color"]);
   }
   if (output.Causes === "") {
     contents.Causes = [];
@@ -7840,10 +7841,10 @@ const deserializeAws_querySingleInstanceHealth = (output: any, context: __SerdeC
     contents.Deployment = deserializeAws_queryDeployment(output["Deployment"], context);
   }
   if (output["AvailabilityZone"] !== undefined) {
-    contents.AvailabilityZone = output["AvailabilityZone"];
+    contents.AvailabilityZone = __expectString(output["AvailabilityZone"]);
   }
   if (output["InstanceType"] !== undefined) {
-    contents.InstanceType = output["InstanceType"];
+    contents.InstanceType = __expectString(output["InstanceType"]);
   }
   return contents;
 };
@@ -7857,7 +7858,7 @@ const deserializeAws_querySolutionStackDescription = (
     PermittedFileTypes: undefined,
   };
   if (output["SolutionStackName"] !== undefined) {
-    contents.SolutionStackName = output["SolutionStackName"];
+    contents.SolutionStackName = __expectString(output["SolutionStackName"]);
   }
   if (output.PermittedFileTypes === "") {
     contents.PermittedFileTypes = [];
@@ -7878,7 +7879,7 @@ const deserializeAws_querySolutionStackFileTypeList = (output: any, context: __S
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7889,13 +7890,13 @@ const deserializeAws_querySourceBuildInformation = (output: any, context: __Serd
     SourceLocation: undefined,
   };
   if (output["SourceType"] !== undefined) {
-    contents.SourceType = output["SourceType"];
+    contents.SourceType = __expectString(output["SourceType"]);
   }
   if (output["SourceRepository"] !== undefined) {
-    contents.SourceRepository = output["SourceRepository"];
+    contents.SourceRepository = __expectString(output["SourceRepository"]);
   }
   if (output["SourceLocation"] !== undefined) {
-    contents.SourceLocation = output["SourceLocation"];
+    contents.SourceLocation = __expectString(output["SourceLocation"]);
   }
   return contents;
 };
@@ -7908,7 +7909,7 @@ const deserializeAws_querySourceBundleDeletionException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -7942,7 +7943,7 @@ const deserializeAws_querySupportedAddonList = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7953,7 +7954,7 @@ const deserializeAws_querySupportedTierList = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7983,10 +7984,10 @@ const deserializeAws_queryTag = (output: any, context: __SerdeContext): Tag => {
     Value: undefined,
   };
   if (output["Key"] !== undefined) {
-    contents.Key = output["Key"];
+    contents.Key = __expectString(output["Key"]);
   }
   if (output["Value"] !== undefined) {
-    contents.Value = output["Value"];
+    contents.Value = __expectString(output["Value"]);
   }
   return contents;
 };
@@ -8010,7 +8011,7 @@ const deserializeAws_queryTooManyApplicationsException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -8023,7 +8024,7 @@ const deserializeAws_queryTooManyApplicationVersionsException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -8033,7 +8034,7 @@ const deserializeAws_queryTooManyBucketsException = (output: any, context: __Ser
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -8046,7 +8047,7 @@ const deserializeAws_queryTooManyConfigurationTemplatesException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -8059,7 +8060,7 @@ const deserializeAws_queryTooManyEnvironmentsException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -8072,7 +8073,7 @@ const deserializeAws_queryTooManyPlatformsException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -8082,7 +8083,7 @@ const deserializeAws_queryTooManyTagsException = (output: any, context: __SerdeC
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -8092,7 +8093,7 @@ const deserializeAws_queryTrigger = (output: any, context: __SerdeContext): Trig
     Name: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   return contents;
 };
@@ -8116,16 +8117,16 @@ const deserializeAws_queryValidationMessage = (output: any, context: __SerdeCont
     OptionName: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   if (output["Severity"] !== undefined) {
-    contents.Severity = output["Severity"];
+    contents.Severity = __expectString(output["Severity"]);
   }
   if (output["Namespace"] !== undefined) {
-    contents.Namespace = output["Namespace"];
+    contents.Namespace = __expectString(output["Namespace"]);
   }
   if (output["OptionName"] !== undefined) {
-    contents.OptionName = output["OptionName"];
+    contents.OptionName = __expectString(output["OptionName"]);
   }
   return contents;
 };
@@ -8148,7 +8149,7 @@ const deserializeAws_queryVersionLabelsList = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 

--- a/clients/client-elastic-inference/protocols/Aws_restJson1.ts
+++ b/clients/client-elastic-inference/protocols/Aws_restJson1.ts
@@ -31,6 +31,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -305,7 +307,7 @@ export const deserializeAws_restJson1DescribeAcceleratorsCommand = async (
     contents.acceleratorSet = deserializeAws_restJson1ElasticInferenceAcceleratorSet(data.acceleratorSet, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -635,7 +637,7 @@ const deserializeAws_restJson1BadRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -652,7 +654,7 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -669,7 +671,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -740,10 +742,7 @@ const serializeAws_restJson1ValueStringList = (input: string[], context: __Serde
 
 const deserializeAws_restJson1AcceleratorType = (output: any, context: __SerdeContext): AcceleratorType => {
   return {
-    acceleratorTypeName:
-      output.acceleratorTypeName !== undefined && output.acceleratorTypeName !== null
-        ? output.acceleratorTypeName
-        : undefined,
+    acceleratorTypeName: __expectString(output.acceleratorTypeName),
     memoryInfo:
       output.memoryInfo !== undefined && output.memoryInfo !== null
         ? deserializeAws_restJson1MemoryInfo(output.memoryInfo, context)
@@ -771,10 +770,9 @@ const deserializeAws_restJson1AcceleratorTypeOffering = (
   context: __SerdeContext
 ): AcceleratorTypeOffering => {
   return {
-    acceleratorType:
-      output.acceleratorType !== undefined && output.acceleratorType !== null ? output.acceleratorType : undefined,
-    location: output.location !== undefined && output.location !== null ? output.location : undefined,
-    locationType: output.locationType !== undefined && output.locationType !== null ? output.locationType : undefined,
+    acceleratorType: __expectString(output.acceleratorType),
+    location: __expectString(output.location),
+    locationType: __expectString(output.locationType),
   } as any;
 };
 
@@ -801,14 +799,10 @@ const deserializeAws_restJson1ElasticInferenceAccelerator = (
       output.acceleratorHealth !== undefined && output.acceleratorHealth !== null
         ? deserializeAws_restJson1ElasticInferenceAcceleratorHealth(output.acceleratorHealth, context)
         : undefined,
-    acceleratorId:
-      output.acceleratorId !== undefined && output.acceleratorId !== null ? output.acceleratorId : undefined,
-    acceleratorType:
-      output.acceleratorType !== undefined && output.acceleratorType !== null ? output.acceleratorType : undefined,
-    attachedResource:
-      output.attachedResource !== undefined && output.attachedResource !== null ? output.attachedResource : undefined,
-    availabilityZone:
-      output.availabilityZone !== undefined && output.availabilityZone !== null ? output.availabilityZone : undefined,
+    acceleratorId: __expectString(output.acceleratorId),
+    acceleratorType: __expectString(output.acceleratorType),
+    attachedResource: __expectString(output.attachedResource),
+    availabilityZone: __expectString(output.availabilityZone),
   } as any;
 };
 
@@ -817,7 +811,7 @@ const deserializeAws_restJson1ElasticInferenceAcceleratorHealth = (
   context: __SerdeContext
 ): ElasticInferenceAcceleratorHealth => {
   return {
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -837,14 +831,14 @@ const deserializeAws_restJson1ElasticInferenceAcceleratorSet = (
 
 const deserializeAws_restJson1KeyValuePair = (output: any, context: __SerdeContext): KeyValuePair => {
   return {
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    key: __expectString(output.key),
+    value: __expectNumber(output.value),
   } as any;
 };
 
 const deserializeAws_restJson1MemoryInfo = (output: any, context: __SerdeContext): MemoryInfo => {
   return {
-    sizeInMiB: output.sizeInMiB !== undefined && output.sizeInMiB !== null ? output.sizeInMiB : undefined,
+    sizeInMiB: __expectNumber(output.sizeInMiB),
   } as any;
 };
 
@@ -855,7 +849,7 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };

--- a/clients/client-elastic-load-balancing-v2/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing-v2/protocols/Aws_query.ts
@@ -215,6 +215,7 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
@@ -5656,10 +5657,10 @@ const deserializeAws_queryAction = (output: any, context: __SerdeContext): Actio
     ForwardConfig: undefined,
   };
   if (output["Type"] !== undefined) {
-    contents.Type = output["Type"];
+    contents.Type = __expectString(output["Type"]);
   }
   if (output["TargetGroupArn"] !== undefined) {
-    contents.TargetGroupArn = output["TargetGroupArn"];
+    contents.TargetGroupArn = __expectString(output["TargetGroupArn"]);
   }
   if (output["AuthenticateOidcConfig"] !== undefined) {
     contents.AuthenticateOidcConfig = deserializeAws_queryAuthenticateOidcActionConfig(
@@ -5734,7 +5735,7 @@ const deserializeAws_queryAllocationIdNotFoundException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -5746,7 +5747,7 @@ const deserializeAws_queryAlpnPolicyName = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -5758,7 +5759,7 @@ const deserializeAws_queryALPNPolicyNotSupportedException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -5773,7 +5774,7 @@ const deserializeAws_queryAuthenticateCognitoActionAuthenticationRequestExtraPar
     }
     return {
       ...acc,
-      [pair["key"]]: pair["value"],
+      [pair["key"]]: __expectString(pair["value"]) as any,
     };
   }, {});
 };
@@ -5793,19 +5794,19 @@ const deserializeAws_queryAuthenticateCognitoActionConfig = (
     OnUnauthenticatedRequest: undefined,
   };
   if (output["UserPoolArn"] !== undefined) {
-    contents.UserPoolArn = output["UserPoolArn"];
+    contents.UserPoolArn = __expectString(output["UserPoolArn"]);
   }
   if (output["UserPoolClientId"] !== undefined) {
-    contents.UserPoolClientId = output["UserPoolClientId"];
+    contents.UserPoolClientId = __expectString(output["UserPoolClientId"]);
   }
   if (output["UserPoolDomain"] !== undefined) {
-    contents.UserPoolDomain = output["UserPoolDomain"];
+    contents.UserPoolDomain = __expectString(output["UserPoolDomain"]);
   }
   if (output["SessionCookieName"] !== undefined) {
-    contents.SessionCookieName = output["SessionCookieName"];
+    contents.SessionCookieName = __expectString(output["SessionCookieName"]);
   }
   if (output["Scope"] !== undefined) {
-    contents.Scope = output["Scope"];
+    contents.Scope = __expectString(output["Scope"]);
   }
   if (output["SessionTimeout"] !== undefined) {
     contents.SessionTimeout = parseInt(output["SessionTimeout"]);
@@ -5824,7 +5825,7 @@ const deserializeAws_queryAuthenticateCognitoActionConfig = (
       );
   }
   if (output["OnUnauthenticatedRequest"] !== undefined) {
-    contents.OnUnauthenticatedRequest = output["OnUnauthenticatedRequest"];
+    contents.OnUnauthenticatedRequest = __expectString(output["OnUnauthenticatedRequest"]);
   }
   return contents;
 };
@@ -5839,7 +5840,7 @@ const deserializeAws_queryAuthenticateOidcActionAuthenticationRequestExtraParams
     }
     return {
       ...acc,
-      [pair["key"]]: pair["value"],
+      [pair["key"]]: __expectString(pair["value"]) as any,
     };
   }, {});
 };
@@ -5863,28 +5864,28 @@ const deserializeAws_queryAuthenticateOidcActionConfig = (
     UseExistingClientSecret: undefined,
   };
   if (output["Issuer"] !== undefined) {
-    contents.Issuer = output["Issuer"];
+    contents.Issuer = __expectString(output["Issuer"]);
   }
   if (output["AuthorizationEndpoint"] !== undefined) {
-    contents.AuthorizationEndpoint = output["AuthorizationEndpoint"];
+    contents.AuthorizationEndpoint = __expectString(output["AuthorizationEndpoint"]);
   }
   if (output["TokenEndpoint"] !== undefined) {
-    contents.TokenEndpoint = output["TokenEndpoint"];
+    contents.TokenEndpoint = __expectString(output["TokenEndpoint"]);
   }
   if (output["UserInfoEndpoint"] !== undefined) {
-    contents.UserInfoEndpoint = output["UserInfoEndpoint"];
+    contents.UserInfoEndpoint = __expectString(output["UserInfoEndpoint"]);
   }
   if (output["ClientId"] !== undefined) {
-    contents.ClientId = output["ClientId"];
+    contents.ClientId = __expectString(output["ClientId"]);
   }
   if (output["ClientSecret"] !== undefined) {
-    contents.ClientSecret = output["ClientSecret"];
+    contents.ClientSecret = __expectString(output["ClientSecret"]);
   }
   if (output["SessionCookieName"] !== undefined) {
-    contents.SessionCookieName = output["SessionCookieName"];
+    contents.SessionCookieName = __expectString(output["SessionCookieName"]);
   }
   if (output["Scope"] !== undefined) {
-    contents.Scope = output["Scope"];
+    contents.Scope = __expectString(output["Scope"]);
   }
   if (output["SessionTimeout"] !== undefined) {
     contents.SessionTimeout = parseInt(output["SessionTimeout"]);
@@ -5903,7 +5904,7 @@ const deserializeAws_queryAuthenticateOidcActionConfig = (
       );
   }
   if (output["OnUnauthenticatedRequest"] !== undefined) {
-    contents.OnUnauthenticatedRequest = output["OnUnauthenticatedRequest"];
+    contents.OnUnauthenticatedRequest = __expectString(output["OnUnauthenticatedRequest"]);
   }
   if (output["UseExistingClientSecret"] !== undefined) {
     contents.UseExistingClientSecret = __parseBoolean(output["UseExistingClientSecret"]);
@@ -5919,13 +5920,13 @@ const deserializeAws_queryAvailabilityZone = (output: any, context: __SerdeConte
     LoadBalancerAddresses: undefined,
   };
   if (output["ZoneName"] !== undefined) {
-    contents.ZoneName = output["ZoneName"];
+    contents.ZoneName = __expectString(output["ZoneName"]);
   }
   if (output["SubnetId"] !== undefined) {
-    contents.SubnetId = output["SubnetId"];
+    contents.SubnetId = __expectString(output["SubnetId"]);
   }
   if (output["OutpostId"] !== undefined) {
-    contents.OutpostId = output["OutpostId"];
+    contents.OutpostId = __expectString(output["OutpostId"]);
   }
   if (output.LoadBalancerAddresses === "") {
     contents.LoadBalancerAddresses = [];
@@ -5947,7 +5948,7 @@ const deserializeAws_queryAvailabilityZoneNotSupportedException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -5969,7 +5970,7 @@ const deserializeAws_queryCertificate = (output: any, context: __SerdeContext): 
     IsDefault: undefined,
   };
   if (output["CertificateArn"] !== undefined) {
-    contents.CertificateArn = output["CertificateArn"];
+    contents.CertificateArn = __expectString(output["CertificateArn"]);
   }
   if (output["IsDefault"] !== undefined) {
     contents.IsDefault = __parseBoolean(output["IsDefault"]);
@@ -5996,7 +5997,7 @@ const deserializeAws_queryCertificateNotFoundException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -6007,7 +6008,7 @@ const deserializeAws_queryCipher = (output: any, context: __SerdeContext): Ciphe
     Priority: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["Priority"] !== undefined) {
     contents.Priority = parseInt(output["Priority"]);
@@ -6130,7 +6131,7 @@ const deserializeAws_queryDescribeAccountLimitsOutput = (
     contents.Limits = deserializeAws_queryLimits(__getArrayIfSingleItem(output["Limits"]["member"]), context);
   }
   if (output["NextMarker"] !== undefined) {
-    contents.NextMarker = output["NextMarker"];
+    contents.NextMarker = __expectString(output["NextMarker"]);
   }
   return contents;
 };
@@ -6153,7 +6154,7 @@ const deserializeAws_queryDescribeListenerCertificatesOutput = (
     );
   }
   if (output["NextMarker"] !== undefined) {
-    contents.NextMarker = output["NextMarker"];
+    contents.NextMarker = __expectString(output["NextMarker"]);
   }
   return contents;
 };
@@ -6170,7 +6171,7 @@ const deserializeAws_queryDescribeListenersOutput = (output: any, context: __Ser
     contents.Listeners = deserializeAws_queryListeners(__getArrayIfSingleItem(output["Listeners"]["member"]), context);
   }
   if (output["NextMarker"] !== undefined) {
-    contents.NextMarker = output["NextMarker"];
+    contents.NextMarker = __expectString(output["NextMarker"]);
   }
   return contents;
 };
@@ -6212,7 +6213,7 @@ const deserializeAws_queryDescribeLoadBalancersOutput = (
     );
   }
   if (output["NextMarker"] !== undefined) {
-    contents.NextMarker = output["NextMarker"];
+    contents.NextMarker = __expectString(output["NextMarker"]);
   }
   return contents;
 };
@@ -6229,7 +6230,7 @@ const deserializeAws_queryDescribeRulesOutput = (output: any, context: __SerdeCo
     contents.Rules = deserializeAws_queryRules(__getArrayIfSingleItem(output["Rules"]["member"]), context);
   }
   if (output["NextMarker"] !== undefined) {
-    contents.NextMarker = output["NextMarker"];
+    contents.NextMarker = __expectString(output["NextMarker"]);
   }
   return contents;
 };
@@ -6252,7 +6253,7 @@ const deserializeAws_queryDescribeSSLPoliciesOutput = (
     );
   }
   if (output["NextMarker"] !== undefined) {
-    contents.NextMarker = output["NextMarker"];
+    contents.NextMarker = __expectString(output["NextMarker"]);
   }
   return contents;
 };
@@ -6310,7 +6311,7 @@ const deserializeAws_queryDescribeTargetGroupsOutput = (
     );
   }
   if (output["NextMarker"] !== undefined) {
-    contents.NextMarker = output["NextMarker"];
+    contents.NextMarker = __expectString(output["NextMarker"]);
   }
   return contents;
 };
@@ -6342,7 +6343,7 @@ const deserializeAws_queryDuplicateListenerException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -6355,7 +6356,7 @@ const deserializeAws_queryDuplicateLoadBalancerNameException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -6368,7 +6369,7 @@ const deserializeAws_queryDuplicateTagKeysException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -6381,7 +6382,7 @@ const deserializeAws_queryDuplicateTargetGroupNameException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -6396,13 +6397,13 @@ const deserializeAws_queryFixedResponseActionConfig = (
     ContentType: undefined,
   };
   if (output["MessageBody"] !== undefined) {
-    contents.MessageBody = output["MessageBody"];
+    contents.MessageBody = __expectString(output["MessageBody"]);
   }
   if (output["StatusCode"] !== undefined) {
-    contents.StatusCode = output["StatusCode"];
+    contents.StatusCode = __expectString(output["StatusCode"]);
   }
   if (output["ContentType"] !== undefined) {
-    contents.ContentType = output["ContentType"];
+    contents.ContentType = __expectString(output["ContentType"]);
   }
   return contents;
 };
@@ -6438,7 +6439,7 @@ const deserializeAws_queryHealthUnavailableException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -6468,7 +6469,7 @@ const deserializeAws_queryHttpHeaderConditionConfig = (
     Values: undefined,
   };
   if (output["HttpHeaderName"] !== undefined) {
-    contents.HttpHeaderName = output["HttpHeaderName"];
+    contents.HttpHeaderName = __expectString(output["HttpHeaderName"]);
   }
   if (output.Values === "") {
     contents.Values = [];
@@ -6503,7 +6504,7 @@ const deserializeAws_queryIncompatibleProtocolsException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -6516,7 +6517,7 @@ const deserializeAws_queryInvalidConfigurationRequestException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -6529,7 +6530,7 @@ const deserializeAws_queryInvalidLoadBalancerActionException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -6539,7 +6540,7 @@ const deserializeAws_queryInvalidSchemeException = (output: any, context: __Serd
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -6552,7 +6553,7 @@ const deserializeAws_queryInvalidSecurityGroupException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -6562,7 +6563,7 @@ const deserializeAws_queryInvalidSubnetException = (output: any, context: __Serd
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -6572,7 +6573,7 @@ const deserializeAws_queryInvalidTargetException = (output: any, context: __Serd
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -6583,10 +6584,10 @@ const deserializeAws_queryLimit = (output: any, context: __SerdeContext): Limit 
     Max: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["Max"] !== undefined) {
-    contents.Max = output["Max"];
+    contents.Max = __expectString(output["Max"]);
   }
   return contents;
 };
@@ -6614,16 +6615,16 @@ const deserializeAws_queryListener = (output: any, context: __SerdeContext): Lis
     AlpnPolicy: undefined,
   };
   if (output["ListenerArn"] !== undefined) {
-    contents.ListenerArn = output["ListenerArn"];
+    contents.ListenerArn = __expectString(output["ListenerArn"]);
   }
   if (output["LoadBalancerArn"] !== undefined) {
-    contents.LoadBalancerArn = output["LoadBalancerArn"];
+    contents.LoadBalancerArn = __expectString(output["LoadBalancerArn"]);
   }
   if (output["Port"] !== undefined) {
     contents.Port = parseInt(output["Port"]);
   }
   if (output["Protocol"] !== undefined) {
-    contents.Protocol = output["Protocol"];
+    contents.Protocol = __expectString(output["Protocol"]);
   }
   if (output.Certificates === "") {
     contents.Certificates = [];
@@ -6635,7 +6636,7 @@ const deserializeAws_queryListener = (output: any, context: __SerdeContext): Lis
     );
   }
   if (output["SslPolicy"] !== undefined) {
-    contents.SslPolicy = output["SslPolicy"];
+    contents.SslPolicy = __expectString(output["SslPolicy"]);
   }
   if (output.DefaultActions === "") {
     contents.DefaultActions = [];
@@ -6666,7 +6667,7 @@ const deserializeAws_queryListenerNotFoundException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -6689,7 +6690,7 @@ const deserializeAws_queryListOfString = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6710,31 +6711,31 @@ const deserializeAws_queryLoadBalancer = (output: any, context: __SerdeContext):
     CustomerOwnedIpv4Pool: undefined,
   };
   if (output["LoadBalancerArn"] !== undefined) {
-    contents.LoadBalancerArn = output["LoadBalancerArn"];
+    contents.LoadBalancerArn = __expectString(output["LoadBalancerArn"]);
   }
   if (output["DNSName"] !== undefined) {
-    contents.DNSName = output["DNSName"];
+    contents.DNSName = __expectString(output["DNSName"]);
   }
   if (output["CanonicalHostedZoneId"] !== undefined) {
-    contents.CanonicalHostedZoneId = output["CanonicalHostedZoneId"];
+    contents.CanonicalHostedZoneId = __expectString(output["CanonicalHostedZoneId"]);
   }
   if (output["CreatedTime"] !== undefined) {
     contents.CreatedTime = new Date(output["CreatedTime"]);
   }
   if (output["LoadBalancerName"] !== undefined) {
-    contents.LoadBalancerName = output["LoadBalancerName"];
+    contents.LoadBalancerName = __expectString(output["LoadBalancerName"]);
   }
   if (output["Scheme"] !== undefined) {
-    contents.Scheme = output["Scheme"];
+    contents.Scheme = __expectString(output["Scheme"]);
   }
   if (output["VpcId"] !== undefined) {
-    contents.VpcId = output["VpcId"];
+    contents.VpcId = __expectString(output["VpcId"]);
   }
   if (output["State"] !== undefined) {
     contents.State = deserializeAws_queryLoadBalancerState(output["State"], context);
   }
   if (output["Type"] !== undefined) {
-    contents.Type = output["Type"];
+    contents.Type = __expectString(output["Type"]);
   }
   if (output.AvailabilityZones === "") {
     contents.AvailabilityZones = [];
@@ -6755,10 +6756,10 @@ const deserializeAws_queryLoadBalancer = (output: any, context: __SerdeContext):
     );
   }
   if (output["IpAddressType"] !== undefined) {
-    contents.IpAddressType = output["IpAddressType"];
+    contents.IpAddressType = __expectString(output["IpAddressType"]);
   }
   if (output["CustomerOwnedIpv4Pool"] !== undefined) {
-    contents.CustomerOwnedIpv4Pool = output["CustomerOwnedIpv4Pool"];
+    contents.CustomerOwnedIpv4Pool = __expectString(output["CustomerOwnedIpv4Pool"]);
   }
   return contents;
 };
@@ -6771,16 +6772,16 @@ const deserializeAws_queryLoadBalancerAddress = (output: any, context: __SerdeCo
     IPv6Address: undefined,
   };
   if (output["IpAddress"] !== undefined) {
-    contents.IpAddress = output["IpAddress"];
+    contents.IpAddress = __expectString(output["IpAddress"]);
   }
   if (output["AllocationId"] !== undefined) {
-    contents.AllocationId = output["AllocationId"];
+    contents.AllocationId = __expectString(output["AllocationId"]);
   }
   if (output["PrivateIPv4Address"] !== undefined) {
-    contents.PrivateIPv4Address = output["PrivateIPv4Address"];
+    contents.PrivateIPv4Address = __expectString(output["PrivateIPv4Address"]);
   }
   if (output["IPv6Address"] !== undefined) {
-    contents.IPv6Address = output["IPv6Address"];
+    contents.IPv6Address = __expectString(output["IPv6Address"]);
   }
   return contents;
 };
@@ -6803,7 +6804,7 @@ const deserializeAws_queryLoadBalancerArns = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6813,10 +6814,10 @@ const deserializeAws_queryLoadBalancerAttribute = (output: any, context: __Serde
     Value: undefined,
   };
   if (output["Key"] !== undefined) {
-    contents.Key = output["Key"];
+    contents.Key = __expectString(output["Key"]);
   }
   if (output["Value"] !== undefined) {
-    contents.Value = output["Value"];
+    contents.Value = __expectString(output["Value"]);
   }
   return contents;
 };
@@ -6840,7 +6841,7 @@ const deserializeAws_queryLoadBalancerNotFoundException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -6862,10 +6863,10 @@ const deserializeAws_queryLoadBalancerState = (output: any, context: __SerdeCont
     Reason: undefined,
   };
   if (output["Code"] !== undefined) {
-    contents.Code = output["Code"];
+    contents.Code = __expectString(output["Code"]);
   }
   if (output["Reason"] !== undefined) {
-    contents.Reason = output["Reason"];
+    contents.Reason = __expectString(output["Reason"]);
   }
   return contents;
 };
@@ -6876,10 +6877,10 @@ const deserializeAws_queryMatcher = (output: any, context: __SerdeContext): Matc
     GrpcCode: undefined,
   };
   if (output["HttpCode"] !== undefined) {
-    contents.HttpCode = output["HttpCode"];
+    contents.HttpCode = __expectString(output["HttpCode"]);
   }
   if (output["GrpcCode"] !== undefined) {
-    contents.GrpcCode = output["GrpcCode"];
+    contents.GrpcCode = __expectString(output["GrpcCode"]);
   }
   return contents;
 };
@@ -6972,7 +6973,7 @@ const deserializeAws_queryOperationNotPermittedException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -6998,7 +6999,7 @@ const deserializeAws_queryPriorityInUseException = (output: any, context: __Serd
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -7028,10 +7029,10 @@ const deserializeAws_queryQueryStringKeyValuePair = (output: any, context: __Ser
     Value: undefined,
   };
   if (output["Key"] !== undefined) {
-    contents.Key = output["Key"];
+    contents.Key = __expectString(output["Key"]);
   }
   if (output["Value"] !== undefined) {
-    contents.Value = output["Value"];
+    contents.Value = __expectString(output["Value"]);
   }
   return contents;
 };
@@ -7060,22 +7061,22 @@ const deserializeAws_queryRedirectActionConfig = (output: any, context: __SerdeC
     StatusCode: undefined,
   };
   if (output["Protocol"] !== undefined) {
-    contents.Protocol = output["Protocol"];
+    contents.Protocol = __expectString(output["Protocol"]);
   }
   if (output["Port"] !== undefined) {
-    contents.Port = output["Port"];
+    contents.Port = __expectString(output["Port"]);
   }
   if (output["Host"] !== undefined) {
-    contents.Host = output["Host"];
+    contents.Host = __expectString(output["Host"]);
   }
   if (output["Path"] !== undefined) {
-    contents.Path = output["Path"];
+    contents.Path = __expectString(output["Path"]);
   }
   if (output["Query"] !== undefined) {
-    contents.Query = output["Query"];
+    contents.Query = __expectString(output["Query"]);
   }
   if (output["StatusCode"] !== undefined) {
-    contents.StatusCode = output["StatusCode"];
+    contents.StatusCode = __expectString(output["StatusCode"]);
   }
   return contents;
 };
@@ -7103,7 +7104,7 @@ const deserializeAws_queryResourceInUseException = (output: any, context: __Serd
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -7117,10 +7118,10 @@ const deserializeAws_queryRule = (output: any, context: __SerdeContext): Rule =>
     IsDefault: undefined,
   };
   if (output["RuleArn"] !== undefined) {
-    contents.RuleArn = output["RuleArn"];
+    contents.RuleArn = __expectString(output["RuleArn"]);
   }
   if (output["Priority"] !== undefined) {
-    contents.Priority = output["Priority"];
+    contents.Priority = __expectString(output["Priority"]);
   }
   if (output.Conditions === "") {
     contents.Conditions = [];
@@ -7155,7 +7156,7 @@ const deserializeAws_queryRuleCondition = (output: any, context: __SerdeContext)
     SourceIpConfig: undefined,
   };
   if (output["Field"] !== undefined) {
-    contents.Field = output["Field"];
+    contents.Field = __expectString(output["Field"]);
   }
   if (output.Values === "") {
     contents.Values = [];
@@ -7203,7 +7204,7 @@ const deserializeAws_queryRuleNotFoundException = (output: any, context: __Serde
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -7226,7 +7227,7 @@ const deserializeAws_querySecurityGroups = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7235,7 +7236,7 @@ const deserializeAws_querySetIpAddressTypeOutput = (output: any, context: __Serd
     IpAddressType: undefined,
   };
   if (output["IpAddressType"] !== undefined) {
-    contents.IpAddressType = output["IpAddressType"];
+    contents.IpAddressType = __expectString(output["IpAddressType"]);
   }
   return contents;
 };
@@ -7284,7 +7285,7 @@ const deserializeAws_querySetSubnetsOutput = (output: any, context: __SerdeConte
     );
   }
   if (output["IpAddressType"] !== undefined) {
-    contents.IpAddressType = output["IpAddressType"];
+    contents.IpAddressType = __expectString(output["IpAddressType"]);
   }
   return contents;
 };
@@ -7335,7 +7336,7 @@ const deserializeAws_querySslPolicy = (output: any, context: __SerdeContext): Ss
     contents.Ciphers = deserializeAws_queryCiphers(__getArrayIfSingleItem(output["Ciphers"]["member"]), context);
   }
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   return contents;
 };
@@ -7348,7 +7349,7 @@ const deserializeAws_querySSLPolicyNotFoundException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -7360,7 +7361,7 @@ const deserializeAws_querySslProtocols = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7369,7 +7370,7 @@ const deserializeAws_querySubnetNotFoundException = (output: any, context: __Ser
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -7380,10 +7381,10 @@ const deserializeAws_queryTag = (output: any, context: __SerdeContext): Tag => {
     Value: undefined,
   };
   if (output["Key"] !== undefined) {
-    contents.Key = output["Key"];
+    contents.Key = __expectString(output["Key"]);
   }
   if (output["Value"] !== undefined) {
-    contents.Value = output["Value"];
+    contents.Value = __expectString(output["Value"]);
   }
   return contents;
 };
@@ -7394,7 +7395,7 @@ const deserializeAws_queryTagDescription = (output: any, context: __SerdeContext
     Tags: undefined,
   };
   if (output["ResourceArn"] !== undefined) {
-    contents.ResourceArn = output["ResourceArn"];
+    contents.ResourceArn = __expectString(output["ResourceArn"]);
   }
   if (output.Tags === "") {
     contents.Tags = [];
@@ -7434,13 +7435,13 @@ const deserializeAws_queryTargetDescription = (output: any, context: __SerdeCont
     AvailabilityZone: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   if (output["Port"] !== undefined) {
     contents.Port = parseInt(output["Port"]);
   }
   if (output["AvailabilityZone"] !== undefined) {
-    contents.AvailabilityZone = output["AvailabilityZone"];
+    contents.AvailabilityZone = __expectString(output["AvailabilityZone"]);
   }
   return contents;
 };
@@ -7466,25 +7467,25 @@ const deserializeAws_queryTargetGroup = (output: any, context: __SerdeContext): 
     ProtocolVersion: undefined,
   };
   if (output["TargetGroupArn"] !== undefined) {
-    contents.TargetGroupArn = output["TargetGroupArn"];
+    contents.TargetGroupArn = __expectString(output["TargetGroupArn"]);
   }
   if (output["TargetGroupName"] !== undefined) {
-    contents.TargetGroupName = output["TargetGroupName"];
+    contents.TargetGroupName = __expectString(output["TargetGroupName"]);
   }
   if (output["Protocol"] !== undefined) {
-    contents.Protocol = output["Protocol"];
+    contents.Protocol = __expectString(output["Protocol"]);
   }
   if (output["Port"] !== undefined) {
     contents.Port = parseInt(output["Port"]);
   }
   if (output["VpcId"] !== undefined) {
-    contents.VpcId = output["VpcId"];
+    contents.VpcId = __expectString(output["VpcId"]);
   }
   if (output["HealthCheckProtocol"] !== undefined) {
-    contents.HealthCheckProtocol = output["HealthCheckProtocol"];
+    contents.HealthCheckProtocol = __expectString(output["HealthCheckProtocol"]);
   }
   if (output["HealthCheckPort"] !== undefined) {
-    contents.HealthCheckPort = output["HealthCheckPort"];
+    contents.HealthCheckPort = __expectString(output["HealthCheckPort"]);
   }
   if (output["HealthCheckEnabled"] !== undefined) {
     contents.HealthCheckEnabled = __parseBoolean(output["HealthCheckEnabled"]);
@@ -7502,7 +7503,7 @@ const deserializeAws_queryTargetGroup = (output: any, context: __SerdeContext): 
     contents.UnhealthyThresholdCount = parseInt(output["UnhealthyThresholdCount"]);
   }
   if (output["HealthCheckPath"] !== undefined) {
-    contents.HealthCheckPath = output["HealthCheckPath"];
+    contents.HealthCheckPath = __expectString(output["HealthCheckPath"]);
   }
   if (output["Matcher"] !== undefined) {
     contents.Matcher = deserializeAws_queryMatcher(output["Matcher"], context);
@@ -7517,10 +7518,10 @@ const deserializeAws_queryTargetGroup = (output: any, context: __SerdeContext): 
     );
   }
   if (output["TargetType"] !== undefined) {
-    contents.TargetType = output["TargetType"];
+    contents.TargetType = __expectString(output["TargetType"]);
   }
   if (output["ProtocolVersion"] !== undefined) {
-    contents.ProtocolVersion = output["ProtocolVersion"];
+    contents.ProtocolVersion = __expectString(output["ProtocolVersion"]);
   }
   return contents;
 };
@@ -7533,7 +7534,7 @@ const deserializeAws_queryTargetGroupAssociationLimitException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -7544,10 +7545,10 @@ const deserializeAws_queryTargetGroupAttribute = (output: any, context: __SerdeC
     Value: undefined,
   };
   if (output["Key"] !== undefined) {
-    contents.Key = output["Key"];
+    contents.Key = __expectString(output["Key"]);
   }
   if (output["Value"] !== undefined) {
-    contents.Value = output["Value"];
+    contents.Value = __expectString(output["Value"]);
   }
   return contents;
 };
@@ -7582,7 +7583,7 @@ const deserializeAws_queryTargetGroupNotFoundException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -7621,7 +7622,7 @@ const deserializeAws_queryTargetGroupTuple = (output: any, context: __SerdeConte
     Weight: undefined,
   };
   if (output["TargetGroupArn"] !== undefined) {
-    contents.TargetGroupArn = output["TargetGroupArn"];
+    contents.TargetGroupArn = __expectString(output["TargetGroupArn"]);
   }
   if (output["Weight"] !== undefined) {
     contents.Weight = parseInt(output["Weight"]);
@@ -7636,13 +7637,13 @@ const deserializeAws_queryTargetHealth = (output: any, context: __SerdeContext):
     Description: undefined,
   };
   if (output["State"] !== undefined) {
-    contents.State = output["State"];
+    contents.State = __expectString(output["State"]);
   }
   if (output["Reason"] !== undefined) {
-    contents.Reason = output["Reason"];
+    contents.Reason = __expectString(output["Reason"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   return contents;
 };
@@ -7657,7 +7658,7 @@ const deserializeAws_queryTargetHealthDescription = (output: any, context: __Ser
     contents.Target = deserializeAws_queryTargetDescription(output["Target"], context);
   }
   if (output["HealthCheckPort"] !== undefined) {
-    contents.HealthCheckPort = output["HealthCheckPort"];
+    contents.HealthCheckPort = __expectString(output["HealthCheckPort"]);
   }
   if (output["TargetHealth"] !== undefined) {
     contents.TargetHealth = deserializeAws_queryTargetHealth(output["TargetHealth"], context);
@@ -7684,7 +7685,7 @@ const deserializeAws_queryTooManyActionsException = (output: any, context: __Ser
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -7697,7 +7698,7 @@ const deserializeAws_queryTooManyCertificatesException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -7710,7 +7711,7 @@ const deserializeAws_queryTooManyListenersException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -7723,7 +7724,7 @@ const deserializeAws_queryTooManyLoadBalancersException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -7736,7 +7737,7 @@ const deserializeAws_queryTooManyRegistrationsForTargetIdException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -7746,7 +7747,7 @@ const deserializeAws_queryTooManyRulesException = (output: any, context: __Serde
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -7756,7 +7757,7 @@ const deserializeAws_queryTooManyTagsException = (output: any, context: __SerdeC
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -7769,7 +7770,7 @@ const deserializeAws_queryTooManyTargetGroupsException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -7779,7 +7780,7 @@ const deserializeAws_queryTooManyTargetsException = (output: any, context: __Ser
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -7792,7 +7793,7 @@ const deserializeAws_queryTooManyUniqueTargetGroupsPerLoadBalancerException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -7805,7 +7806,7 @@ const deserializeAws_queryUnsupportedProtocolException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };

--- a/clients/client-elastic-load-balancing/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing/protocols/Aws_query.ts
@@ -210,6 +210,7 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
@@ -3920,13 +3921,13 @@ const deserializeAws_queryAccessLog = (output: any, context: __SerdeContext): Ac
     contents.Enabled = __parseBoolean(output["Enabled"]);
   }
   if (output["S3BucketName"] !== undefined) {
-    contents.S3BucketName = output["S3BucketName"];
+    contents.S3BucketName = __expectString(output["S3BucketName"]);
   }
   if (output["EmitInterval"] !== undefined) {
     contents.EmitInterval = parseInt(output["EmitInterval"]);
   }
   if (output["S3BucketPrefix"] !== undefined) {
-    contents.S3BucketPrefix = output["S3BucketPrefix"];
+    contents.S3BucketPrefix = __expectString(output["S3BucketPrefix"]);
   }
   return contents;
 };
@@ -3939,7 +3940,7 @@ const deserializeAws_queryAccessPointNotFoundException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -3969,10 +3970,10 @@ const deserializeAws_queryAdditionalAttribute = (output: any, context: __SerdeCo
     Value: undefined,
   };
   if (output["Key"] !== undefined) {
-    contents.Key = output["Key"];
+    contents.Key = __expectString(output["Key"]);
   }
   if (output["Value"] !== undefined) {
-    contents.Value = output["Value"];
+    contents.Value = __expectString(output["Value"]);
   }
   return contents;
 };
@@ -4016,10 +4017,10 @@ const deserializeAws_queryAppCookieStickinessPolicy = (
     CookieName: undefined,
   };
   if (output["PolicyName"] !== undefined) {
-    contents.PolicyName = output["PolicyName"];
+    contents.PolicyName = __expectString(output["PolicyName"]);
   }
   if (output["CookieName"] !== undefined) {
-    contents.CookieName = output["CookieName"];
+    contents.CookieName = __expectString(output["CookieName"]);
   }
   return contents;
 };
@@ -4066,7 +4067,7 @@ const deserializeAws_queryAvailabilityZones = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4115,7 +4116,7 @@ const deserializeAws_queryCertificateNotFoundException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -4162,7 +4163,7 @@ const deserializeAws_queryCreateAccessPointOutput = (output: any, context: __Ser
     DNSName: undefined,
   };
   if (output["DNSName"] !== undefined) {
-    contents.DNSName = output["DNSName"];
+    contents.DNSName = __expectString(output["DNSName"]);
   }
   return contents;
 };
@@ -4238,7 +4239,7 @@ const deserializeAws_queryDependencyThrottleException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -4277,7 +4278,7 @@ const deserializeAws_queryDescribeAccessPointsOutput = (
     );
   }
   if (output["NextMarker"] !== undefined) {
-    contents.NextMarker = output["NextMarker"];
+    contents.NextMarker = __expectString(output["NextMarker"]);
   }
   return contents;
 };
@@ -4297,7 +4298,7 @@ const deserializeAws_queryDescribeAccountLimitsOutput = (
     contents.Limits = deserializeAws_queryLimits(__getArrayIfSingleItem(output["Limits"]["member"]), context);
   }
   if (output["NextMarker"] !== undefined) {
-    contents.NextMarker = output["NextMarker"];
+    contents.NextMarker = __expectString(output["NextMarker"]);
   }
   return contents;
 };
@@ -4415,7 +4416,7 @@ const deserializeAws_queryDuplicateAccessPointNameException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -4428,7 +4429,7 @@ const deserializeAws_queryDuplicateListenerException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -4441,7 +4442,7 @@ const deserializeAws_queryDuplicatePolicyNameException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -4454,7 +4455,7 @@ const deserializeAws_queryDuplicateTagKeysException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -4468,7 +4469,7 @@ const deserializeAws_queryHealthCheck = (output: any, context: __SerdeContext): 
     HealthyThreshold: undefined,
   };
   if (output["Target"] !== undefined) {
-    contents.Target = output["Target"];
+    contents.Target = __expectString(output["Target"]);
   }
   if (output["Interval"] !== undefined) {
     contents.Interval = parseInt(output["Interval"]);
@@ -4490,7 +4491,7 @@ const deserializeAws_queryInstance = (output: any, context: __SerdeContext): Ins
     InstanceId: undefined,
   };
   if (output["InstanceId"] !== undefined) {
-    contents.InstanceId = output["InstanceId"];
+    contents.InstanceId = __expectString(output["InstanceId"]);
   }
   return contents;
 };
@@ -4514,16 +4515,16 @@ const deserializeAws_queryInstanceState = (output: any, context: __SerdeContext)
     Description: undefined,
   };
   if (output["InstanceId"] !== undefined) {
-    contents.InstanceId = output["InstanceId"];
+    contents.InstanceId = __expectString(output["InstanceId"]);
   }
   if (output["State"] !== undefined) {
-    contents.State = output["State"];
+    contents.State = __expectString(output["State"]);
   }
   if (output["ReasonCode"] !== undefined) {
-    contents.ReasonCode = output["ReasonCode"];
+    contents.ReasonCode = __expectString(output["ReasonCode"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   return contents;
 };
@@ -4547,7 +4548,7 @@ const deserializeAws_queryInvalidConfigurationRequestException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -4560,7 +4561,7 @@ const deserializeAws_queryInvalidEndPointException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -4570,7 +4571,7 @@ const deserializeAws_queryInvalidSchemeException = (output: any, context: __Serd
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -4583,7 +4584,7 @@ const deserializeAws_queryInvalidSecurityGroupException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -4593,7 +4594,7 @@ const deserializeAws_queryInvalidSubnetException = (output: any, context: __Serd
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -4621,7 +4622,7 @@ const deserializeAws_queryLBCookieStickinessPolicy = (
     CookieExpirationPeriod: undefined,
   };
   if (output["PolicyName"] !== undefined) {
-    contents.PolicyName = output["PolicyName"];
+    contents.PolicyName = __expectString(output["PolicyName"]);
   }
   if (output["CookieExpirationPeriod"] !== undefined) {
     contents.CookieExpirationPeriod = parseInt(output["CookieExpirationPeriod"]);
@@ -4635,10 +4636,10 @@ const deserializeAws_queryLimit = (output: any, context: __SerdeContext): Limit 
     Max: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["Max"] !== undefined) {
-    contents.Max = output["Max"];
+    contents.Max = __expectString(output["Max"]);
   }
   return contents;
 };
@@ -4663,19 +4664,19 @@ const deserializeAws_queryListener = (output: any, context: __SerdeContext): Lis
     SSLCertificateId: undefined,
   };
   if (output["Protocol"] !== undefined) {
-    contents.Protocol = output["Protocol"];
+    contents.Protocol = __expectString(output["Protocol"]);
   }
   if (output["LoadBalancerPort"] !== undefined) {
     contents.LoadBalancerPort = parseInt(output["LoadBalancerPort"]);
   }
   if (output["InstanceProtocol"] !== undefined) {
-    contents.InstanceProtocol = output["InstanceProtocol"];
+    contents.InstanceProtocol = __expectString(output["InstanceProtocol"]);
   }
   if (output["InstancePort"] !== undefined) {
     contents.InstancePort = parseInt(output["InstancePort"]);
   }
   if (output["SSLCertificateId"] !== undefined) {
-    contents.SSLCertificateId = output["SSLCertificateId"];
+    contents.SSLCertificateId = __expectString(output["SSLCertificateId"]);
   }
   return contents;
 };
@@ -4719,7 +4720,7 @@ const deserializeAws_queryListenerNotFoundException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -4732,7 +4733,7 @@ const deserializeAws_queryLoadBalancerAttributeNotFoundException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -4792,16 +4793,16 @@ const deserializeAws_queryLoadBalancerDescription = (output: any, context: __Ser
     Scheme: undefined,
   };
   if (output["LoadBalancerName"] !== undefined) {
-    contents.LoadBalancerName = output["LoadBalancerName"];
+    contents.LoadBalancerName = __expectString(output["LoadBalancerName"]);
   }
   if (output["DNSName"] !== undefined) {
-    contents.DNSName = output["DNSName"];
+    contents.DNSName = __expectString(output["DNSName"]);
   }
   if (output["CanonicalHostedZoneName"] !== undefined) {
-    contents.CanonicalHostedZoneName = output["CanonicalHostedZoneName"];
+    contents.CanonicalHostedZoneName = __expectString(output["CanonicalHostedZoneName"]);
   }
   if (output["CanonicalHostedZoneNameID"] !== undefined) {
-    contents.CanonicalHostedZoneNameID = output["CanonicalHostedZoneNameID"];
+    contents.CanonicalHostedZoneNameID = __expectString(output["CanonicalHostedZoneNameID"]);
   }
   if (output.ListenerDescriptions === "") {
     contents.ListenerDescriptions = [];
@@ -4843,7 +4844,7 @@ const deserializeAws_queryLoadBalancerDescription = (output: any, context: __Ser
     contents.Subnets = deserializeAws_querySubnets(__getArrayIfSingleItem(output["Subnets"]["member"]), context);
   }
   if (output["VPCId"] !== undefined) {
-    contents.VPCId = output["VPCId"];
+    contents.VPCId = __expectString(output["VPCId"]);
   }
   if (output.Instances === "") {
     contents.Instances = [];
@@ -4870,7 +4871,7 @@ const deserializeAws_queryLoadBalancerDescription = (output: any, context: __Ser
     contents.CreatedTime = new Date(output["CreatedTime"]);
   }
   if (output["Scheme"] !== undefined) {
-    contents.Scheme = output["Scheme"];
+    contents.Scheme = __expectString(output["Scheme"]);
   }
   return contents;
 };
@@ -4898,7 +4899,7 @@ const deserializeAws_queryModifyLoadBalancerAttributesOutput = (
     LoadBalancerAttributes: undefined,
   };
   if (output["LoadBalancerName"] !== undefined) {
-    contents.LoadBalancerName = output["LoadBalancerName"];
+    contents.LoadBalancerName = __expectString(output["LoadBalancerName"]);
   }
   if (output["LoadBalancerAttributes"] !== undefined) {
     contents.LoadBalancerAttributes = deserializeAws_queryLoadBalancerAttributes(
@@ -4917,7 +4918,7 @@ const deserializeAws_queryOperationNotPermittedException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -4973,10 +4974,10 @@ const deserializeAws_queryPolicyAttributeDescription = (
     AttributeValue: undefined,
   };
   if (output["AttributeName"] !== undefined) {
-    contents.AttributeName = output["AttributeName"];
+    contents.AttributeName = __expectString(output["AttributeName"]);
   }
   if (output["AttributeValue"] !== undefined) {
-    contents.AttributeValue = output["AttributeValue"];
+    contents.AttributeValue = __expectString(output["AttributeValue"]);
   }
   return contents;
 };
@@ -5007,19 +5008,19 @@ const deserializeAws_queryPolicyAttributeTypeDescription = (
     Cardinality: undefined,
   };
   if (output["AttributeName"] !== undefined) {
-    contents.AttributeName = output["AttributeName"];
+    contents.AttributeName = __expectString(output["AttributeName"]);
   }
   if (output["AttributeType"] !== undefined) {
-    contents.AttributeType = output["AttributeType"];
+    contents.AttributeType = __expectString(output["AttributeType"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output["DefaultValue"] !== undefined) {
-    contents.DefaultValue = output["DefaultValue"];
+    contents.DefaultValue = __expectString(output["DefaultValue"]);
   }
   if (output["Cardinality"] !== undefined) {
-    contents.Cardinality = output["Cardinality"];
+    contents.Cardinality = __expectString(output["Cardinality"]);
   }
   return contents;
 };
@@ -5045,10 +5046,10 @@ const deserializeAws_queryPolicyDescription = (output: any, context: __SerdeCont
     PolicyAttributeDescriptions: undefined,
   };
   if (output["PolicyName"] !== undefined) {
-    contents.PolicyName = output["PolicyName"];
+    contents.PolicyName = __expectString(output["PolicyName"]);
   }
   if (output["PolicyTypeName"] !== undefined) {
-    contents.PolicyTypeName = output["PolicyTypeName"];
+    contents.PolicyTypeName = __expectString(output["PolicyTypeName"]);
   }
   if (output.PolicyAttributeDescriptions === "") {
     contents.PolicyAttributeDescriptions = [];
@@ -5083,7 +5084,7 @@ const deserializeAws_queryPolicyNames = (output: any, context: __SerdeContext): 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -5092,7 +5093,7 @@ const deserializeAws_queryPolicyNotFoundException = (output: any, context: __Ser
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -5104,10 +5105,10 @@ const deserializeAws_queryPolicyTypeDescription = (output: any, context: __Serde
     PolicyAttributeTypeDescriptions: undefined,
   };
   if (output["PolicyTypeName"] !== undefined) {
-    contents.PolicyTypeName = output["PolicyTypeName"];
+    contents.PolicyTypeName = __expectString(output["PolicyTypeName"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output.PolicyAttributeTypeDescriptions === "") {
     contents.PolicyAttributeTypeDescriptions = [];
@@ -5143,7 +5144,7 @@ const deserializeAws_queryPolicyTypeNotFoundException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -5192,7 +5193,7 @@ const deserializeAws_querySecurityGroups = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -5226,10 +5227,10 @@ const deserializeAws_querySourceSecurityGroup = (output: any, context: __SerdeCo
     GroupName: undefined,
   };
   if (output["OwnerAlias"] !== undefined) {
-    contents.OwnerAlias = output["OwnerAlias"];
+    contents.OwnerAlias = __expectString(output["OwnerAlias"]);
   }
   if (output["GroupName"] !== undefined) {
-    contents.GroupName = output["GroupName"];
+    contents.GroupName = __expectString(output["GroupName"]);
   }
   return contents;
 };
@@ -5239,7 +5240,7 @@ const deserializeAws_querySubnetNotFoundException = (output: any, context: __Ser
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -5251,7 +5252,7 @@ const deserializeAws_querySubnets = (output: any, context: __SerdeContext): stri
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -5261,10 +5262,10 @@ const deserializeAws_queryTag = (output: any, context: __SerdeContext): Tag => {
     Value: undefined,
   };
   if (output["Key"] !== undefined) {
-    contents.Key = output["Key"];
+    contents.Key = __expectString(output["Key"]);
   }
   if (output["Value"] !== undefined) {
-    contents.Value = output["Value"];
+    contents.Value = __expectString(output["Value"]);
   }
   return contents;
 };
@@ -5275,7 +5276,7 @@ const deserializeAws_queryTagDescription = (output: any, context: __SerdeContext
     Tags: undefined,
   };
   if (output["LoadBalancerName"] !== undefined) {
-    contents.LoadBalancerName = output["LoadBalancerName"];
+    contents.LoadBalancerName = __expectString(output["LoadBalancerName"]);
   }
   if (output.Tags === "") {
     contents.Tags = [];
@@ -5316,7 +5317,7 @@ const deserializeAws_queryTooManyAccessPointsException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -5329,7 +5330,7 @@ const deserializeAws_queryTooManyPoliciesException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -5339,7 +5340,7 @@ const deserializeAws_queryTooManyTagsException = (output: any, context: __SerdeC
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -5352,7 +5353,7 @@ const deserializeAws_queryUnsupportedProtocolException = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };

--- a/clients/client-elastic-transcoder/protocols/Aws_restJson1.ts
+++ b/clients/client-elastic-transcoder/protocols/Aws_restJson1.ts
@@ -64,6 +64,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -912,7 +914,7 @@ export const deserializeAws_restJson1CreatePresetCommand = async (
     contents.Preset = deserializeAws_restJson1Preset(data.Preset, context);
   }
   if (data.Warning !== undefined && data.Warning !== null) {
-    contents.Warning = data.Warning;
+    contents.Warning = __expectString(data.Warning);
   }
   return Promise.resolve(contents);
 };
@@ -1177,7 +1179,7 @@ export const deserializeAws_restJson1ListJobsByPipelineCommand = async (
     contents.Jobs = deserializeAws_restJson1Jobs(data.Jobs, context);
   }
   if (data.NextPageToken !== undefined && data.NextPageToken !== null) {
-    contents.NextPageToken = data.NextPageToken;
+    contents.NextPageToken = __expectString(data.NextPageToken);
   }
   return Promise.resolve(contents);
 };
@@ -1268,7 +1270,7 @@ export const deserializeAws_restJson1ListJobsByStatusCommand = async (
     contents.Jobs = deserializeAws_restJson1Jobs(data.Jobs, context);
   }
   if (data.NextPageToken !== undefined && data.NextPageToken !== null) {
-    contents.NextPageToken = data.NextPageToken;
+    contents.NextPageToken = __expectString(data.NextPageToken);
   }
   return Promise.resolve(contents);
 };
@@ -1356,7 +1358,7 @@ export const deserializeAws_restJson1ListPipelinesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextPageToken !== undefined && data.NextPageToken !== null) {
-    contents.NextPageToken = data.NextPageToken;
+    contents.NextPageToken = __expectString(data.NextPageToken);
   }
   if (data.Pipelines !== undefined && data.Pipelines !== null) {
     contents.Pipelines = deserializeAws_restJson1Pipelines(data.Pipelines, context);
@@ -1439,7 +1441,7 @@ export const deserializeAws_restJson1ListPresetsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextPageToken !== undefined && data.NextPageToken !== null) {
-    contents.NextPageToken = data.NextPageToken;
+    contents.NextPageToken = __expectString(data.NextPageToken);
   }
   if (data.Presets !== undefined && data.Presets !== null) {
     contents.Presets = deserializeAws_restJson1Presets(data.Presets, context);
@@ -1790,7 +1792,7 @@ export const deserializeAws_restJson1TestRoleCommand = async (
     contents.Messages = deserializeAws_restJson1ExceptionMessages(data.Messages, context);
   }
   if (data.Success !== undefined && data.Success !== null) {
-    contents.Success = data.Success;
+    contents.Success = __expectString(data.Success);
   }
   return Promise.resolve(contents);
 };
@@ -2165,7 +2167,7 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2182,7 +2184,7 @@ const deserializeAws_restJson1IncompatibleVersionExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2199,7 +2201,7 @@ const deserializeAws_restJson1InternalServiceExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2216,7 +2218,7 @@ const deserializeAws_restJson1LimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2233,7 +2235,7 @@ const deserializeAws_restJson1ResourceInUseExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2250,7 +2252,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2267,7 +2269,7 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2754,24 +2756,22 @@ const deserializeAws_restJson1AccessControls = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1Artwork = (output: any, context: __SerdeContext): Artwork => {
   return {
-    AlbumArtFormat:
-      output.AlbumArtFormat !== undefined && output.AlbumArtFormat !== null ? output.AlbumArtFormat : undefined,
+    AlbumArtFormat: __expectString(output.AlbumArtFormat),
     Encryption:
       output.Encryption !== undefined && output.Encryption !== null
         ? deserializeAws_restJson1Encryption(output.Encryption, context)
         : undefined,
-    InputKey: output.InputKey !== undefined && output.InputKey !== null ? output.InputKey : undefined,
-    MaxHeight: output.MaxHeight !== undefined && output.MaxHeight !== null ? output.MaxHeight : undefined,
-    MaxWidth: output.MaxWidth !== undefined && output.MaxWidth !== null ? output.MaxWidth : undefined,
-    PaddingPolicy:
-      output.PaddingPolicy !== undefined && output.PaddingPolicy !== null ? output.PaddingPolicy : undefined,
-    SizingPolicy: output.SizingPolicy !== undefined && output.SizingPolicy !== null ? output.SizingPolicy : undefined,
+    InputKey: __expectString(output.InputKey),
+    MaxHeight: __expectString(output.MaxHeight),
+    MaxWidth: __expectString(output.MaxWidth),
+    PaddingPolicy: __expectString(output.PaddingPolicy),
+    SizingPolicy: __expectString(output.SizingPolicy),
   } as any;
 };
 
@@ -2788,25 +2788,24 @@ const deserializeAws_restJson1Artworks = (output: any, context: __SerdeContext):
 
 const deserializeAws_restJson1AudioCodecOptions = (output: any, context: __SerdeContext): AudioCodecOptions => {
   return {
-    BitDepth: output.BitDepth !== undefined && output.BitDepth !== null ? output.BitDepth : undefined,
-    BitOrder: output.BitOrder !== undefined && output.BitOrder !== null ? output.BitOrder : undefined,
-    Profile: output.Profile !== undefined && output.Profile !== null ? output.Profile : undefined,
-    Signed: output.Signed !== undefined && output.Signed !== null ? output.Signed : undefined,
+    BitDepth: __expectString(output.BitDepth),
+    BitOrder: __expectString(output.BitOrder),
+    Profile: __expectString(output.Profile),
+    Signed: __expectString(output.Signed),
   } as any;
 };
 
 const deserializeAws_restJson1AudioParameters = (output: any, context: __SerdeContext): AudioParameters => {
   return {
-    AudioPackingMode:
-      output.AudioPackingMode !== undefined && output.AudioPackingMode !== null ? output.AudioPackingMode : undefined,
-    BitRate: output.BitRate !== undefined && output.BitRate !== null ? output.BitRate : undefined,
-    Channels: output.Channels !== undefined && output.Channels !== null ? output.Channels : undefined,
-    Codec: output.Codec !== undefined && output.Codec !== null ? output.Codec : undefined,
+    AudioPackingMode: __expectString(output.AudioPackingMode),
+    BitRate: __expectString(output.BitRate),
+    Channels: __expectString(output.Channels),
+    Codec: __expectString(output.Codec),
     CodecOptions:
       output.CodecOptions !== undefined && output.CodecOptions !== null
         ? deserializeAws_restJson1AudioCodecOptions(output.CodecOptions, context)
         : undefined,
-    SampleRate: output.SampleRate !== undefined && output.SampleRate !== null ? output.SampleRate : undefined,
+    SampleRate: __expectString(output.SampleRate),
   } as any;
 };
 
@@ -2816,8 +2815,8 @@ const deserializeAws_restJson1CaptionFormat = (output: any, context: __SerdeCont
       output.Encryption !== undefined && output.Encryption !== null
         ? deserializeAws_restJson1Encryption(output.Encryption, context)
         : undefined,
-    Format: output.Format !== undefined && output.Format !== null ? output.Format : undefined,
-    Pattern: output.Pattern !== undefined && output.Pattern !== null ? output.Pattern : undefined,
+    Format: __expectString(output.Format),
+    Pattern: __expectString(output.Pattern),
   } as any;
 };
 
@@ -2842,7 +2841,7 @@ const deserializeAws_restJson1Captions = (output: any, context: __SerdeContext):
       output.CaptionSources !== undefined && output.CaptionSources !== null
         ? deserializeAws_restJson1CaptionSources(output.CaptionSources, context)
         : undefined,
-    MergePolicy: output.MergePolicy !== undefined && output.MergePolicy !== null ? output.MergePolicy : undefined,
+    MergePolicy: __expectString(output.MergePolicy),
   } as any;
 };
 
@@ -2852,10 +2851,10 @@ const deserializeAws_restJson1CaptionSource = (output: any, context: __SerdeCont
       output.Encryption !== undefined && output.Encryption !== null
         ? deserializeAws_restJson1Encryption(output.Encryption, context)
         : undefined,
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Label: output.Label !== undefined && output.Label !== null ? output.Label : undefined,
-    Language: output.Language !== undefined && output.Language !== null ? output.Language : undefined,
-    TimeOffset: output.TimeOffset !== undefined && output.TimeOffset !== null ? output.TimeOffset : undefined,
+    Key: __expectString(output.Key),
+    Label: __expectString(output.Label),
+    Language: __expectString(output.Language),
+    TimeOffset: __expectString(output.TimeOffset),
   } as any;
 };
 
@@ -2886,7 +2885,7 @@ const deserializeAws_restJson1CodecOptions = (output: any, context: __SerdeConte
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -2904,24 +2903,20 @@ const deserializeAws_restJson1Composition = (output: any, context: __SerdeContex
 
 const deserializeAws_restJson1DetectedProperties = (output: any, context: __SerdeContext): DetectedProperties => {
   return {
-    DurationMillis:
-      output.DurationMillis !== undefined && output.DurationMillis !== null ? output.DurationMillis : undefined,
-    FileSize: output.FileSize !== undefined && output.FileSize !== null ? output.FileSize : undefined,
-    FrameRate: output.FrameRate !== undefined && output.FrameRate !== null ? output.FrameRate : undefined,
-    Height: output.Height !== undefined && output.Height !== null ? output.Height : undefined,
-    Width: output.Width !== undefined && output.Width !== null ? output.Width : undefined,
+    DurationMillis: __expectNumber(output.DurationMillis),
+    FileSize: __expectNumber(output.FileSize),
+    FrameRate: __expectString(output.FrameRate),
+    Height: __expectNumber(output.Height),
+    Width: __expectNumber(output.Width),
   } as any;
 };
 
 const deserializeAws_restJson1Encryption = (output: any, context: __SerdeContext): Encryption => {
   return {
-    InitializationVector:
-      output.InitializationVector !== undefined && output.InitializationVector !== null
-        ? output.InitializationVector
-        : undefined,
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    KeyMd5: output.KeyMd5 !== undefined && output.KeyMd5 !== null ? output.KeyMd5 : undefined,
-    Mode: output.Mode !== undefined && output.Mode !== null ? output.Mode : undefined,
+    InitializationVector: __expectString(output.InitializationVector),
+    Key: __expectString(output.Key),
+    KeyMd5: __expectString(output.KeyMd5),
+    Mode: __expectString(output.Mode),
   } as any;
 };
 
@@ -2932,25 +2927,18 @@ const deserializeAws_restJson1ExceptionMessages = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1HlsContentProtection = (output: any, context: __SerdeContext): HlsContentProtection => {
   return {
-    InitializationVector:
-      output.InitializationVector !== undefined && output.InitializationVector !== null
-        ? output.InitializationVector
-        : undefined,
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    KeyMd5: output.KeyMd5 !== undefined && output.KeyMd5 !== null ? output.KeyMd5 : undefined,
-    KeyStoragePolicy:
-      output.KeyStoragePolicy !== undefined && output.KeyStoragePolicy !== null ? output.KeyStoragePolicy : undefined,
-    LicenseAcquisitionUrl:
-      output.LicenseAcquisitionUrl !== undefined && output.LicenseAcquisitionUrl !== null
-        ? output.LicenseAcquisitionUrl
-        : undefined,
-    Method: output.Method !== undefined && output.Method !== null ? output.Method : undefined,
+    InitializationVector: __expectString(output.InitializationVector),
+    Key: __expectString(output.Key),
+    KeyMd5: __expectString(output.KeyMd5),
+    KeyStoragePolicy: __expectString(output.KeyStoragePolicy),
+    LicenseAcquisitionUrl: __expectString(output.LicenseAcquisitionUrl),
+    Method: __expectString(output.Method),
   } as any;
 };
 
@@ -2960,14 +2948,14 @@ const deserializeAws_restJson1InputCaptions = (output: any, context: __SerdeCont
       output.CaptionSources !== undefined && output.CaptionSources !== null
         ? deserializeAws_restJson1CaptionSources(output.CaptionSources, context)
         : undefined,
-    MergePolicy: output.MergePolicy !== undefined && output.MergePolicy !== null ? output.MergePolicy : undefined,
+    MergePolicy: __expectString(output.MergePolicy),
   } as any;
 };
 
 const deserializeAws_restJson1Job = (output: any, context: __SerdeContext): Job => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    Arn: __expectString(output.Arn),
+    Id: __expectString(output.Id),
     Input:
       output.Input !== undefined && output.Input !== null
         ? deserializeAws_restJson1JobInput(output.Input, context)
@@ -2980,18 +2968,17 @@ const deserializeAws_restJson1Job = (output: any, context: __SerdeContext): Job 
       output.Output !== undefined && output.Output !== null
         ? deserializeAws_restJson1JobOutput(output.Output, context)
         : undefined,
-    OutputKeyPrefix:
-      output.OutputKeyPrefix !== undefined && output.OutputKeyPrefix !== null ? output.OutputKeyPrefix : undefined,
+    OutputKeyPrefix: __expectString(output.OutputKeyPrefix),
     Outputs:
       output.Outputs !== undefined && output.Outputs !== null
         ? deserializeAws_restJson1JobOutputs(output.Outputs, context)
         : undefined,
-    PipelineId: output.PipelineId !== undefined && output.PipelineId !== null ? output.PipelineId : undefined,
+    PipelineId: __expectString(output.PipelineId),
     Playlists:
       output.Playlists !== undefined && output.Playlists !== null
         ? deserializeAws_restJson1Playlists(output.Playlists, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
     Timing:
       output.Timing !== undefined && output.Timing !== null
         ? deserializeAws_restJson1Timing(output.Timing, context)
@@ -3009,14 +2996,14 @@ const deserializeAws_restJson1JobAlbumArt = (output: any, context: __SerdeContex
       output.Artwork !== undefined && output.Artwork !== null
         ? deserializeAws_restJson1Artworks(output.Artwork, context)
         : undefined,
-    MergePolicy: output.MergePolicy !== undefined && output.MergePolicy !== null ? output.MergePolicy : undefined,
+    MergePolicy: __expectString(output.MergePolicy),
   } as any;
 };
 
 const deserializeAws_restJson1JobInput = (output: any, context: __SerdeContext): JobInput => {
   return {
-    AspectRatio: output.AspectRatio !== undefined && output.AspectRatio !== null ? output.AspectRatio : undefined,
-    Container: output.Container !== undefined && output.Container !== null ? output.Container : undefined,
+    AspectRatio: __expectString(output.AspectRatio),
+    Container: __expectString(output.Container),
     DetectedProperties:
       output.DetectedProperties !== undefined && output.DetectedProperties !== null
         ? deserializeAws_restJson1DetectedProperties(output.DetectedProperties, context)
@@ -3025,14 +3012,14 @@ const deserializeAws_restJson1JobInput = (output: any, context: __SerdeContext):
       output.Encryption !== undefined && output.Encryption !== null
         ? deserializeAws_restJson1Encryption(output.Encryption, context)
         : undefined,
-    FrameRate: output.FrameRate !== undefined && output.FrameRate !== null ? output.FrameRate : undefined,
+    FrameRate: __expectString(output.FrameRate),
     InputCaptions:
       output.InputCaptions !== undefined && output.InputCaptions !== null
         ? deserializeAws_restJson1InputCaptions(output.InputCaptions, context)
         : undefined,
-    Interlaced: output.Interlaced !== undefined && output.Interlaced !== null ? output.Interlaced : undefined,
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Resolution: output.Resolution !== undefined && output.Resolution !== null ? output.Resolution : undefined,
+    Interlaced: __expectString(output.Interlaced),
+    Key: __expectString(output.Key),
+    Resolution: __expectString(output.Resolution),
     TimeSpan:
       output.TimeSpan !== undefined && output.TimeSpan !== null
         ? deserializeAws_restJson1TimeSpan(output.TimeSpan, context)
@@ -3057,10 +3044,7 @@ const deserializeAws_restJson1JobOutput = (output: any, context: __SerdeContext)
       output.AlbumArt !== undefined && output.AlbumArt !== null
         ? deserializeAws_restJson1JobAlbumArt(output.AlbumArt, context)
         : undefined,
-    AppliedColorSpaceConversion:
-      output.AppliedColorSpaceConversion !== undefined && output.AppliedColorSpaceConversion !== null
-        ? output.AppliedColorSpaceConversion
-        : undefined,
+    AppliedColorSpaceConversion: __expectString(output.AppliedColorSpaceConversion),
     Captions:
       output.Captions !== undefined && output.Captions !== null
         ? deserializeAws_restJson1Captions(output.Captions, context)
@@ -3069,35 +3053,32 @@ const deserializeAws_restJson1JobOutput = (output: any, context: __SerdeContext)
       output.Composition !== undefined && output.Composition !== null
         ? deserializeAws_restJson1Composition(output.Composition, context)
         : undefined,
-    Duration: output.Duration !== undefined && output.Duration !== null ? output.Duration : undefined,
-    DurationMillis:
-      output.DurationMillis !== undefined && output.DurationMillis !== null ? output.DurationMillis : undefined,
+    Duration: __expectNumber(output.Duration),
+    DurationMillis: __expectNumber(output.DurationMillis),
     Encryption:
       output.Encryption !== undefined && output.Encryption !== null
         ? deserializeAws_restJson1Encryption(output.Encryption, context)
         : undefined,
-    FileSize: output.FileSize !== undefined && output.FileSize !== null ? output.FileSize : undefined,
-    FrameRate: output.FrameRate !== undefined && output.FrameRate !== null ? output.FrameRate : undefined,
-    Height: output.Height !== undefined && output.Height !== null ? output.Height : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    PresetId: output.PresetId !== undefined && output.PresetId !== null ? output.PresetId : undefined,
-    Rotate: output.Rotate !== undefined && output.Rotate !== null ? output.Rotate : undefined,
-    SegmentDuration:
-      output.SegmentDuration !== undefined && output.SegmentDuration !== null ? output.SegmentDuration : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusDetail: output.StatusDetail !== undefined && output.StatusDetail !== null ? output.StatusDetail : undefined,
+    FileSize: __expectNumber(output.FileSize),
+    FrameRate: __expectString(output.FrameRate),
+    Height: __expectNumber(output.Height),
+    Id: __expectString(output.Id),
+    Key: __expectString(output.Key),
+    PresetId: __expectString(output.PresetId),
+    Rotate: __expectString(output.Rotate),
+    SegmentDuration: __expectString(output.SegmentDuration),
+    Status: __expectString(output.Status),
+    StatusDetail: __expectString(output.StatusDetail),
     ThumbnailEncryption:
       output.ThumbnailEncryption !== undefined && output.ThumbnailEncryption !== null
         ? deserializeAws_restJson1Encryption(output.ThumbnailEncryption, context)
         : undefined,
-    ThumbnailPattern:
-      output.ThumbnailPattern !== undefined && output.ThumbnailPattern !== null ? output.ThumbnailPattern : undefined,
+    ThumbnailPattern: __expectString(output.ThumbnailPattern),
     Watermarks:
       output.Watermarks !== undefined && output.Watermarks !== null
         ? deserializeAws_restJson1JobWatermarks(output.Watermarks, context)
         : undefined,
-    Width: output.Width !== undefined && output.Width !== null ? output.Width : undefined,
+    Width: __expectNumber(output.Width),
   } as any;
 };
 
@@ -3129,11 +3110,8 @@ const deserializeAws_restJson1JobWatermark = (output: any, context: __SerdeConte
       output.Encryption !== undefined && output.Encryption !== null
         ? deserializeAws_restJson1Encryption(output.Encryption, context)
         : undefined,
-    InputKey: output.InputKey !== undefined && output.InputKey !== null ? output.InputKey : undefined,
-    PresetWatermarkId:
-      output.PresetWatermarkId !== undefined && output.PresetWatermarkId !== null
-        ? output.PresetWatermarkId
-        : undefined,
+    InputKey: __expectString(output.InputKey),
+    PresetWatermarkId: __expectString(output.PresetWatermarkId),
   } as any;
 };
 
@@ -3150,10 +3128,10 @@ const deserializeAws_restJson1JobWatermarks = (output: any, context: __SerdeCont
 
 const deserializeAws_restJson1Notifications = (output: any, context: __SerdeContext): Notifications => {
   return {
-    Completed: output.Completed !== undefined && output.Completed !== null ? output.Completed : undefined,
-    Error: output.Error !== undefined && output.Error !== null ? output.Error : undefined,
-    Progressing: output.Progressing !== undefined && output.Progressing !== null ? output.Progressing : undefined,
-    Warning: output.Warning !== undefined && output.Warning !== null ? output.Warning : undefined,
+    Completed: __expectString(output.Completed),
+    Error: __expectString(output.Error),
+    Progressing: __expectString(output.Progressing),
+    Warning: __expectString(output.Warning),
   } as any;
 };
 
@@ -3164,7 +3142,7 @@ const deserializeAws_restJson1OutputKeys = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3174,8 +3152,8 @@ const deserializeAws_restJson1Permission = (output: any, context: __SerdeContext
       output.Access !== undefined && output.Access !== null
         ? deserializeAws_restJson1AccessControls(output.Access, context)
         : undefined,
-    Grantee: output.Grantee !== undefined && output.Grantee !== null ? output.Grantee : undefined,
-    GranteeType: output.GranteeType !== undefined && output.GranteeType !== null ? output.GranteeType : undefined,
+    Grantee: __expectString(output.Grantee),
+    GranteeType: __expectString(output.GranteeType),
   } as any;
 };
 
@@ -3192,22 +3170,22 @@ const deserializeAws_restJson1Permissions = (output: any, context: __SerdeContex
 
 const deserializeAws_restJson1Pipeline = (output: any, context: __SerdeContext): Pipeline => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    AwsKmsKeyArn: output.AwsKmsKeyArn !== undefined && output.AwsKmsKeyArn !== null ? output.AwsKmsKeyArn : undefined,
+    Arn: __expectString(output.Arn),
+    AwsKmsKeyArn: __expectString(output.AwsKmsKeyArn),
     ContentConfig:
       output.ContentConfig !== undefined && output.ContentConfig !== null
         ? deserializeAws_restJson1PipelineOutputConfig(output.ContentConfig, context)
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    InputBucket: output.InputBucket !== undefined && output.InputBucket !== null ? output.InputBucket : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Id: __expectString(output.Id),
+    InputBucket: __expectString(output.InputBucket),
+    Name: __expectString(output.Name),
     Notifications:
       output.Notifications !== undefined && output.Notifications !== null
         ? deserializeAws_restJson1Notifications(output.Notifications, context)
         : undefined,
-    OutputBucket: output.OutputBucket !== undefined && output.OutputBucket !== null ? output.OutputBucket : undefined,
-    Role: output.Role !== undefined && output.Role !== null ? output.Role : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    OutputBucket: __expectString(output.OutputBucket),
+    Role: __expectString(output.Role),
+    Status: __expectString(output.Status),
     ThumbnailConfig:
       output.ThumbnailConfig !== undefined && output.ThumbnailConfig !== null
         ? deserializeAws_restJson1PipelineOutputConfig(output.ThumbnailConfig, context)
@@ -3217,12 +3195,12 @@ const deserializeAws_restJson1Pipeline = (output: any, context: __SerdeContext):
 
 const deserializeAws_restJson1PipelineOutputConfig = (output: any, context: __SerdeContext): PipelineOutputConfig => {
   return {
-    Bucket: output.Bucket !== undefined && output.Bucket !== null ? output.Bucket : undefined,
+    Bucket: __expectString(output.Bucket),
     Permissions:
       output.Permissions !== undefined && output.Permissions !== null
         ? deserializeAws_restJson1Permissions(output.Permissions, context)
         : undefined,
-    StorageClass: output.StorageClass !== undefined && output.StorageClass !== null ? output.StorageClass : undefined,
+    StorageClass: __expectString(output.StorageClass),
   } as any;
 };
 
@@ -3239,12 +3217,12 @@ const deserializeAws_restJson1Pipelines = (output: any, context: __SerdeContext)
 
 const deserializeAws_restJson1Playlist = (output: any, context: __SerdeContext): Playlist => {
   return {
-    Format: output.Format !== undefined && output.Format !== null ? output.Format : undefined,
+    Format: __expectString(output.Format),
     HlsContentProtection:
       output.HlsContentProtection !== undefined && output.HlsContentProtection !== null
         ? deserializeAws_restJson1HlsContentProtection(output.HlsContentProtection, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     OutputKeys:
       output.OutputKeys !== undefined && output.OutputKeys !== null
         ? deserializeAws_restJson1OutputKeys(output.OutputKeys, context)
@@ -3253,8 +3231,8 @@ const deserializeAws_restJson1Playlist = (output: any, context: __SerdeContext):
       output.PlayReadyDrm !== undefined && output.PlayReadyDrm !== null
         ? deserializeAws_restJson1PlayReadyDrm(output.PlayReadyDrm, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusDetail: output.StatusDetail !== undefined && output.StatusDetail !== null ? output.StatusDetail : undefined,
+    Status: __expectString(output.Status),
+    StatusDetail: __expectString(output.StatusDetail),
   } as any;
 };
 
@@ -3271,37 +3249,31 @@ const deserializeAws_restJson1Playlists = (output: any, context: __SerdeContext)
 
 const deserializeAws_restJson1PlayReadyDrm = (output: any, context: __SerdeContext): PlayReadyDrm => {
   return {
-    Format: output.Format !== undefined && output.Format !== null ? output.Format : undefined,
-    InitializationVector:
-      output.InitializationVector !== undefined && output.InitializationVector !== null
-        ? output.InitializationVector
-        : undefined,
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    KeyId: output.KeyId !== undefined && output.KeyId !== null ? output.KeyId : undefined,
-    KeyMd5: output.KeyMd5 !== undefined && output.KeyMd5 !== null ? output.KeyMd5 : undefined,
-    LicenseAcquisitionUrl:
-      output.LicenseAcquisitionUrl !== undefined && output.LicenseAcquisitionUrl !== null
-        ? output.LicenseAcquisitionUrl
-        : undefined,
+    Format: __expectString(output.Format),
+    InitializationVector: __expectString(output.InitializationVector),
+    Key: __expectString(output.Key),
+    KeyId: __expectString(output.KeyId),
+    KeyMd5: __expectString(output.KeyMd5),
+    LicenseAcquisitionUrl: __expectString(output.LicenseAcquisitionUrl),
   } as any;
 };
 
 const deserializeAws_restJson1Preset = (output: any, context: __SerdeContext): Preset => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     Audio:
       output.Audio !== undefined && output.Audio !== null
         ? deserializeAws_restJson1AudioParameters(output.Audio, context)
         : undefined,
-    Container: output.Container !== undefined && output.Container !== null ? output.Container : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Container: __expectString(output.Container),
+    Description: __expectString(output.Description),
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
     Thumbnails:
       output.Thumbnails !== undefined && output.Thumbnails !== null
         ? deserializeAws_restJson1Thumbnails(output.Thumbnails, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
     Video:
       output.Video !== undefined && output.Video !== null
         ? deserializeAws_restJson1VideoParameters(output.Video, context)
@@ -3322,20 +3294,16 @@ const deserializeAws_restJson1Presets = (output: any, context: __SerdeContext): 
 
 const deserializeAws_restJson1PresetWatermark = (output: any, context: __SerdeContext): PresetWatermark => {
   return {
-    HorizontalAlign:
-      output.HorizontalAlign !== undefined && output.HorizontalAlign !== null ? output.HorizontalAlign : undefined,
-    HorizontalOffset:
-      output.HorizontalOffset !== undefined && output.HorizontalOffset !== null ? output.HorizontalOffset : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    MaxHeight: output.MaxHeight !== undefined && output.MaxHeight !== null ? output.MaxHeight : undefined,
-    MaxWidth: output.MaxWidth !== undefined && output.MaxWidth !== null ? output.MaxWidth : undefined,
-    Opacity: output.Opacity !== undefined && output.Opacity !== null ? output.Opacity : undefined,
-    SizingPolicy: output.SizingPolicy !== undefined && output.SizingPolicy !== null ? output.SizingPolicy : undefined,
-    Target: output.Target !== undefined && output.Target !== null ? output.Target : undefined,
-    VerticalAlign:
-      output.VerticalAlign !== undefined && output.VerticalAlign !== null ? output.VerticalAlign : undefined,
-    VerticalOffset:
-      output.VerticalOffset !== undefined && output.VerticalOffset !== null ? output.VerticalOffset : undefined,
+    HorizontalAlign: __expectString(output.HorizontalAlign),
+    HorizontalOffset: __expectString(output.HorizontalOffset),
+    Id: __expectString(output.Id),
+    MaxHeight: __expectString(output.MaxHeight),
+    MaxWidth: __expectString(output.MaxWidth),
+    Opacity: __expectString(output.Opacity),
+    SizingPolicy: __expectString(output.SizingPolicy),
+    Target: __expectString(output.Target),
+    VerticalAlign: __expectString(output.VerticalAlign),
+    VerticalOffset: __expectString(output.VerticalOffset),
   } as any;
 };
 
@@ -3352,33 +3320,29 @@ const deserializeAws_restJson1PresetWatermarks = (output: any, context: __SerdeC
 
 const deserializeAws_restJson1Thumbnails = (output: any, context: __SerdeContext): Thumbnails => {
   return {
-    AspectRatio: output.AspectRatio !== undefined && output.AspectRatio !== null ? output.AspectRatio : undefined,
-    Format: output.Format !== undefined && output.Format !== null ? output.Format : undefined,
-    Interval: output.Interval !== undefined && output.Interval !== null ? output.Interval : undefined,
-    MaxHeight: output.MaxHeight !== undefined && output.MaxHeight !== null ? output.MaxHeight : undefined,
-    MaxWidth: output.MaxWidth !== undefined && output.MaxWidth !== null ? output.MaxWidth : undefined,
-    PaddingPolicy:
-      output.PaddingPolicy !== undefined && output.PaddingPolicy !== null ? output.PaddingPolicy : undefined,
-    Resolution: output.Resolution !== undefined && output.Resolution !== null ? output.Resolution : undefined,
-    SizingPolicy: output.SizingPolicy !== undefined && output.SizingPolicy !== null ? output.SizingPolicy : undefined,
+    AspectRatio: __expectString(output.AspectRatio),
+    Format: __expectString(output.Format),
+    Interval: __expectString(output.Interval),
+    MaxHeight: __expectString(output.MaxHeight),
+    MaxWidth: __expectString(output.MaxWidth),
+    PaddingPolicy: __expectString(output.PaddingPolicy),
+    Resolution: __expectString(output.Resolution),
+    SizingPolicy: __expectString(output.SizingPolicy),
   } as any;
 };
 
 const deserializeAws_restJson1TimeSpan = (output: any, context: __SerdeContext): TimeSpan => {
   return {
-    Duration: output.Duration !== undefined && output.Duration !== null ? output.Duration : undefined,
-    StartTime: output.StartTime !== undefined && output.StartTime !== null ? output.StartTime : undefined,
+    Duration: __expectString(output.Duration),
+    StartTime: __expectString(output.StartTime),
   } as any;
 };
 
 const deserializeAws_restJson1Timing = (output: any, context: __SerdeContext): Timing => {
   return {
-    FinishTimeMillis:
-      output.FinishTimeMillis !== undefined && output.FinishTimeMillis !== null ? output.FinishTimeMillis : undefined,
-    StartTimeMillis:
-      output.StartTimeMillis !== undefined && output.StartTimeMillis !== null ? output.StartTimeMillis : undefined,
-    SubmitTimeMillis:
-      output.SubmitTimeMillis !== undefined && output.SubmitTimeMillis !== null ? output.SubmitTimeMillis : undefined,
+    FinishTimeMillis: __expectNumber(output.FinishTimeMillis),
+    StartTimeMillis: __expectNumber(output.StartTimeMillis),
+    SubmitTimeMillis: __expectNumber(output.SubmitTimeMillis),
   } as any;
 };
 
@@ -3389,35 +3353,30 @@ const deserializeAws_restJson1UserMetadata = (output: any, context: __SerdeConte
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1VideoParameters = (output: any, context: __SerdeContext): VideoParameters => {
   return {
-    AspectRatio: output.AspectRatio !== undefined && output.AspectRatio !== null ? output.AspectRatio : undefined,
-    BitRate: output.BitRate !== undefined && output.BitRate !== null ? output.BitRate : undefined,
-    Codec: output.Codec !== undefined && output.Codec !== null ? output.Codec : undefined,
+    AspectRatio: __expectString(output.AspectRatio),
+    BitRate: __expectString(output.BitRate),
+    Codec: __expectString(output.Codec),
     CodecOptions:
       output.CodecOptions !== undefined && output.CodecOptions !== null
         ? deserializeAws_restJson1CodecOptions(output.CodecOptions, context)
         : undefined,
-    DisplayAspectRatio:
-      output.DisplayAspectRatio !== undefined && output.DisplayAspectRatio !== null
-        ? output.DisplayAspectRatio
-        : undefined,
-    FixedGOP: output.FixedGOP !== undefined && output.FixedGOP !== null ? output.FixedGOP : undefined,
-    FrameRate: output.FrameRate !== undefined && output.FrameRate !== null ? output.FrameRate : undefined,
-    KeyframesMaxDist:
-      output.KeyframesMaxDist !== undefined && output.KeyframesMaxDist !== null ? output.KeyframesMaxDist : undefined,
-    MaxFrameRate: output.MaxFrameRate !== undefined && output.MaxFrameRate !== null ? output.MaxFrameRate : undefined,
-    MaxHeight: output.MaxHeight !== undefined && output.MaxHeight !== null ? output.MaxHeight : undefined,
-    MaxWidth: output.MaxWidth !== undefined && output.MaxWidth !== null ? output.MaxWidth : undefined,
-    PaddingPolicy:
-      output.PaddingPolicy !== undefined && output.PaddingPolicy !== null ? output.PaddingPolicy : undefined,
-    Resolution: output.Resolution !== undefined && output.Resolution !== null ? output.Resolution : undefined,
-    SizingPolicy: output.SizingPolicy !== undefined && output.SizingPolicy !== null ? output.SizingPolicy : undefined,
+    DisplayAspectRatio: __expectString(output.DisplayAspectRatio),
+    FixedGOP: __expectString(output.FixedGOP),
+    FrameRate: __expectString(output.FrameRate),
+    KeyframesMaxDist: __expectString(output.KeyframesMaxDist),
+    MaxFrameRate: __expectString(output.MaxFrameRate),
+    MaxHeight: __expectString(output.MaxHeight),
+    MaxWidth: __expectString(output.MaxWidth),
+    PaddingPolicy: __expectString(output.PaddingPolicy),
+    Resolution: __expectString(output.Resolution),
+    SizingPolicy: __expectString(output.SizingPolicy),
     Watermarks:
       output.Watermarks !== undefined && output.Watermarks !== null
         ? deserializeAws_restJson1PresetWatermarks(output.Watermarks, context)
@@ -3427,8 +3386,8 @@ const deserializeAws_restJson1VideoParameters = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1Warning = (output: any, context: __SerdeContext): Warning => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Message: __expectString(output.Message),
   } as any;
 };
 

--- a/clients/client-elasticache/protocols/Aws_query.ts
+++ b/clients/client-elasticache/protocols/Aws_query.ts
@@ -449,6 +449,7 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
@@ -10766,7 +10767,7 @@ const deserializeAws_queryAPICallRateForCustomerExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -10777,7 +10778,7 @@ const deserializeAws_queryAuthentication = (output: any, context: __SerdeContext
     PasswordCount: undefined,
   };
   if (output["Type"] !== undefined) {
-    contents.Type = output["Type"];
+    contents.Type = __expectString(output["Type"]);
   }
   if (output["PasswordCount"] !== undefined) {
     contents.PasswordCount = parseInt(output["PasswordCount"]);
@@ -10793,7 +10794,7 @@ const deserializeAws_queryAuthorizationAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -10806,7 +10807,7 @@ const deserializeAws_queryAuthorizationNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -10829,7 +10830,7 @@ const deserializeAws_queryAvailabilityZone = (output: any, context: __SerdeConte
     Name: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   return contents;
 };
@@ -10841,7 +10842,7 @@ const deserializeAws_queryAvailabilityZonesList = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -10879,40 +10880,40 @@ const deserializeAws_queryCacheCluster = (output: any, context: __SerdeContext):
     LogDeliveryConfigurations: undefined,
   };
   if (output["CacheClusterId"] !== undefined) {
-    contents.CacheClusterId = output["CacheClusterId"];
+    contents.CacheClusterId = __expectString(output["CacheClusterId"]);
   }
   if (output["ConfigurationEndpoint"] !== undefined) {
     contents.ConfigurationEndpoint = deserializeAws_queryEndpoint(output["ConfigurationEndpoint"], context);
   }
   if (output["ClientDownloadLandingPage"] !== undefined) {
-    contents.ClientDownloadLandingPage = output["ClientDownloadLandingPage"];
+    contents.ClientDownloadLandingPage = __expectString(output["ClientDownloadLandingPage"]);
   }
   if (output["CacheNodeType"] !== undefined) {
-    contents.CacheNodeType = output["CacheNodeType"];
+    contents.CacheNodeType = __expectString(output["CacheNodeType"]);
   }
   if (output["Engine"] !== undefined) {
-    contents.Engine = output["Engine"];
+    contents.Engine = __expectString(output["Engine"]);
   }
   if (output["EngineVersion"] !== undefined) {
-    contents.EngineVersion = output["EngineVersion"];
+    contents.EngineVersion = __expectString(output["EngineVersion"]);
   }
   if (output["CacheClusterStatus"] !== undefined) {
-    contents.CacheClusterStatus = output["CacheClusterStatus"];
+    contents.CacheClusterStatus = __expectString(output["CacheClusterStatus"]);
   }
   if (output["NumCacheNodes"] !== undefined) {
     contents.NumCacheNodes = parseInt(output["NumCacheNodes"]);
   }
   if (output["PreferredAvailabilityZone"] !== undefined) {
-    contents.PreferredAvailabilityZone = output["PreferredAvailabilityZone"];
+    contents.PreferredAvailabilityZone = __expectString(output["PreferredAvailabilityZone"]);
   }
   if (output["PreferredOutpostArn"] !== undefined) {
-    contents.PreferredOutpostArn = output["PreferredOutpostArn"];
+    contents.PreferredOutpostArn = __expectString(output["PreferredOutpostArn"]);
   }
   if (output["CacheClusterCreateTime"] !== undefined) {
     contents.CacheClusterCreateTime = new Date(output["CacheClusterCreateTime"]);
   }
   if (output["PreferredMaintenanceWindow"] !== undefined) {
-    contents.PreferredMaintenanceWindow = output["PreferredMaintenanceWindow"];
+    contents.PreferredMaintenanceWindow = __expectString(output["PreferredMaintenanceWindow"]);
   }
   if (output["PendingModifiedValues"] !== undefined) {
     contents.PendingModifiedValues = deserializeAws_queryPendingModifiedValues(
@@ -10945,7 +10946,7 @@ const deserializeAws_queryCacheCluster = (output: any, context: __SerdeContext):
     );
   }
   if (output["CacheSubnetGroupName"] !== undefined) {
-    contents.CacheSubnetGroupName = output["CacheSubnetGroupName"];
+    contents.CacheSubnetGroupName = __expectString(output["CacheSubnetGroupName"]);
   }
   if (output.CacheNodes === "") {
     contents.CacheNodes = [];
@@ -10969,13 +10970,13 @@ const deserializeAws_queryCacheCluster = (output: any, context: __SerdeContext):
     );
   }
   if (output["ReplicationGroupId"] !== undefined) {
-    contents.ReplicationGroupId = output["ReplicationGroupId"];
+    contents.ReplicationGroupId = __expectString(output["ReplicationGroupId"]);
   }
   if (output["SnapshotRetentionLimit"] !== undefined) {
     contents.SnapshotRetentionLimit = parseInt(output["SnapshotRetentionLimit"]);
   }
   if (output["SnapshotWindow"] !== undefined) {
-    contents.SnapshotWindow = output["SnapshotWindow"];
+    contents.SnapshotWindow = __expectString(output["SnapshotWindow"]);
   }
   if (output["AuthTokenEnabled"] !== undefined) {
     contents.AuthTokenEnabled = __parseBoolean(output["AuthTokenEnabled"]);
@@ -10990,7 +10991,7 @@ const deserializeAws_queryCacheCluster = (output: any, context: __SerdeContext):
     contents.AtRestEncryptionEnabled = __parseBoolean(output["AtRestEncryptionEnabled"]);
   }
   if (output["ARN"] !== undefined) {
-    contents.ARN = output["ARN"];
+    contents.ARN = __expectString(output["ARN"]);
   }
   if (output["ReplicationGroupLogDeliveryEnabled"] !== undefined) {
     contents.ReplicationGroupLogDeliveryEnabled = __parseBoolean(output["ReplicationGroupLogDeliveryEnabled"]);
@@ -11018,7 +11019,7 @@ const deserializeAws_queryCacheClusterAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -11040,7 +11041,7 @@ const deserializeAws_queryCacheClusterMessage = (output: any, context: __SerdeCo
     CacheClusters: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.CacheClusters === "") {
     contents.CacheClusters = [];
@@ -11062,7 +11063,7 @@ const deserializeAws_queryCacheClusterNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -11076,19 +11077,19 @@ const deserializeAws_queryCacheEngineVersion = (output: any, context: __SerdeCon
     CacheEngineVersionDescription: undefined,
   };
   if (output["Engine"] !== undefined) {
-    contents.Engine = output["Engine"];
+    contents.Engine = __expectString(output["Engine"]);
   }
   if (output["EngineVersion"] !== undefined) {
-    contents.EngineVersion = output["EngineVersion"];
+    contents.EngineVersion = __expectString(output["EngineVersion"]);
   }
   if (output["CacheParameterGroupFamily"] !== undefined) {
-    contents.CacheParameterGroupFamily = output["CacheParameterGroupFamily"];
+    contents.CacheParameterGroupFamily = __expectString(output["CacheParameterGroupFamily"]);
   }
   if (output["CacheEngineDescription"] !== undefined) {
-    contents.CacheEngineDescription = output["CacheEngineDescription"];
+    contents.CacheEngineDescription = __expectString(output["CacheEngineDescription"]);
   }
   if (output["CacheEngineVersionDescription"] !== undefined) {
-    contents.CacheEngineVersionDescription = output["CacheEngineVersionDescription"];
+    contents.CacheEngineVersionDescription = __expectString(output["CacheEngineVersionDescription"]);
   }
   return contents;
 };
@@ -11113,7 +11114,7 @@ const deserializeAws_queryCacheEngineVersionMessage = (
     CacheEngineVersions: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.CacheEngineVersions === "") {
     contents.CacheEngineVersions = [];
@@ -11142,10 +11143,10 @@ const deserializeAws_queryCacheNode = (output: any, context: __SerdeContext): Ca
     CustomerOutpostArn: undefined,
   };
   if (output["CacheNodeId"] !== undefined) {
-    contents.CacheNodeId = output["CacheNodeId"];
+    contents.CacheNodeId = __expectString(output["CacheNodeId"]);
   }
   if (output["CacheNodeStatus"] !== undefined) {
-    contents.CacheNodeStatus = output["CacheNodeStatus"];
+    contents.CacheNodeStatus = __expectString(output["CacheNodeStatus"]);
   }
   if (output["CacheNodeCreateTime"] !== undefined) {
     contents.CacheNodeCreateTime = new Date(output["CacheNodeCreateTime"]);
@@ -11154,16 +11155,16 @@ const deserializeAws_queryCacheNode = (output: any, context: __SerdeContext): Ca
     contents.Endpoint = deserializeAws_queryEndpoint(output["Endpoint"], context);
   }
   if (output["ParameterGroupStatus"] !== undefined) {
-    contents.ParameterGroupStatus = output["ParameterGroupStatus"];
+    contents.ParameterGroupStatus = __expectString(output["ParameterGroupStatus"]);
   }
   if (output["SourceCacheNodeId"] !== undefined) {
-    contents.SourceCacheNodeId = output["SourceCacheNodeId"];
+    contents.SourceCacheNodeId = __expectString(output["SourceCacheNodeId"]);
   }
   if (output["CustomerAvailabilityZone"] !== undefined) {
-    contents.CustomerAvailabilityZone = output["CustomerAvailabilityZone"];
+    contents.CustomerAvailabilityZone = __expectString(output["CustomerAvailabilityZone"]);
   }
   if (output["CustomerOutpostArn"] !== undefined) {
-    contents.CustomerOutpostArn = output["CustomerOutpostArn"];
+    contents.CustomerOutpostArn = __expectString(output["CustomerOutpostArn"]);
   }
   return contents;
 };
@@ -11175,7 +11176,7 @@ const deserializeAws_queryCacheNodeIdsList = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -11206,25 +11207,25 @@ const deserializeAws_queryCacheNodeTypeSpecificParameter = (
     ChangeType: undefined,
   };
   if (output["ParameterName"] !== undefined) {
-    contents.ParameterName = output["ParameterName"];
+    contents.ParameterName = __expectString(output["ParameterName"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output["Source"] !== undefined) {
-    contents.Source = output["Source"];
+    contents.Source = __expectString(output["Source"]);
   }
   if (output["DataType"] !== undefined) {
-    contents.DataType = output["DataType"];
+    contents.DataType = __expectString(output["DataType"]);
   }
   if (output["AllowedValues"] !== undefined) {
-    contents.AllowedValues = output["AllowedValues"];
+    contents.AllowedValues = __expectString(output["AllowedValues"]);
   }
   if (output["IsModifiable"] !== undefined) {
     contents.IsModifiable = __parseBoolean(output["IsModifiable"]);
   }
   if (output["MinimumEngineVersion"] !== undefined) {
-    contents.MinimumEngineVersion = output["MinimumEngineVersion"];
+    contents.MinimumEngineVersion = __expectString(output["MinimumEngineVersion"]);
   }
   if (output.CacheNodeTypeSpecificValues === "") {
     contents.CacheNodeTypeSpecificValues = [];
@@ -11239,7 +11240,7 @@ const deserializeAws_queryCacheNodeTypeSpecificParameter = (
     );
   }
   if (output["ChangeType"] !== undefined) {
-    contents.ChangeType = output["ChangeType"];
+    contents.ChangeType = __expectString(output["ChangeType"]);
   }
   return contents;
 };
@@ -11267,10 +11268,10 @@ const deserializeAws_queryCacheNodeTypeSpecificValue = (
     Value: undefined,
   };
   if (output["CacheNodeType"] !== undefined) {
-    contents.CacheNodeType = output["CacheNodeType"];
+    contents.CacheNodeType = __expectString(output["CacheNodeType"]);
   }
   if (output["Value"] !== undefined) {
-    contents.Value = output["Value"];
+    contents.Value = __expectString(output["Value"]);
   }
   return contents;
 };
@@ -11301,10 +11302,10 @@ const deserializeAws_queryCacheNodeUpdateStatus = (output: any, context: __Serde
     NodeUpdateStatusModifiedDate: undefined,
   };
   if (output["CacheNodeId"] !== undefined) {
-    contents.CacheNodeId = output["CacheNodeId"];
+    contents.CacheNodeId = __expectString(output["CacheNodeId"]);
   }
   if (output["NodeUpdateStatus"] !== undefined) {
-    contents.NodeUpdateStatus = output["NodeUpdateStatus"];
+    contents.NodeUpdateStatus = __expectString(output["NodeUpdateStatus"]);
   }
   if (output["NodeDeletionDate"] !== undefined) {
     contents.NodeDeletionDate = new Date(output["NodeDeletionDate"]);
@@ -11316,7 +11317,7 @@ const deserializeAws_queryCacheNodeUpdateStatus = (output: any, context: __Serde
     contents.NodeUpdateEndDate = new Date(output["NodeUpdateEndDate"]);
   }
   if (output["NodeUpdateInitiatedBy"] !== undefined) {
-    contents.NodeUpdateInitiatedBy = output["NodeUpdateInitiatedBy"];
+    contents.NodeUpdateInitiatedBy = __expectString(output["NodeUpdateInitiatedBy"]);
   }
   if (output["NodeUpdateInitiatedDate"] !== undefined) {
     contents.NodeUpdateInitiatedDate = new Date(output["NodeUpdateInitiatedDate"]);
@@ -11350,19 +11351,19 @@ const deserializeAws_queryCacheParameterGroup = (output: any, context: __SerdeCo
     ARN: undefined,
   };
   if (output["CacheParameterGroupName"] !== undefined) {
-    contents.CacheParameterGroupName = output["CacheParameterGroupName"];
+    contents.CacheParameterGroupName = __expectString(output["CacheParameterGroupName"]);
   }
   if (output["CacheParameterGroupFamily"] !== undefined) {
-    contents.CacheParameterGroupFamily = output["CacheParameterGroupFamily"];
+    contents.CacheParameterGroupFamily = __expectString(output["CacheParameterGroupFamily"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output["IsGlobal"] !== undefined) {
     contents.IsGlobal = __parseBoolean(output["IsGlobal"]);
   }
   if (output["ARN"] !== undefined) {
-    contents.ARN = output["ARN"];
+    contents.ARN = __expectString(output["ARN"]);
   }
   return contents;
 };
@@ -11375,7 +11376,7 @@ const deserializeAws_queryCacheParameterGroupAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -11390,7 +11391,7 @@ const deserializeAws_queryCacheParameterGroupDetails = (
     CacheNodeTypeSpecificParameters: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.Parameters === "") {
     contents.Parameters = [];
@@ -11435,7 +11436,7 @@ const deserializeAws_queryCacheParameterGroupNameMessage = (
     CacheParameterGroupName: undefined,
   };
   if (output["CacheParameterGroupName"] !== undefined) {
-    contents.CacheParameterGroupName = output["CacheParameterGroupName"];
+    contents.CacheParameterGroupName = __expectString(output["CacheParameterGroupName"]);
   }
   return contents;
 };
@@ -11448,7 +11449,7 @@ const deserializeAws_queryCacheParameterGroupNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -11461,7 +11462,7 @@ const deserializeAws_queryCacheParameterGroupQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -11475,7 +11476,7 @@ const deserializeAws_queryCacheParameterGroupsMessage = (
     CacheParameterGroups: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.CacheParameterGroups === "") {
     contents.CacheParameterGroups = [];
@@ -11502,10 +11503,10 @@ const deserializeAws_queryCacheParameterGroupStatus = (
     CacheNodeIdsToReboot: undefined,
   };
   if (output["CacheParameterGroupName"] !== undefined) {
-    contents.CacheParameterGroupName = output["CacheParameterGroupName"];
+    contents.CacheParameterGroupName = __expectString(output["CacheParameterGroupName"]);
   }
   if (output["ParameterApplyStatus"] !== undefined) {
-    contents.ParameterApplyStatus = output["ParameterApplyStatus"];
+    contents.ParameterApplyStatus = __expectString(output["ParameterApplyStatus"]);
   }
   if (output.CacheNodeIdsToReboot === "") {
     contents.CacheNodeIdsToReboot = [];
@@ -11528,13 +11529,13 @@ const deserializeAws_queryCacheSecurityGroup = (output: any, context: __SerdeCon
     ARN: undefined,
   };
   if (output["OwnerId"] !== undefined) {
-    contents.OwnerId = output["OwnerId"];
+    contents.OwnerId = __expectString(output["OwnerId"]);
   }
   if (output["CacheSecurityGroupName"] !== undefined) {
-    contents.CacheSecurityGroupName = output["CacheSecurityGroupName"];
+    contents.CacheSecurityGroupName = __expectString(output["CacheSecurityGroupName"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output.EC2SecurityGroups === "") {
     contents.EC2SecurityGroups = [];
@@ -11546,7 +11547,7 @@ const deserializeAws_queryCacheSecurityGroup = (output: any, context: __SerdeCon
     );
   }
   if (output["ARN"] !== undefined) {
-    contents.ARN = output["ARN"];
+    contents.ARN = __expectString(output["ARN"]);
   }
   return contents;
 };
@@ -11559,7 +11560,7 @@ const deserializeAws_queryCacheSecurityGroupAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -11573,10 +11574,10 @@ const deserializeAws_queryCacheSecurityGroupMembership = (
     Status: undefined,
   };
   if (output["CacheSecurityGroupName"] !== undefined) {
-    contents.CacheSecurityGroupName = output["CacheSecurityGroupName"];
+    contents.CacheSecurityGroupName = __expectString(output["CacheSecurityGroupName"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   return contents;
 };
@@ -11604,7 +11605,7 @@ const deserializeAws_queryCacheSecurityGroupMessage = (
     CacheSecurityGroups: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.CacheSecurityGroups === "") {
     contents.CacheSecurityGroups = [];
@@ -11629,7 +11630,7 @@ const deserializeAws_queryCacheSecurityGroupNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -11642,7 +11643,7 @@ const deserializeAws_queryCacheSecurityGroupQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -11667,13 +11668,13 @@ const deserializeAws_queryCacheSubnetGroup = (output: any, context: __SerdeConte
     ARN: undefined,
   };
   if (output["CacheSubnetGroupName"] !== undefined) {
-    contents.CacheSubnetGroupName = output["CacheSubnetGroupName"];
+    contents.CacheSubnetGroupName = __expectString(output["CacheSubnetGroupName"]);
   }
   if (output["CacheSubnetGroupDescription"] !== undefined) {
-    contents.CacheSubnetGroupDescription = output["CacheSubnetGroupDescription"];
+    contents.CacheSubnetGroupDescription = __expectString(output["CacheSubnetGroupDescription"]);
   }
   if (output["VpcId"] !== undefined) {
-    contents.VpcId = output["VpcId"];
+    contents.VpcId = __expectString(output["VpcId"]);
   }
   if (output.Subnets === "") {
     contents.Subnets = [];
@@ -11682,7 +11683,7 @@ const deserializeAws_queryCacheSubnetGroup = (output: any, context: __SerdeConte
     contents.Subnets = deserializeAws_querySubnetList(__getArrayIfSingleItem(output["Subnets"]["Subnet"]), context);
   }
   if (output["ARN"] !== undefined) {
-    contents.ARN = output["ARN"];
+    contents.ARN = __expectString(output["ARN"]);
   }
   return contents;
 };
@@ -11695,7 +11696,7 @@ const deserializeAws_queryCacheSubnetGroupAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -11705,7 +11706,7 @@ const deserializeAws_queryCacheSubnetGroupInUse = (output: any, context: __Serde
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -11716,7 +11717,7 @@ const deserializeAws_queryCacheSubnetGroupMessage = (output: any, context: __Ser
     CacheSubnetGroups: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.CacheSubnetGroups === "") {
     contents.CacheSubnetGroups = [];
@@ -11738,7 +11739,7 @@ const deserializeAws_queryCacheSubnetGroupNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -11751,7 +11752,7 @@ const deserializeAws_queryCacheSubnetGroupQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -11775,7 +11776,7 @@ const deserializeAws_queryCacheSubnetQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -11788,7 +11789,7 @@ const deserializeAws_queryCloudWatchLogsDestinationDetails = (
     LogGroup: undefined,
   };
   if (output["LogGroup"] !== undefined) {
-    contents.LogGroup = output["LogGroup"];
+    contents.LogGroup = __expectString(output["LogGroup"]);
   }
   return contents;
 };
@@ -11800,7 +11801,7 @@ const deserializeAws_queryClusterIdList = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -11812,7 +11813,7 @@ const deserializeAws_queryClusterQuotaForCustomerExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -11968,7 +11969,7 @@ const deserializeAws_queryDefaultUserAssociatedToUserGroupFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -11978,7 +11979,7 @@ const deserializeAws_queryDefaultUserRequired = (output: any, context: __SerdeCo
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -12057,7 +12058,7 @@ const deserializeAws_queryDescribeGlobalReplicationGroupsResult = (
     GlobalReplicationGroups: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.GlobalReplicationGroups === "") {
     contents.GlobalReplicationGroups = [];
@@ -12083,7 +12084,7 @@ const deserializeAws_queryDescribeSnapshotsListMessage = (
     Snapshots: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.Snapshots === "") {
     contents.Snapshots = [];
@@ -12115,7 +12116,7 @@ const deserializeAws_queryDescribeUserGroupsResult = (
     );
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -12132,7 +12133,7 @@ const deserializeAws_queryDescribeUsersResult = (output: any, context: __SerdeCo
     contents.Users = deserializeAws_queryUserList(__getArrayIfSingleItem(output["Users"]["member"]), context);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -12178,7 +12179,7 @@ const deserializeAws_queryDuplicateUserNameFault = (output: any, context: __Serd
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -12190,13 +12191,13 @@ const deserializeAws_queryEC2SecurityGroup = (output: any, context: __SerdeConte
     EC2SecurityGroupOwnerId: undefined,
   };
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["EC2SecurityGroupName"] !== undefined) {
-    contents.EC2SecurityGroupName = output["EC2SecurityGroupName"];
+    contents.EC2SecurityGroupName = __expectString(output["EC2SecurityGroupName"]);
   }
   if (output["EC2SecurityGroupOwnerId"] !== undefined) {
-    contents.EC2SecurityGroupOwnerId = output["EC2SecurityGroupOwnerId"];
+    contents.EC2SecurityGroupOwnerId = __expectString(output["EC2SecurityGroupOwnerId"]);
   }
   return contents;
 };
@@ -12218,7 +12219,7 @@ const deserializeAws_queryEndpoint = (output: any, context: __SerdeContext): End
     Port: undefined,
   };
   if (output["Address"] !== undefined) {
-    contents.Address = output["Address"];
+    contents.Address = __expectString(output["Address"]);
   }
   if (output["Port"] !== undefined) {
     contents.Port = parseInt(output["Port"]);
@@ -12234,10 +12235,10 @@ const deserializeAws_queryEngineDefaults = (output: any, context: __SerdeContext
     CacheNodeTypeSpecificParameters: undefined,
   };
   if (output["CacheParameterGroupFamily"] !== undefined) {
-    contents.CacheParameterGroupFamily = output["CacheParameterGroupFamily"];
+    contents.CacheParameterGroupFamily = __expectString(output["CacheParameterGroupFamily"]);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.Parameters === "") {
     contents.Parameters = [];
@@ -12271,13 +12272,13 @@ const deserializeAws_queryEvent = (output: any, context: __SerdeContext): Event 
     Date: undefined,
   };
   if (output["SourceIdentifier"] !== undefined) {
-    contents.SourceIdentifier = output["SourceIdentifier"];
+    contents.SourceIdentifier = __expectString(output["SourceIdentifier"]);
   }
   if (output["SourceType"] !== undefined) {
-    contents.SourceType = output["SourceType"];
+    contents.SourceType = __expectString(output["SourceType"]);
   }
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   if (output["Date"] !== undefined) {
     contents.Date = new Date(output["Date"]);
@@ -12302,7 +12303,7 @@ const deserializeAws_queryEventsMessage = (output: any, context: __SerdeContext)
     Events: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.Events === "") {
     contents.Events = [];
@@ -12335,10 +12336,10 @@ const deserializeAws_queryGlobalNodeGroup = (output: any, context: __SerdeContex
     Slots: undefined,
   };
   if (output["GlobalNodeGroupId"] !== undefined) {
-    contents.GlobalNodeGroupId = output["GlobalNodeGroupId"];
+    contents.GlobalNodeGroupId = __expectString(output["GlobalNodeGroupId"]);
   }
   if (output["Slots"] !== undefined) {
-    contents.Slots = output["Slots"];
+    contents.Slots = __expectString(output["Slots"]);
   }
   return contents;
 };
@@ -12371,22 +12372,22 @@ const deserializeAws_queryGlobalReplicationGroup = (output: any, context: __Serd
     ARN: undefined,
   };
   if (output["GlobalReplicationGroupId"] !== undefined) {
-    contents.GlobalReplicationGroupId = output["GlobalReplicationGroupId"];
+    contents.GlobalReplicationGroupId = __expectString(output["GlobalReplicationGroupId"]);
   }
   if (output["GlobalReplicationGroupDescription"] !== undefined) {
-    contents.GlobalReplicationGroupDescription = output["GlobalReplicationGroupDescription"];
+    contents.GlobalReplicationGroupDescription = __expectString(output["GlobalReplicationGroupDescription"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["CacheNodeType"] !== undefined) {
-    contents.CacheNodeType = output["CacheNodeType"];
+    contents.CacheNodeType = __expectString(output["CacheNodeType"]);
   }
   if (output["Engine"] !== undefined) {
-    contents.Engine = output["Engine"];
+    contents.Engine = __expectString(output["Engine"]);
   }
   if (output["EngineVersion"] !== undefined) {
-    contents.EngineVersion = output["EngineVersion"];
+    contents.EngineVersion = __expectString(output["EngineVersion"]);
   }
   if (output.Members === "") {
     contents.Members = [];
@@ -12419,7 +12420,7 @@ const deserializeAws_queryGlobalReplicationGroup = (output: any, context: __Serd
     contents.AtRestEncryptionEnabled = __parseBoolean(output["AtRestEncryptionEnabled"]);
   }
   if (output["ARN"] !== undefined) {
-    contents.ARN = output["ARN"];
+    contents.ARN = __expectString(output["ARN"]);
   }
   return contents;
 };
@@ -12432,7 +12433,7 @@ const deserializeAws_queryGlobalReplicationGroupAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -12446,10 +12447,10 @@ const deserializeAws_queryGlobalReplicationGroupInfo = (
     GlobalReplicationGroupMemberRole: undefined,
   };
   if (output["GlobalReplicationGroupId"] !== undefined) {
-    contents.GlobalReplicationGroupId = output["GlobalReplicationGroupId"];
+    contents.GlobalReplicationGroupId = __expectString(output["GlobalReplicationGroupId"]);
   }
   if (output["GlobalReplicationGroupMemberRole"] !== undefined) {
-    contents.GlobalReplicationGroupMemberRole = output["GlobalReplicationGroupMemberRole"];
+    contents.GlobalReplicationGroupMemberRole = __expectString(output["GlobalReplicationGroupMemberRole"]);
   }
   return contents;
 };
@@ -12480,19 +12481,19 @@ const deserializeAws_queryGlobalReplicationGroupMember = (
     Status: undefined,
   };
   if (output["ReplicationGroupId"] !== undefined) {
-    contents.ReplicationGroupId = output["ReplicationGroupId"];
+    contents.ReplicationGroupId = __expectString(output["ReplicationGroupId"]);
   }
   if (output["ReplicationGroupRegion"] !== undefined) {
-    contents.ReplicationGroupRegion = output["ReplicationGroupRegion"];
+    contents.ReplicationGroupRegion = __expectString(output["ReplicationGroupRegion"]);
   }
   if (output["Role"] !== undefined) {
-    contents.Role = output["Role"];
+    contents.Role = __expectString(output["Role"]);
   }
   if (output["AutomaticFailover"] !== undefined) {
-    contents.AutomaticFailover = output["AutomaticFailover"];
+    contents.AutomaticFailover = __expectString(output["AutomaticFailover"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   return contents;
 };
@@ -12519,7 +12520,7 @@ const deserializeAws_queryGlobalReplicationGroupNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -12561,7 +12562,7 @@ const deserializeAws_queryInsufficientCacheClusterCapacityFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -12571,7 +12572,7 @@ const deserializeAws_queryInvalidARNFault = (output: any, context: __SerdeContex
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -12584,7 +12585,7 @@ const deserializeAws_queryInvalidCacheClusterStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -12597,7 +12598,7 @@ const deserializeAws_queryInvalidCacheParameterGroupStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -12610,7 +12611,7 @@ const deserializeAws_queryInvalidCacheSecurityGroupStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -12623,7 +12624,7 @@ const deserializeAws_queryInvalidGlobalReplicationGroupStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -12633,7 +12634,7 @@ const deserializeAws_queryInvalidKMSKeyFault = (output: any, context: __SerdeCon
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -12646,7 +12647,7 @@ const deserializeAws_queryInvalidParameterCombinationException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -12659,7 +12660,7 @@ const deserializeAws_queryInvalidParameterValueException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -12672,7 +12673,7 @@ const deserializeAws_queryInvalidReplicationGroupStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -12685,7 +12686,7 @@ const deserializeAws_queryInvalidSnapshotStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -12695,7 +12696,7 @@ const deserializeAws_queryInvalidSubnet = (output: any, context: __SerdeContext)
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -12708,7 +12709,7 @@ const deserializeAws_queryInvalidUserGroupStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -12718,7 +12719,7 @@ const deserializeAws_queryInvalidUserStateFault = (output: any, context: __Serde
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -12731,7 +12732,7 @@ const deserializeAws_queryInvalidVPCNetworkStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -12744,7 +12745,7 @@ const deserializeAws_queryKinesisFirehoseDestinationDetails = (
     DeliveryStream: undefined,
   };
   if (output["DeliveryStream"] !== undefined) {
-    contents.DeliveryStream = output["DeliveryStream"];
+    contents.DeliveryStream = __expectString(output["DeliveryStream"]);
   }
   return contents;
 };
@@ -12762,22 +12763,22 @@ const deserializeAws_queryLogDeliveryConfiguration = (
     Message: undefined,
   };
   if (output["LogType"] !== undefined) {
-    contents.LogType = output["LogType"];
+    contents.LogType = __expectString(output["LogType"]);
   }
   if (output["DestinationType"] !== undefined) {
-    contents.DestinationType = output["DestinationType"];
+    contents.DestinationType = __expectString(output["DestinationType"]);
   }
   if (output["DestinationDetails"] !== undefined) {
     contents.DestinationDetails = deserializeAws_queryDestinationDetails(output["DestinationDetails"], context);
   }
   if (output["LogFormat"] !== undefined) {
-    contents.LogFormat = output["LogFormat"];
+    contents.LogFormat = __expectString(output["LogFormat"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -12874,10 +12875,10 @@ const deserializeAws_queryNodeGroup = (output: any, context: __SerdeContext): No
     NodeGroupMembers: undefined,
   };
   if (output["NodeGroupId"] !== undefined) {
-    contents.NodeGroupId = output["NodeGroupId"];
+    contents.NodeGroupId = __expectString(output["NodeGroupId"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["PrimaryEndpoint"] !== undefined) {
     contents.PrimaryEndpoint = deserializeAws_queryEndpoint(output["PrimaryEndpoint"], context);
@@ -12886,7 +12887,7 @@ const deserializeAws_queryNodeGroup = (output: any, context: __SerdeContext): No
     contents.ReaderEndpoint = deserializeAws_queryEndpoint(output["ReaderEndpoint"], context);
   }
   if (output["Slots"] !== undefined) {
-    contents.Slots = output["Slots"];
+    contents.Slots = __expectString(output["Slots"]);
   }
   if (output.NodeGroupMembers === "") {
     contents.NodeGroupMembers = [];
@@ -12911,16 +12912,16 @@ const deserializeAws_queryNodeGroupConfiguration = (output: any, context: __Serd
     ReplicaOutpostArns: undefined,
   };
   if (output["NodeGroupId"] !== undefined) {
-    contents.NodeGroupId = output["NodeGroupId"];
+    contents.NodeGroupId = __expectString(output["NodeGroupId"]);
   }
   if (output["Slots"] !== undefined) {
-    contents.Slots = output["Slots"];
+    contents.Slots = __expectString(output["Slots"]);
   }
   if (output["ReplicaCount"] !== undefined) {
     contents.ReplicaCount = parseInt(output["ReplicaCount"]);
   }
   if (output["PrimaryAvailabilityZone"] !== undefined) {
-    contents.PrimaryAvailabilityZone = output["PrimaryAvailabilityZone"];
+    contents.PrimaryAvailabilityZone = __expectString(output["PrimaryAvailabilityZone"]);
   }
   if (output.ReplicaAvailabilityZones === "") {
     contents.ReplicaAvailabilityZones = [];
@@ -12935,7 +12936,7 @@ const deserializeAws_queryNodeGroupConfiguration = (output: any, context: __Serd
     );
   }
   if (output["PrimaryOutpostArn"] !== undefined) {
-    contents.PrimaryOutpostArn = output["PrimaryOutpostArn"];
+    contents.PrimaryOutpostArn = __expectString(output["PrimaryOutpostArn"]);
   }
   if (output.ReplicaOutpostArns === "") {
     contents.ReplicaOutpostArns = [];
@@ -12970,22 +12971,22 @@ const deserializeAws_queryNodeGroupMember = (output: any, context: __SerdeContex
     CurrentRole: undefined,
   };
   if (output["CacheClusterId"] !== undefined) {
-    contents.CacheClusterId = output["CacheClusterId"];
+    contents.CacheClusterId = __expectString(output["CacheClusterId"]);
   }
   if (output["CacheNodeId"] !== undefined) {
-    contents.CacheNodeId = output["CacheNodeId"];
+    contents.CacheNodeId = __expectString(output["CacheNodeId"]);
   }
   if (output["ReadEndpoint"] !== undefined) {
     contents.ReadEndpoint = deserializeAws_queryEndpoint(output["ReadEndpoint"], context);
   }
   if (output["PreferredAvailabilityZone"] !== undefined) {
-    contents.PreferredAvailabilityZone = output["PreferredAvailabilityZone"];
+    contents.PreferredAvailabilityZone = __expectString(output["PreferredAvailabilityZone"]);
   }
   if (output["PreferredOutpostArn"] !== undefined) {
-    contents.PreferredOutpostArn = output["PreferredOutpostArn"];
+    contents.PreferredOutpostArn = __expectString(output["PreferredOutpostArn"]);
   }
   if (output["CurrentRole"] !== undefined) {
-    contents.CurrentRole = output["CurrentRole"];
+    contents.CurrentRole = __expectString(output["CurrentRole"]);
   }
   return contents;
 };
@@ -13017,13 +13018,13 @@ const deserializeAws_queryNodeGroupMemberUpdateStatus = (
     NodeUpdateStatusModifiedDate: undefined,
   };
   if (output["CacheClusterId"] !== undefined) {
-    contents.CacheClusterId = output["CacheClusterId"];
+    contents.CacheClusterId = __expectString(output["CacheClusterId"]);
   }
   if (output["CacheNodeId"] !== undefined) {
-    contents.CacheNodeId = output["CacheNodeId"];
+    contents.CacheNodeId = __expectString(output["CacheNodeId"]);
   }
   if (output["NodeUpdateStatus"] !== undefined) {
-    contents.NodeUpdateStatus = output["NodeUpdateStatus"];
+    contents.NodeUpdateStatus = __expectString(output["NodeUpdateStatus"]);
   }
   if (output["NodeDeletionDate"] !== undefined) {
     contents.NodeDeletionDate = new Date(output["NodeDeletionDate"]);
@@ -13035,7 +13036,7 @@ const deserializeAws_queryNodeGroupMemberUpdateStatus = (
     contents.NodeUpdateEndDate = new Date(output["NodeUpdateEndDate"]);
   }
   if (output["NodeUpdateInitiatedBy"] !== undefined) {
-    contents.NodeUpdateInitiatedBy = output["NodeUpdateInitiatedBy"];
+    contents.NodeUpdateInitiatedBy = __expectString(output["NodeUpdateInitiatedBy"]);
   }
   if (output["NodeUpdateInitiatedDate"] !== undefined) {
     contents.NodeUpdateInitiatedDate = new Date(output["NodeUpdateInitiatedDate"]);
@@ -13065,7 +13066,7 @@ const deserializeAws_queryNodeGroupNotFoundFault = (output: any, context: __Serd
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -13078,7 +13079,7 @@ const deserializeAws_queryNodeGroupsPerReplicationGroupQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -13089,7 +13090,7 @@ const deserializeAws_queryNodeGroupUpdateStatus = (output: any, context: __Serde
     NodeGroupMemberUpdateStatus: undefined,
   };
   if (output["NodeGroupId"] !== undefined) {
-    contents.NodeGroupId = output["NodeGroupId"];
+    contents.NodeGroupId = __expectString(output["NodeGroupId"]);
   }
   if (output.NodeGroupMemberUpdateStatus === "") {
     contents.NodeGroupMemberUpdateStatus = [];
@@ -13128,7 +13129,7 @@ const deserializeAws_queryNodeQuotaForClusterExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -13141,7 +13142,7 @@ const deserializeAws_queryNodeQuotaForCustomerExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -13157,13 +13158,13 @@ const deserializeAws_queryNodeSnapshot = (output: any, context: __SerdeContext):
     SnapshotCreateTime: undefined,
   };
   if (output["CacheClusterId"] !== undefined) {
-    contents.CacheClusterId = output["CacheClusterId"];
+    contents.CacheClusterId = __expectString(output["CacheClusterId"]);
   }
   if (output["NodeGroupId"] !== undefined) {
-    contents.NodeGroupId = output["NodeGroupId"];
+    contents.NodeGroupId = __expectString(output["NodeGroupId"]);
   }
   if (output["CacheNodeId"] !== undefined) {
-    contents.CacheNodeId = output["CacheNodeId"];
+    contents.CacheNodeId = __expectString(output["CacheNodeId"]);
   }
   if (output["NodeGroupConfiguration"] !== undefined) {
     contents.NodeGroupConfiguration = deserializeAws_queryNodeGroupConfiguration(
@@ -13172,7 +13173,7 @@ const deserializeAws_queryNodeSnapshot = (output: any, context: __SerdeContext):
     );
   }
   if (output["CacheSize"] !== undefined) {
-    contents.CacheSize = output["CacheSize"];
+    contents.CacheSize = __expectString(output["CacheSize"]);
   }
   if (output["CacheNodeCreateTime"] !== undefined) {
     contents.CacheNodeCreateTime = new Date(output["CacheNodeCreateTime"]);
@@ -13201,7 +13202,7 @@ const deserializeAws_queryNodeTypeList = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -13210,7 +13211,7 @@ const deserializeAws_queryNoOperationFault = (output: any, context: __SerdeConte
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -13224,10 +13225,10 @@ const deserializeAws_queryNotificationConfiguration = (
     TopicStatus: undefined,
   };
   if (output["TopicArn"] !== undefined) {
-    contents.TopicArn = output["TopicArn"];
+    contents.TopicArn = __expectString(output["TopicArn"]);
   }
   if (output["TopicStatus"] !== undefined) {
-    contents.TopicStatus = output["TopicStatus"];
+    contents.TopicStatus = __expectString(output["TopicStatus"]);
   }
   return contents;
 };
@@ -13239,7 +13240,7 @@ const deserializeAws_queryOutpostArnsList = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -13256,31 +13257,31 @@ const deserializeAws_queryParameter = (output: any, context: __SerdeContext): Pa
     ChangeType: undefined,
   };
   if (output["ParameterName"] !== undefined) {
-    contents.ParameterName = output["ParameterName"];
+    contents.ParameterName = __expectString(output["ParameterName"]);
   }
   if (output["ParameterValue"] !== undefined) {
-    contents.ParameterValue = output["ParameterValue"];
+    contents.ParameterValue = __expectString(output["ParameterValue"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output["Source"] !== undefined) {
-    contents.Source = output["Source"];
+    contents.Source = __expectString(output["Source"]);
   }
   if (output["DataType"] !== undefined) {
-    contents.DataType = output["DataType"];
+    contents.DataType = __expectString(output["DataType"]);
   }
   if (output["AllowedValues"] !== undefined) {
-    contents.AllowedValues = output["AllowedValues"];
+    contents.AllowedValues = __expectString(output["AllowedValues"]);
   }
   if (output["IsModifiable"] !== undefined) {
     contents.IsModifiable = __parseBoolean(output["IsModifiable"]);
   }
   if (output["MinimumEngineVersion"] !== undefined) {
-    contents.MinimumEngineVersion = output["MinimumEngineVersion"];
+    contents.MinimumEngineVersion = __expectString(output["MinimumEngineVersion"]);
   }
   if (output["ChangeType"] !== undefined) {
-    contents.ChangeType = output["ChangeType"];
+    contents.ChangeType = __expectString(output["ChangeType"]);
   }
   return contents;
 };
@@ -13307,16 +13308,16 @@ const deserializeAws_queryPendingLogDeliveryConfiguration = (
     LogFormat: undefined,
   };
   if (output["LogType"] !== undefined) {
-    contents.LogType = output["LogType"];
+    contents.LogType = __expectString(output["LogType"]);
   }
   if (output["DestinationType"] !== undefined) {
-    contents.DestinationType = output["DestinationType"];
+    contents.DestinationType = __expectString(output["DestinationType"]);
   }
   if (output["DestinationDetails"] !== undefined) {
     contents.DestinationDetails = deserializeAws_queryDestinationDetails(output["DestinationDetails"], context);
   }
   if (output["LogFormat"] !== undefined) {
-    contents.LogFormat = output["LogFormat"];
+    contents.LogFormat = __expectString(output["LogFormat"]);
   }
   return contents;
 };
@@ -13357,13 +13358,13 @@ const deserializeAws_queryPendingModifiedValues = (output: any, context: __Serde
     );
   }
   if (output["EngineVersion"] !== undefined) {
-    contents.EngineVersion = output["EngineVersion"];
+    contents.EngineVersion = __expectString(output["EngineVersion"]);
   }
   if (output["CacheNodeType"] !== undefined) {
-    contents.CacheNodeType = output["CacheNodeType"];
+    contents.CacheNodeType = __expectString(output["CacheNodeType"]);
   }
   if (output["AuthTokenStatus"] !== undefined) {
-    contents.AuthTokenStatus = output["AuthTokenStatus"];
+    contents.AuthTokenStatus = __expectString(output["AuthTokenStatus"]);
   }
   if (output.LogDeliveryConfigurations === "") {
     contents.LogDeliveryConfigurations = [];
@@ -13388,16 +13389,16 @@ const deserializeAws_queryProcessedUpdateAction = (output: any, context: __Serde
     UpdateActionStatus: undefined,
   };
   if (output["ReplicationGroupId"] !== undefined) {
-    contents.ReplicationGroupId = output["ReplicationGroupId"];
+    contents.ReplicationGroupId = __expectString(output["ReplicationGroupId"]);
   }
   if (output["CacheClusterId"] !== undefined) {
-    contents.CacheClusterId = output["CacheClusterId"];
+    contents.CacheClusterId = __expectString(output["CacheClusterId"]);
   }
   if (output["ServiceUpdateName"] !== undefined) {
-    contents.ServiceUpdateName = output["ServiceUpdateName"];
+    contents.ServiceUpdateName = __expectString(output["ServiceUpdateName"]);
   }
   if (output["UpdateActionStatus"] !== undefined) {
-    contents.UpdateActionStatus = output["UpdateActionStatus"];
+    contents.UpdateActionStatus = __expectString(output["UpdateActionStatus"]);
   }
   return contents;
 };
@@ -13467,7 +13468,7 @@ const deserializeAws_queryRecurringCharge = (output: any, context: __SerdeContex
     contents.RecurringChargeAmount = parseFloat(output["RecurringChargeAmount"]);
   }
   if (output["RecurringChargeFrequency"] !== undefined) {
-    contents.RecurringChargeFrequency = output["RecurringChargeFrequency"];
+    contents.RecurringChargeFrequency = __expectString(output["RecurringChargeFrequency"]);
   }
   return contents;
 };
@@ -13511,10 +13512,10 @@ const deserializeAws_queryReplicationGroup = (output: any, context: __SerdeConte
     LogDeliveryConfigurations: undefined,
   };
   if (output["ReplicationGroupId"] !== undefined) {
-    contents.ReplicationGroupId = output["ReplicationGroupId"];
+    contents.ReplicationGroupId = __expectString(output["ReplicationGroupId"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output["GlobalReplicationGroupInfo"] !== undefined) {
     contents.GlobalReplicationGroupInfo = deserializeAws_queryGlobalReplicationGroupInfo(
@@ -13523,7 +13524,7 @@ const deserializeAws_queryReplicationGroup = (output: any, context: __SerdeConte
     );
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["PendingModifiedValues"] !== undefined) {
     contents.PendingModifiedValues = deserializeAws_queryReplicationGroupPendingModifiedValues(
@@ -13550,13 +13551,13 @@ const deserializeAws_queryReplicationGroup = (output: any, context: __SerdeConte
     );
   }
   if (output["SnapshottingClusterId"] !== undefined) {
-    contents.SnapshottingClusterId = output["SnapshottingClusterId"];
+    contents.SnapshottingClusterId = __expectString(output["SnapshottingClusterId"]);
   }
   if (output["AutomaticFailover"] !== undefined) {
-    contents.AutomaticFailover = output["AutomaticFailover"];
+    contents.AutomaticFailover = __expectString(output["AutomaticFailover"]);
   }
   if (output["MultiAZ"] !== undefined) {
-    contents.MultiAZ = output["MultiAZ"];
+    contents.MultiAZ = __expectString(output["MultiAZ"]);
   }
   if (output["ConfigurationEndpoint"] !== undefined) {
     contents.ConfigurationEndpoint = deserializeAws_queryEndpoint(output["ConfigurationEndpoint"], context);
@@ -13565,13 +13566,13 @@ const deserializeAws_queryReplicationGroup = (output: any, context: __SerdeConte
     contents.SnapshotRetentionLimit = parseInt(output["SnapshotRetentionLimit"]);
   }
   if (output["SnapshotWindow"] !== undefined) {
-    contents.SnapshotWindow = output["SnapshotWindow"];
+    contents.SnapshotWindow = __expectString(output["SnapshotWindow"]);
   }
   if (output["ClusterEnabled"] !== undefined) {
     contents.ClusterEnabled = __parseBoolean(output["ClusterEnabled"]);
   }
   if (output["CacheNodeType"] !== undefined) {
-    contents.CacheNodeType = output["CacheNodeType"];
+    contents.CacheNodeType = __expectString(output["CacheNodeType"]);
   }
   if (output["AuthTokenEnabled"] !== undefined) {
     contents.AuthTokenEnabled = __parseBoolean(output["AuthTokenEnabled"]);
@@ -13598,10 +13599,10 @@ const deserializeAws_queryReplicationGroup = (output: any, context: __SerdeConte
     );
   }
   if (output["KmsKeyId"] !== undefined) {
-    contents.KmsKeyId = output["KmsKeyId"];
+    contents.KmsKeyId = __expectString(output["KmsKeyId"]);
   }
   if (output["ARN"] !== undefined) {
-    contents.ARN = output["ARN"];
+    contents.ARN = __expectString(output["ARN"]);
   }
   if (output.UserGroupIds === "") {
     contents.UserGroupIds = [];
@@ -13635,7 +13636,7 @@ const deserializeAws_queryReplicationGroupAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -13648,7 +13649,7 @@ const deserializeAws_queryReplicationGroupAlreadyUnderMigrationFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -13670,7 +13671,7 @@ const deserializeAws_queryReplicationGroupMessage = (output: any, context: __Ser
     ReplicationGroups: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.ReplicationGroups === "") {
     contents.ReplicationGroups = [];
@@ -13692,7 +13693,7 @@ const deserializeAws_queryReplicationGroupNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -13705,7 +13706,7 @@ const deserializeAws_queryReplicationGroupNotUnderMigrationFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -13717,7 +13718,7 @@ const deserializeAws_queryReplicationGroupOutpostArnList = (output: any, context
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -13734,16 +13735,16 @@ const deserializeAws_queryReplicationGroupPendingModifiedValues = (
     LogDeliveryConfigurations: undefined,
   };
   if (output["PrimaryClusterId"] !== undefined) {
-    contents.PrimaryClusterId = output["PrimaryClusterId"];
+    contents.PrimaryClusterId = __expectString(output["PrimaryClusterId"]);
   }
   if (output["AutomaticFailoverStatus"] !== undefined) {
-    contents.AutomaticFailoverStatus = output["AutomaticFailoverStatus"];
+    contents.AutomaticFailoverStatus = __expectString(output["AutomaticFailoverStatus"]);
   }
   if (output["Resharding"] !== undefined) {
     contents.Resharding = deserializeAws_queryReshardingStatus(output["Resharding"], context);
   }
   if (output["AuthTokenStatus"] !== undefined) {
-    contents.AuthTokenStatus = output["AuthTokenStatus"];
+    contents.AuthTokenStatus = __expectString(output["AuthTokenStatus"]);
   }
   if (output["UserGroups"] !== undefined) {
     contents.UserGroups = deserializeAws_queryUserGroupsUpdateStatus(output["UserGroups"], context);
@@ -13780,13 +13781,13 @@ const deserializeAws_queryReservedCacheNode = (output: any, context: __SerdeCont
     ReservationARN: undefined,
   };
   if (output["ReservedCacheNodeId"] !== undefined) {
-    contents.ReservedCacheNodeId = output["ReservedCacheNodeId"];
+    contents.ReservedCacheNodeId = __expectString(output["ReservedCacheNodeId"]);
   }
   if (output["ReservedCacheNodesOfferingId"] !== undefined) {
-    contents.ReservedCacheNodesOfferingId = output["ReservedCacheNodesOfferingId"];
+    contents.ReservedCacheNodesOfferingId = __expectString(output["ReservedCacheNodesOfferingId"]);
   }
   if (output["CacheNodeType"] !== undefined) {
-    contents.CacheNodeType = output["CacheNodeType"];
+    contents.CacheNodeType = __expectString(output["CacheNodeType"]);
   }
   if (output["StartTime"] !== undefined) {
     contents.StartTime = new Date(output["StartTime"]);
@@ -13804,13 +13805,13 @@ const deserializeAws_queryReservedCacheNode = (output: any, context: __SerdeCont
     contents.CacheNodeCount = parseInt(output["CacheNodeCount"]);
   }
   if (output["ProductDescription"] !== undefined) {
-    contents.ProductDescription = output["ProductDescription"];
+    contents.ProductDescription = __expectString(output["ProductDescription"]);
   }
   if (output["OfferingType"] !== undefined) {
-    contents.OfferingType = output["OfferingType"];
+    contents.OfferingType = __expectString(output["OfferingType"]);
   }
   if (output["State"] !== undefined) {
-    contents.State = output["State"];
+    contents.State = __expectString(output["State"]);
   }
   if (output.RecurringCharges === "") {
     contents.RecurringCharges = [];
@@ -13822,7 +13823,7 @@ const deserializeAws_queryReservedCacheNode = (output: any, context: __SerdeCont
     );
   }
   if (output["ReservationARN"] !== undefined) {
-    contents.ReservationARN = output["ReservationARN"];
+    contents.ReservationARN = __expectString(output["ReservationARN"]);
   }
   return contents;
 };
@@ -13835,7 +13836,7 @@ const deserializeAws_queryReservedCacheNodeAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -13860,7 +13861,7 @@ const deserializeAws_queryReservedCacheNodeMessage = (
     ReservedCacheNodes: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.ReservedCacheNodes === "") {
     contents.ReservedCacheNodes = [];
@@ -13882,7 +13883,7 @@ const deserializeAws_queryReservedCacheNodeNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -13895,7 +13896,7 @@ const deserializeAws_queryReservedCacheNodeQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -13915,10 +13916,10 @@ const deserializeAws_queryReservedCacheNodesOffering = (
     RecurringCharges: undefined,
   };
   if (output["ReservedCacheNodesOfferingId"] !== undefined) {
-    contents.ReservedCacheNodesOfferingId = output["ReservedCacheNodesOfferingId"];
+    contents.ReservedCacheNodesOfferingId = __expectString(output["ReservedCacheNodesOfferingId"]);
   }
   if (output["CacheNodeType"] !== undefined) {
-    contents.CacheNodeType = output["CacheNodeType"];
+    contents.CacheNodeType = __expectString(output["CacheNodeType"]);
   }
   if (output["Duration"] !== undefined) {
     contents.Duration = parseInt(output["Duration"]);
@@ -13930,10 +13931,10 @@ const deserializeAws_queryReservedCacheNodesOffering = (
     contents.UsagePrice = parseFloat(output["UsagePrice"]);
   }
   if (output["ProductDescription"] !== undefined) {
-    contents.ProductDescription = output["ProductDescription"];
+    contents.ProductDescription = __expectString(output["ProductDescription"]);
   }
   if (output["OfferingType"] !== undefined) {
-    contents.OfferingType = output["OfferingType"];
+    contents.OfferingType = __expectString(output["OfferingType"]);
   }
   if (output.RecurringCharges === "") {
     contents.RecurringCharges = [];
@@ -13970,7 +13971,7 @@ const deserializeAws_queryReservedCacheNodesOfferingMessage = (
     ReservedCacheNodesOfferings: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.ReservedCacheNodesOfferings === "") {
     contents.ReservedCacheNodesOfferings = [];
@@ -13995,7 +13996,7 @@ const deserializeAws_queryReservedCacheNodesOfferingNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -14029,10 +14030,10 @@ const deserializeAws_querySecurityGroupMembership = (output: any, context: __Ser
     Status: undefined,
   };
   if (output["SecurityGroupId"] !== undefined) {
-    contents.SecurityGroupId = output["SecurityGroupId"];
+    contents.SecurityGroupId = __expectString(output["SecurityGroupId"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   return contents;
 };
@@ -14059,7 +14060,7 @@ const deserializeAws_queryServiceLinkedRoleNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -14080,7 +14081,7 @@ const deserializeAws_queryServiceUpdate = (output: any, context: __SerdeContext)
     EstimatedUpdateTime: undefined,
   };
   if (output["ServiceUpdateName"] !== undefined) {
-    contents.ServiceUpdateName = output["ServiceUpdateName"];
+    contents.ServiceUpdateName = __expectString(output["ServiceUpdateName"]);
   }
   if (output["ServiceUpdateReleaseDate"] !== undefined) {
     contents.ServiceUpdateReleaseDate = new Date(output["ServiceUpdateReleaseDate"]);
@@ -14089,31 +14090,31 @@ const deserializeAws_queryServiceUpdate = (output: any, context: __SerdeContext)
     contents.ServiceUpdateEndDate = new Date(output["ServiceUpdateEndDate"]);
   }
   if (output["ServiceUpdateSeverity"] !== undefined) {
-    contents.ServiceUpdateSeverity = output["ServiceUpdateSeverity"];
+    contents.ServiceUpdateSeverity = __expectString(output["ServiceUpdateSeverity"]);
   }
   if (output["ServiceUpdateRecommendedApplyByDate"] !== undefined) {
     contents.ServiceUpdateRecommendedApplyByDate = new Date(output["ServiceUpdateRecommendedApplyByDate"]);
   }
   if (output["ServiceUpdateStatus"] !== undefined) {
-    contents.ServiceUpdateStatus = output["ServiceUpdateStatus"];
+    contents.ServiceUpdateStatus = __expectString(output["ServiceUpdateStatus"]);
   }
   if (output["ServiceUpdateDescription"] !== undefined) {
-    contents.ServiceUpdateDescription = output["ServiceUpdateDescription"];
+    contents.ServiceUpdateDescription = __expectString(output["ServiceUpdateDescription"]);
   }
   if (output["ServiceUpdateType"] !== undefined) {
-    contents.ServiceUpdateType = output["ServiceUpdateType"];
+    contents.ServiceUpdateType = __expectString(output["ServiceUpdateType"]);
   }
   if (output["Engine"] !== undefined) {
-    contents.Engine = output["Engine"];
+    contents.Engine = __expectString(output["Engine"]);
   }
   if (output["EngineVersion"] !== undefined) {
-    contents.EngineVersion = output["EngineVersion"];
+    contents.EngineVersion = __expectString(output["EngineVersion"]);
   }
   if (output["AutoUpdateAfterRecommendedApplyByDate"] !== undefined) {
     contents.AutoUpdateAfterRecommendedApplyByDate = __parseBoolean(output["AutoUpdateAfterRecommendedApplyByDate"]);
   }
   if (output["EstimatedUpdateTime"] !== undefined) {
-    contents.EstimatedUpdateTime = output["EstimatedUpdateTime"];
+    contents.EstimatedUpdateTime = __expectString(output["EstimatedUpdateTime"]);
   }
   return contents;
 };
@@ -14137,7 +14138,7 @@ const deserializeAws_queryServiceUpdateNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -14148,7 +14149,7 @@ const deserializeAws_queryServiceUpdatesMessage = (output: any, context: __Serde
     ServiceUpdates: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.ServiceUpdates === "") {
     contents.ServiceUpdates = [];
@@ -14203,61 +14204,61 @@ const deserializeAws_querySnapshot = (output: any, context: __SerdeContext): Sna
     ARN: undefined,
   };
   if (output["SnapshotName"] !== undefined) {
-    contents.SnapshotName = output["SnapshotName"];
+    contents.SnapshotName = __expectString(output["SnapshotName"]);
   }
   if (output["ReplicationGroupId"] !== undefined) {
-    contents.ReplicationGroupId = output["ReplicationGroupId"];
+    contents.ReplicationGroupId = __expectString(output["ReplicationGroupId"]);
   }
   if (output["ReplicationGroupDescription"] !== undefined) {
-    contents.ReplicationGroupDescription = output["ReplicationGroupDescription"];
+    contents.ReplicationGroupDescription = __expectString(output["ReplicationGroupDescription"]);
   }
   if (output["CacheClusterId"] !== undefined) {
-    contents.CacheClusterId = output["CacheClusterId"];
+    contents.CacheClusterId = __expectString(output["CacheClusterId"]);
   }
   if (output["SnapshotStatus"] !== undefined) {
-    contents.SnapshotStatus = output["SnapshotStatus"];
+    contents.SnapshotStatus = __expectString(output["SnapshotStatus"]);
   }
   if (output["SnapshotSource"] !== undefined) {
-    contents.SnapshotSource = output["SnapshotSource"];
+    contents.SnapshotSource = __expectString(output["SnapshotSource"]);
   }
   if (output["CacheNodeType"] !== undefined) {
-    contents.CacheNodeType = output["CacheNodeType"];
+    contents.CacheNodeType = __expectString(output["CacheNodeType"]);
   }
   if (output["Engine"] !== undefined) {
-    contents.Engine = output["Engine"];
+    contents.Engine = __expectString(output["Engine"]);
   }
   if (output["EngineVersion"] !== undefined) {
-    contents.EngineVersion = output["EngineVersion"];
+    contents.EngineVersion = __expectString(output["EngineVersion"]);
   }
   if (output["NumCacheNodes"] !== undefined) {
     contents.NumCacheNodes = parseInt(output["NumCacheNodes"]);
   }
   if (output["PreferredAvailabilityZone"] !== undefined) {
-    contents.PreferredAvailabilityZone = output["PreferredAvailabilityZone"];
+    contents.PreferredAvailabilityZone = __expectString(output["PreferredAvailabilityZone"]);
   }
   if (output["PreferredOutpostArn"] !== undefined) {
-    contents.PreferredOutpostArn = output["PreferredOutpostArn"];
+    contents.PreferredOutpostArn = __expectString(output["PreferredOutpostArn"]);
   }
   if (output["CacheClusterCreateTime"] !== undefined) {
     contents.CacheClusterCreateTime = new Date(output["CacheClusterCreateTime"]);
   }
   if (output["PreferredMaintenanceWindow"] !== undefined) {
-    contents.PreferredMaintenanceWindow = output["PreferredMaintenanceWindow"];
+    contents.PreferredMaintenanceWindow = __expectString(output["PreferredMaintenanceWindow"]);
   }
   if (output["TopicArn"] !== undefined) {
-    contents.TopicArn = output["TopicArn"];
+    contents.TopicArn = __expectString(output["TopicArn"]);
   }
   if (output["Port"] !== undefined) {
     contents.Port = parseInt(output["Port"]);
   }
   if (output["CacheParameterGroupName"] !== undefined) {
-    contents.CacheParameterGroupName = output["CacheParameterGroupName"];
+    contents.CacheParameterGroupName = __expectString(output["CacheParameterGroupName"]);
   }
   if (output["CacheSubnetGroupName"] !== undefined) {
-    contents.CacheSubnetGroupName = output["CacheSubnetGroupName"];
+    contents.CacheSubnetGroupName = __expectString(output["CacheSubnetGroupName"]);
   }
   if (output["VpcId"] !== undefined) {
-    contents.VpcId = output["VpcId"];
+    contents.VpcId = __expectString(output["VpcId"]);
   }
   if (output["AutoMinorVersionUpgrade"] !== undefined) {
     contents.AutoMinorVersionUpgrade = __parseBoolean(output["AutoMinorVersionUpgrade"]);
@@ -14266,13 +14267,13 @@ const deserializeAws_querySnapshot = (output: any, context: __SerdeContext): Sna
     contents.SnapshotRetentionLimit = parseInt(output["SnapshotRetentionLimit"]);
   }
   if (output["SnapshotWindow"] !== undefined) {
-    contents.SnapshotWindow = output["SnapshotWindow"];
+    contents.SnapshotWindow = __expectString(output["SnapshotWindow"]);
   }
   if (output["NumNodeGroups"] !== undefined) {
     contents.NumNodeGroups = parseInt(output["NumNodeGroups"]);
   }
   if (output["AutomaticFailover"] !== undefined) {
-    contents.AutomaticFailover = output["AutomaticFailover"];
+    contents.AutomaticFailover = __expectString(output["AutomaticFailover"]);
   }
   if (output.NodeSnapshots === "") {
     contents.NodeSnapshots = [];
@@ -14284,10 +14285,10 @@ const deserializeAws_querySnapshot = (output: any, context: __SerdeContext): Sna
     );
   }
   if (output["KmsKeyId"] !== undefined) {
-    contents.KmsKeyId = output["KmsKeyId"];
+    contents.KmsKeyId = __expectString(output["KmsKeyId"]);
   }
   if (output["ARN"] !== undefined) {
-    contents.ARN = output["ARN"];
+    contents.ARN = __expectString(output["ARN"]);
   }
   return contents;
 };
@@ -14300,7 +14301,7 @@ const deserializeAws_querySnapshotAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -14313,7 +14314,7 @@ const deserializeAws_querySnapshotFeatureNotSupportedFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -14334,7 +14335,7 @@ const deserializeAws_querySnapshotNotFoundFault = (output: any, context: __Serde
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -14347,7 +14348,7 @@ const deserializeAws_querySnapshotQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -14369,7 +14370,7 @@ const deserializeAws_querySubnet = (output: any, context: __SerdeContext): Subne
     SubnetOutpost: undefined,
   };
   if (output["SubnetIdentifier"] !== undefined) {
-    contents.SubnetIdentifier = output["SubnetIdentifier"];
+    contents.SubnetIdentifier = __expectString(output["SubnetIdentifier"]);
   }
   if (output["SubnetAvailabilityZone"] !== undefined) {
     contents.SubnetAvailabilityZone = deserializeAws_queryAvailabilityZone(output["SubnetAvailabilityZone"], context);
@@ -14385,7 +14386,7 @@ const deserializeAws_querySubnetInUse = (output: any, context: __SerdeContext): 
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -14406,7 +14407,7 @@ const deserializeAws_querySubnetNotAllowedFault = (output: any, context: __Serde
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -14416,7 +14417,7 @@ const deserializeAws_querySubnetOutpost = (output: any, context: __SerdeContext)
     SubnetOutpostArn: undefined,
   };
   if (output["SubnetOutpostArn"] !== undefined) {
-    contents.SubnetOutpostArn = output["SubnetOutpostArn"];
+    contents.SubnetOutpostArn = __expectString(output["SubnetOutpostArn"]);
   }
   return contents;
 };
@@ -14427,10 +14428,10 @@ const deserializeAws_queryTag = (output: any, context: __SerdeContext): Tag => {
     Value: undefined,
   };
   if (output["Key"] !== undefined) {
-    contents.Key = output["Key"];
+    contents.Key = __expectString(output["Key"]);
   }
   if (output["Value"] !== undefined) {
-    contents.Value = output["Value"];
+    contents.Value = __expectString(output["Value"]);
   }
   return contents;
 };
@@ -14464,7 +14465,7 @@ const deserializeAws_queryTagNotFoundFault = (output: any, context: __SerdeConte
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -14477,7 +14478,7 @@ const deserializeAws_queryTagQuotaPerResourceExceeded = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -14490,7 +14491,7 @@ const deserializeAws_queryTestFailoverNotAvailableFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -14512,7 +14513,7 @@ const deserializeAws_queryUGReplicationGroupIdList = (output: any, context: __Se
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -14525,19 +14526,19 @@ const deserializeAws_queryUnprocessedUpdateAction = (output: any, context: __Ser
     ErrorMessage: undefined,
   };
   if (output["ReplicationGroupId"] !== undefined) {
-    contents.ReplicationGroupId = output["ReplicationGroupId"];
+    contents.ReplicationGroupId = __expectString(output["ReplicationGroupId"]);
   }
   if (output["CacheClusterId"] !== undefined) {
-    contents.CacheClusterId = output["CacheClusterId"];
+    contents.CacheClusterId = __expectString(output["CacheClusterId"]);
   }
   if (output["ServiceUpdateName"] !== undefined) {
-    contents.ServiceUpdateName = output["ServiceUpdateName"];
+    contents.ServiceUpdateName = __expectString(output["ServiceUpdateName"]);
   }
   if (output["ErrorType"] !== undefined) {
-    contents.ErrorType = output["ErrorType"];
+    contents.ErrorType = __expectString(output["ErrorType"]);
   }
   if (output["ErrorMessage"] !== undefined) {
-    contents.ErrorMessage = output["ErrorMessage"];
+    contents.ErrorMessage = __expectString(output["ErrorMessage"]);
   }
   return contents;
 };
@@ -14577,43 +14578,43 @@ const deserializeAws_queryUpdateAction = (output: any, context: __SerdeContext):
     Engine: undefined,
   };
   if (output["ReplicationGroupId"] !== undefined) {
-    contents.ReplicationGroupId = output["ReplicationGroupId"];
+    contents.ReplicationGroupId = __expectString(output["ReplicationGroupId"]);
   }
   if (output["CacheClusterId"] !== undefined) {
-    contents.CacheClusterId = output["CacheClusterId"];
+    contents.CacheClusterId = __expectString(output["CacheClusterId"]);
   }
   if (output["ServiceUpdateName"] !== undefined) {
-    contents.ServiceUpdateName = output["ServiceUpdateName"];
+    contents.ServiceUpdateName = __expectString(output["ServiceUpdateName"]);
   }
   if (output["ServiceUpdateReleaseDate"] !== undefined) {
     contents.ServiceUpdateReleaseDate = new Date(output["ServiceUpdateReleaseDate"]);
   }
   if (output["ServiceUpdateSeverity"] !== undefined) {
-    contents.ServiceUpdateSeverity = output["ServiceUpdateSeverity"];
+    contents.ServiceUpdateSeverity = __expectString(output["ServiceUpdateSeverity"]);
   }
   if (output["ServiceUpdateStatus"] !== undefined) {
-    contents.ServiceUpdateStatus = output["ServiceUpdateStatus"];
+    contents.ServiceUpdateStatus = __expectString(output["ServiceUpdateStatus"]);
   }
   if (output["ServiceUpdateRecommendedApplyByDate"] !== undefined) {
     contents.ServiceUpdateRecommendedApplyByDate = new Date(output["ServiceUpdateRecommendedApplyByDate"]);
   }
   if (output["ServiceUpdateType"] !== undefined) {
-    contents.ServiceUpdateType = output["ServiceUpdateType"];
+    contents.ServiceUpdateType = __expectString(output["ServiceUpdateType"]);
   }
   if (output["UpdateActionAvailableDate"] !== undefined) {
     contents.UpdateActionAvailableDate = new Date(output["UpdateActionAvailableDate"]);
   }
   if (output["UpdateActionStatus"] !== undefined) {
-    contents.UpdateActionStatus = output["UpdateActionStatus"];
+    contents.UpdateActionStatus = __expectString(output["UpdateActionStatus"]);
   }
   if (output["NodesUpdated"] !== undefined) {
-    contents.NodesUpdated = output["NodesUpdated"];
+    contents.NodesUpdated = __expectString(output["NodesUpdated"]);
   }
   if (output["UpdateActionStatusModifiedDate"] !== undefined) {
     contents.UpdateActionStatusModifiedDate = new Date(output["UpdateActionStatusModifiedDate"]);
   }
   if (output["SlaMet"] !== undefined) {
-    contents.SlaMet = output["SlaMet"];
+    contents.SlaMet = __expectString(output["SlaMet"]);
   }
   if (output.NodeGroupUpdateStatus === "") {
     contents.NodeGroupUpdateStatus = [];
@@ -14640,10 +14641,10 @@ const deserializeAws_queryUpdateAction = (output: any, context: __SerdeContext):
     );
   }
   if (output["EstimatedUpdateTime"] !== undefined) {
-    contents.EstimatedUpdateTime = output["EstimatedUpdateTime"];
+    contents.EstimatedUpdateTime = __expectString(output["EstimatedUpdateTime"]);
   }
   if (output["Engine"] !== undefined) {
-    contents.Engine = output["Engine"];
+    contents.Engine = __expectString(output["Engine"]);
   }
   return contents;
 };
@@ -14700,7 +14701,7 @@ const deserializeAws_queryUpdateActionsMessage = (output: any, context: __SerdeC
     UpdateActions: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.UpdateActions === "") {
     contents.UpdateActions = [];
@@ -14726,19 +14727,19 @@ const deserializeAws_queryUser = (output: any, context: __SerdeContext): User =>
     ARN: undefined,
   };
   if (output["UserId"] !== undefined) {
-    contents.UserId = output["UserId"];
+    contents.UserId = __expectString(output["UserId"]);
   }
   if (output["UserName"] !== undefined) {
-    contents.UserName = output["UserName"];
+    contents.UserName = __expectString(output["UserName"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["Engine"] !== undefined) {
-    contents.Engine = output["Engine"];
+    contents.Engine = __expectString(output["Engine"]);
   }
   if (output["AccessString"] !== undefined) {
-    contents.AccessString = output["AccessString"];
+    contents.AccessString = __expectString(output["AccessString"]);
   }
   if (output.UserGroupIds === "") {
     contents.UserGroupIds = [];
@@ -14753,7 +14754,7 @@ const deserializeAws_queryUser = (output: any, context: __SerdeContext): User =>
     contents.Authentication = deserializeAws_queryAuthentication(output["Authentication"], context);
   }
   if (output["ARN"] !== undefined) {
-    contents.ARN = output["ARN"];
+    contents.ARN = __expectString(output["ARN"]);
   }
   return contents;
 };
@@ -14763,7 +14764,7 @@ const deserializeAws_queryUserAlreadyExistsFault = (output: any, context: __Serd
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -14779,13 +14780,13 @@ const deserializeAws_queryUserGroup = (output: any, context: __SerdeContext): Us
     ARN: undefined,
   };
   if (output["UserGroupId"] !== undefined) {
-    contents.UserGroupId = output["UserGroupId"];
+    contents.UserGroupId = __expectString(output["UserGroupId"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["Engine"] !== undefined) {
-    contents.Engine = output["Engine"];
+    contents.Engine = __expectString(output["Engine"]);
   }
   if (output.UserIds === "") {
     contents.UserIds = [];
@@ -14806,7 +14807,7 @@ const deserializeAws_queryUserGroup = (output: any, context: __SerdeContext): Us
     );
   }
   if (output["ARN"] !== undefined) {
-    contents.ARN = output["ARN"];
+    contents.ARN = __expectString(output["ARN"]);
   }
   return contents;
 };
@@ -14819,7 +14820,7 @@ const deserializeAws_queryUserGroupAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -14831,7 +14832,7 @@ const deserializeAws_queryUserGroupIdList = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -14851,7 +14852,7 @@ const deserializeAws_queryUserGroupNotFoundFault = (output: any, context: __Serd
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -14890,7 +14891,7 @@ const deserializeAws_queryUserGroupQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -14928,7 +14929,7 @@ const deserializeAws_queryUserIdList = (output: any, context: __SerdeContext): s
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -14948,7 +14949,7 @@ const deserializeAws_queryUserNotFoundFault = (output: any, context: __SerdeCont
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -14958,7 +14959,7 @@ const deserializeAws_queryUserQuotaExceededFault = (output: any, context: __Serd
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };

--- a/clients/client-elasticsearch-service/protocols/Aws_restJson1.ts
+++ b/clients/client-elasticsearch-service/protocols/Aws_restJson1.ts
@@ -211,6 +211,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -1929,7 +1932,7 @@ export const deserializeAws_restJson1CreateOutboundCrossClusterSearchConnectionC
   };
   const data: any = await parseBody(output.body, context);
   if (data.ConnectionAlias !== undefined && data.ConnectionAlias !== null) {
-    contents.ConnectionAlias = data.ConnectionAlias;
+    contents.ConnectionAlias = __expectString(data.ConnectionAlias);
   }
   if (data.ConnectionStatus !== undefined && data.ConnectionStatus !== null) {
     contents.ConnectionStatus = deserializeAws_restJson1OutboundCrossClusterSearchConnectionStatus(
@@ -1938,7 +1941,7 @@ export const deserializeAws_restJson1CreateOutboundCrossClusterSearchConnectionC
     );
   }
   if (data.CrossClusterSearchConnectionId !== undefined && data.CrossClusterSearchConnectionId !== null) {
-    contents.CrossClusterSearchConnectionId = data.CrossClusterSearchConnectionId;
+    contents.CrossClusterSearchConnectionId = __expectString(data.CrossClusterSearchConnectionId);
   }
   if (data.DestinationDomainInfo !== undefined && data.DestinationDomainInfo !== null) {
     contents.DestinationDomainInfo = deserializeAws_restJson1DomainInformation(data.DestinationDomainInfo, context);
@@ -2503,7 +2506,7 @@ export const deserializeAws_restJson1DescribeDomainAutoTunesCommand = async (
     contents.AutoTunes = deserializeAws_restJson1AutoTuneList(data.AutoTunes, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2913,7 +2916,7 @@ export const deserializeAws_restJson1DescribeInboundCrossClusterSearchConnection
     );
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2983,7 +2986,7 @@ export const deserializeAws_restJson1DescribeOutboundCrossClusterSearchConnectio
     );
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3047,7 +3050,7 @@ export const deserializeAws_restJson1DescribePackagesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.PackageDetailsList !== undefined && data.PackageDetailsList !== null) {
     contents.PackageDetailsList = deserializeAws_restJson1PackageDetailsList(data.PackageDetailsList, context);
@@ -3138,7 +3141,7 @@ export const deserializeAws_restJson1DescribeReservedElasticsearchInstanceOfferi
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (
     data.ReservedElasticsearchInstanceOfferings !== undefined &&
@@ -3227,7 +3230,7 @@ export const deserializeAws_restJson1DescribeReservedElasticsearchInstancesComma
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.ReservedElasticsearchInstances !== undefined && data.ReservedElasticsearchInstances !== null) {
     contents.ReservedElasticsearchInstances = deserializeAws_restJson1ReservedElasticsearchInstanceList(
@@ -3499,10 +3502,10 @@ export const deserializeAws_restJson1GetPackageVersionHistoryCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.PackageID !== undefined && data.PackageID !== null) {
-    contents.PackageID = data.PackageID;
+    contents.PackageID = __expectString(data.PackageID);
   }
   if (data.PackageVersionHistoryList !== undefined && data.PackageVersionHistoryList !== null) {
     contents.PackageVersionHistoryList = deserializeAws_restJson1PackageVersionHistoryList(
@@ -3596,7 +3599,7 @@ export const deserializeAws_restJson1GetUpgradeHistoryCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.UpgradeHistories !== undefined && data.UpgradeHistories !== null) {
     contents.UpgradeHistories = deserializeAws_restJson1UpgradeHistoryList(data.UpgradeHistories, context);
@@ -3688,13 +3691,13 @@ export const deserializeAws_restJson1GetUpgradeStatusCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.StepStatus !== undefined && data.StepStatus !== null) {
-    contents.StepStatus = data.StepStatus;
+    contents.StepStatus = __expectString(data.StepStatus);
   }
   if (data.UpgradeName !== undefined && data.UpgradeName !== null) {
-    contents.UpgradeName = data.UpgradeName;
+    contents.UpgradeName = __expectString(data.UpgradeName);
   }
   if (data.UpgradeStep !== undefined && data.UpgradeStep !== null) {
-    contents.UpgradeStep = data.UpgradeStep;
+    contents.UpgradeStep = __expectString(data.UpgradeStep);
   }
   return Promise.resolve(contents);
 };
@@ -3851,7 +3854,7 @@ export const deserializeAws_restJson1ListDomainsForPackageCommand = async (
     );
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3945,7 +3948,7 @@ export const deserializeAws_restJson1ListElasticsearchInstanceTypesCommand = asy
     );
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -4031,7 +4034,7 @@ export const deserializeAws_restJson1ListElasticsearchVersionsCommand = async (
     );
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -4117,7 +4120,7 @@ export const deserializeAws_restJson1ListPackagesForDomainCommand = async (
     );
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -4284,10 +4287,10 @@ export const deserializeAws_restJson1PurchaseReservedElasticsearchInstanceOfferi
   };
   const data: any = await parseBody(output.body, context);
   if (data.ReservationName !== undefined && data.ReservationName !== null) {
-    contents.ReservationName = data.ReservationName;
+    contents.ReservationName = __expectString(data.ReservationName);
   }
   if (data.ReservedElasticsearchInstanceId !== undefined && data.ReservedElasticsearchInstanceId !== null) {
-    contents.ReservedElasticsearchInstanceId = data.ReservedElasticsearchInstanceId;
+    contents.ReservedElasticsearchInstanceId = __expectString(data.ReservedElasticsearchInstanceId);
   }
   return Promise.resolve(contents);
 };
@@ -4789,13 +4792,13 @@ export const deserializeAws_restJson1UpgradeElasticsearchDomainCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.DomainName !== undefined && data.DomainName !== null) {
-    contents.DomainName = data.DomainName;
+    contents.DomainName = __expectString(data.DomainName);
   }
   if (data.PerformCheckOnly !== undefined && data.PerformCheckOnly !== null) {
-    contents.PerformCheckOnly = data.PerformCheckOnly;
+    contents.PerformCheckOnly = __expectBoolean(data.PerformCheckOnly);
   }
   if (data.TargetVersion !== undefined && data.TargetVersion !== null) {
-    contents.TargetVersion = data.TargetVersion;
+    contents.TargetVersion = __expectString(data.TargetVersion);
   }
   return Promise.resolve(contents);
 };
@@ -4889,7 +4892,7 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -4906,7 +4909,7 @@ const deserializeAws_restJson1BaseExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -4923,7 +4926,7 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -4940,7 +4943,7 @@ const deserializeAws_restJson1DisabledOperationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -4957,7 +4960,7 @@ const deserializeAws_restJson1InternalExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -4974,7 +4977,7 @@ const deserializeAws_restJson1InvalidPaginationTokenExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -4991,7 +4994,7 @@ const deserializeAws_restJson1InvalidTypeExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -5008,7 +5011,7 @@ const deserializeAws_restJson1LimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -5025,7 +5028,7 @@ const deserializeAws_restJson1ResourceAlreadyExistsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -5042,7 +5045,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -5059,7 +5062,7 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -5451,7 +5454,7 @@ const serializeAws_restJson1ZoneAwarenessConfig = (input: ZoneAwarenessConfig, c
 
 const deserializeAws_restJson1AccessPoliciesStatus = (output: any, context: __SerdeContext): AccessPoliciesStatus => {
   return {
-    Options: output.Options !== undefined && output.Options !== null ? output.Options : undefined,
+    Options: __expectString(output.Options),
     Status:
       output.Status !== undefined && output.Status !== null
         ? deserializeAws_restJson1OptionStatus(output.Status, context)
@@ -5461,7 +5464,7 @@ const deserializeAws_restJson1AccessPoliciesStatus = (output: any, context: __Se
 
 const deserializeAws_restJson1AdditionalLimit = (output: any, context: __SerdeContext): AdditionalLimit => {
   return {
-    LimitName: output.LimitName !== undefined && output.LimitName !== null ? output.LimitName : undefined,
+    LimitName: __expectString(output.LimitName),
     LimitValues:
       output.LimitValues !== undefined && output.LimitValues !== null
         ? deserializeAws_restJson1LimitValueList(output.LimitValues, context)
@@ -5487,7 +5490,7 @@ const deserializeAws_restJson1AdvancedOptions = (output: any, context: __SerdeCo
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -5510,11 +5513,8 @@ const deserializeAws_restJson1AdvancedSecurityOptions = (
   context: __SerdeContext
 ): AdvancedSecurityOptions => {
   return {
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
-    InternalUserDatabaseEnabled:
-      output.InternalUserDatabaseEnabled !== undefined && output.InternalUserDatabaseEnabled !== null
-        ? output.InternalUserDatabaseEnabled
-        : undefined,
+    Enabled: __expectBoolean(output.Enabled),
+    InternalUserDatabaseEnabled: __expectBoolean(output.InternalUserDatabaseEnabled),
     SAMLOptions:
       output.SAMLOptions !== undefined && output.SAMLOptions !== null
         ? deserializeAws_restJson1SAMLOptionsOutput(output.SAMLOptions, context)
@@ -5544,7 +5544,7 @@ const deserializeAws_restJson1AutoTune = (output: any, context: __SerdeContext):
       output.AutoTuneDetails !== undefined && output.AutoTuneDetails !== null
         ? deserializeAws_restJson1AutoTuneDetails(output.AutoTuneDetails, context)
         : undefined,
-    AutoTuneType: output.AutoTuneType !== undefined && output.AutoTuneType !== null ? output.AutoTuneType : undefined,
+    AutoTuneType: __expectString(output.AutoTuneType),
   } as any;
 };
 
@@ -5573,10 +5573,7 @@ const deserializeAws_restJson1AutoTuneMaintenanceSchedule = (
   context: __SerdeContext
 ): AutoTuneMaintenanceSchedule => {
   return {
-    CronExpressionForRecurrence:
-      output.CronExpressionForRecurrence !== undefined && output.CronExpressionForRecurrence !== null
-        ? output.CronExpressionForRecurrence
-        : undefined,
+    CronExpressionForRecurrence: __expectString(output.CronExpressionForRecurrence),
     Duration:
       output.Duration !== undefined && output.Duration !== null
         ? deserializeAws_restJson1Duration(output.Duration, context)
@@ -5602,22 +5599,19 @@ const deserializeAws_restJson1AutoTuneMaintenanceScheduleList = (
 
 const deserializeAws_restJson1AutoTuneOptions = (output: any, context: __SerdeContext): AutoTuneOptions => {
   return {
-    DesiredState: output.DesiredState !== undefined && output.DesiredState !== null ? output.DesiredState : undefined,
+    DesiredState: __expectString(output.DesiredState),
     MaintenanceSchedules:
       output.MaintenanceSchedules !== undefined && output.MaintenanceSchedules !== null
         ? deserializeAws_restJson1AutoTuneMaintenanceScheduleList(output.MaintenanceSchedules, context)
         : undefined,
-    RollbackOnDisable:
-      output.RollbackOnDisable !== undefined && output.RollbackOnDisable !== null
-        ? output.RollbackOnDisable
-        : undefined,
+    RollbackOnDisable: __expectString(output.RollbackOnDisable),
   } as any;
 };
 
 const deserializeAws_restJson1AutoTuneOptionsOutput = (output: any, context: __SerdeContext): AutoTuneOptionsOutput => {
   return {
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    ErrorMessage: __expectString(output.ErrorMessage),
+    State: __expectString(output.State),
   } as any;
 };
 
@@ -5640,26 +5634,23 @@ const deserializeAws_restJson1AutoTuneStatus = (output: any, context: __SerdeCon
       output.CreationDate !== undefined && output.CreationDate !== null
         ? new Date(Math.round(output.CreationDate * 1000))
         : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    PendingDeletion:
-      output.PendingDeletion !== undefined && output.PendingDeletion !== null ? output.PendingDeletion : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    ErrorMessage: __expectString(output.ErrorMessage),
+    PendingDeletion: __expectBoolean(output.PendingDeletion),
+    State: __expectString(output.State),
     UpdateDate:
       output.UpdateDate !== undefined && output.UpdateDate !== null
         ? new Date(Math.round(output.UpdateDate * 1000))
         : undefined,
-    UpdateVersion:
-      output.UpdateVersion !== undefined && output.UpdateVersion !== null ? output.UpdateVersion : undefined,
+    UpdateVersion: __expectNumber(output.UpdateVersion),
   } as any;
 };
 
 const deserializeAws_restJson1CognitoOptions = (output: any, context: __SerdeContext): CognitoOptions => {
   return {
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
-    IdentityPoolId:
-      output.IdentityPoolId !== undefined && output.IdentityPoolId !== null ? output.IdentityPoolId : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
-    UserPoolId: output.UserPoolId !== undefined && output.UserPoolId !== null ? output.UserPoolId : undefined,
+    Enabled: __expectBoolean(output.Enabled),
+    IdentityPoolId: __expectString(output.IdentityPoolId),
+    RoleArn: __expectString(output.RoleArn),
+    UserPoolId: __expectString(output.UserPoolId),
   } as any;
 };
 
@@ -5678,7 +5669,7 @@ const deserializeAws_restJson1CognitoOptionsStatus = (output: any, context: __Se
 
 const deserializeAws_restJson1ColdStorageOptions = (output: any, context: __SerdeContext): ColdStorageOptions => {
   return {
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
+    Enabled: __expectBoolean(output.Enabled),
   } as any;
 };
 
@@ -5698,8 +5689,7 @@ const deserializeAws_restJson1CompatibleElasticsearchVersionsList = (
 
 const deserializeAws_restJson1CompatibleVersionsMap = (output: any, context: __SerdeContext): CompatibleVersionsMap => {
   return {
-    SourceVersion:
-      output.SourceVersion !== undefined && output.SourceVersion !== null ? output.SourceVersion : undefined,
+    SourceVersion: __expectString(output.SourceVersion),
     TargetVersions:
       output.TargetVersions !== undefined && output.TargetVersions !== null
         ? deserializeAws_restJson1ElasticsearchVersionList(output.TargetVersions, context)
@@ -5709,21 +5699,11 @@ const deserializeAws_restJson1CompatibleVersionsMap = (output: any, context: __S
 
 const deserializeAws_restJson1DomainEndpointOptions = (output: any, context: __SerdeContext): DomainEndpointOptions => {
   return {
-    CustomEndpoint:
-      output.CustomEndpoint !== undefined && output.CustomEndpoint !== null ? output.CustomEndpoint : undefined,
-    CustomEndpointCertificateArn:
-      output.CustomEndpointCertificateArn !== undefined && output.CustomEndpointCertificateArn !== null
-        ? output.CustomEndpointCertificateArn
-        : undefined,
-    CustomEndpointEnabled:
-      output.CustomEndpointEnabled !== undefined && output.CustomEndpointEnabled !== null
-        ? output.CustomEndpointEnabled
-        : undefined,
-    EnforceHTTPS: output.EnforceHTTPS !== undefined && output.EnforceHTTPS !== null ? output.EnforceHTTPS : undefined,
-    TLSSecurityPolicy:
-      output.TLSSecurityPolicy !== undefined && output.TLSSecurityPolicy !== null
-        ? output.TLSSecurityPolicy
-        : undefined,
+    CustomEndpoint: __expectString(output.CustomEndpoint),
+    CustomEndpointCertificateArn: __expectString(output.CustomEndpointCertificateArn),
+    CustomEndpointEnabled: __expectBoolean(output.CustomEndpointEnabled),
+    EnforceHTTPS: __expectBoolean(output.EnforceHTTPS),
+    TLSSecurityPolicy: __expectString(output.TLSSecurityPolicy),
   } as any;
 };
 
@@ -5745,7 +5725,7 @@ const deserializeAws_restJson1DomainEndpointOptionsStatus = (
 
 const deserializeAws_restJson1DomainInfo = (output: any, context: __SerdeContext): DomainInfo => {
   return {
-    DomainName: output.DomainName !== undefined && output.DomainName !== null ? output.DomainName : undefined,
+    DomainName: __expectString(output.DomainName),
   } as any;
 };
 
@@ -5762,19 +5742,16 @@ const deserializeAws_restJson1DomainInfoList = (output: any, context: __SerdeCon
 
 const deserializeAws_restJson1DomainInformation = (output: any, context: __SerdeContext): DomainInformation => {
   return {
-    DomainName: output.DomainName !== undefined && output.DomainName !== null ? output.DomainName : undefined,
-    OwnerId: output.OwnerId !== undefined && output.OwnerId !== null ? output.OwnerId : undefined,
-    Region: output.Region !== undefined && output.Region !== null ? output.Region : undefined,
+    DomainName: __expectString(output.DomainName),
+    OwnerId: __expectString(output.OwnerId),
+    Region: __expectString(output.Region),
   } as any;
 };
 
 const deserializeAws_restJson1DomainPackageDetails = (output: any, context: __SerdeContext): DomainPackageDetails => {
   return {
-    DomainName: output.DomainName !== undefined && output.DomainName !== null ? output.DomainName : undefined,
-    DomainPackageStatus:
-      output.DomainPackageStatus !== undefined && output.DomainPackageStatus !== null
-        ? output.DomainPackageStatus
-        : undefined,
+    DomainName: __expectString(output.DomainName),
+    DomainPackageStatus: __expectString(output.DomainPackageStatus),
     ErrorDetails:
       output.ErrorDetails !== undefined && output.ErrorDetails !== null
         ? deserializeAws_restJson1ErrorDetails(output.ErrorDetails, context)
@@ -5783,13 +5760,11 @@ const deserializeAws_restJson1DomainPackageDetails = (output: any, context: __Se
       output.LastUpdated !== undefined && output.LastUpdated !== null
         ? new Date(Math.round(output.LastUpdated * 1000))
         : undefined,
-    PackageID: output.PackageID !== undefined && output.PackageID !== null ? output.PackageID : undefined,
-    PackageName: output.PackageName !== undefined && output.PackageName !== null ? output.PackageName : undefined,
-    PackageType: output.PackageType !== undefined && output.PackageType !== null ? output.PackageType : undefined,
-    PackageVersion:
-      output.PackageVersion !== undefined && output.PackageVersion !== null ? output.PackageVersion : undefined,
-    ReferencePath:
-      output.ReferencePath !== undefined && output.ReferencePath !== null ? output.ReferencePath : undefined,
+    PackageID: __expectString(output.PackageID),
+    PackageName: __expectString(output.PackageName),
+    PackageType: __expectString(output.PackageType),
+    PackageVersion: __expectString(output.PackageVersion),
+    ReferencePath: __expectString(output.ReferencePath),
   } as any;
 };
 
@@ -5809,17 +5784,17 @@ const deserializeAws_restJson1DomainPackageDetailsList = (
 
 const deserializeAws_restJson1Duration = (output: any, context: __SerdeContext): Duration => {
   return {
-    Unit: output.Unit !== undefined && output.Unit !== null ? output.Unit : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Unit: __expectString(output.Unit),
+    Value: __expectNumber(output.Value),
   } as any;
 };
 
 const deserializeAws_restJson1EBSOptions = (output: any, context: __SerdeContext): EBSOptions => {
   return {
-    EBSEnabled: output.EBSEnabled !== undefined && output.EBSEnabled !== null ? output.EBSEnabled : undefined,
-    Iops: output.Iops !== undefined && output.Iops !== null ? output.Iops : undefined,
-    VolumeSize: output.VolumeSize !== undefined && output.VolumeSize !== null ? output.VolumeSize : undefined,
-    VolumeType: output.VolumeType !== undefined && output.VolumeType !== null ? output.VolumeType : undefined,
+    EBSEnabled: __expectBoolean(output.EBSEnabled),
+    Iops: __expectNumber(output.Iops),
+    VolumeSize: __expectNumber(output.VolumeSize),
+    VolumeType: __expectString(output.VolumeType),
   } as any;
 };
 
@@ -5845,32 +5820,19 @@ const deserializeAws_restJson1ElasticsearchClusterConfig = (
       output.ColdStorageOptions !== undefined && output.ColdStorageOptions !== null
         ? deserializeAws_restJson1ColdStorageOptions(output.ColdStorageOptions, context)
         : undefined,
-    DedicatedMasterCount:
-      output.DedicatedMasterCount !== undefined && output.DedicatedMasterCount !== null
-        ? output.DedicatedMasterCount
-        : undefined,
-    DedicatedMasterEnabled:
-      output.DedicatedMasterEnabled !== undefined && output.DedicatedMasterEnabled !== null
-        ? output.DedicatedMasterEnabled
-        : undefined,
-    DedicatedMasterType:
-      output.DedicatedMasterType !== undefined && output.DedicatedMasterType !== null
-        ? output.DedicatedMasterType
-        : undefined,
-    InstanceCount:
-      output.InstanceCount !== undefined && output.InstanceCount !== null ? output.InstanceCount : undefined,
-    InstanceType: output.InstanceType !== undefined && output.InstanceType !== null ? output.InstanceType : undefined,
-    WarmCount: output.WarmCount !== undefined && output.WarmCount !== null ? output.WarmCount : undefined,
-    WarmEnabled: output.WarmEnabled !== undefined && output.WarmEnabled !== null ? output.WarmEnabled : undefined,
-    WarmType: output.WarmType !== undefined && output.WarmType !== null ? output.WarmType : undefined,
+    DedicatedMasterCount: __expectNumber(output.DedicatedMasterCount),
+    DedicatedMasterEnabled: __expectBoolean(output.DedicatedMasterEnabled),
+    DedicatedMasterType: __expectString(output.DedicatedMasterType),
+    InstanceCount: __expectNumber(output.InstanceCount),
+    InstanceType: __expectString(output.InstanceType),
+    WarmCount: __expectNumber(output.WarmCount),
+    WarmEnabled: __expectBoolean(output.WarmEnabled),
+    WarmType: __expectString(output.WarmType),
     ZoneAwarenessConfig:
       output.ZoneAwarenessConfig !== undefined && output.ZoneAwarenessConfig !== null
         ? deserializeAws_restJson1ZoneAwarenessConfig(output.ZoneAwarenessConfig, context)
         : undefined,
-    ZoneAwarenessEnabled:
-      output.ZoneAwarenessEnabled !== undefined && output.ZoneAwarenessEnabled !== null
-        ? output.ZoneAwarenessEnabled
-        : undefined,
+    ZoneAwarenessEnabled: __expectBoolean(output.ZoneAwarenessEnabled),
   } as any;
 };
 
@@ -5959,9 +5921,8 @@ const deserializeAws_restJson1ElasticsearchDomainStatus = (
   context: __SerdeContext
 ): ElasticsearchDomainStatus => {
   return {
-    ARN: output.ARN !== undefined && output.ARN !== null ? output.ARN : undefined,
-    AccessPolicies:
-      output.AccessPolicies !== undefined && output.AccessPolicies !== null ? output.AccessPolicies : undefined,
+    ARN: __expectString(output.ARN),
+    AccessPolicies: __expectString(output.AccessPolicies),
     AdvancedOptions:
       output.AdvancedOptions !== undefined && output.AdvancedOptions !== null
         ? deserializeAws_restJson1AdvancedOptions(output.AdvancedOptions, context)
@@ -5978,14 +5939,14 @@ const deserializeAws_restJson1ElasticsearchDomainStatus = (
       output.CognitoOptions !== undefined && output.CognitoOptions !== null
         ? deserializeAws_restJson1CognitoOptions(output.CognitoOptions, context)
         : undefined,
-    Created: output.Created !== undefined && output.Created !== null ? output.Created : undefined,
-    Deleted: output.Deleted !== undefined && output.Deleted !== null ? output.Deleted : undefined,
+    Created: __expectBoolean(output.Created),
+    Deleted: __expectBoolean(output.Deleted),
     DomainEndpointOptions:
       output.DomainEndpointOptions !== undefined && output.DomainEndpointOptions !== null
         ? deserializeAws_restJson1DomainEndpointOptions(output.DomainEndpointOptions, context)
         : undefined,
-    DomainId: output.DomainId !== undefined && output.DomainId !== null ? output.DomainId : undefined,
-    DomainName: output.DomainName !== undefined && output.DomainName !== null ? output.DomainName : undefined,
+    DomainId: __expectString(output.DomainId),
+    DomainName: __expectString(output.DomainName),
     EBSOptions:
       output.EBSOptions !== undefined && output.EBSOptions !== null
         ? deserializeAws_restJson1EBSOptions(output.EBSOptions, context)
@@ -5994,15 +5955,12 @@ const deserializeAws_restJson1ElasticsearchDomainStatus = (
       output.ElasticsearchClusterConfig !== undefined && output.ElasticsearchClusterConfig !== null
         ? deserializeAws_restJson1ElasticsearchClusterConfig(output.ElasticsearchClusterConfig, context)
         : undefined,
-    ElasticsearchVersion:
-      output.ElasticsearchVersion !== undefined && output.ElasticsearchVersion !== null
-        ? output.ElasticsearchVersion
-        : undefined,
+    ElasticsearchVersion: __expectString(output.ElasticsearchVersion),
     EncryptionAtRestOptions:
       output.EncryptionAtRestOptions !== undefined && output.EncryptionAtRestOptions !== null
         ? deserializeAws_restJson1EncryptionAtRestOptions(output.EncryptionAtRestOptions, context)
         : undefined,
-    Endpoint: output.Endpoint !== undefined && output.Endpoint !== null ? output.Endpoint : undefined,
+    Endpoint: __expectString(output.Endpoint),
     Endpoints:
       output.Endpoints !== undefined && output.Endpoints !== null
         ? deserializeAws_restJson1EndpointsMap(output.Endpoints, context)
@@ -6015,7 +5973,7 @@ const deserializeAws_restJson1ElasticsearchDomainStatus = (
       output.NodeToNodeEncryptionOptions !== undefined && output.NodeToNodeEncryptionOptions !== null
         ? deserializeAws_restJson1NodeToNodeEncryptionOptions(output.NodeToNodeEncryptionOptions, context)
         : undefined,
-    Processing: output.Processing !== undefined && output.Processing !== null ? output.Processing : undefined,
+    Processing: __expectBoolean(output.Processing),
     ServiceSoftwareOptions:
       output.ServiceSoftwareOptions !== undefined && output.ServiceSoftwareOptions !== null
         ? deserializeAws_restJson1ServiceSoftwareOptions(output.ServiceSoftwareOptions, context)
@@ -6024,10 +5982,7 @@ const deserializeAws_restJson1ElasticsearchDomainStatus = (
       output.SnapshotOptions !== undefined && output.SnapshotOptions !== null
         ? deserializeAws_restJson1SnapshotOptions(output.SnapshotOptions, context)
         : undefined,
-    UpgradeProcessing:
-      output.UpgradeProcessing !== undefined && output.UpgradeProcessing !== null
-        ? output.UpgradeProcessing
-        : undefined,
+    UpgradeProcessing: __expectBoolean(output.UpgradeProcessing),
     VPCOptions:
       output.VPCOptions !== undefined && output.VPCOptions !== null
         ? deserializeAws_restJson1VPCDerivedInfo(output.VPCOptions, context)
@@ -6059,7 +6014,7 @@ const deserializeAws_restJson1ElasticsearchInstanceTypeList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6070,7 +6025,7 @@ const deserializeAws_restJson1ElasticsearchVersionList = (output: any, context: 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6079,7 +6034,7 @@ const deserializeAws_restJson1ElasticsearchVersionStatus = (
   context: __SerdeContext
 ): ElasticsearchVersionStatus => {
   return {
-    Options: output.Options !== undefined && output.Options !== null ? output.Options : undefined,
+    Options: __expectString(output.Options),
     Status:
       output.Status !== undefined && output.Status !== null
         ? deserializeAws_restJson1OptionStatus(output.Status, context)
@@ -6092,8 +6047,8 @@ const deserializeAws_restJson1EncryptionAtRestOptions = (
   context: __SerdeContext
 ): EncryptionAtRestOptions => {
   return {
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
+    Enabled: __expectBoolean(output.Enabled),
+    KmsKeyId: __expectString(output.KmsKeyId),
   } as any;
 };
 
@@ -6120,15 +6075,15 @@ const deserializeAws_restJson1EndpointsMap = (output: any, context: __SerdeConte
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1ErrorDetails = (output: any, context: __SerdeContext): ErrorDetails => {
   return {
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    ErrorType: output.ErrorType !== undefined && output.ErrorType !== null ? output.ErrorType : undefined,
+    ErrorMessage: __expectString(output.ErrorMessage),
+    ErrorType: __expectString(output.ErrorType),
   } as any;
 };
 
@@ -6141,10 +6096,7 @@ const deserializeAws_restJson1InboundCrossClusterSearchConnection = (
       output.ConnectionStatus !== undefined && output.ConnectionStatus !== null
         ? deserializeAws_restJson1InboundCrossClusterSearchConnectionStatus(output.ConnectionStatus, context)
         : undefined,
-    CrossClusterSearchConnectionId:
-      output.CrossClusterSearchConnectionId !== undefined && output.CrossClusterSearchConnectionId !== null
-        ? output.CrossClusterSearchConnectionId
-        : undefined,
+    CrossClusterSearchConnectionId: __expectString(output.CrossClusterSearchConnectionId),
     DestinationDomainInfo:
       output.DestinationDomainInfo !== undefined && output.DestinationDomainInfo !== null
         ? deserializeAws_restJson1DomainInformation(output.DestinationDomainInfo, context)
@@ -6175,21 +6127,15 @@ const deserializeAws_restJson1InboundCrossClusterSearchConnectionStatus = (
   context: __SerdeContext
 ): InboundCrossClusterSearchConnectionStatus => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    StatusCode: output.StatusCode !== undefined && output.StatusCode !== null ? output.StatusCode : undefined,
+    Message: __expectString(output.Message),
+    StatusCode: __expectString(output.StatusCode),
   } as any;
 };
 
 const deserializeAws_restJson1InstanceCountLimits = (output: any, context: __SerdeContext): InstanceCountLimits => {
   return {
-    MaximumInstanceCount:
-      output.MaximumInstanceCount !== undefined && output.MaximumInstanceCount !== null
-        ? output.MaximumInstanceCount
-        : undefined,
-    MinimumInstanceCount:
-      output.MinimumInstanceCount !== undefined && output.MinimumInstanceCount !== null
-        ? output.MinimumInstanceCount
-        : undefined,
+    MaximumInstanceCount: __expectNumber(output.MaximumInstanceCount),
+    MinimumInstanceCount: __expectNumber(output.MinimumInstanceCount),
   } as any;
 };
 
@@ -6209,7 +6155,7 @@ const deserializeAws_restJson1Issues = (output: any, context: __SerdeContext): s
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6249,17 +6195,14 @@ const deserializeAws_restJson1LimitValueList = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1LogPublishingOption = (output: any, context: __SerdeContext): LogPublishingOption => {
   return {
-    CloudWatchLogsLogGroupArn:
-      output.CloudWatchLogsLogGroupArn !== undefined && output.CloudWatchLogsLogGroupArn !== null
-        ? output.CloudWatchLogsLogGroupArn
-        : undefined,
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
+    CloudWatchLogsLogGroupArn: __expectString(output.CloudWatchLogsLogGroupArn),
+    Enabled: __expectBoolean(output.Enabled),
   } as any;
 };
 
@@ -6302,7 +6245,7 @@ const deserializeAws_restJson1NodeToNodeEncryptionOptions = (
   context: __SerdeContext
 ): NodeToNodeEncryptionOptions => {
   return {
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
+    Enabled: __expectBoolean(output.Enabled),
   } as any;
 };
 
@@ -6328,15 +6271,13 @@ const deserializeAws_restJson1OptionStatus = (output: any, context: __SerdeConte
       output.CreationDate !== undefined && output.CreationDate !== null
         ? new Date(Math.round(output.CreationDate * 1000))
         : undefined,
-    PendingDeletion:
-      output.PendingDeletion !== undefined && output.PendingDeletion !== null ? output.PendingDeletion : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    PendingDeletion: __expectBoolean(output.PendingDeletion),
+    State: __expectString(output.State),
     UpdateDate:
       output.UpdateDate !== undefined && output.UpdateDate !== null
         ? new Date(Math.round(output.UpdateDate * 1000))
         : undefined,
-    UpdateVersion:
-      output.UpdateVersion !== undefined && output.UpdateVersion !== null ? output.UpdateVersion : undefined,
+    UpdateVersion: __expectNumber(output.UpdateVersion),
   } as any;
 };
 
@@ -6345,16 +6286,12 @@ const deserializeAws_restJson1OutboundCrossClusterSearchConnection = (
   context: __SerdeContext
 ): OutboundCrossClusterSearchConnection => {
   return {
-    ConnectionAlias:
-      output.ConnectionAlias !== undefined && output.ConnectionAlias !== null ? output.ConnectionAlias : undefined,
+    ConnectionAlias: __expectString(output.ConnectionAlias),
     ConnectionStatus:
       output.ConnectionStatus !== undefined && output.ConnectionStatus !== null
         ? deserializeAws_restJson1OutboundCrossClusterSearchConnectionStatus(output.ConnectionStatus, context)
         : undefined,
-    CrossClusterSearchConnectionId:
-      output.CrossClusterSearchConnectionId !== undefined && output.CrossClusterSearchConnectionId !== null
-        ? output.CrossClusterSearchConnectionId
-        : undefined,
+    CrossClusterSearchConnectionId: __expectString(output.CrossClusterSearchConnectionId),
     DestinationDomainInfo:
       output.DestinationDomainInfo !== undefined && output.DestinationDomainInfo !== null
         ? deserializeAws_restJson1DomainInformation(output.DestinationDomainInfo, context)
@@ -6385,17 +6322,14 @@ const deserializeAws_restJson1OutboundCrossClusterSearchConnectionStatus = (
   context: __SerdeContext
 ): OutboundCrossClusterSearchConnectionStatus => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    StatusCode: output.StatusCode !== undefined && output.StatusCode !== null ? output.StatusCode : undefined,
+    Message: __expectString(output.Message),
+    StatusCode: __expectString(output.StatusCode),
   } as any;
 };
 
 const deserializeAws_restJson1PackageDetails = (output: any, context: __SerdeContext): PackageDetails => {
   return {
-    AvailablePackageVersion:
-      output.AvailablePackageVersion !== undefined && output.AvailablePackageVersion !== null
-        ? output.AvailablePackageVersion
-        : undefined,
+    AvailablePackageVersion: __expectString(output.AvailablePackageVersion),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
@@ -6408,15 +6342,11 @@ const deserializeAws_restJson1PackageDetails = (output: any, context: __SerdeCon
       output.LastUpdatedAt !== undefined && output.LastUpdatedAt !== null
         ? new Date(Math.round(output.LastUpdatedAt * 1000))
         : undefined,
-    PackageDescription:
-      output.PackageDescription !== undefined && output.PackageDescription !== null
-        ? output.PackageDescription
-        : undefined,
-    PackageID: output.PackageID !== undefined && output.PackageID !== null ? output.PackageID : undefined,
-    PackageName: output.PackageName !== undefined && output.PackageName !== null ? output.PackageName : undefined,
-    PackageStatus:
-      output.PackageStatus !== undefined && output.PackageStatus !== null ? output.PackageStatus : undefined,
-    PackageType: output.PackageType !== undefined && output.PackageType !== null ? output.PackageType : undefined,
+    PackageDescription: __expectString(output.PackageDescription),
+    PackageID: __expectString(output.PackageID),
+    PackageName: __expectString(output.PackageName),
+    PackageStatus: __expectString(output.PackageStatus),
+    PackageType: __expectString(output.PackageType),
   } as any;
 };
 
@@ -6433,14 +6363,12 @@ const deserializeAws_restJson1PackageDetailsList = (output: any, context: __Serd
 
 const deserializeAws_restJson1PackageVersionHistory = (output: any, context: __SerdeContext): PackageVersionHistory => {
   return {
-    CommitMessage:
-      output.CommitMessage !== undefined && output.CommitMessage !== null ? output.CommitMessage : undefined,
+    CommitMessage: __expectString(output.CommitMessage),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    PackageVersion:
-      output.PackageVersion !== undefined && output.PackageVersion !== null ? output.PackageVersion : undefined,
+    PackageVersion: __expectString(output.PackageVersion),
   } as any;
 };
 
@@ -6460,14 +6388,8 @@ const deserializeAws_restJson1PackageVersionHistoryList = (
 
 const deserializeAws_restJson1RecurringCharge = (output: any, context: __SerdeContext): RecurringCharge => {
   return {
-    RecurringChargeAmount:
-      output.RecurringChargeAmount !== undefined && output.RecurringChargeAmount !== null
-        ? output.RecurringChargeAmount
-        : undefined,
-    RecurringChargeFrequency:
-      output.RecurringChargeFrequency !== undefined && output.RecurringChargeFrequency !== null
-        ? output.RecurringChargeFrequency
-        : undefined,
+    RecurringChargeAmount: __expectNumber(output.RecurringChargeAmount),
+    RecurringChargeFrequency: __expectString(output.RecurringChargeFrequency),
   } as any;
 };
 
@@ -6487,40 +6409,25 @@ const deserializeAws_restJson1ReservedElasticsearchInstance = (
   context: __SerdeContext
 ): ReservedElasticsearchInstance => {
   return {
-    CurrencyCode: output.CurrencyCode !== undefined && output.CurrencyCode !== null ? output.CurrencyCode : undefined,
-    Duration: output.Duration !== undefined && output.Duration !== null ? output.Duration : undefined,
-    ElasticsearchInstanceCount:
-      output.ElasticsearchInstanceCount !== undefined && output.ElasticsearchInstanceCount !== null
-        ? output.ElasticsearchInstanceCount
-        : undefined,
-    ElasticsearchInstanceType:
-      output.ElasticsearchInstanceType !== undefined && output.ElasticsearchInstanceType !== null
-        ? output.ElasticsearchInstanceType
-        : undefined,
-    FixedPrice: output.FixedPrice !== undefined && output.FixedPrice !== null ? output.FixedPrice : undefined,
-    PaymentOption:
-      output.PaymentOption !== undefined && output.PaymentOption !== null ? output.PaymentOption : undefined,
+    CurrencyCode: __expectString(output.CurrencyCode),
+    Duration: __expectNumber(output.Duration),
+    ElasticsearchInstanceCount: __expectNumber(output.ElasticsearchInstanceCount),
+    ElasticsearchInstanceType: __expectString(output.ElasticsearchInstanceType),
+    FixedPrice: __expectNumber(output.FixedPrice),
+    PaymentOption: __expectString(output.PaymentOption),
     RecurringCharges:
       output.RecurringCharges !== undefined && output.RecurringCharges !== null
         ? deserializeAws_restJson1RecurringChargeList(output.RecurringCharges, context)
         : undefined,
-    ReservationName:
-      output.ReservationName !== undefined && output.ReservationName !== null ? output.ReservationName : undefined,
-    ReservedElasticsearchInstanceId:
-      output.ReservedElasticsearchInstanceId !== undefined && output.ReservedElasticsearchInstanceId !== null
-        ? output.ReservedElasticsearchInstanceId
-        : undefined,
-    ReservedElasticsearchInstanceOfferingId:
-      output.ReservedElasticsearchInstanceOfferingId !== undefined &&
-      output.ReservedElasticsearchInstanceOfferingId !== null
-        ? output.ReservedElasticsearchInstanceOfferingId
-        : undefined,
+    ReservationName: __expectString(output.ReservationName),
+    ReservedElasticsearchInstanceId: __expectString(output.ReservedElasticsearchInstanceId),
+    ReservedElasticsearchInstanceOfferingId: __expectString(output.ReservedElasticsearchInstanceOfferingId),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
         ? new Date(Math.round(output.StartTime * 1000))
         : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    UsagePrice: output.UsagePrice !== undefined && output.UsagePrice !== null ? output.UsagePrice : undefined,
+    State: __expectString(output.State),
+    UsagePrice: __expectNumber(output.UsagePrice),
   } as any;
 };
 
@@ -6543,25 +6450,17 @@ const deserializeAws_restJson1ReservedElasticsearchInstanceOffering = (
   context: __SerdeContext
 ): ReservedElasticsearchInstanceOffering => {
   return {
-    CurrencyCode: output.CurrencyCode !== undefined && output.CurrencyCode !== null ? output.CurrencyCode : undefined,
-    Duration: output.Duration !== undefined && output.Duration !== null ? output.Duration : undefined,
-    ElasticsearchInstanceType:
-      output.ElasticsearchInstanceType !== undefined && output.ElasticsearchInstanceType !== null
-        ? output.ElasticsearchInstanceType
-        : undefined,
-    FixedPrice: output.FixedPrice !== undefined && output.FixedPrice !== null ? output.FixedPrice : undefined,
-    PaymentOption:
-      output.PaymentOption !== undefined && output.PaymentOption !== null ? output.PaymentOption : undefined,
+    CurrencyCode: __expectString(output.CurrencyCode),
+    Duration: __expectNumber(output.Duration),
+    ElasticsearchInstanceType: __expectString(output.ElasticsearchInstanceType),
+    FixedPrice: __expectNumber(output.FixedPrice),
+    PaymentOption: __expectString(output.PaymentOption),
     RecurringCharges:
       output.RecurringCharges !== undefined && output.RecurringCharges !== null
         ? deserializeAws_restJson1RecurringChargeList(output.RecurringCharges, context)
         : undefined,
-    ReservedElasticsearchInstanceOfferingId:
-      output.ReservedElasticsearchInstanceOfferingId !== undefined &&
-      output.ReservedElasticsearchInstanceOfferingId !== null
-        ? output.ReservedElasticsearchInstanceOfferingId
-        : undefined,
-    UsagePrice: output.UsagePrice !== undefined && output.UsagePrice !== null ? output.UsagePrice : undefined,
+    ReservedElasticsearchInstanceOfferingId: __expectString(output.ReservedElasticsearchInstanceOfferingId),
+    UsagePrice: __expectNumber(output.UsagePrice),
   } as any;
 };
 
@@ -6581,25 +6480,21 @@ const deserializeAws_restJson1ReservedElasticsearchInstanceOfferingList = (
 
 const deserializeAws_restJson1SAMLIdp = (output: any, context: __SerdeContext): SAMLIdp => {
   return {
-    EntityId: output.EntityId !== undefined && output.EntityId !== null ? output.EntityId : undefined,
-    MetadataContent:
-      output.MetadataContent !== undefined && output.MetadataContent !== null ? output.MetadataContent : undefined,
+    EntityId: __expectString(output.EntityId),
+    MetadataContent: __expectString(output.MetadataContent),
   } as any;
 };
 
 const deserializeAws_restJson1SAMLOptionsOutput = (output: any, context: __SerdeContext): SAMLOptionsOutput => {
   return {
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
+    Enabled: __expectBoolean(output.Enabled),
     Idp:
       output.Idp !== undefined && output.Idp !== null
         ? deserializeAws_restJson1SAMLIdp(output.Idp, context)
         : undefined,
-    RolesKey: output.RolesKey !== undefined && output.RolesKey !== null ? output.RolesKey : undefined,
-    SessionTimeoutMinutes:
-      output.SessionTimeoutMinutes !== undefined && output.SessionTimeoutMinutes !== null
-        ? output.SessionTimeoutMinutes
-        : undefined,
-    SubjectKey: output.SubjectKey !== undefined && output.SubjectKey !== null ? output.SubjectKey : undefined,
+    RolesKey: __expectString(output.RolesKey),
+    SessionTimeoutMinutes: __expectNumber(output.SessionTimeoutMinutes),
+    SubjectKey: __expectString(output.SubjectKey),
   } as any;
 };
 
@@ -6608,10 +6503,10 @@ const deserializeAws_restJson1ScheduledAutoTuneDetails = (
   context: __SerdeContext
 ): ScheduledAutoTuneDetails => {
   return {
-    Action: output.Action !== undefined && output.Action !== null ? output.Action : undefined,
-    ActionType: output.ActionType !== undefined && output.ActionType !== null ? output.ActionType : undefined,
+    Action: __expectString(output.Action),
+    ActionType: __expectString(output.ActionType),
     Date: output.Date !== undefined && output.Date !== null ? new Date(Math.round(output.Date * 1000)) : undefined,
-    Severity: output.Severity !== undefined && output.Severity !== null ? output.Severity : undefined,
+    Severity: __expectString(output.Severity),
   } as any;
 };
 
@@ -6624,27 +6519,19 @@ const deserializeAws_restJson1ServiceSoftwareOptions = (
       output.AutomatedUpdateDate !== undefined && output.AutomatedUpdateDate !== null
         ? new Date(Math.round(output.AutomatedUpdateDate * 1000))
         : undefined,
-    Cancellable: output.Cancellable !== undefined && output.Cancellable !== null ? output.Cancellable : undefined,
-    CurrentVersion:
-      output.CurrentVersion !== undefined && output.CurrentVersion !== null ? output.CurrentVersion : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    NewVersion: output.NewVersion !== undefined && output.NewVersion !== null ? output.NewVersion : undefined,
-    OptionalDeployment:
-      output.OptionalDeployment !== undefined && output.OptionalDeployment !== null
-        ? output.OptionalDeployment
-        : undefined,
-    UpdateAvailable:
-      output.UpdateAvailable !== undefined && output.UpdateAvailable !== null ? output.UpdateAvailable : undefined,
-    UpdateStatus: output.UpdateStatus !== undefined && output.UpdateStatus !== null ? output.UpdateStatus : undefined,
+    Cancellable: __expectBoolean(output.Cancellable),
+    CurrentVersion: __expectString(output.CurrentVersion),
+    Description: __expectString(output.Description),
+    NewVersion: __expectString(output.NewVersion),
+    OptionalDeployment: __expectBoolean(output.OptionalDeployment),
+    UpdateAvailable: __expectBoolean(output.UpdateAvailable),
+    UpdateStatus: __expectString(output.UpdateStatus),
   } as any;
 };
 
 const deserializeAws_restJson1SnapshotOptions = (output: any, context: __SerdeContext): SnapshotOptions => {
   return {
-    AutomatedSnapshotStartHour:
-      output.AutomatedSnapshotStartHour !== undefined && output.AutomatedSnapshotStartHour !== null
-        ? output.AutomatedSnapshotStartHour
-        : undefined,
+    AutomatedSnapshotStartHour: __expectNumber(output.AutomatedSnapshotStartHour),
   } as any;
 };
 
@@ -6663,22 +6550,18 @@ const deserializeAws_restJson1SnapshotOptionsStatus = (output: any, context: __S
 
 const deserializeAws_restJson1StorageType = (output: any, context: __SerdeContext): StorageType => {
   return {
-    StorageSubTypeName:
-      output.StorageSubTypeName !== undefined && output.StorageSubTypeName !== null
-        ? output.StorageSubTypeName
-        : undefined,
+    StorageSubTypeName: __expectString(output.StorageSubTypeName),
     StorageTypeLimits:
       output.StorageTypeLimits !== undefined && output.StorageTypeLimits !== null
         ? deserializeAws_restJson1StorageTypeLimitList(output.StorageTypeLimits, context)
         : undefined,
-    StorageTypeName:
-      output.StorageTypeName !== undefined && output.StorageTypeName !== null ? output.StorageTypeName : undefined,
+    StorageTypeName: __expectString(output.StorageTypeName),
   } as any;
 };
 
 const deserializeAws_restJson1StorageTypeLimit = (output: any, context: __SerdeContext): StorageTypeLimit => {
   return {
-    LimitName: output.LimitName !== undefined && output.LimitName !== null ? output.LimitName : undefined,
+    LimitName: __expectString(output.LimitName),
     LimitValues:
       output.LimitValues !== undefined && output.LimitValues !== null
         ? deserializeAws_restJson1LimitValueList(output.LimitValues, context)
@@ -6715,14 +6598,14 @@ const deserializeAws_restJson1StringList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -6747,9 +6630,8 @@ const deserializeAws_restJson1UpgradeHistory = (output: any, context: __SerdeCon
       output.StepsList !== undefined && output.StepsList !== null
         ? deserializeAws_restJson1UpgradeStepsList(output.StepsList, context)
         : undefined,
-    UpgradeName: output.UpgradeName !== undefined && output.UpgradeName !== null ? output.UpgradeName : undefined,
-    UpgradeStatus:
-      output.UpgradeStatus !== undefined && output.UpgradeStatus !== null ? output.UpgradeStatus : undefined,
+    UpgradeName: __expectString(output.UpgradeName),
+    UpgradeStatus: __expectString(output.UpgradeStatus),
   } as any;
 };
 
@@ -6770,13 +6652,9 @@ const deserializeAws_restJson1UpgradeStepItem = (output: any, context: __SerdeCo
       output.Issues !== undefined && output.Issues !== null
         ? deserializeAws_restJson1Issues(output.Issues, context)
         : undefined,
-    ProgressPercent:
-      output.ProgressPercent !== undefined && output.ProgressPercent !== null ? output.ProgressPercent : undefined,
-    UpgradeStep: output.UpgradeStep !== undefined && output.UpgradeStep !== null ? output.UpgradeStep : undefined,
-    UpgradeStepStatus:
-      output.UpgradeStepStatus !== undefined && output.UpgradeStepStatus !== null
-        ? output.UpgradeStepStatus
-        : undefined,
+    ProgressPercent: __expectNumber(output.ProgressPercent),
+    UpgradeStep: __expectString(output.UpgradeStep),
+    UpgradeStepStatus: __expectString(output.UpgradeStepStatus),
   } as any;
 };
 
@@ -6805,7 +6683,7 @@ const deserializeAws_restJson1VPCDerivedInfo = (output: any, context: __SerdeCon
       output.SubnetIds !== undefined && output.SubnetIds !== null
         ? deserializeAws_restJson1StringList(output.SubnetIds, context)
         : undefined,
-    VPCId: output.VPCId !== undefined && output.VPCId !== null ? output.VPCId : undefined,
+    VPCId: __expectString(output.VPCId),
   } as any;
 };
 
@@ -6824,10 +6702,7 @@ const deserializeAws_restJson1VPCDerivedInfoStatus = (output: any, context: __Se
 
 const deserializeAws_restJson1ZoneAwarenessConfig = (output: any, context: __SerdeContext): ZoneAwarenessConfig => {
   return {
-    AvailabilityZoneCount:
-      output.AvailabilityZoneCount !== undefined && output.AvailabilityZoneCount !== null
-        ? output.AvailabilityZoneCount
-        : undefined,
+    AvailabilityZoneCount: __expectNumber(output.AvailabilityZoneCount),
   } as any;
 };
 

--- a/clients/client-emr-containers/protocols/Aws_restJson1.ts
+++ b/clients/client-emr-containers/protocols/Aws_restJson1.ts
@@ -61,6 +61,7 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -616,10 +617,10 @@ export const deserializeAws_restJson1CancelJobRunCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   if (data.virtualClusterId !== undefined && data.virtualClusterId !== null) {
-    contents.virtualClusterId = data.virtualClusterId;
+    contents.virtualClusterId = __expectString(data.virtualClusterId);
   }
   return Promise.resolve(contents);
 };
@@ -685,16 +686,16 @@ export const deserializeAws_restJson1CreateManagedEndpointCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.virtualClusterId !== undefined && data.virtualClusterId !== null) {
-    contents.virtualClusterId = data.virtualClusterId;
+    contents.virtualClusterId = __expectString(data.virtualClusterId);
   }
   return Promise.resolve(contents);
 };
@@ -767,13 +768,13 @@ export const deserializeAws_restJson1CreateVirtualClusterCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   return Promise.resolve(contents);
 };
@@ -845,10 +846,10 @@ export const deserializeAws_restJson1DeleteManagedEndpointCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   if (data.virtualClusterId !== undefined && data.virtualClusterId !== null) {
-    contents.virtualClusterId = data.virtualClusterId;
+    contents.virtualClusterId = __expectString(data.virtualClusterId);
   }
   return Promise.resolve(contents);
 };
@@ -911,7 +912,7 @@ export const deserializeAws_restJson1DeleteVirtualClusterCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   return Promise.resolve(contents);
 };
@@ -1191,7 +1192,7 @@ export const deserializeAws_restJson1ListJobRunsCommand = async (
     contents.jobRuns = deserializeAws_restJson1JobRuns(data.jobRuns, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1258,7 +1259,7 @@ export const deserializeAws_restJson1ListManagedEndpointsCommand = async (
     contents.endpoints = deserializeAws_restJson1Endpoints(data.endpoints, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1393,7 +1394,7 @@ export const deserializeAws_restJson1ListVirtualClustersCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.virtualClusters !== undefined && data.virtualClusters !== null) {
     contents.virtualClusters = deserializeAws_restJson1VirtualClusters(data.virtualClusters, context);
@@ -1462,16 +1463,16 @@ export const deserializeAws_restJson1StartJobRunCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.virtualClusterId !== undefined && data.virtualClusterId !== null) {
-    contents.virtualClusterId = data.virtualClusterId;
+    contents.virtualClusterId = __expectString(data.virtualClusterId);
   }
   return Promise.resolve(contents);
 };
@@ -1675,7 +1676,7 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1692,7 +1693,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1709,7 +1710,7 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1883,18 +1884,14 @@ const deserializeAws_restJson1CloudWatchMonitoringConfiguration = (
   context: __SerdeContext
 ): CloudWatchMonitoringConfiguration => {
   return {
-    logGroupName: output.logGroupName !== undefined && output.logGroupName !== null ? output.logGroupName : undefined,
-    logStreamNamePrefix:
-      output.logStreamNamePrefix !== undefined && output.logStreamNamePrefix !== null
-        ? output.logStreamNamePrefix
-        : undefined,
+    logGroupName: __expectString(output.logGroupName),
+    logStreamNamePrefix: __expectString(output.logStreamNamePrefix),
   } as any;
 };
 
 const deserializeAws_restJson1Configuration = (output: any, context: __SerdeContext): Configuration => {
   return {
-    classification:
-      output.classification !== undefined && output.classification !== null ? output.classification : undefined,
+    classification: __expectString(output.classification),
     configurations:
       output.configurations !== undefined && output.configurations !== null
         ? deserializeAws_restJson1ConfigurationList(output.configurations, context)
@@ -1944,26 +1941,25 @@ const deserializeAws_restJson1ContainerInfo = (output: any, context: __SerdeCont
 
 const deserializeAws_restJson1ContainerProvider = (output: any, context: __SerdeContext): ContainerProvider => {
   return {
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    id: __expectString(output.id),
     info:
       output.info !== undefined && output.info !== null
         ? deserializeAws_restJson1ContainerInfo(output.info, context)
         : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    type: __expectString(output.type),
   } as any;
 };
 
 const deserializeAws_restJson1EksInfo = (output: any, context: __SerdeContext): EksInfo => {
   return {
-    namespace: output.namespace !== undefined && output.namespace !== null ? output.namespace : undefined,
+    namespace: __expectString(output.namespace),
   } as any;
 };
 
 const deserializeAws_restJson1Endpoint = (output: any, context: __SerdeContext): Endpoint => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    certificateArn:
-      output.certificateArn !== undefined && output.certificateArn !== null ? output.certificateArn : undefined,
+    arn: __expectString(output.arn),
+    certificateArn: __expectString(output.certificateArn),
     configurationOverrides:
       output.configurationOverrides !== undefined && output.configurationOverrides !== null
         ? deserializeAws_restJson1ConfigurationOverrides(output.configurationOverrides, context)
@@ -1972,15 +1968,13 @@ const deserializeAws_restJson1Endpoint = (output: any, context: __SerdeContext):
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    executionRoleArn:
-      output.executionRoleArn !== undefined && output.executionRoleArn !== null ? output.executionRoleArn : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    releaseLabel: output.releaseLabel !== undefined && output.releaseLabel !== null ? output.releaseLabel : undefined,
-    securityGroup:
-      output.securityGroup !== undefined && output.securityGroup !== null ? output.securityGroup : undefined,
-    serverUrl: output.serverUrl !== undefined && output.serverUrl !== null ? output.serverUrl : undefined,
-    state: output.state !== undefined && output.state !== null ? output.state : undefined,
+    executionRoleArn: __expectString(output.executionRoleArn),
+    id: __expectString(output.id),
+    name: __expectString(output.name),
+    releaseLabel: __expectString(output.releaseLabel),
+    securityGroup: __expectString(output.securityGroup),
+    serverUrl: __expectString(output.serverUrl),
+    state: __expectString(output.state),
     subnetIds:
       output.subnetIds !== undefined && output.subnetIds !== null
         ? deserializeAws_restJson1SubnetIds(output.subnetIds, context)
@@ -1989,9 +1983,8 @@ const deserializeAws_restJson1Endpoint = (output: any, context: __SerdeContext):
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1TagMap(output.tags, context)
         : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
-    virtualClusterId:
-      output.virtualClusterId !== undefined && output.virtualClusterId !== null ? output.virtualClusterId : undefined,
+    type: __expectString(output.type),
+    virtualClusterId: __expectString(output.virtualClusterId),
   } as any;
 };
 
@@ -2013,7 +2006,7 @@ const deserializeAws_restJson1EntryPointArguments = (output: any, context: __Ser
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2028,8 +2021,8 @@ const deserializeAws_restJson1JobDriver = (output: any, context: __SerdeContext)
 
 const deserializeAws_restJson1JobRun = (output: any, context: __SerdeContext): JobRun => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    clientToken: output.clientToken !== undefined && output.clientToken !== null ? output.clientToken : undefined,
+    arn: __expectString(output.arn),
+    clientToken: __expectString(output.clientToken),
     configurationOverrides:
       output.configurationOverrides !== undefined && output.configurationOverrides !== null
         ? deserializeAws_restJson1ConfigurationOverrides(output.configurationOverrides, context)
@@ -2038,30 +2031,27 @@ const deserializeAws_restJson1JobRun = (output: any, context: __SerdeContext): J
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    createdBy: output.createdBy !== undefined && output.createdBy !== null ? output.createdBy : undefined,
-    executionRoleArn:
-      output.executionRoleArn !== undefined && output.executionRoleArn !== null ? output.executionRoleArn : undefined,
-    failureReason:
-      output.failureReason !== undefined && output.failureReason !== null ? output.failureReason : undefined,
+    createdBy: __expectString(output.createdBy),
+    executionRoleArn: __expectString(output.executionRoleArn),
+    failureReason: __expectString(output.failureReason),
     finishedAt:
       output.finishedAt !== undefined && output.finishedAt !== null
         ? new Date(Math.round(output.finishedAt * 1000))
         : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    id: __expectString(output.id),
     jobDriver:
       output.jobDriver !== undefined && output.jobDriver !== null
         ? deserializeAws_restJson1JobDriver(output.jobDriver, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    releaseLabel: output.releaseLabel !== undefined && output.releaseLabel !== null ? output.releaseLabel : undefined,
-    state: output.state !== undefined && output.state !== null ? output.state : undefined,
-    stateDetails: output.stateDetails !== undefined && output.stateDetails !== null ? output.stateDetails : undefined,
+    name: __expectString(output.name),
+    releaseLabel: __expectString(output.releaseLabel),
+    state: __expectString(output.state),
+    stateDetails: __expectString(output.stateDetails),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1TagMap(output.tags, context)
         : undefined,
-    virtualClusterId:
-      output.virtualClusterId !== undefined && output.virtualClusterId !== null ? output.virtualClusterId : undefined,
+    virtualClusterId: __expectString(output.virtualClusterId),
   } as any;
 };
 
@@ -2085,8 +2075,7 @@ const deserializeAws_restJson1MonitoringConfiguration = (
       output.cloudWatchMonitoringConfiguration !== undefined && output.cloudWatchMonitoringConfiguration !== null
         ? deserializeAws_restJson1CloudWatchMonitoringConfiguration(output.cloudWatchMonitoringConfiguration, context)
         : undefined,
-    persistentAppUI:
-      output.persistentAppUI !== undefined && output.persistentAppUI !== null ? output.persistentAppUI : undefined,
+    persistentAppUI: __expectString(output.persistentAppUI),
     s3MonitoringConfiguration:
       output.s3MonitoringConfiguration !== undefined && output.s3MonitoringConfiguration !== null
         ? deserializeAws_restJson1S3MonitoringConfiguration(output.s3MonitoringConfiguration, context)
@@ -2099,7 +2088,7 @@ const deserializeAws_restJson1S3MonitoringConfiguration = (
   context: __SerdeContext
 ): S3MonitoringConfiguration => {
   return {
-    logUri: output.logUri !== undefined && output.logUri !== null ? output.logUri : undefined,
+    logUri: __expectString(output.logUri),
   } as any;
 };
 
@@ -2113,22 +2102,19 @@ const deserializeAws_restJson1SensitivePropertiesMap = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1SparkSubmitJobDriver = (output: any, context: __SerdeContext): SparkSubmitJobDriver => {
   return {
-    entryPoint: output.entryPoint !== undefined && output.entryPoint !== null ? output.entryPoint : undefined,
+    entryPoint: __expectString(output.entryPoint),
     entryPointArguments:
       output.entryPointArguments !== undefined && output.entryPointArguments !== null
         ? deserializeAws_restJson1EntryPointArguments(output.entryPointArguments, context)
         : undefined,
-    sparkSubmitParameters:
-      output.sparkSubmitParameters !== undefined && output.sparkSubmitParameters !== null
-        ? output.sparkSubmitParameters
-        : undefined,
+    sparkSubmitParameters: __expectString(output.sparkSubmitParameters),
   } as any;
 };
 
@@ -2139,7 +2125,7 @@ const deserializeAws_restJson1SubnetIds = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2150,14 +2136,14 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1VirtualCluster = (output: any, context: __SerdeContext): VirtualCluster => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     containerProvider:
       output.containerProvider !== undefined && output.containerProvider !== null
         ? deserializeAws_restJson1ContainerProvider(output.containerProvider, context)
@@ -2166,9 +2152,9 @@ const deserializeAws_restJson1VirtualCluster = (output: any, context: __SerdeCon
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    state: output.state !== undefined && output.state !== null ? output.state : undefined,
+    id: __expectString(output.id),
+    name: __expectString(output.name),
+    state: __expectString(output.state),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1TagMap(output.tags, context)

--- a/clients/client-emr/protocols/Aws_json1_1.ts
+++ b/clients/client-emr/protocols/Aws_json1_1.ts
@@ -302,7 +302,12 @@ import {
   VolumeSpecification,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -5207,10 +5212,9 @@ const serializeAws_json1_1XmlStringMaxLen256List = (input: string[], context: __
 
 const deserializeAws_json1_1AddInstanceFleetOutput = (output: any, context: __SerdeContext): AddInstanceFleetOutput => {
   return {
-    ClusterArn: output.ClusterArn !== undefined && output.ClusterArn !== null ? output.ClusterArn : undefined,
-    ClusterId: output.ClusterId !== undefined && output.ClusterId !== null ? output.ClusterId : undefined,
-    InstanceFleetId:
-      output.InstanceFleetId !== undefined && output.InstanceFleetId !== null ? output.InstanceFleetId : undefined,
+    ClusterArn: __expectString(output.ClusterArn),
+    ClusterId: __expectString(output.ClusterId),
+    InstanceFleetId: __expectString(output.InstanceFleetId),
   } as any;
 };
 
@@ -5219,12 +5223,12 @@ const deserializeAws_json1_1AddInstanceGroupsOutput = (
   context: __SerdeContext
 ): AddInstanceGroupsOutput => {
   return {
-    ClusterArn: output.ClusterArn !== undefined && output.ClusterArn !== null ? output.ClusterArn : undefined,
+    ClusterArn: __expectString(output.ClusterArn),
     InstanceGroupIds:
       output.InstanceGroupIds !== undefined && output.InstanceGroupIds !== null
         ? deserializeAws_json1_1InstanceGroupIdsList(output.InstanceGroupIds, context)
         : undefined,
-    JobFlowId: output.JobFlowId !== undefined && output.JobFlowId !== null ? output.JobFlowId : undefined,
+    JobFlowId: __expectString(output.JobFlowId),
   } as any;
 };
 
@@ -5251,8 +5255,8 @@ const deserializeAws_json1_1Application = (output: any, context: __SerdeContext)
       output.Args !== undefined && output.Args !== null
         ? deserializeAws_json1_1StringList(output.Args, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    Name: __expectString(output.Name),
+    Version: __expectString(output.Version),
   } as any;
 };
 
@@ -5292,8 +5296,8 @@ const deserializeAws_json1_1AutoScalingPolicyStateChangeReason = (
   context: __SerdeContext
 ): AutoScalingPolicyStateChangeReason => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -5302,7 +5306,7 @@ const deserializeAws_json1_1AutoScalingPolicyStatus = (
   context: __SerdeContext
 ): AutoScalingPolicyStatus => {
   return {
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    State: __expectString(output.State),
     StateChangeReason:
       output.StateChangeReason !== undefined && output.StateChangeReason !== null
         ? deserializeAws_json1_1AutoScalingPolicyStateChangeReason(output.StateChangeReason, context)
@@ -5315,12 +5319,8 @@ const deserializeAws_json1_1BlockPublicAccessConfiguration = (
   context: __SerdeContext
 ): BlockPublicAccessConfiguration => {
   return {
-    BlockPublicSecurityGroupRules:
-      output.BlockPublicSecurityGroupRules !== undefined && output.BlockPublicSecurityGroupRules !== null
-        ? output.BlockPublicSecurityGroupRules
-        : undefined,
-    Classification:
-      output.Classification !== undefined && output.Classification !== null ? output.Classification : undefined,
+    BlockPublicSecurityGroupRules: __expectBoolean(output.BlockPublicSecurityGroupRules),
+    Classification: __expectString(output.Classification),
     Configurations:
       output.Configurations !== undefined && output.Configurations !== null
         ? deserializeAws_json1_1ConfigurationList(output.Configurations, context)
@@ -5342,7 +5342,7 @@ const deserializeAws_json1_1BlockPublicAccessConfigurationMetadata = (
   context: __SerdeContext
 ): BlockPublicAccessConfigurationMetadata => {
   return {
-    CreatedByArn: output.CreatedByArn !== undefined && output.CreatedByArn !== null ? output.CreatedByArn : undefined,
+    CreatedByArn: __expectString(output.CreatedByArn),
     CreationDateTime:
       output.CreationDateTime !== undefined && output.CreationDateTime !== null
         ? new Date(Math.round(output.CreationDateTime * 1000))
@@ -5352,7 +5352,7 @@ const deserializeAws_json1_1BlockPublicAccessConfigurationMetadata = (
 
 const deserializeAws_json1_1BootstrapActionConfig = (output: any, context: __SerdeContext): BootstrapActionConfig => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     ScriptBootstrapAction:
       output.ScriptBootstrapAction !== undefined && output.ScriptBootstrapAction !== null
         ? deserializeAws_json1_1ScriptBootstrapActionConfig(output.ScriptBootstrapAction, context)
@@ -5385,9 +5385,9 @@ const deserializeAws_json1_1BootstrapActionDetailList = (
 
 const deserializeAws_json1_1CancelStepsInfo = (output: any, context: __SerdeContext): CancelStepsInfo => {
   return {
-    Reason: output.Reason !== undefined && output.Reason !== null ? output.Reason : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StepId: output.StepId !== undefined && output.StepId !== null ? output.StepId : undefined,
+    Reason: __expectString(output.Reason),
+    Status: __expectString(output.Status),
+    StepId: __expectString(output.StepId),
   } as any;
 };
 
@@ -5416,24 +5416,18 @@ const deserializeAws_json1_1CloudWatchAlarmDefinition = (
   context: __SerdeContext
 ): CloudWatchAlarmDefinition => {
   return {
-    ComparisonOperator:
-      output.ComparisonOperator !== undefined && output.ComparisonOperator !== null
-        ? output.ComparisonOperator
-        : undefined,
+    ComparisonOperator: __expectString(output.ComparisonOperator),
     Dimensions:
       output.Dimensions !== undefined && output.Dimensions !== null
         ? deserializeAws_json1_1MetricDimensionList(output.Dimensions, context)
         : undefined,
-    EvaluationPeriods:
-      output.EvaluationPeriods !== undefined && output.EvaluationPeriods !== null
-        ? output.EvaluationPeriods
-        : undefined,
-    MetricName: output.MetricName !== undefined && output.MetricName !== null ? output.MetricName : undefined,
-    Namespace: output.Namespace !== undefined && output.Namespace !== null ? output.Namespace : undefined,
-    Period: output.Period !== undefined && output.Period !== null ? output.Period : undefined,
-    Statistic: output.Statistic !== undefined && output.Statistic !== null ? output.Statistic : undefined,
-    Threshold: output.Threshold !== undefined && output.Threshold !== null ? output.Threshold : undefined,
-    Unit: output.Unit !== undefined && output.Unit !== null ? output.Unit : undefined,
+    EvaluationPeriods: __expectNumber(output.EvaluationPeriods),
+    MetricName: __expectString(output.MetricName),
+    Namespace: __expectString(output.Namespace),
+    Period: __expectNumber(output.Period),
+    Statistic: __expectString(output.Statistic),
+    Threshold: __expectNumber(output.Threshold),
+    Unit: __expectString(output.Unit),
   } as any;
 };
 
@@ -5443,94 +5437,53 @@ const deserializeAws_json1_1Cluster = (output: any, context: __SerdeContext): Cl
       output.Applications !== undefined && output.Applications !== null
         ? deserializeAws_json1_1ApplicationList(output.Applications, context)
         : undefined,
-    AutoScalingRole:
-      output.AutoScalingRole !== undefined && output.AutoScalingRole !== null ? output.AutoScalingRole : undefined,
-    AutoTerminate:
-      output.AutoTerminate !== undefined && output.AutoTerminate !== null ? output.AutoTerminate : undefined,
-    ClusterArn: output.ClusterArn !== undefined && output.ClusterArn !== null ? output.ClusterArn : undefined,
+    AutoScalingRole: __expectString(output.AutoScalingRole),
+    AutoTerminate: __expectBoolean(output.AutoTerminate),
+    ClusterArn: __expectString(output.ClusterArn),
     Configurations:
       output.Configurations !== undefined && output.Configurations !== null
         ? deserializeAws_json1_1ConfigurationList(output.Configurations, context)
         : undefined,
-    CustomAmiId: output.CustomAmiId !== undefined && output.CustomAmiId !== null ? output.CustomAmiId : undefined,
-    EbsRootVolumeSize:
-      output.EbsRootVolumeSize !== undefined && output.EbsRootVolumeSize !== null
-        ? output.EbsRootVolumeSize
-        : undefined,
+    CustomAmiId: __expectString(output.CustomAmiId),
+    EbsRootVolumeSize: __expectNumber(output.EbsRootVolumeSize),
     Ec2InstanceAttributes:
       output.Ec2InstanceAttributes !== undefined && output.Ec2InstanceAttributes !== null
         ? deserializeAws_json1_1Ec2InstanceAttributes(output.Ec2InstanceAttributes, context)
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    InstanceCollectionType:
-      output.InstanceCollectionType !== undefined && output.InstanceCollectionType !== null
-        ? output.InstanceCollectionType
-        : undefined,
+    Id: __expectString(output.Id),
+    InstanceCollectionType: __expectString(output.InstanceCollectionType),
     KerberosAttributes:
       output.KerberosAttributes !== undefined && output.KerberosAttributes !== null
         ? deserializeAws_json1_1KerberosAttributes(output.KerberosAttributes, context)
         : undefined,
-    LogEncryptionKmsKeyId:
-      output.LogEncryptionKmsKeyId !== undefined && output.LogEncryptionKmsKeyId !== null
-        ? output.LogEncryptionKmsKeyId
-        : undefined,
-    LogUri: output.LogUri !== undefined && output.LogUri !== null ? output.LogUri : undefined,
-    MasterPublicDnsName:
-      output.MasterPublicDnsName !== undefined && output.MasterPublicDnsName !== null
-        ? output.MasterPublicDnsName
-        : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    NormalizedInstanceHours:
-      output.NormalizedInstanceHours !== undefined && output.NormalizedInstanceHours !== null
-        ? output.NormalizedInstanceHours
-        : undefined,
-    OutpostArn: output.OutpostArn !== undefined && output.OutpostArn !== null ? output.OutpostArn : undefined,
+    LogEncryptionKmsKeyId: __expectString(output.LogEncryptionKmsKeyId),
+    LogUri: __expectString(output.LogUri),
+    MasterPublicDnsName: __expectString(output.MasterPublicDnsName),
+    Name: __expectString(output.Name),
+    NormalizedInstanceHours: __expectNumber(output.NormalizedInstanceHours),
+    OutpostArn: __expectString(output.OutpostArn),
     PlacementGroups:
       output.PlacementGroups !== undefined && output.PlacementGroups !== null
         ? deserializeAws_json1_1PlacementGroupConfigList(output.PlacementGroups, context)
         : undefined,
-    ReleaseLabel: output.ReleaseLabel !== undefined && output.ReleaseLabel !== null ? output.ReleaseLabel : undefined,
-    RepoUpgradeOnBoot:
-      output.RepoUpgradeOnBoot !== undefined && output.RepoUpgradeOnBoot !== null
-        ? output.RepoUpgradeOnBoot
-        : undefined,
-    RequestedAmiVersion:
-      output.RequestedAmiVersion !== undefined && output.RequestedAmiVersion !== null
-        ? output.RequestedAmiVersion
-        : undefined,
-    RunningAmiVersion:
-      output.RunningAmiVersion !== undefined && output.RunningAmiVersion !== null
-        ? output.RunningAmiVersion
-        : undefined,
-    ScaleDownBehavior:
-      output.ScaleDownBehavior !== undefined && output.ScaleDownBehavior !== null
-        ? output.ScaleDownBehavior
-        : undefined,
-    SecurityConfiguration:
-      output.SecurityConfiguration !== undefined && output.SecurityConfiguration !== null
-        ? output.SecurityConfiguration
-        : undefined,
-    ServiceRole: output.ServiceRole !== undefined && output.ServiceRole !== null ? output.ServiceRole : undefined,
+    ReleaseLabel: __expectString(output.ReleaseLabel),
+    RepoUpgradeOnBoot: __expectString(output.RepoUpgradeOnBoot),
+    RequestedAmiVersion: __expectString(output.RequestedAmiVersion),
+    RunningAmiVersion: __expectString(output.RunningAmiVersion),
+    ScaleDownBehavior: __expectString(output.ScaleDownBehavior),
+    SecurityConfiguration: __expectString(output.SecurityConfiguration),
+    ServiceRole: __expectString(output.ServiceRole),
     Status:
       output.Status !== undefined && output.Status !== null
         ? deserializeAws_json1_1ClusterStatus(output.Status, context)
         : undefined,
-    StepConcurrencyLevel:
-      output.StepConcurrencyLevel !== undefined && output.StepConcurrencyLevel !== null
-        ? output.StepConcurrencyLevel
-        : undefined,
+    StepConcurrencyLevel: __expectNumber(output.StepConcurrencyLevel),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_1TagList(output.Tags, context)
         : undefined,
-    TerminationProtected:
-      output.TerminationProtected !== undefined && output.TerminationProtected !== null
-        ? output.TerminationProtected
-        : undefined,
-    VisibleToAllUsers:
-      output.VisibleToAllUsers !== undefined && output.VisibleToAllUsers !== null
-        ? output.VisibleToAllUsers
-        : undefined,
+    TerminationProtected: __expectBoolean(output.TerminationProtected),
+    VisibleToAllUsers: __expectBoolean(output.VisibleToAllUsers),
   } as any;
 };
 
@@ -5539,14 +5492,14 @@ const deserializeAws_json1_1ClusterStateChangeReason = (
   context: __SerdeContext
 ): ClusterStateChangeReason => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1ClusterStatus = (output: any, context: __SerdeContext): ClusterStatus => {
   return {
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    State: __expectString(output.State),
     StateChangeReason:
       output.StateChangeReason !== undefined && output.StateChangeReason !== null
         ? deserializeAws_json1_1ClusterStateChangeReason(output.StateChangeReason, context)
@@ -5560,14 +5513,11 @@ const deserializeAws_json1_1ClusterStatus = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1ClusterSummary = (output: any, context: __SerdeContext): ClusterSummary => {
   return {
-    ClusterArn: output.ClusterArn !== undefined && output.ClusterArn !== null ? output.ClusterArn : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    NormalizedInstanceHours:
-      output.NormalizedInstanceHours !== undefined && output.NormalizedInstanceHours !== null
-        ? output.NormalizedInstanceHours
-        : undefined,
-    OutpostArn: output.OutpostArn !== undefined && output.OutpostArn !== null ? output.OutpostArn : undefined,
+    ClusterArn: __expectString(output.ClusterArn),
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
+    NormalizedInstanceHours: __expectNumber(output.NormalizedInstanceHours),
+    OutpostArn: __expectString(output.OutpostArn),
     Status:
       output.Status !== undefined && output.Status !== null
         ? deserializeAws_json1_1ClusterStatus(output.Status, context)
@@ -5609,8 +5559,8 @@ const deserializeAws_json1_1Command = (output: any, context: __SerdeContext): Co
       output.Args !== undefined && output.Args !== null
         ? deserializeAws_json1_1StringList(output.Args, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    ScriptPath: output.ScriptPath !== undefined && output.ScriptPath !== null ? output.ScriptPath : undefined,
+    Name: __expectString(output.Name),
+    ScriptPath: __expectString(output.ScriptPath),
   } as any;
 };
 
@@ -5627,30 +5577,17 @@ const deserializeAws_json1_1CommandList = (output: any, context: __SerdeContext)
 
 const deserializeAws_json1_1ComputeLimits = (output: any, context: __SerdeContext): ComputeLimits => {
   return {
-    MaximumCapacityUnits:
-      output.MaximumCapacityUnits !== undefined && output.MaximumCapacityUnits !== null
-        ? output.MaximumCapacityUnits
-        : undefined,
-    MaximumCoreCapacityUnits:
-      output.MaximumCoreCapacityUnits !== undefined && output.MaximumCoreCapacityUnits !== null
-        ? output.MaximumCoreCapacityUnits
-        : undefined,
-    MaximumOnDemandCapacityUnits:
-      output.MaximumOnDemandCapacityUnits !== undefined && output.MaximumOnDemandCapacityUnits !== null
-        ? output.MaximumOnDemandCapacityUnits
-        : undefined,
-    MinimumCapacityUnits:
-      output.MinimumCapacityUnits !== undefined && output.MinimumCapacityUnits !== null
-        ? output.MinimumCapacityUnits
-        : undefined,
-    UnitType: output.UnitType !== undefined && output.UnitType !== null ? output.UnitType : undefined,
+    MaximumCapacityUnits: __expectNumber(output.MaximumCapacityUnits),
+    MaximumCoreCapacityUnits: __expectNumber(output.MaximumCoreCapacityUnits),
+    MaximumOnDemandCapacityUnits: __expectNumber(output.MaximumOnDemandCapacityUnits),
+    MinimumCapacityUnits: __expectNumber(output.MinimumCapacityUnits),
+    UnitType: __expectString(output.UnitType),
   } as any;
 };
 
 const deserializeAws_json1_1Configuration = (output: any, context: __SerdeContext): Configuration => {
   return {
-    Classification:
-      output.Classification !== undefined && output.Classification !== null ? output.Classification : undefined,
+    Classification: __expectString(output.Classification),
     Configurations:
       output.Configurations !== undefined && output.Configurations !== null
         ? deserializeAws_json1_1ConfigurationList(output.Configurations, context)
@@ -5682,14 +5619,14 @@ const deserializeAws_json1_1CreateSecurityConfigurationOutput = (
       output.CreationDateTime !== undefined && output.CreationDateTime !== null
         ? new Date(Math.round(output.CreationDateTime * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
 const deserializeAws_json1_1CreateStudioOutput = (output: any, context: __SerdeContext): CreateStudioOutput => {
   return {
-    StudioId: output.StudioId !== undefined && output.StudioId !== null ? output.StudioId : undefined,
-    Url: output.Url !== undefined && output.Url !== null ? output.Url : undefined,
+    StudioId: __expectString(output.StudioId),
+    Url: __expectString(output.Url),
   } as any;
 };
 
@@ -5739,11 +5676,8 @@ const deserializeAws_json1_1DescribeSecurityConfigurationOutput = (
       output.CreationDateTime !== undefined && output.CreationDateTime !== null
         ? new Date(Math.round(output.CreationDateTime * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    SecurityConfiguration:
-      output.SecurityConfiguration !== undefined && output.SecurityConfiguration !== null
-        ? output.SecurityConfiguration
-        : undefined,
+    Name: __expectString(output.Name),
+    SecurityConfiguration: __expectString(output.SecurityConfiguration),
   } as any;
 };
 
@@ -5765,7 +5699,7 @@ const deserializeAws_json1_1DescribeStudioOutput = (output: any, context: __Serd
 
 const deserializeAws_json1_1EbsBlockDevice = (output: any, context: __SerdeContext): EbsBlockDevice => {
   return {
-    Device: output.Device !== undefined && output.Device !== null ? output.Device : undefined,
+    Device: __expectString(output.Device),
     VolumeSpecification:
       output.VolumeSpecification !== undefined && output.VolumeSpecification !== null
         ? deserializeAws_json1_1VolumeSpecification(output.VolumeSpecification, context)
@@ -5786,8 +5720,8 @@ const deserializeAws_json1_1EbsBlockDeviceList = (output: any, context: __SerdeC
 
 const deserializeAws_json1_1EbsVolume = (output: any, context: __SerdeContext): EbsVolume => {
   return {
-    Device: output.Device !== undefined && output.Device !== null ? output.Device : undefined,
-    VolumeId: output.VolumeId !== undefined && output.VolumeId !== null ? output.VolumeId : undefined,
+    Device: __expectString(output.Device),
+    VolumeId: __expectString(output.VolumeId),
   } as any;
 };
 
@@ -5812,24 +5746,12 @@ const deserializeAws_json1_1Ec2InstanceAttributes = (output: any, context: __Ser
       output.AdditionalSlaveSecurityGroups !== undefined && output.AdditionalSlaveSecurityGroups !== null
         ? deserializeAws_json1_1StringList(output.AdditionalSlaveSecurityGroups, context)
         : undefined,
-    Ec2AvailabilityZone:
-      output.Ec2AvailabilityZone !== undefined && output.Ec2AvailabilityZone !== null
-        ? output.Ec2AvailabilityZone
-        : undefined,
-    Ec2KeyName: output.Ec2KeyName !== undefined && output.Ec2KeyName !== null ? output.Ec2KeyName : undefined,
-    Ec2SubnetId: output.Ec2SubnetId !== undefined && output.Ec2SubnetId !== null ? output.Ec2SubnetId : undefined,
-    EmrManagedMasterSecurityGroup:
-      output.EmrManagedMasterSecurityGroup !== undefined && output.EmrManagedMasterSecurityGroup !== null
-        ? output.EmrManagedMasterSecurityGroup
-        : undefined,
-    EmrManagedSlaveSecurityGroup:
-      output.EmrManagedSlaveSecurityGroup !== undefined && output.EmrManagedSlaveSecurityGroup !== null
-        ? output.EmrManagedSlaveSecurityGroup
-        : undefined,
-    IamInstanceProfile:
-      output.IamInstanceProfile !== undefined && output.IamInstanceProfile !== null
-        ? output.IamInstanceProfile
-        : undefined,
+    Ec2AvailabilityZone: __expectString(output.Ec2AvailabilityZone),
+    Ec2KeyName: __expectString(output.Ec2KeyName),
+    Ec2SubnetId: __expectString(output.Ec2SubnetId),
+    EmrManagedMasterSecurityGroup: __expectString(output.EmrManagedMasterSecurityGroup),
+    EmrManagedSlaveSecurityGroup: __expectString(output.EmrManagedSlaveSecurityGroup),
+    IamInstanceProfile: __expectString(output.IamInstanceProfile),
     RequestedEc2AvailabilityZones:
       output.RequestedEc2AvailabilityZones !== undefined && output.RequestedEc2AvailabilityZones !== null
         ? deserializeAws_json1_1XmlStringMaxLen256List(output.RequestedEc2AvailabilityZones, context)
@@ -5838,10 +5760,7 @@ const deserializeAws_json1_1Ec2InstanceAttributes = (output: any, context: __Ser
       output.RequestedEc2SubnetIds !== undefined && output.RequestedEc2SubnetIds !== null
         ? deserializeAws_json1_1XmlStringMaxLen256List(output.RequestedEc2SubnetIds, context)
         : undefined,
-    ServiceAccessSecurityGroup:
-      output.ServiceAccessSecurityGroup !== undefined && output.ServiceAccessSecurityGroup !== null
-        ? output.ServiceAccessSecurityGroup
-        : undefined,
+    ServiceAccessSecurityGroup: __expectString(output.ServiceAccessSecurityGroup),
   } as any;
 };
 
@@ -5852,26 +5771,23 @@ const deserializeAws_json1_1EC2InstanceIdsList = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1ExecutionEngineConfig = (output: any, context: __SerdeContext): ExecutionEngineConfig => {
   return {
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    MasterInstanceSecurityGroupId:
-      output.MasterInstanceSecurityGroupId !== undefined && output.MasterInstanceSecurityGroupId !== null
-        ? output.MasterInstanceSecurityGroupId
-        : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Id: __expectString(output.Id),
+    MasterInstanceSecurityGroupId: __expectString(output.MasterInstanceSecurityGroupId),
+    Type: __expectString(output.Type),
   } as any;
 };
 
 const deserializeAws_json1_1FailureDetails = (output: any, context: __SerdeContext): FailureDetails => {
   return {
-    LogFile: output.LogFile !== undefined && output.LogFile !== null ? output.LogFile : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Reason: output.Reason !== undefined && output.Reason !== null ? output.Reason : undefined,
+    LogFile: __expectString(output.LogFile),
+    Message: __expectString(output.Message),
+    Reason: __expectString(output.Reason),
   } as any;
 };
 
@@ -5925,8 +5841,8 @@ const deserializeAws_json1_1HadoopJarStepConfig = (output: any, context: __Serde
       output.Args !== undefined && output.Args !== null
         ? deserializeAws_json1_1XmlStringList(output.Args, context)
         : undefined,
-    Jar: output.Jar !== undefined && output.Jar !== null ? output.Jar : undefined,
-    MainClass: output.MainClass !== undefined && output.MainClass !== null ? output.MainClass : undefined,
+    Jar: __expectString(output.Jar),
+    MainClass: __expectString(output.MainClass),
     Properties:
       output.Properties !== undefined && output.Properties !== null
         ? deserializeAws_json1_1KeyValueList(output.Properties, context)
@@ -5940,8 +5856,8 @@ const deserializeAws_json1_1HadoopStepConfig = (output: any, context: __SerdeCon
       output.Args !== undefined && output.Args !== null
         ? deserializeAws_json1_1StringList(output.Args, context)
         : undefined,
-    Jar: output.Jar !== undefined && output.Jar !== null ? output.Jar : undefined,
-    MainClass: output.MainClass !== undefined && output.MainClass !== null ? output.MainClass : undefined,
+    Jar: __expectString(output.Jar),
+    MainClass: __expectString(output.MainClass),
     Properties:
       output.Properties !== undefined && output.Properties !== null
         ? deserializeAws_json1_1StringMap(output.Properties, context)
@@ -5955,23 +5871,16 @@ const deserializeAws_json1_1Instance = (output: any, context: __SerdeContext): I
       output.EbsVolumes !== undefined && output.EbsVolumes !== null
         ? deserializeAws_json1_1EbsVolumeList(output.EbsVolumes, context)
         : undefined,
-    Ec2InstanceId:
-      output.Ec2InstanceId !== undefined && output.Ec2InstanceId !== null ? output.Ec2InstanceId : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    InstanceFleetId:
-      output.InstanceFleetId !== undefined && output.InstanceFleetId !== null ? output.InstanceFleetId : undefined,
-    InstanceGroupId:
-      output.InstanceGroupId !== undefined && output.InstanceGroupId !== null ? output.InstanceGroupId : undefined,
-    InstanceType: output.InstanceType !== undefined && output.InstanceType !== null ? output.InstanceType : undefined,
-    Market: output.Market !== undefined && output.Market !== null ? output.Market : undefined,
-    PrivateDnsName:
-      output.PrivateDnsName !== undefined && output.PrivateDnsName !== null ? output.PrivateDnsName : undefined,
-    PrivateIpAddress:
-      output.PrivateIpAddress !== undefined && output.PrivateIpAddress !== null ? output.PrivateIpAddress : undefined,
-    PublicDnsName:
-      output.PublicDnsName !== undefined && output.PublicDnsName !== null ? output.PublicDnsName : undefined,
-    PublicIpAddress:
-      output.PublicIpAddress !== undefined && output.PublicIpAddress !== null ? output.PublicIpAddress : undefined,
+    Ec2InstanceId: __expectString(output.Ec2InstanceId),
+    Id: __expectString(output.Id),
+    InstanceFleetId: __expectString(output.InstanceFleetId),
+    InstanceGroupId: __expectString(output.InstanceGroupId),
+    InstanceType: __expectString(output.InstanceType),
+    Market: __expectString(output.Market),
+    PrivateDnsName: __expectString(output.PrivateDnsName),
+    PrivateIpAddress: __expectString(output.PrivateIpAddress),
+    PublicDnsName: __expectString(output.PublicDnsName),
+    PublicIpAddress: __expectString(output.PublicIpAddress),
     Status:
       output.Status !== undefined && output.Status !== null
         ? deserializeAws_json1_1InstanceStatus(output.Status, context)
@@ -5981,11 +5890,8 @@ const deserializeAws_json1_1Instance = (output: any, context: __SerdeContext): I
 
 const deserializeAws_json1_1InstanceFleet = (output: any, context: __SerdeContext): InstanceFleet => {
   return {
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    InstanceFleetType:
-      output.InstanceFleetType !== undefined && output.InstanceFleetType !== null
-        ? output.InstanceFleetType
-        : undefined,
+    Id: __expectString(output.Id),
+    InstanceFleetType: __expectString(output.InstanceFleetType),
     InstanceTypeSpecifications:
       output.InstanceTypeSpecifications !== undefined && output.InstanceTypeSpecifications !== null
         ? deserializeAws_json1_1InstanceTypeSpecificationList(output.InstanceTypeSpecifications, context)
@@ -5994,27 +5900,15 @@ const deserializeAws_json1_1InstanceFleet = (output: any, context: __SerdeContex
       output.LaunchSpecifications !== undefined && output.LaunchSpecifications !== null
         ? deserializeAws_json1_1InstanceFleetProvisioningSpecifications(output.LaunchSpecifications, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    ProvisionedOnDemandCapacity:
-      output.ProvisionedOnDemandCapacity !== undefined && output.ProvisionedOnDemandCapacity !== null
-        ? output.ProvisionedOnDemandCapacity
-        : undefined,
-    ProvisionedSpotCapacity:
-      output.ProvisionedSpotCapacity !== undefined && output.ProvisionedSpotCapacity !== null
-        ? output.ProvisionedSpotCapacity
-        : undefined,
+    Name: __expectString(output.Name),
+    ProvisionedOnDemandCapacity: __expectNumber(output.ProvisionedOnDemandCapacity),
+    ProvisionedSpotCapacity: __expectNumber(output.ProvisionedSpotCapacity),
     Status:
       output.Status !== undefined && output.Status !== null
         ? deserializeAws_json1_1InstanceFleetStatus(output.Status, context)
         : undefined,
-    TargetOnDemandCapacity:
-      output.TargetOnDemandCapacity !== undefined && output.TargetOnDemandCapacity !== null
-        ? output.TargetOnDemandCapacity
-        : undefined,
-    TargetSpotCapacity:
-      output.TargetSpotCapacity !== undefined && output.TargetSpotCapacity !== null
-        ? output.TargetSpotCapacity
-        : undefined,
+    TargetOnDemandCapacity: __expectNumber(output.TargetOnDemandCapacity),
+    TargetSpotCapacity: __expectNumber(output.TargetSpotCapacity),
   } as any;
 };
 
@@ -6050,14 +5944,14 @@ const deserializeAws_json1_1InstanceFleetStateChangeReason = (
   context: __SerdeContext
 ): InstanceFleetStateChangeReason => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1InstanceFleetStatus = (output: any, context: __SerdeContext): InstanceFleetStatus => {
   return {
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    State: __expectString(output.State),
     StateChangeReason:
       output.StateChangeReason !== undefined && output.StateChangeReason !== null
         ? deserializeAws_json1_1InstanceFleetStateChangeReason(output.StateChangeReason, context)
@@ -6092,46 +5986,30 @@ const deserializeAws_json1_1InstanceGroup = (output: any, context: __SerdeContex
       output.AutoScalingPolicy !== undefined && output.AutoScalingPolicy !== null
         ? deserializeAws_json1_1AutoScalingPolicyDescription(output.AutoScalingPolicy, context)
         : undefined,
-    BidPrice: output.BidPrice !== undefined && output.BidPrice !== null ? output.BidPrice : undefined,
+    BidPrice: __expectString(output.BidPrice),
     Configurations:
       output.Configurations !== undefined && output.Configurations !== null
         ? deserializeAws_json1_1ConfigurationList(output.Configurations, context)
         : undefined,
-    ConfigurationsVersion:
-      output.ConfigurationsVersion !== undefined && output.ConfigurationsVersion !== null
-        ? output.ConfigurationsVersion
-        : undefined,
+    ConfigurationsVersion: __expectNumber(output.ConfigurationsVersion),
     EbsBlockDevices:
       output.EbsBlockDevices !== undefined && output.EbsBlockDevices !== null
         ? deserializeAws_json1_1EbsBlockDeviceList(output.EbsBlockDevices, context)
         : undefined,
-    EbsOptimized: output.EbsOptimized !== undefined && output.EbsOptimized !== null ? output.EbsOptimized : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    InstanceGroupType:
-      output.InstanceGroupType !== undefined && output.InstanceGroupType !== null
-        ? output.InstanceGroupType
-        : undefined,
-    InstanceType: output.InstanceType !== undefined && output.InstanceType !== null ? output.InstanceType : undefined,
+    EbsOptimized: __expectBoolean(output.EbsOptimized),
+    Id: __expectString(output.Id),
+    InstanceGroupType: __expectString(output.InstanceGroupType),
+    InstanceType: __expectString(output.InstanceType),
     LastSuccessfullyAppliedConfigurations:
       output.LastSuccessfullyAppliedConfigurations !== undefined &&
       output.LastSuccessfullyAppliedConfigurations !== null
         ? deserializeAws_json1_1ConfigurationList(output.LastSuccessfullyAppliedConfigurations, context)
         : undefined,
-    LastSuccessfullyAppliedConfigurationsVersion:
-      output.LastSuccessfullyAppliedConfigurationsVersion !== undefined &&
-      output.LastSuccessfullyAppliedConfigurationsVersion !== null
-        ? output.LastSuccessfullyAppliedConfigurationsVersion
-        : undefined,
-    Market: output.Market !== undefined && output.Market !== null ? output.Market : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    RequestedInstanceCount:
-      output.RequestedInstanceCount !== undefined && output.RequestedInstanceCount !== null
-        ? output.RequestedInstanceCount
-        : undefined,
-    RunningInstanceCount:
-      output.RunningInstanceCount !== undefined && output.RunningInstanceCount !== null
-        ? output.RunningInstanceCount
-        : undefined,
+    LastSuccessfullyAppliedConfigurationsVersion: __expectNumber(output.LastSuccessfullyAppliedConfigurationsVersion),
+    Market: __expectString(output.Market),
+    Name: __expectString(output.Name),
+    RequestedInstanceCount: __expectNumber(output.RequestedInstanceCount),
+    RunningInstanceCount: __expectNumber(output.RunningInstanceCount),
     ShrinkPolicy:
       output.ShrinkPolicy !== undefined && output.ShrinkPolicy !== null
         ? deserializeAws_json1_1ShrinkPolicy(output.ShrinkPolicy, context)
@@ -6145,7 +6023,7 @@ const deserializeAws_json1_1InstanceGroup = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1InstanceGroupDetail = (output: any, context: __SerdeContext): InstanceGroupDetail => {
   return {
-    BidPrice: output.BidPrice !== undefined && output.BidPrice !== null ? output.BidPrice : undefined,
+    BidPrice: __expectString(output.BidPrice),
     CreationDateTime:
       output.CreationDateTime !== undefined && output.CreationDateTime !== null
         ? new Date(Math.round(output.CreationDateTime * 1000))
@@ -6154,24 +6032,14 @@ const deserializeAws_json1_1InstanceGroupDetail = (output: any, context: __Serde
       output.EndDateTime !== undefined && output.EndDateTime !== null
         ? new Date(Math.round(output.EndDateTime * 1000))
         : undefined,
-    InstanceGroupId:
-      output.InstanceGroupId !== undefined && output.InstanceGroupId !== null ? output.InstanceGroupId : undefined,
-    InstanceRequestCount:
-      output.InstanceRequestCount !== undefined && output.InstanceRequestCount !== null
-        ? output.InstanceRequestCount
-        : undefined,
-    InstanceRole: output.InstanceRole !== undefined && output.InstanceRole !== null ? output.InstanceRole : undefined,
-    InstanceRunningCount:
-      output.InstanceRunningCount !== undefined && output.InstanceRunningCount !== null
-        ? output.InstanceRunningCount
-        : undefined,
-    InstanceType: output.InstanceType !== undefined && output.InstanceType !== null ? output.InstanceType : undefined,
-    LastStateChangeReason:
-      output.LastStateChangeReason !== undefined && output.LastStateChangeReason !== null
-        ? output.LastStateChangeReason
-        : undefined,
-    Market: output.Market !== undefined && output.Market !== null ? output.Market : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    InstanceGroupId: __expectString(output.InstanceGroupId),
+    InstanceRequestCount: __expectNumber(output.InstanceRequestCount),
+    InstanceRole: __expectString(output.InstanceRole),
+    InstanceRunningCount: __expectNumber(output.InstanceRunningCount),
+    InstanceType: __expectString(output.InstanceType),
+    LastStateChangeReason: __expectString(output.LastStateChangeReason),
+    Market: __expectString(output.Market),
+    Name: __expectString(output.Name),
     ReadyDateTime:
       output.ReadyDateTime !== undefined && output.ReadyDateTime !== null
         ? new Date(Math.round(output.ReadyDateTime * 1000))
@@ -6180,7 +6048,7 @@ const deserializeAws_json1_1InstanceGroupDetail = (output: any, context: __Serde
       output.StartDateTime !== undefined && output.StartDateTime !== null
         ? new Date(Math.round(output.StartDateTime * 1000))
         : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    State: __expectString(output.State),
   } as any;
 };
 
@@ -6202,7 +6070,7 @@ const deserializeAws_json1_1InstanceGroupIdsList = (output: any, context: __Serd
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6222,14 +6090,14 @@ const deserializeAws_json1_1InstanceGroupStateChangeReason = (
   context: __SerdeContext
 ): InstanceGroupStateChangeReason => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1InstanceGroupStatus = (output: any, context: __SerdeContext): InstanceGroupStatus => {
   return {
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    State: __expectString(output.State),
     StateChangeReason:
       output.StateChangeReason !== undefined && output.StateChangeReason !== null
         ? deserializeAws_json1_1InstanceGroupStateChangeReason(output.StateChangeReason, context)
@@ -6271,10 +6139,7 @@ const deserializeAws_json1_1InstanceList = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_1InstanceResizePolicy = (output: any, context: __SerdeContext): InstanceResizePolicy => {
   return {
-    InstanceTerminationTimeout:
-      output.InstanceTerminationTimeout !== undefined && output.InstanceTerminationTimeout !== null
-        ? output.InstanceTerminationTimeout
-        : undefined,
+    InstanceTerminationTimeout: __expectNumber(output.InstanceTerminationTimeout),
     InstancesToProtect:
       output.InstancesToProtect !== undefined && output.InstancesToProtect !== null
         ? deserializeAws_json1_1EC2InstanceIdsList(output.InstancesToProtect, context)
@@ -6291,14 +6156,14 @@ const deserializeAws_json1_1InstanceStateChangeReason = (
   context: __SerdeContext
 ): InstanceStateChangeReason => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1InstanceStatus = (output: any, context: __SerdeContext): InstanceStatus => {
   return {
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    State: __expectString(output.State),
     StateChangeReason:
       output.StateChangeReason !== undefined && output.StateChangeReason !== null
         ? deserializeAws_json1_1InstanceStateChangeReason(output.StateChangeReason, context)
@@ -6332,11 +6197,8 @@ const deserializeAws_json1_1InstanceTypeSpecification = (
   context: __SerdeContext
 ): InstanceTypeSpecification => {
   return {
-    BidPrice: output.BidPrice !== undefined && output.BidPrice !== null ? output.BidPrice : undefined,
-    BidPriceAsPercentageOfOnDemandPrice:
-      output.BidPriceAsPercentageOfOnDemandPrice !== undefined && output.BidPriceAsPercentageOfOnDemandPrice !== null
-        ? output.BidPriceAsPercentageOfOnDemandPrice
-        : undefined,
+    BidPrice: __expectString(output.BidPrice),
+    BidPriceAsPercentageOfOnDemandPrice: __expectNumber(output.BidPriceAsPercentageOfOnDemandPrice),
     Configurations:
       output.Configurations !== undefined && output.Configurations !== null
         ? deserializeAws_json1_1ConfigurationList(output.Configurations, context)
@@ -6345,10 +6207,9 @@ const deserializeAws_json1_1InstanceTypeSpecification = (
       output.EbsBlockDevices !== undefined && output.EbsBlockDevices !== null
         ? deserializeAws_json1_1EbsBlockDeviceList(output.EbsBlockDevices, context)
         : undefined,
-    EbsOptimized: output.EbsOptimized !== undefined && output.EbsOptimized !== null ? output.EbsOptimized : undefined,
-    InstanceType: output.InstanceType !== undefined && output.InstanceType !== null ? output.InstanceType : undefined,
-    WeightedCapacity:
-      output.WeightedCapacity !== undefined && output.WeightedCapacity !== null ? output.WeightedCapacity : undefined,
+    EbsOptimized: __expectBoolean(output.EbsOptimized),
+    InstanceType: __expectString(output.InstanceType),
+    WeightedCapacity: __expectNumber(output.WeightedCapacity),
   } as any;
 };
 
@@ -6375,7 +6236,7 @@ const deserializeAws_json1_1InternalServerException = (
   context: __SerdeContext
 ): InternalServerException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -6384,16 +6245,15 @@ const deserializeAws_json1_1InvalidRequestException = (
   context: __SerdeContext
 ): InvalidRequestException => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1JobFlowDetail = (output: any, context: __SerdeContext): JobFlowDetail => {
   return {
-    AmiVersion: output.AmiVersion !== undefined && output.AmiVersion !== null ? output.AmiVersion : undefined,
-    AutoScalingRole:
-      output.AutoScalingRole !== undefined && output.AutoScalingRole !== null ? output.AutoScalingRole : undefined,
+    AmiVersion: __expectString(output.AmiVersion),
+    AutoScalingRole: __expectString(output.AutoScalingRole),
     BootstrapActions:
       output.BootstrapActions !== undefined && output.BootstrapActions !== null
         ? deserializeAws_json1_1BootstrapActionDetailList(output.BootstrapActions, context)
@@ -6406,19 +6266,13 @@ const deserializeAws_json1_1JobFlowDetail = (output: any, context: __SerdeContex
       output.Instances !== undefined && output.Instances !== null
         ? deserializeAws_json1_1JobFlowInstancesDetail(output.Instances, context)
         : undefined,
-    JobFlowId: output.JobFlowId !== undefined && output.JobFlowId !== null ? output.JobFlowId : undefined,
-    JobFlowRole: output.JobFlowRole !== undefined && output.JobFlowRole !== null ? output.JobFlowRole : undefined,
-    LogEncryptionKmsKeyId:
-      output.LogEncryptionKmsKeyId !== undefined && output.LogEncryptionKmsKeyId !== null
-        ? output.LogEncryptionKmsKeyId
-        : undefined,
-    LogUri: output.LogUri !== undefined && output.LogUri !== null ? output.LogUri : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    ScaleDownBehavior:
-      output.ScaleDownBehavior !== undefined && output.ScaleDownBehavior !== null
-        ? output.ScaleDownBehavior
-        : undefined,
-    ServiceRole: output.ServiceRole !== undefined && output.ServiceRole !== null ? output.ServiceRole : undefined,
+    JobFlowId: __expectString(output.JobFlowId),
+    JobFlowRole: __expectString(output.JobFlowRole),
+    LogEncryptionKmsKeyId: __expectString(output.LogEncryptionKmsKeyId),
+    LogUri: __expectString(output.LogUri),
+    Name: __expectString(output.Name),
+    ScaleDownBehavior: __expectString(output.ScaleDownBehavior),
+    ServiceRole: __expectString(output.ServiceRole),
     Steps:
       output.Steps !== undefined && output.Steps !== null
         ? deserializeAws_json1_1StepDetailList(output.Steps, context)
@@ -6427,10 +6281,7 @@ const deserializeAws_json1_1JobFlowDetail = (output: any, context: __SerdeContex
       output.SupportedProducts !== undefined && output.SupportedProducts !== null
         ? deserializeAws_json1_1SupportedProductsList(output.SupportedProducts, context)
         : undefined,
-    VisibleToAllUsers:
-      output.VisibleToAllUsers !== undefined && output.VisibleToAllUsers !== null
-        ? output.VisibleToAllUsers
-        : undefined,
+    VisibleToAllUsers: __expectBoolean(output.VisibleToAllUsers),
   } as any;
 };
 
@@ -6458,10 +6309,7 @@ const deserializeAws_json1_1JobFlowExecutionStatusDetail = (
       output.EndDateTime !== undefined && output.EndDateTime !== null
         ? new Date(Math.round(output.EndDateTime * 1000))
         : undefined,
-    LastStateChangeReason:
-      output.LastStateChangeReason !== undefined && output.LastStateChangeReason !== null
-        ? output.LastStateChangeReason
-        : undefined,
+    LastStateChangeReason: __expectString(output.LastStateChangeReason),
     ReadyDateTime:
       output.ReadyDateTime !== undefined && output.ReadyDateTime !== null
         ? new Date(Math.round(output.ReadyDateTime * 1000))
@@ -6470,77 +6318,48 @@ const deserializeAws_json1_1JobFlowExecutionStatusDetail = (
       output.StartDateTime !== undefined && output.StartDateTime !== null
         ? new Date(Math.round(output.StartDateTime * 1000))
         : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    State: __expectString(output.State),
   } as any;
 };
 
 const deserializeAws_json1_1JobFlowInstancesDetail = (output: any, context: __SerdeContext): JobFlowInstancesDetail => {
   return {
-    Ec2KeyName: output.Ec2KeyName !== undefined && output.Ec2KeyName !== null ? output.Ec2KeyName : undefined,
-    Ec2SubnetId: output.Ec2SubnetId !== undefined && output.Ec2SubnetId !== null ? output.Ec2SubnetId : undefined,
-    HadoopVersion:
-      output.HadoopVersion !== undefined && output.HadoopVersion !== null ? output.HadoopVersion : undefined,
-    InstanceCount:
-      output.InstanceCount !== undefined && output.InstanceCount !== null ? output.InstanceCount : undefined,
+    Ec2KeyName: __expectString(output.Ec2KeyName),
+    Ec2SubnetId: __expectString(output.Ec2SubnetId),
+    HadoopVersion: __expectString(output.HadoopVersion),
+    InstanceCount: __expectNumber(output.InstanceCount),
     InstanceGroups:
       output.InstanceGroups !== undefined && output.InstanceGroups !== null
         ? deserializeAws_json1_1InstanceGroupDetailList(output.InstanceGroups, context)
         : undefined,
-    KeepJobFlowAliveWhenNoSteps:
-      output.KeepJobFlowAliveWhenNoSteps !== undefined && output.KeepJobFlowAliveWhenNoSteps !== null
-        ? output.KeepJobFlowAliveWhenNoSteps
-        : undefined,
-    MasterInstanceId:
-      output.MasterInstanceId !== undefined && output.MasterInstanceId !== null ? output.MasterInstanceId : undefined,
-    MasterInstanceType:
-      output.MasterInstanceType !== undefined && output.MasterInstanceType !== null
-        ? output.MasterInstanceType
-        : undefined,
-    MasterPublicDnsName:
-      output.MasterPublicDnsName !== undefined && output.MasterPublicDnsName !== null
-        ? output.MasterPublicDnsName
-        : undefined,
-    NormalizedInstanceHours:
-      output.NormalizedInstanceHours !== undefined && output.NormalizedInstanceHours !== null
-        ? output.NormalizedInstanceHours
-        : undefined,
+    KeepJobFlowAliveWhenNoSteps: __expectBoolean(output.KeepJobFlowAliveWhenNoSteps),
+    MasterInstanceId: __expectString(output.MasterInstanceId),
+    MasterInstanceType: __expectString(output.MasterInstanceType),
+    MasterPublicDnsName: __expectString(output.MasterPublicDnsName),
+    NormalizedInstanceHours: __expectNumber(output.NormalizedInstanceHours),
     Placement:
       output.Placement !== undefined && output.Placement !== null
         ? deserializeAws_json1_1PlacementType(output.Placement, context)
         : undefined,
-    SlaveInstanceType:
-      output.SlaveInstanceType !== undefined && output.SlaveInstanceType !== null
-        ? output.SlaveInstanceType
-        : undefined,
-    TerminationProtected:
-      output.TerminationProtected !== undefined && output.TerminationProtected !== null
-        ? output.TerminationProtected
-        : undefined,
+    SlaveInstanceType: __expectString(output.SlaveInstanceType),
+    TerminationProtected: __expectBoolean(output.TerminationProtected),
   } as any;
 };
 
 const deserializeAws_json1_1KerberosAttributes = (output: any, context: __SerdeContext): KerberosAttributes => {
   return {
-    ADDomainJoinPassword:
-      output.ADDomainJoinPassword !== undefined && output.ADDomainJoinPassword !== null
-        ? output.ADDomainJoinPassword
-        : undefined,
-    ADDomainJoinUser:
-      output.ADDomainJoinUser !== undefined && output.ADDomainJoinUser !== null ? output.ADDomainJoinUser : undefined,
-    CrossRealmTrustPrincipalPassword:
-      output.CrossRealmTrustPrincipalPassword !== undefined && output.CrossRealmTrustPrincipalPassword !== null
-        ? output.CrossRealmTrustPrincipalPassword
-        : undefined,
-    KdcAdminPassword:
-      output.KdcAdminPassword !== undefined && output.KdcAdminPassword !== null ? output.KdcAdminPassword : undefined,
-    Realm: output.Realm !== undefined && output.Realm !== null ? output.Realm : undefined,
+    ADDomainJoinPassword: __expectString(output.ADDomainJoinPassword),
+    ADDomainJoinUser: __expectString(output.ADDomainJoinUser),
+    CrossRealmTrustPrincipalPassword: __expectString(output.CrossRealmTrustPrincipalPassword),
+    KdcAdminPassword: __expectString(output.KdcAdminPassword),
+    Realm: __expectString(output.Realm),
   } as any;
 };
 
 const deserializeAws_json1_1KeyValue = (output: any, context: __SerdeContext): KeyValue => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -6564,7 +6383,7 @@ const deserializeAws_json1_1ListBootstrapActionsOutput = (
       output.BootstrapActions !== undefined && output.BootstrapActions !== null
         ? deserializeAws_json1_1CommandList(output.BootstrapActions, context)
         : undefined,
-    Marker: output.Marker !== undefined && output.Marker !== null ? output.Marker : undefined,
+    Marker: __expectString(output.Marker),
   } as any;
 };
 
@@ -6574,7 +6393,7 @@ const deserializeAws_json1_1ListClustersOutput = (output: any, context: __SerdeC
       output.Clusters !== undefined && output.Clusters !== null
         ? deserializeAws_json1_1ClusterSummaryList(output.Clusters, context)
         : undefined,
-    Marker: output.Marker !== undefined && output.Marker !== null ? output.Marker : undefined,
+    Marker: __expectString(output.Marker),
   } as any;
 };
 
@@ -6587,7 +6406,7 @@ const deserializeAws_json1_1ListInstanceFleetsOutput = (
       output.InstanceFleets !== undefined && output.InstanceFleets !== null
         ? deserializeAws_json1_1InstanceFleetList(output.InstanceFleets, context)
         : undefined,
-    Marker: output.Marker !== undefined && output.Marker !== null ? output.Marker : undefined,
+    Marker: __expectString(output.Marker),
   } as any;
 };
 
@@ -6600,7 +6419,7 @@ const deserializeAws_json1_1ListInstanceGroupsOutput = (
       output.InstanceGroups !== undefined && output.InstanceGroups !== null
         ? deserializeAws_json1_1InstanceGroupList(output.InstanceGroups, context)
         : undefined,
-    Marker: output.Marker !== undefined && output.Marker !== null ? output.Marker : undefined,
+    Marker: __expectString(output.Marker),
   } as any;
 };
 
@@ -6610,7 +6429,7 @@ const deserializeAws_json1_1ListInstancesOutput = (output: any, context: __Serde
       output.Instances !== undefined && output.Instances !== null
         ? deserializeAws_json1_1InstanceList(output.Instances, context)
         : undefined,
-    Marker: output.Marker !== undefined && output.Marker !== null ? output.Marker : undefined,
+    Marker: __expectString(output.Marker),
   } as any;
 };
 
@@ -6619,7 +6438,7 @@ const deserializeAws_json1_1ListNotebookExecutionsOutput = (
   context: __SerdeContext
 ): ListNotebookExecutionsOutput => {
   return {
-    Marker: output.Marker !== undefined && output.Marker !== null ? output.Marker : undefined,
+    Marker: __expectString(output.Marker),
     NotebookExecutions:
       output.NotebookExecutions !== undefined && output.NotebookExecutions !== null
         ? deserializeAws_json1_1NotebookExecutionSummaryList(output.NotebookExecutions, context)
@@ -6632,7 +6451,7 @@ const deserializeAws_json1_1ListSecurityConfigurationsOutput = (
   context: __SerdeContext
 ): ListSecurityConfigurationsOutput => {
   return {
-    Marker: output.Marker !== undefined && output.Marker !== null ? output.Marker : undefined,
+    Marker: __expectString(output.Marker),
     SecurityConfigurations:
       output.SecurityConfigurations !== undefined && output.SecurityConfigurations !== null
         ? deserializeAws_json1_1SecurityConfigurationList(output.SecurityConfigurations, context)
@@ -6642,7 +6461,7 @@ const deserializeAws_json1_1ListSecurityConfigurationsOutput = (
 
 const deserializeAws_json1_1ListStepsOutput = (output: any, context: __SerdeContext): ListStepsOutput => {
   return {
-    Marker: output.Marker !== undefined && output.Marker !== null ? output.Marker : undefined,
+    Marker: __expectString(output.Marker),
     Steps:
       output.Steps !== undefined && output.Steps !== null
         ? deserializeAws_json1_1StepSummaryList(output.Steps, context)
@@ -6655,7 +6474,7 @@ const deserializeAws_json1_1ListStudioSessionMappingsOutput = (
   context: __SerdeContext
 ): ListStudioSessionMappingsOutput => {
   return {
-    Marker: output.Marker !== undefined && output.Marker !== null ? output.Marker : undefined,
+    Marker: __expectString(output.Marker),
     SessionMappings:
       output.SessionMappings !== undefined && output.SessionMappings !== null
         ? deserializeAws_json1_1SessionMappingSummaryList(output.SessionMappings, context)
@@ -6665,7 +6484,7 @@ const deserializeAws_json1_1ListStudioSessionMappingsOutput = (
 
 const deserializeAws_json1_1ListStudiosOutput = (output: any, context: __SerdeContext): ListStudiosOutput => {
   return {
-    Marker: output.Marker !== undefined && output.Marker !== null ? output.Marker : undefined,
+    Marker: __expectString(output.Marker),
     Studios:
       output.Studios !== undefined && output.Studios !== null
         ? deserializeAws_json1_1StudioSummaryList(output.Studios, context)
@@ -6684,8 +6503,8 @@ const deserializeAws_json1_1ManagedScalingPolicy = (output: any, context: __Serd
 
 const deserializeAws_json1_1MetricDimension = (output: any, context: __SerdeContext): MetricDimension => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -6702,50 +6521,31 @@ const deserializeAws_json1_1MetricDimensionList = (output: any, context: __Serde
 
 const deserializeAws_json1_1ModifyClusterOutput = (output: any, context: __SerdeContext): ModifyClusterOutput => {
   return {
-    StepConcurrencyLevel:
-      output.StepConcurrencyLevel !== undefined && output.StepConcurrencyLevel !== null
-        ? output.StepConcurrencyLevel
-        : undefined,
+    StepConcurrencyLevel: __expectNumber(output.StepConcurrencyLevel),
   } as any;
 };
 
 const deserializeAws_json1_1NotebookExecution = (output: any, context: __SerdeContext): NotebookExecution => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    EditorId: output.EditorId !== undefined && output.EditorId !== null ? output.EditorId : undefined,
+    Arn: __expectString(output.Arn),
+    EditorId: __expectString(output.EditorId),
     EndTime:
       output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
     ExecutionEngine:
       output.ExecutionEngine !== undefined && output.ExecutionEngine !== null
         ? deserializeAws_json1_1ExecutionEngineConfig(output.ExecutionEngine, context)
         : undefined,
-    LastStateChangeReason:
-      output.LastStateChangeReason !== undefined && output.LastStateChangeReason !== null
-        ? output.LastStateChangeReason
-        : undefined,
-    NotebookExecutionId:
-      output.NotebookExecutionId !== undefined && output.NotebookExecutionId !== null
-        ? output.NotebookExecutionId
-        : undefined,
-    NotebookExecutionName:
-      output.NotebookExecutionName !== undefined && output.NotebookExecutionName !== null
-        ? output.NotebookExecutionName
-        : undefined,
-    NotebookInstanceSecurityGroupId:
-      output.NotebookInstanceSecurityGroupId !== undefined && output.NotebookInstanceSecurityGroupId !== null
-        ? output.NotebookInstanceSecurityGroupId
-        : undefined,
-    NotebookParams:
-      output.NotebookParams !== undefined && output.NotebookParams !== null ? output.NotebookParams : undefined,
-    OutputNotebookURI:
-      output.OutputNotebookURI !== undefined && output.OutputNotebookURI !== null
-        ? output.OutputNotebookURI
-        : undefined,
+    LastStateChangeReason: __expectString(output.LastStateChangeReason),
+    NotebookExecutionId: __expectString(output.NotebookExecutionId),
+    NotebookExecutionName: __expectString(output.NotebookExecutionName),
+    NotebookInstanceSecurityGroupId: __expectString(output.NotebookInstanceSecurityGroupId),
+    NotebookParams: __expectString(output.NotebookParams),
+    OutputNotebookURI: __expectString(output.OutputNotebookURI),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
         ? new Date(Math.round(output.StartTime * 1000))
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_1TagList(output.Tags, context)
@@ -6758,22 +6558,16 @@ const deserializeAws_json1_1NotebookExecutionSummary = (
   context: __SerdeContext
 ): NotebookExecutionSummary => {
   return {
-    EditorId: output.EditorId !== undefined && output.EditorId !== null ? output.EditorId : undefined,
+    EditorId: __expectString(output.EditorId),
     EndTime:
       output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
-    NotebookExecutionId:
-      output.NotebookExecutionId !== undefined && output.NotebookExecutionId !== null
-        ? output.NotebookExecutionId
-        : undefined,
-    NotebookExecutionName:
-      output.NotebookExecutionName !== undefined && output.NotebookExecutionName !== null
-        ? output.NotebookExecutionName
-        : undefined,
+    NotebookExecutionId: __expectString(output.NotebookExecutionId),
+    NotebookExecutionName: __expectString(output.NotebookExecutionName),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
         ? new Date(Math.round(output.StartTime * 1000))
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -6796,16 +6590,9 @@ const deserializeAws_json1_1OnDemandCapacityReservationOptions = (
   context: __SerdeContext
 ): OnDemandCapacityReservationOptions => {
   return {
-    CapacityReservationPreference:
-      output.CapacityReservationPreference !== undefined && output.CapacityReservationPreference !== null
-        ? output.CapacityReservationPreference
-        : undefined,
-    CapacityReservationResourceGroupArn:
-      output.CapacityReservationResourceGroupArn !== undefined && output.CapacityReservationResourceGroupArn !== null
-        ? output.CapacityReservationResourceGroupArn
-        : undefined,
-    UsageStrategy:
-      output.UsageStrategy !== undefined && output.UsageStrategy !== null ? output.UsageStrategy : undefined,
+    CapacityReservationPreference: __expectString(output.CapacityReservationPreference),
+    CapacityReservationResourceGroupArn: __expectString(output.CapacityReservationResourceGroupArn),
+    UsageStrategy: __expectString(output.UsageStrategy),
   } as any;
 };
 
@@ -6814,10 +6601,7 @@ const deserializeAws_json1_1OnDemandProvisioningSpecification = (
   context: __SerdeContext
 ): OnDemandProvisioningSpecification => {
   return {
-    AllocationStrategy:
-      output.AllocationStrategy !== undefined && output.AllocationStrategy !== null
-        ? output.AllocationStrategy
-        : undefined,
+    AllocationStrategy: __expectString(output.AllocationStrategy),
     CapacityReservationOptions:
       output.CapacityReservationOptions !== undefined && output.CapacityReservationOptions !== null
         ? deserializeAws_json1_1OnDemandCapacityReservationOptions(output.CapacityReservationOptions, context)
@@ -6827,11 +6611,8 @@ const deserializeAws_json1_1OnDemandProvisioningSpecification = (
 
 const deserializeAws_json1_1PlacementGroupConfig = (output: any, context: __SerdeContext): PlacementGroupConfig => {
   return {
-    InstanceRole: output.InstanceRole !== undefined && output.InstanceRole !== null ? output.InstanceRole : undefined,
-    PlacementStrategy:
-      output.PlacementStrategy !== undefined && output.PlacementStrategy !== null
-        ? output.PlacementStrategy
-        : undefined,
+    InstanceRole: __expectString(output.InstanceRole),
+    PlacementStrategy: __expectString(output.PlacementStrategy),
   } as any;
 };
 
@@ -6851,8 +6632,7 @@ const deserializeAws_json1_1PlacementGroupConfigList = (
 
 const deserializeAws_json1_1PlacementType = (output: any, context: __SerdeContext): PlacementType => {
   return {
-    AvailabilityZone:
-      output.AvailabilityZone !== undefined && output.AvailabilityZone !== null ? output.AvailabilityZone : undefined,
+    AvailabilityZone: __expectString(output.AvailabilityZone),
     AvailabilityZones:
       output.AvailabilityZones !== undefined && output.AvailabilityZones !== null
         ? deserializeAws_json1_1XmlStringMaxLen256List(output.AvailabilityZones, context)
@@ -6862,8 +6642,8 @@ const deserializeAws_json1_1PlacementType = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1PortRange = (output: any, context: __SerdeContext): PortRange => {
   return {
-    MaxRange: output.MaxRange !== undefined && output.MaxRange !== null ? output.MaxRange : undefined,
-    MinRange: output.MinRange !== undefined && output.MinRange !== null ? output.MinRange : undefined,
+    MaxRange: __expectNumber(output.MaxRange),
+    MinRange: __expectNumber(output.MinRange),
   } as any;
 };
 
@@ -6887,10 +6667,9 @@ const deserializeAws_json1_1PutAutoScalingPolicyOutput = (
       output.AutoScalingPolicy !== undefined && output.AutoScalingPolicy !== null
         ? deserializeAws_json1_1AutoScalingPolicyDescription(output.AutoScalingPolicy, context)
         : undefined,
-    ClusterArn: output.ClusterArn !== undefined && output.ClusterArn !== null ? output.ClusterArn : undefined,
-    ClusterId: output.ClusterId !== undefined && output.ClusterId !== null ? output.ClusterId : undefined,
-    InstanceGroupId:
-      output.InstanceGroupId !== undefined && output.InstanceGroupId !== null ? output.InstanceGroupId : undefined,
+    ClusterArn: __expectString(output.ClusterArn),
+    ClusterId: __expectString(output.ClusterId),
+    InstanceGroupId: __expectString(output.InstanceGroupId),
   } as any;
 };
 
@@ -6928,14 +6707,14 @@ const deserializeAws_json1_1RemoveTagsOutput = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1RunJobFlowOutput = (output: any, context: __SerdeContext): RunJobFlowOutput => {
   return {
-    ClusterArn: output.ClusterArn !== undefined && output.ClusterArn !== null ? output.ClusterArn : undefined,
-    JobFlowId: output.JobFlowId !== undefined && output.JobFlowId !== null ? output.JobFlowId : undefined,
+    ClusterArn: __expectString(output.ClusterArn),
+    JobFlowId: __expectString(output.JobFlowId),
   } as any;
 };
 
 const deserializeAws_json1_1ScalingAction = (output: any, context: __SerdeContext): ScalingAction => {
   return {
-    Market: output.Market !== undefined && output.Market !== null ? output.Market : undefined,
+    Market: __expectString(output.Market),
     SimpleScalingPolicyConfiguration:
       output.SimpleScalingPolicyConfiguration !== undefined && output.SimpleScalingPolicyConfiguration !== null
         ? deserializeAws_json1_1SimpleScalingPolicyConfiguration(output.SimpleScalingPolicyConfiguration, context)
@@ -6945,8 +6724,8 @@ const deserializeAws_json1_1ScalingAction = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1ScalingConstraints = (output: any, context: __SerdeContext): ScalingConstraints => {
   return {
-    MaxCapacity: output.MaxCapacity !== undefined && output.MaxCapacity !== null ? output.MaxCapacity : undefined,
-    MinCapacity: output.MinCapacity !== undefined && output.MinCapacity !== null ? output.MinCapacity : undefined,
+    MaxCapacity: __expectNumber(output.MaxCapacity),
+    MinCapacity: __expectNumber(output.MinCapacity),
   } as any;
 };
 
@@ -6956,8 +6735,8 @@ const deserializeAws_json1_1ScalingRule = (output: any, context: __SerdeContext)
       output.Action !== undefined && output.Action !== null
         ? deserializeAws_json1_1ScalingAction(output.Action, context)
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Description: __expectString(output.Description),
+    Name: __expectString(output.Name),
     Trigger:
       output.Trigger !== undefined && output.Trigger !== null
         ? deserializeAws_json1_1ScalingTrigger(output.Trigger, context)
@@ -6994,7 +6773,7 @@ const deserializeAws_json1_1ScriptBootstrapActionConfig = (
       output.Args !== undefined && output.Args !== null
         ? deserializeAws_json1_1XmlStringList(output.Args, context)
         : undefined,
-    Path: output.Path !== undefined && output.Path !== null ? output.Path : undefined,
+    Path: __expectString(output.Path),
   } as any;
 };
 
@@ -7021,7 +6800,7 @@ const deserializeAws_json1_1SecurityConfigurationSummary = (
       output.CreationDateTime !== undefined && output.CreationDateTime !== null
         ? new Date(Math.round(output.CreationDateTime * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -7031,16 +6810,15 @@ const deserializeAws_json1_1SessionMappingDetail = (output: any, context: __Serd
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    IdentityId: output.IdentityId !== undefined && output.IdentityId !== null ? output.IdentityId : undefined,
-    IdentityName: output.IdentityName !== undefined && output.IdentityName !== null ? output.IdentityName : undefined,
-    IdentityType: output.IdentityType !== undefined && output.IdentityType !== null ? output.IdentityType : undefined,
+    IdentityId: __expectString(output.IdentityId),
+    IdentityName: __expectString(output.IdentityName),
+    IdentityType: __expectString(output.IdentityType),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    SessionPolicyArn:
-      output.SessionPolicyArn !== undefined && output.SessionPolicyArn !== null ? output.SessionPolicyArn : undefined,
-    StudioId: output.StudioId !== undefined && output.StudioId !== null ? output.StudioId : undefined,
+    SessionPolicyArn: __expectString(output.SessionPolicyArn),
+    StudioId: __expectString(output.StudioId),
   } as any;
 };
 
@@ -7050,12 +6828,11 @@ const deserializeAws_json1_1SessionMappingSummary = (output: any, context: __Ser
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    IdentityId: output.IdentityId !== undefined && output.IdentityId !== null ? output.IdentityId : undefined,
-    IdentityName: output.IdentityName !== undefined && output.IdentityName !== null ? output.IdentityName : undefined,
-    IdentityType: output.IdentityType !== undefined && output.IdentityType !== null ? output.IdentityType : undefined,
-    SessionPolicyArn:
-      output.SessionPolicyArn !== undefined && output.SessionPolicyArn !== null ? output.SessionPolicyArn : undefined,
-    StudioId: output.StudioId !== undefined && output.StudioId !== null ? output.StudioId : undefined,
+    IdentityId: __expectString(output.IdentityId),
+    IdentityName: __expectString(output.IdentityName),
+    IdentityType: __expectString(output.IdentityType),
+    SessionPolicyArn: __expectString(output.SessionPolicyArn),
+    StudioId: __expectString(output.StudioId),
   } as any;
 };
 
@@ -7075,10 +6852,7 @@ const deserializeAws_json1_1SessionMappingSummaryList = (
 
 const deserializeAws_json1_1ShrinkPolicy = (output: any, context: __SerdeContext): ShrinkPolicy => {
   return {
-    DecommissionTimeout:
-      output.DecommissionTimeout !== undefined && output.DecommissionTimeout !== null
-        ? output.DecommissionTimeout
-        : undefined,
+    DecommissionTimeout: __expectNumber(output.DecommissionTimeout),
     InstanceResizePolicy:
       output.InstanceResizePolicy !== undefined && output.InstanceResizePolicy !== null
         ? deserializeAws_json1_1InstanceResizePolicy(output.InstanceResizePolicy, context)
@@ -7091,13 +6865,9 @@ const deserializeAws_json1_1SimpleScalingPolicyConfiguration = (
   context: __SerdeContext
 ): SimpleScalingPolicyConfiguration => {
   return {
-    AdjustmentType:
-      output.AdjustmentType !== undefined && output.AdjustmentType !== null ? output.AdjustmentType : undefined,
-    CoolDown: output.CoolDown !== undefined && output.CoolDown !== null ? output.CoolDown : undefined,
-    ScalingAdjustment:
-      output.ScalingAdjustment !== undefined && output.ScalingAdjustment !== null
-        ? output.ScalingAdjustment
-        : undefined,
+    AdjustmentType: __expectString(output.AdjustmentType),
+    CoolDown: __expectNumber(output.CoolDown),
+    ScalingAdjustment: __expectNumber(output.ScalingAdjustment),
   } as any;
 };
 
@@ -7106,20 +6876,10 @@ const deserializeAws_json1_1SpotProvisioningSpecification = (
   context: __SerdeContext
 ): SpotProvisioningSpecification => {
   return {
-    AllocationStrategy:
-      output.AllocationStrategy !== undefined && output.AllocationStrategy !== null
-        ? output.AllocationStrategy
-        : undefined,
-    BlockDurationMinutes:
-      output.BlockDurationMinutes !== undefined && output.BlockDurationMinutes !== null
-        ? output.BlockDurationMinutes
-        : undefined,
-    TimeoutAction:
-      output.TimeoutAction !== undefined && output.TimeoutAction !== null ? output.TimeoutAction : undefined,
-    TimeoutDurationMinutes:
-      output.TimeoutDurationMinutes !== undefined && output.TimeoutDurationMinutes !== null
-        ? output.TimeoutDurationMinutes
-        : undefined,
+    AllocationStrategy: __expectString(output.AllocationStrategy),
+    BlockDurationMinutes: __expectNumber(output.BlockDurationMinutes),
+    TimeoutAction: __expectString(output.TimeoutAction),
+    TimeoutDurationMinutes: __expectNumber(output.TimeoutDurationMinutes),
   } as any;
 };
 
@@ -7128,23 +6888,19 @@ const deserializeAws_json1_1StartNotebookExecutionOutput = (
   context: __SerdeContext
 ): StartNotebookExecutionOutput => {
   return {
-    NotebookExecutionId:
-      output.NotebookExecutionId !== undefined && output.NotebookExecutionId !== null
-        ? output.NotebookExecutionId
-        : undefined,
+    NotebookExecutionId: __expectString(output.NotebookExecutionId),
   } as any;
 };
 
 const deserializeAws_json1_1Step = (output: any, context: __SerdeContext): Step => {
   return {
-    ActionOnFailure:
-      output.ActionOnFailure !== undefined && output.ActionOnFailure !== null ? output.ActionOnFailure : undefined,
+    ActionOnFailure: __expectString(output.ActionOnFailure),
     Config:
       output.Config !== undefined && output.Config !== null
         ? deserializeAws_json1_1HadoopStepConfig(output.Config, context)
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
     Status:
       output.Status !== undefined && output.Status !== null
         ? deserializeAws_json1_1StepStatus(output.Status, context)
@@ -7154,13 +6910,12 @@ const deserializeAws_json1_1Step = (output: any, context: __SerdeContext): Step 
 
 const deserializeAws_json1_1StepConfig = (output: any, context: __SerdeContext): StepConfig => {
   return {
-    ActionOnFailure:
-      output.ActionOnFailure !== undefined && output.ActionOnFailure !== null ? output.ActionOnFailure : undefined,
+    ActionOnFailure: __expectString(output.ActionOnFailure),
     HadoopJarStep:
       output.HadoopJarStep !== undefined && output.HadoopJarStep !== null
         ? deserializeAws_json1_1HadoopJarStepConfig(output.HadoopJarStep, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -7201,15 +6956,12 @@ const deserializeAws_json1_1StepExecutionStatusDetail = (
       output.EndDateTime !== undefined && output.EndDateTime !== null
         ? new Date(Math.round(output.EndDateTime * 1000))
         : undefined,
-    LastStateChangeReason:
-      output.LastStateChangeReason !== undefined && output.LastStateChangeReason !== null
-        ? output.LastStateChangeReason
-        : undefined,
+    LastStateChangeReason: __expectString(output.LastStateChangeReason),
     StartDateTime:
       output.StartDateTime !== undefined && output.StartDateTime !== null
         ? new Date(Math.round(output.StartDateTime * 1000))
         : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    State: __expectString(output.State),
   } as any;
 };
 
@@ -7220,14 +6972,14 @@ const deserializeAws_json1_1StepIdsList = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1StepStateChangeReason = (output: any, context: __SerdeContext): StepStateChangeReason => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7237,7 +6989,7 @@ const deserializeAws_json1_1StepStatus = (output: any, context: __SerdeContext):
       output.FailureDetails !== undefined && output.FailureDetails !== null
         ? deserializeAws_json1_1FailureDetails(output.FailureDetails, context)
         : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    State: __expectString(output.State),
     StateChangeReason:
       output.StateChangeReason !== undefined && output.StateChangeReason !== null
         ? deserializeAws_json1_1StepStateChangeReason(output.StateChangeReason, context)
@@ -7251,14 +7003,13 @@ const deserializeAws_json1_1StepStatus = (output: any, context: __SerdeContext):
 
 const deserializeAws_json1_1StepSummary = (output: any, context: __SerdeContext): StepSummary => {
   return {
-    ActionOnFailure:
-      output.ActionOnFailure !== undefined && output.ActionOnFailure !== null ? output.ActionOnFailure : undefined,
+    ActionOnFailure: __expectString(output.ActionOnFailure),
     Config:
       output.Config !== undefined && output.Config !== null
         ? deserializeAws_json1_1HadoopStepConfig(output.Config, context)
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
     Status:
       output.Status !== undefined && output.Status !== null
         ? deserializeAws_json1_1StepStatus(output.Status, context)
@@ -7301,7 +7052,7 @@ const deserializeAws_json1_1StringList = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7312,31 +7063,25 @@ const deserializeAws_json1_1StringMap = (output: any, context: __SerdeContext): 
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_json1_1Studio = (output: any, context: __SerdeContext): Studio => {
   return {
-    AuthMode: output.AuthMode !== undefined && output.AuthMode !== null ? output.AuthMode : undefined,
+    AuthMode: __expectString(output.AuthMode),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    DefaultS3Location:
-      output.DefaultS3Location !== undefined && output.DefaultS3Location !== null
-        ? output.DefaultS3Location
-        : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    EngineSecurityGroupId:
-      output.EngineSecurityGroupId !== undefined && output.EngineSecurityGroupId !== null
-        ? output.EngineSecurityGroupId
-        : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    ServiceRole: output.ServiceRole !== undefined && output.ServiceRole !== null ? output.ServiceRole : undefined,
-    StudioArn: output.StudioArn !== undefined && output.StudioArn !== null ? output.StudioArn : undefined,
-    StudioId: output.StudioId !== undefined && output.StudioId !== null ? output.StudioId : undefined,
+    DefaultS3Location: __expectString(output.DefaultS3Location),
+    Description: __expectString(output.Description),
+    EngineSecurityGroupId: __expectString(output.EngineSecurityGroupId),
+    Name: __expectString(output.Name),
+    ServiceRole: __expectString(output.ServiceRole),
+    StudioArn: __expectString(output.StudioArn),
+    StudioId: __expectString(output.StudioId),
     SubnetIds:
       output.SubnetIds !== undefined && output.SubnetIds !== null
         ? deserializeAws_json1_1SubnetIdList(output.SubnetIds, context)
@@ -7345,13 +7090,10 @@ const deserializeAws_json1_1Studio = (output: any, context: __SerdeContext): Stu
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_1TagList(output.Tags, context)
         : undefined,
-    Url: output.Url !== undefined && output.Url !== null ? output.Url : undefined,
-    UserRole: output.UserRole !== undefined && output.UserRole !== null ? output.UserRole : undefined,
-    VpcId: output.VpcId !== undefined && output.VpcId !== null ? output.VpcId : undefined,
-    WorkspaceSecurityGroupId:
-      output.WorkspaceSecurityGroupId !== undefined && output.WorkspaceSecurityGroupId !== null
-        ? output.WorkspaceSecurityGroupId
-        : undefined,
+    Url: __expectString(output.Url),
+    UserRole: __expectString(output.UserRole),
+    VpcId: __expectString(output.VpcId),
+    WorkspaceSecurityGroupId: __expectString(output.WorkspaceSecurityGroupId),
   } as any;
 };
 
@@ -7361,11 +7103,11 @@ const deserializeAws_json1_1StudioSummary = (output: any, context: __SerdeContex
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    StudioId: output.StudioId !== undefined && output.StudioId !== null ? output.StudioId : undefined,
-    Url: output.Url !== undefined && output.Url !== null ? output.Url : undefined,
-    VpcId: output.VpcId !== undefined && output.VpcId !== null ? output.VpcId : undefined,
+    Description: __expectString(output.Description),
+    Name: __expectString(output.Name),
+    StudioId: __expectString(output.StudioId),
+    Url: __expectString(output.Url),
+    VpcId: __expectString(output.VpcId),
   } as any;
 };
 
@@ -7387,7 +7129,7 @@ const deserializeAws_json1_1SubnetIdList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7398,14 +7140,14 @@ const deserializeAws_json1_1SupportedProductsList = (output: any, context: __Ser
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -7422,9 +7164,9 @@ const deserializeAws_json1_1TagList = (output: any, context: __SerdeContext): Ta
 
 const deserializeAws_json1_1VolumeSpecification = (output: any, context: __SerdeContext): VolumeSpecification => {
   return {
-    Iops: output.Iops !== undefined && output.Iops !== null ? output.Iops : undefined,
-    SizeInGB: output.SizeInGB !== undefined && output.SizeInGB !== null ? output.SizeInGB : undefined,
-    VolumeType: output.VolumeType !== undefined && output.VolumeType !== null ? output.VolumeType : undefined,
+    Iops: __expectNumber(output.Iops),
+    SizeInGB: __expectNumber(output.SizeInGB),
+    VolumeType: __expectString(output.VolumeType),
   } as any;
 };
 
@@ -7435,7 +7177,7 @@ const deserializeAws_json1_1XmlStringList = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7446,7 +7188,7 @@ const deserializeAws_json1_1XmlStringMaxLen256List = (output: any, context: __Se
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 

--- a/clients/client-eventbridge/protocols/Aws_json1_1.ts
+++ b/clients/client-eventbridge/protocols/Aws_json1_1.ts
@@ -259,7 +259,12 @@ import {
   UpdateConnectionResponse,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -5935,34 +5940,21 @@ const serializeAws_json1_1UpdateConnectionRequest = (input: UpdateConnectionRequ
 
 const deserializeAws_json1_1ApiDestination = (output: any, context: __SerdeContext): ApiDestination => {
   return {
-    ApiDestinationArn:
-      output.ApiDestinationArn !== undefined && output.ApiDestinationArn !== null
-        ? output.ApiDestinationArn
-        : undefined,
-    ApiDestinationState:
-      output.ApiDestinationState !== undefined && output.ApiDestinationState !== null
-        ? output.ApiDestinationState
-        : undefined,
-    ConnectionArn:
-      output.ConnectionArn !== undefined && output.ConnectionArn !== null ? output.ConnectionArn : undefined,
+    ApiDestinationArn: __expectString(output.ApiDestinationArn),
+    ApiDestinationState: __expectString(output.ApiDestinationState),
+    ConnectionArn: __expectString(output.ConnectionArn),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    HttpMethod: output.HttpMethod !== undefined && output.HttpMethod !== null ? output.HttpMethod : undefined,
-    InvocationEndpoint:
-      output.InvocationEndpoint !== undefined && output.InvocationEndpoint !== null
-        ? output.InvocationEndpoint
-        : undefined,
-    InvocationRateLimitPerSecond:
-      output.InvocationRateLimitPerSecond !== undefined && output.InvocationRateLimitPerSecond !== null
-        ? output.InvocationRateLimitPerSecond
-        : undefined,
+    HttpMethod: __expectString(output.HttpMethod),
+    InvocationEndpoint: __expectString(output.InvocationEndpoint),
+    InvocationRateLimitPerSecond: __expectNumber(output.InvocationRateLimitPerSecond),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -5979,19 +5971,17 @@ const deserializeAws_json1_1ApiDestinationResponseList = (output: any, context: 
 
 const deserializeAws_json1_1Archive = (output: any, context: __SerdeContext): Archive => {
   return {
-    ArchiveName: output.ArchiveName !== undefined && output.ArchiveName !== null ? output.ArchiveName : undefined,
+    ArchiveName: __expectString(output.ArchiveName),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    EventCount: output.EventCount !== undefined && output.EventCount !== null ? output.EventCount : undefined,
-    EventSourceArn:
-      output.EventSourceArn !== undefined && output.EventSourceArn !== null ? output.EventSourceArn : undefined,
-    RetentionDays:
-      output.RetentionDays !== undefined && output.RetentionDays !== null ? output.RetentionDays : undefined,
-    SizeBytes: output.SizeBytes !== undefined && output.SizeBytes !== null ? output.SizeBytes : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    StateReason: output.StateReason !== undefined && output.StateReason !== null ? output.StateReason : undefined,
+    EventCount: __expectNumber(output.EventCount),
+    EventSourceArn: __expectString(output.EventSourceArn),
+    RetentionDays: __expectNumber(output.RetentionDays),
+    SizeBytes: __expectNumber(output.SizeBytes),
+    State: __expectString(output.State),
+    StateReason: __expectString(output.StateReason),
   } as any;
 };
 
@@ -6008,8 +5998,7 @@ const deserializeAws_json1_1ArchiveResponseList = (output: any, context: __Serde
 
 const deserializeAws_json1_1AwsVpcConfiguration = (output: any, context: __SerdeContext): AwsVpcConfiguration => {
   return {
-    AssignPublicIp:
-      output.AssignPublicIp !== undefined && output.AssignPublicIp !== null ? output.AssignPublicIp : undefined,
+    AssignPublicIp: __expectString(output.AssignPublicIp),
     SecurityGroups:
       output.SecurityGroups !== undefined && output.SecurityGroups !== null
         ? deserializeAws_json1_1StringList(output.SecurityGroups, context)
@@ -6023,7 +6012,7 @@ const deserializeAws_json1_1AwsVpcConfiguration = (output: any, context: __Serde
 
 const deserializeAws_json1_1BatchArrayProperties = (output: any, context: __SerdeContext): BatchArrayProperties => {
   return {
-    Size: output.Size !== undefined && output.Size !== null ? output.Size : undefined,
+    Size: __expectNumber(output.Size),
   } as any;
 };
 
@@ -6033,9 +6022,8 @@ const deserializeAws_json1_1BatchParameters = (output: any, context: __SerdeCont
       output.ArrayProperties !== undefined && output.ArrayProperties !== null
         ? deserializeAws_json1_1BatchArrayProperties(output.ArrayProperties, context)
         : undefined,
-    JobDefinition:
-      output.JobDefinition !== undefined && output.JobDefinition !== null ? output.JobDefinition : undefined,
-    JobName: output.JobName !== undefined && output.JobName !== null ? output.JobName : undefined,
+    JobDefinition: __expectString(output.JobDefinition),
+    JobName: __expectString(output.JobName),
     RetryStrategy:
       output.RetryStrategy !== undefined && output.RetryStrategy !== null
         ? deserializeAws_json1_1BatchRetryStrategy(output.RetryStrategy, context)
@@ -6045,15 +6033,15 @@ const deserializeAws_json1_1BatchParameters = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_1BatchRetryStrategy = (output: any, context: __SerdeContext): BatchRetryStrategy => {
   return {
-    Attempts: output.Attempts !== undefined && output.Attempts !== null ? output.Attempts : undefined,
+    Attempts: __expectNumber(output.Attempts),
   } as any;
 };
 
 const deserializeAws_json1_1CancelReplayResponse = (output: any, context: __SerdeContext): CancelReplayResponse => {
   return {
-    ReplayArn: output.ReplayArn !== undefined && output.ReplayArn !== null ? output.ReplayArn : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    StateReason: output.StateReason !== undefined && output.StateReason !== null ? output.StateReason : undefined,
+    ReplayArn: __expectString(output.ReplayArn),
+    State: __expectString(output.State),
+    StateReason: __expectString(output.StateReason),
   } as any;
 };
 
@@ -6062,20 +6050,15 @@ const deserializeAws_json1_1ConcurrentModificationException = (
   context: __SerdeContext
 ): ConcurrentModificationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1Connection = (output: any, context: __SerdeContext): Connection => {
   return {
-    AuthorizationType:
-      output.AuthorizationType !== undefined && output.AuthorizationType !== null
-        ? output.AuthorizationType
-        : undefined,
-    ConnectionArn:
-      output.ConnectionArn !== undefined && output.ConnectionArn !== null ? output.ConnectionArn : undefined,
-    ConnectionState:
-      output.ConnectionState !== undefined && output.ConnectionState !== null ? output.ConnectionState : undefined,
+    AuthorizationType: __expectString(output.AuthorizationType),
+    ConnectionArn: __expectString(output.ConnectionArn),
+    ConnectionState: __expectString(output.ConnectionState),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -6088,8 +6071,8 @@ const deserializeAws_json1_1Connection = (output: any, context: __SerdeContext):
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    StateReason: output.StateReason !== undefined && output.StateReason !== null ? output.StateReason : undefined,
+    Name: __expectString(output.Name),
+    StateReason: __expectString(output.StateReason),
   } as any;
 };
 
@@ -6098,7 +6081,7 @@ const deserializeAws_json1_1ConnectionApiKeyAuthResponseParameters = (
   context: __SerdeContext
 ): ConnectionApiKeyAuthResponseParameters => {
   return {
-    ApiKeyName: output.ApiKeyName !== undefined && output.ApiKeyName !== null ? output.ApiKeyName : undefined,
+    ApiKeyName: __expectString(output.ApiKeyName),
   } as any;
 };
 
@@ -6131,7 +6114,7 @@ const deserializeAws_json1_1ConnectionBasicAuthResponseParameters = (
   context: __SerdeContext
 ): ConnectionBasicAuthResponseParameters => {
   return {
-    Username: output.Username !== undefined && output.Username !== null ? output.Username : undefined,
+    Username: __expectString(output.Username),
   } as any;
 };
 
@@ -6140,10 +6123,9 @@ const deserializeAws_json1_1ConnectionBodyParameter = (
   context: __SerdeContext
 ): ConnectionBodyParameter => {
   return {
-    IsValueSecret:
-      output.IsValueSecret !== undefined && output.IsValueSecret !== null ? output.IsValueSecret : undefined,
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    IsValueSecret: __expectBoolean(output.IsValueSecret),
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -6166,10 +6148,9 @@ const deserializeAws_json1_1ConnectionHeaderParameter = (
   context: __SerdeContext
 ): ConnectionHeaderParameter => {
   return {
-    IsValueSecret:
-      output.IsValueSecret !== undefined && output.IsValueSecret !== null ? output.IsValueSecret : undefined,
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    IsValueSecret: __expectBoolean(output.IsValueSecret),
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -6212,7 +6193,7 @@ const deserializeAws_json1_1ConnectionOAuthClientResponseParameters = (
   context: __SerdeContext
 ): ConnectionOAuthClientResponseParameters => {
   return {
-    ClientID: output.ClientID !== undefined && output.ClientID !== null ? output.ClientID : undefined,
+    ClientID: __expectString(output.ClientID),
   } as any;
 };
 
@@ -6221,15 +6202,12 @@ const deserializeAws_json1_1ConnectionOAuthResponseParameters = (
   context: __SerdeContext
 ): ConnectionOAuthResponseParameters => {
   return {
-    AuthorizationEndpoint:
-      output.AuthorizationEndpoint !== undefined && output.AuthorizationEndpoint !== null
-        ? output.AuthorizationEndpoint
-        : undefined,
+    AuthorizationEndpoint: __expectString(output.AuthorizationEndpoint),
     ClientParameters:
       output.ClientParameters !== undefined && output.ClientParameters !== null
         ? deserializeAws_json1_1ConnectionOAuthClientResponseParameters(output.ClientParameters, context)
         : undefined,
-    HttpMethod: output.HttpMethod !== undefined && output.HttpMethod !== null ? output.HttpMethod : undefined,
+    HttpMethod: __expectString(output.HttpMethod),
     OAuthHttpParameters:
       output.OAuthHttpParameters !== undefined && output.OAuthHttpParameters !== null
         ? deserializeAws_json1_1ConnectionHttpParameters(output.OAuthHttpParameters, context)
@@ -6242,10 +6220,9 @@ const deserializeAws_json1_1ConnectionQueryStringParameter = (
   context: __SerdeContext
 ): ConnectionQueryStringParameter => {
   return {
-    IsValueSecret:
-      output.IsValueSecret !== undefined && output.IsValueSecret !== null ? output.IsValueSecret : undefined,
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    IsValueSecret: __expectBoolean(output.IsValueSecret),
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -6279,14 +6256,8 @@ const deserializeAws_json1_1CreateApiDestinationResponse = (
   context: __SerdeContext
 ): CreateApiDestinationResponse => {
   return {
-    ApiDestinationArn:
-      output.ApiDestinationArn !== undefined && output.ApiDestinationArn !== null
-        ? output.ApiDestinationArn
-        : undefined,
-    ApiDestinationState:
-      output.ApiDestinationState !== undefined && output.ApiDestinationState !== null
-        ? output.ApiDestinationState
-        : undefined,
+    ApiDestinationArn: __expectString(output.ApiDestinationArn),
+    ApiDestinationState: __expectString(output.ApiDestinationState),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -6300,13 +6271,13 @@ const deserializeAws_json1_1CreateApiDestinationResponse = (
 
 const deserializeAws_json1_1CreateArchiveResponse = (output: any, context: __SerdeContext): CreateArchiveResponse => {
   return {
-    ArchiveArn: output.ArchiveArn !== undefined && output.ArchiveArn !== null ? output.ArchiveArn : undefined,
+    ArchiveArn: __expectString(output.ArchiveArn),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    StateReason: output.StateReason !== undefined && output.StateReason !== null ? output.StateReason : undefined,
+    State: __expectString(output.State),
+    StateReason: __expectString(output.StateReason),
   } as any;
 };
 
@@ -6315,10 +6286,8 @@ const deserializeAws_json1_1CreateConnectionResponse = (
   context: __SerdeContext
 ): CreateConnectionResponse => {
   return {
-    ConnectionArn:
-      output.ConnectionArn !== undefined && output.ConnectionArn !== null ? output.ConnectionArn : undefined,
-    ConnectionState:
-      output.ConnectionState !== undefined && output.ConnectionState !== null ? output.ConnectionState : undefined,
+    ConnectionArn: __expectString(output.ConnectionArn),
+    ConnectionState: __expectString(output.ConnectionState),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -6332,7 +6301,7 @@ const deserializeAws_json1_1CreateConnectionResponse = (
 
 const deserializeAws_json1_1CreateEventBusResponse = (output: any, context: __SerdeContext): CreateEventBusResponse => {
   return {
-    EventBusArn: output.EventBusArn !== undefined && output.EventBusArn !== null ? output.EventBusArn : undefined,
+    EventBusArn: __expectString(output.EventBusArn),
   } as any;
 };
 
@@ -6341,14 +6310,13 @@ const deserializeAws_json1_1CreatePartnerEventSourceResponse = (
   context: __SerdeContext
 ): CreatePartnerEventSourceResponse => {
   return {
-    EventSourceArn:
-      output.EventSourceArn !== undefined && output.EventSourceArn !== null ? output.EventSourceArn : undefined,
+    EventSourceArn: __expectString(output.EventSourceArn),
   } as any;
 };
 
 const deserializeAws_json1_1DeadLetterConfig = (output: any, context: __SerdeContext): DeadLetterConfig => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
   } as any;
 };
 
@@ -6357,10 +6325,8 @@ const deserializeAws_json1_1DeauthorizeConnectionResponse = (
   context: __SerdeContext
 ): DeauthorizeConnectionResponse => {
   return {
-    ConnectionArn:
-      output.ConnectionArn !== undefined && output.ConnectionArn !== null ? output.ConnectionArn : undefined,
-    ConnectionState:
-      output.ConnectionState !== undefined && output.ConnectionState !== null ? output.ConnectionState : undefined,
+    ConnectionArn: __expectString(output.ConnectionArn),
+    ConnectionState: __expectString(output.ConnectionState),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -6392,10 +6358,8 @@ const deserializeAws_json1_1DeleteConnectionResponse = (
   context: __SerdeContext
 ): DeleteConnectionResponse => {
   return {
-    ConnectionArn:
-      output.ConnectionArn !== undefined && output.ConnectionArn !== null ? output.ConnectionArn : undefined,
-    ConnectionState:
-      output.ConnectionState !== undefined && output.ConnectionState !== null ? output.ConnectionState : undefined,
+    ConnectionArn: __expectString(output.ConnectionArn),
+    ConnectionState: __expectString(output.ConnectionState),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -6416,35 +6380,22 @@ const deserializeAws_json1_1DescribeApiDestinationResponse = (
   context: __SerdeContext
 ): DescribeApiDestinationResponse => {
   return {
-    ApiDestinationArn:
-      output.ApiDestinationArn !== undefined && output.ApiDestinationArn !== null
-        ? output.ApiDestinationArn
-        : undefined,
-    ApiDestinationState:
-      output.ApiDestinationState !== undefined && output.ApiDestinationState !== null
-        ? output.ApiDestinationState
-        : undefined,
-    ConnectionArn:
-      output.ConnectionArn !== undefined && output.ConnectionArn !== null ? output.ConnectionArn : undefined,
+    ApiDestinationArn: __expectString(output.ApiDestinationArn),
+    ApiDestinationState: __expectString(output.ApiDestinationState),
+    ConnectionArn: __expectString(output.ConnectionArn),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    HttpMethod: output.HttpMethod !== undefined && output.HttpMethod !== null ? output.HttpMethod : undefined,
-    InvocationEndpoint:
-      output.InvocationEndpoint !== undefined && output.InvocationEndpoint !== null
-        ? output.InvocationEndpoint
-        : undefined,
-    InvocationRateLimitPerSecond:
-      output.InvocationRateLimitPerSecond !== undefined && output.InvocationRateLimitPerSecond !== null
-        ? output.InvocationRateLimitPerSecond
-        : undefined,
+    Description: __expectString(output.Description),
+    HttpMethod: __expectString(output.HttpMethod),
+    InvocationEndpoint: __expectString(output.InvocationEndpoint),
+    InvocationRateLimitPerSecond: __expectNumber(output.InvocationRateLimitPerSecond),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -6453,22 +6404,20 @@ const deserializeAws_json1_1DescribeArchiveResponse = (
   context: __SerdeContext
 ): DescribeArchiveResponse => {
   return {
-    ArchiveArn: output.ArchiveArn !== undefined && output.ArchiveArn !== null ? output.ArchiveArn : undefined,
-    ArchiveName: output.ArchiveName !== undefined && output.ArchiveName !== null ? output.ArchiveName : undefined,
+    ArchiveArn: __expectString(output.ArchiveArn),
+    ArchiveName: __expectString(output.ArchiveName),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    EventCount: output.EventCount !== undefined && output.EventCount !== null ? output.EventCount : undefined,
-    EventPattern: output.EventPattern !== undefined && output.EventPattern !== null ? output.EventPattern : undefined,
-    EventSourceArn:
-      output.EventSourceArn !== undefined && output.EventSourceArn !== null ? output.EventSourceArn : undefined,
-    RetentionDays:
-      output.RetentionDays !== undefined && output.RetentionDays !== null ? output.RetentionDays : undefined,
-    SizeBytes: output.SizeBytes !== undefined && output.SizeBytes !== null ? output.SizeBytes : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    StateReason: output.StateReason !== undefined && output.StateReason !== null ? output.StateReason : undefined,
+    Description: __expectString(output.Description),
+    EventCount: __expectNumber(output.EventCount),
+    EventPattern: __expectString(output.EventPattern),
+    EventSourceArn: __expectString(output.EventSourceArn),
+    RetentionDays: __expectNumber(output.RetentionDays),
+    SizeBytes: __expectNumber(output.SizeBytes),
+    State: __expectString(output.State),
+    StateReason: __expectString(output.StateReason),
   } as any;
 };
 
@@ -6481,19 +6430,14 @@ const deserializeAws_json1_1DescribeConnectionResponse = (
       output.AuthParameters !== undefined && output.AuthParameters !== null
         ? deserializeAws_json1_1ConnectionAuthResponseParameters(output.AuthParameters, context)
         : undefined,
-    AuthorizationType:
-      output.AuthorizationType !== undefined && output.AuthorizationType !== null
-        ? output.AuthorizationType
-        : undefined,
-    ConnectionArn:
-      output.ConnectionArn !== undefined && output.ConnectionArn !== null ? output.ConnectionArn : undefined,
-    ConnectionState:
-      output.ConnectionState !== undefined && output.ConnectionState !== null ? output.ConnectionState : undefined,
+    AuthorizationType: __expectString(output.AuthorizationType),
+    ConnectionArn: __expectString(output.ConnectionArn),
+    ConnectionState: __expectString(output.ConnectionState),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     LastAuthorizedTime:
       output.LastAuthorizedTime !== undefined && output.LastAuthorizedTime !== null
         ? new Date(Math.round(output.LastAuthorizedTime * 1000))
@@ -6502,9 +6446,9 @@ const deserializeAws_json1_1DescribeConnectionResponse = (
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    SecretArn: output.SecretArn !== undefined && output.SecretArn !== null ? output.SecretArn : undefined,
-    StateReason: output.StateReason !== undefined && output.StateReason !== null ? output.StateReason : undefined,
+    Name: __expectString(output.Name),
+    SecretArn: __expectString(output.SecretArn),
+    StateReason: __expectString(output.StateReason),
   } as any;
 };
 
@@ -6513,9 +6457,9 @@ const deserializeAws_json1_1DescribeEventBusResponse = (
   context: __SerdeContext
 ): DescribeEventBusResponse => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Policy: output.Policy !== undefined && output.Policy !== null ? output.Policy : undefined,
+    Arn: __expectString(output.Arn),
+    Name: __expectString(output.Name),
+    Policy: __expectString(output.Policy),
   } as any;
 };
 
@@ -6524,8 +6468,8 @@ const deserializeAws_json1_1DescribeEventSourceResponse = (
   context: __SerdeContext
 ): DescribeEventSourceResponse => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    CreatedBy: output.CreatedBy !== undefined && output.CreatedBy !== null ? output.CreatedBy : undefined,
+    Arn: __expectString(output.Arn),
+    CreatedBy: __expectString(output.CreatedBy),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -6534,8 +6478,8 @@ const deserializeAws_json1_1DescribeEventSourceResponse = (
       output.ExpirationTime !== undefined && output.ExpirationTime !== null
         ? new Date(Math.round(output.ExpirationTime * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    Name: __expectString(output.Name),
+    State: __expectString(output.State),
   } as any;
 };
 
@@ -6544,14 +6488,14 @@ const deserializeAws_json1_1DescribePartnerEventSourceResponse = (
   context: __SerdeContext
 ): DescribePartnerEventSourceResponse => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Arn: __expectString(output.Arn),
+    Name: __expectString(output.Name),
   } as any;
 };
 
 const deserializeAws_json1_1DescribeReplayResponse = (output: any, context: __SerdeContext): DescribeReplayResponse => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     Destination:
       output.Destination !== undefined && output.Destination !== null
         ? deserializeAws_json1_1ReplayDestination(output.Destination, context)
@@ -6564,68 +6508,60 @@ const deserializeAws_json1_1DescribeReplayResponse = (output: any, context: __Se
       output.EventLastReplayedTime !== undefined && output.EventLastReplayedTime !== null
         ? new Date(Math.round(output.EventLastReplayedTime * 1000))
         : undefined,
-    EventSourceArn:
-      output.EventSourceArn !== undefined && output.EventSourceArn !== null ? output.EventSourceArn : undefined,
+    EventSourceArn: __expectString(output.EventSourceArn),
     EventStartTime:
       output.EventStartTime !== undefined && output.EventStartTime !== null
         ? new Date(Math.round(output.EventStartTime * 1000))
         : undefined,
-    ReplayArn: output.ReplayArn !== undefined && output.ReplayArn !== null ? output.ReplayArn : undefined,
+    ReplayArn: __expectString(output.ReplayArn),
     ReplayEndTime:
       output.ReplayEndTime !== undefined && output.ReplayEndTime !== null
         ? new Date(Math.round(output.ReplayEndTime * 1000))
         : undefined,
-    ReplayName: output.ReplayName !== undefined && output.ReplayName !== null ? output.ReplayName : undefined,
+    ReplayName: __expectString(output.ReplayName),
     ReplayStartTime:
       output.ReplayStartTime !== undefined && output.ReplayStartTime !== null
         ? new Date(Math.round(output.ReplayStartTime * 1000))
         : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    StateReason: output.StateReason !== undefined && output.StateReason !== null ? output.StateReason : undefined,
+    State: __expectString(output.State),
+    StateReason: __expectString(output.StateReason),
   } as any;
 };
 
 const deserializeAws_json1_1DescribeRuleResponse = (output: any, context: __SerdeContext): DescribeRuleResponse => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    CreatedBy: output.CreatedBy !== undefined && output.CreatedBy !== null ? output.CreatedBy : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    EventBusName: output.EventBusName !== undefined && output.EventBusName !== null ? output.EventBusName : undefined,
-    EventPattern: output.EventPattern !== undefined && output.EventPattern !== null ? output.EventPattern : undefined,
-    ManagedBy: output.ManagedBy !== undefined && output.ManagedBy !== null ? output.ManagedBy : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
-    ScheduleExpression:
-      output.ScheduleExpression !== undefined && output.ScheduleExpression !== null
-        ? output.ScheduleExpression
-        : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    Arn: __expectString(output.Arn),
+    CreatedBy: __expectString(output.CreatedBy),
+    Description: __expectString(output.Description),
+    EventBusName: __expectString(output.EventBusName),
+    EventPattern: __expectString(output.EventPattern),
+    ManagedBy: __expectString(output.ManagedBy),
+    Name: __expectString(output.Name),
+    RoleArn: __expectString(output.RoleArn),
+    ScheduleExpression: __expectString(output.ScheduleExpression),
+    State: __expectString(output.State),
   } as any;
 };
 
 const deserializeAws_json1_1EcsParameters = (output: any, context: __SerdeContext): EcsParameters => {
   return {
-    Group: output.Group !== undefined && output.Group !== null ? output.Group : undefined,
-    LaunchType: output.LaunchType !== undefined && output.LaunchType !== null ? output.LaunchType : undefined,
+    Group: __expectString(output.Group),
+    LaunchType: __expectString(output.LaunchType),
     NetworkConfiguration:
       output.NetworkConfiguration !== undefined && output.NetworkConfiguration !== null
         ? deserializeAws_json1_1NetworkConfiguration(output.NetworkConfiguration, context)
         : undefined,
-    PlatformVersion:
-      output.PlatformVersion !== undefined && output.PlatformVersion !== null ? output.PlatformVersion : undefined,
-    TaskCount: output.TaskCount !== undefined && output.TaskCount !== null ? output.TaskCount : undefined,
-    TaskDefinitionArn:
-      output.TaskDefinitionArn !== undefined && output.TaskDefinitionArn !== null
-        ? output.TaskDefinitionArn
-        : undefined,
+    PlatformVersion: __expectString(output.PlatformVersion),
+    TaskCount: __expectNumber(output.TaskCount),
+    TaskDefinitionArn: __expectString(output.TaskDefinitionArn),
   } as any;
 };
 
 const deserializeAws_json1_1EventBus = (output: any, context: __SerdeContext): EventBus => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Policy: output.Policy !== undefined && output.Policy !== null ? output.Policy : undefined,
+    Arn: __expectString(output.Arn),
+    Name: __expectString(output.Name),
+    Policy: __expectString(output.Policy),
   } as any;
 };
 
@@ -6642,8 +6578,8 @@ const deserializeAws_json1_1EventBusList = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_1EventSource = (output: any, context: __SerdeContext): EventSource => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    CreatedBy: output.CreatedBy !== undefined && output.CreatedBy !== null ? output.CreatedBy : undefined,
+    Arn: __expectString(output.Arn),
+    CreatedBy: __expectString(output.CreatedBy),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -6652,8 +6588,8 @@ const deserializeAws_json1_1EventSource = (output: any, context: __SerdeContext)
       output.ExpirationTime !== undefined && output.ExpirationTime !== null
         ? new Date(Math.round(output.ExpirationTime * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    Name: __expectString(output.Name),
+    State: __expectString(output.State),
   } as any;
 };
 
@@ -6675,7 +6611,7 @@ const deserializeAws_json1_1HeaderParametersMap = (output: any, context: __Serde
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -6699,7 +6635,7 @@ const deserializeAws_json1_1HttpParameters = (output: any, context: __SerdeConte
 
 const deserializeAws_json1_1IllegalStatusException = (output: any, context: __SerdeContext): IllegalStatusException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6709,14 +6645,13 @@ const deserializeAws_json1_1InputTransformer = (output: any, context: __SerdeCon
       output.InputPathsMap !== undefined && output.InputPathsMap !== null
         ? deserializeAws_json1_1TransformerPaths(output.InputPathsMap, context)
         : undefined,
-    InputTemplate:
-      output.InputTemplate !== undefined && output.InputTemplate !== null ? output.InputTemplate : undefined,
+    InputTemplate: __expectString(output.InputTemplate),
   } as any;
 };
 
 const deserializeAws_json1_1InternalException = (output: any, context: __SerdeContext): InternalException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6725,26 +6660,25 @@ const deserializeAws_json1_1InvalidEventPatternException = (
   context: __SerdeContext
 ): InvalidEventPatternException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidStateException = (output: any, context: __SerdeContext): InvalidStateException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1KinesisParameters = (output: any, context: __SerdeContext): KinesisParameters => {
   return {
-    PartitionKeyPath:
-      output.PartitionKeyPath !== undefined && output.PartitionKeyPath !== null ? output.PartitionKeyPath : undefined,
+    PartitionKeyPath: __expectString(output.PartitionKeyPath),
   } as any;
 };
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6757,7 +6691,7 @@ const deserializeAws_json1_1ListApiDestinationsResponse = (
       output.ApiDestinations !== undefined && output.ApiDestinations !== null
         ? deserializeAws_json1_1ApiDestinationResponseList(output.ApiDestinations, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -6767,7 +6701,7 @@ const deserializeAws_json1_1ListArchivesResponse = (output: any, context: __Serd
       output.Archives !== undefined && output.Archives !== null
         ? deserializeAws_json1_1ArchiveResponseList(output.Archives, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -6780,7 +6714,7 @@ const deserializeAws_json1_1ListConnectionsResponse = (
       output.Connections !== undefined && output.Connections !== null
         ? deserializeAws_json1_1ConnectionResponseList(output.Connections, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -6790,7 +6724,7 @@ const deserializeAws_json1_1ListEventBusesResponse = (output: any, context: __Se
       output.EventBuses !== undefined && output.EventBuses !== null
         ? deserializeAws_json1_1EventBusList(output.EventBuses, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -6803,7 +6737,7 @@ const deserializeAws_json1_1ListEventSourcesResponse = (
       output.EventSources !== undefined && output.EventSources !== null
         ? deserializeAws_json1_1EventSourceList(output.EventSources, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -6812,7 +6746,7 @@ const deserializeAws_json1_1ListPartnerEventSourceAccountsResponse = (
   context: __SerdeContext
 ): ListPartnerEventSourceAccountsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     PartnerEventSourceAccounts:
       output.PartnerEventSourceAccounts !== undefined && output.PartnerEventSourceAccounts !== null
         ? deserializeAws_json1_1PartnerEventSourceAccountList(output.PartnerEventSourceAccounts, context)
@@ -6825,7 +6759,7 @@ const deserializeAws_json1_1ListPartnerEventSourcesResponse = (
   context: __SerdeContext
 ): ListPartnerEventSourcesResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     PartnerEventSources:
       output.PartnerEventSources !== undefined && output.PartnerEventSources !== null
         ? deserializeAws_json1_1PartnerEventSourceList(output.PartnerEventSources, context)
@@ -6835,7 +6769,7 @@ const deserializeAws_json1_1ListPartnerEventSourcesResponse = (
 
 const deserializeAws_json1_1ListReplaysResponse = (output: any, context: __SerdeContext): ListReplaysResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Replays:
       output.Replays !== undefined && output.Replays !== null
         ? deserializeAws_json1_1ReplayList(output.Replays, context)
@@ -6848,7 +6782,7 @@ const deserializeAws_json1_1ListRuleNamesByTargetResponse = (
   context: __SerdeContext
 ): ListRuleNamesByTargetResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     RuleNames:
       output.RuleNames !== undefined && output.RuleNames !== null
         ? deserializeAws_json1_1RuleNameList(output.RuleNames, context)
@@ -6858,7 +6792,7 @@ const deserializeAws_json1_1ListRuleNamesByTargetResponse = (
 
 const deserializeAws_json1_1ListRulesResponse = (output: any, context: __SerdeContext): ListRulesResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Rules:
       output.Rules !== undefined && output.Rules !== null
         ? deserializeAws_json1_1RuleResponseList(output.Rules, context)
@@ -6883,7 +6817,7 @@ const deserializeAws_json1_1ListTargetsByRuleResponse = (
   context: __SerdeContext
 ): ListTargetsByRuleResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Targets:
       output.Targets !== undefined && output.Targets !== null
         ? deserializeAws_json1_1TargetList(output.Targets, context)
@@ -6893,7 +6827,7 @@ const deserializeAws_json1_1ListTargetsByRuleResponse = (
 
 const deserializeAws_json1_1ManagedRuleException = (output: any, context: __SerdeContext): ManagedRuleException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6911,14 +6845,14 @@ const deserializeAws_json1_1OperationDisabledException = (
   context: __SerdeContext
 ): OperationDisabledException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1PartnerEventSource = (output: any, context: __SerdeContext): PartnerEventSource => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Arn: __expectString(output.Arn),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -6927,7 +6861,7 @@ const deserializeAws_json1_1PartnerEventSourceAccount = (
   context: __SerdeContext
 ): PartnerEventSourceAccount => {
   return {
-    Account: output.Account !== undefined && output.Account !== null ? output.Account : undefined,
+    Account: __expectString(output.Account),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -6936,7 +6870,7 @@ const deserializeAws_json1_1PartnerEventSourceAccount = (
       output.ExpirationTime !== undefined && output.ExpirationTime !== null
         ? new Date(Math.round(output.ExpirationTime * 1000))
         : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    State: __expectString(output.State),
   } as any;
 };
 
@@ -6972,7 +6906,7 @@ const deserializeAws_json1_1PathParameterList = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6981,7 +6915,7 @@ const deserializeAws_json1_1PolicyLengthExceededException = (
   context: __SerdeContext
 ): PolicyLengthExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6991,16 +6925,15 @@ const deserializeAws_json1_1PutEventsResponse = (output: any, context: __SerdeCo
       output.Entries !== undefined && output.Entries !== null
         ? deserializeAws_json1_1PutEventsResultEntryList(output.Entries, context)
         : undefined,
-    FailedEntryCount:
-      output.FailedEntryCount !== undefined && output.FailedEntryCount !== null ? output.FailedEntryCount : undefined,
+    FailedEntryCount: __expectNumber(output.FailedEntryCount),
   } as any;
 };
 
 const deserializeAws_json1_1PutEventsResultEntry = (output: any, context: __SerdeContext): PutEventsResultEntry => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    EventId: output.EventId !== undefined && output.EventId !== null ? output.EventId : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
+    EventId: __expectString(output.EventId),
   } as any;
 };
 
@@ -7027,8 +6960,7 @@ const deserializeAws_json1_1PutPartnerEventsResponse = (
       output.Entries !== undefined && output.Entries !== null
         ? deserializeAws_json1_1PutPartnerEventsResultEntryList(output.Entries, context)
         : undefined,
-    FailedEntryCount:
-      output.FailedEntryCount !== undefined && output.FailedEntryCount !== null ? output.FailedEntryCount : undefined,
+    FailedEntryCount: __expectNumber(output.FailedEntryCount),
   } as any;
 };
 
@@ -7037,9 +6969,9 @@ const deserializeAws_json1_1PutPartnerEventsResultEntry = (
   context: __SerdeContext
 ): PutPartnerEventsResultEntry => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    EventId: output.EventId !== undefined && output.EventId !== null ? output.EventId : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
+    EventId: __expectString(output.EventId),
   } as any;
 };
 
@@ -7059,7 +6991,7 @@ const deserializeAws_json1_1PutPartnerEventsResultEntryList = (
 
 const deserializeAws_json1_1PutRuleResponse = (output: any, context: __SerdeContext): PutRuleResponse => {
   return {
-    RuleArn: output.RuleArn !== undefined && output.RuleArn !== null ? output.RuleArn : undefined,
+    RuleArn: __expectString(output.RuleArn),
   } as any;
 };
 
@@ -7069,16 +7001,15 @@ const deserializeAws_json1_1PutTargetsResponse = (output: any, context: __SerdeC
       output.FailedEntries !== undefined && output.FailedEntries !== null
         ? deserializeAws_json1_1PutTargetsResultEntryList(output.FailedEntries, context)
         : undefined,
-    FailedEntryCount:
-      output.FailedEntryCount !== undefined && output.FailedEntryCount !== null ? output.FailedEntryCount : undefined,
+    FailedEntryCount: __expectNumber(output.FailedEntryCount),
   } as any;
 };
 
 const deserializeAws_json1_1PutTargetsResultEntry = (output: any, context: __SerdeContext): PutTargetsResultEntry => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    TargetId: output.TargetId !== undefined && output.TargetId !== null ? output.TargetId : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
+    TargetId: __expectString(output.TargetId),
   } as any;
 };
 
@@ -7106,21 +7037,19 @@ const deserializeAws_json1_1QueryStringParametersMap = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_json1_1RedshiftDataParameters = (output: any, context: __SerdeContext): RedshiftDataParameters => {
   return {
-    Database: output.Database !== undefined && output.Database !== null ? output.Database : undefined,
-    DbUser: output.DbUser !== undefined && output.DbUser !== null ? output.DbUser : undefined,
-    SecretManagerArn:
-      output.SecretManagerArn !== undefined && output.SecretManagerArn !== null ? output.SecretManagerArn : undefined,
-    Sql: output.Sql !== undefined && output.Sql !== null ? output.Sql : undefined,
-    StatementName:
-      output.StatementName !== undefined && output.StatementName !== null ? output.StatementName : undefined,
-    WithEvent: output.WithEvent !== undefined && output.WithEvent !== null ? output.WithEvent : undefined,
+    Database: __expectString(output.Database),
+    DbUser: __expectString(output.DbUser),
+    SecretManagerArn: __expectString(output.SecretManagerArn),
+    Sql: __expectString(output.Sql),
+    StatementName: __expectString(output.StatementName),
+    WithEvent: __expectBoolean(output.WithEvent),
   } as any;
 };
 
@@ -7130,8 +7059,7 @@ const deserializeAws_json1_1RemoveTargetsResponse = (output: any, context: __Ser
       output.FailedEntries !== undefined && output.FailedEntries !== null
         ? deserializeAws_json1_1RemoveTargetsResultEntryList(output.FailedEntries, context)
         : undefined,
-    FailedEntryCount:
-      output.FailedEntryCount !== undefined && output.FailedEntryCount !== null ? output.FailedEntryCount : undefined,
+    FailedEntryCount: __expectNumber(output.FailedEntryCount),
   } as any;
 };
 
@@ -7140,9 +7068,9 @@ const deserializeAws_json1_1RemoveTargetsResultEntry = (
   context: __SerdeContext
 ): RemoveTargetsResultEntry => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    TargetId: output.TargetId !== undefined && output.TargetId !== null ? output.TargetId : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
+    TargetId: __expectString(output.TargetId),
   } as any;
 };
 
@@ -7170,8 +7098,7 @@ const deserializeAws_json1_1Replay = (output: any, context: __SerdeContext): Rep
       output.EventLastReplayedTime !== undefined && output.EventLastReplayedTime !== null
         ? new Date(Math.round(output.EventLastReplayedTime * 1000))
         : undefined,
-    EventSourceArn:
-      output.EventSourceArn !== undefined && output.EventSourceArn !== null ? output.EventSourceArn : undefined,
+    EventSourceArn: __expectString(output.EventSourceArn),
     EventStartTime:
       output.EventStartTime !== undefined && output.EventStartTime !== null
         ? new Date(Math.round(output.EventStartTime * 1000))
@@ -7180,19 +7107,19 @@ const deserializeAws_json1_1Replay = (output: any, context: __SerdeContext): Rep
       output.ReplayEndTime !== undefined && output.ReplayEndTime !== null
         ? new Date(Math.round(output.ReplayEndTime * 1000))
         : undefined,
-    ReplayName: output.ReplayName !== undefined && output.ReplayName !== null ? output.ReplayName : undefined,
+    ReplayName: __expectString(output.ReplayName),
     ReplayStartTime:
       output.ReplayStartTime !== undefined && output.ReplayStartTime !== null
         ? new Date(Math.round(output.ReplayStartTime * 1000))
         : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    StateReason: output.StateReason !== undefined && output.StateReason !== null ? output.StateReason : undefined,
+    State: __expectString(output.State),
+    StateReason: __expectString(output.StateReason),
   } as any;
 };
 
 const deserializeAws_json1_1ReplayDestination = (output: any, context: __SerdeContext): ReplayDestination => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     FilterArns:
       output.FilterArns !== undefined && output.FilterArns !== null
         ? deserializeAws_json1_1ReplayDestinationFilters(output.FilterArns, context)
@@ -7207,7 +7134,7 @@ const deserializeAws_json1_1ReplayDestinationFilters = (output: any, context: __
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7227,7 +7154,7 @@ const deserializeAws_json1_1ResourceAlreadyExistsException = (
   context: __SerdeContext
 ): ResourceAlreadyExistsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -7236,37 +7163,28 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1RetryPolicy = (output: any, context: __SerdeContext): RetryPolicy => {
   return {
-    MaximumEventAgeInSeconds:
-      output.MaximumEventAgeInSeconds !== undefined && output.MaximumEventAgeInSeconds !== null
-        ? output.MaximumEventAgeInSeconds
-        : undefined,
-    MaximumRetryAttempts:
-      output.MaximumRetryAttempts !== undefined && output.MaximumRetryAttempts !== null
-        ? output.MaximumRetryAttempts
-        : undefined,
+    MaximumEventAgeInSeconds: __expectNumber(output.MaximumEventAgeInSeconds),
+    MaximumRetryAttempts: __expectNumber(output.MaximumRetryAttempts),
   } as any;
 };
 
 const deserializeAws_json1_1Rule = (output: any, context: __SerdeContext): Rule => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    EventBusName: output.EventBusName !== undefined && output.EventBusName !== null ? output.EventBusName : undefined,
-    EventPattern: output.EventPattern !== undefined && output.EventPattern !== null ? output.EventPattern : undefined,
-    ManagedBy: output.ManagedBy !== undefined && output.ManagedBy !== null ? output.ManagedBy : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
-    ScheduleExpression:
-      output.ScheduleExpression !== undefined && output.ScheduleExpression !== null
-        ? output.ScheduleExpression
-        : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    Arn: __expectString(output.Arn),
+    Description: __expectString(output.Description),
+    EventBusName: __expectString(output.EventBusName),
+    EventPattern: __expectString(output.EventPattern),
+    ManagedBy: __expectString(output.ManagedBy),
+    Name: __expectString(output.Name),
+    RoleArn: __expectString(output.RoleArn),
+    ScheduleExpression: __expectString(output.ScheduleExpression),
+    State: __expectString(output.State),
   } as any;
 };
 
@@ -7277,7 +7195,7 @@ const deserializeAws_json1_1RuleNameList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7303,7 +7221,7 @@ const deserializeAws_json1_1RunCommandParameters = (output: any, context: __Serd
 
 const deserializeAws_json1_1RunCommandTarget = (output: any, context: __SerdeContext): RunCommandTarget => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
+    Key: __expectString(output.Key),
     Values:
       output.Values !== undefined && output.Values !== null
         ? deserializeAws_json1_1RunCommandTargetValues(output.Values, context)
@@ -7329,7 +7247,7 @@ const deserializeAws_json1_1RunCommandTargetValues = (output: any, context: __Se
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7338,8 +7256,8 @@ const deserializeAws_json1_1SageMakerPipelineParameter = (
   context: __SerdeContext
 ): SageMakerPipelineParameter => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Name: __expectString(output.Name),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -7371,20 +7289,19 @@ const deserializeAws_json1_1SageMakerPipelineParameters = (
 
 const deserializeAws_json1_1SqsParameters = (output: any, context: __SerdeContext): SqsParameters => {
   return {
-    MessageGroupId:
-      output.MessageGroupId !== undefined && output.MessageGroupId !== null ? output.MessageGroupId : undefined,
+    MessageGroupId: __expectString(output.MessageGroupId),
   } as any;
 };
 
 const deserializeAws_json1_1StartReplayResponse = (output: any, context: __SerdeContext): StartReplayResponse => {
   return {
-    ReplayArn: output.ReplayArn !== undefined && output.ReplayArn !== null ? output.ReplayArn : undefined,
+    ReplayArn: __expectString(output.ReplayArn),
     ReplayStartTime:
       output.ReplayStartTime !== undefined && output.ReplayStartTime !== null
         ? new Date(Math.round(output.ReplayStartTime * 1000))
         : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    StateReason: output.StateReason !== undefined && output.StateReason !== null ? output.StateReason : undefined,
+    State: __expectString(output.State),
+    StateReason: __expectString(output.StateReason),
   } as any;
 };
 
@@ -7395,14 +7312,14 @@ const deserializeAws_json1_1StringList = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -7423,7 +7340,7 @@ const deserializeAws_json1_1TagResourceResponse = (output: any, context: __Serde
 
 const deserializeAws_json1_1Target = (output: any, context: __SerdeContext): Target => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     BatchParameters:
       output.BatchParameters !== undefined && output.BatchParameters !== null
         ? deserializeAws_json1_1BatchParameters(output.BatchParameters, context)
@@ -7440,9 +7357,9 @@ const deserializeAws_json1_1Target = (output: any, context: __SerdeContext): Tar
       output.HttpParameters !== undefined && output.HttpParameters !== null
         ? deserializeAws_json1_1HttpParameters(output.HttpParameters, context)
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Input: output.Input !== undefined && output.Input !== null ? output.Input : undefined,
-    InputPath: output.InputPath !== undefined && output.InputPath !== null ? output.InputPath : undefined,
+    Id: __expectString(output.Id),
+    Input: __expectString(output.Input),
+    InputPath: __expectString(output.InputPath),
     InputTransformer:
       output.InputTransformer !== undefined && output.InputTransformer !== null
         ? deserializeAws_json1_1InputTransformer(output.InputTransformer, context)
@@ -7459,7 +7376,7 @@ const deserializeAws_json1_1Target = (output: any, context: __SerdeContext): Tar
       output.RetryPolicy !== undefined && output.RetryPolicy !== null
         ? deserializeAws_json1_1RetryPolicy(output.RetryPolicy, context)
         : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
+    RoleArn: __expectString(output.RoleArn),
     RunCommandParameters:
       output.RunCommandParameters !== undefined && output.RunCommandParameters !== null
         ? deserializeAws_json1_1RunCommandParameters(output.RunCommandParameters, context)
@@ -7491,7 +7408,7 @@ const deserializeAws_json1_1TestEventPatternResponse = (
   context: __SerdeContext
 ): TestEventPatternResponse => {
   return {
-    Result: output.Result !== undefined && output.Result !== null ? output.Result : undefined,
+    Result: __expectBoolean(output.Result),
   } as any;
 };
 
@@ -7502,7 +7419,7 @@ const deserializeAws_json1_1TransformerPaths = (output: any, context: __SerdeCon
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -7516,14 +7433,8 @@ const deserializeAws_json1_1UpdateApiDestinationResponse = (
   context: __SerdeContext
 ): UpdateApiDestinationResponse => {
   return {
-    ApiDestinationArn:
-      output.ApiDestinationArn !== undefined && output.ApiDestinationArn !== null
-        ? output.ApiDestinationArn
-        : undefined,
-    ApiDestinationState:
-      output.ApiDestinationState !== undefined && output.ApiDestinationState !== null
-        ? output.ApiDestinationState
-        : undefined,
+    ApiDestinationArn: __expectString(output.ApiDestinationArn),
+    ApiDestinationState: __expectString(output.ApiDestinationState),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -7537,13 +7448,13 @@ const deserializeAws_json1_1UpdateApiDestinationResponse = (
 
 const deserializeAws_json1_1UpdateArchiveResponse = (output: any, context: __SerdeContext): UpdateArchiveResponse => {
   return {
-    ArchiveArn: output.ArchiveArn !== undefined && output.ArchiveArn !== null ? output.ArchiveArn : undefined,
+    ArchiveArn: __expectString(output.ArchiveArn),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    StateReason: output.StateReason !== undefined && output.StateReason !== null ? output.StateReason : undefined,
+    State: __expectString(output.State),
+    StateReason: __expectString(output.StateReason),
   } as any;
 };
 
@@ -7552,10 +7463,8 @@ const deserializeAws_json1_1UpdateConnectionResponse = (
   context: __SerdeContext
 ): UpdateConnectionResponse => {
   return {
-    ConnectionArn:
-      output.ConnectionArn !== undefined && output.ConnectionArn !== null ? output.ConnectionArn : undefined,
-    ConnectionState:
-      output.ConnectionState !== undefined && output.ConnectionState !== null ? output.ConnectionState : undefined,
+    ConnectionArn: __expectString(output.ConnectionArn),
+    ConnectionState: __expectString(output.ConnectionState),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))

--- a/clients/client-finspace-data/protocols/Aws_restJson1.ts
+++ b/clients/client-finspace-data/protocols/Aws_restJson1.ts
@@ -17,6 +17,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -219,7 +221,7 @@ export const deserializeAws_restJson1GetProgrammaticAccessCredentialsCommand = a
     contents.credentials = deserializeAws_restJson1Credentials(data.credentials, context);
   }
   if (data.durationInMinutes !== undefined && data.durationInMinutes !== null) {
-    contents.durationInMinutes = data.durationInMinutes;
+    contents.durationInMinutes = __expectNumber(data.durationInMinutes);
   }
   return Promise.resolve(contents);
 };
@@ -292,13 +294,13 @@ export const deserializeAws_restJson1GetWorkingLocationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.s3Bucket !== undefined && data.s3Bucket !== null) {
-    contents.s3Bucket = data.s3Bucket;
+    contents.s3Bucket = __expectString(data.s3Bucket);
   }
   if (data.s3Path !== undefined && data.s3Path !== null) {
-    contents.s3Path = data.s3Path;
+    contents.s3Path = __expectString(data.s3Path);
   }
   if (data.s3Uri !== undefined && data.s3Uri !== null) {
-    contents.s3Uri = data.s3Uri;
+    contents.s3Uri = __expectString(data.s3Uri);
   }
   return Promise.resolve(contents);
 };
@@ -376,7 +378,7 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -393,7 +395,7 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -410,7 +412,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -440,7 +442,7 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -459,8 +461,8 @@ const serializeAws_restJson1stringMap = (input: { [key: string]: string }, conte
 
 const deserializeAws_restJson1ChangesetInfo = (output: any, context: __SerdeContext): ChangesetInfo => {
   return {
-    changeType: output.changeType !== undefined && output.changeType !== null ? output.changeType : undefined,
-    changesetArn: output.changesetArn !== undefined && output.changesetArn !== null ? output.changesetArn : undefined,
+    changeType: __expectString(output.changeType),
+    changesetArn: __expectString(output.changesetArn),
     changesetLabels:
       output.changesetLabels !== undefined && output.changesetLabels !== null
         ? deserializeAws_restJson1stringMap(output.changesetLabels, context)
@@ -469,7 +471,7 @@ const deserializeAws_restJson1ChangesetInfo = (output: any, context: __SerdeCont
       output.createTimestamp !== undefined && output.createTimestamp !== null
         ? new Date(Math.round(output.createTimestamp * 1000))
         : undefined,
-    datasetId: output.datasetId !== undefined && output.datasetId !== null ? output.datasetId : undefined,
+    datasetId: __expectString(output.datasetId),
     errorInfo:
       output.errorInfo !== undefined && output.errorInfo !== null
         ? deserializeAws_restJson1ErrorInfo(output.errorInfo, context)
@@ -478,39 +480,31 @@ const deserializeAws_restJson1ChangesetInfo = (output: any, context: __SerdeCont
       output.formatParams !== undefined && output.formatParams !== null
         ? deserializeAws_restJson1stringMap(output.formatParams, context)
         : undefined,
-    formatType: output.formatType !== undefined && output.formatType !== null ? output.formatType : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    formatType: __expectString(output.formatType),
+    id: __expectString(output.id),
     sourceParams:
       output.sourceParams !== undefined && output.sourceParams !== null
         ? deserializeAws_restJson1stringMap(output.sourceParams, context)
         : undefined,
-    sourceType: output.sourceType !== undefined && output.sourceType !== null ? output.sourceType : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    updatedByChangesetId:
-      output.updatedByChangesetId !== undefined && output.updatedByChangesetId !== null
-        ? output.updatedByChangesetId
-        : undefined,
-    updatesChangesetId:
-      output.updatesChangesetId !== undefined && output.updatesChangesetId !== null
-        ? output.updatesChangesetId
-        : undefined,
+    sourceType: __expectString(output.sourceType),
+    status: __expectString(output.status),
+    updatedByChangesetId: __expectString(output.updatedByChangesetId),
+    updatesChangesetId: __expectString(output.updatesChangesetId),
   } as any;
 };
 
 const deserializeAws_restJson1Credentials = (output: any, context: __SerdeContext): Credentials => {
   return {
-    accessKeyId: output.accessKeyId !== undefined && output.accessKeyId !== null ? output.accessKeyId : undefined,
-    secretAccessKey:
-      output.secretAccessKey !== undefined && output.secretAccessKey !== null ? output.secretAccessKey : undefined,
-    sessionToken: output.sessionToken !== undefined && output.sessionToken !== null ? output.sessionToken : undefined,
+    accessKeyId: __expectString(output.accessKeyId),
+    secretAccessKey: __expectString(output.secretAccessKey),
+    sessionToken: __expectString(output.sessionToken),
   } as any;
 };
 
 const deserializeAws_restJson1ErrorInfo = (output: any, context: __SerdeContext): ErrorInfo => {
   return {
-    errorCategory:
-      output.errorCategory !== undefined && output.errorCategory !== null ? output.errorCategory : undefined,
-    errorMessage: output.errorMessage !== undefined && output.errorMessage !== null ? output.errorMessage : undefined,
+    errorCategory: __expectString(output.errorCategory),
+    errorMessage: __expectString(output.errorMessage),
   } as any;
 };
 
@@ -521,7 +515,7 @@ const deserializeAws_restJson1stringMap = (output: any, context: __SerdeContext)
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };

--- a/clients/client-finspace/protocols/Aws_restJson1.ts
+++ b/clients/client-finspace/protocols/Aws_restJson1.ts
@@ -24,6 +24,7 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -294,13 +295,13 @@ export const deserializeAws_restJson1CreateEnvironmentCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.environmentArn !== undefined && data.environmentArn !== null) {
-    contents.environmentArn = data.environmentArn;
+    contents.environmentArn = __expectString(data.environmentArn);
   }
   if (data.environmentId !== undefined && data.environmentId !== null) {
-    contents.environmentId = data.environmentId;
+    contents.environmentId = __expectString(data.environmentId);
   }
   if (data.environmentUrl !== undefined && data.environmentUrl !== null) {
-    contents.environmentUrl = data.environmentUrl;
+    contents.environmentUrl = __expectString(data.environmentUrl);
   }
   return Promise.resolve(contents);
 };
@@ -561,7 +562,7 @@ export const deserializeAws_restJson1ListEnvironmentsCommand = async (
     contents.environments = deserializeAws_restJson1EnvironmentList(data.environments, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -928,7 +929,7 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -945,7 +946,7 @@ const deserializeAws_restJson1InvalidRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -962,7 +963,7 @@ const deserializeAws_restJson1LimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -979,7 +980,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -996,7 +997,7 @@ const deserializeAws_restJson1ServiceQuotaExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1026,7 +1027,7 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1078,38 +1079,28 @@ const deserializeAws_restJson1AttributeMap = (output: any, context: __SerdeConte
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1Environment = (output: any, context: __SerdeContext): Environment => {
   return {
-    awsAccountId: output.awsAccountId !== undefined && output.awsAccountId !== null ? output.awsAccountId : undefined,
-    dedicatedServiceAccountId:
-      output.dedicatedServiceAccountId !== undefined && output.dedicatedServiceAccountId !== null
-        ? output.dedicatedServiceAccountId
-        : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    environmentArn:
-      output.environmentArn !== undefined && output.environmentArn !== null ? output.environmentArn : undefined,
-    environmentId:
-      output.environmentId !== undefined && output.environmentId !== null ? output.environmentId : undefined,
-    environmentUrl:
-      output.environmentUrl !== undefined && output.environmentUrl !== null ? output.environmentUrl : undefined,
-    federationMode:
-      output.federationMode !== undefined && output.federationMode !== null ? output.federationMode : undefined,
+    awsAccountId: __expectString(output.awsAccountId),
+    dedicatedServiceAccountId: __expectString(output.dedicatedServiceAccountId),
+    description: __expectString(output.description),
+    environmentArn: __expectString(output.environmentArn),
+    environmentId: __expectString(output.environmentId),
+    environmentUrl: __expectString(output.environmentUrl),
+    federationMode: __expectString(output.federationMode),
     federationParameters:
       output.federationParameters !== undefined && output.federationParameters !== null
         ? deserializeAws_restJson1FederationParameters(output.federationParameters, context)
         : undefined,
-    kmsKeyId: output.kmsKeyId !== undefined && output.kmsKeyId !== null ? output.kmsKeyId : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    sageMakerStudioDomainUrl:
-      output.sageMakerStudioDomainUrl !== undefined && output.sageMakerStudioDomainUrl !== null
-        ? output.sageMakerStudioDomainUrl
-        : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    kmsKeyId: __expectString(output.kmsKeyId),
+    name: __expectString(output.name),
+    sageMakerStudioDomainUrl: __expectString(output.sageMakerStudioDomainUrl),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -1126,26 +1117,15 @@ const deserializeAws_restJson1EnvironmentList = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1FederationParameters = (output: any, context: __SerdeContext): FederationParameters => {
   return {
-    applicationCallBackURL:
-      output.applicationCallBackURL !== undefined && output.applicationCallBackURL !== null
-        ? output.applicationCallBackURL
-        : undefined,
+    applicationCallBackURL: __expectString(output.applicationCallBackURL),
     attributeMap:
       output.attributeMap !== undefined && output.attributeMap !== null
         ? deserializeAws_restJson1AttributeMap(output.attributeMap, context)
         : undefined,
-    federationProviderName:
-      output.federationProviderName !== undefined && output.federationProviderName !== null
-        ? output.federationProviderName
-        : undefined,
-    federationURN:
-      output.federationURN !== undefined && output.federationURN !== null ? output.federationURN : undefined,
-    samlMetadataDocument:
-      output.samlMetadataDocument !== undefined && output.samlMetadataDocument !== null
-        ? output.samlMetadataDocument
-        : undefined,
-    samlMetadataURL:
-      output.samlMetadataURL !== undefined && output.samlMetadataURL !== null ? output.samlMetadataURL : undefined,
+    federationProviderName: __expectString(output.federationProviderName),
+    federationURN: __expectString(output.federationURN),
+    samlMetadataDocument: __expectString(output.samlMetadataDocument),
+    samlMetadataURL: __expectString(output.samlMetadataURL),
   } as any;
 };
 
@@ -1156,7 +1136,7 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };

--- a/clients/client-firehose/protocols/Aws_json1_1.ts
+++ b/clients/client-firehose/protocols/Aws_json1_1.ts
@@ -127,7 +127,12 @@ import {
   _Record,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -2400,11 +2405,8 @@ const serializeAws_json1_1VpcConfiguration = (input: VpcConfiguration, context: 
 
 const deserializeAws_json1_1BufferingHints = (output: any, context: __SerdeContext): BufferingHints => {
   return {
-    IntervalInSeconds:
-      output.IntervalInSeconds !== undefined && output.IntervalInSeconds !== null
-        ? output.IntervalInSeconds
-        : undefined,
-    SizeInMBs: output.SizeInMBs !== undefined && output.SizeInMBs !== null ? output.SizeInMBs : undefined,
+    IntervalInSeconds: __expectNumber(output.IntervalInSeconds),
+    SizeInMBs: __expectNumber(output.SizeInMBs),
   } as any;
 };
 
@@ -2413,10 +2415,9 @@ const deserializeAws_json1_1CloudWatchLoggingOptions = (
   context: __SerdeContext
 ): CloudWatchLoggingOptions => {
   return {
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
-    LogGroupName: output.LogGroupName !== undefined && output.LogGroupName !== null ? output.LogGroupName : undefined,
-    LogStreamName:
-      output.LogStreamName !== undefined && output.LogStreamName !== null ? output.LogStreamName : undefined,
+    Enabled: __expectBoolean(output.Enabled),
+    LogGroupName: __expectString(output.LogGroupName),
+    LogStreamName: __expectString(output.LogStreamName),
   } as any;
 };
 
@@ -2430,7 +2431,7 @@ const deserializeAws_json1_1ColumnToJsonKeyMappings = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -2440,17 +2441,15 @@ const deserializeAws_json1_1ConcurrentModificationException = (
   context: __SerdeContext
 ): ConcurrentModificationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1CopyCommand = (output: any, context: __SerdeContext): CopyCommand => {
   return {
-    CopyOptions: output.CopyOptions !== undefined && output.CopyOptions !== null ? output.CopyOptions : undefined,
-    DataTableColumns:
-      output.DataTableColumns !== undefined && output.DataTableColumns !== null ? output.DataTableColumns : undefined,
-    DataTableName:
-      output.DataTableName !== undefined && output.DataTableName !== null ? output.DataTableName : undefined,
+    CopyOptions: __expectString(output.CopyOptions),
+    DataTableColumns: __expectString(output.DataTableColumns),
+    DataTableName: __expectString(output.DataTableName),
   } as any;
 };
 
@@ -2459,10 +2458,7 @@ const deserializeAws_json1_1CreateDeliveryStreamOutput = (
   context: __SerdeContext
 ): CreateDeliveryStreamOutput => {
   return {
-    DeliveryStreamARN:
-      output.DeliveryStreamARN !== undefined && output.DeliveryStreamARN !== null
-        ? output.DeliveryStreamARN
-        : undefined,
+    DeliveryStreamARN: __expectString(output.DeliveryStreamARN),
   } as any;
 };
 
@@ -2471,7 +2467,7 @@ const deserializeAws_json1_1DataFormatConversionConfiguration = (
   context: __SerdeContext
 ): DataFormatConversionConfiguration => {
   return {
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
+    Enabled: __expectBoolean(output.Enabled),
     InputFormatConfiguration:
       output.InputFormatConfiguration !== undefined && output.InputFormatConfiguration !== null
         ? deserializeAws_json1_1InputFormatConfiguration(output.InputFormatConfiguration, context)
@@ -2503,10 +2499,7 @@ const deserializeAws_json1_1DeliveryStreamDescription = (
       output.CreateTimestamp !== undefined && output.CreateTimestamp !== null
         ? new Date(Math.round(output.CreateTimestamp * 1000))
         : undefined,
-    DeliveryStreamARN:
-      output.DeliveryStreamARN !== undefined && output.DeliveryStreamARN !== null
-        ? output.DeliveryStreamARN
-        : undefined,
+    DeliveryStreamARN: __expectString(output.DeliveryStreamARN),
     DeliveryStreamEncryptionConfiguration:
       output.DeliveryStreamEncryptionConfiguration !== undefined &&
       output.DeliveryStreamEncryptionConfiguration !== null
@@ -2515,18 +2508,9 @@ const deserializeAws_json1_1DeliveryStreamDescription = (
             context
           )
         : undefined,
-    DeliveryStreamName:
-      output.DeliveryStreamName !== undefined && output.DeliveryStreamName !== null
-        ? output.DeliveryStreamName
-        : undefined,
-    DeliveryStreamStatus:
-      output.DeliveryStreamStatus !== undefined && output.DeliveryStreamStatus !== null
-        ? output.DeliveryStreamStatus
-        : undefined,
-    DeliveryStreamType:
-      output.DeliveryStreamType !== undefined && output.DeliveryStreamType !== null
-        ? output.DeliveryStreamType
-        : undefined,
+    DeliveryStreamName: __expectString(output.DeliveryStreamName),
+    DeliveryStreamStatus: __expectString(output.DeliveryStreamStatus),
+    DeliveryStreamType: __expectString(output.DeliveryStreamType),
     Destinations:
       output.Destinations !== undefined && output.Destinations !== null
         ? deserializeAws_json1_1DestinationDescriptionList(output.Destinations, context)
@@ -2535,10 +2519,7 @@ const deserializeAws_json1_1DeliveryStreamDescription = (
       output.FailureDescription !== undefined && output.FailureDescription !== null
         ? deserializeAws_json1_1FailureDescription(output.FailureDescription, context)
         : undefined,
-    HasMoreDestinations:
-      output.HasMoreDestinations !== undefined && output.HasMoreDestinations !== null
-        ? output.HasMoreDestinations
-        : undefined,
+    HasMoreDestinations: __expectBoolean(output.HasMoreDestinations),
     LastUpdateTimestamp:
       output.LastUpdateTimestamp !== undefined && output.LastUpdateTimestamp !== null
         ? new Date(Math.round(output.LastUpdateTimestamp * 1000))
@@ -2547,7 +2528,7 @@ const deserializeAws_json1_1DeliveryStreamDescription = (
       output.Source !== undefined && output.Source !== null
         ? deserializeAws_json1_1SourceDescription(output.Source, context)
         : undefined,
-    VersionId: output.VersionId !== undefined && output.VersionId !== null ? output.VersionId : undefined,
+    VersionId: __expectString(output.VersionId),
   } as any;
 };
 
@@ -2560,9 +2541,9 @@ const deserializeAws_json1_1DeliveryStreamEncryptionConfiguration = (
       output.FailureDescription !== undefined && output.FailureDescription !== null
         ? deserializeAws_json1_1FailureDescription(output.FailureDescription, context)
         : undefined,
-    KeyARN: output.KeyARN !== undefined && output.KeyARN !== null ? output.KeyARN : undefined,
-    KeyType: output.KeyType !== undefined && output.KeyType !== null ? output.KeyType : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    KeyARN: __expectString(output.KeyARN),
+    KeyType: __expectString(output.KeyType),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -2573,7 +2554,7 @@ const deserializeAws_json1_1DeliveryStreamNameList = (output: any, context: __Se
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2604,8 +2585,7 @@ const deserializeAws_json1_1Deserializer = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_1DestinationDescription = (output: any, context: __SerdeContext): DestinationDescription => {
   return {
-    DestinationId:
-      output.DestinationId !== undefined && output.DestinationId !== null ? output.DestinationId : undefined,
+    DestinationId: __expectString(output.DestinationId),
     ElasticsearchDestinationDescription:
       output.ElasticsearchDestinationDescription !== undefined && output.ElasticsearchDestinationDescription !== null
         ? deserializeAws_json1_1ElasticsearchDestinationDescription(output.ElasticsearchDestinationDescription, context)
@@ -2652,11 +2632,8 @@ const deserializeAws_json1_1ElasticsearchBufferingHints = (
   context: __SerdeContext
 ): ElasticsearchBufferingHints => {
   return {
-    IntervalInSeconds:
-      output.IntervalInSeconds !== undefined && output.IntervalInSeconds !== null
-        ? output.IntervalInSeconds
-        : undefined,
-    SizeInMBs: output.SizeInMBs !== undefined && output.SizeInMBs !== null ? output.SizeInMBs : undefined,
+    IntervalInSeconds: __expectNumber(output.IntervalInSeconds),
+    SizeInMBs: __expectNumber(output.SizeInMBs),
   } as any;
 };
 
@@ -2673,14 +2650,10 @@ const deserializeAws_json1_1ElasticsearchDestinationDescription = (
       output.CloudWatchLoggingOptions !== undefined && output.CloudWatchLoggingOptions !== null
         ? deserializeAws_json1_1CloudWatchLoggingOptions(output.CloudWatchLoggingOptions, context)
         : undefined,
-    ClusterEndpoint:
-      output.ClusterEndpoint !== undefined && output.ClusterEndpoint !== null ? output.ClusterEndpoint : undefined,
-    DomainARN: output.DomainARN !== undefined && output.DomainARN !== null ? output.DomainARN : undefined,
-    IndexName: output.IndexName !== undefined && output.IndexName !== null ? output.IndexName : undefined,
-    IndexRotationPeriod:
-      output.IndexRotationPeriod !== undefined && output.IndexRotationPeriod !== null
-        ? output.IndexRotationPeriod
-        : undefined,
+    ClusterEndpoint: __expectString(output.ClusterEndpoint),
+    DomainARN: __expectString(output.DomainARN),
+    IndexName: __expectString(output.IndexName),
+    IndexRotationPeriod: __expectString(output.IndexRotationPeriod),
     ProcessingConfiguration:
       output.ProcessingConfiguration !== undefined && output.ProcessingConfiguration !== null
         ? deserializeAws_json1_1ProcessingConfiguration(output.ProcessingConfiguration, context)
@@ -2689,13 +2662,13 @@ const deserializeAws_json1_1ElasticsearchDestinationDescription = (
       output.RetryOptions !== undefined && output.RetryOptions !== null
         ? deserializeAws_json1_1ElasticsearchRetryOptions(output.RetryOptions, context)
         : undefined,
-    RoleARN: output.RoleARN !== undefined && output.RoleARN !== null ? output.RoleARN : undefined,
-    S3BackupMode: output.S3BackupMode !== undefined && output.S3BackupMode !== null ? output.S3BackupMode : undefined,
+    RoleARN: __expectString(output.RoleARN),
+    S3BackupMode: __expectString(output.S3BackupMode),
     S3DestinationDescription:
       output.S3DestinationDescription !== undefined && output.S3DestinationDescription !== null
         ? deserializeAws_json1_1S3DestinationDescription(output.S3DestinationDescription, context)
         : undefined,
-    TypeName: output.TypeName !== undefined && output.TypeName !== null ? output.TypeName : undefined,
+    TypeName: __expectString(output.TypeName),
     VpcConfigurationDescription:
       output.VpcConfigurationDescription !== undefined && output.VpcConfigurationDescription !== null
         ? deserializeAws_json1_1VpcConfigurationDescription(output.VpcConfigurationDescription, context)
@@ -2708,10 +2681,7 @@ const deserializeAws_json1_1ElasticsearchRetryOptions = (
   context: __SerdeContext
 ): ElasticsearchRetryOptions => {
   return {
-    DurationInSeconds:
-      output.DurationInSeconds !== undefined && output.DurationInSeconds !== null
-        ? output.DurationInSeconds
-        : undefined,
+    DurationInSeconds: __expectNumber(output.DurationInSeconds),
   } as any;
 };
 
@@ -2724,10 +2694,7 @@ const deserializeAws_json1_1EncryptionConfiguration = (
       output.KMSEncryptionConfig !== undefined && output.KMSEncryptionConfig !== null
         ? deserializeAws_json1_1KMSEncryptionConfig(output.KMSEncryptionConfig, context)
         : undefined,
-    NoEncryptionConfig:
-      output.NoEncryptionConfig !== undefined && output.NoEncryptionConfig !== null
-        ? output.NoEncryptionConfig
-        : undefined,
+    NoEncryptionConfig: __expectString(output.NoEncryptionConfig),
   } as any;
 };
 
@@ -2736,7 +2703,7 @@ const deserializeAws_json1_1ExtendedS3DestinationDescription = (
   context: __SerdeContext
 ): ExtendedS3DestinationDescription => {
   return {
-    BucketARN: output.BucketARN !== undefined && output.BucketARN !== null ? output.BucketARN : undefined,
+    BucketARN: __expectString(output.BucketARN),
     BufferingHints:
       output.BufferingHints !== undefined && output.BufferingHints !== null
         ? deserializeAws_json1_1BufferingHints(output.BufferingHints, context)
@@ -2745,10 +2712,7 @@ const deserializeAws_json1_1ExtendedS3DestinationDescription = (
       output.CloudWatchLoggingOptions !== undefined && output.CloudWatchLoggingOptions !== null
         ? deserializeAws_json1_1CloudWatchLoggingOptions(output.CloudWatchLoggingOptions, context)
         : undefined,
-    CompressionFormat:
-      output.CompressionFormat !== undefined && output.CompressionFormat !== null
-        ? output.CompressionFormat
-        : undefined,
+    CompressionFormat: __expectString(output.CompressionFormat),
     DataFormatConversionConfiguration:
       output.DataFormatConversionConfiguration !== undefined && output.DataFormatConversionConfiguration !== null
         ? deserializeAws_json1_1DataFormatConversionConfiguration(output.DataFormatConversionConfiguration, context)
@@ -2757,28 +2721,25 @@ const deserializeAws_json1_1ExtendedS3DestinationDescription = (
       output.EncryptionConfiguration !== undefined && output.EncryptionConfiguration !== null
         ? deserializeAws_json1_1EncryptionConfiguration(output.EncryptionConfiguration, context)
         : undefined,
-    ErrorOutputPrefix:
-      output.ErrorOutputPrefix !== undefined && output.ErrorOutputPrefix !== null
-        ? output.ErrorOutputPrefix
-        : undefined,
-    Prefix: output.Prefix !== undefined && output.Prefix !== null ? output.Prefix : undefined,
+    ErrorOutputPrefix: __expectString(output.ErrorOutputPrefix),
+    Prefix: __expectString(output.Prefix),
     ProcessingConfiguration:
       output.ProcessingConfiguration !== undefined && output.ProcessingConfiguration !== null
         ? deserializeAws_json1_1ProcessingConfiguration(output.ProcessingConfiguration, context)
         : undefined,
-    RoleARN: output.RoleARN !== undefined && output.RoleARN !== null ? output.RoleARN : undefined,
+    RoleARN: __expectString(output.RoleARN),
     S3BackupDescription:
       output.S3BackupDescription !== undefined && output.S3BackupDescription !== null
         ? deserializeAws_json1_1S3DestinationDescription(output.S3BackupDescription, context)
         : undefined,
-    S3BackupMode: output.S3BackupMode !== undefined && output.S3BackupMode !== null ? output.S3BackupMode : undefined,
+    S3BackupMode: __expectString(output.S3BackupMode),
   } as any;
 };
 
 const deserializeAws_json1_1FailureDescription = (output: any, context: __SerdeContext): FailureDescription => {
   return {
-    Details: output.Details !== undefined && output.Details !== null ? output.Details : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Details: __expectString(output.Details),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -2796,11 +2757,8 @@ const deserializeAws_json1_1HttpEndpointBufferingHints = (
   context: __SerdeContext
 ): HttpEndpointBufferingHints => {
   return {
-    IntervalInSeconds:
-      output.IntervalInSeconds !== undefined && output.IntervalInSeconds !== null
-        ? output.IntervalInSeconds
-        : undefined,
-    SizeInMBs: output.SizeInMBs !== undefined && output.SizeInMBs !== null ? output.SizeInMBs : undefined,
+    IntervalInSeconds: __expectNumber(output.IntervalInSeconds),
+    SizeInMBs: __expectNumber(output.SizeInMBs),
   } as any;
 };
 
@@ -2809,10 +2767,8 @@ const deserializeAws_json1_1HttpEndpointCommonAttribute = (
   context: __SerdeContext
 ): HttpEndpointCommonAttribute => {
   return {
-    AttributeName:
-      output.AttributeName !== undefined && output.AttributeName !== null ? output.AttributeName : undefined,
-    AttributeValue:
-      output.AttributeValue !== undefined && output.AttributeValue !== null ? output.AttributeValue : undefined,
+    AttributeName: __expectString(output.AttributeName),
+    AttributeValue: __expectString(output.AttributeValue),
   } as any;
 };
 
@@ -2835,8 +2791,8 @@ const deserializeAws_json1_1HttpEndpointDescription = (
   context: __SerdeContext
 ): HttpEndpointDescription => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Url: output.Url !== undefined && output.Url !== null ? output.Url : undefined,
+    Name: __expectString(output.Name),
+    Url: __expectString(output.Url),
   } as any;
 };
 
@@ -2869,8 +2825,8 @@ const deserializeAws_json1_1HttpEndpointDestinationDescription = (
       output.RetryOptions !== undefined && output.RetryOptions !== null
         ? deserializeAws_json1_1HttpEndpointRetryOptions(output.RetryOptions, context)
         : undefined,
-    RoleARN: output.RoleARN !== undefined && output.RoleARN !== null ? output.RoleARN : undefined,
-    S3BackupMode: output.S3BackupMode !== undefined && output.S3BackupMode !== null ? output.S3BackupMode : undefined,
+    RoleARN: __expectString(output.RoleARN),
+    S3BackupMode: __expectString(output.S3BackupMode),
     S3DestinationDescription:
       output.S3DestinationDescription !== undefined && output.S3DestinationDescription !== null
         ? deserializeAws_json1_1S3DestinationDescription(output.S3DestinationDescription, context)
@@ -2887,8 +2843,7 @@ const deserializeAws_json1_1HttpEndpointRequestConfiguration = (
       output.CommonAttributes !== undefined && output.CommonAttributes !== null
         ? deserializeAws_json1_1HttpEndpointCommonAttributesList(output.CommonAttributes, context)
         : undefined,
-    ContentEncoding:
-      output.ContentEncoding !== undefined && output.ContentEncoding !== null ? output.ContentEncoding : undefined,
+    ContentEncoding: __expectString(output.ContentEncoding),
   } as any;
 };
 
@@ -2897,10 +2852,7 @@ const deserializeAws_json1_1HttpEndpointRetryOptions = (
   context: __SerdeContext
 ): HttpEndpointRetryOptions => {
   return {
-    DurationInSeconds:
-      output.DurationInSeconds !== undefined && output.DurationInSeconds !== null
-        ? output.DurationInSeconds
-        : undefined,
+    DurationInSeconds: __expectNumber(output.DurationInSeconds),
   } as any;
 };
 
@@ -2921,7 +2873,7 @@ const deserializeAws_json1_1InvalidArgumentException = (
   context: __SerdeContext
 ): InvalidArgumentException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -2930,8 +2882,8 @@ const deserializeAws_json1_1InvalidKMSResourceException = (
   context: __SerdeContext
 ): InvalidKMSResourceException => {
   return {
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    code: __expectString(output.code),
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -2944,21 +2896,20 @@ const deserializeAws_json1_1KinesisStreamSourceDescription = (
       output.DeliveryStartTimestamp !== undefined && output.DeliveryStartTimestamp !== null
         ? new Date(Math.round(output.DeliveryStartTimestamp * 1000))
         : undefined,
-    KinesisStreamARN:
-      output.KinesisStreamARN !== undefined && output.KinesisStreamARN !== null ? output.KinesisStreamARN : undefined,
-    RoleARN: output.RoleARN !== undefined && output.RoleARN !== null ? output.RoleARN : undefined,
+    KinesisStreamARN: __expectString(output.KinesisStreamARN),
+    RoleARN: __expectString(output.RoleARN),
   } as any;
 };
 
 const deserializeAws_json1_1KMSEncryptionConfig = (output: any, context: __SerdeContext): KMSEncryptionConfig => {
   return {
-    AWSKMSKeyARN: output.AWSKMSKeyARN !== undefined && output.AWSKMSKeyARN !== null ? output.AWSKMSKeyARN : undefined,
+    AWSKMSKeyARN: __expectString(output.AWSKMSKeyARN),
   } as any;
 };
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -2971,10 +2922,7 @@ const deserializeAws_json1_1ListDeliveryStreamsOutput = (
       output.DeliveryStreamNames !== undefined && output.DeliveryStreamNames !== null
         ? deserializeAws_json1_1DeliveryStreamNameList(output.DeliveryStreamNames, context)
         : undefined,
-    HasMoreDeliveryStreams:
-      output.HasMoreDeliveryStreams !== undefined && output.HasMoreDeliveryStreams !== null
-        ? output.HasMoreDeliveryStreams
-        : undefined,
+    HasMoreDeliveryStreams: __expectBoolean(output.HasMoreDeliveryStreams),
   } as any;
 };
 
@@ -2985,7 +2933,7 @@ const deserializeAws_json1_1ListOfNonEmptyStrings = (output: any, context: __Ser
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2999,7 +2947,7 @@ const deserializeAws_json1_1ListOfNonEmptyStringsWithoutWhitespace = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3008,7 +2956,7 @@ const deserializeAws_json1_1ListTagsForDeliveryStreamOutput = (
   context: __SerdeContext
 ): ListTagsForDeliveryStreamOutput => {
   return {
-    HasMoreTags: output.HasMoreTags !== undefined && output.HasMoreTags !== null ? output.HasMoreTags : undefined,
+    HasMoreTags: __expectBoolean(output.HasMoreTags),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_1ListTagsForDeliveryStreamOutputTagList(output.Tags, context)
@@ -3029,46 +2977,30 @@ const deserializeAws_json1_1ListTagsForDeliveryStreamOutputTagList = (output: an
 
 const deserializeAws_json1_1OpenXJsonSerDe = (output: any, context: __SerdeContext): OpenXJsonSerDe => {
   return {
-    CaseInsensitive:
-      output.CaseInsensitive !== undefined && output.CaseInsensitive !== null ? output.CaseInsensitive : undefined,
+    CaseInsensitive: __expectBoolean(output.CaseInsensitive),
     ColumnToJsonKeyMappings:
       output.ColumnToJsonKeyMappings !== undefined && output.ColumnToJsonKeyMappings !== null
         ? deserializeAws_json1_1ColumnToJsonKeyMappings(output.ColumnToJsonKeyMappings, context)
         : undefined,
-    ConvertDotsInJsonKeysToUnderscores:
-      output.ConvertDotsInJsonKeysToUnderscores !== undefined && output.ConvertDotsInJsonKeysToUnderscores !== null
-        ? output.ConvertDotsInJsonKeysToUnderscores
-        : undefined,
+    ConvertDotsInJsonKeysToUnderscores: __expectBoolean(output.ConvertDotsInJsonKeysToUnderscores),
   } as any;
 };
 
 const deserializeAws_json1_1OrcSerDe = (output: any, context: __SerdeContext): OrcSerDe => {
   return {
-    BlockSizeBytes:
-      output.BlockSizeBytes !== undefined && output.BlockSizeBytes !== null ? output.BlockSizeBytes : undefined,
+    BlockSizeBytes: __expectNumber(output.BlockSizeBytes),
     BloomFilterColumns:
       output.BloomFilterColumns !== undefined && output.BloomFilterColumns !== null
         ? deserializeAws_json1_1ListOfNonEmptyStringsWithoutWhitespace(output.BloomFilterColumns, context)
         : undefined,
-    BloomFilterFalsePositiveProbability:
-      output.BloomFilterFalsePositiveProbability !== undefined && output.BloomFilterFalsePositiveProbability !== null
-        ? output.BloomFilterFalsePositiveProbability
-        : undefined,
-    Compression: output.Compression !== undefined && output.Compression !== null ? output.Compression : undefined,
-    DictionaryKeyThreshold:
-      output.DictionaryKeyThreshold !== undefined && output.DictionaryKeyThreshold !== null
-        ? output.DictionaryKeyThreshold
-        : undefined,
-    EnablePadding:
-      output.EnablePadding !== undefined && output.EnablePadding !== null ? output.EnablePadding : undefined,
-    FormatVersion:
-      output.FormatVersion !== undefined && output.FormatVersion !== null ? output.FormatVersion : undefined,
-    PaddingTolerance:
-      output.PaddingTolerance !== undefined && output.PaddingTolerance !== null ? output.PaddingTolerance : undefined,
-    RowIndexStride:
-      output.RowIndexStride !== undefined && output.RowIndexStride !== null ? output.RowIndexStride : undefined,
-    StripeSizeBytes:
-      output.StripeSizeBytes !== undefined && output.StripeSizeBytes !== null ? output.StripeSizeBytes : undefined,
+    BloomFilterFalsePositiveProbability: __expectNumber(output.BloomFilterFalsePositiveProbability),
+    Compression: __expectString(output.Compression),
+    DictionaryKeyThreshold: __expectNumber(output.DictionaryKeyThreshold),
+    EnablePadding: __expectBoolean(output.EnablePadding),
+    FormatVersion: __expectString(output.FormatVersion),
+    PaddingTolerance: __expectNumber(output.PaddingTolerance),
+    RowIndexStride: __expectNumber(output.RowIndexStride),
+    StripeSizeBytes: __expectNumber(output.StripeSizeBytes),
   } as any;
 };
 
@@ -3086,19 +3018,12 @@ const deserializeAws_json1_1OutputFormatConfiguration = (
 
 const deserializeAws_json1_1ParquetSerDe = (output: any, context: __SerdeContext): ParquetSerDe => {
   return {
-    BlockSizeBytes:
-      output.BlockSizeBytes !== undefined && output.BlockSizeBytes !== null ? output.BlockSizeBytes : undefined,
-    Compression: output.Compression !== undefined && output.Compression !== null ? output.Compression : undefined,
-    EnableDictionaryCompression:
-      output.EnableDictionaryCompression !== undefined && output.EnableDictionaryCompression !== null
-        ? output.EnableDictionaryCompression
-        : undefined,
-    MaxPaddingBytes:
-      output.MaxPaddingBytes !== undefined && output.MaxPaddingBytes !== null ? output.MaxPaddingBytes : undefined,
-    PageSizeBytes:
-      output.PageSizeBytes !== undefined && output.PageSizeBytes !== null ? output.PageSizeBytes : undefined,
-    WriterVersion:
-      output.WriterVersion !== undefined && output.WriterVersion !== null ? output.WriterVersion : undefined,
+    BlockSizeBytes: __expectNumber(output.BlockSizeBytes),
+    Compression: __expectString(output.Compression),
+    EnableDictionaryCompression: __expectBoolean(output.EnableDictionaryCompression),
+    MaxPaddingBytes: __expectNumber(output.MaxPaddingBytes),
+    PageSizeBytes: __expectNumber(output.PageSizeBytes),
+    WriterVersion: __expectString(output.WriterVersion),
   } as any;
 };
 
@@ -3107,7 +3032,7 @@ const deserializeAws_json1_1ProcessingConfiguration = (
   context: __SerdeContext
 ): ProcessingConfiguration => {
   return {
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
+    Enabled: __expectBoolean(output.Enabled),
     Processors:
       output.Processors !== undefined && output.Processors !== null
         ? deserializeAws_json1_1ProcessorList(output.Processors, context)
@@ -3121,7 +3046,7 @@ const deserializeAws_json1_1Processor = (output: any, context: __SerdeContext): 
       output.Parameters !== undefined && output.Parameters !== null
         ? deserializeAws_json1_1ProcessorParameterList(output.Parameters, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -3138,10 +3063,8 @@ const deserializeAws_json1_1ProcessorList = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1ProcessorParameter = (output: any, context: __SerdeContext): ProcessorParameter => {
   return {
-    ParameterName:
-      output.ParameterName !== undefined && output.ParameterName !== null ? output.ParameterName : undefined,
-    ParameterValue:
-      output.ParameterValue !== undefined && output.ParameterValue !== null ? output.ParameterValue : undefined,
+    ParameterName: __expectString(output.ParameterName),
+    ParameterValue: __expectString(output.ParameterValue),
   } as any;
 };
 
@@ -3158,9 +3081,8 @@ const deserializeAws_json1_1ProcessorParameterList = (output: any, context: __Se
 
 const deserializeAws_json1_1PutRecordBatchOutput = (output: any, context: __SerdeContext): PutRecordBatchOutput => {
   return {
-    Encrypted: output.Encrypted !== undefined && output.Encrypted !== null ? output.Encrypted : undefined,
-    FailedPutCount:
-      output.FailedPutCount !== undefined && output.FailedPutCount !== null ? output.FailedPutCount : undefined,
+    Encrypted: __expectBoolean(output.Encrypted),
+    FailedPutCount: __expectNumber(output.FailedPutCount),
     RequestResponses:
       output.RequestResponses !== undefined && output.RequestResponses !== null
         ? deserializeAws_json1_1PutRecordBatchResponseEntryList(output.RequestResponses, context)
@@ -3173,9 +3095,9 @@ const deserializeAws_json1_1PutRecordBatchResponseEntry = (
   context: __SerdeContext
 ): PutRecordBatchResponseEntry => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    RecordId: output.RecordId !== undefined && output.RecordId !== null ? output.RecordId : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
+    RecordId: __expectString(output.RecordId),
   } as any;
 };
 
@@ -3195,8 +3117,8 @@ const deserializeAws_json1_1PutRecordBatchResponseEntryList = (
 
 const deserializeAws_json1_1PutRecordOutput = (output: any, context: __SerdeContext): PutRecordOutput => {
   return {
-    Encrypted: output.Encrypted !== undefined && output.Encrypted !== null ? output.Encrypted : undefined,
-    RecordId: output.RecordId !== undefined && output.RecordId !== null ? output.RecordId : undefined,
+    Encrypted: __expectBoolean(output.Encrypted),
+    RecordId: __expectString(output.RecordId),
   } as any;
 };
 
@@ -3209,8 +3131,7 @@ const deserializeAws_json1_1RedshiftDestinationDescription = (
       output.CloudWatchLoggingOptions !== undefined && output.CloudWatchLoggingOptions !== null
         ? deserializeAws_json1_1CloudWatchLoggingOptions(output.CloudWatchLoggingOptions, context)
         : undefined,
-    ClusterJDBCURL:
-      output.ClusterJDBCURL !== undefined && output.ClusterJDBCURL !== null ? output.ClusterJDBCURL : undefined,
+    ClusterJDBCURL: __expectString(output.ClusterJDBCURL),
     CopyCommand:
       output.CopyCommand !== undefined && output.CopyCommand !== null
         ? deserializeAws_json1_1CopyCommand(output.CopyCommand, context)
@@ -3223,32 +3144,29 @@ const deserializeAws_json1_1RedshiftDestinationDescription = (
       output.RetryOptions !== undefined && output.RetryOptions !== null
         ? deserializeAws_json1_1RedshiftRetryOptions(output.RetryOptions, context)
         : undefined,
-    RoleARN: output.RoleARN !== undefined && output.RoleARN !== null ? output.RoleARN : undefined,
+    RoleARN: __expectString(output.RoleARN),
     S3BackupDescription:
       output.S3BackupDescription !== undefined && output.S3BackupDescription !== null
         ? deserializeAws_json1_1S3DestinationDescription(output.S3BackupDescription, context)
         : undefined,
-    S3BackupMode: output.S3BackupMode !== undefined && output.S3BackupMode !== null ? output.S3BackupMode : undefined,
+    S3BackupMode: __expectString(output.S3BackupMode),
     S3DestinationDescription:
       output.S3DestinationDescription !== undefined && output.S3DestinationDescription !== null
         ? deserializeAws_json1_1S3DestinationDescription(output.S3DestinationDescription, context)
         : undefined,
-    Username: output.Username !== undefined && output.Username !== null ? output.Username : undefined,
+    Username: __expectString(output.Username),
   } as any;
 };
 
 const deserializeAws_json1_1RedshiftRetryOptions = (output: any, context: __SerdeContext): RedshiftRetryOptions => {
   return {
-    DurationInSeconds:
-      output.DurationInSeconds !== undefined && output.DurationInSeconds !== null
-        ? output.DurationInSeconds
-        : undefined,
+    DurationInSeconds: __expectNumber(output.DurationInSeconds),
   } as any;
 };
 
 const deserializeAws_json1_1ResourceInUseException = (output: any, context: __SerdeContext): ResourceInUseException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3257,7 +3175,7 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3266,7 +3184,7 @@ const deserializeAws_json1_1S3DestinationDescription = (
   context: __SerdeContext
 ): S3DestinationDescription => {
   return {
-    BucketARN: output.BucketARN !== undefined && output.BucketARN !== null ? output.BucketARN : undefined,
+    BucketARN: __expectString(output.BucketARN),
     BufferingHints:
       output.BufferingHints !== undefined && output.BufferingHints !== null
         ? deserializeAws_json1_1BufferingHints(output.BufferingHints, context)
@@ -3275,31 +3193,25 @@ const deserializeAws_json1_1S3DestinationDescription = (
       output.CloudWatchLoggingOptions !== undefined && output.CloudWatchLoggingOptions !== null
         ? deserializeAws_json1_1CloudWatchLoggingOptions(output.CloudWatchLoggingOptions, context)
         : undefined,
-    CompressionFormat:
-      output.CompressionFormat !== undefined && output.CompressionFormat !== null
-        ? output.CompressionFormat
-        : undefined,
+    CompressionFormat: __expectString(output.CompressionFormat),
     EncryptionConfiguration:
       output.EncryptionConfiguration !== undefined && output.EncryptionConfiguration !== null
         ? deserializeAws_json1_1EncryptionConfiguration(output.EncryptionConfiguration, context)
         : undefined,
-    ErrorOutputPrefix:
-      output.ErrorOutputPrefix !== undefined && output.ErrorOutputPrefix !== null
-        ? output.ErrorOutputPrefix
-        : undefined,
-    Prefix: output.Prefix !== undefined && output.Prefix !== null ? output.Prefix : undefined,
-    RoleARN: output.RoleARN !== undefined && output.RoleARN !== null ? output.RoleARN : undefined,
+    ErrorOutputPrefix: __expectString(output.ErrorOutputPrefix),
+    Prefix: __expectString(output.Prefix),
+    RoleARN: __expectString(output.RoleARN),
   } as any;
 };
 
 const deserializeAws_json1_1SchemaConfiguration = (output: any, context: __SerdeContext): SchemaConfiguration => {
   return {
-    CatalogId: output.CatalogId !== undefined && output.CatalogId !== null ? output.CatalogId : undefined,
-    DatabaseName: output.DatabaseName !== undefined && output.DatabaseName !== null ? output.DatabaseName : undefined,
-    Region: output.Region !== undefined && output.Region !== null ? output.Region : undefined,
-    RoleARN: output.RoleARN !== undefined && output.RoleARN !== null ? output.RoleARN : undefined,
-    TableName: output.TableName !== undefined && output.TableName !== null ? output.TableName : undefined,
-    VersionId: output.VersionId !== undefined && output.VersionId !== null ? output.VersionId : undefined,
+    CatalogId: __expectString(output.CatalogId),
+    DatabaseName: __expectString(output.DatabaseName),
+    Region: __expectString(output.Region),
+    RoleARN: __expectString(output.RoleARN),
+    TableName: __expectString(output.TableName),
+    VersionId: __expectString(output.VersionId),
   } as any;
 };
 
@@ -3310,7 +3222,7 @@ const deserializeAws_json1_1SecurityGroupIdList = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3332,7 +3244,7 @@ const deserializeAws_json1_1ServiceUnavailableException = (
   context: __SerdeContext
 ): ServiceUnavailableException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3354,14 +3266,10 @@ const deserializeAws_json1_1SplunkDestinationDescription = (
       output.CloudWatchLoggingOptions !== undefined && output.CloudWatchLoggingOptions !== null
         ? deserializeAws_json1_1CloudWatchLoggingOptions(output.CloudWatchLoggingOptions, context)
         : undefined,
-    HECAcknowledgmentTimeoutInSeconds:
-      output.HECAcknowledgmentTimeoutInSeconds !== undefined && output.HECAcknowledgmentTimeoutInSeconds !== null
-        ? output.HECAcknowledgmentTimeoutInSeconds
-        : undefined,
-    HECEndpoint: output.HECEndpoint !== undefined && output.HECEndpoint !== null ? output.HECEndpoint : undefined,
-    HECEndpointType:
-      output.HECEndpointType !== undefined && output.HECEndpointType !== null ? output.HECEndpointType : undefined,
-    HECToken: output.HECToken !== undefined && output.HECToken !== null ? output.HECToken : undefined,
+    HECAcknowledgmentTimeoutInSeconds: __expectNumber(output.HECAcknowledgmentTimeoutInSeconds),
+    HECEndpoint: __expectString(output.HECEndpoint),
+    HECEndpointType: __expectString(output.HECEndpointType),
+    HECToken: __expectString(output.HECToken),
     ProcessingConfiguration:
       output.ProcessingConfiguration !== undefined && output.ProcessingConfiguration !== null
         ? deserializeAws_json1_1ProcessingConfiguration(output.ProcessingConfiguration, context)
@@ -3370,7 +3278,7 @@ const deserializeAws_json1_1SplunkDestinationDescription = (
       output.RetryOptions !== undefined && output.RetryOptions !== null
         ? deserializeAws_json1_1SplunkRetryOptions(output.RetryOptions, context)
         : undefined,
-    S3BackupMode: output.S3BackupMode !== undefined && output.S3BackupMode !== null ? output.S3BackupMode : undefined,
+    S3BackupMode: __expectString(output.S3BackupMode),
     S3DestinationDescription:
       output.S3DestinationDescription !== undefined && output.S3DestinationDescription !== null
         ? deserializeAws_json1_1S3DestinationDescription(output.S3DestinationDescription, context)
@@ -3380,10 +3288,7 @@ const deserializeAws_json1_1SplunkDestinationDescription = (
 
 const deserializeAws_json1_1SplunkRetryOptions = (output: any, context: __SerdeContext): SplunkRetryOptions => {
   return {
-    DurationInSeconds:
-      output.DurationInSeconds !== undefined && output.DurationInSeconds !== null
-        ? output.DurationInSeconds
-        : undefined,
+    DurationInSeconds: __expectNumber(output.DurationInSeconds),
   } as any;
 };
 
@@ -3408,14 +3313,14 @@ const deserializeAws_json1_1SubnetIdList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -3445,7 +3350,7 @@ const deserializeAws_json1_1VpcConfigurationDescription = (
   context: __SerdeContext
 ): VpcConfigurationDescription => {
   return {
-    RoleARN: output.RoleARN !== undefined && output.RoleARN !== null ? output.RoleARN : undefined,
+    RoleARN: __expectString(output.RoleARN),
     SecurityGroupIds:
       output.SecurityGroupIds !== undefined && output.SecurityGroupIds !== null
         ? deserializeAws_json1_1SecurityGroupIdList(output.SecurityGroupIds, context)
@@ -3454,7 +3359,7 @@ const deserializeAws_json1_1VpcConfigurationDescription = (
       output.SubnetIds !== undefined && output.SubnetIds !== null
         ? deserializeAws_json1_1SubnetIdList(output.SubnetIds, context)
         : undefined,
-    VpcId: output.VpcId !== undefined && output.VpcId !== null ? output.VpcId : undefined,
+    VpcId: __expectString(output.VpcId),
   } as any;
 };
 

--- a/clients/client-fis/protocols/Aws_restJson1.ts
+++ b/clients/client-fis/protocols/Aws_restJson1.ts
@@ -64,6 +64,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -845,7 +847,7 @@ export const deserializeAws_restJson1ListActionsCommand = async (
     contents.actions = deserializeAws_restJson1ActionSummaryList(data.actions, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -904,7 +906,7 @@ export const deserializeAws_restJson1ListExperimentsCommand = async (
     contents.experiments = deserializeAws_restJson1ExperimentSummaryList(data.experiments, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -966,7 +968,7 @@ export const deserializeAws_restJson1ListExperimentTemplatesCommand = async (
     );
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1366,7 +1368,7 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1383,7 +1385,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1400,7 +1402,7 @@ const deserializeAws_restJson1ServiceQuotaExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1417,7 +1419,7 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1733,8 +1735,8 @@ const serializeAws_restJson1UpdateExperimentTemplateTargetInputMap = (
 
 const deserializeAws_restJson1Action = (output: any, context: __SerdeContext): Action => {
   return {
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    description: __expectString(output.description),
+    id: __expectString(output.id),
     parameters:
       output.parameters !== undefined && output.parameters !== null
         ? deserializeAws_restJson1ActionParameterMap(output.parameters, context)
@@ -1752,8 +1754,8 @@ const deserializeAws_restJson1Action = (output: any, context: __SerdeContext): A
 
 const deserializeAws_restJson1ActionParameter = (output: any, context: __SerdeContext): ActionParameter => {
   return {
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    required: output.required !== undefined && output.required !== null ? output.required : undefined,
+    description: __expectString(output.description),
+    required: __expectBoolean(output.required),
   } as any;
 };
 
@@ -1774,8 +1776,8 @@ const deserializeAws_restJson1ActionParameterMap = (
 
 const deserializeAws_restJson1ActionSummary = (output: any, context: __SerdeContext): ActionSummary => {
   return {
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    description: __expectString(output.description),
+    id: __expectString(output.id),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1TagMap(output.tags, context)
@@ -1800,7 +1802,7 @@ const deserializeAws_restJson1ActionSummaryList = (output: any, context: __Serde
 
 const deserializeAws_restJson1ActionTarget = (output: any, context: __SerdeContext): ActionTarget => {
   return {
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
+    resourceType: __expectString(output.resourceType),
   } as any;
 };
 
@@ -1831,12 +1833,9 @@ const deserializeAws_restJson1Experiment = (output: any, context: __SerdeContext
         : undefined,
     endTime:
       output.endTime !== undefined && output.endTime !== null ? new Date(Math.round(output.endTime * 1000)) : undefined,
-    experimentTemplateId:
-      output.experimentTemplateId !== undefined && output.experimentTemplateId !== null
-        ? output.experimentTemplateId
-        : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
+    experimentTemplateId: __expectString(output.experimentTemplateId),
+    id: __expectString(output.id),
+    roleArn: __expectString(output.roleArn),
     startTime:
       output.startTime !== undefined && output.startTime !== null
         ? new Date(Math.round(output.startTime * 1000))
@@ -1862,8 +1861,8 @@ const deserializeAws_restJson1Experiment = (output: any, context: __SerdeContext
 
 const deserializeAws_restJson1ExperimentAction = (output: any, context: __SerdeContext): ExperimentAction => {
   return {
-    actionId: output.actionId !== undefined && output.actionId !== null ? output.actionId : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    actionId: __expectString(output.actionId),
+    description: __expectString(output.description),
     parameters:
       output.parameters !== undefined && output.parameters !== null
         ? deserializeAws_restJson1ExperimentActionParameterMap(output.parameters, context)
@@ -1908,7 +1907,7 @@ const deserializeAws_restJson1ExperimentActionParameterMap = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -1920,14 +1919,14 @@ const deserializeAws_restJson1ExperimentActionStartAfterList = (output: any, con
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1ExperimentActionState = (output: any, context: __SerdeContext): ExperimentActionState => {
   return {
-    reason: output.reason !== undefined && output.reason !== null ? output.reason : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    reason: __expectString(output.reason),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -1941,15 +1940,15 @@ const deserializeAws_restJson1ExperimentActionTargetMap = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1ExperimentState = (output: any, context: __SerdeContext): ExperimentState => {
   return {
-    reason: output.reason !== undefined && output.reason !== null ? output.reason : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    reason: __expectString(output.reason),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -1958,8 +1957,8 @@ const deserializeAws_restJson1ExperimentStopCondition = (
   context: __SerdeContext
 ): ExperimentStopCondition => {
   return {
-    source: output.source !== undefined && output.source !== null ? output.source : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    source: __expectString(output.source),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -1983,11 +1982,8 @@ const deserializeAws_restJson1ExperimentSummary = (output: any, context: __Serde
       output.creationTime !== undefined && output.creationTime !== null
         ? new Date(Math.round(output.creationTime * 1000))
         : undefined,
-    experimentTemplateId:
-      output.experimentTemplateId !== undefined && output.experimentTemplateId !== null
-        ? output.experimentTemplateId
-        : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    experimentTemplateId: __expectString(output.experimentTemplateId),
+    id: __expectString(output.id),
     state:
       output.state !== undefined && output.state !== null
         ? deserializeAws_restJson1ExperimentState(output.state, context)
@@ -2024,9 +2020,8 @@ const deserializeAws_restJson1ExperimentTarget = (output: any, context: __SerdeC
       output.resourceTags !== undefined && output.resourceTags !== null
         ? deserializeAws_restJson1TagMap(output.resourceTags, context)
         : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
-    selectionMode:
-      output.selectionMode !== undefined && output.selectionMode !== null ? output.selectionMode : undefined,
+    resourceType: __expectString(output.resourceType),
+    selectionMode: __expectString(output.selectionMode),
   } as any;
 };
 
@@ -2035,7 +2030,7 @@ const deserializeAws_restJson1ExperimentTargetFilter = (
   context: __SerdeContext
 ): ExperimentTargetFilter => {
   return {
-    path: output.path !== undefined && output.path !== null ? output.path : undefined,
+    path: __expectString(output.path),
     values:
       output.values !== undefined && output.values !== null
         ? deserializeAws_restJson1ExperimentTargetFilterValues(output.values, context)
@@ -2064,7 +2059,7 @@ const deserializeAws_restJson1ExperimentTargetFilterValues = (output: any, conte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2093,13 +2088,13 @@ const deserializeAws_restJson1ExperimentTemplate = (output: any, context: __Serd
       output.creationTime !== undefined && output.creationTime !== null
         ? new Date(Math.round(output.creationTime * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    description: __expectString(output.description),
+    id: __expectString(output.id),
     lastUpdateTime:
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
         ? new Date(Math.round(output.lastUpdateTime * 1000))
         : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
+    roleArn: __expectString(output.roleArn),
     stopConditions:
       output.stopConditions !== undefined && output.stopConditions !== null
         ? deserializeAws_restJson1ExperimentTemplateStopConditionList(output.stopConditions, context)
@@ -2120,8 +2115,8 @@ const deserializeAws_restJson1ExperimentTemplateAction = (
   context: __SerdeContext
 ): ExperimentTemplateAction => {
   return {
-    actionId: output.actionId !== undefined && output.actionId !== null ? output.actionId : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    actionId: __expectString(output.actionId),
+    description: __expectString(output.description),
     parameters:
       output.parameters !== undefined && output.parameters !== null
         ? deserializeAws_restJson1ExperimentTemplateActionParameterMap(output.parameters, context)
@@ -2165,7 +2160,7 @@ const deserializeAws_restJson1ExperimentTemplateActionParameterMap = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -2180,7 +2175,7 @@ const deserializeAws_restJson1ExperimentTemplateActionStartAfterList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2194,7 +2189,7 @@ const deserializeAws_restJson1ExperimentTemplateActionTargetMap = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -2204,8 +2199,8 @@ const deserializeAws_restJson1ExperimentTemplateStopCondition = (
   context: __SerdeContext
 ): ExperimentTemplateStopCondition => {
   return {
-    source: output.source !== undefined && output.source !== null ? output.source : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    source: __expectString(output.source),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -2232,8 +2227,8 @@ const deserializeAws_restJson1ExperimentTemplateSummary = (
       output.creationTime !== undefined && output.creationTime !== null
         ? new Date(Math.round(output.creationTime * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    description: __expectString(output.description),
+    id: __expectString(output.id),
     lastUpdateTime:
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
         ? new Date(Math.round(output.lastUpdateTime * 1000))
@@ -2276,9 +2271,8 @@ const deserializeAws_restJson1ExperimentTemplateTarget = (
       output.resourceTags !== undefined && output.resourceTags !== null
         ? deserializeAws_restJson1TagMap(output.resourceTags, context)
         : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
-    selectionMode:
-      output.selectionMode !== undefined && output.selectionMode !== null ? output.selectionMode : undefined,
+    resourceType: __expectString(output.resourceType),
+    selectionMode: __expectString(output.selectionMode),
   } as any;
 };
 
@@ -2287,7 +2281,7 @@ const deserializeAws_restJson1ExperimentTemplateTargetFilter = (
   context: __SerdeContext
 ): ExperimentTemplateTargetFilter => {
   return {
-    path: output.path !== undefined && output.path !== null ? output.path : undefined,
+    path: __expectString(output.path),
     values:
       output.values !== undefined && output.values !== null
         ? deserializeAws_restJson1ExperimentTemplateTargetFilterValues(output.values, context)
@@ -2319,7 +2313,7 @@ const deserializeAws_restJson1ExperimentTemplateTargetFilterValues = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2348,7 +2342,7 @@ const deserializeAws_restJson1ResourceArnList = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2359,7 +2353,7 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };

--- a/clients/client-fms/protocols/Aws_json1_1.ts
+++ b/clients/client-fms/protocols/Aws_json1_1.ts
@@ -145,7 +145,12 @@ import {
   ViolationDetail,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -2968,9 +2973,9 @@ const serializeAws_json1_1UntagResourceRequest = (input: UntagResourceRequest, c
 
 const deserializeAws_json1_1App = (output: any, context: __SerdeContext): App => {
   return {
-    AppName: output.AppName !== undefined && output.AppName !== null ? output.AppName : undefined,
-    Port: output.Port !== undefined && output.Port !== null ? output.Port : undefined,
-    Protocol: output.Protocol !== undefined && output.Protocol !== null ? output.Protocol : undefined,
+    AppName: __expectString(output.AppName),
+    Port: __expectNumber(output.Port),
+    Protocol: __expectString(output.Protocol),
   } as any;
 };
 
@@ -2999,10 +3004,9 @@ const deserializeAws_json1_1AppsListData = (output: any, context: __SerdeContext
       output.LastUpdateTime !== undefined && output.LastUpdateTime !== null
         ? new Date(Math.round(output.LastUpdateTime * 1000))
         : undefined,
-    ListId: output.ListId !== undefined && output.ListId !== null ? output.ListId : undefined,
-    ListName: output.ListName !== undefined && output.ListName !== null ? output.ListName : undefined,
-    ListUpdateToken:
-      output.ListUpdateToken !== undefined && output.ListUpdateToken !== null ? output.ListUpdateToken : undefined,
+    ListId: __expectString(output.ListId),
+    ListName: __expectString(output.ListName),
+    ListUpdateToken: __expectString(output.ListUpdateToken),
     PreviousAppsList:
       output.PreviousAppsList !== undefined && output.PreviousAppsList !== null
         ? deserializeAws_json1_1PreviousAppsList(output.PreviousAppsList, context)
@@ -3016,9 +3020,9 @@ const deserializeAws_json1_1AppsListDataSummary = (output: any, context: __Serde
       output.AppsList !== undefined && output.AppsList !== null
         ? deserializeAws_json1_1AppsList(output.AppsList, context)
         : undefined,
-    ListArn: output.ListArn !== undefined && output.ListArn !== null ? output.ListArn : undefined,
-    ListId: output.ListId !== undefined && output.ListId !== null ? output.ListId : undefined,
-    ListName: output.ListName !== undefined && output.ListName !== null ? output.ListName : undefined,
+    ListArn: __expectString(output.ListArn),
+    ListId: __expectString(output.ListId),
+    ListName: __expectString(output.ListName),
   } as any;
 };
 
@@ -3042,8 +3046,7 @@ const deserializeAws_json1_1AwsEc2InstanceViolation = (
       output.AwsEc2NetworkInterfaceViolations !== undefined && output.AwsEc2NetworkInterfaceViolations !== null
         ? deserializeAws_json1_1AwsEc2NetworkInterfaceViolations(output.AwsEc2NetworkInterfaceViolations, context)
         : undefined,
-    ViolationTarget:
-      output.ViolationTarget !== undefined && output.ViolationTarget !== null ? output.ViolationTarget : undefined,
+    ViolationTarget: __expectString(output.ViolationTarget),
   } as any;
 };
 
@@ -3056,8 +3059,7 @@ const deserializeAws_json1_1AwsEc2NetworkInterfaceViolation = (
       output.ViolatingSecurityGroups !== undefined && output.ViolatingSecurityGroups !== null
         ? deserializeAws_json1_1ResourceIdList(output.ViolatingSecurityGroups, context)
         : undefined,
-    ViolationTarget:
-      output.ViolationTarget !== undefined && output.ViolationTarget !== null ? output.ViolationTarget : undefined,
+    ViolationTarget: __expectString(output.ViolationTarget),
   } as any;
 };
 
@@ -3089,21 +3091,16 @@ const deserializeAws_json1_1AwsVPCSecurityGroupViolation = (
       output.PossibleSecurityGroupRemediationActions !== null
         ? deserializeAws_json1_1SecurityGroupRemediationActions(output.PossibleSecurityGroupRemediationActions, context)
         : undefined,
-    ViolationTarget:
-      output.ViolationTarget !== undefined && output.ViolationTarget !== null ? output.ViolationTarget : undefined,
-    ViolationTargetDescription:
-      output.ViolationTargetDescription !== undefined && output.ViolationTargetDescription !== null
-        ? output.ViolationTargetDescription
-        : undefined,
+    ViolationTarget: __expectString(output.ViolationTarget),
+    ViolationTargetDescription: __expectString(output.ViolationTargetDescription),
   } as any;
 };
 
 const deserializeAws_json1_1ComplianceViolator = (output: any, context: __SerdeContext): ComplianceViolator => {
   return {
-    ResourceId: output.ResourceId !== undefined && output.ResourceId !== null ? output.ResourceId : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
-    ViolationReason:
-      output.ViolationReason !== undefined && output.ViolationReason !== null ? output.ViolationReason : undefined,
+    ResourceId: __expectString(output.ResourceId),
+    ResourceType: __expectString(output.ResourceType),
+    ViolationReason: __expectString(output.ViolationReason),
   } as any;
 };
 
@@ -3125,7 +3122,7 @@ const deserializeAws_json1_1CustomerPolicyScopeIdList = (output: any, context: _
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3152,12 +3149,8 @@ const deserializeAws_json1_1DnsDuplicateRuleGroupViolation = (
   context: __SerdeContext
 ): DnsDuplicateRuleGroupViolation => {
   return {
-    ViolationTarget:
-      output.ViolationTarget !== undefined && output.ViolationTarget !== null ? output.ViolationTarget : undefined,
-    ViolationTargetDescription:
-      output.ViolationTargetDescription !== undefined && output.ViolationTargetDescription !== null
-        ? output.ViolationTargetDescription
-        : undefined,
+    ViolationTarget: __expectString(output.ViolationTarget),
+    ViolationTargetDescription: __expectString(output.ViolationTargetDescription),
   } as any;
 };
 
@@ -3166,16 +3159,9 @@ const deserializeAws_json1_1DnsRuleGroupLimitExceededViolation = (
   context: __SerdeContext
 ): DnsRuleGroupLimitExceededViolation => {
   return {
-    NumberOfRuleGroupsAlreadyAssociated:
-      output.NumberOfRuleGroupsAlreadyAssociated !== undefined && output.NumberOfRuleGroupsAlreadyAssociated !== null
-        ? output.NumberOfRuleGroupsAlreadyAssociated
-        : undefined,
-    ViolationTarget:
-      output.ViolationTarget !== undefined && output.ViolationTarget !== null ? output.ViolationTarget : undefined,
-    ViolationTargetDescription:
-      output.ViolationTargetDescription !== undefined && output.ViolationTargetDescription !== null
-        ? output.ViolationTargetDescription
-        : undefined,
+    NumberOfRuleGroupsAlreadyAssociated: __expectNumber(output.NumberOfRuleGroupsAlreadyAssociated),
+    ViolationTarget: __expectString(output.ViolationTarget),
+    ViolationTargetDescription: __expectString(output.ViolationTargetDescription),
   } as any;
 };
 
@@ -3186,7 +3172,7 @@ const deserializeAws_json1_1DnsRuleGroupPriorities = (output: any, context: __Se
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectNumber(entry) as any;
     });
 };
 
@@ -3195,37 +3181,22 @@ const deserializeAws_json1_1DnsRuleGroupPriorityConflictViolation = (
   context: __SerdeContext
 ): DnsRuleGroupPriorityConflictViolation => {
   return {
-    ConflictingPolicyId:
-      output.ConflictingPolicyId !== undefined && output.ConflictingPolicyId !== null
-        ? output.ConflictingPolicyId
-        : undefined,
-    ConflictingPriority:
-      output.ConflictingPriority !== undefined && output.ConflictingPriority !== null
-        ? output.ConflictingPriority
-        : undefined,
+    ConflictingPolicyId: __expectString(output.ConflictingPolicyId),
+    ConflictingPriority: __expectNumber(output.ConflictingPriority),
     UnavailablePriorities:
       output.UnavailablePriorities !== undefined && output.UnavailablePriorities !== null
         ? deserializeAws_json1_1DnsRuleGroupPriorities(output.UnavailablePriorities, context)
         : undefined,
-    ViolationTarget:
-      output.ViolationTarget !== undefined && output.ViolationTarget !== null ? output.ViolationTarget : undefined,
-    ViolationTargetDescription:
-      output.ViolationTargetDescription !== undefined && output.ViolationTargetDescription !== null
-        ? output.ViolationTargetDescription
-        : undefined,
+    ViolationTarget: __expectString(output.ViolationTarget),
+    ViolationTargetDescription: __expectString(output.ViolationTargetDescription),
   } as any;
 };
 
 const deserializeAws_json1_1EvaluationResult = (output: any, context: __SerdeContext): EvaluationResult => {
   return {
-    ComplianceStatus:
-      output.ComplianceStatus !== undefined && output.ComplianceStatus !== null ? output.ComplianceStatus : undefined,
-    EvaluationLimitExceeded:
-      output.EvaluationLimitExceeded !== undefined && output.EvaluationLimitExceeded !== null
-        ? output.EvaluationLimitExceeded
-        : undefined,
-    ViolatorCount:
-      output.ViolatorCount !== undefined && output.ViolatorCount !== null ? output.ViolatorCount : undefined,
+    ComplianceStatus: __expectString(output.ComplianceStatus),
+    EvaluationLimitExceeded: __expectBoolean(output.EvaluationLimitExceeded),
+    ViolatorCount: __expectNumber(output.ViolatorCount),
   } as any;
 };
 
@@ -3245,8 +3216,8 @@ const deserializeAws_json1_1GetAdminAccountResponse = (
   context: __SerdeContext
 ): GetAdminAccountResponse => {
   return {
-    AdminAccount: output.AdminAccount !== undefined && output.AdminAccount !== null ? output.AdminAccount : undefined,
-    RoleStatus: output.RoleStatus !== undefined && output.RoleStatus !== null ? output.RoleStatus : undefined,
+    AdminAccount: __expectString(output.AdminAccount),
+    RoleStatus: __expectString(output.RoleStatus),
   } as any;
 };
 
@@ -3256,7 +3227,7 @@ const deserializeAws_json1_1GetAppsListResponse = (output: any, context: __Serde
       output.AppsList !== undefined && output.AppsList !== null
         ? deserializeAws_json1_1AppsListData(output.AppsList, context)
         : undefined,
-    AppsListArn: output.AppsListArn !== undefined && output.AppsListArn !== null ? output.AppsListArn : undefined,
+    AppsListArn: __expectString(output.AppsListArn),
   } as any;
 };
 
@@ -3277,8 +3248,8 @@ const deserializeAws_json1_1GetNotificationChannelResponse = (
   context: __SerdeContext
 ): GetNotificationChannelResponse => {
   return {
-    SnsRoleName: output.SnsRoleName !== undefined && output.SnsRoleName !== null ? output.SnsRoleName : undefined,
-    SnsTopicArn: output.SnsTopicArn !== undefined && output.SnsTopicArn !== null ? output.SnsTopicArn : undefined,
+    SnsRoleName: __expectString(output.SnsRoleName),
+    SnsTopicArn: __expectString(output.SnsTopicArn),
   } as any;
 };
 
@@ -3288,7 +3259,7 @@ const deserializeAws_json1_1GetPolicyResponse = (output: any, context: __SerdeCo
       output.Policy !== undefined && output.Policy !== null
         ? deserializeAws_json1_1Policy(output.Policy, context)
         : undefined,
-    PolicyArn: output.PolicyArn !== undefined && output.PolicyArn !== null ? output.PolicyArn : undefined,
+    PolicyArn: __expectString(output.PolicyArn),
   } as any;
 };
 
@@ -3297,11 +3268,10 @@ const deserializeAws_json1_1GetProtectionStatusResponse = (
   context: __SerdeContext
 ): GetProtectionStatusResponse => {
   return {
-    AdminAccountId:
-      output.AdminAccountId !== undefined && output.AdminAccountId !== null ? output.AdminAccountId : undefined,
-    Data: output.Data !== undefined && output.Data !== null ? output.Data : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
-    ServiceType: output.ServiceType !== undefined && output.ServiceType !== null ? output.ServiceType : undefined,
+    AdminAccountId: __expectString(output.AdminAccountId),
+    Data: __expectString(output.Data),
+    NextToken: __expectString(output.NextToken),
+    ServiceType: __expectString(output.ServiceType),
   } as any;
 };
 
@@ -3314,8 +3284,7 @@ const deserializeAws_json1_1GetProtocolsListResponse = (
       output.ProtocolsList !== undefined && output.ProtocolsList !== null
         ? deserializeAws_json1_1ProtocolsListData(output.ProtocolsList, context)
         : undefined,
-    ProtocolsListArn:
-      output.ProtocolsListArn !== undefined && output.ProtocolsListArn !== null ? output.ProtocolsListArn : undefined,
+    ProtocolsListArn: __expectString(output.ProtocolsListArn),
   } as any;
 };
 
@@ -3333,13 +3302,13 @@ const deserializeAws_json1_1GetViolationDetailsResponse = (
 
 const deserializeAws_json1_1InternalErrorException = (output: any, context: __SerdeContext): InternalErrorException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidInputException = (output: any, context: __SerdeContext): InvalidInputException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3348,13 +3317,13 @@ const deserializeAws_json1_1InvalidOperationException = (
   context: __SerdeContext
 ): InvalidOperationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidTypeException = (output: any, context: __SerdeContext): InvalidTypeException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3366,7 +3335,7 @@ const deserializeAws_json1_1IssueInfoMap = (output: any, context: __SerdeContext
       }
       return {
         ...acc,
-        [key]: value,
+        [key]: __expectString(value) as any,
       };
     },
     {}
@@ -3375,7 +3344,7 @@ const deserializeAws_json1_1IssueInfoMap = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3385,7 +3354,7 @@ const deserializeAws_json1_1ListAppsListsResponse = (output: any, context: __Ser
       output.AppsLists !== undefined && output.AppsLists !== null
         ? deserializeAws_json1_1AppsListsData(output.AppsLists, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -3394,7 +3363,7 @@ const deserializeAws_json1_1ListComplianceStatusResponse = (
   context: __SerdeContext
 ): ListComplianceStatusResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     PolicyComplianceStatusList:
       output.PolicyComplianceStatusList !== undefined && output.PolicyComplianceStatusList !== null
         ? deserializeAws_json1_1PolicyComplianceStatusList(output.PolicyComplianceStatusList, context)
@@ -3411,13 +3380,13 @@ const deserializeAws_json1_1ListMemberAccountsResponse = (
       output.MemberAccounts !== undefined && output.MemberAccounts !== null
         ? deserializeAws_json1_1MemberAccounts(output.MemberAccounts, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
 const deserializeAws_json1_1ListPoliciesResponse = (output: any, context: __SerdeContext): ListPoliciesResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     PolicyList:
       output.PolicyList !== undefined && output.PolicyList !== null
         ? deserializeAws_json1_1PolicySummaryList(output.PolicyList, context)
@@ -3430,7 +3399,7 @@ const deserializeAws_json1_1ListProtocolsListsResponse = (
   context: __SerdeContext
 ): ListProtocolsListsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     ProtocolsLists:
       output.ProtocolsLists !== undefined && output.ProtocolsLists !== null
         ? deserializeAws_json1_1ProtocolsListsData(output.ProtocolsLists, context)
@@ -3457,7 +3426,7 @@ const deserializeAws_json1_1MemberAccounts = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3468,7 +3437,7 @@ const deserializeAws_json1_1NetworkFirewallActionList = (output: any, context: _
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3477,19 +3446,11 @@ const deserializeAws_json1_1NetworkFirewallMissingExpectedRTViolation = (
   context: __SerdeContext
 ): NetworkFirewallMissingExpectedRTViolation => {
   return {
-    AvailabilityZone:
-      output.AvailabilityZone !== undefined && output.AvailabilityZone !== null ? output.AvailabilityZone : undefined,
-    CurrentRouteTable:
-      output.CurrentRouteTable !== undefined && output.CurrentRouteTable !== null
-        ? output.CurrentRouteTable
-        : undefined,
-    ExpectedRouteTable:
-      output.ExpectedRouteTable !== undefined && output.ExpectedRouteTable !== null
-        ? output.ExpectedRouteTable
-        : undefined,
-    VPC: output.VPC !== undefined && output.VPC !== null ? output.VPC : undefined,
-    ViolationTarget:
-      output.ViolationTarget !== undefined && output.ViolationTarget !== null ? output.ViolationTarget : undefined,
+    AvailabilityZone: __expectString(output.AvailabilityZone),
+    CurrentRouteTable: __expectString(output.CurrentRouteTable),
+    ExpectedRouteTable: __expectString(output.ExpectedRouteTable),
+    VPC: __expectString(output.VPC),
+    ViolationTarget: __expectString(output.ViolationTarget),
   } as any;
 };
 
@@ -3498,15 +3459,10 @@ const deserializeAws_json1_1NetworkFirewallMissingFirewallViolation = (
   context: __SerdeContext
 ): NetworkFirewallMissingFirewallViolation => {
   return {
-    AvailabilityZone:
-      output.AvailabilityZone !== undefined && output.AvailabilityZone !== null ? output.AvailabilityZone : undefined,
-    TargetViolationReason:
-      output.TargetViolationReason !== undefined && output.TargetViolationReason !== null
-        ? output.TargetViolationReason
-        : undefined,
-    VPC: output.VPC !== undefined && output.VPC !== null ? output.VPC : undefined,
-    ViolationTarget:
-      output.ViolationTarget !== undefined && output.ViolationTarget !== null ? output.ViolationTarget : undefined,
+    AvailabilityZone: __expectString(output.AvailabilityZone),
+    TargetViolationReason: __expectString(output.TargetViolationReason),
+    VPC: __expectString(output.VPC),
+    ViolationTarget: __expectString(output.ViolationTarget),
   } as any;
 };
 
@@ -3515,15 +3471,10 @@ const deserializeAws_json1_1NetworkFirewallMissingSubnetViolation = (
   context: __SerdeContext
 ): NetworkFirewallMissingSubnetViolation => {
   return {
-    AvailabilityZone:
-      output.AvailabilityZone !== undefined && output.AvailabilityZone !== null ? output.AvailabilityZone : undefined,
-    TargetViolationReason:
-      output.TargetViolationReason !== undefined && output.TargetViolationReason !== null
-        ? output.TargetViolationReason
-        : undefined,
-    VPC: output.VPC !== undefined && output.VPC !== null ? output.VPC : undefined,
-    ViolationTarget:
-      output.ViolationTarget !== undefined && output.ViolationTarget !== null ? output.ViolationTarget : undefined,
+    AvailabilityZone: __expectString(output.AvailabilityZone),
+    TargetViolationReason: __expectString(output.TargetViolationReason),
+    VPC: __expectString(output.VPC),
+    ViolationTarget: __expectString(output.ViolationTarget),
   } as any;
 };
 
@@ -3568,14 +3519,13 @@ const deserializeAws_json1_1NetworkFirewallPolicyModifiedViolation = (
       output.ExpectedPolicyDescription !== undefined && output.ExpectedPolicyDescription !== null
         ? deserializeAws_json1_1NetworkFirewallPolicyDescription(output.ExpectedPolicyDescription, context)
         : undefined,
-    ViolationTarget:
-      output.ViolationTarget !== undefined && output.ViolationTarget !== null ? output.ViolationTarget : undefined,
+    ViolationTarget: __expectString(output.ViolationTarget),
   } as any;
 };
 
 const deserializeAws_json1_1PartialMatch = (output: any, context: __SerdeContext): PartialMatch => {
   return {
-    Reference: output.Reference !== undefined && output.Reference !== null ? output.Reference : undefined,
+    Reference: __expectString(output.Reference),
     TargetViolationReasons:
       output.TargetViolationReasons !== undefined && output.TargetViolationReasons !== null
         ? deserializeAws_json1_1TargetViolationReasons(output.TargetViolationReasons, context)
@@ -3600,29 +3550,20 @@ const deserializeAws_json1_1Policy = (output: any, context: __SerdeContext): Pol
       output.ExcludeMap !== undefined && output.ExcludeMap !== null
         ? deserializeAws_json1_1CustomerPolicyScopeMap(output.ExcludeMap, context)
         : undefined,
-    ExcludeResourceTags:
-      output.ExcludeResourceTags !== undefined && output.ExcludeResourceTags !== null
-        ? output.ExcludeResourceTags
-        : undefined,
+    ExcludeResourceTags: __expectBoolean(output.ExcludeResourceTags),
     IncludeMap:
       output.IncludeMap !== undefined && output.IncludeMap !== null
         ? deserializeAws_json1_1CustomerPolicyScopeMap(output.IncludeMap, context)
         : undefined,
-    PolicyId: output.PolicyId !== undefined && output.PolicyId !== null ? output.PolicyId : undefined,
-    PolicyName: output.PolicyName !== undefined && output.PolicyName !== null ? output.PolicyName : undefined,
-    PolicyUpdateToken:
-      output.PolicyUpdateToken !== undefined && output.PolicyUpdateToken !== null
-        ? output.PolicyUpdateToken
-        : undefined,
-    RemediationEnabled:
-      output.RemediationEnabled !== undefined && output.RemediationEnabled !== null
-        ? output.RemediationEnabled
-        : undefined,
+    PolicyId: __expectString(output.PolicyId),
+    PolicyName: __expectString(output.PolicyName),
+    PolicyUpdateToken: __expectString(output.PolicyUpdateToken),
+    RemediationEnabled: __expectBoolean(output.RemediationEnabled),
     ResourceTags:
       output.ResourceTags !== undefined && output.ResourceTags !== null
         ? deserializeAws_json1_1ResourceTags(output.ResourceTags, context)
         : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
+    ResourceType: __expectString(output.ResourceType),
     ResourceTypeList:
       output.ResourceTypeList !== undefined && output.ResourceTypeList !== null
         ? deserializeAws_json1_1ResourceTypeList(output.ResourceTypeList, context)
@@ -3636,10 +3577,7 @@ const deserializeAws_json1_1Policy = (output: any, context: __SerdeContext): Pol
 
 const deserializeAws_json1_1PolicyComplianceDetail = (output: any, context: __SerdeContext): PolicyComplianceDetail => {
   return {
-    EvaluationLimitExceeded:
-      output.EvaluationLimitExceeded !== undefined && output.EvaluationLimitExceeded !== null
-        ? output.EvaluationLimitExceeded
-        : undefined,
+    EvaluationLimitExceeded: __expectBoolean(output.EvaluationLimitExceeded),
     ExpiredAt:
       output.ExpiredAt !== undefined && output.ExpiredAt !== null
         ? new Date(Math.round(output.ExpiredAt * 1000))
@@ -3648,10 +3586,9 @@ const deserializeAws_json1_1PolicyComplianceDetail = (output: any, context: __Se
       output.IssueInfoMap !== undefined && output.IssueInfoMap !== null
         ? deserializeAws_json1_1IssueInfoMap(output.IssueInfoMap, context)
         : undefined,
-    MemberAccount:
-      output.MemberAccount !== undefined && output.MemberAccount !== null ? output.MemberAccount : undefined,
-    PolicyId: output.PolicyId !== undefined && output.PolicyId !== null ? output.PolicyId : undefined,
-    PolicyOwner: output.PolicyOwner !== undefined && output.PolicyOwner !== null ? output.PolicyOwner : undefined,
+    MemberAccount: __expectString(output.MemberAccount),
+    PolicyId: __expectString(output.PolicyId),
+    PolicyOwner: __expectString(output.PolicyOwner),
     Violators:
       output.Violators !== undefined && output.Violators !== null
         ? deserializeAws_json1_1ComplianceViolators(output.Violators, context)
@@ -3673,11 +3610,10 @@ const deserializeAws_json1_1PolicyComplianceStatus = (output: any, context: __Se
       output.LastUpdated !== undefined && output.LastUpdated !== null
         ? new Date(Math.round(output.LastUpdated * 1000))
         : undefined,
-    MemberAccount:
-      output.MemberAccount !== undefined && output.MemberAccount !== null ? output.MemberAccount : undefined,
-    PolicyId: output.PolicyId !== undefined && output.PolicyId !== null ? output.PolicyId : undefined,
-    PolicyName: output.PolicyName !== undefined && output.PolicyName !== null ? output.PolicyName : undefined,
-    PolicyOwner: output.PolicyOwner !== undefined && output.PolicyOwner !== null ? output.PolicyOwner : undefined,
+    MemberAccount: __expectString(output.MemberAccount),
+    PolicyId: __expectString(output.PolicyId),
+    PolicyName: __expectString(output.PolicyName),
+    PolicyOwner: __expectString(output.PolicyOwner),
   } as any;
 };
 
@@ -3697,18 +3633,12 @@ const deserializeAws_json1_1PolicyComplianceStatusList = (
 
 const deserializeAws_json1_1PolicySummary = (output: any, context: __SerdeContext): PolicySummary => {
   return {
-    PolicyArn: output.PolicyArn !== undefined && output.PolicyArn !== null ? output.PolicyArn : undefined,
-    PolicyId: output.PolicyId !== undefined && output.PolicyId !== null ? output.PolicyId : undefined,
-    PolicyName: output.PolicyName !== undefined && output.PolicyName !== null ? output.PolicyName : undefined,
-    RemediationEnabled:
-      output.RemediationEnabled !== undefined && output.RemediationEnabled !== null
-        ? output.RemediationEnabled
-        : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
-    SecurityServiceType:
-      output.SecurityServiceType !== undefined && output.SecurityServiceType !== null
-        ? output.SecurityServiceType
-        : undefined,
+    PolicyArn: __expectString(output.PolicyArn),
+    PolicyId: __expectString(output.PolicyId),
+    PolicyName: __expectString(output.PolicyName),
+    RemediationEnabled: __expectBoolean(output.RemediationEnabled),
+    ResourceType: __expectString(output.ResourceType),
+    SecurityServiceType: __expectString(output.SecurityServiceType),
   } as any;
 };
 
@@ -3757,7 +3687,7 @@ const deserializeAws_json1_1ProtocolsList = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3771,10 +3701,9 @@ const deserializeAws_json1_1ProtocolsListData = (output: any, context: __SerdeCo
       output.LastUpdateTime !== undefined && output.LastUpdateTime !== null
         ? new Date(Math.round(output.LastUpdateTime * 1000))
         : undefined,
-    ListId: output.ListId !== undefined && output.ListId !== null ? output.ListId : undefined,
-    ListName: output.ListName !== undefined && output.ListName !== null ? output.ListName : undefined,
-    ListUpdateToken:
-      output.ListUpdateToken !== undefined && output.ListUpdateToken !== null ? output.ListUpdateToken : undefined,
+    ListId: __expectString(output.ListId),
+    ListName: __expectString(output.ListName),
+    ListUpdateToken: __expectString(output.ListUpdateToken),
     PreviousProtocolsList:
       output.PreviousProtocolsList !== undefined && output.PreviousProtocolsList !== null
         ? deserializeAws_json1_1PreviousProtocolsList(output.PreviousProtocolsList, context)
@@ -3791,9 +3720,9 @@ const deserializeAws_json1_1ProtocolsListDataSummary = (
   context: __SerdeContext
 ): ProtocolsListDataSummary => {
   return {
-    ListArn: output.ListArn !== undefined && output.ListArn !== null ? output.ListArn : undefined,
-    ListId: output.ListId !== undefined && output.ListId !== null ? output.ListId : undefined,
-    ListName: output.ListName !== undefined && output.ListName !== null ? output.ListName : undefined,
+    ListArn: __expectString(output.ListArn),
+    ListId: __expectString(output.ListId),
+    ListName: __expectString(output.ListName),
     ProtocolsList:
       output.ProtocolsList !== undefined && output.ProtocolsList !== null
         ? deserializeAws_json1_1ProtocolsList(output.ProtocolsList, context)
@@ -3818,7 +3747,7 @@ const deserializeAws_json1_1PutAppsListResponse = (output: any, context: __Serde
       output.AppsList !== undefined && output.AppsList !== null
         ? deserializeAws_json1_1AppsListData(output.AppsList, context)
         : undefined,
-    AppsListArn: output.AppsListArn !== undefined && output.AppsListArn !== null ? output.AppsListArn : undefined,
+    AppsListArn: __expectString(output.AppsListArn),
   } as any;
 };
 
@@ -3828,7 +3757,7 @@ const deserializeAws_json1_1PutPolicyResponse = (output: any, context: __SerdeCo
       output.Policy !== undefined && output.Policy !== null
         ? deserializeAws_json1_1Policy(output.Policy, context)
         : undefined,
-    PolicyArn: output.PolicyArn !== undefined && output.PolicyArn !== null ? output.PolicyArn : undefined,
+    PolicyArn: __expectString(output.PolicyArn),
   } as any;
 };
 
@@ -3841,8 +3770,7 @@ const deserializeAws_json1_1PutProtocolsListResponse = (
       output.ProtocolsList !== undefined && output.ProtocolsList !== null
         ? deserializeAws_json1_1ProtocolsListData(output.ProtocolsList, context)
         : undefined,
-    ProtocolsListArn:
-      output.ProtocolsListArn !== undefined && output.ProtocolsListArn !== null ? output.ProtocolsListArn : undefined,
+    ProtocolsListArn: __expectString(output.ProtocolsListArn),
   } as any;
 };
 
@@ -3853,7 +3781,7 @@ const deserializeAws_json1_1ResourceIdList = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3862,14 +3790,14 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1ResourceTag = (output: any, context: __SerdeContext): ResourceTag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -3891,7 +3819,7 @@ const deserializeAws_json1_1ResourceTypeList = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3976,13 +3904,9 @@ const deserializeAws_json1_1SecurityGroupRemediationAction = (
   context: __SerdeContext
 ): SecurityGroupRemediationAction => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    IsDefaultAction:
-      output.IsDefaultAction !== undefined && output.IsDefaultAction !== null ? output.IsDefaultAction : undefined,
-    RemediationActionType:
-      output.RemediationActionType !== undefined && output.RemediationActionType !== null
-        ? output.RemediationActionType
-        : undefined,
+    Description: __expectString(output.Description),
+    IsDefaultAction: __expectBoolean(output.IsDefaultAction),
+    RemediationActionType: __expectString(output.RemediationActionType),
     RemediationResult:
       output.RemediationResult !== undefined && output.RemediationResult !== null
         ? deserializeAws_json1_1SecurityGroupRuleDescription(output.RemediationResult, context)
@@ -4009,12 +3933,12 @@ const deserializeAws_json1_1SecurityGroupRuleDescription = (
   context: __SerdeContext
 ): SecurityGroupRuleDescription => {
   return {
-    FromPort: output.FromPort !== undefined && output.FromPort !== null ? output.FromPort : undefined,
-    IPV4Range: output.IPV4Range !== undefined && output.IPV4Range !== null ? output.IPV4Range : undefined,
-    IPV6Range: output.IPV6Range !== undefined && output.IPV6Range !== null ? output.IPV6Range : undefined,
-    PrefixListId: output.PrefixListId !== undefined && output.PrefixListId !== null ? output.PrefixListId : undefined,
-    Protocol: output.Protocol !== undefined && output.Protocol !== null ? output.Protocol : undefined,
-    ToPort: output.ToPort !== undefined && output.ToPort !== null ? output.ToPort : undefined,
+    FromPort: __expectNumber(output.FromPort),
+    IPV4Range: __expectString(output.IPV4Range),
+    IPV6Range: __expectString(output.IPV6Range),
+    PrefixListId: __expectString(output.PrefixListId),
+    Protocol: __expectString(output.Protocol),
+    ToPort: __expectNumber(output.ToPort),
   } as any;
 };
 
@@ -4023,19 +3947,15 @@ const deserializeAws_json1_1SecurityServicePolicyData = (
   context: __SerdeContext
 ): SecurityServicePolicyData => {
   return {
-    ManagedServiceData:
-      output.ManagedServiceData !== undefined && output.ManagedServiceData !== null
-        ? output.ManagedServiceData
-        : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    ManagedServiceData: __expectString(output.ManagedServiceData),
+    Type: __expectString(output.Type),
   } as any;
 };
 
 const deserializeAws_json1_1StatefulRuleGroup = (output: any, context: __SerdeContext): StatefulRuleGroup => {
   return {
-    ResourceId: output.ResourceId !== undefined && output.ResourceId !== null ? output.ResourceId : undefined,
-    RuleGroupName:
-      output.RuleGroupName !== undefined && output.RuleGroupName !== null ? output.RuleGroupName : undefined,
+    ResourceId: __expectString(output.ResourceId),
+    RuleGroupName: __expectString(output.RuleGroupName),
   } as any;
 };
 
@@ -4052,10 +3972,9 @@ const deserializeAws_json1_1StatefulRuleGroupList = (output: any, context: __Ser
 
 const deserializeAws_json1_1StatelessRuleGroup = (output: any, context: __SerdeContext): StatelessRuleGroup => {
   return {
-    Priority: output.Priority !== undefined && output.Priority !== null ? output.Priority : undefined,
-    ResourceId: output.ResourceId !== undefined && output.ResourceId !== null ? output.ResourceId : undefined,
-    RuleGroupName:
-      output.RuleGroupName !== undefined && output.RuleGroupName !== null ? output.RuleGroupName : undefined,
+    Priority: __expectNumber(output.Priority),
+    ResourceId: __expectString(output.ResourceId),
+    RuleGroupName: __expectString(output.RuleGroupName),
   } as any;
 };
 
@@ -4072,8 +3991,8 @@ const deserializeAws_json1_1StatelessRuleGroupList = (output: any, context: __Se
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -4099,7 +4018,7 @@ const deserializeAws_json1_1TargetViolationReasons = (output: any, context: __Se
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4109,19 +4028,15 @@ const deserializeAws_json1_1UntagResourceResponse = (output: any, context: __Ser
 
 const deserializeAws_json1_1ViolationDetail = (output: any, context: __SerdeContext): ViolationDetail => {
   return {
-    MemberAccount:
-      output.MemberAccount !== undefined && output.MemberAccount !== null ? output.MemberAccount : undefined,
-    PolicyId: output.PolicyId !== undefined && output.PolicyId !== null ? output.PolicyId : undefined,
-    ResourceDescription:
-      output.ResourceDescription !== undefined && output.ResourceDescription !== null
-        ? output.ResourceDescription
-        : undefined,
-    ResourceId: output.ResourceId !== undefined && output.ResourceId !== null ? output.ResourceId : undefined,
+    MemberAccount: __expectString(output.MemberAccount),
+    PolicyId: __expectString(output.PolicyId),
+    ResourceDescription: __expectString(output.ResourceDescription),
+    ResourceId: __expectString(output.ResourceId),
     ResourceTags:
       output.ResourceTags !== undefined && output.ResourceTags !== null
         ? deserializeAws_json1_1TagList(output.ResourceTags, context)
         : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
+    ResourceType: __expectString(output.ResourceType),
     ResourceViolations:
       output.ResourceViolations !== undefined && output.ResourceViolations !== null
         ? deserializeAws_json1_1ResourceViolations(output.ResourceViolations, context)

--- a/clients/client-forecast/protocols/Aws_json1_1.ts
+++ b/clients/client-forecast/protocols/Aws_json1_1.ts
@@ -180,7 +180,12 @@ import {
   WindowSummary,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -3883,7 +3888,7 @@ const deserializeAws_json1_1ArnList = (output: any, context: __SerdeContext): st
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3892,7 +3897,7 @@ const deserializeAws_json1_1CategoricalParameterRange = (
   context: __SerdeContext
 ): CategoricalParameterRange => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     Values:
       output.Values !== undefined && output.Values !== null
         ? deserializeAws_json1_1Values(output.Values, context)
@@ -3919,10 +3924,10 @@ const deserializeAws_json1_1ContinuousParameterRange = (
   context: __SerdeContext
 ): ContinuousParameterRange => {
   return {
-    MaxValue: output.MaxValue !== undefined && output.MaxValue !== null ? output.MaxValue : undefined,
-    MinValue: output.MinValue !== undefined && output.MinValue !== null ? output.MinValue : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    ScalingType: output.ScalingType !== undefined && output.ScalingType !== null ? output.ScalingType : undefined,
+    MaxValue: __expectNumber(output.MaxValue),
+    MinValue: __expectNumber(output.MinValue),
+    Name: __expectString(output.Name),
+    ScalingType: __expectString(output.ScalingType),
   } as any;
 };
 
@@ -3945,8 +3950,7 @@ const deserializeAws_json1_1CreateDatasetGroupResponse = (
   context: __SerdeContext
 ): CreateDatasetGroupResponse => {
   return {
-    DatasetGroupArn:
-      output.DatasetGroupArn !== undefined && output.DatasetGroupArn !== null ? output.DatasetGroupArn : undefined,
+    DatasetGroupArn: __expectString(output.DatasetGroupArn),
   } as any;
 };
 
@@ -3955,16 +3959,13 @@ const deserializeAws_json1_1CreateDatasetImportJobResponse = (
   context: __SerdeContext
 ): CreateDatasetImportJobResponse => {
   return {
-    DatasetImportJobArn:
-      output.DatasetImportJobArn !== undefined && output.DatasetImportJobArn !== null
-        ? output.DatasetImportJobArn
-        : undefined,
+    DatasetImportJobArn: __expectString(output.DatasetImportJobArn),
   } as any;
 };
 
 const deserializeAws_json1_1CreateDatasetResponse = (output: any, context: __SerdeContext): CreateDatasetResponse => {
   return {
-    DatasetArn: output.DatasetArn !== undefined && output.DatasetArn !== null ? output.DatasetArn : undefined,
+    DatasetArn: __expectString(output.DatasetArn),
   } as any;
 };
 
@@ -3973,16 +3974,13 @@ const deserializeAws_json1_1CreateForecastExportJobResponse = (
   context: __SerdeContext
 ): CreateForecastExportJobResponse => {
   return {
-    ForecastExportJobArn:
-      output.ForecastExportJobArn !== undefined && output.ForecastExportJobArn !== null
-        ? output.ForecastExportJobArn
-        : undefined,
+    ForecastExportJobArn: __expectString(output.ForecastExportJobArn),
   } as any;
 };
 
 const deserializeAws_json1_1CreateForecastResponse = (output: any, context: __SerdeContext): CreateForecastResponse => {
   return {
-    ForecastArn: output.ForecastArn !== undefined && output.ForecastArn !== null ? output.ForecastArn : undefined,
+    ForecastArn: __expectString(output.ForecastArn),
   } as any;
 };
 
@@ -3991,10 +3989,7 @@ const deserializeAws_json1_1CreatePredictorBacktestExportJobResponse = (
   context: __SerdeContext
 ): CreatePredictorBacktestExportJobResponse => {
   return {
-    PredictorBacktestExportJobArn:
-      output.PredictorBacktestExportJobArn !== undefined && output.PredictorBacktestExportJobArn !== null
-        ? output.PredictorBacktestExportJobArn
-        : undefined,
+    PredictorBacktestExportJobArn: __expectString(output.PredictorBacktestExportJobArn),
   } as any;
 };
 
@@ -4003,7 +3998,7 @@ const deserializeAws_json1_1CreatePredictorResponse = (
   context: __SerdeContext
 ): CreatePredictorResponse => {
   return {
-    PredictorArn: output.PredictorArn !== undefined && output.PredictorArn !== null ? output.PredictorArn : undefined,
+    PredictorArn: __expectString(output.PredictorArn),
   } as any;
 };
 
@@ -4033,10 +4028,8 @@ const deserializeAws_json1_1DatasetGroupSummary = (output: any, context: __Serde
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    DatasetGroupArn:
-      output.DatasetGroupArn !== undefined && output.DatasetGroupArn !== null ? output.DatasetGroupArn : undefined,
-    DatasetGroupName:
-      output.DatasetGroupName !== undefined && output.DatasetGroupName !== null ? output.DatasetGroupName : undefined,
+    DatasetGroupArn: __expectString(output.DatasetGroupArn),
+    DatasetGroupName: __expectString(output.DatasetGroupName),
     LastModificationTime:
       output.LastModificationTime !== undefined && output.LastModificationTime !== null
         ? new Date(Math.round(output.LastModificationTime * 1000))
@@ -4068,20 +4061,14 @@ const deserializeAws_json1_1DatasetImportJobSummary = (
       output.DataSource !== undefined && output.DataSource !== null
         ? deserializeAws_json1_1DataSource(output.DataSource, context)
         : undefined,
-    DatasetImportJobArn:
-      output.DatasetImportJobArn !== undefined && output.DatasetImportJobArn !== null
-        ? output.DatasetImportJobArn
-        : undefined,
-    DatasetImportJobName:
-      output.DatasetImportJobName !== undefined && output.DatasetImportJobName !== null
-        ? output.DatasetImportJobName
-        : undefined,
+    DatasetImportJobArn: __expectString(output.DatasetImportJobArn),
+    DatasetImportJobName: __expectString(output.DatasetImportJobName),
     LastModificationTime:
       output.LastModificationTime !== undefined && output.LastModificationTime !== null
         ? new Date(Math.round(output.LastModificationTime * 1000))
         : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Message: __expectString(output.Message),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -4102,10 +4089,10 @@ const deserializeAws_json1_1DatasetSummary = (output: any, context: __SerdeConte
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    DatasetArn: output.DatasetArn !== undefined && output.DatasetArn !== null ? output.DatasetArn : undefined,
-    DatasetName: output.DatasetName !== undefined && output.DatasetName !== null ? output.DatasetName : undefined,
-    DatasetType: output.DatasetType !== undefined && output.DatasetType !== null ? output.DatasetType : undefined,
-    Domain: output.Domain !== undefined && output.Domain !== null ? output.Domain : undefined,
+    DatasetArn: __expectString(output.DatasetArn),
+    DatasetName: __expectString(output.DatasetName),
+    DatasetType: __expectString(output.DatasetType),
+    Domain: __expectString(output.Domain),
     LastModificationTime:
       output.LastModificationTime !== undefined && output.LastModificationTime !== null
         ? new Date(Math.round(output.LastModificationTime * 1000))
@@ -4135,16 +4122,14 @@ const deserializeAws_json1_1DescribeDatasetGroupResponse = (
       output.DatasetArns !== undefined && output.DatasetArns !== null
         ? deserializeAws_json1_1ArnList(output.DatasetArns, context)
         : undefined,
-    DatasetGroupArn:
-      output.DatasetGroupArn !== undefined && output.DatasetGroupArn !== null ? output.DatasetGroupArn : undefined,
-    DatasetGroupName:
-      output.DatasetGroupName !== undefined && output.DatasetGroupName !== null ? output.DatasetGroupName : undefined,
-    Domain: output.Domain !== undefined && output.Domain !== null ? output.Domain : undefined,
+    DatasetGroupArn: __expectString(output.DatasetGroupArn),
+    DatasetGroupName: __expectString(output.DatasetGroupName),
+    Domain: __expectString(output.Domain),
     LastModificationTime:
       output.LastModificationTime !== undefined && output.LastModificationTime !== null
         ? new Date(Math.round(output.LastModificationTime * 1000))
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -4157,45 +4142,29 @@ const deserializeAws_json1_1DescribeDatasetImportJobResponse = (
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    DataSize: output.DataSize !== undefined && output.DataSize !== null ? output.DataSize : undefined,
+    DataSize: __expectNumber(output.DataSize),
     DataSource:
       output.DataSource !== undefined && output.DataSource !== null
         ? deserializeAws_json1_1DataSource(output.DataSource, context)
         : undefined,
-    DatasetArn: output.DatasetArn !== undefined && output.DatasetArn !== null ? output.DatasetArn : undefined,
-    DatasetImportJobArn:
-      output.DatasetImportJobArn !== undefined && output.DatasetImportJobArn !== null
-        ? output.DatasetImportJobArn
-        : undefined,
-    DatasetImportJobName:
-      output.DatasetImportJobName !== undefined && output.DatasetImportJobName !== null
-        ? output.DatasetImportJobName
-        : undefined,
-    EstimatedTimeRemainingInMinutes:
-      output.EstimatedTimeRemainingInMinutes !== undefined && output.EstimatedTimeRemainingInMinutes !== null
-        ? output.EstimatedTimeRemainingInMinutes
-        : undefined,
+    DatasetArn: __expectString(output.DatasetArn),
+    DatasetImportJobArn: __expectString(output.DatasetImportJobArn),
+    DatasetImportJobName: __expectString(output.DatasetImportJobName),
+    EstimatedTimeRemainingInMinutes: __expectNumber(output.EstimatedTimeRemainingInMinutes),
     FieldStatistics:
       output.FieldStatistics !== undefined && output.FieldStatistics !== null
         ? deserializeAws_json1_1FieldStatistics(output.FieldStatistics, context)
         : undefined,
-    GeolocationFormat:
-      output.GeolocationFormat !== undefined && output.GeolocationFormat !== null
-        ? output.GeolocationFormat
-        : undefined,
+    GeolocationFormat: __expectString(output.GeolocationFormat),
     LastModificationTime:
       output.LastModificationTime !== undefined && output.LastModificationTime !== null
         ? new Date(Math.round(output.LastModificationTime * 1000))
         : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    TimeZone: output.TimeZone !== undefined && output.TimeZone !== null ? output.TimeZone : undefined,
-    TimestampFormat:
-      output.TimestampFormat !== undefined && output.TimestampFormat !== null ? output.TimestampFormat : undefined,
-    UseGeolocationForTimeZone:
-      output.UseGeolocationForTimeZone !== undefined && output.UseGeolocationForTimeZone !== null
-        ? output.UseGeolocationForTimeZone
-        : undefined,
+    Message: __expectString(output.Message),
+    Status: __expectString(output.Status),
+    TimeZone: __expectString(output.TimeZone),
+    TimestampFormat: __expectString(output.TimestampFormat),
+    UseGeolocationForTimeZone: __expectBoolean(output.UseGeolocationForTimeZone),
   } as any;
 };
 
@@ -4208,12 +4177,11 @@ const deserializeAws_json1_1DescribeDatasetResponse = (
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    DataFrequency:
-      output.DataFrequency !== undefined && output.DataFrequency !== null ? output.DataFrequency : undefined,
-    DatasetArn: output.DatasetArn !== undefined && output.DatasetArn !== null ? output.DatasetArn : undefined,
-    DatasetName: output.DatasetName !== undefined && output.DatasetName !== null ? output.DatasetName : undefined,
-    DatasetType: output.DatasetType !== undefined && output.DatasetType !== null ? output.DatasetType : undefined,
-    Domain: output.Domain !== undefined && output.Domain !== null ? output.Domain : undefined,
+    DataFrequency: __expectString(output.DataFrequency),
+    DatasetArn: __expectString(output.DatasetArn),
+    DatasetName: __expectString(output.DatasetName),
+    DatasetType: __expectString(output.DatasetType),
+    Domain: __expectString(output.Domain),
     EncryptionConfig:
       output.EncryptionConfig !== undefined && output.EncryptionConfig !== null
         ? deserializeAws_json1_1EncryptionConfig(output.EncryptionConfig, context)
@@ -4226,7 +4194,7 @@ const deserializeAws_json1_1DescribeDatasetResponse = (
       output.Schema !== undefined && output.Schema !== null
         ? deserializeAws_json1_1Schema(output.Schema, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -4243,21 +4211,15 @@ const deserializeAws_json1_1DescribeForecastExportJobResponse = (
       output.Destination !== undefined && output.Destination !== null
         ? deserializeAws_json1_1DataDestination(output.Destination, context)
         : undefined,
-    ForecastArn: output.ForecastArn !== undefined && output.ForecastArn !== null ? output.ForecastArn : undefined,
-    ForecastExportJobArn:
-      output.ForecastExportJobArn !== undefined && output.ForecastExportJobArn !== null
-        ? output.ForecastExportJobArn
-        : undefined,
-    ForecastExportJobName:
-      output.ForecastExportJobName !== undefined && output.ForecastExportJobName !== null
-        ? output.ForecastExportJobName
-        : undefined,
+    ForecastArn: __expectString(output.ForecastArn),
+    ForecastExportJobArn: __expectString(output.ForecastExportJobArn),
+    ForecastExportJobName: __expectString(output.ForecastExportJobName),
     LastModificationTime:
       output.LastModificationTime !== undefined && output.LastModificationTime !== null
         ? new Date(Math.round(output.LastModificationTime * 1000))
         : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Message: __expectString(output.Message),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -4270,14 +4232,10 @@ const deserializeAws_json1_1DescribeForecastResponse = (
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    DatasetGroupArn:
-      output.DatasetGroupArn !== undefined && output.DatasetGroupArn !== null ? output.DatasetGroupArn : undefined,
-    EstimatedTimeRemainingInMinutes:
-      output.EstimatedTimeRemainingInMinutes !== undefined && output.EstimatedTimeRemainingInMinutes !== null
-        ? output.EstimatedTimeRemainingInMinutes
-        : undefined,
-    ForecastArn: output.ForecastArn !== undefined && output.ForecastArn !== null ? output.ForecastArn : undefined,
-    ForecastName: output.ForecastName !== undefined && output.ForecastName !== null ? output.ForecastName : undefined,
+    DatasetGroupArn: __expectString(output.DatasetGroupArn),
+    EstimatedTimeRemainingInMinutes: __expectNumber(output.EstimatedTimeRemainingInMinutes),
+    ForecastArn: __expectString(output.ForecastArn),
+    ForecastName: __expectString(output.ForecastName),
     ForecastTypes:
       output.ForecastTypes !== undefined && output.ForecastTypes !== null
         ? deserializeAws_json1_1ForecastTypes(output.ForecastTypes, context)
@@ -4286,9 +4244,9 @@ const deserializeAws_json1_1DescribeForecastResponse = (
       output.LastModificationTime !== undefined && output.LastModificationTime !== null
         ? new Date(Math.round(output.LastModificationTime * 1000))
         : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    PredictorArn: output.PredictorArn !== undefined && output.PredictorArn !== null ? output.PredictorArn : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Message: __expectString(output.Message),
+    PredictorArn: __expectString(output.PredictorArn),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -4309,17 +4267,11 @@ const deserializeAws_json1_1DescribePredictorBacktestExportJobResponse = (
       output.LastModificationTime !== undefined && output.LastModificationTime !== null
         ? new Date(Math.round(output.LastModificationTime * 1000))
         : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    PredictorArn: output.PredictorArn !== undefined && output.PredictorArn !== null ? output.PredictorArn : undefined,
-    PredictorBacktestExportJobArn:
-      output.PredictorBacktestExportJobArn !== undefined && output.PredictorBacktestExportJobArn !== null
-        ? output.PredictorBacktestExportJobArn
-        : undefined,
-    PredictorBacktestExportJobName:
-      output.PredictorBacktestExportJobName !== undefined && output.PredictorBacktestExportJobName !== null
-        ? output.PredictorBacktestExportJobName
-        : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Message: __expectString(output.Message),
+    PredictorArn: __expectString(output.PredictorArn),
+    PredictorBacktestExportJobArn: __expectString(output.PredictorBacktestExportJobArn),
+    PredictorBacktestExportJobName: __expectString(output.PredictorBacktestExportJobName),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -4328,15 +4280,12 @@ const deserializeAws_json1_1DescribePredictorResponse = (
   context: __SerdeContext
 ): DescribePredictorResponse => {
   return {
-    AlgorithmArn: output.AlgorithmArn !== undefined && output.AlgorithmArn !== null ? output.AlgorithmArn : undefined,
+    AlgorithmArn: __expectString(output.AlgorithmArn),
     AutoMLAlgorithmArns:
       output.AutoMLAlgorithmArns !== undefined && output.AutoMLAlgorithmArns !== null
         ? deserializeAws_json1_1ArnList(output.AutoMLAlgorithmArns, context)
         : undefined,
-    AutoMLOverrideStrategy:
-      output.AutoMLOverrideStrategy !== undefined && output.AutoMLOverrideStrategy !== null
-        ? output.AutoMLOverrideStrategy
-        : undefined,
+    AutoMLOverrideStrategy: __expectString(output.AutoMLOverrideStrategy),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -4349,10 +4298,7 @@ const deserializeAws_json1_1DescribePredictorResponse = (
       output.EncryptionConfig !== undefined && output.EncryptionConfig !== null
         ? deserializeAws_json1_1EncryptionConfig(output.EncryptionConfig, context)
         : undefined,
-    EstimatedTimeRemainingInMinutes:
-      output.EstimatedTimeRemainingInMinutes !== undefined && output.EstimatedTimeRemainingInMinutes !== null
-        ? output.EstimatedTimeRemainingInMinutes
-        : undefined,
+    EstimatedTimeRemainingInMinutes: __expectNumber(output.EstimatedTimeRemainingInMinutes),
     EvaluationParameters:
       output.EvaluationParameters !== undefined && output.EvaluationParameters !== null
         ? deserializeAws_json1_1EvaluationParameters(output.EvaluationParameters, context)
@@ -4361,8 +4307,7 @@ const deserializeAws_json1_1DescribePredictorResponse = (
       output.FeaturizationConfig !== undefined && output.FeaturizationConfig !== null
         ? deserializeAws_json1_1FeaturizationConfig(output.FeaturizationConfig, context)
         : undefined,
-    ForecastHorizon:
-      output.ForecastHorizon !== undefined && output.ForecastHorizon !== null ? output.ForecastHorizon : undefined,
+    ForecastHorizon: __expectNumber(output.ForecastHorizon),
     ForecastTypes:
       output.ForecastTypes !== undefined && output.ForecastTypes !== null
         ? deserializeAws_json1_1ForecastTypes(output.ForecastTypes, context)
@@ -4379,18 +4324,16 @@ const deserializeAws_json1_1DescribePredictorResponse = (
       output.LastModificationTime !== undefined && output.LastModificationTime !== null
         ? new Date(Math.round(output.LastModificationTime * 1000))
         : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    PerformAutoML:
-      output.PerformAutoML !== undefined && output.PerformAutoML !== null ? output.PerformAutoML : undefined,
-    PerformHPO: output.PerformHPO !== undefined && output.PerformHPO !== null ? output.PerformHPO : undefined,
-    PredictorArn: output.PredictorArn !== undefined && output.PredictorArn !== null ? output.PredictorArn : undefined,
+    Message: __expectString(output.Message),
+    PerformAutoML: __expectBoolean(output.PerformAutoML),
+    PerformHPO: __expectBoolean(output.PerformHPO),
+    PredictorArn: __expectString(output.PredictorArn),
     PredictorExecutionDetails:
       output.PredictorExecutionDetails !== undefined && output.PredictorExecutionDetails !== null
         ? deserializeAws_json1_1PredictorExecutionDetails(output.PredictorExecutionDetails, context)
         : undefined,
-    PredictorName:
-      output.PredictorName !== undefined && output.PredictorName !== null ? output.PredictorName : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    PredictorName: __expectString(output.PredictorName),
+    Status: __expectString(output.Status),
     TrainingParameters:
       output.TrainingParameters !== undefined && output.TrainingParameters !== null
         ? deserializeAws_json1_1TrainingParameters(output.TrainingParameters, context)
@@ -4400,16 +4343,16 @@ const deserializeAws_json1_1DescribePredictorResponse = (
 
 const deserializeAws_json1_1EncryptionConfig = (output: any, context: __SerdeContext): EncryptionConfig => {
   return {
-    KMSKeyArn: output.KMSKeyArn !== undefined && output.KMSKeyArn !== null ? output.KMSKeyArn : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
+    KMSKeyArn: __expectString(output.KMSKeyArn),
+    RoleArn: __expectString(output.RoleArn),
   } as any;
 };
 
 const deserializeAws_json1_1ErrorMetric = (output: any, context: __SerdeContext): ErrorMetric => {
   return {
-    ForecastType: output.ForecastType !== undefined && output.ForecastType !== null ? output.ForecastType : undefined,
-    RMSE: output.RMSE !== undefined && output.RMSE !== null ? output.RMSE : undefined,
-    WAPE: output.WAPE !== undefined && output.WAPE !== null ? output.WAPE : undefined,
+    ForecastType: __expectString(output.ForecastType),
+    RMSE: __expectNumber(output.RMSE),
+    WAPE: __expectNumber(output.WAPE),
   } as any;
 };
 
@@ -4426,20 +4369,14 @@ const deserializeAws_json1_1ErrorMetrics = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_1EvaluationParameters = (output: any, context: __SerdeContext): EvaluationParameters => {
   return {
-    BackTestWindowOffset:
-      output.BackTestWindowOffset !== undefined && output.BackTestWindowOffset !== null
-        ? output.BackTestWindowOffset
-        : undefined,
-    NumberOfBacktestWindows:
-      output.NumberOfBacktestWindows !== undefined && output.NumberOfBacktestWindows !== null
-        ? output.NumberOfBacktestWindows
-        : undefined,
+    BackTestWindowOffset: __expectNumber(output.BackTestWindowOffset),
+    NumberOfBacktestWindows: __expectNumber(output.NumberOfBacktestWindows),
   } as any;
 };
 
 const deserializeAws_json1_1EvaluationResult = (output: any, context: __SerdeContext): EvaluationResult => {
   return {
-    AlgorithmArn: output.AlgorithmArn !== undefined && output.AlgorithmArn !== null ? output.AlgorithmArn : undefined,
+    AlgorithmArn: __expectString(output.AlgorithmArn),
     TestWindows:
       output.TestWindows !== undefined && output.TestWindows !== null
         ? deserializeAws_json1_1TestWindows(output.TestWindows, context)
@@ -4449,8 +4386,7 @@ const deserializeAws_json1_1EvaluationResult = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1Featurization = (output: any, context: __SerdeContext): Featurization => {
   return {
-    AttributeName:
-      output.AttributeName !== undefined && output.AttributeName !== null ? output.AttributeName : undefined,
+    AttributeName: __expectString(output.AttributeName),
     FeaturizationPipeline:
       output.FeaturizationPipeline !== undefined && output.FeaturizationPipeline !== null
         ? deserializeAws_json1_1FeaturizationPipeline(output.FeaturizationPipeline, context)
@@ -4468,19 +4404,13 @@ const deserializeAws_json1_1FeaturizationConfig = (output: any, context: __Serde
       output.ForecastDimensions !== undefined && output.ForecastDimensions !== null
         ? deserializeAws_json1_1ForecastDimensions(output.ForecastDimensions, context)
         : undefined,
-    ForecastFrequency:
-      output.ForecastFrequency !== undefined && output.ForecastFrequency !== null
-        ? output.ForecastFrequency
-        : undefined,
+    ForecastFrequency: __expectString(output.ForecastFrequency),
   } as any;
 };
 
 const deserializeAws_json1_1FeaturizationMethod = (output: any, context: __SerdeContext): FeaturizationMethod => {
   return {
-    FeaturizationMethodName:
-      output.FeaturizationMethodName !== undefined && output.FeaturizationMethodName !== null
-        ? output.FeaturizationMethodName
-        : undefined,
+    FeaturizationMethodName: __expectString(output.FeaturizationMethodName),
     FeaturizationMethodParameters:
       output.FeaturizationMethodParameters !== undefined && output.FeaturizationMethodParameters !== null
         ? deserializeAws_json1_1FeaturizationMethodParameters(output.FeaturizationMethodParameters, context)
@@ -4498,7 +4428,7 @@ const deserializeAws_json1_1FeaturizationMethodParameters = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -4544,7 +4474,7 @@ const deserializeAws_json1_1ForecastDimensions = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4572,20 +4502,14 @@ const deserializeAws_json1_1ForecastExportJobSummary = (
       output.Destination !== undefined && output.Destination !== null
         ? deserializeAws_json1_1DataDestination(output.Destination, context)
         : undefined,
-    ForecastExportJobArn:
-      output.ForecastExportJobArn !== undefined && output.ForecastExportJobArn !== null
-        ? output.ForecastExportJobArn
-        : undefined,
-    ForecastExportJobName:
-      output.ForecastExportJobName !== undefined && output.ForecastExportJobName !== null
-        ? output.ForecastExportJobName
-        : undefined,
+    ForecastExportJobArn: __expectString(output.ForecastExportJobArn),
+    ForecastExportJobName: __expectString(output.ForecastExportJobName),
     LastModificationTime:
       output.LastModificationTime !== undefined && output.LastModificationTime !== null
         ? new Date(Math.round(output.LastModificationTime * 1000))
         : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Message: __expectString(output.Message),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -4606,17 +4530,16 @@ const deserializeAws_json1_1ForecastSummary = (output: any, context: __SerdeCont
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    DatasetGroupArn:
-      output.DatasetGroupArn !== undefined && output.DatasetGroupArn !== null ? output.DatasetGroupArn : undefined,
-    ForecastArn: output.ForecastArn !== undefined && output.ForecastArn !== null ? output.ForecastArn : undefined,
-    ForecastName: output.ForecastName !== undefined && output.ForecastName !== null ? output.ForecastName : undefined,
+    DatasetGroupArn: __expectString(output.DatasetGroupArn),
+    ForecastArn: __expectString(output.ForecastArn),
+    ForecastName: __expectString(output.ForecastName),
     LastModificationTime:
       output.LastModificationTime !== undefined && output.LastModificationTime !== null
         ? new Date(Math.round(output.LastModificationTime * 1000))
         : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    PredictorArn: output.PredictorArn !== undefined && output.PredictorArn !== null ? output.PredictorArn : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Message: __expectString(output.Message),
+    PredictorArn: __expectString(output.PredictorArn),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -4627,7 +4550,7 @@ const deserializeAws_json1_1ForecastTypes = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4636,10 +4559,7 @@ const deserializeAws_json1_1GetAccuracyMetricsResponse = (
   context: __SerdeContext
 ): GetAccuracyMetricsResponse => {
   return {
-    AutoMLOverrideStrategy:
-      output.AutoMLOverrideStrategy !== undefined && output.AutoMLOverrideStrategy !== null
-        ? output.AutoMLOverrideStrategy
-        : undefined,
+    AutoMLOverrideStrategy: __expectString(output.AutoMLOverrideStrategy),
     PredictorEvaluationResults:
       output.PredictorEvaluationResults !== undefined && output.PredictorEvaluationResults !== null
         ? deserializeAws_json1_1PredictorEvaluationResults(output.PredictorEvaluationResults, context)
@@ -4661,8 +4581,7 @@ const deserializeAws_json1_1HyperParameterTuningJobConfig = (
 
 const deserializeAws_json1_1InputDataConfig = (output: any, context: __SerdeContext): InputDataConfig => {
   return {
-    DatasetGroupArn:
-      output.DatasetGroupArn !== undefined && output.DatasetGroupArn !== null ? output.DatasetGroupArn : undefined,
+    DatasetGroupArn: __expectString(output.DatasetGroupArn),
     SupplementaryFeatures:
       output.SupplementaryFeatures !== undefined && output.SupplementaryFeatures !== null
         ? deserializeAws_json1_1SupplementaryFeatures(output.SupplementaryFeatures, context)
@@ -4672,10 +4591,10 @@ const deserializeAws_json1_1InputDataConfig = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_1IntegerParameterRange = (output: any, context: __SerdeContext): IntegerParameterRange => {
   return {
-    MaxValue: output.MaxValue !== undefined && output.MaxValue !== null ? output.MaxValue : undefined,
-    MinValue: output.MinValue !== undefined && output.MinValue !== null ? output.MinValue : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    ScalingType: output.ScalingType !== undefined && output.ScalingType !== null ? output.ScalingType : undefined,
+    MaxValue: __expectNumber(output.MaxValue),
+    MinValue: __expectNumber(output.MinValue),
+    Name: __expectString(output.Name),
+    ScalingType: __expectString(output.ScalingType),
   } as any;
 };
 
@@ -4695,7 +4614,7 @@ const deserializeAws_json1_1IntegerParameterRanges = (
 
 const deserializeAws_json1_1InvalidInputException = (output: any, context: __SerdeContext): InvalidInputException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -4704,13 +4623,13 @@ const deserializeAws_json1_1InvalidNextTokenException = (
   context: __SerdeContext
 ): InvalidNextTokenException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -4723,7 +4642,7 @@ const deserializeAws_json1_1ListDatasetGroupsResponse = (
       output.DatasetGroups !== undefined && output.DatasetGroups !== null
         ? deserializeAws_json1_1DatasetGroups(output.DatasetGroups, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -4736,7 +4655,7 @@ const deserializeAws_json1_1ListDatasetImportJobsResponse = (
       output.DatasetImportJobs !== undefined && output.DatasetImportJobs !== null
         ? deserializeAws_json1_1DatasetImportJobs(output.DatasetImportJobs, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -4746,7 +4665,7 @@ const deserializeAws_json1_1ListDatasetsResponse = (output: any, context: __Serd
       output.Datasets !== undefined && output.Datasets !== null
         ? deserializeAws_json1_1Datasets(output.Datasets, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -4759,7 +4678,7 @@ const deserializeAws_json1_1ListForecastExportJobsResponse = (
       output.ForecastExportJobs !== undefined && output.ForecastExportJobs !== null
         ? deserializeAws_json1_1ForecastExportJobs(output.ForecastExportJobs, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -4769,7 +4688,7 @@ const deserializeAws_json1_1ListForecastsResponse = (output: any, context: __Ser
       output.Forecasts !== undefined && output.Forecasts !== null
         ? deserializeAws_json1_1Forecasts(output.Forecasts, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -4778,7 +4697,7 @@ const deserializeAws_json1_1ListPredictorBacktestExportJobsResponse = (
   context: __SerdeContext
 ): ListPredictorBacktestExportJobsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     PredictorBacktestExportJobs:
       output.PredictorBacktestExportJobs !== undefined && output.PredictorBacktestExportJobs !== null
         ? deserializeAws_json1_1PredictorBacktestExportJobs(output.PredictorBacktestExportJobs, context)
@@ -4788,7 +4707,7 @@ const deserializeAws_json1_1ListPredictorBacktestExportJobsResponse = (
 
 const deserializeAws_json1_1ListPredictorsResponse = (output: any, context: __SerdeContext): ListPredictorsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Predictors:
       output.Predictors !== undefined && output.Predictors !== null
         ? deserializeAws_json1_1Predictors(output.Predictors, context)
@@ -4812,7 +4731,7 @@ const deserializeAws_json1_1Metrics = (output: any, context: __SerdeContext): Me
       output.ErrorMetrics !== undefined && output.ErrorMetrics !== null
         ? deserializeAws_json1_1ErrorMetrics(output.ErrorMetrics, context)
         : undefined,
-    RMSE: output.RMSE !== undefined && output.RMSE !== null ? output.RMSE : undefined,
+    RMSE: __expectNumber(output.RMSE),
     WeightedQuantileLosses:
       output.WeightedQuantileLosses !== undefined && output.WeightedQuantileLosses !== null
         ? deserializeAws_json1_1WeightedQuantileLosses(output.WeightedQuantileLosses, context)
@@ -4868,16 +4787,10 @@ const deserializeAws_json1_1PredictorBacktestExportJobSummary = (
       output.LastModificationTime !== undefined && output.LastModificationTime !== null
         ? new Date(Math.round(output.LastModificationTime * 1000))
         : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    PredictorBacktestExportJobArn:
-      output.PredictorBacktestExportJobArn !== undefined && output.PredictorBacktestExportJobArn !== null
-        ? output.PredictorBacktestExportJobArn
-        : undefined,
-    PredictorBacktestExportJobName:
-      output.PredictorBacktestExportJobName !== undefined && output.PredictorBacktestExportJobName !== null
-        ? output.PredictorBacktestExportJobName
-        : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Message: __expectString(output.Message),
+    PredictorBacktestExportJobArn: __expectString(output.PredictorBacktestExportJobArn),
+    PredictorBacktestExportJobName: __expectString(output.PredictorBacktestExportJobName),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -4894,7 +4807,7 @@ const deserializeAws_json1_1PredictorEvaluationResults = (output: any, context: 
 
 const deserializeAws_json1_1PredictorExecution = (output: any, context: __SerdeContext): PredictorExecution => {
   return {
-    AlgorithmArn: output.AlgorithmArn !== undefined && output.AlgorithmArn !== null ? output.AlgorithmArn : undefined,
+    AlgorithmArn: __expectString(output.AlgorithmArn),
     TestWindows:
       output.TestWindows !== undefined && output.TestWindows !== null
         ? deserializeAws_json1_1TestWindowDetails(output.TestWindows, context)
@@ -4942,17 +4855,15 @@ const deserializeAws_json1_1PredictorSummary = (output: any, context: __SerdeCon
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    DatasetGroupArn:
-      output.DatasetGroupArn !== undefined && output.DatasetGroupArn !== null ? output.DatasetGroupArn : undefined,
+    DatasetGroupArn: __expectString(output.DatasetGroupArn),
     LastModificationTime:
       output.LastModificationTime !== undefined && output.LastModificationTime !== null
         ? new Date(Math.round(output.LastModificationTime * 1000))
         : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    PredictorArn: output.PredictorArn !== undefined && output.PredictorArn !== null ? output.PredictorArn : undefined,
-    PredictorName:
-      output.PredictorName !== undefined && output.PredictorName !== null ? output.PredictorName : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Message: __expectString(output.Message),
+    PredictorArn: __expectString(output.PredictorArn),
+    PredictorName: __expectString(output.PredictorName),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -4961,13 +4872,13 @@ const deserializeAws_json1_1ResourceAlreadyExistsException = (
   context: __SerdeContext
 ): ResourceAlreadyExistsException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1ResourceInUseException = (output: any, context: __SerdeContext): ResourceInUseException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -4976,15 +4887,15 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1S3Config = (output: any, context: __SerdeContext): S3Config => {
   return {
-    KMSKeyArn: output.KMSKeyArn !== undefined && output.KMSKeyArn !== null ? output.KMSKeyArn : undefined,
-    Path: output.Path !== undefined && output.Path !== null ? output.Path : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
+    KMSKeyArn: __expectString(output.KMSKeyArn),
+    Path: __expectString(output.Path),
+    RoleArn: __expectString(output.RoleArn),
   } as any;
 };
 
@@ -4999,10 +4910,8 @@ const deserializeAws_json1_1Schema = (output: any, context: __SerdeContext): Sch
 
 const deserializeAws_json1_1SchemaAttribute = (output: any, context: __SerdeContext): SchemaAttribute => {
   return {
-    AttributeName:
-      output.AttributeName !== undefined && output.AttributeName !== null ? output.AttributeName : undefined,
-    AttributeType:
-      output.AttributeType !== undefined && output.AttributeType !== null ? output.AttributeType : undefined,
+    AttributeName: __expectString(output.AttributeName),
+    AttributeType: __expectString(output.AttributeType),
   } as any;
 };
 
@@ -5019,30 +4928,25 @@ const deserializeAws_json1_1SchemaAttributes = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1Statistics = (output: any, context: __SerdeContext): Statistics => {
   return {
-    Avg: output.Avg !== undefined && output.Avg !== null ? output.Avg : undefined,
-    Count: output.Count !== undefined && output.Count !== null ? output.Count : undefined,
-    CountDistinct:
-      output.CountDistinct !== undefined && output.CountDistinct !== null ? output.CountDistinct : undefined,
-    CountDistinctLong:
-      output.CountDistinctLong !== undefined && output.CountDistinctLong !== null
-        ? output.CountDistinctLong
-        : undefined,
-    CountLong: output.CountLong !== undefined && output.CountLong !== null ? output.CountLong : undefined,
-    CountNan: output.CountNan !== undefined && output.CountNan !== null ? output.CountNan : undefined,
-    CountNanLong: output.CountNanLong !== undefined && output.CountNanLong !== null ? output.CountNanLong : undefined,
-    CountNull: output.CountNull !== undefined && output.CountNull !== null ? output.CountNull : undefined,
-    CountNullLong:
-      output.CountNullLong !== undefined && output.CountNullLong !== null ? output.CountNullLong : undefined,
-    Max: output.Max !== undefined && output.Max !== null ? output.Max : undefined,
-    Min: output.Min !== undefined && output.Min !== null ? output.Min : undefined,
-    Stddev: output.Stddev !== undefined && output.Stddev !== null ? output.Stddev : undefined,
+    Avg: __expectNumber(output.Avg),
+    Count: __expectNumber(output.Count),
+    CountDistinct: __expectNumber(output.CountDistinct),
+    CountDistinctLong: __expectNumber(output.CountDistinctLong),
+    CountLong: __expectNumber(output.CountLong),
+    CountNan: __expectNumber(output.CountNan),
+    CountNanLong: __expectNumber(output.CountNanLong),
+    CountNull: __expectNumber(output.CountNull),
+    CountNullLong: __expectNumber(output.CountNullLong),
+    Max: __expectString(output.Max),
+    Min: __expectString(output.Min),
+    Stddev: __expectNumber(output.Stddev),
   } as any;
 };
 
 const deserializeAws_json1_1SupplementaryFeature = (output: any, context: __SerdeContext): SupplementaryFeature => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Name: __expectString(output.Name),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -5059,8 +4963,8 @@ const deserializeAws_json1_1SupplementaryFeatures = (output: any, context: __Ser
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -5103,8 +5007,8 @@ const deserializeAws_json1_1TestWindows = (output: any, context: __SerdeContext)
 
 const deserializeAws_json1_1TestWindowSummary = (output: any, context: __SerdeContext): TestWindowSummary => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Message: __expectString(output.Message),
+    Status: __expectString(output.Status),
     TestWindowEnd:
       output.TestWindowEnd !== undefined && output.TestWindowEnd !== null
         ? new Date(Math.round(output.TestWindowEnd * 1000))
@@ -5123,7 +5027,7 @@ const deserializeAws_json1_1TrainingParameters = (output: any, context: __SerdeC
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -5146,14 +5050,14 @@ const deserializeAws_json1_1Values = (output: any, context: __SerdeContext): str
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1WeightedQuantileLoss = (output: any, context: __SerdeContext): WeightedQuantileLoss => {
   return {
-    LossValue: output.LossValue !== undefined && output.LossValue !== null ? output.LossValue : undefined,
-    Quantile: output.Quantile !== undefined && output.Quantile !== null ? output.Quantile : undefined,
+    LossValue: __expectNumber(output.LossValue),
+    Quantile: __expectNumber(output.Quantile),
   } as any;
 };
 
@@ -5170,9 +5074,8 @@ const deserializeAws_json1_1WeightedQuantileLosses = (output: any, context: __Se
 
 const deserializeAws_json1_1WindowSummary = (output: any, context: __SerdeContext): WindowSummary => {
   return {
-    EvaluationType:
-      output.EvaluationType !== undefined && output.EvaluationType !== null ? output.EvaluationType : undefined,
-    ItemCount: output.ItemCount !== undefined && output.ItemCount !== null ? output.ItemCount : undefined,
+    EvaluationType: __expectString(output.EvaluationType),
+    ItemCount: __expectNumber(output.ItemCount),
     Metrics:
       output.Metrics !== undefined && output.Metrics !== null
         ? deserializeAws_json1_1Metrics(output.Metrics, context)

--- a/clients/client-forecastquery/protocols/Aws_json1_1.ts
+++ b/clients/client-forecastquery/protocols/Aws_json1_1.ts
@@ -11,7 +11,11 @@ import {
   ResourceNotFoundException,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -219,8 +223,8 @@ const serializeAws_json1_1QueryForecastRequest = (input: QueryForecastRequest, c
 
 const deserializeAws_json1_1DataPoint = (output: any, context: __SerdeContext): DataPoint => {
   return {
-    Timestamp: output.Timestamp !== undefined && output.Timestamp !== null ? output.Timestamp : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Timestamp: __expectString(output.Timestamp),
+    Value: __expectNumber(output.Value),
   } as any;
 };
 
@@ -235,7 +239,7 @@ const deserializeAws_json1_1Forecast = (output: any, context: __SerdeContext): F
 
 const deserializeAws_json1_1InvalidInputException = (output: any, context: __SerdeContext): InvalidInputException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -244,13 +248,13 @@ const deserializeAws_json1_1InvalidNextTokenException = (
   context: __SerdeContext
 ): InvalidNextTokenException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -277,7 +281,7 @@ const deserializeAws_json1_1QueryForecastResponse = (output: any, context: __Ser
 
 const deserializeAws_json1_1ResourceInUseException = (output: any, context: __SerdeContext): ResourceInUseException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -286,7 +290,7 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 

--- a/clients/client-frauddetector/protocols/Aws_json1_1.ts
+++ b/clients/client-frauddetector/protocols/Aws_json1_1.ts
@@ -259,7 +259,12 @@ import {
   VariableEntry,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -6519,7 +6524,7 @@ const serializeAws_json1_1VariableEntryList = (input: VariableEntry[], context: 
 
 const deserializeAws_json1_1AccessDeniedException = (output: any, context: __SerdeContext): AccessDeniedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6528,9 +6533,9 @@ const deserializeAws_json1_1BatchCreateVariableError = (
   context: __SerdeContext
 ): BatchCreateVariableError => {
   return {
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    code: __expectNumber(output.code),
+    message: __expectString(output.message),
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -6562,9 +6567,9 @@ const deserializeAws_json1_1BatchCreateVariableResult = (
 
 const deserializeAws_json1_1BatchGetVariableError = (output: any, context: __SerdeContext): BatchGetVariableError => {
   return {
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    code: __expectNumber(output.code),
+    message: __expectString(output.message),
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -6597,34 +6602,21 @@ const deserializeAws_json1_1BatchGetVariableResult = (output: any, context: __Se
 
 const deserializeAws_json1_1BatchPrediction = (output: any, context: __SerdeContext): BatchPrediction => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    completionTime:
-      output.completionTime !== undefined && output.completionTime !== null ? output.completionTime : undefined,
-    detectorName: output.detectorName !== undefined && output.detectorName !== null ? output.detectorName : undefined,
-    detectorVersion:
-      output.detectorVersion !== undefined && output.detectorVersion !== null ? output.detectorVersion : undefined,
-    eventTypeName:
-      output.eventTypeName !== undefined && output.eventTypeName !== null ? output.eventTypeName : undefined,
-    failureReason:
-      output.failureReason !== undefined && output.failureReason !== null ? output.failureReason : undefined,
-    iamRoleArn: output.iamRoleArn !== undefined && output.iamRoleArn !== null ? output.iamRoleArn : undefined,
-    inputPath: output.inputPath !== undefined && output.inputPath !== null ? output.inputPath : undefined,
-    jobId: output.jobId !== undefined && output.jobId !== null ? output.jobId : undefined,
-    lastHeartbeatTime:
-      output.lastHeartbeatTime !== undefined && output.lastHeartbeatTime !== null
-        ? output.lastHeartbeatTime
-        : undefined,
-    outputPath: output.outputPath !== undefined && output.outputPath !== null ? output.outputPath : undefined,
-    processedRecordsCount:
-      output.processedRecordsCount !== undefined && output.processedRecordsCount !== null
-        ? output.processedRecordsCount
-        : undefined,
-    startTime: output.startTime !== undefined && output.startTime !== null ? output.startTime : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    totalRecordsCount:
-      output.totalRecordsCount !== undefined && output.totalRecordsCount !== null
-        ? output.totalRecordsCount
-        : undefined,
+    arn: __expectString(output.arn),
+    completionTime: __expectString(output.completionTime),
+    detectorName: __expectString(output.detectorName),
+    detectorVersion: __expectString(output.detectorVersion),
+    eventTypeName: __expectString(output.eventTypeName),
+    failureReason: __expectString(output.failureReason),
+    iamRoleArn: __expectString(output.iamRoleArn),
+    inputPath: __expectString(output.inputPath),
+    jobId: __expectString(output.jobId),
+    lastHeartbeatTime: __expectString(output.lastHeartbeatTime),
+    outputPath: __expectString(output.outputPath),
+    processedRecordsCount: __expectNumber(output.processedRecordsCount),
+    startTime: __expectString(output.startTime),
+    status: __expectString(output.status),
+    totalRecordsCount: __expectNumber(output.totalRecordsCount),
   } as any;
 };
 
@@ -6648,7 +6640,7 @@ const deserializeAws_json1_1CancelBatchPredictionJobResult = (
 
 const deserializeAws_json1_1ConflictException = (output: any, context: __SerdeContext): ConflictException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6664,12 +6656,9 @@ const deserializeAws_json1_1CreateDetectorVersionResult = (
   context: __SerdeContext
 ): CreateDetectorVersionResult => {
   return {
-    detectorId: output.detectorId !== undefined && output.detectorId !== null ? output.detectorId : undefined,
-    detectorVersionId:
-      output.detectorVersionId !== undefined && output.detectorVersionId !== null
-        ? output.detectorVersionId
-        : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    detectorId: __expectString(output.detectorId),
+    detectorVersionId: __expectString(output.detectorVersionId),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -6682,13 +6671,10 @@ const deserializeAws_json1_1CreateModelVersionResult = (
   context: __SerdeContext
 ): CreateModelVersionResult => {
   return {
-    modelId: output.modelId !== undefined && output.modelId !== null ? output.modelId : undefined,
-    modelType: output.modelType !== undefined && output.modelType !== null ? output.modelType : undefined,
-    modelVersionNumber:
-      output.modelVersionNumber !== undefined && output.modelVersionNumber !== null
-        ? output.modelVersionNumber
-        : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    modelId: __expectString(output.modelId),
+    modelType: __expectString(output.modelType),
+    modelVersionNumber: __expectString(output.modelVersionNumber),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -6713,7 +6699,7 @@ const deserializeAws_json1_1CsvIndexToVariableMap = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -6797,13 +6783,13 @@ const deserializeAws_json1_1DeleteVariableResult = (output: any, context: __Serd
 
 const deserializeAws_json1_1DescribeDetectorResult = (output: any, context: __SerdeContext): DescribeDetectorResult => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    detectorId: output.detectorId !== undefined && output.detectorId !== null ? output.detectorId : undefined,
+    arn: __expectString(output.arn),
+    detectorId: __expectString(output.detectorId),
     detectorVersionSummaries:
       output.detectorVersionSummaries !== undefined && output.detectorVersionSummaries !== null
         ? deserializeAws_json1_1DetectorVersionSummaryList(output.detectorVersionSummaries, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -6816,20 +6802,18 @@ const deserializeAws_json1_1DescribeModelVersionsResult = (
       output.modelVersionDetails !== undefined && output.modelVersionDetails !== null
         ? deserializeAws_json1_1modelVersionDetailList(output.modelVersionDetails, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
 const deserializeAws_json1_1Detector = (output: any, context: __SerdeContext): Detector => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    createdTime: output.createdTime !== undefined && output.createdTime !== null ? output.createdTime : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    detectorId: output.detectorId !== undefined && output.detectorId !== null ? output.detectorId : undefined,
-    eventTypeName:
-      output.eventTypeName !== undefined && output.eventTypeName !== null ? output.eventTypeName : undefined,
-    lastUpdatedTime:
-      output.lastUpdatedTime !== undefined && output.lastUpdatedTime !== null ? output.lastUpdatedTime : undefined,
+    arn: __expectString(output.arn),
+    createdTime: __expectString(output.createdTime),
+    description: __expectString(output.description),
+    detectorId: __expectString(output.detectorId),
+    eventTypeName: __expectString(output.eventTypeName),
+    lastUpdatedTime: __expectString(output.lastUpdatedTime),
   } as any;
 };
 
@@ -6846,14 +6830,10 @@ const deserializeAws_json1_1DetectorList = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_1DetectorVersionSummary = (output: any, context: __SerdeContext): DetectorVersionSummary => {
   return {
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    detectorVersionId:
-      output.detectorVersionId !== undefined && output.detectorVersionId !== null
-        ? output.detectorVersionId
-        : undefined,
-    lastUpdatedTime:
-      output.lastUpdatedTime !== undefined && output.lastUpdatedTime !== null ? output.lastUpdatedTime : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    description: __expectString(output.description),
+    detectorVersionId: __expectString(output.detectorVersionId),
+    lastUpdatedTime: __expectString(output.lastUpdatedTime),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -6873,12 +6853,11 @@ const deserializeAws_json1_1DetectorVersionSummaryList = (
 
 const deserializeAws_json1_1EntityType = (output: any, context: __SerdeContext): EntityType => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    createdTime: output.createdTime !== undefined && output.createdTime !== null ? output.createdTime : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    lastUpdatedTime:
-      output.lastUpdatedTime !== undefined && output.lastUpdatedTime !== null ? output.lastUpdatedTime : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    arn: __expectString(output.arn),
+    createdTime: __expectString(output.createdTime),
+    description: __expectString(output.description),
+    lastUpdatedTime: __expectString(output.lastUpdatedTime),
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -6895,9 +6874,9 @@ const deserializeAws_json1_1entityTypeList = (output: any, context: __SerdeConte
 
 const deserializeAws_json1_1EventType = (output: any, context: __SerdeContext): EventType => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    createdTime: output.createdTime !== undefined && output.createdTime !== null ? output.createdTime : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    arn: __expectString(output.arn),
+    createdTime: __expectString(output.createdTime),
+    description: __expectString(output.description),
     entityTypes:
       output.entityTypes !== undefined && output.entityTypes !== null
         ? deserializeAws_json1_1NonEmptyListOfStrings(output.entityTypes, context)
@@ -6910,9 +6889,8 @@ const deserializeAws_json1_1EventType = (output: any, context: __SerdeContext): 
       output.labels !== undefined && output.labels !== null
         ? deserializeAws_json1_1ListOfStrings(output.labels, context)
         : undefined,
-    lastUpdatedTime:
-      output.lastUpdatedTime !== undefined && output.lastUpdatedTime !== null ? output.lastUpdatedTime : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    lastUpdatedTime: __expectString(output.lastUpdatedTime),
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -6929,35 +6907,24 @@ const deserializeAws_json1_1eventTypeList = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1ExternalEventsDetail = (output: any, context: __SerdeContext): ExternalEventsDetail => {
   return {
-    dataAccessRoleArn:
-      output.dataAccessRoleArn !== undefined && output.dataAccessRoleArn !== null
-        ? output.dataAccessRoleArn
-        : undefined,
-    dataLocation: output.dataLocation !== undefined && output.dataLocation !== null ? output.dataLocation : undefined,
+    dataAccessRoleArn: __expectString(output.dataAccessRoleArn),
+    dataLocation: __expectString(output.dataLocation),
   } as any;
 };
 
 const deserializeAws_json1_1ExternalModel = (output: any, context: __SerdeContext): ExternalModel => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    createdTime: output.createdTime !== undefined && output.createdTime !== null ? output.createdTime : undefined,
+    arn: __expectString(output.arn),
+    createdTime: __expectString(output.createdTime),
     inputConfiguration:
       output.inputConfiguration !== undefined && output.inputConfiguration !== null
         ? deserializeAws_json1_1ModelInputConfiguration(output.inputConfiguration, context)
         : undefined,
-    invokeModelEndpointRoleArn:
-      output.invokeModelEndpointRoleArn !== undefined && output.invokeModelEndpointRoleArn !== null
-        ? output.invokeModelEndpointRoleArn
-        : undefined,
-    lastUpdatedTime:
-      output.lastUpdatedTime !== undefined && output.lastUpdatedTime !== null ? output.lastUpdatedTime : undefined,
-    modelEndpoint:
-      output.modelEndpoint !== undefined && output.modelEndpoint !== null ? output.modelEndpoint : undefined,
-    modelEndpointStatus:
-      output.modelEndpointStatus !== undefined && output.modelEndpointStatus !== null
-        ? output.modelEndpointStatus
-        : undefined,
-    modelSource: output.modelSource !== undefined && output.modelSource !== null ? output.modelSource : undefined,
+    invokeModelEndpointRoleArn: __expectString(output.invokeModelEndpointRoleArn),
+    lastUpdatedTime: __expectString(output.lastUpdatedTime),
+    modelEndpoint: __expectString(output.modelEndpoint),
+    modelEndpointStatus: __expectString(output.modelEndpointStatus),
+    modelSource: __expectString(output.modelSource),
     outputConfiguration:
       output.outputConfiguration !== undefined && output.outputConfiguration !== null
         ? deserializeAws_json1_1ModelOutputConfiguration(output.outputConfiguration, context)
@@ -6978,11 +6945,11 @@ const deserializeAws_json1_1ExternalModelList = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1FieldValidationMessage = (output: any, context: __SerdeContext): FieldValidationMessage => {
   return {
-    content: output.content !== undefined && output.content !== null ? output.content : undefined,
-    fieldName: output.fieldName !== undefined && output.fieldName !== null ? output.fieldName : undefined,
-    identifier: output.identifier !== undefined && output.identifier !== null ? output.identifier : undefined,
-    title: output.title !== undefined && output.title !== null ? output.title : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    content: __expectString(output.content),
+    fieldName: __expectString(output.fieldName),
+    identifier: __expectString(output.identifier),
+    title: __expectString(output.title),
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -7002,9 +6969,9 @@ const deserializeAws_json1_1fieldValidationMessageList = (
 
 const deserializeAws_json1_1FileValidationMessage = (output: any, context: __SerdeContext): FileValidationMessage => {
   return {
-    content: output.content !== undefined && output.content !== null ? output.content : undefined,
-    title: output.title !== undefined && output.title !== null ? output.title : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    content: __expectString(output.content),
+    title: __expectString(output.title),
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -7031,7 +6998,7 @@ const deserializeAws_json1_1GetBatchPredictionJobsResult = (
       output.batchPredictions !== undefined && output.batchPredictions !== null
         ? deserializeAws_json1_1BatchPredictionList(output.batchPredictions, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -7041,7 +7008,7 @@ const deserializeAws_json1_1GetDetectorsResult = (output: any, context: __SerdeC
       output.detectors !== undefined && output.detectors !== null
         ? deserializeAws_json1_1DetectorList(output.detectors, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -7050,33 +7017,26 @@ const deserializeAws_json1_1GetDetectorVersionResult = (
   context: __SerdeContext
 ): GetDetectorVersionResult => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    createdTime: output.createdTime !== undefined && output.createdTime !== null ? output.createdTime : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    detectorId: output.detectorId !== undefined && output.detectorId !== null ? output.detectorId : undefined,
-    detectorVersionId:
-      output.detectorVersionId !== undefined && output.detectorVersionId !== null
-        ? output.detectorVersionId
-        : undefined,
+    arn: __expectString(output.arn),
+    createdTime: __expectString(output.createdTime),
+    description: __expectString(output.description),
+    detectorId: __expectString(output.detectorId),
+    detectorVersionId: __expectString(output.detectorVersionId),
     externalModelEndpoints:
       output.externalModelEndpoints !== undefined && output.externalModelEndpoints !== null
         ? deserializeAws_json1_1ListOfStrings(output.externalModelEndpoints, context)
         : undefined,
-    lastUpdatedTime:
-      output.lastUpdatedTime !== undefined && output.lastUpdatedTime !== null ? output.lastUpdatedTime : undefined,
+    lastUpdatedTime: __expectString(output.lastUpdatedTime),
     modelVersions:
       output.modelVersions !== undefined && output.modelVersions !== null
         ? deserializeAws_json1_1ListOfModelVersions(output.modelVersions, context)
         : undefined,
-    ruleExecutionMode:
-      output.ruleExecutionMode !== undefined && output.ruleExecutionMode !== null
-        ? output.ruleExecutionMode
-        : undefined,
+    ruleExecutionMode: __expectString(output.ruleExecutionMode),
     rules:
       output.rules !== undefined && output.rules !== null
         ? deserializeAws_json1_1RuleList(output.rules, context)
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -7086,7 +7046,7 @@ const deserializeAws_json1_1GetEntityTypesResult = (output: any, context: __Serd
       output.entityTypes !== undefined && output.entityTypes !== null
         ? deserializeAws_json1_1entityTypeList(output.entityTypes, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -7112,7 +7072,7 @@ const deserializeAws_json1_1GetEventTypesResult = (output: any, context: __Serde
       output.eventTypes !== undefined && output.eventTypes !== null
         ? deserializeAws_json1_1eventTypeList(output.eventTypes, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -7125,7 +7085,7 @@ const deserializeAws_json1_1GetExternalModelsResult = (
       output.externalModels !== undefined && output.externalModels !== null
         ? deserializeAws_json1_1ExternalModelList(output.externalModels, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -7147,7 +7107,7 @@ const deserializeAws_json1_1GetLabelsResult = (output: any, context: __SerdeCont
       output.labels !== undefined && output.labels !== null
         ? deserializeAws_json1_1labelList(output.labels, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -7157,38 +7117,32 @@ const deserializeAws_json1_1GetModelsResult = (output: any, context: __SerdeCont
       output.models !== undefined && output.models !== null
         ? deserializeAws_json1_1modelList(output.models, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
 const deserializeAws_json1_1GetModelVersionResult = (output: any, context: __SerdeContext): GetModelVersionResult => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     externalEventsDetail:
       output.externalEventsDetail !== undefined && output.externalEventsDetail !== null
         ? deserializeAws_json1_1ExternalEventsDetail(output.externalEventsDetail, context)
         : undefined,
-    modelId: output.modelId !== undefined && output.modelId !== null ? output.modelId : undefined,
-    modelType: output.modelType !== undefined && output.modelType !== null ? output.modelType : undefined,
-    modelVersionNumber:
-      output.modelVersionNumber !== undefined && output.modelVersionNumber !== null
-        ? output.modelVersionNumber
-        : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    modelId: __expectString(output.modelId),
+    modelType: __expectString(output.modelType),
+    modelVersionNumber: __expectString(output.modelVersionNumber),
+    status: __expectString(output.status),
     trainingDataSchema:
       output.trainingDataSchema !== undefined && output.trainingDataSchema !== null
         ? deserializeAws_json1_1TrainingDataSchema(output.trainingDataSchema, context)
         : undefined,
-    trainingDataSource:
-      output.trainingDataSource !== undefined && output.trainingDataSource !== null
-        ? output.trainingDataSource
-        : undefined,
+    trainingDataSource: __expectString(output.trainingDataSource),
   } as any;
 };
 
 const deserializeAws_json1_1GetOutcomesResult = (output: any, context: __SerdeContext): GetOutcomesResult => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     outcomes:
       output.outcomes !== undefined && output.outcomes !== null
         ? deserializeAws_json1_1OutcomeList(output.outcomes, context)
@@ -7198,7 +7152,7 @@ const deserializeAws_json1_1GetOutcomesResult = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1GetRulesResult = (output: any, context: __SerdeContext): GetRulesResult => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     ruleDetails:
       output.ruleDetails !== undefined && output.ruleDetails !== null
         ? deserializeAws_json1_1RuleDetailList(output.ruleDetails, context)
@@ -7208,7 +7162,7 @@ const deserializeAws_json1_1GetRulesResult = (output: any, context: __SerdeConte
 
 const deserializeAws_json1_1GetVariablesResult = (output: any, context: __SerdeContext): GetVariablesResult => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     variables:
       output.variables !== undefined && output.variables !== null
         ? deserializeAws_json1_1VariableList(output.variables, context)
@@ -7221,7 +7175,7 @@ const deserializeAws_json1_1InternalServerException = (
   context: __SerdeContext
 ): InternalServerException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -7235,28 +7189,24 @@ const deserializeAws_json1_1JsonKeyToVariableMap = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_json1_1KMSKey = (output: any, context: __SerdeContext): KMSKey => {
   return {
-    kmsEncryptionKeyArn:
-      output.kmsEncryptionKeyArn !== undefined && output.kmsEncryptionKeyArn !== null
-        ? output.kmsEncryptionKeyArn
-        : undefined,
+    kmsEncryptionKeyArn: __expectString(output.kmsEncryptionKeyArn),
   } as any;
 };
 
 const deserializeAws_json1_1Label = (output: any, context: __SerdeContext): Label => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    createdTime: output.createdTime !== undefined && output.createdTime !== null ? output.createdTime : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    lastUpdatedTime:
-      output.lastUpdatedTime !== undefined && output.lastUpdatedTime !== null ? output.lastUpdatedTime : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    arn: __expectString(output.arn),
+    createdTime: __expectString(output.createdTime),
+    description: __expectString(output.description),
+    lastUpdatedTime: __expectString(output.lastUpdatedTime),
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -7332,7 +7282,7 @@ const deserializeAws_json1_1ListOfStrings = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7341,7 +7291,7 @@ const deserializeAws_json1_1ListTagsForResourceResult = (
   context: __SerdeContext
 ): ListTagsForResourceResult => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_json1_1tagList(output.tags, context)
@@ -7351,10 +7301,10 @@ const deserializeAws_json1_1ListTagsForResourceResult = (
 
 const deserializeAws_json1_1MetricDataPoint = (output: any, context: __SerdeContext): MetricDataPoint => {
   return {
-    fpr: output.fpr !== undefined && output.fpr !== null ? output.fpr : undefined,
-    precision: output.precision !== undefined && output.precision !== null ? output.precision : undefined,
-    threshold: output.threshold !== undefined && output.threshold !== null ? output.threshold : undefined,
-    tpr: output.tpr !== undefined && output.tpr !== null ? output.tpr : undefined,
+    fpr: __expectNumber(output.fpr),
+    precision: __expectNumber(output.precision),
+    threshold: __expectNumber(output.threshold),
+    tpr: __expectNumber(output.tpr),
   } as any;
 };
 
@@ -7371,15 +7321,13 @@ const deserializeAws_json1_1metricDataPointsList = (output: any, context: __Serd
 
 const deserializeAws_json1_1Model = (output: any, context: __SerdeContext): Model => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    createdTime: output.createdTime !== undefined && output.createdTime !== null ? output.createdTime : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    eventTypeName:
-      output.eventTypeName !== undefined && output.eventTypeName !== null ? output.eventTypeName : undefined,
-    lastUpdatedTime:
-      output.lastUpdatedTime !== undefined && output.lastUpdatedTime !== null ? output.lastUpdatedTime : undefined,
-    modelId: output.modelId !== undefined && output.modelId !== null ? output.modelId : undefined,
-    modelType: output.modelType !== undefined && output.modelType !== null ? output.modelType : undefined,
+    arn: __expectString(output.arn),
+    createdTime: __expectString(output.createdTime),
+    description: __expectString(output.description),
+    eventTypeName: __expectString(output.eventTypeName),
+    lastUpdatedTime: __expectString(output.lastUpdatedTime),
+    modelId: __expectString(output.modelId),
+    modelType: __expectString(output.modelType),
   } as any;
 };
 
@@ -7388,19 +7336,11 @@ const deserializeAws_json1_1ModelInputConfiguration = (
   context: __SerdeContext
 ): ModelInputConfiguration => {
   return {
-    csvInputTemplate:
-      output.csvInputTemplate !== undefined && output.csvInputTemplate !== null ? output.csvInputTemplate : undefined,
-    eventTypeName:
-      output.eventTypeName !== undefined && output.eventTypeName !== null ? output.eventTypeName : undefined,
-    format: output.format !== undefined && output.format !== null ? output.format : undefined,
-    jsonInputTemplate:
-      output.jsonInputTemplate !== undefined && output.jsonInputTemplate !== null
-        ? output.jsonInputTemplate
-        : undefined,
-    useEventVariables:
-      output.useEventVariables !== undefined && output.useEventVariables !== null
-        ? output.useEventVariables
-        : undefined,
+    csvInputTemplate: __expectString(output.csvInputTemplate),
+    eventTypeName: __expectString(output.eventTypeName),
+    format: __expectString(output.format),
+    jsonInputTemplate: __expectString(output.jsonInputTemplate),
+    useEventVariables: __expectBoolean(output.useEventVariables),
   } as any;
 };
 
@@ -7424,7 +7364,7 @@ const deserializeAws_json1_1ModelOutputConfiguration = (
       output.csvIndexToVariableMap !== undefined && output.csvIndexToVariableMap !== null
         ? deserializeAws_json1_1CsvIndexToVariableMap(output.csvIndexToVariableMap, context)
         : undefined,
-    format: output.format !== undefined && output.format !== null ? output.format : undefined,
+    format: __expectString(output.format),
     jsonKeyToVariableMap:
       output.jsonKeyToVariableMap !== undefined && output.jsonKeyToVariableMap !== null
         ? deserializeAws_json1_1JsonKeyToVariableMap(output.jsonKeyToVariableMap, context)
@@ -7439,7 +7379,7 @@ const deserializeAws_json1_1ModelPredictionMap = (output: any, context: __SerdeC
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectNumber(value) as any,
     };
   }, {});
 };
@@ -7459,41 +7399,31 @@ const deserializeAws_json1_1ModelScores = (output: any, context: __SerdeContext)
 
 const deserializeAws_json1_1ModelVersion = (output: any, context: __SerdeContext): ModelVersion => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    modelId: output.modelId !== undefined && output.modelId !== null ? output.modelId : undefined,
-    modelType: output.modelType !== undefined && output.modelType !== null ? output.modelType : undefined,
-    modelVersionNumber:
-      output.modelVersionNumber !== undefined && output.modelVersionNumber !== null
-        ? output.modelVersionNumber
-        : undefined,
+    arn: __expectString(output.arn),
+    modelId: __expectString(output.modelId),
+    modelType: __expectString(output.modelType),
+    modelVersionNumber: __expectString(output.modelVersionNumber),
   } as any;
 };
 
 const deserializeAws_json1_1ModelVersionDetail = (output: any, context: __SerdeContext): ModelVersionDetail => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    createdTime: output.createdTime !== undefined && output.createdTime !== null ? output.createdTime : undefined,
+    arn: __expectString(output.arn),
+    createdTime: __expectString(output.createdTime),
     externalEventsDetail:
       output.externalEventsDetail !== undefined && output.externalEventsDetail !== null
         ? deserializeAws_json1_1ExternalEventsDetail(output.externalEventsDetail, context)
         : undefined,
-    lastUpdatedTime:
-      output.lastUpdatedTime !== undefined && output.lastUpdatedTime !== null ? output.lastUpdatedTime : undefined,
-    modelId: output.modelId !== undefined && output.modelId !== null ? output.modelId : undefined,
-    modelType: output.modelType !== undefined && output.modelType !== null ? output.modelType : undefined,
-    modelVersionNumber:
-      output.modelVersionNumber !== undefined && output.modelVersionNumber !== null
-        ? output.modelVersionNumber
-        : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    lastUpdatedTime: __expectString(output.lastUpdatedTime),
+    modelId: __expectString(output.modelId),
+    modelType: __expectString(output.modelType),
+    modelVersionNumber: __expectString(output.modelVersionNumber),
+    status: __expectString(output.status),
     trainingDataSchema:
       output.trainingDataSchema !== undefined && output.trainingDataSchema !== null
         ? deserializeAws_json1_1TrainingDataSchema(output.trainingDataSchema, context)
         : undefined,
-    trainingDataSource:
-      output.trainingDataSource !== undefined && output.trainingDataSource !== null
-        ? output.trainingDataSource
-        : undefined,
+    trainingDataSource: __expectString(output.trainingDataSource),
     trainingResult:
       output.trainingResult !== undefined && output.trainingResult !== null
         ? deserializeAws_json1_1TrainingResult(output.trainingResult, context)
@@ -7519,18 +7449,17 @@ const deserializeAws_json1_1NonEmptyListOfStrings = (output: any, context: __Ser
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1Outcome = (output: any, context: __SerdeContext): Outcome => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    createdTime: output.createdTime !== undefined && output.createdTime !== null ? output.createdTime : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    lastUpdatedTime:
-      output.lastUpdatedTime !== undefined && output.lastUpdatedTime !== null ? output.lastUpdatedTime : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    arn: __expectString(output.arn),
+    createdTime: __expectString(output.createdTime),
+    description: __expectString(output.description),
+    lastUpdatedTime: __expectString(output.lastUpdatedTime),
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -7581,34 +7510,33 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1Rule = (output: any, context: __SerdeContext): Rule => {
   return {
-    detectorId: output.detectorId !== undefined && output.detectorId !== null ? output.detectorId : undefined,
-    ruleId: output.ruleId !== undefined && output.ruleId !== null ? output.ruleId : undefined,
-    ruleVersion: output.ruleVersion !== undefined && output.ruleVersion !== null ? output.ruleVersion : undefined,
+    detectorId: __expectString(output.detectorId),
+    ruleId: __expectString(output.ruleId),
+    ruleVersion: __expectString(output.ruleVersion),
   } as any;
 };
 
 const deserializeAws_json1_1RuleDetail = (output: any, context: __SerdeContext): RuleDetail => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    createdTime: output.createdTime !== undefined && output.createdTime !== null ? output.createdTime : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    detectorId: output.detectorId !== undefined && output.detectorId !== null ? output.detectorId : undefined,
-    expression: output.expression !== undefined && output.expression !== null ? output.expression : undefined,
-    language: output.language !== undefined && output.language !== null ? output.language : undefined,
-    lastUpdatedTime:
-      output.lastUpdatedTime !== undefined && output.lastUpdatedTime !== null ? output.lastUpdatedTime : undefined,
+    arn: __expectString(output.arn),
+    createdTime: __expectString(output.createdTime),
+    description: __expectString(output.description),
+    detectorId: __expectString(output.detectorId),
+    expression: __expectString(output.expression),
+    language: __expectString(output.language),
+    lastUpdatedTime: __expectString(output.lastUpdatedTime),
     outcomes:
       output.outcomes !== undefined && output.outcomes !== null
         ? deserializeAws_json1_1NonEmptyListOfStrings(output.outcomes, context)
         : undefined,
-    ruleId: output.ruleId !== undefined && output.ruleId !== null ? output.ruleId : undefined,
-    ruleVersion: output.ruleVersion !== undefined && output.ruleVersion !== null ? output.ruleVersion : undefined,
+    ruleId: __expectString(output.ruleId),
+    ruleVersion: __expectString(output.ruleVersion),
   } as any;
 };
 
@@ -7640,14 +7568,14 @@ const deserializeAws_json1_1RuleResult = (output: any, context: __SerdeContext):
       output.outcomes !== undefined && output.outcomes !== null
         ? deserializeAws_json1_1ListOfStrings(output.outcomes, context)
         : undefined,
-    ruleId: output.ruleId !== undefined && output.ruleId !== null ? output.ruleId : undefined,
+    ruleId: __expectString(output.ruleId),
   } as any;
 };
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    key: __expectString(output.key),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -7668,7 +7596,7 @@ const deserializeAws_json1_1TagResourceResult = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1ThrottlingException = (output: any, context: __SerdeContext): ThrottlingException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -7687,7 +7615,7 @@ const deserializeAws_json1_1TrainingDataSchema = (output: any, context: __SerdeC
 
 const deserializeAws_json1_1TrainingMetrics = (output: any, context: __SerdeContext): TrainingMetrics => {
   return {
-    auc: output.auc !== undefined && output.auc !== null ? output.auc : undefined,
+    auc: __expectNumber(output.auc),
     metricDataPoints:
       output.metricDataPoints !== undefined && output.metricDataPoints !== null
         ? deserializeAws_json1_1metricDataPointsList(output.metricDataPoints, context)
@@ -7742,13 +7670,10 @@ const deserializeAws_json1_1UpdateModelVersionResult = (
   context: __SerdeContext
 ): UpdateModelVersionResult => {
   return {
-    modelId: output.modelId !== undefined && output.modelId !== null ? output.modelId : undefined,
-    modelType: output.modelType !== undefined && output.modelType !== null ? output.modelType : undefined,
-    modelVersionNumber:
-      output.modelVersionNumber !== undefined && output.modelVersionNumber !== null
-        ? output.modelVersionNumber
-        : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    modelId: __expectString(output.modelId),
+    modelType: __expectString(output.modelType),
+    modelVersionNumber: __expectString(output.modelVersionNumber),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -7782,22 +7707,21 @@ const deserializeAws_json1_1UpdateVariableResult = (output: any, context: __Serd
 
 const deserializeAws_json1_1ValidationException = (output: any, context: __SerdeContext): ValidationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1Variable = (output: any, context: __SerdeContext): Variable => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    createdTime: output.createdTime !== undefined && output.createdTime !== null ? output.createdTime : undefined,
-    dataSource: output.dataSource !== undefined && output.dataSource !== null ? output.dataSource : undefined,
-    dataType: output.dataType !== undefined && output.dataType !== null ? output.dataType : undefined,
-    defaultValue: output.defaultValue !== undefined && output.defaultValue !== null ? output.defaultValue : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    lastUpdatedTime:
-      output.lastUpdatedTime !== undefined && output.lastUpdatedTime !== null ? output.lastUpdatedTime : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    variableType: output.variableType !== undefined && output.variableType !== null ? output.variableType : undefined,
+    arn: __expectString(output.arn),
+    createdTime: __expectString(output.createdTime),
+    dataSource: __expectString(output.dataSource),
+    dataType: __expectString(output.dataType),
+    defaultValue: __expectString(output.defaultValue),
+    description: __expectString(output.description),
+    lastUpdatedTime: __expectString(output.lastUpdatedTime),
+    name: __expectString(output.name),
+    variableType: __expectString(output.variableType),
   } as any;
 };
 

--- a/clients/client-fsx/protocols/Aws_json1_1.ts
+++ b/clients/client-fsx/protocols/Aws_json1_1.ts
@@ -142,7 +142,12 @@ import {
   WindowsFileSystemConfiguration,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -3110,43 +3115,33 @@ const deserializeAws_json1_1ActiveDirectoryBackupAttributes = (
   context: __SerdeContext
 ): ActiveDirectoryBackupAttributes => {
   return {
-    ActiveDirectoryId:
-      output.ActiveDirectoryId !== undefined && output.ActiveDirectoryId !== null
-        ? output.ActiveDirectoryId
-        : undefined,
-    DomainName: output.DomainName !== undefined && output.DomainName !== null ? output.DomainName : undefined,
-    ResourceARN: output.ResourceARN !== undefined && output.ResourceARN !== null ? output.ResourceARN : undefined,
+    ActiveDirectoryId: __expectString(output.ActiveDirectoryId),
+    DomainName: __expectString(output.DomainName),
+    ResourceARN: __expectString(output.ResourceARN),
   } as any;
 };
 
 const deserializeAws_json1_1ActiveDirectoryError = (output: any, context: __SerdeContext): ActiveDirectoryError => {
   return {
-    ActiveDirectoryId:
-      output.ActiveDirectoryId !== undefined && output.ActiveDirectoryId !== null
-        ? output.ActiveDirectoryId
-        : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    ActiveDirectoryId: __expectString(output.ActiveDirectoryId),
+    Message: __expectString(output.Message),
+    Type: __expectString(output.Type),
   } as any;
 };
 
 const deserializeAws_json1_1AdministrativeAction = (output: any, context: __SerdeContext): AdministrativeAction => {
   return {
-    AdministrativeActionType:
-      output.AdministrativeActionType !== undefined && output.AdministrativeActionType !== null
-        ? output.AdministrativeActionType
-        : undefined,
+    AdministrativeActionType: __expectString(output.AdministrativeActionType),
     FailureDetails:
       output.FailureDetails !== undefined && output.FailureDetails !== null
         ? deserializeAws_json1_1AdministrativeActionFailureDetails(output.FailureDetails, context)
         : undefined,
-    ProgressPercent:
-      output.ProgressPercent !== undefined && output.ProgressPercent !== null ? output.ProgressPercent : undefined,
+    ProgressPercent: __expectNumber(output.ProgressPercent),
     RequestTime:
       output.RequestTime !== undefined && output.RequestTime !== null
         ? new Date(Math.round(output.RequestTime * 1000))
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
     TargetFileSystemValues:
       output.TargetFileSystemValues !== undefined && output.TargetFileSystemValues !== null
         ? deserializeAws_json1_1FileSystem(output.TargetFileSystemValues, context)
@@ -3159,7 +3154,7 @@ const deserializeAws_json1_1AdministrativeActionFailureDetails = (
   context: __SerdeContext
 ): AdministrativeActionFailureDetails => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3176,8 +3171,8 @@ const deserializeAws_json1_1AdministrativeActions = (output: any, context: __Ser
 
 const deserializeAws_json1_1Alias = (output: any, context: __SerdeContext): Alias => {
   return {
-    Lifecycle: output.Lifecycle !== undefined && output.Lifecycle !== null ? output.Lifecycle : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Lifecycle: __expectString(output.Lifecycle),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -3206,7 +3201,7 @@ const deserializeAws_json1_1AssociateFileSystemAliasesResponse = (
 
 const deserializeAws_json1_1Backup = (output: any, context: __SerdeContext): Backup => {
   return {
-    BackupId: output.BackupId !== undefined && output.BackupId !== null ? output.BackupId : undefined,
+    BackupId: __expectString(output.BackupId),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -3223,53 +3218,48 @@ const deserializeAws_json1_1Backup = (output: any, context: __SerdeContext): Bac
       output.FileSystem !== undefined && output.FileSystem !== null
         ? deserializeAws_json1_1FileSystem(output.FileSystem, context)
         : undefined,
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
-    Lifecycle: output.Lifecycle !== undefined && output.Lifecycle !== null ? output.Lifecycle : undefined,
-    OwnerId: output.OwnerId !== undefined && output.OwnerId !== null ? output.OwnerId : undefined,
-    ProgressPercent:
-      output.ProgressPercent !== undefined && output.ProgressPercent !== null ? output.ProgressPercent : undefined,
-    ResourceARN: output.ResourceARN !== undefined && output.ResourceARN !== null ? output.ResourceARN : undefined,
-    SourceBackupId:
-      output.SourceBackupId !== undefined && output.SourceBackupId !== null ? output.SourceBackupId : undefined,
-    SourceBackupRegion:
-      output.SourceBackupRegion !== undefined && output.SourceBackupRegion !== null
-        ? output.SourceBackupRegion
-        : undefined,
+    KmsKeyId: __expectString(output.KmsKeyId),
+    Lifecycle: __expectString(output.Lifecycle),
+    OwnerId: __expectString(output.OwnerId),
+    ProgressPercent: __expectNumber(output.ProgressPercent),
+    ResourceARN: __expectString(output.ResourceARN),
+    SourceBackupId: __expectString(output.SourceBackupId),
+    SourceBackupRegion: __expectString(output.SourceBackupRegion),
     Tags:
       output.Tags !== undefined && output.Tags !== null ? deserializeAws_json1_1Tags(output.Tags, context) : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
 const deserializeAws_json1_1BackupBeingCopied = (output: any, context: __SerdeContext): BackupBeingCopied => {
   return {
-    BackupId: output.BackupId !== undefined && output.BackupId !== null ? output.BackupId : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    BackupId: __expectString(output.BackupId),
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1BackupFailureDetails = (output: any, context: __SerdeContext): BackupFailureDetails => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1BackupInProgress = (output: any, context: __SerdeContext): BackupInProgress => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1BackupNotFound = (output: any, context: __SerdeContext): BackupNotFound => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1BackupRestoring = (output: any, context: __SerdeContext): BackupRestoring => {
   return {
-    FileSystemId: output.FileSystemId !== undefined && output.FileSystemId !== null ? output.FileSystemId : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    FileSystemId: __expectString(output.FileSystemId),
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3286,7 +3276,7 @@ const deserializeAws_json1_1Backups = (output: any, context: __SerdeContext): Ba
 
 const deserializeAws_json1_1BadRequest = (output: any, context: __SerdeContext): BadRequest => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3295,17 +3285,17 @@ const deserializeAws_json1_1CancelDataRepositoryTaskResponse = (
   context: __SerdeContext
 ): CancelDataRepositoryTaskResponse => {
   return {
-    Lifecycle: output.Lifecycle !== undefined && output.Lifecycle !== null ? output.Lifecycle : undefined,
-    TaskId: output.TaskId !== undefined && output.TaskId !== null ? output.TaskId : undefined,
+    Lifecycle: __expectString(output.Lifecycle),
+    TaskId: __expectString(output.TaskId),
   } as any;
 };
 
 const deserializeAws_json1_1CompletionReport = (output: any, context: __SerdeContext): CompletionReport => {
   return {
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
-    Format: output.Format !== undefined && output.Format !== null ? output.Format : undefined,
-    Path: output.Path !== undefined && output.Path !== null ? output.Path : undefined,
-    Scope: output.Scope !== undefined && output.Scope !== null ? output.Scope : undefined,
+    Enabled: __expectBoolean(output.Enabled),
+    Format: __expectString(output.Format),
+    Path: __expectString(output.Path),
+    Scope: __expectString(output.Scope),
   } as any;
 };
 
@@ -3368,19 +3358,15 @@ const deserializeAws_json1_1DataRepositoryConfiguration = (
   context: __SerdeContext
 ): DataRepositoryConfiguration => {
   return {
-    AutoImportPolicy:
-      output.AutoImportPolicy !== undefined && output.AutoImportPolicy !== null ? output.AutoImportPolicy : undefined,
-    ExportPath: output.ExportPath !== undefined && output.ExportPath !== null ? output.ExportPath : undefined,
+    AutoImportPolicy: __expectString(output.AutoImportPolicy),
+    ExportPath: __expectString(output.ExportPath),
     FailureDetails:
       output.FailureDetails !== undefined && output.FailureDetails !== null
         ? deserializeAws_json1_1DataRepositoryFailureDetails(output.FailureDetails, context)
         : undefined,
-    ImportPath: output.ImportPath !== undefined && output.ImportPath !== null ? output.ImportPath : undefined,
-    ImportedFileChunkSize:
-      output.ImportedFileChunkSize !== undefined && output.ImportedFileChunkSize !== null
-        ? output.ImportedFileChunkSize
-        : undefined,
-    Lifecycle: output.Lifecycle !== undefined && output.Lifecycle !== null ? output.Lifecycle : undefined,
+    ImportPath: __expectString(output.ImportPath),
+    ImportedFileChunkSize: __expectNumber(output.ImportedFileChunkSize),
+    Lifecycle: __expectString(output.Lifecycle),
   } as any;
 };
 
@@ -3389,7 +3375,7 @@ const deserializeAws_json1_1DataRepositoryFailureDetails = (
   context: __SerdeContext
 ): DataRepositoryFailureDetails => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3405,8 +3391,8 @@ const deserializeAws_json1_1DataRepositoryTask = (output: any, context: __SerdeC
       output.FailureDetails !== undefined && output.FailureDetails !== null
         ? deserializeAws_json1_1DataRepositoryTaskFailureDetails(output.FailureDetails, context)
         : undefined,
-    FileSystemId: output.FileSystemId !== undefined && output.FileSystemId !== null ? output.FileSystemId : undefined,
-    Lifecycle: output.Lifecycle !== undefined && output.Lifecycle !== null ? output.Lifecycle : undefined,
+    FileSystemId: __expectString(output.FileSystemId),
+    Lifecycle: __expectString(output.Lifecycle),
     Paths:
       output.Paths !== undefined && output.Paths !== null
         ? deserializeAws_json1_1DataRepositoryTaskPaths(output.Paths, context)
@@ -3415,7 +3401,7 @@ const deserializeAws_json1_1DataRepositoryTask = (output: any, context: __SerdeC
       output.Report !== undefined && output.Report !== null
         ? deserializeAws_json1_1CompletionReport(output.Report, context)
         : undefined,
-    ResourceARN: output.ResourceARN !== undefined && output.ResourceARN !== null ? output.ResourceARN : undefined,
+    ResourceARN: __expectString(output.ResourceARN),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
         ? new Date(Math.round(output.StartTime * 1000))
@@ -3426,8 +3412,8 @@ const deserializeAws_json1_1DataRepositoryTask = (output: any, context: __SerdeC
         : undefined,
     Tags:
       output.Tags !== undefined && output.Tags !== null ? deserializeAws_json1_1Tags(output.Tags, context) : undefined,
-    TaskId: output.TaskId !== undefined && output.TaskId !== null ? output.TaskId : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    TaskId: __expectString(output.TaskId),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -3436,7 +3422,7 @@ const deserializeAws_json1_1DataRepositoryTaskEnded = (
   context: __SerdeContext
 ): DataRepositoryTaskEnded => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3445,7 +3431,7 @@ const deserializeAws_json1_1DataRepositoryTaskExecuting = (
   context: __SerdeContext
 ): DataRepositoryTaskExecuting => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3454,7 +3440,7 @@ const deserializeAws_json1_1DataRepositoryTaskFailureDetails = (
   context: __SerdeContext
 ): DataRepositoryTaskFailureDetails => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3463,7 +3449,7 @@ const deserializeAws_json1_1DataRepositoryTaskNotFound = (
   context: __SerdeContext
 ): DataRepositoryTaskNotFound => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3474,7 +3460,7 @@ const deserializeAws_json1_1DataRepositoryTaskPaths = (output: any, context: __S
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3494,21 +3480,20 @@ const deserializeAws_json1_1DataRepositoryTaskStatus = (
   context: __SerdeContext
 ): DataRepositoryTaskStatus => {
   return {
-    FailedCount: output.FailedCount !== undefined && output.FailedCount !== null ? output.FailedCount : undefined,
+    FailedCount: __expectNumber(output.FailedCount),
     LastUpdatedTime:
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
         ? new Date(Math.round(output.LastUpdatedTime * 1000))
         : undefined,
-    SucceededCount:
-      output.SucceededCount !== undefined && output.SucceededCount !== null ? output.SucceededCount : undefined,
-    TotalCount: output.TotalCount !== undefined && output.TotalCount !== null ? output.TotalCount : undefined,
+    SucceededCount: __expectNumber(output.SucceededCount),
+    TotalCount: __expectNumber(output.TotalCount),
   } as any;
 };
 
 const deserializeAws_json1_1DeleteBackupResponse = (output: any, context: __SerdeContext): DeleteBackupResponse => {
   return {
-    BackupId: output.BackupId !== undefined && output.BackupId !== null ? output.BackupId : undefined,
-    Lifecycle: output.Lifecycle !== undefined && output.Lifecycle !== null ? output.Lifecycle : undefined,
+    BackupId: __expectString(output.BackupId),
+    Lifecycle: __expectString(output.Lifecycle),
   } as any;
 };
 
@@ -3517,8 +3502,7 @@ const deserializeAws_json1_1DeleteFileSystemLustreResponse = (
   context: __SerdeContext
 ): DeleteFileSystemLustreResponse => {
   return {
-    FinalBackupId:
-      output.FinalBackupId !== undefined && output.FinalBackupId !== null ? output.FinalBackupId : undefined,
+    FinalBackupId: __expectString(output.FinalBackupId),
     FinalBackupTags:
       output.FinalBackupTags !== undefined && output.FinalBackupTags !== null
         ? deserializeAws_json1_1Tags(output.FinalBackupTags, context)
@@ -3531,8 +3515,8 @@ const deserializeAws_json1_1DeleteFileSystemResponse = (
   context: __SerdeContext
 ): DeleteFileSystemResponse => {
   return {
-    FileSystemId: output.FileSystemId !== undefined && output.FileSystemId !== null ? output.FileSystemId : undefined,
-    Lifecycle: output.Lifecycle !== undefined && output.Lifecycle !== null ? output.Lifecycle : undefined,
+    FileSystemId: __expectString(output.FileSystemId),
+    Lifecycle: __expectString(output.Lifecycle),
     LustreResponse:
       output.LustreResponse !== undefined && output.LustreResponse !== null
         ? deserializeAws_json1_1DeleteFileSystemLustreResponse(output.LustreResponse, context)
@@ -3549,8 +3533,7 @@ const deserializeAws_json1_1DeleteFileSystemWindowsResponse = (
   context: __SerdeContext
 ): DeleteFileSystemWindowsResponse => {
   return {
-    FinalBackupId:
-      output.FinalBackupId !== undefined && output.FinalBackupId !== null ? output.FinalBackupId : undefined,
+    FinalBackupId: __expectString(output.FinalBackupId),
     FinalBackupTags:
       output.FinalBackupTags !== undefined && output.FinalBackupTags !== null
         ? deserializeAws_json1_1Tags(output.FinalBackupTags, context)
@@ -3567,7 +3550,7 @@ const deserializeAws_json1_1DescribeBackupsResponse = (
       output.Backups !== undefined && output.Backups !== null
         ? deserializeAws_json1_1Backups(output.Backups, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -3580,7 +3563,7 @@ const deserializeAws_json1_1DescribeDataRepositoryTasksResponse = (
       output.DataRepositoryTasks !== undefined && output.DataRepositoryTasks !== null
         ? deserializeAws_json1_1DataRepositoryTasks(output.DataRepositoryTasks, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -3593,7 +3576,7 @@ const deserializeAws_json1_1DescribeFileSystemAliasesResponse = (
       output.Aliases !== undefined && output.Aliases !== null
         ? deserializeAws_json1_1Aliases(output.Aliases, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -3606,7 +3589,7 @@ const deserializeAws_json1_1DescribeFileSystemsResponse = (
       output.FileSystems !== undefined && output.FileSystems !== null
         ? deserializeAws_json1_1FileSystems(output.FileSystems, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -3629,7 +3612,7 @@ const deserializeAws_json1_1DnsIps = (output: any, context: __SerdeContext): str
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3643,16 +3626,15 @@ const deserializeAws_json1_1FileSystem = (output: any, context: __SerdeContext):
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    DNSName: output.DNSName !== undefined && output.DNSName !== null ? output.DNSName : undefined,
+    DNSName: __expectString(output.DNSName),
     FailureDetails:
       output.FailureDetails !== undefined && output.FailureDetails !== null
         ? deserializeAws_json1_1FileSystemFailureDetails(output.FailureDetails, context)
         : undefined,
-    FileSystemId: output.FileSystemId !== undefined && output.FileSystemId !== null ? output.FileSystemId : undefined,
-    FileSystemType:
-      output.FileSystemType !== undefined && output.FileSystemType !== null ? output.FileSystemType : undefined,
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
-    Lifecycle: output.Lifecycle !== undefined && output.Lifecycle !== null ? output.Lifecycle : undefined,
+    FileSystemId: __expectString(output.FileSystemId),
+    FileSystemType: __expectString(output.FileSystemType),
+    KmsKeyId: __expectString(output.KmsKeyId),
+    Lifecycle: __expectString(output.Lifecycle),
     LustreConfiguration:
       output.LustreConfiguration !== undefined && output.LustreConfiguration !== null
         ? deserializeAws_json1_1LustreFileSystemConfiguration(output.LustreConfiguration, context)
@@ -3661,18 +3643,17 @@ const deserializeAws_json1_1FileSystem = (output: any, context: __SerdeContext):
       output.NetworkInterfaceIds !== undefined && output.NetworkInterfaceIds !== null
         ? deserializeAws_json1_1NetworkInterfaceIds(output.NetworkInterfaceIds, context)
         : undefined,
-    OwnerId: output.OwnerId !== undefined && output.OwnerId !== null ? output.OwnerId : undefined,
-    ResourceARN: output.ResourceARN !== undefined && output.ResourceARN !== null ? output.ResourceARN : undefined,
-    StorageCapacity:
-      output.StorageCapacity !== undefined && output.StorageCapacity !== null ? output.StorageCapacity : undefined,
-    StorageType: output.StorageType !== undefined && output.StorageType !== null ? output.StorageType : undefined,
+    OwnerId: __expectString(output.OwnerId),
+    ResourceARN: __expectString(output.ResourceARN),
+    StorageCapacity: __expectNumber(output.StorageCapacity),
+    StorageType: __expectString(output.StorageType),
     SubnetIds:
       output.SubnetIds !== undefined && output.SubnetIds !== null
         ? deserializeAws_json1_1SubnetIds(output.SubnetIds, context)
         : undefined,
     Tags:
       output.Tags !== undefined && output.Tags !== null ? deserializeAws_json1_1Tags(output.Tags, context) : undefined,
-    VpcId: output.VpcId !== undefined && output.VpcId !== null ? output.VpcId : undefined,
+    VpcId: __expectString(output.VpcId),
     WindowsConfiguration:
       output.WindowsConfiguration !== undefined && output.WindowsConfiguration !== null
         ? deserializeAws_json1_1WindowsFileSystemConfiguration(output.WindowsConfiguration, context)
@@ -3685,7 +3666,7 @@ const deserializeAws_json1_1FileSystemFailureDetails = (
   context: __SerdeContext
 ): FileSystemFailureDetails => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3699,13 +3680,13 @@ const deserializeAws_json1_1FileSystemMaintenanceOperations = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1FileSystemNotFound = (output: any, context: __SerdeContext): FileSystemNotFound => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3725,8 +3706,8 @@ const deserializeAws_json1_1IncompatibleParameterError = (
   context: __SerdeContext
 ): IncompatibleParameterError => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Parameter: output.Parameter !== undefined && output.Parameter !== null ? output.Parameter : undefined,
+    Message: __expectString(output.Message),
+    Parameter: __expectString(output.Parameter),
   } as any;
 };
 
@@ -3735,13 +3716,13 @@ const deserializeAws_json1_1IncompatibleRegionForMultiAZ = (
   context: __SerdeContext
 ): IncompatibleRegionForMultiAZ => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1InternalServerError = (output: any, context: __SerdeContext): InternalServerError => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3750,31 +3731,27 @@ const deserializeAws_json1_1InvalidDestinationKmsKey = (
   context: __SerdeContext
 ): InvalidDestinationKmsKey => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidExportPath = (output: any, context: __SerdeContext): InvalidExportPath => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidImportPath = (output: any, context: __SerdeContext): InvalidImportPath => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidNetworkSettings = (output: any, context: __SerdeContext): InvalidNetworkSettings => {
   return {
-    InvalidSecurityGroupId:
-      output.InvalidSecurityGroupId !== undefined && output.InvalidSecurityGroupId !== null
-        ? output.InvalidSecurityGroupId
-        : undefined,
-    InvalidSubnetId:
-      output.InvalidSubnetId !== undefined && output.InvalidSubnetId !== null ? output.InvalidSubnetId : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    InvalidSecurityGroupId: __expectString(output.InvalidSecurityGroupId),
+    InvalidSubnetId: __expectString(output.InvalidSubnetId),
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3783,19 +3760,19 @@ const deserializeAws_json1_1InvalidPerUnitStorageThroughput = (
   context: __SerdeContext
 ): InvalidPerUnitStorageThroughput => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidRegion = (output: any, context: __SerdeContext): InvalidRegion => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidSourceKmsKey = (output: any, context: __SerdeContext): InvalidSourceKmsKey => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3804,7 +3781,7 @@ const deserializeAws_json1_1ListTagsForResourceResponse = (
   context: __SerdeContext
 ): ListTagsForResourceResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Tags:
       output.Tags !== undefined && output.Tags !== null ? deserializeAws_json1_1Tags(output.Tags, context) : undefined,
   } as any;
@@ -3815,39 +3792,19 @@ const deserializeAws_json1_1LustreFileSystemConfiguration = (
   context: __SerdeContext
 ): LustreFileSystemConfiguration => {
   return {
-    AutomaticBackupRetentionDays:
-      output.AutomaticBackupRetentionDays !== undefined && output.AutomaticBackupRetentionDays !== null
-        ? output.AutomaticBackupRetentionDays
-        : undefined,
-    CopyTagsToBackups:
-      output.CopyTagsToBackups !== undefined && output.CopyTagsToBackups !== null
-        ? output.CopyTagsToBackups
-        : undefined,
-    DailyAutomaticBackupStartTime:
-      output.DailyAutomaticBackupStartTime !== undefined && output.DailyAutomaticBackupStartTime !== null
-        ? output.DailyAutomaticBackupStartTime
-        : undefined,
-    DataCompressionType:
-      output.DataCompressionType !== undefined && output.DataCompressionType !== null
-        ? output.DataCompressionType
-        : undefined,
+    AutomaticBackupRetentionDays: __expectNumber(output.AutomaticBackupRetentionDays),
+    CopyTagsToBackups: __expectBoolean(output.CopyTagsToBackups),
+    DailyAutomaticBackupStartTime: __expectString(output.DailyAutomaticBackupStartTime),
+    DataCompressionType: __expectString(output.DataCompressionType),
     DataRepositoryConfiguration:
       output.DataRepositoryConfiguration !== undefined && output.DataRepositoryConfiguration !== null
         ? deserializeAws_json1_1DataRepositoryConfiguration(output.DataRepositoryConfiguration, context)
         : undefined,
-    DeploymentType:
-      output.DeploymentType !== undefined && output.DeploymentType !== null ? output.DeploymentType : undefined,
-    DriveCacheType:
-      output.DriveCacheType !== undefined && output.DriveCacheType !== null ? output.DriveCacheType : undefined,
-    MountName: output.MountName !== undefined && output.MountName !== null ? output.MountName : undefined,
-    PerUnitStorageThroughput:
-      output.PerUnitStorageThroughput !== undefined && output.PerUnitStorageThroughput !== null
-        ? output.PerUnitStorageThroughput
-        : undefined,
-    WeeklyMaintenanceStartTime:
-      output.WeeklyMaintenanceStartTime !== undefined && output.WeeklyMaintenanceStartTime !== null
-        ? output.WeeklyMaintenanceStartTime
-        : undefined,
+    DeploymentType: __expectString(output.DeploymentType),
+    DriveCacheType: __expectString(output.DriveCacheType),
+    MountName: __expectString(output.MountName),
+    PerUnitStorageThroughput: __expectNumber(output.PerUnitStorageThroughput),
+    WeeklyMaintenanceStartTime: __expectString(output.WeeklyMaintenanceStartTime),
   } as any;
 };
 
@@ -3856,7 +3813,7 @@ const deserializeAws_json1_1MissingFileSystemConfiguration = (
   context: __SerdeContext
 ): MissingFileSystemConfiguration => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3867,7 +3824,7 @@ const deserializeAws_json1_1NetworkInterfaceIds = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3876,8 +3833,8 @@ const deserializeAws_json1_1NotServiceResourceError = (
   context: __SerdeContext
 ): NotServiceResourceError => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    ResourceARN: output.ResourceARN !== undefined && output.ResourceARN !== null ? output.ResourceARN : undefined,
+    Message: __expectString(output.Message),
+    ResourceARN: __expectString(output.ResourceARN),
   } as any;
 };
 
@@ -3886,15 +3843,15 @@ const deserializeAws_json1_1ResourceDoesNotSupportTagging = (
   context: __SerdeContext
 ): ResourceDoesNotSupportTagging => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    ResourceARN: output.ResourceARN !== undefined && output.ResourceARN !== null ? output.ResourceARN : undefined,
+    Message: __expectString(output.Message),
+    ResourceARN: __expectString(output.ResourceARN),
   } as any;
 };
 
 const deserializeAws_json1_1ResourceNotFound = (output: any, context: __SerdeContext): ResourceNotFound => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    ResourceARN: output.ResourceARN !== undefined && output.ResourceARN !== null ? output.ResourceARN : undefined,
+    Message: __expectString(output.Message),
+    ResourceARN: __expectString(output.ResourceARN),
   } as any;
 };
 
@@ -3907,23 +3864,17 @@ const deserializeAws_json1_1SelfManagedActiveDirectoryAttributes = (
       output.DnsIps !== undefined && output.DnsIps !== null
         ? deserializeAws_json1_1DnsIps(output.DnsIps, context)
         : undefined,
-    DomainName: output.DomainName !== undefined && output.DomainName !== null ? output.DomainName : undefined,
-    FileSystemAdministratorsGroup:
-      output.FileSystemAdministratorsGroup !== undefined && output.FileSystemAdministratorsGroup !== null
-        ? output.FileSystemAdministratorsGroup
-        : undefined,
-    OrganizationalUnitDistinguishedName:
-      output.OrganizationalUnitDistinguishedName !== undefined && output.OrganizationalUnitDistinguishedName !== null
-        ? output.OrganizationalUnitDistinguishedName
-        : undefined,
-    UserName: output.UserName !== undefined && output.UserName !== null ? output.UserName : undefined,
+    DomainName: __expectString(output.DomainName),
+    FileSystemAdministratorsGroup: __expectString(output.FileSystemAdministratorsGroup),
+    OrganizationalUnitDistinguishedName: __expectString(output.OrganizationalUnitDistinguishedName),
+    UserName: __expectString(output.UserName),
   } as any;
 };
 
 const deserializeAws_json1_1ServiceLimitExceeded = (output: any, context: __SerdeContext): ServiceLimitExceeded => {
   return {
-    Limit: output.Limit !== undefined && output.Limit !== null ? output.Limit : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Limit: __expectString(output.Limit),
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3932,8 +3883,8 @@ const deserializeAws_json1_1SourceBackupUnavailable = (
   context: __SerdeContext
 ): SourceBackupUnavailable => {
   return {
-    BackupId: output.BackupId !== undefined && output.BackupId !== null ? output.BackupId : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    BackupId: __expectString(output.BackupId),
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3944,14 +3895,14 @@ const deserializeAws_json1_1SubnetIds = (output: any, context: __SerdeContext): 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -3972,7 +3923,7 @@ const deserializeAws_json1_1Tags = (output: any, context: __SerdeContext): Tag[]
 
 const deserializeAws_json1_1UnsupportedOperation = (output: any, context: __SerdeContext): UnsupportedOperation => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3997,18 +3948,9 @@ const deserializeAws_json1_1WindowsAuditLogConfiguration = (
   context: __SerdeContext
 ): WindowsAuditLogConfiguration => {
   return {
-    AuditLogDestination:
-      output.AuditLogDestination !== undefined && output.AuditLogDestination !== null
-        ? output.AuditLogDestination
-        : undefined,
-    FileAccessAuditLogLevel:
-      output.FileAccessAuditLogLevel !== undefined && output.FileAccessAuditLogLevel !== null
-        ? output.FileAccessAuditLogLevel
-        : undefined,
-    FileShareAccessAuditLogLevel:
-      output.FileShareAccessAuditLogLevel !== undefined && output.FileShareAccessAuditLogLevel !== null
-        ? output.FileShareAccessAuditLogLevel
-        : undefined,
+    AuditLogDestination: __expectString(output.AuditLogDestination),
+    FileAccessAuditLogLevel: __expectString(output.FileAccessAuditLogLevel),
+    FileShareAccessAuditLogLevel: __expectString(output.FileShareAccessAuditLogLevel),
   } as any;
 };
 
@@ -4017,10 +3959,7 @@ const deserializeAws_json1_1WindowsFileSystemConfiguration = (
   context: __SerdeContext
 ): WindowsFileSystemConfiguration => {
   return {
-    ActiveDirectoryId:
-      output.ActiveDirectoryId !== undefined && output.ActiveDirectoryId !== null
-        ? output.ActiveDirectoryId
-        : undefined,
+    ActiveDirectoryId: __expectString(output.ActiveDirectoryId),
     Aliases:
       output.Aliases !== undefined && output.Aliases !== null
         ? deserializeAws_json1_1Aliases(output.Aliases, context)
@@ -4029,36 +3968,17 @@ const deserializeAws_json1_1WindowsFileSystemConfiguration = (
       output.AuditLogConfiguration !== undefined && output.AuditLogConfiguration !== null
         ? deserializeAws_json1_1WindowsAuditLogConfiguration(output.AuditLogConfiguration, context)
         : undefined,
-    AutomaticBackupRetentionDays:
-      output.AutomaticBackupRetentionDays !== undefined && output.AutomaticBackupRetentionDays !== null
-        ? output.AutomaticBackupRetentionDays
-        : undefined,
-    CopyTagsToBackups:
-      output.CopyTagsToBackups !== undefined && output.CopyTagsToBackups !== null
-        ? output.CopyTagsToBackups
-        : undefined,
-    DailyAutomaticBackupStartTime:
-      output.DailyAutomaticBackupStartTime !== undefined && output.DailyAutomaticBackupStartTime !== null
-        ? output.DailyAutomaticBackupStartTime
-        : undefined,
-    DeploymentType:
-      output.DeploymentType !== undefined && output.DeploymentType !== null ? output.DeploymentType : undefined,
+    AutomaticBackupRetentionDays: __expectNumber(output.AutomaticBackupRetentionDays),
+    CopyTagsToBackups: __expectBoolean(output.CopyTagsToBackups),
+    DailyAutomaticBackupStartTime: __expectString(output.DailyAutomaticBackupStartTime),
+    DeploymentType: __expectString(output.DeploymentType),
     MaintenanceOperationsInProgress:
       output.MaintenanceOperationsInProgress !== undefined && output.MaintenanceOperationsInProgress !== null
         ? deserializeAws_json1_1FileSystemMaintenanceOperations(output.MaintenanceOperationsInProgress, context)
         : undefined,
-    PreferredFileServerIp:
-      output.PreferredFileServerIp !== undefined && output.PreferredFileServerIp !== null
-        ? output.PreferredFileServerIp
-        : undefined,
-    PreferredSubnetId:
-      output.PreferredSubnetId !== undefined && output.PreferredSubnetId !== null
-        ? output.PreferredSubnetId
-        : undefined,
-    RemoteAdministrationEndpoint:
-      output.RemoteAdministrationEndpoint !== undefined && output.RemoteAdministrationEndpoint !== null
-        ? output.RemoteAdministrationEndpoint
-        : undefined,
+    PreferredFileServerIp: __expectString(output.PreferredFileServerIp),
+    PreferredSubnetId: __expectString(output.PreferredSubnetId),
+    RemoteAdministrationEndpoint: __expectString(output.RemoteAdministrationEndpoint),
     SelfManagedActiveDirectoryConfiguration:
       output.SelfManagedActiveDirectoryConfiguration !== undefined &&
       output.SelfManagedActiveDirectoryConfiguration !== null
@@ -4067,14 +3987,8 @@ const deserializeAws_json1_1WindowsFileSystemConfiguration = (
             context
           )
         : undefined,
-    ThroughputCapacity:
-      output.ThroughputCapacity !== undefined && output.ThroughputCapacity !== null
-        ? output.ThroughputCapacity
-        : undefined,
-    WeeklyMaintenanceStartTime:
-      output.WeeklyMaintenanceStartTime !== undefined && output.WeeklyMaintenanceStartTime !== null
-        ? output.WeeklyMaintenanceStartTime
-        : undefined,
+    ThroughputCapacity: __expectNumber(output.ThroughputCapacity),
+    WeeklyMaintenanceStartTime: __expectString(output.WeeklyMaintenanceStartTime),
   } as any;
 };
 

--- a/clients/client-gamelift/protocols/Aws_json1_1.ts
+++ b/clients/client-gamelift/protocols/Aws_json1_1.ts
@@ -525,7 +525,12 @@ import {
   VpcPeeringConnectionStatus,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -11545,18 +11550,18 @@ const deserializeAws_json1_1AcceptMatchOutput = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1Alias = (output: any, context: __SerdeContext): Alias => {
   return {
-    AliasArn: output.AliasArn !== undefined && output.AliasArn !== null ? output.AliasArn : undefined,
-    AliasId: output.AliasId !== undefined && output.AliasId !== null ? output.AliasId : undefined,
+    AliasArn: __expectString(output.AliasArn),
+    AliasId: __expectString(output.AliasId),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     LastUpdatedTime:
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
         ? new Date(Math.round(output.LastUpdatedTime * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     RoutingStrategy:
       output.RoutingStrategy !== undefined && output.RoutingStrategy !== null
         ? deserializeAws_json1_1RoutingStrategy(output.RoutingStrategy, context)
@@ -11577,8 +11582,8 @@ const deserializeAws_json1_1AliasList = (output: any, context: __SerdeContext): 
 
 const deserializeAws_json1_1AttributeValue = (output: any, context: __SerdeContext): AttributeValue => {
   return {
-    N: output.N !== undefined && output.N !== null ? output.N : undefined,
-    S: output.S !== undefined && output.S !== null ? output.S : undefined,
+    N: __expectNumber(output.N),
+    S: __expectString(output.S),
     SDM:
       output.SDM !== undefined && output.SDM !== null
         ? deserializeAws_json1_1StringDoubleMap(output.SDM, context)
@@ -11590,27 +11595,25 @@ const deserializeAws_json1_1AttributeValue = (output: any, context: __SerdeConte
 
 const deserializeAws_json1_1AwsCredentials = (output: any, context: __SerdeContext): AwsCredentials => {
   return {
-    AccessKeyId: output.AccessKeyId !== undefined && output.AccessKeyId !== null ? output.AccessKeyId : undefined,
-    SecretAccessKey:
-      output.SecretAccessKey !== undefined && output.SecretAccessKey !== null ? output.SecretAccessKey : undefined,
-    SessionToken: output.SessionToken !== undefined && output.SessionToken !== null ? output.SessionToken : undefined,
+    AccessKeyId: __expectString(output.AccessKeyId),
+    SecretAccessKey: __expectString(output.SecretAccessKey),
+    SessionToken: __expectString(output.SessionToken),
   } as any;
 };
 
 const deserializeAws_json1_1Build = (output: any, context: __SerdeContext): Build => {
   return {
-    BuildArn: output.BuildArn !== undefined && output.BuildArn !== null ? output.BuildArn : undefined,
-    BuildId: output.BuildId !== undefined && output.BuildId !== null ? output.BuildId : undefined,
+    BuildArn: __expectString(output.BuildArn),
+    BuildId: __expectString(output.BuildId),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    OperatingSystem:
-      output.OperatingSystem !== undefined && output.OperatingSystem !== null ? output.OperatingSystem : undefined,
-    SizeOnDisk: output.SizeOnDisk !== undefined && output.SizeOnDisk !== null ? output.SizeOnDisk : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    Name: __expectString(output.Name),
+    OperatingSystem: __expectString(output.OperatingSystem),
+    SizeOnDisk: __expectNumber(output.SizeOnDisk),
+    Status: __expectString(output.Status),
+    Version: __expectString(output.Version),
   } as any;
 };
 
@@ -11630,8 +11633,7 @@ const deserializeAws_json1_1CertificateConfiguration = (
   context: __SerdeContext
 ): CertificateConfiguration => {
   return {
-    CertificateType:
-      output.CertificateType !== undefined && output.CertificateType !== null ? output.CertificateType : undefined,
+    CertificateType: __expectString(output.CertificateType),
   } as any;
 };
 
@@ -11646,7 +11648,7 @@ const deserializeAws_json1_1ClaimGameServerOutput = (output: any, context: __Ser
 
 const deserializeAws_json1_1ConflictException = (output: any, context: __SerdeContext): ConflictException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -11681,8 +11683,8 @@ const deserializeAws_json1_1CreateFleetLocationsOutput = (
   context: __SerdeContext
 ): CreateFleetLocationsOutput => {
   return {
-    FleetArn: output.FleetArn !== undefined && output.FleetArn !== null ? output.FleetArn : undefined,
-    FleetId: output.FleetId !== undefined && output.FleetId !== null ? output.FleetId : undefined,
+    FleetArn: __expectString(output.FleetArn),
+    FleetId: __expectString(output.FleetId),
     LocationStates:
       output.LocationStates !== undefined && output.LocationStates !== null
         ? deserializeAws_json1_1LocationStateList(output.LocationStates, context)
@@ -11820,8 +11822,8 @@ const deserializeAws_json1_1DeleteFleetLocationsOutput = (
   context: __SerdeContext
 ): DeleteFleetLocationsOutput => {
   return {
-    FleetArn: output.FleetArn !== undefined && output.FleetArn !== null ? output.FleetArn : undefined,
-    FleetId: output.FleetId !== undefined && output.FleetId !== null ? output.FleetId : undefined,
+    FleetArn: __expectString(output.FleetArn),
+    FleetId: __expectString(output.FleetId),
     LocationStates:
       output.LocationStates !== undefined && output.LocationStates !== null
         ? deserializeAws_json1_1LocationStateList(output.LocationStates, context)
@@ -11915,7 +11917,7 @@ const deserializeAws_json1_1DescribeFleetAttributesOutput = (
       output.FleetAttributes !== undefined && output.FleetAttributes !== null
         ? deserializeAws_json1_1FleetAttributesList(output.FleetAttributes, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -11928,7 +11930,7 @@ const deserializeAws_json1_1DescribeFleetCapacityOutput = (
       output.FleetCapacity !== undefined && output.FleetCapacity !== null
         ? deserializeAws_json1_1FleetCapacityList(output.FleetCapacity, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -11941,7 +11943,7 @@ const deserializeAws_json1_1DescribeFleetEventsOutput = (
       output.Events !== undefined && output.Events !== null
         ? deserializeAws_json1_1EventList(output.Events, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -11950,13 +11952,13 @@ const deserializeAws_json1_1DescribeFleetLocationAttributesOutput = (
   context: __SerdeContext
 ): DescribeFleetLocationAttributesOutput => {
   return {
-    FleetArn: output.FleetArn !== undefined && output.FleetArn !== null ? output.FleetArn : undefined,
-    FleetId: output.FleetId !== undefined && output.FleetId !== null ? output.FleetId : undefined,
+    FleetArn: __expectString(output.FleetArn),
+    FleetId: __expectString(output.FleetId),
     LocationAttributes:
       output.LocationAttributes !== undefined && output.LocationAttributes !== null
         ? deserializeAws_json1_1LocationAttributesList(output.LocationAttributes, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -11989,14 +11991,14 @@ const deserializeAws_json1_1DescribeFleetPortSettingsOutput = (
   context: __SerdeContext
 ): DescribeFleetPortSettingsOutput => {
   return {
-    FleetArn: output.FleetArn !== undefined && output.FleetArn !== null ? output.FleetArn : undefined,
-    FleetId: output.FleetId !== undefined && output.FleetId !== null ? output.FleetId : undefined,
+    FleetArn: __expectString(output.FleetArn),
+    FleetId: __expectString(output.FleetId),
     InboundPermissions:
       output.InboundPermissions !== undefined && output.InboundPermissions !== null
         ? deserializeAws_json1_1IpPermissionsList(output.InboundPermissions, context)
         : undefined,
-    Location: output.Location !== undefined && output.Location !== null ? output.Location : undefined,
-    UpdateStatus: output.UpdateStatus !== undefined && output.UpdateStatus !== null ? output.UpdateStatus : undefined,
+    Location: __expectString(output.Location),
+    UpdateStatus: __expectString(output.UpdateStatus),
   } as any;
 };
 
@@ -12009,7 +12011,7 @@ const deserializeAws_json1_1DescribeFleetUtilizationOutput = (
       output.FleetUtilization !== undefined && output.FleetUtilization !== null
         ? deserializeAws_json1_1FleetUtilizationList(output.FleetUtilization, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -12034,7 +12036,7 @@ const deserializeAws_json1_1DescribeGameServerInstancesOutput = (
       output.GameServerInstances !== undefined && output.GameServerInstances !== null
         ? deserializeAws_json1_1GameServerInstances(output.GameServerInstances, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -12059,7 +12061,7 @@ const deserializeAws_json1_1DescribeGameSessionDetailsOutput = (
       output.GameSessionDetails !== undefined && output.GameSessionDetails !== null
         ? deserializeAws_json1_1GameSessionDetailList(output.GameSessionDetails, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -12084,7 +12086,7 @@ const deserializeAws_json1_1DescribeGameSessionQueuesOutput = (
       output.GameSessionQueues !== undefined && output.GameSessionQueues !== null
         ? deserializeAws_json1_1GameSessionQueueList(output.GameSessionQueues, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -12097,7 +12099,7 @@ const deserializeAws_json1_1DescribeGameSessionsOutput = (
       output.GameSessions !== undefined && output.GameSessions !== null
         ? deserializeAws_json1_1GameSessionList(output.GameSessions, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -12110,7 +12112,7 @@ const deserializeAws_json1_1DescribeInstancesOutput = (
       output.Instances !== undefined && output.Instances !== null
         ? deserializeAws_json1_1InstanceList(output.Instances, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -12123,7 +12125,7 @@ const deserializeAws_json1_1DescribeMatchmakingConfigurationsOutput = (
       output.Configurations !== undefined && output.Configurations !== null
         ? deserializeAws_json1_1MatchmakingConfigurationList(output.Configurations, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -12144,7 +12146,7 @@ const deserializeAws_json1_1DescribeMatchmakingRuleSetsOutput = (
   context: __SerdeContext
 ): DescribeMatchmakingRuleSetsOutput => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     RuleSets:
       output.RuleSets !== undefined && output.RuleSets !== null
         ? deserializeAws_json1_1MatchmakingRuleSetList(output.RuleSets, context)
@@ -12157,7 +12159,7 @@ const deserializeAws_json1_1DescribePlayerSessionsOutput = (
   context: __SerdeContext
 ): DescribePlayerSessionsOutput => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     PlayerSessions:
       output.PlayerSessions !== undefined && output.PlayerSessions !== null
         ? deserializeAws_json1_1PlayerSessionList(output.PlayerSessions, context)
@@ -12182,7 +12184,7 @@ const deserializeAws_json1_1DescribeScalingPoliciesOutput = (
   context: __SerdeContext
 ): DescribeScalingPoliciesOutput => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     ScalingPolicies:
       output.ScalingPolicies !== undefined && output.ScalingPolicies !== null
         ? deserializeAws_json1_1ScalingPolicyList(output.ScalingPolicies, context)
@@ -12225,25 +12227,22 @@ const deserializeAws_json1_1DescribeVpcPeeringConnectionsOutput = (
 
 const deserializeAws_json1_1EC2InstanceCounts = (output: any, context: __SerdeContext): EC2InstanceCounts => {
   return {
-    ACTIVE: output.ACTIVE !== undefined && output.ACTIVE !== null ? output.ACTIVE : undefined,
-    DESIRED: output.DESIRED !== undefined && output.DESIRED !== null ? output.DESIRED : undefined,
-    IDLE: output.IDLE !== undefined && output.IDLE !== null ? output.IDLE : undefined,
-    MAXIMUM: output.MAXIMUM !== undefined && output.MAXIMUM !== null ? output.MAXIMUM : undefined,
-    MINIMUM: output.MINIMUM !== undefined && output.MINIMUM !== null ? output.MINIMUM : undefined,
-    PENDING: output.PENDING !== undefined && output.PENDING !== null ? output.PENDING : undefined,
-    TERMINATING: output.TERMINATING !== undefined && output.TERMINATING !== null ? output.TERMINATING : undefined,
+    ACTIVE: __expectNumber(output.ACTIVE),
+    DESIRED: __expectNumber(output.DESIRED),
+    IDLE: __expectNumber(output.IDLE),
+    MAXIMUM: __expectNumber(output.MAXIMUM),
+    MINIMUM: __expectNumber(output.MINIMUM),
+    PENDING: __expectNumber(output.PENDING),
+    TERMINATING: __expectNumber(output.TERMINATING),
   } as any;
 };
 
 const deserializeAws_json1_1EC2InstanceLimit = (output: any, context: __SerdeContext): EC2InstanceLimit => {
   return {
-    CurrentInstances:
-      output.CurrentInstances !== undefined && output.CurrentInstances !== null ? output.CurrentInstances : undefined,
-    EC2InstanceType:
-      output.EC2InstanceType !== undefined && output.EC2InstanceType !== null ? output.EC2InstanceType : undefined,
-    InstanceLimit:
-      output.InstanceLimit !== undefined && output.InstanceLimit !== null ? output.InstanceLimit : undefined,
-    Location: output.Location !== undefined && output.Location !== null ? output.Location : undefined,
+    CurrentInstances: __expectNumber(output.CurrentInstances),
+    EC2InstanceType: __expectString(output.EC2InstanceType),
+    InstanceLimit: __expectNumber(output.InstanceLimit),
+    Location: __expectString(output.Location),
   } as any;
 };
 
@@ -12260,16 +12259,15 @@ const deserializeAws_json1_1EC2InstanceLimitList = (output: any, context: __Serd
 
 const deserializeAws_json1_1Event = (output: any, context: __SerdeContext): Event => {
   return {
-    EventCode: output.EventCode !== undefined && output.EventCode !== null ? output.EventCode : undefined,
-    EventId: output.EventId !== undefined && output.EventId !== null ? output.EventId : undefined,
+    EventCode: __expectString(output.EventCode),
+    EventId: __expectString(output.EventId),
     EventTime:
       output.EventTime !== undefined && output.EventTime !== null
         ? new Date(Math.round(output.EventTime * 1000))
         : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    PreSignedLogUrl:
-      output.PreSignedLogUrl !== undefined && output.PreSignedLogUrl !== null ? output.PreSignedLogUrl : undefined,
-    ResourceId: output.ResourceId !== undefined && output.ResourceId !== null ? output.ResourceId : undefined,
+    Message: __expectString(output.Message),
+    PreSignedLogUrl: __expectString(output.PreSignedLogUrl),
+    ResourceId: __expectString(output.ResourceId),
   } as any;
 };
 
@@ -12300,14 +12298,14 @@ const deserializeAws_json1_1FleetActionList = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1FleetAttributes = (output: any, context: __SerdeContext): FleetAttributes => {
   return {
-    BuildArn: output.BuildArn !== undefined && output.BuildArn !== null ? output.BuildArn : undefined,
-    BuildId: output.BuildId !== undefined && output.BuildId !== null ? output.BuildId : undefined,
+    BuildArn: __expectString(output.BuildArn),
+    BuildId: __expectString(output.BuildId),
     CertificateConfiguration:
       output.CertificateConfiguration !== undefined && output.CertificateConfiguration !== null
         ? deserializeAws_json1_1CertificateConfiguration(output.CertificateConfiguration, context)
@@ -12316,13 +12314,12 @@ const deserializeAws_json1_1FleetAttributes = (output: any, context: __SerdeCont
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    FleetArn: output.FleetArn !== undefined && output.FleetArn !== null ? output.FleetArn : undefined,
-    FleetId: output.FleetId !== undefined && output.FleetId !== null ? output.FleetId : undefined,
-    FleetType: output.FleetType !== undefined && output.FleetType !== null ? output.FleetType : undefined,
-    InstanceRoleArn:
-      output.InstanceRoleArn !== undefined && output.InstanceRoleArn !== null ? output.InstanceRoleArn : undefined,
-    InstanceType: output.InstanceType !== undefined && output.InstanceType !== null ? output.InstanceType : undefined,
+    Description: __expectString(output.Description),
+    FleetArn: __expectString(output.FleetArn),
+    FleetId: __expectString(output.FleetId),
+    FleetType: __expectString(output.FleetType),
+    InstanceRoleArn: __expectString(output.InstanceRoleArn),
+    InstanceType: __expectString(output.InstanceType),
     LogPaths:
       output.LogPaths !== undefined && output.LogPaths !== null
         ? deserializeAws_json1_1StringList(output.LogPaths, context)
@@ -12331,26 +12328,18 @@ const deserializeAws_json1_1FleetAttributes = (output: any, context: __SerdeCont
       output.MetricGroups !== undefined && output.MetricGroups !== null
         ? deserializeAws_json1_1MetricGroupList(output.MetricGroups, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    NewGameSessionProtectionPolicy:
-      output.NewGameSessionProtectionPolicy !== undefined && output.NewGameSessionProtectionPolicy !== null
-        ? output.NewGameSessionProtectionPolicy
-        : undefined,
-    OperatingSystem:
-      output.OperatingSystem !== undefined && output.OperatingSystem !== null ? output.OperatingSystem : undefined,
+    Name: __expectString(output.Name),
+    NewGameSessionProtectionPolicy: __expectString(output.NewGameSessionProtectionPolicy),
+    OperatingSystem: __expectString(output.OperatingSystem),
     ResourceCreationLimitPolicy:
       output.ResourceCreationLimitPolicy !== undefined && output.ResourceCreationLimitPolicy !== null
         ? deserializeAws_json1_1ResourceCreationLimitPolicy(output.ResourceCreationLimitPolicy, context)
         : undefined,
-    ScriptArn: output.ScriptArn !== undefined && output.ScriptArn !== null ? output.ScriptArn : undefined,
-    ScriptId: output.ScriptId !== undefined && output.ScriptId !== null ? output.ScriptId : undefined,
-    ServerLaunchParameters:
-      output.ServerLaunchParameters !== undefined && output.ServerLaunchParameters !== null
-        ? output.ServerLaunchParameters
-        : undefined,
-    ServerLaunchPath:
-      output.ServerLaunchPath !== undefined && output.ServerLaunchPath !== null ? output.ServerLaunchPath : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    ScriptArn: __expectString(output.ScriptArn),
+    ScriptId: __expectString(output.ScriptId),
+    ServerLaunchParameters: __expectString(output.ServerLaunchParameters),
+    ServerLaunchPath: __expectString(output.ServerLaunchPath),
+    Status: __expectString(output.Status),
     StoppedActions:
       output.StoppedActions !== undefined && output.StoppedActions !== null
         ? deserializeAws_json1_1FleetActionList(output.StoppedActions, context)
@@ -12375,14 +12364,14 @@ const deserializeAws_json1_1FleetAttributesList = (output: any, context: __Serde
 
 const deserializeAws_json1_1FleetCapacity = (output: any, context: __SerdeContext): FleetCapacity => {
   return {
-    FleetArn: output.FleetArn !== undefined && output.FleetArn !== null ? output.FleetArn : undefined,
-    FleetId: output.FleetId !== undefined && output.FleetId !== null ? output.FleetId : undefined,
+    FleetArn: __expectString(output.FleetArn),
+    FleetId: __expectString(output.FleetId),
     InstanceCounts:
       output.InstanceCounts !== undefined && output.InstanceCounts !== null
         ? deserializeAws_json1_1EC2InstanceCounts(output.InstanceCounts, context)
         : undefined,
-    InstanceType: output.InstanceType !== undefined && output.InstanceType !== null ? output.InstanceType : undefined,
-    Location: output.Location !== undefined && output.Location !== null ? output.Location : undefined,
+    InstanceType: __expectString(output.InstanceType),
+    Location: __expectString(output.Location),
   } as any;
 };
 
@@ -12391,7 +12380,7 @@ const deserializeAws_json1_1FleetCapacityExceededException = (
   context: __SerdeContext
 ): FleetCapacityExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -12413,31 +12402,19 @@ const deserializeAws_json1_1FleetIdList = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1FleetUtilization = (output: any, context: __SerdeContext): FleetUtilization => {
   return {
-    ActiveGameSessionCount:
-      output.ActiveGameSessionCount !== undefined && output.ActiveGameSessionCount !== null
-        ? output.ActiveGameSessionCount
-        : undefined,
-    ActiveServerProcessCount:
-      output.ActiveServerProcessCount !== undefined && output.ActiveServerProcessCount !== null
-        ? output.ActiveServerProcessCount
-        : undefined,
-    CurrentPlayerSessionCount:
-      output.CurrentPlayerSessionCount !== undefined && output.CurrentPlayerSessionCount !== null
-        ? output.CurrentPlayerSessionCount
-        : undefined,
-    FleetArn: output.FleetArn !== undefined && output.FleetArn !== null ? output.FleetArn : undefined,
-    FleetId: output.FleetId !== undefined && output.FleetId !== null ? output.FleetId : undefined,
-    Location: output.Location !== undefined && output.Location !== null ? output.Location : undefined,
-    MaximumPlayerSessionCount:
-      output.MaximumPlayerSessionCount !== undefined && output.MaximumPlayerSessionCount !== null
-        ? output.MaximumPlayerSessionCount
-        : undefined,
+    ActiveGameSessionCount: __expectNumber(output.ActiveGameSessionCount),
+    ActiveServerProcessCount: __expectNumber(output.ActiveServerProcessCount),
+    CurrentPlayerSessionCount: __expectNumber(output.CurrentPlayerSessionCount),
+    FleetArn: __expectString(output.FleetArn),
+    FleetId: __expectString(output.FleetId),
+    Location: __expectString(output.Location),
+    MaximumPlayerSessionCount: __expectNumber(output.MaximumPlayerSessionCount),
   } as any;
 };
 
@@ -12454,8 +12431,8 @@ const deserializeAws_json1_1FleetUtilizationList = (output: any, context: __Serd
 
 const deserializeAws_json1_1GameProperty = (output: any, context: __SerdeContext): GameProperty => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -12472,21 +12449,13 @@ const deserializeAws_json1_1GamePropertyList = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1GameServer = (output: any, context: __SerdeContext): GameServer => {
   return {
-    ClaimStatus: output.ClaimStatus !== undefined && output.ClaimStatus !== null ? output.ClaimStatus : undefined,
-    ConnectionInfo:
-      output.ConnectionInfo !== undefined && output.ConnectionInfo !== null ? output.ConnectionInfo : undefined,
-    GameServerData:
-      output.GameServerData !== undefined && output.GameServerData !== null ? output.GameServerData : undefined,
-    GameServerGroupArn:
-      output.GameServerGroupArn !== undefined && output.GameServerGroupArn !== null
-        ? output.GameServerGroupArn
-        : undefined,
-    GameServerGroupName:
-      output.GameServerGroupName !== undefined && output.GameServerGroupName !== null
-        ? output.GameServerGroupName
-        : undefined,
-    GameServerId: output.GameServerId !== undefined && output.GameServerId !== null ? output.GameServerId : undefined,
-    InstanceId: output.InstanceId !== undefined && output.InstanceId !== null ? output.InstanceId : undefined,
+    ClaimStatus: __expectString(output.ClaimStatus),
+    ConnectionInfo: __expectString(output.ConnectionInfo),
+    GameServerData: __expectString(output.GameServerData),
+    GameServerGroupArn: __expectString(output.GameServerGroupArn),
+    GameServerGroupName: __expectString(output.GameServerGroupName),
+    GameServerId: __expectString(output.GameServerId),
+    InstanceId: __expectString(output.InstanceId),
     LastClaimTime:
       output.LastClaimTime !== undefined && output.LastClaimTime !== null
         ? new Date(Math.round(output.LastClaimTime * 1000))
@@ -12499,39 +12468,21 @@ const deserializeAws_json1_1GameServer = (output: any, context: __SerdeContext):
       output.RegistrationTime !== undefined && output.RegistrationTime !== null
         ? new Date(Math.round(output.RegistrationTime * 1000))
         : undefined,
-    UtilizationStatus:
-      output.UtilizationStatus !== undefined && output.UtilizationStatus !== null
-        ? output.UtilizationStatus
-        : undefined,
+    UtilizationStatus: __expectString(output.UtilizationStatus),
   } as any;
 };
 
 const deserializeAws_json1_1GameServerGroup = (output: any, context: __SerdeContext): GameServerGroup => {
   return {
-    AutoScalingGroupArn:
-      output.AutoScalingGroupArn !== undefined && output.AutoScalingGroupArn !== null
-        ? output.AutoScalingGroupArn
-        : undefined,
-    BalancingStrategy:
-      output.BalancingStrategy !== undefined && output.BalancingStrategy !== null
-        ? output.BalancingStrategy
-        : undefined,
+    AutoScalingGroupArn: __expectString(output.AutoScalingGroupArn),
+    BalancingStrategy: __expectString(output.BalancingStrategy),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    GameServerGroupArn:
-      output.GameServerGroupArn !== undefined && output.GameServerGroupArn !== null
-        ? output.GameServerGroupArn
-        : undefined,
-    GameServerGroupName:
-      output.GameServerGroupName !== undefined && output.GameServerGroupName !== null
-        ? output.GameServerGroupName
-        : undefined,
-    GameServerProtectionPolicy:
-      output.GameServerProtectionPolicy !== undefined && output.GameServerProtectionPolicy !== null
-        ? output.GameServerProtectionPolicy
-        : undefined,
+    GameServerGroupArn: __expectString(output.GameServerGroupArn),
+    GameServerGroupName: __expectString(output.GameServerGroupName),
+    GameServerProtectionPolicy: __expectString(output.GameServerProtectionPolicy),
     InstanceDefinitions:
       output.InstanceDefinitions !== undefined && output.InstanceDefinitions !== null
         ? deserializeAws_json1_1InstanceDefinitions(output.InstanceDefinitions, context)
@@ -12540,9 +12491,9 @@ const deserializeAws_json1_1GameServerGroup = (output: any, context: __SerdeCont
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
         ? new Date(Math.round(output.LastUpdatedTime * 1000))
         : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusReason: output.StatusReason !== undefined && output.StatusReason !== null ? output.StatusReason : undefined,
+    RoleArn: __expectString(output.RoleArn),
+    Status: __expectString(output.Status),
+    StatusReason: __expectString(output.StatusReason),
     SuspendedActions:
       output.SuspendedActions !== undefined && output.SuspendedActions !== null
         ? deserializeAws_json1_1GameServerGroupActions(output.SuspendedActions, context)
@@ -12560,7 +12511,7 @@ const deserializeAws_json1_1GameServerGroupActions = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -12577,17 +12528,10 @@ const deserializeAws_json1_1GameServerGroups = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1GameServerInstance = (output: any, context: __SerdeContext): GameServerInstance => {
   return {
-    GameServerGroupArn:
-      output.GameServerGroupArn !== undefined && output.GameServerGroupArn !== null
-        ? output.GameServerGroupArn
-        : undefined,
-    GameServerGroupName:
-      output.GameServerGroupName !== undefined && output.GameServerGroupName !== null
-        ? output.GameServerGroupName
-        : undefined,
-    InstanceId: output.InstanceId !== undefined && output.InstanceId !== null ? output.InstanceId : undefined,
-    InstanceStatus:
-      output.InstanceStatus !== undefined && output.InstanceStatus !== null ? output.InstanceStatus : undefined,
+    GameServerGroupArn: __expectString(output.GameServerGroupArn),
+    GameServerGroupName: __expectString(output.GameServerGroupName),
+    InstanceId: __expectString(output.InstanceId),
+    InstanceStatus: __expectString(output.InstanceStatus),
   } as any;
 };
 
@@ -12619,38 +12563,26 @@ const deserializeAws_json1_1GameSession = (output: any, context: __SerdeContext)
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    CreatorId: output.CreatorId !== undefined && output.CreatorId !== null ? output.CreatorId : undefined,
-    CurrentPlayerSessionCount:
-      output.CurrentPlayerSessionCount !== undefined && output.CurrentPlayerSessionCount !== null
-        ? output.CurrentPlayerSessionCount
-        : undefined,
-    DnsName: output.DnsName !== undefined && output.DnsName !== null ? output.DnsName : undefined,
-    FleetArn: output.FleetArn !== undefined && output.FleetArn !== null ? output.FleetArn : undefined,
-    FleetId: output.FleetId !== undefined && output.FleetId !== null ? output.FleetId : undefined,
+    CreatorId: __expectString(output.CreatorId),
+    CurrentPlayerSessionCount: __expectNumber(output.CurrentPlayerSessionCount),
+    DnsName: __expectString(output.DnsName),
+    FleetArn: __expectString(output.FleetArn),
+    FleetId: __expectString(output.FleetId),
     GameProperties:
       output.GameProperties !== undefined && output.GameProperties !== null
         ? deserializeAws_json1_1GamePropertyList(output.GameProperties, context)
         : undefined,
-    GameSessionData:
-      output.GameSessionData !== undefined && output.GameSessionData !== null ? output.GameSessionData : undefined,
-    GameSessionId:
-      output.GameSessionId !== undefined && output.GameSessionId !== null ? output.GameSessionId : undefined,
-    IpAddress: output.IpAddress !== undefined && output.IpAddress !== null ? output.IpAddress : undefined,
-    Location: output.Location !== undefined && output.Location !== null ? output.Location : undefined,
-    MatchmakerData:
-      output.MatchmakerData !== undefined && output.MatchmakerData !== null ? output.MatchmakerData : undefined,
-    MaximumPlayerSessionCount:
-      output.MaximumPlayerSessionCount !== undefined && output.MaximumPlayerSessionCount !== null
-        ? output.MaximumPlayerSessionCount
-        : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    PlayerSessionCreationPolicy:
-      output.PlayerSessionCreationPolicy !== undefined && output.PlayerSessionCreationPolicy !== null
-        ? output.PlayerSessionCreationPolicy
-        : undefined,
-    Port: output.Port !== undefined && output.Port !== null ? output.Port : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusReason: output.StatusReason !== undefined && output.StatusReason !== null ? output.StatusReason : undefined,
+    GameSessionData: __expectString(output.GameSessionData),
+    GameSessionId: __expectString(output.GameSessionId),
+    IpAddress: __expectString(output.IpAddress),
+    Location: __expectString(output.Location),
+    MatchmakerData: __expectString(output.MatchmakerData),
+    MaximumPlayerSessionCount: __expectNumber(output.MaximumPlayerSessionCount),
+    Name: __expectString(output.Name),
+    PlayerSessionCreationPolicy: __expectString(output.PlayerSessionCreationPolicy),
+    Port: __expectNumber(output.Port),
+    Status: __expectString(output.Status),
+    StatusReason: __expectString(output.StatusReason),
     TerminationTime:
       output.TerminationTime !== undefined && output.TerminationTime !== null
         ? new Date(Math.round(output.TerminationTime * 1000))
@@ -12663,15 +12595,14 @@ const deserializeAws_json1_1GameSessionConnectionInfo = (
   context: __SerdeContext
 ): GameSessionConnectionInfo => {
   return {
-    DnsName: output.DnsName !== undefined && output.DnsName !== null ? output.DnsName : undefined,
-    GameSessionArn:
-      output.GameSessionArn !== undefined && output.GameSessionArn !== null ? output.GameSessionArn : undefined,
-    IpAddress: output.IpAddress !== undefined && output.IpAddress !== null ? output.IpAddress : undefined,
+    DnsName: __expectString(output.DnsName),
+    GameSessionArn: __expectString(output.GameSessionArn),
+    IpAddress: __expectString(output.IpAddress),
     MatchedPlayerSessions:
       output.MatchedPlayerSessions !== undefined && output.MatchedPlayerSessions !== null
         ? deserializeAws_json1_1MatchedPlayerSessionList(output.MatchedPlayerSessions, context)
         : undefined,
-    Port: output.Port !== undefined && output.Port !== null ? output.Port : undefined,
+    Port: __expectNumber(output.Port),
   } as any;
 };
 
@@ -12681,8 +12612,7 @@ const deserializeAws_json1_1GameSessionDetail = (output: any, context: __SerdeCo
       output.GameSession !== undefined && output.GameSession !== null
         ? deserializeAws_json1_1GameSession(output.GameSession, context)
         : undefined,
-    ProtectionPolicy:
-      output.ProtectionPolicy !== undefined && output.ProtectionPolicy !== null ? output.ProtectionPolicy : undefined,
+    ProtectionPolicy: __expectString(output.ProtectionPolicy),
   } as any;
 };
 
@@ -12702,7 +12632,7 @@ const deserializeAws_json1_1GameSessionFullException = (
   context: __SerdeContext
 ): GameSessionFullException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -12719,58 +12649,43 @@ const deserializeAws_json1_1GameSessionList = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_1GameSessionPlacement = (output: any, context: __SerdeContext): GameSessionPlacement => {
   return {
-    DnsName: output.DnsName !== undefined && output.DnsName !== null ? output.DnsName : undefined,
+    DnsName: __expectString(output.DnsName),
     EndTime:
       output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
     GameProperties:
       output.GameProperties !== undefined && output.GameProperties !== null
         ? deserializeAws_json1_1GamePropertyList(output.GameProperties, context)
         : undefined,
-    GameSessionArn:
-      output.GameSessionArn !== undefined && output.GameSessionArn !== null ? output.GameSessionArn : undefined,
-    GameSessionData:
-      output.GameSessionData !== undefined && output.GameSessionData !== null ? output.GameSessionData : undefined,
-    GameSessionId:
-      output.GameSessionId !== undefined && output.GameSessionId !== null ? output.GameSessionId : undefined,
-    GameSessionName:
-      output.GameSessionName !== undefined && output.GameSessionName !== null ? output.GameSessionName : undefined,
-    GameSessionQueueName:
-      output.GameSessionQueueName !== undefined && output.GameSessionQueueName !== null
-        ? output.GameSessionQueueName
-        : undefined,
-    GameSessionRegion:
-      output.GameSessionRegion !== undefined && output.GameSessionRegion !== null
-        ? output.GameSessionRegion
-        : undefined,
-    IpAddress: output.IpAddress !== undefined && output.IpAddress !== null ? output.IpAddress : undefined,
-    MatchmakerData:
-      output.MatchmakerData !== undefined && output.MatchmakerData !== null ? output.MatchmakerData : undefined,
-    MaximumPlayerSessionCount:
-      output.MaximumPlayerSessionCount !== undefined && output.MaximumPlayerSessionCount !== null
-        ? output.MaximumPlayerSessionCount
-        : undefined,
+    GameSessionArn: __expectString(output.GameSessionArn),
+    GameSessionData: __expectString(output.GameSessionData),
+    GameSessionId: __expectString(output.GameSessionId),
+    GameSessionName: __expectString(output.GameSessionName),
+    GameSessionQueueName: __expectString(output.GameSessionQueueName),
+    GameSessionRegion: __expectString(output.GameSessionRegion),
+    IpAddress: __expectString(output.IpAddress),
+    MatchmakerData: __expectString(output.MatchmakerData),
+    MaximumPlayerSessionCount: __expectNumber(output.MaximumPlayerSessionCount),
     PlacedPlayerSessions:
       output.PlacedPlayerSessions !== undefined && output.PlacedPlayerSessions !== null
         ? deserializeAws_json1_1PlacedPlayerSessionList(output.PlacedPlayerSessions, context)
         : undefined,
-    PlacementId: output.PlacementId !== undefined && output.PlacementId !== null ? output.PlacementId : undefined,
+    PlacementId: __expectString(output.PlacementId),
     PlayerLatencies:
       output.PlayerLatencies !== undefined && output.PlayerLatencies !== null
         ? deserializeAws_json1_1PlayerLatencyList(output.PlayerLatencies, context)
         : undefined,
-    Port: output.Port !== undefined && output.Port !== null ? output.Port : undefined,
+    Port: __expectNumber(output.Port),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
         ? new Date(Math.round(output.StartTime * 1000))
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
 const deserializeAws_json1_1GameSessionQueue = (output: any, context: __SerdeContext): GameSessionQueue => {
   return {
-    CustomEventData:
-      output.CustomEventData !== undefined && output.CustomEventData !== null ? output.CustomEventData : undefined,
+    CustomEventData: __expectString(output.CustomEventData),
     Destinations:
       output.Destinations !== undefined && output.Destinations !== null
         ? deserializeAws_json1_1GameSessionQueueDestinationList(output.Destinations, context)
@@ -12779,15 +12694,9 @@ const deserializeAws_json1_1GameSessionQueue = (output: any, context: __SerdeCon
       output.FilterConfiguration !== undefined && output.FilterConfiguration !== null
         ? deserializeAws_json1_1FilterConfiguration(output.FilterConfiguration, context)
         : undefined,
-    GameSessionQueueArn:
-      output.GameSessionQueueArn !== undefined && output.GameSessionQueueArn !== null
-        ? output.GameSessionQueueArn
-        : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    NotificationTarget:
-      output.NotificationTarget !== undefined && output.NotificationTarget !== null
-        ? output.NotificationTarget
-        : undefined,
+    GameSessionQueueArn: __expectString(output.GameSessionQueueArn),
+    Name: __expectString(output.Name),
+    NotificationTarget: __expectString(output.NotificationTarget),
     PlayerLatencyPolicies:
       output.PlayerLatencyPolicies !== undefined && output.PlayerLatencyPolicies !== null
         ? deserializeAws_json1_1PlayerLatencyPolicyList(output.PlayerLatencyPolicies, context)
@@ -12796,8 +12705,7 @@ const deserializeAws_json1_1GameSessionQueue = (output: any, context: __SerdeCon
       output.PriorityConfiguration !== undefined && output.PriorityConfiguration !== null
         ? deserializeAws_json1_1PriorityConfiguration(output.PriorityConfiguration, context)
         : undefined,
-    TimeoutInSeconds:
-      output.TimeoutInSeconds !== undefined && output.TimeoutInSeconds !== null ? output.TimeoutInSeconds : undefined,
+    TimeoutInSeconds: __expectNumber(output.TimeoutInSeconds),
   } as any;
 };
 
@@ -12806,8 +12714,7 @@ const deserializeAws_json1_1GameSessionQueueDestination = (
   context: __SerdeContext
 ): GameSessionQueueDestination => {
   return {
-    DestinationArn:
-      output.DestinationArn !== undefined && output.DestinationArn !== null ? output.DestinationArn : undefined,
+    DestinationArn: __expectString(output.DestinationArn),
   } as any;
 };
 
@@ -12841,7 +12748,7 @@ const deserializeAws_json1_1GetGameSessionLogUrlOutput = (
   context: __SerdeContext
 ): GetGameSessionLogUrlOutput => {
   return {
-    PreSignedUrl: output.PreSignedUrl !== undefined && output.PreSignedUrl !== null ? output.PreSignedUrl : undefined,
+    PreSignedUrl: __expectString(output.PreSignedUrl),
   } as any;
 };
 
@@ -12862,7 +12769,7 @@ const deserializeAws_json1_1IdempotentParameterMismatchException = (
   context: __SerdeContext
 ): IdempotentParameterMismatchException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -12872,16 +12779,15 @@ const deserializeAws_json1_1Instance = (output: any, context: __SerdeContext): I
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    DnsName: output.DnsName !== undefined && output.DnsName !== null ? output.DnsName : undefined,
-    FleetArn: output.FleetArn !== undefined && output.FleetArn !== null ? output.FleetArn : undefined,
-    FleetId: output.FleetId !== undefined && output.FleetId !== null ? output.FleetId : undefined,
-    InstanceId: output.InstanceId !== undefined && output.InstanceId !== null ? output.InstanceId : undefined,
-    IpAddress: output.IpAddress !== undefined && output.IpAddress !== null ? output.IpAddress : undefined,
-    Location: output.Location !== undefined && output.Location !== null ? output.Location : undefined,
-    OperatingSystem:
-      output.OperatingSystem !== undefined && output.OperatingSystem !== null ? output.OperatingSystem : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    DnsName: __expectString(output.DnsName),
+    FleetArn: __expectString(output.FleetArn),
+    FleetId: __expectString(output.FleetId),
+    InstanceId: __expectString(output.InstanceId),
+    IpAddress: __expectString(output.IpAddress),
+    Location: __expectString(output.Location),
+    OperatingSystem: __expectString(output.OperatingSystem),
+    Status: __expectString(output.Status),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -12891,26 +12797,24 @@ const deserializeAws_json1_1InstanceAccess = (output: any, context: __SerdeConte
       output.Credentials !== undefined && output.Credentials !== null
         ? deserializeAws_json1_1InstanceCredentials(output.Credentials, context)
         : undefined,
-    FleetId: output.FleetId !== undefined && output.FleetId !== null ? output.FleetId : undefined,
-    InstanceId: output.InstanceId !== undefined && output.InstanceId !== null ? output.InstanceId : undefined,
-    IpAddress: output.IpAddress !== undefined && output.IpAddress !== null ? output.IpAddress : undefined,
-    OperatingSystem:
-      output.OperatingSystem !== undefined && output.OperatingSystem !== null ? output.OperatingSystem : undefined,
+    FleetId: __expectString(output.FleetId),
+    InstanceId: __expectString(output.InstanceId),
+    IpAddress: __expectString(output.IpAddress),
+    OperatingSystem: __expectString(output.OperatingSystem),
   } as any;
 };
 
 const deserializeAws_json1_1InstanceCredentials = (output: any, context: __SerdeContext): InstanceCredentials => {
   return {
-    Secret: output.Secret !== undefined && output.Secret !== null ? output.Secret : undefined,
-    UserName: output.UserName !== undefined && output.UserName !== null ? output.UserName : undefined,
+    Secret: __expectString(output.Secret),
+    UserName: __expectString(output.UserName),
   } as any;
 };
 
 const deserializeAws_json1_1InstanceDefinition = (output: any, context: __SerdeContext): InstanceDefinition => {
   return {
-    InstanceType: output.InstanceType !== undefined && output.InstanceType !== null ? output.InstanceType : undefined,
-    WeightedCapacity:
-      output.WeightedCapacity !== undefined && output.WeightedCapacity !== null ? output.WeightedCapacity : undefined,
+    InstanceType: __expectString(output.InstanceType),
+    WeightedCapacity: __expectString(output.WeightedCapacity),
   } as any;
 };
 
@@ -12941,7 +12845,7 @@ const deserializeAws_json1_1InternalServiceException = (
   context: __SerdeContext
 ): InternalServiceException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -12950,7 +12854,7 @@ const deserializeAws_json1_1InvalidFleetStatusException = (
   context: __SerdeContext
 ): InvalidFleetStatusException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -12959,7 +12863,7 @@ const deserializeAws_json1_1InvalidGameSessionStatusException = (
   context: __SerdeContext
 ): InvalidGameSessionStatusException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -12968,16 +12872,16 @@ const deserializeAws_json1_1InvalidRequestException = (
   context: __SerdeContext
 ): InvalidRequestException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1IpPermission = (output: any, context: __SerdeContext): IpPermission => {
   return {
-    FromPort: output.FromPort !== undefined && output.FromPort !== null ? output.FromPort : undefined,
-    IpRange: output.IpRange !== undefined && output.IpRange !== null ? output.IpRange : undefined,
-    Protocol: output.Protocol !== undefined && output.Protocol !== null ? output.Protocol : undefined,
-    ToPort: output.ToPort !== undefined && output.ToPort !== null ? output.ToPort : undefined,
+    FromPort: __expectNumber(output.FromPort),
+    IpRange: __expectString(output.IpRange),
+    Protocol: __expectString(output.Protocol),
+    ToPort: __expectNumber(output.ToPort),
   } as any;
 };
 
@@ -12999,14 +12903,14 @@ const deserializeAws_json1_1LatencyMap = (output: any, context: __SerdeContext):
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectNumber(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -13016,7 +12920,7 @@ const deserializeAws_json1_1ListAliasesOutput = (output: any, context: __SerdeCo
       output.Aliases !== undefined && output.Aliases !== null
         ? deserializeAws_json1_1AliasList(output.Aliases, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -13026,7 +12930,7 @@ const deserializeAws_json1_1ListBuildsOutput = (output: any, context: __SerdeCon
       output.Builds !== undefined && output.Builds !== null
         ? deserializeAws_json1_1BuildList(output.Builds, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -13036,7 +12940,7 @@ const deserializeAws_json1_1ListFleetsOutput = (output: any, context: __SerdeCon
       output.FleetIds !== undefined && output.FleetIds !== null
         ? deserializeAws_json1_1FleetIdList(output.FleetIds, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -13049,7 +12953,7 @@ const deserializeAws_json1_1ListGameServerGroupsOutput = (
       output.GameServerGroups !== undefined && output.GameServerGroups !== null
         ? deserializeAws_json1_1GameServerGroups(output.GameServerGroups, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -13059,13 +12963,13 @@ const deserializeAws_json1_1ListGameServersOutput = (output: any, context: __Ser
       output.GameServers !== undefined && output.GameServers !== null
         ? deserializeAws_json1_1GameServers(output.GameServers, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
 const deserializeAws_json1_1ListScriptsOutput = (output: any, context: __SerdeContext): ListScriptsOutput => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Scripts:
       output.Scripts !== undefined && output.Scripts !== null
         ? deserializeAws_json1_1ScriptList(output.Scripts, context)
@@ -13095,7 +12999,7 @@ const deserializeAws_json1_1LocationAttributes = (output: any, context: __SerdeC
       output.StoppedActions !== undefined && output.StoppedActions !== null
         ? deserializeAws_json1_1FleetActionList(output.StoppedActions, context)
         : undefined,
-    UpdateStatus: output.UpdateStatus !== undefined && output.UpdateStatus !== null ? output.UpdateStatus : undefined,
+    UpdateStatus: __expectString(output.UpdateStatus),
   } as any;
 };
 
@@ -13117,14 +13021,14 @@ const deserializeAws_json1_1LocationList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1LocationState = (output: any, context: __SerdeContext): LocationState => {
   return {
-    Location: output.Location !== undefined && output.Location !== null ? output.Location : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Location: __expectString(output.Location),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -13141,9 +13045,8 @@ const deserializeAws_json1_1LocationStateList = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1MatchedPlayerSession = (output: any, context: __SerdeContext): MatchedPlayerSession => {
   return {
-    PlayerId: output.PlayerId !== undefined && output.PlayerId !== null ? output.PlayerId : undefined,
-    PlayerSessionId:
-      output.PlayerSessionId !== undefined && output.PlayerSessionId !== null ? output.PlayerSessionId : undefined,
+    PlayerId: __expectString(output.PlayerId),
+    PlayerSessionId: __expectString(output.PlayerSessionId),
   } as any;
 };
 
@@ -13166,51 +13069,32 @@ const deserializeAws_json1_1MatchmakingConfiguration = (
   context: __SerdeContext
 ): MatchmakingConfiguration => {
   return {
-    AcceptanceRequired:
-      output.AcceptanceRequired !== undefined && output.AcceptanceRequired !== null
-        ? output.AcceptanceRequired
-        : undefined,
-    AcceptanceTimeoutSeconds:
-      output.AcceptanceTimeoutSeconds !== undefined && output.AcceptanceTimeoutSeconds !== null
-        ? output.AcceptanceTimeoutSeconds
-        : undefined,
-    AdditionalPlayerCount:
-      output.AdditionalPlayerCount !== undefined && output.AdditionalPlayerCount !== null
-        ? output.AdditionalPlayerCount
-        : undefined,
-    BackfillMode: output.BackfillMode !== undefined && output.BackfillMode !== null ? output.BackfillMode : undefined,
-    ConfigurationArn:
-      output.ConfigurationArn !== undefined && output.ConfigurationArn !== null ? output.ConfigurationArn : undefined,
+    AcceptanceRequired: __expectBoolean(output.AcceptanceRequired),
+    AcceptanceTimeoutSeconds: __expectNumber(output.AcceptanceTimeoutSeconds),
+    AdditionalPlayerCount: __expectNumber(output.AdditionalPlayerCount),
+    BackfillMode: __expectString(output.BackfillMode),
+    ConfigurationArn: __expectString(output.ConfigurationArn),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    CustomEventData:
-      output.CustomEventData !== undefined && output.CustomEventData !== null ? output.CustomEventData : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    FlexMatchMode:
-      output.FlexMatchMode !== undefined && output.FlexMatchMode !== null ? output.FlexMatchMode : undefined,
+    CustomEventData: __expectString(output.CustomEventData),
+    Description: __expectString(output.Description),
+    FlexMatchMode: __expectString(output.FlexMatchMode),
     GameProperties:
       output.GameProperties !== undefined && output.GameProperties !== null
         ? deserializeAws_json1_1GamePropertyList(output.GameProperties, context)
         : undefined,
-    GameSessionData:
-      output.GameSessionData !== undefined && output.GameSessionData !== null ? output.GameSessionData : undefined,
+    GameSessionData: __expectString(output.GameSessionData),
     GameSessionQueueArns:
       output.GameSessionQueueArns !== undefined && output.GameSessionQueueArns !== null
         ? deserializeAws_json1_1QueueArnsList(output.GameSessionQueueArns, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    NotificationTarget:
-      output.NotificationTarget !== undefined && output.NotificationTarget !== null
-        ? output.NotificationTarget
-        : undefined,
-    RequestTimeoutSeconds:
-      output.RequestTimeoutSeconds !== undefined && output.RequestTimeoutSeconds !== null
-        ? output.RequestTimeoutSeconds
-        : undefined,
-    RuleSetArn: output.RuleSetArn !== undefined && output.RuleSetArn !== null ? output.RuleSetArn : undefined,
-    RuleSetName: output.RuleSetName !== undefined && output.RuleSetName !== null ? output.RuleSetName : undefined,
+    Name: __expectString(output.Name),
+    NotificationTarget: __expectString(output.NotificationTarget),
+    RequestTimeoutSeconds: __expectNumber(output.RequestTimeoutSeconds),
+    RuleSetArn: __expectString(output.RuleSetArn),
+    RuleSetName: __expectString(output.RuleSetName),
   } as any;
 };
 
@@ -13234,9 +13118,9 @@ const deserializeAws_json1_1MatchmakingRuleSet = (output: any, context: __SerdeC
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    RuleSetArn: output.RuleSetArn !== undefined && output.RuleSetArn !== null ? output.RuleSetArn : undefined,
-    RuleSetBody: output.RuleSetBody !== undefined && output.RuleSetBody !== null ? output.RuleSetBody : undefined,
-    RuleSetName: output.RuleSetName !== undefined && output.RuleSetName !== null ? output.RuleSetName : undefined,
+    RuleSetArn: __expectString(output.RuleSetArn),
+    RuleSetBody: __expectString(output.RuleSetBody),
+    RuleSetName: __expectString(output.RuleSetName),
   } as any;
 };
 
@@ -13253,18 +13137,11 @@ const deserializeAws_json1_1MatchmakingRuleSetList = (output: any, context: __Se
 
 const deserializeAws_json1_1MatchmakingTicket = (output: any, context: __SerdeContext): MatchmakingTicket => {
   return {
-    ConfigurationArn:
-      output.ConfigurationArn !== undefined && output.ConfigurationArn !== null ? output.ConfigurationArn : undefined,
-    ConfigurationName:
-      output.ConfigurationName !== undefined && output.ConfigurationName !== null
-        ? output.ConfigurationName
-        : undefined,
+    ConfigurationArn: __expectString(output.ConfigurationArn),
+    ConfigurationName: __expectString(output.ConfigurationName),
     EndTime:
       output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
-    EstimatedWaitTime:
-      output.EstimatedWaitTime !== undefined && output.EstimatedWaitTime !== null
-        ? output.EstimatedWaitTime
-        : undefined,
+    EstimatedWaitTime: __expectNumber(output.EstimatedWaitTime),
     GameSessionConnectionInfo:
       output.GameSessionConnectionInfo !== undefined && output.GameSessionConnectionInfo !== null
         ? deserializeAws_json1_1GameSessionConnectionInfo(output.GameSessionConnectionInfo, context)
@@ -13277,11 +13154,10 @@ const deserializeAws_json1_1MatchmakingTicket = (output: any, context: __SerdeCo
       output.StartTime !== undefined && output.StartTime !== null
         ? new Date(Math.round(output.StartTime * 1000))
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusMessage:
-      output.StatusMessage !== undefined && output.StatusMessage !== null ? output.StatusMessage : undefined,
-    StatusReason: output.StatusReason !== undefined && output.StatusReason !== null ? output.StatusReason : undefined,
-    TicketId: output.TicketId !== undefined && output.TicketId !== null ? output.TicketId : undefined,
+    Status: __expectString(output.Status),
+    StatusMessage: __expectString(output.StatusMessage),
+    StatusReason: __expectString(output.StatusReason),
+    TicketId: __expectString(output.TicketId),
   } as any;
 };
 
@@ -13303,27 +13179,26 @@ const deserializeAws_json1_1MetricGroupList = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1NotFoundException = (output: any, context: __SerdeContext): NotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1OutOfCapacityException = (output: any, context: __SerdeContext): OutOfCapacityException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1PlacedPlayerSession = (output: any, context: __SerdeContext): PlacedPlayerSession => {
   return {
-    PlayerId: output.PlayerId !== undefined && output.PlayerId !== null ? output.PlayerId : undefined,
-    PlayerSessionId:
-      output.PlayerSessionId !== undefined && output.PlayerSessionId !== null ? output.PlayerSessionId : undefined,
+    PlayerId: __expectString(output.PlayerId),
+    PlayerSessionId: __expectString(output.PlayerSessionId),
   } as any;
 };
 
@@ -13348,8 +13223,8 @@ const deserializeAws_json1_1Player = (output: any, context: __SerdeContext): Pla
       output.PlayerAttributes !== undefined && output.PlayerAttributes !== null
         ? deserializeAws_json1_1PlayerAttributeMap(output.PlayerAttributes, context)
         : undefined,
-    PlayerId: output.PlayerId !== undefined && output.PlayerId !== null ? output.PlayerId : undefined,
-    Team: output.Team !== undefined && output.Team !== null ? output.Team : undefined,
+    PlayerId: __expectString(output.PlayerId),
+    Team: __expectString(output.Team),
   } as any;
 };
 
@@ -13370,13 +13245,9 @@ const deserializeAws_json1_1PlayerAttributeMap = (
 
 const deserializeAws_json1_1PlayerLatency = (output: any, context: __SerdeContext): PlayerLatency => {
   return {
-    LatencyInMilliseconds:
-      output.LatencyInMilliseconds !== undefined && output.LatencyInMilliseconds !== null
-        ? output.LatencyInMilliseconds
-        : undefined,
-    PlayerId: output.PlayerId !== undefined && output.PlayerId !== null ? output.PlayerId : undefined,
-    RegionIdentifier:
-      output.RegionIdentifier !== undefined && output.RegionIdentifier !== null ? output.RegionIdentifier : undefined,
+    LatencyInMilliseconds: __expectNumber(output.LatencyInMilliseconds),
+    PlayerId: __expectString(output.PlayerId),
+    RegionIdentifier: __expectString(output.RegionIdentifier),
   } as any;
 };
 
@@ -13393,15 +13264,8 @@ const deserializeAws_json1_1PlayerLatencyList = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1PlayerLatencyPolicy = (output: any, context: __SerdeContext): PlayerLatencyPolicy => {
   return {
-    MaximumIndividualPlayerLatencyMilliseconds:
-      output.MaximumIndividualPlayerLatencyMilliseconds !== undefined &&
-      output.MaximumIndividualPlayerLatencyMilliseconds !== null
-        ? output.MaximumIndividualPlayerLatencyMilliseconds
-        : undefined,
-    PolicyDurationSeconds:
-      output.PolicyDurationSeconds !== undefined && output.PolicyDurationSeconds !== null
-        ? output.PolicyDurationSeconds
-        : undefined,
+    MaximumIndividualPlayerLatencyMilliseconds: __expectNumber(output.MaximumIndividualPlayerLatencyMilliseconds),
+    PolicyDurationSeconds: __expectNumber(output.PolicyDurationSeconds),
   } as any;
 };
 
@@ -13433,18 +13297,16 @@ const deserializeAws_json1_1PlayerSession = (output: any, context: __SerdeContex
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    DnsName: output.DnsName !== undefined && output.DnsName !== null ? output.DnsName : undefined,
-    FleetArn: output.FleetArn !== undefined && output.FleetArn !== null ? output.FleetArn : undefined,
-    FleetId: output.FleetId !== undefined && output.FleetId !== null ? output.FleetId : undefined,
-    GameSessionId:
-      output.GameSessionId !== undefined && output.GameSessionId !== null ? output.GameSessionId : undefined,
-    IpAddress: output.IpAddress !== undefined && output.IpAddress !== null ? output.IpAddress : undefined,
-    PlayerData: output.PlayerData !== undefined && output.PlayerData !== null ? output.PlayerData : undefined,
-    PlayerId: output.PlayerId !== undefined && output.PlayerId !== null ? output.PlayerId : undefined,
-    PlayerSessionId:
-      output.PlayerSessionId !== undefined && output.PlayerSessionId !== null ? output.PlayerSessionId : undefined,
-    Port: output.Port !== undefined && output.Port !== null ? output.Port : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    DnsName: __expectString(output.DnsName),
+    FleetArn: __expectString(output.FleetArn),
+    FleetId: __expectString(output.FleetId),
+    GameSessionId: __expectString(output.GameSessionId),
+    IpAddress: __expectString(output.IpAddress),
+    PlayerData: __expectString(output.PlayerData),
+    PlayerId: __expectString(output.PlayerId),
+    PlayerSessionId: __expectString(output.PlayerSessionId),
+    Port: __expectNumber(output.Port),
+    Status: __expectString(output.Status),
     TerminationTime:
       output.TerminationTime !== undefined && output.TerminationTime !== null
         ? new Date(Math.round(output.TerminationTime * 1000))
@@ -13483,13 +13345,13 @@ const deserializeAws_json1_1PriorityTypeList = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1PutScalingPolicyOutput = (output: any, context: __SerdeContext): PutScalingPolicyOutput => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -13500,7 +13362,7 @@ const deserializeAws_json1_1QueueArnsList = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -13534,8 +13396,8 @@ const deserializeAws_json1_1RequestUploadCredentialsOutput = (
 
 const deserializeAws_json1_1ResolveAliasOutput = (output: any, context: __SerdeContext): ResolveAliasOutput => {
   return {
-    FleetArn: output.FleetArn !== undefined && output.FleetArn !== null ? output.FleetArn : undefined,
-    FleetId: output.FleetId !== undefined && output.FleetId !== null ? output.FleetId : undefined,
+    FleetArn: __expectString(output.FleetArn),
+    FleetId: __expectString(output.FleetId),
   } as any;
 };
 
@@ -13544,14 +13406,8 @@ const deserializeAws_json1_1ResourceCreationLimitPolicy = (
   context: __SerdeContext
 ): ResourceCreationLimitPolicy => {
   return {
-    NewGameSessionsPerCreator:
-      output.NewGameSessionsPerCreator !== undefined && output.NewGameSessionsPerCreator !== null
-        ? output.NewGameSessionsPerCreator
-        : undefined,
-    PolicyPeriodInMinutes:
-      output.PolicyPeriodInMinutes !== undefined && output.PolicyPeriodInMinutes !== null
-        ? output.PolicyPeriodInMinutes
-        : undefined,
+    NewGameSessionsPerCreator: __expectNumber(output.NewGameSessionsPerCreator),
+    PolicyPeriodInMinutes: __expectNumber(output.PolicyPeriodInMinutes),
   } as any;
 };
 
@@ -13569,22 +13425,16 @@ const deserializeAws_json1_1ResumeGameServerGroupOutput = (
 
 const deserializeAws_json1_1RoutingStrategy = (output: any, context: __SerdeContext): RoutingStrategy => {
   return {
-    FleetId: output.FleetId !== undefined && output.FleetId !== null ? output.FleetId : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    FleetId: __expectString(output.FleetId),
+    Message: __expectString(output.Message),
+    Type: __expectString(output.Type),
   } as any;
 };
 
 const deserializeAws_json1_1RuntimeConfiguration = (output: any, context: __SerdeContext): RuntimeConfiguration => {
   return {
-    GameSessionActivationTimeoutSeconds:
-      output.GameSessionActivationTimeoutSeconds !== undefined && output.GameSessionActivationTimeoutSeconds !== null
-        ? output.GameSessionActivationTimeoutSeconds
-        : undefined,
-    MaxConcurrentGameSessionActivations:
-      output.MaxConcurrentGameSessionActivations !== undefined && output.MaxConcurrentGameSessionActivations !== null
-        ? output.MaxConcurrentGameSessionActivations
-        : undefined,
+    GameSessionActivationTimeoutSeconds: __expectNumber(output.GameSessionActivationTimeoutSeconds),
+    MaxConcurrentGameSessionActivations: __expectNumber(output.MaxConcurrentGameSessionActivations),
     ServerProcesses:
       output.ServerProcesses !== undefined && output.ServerProcesses !== null
         ? deserializeAws_json1_1ServerProcessList(output.ServerProcesses, context)
@@ -13594,45 +13444,32 @@ const deserializeAws_json1_1RuntimeConfiguration = (output: any, context: __Serd
 
 const deserializeAws_json1_1S3Location = (output: any, context: __SerdeContext): S3Location => {
   return {
-    Bucket: output.Bucket !== undefined && output.Bucket !== null ? output.Bucket : undefined,
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    ObjectVersion:
-      output.ObjectVersion !== undefined && output.ObjectVersion !== null ? output.ObjectVersion : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
+    Bucket: __expectString(output.Bucket),
+    Key: __expectString(output.Key),
+    ObjectVersion: __expectString(output.ObjectVersion),
+    RoleArn: __expectString(output.RoleArn),
   } as any;
 };
 
 const deserializeAws_json1_1ScalingPolicy = (output: any, context: __SerdeContext): ScalingPolicy => {
   return {
-    ComparisonOperator:
-      output.ComparisonOperator !== undefined && output.ComparisonOperator !== null
-        ? output.ComparisonOperator
-        : undefined,
-    EvaluationPeriods:
-      output.EvaluationPeriods !== undefined && output.EvaluationPeriods !== null
-        ? output.EvaluationPeriods
-        : undefined,
-    FleetArn: output.FleetArn !== undefined && output.FleetArn !== null ? output.FleetArn : undefined,
-    FleetId: output.FleetId !== undefined && output.FleetId !== null ? output.FleetId : undefined,
-    Location: output.Location !== undefined && output.Location !== null ? output.Location : undefined,
-    MetricName: output.MetricName !== undefined && output.MetricName !== null ? output.MetricName : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    PolicyType: output.PolicyType !== undefined && output.PolicyType !== null ? output.PolicyType : undefined,
-    ScalingAdjustment:
-      output.ScalingAdjustment !== undefined && output.ScalingAdjustment !== null
-        ? output.ScalingAdjustment
-        : undefined,
-    ScalingAdjustmentType:
-      output.ScalingAdjustmentType !== undefined && output.ScalingAdjustmentType !== null
-        ? output.ScalingAdjustmentType
-        : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    ComparisonOperator: __expectString(output.ComparisonOperator),
+    EvaluationPeriods: __expectNumber(output.EvaluationPeriods),
+    FleetArn: __expectString(output.FleetArn),
+    FleetId: __expectString(output.FleetId),
+    Location: __expectString(output.Location),
+    MetricName: __expectString(output.MetricName),
+    Name: __expectString(output.Name),
+    PolicyType: __expectString(output.PolicyType),
+    ScalingAdjustment: __expectNumber(output.ScalingAdjustment),
+    ScalingAdjustmentType: __expectString(output.ScalingAdjustmentType),
+    Status: __expectString(output.Status),
     TargetConfiguration:
       output.TargetConfiguration !== undefined && output.TargetConfiguration !== null
         ? deserializeAws_json1_1TargetConfiguration(output.TargetConfiguration, context)
         : undefined,
-    Threshold: output.Threshold !== undefined && output.Threshold !== null ? output.Threshold : undefined,
-    UpdateStatus: output.UpdateStatus !== undefined && output.UpdateStatus !== null ? output.UpdateStatus : undefined,
+    Threshold: __expectNumber(output.Threshold),
+    UpdateStatus: __expectString(output.UpdateStatus),
   } as any;
 };
 
@@ -13653,15 +13490,15 @@ const deserializeAws_json1_1Script = (output: any, context: __SerdeContext): Scr
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    ScriptArn: output.ScriptArn !== undefined && output.ScriptArn !== null ? output.ScriptArn : undefined,
-    ScriptId: output.ScriptId !== undefined && output.ScriptId !== null ? output.ScriptId : undefined,
-    SizeOnDisk: output.SizeOnDisk !== undefined && output.SizeOnDisk !== null ? output.SizeOnDisk : undefined,
+    Name: __expectString(output.Name),
+    ScriptArn: __expectString(output.ScriptArn),
+    ScriptId: __expectString(output.ScriptId),
+    SizeOnDisk: __expectNumber(output.SizeOnDisk),
     StorageLocation:
       output.StorageLocation !== undefined && output.StorageLocation !== null
         ? deserializeAws_json1_1S3Location(output.StorageLocation, context)
         : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    Version: __expectString(output.Version),
   } as any;
 };
 
@@ -13685,18 +13522,15 @@ const deserializeAws_json1_1SearchGameSessionsOutput = (
       output.GameSessions !== undefined && output.GameSessions !== null
         ? deserializeAws_json1_1GameSessionList(output.GameSessions, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
 const deserializeAws_json1_1ServerProcess = (output: any, context: __SerdeContext): ServerProcess => {
   return {
-    ConcurrentExecutions:
-      output.ConcurrentExecutions !== undefined && output.ConcurrentExecutions !== null
-        ? output.ConcurrentExecutions
-        : undefined,
-    LaunchPath: output.LaunchPath !== undefined && output.LaunchPath !== null ? output.LaunchPath : undefined,
-    Parameters: output.Parameters !== undefined && output.Parameters !== null ? output.Parameters : undefined,
+    ConcurrentExecutions: __expectNumber(output.ConcurrentExecutions),
+    LaunchPath: __expectString(output.LaunchPath),
+    Parameters: __expectString(output.Parameters),
   } as any;
 };
 
@@ -13716,8 +13550,8 @@ const deserializeAws_json1_1StartFleetActionsOutput = (
   context: __SerdeContext
 ): StartFleetActionsOutput => {
   return {
-    FleetArn: output.FleetArn !== undefined && output.FleetArn !== null ? output.FleetArn : undefined,
-    FleetId: output.FleetId !== undefined && output.FleetId !== null ? output.FleetId : undefined,
+    FleetArn: __expectString(output.FleetArn),
+    FleetId: __expectString(output.FleetId),
   } as any;
 };
 
@@ -13756,8 +13590,8 @@ const deserializeAws_json1_1StartMatchmakingOutput = (output: any, context: __Se
 
 const deserializeAws_json1_1StopFleetActionsOutput = (output: any, context: __SerdeContext): StopFleetActionsOutput => {
   return {
-    FleetArn: output.FleetArn !== undefined && output.FleetArn !== null ? output.FleetArn : undefined,
-    FleetId: output.FleetId !== undefined && output.FleetId !== null ? output.FleetId : undefined,
+    FleetArn: __expectString(output.FleetArn),
+    FleetId: __expectString(output.FleetId),
   } as any;
 };
 
@@ -13784,7 +13618,7 @@ const deserializeAws_json1_1StringDoubleMap = (output: any, context: __SerdeCont
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectNumber(value) as any,
     };
   }, {});
 };
@@ -13796,7 +13630,7 @@ const deserializeAws_json1_1StringList = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -13814,14 +13648,14 @@ const deserializeAws_json1_1SuspendGameServerGroupOutput = (
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
 const deserializeAws_json1_1TaggingFailedException = (output: any, context: __SerdeContext): TaggingFailedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -13842,7 +13676,7 @@ const deserializeAws_json1_1TagResourceResponse = (output: any, context: __Serde
 
 const deserializeAws_json1_1TargetConfiguration = (output: any, context: __SerdeContext): TargetConfiguration => {
   return {
-    TargetValue: output.TargetValue !== undefined && output.TargetValue !== null ? output.TargetValue : undefined,
+    TargetValue: __expectNumber(output.TargetValue),
   } as any;
 };
 
@@ -13851,13 +13685,13 @@ const deserializeAws_json1_1TerminalRoutingStrategyException = (
   context: __SerdeContext
 ): TerminalRoutingStrategyException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1UnauthorizedException = (output: any, context: __SerdeContext): UnauthorizedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -13866,7 +13700,7 @@ const deserializeAws_json1_1UnsupportedRegionException = (
   context: __SerdeContext
 ): UnsupportedRegionException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -13897,7 +13731,7 @@ const deserializeAws_json1_1UpdateFleetAttributesOutput = (
   context: __SerdeContext
 ): UpdateFleetAttributesOutput => {
   return {
-    FleetId: output.FleetId !== undefined && output.FleetId !== null ? output.FleetId : undefined,
+    FleetId: __expectString(output.FleetId),
   } as any;
 };
 
@@ -13906,9 +13740,9 @@ const deserializeAws_json1_1UpdateFleetCapacityOutput = (
   context: __SerdeContext
 ): UpdateFleetCapacityOutput => {
   return {
-    FleetArn: output.FleetArn !== undefined && output.FleetArn !== null ? output.FleetArn : undefined,
-    FleetId: output.FleetId !== undefined && output.FleetId !== null ? output.FleetId : undefined,
-    Location: output.Location !== undefined && output.Location !== null ? output.Location : undefined,
+    FleetArn: __expectString(output.FleetArn),
+    FleetId: __expectString(output.FleetId),
+    Location: __expectString(output.Location),
   } as any;
 };
 
@@ -13917,7 +13751,7 @@ const deserializeAws_json1_1UpdateFleetPortSettingsOutput = (
   context: __SerdeContext
 ): UpdateFleetPortSettingsOutput => {
   return {
-    FleetId: output.FleetId !== undefined && output.FleetId !== null ? output.FleetId : undefined,
+    FleetId: __expectString(output.FleetId),
   } as any;
 };
 
@@ -14004,7 +13838,7 @@ const deserializeAws_json1_1ValidateMatchmakingRuleSetOutput = (
   context: __SerdeContext
 ): ValidateMatchmakingRuleSetOutput => {
   return {
-    Valid: output.Valid !== undefined && output.Valid !== null ? output.Valid : undefined,
+    Valid: __expectBoolean(output.Valid),
   } as any;
 };
 
@@ -14021,15 +13855,9 @@ const deserializeAws_json1_1VpcPeeringAuthorization = (
       output.ExpirationTime !== undefined && output.ExpirationTime !== null
         ? new Date(Math.round(output.ExpirationTime * 1000))
         : undefined,
-    GameLiftAwsAccountId:
-      output.GameLiftAwsAccountId !== undefined && output.GameLiftAwsAccountId !== null
-        ? output.GameLiftAwsAccountId
-        : undefined,
-    PeerVpcAwsAccountId:
-      output.PeerVpcAwsAccountId !== undefined && output.PeerVpcAwsAccountId !== null
-        ? output.PeerVpcAwsAccountId
-        : undefined,
-    PeerVpcId: output.PeerVpcId !== undefined && output.PeerVpcId !== null ? output.PeerVpcId : undefined,
+    GameLiftAwsAccountId: __expectString(output.GameLiftAwsAccountId),
+    PeerVpcAwsAccountId: __expectString(output.PeerVpcAwsAccountId),
+    PeerVpcId: __expectString(output.PeerVpcId),
   } as any;
 };
 
@@ -14049,21 +13877,16 @@ const deserializeAws_json1_1VpcPeeringAuthorizationList = (
 
 const deserializeAws_json1_1VpcPeeringConnection = (output: any, context: __SerdeContext): VpcPeeringConnection => {
   return {
-    FleetArn: output.FleetArn !== undefined && output.FleetArn !== null ? output.FleetArn : undefined,
-    FleetId: output.FleetId !== undefined && output.FleetId !== null ? output.FleetId : undefined,
-    GameLiftVpcId:
-      output.GameLiftVpcId !== undefined && output.GameLiftVpcId !== null ? output.GameLiftVpcId : undefined,
-    IpV4CidrBlock:
-      output.IpV4CidrBlock !== undefined && output.IpV4CidrBlock !== null ? output.IpV4CidrBlock : undefined,
-    PeerVpcId: output.PeerVpcId !== undefined && output.PeerVpcId !== null ? output.PeerVpcId : undefined,
+    FleetArn: __expectString(output.FleetArn),
+    FleetId: __expectString(output.FleetId),
+    GameLiftVpcId: __expectString(output.GameLiftVpcId),
+    IpV4CidrBlock: __expectString(output.IpV4CidrBlock),
+    PeerVpcId: __expectString(output.PeerVpcId),
     Status:
       output.Status !== undefined && output.Status !== null
         ? deserializeAws_json1_1VpcPeeringConnectionStatus(output.Status, context)
         : undefined,
-    VpcPeeringConnectionId:
-      output.VpcPeeringConnectionId !== undefined && output.VpcPeeringConnectionId !== null
-        ? output.VpcPeeringConnectionId
-        : undefined,
+    VpcPeeringConnectionId: __expectString(output.VpcPeeringConnectionId),
   } as any;
 };
 
@@ -14086,8 +13909,8 @@ const deserializeAws_json1_1VpcPeeringConnectionStatus = (
   context: __SerdeContext
 ): VpcPeeringConnectionStatus => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Message: __expectString(output.Message),
   } as any;
 };
 

--- a/clients/client-glacier/protocols/Aws_restJson1.ts
+++ b/clients/client-glacier/protocols/Aws_restJson1.ts
@@ -115,6 +115,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -2288,25 +2291,25 @@ export const deserializeAws_restJson1DescribeJobCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Action !== undefined && data.Action !== null) {
-    contents.Action = data.Action;
+    contents.Action = __expectString(data.Action);
   }
   if (data.ArchiveId !== undefined && data.ArchiveId !== null) {
-    contents.ArchiveId = data.ArchiveId;
+    contents.ArchiveId = __expectString(data.ArchiveId);
   }
   if (data.ArchiveSHA256TreeHash !== undefined && data.ArchiveSHA256TreeHash !== null) {
-    contents.ArchiveSHA256TreeHash = data.ArchiveSHA256TreeHash;
+    contents.ArchiveSHA256TreeHash = __expectString(data.ArchiveSHA256TreeHash);
   }
   if (data.ArchiveSizeInBytes !== undefined && data.ArchiveSizeInBytes !== null) {
-    contents.ArchiveSizeInBytes = data.ArchiveSizeInBytes;
+    contents.ArchiveSizeInBytes = __expectNumber(data.ArchiveSizeInBytes);
   }
   if (data.Completed !== undefined && data.Completed !== null) {
-    contents.Completed = data.Completed;
+    contents.Completed = __expectBoolean(data.Completed);
   }
   if (data.CompletionDate !== undefined && data.CompletionDate !== null) {
-    contents.CompletionDate = data.CompletionDate;
+    contents.CompletionDate = __expectString(data.CompletionDate);
   }
   if (data.CreationDate !== undefined && data.CreationDate !== null) {
-    contents.CreationDate = data.CreationDate;
+    contents.CreationDate = __expectString(data.CreationDate);
   }
   if (data.InventoryRetrievalParameters !== undefined && data.InventoryRetrievalParameters !== null) {
     contents.InventoryRetrievalParameters = deserializeAws_restJson1InventoryRetrievalJobDescription(
@@ -2315,43 +2318,43 @@ export const deserializeAws_restJson1DescribeJobCommand = async (
     );
   }
   if (data.InventorySizeInBytes !== undefined && data.InventorySizeInBytes !== null) {
-    contents.InventorySizeInBytes = data.InventorySizeInBytes;
+    contents.InventorySizeInBytes = __expectNumber(data.InventorySizeInBytes);
   }
   if (data.JobDescription !== undefined && data.JobDescription !== null) {
-    contents.JobDescription = data.JobDescription;
+    contents.JobDescription = __expectString(data.JobDescription);
   }
   if (data.JobId !== undefined && data.JobId !== null) {
-    contents.JobId = data.JobId;
+    contents.JobId = __expectString(data.JobId);
   }
   if (data.JobOutputPath !== undefined && data.JobOutputPath !== null) {
-    contents.JobOutputPath = data.JobOutputPath;
+    contents.JobOutputPath = __expectString(data.JobOutputPath);
   }
   if (data.OutputLocation !== undefined && data.OutputLocation !== null) {
     contents.OutputLocation = deserializeAws_restJson1OutputLocation(data.OutputLocation, context);
   }
   if (data.RetrievalByteRange !== undefined && data.RetrievalByteRange !== null) {
-    contents.RetrievalByteRange = data.RetrievalByteRange;
+    contents.RetrievalByteRange = __expectString(data.RetrievalByteRange);
   }
   if (data.SHA256TreeHash !== undefined && data.SHA256TreeHash !== null) {
-    contents.SHA256TreeHash = data.SHA256TreeHash;
+    contents.SHA256TreeHash = __expectString(data.SHA256TreeHash);
   }
   if (data.SNSTopic !== undefined && data.SNSTopic !== null) {
-    contents.SNSTopic = data.SNSTopic;
+    contents.SNSTopic = __expectString(data.SNSTopic);
   }
   if (data.SelectParameters !== undefined && data.SelectParameters !== null) {
     contents.SelectParameters = deserializeAws_restJson1SelectParameters(data.SelectParameters, context);
   }
   if (data.StatusCode !== undefined && data.StatusCode !== null) {
-    contents.StatusCode = data.StatusCode;
+    contents.StatusCode = __expectString(data.StatusCode);
   }
   if (data.StatusMessage !== undefined && data.StatusMessage !== null) {
-    contents.StatusMessage = data.StatusMessage;
+    contents.StatusMessage = __expectString(data.StatusMessage);
   }
   if (data.Tier !== undefined && data.Tier !== null) {
-    contents.Tier = data.Tier;
+    contents.Tier = __expectString(data.Tier);
   }
   if (data.VaultARN !== undefined && data.VaultARN !== null) {
-    contents.VaultARN = data.VaultARN;
+    contents.VaultARN = __expectString(data.VaultARN);
   }
   return Promise.resolve(contents);
 };
@@ -2435,22 +2438,22 @@ export const deserializeAws_restJson1DescribeVaultCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.CreationDate !== undefined && data.CreationDate !== null) {
-    contents.CreationDate = data.CreationDate;
+    contents.CreationDate = __expectString(data.CreationDate);
   }
   if (data.LastInventoryDate !== undefined && data.LastInventoryDate !== null) {
-    contents.LastInventoryDate = data.LastInventoryDate;
+    contents.LastInventoryDate = __expectString(data.LastInventoryDate);
   }
   if (data.NumberOfArchives !== undefined && data.NumberOfArchives !== null) {
-    contents.NumberOfArchives = data.NumberOfArchives;
+    contents.NumberOfArchives = __expectNumber(data.NumberOfArchives);
   }
   if (data.SizeInBytes !== undefined && data.SizeInBytes !== null) {
-    contents.SizeInBytes = data.SizeInBytes;
+    contents.SizeInBytes = __expectNumber(data.SizeInBytes);
   }
   if (data.VaultARN !== undefined && data.VaultARN !== null) {
-    contents.VaultARN = data.VaultARN;
+    contents.VaultARN = __expectString(data.VaultARN);
   }
   if (data.VaultName !== undefined && data.VaultName !== null) {
-    contents.VaultName = data.VaultName;
+    contents.VaultName = __expectString(data.VaultName);
   }
   return Promise.resolve(contents);
 };
@@ -2781,16 +2784,16 @@ export const deserializeAws_restJson1GetVaultLockCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.CreationDate !== undefined && data.CreationDate !== null) {
-    contents.CreationDate = data.CreationDate;
+    contents.CreationDate = __expectString(data.CreationDate);
   }
   if (data.ExpirationDate !== undefined && data.ExpirationDate !== null) {
-    contents.ExpirationDate = data.ExpirationDate;
+    contents.ExpirationDate = __expectString(data.ExpirationDate);
   }
   if (data.Policy !== undefined && data.Policy !== null) {
-    contents.Policy = data.Policy;
+    contents.Policy = __expectString(data.Policy);
   }
   if (data.State !== undefined && data.State !== null) {
-    contents.State = data.State;
+    contents.State = __expectString(data.State);
   }
   return Promise.resolve(contents);
 };
@@ -3215,7 +3218,7 @@ export const deserializeAws_restJson1ListJobsCommand = async (
     contents.JobList = deserializeAws_restJson1JobList(data.JobList, context);
   }
   if (data.Marker !== undefined && data.Marker !== null) {
-    contents.Marker = data.Marker;
+    contents.Marker = __expectString(data.Marker);
   }
   return Promise.resolve(contents);
 };
@@ -3295,7 +3298,7 @@ export const deserializeAws_restJson1ListMultipartUploadsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Marker !== undefined && data.Marker !== null) {
-    contents.Marker = data.Marker;
+    contents.Marker = __expectString(data.Marker);
   }
   if (data.UploadsList !== undefined && data.UploadsList !== null) {
     contents.UploadsList = deserializeAws_restJson1UploadsList(data.UploadsList, context);
@@ -3383,25 +3386,25 @@ export const deserializeAws_restJson1ListPartsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ArchiveDescription !== undefined && data.ArchiveDescription !== null) {
-    contents.ArchiveDescription = data.ArchiveDescription;
+    contents.ArchiveDescription = __expectString(data.ArchiveDescription);
   }
   if (data.CreationDate !== undefined && data.CreationDate !== null) {
-    contents.CreationDate = data.CreationDate;
+    contents.CreationDate = __expectString(data.CreationDate);
   }
   if (data.Marker !== undefined && data.Marker !== null) {
-    contents.Marker = data.Marker;
+    contents.Marker = __expectString(data.Marker);
   }
   if (data.MultipartUploadId !== undefined && data.MultipartUploadId !== null) {
-    contents.MultipartUploadId = data.MultipartUploadId;
+    contents.MultipartUploadId = __expectString(data.MultipartUploadId);
   }
   if (data.PartSizeInBytes !== undefined && data.PartSizeInBytes !== null) {
-    contents.PartSizeInBytes = data.PartSizeInBytes;
+    contents.PartSizeInBytes = __expectNumber(data.PartSizeInBytes);
   }
   if (data.Parts !== undefined && data.Parts !== null) {
     contents.Parts = deserializeAws_restJson1PartList(data.Parts, context);
   }
   if (data.VaultARN !== undefined && data.VaultARN !== null) {
-    contents.VaultARN = data.VaultARN;
+    contents.VaultARN = __expectString(data.VaultARN);
   }
   return Promise.resolve(contents);
 };
@@ -3634,7 +3637,7 @@ export const deserializeAws_restJson1ListVaultsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Marker !== undefined && data.Marker !== null) {
-    contents.Marker = data.Marker;
+    contents.Marker = __expectString(data.Marker);
   }
   if (data.VaultList !== undefined && data.VaultList !== null) {
     contents.VaultList = deserializeAws_restJson1VaultList(data.VaultList, context);
@@ -4270,13 +4273,13 @@ const deserializeAws_restJson1InsufficientCapacityExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.code !== undefined && data.code !== null) {
-    contents.code = data.code;
+    contents.code = __expectString(data.code);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.type !== undefined && data.type !== null) {
-    contents.type = data.type;
+    contents.type = __expectString(data.type);
   }
   return contents;
 };
@@ -4295,13 +4298,13 @@ const deserializeAws_restJson1InvalidParameterValueExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.code !== undefined && data.code !== null) {
-    contents.code = data.code;
+    contents.code = __expectString(data.code);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.type !== undefined && data.type !== null) {
-    contents.type = data.type;
+    contents.type = __expectString(data.type);
   }
   return contents;
 };
@@ -4320,13 +4323,13 @@ const deserializeAws_restJson1LimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.code !== undefined && data.code !== null) {
-    contents.code = data.code;
+    contents.code = __expectString(data.code);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.type !== undefined && data.type !== null) {
-    contents.type = data.type;
+    contents.type = __expectString(data.type);
   }
   return contents;
 };
@@ -4345,13 +4348,13 @@ const deserializeAws_restJson1MissingParameterValueExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.code !== undefined && data.code !== null) {
-    contents.code = data.code;
+    contents.code = __expectString(data.code);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.type !== undefined && data.type !== null) {
-    contents.type = data.type;
+    contents.type = __expectString(data.type);
   }
   return contents;
 };
@@ -4370,13 +4373,13 @@ const deserializeAws_restJson1PolicyEnforcedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.code !== undefined && data.code !== null) {
-    contents.code = data.code;
+    contents.code = __expectString(data.code);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.type !== undefined && data.type !== null) {
-    contents.type = data.type;
+    contents.type = __expectString(data.type);
   }
   return contents;
 };
@@ -4395,13 +4398,13 @@ const deserializeAws_restJson1RequestTimeoutExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.code !== undefined && data.code !== null) {
-    contents.code = data.code;
+    contents.code = __expectString(data.code);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.type !== undefined && data.type !== null) {
-    contents.type = data.type;
+    contents.type = __expectString(data.type);
   }
   return contents;
 };
@@ -4420,13 +4423,13 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.code !== undefined && data.code !== null) {
-    contents.code = data.code;
+    contents.code = __expectString(data.code);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.type !== undefined && data.type !== null) {
-    contents.type = data.type;
+    contents.type = __expectString(data.type);
   }
   return contents;
 };
@@ -4445,13 +4448,13 @@ const deserializeAws_restJson1ServiceUnavailableExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.code !== undefined && data.code !== null) {
-    contents.code = data.code;
+    contents.code = __expectString(data.code);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.type !== undefined && data.type !== null) {
-    contents.type = data.type;
+    contents.type = __expectString(data.type);
   }
   return contents;
 };
@@ -4724,35 +4727,22 @@ const deserializeAws_restJson1AccessControlPolicyList = (output: any, context: _
 
 const deserializeAws_restJson1CSVInput = (output: any, context: __SerdeContext): CSVInput => {
   return {
-    Comments: output.Comments !== undefined && output.Comments !== null ? output.Comments : undefined,
-    FieldDelimiter:
-      output.FieldDelimiter !== undefined && output.FieldDelimiter !== null ? output.FieldDelimiter : undefined,
-    FileHeaderInfo:
-      output.FileHeaderInfo !== undefined && output.FileHeaderInfo !== null ? output.FileHeaderInfo : undefined,
-    QuoteCharacter:
-      output.QuoteCharacter !== undefined && output.QuoteCharacter !== null ? output.QuoteCharacter : undefined,
-    QuoteEscapeCharacter:
-      output.QuoteEscapeCharacter !== undefined && output.QuoteEscapeCharacter !== null
-        ? output.QuoteEscapeCharacter
-        : undefined,
-    RecordDelimiter:
-      output.RecordDelimiter !== undefined && output.RecordDelimiter !== null ? output.RecordDelimiter : undefined,
+    Comments: __expectString(output.Comments),
+    FieldDelimiter: __expectString(output.FieldDelimiter),
+    FileHeaderInfo: __expectString(output.FileHeaderInfo),
+    QuoteCharacter: __expectString(output.QuoteCharacter),
+    QuoteEscapeCharacter: __expectString(output.QuoteEscapeCharacter),
+    RecordDelimiter: __expectString(output.RecordDelimiter),
   } as any;
 };
 
 const deserializeAws_restJson1CSVOutput = (output: any, context: __SerdeContext): CSVOutput => {
   return {
-    FieldDelimiter:
-      output.FieldDelimiter !== undefined && output.FieldDelimiter !== null ? output.FieldDelimiter : undefined,
-    QuoteCharacter:
-      output.QuoteCharacter !== undefined && output.QuoteCharacter !== null ? output.QuoteCharacter : undefined,
-    QuoteEscapeCharacter:
-      output.QuoteEscapeCharacter !== undefined && output.QuoteEscapeCharacter !== null
-        ? output.QuoteEscapeCharacter
-        : undefined,
-    QuoteFields: output.QuoteFields !== undefined && output.QuoteFields !== null ? output.QuoteFields : undefined,
-    RecordDelimiter:
-      output.RecordDelimiter !== undefined && output.RecordDelimiter !== null ? output.RecordDelimiter : undefined,
+    FieldDelimiter: __expectString(output.FieldDelimiter),
+    QuoteCharacter: __expectString(output.QuoteCharacter),
+    QuoteEscapeCharacter: __expectString(output.QuoteEscapeCharacter),
+    QuoteFields: __expectString(output.QuoteFields),
+    RecordDelimiter: __expectString(output.RecordDelimiter),
   } as any;
 };
 
@@ -4767,8 +4757,8 @@ const deserializeAws_restJson1DataRetrievalPolicy = (output: any, context: __Ser
 
 const deserializeAws_restJson1DataRetrievalRule = (output: any, context: __SerdeContext): DataRetrievalRule => {
   return {
-    BytesPerHour: output.BytesPerHour !== undefined && output.BytesPerHour !== null ? output.BytesPerHour : undefined,
-    Strategy: output.Strategy !== undefined && output.Strategy !== null ? output.Strategy : undefined,
+    BytesPerHour: __expectNumber(output.BytesPerHour),
+    Strategy: __expectString(output.Strategy),
   } as any;
 };
 
@@ -4785,77 +4775,55 @@ const deserializeAws_restJson1DataRetrievalRulesList = (output: any, context: __
 
 const deserializeAws_restJson1DescribeVaultOutput = (output: any, context: __SerdeContext): DescribeVaultOutput => {
   return {
-    CreationDate: output.CreationDate !== undefined && output.CreationDate !== null ? output.CreationDate : undefined,
-    LastInventoryDate:
-      output.LastInventoryDate !== undefined && output.LastInventoryDate !== null
-        ? output.LastInventoryDate
-        : undefined,
-    NumberOfArchives:
-      output.NumberOfArchives !== undefined && output.NumberOfArchives !== null ? output.NumberOfArchives : undefined,
-    SizeInBytes: output.SizeInBytes !== undefined && output.SizeInBytes !== null ? output.SizeInBytes : undefined,
-    VaultARN: output.VaultARN !== undefined && output.VaultARN !== null ? output.VaultARN : undefined,
-    VaultName: output.VaultName !== undefined && output.VaultName !== null ? output.VaultName : undefined,
+    CreationDate: __expectString(output.CreationDate),
+    LastInventoryDate: __expectString(output.LastInventoryDate),
+    NumberOfArchives: __expectNumber(output.NumberOfArchives),
+    SizeInBytes: __expectNumber(output.SizeInBytes),
+    VaultARN: __expectString(output.VaultARN),
+    VaultName: __expectString(output.VaultName),
   } as any;
 };
 
 const deserializeAws_restJson1Encryption = (output: any, context: __SerdeContext): Encryption => {
   return {
-    EncryptionType:
-      output.EncryptionType !== undefined && output.EncryptionType !== null ? output.EncryptionType : undefined,
-    KMSContext: output.KMSContext !== undefined && output.KMSContext !== null ? output.KMSContext : undefined,
-    KMSKeyId: output.KMSKeyId !== undefined && output.KMSKeyId !== null ? output.KMSKeyId : undefined,
+    EncryptionType: __expectString(output.EncryptionType),
+    KMSContext: __expectString(output.KMSContext),
+    KMSKeyId: __expectString(output.KMSKeyId),
   } as any;
 };
 
 const deserializeAws_restJson1GlacierJobDescription = (output: any, context: __SerdeContext): GlacierJobDescription => {
   return {
-    Action: output.Action !== undefined && output.Action !== null ? output.Action : undefined,
-    ArchiveId: output.ArchiveId !== undefined && output.ArchiveId !== null ? output.ArchiveId : undefined,
-    ArchiveSHA256TreeHash:
-      output.ArchiveSHA256TreeHash !== undefined && output.ArchiveSHA256TreeHash !== null
-        ? output.ArchiveSHA256TreeHash
-        : undefined,
-    ArchiveSizeInBytes:
-      output.ArchiveSizeInBytes !== undefined && output.ArchiveSizeInBytes !== null
-        ? output.ArchiveSizeInBytes
-        : undefined,
-    Completed: output.Completed !== undefined && output.Completed !== null ? output.Completed : undefined,
-    CompletionDate:
-      output.CompletionDate !== undefined && output.CompletionDate !== null ? output.CompletionDate : undefined,
-    CreationDate: output.CreationDate !== undefined && output.CreationDate !== null ? output.CreationDate : undefined,
+    Action: __expectString(output.Action),
+    ArchiveId: __expectString(output.ArchiveId),
+    ArchiveSHA256TreeHash: __expectString(output.ArchiveSHA256TreeHash),
+    ArchiveSizeInBytes: __expectNumber(output.ArchiveSizeInBytes),
+    Completed: __expectBoolean(output.Completed),
+    CompletionDate: __expectString(output.CompletionDate),
+    CreationDate: __expectString(output.CreationDate),
     InventoryRetrievalParameters:
       output.InventoryRetrievalParameters !== undefined && output.InventoryRetrievalParameters !== null
         ? deserializeAws_restJson1InventoryRetrievalJobDescription(output.InventoryRetrievalParameters, context)
         : undefined,
-    InventorySizeInBytes:
-      output.InventorySizeInBytes !== undefined && output.InventorySizeInBytes !== null
-        ? output.InventorySizeInBytes
-        : undefined,
-    JobDescription:
-      output.JobDescription !== undefined && output.JobDescription !== null ? output.JobDescription : undefined,
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
-    JobOutputPath:
-      output.JobOutputPath !== undefined && output.JobOutputPath !== null ? output.JobOutputPath : undefined,
+    InventorySizeInBytes: __expectNumber(output.InventorySizeInBytes),
+    JobDescription: __expectString(output.JobDescription),
+    JobId: __expectString(output.JobId),
+    JobOutputPath: __expectString(output.JobOutputPath),
     OutputLocation:
       output.OutputLocation !== undefined && output.OutputLocation !== null
         ? deserializeAws_restJson1OutputLocation(output.OutputLocation, context)
         : undefined,
-    RetrievalByteRange:
-      output.RetrievalByteRange !== undefined && output.RetrievalByteRange !== null
-        ? output.RetrievalByteRange
-        : undefined,
-    SHA256TreeHash:
-      output.SHA256TreeHash !== undefined && output.SHA256TreeHash !== null ? output.SHA256TreeHash : undefined,
-    SNSTopic: output.SNSTopic !== undefined && output.SNSTopic !== null ? output.SNSTopic : undefined,
+    RetrievalByteRange: __expectString(output.RetrievalByteRange),
+    SHA256TreeHash: __expectString(output.SHA256TreeHash),
+    SNSTopic: __expectString(output.SNSTopic),
     SelectParameters:
       output.SelectParameters !== undefined && output.SelectParameters !== null
         ? deserializeAws_restJson1SelectParameters(output.SelectParameters, context)
         : undefined,
-    StatusCode: output.StatusCode !== undefined && output.StatusCode !== null ? output.StatusCode : undefined,
-    StatusMessage:
-      output.StatusMessage !== undefined && output.StatusMessage !== null ? output.StatusMessage : undefined,
-    Tier: output.Tier !== undefined && output.Tier !== null ? output.Tier : undefined,
-    VaultARN: output.VaultARN !== undefined && output.VaultARN !== null ? output.VaultARN : undefined,
+    StatusCode: __expectString(output.StatusCode),
+    StatusMessage: __expectString(output.StatusMessage),
+    Tier: __expectString(output.Tier),
+    VaultARN: __expectString(output.VaultARN),
   } as any;
 };
 
@@ -4865,17 +4833,17 @@ const deserializeAws_restJson1Grant = (output: any, context: __SerdeContext): Gr
       output.Grantee !== undefined && output.Grantee !== null
         ? deserializeAws_restJson1Grantee(output.Grantee, context)
         : undefined,
-    Permission: output.Permission !== undefined && output.Permission !== null ? output.Permission : undefined,
+    Permission: __expectString(output.Permission),
   } as any;
 };
 
 const deserializeAws_restJson1Grantee = (output: any, context: __SerdeContext): Grantee => {
   return {
-    DisplayName: output.DisplayName !== undefined && output.DisplayName !== null ? output.DisplayName : undefined,
-    EmailAddress: output.EmailAddress !== undefined && output.EmailAddress !== null ? output.EmailAddress : undefined,
-    ID: output.ID !== undefined && output.ID !== null ? output.ID : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    URI: output.URI !== undefined && output.URI !== null ? output.URI : undefined,
+    DisplayName: __expectString(output.DisplayName),
+    EmailAddress: __expectString(output.EmailAddress),
+    ID: __expectString(output.ID),
+    Type: __expectString(output.Type),
+    URI: __expectString(output.URI),
   } as any;
 };
 
@@ -4886,7 +4854,7 @@ const deserializeAws_restJson1hashmap = (output: any, context: __SerdeContext): 
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -4905,11 +4873,11 @@ const deserializeAws_restJson1InventoryRetrievalJobDescription = (
   context: __SerdeContext
 ): InventoryRetrievalJobDescription => {
   return {
-    EndDate: output.EndDate !== undefined && output.EndDate !== null ? output.EndDate : undefined,
-    Format: output.Format !== undefined && output.Format !== null ? output.Format : undefined,
-    Limit: output.Limit !== undefined && output.Limit !== null ? output.Limit : undefined,
-    Marker: output.Marker !== undefined && output.Marker !== null ? output.Marker : undefined,
-    StartDate: output.StartDate !== undefined && output.StartDate !== null ? output.StartDate : undefined,
+    EndDate: __expectString(output.EndDate),
+    Format: __expectString(output.Format),
+    Limit: __expectString(output.Limit),
+    Marker: __expectString(output.Marker),
+    StartDate: __expectString(output.StartDate),
   } as any;
 };
 
@@ -4931,7 +4899,7 @@ const deserializeAws_restJson1NotificationEventList = (output: any, context: __S
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4966,9 +4934,8 @@ const deserializeAws_restJson1PartList = (output: any, context: __SerdeContext):
 
 const deserializeAws_restJson1PartListElement = (output: any, context: __SerdeContext): PartListElement => {
   return {
-    RangeInBytes: output.RangeInBytes !== undefined && output.RangeInBytes !== null ? output.RangeInBytes : undefined,
-    SHA256TreeHash:
-      output.SHA256TreeHash !== undefined && output.SHA256TreeHash !== null ? output.SHA256TreeHash : undefined,
+    RangeInBytes: __expectString(output.RangeInBytes),
+    SHA256TreeHash: __expectString(output.SHA256TreeHash),
   } as any;
 };
 
@@ -4977,10 +4944,9 @@ const deserializeAws_restJson1ProvisionedCapacityDescription = (
   context: __SerdeContext
 ): ProvisionedCapacityDescription => {
   return {
-    CapacityId: output.CapacityId !== undefined && output.CapacityId !== null ? output.CapacityId : undefined,
-    ExpirationDate:
-      output.ExpirationDate !== undefined && output.ExpirationDate !== null ? output.ExpirationDate : undefined,
-    StartDate: output.StartDate !== undefined && output.StartDate !== null ? output.StartDate : undefined,
+    CapacityId: __expectString(output.CapacityId),
+    ExpirationDate: __expectString(output.ExpirationDate),
+    StartDate: __expectString(output.StartDate),
   } as any;
 };
 
@@ -5004,14 +4970,14 @@ const deserializeAws_restJson1S3Location = (output: any, context: __SerdeContext
       output.AccessControlList !== undefined && output.AccessControlList !== null
         ? deserializeAws_restJson1AccessControlPolicyList(output.AccessControlList, context)
         : undefined,
-    BucketName: output.BucketName !== undefined && output.BucketName !== null ? output.BucketName : undefined,
-    CannedACL: output.CannedACL !== undefined && output.CannedACL !== null ? output.CannedACL : undefined,
+    BucketName: __expectString(output.BucketName),
+    CannedACL: __expectString(output.CannedACL),
     Encryption:
       output.Encryption !== undefined && output.Encryption !== null
         ? deserializeAws_restJson1Encryption(output.Encryption, context)
         : undefined,
-    Prefix: output.Prefix !== undefined && output.Prefix !== null ? output.Prefix : undefined,
-    StorageClass: output.StorageClass !== undefined && output.StorageClass !== null ? output.StorageClass : undefined,
+    Prefix: __expectString(output.Prefix),
+    StorageClass: __expectString(output.StorageClass),
     Tagging:
       output.Tagging !== undefined && output.Tagging !== null
         ? deserializeAws_restJson1hashmap(output.Tagging, context)
@@ -5025,9 +4991,8 @@ const deserializeAws_restJson1S3Location = (output: any, context: __SerdeContext
 
 const deserializeAws_restJson1SelectParameters = (output: any, context: __SerdeContext): SelectParameters => {
   return {
-    Expression: output.Expression !== undefined && output.Expression !== null ? output.Expression : undefined,
-    ExpressionType:
-      output.ExpressionType !== undefined && output.ExpressionType !== null ? output.ExpressionType : undefined,
+    Expression: __expectString(output.Expression),
+    ExpressionType: __expectString(output.ExpressionType),
     InputSerialization:
       output.InputSerialization !== undefined && output.InputSerialization !== null
         ? deserializeAws_restJson1InputSerialization(output.InputSerialization, context)
@@ -5046,25 +5011,18 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1UploadListElement = (output: any, context: __SerdeContext): UploadListElement => {
   return {
-    ArchiveDescription:
-      output.ArchiveDescription !== undefined && output.ArchiveDescription !== null
-        ? output.ArchiveDescription
-        : undefined,
-    CreationDate: output.CreationDate !== undefined && output.CreationDate !== null ? output.CreationDate : undefined,
-    MultipartUploadId:
-      output.MultipartUploadId !== undefined && output.MultipartUploadId !== null
-        ? output.MultipartUploadId
-        : undefined,
-    PartSizeInBytes:
-      output.PartSizeInBytes !== undefined && output.PartSizeInBytes !== null ? output.PartSizeInBytes : undefined,
-    VaultARN: output.VaultARN !== undefined && output.VaultARN !== null ? output.VaultARN : undefined,
+    ArchiveDescription: __expectString(output.ArchiveDescription),
+    CreationDate: __expectString(output.CreationDate),
+    MultipartUploadId: __expectString(output.MultipartUploadId),
+    PartSizeInBytes: __expectNumber(output.PartSizeInBytes),
+    VaultARN: __expectString(output.VaultARN),
   } as any;
 };
 
@@ -5081,7 +5039,7 @@ const deserializeAws_restJson1UploadsList = (output: any, context: __SerdeContex
 
 const deserializeAws_restJson1VaultAccessPolicy = (output: any, context: __SerdeContext): VaultAccessPolicy => {
   return {
-    Policy: output.Policy !== undefined && output.Policy !== null ? output.Policy : undefined,
+    Policy: __expectString(output.Policy),
   } as any;
 };
 
@@ -5105,7 +5063,7 @@ const deserializeAws_restJson1VaultNotificationConfig = (
       output.Events !== undefined && output.Events !== null
         ? deserializeAws_restJson1NotificationEventList(output.Events, context)
         : undefined,
-    SNSTopic: output.SNSTopic !== undefined && output.SNSTopic !== null ? output.SNSTopic : undefined,
+    SNSTopic: __expectString(output.SNSTopic),
   } as any;
 };
 

--- a/clients/client-global-accelerator/protocols/Aws_json1_1.ts
+++ b/clients/client-global-accelerator/protocols/Aws_json1_1.ts
@@ -270,7 +270,12 @@ import {
   WithdrawByoipCidrResponse,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -5596,16 +5601,14 @@ const serializeAws_json1_1WithdrawByoipCidrRequest = (
 
 const deserializeAws_json1_1Accelerator = (output: any, context: __SerdeContext): Accelerator => {
   return {
-    AcceleratorArn:
-      output.AcceleratorArn !== undefined && output.AcceleratorArn !== null ? output.AcceleratorArn : undefined,
+    AcceleratorArn: __expectString(output.AcceleratorArn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
         : undefined,
-    DnsName: output.DnsName !== undefined && output.DnsName !== null ? output.DnsName : undefined,
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
-    IpAddressType:
-      output.IpAddressType !== undefined && output.IpAddressType !== null ? output.IpAddressType : undefined,
+    DnsName: __expectString(output.DnsName),
+    Enabled: __expectBoolean(output.Enabled),
+    IpAddressType: __expectString(output.IpAddressType),
     IpSets:
       output.IpSets !== undefined && output.IpSets !== null
         ? deserializeAws_json1_1IpSets(output.IpSets, context)
@@ -5614,19 +5617,16 @@ const deserializeAws_json1_1Accelerator = (output: any, context: __SerdeContext)
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Name: __expectString(output.Name),
+    Status: __expectString(output.Status),
   } as any;
 };
 
 const deserializeAws_json1_1AcceleratorAttributes = (output: any, context: __SerdeContext): AcceleratorAttributes => {
   return {
-    FlowLogsEnabled:
-      output.FlowLogsEnabled !== undefined && output.FlowLogsEnabled !== null ? output.FlowLogsEnabled : undefined,
-    FlowLogsS3Bucket:
-      output.FlowLogsS3Bucket !== undefined && output.FlowLogsS3Bucket !== null ? output.FlowLogsS3Bucket : undefined,
-    FlowLogsS3Prefix:
-      output.FlowLogsS3Prefix !== undefined && output.FlowLogsS3Prefix !== null ? output.FlowLogsS3Prefix : undefined,
+    FlowLogsEnabled: __expectBoolean(output.FlowLogsEnabled),
+    FlowLogsS3Bucket: __expectString(output.FlowLogsS3Bucket),
+    FlowLogsS3Prefix: __expectString(output.FlowLogsS3Prefix),
   } as any;
 };
 
@@ -5635,7 +5635,7 @@ const deserializeAws_json1_1AcceleratorNotDisabledException = (
   context: __SerdeContext
 ): AcceleratorNotDisabledException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -5644,7 +5644,7 @@ const deserializeAws_json1_1AcceleratorNotFoundException = (
   context: __SerdeContext
 ): AcceleratorNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -5661,7 +5661,7 @@ const deserializeAws_json1_1Accelerators = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_1AccessDeniedException = (output: any, context: __SerdeContext): AccessDeniedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -5674,8 +5674,7 @@ const deserializeAws_json1_1AddCustomRoutingEndpointsResponse = (
       output.EndpointDescriptions !== undefined && output.EndpointDescriptions !== null
         ? deserializeAws_json1_1CustomRoutingEndpointDescriptions(output.EndpointDescriptions, context)
         : undefined,
-    EndpointGroupArn:
-      output.EndpointGroupArn !== undefined && output.EndpointGroupArn !== null ? output.EndpointGroupArn : undefined,
+    EndpointGroupArn: __expectString(output.EndpointGroupArn),
   } as any;
 };
 
@@ -5696,7 +5695,7 @@ const deserializeAws_json1_1AssociatedEndpointGroupFoundException = (
   context: __SerdeContext
 ): AssociatedEndpointGroupFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -5705,24 +5704,24 @@ const deserializeAws_json1_1AssociatedListenerFoundException = (
   context: __SerdeContext
 ): AssociatedListenerFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1ByoipCidr = (output: any, context: __SerdeContext): ByoipCidr => {
   return {
-    Cidr: output.Cidr !== undefined && output.Cidr !== null ? output.Cidr : undefined,
+    Cidr: __expectString(output.Cidr),
     Events:
       output.Events !== undefined && output.Events !== null
         ? deserializeAws_json1_1ByoipCidrEvents(output.Events, context)
         : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    State: __expectString(output.State),
   } as any;
 };
 
 const deserializeAws_json1_1ByoipCidrEvent = (output: any, context: __SerdeContext): ByoipCidrEvent => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
     Timestamp:
       output.Timestamp !== undefined && output.Timestamp !== null
         ? new Date(Math.round(output.Timestamp * 1000))
@@ -5746,7 +5745,7 @@ const deserializeAws_json1_1ByoipCidrNotFoundException = (
   context: __SerdeContext
 ): ByoipCidrNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -5763,7 +5762,7 @@ const deserializeAws_json1_1ByoipCidrs = (output: any, context: __SerdeContext):
 
 const deserializeAws_json1_1ConflictException = (output: any, context: __SerdeContext): ConflictException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -5841,16 +5840,14 @@ const deserializeAws_json1_1CustomRoutingAccelerator = (
   context: __SerdeContext
 ): CustomRoutingAccelerator => {
   return {
-    AcceleratorArn:
-      output.AcceleratorArn !== undefined && output.AcceleratorArn !== null ? output.AcceleratorArn : undefined,
+    AcceleratorArn: __expectString(output.AcceleratorArn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
         : undefined,
-    DnsName: output.DnsName !== undefined && output.DnsName !== null ? output.DnsName : undefined,
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
-    IpAddressType:
-      output.IpAddressType !== undefined && output.IpAddressType !== null ? output.IpAddressType : undefined,
+    DnsName: __expectString(output.DnsName),
+    Enabled: __expectBoolean(output.Enabled),
+    IpAddressType: __expectString(output.IpAddressType),
     IpSets:
       output.IpSets !== undefined && output.IpSets !== null
         ? deserializeAws_json1_1IpSets(output.IpSets, context)
@@ -5859,8 +5856,8 @@ const deserializeAws_json1_1CustomRoutingAccelerator = (
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Name: __expectString(output.Name),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -5869,12 +5866,9 @@ const deserializeAws_json1_1CustomRoutingAcceleratorAttributes = (
   context: __SerdeContext
 ): CustomRoutingAcceleratorAttributes => {
   return {
-    FlowLogsEnabled:
-      output.FlowLogsEnabled !== undefined && output.FlowLogsEnabled !== null ? output.FlowLogsEnabled : undefined,
-    FlowLogsS3Bucket:
-      output.FlowLogsS3Bucket !== undefined && output.FlowLogsS3Bucket !== null ? output.FlowLogsS3Bucket : undefined,
-    FlowLogsS3Prefix:
-      output.FlowLogsS3Prefix !== undefined && output.FlowLogsS3Prefix !== null ? output.FlowLogsS3Prefix : undefined,
+    FlowLogsEnabled: __expectBoolean(output.FlowLogsEnabled),
+    FlowLogsS3Bucket: __expectString(output.FlowLogsS3Bucket),
+    FlowLogsS3Prefix: __expectString(output.FlowLogsS3Prefix),
   } as any;
 };
 
@@ -5897,12 +5891,12 @@ const deserializeAws_json1_1CustomRoutingDestinationDescription = (
   context: __SerdeContext
 ): CustomRoutingDestinationDescription => {
   return {
-    FromPort: output.FromPort !== undefined && output.FromPort !== null ? output.FromPort : undefined,
+    FromPort: __expectNumber(output.FromPort),
     Protocols:
       output.Protocols !== undefined && output.Protocols !== null
         ? deserializeAws_json1_1Protocols(output.Protocols, context)
         : undefined,
-    ToPort: output.ToPort !== undefined && output.ToPort !== null ? output.ToPort : undefined,
+    ToPort: __expectNumber(output.ToPort),
   } as any;
 };
 
@@ -5925,7 +5919,7 @@ const deserializeAws_json1_1CustomRoutingEndpointDescription = (
   context: __SerdeContext
 ): CustomRoutingEndpointDescription => {
   return {
-    EndpointId: output.EndpointId !== undefined && output.EndpointId !== null ? output.EndpointId : undefined,
+    EndpointId: __expectString(output.EndpointId),
   } as any;
 };
 
@@ -5956,12 +5950,8 @@ const deserializeAws_json1_1CustomRoutingEndpointGroup = (
       output.EndpointDescriptions !== undefined && output.EndpointDescriptions !== null
         ? deserializeAws_json1_1CustomRoutingEndpointDescriptions(output.EndpointDescriptions, context)
         : undefined,
-    EndpointGroupArn:
-      output.EndpointGroupArn !== undefined && output.EndpointGroupArn !== null ? output.EndpointGroupArn : undefined,
-    EndpointGroupRegion:
-      output.EndpointGroupRegion !== undefined && output.EndpointGroupRegion !== null
-        ? output.EndpointGroupRegion
-        : undefined,
+    EndpointGroupArn: __expectString(output.EndpointGroupArn),
+    EndpointGroupRegion: __expectString(output.EndpointGroupRegion),
   } as any;
 };
 
@@ -5981,7 +5971,7 @@ const deserializeAws_json1_1CustomRoutingEndpointGroups = (
 
 const deserializeAws_json1_1CustomRoutingListener = (output: any, context: __SerdeContext): CustomRoutingListener => {
   return {
-    ListenerArn: output.ListenerArn !== undefined && output.ListenerArn !== null ? output.ListenerArn : undefined,
+    ListenerArn: __expectString(output.ListenerArn),
     PortRanges:
       output.PortRanges !== undefined && output.PortRanges !== null
         ? deserializeAws_json1_1PortRanges(output.PortRanges, context)
@@ -6013,7 +6003,7 @@ const deserializeAws_json1_1CustomRoutingProtocols = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6127,8 +6117,7 @@ const deserializeAws_json1_1DescribeListenerResponse = (
 
 const deserializeAws_json1_1DestinationPortMapping = (output: any, context: __SerdeContext): DestinationPortMapping => {
   return {
-    AcceleratorArn:
-      output.AcceleratorArn !== undefined && output.AcceleratorArn !== null ? output.AcceleratorArn : undefined,
+    AcceleratorArn: __expectString(output.AcceleratorArn),
     AcceleratorSocketAddresses:
       output.AcceleratorSocketAddresses !== undefined && output.AcceleratorSocketAddresses !== null
         ? deserializeAws_json1_1SocketAddresses(output.AcceleratorSocketAddresses, context)
@@ -6137,19 +6126,11 @@ const deserializeAws_json1_1DestinationPortMapping = (output: any, context: __Se
       output.DestinationSocketAddress !== undefined && output.DestinationSocketAddress !== null
         ? deserializeAws_json1_1SocketAddress(output.DestinationSocketAddress, context)
         : undefined,
-    DestinationTrafficState:
-      output.DestinationTrafficState !== undefined && output.DestinationTrafficState !== null
-        ? output.DestinationTrafficState
-        : undefined,
-    EndpointGroupArn:
-      output.EndpointGroupArn !== undefined && output.EndpointGroupArn !== null ? output.EndpointGroupArn : undefined,
-    EndpointGroupRegion:
-      output.EndpointGroupRegion !== undefined && output.EndpointGroupRegion !== null
-        ? output.EndpointGroupRegion
-        : undefined,
-    EndpointId: output.EndpointId !== undefined && output.EndpointId !== null ? output.EndpointId : undefined,
-    IpAddressType:
-      output.IpAddressType !== undefined && output.IpAddressType !== null ? output.IpAddressType : undefined,
+    DestinationTrafficState: __expectString(output.DestinationTrafficState),
+    EndpointGroupArn: __expectString(output.EndpointGroupArn),
+    EndpointGroupRegion: __expectString(output.EndpointGroupRegion),
+    EndpointId: __expectString(output.EndpointId),
+    IpAddressType: __expectString(output.IpAddressType),
   } as any;
 };
 
@@ -6172,20 +6153,17 @@ const deserializeAws_json1_1EndpointAlreadyExistsException = (
   context: __SerdeContext
 ): EndpointAlreadyExistsException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1EndpointDescription = (output: any, context: __SerdeContext): EndpointDescription => {
   return {
-    ClientIPPreservationEnabled:
-      output.ClientIPPreservationEnabled !== undefined && output.ClientIPPreservationEnabled !== null
-        ? output.ClientIPPreservationEnabled
-        : undefined,
-    EndpointId: output.EndpointId !== undefined && output.EndpointId !== null ? output.EndpointId : undefined,
-    HealthReason: output.HealthReason !== undefined && output.HealthReason !== null ? output.HealthReason : undefined,
-    HealthState: output.HealthState !== undefined && output.HealthState !== null ? output.HealthState : undefined,
-    Weight: output.Weight !== undefined && output.Weight !== null ? output.Weight : undefined,
+    ClientIPPreservationEnabled: __expectBoolean(output.ClientIPPreservationEnabled),
+    EndpointId: __expectString(output.EndpointId),
+    HealthReason: __expectString(output.HealthReason),
+    HealthState: __expectString(output.HealthState),
+    Weight: __expectNumber(output.Weight),
   } as any;
 };
 
@@ -6206,34 +6184,18 @@ const deserializeAws_json1_1EndpointGroup = (output: any, context: __SerdeContex
       output.EndpointDescriptions !== undefined && output.EndpointDescriptions !== null
         ? deserializeAws_json1_1EndpointDescriptions(output.EndpointDescriptions, context)
         : undefined,
-    EndpointGroupArn:
-      output.EndpointGroupArn !== undefined && output.EndpointGroupArn !== null ? output.EndpointGroupArn : undefined,
-    EndpointGroupRegion:
-      output.EndpointGroupRegion !== undefined && output.EndpointGroupRegion !== null
-        ? output.EndpointGroupRegion
-        : undefined,
-    HealthCheckIntervalSeconds:
-      output.HealthCheckIntervalSeconds !== undefined && output.HealthCheckIntervalSeconds !== null
-        ? output.HealthCheckIntervalSeconds
-        : undefined,
-    HealthCheckPath:
-      output.HealthCheckPath !== undefined && output.HealthCheckPath !== null ? output.HealthCheckPath : undefined,
-    HealthCheckPort:
-      output.HealthCheckPort !== undefined && output.HealthCheckPort !== null ? output.HealthCheckPort : undefined,
-    HealthCheckProtocol:
-      output.HealthCheckProtocol !== undefined && output.HealthCheckProtocol !== null
-        ? output.HealthCheckProtocol
-        : undefined,
+    EndpointGroupArn: __expectString(output.EndpointGroupArn),
+    EndpointGroupRegion: __expectString(output.EndpointGroupRegion),
+    HealthCheckIntervalSeconds: __expectNumber(output.HealthCheckIntervalSeconds),
+    HealthCheckPath: __expectString(output.HealthCheckPath),
+    HealthCheckPort: __expectNumber(output.HealthCheckPort),
+    HealthCheckProtocol: __expectString(output.HealthCheckProtocol),
     PortOverrides:
       output.PortOverrides !== undefined && output.PortOverrides !== null
         ? deserializeAws_json1_1PortOverrides(output.PortOverrides, context)
         : undefined,
-    ThresholdCount:
-      output.ThresholdCount !== undefined && output.ThresholdCount !== null ? output.ThresholdCount : undefined,
-    TrafficDialPercentage:
-      output.TrafficDialPercentage !== undefined && output.TrafficDialPercentage !== null
-        ? output.TrafficDialPercentage
-        : undefined,
+    ThresholdCount: __expectNumber(output.ThresholdCount),
+    TrafficDialPercentage: __expectNumber(output.TrafficDialPercentage),
   } as any;
 };
 
@@ -6242,7 +6204,7 @@ const deserializeAws_json1_1EndpointGroupAlreadyExistsException = (
   context: __SerdeContext
 ): EndpointGroupAlreadyExistsException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -6251,7 +6213,7 @@ const deserializeAws_json1_1EndpointGroupNotFoundException = (
   context: __SerdeContext
 ): EndpointGroupNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -6271,7 +6233,7 @@ const deserializeAws_json1_1EndpointNotFoundException = (
   context: __SerdeContext
 ): EndpointNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -6280,7 +6242,7 @@ const deserializeAws_json1_1IncorrectCidrStateException = (
   context: __SerdeContext
 ): IncorrectCidrStateException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -6289,7 +6251,7 @@ const deserializeAws_json1_1InternalServiceErrorException = (
   context: __SerdeContext
 ): InternalServiceErrorException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -6298,7 +6260,7 @@ const deserializeAws_json1_1InvalidArgumentException = (
   context: __SerdeContext
 ): InvalidArgumentException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -6307,7 +6269,7 @@ const deserializeAws_json1_1InvalidNextTokenException = (
   context: __SerdeContext
 ): InvalidNextTokenException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -6316,7 +6278,7 @@ const deserializeAws_json1_1InvalidPortRangeException = (
   context: __SerdeContext
 ): InvalidPortRangeException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -6327,7 +6289,7 @@ const deserializeAws_json1_1IpAddresses = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6337,7 +6299,7 @@ const deserializeAws_json1_1IpSet = (output: any, context: __SerdeContext): IpSe
       output.IpAddresses !== undefined && output.IpAddresses !== null
         ? deserializeAws_json1_1IpAddresses(output.IpAddresses, context)
         : undefined,
-    IpFamily: output.IpFamily !== undefined && output.IpFamily !== null ? output.IpFamily : undefined,
+    IpFamily: __expectString(output.IpFamily),
   } as any;
 };
 
@@ -6354,7 +6316,7 @@ const deserializeAws_json1_1IpSets = (output: any, context: __SerdeContext): IpS
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -6367,7 +6329,7 @@ const deserializeAws_json1_1ListAcceleratorsResponse = (
       output.Accelerators !== undefined && output.Accelerators !== null
         ? deserializeAws_json1_1Accelerators(output.Accelerators, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -6377,7 +6339,7 @@ const deserializeAws_json1_1ListByoipCidrsResponse = (output: any, context: __Se
       output.ByoipCidrs !== undefined && output.ByoipCidrs !== null
         ? deserializeAws_json1_1ByoipCidrs(output.ByoipCidrs, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -6390,7 +6352,7 @@ const deserializeAws_json1_1ListCustomRoutingAcceleratorsResponse = (
       output.Accelerators !== undefined && output.Accelerators !== null
         ? deserializeAws_json1_1CustomRoutingAccelerators(output.Accelerators, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -6403,7 +6365,7 @@ const deserializeAws_json1_1ListCustomRoutingEndpointGroupsResponse = (
       output.EndpointGroups !== undefined && output.EndpointGroups !== null
         ? deserializeAws_json1_1CustomRoutingEndpointGroups(output.EndpointGroups, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -6416,7 +6378,7 @@ const deserializeAws_json1_1ListCustomRoutingListenersResponse = (
       output.Listeners !== undefined && output.Listeners !== null
         ? deserializeAws_json1_1CustomRoutingListeners(output.Listeners, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -6429,7 +6391,7 @@ const deserializeAws_json1_1ListCustomRoutingPortMappingsByDestinationResponse =
       output.DestinationPortMappings !== undefined && output.DestinationPortMappings !== null
         ? deserializeAws_json1_1DestinationPortMappings(output.DestinationPortMappings, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -6438,7 +6400,7 @@ const deserializeAws_json1_1ListCustomRoutingPortMappingsResponse = (
   context: __SerdeContext
 ): ListCustomRoutingPortMappingsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     PortMappings:
       output.PortMappings !== undefined && output.PortMappings !== null
         ? deserializeAws_json1_1PortMappings(output.PortMappings, context)
@@ -6455,20 +6417,19 @@ const deserializeAws_json1_1ListEndpointGroupsResponse = (
       output.EndpointGroups !== undefined && output.EndpointGroups !== null
         ? deserializeAws_json1_1EndpointGroups(output.EndpointGroups, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
 const deserializeAws_json1_1Listener = (output: any, context: __SerdeContext): Listener => {
   return {
-    ClientAffinity:
-      output.ClientAffinity !== undefined && output.ClientAffinity !== null ? output.ClientAffinity : undefined,
-    ListenerArn: output.ListenerArn !== undefined && output.ListenerArn !== null ? output.ListenerArn : undefined,
+    ClientAffinity: __expectString(output.ClientAffinity),
+    ListenerArn: __expectString(output.ListenerArn),
     PortRanges:
       output.PortRanges !== undefined && output.PortRanges !== null
         ? deserializeAws_json1_1PortRanges(output.PortRanges, context)
         : undefined,
-    Protocol: output.Protocol !== undefined && output.Protocol !== null ? output.Protocol : undefined,
+    Protocol: __expectString(output.Protocol),
   } as any;
 };
 
@@ -6477,7 +6438,7 @@ const deserializeAws_json1_1ListenerNotFoundException = (
   context: __SerdeContext
 ): ListenerNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -6498,7 +6459,7 @@ const deserializeAws_json1_1ListListenersResponse = (output: any, context: __Ser
       output.Listeners !== undefined && output.Listeners !== null
         ? deserializeAws_json1_1Listeners(output.Listeners, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -6514,19 +6475,14 @@ const deserializeAws_json1_1ListTagsForResourceResponse = (
 
 const deserializeAws_json1_1PortMapping = (output: any, context: __SerdeContext): PortMapping => {
   return {
-    AcceleratorPort:
-      output.AcceleratorPort !== undefined && output.AcceleratorPort !== null ? output.AcceleratorPort : undefined,
+    AcceleratorPort: __expectNumber(output.AcceleratorPort),
     DestinationSocketAddress:
       output.DestinationSocketAddress !== undefined && output.DestinationSocketAddress !== null
         ? deserializeAws_json1_1SocketAddress(output.DestinationSocketAddress, context)
         : undefined,
-    DestinationTrafficState:
-      output.DestinationTrafficState !== undefined && output.DestinationTrafficState !== null
-        ? output.DestinationTrafficState
-        : undefined,
-    EndpointGroupArn:
-      output.EndpointGroupArn !== undefined && output.EndpointGroupArn !== null ? output.EndpointGroupArn : undefined,
-    EndpointId: output.EndpointId !== undefined && output.EndpointId !== null ? output.EndpointId : undefined,
+    DestinationTrafficState: __expectString(output.DestinationTrafficState),
+    EndpointGroupArn: __expectString(output.EndpointGroupArn),
+    EndpointId: __expectString(output.EndpointId),
     Protocols:
       output.Protocols !== undefined && output.Protocols !== null
         ? deserializeAws_json1_1CustomRoutingProtocols(output.Protocols, context)
@@ -6547,8 +6503,8 @@ const deserializeAws_json1_1PortMappings = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_1PortOverride = (output: any, context: __SerdeContext): PortOverride => {
   return {
-    EndpointPort: output.EndpointPort !== undefined && output.EndpointPort !== null ? output.EndpointPort : undefined,
-    ListenerPort: output.ListenerPort !== undefined && output.ListenerPort !== null ? output.ListenerPort : undefined,
+    EndpointPort: __expectNumber(output.EndpointPort),
+    ListenerPort: __expectNumber(output.ListenerPort),
   } as any;
 };
 
@@ -6565,8 +6521,8 @@ const deserializeAws_json1_1PortOverrides = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1PortRange = (output: any, context: __SerdeContext): PortRange => {
   return {
-    FromPort: output.FromPort !== undefined && output.FromPort !== null ? output.FromPort : undefined,
-    ToPort: output.ToPort !== undefined && output.ToPort !== null ? output.ToPort : undefined,
+    FromPort: __expectNumber(output.FromPort),
+    ToPort: __expectNumber(output.ToPort),
   } as any;
 };
 
@@ -6588,7 +6544,7 @@ const deserializeAws_json1_1Protocols = (output: any, context: __SerdeContext): 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6606,8 +6562,8 @@ const deserializeAws_json1_1ProvisionByoipCidrResponse = (
 
 const deserializeAws_json1_1SocketAddress = (output: any, context: __SerdeContext): SocketAddress => {
   return {
-    IpAddress: output.IpAddress !== undefined && output.IpAddress !== null ? output.IpAddress : undefined,
-    Port: output.Port !== undefined && output.Port !== null ? output.Port : undefined,
+    IpAddress: __expectString(output.IpAddress),
+    Port: __expectNumber(output.Port),
   } as any;
 };
 
@@ -6624,8 +6580,8 @@ const deserializeAws_json1_1SocketAddresses = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 

--- a/clients/client-glue/protocols/Aws_json1_1.ts
+++ b/clients/client-glue/protocols/Aws_json1_1.ts
@@ -793,7 +793,12 @@ import {
   VersionMismatchException,
 } from "../models/models_1";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -19457,7 +19462,7 @@ const serializeAws_json1_1WorkflowRunProperties = (input: { [key: string]: strin
 
 const deserializeAws_json1_1AccessDeniedException = (output: any, context: __SerdeContext): AccessDeniedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -19467,17 +19472,14 @@ const deserializeAws_json1_1Action = (output: any, context: __SerdeContext): Act
       output.Arguments !== undefined && output.Arguments !== null
         ? deserializeAws_json1_1GenericMap(output.Arguments, context)
         : undefined,
-    CrawlerName: output.CrawlerName !== undefined && output.CrawlerName !== null ? output.CrawlerName : undefined,
-    JobName: output.JobName !== undefined && output.JobName !== null ? output.JobName : undefined,
+    CrawlerName: __expectString(output.CrawlerName),
+    JobName: __expectString(output.JobName),
     NotificationProperty:
       output.NotificationProperty !== undefined && output.NotificationProperty !== null
         ? deserializeAws_json1_1NotificationProperty(output.NotificationProperty, context)
         : undefined,
-    SecurityConfiguration:
-      output.SecurityConfiguration !== undefined && output.SecurityConfiguration !== null
-        ? output.SecurityConfiguration
-        : undefined,
-    Timeout: output.Timeout !== undefined && output.Timeout !== null ? output.Timeout : undefined,
+    SecurityConfiguration: __expectString(output.SecurityConfiguration),
+    Timeout: __expectNumber(output.Timeout),
   } as any;
 };
 
@@ -19494,13 +19496,13 @@ const deserializeAws_json1_1ActionList = (output: any, context: __SerdeContext):
 
 const deserializeAws_json1_1AlreadyExistsException = (output: any, context: __SerdeContext): AlreadyExistsException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1BackfillError = (output: any, context: __SerdeContext): BackfillError => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
+    Code: __expectString(output.Code),
     Partitions:
       output.Partitions !== undefined && output.Partitions !== null
         ? deserializeAws_json1_1BackfillErroredPartitionsList(output.Partitions, context)
@@ -19710,8 +19712,8 @@ const deserializeAws_json1_1BatchStopJobRunError = (output: any, context: __Serd
       output.ErrorDetail !== undefined && output.ErrorDetail !== null
         ? deserializeAws_json1_1ErrorDetail(output.ErrorDetail, context)
         : undefined,
-    JobName: output.JobName !== undefined && output.JobName !== null ? output.JobName : undefined,
-    JobRunId: output.JobRunId !== undefined && output.JobRunId !== null ? output.JobRunId : undefined,
+    JobName: __expectString(output.JobName),
+    JobRunId: __expectString(output.JobRunId),
   } as any;
 };
 
@@ -19750,8 +19752,8 @@ const deserializeAws_json1_1BatchStopJobRunSuccessfulSubmission = (
   context: __SerdeContext
 ): BatchStopJobRunSuccessfulSubmission => {
   return {
-    JobName: output.JobName !== undefined && output.JobName !== null ? output.JobName : undefined,
-    JobRunId: output.JobRunId !== undefined && output.JobRunId !== null ? output.JobRunId : undefined,
+    JobName: __expectString(output.JobName),
+    JobRunId: __expectString(output.JobRunId),
   } as any;
 };
 
@@ -19816,12 +19818,9 @@ const deserializeAws_json1_1BinaryColumnStatisticsData = (
   context: __SerdeContext
 ): BinaryColumnStatisticsData => {
   return {
-    AverageLength:
-      output.AverageLength !== undefined && output.AverageLength !== null ? output.AverageLength : undefined,
-    MaximumLength:
-      output.MaximumLength !== undefined && output.MaximumLength !== null ? output.MaximumLength : undefined,
-    NumberOfNulls:
-      output.NumberOfNulls !== undefined && output.NumberOfNulls !== null ? output.NumberOfNulls : undefined,
+    AverageLength: __expectNumber(output.AverageLength),
+    MaximumLength: __expectNumber(output.MaximumLength),
+    NumberOfNulls: __expectNumber(output.NumberOfNulls),
   } as any;
 };
 
@@ -19830,12 +19829,9 @@ const deserializeAws_json1_1BooleanColumnStatisticsData = (
   context: __SerdeContext
 ): BooleanColumnStatisticsData => {
   return {
-    NumberOfFalses:
-      output.NumberOfFalses !== undefined && output.NumberOfFalses !== null ? output.NumberOfFalses : undefined,
-    NumberOfNulls:
-      output.NumberOfNulls !== undefined && output.NumberOfNulls !== null ? output.NumberOfNulls : undefined,
-    NumberOfTrues:
-      output.NumberOfTrues !== undefined && output.NumberOfTrues !== null ? output.NumberOfTrues : undefined,
+    NumberOfFalses: __expectNumber(output.NumberOfFalses),
+    NumberOfNulls: __expectNumber(output.NumberOfNulls),
+    NumberOfTrues: __expectNumber(output.NumberOfTrues),
   } as any;
 };
 
@@ -19846,7 +19842,7 @@ const deserializeAws_json1_1BoundedPartitionValueList = (output: any, context: _
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -19855,21 +19851,20 @@ const deserializeAws_json1_1CancelMLTaskRunResponse = (
   context: __SerdeContext
 ): CancelMLTaskRunResponse => {
   return {
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    TaskRunId: output.TaskRunId !== undefined && output.TaskRunId !== null ? output.TaskRunId : undefined,
-    TransformId: output.TransformId !== undefined && output.TransformId !== null ? output.TransformId : undefined,
+    Status: __expectString(output.Status),
+    TaskRunId: __expectString(output.TaskRunId),
+    TransformId: __expectString(output.TransformId),
   } as any;
 };
 
 const deserializeAws_json1_1CatalogImportStatus = (output: any, context: __SerdeContext): CatalogImportStatus => {
   return {
-    ImportCompleted:
-      output.ImportCompleted !== undefined && output.ImportCompleted !== null ? output.ImportCompleted : undefined,
+    ImportCompleted: __expectBoolean(output.ImportCompleted),
     ImportTime:
       output.ImportTime !== undefined && output.ImportTime !== null
         ? new Date(Math.round(output.ImportTime * 1000))
         : undefined,
-    ImportedBy: output.ImportedBy !== undefined && output.ImportedBy !== null ? output.ImportedBy : undefined,
+    ImportedBy: __expectString(output.ImportedBy),
   } as any;
 };
 
@@ -19880,13 +19875,13 @@ const deserializeAws_json1_1CatalogTablesList = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1CatalogTarget = (output: any, context: __SerdeContext): CatalogTarget => {
   return {
-    DatabaseName: output.DatabaseName !== undefined && output.DatabaseName !== null ? output.DatabaseName : undefined,
+    DatabaseName: __expectString(output.DatabaseName),
     Tables:
       output.Tables !== undefined && output.Tables !== null
         ? deserializeAws_json1_1CatalogTablesList(output.Tables, context)
@@ -19910,8 +19905,8 @@ const deserializeAws_json1_1CheckSchemaVersionValidityResponse = (
   context: __SerdeContext
 ): CheckSchemaVersionValidityResponse => {
   return {
-    Error: output.Error !== undefined && output.Error !== null ? output.Error : undefined,
-    Valid: output.Valid !== undefined && output.Valid !== null ? output.Valid : undefined,
+    Error: __expectString(output.Error),
+    Valid: __expectBoolean(output.Valid),
   } as any;
 };
 
@@ -19954,26 +19949,22 @@ const deserializeAws_json1_1ClassifierNameList = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1CloudWatchEncryption = (output: any, context: __SerdeContext): CloudWatchEncryption => {
   return {
-    CloudWatchEncryptionMode:
-      output.CloudWatchEncryptionMode !== undefined && output.CloudWatchEncryptionMode !== null
-        ? output.CloudWatchEncryptionMode
-        : undefined,
-    KmsKeyArn: output.KmsKeyArn !== undefined && output.KmsKeyArn !== null ? output.KmsKeyArn : undefined,
+    CloudWatchEncryptionMode: __expectString(output.CloudWatchEncryptionMode),
+    KmsKeyArn: __expectString(output.KmsKeyArn),
   } as any;
 };
 
 const deserializeAws_json1_1CodeGenEdge = (output: any, context: __SerdeContext): CodeGenEdge => {
   return {
-    Source: output.Source !== undefined && output.Source !== null ? output.Source : undefined,
-    Target: output.Target !== undefined && output.Target !== null ? output.Target : undefined,
-    TargetParameter:
-      output.TargetParameter !== undefined && output.TargetParameter !== null ? output.TargetParameter : undefined,
+    Source: __expectString(output.Source),
+    Target: __expectString(output.Target),
+    TargetParameter: __expectString(output.TargetParameter),
   } as any;
 };
 
@@ -19983,17 +19974,17 @@ const deserializeAws_json1_1CodeGenNode = (output: any, context: __SerdeContext)
       output.Args !== undefined && output.Args !== null
         ? deserializeAws_json1_1CodeGenNodeArgs(output.Args, context)
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    LineNumber: output.LineNumber !== undefined && output.LineNumber !== null ? output.LineNumber : undefined,
-    NodeType: output.NodeType !== undefined && output.NodeType !== null ? output.NodeType : undefined,
+    Id: __expectString(output.Id),
+    LineNumber: __expectNumber(output.LineNumber),
+    NodeType: __expectString(output.NodeType),
   } as any;
 };
 
 const deserializeAws_json1_1CodeGenNodeArg = (output: any, context: __SerdeContext): CodeGenNodeArg => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Param: output.Param !== undefined && output.Param !== null ? output.Param : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Name: __expectString(output.Name),
+    Param: __expectBoolean(output.Param),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -20010,19 +20001,19 @@ const deserializeAws_json1_1CodeGenNodeArgs = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_1Column = (output: any, context: __SerdeContext): Column => {
   return {
-    Comment: output.Comment !== undefined && output.Comment !== null ? output.Comment : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Comment: __expectString(output.Comment),
+    Name: __expectString(output.Name),
     Parameters:
       output.Parameters !== undefined && output.Parameters !== null
         ? deserializeAws_json1_1ParametersMap(output.Parameters, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
 const deserializeAws_json1_1ColumnError = (output: any, context: __SerdeContext): ColumnError => {
   return {
-    ColumnName: output.ColumnName !== undefined && output.ColumnName !== null ? output.ColumnName : undefined,
+    ColumnName: __expectString(output.ColumnName),
     Error:
       output.Error !== undefined && output.Error !== null
         ? deserializeAws_json1_1ErrorDetail(output.Error, context)
@@ -20043,8 +20034,8 @@ const deserializeAws_json1_1ColumnErrors = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_1ColumnImportance = (output: any, context: __SerdeContext): ColumnImportance => {
   return {
-    ColumnName: output.ColumnName !== undefined && output.ColumnName !== null ? output.ColumnName : undefined,
-    Importance: output.Importance !== undefined && output.Importance !== null ? output.Importance : undefined,
+    ColumnName: __expectString(output.ColumnName),
+    Importance: __expectNumber(output.Importance),
   } as any;
 };
 
@@ -20076,8 +20067,8 @@ const deserializeAws_json1_1ColumnStatistics = (output: any, context: __SerdeCon
       output.AnalyzedTime !== undefined && output.AnalyzedTime !== null
         ? new Date(Math.round(output.AnalyzedTime * 1000))
         : undefined,
-    ColumnName: output.ColumnName !== undefined && output.ColumnName !== null ? output.ColumnName : undefined,
-    ColumnType: output.ColumnType !== undefined && output.ColumnType !== null ? output.ColumnType : undefined,
+    ColumnName: __expectString(output.ColumnName),
+    ColumnType: __expectString(output.ColumnType),
     StatisticsData:
       output.StatisticsData !== undefined && output.StatisticsData !== null
         ? deserializeAws_json1_1ColumnStatisticsData(output.StatisticsData, context)
@@ -20115,7 +20106,7 @@ const deserializeAws_json1_1ColumnStatisticsData = (output: any, context: __Serd
       output.StringColumnStatisticsData !== undefined && output.StringColumnStatisticsData !== null
         ? deserializeAws_json1_1StringColumnStatisticsData(output.StringColumnStatisticsData, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -20164,7 +20155,7 @@ const deserializeAws_json1_1ColumnValueStringList = (output: any, context: __Ser
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -20173,7 +20164,7 @@ const deserializeAws_json1_1ConcurrentModificationException = (
   context: __SerdeContext
 ): ConcurrentModificationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -20182,18 +20173,17 @@ const deserializeAws_json1_1ConcurrentRunsExceededException = (
   context: __SerdeContext
 ): ConcurrentRunsExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1Condition = (output: any, context: __SerdeContext): Condition => {
   return {
-    CrawlState: output.CrawlState !== undefined && output.CrawlState !== null ? output.CrawlState : undefined,
-    CrawlerName: output.CrawlerName !== undefined && output.CrawlerName !== null ? output.CrawlerName : undefined,
-    JobName: output.JobName !== undefined && output.JobName !== null ? output.JobName : undefined,
-    LogicalOperator:
-      output.LogicalOperator !== undefined && output.LogicalOperator !== null ? output.LogicalOperator : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    CrawlState: __expectString(output.CrawlState),
+    CrawlerName: __expectString(output.CrawlerName),
+    JobName: __expectString(output.JobName),
+    LogicalOperator: __expectString(output.LogicalOperator),
+    State: __expectString(output.State),
   } as any;
 };
 
@@ -20202,7 +20192,7 @@ const deserializeAws_json1_1ConditionCheckFailureException = (
   context: __SerdeContext
 ): ConditionCheckFailureException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -20219,24 +20209,16 @@ const deserializeAws_json1_1ConditionList = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1ConflictException = (output: any, context: __SerdeContext): ConflictException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1ConfusionMatrix = (output: any, context: __SerdeContext): ConfusionMatrix => {
   return {
-    NumFalseNegatives:
-      output.NumFalseNegatives !== undefined && output.NumFalseNegatives !== null
-        ? output.NumFalseNegatives
-        : undefined,
-    NumFalsePositives:
-      output.NumFalsePositives !== undefined && output.NumFalsePositives !== null
-        ? output.NumFalsePositives
-        : undefined,
-    NumTrueNegatives:
-      output.NumTrueNegatives !== undefined && output.NumTrueNegatives !== null ? output.NumTrueNegatives : undefined,
-    NumTruePositives:
-      output.NumTruePositives !== undefined && output.NumTruePositives !== null ? output.NumTruePositives : undefined,
+    NumFalseNegatives: __expectNumber(output.NumFalseNegatives),
+    NumFalsePositives: __expectNumber(output.NumFalsePositives),
+    NumTrueNegatives: __expectNumber(output.NumTrueNegatives),
+    NumTruePositives: __expectNumber(output.NumTruePositives),
   } as any;
 };
 
@@ -20246,15 +20228,13 @@ const deserializeAws_json1_1Connection = (output: any, context: __SerdeContext):
       output.ConnectionProperties !== undefined && output.ConnectionProperties !== null
         ? deserializeAws_json1_1ConnectionProperties(output.ConnectionProperties, context)
         : undefined,
-    ConnectionType:
-      output.ConnectionType !== undefined && output.ConnectionType !== null ? output.ConnectionType : undefined,
+    ConnectionType: __expectString(output.ConnectionType),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    LastUpdatedBy:
-      output.LastUpdatedBy !== undefined && output.LastUpdatedBy !== null ? output.LastUpdatedBy : undefined,
+    Description: __expectString(output.Description),
+    LastUpdatedBy: __expectString(output.LastUpdatedBy),
     LastUpdatedTime:
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
         ? new Date(Math.round(output.LastUpdatedTime * 1000))
@@ -20263,7 +20243,7 @@ const deserializeAws_json1_1Connection = (output: any, context: __SerdeContext):
       output.MatchCriteria !== undefined && output.MatchCriteria !== null
         ? deserializeAws_json1_1MatchCriteria(output.MatchCriteria, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     PhysicalConnectionRequirements:
       output.PhysicalConnectionRequirements !== undefined && output.PhysicalConnectionRequirements !== null
         ? deserializeAws_json1_1PhysicalConnectionRequirements(output.PhysicalConnectionRequirements, context)
@@ -20287,11 +20267,8 @@ const deserializeAws_json1_1ConnectionPasswordEncryption = (
   context: __SerdeContext
 ): ConnectionPasswordEncryption => {
   return {
-    AwsKmsKeyId: output.AwsKmsKeyId !== undefined && output.AwsKmsKeyId !== null ? output.AwsKmsKeyId : undefined,
-    ReturnConnectionPasswordEncrypted:
-      output.ReturnConnectionPasswordEncrypted !== undefined && output.ReturnConnectionPasswordEncrypted !== null
-        ? output.ReturnConnectionPasswordEncrypted
-        : undefined,
+    AwsKmsKeyId: __expectString(output.AwsKmsKeyId),
+    ReturnConnectionPasswordEncrypted: __expectBoolean(output.ReturnConnectionPasswordEncrypted),
   } as any;
 };
 
@@ -20306,7 +20283,7 @@ const deserializeAws_json1_1ConnectionProperties = (
       }
       return {
         ...acc,
-        [key]: value,
+        [key]: __expectString(value) as any,
       };
     },
     {}
@@ -20328,14 +20305,14 @@ const deserializeAws_json1_1Crawl = (output: any, context: __SerdeContext): Craw
       output.CompletedOn !== undefined && output.CompletedOn !== null
         ? new Date(Math.round(output.CompletedOn * 1000))
         : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    LogGroup: output.LogGroup !== undefined && output.LogGroup !== null ? output.LogGroup : undefined,
-    LogStream: output.LogStream !== undefined && output.LogStream !== null ? output.LogStream : undefined,
+    ErrorMessage: __expectString(output.ErrorMessage),
+    LogGroup: __expectString(output.LogGroup),
+    LogStream: __expectString(output.LogStream),
     StartedOn:
       output.StartedOn !== undefined && output.StartedOn !== null
         ? new Date(Math.round(output.StartedOn * 1000))
         : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    State: __expectString(output.State),
   } as any;
 };
 
@@ -20345,20 +20322,15 @@ const deserializeAws_json1_1Crawler = (output: any, context: __SerdeContext): Cr
       output.Classifiers !== undefined && output.Classifiers !== null
         ? deserializeAws_json1_1ClassifierNameList(output.Classifiers, context)
         : undefined,
-    Configuration:
-      output.Configuration !== undefined && output.Configuration !== null ? output.Configuration : undefined,
-    CrawlElapsedTime:
-      output.CrawlElapsedTime !== undefined && output.CrawlElapsedTime !== null ? output.CrawlElapsedTime : undefined,
-    CrawlerSecurityConfiguration:
-      output.CrawlerSecurityConfiguration !== undefined && output.CrawlerSecurityConfiguration !== null
-        ? output.CrawlerSecurityConfiguration
-        : undefined,
+    Configuration: __expectString(output.Configuration),
+    CrawlElapsedTime: __expectNumber(output.CrawlElapsedTime),
+    CrawlerSecurityConfiguration: __expectString(output.CrawlerSecurityConfiguration),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    DatabaseName: output.DatabaseName !== undefined && output.DatabaseName !== null ? output.DatabaseName : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    DatabaseName: __expectString(output.DatabaseName),
+    Description: __expectString(output.Description),
     LastCrawl:
       output.LastCrawl !== undefined && output.LastCrawl !== null
         ? deserializeAws_json1_1LastCrawlInfo(output.LastCrawl, context)
@@ -20371,12 +20343,12 @@ const deserializeAws_json1_1Crawler = (output: any, context: __SerdeContext): Cr
       output.LineageConfiguration !== undefined && output.LineageConfiguration !== null
         ? deserializeAws_json1_1LineageConfiguration(output.LineageConfiguration, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     RecrawlPolicy:
       output.RecrawlPolicy !== undefined && output.RecrawlPolicy !== null
         ? deserializeAws_json1_1RecrawlPolicy(output.RecrawlPolicy, context)
         : undefined,
-    Role: output.Role !== undefined && output.Role !== null ? output.Role : undefined,
+    Role: __expectString(output.Role),
     Schedule:
       output.Schedule !== undefined && output.Schedule !== null
         ? deserializeAws_json1_1Schedule(output.Schedule, context)
@@ -20385,13 +20357,13 @@ const deserializeAws_json1_1Crawler = (output: any, context: __SerdeContext): Cr
       output.SchemaChangePolicy !== undefined && output.SchemaChangePolicy !== null
         ? deserializeAws_json1_1SchemaChangePolicy(output.SchemaChangePolicy, context)
         : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    TablePrefix: output.TablePrefix !== undefined && output.TablePrefix !== null ? output.TablePrefix : undefined,
+    State: __expectString(output.State),
+    TablePrefix: __expectString(output.TablePrefix),
     Targets:
       output.Targets !== undefined && output.Targets !== null
         ? deserializeAws_json1_1CrawlerTargets(output.Targets, context)
         : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    Version: __expectNumber(output.Version),
   } as any;
 };
 
@@ -20408,25 +20380,14 @@ const deserializeAws_json1_1CrawlerList = (output: any, context: __SerdeContext)
 
 const deserializeAws_json1_1CrawlerMetrics = (output: any, context: __SerdeContext): CrawlerMetrics => {
   return {
-    CrawlerName: output.CrawlerName !== undefined && output.CrawlerName !== null ? output.CrawlerName : undefined,
-    LastRuntimeSeconds:
-      output.LastRuntimeSeconds !== undefined && output.LastRuntimeSeconds !== null
-        ? output.LastRuntimeSeconds
-        : undefined,
-    MedianRuntimeSeconds:
-      output.MedianRuntimeSeconds !== undefined && output.MedianRuntimeSeconds !== null
-        ? output.MedianRuntimeSeconds
-        : undefined,
-    StillEstimating:
-      output.StillEstimating !== undefined && output.StillEstimating !== null ? output.StillEstimating : undefined,
-    TablesCreated:
-      output.TablesCreated !== undefined && output.TablesCreated !== null ? output.TablesCreated : undefined,
-    TablesDeleted:
-      output.TablesDeleted !== undefined && output.TablesDeleted !== null ? output.TablesDeleted : undefined,
-    TablesUpdated:
-      output.TablesUpdated !== undefined && output.TablesUpdated !== null ? output.TablesUpdated : undefined,
-    TimeLeftSeconds:
-      output.TimeLeftSeconds !== undefined && output.TimeLeftSeconds !== null ? output.TimeLeftSeconds : undefined,
+    CrawlerName: __expectString(output.CrawlerName),
+    LastRuntimeSeconds: __expectNumber(output.LastRuntimeSeconds),
+    MedianRuntimeSeconds: __expectNumber(output.MedianRuntimeSeconds),
+    StillEstimating: __expectBoolean(output.StillEstimating),
+    TablesCreated: __expectNumber(output.TablesCreated),
+    TablesDeleted: __expectNumber(output.TablesDeleted),
+    TablesUpdated: __expectNumber(output.TablesUpdated),
+    TimeLeftSeconds: __expectNumber(output.TimeLeftSeconds),
   } as any;
 };
 
@@ -20448,7 +20409,7 @@ const deserializeAws_json1_1CrawlerNameList = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -20466,7 +20427,7 @@ const deserializeAws_json1_1CrawlerNotRunningException = (
   context: __SerdeContext
 ): CrawlerNotRunningException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -20475,7 +20436,7 @@ const deserializeAws_json1_1CrawlerRunningException = (
   context: __SerdeContext
 ): CrawlerRunningException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -20484,7 +20445,7 @@ const deserializeAws_json1_1CrawlerStoppingException = (
   context: __SerdeContext
 ): CrawlerStoppingException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -20555,53 +20516,36 @@ const deserializeAws_json1_1CreateDevEndpointResponse = (
       output.Arguments !== undefined && output.Arguments !== null
         ? deserializeAws_json1_1MapValue(output.Arguments, context)
         : undefined,
-    AvailabilityZone:
-      output.AvailabilityZone !== undefined && output.AvailabilityZone !== null ? output.AvailabilityZone : undefined,
+    AvailabilityZone: __expectString(output.AvailabilityZone),
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
         ? new Date(Math.round(output.CreatedTimestamp * 1000))
         : undefined,
-    EndpointName: output.EndpointName !== undefined && output.EndpointName !== null ? output.EndpointName : undefined,
-    ExtraJarsS3Path:
-      output.ExtraJarsS3Path !== undefined && output.ExtraJarsS3Path !== null ? output.ExtraJarsS3Path : undefined,
-    ExtraPythonLibsS3Path:
-      output.ExtraPythonLibsS3Path !== undefined && output.ExtraPythonLibsS3Path !== null
-        ? output.ExtraPythonLibsS3Path
-        : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
-    GlueVersion: output.GlueVersion !== undefined && output.GlueVersion !== null ? output.GlueVersion : undefined,
-    NumberOfNodes:
-      output.NumberOfNodes !== undefined && output.NumberOfNodes !== null ? output.NumberOfNodes : undefined,
-    NumberOfWorkers:
-      output.NumberOfWorkers !== undefined && output.NumberOfWorkers !== null ? output.NumberOfWorkers : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
-    SecurityConfiguration:
-      output.SecurityConfiguration !== undefined && output.SecurityConfiguration !== null
-        ? output.SecurityConfiguration
-        : undefined,
+    EndpointName: __expectString(output.EndpointName),
+    ExtraJarsS3Path: __expectString(output.ExtraJarsS3Path),
+    ExtraPythonLibsS3Path: __expectString(output.ExtraPythonLibsS3Path),
+    FailureReason: __expectString(output.FailureReason),
+    GlueVersion: __expectString(output.GlueVersion),
+    NumberOfNodes: __expectNumber(output.NumberOfNodes),
+    NumberOfWorkers: __expectNumber(output.NumberOfWorkers),
+    RoleArn: __expectString(output.RoleArn),
+    SecurityConfiguration: __expectString(output.SecurityConfiguration),
     SecurityGroupIds:
       output.SecurityGroupIds !== undefined && output.SecurityGroupIds !== null
         ? deserializeAws_json1_1StringList(output.SecurityGroupIds, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    SubnetId: output.SubnetId !== undefined && output.SubnetId !== null ? output.SubnetId : undefined,
-    VpcId: output.VpcId !== undefined && output.VpcId !== null ? output.VpcId : undefined,
-    WorkerType: output.WorkerType !== undefined && output.WorkerType !== null ? output.WorkerType : undefined,
-    YarnEndpointAddress:
-      output.YarnEndpointAddress !== undefined && output.YarnEndpointAddress !== null
-        ? output.YarnEndpointAddress
-        : undefined,
-    ZeppelinRemoteSparkInterpreterPort:
-      output.ZeppelinRemoteSparkInterpreterPort !== undefined && output.ZeppelinRemoteSparkInterpreterPort !== null
-        ? output.ZeppelinRemoteSparkInterpreterPort
-        : undefined,
+    Status: __expectString(output.Status),
+    SubnetId: __expectString(output.SubnetId),
+    VpcId: __expectString(output.VpcId),
+    WorkerType: __expectString(output.WorkerType),
+    YarnEndpointAddress: __expectString(output.YarnEndpointAddress),
+    ZeppelinRemoteSparkInterpreterPort: __expectNumber(output.ZeppelinRemoteSparkInterpreterPort),
   } as any;
 };
 
 const deserializeAws_json1_1CreateJobResponse = (output: any, context: __SerdeContext): CreateJobResponse => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -20610,7 +20554,7 @@ const deserializeAws_json1_1CreateMLTransformResponse = (
   context: __SerdeContext
 ): CreateMLTransformResponse => {
   return {
-    TransformId: output.TransformId !== undefined && output.TransformId !== null ? output.TransformId : undefined,
+    TransformId: __expectString(output.TransformId),
   } as any;
 };
 
@@ -20630,9 +20574,9 @@ const deserializeAws_json1_1CreatePartitionResponse = (
 
 const deserializeAws_json1_1CreateRegistryResponse = (output: any, context: __SerdeContext): CreateRegistryResponse => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    RegistryArn: output.RegistryArn !== undefined && output.RegistryArn !== null ? output.RegistryArn : undefined,
-    RegistryName: output.RegistryName !== undefined && output.RegistryName !== null ? output.RegistryName : undefined,
+    Description: __expectString(output.Description),
+    RegistryArn: __expectString(output.RegistryArn),
+    RegistryName: __expectString(output.RegistryName),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_1TagsMap(output.Tags, context)
@@ -20642,31 +20586,19 @@ const deserializeAws_json1_1CreateRegistryResponse = (output: any, context: __Se
 
 const deserializeAws_json1_1CreateSchemaResponse = (output: any, context: __SerdeContext): CreateSchemaResponse => {
   return {
-    Compatibility:
-      output.Compatibility !== undefined && output.Compatibility !== null ? output.Compatibility : undefined,
-    DataFormat: output.DataFormat !== undefined && output.DataFormat !== null ? output.DataFormat : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    LatestSchemaVersion:
-      output.LatestSchemaVersion !== undefined && output.LatestSchemaVersion !== null
-        ? output.LatestSchemaVersion
-        : undefined,
-    NextSchemaVersion:
-      output.NextSchemaVersion !== undefined && output.NextSchemaVersion !== null
-        ? output.NextSchemaVersion
-        : undefined,
-    RegistryArn: output.RegistryArn !== undefined && output.RegistryArn !== null ? output.RegistryArn : undefined,
-    RegistryName: output.RegistryName !== undefined && output.RegistryName !== null ? output.RegistryName : undefined,
-    SchemaArn: output.SchemaArn !== undefined && output.SchemaArn !== null ? output.SchemaArn : undefined,
-    SchemaCheckpoint:
-      output.SchemaCheckpoint !== undefined && output.SchemaCheckpoint !== null ? output.SchemaCheckpoint : undefined,
-    SchemaName: output.SchemaName !== undefined && output.SchemaName !== null ? output.SchemaName : undefined,
-    SchemaStatus: output.SchemaStatus !== undefined && output.SchemaStatus !== null ? output.SchemaStatus : undefined,
-    SchemaVersionId:
-      output.SchemaVersionId !== undefined && output.SchemaVersionId !== null ? output.SchemaVersionId : undefined,
-    SchemaVersionStatus:
-      output.SchemaVersionStatus !== undefined && output.SchemaVersionStatus !== null
-        ? output.SchemaVersionStatus
-        : undefined,
+    Compatibility: __expectString(output.Compatibility),
+    DataFormat: __expectString(output.DataFormat),
+    Description: __expectString(output.Description),
+    LatestSchemaVersion: __expectNumber(output.LatestSchemaVersion),
+    NextSchemaVersion: __expectNumber(output.NextSchemaVersion),
+    RegistryArn: __expectString(output.RegistryArn),
+    RegistryName: __expectString(output.RegistryName),
+    SchemaArn: __expectString(output.SchemaArn),
+    SchemaCheckpoint: __expectNumber(output.SchemaCheckpoint),
+    SchemaName: __expectString(output.SchemaName),
+    SchemaStatus: __expectString(output.SchemaStatus),
+    SchemaVersionId: __expectString(output.SchemaVersionId),
+    SchemaVersionStatus: __expectString(output.SchemaVersionStatus),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_1TagsMap(output.Tags, context)
@@ -20676,8 +20608,8 @@ const deserializeAws_json1_1CreateSchemaResponse = (output: any, context: __Serd
 
 const deserializeAws_json1_1CreateScriptResponse = (output: any, context: __SerdeContext): CreateScriptResponse => {
   return {
-    PythonScript: output.PythonScript !== undefined && output.PythonScript !== null ? output.PythonScript : undefined,
-    ScalaCode: output.ScalaCode !== undefined && output.ScalaCode !== null ? output.ScalaCode : undefined,
+    PythonScript: __expectString(output.PythonScript),
+    ScalaCode: __expectString(output.ScalaCode),
   } as any;
 };
 
@@ -20690,7 +20622,7 @@ const deserializeAws_json1_1CreateSecurityConfigurationResponse = (
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
         ? new Date(Math.round(output.CreatedTimestamp * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -20700,7 +20632,7 @@ const deserializeAws_json1_1CreateTableResponse = (output: any, context: __Serde
 
 const deserializeAws_json1_1CreateTriggerResponse = (output: any, context: __SerdeContext): CreateTriggerResponse => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -20713,27 +20645,20 @@ const deserializeAws_json1_1CreateUserDefinedFunctionResponse = (
 
 const deserializeAws_json1_1CreateWorkflowResponse = (output: any, context: __SerdeContext): CreateWorkflowResponse => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
 const deserializeAws_json1_1CsvClassifier = (output: any, context: __SerdeContext): CsvClassifier => {
   return {
-    AllowSingleColumn:
-      output.AllowSingleColumn !== undefined && output.AllowSingleColumn !== null
-        ? output.AllowSingleColumn
-        : undefined,
-    ContainsHeader:
-      output.ContainsHeader !== undefined && output.ContainsHeader !== null ? output.ContainsHeader : undefined,
+    AllowSingleColumn: __expectBoolean(output.AllowSingleColumn),
+    ContainsHeader: __expectString(output.ContainsHeader),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    Delimiter: output.Delimiter !== undefined && output.Delimiter !== null ? output.Delimiter : undefined,
-    DisableValueTrimming:
-      output.DisableValueTrimming !== undefined && output.DisableValueTrimming !== null
-        ? output.DisableValueTrimming
-        : undefined,
+    Delimiter: __expectString(output.Delimiter),
+    DisableValueTrimming: __expectBoolean(output.DisableValueTrimming),
     Header:
       output.Header !== undefined && output.Header !== null
         ? deserializeAws_json1_1CsvHeader(output.Header, context)
@@ -20742,9 +20667,9 @@ const deserializeAws_json1_1CsvClassifier = (output: any, context: __SerdeContex
       output.LastUpdated !== undefined && output.LastUpdated !== null
         ? new Date(Math.round(output.LastUpdated * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    QuoteSymbol: output.QuoteSymbol !== undefined && output.QuoteSymbol !== null ? output.QuoteSymbol : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    Name: __expectString(output.Name),
+    QuoteSymbol: __expectString(output.QuoteSymbol),
+    Version: __expectNumber(output.Version),
   } as any;
 };
 
@@ -20755,7 +20680,7 @@ const deserializeAws_json1_1CsvHeader = (output: any, context: __SerdeContext): 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -20783,7 +20708,7 @@ const deserializeAws_json1_1DagNodes = (output: any, context: __SerdeContext): C
 
 const deserializeAws_json1_1Database = (output: any, context: __SerdeContext): Database => {
   return {
-    CatalogId: output.CatalogId !== undefined && output.CatalogId !== null ? output.CatalogId : undefined,
+    CatalogId: __expectString(output.CatalogId),
     CreateTableDefaultPermissions:
       output.CreateTableDefaultPermissions !== undefined && output.CreateTableDefaultPermissions !== null
         ? deserializeAws_json1_1PrincipalPermissionsList(output.CreateTableDefaultPermissions, context)
@@ -20792,9 +20717,9 @@ const deserializeAws_json1_1Database = (output: any, context: __SerdeContext): D
       output.CreateTime !== undefined && output.CreateTime !== null
         ? new Date(Math.round(output.CreateTime * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    LocationUri: output.LocationUri !== undefined && output.LocationUri !== null ? output.LocationUri : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Description: __expectString(output.Description),
+    LocationUri: __expectString(output.LocationUri),
+    Name: __expectString(output.Name),
     Parameters:
       output.Parameters !== undefined && output.Parameters !== null
         ? deserializeAws_json1_1ParametersMap(output.Parameters, context)
@@ -20808,8 +20733,8 @@ const deserializeAws_json1_1Database = (output: any, context: __SerdeContext): D
 
 const deserializeAws_json1_1DatabaseIdentifier = (output: any, context: __SerdeContext): DatabaseIdentifier => {
   return {
-    CatalogId: output.CatalogId !== undefined && output.CatalogId !== null ? output.CatalogId : undefined,
-    DatabaseName: output.DatabaseName !== undefined && output.DatabaseName !== null ? output.DatabaseName : undefined,
+    CatalogId: __expectString(output.CatalogId),
+    DatabaseName: __expectString(output.DatabaseName),
   } as any;
 };
 
@@ -20842,10 +20767,7 @@ const deserializeAws_json1_1DataCatalogEncryptionSettings = (
 
 const deserializeAws_json1_1DataLakePrincipal = (output: any, context: __SerdeContext): DataLakePrincipal => {
   return {
-    DataLakePrincipalIdentifier:
-      output.DataLakePrincipalIdentifier !== undefined && output.DataLakePrincipalIdentifier !== null
-        ? output.DataLakePrincipalIdentifier
-        : undefined,
+    DataLakePrincipalIdentifier: __expectString(output.DataLakePrincipalIdentifier),
   } as any;
 };
 
@@ -20862,12 +20784,8 @@ const deserializeAws_json1_1DateColumnStatisticsData = (
       output.MinimumValue !== undefined && output.MinimumValue !== null
         ? new Date(Math.round(output.MinimumValue * 1000))
         : undefined,
-    NumberOfDistinctValues:
-      output.NumberOfDistinctValues !== undefined && output.NumberOfDistinctValues !== null
-        ? output.NumberOfDistinctValues
-        : undefined,
-    NumberOfNulls:
-      output.NumberOfNulls !== undefined && output.NumberOfNulls !== null ? output.NumberOfNulls : undefined,
+    NumberOfDistinctValues: __expectNumber(output.NumberOfDistinctValues),
+    NumberOfNulls: __expectNumber(output.NumberOfNulls),
   } as any;
 };
 
@@ -20884,18 +20802,14 @@ const deserializeAws_json1_1DecimalColumnStatisticsData = (
       output.MinimumValue !== undefined && output.MinimumValue !== null
         ? deserializeAws_json1_1DecimalNumber(output.MinimumValue, context)
         : undefined,
-    NumberOfDistinctValues:
-      output.NumberOfDistinctValues !== undefined && output.NumberOfDistinctValues !== null
-        ? output.NumberOfDistinctValues
-        : undefined,
-    NumberOfNulls:
-      output.NumberOfNulls !== undefined && output.NumberOfNulls !== null ? output.NumberOfNulls : undefined,
+    NumberOfDistinctValues: __expectNumber(output.NumberOfDistinctValues),
+    NumberOfNulls: __expectNumber(output.NumberOfNulls),
   } as any;
 };
 
 const deserializeAws_json1_1DecimalNumber = (output: any, context: __SerdeContext): DecimalNumber => {
   return {
-    Scale: output.Scale !== undefined && output.Scale !== null ? output.Scale : undefined,
+    Scale: __expectNumber(output.Scale),
     UnscaledValue:
       output.UnscaledValue !== undefined && output.UnscaledValue !== null
         ? context.base64Decoder(output.UnscaledValue)
@@ -20948,7 +20862,7 @@ const deserializeAws_json1_1DeleteDevEndpointResponse = (
 
 const deserializeAws_json1_1DeleteJobResponse = (output: any, context: __SerdeContext): DeleteJobResponse => {
   return {
-    JobName: output.JobName !== undefined && output.JobName !== null ? output.JobName : undefined,
+    JobName: __expectString(output.JobName),
   } as any;
 };
 
@@ -20957,7 +20871,7 @@ const deserializeAws_json1_1DeleteMLTransformResponse = (
   context: __SerdeContext
 ): DeleteMLTransformResponse => {
   return {
-    TransformId: output.TransformId !== undefined && output.TransformId !== null ? output.TransformId : undefined,
+    TransformId: __expectString(output.TransformId),
   } as any;
 };
 
@@ -20977,9 +20891,9 @@ const deserializeAws_json1_1DeletePartitionResponse = (
 
 const deserializeAws_json1_1DeleteRegistryResponse = (output: any, context: __SerdeContext): DeleteRegistryResponse => {
   return {
-    RegistryArn: output.RegistryArn !== undefined && output.RegistryArn !== null ? output.RegistryArn : undefined,
-    RegistryName: output.RegistryName !== undefined && output.RegistryName !== null ? output.RegistryName : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    RegistryArn: __expectString(output.RegistryArn),
+    RegistryName: __expectString(output.RegistryName),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -20992,9 +20906,9 @@ const deserializeAws_json1_1DeleteResourcePolicyResponse = (
 
 const deserializeAws_json1_1DeleteSchemaResponse = (output: any, context: __SerdeContext): DeleteSchemaResponse => {
   return {
-    SchemaArn: output.SchemaArn !== undefined && output.SchemaArn !== null ? output.SchemaArn : undefined,
-    SchemaName: output.SchemaName !== undefined && output.SchemaName !== null ? output.SchemaName : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    SchemaArn: __expectString(output.SchemaArn),
+    SchemaName: __expectString(output.SchemaName),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -21030,7 +20944,7 @@ const deserializeAws_json1_1DeleteTableVersionResponse = (
 
 const deserializeAws_json1_1DeleteTriggerResponse = (output: any, context: __SerdeContext): DeleteTriggerResponse => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -21043,7 +20957,7 @@ const deserializeAws_json1_1DeleteUserDefinedFunctionResponse = (
 
 const deserializeAws_json1_1DeleteWorkflowResponse = (output: any, context: __SerdeContext): DeleteWorkflowResponse => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -21053,62 +20967,42 @@ const deserializeAws_json1_1DevEndpoint = (output: any, context: __SerdeContext)
       output.Arguments !== undefined && output.Arguments !== null
         ? deserializeAws_json1_1MapValue(output.Arguments, context)
         : undefined,
-    AvailabilityZone:
-      output.AvailabilityZone !== undefined && output.AvailabilityZone !== null ? output.AvailabilityZone : undefined,
+    AvailabilityZone: __expectString(output.AvailabilityZone),
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
         ? new Date(Math.round(output.CreatedTimestamp * 1000))
         : undefined,
-    EndpointName: output.EndpointName !== undefined && output.EndpointName !== null ? output.EndpointName : undefined,
-    ExtraJarsS3Path:
-      output.ExtraJarsS3Path !== undefined && output.ExtraJarsS3Path !== null ? output.ExtraJarsS3Path : undefined,
-    ExtraPythonLibsS3Path:
-      output.ExtraPythonLibsS3Path !== undefined && output.ExtraPythonLibsS3Path !== null
-        ? output.ExtraPythonLibsS3Path
-        : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
-    GlueVersion: output.GlueVersion !== undefined && output.GlueVersion !== null ? output.GlueVersion : undefined,
+    EndpointName: __expectString(output.EndpointName),
+    ExtraJarsS3Path: __expectString(output.ExtraJarsS3Path),
+    ExtraPythonLibsS3Path: __expectString(output.ExtraPythonLibsS3Path),
+    FailureReason: __expectString(output.FailureReason),
+    GlueVersion: __expectString(output.GlueVersion),
     LastModifiedTimestamp:
       output.LastModifiedTimestamp !== undefined && output.LastModifiedTimestamp !== null
         ? new Date(Math.round(output.LastModifiedTimestamp * 1000))
         : undefined,
-    LastUpdateStatus:
-      output.LastUpdateStatus !== undefined && output.LastUpdateStatus !== null ? output.LastUpdateStatus : undefined,
-    NumberOfNodes:
-      output.NumberOfNodes !== undefined && output.NumberOfNodes !== null ? output.NumberOfNodes : undefined,
-    NumberOfWorkers:
-      output.NumberOfWorkers !== undefined && output.NumberOfWorkers !== null ? output.NumberOfWorkers : undefined,
-    PrivateAddress:
-      output.PrivateAddress !== undefined && output.PrivateAddress !== null ? output.PrivateAddress : undefined,
-    PublicAddress:
-      output.PublicAddress !== undefined && output.PublicAddress !== null ? output.PublicAddress : undefined,
-    PublicKey: output.PublicKey !== undefined && output.PublicKey !== null ? output.PublicKey : undefined,
+    LastUpdateStatus: __expectString(output.LastUpdateStatus),
+    NumberOfNodes: __expectNumber(output.NumberOfNodes),
+    NumberOfWorkers: __expectNumber(output.NumberOfWorkers),
+    PrivateAddress: __expectString(output.PrivateAddress),
+    PublicAddress: __expectString(output.PublicAddress),
+    PublicKey: __expectString(output.PublicKey),
     PublicKeys:
       output.PublicKeys !== undefined && output.PublicKeys !== null
         ? deserializeAws_json1_1PublicKeysList(output.PublicKeys, context)
         : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
-    SecurityConfiguration:
-      output.SecurityConfiguration !== undefined && output.SecurityConfiguration !== null
-        ? output.SecurityConfiguration
-        : undefined,
+    RoleArn: __expectString(output.RoleArn),
+    SecurityConfiguration: __expectString(output.SecurityConfiguration),
     SecurityGroupIds:
       output.SecurityGroupIds !== undefined && output.SecurityGroupIds !== null
         ? deserializeAws_json1_1StringList(output.SecurityGroupIds, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    SubnetId: output.SubnetId !== undefined && output.SubnetId !== null ? output.SubnetId : undefined,
-    VpcId: output.VpcId !== undefined && output.VpcId !== null ? output.VpcId : undefined,
-    WorkerType: output.WorkerType !== undefined && output.WorkerType !== null ? output.WorkerType : undefined,
-    YarnEndpointAddress:
-      output.YarnEndpointAddress !== undefined && output.YarnEndpointAddress !== null
-        ? output.YarnEndpointAddress
-        : undefined,
-    ZeppelinRemoteSparkInterpreterPort:
-      output.ZeppelinRemoteSparkInterpreterPort !== undefined && output.ZeppelinRemoteSparkInterpreterPort !== null
-        ? output.ZeppelinRemoteSparkInterpreterPort
-        : undefined,
+    Status: __expectString(output.Status),
+    SubnetId: __expectString(output.SubnetId),
+    VpcId: __expectString(output.VpcId),
+    WorkerType: __expectString(output.WorkerType),
+    YarnEndpointAddress: __expectString(output.YarnEndpointAddress),
+    ZeppelinRemoteSparkInterpreterPort: __expectNumber(output.ZeppelinRemoteSparkInterpreterPort),
   } as any;
 };
 
@@ -21130,7 +21024,7 @@ const deserializeAws_json1_1DevEndpointNameList = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -21141,7 +21035,7 @@ const deserializeAws_json1_1DevEndpointNames = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -21150,22 +21044,18 @@ const deserializeAws_json1_1DoubleColumnStatisticsData = (
   context: __SerdeContext
 ): DoubleColumnStatisticsData => {
   return {
-    MaximumValue: output.MaximumValue !== undefined && output.MaximumValue !== null ? output.MaximumValue : undefined,
-    MinimumValue: output.MinimumValue !== undefined && output.MinimumValue !== null ? output.MinimumValue : undefined,
-    NumberOfDistinctValues:
-      output.NumberOfDistinctValues !== undefined && output.NumberOfDistinctValues !== null
-        ? output.NumberOfDistinctValues
-        : undefined,
-    NumberOfNulls:
-      output.NumberOfNulls !== undefined && output.NumberOfNulls !== null ? output.NumberOfNulls : undefined,
+    MaximumValue: __expectNumber(output.MaximumValue),
+    MinimumValue: __expectNumber(output.MinimumValue),
+    NumberOfDistinctValues: __expectNumber(output.NumberOfDistinctValues),
+    NumberOfNulls: __expectNumber(output.NumberOfNulls),
   } as any;
 };
 
 const deserializeAws_json1_1DynamoDBTarget = (output: any, context: __SerdeContext): DynamoDBTarget => {
   return {
-    Path: output.Path !== undefined && output.Path !== null ? output.Path : undefined,
-    scanAll: output.scanAll !== undefined && output.scanAll !== null ? output.scanAll : undefined,
-    scanRate: output.scanRate !== undefined && output.scanRate !== null ? output.scanRate : undefined,
+    Path: __expectString(output.Path),
+    scanAll: __expectBoolean(output.scanAll),
+    scanRate: __expectNumber(output.scanRate),
   } as any;
 };
 
@@ -21182,9 +21072,8 @@ const deserializeAws_json1_1DynamoDBTargetList = (output: any, context: __SerdeC
 
 const deserializeAws_json1_1Edge = (output: any, context: __SerdeContext): Edge => {
   return {
-    DestinationId:
-      output.DestinationId !== undefined && output.DestinationId !== null ? output.DestinationId : undefined,
-    SourceId: output.SourceId !== undefined && output.SourceId !== null ? output.SourceId : undefined,
+    DestinationId: __expectString(output.DestinationId),
+    SourceId: __expectString(output.SourceId),
   } as any;
 };
 
@@ -21201,12 +21090,8 @@ const deserializeAws_json1_1EdgeList = (output: any, context: __SerdeContext): E
 
 const deserializeAws_json1_1EncryptionAtRest = (output: any, context: __SerdeContext): EncryptionAtRest => {
   return {
-    CatalogEncryptionMode:
-      output.CatalogEncryptionMode !== undefined && output.CatalogEncryptionMode !== null
-        ? output.CatalogEncryptionMode
-        : undefined,
-    SseAwsKmsKeyId:
-      output.SseAwsKmsKeyId !== undefined && output.SseAwsKmsKeyId !== null ? output.SseAwsKmsKeyId : undefined,
+    CatalogEncryptionMode: __expectString(output.CatalogEncryptionMode),
+    SseAwsKmsKeyId: __expectString(output.SseAwsKmsKeyId),
   } as any;
 };
 
@@ -21235,7 +21120,7 @@ const deserializeAws_json1_1EntityNotFoundException = (
   context: __SerdeContext
 ): EntityNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -21253,15 +21138,15 @@ const deserializeAws_json1_1ErrorByName = (output: any, context: __SerdeContext)
 
 const deserializeAws_json1_1ErrorDetail = (output: any, context: __SerdeContext): ErrorDetail => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
   } as any;
 };
 
 const deserializeAws_json1_1ErrorDetails = (output: any, context: __SerdeContext): ErrorDetails => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
   } as any;
 };
 
@@ -21271,17 +21156,13 @@ const deserializeAws_json1_1EvaluationMetrics = (output: any, context: __SerdeCo
       output.FindMatchesMetrics !== undefined && output.FindMatchesMetrics !== null
         ? deserializeAws_json1_1FindMatchesMetrics(output.FindMatchesMetrics, context)
         : undefined,
-    TransformType:
-      output.TransformType !== undefined && output.TransformType !== null ? output.TransformType : undefined,
+    TransformType: __expectString(output.TransformType),
   } as any;
 };
 
 const deserializeAws_json1_1ExecutionProperty = (output: any, context: __SerdeContext): ExecutionProperty => {
   return {
-    MaxConcurrentRuns:
-      output.MaxConcurrentRuns !== undefined && output.MaxConcurrentRuns !== null
-        ? output.MaxConcurrentRuns
-        : undefined,
+    MaxConcurrentRuns: __expectNumber(output.MaxConcurrentRuns),
   } as any;
 };
 
@@ -21290,14 +21171,13 @@ const deserializeAws_json1_1ExportLabelsTaskRunProperties = (
   context: __SerdeContext
 ): ExportLabelsTaskRunProperties => {
   return {
-    OutputS3Path: output.OutputS3Path !== undefined && output.OutputS3Path !== null ? output.OutputS3Path : undefined,
+    OutputS3Path: __expectString(output.OutputS3Path),
   } as any;
 };
 
 const deserializeAws_json1_1FindMatchesMetrics = (output: any, context: __SerdeContext): FindMatchesMetrics => {
   return {
-    AreaUnderPRCurve:
-      output.AreaUnderPRCurve !== undefined && output.AreaUnderPRCurve !== null ? output.AreaUnderPRCurve : undefined,
+    AreaUnderPRCurve: __expectNumber(output.AreaUnderPRCurve),
     ColumnImportances:
       output.ColumnImportances !== undefined && output.ColumnImportances !== null
         ? deserializeAws_json1_1ColumnImportanceList(output.ColumnImportances, context)
@@ -21306,30 +21186,18 @@ const deserializeAws_json1_1FindMatchesMetrics = (output: any, context: __SerdeC
       output.ConfusionMatrix !== undefined && output.ConfusionMatrix !== null
         ? deserializeAws_json1_1ConfusionMatrix(output.ConfusionMatrix, context)
         : undefined,
-    F1: output.F1 !== undefined && output.F1 !== null ? output.F1 : undefined,
-    Precision: output.Precision !== undefined && output.Precision !== null ? output.Precision : undefined,
-    Recall: output.Recall !== undefined && output.Recall !== null ? output.Recall : undefined,
+    F1: __expectNumber(output.F1),
+    Precision: __expectNumber(output.Precision),
+    Recall: __expectNumber(output.Recall),
   } as any;
 };
 
 const deserializeAws_json1_1FindMatchesParameters = (output: any, context: __SerdeContext): FindMatchesParameters => {
   return {
-    AccuracyCostTradeoff:
-      output.AccuracyCostTradeoff !== undefined && output.AccuracyCostTradeoff !== null
-        ? output.AccuracyCostTradeoff
-        : undefined,
-    EnforceProvidedLabels:
-      output.EnforceProvidedLabels !== undefined && output.EnforceProvidedLabels !== null
-        ? output.EnforceProvidedLabels
-        : undefined,
-    PrecisionRecallTradeoff:
-      output.PrecisionRecallTradeoff !== undefined && output.PrecisionRecallTradeoff !== null
-        ? output.PrecisionRecallTradeoff
-        : undefined,
-    PrimaryKeyColumnName:
-      output.PrimaryKeyColumnName !== undefined && output.PrimaryKeyColumnName !== null
-        ? output.PrimaryKeyColumnName
-        : undefined,
+    AccuracyCostTradeoff: __expectNumber(output.AccuracyCostTradeoff),
+    EnforceProvidedLabels: __expectBoolean(output.EnforceProvidedLabels),
+    PrecisionRecallTradeoff: __expectNumber(output.PrecisionRecallTradeoff),
+    PrimaryKeyColumnName: __expectString(output.PrimaryKeyColumnName),
   } as any;
 };
 
@@ -21338,9 +21206,9 @@ const deserializeAws_json1_1FindMatchesTaskRunProperties = (
   context: __SerdeContext
 ): FindMatchesTaskRunProperties => {
   return {
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
-    JobName: output.JobName !== undefined && output.JobName !== null ? output.JobName : undefined,
-    JobRunId: output.JobRunId !== undefined && output.JobRunId !== null ? output.JobRunId : undefined,
+    JobId: __expectString(output.JobId),
+    JobName: __expectString(output.JobName),
+    JobRunId: __expectString(output.JobRunId),
   } as any;
 };
 
@@ -21351,7 +21219,7 @@ const deserializeAws_json1_1GenericMap = (output: any, context: __SerdeContext):
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -21383,7 +21251,7 @@ const deserializeAws_json1_1GetClassifiersResponse = (output: any, context: __Se
       output.Classifiers !== undefined && output.Classifiers !== null
         ? deserializeAws_json1_1ClassifierList(output.Classifiers, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -21434,7 +21302,7 @@ const deserializeAws_json1_1GetConnectionsResponse = (output: any, context: __Se
       output.ConnectionList !== undefined && output.ConnectionList !== null
         ? deserializeAws_json1_1ConnectionList(output.ConnectionList, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -21447,7 +21315,7 @@ const deserializeAws_json1_1GetCrawlerMetricsResponse = (
       output.CrawlerMetricsList !== undefined && output.CrawlerMetricsList !== null
         ? deserializeAws_json1_1CrawlerMetricsList(output.CrawlerMetricsList, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -21466,7 +21334,7 @@ const deserializeAws_json1_1GetCrawlersResponse = (output: any, context: __Serde
       output.Crawlers !== undefined && output.Crawlers !== null
         ? deserializeAws_json1_1CrawlerList(output.Crawlers, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -21485,7 +21353,7 @@ const deserializeAws_json1_1GetDatabasesResponse = (output: any, context: __Serd
       output.DatabaseList !== undefined && output.DatabaseList !== null
         ? deserializeAws_json1_1DatabaseList(output.DatabaseList, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -21535,7 +21403,7 @@ const deserializeAws_json1_1GetDevEndpointsResponse = (
       output.DevEndpoints !== undefined && output.DevEndpoints !== null
         ? deserializeAws_json1_1DevEndpointList(output.DevEndpoints, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -21569,7 +21437,7 @@ const deserializeAws_json1_1GetJobRunsResponse = (output: any, context: __SerdeC
       output.JobRuns !== undefined && output.JobRuns !== null
         ? deserializeAws_json1_1JobRunList(output.JobRuns, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -21579,7 +21447,7 @@ const deserializeAws_json1_1GetJobsResponse = (output: any, context: __SerdeCont
       output.Jobs !== undefined && output.Jobs !== null
         ? deserializeAws_json1_1JobList(output.Jobs, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -21598,14 +21466,13 @@ const deserializeAws_json1_1GetMLTaskRunResponse = (output: any, context: __Serd
       output.CompletedOn !== undefined && output.CompletedOn !== null
         ? new Date(Math.round(output.CompletedOn * 1000))
         : undefined,
-    ErrorString: output.ErrorString !== undefined && output.ErrorString !== null ? output.ErrorString : undefined,
-    ExecutionTime:
-      output.ExecutionTime !== undefined && output.ExecutionTime !== null ? output.ExecutionTime : undefined,
+    ErrorString: __expectString(output.ErrorString),
+    ExecutionTime: __expectNumber(output.ExecutionTime),
     LastModifiedOn:
       output.LastModifiedOn !== undefined && output.LastModifiedOn !== null
         ? new Date(Math.round(output.LastModifiedOn * 1000))
         : undefined,
-    LogGroupName: output.LogGroupName !== undefined && output.LogGroupName !== null ? output.LogGroupName : undefined,
+    LogGroupName: __expectString(output.LogGroupName),
     Properties:
       output.Properties !== undefined && output.Properties !== null
         ? deserializeAws_json1_1TaskRunProperties(output.Properties, context)
@@ -21614,15 +21481,15 @@ const deserializeAws_json1_1GetMLTaskRunResponse = (output: any, context: __Serd
       output.StartedOn !== undefined && output.StartedOn !== null
         ? new Date(Math.round(output.StartedOn * 1000))
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    TaskRunId: output.TaskRunId !== undefined && output.TaskRunId !== null ? output.TaskRunId : undefined,
-    TransformId: output.TransformId !== undefined && output.TransformId !== null ? output.TransformId : undefined,
+    Status: __expectString(output.Status),
+    TaskRunId: __expectString(output.TaskRunId),
+    TransformId: __expectString(output.TransformId),
   } as any;
 };
 
 const deserializeAws_json1_1GetMLTaskRunsResponse = (output: any, context: __SerdeContext): GetMLTaskRunsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     TaskRuns:
       output.TaskRuns !== undefined && output.TaskRuns !== null
         ? deserializeAws_json1_1TaskRunList(output.TaskRuns, context)
@@ -21636,43 +21503,42 @@ const deserializeAws_json1_1GetMLTransformResponse = (output: any, context: __Se
       output.CreatedOn !== undefined && output.CreatedOn !== null
         ? new Date(Math.round(output.CreatedOn * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     EvaluationMetrics:
       output.EvaluationMetrics !== undefined && output.EvaluationMetrics !== null
         ? deserializeAws_json1_1EvaluationMetrics(output.EvaluationMetrics, context)
         : undefined,
-    GlueVersion: output.GlueVersion !== undefined && output.GlueVersion !== null ? output.GlueVersion : undefined,
+    GlueVersion: __expectString(output.GlueVersion),
     InputRecordTables:
       output.InputRecordTables !== undefined && output.InputRecordTables !== null
         ? deserializeAws_json1_1GlueTables(output.InputRecordTables, context)
         : undefined,
-    LabelCount: output.LabelCount !== undefined && output.LabelCount !== null ? output.LabelCount : undefined,
+    LabelCount: __expectNumber(output.LabelCount),
     LastModifiedOn:
       output.LastModifiedOn !== undefined && output.LastModifiedOn !== null
         ? new Date(Math.round(output.LastModifiedOn * 1000))
         : undefined,
-    MaxCapacity: output.MaxCapacity !== undefined && output.MaxCapacity !== null ? output.MaxCapacity : undefined,
-    MaxRetries: output.MaxRetries !== undefined && output.MaxRetries !== null ? output.MaxRetries : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    NumberOfWorkers:
-      output.NumberOfWorkers !== undefined && output.NumberOfWorkers !== null ? output.NumberOfWorkers : undefined,
+    MaxCapacity: __expectNumber(output.MaxCapacity),
+    MaxRetries: __expectNumber(output.MaxRetries),
+    Name: __expectString(output.Name),
+    NumberOfWorkers: __expectNumber(output.NumberOfWorkers),
     Parameters:
       output.Parameters !== undefined && output.Parameters !== null
         ? deserializeAws_json1_1TransformParameters(output.Parameters, context)
         : undefined,
-    Role: output.Role !== undefined && output.Role !== null ? output.Role : undefined,
+    Role: __expectString(output.Role),
     Schema:
       output.Schema !== undefined && output.Schema !== null
         ? deserializeAws_json1_1TransformSchema(output.Schema, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    Timeout: output.Timeout !== undefined && output.Timeout !== null ? output.Timeout : undefined,
+    Status: __expectString(output.Status),
+    Timeout: __expectNumber(output.Timeout),
     TransformEncryption:
       output.TransformEncryption !== undefined && output.TransformEncryption !== null
         ? deserializeAws_json1_1TransformEncryption(output.TransformEncryption, context)
         : undefined,
-    TransformId: output.TransformId !== undefined && output.TransformId !== null ? output.TransformId : undefined,
-    WorkerType: output.WorkerType !== undefined && output.WorkerType !== null ? output.WorkerType : undefined,
+    TransformId: __expectString(output.TransformId),
+    WorkerType: __expectString(output.WorkerType),
   } as any;
 };
 
@@ -21681,7 +21547,7 @@ const deserializeAws_json1_1GetMLTransformsResponse = (
   context: __SerdeContext
 ): GetMLTransformsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Transforms:
       output.Transforms !== undefined && output.Transforms !== null
         ? deserializeAws_json1_1TransformList(output.Transforms, context)
@@ -21694,7 +21560,7 @@ const deserializeAws_json1_1GetPartitionIndexesResponse = (
   context: __SerdeContext
 ): GetPartitionIndexesResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     PartitionIndexDescriptorList:
       output.PartitionIndexDescriptorList !== undefined && output.PartitionIndexDescriptorList !== null
         ? deserializeAws_json1_1PartitionIndexDescriptorList(output.PartitionIndexDescriptorList, context)
@@ -21713,7 +21579,7 @@ const deserializeAws_json1_1GetPartitionResponse = (output: any, context: __Serd
 
 const deserializeAws_json1_1GetPartitionsResponse = (output: any, context: __SerdeContext): GetPartitionsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Partitions:
       output.Partitions !== undefined && output.Partitions !== null
         ? deserializeAws_json1_1PartitionList(output.Partitions, context)
@@ -21723,19 +21589,19 @@ const deserializeAws_json1_1GetPartitionsResponse = (output: any, context: __Ser
 
 const deserializeAws_json1_1GetPlanResponse = (output: any, context: __SerdeContext): GetPlanResponse => {
   return {
-    PythonScript: output.PythonScript !== undefined && output.PythonScript !== null ? output.PythonScript : undefined,
-    ScalaCode: output.ScalaCode !== undefined && output.ScalaCode !== null ? output.ScalaCode : undefined,
+    PythonScript: __expectString(output.PythonScript),
+    ScalaCode: __expectString(output.ScalaCode),
   } as any;
 };
 
 const deserializeAws_json1_1GetRegistryResponse = (output: any, context: __SerdeContext): GetRegistryResponse => {
   return {
-    CreatedTime: output.CreatedTime !== undefined && output.CreatedTime !== null ? output.CreatedTime : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    RegistryArn: output.RegistryArn !== undefined && output.RegistryArn !== null ? output.RegistryArn : undefined,
-    RegistryName: output.RegistryName !== undefined && output.RegistryName !== null ? output.RegistryName : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    UpdatedTime: output.UpdatedTime !== undefined && output.UpdatedTime !== null ? output.UpdatedTime : undefined,
+    CreatedTime: __expectString(output.CreatedTime),
+    Description: __expectString(output.Description),
+    RegistryArn: __expectString(output.RegistryArn),
+    RegistryName: __expectString(output.RegistryName),
+    Status: __expectString(output.Status),
+    UpdatedTime: __expectString(output.UpdatedTime),
   } as any;
 };
 
@@ -21748,7 +21614,7 @@ const deserializeAws_json1_1GetResourcePoliciesResponse = (
       output.GetResourcePoliciesResponseList !== undefined && output.GetResourcePoliciesResponseList !== null
         ? deserializeAws_json1_1GetResourcePoliciesResponseList(output.GetResourcePoliciesResponseList, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -21772,8 +21638,8 @@ const deserializeAws_json1_1GetResourcePolicyResponse = (
       output.CreateTime !== undefined && output.CreateTime !== null
         ? new Date(Math.round(output.CreateTime * 1000))
         : undefined,
-    PolicyHash: output.PolicyHash !== undefined && output.PolicyHash !== null ? output.PolicyHash : undefined,
-    PolicyInJson: output.PolicyInJson !== undefined && output.PolicyInJson !== null ? output.PolicyInJson : undefined,
+    PolicyHash: __expectString(output.PolicyHash),
+    PolicyInJson: __expectString(output.PolicyInJson),
     UpdateTime:
       output.UpdateTime !== undefined && output.UpdateTime !== null
         ? new Date(Math.round(output.UpdateTime * 1000))
@@ -21786,38 +21652,29 @@ const deserializeAws_json1_1GetSchemaByDefinitionResponse = (
   context: __SerdeContext
 ): GetSchemaByDefinitionResponse => {
   return {
-    CreatedTime: output.CreatedTime !== undefined && output.CreatedTime !== null ? output.CreatedTime : undefined,
-    DataFormat: output.DataFormat !== undefined && output.DataFormat !== null ? output.DataFormat : undefined,
-    SchemaArn: output.SchemaArn !== undefined && output.SchemaArn !== null ? output.SchemaArn : undefined,
-    SchemaVersionId:
-      output.SchemaVersionId !== undefined && output.SchemaVersionId !== null ? output.SchemaVersionId : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    CreatedTime: __expectString(output.CreatedTime),
+    DataFormat: __expectString(output.DataFormat),
+    SchemaArn: __expectString(output.SchemaArn),
+    SchemaVersionId: __expectString(output.SchemaVersionId),
+    Status: __expectString(output.Status),
   } as any;
 };
 
 const deserializeAws_json1_1GetSchemaResponse = (output: any, context: __SerdeContext): GetSchemaResponse => {
   return {
-    Compatibility:
-      output.Compatibility !== undefined && output.Compatibility !== null ? output.Compatibility : undefined,
-    CreatedTime: output.CreatedTime !== undefined && output.CreatedTime !== null ? output.CreatedTime : undefined,
-    DataFormat: output.DataFormat !== undefined && output.DataFormat !== null ? output.DataFormat : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    LatestSchemaVersion:
-      output.LatestSchemaVersion !== undefined && output.LatestSchemaVersion !== null
-        ? output.LatestSchemaVersion
-        : undefined,
-    NextSchemaVersion:
-      output.NextSchemaVersion !== undefined && output.NextSchemaVersion !== null
-        ? output.NextSchemaVersion
-        : undefined,
-    RegistryArn: output.RegistryArn !== undefined && output.RegistryArn !== null ? output.RegistryArn : undefined,
-    RegistryName: output.RegistryName !== undefined && output.RegistryName !== null ? output.RegistryName : undefined,
-    SchemaArn: output.SchemaArn !== undefined && output.SchemaArn !== null ? output.SchemaArn : undefined,
-    SchemaCheckpoint:
-      output.SchemaCheckpoint !== undefined && output.SchemaCheckpoint !== null ? output.SchemaCheckpoint : undefined,
-    SchemaName: output.SchemaName !== undefined && output.SchemaName !== null ? output.SchemaName : undefined,
-    SchemaStatus: output.SchemaStatus !== undefined && output.SchemaStatus !== null ? output.SchemaStatus : undefined,
-    UpdatedTime: output.UpdatedTime !== undefined && output.UpdatedTime !== null ? output.UpdatedTime : undefined,
+    Compatibility: __expectString(output.Compatibility),
+    CreatedTime: __expectString(output.CreatedTime),
+    DataFormat: __expectString(output.DataFormat),
+    Description: __expectString(output.Description),
+    LatestSchemaVersion: __expectNumber(output.LatestSchemaVersion),
+    NextSchemaVersion: __expectNumber(output.NextSchemaVersion),
+    RegistryArn: __expectString(output.RegistryArn),
+    RegistryName: __expectString(output.RegistryName),
+    SchemaArn: __expectString(output.SchemaArn),
+    SchemaCheckpoint: __expectNumber(output.SchemaCheckpoint),
+    SchemaName: __expectString(output.SchemaName),
+    SchemaStatus: __expectString(output.SchemaStatus),
+    UpdatedTime: __expectString(output.UpdatedTime),
   } as any;
 };
 
@@ -21826,16 +21683,13 @@ const deserializeAws_json1_1GetSchemaVersionResponse = (
   context: __SerdeContext
 ): GetSchemaVersionResponse => {
   return {
-    CreatedTime: output.CreatedTime !== undefined && output.CreatedTime !== null ? output.CreatedTime : undefined,
-    DataFormat: output.DataFormat !== undefined && output.DataFormat !== null ? output.DataFormat : undefined,
-    SchemaArn: output.SchemaArn !== undefined && output.SchemaArn !== null ? output.SchemaArn : undefined,
-    SchemaDefinition:
-      output.SchemaDefinition !== undefined && output.SchemaDefinition !== null ? output.SchemaDefinition : undefined,
-    SchemaVersionId:
-      output.SchemaVersionId !== undefined && output.SchemaVersionId !== null ? output.SchemaVersionId : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    VersionNumber:
-      output.VersionNumber !== undefined && output.VersionNumber !== null ? output.VersionNumber : undefined,
+    CreatedTime: __expectString(output.CreatedTime),
+    DataFormat: __expectString(output.DataFormat),
+    SchemaArn: __expectString(output.SchemaArn),
+    SchemaDefinition: __expectString(output.SchemaDefinition),
+    SchemaVersionId: __expectString(output.SchemaVersionId),
+    Status: __expectString(output.Status),
+    VersionNumber: __expectNumber(output.VersionNumber),
   } as any;
 };
 
@@ -21844,7 +21698,7 @@ const deserializeAws_json1_1GetSchemaVersionsDiffResponse = (
   context: __SerdeContext
 ): GetSchemaVersionsDiffResponse => {
   return {
-    Diff: output.Diff !== undefined && output.Diff !== null ? output.Diff : undefined,
+    Diff: __expectString(output.Diff),
   } as any;
 };
 
@@ -21865,7 +21719,7 @@ const deserializeAws_json1_1GetSecurityConfigurationsResponse = (
   context: __SerdeContext
 ): GetSecurityConfigurationsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     SecurityConfigurations:
       output.SecurityConfigurations !== undefined && output.SecurityConfigurations !== null
         ? deserializeAws_json1_1SecurityConfigurationList(output.SecurityConfigurations, context)
@@ -21884,7 +21738,7 @@ const deserializeAws_json1_1GetTableResponse = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1GetTablesResponse = (output: any, context: __SerdeContext): GetTablesResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     TableList:
       output.TableList !== undefined && output.TableList !== null
         ? deserializeAws_json1_1TableList(output.TableList, context)
@@ -21920,7 +21774,7 @@ const deserializeAws_json1_1GetTableVersionsResponse = (
   context: __SerdeContext
 ): GetTableVersionsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     TableVersions:
       output.TableVersions !== undefined && output.TableVersions !== null
         ? deserializeAws_json1_1GetTableVersionsList(output.TableVersions, context)
@@ -21948,7 +21802,7 @@ const deserializeAws_json1_1GetTriggerResponse = (output: any, context: __SerdeC
 
 const deserializeAws_json1_1GetTriggersResponse = (output: any, context: __SerdeContext): GetTriggersResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Triggers:
       output.Triggers !== undefined && output.Triggers !== null
         ? deserializeAws_json1_1TriggerList(output.Triggers, context)
@@ -21973,7 +21827,7 @@ const deserializeAws_json1_1GetUserDefinedFunctionsResponse = (
   context: __SerdeContext
 ): GetUserDefinedFunctionsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     UserDefinedFunctions:
       output.UserDefinedFunctions !== undefined && output.UserDefinedFunctions !== null
         ? deserializeAws_json1_1UserDefinedFunctionList(output.UserDefinedFunctions, context)
@@ -22016,7 +21870,7 @@ const deserializeAws_json1_1GetWorkflowRunsResponse = (
   context: __SerdeContext
 ): GetWorkflowRunsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Runs:
       output.Runs !== undefined && output.Runs !== null
         ? deserializeAws_json1_1WorkflowRuns(output.Runs, context)
@@ -22029,7 +21883,7 @@ const deserializeAws_json1_1GlueEncryptionException = (
   context: __SerdeContext
 ): GlueEncryptionException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -22039,8 +21893,8 @@ const deserializeAws_json1_1GluePolicy = (output: any, context: __SerdeContext):
       output.CreateTime !== undefined && output.CreateTime !== null
         ? new Date(Math.round(output.CreateTime * 1000))
         : undefined,
-    PolicyHash: output.PolicyHash !== undefined && output.PolicyHash !== null ? output.PolicyHash : undefined,
-    PolicyInJson: output.PolicyInJson !== undefined && output.PolicyInJson !== null ? output.PolicyInJson : undefined,
+    PolicyHash: __expectString(output.PolicyHash),
+    PolicyInJson: __expectString(output.PolicyInJson),
     UpdateTime:
       output.UpdateTime !== undefined && output.UpdateTime !== null
         ? new Date(Math.round(output.UpdateTime * 1000))
@@ -22050,11 +21904,10 @@ const deserializeAws_json1_1GluePolicy = (output: any, context: __SerdeContext):
 
 const deserializeAws_json1_1GlueTable = (output: any, context: __SerdeContext): GlueTable => {
   return {
-    CatalogId: output.CatalogId !== undefined && output.CatalogId !== null ? output.CatalogId : undefined,
-    ConnectionName:
-      output.ConnectionName !== undefined && output.ConnectionName !== null ? output.ConnectionName : undefined,
-    DatabaseName: output.DatabaseName !== undefined && output.DatabaseName !== null ? output.DatabaseName : undefined,
-    TableName: output.TableName !== undefined && output.TableName !== null ? output.TableName : undefined,
+    CatalogId: __expectString(output.CatalogId),
+    ConnectionName: __expectString(output.ConnectionName),
+    DatabaseName: __expectString(output.DatabaseName),
+    TableName: __expectString(output.TableName),
   } as any;
 };
 
@@ -22071,21 +21924,19 @@ const deserializeAws_json1_1GlueTables = (output: any, context: __SerdeContext):
 
 const deserializeAws_json1_1GrokClassifier = (output: any, context: __SerdeContext): GrokClassifier => {
   return {
-    Classification:
-      output.Classification !== undefined && output.Classification !== null ? output.Classification : undefined,
+    Classification: __expectString(output.Classification),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    CustomPatterns:
-      output.CustomPatterns !== undefined && output.CustomPatterns !== null ? output.CustomPatterns : undefined,
-    GrokPattern: output.GrokPattern !== undefined && output.GrokPattern !== null ? output.GrokPattern : undefined,
+    CustomPatterns: __expectString(output.CustomPatterns),
+    GrokPattern: __expectString(output.GrokPattern),
     LastUpdated:
       output.LastUpdated !== undefined && output.LastUpdated !== null
         ? new Date(Math.round(output.LastUpdated * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    Name: __expectString(output.Name),
+    Version: __expectNumber(output.Version),
   } as any;
 };
 
@@ -22094,7 +21945,7 @@ const deserializeAws_json1_1IdempotentParameterMismatchException = (
   context: __SerdeContext
 ): IdempotentParameterMismatchException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -22103,7 +21954,7 @@ const deserializeAws_json1_1IllegalWorkflowStateException = (
   context: __SerdeContext
 ): IllegalWorkflowStateException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -22119,8 +21970,8 @@ const deserializeAws_json1_1ImportLabelsTaskRunProperties = (
   context: __SerdeContext
 ): ImportLabelsTaskRunProperties => {
   return {
-    InputS3Path: output.InputS3Path !== undefined && output.InputS3Path !== null ? output.InputS3Path : undefined,
-    Replace: output.Replace !== undefined && output.Replace !== null ? output.Replace : undefined,
+    InputS3Path: __expectString(output.InputS3Path),
+    Replace: __expectBoolean(output.Replace),
   } as any;
 };
 
@@ -22129,25 +21980,24 @@ const deserializeAws_json1_1InternalServiceException = (
   context: __SerdeContext
 ): InternalServiceException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidInputException = (output: any, context: __SerdeContext): InvalidInputException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1JdbcTarget = (output: any, context: __SerdeContext): JdbcTarget => {
   return {
-    ConnectionName:
-      output.ConnectionName !== undefined && output.ConnectionName !== null ? output.ConnectionName : undefined,
+    ConnectionName: __expectString(output.ConnectionName),
     Exclusions:
       output.Exclusions !== undefined && output.Exclusions !== null
         ? deserializeAws_json1_1PathList(output.Exclusions, context)
         : undefined,
-    Path: output.Path !== undefined && output.Path !== null ? output.Path : undefined,
+    Path: __expectString(output.Path),
   } as any;
 };
 
@@ -22164,10 +22014,7 @@ const deserializeAws_json1_1JdbcTargetList = (output: any, context: __SerdeConte
 
 const deserializeAws_json1_1Job = (output: any, context: __SerdeContext): Job => {
   return {
-    AllocatedCapacity:
-      output.AllocatedCapacity !== undefined && output.AllocatedCapacity !== null
-        ? output.AllocatedCapacity
-        : undefined,
+    AllocatedCapacity: __expectNumber(output.AllocatedCapacity),
     Command:
       output.Command !== undefined && output.Command !== null
         ? deserializeAws_json1_1JobCommand(output.Command, context)
@@ -22184,20 +22031,20 @@ const deserializeAws_json1_1Job = (output: any, context: __SerdeContext): Job =>
       output.DefaultArguments !== undefined && output.DefaultArguments !== null
         ? deserializeAws_json1_1GenericMap(output.DefaultArguments, context)
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     ExecutionProperty:
       output.ExecutionProperty !== undefined && output.ExecutionProperty !== null
         ? deserializeAws_json1_1ExecutionProperty(output.ExecutionProperty, context)
         : undefined,
-    GlueVersion: output.GlueVersion !== undefined && output.GlueVersion !== null ? output.GlueVersion : undefined,
+    GlueVersion: __expectString(output.GlueVersion),
     LastModifiedOn:
       output.LastModifiedOn !== undefined && output.LastModifiedOn !== null
         ? new Date(Math.round(output.LastModifiedOn * 1000))
         : undefined,
-    LogUri: output.LogUri !== undefined && output.LogUri !== null ? output.LogUri : undefined,
-    MaxCapacity: output.MaxCapacity !== undefined && output.MaxCapacity !== null ? output.MaxCapacity : undefined,
-    MaxRetries: output.MaxRetries !== undefined && output.MaxRetries !== null ? output.MaxRetries : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    LogUri: __expectString(output.LogUri),
+    MaxCapacity: __expectNumber(output.MaxCapacity),
+    MaxRetries: __expectNumber(output.MaxRetries),
+    Name: __expectString(output.Name),
     NonOverridableArguments:
       output.NonOverridableArguments !== undefined && output.NonOverridableArguments !== null
         ? deserializeAws_json1_1GenericMap(output.NonOverridableArguments, context)
@@ -22206,48 +22053,38 @@ const deserializeAws_json1_1Job = (output: any, context: __SerdeContext): Job =>
       output.NotificationProperty !== undefined && output.NotificationProperty !== null
         ? deserializeAws_json1_1NotificationProperty(output.NotificationProperty, context)
         : undefined,
-    NumberOfWorkers:
-      output.NumberOfWorkers !== undefined && output.NumberOfWorkers !== null ? output.NumberOfWorkers : undefined,
-    Role: output.Role !== undefined && output.Role !== null ? output.Role : undefined,
-    SecurityConfiguration:
-      output.SecurityConfiguration !== undefined && output.SecurityConfiguration !== null
-        ? output.SecurityConfiguration
-        : undefined,
-    Timeout: output.Timeout !== undefined && output.Timeout !== null ? output.Timeout : undefined,
-    WorkerType: output.WorkerType !== undefined && output.WorkerType !== null ? output.WorkerType : undefined,
+    NumberOfWorkers: __expectNumber(output.NumberOfWorkers),
+    Role: __expectString(output.Role),
+    SecurityConfiguration: __expectString(output.SecurityConfiguration),
+    Timeout: __expectNumber(output.Timeout),
+    WorkerType: __expectString(output.WorkerType),
   } as any;
 };
 
 const deserializeAws_json1_1JobBookmarkEntry = (output: any, context: __SerdeContext): JobBookmarkEntry => {
   return {
-    Attempt: output.Attempt !== undefined && output.Attempt !== null ? output.Attempt : undefined,
-    JobBookmark: output.JobBookmark !== undefined && output.JobBookmark !== null ? output.JobBookmark : undefined,
-    JobName: output.JobName !== undefined && output.JobName !== null ? output.JobName : undefined,
-    PreviousRunId:
-      output.PreviousRunId !== undefined && output.PreviousRunId !== null ? output.PreviousRunId : undefined,
-    Run: output.Run !== undefined && output.Run !== null ? output.Run : undefined,
-    RunId: output.RunId !== undefined && output.RunId !== null ? output.RunId : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    Attempt: __expectNumber(output.Attempt),
+    JobBookmark: __expectString(output.JobBookmark),
+    JobName: __expectString(output.JobName),
+    PreviousRunId: __expectString(output.PreviousRunId),
+    Run: __expectNumber(output.Run),
+    RunId: __expectString(output.RunId),
+    Version: __expectNumber(output.Version),
   } as any;
 };
 
 const deserializeAws_json1_1JobBookmarksEncryption = (output: any, context: __SerdeContext): JobBookmarksEncryption => {
   return {
-    JobBookmarksEncryptionMode:
-      output.JobBookmarksEncryptionMode !== undefined && output.JobBookmarksEncryptionMode !== null
-        ? output.JobBookmarksEncryptionMode
-        : undefined,
-    KmsKeyArn: output.KmsKeyArn !== undefined && output.KmsKeyArn !== null ? output.KmsKeyArn : undefined,
+    JobBookmarksEncryptionMode: __expectString(output.JobBookmarksEncryptionMode),
+    KmsKeyArn: __expectString(output.KmsKeyArn),
   } as any;
 };
 
 const deserializeAws_json1_1JobCommand = (output: any, context: __SerdeContext): JobCommand => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    PythonVersion:
-      output.PythonVersion !== undefined && output.PythonVersion !== null ? output.PythonVersion : undefined,
-    ScriptLocation:
-      output.ScriptLocation !== undefined && output.ScriptLocation !== null ? output.ScriptLocation : undefined,
+    Name: __expectString(output.Name),
+    PythonVersion: __expectString(output.PythonVersion),
+    ScriptLocation: __expectString(output.ScriptLocation),
   } as any;
 };
 
@@ -22269,7 +22106,7 @@ const deserializeAws_json1_1JobNameList = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -22284,55 +22121,46 @@ const deserializeAws_json1_1JobNodeDetails = (output: any, context: __SerdeConte
 
 const deserializeAws_json1_1JobRun = (output: any, context: __SerdeContext): JobRun => {
   return {
-    AllocatedCapacity:
-      output.AllocatedCapacity !== undefined && output.AllocatedCapacity !== null
-        ? output.AllocatedCapacity
-        : undefined,
+    AllocatedCapacity: __expectNumber(output.AllocatedCapacity),
     Arguments:
       output.Arguments !== undefined && output.Arguments !== null
         ? deserializeAws_json1_1GenericMap(output.Arguments, context)
         : undefined,
-    Attempt: output.Attempt !== undefined && output.Attempt !== null ? output.Attempt : undefined,
+    Attempt: __expectNumber(output.Attempt),
     CompletedOn:
       output.CompletedOn !== undefined && output.CompletedOn !== null
         ? new Date(Math.round(output.CompletedOn * 1000))
         : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    ExecutionTime:
-      output.ExecutionTime !== undefined && output.ExecutionTime !== null ? output.ExecutionTime : undefined,
-    GlueVersion: output.GlueVersion !== undefined && output.GlueVersion !== null ? output.GlueVersion : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    JobName: output.JobName !== undefined && output.JobName !== null ? output.JobName : undefined,
-    JobRunState: output.JobRunState !== undefined && output.JobRunState !== null ? output.JobRunState : undefined,
+    ErrorMessage: __expectString(output.ErrorMessage),
+    ExecutionTime: __expectNumber(output.ExecutionTime),
+    GlueVersion: __expectString(output.GlueVersion),
+    Id: __expectString(output.Id),
+    JobName: __expectString(output.JobName),
+    JobRunState: __expectString(output.JobRunState),
     LastModifiedOn:
       output.LastModifiedOn !== undefined && output.LastModifiedOn !== null
         ? new Date(Math.round(output.LastModifiedOn * 1000))
         : undefined,
-    LogGroupName: output.LogGroupName !== undefined && output.LogGroupName !== null ? output.LogGroupName : undefined,
-    MaxCapacity: output.MaxCapacity !== undefined && output.MaxCapacity !== null ? output.MaxCapacity : undefined,
+    LogGroupName: __expectString(output.LogGroupName),
+    MaxCapacity: __expectNumber(output.MaxCapacity),
     NotificationProperty:
       output.NotificationProperty !== undefined && output.NotificationProperty !== null
         ? deserializeAws_json1_1NotificationProperty(output.NotificationProperty, context)
         : undefined,
-    NumberOfWorkers:
-      output.NumberOfWorkers !== undefined && output.NumberOfWorkers !== null ? output.NumberOfWorkers : undefined,
+    NumberOfWorkers: __expectNumber(output.NumberOfWorkers),
     PredecessorRuns:
       output.PredecessorRuns !== undefined && output.PredecessorRuns !== null
         ? deserializeAws_json1_1PredecessorList(output.PredecessorRuns, context)
         : undefined,
-    PreviousRunId:
-      output.PreviousRunId !== undefined && output.PreviousRunId !== null ? output.PreviousRunId : undefined,
-    SecurityConfiguration:
-      output.SecurityConfiguration !== undefined && output.SecurityConfiguration !== null
-        ? output.SecurityConfiguration
-        : undefined,
+    PreviousRunId: __expectString(output.PreviousRunId),
+    SecurityConfiguration: __expectString(output.SecurityConfiguration),
     StartedOn:
       output.StartedOn !== undefined && output.StartedOn !== null
         ? new Date(Math.round(output.StartedOn * 1000))
         : undefined,
-    Timeout: output.Timeout !== undefined && output.Timeout !== null ? output.Timeout : undefined,
-    TriggerName: output.TriggerName !== undefined && output.TriggerName !== null ? output.TriggerName : undefined,
-    WorkerType: output.WorkerType !== undefined && output.WorkerType !== null ? output.WorkerType : undefined,
+    Timeout: __expectNumber(output.Timeout),
+    TriggerName: __expectString(output.TriggerName),
+    WorkerType: __expectString(output.WorkerType),
   } as any;
 };
 
@@ -22353,20 +22181,20 @@ const deserializeAws_json1_1JsonClassifier = (output: any, context: __SerdeConte
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    JsonPath: output.JsonPath !== undefined && output.JsonPath !== null ? output.JsonPath : undefined,
+    JsonPath: __expectString(output.JsonPath),
     LastUpdated:
       output.LastUpdated !== undefined && output.LastUpdated !== null
         ? new Date(Math.round(output.LastUpdated * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    Name: __expectString(output.Name),
+    Version: __expectNumber(output.Version),
   } as any;
 };
 
 const deserializeAws_json1_1KeySchemaElement = (output: any, context: __SerdeContext): KeySchemaElement => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Name: __expectString(output.Name),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -22386,31 +22214,27 @@ const deserializeAws_json1_1LabelingSetGenerationTaskRunProperties = (
   context: __SerdeContext
 ): LabelingSetGenerationTaskRunProperties => {
   return {
-    OutputS3Path: output.OutputS3Path !== undefined && output.OutputS3Path !== null ? output.OutputS3Path : undefined,
+    OutputS3Path: __expectString(output.OutputS3Path),
   } as any;
 };
 
 const deserializeAws_json1_1LastCrawlInfo = (output: any, context: __SerdeContext): LastCrawlInfo => {
   return {
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    LogGroup: output.LogGroup !== undefined && output.LogGroup !== null ? output.LogGroup : undefined,
-    LogStream: output.LogStream !== undefined && output.LogStream !== null ? output.LogStream : undefined,
-    MessagePrefix:
-      output.MessagePrefix !== undefined && output.MessagePrefix !== null ? output.MessagePrefix : undefined,
+    ErrorMessage: __expectString(output.ErrorMessage),
+    LogGroup: __expectString(output.LogGroup),
+    LogStream: __expectString(output.LogStream),
+    MessagePrefix: __expectString(output.MessagePrefix),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
         ? new Date(Math.round(output.StartTime * 1000))
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
 const deserializeAws_json1_1LineageConfiguration = (output: any, context: __SerdeContext): LineageConfiguration => {
   return {
-    CrawlerLineageSettings:
-      output.CrawlerLineageSettings !== undefined && output.CrawlerLineageSettings !== null
-        ? output.CrawlerLineageSettings
-        : undefined,
+    CrawlerLineageSettings: __expectString(output.CrawlerLineageSettings),
   } as any;
 };
 
@@ -22420,7 +22244,7 @@ const deserializeAws_json1_1ListCrawlersResponse = (output: any, context: __Serd
       output.CrawlerNames !== undefined && output.CrawlerNames !== null
         ? deserializeAws_json1_1CrawlerNameList(output.CrawlerNames, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -22433,7 +22257,7 @@ const deserializeAws_json1_1ListDevEndpointsResponse = (
       output.DevEndpointNames !== undefined && output.DevEndpointNames !== null
         ? deserializeAws_json1_1DevEndpointNameList(output.DevEndpointNames, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -22443,7 +22267,7 @@ const deserializeAws_json1_1ListJobsResponse = (output: any, context: __SerdeCon
       output.JobNames !== undefined && output.JobNames !== null
         ? deserializeAws_json1_1JobNameList(output.JobNames, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -22452,7 +22276,7 @@ const deserializeAws_json1_1ListMLTransformsResponse = (
   context: __SerdeContext
 ): ListMLTransformsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     TransformIds:
       output.TransformIds !== undefined && output.TransformIds !== null
         ? deserializeAws_json1_1TransformIdList(output.TransformIds, context)
@@ -22462,7 +22286,7 @@ const deserializeAws_json1_1ListMLTransformsResponse = (
 
 const deserializeAws_json1_1ListRegistriesResponse = (output: any, context: __SerdeContext): ListRegistriesResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Registries:
       output.Registries !== undefined && output.Registries !== null
         ? deserializeAws_json1_1RegistryListDefinition(output.Registries, context)
@@ -22472,7 +22296,7 @@ const deserializeAws_json1_1ListRegistriesResponse = (output: any, context: __Se
 
 const deserializeAws_json1_1ListSchemasResponse = (output: any, context: __SerdeContext): ListSchemasResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Schemas:
       output.Schemas !== undefined && output.Schemas !== null
         ? deserializeAws_json1_1SchemaListDefinition(output.Schemas, context)
@@ -22485,7 +22309,7 @@ const deserializeAws_json1_1ListSchemaVersionsResponse = (
   context: __SerdeContext
 ): ListSchemaVersionsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Schemas:
       output.Schemas !== undefined && output.Schemas !== null
         ? deserializeAws_json1_1SchemaVersionList(output.Schemas, context)
@@ -22495,7 +22319,7 @@ const deserializeAws_json1_1ListSchemaVersionsResponse = (
 
 const deserializeAws_json1_1ListTriggersResponse = (output: any, context: __SerdeContext): ListTriggersResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     TriggerNames:
       output.TriggerNames !== undefined && output.TriggerNames !== null
         ? deserializeAws_json1_1TriggerNameList(output.TriggerNames, context)
@@ -22505,7 +22329,7 @@ const deserializeAws_json1_1ListTriggersResponse = (output: any, context: __Serd
 
 const deserializeAws_json1_1ListWorkflowsResponse = (output: any, context: __SerdeContext): ListWorkflowsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Workflows:
       output.Workflows !== undefined && output.Workflows !== null
         ? deserializeAws_json1_1WorkflowNames(output.Workflows, context)
@@ -22520,7 +22344,7 @@ const deserializeAws_json1_1LocationMap = (output: any, context: __SerdeContext)
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -22530,25 +22354,21 @@ const deserializeAws_json1_1LongColumnStatisticsData = (
   context: __SerdeContext
 ): LongColumnStatisticsData => {
   return {
-    MaximumValue: output.MaximumValue !== undefined && output.MaximumValue !== null ? output.MaximumValue : undefined,
-    MinimumValue: output.MinimumValue !== undefined && output.MinimumValue !== null ? output.MinimumValue : undefined,
-    NumberOfDistinctValues:
-      output.NumberOfDistinctValues !== undefined && output.NumberOfDistinctValues !== null
-        ? output.NumberOfDistinctValues
-        : undefined,
-    NumberOfNulls:
-      output.NumberOfNulls !== undefined && output.NumberOfNulls !== null ? output.NumberOfNulls : undefined,
+    MaximumValue: __expectNumber(output.MaximumValue),
+    MinimumValue: __expectNumber(output.MinimumValue),
+    NumberOfDistinctValues: __expectNumber(output.NumberOfDistinctValues),
+    NumberOfNulls: __expectNumber(output.NumberOfNulls),
   } as any;
 };
 
 const deserializeAws_json1_1MappingEntry = (output: any, context: __SerdeContext): MappingEntry => {
   return {
-    SourcePath: output.SourcePath !== undefined && output.SourcePath !== null ? output.SourcePath : undefined,
-    SourceTable: output.SourceTable !== undefined && output.SourceTable !== null ? output.SourceTable : undefined,
-    SourceType: output.SourceType !== undefined && output.SourceType !== null ? output.SourceType : undefined,
-    TargetPath: output.TargetPath !== undefined && output.TargetPath !== null ? output.TargetPath : undefined,
-    TargetTable: output.TargetTable !== undefined && output.TargetTable !== null ? output.TargetTable : undefined,
-    TargetType: output.TargetType !== undefined && output.TargetType !== null ? output.TargetType : undefined,
+    SourcePath: __expectString(output.SourcePath),
+    SourceTable: __expectString(output.SourceTable),
+    SourceType: __expectString(output.SourceType),
+    TargetPath: __expectString(output.TargetPath),
+    TargetTable: __expectString(output.TargetTable),
+    TargetType: __expectString(output.TargetType),
   } as any;
 };
 
@@ -22570,7 +22390,7 @@ const deserializeAws_json1_1MapValue = (output: any, context: __SerdeContext): {
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -22582,15 +22402,14 @@ const deserializeAws_json1_1MatchCriteria = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1MetadataInfo = (output: any, context: __SerdeContext): MetadataInfo => {
   return {
-    CreatedTime: output.CreatedTime !== undefined && output.CreatedTime !== null ? output.CreatedTime : undefined,
-    MetadataValue:
-      output.MetadataValue !== undefined && output.MetadataValue !== null ? output.MetadataValue : undefined,
+    CreatedTime: __expectString(output.CreatedTime),
+    MetadataValue: __expectString(output.MetadataValue),
     OtherMetadataValueList:
       output.OtherMetadataValueList !== undefined && output.OtherMetadataValueList !== null
         ? deserializeAws_json1_1OtherMetadataValueList(output.OtherMetadataValueList, context)
@@ -22619,43 +22438,42 @@ const deserializeAws_json1_1MLTransform = (output: any, context: __SerdeContext)
       output.CreatedOn !== undefined && output.CreatedOn !== null
         ? new Date(Math.round(output.CreatedOn * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     EvaluationMetrics:
       output.EvaluationMetrics !== undefined && output.EvaluationMetrics !== null
         ? deserializeAws_json1_1EvaluationMetrics(output.EvaluationMetrics, context)
         : undefined,
-    GlueVersion: output.GlueVersion !== undefined && output.GlueVersion !== null ? output.GlueVersion : undefined,
+    GlueVersion: __expectString(output.GlueVersion),
     InputRecordTables:
       output.InputRecordTables !== undefined && output.InputRecordTables !== null
         ? deserializeAws_json1_1GlueTables(output.InputRecordTables, context)
         : undefined,
-    LabelCount: output.LabelCount !== undefined && output.LabelCount !== null ? output.LabelCount : undefined,
+    LabelCount: __expectNumber(output.LabelCount),
     LastModifiedOn:
       output.LastModifiedOn !== undefined && output.LastModifiedOn !== null
         ? new Date(Math.round(output.LastModifiedOn * 1000))
         : undefined,
-    MaxCapacity: output.MaxCapacity !== undefined && output.MaxCapacity !== null ? output.MaxCapacity : undefined,
-    MaxRetries: output.MaxRetries !== undefined && output.MaxRetries !== null ? output.MaxRetries : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    NumberOfWorkers:
-      output.NumberOfWorkers !== undefined && output.NumberOfWorkers !== null ? output.NumberOfWorkers : undefined,
+    MaxCapacity: __expectNumber(output.MaxCapacity),
+    MaxRetries: __expectNumber(output.MaxRetries),
+    Name: __expectString(output.Name),
+    NumberOfWorkers: __expectNumber(output.NumberOfWorkers),
     Parameters:
       output.Parameters !== undefined && output.Parameters !== null
         ? deserializeAws_json1_1TransformParameters(output.Parameters, context)
         : undefined,
-    Role: output.Role !== undefined && output.Role !== null ? output.Role : undefined,
+    Role: __expectString(output.Role),
     Schema:
       output.Schema !== undefined && output.Schema !== null
         ? deserializeAws_json1_1TransformSchema(output.Schema, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    Timeout: output.Timeout !== undefined && output.Timeout !== null ? output.Timeout : undefined,
+    Status: __expectString(output.Status),
+    Timeout: __expectNumber(output.Timeout),
     TransformEncryption:
       output.TransformEncryption !== undefined && output.TransformEncryption !== null
         ? deserializeAws_json1_1TransformEncryption(output.TransformEncryption, context)
         : undefined,
-    TransformId: output.TransformId !== undefined && output.TransformId !== null ? output.TransformId : undefined,
-    WorkerType: output.WorkerType !== undefined && output.WorkerType !== null ? output.WorkerType : undefined,
+    TransformId: __expectString(output.TransformId),
+    WorkerType: __expectString(output.WorkerType),
   } as any;
 };
 
@@ -22664,26 +22482,22 @@ const deserializeAws_json1_1MLTransformNotReadyException = (
   context: __SerdeContext
 ): MLTransformNotReadyException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1MLUserDataEncryption = (output: any, context: __SerdeContext): MLUserDataEncryption => {
   return {
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
-    MlUserDataEncryptionMode:
-      output.MlUserDataEncryptionMode !== undefined && output.MlUserDataEncryptionMode !== null
-        ? output.MlUserDataEncryptionMode
-        : undefined,
+    KmsKeyId: __expectString(output.KmsKeyId),
+    MlUserDataEncryptionMode: __expectString(output.MlUserDataEncryptionMode),
   } as any;
 };
 
 const deserializeAws_json1_1MongoDBTarget = (output: any, context: __SerdeContext): MongoDBTarget => {
   return {
-    ConnectionName:
-      output.ConnectionName !== undefined && output.ConnectionName !== null ? output.ConnectionName : undefined,
-    Path: output.Path !== undefined && output.Path !== null ? output.Path : undefined,
-    ScanAll: output.ScanAll !== undefined && output.ScanAll !== null ? output.ScanAll : undefined,
+    ConnectionName: __expectString(output.ConnectionName),
+    Path: __expectString(output.Path),
+    ScanAll: __expectBoolean(output.ScanAll),
   } as any;
 };
 
@@ -22705,7 +22519,7 @@ const deserializeAws_json1_1NameStringList = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -22719,13 +22533,13 @@ const deserializeAws_json1_1Node = (output: any, context: __SerdeContext): Node 
       output.JobDetails !== undefined && output.JobDetails !== null
         ? deserializeAws_json1_1JobNodeDetails(output.JobDetails, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     TriggerDetails:
       output.TriggerDetails !== undefined && output.TriggerDetails !== null
         ? deserializeAws_json1_1TriggerNodeDetails(output.TriggerDetails, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    UniqueId: output.UniqueId !== undefined && output.UniqueId !== null ? output.UniqueId : undefined,
+    Type: __expectString(output.Type),
+    UniqueId: __expectString(output.UniqueId),
   } as any;
 };
 
@@ -22736,7 +22550,7 @@ const deserializeAws_json1_1NodeIdList = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -22753,14 +22567,13 @@ const deserializeAws_json1_1NodeList = (output: any, context: __SerdeContext): N
 
 const deserializeAws_json1_1NoScheduleException = (output: any, context: __SerdeContext): NoScheduleException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1NotificationProperty = (output: any, context: __SerdeContext): NotificationProperty => {
   return {
-    NotifyDelayAfter:
-      output.NotifyDelayAfter !== undefined && output.NotifyDelayAfter !== null ? output.NotifyDelayAfter : undefined,
+    NotifyDelayAfter: __expectNumber(output.NotifyDelayAfter),
   } as any;
 };
 
@@ -22769,7 +22582,7 @@ const deserializeAws_json1_1OperationTimeoutException = (
   context: __SerdeContext
 ): OperationTimeoutException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -22780,14 +22593,14 @@ const deserializeAws_json1_1OrchestrationStringList = (output: any, context: __S
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1Order = (output: any, context: __SerdeContext): Order => {
   return {
-    Column: output.Column !== undefined && output.Column !== null ? output.Column : undefined,
-    SortOrder: output.SortOrder !== undefined && output.SortOrder !== null ? output.SortOrder : undefined,
+    Column: __expectString(output.Column),
+    SortOrder: __expectNumber(output.SortOrder),
   } as any;
 };
 
@@ -22821,9 +22634,8 @@ const deserializeAws_json1_1OtherMetadataValueListItem = (
   context: __SerdeContext
 ): OtherMetadataValueListItem => {
   return {
-    CreatedTime: output.CreatedTime !== undefined && output.CreatedTime !== null ? output.CreatedTime : undefined,
-    MetadataValue:
-      output.MetadataValue !== undefined && output.MetadataValue !== null ? output.MetadataValue : undefined,
+    CreatedTime: __expectString(output.CreatedTime),
+    MetadataValue: __expectString(output.MetadataValue),
   } as any;
 };
 
@@ -22834,19 +22646,19 @@ const deserializeAws_json1_1ParametersMap = (output: any, context: __SerdeContex
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_json1_1Partition = (output: any, context: __SerdeContext): Partition => {
   return {
-    CatalogId: output.CatalogId !== undefined && output.CatalogId !== null ? output.CatalogId : undefined,
+    CatalogId: __expectString(output.CatalogId),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    DatabaseName: output.DatabaseName !== undefined && output.DatabaseName !== null ? output.DatabaseName : undefined,
+    DatabaseName: __expectString(output.DatabaseName),
     LastAccessTime:
       output.LastAccessTime !== undefined && output.LastAccessTime !== null
         ? new Date(Math.round(output.LastAccessTime * 1000))
@@ -22863,7 +22675,7 @@ const deserializeAws_json1_1Partition = (output: any, context: __SerdeContext): 
       output.StorageDescriptor !== undefined && output.StorageDescriptor !== null
         ? deserializeAws_json1_1StorageDescriptor(output.StorageDescriptor, context)
         : undefined,
-    TableName: output.TableName !== undefined && output.TableName !== null ? output.TableName : undefined,
+    TableName: __expectString(output.TableName),
     Values:
       output.Values !== undefined && output.Values !== null
         ? deserializeAws_json1_1ValueStringList(output.Values, context)
@@ -22904,8 +22716,8 @@ const deserializeAws_json1_1PartitionIndexDescriptor = (
       output.BackfillErrors !== undefined && output.BackfillErrors !== null
         ? deserializeAws_json1_1BackfillErrors(output.BackfillErrors, context)
         : undefined,
-    IndexName: output.IndexName !== undefined && output.IndexName !== null ? output.IndexName : undefined,
-    IndexStatus: output.IndexStatus !== undefined && output.IndexStatus !== null ? output.IndexStatus : undefined,
+    IndexName: __expectString(output.IndexName),
+    IndexStatus: __expectString(output.IndexStatus),
     Keys:
       output.Keys !== undefined && output.Keys !== null
         ? deserializeAws_json1_1KeySchemaElementList(output.Keys, context)
@@ -22954,7 +22766,7 @@ const deserializeAws_json1_1PathList = (output: any, context: __SerdeContext): s
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -22965,7 +22777,7 @@ const deserializeAws_json1_1PermissionList = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -22974,20 +22786,19 @@ const deserializeAws_json1_1PhysicalConnectionRequirements = (
   context: __SerdeContext
 ): PhysicalConnectionRequirements => {
   return {
-    AvailabilityZone:
-      output.AvailabilityZone !== undefined && output.AvailabilityZone !== null ? output.AvailabilityZone : undefined,
+    AvailabilityZone: __expectString(output.AvailabilityZone),
     SecurityGroupIdList:
       output.SecurityGroupIdList !== undefined && output.SecurityGroupIdList !== null
         ? deserializeAws_json1_1SecurityGroupIdList(output.SecurityGroupIdList, context)
         : undefined,
-    SubnetId: output.SubnetId !== undefined && output.SubnetId !== null ? output.SubnetId : undefined,
+    SubnetId: __expectString(output.SubnetId),
   } as any;
 };
 
 const deserializeAws_json1_1Predecessor = (output: any, context: __SerdeContext): Predecessor => {
   return {
-    JobName: output.JobName !== undefined && output.JobName !== null ? output.JobName : undefined,
-    RunId: output.RunId !== undefined && output.RunId !== null ? output.RunId : undefined,
+    JobName: __expectString(output.JobName),
+    RunId: __expectString(output.RunId),
   } as any;
 };
 
@@ -23008,7 +22819,7 @@ const deserializeAws_json1_1Predicate = (output: any, context: __SerdeContext): 
       output.Conditions !== undefined && output.Conditions !== null
         ? deserializeAws_json1_1ConditionList(output.Conditions, context)
         : undefined,
-    Logical: output.Logical !== undefined && output.Logical !== null ? output.Logical : undefined,
+    Logical: __expectString(output.Logical),
   } as any;
 };
 
@@ -23046,7 +22857,7 @@ const deserializeAws_json1_1PublicKeysList = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -23062,7 +22873,7 @@ const deserializeAws_json1_1PutResourcePolicyResponse = (
   context: __SerdeContext
 ): PutResourcePolicyResponse => {
   return {
-    PolicyHash: output.PolicyHash !== undefined && output.PolicyHash !== null ? output.PolicyHash : undefined,
+    PolicyHash: __expectString(output.PolicyHash),
   } as any;
 };
 
@@ -23071,18 +22882,14 @@ const deserializeAws_json1_1PutSchemaVersionMetadataResponse = (
   context: __SerdeContext
 ): PutSchemaVersionMetadataResponse => {
   return {
-    LatestVersion:
-      output.LatestVersion !== undefined && output.LatestVersion !== null ? output.LatestVersion : undefined,
-    MetadataKey: output.MetadataKey !== undefined && output.MetadataKey !== null ? output.MetadataKey : undefined,
-    MetadataValue:
-      output.MetadataValue !== undefined && output.MetadataValue !== null ? output.MetadataValue : undefined,
-    RegistryName: output.RegistryName !== undefined && output.RegistryName !== null ? output.RegistryName : undefined,
-    SchemaArn: output.SchemaArn !== undefined && output.SchemaArn !== null ? output.SchemaArn : undefined,
-    SchemaName: output.SchemaName !== undefined && output.SchemaName !== null ? output.SchemaName : undefined,
-    SchemaVersionId:
-      output.SchemaVersionId !== undefined && output.SchemaVersionId !== null ? output.SchemaVersionId : undefined,
-    VersionNumber:
-      output.VersionNumber !== undefined && output.VersionNumber !== null ? output.VersionNumber : undefined,
+    LatestVersion: __expectBoolean(output.LatestVersion),
+    MetadataKey: __expectString(output.MetadataKey),
+    MetadataValue: __expectString(output.MetadataValue),
+    RegistryName: __expectString(output.RegistryName),
+    SchemaArn: __expectString(output.SchemaArn),
+    SchemaName: __expectString(output.SchemaName),
+    SchemaVersionId: __expectString(output.SchemaVersionId),
+    VersionNumber: __expectNumber(output.VersionNumber),
   } as any;
 };
 
@@ -23102,16 +22909,14 @@ const deserializeAws_json1_1QuerySchemaVersionMetadataResponse = (
       output.MetadataInfoMap !== undefined && output.MetadataInfoMap !== null
         ? deserializeAws_json1_1MetadataInfoMap(output.MetadataInfoMap, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
-    SchemaVersionId:
-      output.SchemaVersionId !== undefined && output.SchemaVersionId !== null ? output.SchemaVersionId : undefined,
+    NextToken: __expectString(output.NextToken),
+    SchemaVersionId: __expectString(output.SchemaVersionId),
   } as any;
 };
 
 const deserializeAws_json1_1RecrawlPolicy = (output: any, context: __SerdeContext): RecrawlPolicy => {
   return {
-    RecrawlBehavior:
-      output.RecrawlBehavior !== undefined && output.RecrawlBehavior !== null ? output.RecrawlBehavior : undefined,
+    RecrawlBehavior: __expectString(output.RecrawlBehavior),
   } as any;
 };
 
@@ -23120,11 +22925,9 @@ const deserializeAws_json1_1RegisterSchemaVersionResponse = (
   context: __SerdeContext
 ): RegisterSchemaVersionResponse => {
   return {
-    SchemaVersionId:
-      output.SchemaVersionId !== undefined && output.SchemaVersionId !== null ? output.SchemaVersionId : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    VersionNumber:
-      output.VersionNumber !== undefined && output.VersionNumber !== null ? output.VersionNumber : undefined,
+    SchemaVersionId: __expectString(output.SchemaVersionId),
+    Status: __expectString(output.Status),
+    VersionNumber: __expectNumber(output.VersionNumber),
   } as any;
 };
 
@@ -23141,12 +22944,12 @@ const deserializeAws_json1_1RegistryListDefinition = (output: any, context: __Se
 
 const deserializeAws_json1_1RegistryListItem = (output: any, context: __SerdeContext): RegistryListItem => {
   return {
-    CreatedTime: output.CreatedTime !== undefined && output.CreatedTime !== null ? output.CreatedTime : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    RegistryArn: output.RegistryArn !== undefined && output.RegistryArn !== null ? output.RegistryArn : undefined,
-    RegistryName: output.RegistryName !== undefined && output.RegistryName !== null ? output.RegistryName : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    UpdatedTime: output.UpdatedTime !== undefined && output.UpdatedTime !== null ? output.UpdatedTime : undefined,
+    CreatedTime: __expectString(output.CreatedTime),
+    Description: __expectString(output.Description),
+    RegistryArn: __expectString(output.RegistryArn),
+    RegistryName: __expectString(output.RegistryName),
+    Status: __expectString(output.Status),
+    UpdatedTime: __expectString(output.UpdatedTime),
   } as any;
 };
 
@@ -23155,18 +22958,14 @@ const deserializeAws_json1_1RemoveSchemaVersionMetadataResponse = (
   context: __SerdeContext
 ): RemoveSchemaVersionMetadataResponse => {
   return {
-    LatestVersion:
-      output.LatestVersion !== undefined && output.LatestVersion !== null ? output.LatestVersion : undefined,
-    MetadataKey: output.MetadataKey !== undefined && output.MetadataKey !== null ? output.MetadataKey : undefined,
-    MetadataValue:
-      output.MetadataValue !== undefined && output.MetadataValue !== null ? output.MetadataValue : undefined,
-    RegistryName: output.RegistryName !== undefined && output.RegistryName !== null ? output.RegistryName : undefined,
-    SchemaArn: output.SchemaArn !== undefined && output.SchemaArn !== null ? output.SchemaArn : undefined,
-    SchemaName: output.SchemaName !== undefined && output.SchemaName !== null ? output.SchemaName : undefined,
-    SchemaVersionId:
-      output.SchemaVersionId !== undefined && output.SchemaVersionId !== null ? output.SchemaVersionId : undefined,
-    VersionNumber:
-      output.VersionNumber !== undefined && output.VersionNumber !== null ? output.VersionNumber : undefined,
+    LatestVersion: __expectBoolean(output.LatestVersion),
+    MetadataKey: __expectString(output.MetadataKey),
+    MetadataValue: __expectString(output.MetadataValue),
+    RegistryName: __expectString(output.RegistryName),
+    SchemaArn: __expectString(output.SchemaArn),
+    SchemaName: __expectString(output.SchemaName),
+    SchemaVersionId: __expectString(output.SchemaVersionId),
+    VersionNumber: __expectNumber(output.VersionNumber),
   } as any;
 };
 
@@ -23187,14 +22986,14 @@ const deserializeAws_json1_1ResourceNumberLimitExceededException = (
   context: __SerdeContext
 ): ResourceNumberLimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1ResourceUri = (output: any, context: __SerdeContext): ResourceUri => {
   return {
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
-    Uri: output.Uri !== undefined && output.Uri !== null ? output.Uri : undefined,
+    ResourceType: __expectString(output.ResourceType),
+    Uri: __expectString(output.Uri),
   } as any;
 };
 
@@ -23218,15 +23017,14 @@ const deserializeAws_json1_1ResumeWorkflowRunResponse = (
       output.NodeIds !== undefined && output.NodeIds !== null
         ? deserializeAws_json1_1NodeIdList(output.NodeIds, context)
         : undefined,
-    RunId: output.RunId !== undefined && output.RunId !== null ? output.RunId : undefined,
+    RunId: __expectString(output.RunId),
   } as any;
 };
 
 const deserializeAws_json1_1S3Encryption = (output: any, context: __SerdeContext): S3Encryption => {
   return {
-    KmsKeyArn: output.KmsKeyArn !== undefined && output.KmsKeyArn !== null ? output.KmsKeyArn : undefined,
-    S3EncryptionMode:
-      output.S3EncryptionMode !== undefined && output.S3EncryptionMode !== null ? output.S3EncryptionMode : undefined,
+    KmsKeyArn: __expectString(output.KmsKeyArn),
+    S3EncryptionMode: __expectString(output.S3EncryptionMode),
   } as any;
 };
 
@@ -23243,14 +23041,13 @@ const deserializeAws_json1_1S3EncryptionList = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1S3Target = (output: any, context: __SerdeContext): S3Target => {
   return {
-    ConnectionName:
-      output.ConnectionName !== undefined && output.ConnectionName !== null ? output.ConnectionName : undefined,
+    ConnectionName: __expectString(output.ConnectionName),
     Exclusions:
       output.Exclusions !== undefined && output.Exclusions !== null
         ? deserializeAws_json1_1PathList(output.Exclusions, context)
         : undefined,
-    Path: output.Path !== undefined && output.Path !== null ? output.Path : undefined,
-    SampleSize: output.SampleSize !== undefined && output.SampleSize !== null ? output.SampleSize : undefined,
+    Path: __expectString(output.Path),
+    SampleSize: __expectNumber(output.SampleSize),
   } as any;
 };
 
@@ -23267,11 +23064,8 @@ const deserializeAws_json1_1S3TargetList = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_1Schedule = (output: any, context: __SerdeContext): Schedule => {
   return {
-    ScheduleExpression:
-      output.ScheduleExpression !== undefined && output.ScheduleExpression !== null
-        ? output.ScheduleExpression
-        : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    ScheduleExpression: __expectString(output.ScheduleExpression),
+    State: __expectString(output.State),
   } as any;
 };
 
@@ -23280,7 +23074,7 @@ const deserializeAws_json1_1SchedulerNotRunningException = (
   context: __SerdeContext
 ): SchedulerNotRunningException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -23289,7 +23083,7 @@ const deserializeAws_json1_1SchedulerRunningException = (
   context: __SerdeContext
 ): SchedulerRunningException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -23298,31 +23092,29 @@ const deserializeAws_json1_1SchedulerTransitioningException = (
   context: __SerdeContext
 ): SchedulerTransitioningException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1SchemaChangePolicy = (output: any, context: __SerdeContext): SchemaChangePolicy => {
   return {
-    DeleteBehavior:
-      output.DeleteBehavior !== undefined && output.DeleteBehavior !== null ? output.DeleteBehavior : undefined,
-    UpdateBehavior:
-      output.UpdateBehavior !== undefined && output.UpdateBehavior !== null ? output.UpdateBehavior : undefined,
+    DeleteBehavior: __expectString(output.DeleteBehavior),
+    UpdateBehavior: __expectString(output.UpdateBehavior),
   } as any;
 };
 
 const deserializeAws_json1_1SchemaColumn = (output: any, context: __SerdeContext): SchemaColumn => {
   return {
-    DataType: output.DataType !== undefined && output.DataType !== null ? output.DataType : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    DataType: __expectString(output.DataType),
+    Name: __expectString(output.Name),
   } as any;
 };
 
 const deserializeAws_json1_1SchemaId = (output: any, context: __SerdeContext): SchemaId => {
   return {
-    RegistryName: output.RegistryName !== undefined && output.RegistryName !== null ? output.RegistryName : undefined,
-    SchemaArn: output.SchemaArn !== undefined && output.SchemaArn !== null ? output.SchemaArn : undefined,
-    SchemaName: output.SchemaName !== undefined && output.SchemaName !== null ? output.SchemaName : undefined,
+    RegistryName: __expectString(output.RegistryName),
+    SchemaArn: __expectString(output.SchemaArn),
+    SchemaName: __expectString(output.SchemaName),
   } as any;
 };
 
@@ -23339,13 +23131,13 @@ const deserializeAws_json1_1SchemaListDefinition = (output: any, context: __Serd
 
 const deserializeAws_json1_1SchemaListItem = (output: any, context: __SerdeContext): SchemaListItem => {
   return {
-    CreatedTime: output.CreatedTime !== undefined && output.CreatedTime !== null ? output.CreatedTime : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    RegistryName: output.RegistryName !== undefined && output.RegistryName !== null ? output.RegistryName : undefined,
-    SchemaArn: output.SchemaArn !== undefined && output.SchemaArn !== null ? output.SchemaArn : undefined,
-    SchemaName: output.SchemaName !== undefined && output.SchemaName !== null ? output.SchemaName : undefined,
-    SchemaStatus: output.SchemaStatus !== undefined && output.SchemaStatus !== null ? output.SchemaStatus : undefined,
-    UpdatedTime: output.UpdatedTime !== undefined && output.UpdatedTime !== null ? output.UpdatedTime : undefined,
+    CreatedTime: __expectString(output.CreatedTime),
+    Description: __expectString(output.Description),
+    RegistryName: __expectString(output.RegistryName),
+    SchemaArn: __expectString(output.SchemaArn),
+    SchemaName: __expectString(output.SchemaName),
+    SchemaStatus: __expectString(output.SchemaStatus),
+    UpdatedTime: __expectString(output.UpdatedTime),
   } as any;
 };
 
@@ -23355,12 +23147,8 @@ const deserializeAws_json1_1SchemaReference = (output: any, context: __SerdeCont
       output.SchemaId !== undefined && output.SchemaId !== null
         ? deserializeAws_json1_1SchemaId(output.SchemaId, context)
         : undefined,
-    SchemaVersionId:
-      output.SchemaVersionId !== undefined && output.SchemaVersionId !== null ? output.SchemaVersionId : undefined,
-    SchemaVersionNumber:
-      output.SchemaVersionNumber !== undefined && output.SchemaVersionNumber !== null
-        ? output.SchemaVersionNumber
-        : undefined,
+    SchemaVersionId: __expectString(output.SchemaVersionId),
+    SchemaVersionNumber: __expectNumber(output.SchemaVersionNumber),
   } as any;
 };
 
@@ -23370,8 +23158,7 @@ const deserializeAws_json1_1SchemaVersionErrorItem = (output: any, context: __Se
       output.ErrorDetails !== undefined && output.ErrorDetails !== null
         ? deserializeAws_json1_1ErrorDetails(output.ErrorDetails, context)
         : undefined,
-    VersionNumber:
-      output.VersionNumber !== undefined && output.VersionNumber !== null ? output.VersionNumber : undefined,
+    VersionNumber: __expectNumber(output.VersionNumber),
   } as any;
 };
 
@@ -23402,19 +23189,17 @@ const deserializeAws_json1_1SchemaVersionList = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1SchemaVersionListItem = (output: any, context: __SerdeContext): SchemaVersionListItem => {
   return {
-    CreatedTime: output.CreatedTime !== undefined && output.CreatedTime !== null ? output.CreatedTime : undefined,
-    SchemaArn: output.SchemaArn !== undefined && output.SchemaArn !== null ? output.SchemaArn : undefined,
-    SchemaVersionId:
-      output.SchemaVersionId !== undefined && output.SchemaVersionId !== null ? output.SchemaVersionId : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    VersionNumber:
-      output.VersionNumber !== undefined && output.VersionNumber !== null ? output.VersionNumber : undefined,
+    CreatedTime: __expectString(output.CreatedTime),
+    SchemaArn: __expectString(output.SchemaArn),
+    SchemaVersionId: __expectString(output.SchemaVersionId),
+    Status: __expectString(output.Status),
+    VersionNumber: __expectNumber(output.VersionNumber),
   } as any;
 };
 
 const deserializeAws_json1_1SearchTablesResponse = (output: any, context: __SerdeContext): SearchTablesResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     TableList:
       output.TableList !== undefined && output.TableList !== null
         ? deserializeAws_json1_1TableList(output.TableList, context)
@@ -23432,7 +23217,7 @@ const deserializeAws_json1_1SecurityConfiguration = (output: any, context: __Ser
       output.EncryptionConfiguration !== undefined && output.EncryptionConfiguration !== null
         ? deserializeAws_json1_1EncryptionConfiguration(output.EncryptionConfiguration, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -23457,21 +23242,18 @@ const deserializeAws_json1_1SecurityGroupIdList = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1SerDeInfo = (output: any, context: __SerdeContext): SerDeInfo => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     Parameters:
       output.Parameters !== undefined && output.Parameters !== null
         ? deserializeAws_json1_1ParametersMap(output.Parameters, context)
         : undefined,
-    SerializationLibrary:
-      output.SerializationLibrary !== undefined && output.SerializationLibrary !== null
-        ? output.SerializationLibrary
-        : undefined,
+    SerializationLibrary: __expectString(output.SerializationLibrary),
   } as any;
 };
 
@@ -23508,7 +23290,7 @@ const deserializeAws_json1_1StartExportLabelsTaskRunResponse = (
   context: __SerdeContext
 ): StartExportLabelsTaskRunResponse => {
   return {
-    TaskRunId: output.TaskRunId !== undefined && output.TaskRunId !== null ? output.TaskRunId : undefined,
+    TaskRunId: __expectString(output.TaskRunId),
   } as any;
 };
 
@@ -23517,13 +23299,13 @@ const deserializeAws_json1_1StartImportLabelsTaskRunResponse = (
   context: __SerdeContext
 ): StartImportLabelsTaskRunResponse => {
   return {
-    TaskRunId: output.TaskRunId !== undefined && output.TaskRunId !== null ? output.TaskRunId : undefined,
+    TaskRunId: __expectString(output.TaskRunId),
   } as any;
 };
 
 const deserializeAws_json1_1StartJobRunResponse = (output: any, context: __SerdeContext): StartJobRunResponse => {
   return {
-    JobRunId: output.JobRunId !== undefined && output.JobRunId !== null ? output.JobRunId : undefined,
+    JobRunId: __expectString(output.JobRunId),
   } as any;
 };
 
@@ -23532,7 +23314,7 @@ const deserializeAws_json1_1StartMLEvaluationTaskRunResponse = (
   context: __SerdeContext
 ): StartMLEvaluationTaskRunResponse => {
   return {
-    TaskRunId: output.TaskRunId !== undefined && output.TaskRunId !== null ? output.TaskRunId : undefined,
+    TaskRunId: __expectString(output.TaskRunId),
   } as any;
 };
 
@@ -23541,13 +23323,13 @@ const deserializeAws_json1_1StartMLLabelingSetGenerationTaskRunResponse = (
   context: __SerdeContext
 ): StartMLLabelingSetGenerationTaskRunResponse => {
   return {
-    TaskRunId: output.TaskRunId !== undefined && output.TaskRunId !== null ? output.TaskRunId : undefined,
+    TaskRunId: __expectString(output.TaskRunId),
   } as any;
 };
 
 const deserializeAws_json1_1StartTriggerResponse = (output: any, context: __SerdeContext): StartTriggerResponse => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -23556,7 +23338,7 @@ const deserializeAws_json1_1StartWorkflowRunResponse = (
   context: __SerdeContext
 ): StartWorkflowRunResponse => {
   return {
-    RunId: output.RunId !== undefined && output.RunId !== null ? output.RunId : undefined,
+    RunId: __expectString(output.RunId),
   } as any;
 };
 
@@ -23573,7 +23355,7 @@ const deserializeAws_json1_1StopCrawlerScheduleResponse = (
 
 const deserializeAws_json1_1StopTriggerResponse = (output: any, context: __SerdeContext): StopTriggerResponse => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -23594,12 +23376,11 @@ const deserializeAws_json1_1StorageDescriptor = (output: any, context: __SerdeCo
       output.Columns !== undefined && output.Columns !== null
         ? deserializeAws_json1_1ColumnList(output.Columns, context)
         : undefined,
-    Compressed: output.Compressed !== undefined && output.Compressed !== null ? output.Compressed : undefined,
-    InputFormat: output.InputFormat !== undefined && output.InputFormat !== null ? output.InputFormat : undefined,
-    Location: output.Location !== undefined && output.Location !== null ? output.Location : undefined,
-    NumberOfBuckets:
-      output.NumberOfBuckets !== undefined && output.NumberOfBuckets !== null ? output.NumberOfBuckets : undefined,
-    OutputFormat: output.OutputFormat !== undefined && output.OutputFormat !== null ? output.OutputFormat : undefined,
+    Compressed: __expectBoolean(output.Compressed),
+    InputFormat: __expectString(output.InputFormat),
+    Location: __expectString(output.Location),
+    NumberOfBuckets: __expectNumber(output.NumberOfBuckets),
+    OutputFormat: __expectString(output.OutputFormat),
     Parameters:
       output.Parameters !== undefined && output.Parameters !== null
         ? deserializeAws_json1_1ParametersMap(output.Parameters, context)
@@ -23620,10 +23401,7 @@ const deserializeAws_json1_1StorageDescriptor = (output: any, context: __SerdeCo
       output.SortColumns !== undefined && output.SortColumns !== null
         ? deserializeAws_json1_1OrderList(output.SortColumns, context)
         : undefined,
-    StoredAsSubDirectories:
-      output.StoredAsSubDirectories !== undefined && output.StoredAsSubDirectories !== null
-        ? output.StoredAsSubDirectories
-        : undefined,
+    StoredAsSubDirectories: __expectBoolean(output.StoredAsSubDirectories),
   } as any;
 };
 
@@ -23632,16 +23410,10 @@ const deserializeAws_json1_1StringColumnStatisticsData = (
   context: __SerdeContext
 ): StringColumnStatisticsData => {
   return {
-    AverageLength:
-      output.AverageLength !== undefined && output.AverageLength !== null ? output.AverageLength : undefined,
-    MaximumLength:
-      output.MaximumLength !== undefined && output.MaximumLength !== null ? output.MaximumLength : undefined,
-    NumberOfDistinctValues:
-      output.NumberOfDistinctValues !== undefined && output.NumberOfDistinctValues !== null
-        ? output.NumberOfDistinctValues
-        : undefined,
-    NumberOfNulls:
-      output.NumberOfNulls !== undefined && output.NumberOfNulls !== null ? output.NumberOfNulls : undefined,
+    AverageLength: __expectNumber(output.AverageLength),
+    MaximumLength: __expectNumber(output.MaximumLength),
+    NumberOfDistinctValues: __expectNumber(output.NumberOfDistinctValues),
+    NumberOfNulls: __expectNumber(output.NumberOfNulls),
   } as any;
 };
 
@@ -23652,24 +23424,21 @@ const deserializeAws_json1_1StringList = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1Table = (output: any, context: __SerdeContext): Table => {
   return {
-    CatalogId: output.CatalogId !== undefined && output.CatalogId !== null ? output.CatalogId : undefined,
+    CatalogId: __expectString(output.CatalogId),
     CreateTime:
       output.CreateTime !== undefined && output.CreateTime !== null
         ? new Date(Math.round(output.CreateTime * 1000))
         : undefined,
-    CreatedBy: output.CreatedBy !== undefined && output.CreatedBy !== null ? output.CreatedBy : undefined,
-    DatabaseName: output.DatabaseName !== undefined && output.DatabaseName !== null ? output.DatabaseName : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    IsRegisteredWithLakeFormation:
-      output.IsRegisteredWithLakeFormation !== undefined && output.IsRegisteredWithLakeFormation !== null
-        ? output.IsRegisteredWithLakeFormation
-        : undefined,
+    CreatedBy: __expectString(output.CreatedBy),
+    DatabaseName: __expectString(output.DatabaseName),
+    Description: __expectString(output.Description),
+    IsRegisteredWithLakeFormation: __expectBoolean(output.IsRegisteredWithLakeFormation),
     LastAccessTime:
       output.LastAccessTime !== undefined && output.LastAccessTime !== null
         ? new Date(Math.round(output.LastAccessTime * 1000))
@@ -23678,8 +23447,8 @@ const deserializeAws_json1_1Table = (output: any, context: __SerdeContext): Tabl
       output.LastAnalyzedTime !== undefined && output.LastAnalyzedTime !== null
         ? new Date(Math.round(output.LastAnalyzedTime * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Owner: output.Owner !== undefined && output.Owner !== null ? output.Owner : undefined,
+    Name: __expectString(output.Name),
+    Owner: __expectString(output.Owner),
     Parameters:
       output.Parameters !== undefined && output.Parameters !== null
         ? deserializeAws_json1_1ParametersMap(output.Parameters, context)
@@ -23688,12 +23457,12 @@ const deserializeAws_json1_1Table = (output: any, context: __SerdeContext): Tabl
       output.PartitionKeys !== undefined && output.PartitionKeys !== null
         ? deserializeAws_json1_1ColumnList(output.PartitionKeys, context)
         : undefined,
-    Retention: output.Retention !== undefined && output.Retention !== null ? output.Retention : undefined,
+    Retention: __expectNumber(output.Retention),
     StorageDescriptor:
       output.StorageDescriptor !== undefined && output.StorageDescriptor !== null
         ? deserializeAws_json1_1StorageDescriptor(output.StorageDescriptor, context)
         : undefined,
-    TableType: output.TableType !== undefined && output.TableType !== null ? output.TableType : undefined,
+    TableType: __expectString(output.TableType),
     TargetTable:
       output.TargetTable !== undefined && output.TargetTable !== null
         ? deserializeAws_json1_1TableIdentifier(output.TargetTable, context)
@@ -23702,10 +23471,8 @@ const deserializeAws_json1_1Table = (output: any, context: __SerdeContext): Tabl
       output.UpdateTime !== undefined && output.UpdateTime !== null
         ? new Date(Math.round(output.UpdateTime * 1000))
         : undefined,
-    ViewExpandedText:
-      output.ViewExpandedText !== undefined && output.ViewExpandedText !== null ? output.ViewExpandedText : undefined,
-    ViewOriginalText:
-      output.ViewOriginalText !== undefined && output.ViewOriginalText !== null ? output.ViewOriginalText : undefined,
+    ViewExpandedText: __expectString(output.ViewExpandedText),
+    ViewOriginalText: __expectString(output.ViewOriginalText),
   } as any;
 };
 
@@ -23715,7 +23482,7 @@ const deserializeAws_json1_1TableError = (output: any, context: __SerdeContext):
       output.ErrorDetail !== undefined && output.ErrorDetail !== null
         ? deserializeAws_json1_1ErrorDetail(output.ErrorDetail, context)
         : undefined,
-    TableName: output.TableName !== undefined && output.TableName !== null ? output.TableName : undefined,
+    TableName: __expectString(output.TableName),
   } as any;
 };
 
@@ -23732,9 +23499,9 @@ const deserializeAws_json1_1TableErrors = (output: any, context: __SerdeContext)
 
 const deserializeAws_json1_1TableIdentifier = (output: any, context: __SerdeContext): TableIdentifier => {
   return {
-    CatalogId: output.CatalogId !== undefined && output.CatalogId !== null ? output.CatalogId : undefined,
-    DatabaseName: output.DatabaseName !== undefined && output.DatabaseName !== null ? output.DatabaseName : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    CatalogId: __expectString(output.CatalogId),
+    DatabaseName: __expectString(output.DatabaseName),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -23755,7 +23522,7 @@ const deserializeAws_json1_1TableVersion = (output: any, context: __SerdeContext
       output.Table !== undefined && output.Table !== null
         ? deserializeAws_json1_1Table(output.Table, context)
         : undefined,
-    VersionId: output.VersionId !== undefined && output.VersionId !== null ? output.VersionId : undefined,
+    VersionId: __expectString(output.VersionId),
   } as any;
 };
 
@@ -23765,8 +23532,8 @@ const deserializeAws_json1_1TableVersionError = (output: any, context: __SerdeCo
       output.ErrorDetail !== undefined && output.ErrorDetail !== null
         ? deserializeAws_json1_1ErrorDetail(output.ErrorDetail, context)
         : undefined,
-    TableName: output.TableName !== undefined && output.TableName !== null ? output.TableName : undefined,
-    VersionId: output.VersionId !== undefined && output.VersionId !== null ? output.VersionId : undefined,
+    TableName: __expectString(output.TableName),
+    VersionId: __expectString(output.VersionId),
   } as any;
 };
 
@@ -23792,7 +23559,7 @@ const deserializeAws_json1_1TagsMap = (output: any, context: __SerdeContext): { 
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -23803,14 +23570,13 @@ const deserializeAws_json1_1TaskRun = (output: any, context: __SerdeContext): Ta
       output.CompletedOn !== undefined && output.CompletedOn !== null
         ? new Date(Math.round(output.CompletedOn * 1000))
         : undefined,
-    ErrorString: output.ErrorString !== undefined && output.ErrorString !== null ? output.ErrorString : undefined,
-    ExecutionTime:
-      output.ExecutionTime !== undefined && output.ExecutionTime !== null ? output.ExecutionTime : undefined,
+    ErrorString: __expectString(output.ErrorString),
+    ExecutionTime: __expectNumber(output.ExecutionTime),
     LastModifiedOn:
       output.LastModifiedOn !== undefined && output.LastModifiedOn !== null
         ? new Date(Math.round(output.LastModifiedOn * 1000))
         : undefined,
-    LogGroupName: output.LogGroupName !== undefined && output.LogGroupName !== null ? output.LogGroupName : undefined,
+    LogGroupName: __expectString(output.LogGroupName),
     Properties:
       output.Properties !== undefined && output.Properties !== null
         ? deserializeAws_json1_1TaskRunProperties(output.Properties, context)
@@ -23819,9 +23585,9 @@ const deserializeAws_json1_1TaskRun = (output: any, context: __SerdeContext): Ta
       output.StartedOn !== undefined && output.StartedOn !== null
         ? new Date(Math.round(output.StartedOn * 1000))
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    TaskRunId: output.TaskRunId !== undefined && output.TaskRunId !== null ? output.TaskRunId : undefined,
-    TransformId: output.TransformId !== undefined && output.TransformId !== null ? output.TransformId : undefined,
+    Status: __expectString(output.Status),
+    TaskRunId: __expectString(output.TaskRunId),
+    TransformId: __expectString(output.TransformId),
   } as any;
 };
 
@@ -23858,7 +23624,7 @@ const deserializeAws_json1_1TaskRunProperties = (output: any, context: __SerdeCo
             context
           )
         : undefined,
-    TaskType: output.TaskType !== undefined && output.TaskType !== null ? output.TaskType : undefined,
+    TaskType: __expectString(output.TaskType),
   } as any;
 };
 
@@ -23868,10 +23634,7 @@ const deserializeAws_json1_1TransformEncryption = (output: any, context: __Serde
       output.MlUserDataEncryption !== undefined && output.MlUserDataEncryption !== null
         ? deserializeAws_json1_1MLUserDataEncryption(output.MlUserDataEncryption, context)
         : undefined,
-    TaskRunSecurityConfigurationName:
-      output.TaskRunSecurityConfigurationName !== undefined && output.TaskRunSecurityConfigurationName !== null
-        ? output.TaskRunSecurityConfigurationName
-        : undefined,
+    TaskRunSecurityConfigurationName: __expectString(output.TaskRunSecurityConfigurationName),
   } as any;
 };
 
@@ -23882,7 +23645,7 @@ const deserializeAws_json1_1TransformIdList = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -23903,8 +23666,7 @@ const deserializeAws_json1_1TransformParameters = (output: any, context: __Serde
       output.FindMatchesParameters !== undefined && output.FindMatchesParameters !== null
         ? deserializeAws_json1_1FindMatchesParameters(output.FindMatchesParameters, context)
         : undefined,
-    TransformType:
-      output.TransformType !== undefined && output.TransformType !== null ? output.TransformType : undefined,
+    TransformType: __expectString(output.TransformType),
   } as any;
 };
 
@@ -23925,17 +23687,17 @@ const deserializeAws_json1_1Trigger = (output: any, context: __SerdeContext): Tr
       output.Actions !== undefined && output.Actions !== null
         ? deserializeAws_json1_1ActionList(output.Actions, context)
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Description: __expectString(output.Description),
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
     Predicate:
       output.Predicate !== undefined && output.Predicate !== null
         ? deserializeAws_json1_1Predicate(output.Predicate, context)
         : undefined,
-    Schedule: output.Schedule !== undefined && output.Schedule !== null ? output.Schedule : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    WorkflowName: output.WorkflowName !== undefined && output.WorkflowName !== null ? output.WorkflowName : undefined,
+    Schedule: __expectString(output.Schedule),
+    State: __expectString(output.State),
+    Type: __expectString(output.Type),
+    WorkflowName: __expectString(output.WorkflowName),
   } as any;
 };
 
@@ -23957,7 +23719,7 @@ const deserializeAws_json1_1TriggerNameList = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -24036,7 +23798,7 @@ const deserializeAws_json1_1UpdateDevEndpointResponse = (
 
 const deserializeAws_json1_1UpdateJobResponse = (output: any, context: __SerdeContext): UpdateJobResponse => {
   return {
-    JobName: output.JobName !== undefined && output.JobName !== null ? output.JobName : undefined,
+    JobName: __expectString(output.JobName),
   } as any;
 };
 
@@ -24045,7 +23807,7 @@ const deserializeAws_json1_1UpdateMLTransformResponse = (
   context: __SerdeContext
 ): UpdateMLTransformResponse => {
   return {
-    TransformId: output.TransformId !== undefined && output.TransformId !== null ? output.TransformId : undefined,
+    TransformId: __expectString(output.TransformId),
   } as any;
 };
 
@@ -24058,16 +23820,16 @@ const deserializeAws_json1_1UpdatePartitionResponse = (
 
 const deserializeAws_json1_1UpdateRegistryResponse = (output: any, context: __SerdeContext): UpdateRegistryResponse => {
   return {
-    RegistryArn: output.RegistryArn !== undefined && output.RegistryArn !== null ? output.RegistryArn : undefined,
-    RegistryName: output.RegistryName !== undefined && output.RegistryName !== null ? output.RegistryName : undefined,
+    RegistryArn: __expectString(output.RegistryArn),
+    RegistryName: __expectString(output.RegistryName),
   } as any;
 };
 
 const deserializeAws_json1_1UpdateSchemaResponse = (output: any, context: __SerdeContext): UpdateSchemaResponse => {
   return {
-    RegistryName: output.RegistryName !== undefined && output.RegistryName !== null ? output.RegistryName : undefined,
-    SchemaArn: output.SchemaArn !== undefined && output.SchemaArn !== null ? output.SchemaArn : undefined,
-    SchemaName: output.SchemaName !== undefined && output.SchemaName !== null ? output.SchemaName : undefined,
+    RegistryName: __expectString(output.RegistryName),
+    SchemaArn: __expectString(output.SchemaArn),
+    SchemaName: __expectString(output.SchemaName),
   } as any;
 };
 
@@ -24093,22 +23855,22 @@ const deserializeAws_json1_1UpdateUserDefinedFunctionResponse = (
 
 const deserializeAws_json1_1UpdateWorkflowResponse = (output: any, context: __SerdeContext): UpdateWorkflowResponse => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
 const deserializeAws_json1_1UserDefinedFunction = (output: any, context: __SerdeContext): UserDefinedFunction => {
   return {
-    CatalogId: output.CatalogId !== undefined && output.CatalogId !== null ? output.CatalogId : undefined,
-    ClassName: output.ClassName !== undefined && output.ClassName !== null ? output.ClassName : undefined,
+    CatalogId: __expectString(output.CatalogId),
+    ClassName: __expectString(output.ClassName),
     CreateTime:
       output.CreateTime !== undefined && output.CreateTime !== null
         ? new Date(Math.round(output.CreateTime * 1000))
         : undefined,
-    DatabaseName: output.DatabaseName !== undefined && output.DatabaseName !== null ? output.DatabaseName : undefined,
-    FunctionName: output.FunctionName !== undefined && output.FunctionName !== null ? output.FunctionName : undefined,
-    OwnerName: output.OwnerName !== undefined && output.OwnerName !== null ? output.OwnerName : undefined,
-    OwnerType: output.OwnerType !== undefined && output.OwnerType !== null ? output.OwnerType : undefined,
+    DatabaseName: __expectString(output.DatabaseName),
+    FunctionName: __expectString(output.FunctionName),
+    OwnerName: __expectString(output.OwnerName),
+    OwnerType: __expectString(output.OwnerType),
     ResourceUris:
       output.ResourceUris !== undefined && output.ResourceUris !== null
         ? deserializeAws_json1_1ResourceUriList(output.ResourceUris, context)
@@ -24129,7 +23891,7 @@ const deserializeAws_json1_1UserDefinedFunctionList = (output: any, context: __S
 
 const deserializeAws_json1_1ValidationException = (output: any, context: __SerdeContext): ValidationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -24140,7 +23902,7 @@ const deserializeAws_json1_1ValueStringList = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -24149,7 +23911,7 @@ const deserializeAws_json1_1VersionMismatchException = (
   context: __SerdeContext
 ): VersionMismatchException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -24163,7 +23925,7 @@ const deserializeAws_json1_1Workflow = (output: any, context: __SerdeContext): W
       output.DefaultRunProperties !== undefined && output.DefaultRunProperties !== null
         ? deserializeAws_json1_1WorkflowRunProperties(output.DefaultRunProperties, context)
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     Graph:
       output.Graph !== undefined && output.Graph !== null
         ? deserializeAws_json1_1WorkflowGraph(output.Graph, context)
@@ -24176,11 +23938,8 @@ const deserializeAws_json1_1Workflow = (output: any, context: __SerdeContext): W
       output.LastRun !== undefined && output.LastRun !== null
         ? deserializeAws_json1_1WorkflowRun(output.LastRun, context)
         : undefined,
-    MaxConcurrentRuns:
-      output.MaxConcurrentRuns !== undefined && output.MaxConcurrentRuns !== null
-        ? output.MaxConcurrentRuns
-        : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    MaxConcurrentRuns: __expectNumber(output.MaxConcurrentRuns),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -24204,7 +23963,7 @@ const deserializeAws_json1_1WorkflowNames = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -24214,14 +23973,13 @@ const deserializeAws_json1_1WorkflowRun = (output: any, context: __SerdeContext)
       output.CompletedOn !== undefined && output.CompletedOn !== null
         ? new Date(Math.round(output.CompletedOn * 1000))
         : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
+    ErrorMessage: __expectString(output.ErrorMessage),
     Graph:
       output.Graph !== undefined && output.Graph !== null
         ? deserializeAws_json1_1WorkflowGraph(output.Graph, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    PreviousRunId:
-      output.PreviousRunId !== undefined && output.PreviousRunId !== null ? output.PreviousRunId : undefined,
+    Name: __expectString(output.Name),
+    PreviousRunId: __expectString(output.PreviousRunId),
     StartedOn:
       output.StartedOn !== undefined && output.StartedOn !== null
         ? new Date(Math.round(output.StartedOn * 1000))
@@ -24230,9 +23988,8 @@ const deserializeAws_json1_1WorkflowRun = (output: any, context: __SerdeContext)
       output.Statistics !== undefined && output.Statistics !== null
         ? deserializeAws_json1_1WorkflowRunStatistics(output.Statistics, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    WorkflowRunId:
-      output.WorkflowRunId !== undefined && output.WorkflowRunId !== null ? output.WorkflowRunId : undefined,
+    Status: __expectString(output.Status),
+    WorkflowRunId: __expectString(output.WorkflowRunId),
     WorkflowRunProperties:
       output.WorkflowRunProperties !== undefined && output.WorkflowRunProperties !== null
         ? deserializeAws_json1_1WorkflowRunProperties(output.WorkflowRunProperties, context)
@@ -24250,7 +24007,7 @@ const deserializeAws_json1_1WorkflowRunProperties = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -24268,17 +24025,12 @@ const deserializeAws_json1_1WorkflowRuns = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_1WorkflowRunStatistics = (output: any, context: __SerdeContext): WorkflowRunStatistics => {
   return {
-    FailedActions:
-      output.FailedActions !== undefined && output.FailedActions !== null ? output.FailedActions : undefined,
-    RunningActions:
-      output.RunningActions !== undefined && output.RunningActions !== null ? output.RunningActions : undefined,
-    StoppedActions:
-      output.StoppedActions !== undefined && output.StoppedActions !== null ? output.StoppedActions : undefined,
-    SucceededActions:
-      output.SucceededActions !== undefined && output.SucceededActions !== null ? output.SucceededActions : undefined,
-    TimeoutActions:
-      output.TimeoutActions !== undefined && output.TimeoutActions !== null ? output.TimeoutActions : undefined,
-    TotalActions: output.TotalActions !== undefined && output.TotalActions !== null ? output.TotalActions : undefined,
+    FailedActions: __expectNumber(output.FailedActions),
+    RunningActions: __expectNumber(output.RunningActions),
+    StoppedActions: __expectNumber(output.StoppedActions),
+    SucceededActions: __expectNumber(output.SucceededActions),
+    TimeoutActions: __expectNumber(output.TimeoutActions),
+    TotalActions: __expectNumber(output.TotalActions),
   } as any;
 };
 
@@ -24295,8 +24047,7 @@ const deserializeAws_json1_1Workflows = (output: any, context: __SerdeContext): 
 
 const deserializeAws_json1_1XMLClassifier = (output: any, context: __SerdeContext): XMLClassifier => {
   return {
-    Classification:
-      output.Classification !== undefined && output.Classification !== null ? output.Classification : undefined,
+    Classification: __expectString(output.Classification),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -24305,9 +24056,9 @@ const deserializeAws_json1_1XMLClassifier = (output: any, context: __SerdeContex
       output.LastUpdated !== undefined && output.LastUpdated !== null
         ? new Date(Math.round(output.LastUpdated * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    RowTag: output.RowTag !== undefined && output.RowTag !== null ? output.RowTag : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    Name: __expectString(output.Name),
+    RowTag: __expectString(output.RowTag),
+    Version: __expectNumber(output.Version),
   } as any;
 };
 

--- a/clients/client-greengrass/protocols/Aws_restJson1.ts
+++ b/clients/client-greengrass/protocols/Aws_restJson1.ts
@@ -368,6 +368,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -3285,7 +3288,7 @@ export const deserializeAws_restJson1AssociateRoleToGroupCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AssociatedAt !== undefined && data.AssociatedAt !== null) {
-    contents.AssociatedAt = data.AssociatedAt;
+    contents.AssociatedAt = __expectString(data.AssociatedAt);
   }
   return Promise.resolve(contents);
 };
@@ -3348,7 +3351,7 @@ export const deserializeAws_restJson1AssociateServiceRoleToAccountCommand = asyn
   };
   const data: any = await parseBody(output.body, context);
   if (data.AssociatedAt !== undefined && data.AssociatedAt !== null) {
-    contents.AssociatedAt = data.AssociatedAt;
+    contents.AssociatedAt = __expectString(data.AssociatedAt);
   }
   return Promise.resolve(contents);
 };
@@ -3417,25 +3420,25 @@ export const deserializeAws_restJson1CreateConnectorDefinitionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationTimestamp !== undefined && data.CreationTimestamp !== null) {
-    contents.CreationTimestamp = data.CreationTimestamp;
+    contents.CreationTimestamp = __expectString(data.CreationTimestamp);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.LastUpdatedTimestamp !== undefined && data.LastUpdatedTimestamp !== null) {
-    contents.LastUpdatedTimestamp = data.LastUpdatedTimestamp;
+    contents.LastUpdatedTimestamp = __expectString(data.LastUpdatedTimestamp);
   }
   if (data.LatestVersion !== undefined && data.LatestVersion !== null) {
-    contents.LatestVersion = data.LatestVersion;
+    contents.LatestVersion = __expectString(data.LatestVersion);
   }
   if (data.LatestVersionArn !== undefined && data.LatestVersionArn !== null) {
-    contents.LatestVersionArn = data.LatestVersionArn;
+    contents.LatestVersionArn = __expectString(data.LatestVersionArn);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   return Promise.resolve(contents);
 };
@@ -3493,16 +3496,16 @@ export const deserializeAws_restJson1CreateConnectorDefinitionVersionCommand = a
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationTimestamp !== undefined && data.CreationTimestamp !== null) {
-    contents.CreationTimestamp = data.CreationTimestamp;
+    contents.CreationTimestamp = __expectString(data.CreationTimestamp);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.Version !== undefined && data.Version !== null) {
-    contents.Version = data.Version;
+    contents.Version = __expectString(data.Version);
   }
   return Promise.resolve(contents);
 };
@@ -3563,25 +3566,25 @@ export const deserializeAws_restJson1CreateCoreDefinitionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationTimestamp !== undefined && data.CreationTimestamp !== null) {
-    contents.CreationTimestamp = data.CreationTimestamp;
+    contents.CreationTimestamp = __expectString(data.CreationTimestamp);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.LastUpdatedTimestamp !== undefined && data.LastUpdatedTimestamp !== null) {
-    contents.LastUpdatedTimestamp = data.LastUpdatedTimestamp;
+    contents.LastUpdatedTimestamp = __expectString(data.LastUpdatedTimestamp);
   }
   if (data.LatestVersion !== undefined && data.LatestVersion !== null) {
-    contents.LatestVersion = data.LatestVersion;
+    contents.LatestVersion = __expectString(data.LatestVersion);
   }
   if (data.LatestVersionArn !== undefined && data.LatestVersionArn !== null) {
-    contents.LatestVersionArn = data.LatestVersionArn;
+    contents.LatestVersionArn = __expectString(data.LatestVersionArn);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   return Promise.resolve(contents);
 };
@@ -3639,16 +3642,16 @@ export const deserializeAws_restJson1CreateCoreDefinitionVersionCommand = async 
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationTimestamp !== undefined && data.CreationTimestamp !== null) {
-    contents.CreationTimestamp = data.CreationTimestamp;
+    contents.CreationTimestamp = __expectString(data.CreationTimestamp);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.Version !== undefined && data.Version !== null) {
-    contents.Version = data.Version;
+    contents.Version = __expectString(data.Version);
   }
   return Promise.resolve(contents);
 };
@@ -3704,10 +3707,10 @@ export const deserializeAws_restJson1CreateDeploymentCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.DeploymentArn !== undefined && data.DeploymentArn !== null) {
-    contents.DeploymentArn = data.DeploymentArn;
+    contents.DeploymentArn = __expectString(data.DeploymentArn);
   }
   if (data.DeploymentId !== undefined && data.DeploymentId !== null) {
-    contents.DeploymentId = data.DeploymentId;
+    contents.DeploymentId = __expectString(data.DeploymentId);
   }
   return Promise.resolve(contents);
 };
@@ -3768,25 +3771,25 @@ export const deserializeAws_restJson1CreateDeviceDefinitionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationTimestamp !== undefined && data.CreationTimestamp !== null) {
-    contents.CreationTimestamp = data.CreationTimestamp;
+    contents.CreationTimestamp = __expectString(data.CreationTimestamp);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.LastUpdatedTimestamp !== undefined && data.LastUpdatedTimestamp !== null) {
-    contents.LastUpdatedTimestamp = data.LastUpdatedTimestamp;
+    contents.LastUpdatedTimestamp = __expectString(data.LastUpdatedTimestamp);
   }
   if (data.LatestVersion !== undefined && data.LatestVersion !== null) {
-    contents.LatestVersion = data.LatestVersion;
+    contents.LatestVersion = __expectString(data.LatestVersion);
   }
   if (data.LatestVersionArn !== undefined && data.LatestVersionArn !== null) {
-    contents.LatestVersionArn = data.LatestVersionArn;
+    contents.LatestVersionArn = __expectString(data.LatestVersionArn);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   return Promise.resolve(contents);
 };
@@ -3844,16 +3847,16 @@ export const deserializeAws_restJson1CreateDeviceDefinitionVersionCommand = asyn
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationTimestamp !== undefined && data.CreationTimestamp !== null) {
-    contents.CreationTimestamp = data.CreationTimestamp;
+    contents.CreationTimestamp = __expectString(data.CreationTimestamp);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.Version !== undefined && data.Version !== null) {
-    contents.Version = data.Version;
+    contents.Version = __expectString(data.Version);
   }
   return Promise.resolve(contents);
 };
@@ -3914,25 +3917,25 @@ export const deserializeAws_restJson1CreateFunctionDefinitionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationTimestamp !== undefined && data.CreationTimestamp !== null) {
-    contents.CreationTimestamp = data.CreationTimestamp;
+    contents.CreationTimestamp = __expectString(data.CreationTimestamp);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.LastUpdatedTimestamp !== undefined && data.LastUpdatedTimestamp !== null) {
-    contents.LastUpdatedTimestamp = data.LastUpdatedTimestamp;
+    contents.LastUpdatedTimestamp = __expectString(data.LastUpdatedTimestamp);
   }
   if (data.LatestVersion !== undefined && data.LatestVersion !== null) {
-    contents.LatestVersion = data.LatestVersion;
+    contents.LatestVersion = __expectString(data.LatestVersion);
   }
   if (data.LatestVersionArn !== undefined && data.LatestVersionArn !== null) {
-    contents.LatestVersionArn = data.LatestVersionArn;
+    contents.LatestVersionArn = __expectString(data.LatestVersionArn);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   return Promise.resolve(contents);
 };
@@ -3990,16 +3993,16 @@ export const deserializeAws_restJson1CreateFunctionDefinitionVersionCommand = as
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationTimestamp !== undefined && data.CreationTimestamp !== null) {
-    contents.CreationTimestamp = data.CreationTimestamp;
+    contents.CreationTimestamp = __expectString(data.CreationTimestamp);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.Version !== undefined && data.Version !== null) {
-    contents.Version = data.Version;
+    contents.Version = __expectString(data.Version);
   }
   return Promise.resolve(contents);
 };
@@ -4060,25 +4063,25 @@ export const deserializeAws_restJson1CreateGroupCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationTimestamp !== undefined && data.CreationTimestamp !== null) {
-    contents.CreationTimestamp = data.CreationTimestamp;
+    contents.CreationTimestamp = __expectString(data.CreationTimestamp);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.LastUpdatedTimestamp !== undefined && data.LastUpdatedTimestamp !== null) {
-    contents.LastUpdatedTimestamp = data.LastUpdatedTimestamp;
+    contents.LastUpdatedTimestamp = __expectString(data.LastUpdatedTimestamp);
   }
   if (data.LatestVersion !== undefined && data.LatestVersion !== null) {
-    contents.LatestVersion = data.LatestVersion;
+    contents.LatestVersion = __expectString(data.LatestVersion);
   }
   if (data.LatestVersionArn !== undefined && data.LatestVersionArn !== null) {
-    contents.LatestVersionArn = data.LatestVersionArn;
+    contents.LatestVersionArn = __expectString(data.LatestVersionArn);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   return Promise.resolve(contents);
 };
@@ -4133,7 +4136,7 @@ export const deserializeAws_restJson1CreateGroupCertificateAuthorityCommand = as
   };
   const data: any = await parseBody(output.body, context);
   if (data.GroupCertificateAuthorityArn !== undefined && data.GroupCertificateAuthorityArn !== null) {
-    contents.GroupCertificateAuthorityArn = data.GroupCertificateAuthorityArn;
+    contents.GroupCertificateAuthorityArn = __expectString(data.GroupCertificateAuthorityArn);
   }
   return Promise.resolve(contents);
 };
@@ -4199,16 +4202,16 @@ export const deserializeAws_restJson1CreateGroupVersionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationTimestamp !== undefined && data.CreationTimestamp !== null) {
-    contents.CreationTimestamp = data.CreationTimestamp;
+    contents.CreationTimestamp = __expectString(data.CreationTimestamp);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.Version !== undefined && data.Version !== null) {
-    contents.Version = data.Version;
+    contents.Version = __expectString(data.Version);
   }
   return Promise.resolve(contents);
 };
@@ -4269,25 +4272,25 @@ export const deserializeAws_restJson1CreateLoggerDefinitionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationTimestamp !== undefined && data.CreationTimestamp !== null) {
-    contents.CreationTimestamp = data.CreationTimestamp;
+    contents.CreationTimestamp = __expectString(data.CreationTimestamp);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.LastUpdatedTimestamp !== undefined && data.LastUpdatedTimestamp !== null) {
-    contents.LastUpdatedTimestamp = data.LastUpdatedTimestamp;
+    contents.LastUpdatedTimestamp = __expectString(data.LastUpdatedTimestamp);
   }
   if (data.LatestVersion !== undefined && data.LatestVersion !== null) {
-    contents.LatestVersion = data.LatestVersion;
+    contents.LatestVersion = __expectString(data.LatestVersion);
   }
   if (data.LatestVersionArn !== undefined && data.LatestVersionArn !== null) {
-    contents.LatestVersionArn = data.LatestVersionArn;
+    contents.LatestVersionArn = __expectString(data.LatestVersionArn);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   return Promise.resolve(contents);
 };
@@ -4345,16 +4348,16 @@ export const deserializeAws_restJson1CreateLoggerDefinitionVersionCommand = asyn
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationTimestamp !== undefined && data.CreationTimestamp !== null) {
-    contents.CreationTimestamp = data.CreationTimestamp;
+    contents.CreationTimestamp = __expectString(data.CreationTimestamp);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.Version !== undefined && data.Version !== null) {
-    contents.Version = data.Version;
+    contents.Version = __expectString(data.Version);
   }
   return Promise.resolve(contents);
 };
@@ -4415,25 +4418,25 @@ export const deserializeAws_restJson1CreateResourceDefinitionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationTimestamp !== undefined && data.CreationTimestamp !== null) {
-    contents.CreationTimestamp = data.CreationTimestamp;
+    contents.CreationTimestamp = __expectString(data.CreationTimestamp);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.LastUpdatedTimestamp !== undefined && data.LastUpdatedTimestamp !== null) {
-    contents.LastUpdatedTimestamp = data.LastUpdatedTimestamp;
+    contents.LastUpdatedTimestamp = __expectString(data.LastUpdatedTimestamp);
   }
   if (data.LatestVersion !== undefined && data.LatestVersion !== null) {
-    contents.LatestVersion = data.LatestVersion;
+    contents.LatestVersion = __expectString(data.LatestVersion);
   }
   if (data.LatestVersionArn !== undefined && data.LatestVersionArn !== null) {
-    contents.LatestVersionArn = data.LatestVersionArn;
+    contents.LatestVersionArn = __expectString(data.LatestVersionArn);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   return Promise.resolve(contents);
 };
@@ -4491,16 +4494,16 @@ export const deserializeAws_restJson1CreateResourceDefinitionVersionCommand = as
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationTimestamp !== undefined && data.CreationTimestamp !== null) {
-    contents.CreationTimestamp = data.CreationTimestamp;
+    contents.CreationTimestamp = __expectString(data.CreationTimestamp);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.Version !== undefined && data.Version !== null) {
-    contents.Version = data.Version;
+    contents.Version = __expectString(data.Version);
   }
   return Promise.resolve(contents);
 };
@@ -4557,13 +4560,13 @@ export const deserializeAws_restJson1CreateSoftwareUpdateJobCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.IotJobArn !== undefined && data.IotJobArn !== null) {
-    contents.IotJobArn = data.IotJobArn;
+    contents.IotJobArn = __expectString(data.IotJobArn);
   }
   if (data.IotJobId !== undefined && data.IotJobId !== null) {
-    contents.IotJobId = data.IotJobId;
+    contents.IotJobId = __expectString(data.IotJobId);
   }
   if (data.PlatformSoftwareVersion !== undefined && data.PlatformSoftwareVersion !== null) {
-    contents.PlatformSoftwareVersion = data.PlatformSoftwareVersion;
+    contents.PlatformSoftwareVersion = __expectString(data.PlatformSoftwareVersion);
   }
   return Promise.resolve(contents);
 };
@@ -4632,25 +4635,25 @@ export const deserializeAws_restJson1CreateSubscriptionDefinitionCommand = async
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationTimestamp !== undefined && data.CreationTimestamp !== null) {
-    contents.CreationTimestamp = data.CreationTimestamp;
+    contents.CreationTimestamp = __expectString(data.CreationTimestamp);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.LastUpdatedTimestamp !== undefined && data.LastUpdatedTimestamp !== null) {
-    contents.LastUpdatedTimestamp = data.LastUpdatedTimestamp;
+    contents.LastUpdatedTimestamp = __expectString(data.LastUpdatedTimestamp);
   }
   if (data.LatestVersion !== undefined && data.LatestVersion !== null) {
-    contents.LatestVersion = data.LatestVersion;
+    contents.LatestVersion = __expectString(data.LatestVersion);
   }
   if (data.LatestVersionArn !== undefined && data.LatestVersionArn !== null) {
-    contents.LatestVersionArn = data.LatestVersionArn;
+    contents.LatestVersionArn = __expectString(data.LatestVersionArn);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   return Promise.resolve(contents);
 };
@@ -4708,16 +4711,16 @@ export const deserializeAws_restJson1CreateSubscriptionDefinitionVersionCommand 
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationTimestamp !== undefined && data.CreationTimestamp !== null) {
-    contents.CreationTimestamp = data.CreationTimestamp;
+    contents.CreationTimestamp = __expectString(data.CreationTimestamp);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.Version !== undefined && data.Version !== null) {
-    contents.Version = data.Version;
+    contents.Version = __expectString(data.Version);
   }
   return Promise.resolve(contents);
 };
@@ -5180,7 +5183,7 @@ export const deserializeAws_restJson1DisassociateRoleFromGroupCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.DisassociatedAt !== undefined && data.DisassociatedAt !== null) {
-    contents.DisassociatedAt = data.DisassociatedAt;
+    contents.DisassociatedAt = __expectString(data.DisassociatedAt);
   }
   return Promise.resolve(contents);
 };
@@ -5243,7 +5246,7 @@ export const deserializeAws_restJson1DisassociateServiceRoleFromAccountCommand =
   };
   const data: any = await parseBody(output.body, context);
   if (data.DisassociatedAt !== undefined && data.DisassociatedAt !== null) {
-    contents.DisassociatedAt = data.DisassociatedAt;
+    contents.DisassociatedAt = __expectString(data.DisassociatedAt);
   }
   return Promise.resolve(contents);
 };
@@ -5299,10 +5302,10 @@ export const deserializeAws_restJson1GetAssociatedRoleCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AssociatedAt !== undefined && data.AssociatedAt !== null) {
-    contents.AssociatedAt = data.AssociatedAt;
+    contents.AssociatedAt = __expectString(data.AssociatedAt);
   }
   if (data.RoleArn !== undefined && data.RoleArn !== null) {
-    contents.RoleArn = data.RoleArn;
+    contents.RoleArn = __expectString(data.RoleArn);
   }
   return Promise.resolve(contents);
 };
@@ -5373,16 +5376,16 @@ export const deserializeAws_restJson1GetBulkDeploymentStatusCommand = async (
     contents.BulkDeploymentMetrics = deserializeAws_restJson1BulkDeploymentMetrics(data.BulkDeploymentMetrics, context);
   }
   if (data.BulkDeploymentStatus !== undefined && data.BulkDeploymentStatus !== null) {
-    contents.BulkDeploymentStatus = data.BulkDeploymentStatus;
+    contents.BulkDeploymentStatus = __expectString(data.BulkDeploymentStatus);
   }
   if (data.CreatedAt !== undefined && data.CreatedAt !== null) {
-    contents.CreatedAt = data.CreatedAt;
+    contents.CreatedAt = __expectString(data.CreatedAt);
   }
   if (data.ErrorDetails !== undefined && data.ErrorDetails !== null) {
     contents.ErrorDetails = deserializeAws_restJson1ErrorDetails(data.ErrorDetails, context);
   }
   if (data.ErrorMessage !== undefined && data.ErrorMessage !== null) {
-    contents.ErrorMessage = data.ErrorMessage;
+    contents.ErrorMessage = __expectString(data.ErrorMessage);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1Tags(data.tags, context);
@@ -5444,7 +5447,7 @@ export const deserializeAws_restJson1GetConnectivityInfoCommand = async (
     contents.ConnectivityInfo = deserializeAws_restJson1__listOfConnectivityInfo(data.ConnectivityInfo, context);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return Promise.resolve(contents);
 };
@@ -5514,25 +5517,25 @@ export const deserializeAws_restJson1GetConnectorDefinitionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationTimestamp !== undefined && data.CreationTimestamp !== null) {
-    contents.CreationTimestamp = data.CreationTimestamp;
+    contents.CreationTimestamp = __expectString(data.CreationTimestamp);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.LastUpdatedTimestamp !== undefined && data.LastUpdatedTimestamp !== null) {
-    contents.LastUpdatedTimestamp = data.LastUpdatedTimestamp;
+    contents.LastUpdatedTimestamp = __expectString(data.LastUpdatedTimestamp);
   }
   if (data.LatestVersion !== undefined && data.LatestVersion !== null) {
-    contents.LatestVersion = data.LatestVersion;
+    contents.LatestVersion = __expectString(data.LatestVersion);
   }
   if (data.LatestVersionArn !== undefined && data.LatestVersionArn !== null) {
-    contents.LatestVersionArn = data.LatestVersionArn;
+    contents.LatestVersionArn = __expectString(data.LatestVersionArn);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1Tags(data.tags, context);
@@ -5595,22 +5598,22 @@ export const deserializeAws_restJson1GetConnectorDefinitionVersionCommand = asyn
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationTimestamp !== undefined && data.CreationTimestamp !== null) {
-    contents.CreationTimestamp = data.CreationTimestamp;
+    contents.CreationTimestamp = __expectString(data.CreationTimestamp);
   }
   if (data.Definition !== undefined && data.Definition !== null) {
     contents.Definition = deserializeAws_restJson1ConnectorDefinitionVersion(data.Definition, context);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Version !== undefined && data.Version !== null) {
-    contents.Version = data.Version;
+    contents.Version = __expectString(data.Version);
   }
   return Promise.resolve(contents);
 };
@@ -5672,25 +5675,25 @@ export const deserializeAws_restJson1GetCoreDefinitionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationTimestamp !== undefined && data.CreationTimestamp !== null) {
-    contents.CreationTimestamp = data.CreationTimestamp;
+    contents.CreationTimestamp = __expectString(data.CreationTimestamp);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.LastUpdatedTimestamp !== undefined && data.LastUpdatedTimestamp !== null) {
-    contents.LastUpdatedTimestamp = data.LastUpdatedTimestamp;
+    contents.LastUpdatedTimestamp = __expectString(data.LastUpdatedTimestamp);
   }
   if (data.LatestVersion !== undefined && data.LatestVersion !== null) {
-    contents.LatestVersion = data.LatestVersion;
+    contents.LatestVersion = __expectString(data.LatestVersion);
   }
   if (data.LatestVersionArn !== undefined && data.LatestVersionArn !== null) {
-    contents.LatestVersionArn = data.LatestVersionArn;
+    contents.LatestVersionArn = __expectString(data.LatestVersionArn);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1Tags(data.tags, context);
@@ -5753,22 +5756,22 @@ export const deserializeAws_restJson1GetCoreDefinitionVersionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationTimestamp !== undefined && data.CreationTimestamp !== null) {
-    contents.CreationTimestamp = data.CreationTimestamp;
+    contents.CreationTimestamp = __expectString(data.CreationTimestamp);
   }
   if (data.Definition !== undefined && data.Definition !== null) {
     contents.Definition = deserializeAws_restJson1CoreDefinitionVersion(data.Definition, context);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Version !== undefined && data.Version !== null) {
-    contents.Version = data.Version;
+    contents.Version = __expectString(data.Version);
   }
   return Promise.resolve(contents);
 };
@@ -5827,19 +5830,19 @@ export const deserializeAws_restJson1GetDeploymentStatusCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.DeploymentStatus !== undefined && data.DeploymentStatus !== null) {
-    contents.DeploymentStatus = data.DeploymentStatus;
+    contents.DeploymentStatus = __expectString(data.DeploymentStatus);
   }
   if (data.DeploymentType !== undefined && data.DeploymentType !== null) {
-    contents.DeploymentType = data.DeploymentType;
+    contents.DeploymentType = __expectString(data.DeploymentType);
   }
   if (data.ErrorDetails !== undefined && data.ErrorDetails !== null) {
     contents.ErrorDetails = deserializeAws_restJson1ErrorDetails(data.ErrorDetails, context);
   }
   if (data.ErrorMessage !== undefined && data.ErrorMessage !== null) {
-    contents.ErrorMessage = data.ErrorMessage;
+    contents.ErrorMessage = __expectString(data.ErrorMessage);
   }
   if (data.UpdatedAt !== undefined && data.UpdatedAt !== null) {
-    contents.UpdatedAt = data.UpdatedAt;
+    contents.UpdatedAt = __expectString(data.UpdatedAt);
   }
   return Promise.resolve(contents);
 };
@@ -5901,25 +5904,25 @@ export const deserializeAws_restJson1GetDeviceDefinitionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationTimestamp !== undefined && data.CreationTimestamp !== null) {
-    contents.CreationTimestamp = data.CreationTimestamp;
+    contents.CreationTimestamp = __expectString(data.CreationTimestamp);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.LastUpdatedTimestamp !== undefined && data.LastUpdatedTimestamp !== null) {
-    contents.LastUpdatedTimestamp = data.LastUpdatedTimestamp;
+    contents.LastUpdatedTimestamp = __expectString(data.LastUpdatedTimestamp);
   }
   if (data.LatestVersion !== undefined && data.LatestVersion !== null) {
-    contents.LatestVersion = data.LatestVersion;
+    contents.LatestVersion = __expectString(data.LatestVersion);
   }
   if (data.LatestVersionArn !== undefined && data.LatestVersionArn !== null) {
-    contents.LatestVersionArn = data.LatestVersionArn;
+    contents.LatestVersionArn = __expectString(data.LatestVersionArn);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1Tags(data.tags, context);
@@ -5982,22 +5985,22 @@ export const deserializeAws_restJson1GetDeviceDefinitionVersionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationTimestamp !== undefined && data.CreationTimestamp !== null) {
-    contents.CreationTimestamp = data.CreationTimestamp;
+    contents.CreationTimestamp = __expectString(data.CreationTimestamp);
   }
   if (data.Definition !== undefined && data.Definition !== null) {
     contents.Definition = deserializeAws_restJson1DeviceDefinitionVersion(data.Definition, context);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Version !== undefined && data.Version !== null) {
-    contents.Version = data.Version;
+    contents.Version = __expectString(data.Version);
   }
   return Promise.resolve(contents);
 };
@@ -6059,25 +6062,25 @@ export const deserializeAws_restJson1GetFunctionDefinitionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationTimestamp !== undefined && data.CreationTimestamp !== null) {
-    contents.CreationTimestamp = data.CreationTimestamp;
+    contents.CreationTimestamp = __expectString(data.CreationTimestamp);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.LastUpdatedTimestamp !== undefined && data.LastUpdatedTimestamp !== null) {
-    contents.LastUpdatedTimestamp = data.LastUpdatedTimestamp;
+    contents.LastUpdatedTimestamp = __expectString(data.LastUpdatedTimestamp);
   }
   if (data.LatestVersion !== undefined && data.LatestVersion !== null) {
-    contents.LatestVersion = data.LatestVersion;
+    contents.LatestVersion = __expectString(data.LatestVersion);
   }
   if (data.LatestVersionArn !== undefined && data.LatestVersionArn !== null) {
-    contents.LatestVersionArn = data.LatestVersionArn;
+    contents.LatestVersionArn = __expectString(data.LatestVersionArn);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1Tags(data.tags, context);
@@ -6140,22 +6143,22 @@ export const deserializeAws_restJson1GetFunctionDefinitionVersionCommand = async
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationTimestamp !== undefined && data.CreationTimestamp !== null) {
-    contents.CreationTimestamp = data.CreationTimestamp;
+    contents.CreationTimestamp = __expectString(data.CreationTimestamp);
   }
   if (data.Definition !== undefined && data.Definition !== null) {
     contents.Definition = deserializeAws_restJson1FunctionDefinitionVersion(data.Definition, context);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Version !== undefined && data.Version !== null) {
-    contents.Version = data.Version;
+    contents.Version = __expectString(data.Version);
   }
   return Promise.resolve(contents);
 };
@@ -6217,25 +6220,25 @@ export const deserializeAws_restJson1GetGroupCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationTimestamp !== undefined && data.CreationTimestamp !== null) {
-    contents.CreationTimestamp = data.CreationTimestamp;
+    contents.CreationTimestamp = __expectString(data.CreationTimestamp);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.LastUpdatedTimestamp !== undefined && data.LastUpdatedTimestamp !== null) {
-    contents.LastUpdatedTimestamp = data.LastUpdatedTimestamp;
+    contents.LastUpdatedTimestamp = __expectString(data.LastUpdatedTimestamp);
   }
   if (data.LatestVersion !== undefined && data.LatestVersion !== null) {
-    contents.LatestVersion = data.LatestVersion;
+    contents.LatestVersion = __expectString(data.LatestVersion);
   }
   if (data.LatestVersionArn !== undefined && data.LatestVersionArn !== null) {
-    contents.LatestVersionArn = data.LatestVersionArn;
+    contents.LatestVersionArn = __expectString(data.LatestVersionArn);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1Tags(data.tags, context);
@@ -6295,13 +6298,13 @@ export const deserializeAws_restJson1GetGroupCertificateAuthorityCommand = async
   };
   const data: any = await parseBody(output.body, context);
   if (data.GroupCertificateAuthorityArn !== undefined && data.GroupCertificateAuthorityArn !== null) {
-    contents.GroupCertificateAuthorityArn = data.GroupCertificateAuthorityArn;
+    contents.GroupCertificateAuthorityArn = __expectString(data.GroupCertificateAuthorityArn);
   }
   if (data.GroupCertificateAuthorityId !== undefined && data.GroupCertificateAuthorityId !== null) {
-    contents.GroupCertificateAuthorityId = data.GroupCertificateAuthorityId;
+    contents.GroupCertificateAuthorityId = __expectString(data.GroupCertificateAuthorityId);
   }
   if (data.PemEncodedCertificate !== undefined && data.PemEncodedCertificate !== null) {
-    contents.PemEncodedCertificate = data.PemEncodedCertificate;
+    contents.PemEncodedCertificate = __expectString(data.PemEncodedCertificate);
   }
   return Promise.resolve(contents);
 };
@@ -6369,13 +6372,13 @@ export const deserializeAws_restJson1GetGroupCertificateConfigurationCommand = a
     data.CertificateAuthorityExpiryInMilliseconds !== undefined &&
     data.CertificateAuthorityExpiryInMilliseconds !== null
   ) {
-    contents.CertificateAuthorityExpiryInMilliseconds = data.CertificateAuthorityExpiryInMilliseconds;
+    contents.CertificateAuthorityExpiryInMilliseconds = __expectString(data.CertificateAuthorityExpiryInMilliseconds);
   }
   if (data.CertificateExpiryInMilliseconds !== undefined && data.CertificateExpiryInMilliseconds !== null) {
-    contents.CertificateExpiryInMilliseconds = data.CertificateExpiryInMilliseconds;
+    contents.CertificateExpiryInMilliseconds = __expectString(data.CertificateExpiryInMilliseconds);
   }
   if (data.GroupId !== undefined && data.GroupId !== null) {
-    contents.GroupId = data.GroupId;
+    contents.GroupId = __expectString(data.GroupId);
   }
   return Promise.resolve(contents);
 };
@@ -6442,19 +6445,19 @@ export const deserializeAws_restJson1GetGroupVersionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationTimestamp !== undefined && data.CreationTimestamp !== null) {
-    contents.CreationTimestamp = data.CreationTimestamp;
+    contents.CreationTimestamp = __expectString(data.CreationTimestamp);
   }
   if (data.Definition !== undefined && data.Definition !== null) {
     contents.Definition = deserializeAws_restJson1GroupVersion(data.Definition, context);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.Version !== undefined && data.Version !== null) {
-    contents.Version = data.Version;
+    contents.Version = __expectString(data.Version);
   }
   return Promise.resolve(contents);
 };
@@ -6516,25 +6519,25 @@ export const deserializeAws_restJson1GetLoggerDefinitionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationTimestamp !== undefined && data.CreationTimestamp !== null) {
-    contents.CreationTimestamp = data.CreationTimestamp;
+    contents.CreationTimestamp = __expectString(data.CreationTimestamp);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.LastUpdatedTimestamp !== undefined && data.LastUpdatedTimestamp !== null) {
-    contents.LastUpdatedTimestamp = data.LastUpdatedTimestamp;
+    contents.LastUpdatedTimestamp = __expectString(data.LastUpdatedTimestamp);
   }
   if (data.LatestVersion !== undefined && data.LatestVersion !== null) {
-    contents.LatestVersion = data.LatestVersion;
+    contents.LatestVersion = __expectString(data.LatestVersion);
   }
   if (data.LatestVersionArn !== undefined && data.LatestVersionArn !== null) {
-    contents.LatestVersionArn = data.LatestVersionArn;
+    contents.LatestVersionArn = __expectString(data.LatestVersionArn);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1Tags(data.tags, context);
@@ -6596,19 +6599,19 @@ export const deserializeAws_restJson1GetLoggerDefinitionVersionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationTimestamp !== undefined && data.CreationTimestamp !== null) {
-    contents.CreationTimestamp = data.CreationTimestamp;
+    contents.CreationTimestamp = __expectString(data.CreationTimestamp);
   }
   if (data.Definition !== undefined && data.Definition !== null) {
     contents.Definition = deserializeAws_restJson1LoggerDefinitionVersion(data.Definition, context);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.Version !== undefined && data.Version !== null) {
-    contents.Version = data.Version;
+    contents.Version = __expectString(data.Version);
   }
   return Promise.resolve(contents);
 };
@@ -6670,25 +6673,25 @@ export const deserializeAws_restJson1GetResourceDefinitionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationTimestamp !== undefined && data.CreationTimestamp !== null) {
-    contents.CreationTimestamp = data.CreationTimestamp;
+    contents.CreationTimestamp = __expectString(data.CreationTimestamp);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.LastUpdatedTimestamp !== undefined && data.LastUpdatedTimestamp !== null) {
-    contents.LastUpdatedTimestamp = data.LastUpdatedTimestamp;
+    contents.LastUpdatedTimestamp = __expectString(data.LastUpdatedTimestamp);
   }
   if (data.LatestVersion !== undefined && data.LatestVersion !== null) {
-    contents.LatestVersion = data.LatestVersion;
+    contents.LatestVersion = __expectString(data.LatestVersion);
   }
   if (data.LatestVersionArn !== undefined && data.LatestVersionArn !== null) {
-    contents.LatestVersionArn = data.LatestVersionArn;
+    contents.LatestVersionArn = __expectString(data.LatestVersionArn);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1Tags(data.tags, context);
@@ -6750,19 +6753,19 @@ export const deserializeAws_restJson1GetResourceDefinitionVersionCommand = async
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationTimestamp !== undefined && data.CreationTimestamp !== null) {
-    contents.CreationTimestamp = data.CreationTimestamp;
+    contents.CreationTimestamp = __expectString(data.CreationTimestamp);
   }
   if (data.Definition !== undefined && data.Definition !== null) {
     contents.Definition = deserializeAws_restJson1ResourceDefinitionVersion(data.Definition, context);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.Version !== undefined && data.Version !== null) {
-    contents.Version = data.Version;
+    contents.Version = __expectString(data.Version);
   }
   return Promise.resolve(contents);
 };
@@ -6818,10 +6821,10 @@ export const deserializeAws_restJson1GetServiceRoleForAccountCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AssociatedAt !== undefined && data.AssociatedAt !== null) {
-    contents.AssociatedAt = data.AssociatedAt;
+    contents.AssociatedAt = __expectString(data.AssociatedAt);
   }
   if (data.RoleArn !== undefined && data.RoleArn !== null) {
-    contents.RoleArn = data.RoleArn;
+    contents.RoleArn = __expectString(data.RoleArn);
   }
   return Promise.resolve(contents);
 };
@@ -6883,25 +6886,25 @@ export const deserializeAws_restJson1GetSubscriptionDefinitionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationTimestamp !== undefined && data.CreationTimestamp !== null) {
-    contents.CreationTimestamp = data.CreationTimestamp;
+    contents.CreationTimestamp = __expectString(data.CreationTimestamp);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.LastUpdatedTimestamp !== undefined && data.LastUpdatedTimestamp !== null) {
-    contents.LastUpdatedTimestamp = data.LastUpdatedTimestamp;
+    contents.LastUpdatedTimestamp = __expectString(data.LastUpdatedTimestamp);
   }
   if (data.LatestVersion !== undefined && data.LatestVersion !== null) {
-    contents.LatestVersion = data.LatestVersion;
+    contents.LatestVersion = __expectString(data.LatestVersion);
   }
   if (data.LatestVersionArn !== undefined && data.LatestVersionArn !== null) {
-    contents.LatestVersionArn = data.LatestVersionArn;
+    contents.LatestVersionArn = __expectString(data.LatestVersionArn);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1Tags(data.tags, context);
@@ -6964,22 +6967,22 @@ export const deserializeAws_restJson1GetSubscriptionDefinitionVersionCommand = a
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationTimestamp !== undefined && data.CreationTimestamp !== null) {
-    contents.CreationTimestamp = data.CreationTimestamp;
+    contents.CreationTimestamp = __expectString(data.CreationTimestamp);
   }
   if (data.Definition !== undefined && data.Definition !== null) {
     contents.Definition = deserializeAws_restJson1SubscriptionDefinitionVersion(data.Definition, context);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Version !== undefined && data.Version !== null) {
-    contents.Version = data.Version;
+    contents.Version = __expectString(data.Version);
   }
   return Promise.resolve(contents);
 };
@@ -7101,7 +7104,7 @@ export const deserializeAws_restJson1ListBulkDeploymentDetailedReportsCommand = 
     contents.Deployments = deserializeAws_restJson1BulkDeploymentResults(data.Deployments, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -7160,7 +7163,7 @@ export const deserializeAws_restJson1ListBulkDeploymentsCommand = async (
     contents.BulkDeployments = deserializeAws_restJson1BulkDeployments(data.BulkDeployments, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -7219,7 +7222,7 @@ export const deserializeAws_restJson1ListConnectorDefinitionsCommand = async (
     contents.Definitions = deserializeAws_restJson1__listOfDefinitionInformation(data.Definitions, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -7267,7 +7270,7 @@ export const deserializeAws_restJson1ListConnectorDefinitionVersionsCommand = as
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Versions !== undefined && data.Versions !== null) {
     contents.Versions = deserializeAws_restJson1__listOfVersionInformation(data.Versions, context);
@@ -7329,7 +7332,7 @@ export const deserializeAws_restJson1ListCoreDefinitionsCommand = async (
     contents.Definitions = deserializeAws_restJson1__listOfDefinitionInformation(data.Definitions, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -7377,7 +7380,7 @@ export const deserializeAws_restJson1ListCoreDefinitionVersionsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Versions !== undefined && data.Versions !== null) {
     contents.Versions = deserializeAws_restJson1__listOfVersionInformation(data.Versions, context);
@@ -7439,7 +7442,7 @@ export const deserializeAws_restJson1ListDeploymentsCommand = async (
     contents.Deployments = deserializeAws_restJson1Deployments(data.Deployments, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -7498,7 +7501,7 @@ export const deserializeAws_restJson1ListDeviceDefinitionsCommand = async (
     contents.Definitions = deserializeAws_restJson1__listOfDefinitionInformation(data.Definitions, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -7546,7 +7549,7 @@ export const deserializeAws_restJson1ListDeviceDefinitionVersionsCommand = async
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Versions !== undefined && data.Versions !== null) {
     contents.Versions = deserializeAws_restJson1__listOfVersionInformation(data.Versions, context);
@@ -7608,7 +7611,7 @@ export const deserializeAws_restJson1ListFunctionDefinitionsCommand = async (
     contents.Definitions = deserializeAws_restJson1__listOfDefinitionInformation(data.Definitions, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -7656,7 +7659,7 @@ export const deserializeAws_restJson1ListFunctionDefinitionVersionsCommand = asy
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Versions !== undefined && data.Versions !== null) {
     contents.Versions = deserializeAws_restJson1__listOfVersionInformation(data.Versions, context);
@@ -7784,7 +7787,7 @@ export const deserializeAws_restJson1ListGroupsCommand = async (
     contents.Groups = deserializeAws_restJson1__listOfGroupInformation(data.Groups, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -7832,7 +7835,7 @@ export const deserializeAws_restJson1ListGroupVersionsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Versions !== undefined && data.Versions !== null) {
     contents.Versions = deserializeAws_restJson1__listOfVersionInformation(data.Versions, context);
@@ -7894,7 +7897,7 @@ export const deserializeAws_restJson1ListLoggerDefinitionsCommand = async (
     contents.Definitions = deserializeAws_restJson1__listOfDefinitionInformation(data.Definitions, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -7942,7 +7945,7 @@ export const deserializeAws_restJson1ListLoggerDefinitionVersionsCommand = async
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Versions !== undefined && data.Versions !== null) {
     contents.Versions = deserializeAws_restJson1__listOfVersionInformation(data.Versions, context);
@@ -8004,7 +8007,7 @@ export const deserializeAws_restJson1ListResourceDefinitionsCommand = async (
     contents.Definitions = deserializeAws_restJson1__listOfDefinitionInformation(data.Definitions, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -8052,7 +8055,7 @@ export const deserializeAws_restJson1ListResourceDefinitionVersionsCommand = asy
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Versions !== undefined && data.Versions !== null) {
     contents.Versions = deserializeAws_restJson1__listOfVersionInformation(data.Versions, context);
@@ -8114,7 +8117,7 @@ export const deserializeAws_restJson1ListSubscriptionDefinitionsCommand = async 
     contents.Definitions = deserializeAws_restJson1__listOfDefinitionInformation(data.Definitions, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -8162,7 +8165,7 @@ export const deserializeAws_restJson1ListSubscriptionDefinitionVersionsCommand =
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Versions !== undefined && data.Versions !== null) {
     contents.Versions = deserializeAws_restJson1__listOfVersionInformation(data.Versions, context);
@@ -8276,10 +8279,10 @@ export const deserializeAws_restJson1ResetDeploymentsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.DeploymentArn !== undefined && data.DeploymentArn !== null) {
-    contents.DeploymentArn = data.DeploymentArn;
+    contents.DeploymentArn = __expectString(data.DeploymentArn);
   }
   if (data.DeploymentId !== undefined && data.DeploymentId !== null) {
-    contents.DeploymentId = data.DeploymentId;
+    contents.DeploymentId = __expectString(data.DeploymentId);
   }
   return Promise.resolve(contents);
 };
@@ -8335,10 +8338,10 @@ export const deserializeAws_restJson1StartBulkDeploymentCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.BulkDeploymentArn !== undefined && data.BulkDeploymentArn !== null) {
-    contents.BulkDeploymentArn = data.BulkDeploymentArn;
+    contents.BulkDeploymentArn = __expectString(data.BulkDeploymentArn);
   }
   if (data.BulkDeploymentId !== undefined && data.BulkDeploymentId !== null) {
-    contents.BulkDeploymentId = data.BulkDeploymentId;
+    contents.BulkDeploymentId = __expectString(data.BulkDeploymentId);
   }
   return Promise.resolve(contents);
 };
@@ -8547,10 +8550,10 @@ export const deserializeAws_restJson1UpdateConnectivityInfoCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   if (data.Version !== undefined && data.Version !== null) {
-    contents.Version = data.Version;
+    contents.Version = __expectString(data.Version);
   }
   return Promise.resolve(contents);
 };
@@ -8873,13 +8876,13 @@ export const deserializeAws_restJson1UpdateGroupCertificateConfigurationCommand 
     data.CertificateAuthorityExpiryInMilliseconds !== undefined &&
     data.CertificateAuthorityExpiryInMilliseconds !== null
   ) {
-    contents.CertificateAuthorityExpiryInMilliseconds = data.CertificateAuthorityExpiryInMilliseconds;
+    contents.CertificateAuthorityExpiryInMilliseconds = __expectString(data.CertificateAuthorityExpiryInMilliseconds);
   }
   if (data.CertificateExpiryInMilliseconds !== undefined && data.CertificateExpiryInMilliseconds !== null) {
-    contents.CertificateExpiryInMilliseconds = data.CertificateExpiryInMilliseconds;
+    contents.CertificateExpiryInMilliseconds = __expectString(data.CertificateExpiryInMilliseconds);
   }
   if (data.GroupId !== undefined && data.GroupId !== null) {
-    contents.GroupId = data.GroupId;
+    contents.GroupId = __expectString(data.GroupId);
   }
   return Promise.resolve(contents);
 };
@@ -9157,7 +9160,7 @@ const deserializeAws_restJson1BadRequestExceptionResponse = async (
     contents.ErrorDetails = deserializeAws_restJson1ErrorDetails(data.ErrorDetails, context);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -9178,7 +9181,7 @@ const deserializeAws_restJson1InternalServerErrorExceptionResponse = async (
     contents.ErrorDetails = deserializeAws_restJson1ErrorDetails(data.ErrorDetails, context);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -9736,7 +9739,7 @@ const deserializeAws_restJson1__listOf__string = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -9902,52 +9905,40 @@ const deserializeAws_restJson1__mapOf__string = (output: any, context: __SerdeCo
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1BulkDeployment = (output: any, context: __SerdeContext): BulkDeployment => {
   return {
-    BulkDeploymentArn:
-      output.BulkDeploymentArn !== undefined && output.BulkDeploymentArn !== null
-        ? output.BulkDeploymentArn
-        : undefined,
-    BulkDeploymentId:
-      output.BulkDeploymentId !== undefined && output.BulkDeploymentId !== null ? output.BulkDeploymentId : undefined,
-    CreatedAt: output.CreatedAt !== undefined && output.CreatedAt !== null ? output.CreatedAt : undefined,
+    BulkDeploymentArn: __expectString(output.BulkDeploymentArn),
+    BulkDeploymentId: __expectString(output.BulkDeploymentId),
+    CreatedAt: __expectString(output.CreatedAt),
   } as any;
 };
 
 const deserializeAws_restJson1BulkDeploymentMetrics = (output: any, context: __SerdeContext): BulkDeploymentMetrics => {
   return {
-    InvalidInputRecords:
-      output.InvalidInputRecords !== undefined && output.InvalidInputRecords !== null
-        ? output.InvalidInputRecords
-        : undefined,
-    RecordsProcessed:
-      output.RecordsProcessed !== undefined && output.RecordsProcessed !== null ? output.RecordsProcessed : undefined,
-    RetryAttempts:
-      output.RetryAttempts !== undefined && output.RetryAttempts !== null ? output.RetryAttempts : undefined,
+    InvalidInputRecords: __expectNumber(output.InvalidInputRecords),
+    RecordsProcessed: __expectNumber(output.RecordsProcessed),
+    RetryAttempts: __expectNumber(output.RetryAttempts),
   } as any;
 };
 
 const deserializeAws_restJson1BulkDeploymentResult = (output: any, context: __SerdeContext): BulkDeploymentResult => {
   return {
-    CreatedAt: output.CreatedAt !== undefined && output.CreatedAt !== null ? output.CreatedAt : undefined,
-    DeploymentArn:
-      output.DeploymentArn !== undefined && output.DeploymentArn !== null ? output.DeploymentArn : undefined,
-    DeploymentId: output.DeploymentId !== undefined && output.DeploymentId !== null ? output.DeploymentId : undefined,
-    DeploymentStatus:
-      output.DeploymentStatus !== undefined && output.DeploymentStatus !== null ? output.DeploymentStatus : undefined,
-    DeploymentType:
-      output.DeploymentType !== undefined && output.DeploymentType !== null ? output.DeploymentType : undefined,
+    CreatedAt: __expectString(output.CreatedAt),
+    DeploymentArn: __expectString(output.DeploymentArn),
+    DeploymentId: __expectString(output.DeploymentId),
+    DeploymentStatus: __expectString(output.DeploymentStatus),
+    DeploymentType: __expectString(output.DeploymentType),
     ErrorDetails:
       output.ErrorDetails !== undefined && output.ErrorDetails !== null
         ? deserializeAws_restJson1ErrorDetails(output.ErrorDetails, context)
         : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    GroupArn: output.GroupArn !== undefined && output.GroupArn !== null ? output.GroupArn : undefined,
+    ErrorMessage: __expectString(output.ErrorMessage),
+    GroupArn: __expectString(output.GroupArn),
   } as any;
 };
 
@@ -9978,17 +9969,17 @@ const deserializeAws_restJson1BulkDeployments = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1ConnectivityInfo = (output: any, context: __SerdeContext): ConnectivityInfo => {
   return {
-    HostAddress: output.HostAddress !== undefined && output.HostAddress !== null ? output.HostAddress : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Metadata: output.Metadata !== undefined && output.Metadata !== null ? output.Metadata : undefined,
-    PortNumber: output.PortNumber !== undefined && output.PortNumber !== null ? output.PortNumber : undefined,
+    HostAddress: __expectString(output.HostAddress),
+    Id: __expectString(output.Id),
+    Metadata: __expectString(output.Metadata),
+    PortNumber: __expectNumber(output.PortNumber),
   } as any;
 };
 
 const deserializeAws_restJson1Connector = (output: any, context: __SerdeContext): Connector => {
   return {
-    ConnectorArn: output.ConnectorArn !== undefined && output.ConnectorArn !== null ? output.ConnectorArn : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    ConnectorArn: __expectString(output.ConnectorArn),
+    Id: __expectString(output.Id),
     Parameters:
       output.Parameters !== undefined && output.Parameters !== null
         ? deserializeAws_restJson1__mapOf__string(output.Parameters, context)
@@ -10010,11 +10001,10 @@ const deserializeAws_restJson1ConnectorDefinitionVersion = (
 
 const deserializeAws_restJson1Core = (output: any, context: __SerdeContext): Core => {
   return {
-    CertificateArn:
-      output.CertificateArn !== undefined && output.CertificateArn !== null ? output.CertificateArn : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    SyncShadow: output.SyncShadow !== undefined && output.SyncShadow !== null ? output.SyncShadow : undefined,
-    ThingArn: output.ThingArn !== undefined && output.ThingArn !== null ? output.ThingArn : undefined,
+    CertificateArn: __expectString(output.CertificateArn),
+    Id: __expectString(output.Id),
+    SyncShadow: __expectBoolean(output.SyncShadow),
+    ThingArn: __expectString(output.ThingArn),
   } as any;
 };
 
@@ -10029,21 +10019,13 @@ const deserializeAws_restJson1CoreDefinitionVersion = (output: any, context: __S
 
 const deserializeAws_restJson1DefinitionInformation = (output: any, context: __SerdeContext): DefinitionInformation => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    CreationTimestamp:
-      output.CreationTimestamp !== undefined && output.CreationTimestamp !== null
-        ? output.CreationTimestamp
-        : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    LastUpdatedTimestamp:
-      output.LastUpdatedTimestamp !== undefined && output.LastUpdatedTimestamp !== null
-        ? output.LastUpdatedTimestamp
-        : undefined,
-    LatestVersion:
-      output.LatestVersion !== undefined && output.LatestVersion !== null ? output.LatestVersion : undefined,
-    LatestVersionArn:
-      output.LatestVersionArn !== undefined && output.LatestVersionArn !== null ? output.LatestVersionArn : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Arn: __expectString(output.Arn),
+    CreationTimestamp: __expectString(output.CreationTimestamp),
+    Id: __expectString(output.Id),
+    LastUpdatedTimestamp: __expectString(output.LastUpdatedTimestamp),
+    LatestVersion: __expectString(output.LatestVersion),
+    LatestVersionArn: __expectString(output.LatestVersionArn),
+    Name: __expectString(output.Name),
     Tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1Tags(output.tags, context)
@@ -10053,13 +10035,11 @@ const deserializeAws_restJson1DefinitionInformation = (output: any, context: __S
 
 const deserializeAws_restJson1Deployment = (output: any, context: __SerdeContext): Deployment => {
   return {
-    CreatedAt: output.CreatedAt !== undefined && output.CreatedAt !== null ? output.CreatedAt : undefined,
-    DeploymentArn:
-      output.DeploymentArn !== undefined && output.DeploymentArn !== null ? output.DeploymentArn : undefined,
-    DeploymentId: output.DeploymentId !== undefined && output.DeploymentId !== null ? output.DeploymentId : undefined,
-    DeploymentType:
-      output.DeploymentType !== undefined && output.DeploymentType !== null ? output.DeploymentType : undefined,
-    GroupArn: output.GroupArn !== undefined && output.GroupArn !== null ? output.GroupArn : undefined,
+    CreatedAt: __expectString(output.CreatedAt),
+    DeploymentArn: __expectString(output.DeploymentArn),
+    DeploymentId: __expectString(output.DeploymentId),
+    DeploymentType: __expectString(output.DeploymentType),
+    GroupArn: __expectString(output.GroupArn),
   } as any;
 };
 
@@ -10076,11 +10056,10 @@ const deserializeAws_restJson1Deployments = (output: any, context: __SerdeContex
 
 const deserializeAws_restJson1Device = (output: any, context: __SerdeContext): Device => {
   return {
-    CertificateArn:
-      output.CertificateArn !== undefined && output.CertificateArn !== null ? output.CertificateArn : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    SyncShadow: output.SyncShadow !== undefined && output.SyncShadow !== null ? output.SyncShadow : undefined,
-    ThingArn: output.ThingArn !== undefined && output.ThingArn !== null ? output.ThingArn : undefined,
+    CertificateArn: __expectString(output.CertificateArn),
+    Id: __expectString(output.Id),
+    SyncShadow: __expectBoolean(output.SyncShadow),
+    ThingArn: __expectString(output.ThingArn),
   } as any;
 };
 
@@ -10098,14 +10077,8 @@ const deserializeAws_restJson1DeviceDefinitionVersion = (
 
 const deserializeAws_restJson1ErrorDetail = (output: any, context: __SerdeContext): ErrorDetail => {
   return {
-    DetailedErrorCode:
-      output.DetailedErrorCode !== undefined && output.DetailedErrorCode !== null
-        ? output.DetailedErrorCode
-        : undefined,
-    DetailedErrorMessage:
-      output.DetailedErrorMessage !== undefined && output.DetailedErrorMessage !== null
-        ? output.DetailedErrorMessage
-        : undefined,
+    DetailedErrorCode: __expectString(output.DetailedErrorCode),
+    DetailedErrorMessage: __expectString(output.DetailedErrorMessage),
   } as any;
 };
 
@@ -10122,27 +10095,27 @@ const deserializeAws_restJson1ErrorDetails = (output: any, context: __SerdeConte
 
 const deserializeAws_restJson1Function = (output: any, context: __SerdeContext): Function => {
   return {
-    FunctionArn: output.FunctionArn !== undefined && output.FunctionArn !== null ? output.FunctionArn : undefined,
+    FunctionArn: __expectString(output.FunctionArn),
     FunctionConfiguration:
       output.FunctionConfiguration !== undefined && output.FunctionConfiguration !== null
         ? deserializeAws_restJson1FunctionConfiguration(output.FunctionConfiguration, context)
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    Id: __expectString(output.Id),
   } as any;
 };
 
 const deserializeAws_restJson1FunctionConfiguration = (output: any, context: __SerdeContext): FunctionConfiguration => {
   return {
-    EncodingType: output.EncodingType !== undefined && output.EncodingType !== null ? output.EncodingType : undefined,
+    EncodingType: __expectString(output.EncodingType),
     Environment:
       output.Environment !== undefined && output.Environment !== null
         ? deserializeAws_restJson1FunctionConfigurationEnvironment(output.Environment, context)
         : undefined,
-    ExecArgs: output.ExecArgs !== undefined && output.ExecArgs !== null ? output.ExecArgs : undefined,
-    Executable: output.Executable !== undefined && output.Executable !== null ? output.Executable : undefined,
-    MemorySize: output.MemorySize !== undefined && output.MemorySize !== null ? output.MemorySize : undefined,
-    Pinned: output.Pinned !== undefined && output.Pinned !== null ? output.Pinned : undefined,
-    Timeout: output.Timeout !== undefined && output.Timeout !== null ? output.Timeout : undefined,
+    ExecArgs: __expectString(output.ExecArgs),
+    Executable: __expectString(output.Executable),
+    MemorySize: __expectNumber(output.MemorySize),
+    Pinned: __expectBoolean(output.Pinned),
+    Timeout: __expectNumber(output.Timeout),
   } as any;
 };
 
@@ -10151,7 +10124,7 @@ const deserializeAws_restJson1FunctionConfigurationEnvironment = (
   context: __SerdeContext
 ): FunctionConfigurationEnvironment => {
   return {
-    AccessSysfs: output.AccessSysfs !== undefined && output.AccessSysfs !== null ? output.AccessSysfs : undefined,
+    AccessSysfs: __expectBoolean(output.AccessSysfs),
     Execution:
       output.Execution !== undefined && output.Execution !== null
         ? deserializeAws_restJson1FunctionExecutionConfig(output.Execution, context)
@@ -10181,8 +10154,7 @@ const deserializeAws_restJson1FunctionDefaultExecutionConfig = (
   context: __SerdeContext
 ): FunctionDefaultExecutionConfig => {
   return {
-    IsolationMode:
-      output.IsolationMode !== undefined && output.IsolationMode !== null ? output.IsolationMode : undefined,
+    IsolationMode: __expectString(output.IsolationMode),
     RunAs:
       output.RunAs !== undefined && output.RunAs !== null
         ? deserializeAws_restJson1FunctionRunAsConfig(output.RunAs, context)
@@ -10211,8 +10183,7 @@ const deserializeAws_restJson1FunctionExecutionConfig = (
   context: __SerdeContext
 ): FunctionExecutionConfig => {
   return {
-    IsolationMode:
-      output.IsolationMode !== undefined && output.IsolationMode !== null ? output.IsolationMode : undefined,
+    IsolationMode: __expectString(output.IsolationMode),
     RunAs:
       output.RunAs !== undefined && output.RunAs !== null
         ? deserializeAws_restJson1FunctionRunAsConfig(output.RunAs, context)
@@ -10222,8 +10193,8 @@ const deserializeAws_restJson1FunctionExecutionConfig = (
 
 const deserializeAws_restJson1FunctionRunAsConfig = (output: any, context: __SerdeContext): FunctionRunAsConfig => {
   return {
-    Gid: output.Gid !== undefined && output.Gid !== null ? output.Gid : undefined,
-    Uid: output.Uid !== undefined && output.Uid !== null ? output.Uid : undefined,
+    Gid: __expectNumber(output.Gid),
+    Uid: __expectNumber(output.Uid),
   } as any;
 };
 
@@ -10232,77 +10203,39 @@ const deserializeAws_restJson1GroupCertificateAuthorityProperties = (
   context: __SerdeContext
 ): GroupCertificateAuthorityProperties => {
   return {
-    GroupCertificateAuthorityArn:
-      output.GroupCertificateAuthorityArn !== undefined && output.GroupCertificateAuthorityArn !== null
-        ? output.GroupCertificateAuthorityArn
-        : undefined,
-    GroupCertificateAuthorityId:
-      output.GroupCertificateAuthorityId !== undefined && output.GroupCertificateAuthorityId !== null
-        ? output.GroupCertificateAuthorityId
-        : undefined,
+    GroupCertificateAuthorityArn: __expectString(output.GroupCertificateAuthorityArn),
+    GroupCertificateAuthorityId: __expectString(output.GroupCertificateAuthorityId),
   } as any;
 };
 
 const deserializeAws_restJson1GroupInformation = (output: any, context: __SerdeContext): GroupInformation => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    CreationTimestamp:
-      output.CreationTimestamp !== undefined && output.CreationTimestamp !== null
-        ? output.CreationTimestamp
-        : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    LastUpdatedTimestamp:
-      output.LastUpdatedTimestamp !== undefined && output.LastUpdatedTimestamp !== null
-        ? output.LastUpdatedTimestamp
-        : undefined,
-    LatestVersion:
-      output.LatestVersion !== undefined && output.LatestVersion !== null ? output.LatestVersion : undefined,
-    LatestVersionArn:
-      output.LatestVersionArn !== undefined && output.LatestVersionArn !== null ? output.LatestVersionArn : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Arn: __expectString(output.Arn),
+    CreationTimestamp: __expectString(output.CreationTimestamp),
+    Id: __expectString(output.Id),
+    LastUpdatedTimestamp: __expectString(output.LastUpdatedTimestamp),
+    LatestVersion: __expectString(output.LatestVersion),
+    LatestVersionArn: __expectString(output.LatestVersionArn),
+    Name: __expectString(output.Name),
   } as any;
 };
 
 const deserializeAws_restJson1GroupOwnerSetting = (output: any, context: __SerdeContext): GroupOwnerSetting => {
   return {
-    AutoAddGroupOwner:
-      output.AutoAddGroupOwner !== undefined && output.AutoAddGroupOwner !== null
-        ? output.AutoAddGroupOwner
-        : undefined,
-    GroupOwner: output.GroupOwner !== undefined && output.GroupOwner !== null ? output.GroupOwner : undefined,
+    AutoAddGroupOwner: __expectBoolean(output.AutoAddGroupOwner),
+    GroupOwner: __expectString(output.GroupOwner),
   } as any;
 };
 
 const deserializeAws_restJson1GroupVersion = (output: any, context: __SerdeContext): GroupVersion => {
   return {
-    ConnectorDefinitionVersionArn:
-      output.ConnectorDefinitionVersionArn !== undefined && output.ConnectorDefinitionVersionArn !== null
-        ? output.ConnectorDefinitionVersionArn
-        : undefined,
-    CoreDefinitionVersionArn:
-      output.CoreDefinitionVersionArn !== undefined && output.CoreDefinitionVersionArn !== null
-        ? output.CoreDefinitionVersionArn
-        : undefined,
-    DeviceDefinitionVersionArn:
-      output.DeviceDefinitionVersionArn !== undefined && output.DeviceDefinitionVersionArn !== null
-        ? output.DeviceDefinitionVersionArn
-        : undefined,
-    FunctionDefinitionVersionArn:
-      output.FunctionDefinitionVersionArn !== undefined && output.FunctionDefinitionVersionArn !== null
-        ? output.FunctionDefinitionVersionArn
-        : undefined,
-    LoggerDefinitionVersionArn:
-      output.LoggerDefinitionVersionArn !== undefined && output.LoggerDefinitionVersionArn !== null
-        ? output.LoggerDefinitionVersionArn
-        : undefined,
-    ResourceDefinitionVersionArn:
-      output.ResourceDefinitionVersionArn !== undefined && output.ResourceDefinitionVersionArn !== null
-        ? output.ResourceDefinitionVersionArn
-        : undefined,
-    SubscriptionDefinitionVersionArn:
-      output.SubscriptionDefinitionVersionArn !== undefined && output.SubscriptionDefinitionVersionArn !== null
-        ? output.SubscriptionDefinitionVersionArn
-        : undefined,
+    ConnectorDefinitionVersionArn: __expectString(output.ConnectorDefinitionVersionArn),
+    CoreDefinitionVersionArn: __expectString(output.CoreDefinitionVersionArn),
+    DeviceDefinitionVersionArn: __expectString(output.DeviceDefinitionVersionArn),
+    FunctionDefinitionVersionArn: __expectString(output.FunctionDefinitionVersionArn),
+    LoggerDefinitionVersionArn: __expectString(output.LoggerDefinitionVersionArn),
+    ResourceDefinitionVersionArn: __expectString(output.ResourceDefinitionVersionArn),
+    SubscriptionDefinitionVersionArn: __expectString(output.SubscriptionDefinitionVersionArn),
   } as any;
 };
 
@@ -10315,7 +10248,7 @@ const deserializeAws_restJson1LocalDeviceResourceData = (
       output.GroupOwnerSetting !== undefined && output.GroupOwnerSetting !== null
         ? deserializeAws_restJson1GroupOwnerSetting(output.GroupOwnerSetting, context)
         : undefined,
-    SourcePath: output.SourcePath !== undefined && output.SourcePath !== null ? output.SourcePath : undefined,
+    SourcePath: __expectString(output.SourcePath),
   } as any;
 };
 
@@ -10324,23 +10257,22 @@ const deserializeAws_restJson1LocalVolumeResourceData = (
   context: __SerdeContext
 ): LocalVolumeResourceData => {
   return {
-    DestinationPath:
-      output.DestinationPath !== undefined && output.DestinationPath !== null ? output.DestinationPath : undefined,
+    DestinationPath: __expectString(output.DestinationPath),
     GroupOwnerSetting:
       output.GroupOwnerSetting !== undefined && output.GroupOwnerSetting !== null
         ? deserializeAws_restJson1GroupOwnerSetting(output.GroupOwnerSetting, context)
         : undefined,
-    SourcePath: output.SourcePath !== undefined && output.SourcePath !== null ? output.SourcePath : undefined,
+    SourcePath: __expectString(output.SourcePath),
   } as any;
 };
 
 const deserializeAws_restJson1Logger = (output: any, context: __SerdeContext): Logger => {
   return {
-    Component: output.Component !== undefined && output.Component !== null ? output.Component : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Level: output.Level !== undefined && output.Level !== null ? output.Level : undefined,
-    Space: output.Space !== undefined && output.Space !== null ? output.Space : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Component: __expectString(output.Component),
+    Id: __expectString(output.Id),
+    Level: __expectString(output.Level),
+    Space: __expectNumber(output.Space),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -10358,8 +10290,8 @@ const deserializeAws_restJson1LoggerDefinitionVersion = (
 
 const deserializeAws_restJson1Resource = (output: any, context: __SerdeContext): Resource => {
   return {
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
     ResourceDataContainer:
       output.ResourceDataContainer !== undefined && output.ResourceDataContainer !== null
         ? deserializeAws_restJson1ResourceDataContainer(output.ResourceDataContainer, context)
@@ -10369,8 +10301,8 @@ const deserializeAws_restJson1Resource = (output: any, context: __SerdeContext):
 
 const deserializeAws_restJson1ResourceAccessPolicy = (output: any, context: __SerdeContext): ResourceAccessPolicy => {
   return {
-    Permission: output.Permission !== undefined && output.Permission !== null ? output.Permission : undefined,
-    ResourceId: output.ResourceId !== undefined && output.ResourceId !== null ? output.ResourceId : undefined,
+    Permission: __expectString(output.Permission),
+    ResourceId: __expectString(output.ResourceId),
   } as any;
 };
 
@@ -10420,9 +10352,8 @@ const deserializeAws_restJson1ResourceDownloadOwnerSetting = (
   context: __SerdeContext
 ): ResourceDownloadOwnerSetting => {
   return {
-    GroupOwner: output.GroupOwner !== undefined && output.GroupOwner !== null ? output.GroupOwner : undefined,
-    GroupPermission:
-      output.GroupPermission !== undefined && output.GroupPermission !== null ? output.GroupPermission : undefined,
+    GroupOwner: __expectString(output.GroupOwner),
+    GroupPermission: __expectString(output.GroupPermission),
   } as any;
 };
 
@@ -10440,13 +10371,12 @@ const deserializeAws_restJson1S3MachineLearningModelResourceData = (
   context: __SerdeContext
 ): S3MachineLearningModelResourceData => {
   return {
-    DestinationPath:
-      output.DestinationPath !== undefined && output.DestinationPath !== null ? output.DestinationPath : undefined,
+    DestinationPath: __expectString(output.DestinationPath),
     OwnerSetting:
       output.OwnerSetting !== undefined && output.OwnerSetting !== null
         ? deserializeAws_restJson1ResourceDownloadOwnerSetting(output.OwnerSetting, context)
         : undefined,
-    S3Uri: output.S3Uri !== undefined && output.S3Uri !== null ? output.S3Uri : undefined,
+    S3Uri: __expectString(output.S3Uri),
   } as any;
 };
 
@@ -10455,14 +10385,12 @@ const deserializeAws_restJson1SageMakerMachineLearningModelResourceData = (
   context: __SerdeContext
 ): SageMakerMachineLearningModelResourceData => {
   return {
-    DestinationPath:
-      output.DestinationPath !== undefined && output.DestinationPath !== null ? output.DestinationPath : undefined,
+    DestinationPath: __expectString(output.DestinationPath),
     OwnerSetting:
       output.OwnerSetting !== undefined && output.OwnerSetting !== null
         ? deserializeAws_restJson1ResourceDownloadOwnerSetting(output.OwnerSetting, context)
         : undefined,
-    SageMakerJobArn:
-      output.SageMakerJobArn !== undefined && output.SageMakerJobArn !== null ? output.SageMakerJobArn : undefined,
+    SageMakerJobArn: __expectString(output.SageMakerJobArn),
   } as any;
 };
 
@@ -10471,7 +10399,7 @@ const deserializeAws_restJson1SecretsManagerSecretResourceData = (
   context: __SerdeContext
 ): SecretsManagerSecretResourceData => {
   return {
-    ARN: output.ARN !== undefined && output.ARN !== null ? output.ARN : undefined,
+    ARN: __expectString(output.ARN),
     AdditionalStagingLabelsToDownload:
       output.AdditionalStagingLabelsToDownload !== undefined && output.AdditionalStagingLabelsToDownload !== null
         ? deserializeAws_restJson1__listOf__string(output.AdditionalStagingLabelsToDownload, context)
@@ -10481,10 +10409,10 @@ const deserializeAws_restJson1SecretsManagerSecretResourceData = (
 
 const deserializeAws_restJson1Subscription = (output: any, context: __SerdeContext): Subscription => {
   return {
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Source: output.Source !== undefined && output.Source !== null ? output.Source : undefined,
-    Subject: output.Subject !== undefined && output.Subject !== null ? output.Subject : undefined,
-    Target: output.Target !== undefined && output.Target !== null ? output.Target : undefined,
+    Id: __expectString(output.Id),
+    Source: __expectString(output.Source),
+    Subject: __expectString(output.Subject),
+    Target: __expectString(output.Target),
   } as any;
 };
 
@@ -10507,7 +10435,7 @@ const deserializeAws_restJson1Tags = (output: any, context: __SerdeContext): { [
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -10517,23 +10445,17 @@ const deserializeAws_restJson1TelemetryConfiguration = (
   context: __SerdeContext
 ): TelemetryConfiguration => {
   return {
-    ConfigurationSyncStatus:
-      output.ConfigurationSyncStatus !== undefined && output.ConfigurationSyncStatus !== null
-        ? output.ConfigurationSyncStatus
-        : undefined,
-    Telemetry: output.Telemetry !== undefined && output.Telemetry !== null ? output.Telemetry : undefined,
+    ConfigurationSyncStatus: __expectString(output.ConfigurationSyncStatus),
+    Telemetry: __expectString(output.Telemetry),
   } as any;
 };
 
 const deserializeAws_restJson1VersionInformation = (output: any, context: __SerdeContext): VersionInformation => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    CreationTimestamp:
-      output.CreationTimestamp !== undefined && output.CreationTimestamp !== null
-        ? output.CreationTimestamp
-        : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    Arn: __expectString(output.Arn),
+    CreationTimestamp: __expectString(output.CreationTimestamp),
+    Id: __expectString(output.Id),
+    Version: __expectString(output.Version),
   } as any;
 };
 

--- a/clients/client-greengrassv2/protocols/Aws_restJson1.ts
+++ b/clients/client-greengrassv2/protocols/Aws_restJson1.ts
@@ -101,6 +101,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -1018,7 +1021,7 @@ export const deserializeAws_restJson1CancelDeploymentCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return Promise.resolve(contents);
 };
@@ -1117,13 +1120,13 @@ export const deserializeAws_restJson1CreateComponentVersionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.componentName !== undefined && data.componentName !== null) {
-    contents.componentName = data.componentName;
+    contents.componentName = __expectString(data.componentName);
   }
   if (data.componentVersion !== undefined && data.componentVersion !== null) {
-    contents.componentVersion = data.componentVersion;
+    contents.componentVersion = __expectString(data.componentVersion);
   }
   if (data.creationTimestamp !== undefined && data.creationTimestamp !== null) {
     contents.creationTimestamp = new Date(Math.round(data.creationTimestamp * 1000));
@@ -1226,13 +1229,13 @@ export const deserializeAws_restJson1CreateDeploymentCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.deploymentId !== undefined && data.deploymentId !== null) {
-    contents.deploymentId = data.deploymentId;
+    contents.deploymentId = __expectString(data.deploymentId);
   }
   if (data.iotJobArn !== undefined && data.iotJobArn !== null) {
-    contents.iotJobArn = data.iotJobArn;
+    contents.iotJobArn = __expectString(data.iotJobArn);
   }
   if (data.iotJobId !== undefined && data.iotJobId !== null) {
-    contents.iotJobId = data.iotJobId;
+    contents.iotJobId = __expectString(data.iotJobId);
   }
   return Promise.resolve(contents);
 };
@@ -1509,25 +1512,25 @@ export const deserializeAws_restJson1DescribeComponentCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.componentName !== undefined && data.componentName !== null) {
-    contents.componentName = data.componentName;
+    contents.componentName = __expectString(data.componentName);
   }
   if (data.componentVersion !== undefined && data.componentVersion !== null) {
-    contents.componentVersion = data.componentVersion;
+    contents.componentVersion = __expectString(data.componentVersion);
   }
   if (data.creationTimestamp !== undefined && data.creationTimestamp !== null) {
     contents.creationTimestamp = new Date(Math.round(data.creationTimestamp * 1000));
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.platforms !== undefined && data.platforms !== null) {
     contents.platforms = deserializeAws_restJson1ComponentPlatformList(data.platforms, context);
   }
   if (data.publisher !== undefined && data.publisher !== null) {
-    contents.publisher = data.publisher;
+    contents.publisher = __expectString(data.publisher);
   }
   if (data.status !== undefined && data.status !== null) {
     contents.status = deserializeAws_restJson1CloudComponentStatus(data.status, context);
@@ -1625,7 +1628,7 @@ export const deserializeAws_restJson1GetComponentCommand = async (
     contents.recipe = context.base64Decoder(data.recipe);
   }
   if (data.recipeOutputFormat !== undefined && data.recipeOutputFormat !== null) {
-    contents.recipeOutputFormat = data.recipeOutputFormat;
+    contents.recipeOutputFormat = __expectString(data.recipeOutputFormat);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
@@ -1715,7 +1718,7 @@ export const deserializeAws_restJson1GetComponentVersionArtifactCommand = async 
   };
   const data: any = await parseBody(output.body, context);
   if (data.preSignedUrl !== undefined && data.preSignedUrl !== null) {
-    contents.preSignedUrl = data.preSignedUrl;
+    contents.preSignedUrl = __expectString(data.preSignedUrl);
   }
   return Promise.resolve(contents);
 };
@@ -1808,22 +1811,22 @@ export const deserializeAws_restJson1GetCoreDeviceCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.architecture !== undefined && data.architecture !== null) {
-    contents.architecture = data.architecture;
+    contents.architecture = __expectString(data.architecture);
   }
   if (data.coreDeviceThingName !== undefined && data.coreDeviceThingName !== null) {
-    contents.coreDeviceThingName = data.coreDeviceThingName;
+    contents.coreDeviceThingName = __expectString(data.coreDeviceThingName);
   }
   if (data.coreVersion !== undefined && data.coreVersion !== null) {
-    contents.coreVersion = data.coreVersion;
+    contents.coreVersion = __expectString(data.coreVersion);
   }
   if (data.lastStatusUpdateTimestamp !== undefined && data.lastStatusUpdateTimestamp !== null) {
     contents.lastStatusUpdateTimestamp = new Date(Math.round(data.lastStatusUpdateTimestamp * 1000));
   }
   if (data.platform !== undefined && data.platform !== null) {
-    contents.platform = data.platform;
+    contents.platform = __expectString(data.platform);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.status = data.status;
+    contents.status = __expectString(data.status);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
@@ -1931,19 +1934,19 @@ export const deserializeAws_restJson1GetDeploymentCommand = async (
     contents.creationTimestamp = new Date(Math.round(data.creationTimestamp * 1000));
   }
   if (data.deploymentId !== undefined && data.deploymentId !== null) {
-    contents.deploymentId = data.deploymentId;
+    contents.deploymentId = __expectString(data.deploymentId);
   }
   if (data.deploymentName !== undefined && data.deploymentName !== null) {
-    contents.deploymentName = data.deploymentName;
+    contents.deploymentName = __expectString(data.deploymentName);
   }
   if (data.deploymentPolicies !== undefined && data.deploymentPolicies !== null) {
     contents.deploymentPolicies = deserializeAws_restJson1DeploymentPolicies(data.deploymentPolicies, context);
   }
   if (data.deploymentStatus !== undefined && data.deploymentStatus !== null) {
-    contents.deploymentStatus = data.deploymentStatus;
+    contents.deploymentStatus = __expectString(data.deploymentStatus);
   }
   if (data.iotJobArn !== undefined && data.iotJobArn !== null) {
-    contents.iotJobArn = data.iotJobArn;
+    contents.iotJobArn = __expectString(data.iotJobArn);
   }
   if (data.iotJobConfiguration !== undefined && data.iotJobConfiguration !== null) {
     contents.iotJobConfiguration = deserializeAws_restJson1DeploymentIoTJobConfiguration(
@@ -1952,19 +1955,19 @@ export const deserializeAws_restJson1GetDeploymentCommand = async (
     );
   }
   if (data.iotJobId !== undefined && data.iotJobId !== null) {
-    contents.iotJobId = data.iotJobId;
+    contents.iotJobId = __expectString(data.iotJobId);
   }
   if (data.isLatestForTarget !== undefined && data.isLatestForTarget !== null) {
-    contents.isLatestForTarget = data.isLatestForTarget;
+    contents.isLatestForTarget = __expectBoolean(data.isLatestForTarget);
   }
   if (data.revisionId !== undefined && data.revisionId !== null) {
-    contents.revisionId = data.revisionId;
+    contents.revisionId = __expectString(data.revisionId);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
   if (data.targetArn !== undefined && data.targetArn !== null) {
-    contents.targetArn = data.targetArn;
+    contents.targetArn = __expectString(data.targetArn);
   }
   return Promise.resolve(contents);
 };
@@ -2058,7 +2061,7 @@ export const deserializeAws_restJson1ListClientDevicesAssociatedWithCoreDeviceCo
     );
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2149,7 +2152,7 @@ export const deserializeAws_restJson1ListComponentsCommand = async (
     contents.components = deserializeAws_restJson1ComponentList(data.components, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2232,7 +2235,7 @@ export const deserializeAws_restJson1ListComponentVersionsCommand = async (
     contents.componentVersions = deserializeAws_restJson1ComponentVersionList(data.componentVersions, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2323,7 +2326,7 @@ export const deserializeAws_restJson1ListCoreDevicesCommand = async (
     contents.coreDevices = deserializeAws_restJson1CoreDevicesList(data.coreDevices, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2406,7 +2409,7 @@ export const deserializeAws_restJson1ListDeploymentsCommand = async (
     contents.deployments = deserializeAws_restJson1DeploymentList(data.deployments, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2492,7 +2495,7 @@ export const deserializeAws_restJson1ListEffectiveDeploymentsCommand = async (
     );
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2583,7 +2586,7 @@ export const deserializeAws_restJson1ListInstalledComponentsCommand = async (
     contents.installedComponents = deserializeAws_restJson1InstalledComponentList(data.installedComponents, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2972,7 +2975,7 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2991,13 +2994,13 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.resourceId !== undefined && data.resourceId !== null) {
-    contents.resourceId = data.resourceId;
+    contents.resourceId = __expectString(data.resourceId);
   }
   if (data.resourceType !== undefined && data.resourceType !== null) {
-    contents.resourceType = data.resourceType;
+    contents.resourceType = __expectString(data.resourceType);
   }
   return contents;
 };
@@ -3018,7 +3021,7 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   }
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -3037,13 +3040,13 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.resourceId !== undefined && data.resourceId !== null) {
-    contents.resourceId = data.resourceId;
+    contents.resourceId = __expectString(data.resourceId);
   }
   if (data.resourceType !== undefined && data.resourceType !== null) {
-    contents.resourceType = data.resourceType;
+    contents.resourceType = __expectString(data.resourceType);
   }
   return contents;
 };
@@ -3064,19 +3067,19 @@ const deserializeAws_restJson1ServiceQuotaExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.quotaCode !== undefined && data.quotaCode !== null) {
-    contents.quotaCode = data.quotaCode;
+    contents.quotaCode = __expectString(data.quotaCode);
   }
   if (data.resourceId !== undefined && data.resourceId !== null) {
-    contents.resourceId = data.resourceId;
+    contents.resourceId = __expectString(data.resourceId);
   }
   if (data.resourceType !== undefined && data.resourceType !== null) {
-    contents.resourceType = data.resourceType;
+    contents.resourceType = __expectString(data.resourceType);
   }
   if (data.serviceCode !== undefined && data.serviceCode !== null) {
-    contents.serviceCode = data.serviceCode;
+    contents.serviceCode = __expectString(data.serviceCode);
   }
   return contents;
 };
@@ -3099,13 +3102,13 @@ const deserializeAws_restJson1ThrottlingExceptionResponse = async (
   }
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.quotaCode !== undefined && data.quotaCode !== null) {
-    contents.quotaCode = data.quotaCode;
+    contents.quotaCode = __expectString(data.quotaCode);
   }
   if (data.serviceCode !== undefined && data.serviceCode !== null) {
-    contents.serviceCode = data.serviceCode;
+    contents.serviceCode = __expectString(data.serviceCode);
   }
   return contents;
 };
@@ -3127,10 +3130,10 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
     contents.fields = deserializeAws_restJson1ValidationExceptionFieldList(data.fields, context);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.reason !== undefined && data.reason !== null) {
-    contents.reason = data.reason;
+    contents.reason = __expectString(data.reason);
   }
   return contents;
 };
@@ -3679,9 +3682,9 @@ const deserializeAws_restJson1AssociateClientDeviceWithCoreDeviceErrorEntry = (
   context: __SerdeContext
 ): AssociateClientDeviceWithCoreDeviceErrorEntry => {
   return {
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    thingName: output.thingName !== undefined && output.thingName !== null ? output.thingName : undefined,
+    code: __expectString(output.code),
+    message: __expectString(output.message),
+    thingName: __expectString(output.thingName),
   } as any;
 };
 
@@ -3708,7 +3711,7 @@ const deserializeAws_restJson1AssociatedClientDevice = (
       output.associationTimestamp !== undefined && output.associationTimestamp !== null
         ? new Date(Math.round(output.associationTimestamp * 1000))
         : undefined,
-    thingName: output.thingName !== undefined && output.thingName !== null ? output.thingName : undefined,
+    thingName: __expectString(output.thingName),
   } as any;
 };
 
@@ -3728,21 +3731,19 @@ const deserializeAws_restJson1AssociatedClientDeviceList = (
 
 const deserializeAws_restJson1CloudComponentStatus = (output: any, context: __SerdeContext): CloudComponentStatus => {
   return {
-    componentState:
-      output.componentState !== undefined && output.componentState !== null ? output.componentState : undefined,
+    componentState: __expectString(output.componentState),
     errors:
       output.errors !== undefined && output.errors !== null
         ? deserializeAws_restJson1StringMap(output.errors, context)
         : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_restJson1Component = (output: any, context: __SerdeContext): Component => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    componentName:
-      output.componentName !== undefined && output.componentName !== null ? output.componentName : undefined,
+    arn: __expectString(output.arn),
+    componentName: __expectString(output.componentName),
     latestVersion:
       output.latestVersion !== undefined && output.latestVersion !== null
         ? deserializeAws_restJson1ComponentLatestVersion(output.latestVersion, context)
@@ -3757,7 +3758,7 @@ const deserializeAws_restJson1ComponentConfigurationPathList = (output: any, con
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3766,7 +3767,7 @@ const deserializeAws_restJson1ComponentConfigurationUpdate = (
   context: __SerdeContext
 ): ComponentConfigurationUpdate => {
   return {
-    merge: output.merge !== undefined && output.merge !== null ? output.merge : undefined,
+    merge: __expectString(output.merge),
     reset:
       output.reset !== undefined && output.reset !== null
         ? deserializeAws_restJson1ComponentConfigurationPathList(output.reset, context)
@@ -3779,8 +3780,7 @@ const deserializeAws_restJson1ComponentDeploymentSpecification = (
   context: __SerdeContext
 ): ComponentDeploymentSpecification => {
   return {
-    componentVersion:
-      output.componentVersion !== undefined && output.componentVersion !== null ? output.componentVersion : undefined,
+    componentVersion: __expectString(output.componentVersion),
     configurationUpdate:
       output.configurationUpdate !== undefined && output.configurationUpdate !== null
         ? deserializeAws_restJson1ComponentConfigurationUpdate(output.configurationUpdate, context)
@@ -3815,19 +3815,18 @@ const deserializeAws_restJson1ComponentLatestVersion = (
   context: __SerdeContext
 ): ComponentLatestVersion => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    componentVersion:
-      output.componentVersion !== undefined && output.componentVersion !== null ? output.componentVersion : undefined,
+    arn: __expectString(output.arn),
+    componentVersion: __expectString(output.componentVersion),
     creationTimestamp:
       output.creationTimestamp !== undefined && output.creationTimestamp !== null
         ? new Date(Math.round(output.creationTimestamp * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    description: __expectString(output.description),
     platforms:
       output.platforms !== undefined && output.platforms !== null
         ? deserializeAws_restJson1ComponentPlatformList(output.platforms, context)
         : undefined,
-    publisher: output.publisher !== undefined && output.publisher !== null ? output.publisher : undefined,
+    publisher: __expectString(output.publisher),
   } as any;
 };
 
@@ -3848,7 +3847,7 @@ const deserializeAws_restJson1ComponentPlatform = (output: any, context: __Serde
       output.attributes !== undefined && output.attributes !== null
         ? deserializeAws_restJson1PlatformAttributesMap(output.attributes, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -3865,7 +3864,7 @@ const deserializeAws_restJson1ComponentPlatformList = (output: any, context: __S
 
 const deserializeAws_restJson1ComponentRunWith = (output: any, context: __SerdeContext): ComponentRunWith => {
   return {
-    posixUser: output.posixUser !== undefined && output.posixUser !== null ? output.posixUser : undefined,
+    posixUser: __expectString(output.posixUser),
   } as any;
 };
 
@@ -3888,25 +3887,20 @@ const deserializeAws_restJson1ComponentVersionListItem = (
   context: __SerdeContext
 ): ComponentVersionListItem => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    componentName:
-      output.componentName !== undefined && output.componentName !== null ? output.componentName : undefined,
-    componentVersion:
-      output.componentVersion !== undefined && output.componentVersion !== null ? output.componentVersion : undefined,
+    arn: __expectString(output.arn),
+    componentName: __expectString(output.componentName),
+    componentVersion: __expectString(output.componentVersion),
   } as any;
 };
 
 const deserializeAws_restJson1CoreDevice = (output: any, context: __SerdeContext): CoreDevice => {
   return {
-    coreDeviceThingName:
-      output.coreDeviceThingName !== undefined && output.coreDeviceThingName !== null
-        ? output.coreDeviceThingName
-        : undefined,
+    coreDeviceThingName: __expectString(output.coreDeviceThingName),
     lastStatusUpdateTimestamp:
       output.lastStatusUpdateTimestamp !== undefined && output.lastStatusUpdateTimestamp !== null
         ? new Date(Math.round(output.lastStatusUpdateTimestamp * 1000))
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -3927,17 +3921,12 @@ const deserializeAws_restJson1Deployment = (output: any, context: __SerdeContext
       output.creationTimestamp !== undefined && output.creationTimestamp !== null
         ? new Date(Math.round(output.creationTimestamp * 1000))
         : undefined,
-    deploymentId: output.deploymentId !== undefined && output.deploymentId !== null ? output.deploymentId : undefined,
-    deploymentName:
-      output.deploymentName !== undefined && output.deploymentName !== null ? output.deploymentName : undefined,
-    deploymentStatus:
-      output.deploymentStatus !== undefined && output.deploymentStatus !== null ? output.deploymentStatus : undefined,
-    isLatestForTarget:
-      output.isLatestForTarget !== undefined && output.isLatestForTarget !== null
-        ? output.isLatestForTarget
-        : undefined,
-    revisionId: output.revisionId !== undefined && output.revisionId !== null ? output.revisionId : undefined,
-    targetArn: output.targetArn !== undefined && output.targetArn !== null ? output.targetArn : undefined,
+    deploymentId: __expectString(output.deploymentId),
+    deploymentName: __expectString(output.deploymentName),
+    deploymentStatus: __expectString(output.deploymentStatus),
+    isLatestForTarget: __expectBoolean(output.isLatestForTarget),
+    revisionId: __expectString(output.revisionId),
+    targetArn: __expectString(output.targetArn),
   } as any;
 };
 
@@ -3946,9 +3935,8 @@ const deserializeAws_restJson1DeploymentComponentUpdatePolicy = (
   context: __SerdeContext
 ): DeploymentComponentUpdatePolicy => {
   return {
-    action: output.action !== undefined && output.action !== null ? output.action : undefined,
-    timeoutInSeconds:
-      output.timeoutInSeconds !== undefined && output.timeoutInSeconds !== null ? output.timeoutInSeconds : undefined,
+    action: __expectString(output.action),
+    timeoutInSeconds: __expectNumber(output.timeoutInSeconds),
   } as any;
 };
 
@@ -3957,8 +3945,7 @@ const deserializeAws_restJson1DeploymentConfigurationValidationPolicy = (
   context: __SerdeContext
 ): DeploymentConfigurationValidationPolicy => {
   return {
-    timeoutInSeconds:
-      output.timeoutInSeconds !== undefined && output.timeoutInSeconds !== null ? output.timeoutInSeconds : undefined,
+    timeoutInSeconds: __expectNumber(output.timeoutInSeconds),
   } as any;
 };
 
@@ -4003,10 +3990,7 @@ const deserializeAws_restJson1DeploymentPolicies = (output: any, context: __Serd
       output.configurationValidationPolicy !== undefined && output.configurationValidationPolicy !== null
         ? deserializeAws_restJson1DeploymentConfigurationValidationPolicy(output.configurationValidationPolicy, context)
         : undefined,
-    failureHandlingPolicy:
-      output.failureHandlingPolicy !== undefined && output.failureHandlingPolicy !== null
-        ? output.failureHandlingPolicy
-        : undefined,
+    failureHandlingPolicy: __expectString(output.failureHandlingPolicy),
   } as any;
 };
 
@@ -4015,9 +3999,9 @@ const deserializeAws_restJson1DisassociateClientDeviceFromCoreDeviceErrorEntry =
   context: __SerdeContext
 ): DisassociateClientDeviceFromCoreDeviceErrorEntry => {
   return {
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    thingName: output.thingName !== undefined && output.thingName !== null ? output.thingName : undefined,
+    code: __expectString(output.code),
+    message: __expectString(output.message),
+    thingName: __expectString(output.thingName),
   } as any;
 };
 
@@ -4037,26 +4021,22 @@ const deserializeAws_restJson1DisassociateClientDeviceFromCoreDeviceErrorList = 
 
 const deserializeAws_restJson1EffectiveDeployment = (output: any, context: __SerdeContext): EffectiveDeployment => {
   return {
-    coreDeviceExecutionStatus:
-      output.coreDeviceExecutionStatus !== undefined && output.coreDeviceExecutionStatus !== null
-        ? output.coreDeviceExecutionStatus
-        : undefined,
+    coreDeviceExecutionStatus: __expectString(output.coreDeviceExecutionStatus),
     creationTimestamp:
       output.creationTimestamp !== undefined && output.creationTimestamp !== null
         ? new Date(Math.round(output.creationTimestamp * 1000))
         : undefined,
-    deploymentId: output.deploymentId !== undefined && output.deploymentId !== null ? output.deploymentId : undefined,
-    deploymentName:
-      output.deploymentName !== undefined && output.deploymentName !== null ? output.deploymentName : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    iotJobArn: output.iotJobArn !== undefined && output.iotJobArn !== null ? output.iotJobArn : undefined,
-    iotJobId: output.iotJobId !== undefined && output.iotJobId !== null ? output.iotJobId : undefined,
+    deploymentId: __expectString(output.deploymentId),
+    deploymentName: __expectString(output.deploymentName),
+    description: __expectString(output.description),
+    iotJobArn: __expectString(output.iotJobArn),
+    iotJobId: __expectString(output.iotJobId),
     modifiedTimestamp:
       output.modifiedTimestamp !== undefined && output.modifiedTimestamp !== null
         ? new Date(Math.round(output.modifiedTimestamp * 1000))
         : undefined,
-    reason: output.reason !== undefined && output.reason !== null ? output.reason : undefined,
-    targetArn: output.targetArn !== undefined && output.targetArn !== null ? output.targetArn : undefined,
+    reason: __expectString(output.reason),
+    targetArn: __expectString(output.targetArn),
   } as any;
 };
 
@@ -4076,17 +4056,11 @@ const deserializeAws_restJson1EffectiveDeploymentsList = (
 
 const deserializeAws_restJson1InstalledComponent = (output: any, context: __SerdeContext): InstalledComponent => {
   return {
-    componentName:
-      output.componentName !== undefined && output.componentName !== null ? output.componentName : undefined,
-    componentVersion:
-      output.componentVersion !== undefined && output.componentVersion !== null ? output.componentVersion : undefined,
-    isRoot: output.isRoot !== undefined && output.isRoot !== null ? output.isRoot : undefined,
-    lifecycleState:
-      output.lifecycleState !== undefined && output.lifecycleState !== null ? output.lifecycleState : undefined,
-    lifecycleStateDetails:
-      output.lifecycleStateDetails !== undefined && output.lifecycleStateDetails !== null
-        ? output.lifecycleStateDetails
-        : undefined,
+    componentName: __expectString(output.componentName),
+    componentVersion: __expectString(output.componentVersion),
+    isRoot: __expectBoolean(output.isRoot),
+    lifecycleState: __expectString(output.lifecycleState),
+    lifecycleStateDetails: __expectString(output.lifecycleStateDetails),
   } as any;
 };
 
@@ -4112,16 +4086,10 @@ const deserializeAws_restJson1IoTJobAbortConfig = (output: any, context: __Serde
 
 const deserializeAws_restJson1IoTJobAbortCriteria = (output: any, context: __SerdeContext): IoTJobAbortCriteria => {
   return {
-    action: output.action !== undefined && output.action !== null ? output.action : undefined,
-    failureType: output.failureType !== undefined && output.failureType !== null ? output.failureType : undefined,
-    minNumberOfExecutedThings:
-      output.minNumberOfExecutedThings !== undefined && output.minNumberOfExecutedThings !== null
-        ? output.minNumberOfExecutedThings
-        : undefined,
-    thresholdPercentage:
-      output.thresholdPercentage !== undefined && output.thresholdPercentage !== null
-        ? output.thresholdPercentage
-        : undefined,
+    action: __expectString(output.action),
+    failureType: __expectString(output.failureType),
+    minNumberOfExecutedThings: __expectNumber(output.minNumberOfExecutedThings),
+    thresholdPercentage: __expectNumber(output.thresholdPercentage),
   } as any;
 };
 
@@ -4148,8 +4116,7 @@ const deserializeAws_restJson1IoTJobExecutionsRolloutConfig = (
       output.exponentialRate !== undefined && output.exponentialRate !== null
         ? deserializeAws_restJson1IoTJobExponentialRolloutRate(output.exponentialRate, context)
         : undefined,
-    maximumPerMinute:
-      output.maximumPerMinute !== undefined && output.maximumPerMinute !== null ? output.maximumPerMinute : undefined,
+    maximumPerMinute: __expectNumber(output.maximumPerMinute),
   } as any;
 };
 
@@ -4158,12 +4125,8 @@ const deserializeAws_restJson1IoTJobExponentialRolloutRate = (
   context: __SerdeContext
 ): IoTJobExponentialRolloutRate => {
   return {
-    baseRatePerMinute:
-      output.baseRatePerMinute !== undefined && output.baseRatePerMinute !== null
-        ? output.baseRatePerMinute
-        : undefined,
-    incrementFactor:
-      output.incrementFactor !== undefined && output.incrementFactor !== null ? output.incrementFactor : undefined,
+    baseRatePerMinute: __expectNumber(output.baseRatePerMinute),
+    incrementFactor: __expectNumber(output.incrementFactor),
     rateIncreaseCriteria:
       output.rateIncreaseCriteria !== undefined && output.rateIncreaseCriteria !== null
         ? deserializeAws_restJson1IoTJobRateIncreaseCriteria(output.rateIncreaseCriteria, context)
@@ -4176,23 +4139,14 @@ const deserializeAws_restJson1IoTJobRateIncreaseCriteria = (
   context: __SerdeContext
 ): IoTJobRateIncreaseCriteria => {
   return {
-    numberOfNotifiedThings:
-      output.numberOfNotifiedThings !== undefined && output.numberOfNotifiedThings !== null
-        ? output.numberOfNotifiedThings
-        : undefined,
-    numberOfSucceededThings:
-      output.numberOfSucceededThings !== undefined && output.numberOfSucceededThings !== null
-        ? output.numberOfSucceededThings
-        : undefined,
+    numberOfNotifiedThings: __expectNumber(output.numberOfNotifiedThings),
+    numberOfSucceededThings: __expectNumber(output.numberOfSucceededThings),
   } as any;
 };
 
 const deserializeAws_restJson1IoTJobTimeoutConfig = (output: any, context: __SerdeContext): IoTJobTimeoutConfig => {
   return {
-    inProgressTimeoutInMinutes:
-      output.inProgressTimeoutInMinutes !== undefined && output.inProgressTimeoutInMinutes !== null
-        ? output.inProgressTimeoutInMinutes
-        : undefined,
+    inProgressTimeoutInMinutes: __expectNumber(output.inProgressTimeoutInMinutes),
   } as any;
 };
 
@@ -4206,7 +4160,7 @@ const deserializeAws_restJson1PlatformAttributesMap = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -4216,11 +4170,9 @@ const deserializeAws_restJson1ResolvedComponentVersion = (
   context: __SerdeContext
 ): ResolvedComponentVersion => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    componentName:
-      output.componentName !== undefined && output.componentName !== null ? output.componentName : undefined,
-    componentVersion:
-      output.componentVersion !== undefined && output.componentVersion !== null ? output.componentVersion : undefined,
+    arn: __expectString(output.arn),
+    componentName: __expectString(output.componentName),
+    componentVersion: __expectString(output.componentVersion),
     recipe: output.recipe !== undefined && output.recipe !== null ? context.base64Decoder(output.recipe) : undefined,
   } as any;
 };
@@ -4246,7 +4198,7 @@ const deserializeAws_restJson1StringMap = (output: any, context: __SerdeContext)
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -4258,7 +4210,7 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -4268,8 +4220,8 @@ const deserializeAws_restJson1ValidationExceptionField = (
   context: __SerdeContext
 ): ValidationExceptionField => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    message: __expectString(output.message),
+    name: __expectString(output.name),
   } as any;
 };
 

--- a/clients/client-groundstation/protocols/Aws_restJson1.ts
+++ b/clients/client-groundstation/protocols/Aws_restJson1.ts
@@ -92,6 +92,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -888,7 +891,7 @@ export const deserializeAws_restJson1CancelContactCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.contactId !== undefined && data.contactId !== null) {
-    contents.contactId = data.contactId;
+    contents.contactId = __expectString(data.contactId);
   }
   return Promise.resolve(contents);
 };
@@ -961,13 +964,13 @@ export const deserializeAws_restJson1CreateConfigCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.configArn !== undefined && data.configArn !== null) {
-    contents.configArn = data.configArn;
+    contents.configArn = __expectString(data.configArn);
   }
   if (data.configId !== undefined && data.configId !== null) {
-    contents.configId = data.configId;
+    contents.configId = __expectString(data.configId);
   }
   if (data.configType !== undefined && data.configType !== null) {
-    contents.configType = data.configType;
+    contents.configType = __expectString(data.configType);
   }
   return Promise.resolve(contents);
 };
@@ -1046,7 +1049,7 @@ export const deserializeAws_restJson1CreateDataflowEndpointGroupCommand = async 
   };
   const data: any = await parseBody(output.body, context);
   if (data.dataflowEndpointGroupId !== undefined && data.dataflowEndpointGroupId !== null) {
-    contents.dataflowEndpointGroupId = data.dataflowEndpointGroupId;
+    contents.dataflowEndpointGroupId = __expectString(data.dataflowEndpointGroupId);
   }
   return Promise.resolve(contents);
 };
@@ -1117,7 +1120,7 @@ export const deserializeAws_restJson1CreateMissionProfileCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.missionProfileId !== undefined && data.missionProfileId !== null) {
-    contents.missionProfileId = data.missionProfileId;
+    contents.missionProfileId = __expectString(data.missionProfileId);
   }
   return Promise.resolve(contents);
 };
@@ -1190,13 +1193,13 @@ export const deserializeAws_restJson1DeleteConfigCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.configArn !== undefined && data.configArn !== null) {
-    contents.configArn = data.configArn;
+    contents.configArn = __expectString(data.configArn);
   }
   if (data.configId !== undefined && data.configId !== null) {
-    contents.configId = data.configId;
+    contents.configId = __expectString(data.configId);
   }
   if (data.configType !== undefined && data.configType !== null) {
-    contents.configType = data.configType;
+    contents.configType = __expectString(data.configType);
   }
   return Promise.resolve(contents);
 };
@@ -1267,7 +1270,7 @@ export const deserializeAws_restJson1DeleteDataflowEndpointGroupCommand = async 
   };
   const data: any = await parseBody(output.body, context);
   if (data.dataflowEndpointGroupId !== undefined && data.dataflowEndpointGroupId !== null) {
-    contents.dataflowEndpointGroupId = data.dataflowEndpointGroupId;
+    contents.dataflowEndpointGroupId = __expectString(data.dataflowEndpointGroupId);
   }
   return Promise.resolve(contents);
 };
@@ -1338,7 +1341,7 @@ export const deserializeAws_restJson1DeleteMissionProfileCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.missionProfileId !== undefined && data.missionProfileId !== null) {
-    contents.missionProfileId = data.missionProfileId;
+    contents.missionProfileId = __expectString(data.missionProfileId);
   }
   return Promise.resolve(contents);
 };
@@ -1422,10 +1425,10 @@ export const deserializeAws_restJson1DescribeContactCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.contactId !== undefined && data.contactId !== null) {
-    contents.contactId = data.contactId;
+    contents.contactId = __expectString(data.contactId);
   }
   if (data.contactStatus !== undefined && data.contactStatus !== null) {
-    contents.contactStatus = data.contactStatus;
+    contents.contactStatus = __expectString(data.contactStatus);
   }
   if (data.dataflowList !== undefined && data.dataflowList !== null) {
     contents.dataflowList = deserializeAws_restJson1DataflowList(data.dataflowList, context);
@@ -1434,16 +1437,16 @@ export const deserializeAws_restJson1DescribeContactCommand = async (
     contents.endTime = new Date(Math.round(data.endTime * 1000));
   }
   if (data.errorMessage !== undefined && data.errorMessage !== null) {
-    contents.errorMessage = data.errorMessage;
+    contents.errorMessage = __expectString(data.errorMessage);
   }
   if (data.groundStation !== undefined && data.groundStation !== null) {
-    contents.groundStation = data.groundStation;
+    contents.groundStation = __expectString(data.groundStation);
   }
   if (data.maximumElevation !== undefined && data.maximumElevation !== null) {
     contents.maximumElevation = deserializeAws_restJson1Elevation(data.maximumElevation, context);
   }
   if (data.missionProfileArn !== undefined && data.missionProfileArn !== null) {
-    contents.missionProfileArn = data.missionProfileArn;
+    contents.missionProfileArn = __expectString(data.missionProfileArn);
   }
   if (data.postPassEndTime !== undefined && data.postPassEndTime !== null) {
     contents.postPassEndTime = new Date(Math.round(data.postPassEndTime * 1000));
@@ -1452,10 +1455,10 @@ export const deserializeAws_restJson1DescribeContactCommand = async (
     contents.prePassStartTime = new Date(Math.round(data.prePassStartTime * 1000));
   }
   if (data.region !== undefined && data.region !== null) {
-    contents.region = data.region;
+    contents.region = __expectString(data.region);
   }
   if (data.satelliteArn !== undefined && data.satelliteArn !== null) {
-    contents.satelliteArn = data.satelliteArn;
+    contents.satelliteArn = __expectString(data.satelliteArn);
   }
   if (data.startTime !== undefined && data.startTime !== null) {
     contents.startTime = new Date(Math.round(data.startTime * 1000));
@@ -1537,19 +1540,19 @@ export const deserializeAws_restJson1GetConfigCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.configArn !== undefined && data.configArn !== null) {
-    contents.configArn = data.configArn;
+    contents.configArn = __expectString(data.configArn);
   }
   if (data.configData !== undefined && data.configData !== null) {
     contents.configData = deserializeAws_restJson1ConfigTypeData(data.configData, context);
   }
   if (data.configId !== undefined && data.configId !== null) {
-    contents.configId = data.configId;
+    contents.configId = __expectString(data.configId);
   }
   if (data.configType !== undefined && data.configType !== null) {
-    contents.configType = data.configType;
+    contents.configType = __expectString(data.configType);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagsMap(data.tags, context);
@@ -1626,10 +1629,10 @@ export const deserializeAws_restJson1GetDataflowEndpointGroupCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.dataflowEndpointGroupArn !== undefined && data.dataflowEndpointGroupArn !== null) {
-    contents.dataflowEndpointGroupArn = data.dataflowEndpointGroupArn;
+    contents.dataflowEndpointGroupArn = __expectString(data.dataflowEndpointGroupArn);
   }
   if (data.dataflowEndpointGroupId !== undefined && data.dataflowEndpointGroupId !== null) {
-    contents.dataflowEndpointGroupId = data.dataflowEndpointGroupId;
+    contents.dataflowEndpointGroupId = __expectString(data.dataflowEndpointGroupId);
   }
   if (data.endpointsDetails !== undefined && data.endpointsDetails !== null) {
     contents.endpointsDetails = deserializeAws_restJson1EndpointDetailsList(data.endpointsDetails, context);
@@ -1710,19 +1713,19 @@ export const deserializeAws_restJson1GetMinuteUsageCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.estimatedMinutesRemaining !== undefined && data.estimatedMinutesRemaining !== null) {
-    contents.estimatedMinutesRemaining = data.estimatedMinutesRemaining;
+    contents.estimatedMinutesRemaining = __expectNumber(data.estimatedMinutesRemaining);
   }
   if (data.isReservedMinutesCustomer !== undefined && data.isReservedMinutesCustomer !== null) {
-    contents.isReservedMinutesCustomer = data.isReservedMinutesCustomer;
+    contents.isReservedMinutesCustomer = __expectBoolean(data.isReservedMinutesCustomer);
   }
   if (data.totalReservedMinuteAllocation !== undefined && data.totalReservedMinuteAllocation !== null) {
-    contents.totalReservedMinuteAllocation = data.totalReservedMinuteAllocation;
+    contents.totalReservedMinuteAllocation = __expectNumber(data.totalReservedMinuteAllocation);
   }
   if (data.totalScheduledMinutes !== undefined && data.totalScheduledMinutes !== null) {
-    contents.totalScheduledMinutes = data.totalScheduledMinutes;
+    contents.totalScheduledMinutes = __expectNumber(data.totalScheduledMinutes);
   }
   if (data.upcomingMinutesScheduled !== undefined && data.upcomingMinutesScheduled !== null) {
-    contents.upcomingMinutesScheduled = data.upcomingMinutesScheduled;
+    contents.upcomingMinutesScheduled = __expectNumber(data.upcomingMinutesScheduled);
   }
   return Promise.resolve(contents);
 };
@@ -1802,34 +1805,34 @@ export const deserializeAws_restJson1GetMissionProfileCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.contactPostPassDurationSeconds !== undefined && data.contactPostPassDurationSeconds !== null) {
-    contents.contactPostPassDurationSeconds = data.contactPostPassDurationSeconds;
+    contents.contactPostPassDurationSeconds = __expectNumber(data.contactPostPassDurationSeconds);
   }
   if (data.contactPrePassDurationSeconds !== undefined && data.contactPrePassDurationSeconds !== null) {
-    contents.contactPrePassDurationSeconds = data.contactPrePassDurationSeconds;
+    contents.contactPrePassDurationSeconds = __expectNumber(data.contactPrePassDurationSeconds);
   }
   if (data.dataflowEdges !== undefined && data.dataflowEdges !== null) {
     contents.dataflowEdges = deserializeAws_restJson1DataflowEdgeList(data.dataflowEdges, context);
   }
   if (data.minimumViableContactDurationSeconds !== undefined && data.minimumViableContactDurationSeconds !== null) {
-    contents.minimumViableContactDurationSeconds = data.minimumViableContactDurationSeconds;
+    contents.minimumViableContactDurationSeconds = __expectNumber(data.minimumViableContactDurationSeconds);
   }
   if (data.missionProfileArn !== undefined && data.missionProfileArn !== null) {
-    contents.missionProfileArn = data.missionProfileArn;
+    contents.missionProfileArn = __expectString(data.missionProfileArn);
   }
   if (data.missionProfileId !== undefined && data.missionProfileId !== null) {
-    contents.missionProfileId = data.missionProfileId;
+    contents.missionProfileId = __expectString(data.missionProfileId);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.region !== undefined && data.region !== null) {
-    contents.region = data.region;
+    contents.region = __expectString(data.region);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagsMap(data.tags, context);
   }
   if (data.trackingConfigArn !== undefined && data.trackingConfigArn !== null) {
-    contents.trackingConfigArn = data.trackingConfigArn;
+    contents.trackingConfigArn = __expectString(data.trackingConfigArn);
   }
   return Promise.resolve(contents);
 };
@@ -1906,13 +1909,13 @@ export const deserializeAws_restJson1GetSatelliteCommand = async (
     contents.groundStations = deserializeAws_restJson1GroundStationIdList(data.groundStations, context);
   }
   if (data.noradSatelliteID !== undefined && data.noradSatelliteID !== null) {
-    contents.noradSatelliteID = data.noradSatelliteID;
+    contents.noradSatelliteID = __expectNumber(data.noradSatelliteID);
   }
   if (data.satelliteArn !== undefined && data.satelliteArn !== null) {
-    contents.satelliteArn = data.satelliteArn;
+    contents.satelliteArn = __expectString(data.satelliteArn);
   }
   if (data.satelliteId !== undefined && data.satelliteId !== null) {
-    contents.satelliteId = data.satelliteId;
+    contents.satelliteId = __expectString(data.satelliteId);
   }
   return Promise.resolve(contents);
 };
@@ -1987,7 +1990,7 @@ export const deserializeAws_restJson1ListConfigsCommand = async (
     contents.configList = deserializeAws_restJson1ConfigList(data.configList, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2062,7 +2065,7 @@ export const deserializeAws_restJson1ListContactsCommand = async (
     contents.contactList = deserializeAws_restJson1ContactList(data.contactList, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2140,7 +2143,7 @@ export const deserializeAws_restJson1ListDataflowEndpointGroupsCommand = async (
     );
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2215,7 +2218,7 @@ export const deserializeAws_restJson1ListGroundStationsCommand = async (
     contents.groundStationList = deserializeAws_restJson1GroundStationList(data.groundStationList, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2290,7 +2293,7 @@ export const deserializeAws_restJson1ListMissionProfilesCommand = async (
     contents.missionProfileList = deserializeAws_restJson1MissionProfileList(data.missionProfileList, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2362,7 +2365,7 @@ export const deserializeAws_restJson1ListSatellitesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.satellites !== undefined && data.satellites !== null) {
     contents.satellites = deserializeAws_restJson1SatelliteList(data.satellites, context);
@@ -2507,7 +2510,7 @@ export const deserializeAws_restJson1ReserveContactCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.contactId !== undefined && data.contactId !== null) {
-    contents.contactId = data.contactId;
+    contents.contactId = __expectString(data.contactId);
   }
   return Promise.resolve(contents);
 };
@@ -2714,13 +2717,13 @@ export const deserializeAws_restJson1UpdateConfigCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.configArn !== undefined && data.configArn !== null) {
-    contents.configArn = data.configArn;
+    contents.configArn = __expectString(data.configArn);
   }
   if (data.configId !== undefined && data.configId !== null) {
-    contents.configId = data.configId;
+    contents.configId = __expectString(data.configId);
   }
   if (data.configType !== undefined && data.configType !== null) {
-    contents.configType = data.configType;
+    contents.configType = __expectString(data.configType);
   }
   return Promise.resolve(contents);
 };
@@ -2791,7 +2794,7 @@ export const deserializeAws_restJson1UpdateMissionProfileCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.missionProfileId !== undefined && data.missionProfileId !== null) {
-    contents.missionProfileId = data.missionProfileId;
+    contents.missionProfileId = __expectString(data.missionProfileId);
   }
   return Promise.resolve(contents);
 };
@@ -2862,10 +2865,10 @@ const deserializeAws_restJson1DependencyExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.parameterName !== undefined && data.parameterName !== null) {
-    contents.parameterName = data.parameterName;
+    contents.parameterName = __expectString(data.parameterName);
   }
   return contents;
 };
@@ -2883,10 +2886,10 @@ const deserializeAws_restJson1InvalidParameterExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.parameterName !== undefined && data.parameterName !== null) {
-    contents.parameterName = data.parameterName;
+    contents.parameterName = __expectString(data.parameterName);
   }
   return contents;
 };
@@ -2904,10 +2907,10 @@ const deserializeAws_restJson1ResourceLimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.parameterName !== undefined && data.parameterName !== null) {
-    contents.parameterName = data.parameterName;
+    contents.parameterName = __expectString(data.parameterName);
   }
   return contents;
 };
@@ -2924,7 +2927,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -3201,7 +3204,7 @@ const deserializeAws_restJson1AntennaDemodDecodeDetails = (
   context: __SerdeContext
 ): AntennaDemodDecodeDetails => {
   return {
-    outputNode: output.outputNode !== undefined && output.outputNode !== null ? output.outputNode : undefined,
+    outputNode: __expectString(output.outputNode),
   } as any;
 };
 
@@ -3244,8 +3247,7 @@ const deserializeAws_restJson1AntennaUplinkConfig = (output: any, context: __Ser
       output.targetEirp !== undefined && output.targetEirp !== null
         ? deserializeAws_restJson1Eirp(output.targetEirp, context)
         : undefined,
-    transmitDisabled:
-      output.transmitDisabled !== undefined && output.transmitDisabled !== null ? output.transmitDisabled : undefined,
+    transmitDisabled: __expectBoolean(output.transmitDisabled),
   } as any;
 };
 
@@ -3284,10 +3286,10 @@ const deserializeAws_restJson1ConfigList = (output: any, context: __SerdeContext
 
 const deserializeAws_restJson1ConfigListItem = (output: any, context: __SerdeContext): ConfigListItem => {
   return {
-    configArn: output.configArn !== undefined && output.configArn !== null ? output.configArn : undefined,
-    configId: output.configId !== undefined && output.configId !== null ? output.configId : undefined,
-    configType: output.configType !== undefined && output.configType !== null ? output.configType : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    configArn: __expectString(output.configArn),
+    configId: __expectString(output.configId),
+    configType: __expectString(output.configType),
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -3335,22 +3337,17 @@ const deserializeAws_restJson1ConfigTypeData = (output: any, context: __SerdeCon
 
 const deserializeAws_restJson1ContactData = (output: any, context: __SerdeContext): ContactData => {
   return {
-    contactId: output.contactId !== undefined && output.contactId !== null ? output.contactId : undefined,
-    contactStatus:
-      output.contactStatus !== undefined && output.contactStatus !== null ? output.contactStatus : undefined,
+    contactId: __expectString(output.contactId),
+    contactStatus: __expectString(output.contactStatus),
     endTime:
       output.endTime !== undefined && output.endTime !== null ? new Date(Math.round(output.endTime * 1000)) : undefined,
-    errorMessage: output.errorMessage !== undefined && output.errorMessage !== null ? output.errorMessage : undefined,
-    groundStation:
-      output.groundStation !== undefined && output.groundStation !== null ? output.groundStation : undefined,
+    errorMessage: __expectString(output.errorMessage),
+    groundStation: __expectString(output.groundStation),
     maximumElevation:
       output.maximumElevation !== undefined && output.maximumElevation !== null
         ? deserializeAws_restJson1Elevation(output.maximumElevation, context)
         : undefined,
-    missionProfileArn:
-      output.missionProfileArn !== undefined && output.missionProfileArn !== null
-        ? output.missionProfileArn
-        : undefined,
+    missionProfileArn: __expectString(output.missionProfileArn),
     postPassEndTime:
       output.postPassEndTime !== undefined && output.postPassEndTime !== null
         ? new Date(Math.round(output.postPassEndTime * 1000))
@@ -3359,8 +3356,8 @@ const deserializeAws_restJson1ContactData = (output: any, context: __SerdeContex
       output.prePassStartTime !== undefined && output.prePassStartTime !== null
         ? new Date(Math.round(output.prePassStartTime * 1000))
         : undefined,
-    region: output.region !== undefined && output.region !== null ? output.region : undefined,
-    satelliteArn: output.satelliteArn !== undefined && output.satelliteArn !== null ? output.satelliteArn : undefined,
+    region: __expectString(output.region),
+    satelliteArn: __expectString(output.satelliteArn),
     startTime:
       output.startTime !== undefined && output.startTime !== null
         ? new Date(Math.round(output.startTime * 1000))
@@ -3389,7 +3386,7 @@ const deserializeAws_restJson1DataflowDetail = (output: any, context: __SerdeCon
       output.destination !== undefined && output.destination !== null
         ? deserializeAws_restJson1Destination(output.destination, context)
         : undefined,
-    errorMessage: output.errorMessage !== undefined && output.errorMessage !== null ? output.errorMessage : undefined,
+    errorMessage: __expectString(output.errorMessage),
     source:
       output.source !== undefined && output.source !== null
         ? deserializeAws_restJson1Source(output.source, context)
@@ -3404,7 +3401,7 @@ const deserializeAws_restJson1DataflowEdge = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3425,9 +3422,9 @@ const deserializeAws_restJson1DataflowEndpoint = (output: any, context: __SerdeC
       output.address !== undefined && output.address !== null
         ? deserializeAws_restJson1SocketAddress(output.address, context)
         : undefined,
-    mtu: output.mtu !== undefined && output.mtu !== null ? output.mtu : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    mtu: __expectNumber(output.mtu),
+    name: __expectString(output.name),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -3436,14 +3433,8 @@ const deserializeAws_restJson1DataflowEndpointConfig = (
   context: __SerdeContext
 ): DataflowEndpointConfig => {
   return {
-    dataflowEndpointName:
-      output.dataflowEndpointName !== undefined && output.dataflowEndpointName !== null
-        ? output.dataflowEndpointName
-        : undefined,
-    dataflowEndpointRegion:
-      output.dataflowEndpointRegion !== undefined && output.dataflowEndpointRegion !== null
-        ? output.dataflowEndpointRegion
-        : undefined,
+    dataflowEndpointName: __expectString(output.dataflowEndpointName),
+    dataflowEndpointRegion: __expectString(output.dataflowEndpointRegion),
   } as any;
 };
 
@@ -3466,14 +3457,8 @@ const deserializeAws_restJson1DataflowEndpointListItem = (
   context: __SerdeContext
 ): DataflowEndpointListItem => {
   return {
-    dataflowEndpointGroupArn:
-      output.dataflowEndpointGroupArn !== undefined && output.dataflowEndpointGroupArn !== null
-        ? output.dataflowEndpointGroupArn
-        : undefined,
-    dataflowEndpointGroupId:
-      output.dataflowEndpointGroupId !== undefined && output.dataflowEndpointGroupId !== null
-        ? output.dataflowEndpointGroupId
-        : undefined,
+    dataflowEndpointGroupArn: __expectString(output.dataflowEndpointGroupArn),
+    dataflowEndpointGroupId: __expectString(output.dataflowEndpointGroupId),
   } as any;
 };
 
@@ -3490,15 +3475,13 @@ const deserializeAws_restJson1DataflowList = (output: any, context: __SerdeConte
 
 const deserializeAws_restJson1DecodeConfig = (output: any, context: __SerdeContext): DecodeConfig => {
   return {
-    unvalidatedJSON:
-      output.unvalidatedJSON !== undefined && output.unvalidatedJSON !== null ? output.unvalidatedJSON : undefined,
+    unvalidatedJSON: __expectString(output.unvalidatedJSON),
   } as any;
 };
 
 const deserializeAws_restJson1DemodulationConfig = (output: any, context: __SerdeContext): DemodulationConfig => {
   return {
-    unvalidatedJSON:
-      output.unvalidatedJSON !== undefined && output.unvalidatedJSON !== null ? output.unvalidatedJSON : undefined,
+    unvalidatedJSON: __expectString(output.unvalidatedJSON),
   } as any;
 };
 
@@ -3508,26 +3491,23 @@ const deserializeAws_restJson1Destination = (output: any, context: __SerdeContex
       output.configDetails !== undefined && output.configDetails !== null
         ? deserializeAws_restJson1ConfigDetails(output.configDetails, context)
         : undefined,
-    configId: output.configId !== undefined && output.configId !== null ? output.configId : undefined,
-    configType: output.configType !== undefined && output.configType !== null ? output.configType : undefined,
-    dataflowDestinationRegion:
-      output.dataflowDestinationRegion !== undefined && output.dataflowDestinationRegion !== null
-        ? output.dataflowDestinationRegion
-        : undefined,
+    configId: __expectString(output.configId),
+    configType: __expectString(output.configType),
+    dataflowDestinationRegion: __expectString(output.dataflowDestinationRegion),
   } as any;
 };
 
 const deserializeAws_restJson1Eirp = (output: any, context: __SerdeContext): Eirp => {
   return {
-    units: output.units !== undefined && output.units !== null ? output.units : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    units: __expectString(output.units),
+    value: __expectNumber(output.value),
   } as any;
 };
 
 const deserializeAws_restJson1Elevation = (output: any, context: __SerdeContext): Elevation => {
   return {
-    unit: output.unit !== undefined && output.unit !== null ? output.unit : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    unit: __expectString(output.unit),
+    value: __expectNumber(output.value),
   } as any;
 };
 
@@ -3557,27 +3537,23 @@ const deserializeAws_restJson1EndpointDetailsList = (output: any, context: __Ser
 
 const deserializeAws_restJson1Frequency = (output: any, context: __SerdeContext): Frequency => {
   return {
-    units: output.units !== undefined && output.units !== null ? output.units : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    units: __expectString(output.units),
+    value: __expectNumber(output.value),
   } as any;
 };
 
 const deserializeAws_restJson1FrequencyBandwidth = (output: any, context: __SerdeContext): FrequencyBandwidth => {
   return {
-    units: output.units !== undefined && output.units !== null ? output.units : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    units: __expectString(output.units),
+    value: __expectNumber(output.value),
   } as any;
 };
 
 const deserializeAws_restJson1GroundStationData = (output: any, context: __SerdeContext): GroundStationData => {
   return {
-    groundStationId:
-      output.groundStationId !== undefined && output.groundStationId !== null ? output.groundStationId : undefined,
-    groundStationName:
-      output.groundStationName !== undefined && output.groundStationName !== null
-        ? output.groundStationName
-        : undefined,
-    region: output.region !== undefined && output.region !== null ? output.region : undefined,
+    groundStationId: __expectString(output.groundStationId),
+    groundStationName: __expectString(output.groundStationName),
+    region: __expectString(output.region),
   } as any;
 };
 
@@ -3588,7 +3564,7 @@ const deserializeAws_restJson1GroundStationIdList = (output: any, context: __Ser
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3619,29 +3595,25 @@ const deserializeAws_restJson1MissionProfileListItem = (
   context: __SerdeContext
 ): MissionProfileListItem => {
   return {
-    missionProfileArn:
-      output.missionProfileArn !== undefined && output.missionProfileArn !== null
-        ? output.missionProfileArn
-        : undefined,
-    missionProfileId:
-      output.missionProfileId !== undefined && output.missionProfileId !== null ? output.missionProfileId : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    region: output.region !== undefined && output.region !== null ? output.region : undefined,
+    missionProfileArn: __expectString(output.missionProfileArn),
+    missionProfileId: __expectString(output.missionProfileId),
+    name: __expectString(output.name),
+    region: __expectString(output.region),
   } as any;
 };
 
 const deserializeAws_restJson1S3RecordingConfig = (output: any, context: __SerdeContext): S3RecordingConfig => {
   return {
-    bucketArn: output.bucketArn !== undefined && output.bucketArn !== null ? output.bucketArn : undefined,
-    prefix: output.prefix !== undefined && output.prefix !== null ? output.prefix : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
+    bucketArn: __expectString(output.bucketArn),
+    prefix: __expectString(output.prefix),
+    roleArn: __expectString(output.roleArn),
   } as any;
 };
 
 const deserializeAws_restJson1S3RecordingDetails = (output: any, context: __SerdeContext): S3RecordingDetails => {
   return {
-    bucketArn: output.bucketArn !== undefined && output.bucketArn !== null ? output.bucketArn : undefined,
-    keyTemplate: output.keyTemplate !== undefined && output.keyTemplate !== null ? output.keyTemplate : undefined,
+    bucketArn: __expectString(output.bucketArn),
+    keyTemplate: __expectString(output.keyTemplate),
   } as any;
 };
 
@@ -3662,16 +3634,15 @@ const deserializeAws_restJson1SatelliteListItem = (output: any, context: __Serde
       output.groundStations !== undefined && output.groundStations !== null
         ? deserializeAws_restJson1GroundStationIdList(output.groundStations, context)
         : undefined,
-    noradSatelliteID:
-      output.noradSatelliteID !== undefined && output.noradSatelliteID !== null ? output.noradSatelliteID : undefined,
-    satelliteArn: output.satelliteArn !== undefined && output.satelliteArn !== null ? output.satelliteArn : undefined,
-    satelliteId: output.satelliteId !== undefined && output.satelliteId !== null ? output.satelliteId : undefined,
+    noradSatelliteID: __expectNumber(output.noradSatelliteID),
+    satelliteArn: __expectString(output.satelliteArn),
+    satelliteId: __expectString(output.satelliteId),
   } as any;
 };
 
 const deserializeAws_restJson1SecurityDetails = (output: any, context: __SerdeContext): SecurityDetails => {
   return {
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
+    roleArn: __expectString(output.roleArn),
     securityGroupIds:
       output.securityGroupIds !== undefined && output.securityGroupIds !== null
         ? deserializeAws_restJson1SecurityGroupIdList(output.securityGroupIds, context)
@@ -3690,14 +3661,14 @@ const deserializeAws_restJson1SecurityGroupIdList = (output: any, context: __Ser
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1SocketAddress = (output: any, context: __SerdeContext): SocketAddress => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    port: output.port !== undefined && output.port !== null ? output.port : undefined,
+    name: __expectString(output.name),
+    port: __expectNumber(output.port),
   } as any;
 };
 
@@ -3707,12 +3678,9 @@ const deserializeAws_restJson1Source = (output: any, context: __SerdeContext): S
       output.configDetails !== undefined && output.configDetails !== null
         ? deserializeAws_restJson1ConfigDetails(output.configDetails, context)
         : undefined,
-    configId: output.configId !== undefined && output.configId !== null ? output.configId : undefined,
-    configType: output.configType !== undefined && output.configType !== null ? output.configType : undefined,
-    dataflowSourceRegion:
-      output.dataflowSourceRegion !== undefined && output.dataflowSourceRegion !== null
-        ? output.dataflowSourceRegion
-        : undefined,
+    configId: __expectString(output.configId),
+    configType: __expectString(output.configType),
+    dataflowSourceRegion: __expectString(output.dataflowSourceRegion),
   } as any;
 };
 
@@ -3726,7 +3694,7 @@ const deserializeAws_restJson1SpectrumConfig = (output: any, context: __SerdeCon
       output.centerFrequency !== undefined && output.centerFrequency !== null
         ? deserializeAws_restJson1Frequency(output.centerFrequency, context)
         : undefined,
-    polarization: output.polarization !== undefined && output.polarization !== null ? output.polarization : undefined,
+    polarization: __expectString(output.polarization),
   } as any;
 };
 
@@ -3737,7 +3705,7 @@ const deserializeAws_restJson1SubnetList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3748,24 +3716,21 @@ const deserializeAws_restJson1TagsMap = (output: any, context: __SerdeContext): 
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1TrackingConfig = (output: any, context: __SerdeContext): TrackingConfig => {
   return {
-    autotrack: output.autotrack !== undefined && output.autotrack !== null ? output.autotrack : undefined,
+    autotrack: __expectString(output.autotrack),
   } as any;
 };
 
 const deserializeAws_restJson1UplinkEchoConfig = (output: any, context: __SerdeContext): UplinkEchoConfig => {
   return {
-    antennaUplinkConfigArn:
-      output.antennaUplinkConfigArn !== undefined && output.antennaUplinkConfigArn !== null
-        ? output.antennaUplinkConfigArn
-        : undefined,
-    enabled: output.enabled !== undefined && output.enabled !== null ? output.enabled : undefined,
+    antennaUplinkConfigArn: __expectString(output.antennaUplinkConfigArn),
+    enabled: __expectBoolean(output.enabled),
   } as any;
 };
 
@@ -3775,7 +3740,7 @@ const deserializeAws_restJson1UplinkSpectrumConfig = (output: any, context: __Se
       output.centerFrequency !== undefined && output.centerFrequency !== null
         ? deserializeAws_restJson1Frequency(output.centerFrequency, context)
         : undefined,
-    polarization: output.polarization !== undefined && output.polarization !== null ? output.polarization : undefined,
+    polarization: __expectString(output.polarization),
   } as any;
 };
 

--- a/clients/client-guardduty/protocols/Aws_restJson1.ts
+++ b/clients/client-guardduty/protocols/Aws_restJson1.ts
@@ -205,6 +205,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -2325,7 +2328,7 @@ export const deserializeAws_restJson1CreateDetectorCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.detectorId !== undefined && data.detectorId !== null) {
-    contents.DetectorId = data.detectorId;
+    contents.DetectorId = __expectString(data.detectorId);
   }
   return Promise.resolve(contents);
 };
@@ -2388,7 +2391,7 @@ export const deserializeAws_restJson1CreateFilterCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.name !== undefined && data.name !== null) {
-    contents.Name = data.name;
+    contents.Name = __expectString(data.name);
   }
   return Promise.resolve(contents);
 };
@@ -2451,7 +2454,7 @@ export const deserializeAws_restJson1CreateIPSetCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ipSetId !== undefined && data.ipSetId !== null) {
-    contents.IpSetId = data.ipSetId;
+    contents.IpSetId = __expectString(data.ipSetId);
   }
   return Promise.resolve(contents);
 };
@@ -2577,7 +2580,7 @@ export const deserializeAws_restJson1CreatePublishingDestinationCommand = async 
   };
   const data: any = await parseBody(output.body, context);
   if (data.destinationId !== undefined && data.destinationId !== null) {
-    contents.DestinationId = data.destinationId;
+    contents.DestinationId = __expectString(data.destinationId);
   }
   return Promise.resolve(contents);
 };
@@ -2699,7 +2702,7 @@ export const deserializeAws_restJson1CreateThreatIntelSetCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.threatIntelSetId !== undefined && data.threatIntelSetId !== null) {
-    contents.ThreatIntelSetId = data.threatIntelSetId;
+    contents.ThreatIntelSetId = __expectString(data.threatIntelSetId);
   }
   return Promise.resolve(contents);
 };
@@ -3248,7 +3251,7 @@ export const deserializeAws_restJson1DescribeOrganizationConfigurationCommand = 
   };
   const data: any = await parseBody(output.body, context);
   if (data.autoEnable !== undefined && data.autoEnable !== null) {
-    contents.AutoEnable = data.autoEnable;
+    contents.AutoEnable = __expectBoolean(data.autoEnable);
   }
   if (data.dataSources !== undefined && data.dataSources !== null) {
     contents.DataSources = deserializeAws_restJson1OrganizationDataSourceConfigurationsResult(
@@ -3257,7 +3260,7 @@ export const deserializeAws_restJson1DescribeOrganizationConfigurationCommand = 
     );
   }
   if (data.memberAccountLimitReached !== undefined && data.memberAccountLimitReached !== null) {
-    contents.MemberAccountLimitReached = data.memberAccountLimitReached;
+    contents.MemberAccountLimitReached = __expectBoolean(data.memberAccountLimitReached);
   }
   return Promise.resolve(contents);
 };
@@ -3324,19 +3327,19 @@ export const deserializeAws_restJson1DescribePublishingDestinationCommand = asyn
   };
   const data: any = await parseBody(output.body, context);
   if (data.destinationId !== undefined && data.destinationId !== null) {
-    contents.DestinationId = data.destinationId;
+    contents.DestinationId = __expectString(data.destinationId);
   }
   if (data.destinationProperties !== undefined && data.destinationProperties !== null) {
     contents.DestinationProperties = deserializeAws_restJson1DestinationProperties(data.destinationProperties, context);
   }
   if (data.destinationType !== undefined && data.destinationType !== null) {
-    contents.DestinationType = data.destinationType;
+    contents.DestinationType = __expectString(data.destinationType);
   }
   if (data.publishingFailureStartTimestamp !== undefined && data.publishingFailureStartTimestamp !== null) {
-    contents.PublishingFailureStartTimestamp = data.publishingFailureStartTimestamp;
+    contents.PublishingFailureStartTimestamp = __expectNumber(data.publishingFailureStartTimestamp);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.Status = data.status;
+    contents.Status = __expectString(data.status);
   }
   return Promise.resolve(contents);
 };
@@ -3645,25 +3648,25 @@ export const deserializeAws_restJson1GetDetectorCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.createdAt !== undefined && data.createdAt !== null) {
-    contents.CreatedAt = data.createdAt;
+    contents.CreatedAt = __expectString(data.createdAt);
   }
   if (data.dataSources !== undefined && data.dataSources !== null) {
     contents.DataSources = deserializeAws_restJson1DataSourceConfigurationsResult(data.dataSources, context);
   }
   if (data.findingPublishingFrequency !== undefined && data.findingPublishingFrequency !== null) {
-    contents.FindingPublishingFrequency = data.findingPublishingFrequency;
+    contents.FindingPublishingFrequency = __expectString(data.findingPublishingFrequency);
   }
   if (data.serviceRole !== undefined && data.serviceRole !== null) {
-    contents.ServiceRole = data.serviceRole;
+    contents.ServiceRole = __expectString(data.serviceRole);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.Status = data.status;
+    contents.Status = __expectString(data.status);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
   if (data.updatedAt !== undefined && data.updatedAt !== null) {
-    contents.UpdatedAt = data.updatedAt;
+    contents.UpdatedAt = __expectString(data.updatedAt);
   }
   return Promise.resolve(contents);
 };
@@ -3731,19 +3734,19 @@ export const deserializeAws_restJson1GetFilterCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.action !== undefined && data.action !== null) {
-    contents.Action = data.action;
+    contents.Action = __expectString(data.action);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.Description = data.description;
+    contents.Description = __expectString(data.description);
   }
   if (data.findingCriteria !== undefined && data.findingCriteria !== null) {
     contents.FindingCriteria = deserializeAws_restJson1FindingCriteria(data.findingCriteria, context);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.Name = data.name;
+    contents.Name = __expectString(data.name);
   }
   if (data.rank !== undefined && data.rank !== null) {
-    contents.Rank = data.rank;
+    contents.Rank = __expectNumber(data.rank);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.tags, context);
@@ -3935,7 +3938,7 @@ export const deserializeAws_restJson1GetInvitationsCountCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.invitationsCount !== undefined && data.invitationsCount !== null) {
-    contents.InvitationsCount = data.invitationsCount;
+    contents.InvitationsCount = __expectNumber(data.invitationsCount);
   }
   return Promise.resolve(contents);
 };
@@ -4002,16 +4005,16 @@ export const deserializeAws_restJson1GetIPSetCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.format !== undefined && data.format !== null) {
-    contents.Format = data.format;
+    contents.Format = __expectString(data.format);
   }
   if (data.location !== undefined && data.location !== null) {
-    contents.Location = data.location;
+    contents.Location = __expectString(data.location);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.Name = data.name;
+    contents.Name = __expectString(data.name);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.Status = data.status;
+    contents.Status = __expectString(data.status);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.tags, context);
@@ -4281,16 +4284,16 @@ export const deserializeAws_restJson1GetThreatIntelSetCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.format !== undefined && data.format !== null) {
-    contents.Format = data.format;
+    contents.Format = __expectString(data.format);
   }
   if (data.location !== undefined && data.location !== null) {
-    contents.Location = data.location;
+    contents.Location = __expectString(data.location);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.Name = data.name;
+    contents.Name = __expectString(data.name);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.Status = data.status;
+    contents.Status = __expectString(data.status);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.tags, context);
@@ -4357,7 +4360,7 @@ export const deserializeAws_restJson1GetUsageStatisticsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   if (data.usageStatistics !== undefined && data.usageStatistics !== null) {
     contents.UsageStatistics = deserializeAws_restJson1UsageStatistics(data.usageStatistics, context);
@@ -4490,7 +4493,7 @@ export const deserializeAws_restJson1ListDetectorsCommand = async (
     contents.DetectorIds = deserializeAws_restJson1DetectorIds(data.detectorIds, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -4557,7 +4560,7 @@ export const deserializeAws_restJson1ListFiltersCommand = async (
     contents.FilterNames = deserializeAws_restJson1FilterNames(data.filterNames, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -4624,7 +4627,7 @@ export const deserializeAws_restJson1ListFindingsCommand = async (
     contents.FindingIds = deserializeAws_restJson1FindingIds(data.findingIds, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -4691,7 +4694,7 @@ export const deserializeAws_restJson1ListInvitationsCommand = async (
     contents.Invitations = deserializeAws_restJson1Invitations(data.invitations, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -4758,7 +4761,7 @@ export const deserializeAws_restJson1ListIPSetsCommand = async (
     contents.IpSetIds = deserializeAws_restJson1IpSetIds(data.ipSetIds, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -4825,7 +4828,7 @@ export const deserializeAws_restJson1ListMembersCommand = async (
     contents.Members = deserializeAws_restJson1Members(data.members, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -4892,7 +4895,7 @@ export const deserializeAws_restJson1ListOrganizationAdminAccountsCommand = asyn
     contents.AdminAccounts = deserializeAws_restJson1AdminAccounts(data.adminAccounts, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -4959,7 +4962,7 @@ export const deserializeAws_restJson1ListPublishingDestinationsCommand = async (
     contents.Destinations = deserializeAws_restJson1Destinations(data.destinations, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -5086,7 +5089,7 @@ export const deserializeAws_restJson1ListThreatIntelSetsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   if (data.threatIntelSetIds !== undefined && data.threatIntelSetIds !== null) {
     contents.ThreatIntelSetIds = deserializeAws_restJson1ThreatIntelSetIds(data.threatIntelSetIds, context);
@@ -5514,7 +5517,7 @@ export const deserializeAws_restJson1UpdateFilterCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.name !== undefined && data.name !== null) {
-    contents.Name = data.name;
+    contents.Name = __expectString(data.name);
   }
   return Promise.resolve(contents);
 };
@@ -5935,10 +5938,10 @@ const deserializeAws_restJson1BadRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   if (data.__type !== undefined && data.__type !== null) {
-    contents.Type = data.__type;
+    contents.Type = __expectString(data.__type);
   }
   return contents;
 };
@@ -5956,10 +5959,10 @@ const deserializeAws_restJson1InternalServerErrorExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   if (data.__type !== undefined && data.__type !== null) {
-    contents.Type = data.__type;
+    contents.Type = __expectString(data.__type);
   }
   return contents;
 };
@@ -6212,23 +6215,17 @@ const serializeAws_restJson1UsageCriteria = (input: UsageCriteria, context: __Se
 
 const deserializeAws_restJson1AccessControlList = (output: any, context: __SerdeContext): AccessControlList => {
   return {
-    AllowsPublicReadAccess:
-      output.allowsPublicReadAccess !== undefined && output.allowsPublicReadAccess !== null
-        ? output.allowsPublicReadAccess
-        : undefined,
-    AllowsPublicWriteAccess:
-      output.allowsPublicWriteAccess !== undefined && output.allowsPublicWriteAccess !== null
-        ? output.allowsPublicWriteAccess
-        : undefined,
+    AllowsPublicReadAccess: __expectBoolean(output.allowsPublicReadAccess),
+    AllowsPublicWriteAccess: __expectBoolean(output.allowsPublicWriteAccess),
   } as any;
 };
 
 const deserializeAws_restJson1AccessKeyDetails = (output: any, context: __SerdeContext): AccessKeyDetails => {
   return {
-    AccessKeyId: output.accessKeyId !== undefined && output.accessKeyId !== null ? output.accessKeyId : undefined,
-    PrincipalId: output.principalId !== undefined && output.principalId !== null ? output.principalId : undefined,
-    UserName: output.userName !== undefined && output.userName !== null ? output.userName : undefined,
-    UserType: output.userType !== undefined && output.userType !== null ? output.userType : undefined,
+    AccessKeyId: __expectString(output.accessKeyId),
+    PrincipalId: __expectString(output.principalId),
+    UserName: __expectString(output.userName),
+    UserType: __expectString(output.userType),
   } as any;
 };
 
@@ -6246,7 +6243,7 @@ const deserializeAws_restJson1AccountLevelPermissions = (
 
 const deserializeAws_restJson1Action = (output: any, context: __SerdeContext): Action => {
   return {
-    ActionType: output.actionType !== undefined && output.actionType !== null ? output.actionType : undefined,
+    ActionType: __expectString(output.actionType),
     AwsApiCallAction:
       output.awsApiCallAction !== undefined && output.awsApiCallAction !== null
         ? deserializeAws_restJson1AwsApiCallAction(output.awsApiCallAction, context)
@@ -6268,9 +6265,8 @@ const deserializeAws_restJson1Action = (output: any, context: __SerdeContext): A
 
 const deserializeAws_restJson1AdminAccount = (output: any, context: __SerdeContext): AdminAccount => {
   return {
-    AdminAccountId:
-      output.adminAccountId !== undefined && output.adminAccountId !== null ? output.adminAccountId : undefined,
-    AdminStatus: output.adminStatus !== undefined && output.adminStatus !== null ? output.adminStatus : undefined,
+    AdminAccountId: __expectString(output.adminAccountId),
+    AdminStatus: __expectString(output.adminStatus),
   } as any;
 };
 
@@ -6287,35 +6283,27 @@ const deserializeAws_restJson1AdminAccounts = (output: any, context: __SerdeCont
 
 const deserializeAws_restJson1AwsApiCallAction = (output: any, context: __SerdeContext): AwsApiCallAction => {
   return {
-    Api: output.api !== undefined && output.api !== null ? output.api : undefined,
-    CallerType: output.callerType !== undefined && output.callerType !== null ? output.callerType : undefined,
+    Api: __expectString(output.api),
+    CallerType: __expectString(output.callerType),
     DomainDetails:
       output.domainDetails !== undefined && output.domainDetails !== null
         ? deserializeAws_restJson1DomainDetails(output.domainDetails, context)
         : undefined,
-    ErrorCode: output.errorCode !== undefined && output.errorCode !== null ? output.errorCode : undefined,
+    ErrorCode: __expectString(output.errorCode),
     RemoteIpDetails:
       output.remoteIpDetails !== undefined && output.remoteIpDetails !== null
         ? deserializeAws_restJson1RemoteIpDetails(output.remoteIpDetails, context)
         : undefined,
-    ServiceName: output.serviceName !== undefined && output.serviceName !== null ? output.serviceName : undefined,
+    ServiceName: __expectString(output.serviceName),
   } as any;
 };
 
 const deserializeAws_restJson1BlockPublicAccess = (output: any, context: __SerdeContext): BlockPublicAccess => {
   return {
-    BlockPublicAcls:
-      output.blockPublicAcls !== undefined && output.blockPublicAcls !== null ? output.blockPublicAcls : undefined,
-    BlockPublicPolicy:
-      output.blockPublicPolicy !== undefined && output.blockPublicPolicy !== null
-        ? output.blockPublicPolicy
-        : undefined,
-    IgnorePublicAcls:
-      output.ignorePublicAcls !== undefined && output.ignorePublicAcls !== null ? output.ignorePublicAcls : undefined,
-    RestrictPublicBuckets:
-      output.restrictPublicBuckets !== undefined && output.restrictPublicBuckets !== null
-        ? output.restrictPublicBuckets
-        : undefined,
+    BlockPublicAcls: __expectBoolean(output.blockPublicAcls),
+    BlockPublicPolicy: __expectBoolean(output.blockPublicPolicy),
+    IgnorePublicAcls: __expectBoolean(output.ignorePublicAcls),
+    RestrictPublicBuckets: __expectBoolean(output.restrictPublicBuckets),
   } as any;
 };
 
@@ -6341,20 +6329,14 @@ const deserializeAws_restJson1BucketLevelPermissions = (
 
 const deserializeAws_restJson1BucketPolicy = (output: any, context: __SerdeContext): BucketPolicy => {
   return {
-    AllowsPublicReadAccess:
-      output.allowsPublicReadAccess !== undefined && output.allowsPublicReadAccess !== null
-        ? output.allowsPublicReadAccess
-        : undefined,
-    AllowsPublicWriteAccess:
-      output.allowsPublicWriteAccess !== undefined && output.allowsPublicWriteAccess !== null
-        ? output.allowsPublicWriteAccess
-        : undefined,
+    AllowsPublicReadAccess: __expectBoolean(output.allowsPublicReadAccess),
+    AllowsPublicWriteAccess: __expectBoolean(output.allowsPublicWriteAccess),
   } as any;
 };
 
 const deserializeAws_restJson1City = (output: any, context: __SerdeContext): City => {
   return {
-    CityName: output.cityName !== undefined && output.cityName !== null ? output.cityName : undefined,
+    CityName: __expectString(output.cityName),
   } as any;
 };
 
@@ -6363,7 +6345,7 @@ const deserializeAws_restJson1CloudTrailConfigurationResult = (
   context: __SerdeContext
 ): CloudTrailConfigurationResult => {
   return {
-    Status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    Status: __expectString(output.status),
   } as any;
 };
 
@@ -6374,18 +6356,14 @@ const deserializeAws_restJson1Condition = (output: any, context: __SerdeContext)
       output.equals !== undefined && output.equals !== null
         ? deserializeAws_restJson1Equals(output.equals, context)
         : undefined,
-    GreaterThan: output.greaterThan !== undefined && output.greaterThan !== null ? output.greaterThan : undefined,
-    GreaterThanOrEqual:
-      output.greaterThanOrEqual !== undefined && output.greaterThanOrEqual !== null
-        ? output.greaterThanOrEqual
-        : undefined,
-    Gt: output.gt !== undefined && output.gt !== null ? output.gt : undefined,
-    Gte: output.gte !== undefined && output.gte !== null ? output.gte : undefined,
-    LessThan: output.lessThan !== undefined && output.lessThan !== null ? output.lessThan : undefined,
-    LessThanOrEqual:
-      output.lessThanOrEqual !== undefined && output.lessThanOrEqual !== null ? output.lessThanOrEqual : undefined,
-    Lt: output.lt !== undefined && output.lt !== null ? output.lt : undefined,
-    Lte: output.lte !== undefined && output.lte !== null ? output.lte : undefined,
+    GreaterThan: __expectNumber(output.greaterThan),
+    GreaterThanOrEqual: __expectNumber(output.greaterThanOrEqual),
+    Gt: __expectNumber(output.gt),
+    Gte: __expectNumber(output.gte),
+    LessThan: __expectNumber(output.lessThan),
+    LessThanOrEqual: __expectNumber(output.lessThanOrEqual),
+    Lt: __expectNumber(output.lt),
+    Lte: __expectNumber(output.lte),
     Neq: output.neq !== undefined && output.neq !== null ? deserializeAws_restJson1Neq(output.neq, context) : undefined,
     NotEquals:
       output.notEquals !== undefined && output.notEquals !== null
@@ -6401,15 +6379,15 @@ const deserializeAws_restJson1CountBySeverity = (output: any, context: __SerdeCo
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectNumber(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1Country = (output: any, context: __SerdeContext): Country => {
   return {
-    CountryCode: output.countryCode !== undefined && output.countryCode !== null ? output.countryCode : undefined,
-    CountryName: output.countryName !== undefined && output.countryName !== null ? output.countryName : undefined,
+    CountryCode: __expectString(output.countryCode),
+    CountryName: __expectString(output.countryName),
   } as any;
 };
 
@@ -6454,28 +6432,23 @@ const deserializeAws_restJson1DefaultServerSideEncryption = (
   context: __SerdeContext
 ): DefaultServerSideEncryption => {
   return {
-    EncryptionType:
-      output.encryptionType !== undefined && output.encryptionType !== null ? output.encryptionType : undefined,
-    KmsMasterKeyArn:
-      output.kmsMasterKeyArn !== undefined && output.kmsMasterKeyArn !== null ? output.kmsMasterKeyArn : undefined,
+    EncryptionType: __expectString(output.encryptionType),
+    KmsMasterKeyArn: __expectString(output.kmsMasterKeyArn),
   } as any;
 };
 
 const deserializeAws_restJson1Destination = (output: any, context: __SerdeContext): Destination => {
   return {
-    DestinationId:
-      output.destinationId !== undefined && output.destinationId !== null ? output.destinationId : undefined,
-    DestinationType:
-      output.destinationType !== undefined && output.destinationType !== null ? output.destinationType : undefined,
-    Status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    DestinationId: __expectString(output.destinationId),
+    DestinationType: __expectString(output.destinationType),
+    Status: __expectString(output.status),
   } as any;
 };
 
 const deserializeAws_restJson1DestinationProperties = (output: any, context: __SerdeContext): DestinationProperties => {
   return {
-    DestinationArn:
-      output.destinationArn !== undefined && output.destinationArn !== null ? output.destinationArn : undefined,
-    KmsKeyArn: output.kmsKeyArn !== undefined && output.kmsKeyArn !== null ? output.kmsKeyArn : undefined,
+    DestinationArn: __expectString(output.destinationArn),
+    KmsKeyArn: __expectString(output.kmsKeyArn),
   } as any;
 };
 
@@ -6497,7 +6470,7 @@ const deserializeAws_restJson1DetectorIds = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6506,19 +6479,19 @@ const deserializeAws_restJson1DNSLogsConfigurationResult = (
   context: __SerdeContext
 ): DNSLogsConfigurationResult => {
   return {
-    Status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    Status: __expectString(output.status),
   } as any;
 };
 
 const deserializeAws_restJson1DnsRequestAction = (output: any, context: __SerdeContext): DnsRequestAction => {
   return {
-    Domain: output.domain !== undefined && output.domain !== null ? output.domain : undefined,
+    Domain: __expectString(output.domain),
   } as any;
 };
 
 const deserializeAws_restJson1DomainDetails = (output: any, context: __SerdeContext): DomainDetails => {
   return {
-    Domain: output.domain !== undefined && output.domain !== null ? output.domain : undefined,
+    Domain: __expectString(output.domain),
   } as any;
 };
 
@@ -6529,7 +6502,7 @@ const deserializeAws_restJson1Eq = (output: any, context: __SerdeContext): strin
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6540,7 +6513,7 @@ const deserializeAws_restJson1Equals = (output: any, context: __SerdeContext): s
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6560,34 +6533,33 @@ const deserializeAws_restJson1FilterNames = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1Finding = (output: any, context: __SerdeContext): Finding => {
   return {
-    AccountId: output.accountId !== undefined && output.accountId !== null ? output.accountId : undefined,
-    Arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    Confidence: output.confidence !== undefined && output.confidence !== null ? output.confidence : undefined,
-    CreatedAt: output.createdAt !== undefined && output.createdAt !== null ? output.createdAt : undefined,
-    Description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    Id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    Partition: output.partition !== undefined && output.partition !== null ? output.partition : undefined,
-    Region: output.region !== undefined && output.region !== null ? output.region : undefined,
+    AccountId: __expectString(output.accountId),
+    Arn: __expectString(output.arn),
+    Confidence: __expectNumber(output.confidence),
+    CreatedAt: __expectString(output.createdAt),
+    Description: __expectString(output.description),
+    Id: __expectString(output.id),
+    Partition: __expectString(output.partition),
+    Region: __expectString(output.region),
     Resource:
       output.resource !== undefined && output.resource !== null
         ? deserializeAws_restJson1Resource(output.resource, context)
         : undefined,
-    SchemaVersion:
-      output.schemaVersion !== undefined && output.schemaVersion !== null ? output.schemaVersion : undefined,
+    SchemaVersion: __expectString(output.schemaVersion),
     Service:
       output.service !== undefined && output.service !== null
         ? deserializeAws_restJson1Service(output.service, context)
         : undefined,
-    Severity: output.severity !== undefined && output.severity !== null ? output.severity : undefined,
-    Title: output.title !== undefined && output.title !== null ? output.title : undefined,
-    Type: output.type !== undefined && output.type !== null ? output.type : undefined,
-    UpdatedAt: output.updatedAt !== undefined && output.updatedAt !== null ? output.updatedAt : undefined,
+    Severity: __expectNumber(output.severity),
+    Title: __expectString(output.title),
+    Type: __expectString(output.type),
+    UpdatedAt: __expectString(output.updatedAt),
   } as any;
 };
 
@@ -6607,7 +6579,7 @@ const deserializeAws_restJson1FindingIds = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6636,46 +6608,43 @@ const deserializeAws_restJson1FlowLogsConfigurationResult = (
   context: __SerdeContext
 ): FlowLogsConfigurationResult => {
   return {
-    Status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    Status: __expectString(output.status),
   } as any;
 };
 
 const deserializeAws_restJson1GeoLocation = (output: any, context: __SerdeContext): GeoLocation => {
   return {
-    Lat: output.lat !== undefined && output.lat !== null ? output.lat : undefined,
-    Lon: output.lon !== undefined && output.lon !== null ? output.lon : undefined,
+    Lat: __expectNumber(output.lat),
+    Lon: __expectNumber(output.lon),
   } as any;
 };
 
 const deserializeAws_restJson1IamInstanceProfile = (output: any, context: __SerdeContext): IamInstanceProfile => {
   return {
-    Arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    Id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    Arn: __expectString(output.arn),
+    Id: __expectString(output.id),
   } as any;
 };
 
 const deserializeAws_restJson1InstanceDetails = (output: any, context: __SerdeContext): InstanceDetails => {
   return {
-    AvailabilityZone:
-      output.availabilityZone !== undefined && output.availabilityZone !== null ? output.availabilityZone : undefined,
+    AvailabilityZone: __expectString(output.availabilityZone),
     IamInstanceProfile:
       output.iamInstanceProfile !== undefined && output.iamInstanceProfile !== null
         ? deserializeAws_restJson1IamInstanceProfile(output.iamInstanceProfile, context)
         : undefined,
-    ImageDescription:
-      output.imageDescription !== undefined && output.imageDescription !== null ? output.imageDescription : undefined,
-    ImageId: output.imageId !== undefined && output.imageId !== null ? output.imageId : undefined,
-    InstanceId: output.instanceId !== undefined && output.instanceId !== null ? output.instanceId : undefined,
-    InstanceState:
-      output.instanceState !== undefined && output.instanceState !== null ? output.instanceState : undefined,
-    InstanceType: output.instanceType !== undefined && output.instanceType !== null ? output.instanceType : undefined,
-    LaunchTime: output.launchTime !== undefined && output.launchTime !== null ? output.launchTime : undefined,
+    ImageDescription: __expectString(output.imageDescription),
+    ImageId: __expectString(output.imageId),
+    InstanceId: __expectString(output.instanceId),
+    InstanceState: __expectString(output.instanceState),
+    InstanceType: __expectString(output.instanceType),
+    LaunchTime: __expectString(output.launchTime),
     NetworkInterfaces:
       output.networkInterfaces !== undefined && output.networkInterfaces !== null
         ? deserializeAws_restJson1NetworkInterfaces(output.networkInterfaces, context)
         : undefined,
-    OutpostArn: output.outpostArn !== undefined && output.outpostArn !== null ? output.outpostArn : undefined,
-    Platform: output.platform !== undefined && output.platform !== null ? output.platform : undefined,
+    OutpostArn: __expectString(output.outpostArn),
+    Platform: __expectString(output.platform),
     ProductCodes:
       output.productCodes !== undefined && output.productCodes !== null
         ? deserializeAws_restJson1ProductCodes(output.productCodes, context)
@@ -6689,13 +6658,10 @@ const deserializeAws_restJson1InstanceDetails = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1Invitation = (output: any, context: __SerdeContext): Invitation => {
   return {
-    AccountId: output.accountId !== undefined && output.accountId !== null ? output.accountId : undefined,
-    InvitationId: output.invitationId !== undefined && output.invitationId !== null ? output.invitationId : undefined,
-    InvitedAt: output.invitedAt !== undefined && output.invitedAt !== null ? output.invitedAt : undefined,
-    RelationshipStatus:
-      output.relationshipStatus !== undefined && output.relationshipStatus !== null
-        ? output.relationshipStatus
-        : undefined,
+    AccountId: __expectString(output.accountId),
+    InvitationId: __expectString(output.invitationId),
+    InvitedAt: __expectString(output.invitedAt),
+    RelationshipStatus: __expectString(output.relationshipStatus),
   } as any;
 };
 
@@ -6717,7 +6683,7 @@ const deserializeAws_restJson1IpSetIds = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6728,47 +6694,41 @@ const deserializeAws_restJson1Ipv6Addresses = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1LocalIpDetails = (output: any, context: __SerdeContext): LocalIpDetails => {
   return {
-    IpAddressV4: output.ipAddressV4 !== undefined && output.ipAddressV4 !== null ? output.ipAddressV4 : undefined,
+    IpAddressV4: __expectString(output.ipAddressV4),
   } as any;
 };
 
 const deserializeAws_restJson1LocalPortDetails = (output: any, context: __SerdeContext): LocalPortDetails => {
   return {
-    Port: output.port !== undefined && output.port !== null ? output.port : undefined,
-    PortName: output.portName !== undefined && output.portName !== null ? output.portName : undefined,
+    Port: __expectNumber(output.port),
+    PortName: __expectString(output.portName),
   } as any;
 };
 
 const deserializeAws_restJson1Master = (output: any, context: __SerdeContext): Master => {
   return {
-    AccountId: output.accountId !== undefined && output.accountId !== null ? output.accountId : undefined,
-    InvitationId: output.invitationId !== undefined && output.invitationId !== null ? output.invitationId : undefined,
-    InvitedAt: output.invitedAt !== undefined && output.invitedAt !== null ? output.invitedAt : undefined,
-    RelationshipStatus:
-      output.relationshipStatus !== undefined && output.relationshipStatus !== null
-        ? output.relationshipStatus
-        : undefined,
+    AccountId: __expectString(output.accountId),
+    InvitationId: __expectString(output.invitationId),
+    InvitedAt: __expectString(output.invitedAt),
+    RelationshipStatus: __expectString(output.relationshipStatus),
   } as any;
 };
 
 const deserializeAws_restJson1Member = (output: any, context: __SerdeContext): Member => {
   return {
-    AccountId: output.accountId !== undefined && output.accountId !== null ? output.accountId : undefined,
-    DetectorId: output.detectorId !== undefined && output.detectorId !== null ? output.detectorId : undefined,
-    Email: output.email !== undefined && output.email !== null ? output.email : undefined,
-    InvitedAt: output.invitedAt !== undefined && output.invitedAt !== null ? output.invitedAt : undefined,
-    MasterId: output.masterId !== undefined && output.masterId !== null ? output.masterId : undefined,
-    RelationshipStatus:
-      output.relationshipStatus !== undefined && output.relationshipStatus !== null
-        ? output.relationshipStatus
-        : undefined,
-    UpdatedAt: output.updatedAt !== undefined && output.updatedAt !== null ? output.updatedAt : undefined,
+    AccountId: __expectString(output.accountId),
+    DetectorId: __expectString(output.detectorId),
+    Email: __expectString(output.email),
+    InvitedAt: __expectString(output.invitedAt),
+    MasterId: __expectString(output.masterId),
+    RelationshipStatus: __expectString(output.relationshipStatus),
+    UpdatedAt: __expectString(output.updatedAt),
   } as any;
 };
 
@@ -6777,7 +6737,7 @@ const deserializeAws_restJson1MemberDataSourceConfiguration = (
   context: __SerdeContext
 ): MemberDataSourceConfiguration => {
   return {
-    AccountId: output.accountId !== undefined && output.accountId !== null ? output.accountId : undefined,
+    AccountId: __expectString(output.accountId),
     DataSources:
       output.dataSources !== undefined && output.dataSources !== null
         ? deserializeAws_restJson1DataSourceConfigurationsResult(output.dataSources, context)
@@ -6817,7 +6777,7 @@ const deserializeAws_restJson1Neq = (output: any, context: __SerdeContext): stri
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6826,11 +6786,8 @@ const deserializeAws_restJson1NetworkConnectionAction = (
   context: __SerdeContext
 ): NetworkConnectionAction => {
   return {
-    Blocked: output.blocked !== undefined && output.blocked !== null ? output.blocked : undefined,
-    ConnectionDirection:
-      output.connectionDirection !== undefined && output.connectionDirection !== null
-        ? output.connectionDirection
-        : undefined,
+    Blocked: __expectBoolean(output.blocked),
+    ConnectionDirection: __expectString(output.connectionDirection),
     LocalIpDetails:
       output.localIpDetails !== undefined && output.localIpDetails !== null
         ? deserializeAws_restJson1LocalIpDetails(output.localIpDetails, context)
@@ -6839,7 +6796,7 @@ const deserializeAws_restJson1NetworkConnectionAction = (
       output.localPortDetails !== undefined && output.localPortDetails !== null
         ? deserializeAws_restJson1LocalPortDetails(output.localPortDetails, context)
         : undefined,
-    Protocol: output.protocol !== undefined && output.protocol !== null ? output.protocol : undefined,
+    Protocol: __expectString(output.protocol),
     RemoteIpDetails:
       output.remoteIpDetails !== undefined && output.remoteIpDetails !== null
         ? deserializeAws_restJson1RemoteIpDetails(output.remoteIpDetails, context)
@@ -6857,27 +6814,21 @@ const deserializeAws_restJson1NetworkInterface = (output: any, context: __SerdeC
       output.ipv6Addresses !== undefined && output.ipv6Addresses !== null
         ? deserializeAws_restJson1Ipv6Addresses(output.ipv6Addresses, context)
         : undefined,
-    NetworkInterfaceId:
-      output.networkInterfaceId !== undefined && output.networkInterfaceId !== null
-        ? output.networkInterfaceId
-        : undefined,
-    PrivateDnsName:
-      output.privateDnsName !== undefined && output.privateDnsName !== null ? output.privateDnsName : undefined,
-    PrivateIpAddress:
-      output.privateIpAddress !== undefined && output.privateIpAddress !== null ? output.privateIpAddress : undefined,
+    NetworkInterfaceId: __expectString(output.networkInterfaceId),
+    PrivateDnsName: __expectString(output.privateDnsName),
+    PrivateIpAddress: __expectString(output.privateIpAddress),
     PrivateIpAddresses:
       output.privateIpAddresses !== undefined && output.privateIpAddresses !== null
         ? deserializeAws_restJson1PrivateIpAddresses(output.privateIpAddresses, context)
         : undefined,
-    PublicDnsName:
-      output.publicDnsName !== undefined && output.publicDnsName !== null ? output.publicDnsName : undefined,
-    PublicIp: output.publicIp !== undefined && output.publicIp !== null ? output.publicIp : undefined,
+    PublicDnsName: __expectString(output.publicDnsName),
+    PublicIp: __expectString(output.publicIp),
     SecurityGroups:
       output.securityGroups !== undefined && output.securityGroups !== null
         ? deserializeAws_restJson1SecurityGroups(output.securityGroups, context)
         : undefined,
-    SubnetId: output.subnetId !== undefined && output.subnetId !== null ? output.subnetId : undefined,
-    VpcId: output.vpcId !== undefined && output.vpcId !== null ? output.vpcId : undefined,
+    SubnetId: __expectString(output.subnetId),
+    VpcId: __expectString(output.vpcId),
   } as any;
 };
 
@@ -6899,16 +6850,16 @@ const deserializeAws_restJson1NotEquals = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1Organization = (output: any, context: __SerdeContext): Organization => {
   return {
-    Asn: output.asn !== undefined && output.asn !== null ? output.asn : undefined,
-    AsnOrg: output.asnOrg !== undefined && output.asnOrg !== null ? output.asnOrg : undefined,
-    Isp: output.isp !== undefined && output.isp !== null ? output.isp : undefined,
-    Org: output.org !== undefined && output.org !== null ? output.org : undefined,
+    Asn: __expectString(output.asn),
+    AsnOrg: __expectString(output.asnOrg),
+    Isp: __expectString(output.isp),
+    Org: __expectString(output.org),
   } as any;
 };
 
@@ -6929,13 +6880,13 @@ const deserializeAws_restJson1OrganizationS3LogsConfigurationResult = (
   context: __SerdeContext
 ): OrganizationS3LogsConfigurationResult => {
   return {
-    AutoEnable: output.autoEnable !== undefined && output.autoEnable !== null ? output.autoEnable : undefined,
+    AutoEnable: __expectBoolean(output.autoEnable),
   } as any;
 };
 
 const deserializeAws_restJson1Owner = (output: any, context: __SerdeContext): Owner => {
   return {
-    Id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    Id: __expectString(output.id),
   } as any;
 };
 
@@ -6957,7 +6908,7 @@ const deserializeAws_restJson1PermissionConfiguration = (
 
 const deserializeAws_restJson1PortProbeAction = (output: any, context: __SerdeContext): PortProbeAction => {
   return {
-    Blocked: output.blocked !== undefined && output.blocked !== null ? output.blocked : undefined,
+    Blocked: __expectBoolean(output.blocked),
     PortProbeDetails:
       output.portProbeDetails !== undefined && output.portProbeDetails !== null
         ? deserializeAws_restJson1PortProbeDetails(output.portProbeDetails, context)
@@ -6998,10 +6949,8 @@ const deserializeAws_restJson1PrivateIpAddressDetails = (
   context: __SerdeContext
 ): PrivateIpAddressDetails => {
   return {
-    PrivateDnsName:
-      output.privateDnsName !== undefined && output.privateDnsName !== null ? output.privateDnsName : undefined,
-    PrivateIpAddress:
-      output.privateIpAddress !== undefined && output.privateIpAddress !== null ? output.privateIpAddress : undefined,
+    PrivateDnsName: __expectString(output.privateDnsName),
+    PrivateIpAddress: __expectString(output.privateIpAddress),
   } as any;
 };
 
@@ -7021,8 +6970,8 @@ const deserializeAws_restJson1PrivateIpAddresses = (
 
 const deserializeAws_restJson1ProductCode = (output: any, context: __SerdeContext): ProductCode => {
   return {
-    Code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    ProductType: output.productType !== undefined && output.productType !== null ? output.productType : undefined,
+    Code: __expectString(output.code),
+    ProductType: __expectString(output.productType),
   } as any;
 };
 
@@ -7039,10 +6988,7 @@ const deserializeAws_restJson1ProductCodes = (output: any, context: __SerdeConte
 
 const deserializeAws_restJson1PublicAccess = (output: any, context: __SerdeContext): PublicAccess => {
   return {
-    EffectivePermission:
-      output.effectivePermission !== undefined && output.effectivePermission !== null
-        ? output.effectivePermission
-        : undefined,
+    EffectivePermission: __expectString(output.effectivePermission),
     PermissionConfiguration:
       output.permissionConfiguration !== undefined && output.permissionConfiguration !== null
         ? deserializeAws_restJson1PermissionConfiguration(output.permissionConfiguration, context)
@@ -7064,7 +7010,7 @@ const deserializeAws_restJson1RemoteIpDetails = (output: any, context: __SerdeCo
       output.geoLocation !== undefined && output.geoLocation !== null
         ? deserializeAws_restJson1GeoLocation(output.geoLocation, context)
         : undefined,
-    IpAddressV4: output.ipAddressV4 !== undefined && output.ipAddressV4 !== null ? output.ipAddressV4 : undefined,
+    IpAddressV4: __expectString(output.ipAddressV4),
     Organization:
       output.organization !== undefined && output.organization !== null
         ? deserializeAws_restJson1Organization(output.organization, context)
@@ -7074,8 +7020,8 @@ const deserializeAws_restJson1RemoteIpDetails = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1RemotePortDetails = (output: any, context: __SerdeContext): RemotePortDetails => {
   return {
-    Port: output.port !== undefined && output.port !== null ? output.port : undefined,
-    PortName: output.portName !== undefined && output.portName !== null ? output.portName : undefined,
+    Port: __expectNumber(output.port),
+    PortName: __expectString(output.portName),
   } as any;
 };
 
@@ -7089,7 +7035,7 @@ const deserializeAws_restJson1Resource = (output: any, context: __SerdeContext):
       output.instanceDetails !== undefined && output.instanceDetails !== null
         ? deserializeAws_restJson1InstanceDetails(output.instanceDetails, context)
         : undefined,
-    ResourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
+    ResourceType: __expectString(output.resourceType),
     S3BucketDetails:
       output.s3BucketDetails !== undefined && output.s3BucketDetails !== null
         ? deserializeAws_restJson1S3BucketDetails(output.s3BucketDetails, context)
@@ -7099,7 +7045,7 @@ const deserializeAws_restJson1Resource = (output: any, context: __SerdeContext):
 
 const deserializeAws_restJson1S3BucketDetail = (output: any, context: __SerdeContext): S3BucketDetail => {
   return {
-    Arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    Arn: __expectString(output.arn),
     CreatedAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
@@ -7108,7 +7054,7 @@ const deserializeAws_restJson1S3BucketDetail = (output: any, context: __SerdeCon
       output.defaultServerSideEncryption !== undefined && output.defaultServerSideEncryption !== null
         ? deserializeAws_restJson1DefaultServerSideEncryption(output.defaultServerSideEncryption, context)
         : undefined,
-    Name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    Name: __expectString(output.name),
     Owner:
       output.owner !== undefined && output.owner !== null
         ? deserializeAws_restJson1Owner(output.owner, context)
@@ -7121,7 +7067,7 @@ const deserializeAws_restJson1S3BucketDetail = (output: any, context: __SerdeCon
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1Tags(output.tags, context)
         : undefined,
-    Type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    Type: __expectString(output.type),
   } as any;
 };
 
@@ -7141,14 +7087,14 @@ const deserializeAws_restJson1S3LogsConfigurationResult = (
   context: __SerdeContext
 ): S3LogsConfigurationResult => {
   return {
-    Status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    Status: __expectString(output.status),
   } as any;
 };
 
 const deserializeAws_restJson1SecurityGroup = (output: any, context: __SerdeContext): SecurityGroup => {
   return {
-    GroupId: output.groupId !== undefined && output.groupId !== null ? output.groupId : undefined,
-    GroupName: output.groupName !== undefined && output.groupName !== null ? output.groupName : undefined,
+    GroupId: __expectString(output.groupId),
+    GroupName: __expectString(output.groupName),
   } as any;
 };
 
@@ -7169,27 +7115,25 @@ const deserializeAws_restJson1Service = (output: any, context: __SerdeContext): 
       output.action !== undefined && output.action !== null
         ? deserializeAws_restJson1Action(output.action, context)
         : undefined,
-    Archived: output.archived !== undefined && output.archived !== null ? output.archived : undefined,
-    Count: output.count !== undefined && output.count !== null ? output.count : undefined,
-    DetectorId: output.detectorId !== undefined && output.detectorId !== null ? output.detectorId : undefined,
-    EventFirstSeen:
-      output.eventFirstSeen !== undefined && output.eventFirstSeen !== null ? output.eventFirstSeen : undefined,
-    EventLastSeen:
-      output.eventLastSeen !== undefined && output.eventLastSeen !== null ? output.eventLastSeen : undefined,
+    Archived: __expectBoolean(output.archived),
+    Count: __expectNumber(output.count),
+    DetectorId: __expectString(output.detectorId),
+    EventFirstSeen: __expectString(output.eventFirstSeen),
+    EventLastSeen: __expectString(output.eventLastSeen),
     Evidence:
       output.evidence !== undefined && output.evidence !== null
         ? deserializeAws_restJson1Evidence(output.evidence, context)
         : undefined,
-    ResourceRole: output.resourceRole !== undefined && output.resourceRole !== null ? output.resourceRole : undefined,
-    ServiceName: output.serviceName !== undefined && output.serviceName !== null ? output.serviceName : undefined,
-    UserFeedback: output.userFeedback !== undefined && output.userFeedback !== null ? output.userFeedback : undefined,
+    ResourceRole: __expectString(output.resourceRole),
+    ServiceName: __expectString(output.serviceName),
+    UserFeedback: __expectString(output.userFeedback),
   } as any;
 };
 
 const deserializeAws_restJson1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.key !== undefined && output.key !== null ? output.key : undefined,
-    Value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    Key: __expectString(output.key),
+    Value: __expectString(output.value),
   } as any;
 };
 
@@ -7200,7 +7144,7 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -7221,8 +7165,7 @@ const deserializeAws_restJson1ThreatIntelligenceDetail = (
   context: __SerdeContext
 ): ThreatIntelligenceDetail => {
   return {
-    ThreatListName:
-      output.threatListName !== undefined && output.threatListName !== null ? output.threatListName : undefined,
+    ThreatListName: __expectString(output.threatListName),
     ThreatNames:
       output.threatNames !== undefined && output.threatNames !== null
         ? deserializeAws_restJson1ThreatNames(output.threatNames, context)
@@ -7251,7 +7194,7 @@ const deserializeAws_restJson1ThreatIntelSetIds = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7262,21 +7205,21 @@ const deserializeAws_restJson1ThreatNames = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1Total = (output: any, context: __SerdeContext): Total => {
   return {
-    Amount: output.amount !== undefined && output.amount !== null ? output.amount : undefined,
-    Unit: output.unit !== undefined && output.unit !== null ? output.unit : undefined,
+    Amount: __expectString(output.amount),
+    Unit: __expectString(output.unit),
   } as any;
 };
 
 const deserializeAws_restJson1UnprocessedAccount = (output: any, context: __SerdeContext): UnprocessedAccount => {
   return {
-    AccountId: output.accountId !== undefined && output.accountId !== null ? output.accountId : undefined,
-    Result: output.result !== undefined && output.result !== null ? output.result : undefined,
+    AccountId: __expectString(output.accountId),
+    Result: __expectString(output.result),
   } as any;
 };
 
@@ -7293,7 +7236,7 @@ const deserializeAws_restJson1UnprocessedAccounts = (output: any, context: __Ser
 
 const deserializeAws_restJson1UsageAccountResult = (output: any, context: __SerdeContext): UsageAccountResult => {
   return {
-    AccountId: output.accountId !== undefined && output.accountId !== null ? output.accountId : undefined,
+    AccountId: __expectString(output.accountId),
     Total:
       output.total !== undefined && output.total !== null
         ? deserializeAws_restJson1Total(output.total, context)
@@ -7314,7 +7257,7 @@ const deserializeAws_restJson1UsageAccountResultList = (output: any, context: __
 
 const deserializeAws_restJson1UsageDataSourceResult = (output: any, context: __SerdeContext): UsageDataSourceResult => {
   return {
-    DataSource: output.dataSource !== undefined && output.dataSource !== null ? output.dataSource : undefined,
+    DataSource: __expectString(output.dataSource),
     Total:
       output.total !== undefined && output.total !== null
         ? deserializeAws_restJson1Total(output.total, context)
@@ -7338,7 +7281,7 @@ const deserializeAws_restJson1UsageDataSourceResultList = (
 
 const deserializeAws_restJson1UsageResourceResult = (output: any, context: __SerdeContext): UsageResourceResult => {
   return {
-    Resource: output.resource !== undefined && output.resource !== null ? output.resource : undefined,
+    Resource: __expectString(output.resource),
     Total:
       output.total !== undefined && output.total !== null
         ? deserializeAws_restJson1Total(output.total, context)

--- a/clients/client-health/protocols/Aws_json1_1.ts
+++ b/clients/client-health/protocols/Aws_json1_1.ts
@@ -92,7 +92,11 @@ import {
   UnsupportedLocale,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -1527,22 +1531,22 @@ const deserializeAws_json1_1affectedAccountsList = (output: any, context: __Serd
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1AffectedEntity = (output: any, context: __SerdeContext): AffectedEntity => {
   return {
-    awsAccountId: output.awsAccountId !== undefined && output.awsAccountId !== null ? output.awsAccountId : undefined,
-    entityArn: output.entityArn !== undefined && output.entityArn !== null ? output.entityArn : undefined,
-    entityUrl: output.entityUrl !== undefined && output.entityUrl !== null ? output.entityUrl : undefined,
-    entityValue: output.entityValue !== undefined && output.entityValue !== null ? output.entityValue : undefined,
-    eventArn: output.eventArn !== undefined && output.eventArn !== null ? output.eventArn : undefined,
+    awsAccountId: __expectString(output.awsAccountId),
+    entityArn: __expectString(output.entityArn),
+    entityUrl: __expectString(output.entityUrl),
+    entityValue: __expectString(output.entityValue),
+    eventArn: __expectString(output.eventArn),
     lastUpdatedTime:
       output.lastUpdatedTime !== undefined && output.lastUpdatedTime !== null
         ? new Date(Math.round(output.lastUpdatedTime * 1000))
         : undefined,
-    statusCode: output.statusCode !== undefined && output.statusCode !== null ? output.statusCode : undefined,
+    statusCode: __expectString(output.statusCode),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_json1_1tagSet(output.tags, context)
@@ -1555,7 +1559,7 @@ const deserializeAws_json1_1ConcurrentModificationException = (
   context: __SerdeContext
 ): ConcurrentModificationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -1568,9 +1572,8 @@ const deserializeAws_json1_1DescribeAffectedAccountsForOrganizationResponse = (
       output.affectedAccounts !== undefined && output.affectedAccounts !== null
         ? deserializeAws_json1_1affectedAccountsList(output.affectedAccounts, context)
         : undefined,
-    eventScopeCode:
-      output.eventScopeCode !== undefined && output.eventScopeCode !== null ? output.eventScopeCode : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    eventScopeCode: __expectString(output.eventScopeCode),
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -1601,7 +1604,7 @@ const deserializeAws_json1_1DescribeAffectedEntitiesForOrganizationResponse = (
       output.failedSet !== undefined && output.failedSet !== null
         ? deserializeAws_json1_1DescribeAffectedEntitiesForOrganizationFailedSet(output.failedSet, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -1614,7 +1617,7 @@ const deserializeAws_json1_1DescribeAffectedEntitiesResponse = (
       output.entities !== undefined && output.entities !== null
         ? deserializeAws_json1_1EntityList(output.entities, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -1639,7 +1642,7 @@ const deserializeAws_json1_1DescribeEventAggregatesResponse = (
       output.eventAggregates !== undefined && output.eventAggregates !== null
         ? deserializeAws_json1_1EventAggregateList(output.eventAggregates, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -1740,7 +1743,7 @@ const deserializeAws_json1_1DescribeEventsForOrganizationResponse = (
       output.events !== undefined && output.events !== null
         ? deserializeAws_json1_1OrganizationEventList(output.events, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -1750,7 +1753,7 @@ const deserializeAws_json1_1DescribeEventsResponse = (output: any, context: __Se
       output.events !== undefined && output.events !== null
         ? deserializeAws_json1_1EventList(output.events, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -1763,7 +1766,7 @@ const deserializeAws_json1_1DescribeEventTypesResponse = (
       output.eventTypes !== undefined && output.eventTypes !== null
         ? deserializeAws_json1_1EventTypeList(output.eventTypes, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -1772,18 +1775,14 @@ const deserializeAws_json1_1DescribeHealthServiceStatusForOrganizationResponse =
   context: __SerdeContext
 ): DescribeHealthServiceStatusForOrganizationResponse => {
   return {
-    healthServiceAccessStatusForOrganization:
-      output.healthServiceAccessStatusForOrganization !== undefined &&
-      output.healthServiceAccessStatusForOrganization !== null
-        ? output.healthServiceAccessStatusForOrganization
-        : undefined,
+    healthServiceAccessStatusForOrganization: __expectString(output.healthServiceAccessStatusForOrganization),
   } as any;
 };
 
 const deserializeAws_json1_1EntityAggregate = (output: any, context: __SerdeContext): EntityAggregate => {
   return {
-    count: output.count !== undefined && output.count !== null ? output.count : undefined,
-    eventArn: output.eventArn !== undefined && output.eventArn !== null ? output.eventArn : undefined,
+    count: __expectNumber(output.count),
+    eventArn: __expectString(output.eventArn),
   } as any;
 };
 
@@ -1811,38 +1810,31 @@ const deserializeAws_json1_1EntityList = (output: any, context: __SerdeContext):
 
 const deserializeAws_json1_1Event = (output: any, context: __SerdeContext): Event => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    availabilityZone:
-      output.availabilityZone !== undefined && output.availabilityZone !== null ? output.availabilityZone : undefined,
+    arn: __expectString(output.arn),
+    availabilityZone: __expectString(output.availabilityZone),
     endTime:
       output.endTime !== undefined && output.endTime !== null ? new Date(Math.round(output.endTime * 1000)) : undefined,
-    eventScopeCode:
-      output.eventScopeCode !== undefined && output.eventScopeCode !== null ? output.eventScopeCode : undefined,
-    eventTypeCategory:
-      output.eventTypeCategory !== undefined && output.eventTypeCategory !== null
-        ? output.eventTypeCategory
-        : undefined,
-    eventTypeCode:
-      output.eventTypeCode !== undefined && output.eventTypeCode !== null ? output.eventTypeCode : undefined,
+    eventScopeCode: __expectString(output.eventScopeCode),
+    eventTypeCategory: __expectString(output.eventTypeCategory),
+    eventTypeCode: __expectString(output.eventTypeCode),
     lastUpdatedTime:
       output.lastUpdatedTime !== undefined && output.lastUpdatedTime !== null
         ? new Date(Math.round(output.lastUpdatedTime * 1000))
         : undefined,
-    region: output.region !== undefined && output.region !== null ? output.region : undefined,
-    service: output.service !== undefined && output.service !== null ? output.service : undefined,
+    region: __expectString(output.region),
+    service: __expectString(output.service),
     startTime:
       output.startTime !== undefined && output.startTime !== null
         ? new Date(Math.round(output.startTime * 1000))
         : undefined,
-    statusCode: output.statusCode !== undefined && output.statusCode !== null ? output.statusCode : undefined,
+    statusCode: __expectString(output.statusCode),
   } as any;
 };
 
 const deserializeAws_json1_1EventAggregate = (output: any, context: __SerdeContext): EventAggregate => {
   return {
-    aggregateValue:
-      output.aggregateValue !== undefined && output.aggregateValue !== null ? output.aggregateValue : undefined,
-    count: output.count !== undefined && output.count !== null ? output.count : undefined,
+    aggregateValue: __expectString(output.aggregateValue),
+    count: __expectNumber(output.count),
   } as any;
 };
 
@@ -1859,10 +1851,7 @@ const deserializeAws_json1_1EventAggregateList = (output: any, context: __SerdeC
 
 const deserializeAws_json1_1EventDescription = (output: any, context: __SerdeContext): EventDescription => {
   return {
-    latestDescription:
-      output.latestDescription !== undefined && output.latestDescription !== null
-        ? output.latestDescription
-        : undefined,
+    latestDescription: __expectString(output.latestDescription),
   } as any;
 };
 
@@ -1885,9 +1874,9 @@ const deserializeAws_json1_1EventDetails = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_1EventDetailsErrorItem = (output: any, context: __SerdeContext): EventDetailsErrorItem => {
   return {
-    errorMessage: output.errorMessage !== undefined && output.errorMessage !== null ? output.errorMessage : undefined,
-    errorName: output.errorName !== undefined && output.errorName !== null ? output.errorName : undefined,
-    eventArn: output.eventArn !== undefined && output.eventArn !== null ? output.eventArn : undefined,
+    errorMessage: __expectString(output.errorMessage),
+    errorName: __expectString(output.errorName),
+    eventArn: __expectString(output.eventArn),
   } as any;
 };
 
@@ -1909,16 +1898,16 @@ const deserializeAws_json1_1eventMetadata = (output: any, context: __SerdeContex
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_json1_1EventType = (output: any, context: __SerdeContext): EventType => {
   return {
-    category: output.category !== undefined && output.category !== null ? output.category : undefined,
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    service: output.service !== undefined && output.service !== null ? output.service : undefined,
+    category: __expectString(output.category),
+    code: __expectString(output.code),
+    service: __expectString(output.service),
   } as any;
 };
 
@@ -1935,7 +1924,7 @@ const deserializeAws_json1_1EventTypeList = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1InvalidPaginationToken = (output: any, context: __SerdeContext): InvalidPaginationToken => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -1944,37 +1933,32 @@ const deserializeAws_json1_1OrganizationAffectedEntitiesErrorItem = (
   context: __SerdeContext
 ): OrganizationAffectedEntitiesErrorItem => {
   return {
-    awsAccountId: output.awsAccountId !== undefined && output.awsAccountId !== null ? output.awsAccountId : undefined,
-    errorMessage: output.errorMessage !== undefined && output.errorMessage !== null ? output.errorMessage : undefined,
-    errorName: output.errorName !== undefined && output.errorName !== null ? output.errorName : undefined,
-    eventArn: output.eventArn !== undefined && output.eventArn !== null ? output.eventArn : undefined,
+    awsAccountId: __expectString(output.awsAccountId),
+    errorMessage: __expectString(output.errorMessage),
+    errorName: __expectString(output.errorName),
+    eventArn: __expectString(output.eventArn),
   } as any;
 };
 
 const deserializeAws_json1_1OrganizationEvent = (output: any, context: __SerdeContext): OrganizationEvent => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     endTime:
       output.endTime !== undefined && output.endTime !== null ? new Date(Math.round(output.endTime * 1000)) : undefined,
-    eventScopeCode:
-      output.eventScopeCode !== undefined && output.eventScopeCode !== null ? output.eventScopeCode : undefined,
-    eventTypeCategory:
-      output.eventTypeCategory !== undefined && output.eventTypeCategory !== null
-        ? output.eventTypeCategory
-        : undefined,
-    eventTypeCode:
-      output.eventTypeCode !== undefined && output.eventTypeCode !== null ? output.eventTypeCode : undefined,
+    eventScopeCode: __expectString(output.eventScopeCode),
+    eventTypeCategory: __expectString(output.eventTypeCategory),
+    eventTypeCode: __expectString(output.eventTypeCode),
     lastUpdatedTime:
       output.lastUpdatedTime !== undefined && output.lastUpdatedTime !== null
         ? new Date(Math.round(output.lastUpdatedTime * 1000))
         : undefined,
-    region: output.region !== undefined && output.region !== null ? output.region : undefined,
-    service: output.service !== undefined && output.service !== null ? output.service : undefined,
+    region: __expectString(output.region),
+    service: __expectString(output.service),
     startTime:
       output.startTime !== undefined && output.startTime !== null
         ? new Date(Math.round(output.startTime * 1000))
         : undefined,
-    statusCode: output.statusCode !== undefined && output.statusCode !== null ? output.statusCode : undefined,
+    statusCode: __expectString(output.statusCode),
   } as any;
 };
 
@@ -1983,7 +1967,7 @@ const deserializeAws_json1_1OrganizationEventDetails = (
   context: __SerdeContext
 ): OrganizationEventDetails => {
   return {
-    awsAccountId: output.awsAccountId !== undefined && output.awsAccountId !== null ? output.awsAccountId : undefined,
+    awsAccountId: __expectString(output.awsAccountId),
     event:
       output.event !== undefined && output.event !== null
         ? deserializeAws_json1_1Event(output.event, context)
@@ -2004,10 +1988,10 @@ const deserializeAws_json1_1OrganizationEventDetailsErrorItem = (
   context: __SerdeContext
 ): OrganizationEventDetailsErrorItem => {
   return {
-    awsAccountId: output.awsAccountId !== undefined && output.awsAccountId !== null ? output.awsAccountId : undefined,
-    errorMessage: output.errorMessage !== undefined && output.errorMessage !== null ? output.errorMessage : undefined,
-    errorName: output.errorName !== undefined && output.errorName !== null ? output.errorName : undefined,
-    eventArn: output.eventArn !== undefined && output.eventArn !== null ? output.eventArn : undefined,
+    awsAccountId: __expectString(output.awsAccountId),
+    errorMessage: __expectString(output.errorMessage),
+    errorName: __expectString(output.errorName),
+    eventArn: __expectString(output.eventArn),
   } as any;
 };
 
@@ -2029,14 +2013,14 @@ const deserializeAws_json1_1tagSet = (output: any, context: __SerdeContext): { [
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_json1_1UnsupportedLocale = (output: any, context: __SerdeContext): UnsupportedLocale => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 

--- a/clients/client-healthlake/protocols/Aws_json1_0.ts
+++ b/clients/client-healthlake/protocols/Aws_json1_0.ts
@@ -53,7 +53,7 @@ import {
   ValidationException,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException, expectString as __expectString } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -1032,13 +1032,13 @@ const serializeAws_json1_0StartFHIRImportJobRequest = (
 
 const deserializeAws_json1_0AccessDeniedException = (output: any, context: __SerdeContext): AccessDeniedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_0ConflictException = (output: any, context: __SerdeContext): ConflictException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -1047,14 +1047,10 @@ const deserializeAws_json1_0CreateFHIRDatastoreResponse = (
   context: __SerdeContext
 ): CreateFHIRDatastoreResponse => {
   return {
-    DatastoreArn: output.DatastoreArn !== undefined && output.DatastoreArn !== null ? output.DatastoreArn : undefined,
-    DatastoreEndpoint:
-      output.DatastoreEndpoint !== undefined && output.DatastoreEndpoint !== null
-        ? output.DatastoreEndpoint
-        : undefined,
-    DatastoreId: output.DatastoreId !== undefined && output.DatastoreId !== null ? output.DatastoreId : undefined,
-    DatastoreStatus:
-      output.DatastoreStatus !== undefined && output.DatastoreStatus !== null ? output.DatastoreStatus : undefined,
+    DatastoreArn: __expectString(output.DatastoreArn),
+    DatastoreEndpoint: __expectString(output.DatastoreEndpoint),
+    DatastoreId: __expectString(output.DatastoreId),
+    DatastoreStatus: __expectString(output.DatastoreStatus),
   } as any;
 };
 
@@ -1064,20 +1060,12 @@ const deserializeAws_json1_0DatastoreProperties = (output: any, context: __Serde
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    DatastoreArn: output.DatastoreArn !== undefined && output.DatastoreArn !== null ? output.DatastoreArn : undefined,
-    DatastoreEndpoint:
-      output.DatastoreEndpoint !== undefined && output.DatastoreEndpoint !== null
-        ? output.DatastoreEndpoint
-        : undefined,
-    DatastoreId: output.DatastoreId !== undefined && output.DatastoreId !== null ? output.DatastoreId : undefined,
-    DatastoreName:
-      output.DatastoreName !== undefined && output.DatastoreName !== null ? output.DatastoreName : undefined,
-    DatastoreStatus:
-      output.DatastoreStatus !== undefined && output.DatastoreStatus !== null ? output.DatastoreStatus : undefined,
-    DatastoreTypeVersion:
-      output.DatastoreTypeVersion !== undefined && output.DatastoreTypeVersion !== null
-        ? output.DatastoreTypeVersion
-        : undefined,
+    DatastoreArn: __expectString(output.DatastoreArn),
+    DatastoreEndpoint: __expectString(output.DatastoreEndpoint),
+    DatastoreId: __expectString(output.DatastoreId),
+    DatastoreName: __expectString(output.DatastoreName),
+    DatastoreStatus: __expectString(output.DatastoreStatus),
+    DatastoreTypeVersion: __expectString(output.DatastoreTypeVersion),
     PreloadDataConfig:
       output.PreloadDataConfig !== undefined && output.PreloadDataConfig !== null
         ? deserializeAws_json1_0PreloadDataConfig(output.PreloadDataConfig, context)
@@ -1101,14 +1089,10 @@ const deserializeAws_json1_0DeleteFHIRDatastoreResponse = (
   context: __SerdeContext
 ): DeleteFHIRDatastoreResponse => {
   return {
-    DatastoreArn: output.DatastoreArn !== undefined && output.DatastoreArn !== null ? output.DatastoreArn : undefined,
-    DatastoreEndpoint:
-      output.DatastoreEndpoint !== undefined && output.DatastoreEndpoint !== null
-        ? output.DatastoreEndpoint
-        : undefined,
-    DatastoreId: output.DatastoreId !== undefined && output.DatastoreId !== null ? output.DatastoreId : undefined,
-    DatastoreStatus:
-      output.DatastoreStatus !== undefined && output.DatastoreStatus !== null ? output.DatastoreStatus : undefined,
+    DatastoreArn: __expectString(output.DatastoreArn),
+    DatastoreEndpoint: __expectString(output.DatastoreEndpoint),
+    DatastoreId: __expectString(output.DatastoreId),
+    DatastoreStatus: __expectString(output.DatastoreStatus),
   } as any;
 };
 
@@ -1150,17 +1134,14 @@ const deserializeAws_json1_0DescribeFHIRImportJobResponse = (
 
 const deserializeAws_json1_0ExportJobProperties = (output: any, context: __SerdeContext): ExportJobProperties => {
   return {
-    DataAccessRoleArn:
-      output.DataAccessRoleArn !== undefined && output.DataAccessRoleArn !== null
-        ? output.DataAccessRoleArn
-        : undefined,
-    DatastoreId: output.DatastoreId !== undefined && output.DatastoreId !== null ? output.DatastoreId : undefined,
+    DataAccessRoleArn: __expectString(output.DataAccessRoleArn),
+    DatastoreId: __expectString(output.DatastoreId),
     EndTime:
       output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
-    JobName: output.JobName !== undefined && output.JobName !== null ? output.JobName : undefined,
-    JobStatus: output.JobStatus !== undefined && output.JobStatus !== null ? output.JobStatus : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    JobId: __expectString(output.JobId),
+    JobName: __expectString(output.JobName),
+    JobStatus: __expectString(output.JobStatus),
+    Message: __expectString(output.Message),
     OutputDataConfig:
       output.OutputDataConfig !== undefined && output.OutputDataConfig !== null
         ? deserializeAws_json1_0OutputDataConfig(output.OutputDataConfig, context)
@@ -1174,21 +1155,18 @@ const deserializeAws_json1_0ExportJobProperties = (output: any, context: __Serde
 
 const deserializeAws_json1_0ImportJobProperties = (output: any, context: __SerdeContext): ImportJobProperties => {
   return {
-    DataAccessRoleArn:
-      output.DataAccessRoleArn !== undefined && output.DataAccessRoleArn !== null
-        ? output.DataAccessRoleArn
-        : undefined,
-    DatastoreId: output.DatastoreId !== undefined && output.DatastoreId !== null ? output.DatastoreId : undefined,
+    DataAccessRoleArn: __expectString(output.DataAccessRoleArn),
+    DatastoreId: __expectString(output.DatastoreId),
     EndTime:
       output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
     InputDataConfig:
       output.InputDataConfig !== undefined && output.InputDataConfig !== null
         ? deserializeAws_json1_0InputDataConfig(output.InputDataConfig, context)
         : undefined,
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
-    JobName: output.JobName !== undefined && output.JobName !== null ? output.JobName : undefined,
-    JobStatus: output.JobStatus !== undefined && output.JobStatus !== null ? output.JobStatus : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    JobId: __expectString(output.JobId),
+    JobName: __expectString(output.JobName),
+    JobStatus: __expectString(output.JobStatus),
+    Message: __expectString(output.Message),
     SubmitTime:
       output.SubmitTime !== undefined && output.SubmitTime !== null
         ? new Date(Math.round(output.SubmitTime * 1000))
@@ -1197,10 +1175,8 @@ const deserializeAws_json1_0ImportJobProperties = (output: any, context: __Serde
 };
 
 const deserializeAws_json1_0InputDataConfig = (output: any, context: __SerdeContext): InputDataConfig => {
-  if (output.S3Uri !== undefined && output.S3Uri !== null) {
-    return {
-      S3Uri: output.S3Uri,
-    };
+  if (__expectString(output.S3Uri) !== undefined) {
+    return { S3Uri: __expectString(output.S3Uri) as any };
   }
   return { $unknown: Object.entries(output)[0] };
 };
@@ -1210,7 +1186,7 @@ const deserializeAws_json1_0InternalServerException = (
   context: __SerdeContext
 ): InternalServerException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -1223,23 +1199,20 @@ const deserializeAws_json1_0ListFHIRDatastoresResponse = (
       output.DatastorePropertiesList !== undefined && output.DatastorePropertiesList !== null
         ? deserializeAws_json1_0DatastorePropertiesList(output.DatastorePropertiesList, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
 const deserializeAws_json1_0OutputDataConfig = (output: any, context: __SerdeContext): OutputDataConfig => {
-  if (output.S3Uri !== undefined && output.S3Uri !== null) {
-    return {
-      S3Uri: output.S3Uri,
-    };
+  if (__expectString(output.S3Uri) !== undefined) {
+    return { S3Uri: __expectString(output.S3Uri) as any };
   }
   return { $unknown: Object.entries(output)[0] };
 };
 
 const deserializeAws_json1_0PreloadDataConfig = (output: any, context: __SerdeContext): PreloadDataConfig => {
   return {
-    PreloadDataType:
-      output.PreloadDataType !== undefined && output.PreloadDataType !== null ? output.PreloadDataType : undefined,
+    PreloadDataType: __expectString(output.PreloadDataType),
   } as any;
 };
 
@@ -1248,7 +1221,7 @@ const deserializeAws_json1_0ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -1257,9 +1230,9 @@ const deserializeAws_json1_0StartFHIRExportJobResponse = (
   context: __SerdeContext
 ): StartFHIRExportJobResponse => {
   return {
-    DatastoreId: output.DatastoreId !== undefined && output.DatastoreId !== null ? output.DatastoreId : undefined,
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
-    JobStatus: output.JobStatus !== undefined && output.JobStatus !== null ? output.JobStatus : undefined,
+    DatastoreId: __expectString(output.DatastoreId),
+    JobId: __expectString(output.JobId),
+    JobStatus: __expectString(output.JobStatus),
   } as any;
 };
 
@@ -1268,21 +1241,21 @@ const deserializeAws_json1_0StartFHIRImportJobResponse = (
   context: __SerdeContext
 ): StartFHIRImportJobResponse => {
   return {
-    DatastoreId: output.DatastoreId !== undefined && output.DatastoreId !== null ? output.DatastoreId : undefined,
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
-    JobStatus: output.JobStatus !== undefined && output.JobStatus !== null ? output.JobStatus : undefined,
+    DatastoreId: __expectString(output.DatastoreId),
+    JobId: __expectString(output.JobId),
+    JobStatus: __expectString(output.JobStatus),
   } as any;
 };
 
 const deserializeAws_json1_0ThrottlingException = (output: any, context: __SerdeContext): ThrottlingException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_0ValidationException = (output: any, context: __SerdeContext): ValidationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 

--- a/clients/client-honeycode/protocols/Aws_restJson1.ts
+++ b/clients/client-honeycode/protocols/Aws_restJson1.ts
@@ -70,6 +70,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -640,7 +643,7 @@ export const deserializeAws_restJson1BatchCreateTableRowsCommand = async (
     contents.failedBatchItems = deserializeAws_restJson1FailedBatchItems(data.failedBatchItems, context);
   }
   if (data.workbookCursor !== undefined && data.workbookCursor !== null) {
-    contents.workbookCursor = data.workbookCursor;
+    contents.workbookCursor = __expectNumber(data.workbookCursor);
   }
   return Promise.resolve(contents);
 };
@@ -755,7 +758,7 @@ export const deserializeAws_restJson1BatchDeleteTableRowsCommand = async (
     contents.failedBatchItems = deserializeAws_restJson1FailedBatchItems(data.failedBatchItems, context);
   }
   if (data.workbookCursor !== undefined && data.workbookCursor !== null) {
-    contents.workbookCursor = data.workbookCursor;
+    contents.workbookCursor = __expectNumber(data.workbookCursor);
   }
   return Promise.resolve(contents);
 };
@@ -862,7 +865,7 @@ export const deserializeAws_restJson1BatchUpdateTableRowsCommand = async (
     contents.failedBatchItems = deserializeAws_restJson1FailedBatchItems(data.failedBatchItems, context);
   }
   if (data.workbookCursor !== undefined && data.workbookCursor !== null) {
-    contents.workbookCursor = data.workbookCursor;
+    contents.workbookCursor = __expectNumber(data.workbookCursor);
   }
   return Promise.resolve(contents);
 };
@@ -973,7 +976,7 @@ export const deserializeAws_restJson1BatchUpsertTableRowsCommand = async (
     contents.rows = deserializeAws_restJson1UpsertRowsResultMap(data.rows, context);
   }
   if (data.workbookCursor !== undefined && data.workbookCursor !== null) {
-    contents.workbookCursor = data.workbookCursor;
+    contents.workbookCursor = __expectNumber(data.workbookCursor);
   }
   return Promise.resolve(contents);
 };
@@ -1089,10 +1092,10 @@ export const deserializeAws_restJson1DescribeTableDataImportJobCommand = async (
     contents.jobMetadata = deserializeAws_restJson1TableDataImportJobMetadata(data.jobMetadata, context);
   }
   if (data.jobStatus !== undefined && data.jobStatus !== null) {
-    contents.jobStatus = data.jobStatus;
+    contents.jobStatus = __expectString(data.jobStatus);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return Promise.resolve(contents);
 };
@@ -1189,13 +1192,13 @@ export const deserializeAws_restJson1GetScreenDataCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.results !== undefined && data.results !== null) {
     contents.results = deserializeAws_restJson1ResultSetMap(data.results, context);
   }
   if (data.workbookCursor !== undefined && data.workbookCursor !== null) {
-    contents.workbookCursor = data.workbookCursor;
+    contents.workbookCursor = __expectNumber(data.workbookCursor);
   }
   return Promise.resolve(contents);
 };
@@ -1298,7 +1301,7 @@ export const deserializeAws_restJson1InvokeScreenAutomationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.workbookCursor !== undefined && data.workbookCursor !== null) {
-    contents.workbookCursor = data.workbookCursor;
+    contents.workbookCursor = __expectNumber(data.workbookCursor);
   }
   return Promise.resolve(contents);
 };
@@ -1419,13 +1422,13 @@ export const deserializeAws_restJson1ListTableColumnsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.tableColumns !== undefined && data.tableColumns !== null) {
     contents.tableColumns = deserializeAws_restJson1TableColumns(data.tableColumns, context);
   }
   if (data.workbookCursor !== undefined && data.workbookCursor !== null) {
-    contents.workbookCursor = data.workbookCursor;
+    contents.workbookCursor = __expectNumber(data.workbookCursor);
   }
   return Promise.resolve(contents);
 };
@@ -1535,7 +1538,7 @@ export const deserializeAws_restJson1ListTableRowsCommand = async (
     contents.columnIds = deserializeAws_restJson1ResourceIds(data.columnIds, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.rowIdsNotFound !== undefined && data.rowIdsNotFound !== null) {
     contents.rowIdsNotFound = deserializeAws_restJson1RowIdList(data.rowIdsNotFound, context);
@@ -1544,7 +1547,7 @@ export const deserializeAws_restJson1ListTableRowsCommand = async (
     contents.rows = deserializeAws_restJson1TableRows(data.rows, context);
   }
   if (data.workbookCursor !== undefined && data.workbookCursor !== null) {
-    contents.workbookCursor = data.workbookCursor;
+    contents.workbookCursor = __expectNumber(data.workbookCursor);
   }
   return Promise.resolve(contents);
 };
@@ -1649,13 +1652,13 @@ export const deserializeAws_restJson1ListTablesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.tables !== undefined && data.tables !== null) {
     contents.tables = deserializeAws_restJson1Tables(data.tables, context);
   }
   if (data.workbookCursor !== undefined && data.workbookCursor !== null) {
-    contents.workbookCursor = data.workbookCursor;
+    contents.workbookCursor = __expectNumber(data.workbookCursor);
   }
   return Promise.resolve(contents);
 };
@@ -1764,13 +1767,13 @@ export const deserializeAws_restJson1QueryTableRowsCommand = async (
     contents.columnIds = deserializeAws_restJson1ResourceIds(data.columnIds, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.rows !== undefined && data.rows !== null) {
     contents.rows = deserializeAws_restJson1TableRows(data.rows, context);
   }
   if (data.workbookCursor !== undefined && data.workbookCursor !== null) {
-    contents.workbookCursor = data.workbookCursor;
+    contents.workbookCursor = __expectNumber(data.workbookCursor);
   }
   return Promise.resolve(contents);
 };
@@ -1874,10 +1877,10 @@ export const deserializeAws_restJson1StartTableDataImportJobCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.jobId !== undefined && data.jobId !== null) {
-    contents.jobId = data.jobId;
+    contents.jobId = __expectString(data.jobId);
   }
   if (data.jobStatus !== undefined && data.jobStatus !== null) {
-    contents.jobStatus = data.jobStatus;
+    contents.jobStatus = __expectString(data.jobStatus);
   }
   return Promise.resolve(contents);
 };
@@ -1971,7 +1974,7 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1988,7 +1991,7 @@ const deserializeAws_restJson1AutomationExecutionExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2005,7 +2008,7 @@ const deserializeAws_restJson1AutomationExecutionTimeoutExceptionResponse = asyn
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2022,7 +2025,7 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2039,7 +2042,7 @@ const deserializeAws_restJson1RequestTimeoutExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2056,7 +2059,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2073,7 +2076,7 @@ const deserializeAws_restJson1ServiceQuotaExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2090,7 +2093,7 @@ const deserializeAws_restJson1ServiceUnavailableExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2107,7 +2110,7 @@ const deserializeAws_restJson1ThrottlingExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2124,7 +2127,7 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2329,11 +2332,10 @@ const serializeAws_restJson1VariableValueMap = (
 
 const deserializeAws_restJson1Cell = (output: any, context: __SerdeContext): Cell => {
   return {
-    format: output.format !== undefined && output.format !== null ? output.format : undefined,
-    formattedValue:
-      output.formattedValue !== undefined && output.formattedValue !== null ? output.formattedValue : undefined,
-    formula: output.formula !== undefined && output.formula !== null ? output.formula : undefined,
-    rawValue: output.rawValue !== undefined && output.rawValue !== null ? output.rawValue : undefined,
+    format: __expectString(output.format),
+    formattedValue: __expectString(output.formattedValue),
+    formula: __expectString(output.formula),
+    rawValue: __expectString(output.rawValue),
   } as any;
 };
 
@@ -2350,8 +2352,8 @@ const deserializeAws_restJson1Cells = (output: any, context: __SerdeContext): Ce
 
 const deserializeAws_restJson1ColumnMetadata = (output: any, context: __SerdeContext): ColumnMetadata => {
   return {
-    format: output.format !== undefined && output.format !== null ? output.format : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    format: __expectString(output.format),
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -2362,18 +2364,16 @@ const deserializeAws_restJson1CreatedRowsMap = (output: any, context: __SerdeCon
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1DataItem = (output: any, context: __SerdeContext): DataItem => {
   return {
-    formattedValue:
-      output.formattedValue !== undefined && output.formattedValue !== null ? output.formattedValue : undefined,
-    overrideFormat:
-      output.overrideFormat !== undefined && output.overrideFormat !== null ? output.overrideFormat : undefined,
-    rawValue: output.rawValue !== undefined && output.rawValue !== null ? output.rawValue : undefined,
+    formattedValue: __expectString(output.formattedValue),
+    overrideFormat: __expectString(output.overrideFormat),
+    rawValue: __expectString(output.rawValue),
   } as any;
 };
 
@@ -2393,14 +2393,10 @@ const deserializeAws_restJson1DelimitedTextImportOptions = (
   context: __SerdeContext
 ): DelimitedTextImportOptions => {
   return {
-    dataCharacterEncoding:
-      output.dataCharacterEncoding !== undefined && output.dataCharacterEncoding !== null
-        ? output.dataCharacterEncoding
-        : undefined,
-    delimiter: output.delimiter !== undefined && output.delimiter !== null ? output.delimiter : undefined,
-    hasHeaderRow: output.hasHeaderRow !== undefined && output.hasHeaderRow !== null ? output.hasHeaderRow : undefined,
-    ignoreEmptyRows:
-      output.ignoreEmptyRows !== undefined && output.ignoreEmptyRows !== null ? output.ignoreEmptyRows : undefined,
+    dataCharacterEncoding: __expectString(output.dataCharacterEncoding),
+    delimiter: __expectString(output.delimiter),
+    hasHeaderRow: __expectBoolean(output.hasHeaderRow),
+    ignoreEmptyRows: __expectBoolean(output.ignoreEmptyRows),
   } as any;
 };
 
@@ -2415,8 +2411,8 @@ const deserializeAws_restJson1DestinationOptions = (output: any, context: __Serd
 
 const deserializeAws_restJson1FailedBatchItem = (output: any, context: __SerdeContext): FailedBatchItem => {
   return {
-    errorMessage: output.errorMessage !== undefined && output.errorMessage !== null ? output.errorMessage : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    errorMessage: __expectString(output.errorMessage),
+    id: __expectString(output.id),
   } as any;
 };
 
@@ -2463,15 +2459,14 @@ const deserializeAws_restJson1ImportDataSourceConfig = (
   context: __SerdeContext
 ): ImportDataSourceConfig => {
   return {
-    dataSourceUrl:
-      output.dataSourceUrl !== undefined && output.dataSourceUrl !== null ? output.dataSourceUrl : undefined,
+    dataSourceUrl: __expectString(output.dataSourceUrl),
   } as any;
 };
 
 const deserializeAws_restJson1ImportJobSubmitter = (output: any, context: __SerdeContext): ImportJobSubmitter => {
   return {
-    email: output.email !== undefined && output.email !== null ? output.email : undefined,
-    userArn: output.userArn !== undefined && output.userArn !== null ? output.userArn : undefined,
+    email: __expectString(output.email),
+    userArn: __expectString(output.userArn),
   } as any;
 };
 
@@ -2495,7 +2490,7 @@ const deserializeAws_restJson1ResourceIds = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2516,7 +2511,7 @@ const deserializeAws_restJson1ResultRow = (output: any, context: __SerdeContext)
       output.dataItems !== undefined && output.dataItems !== null
         ? deserializeAws_restJson1DataItems(output.dataItems, context)
         : undefined,
-    rowId: output.rowId !== undefined && output.rowId !== null ? output.rowId : undefined,
+    rowId: __expectString(output.rowId),
   } as any;
 };
 
@@ -2563,7 +2558,7 @@ const deserializeAws_restJson1RowIdList = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2572,24 +2567,22 @@ const deserializeAws_restJson1SourceDataColumnProperties = (
   context: __SerdeContext
 ): SourceDataColumnProperties => {
   return {
-    columnIndex: output.columnIndex !== undefined && output.columnIndex !== null ? output.columnIndex : undefined,
+    columnIndex: __expectNumber(output.columnIndex),
   } as any;
 };
 
 const deserializeAws_restJson1Table = (output: any, context: __SerdeContext): Table => {
   return {
-    tableId: output.tableId !== undefined && output.tableId !== null ? output.tableId : undefined,
-    tableName: output.tableName !== undefined && output.tableName !== null ? output.tableName : undefined,
+    tableId: __expectString(output.tableId),
+    tableName: __expectString(output.tableName),
   } as any;
 };
 
 const deserializeAws_restJson1TableColumn = (output: any, context: __SerdeContext): TableColumn => {
   return {
-    format: output.format !== undefined && output.format !== null ? output.format : undefined,
-    tableColumnId:
-      output.tableColumnId !== undefined && output.tableColumnId !== null ? output.tableColumnId : undefined,
-    tableColumnName:
-      output.tableColumnName !== undefined && output.tableColumnName !== null ? output.tableColumnName : undefined,
+    format: __expectString(output.format),
+    tableColumnId: __expectString(output.tableColumnId),
+    tableColumnName: __expectString(output.tableColumnName),
   } as any;
 };
 
@@ -2634,7 +2627,7 @@ const deserializeAws_restJson1TableRow = (output: any, context: __SerdeContext):
       output.cells !== undefined && output.cells !== null
         ? deserializeAws_restJson1Cells(output.cells, context)
         : undefined,
-    rowId: output.rowId !== undefined && output.rowId !== null ? output.rowId : undefined,
+    rowId: __expectString(output.rowId),
   } as any;
 };
 
@@ -2666,7 +2659,7 @@ const deserializeAws_restJson1UpsertRowsResult = (output: any, context: __SerdeC
       output.rowIds !== undefined && output.rowIds !== null
         ? deserializeAws_restJson1RowIdList(output.rowIds, context)
         : undefined,
-    upsertAction: output.upsertAction !== undefined && output.upsertAction !== null ? output.upsertAction : undefined,
+    upsertAction: __expectString(output.upsertAction),
   } as any;
 };
 

--- a/clients/client-iam/protocols/Aws_query.ts
+++ b/clients/client-iam/protocols/Aws_query.ts
@@ -704,6 +704,7 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
@@ -17326,16 +17327,16 @@ const deserializeAws_queryAccessDetail = (output: any, context: __SerdeContext):
     TotalAuthenticatedEntities: undefined,
   };
   if (output["ServiceName"] !== undefined) {
-    contents.ServiceName = output["ServiceName"];
+    contents.ServiceName = __expectString(output["ServiceName"]);
   }
   if (output["ServiceNamespace"] !== undefined) {
-    contents.ServiceNamespace = output["ServiceNamespace"];
+    contents.ServiceNamespace = __expectString(output["ServiceNamespace"]);
   }
   if (output["Region"] !== undefined) {
-    contents.Region = output["Region"];
+    contents.Region = __expectString(output["Region"]);
   }
   if (output["EntityPath"] !== undefined) {
-    contents.EntityPath = output["EntityPath"];
+    contents.EntityPath = __expectString(output["EntityPath"]);
   }
   if (output["LastAuthenticatedTime"] !== undefined) {
     contents.LastAuthenticatedTime = new Date(output["LastAuthenticatedTime"]);
@@ -17366,16 +17367,16 @@ const deserializeAws_queryAccessKey = (output: any, context: __SerdeContext): Ac
     CreateDate: undefined,
   };
   if (output["UserName"] !== undefined) {
-    contents.UserName = output["UserName"];
+    contents.UserName = __expectString(output["UserName"]);
   }
   if (output["AccessKeyId"] !== undefined) {
-    contents.AccessKeyId = output["AccessKeyId"];
+    contents.AccessKeyId = __expectString(output["AccessKeyId"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["SecretAccessKey"] !== undefined) {
-    contents.SecretAccessKey = output["SecretAccessKey"];
+    contents.SecretAccessKey = __expectString(output["SecretAccessKey"]);
   }
   if (output["CreateDate"] !== undefined) {
     contents.CreateDate = new Date(output["CreateDate"]);
@@ -17393,10 +17394,10 @@ const deserializeAws_queryAccessKeyLastUsed = (output: any, context: __SerdeCont
     contents.LastUsedDate = new Date(output["LastUsedDate"]);
   }
   if (output["ServiceName"] !== undefined) {
-    contents.ServiceName = output["ServiceName"];
+    contents.ServiceName = __expectString(output["ServiceName"]);
   }
   if (output["Region"] !== undefined) {
-    contents.Region = output["Region"];
+    contents.Region = __expectString(output["Region"]);
   }
   return contents;
 };
@@ -17409,13 +17410,13 @@ const deserializeAws_queryAccessKeyMetadata = (output: any, context: __SerdeCont
     CreateDate: undefined,
   };
   if (output["UserName"] !== undefined) {
-    contents.UserName = output["UserName"];
+    contents.UserName = __expectString(output["UserName"]);
   }
   if (output["AccessKeyId"] !== undefined) {
-    contents.AccessKeyId = output["AccessKeyId"];
+    contents.AccessKeyId = __expectString(output["AccessKeyId"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["CreateDate"] !== undefined) {
     contents.CreateDate = new Date(output["CreateDate"]);
@@ -17441,7 +17442,7 @@ const deserializeAws_queryaccountAliasListType = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -17452,7 +17453,7 @@ const deserializeAws_queryArnListType = (output: any, context: __SerdeContext): 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -17465,10 +17466,10 @@ const deserializeAws_queryAttachedPermissionsBoundary = (
     PermissionsBoundaryArn: undefined,
   };
   if (output["PermissionsBoundaryType"] !== undefined) {
-    contents.PermissionsBoundaryType = output["PermissionsBoundaryType"];
+    contents.PermissionsBoundaryType = __expectString(output["PermissionsBoundaryType"]);
   }
   if (output["PermissionsBoundaryArn"] !== undefined) {
-    contents.PermissionsBoundaryArn = output["PermissionsBoundaryArn"];
+    contents.PermissionsBoundaryArn = __expectString(output["PermissionsBoundaryArn"]);
   }
   return contents;
 };
@@ -17490,10 +17491,10 @@ const deserializeAws_queryAttachedPolicy = (output: any, context: __SerdeContext
     PolicyArn: undefined,
   };
   if (output["PolicyName"] !== undefined) {
-    contents.PolicyName = output["PolicyName"];
+    contents.PolicyName = __expectString(output["PolicyName"]);
   }
   if (output["PolicyArn"] !== undefined) {
-    contents.PolicyArn = output["PolicyArn"];
+    contents.PolicyArn = __expectString(output["PolicyArn"]);
   }
   return contents;
 };
@@ -17516,7 +17517,7 @@ const deserializeAws_queryclientIDListType = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -17528,7 +17529,7 @@ const deserializeAws_queryConcurrentModificationException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17540,7 +17541,7 @@ const deserializeAws_queryContextKeyNamesResultListType = (output: any, context:
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -17599,7 +17600,7 @@ const deserializeAws_queryCreateOpenIDConnectProviderResponse = (
     Tags: undefined,
   };
   if (output["OpenIDConnectProviderArn"] !== undefined) {
-    contents.OpenIDConnectProviderArn = output["OpenIDConnectProviderArn"];
+    contents.OpenIDConnectProviderArn = __expectString(output["OpenIDConnectProviderArn"]);
   }
   if (output.Tags === "") {
     contents.Tags = [];
@@ -17652,7 +17653,7 @@ const deserializeAws_queryCreateSAMLProviderResponse = (
     Tags: undefined,
   };
   if (output["SAMLProviderArn"] !== undefined) {
-    contents.SAMLProviderArn = output["SAMLProviderArn"];
+    contents.SAMLProviderArn = __expectString(output["SAMLProviderArn"]);
   }
   if (output.Tags === "") {
     contents.Tags = [];
@@ -17723,7 +17724,7 @@ const deserializeAws_queryCredentialReportExpiredException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17736,7 +17737,7 @@ const deserializeAws_queryCredentialReportNotPresentException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17749,7 +17750,7 @@ const deserializeAws_queryCredentialReportNotReadyException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17759,7 +17760,7 @@ const deserializeAws_queryDeleteConflictException = (output: any, context: __Ser
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17772,7 +17773,7 @@ const deserializeAws_queryDeleteServiceLinkedRoleResponse = (
     DeletionTaskId: undefined,
   };
   if (output["DeletionTaskId"] !== undefined) {
-    contents.DeletionTaskId = output["DeletionTaskId"];
+    contents.DeletionTaskId = __expectString(output["DeletionTaskId"]);
   }
   return contents;
 };
@@ -17786,7 +17787,7 @@ const deserializeAws_queryDeletionTaskFailureReasonType = (
     RoleUsageList: undefined,
   };
   if (output["Reason"] !== undefined) {
-    contents.Reason = output["Reason"];
+    contents.Reason = __expectString(output["Reason"]);
   }
   if (output.RoleUsageList === "") {
     contents.RoleUsageList = [];
@@ -17808,7 +17809,7 @@ const deserializeAws_queryDuplicateCertificateException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17821,7 +17822,7 @@ const deserializeAws_queryDuplicateSSHPublicKeyException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17834,7 +17835,7 @@ const deserializeAws_queryEntityAlreadyExistsException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17873,19 +17874,19 @@ const deserializeAws_queryEntityInfo = (output: any, context: __SerdeContext): E
     Path: undefined,
   };
   if (output["Arn"] !== undefined) {
-    contents.Arn = output["Arn"];
+    contents.Arn = __expectString(output["Arn"]);
   }
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["Type"] !== undefined) {
-    contents.Type = output["Type"];
+    contents.Type = __expectString(output["Type"]);
   }
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   if (output["Path"] !== undefined) {
-    contents.Path = output["Path"];
+    contents.Path = __expectString(output["Path"]);
   }
   return contents;
 };
@@ -17898,7 +17899,7 @@ const deserializeAws_queryEntityTemporarilyUnmodifiableException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17909,10 +17910,10 @@ const deserializeAws_queryErrorDetails = (output: any, context: __SerdeContext):
     Code: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   if (output["Code"] !== undefined) {
-    contents.Code = output["Code"];
+    contents.Code = __expectString(output["Code"]);
   }
   return contents;
 };
@@ -17927,7 +17928,7 @@ const deserializeAws_queryEvalDecisionDetailsType = (
     }
     return {
       ...acc,
-      [pair["key"]]: pair["value"],
+      [pair["key"]]: __expectString(pair["value"]) as any,
     };
   }, {});
 };
@@ -17945,13 +17946,13 @@ const deserializeAws_queryEvaluationResult = (output: any, context: __SerdeConte
     ResourceSpecificResults: undefined,
   };
   if (output["EvalActionName"] !== undefined) {
-    contents.EvalActionName = output["EvalActionName"];
+    contents.EvalActionName = __expectString(output["EvalActionName"]);
   }
   if (output["EvalResourceName"] !== undefined) {
-    contents.EvalResourceName = output["EvalResourceName"];
+    contents.EvalResourceName = __expectString(output["EvalResourceName"]);
   }
   if (output["EvalDecision"] !== undefined) {
-    contents.EvalDecision = output["EvalDecision"];
+    contents.EvalDecision = __expectString(output["EvalDecision"]);
   }
   if (output.MatchedStatements === "") {
     contents.MatchedStatements = [];
@@ -18024,10 +18025,10 @@ const deserializeAws_queryGenerateCredentialReportResponse = (
     Description: undefined,
   };
   if (output["State"] !== undefined) {
-    contents.State = output["State"];
+    contents.State = __expectString(output["State"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   return contents;
 };
@@ -18040,7 +18041,7 @@ const deserializeAws_queryGenerateOrganizationsAccessReportResponse = (
     JobId: undefined,
   };
   if (output["JobId"] !== undefined) {
-    contents.JobId = output["JobId"];
+    contents.JobId = __expectString(output["JobId"]);
   }
   return contents;
 };
@@ -18053,7 +18054,7 @@ const deserializeAws_queryGenerateServiceLastAccessedDetailsResponse = (
     JobId: undefined,
   };
   if (output["JobId"] !== undefined) {
-    contents.JobId = output["JobId"];
+    contents.JobId = __expectString(output["JobId"]);
   }
   return contents;
 };
@@ -18067,7 +18068,7 @@ const deserializeAws_queryGetAccessKeyLastUsedResponse = (
     AccessKeyLastUsed: undefined,
   };
   if (output["UserName"] !== undefined) {
-    contents.UserName = output["UserName"];
+    contents.UserName = __expectString(output["UserName"]);
   }
   if (output["AccessKeyLastUsed"] !== undefined) {
     contents.AccessKeyLastUsed = deserializeAws_queryAccessKeyLastUsed(output["AccessKeyLastUsed"], context);
@@ -18127,7 +18128,7 @@ const deserializeAws_queryGetAccountAuthorizationDetailsResponse = (
     contents.IsTruncated = __parseBoolean(output["IsTruncated"]);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -18196,7 +18197,7 @@ const deserializeAws_queryGetCredentialReportResponse = (
     contents.Content = context.base64Decoder(output["Content"]);
   }
   if (output["ReportFormat"] !== undefined) {
-    contents.ReportFormat = output["ReportFormat"];
+    contents.ReportFormat = __expectString(output["ReportFormat"]);
   }
   if (output["GeneratedTime"] !== undefined) {
     contents.GeneratedTime = new Date(output["GeneratedTime"]);
@@ -18211,13 +18212,13 @@ const deserializeAws_queryGetGroupPolicyResponse = (output: any, context: __Serd
     PolicyDocument: undefined,
   };
   if (output["GroupName"] !== undefined) {
-    contents.GroupName = output["GroupName"];
+    contents.GroupName = __expectString(output["GroupName"]);
   }
   if (output["PolicyName"] !== undefined) {
-    contents.PolicyName = output["PolicyName"];
+    contents.PolicyName = __expectString(output["PolicyName"]);
   }
   if (output["PolicyDocument"] !== undefined) {
-    contents.PolicyDocument = output["PolicyDocument"];
+    contents.PolicyDocument = __expectString(output["PolicyDocument"]);
   }
   return contents;
 };
@@ -18242,7 +18243,7 @@ const deserializeAws_queryGetGroupResponse = (output: any, context: __SerdeConte
     contents.IsTruncated = __parseBoolean(output["IsTruncated"]);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -18282,7 +18283,7 @@ const deserializeAws_queryGetOpenIDConnectProviderResponse = (
     Tags: undefined,
   };
   if (output["Url"] !== undefined) {
-    contents.Url = output["Url"];
+    contents.Url = __expectString(output["Url"]);
   }
   if (output.ClientIDList === "") {
     contents.ClientIDList = [];
@@ -18330,7 +18331,7 @@ const deserializeAws_queryGetOrganizationsAccessReportResponse = (
     ErrorDetails: undefined,
   };
   if (output["JobStatus"] !== undefined) {
-    contents.JobStatus = output["JobStatus"];
+    contents.JobStatus = __expectString(output["JobStatus"]);
   }
   if (output["JobCreationDate"] !== undefined) {
     contents.JobCreationDate = new Date(output["JobCreationDate"]);
@@ -18357,7 +18358,7 @@ const deserializeAws_queryGetOrganizationsAccessReportResponse = (
     contents.IsTruncated = __parseBoolean(output["IsTruncated"]);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output["ErrorDetails"] !== undefined) {
     contents.ErrorDetails = deserializeAws_queryErrorDetails(output["ErrorDetails"], context);
@@ -18395,13 +18396,13 @@ const deserializeAws_queryGetRolePolicyResponse = (output: any, context: __Serde
     PolicyDocument: undefined,
   };
   if (output["RoleName"] !== undefined) {
-    contents.RoleName = output["RoleName"];
+    contents.RoleName = __expectString(output["RoleName"]);
   }
   if (output["PolicyName"] !== undefined) {
-    contents.PolicyName = output["PolicyName"];
+    contents.PolicyName = __expectString(output["PolicyName"]);
   }
   if (output["PolicyDocument"] !== undefined) {
-    contents.PolicyDocument = output["PolicyDocument"];
+    contents.PolicyDocument = __expectString(output["PolicyDocument"]);
   }
   return contents;
 };
@@ -18424,7 +18425,7 @@ const deserializeAws_queryGetSAMLProviderResponse = (output: any, context: __Ser
     Tags: undefined,
   };
   if (output["SAMLMetadataDocument"] !== undefined) {
-    contents.SAMLMetadataDocument = output["SAMLMetadataDocument"];
+    contents.SAMLMetadataDocument = __expectString(output["SAMLMetadataDocument"]);
   }
   if (output["CreateDate"] !== undefined) {
     contents.CreateDate = new Date(output["CreateDate"]);
@@ -18469,10 +18470,10 @@ const deserializeAws_queryGetServiceLastAccessedDetailsResponse = (
     Error: undefined,
   };
   if (output["JobStatus"] !== undefined) {
-    contents.JobStatus = output["JobStatus"];
+    contents.JobStatus = __expectString(output["JobStatus"]);
   }
   if (output["JobType"] !== undefined) {
-    contents.JobType = output["JobType"];
+    contents.JobType = __expectString(output["JobType"]);
   }
   if (output["JobCreationDate"] !== undefined) {
     contents.JobCreationDate = new Date(output["JobCreationDate"]);
@@ -18493,7 +18494,7 @@ const deserializeAws_queryGetServiceLastAccessedDetailsResponse = (
     contents.IsTruncated = __parseBoolean(output["IsTruncated"]);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output["Error"] !== undefined) {
     contents.Error = deserializeAws_queryErrorDetails(output["Error"], context);
@@ -18515,7 +18516,7 @@ const deserializeAws_queryGetServiceLastAccessedDetailsWithEntitiesResponse = (
     Error: undefined,
   };
   if (output["JobStatus"] !== undefined) {
-    contents.JobStatus = output["JobStatus"];
+    contents.JobStatus = __expectString(output["JobStatus"]);
   }
   if (output["JobCreationDate"] !== undefined) {
     contents.JobCreationDate = new Date(output["JobCreationDate"]);
@@ -18536,7 +18537,7 @@ const deserializeAws_queryGetServiceLastAccessedDetailsWithEntitiesResponse = (
     contents.IsTruncated = __parseBoolean(output["IsTruncated"]);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output["Error"] !== undefined) {
     contents.Error = deserializeAws_queryErrorDetails(output["Error"], context);
@@ -18553,7 +18554,7 @@ const deserializeAws_queryGetServiceLinkedRoleDeletionStatusResponse = (
     Reason: undefined,
   };
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["Reason"] !== undefined) {
     contents.Reason = deserializeAws_queryDeletionTaskFailureReasonType(output["Reason"], context);
@@ -18578,13 +18579,13 @@ const deserializeAws_queryGetUserPolicyResponse = (output: any, context: __Serde
     PolicyDocument: undefined,
   };
   if (output["UserName"] !== undefined) {
-    contents.UserName = output["UserName"];
+    contents.UserName = __expectString(output["UserName"]);
   }
   if (output["PolicyName"] !== undefined) {
-    contents.PolicyName = output["PolicyName"];
+    contents.PolicyName = __expectString(output["PolicyName"]);
   }
   if (output["PolicyDocument"] !== undefined) {
-    contents.PolicyDocument = output["PolicyDocument"];
+    contents.PolicyDocument = __expectString(output["PolicyDocument"]);
   }
   return contents;
 };
@@ -18608,16 +18609,16 @@ const deserializeAws_queryGroup = (output: any, context: __SerdeContext): Group 
     CreateDate: undefined,
   };
   if (output["Path"] !== undefined) {
-    contents.Path = output["Path"];
+    contents.Path = __expectString(output["Path"]);
   }
   if (output["GroupName"] !== undefined) {
-    contents.GroupName = output["GroupName"];
+    contents.GroupName = __expectString(output["GroupName"]);
   }
   if (output["GroupId"] !== undefined) {
-    contents.GroupId = output["GroupId"];
+    contents.GroupId = __expectString(output["GroupId"]);
   }
   if (output["Arn"] !== undefined) {
-    contents.Arn = output["Arn"];
+    contents.Arn = __expectString(output["Arn"]);
   }
   if (output["CreateDate"] !== undefined) {
     contents.CreateDate = new Date(output["CreateDate"]);
@@ -18636,16 +18637,16 @@ const deserializeAws_queryGroupDetail = (output: any, context: __SerdeContext): 
     AttachedManagedPolicies: undefined,
   };
   if (output["Path"] !== undefined) {
-    contents.Path = output["Path"];
+    contents.Path = __expectString(output["Path"]);
   }
   if (output["GroupName"] !== undefined) {
-    contents.GroupName = output["GroupName"];
+    contents.GroupName = __expectString(output["GroupName"]);
   }
   if (output["GroupId"] !== undefined) {
-    contents.GroupId = output["GroupId"];
+    contents.GroupId = __expectString(output["GroupId"]);
   }
   if (output["Arn"] !== undefined) {
-    contents.Arn = output["Arn"];
+    contents.Arn = __expectString(output["Arn"]);
   }
   if (output["CreateDate"] !== undefined) {
     contents.CreateDate = new Date(output["CreateDate"]);
@@ -18700,7 +18701,7 @@ const deserializeAws_querygroupNameListType = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -18715,16 +18716,16 @@ const deserializeAws_queryInstanceProfile = (output: any, context: __SerdeContex
     Tags: undefined,
   };
   if (output["Path"] !== undefined) {
-    contents.Path = output["Path"];
+    contents.Path = __expectString(output["Path"]);
   }
   if (output["InstanceProfileName"] !== undefined) {
-    contents.InstanceProfileName = output["InstanceProfileName"];
+    contents.InstanceProfileName = __expectString(output["InstanceProfileName"]);
   }
   if (output["InstanceProfileId"] !== undefined) {
-    contents.InstanceProfileId = output["InstanceProfileId"];
+    contents.InstanceProfileId = __expectString(output["InstanceProfileId"]);
   }
   if (output["Arn"] !== undefined) {
-    contents.Arn = output["Arn"];
+    contents.Arn = __expectString(output["Arn"]);
   }
   if (output["CreateDate"] !== undefined) {
     contents.CreateDate = new Date(output["CreateDate"]);
@@ -18763,7 +18764,7 @@ const deserializeAws_queryInvalidAuthenticationCodeException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -18776,7 +18777,7 @@ const deserializeAws_queryInvalidCertificateException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -18786,7 +18787,7 @@ const deserializeAws_queryInvalidInputException = (output: any, context: __Serde
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -18799,7 +18800,7 @@ const deserializeAws_queryInvalidPublicKeyException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -18812,7 +18813,7 @@ const deserializeAws_queryInvalidUserTypeException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -18825,7 +18826,7 @@ const deserializeAws_queryKeyPairMismatchException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -18835,7 +18836,7 @@ const deserializeAws_queryLimitExceededException = (output: any, context: __Serd
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -18859,7 +18860,7 @@ const deserializeAws_queryListAccessKeysResponse = (output: any, context: __Serd
     contents.IsTruncated = __parseBoolean(output["IsTruncated"]);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -18886,7 +18887,7 @@ const deserializeAws_queryListAccountAliasesResponse = (
     contents.IsTruncated = __parseBoolean(output["IsTruncated"]);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -18913,7 +18914,7 @@ const deserializeAws_queryListAttachedGroupPoliciesResponse = (
     contents.IsTruncated = __parseBoolean(output["IsTruncated"]);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -18940,7 +18941,7 @@ const deserializeAws_queryListAttachedRolePoliciesResponse = (
     contents.IsTruncated = __parseBoolean(output["IsTruncated"]);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -18967,7 +18968,7 @@ const deserializeAws_queryListAttachedUserPoliciesResponse = (
     contents.IsTruncated = __parseBoolean(output["IsTruncated"]);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -19014,7 +19015,7 @@ const deserializeAws_queryListEntitiesForPolicyResponse = (
     contents.IsTruncated = __parseBoolean(output["IsTruncated"]);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -19041,7 +19042,7 @@ const deserializeAws_queryListGroupPoliciesResponse = (
     contents.IsTruncated = __parseBoolean(output["IsTruncated"]);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -19065,7 +19066,7 @@ const deserializeAws_queryListGroupsForUserResponse = (
     contents.IsTruncated = __parseBoolean(output["IsTruncated"]);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -19086,7 +19087,7 @@ const deserializeAws_queryListGroupsResponse = (output: any, context: __SerdeCon
     contents.IsTruncated = __parseBoolean(output["IsTruncated"]);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -19113,7 +19114,7 @@ const deserializeAws_queryListInstanceProfilesForRoleResponse = (
     contents.IsTruncated = __parseBoolean(output["IsTruncated"]);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -19140,7 +19141,7 @@ const deserializeAws_queryListInstanceProfilesResponse = (
     contents.IsTruncated = __parseBoolean(output["IsTruncated"]);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -19164,7 +19165,7 @@ const deserializeAws_queryListInstanceProfileTagsResponse = (
     contents.IsTruncated = __parseBoolean(output["IsTruncated"]);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -19188,7 +19189,7 @@ const deserializeAws_queryListMFADevicesResponse = (output: any, context: __Serd
     contents.IsTruncated = __parseBoolean(output["IsTruncated"]);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -19212,7 +19213,7 @@ const deserializeAws_queryListMFADeviceTagsResponse = (
     contents.IsTruncated = __parseBoolean(output["IsTruncated"]);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -19258,7 +19259,7 @@ const deserializeAws_queryListOpenIDConnectProviderTagsResponse = (
     contents.IsTruncated = __parseBoolean(output["IsTruncated"]);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -19272,7 +19273,7 @@ const deserializeAws_queryListPoliciesGrantingServiceAccessEntry = (
     Policies: undefined,
   };
   if (output["ServiceNamespace"] !== undefined) {
-    contents.ServiceNamespace = output["ServiceNamespace"];
+    contents.ServiceNamespace = __expectString(output["ServiceNamespace"]);
   }
   if (output.Policies === "") {
     contents.Policies = [];
@@ -19311,7 +19312,7 @@ const deserializeAws_queryListPoliciesGrantingServiceAccessResponse = (
     contents.IsTruncated = __parseBoolean(output["IsTruncated"]);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -19335,7 +19336,7 @@ const deserializeAws_queryListPoliciesResponse = (output: any, context: __SerdeC
     contents.IsTruncated = __parseBoolean(output["IsTruncated"]);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -19370,7 +19371,7 @@ const deserializeAws_queryListPolicyTagsResponse = (output: any, context: __Serd
     contents.IsTruncated = __parseBoolean(output["IsTruncated"]);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -19397,7 +19398,7 @@ const deserializeAws_queryListPolicyVersionsResponse = (
     contents.IsTruncated = __parseBoolean(output["IsTruncated"]);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -19424,7 +19425,7 @@ const deserializeAws_queryListRolePoliciesResponse = (
     contents.IsTruncated = __parseBoolean(output["IsTruncated"]);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -19445,7 +19446,7 @@ const deserializeAws_queryListRolesResponse = (output: any, context: __SerdeCont
     contents.IsTruncated = __parseBoolean(output["IsTruncated"]);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -19466,7 +19467,7 @@ const deserializeAws_queryListRoleTagsResponse = (output: any, context: __SerdeC
     contents.IsTruncated = __parseBoolean(output["IsTruncated"]);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -19509,7 +19510,7 @@ const deserializeAws_queryListSAMLProviderTagsResponse = (
     contents.IsTruncated = __parseBoolean(output["IsTruncated"]);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -19539,7 +19540,7 @@ const deserializeAws_queryListServerCertificatesResponse = (
     contents.IsTruncated = __parseBoolean(output["IsTruncated"]);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -19563,7 +19564,7 @@ const deserializeAws_queryListServerCertificateTagsResponse = (
     contents.IsTruncated = __parseBoolean(output["IsTruncated"]);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -19612,7 +19613,7 @@ const deserializeAws_queryListSigningCertificatesResponse = (
     contents.IsTruncated = __parseBoolean(output["IsTruncated"]);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -19639,7 +19640,7 @@ const deserializeAws_queryListSSHPublicKeysResponse = (
     contents.IsTruncated = __parseBoolean(output["IsTruncated"]);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -19666,7 +19667,7 @@ const deserializeAws_queryListUserPoliciesResponse = (
     contents.IsTruncated = __parseBoolean(output["IsTruncated"]);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -19687,7 +19688,7 @@ const deserializeAws_queryListUsersResponse = (output: any, context: __SerdeCont
     contents.IsTruncated = __parseBoolean(output["IsTruncated"]);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -19708,7 +19709,7 @@ const deserializeAws_queryListUserTagsResponse = (output: any, context: __SerdeC
     contents.IsTruncated = __parseBoolean(output["IsTruncated"]);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -19735,7 +19736,7 @@ const deserializeAws_queryListVirtualMFADevicesResponse = (
     contents.IsTruncated = __parseBoolean(output["IsTruncated"]);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -19747,7 +19748,7 @@ const deserializeAws_queryLoginProfile = (output: any, context: __SerdeContext):
     PasswordResetRequired: undefined,
   };
   if (output["UserName"] !== undefined) {
-    contents.UserName = output["UserName"];
+    contents.UserName = __expectString(output["UserName"]);
   }
   if (output["CreateDate"] !== undefined) {
     contents.CreateDate = new Date(output["CreateDate"]);
@@ -19766,7 +19767,7 @@ const deserializeAws_queryMalformedCertificateException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -19779,7 +19780,7 @@ const deserializeAws_queryMalformedPolicyDocumentException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -19800,19 +19801,19 @@ const deserializeAws_queryManagedPolicyDetail = (output: any, context: __SerdeCo
     PolicyVersionList: undefined,
   };
   if (output["PolicyName"] !== undefined) {
-    contents.PolicyName = output["PolicyName"];
+    contents.PolicyName = __expectString(output["PolicyName"]);
   }
   if (output["PolicyId"] !== undefined) {
-    contents.PolicyId = output["PolicyId"];
+    contents.PolicyId = __expectString(output["PolicyId"]);
   }
   if (output["Arn"] !== undefined) {
-    contents.Arn = output["Arn"];
+    contents.Arn = __expectString(output["Arn"]);
   }
   if (output["Path"] !== undefined) {
-    contents.Path = output["Path"];
+    contents.Path = __expectString(output["Path"]);
   }
   if (output["DefaultVersionId"] !== undefined) {
-    contents.DefaultVersionId = output["DefaultVersionId"];
+    contents.DefaultVersionId = __expectString(output["DefaultVersionId"]);
   }
   if (output["AttachmentCount"] !== undefined) {
     contents.AttachmentCount = parseInt(output["AttachmentCount"]);
@@ -19824,7 +19825,7 @@ const deserializeAws_queryManagedPolicyDetail = (output: any, context: __SerdeCo
     contents.IsAttachable = __parseBoolean(output["IsAttachable"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output["CreateDate"] !== undefined) {
     contents.CreateDate = new Date(output["CreateDate"]);
@@ -19865,10 +19866,10 @@ const deserializeAws_queryMFADevice = (output: any, context: __SerdeContext): MF
     EnableDate: undefined,
   };
   if (output["UserName"] !== undefined) {
-    contents.UserName = output["UserName"];
+    contents.UserName = __expectString(output["UserName"]);
   }
   if (output["SerialNumber"] !== undefined) {
-    contents.SerialNumber = output["SerialNumber"];
+    contents.SerialNumber = __expectString(output["SerialNumber"]);
   }
   if (output["EnableDate"] !== undefined) {
     contents.EnableDate = new Date(output["EnableDate"]);
@@ -19892,7 +19893,7 @@ const deserializeAws_queryNoSuchEntityException = (output: any, context: __Serde
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -19905,7 +19906,7 @@ const deserializeAws_queryOpenIDConnectProviderListEntry = (
     Arn: undefined,
   };
   if (output["Arn"] !== undefined) {
-    contents.Arn = output["Arn"];
+    contents.Arn = __expectString(output["Arn"]);
   }
   return contents;
 };
@@ -19991,7 +19992,7 @@ const deserializeAws_queryPasswordPolicyViolationException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -20025,19 +20026,19 @@ const deserializeAws_queryPolicy = (output: any, context: __SerdeContext): Polic
     Tags: undefined,
   };
   if (output["PolicyName"] !== undefined) {
-    contents.PolicyName = output["PolicyName"];
+    contents.PolicyName = __expectString(output["PolicyName"]);
   }
   if (output["PolicyId"] !== undefined) {
-    contents.PolicyId = output["PolicyId"];
+    contents.PolicyId = __expectString(output["PolicyId"]);
   }
   if (output["Arn"] !== undefined) {
-    contents.Arn = output["Arn"];
+    contents.Arn = __expectString(output["Arn"]);
   }
   if (output["Path"] !== undefined) {
-    contents.Path = output["Path"];
+    contents.Path = __expectString(output["Path"]);
   }
   if (output["DefaultVersionId"] !== undefined) {
-    contents.DefaultVersionId = output["DefaultVersionId"];
+    contents.DefaultVersionId = __expectString(output["DefaultVersionId"]);
   }
   if (output["AttachmentCount"] !== undefined) {
     contents.AttachmentCount = parseInt(output["AttachmentCount"]);
@@ -20049,7 +20050,7 @@ const deserializeAws_queryPolicy = (output: any, context: __SerdeContext): Polic
     contents.IsAttachable = __parseBoolean(output["IsAttachable"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output["CreateDate"] !== undefined) {
     contents.CreateDate = new Date(output["CreateDate"]);
@@ -20072,10 +20073,10 @@ const deserializeAws_queryPolicyDetail = (output: any, context: __SerdeContext):
     PolicyDocument: undefined,
   };
   if (output["PolicyName"] !== undefined) {
-    contents.PolicyName = output["PolicyName"];
+    contents.PolicyName = __expectString(output["PolicyName"]);
   }
   if (output["PolicyDocument"] !== undefined) {
-    contents.PolicyDocument = output["PolicyDocument"];
+    contents.PolicyDocument = __expectString(output["PolicyDocument"]);
   }
   return contents;
 };
@@ -20110,7 +20111,7 @@ const deserializeAws_queryPolicyEvaluationException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -20127,19 +20128,19 @@ const deserializeAws_queryPolicyGrantingServiceAccess = (
     EntityName: undefined,
   };
   if (output["PolicyName"] !== undefined) {
-    contents.PolicyName = output["PolicyName"];
+    contents.PolicyName = __expectString(output["PolicyName"]);
   }
   if (output["PolicyType"] !== undefined) {
-    contents.PolicyType = output["PolicyType"];
+    contents.PolicyType = __expectString(output["PolicyType"]);
   }
   if (output["PolicyArn"] !== undefined) {
-    contents.PolicyArn = output["PolicyArn"];
+    contents.PolicyArn = __expectString(output["PolicyArn"]);
   }
   if (output["EntityType"] !== undefined) {
-    contents.EntityType = output["EntityType"];
+    contents.EntityType = __expectString(output["EntityType"]);
   }
   if (output["EntityName"] !== undefined) {
-    contents.EntityName = output["EntityName"];
+    contents.EntityName = __expectString(output["EntityName"]);
   }
   return contents;
 };
@@ -20164,10 +20165,10 @@ const deserializeAws_queryPolicyGroup = (output: any, context: __SerdeContext): 
     GroupId: undefined,
   };
   if (output["GroupName"] !== undefined) {
-    contents.GroupName = output["GroupName"];
+    contents.GroupName = __expectString(output["GroupName"]);
   }
   if (output["GroupId"] !== undefined) {
-    contents.GroupId = output["GroupId"];
+    contents.GroupId = __expectString(output["GroupId"]);
   }
   return contents;
 };
@@ -20201,7 +20202,7 @@ const deserializeAws_querypolicyNameListType = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -20213,7 +20214,7 @@ const deserializeAws_queryPolicyNotAttachableException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -20224,10 +20225,10 @@ const deserializeAws_queryPolicyRole = (output: any, context: __SerdeContext): P
     RoleId: undefined,
   };
   if (output["RoleName"] !== undefined) {
-    contents.RoleName = output["RoleName"];
+    contents.RoleName = __expectString(output["RoleName"]);
   }
   if (output["RoleId"] !== undefined) {
-    contents.RoleId = output["RoleId"];
+    contents.RoleId = __expectString(output["RoleId"]);
   }
   return contents;
 };
@@ -20249,10 +20250,10 @@ const deserializeAws_queryPolicyUser = (output: any, context: __SerdeContext): P
     UserId: undefined,
   };
   if (output["UserName"] !== undefined) {
-    contents.UserName = output["UserName"];
+    contents.UserName = __expectString(output["UserName"]);
   }
   if (output["UserId"] !== undefined) {
-    contents.UserId = output["UserId"];
+    contents.UserId = __expectString(output["UserId"]);
   }
   return contents;
 };
@@ -20276,10 +20277,10 @@ const deserializeAws_queryPolicyVersion = (output: any, context: __SerdeContext)
     CreateDate: undefined,
   };
   if (output["Document"] !== undefined) {
-    contents.Document = output["Document"];
+    contents.Document = __expectString(output["Document"]);
   }
   if (output["VersionId"] !== undefined) {
-    contents.VersionId = output["VersionId"];
+    contents.VersionId = __expectString(output["VersionId"]);
   }
   if (output["IsDefaultVersion"] !== undefined) {
     contents.IsDefaultVersion = __parseBoolean(output["IsDefaultVersion"]);
@@ -20312,7 +20313,7 @@ const deserializeAws_queryReportGenerationLimitExceededException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -20343,10 +20344,10 @@ const deserializeAws_queryResourceSpecificResult = (output: any, context: __Serd
     PermissionsBoundaryDecisionDetail: undefined,
   };
   if (output["EvalResourceName"] !== undefined) {
-    contents.EvalResourceName = output["EvalResourceName"];
+    contents.EvalResourceName = __expectString(output["EvalResourceName"]);
   }
   if (output["EvalResourceDecision"] !== undefined) {
-    contents.EvalResourceDecision = output["EvalResourceDecision"];
+    contents.EvalResourceDecision = __expectString(output["EvalResourceDecision"]);
   }
   if (output.MatchedStatements === "") {
     contents.MatchedStatements = [];
@@ -20413,25 +20414,25 @@ const deserializeAws_queryRole = (output: any, context: __SerdeContext): Role =>
     RoleLastUsed: undefined,
   };
   if (output["Path"] !== undefined) {
-    contents.Path = output["Path"];
+    contents.Path = __expectString(output["Path"]);
   }
   if (output["RoleName"] !== undefined) {
-    contents.RoleName = output["RoleName"];
+    contents.RoleName = __expectString(output["RoleName"]);
   }
   if (output["RoleId"] !== undefined) {
-    contents.RoleId = output["RoleId"];
+    contents.RoleId = __expectString(output["RoleId"]);
   }
   if (output["Arn"] !== undefined) {
-    contents.Arn = output["Arn"];
+    contents.Arn = __expectString(output["Arn"]);
   }
   if (output["CreateDate"] !== undefined) {
     contents.CreateDate = new Date(output["CreateDate"]);
   }
   if (output["AssumeRolePolicyDocument"] !== undefined) {
-    contents.AssumeRolePolicyDocument = output["AssumeRolePolicyDocument"];
+    contents.AssumeRolePolicyDocument = __expectString(output["AssumeRolePolicyDocument"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output["MaxSessionDuration"] !== undefined) {
     contents.MaxSessionDuration = parseInt(output["MaxSessionDuration"]);
@@ -20470,22 +20471,22 @@ const deserializeAws_queryRoleDetail = (output: any, context: __SerdeContext): R
     RoleLastUsed: undefined,
   };
   if (output["Path"] !== undefined) {
-    contents.Path = output["Path"];
+    contents.Path = __expectString(output["Path"]);
   }
   if (output["RoleName"] !== undefined) {
-    contents.RoleName = output["RoleName"];
+    contents.RoleName = __expectString(output["RoleName"]);
   }
   if (output["RoleId"] !== undefined) {
-    contents.RoleId = output["RoleId"];
+    contents.RoleId = __expectString(output["RoleId"]);
   }
   if (output["Arn"] !== undefined) {
-    contents.Arn = output["Arn"];
+    contents.Arn = __expectString(output["Arn"]);
   }
   if (output["CreateDate"] !== undefined) {
     contents.CreateDate = new Date(output["CreateDate"]);
   }
   if (output["AssumeRolePolicyDocument"] !== undefined) {
-    contents.AssumeRolePolicyDocument = output["AssumeRolePolicyDocument"];
+    contents.AssumeRolePolicyDocument = __expectString(output["AssumeRolePolicyDocument"]);
   }
   if (output.InstanceProfileList === "") {
     contents.InstanceProfileList = [];
@@ -20552,7 +20553,7 @@ const deserializeAws_queryRoleLastUsed = (output: any, context: __SerdeContext):
     contents.LastUsedDate = new Date(output["LastUsedDate"]);
   }
   if (output["Region"] !== undefined) {
-    contents.Region = output["Region"];
+    contents.Region = __expectString(output["Region"]);
   }
   return contents;
 };
@@ -20585,7 +20586,7 @@ const deserializeAws_queryRoleUsageType = (output: any, context: __SerdeContext)
     Resources: undefined,
   };
   if (output["Region"] !== undefined) {
-    contents.Region = output["Region"];
+    contents.Region = __expectString(output["Region"]);
   }
   if (output.Resources === "") {
     contents.Resources = [];
@@ -20606,7 +20607,7 @@ const deserializeAws_querySAMLProviderListEntry = (output: any, context: __Serde
     CreateDate: undefined,
   };
   if (output["Arn"] !== undefined) {
-    contents.Arn = output["Arn"];
+    contents.Arn = __expectString(output["Arn"]);
   }
   if (output["ValidUntil"] !== undefined) {
     contents.ValidUntil = new Date(output["ValidUntil"]);
@@ -20642,10 +20643,10 @@ const deserializeAws_queryServerCertificate = (output: any, context: __SerdeCont
     );
   }
   if (output["CertificateBody"] !== undefined) {
-    contents.CertificateBody = output["CertificateBody"];
+    contents.CertificateBody = __expectString(output["CertificateBody"]);
   }
   if (output["CertificateChain"] !== undefined) {
-    contents.CertificateChain = output["CertificateChain"];
+    contents.CertificateChain = __expectString(output["CertificateChain"]);
   }
   if (output.Tags === "") {
     contents.Tags = [];
@@ -20669,16 +20670,16 @@ const deserializeAws_queryServerCertificateMetadata = (
     Expiration: undefined,
   };
   if (output["Path"] !== undefined) {
-    contents.Path = output["Path"];
+    contents.Path = __expectString(output["Path"]);
   }
   if (output["ServerCertificateName"] !== undefined) {
-    contents.ServerCertificateName = output["ServerCertificateName"];
+    contents.ServerCertificateName = __expectString(output["ServerCertificateName"]);
   }
   if (output["ServerCertificateId"] !== undefined) {
-    contents.ServerCertificateId = output["ServerCertificateId"];
+    contents.ServerCertificateId = __expectString(output["ServerCertificateId"]);
   }
   if (output["Arn"] !== undefined) {
-    contents.Arn = output["Arn"];
+    contents.Arn = __expectString(output["Arn"]);
   }
   if (output["UploadDate"] !== undefined) {
     contents.UploadDate = new Date(output["UploadDate"]);
@@ -20708,7 +20709,7 @@ const deserializeAws_queryServiceFailureException = (output: any, context: __Ser
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -20724,19 +20725,19 @@ const deserializeAws_queryServiceLastAccessed = (output: any, context: __SerdeCo
     TrackedActionsLastAccessed: undefined,
   };
   if (output["ServiceName"] !== undefined) {
-    contents.ServiceName = output["ServiceName"];
+    contents.ServiceName = __expectString(output["ServiceName"]);
   }
   if (output["LastAuthenticated"] !== undefined) {
     contents.LastAuthenticated = new Date(output["LastAuthenticated"]);
   }
   if (output["ServiceNamespace"] !== undefined) {
-    contents.ServiceNamespace = output["ServiceNamespace"];
+    contents.ServiceNamespace = __expectString(output["ServiceNamespace"]);
   }
   if (output["LastAuthenticatedEntity"] !== undefined) {
-    contents.LastAuthenticatedEntity = output["LastAuthenticatedEntity"];
+    contents.LastAuthenticatedEntity = __expectString(output["LastAuthenticatedEntity"]);
   }
   if (output["LastAuthenticatedRegion"] !== undefined) {
-    contents.LastAuthenticatedRegion = output["LastAuthenticatedRegion"];
+    contents.LastAuthenticatedRegion = __expectString(output["LastAuthenticatedRegion"]);
   }
   if (output["TotalAuthenticatedEntities"] !== undefined) {
     contents.TotalAuthenticatedEntities = parseInt(output["TotalAuthenticatedEntities"]);
@@ -20764,7 +20765,7 @@ const deserializeAws_queryServiceNotSupportedException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -20797,22 +20798,22 @@ const deserializeAws_queryServiceSpecificCredential = (
     contents.CreateDate = new Date(output["CreateDate"]);
   }
   if (output["ServiceName"] !== undefined) {
-    contents.ServiceName = output["ServiceName"];
+    contents.ServiceName = __expectString(output["ServiceName"]);
   }
   if (output["ServiceUserName"] !== undefined) {
-    contents.ServiceUserName = output["ServiceUserName"];
+    contents.ServiceUserName = __expectString(output["ServiceUserName"]);
   }
   if (output["ServicePassword"] !== undefined) {
-    contents.ServicePassword = output["ServicePassword"];
+    contents.ServicePassword = __expectString(output["ServicePassword"]);
   }
   if (output["ServiceSpecificCredentialId"] !== undefined) {
-    contents.ServiceSpecificCredentialId = output["ServiceSpecificCredentialId"];
+    contents.ServiceSpecificCredentialId = __expectString(output["ServiceSpecificCredentialId"]);
   }
   if (output["UserName"] !== undefined) {
-    contents.UserName = output["UserName"];
+    contents.UserName = __expectString(output["UserName"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   return contents;
 };
@@ -20830,22 +20831,22 @@ const deserializeAws_queryServiceSpecificCredentialMetadata = (
     ServiceName: undefined,
   };
   if (output["UserName"] !== undefined) {
-    contents.UserName = output["UserName"];
+    contents.UserName = __expectString(output["UserName"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["ServiceUserName"] !== undefined) {
-    contents.ServiceUserName = output["ServiceUserName"];
+    contents.ServiceUserName = __expectString(output["ServiceUserName"]);
   }
   if (output["CreateDate"] !== undefined) {
     contents.CreateDate = new Date(output["CreateDate"]);
   }
   if (output["ServiceSpecificCredentialId"] !== undefined) {
-    contents.ServiceSpecificCredentialId = output["ServiceSpecificCredentialId"];
+    contents.ServiceSpecificCredentialId = __expectString(output["ServiceSpecificCredentialId"]);
   }
   if (output["ServiceName"] !== undefined) {
-    contents.ServiceName = output["ServiceName"];
+    contents.ServiceName = __expectString(output["ServiceName"]);
   }
   return contents;
 };
@@ -20873,16 +20874,16 @@ const deserializeAws_querySigningCertificate = (output: any, context: __SerdeCon
     UploadDate: undefined,
   };
   if (output["UserName"] !== undefined) {
-    contents.UserName = output["UserName"];
+    contents.UserName = __expectString(output["UserName"]);
   }
   if (output["CertificateId"] !== undefined) {
-    contents.CertificateId = output["CertificateId"];
+    contents.CertificateId = __expectString(output["CertificateId"]);
   }
   if (output["CertificateBody"] !== undefined) {
-    contents.CertificateBody = output["CertificateBody"];
+    contents.CertificateBody = __expectString(output["CertificateBody"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["UploadDate"] !== undefined) {
     contents.UploadDate = new Date(output["UploadDate"]);
@@ -20909,7 +20910,7 @@ const deserializeAws_querySimulatePolicyResponse = (output: any, context: __Serd
     contents.IsTruncated = __parseBoolean(output["IsTruncated"]);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -20924,19 +20925,19 @@ const deserializeAws_querySSHPublicKey = (output: any, context: __SerdeContext):
     UploadDate: undefined,
   };
   if (output["UserName"] !== undefined) {
-    contents.UserName = output["UserName"];
+    contents.UserName = __expectString(output["UserName"]);
   }
   if (output["SSHPublicKeyId"] !== undefined) {
-    contents.SSHPublicKeyId = output["SSHPublicKeyId"];
+    contents.SSHPublicKeyId = __expectString(output["SSHPublicKeyId"]);
   }
   if (output["Fingerprint"] !== undefined) {
-    contents.Fingerprint = output["Fingerprint"];
+    contents.Fingerprint = __expectString(output["Fingerprint"]);
   }
   if (output["SSHPublicKeyBody"] !== undefined) {
-    contents.SSHPublicKeyBody = output["SSHPublicKeyBody"];
+    contents.SSHPublicKeyBody = __expectString(output["SSHPublicKeyBody"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["UploadDate"] !== undefined) {
     contents.UploadDate = new Date(output["UploadDate"]);
@@ -20963,13 +20964,13 @@ const deserializeAws_querySSHPublicKeyMetadata = (output: any, context: __SerdeC
     UploadDate: undefined,
   };
   if (output["UserName"] !== undefined) {
-    contents.UserName = output["UserName"];
+    contents.UserName = __expectString(output["UserName"]);
   }
   if (output["SSHPublicKeyId"] !== undefined) {
-    contents.SSHPublicKeyId = output["SSHPublicKeyId"];
+    contents.SSHPublicKeyId = __expectString(output["SSHPublicKeyId"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["UploadDate"] !== undefined) {
     contents.UploadDate = new Date(output["UploadDate"]);
@@ -20985,10 +20986,10 @@ const deserializeAws_queryStatement = (output: any, context: __SerdeContext): St
     EndPosition: undefined,
   };
   if (output["SourcePolicyId"] !== undefined) {
-    contents.SourcePolicyId = output["SourcePolicyId"];
+    contents.SourcePolicyId = __expectString(output["SourcePolicyId"]);
   }
   if (output["SourcePolicyType"] !== undefined) {
-    contents.SourcePolicyType = output["SourcePolicyType"];
+    contents.SourcePolicyType = __expectString(output["SourcePolicyType"]);
   }
   if (output["StartPosition"] !== undefined) {
     contents.StartPosition = deserializeAws_queryPosition(output["StartPosition"], context);
@@ -21028,10 +21029,10 @@ const deserializeAws_queryTag = (output: any, context: __SerdeContext): Tag => {
     Value: undefined,
   };
   if (output["Key"] !== undefined) {
-    contents.Key = output["Key"];
+    contents.Key = __expectString(output["Key"]);
   }
   if (output["Value"] !== undefined) {
-    contents.Value = output["Value"];
+    contents.Value = __expectString(output["Value"]);
   }
   return contents;
 };
@@ -21054,7 +21055,7 @@ const deserializeAws_querythumbprintListType = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -21069,16 +21070,16 @@ const deserializeAws_queryTrackedActionLastAccessed = (
     LastAccessedRegion: undefined,
   };
   if (output["ActionName"] !== undefined) {
-    contents.ActionName = output["ActionName"];
+    contents.ActionName = __expectString(output["ActionName"]);
   }
   if (output["LastAccessedEntity"] !== undefined) {
-    contents.LastAccessedEntity = output["LastAccessedEntity"];
+    contents.LastAccessedEntity = __expectString(output["LastAccessedEntity"]);
   }
   if (output["LastAccessedTime"] !== undefined) {
     contents.LastAccessedTime = new Date(output["LastAccessedTime"]);
   }
   if (output["LastAccessedRegion"] !== undefined) {
-    contents.LastAccessedRegion = output["LastAccessedRegion"];
+    contents.LastAccessedRegion = __expectString(output["LastAccessedRegion"]);
   }
   return contents;
 };
@@ -21105,7 +21106,7 @@ const deserializeAws_queryUnmodifiableEntityException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -21118,7 +21119,7 @@ const deserializeAws_queryUnrecognizedPublicKeyEncodingException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -21149,7 +21150,7 @@ const deserializeAws_queryUpdateSAMLProviderResponse = (
     SAMLProviderArn: undefined,
   };
   if (output["SAMLProviderArn"] !== undefined) {
-    contents.SAMLProviderArn = output["SAMLProviderArn"];
+    contents.SAMLProviderArn = __expectString(output["SAMLProviderArn"]);
   }
   return contents;
 };
@@ -21215,16 +21216,16 @@ const deserializeAws_queryUser = (output: any, context: __SerdeContext): User =>
     Tags: undefined,
   };
   if (output["Path"] !== undefined) {
-    contents.Path = output["Path"];
+    contents.Path = __expectString(output["Path"]);
   }
   if (output["UserName"] !== undefined) {
-    contents.UserName = output["UserName"];
+    contents.UserName = __expectString(output["UserName"]);
   }
   if (output["UserId"] !== undefined) {
-    contents.UserId = output["UserId"];
+    contents.UserId = __expectString(output["UserId"]);
   }
   if (output["Arn"] !== undefined) {
-    contents.Arn = output["Arn"];
+    contents.Arn = __expectString(output["Arn"]);
   }
   if (output["CreateDate"] !== undefined) {
     contents.CreateDate = new Date(output["CreateDate"]);
@@ -21261,16 +21262,16 @@ const deserializeAws_queryUserDetail = (output: any, context: __SerdeContext): U
     Tags: undefined,
   };
   if (output["Path"] !== undefined) {
-    contents.Path = output["Path"];
+    contents.Path = __expectString(output["Path"]);
   }
   if (output["UserName"] !== undefined) {
-    contents.UserName = output["UserName"];
+    contents.UserName = __expectString(output["UserName"]);
   }
   if (output["UserId"] !== undefined) {
-    contents.UserId = output["UserId"];
+    contents.UserId = __expectString(output["UserId"]);
   }
   if (output["Arn"] !== undefined) {
-    contents.Arn = output["Arn"];
+    contents.Arn = __expectString(output["Arn"]);
   }
   if (output["CreateDate"] !== undefined) {
     contents.CreateDate = new Date(output["CreateDate"]);
@@ -21349,7 +21350,7 @@ const deserializeAws_queryVirtualMFADevice = (output: any, context: __SerdeConte
     Tags: undefined,
   };
   if (output["SerialNumber"] !== undefined) {
-    contents.SerialNumber = output["SerialNumber"];
+    contents.SerialNumber = __expectString(output["SerialNumber"]);
   }
   if (output["Base32StringSeed"] !== undefined) {
     contents.Base32StringSeed = context.base64Decoder(output["Base32StringSeed"]);

--- a/clients/client-identitystore/protocols/Aws_json1_1.ts
+++ b/clients/client-identitystore/protocols/Aws_json1_1.ts
@@ -21,7 +21,7 @@ import {
   ValidationException,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException, expectString as __expectString } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -560,29 +560,29 @@ const serializeAws_json1_1ListUsersRequest = (input: ListUsersRequest, context: 
 
 const deserializeAws_json1_1AccessDeniedException = (output: any, context: __SerdeContext): AccessDeniedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
+    Message: __expectString(output.Message),
+    RequestId: __expectString(output.RequestId),
   } as any;
 };
 
 const deserializeAws_json1_1DescribeGroupResponse = (output: any, context: __SerdeContext): DescribeGroupResponse => {
   return {
-    DisplayName: output.DisplayName !== undefined && output.DisplayName !== null ? output.DisplayName : undefined,
-    GroupId: output.GroupId !== undefined && output.GroupId !== null ? output.GroupId : undefined,
+    DisplayName: __expectString(output.DisplayName),
+    GroupId: __expectString(output.GroupId),
   } as any;
 };
 
 const deserializeAws_json1_1DescribeUserResponse = (output: any, context: __SerdeContext): DescribeUserResponse => {
   return {
-    UserId: output.UserId !== undefined && output.UserId !== null ? output.UserId : undefined,
-    UserName: output.UserName !== undefined && output.UserName !== null ? output.UserName : undefined,
+    UserId: __expectString(output.UserId),
+    UserName: __expectString(output.UserName),
   } as any;
 };
 
 const deserializeAws_json1_1Group = (output: any, context: __SerdeContext): Group => {
   return {
-    DisplayName: output.DisplayName !== undefined && output.DisplayName !== null ? output.DisplayName : undefined,
-    GroupId: output.GroupId !== undefined && output.GroupId !== null ? output.GroupId : undefined,
+    DisplayName: __expectString(output.DisplayName),
+    GroupId: __expectString(output.GroupId),
   } as any;
 };
 
@@ -602,8 +602,8 @@ const deserializeAws_json1_1InternalServerException = (
   context: __SerdeContext
 ): InternalServerException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
+    Message: __expectString(output.Message),
+    RequestId: __expectString(output.RequestId),
   } as any;
 };
 
@@ -613,13 +613,13 @@ const deserializeAws_json1_1ListGroupsResponse = (output: any, context: __SerdeC
       output.Groups !== undefined && output.Groups !== null
         ? deserializeAws_json1_1Groups(output.Groups, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
 const deserializeAws_json1_1ListUsersResponse = (output: any, context: __SerdeContext): ListUsersResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Users:
       output.Users !== undefined && output.Users !== null
         ? deserializeAws_json1_1Users(output.Users, context)
@@ -632,24 +632,24 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
-    ResourceId: output.ResourceId !== undefined && output.ResourceId !== null ? output.ResourceId : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
+    Message: __expectString(output.Message),
+    RequestId: __expectString(output.RequestId),
+    ResourceId: __expectString(output.ResourceId),
+    ResourceType: __expectString(output.ResourceType),
   } as any;
 };
 
 const deserializeAws_json1_1ThrottlingException = (output: any, context: __SerdeContext): ThrottlingException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
+    Message: __expectString(output.Message),
+    RequestId: __expectString(output.RequestId),
   } as any;
 };
 
 const deserializeAws_json1_1User = (output: any, context: __SerdeContext): User => {
   return {
-    UserId: output.UserId !== undefined && output.UserId !== null ? output.UserId : undefined,
-    UserName: output.UserName !== undefined && output.UserName !== null ? output.UserName : undefined,
+    UserId: __expectString(output.UserId),
+    UserName: __expectString(output.UserName),
   } as any;
 };
 
@@ -666,8 +666,8 @@ const deserializeAws_json1_1Users = (output: any, context: __SerdeContext): User
 
 const deserializeAws_json1_1ValidationException = (output: any, context: __SerdeContext): ValidationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
+    Message: __expectString(output.Message),
+    RequestId: __expectString(output.RequestId),
   } as any;
 };
 

--- a/clients/client-imagebuilder/protocols/Aws_restJson1.ts
+++ b/clients/client-imagebuilder/protocols/Aws_restJson1.ts
@@ -182,6 +182,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -1662,13 +1665,13 @@ export const deserializeAws_restJson1CancelImageCreationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.clientToken !== undefined && data.clientToken !== null) {
-    contents.clientToken = data.clientToken;
+    contents.clientToken = __expectString(data.clientToken);
   }
   if (data.imageBuildVersionArn !== undefined && data.imageBuildVersionArn !== null) {
-    contents.imageBuildVersionArn = data.imageBuildVersionArn;
+    contents.imageBuildVersionArn = __expectString(data.imageBuildVersionArn);
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -1781,13 +1784,13 @@ export const deserializeAws_restJson1CreateComponentCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.clientToken !== undefined && data.clientToken !== null) {
-    contents.clientToken = data.clientToken;
+    contents.clientToken = __expectString(data.clientToken);
   }
   if (data.componentBuildVersionArn !== undefined && data.componentBuildVersionArn !== null) {
-    contents.componentBuildVersionArn = data.componentBuildVersionArn;
+    contents.componentBuildVersionArn = __expectString(data.componentBuildVersionArn);
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -1924,13 +1927,13 @@ export const deserializeAws_restJson1CreateContainerRecipeCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.clientToken !== undefined && data.clientToken !== null) {
-    contents.clientToken = data.clientToken;
+    contents.clientToken = __expectString(data.clientToken);
   }
   if (data.containerRecipeArn !== undefined && data.containerRecipeArn !== null) {
-    contents.containerRecipeArn = data.containerRecipeArn;
+    contents.containerRecipeArn = __expectString(data.containerRecipeArn);
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -2067,13 +2070,13 @@ export const deserializeAws_restJson1CreateDistributionConfigurationCommand = as
   };
   const data: any = await parseBody(output.body, context);
   if (data.clientToken !== undefined && data.clientToken !== null) {
-    contents.clientToken = data.clientToken;
+    contents.clientToken = __expectString(data.clientToken);
   }
   if (data.distributionConfigurationArn !== undefined && data.distributionConfigurationArn !== null) {
-    contents.distributionConfigurationArn = data.distributionConfigurationArn;
+    contents.distributionConfigurationArn = __expectString(data.distributionConfigurationArn);
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -2210,13 +2213,13 @@ export const deserializeAws_restJson1CreateImageCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.clientToken !== undefined && data.clientToken !== null) {
-    contents.clientToken = data.clientToken;
+    contents.clientToken = __expectString(data.clientToken);
   }
   if (data.imageBuildVersionArn !== undefined && data.imageBuildVersionArn !== null) {
-    contents.imageBuildVersionArn = data.imageBuildVersionArn;
+    contents.imageBuildVersionArn = __expectString(data.imageBuildVersionArn);
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -2337,13 +2340,13 @@ export const deserializeAws_restJson1CreateImagePipelineCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.clientToken !== undefined && data.clientToken !== null) {
-    contents.clientToken = data.clientToken;
+    contents.clientToken = __expectString(data.clientToken);
   }
   if (data.imagePipelineArn !== undefined && data.imagePipelineArn !== null) {
-    contents.imagePipelineArn = data.imagePipelineArn;
+    contents.imagePipelineArn = __expectString(data.imagePipelineArn);
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -2472,13 +2475,13 @@ export const deserializeAws_restJson1CreateImageRecipeCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.clientToken !== undefined && data.clientToken !== null) {
-    contents.clientToken = data.clientToken;
+    contents.clientToken = __expectString(data.clientToken);
   }
   if (data.imageRecipeArn !== undefined && data.imageRecipeArn !== null) {
-    contents.imageRecipeArn = data.imageRecipeArn;
+    contents.imageRecipeArn = __expectString(data.imageRecipeArn);
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -2615,13 +2618,13 @@ export const deserializeAws_restJson1CreateInfrastructureConfigurationCommand = 
   };
   const data: any = await parseBody(output.body, context);
   if (data.clientToken !== undefined && data.clientToken !== null) {
-    contents.clientToken = data.clientToken;
+    contents.clientToken = __expectString(data.clientToken);
   }
   if (data.infrastructureConfigurationArn !== undefined && data.infrastructureConfigurationArn !== null) {
-    contents.infrastructureConfigurationArn = data.infrastructureConfigurationArn;
+    contents.infrastructureConfigurationArn = __expectString(data.infrastructureConfigurationArn);
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -2749,10 +2752,10 @@ export const deserializeAws_restJson1DeleteComponentCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.componentBuildVersionArn !== undefined && data.componentBuildVersionArn !== null) {
-    contents.componentBuildVersionArn = data.componentBuildVersionArn;
+    contents.componentBuildVersionArn = __expectString(data.componentBuildVersionArn);
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -2856,10 +2859,10 @@ export const deserializeAws_restJson1DeleteContainerRecipeCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.containerRecipeArn !== undefined && data.containerRecipeArn !== null) {
-    contents.containerRecipeArn = data.containerRecipeArn;
+    contents.containerRecipeArn = __expectString(data.containerRecipeArn);
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -2963,10 +2966,10 @@ export const deserializeAws_restJson1DeleteDistributionConfigurationCommand = as
   };
   const data: any = await parseBody(output.body, context);
   if (data.distributionConfigurationArn !== undefined && data.distributionConfigurationArn !== null) {
-    contents.distributionConfigurationArn = data.distributionConfigurationArn;
+    contents.distributionConfigurationArn = __expectString(data.distributionConfigurationArn);
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -3070,10 +3073,10 @@ export const deserializeAws_restJson1DeleteImageCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.imageBuildVersionArn !== undefined && data.imageBuildVersionArn !== null) {
-    contents.imageBuildVersionArn = data.imageBuildVersionArn;
+    contents.imageBuildVersionArn = __expectString(data.imageBuildVersionArn);
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -3177,10 +3180,10 @@ export const deserializeAws_restJson1DeleteImagePipelineCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.imagePipelineArn !== undefined && data.imagePipelineArn !== null) {
-    contents.imagePipelineArn = data.imagePipelineArn;
+    contents.imagePipelineArn = __expectString(data.imagePipelineArn);
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -3284,10 +3287,10 @@ export const deserializeAws_restJson1DeleteImageRecipeCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.imageRecipeArn !== undefined && data.imageRecipeArn !== null) {
-    contents.imageRecipeArn = data.imageRecipeArn;
+    contents.imageRecipeArn = __expectString(data.imageRecipeArn);
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -3391,10 +3394,10 @@ export const deserializeAws_restJson1DeleteInfrastructureConfigurationCommand = 
   };
   const data: any = await parseBody(output.body, context);
   if (data.infrastructureConfigurationArn !== undefined && data.infrastructureConfigurationArn !== null) {
-    contents.infrastructureConfigurationArn = data.infrastructureConfigurationArn;
+    contents.infrastructureConfigurationArn = __expectString(data.infrastructureConfigurationArn);
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -3501,7 +3504,7 @@ export const deserializeAws_restJson1GetComponentCommand = async (
     contents.component = deserializeAws_restJson1Component(data.component, context);
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -3597,10 +3600,10 @@ export const deserializeAws_restJson1GetComponentPolicyCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.policy !== undefined && data.policy !== null) {
-    contents.policy = data.policy;
+    contents.policy = __expectString(data.policy);
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -3699,7 +3702,7 @@ export const deserializeAws_restJson1GetContainerRecipeCommand = async (
     contents.containerRecipe = deserializeAws_restJson1ContainerRecipe(data.containerRecipe, context);
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -3795,10 +3798,10 @@ export const deserializeAws_restJson1GetContainerRecipePolicyCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.policy !== undefined && data.policy !== null) {
-    contents.policy = data.policy;
+    contents.policy = __expectString(data.policy);
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -3900,7 +3903,7 @@ export const deserializeAws_restJson1GetDistributionConfigurationCommand = async
     );
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -3999,7 +4002,7 @@ export const deserializeAws_restJson1GetImageCommand = async (
     contents.image = deserializeAws_restJson1Image(data.image, context);
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -4098,7 +4101,7 @@ export const deserializeAws_restJson1GetImagePipelineCommand = async (
     contents.imagePipeline = deserializeAws_restJson1ImagePipeline(data.imagePipeline, context);
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -4194,10 +4197,10 @@ export const deserializeAws_restJson1GetImagePolicyCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.policy !== undefined && data.policy !== null) {
-    contents.policy = data.policy;
+    contents.policy = __expectString(data.policy);
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -4296,7 +4299,7 @@ export const deserializeAws_restJson1GetImageRecipeCommand = async (
     contents.imageRecipe = deserializeAws_restJson1ImageRecipe(data.imageRecipe, context);
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -4392,10 +4395,10 @@ export const deserializeAws_restJson1GetImageRecipePolicyCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.policy !== undefined && data.policy !== null) {
-    contents.policy = data.policy;
+    contents.policy = __expectString(data.policy);
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -4497,7 +4500,7 @@ export const deserializeAws_restJson1GetInfrastructureConfigurationCommand = asy
     );
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -4594,13 +4597,13 @@ export const deserializeAws_restJson1ImportComponentCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.clientToken !== undefined && data.clientToken !== null) {
-    contents.clientToken = data.clientToken;
+    contents.clientToken = __expectString(data.clientToken);
   }
   if (data.componentBuildVersionArn !== undefined && data.componentBuildVersionArn !== null) {
-    contents.componentBuildVersionArn = data.componentBuildVersionArn;
+    contents.componentBuildVersionArn = __expectString(data.componentBuildVersionArn);
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -4732,10 +4735,10 @@ export const deserializeAws_restJson1ListComponentBuildVersionsCommand = async (
     contents.componentSummaryList = deserializeAws_restJson1ComponentSummaryList(data.componentSummaryList, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -4843,10 +4846,10 @@ export const deserializeAws_restJson1ListComponentsCommand = async (
     contents.componentVersionList = deserializeAws_restJson1ComponentVersionList(data.componentVersionList, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -4957,10 +4960,10 @@ export const deserializeAws_restJson1ListContainerRecipesCommand = async (
     );
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -5071,10 +5074,10 @@ export const deserializeAws_restJson1ListDistributionConfigurationsCommand = asy
     );
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -5182,10 +5185,10 @@ export const deserializeAws_restJson1ListImageBuildVersionsCommand = async (
     contents.imageSummaryList = deserializeAws_restJson1ImageSummaryList(data.imageSummaryList, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -5293,10 +5296,10 @@ export const deserializeAws_restJson1ListImagePackagesCommand = async (
     contents.imagePackageList = deserializeAws_restJson1ImagePackageList(data.imagePackageList, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -5412,10 +5415,10 @@ export const deserializeAws_restJson1ListImagePipelineImagesCommand = async (
     contents.imageSummaryList = deserializeAws_restJson1ImageSummaryList(data.imageSummaryList, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -5531,10 +5534,10 @@ export const deserializeAws_restJson1ListImagePipelinesCommand = async (
     contents.imagePipelineList = deserializeAws_restJson1ImagePipelineList(data.imagePipelineList, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -5645,10 +5648,10 @@ export const deserializeAws_restJson1ListImageRecipesCommand = async (
     );
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -5756,10 +5759,10 @@ export const deserializeAws_restJson1ListImagesCommand = async (
     contents.imageVersionList = deserializeAws_restJson1ImageVersionList(data.imageVersionList, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -5873,10 +5876,10 @@ export const deserializeAws_restJson1ListInfrastructureConfigurationsCommand = a
     );
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -6051,10 +6054,10 @@ export const deserializeAws_restJson1PutComponentPolicyCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.componentArn !== undefined && data.componentArn !== null) {
-    contents.componentArn = data.componentArn;
+    contents.componentArn = __expectString(data.componentArn);
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -6166,10 +6169,10 @@ export const deserializeAws_restJson1PutContainerRecipePolicyCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.containerRecipeArn !== undefined && data.containerRecipeArn !== null) {
-    contents.containerRecipeArn = data.containerRecipeArn;
+    contents.containerRecipeArn = __expectString(data.containerRecipeArn);
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -6281,10 +6284,10 @@ export const deserializeAws_restJson1PutImagePolicyCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.imageArn !== undefined && data.imageArn !== null) {
-    contents.imageArn = data.imageArn;
+    contents.imageArn = __expectString(data.imageArn);
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -6396,10 +6399,10 @@ export const deserializeAws_restJson1PutImageRecipePolicyCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.imageRecipeArn !== undefined && data.imageRecipeArn !== null) {
-    contents.imageRecipeArn = data.imageRecipeArn;
+    contents.imageRecipeArn = __expectString(data.imageRecipeArn);
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -6512,13 +6515,13 @@ export const deserializeAws_restJson1StartImagePipelineExecutionCommand = async 
   };
   const data: any = await parseBody(output.body, context);
   if (data.clientToken !== undefined && data.clientToken !== null) {
-    contents.clientToken = data.clientToken;
+    contents.clientToken = __expectString(data.clientToken);
   }
   if (data.imageBuildVersionArn !== undefined && data.imageBuildVersionArn !== null) {
-    contents.imageBuildVersionArn = data.imageBuildVersionArn;
+    contents.imageBuildVersionArn = __expectString(data.imageBuildVersionArn);
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -6773,13 +6776,13 @@ export const deserializeAws_restJson1UpdateDistributionConfigurationCommand = as
   };
   const data: any = await parseBody(output.body, context);
   if (data.clientToken !== undefined && data.clientToken !== null) {
-    contents.clientToken = data.clientToken;
+    contents.clientToken = __expectString(data.clientToken);
   }
   if (data.distributionConfigurationArn !== undefined && data.distributionConfigurationArn !== null) {
-    contents.distributionConfigurationArn = data.distributionConfigurationArn;
+    contents.distributionConfigurationArn = __expectString(data.distributionConfigurationArn);
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -6900,13 +6903,13 @@ export const deserializeAws_restJson1UpdateImagePipelineCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.clientToken !== undefined && data.clientToken !== null) {
-    contents.clientToken = data.clientToken;
+    contents.clientToken = __expectString(data.clientToken);
   }
   if (data.imagePipelineArn !== undefined && data.imagePipelineArn !== null) {
-    contents.imagePipelineArn = data.imagePipelineArn;
+    contents.imagePipelineArn = __expectString(data.imagePipelineArn);
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -7019,13 +7022,13 @@ export const deserializeAws_restJson1UpdateInfrastructureConfigurationCommand = 
   };
   const data: any = await parseBody(output.body, context);
   if (data.clientToken !== undefined && data.clientToken !== null) {
-    contents.clientToken = data.clientToken;
+    contents.clientToken = __expectString(data.clientToken);
   }
   if (data.infrastructureConfigurationArn !== undefined && data.infrastructureConfigurationArn !== null) {
-    contents.infrastructureConfigurationArn = data.infrastructureConfigurationArn;
+    contents.infrastructureConfigurationArn = __expectString(data.infrastructureConfigurationArn);
   }
   if (data.requestId !== undefined && data.requestId !== null) {
-    contents.requestId = data.requestId;
+    contents.requestId = __expectString(data.requestId);
   }
   return Promise.resolve(contents);
 };
@@ -7135,7 +7138,7 @@ const deserializeAws_restJson1CallRateLimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -7152,7 +7155,7 @@ const deserializeAws_restJson1ClientExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -7169,7 +7172,7 @@ const deserializeAws_restJson1ForbiddenExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -7186,7 +7189,7 @@ const deserializeAws_restJson1IdempotentParameterMismatchExceptionResponse = asy
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -7203,7 +7206,7 @@ const deserializeAws_restJson1InvalidPaginationTokenExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -7220,7 +7223,7 @@ const deserializeAws_restJson1InvalidParameterCombinationExceptionResponse = asy
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -7237,7 +7240,7 @@ const deserializeAws_restJson1InvalidParameterExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -7254,7 +7257,7 @@ const deserializeAws_restJson1InvalidParameterValueExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -7271,7 +7274,7 @@ const deserializeAws_restJson1InvalidRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -7288,7 +7291,7 @@ const deserializeAws_restJson1InvalidVersionNumberExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -7305,7 +7308,7 @@ const deserializeAws_restJson1ResourceAlreadyExistsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -7322,7 +7325,7 @@ const deserializeAws_restJson1ResourceDependencyExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -7339,7 +7342,7 @@ const deserializeAws_restJson1ResourceInUseExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -7356,7 +7359,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -7373,7 +7376,7 @@ const deserializeAws_restJson1ServiceExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -7390,7 +7393,7 @@ const deserializeAws_restJson1ServiceQuotaExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -7407,7 +7410,7 @@ const deserializeAws_restJson1ServiceUnavailableExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -7783,17 +7786,17 @@ const deserializeAws_restJson1AccountList = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1Ami = (output: any, context: __SerdeContext): Ami => {
   return {
-    accountId: output.accountId !== undefined && output.accountId !== null ? output.accountId : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    image: output.image !== undefined && output.image !== null ? output.image : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    region: output.region !== undefined && output.region !== null ? output.region : undefined,
+    accountId: __expectString(output.accountId),
+    description: __expectString(output.description),
+    image: __expectString(output.image),
+    name: __expectString(output.name),
+    region: __expectString(output.region),
     state:
       output.state !== undefined && output.state !== null
         ? deserializeAws_restJson1ImageState(output.state, context)
@@ -7810,13 +7813,13 @@ const deserializeAws_restJson1AmiDistributionConfiguration = (
       output.amiTags !== undefined && output.amiTags !== null
         ? deserializeAws_restJson1TagMap(output.amiTags, context)
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    kmsKeyId: output.kmsKeyId !== undefined && output.kmsKeyId !== null ? output.kmsKeyId : undefined,
+    description: __expectString(output.description),
+    kmsKeyId: __expectString(output.kmsKeyId),
     launchPermission:
       output.launchPermission !== undefined && output.launchPermission !== null
         ? deserializeAws_restJson1LaunchPermissionConfiguration(output.launchPermission, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
     targetAccountIds:
       output.targetAccountIds !== undefined && output.targetAccountIds !== null
         ? deserializeAws_restJson1AccountList(output.targetAccountIds, context)
@@ -7837,19 +7840,16 @@ const deserializeAws_restJson1AmiList = (output: any, context: __SerdeContext): 
 
 const deserializeAws_restJson1Component = (output: any, context: __SerdeContext): Component => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    changeDescription:
-      output.changeDescription !== undefined && output.changeDescription !== null
-        ? output.changeDescription
-        : undefined,
-    data: output.data !== undefined && output.data !== null ? output.data : undefined,
-    dateCreated: output.dateCreated !== undefined && output.dateCreated !== null ? output.dateCreated : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    encrypted: output.encrypted !== undefined && output.encrypted !== null ? output.encrypted : undefined,
-    kmsKeyId: output.kmsKeyId !== undefined && output.kmsKeyId !== null ? output.kmsKeyId : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    owner: output.owner !== undefined && output.owner !== null ? output.owner : undefined,
-    platform: output.platform !== undefined && output.platform !== null ? output.platform : undefined,
+    arn: __expectString(output.arn),
+    changeDescription: __expectString(output.changeDescription),
+    data: __expectString(output.data),
+    dateCreated: __expectString(output.dateCreated),
+    description: __expectString(output.description),
+    encrypted: __expectBoolean(output.encrypted),
+    kmsKeyId: __expectString(output.kmsKeyId),
+    name: __expectString(output.name),
+    owner: __expectString(output.owner),
+    platform: __expectString(output.platform),
     supportedOsVersions:
       output.supportedOsVersions !== undefined && output.supportedOsVersions !== null
         ? deserializeAws_restJson1OsVersionList(output.supportedOsVersions, context)
@@ -7858,8 +7858,8 @@ const deserializeAws_restJson1Component = (output: any, context: __SerdeContext)
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1TagMap(output.tags, context)
         : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    type: __expectString(output.type),
+    version: __expectString(output.version),
   } as any;
 };
 
@@ -7868,7 +7868,7 @@ const deserializeAws_restJson1ComponentConfiguration = (
   context: __SerdeContext
 ): ComponentConfiguration => {
   return {
-    componentArn: output.componentArn !== undefined && output.componentArn !== null ? output.componentArn : undefined,
+    componentArn: __expectString(output.componentArn),
   } as any;
 };
 
@@ -7888,16 +7888,13 @@ const deserializeAws_restJson1ComponentConfigurationList = (
 
 const deserializeAws_restJson1ComponentSummary = (output: any, context: __SerdeContext): ComponentSummary => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    changeDescription:
-      output.changeDescription !== undefined && output.changeDescription !== null
-        ? output.changeDescription
-        : undefined,
-    dateCreated: output.dateCreated !== undefined && output.dateCreated !== null ? output.dateCreated : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    owner: output.owner !== undefined && output.owner !== null ? output.owner : undefined,
-    platform: output.platform !== undefined && output.platform !== null ? output.platform : undefined,
+    arn: __expectString(output.arn),
+    changeDescription: __expectString(output.changeDescription),
+    dateCreated: __expectString(output.dateCreated),
+    description: __expectString(output.description),
+    name: __expectString(output.name),
+    owner: __expectString(output.owner),
+    platform: __expectString(output.platform),
     supportedOsVersions:
       output.supportedOsVersions !== undefined && output.supportedOsVersions !== null
         ? deserializeAws_restJson1OsVersionList(output.supportedOsVersions, context)
@@ -7906,8 +7903,8 @@ const deserializeAws_restJson1ComponentSummary = (output: any, context: __SerdeC
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1TagMap(output.tags, context)
         : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    type: __expectString(output.type),
+    version: __expectString(output.version),
   } as any;
 };
 
@@ -7924,18 +7921,18 @@ const deserializeAws_restJson1ComponentSummaryList = (output: any, context: __Se
 
 const deserializeAws_restJson1ComponentVersion = (output: any, context: __SerdeContext): ComponentVersion => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    dateCreated: output.dateCreated !== undefined && output.dateCreated !== null ? output.dateCreated : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    owner: output.owner !== undefined && output.owner !== null ? output.owner : undefined,
-    platform: output.platform !== undefined && output.platform !== null ? output.platform : undefined,
+    arn: __expectString(output.arn),
+    dateCreated: __expectString(output.dateCreated),
+    description: __expectString(output.description),
+    name: __expectString(output.name),
+    owner: __expectString(output.owner),
+    platform: __expectString(output.platform),
     supportedOsVersions:
       output.supportedOsVersions !== undefined && output.supportedOsVersions !== null
         ? deserializeAws_restJson1OsVersionList(output.supportedOsVersions, context)
         : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    type: __expectString(output.type),
+    version: __expectString(output.version),
   } as any;
 };
 
@@ -7956,7 +7953,7 @@ const deserializeAws_restJson1Container = (output: any, context: __SerdeContext)
       output.imageUris !== undefined && output.imageUris !== null
         ? deserializeAws_restJson1StringList(output.imageUris, context)
         : undefined,
-    region: output.region !== undefined && output.region !== null ? output.region : undefined,
+    region: __expectString(output.region),
   } as any;
 };
 
@@ -7969,7 +7966,7 @@ const deserializeAws_restJson1ContainerDistributionConfiguration = (
       output.containerTags !== undefined && output.containerTags !== null
         ? deserializeAws_restJson1StringList(output.containerTags, context)
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    description: __expectString(output.description),
     targetRepository:
       output.targetRepository !== undefined && output.targetRepository !== null
         ? deserializeAws_restJson1TargetContainerRepository(output.targetRepository, context)
@@ -7990,29 +7987,25 @@ const deserializeAws_restJson1ContainerList = (output: any, context: __SerdeCont
 
 const deserializeAws_restJson1ContainerRecipe = (output: any, context: __SerdeContext): ContainerRecipe => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     components:
       output.components !== undefined && output.components !== null
         ? deserializeAws_restJson1ComponentConfigurationList(output.components, context)
         : undefined,
-    containerType:
-      output.containerType !== undefined && output.containerType !== null ? output.containerType : undefined,
-    dateCreated: output.dateCreated !== undefined && output.dateCreated !== null ? output.dateCreated : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    dockerfileTemplateData:
-      output.dockerfileTemplateData !== undefined && output.dockerfileTemplateData !== null
-        ? output.dockerfileTemplateData
-        : undefined,
-    encrypted: output.encrypted !== undefined && output.encrypted !== null ? output.encrypted : undefined,
+    containerType: __expectString(output.containerType),
+    dateCreated: __expectString(output.dateCreated),
+    description: __expectString(output.description),
+    dockerfileTemplateData: __expectString(output.dockerfileTemplateData),
+    encrypted: __expectBoolean(output.encrypted),
     instanceConfiguration:
       output.instanceConfiguration !== undefined && output.instanceConfiguration !== null
         ? deserializeAws_restJson1InstanceConfiguration(output.instanceConfiguration, context)
         : undefined,
-    kmsKeyId: output.kmsKeyId !== undefined && output.kmsKeyId !== null ? output.kmsKeyId : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    owner: output.owner !== undefined && output.owner !== null ? output.owner : undefined,
-    parentImage: output.parentImage !== undefined && output.parentImage !== null ? output.parentImage : undefined,
-    platform: output.platform !== undefined && output.platform !== null ? output.platform : undefined,
+    kmsKeyId: __expectString(output.kmsKeyId),
+    name: __expectString(output.name),
+    owner: __expectString(output.owner),
+    parentImage: __expectString(output.parentImage),
+    platform: __expectString(output.platform),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1TagMap(output.tags, context)
@@ -8021,9 +8014,8 @@ const deserializeAws_restJson1ContainerRecipe = (output: any, context: __SerdeCo
       output.targetRepository !== undefined && output.targetRepository !== null
         ? deserializeAws_restJson1TargetContainerRepository(output.targetRepository, context)
         : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
-    workingDirectory:
-      output.workingDirectory !== undefined && output.workingDirectory !== null ? output.workingDirectory : undefined,
+    version: __expectString(output.version),
+    workingDirectory: __expectString(output.workingDirectory),
   } as any;
 };
 
@@ -8032,14 +8024,13 @@ const deserializeAws_restJson1ContainerRecipeSummary = (
   context: __SerdeContext
 ): ContainerRecipeSummary => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    containerType:
-      output.containerType !== undefined && output.containerType !== null ? output.containerType : undefined,
-    dateCreated: output.dateCreated !== undefined && output.dateCreated !== null ? output.dateCreated : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    owner: output.owner !== undefined && output.owner !== null ? output.owner : undefined,
-    parentImage: output.parentImage !== undefined && output.parentImage !== null ? output.parentImage : undefined,
-    platform: output.platform !== undefined && output.platform !== null ? output.platform : undefined,
+    arn: __expectString(output.arn),
+    containerType: __expectString(output.containerType),
+    dateCreated: __expectString(output.dateCreated),
+    name: __expectString(output.name),
+    owner: __expectString(output.owner),
+    parentImage: __expectString(output.parentImage),
+    platform: __expectString(output.platform),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1TagMap(output.tags, context)
@@ -8079,7 +8070,7 @@ const deserializeAws_restJson1Distribution = (output: any, context: __SerdeConte
       output.licenseConfigurationArns !== undefined && output.licenseConfigurationArns !== null
         ? deserializeAws_restJson1LicenseConfigurationArnList(output.licenseConfigurationArns, context)
         : undefined,
-    region: output.region !== undefined && output.region !== null ? output.region : undefined,
+    region: __expectString(output.region),
   } as any;
 };
 
@@ -8088,21 +8079,20 @@ const deserializeAws_restJson1DistributionConfiguration = (
   context: __SerdeContext
 ): DistributionConfiguration => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    dateCreated: output.dateCreated !== undefined && output.dateCreated !== null ? output.dateCreated : undefined,
-    dateUpdated: output.dateUpdated !== undefined && output.dateUpdated !== null ? output.dateUpdated : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    arn: __expectString(output.arn),
+    dateCreated: __expectString(output.dateCreated),
+    dateUpdated: __expectString(output.dateUpdated),
+    description: __expectString(output.description),
     distributions:
       output.distributions !== undefined && output.distributions !== null
         ? deserializeAws_restJson1DistributionList(output.distributions, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1TagMap(output.tags, context)
         : undefined,
-    timeoutMinutes:
-      output.timeoutMinutes !== undefined && output.timeoutMinutes !== null ? output.timeoutMinutes : undefined,
+    timeoutMinutes: __expectNumber(output.timeoutMinutes),
   } as any;
 };
 
@@ -8111,11 +8101,11 @@ const deserializeAws_restJson1DistributionConfigurationSummary = (
   context: __SerdeContext
 ): DistributionConfigurationSummary => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    dateCreated: output.dateCreated !== undefined && output.dateCreated !== null ? output.dateCreated : undefined,
-    dateUpdated: output.dateUpdated !== undefined && output.dateUpdated !== null ? output.dateUpdated : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    arn: __expectString(output.arn),
+    dateCreated: __expectString(output.dateCreated),
+    dateUpdated: __expectString(output.dateUpdated),
+    description: __expectString(output.description),
+    name: __expectString(output.name),
     regions:
       output.regions !== undefined && output.regions !== null
         ? deserializeAws_restJson1RegionList(output.regions, context)
@@ -8157,35 +8147,29 @@ const deserializeAws_restJson1EbsInstanceBlockDeviceSpecification = (
   context: __SerdeContext
 ): EbsInstanceBlockDeviceSpecification => {
   return {
-    deleteOnTermination:
-      output.deleteOnTermination !== undefined && output.deleteOnTermination !== null
-        ? output.deleteOnTermination
-        : undefined,
-    encrypted: output.encrypted !== undefined && output.encrypted !== null ? output.encrypted : undefined,
-    iops: output.iops !== undefined && output.iops !== null ? output.iops : undefined,
-    kmsKeyId: output.kmsKeyId !== undefined && output.kmsKeyId !== null ? output.kmsKeyId : undefined,
-    snapshotId: output.snapshotId !== undefined && output.snapshotId !== null ? output.snapshotId : undefined,
-    volumeSize: output.volumeSize !== undefined && output.volumeSize !== null ? output.volumeSize : undefined,
-    volumeType: output.volumeType !== undefined && output.volumeType !== null ? output.volumeType : undefined,
+    deleteOnTermination: __expectBoolean(output.deleteOnTermination),
+    encrypted: __expectBoolean(output.encrypted),
+    iops: __expectNumber(output.iops),
+    kmsKeyId: __expectString(output.kmsKeyId),
+    snapshotId: __expectString(output.snapshotId),
+    volumeSize: __expectNumber(output.volumeSize),
+    volumeType: __expectString(output.volumeType),
   } as any;
 };
 
 const deserializeAws_restJson1Image = (output: any, context: __SerdeContext): Image => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     containerRecipe:
       output.containerRecipe !== undefined && output.containerRecipe !== null
         ? deserializeAws_restJson1ContainerRecipe(output.containerRecipe, context)
         : undefined,
-    dateCreated: output.dateCreated !== undefined && output.dateCreated !== null ? output.dateCreated : undefined,
+    dateCreated: __expectString(output.dateCreated),
     distributionConfiguration:
       output.distributionConfiguration !== undefined && output.distributionConfiguration !== null
         ? deserializeAws_restJson1DistributionConfiguration(output.distributionConfiguration, context)
         : undefined,
-    enhancedImageMetadataEnabled:
-      output.enhancedImageMetadataEnabled !== undefined && output.enhancedImageMetadataEnabled !== null
-        ? output.enhancedImageMetadataEnabled
-        : undefined,
+    enhancedImageMetadataEnabled: __expectBoolean(output.enhancedImageMetadataEnabled),
     imageRecipe:
       output.imageRecipe !== undefined && output.imageRecipe !== null
         ? deserializeAws_restJson1ImageRecipe(output.imageRecipe, context)
@@ -8198,21 +8182,15 @@ const deserializeAws_restJson1Image = (output: any, context: __SerdeContext): Im
       output.infrastructureConfiguration !== undefined && output.infrastructureConfiguration !== null
         ? deserializeAws_restJson1InfrastructureConfiguration(output.infrastructureConfiguration, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    osVersion: output.osVersion !== undefined && output.osVersion !== null ? output.osVersion : undefined,
+    name: __expectString(output.name),
+    osVersion: __expectString(output.osVersion),
     outputResources:
       output.outputResources !== undefined && output.outputResources !== null
         ? deserializeAws_restJson1OutputResources(output.outputResources, context)
         : undefined,
-    platform: output.platform !== undefined && output.platform !== null ? output.platform : undefined,
-    sourcePipelineArn:
-      output.sourcePipelineArn !== undefined && output.sourcePipelineArn !== null
-        ? output.sourcePipelineArn
-        : undefined,
-    sourcePipelineName:
-      output.sourcePipelineName !== undefined && output.sourcePipelineName !== null
-        ? output.sourcePipelineName
-        : undefined,
+    platform: __expectString(output.platform),
+    sourcePipelineArn: __expectString(output.sourcePipelineArn),
+    sourcePipelineName: __expectString(output.sourcePipelineName),
     state:
       output.state !== undefined && output.state !== null
         ? deserializeAws_restJson1ImageState(output.state, context)
@@ -8221,16 +8199,15 @@ const deserializeAws_restJson1Image = (output: any, context: __SerdeContext): Im
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1TagMap(output.tags, context)
         : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    type: __expectString(output.type),
+    version: __expectString(output.version),
   } as any;
 };
 
 const deserializeAws_restJson1ImagePackage = (output: any, context: __SerdeContext): ImagePackage => {
   return {
-    packageName: output.packageName !== undefined && output.packageName !== null ? output.packageName : undefined,
-    packageVersion:
-      output.packageVersion !== undefined && output.packageVersion !== null ? output.packageVersion : undefined,
+    packageName: __expectString(output.packageName),
+    packageVersion: __expectString(output.packageVersion),
   } as any;
 };
 
@@ -8247,41 +8224,28 @@ const deserializeAws_restJson1ImagePackageList = (output: any, context: __SerdeC
 
 const deserializeAws_restJson1ImagePipeline = (output: any, context: __SerdeContext): ImagePipeline => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    containerRecipeArn:
-      output.containerRecipeArn !== undefined && output.containerRecipeArn !== null
-        ? output.containerRecipeArn
-        : undefined,
-    dateCreated: output.dateCreated !== undefined && output.dateCreated !== null ? output.dateCreated : undefined,
-    dateLastRun: output.dateLastRun !== undefined && output.dateLastRun !== null ? output.dateLastRun : undefined,
-    dateNextRun: output.dateNextRun !== undefined && output.dateNextRun !== null ? output.dateNextRun : undefined,
-    dateUpdated: output.dateUpdated !== undefined && output.dateUpdated !== null ? output.dateUpdated : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    distributionConfigurationArn:
-      output.distributionConfigurationArn !== undefined && output.distributionConfigurationArn !== null
-        ? output.distributionConfigurationArn
-        : undefined,
-    enhancedImageMetadataEnabled:
-      output.enhancedImageMetadataEnabled !== undefined && output.enhancedImageMetadataEnabled !== null
-        ? output.enhancedImageMetadataEnabled
-        : undefined,
-    imageRecipeArn:
-      output.imageRecipeArn !== undefined && output.imageRecipeArn !== null ? output.imageRecipeArn : undefined,
+    arn: __expectString(output.arn),
+    containerRecipeArn: __expectString(output.containerRecipeArn),
+    dateCreated: __expectString(output.dateCreated),
+    dateLastRun: __expectString(output.dateLastRun),
+    dateNextRun: __expectString(output.dateNextRun),
+    dateUpdated: __expectString(output.dateUpdated),
+    description: __expectString(output.description),
+    distributionConfigurationArn: __expectString(output.distributionConfigurationArn),
+    enhancedImageMetadataEnabled: __expectBoolean(output.enhancedImageMetadataEnabled),
+    imageRecipeArn: __expectString(output.imageRecipeArn),
     imageTestsConfiguration:
       output.imageTestsConfiguration !== undefined && output.imageTestsConfiguration !== null
         ? deserializeAws_restJson1ImageTestsConfiguration(output.imageTestsConfiguration, context)
         : undefined,
-    infrastructureConfigurationArn:
-      output.infrastructureConfigurationArn !== undefined && output.infrastructureConfigurationArn !== null
-        ? output.infrastructureConfigurationArn
-        : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    platform: output.platform !== undefined && output.platform !== null ? output.platform : undefined,
+    infrastructureConfigurationArn: __expectString(output.infrastructureConfigurationArn),
+    name: __expectString(output.name),
+    platform: __expectString(output.platform),
     schedule:
       output.schedule !== undefined && output.schedule !== null
         ? deserializeAws_restJson1Schedule(output.schedule, context)
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1TagMap(output.tags, context)
@@ -8302,7 +8266,7 @@ const deserializeAws_restJson1ImagePipelineList = (output: any, context: __Serde
 
 const deserializeAws_restJson1ImageRecipe = (output: any, context: __SerdeContext): ImageRecipe => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     blockDeviceMappings:
       output.blockDeviceMappings !== undefined && output.blockDeviceMappings !== null
         ? deserializeAws_restJson1InstanceBlockDeviceMappings(output.blockDeviceMappings, context)
@@ -8311,31 +8275,30 @@ const deserializeAws_restJson1ImageRecipe = (output: any, context: __SerdeContex
       output.components !== undefined && output.components !== null
         ? deserializeAws_restJson1ComponentConfigurationList(output.components, context)
         : undefined,
-    dateCreated: output.dateCreated !== undefined && output.dateCreated !== null ? output.dateCreated : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    owner: output.owner !== undefined && output.owner !== null ? output.owner : undefined,
-    parentImage: output.parentImage !== undefined && output.parentImage !== null ? output.parentImage : undefined,
-    platform: output.platform !== undefined && output.platform !== null ? output.platform : undefined,
+    dateCreated: __expectString(output.dateCreated),
+    description: __expectString(output.description),
+    name: __expectString(output.name),
+    owner: __expectString(output.owner),
+    parentImage: __expectString(output.parentImage),
+    platform: __expectString(output.platform),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1TagMap(output.tags, context)
         : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
-    workingDirectory:
-      output.workingDirectory !== undefined && output.workingDirectory !== null ? output.workingDirectory : undefined,
+    type: __expectString(output.type),
+    version: __expectString(output.version),
+    workingDirectory: __expectString(output.workingDirectory),
   } as any;
 };
 
 const deserializeAws_restJson1ImageRecipeSummary = (output: any, context: __SerdeContext): ImageRecipeSummary => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    dateCreated: output.dateCreated !== undefined && output.dateCreated !== null ? output.dateCreated : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    owner: output.owner !== undefined && output.owner !== null ? output.owner : undefined,
-    parentImage: output.parentImage !== undefined && output.parentImage !== null ? output.parentImage : undefined,
-    platform: output.platform !== undefined && output.platform !== null ? output.platform : undefined,
+    arn: __expectString(output.arn),
+    dateCreated: __expectString(output.dateCreated),
+    name: __expectString(output.name),
+    owner: __expectString(output.owner),
+    parentImage: __expectString(output.parentImage),
+    platform: __expectString(output.platform),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1TagMap(output.tags, context)
@@ -8356,23 +8319,23 @@ const deserializeAws_restJson1ImageRecipeSummaryList = (output: any, context: __
 
 const deserializeAws_restJson1ImageState = (output: any, context: __SerdeContext): ImageState => {
   return {
-    reason: output.reason !== undefined && output.reason !== null ? output.reason : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    reason: __expectString(output.reason),
+    status: __expectString(output.status),
   } as any;
 };
 
 const deserializeAws_restJson1ImageSummary = (output: any, context: __SerdeContext): ImageSummary => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    dateCreated: output.dateCreated !== undefined && output.dateCreated !== null ? output.dateCreated : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    osVersion: output.osVersion !== undefined && output.osVersion !== null ? output.osVersion : undefined,
+    arn: __expectString(output.arn),
+    dateCreated: __expectString(output.dateCreated),
+    name: __expectString(output.name),
+    osVersion: __expectString(output.osVersion),
     outputResources:
       output.outputResources !== undefined && output.outputResources !== null
         ? deserializeAws_restJson1OutputResources(output.outputResources, context)
         : undefined,
-    owner: output.owner !== undefined && output.owner !== null ? output.owner : undefined,
-    platform: output.platform !== undefined && output.platform !== null ? output.platform : undefined,
+    owner: __expectString(output.owner),
+    platform: __expectString(output.platform),
     state:
       output.state !== undefined && output.state !== null
         ? deserializeAws_restJson1ImageState(output.state, context)
@@ -8381,8 +8344,8 @@ const deserializeAws_restJson1ImageSummary = (output: any, context: __SerdeConte
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1TagMap(output.tags, context)
         : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    type: __expectString(output.type),
+    version: __expectString(output.version),
   } as any;
 };
 
@@ -8402,25 +8365,21 @@ const deserializeAws_restJson1ImageTestsConfiguration = (
   context: __SerdeContext
 ): ImageTestsConfiguration => {
   return {
-    imageTestsEnabled:
-      output.imageTestsEnabled !== undefined && output.imageTestsEnabled !== null
-        ? output.imageTestsEnabled
-        : undefined,
-    timeoutMinutes:
-      output.timeoutMinutes !== undefined && output.timeoutMinutes !== null ? output.timeoutMinutes : undefined,
+    imageTestsEnabled: __expectBoolean(output.imageTestsEnabled),
+    timeoutMinutes: __expectNumber(output.timeoutMinutes),
   } as any;
 };
 
 const deserializeAws_restJson1ImageVersion = (output: any, context: __SerdeContext): ImageVersion => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    dateCreated: output.dateCreated !== undefined && output.dateCreated !== null ? output.dateCreated : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    osVersion: output.osVersion !== undefined && output.osVersion !== null ? output.osVersion : undefined,
-    owner: output.owner !== undefined && output.owner !== null ? output.owner : undefined,
-    platform: output.platform !== undefined && output.platform !== null ? output.platform : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    arn: __expectString(output.arn),
+    dateCreated: __expectString(output.dateCreated),
+    name: __expectString(output.name),
+    osVersion: __expectString(output.osVersion),
+    owner: __expectString(output.owner),
+    platform: __expectString(output.platform),
+    type: __expectString(output.type),
+    version: __expectString(output.version),
   } as any;
 };
 
@@ -8440,24 +8399,21 @@ const deserializeAws_restJson1InfrastructureConfiguration = (
   context: __SerdeContext
 ): InfrastructureConfiguration => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    dateCreated: output.dateCreated !== undefined && output.dateCreated !== null ? output.dateCreated : undefined,
-    dateUpdated: output.dateUpdated !== undefined && output.dateUpdated !== null ? output.dateUpdated : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    instanceProfileName:
-      output.instanceProfileName !== undefined && output.instanceProfileName !== null
-        ? output.instanceProfileName
-        : undefined,
+    arn: __expectString(output.arn),
+    dateCreated: __expectString(output.dateCreated),
+    dateUpdated: __expectString(output.dateUpdated),
+    description: __expectString(output.description),
+    instanceProfileName: __expectString(output.instanceProfileName),
     instanceTypes:
       output.instanceTypes !== undefined && output.instanceTypes !== null
         ? deserializeAws_restJson1InstanceTypeList(output.instanceTypes, context)
         : undefined,
-    keyPair: output.keyPair !== undefined && output.keyPair !== null ? output.keyPair : undefined,
+    keyPair: __expectString(output.keyPair),
     logging:
       output.logging !== undefined && output.logging !== null
         ? deserializeAws_restJson1Logging(output.logging, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
     resourceTags:
       output.resourceTags !== undefined && output.resourceTags !== null
         ? deserializeAws_restJson1ResourceTagMap(output.resourceTags, context)
@@ -8466,16 +8422,13 @@ const deserializeAws_restJson1InfrastructureConfiguration = (
       output.securityGroupIds !== undefined && output.securityGroupIds !== null
         ? deserializeAws_restJson1SecurityGroupIds(output.securityGroupIds, context)
         : undefined,
-    snsTopicArn: output.snsTopicArn !== undefined && output.snsTopicArn !== null ? output.snsTopicArn : undefined,
-    subnetId: output.subnetId !== undefined && output.subnetId !== null ? output.subnetId : undefined,
+    snsTopicArn: __expectString(output.snsTopicArn),
+    subnetId: __expectString(output.subnetId),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1TagMap(output.tags, context)
         : undefined,
-    terminateInstanceOnFailure:
-      output.terminateInstanceOnFailure !== undefined && output.terminateInstanceOnFailure !== null
-        ? output.terminateInstanceOnFailure
-        : undefined,
+    terminateInstanceOnFailure: __expectBoolean(output.terminateInstanceOnFailure),
   } as any;
 };
 
@@ -8484,19 +8437,16 @@ const deserializeAws_restJson1InfrastructureConfigurationSummary = (
   context: __SerdeContext
 ): InfrastructureConfigurationSummary => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    dateCreated: output.dateCreated !== undefined && output.dateCreated !== null ? output.dateCreated : undefined,
-    dateUpdated: output.dateUpdated !== undefined && output.dateUpdated !== null ? output.dateUpdated : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    instanceProfileName:
-      output.instanceProfileName !== undefined && output.instanceProfileName !== null
-        ? output.instanceProfileName
-        : undefined,
+    arn: __expectString(output.arn),
+    dateCreated: __expectString(output.dateCreated),
+    dateUpdated: __expectString(output.dateUpdated),
+    description: __expectString(output.description),
+    instanceProfileName: __expectString(output.instanceProfileName),
     instanceTypes:
       output.instanceTypes !== undefined && output.instanceTypes !== null
         ? deserializeAws_restJson1InstanceTypeList(output.instanceTypes, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
     resourceTags:
       output.resourceTags !== undefined && output.resourceTags !== null
         ? deserializeAws_restJson1ResourceTagMap(output.resourceTags, context)
@@ -8527,13 +8477,13 @@ const deserializeAws_restJson1InstanceBlockDeviceMapping = (
   context: __SerdeContext
 ): InstanceBlockDeviceMapping => {
   return {
-    deviceName: output.deviceName !== undefined && output.deviceName !== null ? output.deviceName : undefined,
+    deviceName: __expectString(output.deviceName),
     ebs:
       output.ebs !== undefined && output.ebs !== null
         ? deserializeAws_restJson1EbsInstanceBlockDeviceSpecification(output.ebs, context)
         : undefined,
-    noDevice: output.noDevice !== undefined && output.noDevice !== null ? output.noDevice : undefined,
-    virtualName: output.virtualName !== undefined && output.virtualName !== null ? output.virtualName : undefined,
+    noDevice: __expectString(output.noDevice),
+    virtualName: __expectString(output.virtualName),
   } as any;
 };
 
@@ -8557,7 +8507,7 @@ const deserializeAws_restJson1InstanceConfiguration = (output: any, context: __S
       output.blockDeviceMappings !== undefined && output.blockDeviceMappings !== null
         ? deserializeAws_restJson1InstanceBlockDeviceMappings(output.blockDeviceMappings, context)
         : undefined,
-    image: output.image !== undefined && output.image !== null ? output.image : undefined,
+    image: __expectString(output.image),
   } as any;
 };
 
@@ -8568,7 +8518,7 @@ const deserializeAws_restJson1InstanceTypeList = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -8593,13 +8543,9 @@ const deserializeAws_restJson1LaunchTemplateConfiguration = (
   context: __SerdeContext
 ): LaunchTemplateConfiguration => {
   return {
-    accountId: output.accountId !== undefined && output.accountId !== null ? output.accountId : undefined,
-    launchTemplateId:
-      output.launchTemplateId !== undefined && output.launchTemplateId !== null ? output.launchTemplateId : undefined,
-    setDefaultVersion:
-      output.setDefaultVersion !== undefined && output.setDefaultVersion !== null
-        ? output.setDefaultVersion
-        : undefined,
+    accountId: __expectString(output.accountId),
+    launchTemplateId: __expectString(output.launchTemplateId),
+    setDefaultVersion: __expectBoolean(output.setDefaultVersion),
   } as any;
 };
 
@@ -8624,7 +8570,7 @@ const deserializeAws_restJson1LicenseConfigurationArnList = (output: any, contex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -8644,7 +8590,7 @@ const deserializeAws_restJson1OsVersionList = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -8668,7 +8614,7 @@ const deserializeAws_restJson1RegionList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -8679,29 +8625,23 @@ const deserializeAws_restJson1ResourceTagMap = (output: any, context: __SerdeCon
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1S3Logs = (output: any, context: __SerdeContext): S3Logs => {
   return {
-    s3BucketName: output.s3BucketName !== undefined && output.s3BucketName !== null ? output.s3BucketName : undefined,
-    s3KeyPrefix: output.s3KeyPrefix !== undefined && output.s3KeyPrefix !== null ? output.s3KeyPrefix : undefined,
+    s3BucketName: __expectString(output.s3BucketName),
+    s3KeyPrefix: __expectString(output.s3KeyPrefix),
   } as any;
 };
 
 const deserializeAws_restJson1Schedule = (output: any, context: __SerdeContext): Schedule => {
   return {
-    pipelineExecutionStartCondition:
-      output.pipelineExecutionStartCondition !== undefined && output.pipelineExecutionStartCondition !== null
-        ? output.pipelineExecutionStartCondition
-        : undefined,
-    scheduleExpression:
-      output.scheduleExpression !== undefined && output.scheduleExpression !== null
-        ? output.scheduleExpression
-        : undefined,
-    timezone: output.timezone !== undefined && output.timezone !== null ? output.timezone : undefined,
+    pipelineExecutionStartCondition: __expectString(output.pipelineExecutionStartCondition),
+    scheduleExpression: __expectString(output.scheduleExpression),
+    timezone: __expectString(output.timezone),
   } as any;
 };
 
@@ -8712,7 +8652,7 @@ const deserializeAws_restJson1SecurityGroupIds = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -8723,7 +8663,7 @@ const deserializeAws_restJson1StringList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -8734,7 +8674,7 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -8744,9 +8684,8 @@ const deserializeAws_restJson1TargetContainerRepository = (
   context: __SerdeContext
 ): TargetContainerRepository => {
   return {
-    repositoryName:
-      output.repositoryName !== undefined && output.repositoryName !== null ? output.repositoryName : undefined,
-    service: output.service !== undefined && output.service !== null ? output.service : undefined,
+    repositoryName: __expectString(output.repositoryName),
+    service: __expectString(output.service),
   } as any;
 };
 

--- a/clients/client-inspector/protocols/Aws_json1_1.ts
+++ b/clients/client-inspector/protocols/Aws_json1_1.ts
@@ -228,7 +228,12 @@ import {
   UpdateAssessmentTargetRequest,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -4602,9 +4607,9 @@ const serializeAws_json1_1UserAttributeList = (input: Attribute[], context: __Se
 
 const deserializeAws_json1_1AccessDeniedException = (output: any, context: __SerdeContext): AccessDeniedException => {
   return {
-    canRetry: output.canRetry !== undefined && output.canRetry !== null ? output.canRetry : undefined,
-    errorCode: output.errorCode !== undefined && output.errorCode !== null ? output.errorCode : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    canRetry: __expectBoolean(output.canRetry),
+    errorCode: __expectString(output.errorCode),
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -4625,9 +4630,8 @@ const deserializeAws_json1_1AgentAlreadyRunningAssessment = (
   context: __SerdeContext
 ): AgentAlreadyRunningAssessment => {
   return {
-    agentId: output.agentId !== undefined && output.agentId !== null ? output.agentId : undefined,
-    assessmentRunArn:
-      output.assessmentRunArn !== undefined && output.assessmentRunArn !== null ? output.assessmentRunArn : undefined,
+    agentId: __expectString(output.agentId),
+    assessmentRunArn: __expectString(output.assessmentRunArn),
   } as any;
 };
 
@@ -4647,17 +4651,14 @@ const deserializeAws_json1_1AgentAlreadyRunningAssessmentList = (
 
 const deserializeAws_json1_1AgentPreview = (output: any, context: __SerdeContext): AgentPreview => {
   return {
-    agentHealth: output.agentHealth !== undefined && output.agentHealth !== null ? output.agentHealth : undefined,
-    agentId: output.agentId !== undefined && output.agentId !== null ? output.agentId : undefined,
-    agentVersion: output.agentVersion !== undefined && output.agentVersion !== null ? output.agentVersion : undefined,
-    autoScalingGroup:
-      output.autoScalingGroup !== undefined && output.autoScalingGroup !== null ? output.autoScalingGroup : undefined,
-    hostname: output.hostname !== undefined && output.hostname !== null ? output.hostname : undefined,
-    ipv4Address: output.ipv4Address !== undefined && output.ipv4Address !== null ? output.ipv4Address : undefined,
-    kernelVersion:
-      output.kernelVersion !== undefined && output.kernelVersion !== null ? output.kernelVersion : undefined,
-    operatingSystem:
-      output.operatingSystem !== undefined && output.operatingSystem !== null ? output.operatingSystem : undefined,
+    agentHealth: __expectString(output.agentHealth),
+    agentId: __expectString(output.agentId),
+    agentVersion: __expectString(output.agentVersion),
+    autoScalingGroup: __expectString(output.autoScalingGroup),
+    hostname: __expectString(output.hostname),
+    ipv4Address: __expectString(output.ipv4Address),
+    kernelVersion: __expectString(output.kernelVersion),
+    operatingSystem: __expectString(output.operatingSystem),
   } as any;
 };
 
@@ -4681,10 +4682,9 @@ const deserializeAws_json1_1AgentsAlreadyRunningAssessmentException = (
       output.agents !== undefined && output.agents !== null
         ? deserializeAws_json1_1AgentAlreadyRunningAssessmentList(output.agents, context)
         : undefined,
-    agentsTruncated:
-      output.agentsTruncated !== undefined && output.agentsTruncated !== null ? output.agentsTruncated : undefined,
-    canRetry: output.canRetry !== undefined && output.canRetry !== null ? output.canRetry : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    agentsTruncated: __expectBoolean(output.agentsTruncated),
+    canRetry: __expectBoolean(output.canRetry),
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -4695,17 +4695,14 @@ const deserializeAws_json1_1AssessmentRulesPackageArnList = (output: any, contex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1AssessmentRun = (output: any, context: __SerdeContext): AssessmentRun => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    assessmentTemplateArn:
-      output.assessmentTemplateArn !== undefined && output.assessmentTemplateArn !== null
-        ? output.assessmentTemplateArn
-        : undefined,
+    arn: __expectString(output.arn),
+    assessmentTemplateArn: __expectString(output.assessmentTemplateArn),
     completedAt:
       output.completedAt !== undefined && output.completedAt !== null
         ? new Date(Math.round(output.completedAt * 1000))
@@ -4714,17 +4711,13 @@ const deserializeAws_json1_1AssessmentRun = (output: any, context: __SerdeContex
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    dataCollected:
-      output.dataCollected !== undefined && output.dataCollected !== null ? output.dataCollected : undefined,
-    durationInSeconds:
-      output.durationInSeconds !== undefined && output.durationInSeconds !== null
-        ? output.durationInSeconds
-        : undefined,
+    dataCollected: __expectBoolean(output.dataCollected),
+    durationInSeconds: __expectNumber(output.durationInSeconds),
     findingCounts:
       output.findingCounts !== undefined && output.findingCounts !== null
         ? deserializeAws_json1_1AssessmentRunFindingCounts(output.findingCounts, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
     notifications:
       output.notifications !== undefined && output.notifications !== null
         ? deserializeAws_json1_1AssessmentRunNotificationList(output.notifications, context)
@@ -4737,7 +4730,7 @@ const deserializeAws_json1_1AssessmentRun = (output: any, context: __SerdeContex
       output.startedAt !== undefined && output.startedAt !== null
         ? new Date(Math.round(output.startedAt * 1000))
         : undefined,
-    state: output.state !== undefined && output.state !== null ? output.state : undefined,
+    state: __expectString(output.state),
     stateChangedAt:
       output.stateChangedAt !== undefined && output.stateChangedAt !== null
         ? new Date(Math.round(output.stateChangedAt * 1000))
@@ -4755,18 +4748,12 @@ const deserializeAws_json1_1AssessmentRun = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1AssessmentRunAgent = (output: any, context: __SerdeContext): AssessmentRunAgent => {
   return {
-    agentHealth: output.agentHealth !== undefined && output.agentHealth !== null ? output.agentHealth : undefined,
-    agentHealthCode:
-      output.agentHealthCode !== undefined && output.agentHealthCode !== null ? output.agentHealthCode : undefined,
-    agentHealthDetails:
-      output.agentHealthDetails !== undefined && output.agentHealthDetails !== null
-        ? output.agentHealthDetails
-        : undefined,
-    agentId: output.agentId !== undefined && output.agentId !== null ? output.agentId : undefined,
-    assessmentRunArn:
-      output.assessmentRunArn !== undefined && output.assessmentRunArn !== null ? output.assessmentRunArn : undefined,
-    autoScalingGroup:
-      output.autoScalingGroup !== undefined && output.autoScalingGroup !== null ? output.autoScalingGroup : undefined,
+    agentHealth: __expectString(output.agentHealth),
+    agentHealthCode: __expectString(output.agentHealthCode),
+    agentHealthDetails: __expectString(output.agentHealthDetails),
+    agentId: __expectString(output.agentId),
+    assessmentRunArn: __expectString(output.assessmentRunArn),
+    autoScalingGroup: __expectString(output.autoScalingGroup),
     telemetryMetadata:
       output.telemetryMetadata !== undefined && output.telemetryMetadata !== null
         ? deserializeAws_json1_1TelemetryMetadataList(output.telemetryMetadata, context)
@@ -4795,7 +4782,7 @@ const deserializeAws_json1_1AssessmentRunFindingCounts = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectNumber(value) as any,
     };
   }, {});
 };
@@ -4807,7 +4794,7 @@ const deserializeAws_json1_1AssessmentRunInProgressArnList = (output: any, conte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4820,12 +4807,9 @@ const deserializeAws_json1_1AssessmentRunInProgressException = (
       output.assessmentRunArns !== undefined && output.assessmentRunArns !== null
         ? deserializeAws_json1_1AssessmentRunInProgressArnList(output.assessmentRunArns, context)
         : undefined,
-    assessmentRunArnsTruncated:
-      output.assessmentRunArnsTruncated !== undefined && output.assessmentRunArnsTruncated !== null
-        ? output.assessmentRunArnsTruncated
-        : undefined,
-    canRetry: output.canRetry !== undefined && output.canRetry !== null ? output.canRetry : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    assessmentRunArnsTruncated: __expectBoolean(output.assessmentRunArnsTruncated),
+    canRetry: __expectBoolean(output.canRetry),
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -4846,14 +4830,11 @@ const deserializeAws_json1_1AssessmentRunNotification = (
 ): AssessmentRunNotification => {
   return {
     date: output.date !== undefined && output.date !== null ? new Date(Math.round(output.date * 1000)) : undefined,
-    error: output.error !== undefined && output.error !== null ? output.error : undefined,
-    event: output.event !== undefined && output.event !== null ? output.event : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    snsPublishStatusCode:
-      output.snsPublishStatusCode !== undefined && output.snsPublishStatusCode !== null
-        ? output.snsPublishStatusCode
-        : undefined,
-    snsTopicArn: output.snsTopicArn !== undefined && output.snsTopicArn !== null ? output.snsTopicArn : undefined,
+    error: __expectBoolean(output.error),
+    event: __expectString(output.event),
+    message: __expectString(output.message),
+    snsPublishStatusCode: __expectString(output.snsPublishStatusCode),
+    snsTopicArn: __expectString(output.snsTopicArn),
   } as any;
 };
 
@@ -4876,7 +4857,7 @@ const deserializeAws_json1_1AssessmentRunStateChange = (
   context: __SerdeContext
 ): AssessmentRunStateChange => {
   return {
-    state: output.state !== undefined && output.state !== null ? output.state : undefined,
+    state: __expectString(output.state),
     stateChangedAt:
       output.stateChangedAt !== undefined && output.stateChangedAt !== null
         ? new Date(Math.round(output.stateChangedAt * 1000))
@@ -4900,14 +4881,13 @@ const deserializeAws_json1_1AssessmentRunStateChangeList = (
 
 const deserializeAws_json1_1AssessmentTarget = (output: any, context: __SerdeContext): AssessmentTarget => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    resourceGroupArn:
-      output.resourceGroupArn !== undefined && output.resourceGroupArn !== null ? output.resourceGroupArn : undefined,
+    name: __expectString(output.name),
+    resourceGroupArn: __expectString(output.resourceGroupArn),
     updatedAt:
       output.updatedAt !== undefined && output.updatedAt !== null
         ? new Date(Math.round(output.updatedAt * 1000))
@@ -4928,28 +4908,16 @@ const deserializeAws_json1_1AssessmentTargetList = (output: any, context: __Serd
 
 const deserializeAws_json1_1AssessmentTemplate = (output: any, context: __SerdeContext): AssessmentTemplate => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    assessmentRunCount:
-      output.assessmentRunCount !== undefined && output.assessmentRunCount !== null
-        ? output.assessmentRunCount
-        : undefined,
-    assessmentTargetArn:
-      output.assessmentTargetArn !== undefined && output.assessmentTargetArn !== null
-        ? output.assessmentTargetArn
-        : undefined,
+    arn: __expectString(output.arn),
+    assessmentRunCount: __expectNumber(output.assessmentRunCount),
+    assessmentTargetArn: __expectString(output.assessmentTargetArn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    durationInSeconds:
-      output.durationInSeconds !== undefined && output.durationInSeconds !== null
-        ? output.durationInSeconds
-        : undefined,
-    lastAssessmentRunArn:
-      output.lastAssessmentRunArn !== undefined && output.lastAssessmentRunArn !== null
-        ? output.lastAssessmentRunArn
-        : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    durationInSeconds: __expectNumber(output.durationInSeconds),
+    lastAssessmentRunArn: __expectString(output.lastAssessmentRunArn),
+    name: __expectString(output.name),
     rulesPackageArns:
       output.rulesPackageArns !== undefined && output.rulesPackageArns !== null
         ? deserializeAws_json1_1AssessmentTemplateRulesPackageArnList(output.rulesPackageArns, context)
@@ -4982,17 +4950,16 @@ const deserializeAws_json1_1AssessmentTemplateRulesPackageArnList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1AssetAttributes = (output: any, context: __SerdeContext): AssetAttributes => {
   return {
-    agentId: output.agentId !== undefined && output.agentId !== null ? output.agentId : undefined,
-    amiId: output.amiId !== undefined && output.amiId !== null ? output.amiId : undefined,
-    autoScalingGroup:
-      output.autoScalingGroup !== undefined && output.autoScalingGroup !== null ? output.autoScalingGroup : undefined,
-    hostname: output.hostname !== undefined && output.hostname !== null ? output.hostname : undefined,
+    agentId: __expectString(output.agentId),
+    amiId: __expectString(output.amiId),
+    autoScalingGroup: __expectString(output.autoScalingGroup),
+    hostname: __expectString(output.hostname),
     ipv4Addresses:
       output.ipv4Addresses !== undefined && output.ipv4Addresses !== null
         ? deserializeAws_json1_1Ipv4AddressList(output.ipv4Addresses, context)
@@ -5001,8 +4968,7 @@ const deserializeAws_json1_1AssetAttributes = (output: any, context: __SerdeCont
       output.networkInterfaces !== undefined && output.networkInterfaces !== null
         ? deserializeAws_json1_1NetworkInterfaces(output.networkInterfaces, context)
         : undefined,
-    schemaVersion:
-      output.schemaVersion !== undefined && output.schemaVersion !== null ? output.schemaVersion : undefined,
+    schemaVersion: __expectNumber(output.schemaVersion),
     tags:
       output.tags !== undefined && output.tags !== null ? deserializeAws_json1_1Tags(output.tags, context) : undefined,
   } as any;
@@ -5010,8 +4976,8 @@ const deserializeAws_json1_1AssetAttributes = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_1Attribute = (output: any, context: __SerdeContext): Attribute => {
   return {
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    key: __expectString(output.key),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -5031,10 +4997,7 @@ const deserializeAws_json1_1CreateAssessmentTargetResponse = (
   context: __SerdeContext
 ): CreateAssessmentTargetResponse => {
   return {
-    assessmentTargetArn:
-      output.assessmentTargetArn !== undefined && output.assessmentTargetArn !== null
-        ? output.assessmentTargetArn
-        : undefined,
+    assessmentTargetArn: __expectString(output.assessmentTargetArn),
   } as any;
 };
 
@@ -5043,10 +5006,7 @@ const deserializeAws_json1_1CreateAssessmentTemplateResponse = (
   context: __SerdeContext
 ): CreateAssessmentTemplateResponse => {
   return {
-    assessmentTemplateArn:
-      output.assessmentTemplateArn !== undefined && output.assessmentTemplateArn !== null
-        ? output.assessmentTemplateArn
-        : undefined,
+    assessmentTemplateArn: __expectString(output.assessmentTemplateArn),
   } as any;
 };
 
@@ -5055,7 +5015,7 @@ const deserializeAws_json1_1CreateExclusionsPreviewResponse = (
   context: __SerdeContext
 ): CreateExclusionsPreviewResponse => {
   return {
-    previewToken: output.previewToken !== undefined && output.previewToken !== null ? output.previewToken : undefined,
+    previewToken: __expectString(output.previewToken),
   } as any;
 };
 
@@ -5064,8 +5024,7 @@ const deserializeAws_json1_1CreateResourceGroupResponse = (
   context: __SerdeContext
 ): CreateResourceGroupResponse => {
   return {
-    resourceGroupArn:
-      output.resourceGroupArn !== undefined && output.resourceGroupArn !== null ? output.resourceGroupArn : undefined,
+    resourceGroupArn: __expectString(output.resourceGroupArn),
   } as any;
 };
 
@@ -5126,8 +5085,8 @@ const deserializeAws_json1_1DescribeCrossAccountAccessRoleResponse = (
       output.registeredAt !== undefined && output.registeredAt !== null
         ? new Date(Math.round(output.registeredAt * 1000))
         : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
-    valid: output.valid !== undefined && output.valid !== null ? output.valid : undefined,
+    roleArn: __expectString(output.roleArn),
+    valid: __expectBoolean(output.valid),
   } as any;
 };
 
@@ -5197,7 +5156,7 @@ const deserializeAws_json1_1DescribeRulesPackagesResponse = (
 
 const deserializeAws_json1_1EventSubscription = (output: any, context: __SerdeContext): EventSubscription => {
   return {
-    event: output.event !== undefined && output.event !== null ? output.event : undefined,
+    event: __expectString(output.event),
     subscribedAt:
       output.subscribedAt !== undefined && output.subscribedAt !== null
         ? new Date(Math.round(output.subscribedAt * 1000))
@@ -5218,19 +5177,18 @@ const deserializeAws_json1_1EventSubscriptionList = (output: any, context: __Ser
 
 const deserializeAws_json1_1Exclusion = (output: any, context: __SerdeContext): Exclusion => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     attributes:
       output.attributes !== undefined && output.attributes !== null
         ? deserializeAws_json1_1AttributeList(output.attributes, context)
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    recommendation:
-      output.recommendation !== undefined && output.recommendation !== null ? output.recommendation : undefined,
+    description: __expectString(output.description),
+    recommendation: __expectString(output.recommendation),
     scopes:
       output.scopes !== undefined && output.scopes !== null
         ? deserializeAws_json1_1ScopeList(output.scopes, context)
         : undefined,
-    title: output.title !== undefined && output.title !== null ? output.title : undefined,
+    title: __expectString(output.title),
   } as any;
 };
 
@@ -5252,14 +5210,13 @@ const deserializeAws_json1_1ExclusionPreview = (output: any, context: __SerdeCon
       output.attributes !== undefined && output.attributes !== null
         ? deserializeAws_json1_1AttributeList(output.attributes, context)
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    recommendation:
-      output.recommendation !== undefined && output.recommendation !== null ? output.recommendation : undefined,
+    description: __expectString(output.description),
+    recommendation: __expectString(output.recommendation),
     scopes:
       output.scopes !== undefined && output.scopes !== null
         ? deserializeAws_json1_1ScopeList(output.scopes, context)
         : undefined,
-    title: output.title !== undefined && output.title !== null ? output.title : undefined,
+    title: __expectString(output.title),
   } as any;
 };
 
@@ -5276,8 +5233,8 @@ const deserializeAws_json1_1ExclusionPreviewList = (output: any, context: __Serd
 
 const deserializeAws_json1_1FailedItemDetails = (output: any, context: __SerdeContext): FailedItemDetails => {
   return {
-    failureCode: output.failureCode !== undefined && output.failureCode !== null ? output.failureCode : undefined,
-    retryable: output.retryable !== undefined && output.retryable !== null ? output.retryable : undefined,
+    failureCode: __expectString(output.failureCode),
+    retryable: __expectBoolean(output.retryable),
   } as any;
 };
 
@@ -5298,40 +5255,34 @@ const deserializeAws_json1_1FailedItems = (
 
 const deserializeAws_json1_1Finding = (output: any, context: __SerdeContext): Finding => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     assetAttributes:
       output.assetAttributes !== undefined && output.assetAttributes !== null
         ? deserializeAws_json1_1AssetAttributes(output.assetAttributes, context)
         : undefined,
-    assetType: output.assetType !== undefined && output.assetType !== null ? output.assetType : undefined,
+    assetType: __expectString(output.assetType),
     attributes:
       output.attributes !== undefined && output.attributes !== null
         ? deserializeAws_json1_1AttributeList(output.attributes, context)
         : undefined,
-    confidence: output.confidence !== undefined && output.confidence !== null ? output.confidence : undefined,
+    confidence: __expectNumber(output.confidence),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    indicatorOfCompromise:
-      output.indicatorOfCompromise !== undefined && output.indicatorOfCompromise !== null
-        ? output.indicatorOfCompromise
-        : undefined,
-    numericSeverity:
-      output.numericSeverity !== undefined && output.numericSeverity !== null ? output.numericSeverity : undefined,
-    recommendation:
-      output.recommendation !== undefined && output.recommendation !== null ? output.recommendation : undefined,
-    schemaVersion:
-      output.schemaVersion !== undefined && output.schemaVersion !== null ? output.schemaVersion : undefined,
-    service: output.service !== undefined && output.service !== null ? output.service : undefined,
+    description: __expectString(output.description),
+    id: __expectString(output.id),
+    indicatorOfCompromise: __expectBoolean(output.indicatorOfCompromise),
+    numericSeverity: __expectNumber(output.numericSeverity),
+    recommendation: __expectString(output.recommendation),
+    schemaVersion: __expectNumber(output.schemaVersion),
+    service: __expectString(output.service),
     serviceAttributes:
       output.serviceAttributes !== undefined && output.serviceAttributes !== null
         ? deserializeAws_json1_1InspectorServiceAttributes(output.serviceAttributes, context)
         : undefined,
-    severity: output.severity !== undefined && output.severity !== null ? output.severity : undefined,
-    title: output.title !== undefined && output.title !== null ? output.title : undefined,
+    severity: __expectString(output.severity),
+    title: __expectString(output.title),
     updatedAt:
       output.updatedAt !== undefined && output.updatedAt !== null
         ? new Date(Math.round(output.updatedAt * 1000))
@@ -5359,8 +5310,8 @@ const deserializeAws_json1_1GetAssessmentReportResponse = (
   context: __SerdeContext
 ): GetAssessmentReportResponse => {
   return {
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    url: output.url !== undefined && output.url !== null ? output.url : undefined,
+    status: __expectString(output.status),
+    url: __expectString(output.url),
   } as any;
 };
 
@@ -5373,9 +5324,8 @@ const deserializeAws_json1_1GetExclusionsPreviewResponse = (
       output.exclusionPreviews !== undefined && output.exclusionPreviews !== null
         ? deserializeAws_json1_1ExclusionPreviewList(output.exclusionPreviews, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
-    previewStatus:
-      output.previewStatus !== undefined && output.previewStatus !== null ? output.previewStatus : undefined,
+    nextToken: __expectString(output.nextToken),
+    previewStatus: __expectString(output.previewStatus),
   } as any;
 };
 
@@ -5396,19 +5346,16 @@ const deserializeAws_json1_1InspectorServiceAttributes = (
   context: __SerdeContext
 ): InspectorServiceAttributes => {
   return {
-    assessmentRunArn:
-      output.assessmentRunArn !== undefined && output.assessmentRunArn !== null ? output.assessmentRunArn : undefined,
-    rulesPackageArn:
-      output.rulesPackageArn !== undefined && output.rulesPackageArn !== null ? output.rulesPackageArn : undefined,
-    schemaVersion:
-      output.schemaVersion !== undefined && output.schemaVersion !== null ? output.schemaVersion : undefined,
+    assessmentRunArn: __expectString(output.assessmentRunArn),
+    rulesPackageArn: __expectString(output.rulesPackageArn),
+    schemaVersion: __expectNumber(output.schemaVersion),
   } as any;
 };
 
 const deserializeAws_json1_1InternalException = (output: any, context: __SerdeContext): InternalException => {
   return {
-    canRetry: output.canRetry !== undefined && output.canRetry !== null ? output.canRetry : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    canRetry: __expectBoolean(output.canRetry),
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -5417,17 +5364,17 @@ const deserializeAws_json1_1InvalidCrossAccountRoleException = (
   context: __SerdeContext
 ): InvalidCrossAccountRoleException => {
   return {
-    canRetry: output.canRetry !== undefined && output.canRetry !== null ? output.canRetry : undefined,
-    errorCode: output.errorCode !== undefined && output.errorCode !== null ? output.errorCode : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    canRetry: __expectBoolean(output.canRetry),
+    errorCode: __expectString(output.errorCode),
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidInputException = (output: any, context: __SerdeContext): InvalidInputException => {
   return {
-    canRetry: output.canRetry !== undefined && output.canRetry !== null ? output.canRetry : undefined,
-    errorCode: output.errorCode !== undefined && output.errorCode !== null ? output.errorCode : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    canRetry: __expectBoolean(output.canRetry),
+    errorCode: __expectString(output.errorCode),
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -5438,7 +5385,7 @@ const deserializeAws_json1_1Ipv4AddressList = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -5449,15 +5396,15 @@ const deserializeAws_json1_1Ipv6Addresses = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    canRetry: output.canRetry !== undefined && output.canRetry !== null ? output.canRetry : undefined,
-    errorCode: output.errorCode !== undefined && output.errorCode !== null ? output.errorCode : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    canRetry: __expectBoolean(output.canRetry),
+    errorCode: __expectString(output.errorCode),
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -5470,7 +5417,7 @@ const deserializeAws_json1_1ListAssessmentRunAgentsResponse = (
       output.assessmentRunAgents !== undefined && output.assessmentRunAgents !== null
         ? deserializeAws_json1_1AssessmentRunAgentList(output.assessmentRunAgents, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -5483,7 +5430,7 @@ const deserializeAws_json1_1ListAssessmentRunsResponse = (
       output.assessmentRunArns !== undefined && output.assessmentRunArns !== null
         ? deserializeAws_json1_1ListReturnedArnList(output.assessmentRunArns, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -5496,7 +5443,7 @@ const deserializeAws_json1_1ListAssessmentTargetsResponse = (
       output.assessmentTargetArns !== undefined && output.assessmentTargetArns !== null
         ? deserializeAws_json1_1ListReturnedArnList(output.assessmentTargetArns, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -5509,7 +5456,7 @@ const deserializeAws_json1_1ListAssessmentTemplatesResponse = (
       output.assessmentTemplateArns !== undefined && output.assessmentTemplateArns !== null
         ? deserializeAws_json1_1ListReturnedArnList(output.assessmentTemplateArns, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -5518,7 +5465,7 @@ const deserializeAws_json1_1ListEventSubscriptionsResponse = (
   context: __SerdeContext
 ): ListEventSubscriptionsResponse => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     subscriptions:
       output.subscriptions !== undefined && output.subscriptions !== null
         ? deserializeAws_json1_1SubscriptionList(output.subscriptions, context)
@@ -5532,7 +5479,7 @@ const deserializeAws_json1_1ListExclusionsResponse = (output: any, context: __Se
       output.exclusionArns !== undefined && output.exclusionArns !== null
         ? deserializeAws_json1_1ListReturnedArnList(output.exclusionArns, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -5542,7 +5489,7 @@ const deserializeAws_json1_1ListFindingsResponse = (output: any, context: __Serd
       output.findingArns !== undefined && output.findingArns !== null
         ? deserializeAws_json1_1ListReturnedArnList(output.findingArns, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -5553,7 +5500,7 @@ const deserializeAws_json1_1ListReturnedArnList = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -5562,7 +5509,7 @@ const deserializeAws_json1_1ListRulesPackagesResponse = (
   context: __SerdeContext
 ): ListRulesPackagesResponse => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     rulesPackageArns:
       output.rulesPackageArns !== undefined && output.rulesPackageArns !== null
         ? deserializeAws_json1_1ListReturnedArnList(output.rulesPackageArns, context)
@@ -5588,27 +5535,21 @@ const deserializeAws_json1_1NetworkInterface = (output: any, context: __SerdeCon
       output.ipv6Addresses !== undefined && output.ipv6Addresses !== null
         ? deserializeAws_json1_1Ipv6Addresses(output.ipv6Addresses, context)
         : undefined,
-    networkInterfaceId:
-      output.networkInterfaceId !== undefined && output.networkInterfaceId !== null
-        ? output.networkInterfaceId
-        : undefined,
-    privateDnsName:
-      output.privateDnsName !== undefined && output.privateDnsName !== null ? output.privateDnsName : undefined,
-    privateIpAddress:
-      output.privateIpAddress !== undefined && output.privateIpAddress !== null ? output.privateIpAddress : undefined,
+    networkInterfaceId: __expectString(output.networkInterfaceId),
+    privateDnsName: __expectString(output.privateDnsName),
+    privateIpAddress: __expectString(output.privateIpAddress),
     privateIpAddresses:
       output.privateIpAddresses !== undefined && output.privateIpAddresses !== null
         ? deserializeAws_json1_1PrivateIpAddresses(output.privateIpAddresses, context)
         : undefined,
-    publicDnsName:
-      output.publicDnsName !== undefined && output.publicDnsName !== null ? output.publicDnsName : undefined,
-    publicIp: output.publicIp !== undefined && output.publicIp !== null ? output.publicIp : undefined,
+    publicDnsName: __expectString(output.publicDnsName),
+    publicIp: __expectString(output.publicIp),
     securityGroups:
       output.securityGroups !== undefined && output.securityGroups !== null
         ? deserializeAws_json1_1SecurityGroups(output.securityGroups, context)
         : undefined,
-    subnetId: output.subnetId !== undefined && output.subnetId !== null ? output.subnetId : undefined,
-    vpcId: output.vpcId !== undefined && output.vpcId !== null ? output.vpcId : undefined,
+    subnetId: __expectString(output.subnetId),
+    vpcId: __expectString(output.vpcId),
   } as any;
 };
 
@@ -5625,9 +5566,9 @@ const deserializeAws_json1_1NetworkInterfaces = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1NoSuchEntityException = (output: any, context: __SerdeContext): NoSuchEntityException => {
   return {
-    canRetry: output.canRetry !== undefined && output.canRetry !== null ? output.canRetry : undefined,
-    errorCode: output.errorCode !== undefined && output.errorCode !== null ? output.errorCode : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    canRetry: __expectBoolean(output.canRetry),
+    errorCode: __expectString(output.errorCode),
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -5637,7 +5578,7 @@ const deserializeAws_json1_1PreviewAgentsResponse = (output: any, context: __Ser
       output.agentPreviews !== undefined && output.agentPreviews !== null
         ? deserializeAws_json1_1AgentPreviewList(output.agentPreviews, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -5646,16 +5587,14 @@ const deserializeAws_json1_1PreviewGenerationInProgressException = (
   context: __SerdeContext
 ): PreviewGenerationInProgressException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1PrivateIp = (output: any, context: __SerdeContext): PrivateIp => {
   return {
-    privateDnsName:
-      output.privateDnsName !== undefined && output.privateDnsName !== null ? output.privateDnsName : undefined,
-    privateIpAddress:
-      output.privateIpAddress !== undefined && output.privateIpAddress !== null ? output.privateIpAddress : undefined,
+    privateDnsName: __expectString(output.privateDnsName),
+    privateIpAddress: __expectString(output.privateIpAddress),
   } as any;
 };
 
@@ -5684,7 +5623,7 @@ const deserializeAws_json1_1RemoveAttributesFromFindingsResponse = (
 
 const deserializeAws_json1_1ResourceGroup = (output: any, context: __SerdeContext): ResourceGroup => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
@@ -5709,8 +5648,8 @@ const deserializeAws_json1_1ResourceGroupList = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1ResourceGroupTag = (output: any, context: __SerdeContext): ResourceGroupTag => {
   return {
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    key: __expectString(output.key),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -5727,11 +5666,11 @@ const deserializeAws_json1_1ResourceGroupTags = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1RulesPackage = (output: any, context: __SerdeContext): RulesPackage => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    provider: output.provider !== undefined && output.provider !== null ? output.provider : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    arn: __expectString(output.arn),
+    description: __expectString(output.description),
+    name: __expectString(output.name),
+    provider: __expectString(output.provider),
+    version: __expectString(output.version),
   } as any;
 };
 
@@ -5748,8 +5687,8 @@ const deserializeAws_json1_1RulesPackageList = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1Scope = (output: any, context: __SerdeContext): Scope => {
   return {
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    key: __expectString(output.key),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -5766,8 +5705,8 @@ const deserializeAws_json1_1ScopeList = (output: any, context: __SerdeContext): 
 
 const deserializeAws_json1_1SecurityGroup = (output: any, context: __SerdeContext): SecurityGroup => {
   return {
-    groupId: output.groupId !== undefined && output.groupId !== null ? output.groupId : undefined,
-    groupName: output.groupName !== undefined && output.groupName !== null ? output.groupName : undefined,
+    groupId: __expectString(output.groupId),
+    groupName: __expectString(output.groupName),
   } as any;
 };
 
@@ -5787,8 +5726,8 @@ const deserializeAws_json1_1ServiceTemporarilyUnavailableException = (
   context: __SerdeContext
 ): ServiceTemporarilyUnavailableException => {
   return {
-    canRetry: output.canRetry !== undefined && output.canRetry !== null ? output.canRetry : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    canRetry: __expectBoolean(output.canRetry),
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -5797,8 +5736,7 @@ const deserializeAws_json1_1StartAssessmentRunResponse = (
   context: __SerdeContext
 ): StartAssessmentRunResponse => {
   return {
-    assessmentRunArn:
-      output.assessmentRunArn !== undefined && output.assessmentRunArn !== null ? output.assessmentRunArn : undefined,
+    assessmentRunArn: __expectString(output.assessmentRunArn),
   } as any;
 };
 
@@ -5808,8 +5746,8 @@ const deserializeAws_json1_1Subscription = (output: any, context: __SerdeContext
       output.eventSubscriptions !== undefined && output.eventSubscriptions !== null
         ? deserializeAws_json1_1EventSubscriptionList(output.eventSubscriptions, context)
         : undefined,
-    resourceArn: output.resourceArn !== undefined && output.resourceArn !== null ? output.resourceArn : undefined,
-    topicArn: output.topicArn !== undefined && output.topicArn !== null ? output.topicArn : undefined,
+    resourceArn: __expectString(output.resourceArn),
+    topicArn: __expectString(output.topicArn),
   } as any;
 };
 
@@ -5826,8 +5764,8 @@ const deserializeAws_json1_1SubscriptionList = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    key: __expectString(output.key),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -5855,9 +5793,9 @@ const deserializeAws_json1_1Tags = (output: any, context: __SerdeContext): Tag[]
 
 const deserializeAws_json1_1TelemetryMetadata = (output: any, context: __SerdeContext): TelemetryMetadata => {
   return {
-    count: output.count !== undefined && output.count !== null ? output.count : undefined,
-    dataSize: output.dataSize !== undefined && output.dataSize !== null ? output.dataSize : undefined,
-    messageType: output.messageType !== undefined && output.messageType !== null ? output.messageType : undefined,
+    count: __expectNumber(output.count),
+    dataSize: __expectNumber(output.dataSize),
+    messageType: __expectString(output.messageType),
   } as any;
 };
 
@@ -5877,8 +5815,8 @@ const deserializeAws_json1_1UnsupportedFeatureException = (
   context: __SerdeContext
 ): UnsupportedFeatureException => {
   return {
-    canRetry: output.canRetry !== undefined && output.canRetry !== null ? output.canRetry : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    canRetry: __expectBoolean(output.canRetry),
+    message: __expectString(output.message),
   } as any;
 };
 

--- a/clients/client-iot-1click-devices-service/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-1click-devices-service/protocols/Aws_restJson1.ts
@@ -40,6 +40,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -464,10 +467,10 @@ export const deserializeAws_restJson1ClaimDevicesByClaimCodeCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.claimCode !== undefined && data.claimCode !== null) {
-    contents.ClaimCode = data.claimCode;
+    contents.ClaimCode = __expectString(data.claimCode);
   }
   if (data.total !== undefined && data.total !== null) {
-    contents.Total = data.total;
+    contents.Total = __expectNumber(data.total);
   }
   return Promise.resolve(contents);
 };
@@ -609,7 +612,7 @@ export const deserializeAws_restJson1FinalizeDeviceClaimCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.state !== undefined && data.state !== null) {
-    contents.State = data.state;
+    contents.State = __expectString(data.state);
   }
   return Promise.resolve(contents);
 };
@@ -767,7 +770,7 @@ export const deserializeAws_restJson1InitiateDeviceClaimCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.state !== undefined && data.state !== null) {
-    contents.State = data.state;
+    contents.State = __expectString(data.state);
   }
   return Promise.resolve(contents);
 };
@@ -846,7 +849,7 @@ export const deserializeAws_restJson1InvokeDeviceMethodCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.deviceMethodResponse !== undefined && data.deviceMethodResponse !== null) {
-    contents.DeviceMethodResponse = data.deviceMethodResponse;
+    contents.DeviceMethodResponse = __expectString(data.deviceMethodResponse);
   }
   return Promise.resolve(contents);
 };
@@ -945,7 +948,7 @@ export const deserializeAws_restJson1ListDeviceEventsCommand = async (
     contents.Events = deserializeAws_restJson1__listOfDeviceEvent(data.events, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1028,7 +1031,7 @@ export const deserializeAws_restJson1ListDevicesCommand = async (
     contents.Devices = deserializeAws_restJson1__listOfDeviceDescription(data.devices, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1229,7 +1232,7 @@ export const deserializeAws_restJson1UnclaimDeviceCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.state !== undefined && data.state !== null) {
-    contents.State = data.state;
+    contents.State = __expectString(data.state);
   }
   return Promise.resolve(contents);
 };
@@ -1434,10 +1437,10 @@ const deserializeAws_restJson1ForbiddenExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.code !== undefined && data.code !== null) {
-    contents.Code = data.code;
+    contents.Code = __expectString(data.code);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -1455,10 +1458,10 @@ const deserializeAws_restJson1InternalFailureExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.code !== undefined && data.code !== null) {
-    contents.Code = data.code;
+    contents.Code = __expectString(data.code);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -1476,10 +1479,10 @@ const deserializeAws_restJson1InvalidRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.code !== undefined && data.code !== null) {
-    contents.Code = data.code;
+    contents.Code = __expectString(data.code);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -1497,10 +1500,10 @@ const deserializeAws_restJson1PreconditionFailedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.code !== undefined && data.code !== null) {
-    contents.Code = data.code;
+    contents.Code = __expectString(data.code);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -1518,10 +1521,10 @@ const deserializeAws_restJson1RangeNotSatisfiableExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.code !== undefined && data.code !== null) {
-    contents.Code = data.code;
+    contents.Code = __expectString(data.code);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -1539,10 +1542,10 @@ const deserializeAws_restJson1ResourceConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.code !== undefined && data.code !== null) {
-    contents.Code = data.code;
+    contents.Code = __expectString(data.code);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -1560,10 +1563,10 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.code !== undefined && data.code !== null) {
-    contents.Code = data.code;
+    contents.Code = __expectString(data.code);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -1630,7 +1633,7 @@ const deserializeAws_restJson1__mapOf__string = (output: any, context: __SerdeCo
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -1645,8 +1648,8 @@ const deserializeAws_restJson1Device = (output: any, context: __SerdeContext): D
       output.attributes !== undefined && output.attributes !== null
         ? deserializeAws_restJson1Attributes(output.attributes, context)
         : undefined,
-    DeviceId: output.deviceId !== undefined && output.deviceId !== null ? output.deviceId : undefined,
-    Type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    DeviceId: __expectString(output.deviceId),
+    Type: __expectString(output.type),
   } as any;
 };
 
@@ -1657,27 +1660,26 @@ const deserializeAws_restJson1DeviceAttributes = (output: any, context: __SerdeC
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1DeviceDescription = (output: any, context: __SerdeContext): DeviceDescription => {
   return {
-    Arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    Arn: __expectString(output.arn),
     Attributes:
       output.attributes !== undefined && output.attributes !== null
         ? deserializeAws_restJson1DeviceAttributes(output.attributes, context)
         : undefined,
-    DeviceId: output.deviceId !== undefined && output.deviceId !== null ? output.deviceId : undefined,
-    Enabled: output.enabled !== undefined && output.enabled !== null ? output.enabled : undefined,
-    RemainingLife:
-      output.remainingLife !== undefined && output.remainingLife !== null ? output.remainingLife : undefined,
+    DeviceId: __expectString(output.deviceId),
+    Enabled: __expectBoolean(output.enabled),
+    RemainingLife: __expectNumber(output.remainingLife),
     Tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1__mapOf__string(output.tags, context)
         : undefined,
-    Type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    Type: __expectString(output.type),
   } as any;
 };
 
@@ -1687,14 +1689,14 @@ const deserializeAws_restJson1DeviceEvent = (output: any, context: __SerdeContex
       output.device !== undefined && output.device !== null
         ? deserializeAws_restJson1Device(output.device, context)
         : undefined,
-    StdEvent: output.stdEvent !== undefined && output.stdEvent !== null ? output.stdEvent : undefined,
+    StdEvent: __expectString(output.stdEvent),
   } as any;
 };
 
 const deserializeAws_restJson1DeviceMethod = (output: any, context: __SerdeContext): DeviceMethod => {
   return {
-    DeviceType: output.deviceType !== undefined && output.deviceType !== null ? output.deviceType : undefined,
-    MethodName: output.methodName !== undefined && output.methodName !== null ? output.methodName : undefined,
+    DeviceType: __expectString(output.deviceType),
+    MethodName: __expectString(output.methodName),
   } as any;
 };
 

--- a/clients/client-iot-1click-projects/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-1click-projects/protocols/Aws_restJson1.ts
@@ -42,6 +42,7 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -1283,7 +1284,7 @@ export const deserializeAws_restJson1ListPlacementsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.placements !== undefined && data.placements !== null) {
     contents.placements = deserializeAws_restJson1PlacementSummaryList(data.placements, context);
@@ -1358,7 +1359,7 @@ export const deserializeAws_restJson1ListProjectsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.projects !== undefined && data.projects !== null) {
     contents.projects = deserializeAws_restJson1ProjectSummaryList(data.projects, context);
@@ -1779,10 +1780,10 @@ const deserializeAws_restJson1InternalFailureExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.code !== undefined && data.code !== null) {
-    contents.code = data.code;
+    contents.code = __expectString(data.code);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1800,10 +1801,10 @@ const deserializeAws_restJson1InvalidRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.code !== undefined && data.code !== null) {
-    contents.code = data.code;
+    contents.code = __expectString(data.code);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1821,10 +1822,10 @@ const deserializeAws_restJson1ResourceConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.code !== undefined && data.code !== null) {
-    contents.code = data.code;
+    contents.code = __expectString(data.code);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1842,10 +1843,10 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.code !== undefined && data.code !== null) {
-    contents.code = data.code;
+    contents.code = __expectString(data.code);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1863,10 +1864,10 @@ const deserializeAws_restJson1TooManyRequestsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.code !== undefined && data.code !== null) {
-    contents.code = data.code;
+    contents.code = __expectString(data.code);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1976,7 +1977,7 @@ const deserializeAws_restJson1DefaultPlacementAttributeMap = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -1991,7 +1992,7 @@ const deserializeAws_restJson1DeviceCallbackOverrideMap = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -2003,7 +2004,7 @@ const deserializeAws_restJson1DeviceMap = (output: any, context: __SerdeContext)
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -2014,7 +2015,7 @@ const deserializeAws_restJson1DeviceTemplate = (output: any, context: __SerdeCon
       output.callbackOverrides !== undefined && output.callbackOverrides !== null
         ? deserializeAws_restJson1DeviceCallbackOverrideMap(output.callbackOverrides, context)
         : undefined,
-    deviceType: output.deviceType !== undefined && output.deviceType !== null ? output.deviceType : undefined,
+    deviceType: __expectString(output.deviceType),
   } as any;
 };
 
@@ -2043,7 +2044,7 @@ const deserializeAws_restJson1PlacementAttributeMap = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -2058,9 +2059,8 @@ const deserializeAws_restJson1PlacementDescription = (output: any, context: __Se
       output.createdDate !== undefined && output.createdDate !== null
         ? new Date(Math.round(output.createdDate * 1000))
         : undefined,
-    placementName:
-      output.placementName !== undefined && output.placementName !== null ? output.placementName : undefined,
-    projectName: output.projectName !== undefined && output.projectName !== null ? output.projectName : undefined,
+    placementName: __expectString(output.placementName),
+    projectName: __expectString(output.projectName),
     updatedDate:
       output.updatedDate !== undefined && output.updatedDate !== null
         ? new Date(Math.round(output.updatedDate * 1000))
@@ -2074,9 +2074,8 @@ const deserializeAws_restJson1PlacementSummary = (output: any, context: __SerdeC
       output.createdDate !== undefined && output.createdDate !== null
         ? new Date(Math.round(output.createdDate * 1000))
         : undefined,
-    placementName:
-      output.placementName !== undefined && output.placementName !== null ? output.placementName : undefined,
-    projectName: output.projectName !== undefined && output.projectName !== null ? output.projectName : undefined,
+    placementName: __expectString(output.placementName),
+    projectName: __expectString(output.projectName),
     updatedDate:
       output.updatedDate !== undefined && output.updatedDate !== null
         ? new Date(Math.round(output.updatedDate * 1000))
@@ -2110,17 +2109,17 @@ const deserializeAws_restJson1PlacementTemplate = (output: any, context: __Serde
 
 const deserializeAws_restJson1ProjectDescription = (output: any, context: __SerdeContext): ProjectDescription => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdDate:
       output.createdDate !== undefined && output.createdDate !== null
         ? new Date(Math.round(output.createdDate * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    description: __expectString(output.description),
     placementTemplate:
       output.placementTemplate !== undefined && output.placementTemplate !== null
         ? deserializeAws_restJson1PlacementTemplate(output.placementTemplate, context)
         : undefined,
-    projectName: output.projectName !== undefined && output.projectName !== null ? output.projectName : undefined,
+    projectName: __expectString(output.projectName),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1TagMap(output.tags, context)
@@ -2134,12 +2133,12 @@ const deserializeAws_restJson1ProjectDescription = (output: any, context: __Serd
 
 const deserializeAws_restJson1ProjectSummary = (output: any, context: __SerdeContext): ProjectSummary => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdDate:
       output.createdDate !== undefined && output.createdDate !== null
         ? new Date(Math.round(output.createdDate * 1000))
         : undefined,
-    projectName: output.projectName !== undefined && output.projectName !== null ? output.projectName : undefined,
+    projectName: __expectString(output.projectName),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1TagMap(output.tags, context)
@@ -2169,7 +2168,7 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };

--- a/clients/client-iot-data-plane/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-data-plane/protocols/Aws_restJson1.ts
@@ -21,6 +21,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -434,13 +436,13 @@ export const deserializeAws_restJson1ListNamedShadowsForThingCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.results !== undefined && data.results !== null) {
     contents.results = deserializeAws_restJson1NamedShadowList(data.results, context);
   }
   if (data.timestamp !== undefined && data.timestamp !== null) {
-    contents.timestamp = data.timestamp;
+    contents.timestamp = __expectNumber(data.timestamp);
   }
   return Promise.resolve(contents);
 };
@@ -734,7 +736,7 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -751,7 +753,7 @@ const deserializeAws_restJson1InternalFailureExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -768,7 +770,7 @@ const deserializeAws_restJson1InvalidRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -785,7 +787,7 @@ const deserializeAws_restJson1MethodNotAllowedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -802,7 +804,7 @@ const deserializeAws_restJson1RequestEntityTooLargeExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -819,7 +821,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -836,7 +838,7 @@ const deserializeAws_restJson1ServiceUnavailableExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -853,7 +855,7 @@ const deserializeAws_restJson1ThrottlingExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -870,7 +872,7 @@ const deserializeAws_restJson1UnauthorizedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -887,7 +889,7 @@ const deserializeAws_restJson1UnsupportedDocumentEncodingExceptionResponse = asy
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -899,7 +901,7 @@ const deserializeAws_restJson1NamedShadowList = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 

--- a/clients/client-iot-events-data/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-events-data/protocols/Aws_restJson1.ts
@@ -58,6 +58,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -1138,7 +1140,7 @@ export const deserializeAws_restJson1ListAlarmsCommand = async (
     contents.alarmSummaries = deserializeAws_restJson1AlarmSummaries(data.alarmSummaries, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1229,7 +1231,7 @@ export const deserializeAws_restJson1ListDetectorsCommand = async (
     contents.detectorSummaries = deserializeAws_restJson1DetectorSummaries(data.detectorSummaries, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1315,7 +1317,7 @@ const deserializeAws_restJson1InternalFailureExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1332,7 +1334,7 @@ const deserializeAws_restJson1InvalidRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1349,7 +1351,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1366,7 +1368,7 @@ const deserializeAws_restJson1ServiceUnavailableExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1383,7 +1385,7 @@ const deserializeAws_restJson1ThrottlingExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1628,18 +1630,14 @@ const deserializeAws_restJson1AcknowledgeActionConfiguration = (
   context: __SerdeContext
 ): AcknowledgeActionConfiguration => {
   return {
-    note: output.note !== undefined && output.note !== null ? output.note : undefined,
+    note: __expectString(output.note),
   } as any;
 };
 
 const deserializeAws_restJson1Alarm = (output: any, context: __SerdeContext): Alarm => {
   return {
-    alarmModelName:
-      output.alarmModelName !== undefined && output.alarmModelName !== null ? output.alarmModelName : undefined,
-    alarmModelVersion:
-      output.alarmModelVersion !== undefined && output.alarmModelVersion !== null
-        ? output.alarmModelVersion
-        : undefined,
+    alarmModelName: __expectString(output.alarmModelName),
+    alarmModelVersion: __expectString(output.alarmModelVersion),
     alarmState:
       output.alarmState !== undefined && output.alarmState !== null
         ? deserializeAws_restJson1AlarmState(output.alarmState, context)
@@ -1648,12 +1646,12 @@ const deserializeAws_restJson1Alarm = (output: any, context: __SerdeContext): Al
       output.creationTime !== undefined && output.creationTime !== null
         ? new Date(Math.round(output.creationTime * 1000))
         : undefined,
-    keyValue: output.keyValue !== undefined && output.keyValue !== null ? output.keyValue : undefined,
+    keyValue: __expectString(output.keyValue),
     lastUpdateTime:
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
         ? new Date(Math.round(output.lastUpdateTime * 1000))
         : undefined,
-    severity: output.severity !== undefined && output.severity !== null ? output.severity : undefined,
+    severity: __expectNumber(output.severity),
   } as any;
 };
 
@@ -1667,7 +1665,7 @@ const deserializeAws_restJson1AlarmState = (output: any, context: __SerdeContext
       output.ruleEvaluation !== undefined && output.ruleEvaluation !== null
         ? deserializeAws_restJson1RuleEvaluation(output.ruleEvaluation, context)
         : undefined,
-    stateName: output.stateName !== undefined && output.stateName !== null ? output.stateName : undefined,
+    stateName: __expectString(output.stateName),
     systemEvent:
       output.systemEvent !== undefined && output.systemEvent !== null
         ? deserializeAws_restJson1SystemEvent(output.systemEvent, context)
@@ -1688,22 +1686,18 @@ const deserializeAws_restJson1AlarmSummaries = (output: any, context: __SerdeCon
 
 const deserializeAws_restJson1AlarmSummary = (output: any, context: __SerdeContext): AlarmSummary => {
   return {
-    alarmModelName:
-      output.alarmModelName !== undefined && output.alarmModelName !== null ? output.alarmModelName : undefined,
-    alarmModelVersion:
-      output.alarmModelVersion !== undefined && output.alarmModelVersion !== null
-        ? output.alarmModelVersion
-        : undefined,
+    alarmModelName: __expectString(output.alarmModelName),
+    alarmModelVersion: __expectString(output.alarmModelVersion),
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
         ? new Date(Math.round(output.creationTime * 1000))
         : undefined,
-    keyValue: output.keyValue !== undefined && output.keyValue !== null ? output.keyValue : undefined,
+    keyValue: __expectString(output.keyValue),
     lastUpdateTime:
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
         ? new Date(Math.round(output.lastUpdateTime * 1000))
         : undefined,
-    stateName: output.stateName !== undefined && output.stateName !== null ? output.stateName : undefined,
+    stateName: __expectString(output.stateName),
   } as any;
 };
 
@@ -1726,9 +1720,9 @@ const deserializeAws_restJson1BatchAlarmActionErrorEntry = (
   context: __SerdeContext
 ): BatchAlarmActionErrorEntry => {
   return {
-    errorCode: output.errorCode !== undefined && output.errorCode !== null ? output.errorCode : undefined,
-    errorMessage: output.errorMessage !== undefined && output.errorMessage !== null ? output.errorMessage : undefined,
-    requestId: output.requestId !== undefined && output.requestId !== null ? output.requestId : undefined,
+    errorCode: __expectString(output.errorCode),
+    errorMessage: __expectString(output.errorMessage),
+    requestId: __expectString(output.requestId),
   } as any;
 };
 
@@ -1751,9 +1745,9 @@ const deserializeAws_restJson1BatchPutMessageErrorEntry = (
   context: __SerdeContext
 ): BatchPutMessageErrorEntry => {
   return {
-    errorCode: output.errorCode !== undefined && output.errorCode !== null ? output.errorCode : undefined,
-    errorMessage: output.errorMessage !== undefined && output.errorMessage !== null ? output.errorMessage : undefined,
-    messageId: output.messageId !== undefined && output.messageId !== null ? output.messageId : undefined,
+    errorCode: __expectString(output.errorCode),
+    errorMessage: __expectString(output.errorMessage),
+    messageId: __expectString(output.messageId),
   } as any;
 };
 
@@ -1776,9 +1770,9 @@ const deserializeAws_restJson1BatchUpdateDetectorErrorEntry = (
   context: __SerdeContext
 ): BatchUpdateDetectorErrorEntry => {
   return {
-    errorCode: output.errorCode !== undefined && output.errorCode !== null ? output.errorCode : undefined,
-    errorMessage: output.errorMessage !== undefined && output.errorMessage !== null ? output.errorMessage : undefined,
-    messageId: output.messageId !== undefined && output.messageId !== null ? output.messageId : undefined,
+    errorCode: __expectString(output.errorCode),
+    errorMessage: __expectString(output.errorMessage),
+    messageId: __expectString(output.messageId),
   } as any;
 };
 
@@ -1788,7 +1782,7 @@ const deserializeAws_restJson1CustomerAction = (output: any, context: __SerdeCon
       output.acknowledgeActionConfiguration !== undefined && output.acknowledgeActionConfiguration !== null
         ? deserializeAws_restJson1AcknowledgeActionConfiguration(output.acknowledgeActionConfiguration, context)
         : undefined,
-    actionName: output.actionName !== undefined && output.actionName !== null ? output.actionName : undefined,
+    actionName: __expectString(output.actionName),
     disableActionConfiguration:
       output.disableActionConfiguration !== undefined && output.disableActionConfiguration !== null
         ? deserializeAws_restJson1DisableActionConfiguration(output.disableActionConfiguration, context)
@@ -1814,15 +1808,9 @@ const deserializeAws_restJson1Detector = (output: any, context: __SerdeContext):
       output.creationTime !== undefined && output.creationTime !== null
         ? new Date(Math.round(output.creationTime * 1000))
         : undefined,
-    detectorModelName:
-      output.detectorModelName !== undefined && output.detectorModelName !== null
-        ? output.detectorModelName
-        : undefined,
-    detectorModelVersion:
-      output.detectorModelVersion !== undefined && output.detectorModelVersion !== null
-        ? output.detectorModelVersion
-        : undefined,
-    keyValue: output.keyValue !== undefined && output.keyValue !== null ? output.keyValue : undefined,
+    detectorModelName: __expectString(output.detectorModelName),
+    detectorModelVersion: __expectString(output.detectorModelVersion),
+    keyValue: __expectString(output.keyValue),
     lastUpdateTime:
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
         ? new Date(Math.round(output.lastUpdateTime * 1000))
@@ -1836,7 +1824,7 @@ const deserializeAws_restJson1Detector = (output: any, context: __SerdeContext):
 
 const deserializeAws_restJson1DetectorState = (output: any, context: __SerdeContext): DetectorState => {
   return {
-    stateName: output.stateName !== undefined && output.stateName !== null ? output.stateName : undefined,
+    stateName: __expectString(output.stateName),
     timers:
       output.timers !== undefined && output.timers !== null
         ? deserializeAws_restJson1Timers(output.timers, context)
@@ -1850,7 +1838,7 @@ const deserializeAws_restJson1DetectorState = (output: any, context: __SerdeCont
 
 const deserializeAws_restJson1DetectorStateSummary = (output: any, context: __SerdeContext): DetectorStateSummary => {
   return {
-    stateName: output.stateName !== undefined && output.stateName !== null ? output.stateName : undefined,
+    stateName: __expectString(output.stateName),
   } as any;
 };
 
@@ -1871,15 +1859,9 @@ const deserializeAws_restJson1DetectorSummary = (output: any, context: __SerdeCo
       output.creationTime !== undefined && output.creationTime !== null
         ? new Date(Math.round(output.creationTime * 1000))
         : undefined,
-    detectorModelName:
-      output.detectorModelName !== undefined && output.detectorModelName !== null
-        ? output.detectorModelName
-        : undefined,
-    detectorModelVersion:
-      output.detectorModelVersion !== undefined && output.detectorModelVersion !== null
-        ? output.detectorModelVersion
-        : undefined,
-    keyValue: output.keyValue !== undefined && output.keyValue !== null ? output.keyValue : undefined,
+    detectorModelName: __expectString(output.detectorModelName),
+    detectorModelVersion: __expectString(output.detectorModelVersion),
+    keyValue: __expectString(output.keyValue),
     lastUpdateTime:
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
         ? new Date(Math.round(output.lastUpdateTime * 1000))
@@ -1896,7 +1878,7 @@ const deserializeAws_restJson1DisableActionConfiguration = (
   context: __SerdeContext
 ): DisableActionConfiguration => {
   return {
-    note: output.note !== undefined && output.note !== null ? output.note : undefined,
+    note: __expectString(output.note),
   } as any;
 };
 
@@ -1905,7 +1887,7 @@ const deserializeAws_restJson1EnableActionConfiguration = (
   context: __SerdeContext
 ): EnableActionConfiguration => {
   return {
-    note: output.note !== undefined && output.note !== null ? output.note : undefined,
+    note: __expectString(output.note),
   } as any;
 };
 
@@ -1914,7 +1896,7 @@ const deserializeAws_restJson1ResetActionConfiguration = (
   context: __SerdeContext
 ): ResetActionConfiguration => {
   return {
-    note: output.note !== undefined && output.note !== null ? output.note : undefined,
+    note: __expectString(output.note),
   } as any;
 };
 
@@ -1929,13 +1911,9 @@ const deserializeAws_restJson1RuleEvaluation = (output: any, context: __SerdeCon
 
 const deserializeAws_restJson1SimpleRuleEvaluation = (output: any, context: __SerdeContext): SimpleRuleEvaluation => {
   return {
-    inputPropertyValue:
-      output.inputPropertyValue !== undefined && output.inputPropertyValue !== null
-        ? output.inputPropertyValue
-        : undefined,
-    operator: output.operator !== undefined && output.operator !== null ? output.operator : undefined,
-    thresholdValue:
-      output.thresholdValue !== undefined && output.thresholdValue !== null ? output.thresholdValue : undefined,
+    inputPropertyValue: __expectString(output.inputPropertyValue),
+    operator: __expectString(output.operator),
+    thresholdValue: __expectString(output.thresholdValue),
   } as any;
 };
 
@@ -1944,9 +1922,8 @@ const deserializeAws_restJson1SnoozeActionConfiguration = (
   context: __SerdeContext
 ): SnoozeActionConfiguration => {
   return {
-    note: output.note !== undefined && output.note !== null ? output.note : undefined,
-    snoozeDuration:
-      output.snoozeDuration !== undefined && output.snoozeDuration !== null ? output.snoozeDuration : undefined,
+    note: __expectString(output.note),
+    snoozeDuration: __expectNumber(output.snoozeDuration),
   } as any;
 };
 
@@ -1955,13 +1932,13 @@ const deserializeAws_restJson1StateChangeConfiguration = (
   context: __SerdeContext
 ): StateChangeConfiguration => {
   return {
-    triggerType: output.triggerType !== undefined && output.triggerType !== null ? output.triggerType : undefined,
+    triggerType: __expectString(output.triggerType),
   } as any;
 };
 
 const deserializeAws_restJson1SystemEvent = (output: any, context: __SerdeContext): SystemEvent => {
   return {
-    eventType: output.eventType !== undefined && output.eventType !== null ? output.eventType : undefined,
+    eventType: __expectString(output.eventType),
     stateChangeConfiguration:
       output.stateChangeConfiguration !== undefined && output.stateChangeConfiguration !== null
         ? deserializeAws_restJson1StateChangeConfiguration(output.stateChangeConfiguration, context)
@@ -1971,7 +1948,7 @@ const deserializeAws_restJson1SystemEvent = (output: any, context: __SerdeContex
 
 const deserializeAws_restJson1Timer = (output: any, context: __SerdeContext): Timer => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
     timestamp:
       output.timestamp !== undefined && output.timestamp !== null
         ? new Date(Math.round(output.timestamp * 1000))
@@ -1992,8 +1969,8 @@ const deserializeAws_restJson1Timers = (output: any, context: __SerdeContext): T
 
 const deserializeAws_restJson1Variable = (output: any, context: __SerdeContext): Variable => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    name: __expectString(output.name),
+    value: __expectString(output.value),
   } as any;
 };
 

--- a/clients/client-iot-events/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-events/protocols/Aws_restJson1.ts
@@ -133,6 +133,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -955,10 +958,10 @@ export const deserializeAws_restJson1CreateAlarmModelCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.alarmModelArn !== undefined && data.alarmModelArn !== null) {
-    contents.alarmModelArn = data.alarmModelArn;
+    contents.alarmModelArn = __expectString(data.alarmModelArn);
   }
   if (data.alarmModelVersion !== undefined && data.alarmModelVersion !== null) {
-    contents.alarmModelVersion = data.alarmModelVersion;
+    contents.alarmModelVersion = __expectString(data.alarmModelVersion);
   }
   if (data.creationTime !== undefined && data.creationTime !== null) {
     contents.creationTime = new Date(Math.round(data.creationTime * 1000));
@@ -967,7 +970,7 @@ export const deserializeAws_restJson1CreateAlarmModelCommand = async (
     contents.lastUpdateTime = new Date(Math.round(data.lastUpdateTime * 1000));
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.status = data.status;
+    contents.status = __expectString(data.status);
   }
   return Promise.resolve(contents);
 };
@@ -1556,16 +1559,16 @@ export const deserializeAws_restJson1DescribeAlarmModelCommand = async (
     contents.alarmEventActions = deserializeAws_restJson1AlarmEventActions(data.alarmEventActions, context);
   }
   if (data.alarmModelArn !== undefined && data.alarmModelArn !== null) {
-    contents.alarmModelArn = data.alarmModelArn;
+    contents.alarmModelArn = __expectString(data.alarmModelArn);
   }
   if (data.alarmModelDescription !== undefined && data.alarmModelDescription !== null) {
-    contents.alarmModelDescription = data.alarmModelDescription;
+    contents.alarmModelDescription = __expectString(data.alarmModelDescription);
   }
   if (data.alarmModelName !== undefined && data.alarmModelName !== null) {
-    contents.alarmModelName = data.alarmModelName;
+    contents.alarmModelName = __expectString(data.alarmModelName);
   }
   if (data.alarmModelVersion !== undefined && data.alarmModelVersion !== null) {
-    contents.alarmModelVersion = data.alarmModelVersion;
+    contents.alarmModelVersion = __expectString(data.alarmModelVersion);
   }
   if (data.alarmNotification !== undefined && data.alarmNotification !== null) {
     contents.alarmNotification = deserializeAws_restJson1AlarmNotification(data.alarmNotification, context);
@@ -1577,22 +1580,22 @@ export const deserializeAws_restJson1DescribeAlarmModelCommand = async (
     contents.creationTime = new Date(Math.round(data.creationTime * 1000));
   }
   if (data.key !== undefined && data.key !== null) {
-    contents.key = data.key;
+    contents.key = __expectString(data.key);
   }
   if (data.lastUpdateTime !== undefined && data.lastUpdateTime !== null) {
     contents.lastUpdateTime = new Date(Math.round(data.lastUpdateTime * 1000));
   }
   if (data.roleArn !== undefined && data.roleArn !== null) {
-    contents.roleArn = data.roleArn;
+    contents.roleArn = __expectString(data.roleArn);
   }
   if (data.severity !== undefined && data.severity !== null) {
-    contents.severity = data.severity;
+    contents.severity = __expectNumber(data.severity);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.status = data.status;
+    contents.status = __expectString(data.status);
   }
   if (data.statusMessage !== undefined && data.statusMessage !== null) {
-    contents.statusMessage = data.statusMessage;
+    contents.statusMessage = __expectString(data.statusMessage);
   }
   return Promise.resolve(contents);
 };
@@ -1766,7 +1769,7 @@ export const deserializeAws_restJson1DescribeDetectorModelAnalysisCommand = asyn
   };
   const data: any = await parseBody(output.body, context);
   if (data.status !== undefined && data.status !== null) {
-    contents.status = data.status;
+    contents.status = __expectString(data.status);
   }
   return Promise.resolve(contents);
 };
@@ -2039,7 +2042,7 @@ export const deserializeAws_restJson1GetDetectorModelAnalysisResultsCommand = as
     contents.analysisResults = deserializeAws_restJson1AnalysisResults(data.analysisResults, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2130,7 +2133,7 @@ export const deserializeAws_restJson1ListAlarmModelsCommand = async (
     contents.alarmModelSummaries = deserializeAws_restJson1AlarmModelSummaries(data.alarmModelSummaries, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2216,7 +2219,7 @@ export const deserializeAws_restJson1ListAlarmModelVersionsCommand = async (
     );
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2310,7 +2313,7 @@ export const deserializeAws_restJson1ListDetectorModelsCommand = async (
     );
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2396,7 +2399,7 @@ export const deserializeAws_restJson1ListDetectorModelVersionsCommand = async (
     );
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2484,7 +2487,7 @@ export const deserializeAws_restJson1ListInputRoutingsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.routedResources !== undefined && data.routedResources !== null) {
     contents.routedResources = deserializeAws_restJson1RoutedResources(data.routedResources, context);
@@ -2578,7 +2581,7 @@ export const deserializeAws_restJson1ListInputsCommand = async (
     contents.inputSummaries = deserializeAws_restJson1InputSummaries(data.inputSummaries, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2835,7 +2838,7 @@ export const deserializeAws_restJson1StartDetectorModelAnalysisCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.analysisId !== undefined && data.analysisId !== null) {
-    contents.analysisId = data.analysisId;
+    contents.analysisId = __expectString(data.analysisId);
   }
   return Promise.resolve(contents);
 };
@@ -3100,10 +3103,10 @@ export const deserializeAws_restJson1UpdateAlarmModelCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.alarmModelArn !== undefined && data.alarmModelArn !== null) {
-    contents.alarmModelArn = data.alarmModelArn;
+    contents.alarmModelArn = __expectString(data.alarmModelArn);
   }
   if (data.alarmModelVersion !== undefined && data.alarmModelVersion !== null) {
-    contents.alarmModelVersion = data.alarmModelVersion;
+    contents.alarmModelVersion = __expectString(data.alarmModelVersion);
   }
   if (data.creationTime !== undefined && data.creationTime !== null) {
     contents.creationTime = new Date(Math.round(data.creationTime * 1000));
@@ -3112,7 +3115,7 @@ export const deserializeAws_restJson1UpdateAlarmModelCommand = async (
     contents.lastUpdateTime = new Date(Math.round(data.lastUpdateTime * 1000));
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.status = data.status;
+    contents.status = __expectString(data.status);
   }
   return Promise.resolve(contents);
 };
@@ -3399,7 +3402,7 @@ const deserializeAws_restJson1InternalFailureExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -3416,7 +3419,7 @@ const deserializeAws_restJson1InvalidRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -3433,7 +3436,7 @@ const deserializeAws_restJson1LimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -3452,13 +3455,13 @@ const deserializeAws_restJson1ResourceAlreadyExistsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.resourceArn !== undefined && data.resourceArn !== null) {
-    contents.resourceArn = data.resourceArn;
+    contents.resourceArn = __expectString(data.resourceArn);
   }
   if (data.resourceId !== undefined && data.resourceId !== null) {
-    contents.resourceId = data.resourceId;
+    contents.resourceId = __expectString(data.resourceId);
   }
   return contents;
 };
@@ -3475,7 +3478,7 @@ const deserializeAws_restJson1ResourceInUseExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -3492,7 +3495,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -3509,7 +3512,7 @@ const deserializeAws_restJson1ServiceUnavailableExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -3526,7 +3529,7 @@ const deserializeAws_restJson1ThrottlingExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -3543,7 +3546,7 @@ const deserializeAws_restJson1UnsupportedOperationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -4196,7 +4199,7 @@ const serializeAws_restJson1TransitionEvents = (input: TransitionEvent[], contex
 
 const deserializeAws_restJson1AcknowledgeFlow = (output: any, context: __SerdeContext): AcknowledgeFlow => {
   return {
-    enabled: output.enabled !== undefined && output.enabled !== null ? output.enabled : undefined,
+    enabled: __expectBoolean(output.enabled),
   } as any;
 };
 
@@ -4355,12 +4358,8 @@ const deserializeAws_restJson1AlarmModelSummaries = (output: any, context: __Ser
 
 const deserializeAws_restJson1AlarmModelSummary = (output: any, context: __SerdeContext): AlarmModelSummary => {
   return {
-    alarmModelDescription:
-      output.alarmModelDescription !== undefined && output.alarmModelDescription !== null
-        ? output.alarmModelDescription
-        : undefined,
-    alarmModelName:
-      output.alarmModelName !== undefined && output.alarmModelName !== null ? output.alarmModelName : undefined,
+    alarmModelDescription: __expectString(output.alarmModelDescription),
+    alarmModelName: __expectString(output.alarmModelName),
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
         ? new Date(Math.round(output.creationTime * 1000))
@@ -4387,14 +4386,9 @@ const deserializeAws_restJson1AlarmModelVersionSummary = (
   context: __SerdeContext
 ): AlarmModelVersionSummary => {
   return {
-    alarmModelArn:
-      output.alarmModelArn !== undefined && output.alarmModelArn !== null ? output.alarmModelArn : undefined,
-    alarmModelName:
-      output.alarmModelName !== undefined && output.alarmModelName !== null ? output.alarmModelName : undefined,
-    alarmModelVersion:
-      output.alarmModelVersion !== undefined && output.alarmModelVersion !== null
-        ? output.alarmModelVersion
-        : undefined,
+    alarmModelArn: __expectString(output.alarmModelArn),
+    alarmModelName: __expectString(output.alarmModelName),
+    alarmModelVersion: __expectString(output.alarmModelVersion),
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
         ? new Date(Math.round(output.creationTime * 1000))
@@ -4403,10 +4397,9 @@ const deserializeAws_restJson1AlarmModelVersionSummary = (
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
         ? new Date(Math.round(output.lastUpdateTime * 1000))
         : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    statusMessage:
-      output.statusMessage !== undefined && output.statusMessage !== null ? output.statusMessage : undefined,
+    roleArn: __expectString(output.roleArn),
+    status: __expectString(output.status),
+    statusMessage: __expectString(output.statusMessage),
   } as any;
 };
 
@@ -4430,13 +4423,13 @@ const deserializeAws_restJson1AlarmRule = (output: any, context: __SerdeContext)
 
 const deserializeAws_restJson1AnalysisResult = (output: any, context: __SerdeContext): AnalysisResult => {
   return {
-    level: output.level !== undefined && output.level !== null ? output.level : undefined,
+    level: __expectString(output.level),
     locations:
       output.locations !== undefined && output.locations !== null
         ? deserializeAws_restJson1AnalysisResultLocations(output.locations, context)
         : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    message: __expectString(output.message),
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -4445,7 +4438,7 @@ const deserializeAws_restJson1AnalysisResultLocation = (
   context: __SerdeContext
 ): AnalysisResultLocation => {
   return {
-    path: output.path !== undefined && output.path !== null ? output.path : undefined,
+    path: __expectString(output.path),
   } as any;
 };
 
@@ -4479,16 +4472,14 @@ const deserializeAws_restJson1AssetPropertyTimestamp = (
   context: __SerdeContext
 ): AssetPropertyTimestamp => {
   return {
-    offsetInNanos:
-      output.offsetInNanos !== undefined && output.offsetInNanos !== null ? output.offsetInNanos : undefined,
-    timeInSeconds:
-      output.timeInSeconds !== undefined && output.timeInSeconds !== null ? output.timeInSeconds : undefined,
+    offsetInNanos: __expectString(output.offsetInNanos),
+    timeInSeconds: __expectString(output.timeInSeconds),
   } as any;
 };
 
 const deserializeAws_restJson1AssetPropertyValue = (output: any, context: __SerdeContext): AssetPropertyValue => {
   return {
-    quality: output.quality !== undefined && output.quality !== null ? output.quality : undefined,
+    quality: __expectString(output.quality),
     timestamp:
       output.timestamp !== undefined && output.timestamp !== null
         ? deserializeAws_restJson1AssetPropertyTimestamp(output.timestamp, context)
@@ -4502,16 +4493,16 @@ const deserializeAws_restJson1AssetPropertyValue = (output: any, context: __Serd
 
 const deserializeAws_restJson1AssetPropertyVariant = (output: any, context: __SerdeContext): AssetPropertyVariant => {
   return {
-    booleanValue: output.booleanValue !== undefined && output.booleanValue !== null ? output.booleanValue : undefined,
-    doubleValue: output.doubleValue !== undefined && output.doubleValue !== null ? output.doubleValue : undefined,
-    integerValue: output.integerValue !== undefined && output.integerValue !== null ? output.integerValue : undefined,
-    stringValue: output.stringValue !== undefined && output.stringValue !== null ? output.stringValue : undefined,
+    booleanValue: __expectString(output.booleanValue),
+    doubleValue: __expectString(output.doubleValue),
+    integerValue: __expectString(output.integerValue),
+    stringValue: __expectString(output.stringValue),
   } as any;
 };
 
 const deserializeAws_restJson1Attribute = (output: any, context: __SerdeContext): Attribute => {
   return {
-    jsonPath: output.jsonPath !== undefined && output.jsonPath !== null ? output.jsonPath : undefined,
+    jsonPath: __expectString(output.jsonPath),
   } as any;
 };
 
@@ -4528,17 +4519,14 @@ const deserializeAws_restJson1Attributes = (output: any, context: __SerdeContext
 
 const deserializeAws_restJson1ClearTimerAction = (output: any, context: __SerdeContext): ClearTimerAction => {
   return {
-    timerName: output.timerName !== undefined && output.timerName !== null ? output.timerName : undefined,
+    timerName: __expectString(output.timerName),
   } as any;
 };
 
 const deserializeAws_restJson1DetectorDebugOption = (output: any, context: __SerdeContext): DetectorDebugOption => {
   return {
-    detectorModelName:
-      output.detectorModelName !== undefined && output.detectorModelName !== null
-        ? output.detectorModelName
-        : undefined,
-    keyValue: output.keyValue !== undefined && output.keyValue !== null ? output.keyValue : undefined,
+    detectorModelName: __expectString(output.detectorModelName),
+    keyValue: __expectString(output.keyValue),
   } as any;
 };
 
@@ -4575,29 +4563,18 @@ const deserializeAws_restJson1DetectorModelConfiguration = (
       output.creationTime !== undefined && output.creationTime !== null
         ? new Date(Math.round(output.creationTime * 1000))
         : undefined,
-    detectorModelArn:
-      output.detectorModelArn !== undefined && output.detectorModelArn !== null ? output.detectorModelArn : undefined,
-    detectorModelDescription:
-      output.detectorModelDescription !== undefined && output.detectorModelDescription !== null
-        ? output.detectorModelDescription
-        : undefined,
-    detectorModelName:
-      output.detectorModelName !== undefined && output.detectorModelName !== null
-        ? output.detectorModelName
-        : undefined,
-    detectorModelVersion:
-      output.detectorModelVersion !== undefined && output.detectorModelVersion !== null
-        ? output.detectorModelVersion
-        : undefined,
-    evaluationMethod:
-      output.evaluationMethod !== undefined && output.evaluationMethod !== null ? output.evaluationMethod : undefined,
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
+    detectorModelArn: __expectString(output.detectorModelArn),
+    detectorModelDescription: __expectString(output.detectorModelDescription),
+    detectorModelName: __expectString(output.detectorModelName),
+    detectorModelVersion: __expectString(output.detectorModelVersion),
+    evaluationMethod: __expectString(output.evaluationMethod),
+    key: __expectString(output.key),
     lastUpdateTime:
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
         ? new Date(Math.round(output.lastUpdateTime * 1000))
         : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    roleArn: __expectString(output.roleArn),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -4606,8 +4583,7 @@ const deserializeAws_restJson1DetectorModelDefinition = (
   context: __SerdeContext
 ): DetectorModelDefinition => {
   return {
-    initialStateName:
-      output.initialStateName !== undefined && output.initialStateName !== null ? output.initialStateName : undefined,
+    initialStateName: __expectString(output.initialStateName),
     states:
       output.states !== undefined && output.states !== null
         ? deserializeAws_restJson1States(output.states, context)
@@ -4635,14 +4611,8 @@ const deserializeAws_restJson1DetectorModelSummary = (output: any, context: __Se
       output.creationTime !== undefined && output.creationTime !== null
         ? new Date(Math.round(output.creationTime * 1000))
         : undefined,
-    detectorModelDescription:
-      output.detectorModelDescription !== undefined && output.detectorModelDescription !== null
-        ? output.detectorModelDescription
-        : undefined,
-    detectorModelName:
-      output.detectorModelName !== undefined && output.detectorModelName !== null
-        ? output.detectorModelName
-        : undefined,
+    detectorModelDescription: __expectString(output.detectorModelDescription),
+    detectorModelName: __expectString(output.detectorModelName),
   } as any;
 };
 
@@ -4669,44 +4639,34 @@ const deserializeAws_restJson1DetectorModelVersionSummary = (
       output.creationTime !== undefined && output.creationTime !== null
         ? new Date(Math.round(output.creationTime * 1000))
         : undefined,
-    detectorModelArn:
-      output.detectorModelArn !== undefined && output.detectorModelArn !== null ? output.detectorModelArn : undefined,
-    detectorModelName:
-      output.detectorModelName !== undefined && output.detectorModelName !== null
-        ? output.detectorModelName
-        : undefined,
-    detectorModelVersion:
-      output.detectorModelVersion !== undefined && output.detectorModelVersion !== null
-        ? output.detectorModelVersion
-        : undefined,
-    evaluationMethod:
-      output.evaluationMethod !== undefined && output.evaluationMethod !== null ? output.evaluationMethod : undefined,
+    detectorModelArn: __expectString(output.detectorModelArn),
+    detectorModelName: __expectString(output.detectorModelName),
+    detectorModelVersion: __expectString(output.detectorModelVersion),
+    evaluationMethod: __expectString(output.evaluationMethod),
     lastUpdateTime:
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
         ? new Date(Math.round(output.lastUpdateTime * 1000))
         : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    roleArn: __expectString(output.roleArn),
+    status: __expectString(output.status),
   } as any;
 };
 
 const deserializeAws_restJson1DynamoDBAction = (output: any, context: __SerdeContext): DynamoDBAction => {
   return {
-    hashKeyField: output.hashKeyField !== undefined && output.hashKeyField !== null ? output.hashKeyField : undefined,
-    hashKeyType: output.hashKeyType !== undefined && output.hashKeyType !== null ? output.hashKeyType : undefined,
-    hashKeyValue: output.hashKeyValue !== undefined && output.hashKeyValue !== null ? output.hashKeyValue : undefined,
-    operation: output.operation !== undefined && output.operation !== null ? output.operation : undefined,
+    hashKeyField: __expectString(output.hashKeyField),
+    hashKeyType: __expectString(output.hashKeyType),
+    hashKeyValue: __expectString(output.hashKeyValue),
+    operation: __expectString(output.operation),
     payload:
       output.payload !== undefined && output.payload !== null
         ? deserializeAws_restJson1Payload(output.payload, context)
         : undefined,
-    payloadField: output.payloadField !== undefined && output.payloadField !== null ? output.payloadField : undefined,
-    rangeKeyField:
-      output.rangeKeyField !== undefined && output.rangeKeyField !== null ? output.rangeKeyField : undefined,
-    rangeKeyType: output.rangeKeyType !== undefined && output.rangeKeyType !== null ? output.rangeKeyType : undefined,
-    rangeKeyValue:
-      output.rangeKeyValue !== undefined && output.rangeKeyValue !== null ? output.rangeKeyValue : undefined,
-    tableName: output.tableName !== undefined && output.tableName !== null ? output.tableName : undefined,
+    payloadField: __expectString(output.payloadField),
+    rangeKeyField: __expectString(output.rangeKeyField),
+    rangeKeyType: __expectString(output.rangeKeyType),
+    rangeKeyValue: __expectString(output.rangeKeyValue),
+    tableName: __expectString(output.tableName),
   } as any;
 };
 
@@ -4716,7 +4676,7 @@ const deserializeAws_restJson1DynamoDBv2Action = (output: any, context: __SerdeC
       output.payload !== undefined && output.payload !== null
         ? deserializeAws_restJson1Payload(output.payload, context)
         : undefined,
-    tableName: output.tableName !== undefined && output.tableName !== null ? output.tableName : undefined,
+    tableName: __expectString(output.tableName),
   } as any;
 };
 
@@ -4726,7 +4686,7 @@ const deserializeAws_restJson1EmailConfiguration = (output: any, context: __Serd
       output.content !== undefined && output.content !== null
         ? deserializeAws_restJson1EmailContent(output.content, context)
         : undefined,
-    from: output.from !== undefined && output.from !== null ? output.from : undefined,
+    from: __expectString(output.from),
     recipients:
       output.recipients !== undefined && output.recipients !== null
         ? deserializeAws_restJson1EmailRecipients(output.recipients, context)
@@ -4747,11 +4707,8 @@ const deserializeAws_restJson1EmailConfigurations = (output: any, context: __Ser
 
 const deserializeAws_restJson1EmailContent = (output: any, context: __SerdeContext): EmailContent => {
   return {
-    additionalMessage:
-      output.additionalMessage !== undefined && output.additionalMessage !== null
-        ? output.additionalMessage
-        : undefined,
-    subject: output.subject !== undefined && output.subject !== null ? output.subject : undefined,
+    additionalMessage: __expectString(output.additionalMessage),
+    subject: __expectString(output.subject),
   } as any;
 };
 
@@ -4770,8 +4727,8 @@ const deserializeAws_restJson1Event = (output: any, context: __SerdeContext): Ev
       output.actions !== undefined && output.actions !== null
         ? deserializeAws_restJson1Actions(output.actions, context)
         : undefined,
-    condition: output.condition !== undefined && output.condition !== null ? output.condition : undefined,
-    eventName: output.eventName !== undefined && output.eventName !== null ? output.eventName : undefined,
+    condition: __expectString(output.condition),
+    eventName: __expectString(output.eventName),
   } as any;
 };
 
@@ -4788,15 +4745,12 @@ const deserializeAws_restJson1Events = (output: any, context: __SerdeContext): E
 
 const deserializeAws_restJson1FirehoseAction = (output: any, context: __SerdeContext): FirehoseAction => {
   return {
-    deliveryStreamName:
-      output.deliveryStreamName !== undefined && output.deliveryStreamName !== null
-        ? output.deliveryStreamName
-        : undefined,
+    deliveryStreamName: __expectString(output.deliveryStreamName),
     payload:
       output.payload !== undefined && output.payload !== null
         ? deserializeAws_restJson1Payload(output.payload, context)
         : undefined,
-    separator: output.separator !== undefined && output.separator !== null ? output.separator : undefined,
+    separator: __expectString(output.separator),
   } as any;
 };
 
@@ -4805,10 +4759,7 @@ const deserializeAws_restJson1InitializationConfiguration = (
   context: __SerdeContext
 ): InitializationConfiguration => {
   return {
-    disabledOnInitialization:
-      output.disabledOnInitialization !== undefined && output.disabledOnInitialization !== null
-        ? output.disabledOnInitialization
-        : undefined,
+    disabledOnInitialization: __expectBoolean(output.disabledOnInitialization),
   } as any;
 };
 
@@ -4831,15 +4782,14 @@ const deserializeAws_restJson1InputConfiguration = (output: any, context: __Serd
       output.creationTime !== undefined && output.creationTime !== null
         ? new Date(Math.round(output.creationTime * 1000))
         : undefined,
-    inputArn: output.inputArn !== undefined && output.inputArn !== null ? output.inputArn : undefined,
-    inputDescription:
-      output.inputDescription !== undefined && output.inputDescription !== null ? output.inputDescription : undefined,
-    inputName: output.inputName !== undefined && output.inputName !== null ? output.inputName : undefined,
+    inputArn: __expectString(output.inputArn),
+    inputDescription: __expectString(output.inputDescription),
+    inputName: __expectString(output.inputName),
     lastUpdateTime:
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
         ? new Date(Math.round(output.lastUpdateTime * 1000))
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -4869,21 +4819,20 @@ const deserializeAws_restJson1InputSummary = (output: any, context: __SerdeConte
       output.creationTime !== undefined && output.creationTime !== null
         ? new Date(Math.round(output.creationTime * 1000))
         : undefined,
-    inputArn: output.inputArn !== undefined && output.inputArn !== null ? output.inputArn : undefined,
-    inputDescription:
-      output.inputDescription !== undefined && output.inputDescription !== null ? output.inputDescription : undefined,
-    inputName: output.inputName !== undefined && output.inputName !== null ? output.inputName : undefined,
+    inputArn: __expectString(output.inputArn),
+    inputDescription: __expectString(output.inputDescription),
+    inputName: __expectString(output.inputName),
     lastUpdateTime:
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
         ? new Date(Math.round(output.lastUpdateTime * 1000))
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
   } as any;
 };
 
 const deserializeAws_restJson1IotEventsAction = (output: any, context: __SerdeContext): IotEventsAction => {
   return {
-    inputName: output.inputName !== undefined && output.inputName !== null ? output.inputName : undefined,
+    inputName: __expectString(output.inputName),
     payload:
       output.payload !== undefined && output.payload !== null
         ? deserializeAws_restJson1Payload(output.payload, context)
@@ -4893,11 +4842,10 @@ const deserializeAws_restJson1IotEventsAction = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1IotSiteWiseAction = (output: any, context: __SerdeContext): IotSiteWiseAction => {
   return {
-    assetId: output.assetId !== undefined && output.assetId !== null ? output.assetId : undefined,
-    entryId: output.entryId !== undefined && output.entryId !== null ? output.entryId : undefined,
-    propertyAlias:
-      output.propertyAlias !== undefined && output.propertyAlias !== null ? output.propertyAlias : undefined,
-    propertyId: output.propertyId !== undefined && output.propertyId !== null ? output.propertyId : undefined,
+    assetId: __expectString(output.assetId),
+    entryId: __expectString(output.entryId),
+    propertyAlias: __expectString(output.propertyAlias),
+    propertyId: __expectString(output.propertyId),
     propertyValue:
       output.propertyValue !== undefined && output.propertyValue !== null
         ? deserializeAws_restJson1AssetPropertyValue(output.propertyValue, context)
@@ -4907,7 +4855,7 @@ const deserializeAws_restJson1IotSiteWiseAction = (output: any, context: __Serde
 
 const deserializeAws_restJson1IotTopicPublishAction = (output: any, context: __SerdeContext): IotTopicPublishAction => {
   return {
-    mqttTopic: output.mqttTopic !== undefined && output.mqttTopic !== null ? output.mqttTopic : undefined,
+    mqttTopic: __expectString(output.mqttTopic),
     payload:
       output.payload !== undefined && output.payload !== null
         ? deserializeAws_restJson1Payload(output.payload, context)
@@ -4917,7 +4865,7 @@ const deserializeAws_restJson1IotTopicPublishAction = (output: any, context: __S
 
 const deserializeAws_restJson1LambdaAction = (output: any, context: __SerdeContext): LambdaAction => {
   return {
-    functionArn: output.functionArn !== undefined && output.functionArn !== null ? output.functionArn : undefined,
+    functionArn: __expectString(output.functionArn),
     payload:
       output.payload !== undefined && output.payload !== null
         ? deserializeAws_restJson1Payload(output.payload, context)
@@ -4931,9 +4879,9 @@ const deserializeAws_restJson1LoggingOptions = (output: any, context: __SerdeCon
       output.detectorDebugOptions !== undefined && output.detectorDebugOptions !== null
         ? deserializeAws_restJson1DetectorDebugOptions(output.detectorDebugOptions, context)
         : undefined,
-    enabled: output.enabled !== undefined && output.enabled !== null ? output.enabled : undefined,
-    level: output.level !== undefined && output.level !== null ? output.level : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
+    enabled: __expectBoolean(output.enabled),
+    level: __expectString(output.level),
+    roleArn: __expectString(output.roleArn),
   } as any;
 };
 
@@ -5010,11 +4958,8 @@ const deserializeAws_restJson1OnInputLifecycle = (output: any, context: __SerdeC
 
 const deserializeAws_restJson1Payload = (output: any, context: __SerdeContext): Payload => {
   return {
-    contentExpression:
-      output.contentExpression !== undefined && output.contentExpression !== null
-        ? output.contentExpression
-        : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    contentExpression: __expectString(output.contentExpression),
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -5040,14 +4985,14 @@ const deserializeAws_restJson1RecipientDetails = (output: any, context: __SerdeC
 
 const deserializeAws_restJson1ResetTimerAction = (output: any, context: __SerdeContext): ResetTimerAction => {
   return {
-    timerName: output.timerName !== undefined && output.timerName !== null ? output.timerName : undefined,
+    timerName: __expectString(output.timerName),
   } as any;
 };
 
 const deserializeAws_restJson1RoutedResource = (output: any, context: __SerdeContext): RoutedResource => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    arn: __expectString(output.arn),
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -5064,45 +5009,35 @@ const deserializeAws_restJson1RoutedResources = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1SetTimerAction = (output: any, context: __SerdeContext): SetTimerAction => {
   return {
-    durationExpression:
-      output.durationExpression !== undefined && output.durationExpression !== null
-        ? output.durationExpression
-        : undefined,
-    seconds: output.seconds !== undefined && output.seconds !== null ? output.seconds : undefined,
-    timerName: output.timerName !== undefined && output.timerName !== null ? output.timerName : undefined,
+    durationExpression: __expectString(output.durationExpression),
+    seconds: __expectNumber(output.seconds),
+    timerName: __expectString(output.timerName),
   } as any;
 };
 
 const deserializeAws_restJson1SetVariableAction = (output: any, context: __SerdeContext): SetVariableAction => {
   return {
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
-    variableName: output.variableName !== undefined && output.variableName !== null ? output.variableName : undefined,
+    value: __expectString(output.value),
+    variableName: __expectString(output.variableName),
   } as any;
 };
 
 const deserializeAws_restJson1SimpleRule = (output: any, context: __SerdeContext): SimpleRule => {
   return {
-    comparisonOperator:
-      output.comparisonOperator !== undefined && output.comparisonOperator !== null
-        ? output.comparisonOperator
-        : undefined,
-    inputProperty:
-      output.inputProperty !== undefined && output.inputProperty !== null ? output.inputProperty : undefined,
-    threshold: output.threshold !== undefined && output.threshold !== null ? output.threshold : undefined,
+    comparisonOperator: __expectString(output.comparisonOperator),
+    inputProperty: __expectString(output.inputProperty),
+    threshold: __expectString(output.threshold),
   } as any;
 };
 
 const deserializeAws_restJson1SMSConfiguration = (output: any, context: __SerdeContext): SMSConfiguration => {
   return {
-    additionalMessage:
-      output.additionalMessage !== undefined && output.additionalMessage !== null
-        ? output.additionalMessage
-        : undefined,
+    additionalMessage: __expectString(output.additionalMessage),
     recipients:
       output.recipients !== undefined && output.recipients !== null
         ? deserializeAws_restJson1RecipientDetails(output.recipients, context)
         : undefined,
-    senderId: output.senderId !== undefined && output.senderId !== null ? output.senderId : undefined,
+    senderId: __expectString(output.senderId),
   } as any;
 };
 
@@ -5123,7 +5058,7 @@ const deserializeAws_restJson1SNSTopicPublishAction = (output: any, context: __S
       output.payload !== undefined && output.payload !== null
         ? deserializeAws_restJson1Payload(output.payload, context)
         : undefined,
-    targetArn: output.targetArn !== undefined && output.targetArn !== null ? output.targetArn : undefined,
+    targetArn: __expectString(output.targetArn),
   } as any;
 };
 
@@ -5133,16 +5068,15 @@ const deserializeAws_restJson1SqsAction = (output: any, context: __SerdeContext)
       output.payload !== undefined && output.payload !== null
         ? deserializeAws_restJson1Payload(output.payload, context)
         : undefined,
-    queueUrl: output.queueUrl !== undefined && output.queueUrl !== null ? output.queueUrl : undefined,
-    useBase64: output.useBase64 !== undefined && output.useBase64 !== null ? output.useBase64 : undefined,
+    queueUrl: __expectString(output.queueUrl),
+    useBase64: __expectBoolean(output.useBase64),
   } as any;
 };
 
 const deserializeAws_restJson1SSOIdentity = (output: any, context: __SerdeContext): SSOIdentity => {
   return {
-    identityStoreId:
-      output.identityStoreId !== undefined && output.identityStoreId !== null ? output.identityStoreId : undefined,
-    userId: output.userId !== undefined && output.userId !== null ? output.userId : undefined,
+    identityStoreId: __expectString(output.identityStoreId),
+    userId: __expectString(output.userId),
   } as any;
 };
 
@@ -5160,7 +5094,7 @@ const deserializeAws_restJson1State = (output: any, context: __SerdeContext): St
       output.onInput !== undefined && output.onInput !== null
         ? deserializeAws_restJson1OnInputLifecycle(output.onInput, context)
         : undefined,
-    stateName: output.stateName !== undefined && output.stateName !== null ? output.stateName : undefined,
+    stateName: __expectString(output.stateName),
   } as any;
 };
 
@@ -5177,8 +5111,8 @@ const deserializeAws_restJson1States = (output: any, context: __SerdeContext): S
 
 const deserializeAws_restJson1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    key: __expectString(output.key),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -5199,9 +5133,9 @@ const deserializeAws_restJson1TransitionEvent = (output: any, context: __SerdeCo
       output.actions !== undefined && output.actions !== null
         ? deserializeAws_restJson1Actions(output.actions, context)
         : undefined,
-    condition: output.condition !== undefined && output.condition !== null ? output.condition : undefined,
-    eventName: output.eventName !== undefined && output.eventName !== null ? output.eventName : undefined,
-    nextState: output.nextState !== undefined && output.nextState !== null ? output.nextState : undefined,
+    condition: __expectString(output.condition),
+    eventName: __expectString(output.eventName),
+    nextState: __expectString(output.nextState),
   } as any;
 };
 

--- a/clients/client-iot-jobs-data-plane/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-jobs-data-plane/protocols/Aws_restJson1.ts
@@ -26,6 +26,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -489,7 +491,7 @@ export const deserializeAws_restJson1UpdateJobExecutionCommand = async (
     contents.executionState = deserializeAws_restJson1JobExecutionState(data.executionState, context);
   }
   if (data.jobDocument !== undefined && data.jobDocument !== null) {
-    contents.jobDocument = data.jobDocument;
+    contents.jobDocument = __expectString(data.jobDocument);
   }
   return Promise.resolve(contents);
 };
@@ -583,7 +585,7 @@ const deserializeAws_restJson1CertificateValidationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -600,7 +602,7 @@ const deserializeAws_restJson1InvalidRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -617,7 +619,7 @@ const deserializeAws_restJson1InvalidStateTransitionExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -634,7 +636,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -651,7 +653,7 @@ const deserializeAws_restJson1ServiceUnavailableExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -668,7 +670,7 @@ const deserializeAws_restJson1TerminalStateExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -686,7 +688,7 @@ const deserializeAws_restJson1ThrottlingExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.payload !== undefined && data.payload !== null) {
     contents.payload = context.base64Decoder(data.payload);
@@ -713,59 +715,49 @@ const deserializeAws_restJson1DetailsMap = (output: any, context: __SerdeContext
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1JobExecution = (output: any, context: __SerdeContext): JobExecution => {
   return {
-    approximateSecondsBeforeTimedOut:
-      output.approximateSecondsBeforeTimedOut !== undefined && output.approximateSecondsBeforeTimedOut !== null
-        ? output.approximateSecondsBeforeTimedOut
-        : undefined,
-    executionNumber:
-      output.executionNumber !== undefined && output.executionNumber !== null ? output.executionNumber : undefined,
-    jobDocument: output.jobDocument !== undefined && output.jobDocument !== null ? output.jobDocument : undefined,
-    jobId: output.jobId !== undefined && output.jobId !== null ? output.jobId : undefined,
-    lastUpdatedAt:
-      output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null ? output.lastUpdatedAt : undefined,
-    queuedAt: output.queuedAt !== undefined && output.queuedAt !== null ? output.queuedAt : undefined,
-    startedAt: output.startedAt !== undefined && output.startedAt !== null ? output.startedAt : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    approximateSecondsBeforeTimedOut: __expectNumber(output.approximateSecondsBeforeTimedOut),
+    executionNumber: __expectNumber(output.executionNumber),
+    jobDocument: __expectString(output.jobDocument),
+    jobId: __expectString(output.jobId),
+    lastUpdatedAt: __expectNumber(output.lastUpdatedAt),
+    queuedAt: __expectNumber(output.queuedAt),
+    startedAt: __expectNumber(output.startedAt),
+    status: __expectString(output.status),
     statusDetails:
       output.statusDetails !== undefined && output.statusDetails !== null
         ? deserializeAws_restJson1DetailsMap(output.statusDetails, context)
         : undefined,
-    thingName: output.thingName !== undefined && output.thingName !== null ? output.thingName : undefined,
-    versionNumber:
-      output.versionNumber !== undefined && output.versionNumber !== null ? output.versionNumber : undefined,
+    thingName: __expectString(output.thingName),
+    versionNumber: __expectNumber(output.versionNumber),
   } as any;
 };
 
 const deserializeAws_restJson1JobExecutionState = (output: any, context: __SerdeContext): JobExecutionState => {
   return {
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
     statusDetails:
       output.statusDetails !== undefined && output.statusDetails !== null
         ? deserializeAws_restJson1DetailsMap(output.statusDetails, context)
         : undefined,
-    versionNumber:
-      output.versionNumber !== undefined && output.versionNumber !== null ? output.versionNumber : undefined,
+    versionNumber: __expectNumber(output.versionNumber),
   } as any;
 };
 
 const deserializeAws_restJson1JobExecutionSummary = (output: any, context: __SerdeContext): JobExecutionSummary => {
   return {
-    executionNumber:
-      output.executionNumber !== undefined && output.executionNumber !== null ? output.executionNumber : undefined,
-    jobId: output.jobId !== undefined && output.jobId !== null ? output.jobId : undefined,
-    lastUpdatedAt:
-      output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null ? output.lastUpdatedAt : undefined,
-    queuedAt: output.queuedAt !== undefined && output.queuedAt !== null ? output.queuedAt : undefined,
-    startedAt: output.startedAt !== undefined && output.startedAt !== null ? output.startedAt : undefined,
-    versionNumber:
-      output.versionNumber !== undefined && output.versionNumber !== null ? output.versionNumber : undefined,
+    executionNumber: __expectNumber(output.executionNumber),
+    jobId: __expectString(output.jobId),
+    lastUpdatedAt: __expectNumber(output.lastUpdatedAt),
+    queuedAt: __expectNumber(output.queuedAt),
+    startedAt: __expectNumber(output.startedAt),
+    versionNumber: __expectNumber(output.versionNumber),
   } as any;
 };
 

--- a/clients/client-iot-wireless/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-wireless/protocols/Aws_restJson1.ts
@@ -234,6 +234,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -1943,7 +1946,7 @@ export const deserializeAws_restJson1AssociateAwsAccountWithPartnerAccountComman
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.Sidewalk !== undefined && data.Sidewalk !== null) {
     contents.Sidewalk = deserializeAws_restJson1SidewalkAccountInfo(data.Sidewalk, context);
@@ -2132,7 +2135,7 @@ export const deserializeAws_restJson1AssociateWirelessGatewayWithCertificateComm
   };
   const data: any = await parseBody(output.body, context);
   if (data.IotCertificateId !== undefined && data.IotCertificateId !== null) {
-    contents.IotCertificateId = data.IotCertificateId;
+    contents.IotCertificateId = __expectString(data.IotCertificateId);
   }
   return Promise.resolve(contents);
 };
@@ -2319,10 +2322,10 @@ export const deserializeAws_restJson1CreateDestinationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   return Promise.resolve(contents);
 };
@@ -2418,10 +2421,10 @@ export const deserializeAws_restJson1CreateDeviceProfileCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   return Promise.resolve(contents);
 };
@@ -2509,10 +2512,10 @@ export const deserializeAws_restJson1CreateServiceProfileCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   return Promise.resolve(contents);
 };
@@ -2600,10 +2603,10 @@ export const deserializeAws_restJson1CreateWirelessDeviceCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   return Promise.resolve(contents);
 };
@@ -2699,10 +2702,10 @@ export const deserializeAws_restJson1CreateWirelessGatewayCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   return Promise.resolve(contents);
 };
@@ -2790,10 +2793,10 @@ export const deserializeAws_restJson1CreateWirelessGatewayTaskCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Status !== undefined && data.Status !== null) {
-    contents.Status = data.Status;
+    contents.Status = __expectString(data.Status);
   }
   if (data.WirelessGatewayTaskDefinitionId !== undefined && data.WirelessGatewayTaskDefinitionId !== null) {
-    contents.WirelessGatewayTaskDefinitionId = data.WirelessGatewayTaskDefinitionId;
+    contents.WirelessGatewayTaskDefinitionId = __expectString(data.WirelessGatewayTaskDefinitionId);
   }
   return Promise.resolve(contents);
 };
@@ -2889,10 +2892,10 @@ export const deserializeAws_restJson1CreateWirelessGatewayTaskDefinitionCommand 
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   return Promise.resolve(contents);
 };
@@ -3937,22 +3940,22 @@ export const deserializeAws_restJson1GetDestinationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.Expression !== undefined && data.Expression !== null) {
-    contents.Expression = data.Expression;
+    contents.Expression = __expectString(data.Expression);
   }
   if (data.ExpressionType !== undefined && data.ExpressionType !== null) {
-    contents.ExpressionType = data.ExpressionType;
+    contents.ExpressionType = __expectString(data.ExpressionType);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.RoleArn !== undefined && data.RoleArn !== null) {
-    contents.RoleArn = data.RoleArn;
+    contents.RoleArn = __expectString(data.RoleArn);
   }
   return Promise.resolve(contents);
 };
@@ -4042,16 +4045,16 @@ export const deserializeAws_restJson1GetDeviceProfileCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.LoRaWAN !== undefined && data.LoRaWAN !== null) {
     contents.LoRaWAN = deserializeAws_restJson1LoRaWANDeviceProfile(data.LoRaWAN, context);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   return Promise.resolve(contents);
 };
@@ -4140,7 +4143,7 @@ export const deserializeAws_restJson1GetLogLevelsByResourceTypesCommand = async 
   };
   const data: any = await parseBody(output.body, context);
   if (data.DefaultLogLevel !== undefined && data.DefaultLogLevel !== null) {
-    contents.DefaultLogLevel = data.DefaultLogLevel;
+    contents.DefaultLogLevel = __expectString(data.DefaultLogLevel);
   }
   if (data.WirelessDeviceLogOptions !== undefined && data.WirelessDeviceLogOptions !== null) {
     contents.WirelessDeviceLogOptions = deserializeAws_restJson1WirelessDeviceLogOptionList(
@@ -4240,7 +4243,7 @@ export const deserializeAws_restJson1GetPartnerAccountCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AccountLinked !== undefined && data.AccountLinked !== null) {
-    contents.AccountLinked = data.AccountLinked;
+    contents.AccountLinked = __expectBoolean(data.AccountLinked);
   }
   if (data.Sidewalk !== undefined && data.Sidewalk !== null) {
     contents.Sidewalk = deserializeAws_restJson1SidewalkAccountInfoWithFingerprint(data.Sidewalk, context);
@@ -4322,7 +4325,7 @@ export const deserializeAws_restJson1GetResourceLogLevelCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.LogLevel !== undefined && data.LogLevel !== null) {
-    contents.LogLevel = data.LogLevel;
+    contents.LogLevel = __expectString(data.LogLevel);
   }
   return Promise.resolve(contents);
 };
@@ -4411,13 +4414,13 @@ export const deserializeAws_restJson1GetServiceEndpointCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ServerTrust !== undefined && data.ServerTrust !== null) {
-    contents.ServerTrust = data.ServerTrust;
+    contents.ServerTrust = __expectString(data.ServerTrust);
   }
   if (data.ServiceEndpoint !== undefined && data.ServiceEndpoint !== null) {
-    contents.ServiceEndpoint = data.ServiceEndpoint;
+    contents.ServiceEndpoint = __expectString(data.ServiceEndpoint);
   }
   if (data.ServiceType !== undefined && data.ServiceType !== null) {
-    contents.ServiceType = data.ServiceType;
+    contents.ServiceType = __expectString(data.ServiceType);
   }
   return Promise.resolve(contents);
 };
@@ -4499,16 +4502,16 @@ export const deserializeAws_restJson1GetServiceProfileCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.LoRaWAN !== undefined && data.LoRaWAN !== null) {
     contents.LoRaWAN = deserializeAws_restJson1LoRaWANGetServiceProfileInfo(data.LoRaWAN, context);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   return Promise.resolve(contents);
 };
@@ -4604,34 +4607,34 @@ export const deserializeAws_restJson1GetWirelessDeviceCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.DestinationName !== undefined && data.DestinationName !== null) {
-    contents.DestinationName = data.DestinationName;
+    contents.DestinationName = __expectString(data.DestinationName);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.LoRaWAN !== undefined && data.LoRaWAN !== null) {
     contents.LoRaWAN = deserializeAws_restJson1LoRaWANDevice(data.LoRaWAN, context);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.Sidewalk !== undefined && data.Sidewalk !== null) {
     contents.Sidewalk = deserializeAws_restJson1SidewalkDevice(data.Sidewalk, context);
   }
   if (data.ThingArn !== undefined && data.ThingArn !== null) {
-    contents.ThingArn = data.ThingArn;
+    contents.ThingArn = __expectString(data.ThingArn);
   }
   if (data.ThingName !== undefined && data.ThingName !== null) {
-    contents.ThingName = data.ThingName;
+    contents.ThingName = __expectString(data.ThingName);
   }
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   return Promise.resolve(contents);
 };
@@ -4721,7 +4724,7 @@ export const deserializeAws_restJson1GetWirelessDeviceStatisticsCommand = async 
   };
   const data: any = await parseBody(output.body, context);
   if (data.LastUplinkReceivedAt !== undefined && data.LastUplinkReceivedAt !== null) {
-    contents.LastUplinkReceivedAt = data.LastUplinkReceivedAt;
+    contents.LastUplinkReceivedAt = __expectString(data.LastUplinkReceivedAt);
   }
   if (data.LoRaWAN !== undefined && data.LoRaWAN !== null) {
     contents.LoRaWAN = deserializeAws_restJson1LoRaWANDeviceMetadata(data.LoRaWAN, context);
@@ -4730,7 +4733,7 @@ export const deserializeAws_restJson1GetWirelessDeviceStatisticsCommand = async 
     contents.Sidewalk = deserializeAws_restJson1SidewalkDeviceMetadata(data.Sidewalk, context);
   }
   if (data.WirelessDeviceId !== undefined && data.WirelessDeviceId !== null) {
-    contents.WirelessDeviceId = data.WirelessDeviceId;
+    contents.WirelessDeviceId = __expectString(data.WirelessDeviceId);
   }
   return Promise.resolve(contents);
 };
@@ -4823,25 +4826,25 @@ export const deserializeAws_restJson1GetWirelessGatewayCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.Id !== undefined && data.Id !== null) {
-    contents.Id = data.Id;
+    contents.Id = __expectString(data.Id);
   }
   if (data.LoRaWAN !== undefined && data.LoRaWAN !== null) {
     contents.LoRaWAN = deserializeAws_restJson1LoRaWANGateway(data.LoRaWAN, context);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.ThingArn !== undefined && data.ThingArn !== null) {
-    contents.ThingArn = data.ThingArn;
+    contents.ThingArn = __expectString(data.ThingArn);
   }
   if (data.ThingName !== undefined && data.ThingName !== null) {
-    contents.ThingName = data.ThingName;
+    contents.ThingName = __expectString(data.ThingName);
   }
   return Promise.resolve(contents);
 };
@@ -4929,10 +4932,10 @@ export const deserializeAws_restJson1GetWirelessGatewayCertificateCommand = asyn
   };
   const data: any = await parseBody(output.body, context);
   if (data.IotCertificateId !== undefined && data.IotCertificateId !== null) {
-    contents.IotCertificateId = data.IotCertificateId;
+    contents.IotCertificateId = __expectString(data.IotCertificateId);
   }
   if (data.LoRaWANNetworkServerCertificateId !== undefined && data.LoRaWANNetworkServerCertificateId !== null) {
-    contents.LoRaWANNetworkServerCertificateId = data.LoRaWANNetworkServerCertificateId;
+    contents.LoRaWANNetworkServerCertificateId = __expectString(data.LoRaWANNetworkServerCertificateId);
   }
   return Promise.resolve(contents);
 };
@@ -5108,13 +5111,13 @@ export const deserializeAws_restJson1GetWirelessGatewayStatisticsCommand = async
   };
   const data: any = await parseBody(output.body, context);
   if (data.ConnectionStatus !== undefined && data.ConnectionStatus !== null) {
-    contents.ConnectionStatus = data.ConnectionStatus;
+    contents.ConnectionStatus = __expectString(data.ConnectionStatus);
   }
   if (data.LastUplinkReceivedAt !== undefined && data.LastUplinkReceivedAt !== null) {
-    contents.LastUplinkReceivedAt = data.LastUplinkReceivedAt;
+    contents.LastUplinkReceivedAt = __expectString(data.LastUplinkReceivedAt);
   }
   if (data.WirelessGatewayId !== undefined && data.WirelessGatewayId !== null) {
-    contents.WirelessGatewayId = data.WirelessGatewayId;
+    contents.WirelessGatewayId = __expectString(data.WirelessGatewayId);
   }
   return Promise.resolve(contents);
 };
@@ -5205,19 +5208,19 @@ export const deserializeAws_restJson1GetWirelessGatewayTaskCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.LastUplinkReceivedAt !== undefined && data.LastUplinkReceivedAt !== null) {
-    contents.LastUplinkReceivedAt = data.LastUplinkReceivedAt;
+    contents.LastUplinkReceivedAt = __expectString(data.LastUplinkReceivedAt);
   }
   if (data.Status !== undefined && data.Status !== null) {
-    contents.Status = data.Status;
+    contents.Status = __expectString(data.Status);
   }
   if (data.TaskCreatedAt !== undefined && data.TaskCreatedAt !== null) {
-    contents.TaskCreatedAt = data.TaskCreatedAt;
+    contents.TaskCreatedAt = __expectString(data.TaskCreatedAt);
   }
   if (data.WirelessGatewayId !== undefined && data.WirelessGatewayId !== null) {
-    contents.WirelessGatewayId = data.WirelessGatewayId;
+    contents.WirelessGatewayId = __expectString(data.WirelessGatewayId);
   }
   if (data.WirelessGatewayTaskDefinitionId !== undefined && data.WirelessGatewayTaskDefinitionId !== null) {
-    contents.WirelessGatewayTaskDefinitionId = data.WirelessGatewayTaskDefinitionId;
+    contents.WirelessGatewayTaskDefinitionId = __expectString(data.WirelessGatewayTaskDefinitionId);
   }
   return Promise.resolve(contents);
 };
@@ -5307,13 +5310,13 @@ export const deserializeAws_restJson1GetWirelessGatewayTaskDefinitionCommand = a
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.AutoCreateTasks !== undefined && data.AutoCreateTasks !== null) {
-    contents.AutoCreateTasks = data.AutoCreateTasks;
+    contents.AutoCreateTasks = __expectBoolean(data.AutoCreateTasks);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.Update !== undefined && data.Update !== null) {
     contents.Update = deserializeAws_restJson1UpdateWirelessGatewayTaskCreate(data.Update, context);
@@ -5407,7 +5410,7 @@ export const deserializeAws_restJson1ListDestinationsCommand = async (
     contents.DestinationList = deserializeAws_restJson1DestinationList(data.DestinationList, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -5490,7 +5493,7 @@ export const deserializeAws_restJson1ListDeviceProfilesCommand = async (
     contents.DeviceProfileList = deserializeAws_restJson1DeviceProfileList(data.DeviceProfileList, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -5570,7 +5573,7 @@ export const deserializeAws_restJson1ListPartnerAccountsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Sidewalk !== undefined && data.Sidewalk !== null) {
     contents.Sidewalk = deserializeAws_restJson1SidewalkAccountList(data.Sidewalk, context);
@@ -5653,7 +5656,7 @@ export const deserializeAws_restJson1ListServiceProfilesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.ServiceProfileList !== undefined && data.ServiceProfileList !== null) {
     contents.ServiceProfileList = deserializeAws_restJson1ServiceProfileList(data.ServiceProfileList, context);
@@ -5823,7 +5826,7 @@ export const deserializeAws_restJson1ListWirelessDevicesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.WirelessDeviceList !== undefined && data.WirelessDeviceList !== null) {
     contents.WirelessDeviceList = deserializeAws_restJson1WirelessDeviceStatisticsList(
@@ -5909,7 +5912,7 @@ export const deserializeAws_restJson1ListWirelessGatewaysCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.WirelessGatewayList !== undefined && data.WirelessGatewayList !== null) {
     contents.WirelessGatewayList = deserializeAws_restJson1WirelessGatewayStatisticsList(
@@ -5995,7 +5998,7 @@ export const deserializeAws_restJson1ListWirelessGatewayTaskDefinitionsCommand =
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.TaskDefinitions !== undefined && data.TaskDefinitions !== null) {
     contents.TaskDefinitions = deserializeAws_restJson1WirelessGatewayTaskDefinitionList(data.TaskDefinitions, context);
@@ -6326,7 +6329,7 @@ export const deserializeAws_restJson1SendDataToWirelessDeviceCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.MessageId !== undefined && data.MessageId !== null) {
-    contents.MessageId = data.MessageId;
+    contents.MessageId = __expectString(data.MessageId);
   }
   return Promise.resolve(contents);
 };
@@ -6496,7 +6499,7 @@ export const deserializeAws_restJson1TestWirelessDeviceCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Result !== undefined && data.Result !== null) {
-    contents.Result = data.Result;
+    contents.Result = __expectString(data.Result);
   }
   return Promise.resolve(contents);
 };
@@ -7072,7 +7075,7 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -7091,13 +7094,13 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.ResourceId !== undefined && data.ResourceId !== null) {
-    contents.ResourceId = data.ResourceId;
+    contents.ResourceId = __expectString(data.ResourceId);
   }
   if (data.ResourceType !== undefined && data.ResourceType !== null) {
-    contents.ResourceType = data.ResourceType;
+    contents.ResourceType = __expectString(data.ResourceType);
   }
   return contents;
 };
@@ -7114,7 +7117,7 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -7133,13 +7136,13 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.ResourceId !== undefined && data.ResourceId !== null) {
-    contents.ResourceId = data.ResourceId;
+    contents.ResourceId = __expectString(data.ResourceId);
   }
   if (data.ResourceType !== undefined && data.ResourceType !== null) {
-    contents.ResourceType = data.ResourceType;
+    contents.ResourceType = __expectString(data.ResourceType);
   }
   return contents;
 };
@@ -7156,7 +7159,7 @@ const deserializeAws_restJson1ThrottlingExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -7174,10 +7177,10 @@ const deserializeAws_restJson1TooManyTagsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.ResourceName !== undefined && data.ResourceName !== null) {
-    contents.ResourceName = data.ResourceName;
+    contents.ResourceName = __expectString(data.ResourceName);
   }
   return contents;
 };
@@ -7194,7 +7197,7 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -7596,7 +7599,7 @@ const serializeAws_restJson1WirelessMetadata = (input: WirelessMetadata, context
 
 const deserializeAws_restJson1AbpV1_0_x = (output: any, context: __SerdeContext): AbpV1_0_x => {
   return {
-    DevAddr: output.DevAddr !== undefined && output.DevAddr !== null ? output.DevAddr : undefined,
+    DevAddr: __expectString(output.DevAddr),
     SessionKeys:
       output.SessionKeys !== undefined && output.SessionKeys !== null
         ? deserializeAws_restJson1SessionKeysAbpV1_0_x(output.SessionKeys, context)
@@ -7606,7 +7609,7 @@ const deserializeAws_restJson1AbpV1_0_x = (output: any, context: __SerdeContext)
 
 const deserializeAws_restJson1AbpV1_1 = (output: any, context: __SerdeContext): AbpV1_1 => {
   return {
-    DevAddr: output.DevAddr !== undefined && output.DevAddr !== null ? output.DevAddr : undefined,
+    DevAddr: __expectString(output.DevAddr),
     SessionKeys:
       output.SessionKeys !== undefined && output.SessionKeys !== null
         ? deserializeAws_restJson1SessionKeysAbpV1_1(output.SessionKeys, context)
@@ -7616,8 +7619,8 @@ const deserializeAws_restJson1AbpV1_1 = (output: any, context: __SerdeContext): 
 
 const deserializeAws_restJson1CertificateList = (output: any, context: __SerdeContext): CertificateList => {
   return {
-    SigningAlg: output.SigningAlg !== undefined && output.SigningAlg !== null ? output.SigningAlg : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    SigningAlg: __expectString(output.SigningAlg),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -7634,13 +7637,12 @@ const deserializeAws_restJson1DestinationList = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1Destinations = (output: any, context: __SerdeContext): Destinations => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Expression: output.Expression !== undefined && output.Expression !== null ? output.Expression : undefined,
-    ExpressionType:
-      output.ExpressionType !== undefined && output.ExpressionType !== null ? output.ExpressionType : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
+    Arn: __expectString(output.Arn),
+    Description: __expectString(output.Description),
+    Expression: __expectString(output.Expression),
+    ExpressionType: __expectString(output.ExpressionType),
+    Name: __expectString(output.Name),
+    RoleArn: __expectString(output.RoleArn),
   } as any;
 };
 
@@ -7657,9 +7659,9 @@ const deserializeAws_restJson1DeviceCertificateList = (output: any, context: __S
 
 const deserializeAws_restJson1DeviceProfile = (output: any, context: __SerdeContext): DeviceProfile => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Arn: __expectString(output.Arn),
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -7681,7 +7683,7 @@ const deserializeAws_restJson1FactoryPresetFreqsList = (output: any, context: __
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectNumber(entry) as any;
     });
 };
 
@@ -7703,7 +7705,7 @@ const deserializeAws_restJson1JoinEuiRange = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7717,9 +7719,8 @@ const deserializeAws_restJson1LoRaWANDevice = (output: any, context: __SerdeCont
       output.AbpV1_1 !== undefined && output.AbpV1_1 !== null
         ? deserializeAws_restJson1AbpV1_1(output.AbpV1_1, context)
         : undefined,
-    DevEui: output.DevEui !== undefined && output.DevEui !== null ? output.DevEui : undefined,
-    DeviceProfileId:
-      output.DeviceProfileId !== undefined && output.DeviceProfileId !== null ? output.DeviceProfileId : undefined,
+    DevEui: __expectString(output.DevEui),
+    DeviceProfileId: __expectString(output.DeviceProfileId),
     OtaaV1_0_x:
       output.OtaaV1_0_x !== undefined && output.OtaaV1_0_x !== null
         ? deserializeAws_restJson1OtaaV1_0_x(output.OtaaV1_0_x, context)
@@ -7728,66 +7729,54 @@ const deserializeAws_restJson1LoRaWANDevice = (output: any, context: __SerdeCont
       output.OtaaV1_1 !== undefined && output.OtaaV1_1 !== null
         ? deserializeAws_restJson1OtaaV1_1(output.OtaaV1_1, context)
         : undefined,
-    ServiceProfileId:
-      output.ServiceProfileId !== undefined && output.ServiceProfileId !== null ? output.ServiceProfileId : undefined,
+    ServiceProfileId: __expectString(output.ServiceProfileId),
   } as any;
 };
 
 const deserializeAws_restJson1LoRaWANDeviceMetadata = (output: any, context: __SerdeContext): LoRaWANDeviceMetadata => {
   return {
-    DataRate: output.DataRate !== undefined && output.DataRate !== null ? output.DataRate : undefined,
-    DevEui: output.DevEui !== undefined && output.DevEui !== null ? output.DevEui : undefined,
-    FPort: output.FPort !== undefined && output.FPort !== null ? output.FPort : undefined,
-    Frequency: output.Frequency !== undefined && output.Frequency !== null ? output.Frequency : undefined,
+    DataRate: __expectNumber(output.DataRate),
+    DevEui: __expectString(output.DevEui),
+    FPort: __expectNumber(output.FPort),
+    Frequency: __expectNumber(output.Frequency),
     Gateways:
       output.Gateways !== undefined && output.Gateways !== null
         ? deserializeAws_restJson1LoRaWANGatewayMetadataList(output.Gateways, context)
         : undefined,
-    Timestamp: output.Timestamp !== undefined && output.Timestamp !== null ? output.Timestamp : undefined,
+    Timestamp: __expectString(output.Timestamp),
   } as any;
 };
 
 const deserializeAws_restJson1LoRaWANDeviceProfile = (output: any, context: __SerdeContext): LoRaWANDeviceProfile => {
   return {
-    ClassBTimeout:
-      output.ClassBTimeout !== undefined && output.ClassBTimeout !== null ? output.ClassBTimeout : undefined,
-    ClassCTimeout:
-      output.ClassCTimeout !== undefined && output.ClassCTimeout !== null ? output.ClassCTimeout : undefined,
+    ClassBTimeout: __expectNumber(output.ClassBTimeout),
+    ClassCTimeout: __expectNumber(output.ClassCTimeout),
     FactoryPresetFreqsList:
       output.FactoryPresetFreqsList !== undefined && output.FactoryPresetFreqsList !== null
         ? deserializeAws_restJson1FactoryPresetFreqsList(output.FactoryPresetFreqsList, context)
         : undefined,
-    MacVersion: output.MacVersion !== undefined && output.MacVersion !== null ? output.MacVersion : undefined,
-    MaxDutyCycle: output.MaxDutyCycle !== undefined && output.MaxDutyCycle !== null ? output.MaxDutyCycle : undefined,
-    MaxEirp: output.MaxEirp !== undefined && output.MaxEirp !== null ? output.MaxEirp : undefined,
-    PingSlotDr: output.PingSlotDr !== undefined && output.PingSlotDr !== null ? output.PingSlotDr : undefined,
-    PingSlotFreq: output.PingSlotFreq !== undefined && output.PingSlotFreq !== null ? output.PingSlotFreq : undefined,
-    PingSlotPeriod:
-      output.PingSlotPeriod !== undefined && output.PingSlotPeriod !== null ? output.PingSlotPeriod : undefined,
-    RegParamsRevision:
-      output.RegParamsRevision !== undefined && output.RegParamsRevision !== null
-        ? output.RegParamsRevision
-        : undefined,
-    RfRegion: output.RfRegion !== undefined && output.RfRegion !== null ? output.RfRegion : undefined,
-    RxDataRate2: output.RxDataRate2 !== undefined && output.RxDataRate2 !== null ? output.RxDataRate2 : undefined,
-    RxDelay1: output.RxDelay1 !== undefined && output.RxDelay1 !== null ? output.RxDelay1 : undefined,
-    RxDrOffset1: output.RxDrOffset1 !== undefined && output.RxDrOffset1 !== null ? output.RxDrOffset1 : undefined,
-    RxFreq2: output.RxFreq2 !== undefined && output.RxFreq2 !== null ? output.RxFreq2 : undefined,
-    Supports32BitFCnt:
-      output.Supports32BitFCnt !== undefined && output.Supports32BitFCnt !== null
-        ? output.Supports32BitFCnt
-        : undefined,
-    SupportsClassB:
-      output.SupportsClassB !== undefined && output.SupportsClassB !== null ? output.SupportsClassB : undefined,
-    SupportsClassC:
-      output.SupportsClassC !== undefined && output.SupportsClassC !== null ? output.SupportsClassC : undefined,
-    SupportsJoin: output.SupportsJoin !== undefined && output.SupportsJoin !== null ? output.SupportsJoin : undefined,
+    MacVersion: __expectString(output.MacVersion),
+    MaxDutyCycle: __expectNumber(output.MaxDutyCycle),
+    MaxEirp: __expectNumber(output.MaxEirp),
+    PingSlotDr: __expectNumber(output.PingSlotDr),
+    PingSlotFreq: __expectNumber(output.PingSlotFreq),
+    PingSlotPeriod: __expectNumber(output.PingSlotPeriod),
+    RegParamsRevision: __expectString(output.RegParamsRevision),
+    RfRegion: __expectString(output.RfRegion),
+    RxDataRate2: __expectNumber(output.RxDataRate2),
+    RxDelay1: __expectNumber(output.RxDelay1),
+    RxDrOffset1: __expectNumber(output.RxDrOffset1),
+    RxFreq2: __expectNumber(output.RxFreq2),
+    Supports32BitFCnt: __expectBoolean(output.Supports32BitFCnt),
+    SupportsClassB: __expectBoolean(output.SupportsClassB),
+    SupportsClassC: __expectBoolean(output.SupportsClassC),
+    SupportsJoin: __expectBoolean(output.SupportsJoin),
   } as any;
 };
 
 const deserializeAws_restJson1LoRaWANGateway = (output: any, context: __SerdeContext): LoRaWANGateway => {
   return {
-    GatewayEui: output.GatewayEui !== undefined && output.GatewayEui !== null ? output.GatewayEui : undefined,
+    GatewayEui: __expectString(output.GatewayEui),
     JoinEuiFilters:
       output.JoinEuiFilters !== undefined && output.JoinEuiFilters !== null
         ? deserializeAws_restJson1JoinEuiFilters(output.JoinEuiFilters, context)
@@ -7796,7 +7785,7 @@ const deserializeAws_restJson1LoRaWANGateway = (output: any, context: __SerdeCon
       output.NetIdFilters !== undefined && output.NetIdFilters !== null
         ? deserializeAws_restJson1NetIdFilters(output.NetIdFilters, context)
         : undefined,
-    RfRegion: output.RfRegion !== undefined && output.RfRegion !== null ? output.RfRegion : undefined,
+    RfRegion: __expectString(output.RfRegion),
     SubBands:
       output.SubBands !== undefined && output.SubBands !== null
         ? deserializeAws_restJson1SubBands(output.SubBands, context)
@@ -7821,9 +7810,9 @@ const deserializeAws_restJson1LoRaWANGatewayMetadata = (
   context: __SerdeContext
 ): LoRaWANGatewayMetadata => {
   return {
-    GatewayEui: output.GatewayEui !== undefined && output.GatewayEui !== null ? output.GatewayEui : undefined,
-    Rssi: output.Rssi !== undefined && output.Rssi !== null ? output.Rssi : undefined,
-    Snr: output.Snr !== undefined && output.Snr !== null ? output.Snr : undefined,
+    GatewayEui: __expectString(output.GatewayEui),
+    Rssi: __expectNumber(output.Rssi),
+    Snr: __expectNumber(output.Snr),
   } as any;
 };
 
@@ -7843,10 +7832,9 @@ const deserializeAws_restJson1LoRaWANGatewayMetadataList = (
 
 const deserializeAws_restJson1LoRaWANGatewayVersion = (output: any, context: __SerdeContext): LoRaWANGatewayVersion => {
   return {
-    Model: output.Model !== undefined && output.Model !== null ? output.Model : undefined,
-    PackageVersion:
-      output.PackageVersion !== undefined && output.PackageVersion !== null ? output.PackageVersion : undefined,
-    Station: output.Station !== undefined && output.Station !== null ? output.Station : undefined,
+    Model: __expectString(output.Model),
+    PackageVersion: __expectString(output.PackageVersion),
+    Station: __expectString(output.Station),
   } as any;
 };
 
@@ -7855,40 +7843,31 @@ const deserializeAws_restJson1LoRaWANGetServiceProfileInfo = (
   context: __SerdeContext
 ): LoRaWANGetServiceProfileInfo => {
   return {
-    AddGwMetadata:
-      output.AddGwMetadata !== undefined && output.AddGwMetadata !== null ? output.AddGwMetadata : undefined,
-    ChannelMask: output.ChannelMask !== undefined && output.ChannelMask !== null ? output.ChannelMask : undefined,
-    DevStatusReqFreq:
-      output.DevStatusReqFreq !== undefined && output.DevStatusReqFreq !== null ? output.DevStatusReqFreq : undefined,
-    DlBucketSize: output.DlBucketSize !== undefined && output.DlBucketSize !== null ? output.DlBucketSize : undefined,
-    DlRate: output.DlRate !== undefined && output.DlRate !== null ? output.DlRate : undefined,
-    DlRatePolicy: output.DlRatePolicy !== undefined && output.DlRatePolicy !== null ? output.DlRatePolicy : undefined,
-    DrMax: output.DrMax !== undefined && output.DrMax !== null ? output.DrMax : undefined,
-    DrMin: output.DrMin !== undefined && output.DrMin !== null ? output.DrMin : undefined,
-    HrAllowed: output.HrAllowed !== undefined && output.HrAllowed !== null ? output.HrAllowed : undefined,
-    MinGwDiversity:
-      output.MinGwDiversity !== undefined && output.MinGwDiversity !== null ? output.MinGwDiversity : undefined,
-    NwkGeoLoc: output.NwkGeoLoc !== undefined && output.NwkGeoLoc !== null ? output.NwkGeoLoc : undefined,
-    PrAllowed: output.PrAllowed !== undefined && output.PrAllowed !== null ? output.PrAllowed : undefined,
-    RaAllowed: output.RaAllowed !== undefined && output.RaAllowed !== null ? output.RaAllowed : undefined,
-    ReportDevStatusBattery:
-      output.ReportDevStatusBattery !== undefined && output.ReportDevStatusBattery !== null
-        ? output.ReportDevStatusBattery
-        : undefined,
-    ReportDevStatusMargin:
-      output.ReportDevStatusMargin !== undefined && output.ReportDevStatusMargin !== null
-        ? output.ReportDevStatusMargin
-        : undefined,
-    TargetPer: output.TargetPer !== undefined && output.TargetPer !== null ? output.TargetPer : undefined,
-    UlBucketSize: output.UlBucketSize !== undefined && output.UlBucketSize !== null ? output.UlBucketSize : undefined,
-    UlRate: output.UlRate !== undefined && output.UlRate !== null ? output.UlRate : undefined,
-    UlRatePolicy: output.UlRatePolicy !== undefined && output.UlRatePolicy !== null ? output.UlRatePolicy : undefined,
+    AddGwMetadata: __expectBoolean(output.AddGwMetadata),
+    ChannelMask: __expectString(output.ChannelMask),
+    DevStatusReqFreq: __expectNumber(output.DevStatusReqFreq),
+    DlBucketSize: __expectNumber(output.DlBucketSize),
+    DlRate: __expectNumber(output.DlRate),
+    DlRatePolicy: __expectString(output.DlRatePolicy),
+    DrMax: __expectNumber(output.DrMax),
+    DrMin: __expectNumber(output.DrMin),
+    HrAllowed: __expectBoolean(output.HrAllowed),
+    MinGwDiversity: __expectNumber(output.MinGwDiversity),
+    NwkGeoLoc: __expectBoolean(output.NwkGeoLoc),
+    PrAllowed: __expectBoolean(output.PrAllowed),
+    RaAllowed: __expectBoolean(output.RaAllowed),
+    ReportDevStatusBattery: __expectBoolean(output.ReportDevStatusBattery),
+    ReportDevStatusMargin: __expectBoolean(output.ReportDevStatusMargin),
+    TargetPer: __expectNumber(output.TargetPer),
+    UlBucketSize: __expectNumber(output.UlBucketSize),
+    UlRate: __expectNumber(output.UlRate),
+    UlRatePolicy: __expectString(output.UlRatePolicy),
   } as any;
 };
 
 const deserializeAws_restJson1LoRaWANListDevice = (output: any, context: __SerdeContext): LoRaWANListDevice => {
   return {
-    DevEui: output.DevEui !== undefined && output.DevEui !== null ? output.DevEui : undefined,
+    DevEui: __expectString(output.DevEui),
   } as any;
 };
 
@@ -7901,9 +7880,8 @@ const deserializeAws_restJson1LoRaWANUpdateGatewayTaskCreate = (
       output.CurrentVersion !== undefined && output.CurrentVersion !== null
         ? deserializeAws_restJson1LoRaWANGatewayVersion(output.CurrentVersion, context)
         : undefined,
-    SigKeyCrc: output.SigKeyCrc !== undefined && output.SigKeyCrc !== null ? output.SigKeyCrc : undefined,
-    UpdateSignature:
-      output.UpdateSignature !== undefined && output.UpdateSignature !== null ? output.UpdateSignature : undefined,
+    SigKeyCrc: __expectNumber(output.SigKeyCrc),
+    UpdateSignature: __expectString(output.UpdateSignature),
     UpdateVersion:
       output.UpdateVersion !== undefined && output.UpdateVersion !== null
         ? deserializeAws_restJson1LoRaWANGatewayVersion(output.UpdateVersion, context)
@@ -7934,30 +7912,30 @@ const deserializeAws_restJson1NetIdFilters = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1OtaaV1_0_x = (output: any, context: __SerdeContext): OtaaV1_0_x => {
   return {
-    AppEui: output.AppEui !== undefined && output.AppEui !== null ? output.AppEui : undefined,
-    AppKey: output.AppKey !== undefined && output.AppKey !== null ? output.AppKey : undefined,
+    AppEui: __expectString(output.AppEui),
+    AppKey: __expectString(output.AppKey),
   } as any;
 };
 
 const deserializeAws_restJson1OtaaV1_1 = (output: any, context: __SerdeContext): OtaaV1_1 => {
   return {
-    AppKey: output.AppKey !== undefined && output.AppKey !== null ? output.AppKey : undefined,
-    JoinEui: output.JoinEui !== undefined && output.JoinEui !== null ? output.JoinEui : undefined,
-    NwkKey: output.NwkKey !== undefined && output.NwkKey !== null ? output.NwkKey : undefined,
+    AppKey: __expectString(output.AppKey),
+    JoinEui: __expectString(output.JoinEui),
+    NwkKey: __expectString(output.NwkKey),
   } as any;
 };
 
 const deserializeAws_restJson1ServiceProfile = (output: any, context: __SerdeContext): ServiceProfile => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Arn: __expectString(output.Arn),
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -7974,27 +7952,24 @@ const deserializeAws_restJson1ServiceProfileList = (output: any, context: __Serd
 
 const deserializeAws_restJson1SessionKeysAbpV1_0_x = (output: any, context: __SerdeContext): SessionKeysAbpV1_0_x => {
   return {
-    AppSKey: output.AppSKey !== undefined && output.AppSKey !== null ? output.AppSKey : undefined,
-    NwkSKey: output.NwkSKey !== undefined && output.NwkSKey !== null ? output.NwkSKey : undefined,
+    AppSKey: __expectString(output.AppSKey),
+    NwkSKey: __expectString(output.NwkSKey),
   } as any;
 };
 
 const deserializeAws_restJson1SessionKeysAbpV1_1 = (output: any, context: __SerdeContext): SessionKeysAbpV1_1 => {
   return {
-    AppSKey: output.AppSKey !== undefined && output.AppSKey !== null ? output.AppSKey : undefined,
-    FNwkSIntKey: output.FNwkSIntKey !== undefined && output.FNwkSIntKey !== null ? output.FNwkSIntKey : undefined,
-    NwkSEncKey: output.NwkSEncKey !== undefined && output.NwkSEncKey !== null ? output.NwkSEncKey : undefined,
-    SNwkSIntKey: output.SNwkSIntKey !== undefined && output.SNwkSIntKey !== null ? output.SNwkSIntKey : undefined,
+    AppSKey: __expectString(output.AppSKey),
+    FNwkSIntKey: __expectString(output.FNwkSIntKey),
+    NwkSEncKey: __expectString(output.NwkSEncKey),
+    SNwkSIntKey: __expectString(output.SNwkSIntKey),
   } as any;
 };
 
 const deserializeAws_restJson1SidewalkAccountInfo = (output: any, context: __SerdeContext): SidewalkAccountInfo => {
   return {
-    AmazonId: output.AmazonId !== undefined && output.AmazonId !== null ? output.AmazonId : undefined,
-    AppServerPrivateKey:
-      output.AppServerPrivateKey !== undefined && output.AppServerPrivateKey !== null
-        ? output.AppServerPrivateKey
-        : undefined,
+    AmazonId: __expectString(output.AmazonId),
+    AppServerPrivateKey: __expectString(output.AppServerPrivateKey),
   } as any;
 };
 
@@ -8003,9 +7978,9 @@ const deserializeAws_restJson1SidewalkAccountInfoWithFingerprint = (
   context: __SerdeContext
 ): SidewalkAccountInfoWithFingerprint => {
   return {
-    AmazonId: output.AmazonId !== undefined && output.AmazonId !== null ? output.AmazonId : undefined,
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Fingerprint: output.Fingerprint !== undefined && output.Fingerprint !== null ? output.Fingerprint : undefined,
+    AmazonId: __expectString(output.AmazonId),
+    Arn: __expectString(output.Arn),
+    Fingerprint: __expectString(output.Fingerprint),
   } as any;
 };
 
@@ -8029,11 +8004,8 @@ const deserializeAws_restJson1SidewalkDevice = (output: any, context: __SerdeCon
       output.DeviceCertificates !== undefined && output.DeviceCertificates !== null
         ? deserializeAws_restJson1DeviceCertificateList(output.DeviceCertificates, context)
         : undefined,
-    SidewalkId: output.SidewalkId !== undefined && output.SidewalkId !== null ? output.SidewalkId : undefined,
-    SidewalkManufacturingSn:
-      output.SidewalkManufacturingSn !== undefined && output.SidewalkManufacturingSn !== null
-        ? output.SidewalkManufacturingSn
-        : undefined,
+    SidewalkId: __expectString(output.SidewalkId),
+    SidewalkManufacturingSn: __expectString(output.SidewalkManufacturingSn),
   } as any;
 };
 
@@ -8042,25 +8014,22 @@ const deserializeAws_restJson1SidewalkDeviceMetadata = (
   context: __SerdeContext
 ): SidewalkDeviceMetadata => {
   return {
-    BatteryLevel: output.BatteryLevel !== undefined && output.BatteryLevel !== null ? output.BatteryLevel : undefined,
-    DeviceState: output.DeviceState !== undefined && output.DeviceState !== null ? output.DeviceState : undefined,
-    Event: output.Event !== undefined && output.Event !== null ? output.Event : undefined,
-    Rssi: output.Rssi !== undefined && output.Rssi !== null ? output.Rssi : undefined,
+    BatteryLevel: __expectString(output.BatteryLevel),
+    DeviceState: __expectString(output.DeviceState),
+    Event: __expectString(output.Event),
+    Rssi: __expectNumber(output.Rssi),
   } as any;
 };
 
 const deserializeAws_restJson1SidewalkListDevice = (output: any, context: __SerdeContext): SidewalkListDevice => {
   return {
-    AmazonId: output.AmazonId !== undefined && output.AmazonId !== null ? output.AmazonId : undefined,
+    AmazonId: __expectString(output.AmazonId),
     DeviceCertificates:
       output.DeviceCertificates !== undefined && output.DeviceCertificates !== null
         ? deserializeAws_restJson1DeviceCertificateList(output.DeviceCertificates, context)
         : undefined,
-    SidewalkId: output.SidewalkId !== undefined && output.SidewalkId !== null ? output.SidewalkId : undefined,
-    SidewalkManufacturingSn:
-      output.SidewalkManufacturingSn !== undefined && output.SidewalkManufacturingSn !== null
-        ? output.SidewalkManufacturingSn
-        : undefined,
+    SidewalkId: __expectString(output.SidewalkId),
+    SidewalkManufacturingSn: __expectString(output.SidewalkManufacturingSn),
   } as any;
 };
 
@@ -8071,14 +8040,14 @@ const deserializeAws_restJson1SubBands = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectNumber(entry) as any;
     });
 };
 
 const deserializeAws_restJson1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -8102,10 +8071,8 @@ const deserializeAws_restJson1UpdateWirelessGatewayTaskCreate = (
       output.LoRaWAN !== undefined && output.LoRaWAN !== null
         ? deserializeAws_restJson1LoRaWANUpdateGatewayTaskCreate(output.LoRaWAN, context)
         : undefined,
-    UpdateDataRole:
-      output.UpdateDataRole !== undefined && output.UpdateDataRole !== null ? output.UpdateDataRole : undefined,
-    UpdateDataSource:
-      output.UpdateDataSource !== undefined && output.UpdateDataSource !== null ? output.UpdateDataSource : undefined,
+    UpdateDataRole: __expectString(output.UpdateDataRole),
+    UpdateDataSource: __expectString(output.UpdateDataSource),
   } as any;
 };
 
@@ -8114,8 +8081,8 @@ const deserializeAws_restJson1UpdateWirelessGatewayTaskEntry = (
   context: __SerdeContext
 ): UpdateWirelessGatewayTaskEntry => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    Arn: __expectString(output.Arn),
+    Id: __expectString(output.Id),
     LoRaWAN:
       output.LoRaWAN !== undefined && output.LoRaWAN !== null
         ? deserializeAws_restJson1LoRaWANUpdateGatewayTaskEntry(output.LoRaWAN, context)
@@ -8128,8 +8095,8 @@ const deserializeAws_restJson1WirelessDeviceEventLogOption = (
   context: __SerdeContext
 ): WirelessDeviceEventLogOption => {
   return {
-    Event: output.Event !== undefined && output.Event !== null ? output.Event : undefined,
-    LogLevel: output.LogLevel !== undefined && output.LogLevel !== null ? output.LogLevel : undefined,
+    Event: __expectString(output.Event),
+    LogLevel: __expectString(output.LogLevel),
   } as any;
 };
 
@@ -8156,8 +8123,8 @@ const deserializeAws_restJson1WirelessDeviceLogOption = (
       output.Events !== undefined && output.Events !== null
         ? deserializeAws_restJson1WirelessDeviceEventLogOptionList(output.Events, context)
         : undefined,
-    LogLevel: output.LogLevel !== undefined && output.LogLevel !== null ? output.LogLevel : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    LogLevel: __expectString(output.LogLevel),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -8180,24 +8147,20 @@ const deserializeAws_restJson1WirelessDeviceStatistics = (
   context: __SerdeContext
 ): WirelessDeviceStatistics => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    DestinationName:
-      output.DestinationName !== undefined && output.DestinationName !== null ? output.DestinationName : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    LastUplinkReceivedAt:
-      output.LastUplinkReceivedAt !== undefined && output.LastUplinkReceivedAt !== null
-        ? output.LastUplinkReceivedAt
-        : undefined,
+    Arn: __expectString(output.Arn),
+    DestinationName: __expectString(output.DestinationName),
+    Id: __expectString(output.Id),
+    LastUplinkReceivedAt: __expectString(output.LastUplinkReceivedAt),
     LoRaWAN:
       output.LoRaWAN !== undefined && output.LoRaWAN !== null
         ? deserializeAws_restJson1LoRaWANListDevice(output.LoRaWAN, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     Sidewalk:
       output.Sidewalk !== undefined && output.Sidewalk !== null
         ? deserializeAws_restJson1SidewalkListDevice(output.Sidewalk, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -8220,8 +8183,8 @@ const deserializeAws_restJson1WirelessGatewayEventLogOption = (
   context: __SerdeContext
 ): WirelessGatewayEventLogOption => {
   return {
-    Event: output.Event !== undefined && output.Event !== null ? output.Event : undefined,
-    LogLevel: output.LogLevel !== undefined && output.LogLevel !== null ? output.LogLevel : undefined,
+    Event: __expectString(output.Event),
+    LogLevel: __expectString(output.LogLevel),
   } as any;
 };
 
@@ -8248,8 +8211,8 @@ const deserializeAws_restJson1WirelessGatewayLogOption = (
       output.Events !== undefined && output.Events !== null
         ? deserializeAws_restJson1WirelessGatewayEventLogOptionList(output.Events, context)
         : undefined,
-    LogLevel: output.LogLevel !== undefined && output.LogLevel !== null ? output.LogLevel : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    LogLevel: __expectString(output.LogLevel),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -8272,18 +8235,15 @@ const deserializeAws_restJson1WirelessGatewayStatistics = (
   context: __SerdeContext
 ): WirelessGatewayStatistics => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    LastUplinkReceivedAt:
-      output.LastUplinkReceivedAt !== undefined && output.LastUplinkReceivedAt !== null
-        ? output.LastUplinkReceivedAt
-        : undefined,
+    Arn: __expectString(output.Arn),
+    Description: __expectString(output.Description),
+    Id: __expectString(output.Id),
+    LastUplinkReceivedAt: __expectString(output.LastUplinkReceivedAt),
     LoRaWAN:
       output.LoRaWAN !== undefined && output.LoRaWAN !== null
         ? deserializeAws_restJson1LoRaWANGateway(output.LoRaWAN, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 

--- a/clients/client-iot/protocols/Aws_restJson1.ts
+++ b/clients/client-iot/protocols/Aws_restJson1.ts
@@ -845,6 +845,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -8284,13 +8287,13 @@ export const deserializeAws_restJson1AssociateTargetsWithJobCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.jobArn !== undefined && data.jobArn !== null) {
-    contents.jobArn = data.jobArn;
+    contents.jobArn = __expectString(data.jobArn);
   }
   if (data.jobId !== undefined && data.jobId !== null) {
-    contents.jobId = data.jobId;
+    contents.jobId = __expectString(data.jobId);
   }
   return Promise.resolve(contents);
 };
@@ -9083,13 +9086,13 @@ export const deserializeAws_restJson1CancelJobCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.jobArn !== undefined && data.jobArn !== null) {
-    contents.jobArn = data.jobArn;
+    contents.jobArn = __expectString(data.jobArn);
   }
   if (data.jobId !== undefined && data.jobId !== null) {
-    contents.jobId = data.jobId;
+    contents.jobId = __expectString(data.jobId);
   }
   return Promise.resolve(contents);
 };
@@ -9517,10 +9520,10 @@ export const deserializeAws_restJson1CreateAuthorizerCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.authorizerArn !== undefined && data.authorizerArn !== null) {
-    contents.authorizerArn = data.authorizerArn;
+    contents.authorizerArn = __expectString(data.authorizerArn);
   }
   if (data.authorizerName !== undefined && data.authorizerName !== null) {
-    contents.authorizerName = data.authorizerName;
+    contents.authorizerName = __expectString(data.authorizerName);
   }
   return Promise.resolve(contents);
 };
@@ -9625,13 +9628,13 @@ export const deserializeAws_restJson1CreateBillingGroupCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.billingGroupArn !== undefined && data.billingGroupArn !== null) {
-    contents.billingGroupArn = data.billingGroupArn;
+    contents.billingGroupArn = __expectString(data.billingGroupArn);
   }
   if (data.billingGroupId !== undefined && data.billingGroupId !== null) {
-    contents.billingGroupId = data.billingGroupId;
+    contents.billingGroupId = __expectString(data.billingGroupId);
   }
   if (data.billingGroupName !== undefined && data.billingGroupName !== null) {
-    contents.billingGroupName = data.billingGroupName;
+    contents.billingGroupName = __expectString(data.billingGroupName);
   }
   return Promise.resolve(contents);
 };
@@ -9712,13 +9715,13 @@ export const deserializeAws_restJson1CreateCertificateFromCsrCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.certificateArn !== undefined && data.certificateArn !== null) {
-    contents.certificateArn = data.certificateArn;
+    contents.certificateArn = __expectString(data.certificateArn);
   }
   if (data.certificateId !== undefined && data.certificateId !== null) {
-    contents.certificateId = data.certificateId;
+    contents.certificateId = __expectString(data.certificateId);
   }
   if (data.certificatePem !== undefined && data.certificatePem !== null) {
-    contents.certificatePem = data.certificatePem;
+    contents.certificatePem = __expectString(data.certificatePem);
   }
   return Promise.resolve(contents);
 };
@@ -9806,10 +9809,10 @@ export const deserializeAws_restJson1CreateCustomMetricCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.metricArn !== undefined && data.metricArn !== null) {
-    contents.metricArn = data.metricArn;
+    contents.metricArn = __expectString(data.metricArn);
   }
   if (data.metricName !== undefined && data.metricName !== null) {
-    contents.metricName = data.metricName;
+    contents.metricName = __expectString(data.metricName);
   }
   return Promise.resolve(contents);
 };
@@ -9897,10 +9900,10 @@ export const deserializeAws_restJson1CreateDimensionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   return Promise.resolve(contents);
 };
@@ -9988,10 +9991,10 @@ export const deserializeAws_restJson1CreateDomainConfigurationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.domainConfigurationArn !== undefined && data.domainConfigurationArn !== null) {
-    contents.domainConfigurationArn = data.domainConfigurationArn;
+    contents.domainConfigurationArn = __expectString(data.domainConfigurationArn);
   }
   if (data.domainConfigurationName !== undefined && data.domainConfigurationName !== null) {
-    contents.domainConfigurationName = data.domainConfigurationName;
+    contents.domainConfigurationName = __expectString(data.domainConfigurationName);
   }
   return Promise.resolve(contents);
 };
@@ -10107,22 +10110,22 @@ export const deserializeAws_restJson1CreateDynamicThingGroupCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.indexName !== undefined && data.indexName !== null) {
-    contents.indexName = data.indexName;
+    contents.indexName = __expectString(data.indexName);
   }
   if (data.queryString !== undefined && data.queryString !== null) {
-    contents.queryString = data.queryString;
+    contents.queryString = __expectString(data.queryString);
   }
   if (data.queryVersion !== undefined && data.queryVersion !== null) {
-    contents.queryVersion = data.queryVersion;
+    contents.queryVersion = __expectString(data.queryVersion);
   }
   if (data.thingGroupArn !== undefined && data.thingGroupArn !== null) {
-    contents.thingGroupArn = data.thingGroupArn;
+    contents.thingGroupArn = __expectString(data.thingGroupArn);
   }
   if (data.thingGroupId !== undefined && data.thingGroupId !== null) {
-    contents.thingGroupId = data.thingGroupId;
+    contents.thingGroupId = __expectString(data.thingGroupId);
   }
   if (data.thingGroupName !== undefined && data.thingGroupName !== null) {
-    contents.thingGroupName = data.thingGroupName;
+    contents.thingGroupName = __expectString(data.thingGroupName);
   }
   return Promise.resolve(contents);
 };
@@ -10227,13 +10230,13 @@ export const deserializeAws_restJson1CreateJobCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.jobArn !== undefined && data.jobArn !== null) {
-    contents.jobArn = data.jobArn;
+    contents.jobArn = __expectString(data.jobArn);
   }
   if (data.jobId !== undefined && data.jobId !== null) {
-    contents.jobId = data.jobId;
+    contents.jobId = __expectString(data.jobId);
   }
   return Promise.resolve(contents);
 };
@@ -10329,10 +10332,10 @@ export const deserializeAws_restJson1CreateJobTemplateCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.jobTemplateArn !== undefined && data.jobTemplateArn !== null) {
-    contents.jobTemplateArn = data.jobTemplateArn;
+    contents.jobTemplateArn = __expectString(data.jobTemplateArn);
   }
   if (data.jobTemplateId !== undefined && data.jobTemplateId !== null) {
-    contents.jobTemplateId = data.jobTemplateId;
+    contents.jobTemplateId = __expectString(data.jobTemplateId);
   }
   return Promise.resolve(contents);
 };
@@ -10430,13 +10433,13 @@ export const deserializeAws_restJson1CreateKeysAndCertificateCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.certificateArn !== undefined && data.certificateArn !== null) {
-    contents.certificateArn = data.certificateArn;
+    contents.certificateArn = __expectString(data.certificateArn);
   }
   if (data.certificateId !== undefined && data.certificateId !== null) {
-    contents.certificateId = data.certificateId;
+    contents.certificateId = __expectString(data.certificateId);
   }
   if (data.certificatePem !== undefined && data.certificatePem !== null) {
-    contents.certificatePem = data.certificatePem;
+    contents.certificatePem = __expectString(data.certificatePem);
   }
   if (data.keyPair !== undefined && data.keyPair !== null) {
     contents.keyPair = deserializeAws_restJson1KeyPair(data.keyPair, context);
@@ -10527,10 +10530,10 @@ export const deserializeAws_restJson1CreateMitigationActionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.actionArn !== undefined && data.actionArn !== null) {
-    contents.actionArn = data.actionArn;
+    contents.actionArn = __expectString(data.actionArn);
   }
   if (data.actionId !== undefined && data.actionId !== null) {
-    contents.actionId = data.actionId;
+    contents.actionId = __expectString(data.actionId);
   }
   return Promise.resolve(contents);
 };
@@ -10621,19 +10624,19 @@ export const deserializeAws_restJson1CreateOTAUpdateCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.awsIotJobArn !== undefined && data.awsIotJobArn !== null) {
-    contents.awsIotJobArn = data.awsIotJobArn;
+    contents.awsIotJobArn = __expectString(data.awsIotJobArn);
   }
   if (data.awsIotJobId !== undefined && data.awsIotJobId !== null) {
-    contents.awsIotJobId = data.awsIotJobId;
+    contents.awsIotJobId = __expectString(data.awsIotJobId);
   }
   if (data.otaUpdateArn !== undefined && data.otaUpdateArn !== null) {
-    contents.otaUpdateArn = data.otaUpdateArn;
+    contents.otaUpdateArn = __expectString(data.otaUpdateArn);
   }
   if (data.otaUpdateId !== undefined && data.otaUpdateId !== null) {
-    contents.otaUpdateId = data.otaUpdateId;
+    contents.otaUpdateId = __expectString(data.otaUpdateId);
   }
   if (data.otaUpdateStatus !== undefined && data.otaUpdateStatus !== null) {
-    contents.otaUpdateStatus = data.otaUpdateStatus;
+    contents.otaUpdateStatus = __expectString(data.otaUpdateStatus);
   }
   return Promise.resolve(contents);
 };
@@ -10747,16 +10750,16 @@ export const deserializeAws_restJson1CreatePolicyCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.policyArn !== undefined && data.policyArn !== null) {
-    contents.policyArn = data.policyArn;
+    contents.policyArn = __expectString(data.policyArn);
   }
   if (data.policyDocument !== undefined && data.policyDocument !== null) {
-    contents.policyDocument = data.policyDocument;
+    contents.policyDocument = __expectString(data.policyDocument);
   }
   if (data.policyName !== undefined && data.policyName !== null) {
-    contents.policyName = data.policyName;
+    contents.policyName = __expectString(data.policyName);
   }
   if (data.policyVersionId !== undefined && data.policyVersionId !== null) {
-    contents.policyVersionId = data.policyVersionId;
+    contents.policyVersionId = __expectString(data.policyVersionId);
   }
   return Promise.resolve(contents);
 };
@@ -10862,16 +10865,16 @@ export const deserializeAws_restJson1CreatePolicyVersionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.isDefaultVersion !== undefined && data.isDefaultVersion !== null) {
-    contents.isDefaultVersion = data.isDefaultVersion;
+    contents.isDefaultVersion = __expectBoolean(data.isDefaultVersion);
   }
   if (data.policyArn !== undefined && data.policyArn !== null) {
-    contents.policyArn = data.policyArn;
+    contents.policyArn = __expectString(data.policyArn);
   }
   if (data.policyDocument !== undefined && data.policyDocument !== null) {
-    contents.policyDocument = data.policyDocument;
+    contents.policyDocument = __expectString(data.policyDocument);
   }
   if (data.policyVersionId !== undefined && data.policyVersionId !== null) {
-    contents.policyVersionId = data.policyVersionId;
+    contents.policyVersionId = __expectString(data.policyVersionId);
   }
   return Promise.resolve(contents);
 };
@@ -10985,10 +10988,10 @@ export const deserializeAws_restJson1CreateProvisioningClaimCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.certificateId !== undefined && data.certificateId !== null) {
-    contents.certificateId = data.certificateId;
+    contents.certificateId = __expectString(data.certificateId);
   }
   if (data.certificatePem !== undefined && data.certificatePem !== null) {
-    contents.certificatePem = data.certificatePem;
+    contents.certificatePem = __expectString(data.certificatePem);
   }
   if (data.expiration !== undefined && data.expiration !== null) {
     contents.expiration = new Date(Math.round(data.expiration * 1000));
@@ -11091,13 +11094,13 @@ export const deserializeAws_restJson1CreateProvisioningTemplateCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.defaultVersionId !== undefined && data.defaultVersionId !== null) {
-    contents.defaultVersionId = data.defaultVersionId;
+    contents.defaultVersionId = __expectNumber(data.defaultVersionId);
   }
   if (data.templateArn !== undefined && data.templateArn !== null) {
-    contents.templateArn = data.templateArn;
+    contents.templateArn = __expectString(data.templateArn);
   }
   if (data.templateName !== undefined && data.templateName !== null) {
-    contents.templateName = data.templateName;
+    contents.templateName = __expectString(data.templateName);
   }
   return Promise.resolve(contents);
 };
@@ -11195,16 +11198,16 @@ export const deserializeAws_restJson1CreateProvisioningTemplateVersionCommand = 
   };
   const data: any = await parseBody(output.body, context);
   if (data.isDefaultVersion !== undefined && data.isDefaultVersion !== null) {
-    contents.isDefaultVersion = data.isDefaultVersion;
+    contents.isDefaultVersion = __expectBoolean(data.isDefaultVersion);
   }
   if (data.templateArn !== undefined && data.templateArn !== null) {
-    contents.templateArn = data.templateArn;
+    contents.templateArn = __expectString(data.templateArn);
   }
   if (data.templateName !== undefined && data.templateName !== null) {
-    contents.templateName = data.templateName;
+    contents.templateName = __expectString(data.templateName);
   }
   if (data.versionId !== undefined && data.versionId !== null) {
-    contents.versionId = data.versionId;
+    contents.versionId = __expectNumber(data.versionId);
   }
   return Promise.resolve(contents);
 };
@@ -11308,10 +11311,10 @@ export const deserializeAws_restJson1CreateRoleAliasCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.roleAlias !== undefined && data.roleAlias !== null) {
-    contents.roleAlias = data.roleAlias;
+    contents.roleAlias = __expectString(data.roleAlias);
   }
   if (data.roleAliasArn !== undefined && data.roleAliasArn !== null) {
-    contents.roleAliasArn = data.roleAliasArn;
+    contents.roleAliasArn = __expectString(data.roleAliasArn);
   }
   return Promise.resolve(contents);
 };
@@ -11414,7 +11417,7 @@ export const deserializeAws_restJson1CreateScheduledAuditCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.scheduledAuditArn !== undefined && data.scheduledAuditArn !== null) {
-    contents.scheduledAuditArn = data.scheduledAuditArn;
+    contents.scheduledAuditArn = __expectString(data.scheduledAuditArn);
   }
   return Promise.resolve(contents);
 };
@@ -11502,10 +11505,10 @@ export const deserializeAws_restJson1CreateSecurityProfileCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.securityProfileArn !== undefined && data.securityProfileArn !== null) {
-    contents.securityProfileArn = data.securityProfileArn;
+    contents.securityProfileArn = __expectString(data.securityProfileArn);
   }
   if (data.securityProfileName !== undefined && data.securityProfileName !== null) {
-    contents.securityProfileName = data.securityProfileName;
+    contents.securityProfileName = __expectString(data.securityProfileName);
   }
   return Promise.resolve(contents);
 };
@@ -11587,16 +11590,16 @@ export const deserializeAws_restJson1CreateStreamCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.streamArn !== undefined && data.streamArn !== null) {
-    contents.streamArn = data.streamArn;
+    contents.streamArn = __expectString(data.streamArn);
   }
   if (data.streamId !== undefined && data.streamId !== null) {
-    contents.streamId = data.streamId;
+    contents.streamId = __expectString(data.streamId);
   }
   if (data.streamVersion !== undefined && data.streamVersion !== null) {
-    contents.streamVersion = data.streamVersion;
+    contents.streamVersion = __expectNumber(data.streamVersion);
   }
   return Promise.resolve(contents);
 };
@@ -11709,13 +11712,13 @@ export const deserializeAws_restJson1CreateThingCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.thingArn !== undefined && data.thingArn !== null) {
-    contents.thingArn = data.thingArn;
+    contents.thingArn = __expectString(data.thingArn);
   }
   if (data.thingId !== undefined && data.thingId !== null) {
-    contents.thingId = data.thingId;
+    contents.thingId = __expectString(data.thingId);
   }
   if (data.thingName !== undefined && data.thingName !== null) {
-    contents.thingName = data.thingName;
+    contents.thingName = __expectString(data.thingName);
   }
   return Promise.resolve(contents);
 };
@@ -11820,13 +11823,13 @@ export const deserializeAws_restJson1CreateThingGroupCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.thingGroupArn !== undefined && data.thingGroupArn !== null) {
-    contents.thingGroupArn = data.thingGroupArn;
+    contents.thingGroupArn = __expectString(data.thingGroupArn);
   }
   if (data.thingGroupId !== undefined && data.thingGroupId !== null) {
-    contents.thingGroupId = data.thingGroupId;
+    contents.thingGroupId = __expectString(data.thingGroupId);
   }
   if (data.thingGroupName !== undefined && data.thingGroupName !== null) {
-    contents.thingGroupName = data.thingGroupName;
+    contents.thingGroupName = __expectString(data.thingGroupName);
   }
   return Promise.resolve(contents);
 };
@@ -11907,13 +11910,13 @@ export const deserializeAws_restJson1CreateThingTypeCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.thingTypeArn !== undefined && data.thingTypeArn !== null) {
-    contents.thingTypeArn = data.thingTypeArn;
+    contents.thingTypeArn = __expectString(data.thingTypeArn);
   }
   if (data.thingTypeId !== undefined && data.thingTypeId !== null) {
-    contents.thingTypeId = data.thingTypeId;
+    contents.thingTypeId = __expectString(data.thingTypeId);
   }
   if (data.thingTypeName !== undefined && data.thingTypeName !== null) {
-    contents.thingTypeName = data.thingTypeName;
+    contents.thingTypeName = __expectString(data.thingTypeName);
   }
   return Promise.resolve(contents);
 };
@@ -14853,7 +14856,7 @@ export const deserializeAws_restJson1DescribeAccountAuditConfigurationCommand = 
     );
   }
   if (data.roleArn !== undefined && data.roleArn !== null) {
-    contents.roleArn = data.roleArn;
+    contents.roleArn = __expectString(data.roleArn);
   }
   return Promise.resolve(contents);
 };
@@ -15025,7 +15028,7 @@ export const deserializeAws_restJson1DescribeAuditMitigationActionsTaskCommand =
     );
   }
   if (data.taskStatus !== undefined && data.taskStatus !== null) {
-    contents.taskStatus = data.taskStatus;
+    contents.taskStatus = __expectString(data.taskStatus);
   }
   return Promise.resolve(contents);
 };
@@ -15108,10 +15111,10 @@ export const deserializeAws_restJson1DescribeAuditSuppressionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.checkName !== undefined && data.checkName !== null) {
-    contents.checkName = data.checkName;
+    contents.checkName = __expectString(data.checkName);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.expirationDate !== undefined && data.expirationDate !== null) {
     contents.expirationDate = new Date(Math.round(data.expirationDate * 1000));
@@ -15120,7 +15123,7 @@ export const deserializeAws_restJson1DescribeAuditSuppressionCommand = async (
     contents.resourceIdentifier = deserializeAws_restJson1ResourceIdentifier(data.resourceIdentifier, context);
   }
   if (data.suppressIndefinitely !== undefined && data.suppressIndefinitely !== null) {
-    contents.suppressIndefinitely = data.suppressIndefinitely;
+    contents.suppressIndefinitely = __expectBoolean(data.suppressIndefinitely);
   }
   return Promise.resolve(contents);
 };
@@ -15207,7 +15210,7 @@ export const deserializeAws_restJson1DescribeAuditTaskCommand = async (
     contents.auditDetails = deserializeAws_restJson1AuditDetails(data.auditDetails, context);
   }
   if (data.scheduledAuditName !== undefined && data.scheduledAuditName !== null) {
-    contents.scheduledAuditName = data.scheduledAuditName;
+    contents.scheduledAuditName = __expectString(data.scheduledAuditName);
   }
   if (data.taskStartTime !== undefined && data.taskStartTime !== null) {
     contents.taskStartTime = new Date(Math.round(data.taskStartTime * 1000));
@@ -15216,10 +15219,10 @@ export const deserializeAws_restJson1DescribeAuditTaskCommand = async (
     contents.taskStatistics = deserializeAws_restJson1TaskStatistics(data.taskStatistics, context);
   }
   if (data.taskStatus !== undefined && data.taskStatus !== null) {
-    contents.taskStatus = data.taskStatus;
+    contents.taskStatus = __expectString(data.taskStatus);
   }
   if (data.taskType !== undefined && data.taskType !== null) {
-    contents.taskType = data.taskType;
+    contents.taskType = __expectString(data.taskType);
   }
   return Promise.resolve(contents);
 };
@@ -15398,16 +15401,16 @@ export const deserializeAws_restJson1DescribeBillingGroupCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.billingGroupArn !== undefined && data.billingGroupArn !== null) {
-    contents.billingGroupArn = data.billingGroupArn;
+    contents.billingGroupArn = __expectString(data.billingGroupArn);
   }
   if (data.billingGroupId !== undefined && data.billingGroupId !== null) {
-    contents.billingGroupId = data.billingGroupId;
+    contents.billingGroupId = __expectString(data.billingGroupId);
   }
   if (data.billingGroupMetadata !== undefined && data.billingGroupMetadata !== null) {
     contents.billingGroupMetadata = deserializeAws_restJson1BillingGroupMetadata(data.billingGroupMetadata, context);
   }
   if (data.billingGroupName !== undefined && data.billingGroupName !== null) {
-    contents.billingGroupName = data.billingGroupName;
+    contents.billingGroupName = __expectString(data.billingGroupName);
   }
   if (data.billingGroupProperties !== undefined && data.billingGroupProperties !== null) {
     contents.billingGroupProperties = deserializeAws_restJson1BillingGroupProperties(
@@ -15416,7 +15419,7 @@ export const deserializeAws_restJson1DescribeBillingGroupCommand = async (
     );
   }
   if (data.version !== undefined && data.version !== null) {
-    contents.version = data.version;
+    contents.version = __expectNumber(data.version);
   }
   return Promise.resolve(contents);
 };
@@ -15703,19 +15706,19 @@ export const deserializeAws_restJson1DescribeCustomMetricCommand = async (
     contents.creationDate = new Date(Math.round(data.creationDate * 1000));
   }
   if (data.displayName !== undefined && data.displayName !== null) {
-    contents.displayName = data.displayName;
+    contents.displayName = __expectString(data.displayName);
   }
   if (data.lastModifiedDate !== undefined && data.lastModifiedDate !== null) {
     contents.lastModifiedDate = new Date(Math.round(data.lastModifiedDate * 1000));
   }
   if (data.metricArn !== undefined && data.metricArn !== null) {
-    contents.metricArn = data.metricArn;
+    contents.metricArn = __expectString(data.metricArn);
   }
   if (data.metricName !== undefined && data.metricName !== null) {
-    contents.metricName = data.metricName;
+    contents.metricName = __expectString(data.metricName);
   }
   if (data.metricType !== undefined && data.metricType !== null) {
-    contents.metricType = data.metricType;
+    contents.metricType = __expectString(data.metricType);
   }
   return Promise.resolve(contents);
 };
@@ -15973,7 +15976,7 @@ export const deserializeAws_restJson1DescribeDimensionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.creationDate !== undefined && data.creationDate !== null) {
     contents.creationDate = new Date(Math.round(data.creationDate * 1000));
@@ -15982,13 +15985,13 @@ export const deserializeAws_restJson1DescribeDimensionCommand = async (
     contents.lastModifiedDate = new Date(Math.round(data.lastModifiedDate * 1000));
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.stringValues !== undefined && data.stringValues !== null) {
     contents.stringValues = deserializeAws_restJson1DimensionStringValues(data.stringValues, context);
   }
   if (data.type !== undefined && data.type !== null) {
-    contents.type = data.type;
+    contents.type = __expectString(data.type);
   }
   return Promise.resolve(contents);
 };
@@ -16078,19 +16081,19 @@ export const deserializeAws_restJson1DescribeDomainConfigurationCommand = async 
     contents.authorizerConfig = deserializeAws_restJson1AuthorizerConfig(data.authorizerConfig, context);
   }
   if (data.domainConfigurationArn !== undefined && data.domainConfigurationArn !== null) {
-    contents.domainConfigurationArn = data.domainConfigurationArn;
+    contents.domainConfigurationArn = __expectString(data.domainConfigurationArn);
   }
   if (data.domainConfigurationName !== undefined && data.domainConfigurationName !== null) {
-    contents.domainConfigurationName = data.domainConfigurationName;
+    contents.domainConfigurationName = __expectString(data.domainConfigurationName);
   }
   if (data.domainConfigurationStatus !== undefined && data.domainConfigurationStatus !== null) {
-    contents.domainConfigurationStatus = data.domainConfigurationStatus;
+    contents.domainConfigurationStatus = __expectString(data.domainConfigurationStatus);
   }
   if (data.domainName !== undefined && data.domainName !== null) {
-    contents.domainName = data.domainName;
+    contents.domainName = __expectString(data.domainName);
   }
   if (data.domainType !== undefined && data.domainType !== null) {
-    contents.domainType = data.domainType;
+    contents.domainType = __expectString(data.domainType);
   }
   if (data.lastStatusChangeDate !== undefined && data.lastStatusChangeDate !== null) {
     contents.lastStatusChangeDate = new Date(Math.round(data.lastStatusChangeDate * 1000));
@@ -16099,7 +16102,7 @@ export const deserializeAws_restJson1DescribeDomainConfigurationCommand = async 
     contents.serverCertificates = deserializeAws_restJson1ServerCertificates(data.serverCertificates, context);
   }
   if (data.serviceType !== undefined && data.serviceType !== null) {
-    contents.serviceType = data.serviceType;
+    contents.serviceType = __expectString(data.serviceType);
   }
   return Promise.resolve(contents);
 };
@@ -16194,7 +16197,7 @@ export const deserializeAws_restJson1DescribeEndpointCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.endpointAddress !== undefined && data.endpointAddress !== null) {
-    contents.endpointAddress = data.endpointAddress;
+    contents.endpointAddress = __expectString(data.endpointAddress);
   }
   return Promise.resolve(contents);
 };
@@ -16346,13 +16349,13 @@ export const deserializeAws_restJson1DescribeIndexCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.indexName !== undefined && data.indexName !== null) {
-    contents.indexName = data.indexName;
+    contents.indexName = __expectString(data.indexName);
   }
   if (data.indexStatus !== undefined && data.indexStatus !== null) {
-    contents.indexStatus = data.indexStatus;
+    contents.indexStatus = __expectString(data.indexStatus);
   }
   if (data.schema !== undefined && data.schema !== null) {
-    contents.schema = data.schema;
+    contents.schema = __expectString(data.schema);
   }
   return Promise.resolve(contents);
 };
@@ -16448,7 +16451,7 @@ export const deserializeAws_restJson1DescribeJobCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.documentSource !== undefined && data.documentSource !== null) {
-    contents.documentSource = data.documentSource;
+    contents.documentSource = __expectString(data.documentSource);
   }
   if (data.job !== undefined && data.job !== null) {
     contents.job = deserializeAws_restJson1Job(data.job, context);
@@ -16624,13 +16627,13 @@ export const deserializeAws_restJson1DescribeJobTemplateCommand = async (
     contents.createdAt = new Date(Math.round(data.createdAt * 1000));
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.document !== undefined && data.document !== null) {
-    contents.document = data.document;
+    contents.document = __expectString(data.document);
   }
   if (data.documentSource !== undefined && data.documentSource !== null) {
-    contents.documentSource = data.documentSource;
+    contents.documentSource = __expectString(data.documentSource);
   }
   if (data.jobExecutionsRolloutConfig !== undefined && data.jobExecutionsRolloutConfig !== null) {
     contents.jobExecutionsRolloutConfig = deserializeAws_restJson1JobExecutionsRolloutConfig(
@@ -16639,10 +16642,10 @@ export const deserializeAws_restJson1DescribeJobTemplateCommand = async (
     );
   }
   if (data.jobTemplateArn !== undefined && data.jobTemplateArn !== null) {
-    contents.jobTemplateArn = data.jobTemplateArn;
+    contents.jobTemplateArn = __expectString(data.jobTemplateArn);
   }
   if (data.jobTemplateId !== undefined && data.jobTemplateId !== null) {
-    contents.jobTemplateId = data.jobTemplateId;
+    contents.jobTemplateId = __expectString(data.jobTemplateId);
   }
   if (data.presignedUrlConfig !== undefined && data.presignedUrlConfig !== null) {
     contents.presignedUrlConfig = deserializeAws_restJson1PresignedUrlConfig(data.presignedUrlConfig, context);
@@ -16734,19 +16737,19 @@ export const deserializeAws_restJson1DescribeMitigationActionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.actionArn !== undefined && data.actionArn !== null) {
-    contents.actionArn = data.actionArn;
+    contents.actionArn = __expectString(data.actionArn);
   }
   if (data.actionId !== undefined && data.actionId !== null) {
-    contents.actionId = data.actionId;
+    contents.actionId = __expectString(data.actionId);
   }
   if (data.actionName !== undefined && data.actionName !== null) {
-    contents.actionName = data.actionName;
+    contents.actionName = __expectString(data.actionName);
   }
   if (data.actionParams !== undefined && data.actionParams !== null) {
     contents.actionParams = deserializeAws_restJson1MitigationActionParams(data.actionParams, context);
   }
   if (data.actionType !== undefined && data.actionType !== null) {
-    contents.actionType = data.actionType;
+    contents.actionType = __expectString(data.actionType);
   }
   if (data.creationDate !== undefined && data.creationDate !== null) {
     contents.creationDate = new Date(Math.round(data.creationDate * 1000));
@@ -16755,7 +16758,7 @@ export const deserializeAws_restJson1DescribeMitigationActionCommand = async (
     contents.lastModifiedDate = new Date(Math.round(data.lastModifiedDate * 1000));
   }
   if (data.roleArn !== undefined && data.roleArn !== null) {
-    contents.roleArn = data.roleArn;
+    contents.roleArn = __expectString(data.roleArn);
   }
   return Promise.resolve(contents);
 };
@@ -16846,13 +16849,13 @@ export const deserializeAws_restJson1DescribeProvisioningTemplateCommand = async
     contents.creationDate = new Date(Math.round(data.creationDate * 1000));
   }
   if (data.defaultVersionId !== undefined && data.defaultVersionId !== null) {
-    contents.defaultVersionId = data.defaultVersionId;
+    contents.defaultVersionId = __expectNumber(data.defaultVersionId);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.enabled !== undefined && data.enabled !== null) {
-    contents.enabled = data.enabled;
+    contents.enabled = __expectBoolean(data.enabled);
   }
   if (data.lastModifiedDate !== undefined && data.lastModifiedDate !== null) {
     contents.lastModifiedDate = new Date(Math.round(data.lastModifiedDate * 1000));
@@ -16861,16 +16864,16 @@ export const deserializeAws_restJson1DescribeProvisioningTemplateCommand = async
     contents.preProvisioningHook = deserializeAws_restJson1ProvisioningHook(data.preProvisioningHook, context);
   }
   if (data.provisioningRoleArn !== undefined && data.provisioningRoleArn !== null) {
-    contents.provisioningRoleArn = data.provisioningRoleArn;
+    contents.provisioningRoleArn = __expectString(data.provisioningRoleArn);
   }
   if (data.templateArn !== undefined && data.templateArn !== null) {
-    contents.templateArn = data.templateArn;
+    contents.templateArn = __expectString(data.templateArn);
   }
   if (data.templateBody !== undefined && data.templateBody !== null) {
-    contents.templateBody = data.templateBody;
+    contents.templateBody = __expectString(data.templateBody);
   }
   if (data.templateName !== undefined && data.templateName !== null) {
-    contents.templateName = data.templateName;
+    contents.templateName = __expectString(data.templateName);
   }
   return Promise.resolve(contents);
 };
@@ -16963,13 +16966,13 @@ export const deserializeAws_restJson1DescribeProvisioningTemplateVersionCommand 
     contents.creationDate = new Date(Math.round(data.creationDate * 1000));
   }
   if (data.isDefaultVersion !== undefined && data.isDefaultVersion !== null) {
-    contents.isDefaultVersion = data.isDefaultVersion;
+    contents.isDefaultVersion = __expectBoolean(data.isDefaultVersion);
   }
   if (data.templateBody !== undefined && data.templateBody !== null) {
-    contents.templateBody = data.templateBody;
+    contents.templateBody = __expectString(data.templateBody);
   }
   if (data.versionId !== undefined && data.versionId !== null) {
-    contents.versionId = data.versionId;
+    contents.versionId = __expectNumber(data.versionId);
   }
   return Promise.resolve(contents);
 };
@@ -17156,19 +17159,19 @@ export const deserializeAws_restJson1DescribeScheduledAuditCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.dayOfMonth !== undefined && data.dayOfMonth !== null) {
-    contents.dayOfMonth = data.dayOfMonth;
+    contents.dayOfMonth = __expectString(data.dayOfMonth);
   }
   if (data.dayOfWeek !== undefined && data.dayOfWeek !== null) {
-    contents.dayOfWeek = data.dayOfWeek;
+    contents.dayOfWeek = __expectString(data.dayOfWeek);
   }
   if (data.frequency !== undefined && data.frequency !== null) {
-    contents.frequency = data.frequency;
+    contents.frequency = __expectString(data.frequency);
   }
   if (data.scheduledAuditArn !== undefined && data.scheduledAuditArn !== null) {
-    contents.scheduledAuditArn = data.scheduledAuditArn;
+    contents.scheduledAuditArn = __expectString(data.scheduledAuditArn);
   }
   if (data.scheduledAuditName !== undefined && data.scheduledAuditName !== null) {
-    contents.scheduledAuditName = data.scheduledAuditName;
+    contents.scheduledAuditName = __expectString(data.scheduledAuditName);
   }
   if (data.targetCheckNames !== undefined && data.targetCheckNames !== null) {
     contents.targetCheckNames = deserializeAws_restJson1TargetAuditCheckNames(data.targetCheckNames, context);
@@ -17283,16 +17286,16 @@ export const deserializeAws_restJson1DescribeSecurityProfileCommand = async (
     contents.lastModifiedDate = new Date(Math.round(data.lastModifiedDate * 1000));
   }
   if (data.securityProfileArn !== undefined && data.securityProfileArn !== null) {
-    contents.securityProfileArn = data.securityProfileArn;
+    contents.securityProfileArn = __expectString(data.securityProfileArn);
   }
   if (data.securityProfileDescription !== undefined && data.securityProfileDescription !== null) {
-    contents.securityProfileDescription = data.securityProfileDescription;
+    contents.securityProfileDescription = __expectString(data.securityProfileDescription);
   }
   if (data.securityProfileName !== undefined && data.securityProfileName !== null) {
-    contents.securityProfileName = data.securityProfileName;
+    contents.securityProfileName = __expectString(data.securityProfileName);
   }
   if (data.version !== undefined && data.version !== null) {
-    contents.version = data.version;
+    contents.version = __expectNumber(data.version);
   }
   return Promise.resolve(contents);
 };
@@ -17476,25 +17479,25 @@ export const deserializeAws_restJson1DescribeThingCommand = async (
     contents.attributes = deserializeAws_restJson1Attributes(data.attributes, context);
   }
   if (data.billingGroupName !== undefined && data.billingGroupName !== null) {
-    contents.billingGroupName = data.billingGroupName;
+    contents.billingGroupName = __expectString(data.billingGroupName);
   }
   if (data.defaultClientId !== undefined && data.defaultClientId !== null) {
-    contents.defaultClientId = data.defaultClientId;
+    contents.defaultClientId = __expectString(data.defaultClientId);
   }
   if (data.thingArn !== undefined && data.thingArn !== null) {
-    contents.thingArn = data.thingArn;
+    contents.thingArn = __expectString(data.thingArn);
   }
   if (data.thingId !== undefined && data.thingId !== null) {
-    contents.thingId = data.thingId;
+    contents.thingId = __expectString(data.thingId);
   }
   if (data.thingName !== undefined && data.thingName !== null) {
-    contents.thingName = data.thingName;
+    contents.thingName = __expectString(data.thingName);
   }
   if (data.thingTypeName !== undefined && data.thingTypeName !== null) {
-    contents.thingTypeName = data.thingTypeName;
+    contents.thingTypeName = __expectString(data.thingTypeName);
   }
   if (data.version !== undefined && data.version !== null) {
-    contents.version = data.version;
+    contents.version = __expectNumber(data.version);
   }
   return Promise.resolve(contents);
 };
@@ -17598,34 +17601,34 @@ export const deserializeAws_restJson1DescribeThingGroupCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.indexName !== undefined && data.indexName !== null) {
-    contents.indexName = data.indexName;
+    contents.indexName = __expectString(data.indexName);
   }
   if (data.queryString !== undefined && data.queryString !== null) {
-    contents.queryString = data.queryString;
+    contents.queryString = __expectString(data.queryString);
   }
   if (data.queryVersion !== undefined && data.queryVersion !== null) {
-    contents.queryVersion = data.queryVersion;
+    contents.queryVersion = __expectString(data.queryVersion);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.status = data.status;
+    contents.status = __expectString(data.status);
   }
   if (data.thingGroupArn !== undefined && data.thingGroupArn !== null) {
-    contents.thingGroupArn = data.thingGroupArn;
+    contents.thingGroupArn = __expectString(data.thingGroupArn);
   }
   if (data.thingGroupId !== undefined && data.thingGroupId !== null) {
-    contents.thingGroupId = data.thingGroupId;
+    contents.thingGroupId = __expectString(data.thingGroupId);
   }
   if (data.thingGroupMetadata !== undefined && data.thingGroupMetadata !== null) {
     contents.thingGroupMetadata = deserializeAws_restJson1ThingGroupMetadata(data.thingGroupMetadata, context);
   }
   if (data.thingGroupName !== undefined && data.thingGroupName !== null) {
-    contents.thingGroupName = data.thingGroupName;
+    contents.thingGroupName = __expectString(data.thingGroupName);
   }
   if (data.thingGroupProperties !== undefined && data.thingGroupProperties !== null) {
     contents.thingGroupProperties = deserializeAws_restJson1ThingGroupProperties(data.thingGroupProperties, context);
   }
   if (data.version !== undefined && data.version !== null) {
-    contents.version = data.version;
+    contents.version = __expectNumber(data.version);
   }
   return Promise.resolve(contents);
 };
@@ -17718,37 +17721,37 @@ export const deserializeAws_restJson1DescribeThingRegistrationTaskCommand = asyn
     contents.creationDate = new Date(Math.round(data.creationDate * 1000));
   }
   if (data.failureCount !== undefined && data.failureCount !== null) {
-    contents.failureCount = data.failureCount;
+    contents.failureCount = __expectNumber(data.failureCount);
   }
   if (data.inputFileBucket !== undefined && data.inputFileBucket !== null) {
-    contents.inputFileBucket = data.inputFileBucket;
+    contents.inputFileBucket = __expectString(data.inputFileBucket);
   }
   if (data.inputFileKey !== undefined && data.inputFileKey !== null) {
-    contents.inputFileKey = data.inputFileKey;
+    contents.inputFileKey = __expectString(data.inputFileKey);
   }
   if (data.lastModifiedDate !== undefined && data.lastModifiedDate !== null) {
     contents.lastModifiedDate = new Date(Math.round(data.lastModifiedDate * 1000));
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.percentageProgress !== undefined && data.percentageProgress !== null) {
-    contents.percentageProgress = data.percentageProgress;
+    contents.percentageProgress = __expectNumber(data.percentageProgress);
   }
   if (data.roleArn !== undefined && data.roleArn !== null) {
-    contents.roleArn = data.roleArn;
+    contents.roleArn = __expectString(data.roleArn);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.status = data.status;
+    contents.status = __expectString(data.status);
   }
   if (data.successCount !== undefined && data.successCount !== null) {
-    contents.successCount = data.successCount;
+    contents.successCount = __expectNumber(data.successCount);
   }
   if (data.taskId !== undefined && data.taskId !== null) {
-    contents.taskId = data.taskId;
+    contents.taskId = __expectString(data.taskId);
   }
   if (data.templateBody !== undefined && data.templateBody !== null) {
-    contents.templateBody = data.templateBody;
+    contents.templateBody = __expectString(data.templateBody);
   }
   return Promise.resolve(contents);
 };
@@ -17839,16 +17842,16 @@ export const deserializeAws_restJson1DescribeThingTypeCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.thingTypeArn !== undefined && data.thingTypeArn !== null) {
-    contents.thingTypeArn = data.thingTypeArn;
+    contents.thingTypeArn = __expectString(data.thingTypeArn);
   }
   if (data.thingTypeId !== undefined && data.thingTypeId !== null) {
-    contents.thingTypeId = data.thingTypeId;
+    contents.thingTypeId = __expectString(data.thingTypeId);
   }
   if (data.thingTypeMetadata !== undefined && data.thingTypeMetadata !== null) {
     contents.thingTypeMetadata = deserializeAws_restJson1ThingTypeMetadata(data.thingTypeMetadata, context);
   }
   if (data.thingTypeName !== undefined && data.thingTypeName !== null) {
-    contents.thingTypeName = data.thingTypeName;
+    contents.thingTypeName = __expectString(data.thingTypeName);
   }
   if (data.thingTypeProperties !== undefined && data.thingTypeProperties !== null) {
     contents.thingTypeProperties = deserializeAws_restJson1ThingTypeProperties(data.thingTypeProperties, context);
@@ -18461,7 +18464,7 @@ export const deserializeAws_restJson1GetBehaviorModelTrainingSummariesCommand = 
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.summaries !== undefined && data.summaries !== null) {
     contents.summaries = deserializeAws_restJson1BehaviorModelTrainingSummaries(data.summaries, context);
@@ -18543,7 +18546,7 @@ export const deserializeAws_restJson1GetCardinalityCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.cardinality !== undefined && data.cardinality !== null) {
-    contents.cardinality = data.cardinality;
+    contents.cardinality = __expectNumber(data.cardinality);
   }
   return Promise.resolve(contents);
 };
@@ -18862,7 +18865,7 @@ export const deserializeAws_restJson1GetJobDocumentCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.document !== undefined && data.document !== null) {
-    contents.document = data.document;
+    contents.document = __expectString(data.document);
   }
   return Promise.resolve(contents);
 };
@@ -18942,10 +18945,10 @@ export const deserializeAws_restJson1GetLoggingOptionsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.logLevel !== undefined && data.logLevel !== null) {
-    contents.logLevel = data.logLevel;
+    contents.logLevel = __expectString(data.logLevel);
   }
   if (data.roleArn !== undefined && data.roleArn !== null) {
-    contents.roleArn = data.roleArn;
+    contents.roleArn = __expectString(data.roleArn);
   }
   return Promise.resolve(contents);
 };
@@ -19239,22 +19242,22 @@ export const deserializeAws_restJson1GetPolicyCommand = async (
     contents.creationDate = new Date(Math.round(data.creationDate * 1000));
   }
   if (data.defaultVersionId !== undefined && data.defaultVersionId !== null) {
-    contents.defaultVersionId = data.defaultVersionId;
+    contents.defaultVersionId = __expectString(data.defaultVersionId);
   }
   if (data.generationId !== undefined && data.generationId !== null) {
-    contents.generationId = data.generationId;
+    contents.generationId = __expectString(data.generationId);
   }
   if (data.lastModifiedDate !== undefined && data.lastModifiedDate !== null) {
     contents.lastModifiedDate = new Date(Math.round(data.lastModifiedDate * 1000));
   }
   if (data.policyArn !== undefined && data.policyArn !== null) {
-    contents.policyArn = data.policyArn;
+    contents.policyArn = __expectString(data.policyArn);
   }
   if (data.policyDocument !== undefined && data.policyDocument !== null) {
-    contents.policyDocument = data.policyDocument;
+    contents.policyDocument = __expectString(data.policyDocument);
   }
   if (data.policyName !== undefined && data.policyName !== null) {
-    contents.policyName = data.policyName;
+    contents.policyName = __expectString(data.policyName);
   }
   return Promise.resolve(contents);
 };
@@ -19359,25 +19362,25 @@ export const deserializeAws_restJson1GetPolicyVersionCommand = async (
     contents.creationDate = new Date(Math.round(data.creationDate * 1000));
   }
   if (data.generationId !== undefined && data.generationId !== null) {
-    contents.generationId = data.generationId;
+    contents.generationId = __expectString(data.generationId);
   }
   if (data.isDefaultVersion !== undefined && data.isDefaultVersion !== null) {
-    contents.isDefaultVersion = data.isDefaultVersion;
+    contents.isDefaultVersion = __expectBoolean(data.isDefaultVersion);
   }
   if (data.lastModifiedDate !== undefined && data.lastModifiedDate !== null) {
     contents.lastModifiedDate = new Date(Math.round(data.lastModifiedDate * 1000));
   }
   if (data.policyArn !== undefined && data.policyArn !== null) {
-    contents.policyArn = data.policyArn;
+    contents.policyArn = __expectString(data.policyArn);
   }
   if (data.policyDocument !== undefined && data.policyDocument !== null) {
-    contents.policyDocument = data.policyDocument;
+    contents.policyDocument = __expectString(data.policyDocument);
   }
   if (data.policyName !== undefined && data.policyName !== null) {
-    contents.policyName = data.policyName;
+    contents.policyName = __expectString(data.policyName);
   }
   if (data.policyVersionId !== undefined && data.policyVersionId !== null) {
-    contents.policyVersionId = data.policyVersionId;
+    contents.policyVersionId = __expectString(data.policyVersionId);
   }
   return Promise.resolve(contents);
 };
@@ -19472,7 +19475,7 @@ export const deserializeAws_restJson1GetRegistrationCodeCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.registrationCode !== undefined && data.registrationCode !== null) {
-    contents.registrationCode = data.registrationCode;
+    contents.registrationCode = __expectString(data.registrationCode);
   }
   return Promise.resolve(contents);
 };
@@ -19682,7 +19685,7 @@ export const deserializeAws_restJson1GetTopicRuleCommand = async (
     contents.rule = deserializeAws_restJson1TopicRule(data.rule, context);
   }
   if (data.ruleArn !== undefined && data.ruleArn !== null) {
-    contents.ruleArn = data.ruleArn;
+    contents.ruleArn = __expectString(data.ruleArn);
   }
   return Promise.resolve(contents);
 };
@@ -19842,13 +19845,13 @@ export const deserializeAws_restJson1GetV2LoggingOptionsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.defaultLogLevel !== undefined && data.defaultLogLevel !== null) {
-    contents.defaultLogLevel = data.defaultLogLevel;
+    contents.defaultLogLevel = __expectString(data.defaultLogLevel);
   }
   if (data.disableAllLogs !== undefined && data.disableAllLogs !== null) {
-    contents.disableAllLogs = data.disableAllLogs;
+    contents.disableAllLogs = __expectBoolean(data.disableAllLogs);
   }
   if (data.roleArn !== undefined && data.roleArn !== null) {
-    contents.roleArn = data.roleArn;
+    contents.roleArn = __expectString(data.roleArn);
   }
   return Promise.resolve(contents);
 };
@@ -19923,7 +19926,7 @@ export const deserializeAws_restJson1ListActiveViolationsCommand = async (
     contents.activeViolations = deserializeAws_restJson1ActiveViolations(data.activeViolations, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -20003,7 +20006,7 @@ export const deserializeAws_restJson1ListAttachedPoliciesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextMarker !== undefined && data.nextMarker !== null) {
-    contents.nextMarker = data.nextMarker;
+    contents.nextMarker = __expectString(data.nextMarker);
   }
   if (data.policies !== undefined && data.policies !== null) {
     contents.policies = deserializeAws_restJson1Policies(data.policies, context);
@@ -20113,7 +20116,7 @@ export const deserializeAws_restJson1ListAuditFindingsCommand = async (
     contents.findings = deserializeAws_restJson1AuditFindings(data.findings, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -20191,7 +20194,7 @@ export const deserializeAws_restJson1ListAuditMitigationActionsExecutionsCommand
     );
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -20263,7 +20266,7 @@ export const deserializeAws_restJson1ListAuditMitigationActionsTasksCommand = as
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.tasks !== undefined && data.tasks !== null) {
     contents.tasks = deserializeAws_restJson1AuditMitigationActionsTaskMetadataList(data.tasks, context);
@@ -20338,7 +20341,7 @@ export const deserializeAws_restJson1ListAuditSuppressionsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.suppressions !== undefined && data.suppressions !== null) {
     contents.suppressions = deserializeAws_restJson1AuditSuppressionList(data.suppressions, context);
@@ -20413,7 +20416,7 @@ export const deserializeAws_restJson1ListAuditTasksCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.tasks !== undefined && data.tasks !== null) {
     contents.tasks = deserializeAws_restJson1AuditTaskMetadataList(data.tasks, context);
@@ -20491,7 +20494,7 @@ export const deserializeAws_restJson1ListAuthorizersCommand = async (
     contents.authorizers = deserializeAws_restJson1Authorizers(data.authorizers, context);
   }
   if (data.nextMarker !== undefined && data.nextMarker !== null) {
-    contents.nextMarker = data.nextMarker;
+    contents.nextMarker = __expectString(data.nextMarker);
   }
   return Promise.resolve(contents);
 };
@@ -20582,7 +20585,7 @@ export const deserializeAws_restJson1ListBillingGroupsCommand = async (
     contents.billingGroups = deserializeAws_restJson1BillingGroupNameAndArnList(data.billingGroups, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -20665,7 +20668,7 @@ export const deserializeAws_restJson1ListCACertificatesCommand = async (
     contents.certificates = deserializeAws_restJson1CACertificates(data.certificates, context);
   }
   if (data.nextMarker !== undefined && data.nextMarker !== null) {
-    contents.nextMarker = data.nextMarker;
+    contents.nextMarker = __expectString(data.nextMarker);
   }
   return Promise.resolve(contents);
 };
@@ -20756,7 +20759,7 @@ export const deserializeAws_restJson1ListCertificatesCommand = async (
     contents.certificates = deserializeAws_restJson1Certificates(data.certificates, context);
   }
   if (data.nextMarker !== undefined && data.nextMarker !== null) {
-    contents.nextMarker = data.nextMarker;
+    contents.nextMarker = __expectString(data.nextMarker);
   }
   return Promise.resolve(contents);
 };
@@ -20847,7 +20850,7 @@ export const deserializeAws_restJson1ListCertificatesByCACommand = async (
     contents.certificates = deserializeAws_restJson1Certificates(data.certificates, context);
   }
   if (data.nextMarker !== undefined && data.nextMarker !== null) {
-    contents.nextMarker = data.nextMarker;
+    contents.nextMarker = __expectString(data.nextMarker);
   }
   return Promise.resolve(contents);
 };
@@ -20938,7 +20941,7 @@ export const deserializeAws_restJson1ListCustomMetricsCommand = async (
     contents.metricNames = deserializeAws_restJson1MetricNames(data.metricNames, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -21016,7 +21019,7 @@ export const deserializeAws_restJson1ListDetectMitigationActionsExecutionsComman
     );
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -21088,7 +21091,7 @@ export const deserializeAws_restJson1ListDetectMitigationActionsTasksCommand = a
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.tasks !== undefined && data.tasks !== null) {
     contents.tasks = deserializeAws_restJson1DetectMitigationActionsTaskSummaryList(data.tasks, context);
@@ -21166,7 +21169,7 @@ export const deserializeAws_restJson1ListDimensionsCommand = async (
     contents.dimensionNames = deserializeAws_restJson1DimensionNames(data.dimensionNames, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -21241,7 +21244,7 @@ export const deserializeAws_restJson1ListDomainConfigurationsCommand = async (
     contents.domainConfigurations = deserializeAws_restJson1DomainConfigurations(data.domainConfigurations, context);
   }
   if (data.nextMarker !== undefined && data.nextMarker !== null) {
-    contents.nextMarker = data.nextMarker;
+    contents.nextMarker = __expectString(data.nextMarker);
   }
   return Promise.resolve(contents);
 };
@@ -21332,7 +21335,7 @@ export const deserializeAws_restJson1ListIndicesCommand = async (
     contents.indexNames = deserializeAws_restJson1IndexNamesList(data.indexNames, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -21426,7 +21429,7 @@ export const deserializeAws_restJson1ListJobExecutionsForJobCommand = async (
     );
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -21512,7 +21515,7 @@ export const deserializeAws_restJson1ListJobExecutionsForThingCommand = async (
     );
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -21595,7 +21598,7 @@ export const deserializeAws_restJson1ListJobsCommand = async (
     contents.jobs = deserializeAws_restJson1JobSummaryList(data.jobs, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -21678,7 +21681,7 @@ export const deserializeAws_restJson1ListJobTemplatesCommand = async (
     contents.jobTemplates = deserializeAws_restJson1JobTemplateSummaryList(data.jobTemplates, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -21756,7 +21759,7 @@ export const deserializeAws_restJson1ListMitigationActionsCommand = async (
     );
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -21828,7 +21831,7 @@ export const deserializeAws_restJson1ListOTAUpdatesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.otaUpdates !== undefined && data.otaUpdates !== null) {
     contents.otaUpdates = deserializeAws_restJson1OTAUpdatesSummary(data.otaUpdates, context);
@@ -21919,7 +21922,7 @@ export const deserializeAws_restJson1ListOutgoingCertificatesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextMarker !== undefined && data.nextMarker !== null) {
-    contents.nextMarker = data.nextMarker;
+    contents.nextMarker = __expectString(data.nextMarker);
   }
   if (data.outgoingCertificates !== undefined && data.outgoingCertificates !== null) {
     contents.outgoingCertificates = deserializeAws_restJson1OutgoingCertificates(data.outgoingCertificates, context);
@@ -22010,7 +22013,7 @@ export const deserializeAws_restJson1ListPoliciesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextMarker !== undefined && data.nextMarker !== null) {
-    contents.nextMarker = data.nextMarker;
+    contents.nextMarker = __expectString(data.nextMarker);
   }
   if (data.policies !== undefined && data.policies !== null) {
     contents.policies = deserializeAws_restJson1Policies(data.policies, context);
@@ -22101,7 +22104,7 @@ export const deserializeAws_restJson1ListPolicyPrincipalsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextMarker !== undefined && data.nextMarker !== null) {
-    contents.nextMarker = data.nextMarker;
+    contents.nextMarker = __expectString(data.nextMarker);
   }
   if (data.principals !== undefined && data.principals !== null) {
     contents.principals = deserializeAws_restJson1Principals(data.principals, context);
@@ -22295,7 +22298,7 @@ export const deserializeAws_restJson1ListPrincipalPoliciesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextMarker !== undefined && data.nextMarker !== null) {
-    contents.nextMarker = data.nextMarker;
+    contents.nextMarker = __expectString(data.nextMarker);
   }
   if (data.policies !== undefined && data.policies !== null) {
     contents.policies = deserializeAws_restJson1Policies(data.policies, context);
@@ -22394,7 +22397,7 @@ export const deserializeAws_restJson1ListPrincipalThingsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.things !== undefined && data.things !== null) {
     contents.things = deserializeAws_restJson1ThingNameList(data.things, context);
@@ -22493,7 +22496,7 @@ export const deserializeAws_restJson1ListProvisioningTemplatesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.templates !== undefined && data.templates !== null) {
     contents.templates = deserializeAws_restJson1ProvisioningTemplateListing(data.templates, context);
@@ -22576,7 +22579,7 @@ export const deserializeAws_restJson1ListProvisioningTemplateVersionsCommand = a
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.versions !== undefined && data.versions !== null) {
     contents.versions = deserializeAws_restJson1ProvisioningTemplateVersionListing(data.versions, context);
@@ -22667,7 +22670,7 @@ export const deserializeAws_restJson1ListRoleAliasesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextMarker !== undefined && data.nextMarker !== null) {
-    contents.nextMarker = data.nextMarker;
+    contents.nextMarker = __expectString(data.nextMarker);
   }
   if (data.roleAliases !== undefined && data.roleAliases !== null) {
     contents.roleAliases = deserializeAws_restJson1RoleAliases(data.roleAliases, context);
@@ -22758,7 +22761,7 @@ export const deserializeAws_restJson1ListScheduledAuditsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.scheduledAudits !== undefined && data.scheduledAudits !== null) {
     contents.scheduledAudits = deserializeAws_restJson1ScheduledAuditMetadataList(data.scheduledAudits, context);
@@ -22833,7 +22836,7 @@ export const deserializeAws_restJson1ListSecurityProfilesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.securityProfileIdentifiers !== undefined && data.securityProfileIdentifiers !== null) {
     contents.securityProfileIdentifiers = deserializeAws_restJson1SecurityProfileIdentifiers(
@@ -22919,7 +22922,7 @@ export const deserializeAws_restJson1ListSecurityProfilesForTargetCommand = asyn
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.securityProfileTargetMappings !== undefined && data.securityProfileTargetMappings !== null) {
     contents.securityProfileTargetMappings = deserializeAws_restJson1SecurityProfileTargetMappings(
@@ -23005,7 +23008,7 @@ export const deserializeAws_restJson1ListStreamsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.streams !== undefined && data.streams !== null) {
     contents.streams = deserializeAws_restJson1StreamsSummary(data.streams, context);
@@ -23096,7 +23099,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagList(data.tags, context);
@@ -23179,7 +23182,7 @@ export const deserializeAws_restJson1ListTargetsForPolicyCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextMarker !== undefined && data.nextMarker !== null) {
-    contents.nextMarker = data.nextMarker;
+    contents.nextMarker = __expectString(data.nextMarker);
   }
   if (data.targets !== undefined && data.targets !== null) {
     contents.targets = deserializeAws_restJson1PolicyTargets(data.targets, context);
@@ -23286,7 +23289,7 @@ export const deserializeAws_restJson1ListTargetsForSecurityProfileCommand = asyn
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.securityProfileTargets !== undefined && data.securityProfileTargets !== null) {
     contents.securityProfileTargets = deserializeAws_restJson1SecurityProfileTargets(
@@ -23372,7 +23375,7 @@ export const deserializeAws_restJson1ListThingGroupsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.thingGroups !== undefined && data.thingGroups !== null) {
     contents.thingGroups = deserializeAws_restJson1ThingGroupNameAndArnList(data.thingGroups, context);
@@ -23455,7 +23458,7 @@ export const deserializeAws_restJson1ListThingGroupsForThingCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.thingGroups !== undefined && data.thingGroups !== null) {
     contents.thingGroups = deserializeAws_restJson1ThingGroupNameAndArnList(data.thingGroups, context);
@@ -23538,7 +23541,7 @@ export const deserializeAws_restJson1ListThingPrincipalsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.principals !== undefined && data.principals !== null) {
     contents.principals = deserializeAws_restJson1Principals(data.principals, context);
@@ -23638,10 +23641,10 @@ export const deserializeAws_restJson1ListThingRegistrationTaskReportsCommand = a
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.reportType !== undefined && data.reportType !== null) {
-    contents.reportType = data.reportType;
+    contents.reportType = __expectString(data.reportType);
   }
   if (data.resourceLinks !== undefined && data.resourceLinks !== null) {
     contents.resourceLinks = deserializeAws_restJson1S3FileUrlList(data.resourceLinks, context);
@@ -23724,7 +23727,7 @@ export const deserializeAws_restJson1ListThingRegistrationTasksCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.taskIds !== undefined && data.taskIds !== null) {
     contents.taskIds = deserializeAws_restJson1TaskIdList(data.taskIds, context);
@@ -23807,7 +23810,7 @@ export const deserializeAws_restJson1ListThingsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.things !== undefined && data.things !== null) {
     contents.things = deserializeAws_restJson1ThingAttributeList(data.things, context);
@@ -23898,7 +23901,7 @@ export const deserializeAws_restJson1ListThingsInBillingGroupCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.things !== undefined && data.things !== null) {
     contents.things = deserializeAws_restJson1ThingNameList(data.things, context);
@@ -23981,7 +23984,7 @@ export const deserializeAws_restJson1ListThingsInThingGroupCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.things !== undefined && data.things !== null) {
     contents.things = deserializeAws_restJson1ThingNameList(data.things, context);
@@ -24064,7 +24067,7 @@ export const deserializeAws_restJson1ListThingTypesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.thingTypes !== undefined && data.thingTypes !== null) {
     contents.thingTypes = deserializeAws_restJson1ThingTypeList(data.thingTypes, context);
@@ -24161,7 +24164,7 @@ export const deserializeAws_restJson1ListTopicRuleDestinationsCommand = async (
     );
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -24241,7 +24244,7 @@ export const deserializeAws_restJson1ListTopicRulesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.rules !== undefined && data.rules !== null) {
     contents.rules = deserializeAws_restJson1TopicRuleList(data.rules, context);
@@ -24322,7 +24325,7 @@ export const deserializeAws_restJson1ListV2LoggingLevelsCommand = async (
     );
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -24402,7 +24405,7 @@ export const deserializeAws_restJson1ListViolationEventsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.violationEvents !== undefined && data.violationEvents !== null) {
     contents.violationEvents = deserializeAws_restJson1ViolationEvents(data.violationEvents, context);
@@ -24477,10 +24480,10 @@ export const deserializeAws_restJson1RegisterCACertificateCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.certificateArn !== undefined && data.certificateArn !== null) {
-    contents.certificateArn = data.certificateArn;
+    contents.certificateArn = __expectString(data.certificateArn);
   }
   if (data.certificateId !== undefined && data.certificateId !== null) {
-    contents.certificateId = data.certificateId;
+    contents.certificateId = __expectString(data.certificateId);
   }
   return Promise.resolve(contents);
 };
@@ -24600,10 +24603,10 @@ export const deserializeAws_restJson1RegisterCertificateCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.certificateArn !== undefined && data.certificateArn !== null) {
-    contents.certificateArn = data.certificateArn;
+    contents.certificateArn = __expectString(data.certificateArn);
   }
   if (data.certificateId !== undefined && data.certificateId !== null) {
-    contents.certificateId = data.certificateId;
+    contents.certificateId = __expectString(data.certificateId);
   }
   return Promise.resolve(contents);
 };
@@ -24723,10 +24726,10 @@ export const deserializeAws_restJson1RegisterCertificateWithoutCACommand = async
   };
   const data: any = await parseBody(output.body, context);
   if (data.certificateArn !== undefined && data.certificateArn !== null) {
-    contents.certificateArn = data.certificateArn;
+    contents.certificateArn = __expectString(data.certificateArn);
   }
   if (data.certificateId !== undefined && data.certificateId !== null) {
-    contents.certificateId = data.certificateId;
+    contents.certificateId = __expectString(data.certificateId);
   }
   return Promise.resolve(contents);
 };
@@ -24838,7 +24841,7 @@ export const deserializeAws_restJson1RegisterThingCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.certificatePem !== undefined && data.certificatePem !== null) {
-    contents.certificatePem = data.certificatePem;
+    contents.certificatePem = __expectString(data.certificatePem);
   }
   if (data.resourceArns !== undefined && data.resourceArns !== null) {
     contents.resourceArns = deserializeAws_restJson1ResourceArns(data.resourceArns, context);
@@ -25286,7 +25289,7 @@ export const deserializeAws_restJson1SearchIndexCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.thingGroups !== undefined && data.thingGroups !== null) {
     contents.thingGroups = deserializeAws_restJson1ThingGroupDocumentList(data.thingGroups, context);
@@ -25404,10 +25407,10 @@ export const deserializeAws_restJson1SetDefaultAuthorizerCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.authorizerArn !== undefined && data.authorizerArn !== null) {
-    contents.authorizerArn = data.authorizerArn;
+    contents.authorizerArn = __expectString(data.authorizerArn);
   }
   if (data.authorizerName !== undefined && data.authorizerName !== null) {
-    contents.authorizerName = data.authorizerName;
+    contents.authorizerName = __expectString(data.authorizerName);
   }
   return Promise.resolve(contents);
 };
@@ -25818,7 +25821,7 @@ export const deserializeAws_restJson1StartAuditMitigationActionsTaskCommand = as
   };
   const data: any = await parseBody(output.body, context);
   if (data.taskId !== undefined && data.taskId !== null) {
-    contents.taskId = data.taskId;
+    contents.taskId = __expectString(data.taskId);
   }
   return Promise.resolve(contents);
 };
@@ -25905,7 +25908,7 @@ export const deserializeAws_restJson1StartDetectMitigationActionsTaskCommand = a
   };
   const data: any = await parseBody(output.body, context);
   if (data.taskId !== undefined && data.taskId !== null) {
-    contents.taskId = data.taskId;
+    contents.taskId = __expectString(data.taskId);
   }
   return Promise.resolve(contents);
 };
@@ -25992,7 +25995,7 @@ export const deserializeAws_restJson1StartOnDemandAuditTaskCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.taskId !== undefined && data.taskId !== null) {
-    contents.taskId = data.taskId;
+    contents.taskId = __expectString(data.taskId);
   }
   return Promise.resolve(contents);
 };
@@ -26071,7 +26074,7 @@ export const deserializeAws_restJson1StartThingRegistrationTaskCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.taskId !== undefined && data.taskId !== null) {
-    contents.taskId = data.taskId;
+    contents.taskId = __expectString(data.taskId);
   }
   return Promise.resolve(contents);
 };
@@ -26423,19 +26426,19 @@ export const deserializeAws_restJson1TestInvokeAuthorizerCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.disconnectAfterInSeconds !== undefined && data.disconnectAfterInSeconds !== null) {
-    contents.disconnectAfterInSeconds = data.disconnectAfterInSeconds;
+    contents.disconnectAfterInSeconds = __expectNumber(data.disconnectAfterInSeconds);
   }
   if (data.isAuthenticated !== undefined && data.isAuthenticated !== null) {
-    contents.isAuthenticated = data.isAuthenticated;
+    contents.isAuthenticated = __expectBoolean(data.isAuthenticated);
   }
   if (data.policyDocuments !== undefined && data.policyDocuments !== null) {
     contents.policyDocuments = deserializeAws_restJson1PolicyDocuments(data.policyDocuments, context);
   }
   if (data.principalId !== undefined && data.principalId !== null) {
-    contents.principalId = data.principalId;
+    contents.principalId = __expectString(data.principalId);
   }
   if (data.refreshAfterInSeconds !== undefined && data.refreshAfterInSeconds !== null) {
-    contents.refreshAfterInSeconds = data.refreshAfterInSeconds;
+    contents.refreshAfterInSeconds = __expectNumber(data.refreshAfterInSeconds);
   }
   return Promise.resolve(contents);
 };
@@ -26538,7 +26541,7 @@ export const deserializeAws_restJson1TransferCertificateCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.transferredCertificateArn !== undefined && data.transferredCertificateArn !== null) {
-    contents.transferredCertificateArn = data.transferredCertificateArn;
+    contents.transferredCertificateArn = __expectString(data.transferredCertificateArn);
   }
   return Promise.resolve(contents);
 };
@@ -26867,10 +26870,10 @@ export const deserializeAws_restJson1UpdateAuthorizerCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.authorizerArn !== undefined && data.authorizerArn !== null) {
-    contents.authorizerArn = data.authorizerArn;
+    contents.authorizerArn = __expectString(data.authorizerArn);
   }
   if (data.authorizerName !== undefined && data.authorizerName !== null) {
-    contents.authorizerName = data.authorizerName;
+    contents.authorizerName = __expectString(data.authorizerName);
   }
   return Promise.resolve(contents);
 };
@@ -26973,7 +26976,7 @@ export const deserializeAws_restJson1UpdateBillingGroupCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.version !== undefined && data.version !== null) {
-    contents.version = data.version;
+    contents.version = __expectNumber(data.version);
   }
   return Promise.resolve(contents);
 };
@@ -27258,19 +27261,19 @@ export const deserializeAws_restJson1UpdateCustomMetricCommand = async (
     contents.creationDate = new Date(Math.round(data.creationDate * 1000));
   }
   if (data.displayName !== undefined && data.displayName !== null) {
-    contents.displayName = data.displayName;
+    contents.displayName = __expectString(data.displayName);
   }
   if (data.lastModifiedDate !== undefined && data.lastModifiedDate !== null) {
     contents.lastModifiedDate = new Date(Math.round(data.lastModifiedDate * 1000));
   }
   if (data.metricArn !== undefined && data.metricArn !== null) {
-    contents.metricArn = data.metricArn;
+    contents.metricArn = __expectString(data.metricArn);
   }
   if (data.metricName !== undefined && data.metricName !== null) {
-    contents.metricName = data.metricName;
+    contents.metricName = __expectString(data.metricName);
   }
   if (data.metricType !== undefined && data.metricType !== null) {
-    contents.metricType = data.metricType;
+    contents.metricType = __expectString(data.metricType);
   }
   return Promise.resolve(contents);
 };
@@ -27354,7 +27357,7 @@ export const deserializeAws_restJson1UpdateDimensionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.creationDate !== undefined && data.creationDate !== null) {
     contents.creationDate = new Date(Math.round(data.creationDate * 1000));
@@ -27363,13 +27366,13 @@ export const deserializeAws_restJson1UpdateDimensionCommand = async (
     contents.lastModifiedDate = new Date(Math.round(data.lastModifiedDate * 1000));
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.stringValues !== undefined && data.stringValues !== null) {
     contents.stringValues = deserializeAws_restJson1DimensionStringValues(data.stringValues, context);
   }
   if (data.type !== undefined && data.type !== null) {
-    contents.type = data.type;
+    contents.type = __expectString(data.type);
   }
   return Promise.resolve(contents);
 };
@@ -27449,10 +27452,10 @@ export const deserializeAws_restJson1UpdateDomainConfigurationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.domainConfigurationArn !== undefined && data.domainConfigurationArn !== null) {
-    contents.domainConfigurationArn = data.domainConfigurationArn;
+    contents.domainConfigurationArn = __expectString(data.domainConfigurationArn);
   }
   if (data.domainConfigurationName !== undefined && data.domainConfigurationName !== null) {
-    contents.domainConfigurationName = data.domainConfigurationName;
+    contents.domainConfigurationName = __expectString(data.domainConfigurationName);
   }
   return Promise.resolve(contents);
 };
@@ -27555,7 +27558,7 @@ export const deserializeAws_restJson1UpdateDynamicThingGroupCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.version !== undefined && data.version !== null) {
-    contents.version = data.version;
+    contents.version = __expectNumber(data.version);
   }
   return Promise.resolve(contents);
 };
@@ -27876,10 +27879,10 @@ export const deserializeAws_restJson1UpdateMitigationActionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.actionArn !== undefined && data.actionArn !== null) {
-    contents.actionArn = data.actionArn;
+    contents.actionArn = __expectString(data.actionArn);
   }
   if (data.actionId !== undefined && data.actionId !== null) {
-    contents.actionId = data.actionId;
+    contents.actionId = __expectString(data.actionId);
   }
   return Promise.resolve(contents);
 };
@@ -28042,10 +28045,10 @@ export const deserializeAws_restJson1UpdateRoleAliasCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.roleAlias !== undefined && data.roleAlias !== null) {
-    contents.roleAlias = data.roleAlias;
+    contents.roleAlias = __expectString(data.roleAlias);
   }
   if (data.roleAliasArn !== undefined && data.roleAliasArn !== null) {
-    contents.roleAliasArn = data.roleAliasArn;
+    contents.roleAliasArn = __expectString(data.roleAliasArn);
   }
   return Promise.resolve(contents);
 };
@@ -28140,7 +28143,7 @@ export const deserializeAws_restJson1UpdateScheduledAuditCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.scheduledAuditArn !== undefined && data.scheduledAuditArn !== null) {
-    contents.scheduledAuditArn = data.scheduledAuditArn;
+    contents.scheduledAuditArn = __expectString(data.scheduledAuditArn);
   }
   return Promise.resolve(contents);
 };
@@ -28252,16 +28255,16 @@ export const deserializeAws_restJson1UpdateSecurityProfileCommand = async (
     contents.lastModifiedDate = new Date(Math.round(data.lastModifiedDate * 1000));
   }
   if (data.securityProfileArn !== undefined && data.securityProfileArn !== null) {
-    contents.securityProfileArn = data.securityProfileArn;
+    contents.securityProfileArn = __expectString(data.securityProfileArn);
   }
   if (data.securityProfileDescription !== undefined && data.securityProfileDescription !== null) {
-    contents.securityProfileDescription = data.securityProfileDescription;
+    contents.securityProfileDescription = __expectString(data.securityProfileDescription);
   }
   if (data.securityProfileName !== undefined && data.securityProfileName !== null) {
-    contents.securityProfileName = data.securityProfileName;
+    contents.securityProfileName = __expectString(data.securityProfileName);
   }
   if (data.version !== undefined && data.version !== null) {
-    contents.version = data.version;
+    contents.version = __expectNumber(data.version);
   }
   return Promise.resolve(contents);
 };
@@ -28351,16 +28354,16 @@ export const deserializeAws_restJson1UpdateStreamCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.streamArn !== undefined && data.streamArn !== null) {
-    contents.streamArn = data.streamArn;
+    contents.streamArn = __expectString(data.streamArn);
   }
   if (data.streamId !== undefined && data.streamId !== null) {
-    contents.streamId = data.streamId;
+    contents.streamId = __expectString(data.streamId);
   }
   if (data.streamVersion !== undefined && data.streamVersion !== null) {
-    contents.streamVersion = data.streamVersion;
+    contents.streamVersion = __expectNumber(data.streamVersion);
   }
   return Promise.resolve(contents);
 };
@@ -28554,7 +28557,7 @@ export const deserializeAws_restJson1UpdateThingGroupCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.version !== undefined && data.version !== null) {
-    contents.version = data.version;
+    contents.version = __expectNumber(data.version);
   }
   return Promise.resolve(contents);
 };
@@ -28800,7 +28803,7 @@ export const deserializeAws_restJson1ValidateSecurityProfileBehaviorsCommand = a
   };
   const data: any = await parseBody(output.body, context);
   if (data.valid !== undefined && data.valid !== null) {
-    contents.valid = data.valid;
+    contents.valid = __expectBoolean(data.valid);
   }
   if (data.validationErrors !== undefined && data.validationErrors !== null) {
     contents.validationErrors = deserializeAws_restJson1ValidationErrors(data.validationErrors, context);
@@ -28873,7 +28876,7 @@ const deserializeAws_restJson1CertificateConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -28890,7 +28893,7 @@ const deserializeAws_restJson1CertificateStateExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -28907,7 +28910,7 @@ const deserializeAws_restJson1CertificateValidationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -28924,7 +28927,7 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -28941,7 +28944,7 @@ const deserializeAws_restJson1ConflictingResourceUpdateExceptionResponse = async
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -28958,7 +28961,7 @@ const deserializeAws_restJson1DeleteConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -28975,7 +28978,7 @@ const deserializeAws_restJson1IndexNotReadyExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -28992,7 +28995,7 @@ const deserializeAws_restJson1InternalExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -29009,7 +29012,7 @@ const deserializeAws_restJson1InternalFailureExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -29026,7 +29029,7 @@ const deserializeAws_restJson1InvalidAggregationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -29043,7 +29046,7 @@ const deserializeAws_restJson1InvalidQueryExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -29060,7 +29063,7 @@ const deserializeAws_restJson1InvalidRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -29077,7 +29080,7 @@ const deserializeAws_restJson1InvalidResponseExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -29094,7 +29097,7 @@ const deserializeAws_restJson1InvalidStateTransitionExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -29111,7 +29114,7 @@ const deserializeAws_restJson1LimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -29128,7 +29131,7 @@ const deserializeAws_restJson1MalformedPolicyExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -29145,7 +29148,7 @@ const deserializeAws_restJson1NotConfiguredExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -29162,7 +29165,7 @@ const deserializeAws_restJson1RegistrationCodeValidationExceptionResponse = asyn
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -29181,13 +29184,13 @@ const deserializeAws_restJson1ResourceAlreadyExistsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.resourceArn !== undefined && data.resourceArn !== null) {
-    contents.resourceArn = data.resourceArn;
+    contents.resourceArn = __expectString(data.resourceArn);
   }
   if (data.resourceId !== undefined && data.resourceId !== null) {
-    contents.resourceId = data.resourceId;
+    contents.resourceId = __expectString(data.resourceId);
   }
   return contents;
 };
@@ -29204,7 +29207,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -29221,7 +29224,7 @@ const deserializeAws_restJson1ResourceRegistrationFailureExceptionResponse = asy
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -29238,7 +29241,7 @@ const deserializeAws_restJson1ServiceUnavailableExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -29255,7 +29258,7 @@ const deserializeAws_restJson1SqlParseExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -29272,7 +29275,7 @@ const deserializeAws_restJson1TaskAlreadyExistsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -29289,7 +29292,7 @@ const deserializeAws_restJson1ThrottlingExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -29306,7 +29309,7 @@ const deserializeAws_restJson1TransferAlreadyCompletedExceptionResponse = async 
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -29323,7 +29326,7 @@ const deserializeAws_restJson1TransferConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -29340,7 +29343,7 @@ const deserializeAws_restJson1UnauthorizedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -29357,7 +29360,7 @@ const deserializeAws_restJson1VersionConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -29374,7 +29377,7 @@ const deserializeAws_restJson1VersionsLimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -31179,16 +31182,10 @@ const deserializeAws_restJson1AbortConfig = (output: any, context: __SerdeContex
 
 const deserializeAws_restJson1AbortCriteria = (output: any, context: __SerdeContext): AbortCriteria => {
   return {
-    action: output.action !== undefined && output.action !== null ? output.action : undefined,
-    failureType: output.failureType !== undefined && output.failureType !== null ? output.failureType : undefined,
-    minNumberOfExecutedThings:
-      output.minNumberOfExecutedThings !== undefined && output.minNumberOfExecutedThings !== null
-        ? output.minNumberOfExecutedThings
-        : undefined,
-    thresholdPercentage:
-      output.thresholdPercentage !== undefined && output.thresholdPercentage !== null
-        ? output.thresholdPercentage
-        : undefined,
+    action: __expectString(output.action),
+    failureType: __expectString(output.failureType),
+    minNumberOfExecutedThings: __expectNumber(output.minNumberOfExecutedThings),
+    thresholdPercentage: __expectNumber(output.thresholdPercentage),
   } as any;
 };
 
@@ -31315,16 +31312,13 @@ const deserializeAws_restJson1ActiveViolation = (output: any, context: __SerdeCo
       output.lastViolationValue !== undefined && output.lastViolationValue !== null
         ? deserializeAws_restJson1MetricValue(output.lastViolationValue, context)
         : undefined,
-    securityProfileName:
-      output.securityProfileName !== undefined && output.securityProfileName !== null
-        ? output.securityProfileName
-        : undefined,
-    thingName: output.thingName !== undefined && output.thingName !== null ? output.thingName : undefined,
+    securityProfileName: __expectString(output.securityProfileName),
+    thingName: __expectString(output.thingName),
     violationEventAdditionalInfo:
       output.violationEventAdditionalInfo !== undefined && output.violationEventAdditionalInfo !== null
         ? deserializeAws_restJson1ViolationEventAdditionalInfo(output.violationEventAdditionalInfo, context)
         : undefined,
-    violationId: output.violationId !== undefined && output.violationId !== null ? output.violationId : undefined,
+    violationId: __expectString(output.violationId),
     violationStartTime:
       output.violationStartTime !== undefined && output.violationStartTime !== null
         ? new Date(Math.round(output.violationStartTime * 1000))
@@ -31350,7 +31344,7 @@ const deserializeAws_restJson1AdditionalMetricsToRetainList = (output: any, cont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -31378,7 +31372,7 @@ const deserializeAws_restJson1AdditionalParameterMap = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -31388,10 +31382,7 @@ const deserializeAws_restJson1AddThingsToThingGroupParams = (
   context: __SerdeContext
 ): AddThingsToThingGroupParams => {
   return {
-    overrideDynamicGroups:
-      output.overrideDynamicGroups !== undefined && output.overrideDynamicGroups !== null
-        ? output.overrideDynamicGroups
-        : undefined,
+    overrideDynamicGroups: __expectBoolean(output.overrideDynamicGroups),
     thingGroupNames:
       output.thingGroupNames !== undefined && output.thingGroupNames !== null
         ? deserializeAws_restJson1ThingGroupNames(output.thingGroupNames, context)
@@ -31401,9 +31392,8 @@ const deserializeAws_restJson1AddThingsToThingGroupParams = (
 
 const deserializeAws_restJson1AlertTarget = (output: any, context: __SerdeContext): AlertTarget => {
   return {
-    alertTargetArn:
-      output.alertTargetArn !== undefined && output.alertTargetArn !== null ? output.alertTargetArn : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
+    alertTargetArn: __expectString(output.alertTargetArn),
+    roleArn: __expectString(output.roleArn),
   } as any;
 };
 
@@ -31436,16 +31426,14 @@ const deserializeAws_restJson1AssetPropertyTimestamp = (
   context: __SerdeContext
 ): AssetPropertyTimestamp => {
   return {
-    offsetInNanos:
-      output.offsetInNanos !== undefined && output.offsetInNanos !== null ? output.offsetInNanos : undefined,
-    timeInSeconds:
-      output.timeInSeconds !== undefined && output.timeInSeconds !== null ? output.timeInSeconds : undefined,
+    offsetInNanos: __expectString(output.offsetInNanos),
+    timeInSeconds: __expectString(output.timeInSeconds),
   } as any;
 };
 
 const deserializeAws_restJson1AssetPropertyValue = (output: any, context: __SerdeContext): AssetPropertyValue => {
   return {
-    quality: output.quality !== undefined && output.quality !== null ? output.quality : undefined,
+    quality: __expectString(output.quality),
     timestamp:
       output.timestamp !== undefined && output.timestamp !== null
         ? deserializeAws_restJson1AssetPropertyTimestamp(output.timestamp, context)
@@ -31469,25 +31457,17 @@ const deserializeAws_restJson1AssetPropertyValueList = (output: any, context: __
 };
 
 const deserializeAws_restJson1AssetPropertyVariant = (output: any, context: __SerdeContext): AssetPropertyVariant => {
-  if (output.booleanValue !== undefined && output.booleanValue !== null) {
-    return {
-      booleanValue: output.booleanValue,
-    };
+  if (__expectString(output.booleanValue) !== undefined) {
+    return { booleanValue: __expectString(output.booleanValue) as any };
   }
-  if (output.doubleValue !== undefined && output.doubleValue !== null) {
-    return {
-      doubleValue: output.doubleValue,
-    };
+  if (__expectString(output.doubleValue) !== undefined) {
+    return { doubleValue: __expectString(output.doubleValue) as any };
   }
-  if (output.integerValue !== undefined && output.integerValue !== null) {
-    return {
-      integerValue: output.integerValue,
-    };
+  if (__expectString(output.integerValue) !== undefined) {
+    return { integerValue: __expectString(output.integerValue) as any };
   }
-  if (output.stringValue !== undefined && output.stringValue !== null) {
-    return {
-      stringValue: output.stringValue,
-    };
+  if (__expectString(output.stringValue) !== undefined) {
+    return { stringValue: __expectString(output.stringValue) as any };
   }
   return { $unknown: Object.entries(output)[0] };
 };
@@ -31498,7 +31478,7 @@ const deserializeAws_restJson1AttributePayload = (output: any, context: __SerdeC
       output.attributes !== undefined && output.attributes !== null
         ? deserializeAws_restJson1Attributes(output.attributes, context)
         : undefined,
-    merge: output.merge !== undefined && output.merge !== null ? output.merge : undefined,
+    merge: __expectBoolean(output.merge),
   } as any;
 };
 
@@ -31509,7 +31489,7 @@ const deserializeAws_restJson1Attributes = (output: any, context: __SerdeContext
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -31521,7 +31501,7 @@ const deserializeAws_restJson1AttributesMap = (output: any, context: __SerdeCont
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -31531,7 +31511,7 @@ const deserializeAws_restJson1AuditCheckConfiguration = (
   context: __SerdeContext
 ): AuditCheckConfiguration => {
   return {
-    enabled: output.enabled !== undefined && output.enabled !== null ? output.enabled : undefined,
+    enabled: __expectBoolean(output.enabled),
   } as any;
 };
 
@@ -31555,24 +31535,13 @@ const deserializeAws_restJson1AuditCheckConfigurations = (
 
 const deserializeAws_restJson1AuditCheckDetails = (output: any, context: __SerdeContext): AuditCheckDetails => {
   return {
-    checkCompliant:
-      output.checkCompliant !== undefined && output.checkCompliant !== null ? output.checkCompliant : undefined,
-    checkRunStatus:
-      output.checkRunStatus !== undefined && output.checkRunStatus !== null ? output.checkRunStatus : undefined,
-    errorCode: output.errorCode !== undefined && output.errorCode !== null ? output.errorCode : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    nonCompliantResourcesCount:
-      output.nonCompliantResourcesCount !== undefined && output.nonCompliantResourcesCount !== null
-        ? output.nonCompliantResourcesCount
-        : undefined,
-    suppressedNonCompliantResourcesCount:
-      output.suppressedNonCompliantResourcesCount !== undefined && output.suppressedNonCompliantResourcesCount !== null
-        ? output.suppressedNonCompliantResourcesCount
-        : undefined,
-    totalResourcesCount:
-      output.totalResourcesCount !== undefined && output.totalResourcesCount !== null
-        ? output.totalResourcesCount
-        : undefined,
+    checkCompliant: __expectBoolean(output.checkCompliant),
+    checkRunStatus: __expectString(output.checkRunStatus),
+    errorCode: __expectString(output.errorCode),
+    message: __expectString(output.message),
+    nonCompliantResourcesCount: __expectNumber(output.nonCompliantResourcesCount),
+    suppressedNonCompliantResourcesCount: __expectNumber(output.suppressedNonCompliantResourcesCount),
+    totalResourcesCount: __expectNumber(output.totalResourcesCount),
   } as any;
 };
 
@@ -31623,31 +31592,25 @@ const deserializeAws_restJson1AuditDetails = (
 
 const deserializeAws_restJson1AuditFinding = (output: any, context: __SerdeContext): AuditFinding => {
   return {
-    checkName: output.checkName !== undefined && output.checkName !== null ? output.checkName : undefined,
-    findingId: output.findingId !== undefined && output.findingId !== null ? output.findingId : undefined,
+    checkName: __expectString(output.checkName),
+    findingId: __expectString(output.findingId),
     findingTime:
       output.findingTime !== undefined && output.findingTime !== null
         ? new Date(Math.round(output.findingTime * 1000))
         : undefined,
-    isSuppressed: output.isSuppressed !== undefined && output.isSuppressed !== null ? output.isSuppressed : undefined,
+    isSuppressed: __expectBoolean(output.isSuppressed),
     nonCompliantResource:
       output.nonCompliantResource !== undefined && output.nonCompliantResource !== null
         ? deserializeAws_restJson1NonCompliantResource(output.nonCompliantResource, context)
         : undefined,
-    reasonForNonCompliance:
-      output.reasonForNonCompliance !== undefined && output.reasonForNonCompliance !== null
-        ? output.reasonForNonCompliance
-        : undefined,
-    reasonForNonComplianceCode:
-      output.reasonForNonComplianceCode !== undefined && output.reasonForNonComplianceCode !== null
-        ? output.reasonForNonComplianceCode
-        : undefined,
+    reasonForNonCompliance: __expectString(output.reasonForNonCompliance),
+    reasonForNonComplianceCode: __expectString(output.reasonForNonComplianceCode),
     relatedResources:
       output.relatedResources !== undefined && output.relatedResources !== null
         ? deserializeAws_restJson1RelatedResources(output.relatedResources, context)
         : undefined,
-    severity: output.severity !== undefined && output.severity !== null ? output.severity : undefined,
-    taskId: output.taskId !== undefined && output.taskId !== null ? output.taskId : undefined,
+    severity: __expectString(output.severity),
+    taskId: __expectString(output.taskId),
     taskStartTime:
       output.taskStartTime !== undefined && output.taskStartTime !== null
         ? new Date(Math.round(output.taskStartTime * 1000))
@@ -31671,19 +31634,19 @@ const deserializeAws_restJson1AuditMitigationActionExecutionMetadata = (
   context: __SerdeContext
 ): AuditMitigationActionExecutionMetadata => {
   return {
-    actionId: output.actionId !== undefined && output.actionId !== null ? output.actionId : undefined,
-    actionName: output.actionName !== undefined && output.actionName !== null ? output.actionName : undefined,
+    actionId: __expectString(output.actionId),
+    actionName: __expectString(output.actionName),
     endTime:
       output.endTime !== undefined && output.endTime !== null ? new Date(Math.round(output.endTime * 1000)) : undefined,
-    errorCode: output.errorCode !== undefined && output.errorCode !== null ? output.errorCode : undefined,
-    findingId: output.findingId !== undefined && output.findingId !== null ? output.findingId : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    errorCode: __expectString(output.errorCode),
+    findingId: __expectString(output.findingId),
+    message: __expectString(output.message),
     startTime:
       output.startTime !== undefined && output.startTime !== null
         ? new Date(Math.round(output.startTime * 1000))
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    taskId: output.taskId !== undefined && output.taskId !== null ? output.taskId : undefined,
+    status: __expectString(output.status),
+    taskId: __expectString(output.taskId),
   } as any;
 };
 
@@ -31710,8 +31673,8 @@ const deserializeAws_restJson1AuditMitigationActionsTaskMetadata = (
       output.startTime !== undefined && output.startTime !== null
         ? new Date(Math.round(output.startTime * 1000))
         : undefined,
-    taskId: output.taskId !== undefined && output.taskId !== null ? output.taskId : undefined,
-    taskStatus: output.taskStatus !== undefined && output.taskStatus !== null ? output.taskStatus : undefined,
+    taskId: __expectString(output.taskId),
+    taskStatus: __expectString(output.taskStatus),
   } as any;
 };
 
@@ -31756,7 +31719,7 @@ const deserializeAws_restJson1AuditMitigationActionsTaskTarget = (
       output.auditCheckToReasonCodeFilter !== undefined && output.auditCheckToReasonCodeFilter !== null
         ? deserializeAws_restJson1AuditCheckToReasonCodeFilter(output.auditCheckToReasonCodeFilter, context)
         : undefined,
-    auditTaskId: output.auditTaskId !== undefined && output.auditTaskId !== null ? output.auditTaskId : undefined,
+    auditTaskId: __expectString(output.auditTaskId),
     findingIds:
       output.findingIds !== undefined && output.findingIds !== null
         ? deserializeAws_restJson1FindingIds(output.findingIds, context)
@@ -31769,9 +31732,9 @@ const deserializeAws_restJson1AuditNotificationTarget = (
   context: __SerdeContext
 ): AuditNotificationTarget => {
   return {
-    enabled: output.enabled !== undefined && output.enabled !== null ? output.enabled : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
-    targetArn: output.targetArn !== undefined && output.targetArn !== null ? output.targetArn : undefined,
+    enabled: __expectBoolean(output.enabled),
+    roleArn: __expectString(output.roleArn),
+    targetArn: __expectString(output.targetArn),
   } as any;
 };
 
@@ -31795,8 +31758,8 @@ const deserializeAws_restJson1AuditNotificationTargetConfigurations = (
 
 const deserializeAws_restJson1AuditSuppression = (output: any, context: __SerdeContext): AuditSuppression => {
   return {
-    checkName: output.checkName !== undefined && output.checkName !== null ? output.checkName : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    checkName: __expectString(output.checkName),
+    description: __expectString(output.description),
     expirationDate:
       output.expirationDate !== undefined && output.expirationDate !== null
         ? new Date(Math.round(output.expirationDate * 1000))
@@ -31805,10 +31768,7 @@ const deserializeAws_restJson1AuditSuppression = (output: any, context: __SerdeC
       output.resourceIdentifier !== undefined && output.resourceIdentifier !== null
         ? deserializeAws_restJson1ResourceIdentifier(output.resourceIdentifier, context)
         : undefined,
-    suppressIndefinitely:
-      output.suppressIndefinitely !== undefined && output.suppressIndefinitely !== null
-        ? output.suppressIndefinitely
-        : undefined,
+    suppressIndefinitely: __expectBoolean(output.suppressIndefinitely),
   } as any;
 };
 
@@ -31825,9 +31785,9 @@ const deserializeAws_restJson1AuditSuppressionList = (output: any, context: __Se
 
 const deserializeAws_restJson1AuditTaskMetadata = (output: any, context: __SerdeContext): AuditTaskMetadata => {
   return {
-    taskId: output.taskId !== undefined && output.taskId !== null ? output.taskId : undefined,
-    taskStatus: output.taskStatus !== undefined && output.taskStatus !== null ? output.taskStatus : undefined,
-    taskType: output.taskType !== undefined && output.taskType !== null ? output.taskType : undefined,
+    taskId: __expectString(output.taskId),
+    taskStatus: __expectString(output.taskStatus),
+    taskType: __expectString(output.taskType),
   } as any;
 };
 
@@ -31844,7 +31804,7 @@ const deserializeAws_restJson1AuditTaskMetadataList = (output: any, context: __S
 
 const deserializeAws_restJson1AuthInfo = (output: any, context: __SerdeContext): AuthInfo => {
   return {
-    actionType: output.actionType !== undefined && output.actionType !== null ? output.actionType : undefined,
+    actionType: __expectString(output.actionType),
     resources:
       output.resources !== undefined && output.resources !== null
         ? deserializeAws_restJson1Resources(output.resources, context)
@@ -31854,27 +31814,16 @@ const deserializeAws_restJson1AuthInfo = (output: any, context: __SerdeContext):
 
 const deserializeAws_restJson1AuthorizerConfig = (output: any, context: __SerdeContext): AuthorizerConfig => {
   return {
-    allowAuthorizerOverride:
-      output.allowAuthorizerOverride !== undefined && output.allowAuthorizerOverride !== null
-        ? output.allowAuthorizerOverride
-        : undefined,
-    defaultAuthorizerName:
-      output.defaultAuthorizerName !== undefined && output.defaultAuthorizerName !== null
-        ? output.defaultAuthorizerName
-        : undefined,
+    allowAuthorizerOverride: __expectBoolean(output.allowAuthorizerOverride),
+    defaultAuthorizerName: __expectString(output.defaultAuthorizerName),
   } as any;
 };
 
 const deserializeAws_restJson1AuthorizerDescription = (output: any, context: __SerdeContext): AuthorizerDescription => {
   return {
-    authorizerArn:
-      output.authorizerArn !== undefined && output.authorizerArn !== null ? output.authorizerArn : undefined,
-    authorizerFunctionArn:
-      output.authorizerFunctionArn !== undefined && output.authorizerFunctionArn !== null
-        ? output.authorizerFunctionArn
-        : undefined,
-    authorizerName:
-      output.authorizerName !== undefined && output.authorizerName !== null ? output.authorizerName : undefined,
+    authorizerArn: __expectString(output.authorizerArn),
+    authorizerFunctionArn: __expectString(output.authorizerFunctionArn),
+    authorizerName: __expectString(output.authorizerName),
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
         ? new Date(Math.round(output.creationDate * 1000))
@@ -31883,10 +31832,9 @@ const deserializeAws_restJson1AuthorizerDescription = (output: any, context: __S
       output.lastModifiedDate !== undefined && output.lastModifiedDate !== null
         ? new Date(Math.round(output.lastModifiedDate * 1000))
         : undefined,
-    signingDisabled:
-      output.signingDisabled !== undefined && output.signingDisabled !== null ? output.signingDisabled : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    tokenKeyName: output.tokenKeyName !== undefined && output.tokenKeyName !== null ? output.tokenKeyName : undefined,
+    signingDisabled: __expectBoolean(output.signingDisabled),
+    status: __expectString(output.status),
+    tokenKeyName: __expectString(output.tokenKeyName),
     tokenSigningPublicKeys:
       output.tokenSigningPublicKeys !== undefined && output.tokenSigningPublicKeys !== null
         ? deserializeAws_restJson1PublicKeyMap(output.tokenSigningPublicKeys, context)
@@ -31907,10 +31855,8 @@ const deserializeAws_restJson1Authorizers = (output: any, context: __SerdeContex
 
 const deserializeAws_restJson1AuthorizerSummary = (output: any, context: __SerdeContext): AuthorizerSummary => {
   return {
-    authorizerArn:
-      output.authorizerArn !== undefined && output.authorizerArn !== null ? output.authorizerArn : undefined,
-    authorizerName:
-      output.authorizerName !== undefined && output.authorizerName !== null ? output.authorizerName : undefined,
+    authorizerArn: __expectString(output.authorizerArn),
+    authorizerName: __expectString(output.authorizerName),
   } as any;
 };
 
@@ -31920,7 +31866,7 @@ const deserializeAws_restJson1AuthResult = (output: any, context: __SerdeContext
       output.allowed !== undefined && output.allowed !== null
         ? deserializeAws_restJson1Allowed(output.allowed, context)
         : undefined,
-    authDecision: output.authDecision !== undefined && output.authDecision !== null ? output.authDecision : undefined,
+    authDecision: __expectString(output.authDecision),
     authInfo:
       output.authInfo !== undefined && output.authInfo !== null
         ? deserializeAws_restJson1AuthInfo(output.authInfo, context)
@@ -31956,8 +31902,7 @@ const deserializeAws_restJson1AwsJobExecutionsRolloutConfig = (
       output.exponentialRate !== undefined && output.exponentialRate !== null
         ? deserializeAws_restJson1AwsJobExponentialRolloutRate(output.exponentialRate, context)
         : undefined,
-    maximumPerMinute:
-      output.maximumPerMinute !== undefined && output.maximumPerMinute !== null ? output.maximumPerMinute : undefined,
+    maximumPerMinute: __expectNumber(output.maximumPerMinute),
   } as any;
 };
 
@@ -31966,12 +31911,8 @@ const deserializeAws_restJson1AwsJobExponentialRolloutRate = (
   context: __SerdeContext
 ): AwsJobExponentialRolloutRate => {
   return {
-    baseRatePerMinute:
-      output.baseRatePerMinute !== undefined && output.baseRatePerMinute !== null
-        ? output.baseRatePerMinute
-        : undefined,
-    incrementFactor:
-      output.incrementFactor !== undefined && output.incrementFactor !== null ? output.incrementFactor : undefined,
+    baseRatePerMinute: __expectNumber(output.baseRatePerMinute),
+    incrementFactor: __expectNumber(output.incrementFactor),
     rateIncreaseCriteria:
       output.rateIncreaseCriteria !== undefined && output.rateIncreaseCriteria !== null
         ? deserializeAws_restJson1AwsJobRateIncreaseCriteria(output.rateIncreaseCriteria, context)
@@ -31984,7 +31925,7 @@ const deserializeAws_restJson1AwsJobPresignedUrlConfig = (
   context: __SerdeContext
 ): AwsJobPresignedUrlConfig => {
   return {
-    expiresInSec: output.expiresInSec !== undefined && output.expiresInSec !== null ? output.expiresInSec : undefined,
+    expiresInSec: __expectNumber(output.expiresInSec),
   } as any;
 };
 
@@ -31993,14 +31934,8 @@ const deserializeAws_restJson1AwsJobRateIncreaseCriteria = (
   context: __SerdeContext
 ): AwsJobRateIncreaseCriteria => {
   return {
-    numberOfNotifiedThings:
-      output.numberOfNotifiedThings !== undefined && output.numberOfNotifiedThings !== null
-        ? output.numberOfNotifiedThings
-        : undefined,
-    numberOfSucceededThings:
-      output.numberOfSucceededThings !== undefined && output.numberOfSucceededThings !== null
-        ? output.numberOfSucceededThings
-        : undefined,
+    numberOfNotifiedThings: __expectNumber(output.numberOfNotifiedThings),
+    numberOfSucceededThings: __expectNumber(output.numberOfSucceededThings),
   } as any;
 };
 
@@ -32010,33 +31945,22 @@ const deserializeAws_restJson1Behavior = (output: any, context: __SerdeContext):
       output.criteria !== undefined && output.criteria !== null
         ? deserializeAws_restJson1BehaviorCriteria(output.criteria, context)
         : undefined,
-    metric: output.metric !== undefined && output.metric !== null ? output.metric : undefined,
+    metric: __expectString(output.metric),
     metricDimension:
       output.metricDimension !== undefined && output.metricDimension !== null
         ? deserializeAws_restJson1MetricDimension(output.metricDimension, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    suppressAlerts:
-      output.suppressAlerts !== undefined && output.suppressAlerts !== null ? output.suppressAlerts : undefined,
+    name: __expectString(output.name),
+    suppressAlerts: __expectBoolean(output.suppressAlerts),
   } as any;
 };
 
 const deserializeAws_restJson1BehaviorCriteria = (output: any, context: __SerdeContext): BehaviorCriteria => {
   return {
-    comparisonOperator:
-      output.comparisonOperator !== undefined && output.comparisonOperator !== null
-        ? output.comparisonOperator
-        : undefined,
-    consecutiveDatapointsToAlarm:
-      output.consecutiveDatapointsToAlarm !== undefined && output.consecutiveDatapointsToAlarm !== null
-        ? output.consecutiveDatapointsToAlarm
-        : undefined,
-    consecutiveDatapointsToClear:
-      output.consecutiveDatapointsToClear !== undefined && output.consecutiveDatapointsToClear !== null
-        ? output.consecutiveDatapointsToClear
-        : undefined,
-    durationSeconds:
-      output.durationSeconds !== undefined && output.durationSeconds !== null ? output.durationSeconds : undefined,
+    comparisonOperator: __expectString(output.comparisonOperator),
+    consecutiveDatapointsToAlarm: __expectNumber(output.consecutiveDatapointsToAlarm),
+    consecutiveDatapointsToClear: __expectNumber(output.consecutiveDatapointsToClear),
+    durationSeconds: __expectNumber(output.durationSeconds),
     mlDetectionConfig:
       output.mlDetectionConfig !== undefined && output.mlDetectionConfig !== null
         ? deserializeAws_restJson1MachineLearningDetectionConfig(output.mlDetectionConfig, context)
@@ -32071,20 +31995,14 @@ const deserializeAws_restJson1BehaviorModelTrainingSummary = (
   context: __SerdeContext
 ): BehaviorModelTrainingSummary => {
   return {
-    behaviorName: output.behaviorName !== undefined && output.behaviorName !== null ? output.behaviorName : undefined,
-    datapointsCollectionPercentage:
-      output.datapointsCollectionPercentage !== undefined && output.datapointsCollectionPercentage !== null
-        ? output.datapointsCollectionPercentage
-        : undefined,
+    behaviorName: __expectString(output.behaviorName),
+    datapointsCollectionPercentage: __expectNumber(output.datapointsCollectionPercentage),
     lastModelRefreshDate:
       output.lastModelRefreshDate !== undefined && output.lastModelRefreshDate !== null
         ? new Date(Math.round(output.lastModelRefreshDate * 1000))
         : undefined,
-    modelStatus: output.modelStatus !== undefined && output.modelStatus !== null ? output.modelStatus : undefined,
-    securityProfileName:
-      output.securityProfileName !== undefined && output.securityProfileName !== null
-        ? output.securityProfileName
-        : undefined,
+    modelStatus: __expectString(output.modelStatus),
+    securityProfileName: __expectString(output.securityProfileName),
     trainingDataCollectionStartDate:
       output.trainingDataCollectionStartDate !== undefined && output.trainingDataCollectionStartDate !== null
         ? new Date(Math.round(output.trainingDataCollectionStartDate * 1000))
@@ -32131,24 +32049,19 @@ const deserializeAws_restJson1BillingGroupProperties = (
   context: __SerdeContext
 ): BillingGroupProperties => {
   return {
-    billingGroupDescription:
-      output.billingGroupDescription !== undefined && output.billingGroupDescription !== null
-        ? output.billingGroupDescription
-        : undefined,
+    billingGroupDescription: __expectString(output.billingGroupDescription),
   } as any;
 };
 
 const deserializeAws_restJson1CACertificate = (output: any, context: __SerdeContext): CACertificate => {
   return {
-    certificateArn:
-      output.certificateArn !== undefined && output.certificateArn !== null ? output.certificateArn : undefined,
-    certificateId:
-      output.certificateId !== undefined && output.certificateId !== null ? output.certificateId : undefined,
+    certificateArn: __expectString(output.certificateArn),
+    certificateId: __expectString(output.certificateId),
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
         ? new Date(Math.round(output.creationDate * 1000))
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -32157,29 +32070,22 @@ const deserializeAws_restJson1CACertificateDescription = (
   context: __SerdeContext
 ): CACertificateDescription => {
   return {
-    autoRegistrationStatus:
-      output.autoRegistrationStatus !== undefined && output.autoRegistrationStatus !== null
-        ? output.autoRegistrationStatus
-        : undefined,
-    certificateArn:
-      output.certificateArn !== undefined && output.certificateArn !== null ? output.certificateArn : undefined,
-    certificateId:
-      output.certificateId !== undefined && output.certificateId !== null ? output.certificateId : undefined,
-    certificatePem:
-      output.certificatePem !== undefined && output.certificatePem !== null ? output.certificatePem : undefined,
+    autoRegistrationStatus: __expectString(output.autoRegistrationStatus),
+    certificateArn: __expectString(output.certificateArn),
+    certificateId: __expectString(output.certificateId),
+    certificatePem: __expectString(output.certificatePem),
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
         ? new Date(Math.round(output.creationDate * 1000))
         : undefined,
-    customerVersion:
-      output.customerVersion !== undefined && output.customerVersion !== null ? output.customerVersion : undefined,
-    generationId: output.generationId !== undefined && output.generationId !== null ? output.generationId : undefined,
+    customerVersion: __expectNumber(output.customerVersion),
+    generationId: __expectString(output.generationId),
     lastModifiedDate:
       output.lastModifiedDate !== undefined && output.lastModifiedDate !== null
         ? new Date(Math.round(output.lastModifiedDate * 1000))
         : undefined,
-    ownedBy: output.ownedBy !== undefined && output.ownedBy !== null ? output.ownedBy : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    ownedBy: __expectString(output.ownedBy),
+    status: __expectString(output.status),
     validity:
       output.validity !== undefined && output.validity !== null
         ? deserializeAws_restJson1CertificateValidity(output.validity, context)
@@ -32200,17 +32106,14 @@ const deserializeAws_restJson1CACertificates = (output: any, context: __SerdeCon
 
 const deserializeAws_restJson1Certificate = (output: any, context: __SerdeContext): Certificate => {
   return {
-    certificateArn:
-      output.certificateArn !== undefined && output.certificateArn !== null ? output.certificateArn : undefined,
-    certificateId:
-      output.certificateId !== undefined && output.certificateId !== null ? output.certificateId : undefined,
-    certificateMode:
-      output.certificateMode !== undefined && output.certificateMode !== null ? output.certificateMode : undefined,
+    certificateArn: __expectString(output.certificateArn),
+    certificateId: __expectString(output.certificateId),
+    certificateMode: __expectString(output.certificateMode),
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
         ? new Date(Math.round(output.creationDate * 1000))
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -32219,31 +32122,24 @@ const deserializeAws_restJson1CertificateDescription = (
   context: __SerdeContext
 ): CertificateDescription => {
   return {
-    caCertificateId:
-      output.caCertificateId !== undefined && output.caCertificateId !== null ? output.caCertificateId : undefined,
-    certificateArn:
-      output.certificateArn !== undefined && output.certificateArn !== null ? output.certificateArn : undefined,
-    certificateId:
-      output.certificateId !== undefined && output.certificateId !== null ? output.certificateId : undefined,
-    certificateMode:
-      output.certificateMode !== undefined && output.certificateMode !== null ? output.certificateMode : undefined,
-    certificatePem:
-      output.certificatePem !== undefined && output.certificatePem !== null ? output.certificatePem : undefined,
+    caCertificateId: __expectString(output.caCertificateId),
+    certificateArn: __expectString(output.certificateArn),
+    certificateId: __expectString(output.certificateId),
+    certificateMode: __expectString(output.certificateMode),
+    certificatePem: __expectString(output.certificatePem),
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
         ? new Date(Math.round(output.creationDate * 1000))
         : undefined,
-    customerVersion:
-      output.customerVersion !== undefined && output.customerVersion !== null ? output.customerVersion : undefined,
-    generationId: output.generationId !== undefined && output.generationId !== null ? output.generationId : undefined,
+    customerVersion: __expectNumber(output.customerVersion),
+    generationId: __expectString(output.generationId),
     lastModifiedDate:
       output.lastModifiedDate !== undefined && output.lastModifiedDate !== null
         ? new Date(Math.round(output.lastModifiedDate * 1000))
         : undefined,
-    ownedBy: output.ownedBy !== undefined && output.ownedBy !== null ? output.ownedBy : undefined,
-    previousOwnedBy:
-      output.previousOwnedBy !== undefined && output.previousOwnedBy !== null ? output.previousOwnedBy : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    ownedBy: __expectString(output.ownedBy),
+    previousOwnedBy: __expectString(output.previousOwnedBy),
+    status: __expectString(output.status),
     transferData:
       output.transferData !== undefined && output.transferData !== null
         ? deserializeAws_restJson1TransferData(output.transferData, context)
@@ -32286,7 +32182,7 @@ const deserializeAws_restJson1Cidrs = (output: any, context: __SerdeContext): st
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -32297,24 +32193,24 @@ const deserializeAws_restJson1ClientProperties = (output: any, context: __SerdeC
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1CloudwatchAlarmAction = (output: any, context: __SerdeContext): CloudwatchAlarmAction => {
   return {
-    alarmName: output.alarmName !== undefined && output.alarmName !== null ? output.alarmName : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
-    stateReason: output.stateReason !== undefined && output.stateReason !== null ? output.stateReason : undefined,
-    stateValue: output.stateValue !== undefined && output.stateValue !== null ? output.stateValue : undefined,
+    alarmName: __expectString(output.alarmName),
+    roleArn: __expectString(output.roleArn),
+    stateReason: __expectString(output.stateReason),
+    stateValue: __expectString(output.stateValue),
   } as any;
 };
 
 const deserializeAws_restJson1CloudwatchLogsAction = (output: any, context: __SerdeContext): CloudwatchLogsAction => {
   return {
-    logGroupName: output.logGroupName !== undefined && output.logGroupName !== null ? output.logGroupName : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
+    logGroupName: __expectString(output.logGroupName),
+    roleArn: __expectString(output.roleArn),
   } as any;
 };
 
@@ -32323,21 +32219,18 @@ const deserializeAws_restJson1CloudwatchMetricAction = (
   context: __SerdeContext
 ): CloudwatchMetricAction => {
   return {
-    metricName: output.metricName !== undefined && output.metricName !== null ? output.metricName : undefined,
-    metricNamespace:
-      output.metricNamespace !== undefined && output.metricNamespace !== null ? output.metricNamespace : undefined,
-    metricTimestamp:
-      output.metricTimestamp !== undefined && output.metricTimestamp !== null ? output.metricTimestamp : undefined,
-    metricUnit: output.metricUnit !== undefined && output.metricUnit !== null ? output.metricUnit : undefined,
-    metricValue: output.metricValue !== undefined && output.metricValue !== null ? output.metricValue : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
+    metricName: __expectString(output.metricName),
+    metricNamespace: __expectString(output.metricNamespace),
+    metricTimestamp: __expectString(output.metricTimestamp),
+    metricUnit: __expectString(output.metricUnit),
+    metricValue: __expectString(output.metricValue),
+    roleArn: __expectString(output.roleArn),
   } as any;
 };
 
 const deserializeAws_restJson1CodeSigning = (output: any, context: __SerdeContext): CodeSigning => {
   return {
-    awsSignerJobId:
-      output.awsSignerJobId !== undefined && output.awsSignerJobId !== null ? output.awsSignerJobId : undefined,
+    awsSignerJobId: __expectString(output.awsSignerJobId),
     customCodeSigning:
       output.customCodeSigning !== undefined && output.customCodeSigning !== null
         ? deserializeAws_restJson1CustomCodeSigning(output.customCodeSigning, context)
@@ -32354,10 +32247,8 @@ const deserializeAws_restJson1CodeSigningCertificateChain = (
   context: __SerdeContext
 ): CodeSigningCertificateChain => {
   return {
-    certificateName:
-      output.certificateName !== undefined && output.certificateName !== null ? output.certificateName : undefined,
-    inlineDocument:
-      output.inlineDocument !== undefined && output.inlineDocument !== null ? output.inlineDocument : undefined,
+    certificateName: __expectString(output.certificateName),
+    inlineDocument: __expectString(output.inlineDocument),
   } as any;
 };
 
@@ -32372,7 +32263,7 @@ const deserializeAws_restJson1CodeSigningSignature = (output: any, context: __Se
 
 const deserializeAws_restJson1Configuration = (output: any, context: __SerdeContext): Configuration => {
   return {
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
+    Enabled: __expectBoolean(output.Enabled),
   } as any;
 };
 
@@ -32382,16 +32273,12 @@ const deserializeAws_restJson1CustomCodeSigning = (output: any, context: __Serde
       output.certificateChain !== undefined && output.certificateChain !== null
         ? deserializeAws_restJson1CodeSigningCertificateChain(output.certificateChain, context)
         : undefined,
-    hashAlgorithm:
-      output.hashAlgorithm !== undefined && output.hashAlgorithm !== null ? output.hashAlgorithm : undefined,
+    hashAlgorithm: __expectString(output.hashAlgorithm),
     signature:
       output.signature !== undefined && output.signature !== null
         ? deserializeAws_restJson1CodeSigningSignature(output.signature, context)
         : undefined,
-    signatureAlgorithm:
-      output.signatureAlgorithm !== undefined && output.signatureAlgorithm !== null
-        ? output.signatureAlgorithm
-        : undefined,
+    signatureAlgorithm: __expectString(output.signatureAlgorithm),
   } as any;
 };
 
@@ -32424,7 +32311,7 @@ const deserializeAws_restJson1DetailsMap = (output: any, context: __SerdeContext
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -32434,8 +32321,8 @@ const deserializeAws_restJson1DetectMitigationActionExecution = (
   context: __SerdeContext
 ): DetectMitigationActionExecution => {
   return {
-    actionName: output.actionName !== undefined && output.actionName !== null ? output.actionName : undefined,
-    errorCode: output.errorCode !== undefined && output.errorCode !== null ? output.errorCode : undefined,
+    actionName: __expectString(output.actionName),
+    errorCode: __expectString(output.errorCode),
     executionEndDate:
       output.executionEndDate !== undefined && output.executionEndDate !== null
         ? new Date(Math.round(output.executionEndDate * 1000))
@@ -32444,11 +32331,11 @@ const deserializeAws_restJson1DetectMitigationActionExecution = (
       output.executionStartDate !== undefined && output.executionStartDate !== null
         ? new Date(Math.round(output.executionStartDate * 1000))
         : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    taskId: output.taskId !== undefined && output.taskId !== null ? output.taskId : undefined,
-    thingName: output.thingName !== undefined && output.thingName !== null ? output.thingName : undefined,
-    violationId: output.violationId !== undefined && output.violationId !== null ? output.violationId : undefined,
+    message: __expectString(output.message),
+    status: __expectString(output.status),
+    taskId: __expectString(output.taskId),
+    thingName: __expectString(output.thingName),
+    violationId: __expectString(output.violationId),
   } as any;
 };
 
@@ -32471,12 +32358,9 @@ const deserializeAws_restJson1DetectMitigationActionsTaskStatistics = (
   context: __SerdeContext
 ): DetectMitigationActionsTaskStatistics => {
   return {
-    actionsExecuted:
-      output.actionsExecuted !== undefined && output.actionsExecuted !== null ? output.actionsExecuted : undefined,
-    actionsFailed:
-      output.actionsFailed !== undefined && output.actionsFailed !== null ? output.actionsFailed : undefined,
-    actionsSkipped:
-      output.actionsSkipped !== undefined && output.actionsSkipped !== null ? output.actionsSkipped : undefined,
+    actionsExecuted: __expectNumber(output.actionsExecuted),
+    actionsFailed: __expectNumber(output.actionsFailed),
+    actionsSkipped: __expectNumber(output.actionsSkipped),
   } as any;
 };
 
@@ -32489,14 +32373,8 @@ const deserializeAws_restJson1DetectMitigationActionsTaskSummary = (
       output.actionsDefinition !== undefined && output.actionsDefinition !== null
         ? deserializeAws_restJson1MitigationActionList(output.actionsDefinition, context)
         : undefined,
-    onlyActiveViolationsIncluded:
-      output.onlyActiveViolationsIncluded !== undefined && output.onlyActiveViolationsIncluded !== null
-        ? output.onlyActiveViolationsIncluded
-        : undefined,
-    suppressedAlertsIncluded:
-      output.suppressedAlertsIncluded !== undefined && output.suppressedAlertsIncluded !== null
-        ? output.suppressedAlertsIncluded
-        : undefined,
+    onlyActiveViolationsIncluded: __expectBoolean(output.onlyActiveViolationsIncluded),
+    suppressedAlertsIncluded: __expectBoolean(output.suppressedAlertsIncluded),
     target:
       output.target !== undefined && output.target !== null
         ? deserializeAws_restJson1DetectMitigationActionsTaskTarget(output.target, context)
@@ -32505,7 +32383,7 @@ const deserializeAws_restJson1DetectMitigationActionsTaskSummary = (
       output.taskEndTime !== undefined && output.taskEndTime !== null
         ? new Date(Math.round(output.taskEndTime * 1000))
         : undefined,
-    taskId: output.taskId !== undefined && output.taskId !== null ? output.taskId : undefined,
+    taskId: __expectString(output.taskId),
     taskStartTime:
       output.taskStartTime !== undefined && output.taskStartTime !== null
         ? new Date(Math.round(output.taskStartTime * 1000))
@@ -32514,7 +32392,7 @@ const deserializeAws_restJson1DetectMitigationActionsTaskSummary = (
       output.taskStatistics !== undefined && output.taskStatistics !== null
         ? deserializeAws_restJson1DetectMitigationActionsTaskStatistics(output.taskStatistics, context)
         : undefined,
-    taskStatus: output.taskStatus !== undefined && output.taskStatus !== null ? output.taskStatus : undefined,
+    taskStatus: __expectString(output.taskStatus),
     violationEventOccurrenceRange:
       output.violationEventOccurrenceRange !== undefined && output.violationEventOccurrenceRange !== null
         ? deserializeAws_restJson1ViolationEventOccurrenceRange(output.violationEventOccurrenceRange, context)
@@ -32541,11 +32419,8 @@ const deserializeAws_restJson1DetectMitigationActionsTaskTarget = (
   context: __SerdeContext
 ): DetectMitigationActionsTaskTarget => {
   return {
-    behaviorName: output.behaviorName !== undefined && output.behaviorName !== null ? output.behaviorName : undefined,
-    securityProfileName:
-      output.securityProfileName !== undefined && output.securityProfileName !== null
-        ? output.securityProfileName
-        : undefined,
+    behaviorName: __expectString(output.behaviorName),
+    securityProfileName: __expectString(output.securityProfileName),
     violationIds:
       output.violationIds !== undefined && output.violationIds !== null
         ? deserializeAws_restJson1TargetViolationIdsForDetectMitigationActions(output.violationIds, context)
@@ -32560,7 +32435,7 @@ const deserializeAws_restJson1DimensionNames = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -32571,7 +32446,7 @@ const deserializeAws_restJson1DimensionStringValues = (output: any, context: __S
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -32594,32 +32469,24 @@ const deserializeAws_restJson1DomainConfigurationSummary = (
   context: __SerdeContext
 ): DomainConfigurationSummary => {
   return {
-    domainConfigurationArn:
-      output.domainConfigurationArn !== undefined && output.domainConfigurationArn !== null
-        ? output.domainConfigurationArn
-        : undefined,
-    domainConfigurationName:
-      output.domainConfigurationName !== undefined && output.domainConfigurationName !== null
-        ? output.domainConfigurationName
-        : undefined,
-    serviceType: output.serviceType !== undefined && output.serviceType !== null ? output.serviceType : undefined,
+    domainConfigurationArn: __expectString(output.domainConfigurationArn),
+    domainConfigurationName: __expectString(output.domainConfigurationName),
+    serviceType: __expectString(output.serviceType),
   } as any;
 };
 
 const deserializeAws_restJson1DynamoDBAction = (output: any, context: __SerdeContext): DynamoDBAction => {
   return {
-    hashKeyField: output.hashKeyField !== undefined && output.hashKeyField !== null ? output.hashKeyField : undefined,
-    hashKeyType: output.hashKeyType !== undefined && output.hashKeyType !== null ? output.hashKeyType : undefined,
-    hashKeyValue: output.hashKeyValue !== undefined && output.hashKeyValue !== null ? output.hashKeyValue : undefined,
-    operation: output.operation !== undefined && output.operation !== null ? output.operation : undefined,
-    payloadField: output.payloadField !== undefined && output.payloadField !== null ? output.payloadField : undefined,
-    rangeKeyField:
-      output.rangeKeyField !== undefined && output.rangeKeyField !== null ? output.rangeKeyField : undefined,
-    rangeKeyType: output.rangeKeyType !== undefined && output.rangeKeyType !== null ? output.rangeKeyType : undefined,
-    rangeKeyValue:
-      output.rangeKeyValue !== undefined && output.rangeKeyValue !== null ? output.rangeKeyValue : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
-    tableName: output.tableName !== undefined && output.tableName !== null ? output.tableName : undefined,
+    hashKeyField: __expectString(output.hashKeyField),
+    hashKeyType: __expectString(output.hashKeyType),
+    hashKeyValue: __expectString(output.hashKeyValue),
+    operation: __expectString(output.operation),
+    payloadField: __expectString(output.payloadField),
+    rangeKeyField: __expectString(output.rangeKeyField),
+    rangeKeyType: __expectString(output.rangeKeyType),
+    rangeKeyValue: __expectString(output.rangeKeyValue),
+    roleArn: __expectString(output.roleArn),
+    tableName: __expectString(output.tableName),
   } as any;
 };
 
@@ -32629,7 +32496,7 @@ const deserializeAws_restJson1DynamoDBv2Action = (output: any, context: __SerdeC
       output.putItem !== undefined && output.putItem !== null
         ? deserializeAws_restJson1PutItemInput(output.putItem, context)
         : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
+    roleArn: __expectString(output.roleArn),
   } as any;
 };
 
@@ -32646,20 +32513,19 @@ const deserializeAws_restJson1EffectivePolicies = (output: any, context: __Serde
 
 const deserializeAws_restJson1EffectivePolicy = (output: any, context: __SerdeContext): EffectivePolicy => {
   return {
-    policyArn: output.policyArn !== undefined && output.policyArn !== null ? output.policyArn : undefined,
-    policyDocument:
-      output.policyDocument !== undefined && output.policyDocument !== null ? output.policyDocument : undefined,
-    policyName: output.policyName !== undefined && output.policyName !== null ? output.policyName : undefined,
+    policyArn: __expectString(output.policyArn),
+    policyDocument: __expectString(output.policyDocument),
+    policyName: __expectString(output.policyName),
   } as any;
 };
 
 const deserializeAws_restJson1ElasticsearchAction = (output: any, context: __SerdeContext): ElasticsearchAction => {
   return {
-    endpoint: output.endpoint !== undefined && output.endpoint !== null ? output.endpoint : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    index: output.index !== undefined && output.index !== null ? output.index : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    endpoint: __expectString(output.endpoint),
+    id: __expectString(output.id),
+    index: __expectString(output.index),
+    roleArn: __expectString(output.roleArn),
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -32668,18 +32534,15 @@ const deserializeAws_restJson1EnableIoTLoggingParams = (
   context: __SerdeContext
 ): EnableIoTLoggingParams => {
   return {
-    logLevel: output.logLevel !== undefined && output.logLevel !== null ? output.logLevel : undefined,
-    roleArnForLogging:
-      output.roleArnForLogging !== undefined && output.roleArnForLogging !== null
-        ? output.roleArnForLogging
-        : undefined,
+    logLevel: __expectString(output.logLevel),
+    roleArnForLogging: __expectString(output.roleArnForLogging),
   } as any;
 };
 
 const deserializeAws_restJson1ErrorInfo = (output: any, context: __SerdeContext): ErrorInfo => {
   return {
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    code: __expectString(output.code),
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -32715,12 +32578,8 @@ const deserializeAws_restJson1ExponentialRolloutRate = (
   context: __SerdeContext
 ): ExponentialRolloutRate => {
   return {
-    baseRatePerMinute:
-      output.baseRatePerMinute !== undefined && output.baseRatePerMinute !== null
-        ? output.baseRatePerMinute
-        : undefined,
-    incrementFactor:
-      output.incrementFactor !== undefined && output.incrementFactor !== null ? output.incrementFactor : undefined,
+    baseRatePerMinute: __expectNumber(output.baseRatePerMinute),
+    incrementFactor: __expectNumber(output.incrementFactor),
     rateIncreaseCriteria:
       output.rateIncreaseCriteria !== undefined && output.rateIncreaseCriteria !== null
         ? deserializeAws_restJson1RateIncreaseCriteria(output.rateIncreaseCriteria, context)
@@ -32730,8 +32589,8 @@ const deserializeAws_restJson1ExponentialRolloutRate = (
 
 const deserializeAws_restJson1Field = (output: any, context: __SerdeContext): Field => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    name: __expectString(output.name),
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -32766,26 +32625,23 @@ const deserializeAws_restJson1FindingIds = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1FirehoseAction = (output: any, context: __SerdeContext): FirehoseAction => {
   return {
-    batchMode: output.batchMode !== undefined && output.batchMode !== null ? output.batchMode : undefined,
-    deliveryStreamName:
-      output.deliveryStreamName !== undefined && output.deliveryStreamName !== null
-        ? output.deliveryStreamName
-        : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
-    separator: output.separator !== undefined && output.separator !== null ? output.separator : undefined,
+    batchMode: __expectBoolean(output.batchMode),
+    deliveryStreamName: __expectString(output.deliveryStreamName),
+    roleArn: __expectString(output.roleArn),
+    separator: __expectString(output.separator),
   } as any;
 };
 
 const deserializeAws_restJson1GroupNameAndArn = (output: any, context: __SerdeContext): GroupNameAndArn => {
   return {
-    groupArn: output.groupArn !== undefined && output.groupArn !== null ? output.groupArn : undefined,
-    groupName: output.groupName !== undefined && output.groupName !== null ? output.groupName : undefined,
+    groupArn: __expectString(output.groupArn),
+    groupName: __expectString(output.groupName),
   } as any;
 };
 
@@ -32806,20 +32662,19 @@ const deserializeAws_restJson1HttpAction = (output: any, context: __SerdeContext
       output.auth !== undefined && output.auth !== null
         ? deserializeAws_restJson1HttpAuthorization(output.auth, context)
         : undefined,
-    confirmationUrl:
-      output.confirmationUrl !== undefined && output.confirmationUrl !== null ? output.confirmationUrl : undefined,
+    confirmationUrl: __expectString(output.confirmationUrl),
     headers:
       output.headers !== undefined && output.headers !== null
         ? deserializeAws_restJson1HeaderList(output.headers, context)
         : undefined,
-    url: output.url !== undefined && output.url !== null ? output.url : undefined,
+    url: __expectString(output.url),
   } as any;
 };
 
 const deserializeAws_restJson1HttpActionHeader = (output: any, context: __SerdeContext): HttpActionHeader => {
   return {
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    key: __expectString(output.key),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -32837,8 +32692,7 @@ const deserializeAws_restJson1HttpUrlDestinationProperties = (
   context: __SerdeContext
 ): HttpUrlDestinationProperties => {
   return {
-    confirmationUrl:
-      output.confirmationUrl !== undefined && output.confirmationUrl !== null ? output.confirmationUrl : undefined,
+    confirmationUrl: __expectString(output.confirmationUrl),
   } as any;
 };
 
@@ -32847,8 +32701,7 @@ const deserializeAws_restJson1HttpUrlDestinationSummary = (
   context: __SerdeContext
 ): HttpUrlDestinationSummary => {
   return {
-    confirmationUrl:
-      output.confirmationUrl !== undefined && output.confirmationUrl !== null ? output.confirmationUrl : undefined,
+    confirmationUrl: __expectString(output.confirmationUrl),
   } as any;
 };
 
@@ -32868,25 +32721,25 @@ const deserializeAws_restJson1IndexNamesList = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1IotAnalyticsAction = (output: any, context: __SerdeContext): IotAnalyticsAction => {
   return {
-    batchMode: output.batchMode !== undefined && output.batchMode !== null ? output.batchMode : undefined,
-    channelArn: output.channelArn !== undefined && output.channelArn !== null ? output.channelArn : undefined,
-    channelName: output.channelName !== undefined && output.channelName !== null ? output.channelName : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
+    batchMode: __expectBoolean(output.batchMode),
+    channelArn: __expectString(output.channelArn),
+    channelName: __expectString(output.channelName),
+    roleArn: __expectString(output.roleArn),
   } as any;
 };
 
 const deserializeAws_restJson1IotEventsAction = (output: any, context: __SerdeContext): IotEventsAction => {
   return {
-    batchMode: output.batchMode !== undefined && output.batchMode !== null ? output.batchMode : undefined,
-    inputName: output.inputName !== undefined && output.inputName !== null ? output.inputName : undefined,
-    messageId: output.messageId !== undefined && output.messageId !== null ? output.messageId : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
+    batchMode: __expectBoolean(output.batchMode),
+    inputName: __expectString(output.inputName),
+    messageId: __expectString(output.messageId),
+    roleArn: __expectString(output.roleArn),
   } as any;
 };
 
@@ -32896,7 +32749,7 @@ const deserializeAws_restJson1IotSiteWiseAction = (output: any, context: __Serde
       output.putAssetPropertyValueEntries !== undefined && output.putAssetPropertyValueEntries !== null
         ? deserializeAws_restJson1PutAssetPropertyValueEntryList(output.putAssetPropertyValueEntries, context)
         : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
+    roleArn: __expectString(output.roleArn),
   } as any;
 };
 
@@ -32906,7 +32759,7 @@ const deserializeAws_restJson1Job = (output: any, context: __SerdeContext): Job 
       output.abortConfig !== undefined && output.abortConfig !== null
         ? deserializeAws_restJson1AbortConfig(output.abortConfig, context)
         : undefined,
-    comment: output.comment !== undefined && output.comment !== null ? output.comment : undefined,
+    comment: __expectString(output.comment),
     completedAt:
       output.completedAt !== undefined && output.completedAt !== null
         ? new Date(Math.round(output.completedAt * 1000))
@@ -32915,34 +32768,31 @@ const deserializeAws_restJson1Job = (output: any, context: __SerdeContext): Job 
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    forceCanceled:
-      output.forceCanceled !== undefined && output.forceCanceled !== null ? output.forceCanceled : undefined,
-    jobArn: output.jobArn !== undefined && output.jobArn !== null ? output.jobArn : undefined,
+    description: __expectString(output.description),
+    forceCanceled: __expectBoolean(output.forceCanceled),
+    jobArn: __expectString(output.jobArn),
     jobExecutionsRolloutConfig:
       output.jobExecutionsRolloutConfig !== undefined && output.jobExecutionsRolloutConfig !== null
         ? deserializeAws_restJson1JobExecutionsRolloutConfig(output.jobExecutionsRolloutConfig, context)
         : undefined,
-    jobId: output.jobId !== undefined && output.jobId !== null ? output.jobId : undefined,
+    jobId: __expectString(output.jobId),
     jobProcessDetails:
       output.jobProcessDetails !== undefined && output.jobProcessDetails !== null
         ? deserializeAws_restJson1JobProcessDetails(output.jobProcessDetails, context)
         : undefined,
-    jobTemplateArn:
-      output.jobTemplateArn !== undefined && output.jobTemplateArn !== null ? output.jobTemplateArn : undefined,
+    jobTemplateArn: __expectString(output.jobTemplateArn),
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
         ? new Date(Math.round(output.lastUpdatedAt * 1000))
         : undefined,
-    namespaceId: output.namespaceId !== undefined && output.namespaceId !== null ? output.namespaceId : undefined,
+    namespaceId: __expectString(output.namespaceId),
     presignedUrlConfig:
       output.presignedUrlConfig !== undefined && output.presignedUrlConfig !== null
         ? deserializeAws_restJson1PresignedUrlConfig(output.presignedUrlConfig, context)
         : undefined,
-    reasonCode: output.reasonCode !== undefined && output.reasonCode !== null ? output.reasonCode : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    targetSelection:
-      output.targetSelection !== undefined && output.targetSelection !== null ? output.targetSelection : undefined,
+    reasonCode: __expectString(output.reasonCode),
+    status: __expectString(output.status),
+    targetSelection: __expectString(output.targetSelection),
     targets:
       output.targets !== undefined && output.targets !== null
         ? deserializeAws_restJson1JobTargets(output.targets, context)
@@ -32956,15 +32806,10 @@ const deserializeAws_restJson1Job = (output: any, context: __SerdeContext): Job 
 
 const deserializeAws_restJson1JobExecution = (output: any, context: __SerdeContext): JobExecution => {
   return {
-    approximateSecondsBeforeTimedOut:
-      output.approximateSecondsBeforeTimedOut !== undefined && output.approximateSecondsBeforeTimedOut !== null
-        ? output.approximateSecondsBeforeTimedOut
-        : undefined,
-    executionNumber:
-      output.executionNumber !== undefined && output.executionNumber !== null ? output.executionNumber : undefined,
-    forceCanceled:
-      output.forceCanceled !== undefined && output.forceCanceled !== null ? output.forceCanceled : undefined,
-    jobId: output.jobId !== undefined && output.jobId !== null ? output.jobId : undefined,
+    approximateSecondsBeforeTimedOut: __expectNumber(output.approximateSecondsBeforeTimedOut),
+    executionNumber: __expectNumber(output.executionNumber),
+    forceCanceled: __expectBoolean(output.forceCanceled),
+    jobId: __expectString(output.jobId),
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
         ? new Date(Math.round(output.lastUpdatedAt * 1000))
@@ -32977,14 +32822,13 @@ const deserializeAws_restJson1JobExecution = (output: any, context: __SerdeConte
       output.startedAt !== undefined && output.startedAt !== null
         ? new Date(Math.round(output.startedAt * 1000))
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
     statusDetails:
       output.statusDetails !== undefined && output.statusDetails !== null
         ? deserializeAws_restJson1JobExecutionStatusDetails(output.statusDetails, context)
         : undefined,
-    thingArn: output.thingArn !== undefined && output.thingArn !== null ? output.thingArn : undefined,
-    versionNumber:
-      output.versionNumber !== undefined && output.versionNumber !== null ? output.versionNumber : undefined,
+    thingArn: __expectString(output.thingArn),
+    versionNumber: __expectNumber(output.versionNumber),
   } as any;
 };
 
@@ -32997,8 +32841,7 @@ const deserializeAws_restJson1JobExecutionsRolloutConfig = (
       output.exponentialRate !== undefined && output.exponentialRate !== null
         ? deserializeAws_restJson1ExponentialRolloutRate(output.exponentialRate, context)
         : undefined,
-    maximumPerMinute:
-      output.maximumPerMinute !== undefined && output.maximumPerMinute !== null ? output.maximumPerMinute : undefined,
+    maximumPerMinute: __expectNumber(output.maximumPerMinute),
   } as any;
 };
 
@@ -33016,8 +32859,7 @@ const deserializeAws_restJson1JobExecutionStatusDetails = (
 
 const deserializeAws_restJson1JobExecutionSummary = (output: any, context: __SerdeContext): JobExecutionSummary => {
   return {
-    executionNumber:
-      output.executionNumber !== undefined && output.executionNumber !== null ? output.executionNumber : undefined,
+    executionNumber: __expectNumber(output.executionNumber),
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
         ? new Date(Math.round(output.lastUpdatedAt * 1000))
@@ -33030,7 +32872,7 @@ const deserializeAws_restJson1JobExecutionSummary = (output: any, context: __Ser
       output.startedAt !== undefined && output.startedAt !== null
         ? new Date(Math.round(output.startedAt * 1000))
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -33043,7 +32885,7 @@ const deserializeAws_restJson1JobExecutionSummaryForJob = (
       output.jobExecutionSummary !== undefined && output.jobExecutionSummary !== null
         ? deserializeAws_restJson1JobExecutionSummary(output.jobExecutionSummary, context)
         : undefined,
-    thingArn: output.thingArn !== undefined && output.thingArn !== null ? output.thingArn : undefined,
+    thingArn: __expectString(output.thingArn),
   } as any;
 };
 
@@ -33070,7 +32912,7 @@ const deserializeAws_restJson1JobExecutionSummaryForThing = (
       output.jobExecutionSummary !== undefined && output.jobExecutionSummary !== null
         ? deserializeAws_restJson1JobExecutionSummary(output.jobExecutionSummary, context)
         : undefined,
-    jobId: output.jobId !== undefined && output.jobId !== null ? output.jobId : undefined,
+    jobId: __expectString(output.jobId),
   } as any;
 };
 
@@ -33090,38 +32932,14 @@ const deserializeAws_restJson1JobExecutionSummaryForThingList = (
 
 const deserializeAws_restJson1JobProcessDetails = (output: any, context: __SerdeContext): JobProcessDetails => {
   return {
-    numberOfCanceledThings:
-      output.numberOfCanceledThings !== undefined && output.numberOfCanceledThings !== null
-        ? output.numberOfCanceledThings
-        : undefined,
-    numberOfFailedThings:
-      output.numberOfFailedThings !== undefined && output.numberOfFailedThings !== null
-        ? output.numberOfFailedThings
-        : undefined,
-    numberOfInProgressThings:
-      output.numberOfInProgressThings !== undefined && output.numberOfInProgressThings !== null
-        ? output.numberOfInProgressThings
-        : undefined,
-    numberOfQueuedThings:
-      output.numberOfQueuedThings !== undefined && output.numberOfQueuedThings !== null
-        ? output.numberOfQueuedThings
-        : undefined,
-    numberOfRejectedThings:
-      output.numberOfRejectedThings !== undefined && output.numberOfRejectedThings !== null
-        ? output.numberOfRejectedThings
-        : undefined,
-    numberOfRemovedThings:
-      output.numberOfRemovedThings !== undefined && output.numberOfRemovedThings !== null
-        ? output.numberOfRemovedThings
-        : undefined,
-    numberOfSucceededThings:
-      output.numberOfSucceededThings !== undefined && output.numberOfSucceededThings !== null
-        ? output.numberOfSucceededThings
-        : undefined,
-    numberOfTimedOutThings:
-      output.numberOfTimedOutThings !== undefined && output.numberOfTimedOutThings !== null
-        ? output.numberOfTimedOutThings
-        : undefined,
+    numberOfCanceledThings: __expectNumber(output.numberOfCanceledThings),
+    numberOfFailedThings: __expectNumber(output.numberOfFailedThings),
+    numberOfInProgressThings: __expectNumber(output.numberOfInProgressThings),
+    numberOfQueuedThings: __expectNumber(output.numberOfQueuedThings),
+    numberOfRejectedThings: __expectNumber(output.numberOfRejectedThings),
+    numberOfRemovedThings: __expectNumber(output.numberOfRemovedThings),
+    numberOfSucceededThings: __expectNumber(output.numberOfSucceededThings),
+    numberOfTimedOutThings: __expectNumber(output.numberOfTimedOutThings),
     processingTargets:
       output.processingTargets !== undefined && output.processingTargets !== null
         ? deserializeAws_restJson1ProcessingTargetNameList(output.processingTargets, context)
@@ -33139,16 +32957,15 @@ const deserializeAws_restJson1JobSummary = (output: any, context: __SerdeContext
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    jobArn: output.jobArn !== undefined && output.jobArn !== null ? output.jobArn : undefined,
-    jobId: output.jobId !== undefined && output.jobId !== null ? output.jobId : undefined,
+    jobArn: __expectString(output.jobArn),
+    jobId: __expectString(output.jobId),
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
         ? new Date(Math.round(output.lastUpdatedAt * 1000))
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    targetSelection:
-      output.targetSelection !== undefined && output.targetSelection !== null ? output.targetSelection : undefined,
-    thingGroupId: output.thingGroupId !== undefined && output.thingGroupId !== null ? output.thingGroupId : undefined,
+    status: __expectString(output.status),
+    targetSelection: __expectString(output.targetSelection),
+    thingGroupId: __expectString(output.thingGroupId),
   } as any;
 };
 
@@ -33170,7 +32987,7 @@ const deserializeAws_restJson1JobTargets = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -33180,11 +32997,9 @@ const deserializeAws_restJson1JobTemplateSummary = (output: any, context: __Serd
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    jobTemplateArn:
-      output.jobTemplateArn !== undefined && output.jobTemplateArn !== null ? output.jobTemplateArn : undefined,
-    jobTemplateId:
-      output.jobTemplateId !== undefined && output.jobTemplateId !== null ? output.jobTemplateId : undefined,
+    description: __expectString(output.description),
+    jobTemplateArn: __expectString(output.jobTemplateArn),
+    jobTemplateId: __expectString(output.jobTemplateId),
   } as any;
 };
 
@@ -33205,39 +33020,38 @@ const deserializeAws_restJson1KafkaAction = (output: any, context: __SerdeContex
       output.clientProperties !== undefined && output.clientProperties !== null
         ? deserializeAws_restJson1ClientProperties(output.clientProperties, context)
         : undefined,
-    destinationArn:
-      output.destinationArn !== undefined && output.destinationArn !== null ? output.destinationArn : undefined,
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
-    partition: output.partition !== undefined && output.partition !== null ? output.partition : undefined,
-    topic: output.topic !== undefined && output.topic !== null ? output.topic : undefined,
+    destinationArn: __expectString(output.destinationArn),
+    key: __expectString(output.key),
+    partition: __expectString(output.partition),
+    topic: __expectString(output.topic),
   } as any;
 };
 
 const deserializeAws_restJson1KeyPair = (output: any, context: __SerdeContext): KeyPair => {
   return {
-    PrivateKey: output.PrivateKey !== undefined && output.PrivateKey !== null ? output.PrivateKey : undefined,
-    PublicKey: output.PublicKey !== undefined && output.PublicKey !== null ? output.PublicKey : undefined,
+    PrivateKey: __expectString(output.PrivateKey),
+    PublicKey: __expectString(output.PublicKey),
   } as any;
 };
 
 const deserializeAws_restJson1KinesisAction = (output: any, context: __SerdeContext): KinesisAction => {
   return {
-    partitionKey: output.partitionKey !== undefined && output.partitionKey !== null ? output.partitionKey : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
-    streamName: output.streamName !== undefined && output.streamName !== null ? output.streamName : undefined,
+    partitionKey: __expectString(output.partitionKey),
+    roleArn: __expectString(output.roleArn),
+    streamName: __expectString(output.streamName),
   } as any;
 };
 
 const deserializeAws_restJson1LambdaAction = (output: any, context: __SerdeContext): LambdaAction => {
   return {
-    functionArn: output.functionArn !== undefined && output.functionArn !== null ? output.functionArn : undefined,
+    functionArn: __expectString(output.functionArn),
   } as any;
 };
 
 const deserializeAws_restJson1LogTarget = (output: any, context: __SerdeContext): LogTarget => {
   return {
-    targetName: output.targetName !== undefined && output.targetName !== null ? output.targetName : undefined,
-    targetType: output.targetType !== undefined && output.targetType !== null ? output.targetType : undefined,
+    targetName: __expectString(output.targetName),
+    targetType: __expectString(output.targetType),
   } as any;
 };
 
@@ -33246,7 +33060,7 @@ const deserializeAws_restJson1LogTargetConfiguration = (
   context: __SerdeContext
 ): LogTargetConfiguration => {
   return {
-    logLevel: output.logLevel !== undefined && output.logLevel !== null ? output.logLevel : undefined,
+    logLevel: __expectString(output.logLevel),
     logTarget:
       output.logTarget !== undefined && output.logTarget !== null
         ? deserializeAws_restJson1LogTarget(output.logTarget, context)
@@ -33273,16 +33087,14 @@ const deserializeAws_restJson1MachineLearningDetectionConfig = (
   context: __SerdeContext
 ): MachineLearningDetectionConfig => {
   return {
-    confidenceLevel:
-      output.confidenceLevel !== undefined && output.confidenceLevel !== null ? output.confidenceLevel : undefined,
+    confidenceLevel: __expectString(output.confidenceLevel),
   } as any;
 };
 
 const deserializeAws_restJson1MetricDimension = (output: any, context: __SerdeContext): MetricDimension => {
   return {
-    dimensionName:
-      output.dimensionName !== undefined && output.dimensionName !== null ? output.dimensionName : undefined,
-    operator: output.operator !== undefined && output.operator !== null ? output.operator : undefined,
+    dimensionName: __expectString(output.dimensionName),
+    operator: __expectString(output.operator),
   } as any;
 };
 
@@ -33293,13 +33105,13 @@ const deserializeAws_restJson1MetricNames = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1MetricToRetain = (output: any, context: __SerdeContext): MetricToRetain => {
   return {
-    metric: output.metric !== undefined && output.metric !== null ? output.metric : undefined,
+    metric: __expectString(output.metric),
     metricDimension:
       output.metricDimension !== undefined && output.metricDimension !== null
         ? deserializeAws_restJson1MetricDimension(output.metricDimension, context)
@@ -33313,8 +33125,8 @@ const deserializeAws_restJson1MetricValue = (output: any, context: __SerdeContex
       output.cidrs !== undefined && output.cidrs !== null
         ? deserializeAws_restJson1Cidrs(output.cidrs, context)
         : undefined,
-    count: output.count !== undefined && output.count !== null ? output.count : undefined,
-    number: output.number !== undefined && output.number !== null ? output.number : undefined,
+    count: __expectNumber(output.count),
+    number: __expectNumber(output.number),
     numbers:
       output.numbers !== undefined && output.numbers !== null
         ? deserializeAws_restJson1NumberList(output.numbers, context)
@@ -33337,7 +33149,7 @@ const deserializeAws_restJson1MissingContextValues = (output: any, context: __Se
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -33347,9 +33159,9 @@ const deserializeAws_restJson1MitigationAction = (output: any, context: __SerdeC
       output.actionParams !== undefined && output.actionParams !== null
         ? deserializeAws_restJson1MitigationActionParams(output.actionParams, context)
         : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
+    id: __expectString(output.id),
+    name: __expectString(output.name),
+    roleArn: __expectString(output.roleArn),
   } as any;
 };
 
@@ -33358,8 +33170,8 @@ const deserializeAws_restJson1MitigationActionIdentifier = (
   context: __SerdeContext
 ): MitigationActionIdentifier => {
   return {
-    actionArn: output.actionArn !== undefined && output.actionArn !== null ? output.actionArn : undefined,
-    actionName: output.actionName !== undefined && output.actionName !== null ? output.actionName : undefined,
+    actionArn: __expectString(output.actionArn),
+    actionName: __expectString(output.actionName),
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
         ? new Date(Math.round(output.creationDate * 1000))
@@ -33399,7 +33211,7 @@ const deserializeAws_restJson1MitigationActionNameList = (output: any, context: 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -33445,7 +33257,7 @@ const deserializeAws_restJson1NonCompliantResource = (output: any, context: __Se
       output.resourceIdentifier !== undefined && output.resourceIdentifier !== null
         ? deserializeAws_restJson1ResourceIdentifier(output.resourceIdentifier, context)
         : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
+    resourceType: __expectString(output.resourceType),
   } as any;
 };
 
@@ -33456,7 +33268,7 @@ const deserializeAws_restJson1NumberList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectNumber(entry) as any;
     });
 };
 
@@ -33474,9 +33286,9 @@ const deserializeAws_restJson1OTAUpdateFile = (output: any, context: __SerdeCont
       output.fileLocation !== undefined && output.fileLocation !== null
         ? deserializeAws_restJson1FileLocation(output.fileLocation, context)
         : undefined,
-    fileName: output.fileName !== undefined && output.fileName !== null ? output.fileName : undefined,
-    fileType: output.fileType !== undefined && output.fileType !== null ? output.fileType : undefined,
-    fileVersion: output.fileVersion !== undefined && output.fileVersion !== null ? output.fileVersion : undefined,
+    fileName: __expectString(output.fileName),
+    fileType: __expectNumber(output.fileType),
+    fileVersion: __expectString(output.fileVersion),
   } as any;
 };
 
@@ -33497,8 +33309,8 @@ const deserializeAws_restJson1OTAUpdateInfo = (output: any, context: __SerdeCont
       output.additionalParameters !== undefined && output.additionalParameters !== null
         ? deserializeAws_restJson1AdditionalParameterMap(output.additionalParameters, context)
         : undefined,
-    awsIotJobArn: output.awsIotJobArn !== undefined && output.awsIotJobArn !== null ? output.awsIotJobArn : undefined,
-    awsIotJobId: output.awsIotJobId !== undefined && output.awsIotJobId !== null ? output.awsIotJobId : undefined,
+    awsIotJobArn: __expectString(output.awsIotJobArn),
+    awsIotJobId: __expectString(output.awsIotJobId),
     awsJobExecutionsRolloutConfig:
       output.awsJobExecutionsRolloutConfig !== undefined && output.awsJobExecutionsRolloutConfig !== null
         ? deserializeAws_restJson1AwsJobExecutionsRolloutConfig(output.awsJobExecutionsRolloutConfig, context)
@@ -33511,7 +33323,7 @@ const deserializeAws_restJson1OTAUpdateInfo = (output: any, context: __SerdeCont
       output.creationDate !== undefined && output.creationDate !== null
         ? new Date(Math.round(output.creationDate * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    description: __expectString(output.description),
     errorInfo:
       output.errorInfo !== undefined && output.errorInfo !== null
         ? deserializeAws_restJson1ErrorInfo(output.errorInfo, context)
@@ -33520,20 +33332,18 @@ const deserializeAws_restJson1OTAUpdateInfo = (output: any, context: __SerdeCont
       output.lastModifiedDate !== undefined && output.lastModifiedDate !== null
         ? new Date(Math.round(output.lastModifiedDate * 1000))
         : undefined,
-    otaUpdateArn: output.otaUpdateArn !== undefined && output.otaUpdateArn !== null ? output.otaUpdateArn : undefined,
+    otaUpdateArn: __expectString(output.otaUpdateArn),
     otaUpdateFiles:
       output.otaUpdateFiles !== undefined && output.otaUpdateFiles !== null
         ? deserializeAws_restJson1OTAUpdateFiles(output.otaUpdateFiles, context)
         : undefined,
-    otaUpdateId: output.otaUpdateId !== undefined && output.otaUpdateId !== null ? output.otaUpdateId : undefined,
-    otaUpdateStatus:
-      output.otaUpdateStatus !== undefined && output.otaUpdateStatus !== null ? output.otaUpdateStatus : undefined,
+    otaUpdateId: __expectString(output.otaUpdateId),
+    otaUpdateStatus: __expectString(output.otaUpdateStatus),
     protocols:
       output.protocols !== undefined && output.protocols !== null
         ? deserializeAws_restJson1Protocols(output.protocols, context)
         : undefined,
-    targetSelection:
-      output.targetSelection !== undefined && output.targetSelection !== null ? output.targetSelection : undefined,
+    targetSelection: __expectString(output.targetSelection),
     targets:
       output.targets !== undefined && output.targets !== null
         ? deserializeAws_restJson1Targets(output.targets, context)
@@ -33558,17 +33368,15 @@ const deserializeAws_restJson1OTAUpdateSummary = (output: any, context: __SerdeC
       output.creationDate !== undefined && output.creationDate !== null
         ? new Date(Math.round(output.creationDate * 1000))
         : undefined,
-    otaUpdateArn: output.otaUpdateArn !== undefined && output.otaUpdateArn !== null ? output.otaUpdateArn : undefined,
-    otaUpdateId: output.otaUpdateId !== undefined && output.otaUpdateId !== null ? output.otaUpdateId : undefined,
+    otaUpdateArn: __expectString(output.otaUpdateArn),
+    otaUpdateId: __expectString(output.otaUpdateId),
   } as any;
 };
 
 const deserializeAws_restJson1OutgoingCertificate = (output: any, context: __SerdeContext): OutgoingCertificate => {
   return {
-    certificateArn:
-      output.certificateArn !== undefined && output.certificateArn !== null ? output.certificateArn : undefined,
-    certificateId:
-      output.certificateId !== undefined && output.certificateId !== null ? output.certificateId : undefined,
+    certificateArn: __expectString(output.certificateArn),
+    certificateId: __expectString(output.certificateId),
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
         ? new Date(Math.round(output.creationDate * 1000))
@@ -33577,10 +33385,8 @@ const deserializeAws_restJson1OutgoingCertificate = (output: any, context: __Ser
       output.transferDate !== undefined && output.transferDate !== null
         ? new Date(Math.round(output.transferDate * 1000))
         : undefined,
-    transferMessage:
-      output.transferMessage !== undefined && output.transferMessage !== null ? output.transferMessage : undefined,
-    transferredTo:
-      output.transferredTo !== undefined && output.transferredTo !== null ? output.transferredTo : undefined,
+    transferMessage: __expectString(output.transferMessage),
+    transferredTo: __expectString(output.transferredTo),
   } as any;
 };
 
@@ -33608,8 +33414,8 @@ const deserializeAws_restJson1Percentiles = (output: any, context: __SerdeContex
 
 const deserializeAws_restJson1PercentPair = (output: any, context: __SerdeContext): PercentPair => {
   return {
-    percent: output.percent !== undefined && output.percent !== null ? output.percent : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    percent: __expectNumber(output.percent),
+    value: __expectNumber(output.value),
   } as any;
 };
 
@@ -33626,8 +33432,8 @@ const deserializeAws_restJson1Policies = (output: any, context: __SerdeContext):
 
 const deserializeAws_restJson1Policy = (output: any, context: __SerdeContext): Policy => {
   return {
-    policyArn: output.policyArn !== undefined && output.policyArn !== null ? output.policyArn : undefined,
-    policyName: output.policyName !== undefined && output.policyName !== null ? output.policyName : undefined,
+    policyArn: __expectString(output.policyArn),
+    policyName: __expectString(output.policyName),
   } as any;
 };
 
@@ -33638,7 +33444,7 @@ const deserializeAws_restJson1PolicyDocuments = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -33649,7 +33455,7 @@ const deserializeAws_restJson1PolicyTargets = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -33659,9 +33465,8 @@ const deserializeAws_restJson1PolicyVersion = (output: any, context: __SerdeCont
       output.createDate !== undefined && output.createDate !== null
         ? new Date(Math.round(output.createDate * 1000))
         : undefined,
-    isDefaultVersion:
-      output.isDefaultVersion !== undefined && output.isDefaultVersion !== null ? output.isDefaultVersion : undefined,
-    versionId: output.versionId !== undefined && output.versionId !== null ? output.versionId : undefined,
+    isDefaultVersion: __expectBoolean(output.isDefaultVersion),
+    versionId: __expectString(output.versionId),
   } as any;
 };
 
@@ -33670,9 +33475,8 @@ const deserializeAws_restJson1PolicyVersionIdentifier = (
   context: __SerdeContext
 ): PolicyVersionIdentifier => {
   return {
-    policyName: output.policyName !== undefined && output.policyName !== null ? output.policyName : undefined,
-    policyVersionId:
-      output.policyVersionId !== undefined && output.policyVersionId !== null ? output.policyVersionId : undefined,
+    policyName: __expectString(output.policyName),
+    policyVersionId: __expectString(output.policyVersionId),
   } as any;
 };
 
@@ -33694,14 +33498,14 @@ const deserializeAws_restJson1Ports = (output: any, context: __SerdeContext): nu
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectNumber(entry) as any;
     });
 };
 
 const deserializeAws_restJson1PresignedUrlConfig = (output: any, context: __SerdeContext): PresignedUrlConfig => {
   return {
-    expiresInSec: output.expiresInSec !== undefined && output.expiresInSec !== null ? output.expiresInSec : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
+    expiresInSec: __expectNumber(output.expiresInSec),
+    roleArn: __expectString(output.roleArn),
   } as any;
 };
 
@@ -33712,7 +33516,7 @@ const deserializeAws_restJson1Principals = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -33723,7 +33527,7 @@ const deserializeAws_restJson1ProcessingTargetNameList = (output: any, context: 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -33734,15 +33538,14 @@ const deserializeAws_restJson1Protocols = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1ProvisioningHook = (output: any, context: __SerdeContext): ProvisioningHook => {
   return {
-    payloadVersion:
-      output.payloadVersion !== undefined && output.payloadVersion !== null ? output.payloadVersion : undefined,
-    targetArn: output.targetArn !== undefined && output.targetArn !== null ? output.targetArn : undefined,
+    payloadVersion: __expectString(output.payloadVersion),
+    targetArn: __expectString(output.targetArn),
   } as any;
 };
 
@@ -33769,14 +33572,14 @@ const deserializeAws_restJson1ProvisioningTemplateSummary = (
       output.creationDate !== undefined && output.creationDate !== null
         ? new Date(Math.round(output.creationDate * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    enabled: output.enabled !== undefined && output.enabled !== null ? output.enabled : undefined,
+    description: __expectString(output.description),
+    enabled: __expectBoolean(output.enabled),
     lastModifiedDate:
       output.lastModifiedDate !== undefined && output.lastModifiedDate !== null
         ? new Date(Math.round(output.lastModifiedDate * 1000))
         : undefined,
-    templateArn: output.templateArn !== undefined && output.templateArn !== null ? output.templateArn : undefined,
-    templateName: output.templateName !== undefined && output.templateName !== null ? output.templateName : undefined,
+    templateArn: __expectString(output.templateArn),
+    templateName: __expectString(output.templateName),
   } as any;
 };
 
@@ -33803,9 +33606,8 @@ const deserializeAws_restJson1ProvisioningTemplateVersionSummary = (
       output.creationDate !== undefined && output.creationDate !== null
         ? new Date(Math.round(output.creationDate * 1000))
         : undefined,
-    isDefaultVersion:
-      output.isDefaultVersion !== undefined && output.isDefaultVersion !== null ? output.isDefaultVersion : undefined,
-    versionId: output.versionId !== undefined && output.versionId !== null ? output.versionId : undefined,
+    isDefaultVersion: __expectBoolean(output.isDefaultVersion),
+    versionId: __expectNumber(output.versionId),
   } as any;
 };
 
@@ -33816,7 +33618,7 @@ const deserializeAws_restJson1PublicKeyMap = (output: any, context: __SerdeConte
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -33826,7 +33628,7 @@ const deserializeAws_restJson1PublishFindingToSnsParams = (
   context: __SerdeContext
 ): PublishFindingToSnsParams => {
   return {
-    topicArn: output.topicArn !== undefined && output.topicArn !== null ? output.topicArn : undefined,
+    topicArn: __expectString(output.topicArn),
   } as any;
 };
 
@@ -33835,11 +33637,10 @@ const deserializeAws_restJson1PutAssetPropertyValueEntry = (
   context: __SerdeContext
 ): PutAssetPropertyValueEntry => {
   return {
-    assetId: output.assetId !== undefined && output.assetId !== null ? output.assetId : undefined,
-    entryId: output.entryId !== undefined && output.entryId !== null ? output.entryId : undefined,
-    propertyAlias:
-      output.propertyAlias !== undefined && output.propertyAlias !== null ? output.propertyAlias : undefined,
-    propertyId: output.propertyId !== undefined && output.propertyId !== null ? output.propertyId : undefined,
+    assetId: __expectString(output.assetId),
+    entryId: __expectString(output.entryId),
+    propertyAlias: __expectString(output.propertyAlias),
+    propertyId: __expectString(output.propertyId),
     propertyValues:
       output.propertyValues !== undefined && output.propertyValues !== null
         ? deserializeAws_restJson1AssetPropertyValueList(output.propertyValues, context)
@@ -33863,20 +33664,14 @@ const deserializeAws_restJson1PutAssetPropertyValueEntryList = (
 
 const deserializeAws_restJson1PutItemInput = (output: any, context: __SerdeContext): PutItemInput => {
   return {
-    tableName: output.tableName !== undefined && output.tableName !== null ? output.tableName : undefined,
+    tableName: __expectString(output.tableName),
   } as any;
 };
 
 const deserializeAws_restJson1RateIncreaseCriteria = (output: any, context: __SerdeContext): RateIncreaseCriteria => {
   return {
-    numberOfNotifiedThings:
-      output.numberOfNotifiedThings !== undefined && output.numberOfNotifiedThings !== null
-        ? output.numberOfNotifiedThings
-        : undefined,
-    numberOfSucceededThings:
-      output.numberOfSucceededThings !== undefined && output.numberOfSucceededThings !== null
-        ? output.numberOfSucceededThings
-        : undefined,
+    numberOfNotifiedThings: __expectNumber(output.numberOfNotifiedThings),
+    numberOfSucceededThings: __expectNumber(output.numberOfSucceededThings),
   } as any;
 };
 
@@ -33887,14 +33682,14 @@ const deserializeAws_restJson1ReasonForNonComplianceCodes = (output: any, contex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1RegistrationConfig = (output: any, context: __SerdeContext): RegistrationConfig => {
   return {
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
-    templateBody: output.templateBody !== undefined && output.templateBody !== null ? output.templateBody : undefined,
+    roleArn: __expectString(output.roleArn),
+    templateBody: __expectString(output.templateBody),
   } as any;
 };
 
@@ -33908,7 +33703,7 @@ const deserializeAws_restJson1RelatedResource = (output: any, context: __SerdeCo
       output.resourceIdentifier !== undefined && output.resourceIdentifier !== null
         ? deserializeAws_restJson1ResourceIdentifier(output.resourceIdentifier, context)
         : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
+    resourceType: __expectString(output.resourceType),
   } as any;
 };
 
@@ -33928,15 +33723,15 @@ const deserializeAws_restJson1ReplaceDefaultPolicyVersionParams = (
   context: __SerdeContext
 ): ReplaceDefaultPolicyVersionParams => {
   return {
-    templateName: output.templateName !== undefined && output.templateName !== null ? output.templateName : undefined,
+    templateName: __expectString(output.templateName),
   } as any;
 };
 
 const deserializeAws_restJson1RepublishAction = (output: any, context: __SerdeContext): RepublishAction => {
   return {
-    qos: output.qos !== undefined && output.qos !== null ? output.qos : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
-    topic: output.topic !== undefined && output.topic !== null ? output.topic : undefined,
+    qos: __expectNumber(output.qos),
+    roleArn: __expectString(output.roleArn),
+    topic: __expectString(output.topic),
   } as any;
 };
 
@@ -33947,31 +33742,24 @@ const deserializeAws_restJson1ResourceArns = (output: any, context: __SerdeConte
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1ResourceIdentifier = (output: any, context: __SerdeContext): ResourceIdentifier => {
   return {
-    account: output.account !== undefined && output.account !== null ? output.account : undefined,
-    caCertificateId:
-      output.caCertificateId !== undefined && output.caCertificateId !== null ? output.caCertificateId : undefined,
-    clientId: output.clientId !== undefined && output.clientId !== null ? output.clientId : undefined,
-    cognitoIdentityPoolId:
-      output.cognitoIdentityPoolId !== undefined && output.cognitoIdentityPoolId !== null
-        ? output.cognitoIdentityPoolId
-        : undefined,
-    deviceCertificateId:
-      output.deviceCertificateId !== undefined && output.deviceCertificateId !== null
-        ? output.deviceCertificateId
-        : undefined,
-    iamRoleArn: output.iamRoleArn !== undefined && output.iamRoleArn !== null ? output.iamRoleArn : undefined,
+    account: __expectString(output.account),
+    caCertificateId: __expectString(output.caCertificateId),
+    clientId: __expectString(output.clientId),
+    cognitoIdentityPoolId: __expectString(output.cognitoIdentityPoolId),
+    deviceCertificateId: __expectString(output.deviceCertificateId),
+    iamRoleArn: __expectString(output.iamRoleArn),
     policyVersionIdentifier:
       output.policyVersionIdentifier !== undefined && output.policyVersionIdentifier !== null
         ? deserializeAws_restJson1PolicyVersionIdentifier(output.policyVersionIdentifier, context)
         : undefined,
-    roleAliasArn: output.roleAliasArn !== undefined && output.roleAliasArn !== null ? output.roleAliasArn : undefined,
+    roleAliasArn: __expectString(output.roleAliasArn),
   } as any;
 };
 
@@ -33982,7 +33770,7 @@ const deserializeAws_restJson1Resources = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -33992,18 +33780,15 @@ const deserializeAws_restJson1RoleAliasDescription = (output: any, context: __Se
       output.creationDate !== undefined && output.creationDate !== null
         ? new Date(Math.round(output.creationDate * 1000))
         : undefined,
-    credentialDurationSeconds:
-      output.credentialDurationSeconds !== undefined && output.credentialDurationSeconds !== null
-        ? output.credentialDurationSeconds
-        : undefined,
+    credentialDurationSeconds: __expectNumber(output.credentialDurationSeconds),
     lastModifiedDate:
       output.lastModifiedDate !== undefined && output.lastModifiedDate !== null
         ? new Date(Math.round(output.lastModifiedDate * 1000))
         : undefined,
-    owner: output.owner !== undefined && output.owner !== null ? output.owner : undefined,
-    roleAlias: output.roleAlias !== undefined && output.roleAlias !== null ? output.roleAlias : undefined,
-    roleAliasArn: output.roleAliasArn !== undefined && output.roleAliasArn !== null ? output.roleAliasArn : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
+    owner: __expectString(output.owner),
+    roleAlias: __expectString(output.roleAlias),
+    roleAliasArn: __expectString(output.roleAliasArn),
+    roleArn: __expectString(output.roleArn),
   } as any;
 };
 
@@ -34014,23 +33799,23 @@ const deserializeAws_restJson1RoleAliases = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1S3Action = (output: any, context: __SerdeContext): S3Action => {
   return {
-    bucketName: output.bucketName !== undefined && output.bucketName !== null ? output.bucketName : undefined,
-    cannedAcl: output.cannedAcl !== undefined && output.cannedAcl !== null ? output.cannedAcl : undefined,
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
+    bucketName: __expectString(output.bucketName),
+    cannedAcl: __expectString(output.cannedAcl),
+    key: __expectString(output.key),
+    roleArn: __expectString(output.roleArn),
   } as any;
 };
 
 const deserializeAws_restJson1S3Destination = (output: any, context: __SerdeContext): S3Destination => {
   return {
-    bucket: output.bucket !== undefined && output.bucket !== null ? output.bucket : undefined,
-    prefix: output.prefix !== undefined && output.prefix !== null ? output.prefix : undefined,
+    bucket: __expectString(output.bucket),
+    prefix: __expectString(output.prefix),
   } as any;
 };
 
@@ -34041,22 +33826,22 @@ const deserializeAws_restJson1S3FileUrlList = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1S3Location = (output: any, context: __SerdeContext): S3Location => {
   return {
-    bucket: output.bucket !== undefined && output.bucket !== null ? output.bucket : undefined,
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    bucket: __expectString(output.bucket),
+    key: __expectString(output.key),
+    version: __expectString(output.version),
   } as any;
 };
 
 const deserializeAws_restJson1SalesforceAction = (output: any, context: __SerdeContext): SalesforceAction => {
   return {
-    token: output.token !== undefined && output.token !== null ? output.token : undefined,
-    url: output.url !== undefined && output.url !== null ? output.url : undefined,
+    token: __expectString(output.token),
+    url: __expectString(output.url),
   } as any;
 };
 
@@ -34065,17 +33850,11 @@ const deserializeAws_restJson1ScheduledAuditMetadata = (
   context: __SerdeContext
 ): ScheduledAuditMetadata => {
   return {
-    dayOfMonth: output.dayOfMonth !== undefined && output.dayOfMonth !== null ? output.dayOfMonth : undefined,
-    dayOfWeek: output.dayOfWeek !== undefined && output.dayOfWeek !== null ? output.dayOfWeek : undefined,
-    frequency: output.frequency !== undefined && output.frequency !== null ? output.frequency : undefined,
-    scheduledAuditArn:
-      output.scheduledAuditArn !== undefined && output.scheduledAuditArn !== null
-        ? output.scheduledAuditArn
-        : undefined,
-    scheduledAuditName:
-      output.scheduledAuditName !== undefined && output.scheduledAuditName !== null
-        ? output.scheduledAuditName
-        : undefined,
+    dayOfMonth: __expectString(output.dayOfMonth),
+    dayOfWeek: __expectString(output.dayOfWeek),
+    frequency: __expectString(output.frequency),
+    scheduledAuditArn: __expectString(output.scheduledAuditArn),
+    scheduledAuditName: __expectString(output.scheduledAuditName),
   } as any;
 };
 
@@ -34100,7 +33879,7 @@ const deserializeAws_restJson1SearchableAttributes = (output: any, context: __Se
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -34111,7 +33890,7 @@ const deserializeAws_restJson1SecurityGroupList = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -34120,8 +33899,8 @@ const deserializeAws_restJson1SecurityProfileIdentifier = (
   context: __SerdeContext
 ): SecurityProfileIdentifier => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    arn: __expectString(output.arn),
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -34141,7 +33920,7 @@ const deserializeAws_restJson1SecurityProfileIdentifiers = (
 
 const deserializeAws_restJson1SecurityProfileTarget = (output: any, context: __SerdeContext): SecurityProfileTarget => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
   } as any;
 };
 
@@ -34208,18 +33987,9 @@ const deserializeAws_restJson1ServerCertificateSummary = (
   context: __SerdeContext
 ): ServerCertificateSummary => {
   return {
-    serverCertificateArn:
-      output.serverCertificateArn !== undefined && output.serverCertificateArn !== null
-        ? output.serverCertificateArn
-        : undefined,
-    serverCertificateStatus:
-      output.serverCertificateStatus !== undefined && output.serverCertificateStatus !== null
-        ? output.serverCertificateStatus
-        : undefined,
-    serverCertificateStatusDetail:
-      output.serverCertificateStatusDetail !== undefined && output.serverCertificateStatusDetail !== null
-        ? output.serverCertificateStatusDetail
-        : undefined,
+    serverCertificateArn: __expectString(output.serverCertificateArn),
+    serverCertificateStatus: __expectString(output.serverCertificateStatus),
+    serverCertificateStatusDetail: __expectString(output.serverCertificateStatusDetail),
   } as any;
 };
 
@@ -34228,39 +33998,33 @@ const deserializeAws_restJson1SigningProfileParameter = (
   context: __SerdeContext
 ): SigningProfileParameter => {
   return {
-    certificateArn:
-      output.certificateArn !== undefined && output.certificateArn !== null ? output.certificateArn : undefined,
-    certificatePathOnDevice:
-      output.certificatePathOnDevice !== undefined && output.certificatePathOnDevice !== null
-        ? output.certificatePathOnDevice
-        : undefined,
-    platform: output.platform !== undefined && output.platform !== null ? output.platform : undefined,
+    certificateArn: __expectString(output.certificateArn),
+    certificatePathOnDevice: __expectString(output.certificatePathOnDevice),
+    platform: __expectString(output.platform),
   } as any;
 };
 
 const deserializeAws_restJson1SigV4Authorization = (output: any, context: __SerdeContext): SigV4Authorization => {
   return {
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
-    serviceName: output.serviceName !== undefined && output.serviceName !== null ? output.serviceName : undefined,
-    signingRegion:
-      output.signingRegion !== undefined && output.signingRegion !== null ? output.signingRegion : undefined,
+    roleArn: __expectString(output.roleArn),
+    serviceName: __expectString(output.serviceName),
+    signingRegion: __expectString(output.signingRegion),
   } as any;
 };
 
 const deserializeAws_restJson1SnsAction = (output: any, context: __SerdeContext): SnsAction => {
   return {
-    messageFormat:
-      output.messageFormat !== undefined && output.messageFormat !== null ? output.messageFormat : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
-    targetArn: output.targetArn !== undefined && output.targetArn !== null ? output.targetArn : undefined,
+    messageFormat: __expectString(output.messageFormat),
+    roleArn: __expectString(output.roleArn),
+    targetArn: __expectString(output.targetArn),
   } as any;
 };
 
 const deserializeAws_restJson1SqsAction = (output: any, context: __SerdeContext): SqsAction => {
   return {
-    queueUrl: output.queueUrl !== undefined && output.queueUrl !== null ? output.queueUrl : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
-    useBase64: output.useBase64 !== undefined && output.useBase64 !== null ? output.useBase64 : undefined,
+    queueUrl: __expectString(output.queueUrl),
+    roleArn: __expectString(output.roleArn),
+    useBase64: __expectBoolean(output.useBase64),
   } as any;
 };
 
@@ -34273,10 +34037,7 @@ const deserializeAws_restJson1StartSigningJobParameter = (
       output.destination !== undefined && output.destination !== null
         ? deserializeAws_restJson1Destination(output.destination, context)
         : undefined,
-    signingProfileName:
-      output.signingProfileName !== undefined && output.signingProfileName !== null
-        ? output.signingProfileName
-        : undefined,
+    signingProfileName: __expectString(output.signingProfileName),
     signingProfileParameter:
       output.signingProfileParameter !== undefined && output.signingProfileParameter !== null
         ? deserializeAws_restJson1SigningProfileParameter(output.signingProfileParameter, context)
@@ -34286,45 +34047,41 @@ const deserializeAws_restJson1StartSigningJobParameter = (
 
 const deserializeAws_restJson1StatisticalThreshold = (output: any, context: __SerdeContext): StatisticalThreshold => {
   return {
-    statistic: output.statistic !== undefined && output.statistic !== null ? output.statistic : undefined,
+    statistic: __expectString(output.statistic),
   } as any;
 };
 
 const deserializeAws_restJson1Statistics = (output: any, context: __SerdeContext): Statistics => {
   return {
-    average: output.average !== undefined && output.average !== null ? output.average : undefined,
-    count: output.count !== undefined && output.count !== null ? output.count : undefined,
-    maximum: output.maximum !== undefined && output.maximum !== null ? output.maximum : undefined,
-    minimum: output.minimum !== undefined && output.minimum !== null ? output.minimum : undefined,
-    stdDeviation: output.stdDeviation !== undefined && output.stdDeviation !== null ? output.stdDeviation : undefined,
-    sum: output.sum !== undefined && output.sum !== null ? output.sum : undefined,
-    sumOfSquares: output.sumOfSquares !== undefined && output.sumOfSquares !== null ? output.sumOfSquares : undefined,
-    variance: output.variance !== undefined && output.variance !== null ? output.variance : undefined,
+    average: __expectNumber(output.average),
+    count: __expectNumber(output.count),
+    maximum: __expectNumber(output.maximum),
+    minimum: __expectNumber(output.minimum),
+    stdDeviation: __expectNumber(output.stdDeviation),
+    sum: __expectNumber(output.sum),
+    sumOfSquares: __expectNumber(output.sumOfSquares),
+    variance: __expectNumber(output.variance),
   } as any;
 };
 
 const deserializeAws_restJson1StepFunctionsAction = (output: any, context: __SerdeContext): StepFunctionsAction => {
   return {
-    executionNamePrefix:
-      output.executionNamePrefix !== undefined && output.executionNamePrefix !== null
-        ? output.executionNamePrefix
-        : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
-    stateMachineName:
-      output.stateMachineName !== undefined && output.stateMachineName !== null ? output.stateMachineName : undefined,
+    executionNamePrefix: __expectString(output.executionNamePrefix),
+    roleArn: __expectString(output.roleArn),
+    stateMachineName: __expectString(output.stateMachineName),
   } as any;
 };
 
 const deserializeAws_restJson1_Stream = (output: any, context: __SerdeContext): _Stream => {
   return {
-    fileId: output.fileId !== undefined && output.fileId !== null ? output.fileId : undefined,
-    streamId: output.streamId !== undefined && output.streamId !== null ? output.streamId : undefined,
+    fileId: __expectNumber(output.fileId),
+    streamId: __expectString(output.streamId),
   } as any;
 };
 
 const deserializeAws_restJson1StreamFile = (output: any, context: __SerdeContext): StreamFile => {
   return {
-    fileId: output.fileId !== undefined && output.fileId !== null ? output.fileId : undefined,
+    fileId: __expectNumber(output.fileId),
     s3Location:
       output.s3Location !== undefined && output.s3Location !== null
         ? deserializeAws_restJson1S3Location(output.s3Location, context)
@@ -34349,7 +34106,7 @@ const deserializeAws_restJson1StreamInfo = (output: any, context: __SerdeContext
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    description: __expectString(output.description),
     files:
       output.files !== undefined && output.files !== null
         ? deserializeAws_restJson1StreamFiles(output.files, context)
@@ -34358,11 +34115,10 @@ const deserializeAws_restJson1StreamInfo = (output: any, context: __SerdeContext
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
         ? new Date(Math.round(output.lastUpdatedAt * 1000))
         : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
-    streamArn: output.streamArn !== undefined && output.streamArn !== null ? output.streamArn : undefined,
-    streamId: output.streamId !== undefined && output.streamId !== null ? output.streamId : undefined,
-    streamVersion:
-      output.streamVersion !== undefined && output.streamVersion !== null ? output.streamVersion : undefined,
+    roleArn: __expectString(output.roleArn),
+    streamArn: __expectString(output.streamArn),
+    streamId: __expectString(output.streamId),
+    streamVersion: __expectNumber(output.streamVersion),
   } as any;
 };
 
@@ -34379,11 +34135,10 @@ const deserializeAws_restJson1StreamsSummary = (output: any, context: __SerdeCon
 
 const deserializeAws_restJson1StreamSummary = (output: any, context: __SerdeContext): StreamSummary => {
   return {
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    streamArn: output.streamArn !== undefined && output.streamArn !== null ? output.streamArn : undefined,
-    streamId: output.streamId !== undefined && output.streamId !== null ? output.streamId : undefined,
-    streamVersion:
-      output.streamVersion !== undefined && output.streamVersion !== null ? output.streamVersion : undefined,
+    description: __expectString(output.description),
+    streamArn: __expectString(output.streamArn),
+    streamId: __expectString(output.streamId),
+    streamVersion: __expectNumber(output.streamVersion),
   } as any;
 };
 
@@ -34394,7 +34149,7 @@ const deserializeAws_restJson1StringList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -34405,7 +34160,7 @@ const deserializeAws_restJson1StringMap = (output: any, context: __SerdeContext)
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -34417,14 +34172,14 @@ const deserializeAws_restJson1SubnetIdList = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -34446,7 +34201,7 @@ const deserializeAws_restJson1TargetAuditCheckNames = (output: any, context: __S
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -34457,7 +34212,7 @@ const deserializeAws_restJson1Targets = (output: any, context: __SerdeContext): 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -34471,7 +34226,7 @@ const deserializeAws_restJson1TargetViolationIdsForDetectMitigationActions = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -34482,28 +34237,19 @@ const deserializeAws_restJson1TaskIdList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1TaskStatistics = (output: any, context: __SerdeContext): TaskStatistics => {
   return {
-    canceledChecks:
-      output.canceledChecks !== undefined && output.canceledChecks !== null ? output.canceledChecks : undefined,
-    compliantChecks:
-      output.compliantChecks !== undefined && output.compliantChecks !== null ? output.compliantChecks : undefined,
-    failedChecks: output.failedChecks !== undefined && output.failedChecks !== null ? output.failedChecks : undefined,
-    inProgressChecks:
-      output.inProgressChecks !== undefined && output.inProgressChecks !== null ? output.inProgressChecks : undefined,
-    nonCompliantChecks:
-      output.nonCompliantChecks !== undefined && output.nonCompliantChecks !== null
-        ? output.nonCompliantChecks
-        : undefined,
-    totalChecks: output.totalChecks !== undefined && output.totalChecks !== null ? output.totalChecks : undefined,
-    waitingForDataCollectionChecks:
-      output.waitingForDataCollectionChecks !== undefined && output.waitingForDataCollectionChecks !== null
-        ? output.waitingForDataCollectionChecks
-        : undefined,
+    canceledChecks: __expectNumber(output.canceledChecks),
+    compliantChecks: __expectNumber(output.compliantChecks),
+    failedChecks: __expectNumber(output.failedChecks),
+    inProgressChecks: __expectNumber(output.inProgressChecks),
+    nonCompliantChecks: __expectNumber(output.nonCompliantChecks),
+    totalChecks: __expectNumber(output.totalChecks),
+    waitingForDataCollectionChecks: __expectNumber(output.waitingForDataCollectionChecks),
   } as any;
 };
 
@@ -34512,26 +34258,11 @@ const deserializeAws_restJson1TaskStatisticsForAuditCheck = (
   context: __SerdeContext
 ): TaskStatisticsForAuditCheck => {
   return {
-    canceledFindingsCount:
-      output.canceledFindingsCount !== undefined && output.canceledFindingsCount !== null
-        ? output.canceledFindingsCount
-        : undefined,
-    failedFindingsCount:
-      output.failedFindingsCount !== undefined && output.failedFindingsCount !== null
-        ? output.failedFindingsCount
-        : undefined,
-    skippedFindingsCount:
-      output.skippedFindingsCount !== undefined && output.skippedFindingsCount !== null
-        ? output.skippedFindingsCount
-        : undefined,
-    succeededFindingsCount:
-      output.succeededFindingsCount !== undefined && output.succeededFindingsCount !== null
-        ? output.succeededFindingsCount
-        : undefined,
-    totalFindingsCount:
-      output.totalFindingsCount !== undefined && output.totalFindingsCount !== null
-        ? output.totalFindingsCount
-        : undefined,
+    canceledFindingsCount: __expectNumber(output.canceledFindingsCount),
+    failedFindingsCount: __expectNumber(output.failedFindingsCount),
+    skippedFindingsCount: __expectNumber(output.skippedFindingsCount),
+    succeededFindingsCount: __expectNumber(output.succeededFindingsCount),
+    totalFindingsCount: __expectNumber(output.totalFindingsCount),
   } as any;
 };
 
@@ -34541,11 +34272,10 @@ const deserializeAws_restJson1ThingAttribute = (output: any, context: __SerdeCon
       output.attributes !== undefined && output.attributes !== null
         ? deserializeAws_restJson1Attributes(output.attributes, context)
         : undefined,
-    thingArn: output.thingArn !== undefined && output.thingArn !== null ? output.thingArn : undefined,
-    thingName: output.thingName !== undefined && output.thingName !== null ? output.thingName : undefined,
-    thingTypeName:
-      output.thingTypeName !== undefined && output.thingTypeName !== null ? output.thingTypeName : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    thingArn: __expectString(output.thingArn),
+    thingName: __expectString(output.thingName),
+    thingTypeName: __expectString(output.thingTypeName),
+    version: __expectNumber(output.version),
   } as any;
 };
 
@@ -34562,8 +34292,8 @@ const deserializeAws_restJson1ThingAttributeList = (output: any, context: __Serd
 
 const deserializeAws_restJson1ThingConnectivity = (output: any, context: __SerdeContext): ThingConnectivity => {
   return {
-    connected: output.connected !== undefined && output.connected !== null ? output.connected : undefined,
-    timestamp: output.timestamp !== undefined && output.timestamp !== null ? output.timestamp : undefined,
+    connected: __expectBoolean(output.connected),
+    timestamp: __expectNumber(output.timestamp),
   } as any;
 };
 
@@ -34577,15 +34307,14 @@ const deserializeAws_restJson1ThingDocument = (output: any, context: __SerdeCont
       output.connectivity !== undefined && output.connectivity !== null
         ? deserializeAws_restJson1ThingConnectivity(output.connectivity, context)
         : undefined,
-    shadow: output.shadow !== undefined && output.shadow !== null ? output.shadow : undefined,
+    shadow: __expectString(output.shadow),
     thingGroupNames:
       output.thingGroupNames !== undefined && output.thingGroupNames !== null
         ? deserializeAws_restJson1ThingGroupNameList(output.thingGroupNames, context)
         : undefined,
-    thingId: output.thingId !== undefined && output.thingId !== null ? output.thingId : undefined,
-    thingName: output.thingName !== undefined && output.thingName !== null ? output.thingName : undefined,
-    thingTypeName:
-      output.thingTypeName !== undefined && output.thingTypeName !== null ? output.thingTypeName : undefined,
+    thingId: __expectString(output.thingId),
+    thingName: __expectString(output.thingName),
+    thingTypeName: __expectString(output.thingTypeName),
   } as any;
 };
 
@@ -34610,13 +34339,9 @@ const deserializeAws_restJson1ThingGroupDocument = (output: any, context: __Serd
       output.parentGroupNames !== undefined && output.parentGroupNames !== null
         ? deserializeAws_restJson1ThingGroupNameList(output.parentGroupNames, context)
         : undefined,
-    thingGroupDescription:
-      output.thingGroupDescription !== undefined && output.thingGroupDescription !== null
-        ? output.thingGroupDescription
-        : undefined,
-    thingGroupId: output.thingGroupId !== undefined && output.thingGroupId !== null ? output.thingGroupId : undefined,
-    thingGroupName:
-      output.thingGroupName !== undefined && output.thingGroupName !== null ? output.thingGroupName : undefined,
+    thingGroupDescription: __expectString(output.thingGroupDescription),
+    thingGroupId: __expectString(output.thingGroupId),
+    thingGroupName: __expectString(output.thingGroupName),
   } as any;
 };
 
@@ -34644,10 +34369,7 @@ const deserializeAws_restJson1ThingGroupIndexingConfiguration = (
       output.managedFields !== undefined && output.managedFields !== null
         ? deserializeAws_restJson1Fields(output.managedFields, context)
         : undefined,
-    thingGroupIndexingMode:
-      output.thingGroupIndexingMode !== undefined && output.thingGroupIndexingMode !== null
-        ? output.thingGroupIndexingMode
-        : undefined,
+    thingGroupIndexingMode: __expectString(output.thingGroupIndexingMode),
   } as any;
 };
 
@@ -34657,8 +34379,7 @@ const deserializeAws_restJson1ThingGroupMetadata = (output: any, context: __Serd
       output.creationDate !== undefined && output.creationDate !== null
         ? new Date(Math.round(output.creationDate * 1000))
         : undefined,
-    parentGroupName:
-      output.parentGroupName !== undefined && output.parentGroupName !== null ? output.parentGroupName : undefined,
+    parentGroupName: __expectString(output.parentGroupName),
     rootToParentThingGroups:
       output.rootToParentThingGroups !== undefined && output.rootToParentThingGroups !== null
         ? deserializeAws_restJson1ThingGroupNameAndArnList(output.rootToParentThingGroups, context)
@@ -34684,7 +34405,7 @@ const deserializeAws_restJson1ThingGroupNameList = (output: any, context: __Serd
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -34695,7 +34416,7 @@ const deserializeAws_restJson1ThingGroupNames = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -34705,10 +34426,7 @@ const deserializeAws_restJson1ThingGroupProperties = (output: any, context: __Se
       output.attributePayload !== undefined && output.attributePayload !== null
         ? deserializeAws_restJson1AttributePayload(output.attributePayload, context)
         : undefined,
-    thingGroupDescription:
-      output.thingGroupDescription !== undefined && output.thingGroupDescription !== null
-        ? output.thingGroupDescription
-        : undefined,
+    thingGroupDescription: __expectString(output.thingGroupDescription),
   } as any;
 };
 
@@ -34725,14 +34443,8 @@ const deserializeAws_restJson1ThingIndexingConfiguration = (
       output.managedFields !== undefined && output.managedFields !== null
         ? deserializeAws_restJson1Fields(output.managedFields, context)
         : undefined,
-    thingConnectivityIndexingMode:
-      output.thingConnectivityIndexingMode !== undefined && output.thingConnectivityIndexingMode !== null
-        ? output.thingConnectivityIndexingMode
-        : undefined,
-    thingIndexingMode:
-      output.thingIndexingMode !== undefined && output.thingIndexingMode !== null
-        ? output.thingIndexingMode
-        : undefined,
+    thingConnectivityIndexingMode: __expectString(output.thingConnectivityIndexingMode),
+    thingIndexingMode: __expectString(output.thingIndexingMode),
   } as any;
 };
 
@@ -34743,19 +34455,18 @@ const deserializeAws_restJson1ThingNameList = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1ThingTypeDefinition = (output: any, context: __SerdeContext): ThingTypeDefinition => {
   return {
-    thingTypeArn: output.thingTypeArn !== undefined && output.thingTypeArn !== null ? output.thingTypeArn : undefined,
+    thingTypeArn: __expectString(output.thingTypeArn),
     thingTypeMetadata:
       output.thingTypeMetadata !== undefined && output.thingTypeMetadata !== null
         ? deserializeAws_restJson1ThingTypeMetadata(output.thingTypeMetadata, context)
         : undefined,
-    thingTypeName:
-      output.thingTypeName !== undefined && output.thingTypeName !== null ? output.thingTypeName : undefined,
+    thingTypeName: __expectString(output.thingTypeName),
     thingTypeProperties:
       output.thingTypeProperties !== undefined && output.thingTypeProperties !== null
         ? deserializeAws_restJson1ThingTypeProperties(output.thingTypeProperties, context)
@@ -34780,7 +34491,7 @@ const deserializeAws_restJson1ThingTypeMetadata = (output: any, context: __Serde
       output.creationDate !== undefined && output.creationDate !== null
         ? new Date(Math.round(output.creationDate * 1000))
         : undefined,
-    deprecated: output.deprecated !== undefined && output.deprecated !== null ? output.deprecated : undefined,
+    deprecated: __expectBoolean(output.deprecated),
     deprecationDate:
       output.deprecationDate !== undefined && output.deprecationDate !== null
         ? new Date(Math.round(output.deprecationDate * 1000))
@@ -34794,31 +34505,25 @@ const deserializeAws_restJson1ThingTypeProperties = (output: any, context: __Ser
       output.searchableAttributes !== undefined && output.searchableAttributes !== null
         ? deserializeAws_restJson1SearchableAttributes(output.searchableAttributes, context)
         : undefined,
-    thingTypeDescription:
-      output.thingTypeDescription !== undefined && output.thingTypeDescription !== null
-        ? output.thingTypeDescription
-        : undefined,
+    thingTypeDescription: __expectString(output.thingTypeDescription),
   } as any;
 };
 
 const deserializeAws_restJson1TimeoutConfig = (output: any, context: __SerdeContext): TimeoutConfig => {
   return {
-    inProgressTimeoutInMinutes:
-      output.inProgressTimeoutInMinutes !== undefined && output.inProgressTimeoutInMinutes !== null
-        ? output.inProgressTimeoutInMinutes
-        : undefined,
+    inProgressTimeoutInMinutes: __expectNumber(output.inProgressTimeoutInMinutes),
   } as any;
 };
 
 const deserializeAws_restJson1TimestreamAction = (output: any, context: __SerdeContext): TimestreamAction => {
   return {
-    databaseName: output.databaseName !== undefined && output.databaseName !== null ? output.databaseName : undefined,
+    databaseName: __expectString(output.databaseName),
     dimensions:
       output.dimensions !== undefined && output.dimensions !== null
         ? deserializeAws_restJson1TimestreamDimensionList(output.dimensions, context)
         : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
-    tableName: output.tableName !== undefined && output.tableName !== null ? output.tableName : undefined,
+    roleArn: __expectString(output.roleArn),
+    tableName: __expectString(output.tableName),
     timestamp:
       output.timestamp !== undefined && output.timestamp !== null
         ? deserializeAws_restJson1TimestreamTimestamp(output.timestamp, context)
@@ -34828,8 +34533,8 @@ const deserializeAws_restJson1TimestreamAction = (output: any, context: __SerdeC
 
 const deserializeAws_restJson1TimestreamDimension = (output: any, context: __SerdeContext): TimestreamDimension => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    name: __expectString(output.name),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -34849,8 +34554,8 @@ const deserializeAws_restJson1TimestreamDimensionList = (
 
 const deserializeAws_restJson1TimestreamTimestamp = (output: any, context: __SerdeContext): TimestreamTimestamp => {
   return {
-    unit: output.unit !== undefined && output.unit !== null ? output.unit : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    unit: __expectString(output.unit),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -34860,26 +34565,25 @@ const deserializeAws_restJson1TopicRule = (output: any, context: __SerdeContext)
       output.actions !== undefined && output.actions !== null
         ? deserializeAws_restJson1ActionList(output.actions, context)
         : undefined,
-    awsIotSqlVersion:
-      output.awsIotSqlVersion !== undefined && output.awsIotSqlVersion !== null ? output.awsIotSqlVersion : undefined,
+    awsIotSqlVersion: __expectString(output.awsIotSqlVersion),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    description: __expectString(output.description),
     errorAction:
       output.errorAction !== undefined && output.errorAction !== null
         ? deserializeAws_restJson1Action(output.errorAction, context)
         : undefined,
-    ruleDisabled: output.ruleDisabled !== undefined && output.ruleDisabled !== null ? output.ruleDisabled : undefined,
-    ruleName: output.ruleName !== undefined && output.ruleName !== null ? output.ruleName : undefined,
-    sql: output.sql !== undefined && output.sql !== null ? output.sql : undefined,
+    ruleDisabled: __expectBoolean(output.ruleDisabled),
+    ruleName: __expectString(output.ruleName),
+    sql: __expectString(output.sql),
   } as any;
 };
 
 const deserializeAws_restJson1TopicRuleDestination = (output: any, context: __SerdeContext): TopicRuleDestination => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
@@ -34892,8 +34596,8 @@ const deserializeAws_restJson1TopicRuleDestination = (output: any, context: __Se
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
         ? new Date(Math.round(output.lastUpdatedAt * 1000))
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    statusReason: output.statusReason !== undefined && output.statusReason !== null ? output.statusReason : undefined,
+    status: __expectString(output.status),
+    statusReason: __expectString(output.statusReason),
     vpcProperties:
       output.vpcProperties !== undefined && output.vpcProperties !== null
         ? deserializeAws_restJson1VpcDestinationProperties(output.vpcProperties, context)
@@ -34920,7 +34624,7 @@ const deserializeAws_restJson1TopicRuleDestinationSummary = (
   context: __SerdeContext
 ): TopicRuleDestinationSummary => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
@@ -34933,8 +34637,8 @@ const deserializeAws_restJson1TopicRuleDestinationSummary = (
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
         ? new Date(Math.round(output.lastUpdatedAt * 1000))
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    statusReason: output.statusReason !== undefined && output.statusReason !== null ? output.statusReason : undefined,
+    status: __expectString(output.status),
+    statusReason: __expectString(output.statusReason),
     vpcDestinationSummary:
       output.vpcDestinationSummary !== undefined && output.vpcDestinationSummary !== null
         ? deserializeAws_restJson1VpcDestinationSummary(output.vpcDestinationSummary, context)
@@ -34959,10 +34663,10 @@ const deserializeAws_restJson1TopicRuleListItem = (output: any, context: __Serde
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    ruleArn: output.ruleArn !== undefined && output.ruleArn !== null ? output.ruleArn : undefined,
-    ruleDisabled: output.ruleDisabled !== undefined && output.ruleDisabled !== null ? output.ruleDisabled : undefined,
-    ruleName: output.ruleName !== undefined && output.ruleName !== null ? output.ruleName : undefined,
-    topicPattern: output.topicPattern !== undefined && output.topicPattern !== null ? output.topicPattern : undefined,
+    ruleArn: __expectString(output.ruleArn),
+    ruleDisabled: __expectBoolean(output.ruleDisabled),
+    ruleName: __expectString(output.ruleName),
+    topicPattern: __expectString(output.topicPattern),
   } as any;
 };
 
@@ -34976,13 +34680,12 @@ const deserializeAws_restJson1TransferData = (output: any, context: __SerdeConte
       output.rejectDate !== undefined && output.rejectDate !== null
         ? new Date(Math.round(output.rejectDate * 1000))
         : undefined,
-    rejectReason: output.rejectReason !== undefined && output.rejectReason !== null ? output.rejectReason : undefined,
+    rejectReason: __expectString(output.rejectReason),
     transferDate:
       output.transferDate !== undefined && output.transferDate !== null
         ? new Date(Math.round(output.transferDate * 1000))
         : undefined,
-    transferMessage:
-      output.transferMessage !== undefined && output.transferMessage !== null ? output.transferMessage : undefined,
+    transferMessage: __expectString(output.transferMessage),
   } as any;
 };
 
@@ -34991,7 +34694,7 @@ const deserializeAws_restJson1UpdateCACertificateParams = (
   context: __SerdeContext
 ): UpdateCACertificateParams => {
   return {
-    action: output.action !== undefined && output.action !== null ? output.action : undefined,
+    action: __expectString(output.action),
   } as any;
 };
 
@@ -35000,13 +34703,13 @@ const deserializeAws_restJson1UpdateDeviceCertificateParams = (
   context: __SerdeContext
 ): UpdateDeviceCertificateParams => {
   return {
-    action: output.action !== undefined && output.action !== null ? output.action : undefined,
+    action: __expectString(output.action),
   } as any;
 };
 
 const deserializeAws_restJson1ValidationError = (output: any, context: __SerdeContext): ValidationError => {
   return {
-    errorMessage: output.errorMessage !== undefined && output.errorMessage !== null ? output.errorMessage : undefined,
+    errorMessage: __expectString(output.errorMessage),
   } as any;
 };
 
@@ -35031,11 +34734,8 @@ const deserializeAws_restJson1ViolationEvent = (output: any, context: __SerdeCon
       output.metricValue !== undefined && output.metricValue !== null
         ? deserializeAws_restJson1MetricValue(output.metricValue, context)
         : undefined,
-    securityProfileName:
-      output.securityProfileName !== undefined && output.securityProfileName !== null
-        ? output.securityProfileName
-        : undefined,
-    thingName: output.thingName !== undefined && output.thingName !== null ? output.thingName : undefined,
+    securityProfileName: __expectString(output.securityProfileName),
+    thingName: __expectString(output.thingName),
     violationEventAdditionalInfo:
       output.violationEventAdditionalInfo !== undefined && output.violationEventAdditionalInfo !== null
         ? deserializeAws_restJson1ViolationEventAdditionalInfo(output.violationEventAdditionalInfo, context)
@@ -35044,11 +34744,8 @@ const deserializeAws_restJson1ViolationEvent = (output: any, context: __SerdeCon
       output.violationEventTime !== undefined && output.violationEventTime !== null
         ? new Date(Math.round(output.violationEventTime * 1000))
         : undefined,
-    violationEventType:
-      output.violationEventType !== undefined && output.violationEventType !== null
-        ? output.violationEventType
-        : undefined,
-    violationId: output.violationId !== undefined && output.violationId !== null ? output.violationId : undefined,
+    violationEventType: __expectString(output.violationEventType),
+    violationId: __expectString(output.violationId),
   } as any;
 };
 
@@ -35057,8 +34754,7 @@ const deserializeAws_restJson1ViolationEventAdditionalInfo = (
   context: __SerdeContext
 ): ViolationEventAdditionalInfo => {
   return {
-    confidenceLevel:
-      output.confidenceLevel !== undefined && output.confidenceLevel !== null ? output.confidenceLevel : undefined,
+    confidenceLevel: __expectString(output.confidenceLevel),
   } as any;
 };
 
@@ -35092,7 +34788,7 @@ const deserializeAws_restJson1VpcDestinationProperties = (
   context: __SerdeContext
 ): VpcDestinationProperties => {
   return {
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
+    roleArn: __expectString(output.roleArn),
     securityGroups:
       output.securityGroups !== undefined && output.securityGroups !== null
         ? deserializeAws_restJson1SecurityGroupList(output.securityGroups, context)
@@ -35101,13 +34797,13 @@ const deserializeAws_restJson1VpcDestinationProperties = (
       output.subnetIds !== undefined && output.subnetIds !== null
         ? deserializeAws_restJson1SubnetIdList(output.subnetIds, context)
         : undefined,
-    vpcId: output.vpcId !== undefined && output.vpcId !== null ? output.vpcId : undefined,
+    vpcId: __expectString(output.vpcId),
   } as any;
 };
 
 const deserializeAws_restJson1VpcDestinationSummary = (output: any, context: __SerdeContext): VpcDestinationSummary => {
   return {
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
+    roleArn: __expectString(output.roleArn),
     securityGroups:
       output.securityGroups !== undefined && output.securityGroups !== null
         ? deserializeAws_restJson1SecurityGroupList(output.securityGroups, context)
@@ -35116,7 +34812,7 @@ const deserializeAws_restJson1VpcDestinationSummary = (output: any, context: __S
       output.subnetIds !== undefined && output.subnetIds !== null
         ? deserializeAws_restJson1SubnetIdList(output.subnetIds, context)
         : undefined,
-    vpcId: output.vpcId !== undefined && output.vpcId !== null ? output.vpcId : undefined,
+    vpcId: __expectString(output.vpcId),
   } as any;
 };
 

--- a/clients/client-iotanalytics/protocols/Aws_restJson1.ts
+++ b/clients/client-iotanalytics/protocols/Aws_restJson1.ts
@@ -143,6 +143,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -1419,10 +1422,10 @@ export const deserializeAws_restJson1CreateChannelCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.channelArn !== undefined && data.channelArn !== null) {
-    contents.channelArn = data.channelArn;
+    contents.channelArn = __expectString(data.channelArn);
   }
   if (data.channelName !== undefined && data.channelName !== null) {
-    contents.channelName = data.channelName;
+    contents.channelName = __expectString(data.channelName);
   }
   if (data.retentionPeriod !== undefined && data.retentionPeriod !== null) {
     contents.retentionPeriod = deserializeAws_restJson1RetentionPeriod(data.retentionPeriod, context);
@@ -1522,10 +1525,10 @@ export const deserializeAws_restJson1CreateDatasetCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.datasetArn !== undefined && data.datasetArn !== null) {
-    contents.datasetArn = data.datasetArn;
+    contents.datasetArn = __expectString(data.datasetArn);
   }
   if (data.datasetName !== undefined && data.datasetName !== null) {
-    contents.datasetName = data.datasetName;
+    contents.datasetName = __expectString(data.datasetName);
   }
   if (data.retentionPeriod !== undefined && data.retentionPeriod !== null) {
     contents.retentionPeriod = deserializeAws_restJson1RetentionPeriod(data.retentionPeriod, context);
@@ -1623,7 +1626,7 @@ export const deserializeAws_restJson1CreateDatasetContentCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.versionId !== undefined && data.versionId !== null) {
-    contents.versionId = data.versionId;
+    contents.versionId = __expectString(data.versionId);
   }
   return Promise.resolve(contents);
 };
@@ -1712,10 +1715,10 @@ export const deserializeAws_restJson1CreateDatastoreCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.datastoreArn !== undefined && data.datastoreArn !== null) {
-    contents.datastoreArn = data.datastoreArn;
+    contents.datastoreArn = __expectString(data.datastoreArn);
   }
   if (data.datastoreName !== undefined && data.datastoreName !== null) {
-    contents.datastoreName = data.datastoreName;
+    contents.datastoreName = __expectString(data.datastoreName);
   }
   if (data.retentionPeriod !== undefined && data.retentionPeriod !== null) {
     contents.retentionPeriod = deserializeAws_restJson1RetentionPeriod(data.retentionPeriod, context);
@@ -1814,10 +1817,10 @@ export const deserializeAws_restJson1CreatePipelineCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.pipelineArn !== undefined && data.pipelineArn !== null) {
-    contents.pipelineArn = data.pipelineArn;
+    contents.pipelineArn = __expectString(data.pipelineArn);
   }
   if (data.pipelineName !== undefined && data.pipelineName !== null) {
-    contents.pipelineName = data.pipelineName;
+    contents.pipelineName = __expectString(data.pipelineName);
   }
   return Promise.resolve(contents);
 };
@@ -2869,7 +2872,7 @@ export const deserializeAws_restJson1ListChannelsCommand = async (
     contents.channelSummaries = deserializeAws_restJson1ChannelSummaries(data.channelSummaries, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2955,7 +2958,7 @@ export const deserializeAws_restJson1ListDatasetContentsCommand = async (
     );
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3046,7 +3049,7 @@ export const deserializeAws_restJson1ListDatasetsCommand = async (
     contents.datasetSummaries = deserializeAws_restJson1DatasetSummaries(data.datasetSummaries, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3129,7 +3132,7 @@ export const deserializeAws_restJson1ListDatastoresCommand = async (
     contents.datastoreSummaries = deserializeAws_restJson1DatastoreSummaries(data.datastoreSummaries, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3209,7 +3212,7 @@ export const deserializeAws_restJson1ListPipelinesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.pipelineSummaries !== undefined && data.pipelineSummaries !== null) {
     contents.pipelineSummaries = deserializeAws_restJson1PipelineSummaries(data.pipelineSummaries, context);
@@ -3462,7 +3465,7 @@ export const deserializeAws_restJson1RunPipelineActivityCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.logResult !== undefined && data.logResult !== null) {
-    contents.logResult = data.logResult;
+    contents.logResult = __expectString(data.logResult);
   }
   if (data.payloads !== undefined && data.payloads !== null) {
     contents.payloads = deserializeAws_restJson1MessagePayloads(data.payloads, context);
@@ -3631,7 +3634,7 @@ export const deserializeAws_restJson1StartPipelineReprocessingCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.reprocessingId !== undefined && data.reprocessingId !== null) {
-    contents.reprocessingId = data.reprocessingId;
+    contents.reprocessingId = __expectString(data.reprocessingId);
   }
   return Promise.resolve(contents);
 };
@@ -4247,7 +4250,7 @@ const deserializeAws_restJson1InternalFailureExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -4264,7 +4267,7 @@ const deserializeAws_restJson1InvalidRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -4281,7 +4284,7 @@ const deserializeAws_restJson1LimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -4300,13 +4303,13 @@ const deserializeAws_restJson1ResourceAlreadyExistsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.resourceArn !== undefined && data.resourceArn !== null) {
-    contents.resourceArn = data.resourceArn;
+    contents.resourceArn = __expectString(data.resourceArn);
   }
   if (data.resourceId !== undefined && data.resourceId !== null) {
-    contents.resourceId = data.resourceId;
+    contents.resourceId = __expectString(data.resourceId);
   }
   return contents;
 };
@@ -4323,7 +4326,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -4340,7 +4343,7 @@ const deserializeAws_restJson1ServiceUnavailableExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -4357,7 +4360,7 @@ const deserializeAws_restJson1ThrottlingExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -5074,8 +5077,8 @@ const deserializeAws_restJson1AddAttributesActivity = (output: any, context: __S
       output.attributes !== undefined && output.attributes !== null
         ? deserializeAws_restJson1AttributeNameMapping(output.attributes, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    next: output.next !== undefined && output.next !== null ? output.next : undefined,
+    name: __expectString(output.name),
+    next: __expectString(output.next),
   } as any;
 };
 
@@ -5089,7 +5092,7 @@ const deserializeAws_restJson1AttributeNameMapping = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -5101,7 +5104,7 @@ const deserializeAws_restJson1AttributeNames = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -5124,15 +5127,15 @@ const deserializeAws_restJson1BatchPutMessageErrorEntry = (
   context: __SerdeContext
 ): BatchPutMessageErrorEntry => {
   return {
-    errorCode: output.errorCode !== undefined && output.errorCode !== null ? output.errorCode : undefined,
-    errorMessage: output.errorMessage !== undefined && output.errorMessage !== null ? output.errorMessage : undefined,
-    messageId: output.messageId !== undefined && output.messageId !== null ? output.messageId : undefined,
+    errorCode: __expectString(output.errorCode),
+    errorMessage: __expectString(output.errorMessage),
+    messageId: __expectString(output.messageId),
   } as any;
 };
 
 const deserializeAws_restJson1Channel = (output: any, context: __SerdeContext): Channel => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
         ? new Date(Math.round(output.creationTime * 1000))
@@ -5145,12 +5148,12 @@ const deserializeAws_restJson1Channel = (output: any, context: __SerdeContext): 
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
         ? new Date(Math.round(output.lastUpdateTime * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
     retentionPeriod:
       output.retentionPeriod !== undefined && output.retentionPeriod !== null
         ? deserializeAws_restJson1RetentionPeriod(output.retentionPeriod, context)
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
     storage:
       output.storage !== undefined && output.storage !== null
         ? deserializeAws_restJson1ChannelStorage(output.storage, context)
@@ -5160,9 +5163,9 @@ const deserializeAws_restJson1Channel = (output: any, context: __SerdeContext): 
 
 const deserializeAws_restJson1ChannelActivity = (output: any, context: __SerdeContext): ChannelActivity => {
   return {
-    channelName: output.channelName !== undefined && output.channelName !== null ? output.channelName : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    next: output.next !== undefined && output.next !== null ? output.next : undefined,
+    channelName: __expectString(output.channelName),
+    name: __expectString(output.name),
+    next: __expectString(output.next),
   } as any;
 };
 
@@ -5214,7 +5217,7 @@ const deserializeAws_restJson1ChannelSummaries = (output: any, context: __SerdeC
 
 const deserializeAws_restJson1ChannelSummary = (output: any, context: __SerdeContext): ChannelSummary => {
   return {
-    channelName: output.channelName !== undefined && output.channelName !== null ? output.channelName : undefined,
+    channelName: __expectString(output.channelName),
     channelStorage:
       output.channelStorage !== undefined && output.channelStorage !== null
         ? deserializeAws_restJson1ChannelStorageSummary(output.channelStorage, context)
@@ -5231,14 +5234,14 @@ const deserializeAws_restJson1ChannelSummary = (output: any, context: __SerdeCon
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
         ? new Date(Math.round(output.lastUpdateTime * 1000))
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
   } as any;
 };
 
 const deserializeAws_restJson1Column = (output: any, context: __SerdeContext): Column => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    name: __expectString(output.name),
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -5258,9 +5261,8 @@ const deserializeAws_restJson1ContainerDatasetAction = (
   context: __SerdeContext
 ): ContainerDatasetAction => {
   return {
-    executionRoleArn:
-      output.executionRoleArn !== undefined && output.executionRoleArn !== null ? output.executionRoleArn : undefined,
-    image: output.image !== undefined && output.image !== null ? output.image : undefined,
+    executionRoleArn: __expectString(output.executionRoleArn),
+    image: __expectString(output.image),
     resourceConfiguration:
       output.resourceConfiguration !== undefined && output.resourceConfiguration !== null
         ? deserializeAws_restJson1ResourceConfiguration(output.resourceConfiguration, context)
@@ -5277,9 +5279,9 @@ const deserializeAws_restJson1CustomerManagedChannelS3Storage = (
   context: __SerdeContext
 ): CustomerManagedChannelS3Storage => {
   return {
-    bucket: output.bucket !== undefined && output.bucket !== null ? output.bucket : undefined,
-    keyPrefix: output.keyPrefix !== undefined && output.keyPrefix !== null ? output.keyPrefix : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
+    bucket: __expectString(output.bucket),
+    keyPrefix: __expectString(output.keyPrefix),
+    roleArn: __expectString(output.roleArn),
   } as any;
 };
 
@@ -5288,9 +5290,9 @@ const deserializeAws_restJson1CustomerManagedChannelS3StorageSummary = (
   context: __SerdeContext
 ): CustomerManagedChannelS3StorageSummary => {
   return {
-    bucket: output.bucket !== undefined && output.bucket !== null ? output.bucket : undefined,
-    keyPrefix: output.keyPrefix !== undefined && output.keyPrefix !== null ? output.keyPrefix : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
+    bucket: __expectString(output.bucket),
+    keyPrefix: __expectString(output.keyPrefix),
+    roleArn: __expectString(output.roleArn),
   } as any;
 };
 
@@ -5299,9 +5301,9 @@ const deserializeAws_restJson1CustomerManagedDatastoreS3Storage = (
   context: __SerdeContext
 ): CustomerManagedDatastoreS3Storage => {
   return {
-    bucket: output.bucket !== undefined && output.bucket !== null ? output.bucket : undefined,
-    keyPrefix: output.keyPrefix !== undefined && output.keyPrefix !== null ? output.keyPrefix : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
+    bucket: __expectString(output.bucket),
+    keyPrefix: __expectString(output.keyPrefix),
+    roleArn: __expectString(output.roleArn),
   } as any;
 };
 
@@ -5310,9 +5312,9 @@ const deserializeAws_restJson1CustomerManagedDatastoreS3StorageSummary = (
   context: __SerdeContext
 ): CustomerManagedDatastoreS3StorageSummary => {
   return {
-    bucket: output.bucket !== undefined && output.bucket !== null ? output.bucket : undefined,
-    keyPrefix: output.keyPrefix !== undefined && output.keyPrefix !== null ? output.keyPrefix : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
+    bucket: __expectString(output.bucket),
+    keyPrefix: __expectString(output.keyPrefix),
+    roleArn: __expectString(output.roleArn),
   } as any;
 };
 
@@ -5322,7 +5324,7 @@ const deserializeAws_restJson1Dataset = (output: any, context: __SerdeContext): 
       output.actions !== undefined && output.actions !== null
         ? deserializeAws_restJson1DatasetActions(output.actions, context)
         : undefined,
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     contentDeliveryRules:
       output.contentDeliveryRules !== undefined && output.contentDeliveryRules !== null
         ? deserializeAws_restJson1DatasetContentDeliveryRules(output.contentDeliveryRules, context)
@@ -5339,12 +5341,12 @@ const deserializeAws_restJson1Dataset = (output: any, context: __SerdeContext): 
       output.lateDataRules !== undefined && output.lateDataRules !== null
         ? deserializeAws_restJson1LateDataRules(output.lateDataRules, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
     retentionPeriod:
       output.retentionPeriod !== undefined && output.retentionPeriod !== null
         ? deserializeAws_restJson1RetentionPeriod(output.retentionPeriod, context)
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
     triggers:
       output.triggers !== undefined && output.triggers !== null
         ? deserializeAws_restJson1DatasetTriggers(output.triggers, context)
@@ -5358,7 +5360,7 @@ const deserializeAws_restJson1Dataset = (output: any, context: __SerdeContext): 
 
 const deserializeAws_restJson1DatasetAction = (output: any, context: __SerdeContext): DatasetAction => {
   return {
-    actionName: output.actionName !== undefined && output.actionName !== null ? output.actionName : undefined,
+    actionName: __expectString(output.actionName),
     containerAction:
       output.containerAction !== undefined && output.containerAction !== null
         ? deserializeAws_restJson1ContainerDatasetAction(output.containerAction, context)
@@ -5397,8 +5399,8 @@ const deserializeAws_restJson1DatasetActionSummaries = (
 
 const deserializeAws_restJson1DatasetActionSummary = (output: any, context: __SerdeContext): DatasetActionSummary => {
   return {
-    actionName: output.actionName !== undefined && output.actionName !== null ? output.actionName : undefined,
-    actionType: output.actionType !== undefined && output.actionType !== null ? output.actionType : undefined,
+    actionName: __expectString(output.actionName),
+    actionType: __expectString(output.actionType),
   } as any;
 };
 
@@ -5427,7 +5429,7 @@ const deserializeAws_restJson1DatasetContentDeliveryRule = (
       output.destination !== undefined && output.destination !== null
         ? deserializeAws_restJson1DatasetContentDeliveryDestination(output.destination, context)
         : undefined,
-    entryName: output.entryName !== undefined && output.entryName !== null ? output.entryName : undefined,
+    entryName: __expectString(output.entryName),
   } as any;
 };
 
@@ -5447,8 +5449,8 @@ const deserializeAws_restJson1DatasetContentDeliveryRules = (
 
 const deserializeAws_restJson1DatasetContentStatus = (output: any, context: __SerdeContext): DatasetContentStatus => {
   return {
-    reason: output.reason !== undefined && output.reason !== null ? output.reason : undefined,
-    state: output.state !== undefined && output.state !== null ? output.state : undefined,
+    reason: __expectString(output.reason),
+    state: __expectString(output.state),
   } as any;
 };
 
@@ -5484,7 +5486,7 @@ const deserializeAws_restJson1DatasetContentSummary = (output: any, context: __S
       output.status !== undefined && output.status !== null
         ? deserializeAws_restJson1DatasetContentStatus(output.status, context)
         : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    version: __expectString(output.version),
   } as any;
 };
 
@@ -5493,7 +5495,7 @@ const deserializeAws_restJson1DatasetContentVersionValue = (
   context: __SerdeContext
 ): DatasetContentVersionValue => {
   return {
-    datasetName: output.datasetName !== undefined && output.datasetName !== null ? output.datasetName : undefined,
+    datasetName: __expectString(output.datasetName),
   } as any;
 };
 
@@ -5510,8 +5512,8 @@ const deserializeAws_restJson1DatasetEntries = (output: any, context: __SerdeCon
 
 const deserializeAws_restJson1DatasetEntry = (output: any, context: __SerdeContext): DatasetEntry => {
   return {
-    dataURI: output.dataURI !== undefined && output.dataURI !== null ? output.dataURI : undefined,
-    entryName: output.entryName !== undefined && output.entryName !== null ? output.entryName : undefined,
+    dataURI: __expectString(output.dataURI),
+    entryName: __expectString(output.entryName),
   } as any;
 };
 
@@ -5536,12 +5538,12 @@ const deserializeAws_restJson1DatasetSummary = (output: any, context: __SerdeCon
       output.creationTime !== undefined && output.creationTime !== null
         ? new Date(Math.round(output.creationTime * 1000))
         : undefined,
-    datasetName: output.datasetName !== undefined && output.datasetName !== null ? output.datasetName : undefined,
+    datasetName: __expectString(output.datasetName),
     lastUpdateTime:
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
         ? new Date(Math.round(output.lastUpdateTime * 1000))
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
     triggers:
       output.triggers !== undefined && output.triggers !== null
         ? deserializeAws_restJson1DatasetTriggers(output.triggers, context)
@@ -5575,7 +5577,7 @@ const deserializeAws_restJson1DatasetTriggers = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1Datastore = (output: any, context: __SerdeContext): Datastore => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
         ? new Date(Math.round(output.creationTime * 1000))
@@ -5596,12 +5598,12 @@ const deserializeAws_restJson1Datastore = (output: any, context: __SerdeContext)
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
         ? new Date(Math.round(output.lastUpdateTime * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
     retentionPeriod:
       output.retentionPeriod !== undefined && output.retentionPeriod !== null
         ? deserializeAws_restJson1RetentionPeriod(output.retentionPeriod, context)
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
     storage:
       output.storage !== undefined && output.storage !== null
         ? deserializeAws_restJson1DatastoreStorage(output.storage, context)
@@ -5611,9 +5613,8 @@ const deserializeAws_restJson1Datastore = (output: any, context: __SerdeContext)
 
 const deserializeAws_restJson1DatastoreActivity = (output: any, context: __SerdeContext): DatastoreActivity => {
   return {
-    datastoreName:
-      output.datastoreName !== undefined && output.datastoreName !== null ? output.datastoreName : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    datastoreName: __expectString(output.datastoreName),
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -5695,8 +5696,7 @@ const deserializeAws_restJson1DatastoreSummary = (output: any, context: __SerdeC
       output.creationTime !== undefined && output.creationTime !== null
         ? new Date(Math.round(output.creationTime * 1000))
         : undefined,
-    datastoreName:
-      output.datastoreName !== undefined && output.datastoreName !== null ? output.datastoreName : undefined,
+    datastoreName: __expectString(output.datastoreName),
     datastorePartitions:
       output.datastorePartitions !== undefined && output.datastorePartitions !== null
         ? deserializeAws_restJson1DatastorePartitions(output.datastorePartitions, context)
@@ -5705,8 +5705,7 @@ const deserializeAws_restJson1DatastoreSummary = (output: any, context: __SerdeC
       output.datastoreStorage !== undefined && output.datastoreStorage !== null
         ? deserializeAws_restJson1DatastoreStorageSummary(output.datastoreStorage, context)
         : undefined,
-    fileFormatType:
-      output.fileFormatType !== undefined && output.fileFormatType !== null ? output.fileFormatType : undefined,
+    fileFormatType: __expectString(output.fileFormatType),
     lastMessageArrivalTime:
       output.lastMessageArrivalTime !== undefined && output.lastMessageArrivalTime !== null
         ? new Date(Math.round(output.lastMessageArrivalTime * 1000))
@@ -5715,16 +5714,14 @@ const deserializeAws_restJson1DatastoreSummary = (output: any, context: __SerdeC
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
         ? new Date(Math.round(output.lastUpdateTime * 1000))
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
   } as any;
 };
 
 const deserializeAws_restJson1DeltaTime = (output: any, context: __SerdeContext): DeltaTime => {
   return {
-    offsetSeconds:
-      output.offsetSeconds !== undefined && output.offsetSeconds !== null ? output.offsetSeconds : undefined,
-    timeExpression:
-      output.timeExpression !== undefined && output.timeExpression !== null ? output.timeExpression : undefined,
+    offsetSeconds: __expectNumber(output.offsetSeconds),
+    timeExpression: __expectString(output.timeExpression),
   } as any;
 };
 
@@ -5733,8 +5730,7 @@ const deserializeAws_restJson1DeltaTimeSessionWindowConfiguration = (
   context: __SerdeContext
 ): DeltaTimeSessionWindowConfiguration => {
   return {
-    timeoutInMinutes:
-      output.timeoutInMinutes !== undefined && output.timeoutInMinutes !== null ? output.timeoutInMinutes : undefined,
+    timeoutInMinutes: __expectNumber(output.timeoutInMinutes),
   } as any;
 };
 
@@ -5743,11 +5739,11 @@ const deserializeAws_restJson1DeviceRegistryEnrichActivity = (
   context: __SerdeContext
 ): DeviceRegistryEnrichActivity => {
   return {
-    attribute: output.attribute !== undefined && output.attribute !== null ? output.attribute : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    next: output.next !== undefined && output.next !== null ? output.next : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
-    thingName: output.thingName !== undefined && output.thingName !== null ? output.thingName : undefined,
+    attribute: __expectString(output.attribute),
+    name: __expectString(output.name),
+    next: __expectString(output.next),
+    roleArn: __expectString(output.roleArn),
+    thingName: __expectString(output.thingName),
   } as any;
 };
 
@@ -5756,11 +5752,11 @@ const deserializeAws_restJson1DeviceShadowEnrichActivity = (
   context: __SerdeContext
 ): DeviceShadowEnrichActivity => {
   return {
-    attribute: output.attribute !== undefined && output.attribute !== null ? output.attribute : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    next: output.next !== undefined && output.next !== null ? output.next : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
-    thingName: output.thingName !== undefined && output.thingName !== null ? output.thingName : undefined,
+    attribute: __expectString(output.attribute),
+    name: __expectString(output.name),
+    next: __expectString(output.next),
+    roleArn: __expectString(output.roleArn),
+    thingName: __expectString(output.thingName),
   } as any;
 };
 
@@ -5770,10 +5766,7 @@ const deserializeAws_restJson1EstimatedResourceSize = (output: any, context: __S
       output.estimatedOn !== undefined && output.estimatedOn !== null
         ? new Date(Math.round(output.estimatedOn * 1000))
         : undefined,
-    estimatedSizeInBytes:
-      output.estimatedSizeInBytes !== undefined && output.estimatedSizeInBytes !== null
-        ? output.estimatedSizeInBytes
-        : undefined,
+    estimatedSizeInBytes: __expectNumber(output.estimatedSizeInBytes),
   } as any;
 };
 
@@ -5795,16 +5788,16 @@ const deserializeAws_restJson1FileFormatConfiguration = (
 
 const deserializeAws_restJson1FilterActivity = (output: any, context: __SerdeContext): FilterActivity => {
   return {
-    filter: output.filter !== undefined && output.filter !== null ? output.filter : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    next: output.next !== undefined && output.next !== null ? output.next : undefined,
+    filter: __expectString(output.filter),
+    name: __expectString(output.name),
+    next: __expectString(output.next),
   } as any;
 };
 
 const deserializeAws_restJson1GlueConfiguration = (output: any, context: __SerdeContext): GlueConfiguration => {
   return {
-    databaseName: output.databaseName !== undefined && output.databaseName !== null ? output.databaseName : undefined,
-    tableName: output.tableName !== undefined && output.tableName !== null ? output.tableName : undefined,
+    databaseName: __expectString(output.databaseName),
+    tableName: __expectString(output.tableName),
   } as any;
 };
 
@@ -5813,8 +5806,8 @@ const deserializeAws_restJson1IotEventsDestinationConfiguration = (
   context: __SerdeContext
 ): IotEventsDestinationConfiguration => {
   return {
-    inputName: output.inputName !== undefined && output.inputName !== null ? output.inputName : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
+    inputName: __expectString(output.inputName),
+    roleArn: __expectString(output.roleArn),
   } as any;
 };
 
@@ -5824,10 +5817,10 @@ const deserializeAws_restJson1JsonConfiguration = (output: any, context: __Serde
 
 const deserializeAws_restJson1LambdaActivity = (output: any, context: __SerdeContext): LambdaActivity => {
   return {
-    batchSize: output.batchSize !== undefined && output.batchSize !== null ? output.batchSize : undefined,
-    lambdaName: output.lambdaName !== undefined && output.lambdaName !== null ? output.lambdaName : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    next: output.next !== undefined && output.next !== null ? output.next : undefined,
+    batchSize: __expectNumber(output.batchSize),
+    lambdaName: __expectString(output.lambdaName),
+    name: __expectString(output.name),
+    next: __expectString(output.next),
   } as any;
 };
 
@@ -5837,7 +5830,7 @@ const deserializeAws_restJson1LateDataRule = (output: any, context: __SerdeConte
       output.ruleConfiguration !== undefined && output.ruleConfiguration !== null
         ? deserializeAws_restJson1LateDataRuleConfiguration(output.ruleConfiguration, context)
         : undefined,
-    ruleName: output.ruleName !== undefined && output.ruleName !== null ? output.ruleName : undefined,
+    ruleName: __expectString(output.ruleName),
   } as any;
 };
 
@@ -5869,18 +5862,18 @@ const deserializeAws_restJson1LateDataRules = (output: any, context: __SerdeCont
 
 const deserializeAws_restJson1LoggingOptions = (output: any, context: __SerdeContext): LoggingOptions => {
   return {
-    enabled: output.enabled !== undefined && output.enabled !== null ? output.enabled : undefined,
-    level: output.level !== undefined && output.level !== null ? output.level : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
+    enabled: __expectBoolean(output.enabled),
+    level: __expectString(output.level),
+    roleArn: __expectString(output.roleArn),
   } as any;
 };
 
 const deserializeAws_restJson1MathActivity = (output: any, context: __SerdeContext): MathActivity => {
   return {
-    attribute: output.attribute !== undefined && output.attribute !== null ? output.attribute : undefined,
-    math: output.math !== undefined && output.math !== null ? output.math : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    next: output.next !== undefined && output.next !== null ? output.next : undefined,
+    attribute: __expectString(output.attribute),
+    math: __expectString(output.math),
+    name: __expectString(output.name),
+    next: __expectString(output.next),
   } as any;
 };
 
@@ -5897,7 +5890,7 @@ const deserializeAws_restJson1MessagePayloads = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1OutputFileUriValue = (output: any, context: __SerdeContext): OutputFileUriValue => {
   return {
-    fileName: output.fileName !== undefined && output.fileName !== null ? output.fileName : undefined,
+    fileName: __expectString(output.fileName),
   } as any;
 };
 
@@ -5912,8 +5905,7 @@ const deserializeAws_restJson1ParquetConfiguration = (output: any, context: __Se
 
 const deserializeAws_restJson1Partition = (output: any, context: __SerdeContext): Partition => {
   return {
-    attributeName:
-      output.attributeName !== undefined && output.attributeName !== null ? output.attributeName : undefined,
+    attributeName: __expectString(output.attributeName),
   } as any;
 };
 
@@ -5934,7 +5926,7 @@ const deserializeAws_restJson1Pipeline = (output: any, context: __SerdeContext):
       output.activities !== undefined && output.activities !== null
         ? deserializeAws_restJson1PipelineActivities(output.activities, context)
         : undefined,
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
         ? new Date(Math.round(output.creationTime * 1000))
@@ -5943,7 +5935,7 @@ const deserializeAws_restJson1Pipeline = (output: any, context: __SerdeContext):
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
         ? new Date(Math.round(output.lastUpdateTime * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
     reprocessingSummaries:
       output.reprocessingSummaries !== undefined && output.reprocessingSummaries !== null
         ? deserializeAws_restJson1ReprocessingSummaries(output.reprocessingSummaries, context)
@@ -6028,7 +6020,7 @@ const deserializeAws_restJson1PipelineSummary = (output: any, context: __SerdeCo
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
         ? new Date(Math.round(output.lastUpdateTime * 1000))
         : undefined,
-    pipelineName: output.pipelineName !== undefined && output.pipelineName !== null ? output.pipelineName : undefined,
+    pipelineName: __expectString(output.pipelineName),
     reprocessingSummaries:
       output.reprocessingSummaries !== undefined && output.reprocessingSummaries !== null
         ? deserializeAws_restJson1ReprocessingSummaries(output.reprocessingSummaries, context)
@@ -6065,8 +6057,8 @@ const deserializeAws_restJson1RemoveAttributesActivity = (
       output.attributes !== undefined && output.attributes !== null
         ? deserializeAws_restJson1AttributeNames(output.attributes, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    next: output.next !== undefined && output.next !== null ? output.next : undefined,
+    name: __expectString(output.name),
+    next: __expectString(output.next),
   } as any;
 };
 
@@ -6087,23 +6079,22 @@ const deserializeAws_restJson1ReprocessingSummary = (output: any, context: __Ser
       output.creationTime !== undefined && output.creationTime !== null
         ? new Date(Math.round(output.creationTime * 1000))
         : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    id: __expectString(output.id),
+    status: __expectString(output.status),
   } as any;
 };
 
 const deserializeAws_restJson1ResourceConfiguration = (output: any, context: __SerdeContext): ResourceConfiguration => {
   return {
-    computeType: output.computeType !== undefined && output.computeType !== null ? output.computeType : undefined,
-    volumeSizeInGB:
-      output.volumeSizeInGB !== undefined && output.volumeSizeInGB !== null ? output.volumeSizeInGB : undefined,
+    computeType: __expectString(output.computeType),
+    volumeSizeInGB: __expectNumber(output.volumeSizeInGB),
   } as any;
 };
 
 const deserializeAws_restJson1RetentionPeriod = (output: any, context: __SerdeContext): RetentionPeriod => {
   return {
-    numberOfDays: output.numberOfDays !== undefined && output.numberOfDays !== null ? output.numberOfDays : undefined,
-    unlimited: output.unlimited !== undefined && output.unlimited !== null ? output.unlimited : undefined,
+    numberOfDays: __expectNumber(output.numberOfDays),
+    unlimited: __expectBoolean(output.unlimited),
   } as any;
 };
 
@@ -6112,19 +6103,19 @@ const deserializeAws_restJson1S3DestinationConfiguration = (
   context: __SerdeContext
 ): S3DestinationConfiguration => {
   return {
-    bucket: output.bucket !== undefined && output.bucket !== null ? output.bucket : undefined,
+    bucket: __expectString(output.bucket),
     glueConfiguration:
       output.glueConfiguration !== undefined && output.glueConfiguration !== null
         ? deserializeAws_restJson1GlueConfiguration(output.glueConfiguration, context)
         : undefined,
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
+    key: __expectString(output.key),
+    roleArn: __expectString(output.roleArn),
   } as any;
 };
 
 const deserializeAws_restJson1Schedule = (output: any, context: __SerdeContext): Schedule => {
   return {
-    expression: output.expression !== undefined && output.expression !== null ? output.expression : undefined,
+    expression: __expectString(output.expression),
   } as any;
 };
 
@@ -6146,8 +6137,8 @@ const deserializeAws_restJson1SelectAttributesActivity = (
       output.attributes !== undefined && output.attributes !== null
         ? deserializeAws_restJson1AttributeNames(output.attributes, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    next: output.next !== undefined && output.next !== null ? output.next : undefined,
+    name: __expectString(output.name),
+    next: __expectString(output.next),
   } as any;
 };
 
@@ -6185,14 +6176,14 @@ const deserializeAws_restJson1SqlQueryDatasetAction = (output: any, context: __S
       output.filters !== undefined && output.filters !== null
         ? deserializeAws_restJson1QueryFilters(output.filters, context)
         : undefined,
-    sqlQuery: output.sqlQuery !== undefined && output.sqlQuery !== null ? output.sqlQuery : undefined,
+    sqlQuery: __expectString(output.sqlQuery),
   } as any;
 };
 
 const deserializeAws_restJson1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    key: __expectString(output.key),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -6209,16 +6200,14 @@ const deserializeAws_restJson1TagList = (output: any, context: __SerdeContext): 
 
 const deserializeAws_restJson1TimestampPartition = (output: any, context: __SerdeContext): TimestampPartition => {
   return {
-    attributeName:
-      output.attributeName !== undefined && output.attributeName !== null ? output.attributeName : undefined,
-    timestampFormat:
-      output.timestampFormat !== undefined && output.timestampFormat !== null ? output.timestampFormat : undefined,
+    attributeName: __expectString(output.attributeName),
+    timestampFormat: __expectString(output.timestampFormat),
   } as any;
 };
 
 const deserializeAws_restJson1TriggeringDataset = (output: any, context: __SerdeContext): TriggeringDataset => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -6228,13 +6217,13 @@ const deserializeAws_restJson1Variable = (output: any, context: __SerdeContext):
       output.datasetContentVersionValue !== undefined && output.datasetContentVersionValue !== null
         ? deserializeAws_restJson1DatasetContentVersionValue(output.datasetContentVersionValue, context)
         : undefined,
-    doubleValue: output.doubleValue !== undefined && output.doubleValue !== null ? output.doubleValue : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    doubleValue: __expectNumber(output.doubleValue),
+    name: __expectString(output.name),
     outputFileUriValue:
       output.outputFileUriValue !== undefined && output.outputFileUriValue !== null
         ? deserializeAws_restJson1OutputFileUriValue(output.outputFileUriValue, context)
         : undefined,
-    stringValue: output.stringValue !== undefined && output.stringValue !== null ? output.stringValue : undefined,
+    stringValue: __expectString(output.stringValue),
   } as any;
 };
 
@@ -6254,8 +6243,8 @@ const deserializeAws_restJson1VersioningConfiguration = (
   context: __SerdeContext
 ): VersioningConfiguration => {
   return {
-    maxVersions: output.maxVersions !== undefined && output.maxVersions !== null ? output.maxVersions : undefined,
-    unlimited: output.unlimited !== undefined && output.unlimited !== null ? output.unlimited : undefined,
+    maxVersions: __expectNumber(output.maxVersions),
+    unlimited: __expectBoolean(output.unlimited),
   } as any;
 };
 

--- a/clients/client-iotdeviceadvisor/protocols/Aws_restJson1.ts
+++ b/clients/client-iotdeviceadvisor/protocols/Aws_restJson1.ts
@@ -43,6 +43,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -494,13 +497,13 @@ export const deserializeAws_restJson1CreateSuiteDefinitionCommand = async (
     contents.createdAt = new Date(Math.round(data.createdAt * 1000));
   }
   if (data.suiteDefinitionArn !== undefined && data.suiteDefinitionArn !== null) {
-    contents.suiteDefinitionArn = data.suiteDefinitionArn;
+    contents.suiteDefinitionArn = __expectString(data.suiteDefinitionArn);
   }
   if (data.suiteDefinitionId !== undefined && data.suiteDefinitionId !== null) {
-    contents.suiteDefinitionId = data.suiteDefinitionId;
+    contents.suiteDefinitionId = __expectString(data.suiteDefinitionId);
   }
   if (data.suiteDefinitionName !== undefined && data.suiteDefinitionName !== null) {
-    contents.suiteDefinitionName = data.suiteDefinitionName;
+    contents.suiteDefinitionName = __expectString(data.suiteDefinitionName);
   }
   return Promise.resolve(contents);
 };
@@ -635,10 +638,10 @@ export const deserializeAws_restJson1GetSuiteDefinitionCommand = async (
     contents.lastModifiedAt = new Date(Math.round(data.lastModifiedAt * 1000));
   }
   if (data.latestVersion !== undefined && data.latestVersion !== null) {
-    contents.latestVersion = data.latestVersion;
+    contents.latestVersion = __expectString(data.latestVersion);
   }
   if (data.suiteDefinitionArn !== undefined && data.suiteDefinitionArn !== null) {
-    contents.suiteDefinitionArn = data.suiteDefinitionArn;
+    contents.suiteDefinitionArn = __expectString(data.suiteDefinitionArn);
   }
   if (data.suiteDefinitionConfiguration !== undefined && data.suiteDefinitionConfiguration !== null) {
     contents.suiteDefinitionConfiguration = deserializeAws_restJson1SuiteDefinitionConfiguration(
@@ -647,10 +650,10 @@ export const deserializeAws_restJson1GetSuiteDefinitionCommand = async (
     );
   }
   if (data.suiteDefinitionId !== undefined && data.suiteDefinitionId !== null) {
-    contents.suiteDefinitionId = data.suiteDefinitionId;
+    contents.suiteDefinitionId = __expectString(data.suiteDefinitionId);
   }
   if (data.suiteDefinitionVersion !== undefined && data.suiteDefinitionVersion !== null) {
-    contents.suiteDefinitionVersion = data.suiteDefinitionVersion;
+    contents.suiteDefinitionVersion = __expectString(data.suiteDefinitionVersion);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
@@ -737,28 +740,28 @@ export const deserializeAws_restJson1GetSuiteRunCommand = async (
     contents.endTime = new Date(Math.round(data.endTime * 1000));
   }
   if (data.errorReason !== undefined && data.errorReason !== null) {
-    contents.errorReason = data.errorReason;
+    contents.errorReason = __expectString(data.errorReason);
   }
   if (data.startTime !== undefined && data.startTime !== null) {
     contents.startTime = new Date(Math.round(data.startTime * 1000));
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.status = data.status;
+    contents.status = __expectString(data.status);
   }
   if (data.suiteDefinitionId !== undefined && data.suiteDefinitionId !== null) {
-    contents.suiteDefinitionId = data.suiteDefinitionId;
+    contents.suiteDefinitionId = __expectString(data.suiteDefinitionId);
   }
   if (data.suiteDefinitionVersion !== undefined && data.suiteDefinitionVersion !== null) {
-    contents.suiteDefinitionVersion = data.suiteDefinitionVersion;
+    contents.suiteDefinitionVersion = __expectString(data.suiteDefinitionVersion);
   }
   if (data.suiteRunArn !== undefined && data.suiteRunArn !== null) {
-    contents.suiteRunArn = data.suiteRunArn;
+    contents.suiteRunArn = __expectString(data.suiteRunArn);
   }
   if (data.suiteRunConfiguration !== undefined && data.suiteRunConfiguration !== null) {
     contents.suiteRunConfiguration = deserializeAws_restJson1SuiteRunConfiguration(data.suiteRunConfiguration, context);
   }
   if (data.suiteRunId !== undefined && data.suiteRunId !== null) {
-    contents.suiteRunId = data.suiteRunId;
+    contents.suiteRunId = __expectString(data.suiteRunId);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
@@ -835,7 +838,7 @@ export const deserializeAws_restJson1GetSuiteRunReportCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.qualificationReportDownloadUrl !== undefined && data.qualificationReportDownloadUrl !== null) {
-    contents.qualificationReportDownloadUrl = data.qualificationReportDownloadUrl;
+    contents.qualificationReportDownloadUrl = __expectString(data.qualificationReportDownloadUrl);
   }
   return Promise.resolve(contents);
 };
@@ -907,7 +910,7 @@ export const deserializeAws_restJson1ListSuiteDefinitionsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.suiteDefinitionInformationList !== undefined && data.suiteDefinitionInformationList !== null) {
     contents.suiteDefinitionInformationList = deserializeAws_restJson1SuiteDefinitionInformationList(
@@ -977,7 +980,7 @@ export const deserializeAws_restJson1ListSuiteRunsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.suiteRunsList !== undefined && data.suiteRunsList !== null) {
     contents.suiteRunsList = deserializeAws_restJson1SuiteRunsList(data.suiteRunsList, context);
@@ -1119,10 +1122,10 @@ export const deserializeAws_restJson1StartSuiteRunCommand = async (
     contents.createdAt = new Date(Math.round(data.createdAt * 1000));
   }
   if (data.suiteRunArn !== undefined && data.suiteRunArn !== null) {
-    contents.suiteRunArn = data.suiteRunArn;
+    contents.suiteRunArn = __expectString(data.suiteRunArn);
   }
   if (data.suiteRunId !== undefined && data.suiteRunId !== null) {
-    contents.suiteRunId = data.suiteRunId;
+    contents.suiteRunId = __expectString(data.suiteRunId);
   }
   return Promise.resolve(contents);
 };
@@ -1405,16 +1408,16 @@ export const deserializeAws_restJson1UpdateSuiteDefinitionCommand = async (
     contents.lastUpdatedAt = new Date(Math.round(data.lastUpdatedAt * 1000));
   }
   if (data.suiteDefinitionArn !== undefined && data.suiteDefinitionArn !== null) {
-    contents.suiteDefinitionArn = data.suiteDefinitionArn;
+    contents.suiteDefinitionArn = __expectString(data.suiteDefinitionArn);
   }
   if (data.suiteDefinitionId !== undefined && data.suiteDefinitionId !== null) {
-    contents.suiteDefinitionId = data.suiteDefinitionId;
+    contents.suiteDefinitionId = __expectString(data.suiteDefinitionId);
   }
   if (data.suiteDefinitionName !== undefined && data.suiteDefinitionName !== null) {
-    contents.suiteDefinitionName = data.suiteDefinitionName;
+    contents.suiteDefinitionName = __expectString(data.suiteDefinitionName);
   }
   if (data.suiteDefinitionVersion !== undefined && data.suiteDefinitionVersion !== null) {
-    contents.suiteDefinitionVersion = data.suiteDefinitionVersion;
+    contents.suiteDefinitionVersion = __expectString(data.suiteDefinitionVersion);
   }
   return Promise.resolve(contents);
 };
@@ -1476,7 +1479,7 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1493,7 +1496,7 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1510,7 +1513,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1527,7 +1530,7 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1606,9 +1609,8 @@ const serializeAws_restJson1TagMap = (input: { [key: string]: string }, context:
 
 const deserializeAws_restJson1DeviceUnderTest = (output: any, context: __SerdeContext): DeviceUnderTest => {
   return {
-    certificateArn:
-      output.certificateArn !== undefined && output.certificateArn !== null ? output.certificateArn : undefined,
-    thingArn: output.thingArn !== undefined && output.thingArn !== null ? output.thingArn : undefined,
+    certificateArn: __expectString(output.certificateArn),
+    thingArn: __expectString(output.thingArn),
   } as any;
 };
 
@@ -1625,8 +1627,8 @@ const deserializeAws_restJson1DeviceUnderTestList = (output: any, context: __Ser
 
 const deserializeAws_restJson1GroupResult = (output: any, context: __SerdeContext): GroupResult => {
   return {
-    groupId: output.groupId !== undefined && output.groupId !== null ? output.groupId : undefined,
-    groupName: output.groupName !== undefined && output.groupName !== null ? output.groupName : undefined,
+    groupId: __expectString(output.groupId),
+    groupName: __expectString(output.groupName),
     tests:
       output.tests !== undefined && output.tests !== null
         ? deserializeAws_restJson1TestCaseRuns(output.tests, context)
@@ -1652,7 +1654,7 @@ const deserializeAws_restJson1SelectedTestList = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -1661,23 +1663,14 @@ const deserializeAws_restJson1SuiteDefinitionConfiguration = (
   context: __SerdeContext
 ): SuiteDefinitionConfiguration => {
   return {
-    devicePermissionRoleArn:
-      output.devicePermissionRoleArn !== undefined && output.devicePermissionRoleArn !== null
-        ? output.devicePermissionRoleArn
-        : undefined,
+    devicePermissionRoleArn: __expectString(output.devicePermissionRoleArn),
     devices:
       output.devices !== undefined && output.devices !== null
         ? deserializeAws_restJson1DeviceUnderTestList(output.devices, context)
         : undefined,
-    intendedForQualification:
-      output.intendedForQualification !== undefined && output.intendedForQualification !== null
-        ? output.intendedForQualification
-        : undefined,
-    rootGroup: output.rootGroup !== undefined && output.rootGroup !== null ? output.rootGroup : undefined,
-    suiteDefinitionName:
-      output.suiteDefinitionName !== undefined && output.suiteDefinitionName !== null
-        ? output.suiteDefinitionName
-        : undefined,
+    intendedForQualification: __expectBoolean(output.intendedForQualification),
+    rootGroup: __expectString(output.rootGroup),
+    suiteDefinitionName: __expectString(output.suiteDefinitionName),
   } as any;
 };
 
@@ -1694,18 +1687,9 @@ const deserializeAws_restJson1SuiteDefinitionInformation = (
       output.defaultDevices !== undefined && output.defaultDevices !== null
         ? deserializeAws_restJson1DeviceUnderTestList(output.defaultDevices, context)
         : undefined,
-    intendedForQualification:
-      output.intendedForQualification !== undefined && output.intendedForQualification !== null
-        ? output.intendedForQualification
-        : undefined,
-    suiteDefinitionId:
-      output.suiteDefinitionId !== undefined && output.suiteDefinitionId !== null
-        ? output.suiteDefinitionId
-        : undefined,
-    suiteDefinitionName:
-      output.suiteDefinitionName !== undefined && output.suiteDefinitionName !== null
-        ? output.suiteDefinitionName
-        : undefined,
+    intendedForQualification: __expectBoolean(output.intendedForQualification),
+    suiteDefinitionId: __expectString(output.suiteDefinitionId),
+    suiteDefinitionName: __expectString(output.suiteDefinitionName),
   } as any;
 };
 
@@ -1743,26 +1727,17 @@ const deserializeAws_restJson1SuiteRunInformation = (output: any, context: __Ser
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
     endAt: output.endAt !== undefined && output.endAt !== null ? new Date(Math.round(output.endAt * 1000)) : undefined,
-    failed: output.failed !== undefined && output.failed !== null ? output.failed : undefined,
-    passed: output.passed !== undefined && output.passed !== null ? output.passed : undefined,
+    failed: __expectNumber(output.failed),
+    passed: __expectNumber(output.passed),
     startedAt:
       output.startedAt !== undefined && output.startedAt !== null
         ? new Date(Math.round(output.startedAt * 1000))
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    suiteDefinitionId:
-      output.suiteDefinitionId !== undefined && output.suiteDefinitionId !== null
-        ? output.suiteDefinitionId
-        : undefined,
-    suiteDefinitionName:
-      output.suiteDefinitionName !== undefined && output.suiteDefinitionName !== null
-        ? output.suiteDefinitionName
-        : undefined,
-    suiteDefinitionVersion:
-      output.suiteDefinitionVersion !== undefined && output.suiteDefinitionVersion !== null
-        ? output.suiteDefinitionVersion
-        : undefined,
-    suiteRunId: output.suiteRunId !== undefined && output.suiteRunId !== null ? output.suiteRunId : undefined,
+    status: __expectString(output.status),
+    suiteDefinitionId: __expectString(output.suiteDefinitionId),
+    suiteDefinitionName: __expectString(output.suiteDefinitionName),
+    suiteDefinitionVersion: __expectString(output.suiteDefinitionVersion),
+    suiteRunId: __expectString(output.suiteRunId),
   } as any;
 };
 
@@ -1784,7 +1759,7 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -1793,24 +1768,17 @@ const deserializeAws_restJson1TestCaseRun = (output: any, context: __SerdeContex
   return {
     endTime:
       output.endTime !== undefined && output.endTime !== null ? new Date(Math.round(output.endTime * 1000)) : undefined,
-    failure: output.failure !== undefined && output.failure !== null ? output.failure : undefined,
-    logUrl: output.logUrl !== undefined && output.logUrl !== null ? output.logUrl : undefined,
+    failure: __expectString(output.failure),
+    logUrl: __expectString(output.logUrl),
     startTime:
       output.startTime !== undefined && output.startTime !== null
         ? new Date(Math.round(output.startTime * 1000))
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    testCaseDefinitionId:
-      output.testCaseDefinitionId !== undefined && output.testCaseDefinitionId !== null
-        ? output.testCaseDefinitionId
-        : undefined,
-    testCaseDefinitionName:
-      output.testCaseDefinitionName !== undefined && output.testCaseDefinitionName !== null
-        ? output.testCaseDefinitionName
-        : undefined,
-    testCaseRunId:
-      output.testCaseRunId !== undefined && output.testCaseRunId !== null ? output.testCaseRunId : undefined,
-    warnings: output.warnings !== undefined && output.warnings !== null ? output.warnings : undefined,
+    status: __expectString(output.status),
+    testCaseDefinitionId: __expectString(output.testCaseDefinitionId),
+    testCaseDefinitionName: __expectString(output.testCaseDefinitionName),
+    testCaseRunId: __expectString(output.testCaseRunId),
+    warnings: __expectString(output.warnings),
   } as any;
 };
 

--- a/clients/client-iotfleethub/protocols/Aws_restJson1.ts
+++ b/clients/client-iotfleethub/protocols/Aws_restJson1.ts
@@ -24,6 +24,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -291,10 +293,10 @@ export const deserializeAws_restJson1CreateApplicationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.applicationArn !== undefined && data.applicationArn !== null) {
-    contents.applicationArn = data.applicationArn;
+    contents.applicationArn = __expectString(data.applicationArn);
   }
   if (data.applicationId !== undefined && data.applicationId !== null) {
-    contents.applicationId = data.applicationId;
+    contents.applicationId = __expectString(data.applicationId);
   }
   return Promise.resolve(contents);
 };
@@ -459,37 +461,37 @@ export const deserializeAws_restJson1DescribeApplicationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.applicationArn !== undefined && data.applicationArn !== null) {
-    contents.applicationArn = data.applicationArn;
+    contents.applicationArn = __expectString(data.applicationArn);
   }
   if (data.applicationCreationDate !== undefined && data.applicationCreationDate !== null) {
-    contents.applicationCreationDate = data.applicationCreationDate;
+    contents.applicationCreationDate = __expectNumber(data.applicationCreationDate);
   }
   if (data.applicationDescription !== undefined && data.applicationDescription !== null) {
-    contents.applicationDescription = data.applicationDescription;
+    contents.applicationDescription = __expectString(data.applicationDescription);
   }
   if (data.applicationId !== undefined && data.applicationId !== null) {
-    contents.applicationId = data.applicationId;
+    contents.applicationId = __expectString(data.applicationId);
   }
   if (data.applicationLastUpdateDate !== undefined && data.applicationLastUpdateDate !== null) {
-    contents.applicationLastUpdateDate = data.applicationLastUpdateDate;
+    contents.applicationLastUpdateDate = __expectNumber(data.applicationLastUpdateDate);
   }
   if (data.applicationName !== undefined && data.applicationName !== null) {
-    contents.applicationName = data.applicationName;
+    contents.applicationName = __expectString(data.applicationName);
   }
   if (data.applicationState !== undefined && data.applicationState !== null) {
-    contents.applicationState = data.applicationState;
+    contents.applicationState = __expectString(data.applicationState);
   }
   if (data.applicationUrl !== undefined && data.applicationUrl !== null) {
-    contents.applicationUrl = data.applicationUrl;
+    contents.applicationUrl = __expectString(data.applicationUrl);
   }
   if (data.errorMessage !== undefined && data.errorMessage !== null) {
-    contents.errorMessage = data.errorMessage;
+    contents.errorMessage = __expectString(data.errorMessage);
   }
   if (data.roleArn !== undefined && data.roleArn !== null) {
-    contents.roleArn = data.roleArn;
+    contents.roleArn = __expectString(data.roleArn);
   }
   if (data.ssoClientId !== undefined && data.ssoClientId !== null) {
-    contents.ssoClientId = data.ssoClientId;
+    contents.ssoClientId = __expectString(data.ssoClientId);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
@@ -575,7 +577,7 @@ export const deserializeAws_restJson1ListApplicationsCommand = async (
     contents.applicationSummaries = deserializeAws_restJson1ApplicationSummaries(data.applicationSummaries, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -933,7 +935,7 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -950,7 +952,7 @@ const deserializeAws_restJson1InternalFailureExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -967,7 +969,7 @@ const deserializeAws_restJson1InvalidRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -984,7 +986,7 @@ const deserializeAws_restJson1LimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1001,7 +1003,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1018,7 +1020,7 @@ const deserializeAws_restJson1ThrottlingExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1048,26 +1050,13 @@ const deserializeAws_restJson1ApplicationSummaries = (output: any, context: __Se
 
 const deserializeAws_restJson1ApplicationSummary = (output: any, context: __SerdeContext): ApplicationSummary => {
   return {
-    applicationCreationDate:
-      output.applicationCreationDate !== undefined && output.applicationCreationDate !== null
-        ? output.applicationCreationDate
-        : undefined,
-    applicationDescription:
-      output.applicationDescription !== undefined && output.applicationDescription !== null
-        ? output.applicationDescription
-        : undefined,
-    applicationId:
-      output.applicationId !== undefined && output.applicationId !== null ? output.applicationId : undefined,
-    applicationLastUpdateDate:
-      output.applicationLastUpdateDate !== undefined && output.applicationLastUpdateDate !== null
-        ? output.applicationLastUpdateDate
-        : undefined,
-    applicationName:
-      output.applicationName !== undefined && output.applicationName !== null ? output.applicationName : undefined,
-    applicationState:
-      output.applicationState !== undefined && output.applicationState !== null ? output.applicationState : undefined,
-    applicationUrl:
-      output.applicationUrl !== undefined && output.applicationUrl !== null ? output.applicationUrl : undefined,
+    applicationCreationDate: __expectNumber(output.applicationCreationDate),
+    applicationDescription: __expectString(output.applicationDescription),
+    applicationId: __expectString(output.applicationId),
+    applicationLastUpdateDate: __expectNumber(output.applicationLastUpdateDate),
+    applicationName: __expectString(output.applicationName),
+    applicationState: __expectString(output.applicationState),
+    applicationUrl: __expectString(output.applicationUrl),
   } as any;
 };
 
@@ -1078,7 +1067,7 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };

--- a/clients/client-iotsecuretunneling/protocols/Aws_json1_1.ts
+++ b/clients/client-iotsecuretunneling/protocols/Aws_json1_1.ts
@@ -33,7 +33,11 @@ import {
   UntagResourceResponse,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -658,7 +662,7 @@ const deserializeAws_json1_1ConnectionState = (output: any, context: __SerdeCont
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
         ? new Date(Math.round(output.lastUpdatedAt * 1000))
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -677,13 +681,13 @@ const deserializeAws_json1_1DestinationConfig = (output: any, context: __SerdeCo
       output.services !== undefined && output.services !== null
         ? deserializeAws_json1_1ServiceList(output.services, context)
         : undefined,
-    thingName: output.thingName !== undefined && output.thingName !== null ? output.thingName : undefined,
+    thingName: __expectString(output.thingName),
   } as any;
 };
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -701,7 +705,7 @@ const deserializeAws_json1_1ListTagsForResourceResponse = (
 
 const deserializeAws_json1_1ListTunnelsResponse = (output: any, context: __SerdeContext): ListTunnelsResponse => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     tunnelSummaries:
       output.tunnelSummaries !== undefined && output.tunnelSummaries !== null
         ? deserializeAws_json1_1TunnelSummaryList(output.tunnelSummaries, context)
@@ -711,16 +715,10 @@ const deserializeAws_json1_1ListTunnelsResponse = (output: any, context: __Serde
 
 const deserializeAws_json1_1OpenTunnelResponse = (output: any, context: __SerdeContext): OpenTunnelResponse => {
   return {
-    destinationAccessToken:
-      output.destinationAccessToken !== undefined && output.destinationAccessToken !== null
-        ? output.destinationAccessToken
-        : undefined,
-    sourceAccessToken:
-      output.sourceAccessToken !== undefined && output.sourceAccessToken !== null
-        ? output.sourceAccessToken
-        : undefined,
-    tunnelArn: output.tunnelArn !== undefined && output.tunnelArn !== null ? output.tunnelArn : undefined,
-    tunnelId: output.tunnelId !== undefined && output.tunnelId !== null ? output.tunnelId : undefined,
+    destinationAccessToken: __expectString(output.destinationAccessToken),
+    sourceAccessToken: __expectString(output.sourceAccessToken),
+    tunnelArn: __expectString(output.tunnelArn),
+    tunnelId: __expectString(output.tunnelId),
   } as any;
 };
 
@@ -729,7 +727,7 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -740,14 +738,14 @@ const deserializeAws_json1_1ServiceList = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    key: __expectString(output.key),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -768,10 +766,7 @@ const deserializeAws_json1_1TagResourceResponse = (output: any, context: __Serde
 
 const deserializeAws_json1_1TimeoutConfig = (output: any, context: __SerdeContext): TimeoutConfig => {
   return {
-    maxLifetimeTimeoutMinutes:
-      output.maxLifetimeTimeoutMinutes !== undefined && output.maxLifetimeTimeoutMinutes !== null
-        ? output.maxLifetimeTimeoutMinutes
-        : undefined,
+    maxLifetimeTimeoutMinutes: __expectNumber(output.maxLifetimeTimeoutMinutes),
   } as any;
 };
 
@@ -781,7 +776,7 @@ const deserializeAws_json1_1Tunnel = (output: any, context: __SerdeContext): Tun
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    description: __expectString(output.description),
     destinationConfig:
       output.destinationConfig !== undefined && output.destinationConfig !== null
         ? deserializeAws_json1_1DestinationConfig(output.destinationConfig, context)
@@ -798,7 +793,7 @@ const deserializeAws_json1_1Tunnel = (output: any, context: __SerdeContext): Tun
       output.sourceConnectionState !== undefined && output.sourceConnectionState !== null
         ? deserializeAws_json1_1ConnectionState(output.sourceConnectionState, context)
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_json1_1TagList(output.tags, context)
@@ -807,8 +802,8 @@ const deserializeAws_json1_1Tunnel = (output: any, context: __SerdeContext): Tun
       output.timeoutConfig !== undefined && output.timeoutConfig !== null
         ? deserializeAws_json1_1TimeoutConfig(output.timeoutConfig, context)
         : undefined,
-    tunnelArn: output.tunnelArn !== undefined && output.tunnelArn !== null ? output.tunnelArn : undefined,
-    tunnelId: output.tunnelId !== undefined && output.tunnelId !== null ? output.tunnelId : undefined,
+    tunnelArn: __expectString(output.tunnelArn),
+    tunnelId: __expectString(output.tunnelId),
   } as any;
 };
 
@@ -818,14 +813,14 @@ const deserializeAws_json1_1TunnelSummary = (output: any, context: __SerdeContex
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    description: __expectString(output.description),
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
         ? new Date(Math.round(output.lastUpdatedAt * 1000))
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    tunnelArn: output.tunnelArn !== undefined && output.tunnelArn !== null ? output.tunnelArn : undefined,
-    tunnelId: output.tunnelId !== undefined && output.tunnelId !== null ? output.tunnelId : undefined,
+    status: __expectString(output.status),
+    tunnelArn: __expectString(output.tunnelArn),
+    tunnelId: __expectString(output.tunnelId),
   } as any;
 };
 

--- a/clients/client-iotsitewise/protocols/Aws_restJson1.ts
+++ b/clients/client-iotsitewise/protocols/Aws_restJson1.ts
@@ -193,6 +193,9 @@ import {
 } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -2784,10 +2787,10 @@ export const deserializeAws_restJson1CreateAccessPolicyCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.accessPolicyArn !== undefined && data.accessPolicyArn !== null) {
-    contents.accessPolicyArn = data.accessPolicyArn;
+    contents.accessPolicyArn = __expectString(data.accessPolicyArn);
   }
   if (data.accessPolicyId !== undefined && data.accessPolicyId !== null) {
-    contents.accessPolicyId = data.accessPolicyId;
+    contents.accessPolicyId = __expectString(data.accessPolicyId);
   }
   return Promise.resolve(contents);
 };
@@ -2876,10 +2879,10 @@ export const deserializeAws_restJson1CreateAssetCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.assetArn !== undefined && data.assetArn !== null) {
-    contents.assetArn = data.assetArn;
+    contents.assetArn = __expectString(data.assetArn);
   }
   if (data.assetId !== undefined && data.assetId !== null) {
-    contents.assetId = data.assetId;
+    contents.assetId = __expectString(data.assetId);
   }
   if (data.assetStatus !== undefined && data.assetStatus !== null) {
     contents.assetStatus = deserializeAws_restJson1AssetStatus(data.assetStatus, context);
@@ -2987,10 +2990,10 @@ export const deserializeAws_restJson1CreateAssetModelCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.assetModelArn !== undefined && data.assetModelArn !== null) {
-    contents.assetModelArn = data.assetModelArn;
+    contents.assetModelArn = __expectString(data.assetModelArn);
   }
   if (data.assetModelId !== undefined && data.assetModelId !== null) {
-    contents.assetModelId = data.assetModelId;
+    contents.assetModelId = __expectString(data.assetModelId);
   }
   if (data.assetModelStatus !== undefined && data.assetModelStatus !== null) {
     contents.assetModelStatus = deserializeAws_restJson1AssetModelStatus(data.assetModelStatus, context);
@@ -3097,10 +3100,10 @@ export const deserializeAws_restJson1CreateDashboardCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.dashboardArn !== undefined && data.dashboardArn !== null) {
-    contents.dashboardArn = data.dashboardArn;
+    contents.dashboardArn = __expectString(data.dashboardArn);
   }
   if (data.dashboardId !== undefined && data.dashboardId !== null) {
-    contents.dashboardId = data.dashboardId;
+    contents.dashboardId = __expectString(data.dashboardId);
   }
   return Promise.resolve(contents);
 };
@@ -3188,10 +3191,10 @@ export const deserializeAws_restJson1CreateGatewayCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.gatewayArn !== undefined && data.gatewayArn !== null) {
-    contents.gatewayArn = data.gatewayArn;
+    contents.gatewayArn = __expectString(data.gatewayArn);
   }
   if (data.gatewayId !== undefined && data.gatewayId !== null) {
-    contents.gatewayId = data.gatewayId;
+    contents.gatewayId = __expectString(data.gatewayId);
   }
   return Promise.resolve(contents);
 };
@@ -3282,19 +3285,19 @@ export const deserializeAws_restJson1CreatePortalCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.portalArn !== undefined && data.portalArn !== null) {
-    contents.portalArn = data.portalArn;
+    contents.portalArn = __expectString(data.portalArn);
   }
   if (data.portalId !== undefined && data.portalId !== null) {
-    contents.portalId = data.portalId;
+    contents.portalId = __expectString(data.portalId);
   }
   if (data.portalStartUrl !== undefined && data.portalStartUrl !== null) {
-    contents.portalStartUrl = data.portalStartUrl;
+    contents.portalStartUrl = __expectString(data.portalStartUrl);
   }
   if (data.portalStatus !== undefined && data.portalStatus !== null) {
     contents.portalStatus = deserializeAws_restJson1PortalStatus(data.portalStatus, context);
   }
   if (data.ssoApplicationId !== undefined && data.ssoApplicationId !== null) {
-    contents.ssoApplicationId = data.ssoApplicationId;
+    contents.ssoApplicationId = __expectString(data.ssoApplicationId);
   }
   return Promise.resolve(contents);
 };
@@ -3382,10 +3385,10 @@ export const deserializeAws_restJson1CreateProjectCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.projectArn !== undefined && data.projectArn !== null) {
-    contents.projectArn = data.projectArn;
+    contents.projectArn = __expectString(data.projectArn);
   }
   if (data.projectId !== undefined && data.projectId !== null) {
-    contents.projectId = data.projectId;
+    contents.projectId = __expectString(data.projectId);
   }
   return Promise.resolve(contents);
 };
@@ -4039,13 +4042,13 @@ export const deserializeAws_restJson1DescribeAccessPolicyCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.accessPolicyArn !== undefined && data.accessPolicyArn !== null) {
-    contents.accessPolicyArn = data.accessPolicyArn;
+    contents.accessPolicyArn = __expectString(data.accessPolicyArn);
   }
   if (data.accessPolicyCreationDate !== undefined && data.accessPolicyCreationDate !== null) {
     contents.accessPolicyCreationDate = new Date(Math.round(data.accessPolicyCreationDate * 1000));
   }
   if (data.accessPolicyId !== undefined && data.accessPolicyId !== null) {
-    contents.accessPolicyId = data.accessPolicyId;
+    contents.accessPolicyId = __expectString(data.accessPolicyId);
   }
   if (data.accessPolicyIdentity !== undefined && data.accessPolicyIdentity !== null) {
     contents.accessPolicyIdentity = deserializeAws_restJson1Identity(data.accessPolicyIdentity, context);
@@ -4054,7 +4057,7 @@ export const deserializeAws_restJson1DescribeAccessPolicyCommand = async (
     contents.accessPolicyLastUpdateDate = new Date(Math.round(data.accessPolicyLastUpdateDate * 1000));
   }
   if (data.accessPolicyPermission !== undefined && data.accessPolicyPermission !== null) {
-    contents.accessPolicyPermission = data.accessPolicyPermission;
+    contents.accessPolicyPermission = __expectString(data.accessPolicyPermission);
   }
   if (data.accessPolicyResource !== undefined && data.accessPolicyResource !== null) {
     contents.accessPolicyResource = deserializeAws_restJson1Resource(data.accessPolicyResource, context);
@@ -4145,7 +4148,7 @@ export const deserializeAws_restJson1DescribeAssetCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.assetArn !== undefined && data.assetArn !== null) {
-    contents.assetArn = data.assetArn;
+    contents.assetArn = __expectString(data.assetArn);
   }
   if (data.assetCompositeModels !== undefined && data.assetCompositeModels !== null) {
     contents.assetCompositeModels = deserializeAws_restJson1AssetCompositeModels(data.assetCompositeModels, context);
@@ -4157,16 +4160,16 @@ export const deserializeAws_restJson1DescribeAssetCommand = async (
     contents.assetHierarchies = deserializeAws_restJson1AssetHierarchies(data.assetHierarchies, context);
   }
   if (data.assetId !== undefined && data.assetId !== null) {
-    contents.assetId = data.assetId;
+    contents.assetId = __expectString(data.assetId);
   }
   if (data.assetLastUpdateDate !== undefined && data.assetLastUpdateDate !== null) {
     contents.assetLastUpdateDate = new Date(Math.round(data.assetLastUpdateDate * 1000));
   }
   if (data.assetModelId !== undefined && data.assetModelId !== null) {
-    contents.assetModelId = data.assetModelId;
+    contents.assetModelId = __expectString(data.assetModelId);
   }
   if (data.assetName !== undefined && data.assetName !== null) {
-    contents.assetName = data.assetName;
+    contents.assetName = __expectString(data.assetName);
   }
   if (data.assetProperties !== undefined && data.assetProperties !== null) {
     contents.assetProperties = deserializeAws_restJson1AssetProperties(data.assetProperties, context);
@@ -4260,7 +4263,7 @@ export const deserializeAws_restJson1DescribeAssetModelCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.assetModelArn !== undefined && data.assetModelArn !== null) {
-    contents.assetModelArn = data.assetModelArn;
+    contents.assetModelArn = __expectString(data.assetModelArn);
   }
   if (data.assetModelCompositeModels !== undefined && data.assetModelCompositeModels !== null) {
     contents.assetModelCompositeModels = deserializeAws_restJson1AssetModelCompositeModels(
@@ -4272,19 +4275,19 @@ export const deserializeAws_restJson1DescribeAssetModelCommand = async (
     contents.assetModelCreationDate = new Date(Math.round(data.assetModelCreationDate * 1000));
   }
   if (data.assetModelDescription !== undefined && data.assetModelDescription !== null) {
-    contents.assetModelDescription = data.assetModelDescription;
+    contents.assetModelDescription = __expectString(data.assetModelDescription);
   }
   if (data.assetModelHierarchies !== undefined && data.assetModelHierarchies !== null) {
     contents.assetModelHierarchies = deserializeAws_restJson1AssetModelHierarchies(data.assetModelHierarchies, context);
   }
   if (data.assetModelId !== undefined && data.assetModelId !== null) {
-    contents.assetModelId = data.assetModelId;
+    contents.assetModelId = __expectString(data.assetModelId);
   }
   if (data.assetModelLastUpdateDate !== undefined && data.assetModelLastUpdateDate !== null) {
     contents.assetModelLastUpdateDate = new Date(Math.round(data.assetModelLastUpdateDate * 1000));
   }
   if (data.assetModelName !== undefined && data.assetModelName !== null) {
-    contents.assetModelName = data.assetModelName;
+    contents.assetModelName = __expectString(data.assetModelName);
   }
   if (data.assetModelProperties !== undefined && data.assetModelProperties !== null) {
     contents.assetModelProperties = deserializeAws_restJson1AssetModelProperties(data.assetModelProperties, context);
@@ -4373,13 +4376,13 @@ export const deserializeAws_restJson1DescribeAssetPropertyCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.assetId !== undefined && data.assetId !== null) {
-    contents.assetId = data.assetId;
+    contents.assetId = __expectString(data.assetId);
   }
   if (data.assetModelId !== undefined && data.assetModelId !== null) {
-    contents.assetModelId = data.assetModelId;
+    contents.assetModelId = __expectString(data.assetModelId);
   }
   if (data.assetName !== undefined && data.assetName !== null) {
-    contents.assetName = data.assetName;
+    contents.assetName = __expectString(data.assetName);
   }
   if (data.assetProperty !== undefined && data.assetProperty !== null) {
     contents.assetProperty = deserializeAws_restJson1Property(data.assetProperty, context);
@@ -4471,28 +4474,28 @@ export const deserializeAws_restJson1DescribeDashboardCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.dashboardArn !== undefined && data.dashboardArn !== null) {
-    contents.dashboardArn = data.dashboardArn;
+    contents.dashboardArn = __expectString(data.dashboardArn);
   }
   if (data.dashboardCreationDate !== undefined && data.dashboardCreationDate !== null) {
     contents.dashboardCreationDate = new Date(Math.round(data.dashboardCreationDate * 1000));
   }
   if (data.dashboardDefinition !== undefined && data.dashboardDefinition !== null) {
-    contents.dashboardDefinition = data.dashboardDefinition;
+    contents.dashboardDefinition = __expectString(data.dashboardDefinition);
   }
   if (data.dashboardDescription !== undefined && data.dashboardDescription !== null) {
-    contents.dashboardDescription = data.dashboardDescription;
+    contents.dashboardDescription = __expectString(data.dashboardDescription);
   }
   if (data.dashboardId !== undefined && data.dashboardId !== null) {
-    contents.dashboardId = data.dashboardId;
+    contents.dashboardId = __expectString(data.dashboardId);
   }
   if (data.dashboardLastUpdateDate !== undefined && data.dashboardLastUpdateDate !== null) {
     contents.dashboardLastUpdateDate = new Date(Math.round(data.dashboardLastUpdateDate * 1000));
   }
   if (data.dashboardName !== undefined && data.dashboardName !== null) {
-    contents.dashboardName = data.dashboardName;
+    contents.dashboardName = __expectString(data.dashboardName);
   }
   if (data.projectId !== undefined && data.projectId !== null) {
-    contents.projectId = data.projectId;
+    contents.projectId = __expectString(data.projectId);
   }
   return Promise.resolve(contents);
 };
@@ -4576,10 +4579,10 @@ export const deserializeAws_restJson1DescribeDefaultEncryptionConfigurationComma
     contents.configurationStatus = deserializeAws_restJson1ConfigurationStatus(data.configurationStatus, context);
   }
   if (data.encryptionType !== undefined && data.encryptionType !== null) {
-    contents.encryptionType = data.encryptionType;
+    contents.encryptionType = __expectString(data.encryptionType);
   }
   if (data.kmsKeyArn !== undefined && data.kmsKeyArn !== null) {
-    contents.kmsKeyArn = data.kmsKeyArn;
+    contents.kmsKeyArn = __expectString(data.kmsKeyArn);
   }
   return Promise.resolve(contents);
 };
@@ -4659,7 +4662,7 @@ export const deserializeAws_restJson1DescribeGatewayCommand = async (
     contents.creationDate = new Date(Math.round(data.creationDate * 1000));
   }
   if (data.gatewayArn !== undefined && data.gatewayArn !== null) {
-    contents.gatewayArn = data.gatewayArn;
+    contents.gatewayArn = __expectString(data.gatewayArn);
   }
   if (data.gatewayCapabilitySummaries !== undefined && data.gatewayCapabilitySummaries !== null) {
     contents.gatewayCapabilitySummaries = deserializeAws_restJson1GatewayCapabilitySummaries(
@@ -4668,10 +4671,10 @@ export const deserializeAws_restJson1DescribeGatewayCommand = async (
     );
   }
   if (data.gatewayId !== undefined && data.gatewayId !== null) {
-    contents.gatewayId = data.gatewayId;
+    contents.gatewayId = __expectString(data.gatewayId);
   }
   if (data.gatewayName !== undefined && data.gatewayName !== null) {
-    contents.gatewayName = data.gatewayName;
+    contents.gatewayName = __expectString(data.gatewayName);
   }
   if (data.gatewayPlatform !== undefined && data.gatewayPlatform !== null) {
     contents.gatewayPlatform = deserializeAws_restJson1GatewayPlatform(data.gatewayPlatform, context);
@@ -4759,16 +4762,16 @@ export const deserializeAws_restJson1DescribeGatewayCapabilityConfigurationComma
   };
   const data: any = await parseBody(output.body, context);
   if (data.capabilityConfiguration !== undefined && data.capabilityConfiguration !== null) {
-    contents.capabilityConfiguration = data.capabilityConfiguration;
+    contents.capabilityConfiguration = __expectString(data.capabilityConfiguration);
   }
   if (data.capabilityNamespace !== undefined && data.capabilityNamespace !== null) {
-    contents.capabilityNamespace = data.capabilityNamespace;
+    contents.capabilityNamespace = __expectString(data.capabilityNamespace);
   }
   if (data.capabilitySyncStatus !== undefined && data.capabilitySyncStatus !== null) {
-    contents.capabilitySyncStatus = data.capabilitySyncStatus;
+    contents.capabilitySyncStatus = __expectString(data.capabilitySyncStatus);
   }
   if (data.gatewayId !== undefined && data.gatewayId !== null) {
-    contents.gatewayId = data.gatewayId;
+    contents.gatewayId = __expectString(data.gatewayId);
   }
   return Promise.resolve(contents);
 };
@@ -4943,28 +4946,28 @@ export const deserializeAws_restJson1DescribePortalCommand = async (
     contents.alarms = deserializeAws_restJson1Alarms(data.alarms, context);
   }
   if (data.notificationSenderEmail !== undefined && data.notificationSenderEmail !== null) {
-    contents.notificationSenderEmail = data.notificationSenderEmail;
+    contents.notificationSenderEmail = __expectString(data.notificationSenderEmail);
   }
   if (data.portalArn !== undefined && data.portalArn !== null) {
-    contents.portalArn = data.portalArn;
+    contents.portalArn = __expectString(data.portalArn);
   }
   if (data.portalAuthMode !== undefined && data.portalAuthMode !== null) {
-    contents.portalAuthMode = data.portalAuthMode;
+    contents.portalAuthMode = __expectString(data.portalAuthMode);
   }
   if (data.portalClientId !== undefined && data.portalClientId !== null) {
-    contents.portalClientId = data.portalClientId;
+    contents.portalClientId = __expectString(data.portalClientId);
   }
   if (data.portalContactEmail !== undefined && data.portalContactEmail !== null) {
-    contents.portalContactEmail = data.portalContactEmail;
+    contents.portalContactEmail = __expectString(data.portalContactEmail);
   }
   if (data.portalCreationDate !== undefined && data.portalCreationDate !== null) {
     contents.portalCreationDate = new Date(Math.round(data.portalCreationDate * 1000));
   }
   if (data.portalDescription !== undefined && data.portalDescription !== null) {
-    contents.portalDescription = data.portalDescription;
+    contents.portalDescription = __expectString(data.portalDescription);
   }
   if (data.portalId !== undefined && data.portalId !== null) {
-    contents.portalId = data.portalId;
+    contents.portalId = __expectString(data.portalId);
   }
   if (data.portalLastUpdateDate !== undefined && data.portalLastUpdateDate !== null) {
     contents.portalLastUpdateDate = new Date(Math.round(data.portalLastUpdateDate * 1000));
@@ -4973,16 +4976,16 @@ export const deserializeAws_restJson1DescribePortalCommand = async (
     contents.portalLogoImageLocation = deserializeAws_restJson1ImageLocation(data.portalLogoImageLocation, context);
   }
   if (data.portalName !== undefined && data.portalName !== null) {
-    contents.portalName = data.portalName;
+    contents.portalName = __expectString(data.portalName);
   }
   if (data.portalStartUrl !== undefined && data.portalStartUrl !== null) {
-    contents.portalStartUrl = data.portalStartUrl;
+    contents.portalStartUrl = __expectString(data.portalStartUrl);
   }
   if (data.portalStatus !== undefined && data.portalStatus !== null) {
     contents.portalStatus = deserializeAws_restJson1PortalStatus(data.portalStatus, context);
   }
   if (data.roleArn !== undefined && data.roleArn !== null) {
-    contents.roleArn = data.roleArn;
+    contents.roleArn = __expectString(data.roleArn);
   }
   return Promise.resolve(contents);
 };
@@ -5067,25 +5070,25 @@ export const deserializeAws_restJson1DescribeProjectCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.portalId !== undefined && data.portalId !== null) {
-    contents.portalId = data.portalId;
+    contents.portalId = __expectString(data.portalId);
   }
   if (data.projectArn !== undefined && data.projectArn !== null) {
-    contents.projectArn = data.projectArn;
+    contents.projectArn = __expectString(data.projectArn);
   }
   if (data.projectCreationDate !== undefined && data.projectCreationDate !== null) {
     contents.projectCreationDate = new Date(Math.round(data.projectCreationDate * 1000));
   }
   if (data.projectDescription !== undefined && data.projectDescription !== null) {
-    contents.projectDescription = data.projectDescription;
+    contents.projectDescription = __expectString(data.projectDescription);
   }
   if (data.projectId !== undefined && data.projectId !== null) {
-    contents.projectId = data.projectId;
+    contents.projectId = __expectString(data.projectId);
   }
   if (data.projectLastUpdateDate !== undefined && data.projectLastUpdateDate !== null) {
     contents.projectLastUpdateDate = new Date(Math.round(data.projectLastUpdateDate * 1000));
   }
   if (data.projectName !== undefined && data.projectName !== null) {
-    contents.projectName = data.projectName;
+    contents.projectName = __expectString(data.projectName);
   }
   return Promise.resolve(contents);
 };
@@ -5251,7 +5254,7 @@ export const deserializeAws_restJson1GetAssetPropertyAggregatesCommand = async (
     contents.aggregatedValues = deserializeAws_restJson1AggregatedValues(data.aggregatedValues, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -5432,7 +5435,7 @@ export const deserializeAws_restJson1GetAssetPropertyValueHistoryCommand = async
     );
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -5526,7 +5529,7 @@ export const deserializeAws_restJson1GetInterpolatedAssetPropertyValuesCommand =
     );
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -5617,7 +5620,7 @@ export const deserializeAws_restJson1ListAccessPoliciesCommand = async (
     contents.accessPolicySummaries = deserializeAws_restJson1AccessPolicySummaries(data.accessPolicySummaries, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -5692,7 +5695,7 @@ export const deserializeAws_restJson1ListAssetModelsCommand = async (
     contents.assetModelSummaries = deserializeAws_restJson1AssetModelSummaries(data.assetModelSummaries, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -5770,7 +5773,7 @@ export const deserializeAws_restJson1ListAssetRelationshipsCommand = async (
     );
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -5853,7 +5856,7 @@ export const deserializeAws_restJson1ListAssetsCommand = async (
     contents.assetSummaries = deserializeAws_restJson1AssetSummaries(data.assetSummaries, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -5936,7 +5939,7 @@ export const deserializeAws_restJson1ListAssociatedAssetsCommand = async (
     contents.assetSummaries = deserializeAws_restJson1AssociatedAssetsSummaries(data.assetSummaries, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -6019,7 +6022,7 @@ export const deserializeAws_restJson1ListDashboardsCommand = async (
     contents.dashboardSummaries = deserializeAws_restJson1DashboardSummaries(data.dashboardSummaries, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -6094,7 +6097,7 @@ export const deserializeAws_restJson1ListGatewaysCommand = async (
     contents.gatewaySummaries = deserializeAws_restJson1GatewaySummaries(data.gatewaySummaries, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -6166,7 +6169,7 @@ export const deserializeAws_restJson1ListPortalsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.portalSummaries !== undefined && data.portalSummaries !== null) {
     contents.portalSummaries = deserializeAws_restJson1PortalSummaries(data.portalSummaries, context);
@@ -6244,7 +6247,7 @@ export const deserializeAws_restJson1ListProjectAssetsCommand = async (
     contents.assetIds = deserializeAws_restJson1AssetIDs(data.assetIds, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -6316,7 +6319,7 @@ export const deserializeAws_restJson1ListProjectsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.projectSummaries !== undefined && data.projectSummaries !== null) {
     contents.projectSummaries = deserializeAws_restJson1ProjectSummaries(data.projectSummaries, context);
@@ -6498,10 +6501,10 @@ export const deserializeAws_restJson1PutDefaultEncryptionConfigurationCommand = 
     contents.configurationStatus = deserializeAws_restJson1ConfigurationStatus(data.configurationStatus, context);
   }
   if (data.encryptionType !== undefined && data.encryptionType !== null) {
-    contents.encryptionType = data.encryptionType;
+    contents.encryptionType = __expectString(data.encryptionType);
   }
   if (data.kmsKeyArn !== undefined && data.kmsKeyArn !== null) {
-    contents.kmsKeyArn = data.kmsKeyArn;
+    contents.kmsKeyArn = __expectString(data.kmsKeyArn);
   }
   return Promise.resolve(contents);
 };
@@ -7392,10 +7395,10 @@ export const deserializeAws_restJson1UpdateGatewayCapabilityConfigurationCommand
   };
   const data: any = await parseBody(output.body, context);
   if (data.capabilityNamespace !== undefined && data.capabilityNamespace !== null) {
-    contents.capabilityNamespace = data.capabilityNamespace;
+    contents.capabilityNamespace = __expectString(data.capabilityNamespace);
   }
   if (data.capabilitySyncStatus !== undefined && data.capabilitySyncStatus !== null) {
-    contents.capabilitySyncStatus = data.capabilitySyncStatus;
+    contents.capabilitySyncStatus = __expectString(data.capabilitySyncStatus);
   }
   return Promise.resolve(contents);
 };
@@ -7653,13 +7656,13 @@ const deserializeAws_restJson1ConflictingOperationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.resourceArn !== undefined && data.resourceArn !== null) {
-    contents.resourceArn = data.resourceArn;
+    contents.resourceArn = __expectString(data.resourceArn);
   }
   if (data.resourceId !== undefined && data.resourceId !== null) {
-    contents.resourceId = data.resourceId;
+    contents.resourceId = __expectString(data.resourceId);
   }
   return contents;
 };
@@ -7676,7 +7679,7 @@ const deserializeAws_restJson1InternalFailureExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -7693,7 +7696,7 @@ const deserializeAws_restJson1InvalidRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -7710,7 +7713,7 @@ const deserializeAws_restJson1LimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -7729,13 +7732,13 @@ const deserializeAws_restJson1ResourceAlreadyExistsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.resourceArn !== undefined && data.resourceArn !== null) {
-    contents.resourceArn = data.resourceArn;
+    contents.resourceArn = __expectString(data.resourceArn);
   }
   if (data.resourceId !== undefined && data.resourceId !== null) {
-    contents.resourceId = data.resourceId;
+    contents.resourceId = __expectString(data.resourceId);
   }
   return contents;
 };
@@ -7752,7 +7755,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -7769,7 +7772,7 @@ const deserializeAws_restJson1ServiceUnavailableExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -7786,7 +7789,7 @@ const deserializeAws_restJson1ThrottlingExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -7804,10 +7807,10 @@ const deserializeAws_restJson1TooManyTagsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.resourceName !== undefined && data.resourceName !== null) {
-    contents.resourceName = data.resourceName;
+    contents.resourceName = __expectString(data.resourceName);
   }
   return contents;
 };
@@ -7824,7 +7827,7 @@ const deserializeAws_restJson1UnauthorizedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -8270,7 +8273,7 @@ const deserializeAws_restJson1AccessPolicySummary = (output: any, context: __Ser
       output.creationDate !== undefined && output.creationDate !== null
         ? new Date(Math.round(output.creationDate * 1000))
         : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    id: __expectString(output.id),
     identity:
       output.identity !== undefined && output.identity !== null
         ? deserializeAws_restJson1Identity(output.identity, context)
@@ -8279,7 +8282,7 @@ const deserializeAws_restJson1AccessPolicySummary = (output: any, context: __Ser
       output.lastUpdateDate !== undefined && output.lastUpdateDate !== null
         ? new Date(Math.round(output.lastUpdateDate * 1000))
         : undefined,
-    permission: output.permission !== undefined && output.permission !== null ? output.permission : undefined,
+    permission: __expectString(output.permission),
     resource:
       output.resource !== undefined && output.resource !== null
         ? deserializeAws_restJson1Resource(output.resource, context)
@@ -8289,7 +8292,7 @@ const deserializeAws_restJson1AccessPolicySummary = (output: any, context: __Ser
 
 const deserializeAws_restJson1AggregatedValue = (output: any, context: __SerdeContext): AggregatedValue => {
   return {
-    quality: output.quality !== undefined && output.quality !== null ? output.quality : undefined,
+    quality: __expectString(output.quality),
     timestamp:
       output.timestamp !== undefined && output.timestamp !== null
         ? new Date(Math.round(output.timestamp * 1000))
@@ -8314,37 +8317,31 @@ const deserializeAws_restJson1AggregatedValues = (output: any, context: __SerdeC
 
 const deserializeAws_restJson1Aggregates = (output: any, context: __SerdeContext): Aggregates => {
   return {
-    average: output.average !== undefined && output.average !== null ? output.average : undefined,
-    count: output.count !== undefined && output.count !== null ? output.count : undefined,
-    maximum: output.maximum !== undefined && output.maximum !== null ? output.maximum : undefined,
-    minimum: output.minimum !== undefined && output.minimum !== null ? output.minimum : undefined,
-    standardDeviation:
-      output.standardDeviation !== undefined && output.standardDeviation !== null
-        ? output.standardDeviation
-        : undefined,
-    sum: output.sum !== undefined && output.sum !== null ? output.sum : undefined,
+    average: __expectNumber(output.average),
+    count: __expectNumber(output.count),
+    maximum: __expectNumber(output.maximum),
+    minimum: __expectNumber(output.minimum),
+    standardDeviation: __expectNumber(output.standardDeviation),
+    sum: __expectNumber(output.sum),
   } as any;
 };
 
 const deserializeAws_restJson1Alarms = (output: any, context: __SerdeContext): Alarms => {
   return {
-    alarmRoleArn: output.alarmRoleArn !== undefined && output.alarmRoleArn !== null ? output.alarmRoleArn : undefined,
-    notificationLambdaArn:
-      output.notificationLambdaArn !== undefined && output.notificationLambdaArn !== null
-        ? output.notificationLambdaArn
-        : undefined,
+    alarmRoleArn: __expectString(output.alarmRoleArn),
+    notificationLambdaArn: __expectString(output.notificationLambdaArn),
   } as any;
 };
 
 const deserializeAws_restJson1AssetCompositeModel = (output: any, context: __SerdeContext): AssetCompositeModel => {
   return {
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    description: __expectString(output.description),
+    name: __expectString(output.name),
     properties:
       output.properties !== undefined && output.properties !== null
         ? deserializeAws_restJson1AssetProperties(output.properties, context)
         : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -8361,9 +8358,9 @@ const deserializeAws_restJson1AssetCompositeModels = (output: any, context: __Se
 
 const deserializeAws_restJson1AssetErrorDetails = (output: any, context: __SerdeContext): AssetErrorDetails => {
   return {
-    assetId: output.assetId !== undefined && output.assetId !== null ? output.assetId : undefined,
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    assetId: __expectString(output.assetId),
+    code: __expectString(output.code),
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -8380,16 +8377,15 @@ const deserializeAws_restJson1AssetHierarchies = (output: any, context: __SerdeC
 
 const deserializeAws_restJson1AssetHierarchy = (output: any, context: __SerdeContext): AssetHierarchy => {
   return {
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    id: __expectString(output.id),
+    name: __expectString(output.name),
   } as any;
 };
 
 const deserializeAws_restJson1AssetHierarchyInfo = (output: any, context: __SerdeContext): AssetHierarchyInfo => {
   return {
-    childAssetId: output.childAssetId !== undefined && output.childAssetId !== null ? output.childAssetId : undefined,
-    parentAssetId:
-      output.parentAssetId !== undefined && output.parentAssetId !== null ? output.parentAssetId : undefined,
+    childAssetId: __expectString(output.childAssetId),
+    parentAssetId: __expectString(output.parentAssetId),
   } as any;
 };
 
@@ -8400,7 +8396,7 @@ const deserializeAws_restJson1AssetIDs = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -8409,13 +8405,13 @@ const deserializeAws_restJson1AssetModelCompositeModel = (
   context: __SerdeContext
 ): AssetModelCompositeModel => {
   return {
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    description: __expectString(output.description),
+    name: __expectString(output.name),
     properties:
       output.properties !== undefined && output.properties !== null
         ? deserializeAws_restJson1AssetModelProperties(output.properties, context)
         : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -8446,12 +8442,9 @@ const deserializeAws_restJson1AssetModelHierarchies = (output: any, context: __S
 
 const deserializeAws_restJson1AssetModelHierarchy = (output: any, context: __SerdeContext): AssetModelHierarchy => {
   return {
-    childAssetModelId:
-      output.childAssetModelId !== undefined && output.childAssetModelId !== null
-        ? output.childAssetModelId
-        : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    childAssetModelId: __expectString(output.childAssetModelId),
+    id: __expectString(output.id),
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -8468,15 +8461,15 @@ const deserializeAws_restJson1AssetModelProperties = (output: any, context: __Se
 
 const deserializeAws_restJson1AssetModelProperty = (output: any, context: __SerdeContext): AssetModelProperty => {
   return {
-    dataType: output.dataType !== undefined && output.dataType !== null ? output.dataType : undefined,
-    dataTypeSpec: output.dataTypeSpec !== undefined && output.dataTypeSpec !== null ? output.dataTypeSpec : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    dataType: __expectString(output.dataType),
+    dataTypeSpec: __expectString(output.dataTypeSpec),
+    id: __expectString(output.id),
+    name: __expectString(output.name),
     type:
       output.type !== undefined && output.type !== null
         ? deserializeAws_restJson1PropertyType(output.type, context)
         : undefined,
-    unit: output.unit !== undefined && output.unit !== null ? output.unit : undefined,
+    unit: __expectString(output.unit),
   } as any;
 };
 
@@ -8486,7 +8479,7 @@ const deserializeAws_restJson1AssetModelStatus = (output: any, context: __SerdeC
       output.error !== undefined && output.error !== null
         ? deserializeAws_restJson1ErrorDetails(output.error, context)
         : undefined,
-    state: output.state !== undefined && output.state !== null ? output.state : undefined,
+    state: __expectString(output.state),
   } as any;
 };
 
@@ -8503,18 +8496,18 @@ const deserializeAws_restJson1AssetModelSummaries = (output: any, context: __Ser
 
 const deserializeAws_restJson1AssetModelSummary = (output: any, context: __SerdeContext): AssetModelSummary => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
         ? new Date(Math.round(output.creationDate * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    description: __expectString(output.description),
+    id: __expectString(output.id),
     lastUpdateDate:
       output.lastUpdateDate !== undefined && output.lastUpdateDate !== null
         ? new Date(Math.round(output.lastUpdateDate * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
     status:
       output.status !== undefined && output.status !== null
         ? deserializeAws_restJson1AssetModelStatus(output.status, context)
@@ -8535,22 +8528,22 @@ const deserializeAws_restJson1AssetProperties = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1AssetProperty = (output: any, context: __SerdeContext): AssetProperty => {
   return {
-    alias: output.alias !== undefined && output.alias !== null ? output.alias : undefined,
-    dataType: output.dataType !== undefined && output.dataType !== null ? output.dataType : undefined,
-    dataTypeSpec: output.dataTypeSpec !== undefined && output.dataTypeSpec !== null ? output.dataTypeSpec : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    alias: __expectString(output.alias),
+    dataType: __expectString(output.dataType),
+    dataTypeSpec: __expectString(output.dataTypeSpec),
+    id: __expectString(output.id),
+    name: __expectString(output.name),
     notification:
       output.notification !== undefined && output.notification !== null
         ? deserializeAws_restJson1PropertyNotification(output.notification, context)
         : undefined,
-    unit: output.unit !== undefined && output.unit !== null ? output.unit : undefined,
+    unit: __expectString(output.unit),
   } as any;
 };
 
 const deserializeAws_restJson1AssetPropertyValue = (output: any, context: __SerdeContext): AssetPropertyValue => {
   return {
-    quality: output.quality !== undefined && output.quality !== null ? output.quality : undefined,
+    quality: __expectString(output.quality),
     timestamp:
       output.timestamp !== undefined && output.timestamp !== null
         ? deserializeAws_restJson1TimeInNanos(output.timestamp, context)
@@ -8599,8 +8592,7 @@ const deserializeAws_restJson1AssetRelationshipSummary = (
       output.hierarchyInfo !== undefined && output.hierarchyInfo !== null
         ? deserializeAws_restJson1AssetHierarchyInfo(output.hierarchyInfo, context)
         : undefined,
-    relationshipType:
-      output.relationshipType !== undefined && output.relationshipType !== null ? output.relationshipType : undefined,
+    relationshipType: __expectString(output.relationshipType),
   } as any;
 };
 
@@ -8610,7 +8602,7 @@ const deserializeAws_restJson1AssetStatus = (output: any, context: __SerdeContex
       output.error !== undefined && output.error !== null
         ? deserializeAws_restJson1ErrorDetails(output.error, context)
         : undefined,
-    state: output.state !== undefined && output.state !== null ? output.state : undefined,
+    state: __expectString(output.state),
   } as any;
 };
 
@@ -8627,8 +8619,8 @@ const deserializeAws_restJson1AssetSummaries = (output: any, context: __SerdeCon
 
 const deserializeAws_restJson1AssetSummary = (output: any, context: __SerdeContext): AssetSummary => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    assetModelId: output.assetModelId !== undefined && output.assetModelId !== null ? output.assetModelId : undefined,
+    arn: __expectString(output.arn),
+    assetModelId: __expectString(output.assetModelId),
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
         ? new Date(Math.round(output.creationDate * 1000))
@@ -8637,12 +8629,12 @@ const deserializeAws_restJson1AssetSummary = (output: any, context: __SerdeConte
       output.hierarchies !== undefined && output.hierarchies !== null
         ? deserializeAws_restJson1AssetHierarchies(output.hierarchies, context)
         : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    id: __expectString(output.id),
     lastUpdateDate:
       output.lastUpdateDate !== undefined && output.lastUpdateDate !== null
         ? new Date(Math.round(output.lastUpdateDate * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
     status:
       output.status !== undefined && output.status !== null
         ? deserializeAws_restJson1AssetStatus(output.status, context)
@@ -8669,8 +8661,8 @@ const deserializeAws_restJson1AssociatedAssetsSummary = (
   context: __SerdeContext
 ): AssociatedAssetsSummary => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    assetModelId: output.assetModelId !== undefined && output.assetModelId !== null ? output.assetModelId : undefined,
+    arn: __expectString(output.arn),
+    assetModelId: __expectString(output.assetModelId),
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
         ? new Date(Math.round(output.creationDate * 1000))
@@ -8679,12 +8671,12 @@ const deserializeAws_restJson1AssociatedAssetsSummary = (
       output.hierarchies !== undefined && output.hierarchies !== null
         ? deserializeAws_restJson1AssetHierarchies(output.hierarchies, context)
         : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    id: __expectString(output.id),
     lastUpdateDate:
       output.lastUpdateDate !== undefined && output.lastUpdateDate !== null
         ? new Date(Math.round(output.lastUpdateDate * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
     status:
       output.status !== undefined && output.status !== null
         ? deserializeAws_restJson1AssetStatus(output.status, context)
@@ -8694,7 +8686,7 @@ const deserializeAws_restJson1AssociatedAssetsSummary = (
 
 const deserializeAws_restJson1Attribute = (output: any, context: __SerdeContext): Attribute => {
   return {
-    defaultValue: output.defaultValue !== undefined && output.defaultValue !== null ? output.defaultValue : undefined,
+    defaultValue: __expectString(output.defaultValue),
   } as any;
 };
 
@@ -8731,8 +8723,8 @@ const deserializeAws_restJson1BatchPutAssetPropertyError = (
   context: __SerdeContext
 ): BatchPutAssetPropertyError => {
   return {
-    errorCode: output.errorCode !== undefined && output.errorCode !== null ? output.errorCode : undefined,
-    errorMessage: output.errorMessage !== undefined && output.errorMessage !== null ? output.errorMessage : undefined,
+    errorCode: __expectString(output.errorCode),
+    errorMessage: __expectString(output.errorMessage),
     timestamps:
       output.timestamps !== undefined && output.timestamps !== null
         ? deserializeAws_restJson1Timestamps(output.timestamps, context)
@@ -8759,7 +8751,7 @@ const deserializeAws_restJson1BatchPutAssetPropertyErrorEntry = (
   context: __SerdeContext
 ): BatchPutAssetPropertyErrorEntry => {
   return {
-    entryId: output.entryId !== undefined && output.entryId !== null ? output.entryId : undefined,
+    entryId: __expectString(output.entryId),
     errors:
       output.errors !== undefined && output.errors !== null
         ? deserializeAws_restJson1BatchPutAssetPropertyErrors(output.errors, context)
@@ -8790,8 +8782,8 @@ const deserializeAws_restJson1CompositeModelProperty = (
       output.assetProperty !== undefined && output.assetProperty !== null
         ? deserializeAws_restJson1Property(output.assetProperty, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    name: __expectString(output.name),
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -8800,8 +8792,8 @@ const deserializeAws_restJson1ConfigurationErrorDetails = (
   context: __SerdeContext
 ): ConfigurationErrorDetails => {
   return {
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    code: __expectString(output.code),
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -8811,7 +8803,7 @@ const deserializeAws_restJson1ConfigurationStatus = (output: any, context: __Ser
       output.error !== undefined && output.error !== null
         ? deserializeAws_restJson1ConfigurationErrorDetails(output.error, context)
         : undefined,
-    state: output.state !== undefined && output.state !== null ? output.state : undefined,
+    state: __expectString(output.state),
   } as any;
 };
 
@@ -8832,26 +8824,26 @@ const deserializeAws_restJson1DashboardSummary = (output: any, context: __SerdeC
       output.creationDate !== undefined && output.creationDate !== null
         ? new Date(Math.round(output.creationDate * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    description: __expectString(output.description),
+    id: __expectString(output.id),
     lastUpdateDate:
       output.lastUpdateDate !== undefined && output.lastUpdateDate !== null
         ? new Date(Math.round(output.lastUpdateDate * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
   } as any;
 };
 
 const deserializeAws_restJson1ErrorDetails = (output: any, context: __SerdeContext): ErrorDetails => {
   return {
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    code: __expectString(output.code),
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_restJson1ExpressionVariable = (output: any, context: __SerdeContext): ExpressionVariable => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
     value:
       output.value !== undefined && output.value !== null
         ? deserializeAws_restJson1VariableValue(output.value, context)
@@ -8889,14 +8881,8 @@ const deserializeAws_restJson1GatewayCapabilitySummary = (
   context: __SerdeContext
 ): GatewayCapabilitySummary => {
   return {
-    capabilityNamespace:
-      output.capabilityNamespace !== undefined && output.capabilityNamespace !== null
-        ? output.capabilityNamespace
-        : undefined,
-    capabilitySyncStatus:
-      output.capabilitySyncStatus !== undefined && output.capabilitySyncStatus !== null
-        ? output.capabilitySyncStatus
-        : undefined,
+    capabilityNamespace: __expectString(output.capabilityNamespace),
+    capabilitySyncStatus: __expectString(output.capabilitySyncStatus),
   } as any;
 };
 
@@ -8930,8 +8916,8 @@ const deserializeAws_restJson1GatewaySummary = (output: any, context: __SerdeCon
       output.gatewayCapabilitySummaries !== undefined && output.gatewayCapabilitySummaries !== null
         ? deserializeAws_restJson1GatewayCapabilitySummaries(output.gatewayCapabilitySummaries, context)
         : undefined,
-    gatewayId: output.gatewayId !== undefined && output.gatewayId !== null ? output.gatewayId : undefined,
-    gatewayName: output.gatewayName !== undefined && output.gatewayName !== null ? output.gatewayName : undefined,
+    gatewayId: __expectString(output.gatewayId),
+    gatewayName: __expectString(output.gatewayName),
     lastUpdateDate:
       output.lastUpdateDate !== undefined && output.lastUpdateDate !== null
         ? new Date(Math.round(output.lastUpdateDate * 1000))
@@ -8941,25 +8927,25 @@ const deserializeAws_restJson1GatewaySummary = (output: any, context: __SerdeCon
 
 const deserializeAws_restJson1Greengrass = (output: any, context: __SerdeContext): Greengrass => {
   return {
-    groupArn: output.groupArn !== undefined && output.groupArn !== null ? output.groupArn : undefined,
+    groupArn: __expectString(output.groupArn),
   } as any;
 };
 
 const deserializeAws_restJson1GroupIdentity = (output: any, context: __SerdeContext): GroupIdentity => {
   return {
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    id: __expectString(output.id),
   } as any;
 };
 
 const deserializeAws_restJson1IAMRoleIdentity = (output: any, context: __SerdeContext): IAMRoleIdentity => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
   } as any;
 };
 
 const deserializeAws_restJson1IAMUserIdentity = (output: any, context: __SerdeContext): IAMUserIdentity => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
   } as any;
 };
 
@@ -8986,8 +8972,8 @@ const deserializeAws_restJson1Identity = (output: any, context: __SerdeContext):
 
 const deserializeAws_restJson1ImageLocation = (output: any, context: __SerdeContext): ImageLocation => {
   return {
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    url: output.url !== undefined && output.url !== null ? output.url : undefined,
+    id: __expectString(output.id),
+    url: __expectString(output.url),
   } as any;
 };
 
@@ -9023,7 +9009,7 @@ const deserializeAws_restJson1InterpolatedAssetPropertyValues = (
 
 const deserializeAws_restJson1LoggingOptions = (output: any, context: __SerdeContext): LoggingOptions => {
   return {
-    level: output.level !== undefined && output.level !== null ? output.level : undefined,
+    level: __expectString(output.level),
   } as any;
 };
 
@@ -9033,7 +9019,7 @@ const deserializeAws_restJson1Measurement = (output: any, context: __SerdeContex
 
 const deserializeAws_restJson1Metric = (output: any, context: __SerdeContext): Metric => {
   return {
-    expression: output.expression !== undefined && output.expression !== null ? output.expression : undefined,
+    expression: __expectString(output.expression),
     variables:
       output.variables !== undefined && output.variables !== null
         ? deserializeAws_restJson1ExpressionVariables(output.variables, context)
@@ -9056,14 +9042,14 @@ const deserializeAws_restJson1MetricWindow = (output: any, context: __SerdeConte
 
 const deserializeAws_restJson1MonitorErrorDetails = (output: any, context: __SerdeContext): MonitorErrorDetails => {
   return {
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    code: __expectString(output.code),
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_restJson1PortalResource = (output: any, context: __SerdeContext): PortalResource => {
   return {
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    id: __expectString(output.id),
   } as any;
 };
 
@@ -9073,7 +9059,7 @@ const deserializeAws_restJson1PortalStatus = (output: any, context: __SerdeConte
       output.error !== undefined && output.error !== null
         ? deserializeAws_restJson1MonitorErrorDetails(output.error, context)
         : undefined,
-    state: output.state !== undefined && output.state !== null ? output.state : undefined,
+    state: __expectString(output.state),
   } as any;
 };
 
@@ -9094,15 +9080,15 @@ const deserializeAws_restJson1PortalSummary = (output: any, context: __SerdeCont
       output.creationDate !== undefined && output.creationDate !== null
         ? new Date(Math.round(output.creationDate * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    description: __expectString(output.description),
+    id: __expectString(output.id),
     lastUpdateDate:
       output.lastUpdateDate !== undefined && output.lastUpdateDate !== null
         ? new Date(Math.round(output.lastUpdateDate * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
-    startUrl: output.startUrl !== undefined && output.startUrl !== null ? output.startUrl : undefined,
+    name: __expectString(output.name),
+    roleArn: __expectString(output.roleArn),
+    startUrl: __expectString(output.startUrl),
     status:
       output.status !== undefined && output.status !== null
         ? deserializeAws_restJson1PortalStatus(output.status, context)
@@ -9112,7 +9098,7 @@ const deserializeAws_restJson1PortalSummary = (output: any, context: __SerdeCont
 
 const deserializeAws_restJson1ProjectResource = (output: any, context: __SerdeContext): ProjectResource => {
   return {
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    id: __expectString(output.id),
   } as any;
 };
 
@@ -9133,22 +9119,22 @@ const deserializeAws_restJson1ProjectSummary = (output: any, context: __SerdeCon
       output.creationDate !== undefined && output.creationDate !== null
         ? new Date(Math.round(output.creationDate * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    description: __expectString(output.description),
+    id: __expectString(output.id),
     lastUpdateDate:
       output.lastUpdateDate !== undefined && output.lastUpdateDate !== null
         ? new Date(Math.round(output.lastUpdateDate * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
   } as any;
 };
 
 const deserializeAws_restJson1Property = (output: any, context: __SerdeContext): Property => {
   return {
-    alias: output.alias !== undefined && output.alias !== null ? output.alias : undefined,
-    dataType: output.dataType !== undefined && output.dataType !== null ? output.dataType : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    alias: __expectString(output.alias),
+    dataType: __expectString(output.dataType),
+    id: __expectString(output.id),
+    name: __expectString(output.name),
     notification:
       output.notification !== undefined && output.notification !== null
         ? deserializeAws_restJson1PropertyNotification(output.notification, context)
@@ -9157,14 +9143,14 @@ const deserializeAws_restJson1Property = (output: any, context: __SerdeContext):
       output.type !== undefined && output.type !== null
         ? deserializeAws_restJson1PropertyType(output.type, context)
         : undefined,
-    unit: output.unit !== undefined && output.unit !== null ? output.unit : undefined,
+    unit: __expectString(output.unit),
   } as any;
 };
 
 const deserializeAws_restJson1PropertyNotification = (output: any, context: __SerdeContext): PropertyNotification => {
   return {
-    state: output.state !== undefined && output.state !== null ? output.state : undefined,
-    topic: output.topic !== undefined && output.topic !== null ? output.topic : undefined,
+    state: __expectString(output.state),
+    topic: __expectString(output.topic),
   } as any;
 };
 
@@ -9209,17 +9195,15 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1TimeInNanos = (output: any, context: __SerdeContext): TimeInNanos => {
   return {
-    offsetInNanos:
-      output.offsetInNanos !== undefined && output.offsetInNanos !== null ? output.offsetInNanos : undefined,
-    timeInSeconds:
-      output.timeInSeconds !== undefined && output.timeInSeconds !== null ? output.timeInSeconds : undefined,
+    offsetInNanos: __expectNumber(output.offsetInNanos),
+    timeInSeconds: __expectNumber(output.timeInSeconds),
   } as any;
 };
 
@@ -9236,7 +9220,7 @@ const deserializeAws_restJson1Timestamps = (output: any, context: __SerdeContext
 
 const deserializeAws_restJson1Transform = (output: any, context: __SerdeContext): Transform => {
   return {
-    expression: output.expression !== undefined && output.expression !== null ? output.expression : undefined,
+    expression: __expectString(output.expression),
     variables:
       output.variables !== undefined && output.variables !== null
         ? deserializeAws_restJson1ExpressionVariables(output.variables, context)
@@ -9246,29 +9230,29 @@ const deserializeAws_restJson1Transform = (output: any, context: __SerdeContext)
 
 const deserializeAws_restJson1TumblingWindow = (output: any, context: __SerdeContext): TumblingWindow => {
   return {
-    interval: output.interval !== undefined && output.interval !== null ? output.interval : undefined,
+    interval: __expectString(output.interval),
   } as any;
 };
 
 const deserializeAws_restJson1UserIdentity = (output: any, context: __SerdeContext): UserIdentity => {
   return {
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    id: __expectString(output.id),
   } as any;
 };
 
 const deserializeAws_restJson1VariableValue = (output: any, context: __SerdeContext): VariableValue => {
   return {
-    hierarchyId: output.hierarchyId !== undefined && output.hierarchyId !== null ? output.hierarchyId : undefined,
-    propertyId: output.propertyId !== undefined && output.propertyId !== null ? output.propertyId : undefined,
+    hierarchyId: __expectString(output.hierarchyId),
+    propertyId: __expectString(output.propertyId),
   } as any;
 };
 
 const deserializeAws_restJson1Variant = (output: any, context: __SerdeContext): Variant => {
   return {
-    booleanValue: output.booleanValue !== undefined && output.booleanValue !== null ? output.booleanValue : undefined,
-    doubleValue: output.doubleValue !== undefined && output.doubleValue !== null ? output.doubleValue : undefined,
-    integerValue: output.integerValue !== undefined && output.integerValue !== null ? output.integerValue : undefined,
-    stringValue: output.stringValue !== undefined && output.stringValue !== null ? output.stringValue : undefined,
+    booleanValue: __expectBoolean(output.booleanValue),
+    doubleValue: __expectNumber(output.doubleValue),
+    integerValue: __expectNumber(output.integerValue),
+    stringValue: __expectString(output.stringValue),
   } as any;
 };
 

--- a/clients/client-iotthingsgraph/protocols/Aws_json1_1.ts
+++ b/clients/client-iotthingsgraph/protocols/Aws_json1_1.ts
@@ -195,7 +195,12 @@ import {
   UploadEntityDefinitionsResponse,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -4063,8 +4068,8 @@ const deserializeAws_json1_1CreateSystemTemplateResponse = (
 
 const deserializeAws_json1_1DefinitionDocument = (output: any, context: __SerdeContext): DefinitionDocument => {
   return {
-    language: output.language !== undefined && output.language !== null ? output.language : undefined,
-    text: output.text !== undefined && output.text !== null ? output.text : undefined,
+    language: __expectString(output.language),
+    text: __expectString(output.text),
   } as any;
 };
 
@@ -4080,9 +4085,8 @@ const deserializeAws_json1_1DeleteNamespaceResponse = (
   context: __SerdeContext
 ): DeleteNamespaceResponse => {
   return {
-    namespaceArn: output.namespaceArn !== undefined && output.namespaceArn !== null ? output.namespaceArn : undefined,
-    namespaceName:
-      output.namespaceName !== undefined && output.namespaceName !== null ? output.namespaceName : undefined,
+    namespaceArn: __expectString(output.namespaceArn),
+    namespaceName: __expectString(output.namespaceName),
   } as any;
 };
 
@@ -4102,9 +4106,8 @@ const deserializeAws_json1_1DeleteSystemTemplateResponse = (
 
 const deserializeAws_json1_1DependencyRevision = (output: any, context: __SerdeContext): DependencyRevision => {
   return {
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    revisionNumber:
-      output.revisionNumber !== undefined && output.revisionNumber !== null ? output.revisionNumber : undefined,
+    id: __expectString(output.id),
+    revisionNumber: __expectNumber(output.revisionNumber),
   } as any;
 };
 
@@ -4124,10 +4127,7 @@ const deserializeAws_json1_1DeploySystemInstanceResponse = (
   context: __SerdeContext
 ): DeploySystemInstanceResponse => {
   return {
-    greengrassDeploymentId:
-      output.greengrassDeploymentId !== undefined && output.greengrassDeploymentId !== null
-        ? output.greengrassDeploymentId
-        : undefined,
+    greengrassDeploymentId: __expectString(output.greengrassDeploymentId),
     summary:
       output.summary !== undefined && output.summary !== null
         ? deserializeAws_json1_1SystemInstanceSummary(output.summary, context)
@@ -4154,19 +4154,11 @@ const deserializeAws_json1_1DescribeNamespaceResponse = (
   context: __SerdeContext
 ): DescribeNamespaceResponse => {
   return {
-    namespaceArn: output.namespaceArn !== undefined && output.namespaceArn !== null ? output.namespaceArn : undefined,
-    namespaceName:
-      output.namespaceName !== undefined && output.namespaceName !== null ? output.namespaceName : undefined,
-    namespaceVersion:
-      output.namespaceVersion !== undefined && output.namespaceVersion !== null ? output.namespaceVersion : undefined,
-    trackingNamespaceName:
-      output.trackingNamespaceName !== undefined && output.trackingNamespaceName !== null
-        ? output.trackingNamespaceName
-        : undefined,
-    trackingNamespaceVersion:
-      output.trackingNamespaceVersion !== undefined && output.trackingNamespaceVersion !== null
-        ? output.trackingNamespaceVersion
-        : undefined,
+    namespaceArn: __expectString(output.namespaceArn),
+    namespaceName: __expectString(output.namespaceName),
+    namespaceVersion: __expectNumber(output.namespaceVersion),
+    trackingNamespaceName: __expectString(output.trackingNamespaceName),
+    trackingNamespaceVersion: __expectNumber(output.trackingNamespaceVersion),
   } as any;
 };
 
@@ -4179,7 +4171,7 @@ const deserializeAws_json1_1DissociateEntityFromThingResponse = (
 
 const deserializeAws_json1_1EntityDescription = (output: any, context: __SerdeContext): EntityDescription => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
@@ -4188,8 +4180,8 @@ const deserializeAws_json1_1EntityDescription = (output: any, context: __SerdeCo
       output.definition !== undefined && output.definition !== null
         ? deserializeAws_json1_1DefinitionDocument(output.definition, context)
         : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    id: __expectString(output.id),
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -4206,9 +4198,9 @@ const deserializeAws_json1_1EntityDescriptions = (output: any, context: __SerdeC
 
 const deserializeAws_json1_1FlowExecutionMessage = (output: any, context: __SerdeContext): FlowExecutionMessage => {
   return {
-    eventType: output.eventType !== undefined && output.eventType !== null ? output.eventType : undefined,
-    messageId: output.messageId !== undefined && output.messageId !== null ? output.messageId : undefined,
-    payload: output.payload !== undefined && output.payload !== null ? output.payload : undefined,
+    eventType: __expectString(output.eventType),
+    messageId: __expectString(output.messageId),
+    payload: __expectString(output.payload),
     timestamp:
       output.timestamp !== undefined && output.timestamp !== null
         ? new Date(Math.round(output.timestamp * 1000))
@@ -4244,13 +4236,10 @@ const deserializeAws_json1_1FlowExecutionSummary = (output: any, context: __Serd
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    flowExecutionId:
-      output.flowExecutionId !== undefined && output.flowExecutionId !== null ? output.flowExecutionId : undefined,
-    flowTemplateId:
-      output.flowTemplateId !== undefined && output.flowTemplateId !== null ? output.flowTemplateId : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    systemInstanceId:
-      output.systemInstanceId !== undefined && output.systemInstanceId !== null ? output.systemInstanceId : undefined,
+    flowExecutionId: __expectString(output.flowExecutionId),
+    flowTemplateId: __expectString(output.flowTemplateId),
+    status: __expectString(output.status),
+    systemInstanceId: __expectString(output.systemInstanceId),
     updatedAt:
       output.updatedAt !== undefined && output.updatedAt !== null
         ? new Date(Math.round(output.updatedAt * 1000))
@@ -4271,10 +4260,7 @@ const deserializeAws_json1_1FlowTemplateDescription = (
       output.summary !== undefined && output.summary !== null
         ? deserializeAws_json1_1FlowTemplateSummary(output.summary, context)
         : undefined,
-    validatedNamespaceVersion:
-      output.validatedNamespaceVersion !== undefined && output.validatedNamespaceVersion !== null
-        ? output.validatedNamespaceVersion
-        : undefined,
+    validatedNamespaceVersion: __expectNumber(output.validatedNamespaceVersion),
   } as any;
 };
 
@@ -4291,14 +4277,13 @@ const deserializeAws_json1_1FlowTemplateSummaries = (output: any, context: __Ser
 
 const deserializeAws_json1_1FlowTemplateSummary = (output: any, context: __SerdeContext): FlowTemplateSummary => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    revisionNumber:
-      output.revisionNumber !== undefined && output.revisionNumber !== null ? output.revisionNumber : undefined,
+    id: __expectString(output.id),
+    revisionNumber: __expectNumber(output.revisionNumber),
   } as any;
 };
 
@@ -4328,7 +4313,7 @@ const deserializeAws_json1_1GetFlowTemplateRevisionsResponse = (
   context: __SerdeContext
 ): GetFlowTemplateRevisionsResponse => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     summaries:
       output.summaries !== undefined && output.summaries !== null
         ? deserializeAws_json1_1FlowTemplateSummaries(output.summaries, context)
@@ -4341,12 +4326,11 @@ const deserializeAws_json1_1GetNamespaceDeletionStatusResponse = (
   context: __SerdeContext
 ): GetNamespaceDeletionStatusResponse => {
   return {
-    errorCode: output.errorCode !== undefined && output.errorCode !== null ? output.errorCode : undefined,
-    errorMessage: output.errorMessage !== undefined && output.errorMessage !== null ? output.errorMessage : undefined,
-    namespaceArn: output.namespaceArn !== undefined && output.namespaceArn !== null ? output.namespaceArn : undefined,
-    namespaceName:
-      output.namespaceName !== undefined && output.namespaceName !== null ? output.namespaceName : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    errorCode: __expectString(output.errorCode),
+    errorMessage: __expectString(output.errorMessage),
+    namespaceArn: __expectString(output.namespaceArn),
+    namespaceName: __expectString(output.namespaceName),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -4379,7 +4363,7 @@ const deserializeAws_json1_1GetSystemTemplateRevisionsResponse = (
   context: __SerdeContext
 ): GetSystemTemplateRevisionsResponse => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     summaries:
       output.summaries !== undefined && output.summaries !== null
         ? deserializeAws_json1_1SystemTemplateSummaries(output.summaries, context)
@@ -4400,13 +4384,11 @@ const deserializeAws_json1_1GetUploadStatusResponse = (
       output.failureReason !== undefined && output.failureReason !== null
         ? deserializeAws_json1_1StringList(output.failureReason, context)
         : undefined,
-    namespaceArn: output.namespaceArn !== undefined && output.namespaceArn !== null ? output.namespaceArn : undefined,
-    namespaceName:
-      output.namespaceName !== undefined && output.namespaceName !== null ? output.namespaceName : undefined,
-    namespaceVersion:
-      output.namespaceVersion !== undefined && output.namespaceVersion !== null ? output.namespaceVersion : undefined,
-    uploadId: output.uploadId !== undefined && output.uploadId !== null ? output.uploadId : undefined,
-    uploadStatus: output.uploadStatus !== undefined && output.uploadStatus !== null ? output.uploadStatus : undefined,
+    namespaceArn: __expectString(output.namespaceArn),
+    namespaceName: __expectString(output.namespaceName),
+    namespaceVersion: __expectNumber(output.namespaceVersion),
+    uploadId: __expectString(output.uploadId),
+    uploadStatus: __expectString(output.uploadStatus),
   } as any;
 };
 
@@ -4415,7 +4397,7 @@ const deserializeAws_json1_1InternalFailureException = (
   context: __SerdeContext
 ): InternalFailureException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -4424,13 +4406,13 @@ const deserializeAws_json1_1InvalidRequestException = (
   context: __SerdeContext
 ): InvalidRequestException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -4443,7 +4425,7 @@ const deserializeAws_json1_1ListFlowExecutionMessagesResponse = (
       output.messages !== undefined && output.messages !== null
         ? deserializeAws_json1_1FlowExecutionMessages(output.messages, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -4452,7 +4434,7 @@ const deserializeAws_json1_1ListTagsForResourceResponse = (
   context: __SerdeContext
 ): ListTagsForResourceResponse => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_json1_1TagList(output.tags, context)
@@ -4462,14 +4444,8 @@ const deserializeAws_json1_1ListTagsForResourceResponse = (
 
 const deserializeAws_json1_1MetricsConfiguration = (output: any, context: __SerdeContext): MetricsConfiguration => {
   return {
-    cloudMetricEnabled:
-      output.cloudMetricEnabled !== undefined && output.cloudMetricEnabled !== null
-        ? output.cloudMetricEnabled
-        : undefined,
-    metricRuleRoleArn:
-      output.metricRuleRoleArn !== undefined && output.metricRuleRoleArn !== null
-        ? output.metricRuleRoleArn
-        : undefined,
+    cloudMetricEnabled: __expectBoolean(output.cloudMetricEnabled),
+    metricRuleRoleArn: __expectString(output.metricRuleRoleArn),
   } as any;
 };
 
@@ -4478,13 +4454,13 @@ const deserializeAws_json1_1ResourceAlreadyExistsException = (
   context: __SerdeContext
 ): ResourceAlreadyExistsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1ResourceInUseException = (output: any, context: __SerdeContext): ResourceInUseException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -4493,7 +4469,7 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -4503,7 +4479,7 @@ const deserializeAws_json1_1SearchEntitiesResponse = (output: any, context: __Se
       output.descriptions !== undefined && output.descriptions !== null
         ? deserializeAws_json1_1EntityDescriptions(output.descriptions, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -4512,7 +4488,7 @@ const deserializeAws_json1_1SearchFlowExecutionsResponse = (
   context: __SerdeContext
 ): SearchFlowExecutionsResponse => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     summaries:
       output.summaries !== undefined && output.summaries !== null
         ? deserializeAws_json1_1FlowExecutionSummaries(output.summaries, context)
@@ -4525,7 +4501,7 @@ const deserializeAws_json1_1SearchFlowTemplatesResponse = (
   context: __SerdeContext
 ): SearchFlowTemplatesResponse => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     summaries:
       output.summaries !== undefined && output.summaries !== null
         ? deserializeAws_json1_1FlowTemplateSummaries(output.summaries, context)
@@ -4538,7 +4514,7 @@ const deserializeAws_json1_1SearchSystemInstancesResponse = (
   context: __SerdeContext
 ): SearchSystemInstancesResponse => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     summaries:
       output.summaries !== undefined && output.summaries !== null
         ? deserializeAws_json1_1SystemInstanceSummaries(output.summaries, context)
@@ -4551,7 +4527,7 @@ const deserializeAws_json1_1SearchSystemTemplatesResponse = (
   context: __SerdeContext
 ): SearchSystemTemplatesResponse => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     summaries:
       output.summaries !== undefined && output.summaries !== null
         ? deserializeAws_json1_1SystemTemplateSummaries(output.summaries, context)
@@ -4561,7 +4537,7 @@ const deserializeAws_json1_1SearchSystemTemplatesResponse = (
 
 const deserializeAws_json1_1SearchThingsResponse = (output: any, context: __SerdeContext): SearchThingsResponse => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     things:
       output.things !== undefined && output.things !== null
         ? deserializeAws_json1_1Things(output.things, context)
@@ -4576,7 +4552,7 @@ const deserializeAws_json1_1StringList = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4589,15 +4565,12 @@ const deserializeAws_json1_1SystemInstanceDescription = (
       output.definition !== undefined && output.definition !== null
         ? deserializeAws_json1_1DefinitionDocument(output.definition, context)
         : undefined,
-    flowActionsRoleArn:
-      output.flowActionsRoleArn !== undefined && output.flowActionsRoleArn !== null
-        ? output.flowActionsRoleArn
-        : undefined,
+    flowActionsRoleArn: __expectString(output.flowActionsRoleArn),
     metricsConfiguration:
       output.metricsConfiguration !== undefined && output.metricsConfiguration !== null
         ? deserializeAws_json1_1MetricsConfiguration(output.metricsConfiguration, context)
         : undefined,
-    s3BucketName: output.s3BucketName !== undefined && output.s3BucketName !== null ? output.s3BucketName : undefined,
+    s3BucketName: __expectString(output.s3BucketName),
     summary:
       output.summary !== undefined && output.summary !== null
         ? deserializeAws_json1_1SystemInstanceSummary(output.summary, context)
@@ -4606,10 +4579,7 @@ const deserializeAws_json1_1SystemInstanceDescription = (
       output.validatedDependencyRevisions !== undefined && output.validatedDependencyRevisions !== null
         ? deserializeAws_json1_1DependencyRevisions(output.validatedDependencyRevisions, context)
         : undefined,
-    validatedNamespaceVersion:
-      output.validatedNamespaceVersion !== undefined && output.validatedNamespaceVersion !== null
-        ? output.validatedNamespaceVersion
-        : undefined,
+    validatedNamespaceVersion: __expectNumber(output.validatedNamespaceVersion),
   } as any;
 };
 
@@ -4629,26 +4599,17 @@ const deserializeAws_json1_1SystemInstanceSummaries = (
 
 const deserializeAws_json1_1SystemInstanceSummary = (output: any, context: __SerdeContext): SystemInstanceSummary => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    greengrassGroupId:
-      output.greengrassGroupId !== undefined && output.greengrassGroupId !== null
-        ? output.greengrassGroupId
-        : undefined,
-    greengrassGroupName:
-      output.greengrassGroupName !== undefined && output.greengrassGroupName !== null
-        ? output.greengrassGroupName
-        : undefined,
-    greengrassGroupVersionId:
-      output.greengrassGroupVersionId !== undefined && output.greengrassGroupVersionId !== null
-        ? output.greengrassGroupVersionId
-        : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    target: output.target !== undefined && output.target !== null ? output.target : undefined,
+    greengrassGroupId: __expectString(output.greengrassGroupId),
+    greengrassGroupName: __expectString(output.greengrassGroupName),
+    greengrassGroupVersionId: __expectString(output.greengrassGroupVersionId),
+    id: __expectString(output.id),
+    status: __expectString(output.status),
+    target: __expectString(output.target),
     updatedAt:
       output.updatedAt !== undefined && output.updatedAt !== null
         ? new Date(Math.round(output.updatedAt * 1000))
@@ -4669,10 +4630,7 @@ const deserializeAws_json1_1SystemTemplateDescription = (
       output.summary !== undefined && output.summary !== null
         ? deserializeAws_json1_1SystemTemplateSummary(output.summary, context)
         : undefined,
-    validatedNamespaceVersion:
-      output.validatedNamespaceVersion !== undefined && output.validatedNamespaceVersion !== null
-        ? output.validatedNamespaceVersion
-        : undefined,
+    validatedNamespaceVersion: __expectNumber(output.validatedNamespaceVersion),
   } as any;
 };
 
@@ -4692,21 +4650,20 @@ const deserializeAws_json1_1SystemTemplateSummaries = (
 
 const deserializeAws_json1_1SystemTemplateSummary = (output: any, context: __SerdeContext): SystemTemplateSummary => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    revisionNumber:
-      output.revisionNumber !== undefined && output.revisionNumber !== null ? output.revisionNumber : undefined,
+    id: __expectString(output.id),
+    revisionNumber: __expectNumber(output.revisionNumber),
   } as any;
 };
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    key: __expectString(output.key),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -4727,8 +4684,8 @@ const deserializeAws_json1_1TagResourceResponse = (output: any, context: __Serde
 
 const deserializeAws_json1_1Thing = (output: any, context: __SerdeContext): Thing => {
   return {
-    thingArn: output.thingArn !== undefined && output.thingArn !== null ? output.thingArn : undefined,
-    thingName: output.thingName !== undefined && output.thingName !== null ? output.thingName : undefined,
+    thingArn: __expectString(output.thingArn),
+    thingName: __expectString(output.thingName),
   } as any;
 };
 
@@ -4745,7 +4702,7 @@ const deserializeAws_json1_1Things = (output: any, context: __SerdeContext): Thi
 
 const deserializeAws_json1_1ThrottlingException = (output: any, context: __SerdeContext): ThrottlingException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -4794,7 +4751,7 @@ const deserializeAws_json1_1UploadEntityDefinitionsResponse = (
   context: __SerdeContext
 ): UploadEntityDefinitionsResponse => {
   return {
-    uploadId: output.uploadId !== undefined && output.uploadId !== null ? output.uploadId : undefined,
+    uploadId: __expectString(output.uploadId),
   } as any;
 };
 

--- a/clients/client-ivs/protocols/Aws_restJson1.ts
+++ b/clients/client-ivs/protocols/Aws_restJson1.ts
@@ -76,6 +76,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -1946,7 +1949,7 @@ export const deserializeAws_restJson1ListChannelsCommand = async (
     contents.channels = deserializeAws_restJson1ChannelList(data.channels, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2021,7 +2024,7 @@ export const deserializeAws_restJson1ListPlaybackKeyPairsCommand = async (
     contents.keyPairs = deserializeAws_restJson1PlaybackKeyPairList(data.keyPairs, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2085,7 +2088,7 @@ export const deserializeAws_restJson1ListRecordingConfigurationsCommand = async 
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.recordingConfigurations !== undefined && data.recordingConfigurations !== null) {
     contents.recordingConfigurations = deserializeAws_restJson1RecordingConfigurationList(
@@ -2163,7 +2166,7 @@ export const deserializeAws_restJson1ListStreamKeysCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.streamKeys !== undefined && data.streamKeys !== null) {
     contents.streamKeys = deserializeAws_restJson1StreamKeyList(data.streamKeys, context);
@@ -2238,7 +2241,7 @@ export const deserializeAws_restJson1ListStreamsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.streams !== undefined && data.streams !== null) {
     contents.streams = deserializeAws_restJson1StreamList(data.streams, context);
@@ -2297,7 +2300,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1Tags(data.tags, context);
@@ -2757,7 +2760,7 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.exceptionMessage !== undefined && data.exceptionMessage !== null) {
-    contents.exceptionMessage = data.exceptionMessage;
+    contents.exceptionMessage = __expectString(data.exceptionMessage);
   }
   return contents;
 };
@@ -2774,7 +2777,7 @@ const deserializeAws_restJson1ChannelNotBroadcastingResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.exceptionMessage !== undefined && data.exceptionMessage !== null) {
-    contents.exceptionMessage = data.exceptionMessage;
+    contents.exceptionMessage = __expectString(data.exceptionMessage);
   }
   return contents;
 };
@@ -2791,7 +2794,7 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.exceptionMessage !== undefined && data.exceptionMessage !== null) {
-    contents.exceptionMessage = data.exceptionMessage;
+    contents.exceptionMessage = __expectString(data.exceptionMessage);
   }
   return contents;
 };
@@ -2808,7 +2811,7 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.exceptionMessage !== undefined && data.exceptionMessage !== null) {
-    contents.exceptionMessage = data.exceptionMessage;
+    contents.exceptionMessage = __expectString(data.exceptionMessage);
   }
   return contents;
 };
@@ -2825,7 +2828,7 @@ const deserializeAws_restJson1PendingVerificationResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.exceptionMessage !== undefined && data.exceptionMessage !== null) {
-    contents.exceptionMessage = data.exceptionMessage;
+    contents.exceptionMessage = __expectString(data.exceptionMessage);
   }
   return contents;
 };
@@ -2842,7 +2845,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.exceptionMessage !== undefined && data.exceptionMessage !== null) {
-    contents.exceptionMessage = data.exceptionMessage;
+    contents.exceptionMessage = __expectString(data.exceptionMessage);
   }
   return contents;
 };
@@ -2859,7 +2862,7 @@ const deserializeAws_restJson1ServiceQuotaExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.exceptionMessage !== undefined && data.exceptionMessage !== null) {
-    contents.exceptionMessage = data.exceptionMessage;
+    contents.exceptionMessage = __expectString(data.exceptionMessage);
   }
   return contents;
 };
@@ -2876,7 +2879,7 @@ const deserializeAws_restJson1StreamUnavailableResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.exceptionMessage !== undefined && data.exceptionMessage !== null) {
-    contents.exceptionMessage = data.exceptionMessage;
+    contents.exceptionMessage = __expectString(data.exceptionMessage);
   }
   return contents;
 };
@@ -2893,7 +2896,7 @@ const deserializeAws_restJson1ThrottlingExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.exceptionMessage !== undefined && data.exceptionMessage !== null) {
-    contents.exceptionMessage = data.exceptionMessage;
+    contents.exceptionMessage = __expectString(data.exceptionMessage);
   }
   return contents;
 };
@@ -2910,7 +2913,7 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.exceptionMessage !== undefined && data.exceptionMessage !== null) {
-    contents.exceptionMessage = data.exceptionMessage;
+    contents.exceptionMessage = __expectString(data.exceptionMessage);
   }
   return contents;
 };
@@ -2970,9 +2973,9 @@ const serializeAws_restJson1Tags = (input: { [key: string]: string }, context: _
 
 const deserializeAws_restJson1BatchError = (output: any, context: __SerdeContext): BatchError => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    arn: __expectString(output.arn),
+    code: __expectString(output.code),
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -2989,22 +2992,18 @@ const deserializeAws_restJson1BatchErrors = (output: any, context: __SerdeContex
 
 const deserializeAws_restJson1Channel = (output: any, context: __SerdeContext): Channel => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    authorized: output.authorized !== undefined && output.authorized !== null ? output.authorized : undefined,
-    ingestEndpoint:
-      output.ingestEndpoint !== undefined && output.ingestEndpoint !== null ? output.ingestEndpoint : undefined,
-    latencyMode: output.latencyMode !== undefined && output.latencyMode !== null ? output.latencyMode : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    playbackUrl: output.playbackUrl !== undefined && output.playbackUrl !== null ? output.playbackUrl : undefined,
-    recordingConfigurationArn:
-      output.recordingConfigurationArn !== undefined && output.recordingConfigurationArn !== null
-        ? output.recordingConfigurationArn
-        : undefined,
+    arn: __expectString(output.arn),
+    authorized: __expectBoolean(output.authorized),
+    ingestEndpoint: __expectString(output.ingestEndpoint),
+    latencyMode: __expectString(output.latencyMode),
+    name: __expectString(output.name),
+    playbackUrl: __expectString(output.playbackUrl),
+    recordingConfigurationArn: __expectString(output.recordingConfigurationArn),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1Tags(output.tags, context)
         : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -3032,14 +3031,11 @@ const deserializeAws_restJson1Channels = (output: any, context: __SerdeContext):
 
 const deserializeAws_restJson1ChannelSummary = (output: any, context: __SerdeContext): ChannelSummary => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    authorized: output.authorized !== undefined && output.authorized !== null ? output.authorized : undefined,
-    latencyMode: output.latencyMode !== undefined && output.latencyMode !== null ? output.latencyMode : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    recordingConfigurationArn:
-      output.recordingConfigurationArn !== undefined && output.recordingConfigurationArn !== null
-        ? output.recordingConfigurationArn
-        : undefined,
+    arn: __expectString(output.arn),
+    authorized: __expectBoolean(output.authorized),
+    latencyMode: __expectString(output.latencyMode),
+    name: __expectString(output.name),
+    recordingConfigurationArn: __expectString(output.recordingConfigurationArn),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1Tags(output.tags, context)
@@ -3061,9 +3057,9 @@ const deserializeAws_restJson1DestinationConfiguration = (
 
 const deserializeAws_restJson1PlaybackKeyPair = (output: any, context: __SerdeContext): PlaybackKeyPair => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    fingerprint: output.fingerprint !== undefined && output.fingerprint !== null ? output.fingerprint : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    arn: __expectString(output.arn),
+    fingerprint: __expectString(output.fingerprint),
+    name: __expectString(output.name),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1Tags(output.tags, context)
@@ -3090,8 +3086,8 @@ const deserializeAws_restJson1PlaybackKeyPairSummary = (
   context: __SerdeContext
 ): PlaybackKeyPairSummary => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    arn: __expectString(output.arn),
+    name: __expectString(output.name),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1Tags(output.tags, context)
@@ -3104,13 +3100,13 @@ const deserializeAws_restJson1RecordingConfiguration = (
   context: __SerdeContext
 ): RecordingConfiguration => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     destinationConfiguration:
       output.destinationConfiguration !== undefined && output.destinationConfiguration !== null
         ? deserializeAws_restJson1DestinationConfiguration(output.destinationConfiguration, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    state: output.state !== undefined && output.state !== null ? output.state : undefined,
+    name: __expectString(output.name),
+    state: __expectString(output.state),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1Tags(output.tags, context)
@@ -3137,13 +3133,13 @@ const deserializeAws_restJson1RecordingConfigurationSummary = (
   context: __SerdeContext
 ): RecordingConfigurationSummary => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     destinationConfiguration:
       output.destinationConfiguration !== undefined && output.destinationConfiguration !== null
         ? deserializeAws_restJson1DestinationConfiguration(output.destinationConfiguration, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    state: output.state !== undefined && output.state !== null ? output.state : undefined,
+    name: __expectString(output.name),
+    state: __expectString(output.state),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1Tags(output.tags, context)
@@ -3156,30 +3152,30 @@ const deserializeAws_restJson1S3DestinationConfiguration = (
   context: __SerdeContext
 ): S3DestinationConfiguration => {
   return {
-    bucketName: output.bucketName !== undefined && output.bucketName !== null ? output.bucketName : undefined,
+    bucketName: __expectString(output.bucketName),
   } as any;
 };
 
 const deserializeAws_restJson1_Stream = (output: any, context: __SerdeContext): _Stream => {
   return {
-    channelArn: output.channelArn !== undefined && output.channelArn !== null ? output.channelArn : undefined,
-    health: output.health !== undefined && output.health !== null ? output.health : undefined,
-    playbackUrl: output.playbackUrl !== undefined && output.playbackUrl !== null ? output.playbackUrl : undefined,
+    channelArn: __expectString(output.channelArn),
+    health: __expectString(output.health),
+    playbackUrl: __expectString(output.playbackUrl),
     startTime: output.startTime !== undefined && output.startTime !== null ? new Date(output.startTime) : undefined,
-    state: output.state !== undefined && output.state !== null ? output.state : undefined,
-    viewerCount: output.viewerCount !== undefined && output.viewerCount !== null ? output.viewerCount : undefined,
+    state: __expectString(output.state),
+    viewerCount: __expectNumber(output.viewerCount),
   } as any;
 };
 
 const deserializeAws_restJson1StreamKey = (output: any, context: __SerdeContext): StreamKey => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    channelArn: output.channelArn !== undefined && output.channelArn !== null ? output.channelArn : undefined,
+    arn: __expectString(output.arn),
+    channelArn: __expectString(output.channelArn),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1Tags(output.tags, context)
         : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -3207,8 +3203,8 @@ const deserializeAws_restJson1StreamKeys = (output: any, context: __SerdeContext
 
 const deserializeAws_restJson1StreamKeySummary = (output: any, context: __SerdeContext): StreamKeySummary => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    channelArn: output.channelArn !== undefined && output.channelArn !== null ? output.channelArn : undefined,
+    arn: __expectString(output.arn),
+    channelArn: __expectString(output.channelArn),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1Tags(output.tags, context)
@@ -3229,11 +3225,11 @@ const deserializeAws_restJson1StreamList = (output: any, context: __SerdeContext
 
 const deserializeAws_restJson1StreamSummary = (output: any, context: __SerdeContext): StreamSummary => {
   return {
-    channelArn: output.channelArn !== undefined && output.channelArn !== null ? output.channelArn : undefined,
-    health: output.health !== undefined && output.health !== null ? output.health : undefined,
+    channelArn: __expectString(output.channelArn),
+    health: __expectString(output.health),
     startTime: output.startTime !== undefined && output.startTime !== null ? new Date(output.startTime) : undefined,
-    state: output.state !== undefined && output.state !== null ? output.state : undefined,
-    viewerCount: output.viewerCount !== undefined && output.viewerCount !== null ? output.viewerCount : undefined,
+    state: __expectString(output.state),
+    viewerCount: __expectNumber(output.viewerCount),
   } as any;
 };
 
@@ -3244,7 +3240,7 @@ const deserializeAws_restJson1Tags = (output: any, context: __SerdeContext): { [
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };

--- a/clients/client-kafka/protocols/Aws_restJson1.ts
+++ b/clients/client-kafka/protocols/Aws_restJson1.ts
@@ -131,6 +131,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -1143,7 +1146,7 @@ export const deserializeAws_restJson1BatchAssociateScramSecretCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.clusterArn !== undefined && data.clusterArn !== null) {
-    contents.ClusterArn = data.clusterArn;
+    contents.ClusterArn = __expectString(data.clusterArn);
   }
   if (data.unprocessedScramSecrets !== undefined && data.unprocessedScramSecrets !== null) {
     contents.UnprocessedScramSecrets = deserializeAws_restJson1__listOfUnprocessedScramSecret(
@@ -1253,7 +1256,7 @@ export const deserializeAws_restJson1BatchDisassociateScramSecretCommand = async
   };
   const data: any = await parseBody(output.body, context);
   if (data.clusterArn !== undefined && data.clusterArn !== null) {
-    contents.ClusterArn = data.clusterArn;
+    contents.ClusterArn = __expectString(data.clusterArn);
   }
   if (data.unprocessedScramSecrets !== undefined && data.unprocessedScramSecrets !== null) {
     contents.UnprocessedScramSecrets = deserializeAws_restJson1__listOfUnprocessedScramSecret(
@@ -1364,13 +1367,13 @@ export const deserializeAws_restJson1CreateClusterCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.clusterArn !== undefined && data.clusterArn !== null) {
-    contents.ClusterArn = data.clusterArn;
+    contents.ClusterArn = __expectString(data.clusterArn);
   }
   if (data.clusterName !== undefined && data.clusterName !== null) {
-    contents.ClusterName = data.clusterName;
+    contents.ClusterName = __expectString(data.clusterName);
   }
   if (data.state !== undefined && data.state !== null) {
-    contents.State = data.state;
+    contents.State = __expectString(data.state);
   }
   return Promise.resolve(contents);
 };
@@ -1477,7 +1480,7 @@ export const deserializeAws_restJson1CreateConfigurationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.Arn = data.arn;
+    contents.Arn = __expectString(data.arn);
   }
   if (data.creationTime !== undefined && data.creationTime !== null) {
     contents.CreationTime = new Date(data.creationTime);
@@ -1486,10 +1489,10 @@ export const deserializeAws_restJson1CreateConfigurationCommand = async (
     contents.LatestRevision = deserializeAws_restJson1ConfigurationRevision(data.latestRevision, context);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.Name = data.name;
+    contents.Name = __expectString(data.name);
   }
   if (data.state !== undefined && data.state !== null) {
-    contents.State = data.state;
+    contents.State = __expectString(data.state);
   }
   return Promise.resolve(contents);
 };
@@ -1593,10 +1596,10 @@ export const deserializeAws_restJson1DeleteClusterCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.clusterArn !== undefined && data.clusterArn !== null) {
-    contents.ClusterArn = data.clusterArn;
+    contents.ClusterArn = __expectString(data.clusterArn);
   }
   if (data.state !== undefined && data.state !== null) {
-    contents.State = data.state;
+    contents.State = __expectString(data.state);
   }
   return Promise.resolve(contents);
 };
@@ -1676,10 +1679,10 @@ export const deserializeAws_restJson1DeleteConfigurationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.Arn = data.arn;
+    contents.Arn = __expectString(data.arn);
   }
   if (data.state !== undefined && data.state !== null) {
-    contents.State = data.state;
+    contents.State = __expectString(data.state);
   }
   return Promise.resolve(contents);
 };
@@ -1938,13 +1941,13 @@ export const deserializeAws_restJson1DescribeConfigurationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.Arn = data.arn;
+    contents.Arn = __expectString(data.arn);
   }
   if (data.creationTime !== undefined && data.creationTime !== null) {
     contents.CreationTime = new Date(data.creationTime);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.Description = data.description;
+    contents.Description = __expectString(data.description);
   }
   if (data.kafkaVersions !== undefined && data.kafkaVersions !== null) {
     contents.KafkaVersions = deserializeAws_restJson1__listOf__string(data.kafkaVersions, context);
@@ -1953,10 +1956,10 @@ export const deserializeAws_restJson1DescribeConfigurationCommand = async (
     contents.LatestRevision = deserializeAws_restJson1ConfigurationRevision(data.latestRevision, context);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.Name = data.name;
+    contents.Name = __expectString(data.name);
   }
   if (data.state !== undefined && data.state !== null) {
-    contents.State = data.state;
+    contents.State = __expectString(data.state);
   }
   return Promise.resolve(contents);
 };
@@ -2055,16 +2058,16 @@ export const deserializeAws_restJson1DescribeConfigurationRevisionCommand = asyn
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.Arn = data.arn;
+    contents.Arn = __expectString(data.arn);
   }
   if (data.creationTime !== undefined && data.creationTime !== null) {
     contents.CreationTime = new Date(data.creationTime);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.Description = data.description;
+    contents.Description = __expectString(data.description);
   }
   if (data.revision !== undefined && data.revision !== null) {
-    contents.Revision = data.revision;
+    contents.Revision = __expectNumber(data.revision);
   }
   if (data.serverProperties !== undefined && data.serverProperties !== null) {
     contents.ServerProperties = context.base64Decoder(data.serverProperties);
@@ -2165,16 +2168,16 @@ export const deserializeAws_restJson1GetBootstrapBrokersCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.bootstrapBrokerString !== undefined && data.bootstrapBrokerString !== null) {
-    contents.BootstrapBrokerString = data.bootstrapBrokerString;
+    contents.BootstrapBrokerString = __expectString(data.bootstrapBrokerString);
   }
   if (data.bootstrapBrokerStringSaslIam !== undefined && data.bootstrapBrokerStringSaslIam !== null) {
-    contents.BootstrapBrokerStringSaslIam = data.bootstrapBrokerStringSaslIam;
+    contents.BootstrapBrokerStringSaslIam = __expectString(data.bootstrapBrokerStringSaslIam);
   }
   if (data.bootstrapBrokerStringSaslScram !== undefined && data.bootstrapBrokerStringSaslScram !== null) {
-    contents.BootstrapBrokerStringSaslScram = data.bootstrapBrokerStringSaslScram;
+    contents.BootstrapBrokerStringSaslScram = __expectString(data.bootstrapBrokerStringSaslScram);
   }
   if (data.bootstrapBrokerStringTls !== undefined && data.bootstrapBrokerStringTls !== null) {
-    contents.BootstrapBrokerStringTls = data.bootstrapBrokerStringTls;
+    contents.BootstrapBrokerStringTls = __expectString(data.bootstrapBrokerStringTls);
   }
   return Promise.resolve(contents);
 };
@@ -2374,7 +2377,7 @@ export const deserializeAws_restJson1ListClusterOperationsCommand = async (
     );
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2457,7 +2460,7 @@ export const deserializeAws_restJson1ListClustersCommand = async (
     contents.ClusterInfoList = deserializeAws_restJson1__listOfClusterInfo(data.clusterInfoList, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2537,7 +2540,7 @@ export const deserializeAws_restJson1ListConfigurationRevisionsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   if (data.revisions !== undefined && data.revisions !== null) {
     contents.Revisions = deserializeAws_restJson1__listOfConfigurationRevision(data.revisions, context);
@@ -2639,7 +2642,7 @@ export const deserializeAws_restJson1ListConfigurationsCommand = async (
     contents.Configurations = deserializeAws_restJson1__listOfConfiguration(data.configurations, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2730,7 +2733,7 @@ export const deserializeAws_restJson1ListKafkaVersionsCommand = async (
     contents.KafkaVersions = deserializeAws_restJson1__listOfKafkaVersion(data.kafkaVersions, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2810,7 +2813,7 @@ export const deserializeAws_restJson1ListNodesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   if (data.nodeInfoList !== undefined && data.nodeInfoList !== null) {
     contents.NodeInfoList = deserializeAws_restJson1__listOfNodeInfo(data.nodeInfoList, context);
@@ -2893,7 +2896,7 @@ export const deserializeAws_restJson1ListScramSecretsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   if (data.secretArnList !== undefined && data.secretArnList !== null) {
     contents.SecretArnList = deserializeAws_restJson1__listOf__string(data.secretArnList, context);
@@ -3071,10 +3074,10 @@ export const deserializeAws_restJson1RebootBrokerCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.clusterArn !== undefined && data.clusterArn !== null) {
-    contents.ClusterArn = data.clusterArn;
+    contents.ClusterArn = __expectString(data.clusterArn);
   }
   if (data.clusterOperationArn !== undefined && data.clusterOperationArn !== null) {
-    contents.ClusterOperationArn = data.clusterOperationArn;
+    contents.ClusterOperationArn = __expectString(data.clusterOperationArn);
   }
   return Promise.resolve(contents);
 };
@@ -3312,10 +3315,10 @@ export const deserializeAws_restJson1UpdateBrokerCountCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.clusterArn !== undefined && data.clusterArn !== null) {
-    contents.ClusterArn = data.clusterArn;
+    contents.ClusterArn = __expectString(data.clusterArn);
   }
   if (data.clusterOperationArn !== undefined && data.clusterOperationArn !== null) {
-    contents.ClusterOperationArn = data.clusterOperationArn;
+    contents.ClusterOperationArn = __expectString(data.clusterOperationArn);
   }
   return Promise.resolve(contents);
 };
@@ -3403,10 +3406,10 @@ export const deserializeAws_restJson1UpdateBrokerStorageCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.clusterArn !== undefined && data.clusterArn !== null) {
-    contents.ClusterArn = data.clusterArn;
+    contents.ClusterArn = __expectString(data.clusterArn);
   }
   if (data.clusterOperationArn !== undefined && data.clusterOperationArn !== null) {
-    contents.ClusterOperationArn = data.clusterOperationArn;
+    contents.ClusterOperationArn = __expectString(data.clusterOperationArn);
   }
   return Promise.resolve(contents);
 };
@@ -3494,10 +3497,10 @@ export const deserializeAws_restJson1UpdateBrokerTypeCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.clusterArn !== undefined && data.clusterArn !== null) {
-    contents.ClusterArn = data.clusterArn;
+    contents.ClusterArn = __expectString(data.clusterArn);
   }
   if (data.clusterOperationArn !== undefined && data.clusterOperationArn !== null) {
-    contents.ClusterOperationArn = data.clusterOperationArn;
+    contents.ClusterOperationArn = __expectString(data.clusterOperationArn);
   }
   return Promise.resolve(contents);
 };
@@ -3601,10 +3604,10 @@ export const deserializeAws_restJson1UpdateClusterConfigurationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.clusterArn !== undefined && data.clusterArn !== null) {
-    contents.ClusterArn = data.clusterArn;
+    contents.ClusterArn = __expectString(data.clusterArn);
   }
   if (data.clusterOperationArn !== undefined && data.clusterOperationArn !== null) {
-    contents.ClusterOperationArn = data.clusterOperationArn;
+    contents.ClusterOperationArn = __expectString(data.clusterOperationArn);
   }
   return Promise.resolve(contents);
 };
@@ -3700,10 +3703,10 @@ export const deserializeAws_restJson1UpdateClusterKafkaVersionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.clusterArn !== undefined && data.clusterArn !== null) {
-    contents.ClusterArn = data.clusterArn;
+    contents.ClusterArn = __expectString(data.clusterArn);
   }
   if (data.clusterOperationArn !== undefined && data.clusterOperationArn !== null) {
-    contents.ClusterOperationArn = data.clusterOperationArn;
+    contents.ClusterOperationArn = __expectString(data.clusterOperationArn);
   }
   return Promise.resolve(contents);
 };
@@ -3807,7 +3810,7 @@ export const deserializeAws_restJson1UpdateConfigurationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.Arn = data.arn;
+    contents.Arn = __expectString(data.arn);
   }
   if (data.latestRevision !== undefined && data.latestRevision !== null) {
     contents.LatestRevision = deserializeAws_restJson1ConfigurationRevision(data.latestRevision, context);
@@ -3906,10 +3909,10 @@ export const deserializeAws_restJson1UpdateMonitoringCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.clusterArn !== undefined && data.clusterArn !== null) {
-    contents.ClusterArn = data.clusterArn;
+    contents.ClusterArn = __expectString(data.clusterArn);
   }
   if (data.clusterOperationArn !== undefined && data.clusterOperationArn !== null) {
-    contents.ClusterOperationArn = data.clusterOperationArn;
+    contents.ClusterOperationArn = __expectString(data.clusterOperationArn);
   }
   return Promise.resolve(contents);
 };
@@ -3996,10 +3999,10 @@ const deserializeAws_restJson1BadRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.invalidParameter !== undefined && data.invalidParameter !== null) {
-    contents.InvalidParameter = data.invalidParameter;
+    contents.InvalidParameter = __expectString(data.invalidParameter);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -4017,10 +4020,10 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.invalidParameter !== undefined && data.invalidParameter !== null) {
-    contents.InvalidParameter = data.invalidParameter;
+    contents.InvalidParameter = __expectString(data.invalidParameter);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -4038,10 +4041,10 @@ const deserializeAws_restJson1ForbiddenExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.invalidParameter !== undefined && data.invalidParameter !== null) {
-    contents.InvalidParameter = data.invalidParameter;
+    contents.InvalidParameter = __expectString(data.invalidParameter);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -4059,10 +4062,10 @@ const deserializeAws_restJson1InternalServerErrorExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.invalidParameter !== undefined && data.invalidParameter !== null) {
-    contents.InvalidParameter = data.invalidParameter;
+    contents.InvalidParameter = __expectString(data.invalidParameter);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -4080,10 +4083,10 @@ const deserializeAws_restJson1NotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.invalidParameter !== undefined && data.invalidParameter !== null) {
-    contents.InvalidParameter = data.invalidParameter;
+    contents.InvalidParameter = __expectString(data.invalidParameter);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -4101,10 +4104,10 @@ const deserializeAws_restJson1ServiceUnavailableExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.invalidParameter !== undefined && data.invalidParameter !== null) {
-    contents.InvalidParameter = data.invalidParameter;
+    contents.InvalidParameter = __expectString(data.invalidParameter);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -4122,10 +4125,10 @@ const deserializeAws_restJson1TooManyRequestsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.invalidParameter !== undefined && data.invalidParameter !== null) {
-    contents.InvalidParameter = data.invalidParameter;
+    contents.InvalidParameter = __expectString(data.invalidParameter);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -4143,10 +4146,10 @@ const deserializeAws_restJson1UnauthorizedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.invalidParameter !== undefined && data.invalidParameter !== null) {
-    contents.InvalidParameter = data.invalidParameter;
+    contents.InvalidParameter = __expectString(data.invalidParameter);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -4380,7 +4383,7 @@ const deserializeAws_restJson1__listOf__string = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4519,18 +4522,15 @@ const deserializeAws_restJson1__mapOf__string = (output: any, context: __SerdeCo
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1BrokerEBSVolumeInfo = (output: any, context: __SerdeContext): BrokerEBSVolumeInfo => {
   return {
-    KafkaBrokerNodeId:
-      output.kafkaBrokerNodeId !== undefined && output.kafkaBrokerNodeId !== null
-        ? output.kafkaBrokerNodeId
-        : undefined,
-    VolumeSizeGB: output.volumeSizeGB !== undefined && output.volumeSizeGB !== null ? output.volumeSizeGB : undefined,
+    KafkaBrokerNodeId: __expectString(output.kafkaBrokerNodeId),
+    VolumeSizeGB: __expectNumber(output.volumeSizeGB),
   } as any;
 };
 
@@ -4550,15 +4550,12 @@ const deserializeAws_restJson1BrokerLogs = (output: any, context: __SerdeContext
 
 const deserializeAws_restJson1BrokerNodeGroupInfo = (output: any, context: __SerdeContext): BrokerNodeGroupInfo => {
   return {
-    BrokerAZDistribution:
-      output.brokerAZDistribution !== undefined && output.brokerAZDistribution !== null
-        ? output.brokerAZDistribution
-        : undefined,
+    BrokerAZDistribution: __expectString(output.brokerAZDistribution),
     ClientSubnets:
       output.clientSubnets !== undefined && output.clientSubnets !== null
         ? deserializeAws_restJson1__listOf__string(output.clientSubnets, context)
         : undefined,
-    InstanceType: output.instanceType !== undefined && output.instanceType !== null ? output.instanceType : undefined,
+    InstanceType: __expectString(output.instanceType),
     SecurityGroups:
       output.securityGroups !== undefined && output.securityGroups !== null
         ? deserializeAws_restJson1__listOf__string(output.securityGroups, context)
@@ -4572,14 +4569,10 @@ const deserializeAws_restJson1BrokerNodeGroupInfo = (output: any, context: __Ser
 
 const deserializeAws_restJson1BrokerNodeInfo = (output: any, context: __SerdeContext): BrokerNodeInfo => {
   return {
-    AttachedENIId:
-      output.attachedENIId !== undefined && output.attachedENIId !== null ? output.attachedENIId : undefined,
-    BrokerId: output.brokerId !== undefined && output.brokerId !== null ? output.brokerId : undefined,
-    ClientSubnet: output.clientSubnet !== undefined && output.clientSubnet !== null ? output.clientSubnet : undefined,
-    ClientVpcIpAddress:
-      output.clientVpcIpAddress !== undefined && output.clientVpcIpAddress !== null
-        ? output.clientVpcIpAddress
-        : undefined,
+    AttachedENIId: __expectString(output.attachedENIId),
+    BrokerId: __expectNumber(output.brokerId),
+    ClientSubnet: __expectString(output.clientSubnet),
+    ClientVpcIpAddress: __expectString(output.clientVpcIpAddress),
     CurrentBrokerSoftwareInfo:
       output.currentBrokerSoftwareInfo !== undefined && output.currentBrokerSoftwareInfo !== null
         ? deserializeAws_restJson1BrokerSoftwareInfo(output.currentBrokerSoftwareInfo, context)
@@ -4593,13 +4586,9 @@ const deserializeAws_restJson1BrokerNodeInfo = (output: any, context: __SerdeCon
 
 const deserializeAws_restJson1BrokerSoftwareInfo = (output: any, context: __SerdeContext): BrokerSoftwareInfo => {
   return {
-    ConfigurationArn:
-      output.configurationArn !== undefined && output.configurationArn !== null ? output.configurationArn : undefined,
-    ConfigurationRevision:
-      output.configurationRevision !== undefined && output.configurationRevision !== null
-        ? output.configurationRevision
-        : undefined,
-    KafkaVersion: output.kafkaVersion !== undefined && output.kafkaVersion !== null ? output.kafkaVersion : undefined,
+    ConfigurationArn: __expectString(output.configurationArn),
+    ConfigurationRevision: __expectNumber(output.configurationRevision),
+    KafkaVersion: __expectString(output.kafkaVersion),
   } as any;
 };
 
@@ -4615,17 +4604,14 @@ const deserializeAws_restJson1ClientAuthentication = (output: any, context: __Se
 
 const deserializeAws_restJson1CloudWatchLogs = (output: any, context: __SerdeContext): CloudWatchLogs => {
   return {
-    Enabled: output.enabled !== undefined && output.enabled !== null ? output.enabled : undefined,
-    LogGroup: output.logGroup !== undefined && output.logGroup !== null ? output.logGroup : undefined,
+    Enabled: __expectBoolean(output.enabled),
+    LogGroup: __expectString(output.logGroup),
   } as any;
 };
 
 const deserializeAws_restJson1ClusterInfo = (output: any, context: __SerdeContext): ClusterInfo => {
   return {
-    ActiveOperationArn:
-      output.activeOperationArn !== undefined && output.activeOperationArn !== null
-        ? output.activeOperationArn
-        : undefined,
+    ActiveOperationArn: __expectString(output.activeOperationArn),
     BrokerNodeGroupInfo:
       output.brokerNodeGroupInfo !== undefined && output.brokerNodeGroupInfo !== null
         ? deserializeAws_restJson1BrokerNodeGroupInfo(output.brokerNodeGroupInfo, context)
@@ -4634,37 +4620,30 @@ const deserializeAws_restJson1ClusterInfo = (output: any, context: __SerdeContex
       output.clientAuthentication !== undefined && output.clientAuthentication !== null
         ? deserializeAws_restJson1ClientAuthentication(output.clientAuthentication, context)
         : undefined,
-    ClusterArn: output.clusterArn !== undefined && output.clusterArn !== null ? output.clusterArn : undefined,
-    ClusterName: output.clusterName !== undefined && output.clusterName !== null ? output.clusterName : undefined,
+    ClusterArn: __expectString(output.clusterArn),
+    ClusterName: __expectString(output.clusterName),
     CreationTime:
       output.creationTime !== undefined && output.creationTime !== null ? new Date(output.creationTime) : undefined,
     CurrentBrokerSoftwareInfo:
       output.currentBrokerSoftwareInfo !== undefined && output.currentBrokerSoftwareInfo !== null
         ? deserializeAws_restJson1BrokerSoftwareInfo(output.currentBrokerSoftwareInfo, context)
         : undefined,
-    CurrentVersion:
-      output.currentVersion !== undefined && output.currentVersion !== null ? output.currentVersion : undefined,
+    CurrentVersion: __expectString(output.currentVersion),
     EncryptionInfo:
       output.encryptionInfo !== undefined && output.encryptionInfo !== null
         ? deserializeAws_restJson1EncryptionInfo(output.encryptionInfo, context)
         : undefined,
-    EnhancedMonitoring:
-      output.enhancedMonitoring !== undefined && output.enhancedMonitoring !== null
-        ? output.enhancedMonitoring
-        : undefined,
+    EnhancedMonitoring: __expectString(output.enhancedMonitoring),
     LoggingInfo:
       output.loggingInfo !== undefined && output.loggingInfo !== null
         ? deserializeAws_restJson1LoggingInfo(output.loggingInfo, context)
         : undefined,
-    NumberOfBrokerNodes:
-      output.numberOfBrokerNodes !== undefined && output.numberOfBrokerNodes !== null
-        ? output.numberOfBrokerNodes
-        : undefined,
+    NumberOfBrokerNodes: __expectNumber(output.numberOfBrokerNodes),
     OpenMonitoring:
       output.openMonitoring !== undefined && output.openMonitoring !== null
         ? deserializeAws_restJson1OpenMonitoring(output.openMonitoring, context)
         : undefined,
-    State: output.state !== undefined && output.state !== null ? output.state : undefined,
+    State: __expectString(output.state),
     StateInfo:
       output.stateInfo !== undefined && output.stateInfo !== null
         ? deserializeAws_restJson1StateInfo(output.stateInfo, context)
@@ -4673,22 +4652,15 @@ const deserializeAws_restJson1ClusterInfo = (output: any, context: __SerdeContex
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1__mapOf__string(output.tags, context)
         : undefined,
-    ZookeeperConnectString:
-      output.zookeeperConnectString !== undefined && output.zookeeperConnectString !== null
-        ? output.zookeeperConnectString
-        : undefined,
-    ZookeeperConnectStringTls:
-      output.zookeeperConnectStringTls !== undefined && output.zookeeperConnectStringTls !== null
-        ? output.zookeeperConnectStringTls
-        : undefined,
+    ZookeeperConnectString: __expectString(output.zookeeperConnectString),
+    ZookeeperConnectStringTls: __expectString(output.zookeeperConnectStringTls),
   } as any;
 };
 
 const deserializeAws_restJson1ClusterOperationInfo = (output: any, context: __SerdeContext): ClusterOperationInfo => {
   return {
-    ClientRequestId:
-      output.clientRequestId !== undefined && output.clientRequestId !== null ? output.clientRequestId : undefined,
-    ClusterArn: output.clusterArn !== undefined && output.clusterArn !== null ? output.clusterArn : undefined,
+    ClientRequestId: __expectString(output.clientRequestId),
+    ClusterArn: __expectString(output.clusterArn),
     CreationTime:
       output.creationTime !== undefined && output.creationTime !== null ? new Date(output.creationTime) : undefined,
     EndTime: output.endTime !== undefined && output.endTime !== null ? new Date(output.endTime) : undefined,
@@ -4696,15 +4668,13 @@ const deserializeAws_restJson1ClusterOperationInfo = (output: any, context: __Se
       output.errorInfo !== undefined && output.errorInfo !== null
         ? deserializeAws_restJson1ErrorInfo(output.errorInfo, context)
         : undefined,
-    OperationArn: output.operationArn !== undefined && output.operationArn !== null ? output.operationArn : undefined,
-    OperationState:
-      output.operationState !== undefined && output.operationState !== null ? output.operationState : undefined,
+    OperationArn: __expectString(output.operationArn),
+    OperationState: __expectString(output.operationState),
     OperationSteps:
       output.operationSteps !== undefined && output.operationSteps !== null
         ? deserializeAws_restJson1__listOfClusterOperationStep(output.operationSteps, context)
         : undefined,
-    OperationType:
-      output.operationType !== undefined && output.operationType !== null ? output.operationType : undefined,
+    OperationType: __expectString(output.operationType),
     SourceClusterInfo:
       output.sourceClusterInfo !== undefined && output.sourceClusterInfo !== null
         ? deserializeAws_restJson1MutableClusterInfo(output.sourceClusterInfo, context)
@@ -4722,7 +4692,7 @@ const deserializeAws_restJson1ClusterOperationStep = (output: any, context: __Se
       output.stepInfo !== undefined && output.stepInfo !== null
         ? deserializeAws_restJson1ClusterOperationStepInfo(output.stepInfo, context)
         : undefined,
-    StepName: output.stepName !== undefined && output.stepName !== null ? output.stepName : undefined,
+    StepName: __expectString(output.stepName),
   } as any;
 };
 
@@ -4731,7 +4701,7 @@ const deserializeAws_restJson1ClusterOperationStepInfo = (
   context: __SerdeContext
 ): ClusterOperationStepInfo => {
   return {
-    StepStatus: output.stepStatus !== undefined && output.stepStatus !== null ? output.stepStatus : undefined,
+    StepStatus: __expectString(output.stepStatus),
   } as any;
 };
 
@@ -4740,8 +4710,7 @@ const deserializeAws_restJson1CompatibleKafkaVersion = (
   context: __SerdeContext
 ): CompatibleKafkaVersion => {
   return {
-    SourceVersion:
-      output.sourceVersion !== undefined && output.sourceVersion !== null ? output.sourceVersion : undefined,
+    SourceVersion: __expectString(output.sourceVersion),
     TargetVersions:
       output.targetVersions !== undefined && output.targetVersions !== null
         ? deserializeAws_restJson1__listOf__string(output.targetVersions, context)
@@ -4751,10 +4720,10 @@ const deserializeAws_restJson1CompatibleKafkaVersion = (
 
 const deserializeAws_restJson1Configuration = (output: any, context: __SerdeContext): Configuration => {
   return {
-    Arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    Arn: __expectString(output.arn),
     CreationTime:
       output.creationTime !== undefined && output.creationTime !== null ? new Date(output.creationTime) : undefined,
-    Description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    Description: __expectString(output.description),
     KafkaVersions:
       output.kafkaVersions !== undefined && output.kafkaVersions !== null
         ? deserializeAws_restJson1__listOf__string(output.kafkaVersions, context)
@@ -4763,15 +4732,15 @@ const deserializeAws_restJson1Configuration = (output: any, context: __SerdeCont
       output.latestRevision !== undefined && output.latestRevision !== null
         ? deserializeAws_restJson1ConfigurationRevision(output.latestRevision, context)
         : undefined,
-    Name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    State: output.state !== undefined && output.state !== null ? output.state : undefined,
+    Name: __expectString(output.name),
+    State: __expectString(output.state),
   } as any;
 };
 
 const deserializeAws_restJson1ConfigurationInfo = (output: any, context: __SerdeContext): ConfigurationInfo => {
   return {
-    Arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    Revision: output.revision !== undefined && output.revision !== null ? output.revision : undefined,
+    Arn: __expectString(output.arn),
+    Revision: __expectNumber(output.revision),
   } as any;
 };
 
@@ -4779,23 +4748,20 @@ const deserializeAws_restJson1ConfigurationRevision = (output: any, context: __S
   return {
     CreationTime:
       output.creationTime !== undefined && output.creationTime !== null ? new Date(output.creationTime) : undefined,
-    Description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    Revision: output.revision !== undefined && output.revision !== null ? output.revision : undefined,
+    Description: __expectString(output.description),
+    Revision: __expectNumber(output.revision),
   } as any;
 };
 
 const deserializeAws_restJson1EBSStorageInfo = (output: any, context: __SerdeContext): EBSStorageInfo => {
   return {
-    VolumeSize: output.volumeSize !== undefined && output.volumeSize !== null ? output.volumeSize : undefined,
+    VolumeSize: __expectNumber(output.volumeSize),
   } as any;
 };
 
 const deserializeAws_restJson1EncryptionAtRest = (output: any, context: __SerdeContext): EncryptionAtRest => {
   return {
-    DataVolumeKMSKeyId:
-      output.dataVolumeKMSKeyId !== undefined && output.dataVolumeKMSKeyId !== null
-        ? output.dataVolumeKMSKeyId
-        : undefined,
+    DataVolumeKMSKeyId: __expectString(output.dataVolumeKMSKeyId),
   } as any;
 };
 
@@ -4814,43 +4780,41 @@ const deserializeAws_restJson1EncryptionInfo = (output: any, context: __SerdeCon
 
 const deserializeAws_restJson1EncryptionInTransit = (output: any, context: __SerdeContext): EncryptionInTransit => {
   return {
-    ClientBroker: output.clientBroker !== undefined && output.clientBroker !== null ? output.clientBroker : undefined,
-    InCluster: output.inCluster !== undefined && output.inCluster !== null ? output.inCluster : undefined,
+    ClientBroker: __expectString(output.clientBroker),
+    InCluster: __expectBoolean(output.inCluster),
   } as any;
 };
 
 const deserializeAws_restJson1ErrorInfo = (output: any, context: __SerdeContext): ErrorInfo => {
   return {
-    ErrorCode: output.errorCode !== undefined && output.errorCode !== null ? output.errorCode : undefined,
-    ErrorString: output.errorString !== undefined && output.errorString !== null ? output.errorString : undefined,
+    ErrorCode: __expectString(output.errorCode),
+    ErrorString: __expectString(output.errorString),
   } as any;
 };
 
 const deserializeAws_restJson1Firehose = (output: any, context: __SerdeContext): Firehose => {
   return {
-    DeliveryStream:
-      output.deliveryStream !== undefined && output.deliveryStream !== null ? output.deliveryStream : undefined,
-    Enabled: output.enabled !== undefined && output.enabled !== null ? output.enabled : undefined,
+    DeliveryStream: __expectString(output.deliveryStream),
+    Enabled: __expectBoolean(output.enabled),
   } as any;
 };
 
 const deserializeAws_restJson1Iam = (output: any, context: __SerdeContext): Iam => {
   return {
-    Enabled: output.enabled !== undefined && output.enabled !== null ? output.enabled : undefined,
+    Enabled: __expectBoolean(output.enabled),
   } as any;
 };
 
 const deserializeAws_restJson1JmxExporter = (output: any, context: __SerdeContext): JmxExporter => {
   return {
-    EnabledInBroker:
-      output.enabledInBroker !== undefined && output.enabledInBroker !== null ? output.enabledInBroker : undefined,
+    EnabledInBroker: __expectBoolean(output.enabledInBroker),
   } as any;
 };
 
 const deserializeAws_restJson1KafkaVersion = (output: any, context: __SerdeContext): KafkaVersion => {
   return {
-    Status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    Version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    Status: __expectString(output.status),
+    Version: __expectString(output.version),
   } as any;
 };
 
@@ -4873,20 +4837,14 @@ const deserializeAws_restJson1MutableClusterInfo = (output: any, context: __Serd
       output.configurationInfo !== undefined && output.configurationInfo !== null
         ? deserializeAws_restJson1ConfigurationInfo(output.configurationInfo, context)
         : undefined,
-    EnhancedMonitoring:
-      output.enhancedMonitoring !== undefined && output.enhancedMonitoring !== null
-        ? output.enhancedMonitoring
-        : undefined,
-    InstanceType: output.instanceType !== undefined && output.instanceType !== null ? output.instanceType : undefined,
-    KafkaVersion: output.kafkaVersion !== undefined && output.kafkaVersion !== null ? output.kafkaVersion : undefined,
+    EnhancedMonitoring: __expectString(output.enhancedMonitoring),
+    InstanceType: __expectString(output.instanceType),
+    KafkaVersion: __expectString(output.kafkaVersion),
     LoggingInfo:
       output.loggingInfo !== undefined && output.loggingInfo !== null
         ? deserializeAws_restJson1LoggingInfo(output.loggingInfo, context)
         : undefined,
-    NumberOfBrokerNodes:
-      output.numberOfBrokerNodes !== undefined && output.numberOfBrokerNodes !== null
-        ? output.numberOfBrokerNodes
-        : undefined,
+    NumberOfBrokerNodes: __expectNumber(output.numberOfBrokerNodes),
     OpenMonitoring:
       output.openMonitoring !== undefined && output.openMonitoring !== null
         ? deserializeAws_restJson1OpenMonitoring(output.openMonitoring, context)
@@ -4896,24 +4854,20 @@ const deserializeAws_restJson1MutableClusterInfo = (output: any, context: __Serd
 
 const deserializeAws_restJson1NodeExporter = (output: any, context: __SerdeContext): NodeExporter => {
   return {
-    EnabledInBroker:
-      output.enabledInBroker !== undefined && output.enabledInBroker !== null ? output.enabledInBroker : undefined,
+    EnabledInBroker: __expectBoolean(output.enabledInBroker),
   } as any;
 };
 
 const deserializeAws_restJson1NodeInfo = (output: any, context: __SerdeContext): NodeInfo => {
   return {
-    AddedToClusterTime:
-      output.addedToClusterTime !== undefined && output.addedToClusterTime !== null
-        ? output.addedToClusterTime
-        : undefined,
+    AddedToClusterTime: __expectString(output.addedToClusterTime),
     BrokerNodeInfo:
       output.brokerNodeInfo !== undefined && output.brokerNodeInfo !== null
         ? deserializeAws_restJson1BrokerNodeInfo(output.brokerNodeInfo, context)
         : undefined,
-    InstanceType: output.instanceType !== undefined && output.instanceType !== null ? output.instanceType : undefined,
-    NodeARN: output.nodeARN !== undefined && output.nodeARN !== null ? output.nodeARN : undefined,
-    NodeType: output.nodeType !== undefined && output.nodeType !== null ? output.nodeType : undefined,
+    InstanceType: __expectString(output.instanceType),
+    NodeARN: __expectString(output.nodeARN),
+    NodeType: __expectString(output.nodeType),
     ZookeeperNodeInfo:
       output.zookeeperNodeInfo !== undefined && output.zookeeperNodeInfo !== null
         ? deserializeAws_restJson1ZookeeperNodeInfo(output.zookeeperNodeInfo, context)
@@ -4945,9 +4899,9 @@ const deserializeAws_restJson1Prometheus = (output: any, context: __SerdeContext
 
 const deserializeAws_restJson1S3 = (output: any, context: __SerdeContext): S3 => {
   return {
-    Bucket: output.bucket !== undefined && output.bucket !== null ? output.bucket : undefined,
-    Enabled: output.enabled !== undefined && output.enabled !== null ? output.enabled : undefined,
-    Prefix: output.prefix !== undefined && output.prefix !== null ? output.prefix : undefined,
+    Bucket: __expectString(output.bucket),
+    Enabled: __expectBoolean(output.enabled),
+    Prefix: __expectString(output.prefix),
   } as any;
 };
 
@@ -4963,14 +4917,14 @@ const deserializeAws_restJson1Sasl = (output: any, context: __SerdeContext): Sas
 
 const deserializeAws_restJson1Scram = (output: any, context: __SerdeContext): Scram => {
   return {
-    Enabled: output.enabled !== undefined && output.enabled !== null ? output.enabled : undefined,
+    Enabled: __expectBoolean(output.enabled),
   } as any;
 };
 
 const deserializeAws_restJson1StateInfo = (output: any, context: __SerdeContext): StateInfo => {
   return {
-    Code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    Message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    Code: __expectString(output.code),
+    Message: __expectString(output.message),
   } as any;
 };
 
@@ -4997,27 +4951,22 @@ const deserializeAws_restJson1UnprocessedScramSecret = (
   context: __SerdeContext
 ): UnprocessedScramSecret => {
   return {
-    ErrorCode: output.errorCode !== undefined && output.errorCode !== null ? output.errorCode : undefined,
-    ErrorMessage: output.errorMessage !== undefined && output.errorMessage !== null ? output.errorMessage : undefined,
-    SecretArn: output.secretArn !== undefined && output.secretArn !== null ? output.secretArn : undefined,
+    ErrorCode: __expectString(output.errorCode),
+    ErrorMessage: __expectString(output.errorMessage),
+    SecretArn: __expectString(output.secretArn),
   } as any;
 };
 
 const deserializeAws_restJson1ZookeeperNodeInfo = (output: any, context: __SerdeContext): ZookeeperNodeInfo => {
   return {
-    AttachedENIId:
-      output.attachedENIId !== undefined && output.attachedENIId !== null ? output.attachedENIId : undefined,
-    ClientVpcIpAddress:
-      output.clientVpcIpAddress !== undefined && output.clientVpcIpAddress !== null
-        ? output.clientVpcIpAddress
-        : undefined,
+    AttachedENIId: __expectString(output.attachedENIId),
+    ClientVpcIpAddress: __expectString(output.clientVpcIpAddress),
     Endpoints:
       output.endpoints !== undefined && output.endpoints !== null
         ? deserializeAws_restJson1__listOf__string(output.endpoints, context)
         : undefined,
-    ZookeeperId: output.zookeeperId !== undefined && output.zookeeperId !== null ? output.zookeeperId : undefined,
-    ZookeeperVersion:
-      output.zookeeperVersion !== undefined && output.zookeeperVersion !== null ? output.zookeeperVersion : undefined,
+    ZookeeperId: __expectNumber(output.zookeeperId),
+    ZookeeperVersion: __expectString(output.zookeeperVersion),
   } as any;
 };
 

--- a/clients/client-kendra/protocols/Aws_json1_1.ts
+++ b/clients/client-kendra/protocols/Aws_json1_1.ts
@@ -253,7 +253,12 @@ import {
   WebCrawlerConfiguration,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -6560,22 +6565,19 @@ const deserializeAws_json1_1AccessControlListConfiguration = (
   context: __SerdeContext
 ): AccessControlListConfiguration => {
   return {
-    KeyPath: output.KeyPath !== undefined && output.KeyPath !== null ? output.KeyPath : undefined,
+    KeyPath: __expectString(output.KeyPath),
   } as any;
 };
 
 const deserializeAws_json1_1AccessDeniedException = (output: any, context: __SerdeContext): AccessDeniedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1AclConfiguration = (output: any, context: __SerdeContext): AclConfiguration => {
   return {
-    AllowedGroupsColumnName:
-      output.AllowedGroupsColumnName !== undefined && output.AllowedGroupsColumnName !== null
-        ? output.AllowedGroupsColumnName
-        : undefined,
+    AllowedGroupsColumnName: __expectString(output.AllowedGroupsColumnName),
   } as any;
 };
 
@@ -6584,12 +6586,12 @@ const deserializeAws_json1_1AdditionalResultAttribute = (
   context: __SerdeContext
 ): AdditionalResultAttribute => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
+    Key: __expectString(output.Key),
     Value:
       output.Value !== undefined && output.Value !== null
         ? deserializeAws_json1_1AdditionalResultAttributeValue(output.Value, context)
         : undefined,
-    ValueType: output.ValueType !== undefined && output.ValueType !== null ? output.ValueType : undefined,
+    ValueType: __expectString(output.ValueType),
   } as any;
 };
 
@@ -6636,9 +6638,9 @@ const deserializeAws_json1_1BasicAuthenticationConfiguration = (
   context: __SerdeContext
 ): BasicAuthenticationConfiguration => {
   return {
-    Credentials: output.Credentials !== undefined && output.Credentials !== null ? output.Credentials : undefined,
-    Host: output.Host !== undefined && output.Host !== null ? output.Host : undefined,
-    Port: output.Port !== undefined && output.Port !== null ? output.Port : undefined,
+    Credentials: __expectString(output.Credentials),
+    Host: __expectString(output.Host),
+    Port: __expectNumber(output.Port),
   } as any;
 };
 
@@ -6673,9 +6675,9 @@ const deserializeAws_json1_1BatchDeleteDocumentResponseFailedDocument = (
   context: __SerdeContext
 ): BatchDeleteDocumentResponseFailedDocument => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
+    Id: __expectString(output.Id),
   } as any;
 };
 
@@ -6714,9 +6716,9 @@ const deserializeAws_json1_1BatchGetDocumentStatusResponseError = (
   context: __SerdeContext
 ): BatchGetDocumentStatusResponseError => {
   return {
-    DocumentId: output.DocumentId !== undefined && output.DocumentId !== null ? output.DocumentId : undefined,
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
+    DocumentId: __expectString(output.DocumentId),
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
   } as any;
 };
 
@@ -6751,9 +6753,9 @@ const deserializeAws_json1_1BatchPutDocumentResponseFailedDocument = (
   context: __SerdeContext
 ): BatchPutDocumentResponseFailedDocument => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
+    Id: __expectString(output.Id),
   } as any;
 };
 
@@ -6776,14 +6778,8 @@ const deserializeAws_json1_1CapacityUnitsConfiguration = (
   context: __SerdeContext
 ): CapacityUnitsConfiguration => {
   return {
-    QueryCapacityUnits:
-      output.QueryCapacityUnits !== undefined && output.QueryCapacityUnits !== null
-        ? output.QueryCapacityUnits
-        : undefined,
-    StorageCapacityUnits:
-      output.StorageCapacityUnits !== undefined && output.StorageCapacityUnits !== null
-        ? output.StorageCapacityUnits
-        : undefined,
+    QueryCapacityUnits: __expectNumber(output.QueryCapacityUnits),
+    StorageCapacityUnits: __expectNumber(output.StorageCapacityUnits),
   } as any;
 };
 
@@ -6794,7 +6790,7 @@ const deserializeAws_json1_1ChangeDetectingColumns = (output: any, context: __Se
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6804,18 +6800,9 @@ const deserializeAws_json1_1ColumnConfiguration = (output: any, context: __Serde
       output.ChangeDetectingColumns !== undefined && output.ChangeDetectingColumns !== null
         ? deserializeAws_json1_1ChangeDetectingColumns(output.ChangeDetectingColumns, context)
         : undefined,
-    DocumentDataColumnName:
-      output.DocumentDataColumnName !== undefined && output.DocumentDataColumnName !== null
-        ? output.DocumentDataColumnName
-        : undefined,
-    DocumentIdColumnName:
-      output.DocumentIdColumnName !== undefined && output.DocumentIdColumnName !== null
-        ? output.DocumentIdColumnName
-        : undefined,
-    DocumentTitleColumnName:
-      output.DocumentTitleColumnName !== undefined && output.DocumentTitleColumnName !== null
-        ? output.DocumentTitleColumnName
-        : undefined,
+    DocumentDataColumnName: __expectString(output.DocumentDataColumnName),
+    DocumentIdColumnName: __expectString(output.DocumentIdColumnName),
+    DocumentTitleColumnName: __expectString(output.DocumentTitleColumnName),
     FieldMappings:
       output.FieldMappings !== undefined && output.FieldMappings !== null
         ? deserializeAws_json1_1DataSourceToIndexFieldMappingList(output.FieldMappings, context)
@@ -6825,7 +6812,7 @@ const deserializeAws_json1_1ColumnConfiguration = (output: any, context: __Serde
 
 const deserializeAws_json1_1ConflictException = (output: any, context: __SerdeContext): ConflictException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -6838,8 +6825,7 @@ const deserializeAws_json1_1ConfluenceAttachmentConfiguration = (
       output.AttachmentFieldMappings !== undefined && output.AttachmentFieldMappings !== null
         ? deserializeAws_json1_1ConfluenceAttachmentFieldMappingsList(output.AttachmentFieldMappings, context)
         : undefined,
-    CrawlAttachments:
-      output.CrawlAttachments !== undefined && output.CrawlAttachments !== null ? output.CrawlAttachments : undefined,
+    CrawlAttachments: __expectBoolean(output.CrawlAttachments),
   } as any;
 };
 
@@ -6862,14 +6848,9 @@ const deserializeAws_json1_1ConfluenceAttachmentToIndexFieldMapping = (
   context: __SerdeContext
 ): ConfluenceAttachmentToIndexFieldMapping => {
   return {
-    DataSourceFieldName:
-      output.DataSourceFieldName !== undefined && output.DataSourceFieldName !== null
-        ? output.DataSourceFieldName
-        : undefined,
-    DateFieldFormat:
-      output.DateFieldFormat !== undefined && output.DateFieldFormat !== null ? output.DateFieldFormat : undefined,
-    IndexFieldName:
-      output.IndexFieldName !== undefined && output.IndexFieldName !== null ? output.IndexFieldName : undefined,
+    DataSourceFieldName: __expectString(output.DataSourceFieldName),
+    DateFieldFormat: __expectString(output.DateFieldFormat),
+    IndexFieldName: __expectString(output.IndexFieldName),
   } as any;
 };
 
@@ -6904,14 +6885,9 @@ const deserializeAws_json1_1ConfluenceBlogToIndexFieldMapping = (
   context: __SerdeContext
 ): ConfluenceBlogToIndexFieldMapping => {
   return {
-    DataSourceFieldName:
-      output.DataSourceFieldName !== undefined && output.DataSourceFieldName !== null
-        ? output.DataSourceFieldName
-        : undefined,
-    DateFieldFormat:
-      output.DateFieldFormat !== undefined && output.DateFieldFormat !== null ? output.DateFieldFormat : undefined,
-    IndexFieldName:
-      output.IndexFieldName !== undefined && output.IndexFieldName !== null ? output.IndexFieldName : undefined,
+    DataSourceFieldName: __expectString(output.DataSourceFieldName),
+    DateFieldFormat: __expectString(output.DateFieldFormat),
+    IndexFieldName: __expectString(output.IndexFieldName),
   } as any;
 };
 
@@ -6940,13 +6916,13 @@ const deserializeAws_json1_1ConfluenceConfiguration = (
       output.PageConfiguration !== undefined && output.PageConfiguration !== null
         ? deserializeAws_json1_1ConfluencePageConfiguration(output.PageConfiguration, context)
         : undefined,
-    SecretArn: output.SecretArn !== undefined && output.SecretArn !== null ? output.SecretArn : undefined,
-    ServerUrl: output.ServerUrl !== undefined && output.ServerUrl !== null ? output.ServerUrl : undefined,
+    SecretArn: __expectString(output.SecretArn),
+    ServerUrl: __expectString(output.ServerUrl),
     SpaceConfiguration:
       output.SpaceConfiguration !== undefined && output.SpaceConfiguration !== null
         ? deserializeAws_json1_1ConfluenceSpaceConfiguration(output.SpaceConfiguration, context)
         : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    Version: __expectString(output.Version),
     VpcConfiguration:
       output.VpcConfiguration !== undefined && output.VpcConfiguration !== null
         ? deserializeAws_json1_1DataSourceVpcConfiguration(output.VpcConfiguration, context)
@@ -6985,14 +6961,9 @@ const deserializeAws_json1_1ConfluencePageToIndexFieldMapping = (
   context: __SerdeContext
 ): ConfluencePageToIndexFieldMapping => {
   return {
-    DataSourceFieldName:
-      output.DataSourceFieldName !== undefined && output.DataSourceFieldName !== null
-        ? output.DataSourceFieldName
-        : undefined,
-    DateFieldFormat:
-      output.DateFieldFormat !== undefined && output.DateFieldFormat !== null ? output.DateFieldFormat : undefined,
-    IndexFieldName:
-      output.IndexFieldName !== undefined && output.IndexFieldName !== null ? output.IndexFieldName : undefined,
+    DataSourceFieldName: __expectString(output.DataSourceFieldName),
+    DateFieldFormat: __expectString(output.DateFieldFormat),
+    IndexFieldName: __expectString(output.IndexFieldName),
   } as any;
 };
 
@@ -7001,14 +6972,8 @@ const deserializeAws_json1_1ConfluenceSpaceConfiguration = (
   context: __SerdeContext
 ): ConfluenceSpaceConfiguration => {
   return {
-    CrawlArchivedSpaces:
-      output.CrawlArchivedSpaces !== undefined && output.CrawlArchivedSpaces !== null
-        ? output.CrawlArchivedSpaces
-        : undefined,
-    CrawlPersonalSpaces:
-      output.CrawlPersonalSpaces !== undefined && output.CrawlPersonalSpaces !== null
-        ? output.CrawlPersonalSpaces
-        : undefined,
+    CrawlArchivedSpaces: __expectBoolean(output.CrawlArchivedSpaces),
+    CrawlPersonalSpaces: __expectBoolean(output.CrawlPersonalSpaces),
     ExcludeSpaces:
       output.ExcludeSpaces !== undefined && output.ExcludeSpaces !== null
         ? deserializeAws_json1_1ConfluenceSpaceList(output.ExcludeSpaces, context)
@@ -7045,7 +7010,7 @@ const deserializeAws_json1_1ConfluenceSpaceList = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7054,14 +7019,9 @@ const deserializeAws_json1_1ConfluenceSpaceToIndexFieldMapping = (
   context: __SerdeContext
 ): ConfluenceSpaceToIndexFieldMapping => {
   return {
-    DataSourceFieldName:
-      output.DataSourceFieldName !== undefined && output.DataSourceFieldName !== null
-        ? output.DataSourceFieldName
-        : undefined,
-    DateFieldFormat:
-      output.DateFieldFormat !== undefined && output.DateFieldFormat !== null ? output.DateFieldFormat : undefined,
-    IndexFieldName:
-      output.IndexFieldName !== undefined && output.IndexFieldName !== null ? output.IndexFieldName : undefined,
+    DataSourceFieldName: __expectString(output.DataSourceFieldName),
+    DateFieldFormat: __expectString(output.DateFieldFormat),
+    IndexFieldName: __expectString(output.IndexFieldName),
   } as any;
 };
 
@@ -7070,11 +7030,11 @@ const deserializeAws_json1_1ConnectionConfiguration = (
   context: __SerdeContext
 ): ConnectionConfiguration => {
   return {
-    DatabaseHost: output.DatabaseHost !== undefined && output.DatabaseHost !== null ? output.DatabaseHost : undefined,
-    DatabaseName: output.DatabaseName !== undefined && output.DatabaseName !== null ? output.DatabaseName : undefined,
-    DatabasePort: output.DatabasePort !== undefined && output.DatabasePort !== null ? output.DatabasePort : undefined,
-    SecretArn: output.SecretArn !== undefined && output.SecretArn !== null ? output.SecretArn : undefined,
-    TableName: output.TableName !== undefined && output.TableName !== null ? output.TableName : undefined,
+    DatabaseHost: __expectString(output.DatabaseHost),
+    DatabaseName: __expectString(output.DatabaseName),
+    DatabasePort: __expectNumber(output.DatabasePort),
+    SecretArn: __expectString(output.SecretArn),
+    TableName: __expectString(output.TableName),
   } as any;
 };
 
@@ -7083,19 +7043,19 @@ const deserializeAws_json1_1CreateDataSourceResponse = (
   context: __SerdeContext
 ): CreateDataSourceResponse => {
   return {
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    Id: __expectString(output.Id),
   } as any;
 };
 
 const deserializeAws_json1_1CreateFaqResponse = (output: any, context: __SerdeContext): CreateFaqResponse => {
   return {
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    Id: __expectString(output.Id),
   } as any;
 };
 
 const deserializeAws_json1_1CreateIndexResponse = (output: any, context: __SerdeContext): CreateIndexResponse => {
   return {
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    Id: __expectString(output.Id),
   } as any;
 };
 
@@ -7104,7 +7064,7 @@ const deserializeAws_json1_1CreateQuerySuggestionsBlockListResponse = (
   context: __SerdeContext
 ): CreateQuerySuggestionsBlockListResponse => {
   return {
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    Id: __expectString(output.Id),
   } as any;
 };
 
@@ -7113,7 +7073,7 @@ const deserializeAws_json1_1CreateThesaurusResponse = (
   context: __SerdeContext
 ): CreateThesaurusResponse => {
   return {
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    Id: __expectString(output.Id),
   } as any;
 };
 
@@ -7131,10 +7091,7 @@ const deserializeAws_json1_1DatabaseConfiguration = (output: any, context: __Ser
       output.ConnectionConfiguration !== undefined && output.ConnectionConfiguration !== null
         ? deserializeAws_json1_1ConnectionConfiguration(output.ConnectionConfiguration, context)
         : undefined,
-    DatabaseEngineType:
-      output.DatabaseEngineType !== undefined && output.DatabaseEngineType !== null
-        ? output.DatabaseEngineType
-        : undefined,
+    DatabaseEngineType: __expectString(output.DatabaseEngineType),
     SqlConfiguration:
       output.SqlConfiguration !== undefined && output.SqlConfiguration !== null
         ? deserializeAws_json1_1SqlConfiguration(output.SqlConfiguration, context)
@@ -7200,7 +7157,7 @@ const deserializeAws_json1_1DataSourceInclusionsExclusionsStrings = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7210,10 +7167,10 @@ const deserializeAws_json1_1DataSourceSummary = (output: any, context: __SerdeCo
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
+    Status: __expectString(output.Status),
+    Type: __expectString(output.Type),
     UpdatedAt:
       output.UpdatedAt !== undefined && output.UpdatedAt !== null
         ? new Date(Math.round(output.UpdatedAt * 1000))
@@ -7234,15 +7191,12 @@ const deserializeAws_json1_1DataSourceSummaryList = (output: any, context: __Ser
 
 const deserializeAws_json1_1DataSourceSyncJob = (output: any, context: __SerdeContext): DataSourceSyncJob => {
   return {
-    DataSourceErrorCode:
-      output.DataSourceErrorCode !== undefined && output.DataSourceErrorCode !== null
-        ? output.DataSourceErrorCode
-        : undefined,
+    DataSourceErrorCode: __expectString(output.DataSourceErrorCode),
     EndTime:
       output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    ExecutionId: output.ExecutionId !== undefined && output.ExecutionId !== null ? output.ExecutionId : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
+    ExecutionId: __expectString(output.ExecutionId),
     Metrics:
       output.Metrics !== undefined && output.Metrics !== null
         ? deserializeAws_json1_1DataSourceSyncJobMetrics(output.Metrics, context)
@@ -7251,7 +7205,7 @@ const deserializeAws_json1_1DataSourceSyncJob = (output: any, context: __SerdeCo
       output.StartTime !== undefined && output.StartTime !== null
         ? new Date(Math.round(output.StartTime * 1000))
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -7274,18 +7228,11 @@ const deserializeAws_json1_1DataSourceSyncJobMetrics = (
   context: __SerdeContext
 ): DataSourceSyncJobMetrics => {
   return {
-    DocumentsAdded:
-      output.DocumentsAdded !== undefined && output.DocumentsAdded !== null ? output.DocumentsAdded : undefined,
-    DocumentsDeleted:
-      output.DocumentsDeleted !== undefined && output.DocumentsDeleted !== null ? output.DocumentsDeleted : undefined,
-    DocumentsFailed:
-      output.DocumentsFailed !== undefined && output.DocumentsFailed !== null ? output.DocumentsFailed : undefined,
-    DocumentsModified:
-      output.DocumentsModified !== undefined && output.DocumentsModified !== null
-        ? output.DocumentsModified
-        : undefined,
-    DocumentsScanned:
-      output.DocumentsScanned !== undefined && output.DocumentsScanned !== null ? output.DocumentsScanned : undefined,
+    DocumentsAdded: __expectString(output.DocumentsAdded),
+    DocumentsDeleted: __expectString(output.DocumentsDeleted),
+    DocumentsFailed: __expectString(output.DocumentsFailed),
+    DocumentsModified: __expectString(output.DocumentsModified),
+    DocumentsScanned: __expectString(output.DocumentsScanned),
   } as any;
 };
 
@@ -7294,14 +7241,9 @@ const deserializeAws_json1_1DataSourceToIndexFieldMapping = (
   context: __SerdeContext
 ): DataSourceToIndexFieldMapping => {
   return {
-    DataSourceFieldName:
-      output.DataSourceFieldName !== undefined && output.DataSourceFieldName !== null
-        ? output.DataSourceFieldName
-        : undefined,
-    DateFieldFormat:
-      output.DateFieldFormat !== undefined && output.DateFieldFormat !== null ? output.DateFieldFormat : undefined,
-    IndexFieldName:
-      output.IndexFieldName !== undefined && output.IndexFieldName !== null ? output.IndexFieldName : undefined,
+    DataSourceFieldName: __expectString(output.DataSourceFieldName),
+    DateFieldFormat: __expectString(output.DateFieldFormat),
+    IndexFieldName: __expectString(output.IndexFieldName),
   } as any;
 };
 
@@ -7348,15 +7290,15 @@ const deserializeAws_json1_1DescribeDataSourceResponse = (
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    IndexId: output.IndexId !== undefined && output.IndexId !== null ? output.IndexId : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
-    Schedule: output.Schedule !== undefined && output.Schedule !== null ? output.Schedule : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Description: __expectString(output.Description),
+    ErrorMessage: __expectString(output.ErrorMessage),
+    Id: __expectString(output.Id),
+    IndexId: __expectString(output.IndexId),
+    Name: __expectString(output.Name),
+    RoleArn: __expectString(output.RoleArn),
+    Schedule: __expectString(output.Schedule),
+    Status: __expectString(output.Status),
+    Type: __expectString(output.Type),
     UpdatedAt:
       output.UpdatedAt !== undefined && output.UpdatedAt !== null
         ? new Date(Math.round(output.UpdatedAt * 1000))
@@ -7370,18 +7312,18 @@ const deserializeAws_json1_1DescribeFaqResponse = (output: any, context: __Serde
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    FileFormat: output.FileFormat !== undefined && output.FileFormat !== null ? output.FileFormat : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    IndexId: output.IndexId !== undefined && output.IndexId !== null ? output.IndexId : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
+    Description: __expectString(output.Description),
+    ErrorMessage: __expectString(output.ErrorMessage),
+    FileFormat: __expectString(output.FileFormat),
+    Id: __expectString(output.Id),
+    IndexId: __expectString(output.IndexId),
+    Name: __expectString(output.Name),
+    RoleArn: __expectString(output.RoleArn),
     S3Path:
       output.S3Path !== undefined && output.S3Path !== null
         ? deserializeAws_json1_1S3Path(output.S3Path, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
     UpdatedAt:
       output.UpdatedAt !== undefined && output.UpdatedAt !== null
         ? new Date(Math.round(output.UpdatedAt * 1000))
@@ -7399,33 +7341,30 @@ const deserializeAws_json1_1DescribeIndexResponse = (output: any, context: __Ser
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     DocumentMetadataConfigurations:
       output.DocumentMetadataConfigurations !== undefined && output.DocumentMetadataConfigurations !== null
         ? deserializeAws_json1_1DocumentMetadataConfigurationList(output.DocumentMetadataConfigurations, context)
         : undefined,
-    Edition: output.Edition !== undefined && output.Edition !== null ? output.Edition : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    Edition: __expectString(output.Edition),
+    ErrorMessage: __expectString(output.ErrorMessage),
+    Id: __expectString(output.Id),
     IndexStatistics:
       output.IndexStatistics !== undefined && output.IndexStatistics !== null
         ? deserializeAws_json1_1IndexStatistics(output.IndexStatistics, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
+    Name: __expectString(output.Name),
+    RoleArn: __expectString(output.RoleArn),
     ServerSideEncryptionConfiguration:
       output.ServerSideEncryptionConfiguration !== undefined && output.ServerSideEncryptionConfiguration !== null
         ? deserializeAws_json1_1ServerSideEncryptionConfiguration(output.ServerSideEncryptionConfiguration, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
     UpdatedAt:
       output.UpdatedAt !== undefined && output.UpdatedAt !== null
         ? new Date(Math.round(output.UpdatedAt * 1000))
         : undefined,
-    UserContextPolicy:
-      output.UserContextPolicy !== undefined && output.UserContextPolicy !== null
-        ? output.UserContextPolicy
-        : undefined,
+    UserContextPolicy: __expectString(output.UserContextPolicy),
     UserTokenConfigurations:
       output.UserTokenConfigurations !== undefined && output.UserTokenConfigurations !== null
         ? deserializeAws_json1_1UserTokenConfigurationList(output.UserTokenConfigurations, context)
@@ -7442,20 +7381,19 @@ const deserializeAws_json1_1DescribeQuerySuggestionsBlockListResponse = (
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    FileSizeBytes:
-      output.FileSizeBytes !== undefined && output.FileSizeBytes !== null ? output.FileSizeBytes : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    IndexId: output.IndexId !== undefined && output.IndexId !== null ? output.IndexId : undefined,
-    ItemCount: output.ItemCount !== undefined && output.ItemCount !== null ? output.ItemCount : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
+    Description: __expectString(output.Description),
+    ErrorMessage: __expectString(output.ErrorMessage),
+    FileSizeBytes: __expectNumber(output.FileSizeBytes),
+    Id: __expectString(output.Id),
+    IndexId: __expectString(output.IndexId),
+    ItemCount: __expectNumber(output.ItemCount),
+    Name: __expectString(output.Name),
+    RoleArn: __expectString(output.RoleArn),
     SourceS3Path:
       output.SourceS3Path !== undefined && output.SourceS3Path !== null
         ? deserializeAws_json1_1S3Path(output.SourceS3Path, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
     UpdatedAt:
       output.UpdatedAt !== undefined && output.UpdatedAt !== null
         ? new Date(Math.round(output.UpdatedAt * 1000))
@@ -7468,10 +7406,7 @@ const deserializeAws_json1_1DescribeQuerySuggestionsConfigResponse = (
   context: __SerdeContext
 ): DescribeQuerySuggestionsConfigResponse => {
   return {
-    IncludeQueriesWithoutUserInformation:
-      output.IncludeQueriesWithoutUserInformation !== undefined && output.IncludeQueriesWithoutUserInformation !== null
-        ? output.IncludeQueriesWithoutUserInformation
-        : undefined,
+    IncludeQueriesWithoutUserInformation: __expectBoolean(output.IncludeQueriesWithoutUserInformation),
     LastClearTime:
       output.LastClearTime !== undefined && output.LastClearTime !== null
         ? new Date(Math.round(output.LastClearTime * 1000))
@@ -7480,24 +7415,12 @@ const deserializeAws_json1_1DescribeQuerySuggestionsConfigResponse = (
       output.LastSuggestionsBuildTime !== undefined && output.LastSuggestionsBuildTime !== null
         ? new Date(Math.round(output.LastSuggestionsBuildTime * 1000))
         : undefined,
-    MinimumNumberOfQueryingUsers:
-      output.MinimumNumberOfQueryingUsers !== undefined && output.MinimumNumberOfQueryingUsers !== null
-        ? output.MinimumNumberOfQueryingUsers
-        : undefined,
-    MinimumQueryCount:
-      output.MinimumQueryCount !== undefined && output.MinimumQueryCount !== null
-        ? output.MinimumQueryCount
-        : undefined,
-    Mode: output.Mode !== undefined && output.Mode !== null ? output.Mode : undefined,
-    QueryLogLookBackWindowInDays:
-      output.QueryLogLookBackWindowInDays !== undefined && output.QueryLogLookBackWindowInDays !== null
-        ? output.QueryLogLookBackWindowInDays
-        : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    TotalSuggestionsCount:
-      output.TotalSuggestionsCount !== undefined && output.TotalSuggestionsCount !== null
-        ? output.TotalSuggestionsCount
-        : undefined,
+    MinimumNumberOfQueryingUsers: __expectNumber(output.MinimumNumberOfQueryingUsers),
+    MinimumQueryCount: __expectNumber(output.MinimumQueryCount),
+    Mode: __expectString(output.Mode),
+    QueryLogLookBackWindowInDays: __expectNumber(output.QueryLogLookBackWindowInDays),
+    Status: __expectString(output.Status),
+    TotalSuggestionsCount: __expectNumber(output.TotalSuggestionsCount),
   } as any;
 };
 
@@ -7510,22 +7433,20 @@ const deserializeAws_json1_1DescribeThesaurusResponse = (
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    FileSizeBytes:
-      output.FileSizeBytes !== undefined && output.FileSizeBytes !== null ? output.FileSizeBytes : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    IndexId: output.IndexId !== undefined && output.IndexId !== null ? output.IndexId : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
+    Description: __expectString(output.Description),
+    ErrorMessage: __expectString(output.ErrorMessage),
+    FileSizeBytes: __expectNumber(output.FileSizeBytes),
+    Id: __expectString(output.Id),
+    IndexId: __expectString(output.IndexId),
+    Name: __expectString(output.Name),
+    RoleArn: __expectString(output.RoleArn),
     SourceS3Path:
       output.SourceS3Path !== undefined && output.SourceS3Path !== null
         ? deserializeAws_json1_1S3Path(output.SourceS3Path, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    SynonymRuleCount:
-      output.SynonymRuleCount !== undefined && output.SynonymRuleCount !== null ? output.SynonymRuleCount : undefined,
-    TermCount: output.TermCount !== undefined && output.TermCount !== null ? output.TermCount : undefined,
+    Status: __expectString(output.Status),
+    SynonymRuleCount: __expectNumber(output.SynonymRuleCount),
+    TermCount: __expectNumber(output.TermCount),
     UpdatedAt:
       output.UpdatedAt !== undefined && output.UpdatedAt !== null
         ? new Date(Math.round(output.UpdatedAt * 1000))
@@ -7535,7 +7456,7 @@ const deserializeAws_json1_1DescribeThesaurusResponse = (
 
 const deserializeAws_json1_1DocumentAttribute = (output: any, context: __SerdeContext): DocumentAttribute => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
+    Key: __expectString(output.Key),
     Value:
       output.Value !== undefined && output.Value !== null
         ? deserializeAws_json1_1DocumentAttributeValue(output.Value, context)
@@ -7561,7 +7482,7 @@ const deserializeAws_json1_1DocumentAttributeStringListValue = (output: any, con
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7571,20 +7492,16 @@ const deserializeAws_json1_1DocumentAttributeValue = (output: any, context: __Se
       DateValue: new Date(Math.round(output.DateValue * 1000)),
     };
   }
-  if (output.LongValue !== undefined && output.LongValue !== null) {
-    return {
-      LongValue: output.LongValue,
-    };
+  if (__expectNumber(output.LongValue) !== undefined) {
+    return { LongValue: __expectNumber(output.LongValue) as any };
   }
   if (output.StringListValue !== undefined && output.StringListValue !== null) {
     return {
       StringListValue: deserializeAws_json1_1DocumentAttributeStringListValue(output.StringListValue, context),
     };
   }
-  if (output.StringValue !== undefined && output.StringValue !== null) {
-    return {
-      StringValue: output.StringValue,
-    };
+  if (__expectString(output.StringValue) !== undefined) {
+    return { StringValue: __expectString(output.StringValue) as any };
   }
   return { $unknown: Object.entries(output)[0] };
 };
@@ -7594,7 +7511,7 @@ const deserializeAws_json1_1DocumentAttributeValueCountPair = (
   context: __SerdeContext
 ): DocumentAttributeValueCountPair => {
   return {
-    Count: output.Count !== undefined && output.Count !== null ? output.Count : undefined,
+    Count: __expectNumber(output.Count),
     DocumentAttributeValue:
       output.DocumentAttributeValue !== undefined && output.DocumentAttributeValue !== null
         ? deserializeAws_json1_1DocumentAttributeValue(output.DocumentAttributeValue, context)
@@ -7621,7 +7538,7 @@ const deserializeAws_json1_1DocumentMetadataConfiguration = (
   context: __SerdeContext
 ): DocumentMetadataConfiguration => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     Relevance:
       output.Relevance !== undefined && output.Relevance !== null
         ? deserializeAws_json1_1Relevance(output.Relevance, context)
@@ -7630,7 +7547,7 @@ const deserializeAws_json1_1DocumentMetadataConfiguration = (
       output.Search !== undefined && output.Search !== null
         ? deserializeAws_json1_1Search(output.Search, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -7653,7 +7570,7 @@ const deserializeAws_json1_1DocumentsMetadataConfiguration = (
   context: __SerdeContext
 ): DocumentsMetadataConfiguration => {
   return {
-    S3Prefix: output.S3Prefix !== undefined && output.S3Prefix !== null ? output.S3Prefix : undefined,
+    S3Prefix: __expectString(output.S3Prefix),
   } as any;
 };
 
@@ -7675,7 +7592,7 @@ const deserializeAws_json1_1ExcludeMimeTypesList = (output: any, context: __Serd
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7686,7 +7603,7 @@ const deserializeAws_json1_1ExcludeSharedDrivesList = (output: any, context: __S
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7697,24 +7614,18 @@ const deserializeAws_json1_1ExcludeUserAccountsList = (output: any, context: __S
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1FacetResult = (output: any, context: __SerdeContext): FacetResult => {
   return {
-    DocumentAttributeKey:
-      output.DocumentAttributeKey !== undefined && output.DocumentAttributeKey !== null
-        ? output.DocumentAttributeKey
-        : undefined,
+    DocumentAttributeKey: __expectString(output.DocumentAttributeKey),
     DocumentAttributeValueCountPairs:
       output.DocumentAttributeValueCountPairs !== undefined && output.DocumentAttributeValueCountPairs !== null
         ? deserializeAws_json1_1DocumentAttributeValueCountPairList(output.DocumentAttributeValueCountPairs, context)
         : undefined,
-    DocumentAttributeValueType:
-      output.DocumentAttributeValueType !== undefined && output.DocumentAttributeValueType !== null
-        ? output.DocumentAttributeValueType
-        : undefined,
+    DocumentAttributeValueType: __expectString(output.DocumentAttributeValueType),
   } as any;
 };
 
@@ -7731,10 +7642,7 @@ const deserializeAws_json1_1FacetResultList = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_1FaqStatistics = (output: any, context: __SerdeContext): FaqStatistics => {
   return {
-    IndexedQuestionAnswersCount:
-      output.IndexedQuestionAnswersCount !== undefined && output.IndexedQuestionAnswersCount !== null
-        ? output.IndexedQuestionAnswersCount
-        : undefined,
+    IndexedQuestionAnswersCount: __expectNumber(output.IndexedQuestionAnswersCount),
   } as any;
 };
 
@@ -7744,10 +7652,10 @@ const deserializeAws_json1_1FaqSummary = (output: any, context: __SerdeContext):
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    FileFormat: output.FileFormat !== undefined && output.FileFormat !== null ? output.FileFormat : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    FileFormat: __expectString(output.FileFormat),
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
+    Status: __expectString(output.Status),
     UpdatedAt:
       output.UpdatedAt !== undefined && output.UpdatedAt !== null
         ? new Date(Math.round(output.UpdatedAt * 1000))
@@ -7771,10 +7679,7 @@ const deserializeAws_json1_1GetQuerySuggestionsResponse = (
   context: __SerdeContext
 ): GetQuerySuggestionsResponse => {
   return {
-    QuerySuggestionsId:
-      output.QuerySuggestionsId !== undefined && output.QuerySuggestionsId !== null
-        ? output.QuerySuggestionsId
-        : undefined,
+    QuerySuggestionsId: __expectString(output.QuerySuggestionsId),
     Suggestions:
       output.Suggestions !== undefined && output.Suggestions !== null
         ? deserializeAws_json1_1SuggestionList(output.Suggestions, context)
@@ -7811,16 +7716,16 @@ const deserializeAws_json1_1GoogleDriveConfiguration = (
       output.InclusionPatterns !== undefined && output.InclusionPatterns !== null
         ? deserializeAws_json1_1DataSourceInclusionsExclusionsStrings(output.InclusionPatterns, context)
         : undefined,
-    SecretArn: output.SecretArn !== undefined && output.SecretArn !== null ? output.SecretArn : undefined,
+    SecretArn: __expectString(output.SecretArn),
   } as any;
 };
 
 const deserializeAws_json1_1Highlight = (output: any, context: __SerdeContext): Highlight => {
   return {
-    BeginOffset: output.BeginOffset !== undefined && output.BeginOffset !== null ? output.BeginOffset : undefined,
-    EndOffset: output.EndOffset !== undefined && output.EndOffset !== null ? output.EndOffset : undefined,
-    TopAnswer: output.TopAnswer !== undefined && output.TopAnswer !== null ? output.TopAnswer : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    BeginOffset: __expectNumber(output.BeginOffset),
+    EndOffset: __expectNumber(output.EndOffset),
+    TopAnswer: __expectBoolean(output.TopAnswer),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -7844,10 +7749,10 @@ const deserializeAws_json1_1IndexConfigurationSummary = (
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    Edition: output.Edition !== undefined && output.Edition !== null ? output.Edition : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Edition: __expectString(output.Edition),
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
+    Status: __expectString(output.Status),
     UpdatedAt:
       output.UpdatedAt !== undefined && output.UpdatedAt !== null
         ? new Date(Math.round(output.UpdatedAt * 1000))
@@ -7887,7 +7792,7 @@ const deserializeAws_json1_1InternalServerException = (
   context: __SerdeContext
 ): InternalServerException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7896,14 +7801,8 @@ const deserializeAws_json1_1JsonTokenTypeConfiguration = (
   context: __SerdeContext
 ): JsonTokenTypeConfiguration => {
   return {
-    GroupAttributeField:
-      output.GroupAttributeField !== undefined && output.GroupAttributeField !== null
-        ? output.GroupAttributeField
-        : undefined,
-    UserNameAttributeField:
-      output.UserNameAttributeField !== undefined && output.UserNameAttributeField !== null
-        ? output.UserNameAttributeField
-        : undefined,
+    GroupAttributeField: __expectString(output.GroupAttributeField),
+    UserNameAttributeField: __expectString(output.UserNameAttributeField),
   } as any;
 };
 
@@ -7912,20 +7811,13 @@ const deserializeAws_json1_1JwtTokenTypeConfiguration = (
   context: __SerdeContext
 ): JwtTokenTypeConfiguration => {
   return {
-    ClaimRegex: output.ClaimRegex !== undefined && output.ClaimRegex !== null ? output.ClaimRegex : undefined,
-    GroupAttributeField:
-      output.GroupAttributeField !== undefined && output.GroupAttributeField !== null
-        ? output.GroupAttributeField
-        : undefined,
-    Issuer: output.Issuer !== undefined && output.Issuer !== null ? output.Issuer : undefined,
-    KeyLocation: output.KeyLocation !== undefined && output.KeyLocation !== null ? output.KeyLocation : undefined,
-    SecretManagerArn:
-      output.SecretManagerArn !== undefined && output.SecretManagerArn !== null ? output.SecretManagerArn : undefined,
-    URL: output.URL !== undefined && output.URL !== null ? output.URL : undefined,
-    UserNameAttributeField:
-      output.UserNameAttributeField !== undefined && output.UserNameAttributeField !== null
-        ? output.UserNameAttributeField
-        : undefined,
+    ClaimRegex: __expectString(output.ClaimRegex),
+    GroupAttributeField: __expectString(output.GroupAttributeField),
+    Issuer: __expectString(output.Issuer),
+    KeyLocation: __expectString(output.KeyLocation),
+    SecretManagerArn: __expectString(output.SecretManagerArn),
+    URL: __expectString(output.URL),
+    UserNameAttributeField: __expectString(output.UserNameAttributeField),
   } as any;
 };
 
@@ -7934,7 +7826,7 @@ const deserializeAws_json1_1ListDataSourcesResponse = (
   context: __SerdeContext
 ): ListDataSourcesResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     SummaryItems:
       output.SummaryItems !== undefined && output.SummaryItems !== null
         ? deserializeAws_json1_1DataSourceSummaryList(output.SummaryItems, context)
@@ -7951,7 +7843,7 @@ const deserializeAws_json1_1ListDataSourceSyncJobsResponse = (
       output.History !== undefined && output.History !== null
         ? deserializeAws_json1_1DataSourceSyncJobHistoryList(output.History, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -7961,7 +7853,7 @@ const deserializeAws_json1_1ListFaqsResponse = (output: any, context: __SerdeCon
       output.FaqSummaryItems !== undefined && output.FaqSummaryItems !== null
         ? deserializeAws_json1_1FaqSummaryItems(output.FaqSummaryItems, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -7971,7 +7863,7 @@ const deserializeAws_json1_1ListIndicesResponse = (output: any, context: __Serde
       output.IndexConfigurationSummaryItems !== undefined && output.IndexConfigurationSummaryItems !== null
         ? deserializeAws_json1_1IndexConfigurationSummaryList(output.IndexConfigurationSummaryItems, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -7984,7 +7876,7 @@ const deserializeAws_json1_1ListQuerySuggestionsBlockListsResponse = (
       output.BlockListSummaryItems !== undefined && output.BlockListSummaryItems !== null
         ? deserializeAws_json1_1QuerySuggestionsBlockListSummaryItems(output.BlockListSummaryItems, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -8002,7 +7894,7 @@ const deserializeAws_json1_1ListTagsForResourceResponse = (
 
 const deserializeAws_json1_1ListThesauriResponse = (output: any, context: __SerdeContext): ListThesauriResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     ThesaurusSummaryItems:
       output.ThesaurusSummaryItems !== undefined && output.ThesaurusSummaryItems !== null
         ? deserializeAws_json1_1ThesaurusSummaryItems(output.ThesaurusSummaryItems, context)
@@ -8012,10 +7904,7 @@ const deserializeAws_json1_1ListThesauriResponse = (output: any, context: __Serd
 
 const deserializeAws_json1_1OneDriveConfiguration = (output: any, context: __SerdeContext): OneDriveConfiguration => {
   return {
-    DisableLocalGroups:
-      output.DisableLocalGroups !== undefined && output.DisableLocalGroups !== null
-        ? output.DisableLocalGroups
-        : undefined,
+    DisableLocalGroups: __expectBoolean(output.DisableLocalGroups),
     ExclusionPatterns:
       output.ExclusionPatterns !== undefined && output.ExclusionPatterns !== null
         ? deserializeAws_json1_1DataSourceInclusionsExclusionsStrings(output.ExclusionPatterns, context)
@@ -8032,8 +7921,8 @@ const deserializeAws_json1_1OneDriveConfiguration = (output: any, context: __Ser
       output.OneDriveUsers !== undefined && output.OneDriveUsers !== null
         ? deserializeAws_json1_1OneDriveUsers(output.OneDriveUsers, context)
         : undefined,
-    SecretArn: output.SecretArn !== undefined && output.SecretArn !== null ? output.SecretArn : undefined,
-    TenantDomain: output.TenantDomain !== undefined && output.TenantDomain !== null ? output.TenantDomain : undefined,
+    SecretArn: __expectString(output.SecretArn),
+    TenantDomain: __expectString(output.TenantDomain),
   } as any;
 };
 
@@ -8044,7 +7933,7 @@ const deserializeAws_json1_1OneDriveUserList = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -8063,9 +7952,9 @@ const deserializeAws_json1_1OneDriveUsers = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1ProxyConfiguration = (output: any, context: __SerdeContext): ProxyConfiguration => {
   return {
-    Credentials: output.Credentials !== undefined && output.Credentials !== null ? output.Credentials : undefined,
-    Host: output.Host !== undefined && output.Host !== null ? output.Host : undefined,
-    Port: output.Port !== undefined && output.Port !== null ? output.Port : undefined,
+    Credentials: __expectString(output.Credentials),
+    Host: __expectString(output.Host),
+    Port: __expectNumber(output.Port),
   } as any;
 };
 
@@ -8075,15 +7964,12 @@ const deserializeAws_json1_1QueryResult = (output: any, context: __SerdeContext)
       output.FacetResults !== undefined && output.FacetResults !== null
         ? deserializeAws_json1_1FacetResultList(output.FacetResults, context)
         : undefined,
-    QueryId: output.QueryId !== undefined && output.QueryId !== null ? output.QueryId : undefined,
+    QueryId: __expectString(output.QueryId),
     ResultItems:
       output.ResultItems !== undefined && output.ResultItems !== null
         ? deserializeAws_json1_1QueryResultItemList(output.ResultItems, context)
         : undefined,
-    TotalNumberOfResults:
-      output.TotalNumberOfResults !== undefined && output.TotalNumberOfResults !== null
-        ? output.TotalNumberOfResults
-        : undefined,
+    TotalNumberOfResults: __expectNumber(output.TotalNumberOfResults),
   } as any;
 };
 
@@ -8101,20 +7987,19 @@ const deserializeAws_json1_1QueryResultItem = (output: any, context: __SerdeCont
       output.DocumentExcerpt !== undefined && output.DocumentExcerpt !== null
         ? deserializeAws_json1_1TextWithHighlights(output.DocumentExcerpt, context)
         : undefined,
-    DocumentId: output.DocumentId !== undefined && output.DocumentId !== null ? output.DocumentId : undefined,
+    DocumentId: __expectString(output.DocumentId),
     DocumentTitle:
       output.DocumentTitle !== undefined && output.DocumentTitle !== null
         ? deserializeAws_json1_1TextWithHighlights(output.DocumentTitle, context)
         : undefined,
-    DocumentURI: output.DocumentURI !== undefined && output.DocumentURI !== null ? output.DocumentURI : undefined,
-    FeedbackToken:
-      output.FeedbackToken !== undefined && output.FeedbackToken !== null ? output.FeedbackToken : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    DocumentURI: __expectString(output.DocumentURI),
+    FeedbackToken: __expectString(output.FeedbackToken),
+    Id: __expectString(output.Id),
     ScoreAttributes:
       output.ScoreAttributes !== undefined && output.ScoreAttributes !== null
         ? deserializeAws_json1_1ScoreAttributes(output.ScoreAttributes, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -8138,10 +8023,10 @@ const deserializeAws_json1_1QuerySuggestionsBlockListSummary = (
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    ItemCount: output.ItemCount !== undefined && output.ItemCount !== null ? output.ItemCount : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Id: __expectString(output.Id),
+    ItemCount: __expectNumber(output.ItemCount),
+    Name: __expectString(output.Name),
+    Status: __expectString(output.Status),
     UpdatedAt:
       output.UpdatedAt !== undefined && output.UpdatedAt !== null
         ? new Date(Math.round(output.UpdatedAt * 1000))
@@ -8165,10 +8050,10 @@ const deserializeAws_json1_1QuerySuggestionsBlockListSummaryItems = (
 
 const deserializeAws_json1_1Relevance = (output: any, context: __SerdeContext): Relevance => {
   return {
-    Duration: output.Duration !== undefined && output.Duration !== null ? output.Duration : undefined,
-    Freshness: output.Freshness !== undefined && output.Freshness !== null ? output.Freshness : undefined,
-    Importance: output.Importance !== undefined && output.Importance !== null ? output.Importance : undefined,
-    RankOrder: output.RankOrder !== undefined && output.RankOrder !== null ? output.RankOrder : undefined,
+    Duration: __expectString(output.Duration),
+    Freshness: __expectBoolean(output.Freshness),
+    Importance: __expectNumber(output.Importance),
+    RankOrder: __expectString(output.RankOrder),
     ValueImportanceMap:
       output.ValueImportanceMap !== undefined && output.ValueImportanceMap !== null
         ? deserializeAws_json1_1ValueImportanceMap(output.ValueImportanceMap, context)
@@ -8181,13 +8066,13 @@ const deserializeAws_json1_1ResourceAlreadyExistException = (
   context: __SerdeContext
 ): ResourceAlreadyExistException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1ResourceInUseException = (output: any, context: __SerdeContext): ResourceInUseException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -8196,7 +8081,7 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -8205,7 +8090,7 @@ const deserializeAws_json1_1ResourceUnavailableException = (
   context: __SerdeContext
 ): ResourceUnavailableException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -8218,7 +8103,7 @@ const deserializeAws_json1_1S3DataSourceConfiguration = (
       output.AccessControlListConfiguration !== undefined && output.AccessControlListConfiguration !== null
         ? deserializeAws_json1_1AccessControlListConfiguration(output.AccessControlListConfiguration, context)
         : undefined,
-    BucketName: output.BucketName !== undefined && output.BucketName !== null ? output.BucketName : undefined,
+    BucketName: __expectString(output.BucketName),
     DocumentsMetadataConfiguration:
       output.DocumentsMetadataConfiguration !== undefined && output.DocumentsMetadataConfiguration !== null
         ? deserializeAws_json1_1DocumentsMetadataConfiguration(output.DocumentsMetadataConfiguration, context)
@@ -8240,8 +8125,8 @@ const deserializeAws_json1_1S3DataSourceConfiguration = (
 
 const deserializeAws_json1_1S3Path = (output: any, context: __SerdeContext): S3Path => {
   return {
-    Bucket: output.Bucket !== undefined && output.Bucket !== null ? output.Bucket : undefined,
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
+    Bucket: __expectString(output.Bucket),
+    Key: __expectString(output.Key),
   } as any;
 };
 
@@ -8250,14 +8135,8 @@ const deserializeAws_json1_1SalesforceChatterFeedConfiguration = (
   context: __SerdeContext
 ): SalesforceChatterFeedConfiguration => {
   return {
-    DocumentDataFieldName:
-      output.DocumentDataFieldName !== undefined && output.DocumentDataFieldName !== null
-        ? output.DocumentDataFieldName
-        : undefined,
-    DocumentTitleFieldName:
-      output.DocumentTitleFieldName !== undefined && output.DocumentTitleFieldName !== null
-        ? output.DocumentTitleFieldName
-        : undefined,
+    DocumentDataFieldName: __expectString(output.DocumentDataFieldName),
+    DocumentTitleFieldName: __expectString(output.DocumentTitleFieldName),
     FieldMappings:
       output.FieldMappings !== undefined && output.FieldMappings !== null
         ? deserializeAws_json1_1DataSourceToIndexFieldMappingList(output.FieldMappings, context)
@@ -8279,7 +8158,7 @@ const deserializeAws_json1_1SalesforceChatterFeedIncludeFilterTypes = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -8292,8 +8171,7 @@ const deserializeAws_json1_1SalesforceConfiguration = (
       output.ChatterFeedConfiguration !== undefined && output.ChatterFeedConfiguration !== null
         ? deserializeAws_json1_1SalesforceChatterFeedConfiguration(output.ChatterFeedConfiguration, context)
         : undefined,
-    CrawlAttachments:
-      output.CrawlAttachments !== undefined && output.CrawlAttachments !== null ? output.CrawlAttachments : undefined,
+    CrawlAttachments: __expectBoolean(output.CrawlAttachments),
     ExcludeAttachmentFilePatterns:
       output.ExcludeAttachmentFilePatterns !== undefined && output.ExcludeAttachmentFilePatterns !== null
         ? deserializeAws_json1_1DataSourceInclusionsExclusionsStrings(output.ExcludeAttachmentFilePatterns, context)
@@ -8306,8 +8184,8 @@ const deserializeAws_json1_1SalesforceConfiguration = (
       output.KnowledgeArticleConfiguration !== undefined && output.KnowledgeArticleConfiguration !== null
         ? deserializeAws_json1_1SalesforceKnowledgeArticleConfiguration(output.KnowledgeArticleConfiguration, context)
         : undefined,
-    SecretArn: output.SecretArn !== undefined && output.SecretArn !== null ? output.SecretArn : undefined,
-    ServerUrl: output.ServerUrl !== undefined && output.ServerUrl !== null ? output.ServerUrl : undefined,
+    SecretArn: __expectString(output.SecretArn),
+    ServerUrl: __expectString(output.ServerUrl),
     StandardObjectAttachmentConfiguration:
       output.StandardObjectAttachmentConfiguration !== undefined &&
       output.StandardObjectAttachmentConfiguration !== null
@@ -8328,19 +8206,13 @@ const deserializeAws_json1_1SalesforceCustomKnowledgeArticleTypeConfiguration = 
   context: __SerdeContext
 ): SalesforceCustomKnowledgeArticleTypeConfiguration => {
   return {
-    DocumentDataFieldName:
-      output.DocumentDataFieldName !== undefined && output.DocumentDataFieldName !== null
-        ? output.DocumentDataFieldName
-        : undefined,
-    DocumentTitleFieldName:
-      output.DocumentTitleFieldName !== undefined && output.DocumentTitleFieldName !== null
-        ? output.DocumentTitleFieldName
-        : undefined,
+    DocumentDataFieldName: __expectString(output.DocumentDataFieldName),
+    DocumentTitleFieldName: __expectString(output.DocumentTitleFieldName),
     FieldMappings:
       output.FieldMappings !== undefined && output.FieldMappings !== null
         ? deserializeAws_json1_1DataSourceToIndexFieldMappingList(output.FieldMappings, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -8396,7 +8268,7 @@ const deserializeAws_json1_1SalesforceKnowledgeArticleStateList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -8405,14 +8277,8 @@ const deserializeAws_json1_1SalesforceStandardKnowledgeArticleTypeConfiguration 
   context: __SerdeContext
 ): SalesforceStandardKnowledgeArticleTypeConfiguration => {
   return {
-    DocumentDataFieldName:
-      output.DocumentDataFieldName !== undefined && output.DocumentDataFieldName !== null
-        ? output.DocumentDataFieldName
-        : undefined,
-    DocumentTitleFieldName:
-      output.DocumentTitleFieldName !== undefined && output.DocumentTitleFieldName !== null
-        ? output.DocumentTitleFieldName
-        : undefined,
+    DocumentDataFieldName: __expectString(output.DocumentDataFieldName),
+    DocumentTitleFieldName: __expectString(output.DocumentTitleFieldName),
     FieldMappings:
       output.FieldMappings !== undefined && output.FieldMappings !== null
         ? deserializeAws_json1_1DataSourceToIndexFieldMappingList(output.FieldMappings, context)
@@ -8425,10 +8291,7 @@ const deserializeAws_json1_1SalesforceStandardObjectAttachmentConfiguration = (
   context: __SerdeContext
 ): SalesforceStandardObjectAttachmentConfiguration => {
   return {
-    DocumentTitleFieldName:
-      output.DocumentTitleFieldName !== undefined && output.DocumentTitleFieldName !== null
-        ? output.DocumentTitleFieldName
-        : undefined,
+    DocumentTitleFieldName: __expectString(output.DocumentTitleFieldName),
     FieldMappings:
       output.FieldMappings !== undefined && output.FieldMappings !== null
         ? deserializeAws_json1_1DataSourceToIndexFieldMappingList(output.FieldMappings, context)
@@ -8441,19 +8304,13 @@ const deserializeAws_json1_1SalesforceStandardObjectConfiguration = (
   context: __SerdeContext
 ): SalesforceStandardObjectConfiguration => {
   return {
-    DocumentDataFieldName:
-      output.DocumentDataFieldName !== undefined && output.DocumentDataFieldName !== null
-        ? output.DocumentDataFieldName
-        : undefined,
-    DocumentTitleFieldName:
-      output.DocumentTitleFieldName !== undefined && output.DocumentTitleFieldName !== null
-        ? output.DocumentTitleFieldName
-        : undefined,
+    DocumentDataFieldName: __expectString(output.DocumentDataFieldName),
+    DocumentTitleFieldName: __expectString(output.DocumentTitleFieldName),
     FieldMappings:
       output.FieldMappings !== undefined && output.FieldMappings !== null
         ? deserializeAws_json1_1DataSourceToIndexFieldMappingList(output.FieldMappings, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -8473,17 +8330,16 @@ const deserializeAws_json1_1SalesforceStandardObjectConfigurationList = (
 
 const deserializeAws_json1_1ScoreAttributes = (output: any, context: __SerdeContext): ScoreAttributes => {
   return {
-    ScoreConfidence:
-      output.ScoreConfidence !== undefined && output.ScoreConfidence !== null ? output.ScoreConfidence : undefined,
+    ScoreConfidence: __expectString(output.ScoreConfidence),
   } as any;
 };
 
 const deserializeAws_json1_1Search = (output: any, context: __SerdeContext): Search => {
   return {
-    Displayable: output.Displayable !== undefined && output.Displayable !== null ? output.Displayable : undefined,
-    Facetable: output.Facetable !== undefined && output.Facetable !== null ? output.Facetable : undefined,
-    Searchable: output.Searchable !== undefined && output.Searchable !== null ? output.Searchable : undefined,
-    Sortable: output.Sortable !== undefined && output.Sortable !== null ? output.Sortable : undefined,
+    Displayable: __expectBoolean(output.Displayable),
+    Facetable: __expectBoolean(output.Facetable),
+    Searchable: __expectBoolean(output.Searchable),
+    Sortable: __expectBoolean(output.Sortable),
   } as any;
 };
 
@@ -8494,7 +8350,7 @@ const deserializeAws_json1_1SecurityGroupIdList = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -8504,8 +8360,7 @@ const deserializeAws_json1_1SeedUrlConfiguration = (output: any, context: __Serd
       output.SeedUrls !== undefined && output.SeedUrls !== null
         ? deserializeAws_json1_1SeedUrlList(output.SeedUrls, context)
         : undefined,
-    WebCrawlerMode:
-      output.WebCrawlerMode !== undefined && output.WebCrawlerMode !== null ? output.WebCrawlerMode : undefined,
+    WebCrawlerMode: __expectString(output.WebCrawlerMode),
   } as any;
 };
 
@@ -8516,7 +8371,7 @@ const deserializeAws_json1_1SeedUrlList = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -8525,7 +8380,7 @@ const deserializeAws_json1_1ServerSideEncryptionConfiguration = (
   context: __SerdeContext
 ): ServerSideEncryptionConfiguration => {
   return {
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
+    KmsKeyId: __expectString(output.KmsKeyId),
   } as any;
 };
 
@@ -8534,24 +8389,18 @@ const deserializeAws_json1_1ServiceNowConfiguration = (
   context: __SerdeContext
 ): ServiceNowConfiguration => {
   return {
-    AuthenticationType:
-      output.AuthenticationType !== undefined && output.AuthenticationType !== null
-        ? output.AuthenticationType
-        : undefined,
-    HostUrl: output.HostUrl !== undefined && output.HostUrl !== null ? output.HostUrl : undefined,
+    AuthenticationType: __expectString(output.AuthenticationType),
+    HostUrl: __expectString(output.HostUrl),
     KnowledgeArticleConfiguration:
       output.KnowledgeArticleConfiguration !== undefined && output.KnowledgeArticleConfiguration !== null
         ? deserializeAws_json1_1ServiceNowKnowledgeArticleConfiguration(output.KnowledgeArticleConfiguration, context)
         : undefined,
-    SecretArn: output.SecretArn !== undefined && output.SecretArn !== null ? output.SecretArn : undefined,
+    SecretArn: __expectString(output.SecretArn),
     ServiceCatalogConfiguration:
       output.ServiceCatalogConfiguration !== undefined && output.ServiceCatalogConfiguration !== null
         ? deserializeAws_json1_1ServiceNowServiceCatalogConfiguration(output.ServiceCatalogConfiguration, context)
         : undefined,
-    ServiceNowBuildVersion:
-      output.ServiceNowBuildVersion !== undefined && output.ServiceNowBuildVersion !== null
-        ? output.ServiceNowBuildVersion
-        : undefined,
+    ServiceNowBuildVersion: __expectString(output.ServiceNowBuildVersion),
   } as any;
 };
 
@@ -8560,16 +8409,9 @@ const deserializeAws_json1_1ServiceNowKnowledgeArticleConfiguration = (
   context: __SerdeContext
 ): ServiceNowKnowledgeArticleConfiguration => {
   return {
-    CrawlAttachments:
-      output.CrawlAttachments !== undefined && output.CrawlAttachments !== null ? output.CrawlAttachments : undefined,
-    DocumentDataFieldName:
-      output.DocumentDataFieldName !== undefined && output.DocumentDataFieldName !== null
-        ? output.DocumentDataFieldName
-        : undefined,
-    DocumentTitleFieldName:
-      output.DocumentTitleFieldName !== undefined && output.DocumentTitleFieldName !== null
-        ? output.DocumentTitleFieldName
-        : undefined,
+    CrawlAttachments: __expectBoolean(output.CrawlAttachments),
+    DocumentDataFieldName: __expectString(output.DocumentDataFieldName),
+    DocumentTitleFieldName: __expectString(output.DocumentTitleFieldName),
     ExcludeAttachmentFilePatterns:
       output.ExcludeAttachmentFilePatterns !== undefined && output.ExcludeAttachmentFilePatterns !== null
         ? deserializeAws_json1_1DataSourceInclusionsExclusionsStrings(output.ExcludeAttachmentFilePatterns, context)
@@ -8578,7 +8420,7 @@ const deserializeAws_json1_1ServiceNowKnowledgeArticleConfiguration = (
       output.FieldMappings !== undefined && output.FieldMappings !== null
         ? deserializeAws_json1_1DataSourceToIndexFieldMappingList(output.FieldMappings, context)
         : undefined,
-    FilterQuery: output.FilterQuery !== undefined && output.FilterQuery !== null ? output.FilterQuery : undefined,
+    FilterQuery: __expectString(output.FilterQuery),
     IncludeAttachmentFilePatterns:
       output.IncludeAttachmentFilePatterns !== undefined && output.IncludeAttachmentFilePatterns !== null
         ? deserializeAws_json1_1DataSourceInclusionsExclusionsStrings(output.IncludeAttachmentFilePatterns, context)
@@ -8591,16 +8433,9 @@ const deserializeAws_json1_1ServiceNowServiceCatalogConfiguration = (
   context: __SerdeContext
 ): ServiceNowServiceCatalogConfiguration => {
   return {
-    CrawlAttachments:
-      output.CrawlAttachments !== undefined && output.CrawlAttachments !== null ? output.CrawlAttachments : undefined,
-    DocumentDataFieldName:
-      output.DocumentDataFieldName !== undefined && output.DocumentDataFieldName !== null
-        ? output.DocumentDataFieldName
-        : undefined,
-    DocumentTitleFieldName:
-      output.DocumentTitleFieldName !== undefined && output.DocumentTitleFieldName !== null
-        ? output.DocumentTitleFieldName
-        : undefined,
+    CrawlAttachments: __expectBoolean(output.CrawlAttachments),
+    DocumentDataFieldName: __expectString(output.DocumentDataFieldName),
+    DocumentTitleFieldName: __expectString(output.DocumentTitleFieldName),
     ExcludeAttachmentFilePatterns:
       output.ExcludeAttachmentFilePatterns !== undefined && output.ExcludeAttachmentFilePatterns !== null
         ? deserializeAws_json1_1DataSourceInclusionsExclusionsStrings(output.ExcludeAttachmentFilePatterns, context)
@@ -8621,7 +8456,7 @@ const deserializeAws_json1_1ServiceQuotaExceededException = (
   context: __SerdeContext
 ): ServiceQuotaExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -8630,16 +8465,9 @@ const deserializeAws_json1_1SharePointConfiguration = (
   context: __SerdeContext
 ): SharePointConfiguration => {
   return {
-    CrawlAttachments:
-      output.CrawlAttachments !== undefined && output.CrawlAttachments !== null ? output.CrawlAttachments : undefined,
-    DisableLocalGroups:
-      output.DisableLocalGroups !== undefined && output.DisableLocalGroups !== null
-        ? output.DisableLocalGroups
-        : undefined,
-    DocumentTitleFieldName:
-      output.DocumentTitleFieldName !== undefined && output.DocumentTitleFieldName !== null
-        ? output.DocumentTitleFieldName
-        : undefined,
+    CrawlAttachments: __expectBoolean(output.CrawlAttachments),
+    DisableLocalGroups: __expectBoolean(output.DisableLocalGroups),
+    DocumentTitleFieldName: __expectString(output.DocumentTitleFieldName),
     ExclusionPatterns:
       output.ExclusionPatterns !== undefined && output.ExclusionPatterns !== null
         ? deserializeAws_json1_1DataSourceInclusionsExclusionsStrings(output.ExclusionPatterns, context)
@@ -8652,16 +8480,13 @@ const deserializeAws_json1_1SharePointConfiguration = (
       output.InclusionPatterns !== undefined && output.InclusionPatterns !== null
         ? deserializeAws_json1_1DataSourceInclusionsExclusionsStrings(output.InclusionPatterns, context)
         : undefined,
-    SecretArn: output.SecretArn !== undefined && output.SecretArn !== null ? output.SecretArn : undefined,
-    SharePointVersion:
-      output.SharePointVersion !== undefined && output.SharePointVersion !== null
-        ? output.SharePointVersion
-        : undefined,
+    SecretArn: __expectString(output.SecretArn),
+    SharePointVersion: __expectString(output.SharePointVersion),
     Urls:
       output.Urls !== undefined && output.Urls !== null
         ? deserializeAws_json1_1SharePointUrlList(output.Urls, context)
         : undefined,
-    UseChangeLog: output.UseChangeLog !== undefined && output.UseChangeLog !== null ? output.UseChangeLog : undefined,
+    UseChangeLog: __expectBoolean(output.UseChangeLog),
     VpcConfiguration:
       output.VpcConfiguration !== undefined && output.VpcConfiguration !== null
         ? deserializeAws_json1_1DataSourceVpcConfiguration(output.VpcConfiguration, context)
@@ -8676,7 +8501,7 @@ const deserializeAws_json1_1SharePointUrlList = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -8696,16 +8521,13 @@ const deserializeAws_json1_1SiteMapsList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1SqlConfiguration = (output: any, context: __SerdeContext): SqlConfiguration => {
   return {
-    QueryIdentifiersEnclosingOption:
-      output.QueryIdentifiersEnclosingOption !== undefined && output.QueryIdentifiersEnclosingOption !== null
-        ? output.QueryIdentifiersEnclosingOption
-        : undefined,
+    QueryIdentifiersEnclosingOption: __expectString(output.QueryIdentifiersEnclosingOption),
   } as any;
 };
 
@@ -8714,18 +8536,16 @@ const deserializeAws_json1_1StartDataSourceSyncJobResponse = (
   context: __SerdeContext
 ): StartDataSourceSyncJobResponse => {
   return {
-    ExecutionId: output.ExecutionId !== undefined && output.ExecutionId !== null ? output.ExecutionId : undefined,
+    ExecutionId: __expectString(output.ExecutionId),
   } as any;
 };
 
 const deserializeAws_json1_1Status = (output: any, context: __SerdeContext): Status => {
   return {
-    DocumentId: output.DocumentId !== undefined && output.DocumentId !== null ? output.DocumentId : undefined,
-    DocumentStatus:
-      output.DocumentStatus !== undefined && output.DocumentStatus !== null ? output.DocumentStatus : undefined,
-    FailureCode: output.FailureCode !== undefined && output.FailureCode !== null ? output.FailureCode : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
+    DocumentId: __expectString(output.DocumentId),
+    DocumentStatus: __expectString(output.DocumentStatus),
+    FailureCode: __expectString(output.FailureCode),
+    FailureReason: __expectString(output.FailureReason),
   } as any;
 };
 
@@ -8736,13 +8556,13 @@ const deserializeAws_json1_1SubnetIdList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1Suggestion = (output: any, context: __SerdeContext): Suggestion => {
   return {
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    Id: __expectString(output.Id),
     Value:
       output.Value !== undefined && output.Value !== null
         ? deserializeAws_json1_1SuggestionValue(output.Value, context)
@@ -8752,8 +8572,8 @@ const deserializeAws_json1_1Suggestion = (output: any, context: __SerdeContext):
 
 const deserializeAws_json1_1SuggestionHighlight = (output: any, context: __SerdeContext): SuggestionHighlight => {
   return {
-    BeginOffset: output.BeginOffset !== undefined && output.BeginOffset !== null ? output.BeginOffset : undefined,
-    EndOffset: output.EndOffset !== undefined && output.EndOffset !== null ? output.EndOffset : undefined,
+    BeginOffset: __expectNumber(output.BeginOffset),
+    EndOffset: __expectNumber(output.EndOffset),
   } as any;
 };
 
@@ -8788,7 +8608,7 @@ const deserializeAws_json1_1SuggestionTextWithHighlights = (
       output.Highlights !== undefined && output.Highlights !== null
         ? deserializeAws_json1_1SuggestionHighlightList(output.Highlights, context)
         : undefined,
-    Text: output.Text !== undefined && output.Text !== null ? output.Text : undefined,
+    Text: __expectString(output.Text),
   } as any;
 };
 
@@ -8803,8 +8623,8 @@ const deserializeAws_json1_1SuggestionValue = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -8825,12 +8645,8 @@ const deserializeAws_json1_1TagResourceResponse = (output: any, context: __Serde
 
 const deserializeAws_json1_1TextDocumentStatistics = (output: any, context: __SerdeContext): TextDocumentStatistics => {
   return {
-    IndexedTextBytes:
-      output.IndexedTextBytes !== undefined && output.IndexedTextBytes !== null ? output.IndexedTextBytes : undefined,
-    IndexedTextDocumentsCount:
-      output.IndexedTextDocumentsCount !== undefined && output.IndexedTextDocumentsCount !== null
-        ? output.IndexedTextDocumentsCount
-        : undefined,
+    IndexedTextBytes: __expectNumber(output.IndexedTextBytes),
+    IndexedTextDocumentsCount: __expectNumber(output.IndexedTextDocumentsCount),
   } as any;
 };
 
@@ -8840,7 +8656,7 @@ const deserializeAws_json1_1TextWithHighlights = (output: any, context: __SerdeC
       output.Highlights !== undefined && output.Highlights !== null
         ? deserializeAws_json1_1HighlightList(output.Highlights, context)
         : undefined,
-    Text: output.Text !== undefined && output.Text !== null ? output.Text : undefined,
+    Text: __expectString(output.Text),
   } as any;
 };
 
@@ -8850,9 +8666,9 @@ const deserializeAws_json1_1ThesaurusSummary = (output: any, context: __SerdeCon
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
+    Status: __expectString(output.Status),
     UpdatedAt:
       output.UpdatedAt !== undefined && output.UpdatedAt !== null
         ? new Date(Math.round(output.UpdatedAt * 1000))
@@ -8873,7 +8689,7 @@ const deserializeAws_json1_1ThesaurusSummaryItems = (output: any, context: __Ser
 
 const deserializeAws_json1_1ThrottlingException = (output: any, context: __SerdeContext): ThrottlingException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -8923,7 +8739,7 @@ const deserializeAws_json1_1UserTokenConfigurationList = (
 
 const deserializeAws_json1_1ValidationException = (output: any, context: __SerdeContext): ValidationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -8934,7 +8750,7 @@ const deserializeAws_json1_1ValueImportanceMap = (output: any, context: __SerdeC
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectNumber(value) as any,
     };
   }, {});
 };
@@ -8948,17 +8764,10 @@ const deserializeAws_json1_1WebCrawlerConfiguration = (
       output.AuthenticationConfiguration !== undefined && output.AuthenticationConfiguration !== null
         ? deserializeAws_json1_1AuthenticationConfiguration(output.AuthenticationConfiguration, context)
         : undefined,
-    CrawlDepth: output.CrawlDepth !== undefined && output.CrawlDepth !== null ? output.CrawlDepth : undefined,
-    MaxContentSizePerPageInMegaBytes:
-      output.MaxContentSizePerPageInMegaBytes !== undefined && output.MaxContentSizePerPageInMegaBytes !== null
-        ? output.MaxContentSizePerPageInMegaBytes
-        : undefined,
-    MaxLinksPerPage:
-      output.MaxLinksPerPage !== undefined && output.MaxLinksPerPage !== null ? output.MaxLinksPerPage : undefined,
-    MaxUrlsPerMinuteCrawlRate:
-      output.MaxUrlsPerMinuteCrawlRate !== undefined && output.MaxUrlsPerMinuteCrawlRate !== null
-        ? output.MaxUrlsPerMinuteCrawlRate
-        : undefined,
+    CrawlDepth: __expectNumber(output.CrawlDepth),
+    MaxContentSizePerPageInMegaBytes: __expectNumber(output.MaxContentSizePerPageInMegaBytes),
+    MaxLinksPerPage: __expectNumber(output.MaxLinksPerPage),
+    MaxUrlsPerMinuteCrawlRate: __expectNumber(output.MaxUrlsPerMinuteCrawlRate),
     ProxyConfiguration:
       output.ProxyConfiguration !== undefined && output.ProxyConfiguration !== null
         ? deserializeAws_json1_1ProxyConfiguration(output.ProxyConfiguration, context)

--- a/clients/client-kinesis-analytics-v2/protocols/Aws_json1_1.ts
+++ b/clients/client-kinesis-analytics-v2/protocols/Aws_json1_1.ts
@@ -295,7 +295,12 @@ import {
   ZeppelinMonitoringConfigurationUpdate,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -5329,12 +5334,8 @@ const deserializeAws_json1_1AddApplicationCloudWatchLoggingOptionResponse = (
   context: __SerdeContext
 ): AddApplicationCloudWatchLoggingOptionResponse => {
   return {
-    ApplicationARN:
-      output.ApplicationARN !== undefined && output.ApplicationARN !== null ? output.ApplicationARN : undefined,
-    ApplicationVersionId:
-      output.ApplicationVersionId !== undefined && output.ApplicationVersionId !== null
-        ? output.ApplicationVersionId
-        : undefined,
+    ApplicationARN: __expectString(output.ApplicationARN),
+    ApplicationVersionId: __expectNumber(output.ApplicationVersionId),
     CloudWatchLoggingOptionDescriptions:
       output.CloudWatchLoggingOptionDescriptions !== undefined && output.CloudWatchLoggingOptionDescriptions !== null
         ? deserializeAws_json1_1CloudWatchLoggingOptionDescriptions(output.CloudWatchLoggingOptionDescriptions, context)
@@ -5347,13 +5348,9 @@ const deserializeAws_json1_1AddApplicationInputProcessingConfigurationResponse =
   context: __SerdeContext
 ): AddApplicationInputProcessingConfigurationResponse => {
   return {
-    ApplicationARN:
-      output.ApplicationARN !== undefined && output.ApplicationARN !== null ? output.ApplicationARN : undefined,
-    ApplicationVersionId:
-      output.ApplicationVersionId !== undefined && output.ApplicationVersionId !== null
-        ? output.ApplicationVersionId
-        : undefined,
-    InputId: output.InputId !== undefined && output.InputId !== null ? output.InputId : undefined,
+    ApplicationARN: __expectString(output.ApplicationARN),
+    ApplicationVersionId: __expectNumber(output.ApplicationVersionId),
+    InputId: __expectString(output.InputId),
     InputProcessingConfigurationDescription:
       output.InputProcessingConfigurationDescription !== undefined &&
       output.InputProcessingConfigurationDescription !== null
@@ -5370,12 +5367,8 @@ const deserializeAws_json1_1AddApplicationInputResponse = (
   context: __SerdeContext
 ): AddApplicationInputResponse => {
   return {
-    ApplicationARN:
-      output.ApplicationARN !== undefined && output.ApplicationARN !== null ? output.ApplicationARN : undefined,
-    ApplicationVersionId:
-      output.ApplicationVersionId !== undefined && output.ApplicationVersionId !== null
-        ? output.ApplicationVersionId
-        : undefined,
+    ApplicationARN: __expectString(output.ApplicationARN),
+    ApplicationVersionId: __expectNumber(output.ApplicationVersionId),
     InputDescriptions:
       output.InputDescriptions !== undefined && output.InputDescriptions !== null
         ? deserializeAws_json1_1InputDescriptions(output.InputDescriptions, context)
@@ -5388,12 +5381,8 @@ const deserializeAws_json1_1AddApplicationOutputResponse = (
   context: __SerdeContext
 ): AddApplicationOutputResponse => {
   return {
-    ApplicationARN:
-      output.ApplicationARN !== undefined && output.ApplicationARN !== null ? output.ApplicationARN : undefined,
-    ApplicationVersionId:
-      output.ApplicationVersionId !== undefined && output.ApplicationVersionId !== null
-        ? output.ApplicationVersionId
-        : undefined,
+    ApplicationARN: __expectString(output.ApplicationARN),
+    ApplicationVersionId: __expectNumber(output.ApplicationVersionId),
     OutputDescriptions:
       output.OutputDescriptions !== undefined && output.OutputDescriptions !== null
         ? deserializeAws_json1_1OutputDescriptions(output.OutputDescriptions, context)
@@ -5406,12 +5395,8 @@ const deserializeAws_json1_1AddApplicationReferenceDataSourceResponse = (
   context: __SerdeContext
 ): AddApplicationReferenceDataSourceResponse => {
   return {
-    ApplicationARN:
-      output.ApplicationARN !== undefined && output.ApplicationARN !== null ? output.ApplicationARN : undefined,
-    ApplicationVersionId:
-      output.ApplicationVersionId !== undefined && output.ApplicationVersionId !== null
-        ? output.ApplicationVersionId
-        : undefined,
+    ApplicationARN: __expectString(output.ApplicationARN),
+    ApplicationVersionId: __expectNumber(output.ApplicationVersionId),
     ReferenceDataSourceDescriptions:
       output.ReferenceDataSourceDescriptions !== undefined && output.ReferenceDataSourceDescriptions !== null
         ? deserializeAws_json1_1ReferenceDataSourceDescriptions(output.ReferenceDataSourceDescriptions, context)
@@ -5424,12 +5409,8 @@ const deserializeAws_json1_1AddApplicationVpcConfigurationResponse = (
   context: __SerdeContext
 ): AddApplicationVpcConfigurationResponse => {
   return {
-    ApplicationARN:
-      output.ApplicationARN !== undefined && output.ApplicationARN !== null ? output.ApplicationARN : undefined,
-    ApplicationVersionId:
-      output.ApplicationVersionId !== undefined && output.ApplicationVersionId !== null
-        ? output.ApplicationVersionId
-        : undefined,
+    ApplicationARN: __expectString(output.ApplicationARN),
+    ApplicationVersionId: __expectNumber(output.ApplicationVersionId),
     VpcConfigurationDescription:
       output.VpcConfigurationDescription !== undefined && output.VpcConfigurationDescription !== null
         ? deserializeAws_json1_1VpcConfigurationDescription(output.VpcConfigurationDescription, context)
@@ -5446,8 +5427,7 @@ const deserializeAws_json1_1ApplicationCodeConfigurationDescription = (
       output.CodeContentDescription !== undefined && output.CodeContentDescription !== null
         ? deserializeAws_json1_1CodeContentDescription(output.CodeContentDescription, context)
         : undefined,
-    CodeContentType:
-      output.CodeContentType !== undefined && output.CodeContentType !== null ? output.CodeContentType : undefined,
+    CodeContentType: __expectString(output.CodeContentType),
   } as any;
 };
 
@@ -5513,16 +5493,12 @@ const deserializeAws_json1_1ApplicationConfigurationDescription = (
 
 const deserializeAws_json1_1ApplicationDetail = (output: any, context: __SerdeContext): ApplicationDetail => {
   return {
-    ApplicationARN:
-      output.ApplicationARN !== undefined && output.ApplicationARN !== null ? output.ApplicationARN : undefined,
+    ApplicationARN: __expectString(output.ApplicationARN),
     ApplicationConfigurationDescription:
       output.ApplicationConfigurationDescription !== undefined && output.ApplicationConfigurationDescription !== null
         ? deserializeAws_json1_1ApplicationConfigurationDescription(output.ApplicationConfigurationDescription, context)
         : undefined,
-    ApplicationDescription:
-      output.ApplicationDescription !== undefined && output.ApplicationDescription !== null
-        ? output.ApplicationDescription
-        : undefined,
+    ApplicationDescription: __expectString(output.ApplicationDescription),
     ApplicationMaintenanceConfigurationDescription:
       output.ApplicationMaintenanceConfigurationDescription !== undefined &&
       output.ApplicationMaintenanceConfigurationDescription !== null
@@ -5531,36 +5507,18 @@ const deserializeAws_json1_1ApplicationDetail = (output: any, context: __SerdeCo
             context
           )
         : undefined,
-    ApplicationMode:
-      output.ApplicationMode !== undefined && output.ApplicationMode !== null ? output.ApplicationMode : undefined,
-    ApplicationName:
-      output.ApplicationName !== undefined && output.ApplicationName !== null ? output.ApplicationName : undefined,
-    ApplicationStatus:
-      output.ApplicationStatus !== undefined && output.ApplicationStatus !== null
-        ? output.ApplicationStatus
-        : undefined,
-    ApplicationVersionId:
-      output.ApplicationVersionId !== undefined && output.ApplicationVersionId !== null
-        ? output.ApplicationVersionId
-        : undefined,
-    ApplicationVersionRolledBackFrom:
-      output.ApplicationVersionRolledBackFrom !== undefined && output.ApplicationVersionRolledBackFrom !== null
-        ? output.ApplicationVersionRolledBackFrom
-        : undefined,
-    ApplicationVersionRolledBackTo:
-      output.ApplicationVersionRolledBackTo !== undefined && output.ApplicationVersionRolledBackTo !== null
-        ? output.ApplicationVersionRolledBackTo
-        : undefined,
-    ApplicationVersionUpdatedFrom:
-      output.ApplicationVersionUpdatedFrom !== undefined && output.ApplicationVersionUpdatedFrom !== null
-        ? output.ApplicationVersionUpdatedFrom
-        : undefined,
+    ApplicationMode: __expectString(output.ApplicationMode),
+    ApplicationName: __expectString(output.ApplicationName),
+    ApplicationStatus: __expectString(output.ApplicationStatus),
+    ApplicationVersionId: __expectNumber(output.ApplicationVersionId),
+    ApplicationVersionRolledBackFrom: __expectNumber(output.ApplicationVersionRolledBackFrom),
+    ApplicationVersionRolledBackTo: __expectNumber(output.ApplicationVersionRolledBackTo),
+    ApplicationVersionUpdatedFrom: __expectNumber(output.ApplicationVersionUpdatedFrom),
     CloudWatchLoggingOptionDescriptions:
       output.CloudWatchLoggingOptionDescriptions !== undefined && output.CloudWatchLoggingOptionDescriptions !== null
         ? deserializeAws_json1_1CloudWatchLoggingOptionDescriptions(output.CloudWatchLoggingOptionDescriptions, context)
         : undefined,
-    ConditionalToken:
-      output.ConditionalToken !== undefined && output.ConditionalToken !== null ? output.ConditionalToken : undefined,
+    ConditionalToken: __expectString(output.ConditionalToken),
     CreateTimestamp:
       output.CreateTimestamp !== undefined && output.CreateTimestamp !== null
         ? new Date(Math.round(output.CreateTimestamp * 1000))
@@ -5569,14 +5527,8 @@ const deserializeAws_json1_1ApplicationDetail = (output: any, context: __SerdeCo
       output.LastUpdateTimestamp !== undefined && output.LastUpdateTimestamp !== null
         ? new Date(Math.round(output.LastUpdateTimestamp * 1000))
         : undefined,
-    RuntimeEnvironment:
-      output.RuntimeEnvironment !== undefined && output.RuntimeEnvironment !== null
-        ? output.RuntimeEnvironment
-        : undefined,
-    ServiceExecutionRole:
-      output.ServiceExecutionRole !== undefined && output.ServiceExecutionRole !== null
-        ? output.ServiceExecutionRole
-        : undefined,
+    RuntimeEnvironment: __expectString(output.RuntimeEnvironment),
+    ServiceExecutionRole: __expectString(output.ServiceExecutionRole),
   } as any;
 };
 
@@ -5585,15 +5537,8 @@ const deserializeAws_json1_1ApplicationMaintenanceConfigurationDescription = (
   context: __SerdeContext
 ): ApplicationMaintenanceConfigurationDescription => {
   return {
-    ApplicationMaintenanceWindowEndTime:
-      output.ApplicationMaintenanceWindowEndTime !== undefined && output.ApplicationMaintenanceWindowEndTime !== null
-        ? output.ApplicationMaintenanceWindowEndTime
-        : undefined,
-    ApplicationMaintenanceWindowStartTime:
-      output.ApplicationMaintenanceWindowStartTime !== undefined &&
-      output.ApplicationMaintenanceWindowStartTime !== null
-        ? output.ApplicationMaintenanceWindowStartTime
-        : undefined,
+    ApplicationMaintenanceWindowEndTime: __expectString(output.ApplicationMaintenanceWindowEndTime),
+    ApplicationMaintenanceWindowStartTime: __expectString(output.ApplicationMaintenanceWindowStartTime),
   } as any;
 };
 
@@ -5602,11 +5547,8 @@ const deserializeAws_json1_1ApplicationRestoreConfiguration = (
   context: __SerdeContext
 ): ApplicationRestoreConfiguration => {
   return {
-    ApplicationRestoreType:
-      output.ApplicationRestoreType !== undefined && output.ApplicationRestoreType !== null
-        ? output.ApplicationRestoreType
-        : undefined,
-    SnapshotName: output.SnapshotName !== undefined && output.SnapshotName !== null ? output.SnapshotName : undefined,
+    ApplicationRestoreType: __expectString(output.ApplicationRestoreType),
+    SnapshotName: __expectString(output.SnapshotName),
   } as any;
 };
 
@@ -5615,8 +5557,7 @@ const deserializeAws_json1_1ApplicationSnapshotConfigurationDescription = (
   context: __SerdeContext
 ): ApplicationSnapshotConfigurationDescription => {
   return {
-    SnapshotsEnabled:
-      output.SnapshotsEnabled !== undefined && output.SnapshotsEnabled !== null ? output.SnapshotsEnabled : undefined,
+    SnapshotsEnabled: __expectBoolean(output.SnapshotsEnabled),
   } as any;
 };
 
@@ -5633,24 +5574,12 @@ const deserializeAws_json1_1ApplicationSummaries = (output: any, context: __Serd
 
 const deserializeAws_json1_1ApplicationSummary = (output: any, context: __SerdeContext): ApplicationSummary => {
   return {
-    ApplicationARN:
-      output.ApplicationARN !== undefined && output.ApplicationARN !== null ? output.ApplicationARN : undefined,
-    ApplicationMode:
-      output.ApplicationMode !== undefined && output.ApplicationMode !== null ? output.ApplicationMode : undefined,
-    ApplicationName:
-      output.ApplicationName !== undefined && output.ApplicationName !== null ? output.ApplicationName : undefined,
-    ApplicationStatus:
-      output.ApplicationStatus !== undefined && output.ApplicationStatus !== null
-        ? output.ApplicationStatus
-        : undefined,
-    ApplicationVersionId:
-      output.ApplicationVersionId !== undefined && output.ApplicationVersionId !== null
-        ? output.ApplicationVersionId
-        : undefined,
-    RuntimeEnvironment:
-      output.RuntimeEnvironment !== undefined && output.RuntimeEnvironment !== null
-        ? output.RuntimeEnvironment
-        : undefined,
+    ApplicationARN: __expectString(output.ApplicationARN),
+    ApplicationMode: __expectString(output.ApplicationMode),
+    ApplicationName: __expectString(output.ApplicationName),
+    ApplicationStatus: __expectString(output.ApplicationStatus),
+    ApplicationVersionId: __expectNumber(output.ApplicationVersionId),
+    RuntimeEnvironment: __expectString(output.RuntimeEnvironment),
   } as any;
 };
 
@@ -5673,14 +5602,8 @@ const deserializeAws_json1_1ApplicationVersionSummary = (
   context: __SerdeContext
 ): ApplicationVersionSummary => {
   return {
-    ApplicationStatus:
-      output.ApplicationStatus !== undefined && output.ApplicationStatus !== null
-        ? output.ApplicationStatus
-        : undefined,
-    ApplicationVersionId:
-      output.ApplicationVersionId !== undefined && output.ApplicationVersionId !== null
-        ? output.ApplicationVersionId
-        : undefined,
+    ApplicationStatus: __expectString(output.ApplicationStatus),
+    ApplicationVersionId: __expectNumber(output.ApplicationVersionId),
   } as any;
 };
 
@@ -5705,22 +5628,10 @@ const deserializeAws_json1_1CheckpointConfigurationDescription = (
   context: __SerdeContext
 ): CheckpointConfigurationDescription => {
   return {
-    CheckpointInterval:
-      output.CheckpointInterval !== undefined && output.CheckpointInterval !== null
-        ? output.CheckpointInterval
-        : undefined,
-    CheckpointingEnabled:
-      output.CheckpointingEnabled !== undefined && output.CheckpointingEnabled !== null
-        ? output.CheckpointingEnabled
-        : undefined,
-    ConfigurationType:
-      output.ConfigurationType !== undefined && output.ConfigurationType !== null
-        ? output.ConfigurationType
-        : undefined,
-    MinPauseBetweenCheckpoints:
-      output.MinPauseBetweenCheckpoints !== undefined && output.MinPauseBetweenCheckpoints !== null
-        ? output.MinPauseBetweenCheckpoints
-        : undefined,
+    CheckpointInterval: __expectNumber(output.CheckpointInterval),
+    CheckpointingEnabled: __expectBoolean(output.CheckpointingEnabled),
+    ConfigurationType: __expectString(output.ConfigurationType),
+    MinPauseBetweenCheckpoints: __expectNumber(output.MinPauseBetweenCheckpoints),
   } as any;
 };
 
@@ -5729,12 +5640,9 @@ const deserializeAws_json1_1CloudWatchLoggingOptionDescription = (
   context: __SerdeContext
 ): CloudWatchLoggingOptionDescription => {
   return {
-    CloudWatchLoggingOptionId:
-      output.CloudWatchLoggingOptionId !== undefined && output.CloudWatchLoggingOptionId !== null
-        ? output.CloudWatchLoggingOptionId
-        : undefined,
-    LogStreamARN: output.LogStreamARN !== undefined && output.LogStreamARN !== null ? output.LogStreamARN : undefined,
-    RoleARN: output.RoleARN !== undefined && output.RoleARN !== null ? output.RoleARN : undefined,
+    CloudWatchLoggingOptionId: __expectString(output.CloudWatchLoggingOptionId),
+    LogStreamARN: __expectString(output.LogStreamARN),
+    RoleARN: __expectString(output.RoleARN),
   } as any;
 };
 
@@ -5754,8 +5662,8 @@ const deserializeAws_json1_1CloudWatchLoggingOptionDescriptions = (
 
 const deserializeAws_json1_1CodeContentDescription = (output: any, context: __SerdeContext): CodeContentDescription => {
   return {
-    CodeMD5: output.CodeMD5 !== undefined && output.CodeMD5 !== null ? output.CodeMD5 : undefined,
-    CodeSize: output.CodeSize !== undefined && output.CodeSize !== null ? output.CodeSize : undefined,
+    CodeMD5: __expectString(output.CodeMD5),
+    CodeSize: __expectNumber(output.CodeSize),
     S3ApplicationCodeLocationDescription:
       output.S3ApplicationCodeLocationDescription !== undefined && output.S3ApplicationCodeLocationDescription !== null
         ? deserializeAws_json1_1S3ApplicationCodeLocationDescription(
@@ -5763,7 +5671,7 @@ const deserializeAws_json1_1CodeContentDescription = (output: any, context: __Se
             context
           )
         : undefined,
-    TextContent: output.TextContent !== undefined && output.TextContent !== null ? output.TextContent : undefined,
+    TextContent: __expectString(output.TextContent),
   } as any;
 };
 
@@ -5772,7 +5680,7 @@ const deserializeAws_json1_1CodeValidationException = (
   context: __SerdeContext
 ): CodeValidationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -5781,7 +5689,7 @@ const deserializeAws_json1_1ConcurrentModificationException = (
   context: __SerdeContext
 ): ConcurrentModificationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -5790,8 +5698,7 @@ const deserializeAws_json1_1CreateApplicationPresignedUrlResponse = (
   context: __SerdeContext
 ): CreateApplicationPresignedUrlResponse => {
   return {
-    AuthorizedUrl:
-      output.AuthorizedUrl !== undefined && output.AuthorizedUrl !== null ? output.AuthorizedUrl : undefined,
+    AuthorizedUrl: __expectString(output.AuthorizedUrl),
   } as any;
 };
 
@@ -5816,14 +5723,8 @@ const deserializeAws_json1_1CreateApplicationSnapshotResponse = (
 
 const deserializeAws_json1_1CSVMappingParameters = (output: any, context: __SerdeContext): CSVMappingParameters => {
   return {
-    RecordColumnDelimiter:
-      output.RecordColumnDelimiter !== undefined && output.RecordColumnDelimiter !== null
-        ? output.RecordColumnDelimiter
-        : undefined,
-    RecordRowDelimiter:
-      output.RecordRowDelimiter !== undefined && output.RecordRowDelimiter !== null
-        ? output.RecordRowDelimiter
-        : undefined,
+    RecordColumnDelimiter: __expectString(output.RecordColumnDelimiter),
+    RecordRowDelimiter: __expectString(output.RecordRowDelimiter),
   } as any;
 };
 
@@ -5832,7 +5733,7 @@ const deserializeAws_json1_1CustomArtifactConfigurationDescription = (
   context: __SerdeContext
 ): CustomArtifactConfigurationDescription => {
   return {
-    ArtifactType: output.ArtifactType !== undefined && output.ArtifactType !== null ? output.ArtifactType : undefined,
+    ArtifactType: __expectString(output.ArtifactType),
     MavenReferenceDescription:
       output.MavenReferenceDescription !== undefined && output.MavenReferenceDescription !== null
         ? deserializeAws_json1_1MavenReference(output.MavenReferenceDescription, context)
@@ -5863,12 +5764,8 @@ const deserializeAws_json1_1DeleteApplicationCloudWatchLoggingOptionResponse = (
   context: __SerdeContext
 ): DeleteApplicationCloudWatchLoggingOptionResponse => {
   return {
-    ApplicationARN:
-      output.ApplicationARN !== undefined && output.ApplicationARN !== null ? output.ApplicationARN : undefined,
-    ApplicationVersionId:
-      output.ApplicationVersionId !== undefined && output.ApplicationVersionId !== null
-        ? output.ApplicationVersionId
-        : undefined,
+    ApplicationARN: __expectString(output.ApplicationARN),
+    ApplicationVersionId: __expectNumber(output.ApplicationVersionId),
     CloudWatchLoggingOptionDescriptions:
       output.CloudWatchLoggingOptionDescriptions !== undefined && output.CloudWatchLoggingOptionDescriptions !== null
         ? deserializeAws_json1_1CloudWatchLoggingOptionDescriptions(output.CloudWatchLoggingOptionDescriptions, context)
@@ -5881,12 +5778,8 @@ const deserializeAws_json1_1DeleteApplicationInputProcessingConfigurationRespons
   context: __SerdeContext
 ): DeleteApplicationInputProcessingConfigurationResponse => {
   return {
-    ApplicationARN:
-      output.ApplicationARN !== undefined && output.ApplicationARN !== null ? output.ApplicationARN : undefined,
-    ApplicationVersionId:
-      output.ApplicationVersionId !== undefined && output.ApplicationVersionId !== null
-        ? output.ApplicationVersionId
-        : undefined,
+    ApplicationARN: __expectString(output.ApplicationARN),
+    ApplicationVersionId: __expectNumber(output.ApplicationVersionId),
   } as any;
 };
 
@@ -5895,12 +5788,8 @@ const deserializeAws_json1_1DeleteApplicationOutputResponse = (
   context: __SerdeContext
 ): DeleteApplicationOutputResponse => {
   return {
-    ApplicationARN:
-      output.ApplicationARN !== undefined && output.ApplicationARN !== null ? output.ApplicationARN : undefined,
-    ApplicationVersionId:
-      output.ApplicationVersionId !== undefined && output.ApplicationVersionId !== null
-        ? output.ApplicationVersionId
-        : undefined,
+    ApplicationARN: __expectString(output.ApplicationARN),
+    ApplicationVersionId: __expectNumber(output.ApplicationVersionId),
   } as any;
 };
 
@@ -5909,12 +5798,8 @@ const deserializeAws_json1_1DeleteApplicationReferenceDataSourceResponse = (
   context: __SerdeContext
 ): DeleteApplicationReferenceDataSourceResponse => {
   return {
-    ApplicationARN:
-      output.ApplicationARN !== undefined && output.ApplicationARN !== null ? output.ApplicationARN : undefined,
-    ApplicationVersionId:
-      output.ApplicationVersionId !== undefined && output.ApplicationVersionId !== null
-        ? output.ApplicationVersionId
-        : undefined,
+    ApplicationARN: __expectString(output.ApplicationARN),
+    ApplicationVersionId: __expectNumber(output.ApplicationVersionId),
   } as any;
 };
 
@@ -5937,12 +5822,8 @@ const deserializeAws_json1_1DeleteApplicationVpcConfigurationResponse = (
   context: __SerdeContext
 ): DeleteApplicationVpcConfigurationResponse => {
   return {
-    ApplicationARN:
-      output.ApplicationARN !== undefined && output.ApplicationARN !== null ? output.ApplicationARN : undefined,
-    ApplicationVersionId:
-      output.ApplicationVersionId !== undefined && output.ApplicationVersionId !== null
-        ? output.ApplicationVersionId
-        : undefined,
+    ApplicationARN: __expectString(output.ApplicationARN),
+    ApplicationVersionId: __expectNumber(output.ApplicationVersionId),
   } as any;
 };
 
@@ -5996,8 +5877,7 @@ const deserializeAws_json1_1DescribeApplicationVersionResponse = (
 
 const deserializeAws_json1_1DestinationSchema = (output: any, context: __SerdeContext): DestinationSchema => {
   return {
-    RecordFormatType:
-      output.RecordFormatType !== undefined && output.RecordFormatType !== null ? output.RecordFormatType : undefined,
+    RecordFormatType: __expectString(output.RecordFormatType),
   } as any;
 };
 
@@ -6046,10 +5926,7 @@ const deserializeAws_json1_1FlinkApplicationConfigurationDescription = (
       output.CheckpointConfigurationDescription !== undefined && output.CheckpointConfigurationDescription !== null
         ? deserializeAws_json1_1CheckpointConfigurationDescription(output.CheckpointConfigurationDescription, context)
         : undefined,
-    JobPlanDescription:
-      output.JobPlanDescription !== undefined && output.JobPlanDescription !== null
-        ? output.JobPlanDescription
-        : undefined,
+    JobPlanDescription: __expectString(output.JobPlanDescription),
     MonitoringConfigurationDescription:
       output.MonitoringConfigurationDescription !== undefined && output.MonitoringConfigurationDescription !== null
         ? deserializeAws_json1_1MonitoringConfigurationDescription(output.MonitoringConfigurationDescription, context)
@@ -6063,10 +5940,7 @@ const deserializeAws_json1_1FlinkApplicationConfigurationDescription = (
 
 const deserializeAws_json1_1FlinkRunConfiguration = (output: any, context: __SerdeContext): FlinkRunConfiguration => {
   return {
-    AllowNonRestoredState:
-      output.AllowNonRestoredState !== undefined && output.AllowNonRestoredState !== null
-        ? output.AllowNonRestoredState
-        : undefined,
+    AllowNonRestoredState: __expectBoolean(output.AllowNonRestoredState),
   } as any;
 };
 
@@ -6075,7 +5949,7 @@ const deserializeAws_json1_1GlueDataCatalogConfigurationDescription = (
   context: __SerdeContext
 ): GlueDataCatalogConfigurationDescription => {
   return {
-    DatabaseARN: output.DatabaseARN !== undefined && output.DatabaseARN !== null ? output.DatabaseARN : undefined,
+    DatabaseARN: __expectString(output.DatabaseARN),
   } as any;
 };
 
@@ -6086,7 +5960,7 @@ const deserializeAws_json1_1InAppStreamNames = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6096,7 +5970,7 @@ const deserializeAws_json1_1InputDescription = (output: any, context: __SerdeCon
       output.InAppStreamNames !== undefined && output.InAppStreamNames !== null
         ? deserializeAws_json1_1InAppStreamNames(output.InAppStreamNames, context)
         : undefined,
-    InputId: output.InputId !== undefined && output.InputId !== null ? output.InputId : undefined,
+    InputId: __expectString(output.InputId),
     InputParallelism:
       output.InputParallelism !== undefined && output.InputParallelism !== null
         ? deserializeAws_json1_1InputParallelism(output.InputParallelism, context)
@@ -6125,7 +5999,7 @@ const deserializeAws_json1_1InputDescription = (output: any, context: __SerdeCon
       output.KinesisStreamsInputDescription !== undefined && output.KinesisStreamsInputDescription !== null
         ? deserializeAws_json1_1KinesisStreamsInputDescription(output.KinesisStreamsInputDescription, context)
         : undefined,
-    NamePrefix: output.NamePrefix !== undefined && output.NamePrefix !== null ? output.NamePrefix : undefined,
+    NamePrefix: __expectString(output.NamePrefix),
   } as any;
 };
 
@@ -6145,14 +6019,14 @@ const deserializeAws_json1_1InputLambdaProcessorDescription = (
   context: __SerdeContext
 ): InputLambdaProcessorDescription => {
   return {
-    ResourceARN: output.ResourceARN !== undefined && output.ResourceARN !== null ? output.ResourceARN : undefined,
-    RoleARN: output.RoleARN !== undefined && output.RoleARN !== null ? output.RoleARN : undefined,
+    ResourceARN: __expectString(output.ResourceARN),
+    RoleARN: __expectString(output.RoleARN),
   } as any;
 };
 
 const deserializeAws_json1_1InputParallelism = (output: any, context: __SerdeContext): InputParallelism => {
   return {
-    Count: output.Count !== undefined && output.Count !== null ? output.Count : undefined,
+    Count: __expectNumber(output.Count),
   } as any;
 };
 
@@ -6173,10 +6047,7 @@ const deserializeAws_json1_1InputStartingPositionConfiguration = (
   context: __SerdeContext
 ): InputStartingPositionConfiguration => {
   return {
-    InputStartingPosition:
-      output.InputStartingPosition !== undefined && output.InputStartingPosition !== null
-        ? output.InputStartingPosition
-        : undefined,
+    InputStartingPosition: __expectString(output.InputStartingPosition),
   } as any;
 };
 
@@ -6185,7 +6056,7 @@ const deserializeAws_json1_1InvalidApplicationConfigurationException = (
   context: __SerdeContext
 ): InvalidApplicationConfigurationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -6194,7 +6065,7 @@ const deserializeAws_json1_1InvalidArgumentException = (
   context: __SerdeContext
 ): InvalidArgumentException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -6203,14 +6074,13 @@ const deserializeAws_json1_1InvalidRequestException = (
   context: __SerdeContext
 ): InvalidRequestException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1JSONMappingParameters = (output: any, context: __SerdeContext): JSONMappingParameters => {
   return {
-    RecordRowPath:
-      output.RecordRowPath !== undefined && output.RecordRowPath !== null ? output.RecordRowPath : undefined,
+    RecordRowPath: __expectString(output.RecordRowPath),
   } as any;
 };
 
@@ -6219,8 +6089,8 @@ const deserializeAws_json1_1KinesisFirehoseInputDescription = (
   context: __SerdeContext
 ): KinesisFirehoseInputDescription => {
   return {
-    ResourceARN: output.ResourceARN !== undefined && output.ResourceARN !== null ? output.ResourceARN : undefined,
-    RoleARN: output.RoleARN !== undefined && output.RoleARN !== null ? output.RoleARN : undefined,
+    ResourceARN: __expectString(output.ResourceARN),
+    RoleARN: __expectString(output.RoleARN),
   } as any;
 };
 
@@ -6229,8 +6099,8 @@ const deserializeAws_json1_1KinesisFirehoseOutputDescription = (
   context: __SerdeContext
 ): KinesisFirehoseOutputDescription => {
   return {
-    ResourceARN: output.ResourceARN !== undefined && output.ResourceARN !== null ? output.ResourceARN : undefined,
-    RoleARN: output.RoleARN !== undefined && output.RoleARN !== null ? output.RoleARN : undefined,
+    ResourceARN: __expectString(output.ResourceARN),
+    RoleARN: __expectString(output.RoleARN),
   } as any;
 };
 
@@ -6239,8 +6109,8 @@ const deserializeAws_json1_1KinesisStreamsInputDescription = (
   context: __SerdeContext
 ): KinesisStreamsInputDescription => {
   return {
-    ResourceARN: output.ResourceARN !== undefined && output.ResourceARN !== null ? output.ResourceARN : undefined,
-    RoleARN: output.RoleARN !== undefined && output.RoleARN !== null ? output.RoleARN : undefined,
+    ResourceARN: __expectString(output.ResourceARN),
+    RoleARN: __expectString(output.RoleARN),
   } as any;
 };
 
@@ -6249,8 +6119,8 @@ const deserializeAws_json1_1KinesisStreamsOutputDescription = (
   context: __SerdeContext
 ): KinesisStreamsOutputDescription => {
   return {
-    ResourceARN: output.ResourceARN !== undefined && output.ResourceARN !== null ? output.ResourceARN : undefined,
-    RoleARN: output.RoleARN !== undefined && output.RoleARN !== null ? output.RoleARN : undefined,
+    ResourceARN: __expectString(output.ResourceARN),
+    RoleARN: __expectString(output.RoleARN),
   } as any;
 };
 
@@ -6259,14 +6129,14 @@ const deserializeAws_json1_1LambdaOutputDescription = (
   context: __SerdeContext
 ): LambdaOutputDescription => {
   return {
-    ResourceARN: output.ResourceARN !== undefined && output.ResourceARN !== null ? output.ResourceARN : undefined,
-    RoleARN: output.RoleARN !== undefined && output.RoleARN !== null ? output.RoleARN : undefined,
+    ResourceARN: __expectString(output.ResourceARN),
+    RoleARN: __expectString(output.RoleARN),
   } as any;
 };
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -6275,7 +6145,7 @@ const deserializeAws_json1_1ListApplicationSnapshotsResponse = (
   context: __SerdeContext
 ): ListApplicationSnapshotsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     SnapshotSummaries:
       output.SnapshotSummaries !== undefined && output.SnapshotSummaries !== null
         ? deserializeAws_json1_1SnapshotSummaries(output.SnapshotSummaries, context)
@@ -6292,7 +6162,7 @@ const deserializeAws_json1_1ListApplicationsResponse = (
       output.ApplicationSummaries !== undefined && output.ApplicationSummaries !== null
         ? deserializeAws_json1_1ApplicationSummaries(output.ApplicationSummaries, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -6305,7 +6175,7 @@ const deserializeAws_json1_1ListApplicationVersionsResponse = (
       output.ApplicationVersionSummaries !== undefined && output.ApplicationVersionSummaries !== null
         ? deserializeAws_json1_1ApplicationVersionSummaries(output.ApplicationVersionSummaries, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -6334,9 +6204,9 @@ const deserializeAws_json1_1MappingParameters = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1MavenReference = (output: any, context: __SerdeContext): MavenReference => {
   return {
-    ArtifactId: output.ArtifactId !== undefined && output.ArtifactId !== null ? output.ArtifactId : undefined,
-    GroupId: output.GroupId !== undefined && output.GroupId !== null ? output.GroupId : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    ArtifactId: __expectString(output.ArtifactId),
+    GroupId: __expectString(output.GroupId),
+    Version: __expectString(output.Version),
   } as any;
 };
 
@@ -6345,12 +6215,9 @@ const deserializeAws_json1_1MonitoringConfigurationDescription = (
   context: __SerdeContext
 ): MonitoringConfigurationDescription => {
   return {
-    ConfigurationType:
-      output.ConfigurationType !== undefined && output.ConfigurationType !== null
-        ? output.ConfigurationType
-        : undefined,
-    LogLevel: output.LogLevel !== undefined && output.LogLevel !== null ? output.LogLevel : undefined,
-    MetricsLevel: output.MetricsLevel !== undefined && output.MetricsLevel !== null ? output.MetricsLevel : undefined,
+    ConfigurationType: __expectString(output.ConfigurationType),
+    LogLevel: __expectString(output.LogLevel),
+    MetricsLevel: __expectString(output.MetricsLevel),
   } as any;
 };
 
@@ -6372,8 +6239,8 @@ const deserializeAws_json1_1OutputDescription = (output: any, context: __SerdeCo
       output.LambdaOutputDescription !== undefined && output.LambdaOutputDescription !== null
         ? deserializeAws_json1_1LambdaOutputDescription(output.LambdaOutputDescription, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    OutputId: output.OutputId !== undefined && output.OutputId !== null ? output.OutputId : undefined,
+    Name: __expectString(output.Name),
+    OutputId: __expectString(output.OutputId),
   } as any;
 };
 
@@ -6393,23 +6260,11 @@ const deserializeAws_json1_1ParallelismConfigurationDescription = (
   context: __SerdeContext
 ): ParallelismConfigurationDescription => {
   return {
-    AutoScalingEnabled:
-      output.AutoScalingEnabled !== undefined && output.AutoScalingEnabled !== null
-        ? output.AutoScalingEnabled
-        : undefined,
-    ConfigurationType:
-      output.ConfigurationType !== undefined && output.ConfigurationType !== null
-        ? output.ConfigurationType
-        : undefined,
-    CurrentParallelism:
-      output.CurrentParallelism !== undefined && output.CurrentParallelism !== null
-        ? output.CurrentParallelism
-        : undefined,
-    Parallelism: output.Parallelism !== undefined && output.Parallelism !== null ? output.Parallelism : undefined,
-    ParallelismPerKPU:
-      output.ParallelismPerKPU !== undefined && output.ParallelismPerKPU !== null
-        ? output.ParallelismPerKPU
-        : undefined,
+    AutoScalingEnabled: __expectBoolean(output.AutoScalingEnabled),
+    ConfigurationType: __expectString(output.ConfigurationType),
+    CurrentParallelism: __expectNumber(output.CurrentParallelism),
+    Parallelism: __expectNumber(output.Parallelism),
+    ParallelismPerKPU: __expectNumber(output.ParallelismPerKPU),
   } as any;
 };
 
@@ -6420,7 +6275,7 @@ const deserializeAws_json1_1ParsedInputRecord = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6442,14 +6297,13 @@ const deserializeAws_json1_1ProcessedInputRecords = (output: any, context: __Ser
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1PropertyGroup = (output: any, context: __SerdeContext): PropertyGroup => {
   return {
-    PropertyGroupId:
-      output.PropertyGroupId !== undefined && output.PropertyGroupId !== null ? output.PropertyGroupId : undefined,
+    PropertyGroupId: __expectString(output.PropertyGroupId),
     PropertyMap:
       output.PropertyMap !== undefined && output.PropertyMap !== null
         ? deserializeAws_json1_1PropertyMap(output.PropertyMap, context)
@@ -6475,7 +6329,7 @@ const deserializeAws_json1_1PropertyMap = (output: any, context: __SerdeContext)
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -6487,15 +6341,15 @@ const deserializeAws_json1_1RawInputRecords = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1RecordColumn = (output: any, context: __SerdeContext): RecordColumn => {
   return {
-    Mapping: output.Mapping !== undefined && output.Mapping !== null ? output.Mapping : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    SqlType: output.SqlType !== undefined && output.SqlType !== null ? output.SqlType : undefined,
+    Mapping: __expectString(output.Mapping),
+    Name: __expectString(output.Name),
+    SqlType: __expectString(output.SqlType),
   } as any;
 };
 
@@ -6516,8 +6370,7 @@ const deserializeAws_json1_1RecordFormat = (output: any, context: __SerdeContext
       output.MappingParameters !== undefined && output.MappingParameters !== null
         ? deserializeAws_json1_1MappingParameters(output.MappingParameters, context)
         : undefined,
-    RecordFormatType:
-      output.RecordFormatType !== undefined && output.RecordFormatType !== null ? output.RecordFormatType : undefined,
+    RecordFormatType: __expectString(output.RecordFormatType),
   } as any;
 };
 
@@ -6526,7 +6379,7 @@ const deserializeAws_json1_1ReferenceDataSourceDescription = (
   context: __SerdeContext
 ): ReferenceDataSourceDescription => {
   return {
-    ReferenceId: output.ReferenceId !== undefined && output.ReferenceId !== null ? output.ReferenceId : undefined,
+    ReferenceId: __expectString(output.ReferenceId),
     ReferenceSchema:
       output.ReferenceSchema !== undefined && output.ReferenceSchema !== null
         ? deserializeAws_json1_1SourceSchema(output.ReferenceSchema, context)
@@ -6535,7 +6388,7 @@ const deserializeAws_json1_1ReferenceDataSourceDescription = (
       output.S3ReferenceDataSourceDescription !== undefined && output.S3ReferenceDataSourceDescription !== null
         ? deserializeAws_json1_1S3ReferenceDataSourceDescription(output.S3ReferenceDataSourceDescription, context)
         : undefined,
-    TableName: output.TableName !== undefined && output.TableName !== null ? output.TableName : undefined,
+    TableName: __expectString(output.TableName),
   } as any;
 };
 
@@ -6555,7 +6408,7 @@ const deserializeAws_json1_1ReferenceDataSourceDescriptions = (
 
 const deserializeAws_json1_1ResourceInUseException = (output: any, context: __SerdeContext): ResourceInUseException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -6564,7 +6417,7 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -6573,7 +6426,7 @@ const deserializeAws_json1_1ResourceProvisionedThroughputExceededException = (
   context: __SerdeContext
 ): ResourceProvisionedThroughputExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -6614,10 +6467,9 @@ const deserializeAws_json1_1S3ApplicationCodeLocationDescription = (
   context: __SerdeContext
 ): S3ApplicationCodeLocationDescription => {
   return {
-    BucketARN: output.BucketARN !== undefined && output.BucketARN !== null ? output.BucketARN : undefined,
-    FileKey: output.FileKey !== undefined && output.FileKey !== null ? output.FileKey : undefined,
-    ObjectVersion:
-      output.ObjectVersion !== undefined && output.ObjectVersion !== null ? output.ObjectVersion : undefined,
+    BucketARN: __expectString(output.BucketARN),
+    FileKey: __expectString(output.FileKey),
+    ObjectVersion: __expectString(output.ObjectVersion),
   } as any;
 };
 
@@ -6626,17 +6478,16 @@ const deserializeAws_json1_1S3ContentBaseLocationDescription = (
   context: __SerdeContext
 ): S3ContentBaseLocationDescription => {
   return {
-    BasePath: output.BasePath !== undefined && output.BasePath !== null ? output.BasePath : undefined,
-    BucketARN: output.BucketARN !== undefined && output.BucketARN !== null ? output.BucketARN : undefined,
+    BasePath: __expectString(output.BasePath),
+    BucketARN: __expectString(output.BucketARN),
   } as any;
 };
 
 const deserializeAws_json1_1S3ContentLocation = (output: any, context: __SerdeContext): S3ContentLocation => {
   return {
-    BucketARN: output.BucketARN !== undefined && output.BucketARN !== null ? output.BucketARN : undefined,
-    FileKey: output.FileKey !== undefined && output.FileKey !== null ? output.FileKey : undefined,
-    ObjectVersion:
-      output.ObjectVersion !== undefined && output.ObjectVersion !== null ? output.ObjectVersion : undefined,
+    BucketARN: __expectString(output.BucketARN),
+    FileKey: __expectString(output.FileKey),
+    ObjectVersion: __expectString(output.ObjectVersion),
   } as any;
 };
 
@@ -6645,10 +6496,9 @@ const deserializeAws_json1_1S3ReferenceDataSourceDescription = (
   context: __SerdeContext
 ): S3ReferenceDataSourceDescription => {
   return {
-    BucketARN: output.BucketARN !== undefined && output.BucketARN !== null ? output.BucketARN : undefined,
-    FileKey: output.FileKey !== undefined && output.FileKey !== null ? output.FileKey : undefined,
-    ReferenceRoleARN:
-      output.ReferenceRoleARN !== undefined && output.ReferenceRoleARN !== null ? output.ReferenceRoleARN : undefined,
+    BucketARN: __expectString(output.BucketARN),
+    FileKey: __expectString(output.FileKey),
+    ReferenceRoleARN: __expectString(output.ReferenceRoleARN),
   } as any;
 };
 
@@ -6659,7 +6509,7 @@ const deserializeAws_json1_1SecurityGroupIds = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6668,23 +6518,19 @@ const deserializeAws_json1_1ServiceUnavailableException = (
   context: __SerdeContext
 ): ServiceUnavailableException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1SnapshotDetails = (output: any, context: __SerdeContext): SnapshotDetails => {
   return {
-    ApplicationVersionId:
-      output.ApplicationVersionId !== undefined && output.ApplicationVersionId !== null
-        ? output.ApplicationVersionId
-        : undefined,
+    ApplicationVersionId: __expectNumber(output.ApplicationVersionId),
     SnapshotCreationTimestamp:
       output.SnapshotCreationTimestamp !== undefined && output.SnapshotCreationTimestamp !== null
         ? new Date(Math.round(output.SnapshotCreationTimestamp * 1000))
         : undefined,
-    SnapshotName: output.SnapshotName !== undefined && output.SnapshotName !== null ? output.SnapshotName : undefined,
-    SnapshotStatus:
-      output.SnapshotStatus !== undefined && output.SnapshotStatus !== null ? output.SnapshotStatus : undefined,
+    SnapshotName: __expectString(output.SnapshotName),
+    SnapshotStatus: __expectString(output.SnapshotStatus),
   } as any;
 };
 
@@ -6705,8 +6551,7 @@ const deserializeAws_json1_1SourceSchema = (output: any, context: __SerdeContext
       output.RecordColumns !== undefined && output.RecordColumns !== null
         ? deserializeAws_json1_1RecordColumns(output.RecordColumns, context)
         : undefined,
-    RecordEncoding:
-      output.RecordEncoding !== undefined && output.RecordEncoding !== null ? output.RecordEncoding : undefined,
+    RecordEncoding: __expectString(output.RecordEncoding),
     RecordFormat:
       output.RecordFormat !== undefined && output.RecordFormat !== null
         ? deserializeAws_json1_1RecordFormat(output.RecordFormat, context)
@@ -6755,14 +6600,14 @@ const deserializeAws_json1_1SubnetIds = (output: any, context: __SerdeContext): 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -6783,7 +6628,7 @@ const deserializeAws_json1_1Tags = (output: any, context: __SerdeContext): Tag[]
 
 const deserializeAws_json1_1TooManyTagsException = (output: any, context: __SerdeContext): TooManyTagsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6792,7 +6637,7 @@ const deserializeAws_json1_1UnableToDetectSchemaException = (
   context: __SerdeContext
 ): UnableToDetectSchemaException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
     ProcessedInputRecords:
       output.ProcessedInputRecords !== undefined && output.ProcessedInputRecords !== null
         ? deserializeAws_json1_1ProcessedInputRecords(output.ProcessedInputRecords, context)
@@ -6809,7 +6654,7 @@ const deserializeAws_json1_1UnsupportedOperationException = (
   context: __SerdeContext
 ): UnsupportedOperationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -6822,8 +6667,7 @@ const deserializeAws_json1_1UpdateApplicationMaintenanceConfigurationResponse = 
   context: __SerdeContext
 ): UpdateApplicationMaintenanceConfigurationResponse => {
   return {
-    ApplicationARN:
-      output.ApplicationARN !== undefined && output.ApplicationARN !== null ? output.ApplicationARN : undefined,
+    ApplicationARN: __expectString(output.ApplicationARN),
     ApplicationMaintenanceConfigurationDescription:
       output.ApplicationMaintenanceConfigurationDescription !== undefined &&
       output.ApplicationMaintenanceConfigurationDescription !== null
@@ -6860,11 +6704,8 @@ const deserializeAws_json1_1VpcConfigurationDescription = (
       output.SubnetIds !== undefined && output.SubnetIds !== null
         ? deserializeAws_json1_1SubnetIds(output.SubnetIds, context)
         : undefined,
-    VpcConfigurationId:
-      output.VpcConfigurationId !== undefined && output.VpcConfigurationId !== null
-        ? output.VpcConfigurationId
-        : undefined,
-    VpcId: output.VpcId !== undefined && output.VpcId !== null ? output.VpcId : undefined,
+    VpcConfigurationId: __expectString(output.VpcConfigurationId),
+    VpcId: __expectString(output.VpcId),
   } as any;
 };
 
@@ -6922,7 +6763,7 @@ const deserializeAws_json1_1ZeppelinMonitoringConfigurationDescription = (
   context: __SerdeContext
 ): ZeppelinMonitoringConfigurationDescription => {
   return {
-    LogLevel: output.LogLevel !== undefined && output.LogLevel !== null ? output.LogLevel : undefined,
+    LogLevel: __expectString(output.LogLevel),
   } as any;
 };
 

--- a/clients/client-kinesis-analytics/protocols/Aws_json1_1.ts
+++ b/clients/client-kinesis-analytics/protocols/Aws_json1_1.ts
@@ -162,7 +162,12 @@ import {
   UpdateApplicationResponse,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -3166,24 +3171,12 @@ const deserializeAws_json1_1AddApplicationReferenceDataSourceResponse = (
 
 const deserializeAws_json1_1ApplicationDetail = (output: any, context: __SerdeContext): ApplicationDetail => {
   return {
-    ApplicationARN:
-      output.ApplicationARN !== undefined && output.ApplicationARN !== null ? output.ApplicationARN : undefined,
-    ApplicationCode:
-      output.ApplicationCode !== undefined && output.ApplicationCode !== null ? output.ApplicationCode : undefined,
-    ApplicationDescription:
-      output.ApplicationDescription !== undefined && output.ApplicationDescription !== null
-        ? output.ApplicationDescription
-        : undefined,
-    ApplicationName:
-      output.ApplicationName !== undefined && output.ApplicationName !== null ? output.ApplicationName : undefined,
-    ApplicationStatus:
-      output.ApplicationStatus !== undefined && output.ApplicationStatus !== null
-        ? output.ApplicationStatus
-        : undefined,
-    ApplicationVersionId:
-      output.ApplicationVersionId !== undefined && output.ApplicationVersionId !== null
-        ? output.ApplicationVersionId
-        : undefined,
+    ApplicationARN: __expectString(output.ApplicationARN),
+    ApplicationCode: __expectString(output.ApplicationCode),
+    ApplicationDescription: __expectString(output.ApplicationDescription),
+    ApplicationName: __expectString(output.ApplicationName),
+    ApplicationStatus: __expectString(output.ApplicationStatus),
+    ApplicationVersionId: __expectNumber(output.ApplicationVersionId),
     CloudWatchLoggingOptionDescriptions:
       output.CloudWatchLoggingOptionDescriptions !== undefined && output.CloudWatchLoggingOptionDescriptions !== null
         ? deserializeAws_json1_1CloudWatchLoggingOptionDescriptions(output.CloudWatchLoggingOptionDescriptions, context)
@@ -3224,14 +3217,9 @@ const deserializeAws_json1_1ApplicationSummaries = (output: any, context: __Serd
 
 const deserializeAws_json1_1ApplicationSummary = (output: any, context: __SerdeContext): ApplicationSummary => {
   return {
-    ApplicationARN:
-      output.ApplicationARN !== undefined && output.ApplicationARN !== null ? output.ApplicationARN : undefined,
-    ApplicationName:
-      output.ApplicationName !== undefined && output.ApplicationName !== null ? output.ApplicationName : undefined,
-    ApplicationStatus:
-      output.ApplicationStatus !== undefined && output.ApplicationStatus !== null
-        ? output.ApplicationStatus
-        : undefined,
+    ApplicationARN: __expectString(output.ApplicationARN),
+    ApplicationName: __expectString(output.ApplicationName),
+    ApplicationStatus: __expectString(output.ApplicationStatus),
   } as any;
 };
 
@@ -3240,12 +3228,9 @@ const deserializeAws_json1_1CloudWatchLoggingOptionDescription = (
   context: __SerdeContext
 ): CloudWatchLoggingOptionDescription => {
   return {
-    CloudWatchLoggingOptionId:
-      output.CloudWatchLoggingOptionId !== undefined && output.CloudWatchLoggingOptionId !== null
-        ? output.CloudWatchLoggingOptionId
-        : undefined,
-    LogStreamARN: output.LogStreamARN !== undefined && output.LogStreamARN !== null ? output.LogStreamARN : undefined,
-    RoleARN: output.RoleARN !== undefined && output.RoleARN !== null ? output.RoleARN : undefined,
+    CloudWatchLoggingOptionId: __expectString(output.CloudWatchLoggingOptionId),
+    LogStreamARN: __expectString(output.LogStreamARN),
+    RoleARN: __expectString(output.RoleARN),
   } as any;
 };
 
@@ -3268,7 +3253,7 @@ const deserializeAws_json1_1CodeValidationException = (
   context: __SerdeContext
 ): CodeValidationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3277,7 +3262,7 @@ const deserializeAws_json1_1ConcurrentModificationException = (
   context: __SerdeContext
 ): ConcurrentModificationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3295,14 +3280,8 @@ const deserializeAws_json1_1CreateApplicationResponse = (
 
 const deserializeAws_json1_1CSVMappingParameters = (output: any, context: __SerdeContext): CSVMappingParameters => {
   return {
-    RecordColumnDelimiter:
-      output.RecordColumnDelimiter !== undefined && output.RecordColumnDelimiter !== null
-        ? output.RecordColumnDelimiter
-        : undefined,
-    RecordRowDelimiter:
-      output.RecordRowDelimiter !== undefined && output.RecordRowDelimiter !== null
-        ? output.RecordRowDelimiter
-        : undefined,
+    RecordColumnDelimiter: __expectString(output.RecordColumnDelimiter),
+    RecordRowDelimiter: __expectString(output.RecordRowDelimiter),
   } as any;
 };
 
@@ -3355,8 +3334,7 @@ const deserializeAws_json1_1DescribeApplicationResponse = (
 
 const deserializeAws_json1_1DestinationSchema = (output: any, context: __SerdeContext): DestinationSchema => {
   return {
-    RecordFormatType:
-      output.RecordFormatType !== undefined && output.RecordFormatType !== null ? output.RecordFormatType : undefined,
+    RecordFormatType: __expectString(output.RecordFormatType),
   } as any;
 };
 
@@ -3391,7 +3369,7 @@ const deserializeAws_json1_1InAppStreamNames = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3401,7 +3379,7 @@ const deserializeAws_json1_1InputDescription = (output: any, context: __SerdeCon
       output.InAppStreamNames !== undefined && output.InAppStreamNames !== null
         ? deserializeAws_json1_1InAppStreamNames(output.InAppStreamNames, context)
         : undefined,
-    InputId: output.InputId !== undefined && output.InputId !== null ? output.InputId : undefined,
+    InputId: __expectString(output.InputId),
     InputParallelism:
       output.InputParallelism !== undefined && output.InputParallelism !== null
         ? deserializeAws_json1_1InputParallelism(output.InputParallelism, context)
@@ -3430,7 +3408,7 @@ const deserializeAws_json1_1InputDescription = (output: any, context: __SerdeCon
       output.KinesisStreamsInputDescription !== undefined && output.KinesisStreamsInputDescription !== null
         ? deserializeAws_json1_1KinesisStreamsInputDescription(output.KinesisStreamsInputDescription, context)
         : undefined,
-    NamePrefix: output.NamePrefix !== undefined && output.NamePrefix !== null ? output.NamePrefix : undefined,
+    NamePrefix: __expectString(output.NamePrefix),
   } as any;
 };
 
@@ -3450,14 +3428,14 @@ const deserializeAws_json1_1InputLambdaProcessorDescription = (
   context: __SerdeContext
 ): InputLambdaProcessorDescription => {
   return {
-    ResourceARN: output.ResourceARN !== undefined && output.ResourceARN !== null ? output.ResourceARN : undefined,
-    RoleARN: output.RoleARN !== undefined && output.RoleARN !== null ? output.RoleARN : undefined,
+    ResourceARN: __expectString(output.ResourceARN),
+    RoleARN: __expectString(output.RoleARN),
   } as any;
 };
 
 const deserializeAws_json1_1InputParallelism = (output: any, context: __SerdeContext): InputParallelism => {
   return {
-    Count: output.Count !== undefined && output.Count !== null ? output.Count : undefined,
+    Count: __expectNumber(output.Count),
   } as any;
 };
 
@@ -3478,10 +3456,7 @@ const deserializeAws_json1_1InputStartingPositionConfiguration = (
   context: __SerdeContext
 ): InputStartingPositionConfiguration => {
   return {
-    InputStartingPosition:
-      output.InputStartingPosition !== undefined && output.InputStartingPosition !== null
-        ? output.InputStartingPosition
-        : undefined,
+    InputStartingPosition: __expectString(output.InputStartingPosition),
   } as any;
 };
 
@@ -3490,7 +3465,7 @@ const deserializeAws_json1_1InvalidApplicationConfigurationException = (
   context: __SerdeContext
 ): InvalidApplicationConfigurationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3499,14 +3474,13 @@ const deserializeAws_json1_1InvalidArgumentException = (
   context: __SerdeContext
 ): InvalidArgumentException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1JSONMappingParameters = (output: any, context: __SerdeContext): JSONMappingParameters => {
   return {
-    RecordRowPath:
-      output.RecordRowPath !== undefined && output.RecordRowPath !== null ? output.RecordRowPath : undefined,
+    RecordRowPath: __expectString(output.RecordRowPath),
   } as any;
 };
 
@@ -3515,8 +3489,8 @@ const deserializeAws_json1_1KinesisFirehoseInputDescription = (
   context: __SerdeContext
 ): KinesisFirehoseInputDescription => {
   return {
-    ResourceARN: output.ResourceARN !== undefined && output.ResourceARN !== null ? output.ResourceARN : undefined,
-    RoleARN: output.RoleARN !== undefined && output.RoleARN !== null ? output.RoleARN : undefined,
+    ResourceARN: __expectString(output.ResourceARN),
+    RoleARN: __expectString(output.RoleARN),
   } as any;
 };
 
@@ -3525,8 +3499,8 @@ const deserializeAws_json1_1KinesisFirehoseOutputDescription = (
   context: __SerdeContext
 ): KinesisFirehoseOutputDescription => {
   return {
-    ResourceARN: output.ResourceARN !== undefined && output.ResourceARN !== null ? output.ResourceARN : undefined,
-    RoleARN: output.RoleARN !== undefined && output.RoleARN !== null ? output.RoleARN : undefined,
+    ResourceARN: __expectString(output.ResourceARN),
+    RoleARN: __expectString(output.RoleARN),
   } as any;
 };
 
@@ -3535,8 +3509,8 @@ const deserializeAws_json1_1KinesisStreamsInputDescription = (
   context: __SerdeContext
 ): KinesisStreamsInputDescription => {
   return {
-    ResourceARN: output.ResourceARN !== undefined && output.ResourceARN !== null ? output.ResourceARN : undefined,
-    RoleARN: output.RoleARN !== undefined && output.RoleARN !== null ? output.RoleARN : undefined,
+    ResourceARN: __expectString(output.ResourceARN),
+    RoleARN: __expectString(output.RoleARN),
   } as any;
 };
 
@@ -3545,8 +3519,8 @@ const deserializeAws_json1_1KinesisStreamsOutputDescription = (
   context: __SerdeContext
 ): KinesisStreamsOutputDescription => {
   return {
-    ResourceARN: output.ResourceARN !== undefined && output.ResourceARN !== null ? output.ResourceARN : undefined,
-    RoleARN: output.RoleARN !== undefined && output.RoleARN !== null ? output.RoleARN : undefined,
+    ResourceARN: __expectString(output.ResourceARN),
+    RoleARN: __expectString(output.RoleARN),
   } as any;
 };
 
@@ -3555,14 +3529,14 @@ const deserializeAws_json1_1LambdaOutputDescription = (
   context: __SerdeContext
 ): LambdaOutputDescription => {
   return {
-    ResourceARN: output.ResourceARN !== undefined && output.ResourceARN !== null ? output.ResourceARN : undefined,
-    RoleARN: output.RoleARN !== undefined && output.RoleARN !== null ? output.RoleARN : undefined,
+    ResourceARN: __expectString(output.ResourceARN),
+    RoleARN: __expectString(output.RoleARN),
   } as any;
 };
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3575,10 +3549,7 @@ const deserializeAws_json1_1ListApplicationsResponse = (
       output.ApplicationSummaries !== undefined && output.ApplicationSummaries !== null
         ? deserializeAws_json1_1ApplicationSummaries(output.ApplicationSummaries, context)
         : undefined,
-    HasMoreApplications:
-      output.HasMoreApplications !== undefined && output.HasMoreApplications !== null
-        ? output.HasMoreApplications
-        : undefined,
+    HasMoreApplications: __expectBoolean(output.HasMoreApplications),
   } as any;
 };
 
@@ -3623,8 +3594,8 @@ const deserializeAws_json1_1OutputDescription = (output: any, context: __SerdeCo
       output.LambdaOutputDescription !== undefined && output.LambdaOutputDescription !== null
         ? deserializeAws_json1_1LambdaOutputDescription(output.LambdaOutputDescription, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    OutputId: output.OutputId !== undefined && output.OutputId !== null ? output.OutputId : undefined,
+    Name: __expectString(output.Name),
+    OutputId: __expectString(output.OutputId),
   } as any;
 };
 
@@ -3646,7 +3617,7 @@ const deserializeAws_json1_1ParsedInputRecord = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3668,7 +3639,7 @@ const deserializeAws_json1_1ProcessedInputRecords = (output: any, context: __Ser
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3679,15 +3650,15 @@ const deserializeAws_json1_1RawInputRecords = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1RecordColumn = (output: any, context: __SerdeContext): RecordColumn => {
   return {
-    Mapping: output.Mapping !== undefined && output.Mapping !== null ? output.Mapping : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    SqlType: output.SqlType !== undefined && output.SqlType !== null ? output.SqlType : undefined,
+    Mapping: __expectString(output.Mapping),
+    Name: __expectString(output.Name),
+    SqlType: __expectString(output.SqlType),
   } as any;
 };
 
@@ -3708,8 +3679,7 @@ const deserializeAws_json1_1RecordFormat = (output: any, context: __SerdeContext
       output.MappingParameters !== undefined && output.MappingParameters !== null
         ? deserializeAws_json1_1MappingParameters(output.MappingParameters, context)
         : undefined,
-    RecordFormatType:
-      output.RecordFormatType !== undefined && output.RecordFormatType !== null ? output.RecordFormatType : undefined,
+    RecordFormatType: __expectString(output.RecordFormatType),
   } as any;
 };
 
@@ -3718,7 +3688,7 @@ const deserializeAws_json1_1ReferenceDataSourceDescription = (
   context: __SerdeContext
 ): ReferenceDataSourceDescription => {
   return {
-    ReferenceId: output.ReferenceId !== undefined && output.ReferenceId !== null ? output.ReferenceId : undefined,
+    ReferenceId: __expectString(output.ReferenceId),
     ReferenceSchema:
       output.ReferenceSchema !== undefined && output.ReferenceSchema !== null
         ? deserializeAws_json1_1SourceSchema(output.ReferenceSchema, context)
@@ -3727,7 +3697,7 @@ const deserializeAws_json1_1ReferenceDataSourceDescription = (
       output.S3ReferenceDataSourceDescription !== undefined && output.S3ReferenceDataSourceDescription !== null
         ? deserializeAws_json1_1S3ReferenceDataSourceDescription(output.S3ReferenceDataSourceDescription, context)
         : undefined,
-    TableName: output.TableName !== undefined && output.TableName !== null ? output.TableName : undefined,
+    TableName: __expectString(output.TableName),
   } as any;
 };
 
@@ -3747,7 +3717,7 @@ const deserializeAws_json1_1ReferenceDataSourceDescriptions = (
 
 const deserializeAws_json1_1ResourceInUseException = (output: any, context: __SerdeContext): ResourceInUseException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3756,7 +3726,7 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3765,7 +3735,7 @@ const deserializeAws_json1_1ResourceProvisionedThroughputExceededException = (
   context: __SerdeContext
 ): ResourceProvisionedThroughputExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3774,10 +3744,9 @@ const deserializeAws_json1_1S3ReferenceDataSourceDescription = (
   context: __SerdeContext
 ): S3ReferenceDataSourceDescription => {
   return {
-    BucketARN: output.BucketARN !== undefined && output.BucketARN !== null ? output.BucketARN : undefined,
-    FileKey: output.FileKey !== undefined && output.FileKey !== null ? output.FileKey : undefined,
-    ReferenceRoleARN:
-      output.ReferenceRoleARN !== undefined && output.ReferenceRoleARN !== null ? output.ReferenceRoleARN : undefined,
+    BucketARN: __expectString(output.BucketARN),
+    FileKey: __expectString(output.FileKey),
+    ReferenceRoleARN: __expectString(output.ReferenceRoleARN),
   } as any;
 };
 
@@ -3786,7 +3755,7 @@ const deserializeAws_json1_1ServiceUnavailableException = (
   context: __SerdeContext
 ): ServiceUnavailableException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3796,8 +3765,7 @@ const deserializeAws_json1_1SourceSchema = (output: any, context: __SerdeContext
       output.RecordColumns !== undefined && output.RecordColumns !== null
         ? deserializeAws_json1_1RecordColumns(output.RecordColumns, context)
         : undefined,
-    RecordEncoding:
-      output.RecordEncoding !== undefined && output.RecordEncoding !== null ? output.RecordEncoding : undefined,
+    RecordEncoding: __expectString(output.RecordEncoding),
     RecordFormat:
       output.RecordFormat !== undefined && output.RecordFormat !== null
         ? deserializeAws_json1_1RecordFormat(output.RecordFormat, context)
@@ -3821,8 +3789,8 @@ const deserializeAws_json1_1StopApplicationResponse = (
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -3843,7 +3811,7 @@ const deserializeAws_json1_1Tags = (output: any, context: __SerdeContext): Tag[]
 
 const deserializeAws_json1_1TooManyTagsException = (output: any, context: __SerdeContext): TooManyTagsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3860,7 +3828,7 @@ const deserializeAws_json1_1UnableToDetectSchemaException = (
       output.RawInputRecords !== undefined && output.RawInputRecords !== null
         ? deserializeAws_json1_1RawInputRecords(output.RawInputRecords, context)
         : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3869,7 +3837,7 @@ const deserializeAws_json1_1UnsupportedOperationException = (
   context: __SerdeContext
 ): UnsupportedOperationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 

--- a/clients/client-kinesis-video-archived-media/protocols/Aws_restJson1.ts
+++ b/clients/client-kinesis-video-archived-media/protocols/Aws_restJson1.ts
@@ -33,7 +33,11 @@ import {
   UnsupportedStreamMediaTypeException,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -340,7 +344,7 @@ export const deserializeAws_restJson1GetDASHStreamingSessionURLCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.DASHStreamingSessionURL !== undefined && data.DASHStreamingSessionURL !== null) {
-    contents.DASHStreamingSessionURL = data.DASHStreamingSessionURL;
+    contents.DASHStreamingSessionURL = __expectString(data.DASHStreamingSessionURL);
   }
   return Promise.resolve(contents);
 };
@@ -451,7 +455,7 @@ export const deserializeAws_restJson1GetHLSStreamingSessionURLCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.HLSStreamingSessionURL !== undefined && data.HLSStreamingSessionURL !== null) {
-    contents.HLSStreamingSessionURL = data.HLSStreamingSessionURL;
+    contents.HLSStreamingSessionURL = __expectString(data.HLSStreamingSessionURL);
   }
   return Promise.resolve(contents);
 };
@@ -647,7 +651,7 @@ export const deserializeAws_restJson1ListFragmentsCommand = async (
     contents.Fragments = deserializeAws_restJson1FragmentList(data.Fragments, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -725,7 +729,7 @@ const deserializeAws_restJson1ClientLimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -742,7 +746,7 @@ const deserializeAws_restJson1InvalidArgumentExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -759,7 +763,7 @@ const deserializeAws_restJson1InvalidCodecPrivateDataExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -776,7 +780,7 @@ const deserializeAws_restJson1InvalidMediaFrameExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -793,7 +797,7 @@ const deserializeAws_restJson1MissingCodecPrivateDataExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -810,7 +814,7 @@ const deserializeAws_restJson1NoDataRetentionExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -827,7 +831,7 @@ const deserializeAws_restJson1NotAuthorizedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -844,7 +848,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -861,7 +865,7 @@ const deserializeAws_restJson1UnsupportedStreamMediaTypeExceptionResponse = asyn
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -959,16 +963,9 @@ const serializeAws_restJson1TimestampRange = (input: TimestampRange, context: __
 
 const deserializeAws_restJson1Fragment = (output: any, context: __SerdeContext): Fragment => {
   return {
-    FragmentLengthInMilliseconds:
-      output.FragmentLengthInMilliseconds !== undefined && output.FragmentLengthInMilliseconds !== null
-        ? output.FragmentLengthInMilliseconds
-        : undefined,
-    FragmentNumber:
-      output.FragmentNumber !== undefined && output.FragmentNumber !== null ? output.FragmentNumber : undefined,
-    FragmentSizeInBytes:
-      output.FragmentSizeInBytes !== undefined && output.FragmentSizeInBytes !== null
-        ? output.FragmentSizeInBytes
-        : undefined,
+    FragmentLengthInMilliseconds: __expectNumber(output.FragmentLengthInMilliseconds),
+    FragmentNumber: __expectString(output.FragmentNumber),
+    FragmentSizeInBytes: __expectNumber(output.FragmentSizeInBytes),
     ProducerTimestamp:
       output.ProducerTimestamp !== undefined && output.ProducerTimestamp !== null
         ? new Date(Math.round(output.ProducerTimestamp * 1000))

--- a/clients/client-kinesis-video-media/protocols/Aws_restJson1.ts
+++ b/clients/client-kinesis-video-media/protocols/Aws_restJson1.ts
@@ -9,7 +9,7 @@ import {
   StartSelector,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException, expectString as __expectString } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -155,7 +155,7 @@ const deserializeAws_restJson1ClientLimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -172,7 +172,7 @@ const deserializeAws_restJson1ConnectionLimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -189,7 +189,7 @@ const deserializeAws_restJson1InvalidArgumentExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -206,7 +206,7 @@ const deserializeAws_restJson1InvalidEndpointExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -223,7 +223,7 @@ const deserializeAws_restJson1NotAuthorizedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -240,7 +240,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };

--- a/clients/client-kinesis-video-signaling/protocols/Aws_restJson1.ts
+++ b/clients/client-kinesis-video-signaling/protocols/Aws_restJson1.ts
@@ -13,7 +13,11 @@ import {
   SessionExpiredException,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -184,7 +188,7 @@ export const deserializeAws_restJson1SendAlexaOfferToMasterCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Answer !== undefined && data.Answer !== null) {
-    contents.Answer = data.Answer;
+    contents.Answer = __expectString(data.Answer);
   }
   return Promise.resolve(contents);
 };
@@ -262,7 +266,7 @@ const deserializeAws_restJson1ClientLimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -279,7 +283,7 @@ const deserializeAws_restJson1InvalidArgumentExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -296,7 +300,7 @@ const deserializeAws_restJson1InvalidClientExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -313,7 +317,7 @@ const deserializeAws_restJson1NotAuthorizedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -330,7 +334,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -347,20 +351,20 @@ const deserializeAws_restJson1SessionExpiredExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
 
 const deserializeAws_restJson1IceServer = (output: any, context: __SerdeContext): IceServer => {
   return {
-    Password: output.Password !== undefined && output.Password !== null ? output.Password : undefined,
-    Ttl: output.Ttl !== undefined && output.Ttl !== null ? output.Ttl : undefined,
+    Password: __expectString(output.Password),
+    Ttl: __expectNumber(output.Ttl),
     Uris:
       output.Uris !== undefined && output.Uris !== null
         ? deserializeAws_restJson1Uris(output.Uris, context)
         : undefined,
-    Username: output.Username !== undefined && output.Username !== null ? output.Username : undefined,
+    Username: __expectString(output.Username),
   } as any;
 };
 
@@ -382,7 +386,7 @@ const deserializeAws_restJson1Uris = (output: any, context: __SerdeContext): str
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 

--- a/clients/client-kinesis-video/protocols/Aws_restJson1.ts
+++ b/clients/client-kinesis-video/protocols/Aws_restJson1.ts
@@ -66,7 +66,11 @@ import {
   VersionMismatchException,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -618,7 +622,7 @@ export const deserializeAws_restJson1CreateSignalingChannelCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ChannelARN !== undefined && data.ChannelARN !== null) {
-    contents.ChannelARN = data.ChannelARN;
+    contents.ChannelARN = __expectString(data.ChannelARN);
   }
   return Promise.resolve(contents);
 };
@@ -713,7 +717,7 @@ export const deserializeAws_restJson1CreateStreamCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.StreamARN !== undefined && data.StreamARN !== null) {
-    contents.StreamARN = data.StreamARN;
+    contents.StreamARN = __expectString(data.StreamARN);
   }
   return Promise.resolve(contents);
 };
@@ -1156,7 +1160,7 @@ export const deserializeAws_restJson1GetDataEndpointCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.DataEndpoint !== undefined && data.DataEndpoint !== null) {
-    contents.DataEndpoint = data.DataEndpoint;
+    contents.DataEndpoint = __expectString(data.DataEndpoint);
   }
   return Promise.resolve(contents);
 };
@@ -1326,7 +1330,7 @@ export const deserializeAws_restJson1ListSignalingChannelsCommand = async (
     contents.ChannelInfoList = deserializeAws_restJson1ChannelInfoList(data.ChannelInfoList, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1398,7 +1402,7 @@ export const deserializeAws_restJson1ListStreamsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.StreamInfoList !== undefined && data.StreamInfoList !== null) {
     contents.StreamInfoList = deserializeAws_restJson1StreamInfoList(data.StreamInfoList, context);
@@ -1465,7 +1469,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1ResourceTags(data.Tags, context);
@@ -1548,7 +1552,7 @@ export const deserializeAws_restJson1ListTagsForStreamCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1ResourceTags(data.Tags, context);
@@ -2242,7 +2246,7 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -2259,7 +2263,7 @@ const deserializeAws_restJson1AccountChannelLimitExceededExceptionResponse = asy
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -2276,7 +2280,7 @@ const deserializeAws_restJson1AccountStreamLimitExceededExceptionResponse = asyn
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -2293,7 +2297,7 @@ const deserializeAws_restJson1ClientLimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -2310,7 +2314,7 @@ const deserializeAws_restJson1DeviceStreamLimitExceededExceptionResponse = async
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -2327,7 +2331,7 @@ const deserializeAws_restJson1InvalidArgumentExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -2344,7 +2348,7 @@ const deserializeAws_restJson1InvalidDeviceExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -2361,7 +2365,7 @@ const deserializeAws_restJson1InvalidResourceFormatExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -2378,7 +2382,7 @@ const deserializeAws_restJson1NotAuthorizedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -2395,7 +2399,7 @@ const deserializeAws_restJson1ResourceInUseExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -2412,7 +2416,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -2429,7 +2433,7 @@ const deserializeAws_restJson1TagsPerResourceExceededLimitExceptionResponse = as
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -2446,7 +2450,7 @@ const deserializeAws_restJson1VersionMismatchExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -2555,11 +2559,10 @@ const serializeAws_restJson1TagOnCreateList = (input: Tag[], context: __SerdeCon
 
 const deserializeAws_restJson1ChannelInfo = (output: any, context: __SerdeContext): ChannelInfo => {
   return {
-    ChannelARN: output.ChannelARN !== undefined && output.ChannelARN !== null ? output.ChannelARN : undefined,
-    ChannelName: output.ChannelName !== undefined && output.ChannelName !== null ? output.ChannelName : undefined,
-    ChannelStatus:
-      output.ChannelStatus !== undefined && output.ChannelStatus !== null ? output.ChannelStatus : undefined,
-    ChannelType: output.ChannelType !== undefined && output.ChannelType !== null ? output.ChannelType : undefined,
+    ChannelARN: __expectString(output.ChannelARN),
+    ChannelName: __expectString(output.ChannelName),
+    ChannelStatus: __expectString(output.ChannelStatus),
+    ChannelType: __expectString(output.ChannelType),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -2568,7 +2571,7 @@ const deserializeAws_restJson1ChannelInfo = (output: any, context: __SerdeContex
       output.SingleMasterConfiguration !== undefined && output.SingleMasterConfiguration !== null
         ? deserializeAws_restJson1SingleMasterConfiguration(output.SingleMasterConfiguration, context)
         : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    Version: __expectString(output.Version),
   } as any;
 };
 
@@ -2602,9 +2605,8 @@ const deserializeAws_restJson1ResourceEndpointListItem = (
   context: __SerdeContext
 ): ResourceEndpointListItem => {
   return {
-    Protocol: output.Protocol !== undefined && output.Protocol !== null ? output.Protocol : undefined,
-    ResourceEndpoint:
-      output.ResourceEndpoint !== undefined && output.ResourceEndpoint !== null ? output.ResourceEndpoint : undefined,
+    Protocol: __expectString(output.Protocol),
+    ResourceEndpoint: __expectString(output.ResourceEndpoint),
   } as any;
 };
 
@@ -2615,7 +2617,7 @@ const deserializeAws_restJson1ResourceTags = (output: any, context: __SerdeConte
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -2625,10 +2627,7 @@ const deserializeAws_restJson1SingleMasterConfiguration = (
   context: __SerdeContext
 ): SingleMasterConfiguration => {
   return {
-    MessageTtlSeconds:
-      output.MessageTtlSeconds !== undefined && output.MessageTtlSeconds !== null
-        ? output.MessageTtlSeconds
-        : undefined,
+    MessageTtlSeconds: __expectNumber(output.MessageTtlSeconds),
   } as any;
 };
 
@@ -2638,17 +2637,14 @@ const deserializeAws_restJson1StreamInfo = (output: any, context: __SerdeContext
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    DataRetentionInHours:
-      output.DataRetentionInHours !== undefined && output.DataRetentionInHours !== null
-        ? output.DataRetentionInHours
-        : undefined,
-    DeviceName: output.DeviceName !== undefined && output.DeviceName !== null ? output.DeviceName : undefined,
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
-    MediaType: output.MediaType !== undefined && output.MediaType !== null ? output.MediaType : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StreamARN: output.StreamARN !== undefined && output.StreamARN !== null ? output.StreamARN : undefined,
-    StreamName: output.StreamName !== undefined && output.StreamName !== null ? output.StreamName : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    DataRetentionInHours: __expectNumber(output.DataRetentionInHours),
+    DeviceName: __expectString(output.DeviceName),
+    KmsKeyId: __expectString(output.KmsKeyId),
+    MediaType: __expectString(output.MediaType),
+    Status: __expectString(output.Status),
+    StreamARN: __expectString(output.StreamARN),
+    StreamName: __expectString(output.StreamName),
+    Version: __expectString(output.Version),
   } as any;
 };
 

--- a/clients/client-kinesis/protocols/Aws_json1_1.ts
+++ b/clients/client-kinesis/protocols/Aws_json1_1.ts
@@ -141,7 +141,12 @@ import {
   _Record,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -3295,7 +3300,7 @@ const deserializeAws_json1_1ChildShard = (output: any, context: __SerdeContext):
       output.ParentShards !== undefined && output.ParentShards !== null
         ? deserializeAws_json1_1ShardIdList(output.ParentShards, context)
         : undefined,
-    ShardId: output.ShardId !== undefined && output.ShardId !== null ? output.ShardId : undefined,
+    ShardId: __expectString(output.ShardId),
   } as any;
 };
 
@@ -3312,28 +3317,26 @@ const deserializeAws_json1_1ChildShardList = (output: any, context: __SerdeConte
 
 const deserializeAws_json1_1Consumer = (output: any, context: __SerdeContext): Consumer => {
   return {
-    ConsumerARN: output.ConsumerARN !== undefined && output.ConsumerARN !== null ? output.ConsumerARN : undefined,
+    ConsumerARN: __expectString(output.ConsumerARN),
     ConsumerCreationTimestamp:
       output.ConsumerCreationTimestamp !== undefined && output.ConsumerCreationTimestamp !== null
         ? new Date(Math.round(output.ConsumerCreationTimestamp * 1000))
         : undefined,
-    ConsumerName: output.ConsumerName !== undefined && output.ConsumerName !== null ? output.ConsumerName : undefined,
-    ConsumerStatus:
-      output.ConsumerStatus !== undefined && output.ConsumerStatus !== null ? output.ConsumerStatus : undefined,
+    ConsumerName: __expectString(output.ConsumerName),
+    ConsumerStatus: __expectString(output.ConsumerStatus),
   } as any;
 };
 
 const deserializeAws_json1_1ConsumerDescription = (output: any, context: __SerdeContext): ConsumerDescription => {
   return {
-    ConsumerARN: output.ConsumerARN !== undefined && output.ConsumerARN !== null ? output.ConsumerARN : undefined,
+    ConsumerARN: __expectString(output.ConsumerARN),
     ConsumerCreationTimestamp:
       output.ConsumerCreationTimestamp !== undefined && output.ConsumerCreationTimestamp !== null
         ? new Date(Math.round(output.ConsumerCreationTimestamp * 1000))
         : undefined,
-    ConsumerName: output.ConsumerName !== undefined && output.ConsumerName !== null ? output.ConsumerName : undefined,
-    ConsumerStatus:
-      output.ConsumerStatus !== undefined && output.ConsumerStatus !== null ? output.ConsumerStatus : undefined,
-    StreamARN: output.StreamARN !== undefined && output.StreamARN !== null ? output.StreamARN : undefined,
+    ConsumerName: __expectString(output.ConsumerName),
+    ConsumerStatus: __expectString(output.ConsumerStatus),
+    StreamARN: __expectString(output.StreamARN),
   } as any;
 };
 
@@ -3350,9 +3353,8 @@ const deserializeAws_json1_1ConsumerList = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_1DescribeLimitsOutput = (output: any, context: __SerdeContext): DescribeLimitsOutput => {
   return {
-    OpenShardCount:
-      output.OpenShardCount !== undefined && output.OpenShardCount !== null ? output.OpenShardCount : undefined,
-    ShardLimit: output.ShardLimit !== undefined && output.ShardLimit !== null ? output.ShardLimit : undefined,
+    OpenShardCount: __expectNumber(output.OpenShardCount),
+    ShardLimit: __expectNumber(output.ShardLimit),
   } as any;
 };
 
@@ -3422,7 +3424,7 @@ const deserializeAws_json1_1EnhancedMonitoringOutput = (
       output.DesiredShardLevelMetrics !== undefined && output.DesiredShardLevelMetrics !== null
         ? deserializeAws_json1_1MetricsNameList(output.DesiredShardLevelMetrics, context)
         : undefined,
-    StreamName: output.StreamName !== undefined && output.StreamName !== null ? output.StreamName : undefined,
+    StreamName: __expectString(output.StreamName),
   } as any;
 };
 
@@ -3431,7 +3433,7 @@ const deserializeAws_json1_1ExpiredIteratorException = (
   context: __SerdeContext
 ): ExpiredIteratorException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3440,7 +3442,7 @@ const deserializeAws_json1_1ExpiredNextTokenException = (
   context: __SerdeContext
 ): ExpiredNextTokenException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3450,14 +3452,8 @@ const deserializeAws_json1_1GetRecordsOutput = (output: any, context: __SerdeCon
       output.ChildShards !== undefined && output.ChildShards !== null
         ? deserializeAws_json1_1ChildShardList(output.ChildShards, context)
         : undefined,
-    MillisBehindLatest:
-      output.MillisBehindLatest !== undefined && output.MillisBehindLatest !== null
-        ? output.MillisBehindLatest
-        : undefined,
-    NextShardIterator:
-      output.NextShardIterator !== undefined && output.NextShardIterator !== null
-        ? output.NextShardIterator
-        : undefined,
+    MillisBehindLatest: __expectNumber(output.MillisBehindLatest),
+    NextShardIterator: __expectString(output.NextShardIterator),
     Records:
       output.Records !== undefined && output.Records !== null
         ? deserializeAws_json1_1RecordList(output.Records, context)
@@ -3467,17 +3463,14 @@ const deserializeAws_json1_1GetRecordsOutput = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1GetShardIteratorOutput = (output: any, context: __SerdeContext): GetShardIteratorOutput => {
   return {
-    ShardIterator:
-      output.ShardIterator !== undefined && output.ShardIterator !== null ? output.ShardIterator : undefined,
+    ShardIterator: __expectString(output.ShardIterator),
   } as any;
 };
 
 const deserializeAws_json1_1HashKeyRange = (output: any, context: __SerdeContext): HashKeyRange => {
   return {
-    EndingHashKey:
-      output.EndingHashKey !== undefined && output.EndingHashKey !== null ? output.EndingHashKey : undefined,
-    StartingHashKey:
-      output.StartingHashKey !== undefined && output.StartingHashKey !== null ? output.StartingHashKey : undefined,
+    EndingHashKey: __expectString(output.EndingHashKey),
+    StartingHashKey: __expectString(output.StartingHashKey),
   } as any;
 };
 
@@ -3486,7 +3479,7 @@ const deserializeAws_json1_1InternalFailureException = (
   context: __SerdeContext
 ): InternalFailureException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3495,7 +3488,7 @@ const deserializeAws_json1_1InvalidArgumentException = (
   context: __SerdeContext
 ): InvalidArgumentException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3504,13 +3497,13 @@ const deserializeAws_json1_1KMSAccessDeniedException = (
   context: __SerdeContext
 ): KMSAccessDeniedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1KMSDisabledException = (output: any, context: __SerdeContext): KMSDisabledException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3519,37 +3512,37 @@ const deserializeAws_json1_1KMSInvalidStateException = (
   context: __SerdeContext
 ): KMSInvalidStateException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1KMSNotFoundException = (output: any, context: __SerdeContext): KMSNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1KMSOptInRequired = (output: any, context: __SerdeContext): KMSOptInRequired => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1KMSThrottlingException = (output: any, context: __SerdeContext): KMSThrottlingException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1ListShardsOutput = (output: any, context: __SerdeContext): ListShardsOutput => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Shards:
       output.Shards !== undefined && output.Shards !== null
         ? deserializeAws_json1_1ShardList(output.Shards, context)
@@ -3566,14 +3559,13 @@ const deserializeAws_json1_1ListStreamConsumersOutput = (
       output.Consumers !== undefined && output.Consumers !== null
         ? deserializeAws_json1_1ConsumerList(output.Consumers, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
 const deserializeAws_json1_1ListStreamsOutput = (output: any, context: __SerdeContext): ListStreamsOutput => {
   return {
-    HasMoreStreams:
-      output.HasMoreStreams !== undefined && output.HasMoreStreams !== null ? output.HasMoreStreams : undefined,
+    HasMoreStreams: __expectBoolean(output.HasMoreStreams),
     StreamNames:
       output.StreamNames !== undefined && output.StreamNames !== null
         ? deserializeAws_json1_1StreamNameList(output.StreamNames, context)
@@ -3586,7 +3578,7 @@ const deserializeAws_json1_1ListTagsForStreamOutput = (
   context: __SerdeContext
 ): ListTagsForStreamOutput => {
   return {
-    HasMoreTags: output.HasMoreTags !== undefined && output.HasMoreTags !== null ? output.HasMoreTags : undefined,
+    HasMoreTags: __expectBoolean(output.HasMoreTags),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_1TagList(output.Tags, context)
@@ -3601,7 +3593,7 @@ const deserializeAws_json1_1MetricsNameList = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3610,28 +3602,22 @@ const deserializeAws_json1_1ProvisionedThroughputExceededException = (
   context: __SerdeContext
 ): ProvisionedThroughputExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1PutRecordOutput = (output: any, context: __SerdeContext): PutRecordOutput => {
   return {
-    EncryptionType:
-      output.EncryptionType !== undefined && output.EncryptionType !== null ? output.EncryptionType : undefined,
-    SequenceNumber:
-      output.SequenceNumber !== undefined && output.SequenceNumber !== null ? output.SequenceNumber : undefined,
-    ShardId: output.ShardId !== undefined && output.ShardId !== null ? output.ShardId : undefined,
+    EncryptionType: __expectString(output.EncryptionType),
+    SequenceNumber: __expectString(output.SequenceNumber),
+    ShardId: __expectString(output.ShardId),
   } as any;
 };
 
 const deserializeAws_json1_1PutRecordsOutput = (output: any, context: __SerdeContext): PutRecordsOutput => {
   return {
-    EncryptionType:
-      output.EncryptionType !== undefined && output.EncryptionType !== null ? output.EncryptionType : undefined,
-    FailedRecordCount:
-      output.FailedRecordCount !== undefined && output.FailedRecordCount !== null
-        ? output.FailedRecordCount
-        : undefined,
+    EncryptionType: __expectString(output.EncryptionType),
+    FailedRecordCount: __expectNumber(output.FailedRecordCount),
     Records:
       output.Records !== undefined && output.Records !== null
         ? deserializeAws_json1_1PutRecordsResultEntryList(output.Records, context)
@@ -3641,11 +3627,10 @@ const deserializeAws_json1_1PutRecordsOutput = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1PutRecordsResultEntry = (output: any, context: __SerdeContext): PutRecordsResultEntry => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    SequenceNumber:
-      output.SequenceNumber !== undefined && output.SequenceNumber !== null ? output.SequenceNumber : undefined,
-    ShardId: output.ShardId !== undefined && output.ShardId !== null ? output.ShardId : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
+    SequenceNumber: __expectString(output.SequenceNumber),
+    ShardId: __expectString(output.ShardId),
   } as any;
 };
 
@@ -3670,11 +3655,9 @@ const deserializeAws_json1_1_Record = (output: any, context: __SerdeContext): _R
         ? new Date(Math.round(output.ApproximateArrivalTimestamp * 1000))
         : undefined,
     Data: output.Data !== undefined && output.Data !== null ? context.base64Decoder(output.Data) : undefined,
-    EncryptionType:
-      output.EncryptionType !== undefined && output.EncryptionType !== null ? output.EncryptionType : undefined,
-    PartitionKey: output.PartitionKey !== undefined && output.PartitionKey !== null ? output.PartitionKey : undefined,
-    SequenceNumber:
-      output.SequenceNumber !== undefined && output.SequenceNumber !== null ? output.SequenceNumber : undefined,
+    EncryptionType: __expectString(output.EncryptionType),
+    PartitionKey: __expectString(output.PartitionKey),
+    SequenceNumber: __expectString(output.SequenceNumber),
   } as any;
 };
 
@@ -3703,7 +3686,7 @@ const deserializeAws_json1_1RegisterStreamConsumerOutput = (
 
 const deserializeAws_json1_1ResourceInUseException = (output: any, context: __SerdeContext): ResourceInUseException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3712,40 +3695,30 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1SequenceNumberRange = (output: any, context: __SerdeContext): SequenceNumberRange => {
   return {
-    EndingSequenceNumber:
-      output.EndingSequenceNumber !== undefined && output.EndingSequenceNumber !== null
-        ? output.EndingSequenceNumber
-        : undefined,
-    StartingSequenceNumber:
-      output.StartingSequenceNumber !== undefined && output.StartingSequenceNumber !== null
-        ? output.StartingSequenceNumber
-        : undefined,
+    EndingSequenceNumber: __expectString(output.EndingSequenceNumber),
+    StartingSequenceNumber: __expectString(output.StartingSequenceNumber),
   } as any;
 };
 
 const deserializeAws_json1_1Shard = (output: any, context: __SerdeContext): Shard => {
   return {
-    AdjacentParentShardId:
-      output.AdjacentParentShardId !== undefined && output.AdjacentParentShardId !== null
-        ? output.AdjacentParentShardId
-        : undefined,
+    AdjacentParentShardId: __expectString(output.AdjacentParentShardId),
     HashKeyRange:
       output.HashKeyRange !== undefined && output.HashKeyRange !== null
         ? deserializeAws_json1_1HashKeyRange(output.HashKeyRange, context)
         : undefined,
-    ParentShardId:
-      output.ParentShardId !== undefined && output.ParentShardId !== null ? output.ParentShardId : undefined,
+    ParentShardId: __expectString(output.ParentShardId),
     SequenceNumberRange:
       output.SequenceNumberRange !== undefined && output.SequenceNumberRange !== null
         ? deserializeAws_json1_1SequenceNumberRange(output.SequenceNumberRange, context)
         : undefined,
-    ShardId: output.ShardId !== undefined && output.ShardId !== null ? output.ShardId : undefined,
+    ShardId: __expectString(output.ShardId),
   } as any;
 };
 
@@ -3756,7 +3729,7 @@ const deserializeAws_json1_1ShardIdList = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3773,30 +3746,25 @@ const deserializeAws_json1_1ShardList = (output: any, context: __SerdeContext): 
 
 const deserializeAws_json1_1StreamDescription = (output: any, context: __SerdeContext): StreamDescription => {
   return {
-    EncryptionType:
-      output.EncryptionType !== undefined && output.EncryptionType !== null ? output.EncryptionType : undefined,
+    EncryptionType: __expectString(output.EncryptionType),
     EnhancedMonitoring:
       output.EnhancedMonitoring !== undefined && output.EnhancedMonitoring !== null
         ? deserializeAws_json1_1EnhancedMonitoringList(output.EnhancedMonitoring, context)
         : undefined,
-    HasMoreShards:
-      output.HasMoreShards !== undefined && output.HasMoreShards !== null ? output.HasMoreShards : undefined,
-    KeyId: output.KeyId !== undefined && output.KeyId !== null ? output.KeyId : undefined,
-    RetentionPeriodHours:
-      output.RetentionPeriodHours !== undefined && output.RetentionPeriodHours !== null
-        ? output.RetentionPeriodHours
-        : undefined,
+    HasMoreShards: __expectBoolean(output.HasMoreShards),
+    KeyId: __expectString(output.KeyId),
+    RetentionPeriodHours: __expectNumber(output.RetentionPeriodHours),
     Shards:
       output.Shards !== undefined && output.Shards !== null
         ? deserializeAws_json1_1ShardList(output.Shards, context)
         : undefined,
-    StreamARN: output.StreamARN !== undefined && output.StreamARN !== null ? output.StreamARN : undefined,
+    StreamARN: __expectString(output.StreamARN),
     StreamCreationTimestamp:
       output.StreamCreationTimestamp !== undefined && output.StreamCreationTimestamp !== null
         ? new Date(Math.round(output.StreamCreationTimestamp * 1000))
         : undefined,
-    StreamName: output.StreamName !== undefined && output.StreamName !== null ? output.StreamName : undefined,
-    StreamStatus: output.StreamStatus !== undefined && output.StreamStatus !== null ? output.StreamStatus : undefined,
+    StreamName: __expectString(output.StreamName),
+    StreamStatus: __expectString(output.StreamStatus),
   } as any;
 };
 
@@ -3805,28 +3773,22 @@ const deserializeAws_json1_1StreamDescriptionSummary = (
   context: __SerdeContext
 ): StreamDescriptionSummary => {
   return {
-    ConsumerCount:
-      output.ConsumerCount !== undefined && output.ConsumerCount !== null ? output.ConsumerCount : undefined,
-    EncryptionType:
-      output.EncryptionType !== undefined && output.EncryptionType !== null ? output.EncryptionType : undefined,
+    ConsumerCount: __expectNumber(output.ConsumerCount),
+    EncryptionType: __expectString(output.EncryptionType),
     EnhancedMonitoring:
       output.EnhancedMonitoring !== undefined && output.EnhancedMonitoring !== null
         ? deserializeAws_json1_1EnhancedMonitoringList(output.EnhancedMonitoring, context)
         : undefined,
-    KeyId: output.KeyId !== undefined && output.KeyId !== null ? output.KeyId : undefined,
-    OpenShardCount:
-      output.OpenShardCount !== undefined && output.OpenShardCount !== null ? output.OpenShardCount : undefined,
-    RetentionPeriodHours:
-      output.RetentionPeriodHours !== undefined && output.RetentionPeriodHours !== null
-        ? output.RetentionPeriodHours
-        : undefined,
-    StreamARN: output.StreamARN !== undefined && output.StreamARN !== null ? output.StreamARN : undefined,
+    KeyId: __expectString(output.KeyId),
+    OpenShardCount: __expectNumber(output.OpenShardCount),
+    RetentionPeriodHours: __expectNumber(output.RetentionPeriodHours),
+    StreamARN: __expectString(output.StreamARN),
     StreamCreationTimestamp:
       output.StreamCreationTimestamp !== undefined && output.StreamCreationTimestamp !== null
         ? new Date(Math.round(output.StreamCreationTimestamp * 1000))
         : undefined,
-    StreamName: output.StreamName !== undefined && output.StreamName !== null ? output.StreamName : undefined,
-    StreamStatus: output.StreamStatus !== undefined && output.StreamStatus !== null ? output.StreamStatus : undefined,
+    StreamName: __expectString(output.StreamName),
+    StreamStatus: __expectString(output.StreamStatus),
   } as any;
 };
 
@@ -3837,7 +3799,7 @@ const deserializeAws_json1_1StreamNameList = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3847,14 +3809,8 @@ const deserializeAws_json1_1SubscribeToShardEvent = (output: any, context: __Ser
       output.ChildShards !== undefined && output.ChildShards !== null
         ? deserializeAws_json1_1ChildShardList(output.ChildShards, context)
         : undefined,
-    ContinuationSequenceNumber:
-      output.ContinuationSequenceNumber !== undefined && output.ContinuationSequenceNumber !== null
-        ? output.ContinuationSequenceNumber
-        : undefined,
-    MillisBehindLatest:
-      output.MillisBehindLatest !== undefined && output.MillisBehindLatest !== null
-        ? output.MillisBehindLatest
-        : undefined,
+    ContinuationSequenceNumber: __expectString(output.ContinuationSequenceNumber),
+    MillisBehindLatest: __expectNumber(output.MillisBehindLatest),
     Records:
       output.Records !== undefined && output.Records !== null
         ? deserializeAws_json1_1RecordList(output.Records, context)
@@ -3942,8 +3898,8 @@ const deserializeAws_json1_1SubscribeToShardOutput = (output: any, context: __Se
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -3960,13 +3916,9 @@ const deserializeAws_json1_1TagList = (output: any, context: __SerdeContext): Ta
 
 const deserializeAws_json1_1UpdateShardCountOutput = (output: any, context: __SerdeContext): UpdateShardCountOutput => {
   return {
-    CurrentShardCount:
-      output.CurrentShardCount !== undefined && output.CurrentShardCount !== null
-        ? output.CurrentShardCount
-        : undefined,
-    StreamName: output.StreamName !== undefined && output.StreamName !== null ? output.StreamName : undefined,
-    TargetShardCount:
-      output.TargetShardCount !== undefined && output.TargetShardCount !== null ? output.TargetShardCount : undefined,
+    CurrentShardCount: __expectNumber(output.CurrentShardCount),
+    StreamName: __expectString(output.StreamName),
+    TargetShardCount: __expectNumber(output.TargetShardCount),
   } as any;
 };
 

--- a/clients/client-kms/protocols/Aws_json1_1.ts
+++ b/clients/client-kms/protocols/Aws_json1_1.ts
@@ -222,7 +222,12 @@ import {
   VerifyResponse,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -6633,8 +6638,8 @@ const deserializeAws_json1_1AliasList = (output: any, context: __SerdeContext): 
 
 const deserializeAws_json1_1AliasListEntry = (output: any, context: __SerdeContext): AliasListEntry => {
   return {
-    AliasArn: output.AliasArn !== undefined && output.AliasArn !== null ? output.AliasArn : undefined,
-    AliasName: output.AliasName !== undefined && output.AliasName !== null ? output.AliasName : undefined,
+    AliasArn: __expectString(output.AliasArn),
+    AliasName: __expectString(output.AliasName),
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
         ? new Date(Math.round(output.CreationDate * 1000))
@@ -6643,13 +6648,13 @@ const deserializeAws_json1_1AliasListEntry = (output: any, context: __SerdeConte
       output.LastUpdatedDate !== undefined && output.LastUpdatedDate !== null
         ? new Date(Math.round(output.LastUpdatedDate * 1000))
         : undefined,
-    TargetKeyId: output.TargetKeyId !== undefined && output.TargetKeyId !== null ? output.TargetKeyId : undefined,
+    TargetKeyId: __expectString(output.TargetKeyId),
   } as any;
 };
 
 const deserializeAws_json1_1AlreadyExistsException = (output: any, context: __SerdeContext): AlreadyExistsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6658,7 +6663,7 @@ const deserializeAws_json1_1CancelKeyDeletionResponse = (
   context: __SerdeContext
 ): CancelKeyDeletionResponse => {
   return {
-    KeyId: output.KeyId !== undefined && output.KeyId !== null ? output.KeyId : undefined,
+    KeyId: __expectString(output.KeyId),
   } as any;
 };
 
@@ -6667,7 +6672,7 @@ const deserializeAws_json1_1CloudHsmClusterInUseException = (
   context: __SerdeContext
 ): CloudHsmClusterInUseException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6676,7 +6681,7 @@ const deserializeAws_json1_1CloudHsmClusterInvalidConfigurationException = (
   context: __SerdeContext
 ): CloudHsmClusterInvalidConfigurationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6685,7 +6690,7 @@ const deserializeAws_json1_1CloudHsmClusterNotActiveException = (
   context: __SerdeContext
 ): CloudHsmClusterNotActiveException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6694,7 +6699,7 @@ const deserializeAws_json1_1CloudHsmClusterNotFoundException = (
   context: __SerdeContext
 ): CloudHsmClusterNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6703,7 +6708,7 @@ const deserializeAws_json1_1CloudHsmClusterNotRelatedException = (
   context: __SerdeContext
 ): CloudHsmClusterNotRelatedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6719,15 +6724,14 @@ const deserializeAws_json1_1CreateCustomKeyStoreResponse = (
   context: __SerdeContext
 ): CreateCustomKeyStoreResponse => {
   return {
-    CustomKeyStoreId:
-      output.CustomKeyStoreId !== undefined && output.CustomKeyStoreId !== null ? output.CustomKeyStoreId : undefined,
+    CustomKeyStoreId: __expectString(output.CustomKeyStoreId),
   } as any;
 };
 
 const deserializeAws_json1_1CreateGrantResponse = (output: any, context: __SerdeContext): CreateGrantResponse => {
   return {
-    GrantId: output.GrantId !== undefined && output.GrantId !== null ? output.GrantId : undefined,
-    GrantToken: output.GrantToken !== undefined && output.GrantToken !== null ? output.GrantToken : undefined,
+    GrantId: __expectString(output.GrantId),
+    GrantToken: __expectString(output.GrantToken),
   } as any;
 };
 
@@ -6745,7 +6749,7 @@ const deserializeAws_json1_1CustomKeyStoreHasCMKsException = (
   context: __SerdeContext
 ): CustomKeyStoreHasCMKsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6754,7 +6758,7 @@ const deserializeAws_json1_1CustomKeyStoreInvalidStateException = (
   context: __SerdeContext
 ): CustomKeyStoreInvalidStateException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6763,7 +6767,7 @@ const deserializeAws_json1_1CustomKeyStoreNameInUseException = (
   context: __SerdeContext
 ): CustomKeyStoreNameInUseException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6772,7 +6776,7 @@ const deserializeAws_json1_1CustomKeyStoreNotFoundException = (
   context: __SerdeContext
 ): CustomKeyStoreNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6795,40 +6799,23 @@ const deserializeAws_json1_1CustomKeyStoresListEntry = (
   context: __SerdeContext
 ): CustomKeyStoresListEntry => {
   return {
-    CloudHsmClusterId:
-      output.CloudHsmClusterId !== undefined && output.CloudHsmClusterId !== null
-        ? output.CloudHsmClusterId
-        : undefined,
-    ConnectionErrorCode:
-      output.ConnectionErrorCode !== undefined && output.ConnectionErrorCode !== null
-        ? output.ConnectionErrorCode
-        : undefined,
-    ConnectionState:
-      output.ConnectionState !== undefined && output.ConnectionState !== null ? output.ConnectionState : undefined,
+    CloudHsmClusterId: __expectString(output.CloudHsmClusterId),
+    ConnectionErrorCode: __expectString(output.ConnectionErrorCode),
+    ConnectionState: __expectString(output.ConnectionState),
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
         ? new Date(Math.round(output.CreationDate * 1000))
         : undefined,
-    CustomKeyStoreId:
-      output.CustomKeyStoreId !== undefined && output.CustomKeyStoreId !== null ? output.CustomKeyStoreId : undefined,
-    CustomKeyStoreName:
-      output.CustomKeyStoreName !== undefined && output.CustomKeyStoreName !== null
-        ? output.CustomKeyStoreName
-        : undefined,
-    TrustAnchorCertificate:
-      output.TrustAnchorCertificate !== undefined && output.TrustAnchorCertificate !== null
-        ? output.TrustAnchorCertificate
-        : undefined,
+    CustomKeyStoreId: __expectString(output.CustomKeyStoreId),
+    CustomKeyStoreName: __expectString(output.CustomKeyStoreName),
+    TrustAnchorCertificate: __expectString(output.TrustAnchorCertificate),
   } as any;
 };
 
 const deserializeAws_json1_1DecryptResponse = (output: any, context: __SerdeContext): DecryptResponse => {
   return {
-    EncryptionAlgorithm:
-      output.EncryptionAlgorithm !== undefined && output.EncryptionAlgorithm !== null
-        ? output.EncryptionAlgorithm
-        : undefined,
-    KeyId: output.KeyId !== undefined && output.KeyId !== null ? output.KeyId : undefined,
+    EncryptionAlgorithm: __expectString(output.EncryptionAlgorithm),
+    KeyId: __expectString(output.KeyId),
     Plaintext:
       output.Plaintext !== undefined && output.Plaintext !== null ? context.base64Decoder(output.Plaintext) : undefined,
   } as any;
@@ -6846,7 +6833,7 @@ const deserializeAws_json1_1DependencyTimeoutException = (
   context: __SerdeContext
 ): DependencyTimeoutException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6859,8 +6846,8 @@ const deserializeAws_json1_1DescribeCustomKeyStoresResponse = (
       output.CustomKeyStores !== undefined && output.CustomKeyStores !== null
         ? deserializeAws_json1_1CustomKeyStoresList(output.CustomKeyStores, context)
         : undefined,
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
-    Truncated: output.Truncated !== undefined && output.Truncated !== null ? output.Truncated : undefined,
+    NextMarker: __expectString(output.NextMarker),
+    Truncated: __expectBoolean(output.Truncated),
   } as any;
 };
 
@@ -6875,7 +6862,7 @@ const deserializeAws_json1_1DescribeKeyResponse = (output: any, context: __Serde
 
 const deserializeAws_json1_1DisabledException = (output: any, context: __SerdeContext): DisabledException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6896,7 +6883,7 @@ const deserializeAws_json1_1EncryptionAlgorithmSpecList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6910,7 +6897,7 @@ const deserializeAws_json1_1EncryptionContextType = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -6921,11 +6908,8 @@ const deserializeAws_json1_1EncryptResponse = (output: any, context: __SerdeCont
       output.CiphertextBlob !== undefined && output.CiphertextBlob !== null
         ? context.base64Decoder(output.CiphertextBlob)
         : undefined,
-    EncryptionAlgorithm:
-      output.EncryptionAlgorithm !== undefined && output.EncryptionAlgorithm !== null
-        ? output.EncryptionAlgorithm
-        : undefined,
-    KeyId: output.KeyId !== undefined && output.KeyId !== null ? output.KeyId : undefined,
+    EncryptionAlgorithm: __expectString(output.EncryptionAlgorithm),
+    KeyId: __expectString(output.KeyId),
   } as any;
 };
 
@@ -6934,7 +6918,7 @@ const deserializeAws_json1_1ExpiredImportTokenException = (
   context: __SerdeContext
 ): ExpiredImportTokenException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6943,8 +6927,8 @@ const deserializeAws_json1_1GenerateDataKeyPairResponse = (
   context: __SerdeContext
 ): GenerateDataKeyPairResponse => {
   return {
-    KeyId: output.KeyId !== undefined && output.KeyId !== null ? output.KeyId : undefined,
-    KeyPairSpec: output.KeyPairSpec !== undefined && output.KeyPairSpec !== null ? output.KeyPairSpec : undefined,
+    KeyId: __expectString(output.KeyId),
+    KeyPairSpec: __expectString(output.KeyPairSpec),
     PrivateKeyCiphertextBlob:
       output.PrivateKeyCiphertextBlob !== undefined && output.PrivateKeyCiphertextBlob !== null
         ? context.base64Decoder(output.PrivateKeyCiphertextBlob)
@@ -6963,8 +6947,8 @@ const deserializeAws_json1_1GenerateDataKeyPairWithoutPlaintextResponse = (
   context: __SerdeContext
 ): GenerateDataKeyPairWithoutPlaintextResponse => {
   return {
-    KeyId: output.KeyId !== undefined && output.KeyId !== null ? output.KeyId : undefined,
-    KeyPairSpec: output.KeyPairSpec !== undefined && output.KeyPairSpec !== null ? output.KeyPairSpec : undefined,
+    KeyId: __expectString(output.KeyId),
+    KeyPairSpec: __expectString(output.KeyPairSpec),
     PrivateKeyCiphertextBlob:
       output.PrivateKeyCiphertextBlob !== undefined && output.PrivateKeyCiphertextBlob !== null
         ? context.base64Decoder(output.PrivateKeyCiphertextBlob)
@@ -6983,7 +6967,7 @@ const deserializeAws_json1_1GenerateDataKeyResponse = (
       output.CiphertextBlob !== undefined && output.CiphertextBlob !== null
         ? context.base64Decoder(output.CiphertextBlob)
         : undefined,
-    KeyId: output.KeyId !== undefined && output.KeyId !== null ? output.KeyId : undefined,
+    KeyId: __expectString(output.KeyId),
     Plaintext:
       output.Plaintext !== undefined && output.Plaintext !== null ? context.base64Decoder(output.Plaintext) : undefined,
   } as any;
@@ -6998,7 +6982,7 @@ const deserializeAws_json1_1GenerateDataKeyWithoutPlaintextResponse = (
       output.CiphertextBlob !== undefined && output.CiphertextBlob !== null
         ? context.base64Decoder(output.CiphertextBlob)
         : undefined,
-    KeyId: output.KeyId !== undefined && output.KeyId !== null ? output.KeyId : undefined,
+    KeyId: __expectString(output.KeyId),
   } as any;
 };
 
@@ -7011,7 +6995,7 @@ const deserializeAws_json1_1GenerateRandomResponse = (output: any, context: __Se
 
 const deserializeAws_json1_1GetKeyPolicyResponse = (output: any, context: __SerdeContext): GetKeyPolicyResponse => {
   return {
-    Policy: output.Policy !== undefined && output.Policy !== null ? output.Policy : undefined,
+    Policy: __expectString(output.Policy),
   } as any;
 };
 
@@ -7020,10 +7004,7 @@ const deserializeAws_json1_1GetKeyRotationStatusResponse = (
   context: __SerdeContext
 ): GetKeyRotationStatusResponse => {
   return {
-    KeyRotationEnabled:
-      output.KeyRotationEnabled !== undefined && output.KeyRotationEnabled !== null
-        ? output.KeyRotationEnabled
-        : undefined,
+    KeyRotationEnabled: __expectBoolean(output.KeyRotationEnabled),
   } as any;
 };
 
@@ -7036,7 +7017,7 @@ const deserializeAws_json1_1GetParametersForImportResponse = (
       output.ImportToken !== undefined && output.ImportToken !== null
         ? context.base64Decoder(output.ImportToken)
         : undefined,
-    KeyId: output.KeyId !== undefined && output.KeyId !== null ? output.KeyId : undefined,
+    KeyId: __expectString(output.KeyId),
     ParametersValidTo:
       output.ParametersValidTo !== undefined && output.ParametersValidTo !== null
         ? new Date(Math.round(output.ParametersValidTo * 1000))
@@ -7048,16 +7029,13 @@ const deserializeAws_json1_1GetParametersForImportResponse = (
 
 const deserializeAws_json1_1GetPublicKeyResponse = (output: any, context: __SerdeContext): GetPublicKeyResponse => {
   return {
-    CustomerMasterKeySpec:
-      output.CustomerMasterKeySpec !== undefined && output.CustomerMasterKeySpec !== null
-        ? output.CustomerMasterKeySpec
-        : undefined,
+    CustomerMasterKeySpec: __expectString(output.CustomerMasterKeySpec),
     EncryptionAlgorithms:
       output.EncryptionAlgorithms !== undefined && output.EncryptionAlgorithms !== null
         ? deserializeAws_json1_1EncryptionAlgorithmSpecList(output.EncryptionAlgorithms, context)
         : undefined,
-    KeyId: output.KeyId !== undefined && output.KeyId !== null ? output.KeyId : undefined,
-    KeyUsage: output.KeyUsage !== undefined && output.KeyUsage !== null ? output.KeyUsage : undefined,
+    KeyId: __expectString(output.KeyId),
+    KeyUsage: __expectString(output.KeyUsage),
     PublicKey:
       output.PublicKey !== undefined && output.PublicKey !== null ? context.base64Decoder(output.PublicKey) : undefined,
     SigningAlgorithms:
@@ -7101,21 +7079,16 @@ const deserializeAws_json1_1GrantListEntry = (output: any, context: __SerdeConte
       output.CreationDate !== undefined && output.CreationDate !== null
         ? new Date(Math.round(output.CreationDate * 1000))
         : undefined,
-    GrantId: output.GrantId !== undefined && output.GrantId !== null ? output.GrantId : undefined,
-    GranteePrincipal:
-      output.GranteePrincipal !== undefined && output.GranteePrincipal !== null ? output.GranteePrincipal : undefined,
-    IssuingAccount:
-      output.IssuingAccount !== undefined && output.IssuingAccount !== null ? output.IssuingAccount : undefined,
-    KeyId: output.KeyId !== undefined && output.KeyId !== null ? output.KeyId : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    GrantId: __expectString(output.GrantId),
+    GranteePrincipal: __expectString(output.GranteePrincipal),
+    IssuingAccount: __expectString(output.IssuingAccount),
+    KeyId: __expectString(output.KeyId),
+    Name: __expectString(output.Name),
     Operations:
       output.Operations !== undefined && output.Operations !== null
         ? deserializeAws_json1_1GrantOperationList(output.Operations, context)
         : undefined,
-    RetiringPrincipal:
-      output.RetiringPrincipal !== undefined && output.RetiringPrincipal !== null
-        ? output.RetiringPrincipal
-        : undefined,
+    RetiringPrincipal: __expectString(output.RetiringPrincipal),
   } as any;
 };
 
@@ -7129,7 +7102,7 @@ const deserializeAws_json1_1GrantOperationList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7142,7 +7115,7 @@ const deserializeAws_json1_1ImportKeyMaterialResponse = (
 
 const deserializeAws_json1_1IncorrectKeyException = (output: any, context: __SerdeContext): IncorrectKeyException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -7151,7 +7124,7 @@ const deserializeAws_json1_1IncorrectKeyMaterialException = (
   context: __SerdeContext
 ): IncorrectKeyMaterialException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -7160,7 +7133,7 @@ const deserializeAws_json1_1IncorrectTrustAnchorException = (
   context: __SerdeContext
 ): IncorrectTrustAnchorException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -7169,13 +7142,13 @@ const deserializeAws_json1_1InvalidAliasNameException = (
   context: __SerdeContext
 ): InvalidAliasNameException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidArnException = (output: any, context: __SerdeContext): InvalidArnException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -7184,7 +7157,7 @@ const deserializeAws_json1_1InvalidCiphertextException = (
   context: __SerdeContext
 ): InvalidCiphertextException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -7193,7 +7166,7 @@ const deserializeAws_json1_1InvalidGrantIdException = (
   context: __SerdeContext
 ): InvalidGrantIdException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -7202,7 +7175,7 @@ const deserializeAws_json1_1InvalidGrantTokenException = (
   context: __SerdeContext
 ): InvalidGrantTokenException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -7211,7 +7184,7 @@ const deserializeAws_json1_1InvalidImportTokenException = (
   context: __SerdeContext
 ): InvalidImportTokenException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -7220,13 +7193,13 @@ const deserializeAws_json1_1InvalidKeyUsageException = (
   context: __SerdeContext
 ): InvalidKeyUsageException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidMarkerException = (output: any, context: __SerdeContext): InvalidMarkerException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -7243,55 +7216,44 @@ const deserializeAws_json1_1KeyList = (output: any, context: __SerdeContext): Ke
 
 const deserializeAws_json1_1KeyListEntry = (output: any, context: __SerdeContext): KeyListEntry => {
   return {
-    KeyArn: output.KeyArn !== undefined && output.KeyArn !== null ? output.KeyArn : undefined,
-    KeyId: output.KeyId !== undefined && output.KeyId !== null ? output.KeyId : undefined,
+    KeyArn: __expectString(output.KeyArn),
+    KeyId: __expectString(output.KeyId),
   } as any;
 };
 
 const deserializeAws_json1_1KeyMetadata = (output: any, context: __SerdeContext): KeyMetadata => {
   return {
-    AWSAccountId: output.AWSAccountId !== undefined && output.AWSAccountId !== null ? output.AWSAccountId : undefined,
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    CloudHsmClusterId:
-      output.CloudHsmClusterId !== undefined && output.CloudHsmClusterId !== null
-        ? output.CloudHsmClusterId
-        : undefined,
+    AWSAccountId: __expectString(output.AWSAccountId),
+    Arn: __expectString(output.Arn),
+    CloudHsmClusterId: __expectString(output.CloudHsmClusterId),
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
         ? new Date(Math.round(output.CreationDate * 1000))
         : undefined,
-    CustomKeyStoreId:
-      output.CustomKeyStoreId !== undefined && output.CustomKeyStoreId !== null ? output.CustomKeyStoreId : undefined,
-    CustomerMasterKeySpec:
-      output.CustomerMasterKeySpec !== undefined && output.CustomerMasterKeySpec !== null
-        ? output.CustomerMasterKeySpec
-        : undefined,
+    CustomKeyStoreId: __expectString(output.CustomKeyStoreId),
+    CustomerMasterKeySpec: __expectString(output.CustomerMasterKeySpec),
     DeletionDate:
       output.DeletionDate !== undefined && output.DeletionDate !== null
         ? new Date(Math.round(output.DeletionDate * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
+    Description: __expectString(output.Description),
+    Enabled: __expectBoolean(output.Enabled),
     EncryptionAlgorithms:
       output.EncryptionAlgorithms !== undefined && output.EncryptionAlgorithms !== null
         ? deserializeAws_json1_1EncryptionAlgorithmSpecList(output.EncryptionAlgorithms, context)
         : undefined,
-    ExpirationModel:
-      output.ExpirationModel !== undefined && output.ExpirationModel !== null ? output.ExpirationModel : undefined,
-    KeyId: output.KeyId !== undefined && output.KeyId !== null ? output.KeyId : undefined,
-    KeyManager: output.KeyManager !== undefined && output.KeyManager !== null ? output.KeyManager : undefined,
-    KeyState: output.KeyState !== undefined && output.KeyState !== null ? output.KeyState : undefined,
-    KeyUsage: output.KeyUsage !== undefined && output.KeyUsage !== null ? output.KeyUsage : undefined,
-    MultiRegion: output.MultiRegion !== undefined && output.MultiRegion !== null ? output.MultiRegion : undefined,
+    ExpirationModel: __expectString(output.ExpirationModel),
+    KeyId: __expectString(output.KeyId),
+    KeyManager: __expectString(output.KeyManager),
+    KeyState: __expectString(output.KeyState),
+    KeyUsage: __expectString(output.KeyUsage),
+    MultiRegion: __expectBoolean(output.MultiRegion),
     MultiRegionConfiguration:
       output.MultiRegionConfiguration !== undefined && output.MultiRegionConfiguration !== null
         ? deserializeAws_json1_1MultiRegionConfiguration(output.MultiRegionConfiguration, context)
         : undefined,
-    Origin: output.Origin !== undefined && output.Origin !== null ? output.Origin : undefined,
-    PendingDeletionWindowInDays:
-      output.PendingDeletionWindowInDays !== undefined && output.PendingDeletionWindowInDays !== null
-        ? output.PendingDeletionWindowInDays
-        : undefined,
+    Origin: __expectString(output.Origin),
+    PendingDeletionWindowInDays: __expectNumber(output.PendingDeletionWindowInDays),
     SigningAlgorithms:
       output.SigningAlgorithms !== undefined && output.SigningAlgorithms !== null
         ? deserializeAws_json1_1SigningAlgorithmSpecList(output.SigningAlgorithms, context)
@@ -7306,13 +7268,13 @@ const deserializeAws_json1_1KeyUnavailableException = (
   context: __SerdeContext
 ): KeyUnavailableException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1KMSInternalException = (output: any, context: __SerdeContext): KMSInternalException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -7321,7 +7283,7 @@ const deserializeAws_json1_1KMSInvalidSignatureException = (
   context: __SerdeContext
 ): KMSInvalidSignatureException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -7330,13 +7292,13 @@ const deserializeAws_json1_1KMSInvalidStateException = (
   context: __SerdeContext
 ): KMSInvalidStateException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -7346,8 +7308,8 @@ const deserializeAws_json1_1ListAliasesResponse = (output: any, context: __Serde
       output.Aliases !== undefined && output.Aliases !== null
         ? deserializeAws_json1_1AliasList(output.Aliases, context)
         : undefined,
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
-    Truncated: output.Truncated !== undefined && output.Truncated !== null ? output.Truncated : undefined,
+    NextMarker: __expectString(output.NextMarker),
+    Truncated: __expectBoolean(output.Truncated),
   } as any;
 };
 
@@ -7357,8 +7319,8 @@ const deserializeAws_json1_1ListGrantsResponse = (output: any, context: __SerdeC
       output.Grants !== undefined && output.Grants !== null
         ? deserializeAws_json1_1GrantList(output.Grants, context)
         : undefined,
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
-    Truncated: output.Truncated !== undefined && output.Truncated !== null ? output.Truncated : undefined,
+    NextMarker: __expectString(output.NextMarker),
+    Truncated: __expectBoolean(output.Truncated),
   } as any;
 };
 
@@ -7367,12 +7329,12 @@ const deserializeAws_json1_1ListKeyPoliciesResponse = (
   context: __SerdeContext
 ): ListKeyPoliciesResponse => {
   return {
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    NextMarker: __expectString(output.NextMarker),
     PolicyNames:
       output.PolicyNames !== undefined && output.PolicyNames !== null
         ? deserializeAws_json1_1PolicyNameList(output.PolicyNames, context)
         : undefined,
-    Truncated: output.Truncated !== undefined && output.Truncated !== null ? output.Truncated : undefined,
+    Truncated: __expectBoolean(output.Truncated),
   } as any;
 };
 
@@ -7382,8 +7344,8 @@ const deserializeAws_json1_1ListKeysResponse = (output: any, context: __SerdeCon
       output.Keys !== undefined && output.Keys !== null
         ? deserializeAws_json1_1KeyList(output.Keys, context)
         : undefined,
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
-    Truncated: output.Truncated !== undefined && output.Truncated !== null ? output.Truncated : undefined,
+    NextMarker: __expectString(output.NextMarker),
+    Truncated: __expectBoolean(output.Truncated),
   } as any;
 };
 
@@ -7392,12 +7354,12 @@ const deserializeAws_json1_1ListResourceTagsResponse = (
   context: __SerdeContext
 ): ListResourceTagsResponse => {
   return {
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    NextMarker: __expectString(output.NextMarker),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_1TagList(output.Tags, context)
         : undefined,
-    Truncated: output.Truncated !== undefined && output.Truncated !== null ? output.Truncated : undefined,
+    Truncated: __expectBoolean(output.Truncated),
   } as any;
 };
 
@@ -7406,7 +7368,7 @@ const deserializeAws_json1_1MalformedPolicyDocumentException = (
   context: __SerdeContext
 ): MalformedPolicyDocumentException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -7415,10 +7377,7 @@ const deserializeAws_json1_1MultiRegionConfiguration = (
   context: __SerdeContext
 ): MultiRegionConfiguration => {
   return {
-    MultiRegionKeyType:
-      output.MultiRegionKeyType !== undefined && output.MultiRegionKeyType !== null
-        ? output.MultiRegionKeyType
-        : undefined,
+    MultiRegionKeyType: __expectString(output.MultiRegionKeyType),
     PrimaryKey:
       output.PrimaryKey !== undefined && output.PrimaryKey !== null
         ? deserializeAws_json1_1MultiRegionKey(output.PrimaryKey, context)
@@ -7432,8 +7391,8 @@ const deserializeAws_json1_1MultiRegionConfiguration = (
 
 const deserializeAws_json1_1MultiRegionKey = (output: any, context: __SerdeContext): MultiRegionKey => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Region: output.Region !== undefined && output.Region !== null ? output.Region : undefined,
+    Arn: __expectString(output.Arn),
+    Region: __expectString(output.Region),
   } as any;
 };
 
@@ -7450,7 +7409,7 @@ const deserializeAws_json1_1MultiRegionKeyList = (output: any, context: __SerdeC
 
 const deserializeAws_json1_1NotFoundException = (output: any, context: __SerdeContext): NotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -7461,7 +7420,7 @@ const deserializeAws_json1_1PolicyNameList = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7471,16 +7430,10 @@ const deserializeAws_json1_1ReEncryptResponse = (output: any, context: __SerdeCo
       output.CiphertextBlob !== undefined && output.CiphertextBlob !== null
         ? context.base64Decoder(output.CiphertextBlob)
         : undefined,
-    DestinationEncryptionAlgorithm:
-      output.DestinationEncryptionAlgorithm !== undefined && output.DestinationEncryptionAlgorithm !== null
-        ? output.DestinationEncryptionAlgorithm
-        : undefined,
-    KeyId: output.KeyId !== undefined && output.KeyId !== null ? output.KeyId : undefined,
-    SourceEncryptionAlgorithm:
-      output.SourceEncryptionAlgorithm !== undefined && output.SourceEncryptionAlgorithm !== null
-        ? output.SourceEncryptionAlgorithm
-        : undefined,
-    SourceKeyId: output.SourceKeyId !== undefined && output.SourceKeyId !== null ? output.SourceKeyId : undefined,
+    DestinationEncryptionAlgorithm: __expectString(output.DestinationEncryptionAlgorithm),
+    KeyId: __expectString(output.KeyId),
+    SourceEncryptionAlgorithm: __expectString(output.SourceEncryptionAlgorithm),
+    SourceKeyId: __expectString(output.SourceKeyId),
   } as any;
 };
 
@@ -7490,8 +7443,7 @@ const deserializeAws_json1_1ReplicateKeyResponse = (output: any, context: __Serd
       output.ReplicaKeyMetadata !== undefined && output.ReplicaKeyMetadata !== null
         ? deserializeAws_json1_1KeyMetadata(output.ReplicaKeyMetadata, context)
         : undefined,
-    ReplicaPolicy:
-      output.ReplicaPolicy !== undefined && output.ReplicaPolicy !== null ? output.ReplicaPolicy : undefined,
+    ReplicaPolicy: __expectString(output.ReplicaPolicy),
     ReplicaTags:
       output.ReplicaTags !== undefined && output.ReplicaTags !== null
         ? deserializeAws_json1_1TagList(output.ReplicaTags, context)
@@ -7508,12 +7460,9 @@ const deserializeAws_json1_1ScheduleKeyDeletionResponse = (
       output.DeletionDate !== undefined && output.DeletionDate !== null
         ? new Date(Math.round(output.DeletionDate * 1000))
         : undefined,
-    KeyId: output.KeyId !== undefined && output.KeyId !== null ? output.KeyId : undefined,
-    KeyState: output.KeyState !== undefined && output.KeyState !== null ? output.KeyState : undefined,
-    PendingWindowInDays:
-      output.PendingWindowInDays !== undefined && output.PendingWindowInDays !== null
-        ? output.PendingWindowInDays
-        : undefined,
+    KeyId: __expectString(output.KeyId),
+    KeyState: __expectString(output.KeyState),
+    PendingWindowInDays: __expectNumber(output.PendingWindowInDays),
   } as any;
 };
 
@@ -7527,30 +7476,29 @@ const deserializeAws_json1_1SigningAlgorithmSpecList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1SignResponse = (output: any, context: __SerdeContext): SignResponse => {
   return {
-    KeyId: output.KeyId !== undefined && output.KeyId !== null ? output.KeyId : undefined,
+    KeyId: __expectString(output.KeyId),
     Signature:
       output.Signature !== undefined && output.Signature !== null ? context.base64Decoder(output.Signature) : undefined,
-    SigningAlgorithm:
-      output.SigningAlgorithm !== undefined && output.SigningAlgorithm !== null ? output.SigningAlgorithm : undefined,
+    SigningAlgorithm: __expectString(output.SigningAlgorithm),
   } as any;
 };
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    TagKey: output.TagKey !== undefined && output.TagKey !== null ? output.TagKey : undefined,
-    TagValue: output.TagValue !== undefined && output.TagValue !== null ? output.TagValue : undefined,
+    TagKey: __expectString(output.TagKey),
+    TagValue: __expectString(output.TagValue),
   } as any;
 };
 
 const deserializeAws_json1_1TagException = (output: any, context: __SerdeContext): TagException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -7570,7 +7518,7 @@ const deserializeAws_json1_1UnsupportedOperationException = (
   context: __SerdeContext
 ): UnsupportedOperationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -7583,11 +7531,9 @@ const deserializeAws_json1_1UpdateCustomKeyStoreResponse = (
 
 const deserializeAws_json1_1VerifyResponse = (output: any, context: __SerdeContext): VerifyResponse => {
   return {
-    KeyId: output.KeyId !== undefined && output.KeyId !== null ? output.KeyId : undefined,
-    SignatureValid:
-      output.SignatureValid !== undefined && output.SignatureValid !== null ? output.SignatureValid : undefined,
-    SigningAlgorithm:
-      output.SigningAlgorithm !== undefined && output.SigningAlgorithm !== null ? output.SigningAlgorithm : undefined,
+    KeyId: __expectString(output.KeyId),
+    SignatureValid: __expectBoolean(output.SignatureValid),
+    SigningAlgorithm: __expectString(output.SigningAlgorithm),
   } as any;
 };
 

--- a/clients/client-lakeformation/protocols/Aws_json1_1.ts
+++ b/clients/client-lakeformation/protocols/Aws_json1_1.ts
@@ -133,7 +133,7 @@ import {
   UpdateResourceResponse,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException, expectString as __expectString } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -3001,7 +3001,7 @@ const serializeAws_json1_1UpdateResourceRequest = (input: UpdateResourceRequest,
 
 const deserializeAws_json1_1AccessDeniedException = (output: any, context: __SerdeContext): AccessDeniedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3019,7 +3019,7 @@ const deserializeAws_json1_1AddLFTagsToResourceResponse = (
 
 const deserializeAws_json1_1AlreadyExistsException = (output: any, context: __SerdeContext): AlreadyExistsException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3070,7 +3070,7 @@ const deserializeAws_json1_1BatchPermissionsRequestEntry = (
   context: __SerdeContext
 ): BatchPermissionsRequestEntry => {
   return {
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    Id: __expectString(output.Id),
     Permissions:
       output.Permissions !== undefined && output.Permissions !== null
         ? deserializeAws_json1_1PermissionList(output.Permissions, context)
@@ -3112,7 +3112,7 @@ const deserializeAws_json1_1ColumnLFTag = (output: any, context: __SerdeContext)
       output.LFTags !== undefined && output.LFTags !== null
         ? deserializeAws_json1_1LFTagsList(output.LFTags, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -3134,7 +3134,7 @@ const deserializeAws_json1_1ColumnNames = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3152,7 +3152,7 @@ const deserializeAws_json1_1ConcurrentModificationException = (
   context: __SerdeContext
 ): ConcurrentModificationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3173,17 +3173,14 @@ const deserializeAws_json1_1DatabaseLFTagsList = (output: any, context: __SerdeC
 
 const deserializeAws_json1_1DatabaseResource = (output: any, context: __SerdeContext): DatabaseResource => {
   return {
-    CatalogId: output.CatalogId !== undefined && output.CatalogId !== null ? output.CatalogId : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    CatalogId: __expectString(output.CatalogId),
+    Name: __expectString(output.Name),
   } as any;
 };
 
 const deserializeAws_json1_1DataLakePrincipal = (output: any, context: __SerdeContext): DataLakePrincipal => {
   return {
-    DataLakePrincipalIdentifier:
-      output.DataLakePrincipalIdentifier !== undefined && output.DataLakePrincipalIdentifier !== null
-        ? output.DataLakePrincipalIdentifier
-        : undefined,
+    DataLakePrincipalIdentifier: __expectString(output.DataLakePrincipalIdentifier),
   } as any;
 };
 
@@ -3221,8 +3218,8 @@ const deserializeAws_json1_1DataLakeSettings = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1DataLocationResource = (output: any, context: __SerdeContext): DataLocationResource => {
   return {
-    CatalogId: output.CatalogId !== undefined && output.CatalogId !== null ? output.CatalogId : undefined,
-    ResourceArn: output.ResourceArn !== undefined && output.ResourceArn !== null ? output.ResourceArn : undefined,
+    CatalogId: __expectString(output.CatalogId),
+    ResourceArn: __expectString(output.ResourceArn),
   } as any;
 };
 
@@ -3263,14 +3260,14 @@ const deserializeAws_json1_1EntityNotFoundException = (
   context: __SerdeContext
 ): EntityNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1ErrorDetail = (output: any, context: __SerdeContext): ErrorDetail => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
   } as any;
 };
 
@@ -3302,7 +3299,7 @@ const deserializeAws_json1_1GetEffectivePermissionsForPathResponse = (
   context: __SerdeContext
 ): GetEffectivePermissionsForPathResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Permissions:
       output.Permissions !== undefined && output.Permissions !== null
         ? deserializeAws_json1_1PrincipalResourcePermissionsList(output.Permissions, context)
@@ -3312,8 +3309,8 @@ const deserializeAws_json1_1GetEffectivePermissionsForPathResponse = (
 
 const deserializeAws_json1_1GetLFTagResponse = (output: any, context: __SerdeContext): GetLFTagResponse => {
   return {
-    CatalogId: output.CatalogId !== undefined && output.CatalogId !== null ? output.CatalogId : undefined,
-    TagKey: output.TagKey !== undefined && output.TagKey !== null ? output.TagKey : undefined,
+    CatalogId: __expectString(output.CatalogId),
+    TagKey: __expectString(output.TagKey),
     TagValues:
       output.TagValues !== undefined && output.TagValues !== null
         ? deserializeAws_json1_1TagValueList(output.TagValues, context)
@@ -3346,7 +3343,7 @@ const deserializeAws_json1_1GlueEncryptionException = (
   context: __SerdeContext
 ): GlueEncryptionException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3362,19 +3359,19 @@ const deserializeAws_json1_1InternalServiceException = (
   context: __SerdeContext
 ): InternalServiceException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidInputException = (output: any, context: __SerdeContext): InvalidInputException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1LFTag = (output: any, context: __SerdeContext): LFTag => {
   return {
-    TagKey: output.TagKey !== undefined && output.TagKey !== null ? output.TagKey : undefined,
+    TagKey: __expectString(output.TagKey),
     TagValues:
       output.TagValues !== undefined && output.TagValues !== null
         ? deserializeAws_json1_1TagValueList(output.TagValues, context)
@@ -3408,8 +3405,8 @@ const deserializeAws_json1_1LFTagErrors = (output: any, context: __SerdeContext)
 
 const deserializeAws_json1_1LFTagKeyResource = (output: any, context: __SerdeContext): LFTagKeyResource => {
   return {
-    CatalogId: output.CatalogId !== undefined && output.CatalogId !== null ? output.CatalogId : undefined,
-    TagKey: output.TagKey !== undefined && output.TagKey !== null ? output.TagKey : undefined,
+    CatalogId: __expectString(output.CatalogId),
+    TagKey: __expectString(output.TagKey),
     TagValues:
       output.TagValues !== undefined && output.TagValues !== null
         ? deserializeAws_json1_1TagValueList(output.TagValues, context)
@@ -3419,8 +3416,8 @@ const deserializeAws_json1_1LFTagKeyResource = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1LFTagPair = (output: any, context: __SerdeContext): LFTagPair => {
   return {
-    CatalogId: output.CatalogId !== undefined && output.CatalogId !== null ? output.CatalogId : undefined,
-    TagKey: output.TagKey !== undefined && output.TagKey !== null ? output.TagKey : undefined,
+    CatalogId: __expectString(output.CatalogId),
+    TagKey: __expectString(output.TagKey),
     TagValues:
       output.TagValues !== undefined && output.TagValues !== null
         ? deserializeAws_json1_1TagValueList(output.TagValues, context)
@@ -3430,12 +3427,12 @@ const deserializeAws_json1_1LFTagPair = (output: any, context: __SerdeContext): 
 
 const deserializeAws_json1_1LFTagPolicyResource = (output: any, context: __SerdeContext): LFTagPolicyResource => {
   return {
-    CatalogId: output.CatalogId !== undefined && output.CatalogId !== null ? output.CatalogId : undefined,
+    CatalogId: __expectString(output.CatalogId),
     Expression:
       output.Expression !== undefined && output.Expression !== null
         ? deserializeAws_json1_1Expression(output.Expression, context)
         : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
+    ResourceType: __expectString(output.ResourceType),
   } as any;
 };
 
@@ -3456,7 +3453,7 @@ const deserializeAws_json1_1ListLFTagsResponse = (output: any, context: __SerdeC
       output.LFTags !== undefined && output.LFTags !== null
         ? deserializeAws_json1_1LFTagsList(output.LFTags, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -3465,7 +3462,7 @@ const deserializeAws_json1_1ListPermissionsResponse = (
   context: __SerdeContext
 ): ListPermissionsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     PrincipalResourcePermissions:
       output.PrincipalResourcePermissions !== undefined && output.PrincipalResourcePermissions !== null
         ? deserializeAws_json1_1PrincipalResourcePermissionsList(output.PrincipalResourcePermissions, context)
@@ -3475,7 +3472,7 @@ const deserializeAws_json1_1ListPermissionsResponse = (
 
 const deserializeAws_json1_1ListResourcesResponse = (output: any, context: __SerdeContext): ListResourcesResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     ResourceInfoList:
       output.ResourceInfoList !== undefined && output.ResourceInfoList !== null
         ? deserializeAws_json1_1ResourceInfoList(output.ResourceInfoList, context)
@@ -3488,7 +3485,7 @@ const deserializeAws_json1_1OperationTimeoutException = (
   context: __SerdeContext
 ): OperationTimeoutException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3499,7 +3496,7 @@ const deserializeAws_json1_1PermissionList = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3637,8 +3634,8 @@ const deserializeAws_json1_1ResourceInfo = (output: any, context: __SerdeContext
       output.LastModified !== undefined && output.LastModified !== null
         ? new Date(Math.round(output.LastModified * 1000))
         : undefined,
-    ResourceArn: output.ResourceArn !== undefined && output.ResourceArn !== null ? output.ResourceArn : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
+    ResourceArn: __expectString(output.ResourceArn),
+    RoleArn: __expectString(output.RoleArn),
   } as any;
 };
 
@@ -3658,7 +3655,7 @@ const deserializeAws_json1_1ResourceNumberLimitExceededException = (
   context: __SerdeContext
 ): ResourceNumberLimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3669,7 +3666,7 @@ const deserializeAws_json1_1ResourceShareList = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3689,7 +3686,7 @@ const deserializeAws_json1_1SearchDatabasesByLFTagsResponse = (
       output.DatabaseList !== undefined && output.DatabaseList !== null
         ? deserializeAws_json1_1DatabaseLFTagsList(output.DatabaseList, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -3698,7 +3695,7 @@ const deserializeAws_json1_1SearchTablesByLFTagsResponse = (
   context: __SerdeContext
 ): SearchTablesByLFTagsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     TableList:
       output.TableList !== undefined && output.TableList !== null
         ? deserializeAws_json1_1TableLFTagsList(output.TableList, context)
@@ -3719,9 +3716,9 @@ const deserializeAws_json1_1TableLFTagsList = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_1TableResource = (output: any, context: __SerdeContext): TableResource => {
   return {
-    CatalogId: output.CatalogId !== undefined && output.CatalogId !== null ? output.CatalogId : undefined,
-    DatabaseName: output.DatabaseName !== undefined && output.DatabaseName !== null ? output.DatabaseName : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    CatalogId: __expectString(output.CatalogId),
+    DatabaseName: __expectString(output.DatabaseName),
+    Name: __expectString(output.Name),
     TableWildcard:
       output.TableWildcard !== undefined && output.TableWildcard !== null
         ? deserializeAws_json1_1TableWildcard(output.TableWildcard, context)
@@ -3738,7 +3735,7 @@ const deserializeAws_json1_1TableWithColumnsResource = (
   context: __SerdeContext
 ): TableWithColumnsResource => {
   return {
-    CatalogId: output.CatalogId !== undefined && output.CatalogId !== null ? output.CatalogId : undefined,
+    CatalogId: __expectString(output.CatalogId),
     ColumnNames:
       output.ColumnNames !== undefined && output.ColumnNames !== null
         ? deserializeAws_json1_1ColumnNames(output.ColumnNames, context)
@@ -3747,8 +3744,8 @@ const deserializeAws_json1_1TableWithColumnsResource = (
       output.ColumnWildcard !== undefined && output.ColumnWildcard !== null
         ? deserializeAws_json1_1ColumnWildcard(output.ColumnWildcard, context)
         : undefined,
-    DatabaseName: output.DatabaseName !== undefined && output.DatabaseName !== null ? output.DatabaseName : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    DatabaseName: __expectString(output.DatabaseName),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -3793,7 +3790,7 @@ const deserializeAws_json1_1TagValueList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3804,7 +3801,7 @@ const deserializeAws_json1_1TrustedResourceOwners = (output: any, context: __Ser
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 

--- a/clients/client-lambda/protocols/Aws_restJson1.ts
+++ b/clients/client-lambda/protocols/Aws_restJson1.ts
@@ -236,6 +236,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -2353,10 +2356,10 @@ export const deserializeAws_restJson1AddLayerVersionPermissionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.RevisionId !== undefined && data.RevisionId !== null) {
-    contents.RevisionId = data.RevisionId;
+    contents.RevisionId = __expectString(data.RevisionId);
   }
   if (data.Statement !== undefined && data.Statement !== null) {
-    contents.Statement = data.Statement;
+    contents.Statement = __expectString(data.Statement);
   }
   return Promise.resolve(contents);
 };
@@ -2459,7 +2462,7 @@ export const deserializeAws_restJson1AddPermissionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Statement !== undefined && data.Statement !== null) {
-    contents.Statement = data.Statement;
+    contents.Statement = __expectString(data.Statement);
   }
   return Promise.resolve(contents);
 };
@@ -2567,19 +2570,19 @@ export const deserializeAws_restJson1CreateAliasCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AliasArn !== undefined && data.AliasArn !== null) {
-    contents.AliasArn = data.AliasArn;
+    contents.AliasArn = __expectString(data.AliasArn);
   }
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.FunctionVersion !== undefined && data.FunctionVersion !== null) {
-    contents.FunctionVersion = data.FunctionVersion;
+    contents.FunctionVersion = __expectString(data.FunctionVersion);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.RevisionId !== undefined && data.RevisionId !== null) {
-    contents.RevisionId = data.RevisionId;
+    contents.RevisionId = __expectString(data.RevisionId);
   }
   if (data.RoutingConfig !== undefined && data.RoutingConfig !== null) {
     contents.RoutingConfig = deserializeAws_restJson1AliasRoutingConfiguration(data.RoutingConfig, context);
@@ -2753,19 +2756,19 @@ export const deserializeAws_restJson1CreateEventSourceMappingCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.BatchSize !== undefined && data.BatchSize !== null) {
-    contents.BatchSize = data.BatchSize;
+    contents.BatchSize = __expectNumber(data.BatchSize);
   }
   if (data.BisectBatchOnFunctionError !== undefined && data.BisectBatchOnFunctionError !== null) {
-    contents.BisectBatchOnFunctionError = data.BisectBatchOnFunctionError;
+    contents.BisectBatchOnFunctionError = __expectBoolean(data.BisectBatchOnFunctionError);
   }
   if (data.DestinationConfig !== undefined && data.DestinationConfig !== null) {
     contents.DestinationConfig = deserializeAws_restJson1DestinationConfig(data.DestinationConfig, context);
   }
   if (data.EventSourceArn !== undefined && data.EventSourceArn !== null) {
-    contents.EventSourceArn = data.EventSourceArn;
+    contents.EventSourceArn = __expectString(data.EventSourceArn);
   }
   if (data.FunctionArn !== undefined && data.FunctionArn !== null) {
-    contents.FunctionArn = data.FunctionArn;
+    contents.FunctionArn = __expectString(data.FunctionArn);
   }
   if (data.FunctionResponseTypes !== undefined && data.FunctionResponseTypes !== null) {
     contents.FunctionResponseTypes = deserializeAws_restJson1FunctionResponseTypeList(
@@ -2777,19 +2780,19 @@ export const deserializeAws_restJson1CreateEventSourceMappingCommand = async (
     contents.LastModified = new Date(Math.round(data.LastModified * 1000));
   }
   if (data.LastProcessingResult !== undefined && data.LastProcessingResult !== null) {
-    contents.LastProcessingResult = data.LastProcessingResult;
+    contents.LastProcessingResult = __expectString(data.LastProcessingResult);
   }
   if (data.MaximumBatchingWindowInSeconds !== undefined && data.MaximumBatchingWindowInSeconds !== null) {
-    contents.MaximumBatchingWindowInSeconds = data.MaximumBatchingWindowInSeconds;
+    contents.MaximumBatchingWindowInSeconds = __expectNumber(data.MaximumBatchingWindowInSeconds);
   }
   if (data.MaximumRecordAgeInSeconds !== undefined && data.MaximumRecordAgeInSeconds !== null) {
-    contents.MaximumRecordAgeInSeconds = data.MaximumRecordAgeInSeconds;
+    contents.MaximumRecordAgeInSeconds = __expectNumber(data.MaximumRecordAgeInSeconds);
   }
   if (data.MaximumRetryAttempts !== undefined && data.MaximumRetryAttempts !== null) {
-    contents.MaximumRetryAttempts = data.MaximumRetryAttempts;
+    contents.MaximumRetryAttempts = __expectNumber(data.MaximumRetryAttempts);
   }
   if (data.ParallelizationFactor !== undefined && data.ParallelizationFactor !== null) {
-    contents.ParallelizationFactor = data.ParallelizationFactor;
+    contents.ParallelizationFactor = __expectNumber(data.ParallelizationFactor);
   }
   if (data.Queues !== undefined && data.Queues !== null) {
     contents.Queues = deserializeAws_restJson1Queues(data.Queues, context);
@@ -2807,25 +2810,25 @@ export const deserializeAws_restJson1CreateEventSourceMappingCommand = async (
     );
   }
   if (data.StartingPosition !== undefined && data.StartingPosition !== null) {
-    contents.StartingPosition = data.StartingPosition;
+    contents.StartingPosition = __expectString(data.StartingPosition);
   }
   if (data.StartingPositionTimestamp !== undefined && data.StartingPositionTimestamp !== null) {
     contents.StartingPositionTimestamp = new Date(Math.round(data.StartingPositionTimestamp * 1000));
   }
   if (data.State !== undefined && data.State !== null) {
-    contents.State = data.State;
+    contents.State = __expectString(data.State);
   }
   if (data.StateTransitionReason !== undefined && data.StateTransitionReason !== null) {
-    contents.StateTransitionReason = data.StateTransitionReason;
+    contents.StateTransitionReason = __expectString(data.StateTransitionReason);
   }
   if (data.Topics !== undefined && data.Topics !== null) {
     contents.Topics = deserializeAws_restJson1Topics(data.Topics, context);
   }
   if (data.TumblingWindowInSeconds !== undefined && data.TumblingWindowInSeconds !== null) {
-    contents.TumblingWindowInSeconds = data.TumblingWindowInSeconds;
+    contents.TumblingWindowInSeconds = __expectNumber(data.TumblingWindowInSeconds);
   }
   if (data.UUID !== undefined && data.UUID !== null) {
-    contents.UUID = data.UUID;
+    contents.UUID = __expectString(data.UUID);
   }
   return Promise.resolve(contents);
 };
@@ -2942,16 +2945,16 @@ export const deserializeAws_restJson1CreateFunctionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.CodeSha256 !== undefined && data.CodeSha256 !== null) {
-    contents.CodeSha256 = data.CodeSha256;
+    contents.CodeSha256 = __expectString(data.CodeSha256);
   }
   if (data.CodeSize !== undefined && data.CodeSize !== null) {
-    contents.CodeSize = data.CodeSize;
+    contents.CodeSize = __expectNumber(data.CodeSize);
   }
   if (data.DeadLetterConfig !== undefined && data.DeadLetterConfig !== null) {
     contents.DeadLetterConfig = deserializeAws_restJson1DeadLetterConfig(data.DeadLetterConfig, context);
   }
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.Environment !== undefined && data.Environment !== null) {
     contents.Environment = deserializeAws_restJson1EnvironmentResponse(data.Environment, context);
@@ -2960,76 +2963,76 @@ export const deserializeAws_restJson1CreateFunctionCommand = async (
     contents.FileSystemConfigs = deserializeAws_restJson1FileSystemConfigList(data.FileSystemConfigs, context);
   }
   if (data.FunctionArn !== undefined && data.FunctionArn !== null) {
-    contents.FunctionArn = data.FunctionArn;
+    contents.FunctionArn = __expectString(data.FunctionArn);
   }
   if (data.FunctionName !== undefined && data.FunctionName !== null) {
-    contents.FunctionName = data.FunctionName;
+    contents.FunctionName = __expectString(data.FunctionName);
   }
   if (data.Handler !== undefined && data.Handler !== null) {
-    contents.Handler = data.Handler;
+    contents.Handler = __expectString(data.Handler);
   }
   if (data.ImageConfigResponse !== undefined && data.ImageConfigResponse !== null) {
     contents.ImageConfigResponse = deserializeAws_restJson1ImageConfigResponse(data.ImageConfigResponse, context);
   }
   if (data.KMSKeyArn !== undefined && data.KMSKeyArn !== null) {
-    contents.KMSKeyArn = data.KMSKeyArn;
+    contents.KMSKeyArn = __expectString(data.KMSKeyArn);
   }
   if (data.LastModified !== undefined && data.LastModified !== null) {
-    contents.LastModified = data.LastModified;
+    contents.LastModified = __expectString(data.LastModified);
   }
   if (data.LastUpdateStatus !== undefined && data.LastUpdateStatus !== null) {
-    contents.LastUpdateStatus = data.LastUpdateStatus;
+    contents.LastUpdateStatus = __expectString(data.LastUpdateStatus);
   }
   if (data.LastUpdateStatusReason !== undefined && data.LastUpdateStatusReason !== null) {
-    contents.LastUpdateStatusReason = data.LastUpdateStatusReason;
+    contents.LastUpdateStatusReason = __expectString(data.LastUpdateStatusReason);
   }
   if (data.LastUpdateStatusReasonCode !== undefined && data.LastUpdateStatusReasonCode !== null) {
-    contents.LastUpdateStatusReasonCode = data.LastUpdateStatusReasonCode;
+    contents.LastUpdateStatusReasonCode = __expectString(data.LastUpdateStatusReasonCode);
   }
   if (data.Layers !== undefined && data.Layers !== null) {
     contents.Layers = deserializeAws_restJson1LayersReferenceList(data.Layers, context);
   }
   if (data.MasterArn !== undefined && data.MasterArn !== null) {
-    contents.MasterArn = data.MasterArn;
+    contents.MasterArn = __expectString(data.MasterArn);
   }
   if (data.MemorySize !== undefined && data.MemorySize !== null) {
-    contents.MemorySize = data.MemorySize;
+    contents.MemorySize = __expectNumber(data.MemorySize);
   }
   if (data.PackageType !== undefined && data.PackageType !== null) {
-    contents.PackageType = data.PackageType;
+    contents.PackageType = __expectString(data.PackageType);
   }
   if (data.RevisionId !== undefined && data.RevisionId !== null) {
-    contents.RevisionId = data.RevisionId;
+    contents.RevisionId = __expectString(data.RevisionId);
   }
   if (data.Role !== undefined && data.Role !== null) {
-    contents.Role = data.Role;
+    contents.Role = __expectString(data.Role);
   }
   if (data.Runtime !== undefined && data.Runtime !== null) {
-    contents.Runtime = data.Runtime;
+    contents.Runtime = __expectString(data.Runtime);
   }
   if (data.SigningJobArn !== undefined && data.SigningJobArn !== null) {
-    contents.SigningJobArn = data.SigningJobArn;
+    contents.SigningJobArn = __expectString(data.SigningJobArn);
   }
   if (data.SigningProfileVersionArn !== undefined && data.SigningProfileVersionArn !== null) {
-    contents.SigningProfileVersionArn = data.SigningProfileVersionArn;
+    contents.SigningProfileVersionArn = __expectString(data.SigningProfileVersionArn);
   }
   if (data.State !== undefined && data.State !== null) {
-    contents.State = data.State;
+    contents.State = __expectString(data.State);
   }
   if (data.StateReason !== undefined && data.StateReason !== null) {
-    contents.StateReason = data.StateReason;
+    contents.StateReason = __expectString(data.StateReason);
   }
   if (data.StateReasonCode !== undefined && data.StateReasonCode !== null) {
-    contents.StateReasonCode = data.StateReasonCode;
+    contents.StateReasonCode = __expectString(data.StateReasonCode);
   }
   if (data.Timeout !== undefined && data.Timeout !== null) {
-    contents.Timeout = data.Timeout;
+    contents.Timeout = __expectNumber(data.Timeout);
   }
   if (data.TracingConfig !== undefined && data.TracingConfig !== null) {
     contents.TracingConfig = deserializeAws_restJson1TracingConfigResponse(data.TracingConfig, context);
   }
   if (data.Version !== undefined && data.Version !== null) {
-    contents.Version = data.Version;
+    contents.Version = __expectString(data.Version);
   }
   if (data.VpcConfig !== undefined && data.VpcConfig !== null) {
     contents.VpcConfig = deserializeAws_restJson1VpcConfigResponse(data.VpcConfig, context);
@@ -3322,19 +3325,19 @@ export const deserializeAws_restJson1DeleteEventSourceMappingCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.BatchSize !== undefined && data.BatchSize !== null) {
-    contents.BatchSize = data.BatchSize;
+    contents.BatchSize = __expectNumber(data.BatchSize);
   }
   if (data.BisectBatchOnFunctionError !== undefined && data.BisectBatchOnFunctionError !== null) {
-    contents.BisectBatchOnFunctionError = data.BisectBatchOnFunctionError;
+    contents.BisectBatchOnFunctionError = __expectBoolean(data.BisectBatchOnFunctionError);
   }
   if (data.DestinationConfig !== undefined && data.DestinationConfig !== null) {
     contents.DestinationConfig = deserializeAws_restJson1DestinationConfig(data.DestinationConfig, context);
   }
   if (data.EventSourceArn !== undefined && data.EventSourceArn !== null) {
-    contents.EventSourceArn = data.EventSourceArn;
+    contents.EventSourceArn = __expectString(data.EventSourceArn);
   }
   if (data.FunctionArn !== undefined && data.FunctionArn !== null) {
-    contents.FunctionArn = data.FunctionArn;
+    contents.FunctionArn = __expectString(data.FunctionArn);
   }
   if (data.FunctionResponseTypes !== undefined && data.FunctionResponseTypes !== null) {
     contents.FunctionResponseTypes = deserializeAws_restJson1FunctionResponseTypeList(
@@ -3346,19 +3349,19 @@ export const deserializeAws_restJson1DeleteEventSourceMappingCommand = async (
     contents.LastModified = new Date(Math.round(data.LastModified * 1000));
   }
   if (data.LastProcessingResult !== undefined && data.LastProcessingResult !== null) {
-    contents.LastProcessingResult = data.LastProcessingResult;
+    contents.LastProcessingResult = __expectString(data.LastProcessingResult);
   }
   if (data.MaximumBatchingWindowInSeconds !== undefined && data.MaximumBatchingWindowInSeconds !== null) {
-    contents.MaximumBatchingWindowInSeconds = data.MaximumBatchingWindowInSeconds;
+    contents.MaximumBatchingWindowInSeconds = __expectNumber(data.MaximumBatchingWindowInSeconds);
   }
   if (data.MaximumRecordAgeInSeconds !== undefined && data.MaximumRecordAgeInSeconds !== null) {
-    contents.MaximumRecordAgeInSeconds = data.MaximumRecordAgeInSeconds;
+    contents.MaximumRecordAgeInSeconds = __expectNumber(data.MaximumRecordAgeInSeconds);
   }
   if (data.MaximumRetryAttempts !== undefined && data.MaximumRetryAttempts !== null) {
-    contents.MaximumRetryAttempts = data.MaximumRetryAttempts;
+    contents.MaximumRetryAttempts = __expectNumber(data.MaximumRetryAttempts);
   }
   if (data.ParallelizationFactor !== undefined && data.ParallelizationFactor !== null) {
-    contents.ParallelizationFactor = data.ParallelizationFactor;
+    contents.ParallelizationFactor = __expectNumber(data.ParallelizationFactor);
   }
   if (data.Queues !== undefined && data.Queues !== null) {
     contents.Queues = deserializeAws_restJson1Queues(data.Queues, context);
@@ -3376,25 +3379,25 @@ export const deserializeAws_restJson1DeleteEventSourceMappingCommand = async (
     );
   }
   if (data.StartingPosition !== undefined && data.StartingPosition !== null) {
-    contents.StartingPosition = data.StartingPosition;
+    contents.StartingPosition = __expectString(data.StartingPosition);
   }
   if (data.StartingPositionTimestamp !== undefined && data.StartingPositionTimestamp !== null) {
     contents.StartingPositionTimestamp = new Date(Math.round(data.StartingPositionTimestamp * 1000));
   }
   if (data.State !== undefined && data.State !== null) {
-    contents.State = data.State;
+    contents.State = __expectString(data.State);
   }
   if (data.StateTransitionReason !== undefined && data.StateTransitionReason !== null) {
-    contents.StateTransitionReason = data.StateTransitionReason;
+    contents.StateTransitionReason = __expectString(data.StateTransitionReason);
   }
   if (data.Topics !== undefined && data.Topics !== null) {
     contents.Topics = deserializeAws_restJson1Topics(data.Topics, context);
   }
   if (data.TumblingWindowInSeconds !== undefined && data.TumblingWindowInSeconds !== null) {
-    contents.TumblingWindowInSeconds = data.TumblingWindowInSeconds;
+    contents.TumblingWindowInSeconds = __expectNumber(data.TumblingWindowInSeconds);
   }
   if (data.UUID !== undefined && data.UUID !== null) {
-    contents.UUID = data.UUID;
+    contents.UUID = __expectString(data.UUID);
   }
   return Promise.resolve(contents);
 };
@@ -4027,19 +4030,19 @@ export const deserializeAws_restJson1GetAliasCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AliasArn !== undefined && data.AliasArn !== null) {
-    contents.AliasArn = data.AliasArn;
+    contents.AliasArn = __expectString(data.AliasArn);
   }
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.FunctionVersion !== undefined && data.FunctionVersion !== null) {
-    contents.FunctionVersion = data.FunctionVersion;
+    contents.FunctionVersion = __expectString(data.FunctionVersion);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.RevisionId !== undefined && data.RevisionId !== null) {
-    contents.RevisionId = data.RevisionId;
+    contents.RevisionId = __expectString(data.RevisionId);
   }
   if (data.RoutingConfig !== undefined && data.RoutingConfig !== null) {
     contents.RoutingConfig = deserializeAws_restJson1AliasRoutingConfiguration(data.RoutingConfig, context);
@@ -4213,19 +4216,19 @@ export const deserializeAws_restJson1GetEventSourceMappingCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.BatchSize !== undefined && data.BatchSize !== null) {
-    contents.BatchSize = data.BatchSize;
+    contents.BatchSize = __expectNumber(data.BatchSize);
   }
   if (data.BisectBatchOnFunctionError !== undefined && data.BisectBatchOnFunctionError !== null) {
-    contents.BisectBatchOnFunctionError = data.BisectBatchOnFunctionError;
+    contents.BisectBatchOnFunctionError = __expectBoolean(data.BisectBatchOnFunctionError);
   }
   if (data.DestinationConfig !== undefined && data.DestinationConfig !== null) {
     contents.DestinationConfig = deserializeAws_restJson1DestinationConfig(data.DestinationConfig, context);
   }
   if (data.EventSourceArn !== undefined && data.EventSourceArn !== null) {
-    contents.EventSourceArn = data.EventSourceArn;
+    contents.EventSourceArn = __expectString(data.EventSourceArn);
   }
   if (data.FunctionArn !== undefined && data.FunctionArn !== null) {
-    contents.FunctionArn = data.FunctionArn;
+    contents.FunctionArn = __expectString(data.FunctionArn);
   }
   if (data.FunctionResponseTypes !== undefined && data.FunctionResponseTypes !== null) {
     contents.FunctionResponseTypes = deserializeAws_restJson1FunctionResponseTypeList(
@@ -4237,19 +4240,19 @@ export const deserializeAws_restJson1GetEventSourceMappingCommand = async (
     contents.LastModified = new Date(Math.round(data.LastModified * 1000));
   }
   if (data.LastProcessingResult !== undefined && data.LastProcessingResult !== null) {
-    contents.LastProcessingResult = data.LastProcessingResult;
+    contents.LastProcessingResult = __expectString(data.LastProcessingResult);
   }
   if (data.MaximumBatchingWindowInSeconds !== undefined && data.MaximumBatchingWindowInSeconds !== null) {
-    contents.MaximumBatchingWindowInSeconds = data.MaximumBatchingWindowInSeconds;
+    contents.MaximumBatchingWindowInSeconds = __expectNumber(data.MaximumBatchingWindowInSeconds);
   }
   if (data.MaximumRecordAgeInSeconds !== undefined && data.MaximumRecordAgeInSeconds !== null) {
-    contents.MaximumRecordAgeInSeconds = data.MaximumRecordAgeInSeconds;
+    contents.MaximumRecordAgeInSeconds = __expectNumber(data.MaximumRecordAgeInSeconds);
   }
   if (data.MaximumRetryAttempts !== undefined && data.MaximumRetryAttempts !== null) {
-    contents.MaximumRetryAttempts = data.MaximumRetryAttempts;
+    contents.MaximumRetryAttempts = __expectNumber(data.MaximumRetryAttempts);
   }
   if (data.ParallelizationFactor !== undefined && data.ParallelizationFactor !== null) {
-    contents.ParallelizationFactor = data.ParallelizationFactor;
+    contents.ParallelizationFactor = __expectNumber(data.ParallelizationFactor);
   }
   if (data.Queues !== undefined && data.Queues !== null) {
     contents.Queues = deserializeAws_restJson1Queues(data.Queues, context);
@@ -4267,25 +4270,25 @@ export const deserializeAws_restJson1GetEventSourceMappingCommand = async (
     );
   }
   if (data.StartingPosition !== undefined && data.StartingPosition !== null) {
-    contents.StartingPosition = data.StartingPosition;
+    contents.StartingPosition = __expectString(data.StartingPosition);
   }
   if (data.StartingPositionTimestamp !== undefined && data.StartingPositionTimestamp !== null) {
     contents.StartingPositionTimestamp = new Date(Math.round(data.StartingPositionTimestamp * 1000));
   }
   if (data.State !== undefined && data.State !== null) {
-    contents.State = data.State;
+    contents.State = __expectString(data.State);
   }
   if (data.StateTransitionReason !== undefined && data.StateTransitionReason !== null) {
-    contents.StateTransitionReason = data.StateTransitionReason;
+    contents.StateTransitionReason = __expectString(data.StateTransitionReason);
   }
   if (data.Topics !== undefined && data.Topics !== null) {
     contents.Topics = deserializeAws_restJson1Topics(data.Topics, context);
   }
   if (data.TumblingWindowInSeconds !== undefined && data.TumblingWindowInSeconds !== null) {
-    contents.TumblingWindowInSeconds = data.TumblingWindowInSeconds;
+    contents.TumblingWindowInSeconds = __expectNumber(data.TumblingWindowInSeconds);
   }
   if (data.UUID !== undefined && data.UUID !== null) {
-    contents.UUID = data.UUID;
+    contents.UUID = __expectString(data.UUID);
   }
   return Promise.resolve(contents);
 };
@@ -4456,10 +4459,10 @@ export const deserializeAws_restJson1GetFunctionCodeSigningConfigCommand = async
   };
   const data: any = await parseBody(output.body, context);
   if (data.CodeSigningConfigArn !== undefined && data.CodeSigningConfigArn !== null) {
-    contents.CodeSigningConfigArn = data.CodeSigningConfigArn;
+    contents.CodeSigningConfigArn = __expectString(data.CodeSigningConfigArn);
   }
   if (data.FunctionName !== undefined && data.FunctionName !== null) {
-    contents.FunctionName = data.FunctionName;
+    contents.FunctionName = __expectString(data.FunctionName);
   }
   return Promise.resolve(contents);
 };
@@ -4538,7 +4541,7 @@ export const deserializeAws_restJson1GetFunctionConcurrencyCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ReservedConcurrentExecutions !== undefined && data.ReservedConcurrentExecutions !== null) {
-    contents.ReservedConcurrentExecutions = data.ReservedConcurrentExecutions;
+    contents.ReservedConcurrentExecutions = __expectNumber(data.ReservedConcurrentExecutions);
   }
   return Promise.resolve(contents);
 };
@@ -4647,16 +4650,16 @@ export const deserializeAws_restJson1GetFunctionConfigurationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.CodeSha256 !== undefined && data.CodeSha256 !== null) {
-    contents.CodeSha256 = data.CodeSha256;
+    contents.CodeSha256 = __expectString(data.CodeSha256);
   }
   if (data.CodeSize !== undefined && data.CodeSize !== null) {
-    contents.CodeSize = data.CodeSize;
+    contents.CodeSize = __expectNumber(data.CodeSize);
   }
   if (data.DeadLetterConfig !== undefined && data.DeadLetterConfig !== null) {
     contents.DeadLetterConfig = deserializeAws_restJson1DeadLetterConfig(data.DeadLetterConfig, context);
   }
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.Environment !== undefined && data.Environment !== null) {
     contents.Environment = deserializeAws_restJson1EnvironmentResponse(data.Environment, context);
@@ -4665,76 +4668,76 @@ export const deserializeAws_restJson1GetFunctionConfigurationCommand = async (
     contents.FileSystemConfigs = deserializeAws_restJson1FileSystemConfigList(data.FileSystemConfigs, context);
   }
   if (data.FunctionArn !== undefined && data.FunctionArn !== null) {
-    contents.FunctionArn = data.FunctionArn;
+    contents.FunctionArn = __expectString(data.FunctionArn);
   }
   if (data.FunctionName !== undefined && data.FunctionName !== null) {
-    contents.FunctionName = data.FunctionName;
+    contents.FunctionName = __expectString(data.FunctionName);
   }
   if (data.Handler !== undefined && data.Handler !== null) {
-    contents.Handler = data.Handler;
+    contents.Handler = __expectString(data.Handler);
   }
   if (data.ImageConfigResponse !== undefined && data.ImageConfigResponse !== null) {
     contents.ImageConfigResponse = deserializeAws_restJson1ImageConfigResponse(data.ImageConfigResponse, context);
   }
   if (data.KMSKeyArn !== undefined && data.KMSKeyArn !== null) {
-    contents.KMSKeyArn = data.KMSKeyArn;
+    contents.KMSKeyArn = __expectString(data.KMSKeyArn);
   }
   if (data.LastModified !== undefined && data.LastModified !== null) {
-    contents.LastModified = data.LastModified;
+    contents.LastModified = __expectString(data.LastModified);
   }
   if (data.LastUpdateStatus !== undefined && data.LastUpdateStatus !== null) {
-    contents.LastUpdateStatus = data.LastUpdateStatus;
+    contents.LastUpdateStatus = __expectString(data.LastUpdateStatus);
   }
   if (data.LastUpdateStatusReason !== undefined && data.LastUpdateStatusReason !== null) {
-    contents.LastUpdateStatusReason = data.LastUpdateStatusReason;
+    contents.LastUpdateStatusReason = __expectString(data.LastUpdateStatusReason);
   }
   if (data.LastUpdateStatusReasonCode !== undefined && data.LastUpdateStatusReasonCode !== null) {
-    contents.LastUpdateStatusReasonCode = data.LastUpdateStatusReasonCode;
+    contents.LastUpdateStatusReasonCode = __expectString(data.LastUpdateStatusReasonCode);
   }
   if (data.Layers !== undefined && data.Layers !== null) {
     contents.Layers = deserializeAws_restJson1LayersReferenceList(data.Layers, context);
   }
   if (data.MasterArn !== undefined && data.MasterArn !== null) {
-    contents.MasterArn = data.MasterArn;
+    contents.MasterArn = __expectString(data.MasterArn);
   }
   if (data.MemorySize !== undefined && data.MemorySize !== null) {
-    contents.MemorySize = data.MemorySize;
+    contents.MemorySize = __expectNumber(data.MemorySize);
   }
   if (data.PackageType !== undefined && data.PackageType !== null) {
-    contents.PackageType = data.PackageType;
+    contents.PackageType = __expectString(data.PackageType);
   }
   if (data.RevisionId !== undefined && data.RevisionId !== null) {
-    contents.RevisionId = data.RevisionId;
+    contents.RevisionId = __expectString(data.RevisionId);
   }
   if (data.Role !== undefined && data.Role !== null) {
-    contents.Role = data.Role;
+    contents.Role = __expectString(data.Role);
   }
   if (data.Runtime !== undefined && data.Runtime !== null) {
-    contents.Runtime = data.Runtime;
+    contents.Runtime = __expectString(data.Runtime);
   }
   if (data.SigningJobArn !== undefined && data.SigningJobArn !== null) {
-    contents.SigningJobArn = data.SigningJobArn;
+    contents.SigningJobArn = __expectString(data.SigningJobArn);
   }
   if (data.SigningProfileVersionArn !== undefined && data.SigningProfileVersionArn !== null) {
-    contents.SigningProfileVersionArn = data.SigningProfileVersionArn;
+    contents.SigningProfileVersionArn = __expectString(data.SigningProfileVersionArn);
   }
   if (data.State !== undefined && data.State !== null) {
-    contents.State = data.State;
+    contents.State = __expectString(data.State);
   }
   if (data.StateReason !== undefined && data.StateReason !== null) {
-    contents.StateReason = data.StateReason;
+    contents.StateReason = __expectString(data.StateReason);
   }
   if (data.StateReasonCode !== undefined && data.StateReasonCode !== null) {
-    contents.StateReasonCode = data.StateReasonCode;
+    contents.StateReasonCode = __expectString(data.StateReasonCode);
   }
   if (data.Timeout !== undefined && data.Timeout !== null) {
-    contents.Timeout = data.Timeout;
+    contents.Timeout = __expectNumber(data.Timeout);
   }
   if (data.TracingConfig !== undefined && data.TracingConfig !== null) {
     contents.TracingConfig = deserializeAws_restJson1TracingConfigResponse(data.TracingConfig, context);
   }
   if (data.Version !== undefined && data.Version !== null) {
-    contents.Version = data.Version;
+    contents.Version = __expectString(data.Version);
   }
   if (data.VpcConfig !== undefined && data.VpcConfig !== null) {
     contents.VpcConfig = deserializeAws_restJson1VpcConfigResponse(data.VpcConfig, context);
@@ -4823,16 +4826,16 @@ export const deserializeAws_restJson1GetFunctionEventInvokeConfigCommand = async
     contents.DestinationConfig = deserializeAws_restJson1DestinationConfig(data.DestinationConfig, context);
   }
   if (data.FunctionArn !== undefined && data.FunctionArn !== null) {
-    contents.FunctionArn = data.FunctionArn;
+    contents.FunctionArn = __expectString(data.FunctionArn);
   }
   if (data.LastModified !== undefined && data.LastModified !== null) {
     contents.LastModified = new Date(Math.round(data.LastModified * 1000));
   }
   if (data.MaximumEventAgeInSeconds !== undefined && data.MaximumEventAgeInSeconds !== null) {
-    contents.MaximumEventAgeInSeconds = data.MaximumEventAgeInSeconds;
+    contents.MaximumEventAgeInSeconds = __expectNumber(data.MaximumEventAgeInSeconds);
   }
   if (data.MaximumRetryAttempts !== undefined && data.MaximumRetryAttempts !== null) {
-    contents.MaximumRetryAttempts = data.MaximumRetryAttempts;
+    contents.MaximumRetryAttempts = __expectNumber(data.MaximumRetryAttempts);
   }
   return Promise.resolve(contents);
 };
@@ -4924,22 +4927,22 @@ export const deserializeAws_restJson1GetLayerVersionCommand = async (
     contents.Content = deserializeAws_restJson1LayerVersionContentOutput(data.Content, context);
   }
   if (data.CreatedDate !== undefined && data.CreatedDate !== null) {
-    contents.CreatedDate = data.CreatedDate;
+    contents.CreatedDate = __expectString(data.CreatedDate);
   }
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.LayerArn !== undefined && data.LayerArn !== null) {
-    contents.LayerArn = data.LayerArn;
+    contents.LayerArn = __expectString(data.LayerArn);
   }
   if (data.LayerVersionArn !== undefined && data.LayerVersionArn !== null) {
-    contents.LayerVersionArn = data.LayerVersionArn;
+    contents.LayerVersionArn = __expectString(data.LayerVersionArn);
   }
   if (data.LicenseInfo !== undefined && data.LicenseInfo !== null) {
-    contents.LicenseInfo = data.LicenseInfo;
+    contents.LicenseInfo = __expectString(data.LicenseInfo);
   }
   if (data.Version !== undefined && data.Version !== null) {
-    contents.Version = data.Version;
+    contents.Version = __expectNumber(data.Version);
   }
   return Promise.resolve(contents);
 };
@@ -5031,22 +5034,22 @@ export const deserializeAws_restJson1GetLayerVersionByArnCommand = async (
     contents.Content = deserializeAws_restJson1LayerVersionContentOutput(data.Content, context);
   }
   if (data.CreatedDate !== undefined && data.CreatedDate !== null) {
-    contents.CreatedDate = data.CreatedDate;
+    contents.CreatedDate = __expectString(data.CreatedDate);
   }
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.LayerArn !== undefined && data.LayerArn !== null) {
-    contents.LayerArn = data.LayerArn;
+    contents.LayerArn = __expectString(data.LayerArn);
   }
   if (data.LayerVersionArn !== undefined && data.LayerVersionArn !== null) {
-    contents.LayerVersionArn = data.LayerVersionArn;
+    contents.LayerVersionArn = __expectString(data.LayerVersionArn);
   }
   if (data.LicenseInfo !== undefined && data.LicenseInfo !== null) {
-    contents.LicenseInfo = data.LicenseInfo;
+    contents.LicenseInfo = __expectString(data.LicenseInfo);
   }
   if (data.Version !== undefined && data.Version !== null) {
-    contents.Version = data.Version;
+    contents.Version = __expectNumber(data.Version);
   }
   return Promise.resolve(contents);
 };
@@ -5126,10 +5129,10 @@ export const deserializeAws_restJson1GetLayerVersionPolicyCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Policy !== undefined && data.Policy !== null) {
-    contents.Policy = data.Policy;
+    contents.Policy = __expectString(data.Policy);
   }
   if (data.RevisionId !== undefined && data.RevisionId !== null) {
-    contents.RevisionId = data.RevisionId;
+    contents.RevisionId = __expectString(data.RevisionId);
   }
   return Promise.resolve(contents);
 };
@@ -5209,10 +5212,10 @@ export const deserializeAws_restJson1GetPolicyCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Policy !== undefined && data.Policy !== null) {
-    contents.Policy = data.Policy;
+    contents.Policy = __expectString(data.Policy);
   }
   if (data.RevisionId !== undefined && data.RevisionId !== null) {
-    contents.RevisionId = data.RevisionId;
+    contents.RevisionId = __expectString(data.RevisionId);
   }
   return Promise.resolve(contents);
 };
@@ -5299,28 +5302,28 @@ export const deserializeAws_restJson1GetProvisionedConcurrencyConfigCommand = as
     data.AllocatedProvisionedConcurrentExecutions !== undefined &&
     data.AllocatedProvisionedConcurrentExecutions !== null
   ) {
-    contents.AllocatedProvisionedConcurrentExecutions = data.AllocatedProvisionedConcurrentExecutions;
+    contents.AllocatedProvisionedConcurrentExecutions = __expectNumber(data.AllocatedProvisionedConcurrentExecutions);
   }
   if (
     data.AvailableProvisionedConcurrentExecutions !== undefined &&
     data.AvailableProvisionedConcurrentExecutions !== null
   ) {
-    contents.AvailableProvisionedConcurrentExecutions = data.AvailableProvisionedConcurrentExecutions;
+    contents.AvailableProvisionedConcurrentExecutions = __expectNumber(data.AvailableProvisionedConcurrentExecutions);
   }
   if (data.LastModified !== undefined && data.LastModified !== null) {
-    contents.LastModified = data.LastModified;
+    contents.LastModified = __expectString(data.LastModified);
   }
   if (
     data.RequestedProvisionedConcurrentExecutions !== undefined &&
     data.RequestedProvisionedConcurrentExecutions !== null
   ) {
-    contents.RequestedProvisionedConcurrentExecutions = data.RequestedProvisionedConcurrentExecutions;
+    contents.RequestedProvisionedConcurrentExecutions = __expectNumber(data.RequestedProvisionedConcurrentExecutions);
   }
   if (data.Status !== undefined && data.Status !== null) {
-    contents.Status = data.Status;
+    contents.Status = __expectString(data.Status);
   }
   if (data.StatusReason !== undefined && data.StatusReason !== null) {
-    contents.StatusReason = data.StatusReason;
+    contents.StatusReason = __expectString(data.StatusReason);
   }
   return Promise.resolve(contents);
 };
@@ -5767,7 +5770,7 @@ export const deserializeAws_restJson1ListAliasesCommand = async (
     contents.Aliases = deserializeAws_restJson1AliasList(data.Aliases, context);
   }
   if (data.NextMarker !== undefined && data.NextMarker !== null) {
-    contents.NextMarker = data.NextMarker;
+    contents.NextMarker = __expectString(data.NextMarker);
   }
   return Promise.resolve(contents);
 };
@@ -5850,7 +5853,7 @@ export const deserializeAws_restJson1ListCodeSigningConfigsCommand = async (
     contents.CodeSigningConfigs = deserializeAws_restJson1CodeSigningConfigList(data.CodeSigningConfigs, context);
   }
   if (data.NextMarker !== undefined && data.NextMarker !== null) {
-    contents.NextMarker = data.NextMarker;
+    contents.NextMarker = __expectString(data.NextMarker);
   }
   return Promise.resolve(contents);
 };
@@ -5917,7 +5920,7 @@ export const deserializeAws_restJson1ListEventSourceMappingsCommand = async (
     contents.EventSourceMappings = deserializeAws_restJson1EventSourceMappingsList(data.EventSourceMappings, context);
   }
   if (data.NextMarker !== undefined && data.NextMarker !== null) {
-    contents.NextMarker = data.NextMarker;
+    contents.NextMarker = __expectString(data.NextMarker);
   }
   return Promise.resolve(contents);
 };
@@ -6003,7 +6006,7 @@ export const deserializeAws_restJson1ListFunctionEventInvokeConfigsCommand = asy
     );
   }
   if (data.NextMarker !== undefined && data.NextMarker !== null) {
-    contents.NextMarker = data.NextMarker;
+    contents.NextMarker = __expectString(data.NextMarker);
   }
   return Promise.resolve(contents);
 };
@@ -6086,7 +6089,7 @@ export const deserializeAws_restJson1ListFunctionsCommand = async (
     contents.Functions = deserializeAws_restJson1FunctionList(data.Functions, context);
   }
   if (data.NextMarker !== undefined && data.NextMarker !== null) {
-    contents.NextMarker = data.NextMarker;
+    contents.NextMarker = __expectString(data.NextMarker);
   }
   return Promise.resolve(contents);
 };
@@ -6161,7 +6164,7 @@ export const deserializeAws_restJson1ListFunctionsByCodeSigningConfigCommand = a
     contents.FunctionArns = deserializeAws_restJson1FunctionArnList(data.FunctionArns, context);
   }
   if (data.NextMarker !== undefined && data.NextMarker !== null) {
-    contents.NextMarker = data.NextMarker;
+    contents.NextMarker = __expectString(data.NextMarker);
   }
   return Promise.resolve(contents);
 };
@@ -6236,7 +6239,7 @@ export const deserializeAws_restJson1ListLayersCommand = async (
     contents.Layers = deserializeAws_restJson1LayersList(data.Layers, context);
   }
   if (data.NextMarker !== undefined && data.NextMarker !== null) {
-    contents.NextMarker = data.NextMarker;
+    contents.NextMarker = __expectString(data.NextMarker);
   }
   return Promise.resolve(contents);
 };
@@ -6311,7 +6314,7 @@ export const deserializeAws_restJson1ListLayerVersionsCommand = async (
     contents.LayerVersions = deserializeAws_restJson1LayerVersionsList(data.LayerVersions, context);
   }
   if (data.NextMarker !== undefined && data.NextMarker !== null) {
-    contents.NextMarker = data.NextMarker;
+    contents.NextMarker = __expectString(data.NextMarker);
   }
   return Promise.resolve(contents);
 };
@@ -6391,7 +6394,7 @@ export const deserializeAws_restJson1ListProvisionedConcurrencyConfigsCommand = 
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextMarker !== undefined && data.NextMarker !== null) {
-    contents.NextMarker = data.NextMarker;
+    contents.NextMarker = __expectString(data.NextMarker);
   }
   if (data.ProvisionedConcurrencyConfigs !== undefined && data.ProvisionedConcurrencyConfigs !== null) {
     contents.ProvisionedConcurrencyConfigs = deserializeAws_restJson1ProvisionedConcurrencyConfigList(
@@ -6556,7 +6559,7 @@ export const deserializeAws_restJson1ListVersionsByFunctionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextMarker !== undefined && data.NextMarker !== null) {
-    contents.NextMarker = data.NextMarker;
+    contents.NextMarker = __expectString(data.NextMarker);
   }
   if (data.Versions !== undefined && data.Versions !== null) {
     contents.Versions = deserializeAws_restJson1FunctionList(data.Versions, context);
@@ -6651,22 +6654,22 @@ export const deserializeAws_restJson1PublishLayerVersionCommand = async (
     contents.Content = deserializeAws_restJson1LayerVersionContentOutput(data.Content, context);
   }
   if (data.CreatedDate !== undefined && data.CreatedDate !== null) {
-    contents.CreatedDate = data.CreatedDate;
+    contents.CreatedDate = __expectString(data.CreatedDate);
   }
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.LayerArn !== undefined && data.LayerArn !== null) {
-    contents.LayerArn = data.LayerArn;
+    contents.LayerArn = __expectString(data.LayerArn);
   }
   if (data.LayerVersionArn !== undefined && data.LayerVersionArn !== null) {
-    contents.LayerVersionArn = data.LayerVersionArn;
+    contents.LayerVersionArn = __expectString(data.LayerVersionArn);
   }
   if (data.LicenseInfo !== undefined && data.LicenseInfo !== null) {
-    contents.LicenseInfo = data.LicenseInfo;
+    contents.LicenseInfo = __expectString(data.LicenseInfo);
   }
   if (data.Version !== undefined && data.Version !== null) {
-    contents.Version = data.Version;
+    contents.Version = __expectNumber(data.Version);
   }
   return Promise.resolve(contents);
 };
@@ -6783,16 +6786,16 @@ export const deserializeAws_restJson1PublishVersionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.CodeSha256 !== undefined && data.CodeSha256 !== null) {
-    contents.CodeSha256 = data.CodeSha256;
+    contents.CodeSha256 = __expectString(data.CodeSha256);
   }
   if (data.CodeSize !== undefined && data.CodeSize !== null) {
-    contents.CodeSize = data.CodeSize;
+    contents.CodeSize = __expectNumber(data.CodeSize);
   }
   if (data.DeadLetterConfig !== undefined && data.DeadLetterConfig !== null) {
     contents.DeadLetterConfig = deserializeAws_restJson1DeadLetterConfig(data.DeadLetterConfig, context);
   }
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.Environment !== undefined && data.Environment !== null) {
     contents.Environment = deserializeAws_restJson1EnvironmentResponse(data.Environment, context);
@@ -6801,76 +6804,76 @@ export const deserializeAws_restJson1PublishVersionCommand = async (
     contents.FileSystemConfigs = deserializeAws_restJson1FileSystemConfigList(data.FileSystemConfigs, context);
   }
   if (data.FunctionArn !== undefined && data.FunctionArn !== null) {
-    contents.FunctionArn = data.FunctionArn;
+    contents.FunctionArn = __expectString(data.FunctionArn);
   }
   if (data.FunctionName !== undefined && data.FunctionName !== null) {
-    contents.FunctionName = data.FunctionName;
+    contents.FunctionName = __expectString(data.FunctionName);
   }
   if (data.Handler !== undefined && data.Handler !== null) {
-    contents.Handler = data.Handler;
+    contents.Handler = __expectString(data.Handler);
   }
   if (data.ImageConfigResponse !== undefined && data.ImageConfigResponse !== null) {
     contents.ImageConfigResponse = deserializeAws_restJson1ImageConfigResponse(data.ImageConfigResponse, context);
   }
   if (data.KMSKeyArn !== undefined && data.KMSKeyArn !== null) {
-    contents.KMSKeyArn = data.KMSKeyArn;
+    contents.KMSKeyArn = __expectString(data.KMSKeyArn);
   }
   if (data.LastModified !== undefined && data.LastModified !== null) {
-    contents.LastModified = data.LastModified;
+    contents.LastModified = __expectString(data.LastModified);
   }
   if (data.LastUpdateStatus !== undefined && data.LastUpdateStatus !== null) {
-    contents.LastUpdateStatus = data.LastUpdateStatus;
+    contents.LastUpdateStatus = __expectString(data.LastUpdateStatus);
   }
   if (data.LastUpdateStatusReason !== undefined && data.LastUpdateStatusReason !== null) {
-    contents.LastUpdateStatusReason = data.LastUpdateStatusReason;
+    contents.LastUpdateStatusReason = __expectString(data.LastUpdateStatusReason);
   }
   if (data.LastUpdateStatusReasonCode !== undefined && data.LastUpdateStatusReasonCode !== null) {
-    contents.LastUpdateStatusReasonCode = data.LastUpdateStatusReasonCode;
+    contents.LastUpdateStatusReasonCode = __expectString(data.LastUpdateStatusReasonCode);
   }
   if (data.Layers !== undefined && data.Layers !== null) {
     contents.Layers = deserializeAws_restJson1LayersReferenceList(data.Layers, context);
   }
   if (data.MasterArn !== undefined && data.MasterArn !== null) {
-    contents.MasterArn = data.MasterArn;
+    contents.MasterArn = __expectString(data.MasterArn);
   }
   if (data.MemorySize !== undefined && data.MemorySize !== null) {
-    contents.MemorySize = data.MemorySize;
+    contents.MemorySize = __expectNumber(data.MemorySize);
   }
   if (data.PackageType !== undefined && data.PackageType !== null) {
-    contents.PackageType = data.PackageType;
+    contents.PackageType = __expectString(data.PackageType);
   }
   if (data.RevisionId !== undefined && data.RevisionId !== null) {
-    contents.RevisionId = data.RevisionId;
+    contents.RevisionId = __expectString(data.RevisionId);
   }
   if (data.Role !== undefined && data.Role !== null) {
-    contents.Role = data.Role;
+    contents.Role = __expectString(data.Role);
   }
   if (data.Runtime !== undefined && data.Runtime !== null) {
-    contents.Runtime = data.Runtime;
+    contents.Runtime = __expectString(data.Runtime);
   }
   if (data.SigningJobArn !== undefined && data.SigningJobArn !== null) {
-    contents.SigningJobArn = data.SigningJobArn;
+    contents.SigningJobArn = __expectString(data.SigningJobArn);
   }
   if (data.SigningProfileVersionArn !== undefined && data.SigningProfileVersionArn !== null) {
-    contents.SigningProfileVersionArn = data.SigningProfileVersionArn;
+    contents.SigningProfileVersionArn = __expectString(data.SigningProfileVersionArn);
   }
   if (data.State !== undefined && data.State !== null) {
-    contents.State = data.State;
+    contents.State = __expectString(data.State);
   }
   if (data.StateReason !== undefined && data.StateReason !== null) {
-    contents.StateReason = data.StateReason;
+    contents.StateReason = __expectString(data.StateReason);
   }
   if (data.StateReasonCode !== undefined && data.StateReasonCode !== null) {
-    contents.StateReasonCode = data.StateReasonCode;
+    contents.StateReasonCode = __expectString(data.StateReasonCode);
   }
   if (data.Timeout !== undefined && data.Timeout !== null) {
-    contents.Timeout = data.Timeout;
+    contents.Timeout = __expectNumber(data.Timeout);
   }
   if (data.TracingConfig !== undefined && data.TracingConfig !== null) {
     contents.TracingConfig = deserializeAws_restJson1TracingConfigResponse(data.TracingConfig, context);
   }
   if (data.Version !== undefined && data.Version !== null) {
-    contents.Version = data.Version;
+    contents.Version = __expectString(data.Version);
   }
   if (data.VpcConfig !== undefined && data.VpcConfig !== null) {
     contents.VpcConfig = deserializeAws_restJson1VpcConfigResponse(data.VpcConfig, context);
@@ -6977,10 +6980,10 @@ export const deserializeAws_restJson1PutFunctionCodeSigningConfigCommand = async
   };
   const data: any = await parseBody(output.body, context);
   if (data.CodeSigningConfigArn !== undefined && data.CodeSigningConfigArn !== null) {
-    contents.CodeSigningConfigArn = data.CodeSigningConfigArn;
+    contents.CodeSigningConfigArn = __expectString(data.CodeSigningConfigArn);
   }
   if (data.FunctionName !== undefined && data.FunctionName !== null) {
-    contents.FunctionName = data.FunctionName;
+    contents.FunctionName = __expectString(data.FunctionName);
   }
   return Promise.resolve(contents);
 };
@@ -7075,7 +7078,7 @@ export const deserializeAws_restJson1PutFunctionConcurrencyCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ReservedConcurrentExecutions !== undefined && data.ReservedConcurrentExecutions !== null) {
-    contents.ReservedConcurrentExecutions = data.ReservedConcurrentExecutions;
+    contents.ReservedConcurrentExecutions = __expectNumber(data.ReservedConcurrentExecutions);
   }
   return Promise.resolve(contents);
 };
@@ -7169,16 +7172,16 @@ export const deserializeAws_restJson1PutFunctionEventInvokeConfigCommand = async
     contents.DestinationConfig = deserializeAws_restJson1DestinationConfig(data.DestinationConfig, context);
   }
   if (data.FunctionArn !== undefined && data.FunctionArn !== null) {
-    contents.FunctionArn = data.FunctionArn;
+    contents.FunctionArn = __expectString(data.FunctionArn);
   }
   if (data.LastModified !== undefined && data.LastModified !== null) {
     contents.LastModified = new Date(Math.round(data.LastModified * 1000));
   }
   if (data.MaximumEventAgeInSeconds !== undefined && data.MaximumEventAgeInSeconds !== null) {
-    contents.MaximumEventAgeInSeconds = data.MaximumEventAgeInSeconds;
+    contents.MaximumEventAgeInSeconds = __expectNumber(data.MaximumEventAgeInSeconds);
   }
   if (data.MaximumRetryAttempts !== undefined && data.MaximumRetryAttempts !== null) {
-    contents.MaximumRetryAttempts = data.MaximumRetryAttempts;
+    contents.MaximumRetryAttempts = __expectNumber(data.MaximumRetryAttempts);
   }
   return Promise.resolve(contents);
 };
@@ -7265,28 +7268,28 @@ export const deserializeAws_restJson1PutProvisionedConcurrencyConfigCommand = as
     data.AllocatedProvisionedConcurrentExecutions !== undefined &&
     data.AllocatedProvisionedConcurrentExecutions !== null
   ) {
-    contents.AllocatedProvisionedConcurrentExecutions = data.AllocatedProvisionedConcurrentExecutions;
+    contents.AllocatedProvisionedConcurrentExecutions = __expectNumber(data.AllocatedProvisionedConcurrentExecutions);
   }
   if (
     data.AvailableProvisionedConcurrentExecutions !== undefined &&
     data.AvailableProvisionedConcurrentExecutions !== null
   ) {
-    contents.AvailableProvisionedConcurrentExecutions = data.AvailableProvisionedConcurrentExecutions;
+    contents.AvailableProvisionedConcurrentExecutions = __expectNumber(data.AvailableProvisionedConcurrentExecutions);
   }
   if (data.LastModified !== undefined && data.LastModified !== null) {
-    contents.LastModified = data.LastModified;
+    contents.LastModified = __expectString(data.LastModified);
   }
   if (
     data.RequestedProvisionedConcurrentExecutions !== undefined &&
     data.RequestedProvisionedConcurrentExecutions !== null
   ) {
-    contents.RequestedProvisionedConcurrentExecutions = data.RequestedProvisionedConcurrentExecutions;
+    contents.RequestedProvisionedConcurrentExecutions = __expectNumber(data.RequestedProvisionedConcurrentExecutions);
   }
   if (data.Status !== undefined && data.Status !== null) {
-    contents.Status = data.Status;
+    contents.Status = __expectString(data.Status);
   }
   if (data.StatusReason !== undefined && data.StatusReason !== null) {
-    contents.StatusReason = data.StatusReason;
+    contents.StatusReason = __expectString(data.StatusReason);
   }
   return Promise.resolve(contents);
 };
@@ -7710,19 +7713,19 @@ export const deserializeAws_restJson1UpdateAliasCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AliasArn !== undefined && data.AliasArn !== null) {
-    contents.AliasArn = data.AliasArn;
+    contents.AliasArn = __expectString(data.AliasArn);
   }
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.FunctionVersion !== undefined && data.FunctionVersion !== null) {
-    contents.FunctionVersion = data.FunctionVersion;
+    contents.FunctionVersion = __expectString(data.FunctionVersion);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.RevisionId !== undefined && data.RevisionId !== null) {
-    contents.RevisionId = data.RevisionId;
+    contents.RevisionId = __expectString(data.RevisionId);
   }
   if (data.RoutingConfig !== undefined && data.RoutingConfig !== null) {
     contents.RoutingConfig = deserializeAws_restJson1AliasRoutingConfiguration(data.RoutingConfig, context);
@@ -7912,19 +7915,19 @@ export const deserializeAws_restJson1UpdateEventSourceMappingCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.BatchSize !== undefined && data.BatchSize !== null) {
-    contents.BatchSize = data.BatchSize;
+    contents.BatchSize = __expectNumber(data.BatchSize);
   }
   if (data.BisectBatchOnFunctionError !== undefined && data.BisectBatchOnFunctionError !== null) {
-    contents.BisectBatchOnFunctionError = data.BisectBatchOnFunctionError;
+    contents.BisectBatchOnFunctionError = __expectBoolean(data.BisectBatchOnFunctionError);
   }
   if (data.DestinationConfig !== undefined && data.DestinationConfig !== null) {
     contents.DestinationConfig = deserializeAws_restJson1DestinationConfig(data.DestinationConfig, context);
   }
   if (data.EventSourceArn !== undefined && data.EventSourceArn !== null) {
-    contents.EventSourceArn = data.EventSourceArn;
+    contents.EventSourceArn = __expectString(data.EventSourceArn);
   }
   if (data.FunctionArn !== undefined && data.FunctionArn !== null) {
-    contents.FunctionArn = data.FunctionArn;
+    contents.FunctionArn = __expectString(data.FunctionArn);
   }
   if (data.FunctionResponseTypes !== undefined && data.FunctionResponseTypes !== null) {
     contents.FunctionResponseTypes = deserializeAws_restJson1FunctionResponseTypeList(
@@ -7936,19 +7939,19 @@ export const deserializeAws_restJson1UpdateEventSourceMappingCommand = async (
     contents.LastModified = new Date(Math.round(data.LastModified * 1000));
   }
   if (data.LastProcessingResult !== undefined && data.LastProcessingResult !== null) {
-    contents.LastProcessingResult = data.LastProcessingResult;
+    contents.LastProcessingResult = __expectString(data.LastProcessingResult);
   }
   if (data.MaximumBatchingWindowInSeconds !== undefined && data.MaximumBatchingWindowInSeconds !== null) {
-    contents.MaximumBatchingWindowInSeconds = data.MaximumBatchingWindowInSeconds;
+    contents.MaximumBatchingWindowInSeconds = __expectNumber(data.MaximumBatchingWindowInSeconds);
   }
   if (data.MaximumRecordAgeInSeconds !== undefined && data.MaximumRecordAgeInSeconds !== null) {
-    contents.MaximumRecordAgeInSeconds = data.MaximumRecordAgeInSeconds;
+    contents.MaximumRecordAgeInSeconds = __expectNumber(data.MaximumRecordAgeInSeconds);
   }
   if (data.MaximumRetryAttempts !== undefined && data.MaximumRetryAttempts !== null) {
-    contents.MaximumRetryAttempts = data.MaximumRetryAttempts;
+    contents.MaximumRetryAttempts = __expectNumber(data.MaximumRetryAttempts);
   }
   if (data.ParallelizationFactor !== undefined && data.ParallelizationFactor !== null) {
-    contents.ParallelizationFactor = data.ParallelizationFactor;
+    contents.ParallelizationFactor = __expectNumber(data.ParallelizationFactor);
   }
   if (data.Queues !== undefined && data.Queues !== null) {
     contents.Queues = deserializeAws_restJson1Queues(data.Queues, context);
@@ -7966,25 +7969,25 @@ export const deserializeAws_restJson1UpdateEventSourceMappingCommand = async (
     );
   }
   if (data.StartingPosition !== undefined && data.StartingPosition !== null) {
-    contents.StartingPosition = data.StartingPosition;
+    contents.StartingPosition = __expectString(data.StartingPosition);
   }
   if (data.StartingPositionTimestamp !== undefined && data.StartingPositionTimestamp !== null) {
     contents.StartingPositionTimestamp = new Date(Math.round(data.StartingPositionTimestamp * 1000));
   }
   if (data.State !== undefined && data.State !== null) {
-    contents.State = data.State;
+    contents.State = __expectString(data.State);
   }
   if (data.StateTransitionReason !== undefined && data.StateTransitionReason !== null) {
-    contents.StateTransitionReason = data.StateTransitionReason;
+    contents.StateTransitionReason = __expectString(data.StateTransitionReason);
   }
   if (data.Topics !== undefined && data.Topics !== null) {
     contents.Topics = deserializeAws_restJson1Topics(data.Topics, context);
   }
   if (data.TumblingWindowInSeconds !== undefined && data.TumblingWindowInSeconds !== null) {
-    contents.TumblingWindowInSeconds = data.TumblingWindowInSeconds;
+    contents.TumblingWindowInSeconds = __expectNumber(data.TumblingWindowInSeconds);
   }
   if (data.UUID !== undefined && data.UUID !== null) {
-    contents.UUID = data.UUID;
+    contents.UUID = __expectString(data.UUID);
   }
   return Promise.resolve(contents);
 };
@@ -8109,16 +8112,16 @@ export const deserializeAws_restJson1UpdateFunctionCodeCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.CodeSha256 !== undefined && data.CodeSha256 !== null) {
-    contents.CodeSha256 = data.CodeSha256;
+    contents.CodeSha256 = __expectString(data.CodeSha256);
   }
   if (data.CodeSize !== undefined && data.CodeSize !== null) {
-    contents.CodeSize = data.CodeSize;
+    contents.CodeSize = __expectNumber(data.CodeSize);
   }
   if (data.DeadLetterConfig !== undefined && data.DeadLetterConfig !== null) {
     contents.DeadLetterConfig = deserializeAws_restJson1DeadLetterConfig(data.DeadLetterConfig, context);
   }
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.Environment !== undefined && data.Environment !== null) {
     contents.Environment = deserializeAws_restJson1EnvironmentResponse(data.Environment, context);
@@ -8127,76 +8130,76 @@ export const deserializeAws_restJson1UpdateFunctionCodeCommand = async (
     contents.FileSystemConfigs = deserializeAws_restJson1FileSystemConfigList(data.FileSystemConfigs, context);
   }
   if (data.FunctionArn !== undefined && data.FunctionArn !== null) {
-    contents.FunctionArn = data.FunctionArn;
+    contents.FunctionArn = __expectString(data.FunctionArn);
   }
   if (data.FunctionName !== undefined && data.FunctionName !== null) {
-    contents.FunctionName = data.FunctionName;
+    contents.FunctionName = __expectString(data.FunctionName);
   }
   if (data.Handler !== undefined && data.Handler !== null) {
-    contents.Handler = data.Handler;
+    contents.Handler = __expectString(data.Handler);
   }
   if (data.ImageConfigResponse !== undefined && data.ImageConfigResponse !== null) {
     contents.ImageConfigResponse = deserializeAws_restJson1ImageConfigResponse(data.ImageConfigResponse, context);
   }
   if (data.KMSKeyArn !== undefined && data.KMSKeyArn !== null) {
-    contents.KMSKeyArn = data.KMSKeyArn;
+    contents.KMSKeyArn = __expectString(data.KMSKeyArn);
   }
   if (data.LastModified !== undefined && data.LastModified !== null) {
-    contents.LastModified = data.LastModified;
+    contents.LastModified = __expectString(data.LastModified);
   }
   if (data.LastUpdateStatus !== undefined && data.LastUpdateStatus !== null) {
-    contents.LastUpdateStatus = data.LastUpdateStatus;
+    contents.LastUpdateStatus = __expectString(data.LastUpdateStatus);
   }
   if (data.LastUpdateStatusReason !== undefined && data.LastUpdateStatusReason !== null) {
-    contents.LastUpdateStatusReason = data.LastUpdateStatusReason;
+    contents.LastUpdateStatusReason = __expectString(data.LastUpdateStatusReason);
   }
   if (data.LastUpdateStatusReasonCode !== undefined && data.LastUpdateStatusReasonCode !== null) {
-    contents.LastUpdateStatusReasonCode = data.LastUpdateStatusReasonCode;
+    contents.LastUpdateStatusReasonCode = __expectString(data.LastUpdateStatusReasonCode);
   }
   if (data.Layers !== undefined && data.Layers !== null) {
     contents.Layers = deserializeAws_restJson1LayersReferenceList(data.Layers, context);
   }
   if (data.MasterArn !== undefined && data.MasterArn !== null) {
-    contents.MasterArn = data.MasterArn;
+    contents.MasterArn = __expectString(data.MasterArn);
   }
   if (data.MemorySize !== undefined && data.MemorySize !== null) {
-    contents.MemorySize = data.MemorySize;
+    contents.MemorySize = __expectNumber(data.MemorySize);
   }
   if (data.PackageType !== undefined && data.PackageType !== null) {
-    contents.PackageType = data.PackageType;
+    contents.PackageType = __expectString(data.PackageType);
   }
   if (data.RevisionId !== undefined && data.RevisionId !== null) {
-    contents.RevisionId = data.RevisionId;
+    contents.RevisionId = __expectString(data.RevisionId);
   }
   if (data.Role !== undefined && data.Role !== null) {
-    contents.Role = data.Role;
+    contents.Role = __expectString(data.Role);
   }
   if (data.Runtime !== undefined && data.Runtime !== null) {
-    contents.Runtime = data.Runtime;
+    contents.Runtime = __expectString(data.Runtime);
   }
   if (data.SigningJobArn !== undefined && data.SigningJobArn !== null) {
-    contents.SigningJobArn = data.SigningJobArn;
+    contents.SigningJobArn = __expectString(data.SigningJobArn);
   }
   if (data.SigningProfileVersionArn !== undefined && data.SigningProfileVersionArn !== null) {
-    contents.SigningProfileVersionArn = data.SigningProfileVersionArn;
+    contents.SigningProfileVersionArn = __expectString(data.SigningProfileVersionArn);
   }
   if (data.State !== undefined && data.State !== null) {
-    contents.State = data.State;
+    contents.State = __expectString(data.State);
   }
   if (data.StateReason !== undefined && data.StateReason !== null) {
-    contents.StateReason = data.StateReason;
+    contents.StateReason = __expectString(data.StateReason);
   }
   if (data.StateReasonCode !== undefined && data.StateReasonCode !== null) {
-    contents.StateReasonCode = data.StateReasonCode;
+    contents.StateReasonCode = __expectString(data.StateReasonCode);
   }
   if (data.Timeout !== undefined && data.Timeout !== null) {
-    contents.Timeout = data.Timeout;
+    contents.Timeout = __expectNumber(data.Timeout);
   }
   if (data.TracingConfig !== undefined && data.TracingConfig !== null) {
     contents.TracingConfig = deserializeAws_restJson1TracingConfigResponse(data.TracingConfig, context);
   }
   if (data.Version !== undefined && data.Version !== null) {
-    contents.Version = data.Version;
+    contents.Version = __expectString(data.Version);
   }
   if (data.VpcConfig !== undefined && data.VpcConfig !== null) {
     contents.VpcConfig = deserializeAws_restJson1VpcConfigResponse(data.VpcConfig, context);
@@ -8356,16 +8359,16 @@ export const deserializeAws_restJson1UpdateFunctionConfigurationCommand = async 
   };
   const data: any = await parseBody(output.body, context);
   if (data.CodeSha256 !== undefined && data.CodeSha256 !== null) {
-    contents.CodeSha256 = data.CodeSha256;
+    contents.CodeSha256 = __expectString(data.CodeSha256);
   }
   if (data.CodeSize !== undefined && data.CodeSize !== null) {
-    contents.CodeSize = data.CodeSize;
+    contents.CodeSize = __expectNumber(data.CodeSize);
   }
   if (data.DeadLetterConfig !== undefined && data.DeadLetterConfig !== null) {
     contents.DeadLetterConfig = deserializeAws_restJson1DeadLetterConfig(data.DeadLetterConfig, context);
   }
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.Environment !== undefined && data.Environment !== null) {
     contents.Environment = deserializeAws_restJson1EnvironmentResponse(data.Environment, context);
@@ -8374,76 +8377,76 @@ export const deserializeAws_restJson1UpdateFunctionConfigurationCommand = async 
     contents.FileSystemConfigs = deserializeAws_restJson1FileSystemConfigList(data.FileSystemConfigs, context);
   }
   if (data.FunctionArn !== undefined && data.FunctionArn !== null) {
-    contents.FunctionArn = data.FunctionArn;
+    contents.FunctionArn = __expectString(data.FunctionArn);
   }
   if (data.FunctionName !== undefined && data.FunctionName !== null) {
-    contents.FunctionName = data.FunctionName;
+    contents.FunctionName = __expectString(data.FunctionName);
   }
   if (data.Handler !== undefined && data.Handler !== null) {
-    contents.Handler = data.Handler;
+    contents.Handler = __expectString(data.Handler);
   }
   if (data.ImageConfigResponse !== undefined && data.ImageConfigResponse !== null) {
     contents.ImageConfigResponse = deserializeAws_restJson1ImageConfigResponse(data.ImageConfigResponse, context);
   }
   if (data.KMSKeyArn !== undefined && data.KMSKeyArn !== null) {
-    contents.KMSKeyArn = data.KMSKeyArn;
+    contents.KMSKeyArn = __expectString(data.KMSKeyArn);
   }
   if (data.LastModified !== undefined && data.LastModified !== null) {
-    contents.LastModified = data.LastModified;
+    contents.LastModified = __expectString(data.LastModified);
   }
   if (data.LastUpdateStatus !== undefined && data.LastUpdateStatus !== null) {
-    contents.LastUpdateStatus = data.LastUpdateStatus;
+    contents.LastUpdateStatus = __expectString(data.LastUpdateStatus);
   }
   if (data.LastUpdateStatusReason !== undefined && data.LastUpdateStatusReason !== null) {
-    contents.LastUpdateStatusReason = data.LastUpdateStatusReason;
+    contents.LastUpdateStatusReason = __expectString(data.LastUpdateStatusReason);
   }
   if (data.LastUpdateStatusReasonCode !== undefined && data.LastUpdateStatusReasonCode !== null) {
-    contents.LastUpdateStatusReasonCode = data.LastUpdateStatusReasonCode;
+    contents.LastUpdateStatusReasonCode = __expectString(data.LastUpdateStatusReasonCode);
   }
   if (data.Layers !== undefined && data.Layers !== null) {
     contents.Layers = deserializeAws_restJson1LayersReferenceList(data.Layers, context);
   }
   if (data.MasterArn !== undefined && data.MasterArn !== null) {
-    contents.MasterArn = data.MasterArn;
+    contents.MasterArn = __expectString(data.MasterArn);
   }
   if (data.MemorySize !== undefined && data.MemorySize !== null) {
-    contents.MemorySize = data.MemorySize;
+    contents.MemorySize = __expectNumber(data.MemorySize);
   }
   if (data.PackageType !== undefined && data.PackageType !== null) {
-    contents.PackageType = data.PackageType;
+    contents.PackageType = __expectString(data.PackageType);
   }
   if (data.RevisionId !== undefined && data.RevisionId !== null) {
-    contents.RevisionId = data.RevisionId;
+    contents.RevisionId = __expectString(data.RevisionId);
   }
   if (data.Role !== undefined && data.Role !== null) {
-    contents.Role = data.Role;
+    contents.Role = __expectString(data.Role);
   }
   if (data.Runtime !== undefined && data.Runtime !== null) {
-    contents.Runtime = data.Runtime;
+    contents.Runtime = __expectString(data.Runtime);
   }
   if (data.SigningJobArn !== undefined && data.SigningJobArn !== null) {
-    contents.SigningJobArn = data.SigningJobArn;
+    contents.SigningJobArn = __expectString(data.SigningJobArn);
   }
   if (data.SigningProfileVersionArn !== undefined && data.SigningProfileVersionArn !== null) {
-    contents.SigningProfileVersionArn = data.SigningProfileVersionArn;
+    contents.SigningProfileVersionArn = __expectString(data.SigningProfileVersionArn);
   }
   if (data.State !== undefined && data.State !== null) {
-    contents.State = data.State;
+    contents.State = __expectString(data.State);
   }
   if (data.StateReason !== undefined && data.StateReason !== null) {
-    contents.StateReason = data.StateReason;
+    contents.StateReason = __expectString(data.StateReason);
   }
   if (data.StateReasonCode !== undefined && data.StateReasonCode !== null) {
-    contents.StateReasonCode = data.StateReasonCode;
+    contents.StateReasonCode = __expectString(data.StateReasonCode);
   }
   if (data.Timeout !== undefined && data.Timeout !== null) {
-    contents.Timeout = data.Timeout;
+    contents.Timeout = __expectNumber(data.Timeout);
   }
   if (data.TracingConfig !== undefined && data.TracingConfig !== null) {
     contents.TracingConfig = deserializeAws_restJson1TracingConfigResponse(data.TracingConfig, context);
   }
   if (data.Version !== undefined && data.Version !== null) {
-    contents.Version = data.Version;
+    contents.Version = __expectString(data.Version);
   }
   if (data.VpcConfig !== undefined && data.VpcConfig !== null) {
     contents.VpcConfig = deserializeAws_restJson1VpcConfigResponse(data.VpcConfig, context);
@@ -8572,16 +8575,16 @@ export const deserializeAws_restJson1UpdateFunctionEventInvokeConfigCommand = as
     contents.DestinationConfig = deserializeAws_restJson1DestinationConfig(data.DestinationConfig, context);
   }
   if (data.FunctionArn !== undefined && data.FunctionArn !== null) {
-    contents.FunctionArn = data.FunctionArn;
+    contents.FunctionArn = __expectString(data.FunctionArn);
   }
   if (data.LastModified !== undefined && data.LastModified !== null) {
     contents.LastModified = new Date(Math.round(data.LastModified * 1000));
   }
   if (data.MaximumEventAgeInSeconds !== undefined && data.MaximumEventAgeInSeconds !== null) {
-    contents.MaximumEventAgeInSeconds = data.MaximumEventAgeInSeconds;
+    contents.MaximumEventAgeInSeconds = __expectNumber(data.MaximumEventAgeInSeconds);
   }
   if (data.MaximumRetryAttempts !== undefined && data.MaximumRetryAttempts !== null) {
-    contents.MaximumRetryAttempts = data.MaximumRetryAttempts;
+    contents.MaximumRetryAttempts = __expectNumber(data.MaximumRetryAttempts);
   }
   return Promise.resolve(contents);
 };
@@ -8660,10 +8663,10 @@ const deserializeAws_restJson1CodeSigningConfigNotFoundExceptionResponse = async
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   return contents;
 };
@@ -8681,10 +8684,10 @@ const deserializeAws_restJson1CodeStorageExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -8702,10 +8705,10 @@ const deserializeAws_restJson1CodeVerificationFailedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   return contents;
 };
@@ -8723,10 +8726,10 @@ const deserializeAws_restJson1EC2AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   return contents;
 };
@@ -8744,10 +8747,10 @@ const deserializeAws_restJson1EC2ThrottledExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   return contents;
 };
@@ -8766,13 +8769,13 @@ const deserializeAws_restJson1EC2UnexpectedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.EC2ErrorCode !== undefined && data.EC2ErrorCode !== null) {
-    contents.EC2ErrorCode = data.EC2ErrorCode;
+    contents.EC2ErrorCode = __expectString(data.EC2ErrorCode);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   return contents;
 };
@@ -8790,10 +8793,10 @@ const deserializeAws_restJson1EFSIOExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   return contents;
 };
@@ -8811,10 +8814,10 @@ const deserializeAws_restJson1EFSMountConnectivityExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   return contents;
 };
@@ -8832,10 +8835,10 @@ const deserializeAws_restJson1EFSMountFailureExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   return contents;
 };
@@ -8853,10 +8856,10 @@ const deserializeAws_restJson1EFSMountTimeoutExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   return contents;
 };
@@ -8874,10 +8877,10 @@ const deserializeAws_restJson1ENILimitReachedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   return contents;
 };
@@ -8895,10 +8898,10 @@ const deserializeAws_restJson1InvalidCodeSignatureExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   return contents;
 };
@@ -8916,10 +8919,10 @@ const deserializeAws_restJson1InvalidParameterValueExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -8937,10 +8940,10 @@ const deserializeAws_restJson1InvalidRequestContentExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -8958,10 +8961,10 @@ const deserializeAws_restJson1InvalidRuntimeExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   return contents;
 };
@@ -8979,10 +8982,10 @@ const deserializeAws_restJson1InvalidSecurityGroupIDExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   return contents;
 };
@@ -9000,10 +9003,10 @@ const deserializeAws_restJson1InvalidSubnetIDExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   return contents;
 };
@@ -9021,10 +9024,10 @@ const deserializeAws_restJson1InvalidZipFileExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   return contents;
 };
@@ -9042,10 +9045,10 @@ const deserializeAws_restJson1KMSAccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   return contents;
 };
@@ -9063,10 +9066,10 @@ const deserializeAws_restJson1KMSDisabledExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   return contents;
 };
@@ -9084,10 +9087,10 @@ const deserializeAws_restJson1KMSInvalidStateExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   return contents;
 };
@@ -9105,10 +9108,10 @@ const deserializeAws_restJson1KMSNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   return contents;
 };
@@ -9126,10 +9129,10 @@ const deserializeAws_restJson1PolicyLengthExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -9147,10 +9150,10 @@ const deserializeAws_restJson1PreconditionFailedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -9168,10 +9171,10 @@ const deserializeAws_restJson1ProvisionedConcurrencyConfigNotFoundExceptionRespo
   };
   const data: any = parsedOutput.body;
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -9189,10 +9192,10 @@ const deserializeAws_restJson1RequestTooLargeExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -9210,10 +9213,10 @@ const deserializeAws_restJson1ResourceConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -9231,10 +9234,10 @@ const deserializeAws_restJson1ResourceInUseExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   return contents;
 };
@@ -9252,10 +9255,10 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   return contents;
 };
@@ -9273,10 +9276,10 @@ const deserializeAws_restJson1ResourceNotReadyExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -9294,10 +9297,10 @@ const deserializeAws_restJson1ServiceExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   return contents;
 };
@@ -9315,10 +9318,10 @@ const deserializeAws_restJson1SubnetIPAddressLimitReachedExceptionResponse = asy
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   return contents;
 };
@@ -9341,13 +9344,13 @@ const deserializeAws_restJson1TooManyRequestsExceptionResponse = async (
   }
   const data: any = parsedOutput.body;
   if (data.Reason !== undefined && data.Reason !== null) {
-    contents.Reason = data.Reason;
+    contents.Reason = __expectString(data.Reason);
   }
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -9365,10 +9368,10 @@ const deserializeAws_restJson1UnsupportedMediaTypeExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -9714,29 +9717,18 @@ const serializeAws_restJson1VpcConfig = (input: VpcConfig, context: __SerdeConte
 
 const deserializeAws_restJson1AccountLimit = (output: any, context: __SerdeContext): AccountLimit => {
   return {
-    CodeSizeUnzipped:
-      output.CodeSizeUnzipped !== undefined && output.CodeSizeUnzipped !== null ? output.CodeSizeUnzipped : undefined,
-    CodeSizeZipped:
-      output.CodeSizeZipped !== undefined && output.CodeSizeZipped !== null ? output.CodeSizeZipped : undefined,
-    ConcurrentExecutions:
-      output.ConcurrentExecutions !== undefined && output.ConcurrentExecutions !== null
-        ? output.ConcurrentExecutions
-        : undefined,
-    TotalCodeSize:
-      output.TotalCodeSize !== undefined && output.TotalCodeSize !== null ? output.TotalCodeSize : undefined,
-    UnreservedConcurrentExecutions:
-      output.UnreservedConcurrentExecutions !== undefined && output.UnreservedConcurrentExecutions !== null
-        ? output.UnreservedConcurrentExecutions
-        : undefined,
+    CodeSizeUnzipped: __expectNumber(output.CodeSizeUnzipped),
+    CodeSizeZipped: __expectNumber(output.CodeSizeZipped),
+    ConcurrentExecutions: __expectNumber(output.ConcurrentExecutions),
+    TotalCodeSize: __expectNumber(output.TotalCodeSize),
+    UnreservedConcurrentExecutions: __expectNumber(output.UnreservedConcurrentExecutions),
   } as any;
 };
 
 const deserializeAws_restJson1AccountUsage = (output: any, context: __SerdeContext): AccountUsage => {
   return {
-    FunctionCount:
-      output.FunctionCount !== undefined && output.FunctionCount !== null ? output.FunctionCount : undefined,
-    TotalCodeSize:
-      output.TotalCodeSize !== undefined && output.TotalCodeSize !== null ? output.TotalCodeSize : undefined,
+    FunctionCount: __expectNumber(output.FunctionCount),
+    TotalCodeSize: __expectNumber(output.TotalCodeSize),
   } as any;
 };
 
@@ -9750,19 +9742,18 @@ const deserializeAws_restJson1AdditionalVersionWeights = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectNumber(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1AliasConfiguration = (output: any, context: __SerdeContext): AliasConfiguration => {
   return {
-    AliasArn: output.AliasArn !== undefined && output.AliasArn !== null ? output.AliasArn : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    FunctionVersion:
-      output.FunctionVersion !== undefined && output.FunctionVersion !== null ? output.FunctionVersion : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    RevisionId: output.RevisionId !== undefined && output.RevisionId !== null ? output.RevisionId : undefined,
+    AliasArn: __expectString(output.AliasArn),
+    Description: __expectString(output.Description),
+    FunctionVersion: __expectString(output.FunctionVersion),
+    Name: __expectString(output.Name),
+    RevisionId: __expectString(output.RevisionId),
     RoutingConfig:
       output.RoutingConfig !== undefined && output.RoutingConfig !== null
         ? deserializeAws_restJson1AliasRoutingConfiguration(output.RoutingConfig, context)
@@ -9808,20 +9799,14 @@ const deserializeAws_restJson1CodeSigningConfig = (output: any, context: __Serde
       output.AllowedPublishers !== undefined && output.AllowedPublishers !== null
         ? deserializeAws_restJson1AllowedPublishers(output.AllowedPublishers, context)
         : undefined,
-    CodeSigningConfigArn:
-      output.CodeSigningConfigArn !== undefined && output.CodeSigningConfigArn !== null
-        ? output.CodeSigningConfigArn
-        : undefined,
-    CodeSigningConfigId:
-      output.CodeSigningConfigId !== undefined && output.CodeSigningConfigId !== null
-        ? output.CodeSigningConfigId
-        : undefined,
+    CodeSigningConfigArn: __expectString(output.CodeSigningConfigArn),
+    CodeSigningConfigId: __expectString(output.CodeSigningConfigId),
     CodeSigningPolicies:
       output.CodeSigningPolicies !== undefined && output.CodeSigningPolicies !== null
         ? deserializeAws_restJson1CodeSigningPolicies(output.CodeSigningPolicies, context)
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    LastModified: output.LastModified !== undefined && output.LastModified !== null ? output.LastModified : undefined,
+    Description: __expectString(output.Description),
+    LastModified: __expectString(output.LastModified),
   } as any;
 };
 
@@ -9838,10 +9823,7 @@ const deserializeAws_restJson1CodeSigningConfigList = (output: any, context: __S
 
 const deserializeAws_restJson1CodeSigningPolicies = (output: any, context: __SerdeContext): CodeSigningPolicies => {
   return {
-    UntrustedArtifactOnDeployment:
-      output.UntrustedArtifactOnDeployment !== undefined && output.UntrustedArtifactOnDeployment !== null
-        ? output.UntrustedArtifactOnDeployment
-        : undefined,
+    UntrustedArtifactOnDeployment: __expectString(output.UntrustedArtifactOnDeployment),
   } as any;
 };
 
@@ -9852,22 +9834,19 @@ const deserializeAws_restJson1CompatibleRuntimes = (output: any, context: __Serd
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1Concurrency = (output: any, context: __SerdeContext): Concurrency => {
   return {
-    ReservedConcurrentExecutions:
-      output.ReservedConcurrentExecutions !== undefined && output.ReservedConcurrentExecutions !== null
-        ? output.ReservedConcurrentExecutions
-        : undefined,
+    ReservedConcurrentExecutions: __expectNumber(output.ReservedConcurrentExecutions),
   } as any;
 };
 
 const deserializeAws_restJson1DeadLetterConfig = (output: any, context: __SerdeContext): DeadLetterConfig => {
   return {
-    TargetArn: output.TargetArn !== undefined && output.TargetArn !== null ? output.TargetArn : undefined,
+    TargetArn: __expectString(output.TargetArn),
   } as any;
 };
 
@@ -9891,7 +9870,7 @@ const deserializeAws_restJson1EndpointLists = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -9912,8 +9891,8 @@ const deserializeAws_restJson1Endpoints = (output: any, context: __SerdeContext)
 
 const deserializeAws_restJson1EnvironmentError = (output: any, context: __SerdeContext): EnvironmentError => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -9940,7 +9919,7 @@ const deserializeAws_restJson1EnvironmentVariables = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -9950,18 +9929,14 @@ const deserializeAws_restJson1EventSourceMappingConfiguration = (
   context: __SerdeContext
 ): EventSourceMappingConfiguration => {
   return {
-    BatchSize: output.BatchSize !== undefined && output.BatchSize !== null ? output.BatchSize : undefined,
-    BisectBatchOnFunctionError:
-      output.BisectBatchOnFunctionError !== undefined && output.BisectBatchOnFunctionError !== null
-        ? output.BisectBatchOnFunctionError
-        : undefined,
+    BatchSize: __expectNumber(output.BatchSize),
+    BisectBatchOnFunctionError: __expectBoolean(output.BisectBatchOnFunctionError),
     DestinationConfig:
       output.DestinationConfig !== undefined && output.DestinationConfig !== null
         ? deserializeAws_restJson1DestinationConfig(output.DestinationConfig, context)
         : undefined,
-    EventSourceArn:
-      output.EventSourceArn !== undefined && output.EventSourceArn !== null ? output.EventSourceArn : undefined,
-    FunctionArn: output.FunctionArn !== undefined && output.FunctionArn !== null ? output.FunctionArn : undefined,
+    EventSourceArn: __expectString(output.EventSourceArn),
+    FunctionArn: __expectString(output.FunctionArn),
     FunctionResponseTypes:
       output.FunctionResponseTypes !== undefined && output.FunctionResponseTypes !== null
         ? deserializeAws_restJson1FunctionResponseTypeList(output.FunctionResponseTypes, context)
@@ -9970,26 +9945,11 @@ const deserializeAws_restJson1EventSourceMappingConfiguration = (
       output.LastModified !== undefined && output.LastModified !== null
         ? new Date(Math.round(output.LastModified * 1000))
         : undefined,
-    LastProcessingResult:
-      output.LastProcessingResult !== undefined && output.LastProcessingResult !== null
-        ? output.LastProcessingResult
-        : undefined,
-    MaximumBatchingWindowInSeconds:
-      output.MaximumBatchingWindowInSeconds !== undefined && output.MaximumBatchingWindowInSeconds !== null
-        ? output.MaximumBatchingWindowInSeconds
-        : undefined,
-    MaximumRecordAgeInSeconds:
-      output.MaximumRecordAgeInSeconds !== undefined && output.MaximumRecordAgeInSeconds !== null
-        ? output.MaximumRecordAgeInSeconds
-        : undefined,
-    MaximumRetryAttempts:
-      output.MaximumRetryAttempts !== undefined && output.MaximumRetryAttempts !== null
-        ? output.MaximumRetryAttempts
-        : undefined,
-    ParallelizationFactor:
-      output.ParallelizationFactor !== undefined && output.ParallelizationFactor !== null
-        ? output.ParallelizationFactor
-        : undefined,
+    LastProcessingResult: __expectString(output.LastProcessingResult),
+    MaximumBatchingWindowInSeconds: __expectNumber(output.MaximumBatchingWindowInSeconds),
+    MaximumRecordAgeInSeconds: __expectNumber(output.MaximumRecordAgeInSeconds),
+    MaximumRetryAttempts: __expectNumber(output.MaximumRetryAttempts),
+    ParallelizationFactor: __expectNumber(output.ParallelizationFactor),
     Queues:
       output.Queues !== undefined && output.Queues !== null
         ? deserializeAws_restJson1Queues(output.Queues, context)
@@ -10002,26 +9962,19 @@ const deserializeAws_restJson1EventSourceMappingConfiguration = (
       output.SourceAccessConfigurations !== undefined && output.SourceAccessConfigurations !== null
         ? deserializeAws_restJson1SourceAccessConfigurations(output.SourceAccessConfigurations, context)
         : undefined,
-    StartingPosition:
-      output.StartingPosition !== undefined && output.StartingPosition !== null ? output.StartingPosition : undefined,
+    StartingPosition: __expectString(output.StartingPosition),
     StartingPositionTimestamp:
       output.StartingPositionTimestamp !== undefined && output.StartingPositionTimestamp !== null
         ? new Date(Math.round(output.StartingPositionTimestamp * 1000))
         : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    StateTransitionReason:
-      output.StateTransitionReason !== undefined && output.StateTransitionReason !== null
-        ? output.StateTransitionReason
-        : undefined,
+    State: __expectString(output.State),
+    StateTransitionReason: __expectString(output.StateTransitionReason),
     Topics:
       output.Topics !== undefined && output.Topics !== null
         ? deserializeAws_restJson1Topics(output.Topics, context)
         : undefined,
-    TumblingWindowInSeconds:
-      output.TumblingWindowInSeconds !== undefined && output.TumblingWindowInSeconds !== null
-        ? output.TumblingWindowInSeconds
-        : undefined,
-    UUID: output.UUID !== undefined && output.UUID !== null ? output.UUID : undefined,
+    TumblingWindowInSeconds: __expectNumber(output.TumblingWindowInSeconds),
+    UUID: __expectString(output.UUID),
   } as any;
 };
 
@@ -10041,9 +9994,8 @@ const deserializeAws_restJson1EventSourceMappingsList = (
 
 const deserializeAws_restJson1FileSystemConfig = (output: any, context: __SerdeContext): FileSystemConfig => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    LocalMountPath:
-      output.LocalMountPath !== undefined && output.LocalMountPath !== null ? output.LocalMountPath : undefined,
+    Arn: __expectString(output.Arn),
+    LocalMountPath: __expectString(output.LocalMountPath),
   } as any;
 };
 
@@ -10065,30 +10017,28 @@ const deserializeAws_restJson1FunctionArnList = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1FunctionCodeLocation = (output: any, context: __SerdeContext): FunctionCodeLocation => {
   return {
-    ImageUri: output.ImageUri !== undefined && output.ImageUri !== null ? output.ImageUri : undefined,
-    Location: output.Location !== undefined && output.Location !== null ? output.Location : undefined,
-    RepositoryType:
-      output.RepositoryType !== undefined && output.RepositoryType !== null ? output.RepositoryType : undefined,
-    ResolvedImageUri:
-      output.ResolvedImageUri !== undefined && output.ResolvedImageUri !== null ? output.ResolvedImageUri : undefined,
+    ImageUri: __expectString(output.ImageUri),
+    Location: __expectString(output.Location),
+    RepositoryType: __expectString(output.RepositoryType),
+    ResolvedImageUri: __expectString(output.ResolvedImageUri),
   } as any;
 };
 
 const deserializeAws_restJson1FunctionConfiguration = (output: any, context: __SerdeContext): FunctionConfiguration => {
   return {
-    CodeSha256: output.CodeSha256 !== undefined && output.CodeSha256 !== null ? output.CodeSha256 : undefined,
-    CodeSize: output.CodeSize !== undefined && output.CodeSize !== null ? output.CodeSize : undefined,
+    CodeSha256: __expectString(output.CodeSha256),
+    CodeSize: __expectNumber(output.CodeSize),
     DeadLetterConfig:
       output.DeadLetterConfig !== undefined && output.DeadLetterConfig !== null
         ? deserializeAws_restJson1DeadLetterConfig(output.DeadLetterConfig, context)
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     Environment:
       output.Environment !== undefined && output.Environment !== null
         ? deserializeAws_restJson1EnvironmentResponse(output.Environment, context)
@@ -10097,51 +10047,39 @@ const deserializeAws_restJson1FunctionConfiguration = (output: any, context: __S
       output.FileSystemConfigs !== undefined && output.FileSystemConfigs !== null
         ? deserializeAws_restJson1FileSystemConfigList(output.FileSystemConfigs, context)
         : undefined,
-    FunctionArn: output.FunctionArn !== undefined && output.FunctionArn !== null ? output.FunctionArn : undefined,
-    FunctionName: output.FunctionName !== undefined && output.FunctionName !== null ? output.FunctionName : undefined,
-    Handler: output.Handler !== undefined && output.Handler !== null ? output.Handler : undefined,
+    FunctionArn: __expectString(output.FunctionArn),
+    FunctionName: __expectString(output.FunctionName),
+    Handler: __expectString(output.Handler),
     ImageConfigResponse:
       output.ImageConfigResponse !== undefined && output.ImageConfigResponse !== null
         ? deserializeAws_restJson1ImageConfigResponse(output.ImageConfigResponse, context)
         : undefined,
-    KMSKeyArn: output.KMSKeyArn !== undefined && output.KMSKeyArn !== null ? output.KMSKeyArn : undefined,
-    LastModified: output.LastModified !== undefined && output.LastModified !== null ? output.LastModified : undefined,
-    LastUpdateStatus:
-      output.LastUpdateStatus !== undefined && output.LastUpdateStatus !== null ? output.LastUpdateStatus : undefined,
-    LastUpdateStatusReason:
-      output.LastUpdateStatusReason !== undefined && output.LastUpdateStatusReason !== null
-        ? output.LastUpdateStatusReason
-        : undefined,
-    LastUpdateStatusReasonCode:
-      output.LastUpdateStatusReasonCode !== undefined && output.LastUpdateStatusReasonCode !== null
-        ? output.LastUpdateStatusReasonCode
-        : undefined,
+    KMSKeyArn: __expectString(output.KMSKeyArn),
+    LastModified: __expectString(output.LastModified),
+    LastUpdateStatus: __expectString(output.LastUpdateStatus),
+    LastUpdateStatusReason: __expectString(output.LastUpdateStatusReason),
+    LastUpdateStatusReasonCode: __expectString(output.LastUpdateStatusReasonCode),
     Layers:
       output.Layers !== undefined && output.Layers !== null
         ? deserializeAws_restJson1LayersReferenceList(output.Layers, context)
         : undefined,
-    MasterArn: output.MasterArn !== undefined && output.MasterArn !== null ? output.MasterArn : undefined,
-    MemorySize: output.MemorySize !== undefined && output.MemorySize !== null ? output.MemorySize : undefined,
-    PackageType: output.PackageType !== undefined && output.PackageType !== null ? output.PackageType : undefined,
-    RevisionId: output.RevisionId !== undefined && output.RevisionId !== null ? output.RevisionId : undefined,
-    Role: output.Role !== undefined && output.Role !== null ? output.Role : undefined,
-    Runtime: output.Runtime !== undefined && output.Runtime !== null ? output.Runtime : undefined,
-    SigningJobArn:
-      output.SigningJobArn !== undefined && output.SigningJobArn !== null ? output.SigningJobArn : undefined,
-    SigningProfileVersionArn:
-      output.SigningProfileVersionArn !== undefined && output.SigningProfileVersionArn !== null
-        ? output.SigningProfileVersionArn
-        : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    StateReason: output.StateReason !== undefined && output.StateReason !== null ? output.StateReason : undefined,
-    StateReasonCode:
-      output.StateReasonCode !== undefined && output.StateReasonCode !== null ? output.StateReasonCode : undefined,
-    Timeout: output.Timeout !== undefined && output.Timeout !== null ? output.Timeout : undefined,
+    MasterArn: __expectString(output.MasterArn),
+    MemorySize: __expectNumber(output.MemorySize),
+    PackageType: __expectString(output.PackageType),
+    RevisionId: __expectString(output.RevisionId),
+    Role: __expectString(output.Role),
+    Runtime: __expectString(output.Runtime),
+    SigningJobArn: __expectString(output.SigningJobArn),
+    SigningProfileVersionArn: __expectString(output.SigningProfileVersionArn),
+    State: __expectString(output.State),
+    StateReason: __expectString(output.StateReason),
+    StateReasonCode: __expectString(output.StateReasonCode),
+    Timeout: __expectNumber(output.Timeout),
     TracingConfig:
       output.TracingConfig !== undefined && output.TracingConfig !== null
         ? deserializeAws_restJson1TracingConfigResponse(output.TracingConfig, context)
         : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    Version: __expectString(output.Version),
     VpcConfig:
       output.VpcConfig !== undefined && output.VpcConfig !== null
         ? deserializeAws_restJson1VpcConfigResponse(output.VpcConfig, context)
@@ -10158,19 +10096,13 @@ const deserializeAws_restJson1FunctionEventInvokeConfig = (
       output.DestinationConfig !== undefined && output.DestinationConfig !== null
         ? deserializeAws_restJson1DestinationConfig(output.DestinationConfig, context)
         : undefined,
-    FunctionArn: output.FunctionArn !== undefined && output.FunctionArn !== null ? output.FunctionArn : undefined,
+    FunctionArn: __expectString(output.FunctionArn),
     LastModified:
       output.LastModified !== undefined && output.LastModified !== null
         ? new Date(Math.round(output.LastModified * 1000))
         : undefined,
-    MaximumEventAgeInSeconds:
-      output.MaximumEventAgeInSeconds !== undefined && output.MaximumEventAgeInSeconds !== null
-        ? output.MaximumEventAgeInSeconds
-        : undefined,
-    MaximumRetryAttempts:
-      output.MaximumRetryAttempts !== undefined && output.MaximumRetryAttempts !== null
-        ? output.MaximumRetryAttempts
-        : undefined,
+    MaximumEventAgeInSeconds: __expectNumber(output.MaximumEventAgeInSeconds),
+    MaximumRetryAttempts: __expectNumber(output.MaximumRetryAttempts),
   } as any;
 };
 
@@ -10209,7 +10141,7 @@ const deserializeAws_restJson1FunctionResponseTypeList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -10223,15 +10155,14 @@ const deserializeAws_restJson1ImageConfig = (output: any, context: __SerdeContex
       output.EntryPoint !== undefined && output.EntryPoint !== null
         ? deserializeAws_restJson1StringList(output.EntryPoint, context)
         : undefined,
-    WorkingDirectory:
-      output.WorkingDirectory !== undefined && output.WorkingDirectory !== null ? output.WorkingDirectory : undefined,
+    WorkingDirectory: __expectString(output.WorkingDirectory),
   } as any;
 };
 
 const deserializeAws_restJson1ImageConfigError = (output: any, context: __SerdeContext): ImageConfigError => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -10250,14 +10181,10 @@ const deserializeAws_restJson1ImageConfigResponse = (output: any, context: __Ser
 
 const deserializeAws_restJson1Layer = (output: any, context: __SerdeContext): Layer => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    CodeSize: output.CodeSize !== undefined && output.CodeSize !== null ? output.CodeSize : undefined,
-    SigningJobArn:
-      output.SigningJobArn !== undefined && output.SigningJobArn !== null ? output.SigningJobArn : undefined,
-    SigningProfileVersionArn:
-      output.SigningProfileVersionArn !== undefined && output.SigningProfileVersionArn !== null
-        ? output.SigningProfileVersionArn
-        : undefined,
+    Arn: __expectString(output.Arn),
+    CodeSize: __expectNumber(output.CodeSize),
+    SigningJobArn: __expectString(output.SigningJobArn),
+    SigningProfileVersionArn: __expectString(output.SigningProfileVersionArn),
   } as any;
 };
 
@@ -10278,8 +10205,8 @@ const deserializeAws_restJson1LayersListItem = (output: any, context: __SerdeCon
       output.LatestMatchingVersion !== undefined && output.LatestMatchingVersion !== null
         ? deserializeAws_restJson1LayerVersionsListItem(output.LatestMatchingVersion, context)
         : undefined,
-    LayerArn: output.LayerArn !== undefined && output.LayerArn !== null ? output.LayerArn : undefined,
-    LayerName: output.LayerName !== undefined && output.LayerName !== null ? output.LayerName : undefined,
+    LayerArn: __expectString(output.LayerArn),
+    LayerName: __expectString(output.LayerName),
   } as any;
 };
 
@@ -10299,15 +10226,11 @@ const deserializeAws_restJson1LayerVersionContentOutput = (
   context: __SerdeContext
 ): LayerVersionContentOutput => {
   return {
-    CodeSha256: output.CodeSha256 !== undefined && output.CodeSha256 !== null ? output.CodeSha256 : undefined,
-    CodeSize: output.CodeSize !== undefined && output.CodeSize !== null ? output.CodeSize : undefined,
-    Location: output.Location !== undefined && output.Location !== null ? output.Location : undefined,
-    SigningJobArn:
-      output.SigningJobArn !== undefined && output.SigningJobArn !== null ? output.SigningJobArn : undefined,
-    SigningProfileVersionArn:
-      output.SigningProfileVersionArn !== undefined && output.SigningProfileVersionArn !== null
-        ? output.SigningProfileVersionArn
-        : undefined,
+    CodeSha256: __expectString(output.CodeSha256),
+    CodeSize: __expectNumber(output.CodeSize),
+    Location: __expectString(output.Location),
+    SigningJobArn: __expectString(output.SigningJobArn),
+    SigningProfileVersionArn: __expectString(output.SigningProfileVersionArn),
   } as any;
 };
 
@@ -10328,24 +10251,23 @@ const deserializeAws_restJson1LayerVersionsListItem = (output: any, context: __S
       output.CompatibleRuntimes !== undefined && output.CompatibleRuntimes !== null
         ? deserializeAws_restJson1CompatibleRuntimes(output.CompatibleRuntimes, context)
         : undefined,
-    CreatedDate: output.CreatedDate !== undefined && output.CreatedDate !== null ? output.CreatedDate : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    LayerVersionArn:
-      output.LayerVersionArn !== undefined && output.LayerVersionArn !== null ? output.LayerVersionArn : undefined,
-    LicenseInfo: output.LicenseInfo !== undefined && output.LicenseInfo !== null ? output.LicenseInfo : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    CreatedDate: __expectString(output.CreatedDate),
+    Description: __expectString(output.Description),
+    LayerVersionArn: __expectString(output.LayerVersionArn),
+    LicenseInfo: __expectString(output.LicenseInfo),
+    Version: __expectNumber(output.Version),
   } as any;
 };
 
 const deserializeAws_restJson1OnFailure = (output: any, context: __SerdeContext): OnFailure => {
   return {
-    Destination: output.Destination !== undefined && output.Destination !== null ? output.Destination : undefined,
+    Destination: __expectString(output.Destination),
   } as any;
 };
 
 const deserializeAws_restJson1OnSuccess = (output: any, context: __SerdeContext): OnSuccess => {
   return {
-    Destination: output.Destination !== undefined && output.Destination !== null ? output.Destination : undefined,
+    Destination: __expectString(output.Destination),
   } as any;
 };
 
@@ -10368,25 +10290,13 @@ const deserializeAws_restJson1ProvisionedConcurrencyConfigListItem = (
   context: __SerdeContext
 ): ProvisionedConcurrencyConfigListItem => {
   return {
-    AllocatedProvisionedConcurrentExecutions:
-      output.AllocatedProvisionedConcurrentExecutions !== undefined &&
-      output.AllocatedProvisionedConcurrentExecutions !== null
-        ? output.AllocatedProvisionedConcurrentExecutions
-        : undefined,
-    AvailableProvisionedConcurrentExecutions:
-      output.AvailableProvisionedConcurrentExecutions !== undefined &&
-      output.AvailableProvisionedConcurrentExecutions !== null
-        ? output.AvailableProvisionedConcurrentExecutions
-        : undefined,
-    FunctionArn: output.FunctionArn !== undefined && output.FunctionArn !== null ? output.FunctionArn : undefined,
-    LastModified: output.LastModified !== undefined && output.LastModified !== null ? output.LastModified : undefined,
-    RequestedProvisionedConcurrentExecutions:
-      output.RequestedProvisionedConcurrentExecutions !== undefined &&
-      output.RequestedProvisionedConcurrentExecutions !== null
-        ? output.RequestedProvisionedConcurrentExecutions
-        : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusReason: output.StatusReason !== undefined && output.StatusReason !== null ? output.StatusReason : undefined,
+    AllocatedProvisionedConcurrentExecutions: __expectNumber(output.AllocatedProvisionedConcurrentExecutions),
+    AvailableProvisionedConcurrentExecutions: __expectNumber(output.AvailableProvisionedConcurrentExecutions),
+    FunctionArn: __expectString(output.FunctionArn),
+    LastModified: __expectString(output.LastModified),
+    RequestedProvisionedConcurrentExecutions: __expectNumber(output.RequestedProvisionedConcurrentExecutions),
+    Status: __expectString(output.Status),
+    StatusReason: __expectString(output.StatusReason),
   } as any;
 };
 
@@ -10397,7 +10307,7 @@ const deserializeAws_restJson1Queues = (output: any, context: __SerdeContext): s
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -10408,7 +10318,7 @@ const deserializeAws_restJson1SecurityGroupIds = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -10431,7 +10341,7 @@ const deserializeAws_restJson1SigningProfileVersionArns = (output: any, context:
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -10440,8 +10350,8 @@ const deserializeAws_restJson1SourceAccessConfiguration = (
   context: __SerdeContext
 ): SourceAccessConfiguration => {
   return {
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    URI: output.URI !== undefined && output.URI !== null ? output.URI : undefined,
+    Type: __expectString(output.Type),
+    URI: __expectString(output.URI),
   } as any;
 };
 
@@ -10466,7 +10376,7 @@ const deserializeAws_restJson1StringList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -10477,7 +10387,7 @@ const deserializeAws_restJson1SubnetIds = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -10488,7 +10398,7 @@ const deserializeAws_restJson1Tags = (output: any, context: __SerdeContext): { [
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -10500,13 +10410,13 @@ const deserializeAws_restJson1Topics = (output: any, context: __SerdeContext): s
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1TracingConfigResponse = (output: any, context: __SerdeContext): TracingConfigResponse => {
   return {
-    Mode: output.Mode !== undefined && output.Mode !== null ? output.Mode : undefined,
+    Mode: __expectString(output.Mode),
   } as any;
 };
 
@@ -10520,7 +10430,7 @@ const deserializeAws_restJson1VpcConfigResponse = (output: any, context: __Serde
       output.SubnetIds !== undefined && output.SubnetIds !== null
         ? deserializeAws_restJson1SubnetIds(output.SubnetIds, context)
         : undefined,
-    VpcId: output.VpcId !== undefined && output.VpcId !== null ? output.VpcId : undefined,
+    VpcId: __expectString(output.VpcId),
   } as any;
 };
 

--- a/clients/client-lex-model-building-service/protocols/Aws_restJson1.ts
+++ b/clients/client-lex-model-building-service/protocols/Aws_restJson1.ts
@@ -112,6 +112,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -1540,10 +1543,10 @@ export const deserializeAws_restJson1CreateBotVersionCommand = async (
     contents.abortStatement = deserializeAws_restJson1Statement(data.abortStatement, context);
   }
   if (data.checksum !== undefined && data.checksum !== null) {
-    contents.checksum = data.checksum;
+    contents.checksum = __expectString(data.checksum);
   }
   if (data.childDirected !== undefined && data.childDirected !== null) {
-    contents.childDirected = data.childDirected;
+    contents.childDirected = __expectBoolean(data.childDirected);
   }
   if (data.clarificationPrompt !== undefined && data.clarificationPrompt !== null) {
     contents.clarificationPrompt = deserializeAws_restJson1Prompt(data.clarificationPrompt, context);
@@ -1552,19 +1555,19 @@ export const deserializeAws_restJson1CreateBotVersionCommand = async (
     contents.createdDate = new Date(Math.round(data.createdDate * 1000));
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.detectSentiment !== undefined && data.detectSentiment !== null) {
-    contents.detectSentiment = data.detectSentiment;
+    contents.detectSentiment = __expectBoolean(data.detectSentiment);
   }
   if (data.enableModelImprovements !== undefined && data.enableModelImprovements !== null) {
-    contents.enableModelImprovements = data.enableModelImprovements;
+    contents.enableModelImprovements = __expectBoolean(data.enableModelImprovements);
   }
   if (data.failureReason !== undefined && data.failureReason !== null) {
-    contents.failureReason = data.failureReason;
+    contents.failureReason = __expectString(data.failureReason);
   }
   if (data.idleSessionTTLInSeconds !== undefined && data.idleSessionTTLInSeconds !== null) {
-    contents.idleSessionTTLInSeconds = data.idleSessionTTLInSeconds;
+    contents.idleSessionTTLInSeconds = __expectNumber(data.idleSessionTTLInSeconds);
   }
   if (data.intents !== undefined && data.intents !== null) {
     contents.intents = deserializeAws_restJson1IntentList(data.intents, context);
@@ -1573,19 +1576,19 @@ export const deserializeAws_restJson1CreateBotVersionCommand = async (
     contents.lastUpdatedDate = new Date(Math.round(data.lastUpdatedDate * 1000));
   }
   if (data.locale !== undefined && data.locale !== null) {
-    contents.locale = data.locale;
+    contents.locale = __expectString(data.locale);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.status = data.status;
+    contents.status = __expectString(data.status);
   }
   if (data.version !== undefined && data.version !== null) {
-    contents.version = data.version;
+    contents.version = __expectString(data.version);
   }
   if (data.voiceId !== undefined && data.voiceId !== null) {
-    contents.voiceId = data.voiceId;
+    contents.voiceId = __expectString(data.voiceId);
   }
   return Promise.resolve(contents);
 };
@@ -1697,7 +1700,7 @@ export const deserializeAws_restJson1CreateIntentVersionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.checksum !== undefined && data.checksum !== null) {
-    contents.checksum = data.checksum;
+    contents.checksum = __expectString(data.checksum);
   }
   if (data.conclusionStatement !== undefined && data.conclusionStatement !== null) {
     contents.conclusionStatement = deserializeAws_restJson1Statement(data.conclusionStatement, context);
@@ -1709,7 +1712,7 @@ export const deserializeAws_restJson1CreateIntentVersionCommand = async (
     contents.createdDate = new Date(Math.round(data.createdDate * 1000));
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.dialogCodeHook !== undefined && data.dialogCodeHook !== null) {
     contents.dialogCodeHook = deserializeAws_restJson1CodeHook(data.dialogCodeHook, context);
@@ -1730,13 +1733,13 @@ export const deserializeAws_restJson1CreateIntentVersionCommand = async (
     contents.lastUpdatedDate = new Date(Math.round(data.lastUpdatedDate * 1000));
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.outputContexts !== undefined && data.outputContexts !== null) {
     contents.outputContexts = deserializeAws_restJson1OutputContextList(data.outputContexts, context);
   }
   if (data.parentIntentSignature !== undefined && data.parentIntentSignature !== null) {
-    contents.parentIntentSignature = data.parentIntentSignature;
+    contents.parentIntentSignature = __expectString(data.parentIntentSignature);
   }
   if (data.rejectionStatement !== undefined && data.rejectionStatement !== null) {
     contents.rejectionStatement = deserializeAws_restJson1Statement(data.rejectionStatement, context);
@@ -1748,7 +1751,7 @@ export const deserializeAws_restJson1CreateIntentVersionCommand = async (
     contents.slots = deserializeAws_restJson1SlotList(data.slots, context);
   }
   if (data.version !== undefined && data.version !== null) {
-    contents.version = data.version;
+    contents.version = __expectString(data.version);
   }
   return Promise.resolve(contents);
 };
@@ -1852,13 +1855,13 @@ export const deserializeAws_restJson1CreateSlotTypeVersionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.checksum !== undefined && data.checksum !== null) {
-    contents.checksum = data.checksum;
+    contents.checksum = __expectString(data.checksum);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
     contents.createdDate = new Date(Math.round(data.createdDate * 1000));
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.enumerationValues !== undefined && data.enumerationValues !== null) {
     contents.enumerationValues = deserializeAws_restJson1EnumerationValues(data.enumerationValues, context);
@@ -1867,10 +1870,10 @@ export const deserializeAws_restJson1CreateSlotTypeVersionCommand = async (
     contents.lastUpdatedDate = new Date(Math.round(data.lastUpdatedDate * 1000));
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.parentSlotTypeSignature !== undefined && data.parentSlotTypeSignature !== null) {
-    contents.parentSlotTypeSignature = data.parentSlotTypeSignature;
+    contents.parentSlotTypeSignature = __expectString(data.parentSlotTypeSignature);
   }
   if (data.slotTypeConfigurations !== undefined && data.slotTypeConfigurations !== null) {
     contents.slotTypeConfigurations = deserializeAws_restJson1SlotTypeConfigurations(
@@ -1879,10 +1882,10 @@ export const deserializeAws_restJson1CreateSlotTypeVersionCommand = async (
     );
   }
   if (data.valueSelectionStrategy !== undefined && data.valueSelectionStrategy !== null) {
-    contents.valueSelectionStrategy = data.valueSelectionStrategy;
+    contents.valueSelectionStrategy = __expectString(data.valueSelectionStrategy);
   }
   if (data.version !== undefined && data.version !== null) {
-    contents.version = data.version;
+    contents.version = __expectString(data.version);
   }
   return Promise.resolve(contents);
 };
@@ -2792,10 +2795,10 @@ export const deserializeAws_restJson1GetBotCommand = async (
     contents.abortStatement = deserializeAws_restJson1Statement(data.abortStatement, context);
   }
   if (data.checksum !== undefined && data.checksum !== null) {
-    contents.checksum = data.checksum;
+    contents.checksum = __expectString(data.checksum);
   }
   if (data.childDirected !== undefined && data.childDirected !== null) {
-    contents.childDirected = data.childDirected;
+    contents.childDirected = __expectBoolean(data.childDirected);
   }
   if (data.clarificationPrompt !== undefined && data.clarificationPrompt !== null) {
     contents.clarificationPrompt = deserializeAws_restJson1Prompt(data.clarificationPrompt, context);
@@ -2804,19 +2807,19 @@ export const deserializeAws_restJson1GetBotCommand = async (
     contents.createdDate = new Date(Math.round(data.createdDate * 1000));
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.detectSentiment !== undefined && data.detectSentiment !== null) {
-    contents.detectSentiment = data.detectSentiment;
+    contents.detectSentiment = __expectBoolean(data.detectSentiment);
   }
   if (data.enableModelImprovements !== undefined && data.enableModelImprovements !== null) {
-    contents.enableModelImprovements = data.enableModelImprovements;
+    contents.enableModelImprovements = __expectBoolean(data.enableModelImprovements);
   }
   if (data.failureReason !== undefined && data.failureReason !== null) {
-    contents.failureReason = data.failureReason;
+    contents.failureReason = __expectString(data.failureReason);
   }
   if (data.idleSessionTTLInSeconds !== undefined && data.idleSessionTTLInSeconds !== null) {
-    contents.idleSessionTTLInSeconds = data.idleSessionTTLInSeconds;
+    contents.idleSessionTTLInSeconds = __expectNumber(data.idleSessionTTLInSeconds);
   }
   if (data.intents !== undefined && data.intents !== null) {
     contents.intents = deserializeAws_restJson1IntentList(data.intents, context);
@@ -2825,22 +2828,22 @@ export const deserializeAws_restJson1GetBotCommand = async (
     contents.lastUpdatedDate = new Date(Math.round(data.lastUpdatedDate * 1000));
   }
   if (data.locale !== undefined && data.locale !== null) {
-    contents.locale = data.locale;
+    contents.locale = __expectString(data.locale);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.nluIntentConfidenceThreshold !== undefined && data.nluIntentConfidenceThreshold !== null) {
-    contents.nluIntentConfidenceThreshold = data.nluIntentConfidenceThreshold;
+    contents.nluIntentConfidenceThreshold = __expectNumber(data.nluIntentConfidenceThreshold);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.status = data.status;
+    contents.status = __expectString(data.status);
   }
   if (data.version !== undefined && data.version !== null) {
-    contents.version = data.version;
+    contents.version = __expectString(data.version);
   }
   if (data.voiceId !== undefined && data.voiceId !== null) {
-    contents.voiceId = data.voiceId;
+    contents.voiceId = __expectString(data.voiceId);
   }
   return Promise.resolve(contents);
 };
@@ -2926,13 +2929,13 @@ export const deserializeAws_restJson1GetBotAliasCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.botName !== undefined && data.botName !== null) {
-    contents.botName = data.botName;
+    contents.botName = __expectString(data.botName);
   }
   if (data.botVersion !== undefined && data.botVersion !== null) {
-    contents.botVersion = data.botVersion;
+    contents.botVersion = __expectString(data.botVersion);
   }
   if (data.checksum !== undefined && data.checksum !== null) {
-    contents.checksum = data.checksum;
+    contents.checksum = __expectString(data.checksum);
   }
   if (data.conversationLogs !== undefined && data.conversationLogs !== null) {
     contents.conversationLogs = deserializeAws_restJson1ConversationLogsResponse(data.conversationLogs, context);
@@ -2941,13 +2944,13 @@ export const deserializeAws_restJson1GetBotAliasCommand = async (
     contents.createdDate = new Date(Math.round(data.createdDate * 1000));
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.lastUpdatedDate !== undefined && data.lastUpdatedDate !== null) {
     contents.lastUpdatedDate = new Date(Math.round(data.lastUpdatedDate * 1000));
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   return Promise.resolve(contents);
 };
@@ -3030,7 +3033,7 @@ export const deserializeAws_restJson1GetBotAliasesCommand = async (
     contents.BotAliases = deserializeAws_restJson1BotAliasMetadataList(data.BotAliases, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3109,31 +3112,31 @@ export const deserializeAws_restJson1GetBotChannelAssociationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.botAlias !== undefined && data.botAlias !== null) {
-    contents.botAlias = data.botAlias;
+    contents.botAlias = __expectString(data.botAlias);
   }
   if (data.botConfiguration !== undefined && data.botConfiguration !== null) {
     contents.botConfiguration = deserializeAws_restJson1ChannelConfigurationMap(data.botConfiguration, context);
   }
   if (data.botName !== undefined && data.botName !== null) {
-    contents.botName = data.botName;
+    contents.botName = __expectString(data.botName);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
     contents.createdDate = new Date(Math.round(data.createdDate * 1000));
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.failureReason !== undefined && data.failureReason !== null) {
-    contents.failureReason = data.failureReason;
+    contents.failureReason = __expectString(data.failureReason);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.status = data.status;
+    contents.status = __expectString(data.status);
   }
   if (data.type !== undefined && data.type !== null) {
-    contents.type = data.type;
+    contents.type = __expectString(data.type);
   }
   return Promise.resolve(contents);
 };
@@ -3219,7 +3222,7 @@ export const deserializeAws_restJson1GetBotChannelAssociationsCommand = async (
     );
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3294,7 +3297,7 @@ export const deserializeAws_restJson1GetBotsCommand = async (
     contents.bots = deserializeAws_restJson1BotMetadataList(data.bots, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3377,7 +3380,7 @@ export const deserializeAws_restJson1GetBotVersionsCommand = async (
     contents.bots = deserializeAws_restJson1BotMetadataList(data.bots, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3458,7 +3461,7 @@ export const deserializeAws_restJson1GetBuiltinIntentCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.signature !== undefined && data.signature !== null) {
-    contents.signature = data.signature;
+    contents.signature = __expectString(data.signature);
   }
   if (data.slots !== undefined && data.slots !== null) {
     contents.slots = deserializeAws_restJson1BuiltinIntentSlotList(data.slots, context);
@@ -3547,7 +3550,7 @@ export const deserializeAws_restJson1GetBuiltinIntentsCommand = async (
     contents.intents = deserializeAws_restJson1BuiltinIntentMetadataList(data.intents, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3619,7 +3622,7 @@ export const deserializeAws_restJson1GetBuiltinSlotTypesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.slotTypes !== undefined && data.slotTypes !== null) {
     contents.slotTypes = deserializeAws_restJson1BuiltinSlotTypeMetadataList(data.slotTypes, context);
@@ -3699,25 +3702,25 @@ export const deserializeAws_restJson1GetExportCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.exportStatus !== undefined && data.exportStatus !== null) {
-    contents.exportStatus = data.exportStatus;
+    contents.exportStatus = __expectString(data.exportStatus);
   }
   if (data.exportType !== undefined && data.exportType !== null) {
-    contents.exportType = data.exportType;
+    contents.exportType = __expectString(data.exportType);
   }
   if (data.failureReason !== undefined && data.failureReason !== null) {
-    contents.failureReason = data.failureReason;
+    contents.failureReason = __expectString(data.failureReason);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.resourceType !== undefined && data.resourceType !== null) {
-    contents.resourceType = data.resourceType;
+    contents.resourceType = __expectString(data.resourceType);
   }
   if (data.url !== undefined && data.url !== null) {
-    contents.url = data.url;
+    contents.url = __expectString(data.url);
   }
   if (data.version !== undefined && data.version !== null) {
-    contents.version = data.version;
+    contents.version = __expectString(data.version);
   }
   return Promise.resolve(contents);
 };
@@ -3808,19 +3811,19 @@ export const deserializeAws_restJson1GetImportCommand = async (
     contents.failureReason = deserializeAws_restJson1StringList(data.failureReason, context);
   }
   if (data.importId !== undefined && data.importId !== null) {
-    contents.importId = data.importId;
+    contents.importId = __expectString(data.importId);
   }
   if (data.importStatus !== undefined && data.importStatus !== null) {
-    contents.importStatus = data.importStatus;
+    contents.importStatus = __expectString(data.importStatus);
   }
   if (data.mergeStrategy !== undefined && data.mergeStrategy !== null) {
-    contents.mergeStrategy = data.mergeStrategy;
+    contents.mergeStrategy = __expectString(data.mergeStrategy);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.resourceType !== undefined && data.resourceType !== null) {
-    contents.resourceType = data.resourceType;
+    contents.resourceType = __expectString(data.resourceType);
   }
   return Promise.resolve(contents);
 };
@@ -3916,7 +3919,7 @@ export const deserializeAws_restJson1GetIntentCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.checksum !== undefined && data.checksum !== null) {
-    contents.checksum = data.checksum;
+    contents.checksum = __expectString(data.checksum);
   }
   if (data.conclusionStatement !== undefined && data.conclusionStatement !== null) {
     contents.conclusionStatement = deserializeAws_restJson1Statement(data.conclusionStatement, context);
@@ -3928,7 +3931,7 @@ export const deserializeAws_restJson1GetIntentCommand = async (
     contents.createdDate = new Date(Math.round(data.createdDate * 1000));
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.dialogCodeHook !== undefined && data.dialogCodeHook !== null) {
     contents.dialogCodeHook = deserializeAws_restJson1CodeHook(data.dialogCodeHook, context);
@@ -3949,13 +3952,13 @@ export const deserializeAws_restJson1GetIntentCommand = async (
     contents.lastUpdatedDate = new Date(Math.round(data.lastUpdatedDate * 1000));
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.outputContexts !== undefined && data.outputContexts !== null) {
     contents.outputContexts = deserializeAws_restJson1OutputContextList(data.outputContexts, context);
   }
   if (data.parentIntentSignature !== undefined && data.parentIntentSignature !== null) {
-    contents.parentIntentSignature = data.parentIntentSignature;
+    contents.parentIntentSignature = __expectString(data.parentIntentSignature);
   }
   if (data.rejectionStatement !== undefined && data.rejectionStatement !== null) {
     contents.rejectionStatement = deserializeAws_restJson1Statement(data.rejectionStatement, context);
@@ -3967,7 +3970,7 @@ export const deserializeAws_restJson1GetIntentCommand = async (
     contents.slots = deserializeAws_restJson1SlotList(data.slots, context);
   }
   if (data.version !== undefined && data.version !== null) {
-    contents.version = data.version;
+    contents.version = __expectString(data.version);
   }
   return Promise.resolve(contents);
 };
@@ -4050,7 +4053,7 @@ export const deserializeAws_restJson1GetIntentsCommand = async (
     contents.intents = deserializeAws_restJson1IntentMetadataList(data.intents, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -4133,7 +4136,7 @@ export const deserializeAws_restJson1GetIntentVersionsCommand = async (
     contents.intents = deserializeAws_restJson1IntentMetadataList(data.intents, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -4221,13 +4224,13 @@ export const deserializeAws_restJson1GetSlotTypeCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.checksum !== undefined && data.checksum !== null) {
-    contents.checksum = data.checksum;
+    contents.checksum = __expectString(data.checksum);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
     contents.createdDate = new Date(Math.round(data.createdDate * 1000));
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.enumerationValues !== undefined && data.enumerationValues !== null) {
     contents.enumerationValues = deserializeAws_restJson1EnumerationValues(data.enumerationValues, context);
@@ -4236,10 +4239,10 @@ export const deserializeAws_restJson1GetSlotTypeCommand = async (
     contents.lastUpdatedDate = new Date(Math.round(data.lastUpdatedDate * 1000));
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.parentSlotTypeSignature !== undefined && data.parentSlotTypeSignature !== null) {
-    contents.parentSlotTypeSignature = data.parentSlotTypeSignature;
+    contents.parentSlotTypeSignature = __expectString(data.parentSlotTypeSignature);
   }
   if (data.slotTypeConfigurations !== undefined && data.slotTypeConfigurations !== null) {
     contents.slotTypeConfigurations = deserializeAws_restJson1SlotTypeConfigurations(
@@ -4248,10 +4251,10 @@ export const deserializeAws_restJson1GetSlotTypeCommand = async (
     );
   }
   if (data.valueSelectionStrategy !== undefined && data.valueSelectionStrategy !== null) {
-    contents.valueSelectionStrategy = data.valueSelectionStrategy;
+    contents.valueSelectionStrategy = __expectString(data.valueSelectionStrategy);
   }
   if (data.version !== undefined && data.version !== null) {
-    contents.version = data.version;
+    contents.version = __expectString(data.version);
   }
   return Promise.resolve(contents);
 };
@@ -4331,7 +4334,7 @@ export const deserializeAws_restJson1GetSlotTypesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.slotTypes !== undefined && data.slotTypes !== null) {
     contents.slotTypes = deserializeAws_restJson1SlotTypeMetadataList(data.slotTypes, context);
@@ -4414,7 +4417,7 @@ export const deserializeAws_restJson1GetSlotTypeVersionsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.slotTypes !== undefined && data.slotTypes !== null) {
     contents.slotTypes = deserializeAws_restJson1SlotTypeMetadataList(data.slotTypes, context);
@@ -4497,7 +4500,7 @@ export const deserializeAws_restJson1GetUtterancesViewCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.botName !== undefined && data.botName !== null) {
-    contents.botName = data.botName;
+    contents.botName = __expectString(data.botName);
   }
   if (data.utterances !== undefined && data.utterances !== null) {
     contents.utterances = deserializeAws_restJson1ListsOfUtterances(data.utterances, context);
@@ -4672,34 +4675,34 @@ export const deserializeAws_restJson1PutBotCommand = async (
     contents.abortStatement = deserializeAws_restJson1Statement(data.abortStatement, context);
   }
   if (data.checksum !== undefined && data.checksum !== null) {
-    contents.checksum = data.checksum;
+    contents.checksum = __expectString(data.checksum);
   }
   if (data.childDirected !== undefined && data.childDirected !== null) {
-    contents.childDirected = data.childDirected;
+    contents.childDirected = __expectBoolean(data.childDirected);
   }
   if (data.clarificationPrompt !== undefined && data.clarificationPrompt !== null) {
     contents.clarificationPrompt = deserializeAws_restJson1Prompt(data.clarificationPrompt, context);
   }
   if (data.createVersion !== undefined && data.createVersion !== null) {
-    contents.createVersion = data.createVersion;
+    contents.createVersion = __expectBoolean(data.createVersion);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
     contents.createdDate = new Date(Math.round(data.createdDate * 1000));
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.detectSentiment !== undefined && data.detectSentiment !== null) {
-    contents.detectSentiment = data.detectSentiment;
+    contents.detectSentiment = __expectBoolean(data.detectSentiment);
   }
   if (data.enableModelImprovements !== undefined && data.enableModelImprovements !== null) {
-    contents.enableModelImprovements = data.enableModelImprovements;
+    contents.enableModelImprovements = __expectBoolean(data.enableModelImprovements);
   }
   if (data.failureReason !== undefined && data.failureReason !== null) {
-    contents.failureReason = data.failureReason;
+    contents.failureReason = __expectString(data.failureReason);
   }
   if (data.idleSessionTTLInSeconds !== undefined && data.idleSessionTTLInSeconds !== null) {
-    contents.idleSessionTTLInSeconds = data.idleSessionTTLInSeconds;
+    contents.idleSessionTTLInSeconds = __expectNumber(data.idleSessionTTLInSeconds);
   }
   if (data.intents !== undefined && data.intents !== null) {
     contents.intents = deserializeAws_restJson1IntentList(data.intents, context);
@@ -4708,25 +4711,25 @@ export const deserializeAws_restJson1PutBotCommand = async (
     contents.lastUpdatedDate = new Date(Math.round(data.lastUpdatedDate * 1000));
   }
   if (data.locale !== undefined && data.locale !== null) {
-    contents.locale = data.locale;
+    contents.locale = __expectString(data.locale);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.nluIntentConfidenceThreshold !== undefined && data.nluIntentConfidenceThreshold !== null) {
-    contents.nluIntentConfidenceThreshold = data.nluIntentConfidenceThreshold;
+    contents.nluIntentConfidenceThreshold = __expectNumber(data.nluIntentConfidenceThreshold);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.status = data.status;
+    contents.status = __expectString(data.status);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagList(data.tags, context);
   }
   if (data.version !== undefined && data.version !== null) {
-    contents.version = data.version;
+    contents.version = __expectString(data.version);
   }
   if (data.voiceId !== undefined && data.voiceId !== null) {
-    contents.voiceId = data.voiceId;
+    contents.voiceId = __expectString(data.voiceId);
   }
   return Promise.resolve(contents);
 };
@@ -4821,13 +4824,13 @@ export const deserializeAws_restJson1PutBotAliasCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.botName !== undefined && data.botName !== null) {
-    contents.botName = data.botName;
+    contents.botName = __expectString(data.botName);
   }
   if (data.botVersion !== undefined && data.botVersion !== null) {
-    contents.botVersion = data.botVersion;
+    contents.botVersion = __expectString(data.botVersion);
   }
   if (data.checksum !== undefined && data.checksum !== null) {
-    contents.checksum = data.checksum;
+    contents.checksum = __expectString(data.checksum);
   }
   if (data.conversationLogs !== undefined && data.conversationLogs !== null) {
     contents.conversationLogs = deserializeAws_restJson1ConversationLogsResponse(data.conversationLogs, context);
@@ -4836,13 +4839,13 @@ export const deserializeAws_restJson1PutBotAliasCommand = async (
     contents.createdDate = new Date(Math.round(data.createdDate * 1000));
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.lastUpdatedDate !== undefined && data.lastUpdatedDate !== null) {
     contents.lastUpdatedDate = new Date(Math.round(data.lastUpdatedDate * 1000));
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagList(data.tags, context);
@@ -4950,7 +4953,7 @@ export const deserializeAws_restJson1PutIntentCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.checksum !== undefined && data.checksum !== null) {
-    contents.checksum = data.checksum;
+    contents.checksum = __expectString(data.checksum);
   }
   if (data.conclusionStatement !== undefined && data.conclusionStatement !== null) {
     contents.conclusionStatement = deserializeAws_restJson1Statement(data.conclusionStatement, context);
@@ -4959,13 +4962,13 @@ export const deserializeAws_restJson1PutIntentCommand = async (
     contents.confirmationPrompt = deserializeAws_restJson1Prompt(data.confirmationPrompt, context);
   }
   if (data.createVersion !== undefined && data.createVersion !== null) {
-    contents.createVersion = data.createVersion;
+    contents.createVersion = __expectBoolean(data.createVersion);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
     contents.createdDate = new Date(Math.round(data.createdDate * 1000));
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.dialogCodeHook !== undefined && data.dialogCodeHook !== null) {
     contents.dialogCodeHook = deserializeAws_restJson1CodeHook(data.dialogCodeHook, context);
@@ -4986,13 +4989,13 @@ export const deserializeAws_restJson1PutIntentCommand = async (
     contents.lastUpdatedDate = new Date(Math.round(data.lastUpdatedDate * 1000));
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.outputContexts !== undefined && data.outputContexts !== null) {
     contents.outputContexts = deserializeAws_restJson1OutputContextList(data.outputContexts, context);
   }
   if (data.parentIntentSignature !== undefined && data.parentIntentSignature !== null) {
-    contents.parentIntentSignature = data.parentIntentSignature;
+    contents.parentIntentSignature = __expectString(data.parentIntentSignature);
   }
   if (data.rejectionStatement !== undefined && data.rejectionStatement !== null) {
     contents.rejectionStatement = deserializeAws_restJson1Statement(data.rejectionStatement, context);
@@ -5004,7 +5007,7 @@ export const deserializeAws_restJson1PutIntentCommand = async (
     contents.slots = deserializeAws_restJson1SlotList(data.slots, context);
   }
   if (data.version !== undefined && data.version !== null) {
-    contents.version = data.version;
+    contents.version = __expectString(data.version);
   }
   return Promise.resolve(contents);
 };
@@ -5101,16 +5104,16 @@ export const deserializeAws_restJson1PutSlotTypeCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.checksum !== undefined && data.checksum !== null) {
-    contents.checksum = data.checksum;
+    contents.checksum = __expectString(data.checksum);
   }
   if (data.createVersion !== undefined && data.createVersion !== null) {
-    contents.createVersion = data.createVersion;
+    contents.createVersion = __expectBoolean(data.createVersion);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
     contents.createdDate = new Date(Math.round(data.createdDate * 1000));
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.enumerationValues !== undefined && data.enumerationValues !== null) {
     contents.enumerationValues = deserializeAws_restJson1EnumerationValues(data.enumerationValues, context);
@@ -5119,10 +5122,10 @@ export const deserializeAws_restJson1PutSlotTypeCommand = async (
     contents.lastUpdatedDate = new Date(Math.round(data.lastUpdatedDate * 1000));
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.parentSlotTypeSignature !== undefined && data.parentSlotTypeSignature !== null) {
-    contents.parentSlotTypeSignature = data.parentSlotTypeSignature;
+    contents.parentSlotTypeSignature = __expectString(data.parentSlotTypeSignature);
   }
   if (data.slotTypeConfigurations !== undefined && data.slotTypeConfigurations !== null) {
     contents.slotTypeConfigurations = deserializeAws_restJson1SlotTypeConfigurations(
@@ -5131,10 +5134,10 @@ export const deserializeAws_restJson1PutSlotTypeCommand = async (
     );
   }
   if (data.valueSelectionStrategy !== undefined && data.valueSelectionStrategy !== null) {
-    contents.valueSelectionStrategy = data.valueSelectionStrategy;
+    contents.valueSelectionStrategy = __expectString(data.valueSelectionStrategy);
   }
   if (data.version !== undefined && data.version !== null) {
-    contents.version = data.version;
+    contents.version = __expectString(data.version);
   }
   return Promise.resolve(contents);
 };
@@ -5230,19 +5233,19 @@ export const deserializeAws_restJson1StartImportCommand = async (
     contents.createdDate = new Date(Math.round(data.createdDate * 1000));
   }
   if (data.importId !== undefined && data.importId !== null) {
-    contents.importId = data.importId;
+    contents.importId = __expectString(data.importId);
   }
   if (data.importStatus !== undefined && data.importStatus !== null) {
-    contents.importStatus = data.importStatus;
+    contents.importStatus = __expectString(data.importStatus);
   }
   if (data.mergeStrategy !== undefined && data.mergeStrategy !== null) {
-    contents.mergeStrategy = data.mergeStrategy;
+    contents.mergeStrategy = __expectString(data.mergeStrategy);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.resourceType !== undefined && data.resourceType !== null) {
-    contents.resourceType = data.resourceType;
+    contents.resourceType = __expectString(data.resourceType);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagList(data.tags, context);
@@ -5481,7 +5484,7 @@ const deserializeAws_restJson1BadRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -5498,7 +5501,7 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -5515,7 +5518,7 @@ const deserializeAws_restJson1InternalFailureExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -5536,7 +5539,7 @@ const deserializeAws_restJson1LimitExceededExceptionResponse = async (
   }
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -5553,7 +5556,7 @@ const deserializeAws_restJson1NotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -5570,7 +5573,7 @@ const deserializeAws_restJson1PreconditionFailedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -5591,7 +5594,7 @@ const deserializeAws_restJson1ResourceInUseExceptionResponse = async (
     contents.exampleReference = deserializeAws_restJson1ResourceReference(data.exampleReference, context);
   }
   if (data.referenceType !== undefined && data.referenceType !== null) {
-    contents.referenceType = data.referenceType;
+    contents.referenceType = __expectString(data.referenceType);
   }
   return contents;
 };
@@ -5922,9 +5925,9 @@ const serializeAws_restJson1TagList = (input: Tag[], context: __SerdeContext): a
 
 const deserializeAws_restJson1BotAliasMetadata = (output: any, context: __SerdeContext): BotAliasMetadata => {
   return {
-    botName: output.botName !== undefined && output.botName !== null ? output.botName : undefined,
-    botVersion: output.botVersion !== undefined && output.botVersion !== null ? output.botVersion : undefined,
-    checksum: output.checksum !== undefined && output.checksum !== null ? output.checksum : undefined,
+    botName: __expectString(output.botName),
+    botVersion: __expectString(output.botVersion),
+    checksum: __expectString(output.checksum),
     conversationLogs:
       output.conversationLogs !== undefined && output.conversationLogs !== null
         ? deserializeAws_restJson1ConversationLogsResponse(output.conversationLogs, context)
@@ -5933,12 +5936,12 @@ const deserializeAws_restJson1BotAliasMetadata = (output: any, context: __SerdeC
       output.createdDate !== undefined && output.createdDate !== null
         ? new Date(Math.round(output.createdDate * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    description: __expectString(output.description),
     lastUpdatedDate:
       output.lastUpdatedDate !== undefined && output.lastUpdatedDate !== null
         ? new Date(Math.round(output.lastUpdatedDate * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -5955,22 +5958,21 @@ const deserializeAws_restJson1BotAliasMetadataList = (output: any, context: __Se
 
 const deserializeAws_restJson1BotChannelAssociation = (output: any, context: __SerdeContext): BotChannelAssociation => {
   return {
-    botAlias: output.botAlias !== undefined && output.botAlias !== null ? output.botAlias : undefined,
+    botAlias: __expectString(output.botAlias),
     botConfiguration:
       output.botConfiguration !== undefined && output.botConfiguration !== null
         ? deserializeAws_restJson1ChannelConfigurationMap(output.botConfiguration, context)
         : undefined,
-    botName: output.botName !== undefined && output.botName !== null ? output.botName : undefined,
+    botName: __expectString(output.botName),
     createdDate:
       output.createdDate !== undefined && output.createdDate !== null
         ? new Date(Math.round(output.createdDate * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    failureReason:
-      output.failureReason !== undefined && output.failureReason !== null ? output.failureReason : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    description: __expectString(output.description),
+    failureReason: __expectString(output.failureReason),
+    name: __expectString(output.name),
+    status: __expectString(output.status),
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -5994,14 +5996,14 @@ const deserializeAws_restJson1BotMetadata = (output: any, context: __SerdeContex
       output.createdDate !== undefined && output.createdDate !== null
         ? new Date(Math.round(output.createdDate * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    description: __expectString(output.description),
     lastUpdatedDate:
       output.lastUpdatedDate !== undefined && output.lastUpdatedDate !== null
         ? new Date(Math.round(output.lastUpdatedDate * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    name: __expectString(output.name),
+    status: __expectString(output.status),
+    version: __expectString(output.version),
   } as any;
 };
 
@@ -6018,7 +6020,7 @@ const deserializeAws_restJson1BotMetadataList = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1BuiltinIntentMetadata = (output: any, context: __SerdeContext): BuiltinIntentMetadata => {
   return {
-    signature: output.signature !== undefined && output.signature !== null ? output.signature : undefined,
+    signature: __expectString(output.signature),
     supportedLocales:
       output.supportedLocales !== undefined && output.supportedLocales !== null
         ? deserializeAws_restJson1LocaleList(output.supportedLocales, context)
@@ -6042,7 +6044,7 @@ const deserializeAws_restJson1BuiltinIntentMetadataList = (
 
 const deserializeAws_restJson1BuiltinIntentSlot = (output: any, context: __SerdeContext): BuiltinIntentSlot => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -6062,7 +6064,7 @@ const deserializeAws_restJson1BuiltinSlotTypeMetadata = (
   context: __SerdeContext
 ): BuiltinSlotTypeMetadata => {
   return {
-    signature: output.signature !== undefined && output.signature !== null ? output.signature : undefined,
+    signature: __expectString(output.signature),
     supportedLocales:
       output.supportedLocales !== undefined && output.supportedLocales !== null
         ? deserializeAws_restJson1LocaleList(output.supportedLocales, context)
@@ -6094,16 +6096,15 @@ const deserializeAws_restJson1ChannelConfigurationMap = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1CodeHook = (output: any, context: __SerdeContext): CodeHook => {
   return {
-    messageVersion:
-      output.messageVersion !== undefined && output.messageVersion !== null ? output.messageVersion : undefined,
-    uri: output.uri !== undefined && output.uri !== null ? output.uri : undefined,
+    messageVersion: __expectString(output.messageVersion),
+    uri: __expectString(output.uri),
   } as any;
 };
 
@@ -6112,7 +6113,7 @@ const deserializeAws_restJson1ConversationLogsResponse = (
   context: __SerdeContext
 ): ConversationLogsResponse => {
   return {
-    iamRoleArn: output.iamRoleArn !== undefined && output.iamRoleArn !== null ? output.iamRoleArn : undefined,
+    iamRoleArn: __expectString(output.iamRoleArn),
     logSettings:
       output.logSettings !== undefined && output.logSettings !== null
         ? deserializeAws_restJson1LogSettingsResponseList(output.logSettings, context)
@@ -6126,7 +6127,7 @@ const deserializeAws_restJson1EnumerationValue = (output: any, context: __SerdeC
       output.synonyms !== undefined && output.synonyms !== null
         ? deserializeAws_restJson1SynonymList(output.synonyms, context)
         : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -6160,13 +6161,13 @@ const deserializeAws_restJson1FulfillmentActivity = (output: any, context: __Ser
       output.codeHook !== undefined && output.codeHook !== null
         ? deserializeAws_restJson1CodeHook(output.codeHook, context)
         : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    type: __expectString(output.type),
   } as any;
 };
 
 const deserializeAws_restJson1InputContext = (output: any, context: __SerdeContext): InputContext => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -6183,9 +6184,8 @@ const deserializeAws_restJson1InputContextList = (output: any, context: __SerdeC
 
 const deserializeAws_restJson1Intent = (output: any, context: __SerdeContext): Intent => {
   return {
-    intentName: output.intentName !== undefined && output.intentName !== null ? output.intentName : undefined,
-    intentVersion:
-      output.intentVersion !== undefined && output.intentVersion !== null ? output.intentVersion : undefined,
+    intentName: __expectString(output.intentName),
+    intentVersion: __expectString(output.intentVersion),
   } as any;
 };
 
@@ -6206,13 +6206,13 @@ const deserializeAws_restJson1IntentMetadata = (output: any, context: __SerdeCon
       output.createdDate !== undefined && output.createdDate !== null
         ? new Date(Math.round(output.createdDate * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    description: __expectString(output.description),
     lastUpdatedDate:
       output.lastUpdatedDate !== undefined && output.lastUpdatedDate !== null
         ? new Date(Math.round(output.lastUpdatedDate * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    name: __expectString(output.name),
+    version: __expectString(output.version),
   } as any;
 };
 
@@ -6234,18 +6234,15 @@ const deserializeAws_restJson1IntentUtteranceList = (output: any, context: __Ser
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1KendraConfiguration = (output: any, context: __SerdeContext): KendraConfiguration => {
   return {
-    kendraIndex: output.kendraIndex !== undefined && output.kendraIndex !== null ? output.kendraIndex : undefined,
-    queryFilterString:
-      output.queryFilterString !== undefined && output.queryFilterString !== null
-        ? output.queryFilterString
-        : undefined,
-    role: output.role !== undefined && output.role !== null ? output.role : undefined,
+    kendraIndex: __expectString(output.kendraIndex),
+    queryFilterString: __expectString(output.queryFilterString),
+    role: __expectString(output.role),
   } as any;
 };
 
@@ -6278,18 +6275,17 @@ const deserializeAws_restJson1LocaleList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1LogSettingsResponse = (output: any, context: __SerdeContext): LogSettingsResponse => {
   return {
-    destination: output.destination !== undefined && output.destination !== null ? output.destination : undefined,
-    kmsKeyArn: output.kmsKeyArn !== undefined && output.kmsKeyArn !== null ? output.kmsKeyArn : undefined,
-    logType: output.logType !== undefined && output.logType !== null ? output.logType : undefined,
-    resourceArn: output.resourceArn !== undefined && output.resourceArn !== null ? output.resourceArn : undefined,
-    resourcePrefix:
-      output.resourcePrefix !== undefined && output.resourcePrefix !== null ? output.resourcePrefix : undefined,
+    destination: __expectString(output.destination),
+    kmsKeyArn: __expectString(output.kmsKeyArn),
+    logType: __expectString(output.logType),
+    resourceArn: __expectString(output.resourceArn),
+    resourcePrefix: __expectString(output.resourcePrefix),
   } as any;
 };
 
@@ -6309,9 +6305,9 @@ const deserializeAws_restJson1LogSettingsResponseList = (
 
 const deserializeAws_restJson1Message = (output: any, context: __SerdeContext): Message => {
   return {
-    content: output.content !== undefined && output.content !== null ? output.content : undefined,
-    contentType: output.contentType !== undefined && output.contentType !== null ? output.contentType : undefined,
-    groupNumber: output.groupNumber !== undefined && output.groupNumber !== null ? output.groupNumber : undefined,
+    content: __expectString(output.content),
+    contentType: __expectString(output.contentType),
+    groupNumber: __expectNumber(output.groupNumber),
   } as any;
 };
 
@@ -6328,12 +6324,9 @@ const deserializeAws_restJson1MessageList = (output: any, context: __SerdeContex
 
 const deserializeAws_restJson1OutputContext = (output: any, context: __SerdeContext): OutputContext => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    timeToLiveInSeconds:
-      output.timeToLiveInSeconds !== undefined && output.timeToLiveInSeconds !== null
-        ? output.timeToLiveInSeconds
-        : undefined,
-    turnsToLive: output.turnsToLive !== undefined && output.turnsToLive !== null ? output.turnsToLive : undefined,
+    name: __expectString(output.name),
+    timeToLiveInSeconds: __expectNumber(output.timeToLiveInSeconds),
+    turnsToLive: __expectNumber(output.turnsToLive),
   } as any;
 };
 
@@ -6350,19 +6343,19 @@ const deserializeAws_restJson1OutputContextList = (output: any, context: __Serde
 
 const deserializeAws_restJson1Prompt = (output: any, context: __SerdeContext): Prompt => {
   return {
-    maxAttempts: output.maxAttempts !== undefined && output.maxAttempts !== null ? output.maxAttempts : undefined,
+    maxAttempts: __expectNumber(output.maxAttempts),
     messages:
       output.messages !== undefined && output.messages !== null
         ? deserializeAws_restJson1MessageList(output.messages, context)
         : undefined,
-    responseCard: output.responseCard !== undefined && output.responseCard !== null ? output.responseCard : undefined,
+    responseCard: __expectString(output.responseCard),
   } as any;
 };
 
 const deserializeAws_restJson1ResourceReference = (output: any, context: __SerdeContext): ResourceReference => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    name: __expectString(output.name),
+    version: __expectString(output.version),
   } as any;
 };
 
@@ -6372,23 +6365,18 @@ const deserializeAws_restJson1Slot = (output: any, context: __SerdeContext): Slo
       output.defaultValueSpec !== undefined && output.defaultValueSpec !== null
         ? deserializeAws_restJson1SlotDefaultValueSpec(output.defaultValueSpec, context)
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    obfuscationSetting:
-      output.obfuscationSetting !== undefined && output.obfuscationSetting !== null
-        ? output.obfuscationSetting
-        : undefined,
-    priority: output.priority !== undefined && output.priority !== null ? output.priority : undefined,
-    responseCard: output.responseCard !== undefined && output.responseCard !== null ? output.responseCard : undefined,
+    description: __expectString(output.description),
+    name: __expectString(output.name),
+    obfuscationSetting: __expectString(output.obfuscationSetting),
+    priority: __expectNumber(output.priority),
+    responseCard: __expectString(output.responseCard),
     sampleUtterances:
       output.sampleUtterances !== undefined && output.sampleUtterances !== null
         ? deserializeAws_restJson1SlotUtteranceList(output.sampleUtterances, context)
         : undefined,
-    slotConstraint:
-      output.slotConstraint !== undefined && output.slotConstraint !== null ? output.slotConstraint : undefined,
-    slotType: output.slotType !== undefined && output.slotType !== null ? output.slotType : undefined,
-    slotTypeVersion:
-      output.slotTypeVersion !== undefined && output.slotTypeVersion !== null ? output.slotTypeVersion : undefined,
+    slotConstraint: __expectString(output.slotConstraint),
+    slotType: __expectString(output.slotType),
+    slotTypeVersion: __expectString(output.slotTypeVersion),
     valueElicitationPrompt:
       output.valueElicitationPrompt !== undefined && output.valueElicitationPrompt !== null
         ? deserializeAws_restJson1Prompt(output.valueElicitationPrompt, context)
@@ -6398,7 +6386,7 @@ const deserializeAws_restJson1Slot = (output: any, context: __SerdeContext): Slo
 
 const deserializeAws_restJson1SlotDefaultValue = (output: any, context: __SerdeContext): SlotDefaultValue => {
   return {
-    defaultValue: output.defaultValue !== undefined && output.defaultValue !== null ? output.defaultValue : undefined,
+    defaultValue: __expectString(output.defaultValue),
   } as any;
 };
 
@@ -6462,13 +6450,13 @@ const deserializeAws_restJson1SlotTypeMetadata = (output: any, context: __SerdeC
       output.createdDate !== undefined && output.createdDate !== null
         ? new Date(Math.round(output.createdDate * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    description: __expectString(output.description),
     lastUpdatedDate:
       output.lastUpdatedDate !== undefined && output.lastUpdatedDate !== null
         ? new Date(Math.round(output.lastUpdatedDate * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    name: __expectString(output.name),
+    version: __expectString(output.version),
   } as any;
 };
 
@@ -6488,7 +6476,7 @@ const deserializeAws_restJson1SlotTypeRegexConfiguration = (
   context: __SerdeContext
 ): SlotTypeRegexConfiguration => {
   return {
-    pattern: output.pattern !== undefined && output.pattern !== null ? output.pattern : undefined,
+    pattern: __expectString(output.pattern),
   } as any;
 };
 
@@ -6499,7 +6487,7 @@ const deserializeAws_restJson1SlotUtteranceList = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6509,7 +6497,7 @@ const deserializeAws_restJson1Statement = (output: any, context: __SerdeContext)
       output.messages !== undefined && output.messages !== null
         ? deserializeAws_restJson1MessageList(output.messages, context)
         : undefined,
-    responseCard: output.responseCard !== undefined && output.responseCard !== null ? output.responseCard : undefined,
+    responseCard: __expectString(output.responseCard),
   } as any;
 };
 
@@ -6520,7 +6508,7 @@ const deserializeAws_restJson1StringList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6531,14 +6519,14 @@ const deserializeAws_restJson1SynonymList = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    key: __expectString(output.key),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -6555,9 +6543,8 @@ const deserializeAws_restJson1TagList = (output: any, context: __SerdeContext): 
 
 const deserializeAws_restJson1UtteranceData = (output: any, context: __SerdeContext): UtteranceData => {
   return {
-    count: output.count !== undefined && output.count !== null ? output.count : undefined,
-    distinctUsers:
-      output.distinctUsers !== undefined && output.distinctUsers !== null ? output.distinctUsers : undefined,
+    count: __expectNumber(output.count),
+    distinctUsers: __expectNumber(output.distinctUsers),
     firstUtteredDate:
       output.firstUtteredDate !== undefined && output.firstUtteredDate !== null
         ? new Date(Math.round(output.firstUtteredDate * 1000))
@@ -6566,14 +6553,13 @@ const deserializeAws_restJson1UtteranceData = (output: any, context: __SerdeCont
       output.lastUtteredDate !== undefined && output.lastUtteredDate !== null
         ? new Date(Math.round(output.lastUtteredDate * 1000))
         : undefined,
-    utteranceString:
-      output.utteranceString !== undefined && output.utteranceString !== null ? output.utteranceString : undefined,
+    utteranceString: __expectString(output.utteranceString),
   } as any;
 };
 
 const deserializeAws_restJson1UtteranceList = (output: any, context: __SerdeContext): UtteranceList => {
   return {
-    botVersion: output.botVersion !== undefined && output.botVersion !== null ? output.botVersion : undefined,
+    botVersion: __expectString(output.botVersion),
     utterances:
       output.utterances !== undefined && output.utterances !== null
         ? deserializeAws_restJson1ListOfUtterance(output.utterances, context)

--- a/clients/client-lex-models-v2/protocols/Aws_restJson1.ts
+++ b/clients/client-lex-models-v2/protocols/Aws_restJson1.ts
@@ -170,6 +170,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -2723,19 +2726,19 @@ export const deserializeAws_restJson1BuildBotLocaleCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.botId !== undefined && data.botId !== null) {
-    contents.botId = data.botId;
+    contents.botId = __expectString(data.botId);
   }
   if (data.botLocaleStatus !== undefined && data.botLocaleStatus !== null) {
-    contents.botLocaleStatus = data.botLocaleStatus;
+    contents.botLocaleStatus = __expectString(data.botLocaleStatus);
   }
   if (data.botVersion !== undefined && data.botVersion !== null) {
-    contents.botVersion = data.botVersion;
+    contents.botVersion = __expectString(data.botVersion);
   }
   if (data.lastBuildSubmittedDateTime !== undefined && data.lastBuildSubmittedDateTime !== null) {
     contents.lastBuildSubmittedDateTime = new Date(Math.round(data.lastBuildSubmittedDateTime * 1000));
   }
   if (data.localeId !== undefined && data.localeId !== null) {
-    contents.localeId = data.localeId;
+    contents.localeId = __expectString(data.localeId);
   }
   return Promise.resolve(contents);
 };
@@ -2839,13 +2842,13 @@ export const deserializeAws_restJson1CreateBotCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.botId !== undefined && data.botId !== null) {
-    contents.botId = data.botId;
+    contents.botId = __expectString(data.botId);
   }
   if (data.botName !== undefined && data.botName !== null) {
-    contents.botName = data.botName;
+    contents.botName = __expectString(data.botName);
   }
   if (data.botStatus !== undefined && data.botStatus !== null) {
-    contents.botStatus = data.botStatus;
+    contents.botStatus = __expectString(data.botStatus);
   }
   if (data.botTags !== undefined && data.botTags !== null) {
     contents.botTags = deserializeAws_restJson1TagMap(data.botTags, context);
@@ -2857,13 +2860,13 @@ export const deserializeAws_restJson1CreateBotCommand = async (
     contents.dataPrivacy = deserializeAws_restJson1DataPrivacy(data.dataPrivacy, context);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.idleSessionTTLInSeconds !== undefined && data.idleSessionTTLInSeconds !== null) {
-    contents.idleSessionTTLInSeconds = data.idleSessionTTLInSeconds;
+    contents.idleSessionTTLInSeconds = __expectNumber(data.idleSessionTTLInSeconds);
   }
   if (data.roleArn !== undefined && data.roleArn !== null) {
-    contents.roleArn = data.roleArn;
+    contents.roleArn = __expectString(data.roleArn);
   }
   if (data.testBotAliasTags !== undefined && data.testBotAliasTags !== null) {
     contents.testBotAliasTags = deserializeAws_restJson1TagMap(data.testBotAliasTags, context);
@@ -2971,7 +2974,7 @@ export const deserializeAws_restJson1CreateBotAliasCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.botAliasId !== undefined && data.botAliasId !== null) {
-    contents.botAliasId = data.botAliasId;
+    contents.botAliasId = __expectString(data.botAliasId);
   }
   if (data.botAliasLocaleSettings !== undefined && data.botAliasLocaleSettings !== null) {
     contents.botAliasLocaleSettings = deserializeAws_restJson1BotAliasLocaleSettingsMap(
@@ -2980,16 +2983,16 @@ export const deserializeAws_restJson1CreateBotAliasCommand = async (
     );
   }
   if (data.botAliasName !== undefined && data.botAliasName !== null) {
-    contents.botAliasName = data.botAliasName;
+    contents.botAliasName = __expectString(data.botAliasName);
   }
   if (data.botAliasStatus !== undefined && data.botAliasStatus !== null) {
-    contents.botAliasStatus = data.botAliasStatus;
+    contents.botAliasStatus = __expectString(data.botAliasStatus);
   }
   if (data.botId !== undefined && data.botId !== null) {
-    contents.botId = data.botId;
+    contents.botId = __expectString(data.botId);
   }
   if (data.botVersion !== undefined && data.botVersion !== null) {
-    contents.botVersion = data.botVersion;
+    contents.botVersion = __expectString(data.botVersion);
   }
   if (data.conversationLogSettings !== undefined && data.conversationLogSettings !== null) {
     contents.conversationLogSettings = deserializeAws_restJson1ConversationLogSettings(
@@ -3001,7 +3004,7 @@ export const deserializeAws_restJson1CreateBotAliasCommand = async (
     contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.sentimentAnalysisSettings !== undefined && data.sentimentAnalysisSettings !== null) {
     contents.sentimentAnalysisSettings = deserializeAws_restJson1SentimentAnalysisSettings(
@@ -3113,28 +3116,28 @@ export const deserializeAws_restJson1CreateBotLocaleCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.botId !== undefined && data.botId !== null) {
-    contents.botId = data.botId;
+    contents.botId = __expectString(data.botId);
   }
   if (data.botLocaleStatus !== undefined && data.botLocaleStatus !== null) {
-    contents.botLocaleStatus = data.botLocaleStatus;
+    contents.botLocaleStatus = __expectString(data.botLocaleStatus);
   }
   if (data.botVersion !== undefined && data.botVersion !== null) {
-    contents.botVersion = data.botVersion;
+    contents.botVersion = __expectString(data.botVersion);
   }
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
     contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.localeId !== undefined && data.localeId !== null) {
-    contents.localeId = data.localeId;
+    contents.localeId = __expectString(data.localeId);
   }
   if (data.localeName !== undefined && data.localeName !== null) {
-    contents.localeName = data.localeName;
+    contents.localeName = __expectString(data.localeName);
   }
   if (data.nluIntentConfidenceThreshold !== undefined && data.nluIntentConfidenceThreshold !== null) {
-    contents.nluIntentConfidenceThreshold = data.nluIntentConfidenceThreshold;
+    contents.nluIntentConfidenceThreshold = __expectNumber(data.nluIntentConfidenceThreshold);
   }
   if (data.voiceSettings !== undefined && data.voiceSettings !== null) {
     contents.voiceSettings = deserializeAws_restJson1VoiceSettings(data.voiceSettings, context);
@@ -3237,13 +3240,13 @@ export const deserializeAws_restJson1CreateBotVersionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.botId !== undefined && data.botId !== null) {
-    contents.botId = data.botId;
+    contents.botId = __expectString(data.botId);
   }
   if (data.botStatus !== undefined && data.botStatus !== null) {
-    contents.botStatus = data.botStatus;
+    contents.botStatus = __expectString(data.botStatus);
   }
   if (data.botVersion !== undefined && data.botVersion !== null) {
-    contents.botVersion = data.botVersion;
+    contents.botVersion = __expectString(data.botVersion);
   }
   if (data.botVersionLocaleSpecification !== undefined && data.botVersionLocaleSpecification !== null) {
     contents.botVersionLocaleSpecification = deserializeAws_restJson1BotVersionLocaleSpecification(
@@ -3255,7 +3258,7 @@ export const deserializeAws_restJson1CreateBotVersionCommand = async (
     contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   return Promise.resolve(contents);
 };
@@ -3357,13 +3360,13 @@ export const deserializeAws_restJson1CreateExportCommand = async (
     contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
   }
   if (data.exportId !== undefined && data.exportId !== null) {
-    contents.exportId = data.exportId;
+    contents.exportId = __expectString(data.exportId);
   }
   if (data.exportStatus !== undefined && data.exportStatus !== null) {
-    contents.exportStatus = data.exportStatus;
+    contents.exportStatus = __expectString(data.exportStatus);
   }
   if (data.fileFormat !== undefined && data.fileFormat !== null) {
-    contents.fileFormat = data.fileFormat;
+    contents.fileFormat = __expectString(data.fileFormat);
   }
   if (data.resourceSpecification !== undefined && data.resourceSpecification !== null) {
     contents.resourceSpecification = deserializeAws_restJson1ExportResourceSpecification(
@@ -3479,16 +3482,16 @@ export const deserializeAws_restJson1CreateIntentCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.botId !== undefined && data.botId !== null) {
-    contents.botId = data.botId;
+    contents.botId = __expectString(data.botId);
   }
   if (data.botVersion !== undefined && data.botVersion !== null) {
-    contents.botVersion = data.botVersion;
+    contents.botVersion = __expectString(data.botVersion);
   }
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
     contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.dialogCodeHook !== undefined && data.dialogCodeHook !== null) {
     contents.dialogCodeHook = deserializeAws_restJson1DialogCodeHookSettings(data.dialogCodeHook, context);
@@ -3512,22 +3515,22 @@ export const deserializeAws_restJson1CreateIntentCommand = async (
     );
   }
   if (data.intentId !== undefined && data.intentId !== null) {
-    contents.intentId = data.intentId;
+    contents.intentId = __expectString(data.intentId);
   }
   if (data.intentName !== undefined && data.intentName !== null) {
-    contents.intentName = data.intentName;
+    contents.intentName = __expectString(data.intentName);
   }
   if (data.kendraConfiguration !== undefined && data.kendraConfiguration !== null) {
     contents.kendraConfiguration = deserializeAws_restJson1KendraConfiguration(data.kendraConfiguration, context);
   }
   if (data.localeId !== undefined && data.localeId !== null) {
-    contents.localeId = data.localeId;
+    contents.localeId = __expectString(data.localeId);
   }
   if (data.outputContexts !== undefined && data.outputContexts !== null) {
     contents.outputContexts = deserializeAws_restJson1OutputContextsList(data.outputContexts, context);
   }
   if (data.parentIntentSignature !== undefined && data.parentIntentSignature !== null) {
-    contents.parentIntentSignature = data.parentIntentSignature;
+    contents.parentIntentSignature = __expectString(data.parentIntentSignature);
   }
   if (data.sampleUtterances !== undefined && data.sampleUtterances !== null) {
     contents.sampleUtterances = deserializeAws_restJson1SampleUtterancesList(data.sampleUtterances, context);
@@ -3626,10 +3629,10 @@ export const deserializeAws_restJson1CreateResourcePolicyCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.resourceArn !== undefined && data.resourceArn !== null) {
-    contents.resourceArn = data.resourceArn;
+    contents.resourceArn = __expectString(data.resourceArn);
   }
   if (data.revisionId !== undefined && data.revisionId !== null) {
-    contents.revisionId = data.revisionId;
+    contents.revisionId = __expectString(data.revisionId);
   }
   return Promise.resolve(contents);
 };
@@ -3725,10 +3728,10 @@ export const deserializeAws_restJson1CreateResourcePolicyStatementCommand = asyn
   };
   const data: any = await parseBody(output.body, context);
   if (data.resourceArn !== undefined && data.resourceArn !== null) {
-    contents.resourceArn = data.resourceArn;
+    contents.resourceArn = __expectString(data.resourceArn);
   }
   if (data.revisionId !== undefined && data.revisionId !== null) {
-    contents.revisionId = data.revisionId;
+    contents.revisionId = __expectString(data.revisionId);
   }
   return Promise.resolve(contents);
 };
@@ -3842,22 +3845,22 @@ export const deserializeAws_restJson1CreateSlotCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.botId !== undefined && data.botId !== null) {
-    contents.botId = data.botId;
+    contents.botId = __expectString(data.botId);
   }
   if (data.botVersion !== undefined && data.botVersion !== null) {
-    contents.botVersion = data.botVersion;
+    contents.botVersion = __expectString(data.botVersion);
   }
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
     contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.intentId !== undefined && data.intentId !== null) {
-    contents.intentId = data.intentId;
+    contents.intentId = __expectString(data.intentId);
   }
   if (data.localeId !== undefined && data.localeId !== null) {
-    contents.localeId = data.localeId;
+    contents.localeId = __expectString(data.localeId);
   }
   if (data.multipleValuesSetting !== undefined && data.multipleValuesSetting !== null) {
     contents.multipleValuesSetting = deserializeAws_restJson1MultipleValuesSetting(data.multipleValuesSetting, context);
@@ -3866,13 +3869,13 @@ export const deserializeAws_restJson1CreateSlotCommand = async (
     contents.obfuscationSetting = deserializeAws_restJson1ObfuscationSetting(data.obfuscationSetting, context);
   }
   if (data.slotId !== undefined && data.slotId !== null) {
-    contents.slotId = data.slotId;
+    contents.slotId = __expectString(data.slotId);
   }
   if (data.slotName !== undefined && data.slotName !== null) {
-    contents.slotName = data.slotName;
+    contents.slotName = __expectString(data.slotName);
   }
   if (data.slotTypeId !== undefined && data.slotTypeId !== null) {
-    contents.slotTypeId = data.slotTypeId;
+    contents.slotTypeId = __expectString(data.slotTypeId);
   }
   if (data.valueElicitationSetting !== undefined && data.valueElicitationSetting !== null) {
     contents.valueElicitationSetting = deserializeAws_restJson1SlotValueElicitationSetting(
@@ -3982,28 +3985,28 @@ export const deserializeAws_restJson1CreateSlotTypeCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.botId !== undefined && data.botId !== null) {
-    contents.botId = data.botId;
+    contents.botId = __expectString(data.botId);
   }
   if (data.botVersion !== undefined && data.botVersion !== null) {
-    contents.botVersion = data.botVersion;
+    contents.botVersion = __expectString(data.botVersion);
   }
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
     contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.localeId !== undefined && data.localeId !== null) {
-    contents.localeId = data.localeId;
+    contents.localeId = __expectString(data.localeId);
   }
   if (data.parentSlotTypeSignature !== undefined && data.parentSlotTypeSignature !== null) {
-    contents.parentSlotTypeSignature = data.parentSlotTypeSignature;
+    contents.parentSlotTypeSignature = __expectString(data.parentSlotTypeSignature);
   }
   if (data.slotTypeId !== undefined && data.slotTypeId !== null) {
-    contents.slotTypeId = data.slotTypeId;
+    contents.slotTypeId = __expectString(data.slotTypeId);
   }
   if (data.slotTypeName !== undefined && data.slotTypeName !== null) {
-    contents.slotTypeName = data.slotTypeName;
+    contents.slotTypeName = __expectString(data.slotTypeName);
   }
   if (data.slotTypeValues !== undefined && data.slotTypeValues !== null) {
     contents.slotTypeValues = deserializeAws_restJson1SlotTypeValues(data.slotTypeValues, context);
@@ -4108,10 +4111,10 @@ export const deserializeAws_restJson1CreateUploadUrlCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.importId !== undefined && data.importId !== null) {
-    contents.importId = data.importId;
+    contents.importId = __expectString(data.importId);
   }
   if (data.uploadUrl !== undefined && data.uploadUrl !== null) {
-    contents.uploadUrl = data.uploadUrl;
+    contents.uploadUrl = __expectString(data.uploadUrl);
   }
   return Promise.resolve(contents);
 };
@@ -4199,10 +4202,10 @@ export const deserializeAws_restJson1DeleteBotCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.botId !== undefined && data.botId !== null) {
-    contents.botId = data.botId;
+    contents.botId = __expectString(data.botId);
   }
   if (data.botStatus !== undefined && data.botStatus !== null) {
-    contents.botStatus = data.botStatus;
+    contents.botStatus = __expectString(data.botStatus);
   }
   return Promise.resolve(contents);
 };
@@ -4299,13 +4302,13 @@ export const deserializeAws_restJson1DeleteBotAliasCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.botAliasId !== undefined && data.botAliasId !== null) {
-    contents.botAliasId = data.botAliasId;
+    contents.botAliasId = __expectString(data.botAliasId);
   }
   if (data.botAliasStatus !== undefined && data.botAliasStatus !== null) {
-    contents.botAliasStatus = data.botAliasStatus;
+    contents.botAliasStatus = __expectString(data.botAliasStatus);
   }
   if (data.botId !== undefined && data.botId !== null) {
-    contents.botId = data.botId;
+    contents.botId = __expectString(data.botId);
   }
   return Promise.resolve(contents);
 };
@@ -4403,16 +4406,16 @@ export const deserializeAws_restJson1DeleteBotLocaleCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.botId !== undefined && data.botId !== null) {
-    contents.botId = data.botId;
+    contents.botId = __expectString(data.botId);
   }
   if (data.botLocaleStatus !== undefined && data.botLocaleStatus !== null) {
-    contents.botLocaleStatus = data.botLocaleStatus;
+    contents.botLocaleStatus = __expectString(data.botLocaleStatus);
   }
   if (data.botVersion !== undefined && data.botVersion !== null) {
-    contents.botVersion = data.botVersion;
+    contents.botVersion = __expectString(data.botVersion);
   }
   if (data.localeId !== undefined && data.localeId !== null) {
-    contents.localeId = data.localeId;
+    contents.localeId = __expectString(data.localeId);
   }
   return Promise.resolve(contents);
 };
@@ -4509,13 +4512,13 @@ export const deserializeAws_restJson1DeleteBotVersionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.botId !== undefined && data.botId !== null) {
-    contents.botId = data.botId;
+    contents.botId = __expectString(data.botId);
   }
   if (data.botStatus !== undefined && data.botStatus !== null) {
-    contents.botStatus = data.botStatus;
+    contents.botStatus = __expectString(data.botStatus);
   }
   if (data.botVersion !== undefined && data.botVersion !== null) {
-    contents.botVersion = data.botVersion;
+    contents.botVersion = __expectString(data.botVersion);
   }
   return Promise.resolve(contents);
 };
@@ -4611,10 +4614,10 @@ export const deserializeAws_restJson1DeleteExportCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.exportId !== undefined && data.exportId !== null) {
-    contents.exportId = data.exportId;
+    contents.exportId = __expectString(data.exportId);
   }
   if (data.exportStatus !== undefined && data.exportStatus !== null) {
-    contents.exportStatus = data.exportStatus;
+    contents.exportStatus = __expectString(data.exportStatus);
   }
   return Promise.resolve(contents);
 };
@@ -4702,10 +4705,10 @@ export const deserializeAws_restJson1DeleteImportCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.importId !== undefined && data.importId !== null) {
-    contents.importId = data.importId;
+    contents.importId = __expectString(data.importId);
   }
   if (data.importStatus !== undefined && data.importStatus !== null) {
-    contents.importStatus = data.importStatus;
+    contents.importStatus = __expectString(data.importStatus);
   }
   return Promise.resolve(contents);
 };
@@ -4884,10 +4887,10 @@ export const deserializeAws_restJson1DeleteResourcePolicyCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.resourceArn !== undefined && data.resourceArn !== null) {
-    contents.resourceArn = data.resourceArn;
+    contents.resourceArn = __expectString(data.resourceArn);
   }
   if (data.revisionId !== undefined && data.revisionId !== null) {
-    contents.revisionId = data.revisionId;
+    contents.revisionId = __expectString(data.revisionId);
   }
   return Promise.resolve(contents);
 };
@@ -4967,10 +4970,10 @@ export const deserializeAws_restJson1DeleteResourcePolicyStatementCommand = asyn
   };
   const data: any = await parseBody(output.body, context);
   if (data.resourceArn !== undefined && data.resourceArn !== null) {
-    contents.resourceArn = data.resourceArn;
+    contents.resourceArn = __expectString(data.resourceArn);
   }
   if (data.revisionId !== undefined && data.revisionId !== null) {
-    contents.revisionId = data.revisionId;
+    contents.revisionId = __expectString(data.revisionId);
   }
   return Promise.resolve(contents);
 };
@@ -5239,13 +5242,13 @@ export const deserializeAws_restJson1DescribeBotCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.botId !== undefined && data.botId !== null) {
-    contents.botId = data.botId;
+    contents.botId = __expectString(data.botId);
   }
   if (data.botName !== undefined && data.botName !== null) {
-    contents.botName = data.botName;
+    contents.botName = __expectString(data.botName);
   }
   if (data.botStatus !== undefined && data.botStatus !== null) {
-    contents.botStatus = data.botStatus;
+    contents.botStatus = __expectString(data.botStatus);
   }
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
     contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
@@ -5254,16 +5257,16 @@ export const deserializeAws_restJson1DescribeBotCommand = async (
     contents.dataPrivacy = deserializeAws_restJson1DataPrivacy(data.dataPrivacy, context);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.idleSessionTTLInSeconds !== undefined && data.idleSessionTTLInSeconds !== null) {
-    contents.idleSessionTTLInSeconds = data.idleSessionTTLInSeconds;
+    contents.idleSessionTTLInSeconds = __expectNumber(data.idleSessionTTLInSeconds);
   }
   if (data.lastUpdatedDateTime !== undefined && data.lastUpdatedDateTime !== null) {
     contents.lastUpdatedDateTime = new Date(Math.round(data.lastUpdatedDateTime * 1000));
   }
   if (data.roleArn !== undefined && data.roleArn !== null) {
-    contents.roleArn = data.roleArn;
+    contents.roleArn = __expectString(data.roleArn);
   }
   return Promise.resolve(contents);
 };
@@ -5367,7 +5370,7 @@ export const deserializeAws_restJson1DescribeBotAliasCommand = async (
     );
   }
   if (data.botAliasId !== undefined && data.botAliasId !== null) {
-    contents.botAliasId = data.botAliasId;
+    contents.botAliasId = __expectString(data.botAliasId);
   }
   if (data.botAliasLocaleSettings !== undefined && data.botAliasLocaleSettings !== null) {
     contents.botAliasLocaleSettings = deserializeAws_restJson1BotAliasLocaleSettingsMap(
@@ -5376,16 +5379,16 @@ export const deserializeAws_restJson1DescribeBotAliasCommand = async (
     );
   }
   if (data.botAliasName !== undefined && data.botAliasName !== null) {
-    contents.botAliasName = data.botAliasName;
+    contents.botAliasName = __expectString(data.botAliasName);
   }
   if (data.botAliasStatus !== undefined && data.botAliasStatus !== null) {
-    contents.botAliasStatus = data.botAliasStatus;
+    contents.botAliasStatus = __expectString(data.botAliasStatus);
   }
   if (data.botId !== undefined && data.botId !== null) {
-    contents.botId = data.botId;
+    contents.botId = __expectString(data.botId);
   }
   if (data.botVersion !== undefined && data.botVersion !== null) {
-    contents.botVersion = data.botVersion;
+    contents.botVersion = __expectString(data.botVersion);
   }
   if (data.conversationLogSettings !== undefined && data.conversationLogSettings !== null) {
     contents.conversationLogSettings = deserializeAws_restJson1ConversationLogSettings(
@@ -5397,7 +5400,7 @@ export const deserializeAws_restJson1DescribeBotAliasCommand = async (
     contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.lastUpdatedDateTime !== undefined && data.lastUpdatedDateTime !== null) {
     contents.lastUpdatedDateTime = new Date(Math.round(data.lastUpdatedDateTime * 1000));
@@ -5507,7 +5510,7 @@ export const deserializeAws_restJson1DescribeBotLocaleCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.botId !== undefined && data.botId !== null) {
-    contents.botId = data.botId;
+    contents.botId = __expectString(data.botId);
   }
   if (data.botLocaleHistoryEvents !== undefined && data.botLocaleHistoryEvents !== null) {
     contents.botLocaleHistoryEvents = deserializeAws_restJson1BotLocaleHistoryEventsList(
@@ -5516,22 +5519,22 @@ export const deserializeAws_restJson1DescribeBotLocaleCommand = async (
     );
   }
   if (data.botLocaleStatus !== undefined && data.botLocaleStatus !== null) {
-    contents.botLocaleStatus = data.botLocaleStatus;
+    contents.botLocaleStatus = __expectString(data.botLocaleStatus);
   }
   if (data.botVersion !== undefined && data.botVersion !== null) {
-    contents.botVersion = data.botVersion;
+    contents.botVersion = __expectString(data.botVersion);
   }
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
     contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.failureReasons !== undefined && data.failureReasons !== null) {
     contents.failureReasons = deserializeAws_restJson1FailureReasons(data.failureReasons, context);
   }
   if (data.intentsCount !== undefined && data.intentsCount !== null) {
-    contents.intentsCount = data.intentsCount;
+    contents.intentsCount = __expectNumber(data.intentsCount);
   }
   if (data.lastBuildSubmittedDateTime !== undefined && data.lastBuildSubmittedDateTime !== null) {
     contents.lastBuildSubmittedDateTime = new Date(Math.round(data.lastBuildSubmittedDateTime * 1000));
@@ -5540,16 +5543,16 @@ export const deserializeAws_restJson1DescribeBotLocaleCommand = async (
     contents.lastUpdatedDateTime = new Date(Math.round(data.lastUpdatedDateTime * 1000));
   }
   if (data.localeId !== undefined && data.localeId !== null) {
-    contents.localeId = data.localeId;
+    contents.localeId = __expectString(data.localeId);
   }
   if (data.localeName !== undefined && data.localeName !== null) {
-    contents.localeName = data.localeName;
+    contents.localeName = __expectString(data.localeName);
   }
   if (data.nluIntentConfidenceThreshold !== undefined && data.nluIntentConfidenceThreshold !== null) {
-    contents.nluIntentConfidenceThreshold = data.nluIntentConfidenceThreshold;
+    contents.nluIntentConfidenceThreshold = __expectNumber(data.nluIntentConfidenceThreshold);
   }
   if (data.slotTypesCount !== undefined && data.slotTypesCount !== null) {
-    contents.slotTypesCount = data.slotTypesCount;
+    contents.slotTypesCount = __expectNumber(data.slotTypesCount);
   }
   if (data.voiceSettings !== undefined && data.voiceSettings !== null) {
     contents.voiceSettings = deserializeAws_restJson1VoiceSettings(data.voiceSettings, context);
@@ -5648,16 +5651,16 @@ export const deserializeAws_restJson1DescribeBotVersionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.botId !== undefined && data.botId !== null) {
-    contents.botId = data.botId;
+    contents.botId = __expectString(data.botId);
   }
   if (data.botName !== undefined && data.botName !== null) {
-    contents.botName = data.botName;
+    contents.botName = __expectString(data.botName);
   }
   if (data.botStatus !== undefined && data.botStatus !== null) {
-    contents.botStatus = data.botStatus;
+    contents.botStatus = __expectString(data.botStatus);
   }
   if (data.botVersion !== undefined && data.botVersion !== null) {
-    contents.botVersion = data.botVersion;
+    contents.botVersion = __expectString(data.botVersion);
   }
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
     contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
@@ -5666,16 +5669,16 @@ export const deserializeAws_restJson1DescribeBotVersionCommand = async (
     contents.dataPrivacy = deserializeAws_restJson1DataPrivacy(data.dataPrivacy, context);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.failureReasons !== undefined && data.failureReasons !== null) {
     contents.failureReasons = deserializeAws_restJson1FailureReasons(data.failureReasons, context);
   }
   if (data.idleSessionTTLInSeconds !== undefined && data.idleSessionTTLInSeconds !== null) {
-    contents.idleSessionTTLInSeconds = data.idleSessionTTLInSeconds;
+    contents.idleSessionTTLInSeconds = __expectNumber(data.idleSessionTTLInSeconds);
   }
   if (data.roleArn !== undefined && data.roleArn !== null) {
-    contents.roleArn = data.roleArn;
+    contents.roleArn = __expectString(data.roleArn);
   }
   return Promise.resolve(contents);
 };
@@ -5772,19 +5775,19 @@ export const deserializeAws_restJson1DescribeExportCommand = async (
     contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
   }
   if (data.downloadUrl !== undefined && data.downloadUrl !== null) {
-    contents.downloadUrl = data.downloadUrl;
+    contents.downloadUrl = __expectString(data.downloadUrl);
   }
   if (data.exportId !== undefined && data.exportId !== null) {
-    contents.exportId = data.exportId;
+    contents.exportId = __expectString(data.exportId);
   }
   if (data.exportStatus !== undefined && data.exportStatus !== null) {
-    contents.exportStatus = data.exportStatus;
+    contents.exportStatus = __expectString(data.exportStatus);
   }
   if (data.failureReasons !== undefined && data.failureReasons !== null) {
     contents.failureReasons = deserializeAws_restJson1FailureReasons(data.failureReasons, context);
   }
   if (data.fileFormat !== undefined && data.fileFormat !== null) {
-    contents.fileFormat = data.fileFormat;
+    contents.fileFormat = __expectString(data.fileFormat);
   }
   if (data.lastUpdatedDateTime !== undefined && data.lastUpdatedDateTime !== null) {
     contents.lastUpdatedDateTime = new Date(Math.round(data.lastUpdatedDateTime * 1000));
@@ -5886,22 +5889,22 @@ export const deserializeAws_restJson1DescribeImportCommand = async (
     contents.failureReasons = deserializeAws_restJson1FailureReasons(data.failureReasons, context);
   }
   if (data.importId !== undefined && data.importId !== null) {
-    contents.importId = data.importId;
+    contents.importId = __expectString(data.importId);
   }
   if (data.importStatus !== undefined && data.importStatus !== null) {
-    contents.importStatus = data.importStatus;
+    contents.importStatus = __expectString(data.importStatus);
   }
   if (data.importedResourceId !== undefined && data.importedResourceId !== null) {
-    contents.importedResourceId = data.importedResourceId;
+    contents.importedResourceId = __expectString(data.importedResourceId);
   }
   if (data.importedResourceName !== undefined && data.importedResourceName !== null) {
-    contents.importedResourceName = data.importedResourceName;
+    contents.importedResourceName = __expectString(data.importedResourceName);
   }
   if (data.lastUpdatedDateTime !== undefined && data.lastUpdatedDateTime !== null) {
     contents.lastUpdatedDateTime = new Date(Math.round(data.lastUpdatedDateTime * 1000));
   }
   if (data.mergeStrategy !== undefined && data.mergeStrategy !== null) {
-    contents.mergeStrategy = data.mergeStrategy;
+    contents.mergeStrategy = __expectString(data.mergeStrategy);
   }
   if (data.resourceSpecification !== undefined && data.resourceSpecification !== null) {
     contents.resourceSpecification = deserializeAws_restJson1ImportResourceSpecification(
@@ -6003,16 +6006,16 @@ export const deserializeAws_restJson1DescribeIntentCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.botId !== undefined && data.botId !== null) {
-    contents.botId = data.botId;
+    contents.botId = __expectString(data.botId);
   }
   if (data.botVersion !== undefined && data.botVersion !== null) {
-    contents.botVersion = data.botVersion;
+    contents.botVersion = __expectString(data.botVersion);
   }
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
     contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.dialogCodeHook !== undefined && data.dialogCodeHook !== null) {
     contents.dialogCodeHook = deserializeAws_restJson1DialogCodeHookSettings(data.dialogCodeHook, context);
@@ -6036,10 +6039,10 @@ export const deserializeAws_restJson1DescribeIntentCommand = async (
     );
   }
   if (data.intentId !== undefined && data.intentId !== null) {
-    contents.intentId = data.intentId;
+    contents.intentId = __expectString(data.intentId);
   }
   if (data.intentName !== undefined && data.intentName !== null) {
-    contents.intentName = data.intentName;
+    contents.intentName = __expectString(data.intentName);
   }
   if (data.kendraConfiguration !== undefined && data.kendraConfiguration !== null) {
     contents.kendraConfiguration = deserializeAws_restJson1KendraConfiguration(data.kendraConfiguration, context);
@@ -6048,13 +6051,13 @@ export const deserializeAws_restJson1DescribeIntentCommand = async (
     contents.lastUpdatedDateTime = new Date(Math.round(data.lastUpdatedDateTime * 1000));
   }
   if (data.localeId !== undefined && data.localeId !== null) {
-    contents.localeId = data.localeId;
+    contents.localeId = __expectString(data.localeId);
   }
   if (data.outputContexts !== undefined && data.outputContexts !== null) {
     contents.outputContexts = deserializeAws_restJson1OutputContextsList(data.outputContexts, context);
   }
   if (data.parentIntentSignature !== undefined && data.parentIntentSignature !== null) {
-    contents.parentIntentSignature = data.parentIntentSignature;
+    contents.parentIntentSignature = __expectString(data.parentIntentSignature);
   }
   if (data.sampleUtterances !== undefined && data.sampleUtterances !== null) {
     contents.sampleUtterances = deserializeAws_restJson1SampleUtterancesList(data.sampleUtterances, context);
@@ -6149,13 +6152,13 @@ export const deserializeAws_restJson1DescribeResourcePolicyCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.policy !== undefined && data.policy !== null) {
-    contents.policy = data.policy;
+    contents.policy = __expectString(data.policy);
   }
   if (data.resourceArn !== undefined && data.resourceArn !== null) {
-    contents.resourceArn = data.resourceArn;
+    contents.resourceArn = __expectString(data.resourceArn);
   }
   if (data.revisionId !== undefined && data.revisionId !== null) {
-    contents.revisionId = data.revisionId;
+    contents.revisionId = __expectString(data.revisionId);
   }
   return Promise.resolve(contents);
 };
@@ -6238,25 +6241,25 @@ export const deserializeAws_restJson1DescribeSlotCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.botId !== undefined && data.botId !== null) {
-    contents.botId = data.botId;
+    contents.botId = __expectString(data.botId);
   }
   if (data.botVersion !== undefined && data.botVersion !== null) {
-    contents.botVersion = data.botVersion;
+    contents.botVersion = __expectString(data.botVersion);
   }
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
     contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.intentId !== undefined && data.intentId !== null) {
-    contents.intentId = data.intentId;
+    contents.intentId = __expectString(data.intentId);
   }
   if (data.lastUpdatedDateTime !== undefined && data.lastUpdatedDateTime !== null) {
     contents.lastUpdatedDateTime = new Date(Math.round(data.lastUpdatedDateTime * 1000));
   }
   if (data.localeId !== undefined && data.localeId !== null) {
-    contents.localeId = data.localeId;
+    contents.localeId = __expectString(data.localeId);
   }
   if (data.multipleValuesSetting !== undefined && data.multipleValuesSetting !== null) {
     contents.multipleValuesSetting = deserializeAws_restJson1MultipleValuesSetting(data.multipleValuesSetting, context);
@@ -6265,13 +6268,13 @@ export const deserializeAws_restJson1DescribeSlotCommand = async (
     contents.obfuscationSetting = deserializeAws_restJson1ObfuscationSetting(data.obfuscationSetting, context);
   }
   if (data.slotId !== undefined && data.slotId !== null) {
-    contents.slotId = data.slotId;
+    contents.slotId = __expectString(data.slotId);
   }
   if (data.slotName !== undefined && data.slotName !== null) {
-    contents.slotName = data.slotName;
+    contents.slotName = __expectString(data.slotName);
   }
   if (data.slotTypeId !== undefined && data.slotTypeId !== null) {
-    contents.slotTypeId = data.slotTypeId;
+    contents.slotTypeId = __expectString(data.slotTypeId);
   }
   if (data.valueElicitationSetting !== undefined && data.valueElicitationSetting !== null) {
     contents.valueElicitationSetting = deserializeAws_restJson1SlotValueElicitationSetting(
@@ -6374,31 +6377,31 @@ export const deserializeAws_restJson1DescribeSlotTypeCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.botId !== undefined && data.botId !== null) {
-    contents.botId = data.botId;
+    contents.botId = __expectString(data.botId);
   }
   if (data.botVersion !== undefined && data.botVersion !== null) {
-    contents.botVersion = data.botVersion;
+    contents.botVersion = __expectString(data.botVersion);
   }
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
     contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.lastUpdatedDateTime !== undefined && data.lastUpdatedDateTime !== null) {
     contents.lastUpdatedDateTime = new Date(Math.round(data.lastUpdatedDateTime * 1000));
   }
   if (data.localeId !== undefined && data.localeId !== null) {
-    contents.localeId = data.localeId;
+    contents.localeId = __expectString(data.localeId);
   }
   if (data.parentSlotTypeSignature !== undefined && data.parentSlotTypeSignature !== null) {
-    contents.parentSlotTypeSignature = data.parentSlotTypeSignature;
+    contents.parentSlotTypeSignature = __expectString(data.parentSlotTypeSignature);
   }
   if (data.slotTypeId !== undefined && data.slotTypeId !== null) {
-    contents.slotTypeId = data.slotTypeId;
+    contents.slotTypeId = __expectString(data.slotTypeId);
   }
   if (data.slotTypeName !== undefined && data.slotTypeName !== null) {
-    contents.slotTypeName = data.slotTypeName;
+    contents.slotTypeName = __expectString(data.slotTypeName);
   }
   if (data.slotTypeValues !== undefined && data.slotTypeValues !== null) {
     contents.slotTypeValues = deserializeAws_restJson1SlotTypeValues(data.slotTypeValues, context);
@@ -6499,10 +6502,10 @@ export const deserializeAws_restJson1ListBotAliasesCommand = async (
     contents.botAliasSummaries = deserializeAws_restJson1BotAliasSummaryList(data.botAliasSummaries, context);
   }
   if (data.botId !== undefined && data.botId !== null) {
-    contents.botId = data.botId;
+    contents.botId = __expectString(data.botId);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -6584,16 +6587,16 @@ export const deserializeAws_restJson1ListBotLocalesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.botId !== undefined && data.botId !== null) {
-    contents.botId = data.botId;
+    contents.botId = __expectString(data.botId);
   }
   if (data.botLocaleSummaries !== undefined && data.botLocaleSummaries !== null) {
     contents.botLocaleSummaries = deserializeAws_restJson1BotLocaleSummaryList(data.botLocaleSummaries, context);
   }
   if (data.botVersion !== undefined && data.botVersion !== null) {
-    contents.botVersion = data.botVersion;
+    contents.botVersion = __expectString(data.botVersion);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -6676,7 +6679,7 @@ export const deserializeAws_restJson1ListBotsCommand = async (
     contents.botSummaries = deserializeAws_restJson1BotSummaryList(data.botSummaries, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -6757,13 +6760,13 @@ export const deserializeAws_restJson1ListBotVersionsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.botId !== undefined && data.botId !== null) {
-    contents.botId = data.botId;
+    contents.botId = __expectString(data.botId);
   }
   if (data.botVersionSummaries !== undefined && data.botVersionSummaries !== null) {
     contents.botVersionSummaries = deserializeAws_restJson1BotVersionSummaryList(data.botVersionSummaries, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -6850,10 +6853,10 @@ export const deserializeAws_restJson1ListBuiltInIntentsCommand = async (
     );
   }
   if (data.localeId !== undefined && data.localeId !== null) {
-    contents.localeId = data.localeId;
+    contents.localeId = __expectString(data.localeId);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -6940,10 +6943,10 @@ export const deserializeAws_restJson1ListBuiltInSlotTypesCommand = async (
     );
   }
   if (data.localeId !== undefined && data.localeId !== null) {
-    contents.localeId = data.localeId;
+    contents.localeId = __expectString(data.localeId);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -7025,16 +7028,16 @@ export const deserializeAws_restJson1ListExportsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.botId !== undefined && data.botId !== null) {
-    contents.botId = data.botId;
+    contents.botId = __expectString(data.botId);
   }
   if (data.botVersion !== undefined && data.botVersion !== null) {
-    contents.botVersion = data.botVersion;
+    contents.botVersion = __expectString(data.botVersion);
   }
   if (data.exportSummaries !== undefined && data.exportSummaries !== null) {
     contents.exportSummaries = deserializeAws_restJson1ExportSummaryList(data.exportSummaries, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -7108,16 +7111,16 @@ export const deserializeAws_restJson1ListImportsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.botId !== undefined && data.botId !== null) {
-    contents.botId = data.botId;
+    contents.botId = __expectString(data.botId);
   }
   if (data.botVersion !== undefined && data.botVersion !== null) {
-    contents.botVersion = data.botVersion;
+    contents.botVersion = __expectString(data.botVersion);
   }
   if (data.importSummaries !== undefined && data.importSummaries !== null) {
     contents.importSummaries = deserializeAws_restJson1ImportSummaryList(data.importSummaries, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -7192,19 +7195,19 @@ export const deserializeAws_restJson1ListIntentsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.botId !== undefined && data.botId !== null) {
-    contents.botId = data.botId;
+    contents.botId = __expectString(data.botId);
   }
   if (data.botVersion !== undefined && data.botVersion !== null) {
-    contents.botVersion = data.botVersion;
+    contents.botVersion = __expectString(data.botVersion);
   }
   if (data.intentSummaries !== undefined && data.intentSummaries !== null) {
     contents.intentSummaries = deserializeAws_restJson1IntentSummaryList(data.intentSummaries, context);
   }
   if (data.localeId !== undefined && data.localeId !== null) {
-    contents.localeId = data.localeId;
+    contents.localeId = __expectString(data.localeId);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -7288,19 +7291,19 @@ export const deserializeAws_restJson1ListSlotsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.botId !== undefined && data.botId !== null) {
-    contents.botId = data.botId;
+    contents.botId = __expectString(data.botId);
   }
   if (data.botVersion !== undefined && data.botVersion !== null) {
-    contents.botVersion = data.botVersion;
+    contents.botVersion = __expectString(data.botVersion);
   }
   if (data.intentId !== undefined && data.intentId !== null) {
-    contents.intentId = data.intentId;
+    contents.intentId = __expectString(data.intentId);
   }
   if (data.localeId !== undefined && data.localeId !== null) {
-    contents.localeId = data.localeId;
+    contents.localeId = __expectString(data.localeId);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.slotSummaries !== undefined && data.slotSummaries !== null) {
     contents.slotSummaries = deserializeAws_restJson1SlotSummaryList(data.slotSummaries, context);
@@ -7386,16 +7389,16 @@ export const deserializeAws_restJson1ListSlotTypesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.botId !== undefined && data.botId !== null) {
-    contents.botId = data.botId;
+    contents.botId = __expectString(data.botId);
   }
   if (data.botVersion !== undefined && data.botVersion !== null) {
-    contents.botVersion = data.botVersion;
+    contents.botVersion = __expectString(data.botVersion);
   }
   if (data.localeId !== undefined && data.localeId !== null) {
-    contents.localeId = data.localeId;
+    contents.localeId = __expectString(data.localeId);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.slotTypeSummaries !== undefined && data.slotTypeSummaries !== null) {
     contents.slotTypeSummaries = deserializeAws_restJson1SlotTypeSummaryList(data.slotTypeSummaries, context);
@@ -7563,13 +7566,13 @@ export const deserializeAws_restJson1StartImportCommand = async (
     contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
   }
   if (data.importId !== undefined && data.importId !== null) {
-    contents.importId = data.importId;
+    contents.importId = __expectString(data.importId);
   }
   if (data.importStatus !== undefined && data.importStatus !== null) {
-    contents.importStatus = data.importStatus;
+    contents.importStatus = __expectString(data.importStatus);
   }
   if (data.mergeStrategy !== undefined && data.mergeStrategy !== null) {
-    contents.mergeStrategy = data.mergeStrategy;
+    contents.mergeStrategy = __expectString(data.mergeStrategy);
   }
   if (data.resourceSpecification !== undefined && data.resourceSpecification !== null) {
     contents.resourceSpecification = deserializeAws_restJson1ImportResourceSpecification(
@@ -7828,13 +7831,13 @@ export const deserializeAws_restJson1UpdateBotCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.botId !== undefined && data.botId !== null) {
-    contents.botId = data.botId;
+    contents.botId = __expectString(data.botId);
   }
   if (data.botName !== undefined && data.botName !== null) {
-    contents.botName = data.botName;
+    contents.botName = __expectString(data.botName);
   }
   if (data.botStatus !== undefined && data.botStatus !== null) {
-    contents.botStatus = data.botStatus;
+    contents.botStatus = __expectString(data.botStatus);
   }
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
     contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
@@ -7843,16 +7846,16 @@ export const deserializeAws_restJson1UpdateBotCommand = async (
     contents.dataPrivacy = deserializeAws_restJson1DataPrivacy(data.dataPrivacy, context);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.idleSessionTTLInSeconds !== undefined && data.idleSessionTTLInSeconds !== null) {
-    contents.idleSessionTTLInSeconds = data.idleSessionTTLInSeconds;
+    contents.idleSessionTTLInSeconds = __expectNumber(data.idleSessionTTLInSeconds);
   }
   if (data.lastUpdatedDateTime !== undefined && data.lastUpdatedDateTime !== null) {
     contents.lastUpdatedDateTime = new Date(Math.round(data.lastUpdatedDateTime * 1000));
   }
   if (data.roleArn !== undefined && data.roleArn !== null) {
-    contents.roleArn = data.roleArn;
+    contents.roleArn = __expectString(data.roleArn);
   }
   return Promise.resolve(contents);
 };
@@ -7957,7 +7960,7 @@ export const deserializeAws_restJson1UpdateBotAliasCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.botAliasId !== undefined && data.botAliasId !== null) {
-    contents.botAliasId = data.botAliasId;
+    contents.botAliasId = __expectString(data.botAliasId);
   }
   if (data.botAliasLocaleSettings !== undefined && data.botAliasLocaleSettings !== null) {
     contents.botAliasLocaleSettings = deserializeAws_restJson1BotAliasLocaleSettingsMap(
@@ -7966,16 +7969,16 @@ export const deserializeAws_restJson1UpdateBotAliasCommand = async (
     );
   }
   if (data.botAliasName !== undefined && data.botAliasName !== null) {
-    contents.botAliasName = data.botAliasName;
+    contents.botAliasName = __expectString(data.botAliasName);
   }
   if (data.botAliasStatus !== undefined && data.botAliasStatus !== null) {
-    contents.botAliasStatus = data.botAliasStatus;
+    contents.botAliasStatus = __expectString(data.botAliasStatus);
   }
   if (data.botId !== undefined && data.botId !== null) {
-    contents.botId = data.botId;
+    contents.botId = __expectString(data.botId);
   }
   if (data.botVersion !== undefined && data.botVersion !== null) {
-    contents.botVersion = data.botVersion;
+    contents.botVersion = __expectString(data.botVersion);
   }
   if (data.conversationLogSettings !== undefined && data.conversationLogSettings !== null) {
     contents.conversationLogSettings = deserializeAws_restJson1ConversationLogSettings(
@@ -7987,7 +7990,7 @@ export const deserializeAws_restJson1UpdateBotAliasCommand = async (
     contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.lastUpdatedDateTime !== undefined && data.lastUpdatedDateTime !== null) {
     contents.lastUpdatedDateTime = new Date(Math.round(data.lastUpdatedDateTime * 1000));
@@ -8101,19 +8104,19 @@ export const deserializeAws_restJson1UpdateBotLocaleCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.botId !== undefined && data.botId !== null) {
-    contents.botId = data.botId;
+    contents.botId = __expectString(data.botId);
   }
   if (data.botLocaleStatus !== undefined && data.botLocaleStatus !== null) {
-    contents.botLocaleStatus = data.botLocaleStatus;
+    contents.botLocaleStatus = __expectString(data.botLocaleStatus);
   }
   if (data.botVersion !== undefined && data.botVersion !== null) {
-    contents.botVersion = data.botVersion;
+    contents.botVersion = __expectString(data.botVersion);
   }
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
     contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.failureReasons !== undefined && data.failureReasons !== null) {
     contents.failureReasons = deserializeAws_restJson1FailureReasons(data.failureReasons, context);
@@ -8122,13 +8125,13 @@ export const deserializeAws_restJson1UpdateBotLocaleCommand = async (
     contents.lastUpdatedDateTime = new Date(Math.round(data.lastUpdatedDateTime * 1000));
   }
   if (data.localeId !== undefined && data.localeId !== null) {
-    contents.localeId = data.localeId;
+    contents.localeId = __expectString(data.localeId);
   }
   if (data.localeName !== undefined && data.localeName !== null) {
-    contents.localeName = data.localeName;
+    contents.localeName = __expectString(data.localeName);
   }
   if (data.nluIntentConfidenceThreshold !== undefined && data.nluIntentConfidenceThreshold !== null) {
-    contents.nluIntentConfidenceThreshold = data.nluIntentConfidenceThreshold;
+    contents.nluIntentConfidenceThreshold = __expectNumber(data.nluIntentConfidenceThreshold);
   }
   if (data.voiceSettings !== undefined && data.voiceSettings !== null) {
     contents.voiceSettings = deserializeAws_restJson1VoiceSettings(data.voiceSettings, context);
@@ -8234,13 +8237,13 @@ export const deserializeAws_restJson1UpdateExportCommand = async (
     contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
   }
   if (data.exportId !== undefined && data.exportId !== null) {
-    contents.exportId = data.exportId;
+    contents.exportId = __expectString(data.exportId);
   }
   if (data.exportStatus !== undefined && data.exportStatus !== null) {
-    contents.exportStatus = data.exportStatus;
+    contents.exportStatus = __expectString(data.exportStatus);
   }
   if (data.fileFormat !== undefined && data.fileFormat !== null) {
-    contents.fileFormat = data.fileFormat;
+    contents.fileFormat = __expectString(data.fileFormat);
   }
   if (data.lastUpdatedDateTime !== undefined && data.lastUpdatedDateTime !== null) {
     contents.lastUpdatedDateTime = new Date(Math.round(data.lastUpdatedDateTime * 1000));
@@ -8361,16 +8364,16 @@ export const deserializeAws_restJson1UpdateIntentCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.botId !== undefined && data.botId !== null) {
-    contents.botId = data.botId;
+    contents.botId = __expectString(data.botId);
   }
   if (data.botVersion !== undefined && data.botVersion !== null) {
-    contents.botVersion = data.botVersion;
+    contents.botVersion = __expectString(data.botVersion);
   }
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
     contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.dialogCodeHook !== undefined && data.dialogCodeHook !== null) {
     contents.dialogCodeHook = deserializeAws_restJson1DialogCodeHookSettings(data.dialogCodeHook, context);
@@ -8394,10 +8397,10 @@ export const deserializeAws_restJson1UpdateIntentCommand = async (
     );
   }
   if (data.intentId !== undefined && data.intentId !== null) {
-    contents.intentId = data.intentId;
+    contents.intentId = __expectString(data.intentId);
   }
   if (data.intentName !== undefined && data.intentName !== null) {
-    contents.intentName = data.intentName;
+    contents.intentName = __expectString(data.intentName);
   }
   if (data.kendraConfiguration !== undefined && data.kendraConfiguration !== null) {
     contents.kendraConfiguration = deserializeAws_restJson1KendraConfiguration(data.kendraConfiguration, context);
@@ -8406,13 +8409,13 @@ export const deserializeAws_restJson1UpdateIntentCommand = async (
     contents.lastUpdatedDateTime = new Date(Math.round(data.lastUpdatedDateTime * 1000));
   }
   if (data.localeId !== undefined && data.localeId !== null) {
-    contents.localeId = data.localeId;
+    contents.localeId = __expectString(data.localeId);
   }
   if (data.outputContexts !== undefined && data.outputContexts !== null) {
     contents.outputContexts = deserializeAws_restJson1OutputContextsList(data.outputContexts, context);
   }
   if (data.parentIntentSignature !== undefined && data.parentIntentSignature !== null) {
-    contents.parentIntentSignature = data.parentIntentSignature;
+    contents.parentIntentSignature = __expectString(data.parentIntentSignature);
   }
   if (data.sampleUtterances !== undefined && data.sampleUtterances !== null) {
     contents.sampleUtterances = deserializeAws_restJson1SampleUtterancesList(data.sampleUtterances, context);
@@ -8514,10 +8517,10 @@ export const deserializeAws_restJson1UpdateResourcePolicyCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.resourceArn !== undefined && data.resourceArn !== null) {
-    contents.resourceArn = data.resourceArn;
+    contents.resourceArn = __expectString(data.resourceArn);
   }
   if (data.revisionId !== undefined && data.revisionId !== null) {
-    contents.revisionId = data.revisionId;
+    contents.revisionId = __expectString(data.revisionId);
   }
   return Promise.resolve(contents);
 };
@@ -8624,25 +8627,25 @@ export const deserializeAws_restJson1UpdateSlotCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.botId !== undefined && data.botId !== null) {
-    contents.botId = data.botId;
+    contents.botId = __expectString(data.botId);
   }
   if (data.botVersion !== undefined && data.botVersion !== null) {
-    contents.botVersion = data.botVersion;
+    contents.botVersion = __expectString(data.botVersion);
   }
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
     contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.intentId !== undefined && data.intentId !== null) {
-    contents.intentId = data.intentId;
+    contents.intentId = __expectString(data.intentId);
   }
   if (data.lastUpdatedDateTime !== undefined && data.lastUpdatedDateTime !== null) {
     contents.lastUpdatedDateTime = new Date(Math.round(data.lastUpdatedDateTime * 1000));
   }
   if (data.localeId !== undefined && data.localeId !== null) {
-    contents.localeId = data.localeId;
+    contents.localeId = __expectString(data.localeId);
   }
   if (data.multipleValuesSetting !== undefined && data.multipleValuesSetting !== null) {
     contents.multipleValuesSetting = deserializeAws_restJson1MultipleValuesSetting(data.multipleValuesSetting, context);
@@ -8651,13 +8654,13 @@ export const deserializeAws_restJson1UpdateSlotCommand = async (
     contents.obfuscationSetting = deserializeAws_restJson1ObfuscationSetting(data.obfuscationSetting, context);
   }
   if (data.slotId !== undefined && data.slotId !== null) {
-    contents.slotId = data.slotId;
+    contents.slotId = __expectString(data.slotId);
   }
   if (data.slotName !== undefined && data.slotName !== null) {
-    contents.slotName = data.slotName;
+    contents.slotName = __expectString(data.slotName);
   }
   if (data.slotTypeId !== undefined && data.slotTypeId !== null) {
-    contents.slotTypeId = data.slotTypeId;
+    contents.slotTypeId = __expectString(data.slotTypeId);
   }
   if (data.valueElicitationSetting !== undefined && data.valueElicitationSetting !== null) {
     contents.valueElicitationSetting = deserializeAws_restJson1SlotValueElicitationSetting(
@@ -8768,31 +8771,31 @@ export const deserializeAws_restJson1UpdateSlotTypeCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.botId !== undefined && data.botId !== null) {
-    contents.botId = data.botId;
+    contents.botId = __expectString(data.botId);
   }
   if (data.botVersion !== undefined && data.botVersion !== null) {
-    contents.botVersion = data.botVersion;
+    contents.botVersion = __expectString(data.botVersion);
   }
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
     contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.lastUpdatedDateTime !== undefined && data.lastUpdatedDateTime !== null) {
     contents.lastUpdatedDateTime = new Date(Math.round(data.lastUpdatedDateTime * 1000));
   }
   if (data.localeId !== undefined && data.localeId !== null) {
-    contents.localeId = data.localeId;
+    contents.localeId = __expectString(data.localeId);
   }
   if (data.parentSlotTypeSignature !== undefined && data.parentSlotTypeSignature !== null) {
-    contents.parentSlotTypeSignature = data.parentSlotTypeSignature;
+    contents.parentSlotTypeSignature = __expectString(data.parentSlotTypeSignature);
   }
   if (data.slotTypeId !== undefined && data.slotTypeId !== null) {
-    contents.slotTypeId = data.slotTypeId;
+    contents.slotTypeId = __expectString(data.slotTypeId);
   }
   if (data.slotTypeName !== undefined && data.slotTypeName !== null) {
-    contents.slotTypeName = data.slotTypeName;
+    contents.slotTypeName = __expectString(data.slotTypeName);
   }
   if (data.slotTypeValues !== undefined && data.slotTypeValues !== null) {
     contents.slotTypeValues = deserializeAws_restJson1SlotTypeValues(data.slotTypeValues, context);
@@ -8895,7 +8898,7 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -8912,7 +8915,7 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -8929,7 +8932,7 @@ const deserializeAws_restJson1PreconditionFailedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -8946,7 +8949,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -8963,7 +8966,7 @@ const deserializeAws_restJson1ServiceQuotaExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -8984,7 +8987,7 @@ const deserializeAws_restJson1ThrottlingExceptionResponse = async (
   }
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -9001,7 +9004,7 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -10006,7 +10009,7 @@ const deserializeAws_restJson1AudioLogSetting = (output: any, context: __SerdeCo
       output.destination !== undefined && output.destination !== null
         ? deserializeAws_restJson1AudioLogDestination(output.destination, context)
         : undefined,
-    enabled: output.enabled !== undefined && output.enabled !== null ? output.enabled : undefined,
+    enabled: __expectBoolean(output.enabled),
   } as any;
 };
 
@@ -10023,7 +10026,7 @@ const deserializeAws_restJson1AudioLogSettingsList = (output: any, context: __Se
 
 const deserializeAws_restJson1BotAliasHistoryEvent = (output: any, context: __SerdeContext): BotAliasHistoryEvent => {
   return {
-    botVersion: output.botVersion !== undefined && output.botVersion !== null ? output.botVersion : undefined,
+    botVersion: __expectString(output.botVersion),
     endDate:
       output.endDate !== undefined && output.endDate !== null ? new Date(Math.round(output.endDate * 1000)) : undefined,
     startDate:
@@ -10056,7 +10059,7 @@ const deserializeAws_restJson1BotAliasLocaleSettings = (
       output.codeHookSpecification !== undefined && output.codeHookSpecification !== null
         ? deserializeAws_restJson1CodeHookSpecification(output.codeHookSpecification, context)
         : undefined,
-    enabled: output.enabled !== undefined && output.enabled !== null ? output.enabled : undefined,
+    enabled: __expectBoolean(output.enabled),
   } as any;
 };
 
@@ -10080,16 +10083,15 @@ const deserializeAws_restJson1BotAliasLocaleSettingsMap = (
 
 const deserializeAws_restJson1BotAliasSummary = (output: any, context: __SerdeContext): BotAliasSummary => {
   return {
-    botAliasId: output.botAliasId !== undefined && output.botAliasId !== null ? output.botAliasId : undefined,
-    botAliasName: output.botAliasName !== undefined && output.botAliasName !== null ? output.botAliasName : undefined,
-    botAliasStatus:
-      output.botAliasStatus !== undefined && output.botAliasStatus !== null ? output.botAliasStatus : undefined,
-    botVersion: output.botVersion !== undefined && output.botVersion !== null ? output.botVersion : undefined,
+    botAliasId: __expectString(output.botAliasId),
+    botAliasName: __expectString(output.botAliasName),
+    botAliasStatus: __expectString(output.botAliasStatus),
+    botVersion: __expectString(output.botVersion),
     creationDateTime:
       output.creationDateTime !== undefined && output.creationDateTime !== null
         ? new Date(Math.round(output.creationDateTime * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    description: __expectString(output.description),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
         ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
@@ -10113,8 +10115,8 @@ const deserializeAws_restJson1BotExportSpecification = (
   context: __SerdeContext
 ): BotExportSpecification => {
   return {
-    botId: output.botId !== undefined && output.botId !== null ? output.botId : undefined,
-    botVersion: output.botVersion !== undefined && output.botVersion !== null ? output.botVersion : undefined,
+    botId: __expectString(output.botId),
+    botVersion: __expectString(output.botVersion),
   } as any;
 };
 
@@ -10123,7 +10125,7 @@ const deserializeAws_restJson1BotImportSpecification = (
   context: __SerdeContext
 ): BotImportSpecification => {
   return {
-    botName: output.botName !== undefined && output.botName !== null ? output.botName : undefined,
+    botName: __expectString(output.botName),
     botTags:
       output.botTags !== undefined && output.botTags !== null
         ? deserializeAws_restJson1TagMap(output.botTags, context)
@@ -10132,11 +10134,8 @@ const deserializeAws_restJson1BotImportSpecification = (
       output.dataPrivacy !== undefined && output.dataPrivacy !== null
         ? deserializeAws_restJson1DataPrivacy(output.dataPrivacy, context)
         : undefined,
-    idleSessionTTLInSeconds:
-      output.idleSessionTTLInSeconds !== undefined && output.idleSessionTTLInSeconds !== null
-        ? output.idleSessionTTLInSeconds
-        : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
+    idleSessionTTLInSeconds: __expectNumber(output.idleSessionTTLInSeconds),
+    roleArn: __expectString(output.roleArn),
     testBotAliasTags:
       output.testBotAliasTags !== undefined && output.testBotAliasTags !== null
         ? deserializeAws_restJson1TagMap(output.testBotAliasTags, context)
@@ -10149,15 +10148,15 @@ const deserializeAws_restJson1BotLocaleExportSpecification = (
   context: __SerdeContext
 ): BotLocaleExportSpecification => {
   return {
-    botId: output.botId !== undefined && output.botId !== null ? output.botId : undefined,
-    botVersion: output.botVersion !== undefined && output.botVersion !== null ? output.botVersion : undefined,
-    localeId: output.localeId !== undefined && output.localeId !== null ? output.localeId : undefined,
+    botId: __expectString(output.botId),
+    botVersion: __expectString(output.botVersion),
+    localeId: __expectString(output.localeId),
   } as any;
 };
 
 const deserializeAws_restJson1BotLocaleHistoryEvent = (output: any, context: __SerdeContext): BotLocaleHistoryEvent => {
   return {
-    event: output.event !== undefined && output.event !== null ? output.event : undefined,
+    event: __expectString(output.event),
     eventDate:
       output.eventDate !== undefined && output.eventDate !== null
         ? new Date(Math.round(output.eventDate * 1000))
@@ -10184,13 +10183,10 @@ const deserializeAws_restJson1BotLocaleImportSpecification = (
   context: __SerdeContext
 ): BotLocaleImportSpecification => {
   return {
-    botId: output.botId !== undefined && output.botId !== null ? output.botId : undefined,
-    botVersion: output.botVersion !== undefined && output.botVersion !== null ? output.botVersion : undefined,
-    localeId: output.localeId !== undefined && output.localeId !== null ? output.localeId : undefined,
-    nluIntentConfidenceThreshold:
-      output.nluIntentConfidenceThreshold !== undefined && output.nluIntentConfidenceThreshold !== null
-        ? output.nluIntentConfidenceThreshold
-        : undefined,
+    botId: __expectString(output.botId),
+    botVersion: __expectString(output.botVersion),
+    localeId: __expectString(output.localeId),
+    nluIntentConfidenceThreshold: __expectNumber(output.nluIntentConfidenceThreshold),
     voiceSettings:
       output.voiceSettings !== undefined && output.voiceSettings !== null
         ? deserializeAws_restJson1VoiceSettings(output.voiceSettings, context)
@@ -10200,9 +10196,8 @@ const deserializeAws_restJson1BotLocaleImportSpecification = (
 
 const deserializeAws_restJson1BotLocaleSummary = (output: any, context: __SerdeContext): BotLocaleSummary => {
   return {
-    botLocaleStatus:
-      output.botLocaleStatus !== undefined && output.botLocaleStatus !== null ? output.botLocaleStatus : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    botLocaleStatus: __expectString(output.botLocaleStatus),
+    description: __expectString(output.description),
     lastBuildSubmittedDateTime:
       output.lastBuildSubmittedDateTime !== undefined && output.lastBuildSubmittedDateTime !== null
         ? new Date(Math.round(output.lastBuildSubmittedDateTime * 1000))
@@ -10211,8 +10206,8 @@ const deserializeAws_restJson1BotLocaleSummary = (output: any, context: __SerdeC
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
         ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
         : undefined,
-    localeId: output.localeId !== undefined && output.localeId !== null ? output.localeId : undefined,
-    localeName: output.localeName !== undefined && output.localeName !== null ? output.localeName : undefined,
+    localeId: __expectString(output.localeId),
+    localeName: __expectString(output.localeName),
   } as any;
 };
 
@@ -10229,16 +10224,15 @@ const deserializeAws_restJson1BotLocaleSummaryList = (output: any, context: __Se
 
 const deserializeAws_restJson1BotSummary = (output: any, context: __SerdeContext): BotSummary => {
   return {
-    botId: output.botId !== undefined && output.botId !== null ? output.botId : undefined,
-    botName: output.botName !== undefined && output.botName !== null ? output.botName : undefined,
-    botStatus: output.botStatus !== undefined && output.botStatus !== null ? output.botStatus : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    botId: __expectString(output.botId),
+    botName: __expectString(output.botName),
+    botStatus: __expectString(output.botStatus),
+    description: __expectString(output.description),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
         ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
         : undefined,
-    latestBotVersion:
-      output.latestBotVersion !== undefined && output.latestBotVersion !== null ? output.latestBotVersion : undefined,
+    latestBotVersion: __expectString(output.latestBotVersion),
   } as any;
 };
 
@@ -10258,8 +10252,7 @@ const deserializeAws_restJson1BotVersionLocaleDetails = (
   context: __SerdeContext
 ): BotVersionLocaleDetails => {
   return {
-    sourceBotVersion:
-      output.sourceBotVersion !== undefined && output.sourceBotVersion !== null ? output.sourceBotVersion : undefined,
+    sourceBotVersion: __expectString(output.sourceBotVersion),
   } as any;
 };
 
@@ -10283,14 +10276,14 @@ const deserializeAws_restJson1BotVersionLocaleSpecification = (
 
 const deserializeAws_restJson1BotVersionSummary = (output: any, context: __SerdeContext): BotVersionSummary => {
   return {
-    botName: output.botName !== undefined && output.botName !== null ? output.botName : undefined,
-    botStatus: output.botStatus !== undefined && output.botStatus !== null ? output.botStatus : undefined,
-    botVersion: output.botVersion !== undefined && output.botVersion !== null ? output.botVersion : undefined,
+    botName: __expectString(output.botName),
+    botStatus: __expectString(output.botStatus),
+    botVersion: __expectString(output.botVersion),
     creationDateTime:
       output.creationDateTime !== undefined && output.creationDateTime !== null
         ? new Date(Math.round(output.creationDateTime * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    description: __expectString(output.description),
   } as any;
 };
 
@@ -10307,9 +10300,8 @@ const deserializeAws_restJson1BotVersionSummaryList = (output: any, context: __S
 
 const deserializeAws_restJson1BuiltInIntentSummary = (output: any, context: __SerdeContext): BuiltInIntentSummary => {
   return {
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    intentSignature:
-      output.intentSignature !== undefined && output.intentSignature !== null ? output.intentSignature : undefined,
+    description: __expectString(output.description),
+    intentSignature: __expectString(output.intentSignature),
   } as any;
 };
 
@@ -10332,11 +10324,8 @@ const deserializeAws_restJson1BuiltInSlotTypeSummary = (
   context: __SerdeContext
 ): BuiltInSlotTypeSummary => {
   return {
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    slotTypeSignature:
-      output.slotTypeSignature !== undefined && output.slotTypeSignature !== null
-        ? output.slotTypeSignature
-        : undefined,
+    description: __expectString(output.description),
+    slotTypeSignature: __expectString(output.slotTypeSignature),
   } as any;
 };
 
@@ -10356,8 +10345,8 @@ const deserializeAws_restJson1BuiltInSlotTypeSummaryList = (
 
 const deserializeAws_restJson1Button = (output: any, context: __SerdeContext): Button => {
   return {
-    text: output.text !== undefined && output.text !== null ? output.text : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    text: __expectString(output.text),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -10377,11 +10366,8 @@ const deserializeAws_restJson1CloudWatchLogGroupLogDestination = (
   context: __SerdeContext
 ): CloudWatchLogGroupLogDestination => {
   return {
-    cloudWatchLogGroupArn:
-      output.cloudWatchLogGroupArn !== undefined && output.cloudWatchLogGroupArn !== null
-        ? output.cloudWatchLogGroupArn
-        : undefined,
-    logPrefix: output.logPrefix !== undefined && output.logPrefix !== null ? output.logPrefix : undefined,
+    cloudWatchLogGroupArn: __expectString(output.cloudWatchLogGroupArn),
+    logPrefix: __expectString(output.logPrefix),
   } as any;
 };
 
@@ -10412,14 +10398,13 @@ const deserializeAws_restJson1ConversationLogSettings = (
 
 const deserializeAws_restJson1CustomPayload = (output: any, context: __SerdeContext): CustomPayload => {
   return {
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    value: __expectString(output.value),
   } as any;
 };
 
 const deserializeAws_restJson1DataPrivacy = (output: any, context: __SerdeContext): DataPrivacy => {
   return {
-    childDirected:
-      output.childDirected !== undefined && output.childDirected !== null ? output.childDirected : undefined,
+    childDirected: __expectBoolean(output.childDirected),
   } as any;
 };
 
@@ -10428,7 +10413,7 @@ const deserializeAws_restJson1DialogCodeHookSettings = (
   context: __SerdeContext
 ): DialogCodeHookSettings => {
   return {
-    enabled: output.enabled !== undefined && output.enabled !== null ? output.enabled : undefined,
+    enabled: __expectBoolean(output.enabled),
   } as any;
 };
 
@@ -10454,9 +10439,9 @@ const deserializeAws_restJson1ExportSummary = (output: any, context: __SerdeCont
       output.creationDateTime !== undefined && output.creationDateTime !== null
         ? new Date(Math.round(output.creationDateTime * 1000))
         : undefined,
-    exportId: output.exportId !== undefined && output.exportId !== null ? output.exportId : undefined,
-    exportStatus: output.exportStatus !== undefined && output.exportStatus !== null ? output.exportStatus : undefined,
-    fileFormat: output.fileFormat !== undefined && output.fileFormat !== null ? output.fileFormat : undefined,
+    exportId: __expectString(output.exportId),
+    exportStatus: __expectString(output.exportStatus),
+    fileFormat: __expectString(output.fileFormat),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
         ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
@@ -10486,7 +10471,7 @@ const deserializeAws_restJson1FailureReasons = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -10495,7 +10480,7 @@ const deserializeAws_restJson1FulfillmentCodeHookSettings = (
   context: __SerdeContext
 ): FulfillmentCodeHookSettings => {
   return {
-    enabled: output.enabled !== undefined && output.enabled !== null ? output.enabled : undefined,
+    enabled: __expectBoolean(output.enabled),
   } as any;
 };
 
@@ -10505,9 +10490,9 @@ const deserializeAws_restJson1ImageResponseCard = (output: any, context: __Serde
       output.buttons !== undefined && output.buttons !== null
         ? deserializeAws_restJson1ButtonsList(output.buttons, context)
         : undefined,
-    imageUrl: output.imageUrl !== undefined && output.imageUrl !== null ? output.imageUrl : undefined,
-    subtitle: output.subtitle !== undefined && output.subtitle !== null ? output.subtitle : undefined,
-    title: output.title !== undefined && output.title !== null ? output.title : undefined,
+    imageUrl: __expectString(output.imageUrl),
+    subtitle: __expectString(output.subtitle),
+    title: __expectString(output.title),
   } as any;
 };
 
@@ -10533,22 +10518,15 @@ const deserializeAws_restJson1ImportSummary = (output: any, context: __SerdeCont
       output.creationDateTime !== undefined && output.creationDateTime !== null
         ? new Date(Math.round(output.creationDateTime * 1000))
         : undefined,
-    importId: output.importId !== undefined && output.importId !== null ? output.importId : undefined,
-    importStatus: output.importStatus !== undefined && output.importStatus !== null ? output.importStatus : undefined,
-    importedResourceId:
-      output.importedResourceId !== undefined && output.importedResourceId !== null
-        ? output.importedResourceId
-        : undefined,
-    importedResourceName:
-      output.importedResourceName !== undefined && output.importedResourceName !== null
-        ? output.importedResourceName
-        : undefined,
+    importId: __expectString(output.importId),
+    importStatus: __expectString(output.importStatus),
+    importedResourceId: __expectString(output.importedResourceId),
+    importedResourceName: __expectString(output.importedResourceName),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
         ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
         : undefined,
-    mergeStrategy:
-      output.mergeStrategy !== undefined && output.mergeStrategy !== null ? output.mergeStrategy : undefined,
+    mergeStrategy: __expectString(output.mergeStrategy),
   } as any;
 };
 
@@ -10565,7 +10543,7 @@ const deserializeAws_restJson1ImportSummaryList = (output: any, context: __Serde
 
 const deserializeAws_restJson1InputContext = (output: any, context: __SerdeContext): InputContext => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -10607,13 +10585,13 @@ const deserializeAws_restJson1IntentConfirmationSetting = (
 
 const deserializeAws_restJson1IntentSummary = (output: any, context: __SerdeContext): IntentSummary => {
   return {
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    description: __expectString(output.description),
     inputContexts:
       output.inputContexts !== undefined && output.inputContexts !== null
         ? deserializeAws_restJson1InputContextsList(output.inputContexts, context)
         : undefined,
-    intentId: output.intentId !== undefined && output.intentId !== null ? output.intentId : undefined,
-    intentName: output.intentName !== undefined && output.intentName !== null ? output.intentName : undefined,
+    intentId: __expectString(output.intentId),
+    intentName: __expectString(output.intentName),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
         ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
@@ -10622,10 +10600,7 @@ const deserializeAws_restJson1IntentSummary = (output: any, context: __SerdeCont
       output.outputContexts !== undefined && output.outputContexts !== null
         ? deserializeAws_restJson1OutputContextsList(output.outputContexts, context)
         : undefined,
-    parentIntentSignature:
-      output.parentIntentSignature !== undefined && output.parentIntentSignature !== null
-        ? output.parentIntentSignature
-        : undefined,
+    parentIntentSignature: __expectString(output.parentIntentSignature),
   } as any;
 };
 
@@ -10642,25 +10617,16 @@ const deserializeAws_restJson1IntentSummaryList = (output: any, context: __Serde
 
 const deserializeAws_restJson1KendraConfiguration = (output: any, context: __SerdeContext): KendraConfiguration => {
   return {
-    kendraIndex: output.kendraIndex !== undefined && output.kendraIndex !== null ? output.kendraIndex : undefined,
-    queryFilterString:
-      output.queryFilterString !== undefined && output.queryFilterString !== null
-        ? output.queryFilterString
-        : undefined,
-    queryFilterStringEnabled:
-      output.queryFilterStringEnabled !== undefined && output.queryFilterStringEnabled !== null
-        ? output.queryFilterStringEnabled
-        : undefined,
+    kendraIndex: __expectString(output.kendraIndex),
+    queryFilterString: __expectString(output.queryFilterString),
+    queryFilterStringEnabled: __expectBoolean(output.queryFilterStringEnabled),
   } as any;
 };
 
 const deserializeAws_restJson1LambdaCodeHook = (output: any, context: __SerdeContext): LambdaCodeHook => {
   return {
-    codeHookInterfaceVersion:
-      output.codeHookInterfaceVersion !== undefined && output.codeHookInterfaceVersion !== null
-        ? output.codeHookInterfaceVersion
-        : undefined,
-    lambdaARN: output.lambdaARN !== undefined && output.lambdaARN !== null ? output.lambdaARN : undefined,
+    codeHookInterfaceVersion: __expectString(output.codeHookInterfaceVersion),
+    lambdaARN: __expectString(output.lambdaARN),
   } as any;
 };
 
@@ -10722,30 +10688,21 @@ const deserializeAws_restJson1MessageVariationsList = (output: any, context: __S
 
 const deserializeAws_restJson1MultipleValuesSetting = (output: any, context: __SerdeContext): MultipleValuesSetting => {
   return {
-    allowMultipleValues:
-      output.allowMultipleValues !== undefined && output.allowMultipleValues !== null
-        ? output.allowMultipleValues
-        : undefined,
+    allowMultipleValues: __expectBoolean(output.allowMultipleValues),
   } as any;
 };
 
 const deserializeAws_restJson1ObfuscationSetting = (output: any, context: __SerdeContext): ObfuscationSetting => {
   return {
-    obfuscationSettingType:
-      output.obfuscationSettingType !== undefined && output.obfuscationSettingType !== null
-        ? output.obfuscationSettingType
-        : undefined,
+    obfuscationSettingType: __expectString(output.obfuscationSettingType),
   } as any;
 };
 
 const deserializeAws_restJson1OutputContext = (output: any, context: __SerdeContext): OutputContext => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    timeToLiveInSeconds:
-      output.timeToLiveInSeconds !== undefined && output.timeToLiveInSeconds !== null
-        ? output.timeToLiveInSeconds
-        : undefined,
-    turnsToLive: output.turnsToLive !== undefined && output.turnsToLive !== null ? output.turnsToLive : undefined,
+    name: __expectString(output.name),
+    timeToLiveInSeconds: __expectNumber(output.timeToLiveInSeconds),
+    turnsToLive: __expectNumber(output.turnsToLive),
   } as any;
 };
 
@@ -10762,15 +10719,14 @@ const deserializeAws_restJson1OutputContextsList = (output: any, context: __Serd
 
 const deserializeAws_restJson1PlainTextMessage = (output: any, context: __SerdeContext): PlainTextMessage => {
   return {
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    value: __expectString(output.value),
   } as any;
 };
 
 const deserializeAws_restJson1PromptSpecification = (output: any, context: __SerdeContext): PromptSpecification => {
   return {
-    allowInterrupt:
-      output.allowInterrupt !== undefined && output.allowInterrupt !== null ? output.allowInterrupt : undefined,
-    maxRetries: output.maxRetries !== undefined && output.maxRetries !== null ? output.maxRetries : undefined,
+    allowInterrupt: __expectBoolean(output.allowInterrupt),
+    maxRetries: __expectNumber(output.maxRetries),
     messageGroups:
       output.messageGroups !== undefined && output.messageGroups !== null
         ? deserializeAws_restJson1MessageGroupsList(output.messageGroups, context)
@@ -10780,8 +10736,7 @@ const deserializeAws_restJson1PromptSpecification = (output: any, context: __Ser
 
 const deserializeAws_restJson1ResponseSpecification = (output: any, context: __SerdeContext): ResponseSpecification => {
   return {
-    allowInterrupt:
-      output.allowInterrupt !== undefined && output.allowInterrupt !== null ? output.allowInterrupt : undefined,
+    allowInterrupt: __expectBoolean(output.allowInterrupt),
     messageGroups:
       output.messageGroups !== undefined && output.messageGroups !== null
         ? deserializeAws_restJson1MessageGroupsList(output.messageGroups, context)
@@ -10794,15 +10749,15 @@ const deserializeAws_restJson1S3BucketLogDestination = (
   context: __SerdeContext
 ): S3BucketLogDestination => {
   return {
-    kmsKeyArn: output.kmsKeyArn !== undefined && output.kmsKeyArn !== null ? output.kmsKeyArn : undefined,
-    logPrefix: output.logPrefix !== undefined && output.logPrefix !== null ? output.logPrefix : undefined,
-    s3BucketArn: output.s3BucketArn !== undefined && output.s3BucketArn !== null ? output.s3BucketArn : undefined,
+    kmsKeyArn: __expectString(output.kmsKeyArn),
+    logPrefix: __expectString(output.logPrefix),
+    s3BucketArn: __expectString(output.s3BucketArn),
   } as any;
 };
 
 const deserializeAws_restJson1SampleUtterance = (output: any, context: __SerdeContext): SampleUtterance => {
   return {
-    utterance: output.utterance !== undefined && output.utterance !== null ? output.utterance : undefined,
+    utterance: __expectString(output.utterance),
   } as any;
 };
 
@@ -10819,7 +10774,7 @@ const deserializeAws_restJson1SampleUtterancesList = (output: any, context: __Se
 
 const deserializeAws_restJson1SampleValue = (output: any, context: __SerdeContext): SampleValue => {
   return {
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -10828,14 +10783,13 @@ const deserializeAws_restJson1SentimentAnalysisSettings = (
   context: __SerdeContext
 ): SentimentAnalysisSettings => {
   return {
-    detectSentiment:
-      output.detectSentiment !== undefined && output.detectSentiment !== null ? output.detectSentiment : undefined,
+    detectSentiment: __expectBoolean(output.detectSentiment),
   } as any;
 };
 
 const deserializeAws_restJson1SlotDefaultValue = (output: any, context: __SerdeContext): SlotDefaultValue => {
   return {
-    defaultValue: output.defaultValue !== undefined && output.defaultValue !== null ? output.defaultValue : undefined,
+    defaultValue: __expectString(output.defaultValue),
   } as any;
 };
 
@@ -10875,23 +10829,22 @@ const deserializeAws_restJson1SlotPrioritiesList = (output: any, context: __Serd
 
 const deserializeAws_restJson1SlotPriority = (output: any, context: __SerdeContext): SlotPriority => {
   return {
-    priority: output.priority !== undefined && output.priority !== null ? output.priority : undefined,
-    slotId: output.slotId !== undefined && output.slotId !== null ? output.slotId : undefined,
+    priority: __expectNumber(output.priority),
+    slotId: __expectString(output.slotId),
   } as any;
 };
 
 const deserializeAws_restJson1SlotSummary = (output: any, context: __SerdeContext): SlotSummary => {
   return {
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    description: __expectString(output.description),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
         ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
         : undefined,
-    slotConstraint:
-      output.slotConstraint !== undefined && output.slotConstraint !== null ? output.slotConstraint : undefined,
-    slotId: output.slotId !== undefined && output.slotId !== null ? output.slotId : undefined,
-    slotName: output.slotName !== undefined && output.slotName !== null ? output.slotName : undefined,
-    slotTypeId: output.slotTypeId !== undefined && output.slotTypeId !== null ? output.slotTypeId : undefined,
+    slotConstraint: __expectString(output.slotConstraint),
+    slotId: __expectString(output.slotId),
+    slotName: __expectString(output.slotName),
+    slotTypeId: __expectString(output.slotTypeId),
     valueElicitationPromptSpecification:
       output.valueElicitationPromptSpecification !== undefined && output.valueElicitationPromptSpecification !== null
         ? deserializeAws_restJson1PromptSpecification(output.valueElicitationPromptSpecification, context)
@@ -10912,17 +10865,14 @@ const deserializeAws_restJson1SlotSummaryList = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1SlotTypeSummary = (output: any, context: __SerdeContext): SlotTypeSummary => {
   return {
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    description: __expectString(output.description),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
         ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
         : undefined,
-    parentSlotTypeSignature:
-      output.parentSlotTypeSignature !== undefined && output.parentSlotTypeSignature !== null
-        ? output.parentSlotTypeSignature
-        : undefined,
-    slotTypeId: output.slotTypeId !== undefined && output.slotTypeId !== null ? output.slotTypeId : undefined,
-    slotTypeName: output.slotTypeName !== undefined && output.slotTypeName !== null ? output.slotTypeName : undefined,
+    parentSlotTypeSignature: __expectString(output.parentSlotTypeSignature),
+    slotTypeId: __expectString(output.slotTypeId),
+    slotTypeName: __expectString(output.slotTypeName),
   } as any;
 };
 
@@ -10978,8 +10928,7 @@ const deserializeAws_restJson1SlotValueElicitationSetting = (
       output.sampleUtterances !== undefined && output.sampleUtterances !== null
         ? deserializeAws_restJson1SampleUtterancesList(output.sampleUtterances, context)
         : undefined,
-    slotConstraint:
-      output.slotConstraint !== undefined && output.slotConstraint !== null ? output.slotConstraint : undefined,
+    slotConstraint: __expectString(output.slotConstraint),
     waitAndContinueSpecification:
       output.waitAndContinueSpecification !== undefined && output.waitAndContinueSpecification !== null
         ? deserializeAws_restJson1WaitAndContinueSpecification(output.waitAndContinueSpecification, context)
@@ -10989,7 +10938,7 @@ const deserializeAws_restJson1SlotValueElicitationSetting = (
 
 const deserializeAws_restJson1SlotValueRegexFilter = (output: any, context: __SerdeContext): SlotValueRegexFilter => {
   return {
-    pattern: output.pattern !== undefined && output.pattern !== null ? output.pattern : undefined,
+    pattern: __expectString(output.pattern),
   } as any;
 };
 
@@ -11002,16 +10951,13 @@ const deserializeAws_restJson1SlotValueSelectionSetting = (
       output.regexFilter !== undefined && output.regexFilter !== null
         ? deserializeAws_restJson1SlotValueRegexFilter(output.regexFilter, context)
         : undefined,
-    resolutionStrategy:
-      output.resolutionStrategy !== undefined && output.resolutionStrategy !== null
-        ? output.resolutionStrategy
-        : undefined,
+    resolutionStrategy: __expectString(output.resolutionStrategy),
   } as any;
 };
 
 const deserializeAws_restJson1SSMLMessage = (output: any, context: __SerdeContext): SSMLMessage => {
   return {
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -11020,18 +10966,13 @@ const deserializeAws_restJson1StillWaitingResponseSpecification = (
   context: __SerdeContext
 ): StillWaitingResponseSpecification => {
   return {
-    allowInterrupt:
-      output.allowInterrupt !== undefined && output.allowInterrupt !== null ? output.allowInterrupt : undefined,
-    frequencyInSeconds:
-      output.frequencyInSeconds !== undefined && output.frequencyInSeconds !== null
-        ? output.frequencyInSeconds
-        : undefined,
+    allowInterrupt: __expectBoolean(output.allowInterrupt),
+    frequencyInSeconds: __expectNumber(output.frequencyInSeconds),
     messageGroups:
       output.messageGroups !== undefined && output.messageGroups !== null
         ? deserializeAws_restJson1MessageGroupsList(output.messageGroups, context)
         : undefined,
-    timeoutInSeconds:
-      output.timeoutInSeconds !== undefined && output.timeoutInSeconds !== null ? output.timeoutInSeconds : undefined,
+    timeoutInSeconds: __expectNumber(output.timeoutInSeconds),
   } as any;
 };
 
@@ -11053,7 +10994,7 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -11073,7 +11014,7 @@ const deserializeAws_restJson1TextLogSetting = (output: any, context: __SerdeCon
       output.destination !== undefined && output.destination !== null
         ? deserializeAws_restJson1TextLogDestination(output.destination, context)
         : undefined,
-    enabled: output.enabled !== undefined && output.enabled !== null ? output.enabled : undefined,
+    enabled: __expectBoolean(output.enabled),
   } as any;
 };
 
@@ -11090,7 +11031,7 @@ const deserializeAws_restJson1TextLogSettingsList = (output: any, context: __Ser
 
 const deserializeAws_restJson1VoiceSettings = (output: any, context: __SerdeContext): VoiceSettings => {
   return {
-    voiceId: output.voiceId !== undefined && output.voiceId !== null ? output.voiceId : undefined,
+    voiceId: __expectString(output.voiceId),
   } as any;
 };
 

--- a/clients/client-lex-runtime-service/protocols/Aws_restJson1.ts
+++ b/clients/client-lex-runtime-service/protocols/Aws_restJson1.ts
@@ -30,6 +30,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   LazyJsonString as __LazyJsonString,
   SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -346,16 +348,16 @@ export const deserializeAws_restJson1DeleteSessionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.botAlias !== undefined && data.botAlias !== null) {
-    contents.botAlias = data.botAlias;
+    contents.botAlias = __expectString(data.botAlias);
   }
   if (data.botName !== undefined && data.botName !== null) {
-    contents.botName = data.botName;
+    contents.botName = __expectString(data.botName);
   }
   if (data.sessionId !== undefined && data.sessionId !== null) {
-    contents.sessionId = data.sessionId;
+    contents.sessionId = __expectString(data.sessionId);
   }
   if (data.userId !== undefined && data.userId !== null) {
-    contents.userId = data.userId;
+    contents.userId = __expectString(data.userId);
   }
   return Promise.resolve(contents);
 };
@@ -458,7 +460,7 @@ export const deserializeAws_restJson1GetSessionCommand = async (
     contents.sessionAttributes = deserializeAws_restJson1StringMap(data.sessionAttributes, context);
   }
   if (data.sessionId !== undefined && data.sessionId !== null) {
-    contents.sessionId = data.sessionId;
+    contents.sessionId = __expectString(data.sessionId);
   }
   return Promise.resolve(contents);
 };
@@ -765,19 +767,19 @@ export const deserializeAws_restJson1PostTextCommand = async (
     contents.alternativeIntents = deserializeAws_restJson1IntentList(data.alternativeIntents, context);
   }
   if (data.botVersion !== undefined && data.botVersion !== null) {
-    contents.botVersion = data.botVersion;
+    contents.botVersion = __expectString(data.botVersion);
   }
   if (data.dialogState !== undefined && data.dialogState !== null) {
-    contents.dialogState = data.dialogState;
+    contents.dialogState = __expectString(data.dialogState);
   }
   if (data.intentName !== undefined && data.intentName !== null) {
-    contents.intentName = data.intentName;
+    contents.intentName = __expectString(data.intentName);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.messageFormat !== undefined && data.messageFormat !== null) {
-    contents.messageFormat = data.messageFormat;
+    contents.messageFormat = __expectString(data.messageFormat);
   }
   if (data.nluIntentConfidence !== undefined && data.nluIntentConfidence !== null) {
     contents.nluIntentConfidence = deserializeAws_restJson1IntentConfidence(data.nluIntentConfidence, context);
@@ -792,10 +794,10 @@ export const deserializeAws_restJson1PostTextCommand = async (
     contents.sessionAttributes = deserializeAws_restJson1StringMap(data.sessionAttributes, context);
   }
   if (data.sessionId !== undefined && data.sessionId !== null) {
-    contents.sessionId = data.sessionId;
+    contents.sessionId = __expectString(data.sessionId);
   }
   if (data.slotToElicit !== undefined && data.slotToElicit !== null) {
-    contents.slotToElicit = data.slotToElicit;
+    contents.slotToElicit = __expectString(data.slotToElicit);
   }
   if (data.slots !== undefined && data.slots !== null) {
     contents.slots = deserializeAws_restJson1StringMap(data.slots, context);
@@ -1065,7 +1067,7 @@ const deserializeAws_restJson1BadGatewayExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1082,7 +1084,7 @@ const deserializeAws_restJson1BadRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1099,7 +1101,7 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1116,7 +1118,7 @@ const deserializeAws_restJson1DependencyFailedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1133,7 +1135,7 @@ const deserializeAws_restJson1InternalFailureExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1154,7 +1156,7 @@ const deserializeAws_restJson1LimitExceededExceptionResponse = async (
   }
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1171,7 +1173,7 @@ const deserializeAws_restJson1LoopDetectedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1188,7 +1190,7 @@ const deserializeAws_restJson1NotAcceptableExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1205,7 +1207,7 @@ const deserializeAws_restJson1NotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1222,7 +1224,7 @@ const deserializeAws_restJson1RequestTimeoutExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1239,7 +1241,7 @@ const deserializeAws_restJson1UnsupportedMediaTypeExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1351,7 +1353,7 @@ const serializeAws_restJson1StringMap = (input: { [key: string]: string }, conte
 
 const deserializeAws_restJson1ActiveContext = (output: any, context: __SerdeContext): ActiveContext => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
     parameters:
       output.parameters !== undefined && output.parameters !== null
         ? deserializeAws_restJson1ActiveContextParametersMap(output.parameters, context)
@@ -1373,7 +1375,7 @@ const deserializeAws_restJson1ActiveContextParametersMap = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -1394,51 +1396,43 @@ const deserializeAws_restJson1ActiveContextTimeToLive = (
   context: __SerdeContext
 ): ActiveContextTimeToLive => {
   return {
-    timeToLiveInSeconds:
-      output.timeToLiveInSeconds !== undefined && output.timeToLiveInSeconds !== null
-        ? output.timeToLiveInSeconds
-        : undefined,
-    turnsToLive: output.turnsToLive !== undefined && output.turnsToLive !== null ? output.turnsToLive : undefined,
+    timeToLiveInSeconds: __expectNumber(output.timeToLiveInSeconds),
+    turnsToLive: __expectNumber(output.turnsToLive),
   } as any;
 };
 
 const deserializeAws_restJson1Button = (output: any, context: __SerdeContext): Button => {
   return {
-    text: output.text !== undefined && output.text !== null ? output.text : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    text: __expectString(output.text),
+    value: __expectString(output.value),
   } as any;
 };
 
 const deserializeAws_restJson1DialogAction = (output: any, context: __SerdeContext): DialogAction => {
   return {
-    fulfillmentState:
-      output.fulfillmentState !== undefined && output.fulfillmentState !== null ? output.fulfillmentState : undefined,
-    intentName: output.intentName !== undefined && output.intentName !== null ? output.intentName : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    messageFormat:
-      output.messageFormat !== undefined && output.messageFormat !== null ? output.messageFormat : undefined,
-    slotToElicit: output.slotToElicit !== undefined && output.slotToElicit !== null ? output.slotToElicit : undefined,
+    fulfillmentState: __expectString(output.fulfillmentState),
+    intentName: __expectString(output.intentName),
+    message: __expectString(output.message),
+    messageFormat: __expectString(output.messageFormat),
+    slotToElicit: __expectString(output.slotToElicit),
     slots:
       output.slots !== undefined && output.slots !== null
         ? deserializeAws_restJson1StringMap(output.slots, context)
         : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    type: __expectString(output.type),
   } as any;
 };
 
 const deserializeAws_restJson1GenericAttachment = (output: any, context: __SerdeContext): GenericAttachment => {
   return {
-    attachmentLinkUrl:
-      output.attachmentLinkUrl !== undefined && output.attachmentLinkUrl !== null
-        ? output.attachmentLinkUrl
-        : undefined,
+    attachmentLinkUrl: __expectString(output.attachmentLinkUrl),
     buttons:
       output.buttons !== undefined && output.buttons !== null
         ? deserializeAws_restJson1listOfButtons(output.buttons, context)
         : undefined,
-    imageUrl: output.imageUrl !== undefined && output.imageUrl !== null ? output.imageUrl : undefined,
-    subTitle: output.subTitle !== undefined && output.subTitle !== null ? output.subTitle : undefined,
-    title: output.title !== undefined && output.title !== null ? output.title : undefined,
+    imageUrl: __expectString(output.imageUrl),
+    subTitle: __expectString(output.subTitle),
+    title: __expectString(output.title),
   } as any;
 };
 
@@ -1455,7 +1449,7 @@ const deserializeAws_restJson1genericAttachmentList = (output: any, context: __S
 
 const deserializeAws_restJson1IntentConfidence = (output: any, context: __SerdeContext): IntentConfidence => {
   return {
-    score: output.score !== undefined && output.score !== null ? output.score : undefined,
+    score: __expectNumber(output.score),
   } as any;
 };
 
@@ -1472,18 +1466,12 @@ const deserializeAws_restJson1IntentList = (output: any, context: __SerdeContext
 
 const deserializeAws_restJson1IntentSummary = (output: any, context: __SerdeContext): IntentSummary => {
   return {
-    checkpointLabel:
-      output.checkpointLabel !== undefined && output.checkpointLabel !== null ? output.checkpointLabel : undefined,
-    confirmationStatus:
-      output.confirmationStatus !== undefined && output.confirmationStatus !== null
-        ? output.confirmationStatus
-        : undefined,
-    dialogActionType:
-      output.dialogActionType !== undefined && output.dialogActionType !== null ? output.dialogActionType : undefined,
-    fulfillmentState:
-      output.fulfillmentState !== undefined && output.fulfillmentState !== null ? output.fulfillmentState : undefined,
-    intentName: output.intentName !== undefined && output.intentName !== null ? output.intentName : undefined,
-    slotToElicit: output.slotToElicit !== undefined && output.slotToElicit !== null ? output.slotToElicit : undefined,
+    checkpointLabel: __expectString(output.checkpointLabel),
+    confirmationStatus: __expectString(output.confirmationStatus),
+    dialogActionType: __expectString(output.dialogActionType),
+    fulfillmentState: __expectString(output.fulfillmentState),
+    intentName: __expectString(output.intentName),
+    slotToElicit: __expectString(output.slotToElicit),
     slots:
       output.slots !== undefined && output.slots !== null
         ? deserializeAws_restJson1StringMap(output.slots, context)
@@ -1515,7 +1503,7 @@ const deserializeAws_restJson1listOfButtons = (output: any, context: __SerdeCont
 
 const deserializeAws_restJson1PredictedIntent = (output: any, context: __SerdeContext): PredictedIntent => {
   return {
-    intentName: output.intentName !== undefined && output.intentName !== null ? output.intentName : undefined,
+    intentName: __expectString(output.intentName),
     nluIntentConfidence:
       output.nluIntentConfidence !== undefined && output.nluIntentConfidence !== null
         ? deserializeAws_restJson1IntentConfidence(output.nluIntentConfidence, context)
@@ -1529,21 +1517,19 @@ const deserializeAws_restJson1PredictedIntent = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1ResponseCard = (output: any, context: __SerdeContext): ResponseCard => {
   return {
-    contentType: output.contentType !== undefined && output.contentType !== null ? output.contentType : undefined,
+    contentType: __expectString(output.contentType),
     genericAttachments:
       output.genericAttachments !== undefined && output.genericAttachments !== null
         ? deserializeAws_restJson1genericAttachmentList(output.genericAttachments, context)
         : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    version: __expectString(output.version),
   } as any;
 };
 
 const deserializeAws_restJson1SentimentResponse = (output: any, context: __SerdeContext): SentimentResponse => {
   return {
-    sentimentLabel:
-      output.sentimentLabel !== undefined && output.sentimentLabel !== null ? output.sentimentLabel : undefined,
-    sentimentScore:
-      output.sentimentScore !== undefined && output.sentimentScore !== null ? output.sentimentScore : undefined,
+    sentimentLabel: __expectString(output.sentimentLabel),
+    sentimentScore: __expectString(output.sentimentScore),
   } as any;
 };
 
@@ -1554,7 +1540,7 @@ const deserializeAws_restJson1StringMap = (output: any, context: __SerdeContext)
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };

--- a/clients/client-lex-runtime-v2/protocols/Aws_restJson1.ts
+++ b/clients/client-lex-runtime-v2/protocols/Aws_restJson1.ts
@@ -45,6 +45,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -449,16 +451,16 @@ export const deserializeAws_restJson1DeleteSessionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.botAliasId !== undefined && data.botAliasId !== null) {
-    contents.botAliasId = data.botAliasId;
+    contents.botAliasId = __expectString(data.botAliasId);
   }
   if (data.botId !== undefined && data.botId !== null) {
-    contents.botId = data.botId;
+    contents.botId = __expectString(data.botId);
   }
   if (data.localeId !== undefined && data.localeId !== null) {
-    contents.localeId = data.localeId;
+    contents.localeId = __expectString(data.localeId);
   }
   if (data.sessionId !== undefined && data.sessionId !== null) {
-    contents.sessionId = data.sessionId;
+    contents.sessionId = __expectString(data.sessionId);
   }
   return Promise.resolve(contents);
 };
@@ -562,7 +564,7 @@ export const deserializeAws_restJson1GetSessionCommand = async (
     contents.messages = deserializeAws_restJson1Messages(data.messages, context);
   }
   if (data.sessionId !== undefined && data.sessionId !== null) {
-    contents.sessionId = data.sessionId;
+    contents.sessionId = __expectString(data.sessionId);
   }
   if (data.sessionState !== undefined && data.sessionState !== null) {
     contents.sessionState = deserializeAws_restJson1SessionState(data.sessionState, context);
@@ -794,7 +796,7 @@ export const deserializeAws_restJson1RecognizeTextCommand = async (
     contents.requestAttributes = deserializeAws_restJson1StringMap(data.requestAttributes, context);
   }
   if (data.sessionId !== undefined && data.sessionId !== null) {
-    contents.sessionId = data.sessionId;
+    contents.sessionId = __expectString(data.sessionId);
   }
   if (data.sessionState !== undefined && data.sessionState !== null) {
     contents.sessionState = deserializeAws_restJson1SessionState(data.sessionState, context);
@@ -1480,7 +1482,7 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1497,7 +1499,7 @@ const deserializeAws_restJson1BadGatewayExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1514,7 +1516,7 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1531,7 +1533,7 @@ const deserializeAws_restJson1DependencyFailedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1548,7 +1550,7 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1565,7 +1567,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1582,7 +1584,7 @@ const deserializeAws_restJson1ThrottlingExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1599,7 +1601,7 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1900,7 +1902,7 @@ const serializeAws_restJson1Values = (input: Slot[], context: __SerdeContext): a
 
 const deserializeAws_restJson1AccessDeniedException = (output: any, context: __SerdeContext): AccessDeniedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -1910,7 +1912,7 @@ const deserializeAws_restJson1ActiveContext = (output: any, context: __SerdeCont
       output.contextAttributes !== undefined && output.contextAttributes !== null
         ? deserializeAws_restJson1ActiveContextParametersMap(output.contextAttributes, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
     timeToLive:
       output.timeToLive !== undefined && output.timeToLive !== null
         ? deserializeAws_restJson1ActiveContextTimeToLive(output.timeToLive, context)
@@ -1928,7 +1930,7 @@ const deserializeAws_restJson1ActiveContextParametersMap = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -1949,11 +1951,8 @@ const deserializeAws_restJson1ActiveContextTimeToLive = (
   context: __SerdeContext
 ): ActiveContextTimeToLive => {
   return {
-    timeToLiveInSeconds:
-      output.timeToLiveInSeconds !== undefined && output.timeToLiveInSeconds !== null
-        ? output.timeToLiveInSeconds
-        : undefined,
-    turnsToLive: output.turnsToLive !== undefined && output.turnsToLive !== null ? output.turnsToLive : undefined,
+    timeToLiveInSeconds: __expectNumber(output.timeToLiveInSeconds),
+    turnsToLive: __expectNumber(output.turnsToLive),
   } as any;
 };
 
@@ -1963,21 +1962,21 @@ const deserializeAws_restJson1AudioResponseEvent = (output: any, context: __Serd
       output.audioChunk !== undefined && output.audioChunk !== null
         ? context.base64Decoder(output.audioChunk)
         : undefined,
-    contentType: output.contentType !== undefined && output.contentType !== null ? output.contentType : undefined,
-    eventId: output.eventId !== undefined && output.eventId !== null ? output.eventId : undefined,
+    contentType: __expectString(output.contentType),
+    eventId: __expectString(output.eventId),
   } as any;
 };
 
 const deserializeAws_restJson1BadGatewayException = (output: any, context: __SerdeContext): BadGatewayException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_restJson1Button = (output: any, context: __SerdeContext): Button => {
   return {
-    text: output.text !== undefined && output.text !== null ? output.text : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    text: __expectString(output.text),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -1994,13 +1993,13 @@ const deserializeAws_restJson1ButtonsList = (output: any, context: __SerdeContex
 
 const deserializeAws_restJson1ConfidenceScore = (output: any, context: __SerdeContext): ConfidenceScore => {
   return {
-    score: output.score !== undefined && output.score !== null ? output.score : undefined,
+    score: __expectNumber(output.score),
   } as any;
 };
 
 const deserializeAws_restJson1ConflictException = (output: any, context: __SerdeContext): ConflictException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -2009,20 +2008,20 @@ const deserializeAws_restJson1DependencyFailedException = (
   context: __SerdeContext
 ): DependencyFailedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_restJson1DialogAction = (output: any, context: __SerdeContext): DialogAction => {
   return {
-    slotToElicit: output.slotToElicit !== undefined && output.slotToElicit !== null ? output.slotToElicit : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    slotToElicit: __expectString(output.slotToElicit),
+    type: __expectString(output.type),
   } as any;
 };
 
 const deserializeAws_restJson1HeartbeatEvent = (output: any, context: __SerdeContext): HeartbeatEvent => {
   return {
-    eventId: output.eventId !== undefined && output.eventId !== null ? output.eventId : undefined,
+    eventId: __expectString(output.eventId),
   } as any;
 };
 
@@ -2032,31 +2031,28 @@ const deserializeAws_restJson1ImageResponseCard = (output: any, context: __Serde
       output.buttons !== undefined && output.buttons !== null
         ? deserializeAws_restJson1ButtonsList(output.buttons, context)
         : undefined,
-    imageUrl: output.imageUrl !== undefined && output.imageUrl !== null ? output.imageUrl : undefined,
-    subtitle: output.subtitle !== undefined && output.subtitle !== null ? output.subtitle : undefined,
-    title: output.title !== undefined && output.title !== null ? output.title : undefined,
+    imageUrl: __expectString(output.imageUrl),
+    subtitle: __expectString(output.subtitle),
+    title: __expectString(output.title),
   } as any;
 };
 
 const deserializeAws_restJson1Intent = (output: any, context: __SerdeContext): Intent => {
   return {
-    confirmationState:
-      output.confirmationState !== undefined && output.confirmationState !== null
-        ? output.confirmationState
-        : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    confirmationState: __expectString(output.confirmationState),
+    name: __expectString(output.name),
     slots:
       output.slots !== undefined && output.slots !== null
         ? deserializeAws_restJson1Slots(output.slots, context)
         : undefined,
-    state: output.state !== undefined && output.state !== null ? output.state : undefined,
+    state: __expectString(output.state),
   } as any;
 };
 
 const deserializeAws_restJson1IntentResultEvent = (output: any, context: __SerdeContext): IntentResultEvent => {
   return {
-    eventId: output.eventId !== undefined && output.eventId !== null ? output.eventId : undefined,
-    inputMode: output.inputMode !== undefined && output.inputMode !== null ? output.inputMode : undefined,
+    eventId: __expectString(output.eventId),
+    inputMode: __expectString(output.inputMode),
     interpretations:
       output.interpretations !== undefined && output.interpretations !== null
         ? deserializeAws_restJson1Interpretations(output.interpretations, context)
@@ -2065,7 +2061,7 @@ const deserializeAws_restJson1IntentResultEvent = (output: any, context: __Serde
       output.requestAttributes !== undefined && output.requestAttributes !== null
         ? deserializeAws_restJson1StringMap(output.requestAttributes, context)
         : undefined,
-    sessionId: output.sessionId !== undefined && output.sessionId !== null ? output.sessionId : undefined,
+    sessionId: __expectString(output.sessionId),
     sessionState:
       output.sessionState !== undefined && output.sessionState !== null
         ? deserializeAws_restJson1SessionState(output.sessionState, context)
@@ -2078,7 +2074,7 @@ const deserializeAws_restJson1InternalServerException = (
   context: __SerdeContext
 ): InternalServerException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -2112,8 +2108,8 @@ const deserializeAws_restJson1Interpretations = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1Message = (output: any, context: __SerdeContext): Message => {
   return {
-    content: output.content !== undefined && output.content !== null ? output.content : undefined,
-    contentType: output.contentType !== undefined && output.contentType !== null ? output.contentType : undefined,
+    content: __expectString(output.content),
+    contentType: __expectString(output.contentType),
     imageResponseCard:
       output.imageResponseCard !== undefined && output.imageResponseCard !== null
         ? deserializeAws_restJson1ImageResponseCard(output.imageResponseCard, context)
@@ -2137,10 +2133,9 @@ const deserializeAws_restJson1PlaybackInterruptionEvent = (
   context: __SerdeContext
 ): PlaybackInterruptionEvent => {
   return {
-    causedByEventId:
-      output.causedByEventId !== undefined && output.causedByEventId !== null ? output.causedByEventId : undefined,
-    eventId: output.eventId !== undefined && output.eventId !== null ? output.eventId : undefined,
-    eventReason: output.eventReason !== undefined && output.eventReason !== null ? output.eventReason : undefined,
+    causedByEventId: __expectString(output.causedByEventId),
+    eventId: __expectString(output.eventId),
+    eventReason: __expectString(output.eventReason),
   } as any;
 };
 
@@ -2149,13 +2144,13 @@ const deserializeAws_restJson1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_restJson1SentimentResponse = (output: any, context: __SerdeContext): SentimentResponse => {
   return {
-    sentiment: output.sentiment !== undefined && output.sentiment !== null ? output.sentiment : undefined,
+    sentiment: __expectString(output.sentiment),
     sentimentScore:
       output.sentimentScore !== undefined && output.sentimentScore !== null
         ? deserializeAws_restJson1SentimentScore(output.sentimentScore, context)
@@ -2165,10 +2160,10 @@ const deserializeAws_restJson1SentimentResponse = (output: any, context: __Serde
 
 const deserializeAws_restJson1SentimentScore = (output: any, context: __SerdeContext): SentimentScore => {
   return {
-    mixed: output.mixed !== undefined && output.mixed !== null ? output.mixed : undefined,
-    negative: output.negative !== undefined && output.negative !== null ? output.negative : undefined,
-    neutral: output.neutral !== undefined && output.neutral !== null ? output.neutral : undefined,
-    positive: output.positive !== undefined && output.positive !== null ? output.positive : undefined,
+    mixed: __expectNumber(output.mixed),
+    negative: __expectNumber(output.negative),
+    neutral: __expectNumber(output.neutral),
+    positive: __expectNumber(output.positive),
   } as any;
 };
 
@@ -2186,10 +2181,7 @@ const deserializeAws_restJson1SessionState = (output: any, context: __SerdeConte
       output.intent !== undefined && output.intent !== null
         ? deserializeAws_restJson1Intent(output.intent, context)
         : undefined,
-    originatingRequestId:
-      output.originatingRequestId !== undefined && output.originatingRequestId !== null
-        ? output.originatingRequestId
-        : undefined,
+    originatingRequestId: __expectString(output.originatingRequestId),
     sessionAttributes:
       output.sessionAttributes !== undefined && output.sessionAttributes !== null
         ? deserializeAws_restJson1StringMap(output.sessionAttributes, context)
@@ -2199,7 +2191,7 @@ const deserializeAws_restJson1SessionState = (output: any, context: __SerdeConte
 
 const deserializeAws_restJson1Slot = (output: any, context: __SerdeContext): Slot => {
   return {
-    shape: output.shape !== undefined && output.shape !== null ? output.shape : undefined,
+    shape: __expectString(output.shape),
     value:
       output.value !== undefined && output.value !== null
         ? deserializeAws_restJson1Value(output.value, context)
@@ -2316,7 +2308,7 @@ const deserializeAws_restJson1StringList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2327,14 +2319,14 @@ const deserializeAws_restJson1StringMap = (output: any, context: __SerdeContext)
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1TextResponseEvent = (output: any, context: __SerdeContext): TextResponseEvent => {
   return {
-    eventId: output.eventId !== undefined && output.eventId !== null ? output.eventId : undefined,
+    eventId: __expectString(output.eventId),
     messages:
       output.messages !== undefined && output.messages !== null
         ? deserializeAws_restJson1Messages(output.messages, context)
@@ -2344,29 +2336,27 @@ const deserializeAws_restJson1TextResponseEvent = (output: any, context: __Serde
 
 const deserializeAws_restJson1ThrottlingException = (output: any, context: __SerdeContext): ThrottlingException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_restJson1TranscriptEvent = (output: any, context: __SerdeContext): TranscriptEvent => {
   return {
-    eventId: output.eventId !== undefined && output.eventId !== null ? output.eventId : undefined,
-    transcript: output.transcript !== undefined && output.transcript !== null ? output.transcript : undefined,
+    eventId: __expectString(output.eventId),
+    transcript: __expectString(output.transcript),
   } as any;
 };
 
 const deserializeAws_restJson1ValidationException = (output: any, context: __SerdeContext): ValidationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_restJson1Value = (output: any, context: __SerdeContext): Value => {
   return {
-    interpretedValue:
-      output.interpretedValue !== undefined && output.interpretedValue !== null ? output.interpretedValue : undefined,
-    originalValue:
-      output.originalValue !== undefined && output.originalValue !== null ? output.originalValue : undefined,
+    interpretedValue: __expectString(output.interpretedValue),
+    originalValue: __expectString(output.originalValue),
     resolvedValues:
       output.resolvedValues !== undefined && output.resolvedValues !== null
         ? deserializeAws_restJson1StringList(output.resolvedValues, context)

--- a/clients/client-license-manager/protocols/Aws_json1_1.ts
+++ b/clients/client-license-manager/protocols/Aws_json1_1.ts
@@ -262,7 +262,12 @@ import {
   ValidationException,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -6515,15 +6520,15 @@ const serializeAws_json1_1UpdateServiceSettingsRequest = (
 
 const deserializeAws_json1_1AcceptGrantResponse = (output: any, context: __SerdeContext): AcceptGrantResponse => {
   return {
-    GrantArn: output.GrantArn !== undefined && output.GrantArn !== null ? output.GrantArn : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    GrantArn: __expectString(output.GrantArn),
+    Status: __expectString(output.Status),
+    Version: __expectString(output.Version),
   } as any;
 };
 
 const deserializeAws_json1_1AccessDeniedException = (output: any, context: __SerdeContext): AccessDeniedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -6537,7 +6542,7 @@ const deserializeAws_json1_1AllowedOperationList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6548,13 +6553,13 @@ const deserializeAws_json1_1ArnList = (output: any, context: __SerdeContext): st
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1AuthorizationException = (output: any, context: __SerdeContext): AuthorizationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -6572,14 +6577,8 @@ const deserializeAws_json1_1AutomatedDiscoveryInformation = (
 
 const deserializeAws_json1_1BorrowConfiguration = (output: any, context: __SerdeContext): BorrowConfiguration => {
   return {
-    AllowEarlyCheckIn:
-      output.AllowEarlyCheckIn !== undefined && output.AllowEarlyCheckIn !== null
-        ? output.AllowEarlyCheckIn
-        : undefined,
-    MaxTimeToLiveInMinutes:
-      output.MaxTimeToLiveInMinutes !== undefined && output.MaxTimeToLiveInMinutes !== null
-        ? output.MaxTimeToLiveInMinutes
-        : undefined,
+    AllowEarlyCheckIn: __expectBoolean(output.AllowEarlyCheckIn),
+    MaxTimeToLiveInMinutes: __expectNumber(output.MaxTimeToLiveInMinutes),
   } as any;
 };
 
@@ -6600,15 +6599,12 @@ const deserializeAws_json1_1CheckoutBorrowLicenseResponse = (
       output.EntitlementsAllowed !== undefined && output.EntitlementsAllowed !== null
         ? deserializeAws_json1_1EntitlementDataList(output.EntitlementsAllowed, context)
         : undefined,
-    Expiration: output.Expiration !== undefined && output.Expiration !== null ? output.Expiration : undefined,
-    IssuedAt: output.IssuedAt !== undefined && output.IssuedAt !== null ? output.IssuedAt : undefined,
-    LicenseArn: output.LicenseArn !== undefined && output.LicenseArn !== null ? output.LicenseArn : undefined,
-    LicenseConsumptionToken:
-      output.LicenseConsumptionToken !== undefined && output.LicenseConsumptionToken !== null
-        ? output.LicenseConsumptionToken
-        : undefined,
-    NodeId: output.NodeId !== undefined && output.NodeId !== null ? output.NodeId : undefined,
-    SignedToken: output.SignedToken !== undefined && output.SignedToken !== null ? output.SignedToken : undefined,
+    Expiration: __expectString(output.Expiration),
+    IssuedAt: __expectString(output.IssuedAt),
+    LicenseArn: __expectString(output.LicenseArn),
+    LicenseConsumptionToken: __expectString(output.LicenseConsumptionToken),
+    NodeId: __expectString(output.NodeId),
+    SignedToken: __expectString(output.SignedToken),
   } as any;
 };
 
@@ -6617,33 +6613,29 @@ const deserializeAws_json1_1CheckoutLicenseResponse = (
   context: __SerdeContext
 ): CheckoutLicenseResponse => {
   return {
-    CheckoutType: output.CheckoutType !== undefined && output.CheckoutType !== null ? output.CheckoutType : undefined,
+    CheckoutType: __expectString(output.CheckoutType),
     EntitlementsAllowed:
       output.EntitlementsAllowed !== undefined && output.EntitlementsAllowed !== null
         ? deserializeAws_json1_1EntitlementDataList(output.EntitlementsAllowed, context)
         : undefined,
-    Expiration: output.Expiration !== undefined && output.Expiration !== null ? output.Expiration : undefined,
-    IssuedAt: output.IssuedAt !== undefined && output.IssuedAt !== null ? output.IssuedAt : undefined,
-    LicenseConsumptionToken:
-      output.LicenseConsumptionToken !== undefined && output.LicenseConsumptionToken !== null
-        ? output.LicenseConsumptionToken
-        : undefined,
-    NodeId: output.NodeId !== undefined && output.NodeId !== null ? output.NodeId : undefined,
-    SignedToken: output.SignedToken !== undefined && output.SignedToken !== null ? output.SignedToken : undefined,
+    Expiration: __expectString(output.Expiration),
+    IssuedAt: __expectString(output.IssuedAt),
+    LicenseConsumptionToken: __expectString(output.LicenseConsumptionToken),
+    NodeId: __expectString(output.NodeId),
+    SignedToken: __expectString(output.SignedToken),
   } as any;
 };
 
 const deserializeAws_json1_1ConflictException = (output: any, context: __SerdeContext): ConflictException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1ConsumedLicenseSummary = (output: any, context: __SerdeContext): ConsumedLicenseSummary => {
   return {
-    ConsumedLicenses:
-      output.ConsumedLicenses !== undefined && output.ConsumedLicenses !== null ? output.ConsumedLicenses : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
+    ConsumedLicenses: __expectNumber(output.ConsumedLicenses),
+    ResourceType: __expectString(output.ResourceType),
   } as any;
 };
 
@@ -6674,15 +6666,15 @@ const deserializeAws_json1_1ConsumptionConfiguration = (
       output.ProvisionalConfiguration !== undefined && output.ProvisionalConfiguration !== null
         ? deserializeAws_json1_1ProvisionalConfiguration(output.ProvisionalConfiguration, context)
         : undefined,
-    RenewType: output.RenewType !== undefined && output.RenewType !== null ? output.RenewType : undefined,
+    RenewType: __expectString(output.RenewType),
   } as any;
 };
 
 const deserializeAws_json1_1CreateGrantResponse = (output: any, context: __SerdeContext): CreateGrantResponse => {
   return {
-    GrantArn: output.GrantArn !== undefined && output.GrantArn !== null ? output.GrantArn : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    GrantArn: __expectString(output.GrantArn),
+    Status: __expectString(output.Status),
+    Version: __expectString(output.Version),
   } as any;
 };
 
@@ -6691,9 +6683,9 @@ const deserializeAws_json1_1CreateGrantVersionResponse = (
   context: __SerdeContext
 ): CreateGrantVersionResponse => {
   return {
-    GrantArn: output.GrantArn !== undefined && output.GrantArn !== null ? output.GrantArn : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    GrantArn: __expectString(output.GrantArn),
+    Status: __expectString(output.Status),
+    Version: __expectString(output.Version),
   } as any;
 };
 
@@ -6702,10 +6694,7 @@ const deserializeAws_json1_1CreateLicenseConfigurationResponse = (
   context: __SerdeContext
 ): CreateLicenseConfigurationResponse => {
   return {
-    LicenseConfigurationArn:
-      output.LicenseConfigurationArn !== undefined && output.LicenseConfigurationArn !== null
-        ? output.LicenseConfigurationArn
-        : undefined,
+    LicenseConfigurationArn: __expectString(output.LicenseConfigurationArn),
   } as any;
 };
 
@@ -6714,18 +6703,15 @@ const deserializeAws_json1_1CreateLicenseManagerReportGeneratorResponse = (
   context: __SerdeContext
 ): CreateLicenseManagerReportGeneratorResponse => {
   return {
-    LicenseManagerReportGeneratorArn:
-      output.LicenseManagerReportGeneratorArn !== undefined && output.LicenseManagerReportGeneratorArn !== null
-        ? output.LicenseManagerReportGeneratorArn
-        : undefined,
+    LicenseManagerReportGeneratorArn: __expectString(output.LicenseManagerReportGeneratorArn),
   } as any;
 };
 
 const deserializeAws_json1_1CreateLicenseResponse = (output: any, context: __SerdeContext): CreateLicenseResponse => {
   return {
-    LicenseArn: output.LicenseArn !== undefined && output.LicenseArn !== null ? output.LicenseArn : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    LicenseArn: __expectString(output.LicenseArn),
+    Status: __expectString(output.Status),
+    Version: __expectString(output.Version),
   } as any;
 };
 
@@ -6734,32 +6720,32 @@ const deserializeAws_json1_1CreateLicenseVersionResponse = (
   context: __SerdeContext
 ): CreateLicenseVersionResponse => {
   return {
-    LicenseArn: output.LicenseArn !== undefined && output.LicenseArn !== null ? output.LicenseArn : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    LicenseArn: __expectString(output.LicenseArn),
+    Status: __expectString(output.Status),
+    Version: __expectString(output.Version),
   } as any;
 };
 
 const deserializeAws_json1_1CreateTokenResponse = (output: any, context: __SerdeContext): CreateTokenResponse => {
   return {
-    Token: output.Token !== undefined && output.Token !== null ? output.Token : undefined,
-    TokenId: output.TokenId !== undefined && output.TokenId !== null ? output.TokenId : undefined,
-    TokenType: output.TokenType !== undefined && output.TokenType !== null ? output.TokenType : undefined,
+    Token: __expectString(output.Token),
+    TokenId: __expectString(output.TokenId),
+    TokenType: __expectString(output.TokenType),
   } as any;
 };
 
 const deserializeAws_json1_1DatetimeRange = (output: any, context: __SerdeContext): DatetimeRange => {
   return {
-    Begin: output.Begin !== undefined && output.Begin !== null ? output.Begin : undefined,
-    End: output.End !== undefined && output.End !== null ? output.End : undefined,
+    Begin: __expectString(output.Begin),
+    End: __expectString(output.End),
   } as any;
 };
 
 const deserializeAws_json1_1DeleteGrantResponse = (output: any, context: __SerdeContext): DeleteGrantResponse => {
   return {
-    GrantArn: output.GrantArn !== undefined && output.GrantArn !== null ? output.GrantArn : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    GrantArn: __expectString(output.GrantArn),
+    Status: __expectString(output.Status),
+    Version: __expectString(output.Version),
   } as any;
 };
 
@@ -6779,8 +6765,8 @@ const deserializeAws_json1_1DeleteLicenseManagerReportGeneratorResponse = (
 
 const deserializeAws_json1_1DeleteLicenseResponse = (output: any, context: __SerdeContext): DeleteLicenseResponse => {
   return {
-    DeletionDate: output.DeletionDate !== undefined && output.DeletionDate !== null ? output.DeletionDate : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    DeletionDate: __expectString(output.DeletionDate),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -6790,20 +6776,20 @@ const deserializeAws_json1_1DeleteTokenResponse = (output: any, context: __Serde
 
 const deserializeAws_json1_1Entitlement = (output: any, context: __SerdeContext): Entitlement => {
   return {
-    AllowCheckIn: output.AllowCheckIn !== undefined && output.AllowCheckIn !== null ? output.AllowCheckIn : undefined,
-    MaxCount: output.MaxCount !== undefined && output.MaxCount !== null ? output.MaxCount : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Overage: output.Overage !== undefined && output.Overage !== null ? output.Overage : undefined,
-    Unit: output.Unit !== undefined && output.Unit !== null ? output.Unit : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    AllowCheckIn: __expectBoolean(output.AllowCheckIn),
+    MaxCount: __expectNumber(output.MaxCount),
+    Name: __expectString(output.Name),
+    Overage: __expectBoolean(output.Overage),
+    Unit: __expectString(output.Unit),
+    Value: __expectString(output.Value),
   } as any;
 };
 
 const deserializeAws_json1_1EntitlementData = (output: any, context: __SerdeContext): EntitlementData => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Unit: output.Unit !== undefined && output.Unit !== null ? output.Unit : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Name: __expectString(output.Name),
+    Unit: __expectString(output.Unit),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -6834,17 +6820,16 @@ const deserializeAws_json1_1EntitlementNotAllowedException = (
   context: __SerdeContext
 ): EntitlementNotAllowedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1EntitlementUsage = (output: any, context: __SerdeContext): EntitlementUsage => {
   return {
-    ConsumedValue:
-      output.ConsumedValue !== undefined && output.ConsumedValue !== null ? output.ConsumedValue : undefined,
-    MaxCount: output.MaxCount !== undefined && output.MaxCount !== null ? output.MaxCount : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Unit: output.Unit !== undefined && output.Unit !== null ? output.Unit : undefined,
+    ConsumedValue: __expectString(output.ConsumedValue),
+    MaxCount: __expectString(output.MaxCount),
+    Name: __expectString(output.Name),
+    Unit: __expectString(output.Unit),
   } as any;
 };
 
@@ -6864,11 +6849,8 @@ const deserializeAws_json1_1ExtendLicenseConsumptionResponse = (
   context: __SerdeContext
 ): ExtendLicenseConsumptionResponse => {
   return {
-    Expiration: output.Expiration !== undefined && output.Expiration !== null ? output.Expiration : undefined,
-    LicenseConsumptionToken:
-      output.LicenseConsumptionToken !== undefined && output.LicenseConsumptionToken !== null
-        ? output.LicenseConsumptionToken
-        : undefined,
+    Expiration: __expectString(output.Expiration),
+    LicenseConsumptionToken: __expectString(output.LicenseConsumptionToken),
   } as any;
 };
 
@@ -6877,8 +6859,8 @@ const deserializeAws_json1_1FailedDependencyException = (
   context: __SerdeContext
 ): FailedDependencyException => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -6887,13 +6869,13 @@ const deserializeAws_json1_1FilterLimitExceededException = (
   context: __SerdeContext
 ): FilterLimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1GetAccessTokenResponse = (output: any, context: __SerdeContext): GetAccessTokenResponse => {
   return {
-    AccessToken: output.AccessToken !== undefined && output.AccessToken !== null ? output.AccessToken : undefined,
+    AccessToken: __expectString(output.AccessToken),
   } as any;
 };
 
@@ -6919,30 +6901,14 @@ const deserializeAws_json1_1GetLicenseConfigurationResponse = (
       output.ConsumedLicenseSummaryList !== undefined && output.ConsumedLicenseSummaryList !== null
         ? deserializeAws_json1_1ConsumedLicenseSummaryList(output.ConsumedLicenseSummaryList, context)
         : undefined,
-    ConsumedLicenses:
-      output.ConsumedLicenses !== undefined && output.ConsumedLicenses !== null ? output.ConsumedLicenses : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    DisassociateWhenNotFound:
-      output.DisassociateWhenNotFound !== undefined && output.DisassociateWhenNotFound !== null
-        ? output.DisassociateWhenNotFound
-        : undefined,
-    LicenseConfigurationArn:
-      output.LicenseConfigurationArn !== undefined && output.LicenseConfigurationArn !== null
-        ? output.LicenseConfigurationArn
-        : undefined,
-    LicenseConfigurationId:
-      output.LicenseConfigurationId !== undefined && output.LicenseConfigurationId !== null
-        ? output.LicenseConfigurationId
-        : undefined,
-    LicenseCount: output.LicenseCount !== undefined && output.LicenseCount !== null ? output.LicenseCount : undefined,
-    LicenseCountHardLimit:
-      output.LicenseCountHardLimit !== undefined && output.LicenseCountHardLimit !== null
-        ? output.LicenseCountHardLimit
-        : undefined,
-    LicenseCountingType:
-      output.LicenseCountingType !== undefined && output.LicenseCountingType !== null
-        ? output.LicenseCountingType
-        : undefined,
+    ConsumedLicenses: __expectNumber(output.ConsumedLicenses),
+    Description: __expectString(output.Description),
+    DisassociateWhenNotFound: __expectBoolean(output.DisassociateWhenNotFound),
+    LicenseConfigurationArn: __expectString(output.LicenseConfigurationArn),
+    LicenseConfigurationId: __expectString(output.LicenseConfigurationId),
+    LicenseCount: __expectNumber(output.LicenseCount),
+    LicenseCountHardLimit: __expectBoolean(output.LicenseCountHardLimit),
+    LicenseCountingType: __expectString(output.LicenseCountingType),
     LicenseRules:
       output.LicenseRules !== undefined && output.LicenseRules !== null
         ? deserializeAws_json1_1StringList(output.LicenseRules, context)
@@ -6951,14 +6917,13 @@ const deserializeAws_json1_1GetLicenseConfigurationResponse = (
       output.ManagedResourceSummaryList !== undefined && output.ManagedResourceSummaryList !== null
         ? deserializeAws_json1_1ManagedResourceSummaryList(output.ManagedResourceSummaryList, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    OwnerAccountId:
-      output.OwnerAccountId !== undefined && output.OwnerAccountId !== null ? output.OwnerAccountId : undefined,
+    Name: __expectString(output.Name),
+    OwnerAccountId: __expectString(output.OwnerAccountId),
     ProductInformationList:
       output.ProductInformationList !== undefined && output.ProductInformationList !== null
         ? deserializeAws_json1_1ProductInformationList(output.ProductInformationList, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_1TagList(output.Tags, context)
@@ -7004,79 +6969,70 @@ const deserializeAws_json1_1GetServiceSettingsResponse = (
   context: __SerdeContext
 ): GetServiceSettingsResponse => {
   return {
-    EnableCrossAccountsDiscovery:
-      output.EnableCrossAccountsDiscovery !== undefined && output.EnableCrossAccountsDiscovery !== null
-        ? output.EnableCrossAccountsDiscovery
-        : undefined,
-    LicenseManagerResourceShareArn:
-      output.LicenseManagerResourceShareArn !== undefined && output.LicenseManagerResourceShareArn !== null
-        ? output.LicenseManagerResourceShareArn
-        : undefined,
+    EnableCrossAccountsDiscovery: __expectBoolean(output.EnableCrossAccountsDiscovery),
+    LicenseManagerResourceShareArn: __expectString(output.LicenseManagerResourceShareArn),
     OrganizationConfiguration:
       output.OrganizationConfiguration !== undefined && output.OrganizationConfiguration !== null
         ? deserializeAws_json1_1OrganizationConfiguration(output.OrganizationConfiguration, context)
         : undefined,
-    S3BucketArn: output.S3BucketArn !== undefined && output.S3BucketArn !== null ? output.S3BucketArn : undefined,
-    SnsTopicArn: output.SnsTopicArn !== undefined && output.SnsTopicArn !== null ? output.SnsTopicArn : undefined,
+    S3BucketArn: __expectString(output.S3BucketArn),
+    SnsTopicArn: __expectString(output.SnsTopicArn),
   } as any;
 };
 
 const deserializeAws_json1_1Grant = (output: any, context: __SerdeContext): Grant => {
   return {
-    GrantArn: output.GrantArn !== undefined && output.GrantArn !== null ? output.GrantArn : undefined,
-    GrantName: output.GrantName !== undefined && output.GrantName !== null ? output.GrantName : undefined,
-    GrantStatus: output.GrantStatus !== undefined && output.GrantStatus !== null ? output.GrantStatus : undefined,
+    GrantArn: __expectString(output.GrantArn),
+    GrantName: __expectString(output.GrantName),
+    GrantStatus: __expectString(output.GrantStatus),
     GrantedOperations:
       output.GrantedOperations !== undefined && output.GrantedOperations !== null
         ? deserializeAws_json1_1AllowedOperationList(output.GrantedOperations, context)
         : undefined,
-    GranteePrincipalArn:
-      output.GranteePrincipalArn !== undefined && output.GranteePrincipalArn !== null
-        ? output.GranteePrincipalArn
-        : undefined,
-    HomeRegion: output.HomeRegion !== undefined && output.HomeRegion !== null ? output.HomeRegion : undefined,
-    LicenseArn: output.LicenseArn !== undefined && output.LicenseArn !== null ? output.LicenseArn : undefined,
-    ParentArn: output.ParentArn !== undefined && output.ParentArn !== null ? output.ParentArn : undefined,
-    StatusReason: output.StatusReason !== undefined && output.StatusReason !== null ? output.StatusReason : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    GranteePrincipalArn: __expectString(output.GranteePrincipalArn),
+    HomeRegion: __expectString(output.HomeRegion),
+    LicenseArn: __expectString(output.LicenseArn),
+    ParentArn: __expectString(output.ParentArn),
+    StatusReason: __expectString(output.StatusReason),
+    Version: __expectString(output.Version),
   } as any;
 };
 
 const deserializeAws_json1_1GrantedLicense = (output: any, context: __SerdeContext): GrantedLicense => {
   return {
-    Beneficiary: output.Beneficiary !== undefined && output.Beneficiary !== null ? output.Beneficiary : undefined,
+    Beneficiary: __expectString(output.Beneficiary),
     ConsumptionConfiguration:
       output.ConsumptionConfiguration !== undefined && output.ConsumptionConfiguration !== null
         ? deserializeAws_json1_1ConsumptionConfiguration(output.ConsumptionConfiguration, context)
         : undefined,
-    CreateTime: output.CreateTime !== undefined && output.CreateTime !== null ? output.CreateTime : undefined,
+    CreateTime: __expectString(output.CreateTime),
     Entitlements:
       output.Entitlements !== undefined && output.Entitlements !== null
         ? deserializeAws_json1_1EntitlementList(output.Entitlements, context)
         : undefined,
-    HomeRegion: output.HomeRegion !== undefined && output.HomeRegion !== null ? output.HomeRegion : undefined,
+    HomeRegion: __expectString(output.HomeRegion),
     Issuer:
       output.Issuer !== undefined && output.Issuer !== null
         ? deserializeAws_json1_1IssuerDetails(output.Issuer, context)
         : undefined,
-    LicenseArn: output.LicenseArn !== undefined && output.LicenseArn !== null ? output.LicenseArn : undefined,
+    LicenseArn: __expectString(output.LicenseArn),
     LicenseMetadata:
       output.LicenseMetadata !== undefined && output.LicenseMetadata !== null
         ? deserializeAws_json1_1MetadataList(output.LicenseMetadata, context)
         : undefined,
-    LicenseName: output.LicenseName !== undefined && output.LicenseName !== null ? output.LicenseName : undefined,
-    ProductName: output.ProductName !== undefined && output.ProductName !== null ? output.ProductName : undefined,
-    ProductSKU: output.ProductSKU !== undefined && output.ProductSKU !== null ? output.ProductSKU : undefined,
+    LicenseName: __expectString(output.LicenseName),
+    ProductName: __expectString(output.ProductName),
+    ProductSKU: __expectString(output.ProductSKU),
     ReceivedMetadata:
       output.ReceivedMetadata !== undefined && output.ReceivedMetadata !== null
         ? deserializeAws_json1_1ReceivedMetadata(output.ReceivedMetadata, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
     Validity:
       output.Validity !== undefined && output.Validity !== null
         ? deserializeAws_json1_1DatetimeRange(output.Validity, context)
         : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    Version: __expectString(output.Version),
   } as any;
 };
 
@@ -7107,7 +7063,7 @@ const deserializeAws_json1_1InvalidParameterValueException = (
   context: __SerdeContext
 ): InvalidParameterValueException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7116,50 +7072,49 @@ const deserializeAws_json1_1InvalidResourceStateException = (
   context: __SerdeContext
 ): InvalidResourceStateException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1IssuerDetails = (output: any, context: __SerdeContext): IssuerDetails => {
   return {
-    KeyFingerprint:
-      output.KeyFingerprint !== undefined && output.KeyFingerprint !== null ? output.KeyFingerprint : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    SignKey: output.SignKey !== undefined && output.SignKey !== null ? output.SignKey : undefined,
+    KeyFingerprint: __expectString(output.KeyFingerprint),
+    Name: __expectString(output.Name),
+    SignKey: __expectString(output.SignKey),
   } as any;
 };
 
 const deserializeAws_json1_1License = (output: any, context: __SerdeContext): License => {
   return {
-    Beneficiary: output.Beneficiary !== undefined && output.Beneficiary !== null ? output.Beneficiary : undefined,
+    Beneficiary: __expectString(output.Beneficiary),
     ConsumptionConfiguration:
       output.ConsumptionConfiguration !== undefined && output.ConsumptionConfiguration !== null
         ? deserializeAws_json1_1ConsumptionConfiguration(output.ConsumptionConfiguration, context)
         : undefined,
-    CreateTime: output.CreateTime !== undefined && output.CreateTime !== null ? output.CreateTime : undefined,
+    CreateTime: __expectString(output.CreateTime),
     Entitlements:
       output.Entitlements !== undefined && output.Entitlements !== null
         ? deserializeAws_json1_1EntitlementList(output.Entitlements, context)
         : undefined,
-    HomeRegion: output.HomeRegion !== undefined && output.HomeRegion !== null ? output.HomeRegion : undefined,
+    HomeRegion: __expectString(output.HomeRegion),
     Issuer:
       output.Issuer !== undefined && output.Issuer !== null
         ? deserializeAws_json1_1IssuerDetails(output.Issuer, context)
         : undefined,
-    LicenseArn: output.LicenseArn !== undefined && output.LicenseArn !== null ? output.LicenseArn : undefined,
+    LicenseArn: __expectString(output.LicenseArn),
     LicenseMetadata:
       output.LicenseMetadata !== undefined && output.LicenseMetadata !== null
         ? deserializeAws_json1_1MetadataList(output.LicenseMetadata, context)
         : undefined,
-    LicenseName: output.LicenseName !== undefined && output.LicenseName !== null ? output.LicenseName : undefined,
-    ProductName: output.ProductName !== undefined && output.ProductName !== null ? output.ProductName : undefined,
-    ProductSKU: output.ProductSKU !== undefined && output.ProductSKU !== null ? output.ProductSKU : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    LicenseName: __expectString(output.LicenseName),
+    ProductName: __expectString(output.ProductName),
+    ProductSKU: __expectString(output.ProductSKU),
+    Status: __expectString(output.Status),
     Validity:
       output.Validity !== undefined && output.Validity !== null
         ? deserializeAws_json1_1DatetimeRange(output.Validity, context)
         : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    Version: __expectString(output.Version),
   } as any;
 };
 
@@ -7173,30 +7128,14 @@ const deserializeAws_json1_1LicenseConfiguration = (output: any, context: __Serd
       output.ConsumedLicenseSummaryList !== undefined && output.ConsumedLicenseSummaryList !== null
         ? deserializeAws_json1_1ConsumedLicenseSummaryList(output.ConsumedLicenseSummaryList, context)
         : undefined,
-    ConsumedLicenses:
-      output.ConsumedLicenses !== undefined && output.ConsumedLicenses !== null ? output.ConsumedLicenses : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    DisassociateWhenNotFound:
-      output.DisassociateWhenNotFound !== undefined && output.DisassociateWhenNotFound !== null
-        ? output.DisassociateWhenNotFound
-        : undefined,
-    LicenseConfigurationArn:
-      output.LicenseConfigurationArn !== undefined && output.LicenseConfigurationArn !== null
-        ? output.LicenseConfigurationArn
-        : undefined,
-    LicenseConfigurationId:
-      output.LicenseConfigurationId !== undefined && output.LicenseConfigurationId !== null
-        ? output.LicenseConfigurationId
-        : undefined,
-    LicenseCount: output.LicenseCount !== undefined && output.LicenseCount !== null ? output.LicenseCount : undefined,
-    LicenseCountHardLimit:
-      output.LicenseCountHardLimit !== undefined && output.LicenseCountHardLimit !== null
-        ? output.LicenseCountHardLimit
-        : undefined,
-    LicenseCountingType:
-      output.LicenseCountingType !== undefined && output.LicenseCountingType !== null
-        ? output.LicenseCountingType
-        : undefined,
+    ConsumedLicenses: __expectNumber(output.ConsumedLicenses),
+    Description: __expectString(output.Description),
+    DisassociateWhenNotFound: __expectBoolean(output.DisassociateWhenNotFound),
+    LicenseConfigurationArn: __expectString(output.LicenseConfigurationArn),
+    LicenseConfigurationId: __expectString(output.LicenseConfigurationId),
+    LicenseCount: __expectNumber(output.LicenseCount),
+    LicenseCountHardLimit: __expectBoolean(output.LicenseCountHardLimit),
+    LicenseCountingType: __expectString(output.LicenseCountingType),
     LicenseRules:
       output.LicenseRules !== undefined && output.LicenseRules !== null
         ? deserializeAws_json1_1StringList(output.LicenseRules, context)
@@ -7205,14 +7144,13 @@ const deserializeAws_json1_1LicenseConfiguration = (output: any, context: __Serd
       output.ManagedResourceSummaryList !== undefined && output.ManagedResourceSummaryList !== null
         ? deserializeAws_json1_1ManagedResourceSummaryList(output.ManagedResourceSummaryList, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    OwnerAccountId:
-      output.OwnerAccountId !== undefined && output.OwnerAccountId !== null ? output.OwnerAccountId : undefined,
+    Name: __expectString(output.Name),
+    OwnerAccountId: __expectString(output.OwnerAccountId),
     ProductInformationList:
       output.ProductInformationList !== undefined && output.ProductInformationList !== null
         ? deserializeAws_json1_1ProductInformationList(output.ProductInformationList, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -7221,18 +7159,14 @@ const deserializeAws_json1_1LicenseConfigurationAssociation = (
   context: __SerdeContext
 ): LicenseConfigurationAssociation => {
   return {
-    AmiAssociationScope:
-      output.AmiAssociationScope !== undefined && output.AmiAssociationScope !== null
-        ? output.AmiAssociationScope
-        : undefined,
+    AmiAssociationScope: __expectString(output.AmiAssociationScope),
     AssociationTime:
       output.AssociationTime !== undefined && output.AssociationTime !== null
         ? new Date(Math.round(output.AssociationTime * 1000))
         : undefined,
-    ResourceArn: output.ResourceArn !== undefined && output.ResourceArn !== null ? output.ResourceArn : undefined,
-    ResourceOwnerId:
-      output.ResourceOwnerId !== undefined && output.ResourceOwnerId !== null ? output.ResourceOwnerId : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
+    ResourceArn: __expectString(output.ResourceArn),
+    ResourceOwnerId: __expectString(output.ResourceOwnerId),
+    ResourceType: __expectString(output.ResourceType),
   } as any;
 };
 
@@ -7270,14 +7204,11 @@ const deserializeAws_json1_1LicenseConfigurationUsage = (
       output.AssociationTime !== undefined && output.AssociationTime !== null
         ? new Date(Math.round(output.AssociationTime * 1000))
         : undefined,
-    ConsumedLicenses:
-      output.ConsumedLicenses !== undefined && output.ConsumedLicenses !== null ? output.ConsumedLicenses : undefined,
-    ResourceArn: output.ResourceArn !== undefined && output.ResourceArn !== null ? output.ResourceArn : undefined,
-    ResourceOwnerId:
-      output.ResourceOwnerId !== undefined && output.ResourceOwnerId !== null ? output.ResourceOwnerId : undefined,
-    ResourceStatus:
-      output.ResourceStatus !== undefined && output.ResourceStatus !== null ? output.ResourceStatus : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
+    ConsumedLicenses: __expectNumber(output.ConsumedLicenses),
+    ResourceArn: __expectString(output.ResourceArn),
+    ResourceOwnerId: __expectString(output.ResourceOwnerId),
+    ResourceStatus: __expectString(output.ResourceStatus),
+    ResourceType: __expectString(output.ResourceType),
   } as any;
 };
 
@@ -7311,7 +7242,7 @@ const deserializeAws_json1_1LicenseOperationFailure = (
   context: __SerdeContext
 ): LicenseOperationFailure => {
   return {
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
+    ErrorMessage: __expectString(output.ErrorMessage),
     FailureTime:
       output.FailureTime !== undefined && output.FailureTime !== null
         ? new Date(Math.round(output.FailureTime * 1000))
@@ -7320,16 +7251,11 @@ const deserializeAws_json1_1LicenseOperationFailure = (
       output.MetadataList !== undefined && output.MetadataList !== null
         ? deserializeAws_json1_1MetadataList(output.MetadataList, context)
         : undefined,
-    OperationName:
-      output.OperationName !== undefined && output.OperationName !== null ? output.OperationName : undefined,
-    OperationRequestedBy:
-      output.OperationRequestedBy !== undefined && output.OperationRequestedBy !== null
-        ? output.OperationRequestedBy
-        : undefined,
-    ResourceArn: output.ResourceArn !== undefined && output.ResourceArn !== null ? output.ResourceArn : undefined,
-    ResourceOwnerId:
-      output.ResourceOwnerId !== undefined && output.ResourceOwnerId !== null ? output.ResourceOwnerId : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
+    OperationName: __expectString(output.OperationName),
+    OperationRequestedBy: __expectString(output.OperationRequestedBy),
+    ResourceArn: __expectString(output.ResourceArn),
+    ResourceOwnerId: __expectString(output.ResourceOwnerId),
+    ResourceType: __expectString(output.ResourceType),
   } as any;
 };
 
@@ -7349,14 +7275,8 @@ const deserializeAws_json1_1LicenseOperationFailureList = (
 
 const deserializeAws_json1_1LicenseSpecification = (output: any, context: __SerdeContext): LicenseSpecification => {
   return {
-    AmiAssociationScope:
-      output.AmiAssociationScope !== undefined && output.AmiAssociationScope !== null
-        ? output.AmiAssociationScope
-        : undefined,
-    LicenseConfigurationArn:
-      output.LicenseConfigurationArn !== undefined && output.LicenseConfigurationArn !== null
-        ? output.LicenseConfigurationArn
-        : undefined,
+    AmiAssociationScope: __expectString(output.AmiAssociationScope),
+    LicenseConfigurationArn: __expectString(output.LicenseConfigurationArn),
   } as any;
 };
 
@@ -7382,7 +7302,7 @@ const deserializeAws_json1_1LicenseUsage = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_1LicenseUsageException = (output: any, context: __SerdeContext): LicenseUsageException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7395,7 +7315,7 @@ const deserializeAws_json1_1ListAssociationsForLicenseConfigurationResponse = (
       output.LicenseConfigurationAssociations !== undefined && output.LicenseConfigurationAssociations !== null
         ? deserializeAws_json1_1LicenseConfigurationAssociations(output.LicenseConfigurationAssociations, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -7408,7 +7328,7 @@ const deserializeAws_json1_1ListDistributedGrantsResponse = (
       output.Grants !== undefined && output.Grants !== null
         ? deserializeAws_json1_1GrantList(output.Grants, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -7421,7 +7341,7 @@ const deserializeAws_json1_1ListFailuresForLicenseConfigurationOperationsRespons
       output.LicenseOperationFailureList !== undefined && output.LicenseOperationFailureList !== null
         ? deserializeAws_json1_1LicenseOperationFailureList(output.LicenseOperationFailureList, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -7434,7 +7354,7 @@ const deserializeAws_json1_1ListLicenseConfigurationsResponse = (
       output.LicenseConfigurations !== undefined && output.LicenseConfigurations !== null
         ? deserializeAws_json1_1LicenseConfigurations(output.LicenseConfigurations, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -7443,7 +7363,7 @@ const deserializeAws_json1_1ListLicenseManagerReportGeneratorsResponse = (
   context: __SerdeContext
 ): ListLicenseManagerReportGeneratorsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     ReportGenerators:
       output.ReportGenerators !== undefined && output.ReportGenerators !== null
         ? deserializeAws_json1_1ReportGeneratorList(output.ReportGenerators, context)
@@ -7460,7 +7380,7 @@ const deserializeAws_json1_1ListLicenseSpecificationsForResourceResponse = (
       output.LicenseSpecifications !== undefined && output.LicenseSpecifications !== null
         ? deserializeAws_json1_1LicenseSpecifications(output.LicenseSpecifications, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -7470,7 +7390,7 @@ const deserializeAws_json1_1ListLicensesResponse = (output: any, context: __Serd
       output.Licenses !== undefined && output.Licenses !== null
         ? deserializeAws_json1_1LicenseList(output.Licenses, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -7483,7 +7403,7 @@ const deserializeAws_json1_1ListLicenseVersionsResponse = (
       output.Licenses !== undefined && output.Licenses !== null
         ? deserializeAws_json1_1LicenseList(output.Licenses, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -7496,7 +7416,7 @@ const deserializeAws_json1_1ListReceivedGrantsResponse = (
       output.Grants !== undefined && output.Grants !== null
         ? deserializeAws_json1_1GrantList(output.Grants, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -7509,7 +7429,7 @@ const deserializeAws_json1_1ListReceivedLicensesResponse = (
       output.Licenses !== undefined && output.Licenses !== null
         ? deserializeAws_json1_1GrantedLicenseList(output.Licenses, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -7518,7 +7438,7 @@ const deserializeAws_json1_1ListResourceInventoryResponse = (
   context: __SerdeContext
 ): ListResourceInventoryResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     ResourceInventoryList:
       output.ResourceInventoryList !== undefined && output.ResourceInventoryList !== null
         ? deserializeAws_json1_1ResourceInventoryList(output.ResourceInventoryList, context)
@@ -7540,7 +7460,7 @@ const deserializeAws_json1_1ListTagsForResourceResponse = (
 
 const deserializeAws_json1_1ListTokensResponse = (output: any, context: __SerdeContext): ListTokensResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Tokens:
       output.Tokens !== undefined && output.Tokens !== null
         ? deserializeAws_json1_1TokenList(output.Tokens, context)
@@ -7557,15 +7477,14 @@ const deserializeAws_json1_1ListUsageForLicenseConfigurationResponse = (
       output.LicenseConfigurationUsageList !== undefined && output.LicenseConfigurationUsageList !== null
         ? deserializeAws_json1_1LicenseConfigurationUsageList(output.LicenseConfigurationUsageList, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
 const deserializeAws_json1_1ManagedResourceSummary = (output: any, context: __SerdeContext): ManagedResourceSummary => {
   return {
-    AssociationCount:
-      output.AssociationCount !== undefined && output.AssociationCount !== null ? output.AssociationCount : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
+    AssociationCount: __expectNumber(output.AssociationCount),
+    ResourceType: __expectString(output.ResourceType),
   } as any;
 };
 
@@ -7590,14 +7509,14 @@ const deserializeAws_json1_1MaxSize3StringList = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1Metadata = (output: any, context: __SerdeContext): Metadata => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Name: __expectString(output.Name),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -7617,7 +7536,7 @@ const deserializeAws_json1_1NoEntitlementsAllowedException = (
   context: __SerdeContext
 ): NoEntitlementsAllowedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7626,10 +7545,7 @@ const deserializeAws_json1_1OrganizationConfiguration = (
   context: __SerdeContext
 ): OrganizationConfiguration => {
   return {
-    EnableIntegration:
-      output.EnableIntegration !== undefined && output.EnableIntegration !== null
-        ? output.EnableIntegration
-        : undefined,
+    EnableIntegration: __expectBoolean(output.EnableIntegration),
   } as any;
 };
 
@@ -7639,7 +7555,7 @@ const deserializeAws_json1_1ProductInformation = (output: any, context: __SerdeC
       output.ProductInformationFilterList !== undefined && output.ProductInformationFilterList !== null
         ? deserializeAws_json1_1ProductInformationFilterList(output.ProductInformationFilterList, context)
         : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
+    ResourceType: __expectString(output.ResourceType),
   } as any;
 };
 
@@ -7648,14 +7564,8 @@ const deserializeAws_json1_1ProductInformationFilter = (
   context: __SerdeContext
 ): ProductInformationFilter => {
   return {
-    ProductInformationFilterComparator:
-      output.ProductInformationFilterComparator !== undefined && output.ProductInformationFilterComparator !== null
-        ? output.ProductInformationFilterComparator
-        : undefined,
-    ProductInformationFilterName:
-      output.ProductInformationFilterName !== undefined && output.ProductInformationFilterName !== null
-        ? output.ProductInformationFilterName
-        : undefined,
+    ProductInformationFilterComparator: __expectString(output.ProductInformationFilterComparator),
+    ProductInformationFilterName: __expectString(output.ProductInformationFilterName),
     ProductInformationFilterValue:
       output.ProductInformationFilterValue !== undefined && output.ProductInformationFilterValue !== null
         ? deserializeAws_json1_1StringList(output.ProductInformationFilterValue, context)
@@ -7693,10 +7603,7 @@ const deserializeAws_json1_1ProvisionalConfiguration = (
   context: __SerdeContext
 ): ProvisionalConfiguration => {
   return {
-    MaxTimeToLiveInMinutes:
-      output.MaxTimeToLiveInMinutes !== undefined && output.MaxTimeToLiveInMinutes !== null
-        ? output.MaxTimeToLiveInMinutes
-        : undefined,
+    MaxTimeToLiveInMinutes: __expectNumber(output.MaxTimeToLiveInMinutes),
   } as any;
 };
 
@@ -7705,7 +7612,7 @@ const deserializeAws_json1_1RateLimitExceededException = (
   context: __SerdeContext
 ): RateLimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7715,23 +7622,22 @@ const deserializeAws_json1_1ReceivedMetadata = (output: any, context: __SerdeCon
       output.AllowedOperations !== undefined && output.AllowedOperations !== null
         ? deserializeAws_json1_1AllowedOperationList(output.AllowedOperations, context)
         : undefined,
-    ReceivedStatus:
-      output.ReceivedStatus !== undefined && output.ReceivedStatus !== null ? output.ReceivedStatus : undefined,
+    ReceivedStatus: __expectString(output.ReceivedStatus),
   } as any;
 };
 
 const deserializeAws_json1_1RedirectException = (output: any, context: __SerdeContext): RedirectException => {
   return {
-    Location: output.Location !== undefined && output.Location !== null ? output.Location : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Location: __expectString(output.Location),
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1RejectGrantResponse = (output: any, context: __SerdeContext): RejectGrantResponse => {
   return {
-    GrantArn: output.GrantArn !== undefined && output.GrantArn !== null ? output.GrantArn : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    GrantArn: __expectString(output.GrantArn),
+    Status: __expectString(output.Status),
+    Version: __expectString(output.Version),
   } as any;
 };
 
@@ -7746,45 +7652,29 @@ const deserializeAws_json1_1ReportContext = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1ReportFrequency = (output: any, context: __SerdeContext): ReportFrequency => {
   return {
-    period: output.period !== undefined && output.period !== null ? output.period : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    period: __expectString(output.period),
+    value: __expectNumber(output.value),
   } as any;
 };
 
 const deserializeAws_json1_1ReportGenerator = (output: any, context: __SerdeContext): ReportGenerator => {
   return {
-    CreateTime: output.CreateTime !== undefined && output.CreateTime !== null ? output.CreateTime : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    LastReportGenerationTime:
-      output.LastReportGenerationTime !== undefined && output.LastReportGenerationTime !== null
-        ? output.LastReportGenerationTime
-        : undefined,
-    LastRunFailureReason:
-      output.LastRunFailureReason !== undefined && output.LastRunFailureReason !== null
-        ? output.LastRunFailureReason
-        : undefined,
-    LastRunStatus:
-      output.LastRunStatus !== undefined && output.LastRunStatus !== null ? output.LastRunStatus : undefined,
-    LicenseManagerReportGeneratorArn:
-      output.LicenseManagerReportGeneratorArn !== undefined && output.LicenseManagerReportGeneratorArn !== null
-        ? output.LicenseManagerReportGeneratorArn
-        : undefined,
+    CreateTime: __expectString(output.CreateTime),
+    Description: __expectString(output.Description),
+    LastReportGenerationTime: __expectString(output.LastReportGenerationTime),
+    LastRunFailureReason: __expectString(output.LastRunFailureReason),
+    LastRunStatus: __expectString(output.LastRunStatus),
+    LicenseManagerReportGeneratorArn: __expectString(output.LicenseManagerReportGeneratorArn),
     ReportContext:
       output.ReportContext !== undefined && output.ReportContext !== null
         ? deserializeAws_json1_1ReportContext(output.ReportContext, context)
         : undefined,
-    ReportCreatorAccount:
-      output.ReportCreatorAccount !== undefined && output.ReportCreatorAccount !== null
-        ? output.ReportCreatorAccount
-        : undefined,
+    ReportCreatorAccount: __expectString(output.ReportCreatorAccount),
     ReportFrequency:
       output.ReportFrequency !== undefined && output.ReportFrequency !== null
         ? deserializeAws_json1_1ReportFrequency(output.ReportFrequency, context)
         : undefined,
-    ReportGeneratorName:
-      output.ReportGeneratorName !== undefined && output.ReportGeneratorName !== null
-        ? output.ReportGeneratorName
-        : undefined,
+    ReportGeneratorName: __expectString(output.ReportGeneratorName),
     ReportType:
       output.ReportType !== undefined && output.ReportType !== null
         ? deserializeAws_json1_1ReportTypeList(output.ReportType, context)
@@ -7818,22 +7708,18 @@ const deserializeAws_json1_1ReportTypeList = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1ResourceInventory = (output: any, context: __SerdeContext): ResourceInventory => {
   return {
-    Platform: output.Platform !== undefined && output.Platform !== null ? output.Platform : undefined,
-    PlatformVersion:
-      output.PlatformVersion !== undefined && output.PlatformVersion !== null ? output.PlatformVersion : undefined,
-    ResourceArn: output.ResourceArn !== undefined && output.ResourceArn !== null ? output.ResourceArn : undefined,
-    ResourceId: output.ResourceId !== undefined && output.ResourceId !== null ? output.ResourceId : undefined,
-    ResourceOwningAccountId:
-      output.ResourceOwningAccountId !== undefined && output.ResourceOwningAccountId !== null
-        ? output.ResourceOwningAccountId
-        : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
+    Platform: __expectString(output.Platform),
+    PlatformVersion: __expectString(output.PlatformVersion),
+    ResourceArn: __expectString(output.ResourceArn),
+    ResourceId: __expectString(output.ResourceId),
+    ResourceOwningAccountId: __expectString(output.ResourceOwningAccountId),
+    ResourceType: __expectString(output.ResourceType),
   } as any;
 };
 
@@ -7853,7 +7739,7 @@ const deserializeAws_json1_1ResourceLimitExceededException = (
   context: __SerdeContext
 ): ResourceLimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7862,14 +7748,14 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1S3Location = (output: any, context: __SerdeContext): S3Location => {
   return {
-    bucket: output.bucket !== undefined && output.bucket !== null ? output.bucket : undefined,
-    keyPrefix: output.keyPrefix !== undefined && output.keyPrefix !== null ? output.keyPrefix : undefined,
+    bucket: __expectString(output.bucket),
+    keyPrefix: __expectString(output.keyPrefix),
   } as any;
 };
 
@@ -7878,7 +7764,7 @@ const deserializeAws_json1_1ServerInternalException = (
   context: __SerdeContext
 ): ServerInternalException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7889,14 +7775,14 @@ const deserializeAws_json1_1StringList = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -7917,20 +7803,19 @@ const deserializeAws_json1_1TagResourceResponse = (output: any, context: __Serde
 
 const deserializeAws_json1_1TokenData = (output: any, context: __SerdeContext): TokenData => {
   return {
-    ExpirationTime:
-      output.ExpirationTime !== undefined && output.ExpirationTime !== null ? output.ExpirationTime : undefined,
-    LicenseArn: output.LicenseArn !== undefined && output.LicenseArn !== null ? output.LicenseArn : undefined,
+    ExpirationTime: __expectString(output.ExpirationTime),
+    LicenseArn: __expectString(output.LicenseArn),
     RoleArns:
       output.RoleArns !== undefined && output.RoleArns !== null
         ? deserializeAws_json1_1ArnList(output.RoleArns, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    TokenId: output.TokenId !== undefined && output.TokenId !== null ? output.TokenId : undefined,
+    Status: __expectString(output.Status),
+    TokenId: __expectString(output.TokenId),
     TokenProperties:
       output.TokenProperties !== undefined && output.TokenProperties !== null
         ? deserializeAws_json1_1MaxSize3StringList(output.TokenProperties, context)
         : undefined,
-    TokenType: output.TokenType !== undefined && output.TokenType !== null ? output.TokenType : undefined,
+    TokenType: __expectString(output.TokenType),
   } as any;
 };
 
@@ -7950,7 +7835,7 @@ const deserializeAws_json1_1UnsupportedDigitalSignatureMethodException = (
   context: __SerdeContext
 ): UnsupportedDigitalSignatureMethodException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7988,7 +7873,7 @@ const deserializeAws_json1_1UpdateServiceSettingsResponse = (
 
 const deserializeAws_json1_1ValidationException = (output: any, context: __SerdeContext): ValidationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 

--- a/clients/client-lightsail/protocols/Aws_json1_1.ts
+++ b/clients/client-lightsail/protocols/Aws_json1_1.ts
@@ -743,7 +743,12 @@ import {
   UpdateRelationalDatabaseResult,
 } from "../models/models_1";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -18775,10 +18780,10 @@ const serializeAws_json1_1UpdateRelationalDatabaseRequest = (
 
 const deserializeAws_json1_1AccessDeniedException = (output: any, context: __SerdeContext): AccessDeniedException => {
   return {
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    docs: output.docs !== undefined && output.docs !== null ? output.docs : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    tip: output.tip !== undefined && output.tip !== null ? output.tip : undefined,
+    code: __expectString(output.code),
+    docs: __expectString(output.docs),
+    message: __expectString(output.message),
+    tip: __expectString(output.tip),
   } as any;
 };
 
@@ -18787,25 +18792,19 @@ const deserializeAws_json1_1AccountSetupInProgressException = (
   context: __SerdeContext
 ): AccountSetupInProgressException => {
   return {
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    docs: output.docs !== undefined && output.docs !== null ? output.docs : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    tip: output.tip !== undefined && output.tip !== null ? output.tip : undefined,
+    code: __expectString(output.code),
+    docs: __expectString(output.docs),
+    message: __expectString(output.message),
+    tip: __expectString(output.tip),
   } as any;
 };
 
 const deserializeAws_json1_1AddOn = (output: any, context: __SerdeContext): AddOn => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    nextSnapshotTimeOfDay:
-      output.nextSnapshotTimeOfDay !== undefined && output.nextSnapshotTimeOfDay !== null
-        ? output.nextSnapshotTimeOfDay
-        : undefined,
-    snapshotTimeOfDay:
-      output.snapshotTimeOfDay !== undefined && output.snapshotTimeOfDay !== null
-        ? output.snapshotTimeOfDay
-        : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    name: __expectString(output.name),
+    nextSnapshotTimeOfDay: __expectString(output.nextSnapshotTimeOfDay),
+    snapshotTimeOfDay: __expectString(output.snapshotTimeOfDay),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -18822,11 +18821,8 @@ const deserializeAws_json1_1AddOnList = (output: any, context: __SerdeContext): 
 
 const deserializeAws_json1_1Alarm = (output: any, context: __SerdeContext): Alarm => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    comparisonOperator:
-      output.comparisonOperator !== undefined && output.comparisonOperator !== null
-        ? output.comparisonOperator
-        : undefined,
+    arn: __expectString(output.arn),
+    comparisonOperator: __expectString(output.comparisonOperator),
     contactProtocols:
       output.contactProtocols !== undefined && output.contactProtocols !== null
         ? deserializeAws_json1_1ContactProtocolsList(output.contactProtocols, context)
@@ -18835,41 +18831,31 @@ const deserializeAws_json1_1Alarm = (output: any, context: __SerdeContext): Alar
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    datapointsToAlarm:
-      output.datapointsToAlarm !== undefined && output.datapointsToAlarm !== null
-        ? output.datapointsToAlarm
-        : undefined,
-    evaluationPeriods:
-      output.evaluationPeriods !== undefined && output.evaluationPeriods !== null
-        ? output.evaluationPeriods
-        : undefined,
+    datapointsToAlarm: __expectNumber(output.datapointsToAlarm),
+    evaluationPeriods: __expectNumber(output.evaluationPeriods),
     location:
       output.location !== undefined && output.location !== null
         ? deserializeAws_json1_1ResourceLocation(output.location, context)
         : undefined,
-    metricName: output.metricName !== undefined && output.metricName !== null ? output.metricName : undefined,
+    metricName: __expectString(output.metricName),
     monitoredResourceInfo:
       output.monitoredResourceInfo !== undefined && output.monitoredResourceInfo !== null
         ? deserializeAws_json1_1MonitoredResourceInfo(output.monitoredResourceInfo, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    notificationEnabled:
-      output.notificationEnabled !== undefined && output.notificationEnabled !== null
-        ? output.notificationEnabled
-        : undefined,
+    name: __expectString(output.name),
+    notificationEnabled: __expectBoolean(output.notificationEnabled),
     notificationTriggers:
       output.notificationTriggers !== undefined && output.notificationTriggers !== null
         ? deserializeAws_json1_1NotificationTriggerList(output.notificationTriggers, context)
         : undefined,
-    period: output.period !== undefined && output.period !== null ? output.period : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
-    state: output.state !== undefined && output.state !== null ? output.state : undefined,
-    statistic: output.statistic !== undefined && output.statistic !== null ? output.statistic : undefined,
-    supportCode: output.supportCode !== undefined && output.supportCode !== null ? output.supportCode : undefined,
-    threshold: output.threshold !== undefined && output.threshold !== null ? output.threshold : undefined,
-    treatMissingData:
-      output.treatMissingData !== undefined && output.treatMissingData !== null ? output.treatMissingData : undefined,
-    unit: output.unit !== undefined && output.unit !== null ? output.unit : undefined,
+    period: __expectNumber(output.period),
+    resourceType: __expectString(output.resourceType),
+    state: __expectString(output.state),
+    statistic: __expectString(output.statistic),
+    supportCode: __expectString(output.supportCode),
+    threshold: __expectNumber(output.threshold),
+    treatMissingData: __expectString(output.treatMissingData),
+    unit: __expectString(output.unit),
   } as any;
 };
 
@@ -18916,8 +18902,8 @@ const deserializeAws_json1_1AttachDiskResult = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1AttachedDisk = (output: any, context: __SerdeContext): AttachedDisk => {
   return {
-    path: output.path !== undefined && output.path !== null ? output.path : undefined,
-    sizeInGb: output.sizeInGb !== undefined && output.sizeInGb !== null ? output.sizeInGb : undefined,
+    path: __expectString(output.path),
+    sizeInGb: __expectNumber(output.sizeInGb),
   } as any;
 };
 
@@ -18971,12 +18957,12 @@ const deserializeAws_json1_1AutoSnapshotDetails = (output: any, context: __Serde
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    date: output.date !== undefined && output.date !== null ? output.date : undefined,
+    date: __expectString(output.date),
     fromAttachedDisks:
       output.fromAttachedDisks !== undefined && output.fromAttachedDisks !== null
         ? deserializeAws_json1_1AttachedDiskList(output.fromAttachedDisks, context)
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -18993,8 +18979,8 @@ const deserializeAws_json1_1AutoSnapshotDetailsList = (output: any, context: __S
 
 const deserializeAws_json1_1AvailabilityZone = (output: any, context: __SerdeContext): AvailabilityZone => {
   return {
-    state: output.state !== undefined && output.state !== null ? output.state : undefined,
-    zoneName: output.zoneName !== undefined && output.zoneName !== null ? output.zoneName : undefined,
+    state: __expectString(output.state),
+    zoneName: __expectString(output.zoneName),
   } as any;
 };
 
@@ -19011,18 +18997,18 @@ const deserializeAws_json1_1AvailabilityZoneList = (output: any, context: __Serd
 
 const deserializeAws_json1_1Blueprint = (output: any, context: __SerdeContext): Blueprint => {
   return {
-    blueprintId: output.blueprintId !== undefined && output.blueprintId !== null ? output.blueprintId : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    group: output.group !== undefined && output.group !== null ? output.group : undefined,
-    isActive: output.isActive !== undefined && output.isActive !== null ? output.isActive : undefined,
-    licenseUrl: output.licenseUrl !== undefined && output.licenseUrl !== null ? output.licenseUrl : undefined,
-    minPower: output.minPower !== undefined && output.minPower !== null ? output.minPower : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    platform: output.platform !== undefined && output.platform !== null ? output.platform : undefined,
-    productUrl: output.productUrl !== undefined && output.productUrl !== null ? output.productUrl : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
-    versionCode: output.versionCode !== undefined && output.versionCode !== null ? output.versionCode : undefined,
+    blueprintId: __expectString(output.blueprintId),
+    description: __expectString(output.description),
+    group: __expectString(output.group),
+    isActive: __expectBoolean(output.isActive),
+    licenseUrl: __expectString(output.licenseUrl),
+    minPower: __expectNumber(output.minPower),
+    name: __expectString(output.name),
+    platform: __expectString(output.platform),
+    productUrl: __expectString(output.productUrl),
+    type: __expectString(output.type),
+    version: __expectString(output.version),
+    versionCode: __expectString(output.versionCode),
   } as any;
 };
 
@@ -19039,23 +19025,20 @@ const deserializeAws_json1_1BlueprintList = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1Bundle = (output: any, context: __SerdeContext): Bundle => {
   return {
-    bundleId: output.bundleId !== undefined && output.bundleId !== null ? output.bundleId : undefined,
-    cpuCount: output.cpuCount !== undefined && output.cpuCount !== null ? output.cpuCount : undefined,
-    diskSizeInGb: output.diskSizeInGb !== undefined && output.diskSizeInGb !== null ? output.diskSizeInGb : undefined,
-    instanceType: output.instanceType !== undefined && output.instanceType !== null ? output.instanceType : undefined,
-    isActive: output.isActive !== undefined && output.isActive !== null ? output.isActive : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    power: output.power !== undefined && output.power !== null ? output.power : undefined,
-    price: output.price !== undefined && output.price !== null ? output.price : undefined,
-    ramSizeInGb: output.ramSizeInGb !== undefined && output.ramSizeInGb !== null ? output.ramSizeInGb : undefined,
+    bundleId: __expectString(output.bundleId),
+    cpuCount: __expectNumber(output.cpuCount),
+    diskSizeInGb: __expectNumber(output.diskSizeInGb),
+    instanceType: __expectString(output.instanceType),
+    isActive: __expectBoolean(output.isActive),
+    name: __expectString(output.name),
+    power: __expectNumber(output.power),
+    price: __expectNumber(output.price),
+    ramSizeInGb: __expectNumber(output.ramSizeInGb),
     supportedPlatforms:
       output.supportedPlatforms !== undefined && output.supportedPlatforms !== null
         ? deserializeAws_json1_1InstancePlatformList(output.supportedPlatforms, context)
         : undefined,
-    transferPerMonthInGb:
-      output.transferPerMonthInGb !== undefined && output.transferPerMonthInGb !== null
-        ? output.transferPerMonthInGb
-        : undefined,
+    transferPerMonthInGb: __expectNumber(output.transferPerMonthInGb),
   } as any;
 };
 
@@ -19072,7 +19055,7 @@ const deserializeAws_json1_1BundleList = (output: any, context: __SerdeContext):
 
 const deserializeAws_json1_1CacheBehavior = (output: any, context: __SerdeContext): CacheBehavior => {
   return {
-    behavior: output.behavior !== undefined && output.behavior !== null ? output.behavior : undefined,
+    behavior: __expectString(output.behavior),
   } as any;
 };
 
@@ -19089,22 +19072,16 @@ const deserializeAws_json1_1CacheBehaviorList = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1CacheBehaviorPerPath = (output: any, context: __SerdeContext): CacheBehaviorPerPath => {
   return {
-    behavior: output.behavior !== undefined && output.behavior !== null ? output.behavior : undefined,
-    path: output.path !== undefined && output.path !== null ? output.path : undefined,
+    behavior: __expectString(output.behavior),
+    path: __expectString(output.path),
   } as any;
 };
 
 const deserializeAws_json1_1CacheSettings = (output: any, context: __SerdeContext): CacheSettings => {
   return {
-    allowedHTTPMethods:
-      output.allowedHTTPMethods !== undefined && output.allowedHTTPMethods !== null
-        ? output.allowedHTTPMethods
-        : undefined,
-    cachedHTTPMethods:
-      output.cachedHTTPMethods !== undefined && output.cachedHTTPMethods !== null
-        ? output.cachedHTTPMethods
-        : undefined,
-    defaultTTL: output.defaultTTL !== undefined && output.defaultTTL !== null ? output.defaultTTL : undefined,
+    allowedHTTPMethods: __expectString(output.allowedHTTPMethods),
+    cachedHTTPMethods: __expectString(output.cachedHTTPMethods),
+    defaultTTL: __expectNumber(output.defaultTTL),
     forwardedCookies:
       output.forwardedCookies !== undefined && output.forwardedCookies !== null
         ? deserializeAws_json1_1CookieObject(output.forwardedCookies, context)
@@ -19117,36 +19094,32 @@ const deserializeAws_json1_1CacheSettings = (output: any, context: __SerdeContex
       output.forwardedQueryStrings !== undefined && output.forwardedQueryStrings !== null
         ? deserializeAws_json1_1QueryStringObject(output.forwardedQueryStrings, context)
         : undefined,
-    maximumTTL: output.maximumTTL !== undefined && output.maximumTTL !== null ? output.maximumTTL : undefined,
-    minimumTTL: output.minimumTTL !== undefined && output.minimumTTL !== null ? output.minimumTTL : undefined,
+    maximumTTL: __expectNumber(output.maximumTTL),
+    minimumTTL: __expectNumber(output.minimumTTL),
   } as any;
 };
 
 const deserializeAws_json1_1Certificate = (output: any, context: __SerdeContext): Certificate => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    domainName: output.domainName !== undefined && output.domainName !== null ? output.domainName : undefined,
+    domainName: __expectString(output.domainName),
     domainValidationRecords:
       output.domainValidationRecords !== undefined && output.domainValidationRecords !== null
         ? deserializeAws_json1_1DomainValidationRecordList(output.domainValidationRecords, context)
         : undefined,
-    eligibleToRenew:
-      output.eligibleToRenew !== undefined && output.eligibleToRenew !== null ? output.eligibleToRenew : undefined,
-    inUseResourceCount:
-      output.inUseResourceCount !== undefined && output.inUseResourceCount !== null
-        ? output.inUseResourceCount
-        : undefined,
+    eligibleToRenew: __expectString(output.eligibleToRenew),
+    inUseResourceCount: __expectNumber(output.inUseResourceCount),
     issuedAt:
       output.issuedAt !== undefined && output.issuedAt !== null
         ? new Date(Math.round(output.issuedAt * 1000))
         : undefined,
-    issuerCA: output.issuerCA !== undefined && output.issuerCA !== null ? output.issuerCA : undefined,
-    keyAlgorithm: output.keyAlgorithm !== undefined && output.keyAlgorithm !== null ? output.keyAlgorithm : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    issuerCA: __expectString(output.issuerCA),
+    keyAlgorithm: __expectString(output.keyAlgorithm),
+    name: __expectString(output.name),
     notAfter:
       output.notAfter !== undefined && output.notAfter !== null
         ? new Date(Math.round(output.notAfter * 1000))
@@ -19159,23 +19132,19 @@ const deserializeAws_json1_1Certificate = (output: any, context: __SerdeContext)
       output.renewalSummary !== undefined && output.renewalSummary !== null
         ? deserializeAws_json1_1RenewalSummary(output.renewalSummary, context)
         : undefined,
-    requestFailureReason:
-      output.requestFailureReason !== undefined && output.requestFailureReason !== null
-        ? output.requestFailureReason
-        : undefined,
-    revocationReason:
-      output.revocationReason !== undefined && output.revocationReason !== null ? output.revocationReason : undefined,
+    requestFailureReason: __expectString(output.requestFailureReason),
+    revocationReason: __expectString(output.revocationReason),
     revokedAt:
       output.revokedAt !== undefined && output.revokedAt !== null
         ? new Date(Math.round(output.revokedAt * 1000))
         : undefined,
-    serialNumber: output.serialNumber !== undefined && output.serialNumber !== null ? output.serialNumber : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    serialNumber: __expectString(output.serialNumber),
+    status: __expectString(output.status),
     subjectAlternativeNames:
       output.subjectAlternativeNames !== undefined && output.subjectAlternativeNames !== null
         ? deserializeAws_json1_1SubjectAlternativeNameList(output.subjectAlternativeNames, context)
         : undefined,
-    supportCode: output.supportCode !== undefined && output.supportCode !== null ? output.supportCode : undefined,
+    supportCode: __expectString(output.supportCode),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_json1_1TagList(output.tags, context)
@@ -19185,15 +19154,13 @@ const deserializeAws_json1_1Certificate = (output: any, context: __SerdeContext)
 
 const deserializeAws_json1_1CertificateSummary = (output: any, context: __SerdeContext): CertificateSummary => {
   return {
-    certificateArn:
-      output.certificateArn !== undefined && output.certificateArn !== null ? output.certificateArn : undefined,
+    certificateArn: __expectString(output.certificateArn),
     certificateDetail:
       output.certificateDetail !== undefined && output.certificateDetail !== null
         ? deserializeAws_json1_1Certificate(output.certificateDetail, context)
         : undefined,
-    certificateName:
-      output.certificateName !== undefined && output.certificateName !== null ? output.certificateName : undefined,
-    domainName: output.domainName !== undefined && output.domainName !== null ? output.domainName : undefined,
+    certificateName: __expectString(output.certificateName),
+    domainName: __expectString(output.domainName),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_json1_1TagList(output.tags, context)
@@ -19229,7 +19196,7 @@ const deserializeAws_json1_1CloudFormationStackRecord = (
   context: __SerdeContext
 ): CloudFormationStackRecord => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
@@ -19242,13 +19209,13 @@ const deserializeAws_json1_1CloudFormationStackRecord = (
       output.location !== undefined && output.location !== null
         ? deserializeAws_json1_1ResourceLocation(output.location, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
+    name: __expectString(output.name),
+    resourceType: __expectString(output.resourceType),
     sourceInfo:
       output.sourceInfo !== undefined && output.sourceInfo !== null
         ? deserializeAws_json1_1CloudFormationStackRecordSourceInfoList(output.sourceInfo, context)
         : undefined,
-    state: output.state !== undefined && output.state !== null ? output.state : undefined,
+    state: __expectString(output.state),
   } as any;
 };
 
@@ -19271,9 +19238,9 @@ const deserializeAws_json1_1CloudFormationStackRecordSourceInfo = (
   context: __SerdeContext
 ): CloudFormationStackRecordSourceInfo => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
+    arn: __expectString(output.arn),
+    name: __expectString(output.name),
+    resourceType: __expectString(output.resourceType),
   } as any;
 };
 
@@ -19293,9 +19260,8 @@ const deserializeAws_json1_1CloudFormationStackRecordSourceInfoList = (
 
 const deserializeAws_json1_1ContactMethod = (output: any, context: __SerdeContext): ContactMethod => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    contactEndpoint:
-      output.contactEndpoint !== undefined && output.contactEndpoint !== null ? output.contactEndpoint : undefined,
+    arn: __expectString(output.arn),
+    contactEndpoint: __expectString(output.contactEndpoint),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
@@ -19304,11 +19270,11 @@ const deserializeAws_json1_1ContactMethod = (output: any, context: __SerdeContex
       output.location !== undefined && output.location !== null
         ? deserializeAws_json1_1ResourceLocation(output.location, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    protocol: output.protocol !== undefined && output.protocol !== null ? output.protocol : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    supportCode: output.supportCode !== undefined && output.supportCode !== null ? output.supportCode : undefined,
+    name: __expectString(output.name),
+    protocol: __expectString(output.protocol),
+    resourceType: __expectString(output.resourceType),
+    status: __expectString(output.status),
+    supportCode: __expectString(output.supportCode),
   } as any;
 };
 
@@ -19333,7 +19299,7 @@ const deserializeAws_json1_1ContactProtocolsList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -19347,7 +19313,7 @@ const deserializeAws_json1_1Container = (output: any, context: __SerdeContext): 
       output.environment !== undefined && output.environment !== null
         ? deserializeAws_json1_1Environment(output.environment, context)
         : undefined,
-    image: output.image !== undefined && output.image !== null ? output.image : undefined,
+    image: __expectString(output.image),
     ports:
       output.ports !== undefined && output.ports !== null
         ? deserializeAws_json1_1PortMap(output.ports, context)
@@ -19361,8 +19327,8 @@ const deserializeAws_json1_1ContainerImage = (output: any, context: __SerdeConte
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    digest: output.digest !== undefined && output.digest !== null ? output.digest : undefined,
-    image: output.image !== undefined && output.image !== null ? output.image : undefined,
+    digest: __expectString(output.digest),
+    image: __expectString(output.image),
   } as any;
 };
 
@@ -19391,11 +19357,8 @@ const deserializeAws_json1_1ContainerMap = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_1ContainerService = (output: any, context: __SerdeContext): ContainerService => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    containerServiceName:
-      output.containerServiceName !== undefined && output.containerServiceName !== null
-        ? output.containerServiceName
-        : undefined,
+    arn: __expectString(output.arn),
+    containerServiceName: __expectString(output.containerServiceName),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
@@ -19404,7 +19367,7 @@ const deserializeAws_json1_1ContainerService = (output: any, context: __SerdeCon
       output.currentDeployment !== undefined && output.currentDeployment !== null
         ? deserializeAws_json1_1ContainerServiceDeployment(output.currentDeployment, context)
         : undefined,
-    isDisabled: output.isDisabled !== undefined && output.isDisabled !== null ? output.isDisabled : undefined,
+    isDisabled: __expectBoolean(output.isDisabled),
     location:
       output.location !== undefined && output.location !== null
         ? deserializeAws_json1_1ResourceLocation(output.location, context)
@@ -19413,20 +19376,17 @@ const deserializeAws_json1_1ContainerService = (output: any, context: __SerdeCon
       output.nextDeployment !== undefined && output.nextDeployment !== null
         ? deserializeAws_json1_1ContainerServiceDeployment(output.nextDeployment, context)
         : undefined,
-    power: output.power !== undefined && output.power !== null ? output.power : undefined,
-    powerId: output.powerId !== undefined && output.powerId !== null ? output.powerId : undefined,
-    principalArn: output.principalArn !== undefined && output.principalArn !== null ? output.principalArn : undefined,
-    privateDomainName:
-      output.privateDomainName !== undefined && output.privateDomainName !== null
-        ? output.privateDomainName
-        : undefined,
+    power: __expectString(output.power),
+    powerId: __expectString(output.powerId),
+    principalArn: __expectString(output.principalArn),
+    privateDomainName: __expectString(output.privateDomainName),
     publicDomainNames:
       output.publicDomainNames !== undefined && output.publicDomainNames !== null
         ? deserializeAws_json1_1ContainerServicePublicDomains(output.publicDomainNames, context)
         : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
-    scale: output.scale !== undefined && output.scale !== null ? output.scale : undefined,
-    state: output.state !== undefined && output.state !== null ? output.state : undefined,
+    resourceType: __expectString(output.resourceType),
+    scale: __expectNumber(output.scale),
+    state: __expectString(output.state),
     stateDetail:
       output.stateDetail !== undefined && output.stateDetail !== null
         ? deserializeAws_json1_1ContainerServiceStateDetail(output.stateDetail, context)
@@ -19435,7 +19395,7 @@ const deserializeAws_json1_1ContainerService = (output: any, context: __SerdeCon
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_json1_1TagList(output.tags, context)
         : undefined,
-    url: output.url !== undefined && output.url !== null ? output.url : undefined,
+    url: __expectString(output.url),
   } as any;
 };
 
@@ -19456,8 +19416,8 @@ const deserializeAws_json1_1ContainerServiceDeployment = (
       output.publicEndpoint !== undefined && output.publicEndpoint !== null
         ? deserializeAws_json1_1ContainerServiceEndpoint(output.publicEndpoint, context)
         : undefined,
-    state: output.state !== undefined && output.state !== null ? output.state : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    state: __expectString(output.state),
+    version: __expectNumber(output.version),
   } as any;
 };
 
@@ -19480,10 +19440,8 @@ const deserializeAws_json1_1ContainerServiceEndpoint = (
   context: __SerdeContext
 ): ContainerServiceEndpoint => {
   return {
-    containerName:
-      output.containerName !== undefined && output.containerName !== null ? output.containerName : undefined,
-    containerPort:
-      output.containerPort !== undefined && output.containerPort !== null ? output.containerPort : undefined,
+    containerName: __expectString(output.containerName),
+    containerPort: __expectNumber(output.containerPort),
     healthCheck:
       output.healthCheck !== undefined && output.healthCheck !== null
         ? deserializeAws_json1_1ContainerServiceHealthCheckConfig(output.healthCheck, context)
@@ -19496,18 +19454,12 @@ const deserializeAws_json1_1ContainerServiceHealthCheckConfig = (
   context: __SerdeContext
 ): ContainerServiceHealthCheckConfig => {
   return {
-    healthyThreshold:
-      output.healthyThreshold !== undefined && output.healthyThreshold !== null ? output.healthyThreshold : undefined,
-    intervalSeconds:
-      output.intervalSeconds !== undefined && output.intervalSeconds !== null ? output.intervalSeconds : undefined,
-    path: output.path !== undefined && output.path !== null ? output.path : undefined,
-    successCodes: output.successCodes !== undefined && output.successCodes !== null ? output.successCodes : undefined,
-    timeoutSeconds:
-      output.timeoutSeconds !== undefined && output.timeoutSeconds !== null ? output.timeoutSeconds : undefined,
-    unhealthyThreshold:
-      output.unhealthyThreshold !== undefined && output.unhealthyThreshold !== null
-        ? output.unhealthyThreshold
-        : undefined,
+    healthyThreshold: __expectNumber(output.healthyThreshold),
+    intervalSeconds: __expectNumber(output.intervalSeconds),
+    path: __expectString(output.path),
+    successCodes: __expectString(output.successCodes),
+    timeoutSeconds: __expectNumber(output.timeoutSeconds),
+    unhealthyThreshold: __expectNumber(output.unhealthyThreshold),
   } as any;
 };
 
@@ -19531,7 +19483,7 @@ const deserializeAws_json1_1ContainerServiceLogEvent = (
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19559,7 +19511,7 @@ const deserializeAws_json1_1ContainerServiceMetadataEntry = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -19580,12 +19532,12 @@ const deserializeAws_json1_1ContainerServiceMetadataEntryList = (
 
 const deserializeAws_json1_1ContainerServicePower = (output: any, context: __SerdeContext): ContainerServicePower => {
   return {
-    cpuCount: output.cpuCount !== undefined && output.cpuCount !== null ? output.cpuCount : undefined,
-    isActive: output.isActive !== undefined && output.isActive !== null ? output.isActive : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    powerId: output.powerId !== undefined && output.powerId !== null ? output.powerId : undefined,
-    price: output.price !== undefined && output.price !== null ? output.price : undefined,
-    ramSizeInGb: output.ramSizeInGb !== undefined && output.ramSizeInGb !== null ? output.ramSizeInGb : undefined,
+    cpuCount: __expectNumber(output.cpuCount),
+    isActive: __expectBoolean(output.isActive),
+    name: __expectString(output.name),
+    powerId: __expectString(output.powerId),
+    price: __expectNumber(output.price),
+    ramSizeInGb: __expectNumber(output.ramSizeInGb),
   } as any;
 };
 
@@ -19625,7 +19577,7 @@ const deserializeAws_json1_1ContainerServicePublicDomainsList = (output: any, co
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -19638,9 +19590,9 @@ const deserializeAws_json1_1ContainerServiceRegistryLogin = (
       output.expiresAt !== undefined && output.expiresAt !== null
         ? new Date(Math.round(output.expiresAt * 1000))
         : undefined,
-    password: output.password !== undefined && output.password !== null ? output.password : undefined,
-    registry: output.registry !== undefined && output.registry !== null ? output.registry : undefined,
-    username: output.username !== undefined && output.username !== null ? output.username : undefined,
+    password: __expectString(output.password),
+    registry: __expectString(output.registry),
+    username: __expectString(output.username),
   } as any;
 };
 
@@ -19661,8 +19613,8 @@ const deserializeAws_json1_1ContainerServiceStateDetail = (
   context: __SerdeContext
 ): ContainerServiceStateDetail => {
   return {
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    code: __expectString(output.code),
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -19672,7 +19624,7 @@ const deserializeAws_json1_1CookieObject = (output: any, context: __SerdeContext
       output.cookiesAllowList !== undefined && output.cookiesAllowList !== null
         ? deserializeAws_json1_1StringList(output.cookiesAllowList, context)
         : undefined,
-    option: output.option !== undefined && output.option !== null ? output.option : undefined,
+    option: __expectString(output.option),
   } as any;
 };
 
@@ -19874,10 +19826,8 @@ const deserializeAws_json1_1CreateKeyPairResult = (output: any, context: __Serde
       output.operation !== undefined && output.operation !== null
         ? deserializeAws_json1_1Operation(output.operation, context)
         : undefined,
-    privateKeyBase64:
-      output.privateKeyBase64 !== undefined && output.privateKeyBase64 !== null ? output.privateKeyBase64 : undefined,
-    publicKeyBase64:
-      output.publicKeyBase64 !== undefined && output.publicKeyBase64 !== null ? output.publicKeyBase64 : undefined,
+    privateKeyBase64: __expectString(output.privateKeyBase64),
+    publicKeyBase64: __expectString(output.publicKeyBase64),
   } as any;
 };
 
@@ -20146,8 +20096,8 @@ const deserializeAws_json1_1DeleteRelationalDatabaseSnapshotResult = (
 
 const deserializeAws_json1_1DestinationInfo = (output: any, context: __SerdeContext): DestinationInfo => {
   return {
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    service: output.service !== undefined && output.service !== null ? output.service : undefined,
+    id: __expectString(output.id),
+    service: __expectString(output.service),
   } as any;
 };
 
@@ -20208,28 +20158,27 @@ const deserializeAws_json1_1Disk = (output: any, context: __SerdeContext): Disk 
       output.addOns !== undefined && output.addOns !== null
         ? deserializeAws_json1_1AddOnList(output.addOns, context)
         : undefined,
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    attachedTo: output.attachedTo !== undefined && output.attachedTo !== null ? output.attachedTo : undefined,
-    attachmentState:
-      output.attachmentState !== undefined && output.attachmentState !== null ? output.attachmentState : undefined,
+    arn: __expectString(output.arn),
+    attachedTo: __expectString(output.attachedTo),
+    attachmentState: __expectString(output.attachmentState),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    gbInUse: output.gbInUse !== undefined && output.gbInUse !== null ? output.gbInUse : undefined,
-    iops: output.iops !== undefined && output.iops !== null ? output.iops : undefined,
-    isAttached: output.isAttached !== undefined && output.isAttached !== null ? output.isAttached : undefined,
-    isSystemDisk: output.isSystemDisk !== undefined && output.isSystemDisk !== null ? output.isSystemDisk : undefined,
+    gbInUse: __expectNumber(output.gbInUse),
+    iops: __expectNumber(output.iops),
+    isAttached: __expectBoolean(output.isAttached),
+    isSystemDisk: __expectBoolean(output.isSystemDisk),
     location:
       output.location !== undefined && output.location !== null
         ? deserializeAws_json1_1ResourceLocation(output.location, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    path: output.path !== undefined && output.path !== null ? output.path : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
-    sizeInGb: output.sizeInGb !== undefined && output.sizeInGb !== null ? output.sizeInGb : undefined,
-    state: output.state !== undefined && output.state !== null ? output.state : undefined,
-    supportCode: output.supportCode !== undefined && output.supportCode !== null ? output.supportCode : undefined,
+    name: __expectString(output.name),
+    path: __expectString(output.path),
+    resourceType: __expectString(output.resourceType),
+    sizeInGb: __expectNumber(output.sizeInGb),
+    state: __expectString(output.state),
+    supportCode: __expectString(output.supportCode),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_json1_1TagList(output.tags, context)
@@ -20239,10 +20188,10 @@ const deserializeAws_json1_1Disk = (output: any, context: __SerdeContext): Disk 
 
 const deserializeAws_json1_1DiskInfo = (output: any, context: __SerdeContext): DiskInfo => {
   return {
-    isSystemDisk: output.isSystemDisk !== undefined && output.isSystemDisk !== null ? output.isSystemDisk : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    path: output.path !== undefined && output.path !== null ? output.path : undefined,
-    sizeInGb: output.sizeInGb !== undefined && output.sizeInGb !== null ? output.sizeInGb : undefined,
+    isSystemDisk: __expectBoolean(output.isSystemDisk),
+    name: __expectString(output.name),
+    path: __expectString(output.path),
+    sizeInGb: __expectNumber(output.sizeInGb),
   } as any;
 };
 
@@ -20270,31 +20219,26 @@ const deserializeAws_json1_1DiskList = (output: any, context: __SerdeContext): D
 
 const deserializeAws_json1_1DiskSnapshot = (output: any, context: __SerdeContext): DiskSnapshot => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    fromDiskArn: output.fromDiskArn !== undefined && output.fromDiskArn !== null ? output.fromDiskArn : undefined,
-    fromDiskName: output.fromDiskName !== undefined && output.fromDiskName !== null ? output.fromDiskName : undefined,
-    fromInstanceArn:
-      output.fromInstanceArn !== undefined && output.fromInstanceArn !== null ? output.fromInstanceArn : undefined,
-    fromInstanceName:
-      output.fromInstanceName !== undefined && output.fromInstanceName !== null ? output.fromInstanceName : undefined,
-    isFromAutoSnapshot:
-      output.isFromAutoSnapshot !== undefined && output.isFromAutoSnapshot !== null
-        ? output.isFromAutoSnapshot
-        : undefined,
+    fromDiskArn: __expectString(output.fromDiskArn),
+    fromDiskName: __expectString(output.fromDiskName),
+    fromInstanceArn: __expectString(output.fromInstanceArn),
+    fromInstanceName: __expectString(output.fromInstanceName),
+    isFromAutoSnapshot: __expectBoolean(output.isFromAutoSnapshot),
     location:
       output.location !== undefined && output.location !== null
         ? deserializeAws_json1_1ResourceLocation(output.location, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    progress: output.progress !== undefined && output.progress !== null ? output.progress : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
-    sizeInGb: output.sizeInGb !== undefined && output.sizeInGb !== null ? output.sizeInGb : undefined,
-    state: output.state !== undefined && output.state !== null ? output.state : undefined,
-    supportCode: output.supportCode !== undefined && output.supportCode !== null ? output.supportCode : undefined,
+    name: __expectString(output.name),
+    progress: __expectString(output.progress),
+    resourceType: __expectString(output.resourceType),
+    sizeInGb: __expectNumber(output.sizeInGb),
+    state: __expectString(output.state),
+    supportCode: __expectString(output.supportCode),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_json1_1TagList(output.tags, context)
@@ -20304,7 +20248,7 @@ const deserializeAws_json1_1DiskSnapshot = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_1DiskSnapshotInfo = (output: any, context: __SerdeContext): DiskSnapshotInfo => {
   return {
-    sizeInGb: output.sizeInGb !== undefined && output.sizeInGb !== null ? output.sizeInGb : undefined,
+    sizeInGb: __expectNumber(output.sizeInGb),
   } as any;
 };
 
@@ -20321,14 +20265,11 @@ const deserializeAws_json1_1DiskSnapshotList = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1DistributionBundle = (output: any, context: __SerdeContext): DistributionBundle => {
   return {
-    bundleId: output.bundleId !== undefined && output.bundleId !== null ? output.bundleId : undefined,
-    isActive: output.isActive !== undefined && output.isActive !== null ? output.isActive : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    price: output.price !== undefined && output.price !== null ? output.price : undefined,
-    transferPerMonthInGb:
-      output.transferPerMonthInGb !== undefined && output.transferPerMonthInGb !== null
-        ? output.transferPerMonthInGb
-        : undefined,
+    bundleId: __expectString(output.bundleId),
+    isActive: __expectBoolean(output.isActive),
+    name: __expectString(output.name),
+    price: __expectNumber(output.price),
+    transferPerMonthInGb: __expectNumber(output.transferPerMonthInGb),
   } as any;
 };
 
@@ -20356,7 +20297,7 @@ const deserializeAws_json1_1DistributionList = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1Domain = (output: any, context: __SerdeContext): Domain => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
@@ -20369,9 +20310,9 @@ const deserializeAws_json1_1Domain = (output: any, context: __SerdeContext): Dom
       output.location !== undefined && output.location !== null
         ? deserializeAws_json1_1ResourceLocation(output.location, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
-    supportCode: output.supportCode !== undefined && output.supportCode !== null ? output.supportCode : undefined,
+    name: __expectString(output.name),
+    resourceType: __expectString(output.resourceType),
+    supportCode: __expectString(output.supportCode),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_json1_1TagList(output.tags, context)
@@ -20381,15 +20322,15 @@ const deserializeAws_json1_1Domain = (output: any, context: __SerdeContext): Dom
 
 const deserializeAws_json1_1DomainEntry = (output: any, context: __SerdeContext): DomainEntry => {
   return {
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    isAlias: output.isAlias !== undefined && output.isAlias !== null ? output.isAlias : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    id: __expectString(output.id),
+    isAlias: __expectBoolean(output.isAlias),
+    name: __expectString(output.name),
     options:
       output.options !== undefined && output.options !== null
         ? deserializeAws_json1_1DomainEntryOptions(output.options, context)
         : undefined,
-    target: output.target !== undefined && output.target !== null ? output.target : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    target: __expectString(output.target),
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -20411,7 +20352,7 @@ const deserializeAws_json1_1DomainEntryOptions = (output: any, context: __SerdeC
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -20429,7 +20370,7 @@ const deserializeAws_json1_1DomainList = (output: any, context: __SerdeContext):
 
 const deserializeAws_json1_1DomainValidationRecord = (output: any, context: __SerdeContext): DomainValidationRecord => {
   return {
-    domainName: output.domainName !== undefined && output.domainName !== null ? output.domainName : undefined,
+    domainName: __expectString(output.domainName),
     resourceRecord:
       output.resourceRecord !== undefined && output.resourceRecord !== null
         ? deserializeAws_json1_1ResourceRecord(output.resourceRecord, context)
@@ -20456,10 +20397,8 @@ const deserializeAws_json1_1DownloadDefaultKeyPairResult = (
   context: __SerdeContext
 ): DownloadDefaultKeyPairResult => {
   return {
-    privateKeyBase64:
-      output.privateKeyBase64 !== undefined && output.privateKeyBase64 !== null ? output.privateKeyBase64 : undefined,
-    publicKeyBase64:
-      output.publicKeyBase64 !== undefined && output.publicKeyBase64 !== null ? output.publicKeyBase64 : undefined,
+    privateKeyBase64: __expectString(output.privateKeyBase64),
+    publicKeyBase64: __expectString(output.publicKeyBase64),
   } as any;
 };
 
@@ -20479,14 +20418,14 @@ const deserializeAws_json1_1Environment = (output: any, context: __SerdeContext)
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_json1_1ExportSnapshotRecord = (output: any, context: __SerdeContext): ExportSnapshotRecord => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
@@ -20499,13 +20438,13 @@ const deserializeAws_json1_1ExportSnapshotRecord = (output: any, context: __Serd
       output.location !== undefined && output.location !== null
         ? deserializeAws_json1_1ResourceLocation(output.location, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
+    name: __expectString(output.name),
+    resourceType: __expectString(output.resourceType),
     sourceInfo:
       output.sourceInfo !== undefined && output.sourceInfo !== null
         ? deserializeAws_json1_1ExportSnapshotRecordSourceInfo(output.sourceInfo, context)
         : undefined,
-    state: output.state !== undefined && output.state !== null ? output.state : undefined,
+    state: __expectString(output.state),
   } as any;
 };
 
@@ -20528,7 +20467,7 @@ const deserializeAws_json1_1ExportSnapshotRecordSourceInfo = (
   context: __SerdeContext
 ): ExportSnapshotRecordSourceInfo => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
@@ -20537,16 +20476,14 @@ const deserializeAws_json1_1ExportSnapshotRecordSourceInfo = (
       output.diskSnapshotInfo !== undefined && output.diskSnapshotInfo !== null
         ? deserializeAws_json1_1DiskSnapshotInfo(output.diskSnapshotInfo, context)
         : undefined,
-    fromResourceArn:
-      output.fromResourceArn !== undefined && output.fromResourceArn !== null ? output.fromResourceArn : undefined,
-    fromResourceName:
-      output.fromResourceName !== undefined && output.fromResourceName !== null ? output.fromResourceName : undefined,
+    fromResourceArn: __expectString(output.fromResourceArn),
+    fromResourceName: __expectString(output.fromResourceName),
     instanceSnapshotInfo:
       output.instanceSnapshotInfo !== undefined && output.instanceSnapshotInfo !== null
         ? deserializeAws_json1_1InstanceSnapshotInfo(output.instanceSnapshotInfo, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
+    name: __expectString(output.name),
+    resourceType: __expectString(output.resourceType),
   } as any;
 };
 
@@ -20565,8 +20502,7 @@ const deserializeAws_json1_1GetActiveNamesResult = (output: any, context: __Serd
       output.activeNames !== undefined && output.activeNames !== null
         ? deserializeAws_json1_1StringList(output.activeNames, context)
         : undefined,
-    nextPageToken:
-      output.nextPageToken !== undefined && output.nextPageToken !== null ? output.nextPageToken : undefined,
+    nextPageToken: __expectString(output.nextPageToken),
   } as any;
 };
 
@@ -20576,8 +20512,7 @@ const deserializeAws_json1_1GetAlarmsResult = (output: any, context: __SerdeCont
       output.alarms !== undefined && output.alarms !== null
         ? deserializeAws_json1_1AlarmsList(output.alarms, context)
         : undefined,
-    nextPageToken:
-      output.nextPageToken !== undefined && output.nextPageToken !== null ? output.nextPageToken : undefined,
+    nextPageToken: __expectString(output.nextPageToken),
   } as any;
 };
 
@@ -20587,8 +20522,8 @@ const deserializeAws_json1_1GetAutoSnapshotsResult = (output: any, context: __Se
       output.autoSnapshots !== undefined && output.autoSnapshots !== null
         ? deserializeAws_json1_1AutoSnapshotDetailsList(output.autoSnapshots, context)
         : undefined,
-    resourceName: output.resourceName !== undefined && output.resourceName !== null ? output.resourceName : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
+    resourceName: __expectString(output.resourceName),
+    resourceType: __expectString(output.resourceType),
   } as any;
 };
 
@@ -20598,8 +20533,7 @@ const deserializeAws_json1_1GetBlueprintsResult = (output: any, context: __Serde
       output.blueprints !== undefined && output.blueprints !== null
         ? deserializeAws_json1_1BlueprintList(output.blueprints, context)
         : undefined,
-    nextPageToken:
-      output.nextPageToken !== undefined && output.nextPageToken !== null ? output.nextPageToken : undefined,
+    nextPageToken: __expectString(output.nextPageToken),
   } as any;
 };
 
@@ -20609,8 +20543,7 @@ const deserializeAws_json1_1GetBundlesResult = (output: any, context: __SerdeCon
       output.bundles !== undefined && output.bundles !== null
         ? deserializeAws_json1_1BundleList(output.bundles, context)
         : undefined,
-    nextPageToken:
-      output.nextPageToken !== undefined && output.nextPageToken !== null ? output.nextPageToken : undefined,
+    nextPageToken: __expectString(output.nextPageToken),
   } as any;
 };
 
@@ -20632,8 +20565,7 @@ const deserializeAws_json1_1GetCloudFormationStackRecordsResult = (
       output.cloudFormationStackRecords !== undefined && output.cloudFormationStackRecords !== null
         ? deserializeAws_json1_1CloudFormationStackRecordList(output.cloudFormationStackRecords, context)
         : undefined,
-    nextPageToken:
-      output.nextPageToken !== undefined && output.nextPageToken !== null ? output.nextPageToken : undefined,
+    nextPageToken: __expectString(output.nextPageToken),
   } as any;
 };
 
@@ -20679,8 +20611,7 @@ const deserializeAws_json1_1GetContainerLogResult = (output: any, context: __Ser
       output.logEvents !== undefined && output.logEvents !== null
         ? deserializeAws_json1_1ContainerServiceLogEventList(output.logEvents, context)
         : undefined,
-    nextPageToken:
-      output.nextPageToken !== undefined && output.nextPageToken !== null ? output.nextPageToken : undefined,
+    nextPageToken: __expectString(output.nextPageToken),
   } as any;
 };
 
@@ -20705,7 +20636,7 @@ const deserializeAws_json1_1GetContainerServiceMetricDataResult = (
       output.metricData !== undefined && output.metricData !== null
         ? deserializeAws_json1_1MetricDatapointList(output.metricData, context)
         : undefined,
-    metricName: output.metricName !== undefined && output.metricName !== null ? output.metricName : undefined,
+    metricName: __expectString(output.metricName),
   } as any;
 };
 
@@ -20743,8 +20674,7 @@ const deserializeAws_json1_1GetDiskSnapshotsResult = (output: any, context: __Se
       output.diskSnapshots !== undefined && output.diskSnapshots !== null
         ? deserializeAws_json1_1DiskSnapshotList(output.diskSnapshots, context)
         : undefined,
-    nextPageToken:
-      output.nextPageToken !== undefined && output.nextPageToken !== null ? output.nextPageToken : undefined,
+    nextPageToken: __expectString(output.nextPageToken),
   } as any;
 };
 
@@ -20754,8 +20684,7 @@ const deserializeAws_json1_1GetDisksResult = (output: any, context: __SerdeConte
       output.disks !== undefined && output.disks !== null
         ? deserializeAws_json1_1DiskList(output.disks, context)
         : undefined,
-    nextPageToken:
-      output.nextPageToken !== undefined && output.nextPageToken !== null ? output.nextPageToken : undefined,
+    nextPageToken: __expectString(output.nextPageToken),
   } as any;
 };
 
@@ -20780,7 +20709,7 @@ const deserializeAws_json1_1GetDistributionLatestCacheResetResult = (
       output.createTime !== undefined && output.createTime !== null
         ? new Date(Math.round(output.createTime * 1000))
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -20793,7 +20722,7 @@ const deserializeAws_json1_1GetDistributionMetricDataResult = (
       output.metricData !== undefined && output.metricData !== null
         ? deserializeAws_json1_1MetricDatapointList(output.metricData, context)
         : undefined,
-    metricName: output.metricName !== undefined && output.metricName !== null ? output.metricName : undefined,
+    metricName: __expectString(output.metricName),
   } as any;
 };
 
@@ -20803,8 +20732,7 @@ const deserializeAws_json1_1GetDistributionsResult = (output: any, context: __Se
       output.distributions !== undefined && output.distributions !== null
         ? deserializeAws_json1_1DistributionList(output.distributions, context)
         : undefined,
-    nextPageToken:
-      output.nextPageToken !== undefined && output.nextPageToken !== null ? output.nextPageToken : undefined,
+    nextPageToken: __expectString(output.nextPageToken),
   } as any;
 };
 
@@ -20823,8 +20751,7 @@ const deserializeAws_json1_1GetDomainsResult = (output: any, context: __SerdeCon
       output.domains !== undefined && output.domains !== null
         ? deserializeAws_json1_1DomainList(output.domains, context)
         : undefined,
-    nextPageToken:
-      output.nextPageToken !== undefined && output.nextPageToken !== null ? output.nextPageToken : undefined,
+    nextPageToken: __expectString(output.nextPageToken),
   } as any;
 };
 
@@ -20837,8 +20764,7 @@ const deserializeAws_json1_1GetExportSnapshotRecordsResult = (
       output.exportSnapshotRecords !== undefined && output.exportSnapshotRecords !== null
         ? deserializeAws_json1_1ExportSnapshotRecordList(output.exportSnapshotRecords, context)
         : undefined,
-    nextPageToken:
-      output.nextPageToken !== undefined && output.nextPageToken !== null ? output.nextPageToken : undefined,
+    nextPageToken: __expectString(output.nextPageToken),
   } as any;
 };
 
@@ -20863,7 +20789,7 @@ const deserializeAws_json1_1GetInstanceMetricDataResult = (
       output.metricData !== undefined && output.metricData !== null
         ? deserializeAws_json1_1MetricDatapointList(output.metricData, context)
         : undefined,
-    metricName: output.metricName !== undefined && output.metricName !== null ? output.metricName : undefined,
+    metricName: __expectString(output.metricName),
   } as any;
 };
 
@@ -20909,8 +20835,7 @@ const deserializeAws_json1_1GetInstanceSnapshotsResult = (
       output.instanceSnapshots !== undefined && output.instanceSnapshots !== null
         ? deserializeAws_json1_1InstanceSnapshotList(output.instanceSnapshots, context)
         : undefined,
-    nextPageToken:
-      output.nextPageToken !== undefined && output.nextPageToken !== null ? output.nextPageToken : undefined,
+    nextPageToken: __expectString(output.nextPageToken),
   } as any;
 };
 
@@ -20920,8 +20845,7 @@ const deserializeAws_json1_1GetInstancesResult = (output: any, context: __SerdeC
       output.instances !== undefined && output.instances !== null
         ? deserializeAws_json1_1InstanceList(output.instances, context)
         : undefined,
-    nextPageToken:
-      output.nextPageToken !== undefined && output.nextPageToken !== null ? output.nextPageToken : undefined,
+    nextPageToken: __expectString(output.nextPageToken),
   } as any;
 };
 
@@ -20949,8 +20873,7 @@ const deserializeAws_json1_1GetKeyPairsResult = (output: any, context: __SerdeCo
       output.keyPairs !== undefined && output.keyPairs !== null
         ? deserializeAws_json1_1KeyPairList(output.keyPairs, context)
         : undefined,
-    nextPageToken:
-      output.nextPageToken !== undefined && output.nextPageToken !== null ? output.nextPageToken : undefined,
+    nextPageToken: __expectString(output.nextPageToken),
   } as any;
 };
 
@@ -20963,7 +20886,7 @@ const deserializeAws_json1_1GetLoadBalancerMetricDataResult = (
       output.metricData !== undefined && output.metricData !== null
         ? deserializeAws_json1_1MetricDatapointList(output.metricData, context)
         : undefined,
-    metricName: output.metricName !== undefined && output.metricName !== null ? output.metricName : undefined,
+    metricName: __expectString(output.metricName),
   } as any;
 };
 
@@ -20982,8 +20905,7 @@ const deserializeAws_json1_1GetLoadBalancersResult = (output: any, context: __Se
       output.loadBalancers !== undefined && output.loadBalancers !== null
         ? deserializeAws_json1_1LoadBalancerList(output.loadBalancers, context)
         : undefined,
-    nextPageToken:
-      output.nextPageToken !== undefined && output.nextPageToken !== null ? output.nextPageToken : undefined,
+    nextPageToken: __expectString(output.nextPageToken),
   } as any;
 };
 
@@ -21013,10 +20935,8 @@ const deserializeAws_json1_1GetOperationsForResourceResult = (
   context: __SerdeContext
 ): GetOperationsForResourceResult => {
   return {
-    nextPageCount:
-      output.nextPageCount !== undefined && output.nextPageCount !== null ? output.nextPageCount : undefined,
-    nextPageToken:
-      output.nextPageToken !== undefined && output.nextPageToken !== null ? output.nextPageToken : undefined,
+    nextPageCount: __expectString(output.nextPageCount),
+    nextPageToken: __expectString(output.nextPageToken),
     operations:
       output.operations !== undefined && output.operations !== null
         ? deserializeAws_json1_1OperationList(output.operations, context)
@@ -21026,8 +20946,7 @@ const deserializeAws_json1_1GetOperationsForResourceResult = (
 
 const deserializeAws_json1_1GetOperationsResult = (output: any, context: __SerdeContext): GetOperationsResult => {
   return {
-    nextPageToken:
-      output.nextPageToken !== undefined && output.nextPageToken !== null ? output.nextPageToken : undefined,
+    nextPageToken: __expectString(output.nextPageToken),
     operations:
       output.operations !== undefined && output.operations !== null
         ? deserializeAws_json1_1OperationList(output.operations, context)
@@ -21053,8 +20972,7 @@ const deserializeAws_json1_1GetRelationalDatabaseBlueprintsResult = (
       output.blueprints !== undefined && output.blueprints !== null
         ? deserializeAws_json1_1RelationalDatabaseBlueprintList(output.blueprints, context)
         : undefined,
-    nextPageToken:
-      output.nextPageToken !== undefined && output.nextPageToken !== null ? output.nextPageToken : undefined,
+    nextPageToken: __expectString(output.nextPageToken),
   } as any;
 };
 
@@ -21067,8 +20985,7 @@ const deserializeAws_json1_1GetRelationalDatabaseBundlesResult = (
       output.bundles !== undefined && output.bundles !== null
         ? deserializeAws_json1_1RelationalDatabaseBundleList(output.bundles, context)
         : undefined,
-    nextPageToken:
-      output.nextPageToken !== undefined && output.nextPageToken !== null ? output.nextPageToken : undefined,
+    nextPageToken: __expectString(output.nextPageToken),
   } as any;
 };
 
@@ -21077,8 +20994,7 @@ const deserializeAws_json1_1GetRelationalDatabaseEventsResult = (
   context: __SerdeContext
 ): GetRelationalDatabaseEventsResult => {
   return {
-    nextPageToken:
-      output.nextPageToken !== undefined && output.nextPageToken !== null ? output.nextPageToken : undefined,
+    nextPageToken: __expectString(output.nextPageToken),
     relationalDatabaseEvents:
       output.relationalDatabaseEvents !== undefined && output.relationalDatabaseEvents !== null
         ? deserializeAws_json1_1RelationalDatabaseEventList(output.relationalDatabaseEvents, context)
@@ -21091,12 +21007,8 @@ const deserializeAws_json1_1GetRelationalDatabaseLogEventsResult = (
   context: __SerdeContext
 ): GetRelationalDatabaseLogEventsResult => {
   return {
-    nextBackwardToken:
-      output.nextBackwardToken !== undefined && output.nextBackwardToken !== null
-        ? output.nextBackwardToken
-        : undefined,
-    nextForwardToken:
-      output.nextForwardToken !== undefined && output.nextForwardToken !== null ? output.nextForwardToken : undefined,
+    nextBackwardToken: __expectString(output.nextBackwardToken),
+    nextForwardToken: __expectString(output.nextForwardToken),
     resourceLogEvents:
       output.resourceLogEvents !== undefined && output.resourceLogEvents !== null
         ? deserializeAws_json1_1LogEventList(output.resourceLogEvents, context)
@@ -21125,10 +21037,7 @@ const deserializeAws_json1_1GetRelationalDatabaseMasterUserPasswordResult = (
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    masterUserPassword:
-      output.masterUserPassword !== undefined && output.masterUserPassword !== null
-        ? output.masterUserPassword
-        : undefined,
+    masterUserPassword: __expectString(output.masterUserPassword),
   } as any;
 };
 
@@ -21141,7 +21050,7 @@ const deserializeAws_json1_1GetRelationalDatabaseMetricDataResult = (
       output.metricData !== undefined && output.metricData !== null
         ? deserializeAws_json1_1MetricDatapointList(output.metricData, context)
         : undefined,
-    metricName: output.metricName !== undefined && output.metricName !== null ? output.metricName : undefined,
+    metricName: __expectString(output.metricName),
   } as any;
 };
 
@@ -21150,8 +21059,7 @@ const deserializeAws_json1_1GetRelationalDatabaseParametersResult = (
   context: __SerdeContext
 ): GetRelationalDatabaseParametersResult => {
   return {
-    nextPageToken:
-      output.nextPageToken !== undefined && output.nextPageToken !== null ? output.nextPageToken : undefined,
+    nextPageToken: __expectString(output.nextPageToken),
     parameters:
       output.parameters !== undefined && output.parameters !== null
         ? deserializeAws_json1_1RelationalDatabaseParameterList(output.parameters, context)
@@ -21188,8 +21096,7 @@ const deserializeAws_json1_1GetRelationalDatabaseSnapshotsResult = (
   context: __SerdeContext
 ): GetRelationalDatabaseSnapshotsResult => {
   return {
-    nextPageToken:
-      output.nextPageToken !== undefined && output.nextPageToken !== null ? output.nextPageToken : undefined,
+    nextPageToken: __expectString(output.nextPageToken),
     relationalDatabaseSnapshots:
       output.relationalDatabaseSnapshots !== undefined && output.relationalDatabaseSnapshots !== null
         ? deserializeAws_json1_1RelationalDatabaseSnapshotList(output.relationalDatabaseSnapshots, context)
@@ -21202,8 +21109,7 @@ const deserializeAws_json1_1GetRelationalDatabasesResult = (
   context: __SerdeContext
 ): GetRelationalDatabasesResult => {
   return {
-    nextPageToken:
-      output.nextPageToken !== undefined && output.nextPageToken !== null ? output.nextPageToken : undefined,
+    nextPageToken: __expectString(output.nextPageToken),
     relationalDatabases:
       output.relationalDatabases !== undefined && output.relationalDatabases !== null
         ? deserializeAws_json1_1RelationalDatabaseList(output.relationalDatabases, context)
@@ -21222,8 +21128,7 @@ const deserializeAws_json1_1GetStaticIpResult = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1GetStaticIpsResult = (output: any, context: __SerdeContext): GetStaticIpsResult => {
   return {
-    nextPageToken:
-      output.nextPageToken !== undefined && output.nextPageToken !== null ? output.nextPageToken : undefined,
+    nextPageToken: __expectString(output.nextPageToken),
     staticIps:
       output.staticIps !== undefined && output.staticIps !== null
         ? deserializeAws_json1_1StaticIpList(output.staticIps, context)
@@ -21238,7 +21143,7 @@ const deserializeAws_json1_1HeaderForwardList = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -21248,19 +21153,15 @@ const deserializeAws_json1_1HeaderObject = (output: any, context: __SerdeContext
       output.headersAllowList !== undefined && output.headersAllowList !== null
         ? deserializeAws_json1_1HeaderForwardList(output.headersAllowList, context)
         : undefined,
-    option: output.option !== undefined && output.option !== null ? output.option : undefined,
+    option: __expectString(output.option),
   } as any;
 };
 
 const deserializeAws_json1_1HostKeyAttributes = (output: any, context: __SerdeContext): HostKeyAttributes => {
   return {
-    algorithm: output.algorithm !== undefined && output.algorithm !== null ? output.algorithm : undefined,
-    fingerprintSHA1:
-      output.fingerprintSHA1 !== undefined && output.fingerprintSHA1 !== null ? output.fingerprintSHA1 : undefined,
-    fingerprintSHA256:
-      output.fingerprintSHA256 !== undefined && output.fingerprintSHA256 !== null
-        ? output.fingerprintSHA256
-        : undefined,
+    algorithm: __expectString(output.algorithm),
+    fingerprintSHA1: __expectString(output.fingerprintSHA1),
+    fingerprintSHA256: __expectString(output.fingerprintSHA256),
     notValidAfter:
       output.notValidAfter !== undefined && output.notValidAfter !== null
         ? new Date(Math.round(output.notValidAfter * 1000))
@@ -21269,7 +21170,7 @@ const deserializeAws_json1_1HostKeyAttributes = (output: any, context: __SerdeCo
       output.notValidBefore !== undefined && output.notValidBefore !== null
         ? new Date(Math.round(output.notValidBefore * 1000))
         : undefined,
-    publicKey: output.publicKey !== undefined && output.publicKey !== null ? output.publicKey : undefined,
+    publicKey: __expectString(output.publicKey),
     witnessedAt:
       output.witnessedAt !== undefined && output.witnessedAt !== null
         ? new Date(Math.round(output.witnessedAt * 1000))
@@ -21303,11 +21204,10 @@ const deserializeAws_json1_1Instance = (output: any, context: __SerdeContext): I
       output.addOns !== undefined && output.addOns !== null
         ? deserializeAws_json1_1AddOnList(output.addOns, context)
         : undefined,
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    blueprintId: output.blueprintId !== undefined && output.blueprintId !== null ? output.blueprintId : undefined,
-    blueprintName:
-      output.blueprintName !== undefined && output.blueprintName !== null ? output.blueprintName : undefined,
-    bundleId: output.bundleId !== undefined && output.bundleId !== null ? output.bundleId : undefined,
+    arn: __expectString(output.arn),
+    blueprintId: __expectString(output.blueprintId),
+    blueprintName: __expectString(output.blueprintName),
+    bundleId: __expectString(output.bundleId),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
@@ -21316,44 +21216,41 @@ const deserializeAws_json1_1Instance = (output: any, context: __SerdeContext): I
       output.hardware !== undefined && output.hardware !== null
         ? deserializeAws_json1_1InstanceHardware(output.hardware, context)
         : undefined,
-    ipAddressType:
-      output.ipAddressType !== undefined && output.ipAddressType !== null ? output.ipAddressType : undefined,
+    ipAddressType: __expectString(output.ipAddressType),
     ipv6Addresses:
       output.ipv6Addresses !== undefined && output.ipv6Addresses !== null
         ? deserializeAws_json1_1Ipv6AddressList(output.ipv6Addresses, context)
         : undefined,
-    isStaticIp: output.isStaticIp !== undefined && output.isStaticIp !== null ? output.isStaticIp : undefined,
+    isStaticIp: __expectBoolean(output.isStaticIp),
     location:
       output.location !== undefined && output.location !== null
         ? deserializeAws_json1_1ResourceLocation(output.location, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
     networking:
       output.networking !== undefined && output.networking !== null
         ? deserializeAws_json1_1InstanceNetworking(output.networking, context)
         : undefined,
-    privateIpAddress:
-      output.privateIpAddress !== undefined && output.privateIpAddress !== null ? output.privateIpAddress : undefined,
-    publicIpAddress:
-      output.publicIpAddress !== undefined && output.publicIpAddress !== null ? output.publicIpAddress : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
-    sshKeyName: output.sshKeyName !== undefined && output.sshKeyName !== null ? output.sshKeyName : undefined,
+    privateIpAddress: __expectString(output.privateIpAddress),
+    publicIpAddress: __expectString(output.publicIpAddress),
+    resourceType: __expectString(output.resourceType),
+    sshKeyName: __expectString(output.sshKeyName),
     state:
       output.state !== undefined && output.state !== null
         ? deserializeAws_json1_1InstanceState(output.state, context)
         : undefined,
-    supportCode: output.supportCode !== undefined && output.supportCode !== null ? output.supportCode : undefined,
+    supportCode: __expectString(output.supportCode),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_json1_1TagList(output.tags, context)
         : undefined,
-    username: output.username !== undefined && output.username !== null ? output.username : undefined,
+    username: __expectString(output.username),
   } as any;
 };
 
 const deserializeAws_json1_1InstanceAccessDetails = (output: any, context: __SerdeContext): InstanceAccessDetails => {
   return {
-    certKey: output.certKey !== undefined && output.certKey !== null ? output.certKey : undefined,
+    certKey: __expectString(output.certKey),
     expiresAt:
       output.expiresAt !== undefined && output.expiresAt !== null
         ? new Date(Math.round(output.expiresAt * 1000))
@@ -21362,39 +21259,35 @@ const deserializeAws_json1_1InstanceAccessDetails = (output: any, context: __Ser
       output.hostKeys !== undefined && output.hostKeys !== null
         ? deserializeAws_json1_1HostKeysList(output.hostKeys, context)
         : undefined,
-    instanceName: output.instanceName !== undefined && output.instanceName !== null ? output.instanceName : undefined,
-    ipAddress: output.ipAddress !== undefined && output.ipAddress !== null ? output.ipAddress : undefined,
-    password: output.password !== undefined && output.password !== null ? output.password : undefined,
+    instanceName: __expectString(output.instanceName),
+    ipAddress: __expectString(output.ipAddress),
+    password: __expectString(output.password),
     passwordData:
       output.passwordData !== undefined && output.passwordData !== null
         ? deserializeAws_json1_1PasswordData(output.passwordData, context)
         : undefined,
-    privateKey: output.privateKey !== undefined && output.privateKey !== null ? output.privateKey : undefined,
-    protocol: output.protocol !== undefined && output.protocol !== null ? output.protocol : undefined,
-    username: output.username !== undefined && output.username !== null ? output.username : undefined,
+    privateKey: __expectString(output.privateKey),
+    protocol: __expectString(output.protocol),
+    username: __expectString(output.username),
   } as any;
 };
 
 const deserializeAws_json1_1InstanceHardware = (output: any, context: __SerdeContext): InstanceHardware => {
   return {
-    cpuCount: output.cpuCount !== undefined && output.cpuCount !== null ? output.cpuCount : undefined,
+    cpuCount: __expectNumber(output.cpuCount),
     disks:
       output.disks !== undefined && output.disks !== null
         ? deserializeAws_json1_1DiskList(output.disks, context)
         : undefined,
-    ramSizeInGb: output.ramSizeInGb !== undefined && output.ramSizeInGb !== null ? output.ramSizeInGb : undefined,
+    ramSizeInGb: __expectNumber(output.ramSizeInGb),
   } as any;
 };
 
 const deserializeAws_json1_1InstanceHealthSummary = (output: any, context: __SerdeContext): InstanceHealthSummary => {
   return {
-    instanceHealth:
-      output.instanceHealth !== undefined && output.instanceHealth !== null ? output.instanceHealth : undefined,
-    instanceHealthReason:
-      output.instanceHealthReason !== undefined && output.instanceHealthReason !== null
-        ? output.instanceHealthReason
-        : undefined,
-    instanceName: output.instanceName !== undefined && output.instanceName !== null ? output.instanceName : undefined,
+    instanceHealth: __expectString(output.instanceHealth),
+    instanceHealthReason: __expectString(output.instanceHealthReason),
+    instanceName: __expectString(output.instanceName),
   } as any;
 };
 
@@ -21446,16 +21339,15 @@ const deserializeAws_json1_1InstancePlatformList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1InstancePortInfo = (output: any, context: __SerdeContext): InstancePortInfo => {
   return {
-    accessDirection:
-      output.accessDirection !== undefined && output.accessDirection !== null ? output.accessDirection : undefined,
-    accessFrom: output.accessFrom !== undefined && output.accessFrom !== null ? output.accessFrom : undefined,
-    accessType: output.accessType !== undefined && output.accessType !== null ? output.accessType : undefined,
+    accessDirection: __expectString(output.accessDirection),
+    accessFrom: __expectString(output.accessFrom),
+    accessType: __expectString(output.accessType),
     cidrListAliases:
       output.cidrListAliases !== undefined && output.cidrListAliases !== null
         ? deserializeAws_json1_1StringList(output.cidrListAliases, context)
@@ -21464,14 +21356,14 @@ const deserializeAws_json1_1InstancePortInfo = (output: any, context: __SerdeCon
       output.cidrs !== undefined && output.cidrs !== null
         ? deserializeAws_json1_1StringList(output.cidrs, context)
         : undefined,
-    commonName: output.commonName !== undefined && output.commonName !== null ? output.commonName : undefined,
-    fromPort: output.fromPort !== undefined && output.fromPort !== null ? output.fromPort : undefined,
+    commonName: __expectString(output.commonName),
+    fromPort: __expectNumber(output.fromPort),
     ipv6Cidrs:
       output.ipv6Cidrs !== undefined && output.ipv6Cidrs !== null
         ? deserializeAws_json1_1StringList(output.ipv6Cidrs, context)
         : undefined,
-    protocol: output.protocol !== undefined && output.protocol !== null ? output.protocol : undefined,
-    toPort: output.toPort !== undefined && output.toPort !== null ? output.toPort : undefined,
+    protocol: __expectString(output.protocol),
+    toPort: __expectNumber(output.toPort),
   } as any;
 };
 
@@ -21496,14 +21388,14 @@ const deserializeAws_json1_1InstancePortState = (output: any, context: __SerdeCo
       output.cidrs !== undefined && output.cidrs !== null
         ? deserializeAws_json1_1StringList(output.cidrs, context)
         : undefined,
-    fromPort: output.fromPort !== undefined && output.fromPort !== null ? output.fromPort : undefined,
+    fromPort: __expectNumber(output.fromPort),
     ipv6Cidrs:
       output.ipv6Cidrs !== undefined && output.ipv6Cidrs !== null
         ? deserializeAws_json1_1StringList(output.ipv6Cidrs, context)
         : undefined,
-    protocol: output.protocol !== undefined && output.protocol !== null ? output.protocol : undefined,
-    state: output.state !== undefined && output.state !== null ? output.state : undefined,
-    toPort: output.toPort !== undefined && output.toPort !== null ? output.toPort : undefined,
+    protocol: __expectString(output.protocol),
+    state: __expectString(output.state),
+    toPort: __expectNumber(output.toPort),
   } as any;
 };
 
@@ -21520,7 +21412,7 @@ const deserializeAws_json1_1InstancePortStateList = (output: any, context: __Ser
 
 const deserializeAws_json1_1InstanceSnapshot = (output: any, context: __SerdeContext): InstanceSnapshot => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
@@ -21529,27 +21421,21 @@ const deserializeAws_json1_1InstanceSnapshot = (output: any, context: __SerdeCon
       output.fromAttachedDisks !== undefined && output.fromAttachedDisks !== null
         ? deserializeAws_json1_1DiskList(output.fromAttachedDisks, context)
         : undefined,
-    fromBlueprintId:
-      output.fromBlueprintId !== undefined && output.fromBlueprintId !== null ? output.fromBlueprintId : undefined,
-    fromBundleId: output.fromBundleId !== undefined && output.fromBundleId !== null ? output.fromBundleId : undefined,
-    fromInstanceArn:
-      output.fromInstanceArn !== undefined && output.fromInstanceArn !== null ? output.fromInstanceArn : undefined,
-    fromInstanceName:
-      output.fromInstanceName !== undefined && output.fromInstanceName !== null ? output.fromInstanceName : undefined,
-    isFromAutoSnapshot:
-      output.isFromAutoSnapshot !== undefined && output.isFromAutoSnapshot !== null
-        ? output.isFromAutoSnapshot
-        : undefined,
+    fromBlueprintId: __expectString(output.fromBlueprintId),
+    fromBundleId: __expectString(output.fromBundleId),
+    fromInstanceArn: __expectString(output.fromInstanceArn),
+    fromInstanceName: __expectString(output.fromInstanceName),
+    isFromAutoSnapshot: __expectBoolean(output.isFromAutoSnapshot),
     location:
       output.location !== undefined && output.location !== null
         ? deserializeAws_json1_1ResourceLocation(output.location, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    progress: output.progress !== undefined && output.progress !== null ? output.progress : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
-    sizeInGb: output.sizeInGb !== undefined && output.sizeInGb !== null ? output.sizeInGb : undefined,
-    state: output.state !== undefined && output.state !== null ? output.state : undefined,
-    supportCode: output.supportCode !== undefined && output.supportCode !== null ? output.supportCode : undefined,
+    name: __expectString(output.name),
+    progress: __expectString(output.progress),
+    resourceType: __expectString(output.resourceType),
+    sizeInGb: __expectNumber(output.sizeInGb),
+    state: __expectString(output.state),
+    supportCode: __expectString(output.supportCode),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_json1_1TagList(output.tags, context)
@@ -21559,9 +21445,8 @@ const deserializeAws_json1_1InstanceSnapshot = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1InstanceSnapshotInfo = (output: any, context: __SerdeContext): InstanceSnapshotInfo => {
   return {
-    fromBlueprintId:
-      output.fromBlueprintId !== undefined && output.fromBlueprintId !== null ? output.fromBlueprintId : undefined,
-    fromBundleId: output.fromBundleId !== undefined && output.fromBundleId !== null ? output.fromBundleId : undefined,
+    fromBlueprintId: __expectString(output.fromBlueprintId),
+    fromBundleId: __expectString(output.fromBundleId),
     fromDiskInfo:
       output.fromDiskInfo !== undefined && output.fromDiskInfo !== null
         ? deserializeAws_json1_1DiskInfoList(output.fromDiskInfo, context)
@@ -21582,17 +21467,17 @@ const deserializeAws_json1_1InstanceSnapshotList = (output: any, context: __Serd
 
 const deserializeAws_json1_1InstanceState = (output: any, context: __SerdeContext): InstanceState => {
   return {
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    code: __expectNumber(output.code),
+    name: __expectString(output.name),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidInputException = (output: any, context: __SerdeContext): InvalidInputException => {
   return {
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    docs: output.docs !== undefined && output.docs !== null ? output.docs : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    tip: output.tip !== undefined && output.tip !== null ? output.tip : undefined,
+    code: __expectString(output.code),
+    docs: __expectString(output.docs),
+    message: __expectString(output.message),
+    tip: __expectString(output.tip),
   } as any;
 };
 
@@ -21603,31 +21488,31 @@ const deserializeAws_json1_1Ipv6AddressList = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1IsVpcPeeredResult = (output: any, context: __SerdeContext): IsVpcPeeredResult => {
   return {
-    isPeered: output.isPeered !== undefined && output.isPeered !== null ? output.isPeered : undefined,
+    isPeered: __expectBoolean(output.isPeered),
   } as any;
 };
 
 const deserializeAws_json1_1KeyPair = (output: any, context: __SerdeContext): KeyPair => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    fingerprint: output.fingerprint !== undefined && output.fingerprint !== null ? output.fingerprint : undefined,
+    fingerprint: __expectString(output.fingerprint),
     location:
       output.location !== undefined && output.location !== null
         ? deserializeAws_json1_1ResourceLocation(output.location, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
-    supportCode: output.supportCode !== undefined && output.supportCode !== null ? output.supportCode : undefined,
+    name: __expectString(output.name),
+    resourceType: __expectString(output.resourceType),
+    supportCode: __expectString(output.supportCode),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_json1_1TagList(output.tags, context)
@@ -21648,16 +21533,13 @@ const deserializeAws_json1_1KeyPairList = (output: any, context: __SerdeContext)
 
 const deserializeAws_json1_1LightsailDistribution = (output: any, context: __SerdeContext): LightsailDistribution => {
   return {
-    ableToUpdateBundle:
-      output.ableToUpdateBundle !== undefined && output.ableToUpdateBundle !== null
-        ? output.ableToUpdateBundle
-        : undefined,
+    ableToUpdateBundle: __expectBoolean(output.ableToUpdateBundle),
     alternativeDomainNames:
       output.alternativeDomainNames !== undefined && output.alternativeDomainNames !== null
         ? deserializeAws_json1_1StringList(output.alternativeDomainNames, context)
         : undefined,
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    bundleId: output.bundleId !== undefined && output.bundleId !== null ? output.bundleId : undefined,
+    arn: __expectString(output.arn),
+    bundleId: __expectString(output.bundleId),
     cacheBehaviorSettings:
       output.cacheBehaviorSettings !== undefined && output.cacheBehaviorSettings !== null
         ? deserializeAws_json1_1CacheSettings(output.cacheBehaviorSettings, context)
@@ -21666,8 +21548,7 @@ const deserializeAws_json1_1LightsailDistribution = (output: any, context: __Ser
       output.cacheBehaviors !== undefined && output.cacheBehaviors !== null
         ? deserializeAws_json1_1CacheBehaviorList(output.cacheBehaviors, context)
         : undefined,
-    certificateName:
-      output.certificateName !== undefined && output.certificateName !== null ? output.certificateName : undefined,
+    certificateName: __expectString(output.certificateName),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
@@ -21676,24 +21557,22 @@ const deserializeAws_json1_1LightsailDistribution = (output: any, context: __Ser
       output.defaultCacheBehavior !== undefined && output.defaultCacheBehavior !== null
         ? deserializeAws_json1_1CacheBehavior(output.defaultCacheBehavior, context)
         : undefined,
-    domainName: output.domainName !== undefined && output.domainName !== null ? output.domainName : undefined,
-    ipAddressType:
-      output.ipAddressType !== undefined && output.ipAddressType !== null ? output.ipAddressType : undefined,
-    isEnabled: output.isEnabled !== undefined && output.isEnabled !== null ? output.isEnabled : undefined,
+    domainName: __expectString(output.domainName),
+    ipAddressType: __expectString(output.ipAddressType),
+    isEnabled: __expectBoolean(output.isEnabled),
     location:
       output.location !== undefined && output.location !== null
         ? deserializeAws_json1_1ResourceLocation(output.location, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
     origin:
       output.origin !== undefined && output.origin !== null
         ? deserializeAws_json1_1Origin(output.origin, context)
         : undefined,
-    originPublicDNS:
-      output.originPublicDNS !== undefined && output.originPublicDNS !== null ? output.originPublicDNS : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    supportCode: output.supportCode !== undefined && output.supportCode !== null ? output.supportCode : undefined,
+    originPublicDNS: __expectString(output.originPublicDNS),
+    resourceType: __expectString(output.resourceType),
+    status: __expectString(output.status),
+    supportCode: __expectString(output.supportCode),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_json1_1TagList(output.tags, context)
@@ -21703,7 +21582,7 @@ const deserializeAws_json1_1LightsailDistribution = (output: any, context: __Ser
 
 const deserializeAws_json1_1LoadBalancer = (output: any, context: __SerdeContext): LoadBalancer => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     configurationOptions:
       output.configurationOptions !== undefined && output.configurationOptions !== null
         ? deserializeAws_json1_1LoadBalancerConfigurationOptions(output.configurationOptions, context)
@@ -21712,29 +21591,27 @@ const deserializeAws_json1_1LoadBalancer = (output: any, context: __SerdeContext
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    dnsName: output.dnsName !== undefined && output.dnsName !== null ? output.dnsName : undefined,
-    healthCheckPath:
-      output.healthCheckPath !== undefined && output.healthCheckPath !== null ? output.healthCheckPath : undefined,
+    dnsName: __expectString(output.dnsName),
+    healthCheckPath: __expectString(output.healthCheckPath),
     instanceHealthSummary:
       output.instanceHealthSummary !== undefined && output.instanceHealthSummary !== null
         ? deserializeAws_json1_1InstanceHealthSummaryList(output.instanceHealthSummary, context)
         : undefined,
-    instancePort: output.instancePort !== undefined && output.instancePort !== null ? output.instancePort : undefined,
-    ipAddressType:
-      output.ipAddressType !== undefined && output.ipAddressType !== null ? output.ipAddressType : undefined,
+    instancePort: __expectNumber(output.instancePort),
+    ipAddressType: __expectString(output.ipAddressType),
     location:
       output.location !== undefined && output.location !== null
         ? deserializeAws_json1_1ResourceLocation(output.location, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    protocol: output.protocol !== undefined && output.protocol !== null ? output.protocol : undefined,
+    name: __expectString(output.name),
+    protocol: __expectString(output.protocol),
     publicPorts:
       output.publicPorts !== undefined && output.publicPorts !== null
         ? deserializeAws_json1_1PortList(output.publicPorts, context)
         : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
-    state: output.state !== undefined && output.state !== null ? output.state : undefined,
-    supportCode: output.supportCode !== undefined && output.supportCode !== null ? output.supportCode : undefined,
+    resourceType: __expectString(output.resourceType),
+    state: __expectString(output.state),
+    supportCode: __expectString(output.supportCode),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_json1_1TagList(output.tags, context)
@@ -21757,7 +21634,7 @@ const deserializeAws_json1_1LoadBalancerConfigurationOptions = (
       }
       return {
         ...acc,
-        [key]: value,
+        [key]: __expectString(value) as any,
       };
     },
     {}
@@ -21780,12 +21657,12 @@ const deserializeAws_json1_1LoadBalancerTlsCertificate = (
   context: __SerdeContext
 ): LoadBalancerTlsCertificate => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    domainName: output.domainName !== undefined && output.domainName !== null ? output.domainName : undefined,
+    domainName: __expectString(output.domainName),
     domainValidationRecords:
       output.domainValidationRecords !== undefined && output.domainValidationRecords !== null
         ? deserializeAws_json1_1LoadBalancerTlsCertificateDomainValidationRecordList(
@@ -21793,22 +21670,20 @@ const deserializeAws_json1_1LoadBalancerTlsCertificate = (
             context
           )
         : undefined,
-    failureReason:
-      output.failureReason !== undefined && output.failureReason !== null ? output.failureReason : undefined,
-    isAttached: output.isAttached !== undefined && output.isAttached !== null ? output.isAttached : undefined,
+    failureReason: __expectString(output.failureReason),
+    isAttached: __expectBoolean(output.isAttached),
     issuedAt:
       output.issuedAt !== undefined && output.issuedAt !== null
         ? new Date(Math.round(output.issuedAt * 1000))
         : undefined,
-    issuer: output.issuer !== undefined && output.issuer !== null ? output.issuer : undefined,
-    keyAlgorithm: output.keyAlgorithm !== undefined && output.keyAlgorithm !== null ? output.keyAlgorithm : undefined,
-    loadBalancerName:
-      output.loadBalancerName !== undefined && output.loadBalancerName !== null ? output.loadBalancerName : undefined,
+    issuer: __expectString(output.issuer),
+    keyAlgorithm: __expectString(output.keyAlgorithm),
+    loadBalancerName: __expectString(output.loadBalancerName),
     location:
       output.location !== undefined && output.location !== null
         ? deserializeAws_json1_1ResourceLocation(output.location, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
     notAfter:
       output.notAfter !== undefined && output.notAfter !== null
         ? new Date(Math.round(output.notAfter * 1000))
@@ -21821,25 +21696,21 @@ const deserializeAws_json1_1LoadBalancerTlsCertificate = (
       output.renewalSummary !== undefined && output.renewalSummary !== null
         ? deserializeAws_json1_1LoadBalancerTlsCertificateRenewalSummary(output.renewalSummary, context)
         : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
-    revocationReason:
-      output.revocationReason !== undefined && output.revocationReason !== null ? output.revocationReason : undefined,
+    resourceType: __expectString(output.resourceType),
+    revocationReason: __expectString(output.revocationReason),
     revokedAt:
       output.revokedAt !== undefined && output.revokedAt !== null
         ? new Date(Math.round(output.revokedAt * 1000))
         : undefined,
-    serial: output.serial !== undefined && output.serial !== null ? output.serial : undefined,
-    signatureAlgorithm:
-      output.signatureAlgorithm !== undefined && output.signatureAlgorithm !== null
-        ? output.signatureAlgorithm
-        : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    subject: output.subject !== undefined && output.subject !== null ? output.subject : undefined,
+    serial: __expectString(output.serial),
+    signatureAlgorithm: __expectString(output.signatureAlgorithm),
+    status: __expectString(output.status),
+    subject: __expectString(output.subject),
     subjectAlternativeNames:
       output.subjectAlternativeNames !== undefined && output.subjectAlternativeNames !== null
         ? deserializeAws_json1_1StringList(output.subjectAlternativeNames, context)
         : undefined,
-    supportCode: output.supportCode !== undefined && output.supportCode !== null ? output.supportCode : undefined,
+    supportCode: __expectString(output.supportCode),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_json1_1TagList(output.tags, context)
@@ -21852,9 +21723,8 @@ const deserializeAws_json1_1LoadBalancerTlsCertificateDomainValidationOption = (
   context: __SerdeContext
 ): LoadBalancerTlsCertificateDomainValidationOption => {
   return {
-    domainName: output.domainName !== undefined && output.domainName !== null ? output.domainName : undefined,
-    validationStatus:
-      output.validationStatus !== undefined && output.validationStatus !== null ? output.validationStatus : undefined,
+    domainName: __expectString(output.domainName),
+    validationStatus: __expectString(output.validationStatus),
   } as any;
 };
 
@@ -21877,12 +21747,11 @@ const deserializeAws_json1_1LoadBalancerTlsCertificateDomainValidationRecord = (
   context: __SerdeContext
 ): LoadBalancerTlsCertificateDomainValidationRecord => {
   return {
-    domainName: output.domainName !== undefined && output.domainName !== null ? output.domainName : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
-    validationStatus:
-      output.validationStatus !== undefined && output.validationStatus !== null ? output.validationStatus : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    domainName: __expectString(output.domainName),
+    name: __expectString(output.name),
+    type: __expectString(output.type),
+    validationStatus: __expectString(output.validationStatus),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -21926,8 +21795,7 @@ const deserializeAws_json1_1LoadBalancerTlsCertificateRenewalSummary = (
             context
           )
         : undefined,
-    renewalStatus:
-      output.renewalStatus !== undefined && output.renewalStatus !== null ? output.renewalStatus : undefined,
+    renewalStatus: __expectString(output.renewalStatus),
   } as any;
 };
 
@@ -21936,8 +21804,8 @@ const deserializeAws_json1_1LoadBalancerTlsCertificateSummary = (
   context: __SerdeContext
 ): LoadBalancerTlsCertificateSummary => {
   return {
-    isAttached: output.isAttached !== undefined && output.isAttached !== null ? output.isAttached : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    isAttached: __expectBoolean(output.isAttached),
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -21961,7 +21829,7 @@ const deserializeAws_json1_1LogEvent = (output: any, context: __SerdeContext): L
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -21978,16 +21846,16 @@ const deserializeAws_json1_1LogEventList = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_1MetricDatapoint = (output: any, context: __SerdeContext): MetricDatapoint => {
   return {
-    average: output.average !== undefined && output.average !== null ? output.average : undefined,
-    maximum: output.maximum !== undefined && output.maximum !== null ? output.maximum : undefined,
-    minimum: output.minimum !== undefined && output.minimum !== null ? output.minimum : undefined,
-    sampleCount: output.sampleCount !== undefined && output.sampleCount !== null ? output.sampleCount : undefined,
-    sum: output.sum !== undefined && output.sum !== null ? output.sum : undefined,
+    average: __expectNumber(output.average),
+    maximum: __expectNumber(output.maximum),
+    minimum: __expectNumber(output.minimum),
+    sampleCount: __expectNumber(output.sampleCount),
+    sum: __expectNumber(output.sum),
     timestamp:
       output.timestamp !== undefined && output.timestamp !== null
         ? new Date(Math.round(output.timestamp * 1000))
         : undefined,
-    unit: output.unit !== undefined && output.unit !== null ? output.unit : undefined,
+    unit: __expectString(output.unit),
   } as any;
 };
 
@@ -22004,27 +21872,24 @@ const deserializeAws_json1_1MetricDatapointList = (output: any, context: __Serde
 
 const deserializeAws_json1_1MonitoredResourceInfo = (output: any, context: __SerdeContext): MonitoredResourceInfo => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
+    arn: __expectString(output.arn),
+    name: __expectString(output.name),
+    resourceType: __expectString(output.resourceType),
   } as any;
 };
 
 const deserializeAws_json1_1MonthlyTransfer = (output: any, context: __SerdeContext): MonthlyTransfer => {
   return {
-    gbPerMonthAllocated:
-      output.gbPerMonthAllocated !== undefined && output.gbPerMonthAllocated !== null
-        ? output.gbPerMonthAllocated
-        : undefined,
+    gbPerMonthAllocated: __expectNumber(output.gbPerMonthAllocated),
   } as any;
 };
 
 const deserializeAws_json1_1NotFoundException = (output: any, context: __SerdeContext): NotFoundException => {
   return {
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    docs: output.docs !== undefined && output.docs !== null ? output.docs : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    tip: output.tip !== undefined && output.tip !== null ? output.tip : undefined,
+    code: __expectString(output.code),
+    docs: __expectString(output.docs),
+    message: __expectString(output.message),
+    tip: __expectString(output.tip),
   } as any;
 };
 
@@ -22038,7 +21903,7 @@ const deserializeAws_json1_1NotificationTriggerList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -22060,21 +21925,19 @@ const deserializeAws_json1_1Operation = (output: any, context: __SerdeContext): 
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    errorCode: output.errorCode !== undefined && output.errorCode !== null ? output.errorCode : undefined,
-    errorDetails: output.errorDetails !== undefined && output.errorDetails !== null ? output.errorDetails : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    isTerminal: output.isTerminal !== undefined && output.isTerminal !== null ? output.isTerminal : undefined,
+    errorCode: __expectString(output.errorCode),
+    errorDetails: __expectString(output.errorDetails),
+    id: __expectString(output.id),
+    isTerminal: __expectBoolean(output.isTerminal),
     location:
       output.location !== undefined && output.location !== null
         ? deserializeAws_json1_1ResourceLocation(output.location, context)
         : undefined,
-    operationDetails:
-      output.operationDetails !== undefined && output.operationDetails !== null ? output.operationDetails : undefined,
-    operationType:
-      output.operationType !== undefined && output.operationType !== null ? output.operationType : undefined,
-    resourceName: output.resourceName !== undefined && output.resourceName !== null ? output.resourceName : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    operationDetails: __expectString(output.operationDetails),
+    operationType: __expectString(output.operationType),
+    resourceName: __expectString(output.resourceName),
+    resourceType: __expectString(output.resourceType),
+    status: __expectString(output.status),
     statusChangedAt:
       output.statusChangedAt !== undefined && output.statusChangedAt !== null
         ? new Date(Math.round(output.statusChangedAt * 1000))
@@ -22087,10 +21950,10 @@ const deserializeAws_json1_1OperationFailureException = (
   context: __SerdeContext
 ): OperationFailureException => {
   return {
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    docs: output.docs !== undefined && output.docs !== null ? output.docs : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    tip: output.tip !== undefined && output.tip !== null ? output.tip : undefined,
+    code: __expectString(output.code),
+    docs: __expectString(output.docs),
+    message: __expectString(output.message),
+    tip: __expectString(output.tip),
   } as any;
 };
 
@@ -22107,18 +21970,17 @@ const deserializeAws_json1_1OperationList = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1Origin = (output: any, context: __SerdeContext): Origin => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    protocolPolicy:
-      output.protocolPolicy !== undefined && output.protocolPolicy !== null ? output.protocolPolicy : undefined,
-    regionName: output.regionName !== undefined && output.regionName !== null ? output.regionName : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
+    name: __expectString(output.name),
+    protocolPolicy: __expectString(output.protocolPolicy),
+    regionName: __expectString(output.regionName),
+    resourceType: __expectString(output.resourceType),
   } as any;
 };
 
 const deserializeAws_json1_1PasswordData = (output: any, context: __SerdeContext): PasswordData => {
   return {
-    ciphertext: output.ciphertext !== undefined && output.ciphertext !== null ? output.ciphertext : undefined,
-    keyPairName: output.keyPairName !== undefined && output.keyPairName !== null ? output.keyPairName : undefined,
+    ciphertext: __expectString(output.ciphertext),
+    keyPairName: __expectString(output.keyPairName),
   } as any;
 };
 
@@ -22136,12 +21998,12 @@ const deserializeAws_json1_1PendingMaintenanceAction = (
   context: __SerdeContext
 ): PendingMaintenanceAction => {
   return {
-    action: output.action !== undefined && output.action !== null ? output.action : undefined,
+    action: __expectString(output.action),
     currentApplyDate:
       output.currentApplyDate !== undefined && output.currentApplyDate !== null
         ? new Date(Math.round(output.currentApplyDate * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    description: __expectString(output.description),
   } as any;
 };
 
@@ -22164,16 +22026,9 @@ const deserializeAws_json1_1PendingModifiedRelationalDatabaseValues = (
   context: __SerdeContext
 ): PendingModifiedRelationalDatabaseValues => {
   return {
-    backupRetentionEnabled:
-      output.backupRetentionEnabled !== undefined && output.backupRetentionEnabled !== null
-        ? output.backupRetentionEnabled
-        : undefined,
-    engineVersion:
-      output.engineVersion !== undefined && output.engineVersion !== null ? output.engineVersion : undefined,
-    masterUserPassword:
-      output.masterUserPassword !== undefined && output.masterUserPassword !== null
-        ? output.masterUserPassword
-        : undefined,
+    backupRetentionEnabled: __expectBoolean(output.backupRetentionEnabled),
+    engineVersion: __expectString(output.engineVersion),
+    masterUserPassword: __expectString(output.masterUserPassword),
   } as any;
 };
 
@@ -22184,7 +22039,7 @@ const deserializeAws_json1_1PortList = (output: any, context: __SerdeContext): n
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectNumber(entry) as any;
     });
 };
 
@@ -22199,7 +22054,7 @@ const deserializeAws_json1_1PortMap = (
       }
       return {
         ...acc,
-        [key]: value,
+        [key]: __expectString(value) as any,
       };
     },
     {}
@@ -22229,7 +22084,7 @@ const deserializeAws_json1_1PutInstancePublicPortsResult = (
 
 const deserializeAws_json1_1QueryStringObject = (output: any, context: __SerdeContext): QueryStringObject => {
   return {
-    option: output.option !== undefined && output.option !== null ? output.option : undefined,
+    option: __expectBoolean(output.option),
     queryStringsAllowList:
       output.queryStringsAllowList !== undefined && output.queryStringsAllowList !== null
         ? deserializeAws_json1_1StringList(output.queryStringsAllowList, context)
@@ -22264,11 +22119,10 @@ const deserializeAws_json1_1Region = (output: any, context: __SerdeContext): Reg
       output.availabilityZones !== undefined && output.availabilityZones !== null
         ? deserializeAws_json1_1AvailabilityZoneList(output.availabilityZones, context)
         : undefined,
-    continentCode:
-      output.continentCode !== undefined && output.continentCode !== null ? output.continentCode : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    displayName: output.displayName !== undefined && output.displayName !== null ? output.displayName : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    continentCode: __expectString(output.continentCode),
+    description: __expectString(output.description),
+    displayName: __expectString(output.displayName),
+    name: __expectString(output.name),
     relationalDatabaseAvailabilityZones:
       output.relationalDatabaseAvailabilityZones !== undefined && output.relationalDatabaseAvailabilityZones !== null
         ? deserializeAws_json1_1AvailabilityZoneList(output.relationalDatabaseAvailabilityZones, context)
@@ -22301,22 +22155,15 @@ const deserializeAws_json1_1RegisterContainerImageResult = (
 
 const deserializeAws_json1_1RelationalDatabase = (output: any, context: __SerdeContext): RelationalDatabase => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    backupRetentionEnabled:
-      output.backupRetentionEnabled !== undefined && output.backupRetentionEnabled !== null
-        ? output.backupRetentionEnabled
-        : undefined,
-    caCertificateIdentifier:
-      output.caCertificateIdentifier !== undefined && output.caCertificateIdentifier !== null
-        ? output.caCertificateIdentifier
-        : undefined,
+    arn: __expectString(output.arn),
+    backupRetentionEnabled: __expectBoolean(output.backupRetentionEnabled),
+    caCertificateIdentifier: __expectString(output.caCertificateIdentifier),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    engine: output.engine !== undefined && output.engine !== null ? output.engine : undefined,
-    engineVersion:
-      output.engineVersion !== undefined && output.engineVersion !== null ? output.engineVersion : undefined,
+    engine: __expectString(output.engine),
+    engineVersion: __expectString(output.engineVersion),
     hardware:
       output.hardware !== undefined && output.hardware !== null
         ? deserializeAws_json1_1RelationalDatabaseHardware(output.hardware, context)
@@ -22329,21 +22176,14 @@ const deserializeAws_json1_1RelationalDatabase = (output: any, context: __SerdeC
       output.location !== undefined && output.location !== null
         ? deserializeAws_json1_1ResourceLocation(output.location, context)
         : undefined,
-    masterDatabaseName:
-      output.masterDatabaseName !== undefined && output.masterDatabaseName !== null
-        ? output.masterDatabaseName
-        : undefined,
+    masterDatabaseName: __expectString(output.masterDatabaseName),
     masterEndpoint:
       output.masterEndpoint !== undefined && output.masterEndpoint !== null
         ? deserializeAws_json1_1RelationalDatabaseEndpoint(output.masterEndpoint, context)
         : undefined,
-    masterUsername:
-      output.masterUsername !== undefined && output.masterUsername !== null ? output.masterUsername : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    parameterApplyStatus:
-      output.parameterApplyStatus !== undefined && output.parameterApplyStatus !== null
-        ? output.parameterApplyStatus
-        : undefined,
+    masterUsername: __expectString(output.masterUsername),
+    name: __expectString(output.name),
+    parameterApplyStatus: __expectString(output.parameterApplyStatus),
     pendingMaintenanceActions:
       output.pendingMaintenanceActions !== undefined && output.pendingMaintenanceActions !== null
         ? deserializeAws_json1_1PendingMaintenanceActionList(output.pendingMaintenanceActions, context)
@@ -22352,33 +22192,15 @@ const deserializeAws_json1_1RelationalDatabase = (output: any, context: __SerdeC
       output.pendingModifiedValues !== undefined && output.pendingModifiedValues !== null
         ? deserializeAws_json1_1PendingModifiedRelationalDatabaseValues(output.pendingModifiedValues, context)
         : undefined,
-    preferredBackupWindow:
-      output.preferredBackupWindow !== undefined && output.preferredBackupWindow !== null
-        ? output.preferredBackupWindow
-        : undefined,
-    preferredMaintenanceWindow:
-      output.preferredMaintenanceWindow !== undefined && output.preferredMaintenanceWindow !== null
-        ? output.preferredMaintenanceWindow
-        : undefined,
-    publiclyAccessible:
-      output.publiclyAccessible !== undefined && output.publiclyAccessible !== null
-        ? output.publiclyAccessible
-        : undefined,
-    relationalDatabaseBlueprintId:
-      output.relationalDatabaseBlueprintId !== undefined && output.relationalDatabaseBlueprintId !== null
-        ? output.relationalDatabaseBlueprintId
-        : undefined,
-    relationalDatabaseBundleId:
-      output.relationalDatabaseBundleId !== undefined && output.relationalDatabaseBundleId !== null
-        ? output.relationalDatabaseBundleId
-        : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
-    secondaryAvailabilityZone:
-      output.secondaryAvailabilityZone !== undefined && output.secondaryAvailabilityZone !== null
-        ? output.secondaryAvailabilityZone
-        : undefined,
-    state: output.state !== undefined && output.state !== null ? output.state : undefined,
-    supportCode: output.supportCode !== undefined && output.supportCode !== null ? output.supportCode : undefined,
+    preferredBackupWindow: __expectString(output.preferredBackupWindow),
+    preferredMaintenanceWindow: __expectString(output.preferredMaintenanceWindow),
+    publiclyAccessible: __expectBoolean(output.publiclyAccessible),
+    relationalDatabaseBlueprintId: __expectString(output.relationalDatabaseBlueprintId),
+    relationalDatabaseBundleId: __expectString(output.relationalDatabaseBundleId),
+    resourceType: __expectString(output.resourceType),
+    secondaryAvailabilityZone: __expectString(output.secondaryAvailabilityZone),
+    state: __expectString(output.state),
+    supportCode: __expectString(output.supportCode),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_json1_1TagList(output.tags, context)
@@ -22391,20 +22213,12 @@ const deserializeAws_json1_1RelationalDatabaseBlueprint = (
   context: __SerdeContext
 ): RelationalDatabaseBlueprint => {
   return {
-    blueprintId: output.blueprintId !== undefined && output.blueprintId !== null ? output.blueprintId : undefined,
-    engine: output.engine !== undefined && output.engine !== null ? output.engine : undefined,
-    engineDescription:
-      output.engineDescription !== undefined && output.engineDescription !== null
-        ? output.engineDescription
-        : undefined,
-    engineVersion:
-      output.engineVersion !== undefined && output.engineVersion !== null ? output.engineVersion : undefined,
-    engineVersionDescription:
-      output.engineVersionDescription !== undefined && output.engineVersionDescription !== null
-        ? output.engineVersionDescription
-        : undefined,
-    isEngineDefault:
-      output.isEngineDefault !== undefined && output.isEngineDefault !== null ? output.isEngineDefault : undefined,
+    blueprintId: __expectString(output.blueprintId),
+    engine: __expectString(output.engine),
+    engineDescription: __expectString(output.engineDescription),
+    engineVersion: __expectString(output.engineVersion),
+    engineVersionDescription: __expectString(output.engineVersionDescription),
+    isEngineDefault: __expectBoolean(output.isEngineDefault),
   } as any;
 };
 
@@ -22427,18 +22241,15 @@ const deserializeAws_json1_1RelationalDatabaseBundle = (
   context: __SerdeContext
 ): RelationalDatabaseBundle => {
   return {
-    bundleId: output.bundleId !== undefined && output.bundleId !== null ? output.bundleId : undefined,
-    cpuCount: output.cpuCount !== undefined && output.cpuCount !== null ? output.cpuCount : undefined,
-    diskSizeInGb: output.diskSizeInGb !== undefined && output.diskSizeInGb !== null ? output.diskSizeInGb : undefined,
-    isActive: output.isActive !== undefined && output.isActive !== null ? output.isActive : undefined,
-    isEncrypted: output.isEncrypted !== undefined && output.isEncrypted !== null ? output.isEncrypted : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    price: output.price !== undefined && output.price !== null ? output.price : undefined,
-    ramSizeInGb: output.ramSizeInGb !== undefined && output.ramSizeInGb !== null ? output.ramSizeInGb : undefined,
-    transferPerMonthInGb:
-      output.transferPerMonthInGb !== undefined && output.transferPerMonthInGb !== null
-        ? output.transferPerMonthInGb
-        : undefined,
+    bundleId: __expectString(output.bundleId),
+    cpuCount: __expectNumber(output.cpuCount),
+    diskSizeInGb: __expectNumber(output.diskSizeInGb),
+    isActive: __expectBoolean(output.isActive),
+    isEncrypted: __expectBoolean(output.isEncrypted),
+    name: __expectString(output.name),
+    price: __expectNumber(output.price),
+    ramSizeInGb: __expectNumber(output.ramSizeInGb),
+    transferPerMonthInGb: __expectNumber(output.transferPerMonthInGb),
   } as any;
 };
 
@@ -22461,8 +22272,8 @@ const deserializeAws_json1_1RelationalDatabaseEndpoint = (
   context: __SerdeContext
 ): RelationalDatabaseEndpoint => {
   return {
-    address: output.address !== undefined && output.address !== null ? output.address : undefined,
-    port: output.port !== undefined && output.port !== null ? output.port : undefined,
+    address: __expectString(output.address),
+    port: __expectNumber(output.port),
   } as any;
 };
 
@@ -22479,8 +22290,8 @@ const deserializeAws_json1_1RelationalDatabaseEvent = (
       output.eventCategories !== undefined && output.eventCategories !== null
         ? deserializeAws_json1_1StringList(output.eventCategories, context)
         : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    resource: output.resource !== undefined && output.resource !== null ? output.resource : undefined,
+    message: __expectString(output.message),
+    resource: __expectString(output.resource),
   } as any;
 };
 
@@ -22503,9 +22314,9 @@ const deserializeAws_json1_1RelationalDatabaseHardware = (
   context: __SerdeContext
 ): RelationalDatabaseHardware => {
   return {
-    cpuCount: output.cpuCount !== undefined && output.cpuCount !== null ? output.cpuCount : undefined,
-    diskSizeInGb: output.diskSizeInGb !== undefined && output.diskSizeInGb !== null ? output.diskSizeInGb : undefined,
-    ramSizeInGb: output.ramSizeInGb !== undefined && output.ramSizeInGb !== null ? output.ramSizeInGb : undefined,
+    cpuCount: __expectNumber(output.cpuCount),
+    diskSizeInGb: __expectNumber(output.diskSizeInGb),
+    ramSizeInGb: __expectNumber(output.ramSizeInGb),
   } as any;
 };
 
@@ -22525,17 +22336,14 @@ const deserializeAws_json1_1RelationalDatabaseParameter = (
   context: __SerdeContext
 ): RelationalDatabaseParameter => {
   return {
-    allowedValues:
-      output.allowedValues !== undefined && output.allowedValues !== null ? output.allowedValues : undefined,
-    applyMethod: output.applyMethod !== undefined && output.applyMethod !== null ? output.applyMethod : undefined,
-    applyType: output.applyType !== undefined && output.applyType !== null ? output.applyType : undefined,
-    dataType: output.dataType !== undefined && output.dataType !== null ? output.dataType : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    isModifiable: output.isModifiable !== undefined && output.isModifiable !== null ? output.isModifiable : undefined,
-    parameterName:
-      output.parameterName !== undefined && output.parameterName !== null ? output.parameterName : undefined,
-    parameterValue:
-      output.parameterValue !== undefined && output.parameterValue !== null ? output.parameterValue : undefined,
+    allowedValues: __expectString(output.allowedValues),
+    applyMethod: __expectString(output.applyMethod),
+    applyType: __expectString(output.applyType),
+    dataType: __expectString(output.dataType),
+    description: __expectString(output.description),
+    isModifiable: __expectBoolean(output.isModifiable),
+    parameterName: __expectString(output.parameterName),
+    parameterValue: __expectString(output.parameterValue),
   } as any;
 };
 
@@ -22558,39 +22366,26 @@ const deserializeAws_json1_1RelationalDatabaseSnapshot = (
   context: __SerdeContext
 ): RelationalDatabaseSnapshot => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    engine: output.engine !== undefined && output.engine !== null ? output.engine : undefined,
-    engineVersion:
-      output.engineVersion !== undefined && output.engineVersion !== null ? output.engineVersion : undefined,
-    fromRelationalDatabaseArn:
-      output.fromRelationalDatabaseArn !== undefined && output.fromRelationalDatabaseArn !== null
-        ? output.fromRelationalDatabaseArn
-        : undefined,
-    fromRelationalDatabaseBlueprintId:
-      output.fromRelationalDatabaseBlueprintId !== undefined && output.fromRelationalDatabaseBlueprintId !== null
-        ? output.fromRelationalDatabaseBlueprintId
-        : undefined,
-    fromRelationalDatabaseBundleId:
-      output.fromRelationalDatabaseBundleId !== undefined && output.fromRelationalDatabaseBundleId !== null
-        ? output.fromRelationalDatabaseBundleId
-        : undefined,
-    fromRelationalDatabaseName:
-      output.fromRelationalDatabaseName !== undefined && output.fromRelationalDatabaseName !== null
-        ? output.fromRelationalDatabaseName
-        : undefined,
+    engine: __expectString(output.engine),
+    engineVersion: __expectString(output.engineVersion),
+    fromRelationalDatabaseArn: __expectString(output.fromRelationalDatabaseArn),
+    fromRelationalDatabaseBlueprintId: __expectString(output.fromRelationalDatabaseBlueprintId),
+    fromRelationalDatabaseBundleId: __expectString(output.fromRelationalDatabaseBundleId),
+    fromRelationalDatabaseName: __expectString(output.fromRelationalDatabaseName),
     location:
       output.location !== undefined && output.location !== null
         ? deserializeAws_json1_1ResourceLocation(output.location, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
-    sizeInGb: output.sizeInGb !== undefined && output.sizeInGb !== null ? output.sizeInGb : undefined,
-    state: output.state !== undefined && output.state !== null ? output.state : undefined,
-    supportCode: output.supportCode !== undefined && output.supportCode !== null ? output.supportCode : undefined,
+    name: __expectString(output.name),
+    resourceType: __expectString(output.resourceType),
+    sizeInGb: __expectNumber(output.sizeInGb),
+    state: __expectString(output.state),
+    supportCode: __expectString(output.supportCode),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_json1_1TagList(output.tags, context)
@@ -22627,12 +22422,8 @@ const deserializeAws_json1_1RenewalSummary = (output: any, context: __SerdeConte
       output.domainValidationRecords !== undefined && output.domainValidationRecords !== null
         ? deserializeAws_json1_1DomainValidationRecordList(output.domainValidationRecords, context)
         : undefined,
-    renewalStatus:
-      output.renewalStatus !== undefined && output.renewalStatus !== null ? output.renewalStatus : undefined,
-    renewalStatusReason:
-      output.renewalStatusReason !== undefined && output.renewalStatusReason !== null
-        ? output.renewalStatusReason
-        : undefined,
+    renewalStatus: __expectString(output.renewalStatus),
+    renewalStatusReason: __expectString(output.renewalStatusReason),
     updatedAt:
       output.updatedAt !== undefined && output.updatedAt !== null
         ? new Date(Math.round(output.updatedAt * 1000))
@@ -22653,23 +22444,22 @@ const deserializeAws_json1_1ResetDistributionCacheResult = (
       output.operation !== undefined && output.operation !== null
         ? deserializeAws_json1_1Operation(output.operation, context)
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
   } as any;
 };
 
 const deserializeAws_json1_1ResourceLocation = (output: any, context: __SerdeContext): ResourceLocation => {
   return {
-    availabilityZone:
-      output.availabilityZone !== undefined && output.availabilityZone !== null ? output.availabilityZone : undefined,
-    regionName: output.regionName !== undefined && output.regionName !== null ? output.regionName : undefined,
+    availabilityZone: __expectString(output.availabilityZone),
+    regionName: __expectString(output.regionName),
   } as any;
 };
 
 const deserializeAws_json1_1ResourceRecord = (output: any, context: __SerdeContext): ResourceRecord => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    name: __expectString(output.name),
+    type: __expectString(output.type),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -22687,10 +22477,10 @@ const deserializeAws_json1_1SendContactMethodVerificationResult = (
 
 const deserializeAws_json1_1ServiceException = (output: any, context: __SerdeContext): ServiceException => {
   return {
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    docs: output.docs !== undefined && output.docs !== null ? output.docs : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    tip: output.tip !== undefined && output.tip !== null ? output.tip : undefined,
+    code: __expectString(output.code),
+    docs: __expectString(output.docs),
+    message: __expectString(output.message),
+    tip: __expectString(output.tip),
   } as any;
 };
 
@@ -22726,21 +22516,21 @@ const deserializeAws_json1_1StartRelationalDatabaseResult = (
 
 const deserializeAws_json1_1StaticIp = (output: any, context: __SerdeContext): StaticIp => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    attachedTo: output.attachedTo !== undefined && output.attachedTo !== null ? output.attachedTo : undefined,
+    arn: __expectString(output.arn),
+    attachedTo: __expectString(output.attachedTo),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    ipAddress: output.ipAddress !== undefined && output.ipAddress !== null ? output.ipAddress : undefined,
-    isAttached: output.isAttached !== undefined && output.isAttached !== null ? output.isAttached : undefined,
+    ipAddress: __expectString(output.ipAddress),
+    isAttached: __expectBoolean(output.isAttached),
     location:
       output.location !== undefined && output.location !== null
         ? deserializeAws_json1_1ResourceLocation(output.location, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
-    supportCode: output.supportCode !== undefined && output.supportCode !== null ? output.supportCode : undefined,
+    name: __expectString(output.name),
+    resourceType: __expectString(output.resourceType),
+    supportCode: __expectString(output.supportCode),
   } as any;
 };
 
@@ -22783,7 +22573,7 @@ const deserializeAws_json1_1StringList = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -22794,14 +22584,14 @@ const deserializeAws_json1_1SubjectAlternativeNameList = (output: any, context: 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    key: __expectString(output.key),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -22839,10 +22629,10 @@ const deserializeAws_json1_1UnauthenticatedException = (
   context: __SerdeContext
 ): UnauthenticatedException => {
   return {
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    docs: output.docs !== undefined && output.docs !== null ? output.docs : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    tip: output.tip !== undefined && output.tip !== null ? output.tip : undefined,
+    code: __expectString(output.code),
+    docs: __expectString(output.docs),
+    message: __expectString(output.message),
+    tip: __expectString(output.tip),
   } as any;
 };
 

--- a/clients/client-location/protocols/Aws_restJson1.ts
+++ b/clients/client-location/protocols/Aws_restJson1.ts
@@ -160,6 +160,8 @@ import {
 } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -2710,10 +2712,10 @@ export const deserializeAws_restJson1CreateGeofenceCollectionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.CollectionArn !== undefined && data.CollectionArn !== null) {
-    contents.CollectionArn = data.CollectionArn;
+    contents.CollectionArn = __expectString(data.CollectionArn);
   }
   if (data.CollectionName !== undefined && data.CollectionName !== null) {
-    contents.CollectionName = data.CollectionName;
+    contents.CollectionName = __expectString(data.CollectionName);
   }
   if (data.CreateTime !== undefined && data.CreateTime !== null) {
     contents.CreateTime = new Date(data.CreateTime);
@@ -2808,10 +2810,10 @@ export const deserializeAws_restJson1CreateMapCommand = async (
     contents.CreateTime = new Date(data.CreateTime);
   }
   if (data.MapArn !== undefined && data.MapArn !== null) {
-    contents.MapArn = data.MapArn;
+    contents.MapArn = __expectString(data.MapArn);
   }
   if (data.MapName !== undefined && data.MapName !== null) {
-    contents.MapName = data.MapName;
+    contents.MapName = __expectString(data.MapName);
   }
   return Promise.resolve(contents);
 };
@@ -2903,10 +2905,10 @@ export const deserializeAws_restJson1CreatePlaceIndexCommand = async (
     contents.CreateTime = new Date(data.CreateTime);
   }
   if (data.IndexArn !== undefined && data.IndexArn !== null) {
-    contents.IndexArn = data.IndexArn;
+    contents.IndexArn = __expectString(data.IndexArn);
   }
   if (data.IndexName !== undefined && data.IndexName !== null) {
-    contents.IndexName = data.IndexName;
+    contents.IndexName = __expectString(data.IndexName);
   }
   return Promise.resolve(contents);
 };
@@ -2995,10 +2997,10 @@ export const deserializeAws_restJson1CreateRouteCalculatorCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.CalculatorArn !== undefined && data.CalculatorArn !== null) {
-    contents.CalculatorArn = data.CalculatorArn;
+    contents.CalculatorArn = __expectString(data.CalculatorArn);
   }
   if (data.CalculatorName !== undefined && data.CalculatorName !== null) {
-    contents.CalculatorName = data.CalculatorName;
+    contents.CalculatorName = __expectString(data.CalculatorName);
   }
   if (data.CreateTime !== undefined && data.CreateTime !== null) {
     contents.CreateTime = new Date(data.CreateTime);
@@ -3093,10 +3095,10 @@ export const deserializeAws_restJson1CreateTrackerCommand = async (
     contents.CreateTime = new Date(data.CreateTime);
   }
   if (data.TrackerArn !== undefined && data.TrackerArn !== null) {
-    contents.TrackerArn = data.TrackerArn;
+    contents.TrackerArn = __expectString(data.TrackerArn);
   }
   if (data.TrackerName !== undefined && data.TrackerName !== null) {
-    contents.TrackerName = data.TrackerName;
+    contents.TrackerName = __expectString(data.TrackerName);
   }
   return Promise.resolve(contents);
 };
@@ -3606,25 +3608,25 @@ export const deserializeAws_restJson1DescribeGeofenceCollectionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.CollectionArn !== undefined && data.CollectionArn !== null) {
-    contents.CollectionArn = data.CollectionArn;
+    contents.CollectionArn = __expectString(data.CollectionArn);
   }
   if (data.CollectionName !== undefined && data.CollectionName !== null) {
-    contents.CollectionName = data.CollectionName;
+    contents.CollectionName = __expectString(data.CollectionName);
   }
   if (data.CreateTime !== undefined && data.CreateTime !== null) {
     contents.CreateTime = new Date(data.CreateTime);
   }
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.KmsKeyId !== undefined && data.KmsKeyId !== null) {
-    contents.KmsKeyId = data.KmsKeyId;
+    contents.KmsKeyId = __expectString(data.KmsKeyId);
   }
   if (data.PricingPlan !== undefined && data.PricingPlan !== null) {
-    contents.PricingPlan = data.PricingPlan;
+    contents.PricingPlan = __expectString(data.PricingPlan);
   }
   if (data.PricingPlanDataSource !== undefined && data.PricingPlanDataSource !== null) {
-    contents.PricingPlanDataSource = data.PricingPlanDataSource;
+    contents.PricingPlanDataSource = __expectString(data.PricingPlanDataSource);
   }
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
@@ -3731,19 +3733,19 @@ export const deserializeAws_restJson1DescribeMapCommand = async (
     contents.CreateTime = new Date(data.CreateTime);
   }
   if (data.DataSource !== undefined && data.DataSource !== null) {
-    contents.DataSource = data.DataSource;
+    contents.DataSource = __expectString(data.DataSource);
   }
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.MapArn !== undefined && data.MapArn !== null) {
-    contents.MapArn = data.MapArn;
+    contents.MapArn = __expectString(data.MapArn);
   }
   if (data.MapName !== undefined && data.MapName !== null) {
-    contents.MapName = data.MapName;
+    contents.MapName = __expectString(data.MapName);
   }
   if (data.PricingPlan !== undefined && data.PricingPlan !== null) {
-    contents.PricingPlan = data.PricingPlan;
+    contents.PricingPlan = __expectString(data.PricingPlan);
   }
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
@@ -3847,7 +3849,7 @@ export const deserializeAws_restJson1DescribePlaceIndexCommand = async (
     contents.CreateTime = new Date(data.CreateTime);
   }
   if (data.DataSource !== undefined && data.DataSource !== null) {
-    contents.DataSource = data.DataSource;
+    contents.DataSource = __expectString(data.DataSource);
   }
   if (data.DataSourceConfiguration !== undefined && data.DataSourceConfiguration !== null) {
     contents.DataSourceConfiguration = deserializeAws_restJson1DataSourceConfiguration(
@@ -3856,16 +3858,16 @@ export const deserializeAws_restJson1DescribePlaceIndexCommand = async (
     );
   }
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.IndexArn !== undefined && data.IndexArn !== null) {
-    contents.IndexArn = data.IndexArn;
+    contents.IndexArn = __expectString(data.IndexArn);
   }
   if (data.IndexName !== undefined && data.IndexName !== null) {
-    contents.IndexName = data.IndexName;
+    contents.IndexName = __expectString(data.IndexName);
   }
   if (data.PricingPlan !== undefined && data.PricingPlan !== null) {
-    contents.PricingPlan = data.PricingPlan;
+    contents.PricingPlan = __expectString(data.PricingPlan);
   }
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
@@ -3965,22 +3967,22 @@ export const deserializeAws_restJson1DescribeRouteCalculatorCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.CalculatorArn !== undefined && data.CalculatorArn !== null) {
-    contents.CalculatorArn = data.CalculatorArn;
+    contents.CalculatorArn = __expectString(data.CalculatorArn);
   }
   if (data.CalculatorName !== undefined && data.CalculatorName !== null) {
-    contents.CalculatorName = data.CalculatorName;
+    contents.CalculatorName = __expectString(data.CalculatorName);
   }
   if (data.CreateTime !== undefined && data.CreateTime !== null) {
     contents.CreateTime = new Date(data.CreateTime);
   }
   if (data.DataSource !== undefined && data.DataSource !== null) {
-    contents.DataSource = data.DataSource;
+    contents.DataSource = __expectString(data.DataSource);
   }
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.PricingPlan !== undefined && data.PricingPlan !== null) {
-    contents.PricingPlan = data.PricingPlan;
+    contents.PricingPlan = __expectString(data.PricingPlan);
   }
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
@@ -4084,25 +4086,25 @@ export const deserializeAws_restJson1DescribeTrackerCommand = async (
     contents.CreateTime = new Date(data.CreateTime);
   }
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.KmsKeyId !== undefined && data.KmsKeyId !== null) {
-    contents.KmsKeyId = data.KmsKeyId;
+    contents.KmsKeyId = __expectString(data.KmsKeyId);
   }
   if (data.PricingPlan !== undefined && data.PricingPlan !== null) {
-    contents.PricingPlan = data.PricingPlan;
+    contents.PricingPlan = __expectString(data.PricingPlan);
   }
   if (data.PricingPlanDataSource !== undefined && data.PricingPlanDataSource !== null) {
-    contents.PricingPlanDataSource = data.PricingPlanDataSource;
+    contents.PricingPlanDataSource = __expectString(data.PricingPlanDataSource);
   }
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }
   if (data.TrackerArn !== undefined && data.TrackerArn !== null) {
-    contents.TrackerArn = data.TrackerArn;
+    contents.TrackerArn = __expectString(data.TrackerArn);
   }
   if (data.TrackerName !== undefined && data.TrackerName !== null) {
-    contents.TrackerName = data.TrackerName;
+    contents.TrackerName = __expectString(data.TrackerName);
   }
   if (data.UpdateTime !== undefined && data.UpdateTime !== null) {
     contents.UpdateTime = new Date(data.UpdateTime);
@@ -4278,7 +4280,7 @@ export const deserializeAws_restJson1GetDevicePositionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.DeviceId !== undefined && data.DeviceId !== null) {
-    contents.DeviceId = data.DeviceId;
+    contents.DeviceId = __expectString(data.DeviceId);
   }
   if (data.Position !== undefined && data.Position !== null) {
     contents.Position = deserializeAws_restJson1Position(data.Position, context);
@@ -4378,7 +4380,7 @@ export const deserializeAws_restJson1GetDevicePositionHistoryCommand = async (
     contents.DevicePositions = deserializeAws_restJson1DevicePositionList(data.DevicePositions, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -4472,13 +4474,13 @@ export const deserializeAws_restJson1GetGeofenceCommand = async (
     contents.CreateTime = new Date(data.CreateTime);
   }
   if (data.GeofenceId !== undefined && data.GeofenceId !== null) {
-    contents.GeofenceId = data.GeofenceId;
+    contents.GeofenceId = __expectString(data.GeofenceId);
   }
   if (data.Geometry !== undefined && data.Geometry !== null) {
     contents.Geometry = deserializeAws_restJson1GeofenceGeometry(data.Geometry, context);
   }
   if (data.Status !== undefined && data.Status !== null) {
-    contents.Status = data.Status;
+    contents.Status = __expectString(data.Status);
   }
   if (data.UpdateTime !== undefined && data.UpdateTime !== null) {
     contents.UpdateTime = new Date(data.UpdateTime);
@@ -4928,7 +4930,7 @@ export const deserializeAws_restJson1ListDevicePositionsCommand = async (
     contents.Entries = deserializeAws_restJson1ListDevicePositionsResponseEntryList(data.Entries, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -5011,7 +5013,7 @@ export const deserializeAws_restJson1ListGeofenceCollectionsCommand = async (
     contents.Entries = deserializeAws_restJson1ListGeofenceCollectionsResponseEntryList(data.Entries, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -5094,7 +5096,7 @@ export const deserializeAws_restJson1ListGeofencesCommand = async (
     contents.Entries = deserializeAws_restJson1ListGeofenceResponseEntryList(data.Entries, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -5185,7 +5187,7 @@ export const deserializeAws_restJson1ListMapsCommand = async (
     contents.Entries = deserializeAws_restJson1ListMapsResponseEntryList(data.Entries, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -5268,7 +5270,7 @@ export const deserializeAws_restJson1ListPlaceIndexesCommand = async (
     contents.Entries = deserializeAws_restJson1ListPlaceIndexesResponseEntryList(data.Entries, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -5351,7 +5353,7 @@ export const deserializeAws_restJson1ListRouteCalculatorsCommand = async (
     contents.Entries = deserializeAws_restJson1ListRouteCalculatorsResponseEntryList(data.Entries, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -5521,7 +5523,7 @@ export const deserializeAws_restJson1ListTrackerConsumersCommand = async (
     contents.ConsumerArns = deserializeAws_restJson1ArnList(data.ConsumerArns, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -5612,7 +5614,7 @@ export const deserializeAws_restJson1ListTrackersCommand = async (
     contents.Entries = deserializeAws_restJson1ListTrackersResponseEntryList(data.Entries, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -5696,7 +5698,7 @@ export const deserializeAws_restJson1PutGeofenceCommand = async (
     contents.CreateTime = new Date(data.CreateTime);
   }
   if (data.GeofenceId !== undefined && data.GeofenceId !== null) {
-    contents.GeofenceId = data.GeofenceId;
+    contents.GeofenceId = __expectString(data.GeofenceId);
   }
   if (data.UpdateTime !== undefined && data.UpdateTime !== null) {
     contents.UpdateTime = new Date(data.UpdateTime);
@@ -6141,7 +6143,7 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -6158,7 +6160,7 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -6176,7 +6178,7 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -6193,7 +6195,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -6211,7 +6213,7 @@ const deserializeAws_restJson1ThrottlingExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -6233,10 +6235,10 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
     contents.FieldList = deserializeAws_restJson1ValidationExceptionFieldList(data.fieldList, context);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   if (data.reason !== undefined && data.reason !== null) {
-    contents.Reason = data.reason;
+    contents.Reason = __expectString(data.reason);
   }
   return contents;
 };
@@ -6459,7 +6461,7 @@ const deserializeAws_restJson1ArnList = (output: any, context: __SerdeContext): 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6468,7 +6470,7 @@ const deserializeAws_restJson1BatchDeleteDevicePositionHistoryError = (
   context: __SerdeContext
 ): BatchDeleteDevicePositionHistoryError => {
   return {
-    DeviceId: output.DeviceId !== undefined && output.DeviceId !== null ? output.DeviceId : undefined,
+    DeviceId: __expectString(output.DeviceId),
     Error:
       output.Error !== undefined && output.Error !== null
         ? deserializeAws_restJson1BatchItemError(output.Error, context)
@@ -6499,7 +6501,7 @@ const deserializeAws_restJson1BatchDeleteGeofenceError = (
       output.Error !== undefined && output.Error !== null
         ? deserializeAws_restJson1BatchItemError(output.Error, context)
         : undefined,
-    GeofenceId: output.GeofenceId !== undefined && output.GeofenceId !== null ? output.GeofenceId : undefined,
+    GeofenceId: __expectString(output.GeofenceId),
   } as any;
 };
 
@@ -6522,7 +6524,7 @@ const deserializeAws_restJson1BatchEvaluateGeofencesError = (
   context: __SerdeContext
 ): BatchEvaluateGeofencesError => {
   return {
-    DeviceId: output.DeviceId !== undefined && output.DeviceId !== null ? output.DeviceId : undefined,
+    DeviceId: __expectString(output.DeviceId),
     Error:
       output.Error !== undefined && output.Error !== null
         ? deserializeAws_restJson1BatchItemError(output.Error, context)
@@ -6550,7 +6552,7 @@ const deserializeAws_restJson1BatchGetDevicePositionError = (
   context: __SerdeContext
 ): BatchGetDevicePositionError => {
   return {
-    DeviceId: output.DeviceId !== undefined && output.DeviceId !== null ? output.DeviceId : undefined,
+    DeviceId: __expectString(output.DeviceId),
     Error:
       output.Error !== undefined && output.Error !== null
         ? deserializeAws_restJson1BatchItemError(output.Error, context)
@@ -6574,8 +6576,8 @@ const deserializeAws_restJson1BatchGetDevicePositionErrorList = (
 
 const deserializeAws_restJson1BatchItemError = (output: any, context: __SerdeContext): BatchItemError => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -6585,7 +6587,7 @@ const deserializeAws_restJson1BatchPutGeofenceError = (output: any, context: __S
       output.Error !== undefined && output.Error !== null
         ? deserializeAws_restJson1BatchItemError(output.Error, context)
         : undefined,
-    GeofenceId: output.GeofenceId !== undefined && output.GeofenceId !== null ? output.GeofenceId : undefined,
+    GeofenceId: __expectString(output.GeofenceId),
   } as any;
 };
 
@@ -6609,7 +6611,7 @@ const deserializeAws_restJson1BatchPutGeofenceSuccess = (
 ): BatchPutGeofenceSuccess => {
   return {
     CreateTime: output.CreateTime !== undefined && output.CreateTime !== null ? new Date(output.CreateTime) : undefined,
-    GeofenceId: output.GeofenceId !== undefined && output.GeofenceId !== null ? output.GeofenceId : undefined,
+    GeofenceId: __expectString(output.GeofenceId),
     UpdateTime: output.UpdateTime !== undefined && output.UpdateTime !== null ? new Date(output.UpdateTime) : undefined,
   } as any;
 };
@@ -6633,7 +6635,7 @@ const deserializeAws_restJson1BatchUpdateDevicePositionError = (
   context: __SerdeContext
 ): BatchUpdateDevicePositionError => {
   return {
-    DeviceId: output.DeviceId !== undefined && output.DeviceId !== null ? output.DeviceId : undefined,
+    DeviceId: __expectString(output.DeviceId),
     Error:
       output.Error !== undefined && output.Error !== null
         ? deserializeAws_restJson1BatchItemError(output.Error, context)
@@ -6663,17 +6665,16 @@ const deserializeAws_restJson1BoundingBox = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectNumber(entry) as any;
     });
 };
 
 const deserializeAws_restJson1CalculateRouteSummary = (output: any, context: __SerdeContext): CalculateRouteSummary => {
   return {
-    DataSource: output.DataSource !== undefined && output.DataSource !== null ? output.DataSource : undefined,
-    Distance: output.Distance !== undefined && output.Distance !== null ? output.Distance : undefined,
-    DistanceUnit: output.DistanceUnit !== undefined && output.DistanceUnit !== null ? output.DistanceUnit : undefined,
-    DurationSeconds:
-      output.DurationSeconds !== undefined && output.DurationSeconds !== null ? output.DurationSeconds : undefined,
+    DataSource: __expectString(output.DataSource),
+    Distance: __expectNumber(output.Distance),
+    DistanceUnit: __expectString(output.DistanceUnit),
+    DurationSeconds: __expectNumber(output.DurationSeconds),
     RouteBBox:
       output.RouteBBox !== undefined && output.RouteBBox !== null
         ? deserializeAws_restJson1BoundingBox(output.RouteBBox, context)
@@ -6688,7 +6689,7 @@ const deserializeAws_restJson1CountryCodeList = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6697,13 +6698,13 @@ const deserializeAws_restJson1DataSourceConfiguration = (
   context: __SerdeContext
 ): DataSourceConfiguration => {
   return {
-    IntendedUse: output.IntendedUse !== undefined && output.IntendedUse !== null ? output.IntendedUse : undefined,
+    IntendedUse: __expectString(output.IntendedUse),
   } as any;
 };
 
 const deserializeAws_restJson1DevicePosition = (output: any, context: __SerdeContext): DevicePosition => {
   return {
-    DeviceId: output.DeviceId !== undefined && output.DeviceId !== null ? output.DeviceId : undefined,
+    DeviceId: __expectString(output.DeviceId),
     Position:
       output.Position !== undefined && output.Position !== null
         ? deserializeAws_restJson1Position(output.Position, context)
@@ -6736,9 +6737,8 @@ const deserializeAws_restJson1GeofenceGeometry = (output: any, context: __SerdeC
 
 const deserializeAws_restJson1Leg = (output: any, context: __SerdeContext): Leg => {
   return {
-    Distance: output.Distance !== undefined && output.Distance !== null ? output.Distance : undefined,
-    DurationSeconds:
-      output.DurationSeconds !== undefined && output.DurationSeconds !== null ? output.DurationSeconds : undefined,
+    Distance: __expectNumber(output.Distance),
+    DurationSeconds: __expectNumber(output.DurationSeconds),
     EndPosition:
       output.EndPosition !== undefined && output.EndPosition !== null
         ? deserializeAws_restJson1Position(output.EndPosition, context)
@@ -6816,7 +6816,7 @@ const deserializeAws_restJson1ListDevicePositionsResponseEntry = (
   context: __SerdeContext
 ): ListDevicePositionsResponseEntry => {
   return {
-    DeviceId: output.DeviceId !== undefined && output.DeviceId !== null ? output.DeviceId : undefined,
+    DeviceId: __expectString(output.DeviceId),
     Position:
       output.Position !== undefined && output.Position !== null
         ? deserializeAws_restJson1Position(output.Position, context)
@@ -6844,15 +6844,11 @@ const deserializeAws_restJson1ListGeofenceCollectionsResponseEntry = (
   context: __SerdeContext
 ): ListGeofenceCollectionsResponseEntry => {
   return {
-    CollectionName:
-      output.CollectionName !== undefined && output.CollectionName !== null ? output.CollectionName : undefined,
+    CollectionName: __expectString(output.CollectionName),
     CreateTime: output.CreateTime !== undefined && output.CreateTime !== null ? new Date(output.CreateTime) : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    PricingPlan: output.PricingPlan !== undefined && output.PricingPlan !== null ? output.PricingPlan : undefined,
-    PricingPlanDataSource:
-      output.PricingPlanDataSource !== undefined && output.PricingPlanDataSource !== null
-        ? output.PricingPlanDataSource
-        : undefined,
+    Description: __expectString(output.Description),
+    PricingPlan: __expectString(output.PricingPlan),
+    PricingPlanDataSource: __expectString(output.PricingPlanDataSource),
     UpdateTime: output.UpdateTime !== undefined && output.UpdateTime !== null ? new Date(output.UpdateTime) : undefined,
   } as any;
 };
@@ -6877,12 +6873,12 @@ const deserializeAws_restJson1ListGeofenceResponseEntry = (
 ): ListGeofenceResponseEntry => {
   return {
     CreateTime: output.CreateTime !== undefined && output.CreateTime !== null ? new Date(output.CreateTime) : undefined,
-    GeofenceId: output.GeofenceId !== undefined && output.GeofenceId !== null ? output.GeofenceId : undefined,
+    GeofenceId: __expectString(output.GeofenceId),
     Geometry:
       output.Geometry !== undefined && output.Geometry !== null
         ? deserializeAws_restJson1GeofenceGeometry(output.Geometry, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
     UpdateTime: output.UpdateTime !== undefined && output.UpdateTime !== null ? new Date(output.UpdateTime) : undefined,
   } as any;
 };
@@ -6904,10 +6900,10 @@ const deserializeAws_restJson1ListGeofenceResponseEntryList = (
 const deserializeAws_restJson1ListMapsResponseEntry = (output: any, context: __SerdeContext): ListMapsResponseEntry => {
   return {
     CreateTime: output.CreateTime !== undefined && output.CreateTime !== null ? new Date(output.CreateTime) : undefined,
-    DataSource: output.DataSource !== undefined && output.DataSource !== null ? output.DataSource : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    MapName: output.MapName !== undefined && output.MapName !== null ? output.MapName : undefined,
-    PricingPlan: output.PricingPlan !== undefined && output.PricingPlan !== null ? output.PricingPlan : undefined,
+    DataSource: __expectString(output.DataSource),
+    Description: __expectString(output.Description),
+    MapName: __expectString(output.MapName),
+    PricingPlan: __expectString(output.PricingPlan),
     UpdateTime: output.UpdateTime !== undefined && output.UpdateTime !== null ? new Date(output.UpdateTime) : undefined,
   } as any;
 };
@@ -6932,10 +6928,10 @@ const deserializeAws_restJson1ListPlaceIndexesResponseEntry = (
 ): ListPlaceIndexesResponseEntry => {
   return {
     CreateTime: output.CreateTime !== undefined && output.CreateTime !== null ? new Date(output.CreateTime) : undefined,
-    DataSource: output.DataSource !== undefined && output.DataSource !== null ? output.DataSource : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    IndexName: output.IndexName !== undefined && output.IndexName !== null ? output.IndexName : undefined,
-    PricingPlan: output.PricingPlan !== undefined && output.PricingPlan !== null ? output.PricingPlan : undefined,
+    DataSource: __expectString(output.DataSource),
+    Description: __expectString(output.Description),
+    IndexName: __expectString(output.IndexName),
+    PricingPlan: __expectString(output.PricingPlan),
     UpdateTime: output.UpdateTime !== undefined && output.UpdateTime !== null ? new Date(output.UpdateTime) : undefined,
   } as any;
 };
@@ -6959,12 +6955,11 @@ const deserializeAws_restJson1ListRouteCalculatorsResponseEntry = (
   context: __SerdeContext
 ): ListRouteCalculatorsResponseEntry => {
   return {
-    CalculatorName:
-      output.CalculatorName !== undefined && output.CalculatorName !== null ? output.CalculatorName : undefined,
+    CalculatorName: __expectString(output.CalculatorName),
     CreateTime: output.CreateTime !== undefined && output.CreateTime !== null ? new Date(output.CreateTime) : undefined,
-    DataSource: output.DataSource !== undefined && output.DataSource !== null ? output.DataSource : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    PricingPlan: output.PricingPlan !== undefined && output.PricingPlan !== null ? output.PricingPlan : undefined,
+    DataSource: __expectString(output.DataSource),
+    Description: __expectString(output.Description),
+    PricingPlan: __expectString(output.PricingPlan),
     UpdateTime: output.UpdateTime !== undefined && output.UpdateTime !== null ? new Date(output.UpdateTime) : undefined,
   } as any;
 };
@@ -6989,13 +6984,10 @@ const deserializeAws_restJson1ListTrackersResponseEntry = (
 ): ListTrackersResponseEntry => {
   return {
     CreateTime: output.CreateTime !== undefined && output.CreateTime !== null ? new Date(output.CreateTime) : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    PricingPlan: output.PricingPlan !== undefined && output.PricingPlan !== null ? output.PricingPlan : undefined,
-    PricingPlanDataSource:
-      output.PricingPlanDataSource !== undefined && output.PricingPlanDataSource !== null
-        ? output.PricingPlanDataSource
-        : undefined,
-    TrackerName: output.TrackerName !== undefined && output.TrackerName !== null ? output.TrackerName : undefined,
+    Description: __expectString(output.Description),
+    PricingPlan: __expectString(output.PricingPlan),
+    PricingPlanDataSource: __expectString(output.PricingPlanDataSource),
+    TrackerName: __expectString(output.TrackerName),
     UpdateTime: output.UpdateTime !== undefined && output.UpdateTime !== null ? new Date(output.UpdateTime) : undefined,
   } as any;
 };
@@ -7016,26 +7008,25 @@ const deserializeAws_restJson1ListTrackersResponseEntryList = (
 
 const deserializeAws_restJson1MapConfiguration = (output: any, context: __SerdeContext): MapConfiguration => {
   return {
-    Style: output.Style !== undefined && output.Style !== null ? output.Style : undefined,
+    Style: __expectString(output.Style),
   } as any;
 };
 
 const deserializeAws_restJson1Place = (output: any, context: __SerdeContext): Place => {
   return {
-    AddressNumber:
-      output.AddressNumber !== undefined && output.AddressNumber !== null ? output.AddressNumber : undefined,
-    Country: output.Country !== undefined && output.Country !== null ? output.Country : undefined,
+    AddressNumber: __expectString(output.AddressNumber),
+    Country: __expectString(output.Country),
     Geometry:
       output.Geometry !== undefined && output.Geometry !== null
         ? deserializeAws_restJson1PlaceGeometry(output.Geometry, context)
         : undefined,
-    Label: output.Label !== undefined && output.Label !== null ? output.Label : undefined,
-    Municipality: output.Municipality !== undefined && output.Municipality !== null ? output.Municipality : undefined,
-    Neighborhood: output.Neighborhood !== undefined && output.Neighborhood !== null ? output.Neighborhood : undefined,
-    PostalCode: output.PostalCode !== undefined && output.PostalCode !== null ? output.PostalCode : undefined,
-    Region: output.Region !== undefined && output.Region !== null ? output.Region : undefined,
-    Street: output.Street !== undefined && output.Street !== null ? output.Street : undefined,
-    SubRegion: output.SubRegion !== undefined && output.SubRegion !== null ? output.SubRegion : undefined,
+    Label: __expectString(output.Label),
+    Municipality: __expectString(output.Municipality),
+    Neighborhood: __expectString(output.Neighborhood),
+    PostalCode: __expectString(output.PostalCode),
+    Region: __expectString(output.Region),
+    Street: __expectString(output.Street),
+    SubRegion: __expectString(output.SubRegion),
   } as any;
 };
 
@@ -7055,7 +7046,7 @@ const deserializeAws_restJson1Position = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectNumber(entry) as any;
     });
 };
 
@@ -7113,8 +7104,8 @@ const deserializeAws_restJson1SearchPlaceIndexForPositionSummary = (
   context: __SerdeContext
 ): SearchPlaceIndexForPositionSummary => {
   return {
-    DataSource: output.DataSource !== undefined && output.DataSource !== null ? output.DataSource : undefined,
-    MaxResults: output.MaxResults !== undefined && output.MaxResults !== null ? output.MaxResults : undefined,
+    DataSource: __expectString(output.DataSource),
+    MaxResults: __expectNumber(output.MaxResults),
     Position:
       output.Position !== undefined && output.Position !== null
         ? deserializeAws_restJson1Position(output.Position, context)
@@ -7131,7 +7122,7 @@ const deserializeAws_restJson1SearchPlaceIndexForTextSummary = (
       output.BiasPosition !== undefined && output.BiasPosition !== null
         ? deserializeAws_restJson1Position(output.BiasPosition, context)
         : undefined,
-    DataSource: output.DataSource !== undefined && output.DataSource !== null ? output.DataSource : undefined,
+    DataSource: __expectString(output.DataSource),
     FilterBBox:
       output.FilterBBox !== undefined && output.FilterBBox !== null
         ? deserializeAws_restJson1BoundingBox(output.FilterBBox, context)
@@ -7140,26 +7131,24 @@ const deserializeAws_restJson1SearchPlaceIndexForTextSummary = (
       output.FilterCountries !== undefined && output.FilterCountries !== null
         ? deserializeAws_restJson1CountryCodeList(output.FilterCountries, context)
         : undefined,
-    MaxResults: output.MaxResults !== undefined && output.MaxResults !== null ? output.MaxResults : undefined,
+    MaxResults: __expectNumber(output.MaxResults),
     ResultBBox:
       output.ResultBBox !== undefined && output.ResultBBox !== null
         ? deserializeAws_restJson1BoundingBox(output.ResultBBox, context)
         : undefined,
-    Text: output.Text !== undefined && output.Text !== null ? output.Text : undefined,
+    Text: __expectString(output.Text),
   } as any;
 };
 
 const deserializeAws_restJson1Step = (output: any, context: __SerdeContext): Step => {
   return {
-    Distance: output.Distance !== undefined && output.Distance !== null ? output.Distance : undefined,
-    DurationSeconds:
-      output.DurationSeconds !== undefined && output.DurationSeconds !== null ? output.DurationSeconds : undefined,
+    Distance: __expectNumber(output.Distance),
+    DurationSeconds: __expectNumber(output.DurationSeconds),
     EndPosition:
       output.EndPosition !== undefined && output.EndPosition !== null
         ? deserializeAws_restJson1Position(output.EndPosition, context)
         : undefined,
-    GeometryOffset:
-      output.GeometryOffset !== undefined && output.GeometryOffset !== null ? output.GeometryOffset : undefined,
+    GeometryOffset: __expectNumber(output.GeometryOffset),
     StartPosition:
       output.StartPosition !== undefined && output.StartPosition !== null
         ? deserializeAws_restJson1Position(output.StartPosition, context)
@@ -7185,7 +7174,7 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -7195,8 +7184,8 @@ const deserializeAws_restJson1ValidationExceptionField = (
   context: __SerdeContext
 ): ValidationExceptionField => {
   return {
-    Message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    Name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    Message: __expectString(output.message),
+    Name: __expectString(output.name),
   } as any;
 };
 

--- a/clients/client-lookoutequipment/protocols/Aws_json1_0.ts
+++ b/clients/client-lookoutequipment/protocols/Aws_json1_0.ts
@@ -124,7 +124,12 @@ import {
   ValidationException,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { LazyJsonString as __LazyJsonString, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  LazyJsonString as __LazyJsonString,
+  SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -2923,21 +2928,21 @@ const serializeAws_json1_0UpdateInferenceSchedulerRequest = (
 
 const deserializeAws_json1_0AccessDeniedException = (output: any, context: __SerdeContext): AccessDeniedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_0ConflictException = (output: any, context: __SerdeContext): ConflictException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_0CreateDatasetResponse = (output: any, context: __SerdeContext): CreateDatasetResponse => {
   return {
-    DatasetArn: output.DatasetArn !== undefined && output.DatasetArn !== null ? output.DatasetArn : undefined,
-    DatasetName: output.DatasetName !== undefined && output.DatasetName !== null ? output.DatasetName : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    DatasetArn: __expectString(output.DatasetArn),
+    DatasetName: __expectString(output.DatasetName),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -2946,22 +2951,16 @@ const deserializeAws_json1_0CreateInferenceSchedulerResponse = (
   context: __SerdeContext
 ): CreateInferenceSchedulerResponse => {
   return {
-    InferenceSchedulerArn:
-      output.InferenceSchedulerArn !== undefined && output.InferenceSchedulerArn !== null
-        ? output.InferenceSchedulerArn
-        : undefined,
-    InferenceSchedulerName:
-      output.InferenceSchedulerName !== undefined && output.InferenceSchedulerName !== null
-        ? output.InferenceSchedulerName
-        : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    InferenceSchedulerArn: __expectString(output.InferenceSchedulerArn),
+    InferenceSchedulerName: __expectString(output.InferenceSchedulerName),
+    Status: __expectString(output.Status),
   } as any;
 };
 
 const deserializeAws_json1_0CreateModelResponse = (output: any, context: __SerdeContext): CreateModelResponse => {
   return {
-    ModelArn: output.ModelArn !== undefined && output.ModelArn !== null ? output.ModelArn : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    ModelArn: __expectString(output.ModelArn),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -2984,14 +2983,14 @@ const deserializeAws_json1_0DataIngestionJobSummary = (
   context: __SerdeContext
 ): DataIngestionJobSummary => {
   return {
-    DatasetArn: output.DatasetArn !== undefined && output.DatasetArn !== null ? output.DatasetArn : undefined,
-    DatasetName: output.DatasetName !== undefined && output.DatasetName !== null ? output.DatasetName : undefined,
+    DatasetArn: __expectString(output.DatasetArn),
+    DatasetName: __expectString(output.DatasetName),
     IngestionInputConfiguration:
       output.IngestionInputConfiguration !== undefined && output.IngestionInputConfiguration !== null
         ? deserializeAws_json1_0IngestionInputConfiguration(output.IngestionInputConfiguration, context)
         : undefined,
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    JobId: __expectString(output.JobId),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -3000,10 +2999,7 @@ const deserializeAws_json1_0DataPreProcessingConfiguration = (
   context: __SerdeContext
 ): DataPreProcessingConfiguration => {
   return {
-    TargetSamplingRate:
-      output.TargetSamplingRate !== undefined && output.TargetSamplingRate !== null
-        ? output.TargetSamplingRate
-        : undefined,
+    TargetSamplingRate: __expectString(output.TargetSamplingRate),
   } as any;
 };
 
@@ -3024,9 +3020,9 @@ const deserializeAws_json1_0DatasetSummary = (output: any, context: __SerdeConte
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    DatasetArn: output.DatasetArn !== undefined && output.DatasetArn !== null ? output.DatasetArn : undefined,
-    DatasetName: output.DatasetName !== undefined && output.DatasetName !== null ? output.DatasetName : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    DatasetArn: __expectString(output.DatasetArn),
+    DatasetName: __expectString(output.DatasetName),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -3039,15 +3035,15 @@ const deserializeAws_json1_0DescribeDataIngestionJobResponse = (
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    DatasetArn: output.DatasetArn !== undefined && output.DatasetArn !== null ? output.DatasetArn : undefined,
-    FailedReason: output.FailedReason !== undefined && output.FailedReason !== null ? output.FailedReason : undefined,
+    DatasetArn: __expectString(output.DatasetArn),
+    FailedReason: __expectString(output.FailedReason),
     IngestionInputConfiguration:
       output.IngestionInputConfiguration !== undefined && output.IngestionInputConfiguration !== null
         ? deserializeAws_json1_0IngestionInputConfiguration(output.IngestionInputConfiguration, context)
         : undefined,
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    JobId: __expectString(output.JobId),
+    RoleArn: __expectString(output.RoleArn),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -3060,8 +3056,8 @@ const deserializeAws_json1_0DescribeDatasetResponse = (
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    DatasetArn: output.DatasetArn !== undefined && output.DatasetArn !== null ? output.DatasetArn : undefined,
-    DatasetName: output.DatasetName !== undefined && output.DatasetName !== null ? output.DatasetName : undefined,
+    DatasetArn: __expectString(output.DatasetArn),
+    DatasetName: __expectString(output.DatasetName),
     IngestionInputConfiguration:
       output.IngestionInputConfiguration !== undefined && output.IngestionInputConfiguration !== null
         ? deserializeAws_json1_0IngestionInputConfiguration(output.IngestionInputConfiguration, context)
@@ -3071,11 +3067,8 @@ const deserializeAws_json1_0DescribeDatasetResponse = (
         ? new Date(Math.round(output.LastUpdatedAt * 1000))
         : undefined,
     Schema: output.Schema !== undefined && output.Schema !== null ? new __LazyJsonString(output.Schema) : undefined,
-    ServerSideKmsKeyId:
-      output.ServerSideKmsKeyId !== undefined && output.ServerSideKmsKeyId !== null
-        ? output.ServerSideKmsKeyId
-        : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    ServerSideKmsKeyId: __expectString(output.ServerSideKmsKeyId),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -3088,10 +3081,7 @@ const deserializeAws_json1_0DescribeInferenceSchedulerResponse = (
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    DataDelayOffsetInMinutes:
-      output.DataDelayOffsetInMinutes !== undefined && output.DataDelayOffsetInMinutes !== null
-        ? output.DataDelayOffsetInMinutes
-        : undefined,
+    DataDelayOffsetInMinutes: __expectNumber(output.DataDelayOffsetInMinutes),
     DataInputConfiguration:
       output.DataInputConfiguration !== undefined && output.DataInputConfiguration !== null
         ? deserializeAws_json1_0InferenceInputConfiguration(output.DataInputConfiguration, context)
@@ -3100,26 +3090,14 @@ const deserializeAws_json1_0DescribeInferenceSchedulerResponse = (
       output.DataOutputConfiguration !== undefined && output.DataOutputConfiguration !== null
         ? deserializeAws_json1_0InferenceOutputConfiguration(output.DataOutputConfiguration, context)
         : undefined,
-    DataUploadFrequency:
-      output.DataUploadFrequency !== undefined && output.DataUploadFrequency !== null
-        ? output.DataUploadFrequency
-        : undefined,
-    InferenceSchedulerArn:
-      output.InferenceSchedulerArn !== undefined && output.InferenceSchedulerArn !== null
-        ? output.InferenceSchedulerArn
-        : undefined,
-    InferenceSchedulerName:
-      output.InferenceSchedulerName !== undefined && output.InferenceSchedulerName !== null
-        ? output.InferenceSchedulerName
-        : undefined,
-    ModelArn: output.ModelArn !== undefined && output.ModelArn !== null ? output.ModelArn : undefined,
-    ModelName: output.ModelName !== undefined && output.ModelName !== null ? output.ModelName : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
-    ServerSideKmsKeyId:
-      output.ServerSideKmsKeyId !== undefined && output.ServerSideKmsKeyId !== null
-        ? output.ServerSideKmsKeyId
-        : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    DataUploadFrequency: __expectString(output.DataUploadFrequency),
+    InferenceSchedulerArn: __expectString(output.InferenceSchedulerArn),
+    InferenceSchedulerName: __expectString(output.InferenceSchedulerName),
+    ModelArn: __expectString(output.ModelArn),
+    ModelName: __expectString(output.ModelName),
+    RoleArn: __expectString(output.RoleArn),
+    ServerSideKmsKeyId: __expectString(output.ServerSideKmsKeyId),
+    Status: __expectString(output.Status),
     UpdatedAt:
       output.UpdatedAt !== undefined && output.UpdatedAt !== null
         ? new Date(Math.round(output.UpdatedAt * 1000))
@@ -3137,8 +3115,8 @@ const deserializeAws_json1_0DescribeModelResponse = (output: any, context: __Ser
       output.DataPreProcessingConfiguration !== undefined && output.DataPreProcessingConfiguration !== null
         ? deserializeAws_json1_0DataPreProcessingConfiguration(output.DataPreProcessingConfiguration, context)
         : undefined,
-    DatasetArn: output.DatasetArn !== undefined && output.DatasetArn !== null ? output.DatasetArn : undefined,
-    DatasetName: output.DatasetName !== undefined && output.DatasetName !== null ? output.DatasetName : undefined,
+    DatasetArn: __expectString(output.DatasetArn),
+    DatasetName: __expectString(output.DatasetName),
     EvaluationDataEndTime:
       output.EvaluationDataEndTime !== undefined && output.EvaluationDataEndTime !== null
         ? new Date(Math.round(output.EvaluationDataEndTime * 1000))
@@ -3147,7 +3125,7 @@ const deserializeAws_json1_0DescribeModelResponse = (output: any, context: __Ser
       output.EvaluationDataStartTime !== undefined && output.EvaluationDataStartTime !== null
         ? new Date(Math.round(output.EvaluationDataStartTime * 1000))
         : undefined,
-    FailedReason: output.FailedReason !== undefined && output.FailedReason !== null ? output.FailedReason : undefined,
+    FailedReason: __expectString(output.FailedReason),
     LabelsInputConfiguration:
       output.LabelsInputConfiguration !== undefined && output.LabelsInputConfiguration !== null
         ? deserializeAws_json1_0LabelsInputConfiguration(output.LabelsInputConfiguration, context)
@@ -3156,19 +3134,16 @@ const deserializeAws_json1_0DescribeModelResponse = (output: any, context: __Ser
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
         ? new Date(Math.round(output.LastUpdatedTime * 1000))
         : undefined,
-    ModelArn: output.ModelArn !== undefined && output.ModelArn !== null ? output.ModelArn : undefined,
+    ModelArn: __expectString(output.ModelArn),
     ModelMetrics:
       output.ModelMetrics !== undefined && output.ModelMetrics !== null
         ? new __LazyJsonString(output.ModelMetrics)
         : undefined,
-    ModelName: output.ModelName !== undefined && output.ModelName !== null ? output.ModelName : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
+    ModelName: __expectString(output.ModelName),
+    RoleArn: __expectString(output.RoleArn),
     Schema: output.Schema !== undefined && output.Schema !== null ? new __LazyJsonString(output.Schema) : undefined,
-    ServerSideKmsKeyId:
-      output.ServerSideKmsKeyId !== undefined && output.ServerSideKmsKeyId !== null
-        ? output.ServerSideKmsKeyId
-        : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    ServerSideKmsKeyId: __expectString(output.ServerSideKmsKeyId),
+    Status: __expectString(output.Status),
     TrainingDataEndTime:
       output.TrainingDataEndTime !== undefined && output.TrainingDataEndTime !== null
         ? new Date(Math.round(output.TrainingDataEndTime * 1000))
@@ -3227,22 +3202,16 @@ const deserializeAws_json1_0InferenceExecutionSummary = (
       output.DataStartTime !== undefined && output.DataStartTime !== null
         ? new Date(Math.round(output.DataStartTime * 1000))
         : undefined,
-    FailedReason: output.FailedReason !== undefined && output.FailedReason !== null ? output.FailedReason : undefined,
-    InferenceSchedulerArn:
-      output.InferenceSchedulerArn !== undefined && output.InferenceSchedulerArn !== null
-        ? output.InferenceSchedulerArn
-        : undefined,
-    InferenceSchedulerName:
-      output.InferenceSchedulerName !== undefined && output.InferenceSchedulerName !== null
-        ? output.InferenceSchedulerName
-        : undefined,
-    ModelArn: output.ModelArn !== undefined && output.ModelArn !== null ? output.ModelArn : undefined,
-    ModelName: output.ModelName !== undefined && output.ModelName !== null ? output.ModelName : undefined,
+    FailedReason: __expectString(output.FailedReason),
+    InferenceSchedulerArn: __expectString(output.InferenceSchedulerArn),
+    InferenceSchedulerName: __expectString(output.InferenceSchedulerName),
+    ModelArn: __expectString(output.ModelArn),
+    ModelName: __expectString(output.ModelName),
     ScheduledStartTime:
       output.ScheduledStartTime !== undefined && output.ScheduledStartTime !== null
         ? new Date(Math.round(output.ScheduledStartTime * 1000))
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -3255,10 +3224,7 @@ const deserializeAws_json1_0InferenceInputConfiguration = (
       output.InferenceInputNameConfiguration !== undefined && output.InferenceInputNameConfiguration !== null
         ? deserializeAws_json1_0InferenceInputNameConfiguration(output.InferenceInputNameConfiguration, context)
         : undefined,
-    InputTimeZoneOffset:
-      output.InputTimeZoneOffset !== undefined && output.InputTimeZoneOffset !== null
-        ? output.InputTimeZoneOffset
-        : undefined,
+    InputTimeZoneOffset: __expectString(output.InputTimeZoneOffset),
     S3InputConfiguration:
       output.S3InputConfiguration !== undefined && output.S3InputConfiguration !== null
         ? deserializeAws_json1_0InferenceS3InputConfiguration(output.S3InputConfiguration, context)
@@ -3271,12 +3237,8 @@ const deserializeAws_json1_0InferenceInputNameConfiguration = (
   context: __SerdeContext
 ): InferenceInputNameConfiguration => {
   return {
-    ComponentTimestampDelimiter:
-      output.ComponentTimestampDelimiter !== undefined && output.ComponentTimestampDelimiter !== null
-        ? output.ComponentTimestampDelimiter
-        : undefined,
-    TimestampFormat:
-      output.TimestampFormat !== undefined && output.TimestampFormat !== null ? output.TimestampFormat : undefined,
+    ComponentTimestampDelimiter: __expectString(output.ComponentTimestampDelimiter),
+    TimestampFormat: __expectString(output.TimestampFormat),
   } as any;
 };
 
@@ -3285,7 +3247,7 @@ const deserializeAws_json1_0InferenceOutputConfiguration = (
   context: __SerdeContext
 ): InferenceOutputConfiguration => {
   return {
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
+    KmsKeyId: __expectString(output.KmsKeyId),
     S3OutputConfiguration:
       output.S3OutputConfiguration !== undefined && output.S3OutputConfiguration !== null
         ? deserializeAws_json1_0InferenceS3OutputConfiguration(output.S3OutputConfiguration, context)
@@ -3298,8 +3260,8 @@ const deserializeAws_json1_0InferenceS3InputConfiguration = (
   context: __SerdeContext
 ): InferenceS3InputConfiguration => {
   return {
-    Bucket: output.Bucket !== undefined && output.Bucket !== null ? output.Bucket : undefined,
-    Prefix: output.Prefix !== undefined && output.Prefix !== null ? output.Prefix : undefined,
+    Bucket: __expectString(output.Bucket),
+    Prefix: __expectString(output.Prefix),
   } as any;
 };
 
@@ -3308,8 +3270,8 @@ const deserializeAws_json1_0InferenceS3OutputConfiguration = (
   context: __SerdeContext
 ): InferenceS3OutputConfiguration => {
   return {
-    Bucket: output.Bucket !== undefined && output.Bucket !== null ? output.Bucket : undefined,
-    Prefix: output.Prefix !== undefined && output.Prefix !== null ? output.Prefix : undefined,
+    Bucket: __expectString(output.Bucket),
+    Prefix: __expectString(output.Prefix),
   } as any;
 };
 
@@ -3332,25 +3294,13 @@ const deserializeAws_json1_0InferenceSchedulerSummary = (
   context: __SerdeContext
 ): InferenceSchedulerSummary => {
   return {
-    DataDelayOffsetInMinutes:
-      output.DataDelayOffsetInMinutes !== undefined && output.DataDelayOffsetInMinutes !== null
-        ? output.DataDelayOffsetInMinutes
-        : undefined,
-    DataUploadFrequency:
-      output.DataUploadFrequency !== undefined && output.DataUploadFrequency !== null
-        ? output.DataUploadFrequency
-        : undefined,
-    InferenceSchedulerArn:
-      output.InferenceSchedulerArn !== undefined && output.InferenceSchedulerArn !== null
-        ? output.InferenceSchedulerArn
-        : undefined,
-    InferenceSchedulerName:
-      output.InferenceSchedulerName !== undefined && output.InferenceSchedulerName !== null
-        ? output.InferenceSchedulerName
-        : undefined,
-    ModelArn: output.ModelArn !== undefined && output.ModelArn !== null ? output.ModelArn : undefined,
-    ModelName: output.ModelName !== undefined && output.ModelName !== null ? output.ModelName : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    DataDelayOffsetInMinutes: __expectNumber(output.DataDelayOffsetInMinutes),
+    DataUploadFrequency: __expectString(output.DataUploadFrequency),
+    InferenceSchedulerArn: __expectString(output.InferenceSchedulerArn),
+    InferenceSchedulerName: __expectString(output.InferenceSchedulerName),
+    ModelArn: __expectString(output.ModelArn),
+    ModelName: __expectString(output.ModelName),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -3371,8 +3321,8 @@ const deserializeAws_json1_0IngestionS3InputConfiguration = (
   context: __SerdeContext
 ): IngestionS3InputConfiguration => {
   return {
-    Bucket: output.Bucket !== undefined && output.Bucket !== null ? output.Bucket : undefined,
-    Prefix: output.Prefix !== undefined && output.Prefix !== null ? output.Prefix : undefined,
+    Bucket: __expectString(output.Bucket),
+    Prefix: __expectString(output.Prefix),
   } as any;
 };
 
@@ -3381,7 +3331,7 @@ const deserializeAws_json1_0InternalServerException = (
   context: __SerdeContext
 ): InternalServerException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3402,8 +3352,8 @@ const deserializeAws_json1_0LabelsS3InputConfiguration = (
   context: __SerdeContext
 ): LabelsS3InputConfiguration => {
   return {
-    Bucket: output.Bucket !== undefined && output.Bucket !== null ? output.Bucket : undefined,
-    Prefix: output.Prefix !== undefined && output.Prefix !== null ? output.Prefix : undefined,
+    Bucket: __expectString(output.Bucket),
+    Prefix: __expectString(output.Prefix),
   } as any;
 };
 
@@ -3416,7 +3366,7 @@ const deserializeAws_json1_0ListDataIngestionJobsResponse = (
       output.DataIngestionJobSummaries !== undefined && output.DataIngestionJobSummaries !== null
         ? deserializeAws_json1_0DataIngestionJobSummaries(output.DataIngestionJobSummaries, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -3426,7 +3376,7 @@ const deserializeAws_json1_0ListDatasetsResponse = (output: any, context: __Serd
       output.DatasetSummaries !== undefined && output.DatasetSummaries !== null
         ? deserializeAws_json1_0DatasetSummaries(output.DatasetSummaries, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -3439,7 +3389,7 @@ const deserializeAws_json1_0ListInferenceExecutionsResponse = (
       output.InferenceExecutionSummaries !== undefined && output.InferenceExecutionSummaries !== null
         ? deserializeAws_json1_0InferenceExecutionSummaries(output.InferenceExecutionSummaries, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -3452,7 +3402,7 @@ const deserializeAws_json1_0ListInferenceSchedulersResponse = (
       output.InferenceSchedulerSummaries !== undefined && output.InferenceSchedulerSummaries !== null
         ? deserializeAws_json1_0InferenceSchedulerSummaries(output.InferenceSchedulerSummaries, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -3462,7 +3412,7 @@ const deserializeAws_json1_0ListModelsResponse = (output: any, context: __SerdeC
       output.ModelSummaries !== undefined && output.ModelSummaries !== null
         ? deserializeAws_json1_0ModelSummaries(output.ModelSummaries, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -3495,11 +3445,11 @@ const deserializeAws_json1_0ModelSummary = (output: any, context: __SerdeContext
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    DatasetArn: output.DatasetArn !== undefined && output.DatasetArn !== null ? output.DatasetArn : undefined,
-    DatasetName: output.DatasetName !== undefined && output.DatasetName !== null ? output.DatasetName : undefined,
-    ModelArn: output.ModelArn !== undefined && output.ModelArn !== null ? output.ModelArn : undefined,
-    ModelName: output.ModelName !== undefined && output.ModelName !== null ? output.ModelName : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    DatasetArn: __expectString(output.DatasetArn),
+    DatasetName: __expectString(output.DatasetName),
+    ModelArn: __expectString(output.ModelArn),
+    ModelName: __expectString(output.ModelName),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -3508,14 +3458,14 @@ const deserializeAws_json1_0ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_0S3Object = (output: any, context: __SerdeContext): S3Object => {
   return {
-    Bucket: output.Bucket !== undefined && output.Bucket !== null ? output.Bucket : undefined,
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
+    Bucket: __expectString(output.Bucket),
+    Key: __expectString(output.Key),
   } as any;
 };
 
@@ -3524,7 +3474,7 @@ const deserializeAws_json1_0ServiceQuotaExceededException = (
   context: __SerdeContext
 ): ServiceQuotaExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3533,8 +3483,8 @@ const deserializeAws_json1_0StartDataIngestionJobResponse = (
   context: __SerdeContext
 ): StartDataIngestionJobResponse => {
   return {
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    JobId: __expectString(output.JobId),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -3543,17 +3493,11 @@ const deserializeAws_json1_0StartInferenceSchedulerResponse = (
   context: __SerdeContext
 ): StartInferenceSchedulerResponse => {
   return {
-    InferenceSchedulerArn:
-      output.InferenceSchedulerArn !== undefined && output.InferenceSchedulerArn !== null
-        ? output.InferenceSchedulerArn
-        : undefined,
-    InferenceSchedulerName:
-      output.InferenceSchedulerName !== undefined && output.InferenceSchedulerName !== null
-        ? output.InferenceSchedulerName
-        : undefined,
-    ModelArn: output.ModelArn !== undefined && output.ModelArn !== null ? output.ModelArn : undefined,
-    ModelName: output.ModelName !== undefined && output.ModelName !== null ? output.ModelName : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    InferenceSchedulerArn: __expectString(output.InferenceSchedulerArn),
+    InferenceSchedulerName: __expectString(output.InferenceSchedulerName),
+    ModelArn: __expectString(output.ModelArn),
+    ModelName: __expectString(output.ModelName),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -3562,24 +3506,18 @@ const deserializeAws_json1_0StopInferenceSchedulerResponse = (
   context: __SerdeContext
 ): StopInferenceSchedulerResponse => {
   return {
-    InferenceSchedulerArn:
-      output.InferenceSchedulerArn !== undefined && output.InferenceSchedulerArn !== null
-        ? output.InferenceSchedulerArn
-        : undefined,
-    InferenceSchedulerName:
-      output.InferenceSchedulerName !== undefined && output.InferenceSchedulerName !== null
-        ? output.InferenceSchedulerName
-        : undefined,
-    ModelArn: output.ModelArn !== undefined && output.ModelArn !== null ? output.ModelArn : undefined,
-    ModelName: output.ModelName !== undefined && output.ModelName !== null ? output.ModelName : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    InferenceSchedulerArn: __expectString(output.InferenceSchedulerArn),
+    InferenceSchedulerName: __expectString(output.InferenceSchedulerName),
+    ModelArn: __expectString(output.ModelArn),
+    ModelName: __expectString(output.ModelName),
+    Status: __expectString(output.Status),
   } as any;
 };
 
 const deserializeAws_json1_0Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -3600,7 +3538,7 @@ const deserializeAws_json1_0TagResourceResponse = (output: any, context: __Serde
 
 const deserializeAws_json1_0ThrottlingException = (output: any, context: __SerdeContext): ThrottlingException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3610,7 +3548,7 @@ const deserializeAws_json1_0UntagResourceResponse = (output: any, context: __Ser
 
 const deserializeAws_json1_0ValidationException = (output: any, context: __SerdeContext): ValidationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 

--- a/clients/client-lookoutmetrics/protocols/Aws_restJson1.ts
+++ b/clients/client-lookoutmetrics/protocols/Aws_restJson1.ts
@@ -105,6 +105,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -1036,7 +1039,7 @@ export const deserializeAws_restJson1CreateAlertCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AlertArn !== undefined && data.AlertArn !== null) {
-    contents.AlertArn = data.AlertArn;
+    contents.AlertArn = __expectString(data.AlertArn);
   }
   return Promise.resolve(contents);
 };
@@ -1139,7 +1142,7 @@ export const deserializeAws_restJson1CreateAnomalyDetectorCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AnomalyDetectorArn !== undefined && data.AnomalyDetectorArn !== null) {
-    contents.AnomalyDetectorArn = data.AnomalyDetectorArn;
+    contents.AnomalyDetectorArn = __expectString(data.AnomalyDetectorArn);
   }
   return Promise.resolve(contents);
 };
@@ -1234,7 +1237,7 @@ export const deserializeAws_restJson1CreateMetricSetCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.MetricSetArn !== undefined && data.MetricSetArn !== null) {
-    contents.MetricSetArn = data.MetricSetArn;
+    contents.MetricSetArn = __expectString(data.MetricSetArn);
   }
   return Promise.resolve(contents);
 };
@@ -1602,7 +1605,7 @@ export const deserializeAws_restJson1DescribeAnomalyDetectionExecutionsCommand =
     contents.ExecutionList = deserializeAws_restJson1ExecutionList(data.ExecutionList, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1697,7 +1700,7 @@ export const deserializeAws_restJson1DescribeAnomalyDetectorCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AnomalyDetectorArn !== undefined && data.AnomalyDetectorArn !== null) {
-    contents.AnomalyDetectorArn = data.AnomalyDetectorArn;
+    contents.AnomalyDetectorArn = __expectString(data.AnomalyDetectorArn);
   }
   if (data.AnomalyDetectorConfig !== undefined && data.AnomalyDetectorConfig !== null) {
     contents.AnomalyDetectorConfig = deserializeAws_restJson1AnomalyDetectorConfigSummary(
@@ -1706,25 +1709,25 @@ export const deserializeAws_restJson1DescribeAnomalyDetectorCommand = async (
     );
   }
   if (data.AnomalyDetectorDescription !== undefined && data.AnomalyDetectorDescription !== null) {
-    contents.AnomalyDetectorDescription = data.AnomalyDetectorDescription;
+    contents.AnomalyDetectorDescription = __expectString(data.AnomalyDetectorDescription);
   }
   if (data.AnomalyDetectorName !== undefined && data.AnomalyDetectorName !== null) {
-    contents.AnomalyDetectorName = data.AnomalyDetectorName;
+    contents.AnomalyDetectorName = __expectString(data.AnomalyDetectorName);
   }
   if (data.CreationTime !== undefined && data.CreationTime !== null) {
     contents.CreationTime = new Date(Math.round(data.CreationTime * 1000));
   }
   if (data.FailureReason !== undefined && data.FailureReason !== null) {
-    contents.FailureReason = data.FailureReason;
+    contents.FailureReason = __expectString(data.FailureReason);
   }
   if (data.KmsKeyArn !== undefined && data.KmsKeyArn !== null) {
-    contents.KmsKeyArn = data.KmsKeyArn;
+    contents.KmsKeyArn = __expectString(data.KmsKeyArn);
   }
   if (data.LastModificationTime !== undefined && data.LastModificationTime !== null) {
     contents.LastModificationTime = new Date(Math.round(data.LastModificationTime * 1000));
   }
   if (data.Status !== undefined && data.Status !== null) {
-    contents.Status = data.Status;
+    contents.Status = __expectString(data.Status);
   }
   return Promise.resolve(contents);
 };
@@ -1823,7 +1826,7 @@ export const deserializeAws_restJson1DescribeMetricSetCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AnomalyDetectorArn !== undefined && data.AnomalyDetectorArn !== null) {
-    contents.AnomalyDetectorArn = data.AnomalyDetectorArn;
+    contents.AnomalyDetectorArn = __expectString(data.AnomalyDetectorArn);
   }
   if (data.CreationTime !== undefined && data.CreationTime !== null) {
     contents.CreationTime = new Date(Math.round(data.CreationTime * 1000));
@@ -1838,28 +1841,28 @@ export const deserializeAws_restJson1DescribeMetricSetCommand = async (
     contents.MetricList = deserializeAws_restJson1MetricList(data.MetricList, context);
   }
   if (data.MetricSetArn !== undefined && data.MetricSetArn !== null) {
-    contents.MetricSetArn = data.MetricSetArn;
+    contents.MetricSetArn = __expectString(data.MetricSetArn);
   }
   if (data.MetricSetDescription !== undefined && data.MetricSetDescription !== null) {
-    contents.MetricSetDescription = data.MetricSetDescription;
+    contents.MetricSetDescription = __expectString(data.MetricSetDescription);
   }
   if (data.MetricSetFrequency !== undefined && data.MetricSetFrequency !== null) {
-    contents.MetricSetFrequency = data.MetricSetFrequency;
+    contents.MetricSetFrequency = __expectString(data.MetricSetFrequency);
   }
   if (data.MetricSetName !== undefined && data.MetricSetName !== null) {
-    contents.MetricSetName = data.MetricSetName;
+    contents.MetricSetName = __expectString(data.MetricSetName);
   }
   if (data.MetricSource !== undefined && data.MetricSource !== null) {
     contents.MetricSource = deserializeAws_restJson1MetricSource(data.MetricSource, context);
   }
   if (data.Offset !== undefined && data.Offset !== null) {
-    contents.Offset = data.Offset;
+    contents.Offset = __expectNumber(data.Offset);
   }
   if (data.TimestampColumn !== undefined && data.TimestampColumn !== null) {
     contents.TimestampColumn = deserializeAws_restJson1TimestampColumn(data.TimestampColumn, context);
   }
   if (data.Timezone !== undefined && data.Timezone !== null) {
-    contents.Timezone = data.Timezone;
+    contents.Timezone = __expectString(data.Timezone);
   }
   return Promise.resolve(contents);
 };
@@ -2040,7 +2043,7 @@ export const deserializeAws_restJson1GetFeedbackCommand = async (
     );
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2222,7 +2225,7 @@ export const deserializeAws_restJson1ListAlertsCommand = async (
     contents.AlertSummaryList = deserializeAws_restJson1AlertSummaryList(data.AlertSummaryList, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2316,7 +2319,7 @@ export const deserializeAws_restJson1ListAnomalyDetectorsCommand = async (
     );
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2417,7 +2420,7 @@ export const deserializeAws_restJson1ListAnomalyGroupSummariesCommand = async (
     );
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2508,13 +2511,13 @@ export const deserializeAws_restJson1ListAnomalyGroupTimeSeriesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AnomalyGroupId !== undefined && data.AnomalyGroupId !== null) {
-    contents.AnomalyGroupId = data.AnomalyGroupId;
+    contents.AnomalyGroupId = __expectString(data.AnomalyGroupId);
   }
   if (data.MetricName !== undefined && data.MetricName !== null) {
-    contents.MetricName = data.MetricName;
+    contents.MetricName = __expectString(data.MetricName);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.TimeSeriesList !== undefined && data.TimeSeriesList !== null) {
     contents.TimeSeriesList = deserializeAws_restJson1TimeSeriesList(data.TimeSeriesList, context);
@@ -2611,7 +2614,7 @@ export const deserializeAws_restJson1ListMetricSetsCommand = async (
     contents.MetricSetSummaryList = deserializeAws_restJson1MetricSetSummaryList(data.MetricSetSummaryList, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2986,7 +2989,7 @@ export const deserializeAws_restJson1UpdateAnomalyDetectorCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AnomalyDetectorArn !== undefined && data.AnomalyDetectorArn !== null) {
-    contents.AnomalyDetectorArn = data.AnomalyDetectorArn;
+    contents.AnomalyDetectorArn = __expectString(data.AnomalyDetectorArn);
   }
   return Promise.resolve(contents);
 };
@@ -3073,7 +3076,7 @@ export const deserializeAws_restJson1UpdateMetricSetCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.MetricSetArn !== undefined && data.MetricSetArn !== null) {
-    contents.MetricSetArn = data.MetricSetArn;
+    contents.MetricSetArn = __expectString(data.MetricSetArn);
   }
   return Promise.resolve(contents);
 };
@@ -3159,7 +3162,7 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3178,13 +3181,13 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.ResourceId !== undefined && data.ResourceId !== null) {
-    contents.ResourceId = data.ResourceId;
+    contents.ResourceId = __expectString(data.ResourceId);
   }
   if (data.ResourceType !== undefined && data.ResourceType !== null) {
-    contents.ResourceType = data.ResourceType;
+    contents.ResourceType = __expectString(data.ResourceType);
   }
   return contents;
 };
@@ -3201,7 +3204,7 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3220,13 +3223,13 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.ResourceId !== undefined && data.ResourceId !== null) {
-    contents.ResourceId = data.ResourceId;
+    contents.ResourceId = __expectString(data.ResourceId);
   }
   if (data.ResourceType !== undefined && data.ResourceType !== null) {
-    contents.ResourceType = data.ResourceType;
+    contents.ResourceType = __expectString(data.ResourceType);
   }
   return contents;
 };
@@ -3247,19 +3250,19 @@ const deserializeAws_restJson1ServiceQuotaExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.QuotaCode !== undefined && data.QuotaCode !== null) {
-    contents.QuotaCode = data.QuotaCode;
+    contents.QuotaCode = __expectString(data.QuotaCode);
   }
   if (data.ResourceId !== undefined && data.ResourceId !== null) {
-    contents.ResourceId = data.ResourceId;
+    contents.ResourceId = __expectString(data.ResourceId);
   }
   if (data.ResourceType !== undefined && data.ResourceType !== null) {
-    contents.ResourceType = data.ResourceType;
+    contents.ResourceType = __expectString(data.ResourceType);
   }
   if (data.ServiceCode !== undefined && data.ServiceCode !== null) {
-    contents.ServiceCode = data.ServiceCode;
+    contents.ServiceCode = __expectString(data.ServiceCode);
   }
   return contents;
 };
@@ -3276,7 +3279,7 @@ const deserializeAws_restJson1TooManyRequestsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3298,10 +3301,10 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
     contents.Fields = deserializeAws_restJson1ValidationExceptionFieldList(data.Fields, context);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.Reason !== undefined && data.Reason !== null) {
-    contents.Reason = data.Reason;
+    contents.Reason = __expectString(data.Reason);
   }
   return contents;
 };
@@ -3643,20 +3646,13 @@ const deserializeAws_restJson1Alert = (output: any, context: __SerdeContext): Al
       output.Action !== undefined && output.Action !== null
         ? deserializeAws_restJson1Action(output.Action, context)
         : undefined,
-    AlertArn: output.AlertArn !== undefined && output.AlertArn !== null ? output.AlertArn : undefined,
-    AlertDescription:
-      output.AlertDescription !== undefined && output.AlertDescription !== null ? output.AlertDescription : undefined,
-    AlertName: output.AlertName !== undefined && output.AlertName !== null ? output.AlertName : undefined,
-    AlertSensitivityThreshold:
-      output.AlertSensitivityThreshold !== undefined && output.AlertSensitivityThreshold !== null
-        ? output.AlertSensitivityThreshold
-        : undefined,
-    AlertStatus: output.AlertStatus !== undefined && output.AlertStatus !== null ? output.AlertStatus : undefined,
-    AlertType: output.AlertType !== undefined && output.AlertType !== null ? output.AlertType : undefined,
-    AnomalyDetectorArn:
-      output.AnomalyDetectorArn !== undefined && output.AnomalyDetectorArn !== null
-        ? output.AnomalyDetectorArn
-        : undefined,
+    AlertArn: __expectString(output.AlertArn),
+    AlertDescription: __expectString(output.AlertDescription),
+    AlertName: __expectString(output.AlertName),
+    AlertSensitivityThreshold: __expectNumber(output.AlertSensitivityThreshold),
+    AlertStatus: __expectString(output.AlertStatus),
+    AlertType: __expectString(output.AlertType),
+    AnomalyDetectorArn: __expectString(output.AnomalyDetectorArn),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -3670,18 +3666,12 @@ const deserializeAws_restJson1Alert = (output: any, context: __SerdeContext): Al
 
 const deserializeAws_restJson1AlertSummary = (output: any, context: __SerdeContext): AlertSummary => {
   return {
-    AlertArn: output.AlertArn !== undefined && output.AlertArn !== null ? output.AlertArn : undefined,
-    AlertName: output.AlertName !== undefined && output.AlertName !== null ? output.AlertName : undefined,
-    AlertSensitivityThreshold:
-      output.AlertSensitivityThreshold !== undefined && output.AlertSensitivityThreshold !== null
-        ? output.AlertSensitivityThreshold
-        : undefined,
-    AlertStatus: output.AlertStatus !== undefined && output.AlertStatus !== null ? output.AlertStatus : undefined,
-    AlertType: output.AlertType !== undefined && output.AlertType !== null ? output.AlertType : undefined,
-    AnomalyDetectorArn:
-      output.AnomalyDetectorArn !== undefined && output.AnomalyDetectorArn !== null
-        ? output.AnomalyDetectorArn
-        : undefined,
+    AlertArn: __expectString(output.AlertArn),
+    AlertName: __expectString(output.AlertName),
+    AlertSensitivityThreshold: __expectNumber(output.AlertSensitivityThreshold),
+    AlertStatus: __expectString(output.AlertStatus),
+    AlertType: __expectString(output.AlertType),
+    AnomalyDetectorArn: __expectString(output.AnomalyDetectorArn),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -3713,10 +3703,7 @@ const deserializeAws_restJson1AnomalyDetectorConfigSummary = (
   context: __SerdeContext
 ): AnomalyDetectorConfigSummary => {
   return {
-    AnomalyDetectorFrequency:
-      output.AnomalyDetectorFrequency !== undefined && output.AnomalyDetectorFrequency !== null
-        ? output.AnomalyDetectorFrequency
-        : undefined,
+    AnomalyDetectorFrequency: __expectString(output.AnomalyDetectorFrequency),
   } as any;
 };
 
@@ -3725,18 +3712,9 @@ const deserializeAws_restJson1AnomalyDetectorSummary = (
   context: __SerdeContext
 ): AnomalyDetectorSummary => {
   return {
-    AnomalyDetectorArn:
-      output.AnomalyDetectorArn !== undefined && output.AnomalyDetectorArn !== null
-        ? output.AnomalyDetectorArn
-        : undefined,
-    AnomalyDetectorDescription:
-      output.AnomalyDetectorDescription !== undefined && output.AnomalyDetectorDescription !== null
-        ? output.AnomalyDetectorDescription
-        : undefined,
-    AnomalyDetectorName:
-      output.AnomalyDetectorName !== undefined && output.AnomalyDetectorName !== null
-        ? output.AnomalyDetectorName
-        : undefined,
+    AnomalyDetectorArn: __expectString(output.AnomalyDetectorArn),
+    AnomalyDetectorDescription: __expectString(output.AnomalyDetectorDescription),
+    AnomalyDetectorName: __expectString(output.AnomalyDetectorName),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -3745,7 +3723,7 @@ const deserializeAws_restJson1AnomalyDetectorSummary = (
       output.LastModificationTime !== undefined && output.LastModificationTime !== null
         ? new Date(Math.round(output.LastModificationTime * 1000))
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_restJson1TagMap(output.Tags, context)
@@ -3769,22 +3747,15 @@ const deserializeAws_restJson1AnomalyDetectorSummaryList = (
 
 const deserializeAws_restJson1AnomalyGroup = (output: any, context: __SerdeContext): AnomalyGroup => {
   return {
-    AnomalyGroupId:
-      output.AnomalyGroupId !== undefined && output.AnomalyGroupId !== null ? output.AnomalyGroupId : undefined,
-    AnomalyGroupScore:
-      output.AnomalyGroupScore !== undefined && output.AnomalyGroupScore !== null
-        ? output.AnomalyGroupScore
-        : undefined,
-    EndTime: output.EndTime !== undefined && output.EndTime !== null ? output.EndTime : undefined,
+    AnomalyGroupId: __expectString(output.AnomalyGroupId),
+    AnomalyGroupScore: __expectNumber(output.AnomalyGroupScore),
+    EndTime: __expectString(output.EndTime),
     MetricLevelImpactList:
       output.MetricLevelImpactList !== undefined && output.MetricLevelImpactList !== null
         ? deserializeAws_restJson1MetricLevelImpactList(output.MetricLevelImpactList, context)
         : undefined,
-    PrimaryMetricName:
-      output.PrimaryMetricName !== undefined && output.PrimaryMetricName !== null
-        ? output.PrimaryMetricName
-        : undefined,
-    StartTime: output.StartTime !== undefined && output.StartTime !== null ? output.StartTime : undefined,
+    PrimaryMetricName: __expectString(output.PrimaryMetricName),
+    StartTime: __expectString(output.StartTime),
   } as any;
 };
 
@@ -3793,32 +3764,22 @@ const deserializeAws_restJson1AnomalyGroupStatistics = (
   context: __SerdeContext
 ): AnomalyGroupStatistics => {
   return {
-    EvaluationStartDate:
-      output.EvaluationStartDate !== undefined && output.EvaluationStartDate !== null
-        ? output.EvaluationStartDate
-        : undefined,
+    EvaluationStartDate: __expectString(output.EvaluationStartDate),
     ItemizedMetricStatsList:
       output.ItemizedMetricStatsList !== undefined && output.ItemizedMetricStatsList !== null
         ? deserializeAws_restJson1ItemizedMetricStatsList(output.ItemizedMetricStatsList, context)
         : undefined,
-    TotalCount: output.TotalCount !== undefined && output.TotalCount !== null ? output.TotalCount : undefined,
+    TotalCount: __expectNumber(output.TotalCount),
   } as any;
 };
 
 const deserializeAws_restJson1AnomalyGroupSummary = (output: any, context: __SerdeContext): AnomalyGroupSummary => {
   return {
-    AnomalyGroupId:
-      output.AnomalyGroupId !== undefined && output.AnomalyGroupId !== null ? output.AnomalyGroupId : undefined,
-    AnomalyGroupScore:
-      output.AnomalyGroupScore !== undefined && output.AnomalyGroupScore !== null
-        ? output.AnomalyGroupScore
-        : undefined,
-    EndTime: output.EndTime !== undefined && output.EndTime !== null ? output.EndTime : undefined,
-    PrimaryMetricName:
-      output.PrimaryMetricName !== undefined && output.PrimaryMetricName !== null
-        ? output.PrimaryMetricName
-        : undefined,
-    StartTime: output.StartTime !== undefined && output.StartTime !== null ? output.StartTime : undefined,
+    AnomalyGroupId: __expectString(output.AnomalyGroupId),
+    AnomalyGroupScore: __expectNumber(output.AnomalyGroupScore),
+    EndTime: __expectString(output.EndTime),
+    PrimaryMetricName: __expectString(output.PrimaryMetricName),
+    StartTime: __expectString(output.StartTime),
   } as any;
 };
 
@@ -3838,14 +3799,14 @@ const deserializeAws_restJson1AnomalyGroupSummaryList = (
 
 const deserializeAws_restJson1AppFlowConfig = (output: any, context: __SerdeContext): AppFlowConfig => {
   return {
-    FlowName: output.FlowName !== undefined && output.FlowName !== null ? output.FlowName : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
+    FlowName: __expectString(output.FlowName),
+    RoleArn: __expectString(output.RoleArn),
   } as any;
 };
 
 const deserializeAws_restJson1CloudWatchConfig = (output: any, context: __SerdeContext): CloudWatchConfig => {
   return {
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
+    RoleArn: __expectString(output.RoleArn),
   } as any;
 };
 
@@ -3860,24 +3821,21 @@ const deserializeAws_restJson1ContributionMatrix = (output: any, context: __Serd
 
 const deserializeAws_restJson1CsvFormatDescriptor = (output: any, context: __SerdeContext): CsvFormatDescriptor => {
   return {
-    Charset: output.Charset !== undefined && output.Charset !== null ? output.Charset : undefined,
-    ContainsHeader:
-      output.ContainsHeader !== undefined && output.ContainsHeader !== null ? output.ContainsHeader : undefined,
-    Delimiter: output.Delimiter !== undefined && output.Delimiter !== null ? output.Delimiter : undefined,
-    FileCompression:
-      output.FileCompression !== undefined && output.FileCompression !== null ? output.FileCompression : undefined,
+    Charset: __expectString(output.Charset),
+    ContainsHeader: __expectBoolean(output.ContainsHeader),
+    Delimiter: __expectString(output.Delimiter),
+    FileCompression: __expectString(output.FileCompression),
     HeaderList:
       output.HeaderList !== undefined && output.HeaderList !== null
         ? deserializeAws_restJson1HeaderList(output.HeaderList, context)
         : undefined,
-    QuoteSymbol: output.QuoteSymbol !== undefined && output.QuoteSymbol !== null ? output.QuoteSymbol : undefined,
+    QuoteSymbol: __expectString(output.QuoteSymbol),
   } as any;
 };
 
 const deserializeAws_restJson1DimensionContribution = (output: any, context: __SerdeContext): DimensionContribution => {
   return {
-    DimensionName:
-      output.DimensionName !== undefined && output.DimensionName !== null ? output.DimensionName : undefined,
+    DimensionName: __expectString(output.DimensionName),
     DimensionValueContributionList:
       output.DimensionValueContributionList !== undefined && output.DimensionValueContributionList !== null
         ? deserializeAws_restJson1DimensionValueContributionList(output.DimensionValueContributionList, context)
@@ -3906,16 +3864,14 @@ const deserializeAws_restJson1DimensionList = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1DimensionNameValue = (output: any, context: __SerdeContext): DimensionNameValue => {
   return {
-    DimensionName:
-      output.DimensionName !== undefined && output.DimensionName !== null ? output.DimensionName : undefined,
-    DimensionValue:
-      output.DimensionValue !== undefined && output.DimensionValue !== null ? output.DimensionValue : undefined,
+    DimensionName: __expectString(output.DimensionName),
+    DimensionValue: __expectString(output.DimensionValue),
   } as any;
 };
 
@@ -3935,12 +3891,8 @@ const deserializeAws_restJson1DimensionValueContribution = (
   context: __SerdeContext
 ): DimensionValueContribution => {
   return {
-    ContributionScore:
-      output.ContributionScore !== undefined && output.ContributionScore !== null
-        ? output.ContributionScore
-        : undefined,
-    DimensionValue:
-      output.DimensionValue !== undefined && output.DimensionValue !== null ? output.DimensionValue : undefined,
+    ContributionScore: __expectNumber(output.ContributionScore),
+    DimensionValue: __expectString(output.DimensionValue),
   } as any;
 };
 
@@ -3971,10 +3923,9 @@ const deserializeAws_restJson1ExecutionList = (output: any, context: __SerdeCont
 
 const deserializeAws_restJson1ExecutionStatus = (output: any, context: __SerdeContext): ExecutionStatus => {
   return {
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    Timestamp: output.Timestamp !== undefined && output.Timestamp !== null ? output.Timestamp : undefined,
+    FailureReason: __expectString(output.FailureReason),
+    Status: __expectString(output.Status),
+    Timestamp: __expectString(output.Timestamp),
   } as any;
 };
 
@@ -3998,7 +3949,7 @@ const deserializeAws_restJson1HeaderList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4009,7 +3960,7 @@ const deserializeAws_restJson1HeaderValueList = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4020,15 +3971,14 @@ const deserializeAws_restJson1HistoricalDataPathList = (output: any, context: __
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1ItemizedMetricStats = (output: any, context: __SerdeContext): ItemizedMetricStats => {
   return {
-    MetricName: output.MetricName !== undefined && output.MetricName !== null ? output.MetricName : undefined,
-    OccurrenceCount:
-      output.OccurrenceCount !== undefined && output.OccurrenceCount !== null ? output.OccurrenceCount : undefined,
+    MetricName: __expectString(output.MetricName),
+    OccurrenceCount: __expectNumber(output.OccurrenceCount),
   } as any;
 };
 
@@ -4048,27 +3998,23 @@ const deserializeAws_restJson1ItemizedMetricStatsList = (
 
 const deserializeAws_restJson1JsonFormatDescriptor = (output: any, context: __SerdeContext): JsonFormatDescriptor => {
   return {
-    Charset: output.Charset !== undefined && output.Charset !== null ? output.Charset : undefined,
-    FileCompression:
-      output.FileCompression !== undefined && output.FileCompression !== null ? output.FileCompression : undefined,
+    Charset: __expectString(output.Charset),
+    FileCompression: __expectString(output.FileCompression),
   } as any;
 };
 
 const deserializeAws_restJson1LambdaConfiguration = (output: any, context: __SerdeContext): LambdaConfiguration => {
   return {
-    LambdaArn: output.LambdaArn !== undefined && output.LambdaArn !== null ? output.LambdaArn : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
+    LambdaArn: __expectString(output.LambdaArn),
+    RoleArn: __expectString(output.RoleArn),
   } as any;
 };
 
 const deserializeAws_restJson1Metric = (output: any, context: __SerdeContext): Metric => {
   return {
-    AggregationFunction:
-      output.AggregationFunction !== undefined && output.AggregationFunction !== null
-        ? output.AggregationFunction
-        : undefined,
-    MetricName: output.MetricName !== undefined && output.MetricName !== null ? output.MetricName : undefined,
-    Namespace: output.Namespace !== undefined && output.Namespace !== null ? output.Namespace : undefined,
+    AggregationFunction: __expectString(output.AggregationFunction),
+    MetricName: __expectString(output.MetricName),
+    Namespace: __expectString(output.Namespace),
   } as any;
 };
 
@@ -4078,9 +4024,8 @@ const deserializeAws_restJson1MetricLevelImpact = (output: any, context: __Serde
       output.ContributionMatrix !== undefined && output.ContributionMatrix !== null
         ? deserializeAws_restJson1ContributionMatrix(output.ContributionMatrix, context)
         : undefined,
-    MetricName: output.MetricName !== undefined && output.MetricName !== null ? output.MetricName : undefined,
-    NumTimeSeries:
-      output.NumTimeSeries !== undefined && output.NumTimeSeries !== null ? output.NumTimeSeries : undefined,
+    MetricName: __expectString(output.MetricName),
+    NumTimeSeries: __expectNumber(output.NumTimeSeries),
   } as any;
 };
 
@@ -4108,10 +4053,7 @@ const deserializeAws_restJson1MetricList = (output: any, context: __SerdeContext
 
 const deserializeAws_restJson1MetricSetSummary = (output: any, context: __SerdeContext): MetricSetSummary => {
   return {
-    AnomalyDetectorArn:
-      output.AnomalyDetectorArn !== undefined && output.AnomalyDetectorArn !== null
-        ? output.AnomalyDetectorArn
-        : undefined,
+    AnomalyDetectorArn: __expectString(output.AnomalyDetectorArn),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -4120,13 +4062,9 @@ const deserializeAws_restJson1MetricSetSummary = (output: any, context: __SerdeC
       output.LastModificationTime !== undefined && output.LastModificationTime !== null
         ? new Date(Math.round(output.LastModificationTime * 1000))
         : undefined,
-    MetricSetArn: output.MetricSetArn !== undefined && output.MetricSetArn !== null ? output.MetricSetArn : undefined,
-    MetricSetDescription:
-      output.MetricSetDescription !== undefined && output.MetricSetDescription !== null
-        ? output.MetricSetDescription
-        : undefined,
-    MetricSetName:
-      output.MetricSetName !== undefined && output.MetricSetName !== null ? output.MetricSetName : undefined,
+    MetricSetArn: __expectString(output.MetricSetArn),
+    MetricSetDescription: __expectString(output.MetricSetDescription),
+    MetricSetName: __expectString(output.MetricSetName),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_restJson1TagMap(output.Tags, context)
@@ -4177,23 +4115,19 @@ const deserializeAws_restJson1MetricValueList = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectNumber(entry) as any;
     });
 };
 
 const deserializeAws_restJson1RDSSourceConfig = (output: any, context: __SerdeContext): RDSSourceConfig => {
   return {
-    DBInstanceIdentifier:
-      output.DBInstanceIdentifier !== undefined && output.DBInstanceIdentifier !== null
-        ? output.DBInstanceIdentifier
-        : undefined,
-    DatabaseHost: output.DatabaseHost !== undefined && output.DatabaseHost !== null ? output.DatabaseHost : undefined,
-    DatabaseName: output.DatabaseName !== undefined && output.DatabaseName !== null ? output.DatabaseName : undefined,
-    DatabasePort: output.DatabasePort !== undefined && output.DatabasePort !== null ? output.DatabasePort : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
-    SecretManagerArn:
-      output.SecretManagerArn !== undefined && output.SecretManagerArn !== null ? output.SecretManagerArn : undefined,
-    TableName: output.TableName !== undefined && output.TableName !== null ? output.TableName : undefined,
+    DBInstanceIdentifier: __expectString(output.DBInstanceIdentifier),
+    DatabaseHost: __expectString(output.DatabaseHost),
+    DatabaseName: __expectString(output.DatabaseName),
+    DatabasePort: __expectNumber(output.DatabasePort),
+    RoleArn: __expectString(output.RoleArn),
+    SecretManagerArn: __expectString(output.SecretManagerArn),
+    TableName: __expectString(output.TableName),
     VpcConfiguration:
       output.VpcConfiguration !== undefined && output.VpcConfiguration !== null
         ? deserializeAws_restJson1VpcConfiguration(output.VpcConfiguration, context)
@@ -4203,17 +4137,13 @@ const deserializeAws_restJson1RDSSourceConfig = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1RedshiftSourceConfig = (output: any, context: __SerdeContext): RedshiftSourceConfig => {
   return {
-    ClusterIdentifier:
-      output.ClusterIdentifier !== undefined && output.ClusterIdentifier !== null
-        ? output.ClusterIdentifier
-        : undefined,
-    DatabaseHost: output.DatabaseHost !== undefined && output.DatabaseHost !== null ? output.DatabaseHost : undefined,
-    DatabaseName: output.DatabaseName !== undefined && output.DatabaseName !== null ? output.DatabaseName : undefined,
-    DatabasePort: output.DatabasePort !== undefined && output.DatabasePort !== null ? output.DatabasePort : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
-    SecretManagerArn:
-      output.SecretManagerArn !== undefined && output.SecretManagerArn !== null ? output.SecretManagerArn : undefined,
-    TableName: output.TableName !== undefined && output.TableName !== null ? output.TableName : undefined,
+    ClusterIdentifier: __expectString(output.ClusterIdentifier),
+    DatabaseHost: __expectString(output.DatabaseHost),
+    DatabaseName: __expectString(output.DatabaseName),
+    DatabasePort: __expectNumber(output.DatabasePort),
+    RoleArn: __expectString(output.RoleArn),
+    SecretManagerArn: __expectString(output.SecretManagerArn),
+    TableName: __expectString(output.TableName),
     VpcConfiguration:
       output.VpcConfiguration !== undefined && output.VpcConfiguration !== null
         ? deserializeAws_restJson1VpcConfiguration(output.VpcConfiguration, context)
@@ -4231,7 +4161,7 @@ const deserializeAws_restJson1S3SourceConfig = (output: any, context: __SerdeCon
       output.HistoricalDataPathList !== undefined && output.HistoricalDataPathList !== null
         ? deserializeAws_restJson1HistoricalDataPathList(output.HistoricalDataPathList, context)
         : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
+    RoleArn: __expectString(output.RoleArn),
     TemplatedPathList:
       output.TemplatedPathList !== undefined && output.TemplatedPathList !== null
         ? deserializeAws_restJson1TemplatedPathList(output.TemplatedPathList, context)
@@ -4246,7 +4176,7 @@ const deserializeAws_restJson1SampleRow = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4268,14 +4198,14 @@ const deserializeAws_restJson1SecurityGroupIdList = (output: any, context: __Ser
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1SNSConfiguration = (output: any, context: __SerdeContext): SNSConfiguration => {
   return {
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
-    SnsTopicArn: output.SnsTopicArn !== undefined && output.SnsTopicArn !== null ? output.SnsTopicArn : undefined,
+    RoleArn: __expectString(output.RoleArn),
+    SnsTopicArn: __expectString(output.SnsTopicArn),
   } as any;
 };
 
@@ -4286,7 +4216,7 @@ const deserializeAws_restJson1SubnetIdList = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4297,7 +4227,7 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -4309,7 +4239,7 @@ const deserializeAws_restJson1TemplatedPathList = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4323,14 +4253,14 @@ const deserializeAws_restJson1TimeSeries = (output: any, context: __SerdeContext
       output.MetricValueList !== undefined && output.MetricValueList !== null
         ? deserializeAws_restJson1MetricValueList(output.MetricValueList, context)
         : undefined,
-    TimeSeriesId: output.TimeSeriesId !== undefined && output.TimeSeriesId !== null ? output.TimeSeriesId : undefined,
+    TimeSeriesId: __expectString(output.TimeSeriesId),
   } as any;
 };
 
 const deserializeAws_restJson1TimeSeriesFeedback = (output: any, context: __SerdeContext): TimeSeriesFeedback => {
   return {
-    IsAnomaly: output.IsAnomaly !== undefined && output.IsAnomaly !== null ? output.IsAnomaly : undefined,
-    TimeSeriesId: output.TimeSeriesId !== undefined && output.TimeSeriesId !== null ? output.TimeSeriesId : undefined,
+    IsAnomaly: __expectBoolean(output.IsAnomaly),
+    TimeSeriesId: __expectString(output.TimeSeriesId),
   } as any;
 };
 
@@ -4358,8 +4288,8 @@ const deserializeAws_restJson1TimeSeriesList = (output: any, context: __SerdeCon
 
 const deserializeAws_restJson1TimestampColumn = (output: any, context: __SerdeContext): TimestampColumn => {
   return {
-    ColumnFormat: output.ColumnFormat !== undefined && output.ColumnFormat !== null ? output.ColumnFormat : undefined,
-    ColumnName: output.ColumnName !== undefined && output.ColumnName !== null ? output.ColumnName : undefined,
+    ColumnFormat: __expectString(output.ColumnFormat),
+    ColumnName: __expectString(output.ColumnName),
   } as any;
 };
 
@@ -4370,7 +4300,7 @@ const deserializeAws_restJson1TimestampList = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4379,8 +4309,8 @@ const deserializeAws_restJson1ValidationExceptionField = (
   context: __SerdeContext
 ): ValidationExceptionField => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Message: __expectString(output.Message),
+    Name: __expectString(output.Name),
   } as any;
 };
 

--- a/clients/client-lookoutvision/protocols/Aws_restJson1.ts
+++ b/clients/client-lookoutvision/protocols/Aws_restJson1.ts
@@ -52,6 +52,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -1158,7 +1161,7 @@ export const deserializeAws_restJson1DeleteModelCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ModelArn !== undefined && data.ModelArn !== null) {
-    contents.ModelArn = data.ModelArn;
+    contents.ModelArn = __expectString(data.ModelArn);
   }
   return Promise.resolve(contents);
 };
@@ -1253,7 +1256,7 @@ export const deserializeAws_restJson1DeleteProjectCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ProjectArn !== undefined && data.ProjectArn !== null) {
-    contents.ProjectArn = data.ProjectArn;
+    contents.ProjectArn = __expectString(data.ProjectArn);
   }
   return Promise.resolve(contents);
 };
@@ -1732,7 +1735,7 @@ export const deserializeAws_restJson1ListDatasetEntriesCommand = async (
     contents.DatasetEntries = deserializeAws_restJson1DatasetEntryList(data.DatasetEntries, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1831,7 +1834,7 @@ export const deserializeAws_restJson1ListModelsCommand = async (
     contents.Models = deserializeAws_restJson1ModelMetadataList(data.Models, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1927,7 +1930,7 @@ export const deserializeAws_restJson1ListProjectsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Projects !== undefined && data.Projects !== null) {
     contents.Projects = deserializeAws_restJson1ProjectMetadataList(data.Projects, context);
@@ -2120,7 +2123,7 @@ export const deserializeAws_restJson1StartModelCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Status !== undefined && data.Status !== null) {
-    contents.Status = data.Status;
+    contents.Status = __expectString(data.Status);
   }
   return Promise.resolve(contents);
 };
@@ -2223,7 +2226,7 @@ export const deserializeAws_restJson1StopModelCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Status !== undefined && data.Status !== null) {
-    contents.Status = data.Status;
+    contents.Status = __expectString(data.Status);
   }
   return Promise.resolve(contents);
 };
@@ -2508,7 +2511,7 @@ export const deserializeAws_restJson1UpdateDatasetEntriesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Status !== undefined && data.Status !== null) {
-    contents.Status = data.Status;
+    contents.Status = __expectString(data.Status);
   }
   return Promise.resolve(contents);
 };
@@ -2602,7 +2605,7 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -2621,13 +2624,13 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.ResourceId !== undefined && data.ResourceId !== null) {
-    contents.ResourceId = data.ResourceId;
+    contents.ResourceId = __expectString(data.ResourceId);
   }
   if (data.ResourceType !== undefined && data.ResourceType !== null) {
-    contents.ResourceType = data.ResourceType;
+    contents.ResourceType = __expectString(data.ResourceType);
   }
   return contents;
 };
@@ -2648,7 +2651,7 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   }
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -2667,13 +2670,13 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.ResourceId !== undefined && data.ResourceId !== null) {
-    contents.ResourceId = data.ResourceId;
+    contents.ResourceId = __expectString(data.ResourceId);
   }
   if (data.ResourceType !== undefined && data.ResourceType !== null) {
-    contents.ResourceType = data.ResourceType;
+    contents.ResourceType = __expectString(data.ResourceType);
   }
   return contents;
 };
@@ -2694,19 +2697,19 @@ const deserializeAws_restJson1ServiceQuotaExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.QuotaCode !== undefined && data.QuotaCode !== null) {
-    contents.QuotaCode = data.QuotaCode;
+    contents.QuotaCode = __expectString(data.QuotaCode);
   }
   if (data.ResourceId !== undefined && data.ResourceId !== null) {
-    contents.ResourceId = data.ResourceId;
+    contents.ResourceId = __expectString(data.ResourceId);
   }
   if (data.ResourceType !== undefined && data.ResourceType !== null) {
-    contents.ResourceType = data.ResourceType;
+    contents.ResourceType = __expectString(data.ResourceType);
   }
   if (data.ServiceCode !== undefined && data.ServiceCode !== null) {
-    contents.ServiceCode = data.ServiceCode;
+    contents.ServiceCode = __expectString(data.ServiceCode);
   }
   return contents;
 };
@@ -2729,13 +2732,13 @@ const deserializeAws_restJson1ThrottlingExceptionResponse = async (
   }
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.QuotaCode !== undefined && data.QuotaCode !== null) {
-    contents.QuotaCode = data.QuotaCode;
+    contents.QuotaCode = __expectString(data.QuotaCode);
   }
   if (data.ServiceCode !== undefined && data.ServiceCode !== null) {
-    contents.ServiceCode = data.ServiceCode;
+    contents.ServiceCode = __expectString(data.ServiceCode);
   }
   return contents;
 };
@@ -2752,7 +2755,7 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -2822,7 +2825,7 @@ const deserializeAws_restJson1DatasetDescription = (output: any, context: __Serd
       output.CreationTimestamp !== undefined && output.CreationTimestamp !== null
         ? new Date(Math.round(output.CreationTimestamp * 1000))
         : undefined,
-    DatasetType: output.DatasetType !== undefined && output.DatasetType !== null ? output.DatasetType : undefined,
+    DatasetType: __expectString(output.DatasetType),
     ImageStats:
       output.ImageStats !== undefined && output.ImageStats !== null
         ? deserializeAws_restJson1DatasetImageStats(output.ImageStats, context)
@@ -2831,10 +2834,9 @@ const deserializeAws_restJson1DatasetDescription = (output: any, context: __Serd
       output.LastUpdatedTimestamp !== undefined && output.LastUpdatedTimestamp !== null
         ? new Date(Math.round(output.LastUpdatedTimestamp * 1000))
         : undefined,
-    ProjectName: output.ProjectName !== undefined && output.ProjectName !== null ? output.ProjectName : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusMessage:
-      output.StatusMessage !== undefined && output.StatusMessage !== null ? output.StatusMessage : undefined,
+    ProjectName: __expectString(output.ProjectName),
+    Status: __expectString(output.Status),
+    StatusMessage: __expectString(output.StatusMessage),
   } as any;
 };
 
@@ -2845,16 +2847,16 @@ const deserializeAws_restJson1DatasetEntryList = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1DatasetImageStats = (output: any, context: __SerdeContext): DatasetImageStats => {
   return {
-    Anomaly: output.Anomaly !== undefined && output.Anomaly !== null ? output.Anomaly : undefined,
-    Labeled: output.Labeled !== undefined && output.Labeled !== null ? output.Labeled : undefined,
-    Normal: output.Normal !== undefined && output.Normal !== null ? output.Normal : undefined,
-    Total: output.Total !== undefined && output.Total !== null ? output.Total : undefined,
+    Anomaly: __expectNumber(output.Anomaly),
+    Labeled: __expectNumber(output.Labeled),
+    Normal: __expectNumber(output.Normal),
+    Total: __expectNumber(output.Total),
   } as any;
 };
 
@@ -2864,10 +2866,9 @@ const deserializeAws_restJson1DatasetMetadata = (output: any, context: __SerdeCo
       output.CreationTimestamp !== undefined && output.CreationTimestamp !== null
         ? new Date(Math.round(output.CreationTimestamp * 1000))
         : undefined,
-    DatasetType: output.DatasetType !== undefined && output.DatasetType !== null ? output.DatasetType : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusMessage:
-      output.StatusMessage !== undefined && output.StatusMessage !== null ? output.StatusMessage : undefined,
+    DatasetType: __expectString(output.DatasetType),
+    Status: __expectString(output.Status),
+    StatusMessage: __expectString(output.StatusMessage),
   } as any;
 };
 
@@ -2884,8 +2885,8 @@ const deserializeAws_restJson1DatasetMetadataList = (output: any, context: __Ser
 
 const deserializeAws_restJson1DetectAnomalyResult = (output: any, context: __SerdeContext): DetectAnomalyResult => {
   return {
-    Confidence: output.Confidence !== undefined && output.Confidence !== null ? output.Confidence : undefined,
-    IsAnomalous: output.IsAnomalous !== undefined && output.IsAnomalous !== null ? output.IsAnomalous : undefined,
+    Confidence: __expectNumber(output.Confidence),
+    IsAnomalous: __expectBoolean(output.IsAnomalous),
     Source:
       output.Source !== undefined && output.Source !== null
         ? deserializeAws_restJson1ImageSource(output.Source, context)
@@ -2895,7 +2896,7 @@ const deserializeAws_restJson1DetectAnomalyResult = (output: any, context: __Ser
 
 const deserializeAws_restJson1ImageSource = (output: any, context: __SerdeContext): ImageSource => {
   return {
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -2905,7 +2906,7 @@ const deserializeAws_restJson1ModelDescription = (output: any, context: __SerdeC
       output.CreationTimestamp !== undefined && output.CreationTimestamp !== null
         ? new Date(Math.round(output.CreationTimestamp * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     EvaluationEndTimestamp:
       output.EvaluationEndTimestamp !== undefined && output.EvaluationEndTimestamp !== null
         ? new Date(Math.round(output.EvaluationEndTimestamp * 1000))
@@ -2918,9 +2919,9 @@ const deserializeAws_restJson1ModelDescription = (output: any, context: __SerdeC
       output.EvaluationResult !== undefined && output.EvaluationResult !== null
         ? deserializeAws_restJson1OutputS3Object(output.EvaluationResult, context)
         : undefined,
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
-    ModelArn: output.ModelArn !== undefined && output.ModelArn !== null ? output.ModelArn : undefined,
-    ModelVersion: output.ModelVersion !== undefined && output.ModelVersion !== null ? output.ModelVersion : undefined,
+    KmsKeyId: __expectString(output.KmsKeyId),
+    ModelArn: __expectString(output.ModelArn),
+    ModelVersion: __expectString(output.ModelVersion),
     OutputConfig:
       output.OutputConfig !== undefined && output.OutputConfig !== null
         ? deserializeAws_restJson1OutputConfig(output.OutputConfig, context)
@@ -2929,9 +2930,8 @@ const deserializeAws_restJson1ModelDescription = (output: any, context: __SerdeC
       output.Performance !== undefined && output.Performance !== null
         ? deserializeAws_restJson1ModelPerformance(output.Performance, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusMessage:
-      output.StatusMessage !== undefined && output.StatusMessage !== null ? output.StatusMessage : undefined,
+    Status: __expectString(output.Status),
+    StatusMessage: __expectString(output.StatusMessage),
   } as any;
 };
 
@@ -2941,16 +2941,15 @@ const deserializeAws_restJson1ModelMetadata = (output: any, context: __SerdeCont
       output.CreationTimestamp !== undefined && output.CreationTimestamp !== null
         ? new Date(Math.round(output.CreationTimestamp * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    ModelArn: output.ModelArn !== undefined && output.ModelArn !== null ? output.ModelArn : undefined,
-    ModelVersion: output.ModelVersion !== undefined && output.ModelVersion !== null ? output.ModelVersion : undefined,
+    Description: __expectString(output.Description),
+    ModelArn: __expectString(output.ModelArn),
+    ModelVersion: __expectString(output.ModelVersion),
     Performance:
       output.Performance !== undefined && output.Performance !== null
         ? deserializeAws_restJson1ModelPerformance(output.Performance, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusMessage:
-      output.StatusMessage !== undefined && output.StatusMessage !== null ? output.StatusMessage : undefined,
+    Status: __expectString(output.Status),
+    StatusMessage: __expectString(output.StatusMessage),
   } as any;
 };
 
@@ -2967,9 +2966,9 @@ const deserializeAws_restJson1ModelMetadataList = (output: any, context: __Serde
 
 const deserializeAws_restJson1ModelPerformance = (output: any, context: __SerdeContext): ModelPerformance => {
   return {
-    F1Score: output.F1Score !== undefined && output.F1Score !== null ? output.F1Score : undefined,
-    Precision: output.Precision !== undefined && output.Precision !== null ? output.Precision : undefined,
-    Recall: output.Recall !== undefined && output.Recall !== null ? output.Recall : undefined,
+    F1Score: __expectNumber(output.F1Score),
+    Precision: __expectNumber(output.Precision),
+    Recall: __expectNumber(output.Recall),
   } as any;
 };
 
@@ -2984,8 +2983,8 @@ const deserializeAws_restJson1OutputConfig = (output: any, context: __SerdeConte
 
 const deserializeAws_restJson1OutputS3Object = (output: any, context: __SerdeContext): OutputS3Object => {
   return {
-    Bucket: output.Bucket !== undefined && output.Bucket !== null ? output.Bucket : undefined,
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
+    Bucket: __expectString(output.Bucket),
+    Key: __expectString(output.Key),
   } as any;
 };
 
@@ -2999,8 +2998,8 @@ const deserializeAws_restJson1ProjectDescription = (output: any, context: __Serd
       output.Datasets !== undefined && output.Datasets !== null
         ? deserializeAws_restJson1DatasetMetadataList(output.Datasets, context)
         : undefined,
-    ProjectArn: output.ProjectArn !== undefined && output.ProjectArn !== null ? output.ProjectArn : undefined,
-    ProjectName: output.ProjectName !== undefined && output.ProjectName !== null ? output.ProjectName : undefined,
+    ProjectArn: __expectString(output.ProjectArn),
+    ProjectName: __expectString(output.ProjectName),
   } as any;
 };
 
@@ -3010,8 +3009,8 @@ const deserializeAws_restJson1ProjectMetadata = (output: any, context: __SerdeCo
       output.CreationTimestamp !== undefined && output.CreationTimestamp !== null
         ? new Date(Math.round(output.CreationTimestamp * 1000))
         : undefined,
-    ProjectArn: output.ProjectArn !== undefined && output.ProjectArn !== null ? output.ProjectArn : undefined,
-    ProjectName: output.ProjectName !== undefined && output.ProjectName !== null ? output.ProjectName : undefined,
+    ProjectArn: __expectString(output.ProjectArn),
+    ProjectName: __expectString(output.ProjectName),
   } as any;
 };
 
@@ -3028,15 +3027,15 @@ const deserializeAws_restJson1ProjectMetadataList = (output: any, context: __Ser
 
 const deserializeAws_restJson1S3Location = (output: any, context: __SerdeContext): S3Location => {
   return {
-    Bucket: output.Bucket !== undefined && output.Bucket !== null ? output.Bucket : undefined,
-    Prefix: output.Prefix !== undefined && output.Prefix !== null ? output.Prefix : undefined,
+    Bucket: __expectString(output.Bucket),
+    Prefix: __expectString(output.Prefix),
   } as any;
 };
 
 const deserializeAws_restJson1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 

--- a/clients/client-machine-learning/protocols/Aws_json1_1.ts
+++ b/clients/client-machine-learning/protocols/Aws_json1_1.ts
@@ -144,7 +144,12 @@ import {
   UpdateMLModelOutput,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -3074,55 +3079,41 @@ const serializeAws_json1_1UpdateMLModelInput = (input: UpdateMLModelInput, conte
 
 const deserializeAws_json1_1AddTagsOutput = (output: any, context: __SerdeContext): AddTagsOutput => {
   return {
-    ResourceId: output.ResourceId !== undefined && output.ResourceId !== null ? output.ResourceId : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
+    ResourceId: __expectString(output.ResourceId),
+    ResourceType: __expectString(output.ResourceType),
   } as any;
 };
 
 const deserializeAws_json1_1BatchPrediction = (output: any, context: __SerdeContext): BatchPrediction => {
   return {
-    BatchPredictionDataSourceId:
-      output.BatchPredictionDataSourceId !== undefined && output.BatchPredictionDataSourceId !== null
-        ? output.BatchPredictionDataSourceId
-        : undefined,
-    BatchPredictionId:
-      output.BatchPredictionId !== undefined && output.BatchPredictionId !== null
-        ? output.BatchPredictionId
-        : undefined,
-    ComputeTime: output.ComputeTime !== undefined && output.ComputeTime !== null ? output.ComputeTime : undefined,
+    BatchPredictionDataSourceId: __expectString(output.BatchPredictionDataSourceId),
+    BatchPredictionId: __expectString(output.BatchPredictionId),
+    ComputeTime: __expectNumber(output.ComputeTime),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    CreatedByIamUser:
-      output.CreatedByIamUser !== undefined && output.CreatedByIamUser !== null ? output.CreatedByIamUser : undefined,
+    CreatedByIamUser: __expectString(output.CreatedByIamUser),
     FinishedAt:
       output.FinishedAt !== undefined && output.FinishedAt !== null
         ? new Date(Math.round(output.FinishedAt * 1000))
         : undefined,
-    InputDataLocationS3:
-      output.InputDataLocationS3 !== undefined && output.InputDataLocationS3 !== null
-        ? output.InputDataLocationS3
-        : undefined,
-    InvalidRecordCount:
-      output.InvalidRecordCount !== undefined && output.InvalidRecordCount !== null
-        ? output.InvalidRecordCount
-        : undefined,
+    InputDataLocationS3: __expectString(output.InputDataLocationS3),
+    InvalidRecordCount: __expectNumber(output.InvalidRecordCount),
     LastUpdatedAt:
       output.LastUpdatedAt !== undefined && output.LastUpdatedAt !== null
         ? new Date(Math.round(output.LastUpdatedAt * 1000))
         : undefined,
-    MLModelId: output.MLModelId !== undefined && output.MLModelId !== null ? output.MLModelId : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    OutputUri: output.OutputUri !== undefined && output.OutputUri !== null ? output.OutputUri : undefined,
+    MLModelId: __expectString(output.MLModelId),
+    Message: __expectString(output.Message),
+    Name: __expectString(output.Name),
+    OutputUri: __expectString(output.OutputUri),
     StartedAt:
       output.StartedAt !== undefined && output.StartedAt !== null
         ? new Date(Math.round(output.StartedAt * 1000))
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    TotalRecordCount:
-      output.TotalRecordCount !== undefined && output.TotalRecordCount !== null ? output.TotalRecordCount : undefined,
+    Status: __expectString(output.Status),
+    TotalRecordCount: __expectNumber(output.TotalRecordCount),
   } as any;
 };
 
@@ -3142,10 +3133,7 @@ const deserializeAws_json1_1CreateBatchPredictionOutput = (
   context: __SerdeContext
 ): CreateBatchPredictionOutput => {
   return {
-    BatchPredictionId:
-      output.BatchPredictionId !== undefined && output.BatchPredictionId !== null
-        ? output.BatchPredictionId
-        : undefined,
+    BatchPredictionId: __expectString(output.BatchPredictionId),
   } as any;
 };
 
@@ -3154,7 +3142,7 @@ const deserializeAws_json1_1CreateDataSourceFromRDSOutput = (
   context: __SerdeContext
 ): CreateDataSourceFromRDSOutput => {
   return {
-    DataSourceId: output.DataSourceId !== undefined && output.DataSourceId !== null ? output.DataSourceId : undefined,
+    DataSourceId: __expectString(output.DataSourceId),
   } as any;
 };
 
@@ -3163,7 +3151,7 @@ const deserializeAws_json1_1CreateDataSourceFromRedshiftOutput = (
   context: __SerdeContext
 ): CreateDataSourceFromRedshiftOutput => {
   return {
-    DataSourceId: output.DataSourceId !== undefined && output.DataSourceId !== null ? output.DataSourceId : undefined,
+    DataSourceId: __expectString(output.DataSourceId),
   } as any;
 };
 
@@ -3172,19 +3160,19 @@ const deserializeAws_json1_1CreateDataSourceFromS3Output = (
   context: __SerdeContext
 ): CreateDataSourceFromS3Output => {
   return {
-    DataSourceId: output.DataSourceId !== undefined && output.DataSourceId !== null ? output.DataSourceId : undefined,
+    DataSourceId: __expectString(output.DataSourceId),
   } as any;
 };
 
 const deserializeAws_json1_1CreateEvaluationOutput = (output: any, context: __SerdeContext): CreateEvaluationOutput => {
   return {
-    EvaluationId: output.EvaluationId !== undefined && output.EvaluationId !== null ? output.EvaluationId : undefined,
+    EvaluationId: __expectString(output.EvaluationId),
   } as any;
 };
 
 const deserializeAws_json1_1CreateMLModelOutput = (output: any, context: __SerdeContext): CreateMLModelOutput => {
   return {
-    MLModelId: output.MLModelId !== undefined && output.MLModelId !== null ? output.MLModelId : undefined,
+    MLModelId: __expectString(output.MLModelId),
   } as any;
 };
 
@@ -3193,7 +3181,7 @@ const deserializeAws_json1_1CreateRealtimeEndpointOutput = (
   context: __SerdeContext
 ): CreateRealtimeEndpointOutput => {
   return {
-    MLModelId: output.MLModelId !== undefined && output.MLModelId !== null ? output.MLModelId : undefined,
+    MLModelId: __expectString(output.MLModelId),
     RealtimeEndpointInfo:
       output.RealtimeEndpointInfo !== undefined && output.RealtimeEndpointInfo !== null
         ? deserializeAws_json1_1RealtimeEndpointInfo(output.RealtimeEndpointInfo, context)
@@ -3203,26 +3191,17 @@ const deserializeAws_json1_1CreateRealtimeEndpointOutput = (
 
 const deserializeAws_json1_1DataSource = (output: any, context: __SerdeContext): DataSource => {
   return {
-    ComputeStatistics:
-      output.ComputeStatistics !== undefined && output.ComputeStatistics !== null
-        ? output.ComputeStatistics
-        : undefined,
-    ComputeTime: output.ComputeTime !== undefined && output.ComputeTime !== null ? output.ComputeTime : undefined,
+    ComputeStatistics: __expectBoolean(output.ComputeStatistics),
+    ComputeTime: __expectNumber(output.ComputeTime),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    CreatedByIamUser:
-      output.CreatedByIamUser !== undefined && output.CreatedByIamUser !== null ? output.CreatedByIamUser : undefined,
-    DataLocationS3:
-      output.DataLocationS3 !== undefined && output.DataLocationS3 !== null ? output.DataLocationS3 : undefined,
-    DataRearrangement:
-      output.DataRearrangement !== undefined && output.DataRearrangement !== null
-        ? output.DataRearrangement
-        : undefined,
-    DataSizeInBytes:
-      output.DataSizeInBytes !== undefined && output.DataSizeInBytes !== null ? output.DataSizeInBytes : undefined,
-    DataSourceId: output.DataSourceId !== undefined && output.DataSourceId !== null ? output.DataSourceId : undefined,
+    CreatedByIamUser: __expectString(output.CreatedByIamUser),
+    DataLocationS3: __expectString(output.DataLocationS3),
+    DataRearrangement: __expectString(output.DataRearrangement),
+    DataSizeInBytes: __expectNumber(output.DataSizeInBytes),
+    DataSourceId: __expectString(output.DataSourceId),
     FinishedAt:
       output.FinishedAt !== undefined && output.FinishedAt !== null
         ? new Date(Math.round(output.FinishedAt * 1000))
@@ -3231,10 +3210,9 @@ const deserializeAws_json1_1DataSource = (output: any, context: __SerdeContext):
       output.LastUpdatedAt !== undefined && output.LastUpdatedAt !== null
         ? new Date(Math.round(output.LastUpdatedAt * 1000))
         : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    NumberOfFiles:
-      output.NumberOfFiles !== undefined && output.NumberOfFiles !== null ? output.NumberOfFiles : undefined,
+    Message: __expectString(output.Message),
+    Name: __expectString(output.Name),
+    NumberOfFiles: __expectNumber(output.NumberOfFiles),
     RDSMetadata:
       output.RDSMetadata !== undefined && output.RDSMetadata !== null
         ? deserializeAws_json1_1RDSMetadata(output.RDSMetadata, context)
@@ -3243,12 +3221,12 @@ const deserializeAws_json1_1DataSource = (output: any, context: __SerdeContext):
       output.RedshiftMetadata !== undefined && output.RedshiftMetadata !== null
         ? deserializeAws_json1_1RedshiftMetadata(output.RedshiftMetadata, context)
         : undefined,
-    RoleARN: output.RoleARN !== undefined && output.RoleARN !== null ? output.RoleARN : undefined,
+    RoleARN: __expectString(output.RoleARN),
     StartedAt:
       output.StartedAt !== undefined && output.StartedAt !== null
         ? new Date(Math.round(output.StartedAt * 1000))
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -3268,28 +3246,25 @@ const deserializeAws_json1_1DeleteBatchPredictionOutput = (
   context: __SerdeContext
 ): DeleteBatchPredictionOutput => {
   return {
-    BatchPredictionId:
-      output.BatchPredictionId !== undefined && output.BatchPredictionId !== null
-        ? output.BatchPredictionId
-        : undefined,
+    BatchPredictionId: __expectString(output.BatchPredictionId),
   } as any;
 };
 
 const deserializeAws_json1_1DeleteDataSourceOutput = (output: any, context: __SerdeContext): DeleteDataSourceOutput => {
   return {
-    DataSourceId: output.DataSourceId !== undefined && output.DataSourceId !== null ? output.DataSourceId : undefined,
+    DataSourceId: __expectString(output.DataSourceId),
   } as any;
 };
 
 const deserializeAws_json1_1DeleteEvaluationOutput = (output: any, context: __SerdeContext): DeleteEvaluationOutput => {
   return {
-    EvaluationId: output.EvaluationId !== undefined && output.EvaluationId !== null ? output.EvaluationId : undefined,
+    EvaluationId: __expectString(output.EvaluationId),
   } as any;
 };
 
 const deserializeAws_json1_1DeleteMLModelOutput = (output: any, context: __SerdeContext): DeleteMLModelOutput => {
   return {
-    MLModelId: output.MLModelId !== undefined && output.MLModelId !== null ? output.MLModelId : undefined,
+    MLModelId: __expectString(output.MLModelId),
   } as any;
 };
 
@@ -3298,7 +3273,7 @@ const deserializeAws_json1_1DeleteRealtimeEndpointOutput = (
   context: __SerdeContext
 ): DeleteRealtimeEndpointOutput => {
   return {
-    MLModelId: output.MLModelId !== undefined && output.MLModelId !== null ? output.MLModelId : undefined,
+    MLModelId: __expectString(output.MLModelId),
     RealtimeEndpointInfo:
       output.RealtimeEndpointInfo !== undefined && output.RealtimeEndpointInfo !== null
         ? deserializeAws_json1_1RealtimeEndpointInfo(output.RealtimeEndpointInfo, context)
@@ -3308,8 +3283,8 @@ const deserializeAws_json1_1DeleteRealtimeEndpointOutput = (
 
 const deserializeAws_json1_1DeleteTagsOutput = (output: any, context: __SerdeContext): DeleteTagsOutput => {
   return {
-    ResourceId: output.ResourceId !== undefined && output.ResourceId !== null ? output.ResourceId : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
+    ResourceId: __expectString(output.ResourceId),
+    ResourceType: __expectString(output.ResourceType),
   } as any;
 };
 
@@ -3318,7 +3293,7 @@ const deserializeAws_json1_1DescribeBatchPredictionsOutput = (
   context: __SerdeContext
 ): DescribeBatchPredictionsOutput => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Results:
       output.Results !== undefined && output.Results !== null
         ? deserializeAws_json1_1BatchPredictions(output.Results, context)
@@ -3331,7 +3306,7 @@ const deserializeAws_json1_1DescribeDataSourcesOutput = (
   context: __SerdeContext
 ): DescribeDataSourcesOutput => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Results:
       output.Results !== undefined && output.Results !== null
         ? deserializeAws_json1_1DataSources(output.Results, context)
@@ -3344,7 +3319,7 @@ const deserializeAws_json1_1DescribeEvaluationsOutput = (
   context: __SerdeContext
 ): DescribeEvaluationsOutput => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Results:
       output.Results !== undefined && output.Results !== null
         ? deserializeAws_json1_1Evaluations(output.Results, context)
@@ -3354,7 +3329,7 @@ const deserializeAws_json1_1DescribeEvaluationsOutput = (
 
 const deserializeAws_json1_1DescribeMLModelsOutput = (output: any, context: __SerdeContext): DescribeMLModelsOutput => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Results:
       output.Results !== undefined && output.Results !== null
         ? deserializeAws_json1_1MLModels(output.Results, context)
@@ -3364,8 +3339,8 @@ const deserializeAws_json1_1DescribeMLModelsOutput = (output: any, context: __Se
 
 const deserializeAws_json1_1DescribeTagsOutput = (output: any, context: __SerdeContext): DescribeTagsOutput => {
   return {
-    ResourceId: output.ResourceId !== undefined && output.ResourceId !== null ? output.ResourceId : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
+    ResourceId: __expectString(output.ResourceId),
+    ResourceType: __expectString(output.ResourceType),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_1TagList(output.Tags, context)
@@ -3381,7 +3356,7 @@ const deserializeAws_json1_1DetailsMap = (output: any, context: __SerdeContext):
       }
       return {
         ...acc,
-        [key]: value,
+        [key]: __expectString(value) as any,
       };
     },
     {}
@@ -3390,33 +3365,26 @@ const deserializeAws_json1_1DetailsMap = (output: any, context: __SerdeContext):
 
 const deserializeAws_json1_1Evaluation = (output: any, context: __SerdeContext): Evaluation => {
   return {
-    ComputeTime: output.ComputeTime !== undefined && output.ComputeTime !== null ? output.ComputeTime : undefined,
+    ComputeTime: __expectNumber(output.ComputeTime),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    CreatedByIamUser:
-      output.CreatedByIamUser !== undefined && output.CreatedByIamUser !== null ? output.CreatedByIamUser : undefined,
-    EvaluationDataSourceId:
-      output.EvaluationDataSourceId !== undefined && output.EvaluationDataSourceId !== null
-        ? output.EvaluationDataSourceId
-        : undefined,
-    EvaluationId: output.EvaluationId !== undefined && output.EvaluationId !== null ? output.EvaluationId : undefined,
+    CreatedByIamUser: __expectString(output.CreatedByIamUser),
+    EvaluationDataSourceId: __expectString(output.EvaluationDataSourceId),
+    EvaluationId: __expectString(output.EvaluationId),
     FinishedAt:
       output.FinishedAt !== undefined && output.FinishedAt !== null
         ? new Date(Math.round(output.FinishedAt * 1000))
         : undefined,
-    InputDataLocationS3:
-      output.InputDataLocationS3 !== undefined && output.InputDataLocationS3 !== null
-        ? output.InputDataLocationS3
-        : undefined,
+    InputDataLocationS3: __expectString(output.InputDataLocationS3),
     LastUpdatedAt:
       output.LastUpdatedAt !== undefined && output.LastUpdatedAt !== null
         ? new Date(Math.round(output.LastUpdatedAt * 1000))
         : undefined,
-    MLModelId: output.MLModelId !== undefined && output.MLModelId !== null ? output.MLModelId : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    MLModelId: __expectString(output.MLModelId),
+    Message: __expectString(output.Message),
+    Name: __expectString(output.Name),
     PerformanceMetrics:
       output.PerformanceMetrics !== undefined && output.PerformanceMetrics !== null
         ? deserializeAws_json1_1PerformanceMetrics(output.PerformanceMetrics, context)
@@ -3425,7 +3393,7 @@ const deserializeAws_json1_1Evaluation = (output: any, context: __SerdeContext):
       output.StartedAt !== undefined && output.StartedAt !== null
         ? new Date(Math.round(output.StartedAt * 1000))
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -3445,76 +3413,52 @@ const deserializeAws_json1_1GetBatchPredictionOutput = (
   context: __SerdeContext
 ): GetBatchPredictionOutput => {
   return {
-    BatchPredictionDataSourceId:
-      output.BatchPredictionDataSourceId !== undefined && output.BatchPredictionDataSourceId !== null
-        ? output.BatchPredictionDataSourceId
-        : undefined,
-    BatchPredictionId:
-      output.BatchPredictionId !== undefined && output.BatchPredictionId !== null
-        ? output.BatchPredictionId
-        : undefined,
-    ComputeTime: output.ComputeTime !== undefined && output.ComputeTime !== null ? output.ComputeTime : undefined,
+    BatchPredictionDataSourceId: __expectString(output.BatchPredictionDataSourceId),
+    BatchPredictionId: __expectString(output.BatchPredictionId),
+    ComputeTime: __expectNumber(output.ComputeTime),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    CreatedByIamUser:
-      output.CreatedByIamUser !== undefined && output.CreatedByIamUser !== null ? output.CreatedByIamUser : undefined,
+    CreatedByIamUser: __expectString(output.CreatedByIamUser),
     FinishedAt:
       output.FinishedAt !== undefined && output.FinishedAt !== null
         ? new Date(Math.round(output.FinishedAt * 1000))
         : undefined,
-    InputDataLocationS3:
-      output.InputDataLocationS3 !== undefined && output.InputDataLocationS3 !== null
-        ? output.InputDataLocationS3
-        : undefined,
-    InvalidRecordCount:
-      output.InvalidRecordCount !== undefined && output.InvalidRecordCount !== null
-        ? output.InvalidRecordCount
-        : undefined,
+    InputDataLocationS3: __expectString(output.InputDataLocationS3),
+    InvalidRecordCount: __expectNumber(output.InvalidRecordCount),
     LastUpdatedAt:
       output.LastUpdatedAt !== undefined && output.LastUpdatedAt !== null
         ? new Date(Math.round(output.LastUpdatedAt * 1000))
         : undefined,
-    LogUri: output.LogUri !== undefined && output.LogUri !== null ? output.LogUri : undefined,
-    MLModelId: output.MLModelId !== undefined && output.MLModelId !== null ? output.MLModelId : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    OutputUri: output.OutputUri !== undefined && output.OutputUri !== null ? output.OutputUri : undefined,
+    LogUri: __expectString(output.LogUri),
+    MLModelId: __expectString(output.MLModelId),
+    Message: __expectString(output.Message),
+    Name: __expectString(output.Name),
+    OutputUri: __expectString(output.OutputUri),
     StartedAt:
       output.StartedAt !== undefined && output.StartedAt !== null
         ? new Date(Math.round(output.StartedAt * 1000))
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    TotalRecordCount:
-      output.TotalRecordCount !== undefined && output.TotalRecordCount !== null ? output.TotalRecordCount : undefined,
+    Status: __expectString(output.Status),
+    TotalRecordCount: __expectNumber(output.TotalRecordCount),
   } as any;
 };
 
 const deserializeAws_json1_1GetDataSourceOutput = (output: any, context: __SerdeContext): GetDataSourceOutput => {
   return {
-    ComputeStatistics:
-      output.ComputeStatistics !== undefined && output.ComputeStatistics !== null
-        ? output.ComputeStatistics
-        : undefined,
-    ComputeTime: output.ComputeTime !== undefined && output.ComputeTime !== null ? output.ComputeTime : undefined,
+    ComputeStatistics: __expectBoolean(output.ComputeStatistics),
+    ComputeTime: __expectNumber(output.ComputeTime),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    CreatedByIamUser:
-      output.CreatedByIamUser !== undefined && output.CreatedByIamUser !== null ? output.CreatedByIamUser : undefined,
-    DataLocationS3:
-      output.DataLocationS3 !== undefined && output.DataLocationS3 !== null ? output.DataLocationS3 : undefined,
-    DataRearrangement:
-      output.DataRearrangement !== undefined && output.DataRearrangement !== null
-        ? output.DataRearrangement
-        : undefined,
-    DataSizeInBytes:
-      output.DataSizeInBytes !== undefined && output.DataSizeInBytes !== null ? output.DataSizeInBytes : undefined,
-    DataSourceId: output.DataSourceId !== undefined && output.DataSourceId !== null ? output.DataSourceId : undefined,
-    DataSourceSchema:
-      output.DataSourceSchema !== undefined && output.DataSourceSchema !== null ? output.DataSourceSchema : undefined,
+    CreatedByIamUser: __expectString(output.CreatedByIamUser),
+    DataLocationS3: __expectString(output.DataLocationS3),
+    DataRearrangement: __expectString(output.DataRearrangement),
+    DataSizeInBytes: __expectNumber(output.DataSizeInBytes),
+    DataSourceId: __expectString(output.DataSourceId),
+    DataSourceSchema: __expectString(output.DataSourceSchema),
     FinishedAt:
       output.FinishedAt !== undefined && output.FinishedAt !== null
         ? new Date(Math.round(output.FinishedAt * 1000))
@@ -3523,11 +3467,10 @@ const deserializeAws_json1_1GetDataSourceOutput = (output: any, context: __Serde
       output.LastUpdatedAt !== undefined && output.LastUpdatedAt !== null
         ? new Date(Math.round(output.LastUpdatedAt * 1000))
         : undefined,
-    LogUri: output.LogUri !== undefined && output.LogUri !== null ? output.LogUri : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    NumberOfFiles:
-      output.NumberOfFiles !== undefined && output.NumberOfFiles !== null ? output.NumberOfFiles : undefined,
+    LogUri: __expectString(output.LogUri),
+    Message: __expectString(output.Message),
+    Name: __expectString(output.Name),
+    NumberOfFiles: __expectNumber(output.NumberOfFiles),
     RDSMetadata:
       output.RDSMetadata !== undefined && output.RDSMetadata !== null
         ? deserializeAws_json1_1RDSMetadata(output.RDSMetadata, context)
@@ -3536,45 +3479,38 @@ const deserializeAws_json1_1GetDataSourceOutput = (output: any, context: __Serde
       output.RedshiftMetadata !== undefined && output.RedshiftMetadata !== null
         ? deserializeAws_json1_1RedshiftMetadata(output.RedshiftMetadata, context)
         : undefined,
-    RoleARN: output.RoleARN !== undefined && output.RoleARN !== null ? output.RoleARN : undefined,
+    RoleARN: __expectString(output.RoleARN),
     StartedAt:
       output.StartedAt !== undefined && output.StartedAt !== null
         ? new Date(Math.round(output.StartedAt * 1000))
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
 const deserializeAws_json1_1GetEvaluationOutput = (output: any, context: __SerdeContext): GetEvaluationOutput => {
   return {
-    ComputeTime: output.ComputeTime !== undefined && output.ComputeTime !== null ? output.ComputeTime : undefined,
+    ComputeTime: __expectNumber(output.ComputeTime),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    CreatedByIamUser:
-      output.CreatedByIamUser !== undefined && output.CreatedByIamUser !== null ? output.CreatedByIamUser : undefined,
-    EvaluationDataSourceId:
-      output.EvaluationDataSourceId !== undefined && output.EvaluationDataSourceId !== null
-        ? output.EvaluationDataSourceId
-        : undefined,
-    EvaluationId: output.EvaluationId !== undefined && output.EvaluationId !== null ? output.EvaluationId : undefined,
+    CreatedByIamUser: __expectString(output.CreatedByIamUser),
+    EvaluationDataSourceId: __expectString(output.EvaluationDataSourceId),
+    EvaluationId: __expectString(output.EvaluationId),
     FinishedAt:
       output.FinishedAt !== undefined && output.FinishedAt !== null
         ? new Date(Math.round(output.FinishedAt * 1000))
         : undefined,
-    InputDataLocationS3:
-      output.InputDataLocationS3 !== undefined && output.InputDataLocationS3 !== null
-        ? output.InputDataLocationS3
-        : undefined,
+    InputDataLocationS3: __expectString(output.InputDataLocationS3),
     LastUpdatedAt:
       output.LastUpdatedAt !== undefined && output.LastUpdatedAt !== null
         ? new Date(Math.round(output.LastUpdatedAt * 1000))
         : undefined,
-    LogUri: output.LogUri !== undefined && output.LogUri !== null ? output.LogUri : undefined,
-    MLModelId: output.MLModelId !== undefined && output.MLModelId !== null ? output.MLModelId : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    LogUri: __expectString(output.LogUri),
+    MLModelId: __expectString(output.MLModelId),
+    Message: __expectString(output.Message),
+    Name: __expectString(output.Name),
     PerformanceMetrics:
       output.PerformanceMetrics !== undefined && output.PerformanceMetrics !== null
         ? deserializeAws_json1_1PerformanceMetrics(output.PerformanceMetrics, context)
@@ -3583,19 +3519,18 @@ const deserializeAws_json1_1GetEvaluationOutput = (output: any, context: __Serde
       output.StartedAt !== undefined && output.StartedAt !== null
         ? new Date(Math.round(output.StartedAt * 1000))
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
 const deserializeAws_json1_1GetMLModelOutput = (output: any, context: __SerdeContext): GetMLModelOutput => {
   return {
-    ComputeTime: output.ComputeTime !== undefined && output.ComputeTime !== null ? output.ComputeTime : undefined,
+    ComputeTime: __expectNumber(output.ComputeTime),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    CreatedByIamUser:
-      output.CreatedByIamUser !== undefined && output.CreatedByIamUser !== null ? output.CreatedByIamUser : undefined,
+    CreatedByIamUser: __expectString(output.CreatedByIamUser),
     EndpointInfo:
       output.EndpointInfo !== undefined && output.EndpointInfo !== null
         ? deserializeAws_json1_1RealtimeEndpointInfo(output.EndpointInfo, context)
@@ -3604,37 +3539,30 @@ const deserializeAws_json1_1GetMLModelOutput = (output: any, context: __SerdeCon
       output.FinishedAt !== undefined && output.FinishedAt !== null
         ? new Date(Math.round(output.FinishedAt * 1000))
         : undefined,
-    InputDataLocationS3:
-      output.InputDataLocationS3 !== undefined && output.InputDataLocationS3 !== null
-        ? output.InputDataLocationS3
-        : undefined,
+    InputDataLocationS3: __expectString(output.InputDataLocationS3),
     LastUpdatedAt:
       output.LastUpdatedAt !== undefined && output.LastUpdatedAt !== null
         ? new Date(Math.round(output.LastUpdatedAt * 1000))
         : undefined,
-    LogUri: output.LogUri !== undefined && output.LogUri !== null ? output.LogUri : undefined,
-    MLModelId: output.MLModelId !== undefined && output.MLModelId !== null ? output.MLModelId : undefined,
-    MLModelType: output.MLModelType !== undefined && output.MLModelType !== null ? output.MLModelType : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Recipe: output.Recipe !== undefined && output.Recipe !== null ? output.Recipe : undefined,
-    Schema: output.Schema !== undefined && output.Schema !== null ? output.Schema : undefined,
-    ScoreThreshold:
-      output.ScoreThreshold !== undefined && output.ScoreThreshold !== null ? output.ScoreThreshold : undefined,
+    LogUri: __expectString(output.LogUri),
+    MLModelId: __expectString(output.MLModelId),
+    MLModelType: __expectString(output.MLModelType),
+    Message: __expectString(output.Message),
+    Name: __expectString(output.Name),
+    Recipe: __expectString(output.Recipe),
+    Schema: __expectString(output.Schema),
+    ScoreThreshold: __expectNumber(output.ScoreThreshold),
     ScoreThresholdLastUpdatedAt:
       output.ScoreThresholdLastUpdatedAt !== undefined && output.ScoreThresholdLastUpdatedAt !== null
         ? new Date(Math.round(output.ScoreThresholdLastUpdatedAt * 1000))
         : undefined,
-    SizeInBytes: output.SizeInBytes !== undefined && output.SizeInBytes !== null ? output.SizeInBytes : undefined,
+    SizeInBytes: __expectNumber(output.SizeInBytes),
     StartedAt:
       output.StartedAt !== undefined && output.StartedAt !== null
         ? new Date(Math.round(output.StartedAt * 1000))
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    TrainingDataSourceId:
-      output.TrainingDataSourceId !== undefined && output.TrainingDataSourceId !== null
-        ? output.TrainingDataSourceId
-        : undefined,
+    Status: __expectString(output.Status),
+    TrainingDataSourceId: __expectString(output.TrainingDataSourceId),
     TrainingParameters:
       output.TrainingParameters !== undefined && output.TrainingParameters !== null
         ? deserializeAws_json1_1TrainingParameters(output.TrainingParameters, context)
@@ -3647,8 +3575,8 @@ const deserializeAws_json1_1IdempotentParameterMismatchException = (
   context: __SerdeContext
 ): IdempotentParameterMismatchException => {
   return {
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    code: __expectNumber(output.code),
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3657,41 +3585,40 @@ const deserializeAws_json1_1InternalServerException = (
   context: __SerdeContext
 ): InternalServerException => {
   return {
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    code: __expectNumber(output.code),
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidInputException = (output: any, context: __SerdeContext): InvalidInputException => {
   return {
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    code: __expectNumber(output.code),
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidTagException = (output: any, context: __SerdeContext): InvalidTagException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    code: __expectNumber(output.code),
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1MLModel = (output: any, context: __SerdeContext): MLModel => {
   return {
-    Algorithm: output.Algorithm !== undefined && output.Algorithm !== null ? output.Algorithm : undefined,
-    ComputeTime: output.ComputeTime !== undefined && output.ComputeTime !== null ? output.ComputeTime : undefined,
+    Algorithm: __expectString(output.Algorithm),
+    ComputeTime: __expectNumber(output.ComputeTime),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    CreatedByIamUser:
-      output.CreatedByIamUser !== undefined && output.CreatedByIamUser !== null ? output.CreatedByIamUser : undefined,
+    CreatedByIamUser: __expectString(output.CreatedByIamUser),
     EndpointInfo:
       output.EndpointInfo !== undefined && output.EndpointInfo !== null
         ? deserializeAws_json1_1RealtimeEndpointInfo(output.EndpointInfo, context)
@@ -3700,34 +3627,27 @@ const deserializeAws_json1_1MLModel = (output: any, context: __SerdeContext): ML
       output.FinishedAt !== undefined && output.FinishedAt !== null
         ? new Date(Math.round(output.FinishedAt * 1000))
         : undefined,
-    InputDataLocationS3:
-      output.InputDataLocationS3 !== undefined && output.InputDataLocationS3 !== null
-        ? output.InputDataLocationS3
-        : undefined,
+    InputDataLocationS3: __expectString(output.InputDataLocationS3),
     LastUpdatedAt:
       output.LastUpdatedAt !== undefined && output.LastUpdatedAt !== null
         ? new Date(Math.round(output.LastUpdatedAt * 1000))
         : undefined,
-    MLModelId: output.MLModelId !== undefined && output.MLModelId !== null ? output.MLModelId : undefined,
-    MLModelType: output.MLModelType !== undefined && output.MLModelType !== null ? output.MLModelType : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    ScoreThreshold:
-      output.ScoreThreshold !== undefined && output.ScoreThreshold !== null ? output.ScoreThreshold : undefined,
+    MLModelId: __expectString(output.MLModelId),
+    MLModelType: __expectString(output.MLModelType),
+    Message: __expectString(output.Message),
+    Name: __expectString(output.Name),
+    ScoreThreshold: __expectNumber(output.ScoreThreshold),
     ScoreThresholdLastUpdatedAt:
       output.ScoreThresholdLastUpdatedAt !== undefined && output.ScoreThresholdLastUpdatedAt !== null
         ? new Date(Math.round(output.ScoreThresholdLastUpdatedAt * 1000))
         : undefined,
-    SizeInBytes: output.SizeInBytes !== undefined && output.SizeInBytes !== null ? output.SizeInBytes : undefined,
+    SizeInBytes: __expectNumber(output.SizeInBytes),
     StartedAt:
       output.StartedAt !== undefined && output.StartedAt !== null
         ? new Date(Math.round(output.StartedAt * 1000))
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    TrainingDataSourceId:
-      output.TrainingDataSourceId !== undefined && output.TrainingDataSourceId !== null
-        ? output.TrainingDataSourceId
-        : undefined,
+    Status: __expectString(output.Status),
+    TrainingDataSourceId: __expectString(output.TrainingDataSourceId),
     TrainingParameters:
       output.TrainingParameters !== undefined && output.TrainingParameters !== null
         ? deserializeAws_json1_1TrainingParameters(output.TrainingParameters, context)
@@ -3765,7 +3685,7 @@ const deserializeAws_json1_1PerformanceMetricsProperties = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -3776,14 +3696,12 @@ const deserializeAws_json1_1Prediction = (output: any, context: __SerdeContext):
       output.details !== undefined && output.details !== null
         ? deserializeAws_json1_1DetailsMap(output.details, context)
         : undefined,
-    predictedLabel:
-      output.predictedLabel !== undefined && output.predictedLabel !== null ? output.predictedLabel : undefined,
+    predictedLabel: __expectString(output.predictedLabel),
     predictedScores:
       output.predictedScores !== undefined && output.predictedScores !== null
         ? deserializeAws_json1_1ScoreValuePerLabelMap(output.predictedScores, context)
         : undefined,
-    predictedValue:
-      output.predictedValue !== undefined && output.predictedValue !== null ? output.predictedValue : undefined,
+    predictedValue: __expectNumber(output.predictedValue),
   } as any;
 };
 
@@ -3792,7 +3710,7 @@ const deserializeAws_json1_1PredictorNotMountedException = (
   context: __SerdeContext
 ): PredictorNotMountedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3807,28 +3725,22 @@ const deserializeAws_json1_1PredictOutput = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1RDSDatabase = (output: any, context: __SerdeContext): RDSDatabase => {
   return {
-    DatabaseName: output.DatabaseName !== undefined && output.DatabaseName !== null ? output.DatabaseName : undefined,
-    InstanceIdentifier:
-      output.InstanceIdentifier !== undefined && output.InstanceIdentifier !== null
-        ? output.InstanceIdentifier
-        : undefined,
+    DatabaseName: __expectString(output.DatabaseName),
+    InstanceIdentifier: __expectString(output.InstanceIdentifier),
   } as any;
 };
 
 const deserializeAws_json1_1RDSMetadata = (output: any, context: __SerdeContext): RDSMetadata => {
   return {
-    DataPipelineId:
-      output.DataPipelineId !== undefined && output.DataPipelineId !== null ? output.DataPipelineId : undefined,
+    DataPipelineId: __expectString(output.DataPipelineId),
     Database:
       output.Database !== undefined && output.Database !== null
         ? deserializeAws_json1_1RDSDatabase(output.Database, context)
         : undefined,
-    DatabaseUserName:
-      output.DatabaseUserName !== undefined && output.DatabaseUserName !== null ? output.DatabaseUserName : undefined,
-    ResourceRole: output.ResourceRole !== undefined && output.ResourceRole !== null ? output.ResourceRole : undefined,
-    SelectSqlQuery:
-      output.SelectSqlQuery !== undefined && output.SelectSqlQuery !== null ? output.SelectSqlQuery : undefined,
-    ServiceRole: output.ServiceRole !== undefined && output.ServiceRole !== null ? output.ServiceRole : undefined,
+    DatabaseUserName: __expectString(output.DatabaseUserName),
+    ResourceRole: __expectString(output.ResourceRole),
+    SelectSqlQuery: __expectString(output.SelectSqlQuery),
+    ServiceRole: __expectString(output.ServiceRole),
   } as any;
 };
 
@@ -3838,36 +3750,27 @@ const deserializeAws_json1_1RealtimeEndpointInfo = (output: any, context: __Serd
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    EndpointStatus:
-      output.EndpointStatus !== undefined && output.EndpointStatus !== null ? output.EndpointStatus : undefined,
-    EndpointUrl: output.EndpointUrl !== undefined && output.EndpointUrl !== null ? output.EndpointUrl : undefined,
-    PeakRequestsPerSecond:
-      output.PeakRequestsPerSecond !== undefined && output.PeakRequestsPerSecond !== null
-        ? output.PeakRequestsPerSecond
-        : undefined,
+    EndpointStatus: __expectString(output.EndpointStatus),
+    EndpointUrl: __expectString(output.EndpointUrl),
+    PeakRequestsPerSecond: __expectNumber(output.PeakRequestsPerSecond),
   } as any;
 };
 
 const deserializeAws_json1_1RedshiftDatabase = (output: any, context: __SerdeContext): RedshiftDatabase => {
   return {
-    ClusterIdentifier:
-      output.ClusterIdentifier !== undefined && output.ClusterIdentifier !== null
-        ? output.ClusterIdentifier
-        : undefined,
-    DatabaseName: output.DatabaseName !== undefined && output.DatabaseName !== null ? output.DatabaseName : undefined,
+    ClusterIdentifier: __expectString(output.ClusterIdentifier),
+    DatabaseName: __expectString(output.DatabaseName),
   } as any;
 };
 
 const deserializeAws_json1_1RedshiftMetadata = (output: any, context: __SerdeContext): RedshiftMetadata => {
   return {
-    DatabaseUserName:
-      output.DatabaseUserName !== undefined && output.DatabaseUserName !== null ? output.DatabaseUserName : undefined,
+    DatabaseUserName: __expectString(output.DatabaseUserName),
     RedshiftDatabase:
       output.RedshiftDatabase !== undefined && output.RedshiftDatabase !== null
         ? deserializeAws_json1_1RedshiftDatabase(output.RedshiftDatabase, context)
         : undefined,
-    SelectSqlQuery:
-      output.SelectSqlQuery !== undefined && output.SelectSqlQuery !== null ? output.SelectSqlQuery : undefined,
+    SelectSqlQuery: __expectString(output.SelectSqlQuery),
   } as any;
 };
 
@@ -3876,8 +3779,8 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    code: __expectNumber(output.code),
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3891,15 +3794,15 @@ const deserializeAws_json1_1ScoreValuePerLabelMap = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectNumber(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -3908,7 +3811,7 @@ const deserializeAws_json1_1TagLimitExceededException = (
   context: __SerdeContext
 ): TagLimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3930,7 +3833,7 @@ const deserializeAws_json1_1TrainingParameters = (output: any, context: __SerdeC
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -3940,28 +3843,25 @@ const deserializeAws_json1_1UpdateBatchPredictionOutput = (
   context: __SerdeContext
 ): UpdateBatchPredictionOutput => {
   return {
-    BatchPredictionId:
-      output.BatchPredictionId !== undefined && output.BatchPredictionId !== null
-        ? output.BatchPredictionId
-        : undefined,
+    BatchPredictionId: __expectString(output.BatchPredictionId),
   } as any;
 };
 
 const deserializeAws_json1_1UpdateDataSourceOutput = (output: any, context: __SerdeContext): UpdateDataSourceOutput => {
   return {
-    DataSourceId: output.DataSourceId !== undefined && output.DataSourceId !== null ? output.DataSourceId : undefined,
+    DataSourceId: __expectString(output.DataSourceId),
   } as any;
 };
 
 const deserializeAws_json1_1UpdateEvaluationOutput = (output: any, context: __SerdeContext): UpdateEvaluationOutput => {
   return {
-    EvaluationId: output.EvaluationId !== undefined && output.EvaluationId !== null ? output.EvaluationId : undefined,
+    EvaluationId: __expectString(output.EvaluationId),
   } as any;
 };
 
 const deserializeAws_json1_1UpdateMLModelOutput = (output: any, context: __SerdeContext): UpdateMLModelOutput => {
   return {
-    MLModelId: output.MLModelId !== undefined && output.MLModelId !== null ? output.MLModelId : undefined,
+    MLModelId: __expectString(output.MLModelId),
   } as any;
 };
 

--- a/clients/client-macie/protocols/Aws_json1_1.ts
+++ b/clients/client-macie/protocols/Aws_json1_1.ts
@@ -43,7 +43,7 @@ import {
   UpdateS3ResourcesResult,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException, expectString as __expectString } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -853,8 +853,8 @@ const serializeAws_json1_1UpdateS3ResourcesRequest = (
 
 const deserializeAws_json1_1AccessDeniedException = (output: any, context: __SerdeContext): AccessDeniedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
+    message: __expectString(output.message),
+    resourceType: __expectString(output.resourceType),
   } as any;
 };
 
@@ -872,8 +872,8 @@ const deserializeAws_json1_1AssociateS3ResourcesResult = (
 
 const deserializeAws_json1_1ClassificationType = (output: any, context: __SerdeContext): ClassificationType => {
   return {
-    continuous: output.continuous !== undefined && output.continuous !== null ? output.continuous : undefined,
-    oneTime: output.oneTime !== undefined && output.oneTime !== null ? output.oneTime : undefined,
+    continuous: __expectString(output.continuous),
+    oneTime: __expectString(output.oneTime),
   } as any;
 };
 
@@ -891,8 +891,8 @@ const deserializeAws_json1_1DisassociateS3ResourcesResult = (
 
 const deserializeAws_json1_1FailedS3Resource = (output: any, context: __SerdeContext): FailedS3Resource => {
   return {
-    errorCode: output.errorCode !== undefined && output.errorCode !== null ? output.errorCode : undefined,
-    errorMessage: output.errorMessage !== undefined && output.errorMessage !== null ? output.errorMessage : undefined,
+    errorCode: __expectString(output.errorCode),
+    errorMessage: __expectString(output.errorMessage),
     failedItem:
       output.failedItem !== undefined && output.failedItem !== null
         ? deserializeAws_json1_1S3Resource(output.failedItem, context)
@@ -913,24 +913,24 @@ const deserializeAws_json1_1FailedS3Resources = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1InternalException = (output: any, context: __SerdeContext): InternalException => {
   return {
-    errorCode: output.errorCode !== undefined && output.errorCode !== null ? output.errorCode : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    errorCode: __expectString(output.errorCode),
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidInputException = (output: any, context: __SerdeContext): InvalidInputException => {
   return {
-    errorCode: output.errorCode !== undefined && output.errorCode !== null ? output.errorCode : undefined,
-    fieldName: output.fieldName !== undefined && output.fieldName !== null ? output.fieldName : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    errorCode: __expectString(output.errorCode),
+    fieldName: __expectString(output.fieldName),
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    errorCode: output.errorCode !== undefined && output.errorCode !== null ? output.errorCode : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
+    errorCode: __expectString(output.errorCode),
+    message: __expectString(output.message),
+    resourceType: __expectString(output.resourceType),
   } as any;
 };
 
@@ -943,13 +943,13 @@ const deserializeAws_json1_1ListMemberAccountsResult = (
       output.memberAccounts !== undefined && output.memberAccounts !== null
         ? deserializeAws_json1_1MemberAccounts(output.memberAccounts, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
 const deserializeAws_json1_1ListS3ResourcesResult = (output: any, context: __SerdeContext): ListS3ResourcesResult => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     s3Resources:
       output.s3Resources !== undefined && output.s3Resources !== null
         ? deserializeAws_json1_1S3ResourcesClassification(output.s3Resources, context)
@@ -959,7 +959,7 @@ const deserializeAws_json1_1ListS3ResourcesResult = (output: any, context: __Ser
 
 const deserializeAws_json1_1MemberAccount = (output: any, context: __SerdeContext): MemberAccount => {
   return {
-    accountId: output.accountId !== undefined && output.accountId !== null ? output.accountId : undefined,
+    accountId: __expectString(output.accountId),
   } as any;
 };
 
@@ -976,8 +976,8 @@ const deserializeAws_json1_1MemberAccounts = (output: any, context: __SerdeConte
 
 const deserializeAws_json1_1S3Resource = (output: any, context: __SerdeContext): S3Resource => {
   return {
-    bucketName: output.bucketName !== undefined && output.bucketName !== null ? output.bucketName : undefined,
-    prefix: output.prefix !== undefined && output.prefix !== null ? output.prefix : undefined,
+    bucketName: __expectString(output.bucketName),
+    prefix: __expectString(output.prefix),
   } as any;
 };
 
@@ -986,12 +986,12 @@ const deserializeAws_json1_1S3ResourceClassification = (
   context: __SerdeContext
 ): S3ResourceClassification => {
   return {
-    bucketName: output.bucketName !== undefined && output.bucketName !== null ? output.bucketName : undefined,
+    bucketName: __expectString(output.bucketName),
     classificationType:
       output.classificationType !== undefined && output.classificationType !== null
         ? deserializeAws_json1_1ClassificationType(output.classificationType, context)
         : undefined,
-    prefix: output.prefix !== undefined && output.prefix !== null ? output.prefix : undefined,
+    prefix: __expectString(output.prefix),
   } as any;
 };
 

--- a/clients/client-macie2/protocols/Aws_restJson1.ts
+++ b/clients/client-macie2/protocols/Aws_restJson1.ts
@@ -278,6 +278,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -2056,10 +2059,10 @@ export const deserializeAws_restJson1CreateClassificationJobCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.jobArn !== undefined && data.jobArn !== null) {
-    contents.jobArn = data.jobArn;
+    contents.jobArn = __expectString(data.jobArn);
   }
   if (data.jobId !== undefined && data.jobId !== null) {
-    contents.jobId = data.jobId;
+    contents.jobId = __expectString(data.jobId);
   }
   return Promise.resolve(contents);
 };
@@ -2162,7 +2165,7 @@ export const deserializeAws_restJson1CreateCustomDataIdentifierCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.customDataIdentifierId !== undefined && data.customDataIdentifierId !== null) {
-    contents.customDataIdentifierId = data.customDataIdentifierId;
+    contents.customDataIdentifierId = __expectString(data.customDataIdentifierId);
   }
   return Promise.resolve(contents);
 };
@@ -2266,10 +2269,10 @@ export const deserializeAws_restJson1CreateFindingsFilterCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   return Promise.resolve(contents);
 };
@@ -2478,7 +2481,7 @@ export const deserializeAws_restJson1CreateMemberCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   return Promise.resolve(contents);
 };
@@ -3193,7 +3196,7 @@ export const deserializeAws_restJson1DescribeBucketsCommand = async (
     contents.buckets = deserializeAws_restJson1__listOfBucketMetadata(data.buckets, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3313,7 +3316,7 @@ export const deserializeAws_restJson1DescribeClassificationJobCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.clientToken !== undefined && data.clientToken !== null) {
-    contents.clientToken = data.clientToken;
+    contents.clientToken = __expectString(data.clientToken);
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
     contents.createdAt = new Date(data.createdAt);
@@ -3322,22 +3325,22 @@ export const deserializeAws_restJson1DescribeClassificationJobCommand = async (
     contents.customDataIdentifierIds = deserializeAws_restJson1__listOf__string(data.customDataIdentifierIds, context);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.initialRun !== undefined && data.initialRun !== null) {
-    contents.initialRun = data.initialRun;
+    contents.initialRun = __expectBoolean(data.initialRun);
   }
   if (data.jobArn !== undefined && data.jobArn !== null) {
-    contents.jobArn = data.jobArn;
+    contents.jobArn = __expectString(data.jobArn);
   }
   if (data.jobId !== undefined && data.jobId !== null) {
-    contents.jobId = data.jobId;
+    contents.jobId = __expectString(data.jobId);
   }
   if (data.jobStatus !== undefined && data.jobStatus !== null) {
-    contents.jobStatus = data.jobStatus;
+    contents.jobStatus = __expectString(data.jobStatus);
   }
   if (data.jobType !== undefined && data.jobType !== null) {
-    contents.jobType = data.jobType;
+    contents.jobType = __expectString(data.jobType);
   }
   if (data.lastRunErrorStatus !== undefined && data.lastRunErrorStatus !== null) {
     contents.lastRunErrorStatus = deserializeAws_restJson1LastRunErrorStatus(data.lastRunErrorStatus, context);
@@ -3346,13 +3349,13 @@ export const deserializeAws_restJson1DescribeClassificationJobCommand = async (
     contents.lastRunTime = new Date(data.lastRunTime);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.s3JobDefinition !== undefined && data.s3JobDefinition !== null) {
     contents.s3JobDefinition = deserializeAws_restJson1S3JobDefinition(data.s3JobDefinition, context);
   }
   if (data.samplingPercentage !== undefined && data.samplingPercentage !== null) {
-    contents.samplingPercentage = data.samplingPercentage;
+    contents.samplingPercentage = __expectNumber(data.samplingPercentage);
   }
   if (data.scheduleFrequency !== undefined && data.scheduleFrequency !== null) {
     contents.scheduleFrequency = deserializeAws_restJson1JobScheduleFrequency(data.scheduleFrequency, context);
@@ -3468,10 +3471,10 @@ export const deserializeAws_restJson1DescribeOrganizationConfigurationCommand = 
   };
   const data: any = await parseBody(output.body, context);
   if (data.autoEnable !== undefined && data.autoEnable !== null) {
-    contents.autoEnable = data.autoEnable;
+    contents.autoEnable = __expectBoolean(data.autoEnable);
   }
   if (data.maxAccountLimitReached !== undefined && data.maxAccountLimitReached !== null) {
-    contents.maxAccountLimitReached = data.maxAccountLimitReached;
+    contents.maxAccountLimitReached = __expectBoolean(data.maxAccountLimitReached);
   }
   return Promise.resolve(contents);
 };
@@ -4382,7 +4385,7 @@ export const deserializeAws_restJson1GetBucketStatisticsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.bucketCount !== undefined && data.bucketCount !== null) {
-    contents.bucketCount = data.bucketCount;
+    contents.bucketCount = __expectNumber(data.bucketCount);
   }
   if (data.bucketCountByEffectivePermission !== undefined && data.bucketCountByEffectivePermission !== null) {
     contents.bucketCountByEffectivePermission = deserializeAws_restJson1BucketCountByEffectivePermission(
@@ -4413,22 +4416,22 @@ export const deserializeAws_restJson1GetBucketStatisticsCommand = async (
     );
   }
   if (data.classifiableObjectCount !== undefined && data.classifiableObjectCount !== null) {
-    contents.classifiableObjectCount = data.classifiableObjectCount;
+    contents.classifiableObjectCount = __expectNumber(data.classifiableObjectCount);
   }
   if (data.classifiableSizeInBytes !== undefined && data.classifiableSizeInBytes !== null) {
-    contents.classifiableSizeInBytes = data.classifiableSizeInBytes;
+    contents.classifiableSizeInBytes = __expectNumber(data.classifiableSizeInBytes);
   }
   if (data.lastUpdated !== undefined && data.lastUpdated !== null) {
     contents.lastUpdated = new Date(data.lastUpdated);
   }
   if (data.objectCount !== undefined && data.objectCount !== null) {
-    contents.objectCount = data.objectCount;
+    contents.objectCount = __expectNumber(data.objectCount);
   }
   if (data.sizeInBytes !== undefined && data.sizeInBytes !== null) {
-    contents.sizeInBytes = data.sizeInBytes;
+    contents.sizeInBytes = __expectNumber(data.sizeInBytes);
   }
   if (data.sizeInBytesCompressed !== undefined && data.sizeInBytesCompressed !== null) {
-    contents.sizeInBytesCompressed = data.sizeInBytesCompressed;
+    contents.sizeInBytesCompressed = __expectNumber(data.sizeInBytesCompressed);
   }
   if (data.unclassifiableObjectCount !== undefined && data.unclassifiableObjectCount !== null) {
     contents.unclassifiableObjectCount = deserializeAws_restJson1ObjectLevelStatistics(
@@ -4656,19 +4659,19 @@ export const deserializeAws_restJson1GetCustomDataIdentifierCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
     contents.createdAt = new Date(data.createdAt);
   }
   if (data.deleted !== undefined && data.deleted !== null) {
-    contents.deleted = data.deleted;
+    contents.deleted = __expectBoolean(data.deleted);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   if (data.ignoreWords !== undefined && data.ignoreWords !== null) {
     contents.ignoreWords = deserializeAws_restJson1__listOf__string(data.ignoreWords, context);
@@ -4677,13 +4680,13 @@ export const deserializeAws_restJson1GetCustomDataIdentifierCommand = async (
     contents.keywords = deserializeAws_restJson1__listOf__string(data.keywords, context);
   }
   if (data.maximumMatchDistance !== undefined && data.maximumMatchDistance !== null) {
-    contents.maximumMatchDistance = data.maximumMatchDistance;
+    contents.maximumMatchDistance = __expectNumber(data.maximumMatchDistance);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.regex !== undefined && data.regex !== null) {
-    contents.regex = data.regex;
+    contents.regex = __expectString(data.regex);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
@@ -4899,25 +4902,25 @@ export const deserializeAws_restJson1GetFindingsFilterCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.action !== undefined && data.action !== null) {
-    contents.action = data.action;
+    contents.action = __expectString(data.action);
   }
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.findingCriteria !== undefined && data.findingCriteria !== null) {
     contents.findingCriteria = deserializeAws_restJson1FindingCriteria(data.findingCriteria, context);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.position !== undefined && data.position !== null) {
-    contents.position = data.position;
+    contents.position = __expectNumber(data.position);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
@@ -5232,7 +5235,7 @@ export const deserializeAws_restJson1GetInvitationsCountCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.invitationsCount !== undefined && data.invitationsCount !== null) {
-    contents.invitationsCount = data.invitationsCount;
+    contents.invitationsCount = __expectNumber(data.invitationsCount);
   }
   return Promise.resolve(contents);
 };
@@ -5342,13 +5345,13 @@ export const deserializeAws_restJson1GetMacieSessionCommand = async (
     contents.createdAt = new Date(data.createdAt);
   }
   if (data.findingPublishingFrequency !== undefined && data.findingPublishingFrequency !== null) {
-    contents.findingPublishingFrequency = data.findingPublishingFrequency;
+    contents.findingPublishingFrequency = __expectString(data.findingPublishingFrequency);
   }
   if (data.serviceRole !== undefined && data.serviceRole !== null) {
-    contents.serviceRole = data.serviceRole;
+    contents.serviceRole = __expectString(data.serviceRole);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.status = data.status;
+    contents.status = __expectString(data.status);
   }
   if (data.updatedAt !== undefined && data.updatedAt !== null) {
     contents.updatedAt = new Date(data.updatedAt);
@@ -5565,25 +5568,25 @@ export const deserializeAws_restJson1GetMemberCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.accountId !== undefined && data.accountId !== null) {
-    contents.accountId = data.accountId;
+    contents.accountId = __expectString(data.accountId);
   }
   if (data.administratorAccountId !== undefined && data.administratorAccountId !== null) {
-    contents.administratorAccountId = data.administratorAccountId;
+    contents.administratorAccountId = __expectString(data.administratorAccountId);
   }
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.email !== undefined && data.email !== null) {
-    contents.email = data.email;
+    contents.email = __expectString(data.email);
   }
   if (data.invitedAt !== undefined && data.invitedAt !== null) {
     contents.invitedAt = new Date(data.invitedAt);
   }
   if (data.masterAccountId !== undefined && data.masterAccountId !== null) {
-    contents.masterAccountId = data.masterAccountId;
+    contents.masterAccountId = __expectString(data.masterAccountId);
   }
   if (data.relationshipStatus !== undefined && data.relationshipStatus !== null) {
-    contents.relationshipStatus = data.relationshipStatus;
+    contents.relationshipStatus = __expectString(data.relationshipStatus);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
@@ -5694,13 +5697,13 @@ export const deserializeAws_restJson1GetUsageStatisticsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.records !== undefined && data.records !== null) {
     contents.records = deserializeAws_restJson1__listOfUsageRecord(data.records, context);
   }
   if (data.timeRange !== undefined && data.timeRange !== null) {
-    contents.timeRange = data.timeRange;
+    contents.timeRange = __expectString(data.timeRange);
   }
   return Promise.resolve(contents);
 };
@@ -5804,7 +5807,7 @@ export const deserializeAws_restJson1GetUsageTotalsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.timeRange !== undefined && data.timeRange !== null) {
-    contents.timeRange = data.timeRange;
+    contents.timeRange = __expectString(data.timeRange);
   }
   if (data.usageTotals !== undefined && data.usageTotals !== null) {
     contents.usageTotals = deserializeAws_restJson1__listOfUsageTotal(data.usageTotals, context);
@@ -5914,7 +5917,7 @@ export const deserializeAws_restJson1ListClassificationJobsCommand = async (
     contents.items = deserializeAws_restJson1__listOfJobSummary(data.items, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -6021,7 +6024,7 @@ export const deserializeAws_restJson1ListCustomDataIdentifiersCommand = async (
     contents.items = deserializeAws_restJson1__listOfCustomDataIdentifierSummary(data.items, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -6128,7 +6131,7 @@ export const deserializeAws_restJson1ListFindingsCommand = async (
     contents.findingIds = deserializeAws_restJson1__listOf__string(data.findingIds, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -6238,7 +6241,7 @@ export const deserializeAws_restJson1ListFindingsFiltersCommand = async (
     );
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -6345,7 +6348,7 @@ export const deserializeAws_restJson1ListInvitationsCommand = async (
     contents.invitations = deserializeAws_restJson1__listOfInvitation(data.invitations, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -6452,7 +6455,7 @@ export const deserializeAws_restJson1ListMembersCommand = async (
     contents.members = deserializeAws_restJson1__listOfMember(data.members, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -6559,7 +6562,7 @@ export const deserializeAws_restJson1ListOrganizationAdminAccountsCommand = asyn
     contents.adminAccounts = deserializeAws_restJson1__listOfAdminAccount(data.adminAccounts, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -6915,7 +6918,7 @@ export const deserializeAws_restJson1SearchResourcesCommand = async (
     contents.matchingResources = deserializeAws_restJson1__listOfMatchingResource(data.matchingResources, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -7061,7 +7064,7 @@ export const deserializeAws_restJson1TestCustomDataIdentifierCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.matchCount !== undefined && data.matchCount !== null) {
-    contents.matchCount = data.matchCount;
+    contents.matchCount = __expectNumber(data.matchCount);
   }
   return Promise.resolve(contents);
 };
@@ -7307,10 +7310,10 @@ export const deserializeAws_restJson1UpdateFindingsFilterCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   return Promise.resolve(contents);
 };
@@ -7709,7 +7712,7 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -7726,7 +7729,7 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -7743,7 +7746,7 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -7760,7 +7763,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -7777,7 +7780,7 @@ const deserializeAws_restJson1ServiceQuotaExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -7794,7 +7797,7 @@ const deserializeAws_restJson1ThrottlingExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -7811,7 +7814,7 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -8418,7 +8421,7 @@ const deserializeAws_restJson1__listOf__string = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -8673,14 +8676,8 @@ const deserializeAws_restJson1__listOfUsageTotal = (output: any, context: __Serd
 
 const deserializeAws_restJson1AccessControlList = (output: any, context: __SerdeContext): AccessControlList => {
   return {
-    allowsPublicReadAccess:
-      output.allowsPublicReadAccess !== undefined && output.allowsPublicReadAccess !== null
-        ? output.allowsPublicReadAccess
-        : undefined,
-    allowsPublicWriteAccess:
-      output.allowsPublicWriteAccess !== undefined && output.allowsPublicWriteAccess !== null
-        ? output.allowsPublicWriteAccess
-        : undefined,
+    allowsPublicReadAccess: __expectBoolean(output.allowsPublicReadAccess),
+    allowsPublicWriteAccess: __expectBoolean(output.allowsPublicWriteAccess),
   } as any;
 };
 
@@ -8698,16 +8695,15 @@ const deserializeAws_restJson1AccountLevelPermissions = (
 
 const deserializeAws_restJson1AdminAccount = (output: any, context: __SerdeContext): AdminAccount => {
   return {
-    accountId: output.accountId !== undefined && output.accountId !== null ? output.accountId : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    accountId: __expectString(output.accountId),
+    status: __expectString(output.status),
   } as any;
 };
 
 const deserializeAws_restJson1ApiCallDetails = (output: any, context: __SerdeContext): ApiCallDetails => {
   return {
-    api: output.api !== undefined && output.api !== null ? output.api : undefined,
-    apiServiceName:
-      output.apiServiceName !== undefined && output.apiServiceName !== null ? output.apiServiceName : undefined,
+    api: __expectString(output.api),
+    apiServiceName: __expectString(output.apiServiceName),
     firstSeen: output.firstSeen !== undefined && output.firstSeen !== null ? new Date(output.firstSeen) : undefined,
     lastSeen: output.lastSeen !== undefined && output.lastSeen !== null ? new Date(output.lastSeen) : undefined,
   } as any;
@@ -8715,10 +8711,10 @@ const deserializeAws_restJson1ApiCallDetails = (output: any, context: __SerdeCon
 
 const deserializeAws_restJson1AssumedRole = (output: any, context: __SerdeContext): AssumedRole => {
   return {
-    accessKeyId: output.accessKeyId !== undefined && output.accessKeyId !== null ? output.accessKeyId : undefined,
-    accountId: output.accountId !== undefined && output.accountId !== null ? output.accountId : undefined,
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    principalId: output.principalId !== undefined && output.principalId !== null ? output.principalId : undefined,
+    accessKeyId: __expectString(output.accessKeyId),
+    accountId: __expectString(output.accountId),
+    arn: __expectString(output.arn),
+    principalId: __expectString(output.principalId),
     sessionContext:
       output.sessionContext !== undefined && output.sessionContext !== null
         ? deserializeAws_restJson1SessionContext(output.sessionContext, context)
@@ -8728,14 +8724,14 @@ const deserializeAws_restJson1AssumedRole = (output: any, context: __SerdeContex
 
 const deserializeAws_restJson1AwsAccount = (output: any, context: __SerdeContext): AwsAccount => {
   return {
-    accountId: output.accountId !== undefined && output.accountId !== null ? output.accountId : undefined,
-    principalId: output.principalId !== undefined && output.principalId !== null ? output.principalId : undefined,
+    accountId: __expectString(output.accountId),
+    principalId: __expectString(output.principalId),
   } as any;
 };
 
 const deserializeAws_restJson1AwsService = (output: any, context: __SerdeContext): AwsService => {
   return {
-    invokedBy: output.invokedBy !== undefined && output.invokedBy !== null ? output.invokedBy : undefined,
+    invokedBy: __expectString(output.invokedBy),
   } as any;
 };
 
@@ -8744,29 +8740,21 @@ const deserializeAws_restJson1BatchGetCustomDataIdentifierSummary = (
   context: __SerdeContext
 ): BatchGetCustomDataIdentifierSummary => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt: output.createdAt !== undefined && output.createdAt !== null ? new Date(output.createdAt) : undefined,
-    deleted: output.deleted !== undefined && output.deleted !== null ? output.deleted : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    deleted: __expectBoolean(output.deleted),
+    description: __expectString(output.description),
+    id: __expectString(output.id),
+    name: __expectString(output.name),
   } as any;
 };
 
 const deserializeAws_restJson1BlockPublicAccess = (output: any, context: __SerdeContext): BlockPublicAccess => {
   return {
-    blockPublicAcls:
-      output.blockPublicAcls !== undefined && output.blockPublicAcls !== null ? output.blockPublicAcls : undefined,
-    blockPublicPolicy:
-      output.blockPublicPolicy !== undefined && output.blockPublicPolicy !== null
-        ? output.blockPublicPolicy
-        : undefined,
-    ignorePublicAcls:
-      output.ignorePublicAcls !== undefined && output.ignorePublicAcls !== null ? output.ignorePublicAcls : undefined,
-    restrictPublicBuckets:
-      output.restrictPublicBuckets !== undefined && output.restrictPublicBuckets !== null
-        ? output.restrictPublicBuckets
-        : undefined,
+    blockPublicAcls: __expectBoolean(output.blockPublicAcls),
+    blockPublicPolicy: __expectBoolean(output.blockPublicPolicy),
+    ignorePublicAcls: __expectBoolean(output.ignorePublicAcls),
+    restrictPublicBuckets: __expectBoolean(output.restrictPublicBuckets),
   } as any;
 };
 
@@ -8775,15 +8763,10 @@ const deserializeAws_restJson1BucketCountByEffectivePermission = (
   context: __SerdeContext
 ): BucketCountByEffectivePermission => {
   return {
-    publiclyAccessible:
-      output.publiclyAccessible !== undefined && output.publiclyAccessible !== null
-        ? output.publiclyAccessible
-        : undefined,
-    publiclyReadable:
-      output.publiclyReadable !== undefined && output.publiclyReadable !== null ? output.publiclyReadable : undefined,
-    publiclyWritable:
-      output.publiclyWritable !== undefined && output.publiclyWritable !== null ? output.publiclyWritable : undefined,
-    unknown: output.unknown !== undefined && output.unknown !== null ? output.unknown : undefined,
+    publiclyAccessible: __expectNumber(output.publiclyAccessible),
+    publiclyReadable: __expectNumber(output.publiclyReadable),
+    publiclyWritable: __expectNumber(output.publiclyWritable),
+    unknown: __expectNumber(output.unknown),
   } as any;
 };
 
@@ -8792,10 +8775,10 @@ const deserializeAws_restJson1BucketCountByEncryptionType = (
   context: __SerdeContext
 ): BucketCountByEncryptionType => {
   return {
-    kmsManaged: output.kmsManaged !== undefined && output.kmsManaged !== null ? output.kmsManaged : undefined,
-    s3Managed: output.s3Managed !== undefined && output.s3Managed !== null ? output.s3Managed : undefined,
-    unencrypted: output.unencrypted !== undefined && output.unencrypted !== null ? output.unencrypted : undefined,
-    unknown: output.unknown !== undefined && output.unknown !== null ? output.unknown : undefined,
+    kmsManaged: __expectNumber(output.kmsManaged),
+    s3Managed: __expectNumber(output.s3Managed),
+    unencrypted: __expectNumber(output.unencrypted),
+    unknown: __expectNumber(output.unknown),
   } as any;
 };
 
@@ -8804,10 +8787,10 @@ const deserializeAws_restJson1BucketCountBySharedAccessType = (
   context: __SerdeContext
 ): BucketCountBySharedAccessType => {
   return {
-    external: output.external !== undefined && output.external !== null ? output.external : undefined,
-    internal: output.internal !== undefined && output.internal !== null ? output.internal : undefined,
-    notShared: output.notShared !== undefined && output.notShared !== null ? output.notShared : undefined,
-    unknown: output.unknown !== undefined && output.unknown !== null ? output.unknown : undefined,
+    external: __expectNumber(output.external),
+    internal: __expectNumber(output.internal),
+    notShared: __expectNumber(output.notShared),
+    unknown: __expectNumber(output.unknown),
   } as any;
 };
 
@@ -8816,15 +8799,9 @@ const deserializeAws_restJson1BucketCountPolicyAllowsUnencryptedObjectUploads = 
   context: __SerdeContext
 ): BucketCountPolicyAllowsUnencryptedObjectUploads => {
   return {
-    allowsUnencryptedObjectUploads:
-      output.allowsUnencryptedObjectUploads !== undefined && output.allowsUnencryptedObjectUploads !== null
-        ? output.allowsUnencryptedObjectUploads
-        : undefined,
-    deniesUnencryptedObjectUploads:
-      output.deniesUnencryptedObjectUploads !== undefined && output.deniesUnencryptedObjectUploads !== null
-        ? output.deniesUnencryptedObjectUploads
-        : undefined,
-    unknown: output.unknown !== undefined && output.unknown !== null ? output.unknown : undefined,
+    allowsUnencryptedObjectUploads: __expectNumber(output.allowsUnencryptedObjectUploads),
+    deniesUnencryptedObjectUploads: __expectNumber(output.deniesUnencryptedObjectUploads),
+    unknown: __expectNumber(output.unknown),
   } as any;
 };
 
@@ -8850,32 +8827,23 @@ const deserializeAws_restJson1BucketLevelPermissions = (
 
 const deserializeAws_restJson1BucketMetadata = (output: any, context: __SerdeContext): BucketMetadata => {
   return {
-    accountId: output.accountId !== undefined && output.accountId !== null ? output.accountId : undefined,
-    allowsUnencryptedObjectUploads:
-      output.allowsUnencryptedObjectUploads !== undefined && output.allowsUnencryptedObjectUploads !== null
-        ? output.allowsUnencryptedObjectUploads
-        : undefined,
-    bucketArn: output.bucketArn !== undefined && output.bucketArn !== null ? output.bucketArn : undefined,
+    accountId: __expectString(output.accountId),
+    allowsUnencryptedObjectUploads: __expectString(output.allowsUnencryptedObjectUploads),
+    bucketArn: __expectString(output.bucketArn),
     bucketCreatedAt:
       output.bucketCreatedAt !== undefined && output.bucketCreatedAt !== null
         ? new Date(output.bucketCreatedAt)
         : undefined,
-    bucketName: output.bucketName !== undefined && output.bucketName !== null ? output.bucketName : undefined,
-    classifiableObjectCount:
-      output.classifiableObjectCount !== undefined && output.classifiableObjectCount !== null
-        ? output.classifiableObjectCount
-        : undefined,
-    classifiableSizeInBytes:
-      output.classifiableSizeInBytes !== undefined && output.classifiableSizeInBytes !== null
-        ? output.classifiableSizeInBytes
-        : undefined,
+    bucketName: __expectString(output.bucketName),
+    classifiableObjectCount: __expectNumber(output.classifiableObjectCount),
+    classifiableSizeInBytes: __expectNumber(output.classifiableSizeInBytes),
     jobDetails:
       output.jobDetails !== undefined && output.jobDetails !== null
         ? deserializeAws_restJson1JobDetails(output.jobDetails, context)
         : undefined,
     lastUpdated:
       output.lastUpdated !== undefined && output.lastUpdated !== null ? new Date(output.lastUpdated) : undefined,
-    objectCount: output.objectCount !== undefined && output.objectCount !== null ? output.objectCount : undefined,
+    objectCount: __expectNumber(output.objectCount),
     objectCountByEncryptionType:
       output.objectCountByEncryptionType !== undefined && output.objectCountByEncryptionType !== null
         ? deserializeAws_restJson1ObjectCountByEncryptionType(output.objectCountByEncryptionType, context)
@@ -8884,7 +8852,7 @@ const deserializeAws_restJson1BucketMetadata = (output: any, context: __SerdeCon
       output.publicAccess !== undefined && output.publicAccess !== null
         ? deserializeAws_restJson1BucketPublicAccess(output.publicAccess, context)
         : undefined,
-    region: output.region !== undefined && output.region !== null ? output.region : undefined,
+    region: __expectString(output.region),
     replicationDetails:
       output.replicationDetails !== undefined && output.replicationDetails !== null
         ? deserializeAws_restJson1ReplicationDetails(output.replicationDetails, context)
@@ -8893,12 +8861,9 @@ const deserializeAws_restJson1BucketMetadata = (output: any, context: __SerdeCon
       output.serverSideEncryption !== undefined && output.serverSideEncryption !== null
         ? deserializeAws_restJson1BucketServerSideEncryption(output.serverSideEncryption, context)
         : undefined,
-    sharedAccess: output.sharedAccess !== undefined && output.sharedAccess !== null ? output.sharedAccess : undefined,
-    sizeInBytes: output.sizeInBytes !== undefined && output.sizeInBytes !== null ? output.sizeInBytes : undefined,
-    sizeInBytesCompressed:
-      output.sizeInBytesCompressed !== undefined && output.sizeInBytesCompressed !== null
-        ? output.sizeInBytesCompressed
-        : undefined,
+    sharedAccess: __expectString(output.sharedAccess),
+    sizeInBytes: __expectNumber(output.sizeInBytes),
+    sizeInBytesCompressed: __expectNumber(output.sizeInBytesCompressed),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1__listOfKeyValuePair(output.tags, context)
@@ -8911,7 +8876,7 @@ const deserializeAws_restJson1BucketMetadata = (output: any, context: __SerdeCon
       output.unclassifiableObjectSizeInBytes !== undefined && output.unclassifiableObjectSizeInBytes !== null
         ? deserializeAws_restJson1ObjectLevelStatistics(output.unclassifiableObjectSizeInBytes, context)
         : undefined,
-    versioning: output.versioning !== undefined && output.versioning !== null ? output.versioning : undefined,
+    versioning: __expectBoolean(output.versioning),
   } as any;
 };
 
@@ -8933,23 +8898,14 @@ const deserializeAws_restJson1BucketPermissionConfiguration = (
 
 const deserializeAws_restJson1BucketPolicy = (output: any, context: __SerdeContext): BucketPolicy => {
   return {
-    allowsPublicReadAccess:
-      output.allowsPublicReadAccess !== undefined && output.allowsPublicReadAccess !== null
-        ? output.allowsPublicReadAccess
-        : undefined,
-    allowsPublicWriteAccess:
-      output.allowsPublicWriteAccess !== undefined && output.allowsPublicWriteAccess !== null
-        ? output.allowsPublicWriteAccess
-        : undefined,
+    allowsPublicReadAccess: __expectBoolean(output.allowsPublicReadAccess),
+    allowsPublicWriteAccess: __expectBoolean(output.allowsPublicWriteAccess),
   } as any;
 };
 
 const deserializeAws_restJson1BucketPublicAccess = (output: any, context: __SerdeContext): BucketPublicAccess => {
   return {
-    effectivePermission:
-      output.effectivePermission !== undefined && output.effectivePermission !== null
-        ? output.effectivePermission
-        : undefined,
+    effectivePermission: __expectString(output.effectivePermission),
     permissionConfiguration:
       output.permissionConfiguration !== undefined && output.permissionConfiguration !== null
         ? deserializeAws_restJson1BucketPermissionConfiguration(output.permissionConfiguration, context)
@@ -8962,19 +8918,17 @@ const deserializeAws_restJson1BucketServerSideEncryption = (
   context: __SerdeContext
 ): BucketServerSideEncryption => {
   return {
-    kmsMasterKeyId:
-      output.kmsMasterKeyId !== undefined && output.kmsMasterKeyId !== null ? output.kmsMasterKeyId : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    kmsMasterKeyId: __expectString(output.kmsMasterKeyId),
+    type: __expectString(output.type),
   } as any;
 };
 
 const deserializeAws_restJson1Cell = (output: any, context: __SerdeContext): Cell => {
   return {
-    cellReference:
-      output.cellReference !== undefined && output.cellReference !== null ? output.cellReference : undefined,
-    column: output.column !== undefined && output.column !== null ? output.column : undefined,
-    columnName: output.columnName !== undefined && output.columnName !== null ? output.columnName : undefined,
-    row: output.row !== undefined && output.row !== null ? output.row : undefined,
+    cellReference: __expectString(output.cellReference),
+    column: __expectNumber(output.column),
+    columnName: __expectString(output.columnName),
+    row: __expectNumber(output.row),
   } as any;
 };
 
@@ -8991,12 +8945,9 @@ const deserializeAws_restJson1Cells = (output: any, context: __SerdeContext): Ce
 
 const deserializeAws_restJson1ClassificationDetails = (output: any, context: __SerdeContext): ClassificationDetails => {
   return {
-    detailedResultsLocation:
-      output.detailedResultsLocation !== undefined && output.detailedResultsLocation !== null
-        ? output.detailedResultsLocation
-        : undefined,
-    jobArn: output.jobArn !== undefined && output.jobArn !== null ? output.jobArn : undefined,
-    jobId: output.jobId !== undefined && output.jobId !== null ? output.jobId : undefined,
+    detailedResultsLocation: __expectString(output.detailedResultsLocation),
+    jobArn: __expectString(output.jobArn),
+    jobId: __expectString(output.jobId),
     result:
       output.result !== undefined && output.result !== null
         ? deserializeAws_restJson1ClassificationResult(output.result, context)
@@ -9018,21 +8969,17 @@ const deserializeAws_restJson1ClassificationExportConfiguration = (
 
 const deserializeAws_restJson1ClassificationResult = (output: any, context: __SerdeContext): ClassificationResult => {
   return {
-    additionalOccurrences:
-      output.additionalOccurrences !== undefined && output.additionalOccurrences !== null
-        ? output.additionalOccurrences
-        : undefined,
+    additionalOccurrences: __expectBoolean(output.additionalOccurrences),
     customDataIdentifiers:
       output.customDataIdentifiers !== undefined && output.customDataIdentifiers !== null
         ? deserializeAws_restJson1CustomDataIdentifiers(output.customDataIdentifiers, context)
         : undefined,
-    mimeType: output.mimeType !== undefined && output.mimeType !== null ? output.mimeType : undefined,
+    mimeType: __expectString(output.mimeType),
     sensitiveData:
       output.sensitiveData !== undefined && output.sensitiveData !== null
         ? deserializeAws_restJson1SensitiveData(output.sensitiveData, context)
         : undefined,
-    sizeClassified:
-      output.sizeClassified !== undefined && output.sizeClassified !== null ? output.sizeClassified : undefined,
+    sizeClassified: __expectNumber(output.sizeClassified),
     status:
       output.status !== undefined && output.status !== null
         ? deserializeAws_restJson1ClassificationResultStatus(output.status, context)
@@ -9045,8 +8992,8 @@ const deserializeAws_restJson1ClassificationResultStatus = (
   context: __SerdeContext
 ): ClassificationResultStatus => {
   return {
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    reason: output.reason !== undefined && output.reason !== null ? output.reason : undefined,
+    code: __expectString(output.code),
+    reason: __expectString(output.reason),
   } as any;
 };
 
@@ -9103,10 +9050,10 @@ const deserializeAws_restJson1CriterionAdditionalProperties = (
       output.eqExactMatch !== undefined && output.eqExactMatch !== null
         ? deserializeAws_restJson1__listOf__string(output.eqExactMatch, context)
         : undefined,
-    gt: output.gt !== undefined && output.gt !== null ? output.gt : undefined,
-    gte: output.gte !== undefined && output.gte !== null ? output.gte : undefined,
-    lt: output.lt !== undefined && output.lt !== null ? output.lt : undefined,
-    lte: output.lte !== undefined && output.lte !== null ? output.lte : undefined,
+    gt: __expectNumber(output.gt),
+    gte: __expectNumber(output.gte),
+    lt: __expectNumber(output.lt),
+    lte: __expectNumber(output.lte),
     neq:
       output.neq !== undefined && output.neq !== null
         ? deserializeAws_restJson1__listOf__string(output.neq, context)
@@ -9120,7 +9067,7 @@ const deserializeAws_restJson1CustomDataIdentifiers = (output: any, context: __S
       output.detections !== undefined && output.detections !== null
         ? deserializeAws_restJson1CustomDetections(output.detections, context)
         : undefined,
-    totalCount: output.totalCount !== undefined && output.totalCount !== null ? output.totalCount : undefined,
+    totalCount: __expectNumber(output.totalCount),
   } as any;
 };
 
@@ -9129,19 +9076,19 @@ const deserializeAws_restJson1CustomDataIdentifierSummary = (
   context: __SerdeContext
 ): CustomDataIdentifierSummary => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt: output.createdAt !== undefined && output.createdAt !== null ? new Date(output.createdAt) : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    description: __expectString(output.description),
+    id: __expectString(output.id),
+    name: __expectString(output.name),
   } as any;
 };
 
 const deserializeAws_restJson1CustomDetection = (output: any, context: __SerdeContext): CustomDetection => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    count: output.count !== undefined && output.count !== null ? output.count : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    arn: __expectString(output.arn),
+    count: __expectNumber(output.count),
+    name: __expectString(output.name),
     occurrences:
       output.occurrences !== undefined && output.occurrences !== null
         ? deserializeAws_restJson1Occurrences(output.occurrences, context)
@@ -9166,12 +9113,12 @@ const deserializeAws_restJson1DailySchedule = (output: any, context: __SerdeCont
 
 const deserializeAws_restJson1DefaultDetection = (output: any, context: __SerdeContext): DefaultDetection => {
   return {
-    count: output.count !== undefined && output.count !== null ? output.count : undefined,
+    count: __expectNumber(output.count),
     occurrences:
       output.occurrences !== undefined && output.occurrences !== null
         ? deserializeAws_restJson1Occurrences(output.occurrences, context)
         : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -9188,16 +9135,16 @@ const deserializeAws_restJson1DefaultDetections = (output: any, context: __Serde
 
 const deserializeAws_restJson1DomainDetails = (output: any, context: __SerdeContext): DomainDetails => {
   return {
-    domainName: output.domainName !== undefined && output.domainName !== null ? output.domainName : undefined,
+    domainName: __expectString(output.domainName),
   } as any;
 };
 
 const deserializeAws_restJson1FederatedUser = (output: any, context: __SerdeContext): FederatedUser => {
   return {
-    accessKeyId: output.accessKeyId !== undefined && output.accessKeyId !== null ? output.accessKeyId : undefined,
-    accountId: output.accountId !== undefined && output.accountId !== null ? output.accountId : undefined,
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    principalId: output.principalId !== undefined && output.principalId !== null ? output.principalId : undefined,
+    accessKeyId: __expectString(output.accessKeyId),
+    accountId: __expectString(output.accountId),
+    arn: __expectString(output.arn),
+    principalId: __expectString(output.principalId),
     sessionContext:
       output.sessionContext !== undefined && output.sessionContext !== null
         ? deserializeAws_restJson1SessionContext(output.sessionContext, context)
@@ -9207,43 +9154,42 @@ const deserializeAws_restJson1FederatedUser = (output: any, context: __SerdeCont
 
 const deserializeAws_restJson1Finding = (output: any, context: __SerdeContext): Finding => {
   return {
-    accountId: output.accountId !== undefined && output.accountId !== null ? output.accountId : undefined,
-    archived: output.archived !== undefined && output.archived !== null ? output.archived : undefined,
-    category: output.category !== undefined && output.category !== null ? output.category : undefined,
+    accountId: __expectString(output.accountId),
+    archived: __expectBoolean(output.archived),
+    category: __expectString(output.category),
     classificationDetails:
       output.classificationDetails !== undefined && output.classificationDetails !== null
         ? deserializeAws_restJson1ClassificationDetails(output.classificationDetails, context)
         : undefined,
-    count: output.count !== undefined && output.count !== null ? output.count : undefined,
+    count: __expectNumber(output.count),
     createdAt: output.createdAt !== undefined && output.createdAt !== null ? new Date(output.createdAt) : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    partition: output.partition !== undefined && output.partition !== null ? output.partition : undefined,
+    description: __expectString(output.description),
+    id: __expectString(output.id),
+    partition: __expectString(output.partition),
     policyDetails:
       output.policyDetails !== undefined && output.policyDetails !== null
         ? deserializeAws_restJson1PolicyDetails(output.policyDetails, context)
         : undefined,
-    region: output.region !== undefined && output.region !== null ? output.region : undefined,
+    region: __expectString(output.region),
     resourcesAffected:
       output.resourcesAffected !== undefined && output.resourcesAffected !== null
         ? deserializeAws_restJson1ResourcesAffected(output.resourcesAffected, context)
         : undefined,
-    sample: output.sample !== undefined && output.sample !== null ? output.sample : undefined,
-    schemaVersion:
-      output.schemaVersion !== undefined && output.schemaVersion !== null ? output.schemaVersion : undefined,
+    sample: __expectBoolean(output.sample),
+    schemaVersion: __expectString(output.schemaVersion),
     severity:
       output.severity !== undefined && output.severity !== null
         ? deserializeAws_restJson1Severity(output.severity, context)
         : undefined,
-    title: output.title !== undefined && output.title !== null ? output.title : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    title: __expectString(output.title),
+    type: __expectString(output.type),
     updatedAt: output.updatedAt !== undefined && output.updatedAt !== null ? new Date(output.updatedAt) : undefined,
   } as any;
 };
 
 const deserializeAws_restJson1FindingAction = (output: any, context: __SerdeContext): FindingAction => {
   return {
-    actionType: output.actionType !== undefined && output.actionType !== null ? output.actionType : undefined,
+    actionType: __expectString(output.actionType),
     apiCallDetails:
       output.apiCallDetails !== undefined && output.apiCallDetails !== null
         ? deserializeAws_restJson1ApiCallDetails(output.apiCallDetails, context)
@@ -9282,10 +9228,10 @@ const deserializeAws_restJson1FindingsFilterListItem = (
   context: __SerdeContext
 ): FindingsFilterListItem => {
   return {
-    action: output.action !== undefined && output.action !== null ? output.action : undefined,
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    action: __expectString(output.action),
+    arn: __expectString(output.arn),
+    id: __expectString(output.id),
+    name: __expectString(output.name),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1TagMap(output.tags, context)
@@ -9295,35 +9241,32 @@ const deserializeAws_restJson1FindingsFilterListItem = (
 
 const deserializeAws_restJson1GroupCount = (output: any, context: __SerdeContext): GroupCount => {
   return {
-    count: output.count !== undefined && output.count !== null ? output.count : undefined,
-    groupKey: output.groupKey !== undefined && output.groupKey !== null ? output.groupKey : undefined,
+    count: __expectNumber(output.count),
+    groupKey: __expectString(output.groupKey),
   } as any;
 };
 
 const deserializeAws_restJson1IamUser = (output: any, context: __SerdeContext): IamUser => {
   return {
-    accountId: output.accountId !== undefined && output.accountId !== null ? output.accountId : undefined,
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    principalId: output.principalId !== undefined && output.principalId !== null ? output.principalId : undefined,
-    userName: output.userName !== undefined && output.userName !== null ? output.userName : undefined,
+    accountId: __expectString(output.accountId),
+    arn: __expectString(output.arn),
+    principalId: __expectString(output.principalId),
+    userName: __expectString(output.userName),
   } as any;
 };
 
 const deserializeAws_restJson1Invitation = (output: any, context: __SerdeContext): Invitation => {
   return {
-    accountId: output.accountId !== undefined && output.accountId !== null ? output.accountId : undefined,
-    invitationId: output.invitationId !== undefined && output.invitationId !== null ? output.invitationId : undefined,
+    accountId: __expectString(output.accountId),
+    invitationId: __expectString(output.invitationId),
     invitedAt: output.invitedAt !== undefined && output.invitedAt !== null ? new Date(output.invitedAt) : undefined,
-    relationshipStatus:
-      output.relationshipStatus !== undefined && output.relationshipStatus !== null
-        ? output.relationshipStatus
-        : undefined,
+    relationshipStatus: __expectString(output.relationshipStatus),
   } as any;
 };
 
 const deserializeAws_restJson1IpAddressDetails = (output: any, context: __SerdeContext): IpAddressDetails => {
   return {
-    ipAddressV4: output.ipAddressV4 !== undefined && output.ipAddressV4 !== null ? output.ipAddressV4 : undefined,
+    ipAddressV4: __expectString(output.ipAddressV4),
     ipCity:
       output.ipCity !== undefined && output.ipCity !== null
         ? deserializeAws_restJson1IpCity(output.ipCity, context)
@@ -9345,40 +9288,38 @@ const deserializeAws_restJson1IpAddressDetails = (output: any, context: __SerdeC
 
 const deserializeAws_restJson1IpCity = (output: any, context: __SerdeContext): IpCity => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
   } as any;
 };
 
 const deserializeAws_restJson1IpCountry = (output: any, context: __SerdeContext): IpCountry => {
   return {
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    code: __expectString(output.code),
+    name: __expectString(output.name),
   } as any;
 };
 
 const deserializeAws_restJson1IpGeoLocation = (output: any, context: __SerdeContext): IpGeoLocation => {
   return {
-    lat: output.lat !== undefined && output.lat !== null ? output.lat : undefined,
-    lon: output.lon !== undefined && output.lon !== null ? output.lon : undefined,
+    lat: __expectNumber(output.lat),
+    lon: __expectNumber(output.lon),
   } as any;
 };
 
 const deserializeAws_restJson1IpOwner = (output: any, context: __SerdeContext): IpOwner => {
   return {
-    asn: output.asn !== undefined && output.asn !== null ? output.asn : undefined,
-    asnOrg: output.asnOrg !== undefined && output.asnOrg !== null ? output.asnOrg : undefined,
-    isp: output.isp !== undefined && output.isp !== null ? output.isp : undefined,
-    org: output.org !== undefined && output.org !== null ? output.org : undefined,
+    asn: __expectString(output.asn),
+    asnOrg: __expectString(output.asnOrg),
+    isp: __expectString(output.isp),
+    org: __expectString(output.org),
   } as any;
 };
 
 const deserializeAws_restJson1JobDetails = (output: any, context: __SerdeContext): JobDetails => {
   return {
-    isDefinedInJob:
-      output.isDefinedInJob !== undefined && output.isDefinedInJob !== null ? output.isDefinedInJob : undefined,
-    isMonitoredByJob:
-      output.isMonitoredByJob !== undefined && output.isMonitoredByJob !== null ? output.isMonitoredByJob : undefined,
-    lastJobId: output.lastJobId !== undefined && output.lastJobId !== null ? output.lastJobId : undefined,
+    isDefinedInJob: __expectString(output.isDefinedInJob),
+    isMonitoredByJob: __expectString(output.isMonitoredByJob),
+    lastJobId: __expectString(output.lastJobId),
     lastJobRunTime:
       output.lastJobRunTime !== undefined && output.lastJobRunTime !== null
         ? new Date(output.lastJobRunTime)
@@ -9436,14 +9377,14 @@ const deserializeAws_restJson1JobSummary = (output: any, context: __SerdeContext
         ? deserializeAws_restJson1__listOfS3BucketDefinitionForJob(output.bucketDefinitions, context)
         : undefined,
     createdAt: output.createdAt !== undefined && output.createdAt !== null ? new Date(output.createdAt) : undefined,
-    jobId: output.jobId !== undefined && output.jobId !== null ? output.jobId : undefined,
-    jobStatus: output.jobStatus !== undefined && output.jobStatus !== null ? output.jobStatus : undefined,
-    jobType: output.jobType !== undefined && output.jobType !== null ? output.jobType : undefined,
+    jobId: __expectString(output.jobId),
+    jobStatus: __expectString(output.jobStatus),
+    jobType: __expectString(output.jobType),
     lastRunErrorStatus:
       output.lastRunErrorStatus !== undefined && output.lastRunErrorStatus !== null
         ? deserializeAws_restJson1LastRunErrorStatus(output.lastRunErrorStatus, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
     userPausedDetails:
       output.userPausedDetails !== undefined && output.userPausedDetails !== null
         ? deserializeAws_restJson1UserPausedDetails(output.userPausedDetails, context)
@@ -9453,8 +9394,8 @@ const deserializeAws_restJson1JobSummary = (output: any, context: __SerdeContext
 
 const deserializeAws_restJson1KeyValuePair = (output: any, context: __SerdeContext): KeyValuePair => {
   return {
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    key: __expectString(output.key),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -9471,36 +9412,27 @@ const deserializeAws_restJson1KeyValuePairList = (output: any, context: __SerdeC
 
 const deserializeAws_restJson1LastRunErrorStatus = (output: any, context: __SerdeContext): LastRunErrorStatus => {
   return {
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
+    code: __expectString(output.code),
   } as any;
 };
 
 const deserializeAws_restJson1MatchingBucket = (output: any, context: __SerdeContext): MatchingBucket => {
   return {
-    accountId: output.accountId !== undefined && output.accountId !== null ? output.accountId : undefined,
-    bucketName: output.bucketName !== undefined && output.bucketName !== null ? output.bucketName : undefined,
-    classifiableObjectCount:
-      output.classifiableObjectCount !== undefined && output.classifiableObjectCount !== null
-        ? output.classifiableObjectCount
-        : undefined,
-    classifiableSizeInBytes:
-      output.classifiableSizeInBytes !== undefined && output.classifiableSizeInBytes !== null
-        ? output.classifiableSizeInBytes
-        : undefined,
+    accountId: __expectString(output.accountId),
+    bucketName: __expectString(output.bucketName),
+    classifiableObjectCount: __expectNumber(output.classifiableObjectCount),
+    classifiableSizeInBytes: __expectNumber(output.classifiableSizeInBytes),
     jobDetails:
       output.jobDetails !== undefined && output.jobDetails !== null
         ? deserializeAws_restJson1JobDetails(output.jobDetails, context)
         : undefined,
-    objectCount: output.objectCount !== undefined && output.objectCount !== null ? output.objectCount : undefined,
+    objectCount: __expectNumber(output.objectCount),
     objectCountByEncryptionType:
       output.objectCountByEncryptionType !== undefined && output.objectCountByEncryptionType !== null
         ? deserializeAws_restJson1ObjectCountByEncryptionType(output.objectCountByEncryptionType, context)
         : undefined,
-    sizeInBytes: output.sizeInBytes !== undefined && output.sizeInBytes !== null ? output.sizeInBytes : undefined,
-    sizeInBytesCompressed:
-      output.sizeInBytesCompressed !== undefined && output.sizeInBytesCompressed !== null
-        ? output.sizeInBytesCompressed
-        : undefined,
+    sizeInBytes: __expectNumber(output.sizeInBytes),
+    sizeInBytesCompressed: __expectNumber(output.sizeInBytesCompressed),
     unclassifiableObjectCount:
       output.unclassifiableObjectCount !== undefined && output.unclassifiableObjectCount !== null
         ? deserializeAws_restJson1ObjectLevelStatistics(output.unclassifiableObjectCount, context)
@@ -9523,20 +9455,13 @@ const deserializeAws_restJson1MatchingResource = (output: any, context: __SerdeC
 
 const deserializeAws_restJson1Member = (output: any, context: __SerdeContext): Member => {
   return {
-    accountId: output.accountId !== undefined && output.accountId !== null ? output.accountId : undefined,
-    administratorAccountId:
-      output.administratorAccountId !== undefined && output.administratorAccountId !== null
-        ? output.administratorAccountId
-        : undefined,
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    email: output.email !== undefined && output.email !== null ? output.email : undefined,
+    accountId: __expectString(output.accountId),
+    administratorAccountId: __expectString(output.administratorAccountId),
+    arn: __expectString(output.arn),
+    email: __expectString(output.email),
     invitedAt: output.invitedAt !== undefined && output.invitedAt !== null ? new Date(output.invitedAt) : undefined,
-    masterAccountId:
-      output.masterAccountId !== undefined && output.masterAccountId !== null ? output.masterAccountId : undefined,
-    relationshipStatus:
-      output.relationshipStatus !== undefined && output.relationshipStatus !== null
-        ? output.relationshipStatus
-        : undefined,
+    masterAccountId: __expectString(output.masterAccountId),
+    relationshipStatus: __expectString(output.relationshipStatus),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1TagMap(output.tags, context)
@@ -9547,7 +9472,7 @@ const deserializeAws_restJson1Member = (output: any, context: __SerdeContext): M
 
 const deserializeAws_restJson1MonthlySchedule = (output: any, context: __SerdeContext): MonthlySchedule => {
   return {
-    dayOfMonth: output.dayOfMonth !== undefined && output.dayOfMonth !== null ? output.dayOfMonth : undefined,
+    dayOfMonth: __expectNumber(output.dayOfMonth),
   } as any;
 };
 
@@ -9556,20 +9481,19 @@ const deserializeAws_restJson1ObjectCountByEncryptionType = (
   context: __SerdeContext
 ): ObjectCountByEncryptionType => {
   return {
-    customerManaged:
-      output.customerManaged !== undefined && output.customerManaged !== null ? output.customerManaged : undefined,
-    kmsManaged: output.kmsManaged !== undefined && output.kmsManaged !== null ? output.kmsManaged : undefined,
-    s3Managed: output.s3Managed !== undefined && output.s3Managed !== null ? output.s3Managed : undefined,
-    unencrypted: output.unencrypted !== undefined && output.unencrypted !== null ? output.unencrypted : undefined,
-    unknown: output.unknown !== undefined && output.unknown !== null ? output.unknown : undefined,
+    customerManaged: __expectNumber(output.customerManaged),
+    kmsManaged: __expectNumber(output.kmsManaged),
+    s3Managed: __expectNumber(output.s3Managed),
+    unencrypted: __expectNumber(output.unencrypted),
+    unknown: __expectNumber(output.unknown),
   } as any;
 };
 
 const deserializeAws_restJson1ObjectLevelStatistics = (output: any, context: __SerdeContext): ObjectLevelStatistics => {
   return {
-    fileType: output.fileType !== undefined && output.fileType !== null ? output.fileType : undefined,
-    storageClass: output.storageClass !== undefined && output.storageClass !== null ? output.storageClass : undefined,
-    total: output.total !== undefined && output.total !== null ? output.total : undefined,
+    fileType: __expectNumber(output.fileType),
+    storageClass: __expectNumber(output.storageClass),
+    total: __expectNumber(output.total),
   } as any;
 };
 
@@ -9608,7 +9532,7 @@ const deserializeAws_restJson1Page = (output: any, context: __SerdeContext): Pag
       output.offsetRange !== undefined && output.offsetRange !== null
         ? deserializeAws_restJson1Range(output.offsetRange, context)
         : undefined,
-    pageNumber: output.pageNumber !== undefined && output.pageNumber !== null ? output.pageNumber : undefined,
+    pageNumber: __expectNumber(output.pageNumber),
   } as any;
 };
 
@@ -9638,9 +9562,9 @@ const deserializeAws_restJson1PolicyDetails = (output: any, context: __SerdeCont
 
 const deserializeAws_restJson1Range = (output: any, context: __SerdeContext): Range => {
   return {
-    end: output.end !== undefined && output.end !== null ? output.end : undefined,
-    start: output.start !== undefined && output.start !== null ? output.start : undefined,
-    startColumn: output.startColumn !== undefined && output.startColumn !== null ? output.startColumn : undefined,
+    end: __expectNumber(output.end),
+    start: __expectNumber(output.start),
+    startColumn: __expectNumber(output.startColumn),
   } as any;
 };
 
@@ -9657,8 +9581,8 @@ const deserializeAws_restJson1Ranges = (output: any, context: __SerdeContext): R
 
 const deserializeAws_restJson1_Record = (output: any, context: __SerdeContext): _Record => {
   return {
-    jsonPath: output.jsonPath !== undefined && output.jsonPath !== null ? output.jsonPath : undefined,
-    recordIndex: output.recordIndex !== undefined && output.recordIndex !== null ? output.recordIndex : undefined,
+    jsonPath: __expectString(output.jsonPath),
+    recordIndex: __expectNumber(output.recordIndex),
   } as any;
 };
 
@@ -9675,11 +9599,8 @@ const deserializeAws_restJson1Records = (output: any, context: __SerdeContext): 
 
 const deserializeAws_restJson1ReplicationDetails = (output: any, context: __SerdeContext): ReplicationDetails => {
   return {
-    replicated: output.replicated !== undefined && output.replicated !== null ? output.replicated : undefined,
-    replicatedExternally:
-      output.replicatedExternally !== undefined && output.replicatedExternally !== null
-        ? output.replicatedExternally
-        : undefined,
+    replicated: __expectBoolean(output.replicated),
+    replicatedExternally: __expectBoolean(output.replicatedExternally),
     replicationAccounts:
       output.replicationAccounts !== undefined && output.replicationAccounts !== null
         ? deserializeAws_restJson1__listOf__string(output.replicationAccounts, context)
@@ -9702,17 +9623,14 @@ const deserializeAws_restJson1ResourcesAffected = (output: any, context: __Serde
 
 const deserializeAws_restJson1S3Bucket = (output: any, context: __SerdeContext): S3Bucket => {
   return {
-    allowsUnencryptedObjectUploads:
-      output.allowsUnencryptedObjectUploads !== undefined && output.allowsUnencryptedObjectUploads !== null
-        ? output.allowsUnencryptedObjectUploads
-        : undefined,
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    allowsUnencryptedObjectUploads: __expectString(output.allowsUnencryptedObjectUploads),
+    arn: __expectString(output.arn),
     createdAt: output.createdAt !== undefined && output.createdAt !== null ? new Date(output.createdAt) : undefined,
     defaultServerSideEncryption:
       output.defaultServerSideEncryption !== undefined && output.defaultServerSideEncryption !== null
         ? deserializeAws_restJson1ServerSideEncryption(output.defaultServerSideEncryption, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
     owner:
       output.owner !== undefined && output.owner !== null
         ? deserializeAws_restJson1S3BucketOwner(output.owner, context)
@@ -9749,7 +9667,7 @@ const deserializeAws_restJson1S3BucketDefinitionForJob = (
   context: __SerdeContext
 ): S3BucketDefinitionForJob => {
   return {
-    accountId: output.accountId !== undefined && output.accountId !== null ? output.accountId : undefined,
+    accountId: __expectString(output.accountId),
     buckets:
       output.buckets !== undefined && output.buckets !== null
         ? deserializeAws_restJson1__listOf__string(output.buckets, context)
@@ -9759,16 +9677,16 @@ const deserializeAws_restJson1S3BucketDefinitionForJob = (
 
 const deserializeAws_restJson1S3BucketOwner = (output: any, context: __SerdeContext): S3BucketOwner => {
   return {
-    displayName: output.displayName !== undefined && output.displayName !== null ? output.displayName : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    displayName: __expectString(output.displayName),
+    id: __expectString(output.id),
   } as any;
 };
 
 const deserializeAws_restJson1S3Destination = (output: any, context: __SerdeContext): S3Destination => {
   return {
-    bucketName: output.bucketName !== undefined && output.bucketName !== null ? output.bucketName : undefined,
-    keyPrefix: output.keyPrefix !== undefined && output.keyPrefix !== null ? output.keyPrefix : undefined,
-    kmsKeyArn: output.kmsKeyArn !== undefined && output.kmsKeyArn !== null ? output.kmsKeyArn : undefined,
+    bucketName: __expectString(output.bucketName),
+    keyPrefix: __expectString(output.keyPrefix),
+    kmsKeyArn: __expectString(output.kmsKeyArn),
   } as any;
 };
 
@@ -9791,25 +9709,25 @@ const deserializeAws_restJson1S3JobDefinition = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1S3Object = (output: any, context: __SerdeContext): S3Object => {
   return {
-    bucketArn: output.bucketArn !== undefined && output.bucketArn !== null ? output.bucketArn : undefined,
-    eTag: output.eTag !== undefined && output.eTag !== null ? output.eTag : undefined,
-    extension: output.extension !== undefined && output.extension !== null ? output.extension : undefined,
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
+    bucketArn: __expectString(output.bucketArn),
+    eTag: __expectString(output.eTag),
+    extension: __expectString(output.extension),
+    key: __expectString(output.key),
     lastModified:
       output.lastModified !== undefined && output.lastModified !== null ? new Date(output.lastModified) : undefined,
-    path: output.path !== undefined && output.path !== null ? output.path : undefined,
-    publicAccess: output.publicAccess !== undefined && output.publicAccess !== null ? output.publicAccess : undefined,
+    path: __expectString(output.path),
+    publicAccess: __expectBoolean(output.publicAccess),
     serverSideEncryption:
       output.serverSideEncryption !== undefined && output.serverSideEncryption !== null
         ? deserializeAws_restJson1ServerSideEncryption(output.serverSideEncryption, context)
         : undefined,
-    size: output.size !== undefined && output.size !== null ? output.size : undefined,
-    storageClass: output.storageClass !== undefined && output.storageClass !== null ? output.storageClass : undefined,
+    size: __expectNumber(output.size),
+    storageClass: __expectString(output.storageClass),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1KeyValuePairList(output.tags, context)
         : undefined,
-    versionId: output.versionId !== undefined && output.versionId !== null ? output.versionId : undefined,
+    versionId: __expectString(output.versionId),
   } as any;
 };
 
@@ -9831,14 +9749,8 @@ const deserializeAws_restJson1SecurityHubConfiguration = (
   context: __SerdeContext
 ): SecurityHubConfiguration => {
   return {
-    publishClassificationFindings:
-      output.publishClassificationFindings !== undefined && output.publishClassificationFindings !== null
-        ? output.publishClassificationFindings
-        : undefined,
-    publishPolicyFindings:
-      output.publishPolicyFindings !== undefined && output.publishPolicyFindings !== null
-        ? output.publishPolicyFindings
-        : undefined,
+    publishClassificationFindings: __expectBoolean(output.publishClassificationFindings),
+    publishPolicyFindings: __expectBoolean(output.publishPolicyFindings),
   } as any;
 };
 
@@ -9855,30 +9767,27 @@ const deserializeAws_restJson1SensitiveData = (output: any, context: __SerdeCont
 
 const deserializeAws_restJson1SensitiveDataItem = (output: any, context: __SerdeContext): SensitiveDataItem => {
   return {
-    category: output.category !== undefined && output.category !== null ? output.category : undefined,
+    category: __expectString(output.category),
     detections:
       output.detections !== undefined && output.detections !== null
         ? deserializeAws_restJson1DefaultDetections(output.detections, context)
         : undefined,
-    totalCount: output.totalCount !== undefined && output.totalCount !== null ? output.totalCount : undefined,
+    totalCount: __expectNumber(output.totalCount),
   } as any;
 };
 
 const deserializeAws_restJson1ServerSideEncryption = (output: any, context: __SerdeContext): ServerSideEncryption => {
   return {
-    encryptionType:
-      output.encryptionType !== undefined && output.encryptionType !== null ? output.encryptionType : undefined,
-    kmsMasterKeyId:
-      output.kmsMasterKeyId !== undefined && output.kmsMasterKeyId !== null ? output.kmsMasterKeyId : undefined,
+    encryptionType: __expectString(output.encryptionType),
+    kmsMasterKeyId: __expectString(output.kmsMasterKeyId),
   } as any;
 };
 
 const deserializeAws_restJson1ServiceLimit = (output: any, context: __SerdeContext): ServiceLimit => {
   return {
-    isServiceLimited:
-      output.isServiceLimited !== undefined && output.isServiceLimited !== null ? output.isServiceLimited : undefined,
-    unit: output.unit !== undefined && output.unit !== null ? output.unit : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    isServiceLimited: __expectBoolean(output.isServiceLimited),
+    unit: __expectString(output.unit),
+    value: __expectNumber(output.value),
   } as any;
 };
 
@@ -9902,32 +9811,31 @@ const deserializeAws_restJson1SessionContextAttributes = (
   return {
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null ? new Date(output.creationDate) : undefined,
-    mfaAuthenticated:
-      output.mfaAuthenticated !== undefined && output.mfaAuthenticated !== null ? output.mfaAuthenticated : undefined,
+    mfaAuthenticated: __expectBoolean(output.mfaAuthenticated),
   } as any;
 };
 
 const deserializeAws_restJson1SessionIssuer = (output: any, context: __SerdeContext): SessionIssuer => {
   return {
-    accountId: output.accountId !== undefined && output.accountId !== null ? output.accountId : undefined,
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    principalId: output.principalId !== undefined && output.principalId !== null ? output.principalId : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
-    userName: output.userName !== undefined && output.userName !== null ? output.userName : undefined,
+    accountId: __expectString(output.accountId),
+    arn: __expectString(output.arn),
+    principalId: __expectString(output.principalId),
+    type: __expectString(output.type),
+    userName: __expectString(output.userName),
   } as any;
 };
 
 const deserializeAws_restJson1Severity = (output: any, context: __SerdeContext): Severity => {
   return {
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    score: output.score !== undefined && output.score !== null ? output.score : undefined,
+    description: __expectString(output.description),
+    score: __expectNumber(output.score),
   } as any;
 };
 
 const deserializeAws_restJson1SimpleCriterionForJob = (output: any, context: __SerdeContext): SimpleCriterionForJob => {
   return {
-    comparator: output.comparator !== undefined && output.comparator !== null ? output.comparator : undefined,
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
+    comparator: __expectString(output.comparator),
+    key: __expectString(output.key),
     values:
       output.values !== undefined && output.values !== null
         ? deserializeAws_restJson1__listOf__string(output.values, context)
@@ -9937,8 +9845,8 @@ const deserializeAws_restJson1SimpleCriterionForJob = (output: any, context: __S
 
 const deserializeAws_restJson1SimpleScopeTerm = (output: any, context: __SerdeContext): SimpleScopeTerm => {
   return {
-    comparator: output.comparator !== undefined && output.comparator !== null ? output.comparator : undefined,
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
+    comparator: __expectString(output.comparator),
+    key: __expectString(output.key),
     values:
       output.values !== undefined && output.values !== null
         ? deserializeAws_restJson1__listOf__string(output.values, context)
@@ -9948,17 +9856,14 @@ const deserializeAws_restJson1SimpleScopeTerm = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1Statistics = (output: any, context: __SerdeContext): Statistics => {
   return {
-    approximateNumberOfObjectsToProcess:
-      output.approximateNumberOfObjectsToProcess !== undefined && output.approximateNumberOfObjectsToProcess !== null
-        ? output.approximateNumberOfObjectsToProcess
-        : undefined,
-    numberOfRuns: output.numberOfRuns !== undefined && output.numberOfRuns !== null ? output.numberOfRuns : undefined,
+    approximateNumberOfObjectsToProcess: __expectNumber(output.approximateNumberOfObjectsToProcess),
+    numberOfRuns: __expectNumber(output.numberOfRuns),
   } as any;
 };
 
 const deserializeAws_restJson1TagCriterionForJob = (output: any, context: __SerdeContext): TagCriterionForJob => {
   return {
-    comparator: output.comparator !== undefined && output.comparator !== null ? output.comparator : undefined,
+    comparator: __expectString(output.comparator),
     tagValues:
       output.tagValues !== undefined && output.tagValues !== null
         ? deserializeAws_restJson1__listOfTagCriterionPairForJob(output.tagValues, context)
@@ -9971,8 +9876,8 @@ const deserializeAws_restJson1TagCriterionPairForJob = (
   context: __SerdeContext
 ): TagCriterionPairForJob => {
   return {
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    key: __expectString(output.key),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -9983,54 +9888,53 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1TagScopeTerm = (output: any, context: __SerdeContext): TagScopeTerm => {
   return {
-    comparator: output.comparator !== undefined && output.comparator !== null ? output.comparator : undefined,
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
+    comparator: __expectString(output.comparator),
+    key: __expectString(output.key),
     tagValues:
       output.tagValues !== undefined && output.tagValues !== null
         ? deserializeAws_restJson1__listOfTagValuePair(output.tagValues, context)
         : undefined,
-    target: output.target !== undefined && output.target !== null ? output.target : undefined,
+    target: __expectString(output.target),
   } as any;
 };
 
 const deserializeAws_restJson1TagValuePair = (output: any, context: __SerdeContext): TagValuePair => {
   return {
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    key: __expectString(output.key),
+    value: __expectString(output.value),
   } as any;
 };
 
 const deserializeAws_restJson1UnprocessedAccount = (output: any, context: __SerdeContext): UnprocessedAccount => {
   return {
-    accountId: output.accountId !== undefined && output.accountId !== null ? output.accountId : undefined,
-    errorCode: output.errorCode !== undefined && output.errorCode !== null ? output.errorCode : undefined,
-    errorMessage: output.errorMessage !== undefined && output.errorMessage !== null ? output.errorMessage : undefined,
+    accountId: __expectString(output.accountId),
+    errorCode: __expectString(output.errorCode),
+    errorMessage: __expectString(output.errorMessage),
   } as any;
 };
 
 const deserializeAws_restJson1UsageByAccount = (output: any, context: __SerdeContext): UsageByAccount => {
   return {
-    currency: output.currency !== undefined && output.currency !== null ? output.currency : undefined,
-    estimatedCost:
-      output.estimatedCost !== undefined && output.estimatedCost !== null ? output.estimatedCost : undefined,
+    currency: __expectString(output.currency),
+    estimatedCost: __expectString(output.estimatedCost),
     serviceLimit:
       output.serviceLimit !== undefined && output.serviceLimit !== null
         ? deserializeAws_restJson1ServiceLimit(output.serviceLimit, context)
         : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    type: __expectString(output.type),
   } as any;
 };
 
 const deserializeAws_restJson1UsageRecord = (output: any, context: __SerdeContext): UsageRecord => {
   return {
-    accountId: output.accountId !== undefined && output.accountId !== null ? output.accountId : undefined,
+    accountId: __expectString(output.accountId),
     freeTrialStartDate:
       output.freeTrialStartDate !== undefined && output.freeTrialStartDate !== null
         ? new Date(output.freeTrialStartDate)
@@ -10044,10 +9948,9 @@ const deserializeAws_restJson1UsageRecord = (output: any, context: __SerdeContex
 
 const deserializeAws_restJson1UsageTotal = (output: any, context: __SerdeContext): UsageTotal => {
   return {
-    currency: output.currency !== undefined && output.currency !== null ? output.currency : undefined,
-    estimatedCost:
-      output.estimatedCost !== undefined && output.estimatedCost !== null ? output.estimatedCost : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    currency: __expectString(output.currency),
+    estimatedCost: __expectString(output.estimatedCost),
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -10077,15 +9980,15 @@ const deserializeAws_restJson1UserIdentity = (output: any, context: __SerdeConte
       output.root !== undefined && output.root !== null
         ? deserializeAws_restJson1UserIdentityRoot(output.root, context)
         : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    type: __expectString(output.type),
   } as any;
 };
 
 const deserializeAws_restJson1UserIdentityRoot = (output: any, context: __SerdeContext): UserIdentityRoot => {
   return {
-    accountId: output.accountId !== undefined && output.accountId !== null ? output.accountId : undefined,
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    principalId: output.principalId !== undefined && output.principalId !== null ? output.principalId : undefined,
+    accountId: __expectString(output.accountId),
+    arn: __expectString(output.arn),
+    principalId: __expectString(output.principalId),
   } as any;
 };
 
@@ -10093,10 +9996,7 @@ const deserializeAws_restJson1UserPausedDetails = (output: any, context: __Serde
   return {
     jobExpiresAt:
       output.jobExpiresAt !== undefined && output.jobExpiresAt !== null ? new Date(output.jobExpiresAt) : undefined,
-    jobImminentExpirationHealthEventArn:
-      output.jobImminentExpirationHealthEventArn !== undefined && output.jobImminentExpirationHealthEventArn !== null
-        ? output.jobImminentExpirationHealthEventArn
-        : undefined,
+    jobImminentExpirationHealthEventArn: __expectString(output.jobImminentExpirationHealthEventArn),
     jobPausedAt:
       output.jobPausedAt !== undefined && output.jobPausedAt !== null ? new Date(output.jobPausedAt) : undefined,
   } as any;
@@ -10104,7 +10004,7 @@ const deserializeAws_restJson1UserPausedDetails = (output: any, context: __Serde
 
 const deserializeAws_restJson1WeeklySchedule = (output: any, context: __SerdeContext): WeeklySchedule => {
   return {
-    dayOfWeek: output.dayOfWeek !== undefined && output.dayOfWeek !== null ? output.dayOfWeek : undefined,
+    dayOfWeek: __expectString(output.dayOfWeek),
   } as any;
 };
 

--- a/clients/client-managedblockchain/protocols/Aws_restJson1.ts
+++ b/clients/client-managedblockchain/protocols/Aws_restJson1.ts
@@ -74,6 +74,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -938,7 +941,7 @@ export const deserializeAws_restJson1CreateMemberCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.MemberId !== undefined && data.MemberId !== null) {
-    contents.MemberId = data.MemberId;
+    contents.MemberId = __expectString(data.MemberId);
   }
   return Promise.resolve(contents);
 };
@@ -1058,10 +1061,10 @@ export const deserializeAws_restJson1CreateNetworkCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.MemberId !== undefined && data.MemberId !== null) {
-    contents.MemberId = data.MemberId;
+    contents.MemberId = __expectString(data.MemberId);
   }
   if (data.NetworkId !== undefined && data.NetworkId !== null) {
-    contents.NetworkId = data.NetworkId;
+    contents.NetworkId = __expectString(data.NetworkId);
   }
   return Promise.resolve(contents);
 };
@@ -1164,7 +1167,7 @@ export const deserializeAws_restJson1CreateNodeCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NodeId !== undefined && data.NodeId !== null) {
-    contents.NodeId = data.NodeId;
+    contents.NodeId = __expectString(data.NodeId);
   }
   return Promise.resolve(contents);
 };
@@ -1283,7 +1286,7 @@ export const deserializeAws_restJson1CreateProposalCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ProposalId !== undefined && data.ProposalId !== null) {
-    contents.ProposalId = data.ProposalId;
+    contents.ProposalId = __expectString(data.ProposalId);
   }
   return Promise.resolve(contents);
 };
@@ -1920,7 +1923,7 @@ export const deserializeAws_restJson1ListInvitationsCommand = async (
     contents.Invitations = deserializeAws_restJson1InvitationList(data.Invitations, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2019,7 +2022,7 @@ export const deserializeAws_restJson1ListMembersCommand = async (
     contents.Members = deserializeAws_restJson1MemberSummaryList(data.Members, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2102,7 +2105,7 @@ export const deserializeAws_restJson1ListNetworksCommand = async (
     contents.Networks = deserializeAws_restJson1NetworkSummaryList(data.Networks, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2182,7 +2185,7 @@ export const deserializeAws_restJson1ListNodesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Nodes !== undefined && data.Nodes !== null) {
     contents.Nodes = deserializeAws_restJson1NodeSummaryList(data.Nodes, context);
@@ -2265,7 +2268,7 @@ export const deserializeAws_restJson1ListProposalsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Proposals !== undefined && data.Proposals !== null) {
     contents.Proposals = deserializeAws_restJson1ProposalSummaryList(data.Proposals, context);
@@ -2356,7 +2359,7 @@ export const deserializeAws_restJson1ListProposalVotesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.ProposalVotes !== undefined && data.ProposalVotes !== null) {
     contents.ProposalVotes = deserializeAws_restJson1ProposalVoteList(data.ProposalVotes, context);
@@ -3022,7 +3025,7 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3039,7 +3042,7 @@ const deserializeAws_restJson1IllegalActionExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3069,7 +3072,7 @@ const deserializeAws_restJson1InvalidRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3086,7 +3089,7 @@ const deserializeAws_restJson1ResourceAlreadyExistsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3103,7 +3106,7 @@ const deserializeAws_restJson1ResourceLimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3121,10 +3124,10 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.ResourceName !== undefined && data.ResourceName !== null) {
-    contents.ResourceName = data.ResourceName;
+    contents.ResourceName = __expectString(data.ResourceName);
   }
   return contents;
 };
@@ -3141,7 +3144,7 @@ const deserializeAws_restJson1ResourceNotReadyExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3172,10 +3175,10 @@ const deserializeAws_restJson1TooManyTagsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.ResourceName !== undefined && data.ResourceName !== null) {
-    contents.ResourceName = data.ResourceName;
+    contents.ResourceName = __expectString(data.ResourceName);
   }
   return contents;
 };
@@ -3405,36 +3408,27 @@ const deserializeAws_restJson1ApprovalThresholdPolicy = (
   context: __SerdeContext
 ): ApprovalThresholdPolicy => {
   return {
-    ProposalDurationInHours:
-      output.ProposalDurationInHours !== undefined && output.ProposalDurationInHours !== null
-        ? output.ProposalDurationInHours
-        : undefined,
-    ThresholdComparator:
-      output.ThresholdComparator !== undefined && output.ThresholdComparator !== null
-        ? output.ThresholdComparator
-        : undefined,
-    ThresholdPercentage:
-      output.ThresholdPercentage !== undefined && output.ThresholdPercentage !== null
-        ? output.ThresholdPercentage
-        : undefined,
+    ProposalDurationInHours: __expectNumber(output.ProposalDurationInHours),
+    ThresholdComparator: __expectString(output.ThresholdComparator),
+    ThresholdPercentage: __expectNumber(output.ThresholdPercentage),
   } as any;
 };
 
 const deserializeAws_restJson1Invitation = (output: any, context: __SerdeContext): Invitation => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null ? new Date(output.CreationDate) : undefined,
     ExpirationDate:
       output.ExpirationDate !== undefined && output.ExpirationDate !== null
         ? new Date(output.ExpirationDate)
         : undefined,
-    InvitationId: output.InvitationId !== undefined && output.InvitationId !== null ? output.InvitationId : undefined,
+    InvitationId: __expectString(output.InvitationId),
     NetworkSummary:
       output.NetworkSummary !== undefined && output.NetworkSummary !== null
         ? deserializeAws_restJson1NetworkSummary(output.NetworkSummary, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -3451,7 +3445,7 @@ const deserializeAws_restJson1InvitationList = (output: any, context: __SerdeCon
 
 const deserializeAws_restJson1InviteAction = (output: any, context: __SerdeContext): InviteAction => {
   return {
-    Principal: output.Principal !== undefined && output.Principal !== null ? output.Principal : undefined,
+    Principal: __expectString(output.Principal),
   } as any;
 };
 
@@ -3468,7 +3462,7 @@ const deserializeAws_restJson1InviteActionList = (output: any, context: __SerdeC
 
 const deserializeAws_restJson1LogConfiguration = (output: any, context: __SerdeContext): LogConfiguration => {
   return {
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
+    Enabled: __expectBoolean(output.Enabled),
   } as any;
 };
 
@@ -3483,23 +3477,23 @@ const deserializeAws_restJson1LogConfigurations = (output: any, context: __Serde
 
 const deserializeAws_restJson1Member = (output: any, context: __SerdeContext): Member => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null ? new Date(output.CreationDate) : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     FrameworkAttributes:
       output.FrameworkAttributes !== undefined && output.FrameworkAttributes !== null
         ? deserializeAws_restJson1MemberFrameworkAttributes(output.FrameworkAttributes, context)
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    KmsKeyArn: output.KmsKeyArn !== undefined && output.KmsKeyArn !== null ? output.KmsKeyArn : undefined,
+    Id: __expectString(output.Id),
+    KmsKeyArn: __expectString(output.KmsKeyArn),
     LogPublishingConfiguration:
       output.LogPublishingConfiguration !== undefined && output.LogPublishingConfiguration !== null
         ? deserializeAws_restJson1MemberLogPublishingConfiguration(output.LogPublishingConfiguration, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    NetworkId: output.NetworkId !== undefined && output.NetworkId !== null ? output.NetworkId : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Name: __expectString(output.Name),
+    NetworkId: __expectString(output.NetworkId),
+    Status: __expectString(output.Status),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_restJson1OutputTagMap(output.Tags, context)
@@ -3512,9 +3506,8 @@ const deserializeAws_restJson1MemberFabricAttributes = (
   context: __SerdeContext
 ): MemberFabricAttributes => {
   return {
-    AdminUsername:
-      output.AdminUsername !== undefined && output.AdminUsername !== null ? output.AdminUsername : undefined,
-    CaEndpoint: output.CaEndpoint !== undefined && output.CaEndpoint !== null ? output.CaEndpoint : undefined,
+    AdminUsername: __expectString(output.AdminUsername),
+    CaEndpoint: __expectString(output.CaEndpoint),
   } as any;
 };
 
@@ -3556,14 +3549,14 @@ const deserializeAws_restJson1MemberLogPublishingConfiguration = (
 
 const deserializeAws_restJson1MemberSummary = (output: any, context: __SerdeContext): MemberSummary => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null ? new Date(output.CreationDate) : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    IsOwned: output.IsOwned !== undefined && output.IsOwned !== null ? output.IsOwned : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Description: __expectString(output.Description),
+    Id: __expectString(output.Id),
+    IsOwned: __expectBoolean(output.IsOwned),
+    Name: __expectString(output.Name),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -3580,20 +3573,19 @@ const deserializeAws_restJson1MemberSummaryList = (output: any, context: __Serde
 
 const deserializeAws_restJson1Network = (output: any, context: __SerdeContext): Network => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null ? new Date(output.CreationDate) : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Framework: output.Framework !== undefined && output.Framework !== null ? output.Framework : undefined,
+    Description: __expectString(output.Description),
+    Framework: __expectString(output.Framework),
     FrameworkAttributes:
       output.FrameworkAttributes !== undefined && output.FrameworkAttributes !== null
         ? deserializeAws_restJson1NetworkFrameworkAttributes(output.FrameworkAttributes, context)
         : undefined,
-    FrameworkVersion:
-      output.FrameworkVersion !== undefined && output.FrameworkVersion !== null ? output.FrameworkVersion : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    FrameworkVersion: __expectString(output.FrameworkVersion),
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
+    Status: __expectString(output.Status),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_restJson1OutputTagMap(output.Tags, context)
@@ -3602,10 +3594,7 @@ const deserializeAws_restJson1Network = (output: any, context: __SerdeContext): 
       output.VotingPolicy !== undefined && output.VotingPolicy !== null
         ? deserializeAws_restJson1VotingPolicy(output.VotingPolicy, context)
         : undefined,
-    VpcEndpointServiceName:
-      output.VpcEndpointServiceName !== undefined && output.VpcEndpointServiceName !== null
-        ? output.VpcEndpointServiceName
-        : undefined,
+    VpcEndpointServiceName: __expectString(output.VpcEndpointServiceName),
   } as any;
 };
 
@@ -3614,7 +3603,7 @@ const deserializeAws_restJson1NetworkEthereumAttributes = (
   context: __SerdeContext
 ): NetworkEthereumAttributes => {
   return {
-    ChainId: output.ChainId !== undefined && output.ChainId !== null ? output.ChainId : undefined,
+    ChainId: __expectString(output.ChainId),
   } as any;
 };
 
@@ -3623,11 +3612,8 @@ const deserializeAws_restJson1NetworkFabricAttributes = (
   context: __SerdeContext
 ): NetworkFabricAttributes => {
   return {
-    Edition: output.Edition !== undefined && output.Edition !== null ? output.Edition : undefined,
-    OrderingServiceEndpoint:
-      output.OrderingServiceEndpoint !== undefined && output.OrderingServiceEndpoint !== null
-        ? output.OrderingServiceEndpoint
-        : undefined,
+    Edition: __expectString(output.Edition),
+    OrderingServiceEndpoint: __expectString(output.OrderingServiceEndpoint),
   } as any;
 };
 
@@ -3649,16 +3635,15 @@ const deserializeAws_restJson1NetworkFrameworkAttributes = (
 
 const deserializeAws_restJson1NetworkSummary = (output: any, context: __SerdeContext): NetworkSummary => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null ? new Date(output.CreationDate) : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Framework: output.Framework !== undefined && output.Framework !== null ? output.Framework : undefined,
-    FrameworkVersion:
-      output.FrameworkVersion !== undefined && output.FrameworkVersion !== null ? output.FrameworkVersion : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Description: __expectString(output.Description),
+    Framework: __expectString(output.Framework),
+    FrameworkVersion: __expectString(output.FrameworkVersion),
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -3675,26 +3660,25 @@ const deserializeAws_restJson1NetworkSummaryList = (output: any, context: __Serd
 
 const deserializeAws_restJson1Node = (output: any, context: __SerdeContext): Node => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    AvailabilityZone:
-      output.AvailabilityZone !== undefined && output.AvailabilityZone !== null ? output.AvailabilityZone : undefined,
+    Arn: __expectString(output.Arn),
+    AvailabilityZone: __expectString(output.AvailabilityZone),
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null ? new Date(output.CreationDate) : undefined,
     FrameworkAttributes:
       output.FrameworkAttributes !== undefined && output.FrameworkAttributes !== null
         ? deserializeAws_restJson1NodeFrameworkAttributes(output.FrameworkAttributes, context)
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    InstanceType: output.InstanceType !== undefined && output.InstanceType !== null ? output.InstanceType : undefined,
-    KmsKeyArn: output.KmsKeyArn !== undefined && output.KmsKeyArn !== null ? output.KmsKeyArn : undefined,
+    Id: __expectString(output.Id),
+    InstanceType: __expectString(output.InstanceType),
+    KmsKeyArn: __expectString(output.KmsKeyArn),
     LogPublishingConfiguration:
       output.LogPublishingConfiguration !== undefined && output.LogPublishingConfiguration !== null
         ? deserializeAws_restJson1NodeLogPublishingConfiguration(output.LogPublishingConfiguration, context)
         : undefined,
-    MemberId: output.MemberId !== undefined && output.MemberId !== null ? output.MemberId : undefined,
-    NetworkId: output.NetworkId !== undefined && output.NetworkId !== null ? output.NetworkId : undefined,
-    StateDB: output.StateDB !== undefined && output.StateDB !== null ? output.StateDB : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    MemberId: __expectString(output.MemberId),
+    NetworkId: __expectString(output.NetworkId),
+    StateDB: __expectString(output.StateDB),
+    Status: __expectString(output.Status),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_restJson1OutputTagMap(output.Tags, context)
@@ -3707,21 +3691,15 @@ const deserializeAws_restJson1NodeEthereumAttributes = (
   context: __SerdeContext
 ): NodeEthereumAttributes => {
   return {
-    HttpEndpoint: output.HttpEndpoint !== undefined && output.HttpEndpoint !== null ? output.HttpEndpoint : undefined,
-    WebSocketEndpoint:
-      output.WebSocketEndpoint !== undefined && output.WebSocketEndpoint !== null
-        ? output.WebSocketEndpoint
-        : undefined,
+    HttpEndpoint: __expectString(output.HttpEndpoint),
+    WebSocketEndpoint: __expectString(output.WebSocketEndpoint),
   } as any;
 };
 
 const deserializeAws_restJson1NodeFabricAttributes = (output: any, context: __SerdeContext): NodeFabricAttributes => {
   return {
-    PeerEndpoint: output.PeerEndpoint !== undefined && output.PeerEndpoint !== null ? output.PeerEndpoint : undefined,
-    PeerEventEndpoint:
-      output.PeerEventEndpoint !== undefined && output.PeerEventEndpoint !== null
-        ? output.PeerEventEndpoint
-        : undefined,
+    PeerEndpoint: __expectString(output.PeerEndpoint),
+    PeerEventEndpoint: __expectString(output.PeerEventEndpoint),
   } as any;
 };
 
@@ -3771,14 +3749,13 @@ const deserializeAws_restJson1NodeLogPublishingConfiguration = (
 
 const deserializeAws_restJson1NodeSummary = (output: any, context: __SerdeContext): NodeSummary => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    AvailabilityZone:
-      output.AvailabilityZone !== undefined && output.AvailabilityZone !== null ? output.AvailabilityZone : undefined,
+    Arn: __expectString(output.Arn),
+    AvailabilityZone: __expectString(output.AvailabilityZone),
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null ? new Date(output.CreationDate) : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    InstanceType: output.InstanceType !== undefined && output.InstanceType !== null ? output.InstanceType : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Id: __expectString(output.Id),
+    InstanceType: __expectString(output.InstanceType),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -3800,7 +3777,7 @@ const deserializeAws_restJson1OutputTagMap = (output: any, context: __SerdeConte
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -3811,35 +3788,26 @@ const deserializeAws_restJson1Proposal = (output: any, context: __SerdeContext):
       output.Actions !== undefined && output.Actions !== null
         ? deserializeAws_restJson1ProposalActions(output.Actions, context)
         : undefined,
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null ? new Date(output.CreationDate) : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     ExpirationDate:
       output.ExpirationDate !== undefined && output.ExpirationDate !== null
         ? new Date(output.ExpirationDate)
         : undefined,
-    NetworkId: output.NetworkId !== undefined && output.NetworkId !== null ? output.NetworkId : undefined,
-    NoVoteCount: output.NoVoteCount !== undefined && output.NoVoteCount !== null ? output.NoVoteCount : undefined,
-    OutstandingVoteCount:
-      output.OutstandingVoteCount !== undefined && output.OutstandingVoteCount !== null
-        ? output.OutstandingVoteCount
-        : undefined,
-    ProposalId: output.ProposalId !== undefined && output.ProposalId !== null ? output.ProposalId : undefined,
-    ProposedByMemberId:
-      output.ProposedByMemberId !== undefined && output.ProposedByMemberId !== null
-        ? output.ProposedByMemberId
-        : undefined,
-    ProposedByMemberName:
-      output.ProposedByMemberName !== undefined && output.ProposedByMemberName !== null
-        ? output.ProposedByMemberName
-        : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    NetworkId: __expectString(output.NetworkId),
+    NoVoteCount: __expectNumber(output.NoVoteCount),
+    OutstandingVoteCount: __expectNumber(output.OutstandingVoteCount),
+    ProposalId: __expectString(output.ProposalId),
+    ProposedByMemberId: __expectString(output.ProposedByMemberId),
+    ProposedByMemberName: __expectString(output.ProposedByMemberName),
+    Status: __expectString(output.Status),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_restJson1OutputTagMap(output.Tags, context)
         : undefined,
-    YesVoteCount: output.YesVoteCount !== undefined && output.YesVoteCount !== null ? output.YesVoteCount : undefined,
+    YesVoteCount: __expectNumber(output.YesVoteCount),
   } as any;
 };
 
@@ -3858,24 +3826,18 @@ const deserializeAws_restJson1ProposalActions = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1ProposalSummary = (output: any, context: __SerdeContext): ProposalSummary => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null ? new Date(output.CreationDate) : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     ExpirationDate:
       output.ExpirationDate !== undefined && output.ExpirationDate !== null
         ? new Date(output.ExpirationDate)
         : undefined,
-    ProposalId: output.ProposalId !== undefined && output.ProposalId !== null ? output.ProposalId : undefined,
-    ProposedByMemberId:
-      output.ProposedByMemberId !== undefined && output.ProposedByMemberId !== null
-        ? output.ProposedByMemberId
-        : undefined,
-    ProposedByMemberName:
-      output.ProposedByMemberName !== undefined && output.ProposedByMemberName !== null
-        ? output.ProposedByMemberName
-        : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    ProposalId: __expectString(output.ProposalId),
+    ProposedByMemberId: __expectString(output.ProposedByMemberId),
+    ProposedByMemberName: __expectString(output.ProposedByMemberName),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -3903,7 +3865,7 @@ const deserializeAws_restJson1ProposalVoteList = (output: any, context: __SerdeC
 
 const deserializeAws_restJson1RemoveAction = (output: any, context: __SerdeContext): RemoveAction => {
   return {
-    MemberId: output.MemberId !== undefined && output.MemberId !== null ? output.MemberId : undefined,
+    MemberId: __expectString(output.MemberId),
   } as any;
 };
 
@@ -3920,9 +3882,9 @@ const deserializeAws_restJson1RemoveActionList = (output: any, context: __SerdeC
 
 const deserializeAws_restJson1VoteSummary = (output: any, context: __SerdeContext): VoteSummary => {
   return {
-    MemberId: output.MemberId !== undefined && output.MemberId !== null ? output.MemberId : undefined,
-    MemberName: output.MemberName !== undefined && output.MemberName !== null ? output.MemberName : undefined,
-    Vote: output.Vote !== undefined && output.Vote !== null ? output.Vote : undefined,
+    MemberId: __expectString(output.MemberId),
+    MemberName: __expectString(output.MemberName),
+    Vote: __expectString(output.Vote),
   } as any;
 };
 

--- a/clients/client-marketplace-catalog/protocols/Aws_restJson1.ts
+++ b/clients/client-marketplace-catalog/protocols/Aws_restJson1.ts
@@ -25,6 +25,7 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -208,10 +209,10 @@ export const deserializeAws_restJson1CancelChangeSetCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ChangeSetArn !== undefined && data.ChangeSetArn !== null) {
-    contents.ChangeSetArn = data.ChangeSetArn;
+    contents.ChangeSetArn = __expectString(data.ChangeSetArn);
   }
   if (data.ChangeSetId !== undefined && data.ChangeSetId !== null) {
-    contents.ChangeSetId = data.ChangeSetId;
+    contents.ChangeSetId = __expectString(data.ChangeSetId);
   }
   return Promise.resolve(contents);
 };
@@ -317,28 +318,28 @@ export const deserializeAws_restJson1DescribeChangeSetCommand = async (
     contents.ChangeSet = deserializeAws_restJson1ChangeSetDescription(data.ChangeSet, context);
   }
   if (data.ChangeSetArn !== undefined && data.ChangeSetArn !== null) {
-    contents.ChangeSetArn = data.ChangeSetArn;
+    contents.ChangeSetArn = __expectString(data.ChangeSetArn);
   }
   if (data.ChangeSetId !== undefined && data.ChangeSetId !== null) {
-    contents.ChangeSetId = data.ChangeSetId;
+    contents.ChangeSetId = __expectString(data.ChangeSetId);
   }
   if (data.ChangeSetName !== undefined && data.ChangeSetName !== null) {
-    contents.ChangeSetName = data.ChangeSetName;
+    contents.ChangeSetName = __expectString(data.ChangeSetName);
   }
   if (data.EndTime !== undefined && data.EndTime !== null) {
-    contents.EndTime = data.EndTime;
+    contents.EndTime = __expectString(data.EndTime);
   }
   if (data.FailureCode !== undefined && data.FailureCode !== null) {
-    contents.FailureCode = data.FailureCode;
+    contents.FailureCode = __expectString(data.FailureCode);
   }
   if (data.FailureDescription !== undefined && data.FailureDescription !== null) {
-    contents.FailureDescription = data.FailureDescription;
+    contents.FailureDescription = __expectString(data.FailureDescription);
   }
   if (data.StartTime !== undefined && data.StartTime !== null) {
-    contents.StartTime = data.StartTime;
+    contents.StartTime = __expectString(data.StartTime);
   }
   if (data.Status !== undefined && data.Status !== null) {
-    contents.Status = data.Status;
+    contents.Status = __expectString(data.Status);
   }
   return Promise.resolve(contents);
 };
@@ -429,19 +430,19 @@ export const deserializeAws_restJson1DescribeEntityCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Details !== undefined && data.Details !== null) {
-    contents.Details = data.Details;
+    contents.Details = __expectString(data.Details);
   }
   if (data.EntityArn !== undefined && data.EntityArn !== null) {
-    contents.EntityArn = data.EntityArn;
+    contents.EntityArn = __expectString(data.EntityArn);
   }
   if (data.EntityIdentifier !== undefined && data.EntityIdentifier !== null) {
-    contents.EntityIdentifier = data.EntityIdentifier;
+    contents.EntityIdentifier = __expectString(data.EntityIdentifier);
   }
   if (data.EntityType !== undefined && data.EntityType !== null) {
-    contents.EntityType = data.EntityType;
+    contents.EntityType = __expectString(data.EntityType);
   }
   if (data.LastModifiedDate !== undefined && data.LastModifiedDate !== null) {
-    contents.LastModifiedDate = data.LastModifiedDate;
+    contents.LastModifiedDate = __expectString(data.LastModifiedDate);
   }
   return Promise.resolve(contents);
 };
@@ -540,7 +541,7 @@ export const deserializeAws_restJson1ListChangeSetsCommand = async (
     contents.ChangeSetSummaryList = deserializeAws_restJson1ChangeSetSummaryList(data.ChangeSetSummaryList, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -623,7 +624,7 @@ export const deserializeAws_restJson1ListEntitiesCommand = async (
     contents.EntitySummaryList = deserializeAws_restJson1EntitySummaryList(data.EntitySummaryList, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -711,10 +712,10 @@ export const deserializeAws_restJson1StartChangeSetCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ChangeSetArn !== undefined && data.ChangeSetArn !== null) {
-    contents.ChangeSetArn = data.ChangeSetArn;
+    contents.ChangeSetArn = __expectString(data.ChangeSetArn);
   }
   if (data.ChangeSetId !== undefined && data.ChangeSetId !== null) {
-    contents.ChangeSetId = data.ChangeSetId;
+    contents.ChangeSetId = __expectString(data.ChangeSetId);
   }
   return Promise.resolve(contents);
 };
@@ -816,7 +817,7 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -833,7 +834,7 @@ const deserializeAws_restJson1InternalServiceExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -850,7 +851,7 @@ const deserializeAws_restJson1ResourceInUseExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -867,7 +868,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -884,7 +885,7 @@ const deserializeAws_restJson1ResourceNotSupportedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -901,7 +902,7 @@ const deserializeAws_restJson1ServiceQuotaExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -918,7 +919,7 @@ const deserializeAws_restJson1ThrottlingExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -935,7 +936,7 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1035,26 +1036,25 @@ const deserializeAws_restJson1ChangeSetSummaryListItem = (
   context: __SerdeContext
 ): ChangeSetSummaryListItem => {
   return {
-    ChangeSetArn: output.ChangeSetArn !== undefined && output.ChangeSetArn !== null ? output.ChangeSetArn : undefined,
-    ChangeSetId: output.ChangeSetId !== undefined && output.ChangeSetId !== null ? output.ChangeSetId : undefined,
-    ChangeSetName:
-      output.ChangeSetName !== undefined && output.ChangeSetName !== null ? output.ChangeSetName : undefined,
-    EndTime: output.EndTime !== undefined && output.EndTime !== null ? output.EndTime : undefined,
+    ChangeSetArn: __expectString(output.ChangeSetArn),
+    ChangeSetId: __expectString(output.ChangeSetId),
+    ChangeSetName: __expectString(output.ChangeSetName),
+    EndTime: __expectString(output.EndTime),
     EntityIdList:
       output.EntityIdList !== undefined && output.EntityIdList !== null
         ? deserializeAws_restJson1ResourceIdList(output.EntityIdList, context)
         : undefined,
-    FailureCode: output.FailureCode !== undefined && output.FailureCode !== null ? output.FailureCode : undefined,
-    StartTime: output.StartTime !== undefined && output.StartTime !== null ? output.StartTime : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    FailureCode: __expectString(output.FailureCode),
+    StartTime: __expectString(output.StartTime),
+    Status: __expectString(output.Status),
   } as any;
 };
 
 const deserializeAws_restJson1ChangeSummary = (output: any, context: __SerdeContext): ChangeSummary => {
   return {
-    ChangeName: output.ChangeName !== undefined && output.ChangeName !== null ? output.ChangeName : undefined,
-    ChangeType: output.ChangeType !== undefined && output.ChangeType !== null ? output.ChangeType : undefined,
-    Details: output.Details !== undefined && output.Details !== null ? output.Details : undefined,
+    ChangeName: __expectString(output.ChangeName),
+    ChangeType: __expectString(output.ChangeType),
+    Details: __expectString(output.Details),
     Entity:
       output.Entity !== undefined && output.Entity !== null
         ? deserializeAws_restJson1Entity(output.Entity, context)
@@ -1068,20 +1068,19 @@ const deserializeAws_restJson1ChangeSummary = (output: any, context: __SerdeCont
 
 const deserializeAws_restJson1Entity = (output: any, context: __SerdeContext): Entity => {
   return {
-    Identifier: output.Identifier !== undefined && output.Identifier !== null ? output.Identifier : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Identifier: __expectString(output.Identifier),
+    Type: __expectString(output.Type),
   } as any;
 };
 
 const deserializeAws_restJson1EntitySummary = (output: any, context: __SerdeContext): EntitySummary => {
   return {
-    EntityArn: output.EntityArn !== undefined && output.EntityArn !== null ? output.EntityArn : undefined,
-    EntityId: output.EntityId !== undefined && output.EntityId !== null ? output.EntityId : undefined,
-    EntityType: output.EntityType !== undefined && output.EntityType !== null ? output.EntityType : undefined,
-    LastModifiedDate:
-      output.LastModifiedDate !== undefined && output.LastModifiedDate !== null ? output.LastModifiedDate : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Visibility: output.Visibility !== undefined && output.Visibility !== null ? output.Visibility : undefined,
+    EntityArn: __expectString(output.EntityArn),
+    EntityId: __expectString(output.EntityId),
+    EntityType: __expectString(output.EntityType),
+    LastModifiedDate: __expectString(output.LastModifiedDate),
+    Name: __expectString(output.Name),
+    Visibility: __expectString(output.Visibility),
   } as any;
 };
 
@@ -1098,8 +1097,8 @@ const deserializeAws_restJson1EntitySummaryList = (output: any, context: __Serde
 
 const deserializeAws_restJson1ErrorDetail = (output: any, context: __SerdeContext): ErrorDetail => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
   } as any;
 };
 
@@ -1121,7 +1120,7 @@ const deserializeAws_restJson1ResourceIdList = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 

--- a/clients/client-marketplace-commerce-analytics/protocols/Aws_json1_1.ts
+++ b/clients/client-marketplace-commerce-analytics/protocols/Aws_json1_1.ts
@@ -11,7 +11,7 @@ import {
   StartSupportDataExportResult,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException, expectString as __expectString } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -224,8 +224,7 @@ const serializeAws_json1_1StartSupportDataExportRequest = (
 
 const deserializeAws_json1_1GenerateDataSetResult = (output: any, context: __SerdeContext): GenerateDataSetResult => {
   return {
-    dataSetRequestId:
-      output.dataSetRequestId !== undefined && output.dataSetRequestId !== null ? output.dataSetRequestId : undefined,
+    dataSetRequestId: __expectString(output.dataSetRequestId),
   } as any;
 };
 
@@ -234,7 +233,7 @@ const deserializeAws_json1_1MarketplaceCommerceAnalyticsException = (
   context: __SerdeContext
 ): MarketplaceCommerceAnalyticsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -243,8 +242,7 @@ const deserializeAws_json1_1StartSupportDataExportResult = (
   context: __SerdeContext
 ): StartSupportDataExportResult => {
   return {
-    dataSetRequestId:
-      output.dataSetRequestId !== undefined && output.dataSetRequestId !== null ? output.dataSetRequestId : undefined,
+    dataSetRequestId: __expectString(output.dataSetRequestId),
   } as any;
 };
 

--- a/clients/client-marketplace-entitlement-service/protocols/Aws_json1_1.ts
+++ b/clients/client-marketplace-entitlement-service/protocols/Aws_json1_1.ts
@@ -10,7 +10,12 @@ import {
   ThrottlingException,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -188,16 +193,13 @@ const serializeAws_json1_1GetEntitlementsRequest = (input: GetEntitlementsReques
 
 const deserializeAws_json1_1Entitlement = (output: any, context: __SerdeContext): Entitlement => {
   return {
-    CustomerIdentifier:
-      output.CustomerIdentifier !== undefined && output.CustomerIdentifier !== null
-        ? output.CustomerIdentifier
-        : undefined,
-    Dimension: output.Dimension !== undefined && output.Dimension !== null ? output.Dimension : undefined,
+    CustomerIdentifier: __expectString(output.CustomerIdentifier),
+    Dimension: __expectString(output.Dimension),
     ExpirationDate:
       output.ExpirationDate !== undefined && output.ExpirationDate !== null
         ? new Date(Math.round(output.ExpirationDate * 1000))
         : undefined,
-    ProductCode: output.ProductCode !== undefined && output.ProductCode !== null ? output.ProductCode : undefined,
+    ProductCode: __expectString(output.ProductCode),
     Value:
       output.Value !== undefined && output.Value !== null
         ? deserializeAws_json1_1EntitlementValue(output.Value, context)
@@ -217,25 +219,17 @@ const deserializeAws_json1_1EntitlementList = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_json1_1EntitlementValue = (output: any, context: __SerdeContext): EntitlementValue => {
-  if (output.BooleanValue !== undefined && output.BooleanValue !== null) {
-    return {
-      BooleanValue: output.BooleanValue,
-    };
+  if (__expectBoolean(output.BooleanValue) !== undefined) {
+    return { BooleanValue: __expectBoolean(output.BooleanValue) as any };
   }
-  if (output.DoubleValue !== undefined && output.DoubleValue !== null) {
-    return {
-      DoubleValue: output.DoubleValue,
-    };
+  if (__expectNumber(output.DoubleValue) !== undefined) {
+    return { DoubleValue: __expectNumber(output.DoubleValue) as any };
   }
-  if (output.IntegerValue !== undefined && output.IntegerValue !== null) {
-    return {
-      IntegerValue: output.IntegerValue,
-    };
+  if (__expectNumber(output.IntegerValue) !== undefined) {
+    return { IntegerValue: __expectNumber(output.IntegerValue) as any };
   }
-  if (output.StringValue !== undefined && output.StringValue !== null) {
-    return {
-      StringValue: output.StringValue,
-    };
+  if (__expectString(output.StringValue) !== undefined) {
+    return { StringValue: __expectString(output.StringValue) as any };
   }
   return { $unknown: Object.entries(output)[0] };
 };
@@ -246,7 +240,7 @@ const deserializeAws_json1_1GetEntitlementsResult = (output: any, context: __Ser
       output.Entitlements !== undefined && output.Entitlements !== null
         ? deserializeAws_json1_1EntitlementList(output.Entitlements, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -255,7 +249,7 @@ const deserializeAws_json1_1InternalServiceErrorException = (
   context: __SerdeContext
 ): InternalServiceErrorException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -264,13 +258,13 @@ const deserializeAws_json1_1InvalidParameterException = (
   context: __SerdeContext
 ): InvalidParameterException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1ThrottlingException = (output: any, context: __SerdeContext): ThrottlingException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 

--- a/clients/client-marketplace-metering/protocols/Aws_json1_1.ts
+++ b/clients/client-marketplace-metering/protocols/Aws_json1_1.ts
@@ -34,7 +34,11 @@ import {
   UsageRecordResult,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -913,13 +917,13 @@ const deserializeAws_json1_1CustomerNotEntitledException = (
   context: __SerdeContext
 ): CustomerNotEntitledException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1DisabledApiException = (output: any, context: __SerdeContext): DisabledApiException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -928,13 +932,13 @@ const deserializeAws_json1_1DuplicateRequestException = (
   context: __SerdeContext
 ): DuplicateRequestException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1ExpiredTokenException = (output: any, context: __SerdeContext): ExpiredTokenException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -943,7 +947,7 @@ const deserializeAws_json1_1InternalServiceErrorException = (
   context: __SerdeContext
 ): InternalServiceErrorException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -952,7 +956,7 @@ const deserializeAws_json1_1InvalidCustomerIdentifierException = (
   context: __SerdeContext
 ): InvalidCustomerIdentifierException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -961,7 +965,7 @@ const deserializeAws_json1_1InvalidEndpointRegionException = (
   context: __SerdeContext
 ): InvalidEndpointRegionException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -970,7 +974,7 @@ const deserializeAws_json1_1InvalidProductCodeException = (
   context: __SerdeContext
 ): InvalidProductCodeException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -979,25 +983,25 @@ const deserializeAws_json1_1InvalidPublicKeyVersionException = (
   context: __SerdeContext
 ): InvalidPublicKeyVersionException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidRegionException = (output: any, context: __SerdeContext): InvalidRegionException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidTagException = (output: any, context: __SerdeContext): InvalidTagException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidTokenException = (output: any, context: __SerdeContext): InvalidTokenException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -1006,7 +1010,7 @@ const deserializeAws_json1_1InvalidUsageAllocationsException = (
   context: __SerdeContext
 ): InvalidUsageAllocationsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -1015,14 +1019,13 @@ const deserializeAws_json1_1InvalidUsageDimensionException = (
   context: __SerdeContext
 ): InvalidUsageDimensionException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1MeterUsageResult = (output: any, context: __SerdeContext): MeterUsageResult => {
   return {
-    MeteringRecordId:
-      output.MeteringRecordId !== undefined && output.MeteringRecordId !== null ? output.MeteringRecordId : undefined,
+    MeteringRecordId: __expectString(output.MeteringRecordId),
   } as any;
 };
 
@@ -1031,7 +1034,7 @@ const deserializeAws_json1_1PlatformNotSupportedException = (
   context: __SerdeContext
 ): PlatformNotSupportedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -1041,24 +1044,21 @@ const deserializeAws_json1_1RegisterUsageResult = (output: any, context: __Serde
       output.PublicKeyRotationTimestamp !== undefined && output.PublicKeyRotationTimestamp !== null
         ? new Date(Math.round(output.PublicKeyRotationTimestamp * 1000))
         : undefined,
-    Signature: output.Signature !== undefined && output.Signature !== null ? output.Signature : undefined,
+    Signature: __expectString(output.Signature),
   } as any;
 };
 
 const deserializeAws_json1_1ResolveCustomerResult = (output: any, context: __SerdeContext): ResolveCustomerResult => {
   return {
-    CustomerIdentifier:
-      output.CustomerIdentifier !== undefined && output.CustomerIdentifier !== null
-        ? output.CustomerIdentifier
-        : undefined,
-    ProductCode: output.ProductCode !== undefined && output.ProductCode !== null ? output.ProductCode : undefined,
+    CustomerIdentifier: __expectString(output.CustomerIdentifier),
+    ProductCode: __expectString(output.ProductCode),
   } as any;
 };
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -1075,7 +1075,7 @@ const deserializeAws_json1_1TagList = (output: any, context: __SerdeContext): Ta
 
 const deserializeAws_json1_1ThrottlingException = (output: any, context: __SerdeContext): ThrottlingException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -1084,16 +1084,13 @@ const deserializeAws_json1_1TimestampOutOfBoundsException = (
   context: __SerdeContext
 ): TimestampOutOfBoundsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1UsageAllocation = (output: any, context: __SerdeContext): UsageAllocation => {
   return {
-    AllocatedUsageQuantity:
-      output.AllocatedUsageQuantity !== undefined && output.AllocatedUsageQuantity !== null
-        ? output.AllocatedUsageQuantity
-        : undefined,
+    AllocatedUsageQuantity: __expectNumber(output.AllocatedUsageQuantity),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_1TagList(output.Tags, context)
@@ -1114,12 +1111,9 @@ const deserializeAws_json1_1UsageAllocations = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1UsageRecord = (output: any, context: __SerdeContext): UsageRecord => {
   return {
-    CustomerIdentifier:
-      output.CustomerIdentifier !== undefined && output.CustomerIdentifier !== null
-        ? output.CustomerIdentifier
-        : undefined,
-    Dimension: output.Dimension !== undefined && output.Dimension !== null ? output.Dimension : undefined,
-    Quantity: output.Quantity !== undefined && output.Quantity !== null ? output.Quantity : undefined,
+    CustomerIdentifier: __expectString(output.CustomerIdentifier),
+    Dimension: __expectString(output.Dimension),
+    Quantity: __expectNumber(output.Quantity),
     Timestamp:
       output.Timestamp !== undefined && output.Timestamp !== null
         ? new Date(Math.round(output.Timestamp * 1000))
@@ -1144,9 +1138,8 @@ const deserializeAws_json1_1UsageRecordList = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_1UsageRecordResult = (output: any, context: __SerdeContext): UsageRecordResult => {
   return {
-    MeteringRecordId:
-      output.MeteringRecordId !== undefined && output.MeteringRecordId !== null ? output.MeteringRecordId : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    MeteringRecordId: __expectString(output.MeteringRecordId),
+    Status: __expectString(output.Status),
     UsageRecord:
       output.UsageRecord !== undefined && output.UsageRecord !== null
         ? deserializeAws_json1_1UsageRecord(output.UsageRecord, context)

--- a/clients/client-mediaconnect/protocols/Aws_restJson1.ts
+++ b/clients/client-mediaconnect/protocols/Aws_restJson1.ts
@@ -112,6 +112,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -1204,7 +1206,7 @@ export const deserializeAws_restJson1AddFlowMediaStreamsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.flowArn !== undefined && data.flowArn !== null) {
-    contents.FlowArn = data.flowArn;
+    contents.FlowArn = __expectString(data.flowArn);
   }
   if (data.mediaStreams !== undefined && data.mediaStreams !== null) {
     contents.MediaStreams = deserializeAws_restJson1__listOfMediaStream(data.mediaStreams, context);
@@ -1303,7 +1305,7 @@ export const deserializeAws_restJson1AddFlowOutputsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.flowArn !== undefined && data.flowArn !== null) {
-    contents.FlowArn = data.flowArn;
+    contents.FlowArn = __expectString(data.flowArn);
   }
   if (data.outputs !== undefined && data.outputs !== null) {
     contents.Outputs = deserializeAws_restJson1__listOfOutput(data.outputs, context);
@@ -1410,7 +1412,7 @@ export const deserializeAws_restJson1AddFlowSourcesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.flowArn !== undefined && data.flowArn !== null) {
-    contents.FlowArn = data.flowArn;
+    contents.FlowArn = __expectString(data.flowArn);
   }
   if (data.sources !== undefined && data.sources !== null) {
     contents.Sources = deserializeAws_restJson1__listOfSource(data.sources, context);
@@ -1509,7 +1511,7 @@ export const deserializeAws_restJson1AddFlowVpcInterfacesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.flowArn !== undefined && data.flowArn !== null) {
-    contents.FlowArn = data.flowArn;
+    contents.FlowArn = __expectString(data.flowArn);
   }
   if (data.vpcInterfaces !== undefined && data.vpcInterfaces !== null) {
     contents.VpcInterfaces = deserializeAws_restJson1__listOfVpcInterface(data.vpcInterfaces, context);
@@ -1703,10 +1705,10 @@ export const deserializeAws_restJson1DeleteFlowCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.flowArn !== undefined && data.flowArn !== null) {
-    contents.FlowArn = data.flowArn;
+    contents.FlowArn = __expectString(data.flowArn);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.Status = data.status;
+    contents.Status = __expectString(data.status);
   }
   return Promise.resolve(contents);
 };
@@ -2078,7 +2080,7 @@ export const deserializeAws_restJson1GrantFlowEntitlementsCommand = async (
     contents.Entitlements = deserializeAws_restJson1__listOfEntitlement(data.entitlements, context);
   }
   if (data.flowArn !== undefined && data.flowArn !== null) {
-    contents.FlowArn = data.flowArn;
+    contents.FlowArn = __expectString(data.flowArn);
   }
   return Promise.resolve(contents);
 };
@@ -2185,7 +2187,7 @@ export const deserializeAws_restJson1ListEntitlementsCommand = async (
     contents.Entitlements = deserializeAws_restJson1__listOfListedEntitlement(data.entitlements, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2268,7 +2270,7 @@ export const deserializeAws_restJson1ListFlowsCommand = async (
     contents.Flows = deserializeAws_restJson1__listOfListedFlow(data.flows, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2348,7 +2350,7 @@ export const deserializeAws_restJson1ListOfferingsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   if (data.offerings !== undefined && data.offerings !== null) {
     contents.Offerings = deserializeAws_restJson1__listOfOffering(data.offerings, context);
@@ -2431,7 +2433,7 @@ export const deserializeAws_restJson1ListReservationsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   if (data.reservations !== undefined && data.reservations !== null) {
     contents.Reservations = deserializeAws_restJson1__listOfReservation(data.reservations, context);
@@ -2680,10 +2682,10 @@ export const deserializeAws_restJson1RemoveFlowMediaStreamCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.flowArn !== undefined && data.flowArn !== null) {
-    contents.FlowArn = data.flowArn;
+    contents.FlowArn = __expectString(data.flowArn);
   }
   if (data.mediaStreamName !== undefined && data.mediaStreamName !== null) {
-    contents.MediaStreamName = data.mediaStreamName;
+    contents.MediaStreamName = __expectString(data.mediaStreamName);
   }
   return Promise.resolve(contents);
 };
@@ -2779,10 +2781,10 @@ export const deserializeAws_restJson1RemoveFlowOutputCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.flowArn !== undefined && data.flowArn !== null) {
-    contents.FlowArn = data.flowArn;
+    contents.FlowArn = __expectString(data.flowArn);
   }
   if (data.outputArn !== undefined && data.outputArn !== null) {
-    contents.OutputArn = data.outputArn;
+    contents.OutputArn = __expectString(data.outputArn);
   }
   return Promise.resolve(contents);
 };
@@ -2878,10 +2880,10 @@ export const deserializeAws_restJson1RemoveFlowSourceCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.flowArn !== undefined && data.flowArn !== null) {
-    contents.FlowArn = data.flowArn;
+    contents.FlowArn = __expectString(data.flowArn);
   }
   if (data.sourceArn !== undefined && data.sourceArn !== null) {
-    contents.SourceArn = data.sourceArn;
+    contents.SourceArn = __expectString(data.sourceArn);
   }
   return Promise.resolve(contents);
 };
@@ -2978,7 +2980,7 @@ export const deserializeAws_restJson1RemoveFlowVpcInterfaceCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.flowArn !== undefined && data.flowArn !== null) {
-    contents.FlowArn = data.flowArn;
+    contents.FlowArn = __expectString(data.flowArn);
   }
   if (data.nonDeletedNetworkInterfaceIds !== undefined && data.nonDeletedNetworkInterfaceIds !== null) {
     contents.NonDeletedNetworkInterfaceIds = deserializeAws_restJson1__listOf__string(
@@ -2987,7 +2989,7 @@ export const deserializeAws_restJson1RemoveFlowVpcInterfaceCommand = async (
     );
   }
   if (data.vpcInterfaceName !== undefined && data.vpcInterfaceName !== null) {
-    contents.VpcInterfaceName = data.vpcInterfaceName;
+    contents.VpcInterfaceName = __expectString(data.vpcInterfaceName);
   }
   return Promise.resolve(contents);
 };
@@ -3083,10 +3085,10 @@ export const deserializeAws_restJson1RevokeFlowEntitlementCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.entitlementArn !== undefined && data.entitlementArn !== null) {
-    contents.EntitlementArn = data.entitlementArn;
+    contents.EntitlementArn = __expectString(data.entitlementArn);
   }
   if (data.flowArn !== undefined && data.flowArn !== null) {
-    contents.FlowArn = data.flowArn;
+    contents.FlowArn = __expectString(data.flowArn);
   }
   return Promise.resolve(contents);
 };
@@ -3182,10 +3184,10 @@ export const deserializeAws_restJson1StartFlowCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.flowArn !== undefined && data.flowArn !== null) {
-    contents.FlowArn = data.flowArn;
+    contents.FlowArn = __expectString(data.flowArn);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.Status = data.status;
+    contents.Status = __expectString(data.status);
   }
   return Promise.resolve(contents);
 };
@@ -3281,10 +3283,10 @@ export const deserializeAws_restJson1StopFlowCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.flowArn !== undefined && data.flowArn !== null) {
-    contents.FlowArn = data.flowArn;
+    contents.FlowArn = __expectString(data.flowArn);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.Status = data.status;
+    contents.Status = __expectString(data.status);
   }
   return Promise.resolve(contents);
 };
@@ -3612,7 +3614,7 @@ export const deserializeAws_restJson1UpdateFlowEntitlementCommand = async (
     contents.Entitlement = deserializeAws_restJson1Entitlement(data.entitlement, context);
   }
   if (data.flowArn !== undefined && data.flowArn !== null) {
-    contents.FlowArn = data.flowArn;
+    contents.FlowArn = __expectString(data.flowArn);
   }
   return Promise.resolve(contents);
 };
@@ -3708,7 +3710,7 @@ export const deserializeAws_restJson1UpdateFlowMediaStreamCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.flowArn !== undefined && data.flowArn !== null) {
-    contents.FlowArn = data.flowArn;
+    contents.FlowArn = __expectString(data.flowArn);
   }
   if (data.mediaStream !== undefined && data.mediaStream !== null) {
     contents.MediaStream = deserializeAws_restJson1MediaStream(data.mediaStream, context);
@@ -3807,7 +3809,7 @@ export const deserializeAws_restJson1UpdateFlowOutputCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.flowArn !== undefined && data.flowArn !== null) {
-    contents.FlowArn = data.flowArn;
+    contents.FlowArn = __expectString(data.flowArn);
   }
   if (data.output !== undefined && data.output !== null) {
     contents.Output = deserializeAws_restJson1Output(data.output, context);
@@ -3906,7 +3908,7 @@ export const deserializeAws_restJson1UpdateFlowSourceCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.flowArn !== undefined && data.flowArn !== null) {
-    contents.FlowArn = data.flowArn;
+    contents.FlowArn = __expectString(data.flowArn);
   }
   if (data.source !== undefined && data.source !== null) {
     contents.Source = deserializeAws_restJson1Source(data.source, context);
@@ -4003,7 +4005,7 @@ const deserializeAws_restJson1AddFlowOutputs420ExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -4020,7 +4022,7 @@ const deserializeAws_restJson1BadRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -4037,7 +4039,7 @@ const deserializeAws_restJson1CreateFlow420ExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -4054,7 +4056,7 @@ const deserializeAws_restJson1ForbiddenExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -4071,7 +4073,7 @@ const deserializeAws_restJson1GrantFlowEntitlements420ExceptionResponse = async 
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -4088,7 +4090,7 @@ const deserializeAws_restJson1InternalServerErrorExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -4105,7 +4107,7 @@ const deserializeAws_restJson1NotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -4122,7 +4124,7 @@ const deserializeAws_restJson1ServiceUnavailableExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -4139,7 +4141,7 @@ const deserializeAws_restJson1TooManyRequestsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -4587,7 +4589,7 @@ const deserializeAws_restJson1__listOf__string = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4756,7 +4758,7 @@ const deserializeAws_restJson1__mapOf__string = (output: any, context: __SerdeCo
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -4766,64 +4768,48 @@ const deserializeAws_restJson1DestinationConfiguration = (
   context: __SerdeContext
 ): DestinationConfiguration => {
   return {
-    DestinationIp:
-      output.destinationIp !== undefined && output.destinationIp !== null ? output.destinationIp : undefined,
-    DestinationPort:
-      output.destinationPort !== undefined && output.destinationPort !== null ? output.destinationPort : undefined,
+    DestinationIp: __expectString(output.destinationIp),
+    DestinationPort: __expectNumber(output.destinationPort),
     Interface:
       output.interface !== undefined && output.interface !== null
         ? deserializeAws_restJson1Interface(output.interface, context)
         : undefined,
-    OutboundIp: output.outboundIp !== undefined && output.outboundIp !== null ? output.outboundIp : undefined,
+    OutboundIp: __expectString(output.outboundIp),
   } as any;
 };
 
 const deserializeAws_restJson1EncodingParameters = (output: any, context: __SerdeContext): EncodingParameters => {
   return {
-    CompressionFactor:
-      output.compressionFactor !== undefined && output.compressionFactor !== null
-        ? output.compressionFactor
-        : undefined,
-    EncoderProfile:
-      output.encoderProfile !== undefined && output.encoderProfile !== null ? output.encoderProfile : undefined,
+    CompressionFactor: __expectNumber(output.compressionFactor),
+    EncoderProfile: __expectString(output.encoderProfile),
   } as any;
 };
 
 const deserializeAws_restJson1Encryption = (output: any, context: __SerdeContext): Encryption => {
   return {
-    Algorithm: output.algorithm !== undefined && output.algorithm !== null ? output.algorithm : undefined,
-    ConstantInitializationVector:
-      output.constantInitializationVector !== undefined && output.constantInitializationVector !== null
-        ? output.constantInitializationVector
-        : undefined,
-    DeviceId: output.deviceId !== undefined && output.deviceId !== null ? output.deviceId : undefined,
-    KeyType: output.keyType !== undefined && output.keyType !== null ? output.keyType : undefined,
-    Region: output.region !== undefined && output.region !== null ? output.region : undefined,
-    ResourceId: output.resourceId !== undefined && output.resourceId !== null ? output.resourceId : undefined,
-    RoleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
-    SecretArn: output.secretArn !== undefined && output.secretArn !== null ? output.secretArn : undefined,
-    Url: output.url !== undefined && output.url !== null ? output.url : undefined,
+    Algorithm: __expectString(output.algorithm),
+    ConstantInitializationVector: __expectString(output.constantInitializationVector),
+    DeviceId: __expectString(output.deviceId),
+    KeyType: __expectString(output.keyType),
+    Region: __expectString(output.region),
+    ResourceId: __expectString(output.resourceId),
+    RoleArn: __expectString(output.roleArn),
+    SecretArn: __expectString(output.secretArn),
+    Url: __expectString(output.url),
   } as any;
 };
 
 const deserializeAws_restJson1Entitlement = (output: any, context: __SerdeContext): Entitlement => {
   return {
-    DataTransferSubscriberFeePercent:
-      output.dataTransferSubscriberFeePercent !== undefined && output.dataTransferSubscriberFeePercent !== null
-        ? output.dataTransferSubscriberFeePercent
-        : undefined,
-    Description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    DataTransferSubscriberFeePercent: __expectNumber(output.dataTransferSubscriberFeePercent),
+    Description: __expectString(output.description),
     Encryption:
       output.encryption !== undefined && output.encryption !== null
         ? deserializeAws_restJson1Encryption(output.encryption, context)
         : undefined,
-    EntitlementArn:
-      output.entitlementArn !== undefined && output.entitlementArn !== null ? output.entitlementArn : undefined,
-    EntitlementStatus:
-      output.entitlementStatus !== undefined && output.entitlementStatus !== null
-        ? output.entitlementStatus
-        : undefined,
-    Name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    EntitlementArn: __expectString(output.entitlementArn),
+    EntitlementStatus: __expectString(output.entitlementStatus),
+    Name: __expectString(output.name),
     Subscribers:
       output.subscribers !== undefined && output.subscribers !== null
         ? deserializeAws_restJson1__listOf__string(output.subscribers, context)
@@ -4833,33 +4819,31 @@ const deserializeAws_restJson1Entitlement = (output: any, context: __SerdeContex
 
 const deserializeAws_restJson1FailoverConfig = (output: any, context: __SerdeContext): FailoverConfig => {
   return {
-    FailoverMode: output.failoverMode !== undefined && output.failoverMode !== null ? output.failoverMode : undefined,
-    RecoveryWindow:
-      output.recoveryWindow !== undefined && output.recoveryWindow !== null ? output.recoveryWindow : undefined,
+    FailoverMode: __expectString(output.failoverMode),
+    RecoveryWindow: __expectNumber(output.recoveryWindow),
     SourcePriority:
       output.sourcePriority !== undefined && output.sourcePriority !== null
         ? deserializeAws_restJson1SourcePriority(output.sourcePriority, context)
         : undefined,
-    State: output.state !== undefined && output.state !== null ? output.state : undefined,
+    State: __expectString(output.state),
   } as any;
 };
 
 const deserializeAws_restJson1Flow = (output: any, context: __SerdeContext): Flow => {
   return {
-    AvailabilityZone:
-      output.availabilityZone !== undefined && output.availabilityZone !== null ? output.availabilityZone : undefined,
-    Description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    EgressIp: output.egressIp !== undefined && output.egressIp !== null ? output.egressIp : undefined,
+    AvailabilityZone: __expectString(output.availabilityZone),
+    Description: __expectString(output.description),
+    EgressIp: __expectString(output.egressIp),
     Entitlements:
       output.entitlements !== undefined && output.entitlements !== null
         ? deserializeAws_restJson1__listOfEntitlement(output.entitlements, context)
         : undefined,
-    FlowArn: output.flowArn !== undefined && output.flowArn !== null ? output.flowArn : undefined,
+    FlowArn: __expectString(output.flowArn),
     MediaStreams:
       output.mediaStreams !== undefined && output.mediaStreams !== null
         ? deserializeAws_restJson1__listOfMediaStream(output.mediaStreams, context)
         : undefined,
-    Name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    Name: __expectString(output.name),
     Outputs:
       output.outputs !== undefined && output.outputs !== null
         ? deserializeAws_restJson1__listOfOutput(output.outputs, context)
@@ -4876,7 +4860,7 @@ const deserializeAws_restJson1Flow = (output: any, context: __SerdeContext): Flo
       output.sources !== undefined && output.sources !== null
         ? deserializeAws_restJson1__listOfSource(output.sources, context)
         : undefined,
-    Status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    Status: __expectString(output.status),
     VpcInterfaces:
       output.vpcInterfaces !== undefined && output.vpcInterfaces !== null
         ? deserializeAws_restJson1__listOfVpcInterface(output.vpcInterfaces, context)
@@ -4886,21 +4870,20 @@ const deserializeAws_restJson1Flow = (output: any, context: __SerdeContext): Flo
 
 const deserializeAws_restJson1Fmtp = (output: any, context: __SerdeContext): Fmtp => {
   return {
-    ChannelOrder: output.channelOrder !== undefined && output.channelOrder !== null ? output.channelOrder : undefined,
-    Colorimetry: output.colorimetry !== undefined && output.colorimetry !== null ? output.colorimetry : undefined,
-    ExactFramerate:
-      output.exactFramerate !== undefined && output.exactFramerate !== null ? output.exactFramerate : undefined,
-    Par: output.par !== undefined && output.par !== null ? output.par : undefined,
-    Range: output.range !== undefined && output.range !== null ? output.range : undefined,
-    ScanMode: output.scanMode !== undefined && output.scanMode !== null ? output.scanMode : undefined,
-    Tcs: output.tcs !== undefined && output.tcs !== null ? output.tcs : undefined,
+    ChannelOrder: __expectString(output.channelOrder),
+    Colorimetry: __expectString(output.colorimetry),
+    ExactFramerate: __expectString(output.exactFramerate),
+    Par: __expectString(output.par),
+    Range: __expectString(output.range),
+    ScanMode: __expectString(output.scanMode),
+    Tcs: __expectString(output.tcs),
   } as any;
 };
 
 const deserializeAws_restJson1InputConfiguration = (output: any, context: __SerdeContext): InputConfiguration => {
   return {
-    InputIp: output.inputIp !== undefined && output.inputIp !== null ? output.inputIp : undefined,
-    InputPort: output.inputPort !== undefined && output.inputPort !== null ? output.inputPort : undefined,
+    InputIp: __expectString(output.inputIp),
+    InputPort: __expectNumber(output.inputPort),
     Interface:
       output.interface !== undefined && output.interface !== null
         ? deserializeAws_restJson1Interface(output.interface, context)
@@ -4910,32 +4893,26 @@ const deserializeAws_restJson1InputConfiguration = (output: any, context: __Serd
 
 const deserializeAws_restJson1Interface = (output: any, context: __SerdeContext): Interface => {
   return {
-    Name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    Name: __expectString(output.name),
   } as any;
 };
 
 const deserializeAws_restJson1ListedEntitlement = (output: any, context: __SerdeContext): ListedEntitlement => {
   return {
-    DataTransferSubscriberFeePercent:
-      output.dataTransferSubscriberFeePercent !== undefined && output.dataTransferSubscriberFeePercent !== null
-        ? output.dataTransferSubscriberFeePercent
-        : undefined,
-    EntitlementArn:
-      output.entitlementArn !== undefined && output.entitlementArn !== null ? output.entitlementArn : undefined,
-    EntitlementName:
-      output.entitlementName !== undefined && output.entitlementName !== null ? output.entitlementName : undefined,
+    DataTransferSubscriberFeePercent: __expectNumber(output.dataTransferSubscriberFeePercent),
+    EntitlementArn: __expectString(output.entitlementArn),
+    EntitlementName: __expectString(output.entitlementName),
   } as any;
 };
 
 const deserializeAws_restJson1ListedFlow = (output: any, context: __SerdeContext): ListedFlow => {
   return {
-    AvailabilityZone:
-      output.availabilityZone !== undefined && output.availabilityZone !== null ? output.availabilityZone : undefined,
-    Description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    FlowArn: output.flowArn !== undefined && output.flowArn !== null ? output.flowArn : undefined,
-    Name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    SourceType: output.sourceType !== undefined && output.sourceType !== null ? output.sourceType : undefined,
-    Status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    AvailabilityZone: __expectString(output.availabilityZone),
+    Description: __expectString(output.description),
+    FlowArn: __expectString(output.flowArn),
+    Name: __expectString(output.name),
+    SourceType: __expectString(output.sourceType),
+    Status: __expectString(output.status),
   } as any;
 };
 
@@ -4945,16 +4922,13 @@ const deserializeAws_restJson1MediaStream = (output: any, context: __SerdeContex
       output.attributes !== undefined && output.attributes !== null
         ? deserializeAws_restJson1MediaStreamAttributes(output.attributes, context)
         : undefined,
-    ClockRate: output.clockRate !== undefined && output.clockRate !== null ? output.clockRate : undefined,
-    Description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    Fmt: output.fmt !== undefined && output.fmt !== null ? output.fmt : undefined,
-    MediaStreamId:
-      output.mediaStreamId !== undefined && output.mediaStreamId !== null ? output.mediaStreamId : undefined,
-    MediaStreamName:
-      output.mediaStreamName !== undefined && output.mediaStreamName !== null ? output.mediaStreamName : undefined,
-    MediaStreamType:
-      output.mediaStreamType !== undefined && output.mediaStreamType !== null ? output.mediaStreamType : undefined,
-    VideoFormat: output.videoFormat !== undefined && output.videoFormat !== null ? output.videoFormat : undefined,
+    ClockRate: __expectNumber(output.clockRate),
+    Description: __expectString(output.description),
+    Fmt: __expectNumber(output.fmt),
+    MediaStreamId: __expectNumber(output.mediaStreamId),
+    MediaStreamName: __expectString(output.mediaStreamName),
+    MediaStreamType: __expectString(output.mediaStreamType),
+    VideoFormat: __expectString(output.videoFormat),
   } as any;
 };
 
@@ -4964,7 +4938,7 @@ const deserializeAws_restJson1MediaStreamAttributes = (output: any, context: __S
       output.fmtp !== undefined && output.fmtp !== null
         ? deserializeAws_restJson1Fmtp(output.fmtp, context)
         : undefined,
-    Lang: output.lang !== undefined && output.lang !== null ? output.lang : undefined,
+    Lang: __expectString(output.lang),
   } as any;
 };
 
@@ -4977,13 +4951,12 @@ const deserializeAws_restJson1MediaStreamOutputConfiguration = (
       output.destinationConfigurations !== undefined && output.destinationConfigurations !== null
         ? deserializeAws_restJson1__listOfDestinationConfiguration(output.destinationConfigurations, context)
         : undefined,
-    EncodingName: output.encodingName !== undefined && output.encodingName !== null ? output.encodingName : undefined,
+    EncodingName: __expectString(output.encodingName),
     EncodingParameters:
       output.encodingParameters !== undefined && output.encodingParameters !== null
         ? deserializeAws_restJson1EncodingParameters(output.encodingParameters, context)
         : undefined,
-    MediaStreamName:
-      output.mediaStreamName !== undefined && output.mediaStreamName !== null ? output.mediaStreamName : undefined,
+    MediaStreamName: __expectString(output.mediaStreamName),
   } as any;
 };
 
@@ -4992,13 +4965,12 @@ const deserializeAws_restJson1MediaStreamSourceConfiguration = (
   context: __SerdeContext
 ): MediaStreamSourceConfiguration => {
   return {
-    EncodingName: output.encodingName !== undefined && output.encodingName !== null ? output.encodingName : undefined,
+    EncodingName: __expectString(output.encodingName),
     InputConfigurations:
       output.inputConfigurations !== undefined && output.inputConfigurations !== null
         ? deserializeAws_restJson1__listOfInputConfiguration(output.inputConfigurations, context)
         : undefined,
-    MediaStreamName:
-      output.mediaStreamName !== undefined && output.mediaStreamName !== null ? output.mediaStreamName : undefined,
+    MediaStreamName: __expectString(output.mediaStreamName),
   } as any;
 };
 
@@ -5013,17 +4985,13 @@ const deserializeAws_restJson1Messages = (output: any, context: __SerdeContext):
 
 const deserializeAws_restJson1Offering = (output: any, context: __SerdeContext): Offering => {
   return {
-    CurrencyCode: output.currencyCode !== undefined && output.currencyCode !== null ? output.currencyCode : undefined,
-    Duration: output.duration !== undefined && output.duration !== null ? output.duration : undefined,
-    DurationUnits:
-      output.durationUnits !== undefined && output.durationUnits !== null ? output.durationUnits : undefined,
-    OfferingArn: output.offeringArn !== undefined && output.offeringArn !== null ? output.offeringArn : undefined,
-    OfferingDescription:
-      output.offeringDescription !== undefined && output.offeringDescription !== null
-        ? output.offeringDescription
-        : undefined,
-    PricePerUnit: output.pricePerUnit !== undefined && output.pricePerUnit !== null ? output.pricePerUnit : undefined,
-    PriceUnits: output.priceUnits !== undefined && output.priceUnits !== null ? output.priceUnits : undefined,
+    CurrencyCode: __expectString(output.currencyCode),
+    Duration: __expectNumber(output.duration),
+    DurationUnits: __expectString(output.durationUnits),
+    OfferingArn: __expectString(output.offeringArn),
+    OfferingDescription: __expectString(output.offeringDescription),
+    PricePerUnit: __expectString(output.pricePerUnit),
+    PriceUnits: __expectString(output.priceUnits),
     ResourceSpecification:
       output.resourceSpecification !== undefined && output.resourceSpecification !== null
         ? deserializeAws_restJson1ResourceSpecification(output.resourceSpecification, context)
@@ -5033,24 +5001,16 @@ const deserializeAws_restJson1Offering = (output: any, context: __SerdeContext):
 
 const deserializeAws_restJson1Output = (output: any, context: __SerdeContext): Output => {
   return {
-    DataTransferSubscriberFeePercent:
-      output.dataTransferSubscriberFeePercent !== undefined && output.dataTransferSubscriberFeePercent !== null
-        ? output.dataTransferSubscriberFeePercent
-        : undefined,
-    Description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    Destination: output.destination !== undefined && output.destination !== null ? output.destination : undefined,
+    DataTransferSubscriberFeePercent: __expectNumber(output.dataTransferSubscriberFeePercent),
+    Description: __expectString(output.description),
+    Destination: __expectString(output.destination),
     Encryption:
       output.encryption !== undefined && output.encryption !== null
         ? deserializeAws_restJson1Encryption(output.encryption, context)
         : undefined,
-    EntitlementArn:
-      output.entitlementArn !== undefined && output.entitlementArn !== null ? output.entitlementArn : undefined,
-    ListenerAddress:
-      output.listenerAddress !== undefined && output.listenerAddress !== null ? output.listenerAddress : undefined,
-    MediaLiveInputArn:
-      output.mediaLiveInputArn !== undefined && output.mediaLiveInputArn !== null
-        ? output.mediaLiveInputArn
-        : undefined,
+    EntitlementArn: __expectString(output.entitlementArn),
+    ListenerAddress: __expectString(output.listenerAddress),
+    MediaLiveInputArn: __expectString(output.mediaLiveInputArn),
     MediaStreamOutputConfigurations:
       output.mediaStreamOutputConfigurations !== undefined && output.mediaStreamOutputConfigurations !== null
         ? deserializeAws_restJson1__listOfMediaStreamOutputConfiguration(
@@ -5058,9 +5018,9 @@ const deserializeAws_restJson1Output = (output: any, context: __SerdeContext): O
             context
           )
         : undefined,
-    Name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    OutputArn: output.outputArn !== undefined && output.outputArn !== null ? output.outputArn : undefined,
-    Port: output.port !== undefined && output.port !== null ? output.port : undefined,
+    Name: __expectString(output.name),
+    OutputArn: __expectString(output.outputArn),
+    Port: __expectNumber(output.port),
     Transport:
       output.transport !== undefined && output.transport !== null
         ? deserializeAws_restJson1Transport(output.transport, context)
@@ -5074,55 +5034,43 @@ const deserializeAws_restJson1Output = (output: any, context: __SerdeContext): O
 
 const deserializeAws_restJson1Reservation = (output: any, context: __SerdeContext): Reservation => {
   return {
-    CurrencyCode: output.currencyCode !== undefined && output.currencyCode !== null ? output.currencyCode : undefined,
-    Duration: output.duration !== undefined && output.duration !== null ? output.duration : undefined,
-    DurationUnits:
-      output.durationUnits !== undefined && output.durationUnits !== null ? output.durationUnits : undefined,
-    End: output.end !== undefined && output.end !== null ? output.end : undefined,
-    OfferingArn: output.offeringArn !== undefined && output.offeringArn !== null ? output.offeringArn : undefined,
-    OfferingDescription:
-      output.offeringDescription !== undefined && output.offeringDescription !== null
-        ? output.offeringDescription
-        : undefined,
-    PricePerUnit: output.pricePerUnit !== undefined && output.pricePerUnit !== null ? output.pricePerUnit : undefined,
-    PriceUnits: output.priceUnits !== undefined && output.priceUnits !== null ? output.priceUnits : undefined,
-    ReservationArn:
-      output.reservationArn !== undefined && output.reservationArn !== null ? output.reservationArn : undefined,
-    ReservationName:
-      output.reservationName !== undefined && output.reservationName !== null ? output.reservationName : undefined,
-    ReservationState:
-      output.reservationState !== undefined && output.reservationState !== null ? output.reservationState : undefined,
+    CurrencyCode: __expectString(output.currencyCode),
+    Duration: __expectNumber(output.duration),
+    DurationUnits: __expectString(output.durationUnits),
+    End: __expectString(output.end),
+    OfferingArn: __expectString(output.offeringArn),
+    OfferingDescription: __expectString(output.offeringDescription),
+    PricePerUnit: __expectString(output.pricePerUnit),
+    PriceUnits: __expectString(output.priceUnits),
+    ReservationArn: __expectString(output.reservationArn),
+    ReservationName: __expectString(output.reservationName),
+    ReservationState: __expectString(output.reservationState),
     ResourceSpecification:
       output.resourceSpecification !== undefined && output.resourceSpecification !== null
         ? deserializeAws_restJson1ResourceSpecification(output.resourceSpecification, context)
         : undefined,
-    Start: output.start !== undefined && output.start !== null ? output.start : undefined,
+    Start: __expectString(output.start),
   } as any;
 };
 
 const deserializeAws_restJson1ResourceSpecification = (output: any, context: __SerdeContext): ResourceSpecification => {
   return {
-    ReservedBitrate:
-      output.reservedBitrate !== undefined && output.reservedBitrate !== null ? output.reservedBitrate : undefined,
-    ResourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
+    ReservedBitrate: __expectNumber(output.reservedBitrate),
+    ResourceType: __expectString(output.resourceType),
   } as any;
 };
 
 const deserializeAws_restJson1Source = (output: any, context: __SerdeContext): Source => {
   return {
-    DataTransferSubscriberFeePercent:
-      output.dataTransferSubscriberFeePercent !== undefined && output.dataTransferSubscriberFeePercent !== null
-        ? output.dataTransferSubscriberFeePercent
-        : undefined,
+    DataTransferSubscriberFeePercent: __expectNumber(output.dataTransferSubscriberFeePercent),
     Decryption:
       output.decryption !== undefined && output.decryption !== null
         ? deserializeAws_restJson1Encryption(output.decryption, context)
         : undefined,
-    Description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    EntitlementArn:
-      output.entitlementArn !== undefined && output.entitlementArn !== null ? output.entitlementArn : undefined,
-    IngestIp: output.ingestIp !== undefined && output.ingestIp !== null ? output.ingestIp : undefined,
-    IngestPort: output.ingestPort !== undefined && output.ingestPort !== null ? output.ingestPort : undefined,
+    Description: __expectString(output.description),
+    EntitlementArn: __expectString(output.entitlementArn),
+    IngestIp: __expectString(output.ingestIp),
+    IngestPort: __expectNumber(output.ingestPort),
     MediaStreamSourceConfigurations:
       output.mediaStreamSourceConfigurations !== undefined && output.mediaStreamSourceConfigurations !== null
         ? deserializeAws_restJson1__listOfMediaStreamSourceConfiguration(
@@ -5130,23 +5078,20 @@ const deserializeAws_restJson1Source = (output: any, context: __SerdeContext): S
             context
           )
         : undefined,
-    Name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    SourceArn: output.sourceArn !== undefined && output.sourceArn !== null ? output.sourceArn : undefined,
+    Name: __expectString(output.name),
+    SourceArn: __expectString(output.sourceArn),
     Transport:
       output.transport !== undefined && output.transport !== null
         ? deserializeAws_restJson1Transport(output.transport, context)
         : undefined,
-    VpcInterfaceName:
-      output.vpcInterfaceName !== undefined && output.vpcInterfaceName !== null ? output.vpcInterfaceName : undefined,
-    WhitelistCidr:
-      output.whitelistCidr !== undefined && output.whitelistCidr !== null ? output.whitelistCidr : undefined,
+    VpcInterfaceName: __expectString(output.vpcInterfaceName),
+    WhitelistCidr: __expectString(output.whitelistCidr),
   } as any;
 };
 
 const deserializeAws_restJson1SourcePriority = (output: any, context: __SerdeContext): SourcePriority => {
   return {
-    PrimarySource:
-      output.primarySource !== undefined && output.primarySource !== null ? output.primarySource : undefined,
+    PrimarySource: __expectString(output.primarySource),
   } as any;
 };
 
@@ -5156,36 +5101,31 @@ const deserializeAws_restJson1Transport = (output: any, context: __SerdeContext)
       output.cidrAllowList !== undefined && output.cidrAllowList !== null
         ? deserializeAws_restJson1__listOf__string(output.cidrAllowList, context)
         : undefined,
-    MaxBitrate: output.maxBitrate !== undefined && output.maxBitrate !== null ? output.maxBitrate : undefined,
-    MaxLatency: output.maxLatency !== undefined && output.maxLatency !== null ? output.maxLatency : undefined,
-    MaxSyncBuffer:
-      output.maxSyncBuffer !== undefined && output.maxSyncBuffer !== null ? output.maxSyncBuffer : undefined,
-    MinLatency: output.minLatency !== undefined && output.minLatency !== null ? output.minLatency : undefined,
-    Protocol: output.protocol !== undefined && output.protocol !== null ? output.protocol : undefined,
-    RemoteId: output.remoteId !== undefined && output.remoteId !== null ? output.remoteId : undefined,
-    SmoothingLatency:
-      output.smoothingLatency !== undefined && output.smoothingLatency !== null ? output.smoothingLatency : undefined,
-    StreamId: output.streamId !== undefined && output.streamId !== null ? output.streamId : undefined,
+    MaxBitrate: __expectNumber(output.maxBitrate),
+    MaxLatency: __expectNumber(output.maxLatency),
+    MaxSyncBuffer: __expectNumber(output.maxSyncBuffer),
+    MinLatency: __expectNumber(output.minLatency),
+    Protocol: __expectString(output.protocol),
+    RemoteId: __expectString(output.remoteId),
+    SmoothingLatency: __expectNumber(output.smoothingLatency),
+    StreamId: __expectString(output.streamId),
   } as any;
 };
 
 const deserializeAws_restJson1VpcInterface = (output: any, context: __SerdeContext): VpcInterface => {
   return {
-    Name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    Name: __expectString(output.name),
     NetworkInterfaceIds:
       output.networkInterfaceIds !== undefined && output.networkInterfaceIds !== null
         ? deserializeAws_restJson1__listOf__string(output.networkInterfaceIds, context)
         : undefined,
-    NetworkInterfaceType:
-      output.networkInterfaceType !== undefined && output.networkInterfaceType !== null
-        ? output.networkInterfaceType
-        : undefined,
-    RoleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
+    NetworkInterfaceType: __expectString(output.networkInterfaceType),
+    RoleArn: __expectString(output.roleArn),
     SecurityGroupIds:
       output.securityGroupIds !== undefined && output.securityGroupIds !== null
         ? deserializeAws_restJson1__listOf__string(output.securityGroupIds, context)
         : undefined,
-    SubnetId: output.subnetId !== undefined && output.subnetId !== null ? output.subnetId : undefined,
+    SubnetId: __expectString(output.subnetId),
   } as any;
 };
 
@@ -5194,8 +5134,7 @@ const deserializeAws_restJson1VpcInterfaceAttachment = (
   context: __SerdeContext
 ): VpcInterfaceAttachment => {
   return {
-    VpcInterfaceName:
-      output.vpcInterfaceName !== undefined && output.vpcInterfaceName !== null ? output.vpcInterfaceName : undefined,
+    VpcInterfaceName: __expectString(output.vpcInterfaceName),
   } as any;
 };
 

--- a/clients/client-mediaconvert/protocols/Aws_restJson1.ts
+++ b/clients/client-mediaconvert/protocols/Aws_restJson1.ts
@@ -196,6 +196,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -1832,7 +1834,7 @@ export const deserializeAws_restJson1DescribeEndpointsCommand = async (
     contents.Endpoints = deserializeAws_restJson1__listOfEndpoint(data.endpoints, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2402,7 +2404,7 @@ export const deserializeAws_restJson1ListJobsCommand = async (
     contents.Jobs = deserializeAws_restJson1__listOfJob(data.jobs, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2501,7 +2503,7 @@ export const deserializeAws_restJson1ListJobTemplatesCommand = async (
     contents.JobTemplates = deserializeAws_restJson1__listOfJobTemplate(data.jobTemplates, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2597,7 +2599,7 @@ export const deserializeAws_restJson1ListPresetsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   if (data.presets !== undefined && data.presets !== null) {
     contents.Presets = deserializeAws_restJson1__listOfPreset(data.presets, context);
@@ -2696,7 +2698,7 @@ export const deserializeAws_restJson1ListQueuesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   if (data.queues !== undefined && data.queues !== null) {
     contents.Queues = deserializeAws_restJson1__listOfQueue(data.queues, context);
@@ -3355,7 +3357,7 @@ const deserializeAws_restJson1BadRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -3372,7 +3374,7 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -3389,7 +3391,7 @@ const deserializeAws_restJson1ForbiddenExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -3406,7 +3408,7 @@ const deserializeAws_restJson1InternalServerErrorExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -3423,7 +3425,7 @@ const deserializeAws_restJson1NotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -3440,7 +3442,7 @@ const deserializeAws_restJson1TooManyRequestsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -6398,7 +6400,7 @@ const deserializeAws_restJson1__listOf__doubleMinNegative60Max6 = (output: any, 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectNumber(entry) as any;
     });
 };
 
@@ -6409,7 +6411,7 @@ const deserializeAws_restJson1__listOf__integerMin1Max2147483647 = (output: any,
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectNumber(entry) as any;
     });
 };
 
@@ -6420,7 +6422,7 @@ const deserializeAws_restJson1__listOf__integerMin32Max8182 = (output: any, cont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectNumber(entry) as any;
     });
 };
 
@@ -6431,7 +6433,7 @@ const deserializeAws_restJson1__listOf__integerMinNegative60Max6 = (output: any,
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectNumber(entry) as any;
     });
 };
 
@@ -6442,7 +6444,7 @@ const deserializeAws_restJson1__listOf__string = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6453,7 +6455,7 @@ const deserializeAws_restJson1__listOf__stringMin1 = (output: any, context: __Se
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6467,7 +6469,7 @@ const deserializeAws_restJson1__listOf__stringMin36Max36Pattern09aFAF809aFAF409a
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6481,7 +6483,7 @@ const deserializeAws_restJson1__listOf__stringPattern09aFAF809aFAF409aFAF409aFAF
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6495,7 +6497,7 @@ const deserializeAws_restJson1__listOf__stringPatternS3ASSETMAPXml = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6601,7 +6603,7 @@ const deserializeAws_restJson1__listOfHlsAdMarkers = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6825,7 +6827,7 @@ const deserializeAws_restJson1__listOfTeletextPageType = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6836,7 +6838,7 @@ const deserializeAws_restJson1__mapOf__string = (output: any, context: __SerdeCo
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -6888,60 +6890,44 @@ const deserializeAws_restJson1__mapOfCaptionSelector = (
 
 const deserializeAws_restJson1AacSettings = (output: any, context: __SerdeContext): AacSettings => {
   return {
-    AudioDescriptionBroadcasterMix:
-      output.audioDescriptionBroadcasterMix !== undefined && output.audioDescriptionBroadcasterMix !== null
-        ? output.audioDescriptionBroadcasterMix
-        : undefined,
-    Bitrate: output.bitrate !== undefined && output.bitrate !== null ? output.bitrate : undefined,
-    CodecProfile: output.codecProfile !== undefined && output.codecProfile !== null ? output.codecProfile : undefined,
-    CodingMode: output.codingMode !== undefined && output.codingMode !== null ? output.codingMode : undefined,
-    RateControlMode:
-      output.rateControlMode !== undefined && output.rateControlMode !== null ? output.rateControlMode : undefined,
-    RawFormat: output.rawFormat !== undefined && output.rawFormat !== null ? output.rawFormat : undefined,
-    SampleRate: output.sampleRate !== undefined && output.sampleRate !== null ? output.sampleRate : undefined,
-    Specification:
-      output.specification !== undefined && output.specification !== null ? output.specification : undefined,
-    VbrQuality: output.vbrQuality !== undefined && output.vbrQuality !== null ? output.vbrQuality : undefined,
+    AudioDescriptionBroadcasterMix: __expectString(output.audioDescriptionBroadcasterMix),
+    Bitrate: __expectNumber(output.bitrate),
+    CodecProfile: __expectString(output.codecProfile),
+    CodingMode: __expectString(output.codingMode),
+    RateControlMode: __expectString(output.rateControlMode),
+    RawFormat: __expectString(output.rawFormat),
+    SampleRate: __expectNumber(output.sampleRate),
+    Specification: __expectString(output.specification),
+    VbrQuality: __expectString(output.vbrQuality),
   } as any;
 };
 
 const deserializeAws_restJson1Ac3Settings = (output: any, context: __SerdeContext): Ac3Settings => {
   return {
-    Bitrate: output.bitrate !== undefined && output.bitrate !== null ? output.bitrate : undefined,
-    BitstreamMode:
-      output.bitstreamMode !== undefined && output.bitstreamMode !== null ? output.bitstreamMode : undefined,
-    CodingMode: output.codingMode !== undefined && output.codingMode !== null ? output.codingMode : undefined,
-    Dialnorm: output.dialnorm !== undefined && output.dialnorm !== null ? output.dialnorm : undefined,
-    DynamicRangeCompressionLine:
-      output.dynamicRangeCompressionLine !== undefined && output.dynamicRangeCompressionLine !== null
-        ? output.dynamicRangeCompressionLine
-        : undefined,
-    DynamicRangeCompressionProfile:
-      output.dynamicRangeCompressionProfile !== undefined && output.dynamicRangeCompressionProfile !== null
-        ? output.dynamicRangeCompressionProfile
-        : undefined,
-    DynamicRangeCompressionRf:
-      output.dynamicRangeCompressionRf !== undefined && output.dynamicRangeCompressionRf !== null
-        ? output.dynamicRangeCompressionRf
-        : undefined,
-    LfeFilter: output.lfeFilter !== undefined && output.lfeFilter !== null ? output.lfeFilter : undefined,
-    MetadataControl:
-      output.metadataControl !== undefined && output.metadataControl !== null ? output.metadataControl : undefined,
-    SampleRate: output.sampleRate !== undefined && output.sampleRate !== null ? output.sampleRate : undefined,
+    Bitrate: __expectNumber(output.bitrate),
+    BitstreamMode: __expectString(output.bitstreamMode),
+    CodingMode: __expectString(output.codingMode),
+    Dialnorm: __expectNumber(output.dialnorm),
+    DynamicRangeCompressionLine: __expectString(output.dynamicRangeCompressionLine),
+    DynamicRangeCompressionProfile: __expectString(output.dynamicRangeCompressionProfile),
+    DynamicRangeCompressionRf: __expectString(output.dynamicRangeCompressionRf),
+    LfeFilter: __expectString(output.lfeFilter),
+    MetadataControl: __expectString(output.metadataControl),
+    SampleRate: __expectNumber(output.sampleRate),
   } as any;
 };
 
 const deserializeAws_restJson1AccelerationSettings = (output: any, context: __SerdeContext): AccelerationSettings => {
   return {
-    Mode: output.mode !== undefined && output.mode !== null ? output.mode : undefined,
+    Mode: __expectString(output.mode),
   } as any;
 };
 
 const deserializeAws_restJson1AiffSettings = (output: any, context: __SerdeContext): AiffSettings => {
   return {
-    BitDepth: output.bitDepth !== undefined && output.bitDepth !== null ? output.bitDepth : undefined,
-    Channels: output.channels !== undefined && output.channels !== null ? output.channels : undefined,
-    SampleRate: output.sampleRate !== undefined && output.sampleRate !== null ? output.sampleRate : undefined,
+    BitDepth: __expectNumber(output.bitDepth),
+    Channels: __expectNumber(output.channels),
+    SampleRate: __expectNumber(output.sampleRate),
   } as any;
 };
 
@@ -6950,16 +6936,9 @@ const deserializeAws_restJson1AncillarySourceSettings = (
   context: __SerdeContext
 ): AncillarySourceSettings => {
   return {
-    Convert608To708:
-      output.convert608To708 !== undefined && output.convert608To708 !== null ? output.convert608To708 : undefined,
-    SourceAncillaryChannelNumber:
-      output.sourceAncillaryChannelNumber !== undefined && output.sourceAncillaryChannelNumber !== null
-        ? output.sourceAncillaryChannelNumber
-        : undefined,
-    TerminateCaptions:
-      output.terminateCaptions !== undefined && output.terminateCaptions !== null
-        ? output.terminateCaptions
-        : undefined,
+    Convert608To708: __expectString(output.convert608To708),
+    SourceAncillaryChannelNumber: __expectNumber(output.sourceAncillaryChannelNumber),
+    TerminateCaptions: __expectString(output.terminateCaptions),
   } as any;
 };
 
@@ -6968,7 +6947,7 @@ const deserializeAws_restJson1AudioChannelTaggingSettings = (
   context: __SerdeContext
 ): AudioChannelTaggingSettings => {
   return {
-    ChannelTag: output.channelTag !== undefined && output.channelTag !== null ? output.channelTag : undefined,
+    ChannelTag: __expectString(output.channelTag),
   } as any;
 };
 
@@ -6986,7 +6965,7 @@ const deserializeAws_restJson1AudioCodecSettings = (output: any, context: __Serd
       output.aiffSettings !== undefined && output.aiffSettings !== null
         ? deserializeAws_restJson1AiffSettings(output.aiffSettings, context)
         : undefined,
-    Codec: output.codec !== undefined && output.codec !== null ? output.codec : undefined,
+    Codec: __expectString(output.codec),
     Eac3AtmosSettings:
       output.eac3AtmosSettings !== undefined && output.eac3AtmosSettings !== null
         ? deserializeAws_restJson1Eac3AtmosSettings(output.eac3AtmosSettings, context)
@@ -7028,29 +7007,21 @@ const deserializeAws_restJson1AudioDescription = (output: any, context: __SerdeC
       output.audioNormalizationSettings !== undefined && output.audioNormalizationSettings !== null
         ? deserializeAws_restJson1AudioNormalizationSettings(output.audioNormalizationSettings, context)
         : undefined,
-    AudioSourceName:
-      output.audioSourceName !== undefined && output.audioSourceName !== null ? output.audioSourceName : undefined,
-    AudioType: output.audioType !== undefined && output.audioType !== null ? output.audioType : undefined,
-    AudioTypeControl:
-      output.audioTypeControl !== undefined && output.audioTypeControl !== null ? output.audioTypeControl : undefined,
+    AudioSourceName: __expectString(output.audioSourceName),
+    AudioType: __expectNumber(output.audioType),
+    AudioTypeControl: __expectString(output.audioTypeControl),
     CodecSettings:
       output.codecSettings !== undefined && output.codecSettings !== null
         ? deserializeAws_restJson1AudioCodecSettings(output.codecSettings, context)
         : undefined,
-    CustomLanguageCode:
-      output.customLanguageCode !== undefined && output.customLanguageCode !== null
-        ? output.customLanguageCode
-        : undefined,
-    LanguageCode: output.languageCode !== undefined && output.languageCode !== null ? output.languageCode : undefined,
-    LanguageCodeControl:
-      output.languageCodeControl !== undefined && output.languageCodeControl !== null
-        ? output.languageCodeControl
-        : undefined,
+    CustomLanguageCode: __expectString(output.customLanguageCode),
+    LanguageCode: __expectString(output.languageCode),
+    LanguageCodeControl: __expectString(output.languageCodeControl),
     RemixSettings:
       output.remixSettings !== undefined && output.remixSettings !== null
         ? deserializeAws_restJson1RemixSettings(output.remixSettings, context)
         : undefined,
-    StreamName: output.streamName !== undefined && output.streamName !== null ? output.streamName : undefined,
+    StreamName: __expectString(output.streamName),
   } as any;
 };
 
@@ -7059,46 +7030,32 @@ const deserializeAws_restJson1AudioNormalizationSettings = (
   context: __SerdeContext
 ): AudioNormalizationSettings => {
   return {
-    Algorithm: output.algorithm !== undefined && output.algorithm !== null ? output.algorithm : undefined,
-    AlgorithmControl:
-      output.algorithmControl !== undefined && output.algorithmControl !== null ? output.algorithmControl : undefined,
-    CorrectionGateLevel:
-      output.correctionGateLevel !== undefined && output.correctionGateLevel !== null
-        ? output.correctionGateLevel
-        : undefined,
-    LoudnessLogging:
-      output.loudnessLogging !== undefined && output.loudnessLogging !== null ? output.loudnessLogging : undefined,
-    PeakCalculation:
-      output.peakCalculation !== undefined && output.peakCalculation !== null ? output.peakCalculation : undefined,
-    TargetLkfs: output.targetLkfs !== undefined && output.targetLkfs !== null ? output.targetLkfs : undefined,
+    Algorithm: __expectString(output.algorithm),
+    AlgorithmControl: __expectString(output.algorithmControl),
+    CorrectionGateLevel: __expectNumber(output.correctionGateLevel),
+    LoudnessLogging: __expectString(output.loudnessLogging),
+    PeakCalculation: __expectString(output.peakCalculation),
+    TargetLkfs: __expectNumber(output.targetLkfs),
   } as any;
 };
 
 const deserializeAws_restJson1AudioSelector = (output: any, context: __SerdeContext): AudioSelector => {
   return {
-    CustomLanguageCode:
-      output.customLanguageCode !== undefined && output.customLanguageCode !== null
-        ? output.customLanguageCode
-        : undefined,
-    DefaultSelection:
-      output.defaultSelection !== undefined && output.defaultSelection !== null ? output.defaultSelection : undefined,
-    ExternalAudioFileInput:
-      output.externalAudioFileInput !== undefined && output.externalAudioFileInput !== null
-        ? output.externalAudioFileInput
-        : undefined,
-    LanguageCode: output.languageCode !== undefined && output.languageCode !== null ? output.languageCode : undefined,
-    Offset: output.offset !== undefined && output.offset !== null ? output.offset : undefined,
+    CustomLanguageCode: __expectString(output.customLanguageCode),
+    DefaultSelection: __expectString(output.defaultSelection),
+    ExternalAudioFileInput: __expectString(output.externalAudioFileInput),
+    LanguageCode: __expectString(output.languageCode),
+    Offset: __expectNumber(output.offset),
     Pids:
       output.pids !== undefined && output.pids !== null
         ? deserializeAws_restJson1__listOf__integerMin1Max2147483647(output.pids, context)
         : undefined,
-    ProgramSelection:
-      output.programSelection !== undefined && output.programSelection !== null ? output.programSelection : undefined,
+    ProgramSelection: __expectNumber(output.programSelection),
     RemixSettings:
       output.remixSettings !== undefined && output.remixSettings !== null
         ? deserializeAws_restJson1RemixSettings(output.remixSettings, context)
         : undefined,
-    SelectorType: output.selectorType !== undefined && output.selectorType !== null ? output.selectorType : undefined,
+    SelectorType: __expectString(output.selectorType),
     Tracks:
       output.tracks !== undefined && output.tracks !== null
         ? deserializeAws_restJson1__listOf__integerMin1Max2147483647(output.tracks, context)
@@ -7117,12 +7074,9 @@ const deserializeAws_restJson1AudioSelectorGroup = (output: any, context: __Serd
 
 const deserializeAws_restJson1AutomatedAbrSettings = (output: any, context: __SerdeContext): AutomatedAbrSettings => {
   return {
-    MaxAbrBitrate:
-      output.maxAbrBitrate !== undefined && output.maxAbrBitrate !== null ? output.maxAbrBitrate : undefined,
-    MaxRenditions:
-      output.maxRenditions !== undefined && output.maxRenditions !== null ? output.maxRenditions : undefined,
-    MinAbrBitrate:
-      output.minAbrBitrate !== undefined && output.minAbrBitrate !== null ? output.minAbrBitrate : undefined,
+    MaxAbrBitrate: __expectNumber(output.maxAbrBitrate),
+    MaxRenditions: __expectNumber(output.maxRenditions),
+    MinAbrBitrate: __expectNumber(output.minAbrBitrate),
   } as any;
 };
 
@@ -7140,103 +7094,58 @@ const deserializeAws_restJson1AutomatedEncodingSettings = (
 
 const deserializeAws_restJson1Av1QvbrSettings = (output: any, context: __SerdeContext): Av1QvbrSettings => {
   return {
-    QvbrQualityLevel:
-      output.qvbrQualityLevel !== undefined && output.qvbrQualityLevel !== null ? output.qvbrQualityLevel : undefined,
-    QvbrQualityLevelFineTune:
-      output.qvbrQualityLevelFineTune !== undefined && output.qvbrQualityLevelFineTune !== null
-        ? output.qvbrQualityLevelFineTune
-        : undefined,
+    QvbrQualityLevel: __expectNumber(output.qvbrQualityLevel),
+    QvbrQualityLevelFineTune: __expectNumber(output.qvbrQualityLevelFineTune),
   } as any;
 };
 
 const deserializeAws_restJson1Av1Settings = (output: any, context: __SerdeContext): Av1Settings => {
   return {
-    AdaptiveQuantization:
-      output.adaptiveQuantization !== undefined && output.adaptiveQuantization !== null
-        ? output.adaptiveQuantization
-        : undefined,
-    FramerateControl:
-      output.framerateControl !== undefined && output.framerateControl !== null ? output.framerateControl : undefined,
-    FramerateConversionAlgorithm:
-      output.framerateConversionAlgorithm !== undefined && output.framerateConversionAlgorithm !== null
-        ? output.framerateConversionAlgorithm
-        : undefined,
-    FramerateDenominator:
-      output.framerateDenominator !== undefined && output.framerateDenominator !== null
-        ? output.framerateDenominator
-        : undefined,
-    FramerateNumerator:
-      output.framerateNumerator !== undefined && output.framerateNumerator !== null
-        ? output.framerateNumerator
-        : undefined,
-    GopSize: output.gopSize !== undefined && output.gopSize !== null ? output.gopSize : undefined,
-    MaxBitrate: output.maxBitrate !== undefined && output.maxBitrate !== null ? output.maxBitrate : undefined,
-    NumberBFramesBetweenReferenceFrames:
-      output.numberBFramesBetweenReferenceFrames !== undefined && output.numberBFramesBetweenReferenceFrames !== null
-        ? output.numberBFramesBetweenReferenceFrames
-        : undefined,
+    AdaptiveQuantization: __expectString(output.adaptiveQuantization),
+    FramerateControl: __expectString(output.framerateControl),
+    FramerateConversionAlgorithm: __expectString(output.framerateConversionAlgorithm),
+    FramerateDenominator: __expectNumber(output.framerateDenominator),
+    FramerateNumerator: __expectNumber(output.framerateNumerator),
+    GopSize: __expectNumber(output.gopSize),
+    MaxBitrate: __expectNumber(output.maxBitrate),
+    NumberBFramesBetweenReferenceFrames: __expectNumber(output.numberBFramesBetweenReferenceFrames),
     QvbrSettings:
       output.qvbrSettings !== undefined && output.qvbrSettings !== null
         ? deserializeAws_restJson1Av1QvbrSettings(output.qvbrSettings, context)
         : undefined,
-    RateControlMode:
-      output.rateControlMode !== undefined && output.rateControlMode !== null ? output.rateControlMode : undefined,
-    Slices: output.slices !== undefined && output.slices !== null ? output.slices : undefined,
-    SpatialAdaptiveQuantization:
-      output.spatialAdaptiveQuantization !== undefined && output.spatialAdaptiveQuantization !== null
-        ? output.spatialAdaptiveQuantization
-        : undefined,
+    RateControlMode: __expectString(output.rateControlMode),
+    Slices: __expectNumber(output.slices),
+    SpatialAdaptiveQuantization: __expectString(output.spatialAdaptiveQuantization),
   } as any;
 };
 
 const deserializeAws_restJson1AvailBlanking = (output: any, context: __SerdeContext): AvailBlanking => {
   return {
-    AvailBlankingImage:
-      output.availBlankingImage !== undefined && output.availBlankingImage !== null
-        ? output.availBlankingImage
-        : undefined,
+    AvailBlankingImage: __expectString(output.availBlankingImage),
   } as any;
 };
 
 const deserializeAws_restJson1AvcIntraSettings = (output: any, context: __SerdeContext): AvcIntraSettings => {
   return {
-    AvcIntraClass:
-      output.avcIntraClass !== undefined && output.avcIntraClass !== null ? output.avcIntraClass : undefined,
+    AvcIntraClass: __expectString(output.avcIntraClass),
     AvcIntraUhdSettings:
       output.avcIntraUhdSettings !== undefined && output.avcIntraUhdSettings !== null
         ? deserializeAws_restJson1AvcIntraUhdSettings(output.avcIntraUhdSettings, context)
         : undefined,
-    FramerateControl:
-      output.framerateControl !== undefined && output.framerateControl !== null ? output.framerateControl : undefined,
-    FramerateConversionAlgorithm:
-      output.framerateConversionAlgorithm !== undefined && output.framerateConversionAlgorithm !== null
-        ? output.framerateConversionAlgorithm
-        : undefined,
-    FramerateDenominator:
-      output.framerateDenominator !== undefined && output.framerateDenominator !== null
-        ? output.framerateDenominator
-        : undefined,
-    FramerateNumerator:
-      output.framerateNumerator !== undefined && output.framerateNumerator !== null
-        ? output.framerateNumerator
-        : undefined,
-    InterlaceMode:
-      output.interlaceMode !== undefined && output.interlaceMode !== null ? output.interlaceMode : undefined,
-    ScanTypeConversionMode:
-      output.scanTypeConversionMode !== undefined && output.scanTypeConversionMode !== null
-        ? output.scanTypeConversionMode
-        : undefined,
-    SlowPal: output.slowPal !== undefined && output.slowPal !== null ? output.slowPal : undefined,
-    Telecine: output.telecine !== undefined && output.telecine !== null ? output.telecine : undefined,
+    FramerateControl: __expectString(output.framerateControl),
+    FramerateConversionAlgorithm: __expectString(output.framerateConversionAlgorithm),
+    FramerateDenominator: __expectNumber(output.framerateDenominator),
+    FramerateNumerator: __expectNumber(output.framerateNumerator),
+    InterlaceMode: __expectString(output.interlaceMode),
+    ScanTypeConversionMode: __expectString(output.scanTypeConversionMode),
+    SlowPal: __expectString(output.slowPal),
+    Telecine: __expectString(output.telecine),
   } as any;
 };
 
 const deserializeAws_restJson1AvcIntraUhdSettings = (output: any, context: __SerdeContext): AvcIntraUhdSettings => {
   return {
-    QualityTuningLevel:
-      output.qualityTuningLevel !== undefined && output.qualityTuningLevel !== null
-        ? output.qualityTuningLevel
-        : undefined,
+    QualityTuningLevel: __expectString(output.qualityTuningLevel),
   } as any;
 };
 
@@ -7245,54 +7154,36 @@ const deserializeAws_restJson1BurninDestinationSettings = (
   context: __SerdeContext
 ): BurninDestinationSettings => {
   return {
-    Alignment: output.alignment !== undefined && output.alignment !== null ? output.alignment : undefined,
-    BackgroundColor:
-      output.backgroundColor !== undefined && output.backgroundColor !== null ? output.backgroundColor : undefined,
-    BackgroundOpacity:
-      output.backgroundOpacity !== undefined && output.backgroundOpacity !== null
-        ? output.backgroundOpacity
-        : undefined,
-    FontColor: output.fontColor !== undefined && output.fontColor !== null ? output.fontColor : undefined,
-    FontOpacity: output.fontOpacity !== undefined && output.fontOpacity !== null ? output.fontOpacity : undefined,
-    FontResolution:
-      output.fontResolution !== undefined && output.fontResolution !== null ? output.fontResolution : undefined,
-    FontScript: output.fontScript !== undefined && output.fontScript !== null ? output.fontScript : undefined,
-    FontSize: output.fontSize !== undefined && output.fontSize !== null ? output.fontSize : undefined,
-    OutlineColor: output.outlineColor !== undefined && output.outlineColor !== null ? output.outlineColor : undefined,
-    OutlineSize: output.outlineSize !== undefined && output.outlineSize !== null ? output.outlineSize : undefined,
-    ShadowColor: output.shadowColor !== undefined && output.shadowColor !== null ? output.shadowColor : undefined,
-    ShadowOpacity:
-      output.shadowOpacity !== undefined && output.shadowOpacity !== null ? output.shadowOpacity : undefined,
-    ShadowXOffset:
-      output.shadowXOffset !== undefined && output.shadowXOffset !== null ? output.shadowXOffset : undefined,
-    ShadowYOffset:
-      output.shadowYOffset !== undefined && output.shadowYOffset !== null ? output.shadowYOffset : undefined,
-    TeletextSpacing:
-      output.teletextSpacing !== undefined && output.teletextSpacing !== null ? output.teletextSpacing : undefined,
-    XPosition: output.xPosition !== undefined && output.xPosition !== null ? output.xPosition : undefined,
-    YPosition: output.yPosition !== undefined && output.yPosition !== null ? output.yPosition : undefined,
+    Alignment: __expectString(output.alignment),
+    BackgroundColor: __expectString(output.backgroundColor),
+    BackgroundOpacity: __expectNumber(output.backgroundOpacity),
+    FontColor: __expectString(output.fontColor),
+    FontOpacity: __expectNumber(output.fontOpacity),
+    FontResolution: __expectNumber(output.fontResolution),
+    FontScript: __expectString(output.fontScript),
+    FontSize: __expectNumber(output.fontSize),
+    OutlineColor: __expectString(output.outlineColor),
+    OutlineSize: __expectNumber(output.outlineSize),
+    ShadowColor: __expectString(output.shadowColor),
+    ShadowOpacity: __expectNumber(output.shadowOpacity),
+    ShadowXOffset: __expectNumber(output.shadowXOffset),
+    ShadowYOffset: __expectNumber(output.shadowYOffset),
+    TeletextSpacing: __expectString(output.teletextSpacing),
+    XPosition: __expectNumber(output.xPosition),
+    YPosition: __expectNumber(output.yPosition),
   } as any;
 };
 
 const deserializeAws_restJson1CaptionDescription = (output: any, context: __SerdeContext): CaptionDescription => {
   return {
-    CaptionSelectorName:
-      output.captionSelectorName !== undefined && output.captionSelectorName !== null
-        ? output.captionSelectorName
-        : undefined,
-    CustomLanguageCode:
-      output.customLanguageCode !== undefined && output.customLanguageCode !== null
-        ? output.customLanguageCode
-        : undefined,
+    CaptionSelectorName: __expectString(output.captionSelectorName),
+    CustomLanguageCode: __expectString(output.customLanguageCode),
     DestinationSettings:
       output.destinationSettings !== undefined && output.destinationSettings !== null
         ? deserializeAws_restJson1CaptionDestinationSettings(output.destinationSettings, context)
         : undefined,
-    LanguageCode: output.languageCode !== undefined && output.languageCode !== null ? output.languageCode : undefined,
-    LanguageDescription:
-      output.languageDescription !== undefined && output.languageDescription !== null
-        ? output.languageDescription
-        : undefined,
+    LanguageCode: __expectString(output.languageCode),
+    LanguageDescription: __expectString(output.languageDescription),
   } as any;
 };
 
@@ -7301,19 +7192,13 @@ const deserializeAws_restJson1CaptionDescriptionPreset = (
   context: __SerdeContext
 ): CaptionDescriptionPreset => {
   return {
-    CustomLanguageCode:
-      output.customLanguageCode !== undefined && output.customLanguageCode !== null
-        ? output.customLanguageCode
-        : undefined,
+    CustomLanguageCode: __expectString(output.customLanguageCode),
     DestinationSettings:
       output.destinationSettings !== undefined && output.destinationSettings !== null
         ? deserializeAws_restJson1CaptionDestinationSettings(output.destinationSettings, context)
         : undefined,
-    LanguageCode: output.languageCode !== undefined && output.languageCode !== null ? output.languageCode : undefined,
-    LanguageDescription:
-      output.languageDescription !== undefined && output.languageDescription !== null
-        ? output.languageDescription
-        : undefined,
+    LanguageCode: __expectString(output.languageCode),
+    LanguageDescription: __expectString(output.languageDescription),
   } as any;
 };
 
@@ -7326,8 +7211,7 @@ const deserializeAws_restJson1CaptionDestinationSettings = (
       output.burninDestinationSettings !== undefined && output.burninDestinationSettings !== null
         ? deserializeAws_restJson1BurninDestinationSettings(output.burninDestinationSettings, context)
         : undefined,
-    DestinationType:
-      output.destinationType !== undefined && output.destinationType !== null ? output.destinationType : undefined,
+    DestinationType: __expectString(output.destinationType),
     DvbSubDestinationSettings:
       output.dvbSubDestinationSettings !== undefined && output.dvbSubDestinationSettings !== null
         ? deserializeAws_restJson1DvbSubDestinationSettings(output.dvbSubDestinationSettings, context)
@@ -7361,11 +7245,8 @@ const deserializeAws_restJson1CaptionDestinationSettings = (
 
 const deserializeAws_restJson1CaptionSelector = (output: any, context: __SerdeContext): CaptionSelector => {
   return {
-    CustomLanguageCode:
-      output.customLanguageCode !== undefined && output.customLanguageCode !== null
-        ? output.customLanguageCode
-        : undefined,
-    LanguageCode: output.languageCode !== undefined && output.languageCode !== null ? output.languageCode : undefined,
+    CustomLanguageCode: __expectString(output.customLanguageCode),
+    LanguageCode: __expectString(output.languageCode),
     SourceSettings:
       output.sourceSettings !== undefined && output.sourceSettings !== null
         ? deserializeAws_restJson1CaptionSourceSettings(output.sourceSettings, context)
@@ -7378,14 +7259,8 @@ const deserializeAws_restJson1CaptionSourceFramerate = (
   context: __SerdeContext
 ): CaptionSourceFramerate => {
   return {
-    FramerateDenominator:
-      output.framerateDenominator !== undefined && output.framerateDenominator !== null
-        ? output.framerateDenominator
-        : undefined,
-    FramerateNumerator:
-      output.framerateNumerator !== undefined && output.framerateNumerator !== null
-        ? output.framerateNumerator
-        : undefined,
+    FramerateDenominator: __expectNumber(output.framerateDenominator),
+    FramerateNumerator: __expectNumber(output.framerateNumerator),
   } as any;
 };
 
@@ -7407,7 +7282,7 @@ const deserializeAws_restJson1CaptionSourceSettings = (output: any, context: __S
       output.fileSourceSettings !== undefined && output.fileSourceSettings !== null
         ? deserializeAws_restJson1FileSourceSettings(output.fileSourceSettings, context)
         : undefined,
-    SourceType: output.sourceType !== undefined && output.sourceType !== null ? output.sourceType : undefined,
+    SourceType: __expectString(output.sourceType),
     TeletextSourceSettings:
       output.teletextSourceSettings !== undefined && output.teletextSourceSettings !== null
         ? deserializeAws_restJson1TeletextSourceSettings(output.teletextSourceSettings, context)
@@ -7433,10 +7308,7 @@ const deserializeAws_restJson1CmafAdditionalManifest = (
   context: __SerdeContext
 ): CmafAdditionalManifest => {
   return {
-    ManifestNameModifier:
-      output.manifestNameModifier !== undefined && output.manifestNameModifier !== null
-        ? output.manifestNameModifier
-        : undefined,
+    ManifestNameModifier: __expectString(output.manifestNameModifier),
     SelectedOutputs:
       output.selectedOutputs !== undefined && output.selectedOutputs !== null
         ? deserializeAws_restJson1__listOf__stringMin1(output.selectedOutputs, context)
@@ -7449,16 +7321,9 @@ const deserializeAws_restJson1CmafEncryptionSettings = (
   context: __SerdeContext
 ): CmafEncryptionSettings => {
   return {
-    ConstantInitializationVector:
-      output.constantInitializationVector !== undefined && output.constantInitializationVector !== null
-        ? output.constantInitializationVector
-        : undefined,
-    EncryptionMethod:
-      output.encryptionMethod !== undefined && output.encryptionMethod !== null ? output.encryptionMethod : undefined,
-    InitializationVectorInManifest:
-      output.initializationVectorInManifest !== undefined && output.initializationVectorInManifest !== null
-        ? output.initializationVectorInManifest
-        : undefined,
+    ConstantInitializationVector: __expectString(output.constantInitializationVector),
+    EncryptionMethod: __expectString(output.encryptionMethod),
+    InitializationVectorInManifest: __expectString(output.initializationVectorInManifest),
     SpekeKeyProvider:
       output.spekeKeyProvider !== undefined && output.spekeKeyProvider !== null
         ? deserializeAws_restJson1SpekeKeyProviderCmaf(output.spekeKeyProvider, context)
@@ -7467,7 +7332,7 @@ const deserializeAws_restJson1CmafEncryptionSettings = (
       output.staticKeyProvider !== undefined && output.staticKeyProvider !== null
         ? deserializeAws_restJson1StaticKeyProvider(output.staticKeyProvider, context)
         : undefined,
-    Type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    Type: __expectString(output.type),
   } as any;
 };
 
@@ -7477,13 +7342,10 @@ const deserializeAws_restJson1CmafGroupSettings = (output: any, context: __Serde
       output.additionalManifests !== undefined && output.additionalManifests !== null
         ? deserializeAws_restJson1__listOfCmafAdditionalManifest(output.additionalManifests, context)
         : undefined,
-    BaseUrl: output.baseUrl !== undefined && output.baseUrl !== null ? output.baseUrl : undefined,
-    ClientCache: output.clientCache !== undefined && output.clientCache !== null ? output.clientCache : undefined,
-    CodecSpecification:
-      output.codecSpecification !== undefined && output.codecSpecification !== null
-        ? output.codecSpecification
-        : undefined,
-    Destination: output.destination !== undefined && output.destination !== null ? output.destination : undefined,
+    BaseUrl: __expectString(output.baseUrl),
+    ClientCache: __expectString(output.clientCache),
+    CodecSpecification: __expectString(output.codecSpecification),
+    Destination: __expectString(output.destination),
     DestinationSettings:
       output.destinationSettings !== undefined && output.destinationSettings !== null
         ? deserializeAws_restJson1DestinationSettings(output.destinationSettings, context)
@@ -7492,86 +7354,46 @@ const deserializeAws_restJson1CmafGroupSettings = (output: any, context: __Serde
       output.encryption !== undefined && output.encryption !== null
         ? deserializeAws_restJson1CmafEncryptionSettings(output.encryption, context)
         : undefined,
-    FragmentLength:
-      output.fragmentLength !== undefined && output.fragmentLength !== null ? output.fragmentLength : undefined,
-    ManifestCompression:
-      output.manifestCompression !== undefined && output.manifestCompression !== null
-        ? output.manifestCompression
-        : undefined,
-    ManifestDurationFormat:
-      output.manifestDurationFormat !== undefined && output.manifestDurationFormat !== null
-        ? output.manifestDurationFormat
-        : undefined,
-    MinBufferTime:
-      output.minBufferTime !== undefined && output.minBufferTime !== null ? output.minBufferTime : undefined,
-    MinFinalSegmentLength:
-      output.minFinalSegmentLength !== undefined && output.minFinalSegmentLength !== null
-        ? output.minFinalSegmentLength
-        : undefined,
-    MpdProfile: output.mpdProfile !== undefined && output.mpdProfile !== null ? output.mpdProfile : undefined,
-    PtsOffsetHandlingForBFrames:
-      output.ptsOffsetHandlingForBFrames !== undefined && output.ptsOffsetHandlingForBFrames !== null
-        ? output.ptsOffsetHandlingForBFrames
-        : undefined,
-    SegmentControl:
-      output.segmentControl !== undefined && output.segmentControl !== null ? output.segmentControl : undefined,
-    SegmentLength:
-      output.segmentLength !== undefined && output.segmentLength !== null ? output.segmentLength : undefined,
-    StreamInfResolution:
-      output.streamInfResolution !== undefined && output.streamInfResolution !== null
-        ? output.streamInfResolution
-        : undefined,
-    WriteDashManifest:
-      output.writeDashManifest !== undefined && output.writeDashManifest !== null
-        ? output.writeDashManifest
-        : undefined,
-    WriteHlsManifest:
-      output.writeHlsManifest !== undefined && output.writeHlsManifest !== null ? output.writeHlsManifest : undefined,
-    WriteSegmentTimelineInRepresentation:
-      output.writeSegmentTimelineInRepresentation !== undefined && output.writeSegmentTimelineInRepresentation !== null
-        ? output.writeSegmentTimelineInRepresentation
-        : undefined,
+    FragmentLength: __expectNumber(output.fragmentLength),
+    ManifestCompression: __expectString(output.manifestCompression),
+    ManifestDurationFormat: __expectString(output.manifestDurationFormat),
+    MinBufferTime: __expectNumber(output.minBufferTime),
+    MinFinalSegmentLength: __expectNumber(output.minFinalSegmentLength),
+    MpdProfile: __expectString(output.mpdProfile),
+    PtsOffsetHandlingForBFrames: __expectString(output.ptsOffsetHandlingForBFrames),
+    SegmentControl: __expectString(output.segmentControl),
+    SegmentLength: __expectNumber(output.segmentLength),
+    StreamInfResolution: __expectString(output.streamInfResolution),
+    WriteDashManifest: __expectString(output.writeDashManifest),
+    WriteHlsManifest: __expectString(output.writeHlsManifest),
+    WriteSegmentTimelineInRepresentation: __expectString(output.writeSegmentTimelineInRepresentation),
   } as any;
 };
 
 const deserializeAws_restJson1CmfcSettings = (output: any, context: __SerdeContext): CmfcSettings => {
   return {
-    AudioDuration:
-      output.audioDuration !== undefined && output.audioDuration !== null ? output.audioDuration : undefined,
-    AudioGroupId: output.audioGroupId !== undefined && output.audioGroupId !== null ? output.audioGroupId : undefined,
-    AudioRenditionSets:
-      output.audioRenditionSets !== undefined && output.audioRenditionSets !== null
-        ? output.audioRenditionSets
-        : undefined,
-    AudioTrackType:
-      output.audioTrackType !== undefined && output.audioTrackType !== null ? output.audioTrackType : undefined,
-    DescriptiveVideoServiceFlag:
-      output.descriptiveVideoServiceFlag !== undefined && output.descriptiveVideoServiceFlag !== null
-        ? output.descriptiveVideoServiceFlag
-        : undefined,
-    IFrameOnlyManifest:
-      output.iFrameOnlyManifest !== undefined && output.iFrameOnlyManifest !== null
-        ? output.iFrameOnlyManifest
-        : undefined,
-    Scte35Esam: output.scte35Esam !== undefined && output.scte35Esam !== null ? output.scte35Esam : undefined,
-    Scte35Source: output.scte35Source !== undefined && output.scte35Source !== null ? output.scte35Source : undefined,
+    AudioDuration: __expectString(output.audioDuration),
+    AudioGroupId: __expectString(output.audioGroupId),
+    AudioRenditionSets: __expectString(output.audioRenditionSets),
+    AudioTrackType: __expectString(output.audioTrackType),
+    DescriptiveVideoServiceFlag: __expectString(output.descriptiveVideoServiceFlag),
+    IFrameOnlyManifest: __expectString(output.iFrameOnlyManifest),
+    Scte35Esam: __expectString(output.scte35Esam),
+    Scte35Source: __expectString(output.scte35Source),
   } as any;
 };
 
 const deserializeAws_restJson1ColorCorrector = (output: any, context: __SerdeContext): ColorCorrector => {
   return {
-    Brightness: output.brightness !== undefined && output.brightness !== null ? output.brightness : undefined,
-    ColorSpaceConversion:
-      output.colorSpaceConversion !== undefined && output.colorSpaceConversion !== null
-        ? output.colorSpaceConversion
-        : undefined,
-    Contrast: output.contrast !== undefined && output.contrast !== null ? output.contrast : undefined,
+    Brightness: __expectNumber(output.brightness),
+    ColorSpaceConversion: __expectString(output.colorSpaceConversion),
+    Contrast: __expectNumber(output.contrast),
     Hdr10Metadata:
       output.hdr10Metadata !== undefined && output.hdr10Metadata !== null
         ? deserializeAws_restJson1Hdr10Metadata(output.hdr10Metadata, context)
         : undefined,
-    Hue: output.hue !== undefined && output.hue !== null ? output.hue : undefined,
-    Saturation: output.saturation !== undefined && output.saturation !== null ? output.saturation : undefined,
+    Hue: __expectNumber(output.hue),
+    Saturation: __expectNumber(output.saturation),
   } as any;
 };
 
@@ -7581,7 +7403,7 @@ const deserializeAws_restJson1ContainerSettings = (output: any, context: __Serde
       output.cmfcSettings !== undefined && output.cmfcSettings !== null
         ? deserializeAws_restJson1CmfcSettings(output.cmfcSettings, context)
         : undefined,
-    Container: output.container !== undefined && output.container !== null ? output.container : undefined,
+    Container: __expectString(output.container),
     F4vSettings:
       output.f4vSettings !== undefined && output.f4vSettings !== null
         ? deserializeAws_restJson1F4vSettings(output.f4vSettings, context)
@@ -7618,10 +7440,7 @@ const deserializeAws_restJson1DashAdditionalManifest = (
   context: __SerdeContext
 ): DashAdditionalManifest => {
   return {
-    ManifestNameModifier:
-      output.manifestNameModifier !== undefined && output.manifestNameModifier !== null
-        ? output.manifestNameModifier
-        : undefined,
+    ManifestNameModifier: __expectString(output.manifestNameModifier),
     SelectedOutputs:
       output.selectedOutputs !== undefined && output.selectedOutputs !== null
         ? deserializeAws_restJson1__listOf__stringMin1(output.selectedOutputs, context)
@@ -7634,10 +7453,7 @@ const deserializeAws_restJson1DashIsoEncryptionSettings = (
   context: __SerdeContext
 ): DashIsoEncryptionSettings => {
   return {
-    PlaybackDeviceCompatibility:
-      output.playbackDeviceCompatibility !== undefined && output.playbackDeviceCompatibility !== null
-        ? output.playbackDeviceCompatibility
-        : undefined,
+    PlaybackDeviceCompatibility: __expectString(output.playbackDeviceCompatibility),
     SpekeKeyProvider:
       output.spekeKeyProvider !== undefined && output.spekeKeyProvider !== null
         ? deserializeAws_restJson1SpekeKeyProvider(output.spekeKeyProvider, context)
@@ -7651,12 +7467,9 @@ const deserializeAws_restJson1DashIsoGroupSettings = (output: any, context: __Se
       output.additionalManifests !== undefined && output.additionalManifests !== null
         ? deserializeAws_restJson1__listOfDashAdditionalManifest(output.additionalManifests, context)
         : undefined,
-    AudioChannelConfigSchemeIdUri:
-      output.audioChannelConfigSchemeIdUri !== undefined && output.audioChannelConfigSchemeIdUri !== null
-        ? output.audioChannelConfigSchemeIdUri
-        : undefined,
-    BaseUrl: output.baseUrl !== undefined && output.baseUrl !== null ? output.baseUrl : undefined,
-    Destination: output.destination !== undefined && output.destination !== null ? output.destination : undefined,
+    AudioChannelConfigSchemeIdUri: __expectString(output.audioChannelConfigSchemeIdUri),
+    BaseUrl: __expectString(output.baseUrl),
+    Destination: __expectString(output.destination),
     DestinationSettings:
       output.destinationSettings !== undefined && output.destinationSettings !== null
         ? deserializeAws_restJson1DestinationSettings(output.destinationSettings, context)
@@ -7665,37 +7478,23 @@ const deserializeAws_restJson1DashIsoGroupSettings = (output: any, context: __Se
       output.encryption !== undefined && output.encryption !== null
         ? deserializeAws_restJson1DashIsoEncryptionSettings(output.encryption, context)
         : undefined,
-    FragmentLength:
-      output.fragmentLength !== undefined && output.fragmentLength !== null ? output.fragmentLength : undefined,
-    HbbtvCompliance:
-      output.hbbtvCompliance !== undefined && output.hbbtvCompliance !== null ? output.hbbtvCompliance : undefined,
-    MinBufferTime:
-      output.minBufferTime !== undefined && output.minBufferTime !== null ? output.minBufferTime : undefined,
-    MinFinalSegmentLength:
-      output.minFinalSegmentLength !== undefined && output.minFinalSegmentLength !== null
-        ? output.minFinalSegmentLength
-        : undefined,
-    MpdProfile: output.mpdProfile !== undefined && output.mpdProfile !== null ? output.mpdProfile : undefined,
-    PtsOffsetHandlingForBFrames:
-      output.ptsOffsetHandlingForBFrames !== undefined && output.ptsOffsetHandlingForBFrames !== null
-        ? output.ptsOffsetHandlingForBFrames
-        : undefined,
-    SegmentControl:
-      output.segmentControl !== undefined && output.segmentControl !== null ? output.segmentControl : undefined,
-    SegmentLength:
-      output.segmentLength !== undefined && output.segmentLength !== null ? output.segmentLength : undefined,
-    WriteSegmentTimelineInRepresentation:
-      output.writeSegmentTimelineInRepresentation !== undefined && output.writeSegmentTimelineInRepresentation !== null
-        ? output.writeSegmentTimelineInRepresentation
-        : undefined,
+    FragmentLength: __expectNumber(output.fragmentLength),
+    HbbtvCompliance: __expectString(output.hbbtvCompliance),
+    MinBufferTime: __expectNumber(output.minBufferTime),
+    MinFinalSegmentLength: __expectNumber(output.minFinalSegmentLength),
+    MpdProfile: __expectString(output.mpdProfile),
+    PtsOffsetHandlingForBFrames: __expectString(output.ptsOffsetHandlingForBFrames),
+    SegmentControl: __expectString(output.segmentControl),
+    SegmentLength: __expectNumber(output.segmentLength),
+    WriteSegmentTimelineInRepresentation: __expectString(output.writeSegmentTimelineInRepresentation),
   } as any;
 };
 
 const deserializeAws_restJson1Deinterlacer = (output: any, context: __SerdeContext): Deinterlacer => {
   return {
-    Algorithm: output.algorithm !== undefined && output.algorithm !== null ? output.algorithm : undefined,
-    Control: output.control !== undefined && output.control !== null ? output.control : undefined,
-    Mode: output.mode !== undefined && output.mode !== null ? output.mode : undefined,
+    Algorithm: __expectString(output.algorithm),
+    Control: __expectString(output.control),
+    Mode: __expectString(output.mode),
   } as any;
 };
 
@@ -7714,8 +7513,8 @@ const deserializeAws_restJson1DolbyVision = (output: any, context: __SerdeContex
       output.l6Metadata !== undefined && output.l6Metadata !== null
         ? deserializeAws_restJson1DolbyVisionLevel6Metadata(output.l6Metadata, context)
         : undefined,
-    L6Mode: output.l6Mode !== undefined && output.l6Mode !== null ? output.l6Mode : undefined,
-    Profile: output.profile !== undefined && output.profile !== null ? output.profile : undefined,
+    L6Mode: __expectString(output.l6Mode),
+    Profile: __expectString(output.profile),
   } as any;
 };
 
@@ -7724,28 +7523,25 @@ const deserializeAws_restJson1DolbyVisionLevel6Metadata = (
   context: __SerdeContext
 ): DolbyVisionLevel6Metadata => {
   return {
-    MaxCll: output.maxCll !== undefined && output.maxCll !== null ? output.maxCll : undefined,
-    MaxFall: output.maxFall !== undefined && output.maxFall !== null ? output.maxFall : undefined,
+    MaxCll: __expectNumber(output.maxCll),
+    MaxFall: __expectNumber(output.maxFall),
   } as any;
 };
 
 const deserializeAws_restJson1DvbNitSettings = (output: any, context: __SerdeContext): DvbNitSettings => {
   return {
-    NetworkId: output.networkId !== undefined && output.networkId !== null ? output.networkId : undefined,
-    NetworkName: output.networkName !== undefined && output.networkName !== null ? output.networkName : undefined,
-    NitInterval: output.nitInterval !== undefined && output.nitInterval !== null ? output.nitInterval : undefined,
+    NetworkId: __expectNumber(output.networkId),
+    NetworkName: __expectString(output.networkName),
+    NitInterval: __expectNumber(output.nitInterval),
   } as any;
 };
 
 const deserializeAws_restJson1DvbSdtSettings = (output: any, context: __SerdeContext): DvbSdtSettings => {
   return {
-    OutputSdt: output.outputSdt !== undefined && output.outputSdt !== null ? output.outputSdt : undefined,
-    SdtInterval: output.sdtInterval !== undefined && output.sdtInterval !== null ? output.sdtInterval : undefined,
-    ServiceName: output.serviceName !== undefined && output.serviceName !== null ? output.serviceName : undefined,
-    ServiceProviderName:
-      output.serviceProviderName !== undefined && output.serviceProviderName !== null
-        ? output.serviceProviderName
-        : undefined,
+    OutputSdt: __expectString(output.outputSdt),
+    SdtInterval: __expectNumber(output.sdtInterval),
+    ServiceName: __expectString(output.serviceName),
+    ServiceProviderName: __expectString(output.serviceProviderName),
   } as any;
 };
 
@@ -7754,152 +7550,87 @@ const deserializeAws_restJson1DvbSubDestinationSettings = (
   context: __SerdeContext
 ): DvbSubDestinationSettings => {
   return {
-    Alignment: output.alignment !== undefined && output.alignment !== null ? output.alignment : undefined,
-    BackgroundColor:
-      output.backgroundColor !== undefined && output.backgroundColor !== null ? output.backgroundColor : undefined,
-    BackgroundOpacity:
-      output.backgroundOpacity !== undefined && output.backgroundOpacity !== null
-        ? output.backgroundOpacity
-        : undefined,
-    DdsHandling: output.ddsHandling !== undefined && output.ddsHandling !== null ? output.ddsHandling : undefined,
-    DdsXCoordinate:
-      output.ddsXCoordinate !== undefined && output.ddsXCoordinate !== null ? output.ddsXCoordinate : undefined,
-    DdsYCoordinate:
-      output.ddsYCoordinate !== undefined && output.ddsYCoordinate !== null ? output.ddsYCoordinate : undefined,
-    FontColor: output.fontColor !== undefined && output.fontColor !== null ? output.fontColor : undefined,
-    FontOpacity: output.fontOpacity !== undefined && output.fontOpacity !== null ? output.fontOpacity : undefined,
-    FontResolution:
-      output.fontResolution !== undefined && output.fontResolution !== null ? output.fontResolution : undefined,
-    FontScript: output.fontScript !== undefined && output.fontScript !== null ? output.fontScript : undefined,
-    FontSize: output.fontSize !== undefined && output.fontSize !== null ? output.fontSize : undefined,
-    Height: output.height !== undefined && output.height !== null ? output.height : undefined,
-    OutlineColor: output.outlineColor !== undefined && output.outlineColor !== null ? output.outlineColor : undefined,
-    OutlineSize: output.outlineSize !== undefined && output.outlineSize !== null ? output.outlineSize : undefined,
-    ShadowColor: output.shadowColor !== undefined && output.shadowColor !== null ? output.shadowColor : undefined,
-    ShadowOpacity:
-      output.shadowOpacity !== undefined && output.shadowOpacity !== null ? output.shadowOpacity : undefined,
-    ShadowXOffset:
-      output.shadowXOffset !== undefined && output.shadowXOffset !== null ? output.shadowXOffset : undefined,
-    ShadowYOffset:
-      output.shadowYOffset !== undefined && output.shadowYOffset !== null ? output.shadowYOffset : undefined,
-    SubtitlingType:
-      output.subtitlingType !== undefined && output.subtitlingType !== null ? output.subtitlingType : undefined,
-    TeletextSpacing:
-      output.teletextSpacing !== undefined && output.teletextSpacing !== null ? output.teletextSpacing : undefined,
-    Width: output.width !== undefined && output.width !== null ? output.width : undefined,
-    XPosition: output.xPosition !== undefined && output.xPosition !== null ? output.xPosition : undefined,
-    YPosition: output.yPosition !== undefined && output.yPosition !== null ? output.yPosition : undefined,
+    Alignment: __expectString(output.alignment),
+    BackgroundColor: __expectString(output.backgroundColor),
+    BackgroundOpacity: __expectNumber(output.backgroundOpacity),
+    DdsHandling: __expectString(output.ddsHandling),
+    DdsXCoordinate: __expectNumber(output.ddsXCoordinate),
+    DdsYCoordinate: __expectNumber(output.ddsYCoordinate),
+    FontColor: __expectString(output.fontColor),
+    FontOpacity: __expectNumber(output.fontOpacity),
+    FontResolution: __expectNumber(output.fontResolution),
+    FontScript: __expectString(output.fontScript),
+    FontSize: __expectNumber(output.fontSize),
+    Height: __expectNumber(output.height),
+    OutlineColor: __expectString(output.outlineColor),
+    OutlineSize: __expectNumber(output.outlineSize),
+    ShadowColor: __expectString(output.shadowColor),
+    ShadowOpacity: __expectNumber(output.shadowOpacity),
+    ShadowXOffset: __expectNumber(output.shadowXOffset),
+    ShadowYOffset: __expectNumber(output.shadowYOffset),
+    SubtitlingType: __expectString(output.subtitlingType),
+    TeletextSpacing: __expectString(output.teletextSpacing),
+    Width: __expectNumber(output.width),
+    XPosition: __expectNumber(output.xPosition),
+    YPosition: __expectNumber(output.yPosition),
   } as any;
 };
 
 const deserializeAws_restJson1DvbSubSourceSettings = (output: any, context: __SerdeContext): DvbSubSourceSettings => {
   return {
-    Pid: output.pid !== undefined && output.pid !== null ? output.pid : undefined,
+    Pid: __expectNumber(output.pid),
   } as any;
 };
 
 const deserializeAws_restJson1DvbTdtSettings = (output: any, context: __SerdeContext): DvbTdtSettings => {
   return {
-    TdtInterval: output.tdtInterval !== undefined && output.tdtInterval !== null ? output.tdtInterval : undefined,
+    TdtInterval: __expectNumber(output.tdtInterval),
   } as any;
 };
 
 const deserializeAws_restJson1Eac3AtmosSettings = (output: any, context: __SerdeContext): Eac3AtmosSettings => {
   return {
-    Bitrate: output.bitrate !== undefined && output.bitrate !== null ? output.bitrate : undefined,
-    BitstreamMode:
-      output.bitstreamMode !== undefined && output.bitstreamMode !== null ? output.bitstreamMode : undefined,
-    CodingMode: output.codingMode !== undefined && output.codingMode !== null ? output.codingMode : undefined,
-    DialogueIntelligence:
-      output.dialogueIntelligence !== undefined && output.dialogueIntelligence !== null
-        ? output.dialogueIntelligence
-        : undefined,
-    DynamicRangeCompressionLine:
-      output.dynamicRangeCompressionLine !== undefined && output.dynamicRangeCompressionLine !== null
-        ? output.dynamicRangeCompressionLine
-        : undefined,
-    DynamicRangeCompressionRf:
-      output.dynamicRangeCompressionRf !== undefined && output.dynamicRangeCompressionRf !== null
-        ? output.dynamicRangeCompressionRf
-        : undefined,
-    LoRoCenterMixLevel:
-      output.loRoCenterMixLevel !== undefined && output.loRoCenterMixLevel !== null
-        ? output.loRoCenterMixLevel
-        : undefined,
-    LoRoSurroundMixLevel:
-      output.loRoSurroundMixLevel !== undefined && output.loRoSurroundMixLevel !== null
-        ? output.loRoSurroundMixLevel
-        : undefined,
-    LtRtCenterMixLevel:
-      output.ltRtCenterMixLevel !== undefined && output.ltRtCenterMixLevel !== null
-        ? output.ltRtCenterMixLevel
-        : undefined,
-    LtRtSurroundMixLevel:
-      output.ltRtSurroundMixLevel !== undefined && output.ltRtSurroundMixLevel !== null
-        ? output.ltRtSurroundMixLevel
-        : undefined,
-    MeteringMode: output.meteringMode !== undefined && output.meteringMode !== null ? output.meteringMode : undefined,
-    SampleRate: output.sampleRate !== undefined && output.sampleRate !== null ? output.sampleRate : undefined,
-    SpeechThreshold:
-      output.speechThreshold !== undefined && output.speechThreshold !== null ? output.speechThreshold : undefined,
-    StereoDownmix:
-      output.stereoDownmix !== undefined && output.stereoDownmix !== null ? output.stereoDownmix : undefined,
-    SurroundExMode:
-      output.surroundExMode !== undefined && output.surroundExMode !== null ? output.surroundExMode : undefined,
+    Bitrate: __expectNumber(output.bitrate),
+    BitstreamMode: __expectString(output.bitstreamMode),
+    CodingMode: __expectString(output.codingMode),
+    DialogueIntelligence: __expectString(output.dialogueIntelligence),
+    DynamicRangeCompressionLine: __expectString(output.dynamicRangeCompressionLine),
+    DynamicRangeCompressionRf: __expectString(output.dynamicRangeCompressionRf),
+    LoRoCenterMixLevel: __expectNumber(output.loRoCenterMixLevel),
+    LoRoSurroundMixLevel: __expectNumber(output.loRoSurroundMixLevel),
+    LtRtCenterMixLevel: __expectNumber(output.ltRtCenterMixLevel),
+    LtRtSurroundMixLevel: __expectNumber(output.ltRtSurroundMixLevel),
+    MeteringMode: __expectString(output.meteringMode),
+    SampleRate: __expectNumber(output.sampleRate),
+    SpeechThreshold: __expectNumber(output.speechThreshold),
+    StereoDownmix: __expectString(output.stereoDownmix),
+    SurroundExMode: __expectString(output.surroundExMode),
   } as any;
 };
 
 const deserializeAws_restJson1Eac3Settings = (output: any, context: __SerdeContext): Eac3Settings => {
   return {
-    AttenuationControl:
-      output.attenuationControl !== undefined && output.attenuationControl !== null
-        ? output.attenuationControl
-        : undefined,
-    Bitrate: output.bitrate !== undefined && output.bitrate !== null ? output.bitrate : undefined,
-    BitstreamMode:
-      output.bitstreamMode !== undefined && output.bitstreamMode !== null ? output.bitstreamMode : undefined,
-    CodingMode: output.codingMode !== undefined && output.codingMode !== null ? output.codingMode : undefined,
-    DcFilter: output.dcFilter !== undefined && output.dcFilter !== null ? output.dcFilter : undefined,
-    Dialnorm: output.dialnorm !== undefined && output.dialnorm !== null ? output.dialnorm : undefined,
-    DynamicRangeCompressionLine:
-      output.dynamicRangeCompressionLine !== undefined && output.dynamicRangeCompressionLine !== null
-        ? output.dynamicRangeCompressionLine
-        : undefined,
-    DynamicRangeCompressionRf:
-      output.dynamicRangeCompressionRf !== undefined && output.dynamicRangeCompressionRf !== null
-        ? output.dynamicRangeCompressionRf
-        : undefined,
-    LfeControl: output.lfeControl !== undefined && output.lfeControl !== null ? output.lfeControl : undefined,
-    LfeFilter: output.lfeFilter !== undefined && output.lfeFilter !== null ? output.lfeFilter : undefined,
-    LoRoCenterMixLevel:
-      output.loRoCenterMixLevel !== undefined && output.loRoCenterMixLevel !== null
-        ? output.loRoCenterMixLevel
-        : undefined,
-    LoRoSurroundMixLevel:
-      output.loRoSurroundMixLevel !== undefined && output.loRoSurroundMixLevel !== null
-        ? output.loRoSurroundMixLevel
-        : undefined,
-    LtRtCenterMixLevel:
-      output.ltRtCenterMixLevel !== undefined && output.ltRtCenterMixLevel !== null
-        ? output.ltRtCenterMixLevel
-        : undefined,
-    LtRtSurroundMixLevel:
-      output.ltRtSurroundMixLevel !== undefined && output.ltRtSurroundMixLevel !== null
-        ? output.ltRtSurroundMixLevel
-        : undefined,
-    MetadataControl:
-      output.metadataControl !== undefined && output.metadataControl !== null ? output.metadataControl : undefined,
-    PassthroughControl:
-      output.passthroughControl !== undefined && output.passthroughControl !== null
-        ? output.passthroughControl
-        : undefined,
-    PhaseControl: output.phaseControl !== undefined && output.phaseControl !== null ? output.phaseControl : undefined,
-    SampleRate: output.sampleRate !== undefined && output.sampleRate !== null ? output.sampleRate : undefined,
-    StereoDownmix:
-      output.stereoDownmix !== undefined && output.stereoDownmix !== null ? output.stereoDownmix : undefined,
-    SurroundExMode:
-      output.surroundExMode !== undefined && output.surroundExMode !== null ? output.surroundExMode : undefined,
-    SurroundMode: output.surroundMode !== undefined && output.surroundMode !== null ? output.surroundMode : undefined,
+    AttenuationControl: __expectString(output.attenuationControl),
+    Bitrate: __expectNumber(output.bitrate),
+    BitstreamMode: __expectString(output.bitstreamMode),
+    CodingMode: __expectString(output.codingMode),
+    DcFilter: __expectString(output.dcFilter),
+    Dialnorm: __expectNumber(output.dialnorm),
+    DynamicRangeCompressionLine: __expectString(output.dynamicRangeCompressionLine),
+    DynamicRangeCompressionRf: __expectString(output.dynamicRangeCompressionRf),
+    LfeControl: __expectString(output.lfeControl),
+    LfeFilter: __expectString(output.lfeFilter),
+    LoRoCenterMixLevel: __expectNumber(output.loRoCenterMixLevel),
+    LoRoSurroundMixLevel: __expectNumber(output.loRoSurroundMixLevel),
+    LtRtCenterMixLevel: __expectNumber(output.ltRtCenterMixLevel),
+    LtRtSurroundMixLevel: __expectNumber(output.ltRtSurroundMixLevel),
+    MetadataControl: __expectString(output.metadataControl),
+    PassthroughControl: __expectString(output.passthroughControl),
+    PhaseControl: __expectString(output.phaseControl),
+    SampleRate: __expectNumber(output.sampleRate),
+    StereoDownmix: __expectString(output.stereoDownmix),
+    SurroundExMode: __expectString(output.surroundExMode),
+    SurroundMode: __expectString(output.surroundMode),
   } as any;
 };
 
@@ -7908,14 +7639,8 @@ const deserializeAws_restJson1EmbeddedDestinationSettings = (
   context: __SerdeContext
 ): EmbeddedDestinationSettings => {
   return {
-    Destination608ChannelNumber:
-      output.destination608ChannelNumber !== undefined && output.destination608ChannelNumber !== null
-        ? output.destination608ChannelNumber
-        : undefined,
-    Destination708ServiceNumber:
-      output.destination708ServiceNumber !== undefined && output.destination708ServiceNumber !== null
-        ? output.destination708ServiceNumber
-        : undefined,
+    Destination608ChannelNumber: __expectNumber(output.destination608ChannelNumber),
+    Destination708ServiceNumber: __expectNumber(output.destination708ServiceNumber),
   } as any;
 };
 
@@ -7924,26 +7649,16 @@ const deserializeAws_restJson1EmbeddedSourceSettings = (
   context: __SerdeContext
 ): EmbeddedSourceSettings => {
   return {
-    Convert608To708:
-      output.convert608To708 !== undefined && output.convert608To708 !== null ? output.convert608To708 : undefined,
-    Source608ChannelNumber:
-      output.source608ChannelNumber !== undefined && output.source608ChannelNumber !== null
-        ? output.source608ChannelNumber
-        : undefined,
-    Source608TrackNumber:
-      output.source608TrackNumber !== undefined && output.source608TrackNumber !== null
-        ? output.source608TrackNumber
-        : undefined,
-    TerminateCaptions:
-      output.terminateCaptions !== undefined && output.terminateCaptions !== null
-        ? output.terminateCaptions
-        : undefined,
+    Convert608To708: __expectString(output.convert608To708),
+    Source608ChannelNumber: __expectNumber(output.source608ChannelNumber),
+    Source608TrackNumber: __expectNumber(output.source608TrackNumber),
+    TerminateCaptions: __expectString(output.terminateCaptions),
   } as any;
 };
 
 const deserializeAws_restJson1Endpoint = (output: any, context: __SerdeContext): Endpoint => {
   return {
-    Url: output.url !== undefined && output.url !== null ? output.url : undefined,
+    Url: __expectString(output.url),
   } as any;
 };
 
@@ -7952,7 +7667,7 @@ const deserializeAws_restJson1EsamManifestConfirmConditionNotification = (
   context: __SerdeContext
 ): EsamManifestConfirmConditionNotification => {
   return {
-    MccXml: output.mccXml !== undefined && output.mccXml !== null ? output.mccXml : undefined,
+    MccXml: __expectString(output.mccXml),
   } as any;
 };
 
@@ -7965,10 +7680,7 @@ const deserializeAws_restJson1EsamSettings = (output: any, context: __SerdeConte
             context
           )
         : undefined,
-    ResponseSignalPreroll:
-      output.responseSignalPreroll !== undefined && output.responseSignalPreroll !== null
-        ? output.responseSignalPreroll
-        : undefined,
+    ResponseSignalPreroll: __expectNumber(output.responseSignalPreroll),
     SignalProcessingNotification:
       output.signalProcessingNotification !== undefined && output.signalProcessingNotification !== null
         ? deserializeAws_restJson1EsamSignalProcessingNotification(output.signalProcessingNotification, context)
@@ -7981,20 +7693,19 @@ const deserializeAws_restJson1EsamSignalProcessingNotification = (
   context: __SerdeContext
 ): EsamSignalProcessingNotification => {
   return {
-    SccXml: output.sccXml !== undefined && output.sccXml !== null ? output.sccXml : undefined,
+    SccXml: __expectString(output.sccXml),
   } as any;
 };
 
 const deserializeAws_restJson1F4vSettings = (output: any, context: __SerdeContext): F4vSettings => {
   return {
-    MoovPlacement:
-      output.moovPlacement !== undefined && output.moovPlacement !== null ? output.moovPlacement : undefined,
+    MoovPlacement: __expectString(output.moovPlacement),
   } as any;
 };
 
 const deserializeAws_restJson1FileGroupSettings = (output: any, context: __SerdeContext): FileGroupSettings => {
   return {
-    Destination: output.destination !== undefined && output.destination !== null ? output.destination : undefined,
+    Destination: __expectString(output.destination),
     DestinationSettings:
       output.destinationSettings !== undefined && output.destinationSettings !== null
         ? deserializeAws_restJson1DestinationSettings(output.destinationSettings, context)
@@ -8004,300 +7715,157 @@ const deserializeAws_restJson1FileGroupSettings = (output: any, context: __Serde
 
 const deserializeAws_restJson1FileSourceSettings = (output: any, context: __SerdeContext): FileSourceSettings => {
   return {
-    Convert608To708:
-      output.convert608To708 !== undefined && output.convert608To708 !== null ? output.convert608To708 : undefined,
+    Convert608To708: __expectString(output.convert608To708),
     Framerate:
       output.framerate !== undefined && output.framerate !== null
         ? deserializeAws_restJson1CaptionSourceFramerate(output.framerate, context)
         : undefined,
-    SourceFile: output.sourceFile !== undefined && output.sourceFile !== null ? output.sourceFile : undefined,
-    TimeDelta: output.timeDelta !== undefined && output.timeDelta !== null ? output.timeDelta : undefined,
+    SourceFile: __expectString(output.sourceFile),
+    TimeDelta: __expectNumber(output.timeDelta),
   } as any;
 };
 
 const deserializeAws_restJson1FrameCaptureSettings = (output: any, context: __SerdeContext): FrameCaptureSettings => {
   return {
-    FramerateDenominator:
-      output.framerateDenominator !== undefined && output.framerateDenominator !== null
-        ? output.framerateDenominator
-        : undefined,
-    FramerateNumerator:
-      output.framerateNumerator !== undefined && output.framerateNumerator !== null
-        ? output.framerateNumerator
-        : undefined,
-    MaxCaptures: output.maxCaptures !== undefined && output.maxCaptures !== null ? output.maxCaptures : undefined,
-    Quality: output.quality !== undefined && output.quality !== null ? output.quality : undefined,
+    FramerateDenominator: __expectNumber(output.framerateDenominator),
+    FramerateNumerator: __expectNumber(output.framerateNumerator),
+    MaxCaptures: __expectNumber(output.maxCaptures),
+    Quality: __expectNumber(output.quality),
   } as any;
 };
 
 const deserializeAws_restJson1H264QvbrSettings = (output: any, context: __SerdeContext): H264QvbrSettings => {
   return {
-    MaxAverageBitrate:
-      output.maxAverageBitrate !== undefined && output.maxAverageBitrate !== null
-        ? output.maxAverageBitrate
-        : undefined,
-    QvbrQualityLevel:
-      output.qvbrQualityLevel !== undefined && output.qvbrQualityLevel !== null ? output.qvbrQualityLevel : undefined,
-    QvbrQualityLevelFineTune:
-      output.qvbrQualityLevelFineTune !== undefined && output.qvbrQualityLevelFineTune !== null
-        ? output.qvbrQualityLevelFineTune
-        : undefined,
+    MaxAverageBitrate: __expectNumber(output.maxAverageBitrate),
+    QvbrQualityLevel: __expectNumber(output.qvbrQualityLevel),
+    QvbrQualityLevelFineTune: __expectNumber(output.qvbrQualityLevelFineTune),
   } as any;
 };
 
 const deserializeAws_restJson1H264Settings = (output: any, context: __SerdeContext): H264Settings => {
   return {
-    AdaptiveQuantization:
-      output.adaptiveQuantization !== undefined && output.adaptiveQuantization !== null
-        ? output.adaptiveQuantization
-        : undefined,
-    Bitrate: output.bitrate !== undefined && output.bitrate !== null ? output.bitrate : undefined,
-    CodecLevel: output.codecLevel !== undefined && output.codecLevel !== null ? output.codecLevel : undefined,
-    CodecProfile: output.codecProfile !== undefined && output.codecProfile !== null ? output.codecProfile : undefined,
-    DynamicSubGop:
-      output.dynamicSubGop !== undefined && output.dynamicSubGop !== null ? output.dynamicSubGop : undefined,
-    EntropyEncoding:
-      output.entropyEncoding !== undefined && output.entropyEncoding !== null ? output.entropyEncoding : undefined,
-    FieldEncoding:
-      output.fieldEncoding !== undefined && output.fieldEncoding !== null ? output.fieldEncoding : undefined,
-    FlickerAdaptiveQuantization:
-      output.flickerAdaptiveQuantization !== undefined && output.flickerAdaptiveQuantization !== null
-        ? output.flickerAdaptiveQuantization
-        : undefined,
-    FramerateControl:
-      output.framerateControl !== undefined && output.framerateControl !== null ? output.framerateControl : undefined,
-    FramerateConversionAlgorithm:
-      output.framerateConversionAlgorithm !== undefined && output.framerateConversionAlgorithm !== null
-        ? output.framerateConversionAlgorithm
-        : undefined,
-    FramerateDenominator:
-      output.framerateDenominator !== undefined && output.framerateDenominator !== null
-        ? output.framerateDenominator
-        : undefined,
-    FramerateNumerator:
-      output.framerateNumerator !== undefined && output.framerateNumerator !== null
-        ? output.framerateNumerator
-        : undefined,
-    GopBReference:
-      output.gopBReference !== undefined && output.gopBReference !== null ? output.gopBReference : undefined,
-    GopClosedCadence:
-      output.gopClosedCadence !== undefined && output.gopClosedCadence !== null ? output.gopClosedCadence : undefined,
-    GopSize: output.gopSize !== undefined && output.gopSize !== null ? output.gopSize : undefined,
-    GopSizeUnits: output.gopSizeUnits !== undefined && output.gopSizeUnits !== null ? output.gopSizeUnits : undefined,
-    HrdBufferInitialFillPercentage:
-      output.hrdBufferInitialFillPercentage !== undefined && output.hrdBufferInitialFillPercentage !== null
-        ? output.hrdBufferInitialFillPercentage
-        : undefined,
-    HrdBufferSize:
-      output.hrdBufferSize !== undefined && output.hrdBufferSize !== null ? output.hrdBufferSize : undefined,
-    InterlaceMode:
-      output.interlaceMode !== undefined && output.interlaceMode !== null ? output.interlaceMode : undefined,
-    MaxBitrate: output.maxBitrate !== undefined && output.maxBitrate !== null ? output.maxBitrate : undefined,
-    MinIInterval: output.minIInterval !== undefined && output.minIInterval !== null ? output.minIInterval : undefined,
-    NumberBFramesBetweenReferenceFrames:
-      output.numberBFramesBetweenReferenceFrames !== undefined && output.numberBFramesBetweenReferenceFrames !== null
-        ? output.numberBFramesBetweenReferenceFrames
-        : undefined,
-    NumberReferenceFrames:
-      output.numberReferenceFrames !== undefined && output.numberReferenceFrames !== null
-        ? output.numberReferenceFrames
-        : undefined,
-    ParControl: output.parControl !== undefined && output.parControl !== null ? output.parControl : undefined,
-    ParDenominator:
-      output.parDenominator !== undefined && output.parDenominator !== null ? output.parDenominator : undefined,
-    ParNumerator: output.parNumerator !== undefined && output.parNumerator !== null ? output.parNumerator : undefined,
-    QualityTuningLevel:
-      output.qualityTuningLevel !== undefined && output.qualityTuningLevel !== null
-        ? output.qualityTuningLevel
-        : undefined,
+    AdaptiveQuantization: __expectString(output.adaptiveQuantization),
+    Bitrate: __expectNumber(output.bitrate),
+    CodecLevel: __expectString(output.codecLevel),
+    CodecProfile: __expectString(output.codecProfile),
+    DynamicSubGop: __expectString(output.dynamicSubGop),
+    EntropyEncoding: __expectString(output.entropyEncoding),
+    FieldEncoding: __expectString(output.fieldEncoding),
+    FlickerAdaptiveQuantization: __expectString(output.flickerAdaptiveQuantization),
+    FramerateControl: __expectString(output.framerateControl),
+    FramerateConversionAlgorithm: __expectString(output.framerateConversionAlgorithm),
+    FramerateDenominator: __expectNumber(output.framerateDenominator),
+    FramerateNumerator: __expectNumber(output.framerateNumerator),
+    GopBReference: __expectString(output.gopBReference),
+    GopClosedCadence: __expectNumber(output.gopClosedCadence),
+    GopSize: __expectNumber(output.gopSize),
+    GopSizeUnits: __expectString(output.gopSizeUnits),
+    HrdBufferInitialFillPercentage: __expectNumber(output.hrdBufferInitialFillPercentage),
+    HrdBufferSize: __expectNumber(output.hrdBufferSize),
+    InterlaceMode: __expectString(output.interlaceMode),
+    MaxBitrate: __expectNumber(output.maxBitrate),
+    MinIInterval: __expectNumber(output.minIInterval),
+    NumberBFramesBetweenReferenceFrames: __expectNumber(output.numberBFramesBetweenReferenceFrames),
+    NumberReferenceFrames: __expectNumber(output.numberReferenceFrames),
+    ParControl: __expectString(output.parControl),
+    ParDenominator: __expectNumber(output.parDenominator),
+    ParNumerator: __expectNumber(output.parNumerator),
+    QualityTuningLevel: __expectString(output.qualityTuningLevel),
     QvbrSettings:
       output.qvbrSettings !== undefined && output.qvbrSettings !== null
         ? deserializeAws_restJson1H264QvbrSettings(output.qvbrSettings, context)
         : undefined,
-    RateControlMode:
-      output.rateControlMode !== undefined && output.rateControlMode !== null ? output.rateControlMode : undefined,
-    RepeatPps: output.repeatPps !== undefined && output.repeatPps !== null ? output.repeatPps : undefined,
-    ScanTypeConversionMode:
-      output.scanTypeConversionMode !== undefined && output.scanTypeConversionMode !== null
-        ? output.scanTypeConversionMode
-        : undefined,
-    SceneChangeDetect:
-      output.sceneChangeDetect !== undefined && output.sceneChangeDetect !== null
-        ? output.sceneChangeDetect
-        : undefined,
-    Slices: output.slices !== undefined && output.slices !== null ? output.slices : undefined,
-    SlowPal: output.slowPal !== undefined && output.slowPal !== null ? output.slowPal : undefined,
-    Softness: output.softness !== undefined && output.softness !== null ? output.softness : undefined,
-    SpatialAdaptiveQuantization:
-      output.spatialAdaptiveQuantization !== undefined && output.spatialAdaptiveQuantization !== null
-        ? output.spatialAdaptiveQuantization
-        : undefined,
-    Syntax: output.syntax !== undefined && output.syntax !== null ? output.syntax : undefined,
-    Telecine: output.telecine !== undefined && output.telecine !== null ? output.telecine : undefined,
-    TemporalAdaptiveQuantization:
-      output.temporalAdaptiveQuantization !== undefined && output.temporalAdaptiveQuantization !== null
-        ? output.temporalAdaptiveQuantization
-        : undefined,
-    UnregisteredSeiTimecode:
-      output.unregisteredSeiTimecode !== undefined && output.unregisteredSeiTimecode !== null
-        ? output.unregisteredSeiTimecode
-        : undefined,
+    RateControlMode: __expectString(output.rateControlMode),
+    RepeatPps: __expectString(output.repeatPps),
+    ScanTypeConversionMode: __expectString(output.scanTypeConversionMode),
+    SceneChangeDetect: __expectString(output.sceneChangeDetect),
+    Slices: __expectNumber(output.slices),
+    SlowPal: __expectString(output.slowPal),
+    Softness: __expectNumber(output.softness),
+    SpatialAdaptiveQuantization: __expectString(output.spatialAdaptiveQuantization),
+    Syntax: __expectString(output.syntax),
+    Telecine: __expectString(output.telecine),
+    TemporalAdaptiveQuantization: __expectString(output.temporalAdaptiveQuantization),
+    UnregisteredSeiTimecode: __expectString(output.unregisteredSeiTimecode),
   } as any;
 };
 
 const deserializeAws_restJson1H265QvbrSettings = (output: any, context: __SerdeContext): H265QvbrSettings => {
   return {
-    MaxAverageBitrate:
-      output.maxAverageBitrate !== undefined && output.maxAverageBitrate !== null
-        ? output.maxAverageBitrate
-        : undefined,
-    QvbrQualityLevel:
-      output.qvbrQualityLevel !== undefined && output.qvbrQualityLevel !== null ? output.qvbrQualityLevel : undefined,
-    QvbrQualityLevelFineTune:
-      output.qvbrQualityLevelFineTune !== undefined && output.qvbrQualityLevelFineTune !== null
-        ? output.qvbrQualityLevelFineTune
-        : undefined,
+    MaxAverageBitrate: __expectNumber(output.maxAverageBitrate),
+    QvbrQualityLevel: __expectNumber(output.qvbrQualityLevel),
+    QvbrQualityLevelFineTune: __expectNumber(output.qvbrQualityLevelFineTune),
   } as any;
 };
 
 const deserializeAws_restJson1H265Settings = (output: any, context: __SerdeContext): H265Settings => {
   return {
-    AdaptiveQuantization:
-      output.adaptiveQuantization !== undefined && output.adaptiveQuantization !== null
-        ? output.adaptiveQuantization
-        : undefined,
-    AlternateTransferFunctionSei:
-      output.alternateTransferFunctionSei !== undefined && output.alternateTransferFunctionSei !== null
-        ? output.alternateTransferFunctionSei
-        : undefined,
-    Bitrate: output.bitrate !== undefined && output.bitrate !== null ? output.bitrate : undefined,
-    CodecLevel: output.codecLevel !== undefined && output.codecLevel !== null ? output.codecLevel : undefined,
-    CodecProfile: output.codecProfile !== undefined && output.codecProfile !== null ? output.codecProfile : undefined,
-    DynamicSubGop:
-      output.dynamicSubGop !== undefined && output.dynamicSubGop !== null ? output.dynamicSubGop : undefined,
-    FlickerAdaptiveQuantization:
-      output.flickerAdaptiveQuantization !== undefined && output.flickerAdaptiveQuantization !== null
-        ? output.flickerAdaptiveQuantization
-        : undefined,
-    FramerateControl:
-      output.framerateControl !== undefined && output.framerateControl !== null ? output.framerateControl : undefined,
-    FramerateConversionAlgorithm:
-      output.framerateConversionAlgorithm !== undefined && output.framerateConversionAlgorithm !== null
-        ? output.framerateConversionAlgorithm
-        : undefined,
-    FramerateDenominator:
-      output.framerateDenominator !== undefined && output.framerateDenominator !== null
-        ? output.framerateDenominator
-        : undefined,
-    FramerateNumerator:
-      output.framerateNumerator !== undefined && output.framerateNumerator !== null
-        ? output.framerateNumerator
-        : undefined,
-    GopBReference:
-      output.gopBReference !== undefined && output.gopBReference !== null ? output.gopBReference : undefined,
-    GopClosedCadence:
-      output.gopClosedCadence !== undefined && output.gopClosedCadence !== null ? output.gopClosedCadence : undefined,
-    GopSize: output.gopSize !== undefined && output.gopSize !== null ? output.gopSize : undefined,
-    GopSizeUnits: output.gopSizeUnits !== undefined && output.gopSizeUnits !== null ? output.gopSizeUnits : undefined,
-    HrdBufferInitialFillPercentage:
-      output.hrdBufferInitialFillPercentage !== undefined && output.hrdBufferInitialFillPercentage !== null
-        ? output.hrdBufferInitialFillPercentage
-        : undefined,
-    HrdBufferSize:
-      output.hrdBufferSize !== undefined && output.hrdBufferSize !== null ? output.hrdBufferSize : undefined,
-    InterlaceMode:
-      output.interlaceMode !== undefined && output.interlaceMode !== null ? output.interlaceMode : undefined,
-    MaxBitrate: output.maxBitrate !== undefined && output.maxBitrate !== null ? output.maxBitrate : undefined,
-    MinIInterval: output.minIInterval !== undefined && output.minIInterval !== null ? output.minIInterval : undefined,
-    NumberBFramesBetweenReferenceFrames:
-      output.numberBFramesBetweenReferenceFrames !== undefined && output.numberBFramesBetweenReferenceFrames !== null
-        ? output.numberBFramesBetweenReferenceFrames
-        : undefined,
-    NumberReferenceFrames:
-      output.numberReferenceFrames !== undefined && output.numberReferenceFrames !== null
-        ? output.numberReferenceFrames
-        : undefined,
-    ParControl: output.parControl !== undefined && output.parControl !== null ? output.parControl : undefined,
-    ParDenominator:
-      output.parDenominator !== undefined && output.parDenominator !== null ? output.parDenominator : undefined,
-    ParNumerator: output.parNumerator !== undefined && output.parNumerator !== null ? output.parNumerator : undefined,
-    QualityTuningLevel:
-      output.qualityTuningLevel !== undefined && output.qualityTuningLevel !== null
-        ? output.qualityTuningLevel
-        : undefined,
+    AdaptiveQuantization: __expectString(output.adaptiveQuantization),
+    AlternateTransferFunctionSei: __expectString(output.alternateTransferFunctionSei),
+    Bitrate: __expectNumber(output.bitrate),
+    CodecLevel: __expectString(output.codecLevel),
+    CodecProfile: __expectString(output.codecProfile),
+    DynamicSubGop: __expectString(output.dynamicSubGop),
+    FlickerAdaptiveQuantization: __expectString(output.flickerAdaptiveQuantization),
+    FramerateControl: __expectString(output.framerateControl),
+    FramerateConversionAlgorithm: __expectString(output.framerateConversionAlgorithm),
+    FramerateDenominator: __expectNumber(output.framerateDenominator),
+    FramerateNumerator: __expectNumber(output.framerateNumerator),
+    GopBReference: __expectString(output.gopBReference),
+    GopClosedCadence: __expectNumber(output.gopClosedCadence),
+    GopSize: __expectNumber(output.gopSize),
+    GopSizeUnits: __expectString(output.gopSizeUnits),
+    HrdBufferInitialFillPercentage: __expectNumber(output.hrdBufferInitialFillPercentage),
+    HrdBufferSize: __expectNumber(output.hrdBufferSize),
+    InterlaceMode: __expectString(output.interlaceMode),
+    MaxBitrate: __expectNumber(output.maxBitrate),
+    MinIInterval: __expectNumber(output.minIInterval),
+    NumberBFramesBetweenReferenceFrames: __expectNumber(output.numberBFramesBetweenReferenceFrames),
+    NumberReferenceFrames: __expectNumber(output.numberReferenceFrames),
+    ParControl: __expectString(output.parControl),
+    ParDenominator: __expectNumber(output.parDenominator),
+    ParNumerator: __expectNumber(output.parNumerator),
+    QualityTuningLevel: __expectString(output.qualityTuningLevel),
     QvbrSettings:
       output.qvbrSettings !== undefined && output.qvbrSettings !== null
         ? deserializeAws_restJson1H265QvbrSettings(output.qvbrSettings, context)
         : undefined,
-    RateControlMode:
-      output.rateControlMode !== undefined && output.rateControlMode !== null ? output.rateControlMode : undefined,
-    SampleAdaptiveOffsetFilterMode:
-      output.sampleAdaptiveOffsetFilterMode !== undefined && output.sampleAdaptiveOffsetFilterMode !== null
-        ? output.sampleAdaptiveOffsetFilterMode
-        : undefined,
-    ScanTypeConversionMode:
-      output.scanTypeConversionMode !== undefined && output.scanTypeConversionMode !== null
-        ? output.scanTypeConversionMode
-        : undefined,
-    SceneChangeDetect:
-      output.sceneChangeDetect !== undefined && output.sceneChangeDetect !== null
-        ? output.sceneChangeDetect
-        : undefined,
-    Slices: output.slices !== undefined && output.slices !== null ? output.slices : undefined,
-    SlowPal: output.slowPal !== undefined && output.slowPal !== null ? output.slowPal : undefined,
-    SpatialAdaptiveQuantization:
-      output.spatialAdaptiveQuantization !== undefined && output.spatialAdaptiveQuantization !== null
-        ? output.spatialAdaptiveQuantization
-        : undefined,
-    Telecine: output.telecine !== undefined && output.telecine !== null ? output.telecine : undefined,
-    TemporalAdaptiveQuantization:
-      output.temporalAdaptiveQuantization !== undefined && output.temporalAdaptiveQuantization !== null
-        ? output.temporalAdaptiveQuantization
-        : undefined,
-    TemporalIds: output.temporalIds !== undefined && output.temporalIds !== null ? output.temporalIds : undefined,
-    Tiles: output.tiles !== undefined && output.tiles !== null ? output.tiles : undefined,
-    UnregisteredSeiTimecode:
-      output.unregisteredSeiTimecode !== undefined && output.unregisteredSeiTimecode !== null
-        ? output.unregisteredSeiTimecode
-        : undefined,
-    WriteMp4PackagingType:
-      output.writeMp4PackagingType !== undefined && output.writeMp4PackagingType !== null
-        ? output.writeMp4PackagingType
-        : undefined,
+    RateControlMode: __expectString(output.rateControlMode),
+    SampleAdaptiveOffsetFilterMode: __expectString(output.sampleAdaptiveOffsetFilterMode),
+    ScanTypeConversionMode: __expectString(output.scanTypeConversionMode),
+    SceneChangeDetect: __expectString(output.sceneChangeDetect),
+    Slices: __expectNumber(output.slices),
+    SlowPal: __expectString(output.slowPal),
+    SpatialAdaptiveQuantization: __expectString(output.spatialAdaptiveQuantization),
+    Telecine: __expectString(output.telecine),
+    TemporalAdaptiveQuantization: __expectString(output.temporalAdaptiveQuantization),
+    TemporalIds: __expectString(output.temporalIds),
+    Tiles: __expectString(output.tiles),
+    UnregisteredSeiTimecode: __expectString(output.unregisteredSeiTimecode),
+    WriteMp4PackagingType: __expectString(output.writeMp4PackagingType),
   } as any;
 };
 
 const deserializeAws_restJson1Hdr10Metadata = (output: any, context: __SerdeContext): Hdr10Metadata => {
   return {
-    BluePrimaryX: output.bluePrimaryX !== undefined && output.bluePrimaryX !== null ? output.bluePrimaryX : undefined,
-    BluePrimaryY: output.bluePrimaryY !== undefined && output.bluePrimaryY !== null ? output.bluePrimaryY : undefined,
-    GreenPrimaryX:
-      output.greenPrimaryX !== undefined && output.greenPrimaryX !== null ? output.greenPrimaryX : undefined,
-    GreenPrimaryY:
-      output.greenPrimaryY !== undefined && output.greenPrimaryY !== null ? output.greenPrimaryY : undefined,
-    MaxContentLightLevel:
-      output.maxContentLightLevel !== undefined && output.maxContentLightLevel !== null
-        ? output.maxContentLightLevel
-        : undefined,
-    MaxFrameAverageLightLevel:
-      output.maxFrameAverageLightLevel !== undefined && output.maxFrameAverageLightLevel !== null
-        ? output.maxFrameAverageLightLevel
-        : undefined,
-    MaxLuminance: output.maxLuminance !== undefined && output.maxLuminance !== null ? output.maxLuminance : undefined,
-    MinLuminance: output.minLuminance !== undefined && output.minLuminance !== null ? output.minLuminance : undefined,
-    RedPrimaryX: output.redPrimaryX !== undefined && output.redPrimaryX !== null ? output.redPrimaryX : undefined,
-    RedPrimaryY: output.redPrimaryY !== undefined && output.redPrimaryY !== null ? output.redPrimaryY : undefined,
-    WhitePointX: output.whitePointX !== undefined && output.whitePointX !== null ? output.whitePointX : undefined,
-    WhitePointY: output.whitePointY !== undefined && output.whitePointY !== null ? output.whitePointY : undefined,
+    BluePrimaryX: __expectNumber(output.bluePrimaryX),
+    BluePrimaryY: __expectNumber(output.bluePrimaryY),
+    GreenPrimaryX: __expectNumber(output.greenPrimaryX),
+    GreenPrimaryY: __expectNumber(output.greenPrimaryY),
+    MaxContentLightLevel: __expectNumber(output.maxContentLightLevel),
+    MaxFrameAverageLightLevel: __expectNumber(output.maxFrameAverageLightLevel),
+    MaxLuminance: __expectNumber(output.maxLuminance),
+    MinLuminance: __expectNumber(output.minLuminance),
+    RedPrimaryX: __expectNumber(output.redPrimaryX),
+    RedPrimaryY: __expectNumber(output.redPrimaryY),
+    WhitePointX: __expectNumber(output.whitePointX),
+    WhitePointY: __expectNumber(output.whitePointY),
   } as any;
 };
 
 const deserializeAws_restJson1HlsAdditionalManifest = (output: any, context: __SerdeContext): HlsAdditionalManifest => {
   return {
-    ManifestNameModifier:
-      output.manifestNameModifier !== undefined && output.manifestNameModifier !== null
-        ? output.manifestNameModifier
-        : undefined,
+    ManifestNameModifier: __expectString(output.manifestNameModifier),
     SelectedOutputs:
       output.selectedOutputs !== undefined && output.selectedOutputs !== null
         ? deserializeAws_restJson1__listOf__stringMin1(output.selectedOutputs, context)
@@ -8310,34 +7878,19 @@ const deserializeAws_restJson1HlsCaptionLanguageMapping = (
   context: __SerdeContext
 ): HlsCaptionLanguageMapping => {
   return {
-    CaptionChannel:
-      output.captionChannel !== undefined && output.captionChannel !== null ? output.captionChannel : undefined,
-    CustomLanguageCode:
-      output.customLanguageCode !== undefined && output.customLanguageCode !== null
-        ? output.customLanguageCode
-        : undefined,
-    LanguageCode: output.languageCode !== undefined && output.languageCode !== null ? output.languageCode : undefined,
-    LanguageDescription:
-      output.languageDescription !== undefined && output.languageDescription !== null
-        ? output.languageDescription
-        : undefined,
+    CaptionChannel: __expectNumber(output.captionChannel),
+    CustomLanguageCode: __expectString(output.customLanguageCode),
+    LanguageCode: __expectString(output.languageCode),
+    LanguageDescription: __expectString(output.languageDescription),
   } as any;
 };
 
 const deserializeAws_restJson1HlsEncryptionSettings = (output: any, context: __SerdeContext): HlsEncryptionSettings => {
   return {
-    ConstantInitializationVector:
-      output.constantInitializationVector !== undefined && output.constantInitializationVector !== null
-        ? output.constantInitializationVector
-        : undefined,
-    EncryptionMethod:
-      output.encryptionMethod !== undefined && output.encryptionMethod !== null ? output.encryptionMethod : undefined,
-    InitializationVectorInManifest:
-      output.initializationVectorInManifest !== undefined && output.initializationVectorInManifest !== null
-        ? output.initializationVectorInManifest
-        : undefined,
-    OfflineEncrypted:
-      output.offlineEncrypted !== undefined && output.offlineEncrypted !== null ? output.offlineEncrypted : undefined,
+    ConstantInitializationVector: __expectString(output.constantInitializationVector),
+    EncryptionMethod: __expectString(output.encryptionMethod),
+    InitializationVectorInManifest: __expectString(output.initializationVectorInManifest),
+    OfflineEncrypted: __expectString(output.offlineEncrypted),
     SpekeKeyProvider:
       output.spekeKeyProvider !== undefined && output.spekeKeyProvider !== null
         ? deserializeAws_restJson1SpekeKeyProvider(output.spekeKeyProvider, context)
@@ -8346,7 +7899,7 @@ const deserializeAws_restJson1HlsEncryptionSettings = (output: any, context: __S
       output.staticKeyProvider !== undefined && output.staticKeyProvider !== null
         ? deserializeAws_restJson1StaticKeyProvider(output.staticKeyProvider, context)
         : undefined,
-    Type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    Type: __expectString(output.type),
   } as any;
 };
 
@@ -8360,122 +7913,66 @@ const deserializeAws_restJson1HlsGroupSettings = (output: any, context: __SerdeC
       output.additionalManifests !== undefined && output.additionalManifests !== null
         ? deserializeAws_restJson1__listOfHlsAdditionalManifest(output.additionalManifests, context)
         : undefined,
-    AudioOnlyHeader:
-      output.audioOnlyHeader !== undefined && output.audioOnlyHeader !== null ? output.audioOnlyHeader : undefined,
-    BaseUrl: output.baseUrl !== undefined && output.baseUrl !== null ? output.baseUrl : undefined,
+    AudioOnlyHeader: __expectString(output.audioOnlyHeader),
+    BaseUrl: __expectString(output.baseUrl),
     CaptionLanguageMappings:
       output.captionLanguageMappings !== undefined && output.captionLanguageMappings !== null
         ? deserializeAws_restJson1__listOfHlsCaptionLanguageMapping(output.captionLanguageMappings, context)
         : undefined,
-    CaptionLanguageSetting:
-      output.captionLanguageSetting !== undefined && output.captionLanguageSetting !== null
-        ? output.captionLanguageSetting
-        : undefined,
-    ClientCache: output.clientCache !== undefined && output.clientCache !== null ? output.clientCache : undefined,
-    CodecSpecification:
-      output.codecSpecification !== undefined && output.codecSpecification !== null
-        ? output.codecSpecification
-        : undefined,
-    Destination: output.destination !== undefined && output.destination !== null ? output.destination : undefined,
+    CaptionLanguageSetting: __expectString(output.captionLanguageSetting),
+    ClientCache: __expectString(output.clientCache),
+    CodecSpecification: __expectString(output.codecSpecification),
+    Destination: __expectString(output.destination),
     DestinationSettings:
       output.destinationSettings !== undefined && output.destinationSettings !== null
         ? deserializeAws_restJson1DestinationSettings(output.destinationSettings, context)
         : undefined,
-    DirectoryStructure:
-      output.directoryStructure !== undefined && output.directoryStructure !== null
-        ? output.directoryStructure
-        : undefined,
+    DirectoryStructure: __expectString(output.directoryStructure),
     Encryption:
       output.encryption !== undefined && output.encryption !== null
         ? deserializeAws_restJson1HlsEncryptionSettings(output.encryption, context)
         : undefined,
-    ManifestCompression:
-      output.manifestCompression !== undefined && output.manifestCompression !== null
-        ? output.manifestCompression
-        : undefined,
-    ManifestDurationFormat:
-      output.manifestDurationFormat !== undefined && output.manifestDurationFormat !== null
-        ? output.manifestDurationFormat
-        : undefined,
-    MinFinalSegmentLength:
-      output.minFinalSegmentLength !== undefined && output.minFinalSegmentLength !== null
-        ? output.minFinalSegmentLength
-        : undefined,
-    MinSegmentLength:
-      output.minSegmentLength !== undefined && output.minSegmentLength !== null ? output.minSegmentLength : undefined,
-    OutputSelection:
-      output.outputSelection !== undefined && output.outputSelection !== null ? output.outputSelection : undefined,
-    ProgramDateTime:
-      output.programDateTime !== undefined && output.programDateTime !== null ? output.programDateTime : undefined,
-    ProgramDateTimePeriod:
-      output.programDateTimePeriod !== undefined && output.programDateTimePeriod !== null
-        ? output.programDateTimePeriod
-        : undefined,
-    SegmentControl:
-      output.segmentControl !== undefined && output.segmentControl !== null ? output.segmentControl : undefined,
-    SegmentLength:
-      output.segmentLength !== undefined && output.segmentLength !== null ? output.segmentLength : undefined,
-    SegmentsPerSubdirectory:
-      output.segmentsPerSubdirectory !== undefined && output.segmentsPerSubdirectory !== null
-        ? output.segmentsPerSubdirectory
-        : undefined,
-    StreamInfResolution:
-      output.streamInfResolution !== undefined && output.streamInfResolution !== null
-        ? output.streamInfResolution
-        : undefined,
-    TimedMetadataId3Frame:
-      output.timedMetadataId3Frame !== undefined && output.timedMetadataId3Frame !== null
-        ? output.timedMetadataId3Frame
-        : undefined,
-    TimedMetadataId3Period:
-      output.timedMetadataId3Period !== undefined && output.timedMetadataId3Period !== null
-        ? output.timedMetadataId3Period
-        : undefined,
-    TimestampDeltaMilliseconds:
-      output.timestampDeltaMilliseconds !== undefined && output.timestampDeltaMilliseconds !== null
-        ? output.timestampDeltaMilliseconds
-        : undefined,
+    ManifestCompression: __expectString(output.manifestCompression),
+    ManifestDurationFormat: __expectString(output.manifestDurationFormat),
+    MinFinalSegmentLength: __expectNumber(output.minFinalSegmentLength),
+    MinSegmentLength: __expectNumber(output.minSegmentLength),
+    OutputSelection: __expectString(output.outputSelection),
+    ProgramDateTime: __expectString(output.programDateTime),
+    ProgramDateTimePeriod: __expectNumber(output.programDateTimePeriod),
+    SegmentControl: __expectString(output.segmentControl),
+    SegmentLength: __expectNumber(output.segmentLength),
+    SegmentsPerSubdirectory: __expectNumber(output.segmentsPerSubdirectory),
+    StreamInfResolution: __expectString(output.streamInfResolution),
+    TimedMetadataId3Frame: __expectString(output.timedMetadataId3Frame),
+    TimedMetadataId3Period: __expectNumber(output.timedMetadataId3Period),
+    TimestampDeltaMilliseconds: __expectNumber(output.timestampDeltaMilliseconds),
   } as any;
 };
 
 const deserializeAws_restJson1HlsSettings = (output: any, context: __SerdeContext): HlsSettings => {
   return {
-    AudioGroupId: output.audioGroupId !== undefined && output.audioGroupId !== null ? output.audioGroupId : undefined,
-    AudioOnlyContainer:
-      output.audioOnlyContainer !== undefined && output.audioOnlyContainer !== null
-        ? output.audioOnlyContainer
-        : undefined,
-    AudioRenditionSets:
-      output.audioRenditionSets !== undefined && output.audioRenditionSets !== null
-        ? output.audioRenditionSets
-        : undefined,
-    AudioTrackType:
-      output.audioTrackType !== undefined && output.audioTrackType !== null ? output.audioTrackType : undefined,
-    DescriptiveVideoServiceFlag:
-      output.descriptiveVideoServiceFlag !== undefined && output.descriptiveVideoServiceFlag !== null
-        ? output.descriptiveVideoServiceFlag
-        : undefined,
-    IFrameOnlyManifest:
-      output.iFrameOnlyManifest !== undefined && output.iFrameOnlyManifest !== null
-        ? output.iFrameOnlyManifest
-        : undefined,
-    SegmentModifier:
-      output.segmentModifier !== undefined && output.segmentModifier !== null ? output.segmentModifier : undefined,
+    AudioGroupId: __expectString(output.audioGroupId),
+    AudioOnlyContainer: __expectString(output.audioOnlyContainer),
+    AudioRenditionSets: __expectString(output.audioRenditionSets),
+    AudioTrackType: __expectString(output.audioTrackType),
+    DescriptiveVideoServiceFlag: __expectString(output.descriptiveVideoServiceFlag),
+    IFrameOnlyManifest: __expectString(output.iFrameOnlyManifest),
+    SegmentModifier: __expectString(output.segmentModifier),
   } as any;
 };
 
 const deserializeAws_restJson1HopDestination = (output: any, context: __SerdeContext): HopDestination => {
   return {
-    Priority: output.priority !== undefined && output.priority !== null ? output.priority : undefined,
-    Queue: output.queue !== undefined && output.queue !== null ? output.queue : undefined,
-    WaitMinutes: output.waitMinutes !== undefined && output.waitMinutes !== null ? output.waitMinutes : undefined,
+    Priority: __expectNumber(output.priority),
+    Queue: __expectString(output.queue),
+    WaitMinutes: __expectNumber(output.waitMinutes),
   } as any;
 };
 
 const deserializeAws_restJson1Id3Insertion = (output: any, context: __SerdeContext): Id3Insertion => {
   return {
-    Id3: output.id3 !== undefined && output.id3 !== null ? output.id3 : undefined,
-    Timecode: output.timecode !== undefined && output.timecode !== null ? output.timecode : undefined,
+    Id3: __expectString(output.id3),
+    Timecode: __expectString(output.timecode),
   } as any;
 };
 
@@ -8493,8 +7990,7 @@ const deserializeAws_restJson1ImscDestinationSettings = (
   context: __SerdeContext
 ): ImscDestinationSettings => {
   return {
-    StylePassthrough:
-      output.stylePassthrough !== undefined && output.stylePassthrough !== null ? output.stylePassthrough : undefined,
+    StylePassthrough: __expectString(output.stylePassthrough),
   } as any;
 };
 
@@ -8516,18 +8012,15 @@ const deserializeAws_restJson1Input = (output: any, context: __SerdeContext): In
       output.crop !== undefined && output.crop !== null
         ? deserializeAws_restJson1Rectangle(output.crop, context)
         : undefined,
-    DeblockFilter:
-      output.deblockFilter !== undefined && output.deblockFilter !== null ? output.deblockFilter : undefined,
+    DeblockFilter: __expectString(output.deblockFilter),
     DecryptionSettings:
       output.decryptionSettings !== undefined && output.decryptionSettings !== null
         ? deserializeAws_restJson1InputDecryptionSettings(output.decryptionSettings, context)
         : undefined,
-    DenoiseFilter:
-      output.denoiseFilter !== undefined && output.denoiseFilter !== null ? output.denoiseFilter : undefined,
-    FileInput: output.fileInput !== undefined && output.fileInput !== null ? output.fileInput : undefined,
-    FilterEnable: output.filterEnable !== undefined && output.filterEnable !== null ? output.filterEnable : undefined,
-    FilterStrength:
-      output.filterStrength !== undefined && output.filterStrength !== null ? output.filterStrength : undefined,
+    DenoiseFilter: __expectString(output.denoiseFilter),
+    FileInput: __expectString(output.fileInput),
+    FilterEnable: __expectString(output.filterEnable),
+    FilterStrength: __expectNumber(output.filterStrength),
     ImageInserter:
       output.imageInserter !== undefined && output.imageInserter !== null
         ? deserializeAws_restJson1ImageInserter(output.imageInserter, context)
@@ -8536,23 +8029,19 @@ const deserializeAws_restJson1Input = (output: any, context: __SerdeContext): In
       output.inputClippings !== undefined && output.inputClippings !== null
         ? deserializeAws_restJson1__listOfInputClipping(output.inputClippings, context)
         : undefined,
-    InputScanType:
-      output.inputScanType !== undefined && output.inputScanType !== null ? output.inputScanType : undefined,
+    InputScanType: __expectString(output.inputScanType),
     Position:
       output.position !== undefined && output.position !== null
         ? deserializeAws_restJson1Rectangle(output.position, context)
         : undefined,
-    ProgramNumber:
-      output.programNumber !== undefined && output.programNumber !== null ? output.programNumber : undefined,
-    PsiControl: output.psiControl !== undefined && output.psiControl !== null ? output.psiControl : undefined,
+    ProgramNumber: __expectNumber(output.programNumber),
+    PsiControl: __expectString(output.psiControl),
     SupplementalImps:
       output.supplementalImps !== undefined && output.supplementalImps !== null
         ? deserializeAws_restJson1__listOf__stringPatternS3ASSETMAPXml(output.supplementalImps, context)
         : undefined,
-    TimecodeSource:
-      output.timecodeSource !== undefined && output.timecodeSource !== null ? output.timecodeSource : undefined,
-    TimecodeStart:
-      output.timecodeStart !== undefined && output.timecodeStart !== null ? output.timecodeStart : undefined,
+    TimecodeSource: __expectString(output.timecodeSource),
+    TimecodeStart: __expectString(output.timecodeStart),
     VideoSelector:
       output.videoSelector !== undefined && output.videoSelector !== null
         ? deserializeAws_restJson1VideoSelector(output.videoSelector, context)
@@ -8562,9 +8051,8 @@ const deserializeAws_restJson1Input = (output: any, context: __SerdeContext): In
 
 const deserializeAws_restJson1InputClipping = (output: any, context: __SerdeContext): InputClipping => {
   return {
-    EndTimecode: output.endTimecode !== undefined && output.endTimecode !== null ? output.endTimecode : undefined,
-    StartTimecode:
-      output.startTimecode !== undefined && output.startTimecode !== null ? output.startTimecode : undefined,
+    EndTimecode: __expectString(output.endTimecode),
+    StartTimecode: __expectString(output.startTimecode),
   } as any;
 };
 
@@ -8573,17 +8061,10 @@ const deserializeAws_restJson1InputDecryptionSettings = (
   context: __SerdeContext
 ): InputDecryptionSettings => {
   return {
-    DecryptionMode:
-      output.decryptionMode !== undefined && output.decryptionMode !== null ? output.decryptionMode : undefined,
-    EncryptedDecryptionKey:
-      output.encryptedDecryptionKey !== undefined && output.encryptedDecryptionKey !== null
-        ? output.encryptedDecryptionKey
-        : undefined,
-    InitializationVector:
-      output.initializationVector !== undefined && output.initializationVector !== null
-        ? output.initializationVector
-        : undefined,
-    KmsKeyRegion: output.kmsKeyRegion !== undefined && output.kmsKeyRegion !== null ? output.kmsKeyRegion : undefined,
+    DecryptionMode: __expectString(output.decryptionMode),
+    EncryptedDecryptionKey: __expectString(output.encryptedDecryptionKey),
+    InitializationVector: __expectString(output.initializationVector),
+    KmsKeyRegion: __expectString(output.kmsKeyRegion),
   } as any;
 };
 
@@ -8605,13 +8086,10 @@ const deserializeAws_restJson1InputTemplate = (output: any, context: __SerdeCont
       output.crop !== undefined && output.crop !== null
         ? deserializeAws_restJson1Rectangle(output.crop, context)
         : undefined,
-    DeblockFilter:
-      output.deblockFilter !== undefined && output.deblockFilter !== null ? output.deblockFilter : undefined,
-    DenoiseFilter:
-      output.denoiseFilter !== undefined && output.denoiseFilter !== null ? output.denoiseFilter : undefined,
-    FilterEnable: output.filterEnable !== undefined && output.filterEnable !== null ? output.filterEnable : undefined,
-    FilterStrength:
-      output.filterStrength !== undefined && output.filterStrength !== null ? output.filterStrength : undefined,
+    DeblockFilter: __expectString(output.deblockFilter),
+    DenoiseFilter: __expectString(output.denoiseFilter),
+    FilterEnable: __expectString(output.filterEnable),
+    FilterStrength: __expectNumber(output.filterStrength),
     ImageInserter:
       output.imageInserter !== undefined && output.imageInserter !== null
         ? deserializeAws_restJson1ImageInserter(output.imageInserter, context)
@@ -8620,19 +8098,15 @@ const deserializeAws_restJson1InputTemplate = (output: any, context: __SerdeCont
       output.inputClippings !== undefined && output.inputClippings !== null
         ? deserializeAws_restJson1__listOfInputClipping(output.inputClippings, context)
         : undefined,
-    InputScanType:
-      output.inputScanType !== undefined && output.inputScanType !== null ? output.inputScanType : undefined,
+    InputScanType: __expectString(output.inputScanType),
     Position:
       output.position !== undefined && output.position !== null
         ? deserializeAws_restJson1Rectangle(output.position, context)
         : undefined,
-    ProgramNumber:
-      output.programNumber !== undefined && output.programNumber !== null ? output.programNumber : undefined,
-    PsiControl: output.psiControl !== undefined && output.psiControl !== null ? output.psiControl : undefined,
-    TimecodeSource:
-      output.timecodeSource !== undefined && output.timecodeSource !== null ? output.timecodeSource : undefined,
-    TimecodeStart:
-      output.timecodeStart !== undefined && output.timecodeStart !== null ? output.timecodeStart : undefined,
+    ProgramNumber: __expectNumber(output.programNumber),
+    PsiControl: __expectString(output.psiControl),
+    TimecodeSource: __expectString(output.timecodeSource),
+    TimecodeStart: __expectString(output.timecodeStart),
     VideoSelector:
       output.videoSelector !== undefined && output.videoSelector !== null
         ? deserializeAws_restJson1VideoSelector(output.videoSelector, context)
@@ -8642,20 +8116,17 @@ const deserializeAws_restJson1InputTemplate = (output: any, context: __SerdeCont
 
 const deserializeAws_restJson1InsertableImage = (output: any, context: __SerdeContext): InsertableImage => {
   return {
-    Duration: output.duration !== undefined && output.duration !== null ? output.duration : undefined,
-    FadeIn: output.fadeIn !== undefined && output.fadeIn !== null ? output.fadeIn : undefined,
-    FadeOut: output.fadeOut !== undefined && output.fadeOut !== null ? output.fadeOut : undefined,
-    Height: output.height !== undefined && output.height !== null ? output.height : undefined,
-    ImageInserterInput:
-      output.imageInserterInput !== undefined && output.imageInserterInput !== null
-        ? output.imageInserterInput
-        : undefined,
-    ImageX: output.imageX !== undefined && output.imageX !== null ? output.imageX : undefined,
-    ImageY: output.imageY !== undefined && output.imageY !== null ? output.imageY : undefined,
-    Layer: output.layer !== undefined && output.layer !== null ? output.layer : undefined,
-    Opacity: output.opacity !== undefined && output.opacity !== null ? output.opacity : undefined,
-    StartTime: output.startTime !== undefined && output.startTime !== null ? output.startTime : undefined,
-    Width: output.width !== undefined && output.width !== null ? output.width : undefined,
+    Duration: __expectNumber(output.duration),
+    FadeIn: __expectNumber(output.fadeIn),
+    FadeOut: __expectNumber(output.fadeOut),
+    Height: __expectNumber(output.height),
+    ImageInserterInput: __expectString(output.imageInserterInput),
+    ImageX: __expectNumber(output.imageX),
+    ImageY: __expectNumber(output.imageY),
+    Layer: __expectNumber(output.layer),
+    Opacity: __expectNumber(output.opacity),
+    StartTime: __expectString(output.startTime),
+    Width: __expectNumber(output.width),
   } as any;
 };
 
@@ -8665,32 +8136,23 @@ const deserializeAws_restJson1Job = (output: any, context: __SerdeContext): Job 
       output.accelerationSettings !== undefined && output.accelerationSettings !== null
         ? deserializeAws_restJson1AccelerationSettings(output.accelerationSettings, context)
         : undefined,
-    AccelerationStatus:
-      output.accelerationStatus !== undefined && output.accelerationStatus !== null
-        ? output.accelerationStatus
-        : undefined,
-    Arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    BillingTagsSource:
-      output.billingTagsSource !== undefined && output.billingTagsSource !== null
-        ? output.billingTagsSource
-        : undefined,
+    AccelerationStatus: __expectString(output.accelerationStatus),
+    Arn: __expectString(output.arn),
+    BillingTagsSource: __expectString(output.billingTagsSource),
     CreatedAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    CurrentPhase: output.currentPhase !== undefined && output.currentPhase !== null ? output.currentPhase : undefined,
-    ErrorCode: output.errorCode !== undefined && output.errorCode !== null ? output.errorCode : undefined,
-    ErrorMessage: output.errorMessage !== undefined && output.errorMessage !== null ? output.errorMessage : undefined,
+    CurrentPhase: __expectString(output.currentPhase),
+    ErrorCode: __expectNumber(output.errorCode),
+    ErrorMessage: __expectString(output.errorMessage),
     HopDestinations:
       output.hopDestinations !== undefined && output.hopDestinations !== null
         ? deserializeAws_restJson1__listOfHopDestination(output.hopDestinations, context)
         : undefined,
-    Id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    JobPercentComplete:
-      output.jobPercentComplete !== undefined && output.jobPercentComplete !== null
-        ? output.jobPercentComplete
-        : undefined,
-    JobTemplate: output.jobTemplate !== undefined && output.jobTemplate !== null ? output.jobTemplate : undefined,
+    Id: __expectString(output.id),
+    JobPercentComplete: __expectNumber(output.jobPercentComplete),
+    JobTemplate: __expectString(output.jobTemplate),
     Messages:
       output.messages !== undefined && output.messages !== null
         ? deserializeAws_restJson1JobMessages(output.messages, context)
@@ -8699,27 +8161,21 @@ const deserializeAws_restJson1Job = (output: any, context: __SerdeContext): Job 
       output.outputGroupDetails !== undefined && output.outputGroupDetails !== null
         ? deserializeAws_restJson1__listOfOutputGroupDetail(output.outputGroupDetails, context)
         : undefined,
-    Priority: output.priority !== undefined && output.priority !== null ? output.priority : undefined,
-    Queue: output.queue !== undefined && output.queue !== null ? output.queue : undefined,
+    Priority: __expectNumber(output.priority),
+    Queue: __expectString(output.queue),
     QueueTransitions:
       output.queueTransitions !== undefined && output.queueTransitions !== null
         ? deserializeAws_restJson1__listOfQueueTransition(output.queueTransitions, context)
         : undefined,
-    RetryCount: output.retryCount !== undefined && output.retryCount !== null ? output.retryCount : undefined,
-    Role: output.role !== undefined && output.role !== null ? output.role : undefined,
+    RetryCount: __expectNumber(output.retryCount),
+    Role: __expectString(output.role),
     Settings:
       output.settings !== undefined && output.settings !== null
         ? deserializeAws_restJson1JobSettings(output.settings, context)
         : undefined,
-    SimulateReservedQueue:
-      output.simulateReservedQueue !== undefined && output.simulateReservedQueue !== null
-        ? output.simulateReservedQueue
-        : undefined,
-    Status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    StatusUpdateInterval:
-      output.statusUpdateInterval !== undefined && output.statusUpdateInterval !== null
-        ? output.statusUpdateInterval
-        : undefined,
+    SimulateReservedQueue: __expectString(output.simulateReservedQueue),
+    Status: __expectString(output.status),
+    StatusUpdateInterval: __expectString(output.statusUpdateInterval),
     Timing:
       output.timing !== undefined && output.timing !== null
         ? deserializeAws_restJson1Timing(output.timing, context)
@@ -8746,8 +8202,7 @@ const deserializeAws_restJson1JobMessages = (output: any, context: __SerdeContex
 
 const deserializeAws_restJson1JobSettings = (output: any, context: __SerdeContext): JobSettings => {
   return {
-    AdAvailOffset:
-      output.adAvailOffset !== undefined && output.adAvailOffset !== null ? output.adAvailOffset : undefined,
+    AdAvailOffset: __expectNumber(output.adAvailOffset),
     AvailBlanking:
       output.availBlanking !== undefined && output.availBlanking !== null
         ? deserializeAws_restJson1AvailBlanking(output.availBlanking, context)
@@ -8797,13 +8252,13 @@ const deserializeAws_restJson1JobTemplate = (output: any, context: __SerdeContex
       output.accelerationSettings !== undefined && output.accelerationSettings !== null
         ? deserializeAws_restJson1AccelerationSettings(output.accelerationSettings, context)
         : undefined,
-    Arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    Category: output.category !== undefined && output.category !== null ? output.category : undefined,
+    Arn: __expectString(output.arn),
+    Category: __expectString(output.category),
     CreatedAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    Description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    Description: __expectString(output.description),
     HopDestinations:
       output.hopDestinations !== undefined && output.hopDestinations !== null
         ? deserializeAws_restJson1__listOfHopDestination(output.hopDestinations, context)
@@ -8812,25 +8267,21 @@ const deserializeAws_restJson1JobTemplate = (output: any, context: __SerdeContex
       output.lastUpdated !== undefined && output.lastUpdated !== null
         ? new Date(Math.round(output.lastUpdated * 1000))
         : undefined,
-    Name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    Priority: output.priority !== undefined && output.priority !== null ? output.priority : undefined,
-    Queue: output.queue !== undefined && output.queue !== null ? output.queue : undefined,
+    Name: __expectString(output.name),
+    Priority: __expectNumber(output.priority),
+    Queue: __expectString(output.queue),
     Settings:
       output.settings !== undefined && output.settings !== null
         ? deserializeAws_restJson1JobTemplateSettings(output.settings, context)
         : undefined,
-    StatusUpdateInterval:
-      output.statusUpdateInterval !== undefined && output.statusUpdateInterval !== null
-        ? output.statusUpdateInterval
-        : undefined,
-    Type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    StatusUpdateInterval: __expectString(output.statusUpdateInterval),
+    Type: __expectString(output.type),
   } as any;
 };
 
 const deserializeAws_restJson1JobTemplateSettings = (output: any, context: __SerdeContext): JobTemplateSettings => {
   return {
-    AdAvailOffset:
-      output.adAvailOffset !== undefined && output.adAvailOffset !== null ? output.adAvailOffset : undefined,
+    AdAvailOffset: __expectNumber(output.adAvailOffset),
     AvailBlanking:
       output.availBlanking !== undefined && output.availBlanking !== null
         ? deserializeAws_restJson1AvailBlanking(output.availBlanking, context)
@@ -8879,52 +8330,39 @@ const deserializeAws_restJson1KantarWatermarkSettings = (
   context: __SerdeContext
 ): KantarWatermarkSettings => {
   return {
-    ChannelName: output.channelName !== undefined && output.channelName !== null ? output.channelName : undefined,
-    ContentReference:
-      output.contentReference !== undefined && output.contentReference !== null ? output.contentReference : undefined,
-    CredentialsSecretName:
-      output.credentialsSecretName !== undefined && output.credentialsSecretName !== null
-        ? output.credentialsSecretName
-        : undefined,
-    FileOffset: output.fileOffset !== undefined && output.fileOffset !== null ? output.fileOffset : undefined,
-    KantarLicenseId:
-      output.kantarLicenseId !== undefined && output.kantarLicenseId !== null ? output.kantarLicenseId : undefined,
-    KantarServerUrl:
-      output.kantarServerUrl !== undefined && output.kantarServerUrl !== null ? output.kantarServerUrl : undefined,
-    LogDestination:
-      output.logDestination !== undefined && output.logDestination !== null ? output.logDestination : undefined,
-    Metadata3: output.metadata3 !== undefined && output.metadata3 !== null ? output.metadata3 : undefined,
-    Metadata4: output.metadata4 !== undefined && output.metadata4 !== null ? output.metadata4 : undefined,
-    Metadata5: output.metadata5 !== undefined && output.metadata5 !== null ? output.metadata5 : undefined,
-    Metadata6: output.metadata6 !== undefined && output.metadata6 !== null ? output.metadata6 : undefined,
-    Metadata7: output.metadata7 !== undefined && output.metadata7 !== null ? output.metadata7 : undefined,
-    Metadata8: output.metadata8 !== undefined && output.metadata8 !== null ? output.metadata8 : undefined,
+    ChannelName: __expectString(output.channelName),
+    ContentReference: __expectString(output.contentReference),
+    CredentialsSecretName: __expectString(output.credentialsSecretName),
+    FileOffset: __expectNumber(output.fileOffset),
+    KantarLicenseId: __expectNumber(output.kantarLicenseId),
+    KantarServerUrl: __expectString(output.kantarServerUrl),
+    LogDestination: __expectString(output.logDestination),
+    Metadata3: __expectString(output.metadata3),
+    Metadata4: __expectString(output.metadata4),
+    Metadata5: __expectString(output.metadata5),
+    Metadata6: __expectString(output.metadata6),
+    Metadata7: __expectString(output.metadata7),
+    Metadata8: __expectString(output.metadata8),
   } as any;
 };
 
 const deserializeAws_restJson1M2tsScte35Esam = (output: any, context: __SerdeContext): M2tsScte35Esam => {
   return {
-    Scte35EsamPid:
-      output.scte35EsamPid !== undefined && output.scte35EsamPid !== null ? output.scte35EsamPid : undefined,
+    Scte35EsamPid: __expectNumber(output.scte35EsamPid),
   } as any;
 };
 
 const deserializeAws_restJson1M2tsSettings = (output: any, context: __SerdeContext): M2tsSettings => {
   return {
-    AudioBufferModel:
-      output.audioBufferModel !== undefined && output.audioBufferModel !== null ? output.audioBufferModel : undefined,
-    AudioDuration:
-      output.audioDuration !== undefined && output.audioDuration !== null ? output.audioDuration : undefined,
-    AudioFramesPerPes:
-      output.audioFramesPerPes !== undefined && output.audioFramesPerPes !== null
-        ? output.audioFramesPerPes
-        : undefined,
+    AudioBufferModel: __expectString(output.audioBufferModel),
+    AudioDuration: __expectString(output.audioDuration),
+    AudioFramesPerPes: __expectNumber(output.audioFramesPerPes),
     AudioPids:
       output.audioPids !== undefined && output.audioPids !== null
         ? deserializeAws_restJson1__listOf__integerMin32Max8182(output.audioPids, context)
         : undefined,
-    Bitrate: output.bitrate !== undefined && output.bitrate !== null ? output.bitrate : undefined,
-    BufferModel: output.bufferModel !== undefined && output.bufferModel !== null ? output.bufferModel : undefined,
+    Bitrate: __expectNumber(output.bitrate),
+    BufferModel: __expectString(output.bufferModel),
     DvbNitSettings:
       output.dvbNitSettings !== undefined && output.dvbNitSettings !== null
         ? deserializeAws_restJson1DvbNitSettings(output.dvbNitSettings, context)
@@ -8941,101 +8379,62 @@ const deserializeAws_restJson1M2tsSettings = (output: any, context: __SerdeConte
       output.dvbTdtSettings !== undefined && output.dvbTdtSettings !== null
         ? deserializeAws_restJson1DvbTdtSettings(output.dvbTdtSettings, context)
         : undefined,
-    DvbTeletextPid:
-      output.dvbTeletextPid !== undefined && output.dvbTeletextPid !== null ? output.dvbTeletextPid : undefined,
-    EbpAudioInterval:
-      output.ebpAudioInterval !== undefined && output.ebpAudioInterval !== null ? output.ebpAudioInterval : undefined,
-    EbpPlacement: output.ebpPlacement !== undefined && output.ebpPlacement !== null ? output.ebpPlacement : undefined,
-    EsRateInPes: output.esRateInPes !== undefined && output.esRateInPes !== null ? output.esRateInPes : undefined,
-    ForceTsVideoEbpOrder:
-      output.forceTsVideoEbpOrder !== undefined && output.forceTsVideoEbpOrder !== null
-        ? output.forceTsVideoEbpOrder
-        : undefined,
-    FragmentTime: output.fragmentTime !== undefined && output.fragmentTime !== null ? output.fragmentTime : undefined,
-    MaxPcrInterval:
-      output.maxPcrInterval !== undefined && output.maxPcrInterval !== null ? output.maxPcrInterval : undefined,
-    MinEbpInterval:
-      output.minEbpInterval !== undefined && output.minEbpInterval !== null ? output.minEbpInterval : undefined,
-    NielsenId3: output.nielsenId3 !== undefined && output.nielsenId3 !== null ? output.nielsenId3 : undefined,
-    NullPacketBitrate:
-      output.nullPacketBitrate !== undefined && output.nullPacketBitrate !== null
-        ? output.nullPacketBitrate
-        : undefined,
-    PatInterval: output.patInterval !== undefined && output.patInterval !== null ? output.patInterval : undefined,
-    PcrControl: output.pcrControl !== undefined && output.pcrControl !== null ? output.pcrControl : undefined,
-    PcrPid: output.pcrPid !== undefined && output.pcrPid !== null ? output.pcrPid : undefined,
-    PmtInterval: output.pmtInterval !== undefined && output.pmtInterval !== null ? output.pmtInterval : undefined,
-    PmtPid: output.pmtPid !== undefined && output.pmtPid !== null ? output.pmtPid : undefined,
-    PrivateMetadataPid:
-      output.privateMetadataPid !== undefined && output.privateMetadataPid !== null
-        ? output.privateMetadataPid
-        : undefined,
-    ProgramNumber:
-      output.programNumber !== undefined && output.programNumber !== null ? output.programNumber : undefined,
-    RateMode: output.rateMode !== undefined && output.rateMode !== null ? output.rateMode : undefined,
+    DvbTeletextPid: __expectNumber(output.dvbTeletextPid),
+    EbpAudioInterval: __expectString(output.ebpAudioInterval),
+    EbpPlacement: __expectString(output.ebpPlacement),
+    EsRateInPes: __expectString(output.esRateInPes),
+    ForceTsVideoEbpOrder: __expectString(output.forceTsVideoEbpOrder),
+    FragmentTime: __expectNumber(output.fragmentTime),
+    MaxPcrInterval: __expectNumber(output.maxPcrInterval),
+    MinEbpInterval: __expectNumber(output.minEbpInterval),
+    NielsenId3: __expectString(output.nielsenId3),
+    NullPacketBitrate: __expectNumber(output.nullPacketBitrate),
+    PatInterval: __expectNumber(output.patInterval),
+    PcrControl: __expectString(output.pcrControl),
+    PcrPid: __expectNumber(output.pcrPid),
+    PmtInterval: __expectNumber(output.pmtInterval),
+    PmtPid: __expectNumber(output.pmtPid),
+    PrivateMetadataPid: __expectNumber(output.privateMetadataPid),
+    ProgramNumber: __expectNumber(output.programNumber),
+    RateMode: __expectString(output.rateMode),
     Scte35Esam:
       output.scte35Esam !== undefined && output.scte35Esam !== null
         ? deserializeAws_restJson1M2tsScte35Esam(output.scte35Esam, context)
         : undefined,
-    Scte35Pid: output.scte35Pid !== undefined && output.scte35Pid !== null ? output.scte35Pid : undefined,
-    Scte35Source: output.scte35Source !== undefined && output.scte35Source !== null ? output.scte35Source : undefined,
-    SegmentationMarkers:
-      output.segmentationMarkers !== undefined && output.segmentationMarkers !== null
-        ? output.segmentationMarkers
-        : undefined,
-    SegmentationStyle:
-      output.segmentationStyle !== undefined && output.segmentationStyle !== null
-        ? output.segmentationStyle
-        : undefined,
-    SegmentationTime:
-      output.segmentationTime !== undefined && output.segmentationTime !== null ? output.segmentationTime : undefined,
-    TimedMetadataPid:
-      output.timedMetadataPid !== undefined && output.timedMetadataPid !== null ? output.timedMetadataPid : undefined,
-    TransportStreamId:
-      output.transportStreamId !== undefined && output.transportStreamId !== null
-        ? output.transportStreamId
-        : undefined,
-    VideoPid: output.videoPid !== undefined && output.videoPid !== null ? output.videoPid : undefined,
+    Scte35Pid: __expectNumber(output.scte35Pid),
+    Scte35Source: __expectString(output.scte35Source),
+    SegmentationMarkers: __expectString(output.segmentationMarkers),
+    SegmentationStyle: __expectString(output.segmentationStyle),
+    SegmentationTime: __expectNumber(output.segmentationTime),
+    TimedMetadataPid: __expectNumber(output.timedMetadataPid),
+    TransportStreamId: __expectNumber(output.transportStreamId),
+    VideoPid: __expectNumber(output.videoPid),
   } as any;
 };
 
 const deserializeAws_restJson1M3u8Settings = (output: any, context: __SerdeContext): M3u8Settings => {
   return {
-    AudioDuration:
-      output.audioDuration !== undefined && output.audioDuration !== null ? output.audioDuration : undefined,
-    AudioFramesPerPes:
-      output.audioFramesPerPes !== undefined && output.audioFramesPerPes !== null
-        ? output.audioFramesPerPes
-        : undefined,
+    AudioDuration: __expectString(output.audioDuration),
+    AudioFramesPerPes: __expectNumber(output.audioFramesPerPes),
     AudioPids:
       output.audioPids !== undefined && output.audioPids !== null
         ? deserializeAws_restJson1__listOf__integerMin32Max8182(output.audioPids, context)
         : undefined,
-    MaxPcrInterval:
-      output.maxPcrInterval !== undefined && output.maxPcrInterval !== null ? output.maxPcrInterval : undefined,
-    NielsenId3: output.nielsenId3 !== undefined && output.nielsenId3 !== null ? output.nielsenId3 : undefined,
-    PatInterval: output.patInterval !== undefined && output.patInterval !== null ? output.patInterval : undefined,
-    PcrControl: output.pcrControl !== undefined && output.pcrControl !== null ? output.pcrControl : undefined,
-    PcrPid: output.pcrPid !== undefined && output.pcrPid !== null ? output.pcrPid : undefined,
-    PmtInterval: output.pmtInterval !== undefined && output.pmtInterval !== null ? output.pmtInterval : undefined,
-    PmtPid: output.pmtPid !== undefined && output.pmtPid !== null ? output.pmtPid : undefined,
-    PrivateMetadataPid:
-      output.privateMetadataPid !== undefined && output.privateMetadataPid !== null
-        ? output.privateMetadataPid
-        : undefined,
-    ProgramNumber:
-      output.programNumber !== undefined && output.programNumber !== null ? output.programNumber : undefined,
-    Scte35Pid: output.scte35Pid !== undefined && output.scte35Pid !== null ? output.scte35Pid : undefined,
-    Scte35Source: output.scte35Source !== undefined && output.scte35Source !== null ? output.scte35Source : undefined,
-    TimedMetadata:
-      output.timedMetadata !== undefined && output.timedMetadata !== null ? output.timedMetadata : undefined,
-    TimedMetadataPid:
-      output.timedMetadataPid !== undefined && output.timedMetadataPid !== null ? output.timedMetadataPid : undefined,
-    TransportStreamId:
-      output.transportStreamId !== undefined && output.transportStreamId !== null
-        ? output.transportStreamId
-        : undefined,
-    VideoPid: output.videoPid !== undefined && output.videoPid !== null ? output.videoPid : undefined,
+    MaxPcrInterval: __expectNumber(output.maxPcrInterval),
+    NielsenId3: __expectString(output.nielsenId3),
+    PatInterval: __expectNumber(output.patInterval),
+    PcrControl: __expectString(output.pcrControl),
+    PcrPid: __expectNumber(output.pcrPid),
+    PmtInterval: __expectNumber(output.pmtInterval),
+    PmtPid: __expectNumber(output.pmtPid),
+    PrivateMetadataPid: __expectNumber(output.privateMetadataPid),
+    ProgramNumber: __expectNumber(output.programNumber),
+    Scte35Pid: __expectNumber(output.scte35Pid),
+    Scte35Source: __expectString(output.scte35Source),
+    TimedMetadata: __expectString(output.timedMetadata),
+    TimedMetadataPid: __expectNumber(output.timedMetadataPid),
+    TransportStreamId: __expectNumber(output.transportStreamId),
+    VideoPid: __expectNumber(output.videoPid),
   } as any;
 };
 
@@ -9045,15 +8444,14 @@ const deserializeAws_restJson1MotionImageInserter = (output: any, context: __Ser
       output.framerate !== undefined && output.framerate !== null
         ? deserializeAws_restJson1MotionImageInsertionFramerate(output.framerate, context)
         : undefined,
-    Input: output.input !== undefined && output.input !== null ? output.input : undefined,
-    InsertionMode:
-      output.insertionMode !== undefined && output.insertionMode !== null ? output.insertionMode : undefined,
+    Input: __expectString(output.input),
+    InsertionMode: __expectString(output.insertionMode),
     Offset:
       output.offset !== undefined && output.offset !== null
         ? deserializeAws_restJson1MotionImageInsertionOffset(output.offset, context)
         : undefined,
-    Playback: output.playback !== undefined && output.playback !== null ? output.playback : undefined,
-    StartTime: output.startTime !== undefined && output.startTime !== null ? output.startTime : undefined,
+    Playback: __expectString(output.playback),
+    StartTime: __expectString(output.startTime),
   } as any;
 };
 
@@ -9062,14 +8460,8 @@ const deserializeAws_restJson1MotionImageInsertionFramerate = (
   context: __SerdeContext
 ): MotionImageInsertionFramerate => {
   return {
-    FramerateDenominator:
-      output.framerateDenominator !== undefined && output.framerateDenominator !== null
-        ? output.framerateDenominator
-        : undefined,
-    FramerateNumerator:
-      output.framerateNumerator !== undefined && output.framerateNumerator !== null
-        ? output.framerateNumerator
-        : undefined,
+    FramerateDenominator: __expectNumber(output.framerateDenominator),
+    FramerateNumerator: __expectNumber(output.framerateNumerator),
   } as any;
 };
 
@@ -9078,150 +8470,94 @@ const deserializeAws_restJson1MotionImageInsertionOffset = (
   context: __SerdeContext
 ): MotionImageInsertionOffset => {
   return {
-    ImageX: output.imageX !== undefined && output.imageX !== null ? output.imageX : undefined,
-    ImageY: output.imageY !== undefined && output.imageY !== null ? output.imageY : undefined,
+    ImageX: __expectNumber(output.imageX),
+    ImageY: __expectNumber(output.imageY),
   } as any;
 };
 
 const deserializeAws_restJson1MovSettings = (output: any, context: __SerdeContext): MovSettings => {
   return {
-    ClapAtom: output.clapAtom !== undefined && output.clapAtom !== null ? output.clapAtom : undefined,
-    CslgAtom: output.cslgAtom !== undefined && output.cslgAtom !== null ? output.cslgAtom : undefined,
-    Mpeg2FourCCControl:
-      output.mpeg2FourCCControl !== undefined && output.mpeg2FourCCControl !== null
-        ? output.mpeg2FourCCControl
-        : undefined,
-    PaddingControl:
-      output.paddingControl !== undefined && output.paddingControl !== null ? output.paddingControl : undefined,
-    Reference: output.reference !== undefined && output.reference !== null ? output.reference : undefined,
+    ClapAtom: __expectString(output.clapAtom),
+    CslgAtom: __expectString(output.cslgAtom),
+    Mpeg2FourCCControl: __expectString(output.mpeg2FourCCControl),
+    PaddingControl: __expectString(output.paddingControl),
+    Reference: __expectString(output.reference),
   } as any;
 };
 
 const deserializeAws_restJson1Mp2Settings = (output: any, context: __SerdeContext): Mp2Settings => {
   return {
-    Bitrate: output.bitrate !== undefined && output.bitrate !== null ? output.bitrate : undefined,
-    Channels: output.channels !== undefined && output.channels !== null ? output.channels : undefined,
-    SampleRate: output.sampleRate !== undefined && output.sampleRate !== null ? output.sampleRate : undefined,
+    Bitrate: __expectNumber(output.bitrate),
+    Channels: __expectNumber(output.channels),
+    SampleRate: __expectNumber(output.sampleRate),
   } as any;
 };
 
 const deserializeAws_restJson1Mp3Settings = (output: any, context: __SerdeContext): Mp3Settings => {
   return {
-    Bitrate: output.bitrate !== undefined && output.bitrate !== null ? output.bitrate : undefined,
-    Channels: output.channels !== undefined && output.channels !== null ? output.channels : undefined,
-    RateControlMode:
-      output.rateControlMode !== undefined && output.rateControlMode !== null ? output.rateControlMode : undefined,
-    SampleRate: output.sampleRate !== undefined && output.sampleRate !== null ? output.sampleRate : undefined,
-    VbrQuality: output.vbrQuality !== undefined && output.vbrQuality !== null ? output.vbrQuality : undefined,
+    Bitrate: __expectNumber(output.bitrate),
+    Channels: __expectNumber(output.channels),
+    RateControlMode: __expectString(output.rateControlMode),
+    SampleRate: __expectNumber(output.sampleRate),
+    VbrQuality: __expectNumber(output.vbrQuality),
   } as any;
 };
 
 const deserializeAws_restJson1Mp4Settings = (output: any, context: __SerdeContext): Mp4Settings => {
   return {
-    AudioDuration:
-      output.audioDuration !== undefined && output.audioDuration !== null ? output.audioDuration : undefined,
-    CslgAtom: output.cslgAtom !== undefined && output.cslgAtom !== null ? output.cslgAtom : undefined,
-    CttsVersion: output.cttsVersion !== undefined && output.cttsVersion !== null ? output.cttsVersion : undefined,
-    FreeSpaceBox: output.freeSpaceBox !== undefined && output.freeSpaceBox !== null ? output.freeSpaceBox : undefined,
-    MoovPlacement:
-      output.moovPlacement !== undefined && output.moovPlacement !== null ? output.moovPlacement : undefined,
-    Mp4MajorBrand:
-      output.mp4MajorBrand !== undefined && output.mp4MajorBrand !== null ? output.mp4MajorBrand : undefined,
+    AudioDuration: __expectString(output.audioDuration),
+    CslgAtom: __expectString(output.cslgAtom),
+    CttsVersion: __expectNumber(output.cttsVersion),
+    FreeSpaceBox: __expectString(output.freeSpaceBox),
+    MoovPlacement: __expectString(output.moovPlacement),
+    Mp4MajorBrand: __expectString(output.mp4MajorBrand),
   } as any;
 };
 
 const deserializeAws_restJson1MpdSettings = (output: any, context: __SerdeContext): MpdSettings => {
   return {
-    AccessibilityCaptionHints:
-      output.accessibilityCaptionHints !== undefined && output.accessibilityCaptionHints !== null
-        ? output.accessibilityCaptionHints
-        : undefined,
-    AudioDuration:
-      output.audioDuration !== undefined && output.audioDuration !== null ? output.audioDuration : undefined,
-    CaptionContainerType:
-      output.captionContainerType !== undefined && output.captionContainerType !== null
-        ? output.captionContainerType
-        : undefined,
-    Scte35Esam: output.scte35Esam !== undefined && output.scte35Esam !== null ? output.scte35Esam : undefined,
-    Scte35Source: output.scte35Source !== undefined && output.scte35Source !== null ? output.scte35Source : undefined,
+    AccessibilityCaptionHints: __expectString(output.accessibilityCaptionHints),
+    AudioDuration: __expectString(output.audioDuration),
+    CaptionContainerType: __expectString(output.captionContainerType),
+    Scte35Esam: __expectString(output.scte35Esam),
+    Scte35Source: __expectString(output.scte35Source),
   } as any;
 };
 
 const deserializeAws_restJson1Mpeg2Settings = (output: any, context: __SerdeContext): Mpeg2Settings => {
   return {
-    AdaptiveQuantization:
-      output.adaptiveQuantization !== undefined && output.adaptiveQuantization !== null
-        ? output.adaptiveQuantization
-        : undefined,
-    Bitrate: output.bitrate !== undefined && output.bitrate !== null ? output.bitrate : undefined,
-    CodecLevel: output.codecLevel !== undefined && output.codecLevel !== null ? output.codecLevel : undefined,
-    CodecProfile: output.codecProfile !== undefined && output.codecProfile !== null ? output.codecProfile : undefined,
-    DynamicSubGop:
-      output.dynamicSubGop !== undefined && output.dynamicSubGop !== null ? output.dynamicSubGop : undefined,
-    FramerateControl:
-      output.framerateControl !== undefined && output.framerateControl !== null ? output.framerateControl : undefined,
-    FramerateConversionAlgorithm:
-      output.framerateConversionAlgorithm !== undefined && output.framerateConversionAlgorithm !== null
-        ? output.framerateConversionAlgorithm
-        : undefined,
-    FramerateDenominator:
-      output.framerateDenominator !== undefined && output.framerateDenominator !== null
-        ? output.framerateDenominator
-        : undefined,
-    FramerateNumerator:
-      output.framerateNumerator !== undefined && output.framerateNumerator !== null
-        ? output.framerateNumerator
-        : undefined,
-    GopClosedCadence:
-      output.gopClosedCadence !== undefined && output.gopClosedCadence !== null ? output.gopClosedCadence : undefined,
-    GopSize: output.gopSize !== undefined && output.gopSize !== null ? output.gopSize : undefined,
-    GopSizeUnits: output.gopSizeUnits !== undefined && output.gopSizeUnits !== null ? output.gopSizeUnits : undefined,
-    HrdBufferInitialFillPercentage:
-      output.hrdBufferInitialFillPercentage !== undefined && output.hrdBufferInitialFillPercentage !== null
-        ? output.hrdBufferInitialFillPercentage
-        : undefined,
-    HrdBufferSize:
-      output.hrdBufferSize !== undefined && output.hrdBufferSize !== null ? output.hrdBufferSize : undefined,
-    InterlaceMode:
-      output.interlaceMode !== undefined && output.interlaceMode !== null ? output.interlaceMode : undefined,
-    IntraDcPrecision:
-      output.intraDcPrecision !== undefined && output.intraDcPrecision !== null ? output.intraDcPrecision : undefined,
-    MaxBitrate: output.maxBitrate !== undefined && output.maxBitrate !== null ? output.maxBitrate : undefined,
-    MinIInterval: output.minIInterval !== undefined && output.minIInterval !== null ? output.minIInterval : undefined,
-    NumberBFramesBetweenReferenceFrames:
-      output.numberBFramesBetweenReferenceFrames !== undefined && output.numberBFramesBetweenReferenceFrames !== null
-        ? output.numberBFramesBetweenReferenceFrames
-        : undefined,
-    ParControl: output.parControl !== undefined && output.parControl !== null ? output.parControl : undefined,
-    ParDenominator:
-      output.parDenominator !== undefined && output.parDenominator !== null ? output.parDenominator : undefined,
-    ParNumerator: output.parNumerator !== undefined && output.parNumerator !== null ? output.parNumerator : undefined,
-    QualityTuningLevel:
-      output.qualityTuningLevel !== undefined && output.qualityTuningLevel !== null
-        ? output.qualityTuningLevel
-        : undefined,
-    RateControlMode:
-      output.rateControlMode !== undefined && output.rateControlMode !== null ? output.rateControlMode : undefined,
-    ScanTypeConversionMode:
-      output.scanTypeConversionMode !== undefined && output.scanTypeConversionMode !== null
-        ? output.scanTypeConversionMode
-        : undefined,
-    SceneChangeDetect:
-      output.sceneChangeDetect !== undefined && output.sceneChangeDetect !== null
-        ? output.sceneChangeDetect
-        : undefined,
-    SlowPal: output.slowPal !== undefined && output.slowPal !== null ? output.slowPal : undefined,
-    Softness: output.softness !== undefined && output.softness !== null ? output.softness : undefined,
-    SpatialAdaptiveQuantization:
-      output.spatialAdaptiveQuantization !== undefined && output.spatialAdaptiveQuantization !== null
-        ? output.spatialAdaptiveQuantization
-        : undefined,
-    Syntax: output.syntax !== undefined && output.syntax !== null ? output.syntax : undefined,
-    Telecine: output.telecine !== undefined && output.telecine !== null ? output.telecine : undefined,
-    TemporalAdaptiveQuantization:
-      output.temporalAdaptiveQuantization !== undefined && output.temporalAdaptiveQuantization !== null
-        ? output.temporalAdaptiveQuantization
-        : undefined,
+    AdaptiveQuantization: __expectString(output.adaptiveQuantization),
+    Bitrate: __expectNumber(output.bitrate),
+    CodecLevel: __expectString(output.codecLevel),
+    CodecProfile: __expectString(output.codecProfile),
+    DynamicSubGop: __expectString(output.dynamicSubGop),
+    FramerateControl: __expectString(output.framerateControl),
+    FramerateConversionAlgorithm: __expectString(output.framerateConversionAlgorithm),
+    FramerateDenominator: __expectNumber(output.framerateDenominator),
+    FramerateNumerator: __expectNumber(output.framerateNumerator),
+    GopClosedCadence: __expectNumber(output.gopClosedCadence),
+    GopSize: __expectNumber(output.gopSize),
+    GopSizeUnits: __expectString(output.gopSizeUnits),
+    HrdBufferInitialFillPercentage: __expectNumber(output.hrdBufferInitialFillPercentage),
+    HrdBufferSize: __expectNumber(output.hrdBufferSize),
+    InterlaceMode: __expectString(output.interlaceMode),
+    IntraDcPrecision: __expectString(output.intraDcPrecision),
+    MaxBitrate: __expectNumber(output.maxBitrate),
+    MinIInterval: __expectNumber(output.minIInterval),
+    NumberBFramesBetweenReferenceFrames: __expectNumber(output.numberBFramesBetweenReferenceFrames),
+    ParControl: __expectString(output.parControl),
+    ParDenominator: __expectNumber(output.parDenominator),
+    ParNumerator: __expectNumber(output.parNumerator),
+    QualityTuningLevel: __expectString(output.qualityTuningLevel),
+    RateControlMode: __expectString(output.rateControlMode),
+    ScanTypeConversionMode: __expectString(output.scanTypeConversionMode),
+    SceneChangeDetect: __expectString(output.sceneChangeDetect),
+    SlowPal: __expectString(output.slowPal),
+    Softness: __expectNumber(output.softness),
+    SpatialAdaptiveQuantization: __expectString(output.spatialAdaptiveQuantization),
+    Syntax: __expectString(output.syntax),
+    Telecine: __expectString(output.telecine),
+    TemporalAdaptiveQuantization: __expectString(output.temporalAdaptiveQuantization),
   } as any;
 };
 
@@ -9230,10 +8566,7 @@ const deserializeAws_restJson1MsSmoothAdditionalManifest = (
   context: __SerdeContext
 ): MsSmoothAdditionalManifest => {
   return {
-    ManifestNameModifier:
-      output.manifestNameModifier !== undefined && output.manifestNameModifier !== null
-        ? output.manifestNameModifier
-        : undefined,
+    ManifestNameModifier: __expectString(output.manifestNameModifier),
     SelectedOutputs:
       output.selectedOutputs !== undefined && output.selectedOutputs !== null
         ? deserializeAws_restJson1__listOf__stringMin1(output.selectedOutputs, context)
@@ -9259,11 +8592,8 @@ const deserializeAws_restJson1MsSmoothGroupSettings = (output: any, context: __S
       output.additionalManifests !== undefined && output.additionalManifests !== null
         ? deserializeAws_restJson1__listOfMsSmoothAdditionalManifest(output.additionalManifests, context)
         : undefined,
-    AudioDeduplication:
-      output.audioDeduplication !== undefined && output.audioDeduplication !== null
-        ? output.audioDeduplication
-        : undefined,
-    Destination: output.destination !== undefined && output.destination !== null ? output.destination : undefined,
+    AudioDeduplication: __expectString(output.audioDeduplication),
+    Destination: __expectString(output.destination),
     DestinationSettings:
       output.destinationSettings !== undefined && output.destinationSettings !== null
         ? deserializeAws_restJson1DestinationSettings(output.destinationSettings, context)
@@ -9272,17 +8602,15 @@ const deserializeAws_restJson1MsSmoothGroupSettings = (output: any, context: __S
       output.encryption !== undefined && output.encryption !== null
         ? deserializeAws_restJson1MsSmoothEncryptionSettings(output.encryption, context)
         : undefined,
-    FragmentLength:
-      output.fragmentLength !== undefined && output.fragmentLength !== null ? output.fragmentLength : undefined,
-    ManifestEncoding:
-      output.manifestEncoding !== undefined && output.manifestEncoding !== null ? output.manifestEncoding : undefined,
+    FragmentLength: __expectNumber(output.fragmentLength),
+    ManifestEncoding: __expectString(output.manifestEncoding),
   } as any;
 };
 
 const deserializeAws_restJson1MxfSettings = (output: any, context: __SerdeContext): MxfSettings => {
   return {
-    AfdSignaling: output.afdSignaling !== undefined && output.afdSignaling !== null ? output.afdSignaling : undefined,
-    Profile: output.profile !== undefined && output.profile !== null ? output.profile : undefined,
+    AfdSignaling: __expectString(output.afdSignaling),
+    Profile: __expectString(output.profile),
   } as any;
 };
 
@@ -9291,18 +8619,17 @@ const deserializeAws_restJson1NexGuardFileMarkerSettings = (
   context: __SerdeContext
 ): NexGuardFileMarkerSettings => {
   return {
-    License: output.license !== undefined && output.license !== null ? output.license : undefined,
-    Payload: output.payload !== undefined && output.payload !== null ? output.payload : undefined,
-    Preset: output.preset !== undefined && output.preset !== null ? output.preset : undefined,
-    Strength: output.strength !== undefined && output.strength !== null ? output.strength : undefined,
+    License: __expectString(output.license),
+    Payload: __expectNumber(output.payload),
+    Preset: __expectString(output.preset),
+    Strength: __expectString(output.strength),
   } as any;
 };
 
 const deserializeAws_restJson1NielsenConfiguration = (output: any, context: __SerdeContext): NielsenConfiguration => {
   return {
-    BreakoutCode: output.breakoutCode !== undefined && output.breakoutCode !== null ? output.breakoutCode : undefined,
-    DistributorId:
-      output.distributorId !== undefined && output.distributorId !== null ? output.distributorId : undefined,
+    BreakoutCode: __expectNumber(output.breakoutCode),
+    DistributorId: __expectString(output.distributorId),
   } as any;
 };
 
@@ -9311,35 +8638,23 @@ const deserializeAws_restJson1NielsenNonLinearWatermarkSettings = (
   context: __SerdeContext
 ): NielsenNonLinearWatermarkSettings => {
   return {
-    ActiveWatermarkProcess:
-      output.activeWatermarkProcess !== undefined && output.activeWatermarkProcess !== null
-        ? output.activeWatermarkProcess
-        : undefined,
-    AdiFilename: output.adiFilename !== undefined && output.adiFilename !== null ? output.adiFilename : undefined,
-    AssetId: output.assetId !== undefined && output.assetId !== null ? output.assetId : undefined,
-    AssetName: output.assetName !== undefined && output.assetName !== null ? output.assetName : undefined,
-    CbetSourceId: output.cbetSourceId !== undefined && output.cbetSourceId !== null ? output.cbetSourceId : undefined,
-    EpisodeId: output.episodeId !== undefined && output.episodeId !== null ? output.episodeId : undefined,
-    MetadataDestination:
-      output.metadataDestination !== undefined && output.metadataDestination !== null
-        ? output.metadataDestination
-        : undefined,
-    SourceId: output.sourceId !== undefined && output.sourceId !== null ? output.sourceId : undefined,
-    SourceWatermarkStatus:
-      output.sourceWatermarkStatus !== undefined && output.sourceWatermarkStatus !== null
-        ? output.sourceWatermarkStatus
-        : undefined,
-    TicServerUrl: output.ticServerUrl !== undefined && output.ticServerUrl !== null ? output.ticServerUrl : undefined,
-    UniqueTicPerAudioTrack:
-      output.uniqueTicPerAudioTrack !== undefined && output.uniqueTicPerAudioTrack !== null
-        ? output.uniqueTicPerAudioTrack
-        : undefined,
+    ActiveWatermarkProcess: __expectString(output.activeWatermarkProcess),
+    AdiFilename: __expectString(output.adiFilename),
+    AssetId: __expectString(output.assetId),
+    AssetName: __expectString(output.assetName),
+    CbetSourceId: __expectString(output.cbetSourceId),
+    EpisodeId: __expectString(output.episodeId),
+    MetadataDestination: __expectString(output.metadataDestination),
+    SourceId: __expectNumber(output.sourceId),
+    SourceWatermarkStatus: __expectString(output.sourceWatermarkStatus),
+    TicServerUrl: __expectString(output.ticServerUrl),
+    UniqueTicPerAudioTrack: __expectString(output.uniqueTicPerAudioTrack),
   } as any;
 };
 
 const deserializeAws_restJson1NoiseReducer = (output: any, context: __SerdeContext): NoiseReducer => {
   return {
-    Filter: output.filter !== undefined && output.filter !== null ? output.filter : undefined,
+    Filter: __expectString(output.filter),
     FilterSettings:
       output.filterSettings !== undefined && output.filterSettings !== null
         ? deserializeAws_restJson1NoiseReducerFilterSettings(output.filterSettings, context)
@@ -9360,7 +8675,7 @@ const deserializeAws_restJson1NoiseReducerFilterSettings = (
   context: __SerdeContext
 ): NoiseReducerFilterSettings => {
   return {
-    Strength: output.strength !== undefined && output.strength !== null ? output.strength : undefined,
+    Strength: __expectNumber(output.strength),
   } as any;
 };
 
@@ -9369,12 +8684,9 @@ const deserializeAws_restJson1NoiseReducerSpatialFilterSettings = (
   context: __SerdeContext
 ): NoiseReducerSpatialFilterSettings => {
   return {
-    PostFilterSharpenStrength:
-      output.postFilterSharpenStrength !== undefined && output.postFilterSharpenStrength !== null
-        ? output.postFilterSharpenStrength
-        : undefined,
-    Speed: output.speed !== undefined && output.speed !== null ? output.speed : undefined,
-    Strength: output.strength !== undefined && output.strength !== null ? output.strength : undefined,
+    PostFilterSharpenStrength: __expectNumber(output.postFilterSharpenStrength),
+    Speed: __expectNumber(output.speed),
+    Strength: __expectNumber(output.strength),
   } as any;
 };
 
@@ -9383,22 +8695,18 @@ const deserializeAws_restJson1NoiseReducerTemporalFilterSettings = (
   context: __SerdeContext
 ): NoiseReducerTemporalFilterSettings => {
   return {
-    AggressiveMode:
-      output.aggressiveMode !== undefined && output.aggressiveMode !== null ? output.aggressiveMode : undefined,
-    PostTemporalSharpening:
-      output.postTemporalSharpening !== undefined && output.postTemporalSharpening !== null
-        ? output.postTemporalSharpening
-        : undefined,
-    Speed: output.speed !== undefined && output.speed !== null ? output.speed : undefined,
-    Strength: output.strength !== undefined && output.strength !== null ? output.strength : undefined,
+    AggressiveMode: __expectNumber(output.aggressiveMode),
+    PostTemporalSharpening: __expectString(output.postTemporalSharpening),
+    Speed: __expectNumber(output.speed),
+    Strength: __expectNumber(output.strength),
   } as any;
 };
 
 const deserializeAws_restJson1OpusSettings = (output: any, context: __SerdeContext): OpusSettings => {
   return {
-    Bitrate: output.bitrate !== undefined && output.bitrate !== null ? output.bitrate : undefined,
-    Channels: output.channels !== undefined && output.channels !== null ? output.channels : undefined,
-    SampleRate: output.sampleRate !== undefined && output.sampleRate !== null ? output.sampleRate : undefined,
+    Bitrate: __expectNumber(output.bitrate),
+    Channels: __expectNumber(output.channels),
+    SampleRate: __expectNumber(output.sampleRate),
   } as any;
 };
 
@@ -9416,13 +8724,13 @@ const deserializeAws_restJson1Output = (output: any, context: __SerdeContext): O
       output.containerSettings !== undefined && output.containerSettings !== null
         ? deserializeAws_restJson1ContainerSettings(output.containerSettings, context)
         : undefined,
-    Extension: output.extension !== undefined && output.extension !== null ? output.extension : undefined,
-    NameModifier: output.nameModifier !== undefined && output.nameModifier !== null ? output.nameModifier : undefined,
+    Extension: __expectString(output.extension),
+    NameModifier: __expectString(output.nameModifier),
     OutputSettings:
       output.outputSettings !== undefined && output.outputSettings !== null
         ? deserializeAws_restJson1OutputSettings(output.outputSettings, context)
         : undefined,
-    Preset: output.preset !== undefined && output.preset !== null ? output.preset : undefined,
+    Preset: __expectString(output.preset),
     VideoDescription:
       output.videoDescription !== undefined && output.videoDescription !== null
         ? deserializeAws_restJson1VideoDescription(output.videoDescription, context)
@@ -9445,7 +8753,7 @@ const deserializeAws_restJson1OutputChannelMapping = (output: any, context: __Se
 
 const deserializeAws_restJson1OutputDetail = (output: any, context: __SerdeContext): OutputDetail => {
   return {
-    DurationInMs: output.durationInMs !== undefined && output.durationInMs !== null ? output.durationInMs : undefined,
+    DurationInMs: __expectNumber(output.durationInMs),
     VideoDetails:
       output.videoDetails !== undefined && output.videoDetails !== null
         ? deserializeAws_restJson1VideoDetail(output.videoDetails, context)
@@ -9459,8 +8767,8 @@ const deserializeAws_restJson1OutputGroup = (output: any, context: __SerdeContex
       output.automatedEncodingSettings !== undefined && output.automatedEncodingSettings !== null
         ? deserializeAws_restJson1AutomatedEncodingSettings(output.automatedEncodingSettings, context)
         : undefined,
-    CustomName: output.customName !== undefined && output.customName !== null ? output.customName : undefined,
-    Name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    CustomName: __expectString(output.customName),
+    Name: __expectString(output.name),
     OutputGroupSettings:
       output.outputGroupSettings !== undefined && output.outputGroupSettings !== null
         ? deserializeAws_restJson1OutputGroupSettings(output.outputGroupSettings, context)
@@ -9503,7 +8811,7 @@ const deserializeAws_restJson1OutputGroupSettings = (output: any, context: __Ser
       output.msSmoothGroupSettings !== undefined && output.msSmoothGroupSettings !== null
         ? deserializeAws_restJson1MsSmoothGroupSettings(output.msSmoothGroupSettings, context)
         : undefined,
-    Type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    Type: __expectString(output.type),
   } as any;
 };
 
@@ -9527,23 +8835,23 @@ const deserializeAws_restJson1PartnerWatermarking = (output: any, context: __Ser
 
 const deserializeAws_restJson1Preset = (output: any, context: __SerdeContext): Preset => {
   return {
-    Arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    Category: output.category !== undefined && output.category !== null ? output.category : undefined,
+    Arn: __expectString(output.arn),
+    Category: __expectString(output.category),
     CreatedAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    Description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    Description: __expectString(output.description),
     LastUpdated:
       output.lastUpdated !== undefined && output.lastUpdated !== null
         ? new Date(Math.round(output.lastUpdated * 1000))
         : undefined,
-    Name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    Name: __expectString(output.name),
     Settings:
       output.settings !== undefined && output.settings !== null
         ? deserializeAws_restJson1PresetSettings(output.settings, context)
         : undefined,
-    Type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    Type: __expectString(output.type),
   } as any;
 };
 
@@ -9570,72 +8878,50 @@ const deserializeAws_restJson1PresetSettings = (output: any, context: __SerdeCon
 
 const deserializeAws_restJson1ProresSettings = (output: any, context: __SerdeContext): ProresSettings => {
   return {
-    CodecProfile: output.codecProfile !== undefined && output.codecProfile !== null ? output.codecProfile : undefined,
-    FramerateControl:
-      output.framerateControl !== undefined && output.framerateControl !== null ? output.framerateControl : undefined,
-    FramerateConversionAlgorithm:
-      output.framerateConversionAlgorithm !== undefined && output.framerateConversionAlgorithm !== null
-        ? output.framerateConversionAlgorithm
-        : undefined,
-    FramerateDenominator:
-      output.framerateDenominator !== undefined && output.framerateDenominator !== null
-        ? output.framerateDenominator
-        : undefined,
-    FramerateNumerator:
-      output.framerateNumerator !== undefined && output.framerateNumerator !== null
-        ? output.framerateNumerator
-        : undefined,
-    InterlaceMode:
-      output.interlaceMode !== undefined && output.interlaceMode !== null ? output.interlaceMode : undefined,
-    ParControl: output.parControl !== undefined && output.parControl !== null ? output.parControl : undefined,
-    ParDenominator:
-      output.parDenominator !== undefined && output.parDenominator !== null ? output.parDenominator : undefined,
-    ParNumerator: output.parNumerator !== undefined && output.parNumerator !== null ? output.parNumerator : undefined,
-    ScanTypeConversionMode:
-      output.scanTypeConversionMode !== undefined && output.scanTypeConversionMode !== null
-        ? output.scanTypeConversionMode
-        : undefined,
-    SlowPal: output.slowPal !== undefined && output.slowPal !== null ? output.slowPal : undefined,
-    Telecine: output.telecine !== undefined && output.telecine !== null ? output.telecine : undefined,
+    CodecProfile: __expectString(output.codecProfile),
+    FramerateControl: __expectString(output.framerateControl),
+    FramerateConversionAlgorithm: __expectString(output.framerateConversionAlgorithm),
+    FramerateDenominator: __expectNumber(output.framerateDenominator),
+    FramerateNumerator: __expectNumber(output.framerateNumerator),
+    InterlaceMode: __expectString(output.interlaceMode),
+    ParControl: __expectString(output.parControl),
+    ParDenominator: __expectNumber(output.parDenominator),
+    ParNumerator: __expectNumber(output.parNumerator),
+    ScanTypeConversionMode: __expectString(output.scanTypeConversionMode),
+    SlowPal: __expectString(output.slowPal),
+    Telecine: __expectString(output.telecine),
   } as any;
 };
 
 const deserializeAws_restJson1Queue = (output: any, context: __SerdeContext): Queue => {
   return {
-    Arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    Arn: __expectString(output.arn),
     CreatedAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    Description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    Description: __expectString(output.description),
     LastUpdated:
       output.lastUpdated !== undefined && output.lastUpdated !== null
         ? new Date(Math.round(output.lastUpdated * 1000))
         : undefined,
-    Name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    PricingPlan: output.pricingPlan !== undefined && output.pricingPlan !== null ? output.pricingPlan : undefined,
-    ProgressingJobsCount:
-      output.progressingJobsCount !== undefined && output.progressingJobsCount !== null
-        ? output.progressingJobsCount
-        : undefined,
+    Name: __expectString(output.name),
+    PricingPlan: __expectString(output.pricingPlan),
+    ProgressingJobsCount: __expectNumber(output.progressingJobsCount),
     ReservationPlan:
       output.reservationPlan !== undefined && output.reservationPlan !== null
         ? deserializeAws_restJson1ReservationPlan(output.reservationPlan, context)
         : undefined,
-    Status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    SubmittedJobsCount:
-      output.submittedJobsCount !== undefined && output.submittedJobsCount !== null
-        ? output.submittedJobsCount
-        : undefined,
-    Type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    Status: __expectString(output.status),
+    SubmittedJobsCount: __expectNumber(output.submittedJobsCount),
+    Type: __expectString(output.type),
   } as any;
 };
 
 const deserializeAws_restJson1QueueTransition = (output: any, context: __SerdeContext): QueueTransition => {
   return {
-    DestinationQueue:
-      output.destinationQueue !== undefined && output.destinationQueue !== null ? output.destinationQueue : undefined,
-    SourceQueue: output.sourceQueue !== undefined && output.sourceQueue !== null ? output.sourceQueue : undefined,
+    DestinationQueue: __expectString(output.destinationQueue),
+    SourceQueue: __expectString(output.sourceQueue),
     Timestamp:
       output.timestamp !== undefined && output.timestamp !== null
         ? new Date(Math.round(output.timestamp * 1000))
@@ -9645,10 +8931,10 @@ const deserializeAws_restJson1QueueTransition = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1Rectangle = (output: any, context: __SerdeContext): Rectangle => {
   return {
-    Height: output.height !== undefined && output.height !== null ? output.height : undefined,
-    Width: output.width !== undefined && output.width !== null ? output.width : undefined,
-    X: output.x !== undefined && output.x !== null ? output.x : undefined,
-    Y: output.y !== undefined && output.y !== null ? output.y : undefined,
+    Height: __expectNumber(output.height),
+    Width: __expectNumber(output.width),
+    X: __expectNumber(output.x),
+    Y: __expectNumber(output.y),
   } as any;
 };
 
@@ -9658,14 +8944,14 @@ const deserializeAws_restJson1RemixSettings = (output: any, context: __SerdeCont
       output.channelMapping !== undefined && output.channelMapping !== null
         ? deserializeAws_restJson1ChannelMapping(output.channelMapping, context)
         : undefined,
-    ChannelsIn: output.channelsIn !== undefined && output.channelsIn !== null ? output.channelsIn : undefined,
-    ChannelsOut: output.channelsOut !== undefined && output.channelsOut !== null ? output.channelsOut : undefined,
+    ChannelsIn: __expectNumber(output.channelsIn),
+    ChannelsOut: __expectNumber(output.channelsOut),
   } as any;
 };
 
 const deserializeAws_restJson1ReservationPlan = (output: any, context: __SerdeContext): ReservationPlan => {
   return {
-    Commitment: output.commitment !== undefined && output.commitment !== null ? output.commitment : undefined,
+    Commitment: __expectString(output.commitment),
     ExpiresAt:
       output.expiresAt !== undefined && output.expiresAt !== null
         ? new Date(Math.round(output.expiresAt * 1000))
@@ -9674,16 +8960,15 @@ const deserializeAws_restJson1ReservationPlan = (output: any, context: __SerdeCo
       output.purchasedAt !== undefined && output.purchasedAt !== null
         ? new Date(Math.round(output.purchasedAt * 1000))
         : undefined,
-    RenewalType: output.renewalType !== undefined && output.renewalType !== null ? output.renewalType : undefined,
-    ReservedSlots:
-      output.reservedSlots !== undefined && output.reservedSlots !== null ? output.reservedSlots : undefined,
-    Status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    RenewalType: __expectString(output.renewalType),
+    ReservedSlots: __expectNumber(output.reservedSlots),
+    Status: __expectString(output.status),
   } as any;
 };
 
 const deserializeAws_restJson1ResourceTags = (output: any, context: __SerdeContext): ResourceTags => {
   return {
-    Arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    Arn: __expectString(output.arn),
     Tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1__mapOf__string(output.tags, context)
@@ -9696,7 +8981,7 @@ const deserializeAws_restJson1S3DestinationAccessControl = (
   context: __SerdeContext
 ): S3DestinationAccessControl => {
   return {
-    CannedAcl: output.cannedAcl !== undefined && output.cannedAcl !== null ? output.cannedAcl : undefined,
+    CannedAcl: __expectString(output.cannedAcl),
   } as any;
 };
 
@@ -9715,9 +9000,8 @@ const deserializeAws_restJson1S3DestinationSettings = (output: any, context: __S
 
 const deserializeAws_restJson1S3EncryptionSettings = (output: any, context: __SerdeContext): S3EncryptionSettings => {
   return {
-    EncryptionType:
-      output.encryptionType !== undefined && output.encryptionType !== null ? output.encryptionType : undefined,
-    KmsKeyArn: output.kmsKeyArn !== undefined && output.kmsKeyArn !== null ? output.kmsKeyArn : undefined,
+    EncryptionType: __expectString(output.encryptionType),
+    KmsKeyArn: __expectString(output.kmsKeyArn),
   } as any;
 };
 
@@ -9726,27 +9010,25 @@ const deserializeAws_restJson1SccDestinationSettings = (
   context: __SerdeContext
 ): SccDestinationSettings => {
   return {
-    Framerate: output.framerate !== undefined && output.framerate !== null ? output.framerate : undefined,
+    Framerate: __expectString(output.framerate),
   } as any;
 };
 
 const deserializeAws_restJson1SpekeKeyProvider = (output: any, context: __SerdeContext): SpekeKeyProvider => {
   return {
-    CertificateArn:
-      output.certificateArn !== undefined && output.certificateArn !== null ? output.certificateArn : undefined,
-    ResourceId: output.resourceId !== undefined && output.resourceId !== null ? output.resourceId : undefined,
+    CertificateArn: __expectString(output.certificateArn),
+    ResourceId: __expectString(output.resourceId),
     SystemIds:
       output.systemIds !== undefined && output.systemIds !== null
         ? deserializeAws_restJson1__listOf__stringPattern09aFAF809aFAF409aFAF409aFAF409aFAF12(output.systemIds, context)
         : undefined,
-    Url: output.url !== undefined && output.url !== null ? output.url : undefined,
+    Url: __expectString(output.url),
   } as any;
 };
 
 const deserializeAws_restJson1SpekeKeyProviderCmaf = (output: any, context: __SerdeContext): SpekeKeyProviderCmaf => {
   return {
-    CertificateArn:
-      output.certificateArn !== undefined && output.certificateArn !== null ? output.certificateArn : undefined,
+    CertificateArn: __expectString(output.certificateArn),
     DashSignaledSystemIds:
       output.dashSignaledSystemIds !== undefined && output.dashSignaledSystemIds !== null
         ? deserializeAws_restJson1__listOf__stringMin36Max36Pattern09aFAF809aFAF409aFAF409aFAF409aFAF12(
@@ -9761,21 +9043,17 @@ const deserializeAws_restJson1SpekeKeyProviderCmaf = (output: any, context: __Se
             context
           )
         : undefined,
-    ResourceId: output.resourceId !== undefined && output.resourceId !== null ? output.resourceId : undefined,
-    Url: output.url !== undefined && output.url !== null ? output.url : undefined,
+    ResourceId: __expectString(output.resourceId),
+    Url: __expectString(output.url),
   } as any;
 };
 
 const deserializeAws_restJson1StaticKeyProvider = (output: any, context: __SerdeContext): StaticKeyProvider => {
   return {
-    KeyFormat: output.keyFormat !== undefined && output.keyFormat !== null ? output.keyFormat : undefined,
-    KeyFormatVersions:
-      output.keyFormatVersions !== undefined && output.keyFormatVersions !== null
-        ? output.keyFormatVersions
-        : undefined,
-    StaticKeyValue:
-      output.staticKeyValue !== undefined && output.staticKeyValue !== null ? output.staticKeyValue : undefined,
-    Url: output.url !== undefined && output.url !== null ? output.url : undefined,
+    KeyFormat: __expectString(output.keyFormat),
+    KeyFormatVersions: __expectString(output.keyFormatVersions),
+    StaticKeyValue: __expectString(output.staticKeyValue),
+    Url: __expectString(output.url),
   } as any;
 };
 
@@ -9784,7 +9062,7 @@ const deserializeAws_restJson1TeletextDestinationSettings = (
   context: __SerdeContext
 ): TeletextDestinationSettings => {
   return {
-    PageNumber: output.pageNumber !== undefined && output.pageNumber !== null ? output.pageNumber : undefined,
+    PageNumber: __expectString(output.pageNumber),
     PageTypes:
       output.pageTypes !== undefined && output.pageTypes !== null
         ? deserializeAws_restJson1__listOfTeletextPageType(output.pageTypes, context)
@@ -9797,25 +9075,24 @@ const deserializeAws_restJson1TeletextSourceSettings = (
   context: __SerdeContext
 ): TeletextSourceSettings => {
   return {
-    PageNumber: output.pageNumber !== undefined && output.pageNumber !== null ? output.pageNumber : undefined,
+    PageNumber: __expectString(output.pageNumber),
   } as any;
 };
 
 const deserializeAws_restJson1TimecodeBurnin = (output: any, context: __SerdeContext): TimecodeBurnin => {
   return {
-    FontSize: output.fontSize !== undefined && output.fontSize !== null ? output.fontSize : undefined,
-    Position: output.position !== undefined && output.position !== null ? output.position : undefined,
-    Prefix: output.prefix !== undefined && output.prefix !== null ? output.prefix : undefined,
+    FontSize: __expectNumber(output.fontSize),
+    Position: __expectString(output.position),
+    Prefix: __expectString(output.prefix),
   } as any;
 };
 
 const deserializeAws_restJson1TimecodeConfig = (output: any, context: __SerdeContext): TimecodeConfig => {
   return {
-    Anchor: output.anchor !== undefined && output.anchor !== null ? output.anchor : undefined,
-    Source: output.source !== undefined && output.source !== null ? output.source : undefined,
-    Start: output.start !== undefined && output.start !== null ? output.start : undefined,
-    TimestampOffset:
-      output.timestampOffset !== undefined && output.timestampOffset !== null ? output.timestampOffset : undefined,
+    Anchor: __expectString(output.anchor),
+    Source: __expectString(output.source),
+    Start: __expectString(output.start),
+    TimestampOffset: __expectString(output.timestampOffset),
   } as any;
 };
 
@@ -9850,7 +9127,7 @@ const deserializeAws_restJson1Timing = (output: any, context: __SerdeContext): T
 
 const deserializeAws_restJson1TrackSourceSettings = (output: any, context: __SerdeContext): TrackSourceSettings => {
   return {
-    TrackNumber: output.trackNumber !== undefined && output.trackNumber !== null ? output.trackNumber : undefined,
+    TrackNumber: __expectNumber(output.trackNumber),
   } as any;
 };
 
@@ -9859,36 +9136,21 @@ const deserializeAws_restJson1TtmlDestinationSettings = (
   context: __SerdeContext
 ): TtmlDestinationSettings => {
   return {
-    StylePassthrough:
-      output.stylePassthrough !== undefined && output.stylePassthrough !== null ? output.stylePassthrough : undefined,
+    StylePassthrough: __expectString(output.stylePassthrough),
   } as any;
 };
 
 const deserializeAws_restJson1Vc3Settings = (output: any, context: __SerdeContext): Vc3Settings => {
   return {
-    FramerateControl:
-      output.framerateControl !== undefined && output.framerateControl !== null ? output.framerateControl : undefined,
-    FramerateConversionAlgorithm:
-      output.framerateConversionAlgorithm !== undefined && output.framerateConversionAlgorithm !== null
-        ? output.framerateConversionAlgorithm
-        : undefined,
-    FramerateDenominator:
-      output.framerateDenominator !== undefined && output.framerateDenominator !== null
-        ? output.framerateDenominator
-        : undefined,
-    FramerateNumerator:
-      output.framerateNumerator !== undefined && output.framerateNumerator !== null
-        ? output.framerateNumerator
-        : undefined,
-    InterlaceMode:
-      output.interlaceMode !== undefined && output.interlaceMode !== null ? output.interlaceMode : undefined,
-    ScanTypeConversionMode:
-      output.scanTypeConversionMode !== undefined && output.scanTypeConversionMode !== null
-        ? output.scanTypeConversionMode
-        : undefined,
-    SlowPal: output.slowPal !== undefined && output.slowPal !== null ? output.slowPal : undefined,
-    Telecine: output.telecine !== undefined && output.telecine !== null ? output.telecine : undefined,
-    Vc3Class: output.vc3Class !== undefined && output.vc3Class !== null ? output.vc3Class : undefined,
+    FramerateControl: __expectString(output.framerateControl),
+    FramerateConversionAlgorithm: __expectString(output.framerateConversionAlgorithm),
+    FramerateDenominator: __expectNumber(output.framerateDenominator),
+    FramerateNumerator: __expectNumber(output.framerateNumerator),
+    InterlaceMode: __expectString(output.interlaceMode),
+    ScanTypeConversionMode: __expectString(output.scanTypeConversionMode),
+    SlowPal: __expectString(output.slowPal),
+    Telecine: __expectString(output.telecine),
+    Vc3Class: __expectString(output.vc3Class),
   } as any;
 };
 
@@ -9902,7 +9164,7 @@ const deserializeAws_restJson1VideoCodecSettings = (output: any, context: __Serd
       output.avcIntraSettings !== undefined && output.avcIntraSettings !== null
         ? deserializeAws_restJson1AvcIntraSettings(output.avcIntraSettings, context)
         : undefined,
-    Codec: output.codec !== undefined && output.codec !== null ? output.codec : undefined,
+    Codec: __expectString(output.codec),
     FrameCaptureSettings:
       output.frameCaptureSettings !== undefined && output.frameCaptureSettings !== null
         ? deserializeAws_restJson1FrameCaptureSettings(output.frameCaptureSettings, context)
@@ -9940,48 +9202,40 @@ const deserializeAws_restJson1VideoCodecSettings = (output: any, context: __Serd
 
 const deserializeAws_restJson1VideoDescription = (output: any, context: __SerdeContext): VideoDescription => {
   return {
-    AfdSignaling: output.afdSignaling !== undefined && output.afdSignaling !== null ? output.afdSignaling : undefined,
-    AntiAlias: output.antiAlias !== undefined && output.antiAlias !== null ? output.antiAlias : undefined,
+    AfdSignaling: __expectString(output.afdSignaling),
+    AntiAlias: __expectString(output.antiAlias),
     CodecSettings:
       output.codecSettings !== undefined && output.codecSettings !== null
         ? deserializeAws_restJson1VideoCodecSettings(output.codecSettings, context)
         : undefined,
-    ColorMetadata:
-      output.colorMetadata !== undefined && output.colorMetadata !== null ? output.colorMetadata : undefined,
+    ColorMetadata: __expectString(output.colorMetadata),
     Crop:
       output.crop !== undefined && output.crop !== null
         ? deserializeAws_restJson1Rectangle(output.crop, context)
         : undefined,
-    DropFrameTimecode:
-      output.dropFrameTimecode !== undefined && output.dropFrameTimecode !== null
-        ? output.dropFrameTimecode
-        : undefined,
-    FixedAfd: output.fixedAfd !== undefined && output.fixedAfd !== null ? output.fixedAfd : undefined,
-    Height: output.height !== undefined && output.height !== null ? output.height : undefined,
+    DropFrameTimecode: __expectString(output.dropFrameTimecode),
+    FixedAfd: __expectNumber(output.fixedAfd),
+    Height: __expectNumber(output.height),
     Position:
       output.position !== undefined && output.position !== null
         ? deserializeAws_restJson1Rectangle(output.position, context)
         : undefined,
-    RespondToAfd: output.respondToAfd !== undefined && output.respondToAfd !== null ? output.respondToAfd : undefined,
-    ScalingBehavior:
-      output.scalingBehavior !== undefined && output.scalingBehavior !== null ? output.scalingBehavior : undefined,
-    Sharpness: output.sharpness !== undefined && output.sharpness !== null ? output.sharpness : undefined,
-    TimecodeInsertion:
-      output.timecodeInsertion !== undefined && output.timecodeInsertion !== null
-        ? output.timecodeInsertion
-        : undefined,
+    RespondToAfd: __expectString(output.respondToAfd),
+    ScalingBehavior: __expectString(output.scalingBehavior),
+    Sharpness: __expectNumber(output.sharpness),
+    TimecodeInsertion: __expectString(output.timecodeInsertion),
     VideoPreprocessors:
       output.videoPreprocessors !== undefined && output.videoPreprocessors !== null
         ? deserializeAws_restJson1VideoPreprocessor(output.videoPreprocessors, context)
         : undefined,
-    Width: output.width !== undefined && output.width !== null ? output.width : undefined,
+    Width: __expectNumber(output.width),
   } as any;
 };
 
 const deserializeAws_restJson1VideoDetail = (output: any, context: __SerdeContext): VideoDetail => {
   return {
-    HeightInPx: output.heightInPx !== undefined && output.heightInPx !== null ? output.heightInPx : undefined,
-    WidthInPx: output.widthInPx !== undefined && output.widthInPx !== null ? output.widthInPx : undefined,
+    HeightInPx: __expectNumber(output.heightInPx),
+    WidthInPx: __expectNumber(output.widthInPx),
   } as any;
 };
 
@@ -10020,105 +9274,70 @@ const deserializeAws_restJson1VideoPreprocessor = (output: any, context: __Serde
 
 const deserializeAws_restJson1VideoSelector = (output: any, context: __SerdeContext): VideoSelector => {
   return {
-    AlphaBehavior:
-      output.alphaBehavior !== undefined && output.alphaBehavior !== null ? output.alphaBehavior : undefined,
-    ColorSpace: output.colorSpace !== undefined && output.colorSpace !== null ? output.colorSpace : undefined,
-    ColorSpaceUsage:
-      output.colorSpaceUsage !== undefined && output.colorSpaceUsage !== null ? output.colorSpaceUsage : undefined,
+    AlphaBehavior: __expectString(output.alphaBehavior),
+    ColorSpace: __expectString(output.colorSpace),
+    ColorSpaceUsage: __expectString(output.colorSpaceUsage),
     Hdr10Metadata:
       output.hdr10Metadata !== undefined && output.hdr10Metadata !== null
         ? deserializeAws_restJson1Hdr10Metadata(output.hdr10Metadata, context)
         : undefined,
-    Pid: output.pid !== undefined && output.pid !== null ? output.pid : undefined,
-    ProgramNumber:
-      output.programNumber !== undefined && output.programNumber !== null ? output.programNumber : undefined,
-    Rotate: output.rotate !== undefined && output.rotate !== null ? output.rotate : undefined,
-    SampleRange: output.sampleRange !== undefined && output.sampleRange !== null ? output.sampleRange : undefined,
+    Pid: __expectNumber(output.pid),
+    ProgramNumber: __expectNumber(output.programNumber),
+    Rotate: __expectString(output.rotate),
+    SampleRange: __expectString(output.sampleRange),
   } as any;
 };
 
 const deserializeAws_restJson1VorbisSettings = (output: any, context: __SerdeContext): VorbisSettings => {
   return {
-    Channels: output.channels !== undefined && output.channels !== null ? output.channels : undefined,
-    SampleRate: output.sampleRate !== undefined && output.sampleRate !== null ? output.sampleRate : undefined,
-    VbrQuality: output.vbrQuality !== undefined && output.vbrQuality !== null ? output.vbrQuality : undefined,
+    Channels: __expectNumber(output.channels),
+    SampleRate: __expectNumber(output.sampleRate),
+    VbrQuality: __expectNumber(output.vbrQuality),
   } as any;
 };
 
 const deserializeAws_restJson1Vp8Settings = (output: any, context: __SerdeContext): Vp8Settings => {
   return {
-    Bitrate: output.bitrate !== undefined && output.bitrate !== null ? output.bitrate : undefined,
-    FramerateControl:
-      output.framerateControl !== undefined && output.framerateControl !== null ? output.framerateControl : undefined,
-    FramerateConversionAlgorithm:
-      output.framerateConversionAlgorithm !== undefined && output.framerateConversionAlgorithm !== null
-        ? output.framerateConversionAlgorithm
-        : undefined,
-    FramerateDenominator:
-      output.framerateDenominator !== undefined && output.framerateDenominator !== null
-        ? output.framerateDenominator
-        : undefined,
-    FramerateNumerator:
-      output.framerateNumerator !== undefined && output.framerateNumerator !== null
-        ? output.framerateNumerator
-        : undefined,
-    GopSize: output.gopSize !== undefined && output.gopSize !== null ? output.gopSize : undefined,
-    HrdBufferSize:
-      output.hrdBufferSize !== undefined && output.hrdBufferSize !== null ? output.hrdBufferSize : undefined,
-    MaxBitrate: output.maxBitrate !== undefined && output.maxBitrate !== null ? output.maxBitrate : undefined,
-    ParControl: output.parControl !== undefined && output.parControl !== null ? output.parControl : undefined,
-    ParDenominator:
-      output.parDenominator !== undefined && output.parDenominator !== null ? output.parDenominator : undefined,
-    ParNumerator: output.parNumerator !== undefined && output.parNumerator !== null ? output.parNumerator : undefined,
-    QualityTuningLevel:
-      output.qualityTuningLevel !== undefined && output.qualityTuningLevel !== null
-        ? output.qualityTuningLevel
-        : undefined,
-    RateControlMode:
-      output.rateControlMode !== undefined && output.rateControlMode !== null ? output.rateControlMode : undefined,
+    Bitrate: __expectNumber(output.bitrate),
+    FramerateControl: __expectString(output.framerateControl),
+    FramerateConversionAlgorithm: __expectString(output.framerateConversionAlgorithm),
+    FramerateDenominator: __expectNumber(output.framerateDenominator),
+    FramerateNumerator: __expectNumber(output.framerateNumerator),
+    GopSize: __expectNumber(output.gopSize),
+    HrdBufferSize: __expectNumber(output.hrdBufferSize),
+    MaxBitrate: __expectNumber(output.maxBitrate),
+    ParControl: __expectString(output.parControl),
+    ParDenominator: __expectNumber(output.parDenominator),
+    ParNumerator: __expectNumber(output.parNumerator),
+    QualityTuningLevel: __expectString(output.qualityTuningLevel),
+    RateControlMode: __expectString(output.rateControlMode),
   } as any;
 };
 
 const deserializeAws_restJson1Vp9Settings = (output: any, context: __SerdeContext): Vp9Settings => {
   return {
-    Bitrate: output.bitrate !== undefined && output.bitrate !== null ? output.bitrate : undefined,
-    FramerateControl:
-      output.framerateControl !== undefined && output.framerateControl !== null ? output.framerateControl : undefined,
-    FramerateConversionAlgorithm:
-      output.framerateConversionAlgorithm !== undefined && output.framerateConversionAlgorithm !== null
-        ? output.framerateConversionAlgorithm
-        : undefined,
-    FramerateDenominator:
-      output.framerateDenominator !== undefined && output.framerateDenominator !== null
-        ? output.framerateDenominator
-        : undefined,
-    FramerateNumerator:
-      output.framerateNumerator !== undefined && output.framerateNumerator !== null
-        ? output.framerateNumerator
-        : undefined,
-    GopSize: output.gopSize !== undefined && output.gopSize !== null ? output.gopSize : undefined,
-    HrdBufferSize:
-      output.hrdBufferSize !== undefined && output.hrdBufferSize !== null ? output.hrdBufferSize : undefined,
-    MaxBitrate: output.maxBitrate !== undefined && output.maxBitrate !== null ? output.maxBitrate : undefined,
-    ParControl: output.parControl !== undefined && output.parControl !== null ? output.parControl : undefined,
-    ParDenominator:
-      output.parDenominator !== undefined && output.parDenominator !== null ? output.parDenominator : undefined,
-    ParNumerator: output.parNumerator !== undefined && output.parNumerator !== null ? output.parNumerator : undefined,
-    QualityTuningLevel:
-      output.qualityTuningLevel !== undefined && output.qualityTuningLevel !== null
-        ? output.qualityTuningLevel
-        : undefined,
-    RateControlMode:
-      output.rateControlMode !== undefined && output.rateControlMode !== null ? output.rateControlMode : undefined,
+    Bitrate: __expectNumber(output.bitrate),
+    FramerateControl: __expectString(output.framerateControl),
+    FramerateConversionAlgorithm: __expectString(output.framerateConversionAlgorithm),
+    FramerateDenominator: __expectNumber(output.framerateDenominator),
+    FramerateNumerator: __expectNumber(output.framerateNumerator),
+    GopSize: __expectNumber(output.gopSize),
+    HrdBufferSize: __expectNumber(output.hrdBufferSize),
+    MaxBitrate: __expectNumber(output.maxBitrate),
+    ParControl: __expectString(output.parControl),
+    ParDenominator: __expectNumber(output.parDenominator),
+    ParNumerator: __expectNumber(output.parNumerator),
+    QualityTuningLevel: __expectString(output.qualityTuningLevel),
+    RateControlMode: __expectString(output.rateControlMode),
   } as any;
 };
 
 const deserializeAws_restJson1WavSettings = (output: any, context: __SerdeContext): WavSettings => {
   return {
-    BitDepth: output.bitDepth !== undefined && output.bitDepth !== null ? output.bitDepth : undefined,
-    Channels: output.channels !== undefined && output.channels !== null ? output.channels : undefined,
-    Format: output.format !== undefined && output.format !== null ? output.format : undefined,
-    SampleRate: output.sampleRate !== undefined && output.sampleRate !== null ? output.sampleRate : undefined,
+    BitDepth: __expectNumber(output.bitDepth),
+    Channels: __expectNumber(output.channels),
+    Format: __expectString(output.format),
+    SampleRate: __expectNumber(output.sampleRate),
   } as any;
 };
 
@@ -10127,8 +9346,7 @@ const deserializeAws_restJson1WebvttDestinationSettings = (
   context: __SerdeContext
 ): WebvttDestinationSettings => {
   return {
-    StylePassthrough:
-      output.stylePassthrough !== undefined && output.stylePassthrough !== null ? output.stylePassthrough : undefined,
+    StylePassthrough: __expectString(output.stylePassthrough),
   } as any;
 };
 

--- a/clients/client-medialive/protocols/Aws_restJson1.ts
+++ b/clients/client-medialive/protocols/Aws_restJson1.ts
@@ -352,6 +352,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -3592,13 +3594,13 @@ export const deserializeAws_restJson1DeleteChannelCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.Arn = data.arn;
+    contents.Arn = __expectString(data.arn);
   }
   if (data.cdiInputSpecification !== undefined && data.cdiInputSpecification !== null) {
     contents.CdiInputSpecification = deserializeAws_restJson1CdiInputSpecification(data.cdiInputSpecification, context);
   }
   if (data.channelClass !== undefined && data.channelClass !== null) {
-    contents.ChannelClass = data.channelClass;
+    contents.ChannelClass = __expectString(data.channelClass);
   }
   if (data.destinations !== undefined && data.destinations !== null) {
     contents.Destinations = deserializeAws_restJson1__listOfOutputDestination(data.destinations, context);
@@ -3610,7 +3612,7 @@ export const deserializeAws_restJson1DeleteChannelCommand = async (
     contents.EncoderSettings = deserializeAws_restJson1EncoderSettings(data.encoderSettings, context);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.Id = data.id;
+    contents.Id = __expectString(data.id);
   }
   if (data.inputAttachments !== undefined && data.inputAttachments !== null) {
     contents.InputAttachments = deserializeAws_restJson1__listOfInputAttachment(data.inputAttachments, context);
@@ -3619,22 +3621,22 @@ export const deserializeAws_restJson1DeleteChannelCommand = async (
     contents.InputSpecification = deserializeAws_restJson1InputSpecification(data.inputSpecification, context);
   }
   if (data.logLevel !== undefined && data.logLevel !== null) {
-    contents.LogLevel = data.logLevel;
+    contents.LogLevel = __expectString(data.logLevel);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.Name = data.name;
+    contents.Name = __expectString(data.name);
   }
   if (data.pipelineDetails !== undefined && data.pipelineDetails !== null) {
     contents.PipelineDetails = deserializeAws_restJson1__listOfPipelineDetail(data.pipelineDetails, context);
   }
   if (data.pipelinesRunningCount !== undefined && data.pipelinesRunningCount !== null) {
-    contents.PipelinesRunningCount = data.pipelinesRunningCount;
+    contents.PipelinesRunningCount = __expectNumber(data.pipelinesRunningCount);
   }
   if (data.roleArn !== undefined && data.roleArn !== null) {
-    contents.RoleArn = data.roleArn;
+    contents.RoleArn = __expectString(data.roleArn);
   }
   if (data.state !== undefined && data.state !== null) {
-    contents.State = data.state;
+    contents.State = __expectString(data.state);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
@@ -3966,7 +3968,7 @@ export const deserializeAws_restJson1DeleteMultiplexCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.Arn = data.arn;
+    contents.Arn = __expectString(data.arn);
   }
   if (data.availabilityZones !== undefined && data.availabilityZones !== null) {
     contents.AvailabilityZones = deserializeAws_restJson1__listOf__string(data.availabilityZones, context);
@@ -3975,22 +3977,22 @@ export const deserializeAws_restJson1DeleteMultiplexCommand = async (
     contents.Destinations = deserializeAws_restJson1__listOfMultiplexOutputDestination(data.destinations, context);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.Id = data.id;
+    contents.Id = __expectString(data.id);
   }
   if (data.multiplexSettings !== undefined && data.multiplexSettings !== null) {
     contents.MultiplexSettings = deserializeAws_restJson1MultiplexSettings(data.multiplexSettings, context);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.Name = data.name;
+    contents.Name = __expectString(data.name);
   }
   if (data.pipelinesRunningCount !== undefined && data.pipelinesRunningCount !== null) {
-    contents.PipelinesRunningCount = data.pipelinesRunningCount;
+    contents.PipelinesRunningCount = __expectNumber(data.pipelinesRunningCount);
   }
   if (data.programCount !== undefined && data.programCount !== null) {
-    contents.ProgramCount = data.programCount;
+    contents.ProgramCount = __expectNumber(data.programCount);
   }
   if (data.state !== undefined && data.state !== null) {
-    contents.State = data.state;
+    contents.State = __expectString(data.state);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
@@ -4108,7 +4110,7 @@ export const deserializeAws_restJson1DeleteMultiplexProgramCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.channelId !== undefined && data.channelId !== null) {
-    contents.ChannelId = data.channelId;
+    contents.ChannelId = __expectString(data.channelId);
   }
   if (data.multiplexProgramSettings !== undefined && data.multiplexProgramSettings !== null) {
     contents.MultiplexProgramSettings = deserializeAws_restJson1MultiplexProgramSettings(
@@ -4129,7 +4131,7 @@ export const deserializeAws_restJson1DeleteMultiplexProgramCommand = async (
     );
   }
   if (data.programName !== undefined && data.programName !== null) {
-    contents.ProgramName = data.programName;
+    contents.ProgramName = __expectString(data.programName);
   }
   return Promise.resolve(contents);
 };
@@ -4257,43 +4259,43 @@ export const deserializeAws_restJson1DeleteReservationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.Arn = data.arn;
+    contents.Arn = __expectString(data.arn);
   }
   if (data.count !== undefined && data.count !== null) {
-    contents.Count = data.count;
+    contents.Count = __expectNumber(data.count);
   }
   if (data.currencyCode !== undefined && data.currencyCode !== null) {
-    contents.CurrencyCode = data.currencyCode;
+    contents.CurrencyCode = __expectString(data.currencyCode);
   }
   if (data.duration !== undefined && data.duration !== null) {
-    contents.Duration = data.duration;
+    contents.Duration = __expectNumber(data.duration);
   }
   if (data.durationUnits !== undefined && data.durationUnits !== null) {
-    contents.DurationUnits = data.durationUnits;
+    contents.DurationUnits = __expectString(data.durationUnits);
   }
   if (data.end !== undefined && data.end !== null) {
-    contents.End = data.end;
+    contents.End = __expectString(data.end);
   }
   if (data.fixedPrice !== undefined && data.fixedPrice !== null) {
-    contents.FixedPrice = data.fixedPrice;
+    contents.FixedPrice = __expectNumber(data.fixedPrice);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.Name = data.name;
+    contents.Name = __expectString(data.name);
   }
   if (data.offeringDescription !== undefined && data.offeringDescription !== null) {
-    contents.OfferingDescription = data.offeringDescription;
+    contents.OfferingDescription = __expectString(data.offeringDescription);
   }
   if (data.offeringId !== undefined && data.offeringId !== null) {
-    contents.OfferingId = data.offeringId;
+    contents.OfferingId = __expectString(data.offeringId);
   }
   if (data.offeringType !== undefined && data.offeringType !== null) {
-    contents.OfferingType = data.offeringType;
+    contents.OfferingType = __expectString(data.offeringType);
   }
   if (data.region !== undefined && data.region !== null) {
-    contents.Region = data.region;
+    contents.Region = __expectString(data.region);
   }
   if (data.reservationId !== undefined && data.reservationId !== null) {
-    contents.ReservationId = data.reservationId;
+    contents.ReservationId = __expectString(data.reservationId);
   }
   if (data.resourceSpecification !== undefined && data.resourceSpecification !== null) {
     contents.ResourceSpecification = deserializeAws_restJson1ReservationResourceSpecification(
@@ -4302,16 +4304,16 @@ export const deserializeAws_restJson1DeleteReservationCommand = async (
     );
   }
   if (data.start !== undefined && data.start !== null) {
-    contents.Start = data.start;
+    contents.Start = __expectString(data.start);
   }
   if (data.state !== undefined && data.state !== null) {
-    contents.State = data.state;
+    contents.State = __expectString(data.state);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
   }
   if (data.usagePrice !== undefined && data.usagePrice !== null) {
-    contents.UsagePrice = data.usagePrice;
+    contents.UsagePrice = __expectNumber(data.usagePrice);
   }
   return Promise.resolve(contents);
 };
@@ -4612,13 +4614,13 @@ export const deserializeAws_restJson1DescribeChannelCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.Arn = data.arn;
+    contents.Arn = __expectString(data.arn);
   }
   if (data.cdiInputSpecification !== undefined && data.cdiInputSpecification !== null) {
     contents.CdiInputSpecification = deserializeAws_restJson1CdiInputSpecification(data.cdiInputSpecification, context);
   }
   if (data.channelClass !== undefined && data.channelClass !== null) {
-    contents.ChannelClass = data.channelClass;
+    contents.ChannelClass = __expectString(data.channelClass);
   }
   if (data.destinations !== undefined && data.destinations !== null) {
     contents.Destinations = deserializeAws_restJson1__listOfOutputDestination(data.destinations, context);
@@ -4630,7 +4632,7 @@ export const deserializeAws_restJson1DescribeChannelCommand = async (
     contents.EncoderSettings = deserializeAws_restJson1EncoderSettings(data.encoderSettings, context);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.Id = data.id;
+    contents.Id = __expectString(data.id);
   }
   if (data.inputAttachments !== undefined && data.inputAttachments !== null) {
     contents.InputAttachments = deserializeAws_restJson1__listOfInputAttachment(data.inputAttachments, context);
@@ -4639,22 +4641,22 @@ export const deserializeAws_restJson1DescribeChannelCommand = async (
     contents.InputSpecification = deserializeAws_restJson1InputSpecification(data.inputSpecification, context);
   }
   if (data.logLevel !== undefined && data.logLevel !== null) {
-    contents.LogLevel = data.logLevel;
+    contents.LogLevel = __expectString(data.logLevel);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.Name = data.name;
+    contents.Name = __expectString(data.name);
   }
   if (data.pipelineDetails !== undefined && data.pipelineDetails !== null) {
     contents.PipelineDetails = deserializeAws_restJson1__listOfPipelineDetail(data.pipelineDetails, context);
   }
   if (data.pipelinesRunningCount !== undefined && data.pipelinesRunningCount !== null) {
-    contents.PipelinesRunningCount = data.pipelinesRunningCount;
+    contents.PipelinesRunningCount = __expectNumber(data.pipelinesRunningCount);
   }
   if (data.roleArn !== undefined && data.roleArn !== null) {
-    contents.RoleArn = data.roleArn;
+    contents.RoleArn = __expectString(data.roleArn);
   }
   if (data.state !== undefined && data.state !== null) {
-    contents.State = data.state;
+    contents.State = __expectString(data.state);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
@@ -4778,7 +4780,7 @@ export const deserializeAws_restJson1DescribeInputCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.Arn = data.arn;
+    contents.Arn = __expectString(data.arn);
   }
   if (data.attachedChannels !== undefined && data.attachedChannels !== null) {
     contents.AttachedChannels = deserializeAws_restJson1__listOf__string(data.attachedChannels, context);
@@ -4787,10 +4789,10 @@ export const deserializeAws_restJson1DescribeInputCommand = async (
     contents.Destinations = deserializeAws_restJson1__listOfInputDestination(data.destinations, context);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.Id = data.id;
+    contents.Id = __expectString(data.id);
   }
   if (data.inputClass !== undefined && data.inputClass !== null) {
-    contents.InputClass = data.inputClass;
+    contents.InputClass = __expectString(data.inputClass);
   }
   if (data.inputDevices !== undefined && data.inputDevices !== null) {
     contents.InputDevices = deserializeAws_restJson1__listOfInputDeviceSettings(data.inputDevices, context);
@@ -4799,16 +4801,16 @@ export const deserializeAws_restJson1DescribeInputCommand = async (
     contents.InputPartnerIds = deserializeAws_restJson1__listOf__string(data.inputPartnerIds, context);
   }
   if (data.inputSourceType !== undefined && data.inputSourceType !== null) {
-    contents.InputSourceType = data.inputSourceType;
+    contents.InputSourceType = __expectString(data.inputSourceType);
   }
   if (data.mediaConnectFlows !== undefined && data.mediaConnectFlows !== null) {
     contents.MediaConnectFlows = deserializeAws_restJson1__listOfMediaConnectFlow(data.mediaConnectFlows, context);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.Name = data.name;
+    contents.Name = __expectString(data.name);
   }
   if (data.roleArn !== undefined && data.roleArn !== null) {
-    contents.RoleArn = data.roleArn;
+    contents.RoleArn = __expectString(data.roleArn);
   }
   if (data.securityGroups !== undefined && data.securityGroups !== null) {
     contents.SecurityGroups = deserializeAws_restJson1__listOf__string(data.securityGroups, context);
@@ -4817,13 +4819,13 @@ export const deserializeAws_restJson1DescribeInputCommand = async (
     contents.Sources = deserializeAws_restJson1__listOfInputSource(data.sources, context);
   }
   if (data.state !== undefined && data.state !== null) {
-    contents.State = data.state;
+    contents.State = __expectString(data.state);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
   }
   if (data.type !== undefined && data.type !== null) {
-    contents.Type = data.type;
+    contents.Type = __expectString(data.type);
   }
   return Promise.resolve(contents);
 };
@@ -4937,37 +4939,37 @@ export const deserializeAws_restJson1DescribeInputDeviceCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.Arn = data.arn;
+    contents.Arn = __expectString(data.arn);
   }
   if (data.connectionState !== undefined && data.connectionState !== null) {
-    contents.ConnectionState = data.connectionState;
+    contents.ConnectionState = __expectString(data.connectionState);
   }
   if (data.deviceSettingsSyncState !== undefined && data.deviceSettingsSyncState !== null) {
-    contents.DeviceSettingsSyncState = data.deviceSettingsSyncState;
+    contents.DeviceSettingsSyncState = __expectString(data.deviceSettingsSyncState);
   }
   if (data.deviceUpdateStatus !== undefined && data.deviceUpdateStatus !== null) {
-    contents.DeviceUpdateStatus = data.deviceUpdateStatus;
+    contents.DeviceUpdateStatus = __expectString(data.deviceUpdateStatus);
   }
   if (data.hdDeviceSettings !== undefined && data.hdDeviceSettings !== null) {
     contents.HdDeviceSettings = deserializeAws_restJson1InputDeviceHdSettings(data.hdDeviceSettings, context);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.Id = data.id;
+    contents.Id = __expectString(data.id);
   }
   if (data.macAddress !== undefined && data.macAddress !== null) {
-    contents.MacAddress = data.macAddress;
+    contents.MacAddress = __expectString(data.macAddress);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.Name = data.name;
+    contents.Name = __expectString(data.name);
   }
   if (data.networkSettings !== undefined && data.networkSettings !== null) {
     contents.NetworkSettings = deserializeAws_restJson1InputDeviceNetworkSettings(data.networkSettings, context);
   }
   if (data.serialNumber !== undefined && data.serialNumber !== null) {
-    contents.SerialNumber = data.serialNumber;
+    contents.SerialNumber = __expectString(data.serialNumber);
   }
   if (data.type !== undefined && data.type !== null) {
-    contents.Type = data.type;
+    contents.Type = __expectString(data.type);
   }
   if (data.uhdDeviceSettings !== undefined && data.uhdDeviceSettings !== null) {
     contents.UhdDeviceSettings = deserializeAws_restJson1InputDeviceUhdSettings(data.uhdDeviceSettings, context);
@@ -5195,16 +5197,16 @@ export const deserializeAws_restJson1DescribeInputSecurityGroupCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.Arn = data.arn;
+    contents.Arn = __expectString(data.arn);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.Id = data.id;
+    contents.Id = __expectString(data.id);
   }
   if (data.inputs !== undefined && data.inputs !== null) {
     contents.Inputs = deserializeAws_restJson1__listOf__string(data.inputs, context);
   }
   if (data.state !== undefined && data.state !== null) {
-    contents.State = data.state;
+    contents.State = __expectString(data.state);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
@@ -5322,7 +5324,7 @@ export const deserializeAws_restJson1DescribeMultiplexCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.Arn = data.arn;
+    contents.Arn = __expectString(data.arn);
   }
   if (data.availabilityZones !== undefined && data.availabilityZones !== null) {
     contents.AvailabilityZones = deserializeAws_restJson1__listOf__string(data.availabilityZones, context);
@@ -5331,22 +5333,22 @@ export const deserializeAws_restJson1DescribeMultiplexCommand = async (
     contents.Destinations = deserializeAws_restJson1__listOfMultiplexOutputDestination(data.destinations, context);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.Id = data.id;
+    contents.Id = __expectString(data.id);
   }
   if (data.multiplexSettings !== undefined && data.multiplexSettings !== null) {
     contents.MultiplexSettings = deserializeAws_restJson1MultiplexSettings(data.multiplexSettings, context);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.Name = data.name;
+    contents.Name = __expectString(data.name);
   }
   if (data.pipelinesRunningCount !== undefined && data.pipelinesRunningCount !== null) {
-    contents.PipelinesRunningCount = data.pipelinesRunningCount;
+    contents.PipelinesRunningCount = __expectNumber(data.pipelinesRunningCount);
   }
   if (data.programCount !== undefined && data.programCount !== null) {
-    contents.ProgramCount = data.programCount;
+    contents.ProgramCount = __expectNumber(data.programCount);
   }
   if (data.state !== undefined && data.state !== null) {
-    contents.State = data.state;
+    contents.State = __expectString(data.state);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
@@ -5456,7 +5458,7 @@ export const deserializeAws_restJson1DescribeMultiplexProgramCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.channelId !== undefined && data.channelId !== null) {
-    contents.ChannelId = data.channelId;
+    contents.ChannelId = __expectString(data.channelId);
   }
   if (data.multiplexProgramSettings !== undefined && data.multiplexProgramSettings !== null) {
     contents.MultiplexProgramSettings = deserializeAws_restJson1MultiplexProgramSettings(
@@ -5477,7 +5479,7 @@ export const deserializeAws_restJson1DescribeMultiplexProgramCommand = async (
     );
   }
   if (data.programName !== undefined && data.programName !== null) {
-    contents.ProgramName = data.programName;
+    contents.ProgramName = __expectString(data.programName);
   }
   return Promise.resolve(contents);
 };
@@ -5590,31 +5592,31 @@ export const deserializeAws_restJson1DescribeOfferingCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.Arn = data.arn;
+    contents.Arn = __expectString(data.arn);
   }
   if (data.currencyCode !== undefined && data.currencyCode !== null) {
-    contents.CurrencyCode = data.currencyCode;
+    contents.CurrencyCode = __expectString(data.currencyCode);
   }
   if (data.duration !== undefined && data.duration !== null) {
-    contents.Duration = data.duration;
+    contents.Duration = __expectNumber(data.duration);
   }
   if (data.durationUnits !== undefined && data.durationUnits !== null) {
-    contents.DurationUnits = data.durationUnits;
+    contents.DurationUnits = __expectString(data.durationUnits);
   }
   if (data.fixedPrice !== undefined && data.fixedPrice !== null) {
-    contents.FixedPrice = data.fixedPrice;
+    contents.FixedPrice = __expectNumber(data.fixedPrice);
   }
   if (data.offeringDescription !== undefined && data.offeringDescription !== null) {
-    contents.OfferingDescription = data.offeringDescription;
+    contents.OfferingDescription = __expectString(data.offeringDescription);
   }
   if (data.offeringId !== undefined && data.offeringId !== null) {
-    contents.OfferingId = data.offeringId;
+    contents.OfferingId = __expectString(data.offeringId);
   }
   if (data.offeringType !== undefined && data.offeringType !== null) {
-    contents.OfferingType = data.offeringType;
+    contents.OfferingType = __expectString(data.offeringType);
   }
   if (data.region !== undefined && data.region !== null) {
-    contents.Region = data.region;
+    contents.Region = __expectString(data.region);
   }
   if (data.resourceSpecification !== undefined && data.resourceSpecification !== null) {
     contents.ResourceSpecification = deserializeAws_restJson1ReservationResourceSpecification(
@@ -5623,7 +5625,7 @@ export const deserializeAws_restJson1DescribeOfferingCommand = async (
     );
   }
   if (data.usagePrice !== undefined && data.usagePrice !== null) {
-    contents.UsagePrice = data.usagePrice;
+    contents.UsagePrice = __expectNumber(data.usagePrice);
   }
   return Promise.resolve(contents);
 };
@@ -5743,43 +5745,43 @@ export const deserializeAws_restJson1DescribeReservationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.Arn = data.arn;
+    contents.Arn = __expectString(data.arn);
   }
   if (data.count !== undefined && data.count !== null) {
-    contents.Count = data.count;
+    contents.Count = __expectNumber(data.count);
   }
   if (data.currencyCode !== undefined && data.currencyCode !== null) {
-    contents.CurrencyCode = data.currencyCode;
+    contents.CurrencyCode = __expectString(data.currencyCode);
   }
   if (data.duration !== undefined && data.duration !== null) {
-    contents.Duration = data.duration;
+    contents.Duration = __expectNumber(data.duration);
   }
   if (data.durationUnits !== undefined && data.durationUnits !== null) {
-    contents.DurationUnits = data.durationUnits;
+    contents.DurationUnits = __expectString(data.durationUnits);
   }
   if (data.end !== undefined && data.end !== null) {
-    contents.End = data.end;
+    contents.End = __expectString(data.end);
   }
   if (data.fixedPrice !== undefined && data.fixedPrice !== null) {
-    contents.FixedPrice = data.fixedPrice;
+    contents.FixedPrice = __expectNumber(data.fixedPrice);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.Name = data.name;
+    contents.Name = __expectString(data.name);
   }
   if (data.offeringDescription !== undefined && data.offeringDescription !== null) {
-    contents.OfferingDescription = data.offeringDescription;
+    contents.OfferingDescription = __expectString(data.offeringDescription);
   }
   if (data.offeringId !== undefined && data.offeringId !== null) {
-    contents.OfferingId = data.offeringId;
+    contents.OfferingId = __expectString(data.offeringId);
   }
   if (data.offeringType !== undefined && data.offeringType !== null) {
-    contents.OfferingType = data.offeringType;
+    contents.OfferingType = __expectString(data.offeringType);
   }
   if (data.region !== undefined && data.region !== null) {
-    contents.Region = data.region;
+    contents.Region = __expectString(data.region);
   }
   if (data.reservationId !== undefined && data.reservationId !== null) {
-    contents.ReservationId = data.reservationId;
+    contents.ReservationId = __expectString(data.reservationId);
   }
   if (data.resourceSpecification !== undefined && data.resourceSpecification !== null) {
     contents.ResourceSpecification = deserializeAws_restJson1ReservationResourceSpecification(
@@ -5788,16 +5790,16 @@ export const deserializeAws_restJson1DescribeReservationCommand = async (
     );
   }
   if (data.start !== undefined && data.start !== null) {
-    contents.Start = data.start;
+    contents.Start = __expectString(data.start);
   }
   if (data.state !== undefined && data.state !== null) {
-    contents.State = data.state;
+    contents.State = __expectString(data.state);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
   }
   if (data.usagePrice !== undefined && data.usagePrice !== null) {
-    contents.UsagePrice = data.usagePrice;
+    contents.UsagePrice = __expectNumber(data.usagePrice);
   }
   return Promise.resolve(contents);
 };
@@ -5901,7 +5903,7 @@ export const deserializeAws_restJson1DescribeScheduleCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   if (data.scheduleActions !== undefined && data.scheduleActions !== null) {
     contents.ScheduleActions = deserializeAws_restJson1__listOfScheduleAction(data.scheduleActions, context);
@@ -6011,7 +6013,7 @@ export const deserializeAws_restJson1ListChannelsCommand = async (
     contents.Channels = deserializeAws_restJson1__listOfChannelSummary(data.channels, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -6110,7 +6112,7 @@ export const deserializeAws_restJson1ListInputDevicesCommand = async (
     contents.InputDevices = deserializeAws_restJson1__listOfInputDeviceSummary(data.inputDevices, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -6212,7 +6214,7 @@ export const deserializeAws_restJson1ListInputDeviceTransfersCommand = async (
     );
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -6319,7 +6321,7 @@ export const deserializeAws_restJson1ListInputsCommand = async (
     contents.Inputs = deserializeAws_restJson1__listOfInput(data.inputs, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -6421,7 +6423,7 @@ export const deserializeAws_restJson1ListInputSecurityGroupsCommand = async (
     );
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -6520,7 +6522,7 @@ export const deserializeAws_restJson1ListMultiplexesCommand = async (
     contents.Multiplexes = deserializeAws_restJson1__listOfMultiplexSummary(data.multiplexes, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -6622,7 +6624,7 @@ export const deserializeAws_restJson1ListMultiplexProgramsCommand = async (
     );
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -6726,7 +6728,7 @@ export const deserializeAws_restJson1ListOfferingsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   if (data.offerings !== undefined && data.offerings !== null) {
     contents.Offerings = deserializeAws_restJson1__listOfOffering(data.offerings, context);
@@ -6825,7 +6827,7 @@ export const deserializeAws_restJson1ListReservationsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   if (data.reservations !== undefined && data.reservations !== null) {
     contents.Reservations = deserializeAws_restJson1__listOfReservation(data.reservations, context);
@@ -7244,13 +7246,13 @@ export const deserializeAws_restJson1StartChannelCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.Arn = data.arn;
+    contents.Arn = __expectString(data.arn);
   }
   if (data.cdiInputSpecification !== undefined && data.cdiInputSpecification !== null) {
     contents.CdiInputSpecification = deserializeAws_restJson1CdiInputSpecification(data.cdiInputSpecification, context);
   }
   if (data.channelClass !== undefined && data.channelClass !== null) {
-    contents.ChannelClass = data.channelClass;
+    contents.ChannelClass = __expectString(data.channelClass);
   }
   if (data.destinations !== undefined && data.destinations !== null) {
     contents.Destinations = deserializeAws_restJson1__listOfOutputDestination(data.destinations, context);
@@ -7262,7 +7264,7 @@ export const deserializeAws_restJson1StartChannelCommand = async (
     contents.EncoderSettings = deserializeAws_restJson1EncoderSettings(data.encoderSettings, context);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.Id = data.id;
+    contents.Id = __expectString(data.id);
   }
   if (data.inputAttachments !== undefined && data.inputAttachments !== null) {
     contents.InputAttachments = deserializeAws_restJson1__listOfInputAttachment(data.inputAttachments, context);
@@ -7271,22 +7273,22 @@ export const deserializeAws_restJson1StartChannelCommand = async (
     contents.InputSpecification = deserializeAws_restJson1InputSpecification(data.inputSpecification, context);
   }
   if (data.logLevel !== undefined && data.logLevel !== null) {
-    contents.LogLevel = data.logLevel;
+    contents.LogLevel = __expectString(data.logLevel);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.Name = data.name;
+    contents.Name = __expectString(data.name);
   }
   if (data.pipelineDetails !== undefined && data.pipelineDetails !== null) {
     contents.PipelineDetails = deserializeAws_restJson1__listOfPipelineDetail(data.pipelineDetails, context);
   }
   if (data.pipelinesRunningCount !== undefined && data.pipelinesRunningCount !== null) {
-    contents.PipelinesRunningCount = data.pipelinesRunningCount;
+    contents.PipelinesRunningCount = __expectNumber(data.pipelinesRunningCount);
   }
   if (data.roleArn !== undefined && data.roleArn !== null) {
-    contents.RoleArn = data.roleArn;
+    contents.RoleArn = __expectString(data.roleArn);
   }
   if (data.state !== undefined && data.state !== null) {
-    contents.State = data.state;
+    contents.State = __expectString(data.state);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
@@ -7412,7 +7414,7 @@ export const deserializeAws_restJson1StartMultiplexCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.Arn = data.arn;
+    contents.Arn = __expectString(data.arn);
   }
   if (data.availabilityZones !== undefined && data.availabilityZones !== null) {
     contents.AvailabilityZones = deserializeAws_restJson1__listOf__string(data.availabilityZones, context);
@@ -7421,22 +7423,22 @@ export const deserializeAws_restJson1StartMultiplexCommand = async (
     contents.Destinations = deserializeAws_restJson1__listOfMultiplexOutputDestination(data.destinations, context);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.Id = data.id;
+    contents.Id = __expectString(data.id);
   }
   if (data.multiplexSettings !== undefined && data.multiplexSettings !== null) {
     contents.MultiplexSettings = deserializeAws_restJson1MultiplexSettings(data.multiplexSettings, context);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.Name = data.name;
+    contents.Name = __expectString(data.name);
   }
   if (data.pipelinesRunningCount !== undefined && data.pipelinesRunningCount !== null) {
-    contents.PipelinesRunningCount = data.pipelinesRunningCount;
+    contents.PipelinesRunningCount = __expectNumber(data.pipelinesRunningCount);
   }
   if (data.programCount !== undefined && data.programCount !== null) {
-    contents.ProgramCount = data.programCount;
+    contents.ProgramCount = __expectNumber(data.programCount);
   }
   if (data.state !== undefined && data.state !== null) {
-    contents.State = data.state;
+    contents.State = __expectString(data.state);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
@@ -7566,13 +7568,13 @@ export const deserializeAws_restJson1StopChannelCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.Arn = data.arn;
+    contents.Arn = __expectString(data.arn);
   }
   if (data.cdiInputSpecification !== undefined && data.cdiInputSpecification !== null) {
     contents.CdiInputSpecification = deserializeAws_restJson1CdiInputSpecification(data.cdiInputSpecification, context);
   }
   if (data.channelClass !== undefined && data.channelClass !== null) {
-    contents.ChannelClass = data.channelClass;
+    contents.ChannelClass = __expectString(data.channelClass);
   }
   if (data.destinations !== undefined && data.destinations !== null) {
     contents.Destinations = deserializeAws_restJson1__listOfOutputDestination(data.destinations, context);
@@ -7584,7 +7586,7 @@ export const deserializeAws_restJson1StopChannelCommand = async (
     contents.EncoderSettings = deserializeAws_restJson1EncoderSettings(data.encoderSettings, context);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.Id = data.id;
+    contents.Id = __expectString(data.id);
   }
   if (data.inputAttachments !== undefined && data.inputAttachments !== null) {
     contents.InputAttachments = deserializeAws_restJson1__listOfInputAttachment(data.inputAttachments, context);
@@ -7593,22 +7595,22 @@ export const deserializeAws_restJson1StopChannelCommand = async (
     contents.InputSpecification = deserializeAws_restJson1InputSpecification(data.inputSpecification, context);
   }
   if (data.logLevel !== undefined && data.logLevel !== null) {
-    contents.LogLevel = data.logLevel;
+    contents.LogLevel = __expectString(data.logLevel);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.Name = data.name;
+    contents.Name = __expectString(data.name);
   }
   if (data.pipelineDetails !== undefined && data.pipelineDetails !== null) {
     contents.PipelineDetails = deserializeAws_restJson1__listOfPipelineDetail(data.pipelineDetails, context);
   }
   if (data.pipelinesRunningCount !== undefined && data.pipelinesRunningCount !== null) {
-    contents.PipelinesRunningCount = data.pipelinesRunningCount;
+    contents.PipelinesRunningCount = __expectNumber(data.pipelinesRunningCount);
   }
   if (data.roleArn !== undefined && data.roleArn !== null) {
-    contents.RoleArn = data.roleArn;
+    contents.RoleArn = __expectString(data.roleArn);
   }
   if (data.state !== undefined && data.state !== null) {
-    contents.State = data.state;
+    contents.State = __expectString(data.state);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
@@ -7734,7 +7736,7 @@ export const deserializeAws_restJson1StopMultiplexCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.Arn = data.arn;
+    contents.Arn = __expectString(data.arn);
   }
   if (data.availabilityZones !== undefined && data.availabilityZones !== null) {
     contents.AvailabilityZones = deserializeAws_restJson1__listOf__string(data.availabilityZones, context);
@@ -7743,22 +7745,22 @@ export const deserializeAws_restJson1StopMultiplexCommand = async (
     contents.Destinations = deserializeAws_restJson1__listOfMultiplexOutputDestination(data.destinations, context);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.Id = data.id;
+    contents.Id = __expectString(data.id);
   }
   if (data.multiplexSettings !== undefined && data.multiplexSettings !== null) {
     contents.MultiplexSettings = deserializeAws_restJson1MultiplexSettings(data.multiplexSettings, context);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.Name = data.name;
+    contents.Name = __expectString(data.name);
   }
   if (data.pipelinesRunningCount !== undefined && data.pipelinesRunningCount !== null) {
-    contents.PipelinesRunningCount = data.pipelinesRunningCount;
+    contents.PipelinesRunningCount = __expectNumber(data.pipelinesRunningCount);
   }
   if (data.programCount !== undefined && data.programCount !== null) {
-    contents.ProgramCount = data.programCount;
+    contents.ProgramCount = __expectNumber(data.programCount);
   }
   if (data.state !== undefined && data.state !== null) {
-    contents.State = data.state;
+    contents.State = __expectString(data.state);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
@@ -8323,37 +8325,37 @@ export const deserializeAws_restJson1UpdateInputDeviceCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.Arn = data.arn;
+    contents.Arn = __expectString(data.arn);
   }
   if (data.connectionState !== undefined && data.connectionState !== null) {
-    contents.ConnectionState = data.connectionState;
+    contents.ConnectionState = __expectString(data.connectionState);
   }
   if (data.deviceSettingsSyncState !== undefined && data.deviceSettingsSyncState !== null) {
-    contents.DeviceSettingsSyncState = data.deviceSettingsSyncState;
+    contents.DeviceSettingsSyncState = __expectString(data.deviceSettingsSyncState);
   }
   if (data.deviceUpdateStatus !== undefined && data.deviceUpdateStatus !== null) {
-    contents.DeviceUpdateStatus = data.deviceUpdateStatus;
+    contents.DeviceUpdateStatus = __expectString(data.deviceUpdateStatus);
   }
   if (data.hdDeviceSettings !== undefined && data.hdDeviceSettings !== null) {
     contents.HdDeviceSettings = deserializeAws_restJson1InputDeviceHdSettings(data.hdDeviceSettings, context);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.Id = data.id;
+    contents.Id = __expectString(data.id);
   }
   if (data.macAddress !== undefined && data.macAddress !== null) {
-    contents.MacAddress = data.macAddress;
+    contents.MacAddress = __expectString(data.macAddress);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.Name = data.name;
+    contents.Name = __expectString(data.name);
   }
   if (data.networkSettings !== undefined && data.networkSettings !== null) {
     contents.NetworkSettings = deserializeAws_restJson1InputDeviceNetworkSettings(data.networkSettings, context);
   }
   if (data.serialNumber !== undefined && data.serialNumber !== null) {
-    contents.SerialNumber = data.serialNumber;
+    contents.SerialNumber = __expectString(data.serialNumber);
   }
   if (data.type !== undefined && data.type !== null) {
-    contents.Type = data.type;
+    contents.Type = __expectString(data.type);
   }
   if (data.uhdDeviceSettings !== undefined && data.uhdDeviceSettings !== null) {
     contents.UhdDeviceSettings = deserializeAws_restJson1InputDeviceUhdSettings(data.uhdDeviceSettings, context);
@@ -8902,7 +8904,7 @@ const deserializeAws_restJson1BadGatewayExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -8919,7 +8921,7 @@ const deserializeAws_restJson1BadRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -8936,7 +8938,7 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -8953,7 +8955,7 @@ const deserializeAws_restJson1ForbiddenExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -8970,7 +8972,7 @@ const deserializeAws_restJson1GatewayTimeoutExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -8987,7 +8989,7 @@ const deserializeAws_restJson1InternalServerErrorExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -9004,7 +9006,7 @@ const deserializeAws_restJson1NotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -9021,7 +9023,7 @@ const deserializeAws_restJson1TooManyRequestsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -9039,7 +9041,7 @@ const deserializeAws_restJson1UnprocessableEntityExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   if (data.validationErrors !== undefined && data.validationErrors !== null) {
     contents.ValidationErrors = deserializeAws_restJson1__listOfValidationError(data.validationErrors, context);
@@ -12177,7 +12179,7 @@ const deserializeAws_restJson1__listOf__integer = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectNumber(entry) as any;
     });
 };
 
@@ -12188,7 +12190,7 @@ const deserializeAws_restJson1__listOf__string = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -12355,7 +12357,7 @@ const deserializeAws_restJson1__listOfHlsAdMarkers = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -12658,7 +12660,7 @@ const deserializeAws_restJson1__listOfRtmpAdMarkers = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -12722,30 +12724,27 @@ const deserializeAws_restJson1__listOfVideoDescription = (output: any, context: 
 
 const deserializeAws_restJson1AacSettings = (output: any, context: __SerdeContext): AacSettings => {
   return {
-    Bitrate: output.bitrate !== undefined && output.bitrate !== null ? output.bitrate : undefined,
-    CodingMode: output.codingMode !== undefined && output.codingMode !== null ? output.codingMode : undefined,
-    InputType: output.inputType !== undefined && output.inputType !== null ? output.inputType : undefined,
-    Profile: output.profile !== undefined && output.profile !== null ? output.profile : undefined,
-    RateControlMode:
-      output.rateControlMode !== undefined && output.rateControlMode !== null ? output.rateControlMode : undefined,
-    RawFormat: output.rawFormat !== undefined && output.rawFormat !== null ? output.rawFormat : undefined,
-    SampleRate: output.sampleRate !== undefined && output.sampleRate !== null ? output.sampleRate : undefined,
-    Spec: output.spec !== undefined && output.spec !== null ? output.spec : undefined,
-    VbrQuality: output.vbrQuality !== undefined && output.vbrQuality !== null ? output.vbrQuality : undefined,
+    Bitrate: __expectNumber(output.bitrate),
+    CodingMode: __expectString(output.codingMode),
+    InputType: __expectString(output.inputType),
+    Profile: __expectString(output.profile),
+    RateControlMode: __expectString(output.rateControlMode),
+    RawFormat: __expectString(output.rawFormat),
+    SampleRate: __expectNumber(output.sampleRate),
+    Spec: __expectString(output.spec),
+    VbrQuality: __expectString(output.vbrQuality),
   } as any;
 };
 
 const deserializeAws_restJson1Ac3Settings = (output: any, context: __SerdeContext): Ac3Settings => {
   return {
-    Bitrate: output.bitrate !== undefined && output.bitrate !== null ? output.bitrate : undefined,
-    BitstreamMode:
-      output.bitstreamMode !== undefined && output.bitstreamMode !== null ? output.bitstreamMode : undefined,
-    CodingMode: output.codingMode !== undefined && output.codingMode !== null ? output.codingMode : undefined,
-    Dialnorm: output.dialnorm !== undefined && output.dialnorm !== null ? output.dialnorm : undefined,
-    DrcProfile: output.drcProfile !== undefined && output.drcProfile !== null ? output.drcProfile : undefined,
-    LfeFilter: output.lfeFilter !== undefined && output.lfeFilter !== null ? output.lfeFilter : undefined,
-    MetadataControl:
-      output.metadataControl !== undefined && output.metadataControl !== null ? output.metadataControl : undefined,
+    Bitrate: __expectNumber(output.bitrate),
+    BitstreamMode: __expectString(output.bitstreamMode),
+    CodingMode: __expectString(output.codingMode),
+    Dialnorm: __expectNumber(output.dialnorm),
+    DrcProfile: __expectString(output.drcProfile),
+    LfeFilter: __expectString(output.lfeFilter),
+    MetadataControl: __expectString(output.metadataControl),
   } as any;
 };
 
@@ -12754,10 +12753,7 @@ const deserializeAws_restJson1AncillarySourceSettings = (
   context: __SerdeContext
 ): AncillarySourceSettings => {
   return {
-    SourceAncillaryChannelNumber:
-      output.sourceAncillaryChannelNumber !== undefined && output.sourceAncillaryChannelNumber !== null
-        ? output.sourceAncillaryChannelNumber
-        : undefined,
+    SourceAncillaryChannelNumber: __expectNumber(output.sourceAncillaryChannelNumber),
   } as any;
 };
 
@@ -12796,8 +12792,7 @@ const deserializeAws_restJson1ArchiveGroupSettings = (output: any, context: __Se
       output.destination !== undefined && output.destination !== null
         ? deserializeAws_restJson1OutputLocationRef(output.destination, context)
         : undefined,
-    RolloverInterval:
-      output.rolloverInterval !== undefined && output.rolloverInterval !== null ? output.rolloverInterval : undefined,
+    RolloverInterval: __expectNumber(output.rolloverInterval),
   } as any;
 };
 
@@ -12807,14 +12802,14 @@ const deserializeAws_restJson1ArchiveOutputSettings = (output: any, context: __S
       output.containerSettings !== undefined && output.containerSettings !== null
         ? deserializeAws_restJson1ArchiveContainerSettings(output.containerSettings, context)
         : undefined,
-    Extension: output.extension !== undefined && output.extension !== null ? output.extension : undefined,
-    NameModifier: output.nameModifier !== undefined && output.nameModifier !== null ? output.nameModifier : undefined,
+    Extension: __expectString(output.extension),
+    NameModifier: __expectString(output.nameModifier),
   } as any;
 };
 
 const deserializeAws_restJson1ArchiveS3Settings = (output: any, context: __SerdeContext): ArchiveS3Settings => {
   return {
-    CannedAcl: output.cannedAcl !== undefined && output.cannedAcl !== null ? output.cannedAcl : undefined,
+    CannedAcl: __expectString(output.cannedAcl),
   } as any;
 };
 
@@ -12835,8 +12830,7 @@ const deserializeAws_restJson1AudioChannelMapping = (output: any, context: __Ser
       output.inputChannelLevels !== undefined && output.inputChannelLevels !== null
         ? deserializeAws_restJson1__listOfInputChannelLevel(output.inputChannelLevels, context)
         : undefined,
-    OutputChannel:
-      output.outputChannel !== undefined && output.outputChannel !== null ? output.outputChannel : undefined,
+    OutputChannel: __expectNumber(output.outputChannel),
   } as any;
 };
 
@@ -12875,28 +12869,21 @@ const deserializeAws_restJson1AudioDescription = (output: any, context: __SerdeC
       output.audioNormalizationSettings !== undefined && output.audioNormalizationSettings !== null
         ? deserializeAws_restJson1AudioNormalizationSettings(output.audioNormalizationSettings, context)
         : undefined,
-    AudioSelectorName:
-      output.audioSelectorName !== undefined && output.audioSelectorName !== null
-        ? output.audioSelectorName
-        : undefined,
-    AudioType: output.audioType !== undefined && output.audioType !== null ? output.audioType : undefined,
-    AudioTypeControl:
-      output.audioTypeControl !== undefined && output.audioTypeControl !== null ? output.audioTypeControl : undefined,
+    AudioSelectorName: __expectString(output.audioSelectorName),
+    AudioType: __expectString(output.audioType),
+    AudioTypeControl: __expectString(output.audioTypeControl),
     CodecSettings:
       output.codecSettings !== undefined && output.codecSettings !== null
         ? deserializeAws_restJson1AudioCodecSettings(output.codecSettings, context)
         : undefined,
-    LanguageCode: output.languageCode !== undefined && output.languageCode !== null ? output.languageCode : undefined,
-    LanguageCodeControl:
-      output.languageCodeControl !== undefined && output.languageCodeControl !== null
-        ? output.languageCodeControl
-        : undefined,
-    Name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    LanguageCode: __expectString(output.languageCode),
+    LanguageCodeControl: __expectString(output.languageCodeControl),
+    Name: __expectString(output.name),
     RemixSettings:
       output.remixSettings !== undefined && output.remixSettings !== null
         ? deserializeAws_restJson1RemixSettings(output.remixSettings, context)
         : undefined,
-    StreamName: output.streamName !== undefined && output.streamName !== null ? output.streamName : undefined,
+    StreamName: __expectString(output.streamName),
   } as any;
 };
 
@@ -12905,11 +12892,8 @@ const deserializeAws_restJson1AudioLanguageSelection = (
   context: __SerdeContext
 ): AudioLanguageSelection => {
   return {
-    LanguageCode: output.languageCode !== undefined && output.languageCode !== null ? output.languageCode : undefined,
-    LanguageSelectionPolicy:
-      output.languageSelectionPolicy !== undefined && output.languageSelectionPolicy !== null
-        ? output.languageSelectionPolicy
-        : undefined,
+    LanguageCode: __expectString(output.languageCode),
+    LanguageSelectionPolicy: __expectString(output.languageSelectionPolicy),
   } as any;
 };
 
@@ -12918,35 +12902,33 @@ const deserializeAws_restJson1AudioNormalizationSettings = (
   context: __SerdeContext
 ): AudioNormalizationSettings => {
   return {
-    Algorithm: output.algorithm !== undefined && output.algorithm !== null ? output.algorithm : undefined,
-    AlgorithmControl:
-      output.algorithmControl !== undefined && output.algorithmControl !== null ? output.algorithmControl : undefined,
-    TargetLkfs: output.targetLkfs !== undefined && output.targetLkfs !== null ? output.targetLkfs : undefined,
+    Algorithm: __expectString(output.algorithm),
+    AlgorithmControl: __expectString(output.algorithmControl),
+    TargetLkfs: __expectNumber(output.targetLkfs),
   } as any;
 };
 
 const deserializeAws_restJson1AudioOnlyHlsSettings = (output: any, context: __SerdeContext): AudioOnlyHlsSettings => {
   return {
-    AudioGroupId: output.audioGroupId !== undefined && output.audioGroupId !== null ? output.audioGroupId : undefined,
+    AudioGroupId: __expectString(output.audioGroupId),
     AudioOnlyImage:
       output.audioOnlyImage !== undefined && output.audioOnlyImage !== null
         ? deserializeAws_restJson1InputLocation(output.audioOnlyImage, context)
         : undefined,
-    AudioTrackType:
-      output.audioTrackType !== undefined && output.audioTrackType !== null ? output.audioTrackType : undefined,
-    SegmentType: output.segmentType !== undefined && output.segmentType !== null ? output.segmentType : undefined,
+    AudioTrackType: __expectString(output.audioTrackType),
+    SegmentType: __expectString(output.segmentType),
   } as any;
 };
 
 const deserializeAws_restJson1AudioPidSelection = (output: any, context: __SerdeContext): AudioPidSelection => {
   return {
-    Pid: output.pid !== undefined && output.pid !== null ? output.pid : undefined,
+    Pid: __expectNumber(output.pid),
   } as any;
 };
 
 const deserializeAws_restJson1AudioSelector = (output: any, context: __SerdeContext): AudioSelector => {
   return {
-    Name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    Name: __expectString(output.name),
     SelectorSettings:
       output.selectorSettings !== undefined && output.selectorSettings !== null
         ? deserializeAws_restJson1AudioSelectorSettings(output.selectorSettings, context)
@@ -12976,20 +12958,14 @@ const deserializeAws_restJson1AudioSilenceFailoverSettings = (
   context: __SerdeContext
 ): AudioSilenceFailoverSettings => {
   return {
-    AudioSelectorName:
-      output.audioSelectorName !== undefined && output.audioSelectorName !== null
-        ? output.audioSelectorName
-        : undefined,
-    AudioSilenceThresholdMsec:
-      output.audioSilenceThresholdMsec !== undefined && output.audioSilenceThresholdMsec !== null
-        ? output.audioSilenceThresholdMsec
-        : undefined,
+    AudioSelectorName: __expectString(output.audioSelectorName),
+    AudioSilenceThresholdMsec: __expectNumber(output.audioSilenceThresholdMsec),
   } as any;
 };
 
 const deserializeAws_restJson1AudioTrack = (output: any, context: __SerdeContext): AudioTrack => {
   return {
-    Track: output.track !== undefined && output.track !== null ? output.track : undefined,
+    Track: __expectNumber(output.track),
   } as any;
 };
 
@@ -13007,18 +12983,13 @@ const deserializeAws_restJson1AutomaticInputFailoverSettings = (
   context: __SerdeContext
 ): AutomaticInputFailoverSettings => {
   return {
-    ErrorClearTimeMsec:
-      output.errorClearTimeMsec !== undefined && output.errorClearTimeMsec !== null
-        ? output.errorClearTimeMsec
-        : undefined,
+    ErrorClearTimeMsec: __expectNumber(output.errorClearTimeMsec),
     FailoverConditions:
       output.failoverConditions !== undefined && output.failoverConditions !== null
         ? deserializeAws_restJson1__listOfFailoverCondition(output.failoverConditions, context)
         : undefined,
-    InputPreference:
-      output.inputPreference !== undefined && output.inputPreference !== null ? output.inputPreference : undefined,
-    SecondaryInputId:
-      output.secondaryInputId !== undefined && output.secondaryInputId !== null ? output.secondaryInputId : undefined,
+    InputPreference: __expectString(output.inputPreference),
+    SecondaryInputId: __expectString(output.secondaryInputId),
   } as any;
 };
 
@@ -13028,7 +12999,7 @@ const deserializeAws_restJson1AvailBlanking = (output: any, context: __SerdeCont
       output.availBlankingImage !== undefined && output.availBlankingImage !== null
         ? deserializeAws_restJson1InputLocation(output.availBlankingImage, context)
         : undefined,
-    State: output.state !== undefined && output.state !== null ? output.state : undefined,
+    State: __expectString(output.state),
   } as any;
 };
 
@@ -13059,10 +13030,10 @@ const deserializeAws_restJson1BatchFailedResultModel = (
   context: __SerdeContext
 ): BatchFailedResultModel => {
   return {
-    Arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    Code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    Id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    Message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    Arn: __expectString(output.arn),
+    Code: __expectString(output.code),
+    Id: __expectString(output.id),
+    Message: __expectString(output.message),
   } as any;
 };
 
@@ -13095,9 +13066,9 @@ const deserializeAws_restJson1BatchSuccessfulResultModel = (
   context: __SerdeContext
 ): BatchSuccessfulResultModel => {
   return {
-    Arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    Id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    State: output.state !== undefined && output.state !== null ? output.state : undefined,
+    Arn: __expectString(output.arn),
+    Id: __expectString(output.id),
+    State: __expectString(output.state),
   } as any;
 };
 
@@ -13107,16 +13078,13 @@ const deserializeAws_restJson1BlackoutSlate = (output: any, context: __SerdeCont
       output.blackoutSlateImage !== undefined && output.blackoutSlateImage !== null
         ? deserializeAws_restJson1InputLocation(output.blackoutSlateImage, context)
         : undefined,
-    NetworkEndBlackout:
-      output.networkEndBlackout !== undefined && output.networkEndBlackout !== null
-        ? output.networkEndBlackout
-        : undefined,
+    NetworkEndBlackout: __expectString(output.networkEndBlackout),
     NetworkEndBlackoutImage:
       output.networkEndBlackoutImage !== undefined && output.networkEndBlackoutImage !== null
         ? deserializeAws_restJson1InputLocation(output.networkEndBlackoutImage, context)
         : undefined,
-    NetworkId: output.networkId !== undefined && output.networkId !== null ? output.networkId : undefined,
-    State: output.state !== undefined && output.state !== null ? output.state : undefined,
+    NetworkId: __expectString(output.networkId),
+    State: __expectString(output.state),
   } as any;
 };
 
@@ -13125,56 +13093,39 @@ const deserializeAws_restJson1BurnInDestinationSettings = (
   context: __SerdeContext
 ): BurnInDestinationSettings => {
   return {
-    Alignment: output.alignment !== undefined && output.alignment !== null ? output.alignment : undefined,
-    BackgroundColor:
-      output.backgroundColor !== undefined && output.backgroundColor !== null ? output.backgroundColor : undefined,
-    BackgroundOpacity:
-      output.backgroundOpacity !== undefined && output.backgroundOpacity !== null
-        ? output.backgroundOpacity
-        : undefined,
+    Alignment: __expectString(output.alignment),
+    BackgroundColor: __expectString(output.backgroundColor),
+    BackgroundOpacity: __expectNumber(output.backgroundOpacity),
     Font:
       output.font !== undefined && output.font !== null
         ? deserializeAws_restJson1InputLocation(output.font, context)
         : undefined,
-    FontColor: output.fontColor !== undefined && output.fontColor !== null ? output.fontColor : undefined,
-    FontOpacity: output.fontOpacity !== undefined && output.fontOpacity !== null ? output.fontOpacity : undefined,
-    FontResolution:
-      output.fontResolution !== undefined && output.fontResolution !== null ? output.fontResolution : undefined,
-    FontSize: output.fontSize !== undefined && output.fontSize !== null ? output.fontSize : undefined,
-    OutlineColor: output.outlineColor !== undefined && output.outlineColor !== null ? output.outlineColor : undefined,
-    OutlineSize: output.outlineSize !== undefined && output.outlineSize !== null ? output.outlineSize : undefined,
-    ShadowColor: output.shadowColor !== undefined && output.shadowColor !== null ? output.shadowColor : undefined,
-    ShadowOpacity:
-      output.shadowOpacity !== undefined && output.shadowOpacity !== null ? output.shadowOpacity : undefined,
-    ShadowXOffset:
-      output.shadowXOffset !== undefined && output.shadowXOffset !== null ? output.shadowXOffset : undefined,
-    ShadowYOffset:
-      output.shadowYOffset !== undefined && output.shadowYOffset !== null ? output.shadowYOffset : undefined,
-    TeletextGridControl:
-      output.teletextGridControl !== undefined && output.teletextGridControl !== null
-        ? output.teletextGridControl
-        : undefined,
-    XPosition: output.xPosition !== undefined && output.xPosition !== null ? output.xPosition : undefined,
-    YPosition: output.yPosition !== undefined && output.yPosition !== null ? output.yPosition : undefined,
+    FontColor: __expectString(output.fontColor),
+    FontOpacity: __expectNumber(output.fontOpacity),
+    FontResolution: __expectNumber(output.fontResolution),
+    FontSize: __expectString(output.fontSize),
+    OutlineColor: __expectString(output.outlineColor),
+    OutlineSize: __expectNumber(output.outlineSize),
+    ShadowColor: __expectString(output.shadowColor),
+    ShadowOpacity: __expectNumber(output.shadowOpacity),
+    ShadowXOffset: __expectNumber(output.shadowXOffset),
+    ShadowYOffset: __expectNumber(output.shadowYOffset),
+    TeletextGridControl: __expectString(output.teletextGridControl),
+    XPosition: __expectNumber(output.xPosition),
+    YPosition: __expectNumber(output.yPosition),
   } as any;
 };
 
 const deserializeAws_restJson1CaptionDescription = (output: any, context: __SerdeContext): CaptionDescription => {
   return {
-    CaptionSelectorName:
-      output.captionSelectorName !== undefined && output.captionSelectorName !== null
-        ? output.captionSelectorName
-        : undefined,
+    CaptionSelectorName: __expectString(output.captionSelectorName),
     DestinationSettings:
       output.destinationSettings !== undefined && output.destinationSettings !== null
         ? deserializeAws_restJson1CaptionDestinationSettings(output.destinationSettings, context)
         : undefined,
-    LanguageCode: output.languageCode !== undefined && output.languageCode !== null ? output.languageCode : undefined,
-    LanguageDescription:
-      output.languageDescription !== undefined && output.languageDescription !== null
-        ? output.languageDescription
-        : undefined,
-    Name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    LanguageCode: __expectString(output.languageCode),
+    LanguageDescription: __expectString(output.languageDescription),
+    Name: __expectString(output.name),
   } as any;
 };
 
@@ -13251,29 +13202,25 @@ const deserializeAws_restJson1CaptionLanguageMapping = (
   context: __SerdeContext
 ): CaptionLanguageMapping => {
   return {
-    CaptionChannel:
-      output.captionChannel !== undefined && output.captionChannel !== null ? output.captionChannel : undefined,
-    LanguageCode: output.languageCode !== undefined && output.languageCode !== null ? output.languageCode : undefined,
-    LanguageDescription:
-      output.languageDescription !== undefined && output.languageDescription !== null
-        ? output.languageDescription
-        : undefined,
+    CaptionChannel: __expectNumber(output.captionChannel),
+    LanguageCode: __expectString(output.languageCode),
+    LanguageDescription: __expectString(output.languageDescription),
   } as any;
 };
 
 const deserializeAws_restJson1CaptionRectangle = (output: any, context: __SerdeContext): CaptionRectangle => {
   return {
-    Height: output.height !== undefined && output.height !== null ? output.height : undefined,
-    LeftOffset: output.leftOffset !== undefined && output.leftOffset !== null ? output.leftOffset : undefined,
-    TopOffset: output.topOffset !== undefined && output.topOffset !== null ? output.topOffset : undefined,
-    Width: output.width !== undefined && output.width !== null ? output.width : undefined,
+    Height: __expectNumber(output.height),
+    LeftOffset: __expectNumber(output.leftOffset),
+    TopOffset: __expectNumber(output.topOffset),
+    Width: __expectNumber(output.width),
   } as any;
 };
 
 const deserializeAws_restJson1CaptionSelector = (output: any, context: __SerdeContext): CaptionSelector => {
   return {
-    LanguageCode: output.languageCode !== undefined && output.languageCode !== null ? output.languageCode : undefined,
-    Name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    LanguageCode: __expectString(output.languageCode),
+    Name: __expectString(output.name),
     SelectorSettings:
       output.selectorSettings !== undefined && output.selectorSettings !== null
         ? deserializeAws_restJson1CaptionSelectorSettings(output.selectorSettings, context)
@@ -13319,18 +13266,18 @@ const deserializeAws_restJson1CaptionSelectorSettings = (
 
 const deserializeAws_restJson1CdiInputSpecification = (output: any, context: __SerdeContext): CdiInputSpecification => {
   return {
-    Resolution: output.resolution !== undefined && output.resolution !== null ? output.resolution : undefined,
+    Resolution: __expectString(output.resolution),
   } as any;
 };
 
 const deserializeAws_restJson1Channel = (output: any, context: __SerdeContext): Channel => {
   return {
-    Arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    Arn: __expectString(output.arn),
     CdiInputSpecification:
       output.cdiInputSpecification !== undefined && output.cdiInputSpecification !== null
         ? deserializeAws_restJson1CdiInputSpecification(output.cdiInputSpecification, context)
         : undefined,
-    ChannelClass: output.channelClass !== undefined && output.channelClass !== null ? output.channelClass : undefined,
+    ChannelClass: __expectString(output.channelClass),
     Destinations:
       output.destinations !== undefined && output.destinations !== null
         ? deserializeAws_restJson1__listOfOutputDestination(output.destinations, context)
@@ -13343,7 +13290,7 @@ const deserializeAws_restJson1Channel = (output: any, context: __SerdeContext): 
       output.encoderSettings !== undefined && output.encoderSettings !== null
         ? deserializeAws_restJson1EncoderSettings(output.encoderSettings, context)
         : undefined,
-    Id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    Id: __expectString(output.id),
     InputAttachments:
       output.inputAttachments !== undefined && output.inputAttachments !== null
         ? deserializeAws_restJson1__listOfInputAttachment(output.inputAttachments, context)
@@ -13352,18 +13299,15 @@ const deserializeAws_restJson1Channel = (output: any, context: __SerdeContext): 
       output.inputSpecification !== undefined && output.inputSpecification !== null
         ? deserializeAws_restJson1InputSpecification(output.inputSpecification, context)
         : undefined,
-    LogLevel: output.logLevel !== undefined && output.logLevel !== null ? output.logLevel : undefined,
-    Name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    LogLevel: __expectString(output.logLevel),
+    Name: __expectString(output.name),
     PipelineDetails:
       output.pipelineDetails !== undefined && output.pipelineDetails !== null
         ? deserializeAws_restJson1__listOfPipelineDetail(output.pipelineDetails, context)
         : undefined,
-    PipelinesRunningCount:
-      output.pipelinesRunningCount !== undefined && output.pipelinesRunningCount !== null
-        ? output.pipelinesRunningCount
-        : undefined,
-    RoleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
-    State: output.state !== undefined && output.state !== null ? output.state : undefined,
+    PipelinesRunningCount: __expectNumber(output.pipelinesRunningCount),
+    RoleArn: __expectString(output.roleArn),
+    State: __expectString(output.state),
     Tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1Tags(output.tags, context)
@@ -13377,18 +13321,18 @@ const deserializeAws_restJson1Channel = (output: any, context: __SerdeContext): 
 
 const deserializeAws_restJson1ChannelEgressEndpoint = (output: any, context: __SerdeContext): ChannelEgressEndpoint => {
   return {
-    SourceIp: output.sourceIp !== undefined && output.sourceIp !== null ? output.sourceIp : undefined,
+    SourceIp: __expectString(output.sourceIp),
   } as any;
 };
 
 const deserializeAws_restJson1ChannelSummary = (output: any, context: __SerdeContext): ChannelSummary => {
   return {
-    Arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    Arn: __expectString(output.arn),
     CdiInputSpecification:
       output.cdiInputSpecification !== undefined && output.cdiInputSpecification !== null
         ? deserializeAws_restJson1CdiInputSpecification(output.cdiInputSpecification, context)
         : undefined,
-    ChannelClass: output.channelClass !== undefined && output.channelClass !== null ? output.channelClass : undefined,
+    ChannelClass: __expectString(output.channelClass),
     Destinations:
       output.destinations !== undefined && output.destinations !== null
         ? deserializeAws_restJson1__listOfOutputDestination(output.destinations, context)
@@ -13397,7 +13341,7 @@ const deserializeAws_restJson1ChannelSummary = (output: any, context: __SerdeCon
       output.egressEndpoints !== undefined && output.egressEndpoints !== null
         ? deserializeAws_restJson1__listOfChannelEgressEndpoint(output.egressEndpoints, context)
         : undefined,
-    Id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    Id: __expectString(output.id),
     InputAttachments:
       output.inputAttachments !== undefined && output.inputAttachments !== null
         ? deserializeAws_restJson1__listOfInputAttachment(output.inputAttachments, context)
@@ -13406,14 +13350,11 @@ const deserializeAws_restJson1ChannelSummary = (output: any, context: __SerdeCon
       output.inputSpecification !== undefined && output.inputSpecification !== null
         ? deserializeAws_restJson1InputSpecification(output.inputSpecification, context)
         : undefined,
-    LogLevel: output.logLevel !== undefined && output.logLevel !== null ? output.logLevel : undefined,
-    Name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    PipelinesRunningCount:
-      output.pipelinesRunningCount !== undefined && output.pipelinesRunningCount !== null
-        ? output.pipelinesRunningCount
-        : undefined,
-    RoleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
-    State: output.state !== undefined && output.state !== null ? output.state : undefined,
+    LogLevel: __expectString(output.logLevel),
+    Name: __expectString(output.name),
+    PipelinesRunningCount: __expectNumber(output.pipelinesRunningCount),
+    RoleArn: __expectString(output.roleArn),
+    State: __expectString(output.state),
     Tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1Tags(output.tags, context)
@@ -13434,21 +13375,18 @@ const deserializeAws_restJson1ColorSpacePassthroughSettings = (
 
 const deserializeAws_restJson1DvbNitSettings = (output: any, context: __SerdeContext): DvbNitSettings => {
   return {
-    NetworkId: output.networkId !== undefined && output.networkId !== null ? output.networkId : undefined,
-    NetworkName: output.networkName !== undefined && output.networkName !== null ? output.networkName : undefined,
-    RepInterval: output.repInterval !== undefined && output.repInterval !== null ? output.repInterval : undefined,
+    NetworkId: __expectNumber(output.networkId),
+    NetworkName: __expectString(output.networkName),
+    RepInterval: __expectNumber(output.repInterval),
   } as any;
 };
 
 const deserializeAws_restJson1DvbSdtSettings = (output: any, context: __SerdeContext): DvbSdtSettings => {
   return {
-    OutputSdt: output.outputSdt !== undefined && output.outputSdt !== null ? output.outputSdt : undefined,
-    RepInterval: output.repInterval !== undefined && output.repInterval !== null ? output.repInterval : undefined,
-    ServiceName: output.serviceName !== undefined && output.serviceName !== null ? output.serviceName : undefined,
-    ServiceProviderName:
-      output.serviceProviderName !== undefined && output.serviceProviderName !== null
-        ? output.serviceProviderName
-        : undefined,
+    OutputSdt: __expectString(output.outputSdt),
+    RepInterval: __expectNumber(output.repInterval),
+    ServiceName: __expectString(output.serviceName),
+    ServiceProviderName: __expectString(output.serviceProviderName),
   } as any;
 };
 
@@ -13457,97 +13395,64 @@ const deserializeAws_restJson1DvbSubDestinationSettings = (
   context: __SerdeContext
 ): DvbSubDestinationSettings => {
   return {
-    Alignment: output.alignment !== undefined && output.alignment !== null ? output.alignment : undefined,
-    BackgroundColor:
-      output.backgroundColor !== undefined && output.backgroundColor !== null ? output.backgroundColor : undefined,
-    BackgroundOpacity:
-      output.backgroundOpacity !== undefined && output.backgroundOpacity !== null
-        ? output.backgroundOpacity
-        : undefined,
+    Alignment: __expectString(output.alignment),
+    BackgroundColor: __expectString(output.backgroundColor),
+    BackgroundOpacity: __expectNumber(output.backgroundOpacity),
     Font:
       output.font !== undefined && output.font !== null
         ? deserializeAws_restJson1InputLocation(output.font, context)
         : undefined,
-    FontColor: output.fontColor !== undefined && output.fontColor !== null ? output.fontColor : undefined,
-    FontOpacity: output.fontOpacity !== undefined && output.fontOpacity !== null ? output.fontOpacity : undefined,
-    FontResolution:
-      output.fontResolution !== undefined && output.fontResolution !== null ? output.fontResolution : undefined,
-    FontSize: output.fontSize !== undefined && output.fontSize !== null ? output.fontSize : undefined,
-    OutlineColor: output.outlineColor !== undefined && output.outlineColor !== null ? output.outlineColor : undefined,
-    OutlineSize: output.outlineSize !== undefined && output.outlineSize !== null ? output.outlineSize : undefined,
-    ShadowColor: output.shadowColor !== undefined && output.shadowColor !== null ? output.shadowColor : undefined,
-    ShadowOpacity:
-      output.shadowOpacity !== undefined && output.shadowOpacity !== null ? output.shadowOpacity : undefined,
-    ShadowXOffset:
-      output.shadowXOffset !== undefined && output.shadowXOffset !== null ? output.shadowXOffset : undefined,
-    ShadowYOffset:
-      output.shadowYOffset !== undefined && output.shadowYOffset !== null ? output.shadowYOffset : undefined,
-    TeletextGridControl:
-      output.teletextGridControl !== undefined && output.teletextGridControl !== null
-        ? output.teletextGridControl
-        : undefined,
-    XPosition: output.xPosition !== undefined && output.xPosition !== null ? output.xPosition : undefined,
-    YPosition: output.yPosition !== undefined && output.yPosition !== null ? output.yPosition : undefined,
+    FontColor: __expectString(output.fontColor),
+    FontOpacity: __expectNumber(output.fontOpacity),
+    FontResolution: __expectNumber(output.fontResolution),
+    FontSize: __expectString(output.fontSize),
+    OutlineColor: __expectString(output.outlineColor),
+    OutlineSize: __expectNumber(output.outlineSize),
+    ShadowColor: __expectString(output.shadowColor),
+    ShadowOpacity: __expectNumber(output.shadowOpacity),
+    ShadowXOffset: __expectNumber(output.shadowXOffset),
+    ShadowYOffset: __expectNumber(output.shadowYOffset),
+    TeletextGridControl: __expectString(output.teletextGridControl),
+    XPosition: __expectNumber(output.xPosition),
+    YPosition: __expectNumber(output.yPosition),
   } as any;
 };
 
 const deserializeAws_restJson1DvbSubSourceSettings = (output: any, context: __SerdeContext): DvbSubSourceSettings => {
   return {
-    OcrLanguage: output.ocrLanguage !== undefined && output.ocrLanguage !== null ? output.ocrLanguage : undefined,
-    Pid: output.pid !== undefined && output.pid !== null ? output.pid : undefined,
+    OcrLanguage: __expectString(output.ocrLanguage),
+    Pid: __expectNumber(output.pid),
   } as any;
 };
 
 const deserializeAws_restJson1DvbTdtSettings = (output: any, context: __SerdeContext): DvbTdtSettings => {
   return {
-    RepInterval: output.repInterval !== undefined && output.repInterval !== null ? output.repInterval : undefined,
+    RepInterval: __expectNumber(output.repInterval),
   } as any;
 };
 
 const deserializeAws_restJson1Eac3Settings = (output: any, context: __SerdeContext): Eac3Settings => {
   return {
-    AttenuationControl:
-      output.attenuationControl !== undefined && output.attenuationControl !== null
-        ? output.attenuationControl
-        : undefined,
-    Bitrate: output.bitrate !== undefined && output.bitrate !== null ? output.bitrate : undefined,
-    BitstreamMode:
-      output.bitstreamMode !== undefined && output.bitstreamMode !== null ? output.bitstreamMode : undefined,
-    CodingMode: output.codingMode !== undefined && output.codingMode !== null ? output.codingMode : undefined,
-    DcFilter: output.dcFilter !== undefined && output.dcFilter !== null ? output.dcFilter : undefined,
-    Dialnorm: output.dialnorm !== undefined && output.dialnorm !== null ? output.dialnorm : undefined,
-    DrcLine: output.drcLine !== undefined && output.drcLine !== null ? output.drcLine : undefined,
-    DrcRf: output.drcRf !== undefined && output.drcRf !== null ? output.drcRf : undefined,
-    LfeControl: output.lfeControl !== undefined && output.lfeControl !== null ? output.lfeControl : undefined,
-    LfeFilter: output.lfeFilter !== undefined && output.lfeFilter !== null ? output.lfeFilter : undefined,
-    LoRoCenterMixLevel:
-      output.loRoCenterMixLevel !== undefined && output.loRoCenterMixLevel !== null
-        ? output.loRoCenterMixLevel
-        : undefined,
-    LoRoSurroundMixLevel:
-      output.loRoSurroundMixLevel !== undefined && output.loRoSurroundMixLevel !== null
-        ? output.loRoSurroundMixLevel
-        : undefined,
-    LtRtCenterMixLevel:
-      output.ltRtCenterMixLevel !== undefined && output.ltRtCenterMixLevel !== null
-        ? output.ltRtCenterMixLevel
-        : undefined,
-    LtRtSurroundMixLevel:
-      output.ltRtSurroundMixLevel !== undefined && output.ltRtSurroundMixLevel !== null
-        ? output.ltRtSurroundMixLevel
-        : undefined,
-    MetadataControl:
-      output.metadataControl !== undefined && output.metadataControl !== null ? output.metadataControl : undefined,
-    PassthroughControl:
-      output.passthroughControl !== undefined && output.passthroughControl !== null
-        ? output.passthroughControl
-        : undefined,
-    PhaseControl: output.phaseControl !== undefined && output.phaseControl !== null ? output.phaseControl : undefined,
-    StereoDownmix:
-      output.stereoDownmix !== undefined && output.stereoDownmix !== null ? output.stereoDownmix : undefined,
-    SurroundExMode:
-      output.surroundExMode !== undefined && output.surroundExMode !== null ? output.surroundExMode : undefined,
-    SurroundMode: output.surroundMode !== undefined && output.surroundMode !== null ? output.surroundMode : undefined,
+    AttenuationControl: __expectString(output.attenuationControl),
+    Bitrate: __expectNumber(output.bitrate),
+    BitstreamMode: __expectString(output.bitstreamMode),
+    CodingMode: __expectString(output.codingMode),
+    DcFilter: __expectString(output.dcFilter),
+    Dialnorm: __expectNumber(output.dialnorm),
+    DrcLine: __expectString(output.drcLine),
+    DrcRf: __expectString(output.drcRf),
+    LfeControl: __expectString(output.lfeControl),
+    LfeFilter: __expectString(output.lfeFilter),
+    LoRoCenterMixLevel: __expectNumber(output.loRoCenterMixLevel),
+    LoRoSurroundMixLevel: __expectNumber(output.loRoSurroundMixLevel),
+    LtRtCenterMixLevel: __expectNumber(output.ltRtCenterMixLevel),
+    LtRtSurroundMixLevel: __expectNumber(output.ltRtSurroundMixLevel),
+    MetadataControl: __expectString(output.metadataControl),
+    PassthroughControl: __expectString(output.passthroughControl),
+    PhaseControl: __expectString(output.phaseControl),
+    StereoDownmix: __expectString(output.stereoDownmix),
+    SurroundExMode: __expectString(output.surroundExMode),
+    SurroundMode: __expectString(output.surroundMode),
   } as any;
 };
 
@@ -13556,11 +13461,10 @@ const deserializeAws_restJson1EbuTtDDestinationSettings = (
   context: __SerdeContext
 ): EbuTtDDestinationSettings => {
   return {
-    CopyrightHolder:
-      output.copyrightHolder !== undefined && output.copyrightHolder !== null ? output.copyrightHolder : undefined,
-    FillLineGap: output.fillLineGap !== undefined && output.fillLineGap !== null ? output.fillLineGap : undefined,
-    FontFamily: output.fontFamily !== undefined && output.fontFamily !== null ? output.fontFamily : undefined,
-    StyleControl: output.styleControl !== undefined && output.styleControl !== null ? output.styleControl : undefined,
+    CopyrightHolder: __expectString(output.copyrightHolder),
+    FillLineGap: __expectString(output.fillLineGap),
+    FontFamily: __expectString(output.fontFamily),
+    StyleControl: __expectString(output.styleControl),
   } as any;
 };
 
@@ -13583,18 +13487,10 @@ const deserializeAws_restJson1EmbeddedSourceSettings = (
   context: __SerdeContext
 ): EmbeddedSourceSettings => {
   return {
-    Convert608To708:
-      output.convert608To708 !== undefined && output.convert608To708 !== null ? output.convert608To708 : undefined,
-    Scte20Detection:
-      output.scte20Detection !== undefined && output.scte20Detection !== null ? output.scte20Detection : undefined,
-    Source608ChannelNumber:
-      output.source608ChannelNumber !== undefined && output.source608ChannelNumber !== null
-        ? output.source608ChannelNumber
-        : undefined,
-    Source608TrackNumber:
-      output.source608TrackNumber !== undefined && output.source608TrackNumber !== null
-        ? output.source608TrackNumber
-        : undefined,
+    Convert608To708: __expectString(output.convert608To708),
+    Scte20Detection: __expectString(output.scte20Detection),
+    Source608ChannelNumber: __expectNumber(output.source608ChannelNumber),
+    Source608TrackNumber: __expectNumber(output.source608TrackNumber),
   } as any;
 };
 
@@ -13682,18 +13578,15 @@ const deserializeAws_restJson1FailoverConditionSettings = (
 
 const deserializeAws_restJson1FeatureActivations = (output: any, context: __SerdeContext): FeatureActivations => {
   return {
-    InputPrepareScheduleActions:
-      output.inputPrepareScheduleActions !== undefined && output.inputPrepareScheduleActions !== null
-        ? output.inputPrepareScheduleActions
-        : undefined,
+    InputPrepareScheduleActions: __expectString(output.inputPrepareScheduleActions),
   } as any;
 };
 
 const deserializeAws_restJson1FecOutputSettings = (output: any, context: __SerdeContext): FecOutputSettings => {
   return {
-    ColumnDepth: output.columnDepth !== undefined && output.columnDepth !== null ? output.columnDepth : undefined,
-    IncludeFec: output.includeFec !== undefined && output.includeFec !== null ? output.includeFec : undefined,
-    RowLength: output.rowLength !== undefined && output.rowLength !== null ? output.rowLength : undefined,
+    ColumnDepth: __expectNumber(output.columnDepth),
+    IncludeFec: __expectString(output.includeFec),
+    RowLength: __expectNumber(output.rowLength),
   } as any;
 };
 
@@ -13702,24 +13595,15 @@ const deserializeAws_restJson1FixedModeScheduleActionStartSettings = (
   context: __SerdeContext
 ): FixedModeScheduleActionStartSettings => {
   return {
-    Time: output.time !== undefined && output.time !== null ? output.time : undefined,
+    Time: __expectString(output.time),
   } as any;
 };
 
 const deserializeAws_restJson1Fmp4HlsSettings = (output: any, context: __SerdeContext): Fmp4HlsSettings => {
   return {
-    AudioRenditionSets:
-      output.audioRenditionSets !== undefined && output.audioRenditionSets !== null
-        ? output.audioRenditionSets
-        : undefined,
-    NielsenId3Behavior:
-      output.nielsenId3Behavior !== undefined && output.nielsenId3Behavior !== null
-        ? output.nielsenId3Behavior
-        : undefined,
-    TimedMetadataBehavior:
-      output.timedMetadataBehavior !== undefined && output.timedMetadataBehavior !== null
-        ? output.timedMetadataBehavior
-        : undefined,
+    AudioRenditionSets: __expectString(output.audioRenditionSets),
+    NielsenId3Behavior: __expectString(output.nielsenId3Behavior),
+    TimedMetadataBehavior: __expectString(output.timedMetadataBehavior),
   } as any;
 };
 
@@ -13728,11 +13612,8 @@ const deserializeAws_restJson1FollowModeScheduleActionStartSettings = (
   context: __SerdeContext
 ): FollowModeScheduleActionStartSettings => {
   return {
-    FollowPoint: output.followPoint !== undefined && output.followPoint !== null ? output.followPoint : undefined,
-    ReferenceActionName:
-      output.referenceActionName !== undefined && output.referenceActionName !== null
-        ? output.referenceActionName
-        : undefined,
+    FollowPoint: __expectString(output.followPoint),
+    ReferenceActionName: __expectString(output.referenceActionName),
   } as any;
 };
 
@@ -13776,7 +13657,7 @@ const deserializeAws_restJson1FrameCaptureOutputSettings = (
   context: __SerdeContext
 ): FrameCaptureOutputSettings => {
   return {
-    NameModifier: output.nameModifier !== undefined && output.nameModifier !== null ? output.nameModifier : undefined,
+    NameModifier: __expectString(output.nameModifier),
   } as any;
 };
 
@@ -13785,43 +13666,28 @@ const deserializeAws_restJson1FrameCaptureS3Settings = (
   context: __SerdeContext
 ): FrameCaptureS3Settings => {
   return {
-    CannedAcl: output.cannedAcl !== undefined && output.cannedAcl !== null ? output.cannedAcl : undefined,
+    CannedAcl: __expectString(output.cannedAcl),
   } as any;
 };
 
 const deserializeAws_restJson1FrameCaptureSettings = (output: any, context: __SerdeContext): FrameCaptureSettings => {
   return {
-    CaptureInterval:
-      output.captureInterval !== undefined && output.captureInterval !== null ? output.captureInterval : undefined,
-    CaptureIntervalUnits:
-      output.captureIntervalUnits !== undefined && output.captureIntervalUnits !== null
-        ? output.captureIntervalUnits
-        : undefined,
+    CaptureInterval: __expectNumber(output.captureInterval),
+    CaptureIntervalUnits: __expectString(output.captureIntervalUnits),
   } as any;
 };
 
 const deserializeAws_restJson1GlobalConfiguration = (output: any, context: __SerdeContext): GlobalConfiguration => {
   return {
-    InitialAudioGain:
-      output.initialAudioGain !== undefined && output.initialAudioGain !== null ? output.initialAudioGain : undefined,
-    InputEndAction:
-      output.inputEndAction !== undefined && output.inputEndAction !== null ? output.inputEndAction : undefined,
+    InitialAudioGain: __expectNumber(output.initialAudioGain),
+    InputEndAction: __expectString(output.inputEndAction),
     InputLossBehavior:
       output.inputLossBehavior !== undefined && output.inputLossBehavior !== null
         ? deserializeAws_restJson1InputLossBehavior(output.inputLossBehavior, context)
         : undefined,
-    OutputLockingMode:
-      output.outputLockingMode !== undefined && output.outputLockingMode !== null
-        ? output.outputLockingMode
-        : undefined,
-    OutputTimingSource:
-      output.outputTimingSource !== undefined && output.outputTimingSource !== null
-        ? output.outputTimingSource
-        : undefined,
-    SupportLowFramerateInputs:
-      output.supportLowFramerateInputs !== undefined && output.supportLowFramerateInputs !== null
-        ? output.supportLowFramerateInputs
-        : undefined,
+    OutputLockingMode: __expectString(output.outputLockingMode),
+    OutputTimingSource: __expectString(output.outputTimingSource),
+    SupportLowFramerateInputs: __expectString(output.supportLowFramerateInputs),
   } as any;
 };
 
@@ -13856,83 +13722,53 @@ const deserializeAws_restJson1H264FilterSettings = (output: any, context: __Serd
 
 const deserializeAws_restJson1H264Settings = (output: any, context: __SerdeContext): H264Settings => {
   return {
-    AdaptiveQuantization:
-      output.adaptiveQuantization !== undefined && output.adaptiveQuantization !== null
-        ? output.adaptiveQuantization
-        : undefined,
-    AfdSignaling: output.afdSignaling !== undefined && output.afdSignaling !== null ? output.afdSignaling : undefined,
-    Bitrate: output.bitrate !== undefined && output.bitrate !== null ? output.bitrate : undefined,
-    BufFillPct: output.bufFillPct !== undefined && output.bufFillPct !== null ? output.bufFillPct : undefined,
-    BufSize: output.bufSize !== undefined && output.bufSize !== null ? output.bufSize : undefined,
-    ColorMetadata:
-      output.colorMetadata !== undefined && output.colorMetadata !== null ? output.colorMetadata : undefined,
+    AdaptiveQuantization: __expectString(output.adaptiveQuantization),
+    AfdSignaling: __expectString(output.afdSignaling),
+    Bitrate: __expectNumber(output.bitrate),
+    BufFillPct: __expectNumber(output.bufFillPct),
+    BufSize: __expectNumber(output.bufSize),
+    ColorMetadata: __expectString(output.colorMetadata),
     ColorSpaceSettings:
       output.colorSpaceSettings !== undefined && output.colorSpaceSettings !== null
         ? deserializeAws_restJson1H264ColorSpaceSettings(output.colorSpaceSettings, context)
         : undefined,
-    EntropyEncoding:
-      output.entropyEncoding !== undefined && output.entropyEncoding !== null ? output.entropyEncoding : undefined,
+    EntropyEncoding: __expectString(output.entropyEncoding),
     FilterSettings:
       output.filterSettings !== undefined && output.filterSettings !== null
         ? deserializeAws_restJson1H264FilterSettings(output.filterSettings, context)
         : undefined,
-    FixedAfd: output.fixedAfd !== undefined && output.fixedAfd !== null ? output.fixedAfd : undefined,
-    FlickerAq: output.flickerAq !== undefined && output.flickerAq !== null ? output.flickerAq : undefined,
-    ForceFieldPictures:
-      output.forceFieldPictures !== undefined && output.forceFieldPictures !== null
-        ? output.forceFieldPictures
-        : undefined,
-    FramerateControl:
-      output.framerateControl !== undefined && output.framerateControl !== null ? output.framerateControl : undefined,
-    FramerateDenominator:
-      output.framerateDenominator !== undefined && output.framerateDenominator !== null
-        ? output.framerateDenominator
-        : undefined,
-    FramerateNumerator:
-      output.framerateNumerator !== undefined && output.framerateNumerator !== null
-        ? output.framerateNumerator
-        : undefined,
-    GopBReference:
-      output.gopBReference !== undefined && output.gopBReference !== null ? output.gopBReference : undefined,
-    GopClosedCadence:
-      output.gopClosedCadence !== undefined && output.gopClosedCadence !== null ? output.gopClosedCadence : undefined,
-    GopNumBFrames:
-      output.gopNumBFrames !== undefined && output.gopNumBFrames !== null ? output.gopNumBFrames : undefined,
-    GopSize: output.gopSize !== undefined && output.gopSize !== null ? output.gopSize : undefined,
-    GopSizeUnits: output.gopSizeUnits !== undefined && output.gopSizeUnits !== null ? output.gopSizeUnits : undefined,
-    Level: output.level !== undefined && output.level !== null ? output.level : undefined,
-    LookAheadRateControl:
-      output.lookAheadRateControl !== undefined && output.lookAheadRateControl !== null
-        ? output.lookAheadRateControl
-        : undefined,
-    MaxBitrate: output.maxBitrate !== undefined && output.maxBitrate !== null ? output.maxBitrate : undefined,
-    MinIInterval: output.minIInterval !== undefined && output.minIInterval !== null ? output.minIInterval : undefined,
-    NumRefFrames: output.numRefFrames !== undefined && output.numRefFrames !== null ? output.numRefFrames : undefined,
-    ParControl: output.parControl !== undefined && output.parControl !== null ? output.parControl : undefined,
-    ParDenominator:
-      output.parDenominator !== undefined && output.parDenominator !== null ? output.parDenominator : undefined,
-    ParNumerator: output.parNumerator !== undefined && output.parNumerator !== null ? output.parNumerator : undefined,
-    Profile: output.profile !== undefined && output.profile !== null ? output.profile : undefined,
-    QualityLevel: output.qualityLevel !== undefined && output.qualityLevel !== null ? output.qualityLevel : undefined,
-    QvbrQualityLevel:
-      output.qvbrQualityLevel !== undefined && output.qvbrQualityLevel !== null ? output.qvbrQualityLevel : undefined,
-    RateControlMode:
-      output.rateControlMode !== undefined && output.rateControlMode !== null ? output.rateControlMode : undefined,
-    ScanType: output.scanType !== undefined && output.scanType !== null ? output.scanType : undefined,
-    SceneChangeDetect:
-      output.sceneChangeDetect !== undefined && output.sceneChangeDetect !== null
-        ? output.sceneChangeDetect
-        : undefined,
-    Slices: output.slices !== undefined && output.slices !== null ? output.slices : undefined,
-    Softness: output.softness !== undefined && output.softness !== null ? output.softness : undefined,
-    SpatialAq: output.spatialAq !== undefined && output.spatialAq !== null ? output.spatialAq : undefined,
-    SubgopLength: output.subgopLength !== undefined && output.subgopLength !== null ? output.subgopLength : undefined,
-    Syntax: output.syntax !== undefined && output.syntax !== null ? output.syntax : undefined,
-    TemporalAq: output.temporalAq !== undefined && output.temporalAq !== null ? output.temporalAq : undefined,
-    TimecodeInsertion:
-      output.timecodeInsertion !== undefined && output.timecodeInsertion !== null
-        ? output.timecodeInsertion
-        : undefined,
+    FixedAfd: __expectString(output.fixedAfd),
+    FlickerAq: __expectString(output.flickerAq),
+    ForceFieldPictures: __expectString(output.forceFieldPictures),
+    FramerateControl: __expectString(output.framerateControl),
+    FramerateDenominator: __expectNumber(output.framerateDenominator),
+    FramerateNumerator: __expectNumber(output.framerateNumerator),
+    GopBReference: __expectString(output.gopBReference),
+    GopClosedCadence: __expectNumber(output.gopClosedCadence),
+    GopNumBFrames: __expectNumber(output.gopNumBFrames),
+    GopSize: __expectNumber(output.gopSize),
+    GopSizeUnits: __expectString(output.gopSizeUnits),
+    Level: __expectString(output.level),
+    LookAheadRateControl: __expectString(output.lookAheadRateControl),
+    MaxBitrate: __expectNumber(output.maxBitrate),
+    MinIInterval: __expectNumber(output.minIInterval),
+    NumRefFrames: __expectNumber(output.numRefFrames),
+    ParControl: __expectString(output.parControl),
+    ParDenominator: __expectNumber(output.parDenominator),
+    ParNumerator: __expectNumber(output.parNumerator),
+    Profile: __expectString(output.profile),
+    QualityLevel: __expectString(output.qualityLevel),
+    QvbrQualityLevel: __expectNumber(output.qvbrQualityLevel),
+    RateControlMode: __expectString(output.rateControlMode),
+    ScanType: __expectString(output.scanType),
+    SceneChangeDetect: __expectString(output.sceneChangeDetect),
+    Slices: __expectNumber(output.slices),
+    Softness: __expectNumber(output.softness),
+    SpatialAq: __expectString(output.spatialAq),
+    SubgopLength: __expectString(output.subgopLength),
+    Syntax: __expectString(output.syntax),
+    TemporalAq: __expectString(output.temporalAq),
+    TimecodeInsertion: __expectString(output.timecodeInsertion),
   } as any;
 };
 
@@ -13971,19 +13807,12 @@ const deserializeAws_restJson1H265FilterSettings = (output: any, context: __Serd
 
 const deserializeAws_restJson1H265Settings = (output: any, context: __SerdeContext): H265Settings => {
   return {
-    AdaptiveQuantization:
-      output.adaptiveQuantization !== undefined && output.adaptiveQuantization !== null
-        ? output.adaptiveQuantization
-        : undefined,
-    AfdSignaling: output.afdSignaling !== undefined && output.afdSignaling !== null ? output.afdSignaling : undefined,
-    AlternativeTransferFunction:
-      output.alternativeTransferFunction !== undefined && output.alternativeTransferFunction !== null
-        ? output.alternativeTransferFunction
-        : undefined,
-    Bitrate: output.bitrate !== undefined && output.bitrate !== null ? output.bitrate : undefined,
-    BufSize: output.bufSize !== undefined && output.bufSize !== null ? output.bufSize : undefined,
-    ColorMetadata:
-      output.colorMetadata !== undefined && output.colorMetadata !== null ? output.colorMetadata : undefined,
+    AdaptiveQuantization: __expectString(output.adaptiveQuantization),
+    AfdSignaling: __expectString(output.afdSignaling),
+    AlternativeTransferFunction: __expectString(output.alternativeTransferFunction),
+    Bitrate: __expectNumber(output.bitrate),
+    BufSize: __expectNumber(output.bufSize),
+    ColorMetadata: __expectString(output.colorMetadata),
     ColorSpaceSettings:
       output.colorSpaceSettings !== undefined && output.colorSpaceSettings !== null
         ? deserializeAws_restJson1H265ColorSpaceSettings(output.colorSpaceSettings, context)
@@ -13992,87 +13821,55 @@ const deserializeAws_restJson1H265Settings = (output: any, context: __SerdeConte
       output.filterSettings !== undefined && output.filterSettings !== null
         ? deserializeAws_restJson1H265FilterSettings(output.filterSettings, context)
         : undefined,
-    FixedAfd: output.fixedAfd !== undefined && output.fixedAfd !== null ? output.fixedAfd : undefined,
-    FlickerAq: output.flickerAq !== undefined && output.flickerAq !== null ? output.flickerAq : undefined,
-    FramerateDenominator:
-      output.framerateDenominator !== undefined && output.framerateDenominator !== null
-        ? output.framerateDenominator
-        : undefined,
-    FramerateNumerator:
-      output.framerateNumerator !== undefined && output.framerateNumerator !== null
-        ? output.framerateNumerator
-        : undefined,
-    GopClosedCadence:
-      output.gopClosedCadence !== undefined && output.gopClosedCadence !== null ? output.gopClosedCadence : undefined,
-    GopSize: output.gopSize !== undefined && output.gopSize !== null ? output.gopSize : undefined,
-    GopSizeUnits: output.gopSizeUnits !== undefined && output.gopSizeUnits !== null ? output.gopSizeUnits : undefined,
-    Level: output.level !== undefined && output.level !== null ? output.level : undefined,
-    LookAheadRateControl:
-      output.lookAheadRateControl !== undefined && output.lookAheadRateControl !== null
-        ? output.lookAheadRateControl
-        : undefined,
-    MaxBitrate: output.maxBitrate !== undefined && output.maxBitrate !== null ? output.maxBitrate : undefined,
-    MinIInterval: output.minIInterval !== undefined && output.minIInterval !== null ? output.minIInterval : undefined,
-    ParDenominator:
-      output.parDenominator !== undefined && output.parDenominator !== null ? output.parDenominator : undefined,
-    ParNumerator: output.parNumerator !== undefined && output.parNumerator !== null ? output.parNumerator : undefined,
-    Profile: output.profile !== undefined && output.profile !== null ? output.profile : undefined,
-    QvbrQualityLevel:
-      output.qvbrQualityLevel !== undefined && output.qvbrQualityLevel !== null ? output.qvbrQualityLevel : undefined,
-    RateControlMode:
-      output.rateControlMode !== undefined && output.rateControlMode !== null ? output.rateControlMode : undefined,
-    ScanType: output.scanType !== undefined && output.scanType !== null ? output.scanType : undefined,
-    SceneChangeDetect:
-      output.sceneChangeDetect !== undefined && output.sceneChangeDetect !== null
-        ? output.sceneChangeDetect
-        : undefined,
-    Slices: output.slices !== undefined && output.slices !== null ? output.slices : undefined,
-    Tier: output.tier !== undefined && output.tier !== null ? output.tier : undefined,
-    TimecodeInsertion:
-      output.timecodeInsertion !== undefined && output.timecodeInsertion !== null
-        ? output.timecodeInsertion
-        : undefined,
+    FixedAfd: __expectString(output.fixedAfd),
+    FlickerAq: __expectString(output.flickerAq),
+    FramerateDenominator: __expectNumber(output.framerateDenominator),
+    FramerateNumerator: __expectNumber(output.framerateNumerator),
+    GopClosedCadence: __expectNumber(output.gopClosedCadence),
+    GopSize: __expectNumber(output.gopSize),
+    GopSizeUnits: __expectString(output.gopSizeUnits),
+    Level: __expectString(output.level),
+    LookAheadRateControl: __expectString(output.lookAheadRateControl),
+    MaxBitrate: __expectNumber(output.maxBitrate),
+    MinIInterval: __expectNumber(output.minIInterval),
+    ParDenominator: __expectNumber(output.parDenominator),
+    ParNumerator: __expectNumber(output.parNumerator),
+    Profile: __expectString(output.profile),
+    QvbrQualityLevel: __expectNumber(output.qvbrQualityLevel),
+    RateControlMode: __expectString(output.rateControlMode),
+    ScanType: __expectString(output.scanType),
+    SceneChangeDetect: __expectString(output.sceneChangeDetect),
+    Slices: __expectNumber(output.slices),
+    Tier: __expectString(output.tier),
+    TimecodeInsertion: __expectString(output.timecodeInsertion),
   } as any;
 };
 
 const deserializeAws_restJson1Hdr10Settings = (output: any, context: __SerdeContext): Hdr10Settings => {
   return {
-    MaxCll: output.maxCll !== undefined && output.maxCll !== null ? output.maxCll : undefined,
-    MaxFall: output.maxFall !== undefined && output.maxFall !== null ? output.maxFall : undefined,
+    MaxCll: __expectNumber(output.maxCll),
+    MaxFall: __expectNumber(output.maxFall),
   } as any;
 };
 
 const deserializeAws_restJson1HlsAkamaiSettings = (output: any, context: __SerdeContext): HlsAkamaiSettings => {
   return {
-    ConnectionRetryInterval:
-      output.connectionRetryInterval !== undefined && output.connectionRetryInterval !== null
-        ? output.connectionRetryInterval
-        : undefined,
-    FilecacheDuration:
-      output.filecacheDuration !== undefined && output.filecacheDuration !== null
-        ? output.filecacheDuration
-        : undefined,
-    HttpTransferMode:
-      output.httpTransferMode !== undefined && output.httpTransferMode !== null ? output.httpTransferMode : undefined,
-    NumRetries: output.numRetries !== undefined && output.numRetries !== null ? output.numRetries : undefined,
-    RestartDelay: output.restartDelay !== undefined && output.restartDelay !== null ? output.restartDelay : undefined,
-    Salt: output.salt !== undefined && output.salt !== null ? output.salt : undefined,
-    Token: output.token !== undefined && output.token !== null ? output.token : undefined,
+    ConnectionRetryInterval: __expectNumber(output.connectionRetryInterval),
+    FilecacheDuration: __expectNumber(output.filecacheDuration),
+    HttpTransferMode: __expectString(output.httpTransferMode),
+    NumRetries: __expectNumber(output.numRetries),
+    RestartDelay: __expectNumber(output.restartDelay),
+    Salt: __expectString(output.salt),
+    Token: __expectString(output.token),
   } as any;
 };
 
 const deserializeAws_restJson1HlsBasicPutSettings = (output: any, context: __SerdeContext): HlsBasicPutSettings => {
   return {
-    ConnectionRetryInterval:
-      output.connectionRetryInterval !== undefined && output.connectionRetryInterval !== null
-        ? output.connectionRetryInterval
-        : undefined,
-    FilecacheDuration:
-      output.filecacheDuration !== undefined && output.filecacheDuration !== null
-        ? output.filecacheDuration
-        : undefined,
-    NumRetries: output.numRetries !== undefined && output.numRetries !== null ? output.numRetries : undefined,
-    RestartDelay: output.restartDelay !== undefined && output.restartDelay !== null ? output.restartDelay : undefined,
+    ConnectionRetryInterval: __expectNumber(output.connectionRetryInterval),
+    FilecacheDuration: __expectNumber(output.filecacheDuration),
+    NumRetries: __expectNumber(output.numRetries),
+    RestartDelay: __expectNumber(output.restartDelay),
   } as any;
 };
 
@@ -14107,122 +13904,59 @@ const deserializeAws_restJson1HlsGroupSettings = (output: any, context: __SerdeC
       output.adMarkers !== undefined && output.adMarkers !== null
         ? deserializeAws_restJson1__listOfHlsAdMarkers(output.adMarkers, context)
         : undefined,
-    BaseUrlContent:
-      output.baseUrlContent !== undefined && output.baseUrlContent !== null ? output.baseUrlContent : undefined,
-    BaseUrlContent1:
-      output.baseUrlContent1 !== undefined && output.baseUrlContent1 !== null ? output.baseUrlContent1 : undefined,
-    BaseUrlManifest:
-      output.baseUrlManifest !== undefined && output.baseUrlManifest !== null ? output.baseUrlManifest : undefined,
-    BaseUrlManifest1:
-      output.baseUrlManifest1 !== undefined && output.baseUrlManifest1 !== null ? output.baseUrlManifest1 : undefined,
+    BaseUrlContent: __expectString(output.baseUrlContent),
+    BaseUrlContent1: __expectString(output.baseUrlContent1),
+    BaseUrlManifest: __expectString(output.baseUrlManifest),
+    BaseUrlManifest1: __expectString(output.baseUrlManifest1),
     CaptionLanguageMappings:
       output.captionLanguageMappings !== undefined && output.captionLanguageMappings !== null
         ? deserializeAws_restJson1__listOfCaptionLanguageMapping(output.captionLanguageMappings, context)
         : undefined,
-    CaptionLanguageSetting:
-      output.captionLanguageSetting !== undefined && output.captionLanguageSetting !== null
-        ? output.captionLanguageSetting
-        : undefined,
-    ClientCache: output.clientCache !== undefined && output.clientCache !== null ? output.clientCache : undefined,
-    CodecSpecification:
-      output.codecSpecification !== undefined && output.codecSpecification !== null
-        ? output.codecSpecification
-        : undefined,
-    ConstantIv: output.constantIv !== undefined && output.constantIv !== null ? output.constantIv : undefined,
+    CaptionLanguageSetting: __expectString(output.captionLanguageSetting),
+    ClientCache: __expectString(output.clientCache),
+    CodecSpecification: __expectString(output.codecSpecification),
+    ConstantIv: __expectString(output.constantIv),
     Destination:
       output.destination !== undefined && output.destination !== null
         ? deserializeAws_restJson1OutputLocationRef(output.destination, context)
         : undefined,
-    DirectoryStructure:
-      output.directoryStructure !== undefined && output.directoryStructure !== null
-        ? output.directoryStructure
-        : undefined,
-    DiscontinuityTags:
-      output.discontinuityTags !== undefined && output.discontinuityTags !== null
-        ? output.discontinuityTags
-        : undefined,
-    EncryptionType:
-      output.encryptionType !== undefined && output.encryptionType !== null ? output.encryptionType : undefined,
+    DirectoryStructure: __expectString(output.directoryStructure),
+    DiscontinuityTags: __expectString(output.discontinuityTags),
+    EncryptionType: __expectString(output.encryptionType),
     HlsCdnSettings:
       output.hlsCdnSettings !== undefined && output.hlsCdnSettings !== null
         ? deserializeAws_restJson1HlsCdnSettings(output.hlsCdnSettings, context)
         : undefined,
-    HlsId3SegmentTagging:
-      output.hlsId3SegmentTagging !== undefined && output.hlsId3SegmentTagging !== null
-        ? output.hlsId3SegmentTagging
-        : undefined,
-    IFrameOnlyPlaylists:
-      output.iFrameOnlyPlaylists !== undefined && output.iFrameOnlyPlaylists !== null
-        ? output.iFrameOnlyPlaylists
-        : undefined,
-    IncompleteSegmentBehavior:
-      output.incompleteSegmentBehavior !== undefined && output.incompleteSegmentBehavior !== null
-        ? output.incompleteSegmentBehavior
-        : undefined,
-    IndexNSegments:
-      output.indexNSegments !== undefined && output.indexNSegments !== null ? output.indexNSegments : undefined,
-    InputLossAction:
-      output.inputLossAction !== undefined && output.inputLossAction !== null ? output.inputLossAction : undefined,
-    IvInManifest: output.ivInManifest !== undefined && output.ivInManifest !== null ? output.ivInManifest : undefined,
-    IvSource: output.ivSource !== undefined && output.ivSource !== null ? output.ivSource : undefined,
-    KeepSegments: output.keepSegments !== undefined && output.keepSegments !== null ? output.keepSegments : undefined,
-    KeyFormat: output.keyFormat !== undefined && output.keyFormat !== null ? output.keyFormat : undefined,
-    KeyFormatVersions:
-      output.keyFormatVersions !== undefined && output.keyFormatVersions !== null
-        ? output.keyFormatVersions
-        : undefined,
+    HlsId3SegmentTagging: __expectString(output.hlsId3SegmentTagging),
+    IFrameOnlyPlaylists: __expectString(output.iFrameOnlyPlaylists),
+    IncompleteSegmentBehavior: __expectString(output.incompleteSegmentBehavior),
+    IndexNSegments: __expectNumber(output.indexNSegments),
+    InputLossAction: __expectString(output.inputLossAction),
+    IvInManifest: __expectString(output.ivInManifest),
+    IvSource: __expectString(output.ivSource),
+    KeepSegments: __expectNumber(output.keepSegments),
+    KeyFormat: __expectString(output.keyFormat),
+    KeyFormatVersions: __expectString(output.keyFormatVersions),
     KeyProviderSettings:
       output.keyProviderSettings !== undefined && output.keyProviderSettings !== null
         ? deserializeAws_restJson1KeyProviderSettings(output.keyProviderSettings, context)
         : undefined,
-    ManifestCompression:
-      output.manifestCompression !== undefined && output.manifestCompression !== null
-        ? output.manifestCompression
-        : undefined,
-    ManifestDurationFormat:
-      output.manifestDurationFormat !== undefined && output.manifestDurationFormat !== null
-        ? output.manifestDurationFormat
-        : undefined,
-    MinSegmentLength:
-      output.minSegmentLength !== undefined && output.minSegmentLength !== null ? output.minSegmentLength : undefined,
-    Mode: output.mode !== undefined && output.mode !== null ? output.mode : undefined,
-    OutputSelection:
-      output.outputSelection !== undefined && output.outputSelection !== null ? output.outputSelection : undefined,
-    ProgramDateTime:
-      output.programDateTime !== undefined && output.programDateTime !== null ? output.programDateTime : undefined,
-    ProgramDateTimePeriod:
-      output.programDateTimePeriod !== undefined && output.programDateTimePeriod !== null
-        ? output.programDateTimePeriod
-        : undefined,
-    RedundantManifest:
-      output.redundantManifest !== undefined && output.redundantManifest !== null
-        ? output.redundantManifest
-        : undefined,
-    SegmentLength:
-      output.segmentLength !== undefined && output.segmentLength !== null ? output.segmentLength : undefined,
-    SegmentationMode:
-      output.segmentationMode !== undefined && output.segmentationMode !== null ? output.segmentationMode : undefined,
-    SegmentsPerSubdirectory:
-      output.segmentsPerSubdirectory !== undefined && output.segmentsPerSubdirectory !== null
-        ? output.segmentsPerSubdirectory
-        : undefined,
-    StreamInfResolution:
-      output.streamInfResolution !== undefined && output.streamInfResolution !== null
-        ? output.streamInfResolution
-        : undefined,
-    TimedMetadataId3Frame:
-      output.timedMetadataId3Frame !== undefined && output.timedMetadataId3Frame !== null
-        ? output.timedMetadataId3Frame
-        : undefined,
-    TimedMetadataId3Period:
-      output.timedMetadataId3Period !== undefined && output.timedMetadataId3Period !== null
-        ? output.timedMetadataId3Period
-        : undefined,
-    TimestampDeltaMilliseconds:
-      output.timestampDeltaMilliseconds !== undefined && output.timestampDeltaMilliseconds !== null
-        ? output.timestampDeltaMilliseconds
-        : undefined,
-    TsFileMode: output.tsFileMode !== undefined && output.tsFileMode !== null ? output.tsFileMode : undefined,
+    ManifestCompression: __expectString(output.manifestCompression),
+    ManifestDurationFormat: __expectString(output.manifestDurationFormat),
+    MinSegmentLength: __expectNumber(output.minSegmentLength),
+    Mode: __expectString(output.mode),
+    OutputSelection: __expectString(output.outputSelection),
+    ProgramDateTime: __expectString(output.programDateTime),
+    ProgramDateTimePeriod: __expectNumber(output.programDateTimePeriod),
+    RedundantManifest: __expectString(output.redundantManifest),
+    SegmentLength: __expectNumber(output.segmentLength),
+    SegmentationMode: __expectString(output.segmentationMode),
+    SegmentsPerSubdirectory: __expectNumber(output.segmentsPerSubdirectory),
+    StreamInfResolution: __expectString(output.streamInfResolution),
+    TimedMetadataId3Frame: __expectString(output.timedMetadataId3Frame),
+    TimedMetadataId3Period: __expectNumber(output.timedMetadataId3Period),
+    TimestampDeltaMilliseconds: __expectNumber(output.timestampDeltaMilliseconds),
+    TsFileMode: __expectString(output.tsFileMode),
   } as any;
 };
 
@@ -14231,60 +13965,45 @@ const deserializeAws_restJson1HlsId3SegmentTaggingScheduleActionSettings = (
   context: __SerdeContext
 ): HlsId3SegmentTaggingScheduleActionSettings => {
   return {
-    Tag: output.tag !== undefined && output.tag !== null ? output.tag : undefined,
+    Tag: __expectString(output.tag),
   } as any;
 };
 
 const deserializeAws_restJson1HlsInputSettings = (output: any, context: __SerdeContext): HlsInputSettings => {
   return {
-    Bandwidth: output.bandwidth !== undefined && output.bandwidth !== null ? output.bandwidth : undefined,
-    BufferSegments:
-      output.bufferSegments !== undefined && output.bufferSegments !== null ? output.bufferSegments : undefined,
-    Retries: output.retries !== undefined && output.retries !== null ? output.retries : undefined,
-    RetryInterval:
-      output.retryInterval !== undefined && output.retryInterval !== null ? output.retryInterval : undefined,
-    Scte35Source: output.scte35Source !== undefined && output.scte35Source !== null ? output.scte35Source : undefined,
+    Bandwidth: __expectNumber(output.bandwidth),
+    BufferSegments: __expectNumber(output.bufferSegments),
+    Retries: __expectNumber(output.retries),
+    RetryInterval: __expectNumber(output.retryInterval),
+    Scte35Source: __expectString(output.scte35Source),
   } as any;
 };
 
 const deserializeAws_restJson1HlsMediaStoreSettings = (output: any, context: __SerdeContext): HlsMediaStoreSettings => {
   return {
-    ConnectionRetryInterval:
-      output.connectionRetryInterval !== undefined && output.connectionRetryInterval !== null
-        ? output.connectionRetryInterval
-        : undefined,
-    FilecacheDuration:
-      output.filecacheDuration !== undefined && output.filecacheDuration !== null
-        ? output.filecacheDuration
-        : undefined,
-    MediaStoreStorageClass:
-      output.mediaStoreStorageClass !== undefined && output.mediaStoreStorageClass !== null
-        ? output.mediaStoreStorageClass
-        : undefined,
-    NumRetries: output.numRetries !== undefined && output.numRetries !== null ? output.numRetries : undefined,
-    RestartDelay: output.restartDelay !== undefined && output.restartDelay !== null ? output.restartDelay : undefined,
+    ConnectionRetryInterval: __expectNumber(output.connectionRetryInterval),
+    FilecacheDuration: __expectNumber(output.filecacheDuration),
+    MediaStoreStorageClass: __expectString(output.mediaStoreStorageClass),
+    NumRetries: __expectNumber(output.numRetries),
+    RestartDelay: __expectNumber(output.restartDelay),
   } as any;
 };
 
 const deserializeAws_restJson1HlsOutputSettings = (output: any, context: __SerdeContext): HlsOutputSettings => {
   return {
-    H265PackagingType:
-      output.h265PackagingType !== undefined && output.h265PackagingType !== null
-        ? output.h265PackagingType
-        : undefined,
+    H265PackagingType: __expectString(output.h265PackagingType),
     HlsSettings:
       output.hlsSettings !== undefined && output.hlsSettings !== null
         ? deserializeAws_restJson1HlsSettings(output.hlsSettings, context)
         : undefined,
-    NameModifier: output.nameModifier !== undefined && output.nameModifier !== null ? output.nameModifier : undefined,
-    SegmentModifier:
-      output.segmentModifier !== undefined && output.segmentModifier !== null ? output.segmentModifier : undefined,
+    NameModifier: __expectString(output.nameModifier),
+    SegmentModifier: __expectString(output.segmentModifier),
   } as any;
 };
 
 const deserializeAws_restJson1HlsS3Settings = (output: any, context: __SerdeContext): HlsS3Settings => {
   return {
-    CannedAcl: output.cannedAcl !== undefined && output.cannedAcl !== null ? output.cannedAcl : undefined,
+    CannedAcl: __expectString(output.cannedAcl),
   } as any;
 };
 
@@ -14314,24 +14033,17 @@ const deserializeAws_restJson1HlsTimedMetadataScheduleActionSettings = (
   context: __SerdeContext
 ): HlsTimedMetadataScheduleActionSettings => {
   return {
-    Id3: output.id3 !== undefined && output.id3 !== null ? output.id3 : undefined,
+    Id3: __expectString(output.id3),
   } as any;
 };
 
 const deserializeAws_restJson1HlsWebdavSettings = (output: any, context: __SerdeContext): HlsWebdavSettings => {
   return {
-    ConnectionRetryInterval:
-      output.connectionRetryInterval !== undefined && output.connectionRetryInterval !== null
-        ? output.connectionRetryInterval
-        : undefined,
-    FilecacheDuration:
-      output.filecacheDuration !== undefined && output.filecacheDuration !== null
-        ? output.filecacheDuration
-        : undefined,
-    HttpTransferMode:
-      output.httpTransferMode !== undefined && output.httpTransferMode !== null ? output.httpTransferMode : undefined,
-    NumRetries: output.numRetries !== undefined && output.numRetries !== null ? output.numRetries : undefined,
-    RestartDelay: output.restartDelay !== undefined && output.restartDelay !== null ? output.restartDelay : undefined,
+    ConnectionRetryInterval: __expectNumber(output.connectionRetryInterval),
+    FilecacheDuration: __expectNumber(output.filecacheDuration),
+    HttpTransferMode: __expectString(output.httpTransferMode),
+    NumRetries: __expectNumber(output.numRetries),
+    RestartDelay: __expectNumber(output.restartDelay),
   } as any;
 };
 
@@ -14351,7 +14063,7 @@ const deserializeAws_restJson1ImmediateModeScheduleActionStartSettings = (
 
 const deserializeAws_restJson1Input = (output: any, context: __SerdeContext): Input => {
   return {
-    Arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    Arn: __expectString(output.arn),
     AttachedChannels:
       output.attachedChannels !== undefined && output.attachedChannels !== null
         ? deserializeAws_restJson1__listOf__string(output.attachedChannels, context)
@@ -14360,8 +14072,8 @@ const deserializeAws_restJson1Input = (output: any, context: __SerdeContext): In
       output.destinations !== undefined && output.destinations !== null
         ? deserializeAws_restJson1__listOfInputDestination(output.destinations, context)
         : undefined,
-    Id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    InputClass: output.inputClass !== undefined && output.inputClass !== null ? output.inputClass : undefined,
+    Id: __expectString(output.id),
+    InputClass: __expectString(output.inputClass),
     InputDevices:
       output.inputDevices !== undefined && output.inputDevices !== null
         ? deserializeAws_restJson1__listOfInputDeviceSettings(output.inputDevices, context)
@@ -14370,14 +14082,13 @@ const deserializeAws_restJson1Input = (output: any, context: __SerdeContext): In
       output.inputPartnerIds !== undefined && output.inputPartnerIds !== null
         ? deserializeAws_restJson1__listOf__string(output.inputPartnerIds, context)
         : undefined,
-    InputSourceType:
-      output.inputSourceType !== undefined && output.inputSourceType !== null ? output.inputSourceType : undefined,
+    InputSourceType: __expectString(output.inputSourceType),
     MediaConnectFlows:
       output.mediaConnectFlows !== undefined && output.mediaConnectFlows !== null
         ? deserializeAws_restJson1__listOfMediaConnectFlow(output.mediaConnectFlows, context)
         : undefined,
-    Name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    RoleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
+    Name: __expectString(output.name),
+    RoleArn: __expectString(output.roleArn),
     SecurityGroups:
       output.securityGroups !== undefined && output.securityGroups !== null
         ? deserializeAws_restJson1__listOf__string(output.securityGroups, context)
@@ -14386,12 +14097,12 @@ const deserializeAws_restJson1Input = (output: any, context: __SerdeContext): In
       output.sources !== undefined && output.sources !== null
         ? deserializeAws_restJson1__listOfInputSource(output.sources, context)
         : undefined,
-    State: output.state !== undefined && output.state !== null ? output.state : undefined,
+    State: __expectString(output.state),
     Tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1Tags(output.tags, context)
         : undefined,
-    Type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    Type: __expectString(output.type),
   } as any;
 };
 
@@ -14401,11 +14112,8 @@ const deserializeAws_restJson1InputAttachment = (output: any, context: __SerdeCo
       output.automaticInputFailoverSettings !== undefined && output.automaticInputFailoverSettings !== null
         ? deserializeAws_restJson1AutomaticInputFailoverSettings(output.automaticInputFailoverSettings, context)
         : undefined,
-    InputAttachmentName:
-      output.inputAttachmentName !== undefined && output.inputAttachmentName !== null
-        ? output.inputAttachmentName
-        : undefined,
-    InputId: output.inputId !== undefined && output.inputId !== null ? output.inputId : undefined,
+    InputAttachmentName: __expectString(output.inputAttachmentName),
+    InputId: __expectString(output.inputId),
     InputSettings:
       output.inputSettings !== undefined && output.inputSettings !== null
         ? deserializeAws_restJson1InputSettings(output.inputSettings, context)
@@ -14415,17 +14123,14 @@ const deserializeAws_restJson1InputAttachment = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1InputChannelLevel = (output: any, context: __SerdeContext): InputChannelLevel => {
   return {
-    Gain: output.gain !== undefined && output.gain !== null ? output.gain : undefined,
-    InputChannel: output.inputChannel !== undefined && output.inputChannel !== null ? output.inputChannel : undefined,
+    Gain: __expectNumber(output.gain),
+    InputChannel: __expectNumber(output.inputChannel),
   } as any;
 };
 
 const deserializeAws_restJson1InputClippingSettings = (output: any, context: __SerdeContext): InputClippingSettings => {
   return {
-    InputTimecodeSource:
-      output.inputTimecodeSource !== undefined && output.inputTimecodeSource !== null
-        ? output.inputTimecodeSource
-        : undefined,
+    InputTimecodeSource: __expectString(output.inputTimecodeSource),
     StartTimecode:
       output.startTimecode !== undefined && output.startTimecode !== null
         ? deserializeAws_restJson1StartTimecode(output.startTimecode, context)
@@ -14439,9 +14144,9 @@ const deserializeAws_restJson1InputClippingSettings = (output: any, context: __S
 
 const deserializeAws_restJson1InputDestination = (output: any, context: __SerdeContext): InputDestination => {
   return {
-    Ip: output.ip !== undefined && output.ip !== null ? output.ip : undefined,
-    Port: output.port !== undefined && output.port !== null ? output.port : undefined,
-    Url: output.url !== undefined && output.url !== null ? output.url : undefined,
+    Ip: __expectString(output.ip),
+    Port: __expectString(output.port),
+    Url: __expectString(output.url),
     Vpc:
       output.vpc !== undefined && output.vpc !== null
         ? deserializeAws_restJson1InputDestinationVpc(output.vpc, context)
@@ -14451,26 +14156,21 @@ const deserializeAws_restJson1InputDestination = (output: any, context: __SerdeC
 
 const deserializeAws_restJson1InputDestinationVpc = (output: any, context: __SerdeContext): InputDestinationVpc => {
   return {
-    AvailabilityZone:
-      output.availabilityZone !== undefined && output.availabilityZone !== null ? output.availabilityZone : undefined,
-    NetworkInterfaceId:
-      output.networkInterfaceId !== undefined && output.networkInterfaceId !== null
-        ? output.networkInterfaceId
-        : undefined,
+    AvailabilityZone: __expectString(output.availabilityZone),
+    NetworkInterfaceId: __expectString(output.networkInterfaceId),
   } as any;
 };
 
 const deserializeAws_restJson1InputDeviceHdSettings = (output: any, context: __SerdeContext): InputDeviceHdSettings => {
   return {
-    ActiveInput: output.activeInput !== undefined && output.activeInput !== null ? output.activeInput : undefined,
-    ConfiguredInput:
-      output.configuredInput !== undefined && output.configuredInput !== null ? output.configuredInput : undefined,
-    DeviceState: output.deviceState !== undefined && output.deviceState !== null ? output.deviceState : undefined,
-    Framerate: output.framerate !== undefined && output.framerate !== null ? output.framerate : undefined,
-    Height: output.height !== undefined && output.height !== null ? output.height : undefined,
-    MaxBitrate: output.maxBitrate !== undefined && output.maxBitrate !== null ? output.maxBitrate : undefined,
-    ScanType: output.scanType !== undefined && output.scanType !== null ? output.scanType : undefined,
-    Width: output.width !== undefined && output.width !== null ? output.width : undefined,
+    ActiveInput: __expectString(output.activeInput),
+    ConfiguredInput: __expectString(output.configuredInput),
+    DeviceState: __expectString(output.deviceState),
+    Framerate: __expectNumber(output.framerate),
+    Height: __expectNumber(output.height),
+    MaxBitrate: __expectNumber(output.maxBitrate),
+    ScanType: __expectString(output.scanType),
+    Width: __expectNumber(output.width),
   } as any;
 };
 
@@ -14483,45 +14183,38 @@ const deserializeAws_restJson1InputDeviceNetworkSettings = (
       output.dnsAddresses !== undefined && output.dnsAddresses !== null
         ? deserializeAws_restJson1__listOf__string(output.dnsAddresses, context)
         : undefined,
-    Gateway: output.gateway !== undefined && output.gateway !== null ? output.gateway : undefined,
-    IpAddress: output.ipAddress !== undefined && output.ipAddress !== null ? output.ipAddress : undefined,
-    IpScheme: output.ipScheme !== undefined && output.ipScheme !== null ? output.ipScheme : undefined,
-    SubnetMask: output.subnetMask !== undefined && output.subnetMask !== null ? output.subnetMask : undefined,
+    Gateway: __expectString(output.gateway),
+    IpAddress: __expectString(output.ipAddress),
+    IpScheme: __expectString(output.ipScheme),
+    SubnetMask: __expectString(output.subnetMask),
   } as any;
 };
 
 const deserializeAws_restJson1InputDeviceSettings = (output: any, context: __SerdeContext): InputDeviceSettings => {
   return {
-    Id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    Id: __expectString(output.id),
   } as any;
 };
 
 const deserializeAws_restJson1InputDeviceSummary = (output: any, context: __SerdeContext): InputDeviceSummary => {
   return {
-    Arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    ConnectionState:
-      output.connectionState !== undefined && output.connectionState !== null ? output.connectionState : undefined,
-    DeviceSettingsSyncState:
-      output.deviceSettingsSyncState !== undefined && output.deviceSettingsSyncState !== null
-        ? output.deviceSettingsSyncState
-        : undefined,
-    DeviceUpdateStatus:
-      output.deviceUpdateStatus !== undefined && output.deviceUpdateStatus !== null
-        ? output.deviceUpdateStatus
-        : undefined,
+    Arn: __expectString(output.arn),
+    ConnectionState: __expectString(output.connectionState),
+    DeviceSettingsSyncState: __expectString(output.deviceSettingsSyncState),
+    DeviceUpdateStatus: __expectString(output.deviceUpdateStatus),
     HdDeviceSettings:
       output.hdDeviceSettings !== undefined && output.hdDeviceSettings !== null
         ? deserializeAws_restJson1InputDeviceHdSettings(output.hdDeviceSettings, context)
         : undefined,
-    Id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    MacAddress: output.macAddress !== undefined && output.macAddress !== null ? output.macAddress : undefined,
-    Name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    Id: __expectString(output.id),
+    MacAddress: __expectString(output.macAddress),
+    Name: __expectString(output.name),
     NetworkSettings:
       output.networkSettings !== undefined && output.networkSettings !== null
         ? deserializeAws_restJson1InputDeviceNetworkSettings(output.networkSettings, context)
         : undefined,
-    SerialNumber: output.serialNumber !== undefined && output.serialNumber !== null ? output.serialNumber : undefined,
-    Type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    SerialNumber: __expectString(output.serialNumber),
+    Type: __expectString(output.type),
     UhdDeviceSettings:
       output.uhdDeviceSettings !== undefined && output.uhdDeviceSettings !== null
         ? deserializeAws_restJson1InputDeviceUhdSettings(output.uhdDeviceSettings, context)
@@ -14534,45 +14227,35 @@ const deserializeAws_restJson1InputDeviceUhdSettings = (
   context: __SerdeContext
 ): InputDeviceUhdSettings => {
   return {
-    ActiveInput: output.activeInput !== undefined && output.activeInput !== null ? output.activeInput : undefined,
-    ConfiguredInput:
-      output.configuredInput !== undefined && output.configuredInput !== null ? output.configuredInput : undefined,
-    DeviceState: output.deviceState !== undefined && output.deviceState !== null ? output.deviceState : undefined,
-    Framerate: output.framerate !== undefined && output.framerate !== null ? output.framerate : undefined,
-    Height: output.height !== undefined && output.height !== null ? output.height : undefined,
-    MaxBitrate: output.maxBitrate !== undefined && output.maxBitrate !== null ? output.maxBitrate : undefined,
-    ScanType: output.scanType !== undefined && output.scanType !== null ? output.scanType : undefined,
-    Width: output.width !== undefined && output.width !== null ? output.width : undefined,
+    ActiveInput: __expectString(output.activeInput),
+    ConfiguredInput: __expectString(output.configuredInput),
+    DeviceState: __expectString(output.deviceState),
+    Framerate: __expectNumber(output.framerate),
+    Height: __expectNumber(output.height),
+    MaxBitrate: __expectNumber(output.maxBitrate),
+    ScanType: __expectString(output.scanType),
+    Width: __expectNumber(output.width),
   } as any;
 };
 
 const deserializeAws_restJson1InputLocation = (output: any, context: __SerdeContext): InputLocation => {
   return {
-    PasswordParam:
-      output.passwordParam !== undefined && output.passwordParam !== null ? output.passwordParam : undefined,
-    Uri: output.uri !== undefined && output.uri !== null ? output.uri : undefined,
-    Username: output.username !== undefined && output.username !== null ? output.username : undefined,
+    PasswordParam: __expectString(output.passwordParam),
+    Uri: __expectString(output.uri),
+    Username: __expectString(output.username),
   } as any;
 };
 
 const deserializeAws_restJson1InputLossBehavior = (output: any, context: __SerdeContext): InputLossBehavior => {
   return {
-    BlackFrameMsec:
-      output.blackFrameMsec !== undefined && output.blackFrameMsec !== null ? output.blackFrameMsec : undefined,
-    InputLossImageColor:
-      output.inputLossImageColor !== undefined && output.inputLossImageColor !== null
-        ? output.inputLossImageColor
-        : undefined,
+    BlackFrameMsec: __expectNumber(output.blackFrameMsec),
+    InputLossImageColor: __expectString(output.inputLossImageColor),
     InputLossImageSlate:
       output.inputLossImageSlate !== undefined && output.inputLossImageSlate !== null
         ? deserializeAws_restJson1InputLocation(output.inputLossImageSlate, context)
         : undefined,
-    InputLossImageType:
-      output.inputLossImageType !== undefined && output.inputLossImageType !== null
-        ? output.inputLossImageType
-        : undefined,
-    RepeatFrameMsec:
-      output.repeatFrameMsec !== undefined && output.repeatFrameMsec !== null ? output.repeatFrameMsec : undefined,
+    InputLossImageType: __expectString(output.inputLossImageType),
+    RepeatFrameMsec: __expectNumber(output.repeatFrameMsec),
   } as any;
 };
 
@@ -14581,10 +14264,7 @@ const deserializeAws_restJson1InputLossFailoverSettings = (
   context: __SerdeContext
 ): InputLossFailoverSettings => {
   return {
-    InputLossThresholdMsec:
-      output.inputLossThresholdMsec !== undefined && output.inputLossThresholdMsec !== null
-        ? output.inputLossThresholdMsec
-        : undefined,
+    InputLossThresholdMsec: __expectNumber(output.inputLossThresholdMsec),
   } as any;
 };
 
@@ -14593,10 +14273,7 @@ const deserializeAws_restJson1InputPrepareScheduleActionSettings = (
   context: __SerdeContext
 ): InputPrepareScheduleActionSettings => {
   return {
-    InputAttachmentNameReference:
-      output.inputAttachmentNameReference !== undefined && output.inputAttachmentNameReference !== null
-        ? output.inputAttachmentNameReference
-        : undefined,
+    InputAttachmentNameReference: __expectString(output.inputAttachmentNameReference),
     InputClippingSettings:
       output.inputClippingSettings !== undefined && output.inputClippingSettings !== null
         ? deserializeAws_restJson1InputClippingSettings(output.inputClippingSettings, context)
@@ -14610,13 +14287,13 @@ const deserializeAws_restJson1InputPrepareScheduleActionSettings = (
 
 const deserializeAws_restJson1InputSecurityGroup = (output: any, context: __SerdeContext): InputSecurityGroup => {
   return {
-    Arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    Id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    Arn: __expectString(output.arn),
+    Id: __expectString(output.id),
     Inputs:
       output.inputs !== undefined && output.inputs !== null
         ? deserializeAws_restJson1__listOf__string(output.inputs, context)
         : undefined,
-    State: output.state !== undefined && output.state !== null ? output.state : undefined,
+    State: __expectString(output.state),
     Tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1Tags(output.tags, context)
@@ -14638,25 +14315,16 @@ const deserializeAws_restJson1InputSettings = (output: any, context: __SerdeCont
       output.captionSelectors !== undefined && output.captionSelectors !== null
         ? deserializeAws_restJson1__listOfCaptionSelector(output.captionSelectors, context)
         : undefined,
-    DeblockFilter:
-      output.deblockFilter !== undefined && output.deblockFilter !== null ? output.deblockFilter : undefined,
-    DenoiseFilter:
-      output.denoiseFilter !== undefined && output.denoiseFilter !== null ? output.denoiseFilter : undefined,
-    FilterStrength:
-      output.filterStrength !== undefined && output.filterStrength !== null ? output.filterStrength : undefined,
-    InputFilter: output.inputFilter !== undefined && output.inputFilter !== null ? output.inputFilter : undefined,
+    DeblockFilter: __expectString(output.deblockFilter),
+    DenoiseFilter: __expectString(output.denoiseFilter),
+    FilterStrength: __expectNumber(output.filterStrength),
+    InputFilter: __expectString(output.inputFilter),
     NetworkInputSettings:
       output.networkInputSettings !== undefined && output.networkInputSettings !== null
         ? deserializeAws_restJson1NetworkInputSettings(output.networkInputSettings, context)
         : undefined,
-    Smpte2038DataPreference:
-      output.smpte2038DataPreference !== undefined && output.smpte2038DataPreference !== null
-        ? output.smpte2038DataPreference
-        : undefined,
-    SourceEndBehavior:
-      output.sourceEndBehavior !== undefined && output.sourceEndBehavior !== null
-        ? output.sourceEndBehavior
-        : undefined,
+    Smpte2038DataPreference: __expectString(output.smpte2038DataPreference),
+    SourceEndBehavior: __expectString(output.sourceEndBehavior),
     VideoSelector:
       output.videoSelector !== undefined && output.videoSelector !== null
         ? deserializeAws_restJson1VideoSelector(output.videoSelector, context)
@@ -14666,19 +14334,17 @@ const deserializeAws_restJson1InputSettings = (output: any, context: __SerdeCont
 
 const deserializeAws_restJson1InputSource = (output: any, context: __SerdeContext): InputSource => {
   return {
-    PasswordParam:
-      output.passwordParam !== undefined && output.passwordParam !== null ? output.passwordParam : undefined,
-    Url: output.url !== undefined && output.url !== null ? output.url : undefined,
-    Username: output.username !== undefined && output.username !== null ? output.username : undefined,
+    PasswordParam: __expectString(output.passwordParam),
+    Url: __expectString(output.url),
+    Username: __expectString(output.username),
   } as any;
 };
 
 const deserializeAws_restJson1InputSpecification = (output: any, context: __SerdeContext): InputSpecification => {
   return {
-    Codec: output.codec !== undefined && output.codec !== null ? output.codec : undefined,
-    MaximumBitrate:
-      output.maximumBitrate !== undefined && output.maximumBitrate !== null ? output.maximumBitrate : undefined,
-    Resolution: output.resolution !== undefined && output.resolution !== null ? output.resolution : undefined,
+    Codec: __expectString(output.codec),
+    MaximumBitrate: __expectString(output.maximumBitrate),
+    Resolution: __expectString(output.resolution),
   } as any;
 };
 
@@ -14687,10 +14353,7 @@ const deserializeAws_restJson1InputSwitchScheduleActionSettings = (
   context: __SerdeContext
 ): InputSwitchScheduleActionSettings => {
   return {
-    InputAttachmentNameReference:
-      output.inputAttachmentNameReference !== undefined && output.inputAttachmentNameReference !== null
-        ? output.inputAttachmentNameReference
-        : undefined,
+    InputAttachmentNameReference: __expectString(output.inputAttachmentNameReference),
     InputClippingSettings:
       output.inputClippingSettings !== undefined && output.inputClippingSettings !== null
         ? deserializeAws_restJson1InputClippingSettings(output.inputClippingSettings, context)
@@ -14704,7 +14367,7 @@ const deserializeAws_restJson1InputSwitchScheduleActionSettings = (
 
 const deserializeAws_restJson1InputWhitelistRule = (output: any, context: __SerdeContext): InputWhitelistRule => {
   return {
-    Cidr: output.cidr !== undefined && output.cidr !== null ? output.cidr : undefined,
+    Cidr: __expectString(output.cidr),
   } as any;
 };
 
@@ -14719,29 +14382,17 @@ const deserializeAws_restJson1KeyProviderSettings = (output: any, context: __Ser
 
 const deserializeAws_restJson1M2tsSettings = (output: any, context: __SerdeContext): M2tsSettings => {
   return {
-    AbsentInputAudioBehavior:
-      output.absentInputAudioBehavior !== undefined && output.absentInputAudioBehavior !== null
-        ? output.absentInputAudioBehavior
-        : undefined,
-    Arib: output.arib !== undefined && output.arib !== null ? output.arib : undefined,
-    AribCaptionsPid:
-      output.aribCaptionsPid !== undefined && output.aribCaptionsPid !== null ? output.aribCaptionsPid : undefined,
-    AribCaptionsPidControl:
-      output.aribCaptionsPidControl !== undefined && output.aribCaptionsPidControl !== null
-        ? output.aribCaptionsPidControl
-        : undefined,
-    AudioBufferModel:
-      output.audioBufferModel !== undefined && output.audioBufferModel !== null ? output.audioBufferModel : undefined,
-    AudioFramesPerPes:
-      output.audioFramesPerPes !== undefined && output.audioFramesPerPes !== null
-        ? output.audioFramesPerPes
-        : undefined,
-    AudioPids: output.audioPids !== undefined && output.audioPids !== null ? output.audioPids : undefined,
-    AudioStreamType:
-      output.audioStreamType !== undefined && output.audioStreamType !== null ? output.audioStreamType : undefined,
-    Bitrate: output.bitrate !== undefined && output.bitrate !== null ? output.bitrate : undefined,
-    BufferModel: output.bufferModel !== undefined && output.bufferModel !== null ? output.bufferModel : undefined,
-    CcDescriptor: output.ccDescriptor !== undefined && output.ccDescriptor !== null ? output.ccDescriptor : undefined,
+    AbsentInputAudioBehavior: __expectString(output.absentInputAudioBehavior),
+    Arib: __expectString(output.arib),
+    AribCaptionsPid: __expectString(output.aribCaptionsPid),
+    AribCaptionsPidControl: __expectString(output.aribCaptionsPidControl),
+    AudioBufferModel: __expectString(output.audioBufferModel),
+    AudioFramesPerPes: __expectNumber(output.audioFramesPerPes),
+    AudioPids: __expectString(output.audioPids),
+    AudioStreamType: __expectString(output.audioStreamType),
+    Bitrate: __expectNumber(output.bitrate),
+    BufferModel: __expectString(output.bufferModel),
+    CcDescriptor: __expectString(output.ccDescriptor),
     DvbNitSettings:
       output.dvbNitSettings !== undefined && output.dvbNitSettings !== null
         ? deserializeAws_restJson1DvbNitSettings(output.dvbNitSettings, context)
@@ -14750,110 +14401,71 @@ const deserializeAws_restJson1M2tsSettings = (output: any, context: __SerdeConte
       output.dvbSdtSettings !== undefined && output.dvbSdtSettings !== null
         ? deserializeAws_restJson1DvbSdtSettings(output.dvbSdtSettings, context)
         : undefined,
-    DvbSubPids: output.dvbSubPids !== undefined && output.dvbSubPids !== null ? output.dvbSubPids : undefined,
+    DvbSubPids: __expectString(output.dvbSubPids),
     DvbTdtSettings:
       output.dvbTdtSettings !== undefined && output.dvbTdtSettings !== null
         ? deserializeAws_restJson1DvbTdtSettings(output.dvbTdtSettings, context)
         : undefined,
-    DvbTeletextPid:
-      output.dvbTeletextPid !== undefined && output.dvbTeletextPid !== null ? output.dvbTeletextPid : undefined,
-    Ebif: output.ebif !== undefined && output.ebif !== null ? output.ebif : undefined,
-    EbpAudioInterval:
-      output.ebpAudioInterval !== undefined && output.ebpAudioInterval !== null ? output.ebpAudioInterval : undefined,
-    EbpLookaheadMs:
-      output.ebpLookaheadMs !== undefined && output.ebpLookaheadMs !== null ? output.ebpLookaheadMs : undefined,
-    EbpPlacement: output.ebpPlacement !== undefined && output.ebpPlacement !== null ? output.ebpPlacement : undefined,
-    EcmPid: output.ecmPid !== undefined && output.ecmPid !== null ? output.ecmPid : undefined,
-    EsRateInPes: output.esRateInPes !== undefined && output.esRateInPes !== null ? output.esRateInPes : undefined,
-    EtvPlatformPid:
-      output.etvPlatformPid !== undefined && output.etvPlatformPid !== null ? output.etvPlatformPid : undefined,
-    EtvSignalPid: output.etvSignalPid !== undefined && output.etvSignalPid !== null ? output.etvSignalPid : undefined,
-    FragmentTime: output.fragmentTime !== undefined && output.fragmentTime !== null ? output.fragmentTime : undefined,
-    Klv: output.klv !== undefined && output.klv !== null ? output.klv : undefined,
-    KlvDataPids: output.klvDataPids !== undefined && output.klvDataPids !== null ? output.klvDataPids : undefined,
-    NielsenId3Behavior:
-      output.nielsenId3Behavior !== undefined && output.nielsenId3Behavior !== null
-        ? output.nielsenId3Behavior
-        : undefined,
-    NullPacketBitrate:
-      output.nullPacketBitrate !== undefined && output.nullPacketBitrate !== null
-        ? output.nullPacketBitrate
-        : undefined,
-    PatInterval: output.patInterval !== undefined && output.patInterval !== null ? output.patInterval : undefined,
-    PcrControl: output.pcrControl !== undefined && output.pcrControl !== null ? output.pcrControl : undefined,
-    PcrPeriod: output.pcrPeriod !== undefined && output.pcrPeriod !== null ? output.pcrPeriod : undefined,
-    PcrPid: output.pcrPid !== undefined && output.pcrPid !== null ? output.pcrPid : undefined,
-    PmtInterval: output.pmtInterval !== undefined && output.pmtInterval !== null ? output.pmtInterval : undefined,
-    PmtPid: output.pmtPid !== undefined && output.pmtPid !== null ? output.pmtPid : undefined,
-    ProgramNum: output.programNum !== undefined && output.programNum !== null ? output.programNum : undefined,
-    RateMode: output.rateMode !== undefined && output.rateMode !== null ? output.rateMode : undefined,
-    Scte27Pids: output.scte27Pids !== undefined && output.scte27Pids !== null ? output.scte27Pids : undefined,
-    Scte35Control:
-      output.scte35Control !== undefined && output.scte35Control !== null ? output.scte35Control : undefined,
-    Scte35Pid: output.scte35Pid !== undefined && output.scte35Pid !== null ? output.scte35Pid : undefined,
-    SegmentationMarkers:
-      output.segmentationMarkers !== undefined && output.segmentationMarkers !== null
-        ? output.segmentationMarkers
-        : undefined,
-    SegmentationStyle:
-      output.segmentationStyle !== undefined && output.segmentationStyle !== null
-        ? output.segmentationStyle
-        : undefined,
-    SegmentationTime:
-      output.segmentationTime !== undefined && output.segmentationTime !== null ? output.segmentationTime : undefined,
-    TimedMetadataBehavior:
-      output.timedMetadataBehavior !== undefined && output.timedMetadataBehavior !== null
-        ? output.timedMetadataBehavior
-        : undefined,
-    TimedMetadataPid:
-      output.timedMetadataPid !== undefined && output.timedMetadataPid !== null ? output.timedMetadataPid : undefined,
-    TransportStreamId:
-      output.transportStreamId !== undefined && output.transportStreamId !== null
-        ? output.transportStreamId
-        : undefined,
-    VideoPid: output.videoPid !== undefined && output.videoPid !== null ? output.videoPid : undefined,
+    DvbTeletextPid: __expectString(output.dvbTeletextPid),
+    Ebif: __expectString(output.ebif),
+    EbpAudioInterval: __expectString(output.ebpAudioInterval),
+    EbpLookaheadMs: __expectNumber(output.ebpLookaheadMs),
+    EbpPlacement: __expectString(output.ebpPlacement),
+    EcmPid: __expectString(output.ecmPid),
+    EsRateInPes: __expectString(output.esRateInPes),
+    EtvPlatformPid: __expectString(output.etvPlatformPid),
+    EtvSignalPid: __expectString(output.etvSignalPid),
+    FragmentTime: __expectNumber(output.fragmentTime),
+    Klv: __expectString(output.klv),
+    KlvDataPids: __expectString(output.klvDataPids),
+    NielsenId3Behavior: __expectString(output.nielsenId3Behavior),
+    NullPacketBitrate: __expectNumber(output.nullPacketBitrate),
+    PatInterval: __expectNumber(output.patInterval),
+    PcrControl: __expectString(output.pcrControl),
+    PcrPeriod: __expectNumber(output.pcrPeriod),
+    PcrPid: __expectString(output.pcrPid),
+    PmtInterval: __expectNumber(output.pmtInterval),
+    PmtPid: __expectString(output.pmtPid),
+    ProgramNum: __expectNumber(output.programNum),
+    RateMode: __expectString(output.rateMode),
+    Scte27Pids: __expectString(output.scte27Pids),
+    Scte35Control: __expectString(output.scte35Control),
+    Scte35Pid: __expectString(output.scte35Pid),
+    SegmentationMarkers: __expectString(output.segmentationMarkers),
+    SegmentationStyle: __expectString(output.segmentationStyle),
+    SegmentationTime: __expectNumber(output.segmentationTime),
+    TimedMetadataBehavior: __expectString(output.timedMetadataBehavior),
+    TimedMetadataPid: __expectString(output.timedMetadataPid),
+    TransportStreamId: __expectNumber(output.transportStreamId),
+    VideoPid: __expectString(output.videoPid),
   } as any;
 };
 
 const deserializeAws_restJson1M3u8Settings = (output: any, context: __SerdeContext): M3u8Settings => {
   return {
-    AudioFramesPerPes:
-      output.audioFramesPerPes !== undefined && output.audioFramesPerPes !== null
-        ? output.audioFramesPerPes
-        : undefined,
-    AudioPids: output.audioPids !== undefined && output.audioPids !== null ? output.audioPids : undefined,
-    EcmPid: output.ecmPid !== undefined && output.ecmPid !== null ? output.ecmPid : undefined,
-    NielsenId3Behavior:
-      output.nielsenId3Behavior !== undefined && output.nielsenId3Behavior !== null
-        ? output.nielsenId3Behavior
-        : undefined,
-    PatInterval: output.patInterval !== undefined && output.patInterval !== null ? output.patInterval : undefined,
-    PcrControl: output.pcrControl !== undefined && output.pcrControl !== null ? output.pcrControl : undefined,
-    PcrPeriod: output.pcrPeriod !== undefined && output.pcrPeriod !== null ? output.pcrPeriod : undefined,
-    PcrPid: output.pcrPid !== undefined && output.pcrPid !== null ? output.pcrPid : undefined,
-    PmtInterval: output.pmtInterval !== undefined && output.pmtInterval !== null ? output.pmtInterval : undefined,
-    PmtPid: output.pmtPid !== undefined && output.pmtPid !== null ? output.pmtPid : undefined,
-    ProgramNum: output.programNum !== undefined && output.programNum !== null ? output.programNum : undefined,
-    Scte35Behavior:
-      output.scte35Behavior !== undefined && output.scte35Behavior !== null ? output.scte35Behavior : undefined,
-    Scte35Pid: output.scte35Pid !== undefined && output.scte35Pid !== null ? output.scte35Pid : undefined,
-    TimedMetadataBehavior:
-      output.timedMetadataBehavior !== undefined && output.timedMetadataBehavior !== null
-        ? output.timedMetadataBehavior
-        : undefined,
-    TimedMetadataPid:
-      output.timedMetadataPid !== undefined && output.timedMetadataPid !== null ? output.timedMetadataPid : undefined,
-    TransportStreamId:
-      output.transportStreamId !== undefined && output.transportStreamId !== null
-        ? output.transportStreamId
-        : undefined,
-    VideoPid: output.videoPid !== undefined && output.videoPid !== null ? output.videoPid : undefined,
+    AudioFramesPerPes: __expectNumber(output.audioFramesPerPes),
+    AudioPids: __expectString(output.audioPids),
+    EcmPid: __expectString(output.ecmPid),
+    NielsenId3Behavior: __expectString(output.nielsenId3Behavior),
+    PatInterval: __expectNumber(output.patInterval),
+    PcrControl: __expectString(output.pcrControl),
+    PcrPeriod: __expectNumber(output.pcrPeriod),
+    PcrPid: __expectString(output.pcrPid),
+    PmtInterval: __expectNumber(output.pmtInterval),
+    PmtPid: __expectString(output.pmtPid),
+    ProgramNum: __expectNumber(output.programNum),
+    Scte35Behavior: __expectString(output.scte35Behavior),
+    Scte35Pid: __expectString(output.scte35Pid),
+    TimedMetadataBehavior: __expectString(output.timedMetadataBehavior),
+    TimedMetadataPid: __expectString(output.timedMetadataPid),
+    TransportStreamId: __expectNumber(output.transportStreamId),
+    VideoPid: __expectString(output.videoPid),
   } as any;
 };
 
 const deserializeAws_restJson1MediaConnectFlow = (output: any, context: __SerdeContext): MediaConnectFlow => {
   return {
-    FlowArn: output.flowArn !== undefined && output.flowArn !== null ? output.flowArn : undefined,
+    FlowArn: __expectString(output.flowArn),
   } as any;
 };
 
@@ -14874,7 +14486,7 @@ const deserializeAws_restJson1MediaPackageOutputDestinationSettings = (
   context: __SerdeContext
 ): MediaPackageOutputDestinationSettings => {
   return {
-    ChannelId: output.channelId !== undefined && output.channelId !== null ? output.channelId : undefined,
+    ChannelId: __expectString(output.channelId),
   } as any;
 };
 
@@ -14890,11 +14502,10 @@ const deserializeAws_restJson1MotionGraphicsActivateScheduleActionSettings = (
   context: __SerdeContext
 ): MotionGraphicsActivateScheduleActionSettings => {
   return {
-    Duration: output.duration !== undefined && output.duration !== null ? output.duration : undefined,
-    PasswordParam:
-      output.passwordParam !== undefined && output.passwordParam !== null ? output.passwordParam : undefined,
-    Url: output.url !== undefined && output.url !== null ? output.url : undefined,
-    Username: output.username !== undefined && output.username !== null ? output.username : undefined,
+    Duration: __expectNumber(output.duration),
+    PasswordParam: __expectString(output.passwordParam),
+    Url: __expectString(output.url),
+    Username: __expectString(output.username),
   } as any;
 };
 
@@ -14903,10 +14514,7 @@ const deserializeAws_restJson1MotionGraphicsConfiguration = (
   context: __SerdeContext
 ): MotionGraphicsConfiguration => {
   return {
-    MotionGraphicsInsertion:
-      output.motionGraphicsInsertion !== undefined && output.motionGraphicsInsertion !== null
-        ? output.motionGraphicsInsertion
-        : undefined,
+    MotionGraphicsInsertion: __expectString(output.motionGraphicsInsertion),
     MotionGraphicsSettings:
       output.motionGraphicsSettings !== undefined && output.motionGraphicsSettings !== null
         ? deserializeAws_restJson1MotionGraphicsSettings(output.motionGraphicsSettings, context)
@@ -14935,9 +14543,9 @@ const deserializeAws_restJson1MotionGraphicsSettings = (
 
 const deserializeAws_restJson1Mp2Settings = (output: any, context: __SerdeContext): Mp2Settings => {
   return {
-    Bitrate: output.bitrate !== undefined && output.bitrate !== null ? output.bitrate : undefined,
-    CodingMode: output.codingMode !== undefined && output.codingMode !== null ? output.codingMode : undefined,
-    SampleRate: output.sampleRate !== undefined && output.sampleRate !== null ? output.sampleRate : undefined,
+    Bitrate: __expectNumber(output.bitrate),
+    CodingMode: __expectString(output.codingMode),
+    SampleRate: __expectNumber(output.sampleRate),
   } as any;
 };
 
@@ -14952,97 +14560,52 @@ const deserializeAws_restJson1Mpeg2FilterSettings = (output: any, context: __Ser
 
 const deserializeAws_restJson1Mpeg2Settings = (output: any, context: __SerdeContext): Mpeg2Settings => {
   return {
-    AdaptiveQuantization:
-      output.adaptiveQuantization !== undefined && output.adaptiveQuantization !== null
-        ? output.adaptiveQuantization
-        : undefined,
-    AfdSignaling: output.afdSignaling !== undefined && output.afdSignaling !== null ? output.afdSignaling : undefined,
-    ColorMetadata:
-      output.colorMetadata !== undefined && output.colorMetadata !== null ? output.colorMetadata : undefined,
-    ColorSpace: output.colorSpace !== undefined && output.colorSpace !== null ? output.colorSpace : undefined,
-    DisplayAspectRatio:
-      output.displayAspectRatio !== undefined && output.displayAspectRatio !== null
-        ? output.displayAspectRatio
-        : undefined,
+    AdaptiveQuantization: __expectString(output.adaptiveQuantization),
+    AfdSignaling: __expectString(output.afdSignaling),
+    ColorMetadata: __expectString(output.colorMetadata),
+    ColorSpace: __expectString(output.colorSpace),
+    DisplayAspectRatio: __expectString(output.displayAspectRatio),
     FilterSettings:
       output.filterSettings !== undefined && output.filterSettings !== null
         ? deserializeAws_restJson1Mpeg2FilterSettings(output.filterSettings, context)
         : undefined,
-    FixedAfd: output.fixedAfd !== undefined && output.fixedAfd !== null ? output.fixedAfd : undefined,
-    FramerateDenominator:
-      output.framerateDenominator !== undefined && output.framerateDenominator !== null
-        ? output.framerateDenominator
-        : undefined,
-    FramerateNumerator:
-      output.framerateNumerator !== undefined && output.framerateNumerator !== null
-        ? output.framerateNumerator
-        : undefined,
-    GopClosedCadence:
-      output.gopClosedCadence !== undefined && output.gopClosedCadence !== null ? output.gopClosedCadence : undefined,
-    GopNumBFrames:
-      output.gopNumBFrames !== undefined && output.gopNumBFrames !== null ? output.gopNumBFrames : undefined,
-    GopSize: output.gopSize !== undefined && output.gopSize !== null ? output.gopSize : undefined,
-    GopSizeUnits: output.gopSizeUnits !== undefined && output.gopSizeUnits !== null ? output.gopSizeUnits : undefined,
-    ScanType: output.scanType !== undefined && output.scanType !== null ? output.scanType : undefined,
-    SubgopLength: output.subgopLength !== undefined && output.subgopLength !== null ? output.subgopLength : undefined,
-    TimecodeInsertion:
-      output.timecodeInsertion !== undefined && output.timecodeInsertion !== null
-        ? output.timecodeInsertion
-        : undefined,
+    FixedAfd: __expectString(output.fixedAfd),
+    FramerateDenominator: __expectNumber(output.framerateDenominator),
+    FramerateNumerator: __expectNumber(output.framerateNumerator),
+    GopClosedCadence: __expectNumber(output.gopClosedCadence),
+    GopNumBFrames: __expectNumber(output.gopNumBFrames),
+    GopSize: __expectNumber(output.gopSize),
+    GopSizeUnits: __expectString(output.gopSizeUnits),
+    ScanType: __expectString(output.scanType),
+    SubgopLength: __expectString(output.subgopLength),
+    TimecodeInsertion: __expectString(output.timecodeInsertion),
   } as any;
 };
 
 const deserializeAws_restJson1MsSmoothGroupSettings = (output: any, context: __SerdeContext): MsSmoothGroupSettings => {
   return {
-    AcquisitionPointId:
-      output.acquisitionPointId !== undefined && output.acquisitionPointId !== null
-        ? output.acquisitionPointId
-        : undefined,
-    AudioOnlyTimecodeControl:
-      output.audioOnlyTimecodeControl !== undefined && output.audioOnlyTimecodeControl !== null
-        ? output.audioOnlyTimecodeControl
-        : undefined,
-    CertificateMode:
-      output.certificateMode !== undefined && output.certificateMode !== null ? output.certificateMode : undefined,
-    ConnectionRetryInterval:
-      output.connectionRetryInterval !== undefined && output.connectionRetryInterval !== null
-        ? output.connectionRetryInterval
-        : undefined,
+    AcquisitionPointId: __expectString(output.acquisitionPointId),
+    AudioOnlyTimecodeControl: __expectString(output.audioOnlyTimecodeControl),
+    CertificateMode: __expectString(output.certificateMode),
+    ConnectionRetryInterval: __expectNumber(output.connectionRetryInterval),
     Destination:
       output.destination !== undefined && output.destination !== null
         ? deserializeAws_restJson1OutputLocationRef(output.destination, context)
         : undefined,
-    EventId: output.eventId !== undefined && output.eventId !== null ? output.eventId : undefined,
-    EventIdMode: output.eventIdMode !== undefined && output.eventIdMode !== null ? output.eventIdMode : undefined,
-    EventStopBehavior:
-      output.eventStopBehavior !== undefined && output.eventStopBehavior !== null
-        ? output.eventStopBehavior
-        : undefined,
-    FilecacheDuration:
-      output.filecacheDuration !== undefined && output.filecacheDuration !== null
-        ? output.filecacheDuration
-        : undefined,
-    FragmentLength:
-      output.fragmentLength !== undefined && output.fragmentLength !== null ? output.fragmentLength : undefined,
-    InputLossAction:
-      output.inputLossAction !== undefined && output.inputLossAction !== null ? output.inputLossAction : undefined,
-    NumRetries: output.numRetries !== undefined && output.numRetries !== null ? output.numRetries : undefined,
-    RestartDelay: output.restartDelay !== undefined && output.restartDelay !== null ? output.restartDelay : undefined,
-    SegmentationMode:
-      output.segmentationMode !== undefined && output.segmentationMode !== null ? output.segmentationMode : undefined,
-    SendDelayMs: output.sendDelayMs !== undefined && output.sendDelayMs !== null ? output.sendDelayMs : undefined,
-    SparseTrackType:
-      output.sparseTrackType !== undefined && output.sparseTrackType !== null ? output.sparseTrackType : undefined,
-    StreamManifestBehavior:
-      output.streamManifestBehavior !== undefined && output.streamManifestBehavior !== null
-        ? output.streamManifestBehavior
-        : undefined,
-    TimestampOffset:
-      output.timestampOffset !== undefined && output.timestampOffset !== null ? output.timestampOffset : undefined,
-    TimestampOffsetMode:
-      output.timestampOffsetMode !== undefined && output.timestampOffsetMode !== null
-        ? output.timestampOffsetMode
-        : undefined,
+    EventId: __expectString(output.eventId),
+    EventIdMode: __expectString(output.eventIdMode),
+    EventStopBehavior: __expectString(output.eventStopBehavior),
+    FilecacheDuration: __expectNumber(output.filecacheDuration),
+    FragmentLength: __expectNumber(output.fragmentLength),
+    InputLossAction: __expectString(output.inputLossAction),
+    NumRetries: __expectNumber(output.numRetries),
+    RestartDelay: __expectNumber(output.restartDelay),
+    SegmentationMode: __expectString(output.segmentationMode),
+    SendDelayMs: __expectNumber(output.sendDelayMs),
+    SparseTrackType: __expectString(output.sparseTrackType),
+    StreamManifestBehavior: __expectString(output.streamManifestBehavior),
+    TimestampOffset: __expectString(output.timestampOffset),
+    TimestampOffsetMode: __expectString(output.timestampOffsetMode),
   } as any;
 };
 
@@ -15051,17 +14614,14 @@ const deserializeAws_restJson1MsSmoothOutputSettings = (
   context: __SerdeContext
 ): MsSmoothOutputSettings => {
   return {
-    H265PackagingType:
-      output.h265PackagingType !== undefined && output.h265PackagingType !== null
-        ? output.h265PackagingType
-        : undefined,
-    NameModifier: output.nameModifier !== undefined && output.nameModifier !== null ? output.nameModifier : undefined,
+    H265PackagingType: __expectString(output.h265PackagingType),
+    NameModifier: __expectString(output.nameModifier),
   } as any;
 };
 
 const deserializeAws_restJson1Multiplex = (output: any, context: __SerdeContext): Multiplex => {
   return {
-    Arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    Arn: __expectString(output.arn),
     AvailabilityZones:
       output.availabilityZones !== undefined && output.availabilityZones !== null
         ? deserializeAws_restJson1__listOf__string(output.availabilityZones, context)
@@ -15070,18 +14630,15 @@ const deserializeAws_restJson1Multiplex = (output: any, context: __SerdeContext)
       output.destinations !== undefined && output.destinations !== null
         ? deserializeAws_restJson1__listOfMultiplexOutputDestination(output.destinations, context)
         : undefined,
-    Id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    Id: __expectString(output.id),
     MultiplexSettings:
       output.multiplexSettings !== undefined && output.multiplexSettings !== null
         ? deserializeAws_restJson1MultiplexSettings(output.multiplexSettings, context)
         : undefined,
-    Name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    PipelinesRunningCount:
-      output.pipelinesRunningCount !== undefined && output.pipelinesRunningCount !== null
-        ? output.pipelinesRunningCount
-        : undefined,
-    ProgramCount: output.programCount !== undefined && output.programCount !== null ? output.programCount : undefined,
-    State: output.state !== undefined && output.state !== null ? output.state : undefined,
+    Name: __expectString(output.name),
+    PipelinesRunningCount: __expectNumber(output.pipelinesRunningCount),
+    ProgramCount: __expectNumber(output.programCount),
+    State: __expectString(output.state),
     Tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1Tags(output.tags, context)
@@ -15101,8 +14658,7 @@ const deserializeAws_restJson1MultiplexMediaConnectOutputDestinationSettings = (
   context: __SerdeContext
 ): MultiplexMediaConnectOutputDestinationSettings => {
   return {
-    EntitlementArn:
-      output.entitlementArn !== undefined && output.entitlementArn !== null ? output.entitlementArn : undefined,
+    EntitlementArn: __expectString(output.entitlementArn),
   } as any;
 };
 
@@ -15132,7 +14688,7 @@ const deserializeAws_restJson1MultiplexOutputSettings = (
 
 const deserializeAws_restJson1MultiplexProgram = (output: any, context: __SerdeContext): MultiplexProgram => {
   return {
-    ChannelId: output.channelId !== undefined && output.channelId !== null ? output.channelId : undefined,
+    ChannelId: __expectString(output.channelId),
     MultiplexProgramSettings:
       output.multiplexProgramSettings !== undefined && output.multiplexProgramSettings !== null
         ? deserializeAws_restJson1MultiplexProgramSettings(output.multiplexProgramSettings, context)
@@ -15145,7 +14701,7 @@ const deserializeAws_restJson1MultiplexProgram = (output: any, context: __SerdeC
       output.pipelineDetails !== undefined && output.pipelineDetails !== null
         ? deserializeAws_restJson1__listOfMultiplexProgramPipelineDetail(output.pipelineDetails, context)
         : undefined,
-    ProgramName: output.programName !== undefined && output.programName !== null ? output.programName : undefined,
+    ProgramName: __expectString(output.programName),
   } as any;
 };
 
@@ -15154,8 +14710,8 @@ const deserializeAws_restJson1MultiplexProgramChannelDestinationSettings = (
   context: __SerdeContext
 ): MultiplexProgramChannelDestinationSettings => {
   return {
-    MultiplexId: output.multiplexId !== undefined && output.multiplexId !== null ? output.multiplexId : undefined,
-    ProgramName: output.programName !== undefined && output.programName !== null ? output.programName : undefined,
+    MultiplexId: __expectString(output.multiplexId),
+    ProgramName: __expectString(output.programName),
   } as any;
 };
 
@@ -15172,29 +14728,23 @@ const deserializeAws_restJson1MultiplexProgramPacketIdentifiersMap = (
       output.dvbSubPids !== undefined && output.dvbSubPids !== null
         ? deserializeAws_restJson1__listOf__integer(output.dvbSubPids, context)
         : undefined,
-    DvbTeletextPid:
-      output.dvbTeletextPid !== undefined && output.dvbTeletextPid !== null ? output.dvbTeletextPid : undefined,
-    EtvPlatformPid:
-      output.etvPlatformPid !== undefined && output.etvPlatformPid !== null ? output.etvPlatformPid : undefined,
-    EtvSignalPid: output.etvSignalPid !== undefined && output.etvSignalPid !== null ? output.etvSignalPid : undefined,
+    DvbTeletextPid: __expectNumber(output.dvbTeletextPid),
+    EtvPlatformPid: __expectNumber(output.etvPlatformPid),
+    EtvSignalPid: __expectNumber(output.etvSignalPid),
     KlvDataPids:
       output.klvDataPids !== undefined && output.klvDataPids !== null
         ? deserializeAws_restJson1__listOf__integer(output.klvDataPids, context)
         : undefined,
-    PcrPid: output.pcrPid !== undefined && output.pcrPid !== null ? output.pcrPid : undefined,
-    PmtPid: output.pmtPid !== undefined && output.pmtPid !== null ? output.pmtPid : undefined,
-    PrivateMetadataPid:
-      output.privateMetadataPid !== undefined && output.privateMetadataPid !== null
-        ? output.privateMetadataPid
-        : undefined,
+    PcrPid: __expectNumber(output.pcrPid),
+    PmtPid: __expectNumber(output.pmtPid),
+    PrivateMetadataPid: __expectNumber(output.privateMetadataPid),
     Scte27Pids:
       output.scte27Pids !== undefined && output.scte27Pids !== null
         ? deserializeAws_restJson1__listOf__integer(output.scte27Pids, context)
         : undefined,
-    Scte35Pid: output.scte35Pid !== undefined && output.scte35Pid !== null ? output.scte35Pid : undefined,
-    TimedMetadataPid:
-      output.timedMetadataPid !== undefined && output.timedMetadataPid !== null ? output.timedMetadataPid : undefined,
-    VideoPid: output.videoPid !== undefined && output.videoPid !== null ? output.videoPid : undefined,
+    Scte35Pid: __expectNumber(output.scte35Pid),
+    TimedMetadataPid: __expectNumber(output.timedMetadataPid),
+    VideoPid: __expectNumber(output.videoPid),
   } as any;
 };
 
@@ -15203,11 +14753,8 @@ const deserializeAws_restJson1MultiplexProgramPipelineDetail = (
   context: __SerdeContext
 ): MultiplexProgramPipelineDetail => {
   return {
-    ActiveChannelPipeline:
-      output.activeChannelPipeline !== undefined && output.activeChannelPipeline !== null
-        ? output.activeChannelPipeline
-        : undefined,
-    PipelineId: output.pipelineId !== undefined && output.pipelineId !== null ? output.pipelineId : undefined,
+    ActiveChannelPipeline: __expectString(output.activeChannelPipeline),
+    PipelineId: __expectString(output.pipelineId),
   } as any;
 };
 
@@ -15216,8 +14763,8 @@ const deserializeAws_restJson1MultiplexProgramServiceDescriptor = (
   context: __SerdeContext
 ): MultiplexProgramServiceDescriptor => {
   return {
-    ProviderName: output.providerName !== undefined && output.providerName !== null ? output.providerName : undefined,
-    ServiceName: output.serviceName !== undefined && output.serviceName !== null ? output.serviceName : undefined,
+    ProviderName: __expectString(output.providerName),
+    ServiceName: __expectString(output.serviceName),
   } as any;
 };
 
@@ -15226,12 +14773,8 @@ const deserializeAws_restJson1MultiplexProgramSettings = (
   context: __SerdeContext
 ): MultiplexProgramSettings => {
   return {
-    PreferredChannelPipeline:
-      output.preferredChannelPipeline !== undefined && output.preferredChannelPipeline !== null
-        ? output.preferredChannelPipeline
-        : undefined,
-    ProgramNumber:
-      output.programNumber !== undefined && output.programNumber !== null ? output.programNumber : undefined,
+    PreferredChannelPipeline: __expectString(output.preferredChannelPipeline),
+    ProgramNumber: __expectNumber(output.programNumber),
     ServiceDescriptor:
       output.serviceDescriptor !== undefined && output.serviceDescriptor !== null
         ? deserializeAws_restJson1MultiplexProgramServiceDescriptor(output.serviceDescriptor, context)
@@ -15248,29 +14791,17 @@ const deserializeAws_restJson1MultiplexProgramSummary = (
   context: __SerdeContext
 ): MultiplexProgramSummary => {
   return {
-    ChannelId: output.channelId !== undefined && output.channelId !== null ? output.channelId : undefined,
-    ProgramName: output.programName !== undefined && output.programName !== null ? output.programName : undefined,
+    ChannelId: __expectString(output.channelId),
+    ProgramName: __expectString(output.programName),
   } as any;
 };
 
 const deserializeAws_restJson1MultiplexSettings = (output: any, context: __SerdeContext): MultiplexSettings => {
   return {
-    MaximumVideoBufferDelayMilliseconds:
-      output.maximumVideoBufferDelayMilliseconds !== undefined && output.maximumVideoBufferDelayMilliseconds !== null
-        ? output.maximumVideoBufferDelayMilliseconds
-        : undefined,
-    TransportStreamBitrate:
-      output.transportStreamBitrate !== undefined && output.transportStreamBitrate !== null
-        ? output.transportStreamBitrate
-        : undefined,
-    TransportStreamId:
-      output.transportStreamId !== undefined && output.transportStreamId !== null
-        ? output.transportStreamId
-        : undefined,
-    TransportStreamReservedBitrate:
-      output.transportStreamReservedBitrate !== undefined && output.transportStreamReservedBitrate !== null
-        ? output.transportStreamReservedBitrate
-        : undefined,
+    MaximumVideoBufferDelayMilliseconds: __expectNumber(output.maximumVideoBufferDelayMilliseconds),
+    TransportStreamBitrate: __expectNumber(output.transportStreamBitrate),
+    TransportStreamId: __expectNumber(output.transportStreamId),
+    TransportStreamReservedBitrate: __expectNumber(output.transportStreamReservedBitrate),
   } as any;
 };
 
@@ -15279,10 +14810,7 @@ const deserializeAws_restJson1MultiplexSettingsSummary = (
   context: __SerdeContext
 ): MultiplexSettingsSummary => {
   return {
-    TransportStreamBitrate:
-      output.transportStreamBitrate !== undefined && output.transportStreamBitrate !== null
-        ? output.transportStreamBitrate
-        : undefined,
+    TransportStreamBitrate: __expectNumber(output.transportStreamBitrate),
   } as any;
 };
 
@@ -15291,33 +14819,28 @@ const deserializeAws_restJson1MultiplexStatmuxVideoSettings = (
   context: __SerdeContext
 ): MultiplexStatmuxVideoSettings => {
   return {
-    MaximumBitrate:
-      output.maximumBitrate !== undefined && output.maximumBitrate !== null ? output.maximumBitrate : undefined,
-    MinimumBitrate:
-      output.minimumBitrate !== undefined && output.minimumBitrate !== null ? output.minimumBitrate : undefined,
-    Priority: output.priority !== undefined && output.priority !== null ? output.priority : undefined,
+    MaximumBitrate: __expectNumber(output.maximumBitrate),
+    MinimumBitrate: __expectNumber(output.minimumBitrate),
+    Priority: __expectNumber(output.priority),
   } as any;
 };
 
 const deserializeAws_restJson1MultiplexSummary = (output: any, context: __SerdeContext): MultiplexSummary => {
   return {
-    Arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    Arn: __expectString(output.arn),
     AvailabilityZones:
       output.availabilityZones !== undefined && output.availabilityZones !== null
         ? deserializeAws_restJson1__listOf__string(output.availabilityZones, context)
         : undefined,
-    Id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    Id: __expectString(output.id),
     MultiplexSettings:
       output.multiplexSettings !== undefined && output.multiplexSettings !== null
         ? deserializeAws_restJson1MultiplexSettingsSummary(output.multiplexSettings, context)
         : undefined,
-    Name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    PipelinesRunningCount:
-      output.pipelinesRunningCount !== undefined && output.pipelinesRunningCount !== null
-        ? output.pipelinesRunningCount
-        : undefined,
-    ProgramCount: output.programCount !== undefined && output.programCount !== null ? output.programCount : undefined,
-    State: output.state !== undefined && output.state !== null ? output.state : undefined,
+    Name: __expectString(output.name),
+    PipelinesRunningCount: __expectNumber(output.pipelinesRunningCount),
+    ProgramCount: __expectNumber(output.programCount),
+    State: __expectString(output.state),
     Tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1Tags(output.tags, context)
@@ -15330,8 +14853,7 @@ const deserializeAws_restJson1MultiplexVideoSettings = (
   context: __SerdeContext
 ): MultiplexVideoSettings => {
   return {
-    ConstantBitrate:
-      output.constantBitrate !== undefined && output.constantBitrate !== null ? output.constantBitrate : undefined,
+    ConstantBitrate: __expectNumber(output.constantBitrate),
     StatmuxSettings:
       output.statmuxSettings !== undefined && output.statmuxSettings !== null
         ? deserializeAws_restJson1MultiplexStatmuxVideoSettings(output.statmuxSettings, context)
@@ -15345,42 +14867,33 @@ const deserializeAws_restJson1NetworkInputSettings = (output: any, context: __Se
       output.hlsInputSettings !== undefined && output.hlsInputSettings !== null
         ? deserializeAws_restJson1HlsInputSettings(output.hlsInputSettings, context)
         : undefined,
-    ServerValidation:
-      output.serverValidation !== undefined && output.serverValidation !== null ? output.serverValidation : undefined,
+    ServerValidation: __expectString(output.serverValidation),
   } as any;
 };
 
 const deserializeAws_restJson1NielsenConfiguration = (output: any, context: __SerdeContext): NielsenConfiguration => {
   return {
-    DistributorId:
-      output.distributorId !== undefined && output.distributorId !== null ? output.distributorId : undefined,
-    NielsenPcmToId3Tagging:
-      output.nielsenPcmToId3Tagging !== undefined && output.nielsenPcmToId3Tagging !== null
-        ? output.nielsenPcmToId3Tagging
-        : undefined,
+    DistributorId: __expectString(output.distributorId),
+    NielsenPcmToId3Tagging: __expectString(output.nielsenPcmToId3Tagging),
   } as any;
 };
 
 const deserializeAws_restJson1Offering = (output: any, context: __SerdeContext): Offering => {
   return {
-    Arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    CurrencyCode: output.currencyCode !== undefined && output.currencyCode !== null ? output.currencyCode : undefined,
-    Duration: output.duration !== undefined && output.duration !== null ? output.duration : undefined,
-    DurationUnits:
-      output.durationUnits !== undefined && output.durationUnits !== null ? output.durationUnits : undefined,
-    FixedPrice: output.fixedPrice !== undefined && output.fixedPrice !== null ? output.fixedPrice : undefined,
-    OfferingDescription:
-      output.offeringDescription !== undefined && output.offeringDescription !== null
-        ? output.offeringDescription
-        : undefined,
-    OfferingId: output.offeringId !== undefined && output.offeringId !== null ? output.offeringId : undefined,
-    OfferingType: output.offeringType !== undefined && output.offeringType !== null ? output.offeringType : undefined,
-    Region: output.region !== undefined && output.region !== null ? output.region : undefined,
+    Arn: __expectString(output.arn),
+    CurrencyCode: __expectString(output.currencyCode),
+    Duration: __expectNumber(output.duration),
+    DurationUnits: __expectString(output.durationUnits),
+    FixedPrice: __expectNumber(output.fixedPrice),
+    OfferingDescription: __expectString(output.offeringDescription),
+    OfferingId: __expectString(output.offeringId),
+    OfferingType: __expectString(output.offeringType),
+    Region: __expectString(output.region),
     ResourceSpecification:
       output.resourceSpecification !== undefined && output.resourceSpecification !== null
         ? deserializeAws_restJson1ReservationResourceSpecification(output.resourceSpecification, context)
         : undefined,
-    UsagePrice: output.usagePrice !== undefined && output.usagePrice !== null ? output.usagePrice : undefined,
+    UsagePrice: __expectNumber(output.usagePrice),
   } as any;
 };
 
@@ -15394,21 +14907,18 @@ const deserializeAws_restJson1Output = (output: any, context: __SerdeContext): O
       output.captionDescriptionNames !== undefined && output.captionDescriptionNames !== null
         ? deserializeAws_restJson1__listOf__string(output.captionDescriptionNames, context)
         : undefined,
-    OutputName: output.outputName !== undefined && output.outputName !== null ? output.outputName : undefined,
+    OutputName: __expectString(output.outputName),
     OutputSettings:
       output.outputSettings !== undefined && output.outputSettings !== null
         ? deserializeAws_restJson1OutputSettings(output.outputSettings, context)
         : undefined,
-    VideoDescriptionName:
-      output.videoDescriptionName !== undefined && output.videoDescriptionName !== null
-        ? output.videoDescriptionName
-        : undefined,
+    VideoDescriptionName: __expectString(output.videoDescriptionName),
   } as any;
 };
 
 const deserializeAws_restJson1OutputDestination = (output: any, context: __SerdeContext): OutputDestination => {
   return {
-    Id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    Id: __expectString(output.id),
     MediaPackageSettings:
       output.mediaPackageSettings !== undefined && output.mediaPackageSettings !== null
         ? deserializeAws_restJson1__listOfMediaPackageOutputDestinationSettings(output.mediaPackageSettings, context)
@@ -15429,17 +14939,16 @@ const deserializeAws_restJson1OutputDestinationSettings = (
   context: __SerdeContext
 ): OutputDestinationSettings => {
   return {
-    PasswordParam:
-      output.passwordParam !== undefined && output.passwordParam !== null ? output.passwordParam : undefined,
-    StreamName: output.streamName !== undefined && output.streamName !== null ? output.streamName : undefined,
-    Url: output.url !== undefined && output.url !== null ? output.url : undefined,
-    Username: output.username !== undefined && output.username !== null ? output.username : undefined,
+    PasswordParam: __expectString(output.passwordParam),
+    StreamName: __expectString(output.streamName),
+    Url: __expectString(output.url),
+    Username: __expectString(output.username),
   } as any;
 };
 
 const deserializeAws_restJson1OutputGroup = (output: any, context: __SerdeContext): OutputGroup => {
   return {
-    Name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    Name: __expectString(output.name),
     OutputGroupSettings:
       output.outputGroupSettings !== undefined && output.outputGroupSettings !== null
         ? deserializeAws_restJson1OutputGroupSettings(output.outputGroupSettings, context)
@@ -15490,8 +14999,7 @@ const deserializeAws_restJson1OutputGroupSettings = (output: any, context: __Ser
 
 const deserializeAws_restJson1OutputLocationRef = (output: any, context: __SerdeContext): OutputLocationRef => {
   return {
-    DestinationRefId:
-      output.destinationRefId !== undefined && output.destinationRefId !== null ? output.destinationRefId : undefined,
+    DestinationRefId: __expectString(output.destinationRefId),
   } as any;
 };
 
@@ -15550,23 +15058,11 @@ const deserializeAws_restJson1PauseStateScheduleActionSettings = (
 
 const deserializeAws_restJson1PipelineDetail = (output: any, context: __SerdeContext): PipelineDetail => {
   return {
-    ActiveInputAttachmentName:
-      output.activeInputAttachmentName !== undefined && output.activeInputAttachmentName !== null
-        ? output.activeInputAttachmentName
-        : undefined,
-    ActiveInputSwitchActionName:
-      output.activeInputSwitchActionName !== undefined && output.activeInputSwitchActionName !== null
-        ? output.activeInputSwitchActionName
-        : undefined,
-    ActiveMotionGraphicsActionName:
-      output.activeMotionGraphicsActionName !== undefined && output.activeMotionGraphicsActionName !== null
-        ? output.activeMotionGraphicsActionName
-        : undefined,
-    ActiveMotionGraphicsUri:
-      output.activeMotionGraphicsUri !== undefined && output.activeMotionGraphicsUri !== null
-        ? output.activeMotionGraphicsUri
-        : undefined,
-    PipelineId: output.pipelineId !== undefined && output.pipelineId !== null ? output.pipelineId : undefined,
+    ActiveInputAttachmentName: __expectString(output.activeInputAttachmentName),
+    ActiveInputSwitchActionName: __expectString(output.activeInputSwitchActionName),
+    ActiveMotionGraphicsActionName: __expectString(output.activeMotionGraphicsActionName),
+    ActiveMotionGraphicsUri: __expectString(output.activeMotionGraphicsUri),
+    PipelineId: __expectString(output.pipelineId),
   } as any;
 };
 
@@ -15575,7 +15071,7 @@ const deserializeAws_restJson1PipelinePauseStateSettings = (
   context: __SerdeContext
 ): PipelinePauseStateSettings => {
   return {
-    PipelineId: output.pipelineId !== undefined && output.pipelineId !== null ? output.pipelineId : undefined,
+    PipelineId: __expectString(output.pipelineId),
   } as any;
 };
 
@@ -15597,42 +15093,37 @@ const deserializeAws_restJson1RemixSettings = (output: any, context: __SerdeCont
       output.channelMappings !== undefined && output.channelMappings !== null
         ? deserializeAws_restJson1__listOfAudioChannelMapping(output.channelMappings, context)
         : undefined,
-    ChannelsIn: output.channelsIn !== undefined && output.channelsIn !== null ? output.channelsIn : undefined,
-    ChannelsOut: output.channelsOut !== undefined && output.channelsOut !== null ? output.channelsOut : undefined,
+    ChannelsIn: __expectNumber(output.channelsIn),
+    ChannelsOut: __expectNumber(output.channelsOut),
   } as any;
 };
 
 const deserializeAws_restJson1Reservation = (output: any, context: __SerdeContext): Reservation => {
   return {
-    Arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    Count: output.count !== undefined && output.count !== null ? output.count : undefined,
-    CurrencyCode: output.currencyCode !== undefined && output.currencyCode !== null ? output.currencyCode : undefined,
-    Duration: output.duration !== undefined && output.duration !== null ? output.duration : undefined,
-    DurationUnits:
-      output.durationUnits !== undefined && output.durationUnits !== null ? output.durationUnits : undefined,
-    End: output.end !== undefined && output.end !== null ? output.end : undefined,
-    FixedPrice: output.fixedPrice !== undefined && output.fixedPrice !== null ? output.fixedPrice : undefined,
-    Name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    OfferingDescription:
-      output.offeringDescription !== undefined && output.offeringDescription !== null
-        ? output.offeringDescription
-        : undefined,
-    OfferingId: output.offeringId !== undefined && output.offeringId !== null ? output.offeringId : undefined,
-    OfferingType: output.offeringType !== undefined && output.offeringType !== null ? output.offeringType : undefined,
-    Region: output.region !== undefined && output.region !== null ? output.region : undefined,
-    ReservationId:
-      output.reservationId !== undefined && output.reservationId !== null ? output.reservationId : undefined,
+    Arn: __expectString(output.arn),
+    Count: __expectNumber(output.count),
+    CurrencyCode: __expectString(output.currencyCode),
+    Duration: __expectNumber(output.duration),
+    DurationUnits: __expectString(output.durationUnits),
+    End: __expectString(output.end),
+    FixedPrice: __expectNumber(output.fixedPrice),
+    Name: __expectString(output.name),
+    OfferingDescription: __expectString(output.offeringDescription),
+    OfferingId: __expectString(output.offeringId),
+    OfferingType: __expectString(output.offeringType),
+    Region: __expectString(output.region),
+    ReservationId: __expectString(output.reservationId),
     ResourceSpecification:
       output.resourceSpecification !== undefined && output.resourceSpecification !== null
         ? deserializeAws_restJson1ReservationResourceSpecification(output.resourceSpecification, context)
         : undefined,
-    Start: output.start !== undefined && output.start !== null ? output.start : undefined,
-    State: output.state !== undefined && output.state !== null ? output.state : undefined,
+    Start: __expectString(output.start),
+    State: __expectString(output.state),
     Tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1Tags(output.tags, context)
         : undefined,
-    UsagePrice: output.usagePrice !== undefined && output.usagePrice !== null ? output.usagePrice : undefined,
+    UsagePrice: __expectNumber(output.usagePrice),
   } as any;
 };
 
@@ -15641,17 +15132,14 @@ const deserializeAws_restJson1ReservationResourceSpecification = (
   context: __SerdeContext
 ): ReservationResourceSpecification => {
   return {
-    ChannelClass: output.channelClass !== undefined && output.channelClass !== null ? output.channelClass : undefined,
-    Codec: output.codec !== undefined && output.codec !== null ? output.codec : undefined,
-    MaximumBitrate:
-      output.maximumBitrate !== undefined && output.maximumBitrate !== null ? output.maximumBitrate : undefined,
-    MaximumFramerate:
-      output.maximumFramerate !== undefined && output.maximumFramerate !== null ? output.maximumFramerate : undefined,
-    Resolution: output.resolution !== undefined && output.resolution !== null ? output.resolution : undefined,
-    ResourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
-    SpecialFeature:
-      output.specialFeature !== undefined && output.specialFeature !== null ? output.specialFeature : undefined,
-    VideoQuality: output.videoQuality !== undefined && output.videoQuality !== null ? output.videoQuality : undefined,
+    ChannelClass: __expectString(output.channelClass),
+    Codec: __expectString(output.codec),
+    MaximumBitrate: __expectString(output.maximumBitrate),
+    MaximumFramerate: __expectString(output.maximumFramerate),
+    Resolution: __expectString(output.resolution),
+    ResourceType: __expectString(output.resourceType),
+    SpecialFeature: __expectString(output.specialFeature),
+    VideoQuality: __expectString(output.videoQuality),
   } as any;
 };
 
@@ -15668,41 +15156,30 @@ const deserializeAws_restJson1RtmpGroupSettings = (output: any, context: __Serde
       output.adMarkers !== undefined && output.adMarkers !== null
         ? deserializeAws_restJson1__listOfRtmpAdMarkers(output.adMarkers, context)
         : undefined,
-    AuthenticationScheme:
-      output.authenticationScheme !== undefined && output.authenticationScheme !== null
-        ? output.authenticationScheme
-        : undefined,
-    CacheFullBehavior:
-      output.cacheFullBehavior !== undefined && output.cacheFullBehavior !== null
-        ? output.cacheFullBehavior
-        : undefined,
-    CacheLength: output.cacheLength !== undefined && output.cacheLength !== null ? output.cacheLength : undefined,
-    CaptionData: output.captionData !== undefined && output.captionData !== null ? output.captionData : undefined,
-    InputLossAction:
-      output.inputLossAction !== undefined && output.inputLossAction !== null ? output.inputLossAction : undefined,
-    RestartDelay: output.restartDelay !== undefined && output.restartDelay !== null ? output.restartDelay : undefined,
+    AuthenticationScheme: __expectString(output.authenticationScheme),
+    CacheFullBehavior: __expectString(output.cacheFullBehavior),
+    CacheLength: __expectNumber(output.cacheLength),
+    CaptionData: __expectString(output.captionData),
+    InputLossAction: __expectString(output.inputLossAction),
+    RestartDelay: __expectNumber(output.restartDelay),
   } as any;
 };
 
 const deserializeAws_restJson1RtmpOutputSettings = (output: any, context: __SerdeContext): RtmpOutputSettings => {
   return {
-    CertificateMode:
-      output.certificateMode !== undefined && output.certificateMode !== null ? output.certificateMode : undefined,
-    ConnectionRetryInterval:
-      output.connectionRetryInterval !== undefined && output.connectionRetryInterval !== null
-        ? output.connectionRetryInterval
-        : undefined,
+    CertificateMode: __expectString(output.certificateMode),
+    ConnectionRetryInterval: __expectNumber(output.connectionRetryInterval),
     Destination:
       output.destination !== undefined && output.destination !== null
         ? deserializeAws_restJson1OutputLocationRef(output.destination, context)
         : undefined,
-    NumRetries: output.numRetries !== undefined && output.numRetries !== null ? output.numRetries : undefined,
+    NumRetries: __expectNumber(output.numRetries),
   } as any;
 };
 
 const deserializeAws_restJson1ScheduleAction = (output: any, context: __SerdeContext): ScheduleAction => {
   return {
-    ActionName: output.actionName !== undefined && output.actionName !== null ? output.actionName : undefined,
+    ActionName: __expectString(output.actionName),
     ScheduleActionSettings:
       output.scheduleActionSettings !== undefined && output.scheduleActionSettings !== null
         ? deserializeAws_restJson1ScheduleActionSettings(output.scheduleActionSettings, context)
@@ -15826,12 +15303,8 @@ const deserializeAws_restJson1Scte20PlusEmbeddedDestinationSettings = (
 
 const deserializeAws_restJson1Scte20SourceSettings = (output: any, context: __SerdeContext): Scte20SourceSettings => {
   return {
-    Convert608To708:
-      output.convert608To708 !== undefined && output.convert608To708 !== null ? output.convert608To708 : undefined,
-    Source608ChannelNumber:
-      output.source608ChannelNumber !== undefined && output.source608ChannelNumber !== null
-        ? output.source608ChannelNumber
-        : undefined,
+    Convert608To708: __expectString(output.convert608To708),
+    Source608ChannelNumber: __expectNumber(output.source608ChannelNumber),
   } as any;
 };
 
@@ -15844,8 +15317,8 @@ const deserializeAws_restJson1Scte27DestinationSettings = (
 
 const deserializeAws_restJson1Scte27SourceSettings = (output: any, context: __SerdeContext): Scte27SourceSettings => {
   return {
-    OcrLanguage: output.ocrLanguage !== undefined && output.ocrLanguage !== null ? output.ocrLanguage : undefined,
-    Pid: output.pid !== undefined && output.pid !== null ? output.pid : undefined,
+    OcrLanguage: __expectString(output.ocrLanguage),
+    Pid: __expectNumber(output.pid),
   } as any;
 };
 
@@ -15854,22 +15327,10 @@ const deserializeAws_restJson1Scte35DeliveryRestrictions = (
   context: __SerdeContext
 ): Scte35DeliveryRestrictions => {
   return {
-    ArchiveAllowedFlag:
-      output.archiveAllowedFlag !== undefined && output.archiveAllowedFlag !== null
-        ? output.archiveAllowedFlag
-        : undefined,
-    DeviceRestrictions:
-      output.deviceRestrictions !== undefined && output.deviceRestrictions !== null
-        ? output.deviceRestrictions
-        : undefined,
-    NoRegionalBlackoutFlag:
-      output.noRegionalBlackoutFlag !== undefined && output.noRegionalBlackoutFlag !== null
-        ? output.noRegionalBlackoutFlag
-        : undefined,
-    WebDeliveryAllowedFlag:
-      output.webDeliveryAllowedFlag !== undefined && output.webDeliveryAllowedFlag !== null
-        ? output.webDeliveryAllowedFlag
-        : undefined,
+    ArchiveAllowedFlag: __expectString(output.archiveAllowedFlag),
+    DeviceRestrictions: __expectString(output.deviceRestrictions),
+    NoRegionalBlackoutFlag: __expectString(output.noRegionalBlackoutFlag),
+    WebDeliveryAllowedFlag: __expectString(output.webDeliveryAllowedFlag),
   } as any;
 };
 
@@ -15903,8 +15364,7 @@ const deserializeAws_restJson1Scte35ReturnToNetworkScheduleActionSettings = (
   context: __SerdeContext
 ): Scte35ReturnToNetworkScheduleActionSettings => {
   return {
-    SpliceEventId:
-      output.spliceEventId !== undefined && output.spliceEventId !== null ? output.spliceEventId : undefined,
+    SpliceEventId: __expectNumber(output.spliceEventId),
   } as any;
 };
 
@@ -15917,52 +15377,24 @@ const deserializeAws_restJson1Scte35SegmentationDescriptor = (
       output.deliveryRestrictions !== undefined && output.deliveryRestrictions !== null
         ? deserializeAws_restJson1Scte35DeliveryRestrictions(output.deliveryRestrictions, context)
         : undefined,
-    SegmentNum: output.segmentNum !== undefined && output.segmentNum !== null ? output.segmentNum : undefined,
-    SegmentationCancelIndicator:
-      output.segmentationCancelIndicator !== undefined && output.segmentationCancelIndicator !== null
-        ? output.segmentationCancelIndicator
-        : undefined,
-    SegmentationDuration:
-      output.segmentationDuration !== undefined && output.segmentationDuration !== null
-        ? output.segmentationDuration
-        : undefined,
-    SegmentationEventId:
-      output.segmentationEventId !== undefined && output.segmentationEventId !== null
-        ? output.segmentationEventId
-        : undefined,
-    SegmentationTypeId:
-      output.segmentationTypeId !== undefined && output.segmentationTypeId !== null
-        ? output.segmentationTypeId
-        : undefined,
-    SegmentationUpid:
-      output.segmentationUpid !== undefined && output.segmentationUpid !== null ? output.segmentationUpid : undefined,
-    SegmentationUpidType:
-      output.segmentationUpidType !== undefined && output.segmentationUpidType !== null
-        ? output.segmentationUpidType
-        : undefined,
-    SegmentsExpected:
-      output.segmentsExpected !== undefined && output.segmentsExpected !== null ? output.segmentsExpected : undefined,
-    SubSegmentNum:
-      output.subSegmentNum !== undefined && output.subSegmentNum !== null ? output.subSegmentNum : undefined,
-    SubSegmentsExpected:
-      output.subSegmentsExpected !== undefined && output.subSegmentsExpected !== null
-        ? output.subSegmentsExpected
-        : undefined,
+    SegmentNum: __expectNumber(output.segmentNum),
+    SegmentationCancelIndicator: __expectString(output.segmentationCancelIndicator),
+    SegmentationDuration: __expectNumber(output.segmentationDuration),
+    SegmentationEventId: __expectNumber(output.segmentationEventId),
+    SegmentationTypeId: __expectNumber(output.segmentationTypeId),
+    SegmentationUpid: __expectString(output.segmentationUpid),
+    SegmentationUpidType: __expectNumber(output.segmentationUpidType),
+    SegmentsExpected: __expectNumber(output.segmentsExpected),
+    SubSegmentNum: __expectNumber(output.subSegmentNum),
+    SubSegmentsExpected: __expectNumber(output.subSegmentsExpected),
   } as any;
 };
 
 const deserializeAws_restJson1Scte35SpliceInsert = (output: any, context: __SerdeContext): Scte35SpliceInsert => {
   return {
-    AdAvailOffset:
-      output.adAvailOffset !== undefined && output.adAvailOffset !== null ? output.adAvailOffset : undefined,
-    NoRegionalBlackoutFlag:
-      output.noRegionalBlackoutFlag !== undefined && output.noRegionalBlackoutFlag !== null
-        ? output.noRegionalBlackoutFlag
-        : undefined,
-    WebDeliveryAllowedFlag:
-      output.webDeliveryAllowedFlag !== undefined && output.webDeliveryAllowedFlag !== null
-        ? output.webDeliveryAllowedFlag
-        : undefined,
+    AdAvailOffset: __expectNumber(output.adAvailOffset),
+    NoRegionalBlackoutFlag: __expectString(output.noRegionalBlackoutFlag),
+    WebDeliveryAllowedFlag: __expectString(output.webDeliveryAllowedFlag),
   } as any;
 };
 
@@ -15971,24 +15403,16 @@ const deserializeAws_restJson1Scte35SpliceInsertScheduleActionSettings = (
   context: __SerdeContext
 ): Scte35SpliceInsertScheduleActionSettings => {
   return {
-    Duration: output.duration !== undefined && output.duration !== null ? output.duration : undefined,
-    SpliceEventId:
-      output.spliceEventId !== undefined && output.spliceEventId !== null ? output.spliceEventId : undefined,
+    Duration: __expectNumber(output.duration),
+    SpliceEventId: __expectNumber(output.spliceEventId),
   } as any;
 };
 
 const deserializeAws_restJson1Scte35TimeSignalApos = (output: any, context: __SerdeContext): Scte35TimeSignalApos => {
   return {
-    AdAvailOffset:
-      output.adAvailOffset !== undefined && output.adAvailOffset !== null ? output.adAvailOffset : undefined,
-    NoRegionalBlackoutFlag:
-      output.noRegionalBlackoutFlag !== undefined && output.noRegionalBlackoutFlag !== null
-        ? output.noRegionalBlackoutFlag
-        : undefined,
-    WebDeliveryAllowedFlag:
-      output.webDeliveryAllowedFlag !== undefined && output.webDeliveryAllowedFlag !== null
-        ? output.webDeliveryAllowedFlag
-        : undefined,
+    AdAvailOffset: __expectNumber(output.adAvailOffset),
+    NoRegionalBlackoutFlag: __expectString(output.noRegionalBlackoutFlag),
+    WebDeliveryAllowedFlag: __expectString(output.webDeliveryAllowedFlag),
   } as any;
 };
 
@@ -16013,10 +15437,7 @@ const deserializeAws_restJson1SmpteTtDestinationSettings = (
 
 const deserializeAws_restJson1StandardHlsSettings = (output: any, context: __SerdeContext): StandardHlsSettings => {
   return {
-    AudioRenditionSets:
-      output.audioRenditionSets !== undefined && output.audioRenditionSets !== null
-        ? output.audioRenditionSets
-        : undefined,
+    AudioRenditionSets: __expectString(output.audioRenditionSets),
     M3u8Settings:
       output.m3u8Settings !== undefined && output.m3u8Settings !== null
         ? deserializeAws_restJson1M3u8Settings(output.m3u8Settings, context)
@@ -16026,7 +15447,7 @@ const deserializeAws_restJson1StandardHlsSettings = (output: any, context: __Ser
 
 const deserializeAws_restJson1StartTimecode = (output: any, context: __SerdeContext): StartTimecode => {
   return {
-    Timecode: output.timecode !== undefined && output.timecode !== null ? output.timecode : undefined,
+    Timecode: __expectString(output.timecode),
   } as any;
 };
 
@@ -16035,19 +15456,19 @@ const deserializeAws_restJson1StaticImageActivateScheduleActionSettings = (
   context: __SerdeContext
 ): StaticImageActivateScheduleActionSettings => {
   return {
-    Duration: output.duration !== undefined && output.duration !== null ? output.duration : undefined,
-    FadeIn: output.fadeIn !== undefined && output.fadeIn !== null ? output.fadeIn : undefined,
-    FadeOut: output.fadeOut !== undefined && output.fadeOut !== null ? output.fadeOut : undefined,
-    Height: output.height !== undefined && output.height !== null ? output.height : undefined,
+    Duration: __expectNumber(output.duration),
+    FadeIn: __expectNumber(output.fadeIn),
+    FadeOut: __expectNumber(output.fadeOut),
+    Height: __expectNumber(output.height),
     Image:
       output.image !== undefined && output.image !== null
         ? deserializeAws_restJson1InputLocation(output.image, context)
         : undefined,
-    ImageX: output.imageX !== undefined && output.imageX !== null ? output.imageX : undefined,
-    ImageY: output.imageY !== undefined && output.imageY !== null ? output.imageY : undefined,
-    Layer: output.layer !== undefined && output.layer !== null ? output.layer : undefined,
-    Opacity: output.opacity !== undefined && output.opacity !== null ? output.opacity : undefined,
-    Width: output.width !== undefined && output.width !== null ? output.width : undefined,
+    ImageX: __expectNumber(output.imageX),
+    ImageY: __expectNumber(output.imageY),
+    Layer: __expectNumber(output.layer),
+    Opacity: __expectNumber(output.opacity),
+    Width: __expectNumber(output.width),
   } as any;
 };
 
@@ -16056,8 +15477,8 @@ const deserializeAws_restJson1StaticImageDeactivateScheduleActionSettings = (
   context: __SerdeContext
 ): StaticImageDeactivateScheduleActionSettings => {
   return {
-    FadeOut: output.fadeOut !== undefined && output.fadeOut !== null ? output.fadeOut : undefined,
-    Layer: output.layer !== undefined && output.layer !== null ? output.layer : undefined,
+    FadeOut: __expectNumber(output.fadeOut),
+    Layer: __expectNumber(output.layer),
   } as any;
 };
 
@@ -16067,18 +15488,14 @@ const deserializeAws_restJson1StaticKeySettings = (output: any, context: __Serde
       output.keyProviderServer !== undefined && output.keyProviderServer !== null
         ? deserializeAws_restJson1InputLocation(output.keyProviderServer, context)
         : undefined,
-    StaticKeyValue:
-      output.staticKeyValue !== undefined && output.staticKeyValue !== null ? output.staticKeyValue : undefined,
+    StaticKeyValue: __expectString(output.staticKeyValue),
   } as any;
 };
 
 const deserializeAws_restJson1StopTimecode = (output: any, context: __SerdeContext): StopTimecode => {
   return {
-    LastFrameClippingBehavior:
-      output.lastFrameClippingBehavior !== undefined && output.lastFrameClippingBehavior !== null
-        ? output.lastFrameClippingBehavior
-        : undefined,
-    Timecode: output.timecode !== undefined && output.timecode !== null ? output.timecode : undefined,
+    LastFrameClippingBehavior: __expectString(output.lastFrameClippingBehavior),
+    Timecode: __expectString(output.timecode),
   } as any;
 };
 
@@ -16089,7 +15506,7 @@ const deserializeAws_restJson1Tags = (output: any, context: __SerdeContext): { [
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -16110,7 +15527,7 @@ const deserializeAws_restJson1TeletextSourceSettings = (
       output.outputRectangle !== undefined && output.outputRectangle !== null
         ? deserializeAws_restJson1CaptionRectangle(output.outputRectangle, context)
         : undefined,
-    PageNumber: output.pageNumber !== undefined && output.pageNumber !== null ? output.pageNumber : undefined,
+    PageNumber: __expectString(output.pageNumber),
   } as any;
 };
 
@@ -16119,19 +15536,15 @@ const deserializeAws_restJson1TemporalFilterSettings = (
   context: __SerdeContext
 ): TemporalFilterSettings => {
   return {
-    PostFilterSharpening:
-      output.postFilterSharpening !== undefined && output.postFilterSharpening !== null
-        ? output.postFilterSharpening
-        : undefined,
-    Strength: output.strength !== undefined && output.strength !== null ? output.strength : undefined,
+    PostFilterSharpening: __expectString(output.postFilterSharpening),
+    Strength: __expectString(output.strength),
   } as any;
 };
 
 const deserializeAws_restJson1TimecodeConfig = (output: any, context: __SerdeContext): TimecodeConfig => {
   return {
-    Source: output.source !== undefined && output.source !== null ? output.source : undefined,
-    SyncThreshold:
-      output.syncThreshold !== undefined && output.syncThreshold !== null ? output.syncThreshold : undefined,
+    Source: __expectString(output.source),
+    SyncThreshold: __expectNumber(output.syncThreshold),
   } as any;
 };
 
@@ -16140,11 +15553,10 @@ const deserializeAws_restJson1TransferringInputDeviceSummary = (
   context: __SerdeContext
 ): TransferringInputDeviceSummary => {
   return {
-    Id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    Message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    TargetCustomerId:
-      output.targetCustomerId !== undefined && output.targetCustomerId !== null ? output.targetCustomerId : undefined,
-    TransferType: output.transferType !== undefined && output.transferType !== null ? output.transferType : undefined,
+    Id: __expectString(output.id),
+    Message: __expectString(output.message),
+    TargetCustomerId: __expectString(output.targetCustomerId),
+    TransferType: __expectString(output.transferType),
   } as any;
 };
 
@@ -16153,7 +15565,7 @@ const deserializeAws_restJson1TtmlDestinationSettings = (
   context: __SerdeContext
 ): TtmlDestinationSettings => {
   return {
-    StyleControl: output.styleControl !== undefined && output.styleControl !== null ? output.styleControl : undefined,
+    StyleControl: __expectString(output.styleControl),
   } as any;
 };
 
@@ -16168,22 +15580,15 @@ const deserializeAws_restJson1UdpContainerSettings = (output: any, context: __Se
 
 const deserializeAws_restJson1UdpGroupSettings = (output: any, context: __SerdeContext): UdpGroupSettings => {
   return {
-    InputLossAction:
-      output.inputLossAction !== undefined && output.inputLossAction !== null ? output.inputLossAction : undefined,
-    TimedMetadataId3Frame:
-      output.timedMetadataId3Frame !== undefined && output.timedMetadataId3Frame !== null
-        ? output.timedMetadataId3Frame
-        : undefined,
-    TimedMetadataId3Period:
-      output.timedMetadataId3Period !== undefined && output.timedMetadataId3Period !== null
-        ? output.timedMetadataId3Period
-        : undefined,
+    InputLossAction: __expectString(output.inputLossAction),
+    TimedMetadataId3Frame: __expectString(output.timedMetadataId3Frame),
+    TimedMetadataId3Period: __expectNumber(output.timedMetadataId3Period),
   } as any;
 };
 
 const deserializeAws_restJson1UdpOutputSettings = (output: any, context: __SerdeContext): UdpOutputSettings => {
   return {
-    BufferMsec: output.bufferMsec !== undefined && output.bufferMsec !== null ? output.bufferMsec : undefined,
+    BufferMsec: __expectNumber(output.bufferMsec),
     ContainerSettings:
       output.containerSettings !== undefined && output.containerSettings !== null
         ? deserializeAws_restJson1UdpContainerSettings(output.containerSettings, context)
@@ -16201,8 +15606,8 @@ const deserializeAws_restJson1UdpOutputSettings = (output: any, context: __Serde
 
 const deserializeAws_restJson1ValidationError = (output: any, context: __SerdeContext): ValidationError => {
   return {
-    ElementPath: output.elementPath !== undefined && output.elementPath !== null ? output.elementPath : undefined,
-    ErrorMessage: output.errorMessage !== undefined && output.errorMessage !== null ? output.errorMessage : undefined,
+    ElementPath: __expectString(output.elementPath),
+    ErrorMessage: __expectString(output.errorMessage),
   } as any;
 };
 
@@ -16211,14 +15616,8 @@ const deserializeAws_restJson1VideoBlackFailoverSettings = (
   context: __SerdeContext
 ): VideoBlackFailoverSettings => {
   return {
-    BlackDetectThreshold:
-      output.blackDetectThreshold !== undefined && output.blackDetectThreshold !== null
-        ? output.blackDetectThreshold
-        : undefined,
-    VideoBlackThresholdMsec:
-      output.videoBlackThresholdMsec !== undefined && output.videoBlackThresholdMsec !== null
-        ? output.videoBlackThresholdMsec
-        : undefined,
+    BlackDetectThreshold: __expectNumber(output.blackDetectThreshold),
+    VideoBlackThresholdMsec: __expectNumber(output.videoBlackThresholdMsec),
   } as any;
 };
 
@@ -16249,25 +15648,23 @@ const deserializeAws_restJson1VideoDescription = (output: any, context: __SerdeC
       output.codecSettings !== undefined && output.codecSettings !== null
         ? deserializeAws_restJson1VideoCodecSettings(output.codecSettings, context)
         : undefined,
-    Height: output.height !== undefined && output.height !== null ? output.height : undefined,
-    Name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    RespondToAfd: output.respondToAfd !== undefined && output.respondToAfd !== null ? output.respondToAfd : undefined,
-    ScalingBehavior:
-      output.scalingBehavior !== undefined && output.scalingBehavior !== null ? output.scalingBehavior : undefined,
-    Sharpness: output.sharpness !== undefined && output.sharpness !== null ? output.sharpness : undefined,
-    Width: output.width !== undefined && output.width !== null ? output.width : undefined,
+    Height: __expectNumber(output.height),
+    Name: __expectString(output.name),
+    RespondToAfd: __expectString(output.respondToAfd),
+    ScalingBehavior: __expectString(output.scalingBehavior),
+    Sharpness: __expectNumber(output.sharpness),
+    Width: __expectNumber(output.width),
   } as any;
 };
 
 const deserializeAws_restJson1VideoSelector = (output: any, context: __SerdeContext): VideoSelector => {
   return {
-    ColorSpace: output.colorSpace !== undefined && output.colorSpace !== null ? output.colorSpace : undefined,
+    ColorSpace: __expectString(output.colorSpace),
     ColorSpaceSettings:
       output.colorSpaceSettings !== undefined && output.colorSpaceSettings !== null
         ? deserializeAws_restJson1VideoSelectorColorSpaceSettings(output.colorSpaceSettings, context)
         : undefined,
-    ColorSpaceUsage:
-      output.colorSpaceUsage !== undefined && output.colorSpaceUsage !== null ? output.colorSpaceUsage : undefined,
+    ColorSpaceUsage: __expectString(output.colorSpaceUsage),
     SelectorSettings:
       output.selectorSettings !== undefined && output.selectorSettings !== null
         ? deserializeAws_restJson1VideoSelectorSettings(output.selectorSettings, context)
@@ -16289,7 +15686,7 @@ const deserializeAws_restJson1VideoSelectorColorSpaceSettings = (
 
 const deserializeAws_restJson1VideoSelectorPid = (output: any, context: __SerdeContext): VideoSelectorPid => {
   return {
-    Pid: output.pid !== undefined && output.pid !== null ? output.pid : undefined,
+    Pid: __expectNumber(output.pid),
   } as any;
 };
 
@@ -16298,7 +15695,7 @@ const deserializeAws_restJson1VideoSelectorProgramId = (
   context: __SerdeContext
 ): VideoSelectorProgramId => {
   return {
-    ProgramId: output.programId !== undefined && output.programId !== null ? output.programId : undefined,
+    ProgramId: __expectNumber(output.programId),
   } as any;
 };
 
@@ -16341,9 +15738,9 @@ const deserializeAws_restJson1VpcOutputSettingsDescription = (
 
 const deserializeAws_restJson1WavSettings = (output: any, context: __SerdeContext): WavSettings => {
   return {
-    BitDepth: output.bitDepth !== undefined && output.bitDepth !== null ? output.bitDepth : undefined,
-    CodingMode: output.codingMode !== undefined && output.codingMode !== null ? output.codingMode : undefined,
-    SampleRate: output.sampleRate !== undefined && output.sampleRate !== null ? output.sampleRate : undefined,
+    BitDepth: __expectNumber(output.bitDepth),
+    CodingMode: __expectString(output.codingMode),
+    SampleRate: __expectNumber(output.sampleRate),
   } as any;
 };
 

--- a/clients/client-mediapackage-vod/protocols/Aws_restJson1.ts
+++ b/clients/client-mediapackage-vod/protocols/Aws_restJson1.ts
@@ -76,6 +76,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -609,19 +612,19 @@ export const deserializeAws_restJson1ConfigureLogsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.Arn = data.arn;
+    contents.Arn = __expectString(data.arn);
   }
   if (data.authorization !== undefined && data.authorization !== null) {
     contents.Authorization = deserializeAws_restJson1Authorization(data.authorization, context);
   }
   if (data.domainName !== undefined && data.domainName !== null) {
-    contents.DomainName = data.domainName;
+    contents.DomainName = __expectString(data.domainName);
   }
   if (data.egressAccessLogs !== undefined && data.egressAccessLogs !== null) {
     contents.EgressAccessLogs = deserializeAws_restJson1EgressAccessLogs(data.egressAccessLogs, context);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.Id = data.id;
+    contents.Id = __expectString(data.id);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
@@ -727,28 +730,28 @@ export const deserializeAws_restJson1CreateAssetCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.Arn = data.arn;
+    contents.Arn = __expectString(data.arn);
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
-    contents.CreatedAt = data.createdAt;
+    contents.CreatedAt = __expectString(data.createdAt);
   }
   if (data.egressEndpoints !== undefined && data.egressEndpoints !== null) {
     contents.EgressEndpoints = deserializeAws_restJson1__listOfEgressEndpoint(data.egressEndpoints, context);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.Id = data.id;
+    contents.Id = __expectString(data.id);
   }
   if (data.packagingGroupId !== undefined && data.packagingGroupId !== null) {
-    contents.PackagingGroupId = data.packagingGroupId;
+    contents.PackagingGroupId = __expectString(data.packagingGroupId);
   }
   if (data.resourceId !== undefined && data.resourceId !== null) {
-    contents.ResourceId = data.resourceId;
+    contents.ResourceId = __expectString(data.resourceId);
   }
   if (data.sourceArn !== undefined && data.sourceArn !== null) {
-    contents.SourceArn = data.sourceArn;
+    contents.SourceArn = __expectString(data.sourceArn);
   }
   if (data.sourceRoleArn !== undefined && data.sourceRoleArn !== null) {
-    contents.SourceRoleArn = data.sourceRoleArn;
+    contents.SourceRoleArn = __expectString(data.sourceRoleArn);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
@@ -853,7 +856,7 @@ export const deserializeAws_restJson1CreatePackagingConfigurationCommand = async
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.Arn = data.arn;
+    contents.Arn = __expectString(data.arn);
   }
   if (data.cmafPackage !== undefined && data.cmafPackage !== null) {
     contents.CmafPackage = deserializeAws_restJson1CmafPackage(data.cmafPackage, context);
@@ -865,13 +868,13 @@ export const deserializeAws_restJson1CreatePackagingConfigurationCommand = async
     contents.HlsPackage = deserializeAws_restJson1HlsPackage(data.hlsPackage, context);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.Id = data.id;
+    contents.Id = __expectString(data.id);
   }
   if (data.mssPackage !== undefined && data.mssPackage !== null) {
     contents.MssPackage = deserializeAws_restJson1MssPackage(data.mssPackage, context);
   }
   if (data.packagingGroupId !== undefined && data.packagingGroupId !== null) {
-    contents.PackagingGroupId = data.packagingGroupId;
+    contents.PackagingGroupId = __expectString(data.packagingGroupId);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
@@ -974,19 +977,19 @@ export const deserializeAws_restJson1CreatePackagingGroupCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.Arn = data.arn;
+    contents.Arn = __expectString(data.arn);
   }
   if (data.authorization !== undefined && data.authorization !== null) {
     contents.Authorization = deserializeAws_restJson1Authorization(data.authorization, context);
   }
   if (data.domainName !== undefined && data.domainName !== null) {
-    contents.DomainName = data.domainName;
+    contents.DomainName = __expectString(data.domainName);
   }
   if (data.egressAccessLogs !== undefined && data.egressAccessLogs !== null) {
     contents.EgressAccessLogs = deserializeAws_restJson1EgressAccessLogs(data.egressAccessLogs, context);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.Id = data.id;
+    contents.Id = __expectString(data.id);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
@@ -1365,28 +1368,28 @@ export const deserializeAws_restJson1DescribeAssetCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.Arn = data.arn;
+    contents.Arn = __expectString(data.arn);
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
-    contents.CreatedAt = data.createdAt;
+    contents.CreatedAt = __expectString(data.createdAt);
   }
   if (data.egressEndpoints !== undefined && data.egressEndpoints !== null) {
     contents.EgressEndpoints = deserializeAws_restJson1__listOfEgressEndpoint(data.egressEndpoints, context);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.Id = data.id;
+    contents.Id = __expectString(data.id);
   }
   if (data.packagingGroupId !== undefined && data.packagingGroupId !== null) {
-    contents.PackagingGroupId = data.packagingGroupId;
+    contents.PackagingGroupId = __expectString(data.packagingGroupId);
   }
   if (data.resourceId !== undefined && data.resourceId !== null) {
-    contents.ResourceId = data.resourceId;
+    contents.ResourceId = __expectString(data.resourceId);
   }
   if (data.sourceArn !== undefined && data.sourceArn !== null) {
-    contents.SourceArn = data.sourceArn;
+    contents.SourceArn = __expectString(data.sourceArn);
   }
   if (data.sourceRoleArn !== undefined && data.sourceRoleArn !== null) {
-    contents.SourceRoleArn = data.sourceRoleArn;
+    contents.SourceRoleArn = __expectString(data.sourceRoleArn);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
@@ -1491,7 +1494,7 @@ export const deserializeAws_restJson1DescribePackagingConfigurationCommand = asy
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.Arn = data.arn;
+    contents.Arn = __expectString(data.arn);
   }
   if (data.cmafPackage !== undefined && data.cmafPackage !== null) {
     contents.CmafPackage = deserializeAws_restJson1CmafPackage(data.cmafPackage, context);
@@ -1503,13 +1506,13 @@ export const deserializeAws_restJson1DescribePackagingConfigurationCommand = asy
     contents.HlsPackage = deserializeAws_restJson1HlsPackage(data.hlsPackage, context);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.Id = data.id;
+    contents.Id = __expectString(data.id);
   }
   if (data.mssPackage !== undefined && data.mssPackage !== null) {
     contents.MssPackage = deserializeAws_restJson1MssPackage(data.mssPackage, context);
   }
   if (data.packagingGroupId !== undefined && data.packagingGroupId !== null) {
-    contents.PackagingGroupId = data.packagingGroupId;
+    contents.PackagingGroupId = __expectString(data.packagingGroupId);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
@@ -1612,19 +1615,19 @@ export const deserializeAws_restJson1DescribePackagingGroupCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.Arn = data.arn;
+    contents.Arn = __expectString(data.arn);
   }
   if (data.authorization !== undefined && data.authorization !== null) {
     contents.Authorization = deserializeAws_restJson1Authorization(data.authorization, context);
   }
   if (data.domainName !== undefined && data.domainName !== null) {
-    contents.DomainName = data.domainName;
+    contents.DomainName = __expectString(data.domainName);
   }
   if (data.egressAccessLogs !== undefined && data.egressAccessLogs !== null) {
     contents.EgressAccessLogs = deserializeAws_restJson1EgressAccessLogs(data.egressAccessLogs, context);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.Id = data.id;
+    contents.Id = __expectString(data.id);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
@@ -1726,7 +1729,7 @@ export const deserializeAws_restJson1ListAssetsCommand = async (
     contents.Assets = deserializeAws_restJson1__listOfAssetShallow(data.assets, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1822,7 +1825,7 @@ export const deserializeAws_restJson1ListPackagingConfigurationsCommand = async 
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   if (data.packagingConfigurations !== undefined && data.packagingConfigurations !== null) {
     contents.PackagingConfigurations = deserializeAws_restJson1__listOfPackagingConfiguration(
@@ -1924,7 +1927,7 @@ export const deserializeAws_restJson1ListPackagingGroupsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   if (data.packagingGroups !== undefined && data.packagingGroups !== null) {
     contents.PackagingGroups = deserializeAws_restJson1__listOfPackagingGroup(data.packagingGroups, context);
@@ -2160,19 +2163,19 @@ export const deserializeAws_restJson1UpdatePackagingGroupCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.Arn = data.arn;
+    contents.Arn = __expectString(data.arn);
   }
   if (data.authorization !== undefined && data.authorization !== null) {
     contents.Authorization = deserializeAws_restJson1Authorization(data.authorization, context);
   }
   if (data.domainName !== undefined && data.domainName !== null) {
-    contents.DomainName = data.domainName;
+    contents.DomainName = __expectString(data.domainName);
   }
   if (data.egressAccessLogs !== undefined && data.egressAccessLogs !== null) {
     contents.EgressAccessLogs = deserializeAws_restJson1EgressAccessLogs(data.egressAccessLogs, context);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.Id = data.id;
+    contents.Id = __expectString(data.id);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
@@ -2269,7 +2272,7 @@ const deserializeAws_restJson1ForbiddenExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -2286,7 +2289,7 @@ const deserializeAws_restJson1InternalServerErrorExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -2303,7 +2306,7 @@ const deserializeAws_restJson1NotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -2320,7 +2323,7 @@ const deserializeAws_restJson1ServiceUnavailableExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -2337,7 +2340,7 @@ const deserializeAws_restJson1TooManyRequestsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -2354,7 +2357,7 @@ const deserializeAws_restJson1UnprocessableEntityExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -2638,7 +2641,7 @@ const deserializeAws_restJson1__listOf__PeriodTriggersElement = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2649,7 +2652,7 @@ const deserializeAws_restJson1__listOf__string = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2740,22 +2743,20 @@ const deserializeAws_restJson1__mapOf__string = (output: any, context: __SerdeCo
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1AssetShallow = (output: any, context: __SerdeContext): AssetShallow => {
   return {
-    Arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    CreatedAt: output.createdAt !== undefined && output.createdAt !== null ? output.createdAt : undefined,
-    Id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    PackagingGroupId:
-      output.packagingGroupId !== undefined && output.packagingGroupId !== null ? output.packagingGroupId : undefined,
-    ResourceId: output.resourceId !== undefined && output.resourceId !== null ? output.resourceId : undefined,
-    SourceArn: output.sourceArn !== undefined && output.sourceArn !== null ? output.sourceArn : undefined,
-    SourceRoleArn:
-      output.sourceRoleArn !== undefined && output.sourceRoleArn !== null ? output.sourceRoleArn : undefined,
+    Arn: __expectString(output.arn),
+    CreatedAt: __expectString(output.createdAt),
+    Id: __expectString(output.id),
+    PackagingGroupId: __expectString(output.packagingGroupId),
+    ResourceId: __expectString(output.resourceId),
+    SourceArn: __expectString(output.sourceArn),
+    SourceRoleArn: __expectString(output.sourceRoleArn),
     Tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1Tags(output.tags, context)
@@ -2765,12 +2766,8 @@ const deserializeAws_restJson1AssetShallow = (output: any, context: __SerdeConte
 
 const deserializeAws_restJson1Authorization = (output: any, context: __SerdeContext): Authorization => {
   return {
-    CdnIdentifierSecret:
-      output.cdnIdentifierSecret !== undefined && output.cdnIdentifierSecret !== null
-        ? output.cdnIdentifierSecret
-        : undefined,
-    SecretsRoleArn:
-      output.secretsRoleArn !== undefined && output.secretsRoleArn !== null ? output.secretsRoleArn : undefined,
+    CdnIdentifierSecret: __expectString(output.cdnIdentifierSecret),
+    SecretsRoleArn: __expectString(output.secretsRoleArn),
   } as any;
 };
 
@@ -2793,15 +2790,8 @@ const deserializeAws_restJson1CmafPackage = (output: any, context: __SerdeContex
       output.hlsManifests !== undefined && output.hlsManifests !== null
         ? deserializeAws_restJson1__listOfHlsManifest(output.hlsManifests, context)
         : undefined,
-    IncludeEncoderConfigurationInSegments:
-      output.includeEncoderConfigurationInSegments !== undefined &&
-      output.includeEncoderConfigurationInSegments !== null
-        ? output.includeEncoderConfigurationInSegments
-        : undefined,
-    SegmentDurationSeconds:
-      output.segmentDurationSeconds !== undefined && output.segmentDurationSeconds !== null
-        ? output.segmentDurationSeconds
-        : undefined,
+    IncludeEncoderConfigurationInSegments: __expectBoolean(output.includeEncoderConfigurationInSegments),
+    SegmentDurationSeconds: __expectNumber(output.segmentDurationSeconds),
   } as any;
 };
 
@@ -2816,14 +2806,10 @@ const deserializeAws_restJson1DashEncryption = (output: any, context: __SerdeCon
 
 const deserializeAws_restJson1DashManifest = (output: any, context: __SerdeContext): DashManifest => {
   return {
-    ManifestLayout:
-      output.manifestLayout !== undefined && output.manifestLayout !== null ? output.manifestLayout : undefined,
-    ManifestName: output.manifestName !== undefined && output.manifestName !== null ? output.manifestName : undefined,
-    MinBufferTimeSeconds:
-      output.minBufferTimeSeconds !== undefined && output.minBufferTimeSeconds !== null
-        ? output.minBufferTimeSeconds
-        : undefined,
-    Profile: output.profile !== undefined && output.profile !== null ? output.profile : undefined,
+    ManifestLayout: __expectString(output.manifestLayout),
+    ManifestName: __expectString(output.manifestName),
+    MinBufferTimeSeconds: __expectNumber(output.minBufferTimeSeconds),
+    Profile: __expectString(output.profile),
     StreamSelection:
       output.streamSelection !== undefined && output.streamSelection !== null
         ? deserializeAws_restJson1StreamSelection(output.streamSelection, context)
@@ -2841,50 +2827,33 @@ const deserializeAws_restJson1DashPackage = (output: any, context: __SerdeContex
       output.encryption !== undefined && output.encryption !== null
         ? deserializeAws_restJson1DashEncryption(output.encryption, context)
         : undefined,
-    IncludeEncoderConfigurationInSegments:
-      output.includeEncoderConfigurationInSegments !== undefined &&
-      output.includeEncoderConfigurationInSegments !== null
-        ? output.includeEncoderConfigurationInSegments
-        : undefined,
+    IncludeEncoderConfigurationInSegments: __expectBoolean(output.includeEncoderConfigurationInSegments),
     PeriodTriggers:
       output.periodTriggers !== undefined && output.periodTriggers !== null
         ? deserializeAws_restJson1__listOf__PeriodTriggersElement(output.periodTriggers, context)
         : undefined,
-    SegmentDurationSeconds:
-      output.segmentDurationSeconds !== undefined && output.segmentDurationSeconds !== null
-        ? output.segmentDurationSeconds
-        : undefined,
-    SegmentTemplateFormat:
-      output.segmentTemplateFormat !== undefined && output.segmentTemplateFormat !== null
-        ? output.segmentTemplateFormat
-        : undefined,
+    SegmentDurationSeconds: __expectNumber(output.segmentDurationSeconds),
+    SegmentTemplateFormat: __expectString(output.segmentTemplateFormat),
   } as any;
 };
 
 const deserializeAws_restJson1EgressAccessLogs = (output: any, context: __SerdeContext): EgressAccessLogs => {
   return {
-    LogGroupName: output.logGroupName !== undefined && output.logGroupName !== null ? output.logGroupName : undefined,
+    LogGroupName: __expectString(output.logGroupName),
   } as any;
 };
 
 const deserializeAws_restJson1EgressEndpoint = (output: any, context: __SerdeContext): EgressEndpoint => {
   return {
-    PackagingConfigurationId:
-      output.packagingConfigurationId !== undefined && output.packagingConfigurationId !== null
-        ? output.packagingConfigurationId
-        : undefined,
-    Url: output.url !== undefined && output.url !== null ? output.url : undefined,
+    PackagingConfigurationId: __expectString(output.packagingConfigurationId),
+    Url: __expectString(output.url),
   } as any;
 };
 
 const deserializeAws_restJson1HlsEncryption = (output: any, context: __SerdeContext): HlsEncryption => {
   return {
-    ConstantInitializationVector:
-      output.constantInitializationVector !== undefined && output.constantInitializationVector !== null
-        ? output.constantInitializationVector
-        : undefined,
-    EncryptionMethod:
-      output.encryptionMethod !== undefined && output.encryptionMethod !== null ? output.encryptionMethod : undefined,
+    ConstantInitializationVector: __expectString(output.constantInitializationVector),
+    EncryptionMethod: __expectString(output.encryptionMethod),
     SpekeKeyProvider:
       output.spekeKeyProvider !== undefined && output.spekeKeyProvider !== null
         ? deserializeAws_restJson1SpekeKeyProvider(output.spekeKeyProvider, context)
@@ -2894,18 +2863,11 @@ const deserializeAws_restJson1HlsEncryption = (output: any, context: __SerdeCont
 
 const deserializeAws_restJson1HlsManifest = (output: any, context: __SerdeContext): HlsManifest => {
   return {
-    AdMarkers: output.adMarkers !== undefined && output.adMarkers !== null ? output.adMarkers : undefined,
-    IncludeIframeOnlyStream:
-      output.includeIframeOnlyStream !== undefined && output.includeIframeOnlyStream !== null
-        ? output.includeIframeOnlyStream
-        : undefined,
-    ManifestName: output.manifestName !== undefined && output.manifestName !== null ? output.manifestName : undefined,
-    ProgramDateTimeIntervalSeconds:
-      output.programDateTimeIntervalSeconds !== undefined && output.programDateTimeIntervalSeconds !== null
-        ? output.programDateTimeIntervalSeconds
-        : undefined,
-    RepeatExtXKey:
-      output.repeatExtXKey !== undefined && output.repeatExtXKey !== null ? output.repeatExtXKey : undefined,
+    AdMarkers: __expectString(output.adMarkers),
+    IncludeIframeOnlyStream: __expectBoolean(output.includeIframeOnlyStream),
+    ManifestName: __expectString(output.manifestName),
+    ProgramDateTimeIntervalSeconds: __expectNumber(output.programDateTimeIntervalSeconds),
+    RepeatExtXKey: __expectBoolean(output.repeatExtXKey),
     StreamSelection:
       output.streamSelection !== undefined && output.streamSelection !== null
         ? deserializeAws_restJson1StreamSelection(output.streamSelection, context)
@@ -2923,14 +2885,8 @@ const deserializeAws_restJson1HlsPackage = (output: any, context: __SerdeContext
       output.hlsManifests !== undefined && output.hlsManifests !== null
         ? deserializeAws_restJson1__listOfHlsManifest(output.hlsManifests, context)
         : undefined,
-    SegmentDurationSeconds:
-      output.segmentDurationSeconds !== undefined && output.segmentDurationSeconds !== null
-        ? output.segmentDurationSeconds
-        : undefined,
-    UseAudioRenditionGroup:
-      output.useAudioRenditionGroup !== undefined && output.useAudioRenditionGroup !== null
-        ? output.useAudioRenditionGroup
-        : undefined,
+    SegmentDurationSeconds: __expectNumber(output.segmentDurationSeconds),
+    UseAudioRenditionGroup: __expectBoolean(output.useAudioRenditionGroup),
   } as any;
 };
 
@@ -2945,7 +2901,7 @@ const deserializeAws_restJson1MssEncryption = (output: any, context: __SerdeCont
 
 const deserializeAws_restJson1MssManifest = (output: any, context: __SerdeContext): MssManifest => {
   return {
-    ManifestName: output.manifestName !== undefined && output.manifestName !== null ? output.manifestName : undefined,
+    ManifestName: __expectString(output.manifestName),
     StreamSelection:
       output.streamSelection !== undefined && output.streamSelection !== null
         ? deserializeAws_restJson1StreamSelection(output.streamSelection, context)
@@ -2963,10 +2919,7 @@ const deserializeAws_restJson1MssPackage = (output: any, context: __SerdeContext
       output.mssManifests !== undefined && output.mssManifests !== null
         ? deserializeAws_restJson1__listOfMssManifest(output.mssManifests, context)
         : undefined,
-    SegmentDurationSeconds:
-      output.segmentDurationSeconds !== undefined && output.segmentDurationSeconds !== null
-        ? output.segmentDurationSeconds
-        : undefined,
+    SegmentDurationSeconds: __expectNumber(output.segmentDurationSeconds),
   } as any;
 };
 
@@ -2975,7 +2928,7 @@ const deserializeAws_restJson1PackagingConfiguration = (
   context: __SerdeContext
 ): PackagingConfiguration => {
   return {
-    Arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    Arn: __expectString(output.arn),
     CmafPackage:
       output.cmafPackage !== undefined && output.cmafPackage !== null
         ? deserializeAws_restJson1CmafPackage(output.cmafPackage, context)
@@ -2988,13 +2941,12 @@ const deserializeAws_restJson1PackagingConfiguration = (
       output.hlsPackage !== undefined && output.hlsPackage !== null
         ? deserializeAws_restJson1HlsPackage(output.hlsPackage, context)
         : undefined,
-    Id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    Id: __expectString(output.id),
     MssPackage:
       output.mssPackage !== undefined && output.mssPackage !== null
         ? deserializeAws_restJson1MssPackage(output.mssPackage, context)
         : undefined,
-    PackagingGroupId:
-      output.packagingGroupId !== undefined && output.packagingGroupId !== null ? output.packagingGroupId : undefined,
+    PackagingGroupId: __expectString(output.packagingGroupId),
     Tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1Tags(output.tags, context)
@@ -3004,17 +2956,17 @@ const deserializeAws_restJson1PackagingConfiguration = (
 
 const deserializeAws_restJson1PackagingGroup = (output: any, context: __SerdeContext): PackagingGroup => {
   return {
-    Arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    Arn: __expectString(output.arn),
     Authorization:
       output.authorization !== undefined && output.authorization !== null
         ? deserializeAws_restJson1Authorization(output.authorization, context)
         : undefined,
-    DomainName: output.domainName !== undefined && output.domainName !== null ? output.domainName : undefined,
+    DomainName: __expectString(output.domainName),
     EgressAccessLogs:
       output.egressAccessLogs !== undefined && output.egressAccessLogs !== null
         ? deserializeAws_restJson1EgressAccessLogs(output.egressAccessLogs, context)
         : undefined,
-    Id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    Id: __expectString(output.id),
     Tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1Tags(output.tags, context)
@@ -3024,26 +2976,20 @@ const deserializeAws_restJson1PackagingGroup = (output: any, context: __SerdeCon
 
 const deserializeAws_restJson1SpekeKeyProvider = (output: any, context: __SerdeContext): SpekeKeyProvider => {
   return {
-    RoleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
+    RoleArn: __expectString(output.roleArn),
     SystemIds:
       output.systemIds !== undefined && output.systemIds !== null
         ? deserializeAws_restJson1__listOf__string(output.systemIds, context)
         : undefined,
-    Url: output.url !== undefined && output.url !== null ? output.url : undefined,
+    Url: __expectString(output.url),
   } as any;
 };
 
 const deserializeAws_restJson1StreamSelection = (output: any, context: __SerdeContext): StreamSelection => {
   return {
-    MaxVideoBitsPerSecond:
-      output.maxVideoBitsPerSecond !== undefined && output.maxVideoBitsPerSecond !== null
-        ? output.maxVideoBitsPerSecond
-        : undefined,
-    MinVideoBitsPerSecond:
-      output.minVideoBitsPerSecond !== undefined && output.minVideoBitsPerSecond !== null
-        ? output.minVideoBitsPerSecond
-        : undefined,
-    StreamOrder: output.streamOrder !== undefined && output.streamOrder !== null ? output.streamOrder : undefined,
+    MaxVideoBitsPerSecond: __expectNumber(output.maxVideoBitsPerSecond),
+    MinVideoBitsPerSecond: __expectNumber(output.minVideoBitsPerSecond),
+    StreamOrder: __expectString(output.streamOrder),
   } as any;
 };
 
@@ -3054,7 +3000,7 @@ const deserializeAws_restJson1Tags = (output: any, context: __SerdeContext): { [
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };

--- a/clients/client-mediapackage/protocols/Aws_restJson1.ts
+++ b/clients/client-mediapackage/protocols/Aws_restJson1.ts
@@ -77,6 +77,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -714,10 +717,10 @@ export const deserializeAws_restJson1ConfigureLogsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.Arn = data.arn;
+    contents.Arn = __expectString(data.arn);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.Description = data.description;
+    contents.Description = __expectString(data.description);
   }
   if (data.egressAccessLogs !== undefined && data.egressAccessLogs !== null) {
     contents.EgressAccessLogs = deserializeAws_restJson1EgressAccessLogs(data.egressAccessLogs, context);
@@ -726,7 +729,7 @@ export const deserializeAws_restJson1ConfigureLogsCommand = async (
     contents.HlsIngest = deserializeAws_restJson1HlsIngest(data.hlsIngest, context);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.Id = data.id;
+    contents.Id = __expectString(data.id);
   }
   if (data.ingressAccessLogs !== undefined && data.ingressAccessLogs !== null) {
     contents.IngressAccessLogs = deserializeAws_restJson1IngressAccessLogs(data.ingressAccessLogs, context);
@@ -833,10 +836,10 @@ export const deserializeAws_restJson1CreateChannelCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.Arn = data.arn;
+    contents.Arn = __expectString(data.arn);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.Description = data.description;
+    contents.Description = __expectString(data.description);
   }
   if (data.egressAccessLogs !== undefined && data.egressAccessLogs !== null) {
     contents.EgressAccessLogs = deserializeAws_restJson1EgressAccessLogs(data.egressAccessLogs, context);
@@ -845,7 +848,7 @@ export const deserializeAws_restJson1CreateChannelCommand = async (
     contents.HlsIngest = deserializeAws_restJson1HlsIngest(data.hlsIngest, context);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.Id = data.id;
+    contents.Id = __expectString(data.id);
   }
   if (data.ingressAccessLogs !== undefined && data.ingressAccessLogs !== null) {
     contents.IngressAccessLogs = deserializeAws_restJson1IngressAccessLogs(data.ingressAccessLogs, context);
@@ -954,31 +957,31 @@ export const deserializeAws_restJson1CreateHarvestJobCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.Arn = data.arn;
+    contents.Arn = __expectString(data.arn);
   }
   if (data.channelId !== undefined && data.channelId !== null) {
-    contents.ChannelId = data.channelId;
+    contents.ChannelId = __expectString(data.channelId);
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
-    contents.CreatedAt = data.createdAt;
+    contents.CreatedAt = __expectString(data.createdAt);
   }
   if (data.endTime !== undefined && data.endTime !== null) {
-    contents.EndTime = data.endTime;
+    contents.EndTime = __expectString(data.endTime);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.Id = data.id;
+    contents.Id = __expectString(data.id);
   }
   if (data.originEndpointId !== undefined && data.originEndpointId !== null) {
-    contents.OriginEndpointId = data.originEndpointId;
+    contents.OriginEndpointId = __expectString(data.originEndpointId);
   }
   if (data.s3Destination !== undefined && data.s3Destination !== null) {
     contents.S3Destination = deserializeAws_restJson1S3Destination(data.s3Destination, context);
   }
   if (data.startTime !== undefined && data.startTime !== null) {
-    contents.StartTime = data.startTime;
+    contents.StartTime = __expectString(data.startTime);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.Status = data.status;
+    contents.Status = __expectString(data.status);
   }
   return Promise.resolve(contents);
 };
@@ -1088,13 +1091,13 @@ export const deserializeAws_restJson1CreateOriginEndpointCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.Arn = data.arn;
+    contents.Arn = __expectString(data.arn);
   }
   if (data.authorization !== undefined && data.authorization !== null) {
     contents.Authorization = deserializeAws_restJson1Authorization(data.authorization, context);
   }
   if (data.channelId !== undefined && data.channelId !== null) {
-    contents.ChannelId = data.channelId;
+    contents.ChannelId = __expectString(data.channelId);
   }
   if (data.cmafPackage !== undefined && data.cmafPackage !== null) {
     contents.CmafPackage = deserializeAws_restJson1CmafPackage(data.cmafPackage, context);
@@ -1103,34 +1106,34 @@ export const deserializeAws_restJson1CreateOriginEndpointCommand = async (
     contents.DashPackage = deserializeAws_restJson1DashPackage(data.dashPackage, context);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.Description = data.description;
+    contents.Description = __expectString(data.description);
   }
   if (data.hlsPackage !== undefined && data.hlsPackage !== null) {
     contents.HlsPackage = deserializeAws_restJson1HlsPackage(data.hlsPackage, context);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.Id = data.id;
+    contents.Id = __expectString(data.id);
   }
   if (data.manifestName !== undefined && data.manifestName !== null) {
-    contents.ManifestName = data.manifestName;
+    contents.ManifestName = __expectString(data.manifestName);
   }
   if (data.mssPackage !== undefined && data.mssPackage !== null) {
     contents.MssPackage = deserializeAws_restJson1MssPackage(data.mssPackage, context);
   }
   if (data.origination !== undefined && data.origination !== null) {
-    contents.Origination = data.origination;
+    contents.Origination = __expectString(data.origination);
   }
   if (data.startoverWindowSeconds !== undefined && data.startoverWindowSeconds !== null) {
-    contents.StartoverWindowSeconds = data.startoverWindowSeconds;
+    contents.StartoverWindowSeconds = __expectNumber(data.startoverWindowSeconds);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
   }
   if (data.timeDelaySeconds !== undefined && data.timeDelaySeconds !== null) {
-    contents.TimeDelaySeconds = data.timeDelaySeconds;
+    contents.TimeDelaySeconds = __expectNumber(data.timeDelaySeconds);
   }
   if (data.url !== undefined && data.url !== null) {
-    contents.Url = data.url;
+    contents.Url = __expectString(data.url);
   }
   if (data.whitelist !== undefined && data.whitelist !== null) {
     contents.Whitelist = deserializeAws_restJson1__listOf__string(data.whitelist, context);
@@ -1416,10 +1419,10 @@ export const deserializeAws_restJson1DescribeChannelCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.Arn = data.arn;
+    contents.Arn = __expectString(data.arn);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.Description = data.description;
+    contents.Description = __expectString(data.description);
   }
   if (data.egressAccessLogs !== undefined && data.egressAccessLogs !== null) {
     contents.EgressAccessLogs = deserializeAws_restJson1EgressAccessLogs(data.egressAccessLogs, context);
@@ -1428,7 +1431,7 @@ export const deserializeAws_restJson1DescribeChannelCommand = async (
     contents.HlsIngest = deserializeAws_restJson1HlsIngest(data.hlsIngest, context);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.Id = data.id;
+    contents.Id = __expectString(data.id);
   }
   if (data.ingressAccessLogs !== undefined && data.ingressAccessLogs !== null) {
     contents.IngressAccessLogs = deserializeAws_restJson1IngressAccessLogs(data.ingressAccessLogs, context);
@@ -1537,31 +1540,31 @@ export const deserializeAws_restJson1DescribeHarvestJobCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.Arn = data.arn;
+    contents.Arn = __expectString(data.arn);
   }
   if (data.channelId !== undefined && data.channelId !== null) {
-    contents.ChannelId = data.channelId;
+    contents.ChannelId = __expectString(data.channelId);
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
-    contents.CreatedAt = data.createdAt;
+    contents.CreatedAt = __expectString(data.createdAt);
   }
   if (data.endTime !== undefined && data.endTime !== null) {
-    contents.EndTime = data.endTime;
+    contents.EndTime = __expectString(data.endTime);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.Id = data.id;
+    contents.Id = __expectString(data.id);
   }
   if (data.originEndpointId !== undefined && data.originEndpointId !== null) {
-    contents.OriginEndpointId = data.originEndpointId;
+    contents.OriginEndpointId = __expectString(data.originEndpointId);
   }
   if (data.s3Destination !== undefined && data.s3Destination !== null) {
     contents.S3Destination = deserializeAws_restJson1S3Destination(data.s3Destination, context);
   }
   if (data.startTime !== undefined && data.startTime !== null) {
-    contents.StartTime = data.startTime;
+    contents.StartTime = __expectString(data.startTime);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.Status = data.status;
+    contents.Status = __expectString(data.status);
   }
   return Promise.resolve(contents);
 };
@@ -1671,13 +1674,13 @@ export const deserializeAws_restJson1DescribeOriginEndpointCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.Arn = data.arn;
+    contents.Arn = __expectString(data.arn);
   }
   if (data.authorization !== undefined && data.authorization !== null) {
     contents.Authorization = deserializeAws_restJson1Authorization(data.authorization, context);
   }
   if (data.channelId !== undefined && data.channelId !== null) {
-    contents.ChannelId = data.channelId;
+    contents.ChannelId = __expectString(data.channelId);
   }
   if (data.cmafPackage !== undefined && data.cmafPackage !== null) {
     contents.CmafPackage = deserializeAws_restJson1CmafPackage(data.cmafPackage, context);
@@ -1686,34 +1689,34 @@ export const deserializeAws_restJson1DescribeOriginEndpointCommand = async (
     contents.DashPackage = deserializeAws_restJson1DashPackage(data.dashPackage, context);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.Description = data.description;
+    contents.Description = __expectString(data.description);
   }
   if (data.hlsPackage !== undefined && data.hlsPackage !== null) {
     contents.HlsPackage = deserializeAws_restJson1HlsPackage(data.hlsPackage, context);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.Id = data.id;
+    contents.Id = __expectString(data.id);
   }
   if (data.manifestName !== undefined && data.manifestName !== null) {
-    contents.ManifestName = data.manifestName;
+    contents.ManifestName = __expectString(data.manifestName);
   }
   if (data.mssPackage !== undefined && data.mssPackage !== null) {
     contents.MssPackage = deserializeAws_restJson1MssPackage(data.mssPackage, context);
   }
   if (data.origination !== undefined && data.origination !== null) {
-    contents.Origination = data.origination;
+    contents.Origination = __expectString(data.origination);
   }
   if (data.startoverWindowSeconds !== undefined && data.startoverWindowSeconds !== null) {
-    contents.StartoverWindowSeconds = data.startoverWindowSeconds;
+    contents.StartoverWindowSeconds = __expectNumber(data.startoverWindowSeconds);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
   }
   if (data.timeDelaySeconds !== undefined && data.timeDelaySeconds !== null) {
-    contents.TimeDelaySeconds = data.timeDelaySeconds;
+    contents.TimeDelaySeconds = __expectNumber(data.timeDelaySeconds);
   }
   if (data.url !== undefined && data.url !== null) {
-    contents.Url = data.url;
+    contents.Url = __expectString(data.url);
   }
   if (data.whitelist !== undefined && data.whitelist !== null) {
     contents.Whitelist = deserializeAws_restJson1__listOf__string(data.whitelist, context);
@@ -1815,7 +1818,7 @@ export const deserializeAws_restJson1ListChannelsCommand = async (
     contents.Channels = deserializeAws_restJson1__listOfChannel(data.channels, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1914,7 +1917,7 @@ export const deserializeAws_restJson1ListHarvestJobsCommand = async (
     contents.HarvestJobs = deserializeAws_restJson1__listOfHarvestJob(data.harvestJobs, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2010,7 +2013,7 @@ export const deserializeAws_restJson1ListOriginEndpointsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   if (data.originEndpoints !== undefined && data.originEndpoints !== null) {
     contents.OriginEndpoints = deserializeAws_restJson1__listOfOriginEndpoint(data.originEndpoints, context);
@@ -2161,10 +2164,10 @@ export const deserializeAws_restJson1RotateChannelCredentialsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.Arn = data.arn;
+    contents.Arn = __expectString(data.arn);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.Description = data.description;
+    contents.Description = __expectString(data.description);
   }
   if (data.egressAccessLogs !== undefined && data.egressAccessLogs !== null) {
     contents.EgressAccessLogs = deserializeAws_restJson1EgressAccessLogs(data.egressAccessLogs, context);
@@ -2173,7 +2176,7 @@ export const deserializeAws_restJson1RotateChannelCredentialsCommand = async (
     contents.HlsIngest = deserializeAws_restJson1HlsIngest(data.hlsIngest, context);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.Id = data.id;
+    contents.Id = __expectString(data.id);
   }
   if (data.ingressAccessLogs !== undefined && data.ingressAccessLogs !== null) {
     contents.IngressAccessLogs = deserializeAws_restJson1IngressAccessLogs(data.ingressAccessLogs, context);
@@ -2280,10 +2283,10 @@ export const deserializeAws_restJson1RotateIngestEndpointCredentialsCommand = as
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.Arn = data.arn;
+    contents.Arn = __expectString(data.arn);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.Description = data.description;
+    contents.Description = __expectString(data.description);
   }
   if (data.egressAccessLogs !== undefined && data.egressAccessLogs !== null) {
     contents.EgressAccessLogs = deserializeAws_restJson1EgressAccessLogs(data.egressAccessLogs, context);
@@ -2292,7 +2295,7 @@ export const deserializeAws_restJson1RotateIngestEndpointCredentialsCommand = as
     contents.HlsIngest = deserializeAws_restJson1HlsIngest(data.hlsIngest, context);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.Id = data.id;
+    contents.Id = __expectString(data.id);
   }
   if (data.ingressAccessLogs !== undefined && data.ingressAccessLogs !== null) {
     contents.IngressAccessLogs = deserializeAws_restJson1IngressAccessLogs(data.ingressAccessLogs, context);
@@ -2485,10 +2488,10 @@ export const deserializeAws_restJson1UpdateChannelCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.Arn = data.arn;
+    contents.Arn = __expectString(data.arn);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.Description = data.description;
+    contents.Description = __expectString(data.description);
   }
   if (data.egressAccessLogs !== undefined && data.egressAccessLogs !== null) {
     contents.EgressAccessLogs = deserializeAws_restJson1EgressAccessLogs(data.egressAccessLogs, context);
@@ -2497,7 +2500,7 @@ export const deserializeAws_restJson1UpdateChannelCommand = async (
     contents.HlsIngest = deserializeAws_restJson1HlsIngest(data.hlsIngest, context);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.Id = data.id;
+    contents.Id = __expectString(data.id);
   }
   if (data.ingressAccessLogs !== undefined && data.ingressAccessLogs !== null) {
     contents.IngressAccessLogs = deserializeAws_restJson1IngressAccessLogs(data.ingressAccessLogs, context);
@@ -2613,13 +2616,13 @@ export const deserializeAws_restJson1UpdateOriginEndpointCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.Arn = data.arn;
+    contents.Arn = __expectString(data.arn);
   }
   if (data.authorization !== undefined && data.authorization !== null) {
     contents.Authorization = deserializeAws_restJson1Authorization(data.authorization, context);
   }
   if (data.channelId !== undefined && data.channelId !== null) {
-    contents.ChannelId = data.channelId;
+    contents.ChannelId = __expectString(data.channelId);
   }
   if (data.cmafPackage !== undefined && data.cmafPackage !== null) {
     contents.CmafPackage = deserializeAws_restJson1CmafPackage(data.cmafPackage, context);
@@ -2628,34 +2631,34 @@ export const deserializeAws_restJson1UpdateOriginEndpointCommand = async (
     contents.DashPackage = deserializeAws_restJson1DashPackage(data.dashPackage, context);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.Description = data.description;
+    contents.Description = __expectString(data.description);
   }
   if (data.hlsPackage !== undefined && data.hlsPackage !== null) {
     contents.HlsPackage = deserializeAws_restJson1HlsPackage(data.hlsPackage, context);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.Id = data.id;
+    contents.Id = __expectString(data.id);
   }
   if (data.manifestName !== undefined && data.manifestName !== null) {
-    contents.ManifestName = data.manifestName;
+    contents.ManifestName = __expectString(data.manifestName);
   }
   if (data.mssPackage !== undefined && data.mssPackage !== null) {
     contents.MssPackage = deserializeAws_restJson1MssPackage(data.mssPackage, context);
   }
   if (data.origination !== undefined && data.origination !== null) {
-    contents.Origination = data.origination;
+    contents.Origination = __expectString(data.origination);
   }
   if (data.startoverWindowSeconds !== undefined && data.startoverWindowSeconds !== null) {
-    contents.StartoverWindowSeconds = data.startoverWindowSeconds;
+    contents.StartoverWindowSeconds = __expectNumber(data.startoverWindowSeconds);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
   }
   if (data.timeDelaySeconds !== undefined && data.timeDelaySeconds !== null) {
-    contents.TimeDelaySeconds = data.timeDelaySeconds;
+    contents.TimeDelaySeconds = __expectNumber(data.timeDelaySeconds);
   }
   if (data.url !== undefined && data.url !== null) {
-    contents.Url = data.url;
+    contents.Url = __expectString(data.url);
   }
   if (data.whitelist !== undefined && data.whitelist !== null) {
     contents.Whitelist = deserializeAws_restJson1__listOf__string(data.whitelist, context);
@@ -2752,7 +2755,7 @@ const deserializeAws_restJson1ForbiddenExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -2769,7 +2772,7 @@ const deserializeAws_restJson1InternalServerErrorExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -2786,7 +2789,7 @@ const deserializeAws_restJson1NotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -2803,7 +2806,7 @@ const deserializeAws_restJson1ServiceUnavailableExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -2820,7 +2823,7 @@ const deserializeAws_restJson1TooManyRequestsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -2837,7 +2840,7 @@ const deserializeAws_restJson1UnprocessableEntityExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -3176,7 +3179,7 @@ const deserializeAws_restJson1__listOf__PeriodTriggersElement = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3187,7 +3190,7 @@ const deserializeAws_restJson1__listOf__string = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3253,7 +3256,7 @@ const deserializeAws_restJson1__mapOf__string = (output: any, context: __SerdeCo
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -3265,25 +3268,21 @@ const deserializeAws_restJson1AdTriggers = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1Authorization = (output: any, context: __SerdeContext): Authorization => {
   return {
-    CdnIdentifierSecret:
-      output.cdnIdentifierSecret !== undefined && output.cdnIdentifierSecret !== null
-        ? output.cdnIdentifierSecret
-        : undefined,
-    SecretsRoleArn:
-      output.secretsRoleArn !== undefined && output.secretsRoleArn !== null ? output.secretsRoleArn : undefined,
+    CdnIdentifierSecret: __expectString(output.cdnIdentifierSecret),
+    SecretsRoleArn: __expectString(output.secretsRoleArn),
   } as any;
 };
 
 const deserializeAws_restJson1Channel = (output: any, context: __SerdeContext): Channel => {
   return {
-    Arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    Description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    Arn: __expectString(output.arn),
+    Description: __expectString(output.description),
     EgressAccessLogs:
       output.egressAccessLogs !== undefined && output.egressAccessLogs !== null
         ? deserializeAws_restJson1EgressAccessLogs(output.egressAccessLogs, context)
@@ -3292,7 +3291,7 @@ const deserializeAws_restJson1Channel = (output: any, context: __SerdeContext): 
       output.hlsIngest !== undefined && output.hlsIngest !== null
         ? deserializeAws_restJson1HlsIngest(output.hlsIngest, context)
         : undefined,
-    Id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    Id: __expectString(output.id),
     IngressAccessLogs:
       output.ingressAccessLogs !== undefined && output.ingressAccessLogs !== null
         ? deserializeAws_restJson1IngressAccessLogs(output.ingressAccessLogs, context)
@@ -3306,14 +3305,8 @@ const deserializeAws_restJson1Channel = (output: any, context: __SerdeContext): 
 
 const deserializeAws_restJson1CmafEncryption = (output: any, context: __SerdeContext): CmafEncryption => {
   return {
-    ConstantInitializationVector:
-      output.constantInitializationVector !== undefined && output.constantInitializationVector !== null
-        ? output.constantInitializationVector
-        : undefined,
-    KeyRotationIntervalSeconds:
-      output.keyRotationIntervalSeconds !== undefined && output.keyRotationIntervalSeconds !== null
-        ? output.keyRotationIntervalSeconds
-        : undefined,
+    ConstantInitializationVector: __expectString(output.constantInitializationVector),
+    KeyRotationIntervalSeconds: __expectNumber(output.keyRotationIntervalSeconds),
     SpekeKeyProvider:
       output.spekeKeyProvider !== undefined && output.spekeKeyProvider !== null
         ? deserializeAws_restJson1SpekeKeyProvider(output.spekeKeyProvider, context)
@@ -3331,12 +3324,8 @@ const deserializeAws_restJson1CmafPackage = (output: any, context: __SerdeContex
       output.hlsManifests !== undefined && output.hlsManifests !== null
         ? deserializeAws_restJson1__listOfHlsManifest(output.hlsManifests, context)
         : undefined,
-    SegmentDurationSeconds:
-      output.segmentDurationSeconds !== undefined && output.segmentDurationSeconds !== null
-        ? output.segmentDurationSeconds
-        : undefined,
-    SegmentPrefix:
-      output.segmentPrefix !== undefined && output.segmentPrefix !== null ? output.segmentPrefix : undefined,
+    SegmentDurationSeconds: __expectNumber(output.segmentDurationSeconds),
+    SegmentPrefix: __expectString(output.segmentPrefix),
     StreamSelection:
       output.streamSelection !== undefined && output.streamSelection !== null
         ? deserializeAws_restJson1StreamSelection(output.streamSelection, context)
@@ -3346,10 +3335,7 @@ const deserializeAws_restJson1CmafPackage = (output: any, context: __SerdeContex
 
 const deserializeAws_restJson1DashEncryption = (output: any, context: __SerdeContext): DashEncryption => {
   return {
-    KeyRotationIntervalSeconds:
-      output.keyRotationIntervalSeconds !== undefined && output.keyRotationIntervalSeconds !== null
-        ? output.keyRotationIntervalSeconds
-        : undefined,
+    KeyRotationIntervalSeconds: __expectNumber(output.keyRotationIntervalSeconds),
     SpekeKeyProvider:
       output.spekeKeyProvider !== undefined && output.spekeKeyProvider !== null
         ? deserializeAws_restJson1SpekeKeyProvider(output.spekeKeyProvider, context)
@@ -3363,57 +3349,35 @@ const deserializeAws_restJson1DashPackage = (output: any, context: __SerdeContex
       output.adTriggers !== undefined && output.adTriggers !== null
         ? deserializeAws_restJson1AdTriggers(output.adTriggers, context)
         : undefined,
-    AdsOnDeliveryRestrictions:
-      output.adsOnDeliveryRestrictions !== undefined && output.adsOnDeliveryRestrictions !== null
-        ? output.adsOnDeliveryRestrictions
-        : undefined,
+    AdsOnDeliveryRestrictions: __expectString(output.adsOnDeliveryRestrictions),
     Encryption:
       output.encryption !== undefined && output.encryption !== null
         ? deserializeAws_restJson1DashEncryption(output.encryption, context)
         : undefined,
-    ManifestLayout:
-      output.manifestLayout !== undefined && output.manifestLayout !== null ? output.manifestLayout : undefined,
-    ManifestWindowSeconds:
-      output.manifestWindowSeconds !== undefined && output.manifestWindowSeconds !== null
-        ? output.manifestWindowSeconds
-        : undefined,
-    MinBufferTimeSeconds:
-      output.minBufferTimeSeconds !== undefined && output.minBufferTimeSeconds !== null
-        ? output.minBufferTimeSeconds
-        : undefined,
-    MinUpdatePeriodSeconds:
-      output.minUpdatePeriodSeconds !== undefined && output.minUpdatePeriodSeconds !== null
-        ? output.minUpdatePeriodSeconds
-        : undefined,
+    ManifestLayout: __expectString(output.manifestLayout),
+    ManifestWindowSeconds: __expectNumber(output.manifestWindowSeconds),
+    MinBufferTimeSeconds: __expectNumber(output.minBufferTimeSeconds),
+    MinUpdatePeriodSeconds: __expectNumber(output.minUpdatePeriodSeconds),
     PeriodTriggers:
       output.periodTriggers !== undefined && output.periodTriggers !== null
         ? deserializeAws_restJson1__listOf__PeriodTriggersElement(output.periodTriggers, context)
         : undefined,
-    Profile: output.profile !== undefined && output.profile !== null ? output.profile : undefined,
-    SegmentDurationSeconds:
-      output.segmentDurationSeconds !== undefined && output.segmentDurationSeconds !== null
-        ? output.segmentDurationSeconds
-        : undefined,
-    SegmentTemplateFormat:
-      output.segmentTemplateFormat !== undefined && output.segmentTemplateFormat !== null
-        ? output.segmentTemplateFormat
-        : undefined,
+    Profile: __expectString(output.profile),
+    SegmentDurationSeconds: __expectNumber(output.segmentDurationSeconds),
+    SegmentTemplateFormat: __expectString(output.segmentTemplateFormat),
     StreamSelection:
       output.streamSelection !== undefined && output.streamSelection !== null
         ? deserializeAws_restJson1StreamSelection(output.streamSelection, context)
         : undefined,
-    SuggestedPresentationDelaySeconds:
-      output.suggestedPresentationDelaySeconds !== undefined && output.suggestedPresentationDelaySeconds !== null
-        ? output.suggestedPresentationDelaySeconds
-        : undefined,
-    UtcTiming: output.utcTiming !== undefined && output.utcTiming !== null ? output.utcTiming : undefined,
-    UtcTimingUri: output.utcTimingUri !== undefined && output.utcTimingUri !== null ? output.utcTimingUri : undefined,
+    SuggestedPresentationDelaySeconds: __expectNumber(output.suggestedPresentationDelaySeconds),
+    UtcTiming: __expectString(output.utcTiming),
+    UtcTimingUri: __expectString(output.utcTimingUri),
   } as any;
 };
 
 const deserializeAws_restJson1EgressAccessLogs = (output: any, context: __SerdeContext): EgressAccessLogs => {
   return {
-    LogGroupName: output.logGroupName !== undefined && output.logGroupName !== null ? output.logGroupName : undefined,
+    LogGroupName: __expectString(output.logGroupName),
   } as any;
 };
 
@@ -3422,49 +3386,34 @@ const deserializeAws_restJson1EncryptionContractConfiguration = (
   context: __SerdeContext
 ): EncryptionContractConfiguration => {
   return {
-    PresetSpeke20Audio:
-      output.presetSpeke20Audio !== undefined && output.presetSpeke20Audio !== null
-        ? output.presetSpeke20Audio
-        : undefined,
-    PresetSpeke20Video:
-      output.presetSpeke20Video !== undefined && output.presetSpeke20Video !== null
-        ? output.presetSpeke20Video
-        : undefined,
+    PresetSpeke20Audio: __expectString(output.presetSpeke20Audio),
+    PresetSpeke20Video: __expectString(output.presetSpeke20Video),
   } as any;
 };
 
 const deserializeAws_restJson1HarvestJob = (output: any, context: __SerdeContext): HarvestJob => {
   return {
-    Arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    ChannelId: output.channelId !== undefined && output.channelId !== null ? output.channelId : undefined,
-    CreatedAt: output.createdAt !== undefined && output.createdAt !== null ? output.createdAt : undefined,
-    EndTime: output.endTime !== undefined && output.endTime !== null ? output.endTime : undefined,
-    Id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    OriginEndpointId:
-      output.originEndpointId !== undefined && output.originEndpointId !== null ? output.originEndpointId : undefined,
+    Arn: __expectString(output.arn),
+    ChannelId: __expectString(output.channelId),
+    CreatedAt: __expectString(output.createdAt),
+    EndTime: __expectString(output.endTime),
+    Id: __expectString(output.id),
+    OriginEndpointId: __expectString(output.originEndpointId),
     S3Destination:
       output.s3Destination !== undefined && output.s3Destination !== null
         ? deserializeAws_restJson1S3Destination(output.s3Destination, context)
         : undefined,
-    StartTime: output.startTime !== undefined && output.startTime !== null ? output.startTime : undefined,
-    Status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    StartTime: __expectString(output.startTime),
+    Status: __expectString(output.status),
   } as any;
 };
 
 const deserializeAws_restJson1HlsEncryption = (output: any, context: __SerdeContext): HlsEncryption => {
   return {
-    ConstantInitializationVector:
-      output.constantInitializationVector !== undefined && output.constantInitializationVector !== null
-        ? output.constantInitializationVector
-        : undefined,
-    EncryptionMethod:
-      output.encryptionMethod !== undefined && output.encryptionMethod !== null ? output.encryptionMethod : undefined,
-    KeyRotationIntervalSeconds:
-      output.keyRotationIntervalSeconds !== undefined && output.keyRotationIntervalSeconds !== null
-        ? output.keyRotationIntervalSeconds
-        : undefined,
-    RepeatExtXKey:
-      output.repeatExtXKey !== undefined && output.repeatExtXKey !== null ? output.repeatExtXKey : undefined,
+    ConstantInitializationVector: __expectString(output.constantInitializationVector),
+    EncryptionMethod: __expectString(output.encryptionMethod),
+    KeyRotationIntervalSeconds: __expectNumber(output.keyRotationIntervalSeconds),
+    RepeatExtXKey: __expectBoolean(output.repeatExtXKey),
     SpekeKeyProvider:
       output.spekeKeyProvider !== undefined && output.spekeKeyProvider !== null
         ? deserializeAws_restJson1SpekeKeyProvider(output.spekeKeyProvider, context)
@@ -3483,81 +3432,54 @@ const deserializeAws_restJson1HlsIngest = (output: any, context: __SerdeContext)
 
 const deserializeAws_restJson1HlsManifest = (output: any, context: __SerdeContext): HlsManifest => {
   return {
-    AdMarkers: output.adMarkers !== undefined && output.adMarkers !== null ? output.adMarkers : undefined,
-    Id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    IncludeIframeOnlyStream:
-      output.includeIframeOnlyStream !== undefined && output.includeIframeOnlyStream !== null
-        ? output.includeIframeOnlyStream
-        : undefined,
-    ManifestName: output.manifestName !== undefined && output.manifestName !== null ? output.manifestName : undefined,
-    PlaylistType: output.playlistType !== undefined && output.playlistType !== null ? output.playlistType : undefined,
-    PlaylistWindowSeconds:
-      output.playlistWindowSeconds !== undefined && output.playlistWindowSeconds !== null
-        ? output.playlistWindowSeconds
-        : undefined,
-    ProgramDateTimeIntervalSeconds:
-      output.programDateTimeIntervalSeconds !== undefined && output.programDateTimeIntervalSeconds !== null
-        ? output.programDateTimeIntervalSeconds
-        : undefined,
-    Url: output.url !== undefined && output.url !== null ? output.url : undefined,
+    AdMarkers: __expectString(output.adMarkers),
+    Id: __expectString(output.id),
+    IncludeIframeOnlyStream: __expectBoolean(output.includeIframeOnlyStream),
+    ManifestName: __expectString(output.manifestName),
+    PlaylistType: __expectString(output.playlistType),
+    PlaylistWindowSeconds: __expectNumber(output.playlistWindowSeconds),
+    ProgramDateTimeIntervalSeconds: __expectNumber(output.programDateTimeIntervalSeconds),
+    Url: __expectString(output.url),
   } as any;
 };
 
 const deserializeAws_restJson1HlsPackage = (output: any, context: __SerdeContext): HlsPackage => {
   return {
-    AdMarkers: output.adMarkers !== undefined && output.adMarkers !== null ? output.adMarkers : undefined,
+    AdMarkers: __expectString(output.adMarkers),
     AdTriggers:
       output.adTriggers !== undefined && output.adTriggers !== null
         ? deserializeAws_restJson1AdTriggers(output.adTriggers, context)
         : undefined,
-    AdsOnDeliveryRestrictions:
-      output.adsOnDeliveryRestrictions !== undefined && output.adsOnDeliveryRestrictions !== null
-        ? output.adsOnDeliveryRestrictions
-        : undefined,
+    AdsOnDeliveryRestrictions: __expectString(output.adsOnDeliveryRestrictions),
     Encryption:
       output.encryption !== undefined && output.encryption !== null
         ? deserializeAws_restJson1HlsEncryption(output.encryption, context)
         : undefined,
-    IncludeIframeOnlyStream:
-      output.includeIframeOnlyStream !== undefined && output.includeIframeOnlyStream !== null
-        ? output.includeIframeOnlyStream
-        : undefined,
-    PlaylistType: output.playlistType !== undefined && output.playlistType !== null ? output.playlistType : undefined,
-    PlaylistWindowSeconds:
-      output.playlistWindowSeconds !== undefined && output.playlistWindowSeconds !== null
-        ? output.playlistWindowSeconds
-        : undefined,
-    ProgramDateTimeIntervalSeconds:
-      output.programDateTimeIntervalSeconds !== undefined && output.programDateTimeIntervalSeconds !== null
-        ? output.programDateTimeIntervalSeconds
-        : undefined,
-    SegmentDurationSeconds:
-      output.segmentDurationSeconds !== undefined && output.segmentDurationSeconds !== null
-        ? output.segmentDurationSeconds
-        : undefined,
+    IncludeIframeOnlyStream: __expectBoolean(output.includeIframeOnlyStream),
+    PlaylistType: __expectString(output.playlistType),
+    PlaylistWindowSeconds: __expectNumber(output.playlistWindowSeconds),
+    ProgramDateTimeIntervalSeconds: __expectNumber(output.programDateTimeIntervalSeconds),
+    SegmentDurationSeconds: __expectNumber(output.segmentDurationSeconds),
     StreamSelection:
       output.streamSelection !== undefined && output.streamSelection !== null
         ? deserializeAws_restJson1StreamSelection(output.streamSelection, context)
         : undefined,
-    UseAudioRenditionGroup:
-      output.useAudioRenditionGroup !== undefined && output.useAudioRenditionGroup !== null
-        ? output.useAudioRenditionGroup
-        : undefined,
+    UseAudioRenditionGroup: __expectBoolean(output.useAudioRenditionGroup),
   } as any;
 };
 
 const deserializeAws_restJson1IngestEndpoint = (output: any, context: __SerdeContext): IngestEndpoint => {
   return {
-    Id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    Password: output.password !== undefined && output.password !== null ? output.password : undefined,
-    Url: output.url !== undefined && output.url !== null ? output.url : undefined,
-    Username: output.username !== undefined && output.username !== null ? output.username : undefined,
+    Id: __expectString(output.id),
+    Password: __expectString(output.password),
+    Url: __expectString(output.url),
+    Username: __expectString(output.username),
   } as any;
 };
 
 const deserializeAws_restJson1IngressAccessLogs = (output: any, context: __SerdeContext): IngressAccessLogs => {
   return {
-    LogGroupName: output.logGroupName !== undefined && output.logGroupName !== null ? output.logGroupName : undefined,
+    LogGroupName: __expectString(output.logGroupName),
   } as any;
 };
 
@@ -3576,14 +3498,8 @@ const deserializeAws_restJson1MssPackage = (output: any, context: __SerdeContext
       output.encryption !== undefined && output.encryption !== null
         ? deserializeAws_restJson1MssEncryption(output.encryption, context)
         : undefined,
-    ManifestWindowSeconds:
-      output.manifestWindowSeconds !== undefined && output.manifestWindowSeconds !== null
-        ? output.manifestWindowSeconds
-        : undefined,
-    SegmentDurationSeconds:
-      output.segmentDurationSeconds !== undefined && output.segmentDurationSeconds !== null
-        ? output.segmentDurationSeconds
-        : undefined,
+    ManifestWindowSeconds: __expectNumber(output.manifestWindowSeconds),
+    SegmentDurationSeconds: __expectNumber(output.segmentDurationSeconds),
     StreamSelection:
       output.streamSelection !== undefined && output.streamSelection !== null
         ? deserializeAws_restJson1StreamSelection(output.streamSelection, context)
@@ -3593,12 +3509,12 @@ const deserializeAws_restJson1MssPackage = (output: any, context: __SerdeContext
 
 const deserializeAws_restJson1OriginEndpoint = (output: any, context: __SerdeContext): OriginEndpoint => {
   return {
-    Arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    Arn: __expectString(output.arn),
     Authorization:
       output.authorization !== undefined && output.authorization !== null
         ? deserializeAws_restJson1Authorization(output.authorization, context)
         : undefined,
-    ChannelId: output.channelId !== undefined && output.channelId !== null ? output.channelId : undefined,
+    ChannelId: __expectString(output.channelId),
     CmafPackage:
       output.cmafPackage !== undefined && output.cmafPackage !== null
         ? deserializeAws_restJson1CmafPackage(output.cmafPackage, context)
@@ -3607,29 +3523,25 @@ const deserializeAws_restJson1OriginEndpoint = (output: any, context: __SerdeCon
       output.dashPackage !== undefined && output.dashPackage !== null
         ? deserializeAws_restJson1DashPackage(output.dashPackage, context)
         : undefined,
-    Description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    Description: __expectString(output.description),
     HlsPackage:
       output.hlsPackage !== undefined && output.hlsPackage !== null
         ? deserializeAws_restJson1HlsPackage(output.hlsPackage, context)
         : undefined,
-    Id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    ManifestName: output.manifestName !== undefined && output.manifestName !== null ? output.manifestName : undefined,
+    Id: __expectString(output.id),
+    ManifestName: __expectString(output.manifestName),
     MssPackage:
       output.mssPackage !== undefined && output.mssPackage !== null
         ? deserializeAws_restJson1MssPackage(output.mssPackage, context)
         : undefined,
-    Origination: output.origination !== undefined && output.origination !== null ? output.origination : undefined,
-    StartoverWindowSeconds:
-      output.startoverWindowSeconds !== undefined && output.startoverWindowSeconds !== null
-        ? output.startoverWindowSeconds
-        : undefined,
+    Origination: __expectString(output.origination),
+    StartoverWindowSeconds: __expectNumber(output.startoverWindowSeconds),
     Tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1Tags(output.tags, context)
         : undefined,
-    TimeDelaySeconds:
-      output.timeDelaySeconds !== undefined && output.timeDelaySeconds !== null ? output.timeDelaySeconds : undefined,
-    Url: output.url !== undefined && output.url !== null ? output.url : undefined,
+    TimeDelaySeconds: __expectNumber(output.timeDelaySeconds),
+    Url: __expectString(output.url),
     Whitelist:
       output.whitelist !== undefined && output.whitelist !== null
         ? deserializeAws_restJson1__listOf__string(output.whitelist, context)
@@ -3639,41 +3551,34 @@ const deserializeAws_restJson1OriginEndpoint = (output: any, context: __SerdeCon
 
 const deserializeAws_restJson1S3Destination = (output: any, context: __SerdeContext): S3Destination => {
   return {
-    BucketName: output.bucketName !== undefined && output.bucketName !== null ? output.bucketName : undefined,
-    ManifestKey: output.manifestKey !== undefined && output.manifestKey !== null ? output.manifestKey : undefined,
-    RoleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
+    BucketName: __expectString(output.bucketName),
+    ManifestKey: __expectString(output.manifestKey),
+    RoleArn: __expectString(output.roleArn),
   } as any;
 };
 
 const deserializeAws_restJson1SpekeKeyProvider = (output: any, context: __SerdeContext): SpekeKeyProvider => {
   return {
-    CertificateArn:
-      output.certificateArn !== undefined && output.certificateArn !== null ? output.certificateArn : undefined,
+    CertificateArn: __expectString(output.certificateArn),
     EncryptionContractConfiguration:
       output.encryptionContractConfiguration !== undefined && output.encryptionContractConfiguration !== null
         ? deserializeAws_restJson1EncryptionContractConfiguration(output.encryptionContractConfiguration, context)
         : undefined,
-    ResourceId: output.resourceId !== undefined && output.resourceId !== null ? output.resourceId : undefined,
-    RoleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
+    ResourceId: __expectString(output.resourceId),
+    RoleArn: __expectString(output.roleArn),
     SystemIds:
       output.systemIds !== undefined && output.systemIds !== null
         ? deserializeAws_restJson1__listOf__string(output.systemIds, context)
         : undefined,
-    Url: output.url !== undefined && output.url !== null ? output.url : undefined,
+    Url: __expectString(output.url),
   } as any;
 };
 
 const deserializeAws_restJson1StreamSelection = (output: any, context: __SerdeContext): StreamSelection => {
   return {
-    MaxVideoBitsPerSecond:
-      output.maxVideoBitsPerSecond !== undefined && output.maxVideoBitsPerSecond !== null
-        ? output.maxVideoBitsPerSecond
-        : undefined,
-    MinVideoBitsPerSecond:
-      output.minVideoBitsPerSecond !== undefined && output.minVideoBitsPerSecond !== null
-        ? output.minVideoBitsPerSecond
-        : undefined,
-    StreamOrder: output.streamOrder !== undefined && output.streamOrder !== null ? output.streamOrder : undefined,
+    MaxVideoBitsPerSecond: __expectNumber(output.maxVideoBitsPerSecond),
+    MinVideoBitsPerSecond: __expectNumber(output.minVideoBitsPerSecond),
+    StreamOrder: __expectString(output.streamOrder),
   } as any;
 };
 
@@ -3684,7 +3589,7 @@ const deserializeAws_restJson1Tags = (output: any, context: __SerdeContext): { [
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };

--- a/clients/client-mediastore-data/protocols/Aws_restJson1.ts
+++ b/clients/client-mediastore-data/protocols/Aws_restJson1.ts
@@ -13,6 +13,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -473,7 +475,7 @@ export const deserializeAws_restJson1ListItemsCommand = async (
     contents.Items = deserializeAws_restJson1ItemList(data.Items, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -538,13 +540,13 @@ export const deserializeAws_restJson1PutObjectCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ContentSHA256 !== undefined && data.ContentSHA256 !== null) {
-    contents.ContentSHA256 = data.ContentSHA256;
+    contents.ContentSHA256 = __expectString(data.ContentSHA256);
   }
   if (data.ETag !== undefined && data.ETag !== null) {
-    contents.ETag = data.ETag;
+    contents.ETag = __expectString(data.ETag);
   }
   if (data.StorageClass !== undefined && data.StorageClass !== null) {
-    contents.StorageClass = data.StorageClass;
+    contents.StorageClass = __expectString(data.StorageClass);
   }
   return Promise.resolve(contents);
 };
@@ -606,7 +608,7 @@ const deserializeAws_restJson1ContainerNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -623,7 +625,7 @@ const deserializeAws_restJson1InternalServerErrorResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -640,7 +642,7 @@ const deserializeAws_restJson1ObjectNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -657,23 +659,22 @@ const deserializeAws_restJson1RequestedRangeNotSatisfiableExceptionResponse = as
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
 
 const deserializeAws_restJson1Item = (output: any, context: __SerdeContext): Item => {
   return {
-    ContentLength:
-      output.ContentLength !== undefined && output.ContentLength !== null ? output.ContentLength : undefined,
-    ContentType: output.ContentType !== undefined && output.ContentType !== null ? output.ContentType : undefined,
-    ETag: output.ETag !== undefined && output.ETag !== null ? output.ETag : undefined,
+    ContentLength: __expectNumber(output.ContentLength),
+    ContentType: __expectString(output.ContentType),
+    ETag: __expectString(output.ETag),
     LastModified:
       output.LastModified !== undefined && output.LastModified !== null
         ? new Date(Math.round(output.LastModified * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Name: __expectString(output.Name),
+    Type: __expectString(output.Type),
   } as any;
 };
 

--- a/clients/client-mediastore/protocols/Aws_json1_1.ts
+++ b/clients/client-mediastore/protocols/Aws_json1_1.ts
@@ -85,7 +85,12 @@ import {
   UntagResourceOutput,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -2257,7 +2262,7 @@ const deserializeAws_json1_1AllowedHeaders = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2268,7 +2273,7 @@ const deserializeAws_json1_1AllowedMethods = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2279,24 +2284,21 @@ const deserializeAws_json1_1AllowedOrigins = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1Container = (output: any, context: __SerdeContext): Container => {
   return {
-    ARN: output.ARN !== undefined && output.ARN !== null ? output.ARN : undefined,
-    AccessLoggingEnabled:
-      output.AccessLoggingEnabled !== undefined && output.AccessLoggingEnabled !== null
-        ? output.AccessLoggingEnabled
-        : undefined,
+    ARN: __expectString(output.ARN),
+    AccessLoggingEnabled: __expectBoolean(output.AccessLoggingEnabled),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    Endpoint: output.Endpoint !== undefined && output.Endpoint !== null ? output.Endpoint : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Endpoint: __expectString(output.Endpoint),
+    Name: __expectString(output.Name),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -2305,7 +2307,7 @@ const deserializeAws_json1_1ContainerInUseException = (
   context: __SerdeContext
 ): ContainerInUseException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2325,7 +2327,7 @@ const deserializeAws_json1_1ContainerNotFoundException = (
   context: __SerdeContext
 ): ContainerNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2345,7 +2347,7 @@ const deserializeAws_json1_1CorsPolicyNotFoundException = (
   context: __SerdeContext
 ): CorsPolicyNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2367,8 +2369,7 @@ const deserializeAws_json1_1CorsRule = (output: any, context: __SerdeContext): C
       output.ExposeHeaders !== undefined && output.ExposeHeaders !== null
         ? deserializeAws_json1_1ExposeHeaders(output.ExposeHeaders, context)
         : undefined,
-    MaxAgeSeconds:
-      output.MaxAgeSeconds !== undefined && output.MaxAgeSeconds !== null ? output.MaxAgeSeconds : undefined,
+    MaxAgeSeconds: __expectNumber(output.MaxAgeSeconds),
   } as any;
 };
 
@@ -2429,7 +2430,7 @@ const deserializeAws_json1_1ExposeHeaders = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2438,7 +2439,7 @@ const deserializeAws_json1_1GetContainerPolicyOutput = (
   context: __SerdeContext
 ): GetContainerPolicyOutput => {
   return {
-    Policy: output.Policy !== undefined && output.Policy !== null ? output.Policy : undefined,
+    Policy: __expectString(output.Policy),
   } as any;
 };
 
@@ -2456,8 +2457,7 @@ const deserializeAws_json1_1GetLifecyclePolicyOutput = (
   context: __SerdeContext
 ): GetLifecyclePolicyOutput => {
   return {
-    LifecyclePolicy:
-      output.LifecyclePolicy !== undefined && output.LifecyclePolicy !== null ? output.LifecyclePolicy : undefined,
+    LifecyclePolicy: __expectString(output.LifecyclePolicy),
   } as any;
 };
 
@@ -2472,13 +2472,13 @@ const deserializeAws_json1_1GetMetricPolicyOutput = (output: any, context: __Ser
 
 const deserializeAws_json1_1InternalServerError = (output: any, context: __SerdeContext): InternalServerError => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2488,7 +2488,7 @@ const deserializeAws_json1_1ListContainersOutput = (output: any, context: __Serd
       output.Containers !== undefined && output.Containers !== null
         ? deserializeAws_json1_1ContainerList(output.Containers, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -2506,10 +2506,7 @@ const deserializeAws_json1_1ListTagsForResourceOutput = (
 
 const deserializeAws_json1_1MetricPolicy = (output: any, context: __SerdeContext): MetricPolicy => {
   return {
-    ContainerLevelMetrics:
-      output.ContainerLevelMetrics !== undefined && output.ContainerLevelMetrics !== null
-        ? output.ContainerLevelMetrics
-        : undefined,
+    ContainerLevelMetrics: __expectString(output.ContainerLevelMetrics),
     MetricPolicyRules:
       output.MetricPolicyRules !== undefined && output.MetricPolicyRules !== null
         ? deserializeAws_json1_1MetricPolicyRules(output.MetricPolicyRules, context)
@@ -2519,9 +2516,8 @@ const deserializeAws_json1_1MetricPolicy = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_1MetricPolicyRule = (output: any, context: __SerdeContext): MetricPolicyRule => {
   return {
-    ObjectGroup: output.ObjectGroup !== undefined && output.ObjectGroup !== null ? output.ObjectGroup : undefined,
-    ObjectGroupName:
-      output.ObjectGroupName !== undefined && output.ObjectGroupName !== null ? output.ObjectGroupName : undefined,
+    ObjectGroup: __expectString(output.ObjectGroup),
+    ObjectGroupName: __expectString(output.ObjectGroupName),
   } as any;
 };
 
@@ -2541,7 +2537,7 @@ const deserializeAws_json1_1PolicyNotFoundException = (
   context: __SerdeContext
 ): PolicyNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2583,8 +2579,8 @@ const deserializeAws_json1_1StopAccessLoggingOutput = (
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 

--- a/clients/client-mediatailor/protocols/Aws_restJson1.ts
+++ b/clients/client-mediatailor/protocols/Aws_restJson1.ts
@@ -96,6 +96,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -1200,13 +1203,13 @@ export const deserializeAws_restJson1CreateChannelCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.ChannelName !== undefined && data.ChannelName !== null) {
-    contents.ChannelName = data.ChannelName;
+    contents.ChannelName = __expectString(data.ChannelName);
   }
   if (data.ChannelState !== undefined && data.ChannelState !== null) {
-    contents.ChannelState = data.ChannelState;
+    contents.ChannelState = __expectString(data.ChannelState);
   }
   if (data.CreationTime !== undefined && data.CreationTime !== null) {
     contents.CreationTime = new Date(Math.round(data.CreationTime * 1000));
@@ -1218,7 +1221,7 @@ export const deserializeAws_restJson1CreateChannelCommand = async (
     contents.Outputs = deserializeAws_restJson1ResponseOutputs(data.Outputs, context);
   }
   if (data.PlaybackMode !== undefined && data.PlaybackMode !== null) {
-    contents.PlaybackMode = data.PlaybackMode;
+    contents.PlaybackMode = __expectString(data.PlaybackMode);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1__mapOf__string(data.tags, context);
@@ -1277,22 +1280,22 @@ export const deserializeAws_restJson1CreateProgramCommand = async (
     contents.AdBreaks = deserializeAws_restJson1__listOfAdBreak(data.AdBreaks, context);
   }
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.ChannelName !== undefined && data.ChannelName !== null) {
-    contents.ChannelName = data.ChannelName;
+    contents.ChannelName = __expectString(data.ChannelName);
   }
   if (data.CreationTime !== undefined && data.CreationTime !== null) {
     contents.CreationTime = new Date(Math.round(data.CreationTime * 1000));
   }
   if (data.ProgramName !== undefined && data.ProgramName !== null) {
-    contents.ProgramName = data.ProgramName;
+    contents.ProgramName = __expectString(data.ProgramName);
   }
   if (data.SourceLocationName !== undefined && data.SourceLocationName !== null) {
-    contents.SourceLocationName = data.SourceLocationName;
+    contents.SourceLocationName = __expectString(data.SourceLocationName);
   }
   if (data.VodSourceName !== undefined && data.VodSourceName !== null) {
-    contents.VodSourceName = data.VodSourceName;
+    contents.VodSourceName = __expectString(data.VodSourceName);
   }
   return Promise.resolve(contents);
 };
@@ -1349,7 +1352,7 @@ export const deserializeAws_restJson1CreateSourceLocationCommand = async (
     contents.AccessConfiguration = deserializeAws_restJson1AccessConfiguration(data.AccessConfiguration, context);
   }
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationTime !== undefined && data.CreationTime !== null) {
     contents.CreationTime = new Date(Math.round(data.CreationTime * 1000));
@@ -1367,7 +1370,7 @@ export const deserializeAws_restJson1CreateSourceLocationCommand = async (
     contents.LastModifiedTime = new Date(Math.round(data.LastModifiedTime * 1000));
   }
   if (data.SourceLocationName !== undefined && data.SourceLocationName !== null) {
-    contents.SourceLocationName = data.SourceLocationName;
+    contents.SourceLocationName = __expectString(data.SourceLocationName);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1__mapOf__string(data.tags, context);
@@ -1423,7 +1426,7 @@ export const deserializeAws_restJson1CreateVodSourceCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationTime !== undefined && data.CreationTime !== null) {
     contents.CreationTime = new Date(Math.round(data.CreationTime * 1000));
@@ -1438,13 +1441,13 @@ export const deserializeAws_restJson1CreateVodSourceCommand = async (
     contents.LastModifiedTime = new Date(Math.round(data.LastModifiedTime * 1000));
   }
   if (data.SourceLocationName !== undefined && data.SourceLocationName !== null) {
-    contents.SourceLocationName = data.SourceLocationName;
+    contents.SourceLocationName = __expectString(data.SourceLocationName);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1__mapOf__string(data.tags, context);
   }
   if (data.VodSourceName !== undefined && data.VodSourceName !== null) {
-    contents.VodSourceName = data.VodSourceName;
+    contents.VodSourceName = __expectString(data.VodSourceName);
   }
   return Promise.resolve(contents);
 };
@@ -1756,13 +1759,13 @@ export const deserializeAws_restJson1DescribeChannelCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.ChannelName !== undefined && data.ChannelName !== null) {
-    contents.ChannelName = data.ChannelName;
+    contents.ChannelName = __expectString(data.ChannelName);
   }
   if (data.ChannelState !== undefined && data.ChannelState !== null) {
-    contents.ChannelState = data.ChannelState;
+    contents.ChannelState = __expectString(data.ChannelState);
   }
   if (data.CreationTime !== undefined && data.CreationTime !== null) {
     contents.CreationTime = new Date(Math.round(data.CreationTime * 1000));
@@ -1774,7 +1777,7 @@ export const deserializeAws_restJson1DescribeChannelCommand = async (
     contents.Outputs = deserializeAws_restJson1ResponseOutputs(data.Outputs, context);
   }
   if (data.PlaybackMode !== undefined && data.PlaybackMode !== null) {
-    contents.PlaybackMode = data.PlaybackMode;
+    contents.PlaybackMode = __expectString(data.PlaybackMode);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1__mapOf__string(data.tags, context);
@@ -1833,22 +1836,22 @@ export const deserializeAws_restJson1DescribeProgramCommand = async (
     contents.AdBreaks = deserializeAws_restJson1__listOfAdBreak(data.AdBreaks, context);
   }
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.ChannelName !== undefined && data.ChannelName !== null) {
-    contents.ChannelName = data.ChannelName;
+    contents.ChannelName = __expectString(data.ChannelName);
   }
   if (data.CreationTime !== undefined && data.CreationTime !== null) {
     contents.CreationTime = new Date(Math.round(data.CreationTime * 1000));
   }
   if (data.ProgramName !== undefined && data.ProgramName !== null) {
-    contents.ProgramName = data.ProgramName;
+    contents.ProgramName = __expectString(data.ProgramName);
   }
   if (data.SourceLocationName !== undefined && data.SourceLocationName !== null) {
-    contents.SourceLocationName = data.SourceLocationName;
+    contents.SourceLocationName = __expectString(data.SourceLocationName);
   }
   if (data.VodSourceName !== undefined && data.VodSourceName !== null) {
-    contents.VodSourceName = data.VodSourceName;
+    contents.VodSourceName = __expectString(data.VodSourceName);
   }
   return Promise.resolve(contents);
 };
@@ -1905,7 +1908,7 @@ export const deserializeAws_restJson1DescribeSourceLocationCommand = async (
     contents.AccessConfiguration = deserializeAws_restJson1AccessConfiguration(data.AccessConfiguration, context);
   }
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationTime !== undefined && data.CreationTime !== null) {
     contents.CreationTime = new Date(Math.round(data.CreationTime * 1000));
@@ -1923,7 +1926,7 @@ export const deserializeAws_restJson1DescribeSourceLocationCommand = async (
     contents.LastModifiedTime = new Date(Math.round(data.LastModifiedTime * 1000));
   }
   if (data.SourceLocationName !== undefined && data.SourceLocationName !== null) {
-    contents.SourceLocationName = data.SourceLocationName;
+    contents.SourceLocationName = __expectString(data.SourceLocationName);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1__mapOf__string(data.tags, context);
@@ -1979,7 +1982,7 @@ export const deserializeAws_restJson1DescribeVodSourceCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationTime !== undefined && data.CreationTime !== null) {
     contents.CreationTime = new Date(Math.round(data.CreationTime * 1000));
@@ -1994,13 +1997,13 @@ export const deserializeAws_restJson1DescribeVodSourceCommand = async (
     contents.LastModifiedTime = new Date(Math.round(data.LastModifiedTime * 1000));
   }
   if (data.SourceLocationName !== undefined && data.SourceLocationName !== null) {
-    contents.SourceLocationName = data.SourceLocationName;
+    contents.SourceLocationName = __expectString(data.SourceLocationName);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1__mapOf__string(data.tags, context);
   }
   if (data.VodSourceName !== undefined && data.VodSourceName !== null) {
-    contents.VodSourceName = data.VodSourceName;
+    contents.VodSourceName = __expectString(data.VodSourceName);
   }
   return Promise.resolve(contents);
 };
@@ -2047,7 +2050,7 @@ export const deserializeAws_restJson1GetChannelPolicyCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Policy !== undefined && data.Policy !== null) {
-    contents.Policy = data.Policy;
+    contents.Policy = __expectString(data.Policy);
   }
   return Promise.resolve(contents);
 };
@@ -2098,7 +2101,7 @@ export const deserializeAws_restJson1GetChannelScheduleCommand = async (
     contents.Items = deserializeAws_restJson1__listOfScheduleEntry(data.Items, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2162,7 +2165,7 @@ export const deserializeAws_restJson1GetPlaybackConfigurationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AdDecisionServerUrl !== undefined && data.AdDecisionServerUrl !== null) {
-    contents.AdDecisionServerUrl = data.AdDecisionServerUrl;
+    contents.AdDecisionServerUrl = __expectString(data.AdDecisionServerUrl);
   }
   if (data.AvailSuppression !== undefined && data.AvailSuppression !== null) {
     contents.AvailSuppression = deserializeAws_restJson1AvailSuppression(data.AvailSuppression, context);
@@ -2198,31 +2201,31 @@ export const deserializeAws_restJson1GetPlaybackConfigurationCommand = async (
     );
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.PersonalizationThresholdSeconds !== undefined && data.PersonalizationThresholdSeconds !== null) {
-    contents.PersonalizationThresholdSeconds = data.PersonalizationThresholdSeconds;
+    contents.PersonalizationThresholdSeconds = __expectNumber(data.PersonalizationThresholdSeconds);
   }
   if (data.PlaybackConfigurationArn !== undefined && data.PlaybackConfigurationArn !== null) {
-    contents.PlaybackConfigurationArn = data.PlaybackConfigurationArn;
+    contents.PlaybackConfigurationArn = __expectString(data.PlaybackConfigurationArn);
   }
   if (data.PlaybackEndpointPrefix !== undefined && data.PlaybackEndpointPrefix !== null) {
-    contents.PlaybackEndpointPrefix = data.PlaybackEndpointPrefix;
+    contents.PlaybackEndpointPrefix = __expectString(data.PlaybackEndpointPrefix);
   }
   if (data.SessionInitializationEndpointPrefix !== undefined && data.SessionInitializationEndpointPrefix !== null) {
-    contents.SessionInitializationEndpointPrefix = data.SessionInitializationEndpointPrefix;
+    contents.SessionInitializationEndpointPrefix = __expectString(data.SessionInitializationEndpointPrefix);
   }
   if (data.SlateAdUrl !== undefined && data.SlateAdUrl !== null) {
-    contents.SlateAdUrl = data.SlateAdUrl;
+    contents.SlateAdUrl = __expectString(data.SlateAdUrl);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1__mapOf__string(data.tags, context);
   }
   if (data.TranscodeProfileName !== undefined && data.TranscodeProfileName !== null) {
-    contents.TranscodeProfileName = data.TranscodeProfileName;
+    contents.TranscodeProfileName = __expectString(data.TranscodeProfileName);
   }
   if (data.VideoContentSourceUrl !== undefined && data.VideoContentSourceUrl !== null) {
-    contents.VideoContentSourceUrl = data.VideoContentSourceUrl;
+    contents.VideoContentSourceUrl = __expectString(data.VideoContentSourceUrl);
   }
   return Promise.resolve(contents);
 };
@@ -2273,7 +2276,7 @@ export const deserializeAws_restJson1ListChannelsCommand = async (
     contents.Items = deserializeAws_restJson1__listOfChannel(data.Items, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2324,7 +2327,7 @@ export const deserializeAws_restJson1ListPlaybackConfigurationsCommand = async (
     contents.Items = deserializeAws_restJson1__listOfPlaybackConfiguration(data.Items, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2375,7 +2378,7 @@ export const deserializeAws_restJson1ListSourceLocationsCommand = async (
     contents.Items = deserializeAws_restJson1__listOfSourceLocation(data.Items, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2481,7 +2484,7 @@ export const deserializeAws_restJson1ListVodSourcesCommand = async (
     contents.Items = deserializeAws_restJson1__listOfVodSource(data.Items, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2588,7 +2591,7 @@ export const deserializeAws_restJson1PutPlaybackConfigurationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AdDecisionServerUrl !== undefined && data.AdDecisionServerUrl !== null) {
-    contents.AdDecisionServerUrl = data.AdDecisionServerUrl;
+    contents.AdDecisionServerUrl = __expectString(data.AdDecisionServerUrl);
   }
   if (data.AvailSuppression !== undefined && data.AvailSuppression !== null) {
     contents.AvailSuppression = deserializeAws_restJson1AvailSuppression(data.AvailSuppression, context);
@@ -2624,31 +2627,31 @@ export const deserializeAws_restJson1PutPlaybackConfigurationCommand = async (
     );
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.PersonalizationThresholdSeconds !== undefined && data.PersonalizationThresholdSeconds !== null) {
-    contents.PersonalizationThresholdSeconds = data.PersonalizationThresholdSeconds;
+    contents.PersonalizationThresholdSeconds = __expectNumber(data.PersonalizationThresholdSeconds);
   }
   if (data.PlaybackConfigurationArn !== undefined && data.PlaybackConfigurationArn !== null) {
-    contents.PlaybackConfigurationArn = data.PlaybackConfigurationArn;
+    contents.PlaybackConfigurationArn = __expectString(data.PlaybackConfigurationArn);
   }
   if (data.PlaybackEndpointPrefix !== undefined && data.PlaybackEndpointPrefix !== null) {
-    contents.PlaybackEndpointPrefix = data.PlaybackEndpointPrefix;
+    contents.PlaybackEndpointPrefix = __expectString(data.PlaybackEndpointPrefix);
   }
   if (data.SessionInitializationEndpointPrefix !== undefined && data.SessionInitializationEndpointPrefix !== null) {
-    contents.SessionInitializationEndpointPrefix = data.SessionInitializationEndpointPrefix;
+    contents.SessionInitializationEndpointPrefix = __expectString(data.SessionInitializationEndpointPrefix);
   }
   if (data.SlateAdUrl !== undefined && data.SlateAdUrl !== null) {
-    contents.SlateAdUrl = data.SlateAdUrl;
+    contents.SlateAdUrl = __expectString(data.SlateAdUrl);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1__mapOf__string(data.tags, context);
   }
   if (data.TranscodeProfileName !== undefined && data.TranscodeProfileName !== null) {
-    contents.TranscodeProfileName = data.TranscodeProfileName;
+    contents.TranscodeProfileName = __expectString(data.TranscodeProfileName);
   }
   if (data.VideoContentSourceUrl !== undefined && data.VideoContentSourceUrl !== null) {
-    contents.VideoContentSourceUrl = data.VideoContentSourceUrl;
+    contents.VideoContentSourceUrl = __expectString(data.VideoContentSourceUrl);
   }
   return Promise.resolve(contents);
 };
@@ -2890,13 +2893,13 @@ export const deserializeAws_restJson1UpdateChannelCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.ChannelName !== undefined && data.ChannelName !== null) {
-    contents.ChannelName = data.ChannelName;
+    contents.ChannelName = __expectString(data.ChannelName);
   }
   if (data.ChannelState !== undefined && data.ChannelState !== null) {
-    contents.ChannelState = data.ChannelState;
+    contents.ChannelState = __expectString(data.ChannelState);
   }
   if (data.CreationTime !== undefined && data.CreationTime !== null) {
     contents.CreationTime = new Date(Math.round(data.CreationTime * 1000));
@@ -2908,7 +2911,7 @@ export const deserializeAws_restJson1UpdateChannelCommand = async (
     contents.Outputs = deserializeAws_restJson1ResponseOutputs(data.Outputs, context);
   }
   if (data.PlaybackMode !== undefined && data.PlaybackMode !== null) {
-    contents.PlaybackMode = data.PlaybackMode;
+    contents.PlaybackMode = __expectString(data.PlaybackMode);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1__mapOf__string(data.tags, context);
@@ -2968,7 +2971,7 @@ export const deserializeAws_restJson1UpdateSourceLocationCommand = async (
     contents.AccessConfiguration = deserializeAws_restJson1AccessConfiguration(data.AccessConfiguration, context);
   }
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationTime !== undefined && data.CreationTime !== null) {
     contents.CreationTime = new Date(Math.round(data.CreationTime * 1000));
@@ -2986,7 +2989,7 @@ export const deserializeAws_restJson1UpdateSourceLocationCommand = async (
     contents.LastModifiedTime = new Date(Math.round(data.LastModifiedTime * 1000));
   }
   if (data.SourceLocationName !== undefined && data.SourceLocationName !== null) {
-    contents.SourceLocationName = data.SourceLocationName;
+    contents.SourceLocationName = __expectString(data.SourceLocationName);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1__mapOf__string(data.tags, context);
@@ -3042,7 +3045,7 @@ export const deserializeAws_restJson1UpdateVodSourceCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationTime !== undefined && data.CreationTime !== null) {
     contents.CreationTime = new Date(Math.round(data.CreationTime * 1000));
@@ -3057,13 +3060,13 @@ export const deserializeAws_restJson1UpdateVodSourceCommand = async (
     contents.LastModifiedTime = new Date(Math.round(data.LastModifiedTime * 1000));
   }
   if (data.SourceLocationName !== undefined && data.SourceLocationName !== null) {
-    contents.SourceLocationName = data.SourceLocationName;
+    contents.SourceLocationName = __expectString(data.SourceLocationName);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1__mapOf__string(data.tags, context);
   }
   if (data.VodSourceName !== undefined && data.VodSourceName !== null) {
-    contents.VodSourceName = data.VodSourceName;
+    contents.VodSourceName = __expectString(data.VodSourceName);
   }
   return Promise.resolve(contents);
 };
@@ -3109,7 +3112,7 @@ const deserializeAws_restJson1BadRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3457,14 +3460,14 @@ const deserializeAws_restJson1__mapOf__string = (output: any, context: __SerdeCo
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1AccessConfiguration = (output: any, context: __SerdeContext): AccessConfiguration => {
   return {
-    AccessType: output.AccessType !== undefined && output.AccessType !== null ? output.AccessType : undefined,
+    AccessType: __expectString(output.AccessType),
     SecretsManagerAccessTokenConfiguration:
       output.SecretsManagerAccessTokenConfiguration !== undefined &&
       output.SecretsManagerAccessTokenConfiguration !== null
@@ -3478,8 +3481,8 @@ const deserializeAws_restJson1AccessConfiguration = (output: any, context: __Ser
 
 const deserializeAws_restJson1AdBreak = (output: any, context: __SerdeContext): AdBreak => {
   return {
-    MessageType: output.MessageType !== undefined && output.MessageType !== null ? output.MessageType : undefined,
-    OffsetMillis: output.OffsetMillis !== undefined && output.OffsetMillis !== null ? output.OffsetMillis : undefined,
+    MessageType: __expectString(output.MessageType),
+    OffsetMillis: __expectNumber(output.OffsetMillis),
     Slate:
       output.Slate !== undefined && output.Slate !== null
         ? deserializeAws_restJson1SlateSource(output.Slate, context)
@@ -3493,42 +3496,36 @@ const deserializeAws_restJson1AdBreak = (output: any, context: __SerdeContext): 
 
 const deserializeAws_restJson1AdMarkerPassthrough = (output: any, context: __SerdeContext): AdMarkerPassthrough => {
   return {
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
+    Enabled: __expectBoolean(output.Enabled),
   } as any;
 };
 
 const deserializeAws_restJson1AvailSuppression = (output: any, context: __SerdeContext): AvailSuppression => {
   return {
-    Mode: output.Mode !== undefined && output.Mode !== null ? output.Mode : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Mode: __expectString(output.Mode),
+    Value: __expectString(output.Value),
   } as any;
 };
 
 const deserializeAws_restJson1Bumper = (output: any, context: __SerdeContext): Bumper => {
   return {
-    EndUrl: output.EndUrl !== undefined && output.EndUrl !== null ? output.EndUrl : undefined,
-    StartUrl: output.StartUrl !== undefined && output.StartUrl !== null ? output.StartUrl : undefined,
+    EndUrl: __expectString(output.EndUrl),
+    StartUrl: __expectString(output.StartUrl),
   } as any;
 };
 
 const deserializeAws_restJson1CdnConfiguration = (output: any, context: __SerdeContext): CdnConfiguration => {
   return {
-    AdSegmentUrlPrefix:
-      output.AdSegmentUrlPrefix !== undefined && output.AdSegmentUrlPrefix !== null
-        ? output.AdSegmentUrlPrefix
-        : undefined,
-    ContentSegmentUrlPrefix:
-      output.ContentSegmentUrlPrefix !== undefined && output.ContentSegmentUrlPrefix !== null
-        ? output.ContentSegmentUrlPrefix
-        : undefined,
+    AdSegmentUrlPrefix: __expectString(output.AdSegmentUrlPrefix),
+    ContentSegmentUrlPrefix: __expectString(output.ContentSegmentUrlPrefix),
   } as any;
 };
 
 const deserializeAws_restJson1Channel = (output: any, context: __SerdeContext): Channel => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    ChannelName: output.ChannelName !== undefined && output.ChannelName !== null ? output.ChannelName : undefined,
-    ChannelState: output.ChannelState !== undefined && output.ChannelState !== null ? output.ChannelState : undefined,
+    Arn: __expectString(output.Arn),
+    ChannelName: __expectString(output.ChannelName),
+    ChannelState: __expectString(output.ChannelState),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -3541,7 +3538,7 @@ const deserializeAws_restJson1Channel = (output: any, context: __SerdeContext): 
       output.Outputs !== undefined && output.Outputs !== null
         ? deserializeAws_restJson1ResponseOutputs(output.Outputs, context)
         : undefined,
-    PlaybackMode: output.PlaybackMode !== undefined && output.PlaybackMode !== null ? output.PlaybackMode : undefined,
+    PlaybackMode: __expectString(output.PlaybackMode),
     Tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1__mapOf__string(output.tags, context)
@@ -3569,36 +3566,18 @@ const deserializeAws_restJson1ConfigurationAliasesResponse = (
 
 const deserializeAws_restJson1DashConfiguration = (output: any, context: __SerdeContext): DashConfiguration => {
   return {
-    ManifestEndpointPrefix:
-      output.ManifestEndpointPrefix !== undefined && output.ManifestEndpointPrefix !== null
-        ? output.ManifestEndpointPrefix
-        : undefined,
-    MpdLocation: output.MpdLocation !== undefined && output.MpdLocation !== null ? output.MpdLocation : undefined,
-    OriginManifestType:
-      output.OriginManifestType !== undefined && output.OriginManifestType !== null
-        ? output.OriginManifestType
-        : undefined,
+    ManifestEndpointPrefix: __expectString(output.ManifestEndpointPrefix),
+    MpdLocation: __expectString(output.MpdLocation),
+    OriginManifestType: __expectString(output.OriginManifestType),
   } as any;
 };
 
 const deserializeAws_restJson1DashPlaylistSettings = (output: any, context: __SerdeContext): DashPlaylistSettings => {
   return {
-    ManifestWindowSeconds:
-      output.ManifestWindowSeconds !== undefined && output.ManifestWindowSeconds !== null
-        ? output.ManifestWindowSeconds
-        : undefined,
-    MinBufferTimeSeconds:
-      output.MinBufferTimeSeconds !== undefined && output.MinBufferTimeSeconds !== null
-        ? output.MinBufferTimeSeconds
-        : undefined,
-    MinUpdatePeriodSeconds:
-      output.MinUpdatePeriodSeconds !== undefined && output.MinUpdatePeriodSeconds !== null
-        ? output.MinUpdatePeriodSeconds
-        : undefined,
-    SuggestedPresentationDelaySeconds:
-      output.SuggestedPresentationDelaySeconds !== undefined && output.SuggestedPresentationDelaySeconds !== null
-        ? output.SuggestedPresentationDelaySeconds
-        : undefined,
+    ManifestWindowSeconds: __expectNumber(output.ManifestWindowSeconds),
+    MinBufferTimeSeconds: __expectNumber(output.MinBufferTimeSeconds),
+    MinUpdatePeriodSeconds: __expectNumber(output.MinUpdatePeriodSeconds),
+    SuggestedPresentationDelaySeconds: __expectNumber(output.SuggestedPresentationDelaySeconds),
   } as any;
 };
 
@@ -3607,31 +3586,25 @@ const deserializeAws_restJson1DefaultSegmentDeliveryConfiguration = (
   context: __SerdeContext
 ): DefaultSegmentDeliveryConfiguration => {
   return {
-    BaseUrl: output.BaseUrl !== undefined && output.BaseUrl !== null ? output.BaseUrl : undefined,
+    BaseUrl: __expectString(output.BaseUrl),
   } as any;
 };
 
 const deserializeAws_restJson1HlsConfiguration = (output: any, context: __SerdeContext): HlsConfiguration => {
   return {
-    ManifestEndpointPrefix:
-      output.ManifestEndpointPrefix !== undefined && output.ManifestEndpointPrefix !== null
-        ? output.ManifestEndpointPrefix
-        : undefined,
+    ManifestEndpointPrefix: __expectString(output.ManifestEndpointPrefix),
   } as any;
 };
 
 const deserializeAws_restJson1HlsPlaylistSettings = (output: any, context: __SerdeContext): HlsPlaylistSettings => {
   return {
-    ManifestWindowSeconds:
-      output.ManifestWindowSeconds !== undefined && output.ManifestWindowSeconds !== null
-        ? output.ManifestWindowSeconds
-        : undefined,
+    ManifestWindowSeconds: __expectNumber(output.ManifestWindowSeconds),
   } as any;
 };
 
 const deserializeAws_restJson1HttpConfiguration = (output: any, context: __SerdeContext): HttpConfiguration => {
   return {
-    BaseUrl: output.BaseUrl !== undefined && output.BaseUrl !== null ? output.BaseUrl : undefined,
+    BaseUrl: __expectString(output.BaseUrl),
   } as any;
 };
 
@@ -3640,9 +3613,9 @@ const deserializeAws_restJson1HttpPackageConfiguration = (
   context: __SerdeContext
 ): HttpPackageConfiguration => {
   return {
-    Path: output.Path !== undefined && output.Path !== null ? output.Path : undefined,
-    SourceGroup: output.SourceGroup !== undefined && output.SourceGroup !== null ? output.SourceGroup : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Path: __expectString(output.Path),
+    SourceGroup: __expectString(output.SourceGroup),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -3665,14 +3638,8 @@ const deserializeAws_restJson1LivePreRollConfiguration = (
   context: __SerdeContext
 ): LivePreRollConfiguration => {
   return {
-    AdDecisionServerUrl:
-      output.AdDecisionServerUrl !== undefined && output.AdDecisionServerUrl !== null
-        ? output.AdDecisionServerUrl
-        : undefined,
-    MaxDurationSeconds:
-      output.MaxDurationSeconds !== undefined && output.MaxDurationSeconds !== null
-        ? output.MaxDurationSeconds
-        : undefined,
+    AdDecisionServerUrl: __expectString(output.AdDecisionServerUrl),
+    MaxDurationSeconds: __expectNumber(output.MaxDurationSeconds),
   } as any;
 };
 
@@ -3690,10 +3657,7 @@ const deserializeAws_restJson1ManifestProcessingRules = (
 
 const deserializeAws_restJson1PlaybackConfiguration = (output: any, context: __SerdeContext): PlaybackConfiguration => {
   return {
-    AdDecisionServerUrl:
-      output.AdDecisionServerUrl !== undefined && output.AdDecisionServerUrl !== null
-        ? output.AdDecisionServerUrl
-        : undefined,
+    AdDecisionServerUrl: __expectString(output.AdDecisionServerUrl),
     AvailSuppression:
       output.AvailSuppression !== undefined && output.AvailSuppression !== null
         ? deserializeAws_restJson1AvailSuppression(output.AvailSuppression, context)
@@ -3726,36 +3690,18 @@ const deserializeAws_restJson1PlaybackConfiguration = (output: any, context: __S
       output.ManifestProcessingRules !== undefined && output.ManifestProcessingRules !== null
         ? deserializeAws_restJson1ManifestProcessingRules(output.ManifestProcessingRules, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    PersonalizationThresholdSeconds:
-      output.PersonalizationThresholdSeconds !== undefined && output.PersonalizationThresholdSeconds !== null
-        ? output.PersonalizationThresholdSeconds
-        : undefined,
-    PlaybackConfigurationArn:
-      output.PlaybackConfigurationArn !== undefined && output.PlaybackConfigurationArn !== null
-        ? output.PlaybackConfigurationArn
-        : undefined,
-    PlaybackEndpointPrefix:
-      output.PlaybackEndpointPrefix !== undefined && output.PlaybackEndpointPrefix !== null
-        ? output.PlaybackEndpointPrefix
-        : undefined,
-    SessionInitializationEndpointPrefix:
-      output.SessionInitializationEndpointPrefix !== undefined && output.SessionInitializationEndpointPrefix !== null
-        ? output.SessionInitializationEndpointPrefix
-        : undefined,
-    SlateAdUrl: output.SlateAdUrl !== undefined && output.SlateAdUrl !== null ? output.SlateAdUrl : undefined,
+    Name: __expectString(output.Name),
+    PersonalizationThresholdSeconds: __expectNumber(output.PersonalizationThresholdSeconds),
+    PlaybackConfigurationArn: __expectString(output.PlaybackConfigurationArn),
+    PlaybackEndpointPrefix: __expectString(output.PlaybackEndpointPrefix),
+    SessionInitializationEndpointPrefix: __expectString(output.SessionInitializationEndpointPrefix),
+    SlateAdUrl: __expectString(output.SlateAdUrl),
     Tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1__mapOf__string(output.tags, context)
         : undefined,
-    TranscodeProfileName:
-      output.TranscodeProfileName !== undefined && output.TranscodeProfileName !== null
-        ? output.TranscodeProfileName
-        : undefined,
-    VideoContentSourceUrl:
-      output.VideoContentSourceUrl !== undefined && output.VideoContentSourceUrl !== null
-        ? output.VideoContentSourceUrl
-        : undefined,
+    TranscodeProfileName: __expectString(output.TranscodeProfileName),
+    VideoContentSourceUrl: __expectString(output.VideoContentSourceUrl),
   } as any;
 };
 
@@ -3769,9 +3715,9 @@ const deserializeAws_restJson1ResponseOutputItem = (output: any, context: __Serd
       output.HlsPlaylistSettings !== undefined && output.HlsPlaylistSettings !== null
         ? deserializeAws_restJson1HlsPlaylistSettings(output.HlsPlaylistSettings, context)
         : undefined,
-    ManifestName: output.ManifestName !== undefined && output.ManifestName !== null ? output.ManifestName : undefined,
-    PlaybackUrl: output.PlaybackUrl !== undefined && output.PlaybackUrl !== null ? output.PlaybackUrl : undefined,
-    SourceGroup: output.SourceGroup !== undefined && output.SourceGroup !== null ? output.SourceGroup : undefined,
+    ManifestName: __expectString(output.ManifestName),
+    PlaybackUrl: __expectString(output.PlaybackUrl),
+    SourceGroup: __expectString(output.SourceGroup),
   } as any;
 };
 
@@ -3788,23 +3734,16 @@ const deserializeAws_restJson1ResponseOutputs = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1ScheduleEntry = (output: any, context: __SerdeContext): ScheduleEntry => {
   return {
-    ApproximateDurationSeconds:
-      output.ApproximateDurationSeconds !== undefined && output.ApproximateDurationSeconds !== null
-        ? output.ApproximateDurationSeconds
-        : undefined,
+    ApproximateDurationSeconds: __expectNumber(output.ApproximateDurationSeconds),
     ApproximateStartTime:
       output.ApproximateStartTime !== undefined && output.ApproximateStartTime !== null
         ? new Date(Math.round(output.ApproximateStartTime * 1000))
         : undefined,
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    ChannelName: output.ChannelName !== undefined && output.ChannelName !== null ? output.ChannelName : undefined,
-    ProgramName: output.ProgramName !== undefined && output.ProgramName !== null ? output.ProgramName : undefined,
-    SourceLocationName:
-      output.SourceLocationName !== undefined && output.SourceLocationName !== null
-        ? output.SourceLocationName
-        : undefined,
-    VodSourceName:
-      output.VodSourceName !== undefined && output.VodSourceName !== null ? output.VodSourceName : undefined,
+    Arn: __expectString(output.Arn),
+    ChannelName: __expectString(output.ChannelName),
+    ProgramName: __expectString(output.ProgramName),
+    SourceLocationName: __expectString(output.SourceLocationName),
+    VodSourceName: __expectString(output.VodSourceName),
   } as any;
 };
 
@@ -3813,21 +3752,16 @@ const deserializeAws_restJson1SecretsManagerAccessTokenConfiguration = (
   context: __SerdeContext
 ): SecretsManagerAccessTokenConfiguration => {
   return {
-    HeaderName: output.HeaderName !== undefined && output.HeaderName !== null ? output.HeaderName : undefined,
-    SecretArn: output.SecretArn !== undefined && output.SecretArn !== null ? output.SecretArn : undefined,
-    SecretStringKey:
-      output.SecretStringKey !== undefined && output.SecretStringKey !== null ? output.SecretStringKey : undefined,
+    HeaderName: __expectString(output.HeaderName),
+    SecretArn: __expectString(output.SecretArn),
+    SecretStringKey: __expectString(output.SecretStringKey),
   } as any;
 };
 
 const deserializeAws_restJson1SlateSource = (output: any, context: __SerdeContext): SlateSource => {
   return {
-    SourceLocationName:
-      output.SourceLocationName !== undefined && output.SourceLocationName !== null
-        ? output.SourceLocationName
-        : undefined,
-    VodSourceName:
-      output.VodSourceName !== undefined && output.VodSourceName !== null ? output.VodSourceName : undefined,
+    SourceLocationName: __expectString(output.SourceLocationName),
+    VodSourceName: __expectString(output.VodSourceName),
   } as any;
 };
 
@@ -3837,7 +3771,7 @@ const deserializeAws_restJson1SourceLocation = (output: any, context: __SerdeCon
       output.AccessConfiguration !== undefined && output.AccessConfiguration !== null
         ? deserializeAws_restJson1AccessConfiguration(output.AccessConfiguration, context)
         : undefined,
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -3857,10 +3791,7 @@ const deserializeAws_restJson1SourceLocation = (output: any, context: __SerdeCon
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    SourceLocationName:
-      output.SourceLocationName !== undefined && output.SourceLocationName !== null
-        ? output.SourceLocationName
-        : undefined,
+    SourceLocationName: __expectString(output.SourceLocationName),
     Tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1__mapOf__string(output.tags, context)
@@ -3870,19 +3801,16 @@ const deserializeAws_restJson1SourceLocation = (output: any, context: __SerdeCon
 
 const deserializeAws_restJson1SpliceInsertMessage = (output: any, context: __SerdeContext): SpliceInsertMessage => {
   return {
-    AvailNum: output.AvailNum !== undefined && output.AvailNum !== null ? output.AvailNum : undefined,
-    AvailsExpected:
-      output.AvailsExpected !== undefined && output.AvailsExpected !== null ? output.AvailsExpected : undefined,
-    SpliceEventId:
-      output.SpliceEventId !== undefined && output.SpliceEventId !== null ? output.SpliceEventId : undefined,
-    UniqueProgramId:
-      output.UniqueProgramId !== undefined && output.UniqueProgramId !== null ? output.UniqueProgramId : undefined,
+    AvailNum: __expectNumber(output.AvailNum),
+    AvailsExpected: __expectNumber(output.AvailsExpected),
+    SpliceEventId: __expectNumber(output.SpliceEventId),
+    UniqueProgramId: __expectNumber(output.UniqueProgramId),
   } as any;
 };
 
 const deserializeAws_restJson1VodSource = (output: any, context: __SerdeContext): VodSource => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -3895,16 +3823,12 @@ const deserializeAws_restJson1VodSource = (output: any, context: __SerdeContext)
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    SourceLocationName:
-      output.SourceLocationName !== undefined && output.SourceLocationName !== null
-        ? output.SourceLocationName
-        : undefined,
+    SourceLocationName: __expectString(output.SourceLocationName),
     Tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1__mapOf__string(output.tags, context)
         : undefined,
-    VodSourceName:
-      output.VodSourceName !== undefined && output.VodSourceName !== null ? output.VodSourceName : undefined,
+    VodSourceName: __expectString(output.VodSourceName),
   } as any;
 };
 

--- a/clients/client-mgn/protocols/Aws_restJson1.ts
+++ b/clients/client-mgn/protocols/Aws_restJson1.ts
@@ -113,6 +113,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -944,13 +947,13 @@ export const deserializeAws_restJson1ChangeServerLifeCycleStateCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.dataReplicationInfo !== undefined && data.dataReplicationInfo !== null) {
     contents.dataReplicationInfo = deserializeAws_restJson1DataReplicationInfo(data.dataReplicationInfo, context);
   }
   if (data.isArchived !== undefined && data.isArchived !== null) {
-    contents.isArchived = data.isArchived;
+    contents.isArchived = __expectBoolean(data.isArchived);
   }
   if (data.launchedInstance !== undefined && data.launchedInstance !== null) {
     contents.launchedInstance = deserializeAws_restJson1LaunchedInstance(data.launchedInstance, context);
@@ -962,7 +965,7 @@ export const deserializeAws_restJson1ChangeServerLifeCycleStateCommand = async (
     contents.sourceProperties = deserializeAws_restJson1SourceProperties(data.sourceProperties, context);
   }
   if (data.sourceServerID !== undefined && data.sourceServerID !== null) {
-    contents.sourceServerID = data.sourceServerID;
+    contents.sourceServerID = __expectString(data.sourceServerID);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagsMap(data.tags, context);
@@ -1058,34 +1061,34 @@ export const deserializeAws_restJson1CreateReplicationConfigurationTemplateComma
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.associateDefaultSecurityGroup !== undefined && data.associateDefaultSecurityGroup !== null) {
-    contents.associateDefaultSecurityGroup = data.associateDefaultSecurityGroup;
+    contents.associateDefaultSecurityGroup = __expectBoolean(data.associateDefaultSecurityGroup);
   }
   if (data.bandwidthThrottling !== undefined && data.bandwidthThrottling !== null) {
-    contents.bandwidthThrottling = data.bandwidthThrottling;
+    contents.bandwidthThrottling = __expectNumber(data.bandwidthThrottling);
   }
   if (data.createPublicIP !== undefined && data.createPublicIP !== null) {
-    contents.createPublicIP = data.createPublicIP;
+    contents.createPublicIP = __expectBoolean(data.createPublicIP);
   }
   if (data.dataPlaneRouting !== undefined && data.dataPlaneRouting !== null) {
-    contents.dataPlaneRouting = data.dataPlaneRouting;
+    contents.dataPlaneRouting = __expectString(data.dataPlaneRouting);
   }
   if (data.defaultLargeStagingDiskType !== undefined && data.defaultLargeStagingDiskType !== null) {
-    contents.defaultLargeStagingDiskType = data.defaultLargeStagingDiskType;
+    contents.defaultLargeStagingDiskType = __expectString(data.defaultLargeStagingDiskType);
   }
   if (data.ebsEncryption !== undefined && data.ebsEncryption !== null) {
-    contents.ebsEncryption = data.ebsEncryption;
+    contents.ebsEncryption = __expectString(data.ebsEncryption);
   }
   if (data.ebsEncryptionKeyArn !== undefined && data.ebsEncryptionKeyArn !== null) {
-    contents.ebsEncryptionKeyArn = data.ebsEncryptionKeyArn;
+    contents.ebsEncryptionKeyArn = __expectString(data.ebsEncryptionKeyArn);
   }
   if (data.replicationConfigurationTemplateID !== undefined && data.replicationConfigurationTemplateID !== null) {
-    contents.replicationConfigurationTemplateID = data.replicationConfigurationTemplateID;
+    contents.replicationConfigurationTemplateID = __expectString(data.replicationConfigurationTemplateID);
   }
   if (data.replicationServerInstanceType !== undefined && data.replicationServerInstanceType !== null) {
-    contents.replicationServerInstanceType = data.replicationServerInstanceType;
+    contents.replicationServerInstanceType = __expectString(data.replicationServerInstanceType);
   }
   if (data.replicationServersSecurityGroupsIDs !== undefined && data.replicationServersSecurityGroupsIDs !== null) {
     contents.replicationServersSecurityGroupsIDs = deserializeAws_restJson1ReplicationServersSecurityGroupsIDs(
@@ -1094,7 +1097,7 @@ export const deserializeAws_restJson1CreateReplicationConfigurationTemplateComma
     );
   }
   if (data.stagingAreaSubnetId !== undefined && data.stagingAreaSubnetId !== null) {
-    contents.stagingAreaSubnetId = data.stagingAreaSubnetId;
+    contents.stagingAreaSubnetId = __expectString(data.stagingAreaSubnetId);
   }
   if (data.stagingAreaTags !== undefined && data.stagingAreaTags !== null) {
     contents.stagingAreaTags = deserializeAws_restJson1TagsMap(data.stagingAreaTags, context);
@@ -1103,7 +1106,7 @@ export const deserializeAws_restJson1CreateReplicationConfigurationTemplateComma
     contents.tags = deserializeAws_restJson1TagsMap(data.tags, context);
   }
   if (data.useDedicatedReplicationServer !== undefined && data.useDedicatedReplicationServer !== null) {
-    contents.useDedicatedReplicationServer = data.useDedicatedReplicationServer;
+    contents.useDedicatedReplicationServer = __expectBoolean(data.useDedicatedReplicationServer);
   }
   return Promise.resolve(contents);
 };
@@ -1371,7 +1374,7 @@ export const deserializeAws_restJson1DescribeJobLogItemsCommand = async (
     contents.items = deserializeAws_restJson1JobLogs(data.items, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1438,7 +1441,7 @@ export const deserializeAws_restJson1DescribeJobsCommand = async (
     contents.items = deserializeAws_restJson1JobsList(data.items, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1505,7 +1508,7 @@ export const deserializeAws_restJson1DescribeReplicationConfigurationTemplatesCo
     contents.items = deserializeAws_restJson1ReplicationConfigurationTemplates(data.items, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1580,7 +1583,7 @@ export const deserializeAws_restJson1DescribeSourceServersCommand = async (
     contents.items = deserializeAws_restJson1SourceServersList(data.items, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1650,13 +1653,13 @@ export const deserializeAws_restJson1DisconnectFromServiceCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.dataReplicationInfo !== undefined && data.dataReplicationInfo !== null) {
     contents.dataReplicationInfo = deserializeAws_restJson1DataReplicationInfo(data.dataReplicationInfo, context);
   }
   if (data.isArchived !== undefined && data.isArchived !== null) {
-    contents.isArchived = data.isArchived;
+    contents.isArchived = __expectBoolean(data.isArchived);
   }
   if (data.launchedInstance !== undefined && data.launchedInstance !== null) {
     contents.launchedInstance = deserializeAws_restJson1LaunchedInstance(data.launchedInstance, context);
@@ -1668,7 +1671,7 @@ export const deserializeAws_restJson1DisconnectFromServiceCommand = async (
     contents.sourceProperties = deserializeAws_restJson1SourceProperties(data.sourceProperties, context);
   }
   if (data.sourceServerID !== undefined && data.sourceServerID !== null) {
-    contents.sourceServerID = data.sourceServerID;
+    contents.sourceServerID = __expectString(data.sourceServerID);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagsMap(data.tags, context);
@@ -1749,13 +1752,13 @@ export const deserializeAws_restJson1FinalizeCutoverCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.dataReplicationInfo !== undefined && data.dataReplicationInfo !== null) {
     contents.dataReplicationInfo = deserializeAws_restJson1DataReplicationInfo(data.dataReplicationInfo, context);
   }
   if (data.isArchived !== undefined && data.isArchived !== null) {
-    contents.isArchived = data.isArchived;
+    contents.isArchived = __expectBoolean(data.isArchived);
   }
   if (data.launchedInstance !== undefined && data.launchedInstance !== null) {
     contents.launchedInstance = deserializeAws_restJson1LaunchedInstance(data.launchedInstance, context);
@@ -1767,7 +1770,7 @@ export const deserializeAws_restJson1FinalizeCutoverCommand = async (
     contents.sourceProperties = deserializeAws_restJson1SourceProperties(data.sourceProperties, context);
   }
   if (data.sourceServerID !== undefined && data.sourceServerID !== null) {
-    contents.sourceServerID = data.sourceServerID;
+    contents.sourceServerID = __expectString(data.sourceServerID);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagsMap(data.tags, context);
@@ -1856,28 +1859,28 @@ export const deserializeAws_restJson1GetLaunchConfigurationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.copyPrivateIp !== undefined && data.copyPrivateIp !== null) {
-    contents.copyPrivateIp = data.copyPrivateIp;
+    contents.copyPrivateIp = __expectBoolean(data.copyPrivateIp);
   }
   if (data.copyTags !== undefined && data.copyTags !== null) {
-    contents.copyTags = data.copyTags;
+    contents.copyTags = __expectBoolean(data.copyTags);
   }
   if (data.ec2LaunchTemplateID !== undefined && data.ec2LaunchTemplateID !== null) {
-    contents.ec2LaunchTemplateID = data.ec2LaunchTemplateID;
+    contents.ec2LaunchTemplateID = __expectString(data.ec2LaunchTemplateID);
   }
   if (data.launchDisposition !== undefined && data.launchDisposition !== null) {
-    contents.launchDisposition = data.launchDisposition;
+    contents.launchDisposition = __expectString(data.launchDisposition);
   }
   if (data.licensing !== undefined && data.licensing !== null) {
     contents.licensing = deserializeAws_restJson1Licensing(data.licensing, context);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.sourceServerID !== undefined && data.sourceServerID !== null) {
-    contents.sourceServerID = data.sourceServerID;
+    contents.sourceServerID = __expectString(data.sourceServerID);
   }
   if (data.targetInstanceTypeRightSizingMethod !== undefined && data.targetInstanceTypeRightSizingMethod !== null) {
-    contents.targetInstanceTypeRightSizingMethod = data.targetInstanceTypeRightSizingMethod;
+    contents.targetInstanceTypeRightSizingMethod = __expectString(data.targetInstanceTypeRightSizingMethod);
   }
   return Promise.resolve(contents);
 };
@@ -1954,28 +1957,28 @@ export const deserializeAws_restJson1GetReplicationConfigurationCommand = async 
   };
   const data: any = await parseBody(output.body, context);
   if (data.associateDefaultSecurityGroup !== undefined && data.associateDefaultSecurityGroup !== null) {
-    contents.associateDefaultSecurityGroup = data.associateDefaultSecurityGroup;
+    contents.associateDefaultSecurityGroup = __expectBoolean(data.associateDefaultSecurityGroup);
   }
   if (data.bandwidthThrottling !== undefined && data.bandwidthThrottling !== null) {
-    contents.bandwidthThrottling = data.bandwidthThrottling;
+    contents.bandwidthThrottling = __expectNumber(data.bandwidthThrottling);
   }
   if (data.createPublicIP !== undefined && data.createPublicIP !== null) {
-    contents.createPublicIP = data.createPublicIP;
+    contents.createPublicIP = __expectBoolean(data.createPublicIP);
   }
   if (data.dataPlaneRouting !== undefined && data.dataPlaneRouting !== null) {
-    contents.dataPlaneRouting = data.dataPlaneRouting;
+    contents.dataPlaneRouting = __expectString(data.dataPlaneRouting);
   }
   if (data.defaultLargeStagingDiskType !== undefined && data.defaultLargeStagingDiskType !== null) {
-    contents.defaultLargeStagingDiskType = data.defaultLargeStagingDiskType;
+    contents.defaultLargeStagingDiskType = __expectString(data.defaultLargeStagingDiskType);
   }
   if (data.ebsEncryption !== undefined && data.ebsEncryption !== null) {
-    contents.ebsEncryption = data.ebsEncryption;
+    contents.ebsEncryption = __expectString(data.ebsEncryption);
   }
   if (data.ebsEncryptionKeyArn !== undefined && data.ebsEncryptionKeyArn !== null) {
-    contents.ebsEncryptionKeyArn = data.ebsEncryptionKeyArn;
+    contents.ebsEncryptionKeyArn = __expectString(data.ebsEncryptionKeyArn);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.replicatedDisks !== undefined && data.replicatedDisks !== null) {
     contents.replicatedDisks = deserializeAws_restJson1ReplicationConfigurationReplicatedDisks(
@@ -1984,7 +1987,7 @@ export const deserializeAws_restJson1GetReplicationConfigurationCommand = async 
     );
   }
   if (data.replicationServerInstanceType !== undefined && data.replicationServerInstanceType !== null) {
-    contents.replicationServerInstanceType = data.replicationServerInstanceType;
+    contents.replicationServerInstanceType = __expectString(data.replicationServerInstanceType);
   }
   if (data.replicationServersSecurityGroupsIDs !== undefined && data.replicationServersSecurityGroupsIDs !== null) {
     contents.replicationServersSecurityGroupsIDs = deserializeAws_restJson1ReplicationServersSecurityGroupsIDs(
@@ -1993,16 +1996,16 @@ export const deserializeAws_restJson1GetReplicationConfigurationCommand = async 
     );
   }
   if (data.sourceServerID !== undefined && data.sourceServerID !== null) {
-    contents.sourceServerID = data.sourceServerID;
+    contents.sourceServerID = __expectString(data.sourceServerID);
   }
   if (data.stagingAreaSubnetId !== undefined && data.stagingAreaSubnetId !== null) {
-    contents.stagingAreaSubnetId = data.stagingAreaSubnetId;
+    contents.stagingAreaSubnetId = __expectString(data.stagingAreaSubnetId);
   }
   if (data.stagingAreaTags !== undefined && data.stagingAreaTags !== null) {
     contents.stagingAreaTags = deserializeAws_restJson1TagsMap(data.stagingAreaTags, context);
   }
   if (data.useDedicatedReplicationServer !== undefined && data.useDedicatedReplicationServer !== null) {
-    contents.useDedicatedReplicationServer = data.useDedicatedReplicationServer;
+    contents.useDedicatedReplicationServer = __expectBoolean(data.useDedicatedReplicationServer);
   }
   return Promise.resolve(contents);
 };
@@ -2218,13 +2221,13 @@ export const deserializeAws_restJson1MarkAsArchivedCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.dataReplicationInfo !== undefined && data.dataReplicationInfo !== null) {
     contents.dataReplicationInfo = deserializeAws_restJson1DataReplicationInfo(data.dataReplicationInfo, context);
   }
   if (data.isArchived !== undefined && data.isArchived !== null) {
-    contents.isArchived = data.isArchived;
+    contents.isArchived = __expectBoolean(data.isArchived);
   }
   if (data.launchedInstance !== undefined && data.launchedInstance !== null) {
     contents.launchedInstance = deserializeAws_restJson1LaunchedInstance(data.launchedInstance, context);
@@ -2236,7 +2239,7 @@ export const deserializeAws_restJson1MarkAsArchivedCommand = async (
     contents.sourceProperties = deserializeAws_restJson1SourceProperties(data.sourceProperties, context);
   }
   if (data.sourceServerID !== undefined && data.sourceServerID !== null) {
-    contents.sourceServerID = data.sourceServerID;
+    contents.sourceServerID = __expectString(data.sourceServerID);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagsMap(data.tags, context);
@@ -2317,13 +2320,13 @@ export const deserializeAws_restJson1RetryDataReplicationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.dataReplicationInfo !== undefined && data.dataReplicationInfo !== null) {
     contents.dataReplicationInfo = deserializeAws_restJson1DataReplicationInfo(data.dataReplicationInfo, context);
   }
   if (data.isArchived !== undefined && data.isArchived !== null) {
-    contents.isArchived = data.isArchived;
+    contents.isArchived = __expectBoolean(data.isArchived);
   }
   if (data.launchedInstance !== undefined && data.launchedInstance !== null) {
     contents.launchedInstance = deserializeAws_restJson1LaunchedInstance(data.launchedInstance, context);
@@ -2335,7 +2338,7 @@ export const deserializeAws_restJson1RetryDataReplicationCommand = async (
     contents.sourceProperties = deserializeAws_restJson1SourceProperties(data.sourceProperties, context);
   }
   if (data.sourceServerID !== undefined && data.sourceServerID !== null) {
-    contents.sourceServerID = data.sourceServerID;
+    contents.sourceServerID = __expectString(data.sourceServerID);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagsMap(data.tags, context);
@@ -2795,28 +2798,28 @@ export const deserializeAws_restJson1UpdateLaunchConfigurationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.copyPrivateIp !== undefined && data.copyPrivateIp !== null) {
-    contents.copyPrivateIp = data.copyPrivateIp;
+    contents.copyPrivateIp = __expectBoolean(data.copyPrivateIp);
   }
   if (data.copyTags !== undefined && data.copyTags !== null) {
-    contents.copyTags = data.copyTags;
+    contents.copyTags = __expectBoolean(data.copyTags);
   }
   if (data.ec2LaunchTemplateID !== undefined && data.ec2LaunchTemplateID !== null) {
-    contents.ec2LaunchTemplateID = data.ec2LaunchTemplateID;
+    contents.ec2LaunchTemplateID = __expectString(data.ec2LaunchTemplateID);
   }
   if (data.launchDisposition !== undefined && data.launchDisposition !== null) {
-    contents.launchDisposition = data.launchDisposition;
+    contents.launchDisposition = __expectString(data.launchDisposition);
   }
   if (data.licensing !== undefined && data.licensing !== null) {
     contents.licensing = deserializeAws_restJson1Licensing(data.licensing, context);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.sourceServerID !== undefined && data.sourceServerID !== null) {
-    contents.sourceServerID = data.sourceServerID;
+    contents.sourceServerID = __expectString(data.sourceServerID);
   }
   if (data.targetInstanceTypeRightSizingMethod !== undefined && data.targetInstanceTypeRightSizingMethod !== null) {
-    contents.targetInstanceTypeRightSizingMethod = data.targetInstanceTypeRightSizingMethod;
+    contents.targetInstanceTypeRightSizingMethod = __expectString(data.targetInstanceTypeRightSizingMethod);
   }
   return Promise.resolve(contents);
 };
@@ -2909,28 +2912,28 @@ export const deserializeAws_restJson1UpdateReplicationConfigurationCommand = asy
   };
   const data: any = await parseBody(output.body, context);
   if (data.associateDefaultSecurityGroup !== undefined && data.associateDefaultSecurityGroup !== null) {
-    contents.associateDefaultSecurityGroup = data.associateDefaultSecurityGroup;
+    contents.associateDefaultSecurityGroup = __expectBoolean(data.associateDefaultSecurityGroup);
   }
   if (data.bandwidthThrottling !== undefined && data.bandwidthThrottling !== null) {
-    contents.bandwidthThrottling = data.bandwidthThrottling;
+    contents.bandwidthThrottling = __expectNumber(data.bandwidthThrottling);
   }
   if (data.createPublicIP !== undefined && data.createPublicIP !== null) {
-    contents.createPublicIP = data.createPublicIP;
+    contents.createPublicIP = __expectBoolean(data.createPublicIP);
   }
   if (data.dataPlaneRouting !== undefined && data.dataPlaneRouting !== null) {
-    contents.dataPlaneRouting = data.dataPlaneRouting;
+    contents.dataPlaneRouting = __expectString(data.dataPlaneRouting);
   }
   if (data.defaultLargeStagingDiskType !== undefined && data.defaultLargeStagingDiskType !== null) {
-    contents.defaultLargeStagingDiskType = data.defaultLargeStagingDiskType;
+    contents.defaultLargeStagingDiskType = __expectString(data.defaultLargeStagingDiskType);
   }
   if (data.ebsEncryption !== undefined && data.ebsEncryption !== null) {
-    contents.ebsEncryption = data.ebsEncryption;
+    contents.ebsEncryption = __expectString(data.ebsEncryption);
   }
   if (data.ebsEncryptionKeyArn !== undefined && data.ebsEncryptionKeyArn !== null) {
-    contents.ebsEncryptionKeyArn = data.ebsEncryptionKeyArn;
+    contents.ebsEncryptionKeyArn = __expectString(data.ebsEncryptionKeyArn);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.replicatedDisks !== undefined && data.replicatedDisks !== null) {
     contents.replicatedDisks = deserializeAws_restJson1ReplicationConfigurationReplicatedDisks(
@@ -2939,7 +2942,7 @@ export const deserializeAws_restJson1UpdateReplicationConfigurationCommand = asy
     );
   }
   if (data.replicationServerInstanceType !== undefined && data.replicationServerInstanceType !== null) {
-    contents.replicationServerInstanceType = data.replicationServerInstanceType;
+    contents.replicationServerInstanceType = __expectString(data.replicationServerInstanceType);
   }
   if (data.replicationServersSecurityGroupsIDs !== undefined && data.replicationServersSecurityGroupsIDs !== null) {
     contents.replicationServersSecurityGroupsIDs = deserializeAws_restJson1ReplicationServersSecurityGroupsIDs(
@@ -2948,16 +2951,16 @@ export const deserializeAws_restJson1UpdateReplicationConfigurationCommand = asy
     );
   }
   if (data.sourceServerID !== undefined && data.sourceServerID !== null) {
-    contents.sourceServerID = data.sourceServerID;
+    contents.sourceServerID = __expectString(data.sourceServerID);
   }
   if (data.stagingAreaSubnetId !== undefined && data.stagingAreaSubnetId !== null) {
-    contents.stagingAreaSubnetId = data.stagingAreaSubnetId;
+    contents.stagingAreaSubnetId = __expectString(data.stagingAreaSubnetId);
   }
   if (data.stagingAreaTags !== undefined && data.stagingAreaTags !== null) {
     contents.stagingAreaTags = deserializeAws_restJson1TagsMap(data.stagingAreaTags, context);
   }
   if (data.useDedicatedReplicationServer !== undefined && data.useDedicatedReplicationServer !== null) {
-    contents.useDedicatedReplicationServer = data.useDedicatedReplicationServer;
+    contents.useDedicatedReplicationServer = __expectBoolean(data.useDedicatedReplicationServer);
   }
   return Promise.resolve(contents);
 };
@@ -3050,34 +3053,34 @@ export const deserializeAws_restJson1UpdateReplicationConfigurationTemplateComma
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.associateDefaultSecurityGroup !== undefined && data.associateDefaultSecurityGroup !== null) {
-    contents.associateDefaultSecurityGroup = data.associateDefaultSecurityGroup;
+    contents.associateDefaultSecurityGroup = __expectBoolean(data.associateDefaultSecurityGroup);
   }
   if (data.bandwidthThrottling !== undefined && data.bandwidthThrottling !== null) {
-    contents.bandwidthThrottling = data.bandwidthThrottling;
+    contents.bandwidthThrottling = __expectNumber(data.bandwidthThrottling);
   }
   if (data.createPublicIP !== undefined && data.createPublicIP !== null) {
-    contents.createPublicIP = data.createPublicIP;
+    contents.createPublicIP = __expectBoolean(data.createPublicIP);
   }
   if (data.dataPlaneRouting !== undefined && data.dataPlaneRouting !== null) {
-    contents.dataPlaneRouting = data.dataPlaneRouting;
+    contents.dataPlaneRouting = __expectString(data.dataPlaneRouting);
   }
   if (data.defaultLargeStagingDiskType !== undefined && data.defaultLargeStagingDiskType !== null) {
-    contents.defaultLargeStagingDiskType = data.defaultLargeStagingDiskType;
+    contents.defaultLargeStagingDiskType = __expectString(data.defaultLargeStagingDiskType);
   }
   if (data.ebsEncryption !== undefined && data.ebsEncryption !== null) {
-    contents.ebsEncryption = data.ebsEncryption;
+    contents.ebsEncryption = __expectString(data.ebsEncryption);
   }
   if (data.ebsEncryptionKeyArn !== undefined && data.ebsEncryptionKeyArn !== null) {
-    contents.ebsEncryptionKeyArn = data.ebsEncryptionKeyArn;
+    contents.ebsEncryptionKeyArn = __expectString(data.ebsEncryptionKeyArn);
   }
   if (data.replicationConfigurationTemplateID !== undefined && data.replicationConfigurationTemplateID !== null) {
-    contents.replicationConfigurationTemplateID = data.replicationConfigurationTemplateID;
+    contents.replicationConfigurationTemplateID = __expectString(data.replicationConfigurationTemplateID);
   }
   if (data.replicationServerInstanceType !== undefined && data.replicationServerInstanceType !== null) {
-    contents.replicationServerInstanceType = data.replicationServerInstanceType;
+    contents.replicationServerInstanceType = __expectString(data.replicationServerInstanceType);
   }
   if (data.replicationServersSecurityGroupsIDs !== undefined && data.replicationServersSecurityGroupsIDs !== null) {
     contents.replicationServersSecurityGroupsIDs = deserializeAws_restJson1ReplicationServersSecurityGroupsIDs(
@@ -3086,7 +3089,7 @@ export const deserializeAws_restJson1UpdateReplicationConfigurationTemplateComma
     );
   }
   if (data.stagingAreaSubnetId !== undefined && data.stagingAreaSubnetId !== null) {
-    contents.stagingAreaSubnetId = data.stagingAreaSubnetId;
+    contents.stagingAreaSubnetId = __expectString(data.stagingAreaSubnetId);
   }
   if (data.stagingAreaTags !== undefined && data.stagingAreaTags !== null) {
     contents.stagingAreaTags = deserializeAws_restJson1TagsMap(data.stagingAreaTags, context);
@@ -3095,7 +3098,7 @@ export const deserializeAws_restJson1UpdateReplicationConfigurationTemplateComma
     contents.tags = deserializeAws_restJson1TagsMap(data.tags, context);
   }
   if (data.useDedicatedReplicationServer !== undefined && data.useDedicatedReplicationServer !== null) {
-    contents.useDedicatedReplicationServer = data.useDedicatedReplicationServer;
+    contents.useDedicatedReplicationServer = __expectBoolean(data.useDedicatedReplicationServer);
   }
   return Promise.resolve(contents);
 };
@@ -3166,10 +3169,10 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.code !== undefined && data.code !== null) {
-    contents.code = data.code;
+    contents.code = __expectString(data.code);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -3189,16 +3192,16 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.code !== undefined && data.code !== null) {
-    contents.code = data.code;
+    contents.code = __expectString(data.code);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.resourceId !== undefined && data.resourceId !== null) {
-    contents.resourceId = data.resourceId;
+    contents.resourceId = __expectString(data.resourceId);
   }
   if (data.resourceType !== undefined && data.resourceType !== null) {
-    contents.resourceType = data.resourceType;
+    contents.resourceType = __expectString(data.resourceType);
   }
   return contents;
 };
@@ -3219,7 +3222,7 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   }
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -3239,16 +3242,16 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.code !== undefined && data.code !== null) {
-    contents.code = data.code;
+    contents.code = __expectString(data.code);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.resourceId !== undefined && data.resourceId !== null) {
-    contents.resourceId = data.resourceId;
+    contents.resourceId = __expectString(data.resourceId);
   }
   if (data.resourceType !== undefined && data.resourceType !== null) {
-    contents.resourceType = data.resourceType;
+    contents.resourceType = __expectString(data.resourceType);
   }
   return contents;
 };
@@ -3271,13 +3274,13 @@ const deserializeAws_restJson1ThrottlingExceptionResponse = async (
   }
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.quotaCode !== undefined && data.quotaCode !== null) {
-    contents.quotaCode = data.quotaCode;
+    contents.quotaCode = __expectString(data.quotaCode);
   }
   if (data.serviceCode !== undefined && data.serviceCode !== null) {
-    contents.serviceCode = data.serviceCode;
+    contents.serviceCode = __expectString(data.serviceCode);
   }
   return contents;
 };
@@ -3295,10 +3298,10 @@ const deserializeAws_restJson1UninitializedAccountExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.code !== undefined && data.code !== null) {
-    contents.code = data.code;
+    contents.code = __expectString(data.code);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -3318,16 +3321,16 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.code !== undefined && data.code !== null) {
-    contents.code = data.code;
+    contents.code = __expectString(data.code);
   }
   if (data.fieldList !== undefined && data.fieldList !== null) {
     contents.fieldList = deserializeAws_restJson1ValidationExceptionFieldList(data.fieldList, context);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.reason !== undefined && data.reason !== null) {
-    contents.reason = data.reason;
+    contents.reason = __expectString(data.reason);
   }
   return contents;
 };
@@ -3498,8 +3501,8 @@ const serializeAws_restJson1TerminateTargetInstancesRequestSourceServerIDs = (
 
 const deserializeAws_restJson1CPU = (output: any, context: __SerdeContext): CPU => {
   return {
-    cores: output.cores !== undefined && output.cores !== null ? output.cores : undefined,
-    modelName: output.modelName !== undefined && output.modelName !== null ? output.modelName : undefined,
+    cores: __expectNumber(output.cores),
+    modelName: __expectString(output.modelName),
   } as any;
 };
 
@@ -3516,8 +3519,8 @@ const deserializeAws_restJson1Cpus = (output: any, context: __SerdeContext): CPU
 
 const deserializeAws_restJson1DataReplicationError = (output: any, context: __SerdeContext): DataReplicationError => {
   return {
-    error: output.error !== undefined && output.error !== null ? output.error : undefined,
-    rawError: output.rawError !== undefined && output.rawError !== null ? output.rawError : undefined,
+    error: __expectString(output.error),
+    rawError: __expectString(output.rawError),
   } as any;
 };
 
@@ -3531,12 +3534,9 @@ const deserializeAws_restJson1DataReplicationInfo = (output: any, context: __Ser
       output.dataReplicationInitiation !== undefined && output.dataReplicationInitiation !== null
         ? deserializeAws_restJson1DataReplicationInitiation(output.dataReplicationInitiation, context)
         : undefined,
-    dataReplicationState:
-      output.dataReplicationState !== undefined && output.dataReplicationState !== null
-        ? output.dataReplicationState
-        : undefined,
-    etaDateTime: output.etaDateTime !== undefined && output.etaDateTime !== null ? output.etaDateTime : undefined,
-    lagDuration: output.lagDuration !== undefined && output.lagDuration !== null ? output.lagDuration : undefined,
+    dataReplicationState: __expectString(output.dataReplicationState),
+    etaDateTime: __expectString(output.etaDateTime),
+    lagDuration: __expectString(output.lagDuration),
     replicatedDisks:
       output.replicatedDisks !== undefined && output.replicatedDisks !== null
         ? deserializeAws_restJson1DataReplicationInfoReplicatedDisks(output.replicatedDisks, context)
@@ -3549,23 +3549,11 @@ const deserializeAws_restJson1DataReplicationInfoReplicatedDisk = (
   context: __SerdeContext
 ): DataReplicationInfoReplicatedDisk => {
   return {
-    backloggedStorageBytes:
-      output.backloggedStorageBytes !== undefined && output.backloggedStorageBytes !== null
-        ? output.backloggedStorageBytes
-        : undefined,
-    deviceName: output.deviceName !== undefined && output.deviceName !== null ? output.deviceName : undefined,
-    replicatedStorageBytes:
-      output.replicatedStorageBytes !== undefined && output.replicatedStorageBytes !== null
-        ? output.replicatedStorageBytes
-        : undefined,
-    rescannedStorageBytes:
-      output.rescannedStorageBytes !== undefined && output.rescannedStorageBytes !== null
-        ? output.rescannedStorageBytes
-        : undefined,
-    totalStorageBytes:
-      output.totalStorageBytes !== undefined && output.totalStorageBytes !== null
-        ? output.totalStorageBytes
-        : undefined,
+    backloggedStorageBytes: __expectNumber(output.backloggedStorageBytes),
+    deviceName: __expectString(output.deviceName),
+    replicatedStorageBytes: __expectNumber(output.replicatedStorageBytes),
+    rescannedStorageBytes: __expectNumber(output.rescannedStorageBytes),
+    totalStorageBytes: __expectNumber(output.totalStorageBytes),
   } as any;
 };
 
@@ -3588,12 +3576,8 @@ const deserializeAws_restJson1DataReplicationInitiation = (
   context: __SerdeContext
 ): DataReplicationInitiation => {
   return {
-    nextAttemptDateTime:
-      output.nextAttemptDateTime !== undefined && output.nextAttemptDateTime !== null
-        ? output.nextAttemptDateTime
-        : undefined,
-    startDateTime:
-      output.startDateTime !== undefined && output.startDateTime !== null ? output.startDateTime : undefined,
+    nextAttemptDateTime: __expectString(output.nextAttemptDateTime),
+    startDateTime: __expectString(output.startDateTime),
     steps:
       output.steps !== undefined && output.steps !== null
         ? deserializeAws_restJson1DataReplicationInitiationSteps(output.steps, context)
@@ -3606,8 +3590,8 @@ const deserializeAws_restJson1DataReplicationInitiationStep = (
   context: __SerdeContext
 ): DataReplicationInitiationStep => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    name: __expectString(output.name),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -3627,8 +3611,8 @@ const deserializeAws_restJson1DataReplicationInitiationSteps = (
 
 const deserializeAws_restJson1Disk = (output: any, context: __SerdeContext): Disk => {
   return {
-    bytes: output.bytes !== undefined && output.bytes !== null ? output.bytes : undefined,
-    deviceName: output.deviceName !== undefined && output.deviceName !== null ? output.deviceName : undefined,
+    bytes: __expectNumber(output.bytes),
+    deviceName: __expectString(output.deviceName),
   } as any;
 };
 
@@ -3645,11 +3629,10 @@ const deserializeAws_restJson1Disks = (output: any, context: __SerdeContext): Di
 
 const deserializeAws_restJson1IdentificationHints = (output: any, context: __SerdeContext): IdentificationHints => {
   return {
-    awsInstanceID:
-      output.awsInstanceID !== undefined && output.awsInstanceID !== null ? output.awsInstanceID : undefined,
-    fqdn: output.fqdn !== undefined && output.fqdn !== null ? output.fqdn : undefined,
-    hostname: output.hostname !== undefined && output.hostname !== null ? output.hostname : undefined,
-    vmWareUuid: output.vmWareUuid !== undefined && output.vmWareUuid !== null ? output.vmWareUuid : undefined,
+    awsInstanceID: __expectString(output.awsInstanceID),
+    fqdn: __expectString(output.fqdn),
+    hostname: __expectString(output.hostname),
+    vmWareUuid: __expectString(output.vmWareUuid),
   } as any;
 };
 
@@ -3660,53 +3643,47 @@ const deserializeAws_restJson1IPsList = (output: any, context: __SerdeContext): 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1Job = (output: any, context: __SerdeContext): Job => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    creationDateTime:
-      output.creationDateTime !== undefined && output.creationDateTime !== null ? output.creationDateTime : undefined,
-    endDateTime: output.endDateTime !== undefined && output.endDateTime !== null ? output.endDateTime : undefined,
-    initiatedBy: output.initiatedBy !== undefined && output.initiatedBy !== null ? output.initiatedBy : undefined,
-    jobID: output.jobID !== undefined && output.jobID !== null ? output.jobID : undefined,
+    arn: __expectString(output.arn),
+    creationDateTime: __expectString(output.creationDateTime),
+    endDateTime: __expectString(output.endDateTime),
+    initiatedBy: __expectString(output.initiatedBy),
+    jobID: __expectString(output.jobID),
     participatingServers:
       output.participatingServers !== undefined && output.participatingServers !== null
         ? deserializeAws_restJson1ParticipatingServers(output.participatingServers, context)
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1TagsMap(output.tags, context)
         : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    type: __expectString(output.type),
   } as any;
 };
 
 const deserializeAws_restJson1JobLog = (output: any, context: __SerdeContext): JobLog => {
   return {
-    event: output.event !== undefined && output.event !== null ? output.event : undefined,
+    event: __expectString(output.event),
     eventData:
       output.eventData !== undefined && output.eventData !== null
         ? deserializeAws_restJson1JobLogEventData(output.eventData, context)
         : undefined,
-    logDateTime: output.logDateTime !== undefined && output.logDateTime !== null ? output.logDateTime : undefined,
+    logDateTime: __expectString(output.logDateTime),
   } as any;
 };
 
 const deserializeAws_restJson1JobLogEventData = (output: any, context: __SerdeContext): JobLogEventData => {
   return {
-    conversionServerID:
-      output.conversionServerID !== undefined && output.conversionServerID !== null
-        ? output.conversionServerID
-        : undefined,
-    rawError: output.rawError !== undefined && output.rawError !== null ? output.rawError : undefined,
-    sourceServerID:
-      output.sourceServerID !== undefined && output.sourceServerID !== null ? output.sourceServerID : undefined,
-    targetInstanceID:
-      output.targetInstanceID !== undefined && output.targetInstanceID !== null ? output.targetInstanceID : undefined,
+    conversionServerID: __expectString(output.conversionServerID),
+    rawError: __expectString(output.rawError),
+    sourceServerID: __expectString(output.sourceServerID),
+    targetInstanceID: __expectString(output.targetInstanceID),
   } as any;
 };
 
@@ -3734,46 +3711,33 @@ const deserializeAws_restJson1JobsList = (output: any, context: __SerdeContext):
 
 const deserializeAws_restJson1LaunchedInstance = (output: any, context: __SerdeContext): LaunchedInstance => {
   return {
-    ec2InstanceID:
-      output.ec2InstanceID !== undefined && output.ec2InstanceID !== null ? output.ec2InstanceID : undefined,
-    firstBoot: output.firstBoot !== undefined && output.firstBoot !== null ? output.firstBoot : undefined,
-    jobID: output.jobID !== undefined && output.jobID !== null ? output.jobID : undefined,
+    ec2InstanceID: __expectString(output.ec2InstanceID),
+    firstBoot: __expectString(output.firstBoot),
+    jobID: __expectString(output.jobID),
   } as any;
 };
 
 const deserializeAws_restJson1Licensing = (output: any, context: __SerdeContext): Licensing => {
   return {
-    osByol: output.osByol !== undefined && output.osByol !== null ? output.osByol : undefined,
+    osByol: __expectBoolean(output.osByol),
   } as any;
 };
 
 const deserializeAws_restJson1LifeCycle = (output: any, context: __SerdeContext): LifeCycle => {
   return {
-    addedToServiceDateTime:
-      output.addedToServiceDateTime !== undefined && output.addedToServiceDateTime !== null
-        ? output.addedToServiceDateTime
-        : undefined,
-    elapsedReplicationDuration:
-      output.elapsedReplicationDuration !== undefined && output.elapsedReplicationDuration !== null
-        ? output.elapsedReplicationDuration
-        : undefined,
-    firstByteDateTime:
-      output.firstByteDateTime !== undefined && output.firstByteDateTime !== null
-        ? output.firstByteDateTime
-        : undefined,
+    addedToServiceDateTime: __expectString(output.addedToServiceDateTime),
+    elapsedReplicationDuration: __expectString(output.elapsedReplicationDuration),
+    firstByteDateTime: __expectString(output.firstByteDateTime),
     lastCutover:
       output.lastCutover !== undefined && output.lastCutover !== null
         ? deserializeAws_restJson1LifeCycleLastCutover(output.lastCutover, context)
         : undefined,
-    lastSeenByServiceDateTime:
-      output.lastSeenByServiceDateTime !== undefined && output.lastSeenByServiceDateTime !== null
-        ? output.lastSeenByServiceDateTime
-        : undefined,
+    lastSeenByServiceDateTime: __expectString(output.lastSeenByServiceDateTime),
     lastTest:
       output.lastTest !== undefined && output.lastTest !== null
         ? deserializeAws_restJson1LifeCycleLastTest(output.lastTest, context)
         : undefined,
-    state: output.state !== undefined && output.state !== null ? output.state : undefined,
+    state: __expectString(output.state),
   } as any;
 };
 
@@ -3799,8 +3763,7 @@ const deserializeAws_restJson1LifeCycleLastCutoverFinalized = (
   context: __SerdeContext
 ): LifeCycleLastCutoverFinalized => {
   return {
-    apiCallDateTime:
-      output.apiCallDateTime !== undefined && output.apiCallDateTime !== null ? output.apiCallDateTime : undefined,
+    apiCallDateTime: __expectString(output.apiCallDateTime),
   } as any;
 };
 
@@ -3809,9 +3772,8 @@ const deserializeAws_restJson1LifeCycleLastCutoverInitiated = (
   context: __SerdeContext
 ): LifeCycleLastCutoverInitiated => {
   return {
-    apiCallDateTime:
-      output.apiCallDateTime !== undefined && output.apiCallDateTime !== null ? output.apiCallDateTime : undefined,
-    jobID: output.jobID !== undefined && output.jobID !== null ? output.jobID : undefined,
+    apiCallDateTime: __expectString(output.apiCallDateTime),
+    jobID: __expectString(output.jobID),
   } as any;
 };
 
@@ -3820,8 +3782,7 @@ const deserializeAws_restJson1LifeCycleLastCutoverReverted = (
   context: __SerdeContext
 ): LifeCycleLastCutoverReverted => {
   return {
-    apiCallDateTime:
-      output.apiCallDateTime !== undefined && output.apiCallDateTime !== null ? output.apiCallDateTime : undefined,
+    apiCallDateTime: __expectString(output.apiCallDateTime),
   } as any;
 };
 
@@ -3847,8 +3808,7 @@ const deserializeAws_restJson1LifeCycleLastTestFinalized = (
   context: __SerdeContext
 ): LifeCycleLastTestFinalized => {
   return {
-    apiCallDateTime:
-      output.apiCallDateTime !== undefined && output.apiCallDateTime !== null ? output.apiCallDateTime : undefined,
+    apiCallDateTime: __expectString(output.apiCallDateTime),
   } as any;
 };
 
@@ -3857,9 +3817,8 @@ const deserializeAws_restJson1LifeCycleLastTestInitiated = (
   context: __SerdeContext
 ): LifeCycleLastTestInitiated => {
   return {
-    apiCallDateTime:
-      output.apiCallDateTime !== undefined && output.apiCallDateTime !== null ? output.apiCallDateTime : undefined,
-    jobID: output.jobID !== undefined && output.jobID !== null ? output.jobID : undefined,
+    apiCallDateTime: __expectString(output.apiCallDateTime),
+    jobID: __expectString(output.jobID),
   } as any;
 };
 
@@ -3868,8 +3827,7 @@ const deserializeAws_restJson1LifeCycleLastTestReverted = (
   context: __SerdeContext
 ): LifeCycleLastTestReverted => {
   return {
-    apiCallDateTime:
-      output.apiCallDateTime !== undefined && output.apiCallDateTime !== null ? output.apiCallDateTime : undefined,
+    apiCallDateTime: __expectString(output.apiCallDateTime),
   } as any;
 };
 
@@ -3879,8 +3837,8 @@ const deserializeAws_restJson1NetworkInterface = (output: any, context: __SerdeC
       output.ips !== undefined && output.ips !== null
         ? deserializeAws_restJson1IPsList(output.ips, context)
         : undefined,
-    isPrimary: output.isPrimary !== undefined && output.isPrimary !== null ? output.isPrimary : undefined,
-    macAddress: output.macAddress !== undefined && output.macAddress !== null ? output.macAddress : undefined,
+    isPrimary: __expectBoolean(output.isPrimary),
+    macAddress: __expectString(output.macAddress),
   } as any;
 };
 
@@ -3897,15 +3855,14 @@ const deserializeAws_restJson1NetworkInterfaces = (output: any, context: __Serde
 
 const deserializeAws_restJson1OS = (output: any, context: __SerdeContext): OS => {
   return {
-    fullString: output.fullString !== undefined && output.fullString !== null ? output.fullString : undefined,
+    fullString: __expectString(output.fullString),
   } as any;
 };
 
 const deserializeAws_restJson1ParticipatingServer = (output: any, context: __SerdeContext): ParticipatingServer => {
   return {
-    launchStatus: output.launchStatus !== undefined && output.launchStatus !== null ? output.launchStatus : undefined,
-    sourceServerID:
-      output.sourceServerID !== undefined && output.sourceServerID !== null ? output.sourceServerID : undefined,
+    launchStatus: __expectString(output.launchStatus),
+    sourceServerID: __expectString(output.sourceServerID),
   } as any;
 };
 
@@ -3925,11 +3882,10 @@ const deserializeAws_restJson1ReplicationConfigurationReplicatedDisk = (
   context: __SerdeContext
 ): ReplicationConfigurationReplicatedDisk => {
   return {
-    deviceName: output.deviceName !== undefined && output.deviceName !== null ? output.deviceName : undefined,
-    iops: output.iops !== undefined && output.iops !== null ? output.iops : undefined,
-    isBootDisk: output.isBootDisk !== undefined && output.isBootDisk !== null ? output.isBootDisk : undefined,
-    stagingDiskType:
-      output.stagingDiskType !== undefined && output.stagingDiskType !== null ? output.stagingDiskType : undefined,
+    deviceName: __expectString(output.deviceName),
+    iops: __expectNumber(output.iops),
+    isBootDisk: __expectBoolean(output.isBootDisk),
+    stagingDiskType: __expectString(output.stagingDiskType),
   } as any;
 };
 
@@ -3952,37 +3908,16 @@ const deserializeAws_restJson1ReplicationConfigurationTemplate = (
   context: __SerdeContext
 ): ReplicationConfigurationTemplate => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    associateDefaultSecurityGroup:
-      output.associateDefaultSecurityGroup !== undefined && output.associateDefaultSecurityGroup !== null
-        ? output.associateDefaultSecurityGroup
-        : undefined,
-    bandwidthThrottling:
-      output.bandwidthThrottling !== undefined && output.bandwidthThrottling !== null
-        ? output.bandwidthThrottling
-        : undefined,
-    createPublicIP:
-      output.createPublicIP !== undefined && output.createPublicIP !== null ? output.createPublicIP : undefined,
-    dataPlaneRouting:
-      output.dataPlaneRouting !== undefined && output.dataPlaneRouting !== null ? output.dataPlaneRouting : undefined,
-    defaultLargeStagingDiskType:
-      output.defaultLargeStagingDiskType !== undefined && output.defaultLargeStagingDiskType !== null
-        ? output.defaultLargeStagingDiskType
-        : undefined,
-    ebsEncryption:
-      output.ebsEncryption !== undefined && output.ebsEncryption !== null ? output.ebsEncryption : undefined,
-    ebsEncryptionKeyArn:
-      output.ebsEncryptionKeyArn !== undefined && output.ebsEncryptionKeyArn !== null
-        ? output.ebsEncryptionKeyArn
-        : undefined,
-    replicationConfigurationTemplateID:
-      output.replicationConfigurationTemplateID !== undefined && output.replicationConfigurationTemplateID !== null
-        ? output.replicationConfigurationTemplateID
-        : undefined,
-    replicationServerInstanceType:
-      output.replicationServerInstanceType !== undefined && output.replicationServerInstanceType !== null
-        ? output.replicationServerInstanceType
-        : undefined,
+    arn: __expectString(output.arn),
+    associateDefaultSecurityGroup: __expectBoolean(output.associateDefaultSecurityGroup),
+    bandwidthThrottling: __expectNumber(output.bandwidthThrottling),
+    createPublicIP: __expectBoolean(output.createPublicIP),
+    dataPlaneRouting: __expectString(output.dataPlaneRouting),
+    defaultLargeStagingDiskType: __expectString(output.defaultLargeStagingDiskType),
+    ebsEncryption: __expectString(output.ebsEncryption),
+    ebsEncryptionKeyArn: __expectString(output.ebsEncryptionKeyArn),
+    replicationConfigurationTemplateID: __expectString(output.replicationConfigurationTemplateID),
+    replicationServerInstanceType: __expectString(output.replicationServerInstanceType),
     replicationServersSecurityGroupsIDs:
       output.replicationServersSecurityGroupsIDs !== undefined && output.replicationServersSecurityGroupsIDs !== null
         ? deserializeAws_restJson1ReplicationServersSecurityGroupsIDs(
@@ -3990,10 +3925,7 @@ const deserializeAws_restJson1ReplicationConfigurationTemplate = (
             context
           )
         : undefined,
-    stagingAreaSubnetId:
-      output.stagingAreaSubnetId !== undefined && output.stagingAreaSubnetId !== null
-        ? output.stagingAreaSubnetId
-        : undefined,
+    stagingAreaSubnetId: __expectString(output.stagingAreaSubnetId),
     stagingAreaTags:
       output.stagingAreaTags !== undefined && output.stagingAreaTags !== null
         ? deserializeAws_restJson1TagsMap(output.stagingAreaTags, context)
@@ -4002,10 +3934,7 @@ const deserializeAws_restJson1ReplicationConfigurationTemplate = (
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1TagsMap(output.tags, context)
         : undefined,
-    useDedicatedReplicationServer:
-      output.useDedicatedReplicationServer !== undefined && output.useDedicatedReplicationServer !== null
-        ? output.useDedicatedReplicationServer
-        : undefined,
+    useDedicatedReplicationServer: __expectBoolean(output.useDedicatedReplicationServer),
   } as any;
 };
 
@@ -4033,7 +3962,7 @@ const deserializeAws_restJson1ReplicationServersSecurityGroupsIDs = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4051,31 +3980,25 @@ const deserializeAws_restJson1SourceProperties = (output: any, context: __SerdeC
       output.identificationHints !== undefined && output.identificationHints !== null
         ? deserializeAws_restJson1IdentificationHints(output.identificationHints, context)
         : undefined,
-    lastUpdatedDateTime:
-      output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
-        ? output.lastUpdatedDateTime
-        : undefined,
+    lastUpdatedDateTime: __expectString(output.lastUpdatedDateTime),
     networkInterfaces:
       output.networkInterfaces !== undefined && output.networkInterfaces !== null
         ? deserializeAws_restJson1NetworkInterfaces(output.networkInterfaces, context)
         : undefined,
     os: output.os !== undefined && output.os !== null ? deserializeAws_restJson1OS(output.os, context) : undefined,
-    ramBytes: output.ramBytes !== undefined && output.ramBytes !== null ? output.ramBytes : undefined,
-    recommendedInstanceType:
-      output.recommendedInstanceType !== undefined && output.recommendedInstanceType !== null
-        ? output.recommendedInstanceType
-        : undefined,
+    ramBytes: __expectNumber(output.ramBytes),
+    recommendedInstanceType: __expectString(output.recommendedInstanceType),
   } as any;
 };
 
 const deserializeAws_restJson1SourceServer = (output: any, context: __SerdeContext): SourceServer => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     dataReplicationInfo:
       output.dataReplicationInfo !== undefined && output.dataReplicationInfo !== null
         ? deserializeAws_restJson1DataReplicationInfo(output.dataReplicationInfo, context)
         : undefined,
-    isArchived: output.isArchived !== undefined && output.isArchived !== null ? output.isArchived : undefined,
+    isArchived: __expectBoolean(output.isArchived),
     launchedInstance:
       output.launchedInstance !== undefined && output.launchedInstance !== null
         ? deserializeAws_restJson1LaunchedInstance(output.launchedInstance, context)
@@ -4088,8 +4011,7 @@ const deserializeAws_restJson1SourceServer = (output: any, context: __SerdeConte
       output.sourceProperties !== undefined && output.sourceProperties !== null
         ? deserializeAws_restJson1SourceProperties(output.sourceProperties, context)
         : undefined,
-    sourceServerID:
-      output.sourceServerID !== undefined && output.sourceServerID !== null ? output.sourceServerID : undefined,
+    sourceServerID: __expectString(output.sourceServerID),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1TagsMap(output.tags, context)
@@ -4115,7 +4037,7 @@ const deserializeAws_restJson1TagsMap = (output: any, context: __SerdeContext): 
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -4125,8 +4047,8 @@ const deserializeAws_restJson1ValidationExceptionField = (
   context: __SerdeContext
 ): ValidationExceptionField => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    message: __expectString(output.message),
+    name: __expectString(output.name),
   } as any;
 };
 

--- a/clients/client-migration-hub/protocols/Aws_json1_1.ts
+++ b/clients/client-migration-hub/protocols/Aws_json1_1.ts
@@ -118,7 +118,11 @@ import {
   UnauthorizedOperation,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -2686,18 +2690,14 @@ const serializeAws_json1_1Task = (input: Task, context: __SerdeContext): any => 
 
 const deserializeAws_json1_1AccessDeniedException = (output: any, context: __SerdeContext): AccessDeniedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1ApplicationState = (output: any, context: __SerdeContext): ApplicationState => {
   return {
-    ApplicationId:
-      output.ApplicationId !== undefined && output.ApplicationId !== null ? output.ApplicationId : undefined,
-    ApplicationStatus:
-      output.ApplicationStatus !== undefined && output.ApplicationStatus !== null
-        ? output.ApplicationStatus
-        : undefined,
+    ApplicationId: __expectString(output.ApplicationId),
+    ApplicationStatus: __expectString(output.ApplicationStatus),
     LastUpdatedTime:
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
         ? new Date(Math.round(output.LastUpdatedTime * 1000))
@@ -2732,8 +2732,8 @@ const deserializeAws_json1_1AssociateDiscoveredResourceResult = (
 
 const deserializeAws_json1_1CreatedArtifact = (output: any, context: __SerdeContext): CreatedArtifact => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Description: __expectString(output.Description),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -2767,10 +2767,7 @@ const deserializeAws_json1_1DescribeApplicationStateResult = (
   context: __SerdeContext
 ): DescribeApplicationStateResult => {
   return {
-    ApplicationStatus:
-      output.ApplicationStatus !== undefined && output.ApplicationStatus !== null
-        ? output.ApplicationStatus
-        : undefined,
+    ApplicationStatus: __expectString(output.ApplicationStatus),
     LastUpdatedTime:
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
         ? new Date(Math.round(output.LastUpdatedTime * 1000))
@@ -2806,9 +2803,8 @@ const deserializeAws_json1_1DisassociateDiscoveredResourceResult = (
 
 const deserializeAws_json1_1DiscoveredResource = (output: any, context: __SerdeContext): DiscoveredResource => {
   return {
-    ConfigurationId:
-      output.ConfigurationId !== undefined && output.ConfigurationId !== null ? output.ConfigurationId : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    ConfigurationId: __expectString(output.ConfigurationId),
+    Description: __expectString(output.Description),
   } as any;
 };
 
@@ -2825,7 +2821,7 @@ const deserializeAws_json1_1DiscoveredResourceList = (output: any, context: __Se
 
 const deserializeAws_json1_1DryRunOperation = (output: any, context: __SerdeContext): DryRunOperation => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2834,7 +2830,7 @@ const deserializeAws_json1_1HomeRegionNotSetException = (
   context: __SerdeContext
 ): HomeRegionNotSetException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2847,13 +2843,13 @@ const deserializeAws_json1_1ImportMigrationTaskResult = (
 
 const deserializeAws_json1_1InternalServerError = (output: any, context: __SerdeContext): InternalServerError => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidInputException = (output: any, context: __SerdeContext): InvalidInputException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2880,7 +2876,7 @@ const deserializeAws_json1_1ListApplicationStatesResult = (
       output.ApplicationStateList !== undefined && output.ApplicationStateList !== null
         ? deserializeAws_json1_1ApplicationStateList(output.ApplicationStateList, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -2893,7 +2889,7 @@ const deserializeAws_json1_1ListCreatedArtifactsResult = (
       output.CreatedArtifactList !== undefined && output.CreatedArtifactList !== null
         ? deserializeAws_json1_1CreatedArtifactList(output.CreatedArtifactList, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -2906,7 +2902,7 @@ const deserializeAws_json1_1ListDiscoveredResourcesResult = (
       output.DiscoveredResourceList !== undefined && output.DiscoveredResourceList !== null
         ? deserializeAws_json1_1DiscoveredResourceList(output.DiscoveredResourceList, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -2919,7 +2915,7 @@ const deserializeAws_json1_1ListMigrationTasksResult = (
       output.MigrationTaskSummaryList !== undefined && output.MigrationTaskSummaryList !== null
         ? deserializeAws_json1_1MigrationTaskSummaryList(output.MigrationTaskSummaryList, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -2928,7 +2924,7 @@ const deserializeAws_json1_1ListProgressUpdateStreamsResult = (
   context: __SerdeContext
 ): ListProgressUpdateStreamsResult => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     ProgressUpdateStreamSummaryList:
       output.ProgressUpdateStreamSummaryList !== undefined && output.ProgressUpdateStreamSummaryList !== null
         ? deserializeAws_json1_1ProgressUpdateStreamSummaryList(output.ProgressUpdateStreamSummaryList, context)
@@ -2938,14 +2934,8 @@ const deserializeAws_json1_1ListProgressUpdateStreamsResult = (
 
 const deserializeAws_json1_1MigrationTask = (output: any, context: __SerdeContext): MigrationTask => {
   return {
-    MigrationTaskName:
-      output.MigrationTaskName !== undefined && output.MigrationTaskName !== null
-        ? output.MigrationTaskName
-        : undefined,
-    ProgressUpdateStream:
-      output.ProgressUpdateStream !== undefined && output.ProgressUpdateStream !== null
-        ? output.ProgressUpdateStream
-        : undefined,
+    MigrationTaskName: __expectString(output.MigrationTaskName),
+    ProgressUpdateStream: __expectString(output.ProgressUpdateStream),
     ResourceAttributeList:
       output.ResourceAttributeList !== undefined && output.ResourceAttributeList !== null
         ? deserializeAws_json1_1LatestResourceAttributeList(output.ResourceAttributeList, context)
@@ -2961,18 +2951,11 @@ const deserializeAws_json1_1MigrationTask = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1MigrationTaskSummary = (output: any, context: __SerdeContext): MigrationTaskSummary => {
   return {
-    MigrationTaskName:
-      output.MigrationTaskName !== undefined && output.MigrationTaskName !== null
-        ? output.MigrationTaskName
-        : undefined,
-    ProgressPercent:
-      output.ProgressPercent !== undefined && output.ProgressPercent !== null ? output.ProgressPercent : undefined,
-    ProgressUpdateStream:
-      output.ProgressUpdateStream !== undefined && output.ProgressUpdateStream !== null
-        ? output.ProgressUpdateStream
-        : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusDetail: output.StatusDetail !== undefined && output.StatusDetail !== null ? output.StatusDetail : undefined,
+    MigrationTaskName: __expectString(output.MigrationTaskName),
+    ProgressPercent: __expectNumber(output.ProgressPercent),
+    ProgressUpdateStream: __expectString(output.ProgressUpdateStream),
+    Status: __expectString(output.Status),
+    StatusDetail: __expectString(output.StatusDetail),
     UpdateDateTime:
       output.UpdateDateTime !== undefined && output.UpdateDateTime !== null
         ? new Date(Math.round(output.UpdateDateTime * 1000))
@@ -3010,7 +2993,7 @@ const deserializeAws_json1_1NotifyMigrationTaskStateResult = (
 
 const deserializeAws_json1_1PolicyErrorException = (output: any, context: __SerdeContext): PolicyErrorException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3019,10 +3002,7 @@ const deserializeAws_json1_1ProgressUpdateStreamSummary = (
   context: __SerdeContext
 ): ProgressUpdateStreamSummary => {
   return {
-    ProgressUpdateStreamName:
-      output.ProgressUpdateStreamName !== undefined && output.ProgressUpdateStreamName !== null
-        ? output.ProgressUpdateStreamName
-        : undefined,
+    ProgressUpdateStreamName: __expectString(output.ProgressUpdateStreamName),
   } as any;
 };
 
@@ -3049,8 +3029,8 @@ const deserializeAws_json1_1PutResourceAttributesResult = (
 
 const deserializeAws_json1_1ResourceAttribute = (output: any, context: __SerdeContext): ResourceAttribute => {
   return {
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Type: __expectString(output.Type),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -3059,7 +3039,7 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3068,32 +3048,28 @@ const deserializeAws_json1_1ServiceUnavailableException = (
   context: __SerdeContext
 ): ServiceUnavailableException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1Task = (output: any, context: __SerdeContext): Task => {
   return {
-    ProgressPercent:
-      output.ProgressPercent !== undefined && output.ProgressPercent !== null ? output.ProgressPercent : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusDetail: output.StatusDetail !== undefined && output.StatusDetail !== null ? output.StatusDetail : undefined,
+    ProgressPercent: __expectNumber(output.ProgressPercent),
+    Status: __expectString(output.Status),
+    StatusDetail: __expectString(output.StatusDetail),
   } as any;
 };
 
 const deserializeAws_json1_1ThrottlingException = (output: any, context: __SerdeContext): ThrottlingException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RetryAfterSeconds:
-      output.RetryAfterSeconds !== undefined && output.RetryAfterSeconds !== null
-        ? output.RetryAfterSeconds
-        : undefined,
+    Message: __expectString(output.Message),
+    RetryAfterSeconds: __expectNumber(output.RetryAfterSeconds),
   } as any;
 };
 
 const deserializeAws_json1_1UnauthorizedOperation = (output: any, context: __SerdeContext): UnauthorizedOperation => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 

--- a/clients/client-migrationhub-config/protocols/Aws_json1_1.ts
+++ b/clients/client-migrationhub-config/protocols/Aws_json1_1.ts
@@ -24,7 +24,11 @@ import {
   ThrottlingException,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -467,7 +471,7 @@ const serializeAws_json1_1Target = (input: Target, context: __SerdeContext): any
 
 const deserializeAws_json1_1AccessDeniedException = (output: any, context: __SerdeContext): AccessDeniedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -492,26 +496,26 @@ const deserializeAws_json1_1DescribeHomeRegionControlsResult = (
       output.HomeRegionControls !== undefined && output.HomeRegionControls !== null
         ? deserializeAws_json1_1HomeRegionControls(output.HomeRegionControls, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
 const deserializeAws_json1_1DryRunOperation = (output: any, context: __SerdeContext): DryRunOperation => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1GetHomeRegionResult = (output: any, context: __SerdeContext): GetHomeRegionResult => {
   return {
-    HomeRegion: output.HomeRegion !== undefined && output.HomeRegion !== null ? output.HomeRegion : undefined,
+    HomeRegion: __expectString(output.HomeRegion),
   } as any;
 };
 
 const deserializeAws_json1_1HomeRegionControl = (output: any, context: __SerdeContext): HomeRegionControl => {
   return {
-    ControlId: output.ControlId !== undefined && output.ControlId !== null ? output.ControlId : undefined,
-    HomeRegion: output.HomeRegion !== undefined && output.HomeRegion !== null ? output.HomeRegion : undefined,
+    ControlId: __expectString(output.ControlId),
+    HomeRegion: __expectString(output.HomeRegion),
     RequestedTime:
       output.RequestedTime !== undefined && output.RequestedTime !== null
         ? new Date(Math.round(output.RequestedTime * 1000))
@@ -536,13 +540,13 @@ const deserializeAws_json1_1HomeRegionControls = (output: any, context: __SerdeC
 
 const deserializeAws_json1_1InternalServerError = (output: any, context: __SerdeContext): InternalServerError => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidInputException = (output: any, context: __SerdeContext): InvalidInputException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -551,24 +555,21 @@ const deserializeAws_json1_1ServiceUnavailableException = (
   context: __SerdeContext
 ): ServiceUnavailableException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1Target = (output: any, context: __SerdeContext): Target => {
   return {
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Id: __expectString(output.Id),
+    Type: __expectString(output.Type),
   } as any;
 };
 
 const deserializeAws_json1_1ThrottlingException = (output: any, context: __SerdeContext): ThrottlingException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RetryAfterSeconds:
-      output.RetryAfterSeconds !== undefined && output.RetryAfterSeconds !== null
-        ? output.RetryAfterSeconds
-        : undefined,
+    Message: __expectString(output.Message),
+    RetryAfterSeconds: __expectNumber(output.RetryAfterSeconds),
   } as any;
 };
 

--- a/clients/client-mobile/protocols/Aws_restJson1.ts
+++ b/clients/client-mobile/protocols/Aws_restJson1.ts
@@ -25,6 +25,7 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -678,7 +679,7 @@ export const deserializeAws_restJson1ExportBundleCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.downloadUrl !== undefined && data.downloadUrl !== null) {
-    contents.downloadUrl = data.downloadUrl;
+    contents.downloadUrl = __expectString(data.downloadUrl);
   }
   return Promise.resolve(contents);
 };
@@ -775,13 +776,13 @@ export const deserializeAws_restJson1ExportProjectCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.downloadUrl !== undefined && data.downloadUrl !== null) {
-    contents.downloadUrl = data.downloadUrl;
+    contents.downloadUrl = __expectString(data.downloadUrl);
   }
   if (data.shareUrl !== undefined && data.shareUrl !== null) {
-    contents.shareUrl = data.shareUrl;
+    contents.shareUrl = __expectString(data.shareUrl);
   }
   if (data.snapshotId !== undefined && data.snapshotId !== null) {
-    contents.snapshotId = data.snapshotId;
+    contents.snapshotId = __expectString(data.snapshotId);
   }
   return Promise.resolve(contents);
 };
@@ -880,7 +881,7 @@ export const deserializeAws_restJson1ListBundlesCommand = async (
     contents.bundleList = deserializeAws_restJson1BundleList(data.bundleList, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -968,7 +969,7 @@ export const deserializeAws_restJson1ListProjectsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.projects !== undefined && data.projects !== null) {
     contents.projects = deserializeAws_restJson1ProjectSummaries(data.projects, context);
@@ -1168,7 +1169,7 @@ const deserializeAws_restJson1AccountActionRequiredExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1185,7 +1186,7 @@ const deserializeAws_restJson1BadRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1202,7 +1203,7 @@ const deserializeAws_restJson1InternalFailureExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1223,7 +1224,7 @@ const deserializeAws_restJson1LimitExceededExceptionResponse = async (
   }
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1240,7 +1241,7 @@ const deserializeAws_restJson1NotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1261,7 +1262,7 @@ const deserializeAws_restJson1ServiceUnavailableExceptionResponse = async (
   }
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1282,7 +1283,7 @@ const deserializeAws_restJson1TooManyRequestsExceptionResponse = async (
   }
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1299,7 +1300,7 @@ const deserializeAws_restJson1UnauthorizedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1311,7 +1312,7 @@ const deserializeAws_restJson1Attributes = (output: any, context: __SerdeContext
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -1322,11 +1323,11 @@ const deserializeAws_restJson1BundleDetails = (output: any, context: __SerdeCont
       output.availablePlatforms !== undefined && output.availablePlatforms !== null
         ? deserializeAws_restJson1Platforms(output.availablePlatforms, context)
         : undefined,
-    bundleId: output.bundleId !== undefined && output.bundleId !== null ? output.bundleId : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    iconUrl: output.iconUrl !== undefined && output.iconUrl !== null ? output.iconUrl : undefined,
-    title: output.title !== undefined && output.title !== null ? output.title : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    bundleId: __expectString(output.bundleId),
+    description: __expectString(output.description),
+    iconUrl: __expectString(output.iconUrl),
+    title: __expectString(output.title),
+    version: __expectString(output.version),
   } as any;
 };
 
@@ -1348,13 +1349,13 @@ const deserializeAws_restJson1Platforms = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1ProjectDetails = (output: any, context: __SerdeContext): ProjectDetails => {
   return {
-    consoleUrl: output.consoleUrl !== undefined && output.consoleUrl !== null ? output.consoleUrl : undefined,
+    consoleUrl: __expectString(output.consoleUrl),
     createdDate:
       output.createdDate !== undefined && output.createdDate !== null
         ? new Date(Math.round(output.createdDate * 1000))
@@ -1363,14 +1364,14 @@ const deserializeAws_restJson1ProjectDetails = (output: any, context: __SerdeCon
       output.lastUpdatedDate !== undefined && output.lastUpdatedDate !== null
         ? new Date(Math.round(output.lastUpdatedDate * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    projectId: output.projectId !== undefined && output.projectId !== null ? output.projectId : undefined,
-    region: output.region !== undefined && output.region !== null ? output.region : undefined,
+    name: __expectString(output.name),
+    projectId: __expectString(output.projectId),
+    region: __expectString(output.region),
     resources:
       output.resources !== undefined && output.resources !== null
         ? deserializeAws_restJson1Resources(output.resources, context)
         : undefined,
-    state: output.state !== undefined && output.state !== null ? output.state : undefined,
+    state: __expectString(output.state),
   } as any;
 };
 
@@ -1387,21 +1388,21 @@ const deserializeAws_restJson1ProjectSummaries = (output: any, context: __SerdeC
 
 const deserializeAws_restJson1ProjectSummary = (output: any, context: __SerdeContext): ProjectSummary => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    projectId: output.projectId !== undefined && output.projectId !== null ? output.projectId : undefined,
+    name: __expectString(output.name),
+    projectId: __expectString(output.projectId),
   } as any;
 };
 
 const deserializeAws_restJson1Resource = (output: any, context: __SerdeContext): Resource => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     attributes:
       output.attributes !== undefined && output.attributes !== null
         ? deserializeAws_restJson1Attributes(output.attributes, context)
         : undefined,
-    feature: output.feature !== undefined && output.feature !== null ? output.feature : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    feature: __expectString(output.feature),
+    name: __expectString(output.name),
+    type: __expectString(output.type),
   } as any;
 };
 

--- a/clients/client-mq/protocols/Aws_restJson1.ts
+++ b/clients/client-mq/protocols/Aws_restJson1.ts
@@ -74,6 +74,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -852,10 +855,10 @@ export const deserializeAws_restJson1CreateBrokerCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.brokerArn !== undefined && data.brokerArn !== null) {
-    contents.BrokerArn = data.brokerArn;
+    contents.BrokerArn = __expectString(data.brokerArn);
   }
   if (data.brokerId !== undefined && data.brokerId !== null) {
-    contents.BrokerId = data.brokerId;
+    contents.BrokerId = __expectString(data.brokerId);
   }
   return Promise.resolve(contents);
 };
@@ -947,22 +950,22 @@ export const deserializeAws_restJson1CreateConfigurationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.Arn = data.arn;
+    contents.Arn = __expectString(data.arn);
   }
   if (data.authenticationStrategy !== undefined && data.authenticationStrategy !== null) {
-    contents.AuthenticationStrategy = data.authenticationStrategy;
+    contents.AuthenticationStrategy = __expectString(data.authenticationStrategy);
   }
   if (data.created !== undefined && data.created !== null) {
     contents.Created = new Date(data.created);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.Id = data.id;
+    contents.Id = __expectString(data.id);
   }
   if (data.latestRevision !== undefined && data.latestRevision !== null) {
     contents.LatestRevision = deserializeAws_restJson1ConfigurationRevision(data.latestRevision, context);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.Name = data.name;
+    contents.Name = __expectString(data.name);
   }
   return Promise.resolve(contents);
 };
@@ -1199,7 +1202,7 @@ export const deserializeAws_restJson1DeleteBrokerCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.brokerId !== undefined && data.brokerId !== null) {
-    contents.BrokerId = data.brokerId;
+    contents.BrokerId = __expectString(data.brokerId);
   }
   return Promise.resolve(contents);
 };
@@ -1455,25 +1458,25 @@ export const deserializeAws_restJson1DescribeBrokerCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.authenticationStrategy !== undefined && data.authenticationStrategy !== null) {
-    contents.AuthenticationStrategy = data.authenticationStrategy;
+    contents.AuthenticationStrategy = __expectString(data.authenticationStrategy);
   }
   if (data.autoMinorVersionUpgrade !== undefined && data.autoMinorVersionUpgrade !== null) {
-    contents.AutoMinorVersionUpgrade = data.autoMinorVersionUpgrade;
+    contents.AutoMinorVersionUpgrade = __expectBoolean(data.autoMinorVersionUpgrade);
   }
   if (data.brokerArn !== undefined && data.brokerArn !== null) {
-    contents.BrokerArn = data.brokerArn;
+    contents.BrokerArn = __expectString(data.brokerArn);
   }
   if (data.brokerId !== undefined && data.brokerId !== null) {
-    contents.BrokerId = data.brokerId;
+    contents.BrokerId = __expectString(data.brokerId);
   }
   if (data.brokerInstances !== undefined && data.brokerInstances !== null) {
     contents.BrokerInstances = deserializeAws_restJson1__listOfBrokerInstance(data.brokerInstances, context);
   }
   if (data.brokerName !== undefined && data.brokerName !== null) {
-    contents.BrokerName = data.brokerName;
+    contents.BrokerName = __expectString(data.brokerName);
   }
   if (data.brokerState !== undefined && data.brokerState !== null) {
-    contents.BrokerState = data.brokerState;
+    contents.BrokerState = __expectString(data.brokerState);
   }
   if (data.configurations !== undefined && data.configurations !== null) {
     contents.Configurations = deserializeAws_restJson1Configurations(data.configurations, context);
@@ -1482,19 +1485,19 @@ export const deserializeAws_restJson1DescribeBrokerCommand = async (
     contents.Created = new Date(data.created);
   }
   if (data.deploymentMode !== undefined && data.deploymentMode !== null) {
-    contents.DeploymentMode = data.deploymentMode;
+    contents.DeploymentMode = __expectString(data.deploymentMode);
   }
   if (data.encryptionOptions !== undefined && data.encryptionOptions !== null) {
     contents.EncryptionOptions = deserializeAws_restJson1EncryptionOptions(data.encryptionOptions, context);
   }
   if (data.engineType !== undefined && data.engineType !== null) {
-    contents.EngineType = data.engineType;
+    contents.EngineType = __expectString(data.engineType);
   }
   if (data.engineVersion !== undefined && data.engineVersion !== null) {
-    contents.EngineVersion = data.engineVersion;
+    contents.EngineVersion = __expectString(data.engineVersion);
   }
   if (data.hostInstanceType !== undefined && data.hostInstanceType !== null) {
-    contents.HostInstanceType = data.hostInstanceType;
+    contents.HostInstanceType = __expectString(data.hostInstanceType);
   }
   if (data.ldapServerMetadata !== undefined && data.ldapServerMetadata !== null) {
     contents.LdapServerMetadata = deserializeAws_restJson1LdapServerMetadataOutput(data.ldapServerMetadata, context);
@@ -1509,13 +1512,13 @@ export const deserializeAws_restJson1DescribeBrokerCommand = async (
     );
   }
   if (data.pendingAuthenticationStrategy !== undefined && data.pendingAuthenticationStrategy !== null) {
-    contents.PendingAuthenticationStrategy = data.pendingAuthenticationStrategy;
+    contents.PendingAuthenticationStrategy = __expectString(data.pendingAuthenticationStrategy);
   }
   if (data.pendingEngineVersion !== undefined && data.pendingEngineVersion !== null) {
-    contents.PendingEngineVersion = data.pendingEngineVersion;
+    contents.PendingEngineVersion = __expectString(data.pendingEngineVersion);
   }
   if (data.pendingHostInstanceType !== undefined && data.pendingHostInstanceType !== null) {
-    contents.PendingHostInstanceType = data.pendingHostInstanceType;
+    contents.PendingHostInstanceType = __expectString(data.pendingHostInstanceType);
   }
   if (data.pendingLdapServerMetadata !== undefined && data.pendingLdapServerMetadata !== null) {
     contents.PendingLdapServerMetadata = deserializeAws_restJson1LdapServerMetadataOutput(
@@ -1527,13 +1530,13 @@ export const deserializeAws_restJson1DescribeBrokerCommand = async (
     contents.PendingSecurityGroups = deserializeAws_restJson1__listOf__string(data.pendingSecurityGroups, context);
   }
   if (data.publiclyAccessible !== undefined && data.publiclyAccessible !== null) {
-    contents.PubliclyAccessible = data.publiclyAccessible;
+    contents.PubliclyAccessible = __expectBoolean(data.publiclyAccessible);
   }
   if (data.securityGroups !== undefined && data.securityGroups !== null) {
     contents.SecurityGroups = deserializeAws_restJson1__listOf__string(data.securityGroups, context);
   }
   if (data.storageType !== undefined && data.storageType !== null) {
-    contents.StorageType = data.storageType;
+    contents.StorageType = __expectString(data.storageType);
   }
   if (data.subnetIds !== undefined && data.subnetIds !== null) {
     contents.SubnetIds = deserializeAws_restJson1__listOf__string(data.subnetIds, context);
@@ -1626,10 +1629,10 @@ export const deserializeAws_restJson1DescribeBrokerEngineTypesCommand = async (
     contents.BrokerEngineTypes = deserializeAws_restJson1__listOfBrokerEngineType(data.brokerEngineTypes, context);
   }
   if (data.maxResults !== undefined && data.maxResults !== null) {
-    contents.MaxResults = data.maxResults;
+    contents.MaxResults = __expectNumber(data.maxResults);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1708,10 +1711,10 @@ export const deserializeAws_restJson1DescribeBrokerInstanceOptionsCommand = asyn
     );
   }
   if (data.maxResults !== undefined && data.maxResults !== null) {
-    contents.MaxResults = data.maxResults;
+    contents.MaxResults = __expectNumber(data.maxResults);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1791,31 +1794,31 @@ export const deserializeAws_restJson1DescribeConfigurationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.Arn = data.arn;
+    contents.Arn = __expectString(data.arn);
   }
   if (data.authenticationStrategy !== undefined && data.authenticationStrategy !== null) {
-    contents.AuthenticationStrategy = data.authenticationStrategy;
+    contents.AuthenticationStrategy = __expectString(data.authenticationStrategy);
   }
   if (data.created !== undefined && data.created !== null) {
     contents.Created = new Date(data.created);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.Description = data.description;
+    contents.Description = __expectString(data.description);
   }
   if (data.engineType !== undefined && data.engineType !== null) {
-    contents.EngineType = data.engineType;
+    contents.EngineType = __expectString(data.engineType);
   }
   if (data.engineVersion !== undefined && data.engineVersion !== null) {
-    contents.EngineVersion = data.engineVersion;
+    contents.EngineVersion = __expectString(data.engineVersion);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.Id = data.id;
+    contents.Id = __expectString(data.id);
   }
   if (data.latestRevision !== undefined && data.latestRevision !== null) {
     contents.LatestRevision = deserializeAws_restJson1ConfigurationRevision(data.latestRevision, context);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.Name = data.name;
+    contents.Name = __expectString(data.name);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1__mapOf__string(data.tags, context);
@@ -1900,16 +1903,16 @@ export const deserializeAws_restJson1DescribeConfigurationRevisionCommand = asyn
   };
   const data: any = await parseBody(output.body, context);
   if (data.configurationId !== undefined && data.configurationId !== null) {
-    contents.ConfigurationId = data.configurationId;
+    contents.ConfigurationId = __expectString(data.configurationId);
   }
   if (data.created !== undefined && data.created !== null) {
     contents.Created = new Date(data.created);
   }
   if (data.data !== undefined && data.data !== null) {
-    contents.Data = data.data;
+    contents.Data = __expectString(data.data);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.Description = data.description;
+    contents.Description = __expectString(data.description);
   }
   return Promise.resolve(contents);
 };
@@ -1992,10 +1995,10 @@ export const deserializeAws_restJson1DescribeUserCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.brokerId !== undefined && data.brokerId !== null) {
-    contents.BrokerId = data.brokerId;
+    contents.BrokerId = __expectString(data.brokerId);
   }
   if (data.consoleAccess !== undefined && data.consoleAccess !== null) {
-    contents.ConsoleAccess = data.consoleAccess;
+    contents.ConsoleAccess = __expectBoolean(data.consoleAccess);
   }
   if (data.groups !== undefined && data.groups !== null) {
     contents.Groups = deserializeAws_restJson1__listOf__string(data.groups, context);
@@ -2004,7 +2007,7 @@ export const deserializeAws_restJson1DescribeUserCommand = async (
     contents.Pending = deserializeAws_restJson1UserPendingChanges(data.pending, context);
   }
   if (data.username !== undefined && data.username !== null) {
-    contents.Username = data.username;
+    contents.Username = __expectString(data.username);
   }
   return Promise.resolve(contents);
 };
@@ -2087,7 +2090,7 @@ export const deserializeAws_restJson1ListBrokersCommand = async (
     contents.BrokerSummaries = deserializeAws_restJson1__listOfBrokerSummary(data.brokerSummaries, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2161,13 +2164,13 @@ export const deserializeAws_restJson1ListConfigurationRevisionsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.configurationId !== undefined && data.configurationId !== null) {
-    contents.ConfigurationId = data.configurationId;
+    contents.ConfigurationId = __expectString(data.configurationId);
   }
   if (data.maxResults !== undefined && data.maxResults !== null) {
-    contents.MaxResults = data.maxResults;
+    contents.MaxResults = __expectNumber(data.maxResults);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   if (data.revisions !== undefined && data.revisions !== null) {
     contents.Revisions = deserializeAws_restJson1__listOfConfigurationRevision(data.revisions, context);
@@ -2254,10 +2257,10 @@ export const deserializeAws_restJson1ListConfigurationsCommand = async (
     contents.Configurations = deserializeAws_restJson1__listOfConfiguration(data.configurations, context);
   }
   if (data.maxResults !== undefined && data.maxResults !== null) {
-    contents.MaxResults = data.maxResults;
+    contents.MaxResults = __expectNumber(data.maxResults);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2410,13 +2413,13 @@ export const deserializeAws_restJson1ListUsersCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.brokerId !== undefined && data.brokerId !== null) {
-    contents.BrokerId = data.brokerId;
+    contents.BrokerId = __expectString(data.brokerId);
   }
   if (data.maxResults !== undefined && data.maxResults !== null) {
-    contents.MaxResults = data.maxResults;
+    contents.MaxResults = __expectNumber(data.maxResults);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   if (data.users !== undefined && data.users !== null) {
     contents.Users = deserializeAws_restJson1__listOfUserSummary(data.users, context);
@@ -2581,22 +2584,22 @@ export const deserializeAws_restJson1UpdateBrokerCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.authenticationStrategy !== undefined && data.authenticationStrategy !== null) {
-    contents.AuthenticationStrategy = data.authenticationStrategy;
+    contents.AuthenticationStrategy = __expectString(data.authenticationStrategy);
   }
   if (data.autoMinorVersionUpgrade !== undefined && data.autoMinorVersionUpgrade !== null) {
-    contents.AutoMinorVersionUpgrade = data.autoMinorVersionUpgrade;
+    contents.AutoMinorVersionUpgrade = __expectBoolean(data.autoMinorVersionUpgrade);
   }
   if (data.brokerId !== undefined && data.brokerId !== null) {
-    contents.BrokerId = data.brokerId;
+    contents.BrokerId = __expectString(data.brokerId);
   }
   if (data.configuration !== undefined && data.configuration !== null) {
     contents.Configuration = deserializeAws_restJson1ConfigurationId(data.configuration, context);
   }
   if (data.engineVersion !== undefined && data.engineVersion !== null) {
-    contents.EngineVersion = data.engineVersion;
+    contents.EngineVersion = __expectString(data.engineVersion);
   }
   if (data.hostInstanceType !== undefined && data.hostInstanceType !== null) {
-    contents.HostInstanceType = data.hostInstanceType;
+    contents.HostInstanceType = __expectString(data.hostInstanceType);
   }
   if (data.ldapServerMetadata !== undefined && data.ldapServerMetadata !== null) {
     contents.LdapServerMetadata = deserializeAws_restJson1LdapServerMetadataOutput(data.ldapServerMetadata, context);
@@ -2697,19 +2700,19 @@ export const deserializeAws_restJson1UpdateConfigurationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.Arn = data.arn;
+    contents.Arn = __expectString(data.arn);
   }
   if (data.created !== undefined && data.created !== null) {
     contents.Created = new Date(data.created);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.Id = data.id;
+    contents.Id = __expectString(data.id);
   }
   if (data.latestRevision !== undefined && data.latestRevision !== null) {
     contents.LatestRevision = deserializeAws_restJson1ConfigurationRevision(data.latestRevision, context);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.Name = data.name;
+    contents.Name = __expectString(data.name);
   }
   if (data.warnings !== undefined && data.warnings !== null) {
     contents.Warnings = deserializeAws_restJson1__listOfSanitizationWarning(data.warnings, context);
@@ -2882,10 +2885,10 @@ const deserializeAws_restJson1BadRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.errorAttribute !== undefined && data.errorAttribute !== null) {
-    contents.ErrorAttribute = data.errorAttribute;
+    contents.ErrorAttribute = __expectString(data.errorAttribute);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -2903,10 +2906,10 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.errorAttribute !== undefined && data.errorAttribute !== null) {
-    contents.ErrorAttribute = data.errorAttribute;
+    contents.ErrorAttribute = __expectString(data.errorAttribute);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -2924,10 +2927,10 @@ const deserializeAws_restJson1ForbiddenExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.errorAttribute !== undefined && data.errorAttribute !== null) {
-    contents.ErrorAttribute = data.errorAttribute;
+    contents.ErrorAttribute = __expectString(data.errorAttribute);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -2945,10 +2948,10 @@ const deserializeAws_restJson1InternalServerErrorExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.errorAttribute !== undefined && data.errorAttribute !== null) {
-    contents.ErrorAttribute = data.errorAttribute;
+    contents.ErrorAttribute = __expectString(data.errorAttribute);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -2966,10 +2969,10 @@ const deserializeAws_restJson1NotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.errorAttribute !== undefined && data.errorAttribute !== null) {
-    contents.ErrorAttribute = data.errorAttribute;
+    contents.ErrorAttribute = __expectString(data.errorAttribute);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -2987,10 +2990,10 @@ const deserializeAws_restJson1UnauthorizedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.errorAttribute !== undefined && data.errorAttribute !== null) {
-    contents.ErrorAttribute = data.errorAttribute;
+    contents.ErrorAttribute = __expectString(data.errorAttribute);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -3102,7 +3105,7 @@ const deserializeAws_restJson1__listOf__string = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3210,7 +3213,7 @@ const deserializeAws_restJson1__listOfDeploymentMode = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3257,20 +3260,20 @@ const deserializeAws_restJson1__mapOf__string = (output: any, context: __SerdeCo
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1AvailabilityZone = (output: any, context: __SerdeContext): AvailabilityZone => {
   return {
-    Name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    Name: __expectString(output.name),
   } as any;
 };
 
 const deserializeAws_restJson1BrokerEngineType = (output: any, context: __SerdeContext): BrokerEngineType => {
   return {
-    EngineType: output.engineType !== undefined && output.engineType !== null ? output.engineType : undefined,
+    EngineType: __expectString(output.engineType),
     EngineVersions:
       output.engineVersions !== undefined && output.engineVersions !== null
         ? deserializeAws_restJson1__listOfEngineVersion(output.engineVersions, context)
@@ -3280,12 +3283,12 @@ const deserializeAws_restJson1BrokerEngineType = (output: any, context: __SerdeC
 
 const deserializeAws_restJson1BrokerInstance = (output: any, context: __SerdeContext): BrokerInstance => {
   return {
-    ConsoleURL: output.consoleURL !== undefined && output.consoleURL !== null ? output.consoleURL : undefined,
+    ConsoleURL: __expectString(output.consoleURL),
     Endpoints:
       output.endpoints !== undefined && output.endpoints !== null
         ? deserializeAws_restJson1__listOf__string(output.endpoints, context)
         : undefined,
-    IpAddress: output.ipAddress !== undefined && output.ipAddress !== null ? output.ipAddress : undefined,
+    IpAddress: __expectString(output.ipAddress),
   } as any;
 };
 
@@ -3295,10 +3298,9 @@ const deserializeAws_restJson1BrokerInstanceOption = (output: any, context: __Se
       output.availabilityZones !== undefined && output.availabilityZones !== null
         ? deserializeAws_restJson1__listOfAvailabilityZone(output.availabilityZones, context)
         : undefined,
-    EngineType: output.engineType !== undefined && output.engineType !== null ? output.engineType : undefined,
-    HostInstanceType:
-      output.hostInstanceType !== undefined && output.hostInstanceType !== null ? output.hostInstanceType : undefined,
-    StorageType: output.storageType !== undefined && output.storageType !== null ? output.storageType : undefined,
+    EngineType: __expectString(output.engineType),
+    HostInstanceType: __expectString(output.hostInstanceType),
+    StorageType: __expectString(output.storageType),
     SupportedDeploymentModes:
       output.supportedDeploymentModes !== undefined && output.supportedDeploymentModes !== null
         ? deserializeAws_restJson1__listOfDeploymentMode(output.supportedDeploymentModes, context)
@@ -3312,37 +3314,31 @@ const deserializeAws_restJson1BrokerInstanceOption = (output: any, context: __Se
 
 const deserializeAws_restJson1BrokerSummary = (output: any, context: __SerdeContext): BrokerSummary => {
   return {
-    BrokerArn: output.brokerArn !== undefined && output.brokerArn !== null ? output.brokerArn : undefined,
-    BrokerId: output.brokerId !== undefined && output.brokerId !== null ? output.brokerId : undefined,
-    BrokerName: output.brokerName !== undefined && output.brokerName !== null ? output.brokerName : undefined,
-    BrokerState: output.brokerState !== undefined && output.brokerState !== null ? output.brokerState : undefined,
+    BrokerArn: __expectString(output.brokerArn),
+    BrokerId: __expectString(output.brokerId),
+    BrokerName: __expectString(output.brokerName),
+    BrokerState: __expectString(output.brokerState),
     Created: output.created !== undefined && output.created !== null ? new Date(output.created) : undefined,
-    DeploymentMode:
-      output.deploymentMode !== undefined && output.deploymentMode !== null ? output.deploymentMode : undefined,
-    EngineType: output.engineType !== undefined && output.engineType !== null ? output.engineType : undefined,
-    HostInstanceType:
-      output.hostInstanceType !== undefined && output.hostInstanceType !== null ? output.hostInstanceType : undefined,
+    DeploymentMode: __expectString(output.deploymentMode),
+    EngineType: __expectString(output.engineType),
+    HostInstanceType: __expectString(output.hostInstanceType),
   } as any;
 };
 
 const deserializeAws_restJson1Configuration = (output: any, context: __SerdeContext): Configuration => {
   return {
-    Arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    AuthenticationStrategy:
-      output.authenticationStrategy !== undefined && output.authenticationStrategy !== null
-        ? output.authenticationStrategy
-        : undefined,
+    Arn: __expectString(output.arn),
+    AuthenticationStrategy: __expectString(output.authenticationStrategy),
     Created: output.created !== undefined && output.created !== null ? new Date(output.created) : undefined,
-    Description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    EngineType: output.engineType !== undefined && output.engineType !== null ? output.engineType : undefined,
-    EngineVersion:
-      output.engineVersion !== undefined && output.engineVersion !== null ? output.engineVersion : undefined,
-    Id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    Description: __expectString(output.description),
+    EngineType: __expectString(output.engineType),
+    EngineVersion: __expectString(output.engineVersion),
+    Id: __expectString(output.id),
     LatestRevision:
       output.latestRevision !== undefined && output.latestRevision !== null
         ? deserializeAws_restJson1ConfigurationRevision(output.latestRevision, context)
         : undefined,
-    Name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    Name: __expectString(output.name),
     Tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1__mapOf__string(output.tags, context)
@@ -3352,16 +3348,16 @@ const deserializeAws_restJson1Configuration = (output: any, context: __SerdeCont
 
 const deserializeAws_restJson1ConfigurationId = (output: any, context: __SerdeContext): ConfigurationId => {
   return {
-    Id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    Revision: output.revision !== undefined && output.revision !== null ? output.revision : undefined,
+    Id: __expectString(output.id),
+    Revision: __expectNumber(output.revision),
   } as any;
 };
 
 const deserializeAws_restJson1ConfigurationRevision = (output: any, context: __SerdeContext): ConfigurationRevision => {
   return {
     Created: output.created !== undefined && output.created !== null ? new Date(output.created) : undefined,
-    Description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    Revision: output.revision !== undefined && output.revision !== null ? output.revision : undefined,
+    Description: __expectString(output.description),
+    Revision: __expectNumber(output.revision),
   } as any;
 };
 
@@ -3384,15 +3380,14 @@ const deserializeAws_restJson1Configurations = (output: any, context: __SerdeCon
 
 const deserializeAws_restJson1EncryptionOptions = (output: any, context: __SerdeContext): EncryptionOptions => {
   return {
-    KmsKeyId: output.kmsKeyId !== undefined && output.kmsKeyId !== null ? output.kmsKeyId : undefined,
-    UseAwsOwnedKey:
-      output.useAwsOwnedKey !== undefined && output.useAwsOwnedKey !== null ? output.useAwsOwnedKey : undefined,
+    KmsKeyId: __expectString(output.kmsKeyId),
+    UseAwsOwnedKey: __expectBoolean(output.useAwsOwnedKey),
   } as any;
 };
 
 const deserializeAws_restJson1EngineVersion = (output: any, context: __SerdeContext): EngineVersion => {
   return {
-    Name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    Name: __expectString(output.name),
   } as any;
 };
 
@@ -3405,48 +3400,31 @@ const deserializeAws_restJson1LdapServerMetadataOutput = (
       output.hosts !== undefined && output.hosts !== null
         ? deserializeAws_restJson1__listOf__string(output.hosts, context)
         : undefined,
-    RoleBase: output.roleBase !== undefined && output.roleBase !== null ? output.roleBase : undefined,
-    RoleName: output.roleName !== undefined && output.roleName !== null ? output.roleName : undefined,
-    RoleSearchMatching:
-      output.roleSearchMatching !== undefined && output.roleSearchMatching !== null
-        ? output.roleSearchMatching
-        : undefined,
-    RoleSearchSubtree:
-      output.roleSearchSubtree !== undefined && output.roleSearchSubtree !== null
-        ? output.roleSearchSubtree
-        : undefined,
-    ServiceAccountUsername:
-      output.serviceAccountUsername !== undefined && output.serviceAccountUsername !== null
-        ? output.serviceAccountUsername
-        : undefined,
-    UserBase: output.userBase !== undefined && output.userBase !== null ? output.userBase : undefined,
-    UserRoleName: output.userRoleName !== undefined && output.userRoleName !== null ? output.userRoleName : undefined,
-    UserSearchMatching:
-      output.userSearchMatching !== undefined && output.userSearchMatching !== null
-        ? output.userSearchMatching
-        : undefined,
-    UserSearchSubtree:
-      output.userSearchSubtree !== undefined && output.userSearchSubtree !== null
-        ? output.userSearchSubtree
-        : undefined,
+    RoleBase: __expectString(output.roleBase),
+    RoleName: __expectString(output.roleName),
+    RoleSearchMatching: __expectString(output.roleSearchMatching),
+    RoleSearchSubtree: __expectBoolean(output.roleSearchSubtree),
+    ServiceAccountUsername: __expectString(output.serviceAccountUsername),
+    UserBase: __expectString(output.userBase),
+    UserRoleName: __expectString(output.userRoleName),
+    UserSearchMatching: __expectString(output.userSearchMatching),
+    UserSearchSubtree: __expectBoolean(output.userSearchSubtree),
   } as any;
 };
 
 const deserializeAws_restJson1Logs = (output: any, context: __SerdeContext): Logs => {
   return {
-    Audit: output.audit !== undefined && output.audit !== null ? output.audit : undefined,
-    General: output.general !== undefined && output.general !== null ? output.general : undefined,
+    Audit: __expectBoolean(output.audit),
+    General: __expectBoolean(output.general),
   } as any;
 };
 
 const deserializeAws_restJson1LogsSummary = (output: any, context: __SerdeContext): LogsSummary => {
   return {
-    Audit: output.audit !== undefined && output.audit !== null ? output.audit : undefined,
-    AuditLogGroup:
-      output.auditLogGroup !== undefined && output.auditLogGroup !== null ? output.auditLogGroup : undefined,
-    General: output.general !== undefined && output.general !== null ? output.general : undefined,
-    GeneralLogGroup:
-      output.generalLogGroup !== undefined && output.generalLogGroup !== null ? output.generalLogGroup : undefined,
+    Audit: __expectBoolean(output.audit),
+    AuditLogGroup: __expectString(output.auditLogGroup),
+    General: __expectBoolean(output.general),
+    GeneralLogGroup: __expectString(output.generalLogGroup),
     Pending:
       output.pending !== undefined && output.pending !== null
         ? deserializeAws_restJson1PendingLogs(output.pending, context)
@@ -3456,46 +3434,42 @@ const deserializeAws_restJson1LogsSummary = (output: any, context: __SerdeContex
 
 const deserializeAws_restJson1PendingLogs = (output: any, context: __SerdeContext): PendingLogs => {
   return {
-    Audit: output.audit !== undefined && output.audit !== null ? output.audit : undefined,
-    General: output.general !== undefined && output.general !== null ? output.general : undefined,
+    Audit: __expectBoolean(output.audit),
+    General: __expectBoolean(output.general),
   } as any;
 };
 
 const deserializeAws_restJson1SanitizationWarning = (output: any, context: __SerdeContext): SanitizationWarning => {
   return {
-    AttributeName:
-      output.attributeName !== undefined && output.attributeName !== null ? output.attributeName : undefined,
-    ElementName: output.elementName !== undefined && output.elementName !== null ? output.elementName : undefined,
-    Reason: output.reason !== undefined && output.reason !== null ? output.reason : undefined,
+    AttributeName: __expectString(output.attributeName),
+    ElementName: __expectString(output.elementName),
+    Reason: __expectString(output.reason),
   } as any;
 };
 
 const deserializeAws_restJson1UserPendingChanges = (output: any, context: __SerdeContext): UserPendingChanges => {
   return {
-    ConsoleAccess:
-      output.consoleAccess !== undefined && output.consoleAccess !== null ? output.consoleAccess : undefined,
+    ConsoleAccess: __expectBoolean(output.consoleAccess),
     Groups:
       output.groups !== undefined && output.groups !== null
         ? deserializeAws_restJson1__listOf__string(output.groups, context)
         : undefined,
-    PendingChange:
-      output.pendingChange !== undefined && output.pendingChange !== null ? output.pendingChange : undefined,
+    PendingChange: __expectString(output.pendingChange),
   } as any;
 };
 
 const deserializeAws_restJson1UserSummary = (output: any, context: __SerdeContext): UserSummary => {
   return {
-    PendingChange:
-      output.pendingChange !== undefined && output.pendingChange !== null ? output.pendingChange : undefined,
-    Username: output.username !== undefined && output.username !== null ? output.username : undefined,
+    PendingChange: __expectString(output.pendingChange),
+    Username: __expectString(output.username),
   } as any;
 };
 
 const deserializeAws_restJson1WeeklyStartTime = (output: any, context: __SerdeContext): WeeklyStartTime => {
   return {
-    DayOfWeek: output.dayOfWeek !== undefined && output.dayOfWeek !== null ? output.dayOfWeek : undefined,
-    TimeOfDay: output.timeOfDay !== undefined && output.timeOfDay !== null ? output.timeOfDay : undefined,
-    TimeZone: output.timeZone !== undefined && output.timeZone !== null ? output.timeZone : undefined,
+    DayOfWeek: __expectString(output.dayOfWeek),
+    TimeOfDay: __expectString(output.timeOfDay),
+    TimeZone: __expectString(output.timeZone),
   } as any;
 };
 

--- a/clients/client-mturk/protocols/Aws_json1_1.ts
+++ b/clients/client-mturk/protocols/Aws_json1_1.ts
@@ -204,7 +204,12 @@ import {
   WorkerBlock,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -3899,14 +3904,13 @@ const deserializeAws_json1_1Assignment = (output: any, context: __SerdeContext):
       output.AcceptTime !== undefined && output.AcceptTime !== null
         ? new Date(Math.round(output.AcceptTime * 1000))
         : undefined,
-    Answer: output.Answer !== undefined && output.Answer !== null ? output.Answer : undefined,
+    Answer: __expectString(output.Answer),
     ApprovalTime:
       output.ApprovalTime !== undefined && output.ApprovalTime !== null
         ? new Date(Math.round(output.ApprovalTime * 1000))
         : undefined,
-    AssignmentId: output.AssignmentId !== undefined && output.AssignmentId !== null ? output.AssignmentId : undefined,
-    AssignmentStatus:
-      output.AssignmentStatus !== undefined && output.AssignmentStatus !== null ? output.AssignmentStatus : undefined,
+    AssignmentId: __expectString(output.AssignmentId),
+    AssignmentStatus: __expectString(output.AssignmentStatus),
     AutoApprovalTime:
       output.AutoApprovalTime !== undefined && output.AutoApprovalTime !== null
         ? new Date(Math.round(output.AutoApprovalTime * 1000))
@@ -3915,20 +3919,17 @@ const deserializeAws_json1_1Assignment = (output: any, context: __SerdeContext):
       output.Deadline !== undefined && output.Deadline !== null
         ? new Date(Math.round(output.Deadline * 1000))
         : undefined,
-    HITId: output.HITId !== undefined && output.HITId !== null ? output.HITId : undefined,
+    HITId: __expectString(output.HITId),
     RejectionTime:
       output.RejectionTime !== undefined && output.RejectionTime !== null
         ? new Date(Math.round(output.RejectionTime * 1000))
         : undefined,
-    RequesterFeedback:
-      output.RequesterFeedback !== undefined && output.RequesterFeedback !== null
-        ? output.RequesterFeedback
-        : undefined,
+    RequesterFeedback: __expectString(output.RequesterFeedback),
     SubmitTime:
       output.SubmitTime !== undefined && output.SubmitTime !== null
         ? new Date(Math.round(output.SubmitTime * 1000))
         : undefined,
-    WorkerId: output.WorkerId !== undefined && output.WorkerId !== null ? output.WorkerId : undefined,
+    WorkerId: __expectString(output.WorkerId),
   } as any;
 };
 
@@ -3952,14 +3953,14 @@ const deserializeAws_json1_1AssociateQualificationWithWorkerResponse = (
 
 const deserializeAws_json1_1BonusPayment = (output: any, context: __SerdeContext): BonusPayment => {
   return {
-    AssignmentId: output.AssignmentId !== undefined && output.AssignmentId !== null ? output.AssignmentId : undefined,
-    BonusAmount: output.BonusAmount !== undefined && output.BonusAmount !== null ? output.BonusAmount : undefined,
+    AssignmentId: __expectString(output.AssignmentId),
+    BonusAmount: __expectString(output.BonusAmount),
     GrantTime:
       output.GrantTime !== undefined && output.GrantTime !== null
         ? new Date(Math.round(output.GrantTime * 1000))
         : undefined,
-    Reason: output.Reason !== undefined && output.Reason !== null ? output.Reason : undefined,
-    WorkerId: output.WorkerId !== undefined && output.WorkerId !== null ? output.WorkerId : undefined,
+    Reason: __expectString(output.Reason),
+    WorkerId: __expectString(output.WorkerId),
   } as any;
 };
 
@@ -3989,7 +3990,7 @@ const deserializeAws_json1_1CreateHITResponse = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1CreateHITTypeResponse = (output: any, context: __SerdeContext): CreateHITTypeResponse => {
   return {
-    HITTypeId: output.HITTypeId !== undefined && output.HITTypeId !== null ? output.HITTypeId : undefined,
+    HITTypeId: __expectString(output.HITTypeId),
   } as any;
 };
 
@@ -4051,10 +4052,8 @@ const deserializeAws_json1_1GetAccountBalanceResponse = (
   context: __SerdeContext
 ): GetAccountBalanceResponse => {
   return {
-    AvailableBalance:
-      output.AvailableBalance !== undefined && output.AvailableBalance !== null ? output.AvailableBalance : undefined,
-    OnHoldBalance:
-      output.OnHoldBalance !== undefined && output.OnHoldBalance !== null ? output.OnHoldBalance : undefined,
+    AvailableBalance: __expectString(output.AvailableBalance),
+    OnHoldBalance: __expectString(output.OnHoldBalance),
   } as any;
 };
 
@@ -4073,8 +4072,7 @@ const deserializeAws_json1_1GetFileUploadURLResponse = (
   context: __SerdeContext
 ): GetFileUploadURLResponse => {
   return {
-    FileUploadURL:
-      output.FileUploadURL !== undefined && output.FileUploadURL !== null ? output.FileUploadURL : undefined,
+    FileUploadURL: __expectString(output.FileUploadURL),
   } as any;
 };
 
@@ -4110,56 +4108,36 @@ const deserializeAws_json1_1GetQualificationTypeResponse = (
 
 const deserializeAws_json1_1HIT = (output: any, context: __SerdeContext): HIT => {
   return {
-    AssignmentDurationInSeconds:
-      output.AssignmentDurationInSeconds !== undefined && output.AssignmentDurationInSeconds !== null
-        ? output.AssignmentDurationInSeconds
-        : undefined,
-    AutoApprovalDelayInSeconds:
-      output.AutoApprovalDelayInSeconds !== undefined && output.AutoApprovalDelayInSeconds !== null
-        ? output.AutoApprovalDelayInSeconds
-        : undefined,
+    AssignmentDurationInSeconds: __expectNumber(output.AssignmentDurationInSeconds),
+    AutoApprovalDelayInSeconds: __expectNumber(output.AutoApprovalDelayInSeconds),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     Expiration:
       output.Expiration !== undefined && output.Expiration !== null
         ? new Date(Math.round(output.Expiration * 1000))
         : undefined,
-    HITGroupId: output.HITGroupId !== undefined && output.HITGroupId !== null ? output.HITGroupId : undefined,
-    HITId: output.HITId !== undefined && output.HITId !== null ? output.HITId : undefined,
-    HITLayoutId: output.HITLayoutId !== undefined && output.HITLayoutId !== null ? output.HITLayoutId : undefined,
-    HITReviewStatus:
-      output.HITReviewStatus !== undefined && output.HITReviewStatus !== null ? output.HITReviewStatus : undefined,
-    HITStatus: output.HITStatus !== undefined && output.HITStatus !== null ? output.HITStatus : undefined,
-    HITTypeId: output.HITTypeId !== undefined && output.HITTypeId !== null ? output.HITTypeId : undefined,
-    Keywords: output.Keywords !== undefined && output.Keywords !== null ? output.Keywords : undefined,
-    MaxAssignments:
-      output.MaxAssignments !== undefined && output.MaxAssignments !== null ? output.MaxAssignments : undefined,
-    NumberOfAssignmentsAvailable:
-      output.NumberOfAssignmentsAvailable !== undefined && output.NumberOfAssignmentsAvailable !== null
-        ? output.NumberOfAssignmentsAvailable
-        : undefined,
-    NumberOfAssignmentsCompleted:
-      output.NumberOfAssignmentsCompleted !== undefined && output.NumberOfAssignmentsCompleted !== null
-        ? output.NumberOfAssignmentsCompleted
-        : undefined,
-    NumberOfAssignmentsPending:
-      output.NumberOfAssignmentsPending !== undefined && output.NumberOfAssignmentsPending !== null
-        ? output.NumberOfAssignmentsPending
-        : undefined,
+    HITGroupId: __expectString(output.HITGroupId),
+    HITId: __expectString(output.HITId),
+    HITLayoutId: __expectString(output.HITLayoutId),
+    HITReviewStatus: __expectString(output.HITReviewStatus),
+    HITStatus: __expectString(output.HITStatus),
+    HITTypeId: __expectString(output.HITTypeId),
+    Keywords: __expectString(output.Keywords),
+    MaxAssignments: __expectNumber(output.MaxAssignments),
+    NumberOfAssignmentsAvailable: __expectNumber(output.NumberOfAssignmentsAvailable),
+    NumberOfAssignmentsCompleted: __expectNumber(output.NumberOfAssignmentsCompleted),
+    NumberOfAssignmentsPending: __expectNumber(output.NumberOfAssignmentsPending),
     QualificationRequirements:
       output.QualificationRequirements !== undefined && output.QualificationRequirements !== null
         ? deserializeAws_json1_1QualificationRequirementList(output.QualificationRequirements, context)
         : undefined,
-    Question: output.Question !== undefined && output.Question !== null ? output.Question : undefined,
-    RequesterAnnotation:
-      output.RequesterAnnotation !== undefined && output.RequesterAnnotation !== null
-        ? output.RequesterAnnotation
-        : undefined,
-    Reward: output.Reward !== undefined && output.Reward !== null ? output.Reward : undefined,
-    Title: output.Title !== undefined && output.Title !== null ? output.Title : undefined,
+    Question: __expectString(output.Question),
+    RequesterAnnotation: __expectString(output.RequesterAnnotation),
+    Reward: __expectString(output.Reward),
+    Title: __expectString(output.Title),
   } as any;
 };
 
@@ -4181,7 +4159,7 @@ const deserializeAws_json1_1IntegerList = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectNumber(entry) as any;
     });
 };
 
@@ -4194,8 +4172,8 @@ const deserializeAws_json1_1ListAssignmentsForHITResponse = (
       output.Assignments !== undefined && output.Assignments !== null
         ? deserializeAws_json1_1AssignmentList(output.Assignments, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
-    NumResults: output.NumResults !== undefined && output.NumResults !== null ? output.NumResults : undefined,
+    NextToken: __expectString(output.NextToken),
+    NumResults: __expectNumber(output.NumResults),
   } as any;
 };
 
@@ -4208,8 +4186,8 @@ const deserializeAws_json1_1ListBonusPaymentsResponse = (
       output.BonusPayments !== undefined && output.BonusPayments !== null
         ? deserializeAws_json1_1BonusPaymentList(output.BonusPayments, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
-    NumResults: output.NumResults !== undefined && output.NumResults !== null ? output.NumResults : undefined,
+    NextToken: __expectString(output.NextToken),
+    NumResults: __expectNumber(output.NumResults),
   } as any;
 };
 
@@ -4222,8 +4200,8 @@ const deserializeAws_json1_1ListHITsForQualificationTypeResponse = (
       output.HITs !== undefined && output.HITs !== null
         ? deserializeAws_json1_1HITList(output.HITs, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
-    NumResults: output.NumResults !== undefined && output.NumResults !== null ? output.NumResults : undefined,
+    NextToken: __expectString(output.NextToken),
+    NumResults: __expectNumber(output.NumResults),
   } as any;
 };
 
@@ -4233,8 +4211,8 @@ const deserializeAws_json1_1ListHITsResponse = (output: any, context: __SerdeCon
       output.HITs !== undefined && output.HITs !== null
         ? deserializeAws_json1_1HITList(output.HITs, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
-    NumResults: output.NumResults !== undefined && output.NumResults !== null ? output.NumResults : undefined,
+    NextToken: __expectString(output.NextToken),
+    NumResults: __expectNumber(output.NumResults),
   } as any;
 };
 
@@ -4243,8 +4221,8 @@ const deserializeAws_json1_1ListQualificationRequestsResponse = (
   context: __SerdeContext
 ): ListQualificationRequestsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
-    NumResults: output.NumResults !== undefined && output.NumResults !== null ? output.NumResults : undefined,
+    NextToken: __expectString(output.NextToken),
+    NumResults: __expectNumber(output.NumResults),
     QualificationRequests:
       output.QualificationRequests !== undefined && output.QualificationRequests !== null
         ? deserializeAws_json1_1QualificationRequestList(output.QualificationRequests, context)
@@ -4257,8 +4235,8 @@ const deserializeAws_json1_1ListQualificationTypesResponse = (
   context: __SerdeContext
 ): ListQualificationTypesResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
-    NumResults: output.NumResults !== undefined && output.NumResults !== null ? output.NumResults : undefined,
+    NextToken: __expectString(output.NextToken),
+    NumResults: __expectNumber(output.NumResults),
     QualificationTypes:
       output.QualificationTypes !== undefined && output.QualificationTypes !== null
         ? deserializeAws_json1_1QualificationTypeList(output.QualificationTypes, context)
@@ -4275,8 +4253,8 @@ const deserializeAws_json1_1ListReviewableHITsResponse = (
       output.HITs !== undefined && output.HITs !== null
         ? deserializeAws_json1_1HITList(output.HITs, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
-    NumResults: output.NumResults !== undefined && output.NumResults !== null ? output.NumResults : undefined,
+    NextToken: __expectString(output.NextToken),
+    NumResults: __expectNumber(output.NumResults),
   } as any;
 };
 
@@ -4293,7 +4271,7 @@ const deserializeAws_json1_1ListReviewPolicyResultsForHITResponse = (
       output.AssignmentReviewReport !== undefined && output.AssignmentReviewReport !== null
         ? deserializeAws_json1_1ReviewReport(output.AssignmentReviewReport, context)
         : undefined,
-    HITId: output.HITId !== undefined && output.HITId !== null ? output.HITId : undefined,
+    HITId: __expectString(output.HITId),
     HITReviewPolicy:
       output.HITReviewPolicy !== undefined && output.HITReviewPolicy !== null
         ? deserializeAws_json1_1ReviewPolicy(output.HITReviewPolicy, context)
@@ -4302,7 +4280,7 @@ const deserializeAws_json1_1ListReviewPolicyResultsForHITResponse = (
       output.HITReviewReport !== undefined && output.HITReviewReport !== null
         ? deserializeAws_json1_1ReviewReport(output.HITReviewReport, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -4311,8 +4289,8 @@ const deserializeAws_json1_1ListWorkerBlocksResponse = (
   context: __SerdeContext
 ): ListWorkerBlocksResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
-    NumResults: output.NumResults !== undefined && output.NumResults !== null ? output.NumResults : undefined,
+    NextToken: __expectString(output.NextToken),
+    NumResults: __expectNumber(output.NumResults),
     WorkerBlocks:
       output.WorkerBlocks !== undefined && output.WorkerBlocks !== null
         ? deserializeAws_json1_1WorkerBlockList(output.WorkerBlocks, context)
@@ -4325,8 +4303,8 @@ const deserializeAws_json1_1ListWorkersWithQualificationTypeResponse = (
   context: __SerdeContext
 ): ListWorkersWithQualificationTypeResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
-    NumResults: output.NumResults !== undefined && output.NumResults !== null ? output.NumResults : undefined,
+    NextToken: __expectString(output.NextToken),
+    NumResults: __expectNumber(output.NumResults),
     Qualifications:
       output.Qualifications !== undefined && output.Qualifications !== null
         ? deserializeAws_json1_1QualificationList(output.Qualifications, context)
@@ -4336,8 +4314,8 @@ const deserializeAws_json1_1ListWorkersWithQualificationTypeResponse = (
 
 const deserializeAws_json1_1Locale = (output: any, context: __SerdeContext): Locale => {
   return {
-    Country: output.Country !== undefined && output.Country !== null ? output.Country : undefined,
-    Subdivision: output.Subdivision !== undefined && output.Subdivision !== null ? output.Subdivision : undefined,
+    Country: __expectString(output.Country),
+    Subdivision: __expectString(output.Subdivision),
   } as any;
 };
 
@@ -4357,15 +4335,9 @@ const deserializeAws_json1_1NotifyWorkersFailureStatus = (
   context: __SerdeContext
 ): NotifyWorkersFailureStatus => {
   return {
-    NotifyWorkersFailureCode:
-      output.NotifyWorkersFailureCode !== undefined && output.NotifyWorkersFailureCode !== null
-        ? output.NotifyWorkersFailureCode
-        : undefined,
-    NotifyWorkersFailureMessage:
-      output.NotifyWorkersFailureMessage !== undefined && output.NotifyWorkersFailureMessage !== null
-        ? output.NotifyWorkersFailureMessage
-        : undefined,
-    WorkerId: output.WorkerId !== undefined && output.WorkerId !== null ? output.WorkerId : undefined,
+    NotifyWorkersFailureCode: __expectString(output.NotifyWorkersFailureCode),
+    NotifyWorkersFailureMessage: __expectString(output.NotifyWorkersFailureMessage),
+    WorkerId: __expectString(output.WorkerId),
   } as any;
 };
 
@@ -4394,7 +4366,7 @@ const deserializeAws_json1_1NotifyWorkersResponse = (output: any, context: __Ser
 
 const deserializeAws_json1_1ParameterMapEntry = (output: any, context: __SerdeContext): ParameterMapEntry => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
+    Key: __expectString(output.Key),
     Values:
       output.Values !== undefined && output.Values !== null
         ? deserializeAws_json1_1StringList(output.Values, context)
@@ -4415,7 +4387,7 @@ const deserializeAws_json1_1ParameterMapEntryList = (output: any, context: __Ser
 
 const deserializeAws_json1_1PolicyParameter = (output: any, context: __SerdeContext): PolicyParameter => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
+    Key: __expectString(output.Key),
     MapEntries:
       output.MapEntries !== undefined && output.MapEntries !== null
         ? deserializeAws_json1_1ParameterMapEntryList(output.MapEntries, context)
@@ -4444,17 +4416,14 @@ const deserializeAws_json1_1Qualification = (output: any, context: __SerdeContex
       output.GrantTime !== undefined && output.GrantTime !== null
         ? new Date(Math.round(output.GrantTime * 1000))
         : undefined,
-    IntegerValue: output.IntegerValue !== undefined && output.IntegerValue !== null ? output.IntegerValue : undefined,
+    IntegerValue: __expectNumber(output.IntegerValue),
     LocaleValue:
       output.LocaleValue !== undefined && output.LocaleValue !== null
         ? deserializeAws_json1_1Locale(output.LocaleValue, context)
         : undefined,
-    QualificationTypeId:
-      output.QualificationTypeId !== undefined && output.QualificationTypeId !== null
-        ? output.QualificationTypeId
-        : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    WorkerId: output.WorkerId !== undefined && output.WorkerId !== null ? output.WorkerId : undefined,
+    QualificationTypeId: __expectString(output.QualificationTypeId),
+    Status: __expectString(output.Status),
+    WorkerId: __expectString(output.WorkerId),
   } as any;
 };
 
@@ -4471,21 +4440,15 @@ const deserializeAws_json1_1QualificationList = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1QualificationRequest = (output: any, context: __SerdeContext): QualificationRequest => {
   return {
-    Answer: output.Answer !== undefined && output.Answer !== null ? output.Answer : undefined,
-    QualificationRequestId:
-      output.QualificationRequestId !== undefined && output.QualificationRequestId !== null
-        ? output.QualificationRequestId
-        : undefined,
-    QualificationTypeId:
-      output.QualificationTypeId !== undefined && output.QualificationTypeId !== null
-        ? output.QualificationTypeId
-        : undefined,
+    Answer: __expectString(output.Answer),
+    QualificationRequestId: __expectString(output.QualificationRequestId),
+    QualificationTypeId: __expectString(output.QualificationTypeId),
     SubmitTime:
       output.SubmitTime !== undefined && output.SubmitTime !== null
         ? new Date(Math.round(output.SubmitTime * 1000))
         : undefined,
-    Test: output.Test !== undefined && output.Test !== null ? output.Test : undefined,
-    WorkerId: output.WorkerId !== undefined && output.WorkerId !== null ? output.WorkerId : undefined,
+    Test: __expectString(output.Test),
+    WorkerId: __expectString(output.WorkerId),
   } as any;
 };
 
@@ -4508,9 +4471,8 @@ const deserializeAws_json1_1QualificationRequirement = (
   context: __SerdeContext
 ): QualificationRequirement => {
   return {
-    ActionsGuarded:
-      output.ActionsGuarded !== undefined && output.ActionsGuarded !== null ? output.ActionsGuarded : undefined,
-    Comparator: output.Comparator !== undefined && output.Comparator !== null ? output.Comparator : undefined,
+    ActionsGuarded: __expectString(output.ActionsGuarded),
+    Comparator: __expectString(output.Comparator),
     IntegerValues:
       output.IntegerValues !== undefined && output.IntegerValues !== null
         ? deserializeAws_json1_1IntegerList(output.IntegerValues, context)
@@ -4519,14 +4481,8 @@ const deserializeAws_json1_1QualificationRequirement = (
       output.LocaleValues !== undefined && output.LocaleValues !== null
         ? deserializeAws_json1_1LocaleList(output.LocaleValues, context)
         : undefined,
-    QualificationTypeId:
-      output.QualificationTypeId !== undefined && output.QualificationTypeId !== null
-        ? output.QualificationTypeId
-        : undefined,
-    RequiredToPreview:
-      output.RequiredToPreview !== undefined && output.RequiredToPreview !== null
-        ? output.RequiredToPreview
-        : undefined,
+    QualificationTypeId: __expectString(output.QualificationTypeId),
+    RequiredToPreview: __expectBoolean(output.RequiredToPreview),
   } as any;
 };
 
@@ -4546,36 +4502,22 @@ const deserializeAws_json1_1QualificationRequirementList = (
 
 const deserializeAws_json1_1QualificationType = (output: any, context: __SerdeContext): QualificationType => {
   return {
-    AnswerKey: output.AnswerKey !== undefined && output.AnswerKey !== null ? output.AnswerKey : undefined,
-    AutoGranted: output.AutoGranted !== undefined && output.AutoGranted !== null ? output.AutoGranted : undefined,
-    AutoGrantedValue:
-      output.AutoGrantedValue !== undefined && output.AutoGrantedValue !== null ? output.AutoGrantedValue : undefined,
+    AnswerKey: __expectString(output.AnswerKey),
+    AutoGranted: __expectBoolean(output.AutoGranted),
+    AutoGrantedValue: __expectNumber(output.AutoGrantedValue),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    IsRequestable:
-      output.IsRequestable !== undefined && output.IsRequestable !== null ? output.IsRequestable : undefined,
-    Keywords: output.Keywords !== undefined && output.Keywords !== null ? output.Keywords : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    QualificationTypeId:
-      output.QualificationTypeId !== undefined && output.QualificationTypeId !== null
-        ? output.QualificationTypeId
-        : undefined,
-    QualificationTypeStatus:
-      output.QualificationTypeStatus !== undefined && output.QualificationTypeStatus !== null
-        ? output.QualificationTypeStatus
-        : undefined,
-    RetryDelayInSeconds:
-      output.RetryDelayInSeconds !== undefined && output.RetryDelayInSeconds !== null
-        ? output.RetryDelayInSeconds
-        : undefined,
-    Test: output.Test !== undefined && output.Test !== null ? output.Test : undefined,
-    TestDurationInSeconds:
-      output.TestDurationInSeconds !== undefined && output.TestDurationInSeconds !== null
-        ? output.TestDurationInSeconds
-        : undefined,
+    Description: __expectString(output.Description),
+    IsRequestable: __expectBoolean(output.IsRequestable),
+    Keywords: __expectString(output.Keywords),
+    Name: __expectString(output.Name),
+    QualificationTypeId: __expectString(output.QualificationTypeId),
+    QualificationTypeStatus: __expectString(output.QualificationTypeStatus),
+    RetryDelayInSeconds: __expectNumber(output.RetryDelayInSeconds),
+    Test: __expectString(output.Test),
+    TestDurationInSeconds: __expectNumber(output.TestDurationInSeconds),
   } as any;
 };
 
@@ -4606,25 +4548,24 @@ const deserializeAws_json1_1RejectQualificationRequestResponse = (
 
 const deserializeAws_json1_1RequestError = (output: any, context: __SerdeContext): RequestError => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    TurkErrorCode:
-      output.TurkErrorCode !== undefined && output.TurkErrorCode !== null ? output.TurkErrorCode : undefined,
+    Message: __expectString(output.Message),
+    TurkErrorCode: __expectString(output.TurkErrorCode),
   } as any;
 };
 
 const deserializeAws_json1_1ReviewActionDetail = (output: any, context: __SerdeContext): ReviewActionDetail => {
   return {
-    ActionId: output.ActionId !== undefined && output.ActionId !== null ? output.ActionId : undefined,
-    ActionName: output.ActionName !== undefined && output.ActionName !== null ? output.ActionName : undefined,
+    ActionId: __expectString(output.ActionId),
+    ActionName: __expectString(output.ActionName),
     CompleteTime:
       output.CompleteTime !== undefined && output.CompleteTime !== null
         ? new Date(Math.round(output.CompleteTime * 1000))
         : undefined,
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    Result: output.Result !== undefined && output.Result !== null ? output.Result : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    TargetId: output.TargetId !== undefined && output.TargetId !== null ? output.TargetId : undefined,
-    TargetType: output.TargetType !== undefined && output.TargetType !== null ? output.TargetType : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    Result: __expectString(output.Result),
+    Status: __expectString(output.Status),
+    TargetId: __expectString(output.TargetId),
+    TargetType: __expectString(output.TargetType),
   } as any;
 };
 
@@ -4645,7 +4586,7 @@ const deserializeAws_json1_1ReviewPolicy = (output: any, context: __SerdeContext
       output.Parameters !== undefined && output.Parameters !== null
         ? deserializeAws_json1_1PolicyParameterList(output.Parameters, context)
         : undefined,
-    PolicyName: output.PolicyName !== undefined && output.PolicyName !== null ? output.PolicyName : undefined,
+    PolicyName: __expectString(output.PolicyName),
   } as any;
 };
 
@@ -4664,12 +4605,12 @@ const deserializeAws_json1_1ReviewReport = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_1ReviewResultDetail = (output: any, context: __SerdeContext): ReviewResultDetail => {
   return {
-    ActionId: output.ActionId !== undefined && output.ActionId !== null ? output.ActionId : undefined,
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    QuestionId: output.QuestionId !== undefined && output.QuestionId !== null ? output.QuestionId : undefined,
-    SubjectId: output.SubjectId !== undefined && output.SubjectId !== null ? output.SubjectId : undefined,
-    SubjectType: output.SubjectType !== undefined && output.SubjectType !== null ? output.SubjectType : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    ActionId: __expectString(output.ActionId),
+    Key: __expectString(output.Key),
+    QuestionId: __expectString(output.QuestionId),
+    SubjectId: __expectString(output.SubjectId),
+    SubjectType: __expectString(output.SubjectType),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -4697,9 +4638,8 @@ const deserializeAws_json1_1SendTestEventNotificationResponse = (
 
 const deserializeAws_json1_1ServiceFault = (output: any, context: __SerdeContext): ServiceFault => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    TurkErrorCode:
-      output.TurkErrorCode !== undefined && output.TurkErrorCode !== null ? output.TurkErrorCode : undefined,
+    Message: __expectString(output.Message),
+    TurkErrorCode: __expectString(output.TurkErrorCode),
   } as any;
 };
 
@@ -4710,7 +4650,7 @@ const deserializeAws_json1_1StringList = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4756,8 +4696,8 @@ const deserializeAws_json1_1UpdateQualificationTypeResponse = (
 
 const deserializeAws_json1_1WorkerBlock = (output: any, context: __SerdeContext): WorkerBlock => {
   return {
-    Reason: output.Reason !== undefined && output.Reason !== null ? output.Reason : undefined,
-    WorkerId: output.WorkerId !== undefined && output.WorkerId !== null ? output.WorkerId : undefined,
+    Reason: __expectString(output.Reason),
+    WorkerId: __expectString(output.WorkerId),
   } as any;
 };
 

--- a/clients/client-mwaa/protocols/Aws_restJson1.ts
+++ b/clients/client-mwaa/protocols/Aws_restJson1.ts
@@ -40,6 +40,9 @@ import {
 } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -552,10 +555,10 @@ export const deserializeAws_restJson1CreateCliTokenCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.CliToken !== undefined && data.CliToken !== null) {
-    contents.CliToken = data.CliToken;
+    contents.CliToken = __expectString(data.CliToken);
   }
   if (data.WebServerHostname !== undefined && data.WebServerHostname !== null) {
-    contents.WebServerHostname = data.WebServerHostname;
+    contents.WebServerHostname = __expectString(data.WebServerHostname);
   }
   return Promise.resolve(contents);
 };
@@ -610,7 +613,7 @@ export const deserializeAws_restJson1CreateEnvironmentCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   return Promise.resolve(contents);
 };
@@ -674,10 +677,10 @@ export const deserializeAws_restJson1CreateWebLoginTokenCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.WebServerHostname !== undefined && data.WebServerHostname !== null) {
-    contents.WebServerHostname = data.WebServerHostname;
+    contents.WebServerHostname = __expectString(data.WebServerHostname);
   }
   if (data.WebToken !== undefined && data.WebToken !== null) {
-    contents.WebToken = data.WebToken;
+    contents.WebToken = __expectString(data.WebToken);
   }
   return Promise.resolve(contents);
 };
@@ -898,7 +901,7 @@ export const deserializeAws_restJson1ListEnvironmentsCommand = async (
     contents.Environments = deserializeAws_restJson1EnvironmentList(data.Environments, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1225,7 +1228,7 @@ export const deserializeAws_restJson1UpdateEnvironmentCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   return Promise.resolve(contents);
 };
@@ -1295,7 +1298,7 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1312,7 +1315,7 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1329,7 +1332,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1346,7 +1349,7 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1525,7 +1528,7 @@ const deserializeAws_restJson1AirflowConfigurationOptions = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -1536,19 +1539,16 @@ const deserializeAws_restJson1Environment = (output: any, context: __SerdeContex
       output.AirflowConfigurationOptions !== undefined && output.AirflowConfigurationOptions !== null
         ? deserializeAws_restJson1AirflowConfigurationOptions(output.AirflowConfigurationOptions, context)
         : undefined,
-    AirflowVersion:
-      output.AirflowVersion !== undefined && output.AirflowVersion !== null ? output.AirflowVersion : undefined,
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    AirflowVersion: __expectString(output.AirflowVersion),
+    Arn: __expectString(output.Arn),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    DagS3Path: output.DagS3Path !== undefined && output.DagS3Path !== null ? output.DagS3Path : undefined,
-    EnvironmentClass:
-      output.EnvironmentClass !== undefined && output.EnvironmentClass !== null ? output.EnvironmentClass : undefined,
-    ExecutionRoleArn:
-      output.ExecutionRoleArn !== undefined && output.ExecutionRoleArn !== null ? output.ExecutionRoleArn : undefined,
-    KmsKey: output.KmsKey !== undefined && output.KmsKey !== null ? output.KmsKey : undefined,
+    DagS3Path: __expectString(output.DagS3Path),
+    EnvironmentClass: __expectString(output.EnvironmentClass),
+    ExecutionRoleArn: __expectString(output.ExecutionRoleArn),
+    KmsKey: __expectString(output.KmsKey),
     LastUpdate:
       output.LastUpdate !== undefined && output.LastUpdate !== null
         ? deserializeAws_restJson1LastUpdate(output.LastUpdate, context)
@@ -1557,46 +1557,28 @@ const deserializeAws_restJson1Environment = (output: any, context: __SerdeContex
       output.LoggingConfiguration !== undefined && output.LoggingConfiguration !== null
         ? deserializeAws_restJson1LoggingConfiguration(output.LoggingConfiguration, context)
         : undefined,
-    MaxWorkers: output.MaxWorkers !== undefined && output.MaxWorkers !== null ? output.MaxWorkers : undefined,
-    MinWorkers: output.MinWorkers !== undefined && output.MinWorkers !== null ? output.MinWorkers : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    MaxWorkers: __expectNumber(output.MaxWorkers),
+    MinWorkers: __expectNumber(output.MinWorkers),
+    Name: __expectString(output.Name),
     NetworkConfiguration:
       output.NetworkConfiguration !== undefined && output.NetworkConfiguration !== null
         ? deserializeAws_restJson1NetworkConfiguration(output.NetworkConfiguration, context)
         : undefined,
-    PluginsS3ObjectVersion:
-      output.PluginsS3ObjectVersion !== undefined && output.PluginsS3ObjectVersion !== null
-        ? output.PluginsS3ObjectVersion
-        : undefined,
-    PluginsS3Path:
-      output.PluginsS3Path !== undefined && output.PluginsS3Path !== null ? output.PluginsS3Path : undefined,
-    RequirementsS3ObjectVersion:
-      output.RequirementsS3ObjectVersion !== undefined && output.RequirementsS3ObjectVersion !== null
-        ? output.RequirementsS3ObjectVersion
-        : undefined,
-    RequirementsS3Path:
-      output.RequirementsS3Path !== undefined && output.RequirementsS3Path !== null
-        ? output.RequirementsS3Path
-        : undefined,
-    Schedulers: output.Schedulers !== undefined && output.Schedulers !== null ? output.Schedulers : undefined,
-    ServiceRoleArn:
-      output.ServiceRoleArn !== undefined && output.ServiceRoleArn !== null ? output.ServiceRoleArn : undefined,
-    SourceBucketArn:
-      output.SourceBucketArn !== undefined && output.SourceBucketArn !== null ? output.SourceBucketArn : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    PluginsS3ObjectVersion: __expectString(output.PluginsS3ObjectVersion),
+    PluginsS3Path: __expectString(output.PluginsS3Path),
+    RequirementsS3ObjectVersion: __expectString(output.RequirementsS3ObjectVersion),
+    RequirementsS3Path: __expectString(output.RequirementsS3Path),
+    Schedulers: __expectNumber(output.Schedulers),
+    ServiceRoleArn: __expectString(output.ServiceRoleArn),
+    SourceBucketArn: __expectString(output.SourceBucketArn),
+    Status: __expectString(output.Status),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_restJson1TagMap(output.Tags, context)
         : undefined,
-    WebserverAccessMode:
-      output.WebserverAccessMode !== undefined && output.WebserverAccessMode !== null
-        ? output.WebserverAccessMode
-        : undefined,
-    WebserverUrl: output.WebserverUrl !== undefined && output.WebserverUrl !== null ? output.WebserverUrl : undefined,
-    WeeklyMaintenanceWindowStart:
-      output.WeeklyMaintenanceWindowStart !== undefined && output.WeeklyMaintenanceWindowStart !== null
-        ? output.WeeklyMaintenanceWindowStart
-        : undefined,
+    WebserverAccessMode: __expectString(output.WebserverAccessMode),
+    WebserverUrl: __expectString(output.WebserverUrl),
+    WeeklyMaintenanceWindowStart: __expectString(output.WeeklyMaintenanceWindowStart),
   } as any;
 };
 
@@ -1607,7 +1589,7 @@ const deserializeAws_restJson1EnvironmentList = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -1621,7 +1603,7 @@ const deserializeAws_restJson1LastUpdate = (output: any, context: __SerdeContext
       output.Error !== undefined && output.Error !== null
         ? deserializeAws_restJson1UpdateError(output.Error, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -1655,12 +1637,9 @@ const deserializeAws_restJson1ModuleLoggingConfiguration = (
   context: __SerdeContext
 ): ModuleLoggingConfiguration => {
   return {
-    CloudWatchLogGroupArn:
-      output.CloudWatchLogGroupArn !== undefined && output.CloudWatchLogGroupArn !== null
-        ? output.CloudWatchLogGroupArn
-        : undefined,
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
-    LogLevel: output.LogLevel !== undefined && output.LogLevel !== null ? output.LogLevel : undefined,
+    CloudWatchLogGroupArn: __expectString(output.CloudWatchLogGroupArn),
+    Enabled: __expectBoolean(output.Enabled),
+    LogLevel: __expectString(output.LogLevel),
   } as any;
 };
 
@@ -1684,7 +1663,7 @@ const deserializeAws_restJson1SecurityGroupList = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -1695,7 +1674,7 @@ const deserializeAws_restJson1SubnetList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -1706,15 +1685,15 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1UpdateError = (output: any, context: __SerdeContext): UpdateError => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
   } as any;
 };
 

--- a/clients/client-neptune/protocols/Aws_query.ts
+++ b/clients/client-neptune/protocols/Aws_query.ts
@@ -435,6 +435,7 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
@@ -9252,7 +9253,7 @@ const deserializeAws_queryAttributeValueList = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -9264,7 +9265,7 @@ const deserializeAws_queryAuthorizationNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -9274,7 +9275,7 @@ const deserializeAws_queryAvailabilityZone = (output: any, context: __SerdeConte
     Name: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   return contents;
 };
@@ -9297,7 +9298,7 @@ const deserializeAws_queryAvailabilityZones = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -9309,7 +9310,7 @@ const deserializeAws_queryCertificateNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -9320,10 +9321,10 @@ const deserializeAws_queryCharacterSet = (output: any, context: __SerdeContext):
     CharacterSetDescription: undefined,
   };
   if (output["CharacterSetName"] !== undefined) {
-    contents.CharacterSetName = output["CharacterSetName"];
+    contents.CharacterSetName = __expectString(output["CharacterSetName"]);
   }
   if (output["CharacterSetDescription"] !== undefined) {
-    contents.CharacterSetDescription = output["CharacterSetDescription"];
+    contents.CharacterSetDescription = __expectString(output["CharacterSetDescription"]);
   }
   return contents;
 };
@@ -9387,25 +9388,25 @@ const deserializeAws_queryCreateDBClusterEndpointOutput = (
     DBClusterEndpointArn: undefined,
   };
   if (output["DBClusterEndpointIdentifier"] !== undefined) {
-    contents.DBClusterEndpointIdentifier = output["DBClusterEndpointIdentifier"];
+    contents.DBClusterEndpointIdentifier = __expectString(output["DBClusterEndpointIdentifier"]);
   }
   if (output["DBClusterIdentifier"] !== undefined) {
-    contents.DBClusterIdentifier = output["DBClusterIdentifier"];
+    contents.DBClusterIdentifier = __expectString(output["DBClusterIdentifier"]);
   }
   if (output["DBClusterEndpointResourceIdentifier"] !== undefined) {
-    contents.DBClusterEndpointResourceIdentifier = output["DBClusterEndpointResourceIdentifier"];
+    contents.DBClusterEndpointResourceIdentifier = __expectString(output["DBClusterEndpointResourceIdentifier"]);
   }
   if (output["Endpoint"] !== undefined) {
-    contents.Endpoint = output["Endpoint"];
+    contents.Endpoint = __expectString(output["Endpoint"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["EndpointType"] !== undefined) {
-    contents.EndpointType = output["EndpointType"];
+    contents.EndpointType = __expectString(output["EndpointType"]);
   }
   if (output["CustomEndpointType"] !== undefined) {
-    contents.CustomEndpointType = output["CustomEndpointType"];
+    contents.CustomEndpointType = __expectString(output["CustomEndpointType"]);
   }
   if (output.StaticMembers === "") {
     contents.StaticMembers = [];
@@ -9426,7 +9427,7 @@ const deserializeAws_queryCreateDBClusterEndpointOutput = (
     );
   }
   if (output["DBClusterEndpointArn"] !== undefined) {
-    contents.DBClusterEndpointArn = output["DBClusterEndpointArn"];
+    contents.DBClusterEndpointArn = __expectString(output["DBClusterEndpointArn"]);
   }
   return contents;
 };
@@ -9578,43 +9579,43 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
     contents.BackupRetentionPeriod = parseInt(output["BackupRetentionPeriod"]);
   }
   if (output["CharacterSetName"] !== undefined) {
-    contents.CharacterSetName = output["CharacterSetName"];
+    contents.CharacterSetName = __expectString(output["CharacterSetName"]);
   }
   if (output["DatabaseName"] !== undefined) {
-    contents.DatabaseName = output["DatabaseName"];
+    contents.DatabaseName = __expectString(output["DatabaseName"]);
   }
   if (output["DBClusterIdentifier"] !== undefined) {
-    contents.DBClusterIdentifier = output["DBClusterIdentifier"];
+    contents.DBClusterIdentifier = __expectString(output["DBClusterIdentifier"]);
   }
   if (output["DBClusterParameterGroup"] !== undefined) {
-    contents.DBClusterParameterGroup = output["DBClusterParameterGroup"];
+    contents.DBClusterParameterGroup = __expectString(output["DBClusterParameterGroup"]);
   }
   if (output["DBSubnetGroup"] !== undefined) {
-    contents.DBSubnetGroup = output["DBSubnetGroup"];
+    contents.DBSubnetGroup = __expectString(output["DBSubnetGroup"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["PercentProgress"] !== undefined) {
-    contents.PercentProgress = output["PercentProgress"];
+    contents.PercentProgress = __expectString(output["PercentProgress"]);
   }
   if (output["EarliestRestorableTime"] !== undefined) {
     contents.EarliestRestorableTime = new Date(output["EarliestRestorableTime"]);
   }
   if (output["Endpoint"] !== undefined) {
-    contents.Endpoint = output["Endpoint"];
+    contents.Endpoint = __expectString(output["Endpoint"]);
   }
   if (output["ReaderEndpoint"] !== undefined) {
-    contents.ReaderEndpoint = output["ReaderEndpoint"];
+    contents.ReaderEndpoint = __expectString(output["ReaderEndpoint"]);
   }
   if (output["MultiAZ"] !== undefined) {
     contents.MultiAZ = __parseBoolean(output["MultiAZ"]);
   }
   if (output["Engine"] !== undefined) {
-    contents.Engine = output["Engine"];
+    contents.Engine = __expectString(output["Engine"]);
   }
   if (output["EngineVersion"] !== undefined) {
-    contents.EngineVersion = output["EngineVersion"];
+    contents.EngineVersion = __expectString(output["EngineVersion"]);
   }
   if (output["LatestRestorableTime"] !== undefined) {
     contents.LatestRestorableTime = new Date(output["LatestRestorableTime"]);
@@ -9623,7 +9624,7 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
     contents.Port = parseInt(output["Port"]);
   }
   if (output["MasterUsername"] !== undefined) {
-    contents.MasterUsername = output["MasterUsername"];
+    contents.MasterUsername = __expectString(output["MasterUsername"]);
   }
   if (output.DBClusterOptionGroupMemberships === "") {
     contents.DBClusterOptionGroupMemberships = [];
@@ -9638,13 +9639,13 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
     );
   }
   if (output["PreferredBackupWindow"] !== undefined) {
-    contents.PreferredBackupWindow = output["PreferredBackupWindow"];
+    contents.PreferredBackupWindow = __expectString(output["PreferredBackupWindow"]);
   }
   if (output["PreferredMaintenanceWindow"] !== undefined) {
-    contents.PreferredMaintenanceWindow = output["PreferredMaintenanceWindow"];
+    contents.PreferredMaintenanceWindow = __expectString(output["PreferredMaintenanceWindow"]);
   }
   if (output["ReplicationSourceIdentifier"] !== undefined) {
-    contents.ReplicationSourceIdentifier = output["ReplicationSourceIdentifier"];
+    contents.ReplicationSourceIdentifier = __expectString(output["ReplicationSourceIdentifier"]);
   }
   if (output.ReadReplicaIdentifiers === "") {
     contents.ReadReplicaIdentifiers = [];
@@ -9680,19 +9681,19 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
     );
   }
   if (output["HostedZoneId"] !== undefined) {
-    contents.HostedZoneId = output["HostedZoneId"];
+    contents.HostedZoneId = __expectString(output["HostedZoneId"]);
   }
   if (output["StorageEncrypted"] !== undefined) {
     contents.StorageEncrypted = __parseBoolean(output["StorageEncrypted"]);
   }
   if (output["KmsKeyId"] !== undefined) {
-    contents.KmsKeyId = output["KmsKeyId"];
+    contents.KmsKeyId = __expectString(output["KmsKeyId"]);
   }
   if (output["DbClusterResourceId"] !== undefined) {
-    contents.DbClusterResourceId = output["DbClusterResourceId"];
+    contents.DbClusterResourceId = __expectString(output["DbClusterResourceId"]);
   }
   if (output["DBClusterArn"] !== undefined) {
-    contents.DBClusterArn = output["DBClusterArn"];
+    contents.DBClusterArn = __expectString(output["DBClusterArn"]);
   }
   if (output.AssociatedRoles === "") {
     contents.AssociatedRoles = [];
@@ -9707,7 +9708,7 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
     contents.IAMDatabaseAuthenticationEnabled = __parseBoolean(output["IAMDatabaseAuthenticationEnabled"]);
   }
   if (output["CloneGroupId"] !== undefined) {
-    contents.CloneGroupId = output["CloneGroupId"];
+    contents.CloneGroupId = __expectString(output["CloneGroupId"]);
   }
   if (output["ClusterCreateTime"] !== undefined) {
     contents.ClusterCreateTime = new Date(output["ClusterCreateTime"]);
@@ -9747,7 +9748,7 @@ const deserializeAws_queryDBClusterAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -9766,25 +9767,25 @@ const deserializeAws_queryDBClusterEndpoint = (output: any, context: __SerdeCont
     DBClusterEndpointArn: undefined,
   };
   if (output["DBClusterEndpointIdentifier"] !== undefined) {
-    contents.DBClusterEndpointIdentifier = output["DBClusterEndpointIdentifier"];
+    contents.DBClusterEndpointIdentifier = __expectString(output["DBClusterEndpointIdentifier"]);
   }
   if (output["DBClusterIdentifier"] !== undefined) {
-    contents.DBClusterIdentifier = output["DBClusterIdentifier"];
+    contents.DBClusterIdentifier = __expectString(output["DBClusterIdentifier"]);
   }
   if (output["DBClusterEndpointResourceIdentifier"] !== undefined) {
-    contents.DBClusterEndpointResourceIdentifier = output["DBClusterEndpointResourceIdentifier"];
+    contents.DBClusterEndpointResourceIdentifier = __expectString(output["DBClusterEndpointResourceIdentifier"]);
   }
   if (output["Endpoint"] !== undefined) {
-    contents.Endpoint = output["Endpoint"];
+    contents.Endpoint = __expectString(output["Endpoint"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["EndpointType"] !== undefined) {
-    contents.EndpointType = output["EndpointType"];
+    contents.EndpointType = __expectString(output["EndpointType"]);
   }
   if (output["CustomEndpointType"] !== undefined) {
-    contents.CustomEndpointType = output["CustomEndpointType"];
+    contents.CustomEndpointType = __expectString(output["CustomEndpointType"]);
   }
   if (output.StaticMembers === "") {
     contents.StaticMembers = [];
@@ -9805,7 +9806,7 @@ const deserializeAws_queryDBClusterEndpoint = (output: any, context: __SerdeCont
     );
   }
   if (output["DBClusterEndpointArn"] !== undefined) {
-    contents.DBClusterEndpointArn = output["DBClusterEndpointArn"];
+    contents.DBClusterEndpointArn = __expectString(output["DBClusterEndpointArn"]);
   }
   return contents;
 };
@@ -9818,7 +9819,7 @@ const deserializeAws_queryDBClusterEndpointAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -9843,7 +9844,7 @@ const deserializeAws_queryDBClusterEndpointMessage = (
     DBClusterEndpoints: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.DBClusterEndpoints === "") {
     contents.DBClusterEndpoints = [];
@@ -9868,7 +9869,7 @@ const deserializeAws_queryDBClusterEndpointNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -9881,7 +9882,7 @@ const deserializeAws_queryDBClusterEndpointQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -9905,13 +9906,13 @@ const deserializeAws_queryDBClusterMember = (output: any, context: __SerdeContex
     PromotionTier: undefined,
   };
   if (output["DBInstanceIdentifier"] !== undefined) {
-    contents.DBInstanceIdentifier = output["DBInstanceIdentifier"];
+    contents.DBInstanceIdentifier = __expectString(output["DBInstanceIdentifier"]);
   }
   if (output["IsClusterWriter"] !== undefined) {
     contents.IsClusterWriter = __parseBoolean(output["IsClusterWriter"]);
   }
   if (output["DBClusterParameterGroupStatus"] !== undefined) {
-    contents.DBClusterParameterGroupStatus = output["DBClusterParameterGroupStatus"];
+    contents.DBClusterParameterGroupStatus = __expectString(output["DBClusterParameterGroupStatus"]);
   }
   if (output["PromotionTier"] !== undefined) {
     contents.PromotionTier = parseInt(output["PromotionTier"]);
@@ -9936,7 +9937,7 @@ const deserializeAws_queryDBClusterMessage = (output: any, context: __SerdeConte
     DBClusters: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.DBClusters === "") {
     contents.DBClusters = [];
@@ -9955,7 +9956,7 @@ const deserializeAws_queryDBClusterNotFoundFault = (output: any, context: __Serd
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -9983,10 +9984,10 @@ const deserializeAws_queryDBClusterOptionGroupStatus = (
     Status: undefined,
   };
   if (output["DBClusterOptionGroupName"] !== undefined) {
-    contents.DBClusterOptionGroupName = output["DBClusterOptionGroupName"];
+    contents.DBClusterOptionGroupName = __expectString(output["DBClusterOptionGroupName"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   return contents;
 };
@@ -9999,16 +10000,16 @@ const deserializeAws_queryDBClusterParameterGroup = (output: any, context: __Ser
     DBClusterParameterGroupArn: undefined,
   };
   if (output["DBClusterParameterGroupName"] !== undefined) {
-    contents.DBClusterParameterGroupName = output["DBClusterParameterGroupName"];
+    contents.DBClusterParameterGroupName = __expectString(output["DBClusterParameterGroupName"]);
   }
   if (output["DBParameterGroupFamily"] !== undefined) {
-    contents.DBParameterGroupFamily = output["DBParameterGroupFamily"];
+    contents.DBParameterGroupFamily = __expectString(output["DBParameterGroupFamily"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output["DBClusterParameterGroupArn"] !== undefined) {
-    contents.DBClusterParameterGroupArn = output["DBClusterParameterGroupArn"];
+    contents.DBClusterParameterGroupArn = __expectString(output["DBClusterParameterGroupArn"]);
   }
   return contents;
 };
@@ -10031,7 +10032,7 @@ const deserializeAws_queryDBClusterParameterGroupDetails = (
     );
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -10058,7 +10059,7 @@ const deserializeAws_queryDBClusterParameterGroupNameMessage = (
     DBClusterParameterGroupName: undefined,
   };
   if (output["DBClusterParameterGroupName"] !== undefined) {
-    contents.DBClusterParameterGroupName = output["DBClusterParameterGroupName"];
+    contents.DBClusterParameterGroupName = __expectString(output["DBClusterParameterGroupName"]);
   }
   return contents;
 };
@@ -10071,7 +10072,7 @@ const deserializeAws_queryDBClusterParameterGroupNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -10085,7 +10086,7 @@ const deserializeAws_queryDBClusterParameterGroupsMessage = (
     DBClusterParameterGroups: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.DBClusterParameterGroups === "") {
     contents.DBClusterParameterGroups = [];
@@ -10110,7 +10111,7 @@ const deserializeAws_queryDBClusterQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -10122,13 +10123,13 @@ const deserializeAws_queryDBClusterRole = (output: any, context: __SerdeContext)
     FeatureName: undefined,
   };
   if (output["RoleArn"] !== undefined) {
-    contents.RoleArn = output["RoleArn"];
+    contents.RoleArn = __expectString(output["RoleArn"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["FeatureName"] !== undefined) {
-    contents.FeatureName = output["FeatureName"];
+    contents.FeatureName = __expectString(output["FeatureName"]);
   }
   return contents;
 };
@@ -10141,7 +10142,7 @@ const deserializeAws_queryDBClusterRoleAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -10154,7 +10155,7 @@ const deserializeAws_queryDBClusterRoleNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -10167,7 +10168,7 @@ const deserializeAws_queryDBClusterRoleQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -10216,43 +10217,43 @@ const deserializeAws_queryDBClusterSnapshot = (output: any, context: __SerdeCont
     );
   }
   if (output["DBClusterSnapshotIdentifier"] !== undefined) {
-    contents.DBClusterSnapshotIdentifier = output["DBClusterSnapshotIdentifier"];
+    contents.DBClusterSnapshotIdentifier = __expectString(output["DBClusterSnapshotIdentifier"]);
   }
   if (output["DBClusterIdentifier"] !== undefined) {
-    contents.DBClusterIdentifier = output["DBClusterIdentifier"];
+    contents.DBClusterIdentifier = __expectString(output["DBClusterIdentifier"]);
   }
   if (output["SnapshotCreateTime"] !== undefined) {
     contents.SnapshotCreateTime = new Date(output["SnapshotCreateTime"]);
   }
   if (output["Engine"] !== undefined) {
-    contents.Engine = output["Engine"];
+    contents.Engine = __expectString(output["Engine"]);
   }
   if (output["AllocatedStorage"] !== undefined) {
     contents.AllocatedStorage = parseInt(output["AllocatedStorage"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["Port"] !== undefined) {
     contents.Port = parseInt(output["Port"]);
   }
   if (output["VpcId"] !== undefined) {
-    contents.VpcId = output["VpcId"];
+    contents.VpcId = __expectString(output["VpcId"]);
   }
   if (output["ClusterCreateTime"] !== undefined) {
     contents.ClusterCreateTime = new Date(output["ClusterCreateTime"]);
   }
   if (output["MasterUsername"] !== undefined) {
-    contents.MasterUsername = output["MasterUsername"];
+    contents.MasterUsername = __expectString(output["MasterUsername"]);
   }
   if (output["EngineVersion"] !== undefined) {
-    contents.EngineVersion = output["EngineVersion"];
+    contents.EngineVersion = __expectString(output["EngineVersion"]);
   }
   if (output["LicenseModel"] !== undefined) {
-    contents.LicenseModel = output["LicenseModel"];
+    contents.LicenseModel = __expectString(output["LicenseModel"]);
   }
   if (output["SnapshotType"] !== undefined) {
-    contents.SnapshotType = output["SnapshotType"];
+    contents.SnapshotType = __expectString(output["SnapshotType"]);
   }
   if (output["PercentProgress"] !== undefined) {
     contents.PercentProgress = parseInt(output["PercentProgress"]);
@@ -10261,13 +10262,13 @@ const deserializeAws_queryDBClusterSnapshot = (output: any, context: __SerdeCont
     contents.StorageEncrypted = __parseBoolean(output["StorageEncrypted"]);
   }
   if (output["KmsKeyId"] !== undefined) {
-    contents.KmsKeyId = output["KmsKeyId"];
+    contents.KmsKeyId = __expectString(output["KmsKeyId"]);
   }
   if (output["DBClusterSnapshotArn"] !== undefined) {
-    contents.DBClusterSnapshotArn = output["DBClusterSnapshotArn"];
+    contents.DBClusterSnapshotArn = __expectString(output["DBClusterSnapshotArn"]);
   }
   if (output["SourceDBClusterSnapshotArn"] !== undefined) {
-    contents.SourceDBClusterSnapshotArn = output["SourceDBClusterSnapshotArn"];
+    contents.SourceDBClusterSnapshotArn = __expectString(output["SourceDBClusterSnapshotArn"]);
   }
   if (output["IAMDatabaseAuthenticationEnabled"] !== undefined) {
     contents.IAMDatabaseAuthenticationEnabled = __parseBoolean(output["IAMDatabaseAuthenticationEnabled"]);
@@ -10283,7 +10284,7 @@ const deserializeAws_queryDBClusterSnapshotAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -10297,7 +10298,7 @@ const deserializeAws_queryDBClusterSnapshotAttribute = (
     AttributeValues: undefined,
   };
   if (output["AttributeName"] !== undefined) {
-    contents.AttributeName = output["AttributeName"];
+    contents.AttributeName = __expectString(output["AttributeName"]);
   }
   if (output.AttributeValues === "") {
     contents.AttributeValues = [];
@@ -10334,7 +10335,7 @@ const deserializeAws_queryDBClusterSnapshotAttributesResult = (
     DBClusterSnapshotAttributes: undefined,
   };
   if (output["DBClusterSnapshotIdentifier"] !== undefined) {
-    contents.DBClusterSnapshotIdentifier = output["DBClusterSnapshotIdentifier"];
+    contents.DBClusterSnapshotIdentifier = __expectString(output["DBClusterSnapshotIdentifier"]);
   }
   if (output.DBClusterSnapshotAttributes === "") {
     contents.DBClusterSnapshotAttributes = [];
@@ -10371,7 +10372,7 @@ const deserializeAws_queryDBClusterSnapshotMessage = (
     DBClusterSnapshots: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.DBClusterSnapshots === "") {
     contents.DBClusterSnapshots = [];
@@ -10393,7 +10394,7 @@ const deserializeAws_queryDBClusterSnapshotNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -10414,19 +10415,19 @@ const deserializeAws_queryDBEngineVersion = (output: any, context: __SerdeContex
     SupportsReadReplica: undefined,
   };
   if (output["Engine"] !== undefined) {
-    contents.Engine = output["Engine"];
+    contents.Engine = __expectString(output["Engine"]);
   }
   if (output["EngineVersion"] !== undefined) {
-    contents.EngineVersion = output["EngineVersion"];
+    contents.EngineVersion = __expectString(output["EngineVersion"]);
   }
   if (output["DBParameterGroupFamily"] !== undefined) {
-    contents.DBParameterGroupFamily = output["DBParameterGroupFamily"];
+    contents.DBParameterGroupFamily = __expectString(output["DBParameterGroupFamily"]);
   }
   if (output["DBEngineDescription"] !== undefined) {
-    contents.DBEngineDescription = output["DBEngineDescription"];
+    contents.DBEngineDescription = __expectString(output["DBEngineDescription"]);
   }
   if (output["DBEngineVersionDescription"] !== undefined) {
-    contents.DBEngineVersionDescription = output["DBEngineVersionDescription"];
+    contents.DBEngineVersionDescription = __expectString(output["DBEngineVersionDescription"]);
   }
   if (output["DefaultCharacterSet"] !== undefined) {
     contents.DefaultCharacterSet = deserializeAws_queryCharacterSet(output["DefaultCharacterSet"], context);
@@ -10496,7 +10497,7 @@ const deserializeAws_queryDBEngineVersionMessage = (output: any, context: __Serd
     DBEngineVersions: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.DBEngineVersions === "") {
     contents.DBEngineVersions = [];
@@ -10567,22 +10568,22 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
     DeletionProtection: undefined,
   };
   if (output["DBInstanceIdentifier"] !== undefined) {
-    contents.DBInstanceIdentifier = output["DBInstanceIdentifier"];
+    contents.DBInstanceIdentifier = __expectString(output["DBInstanceIdentifier"]);
   }
   if (output["DBInstanceClass"] !== undefined) {
-    contents.DBInstanceClass = output["DBInstanceClass"];
+    contents.DBInstanceClass = __expectString(output["DBInstanceClass"]);
   }
   if (output["Engine"] !== undefined) {
-    contents.Engine = output["Engine"];
+    contents.Engine = __expectString(output["Engine"]);
   }
   if (output["DBInstanceStatus"] !== undefined) {
-    contents.DBInstanceStatus = output["DBInstanceStatus"];
+    contents.DBInstanceStatus = __expectString(output["DBInstanceStatus"]);
   }
   if (output["MasterUsername"] !== undefined) {
-    contents.MasterUsername = output["MasterUsername"];
+    contents.MasterUsername = __expectString(output["MasterUsername"]);
   }
   if (output["DBName"] !== undefined) {
-    contents.DBName = output["DBName"];
+    contents.DBName = __expectString(output["DBName"]);
   }
   if (output["Endpoint"] !== undefined) {
     contents.Endpoint = deserializeAws_queryEndpoint(output["Endpoint"], context);
@@ -10594,7 +10595,7 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
     contents.InstanceCreateTime = new Date(output["InstanceCreateTime"]);
   }
   if (output["PreferredBackupWindow"] !== undefined) {
-    contents.PreferredBackupWindow = output["PreferredBackupWindow"];
+    contents.PreferredBackupWindow = __expectString(output["PreferredBackupWindow"]);
   }
   if (output["BackupRetentionPeriod"] !== undefined) {
     contents.BackupRetentionPeriod = parseInt(output["BackupRetentionPeriod"]);
@@ -10630,13 +10631,13 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
     );
   }
   if (output["AvailabilityZone"] !== undefined) {
-    contents.AvailabilityZone = output["AvailabilityZone"];
+    contents.AvailabilityZone = __expectString(output["AvailabilityZone"]);
   }
   if (output["DBSubnetGroup"] !== undefined) {
     contents.DBSubnetGroup = deserializeAws_queryDBSubnetGroup(output["DBSubnetGroup"], context);
   }
   if (output["PreferredMaintenanceWindow"] !== undefined) {
-    contents.PreferredMaintenanceWindow = output["PreferredMaintenanceWindow"];
+    contents.PreferredMaintenanceWindow = __expectString(output["PreferredMaintenanceWindow"]);
   }
   if (output["PendingModifiedValues"] !== undefined) {
     contents.PendingModifiedValues = deserializeAws_queryPendingModifiedValues(
@@ -10651,13 +10652,13 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
     contents.MultiAZ = __parseBoolean(output["MultiAZ"]);
   }
   if (output["EngineVersion"] !== undefined) {
-    contents.EngineVersion = output["EngineVersion"];
+    contents.EngineVersion = __expectString(output["EngineVersion"]);
   }
   if (output["AutoMinorVersionUpgrade"] !== undefined) {
     contents.AutoMinorVersionUpgrade = __parseBoolean(output["AutoMinorVersionUpgrade"]);
   }
   if (output["ReadReplicaSourceDBInstanceIdentifier"] !== undefined) {
-    contents.ReadReplicaSourceDBInstanceIdentifier = output["ReadReplicaSourceDBInstanceIdentifier"];
+    contents.ReadReplicaSourceDBInstanceIdentifier = __expectString(output["ReadReplicaSourceDBInstanceIdentifier"]);
   }
   if (output.ReadReplicaDBInstanceIdentifiers === "") {
     contents.ReadReplicaDBInstanceIdentifiers = [];
@@ -10684,7 +10685,7 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
     );
   }
   if (output["LicenseModel"] !== undefined) {
-    contents.LicenseModel = output["LicenseModel"];
+    contents.LicenseModel = __expectString(output["LicenseModel"]);
   }
   if (output["Iops"] !== undefined) {
     contents.Iops = parseInt(output["Iops"]);
@@ -10702,10 +10703,10 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
     );
   }
   if (output["CharacterSetName"] !== undefined) {
-    contents.CharacterSetName = output["CharacterSetName"];
+    contents.CharacterSetName = __expectString(output["CharacterSetName"]);
   }
   if (output["SecondaryAvailabilityZone"] !== undefined) {
-    contents.SecondaryAvailabilityZone = output["SecondaryAvailabilityZone"];
+    contents.SecondaryAvailabilityZone = __expectString(output["SecondaryAvailabilityZone"]);
   }
   if (output["PubliclyAccessible"] !== undefined) {
     contents.PubliclyAccessible = __parseBoolean(output["PubliclyAccessible"]);
@@ -10720,28 +10721,28 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
     );
   }
   if (output["StorageType"] !== undefined) {
-    contents.StorageType = output["StorageType"];
+    contents.StorageType = __expectString(output["StorageType"]);
   }
   if (output["TdeCredentialArn"] !== undefined) {
-    contents.TdeCredentialArn = output["TdeCredentialArn"];
+    contents.TdeCredentialArn = __expectString(output["TdeCredentialArn"]);
   }
   if (output["DbInstancePort"] !== undefined) {
     contents.DbInstancePort = parseInt(output["DbInstancePort"]);
   }
   if (output["DBClusterIdentifier"] !== undefined) {
-    contents.DBClusterIdentifier = output["DBClusterIdentifier"];
+    contents.DBClusterIdentifier = __expectString(output["DBClusterIdentifier"]);
   }
   if (output["StorageEncrypted"] !== undefined) {
     contents.StorageEncrypted = __parseBoolean(output["StorageEncrypted"]);
   }
   if (output["KmsKeyId"] !== undefined) {
-    contents.KmsKeyId = output["KmsKeyId"];
+    contents.KmsKeyId = __expectString(output["KmsKeyId"]);
   }
   if (output["DbiResourceId"] !== undefined) {
-    contents.DbiResourceId = output["DbiResourceId"];
+    contents.DbiResourceId = __expectString(output["DbiResourceId"]);
   }
   if (output["CACertificateIdentifier"] !== undefined) {
-    contents.CACertificateIdentifier = output["CACertificateIdentifier"];
+    contents.CACertificateIdentifier = __expectString(output["CACertificateIdentifier"]);
   }
   if (output.DomainMemberships === "") {
     contents.DomainMemberships = [];
@@ -10759,19 +10760,19 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
     contents.MonitoringInterval = parseInt(output["MonitoringInterval"]);
   }
   if (output["EnhancedMonitoringResourceArn"] !== undefined) {
-    contents.EnhancedMonitoringResourceArn = output["EnhancedMonitoringResourceArn"];
+    contents.EnhancedMonitoringResourceArn = __expectString(output["EnhancedMonitoringResourceArn"]);
   }
   if (output["MonitoringRoleArn"] !== undefined) {
-    contents.MonitoringRoleArn = output["MonitoringRoleArn"];
+    contents.MonitoringRoleArn = __expectString(output["MonitoringRoleArn"]);
   }
   if (output["PromotionTier"] !== undefined) {
     contents.PromotionTier = parseInt(output["PromotionTier"]);
   }
   if (output["DBInstanceArn"] !== undefined) {
-    contents.DBInstanceArn = output["DBInstanceArn"];
+    contents.DBInstanceArn = __expectString(output["DBInstanceArn"]);
   }
   if (output["Timezone"] !== undefined) {
-    contents.Timezone = output["Timezone"];
+    contents.Timezone = __expectString(output["Timezone"]);
   }
   if (output["IAMDatabaseAuthenticationEnabled"] !== undefined) {
     contents.IAMDatabaseAuthenticationEnabled = __parseBoolean(output["IAMDatabaseAuthenticationEnabled"]);
@@ -10780,7 +10781,7 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
     contents.PerformanceInsightsEnabled = __parseBoolean(output["PerformanceInsightsEnabled"]);
   }
   if (output["PerformanceInsightsKMSKeyId"] !== undefined) {
-    contents.PerformanceInsightsKMSKeyId = output["PerformanceInsightsKMSKeyId"];
+    contents.PerformanceInsightsKMSKeyId = __expectString(output["PerformanceInsightsKMSKeyId"]);
   }
   if (output.EnabledCloudwatchLogsExports === "") {
     contents.EnabledCloudwatchLogsExports = [];
@@ -10808,7 +10809,7 @@ const deserializeAws_queryDBInstanceAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -10830,7 +10831,7 @@ const deserializeAws_queryDBInstanceMessage = (output: any, context: __SerdeCont
     DBInstances: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.DBInstances === "") {
     contents.DBInstances = [];
@@ -10849,7 +10850,7 @@ const deserializeAws_queryDBInstanceNotFoundFault = (output: any, context: __Ser
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -10862,16 +10863,16 @@ const deserializeAws_queryDBInstanceStatusInfo = (output: any, context: __SerdeC
     Message: undefined,
   };
   if (output["StatusType"] !== undefined) {
-    contents.StatusType = output["StatusType"];
+    contents.StatusType = __expectString(output["StatusType"]);
   }
   if (output["Normal"] !== undefined) {
     contents.Normal = __parseBoolean(output["Normal"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -10895,16 +10896,16 @@ const deserializeAws_queryDBParameterGroup = (output: any, context: __SerdeConte
     DBParameterGroupArn: undefined,
   };
   if (output["DBParameterGroupName"] !== undefined) {
-    contents.DBParameterGroupName = output["DBParameterGroupName"];
+    contents.DBParameterGroupName = __expectString(output["DBParameterGroupName"]);
   }
   if (output["DBParameterGroupFamily"] !== undefined) {
-    contents.DBParameterGroupFamily = output["DBParameterGroupFamily"];
+    contents.DBParameterGroupFamily = __expectString(output["DBParameterGroupFamily"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output["DBParameterGroupArn"] !== undefined) {
-    contents.DBParameterGroupArn = output["DBParameterGroupArn"];
+    contents.DBParameterGroupArn = __expectString(output["DBParameterGroupArn"]);
   }
   return contents;
 };
@@ -10917,7 +10918,7 @@ const deserializeAws_queryDBParameterGroupAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -10937,7 +10938,7 @@ const deserializeAws_queryDBParameterGroupDetails = (output: any, context: __Ser
     );
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -10961,7 +10962,7 @@ const deserializeAws_queryDBParameterGroupNameMessage = (
     DBParameterGroupName: undefined,
   };
   if (output["DBParameterGroupName"] !== undefined) {
-    contents.DBParameterGroupName = output["DBParameterGroupName"];
+    contents.DBParameterGroupName = __expectString(output["DBParameterGroupName"]);
   }
   return contents;
 };
@@ -10974,7 +10975,7 @@ const deserializeAws_queryDBParameterGroupNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -10987,7 +10988,7 @@ const deserializeAws_queryDBParameterGroupQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -11001,7 +11002,7 @@ const deserializeAws_queryDBParameterGroupsMessage = (
     DBParameterGroups: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.DBParameterGroups === "") {
     contents.DBParameterGroups = [];
@@ -11021,10 +11022,10 @@ const deserializeAws_queryDBParameterGroupStatus = (output: any, context: __Serd
     ParameterApplyStatus: undefined,
   };
   if (output["DBParameterGroupName"] !== undefined) {
-    contents.DBParameterGroupName = output["DBParameterGroupName"];
+    contents.DBParameterGroupName = __expectString(output["DBParameterGroupName"]);
   }
   if (output["ParameterApplyStatus"] !== undefined) {
-    contents.ParameterApplyStatus = output["ParameterApplyStatus"];
+    contents.ParameterApplyStatus = __expectString(output["ParameterApplyStatus"]);
   }
   return contents;
 };
@@ -11052,10 +11053,10 @@ const deserializeAws_queryDBSecurityGroupMembership = (
     Status: undefined,
   };
   if (output["DBSecurityGroupName"] !== undefined) {
-    contents.DBSecurityGroupName = output["DBSecurityGroupName"];
+    contents.DBSecurityGroupName = __expectString(output["DBSecurityGroupName"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   return contents;
 };
@@ -11082,7 +11083,7 @@ const deserializeAws_queryDBSecurityGroupNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -11095,7 +11096,7 @@ const deserializeAws_queryDBSnapshotAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -11105,7 +11106,7 @@ const deserializeAws_queryDBSnapshotNotFoundFault = (output: any, context: __Ser
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -11120,16 +11121,16 @@ const deserializeAws_queryDBSubnetGroup = (output: any, context: __SerdeContext)
     DBSubnetGroupArn: undefined,
   };
   if (output["DBSubnetGroupName"] !== undefined) {
-    contents.DBSubnetGroupName = output["DBSubnetGroupName"];
+    contents.DBSubnetGroupName = __expectString(output["DBSubnetGroupName"]);
   }
   if (output["DBSubnetGroupDescription"] !== undefined) {
-    contents.DBSubnetGroupDescription = output["DBSubnetGroupDescription"];
+    contents.DBSubnetGroupDescription = __expectString(output["DBSubnetGroupDescription"]);
   }
   if (output["VpcId"] !== undefined) {
-    contents.VpcId = output["VpcId"];
+    contents.VpcId = __expectString(output["VpcId"]);
   }
   if (output["SubnetGroupStatus"] !== undefined) {
-    contents.SubnetGroupStatus = output["SubnetGroupStatus"];
+    contents.SubnetGroupStatus = __expectString(output["SubnetGroupStatus"]);
   }
   if (output.Subnets === "") {
     contents.Subnets = [];
@@ -11138,7 +11139,7 @@ const deserializeAws_queryDBSubnetGroup = (output: any, context: __SerdeContext)
     contents.Subnets = deserializeAws_querySubnetList(__getArrayIfSingleItem(output["Subnets"]["Subnet"]), context);
   }
   if (output["DBSubnetGroupArn"] !== undefined) {
-    contents.DBSubnetGroupArn = output["DBSubnetGroupArn"];
+    contents.DBSubnetGroupArn = __expectString(output["DBSubnetGroupArn"]);
   }
   return contents;
 };
@@ -11151,7 +11152,7 @@ const deserializeAws_queryDBSubnetGroupAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -11164,7 +11165,7 @@ const deserializeAws_queryDBSubnetGroupDoesNotCoverEnoughAZs = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -11175,7 +11176,7 @@ const deserializeAws_queryDBSubnetGroupMessage = (output: any, context: __SerdeC
     DBSubnetGroups: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.DBSubnetGroups === "") {
     contents.DBSubnetGroups = [];
@@ -11197,7 +11198,7 @@ const deserializeAws_queryDBSubnetGroupNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -11210,7 +11211,7 @@ const deserializeAws_queryDBSubnetGroupQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -11234,7 +11235,7 @@ const deserializeAws_queryDBSubnetQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -11247,7 +11248,7 @@ const deserializeAws_queryDBUpgradeDependencyFailureFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -11269,25 +11270,25 @@ const deserializeAws_queryDeleteDBClusterEndpointOutput = (
     DBClusterEndpointArn: undefined,
   };
   if (output["DBClusterEndpointIdentifier"] !== undefined) {
-    contents.DBClusterEndpointIdentifier = output["DBClusterEndpointIdentifier"];
+    contents.DBClusterEndpointIdentifier = __expectString(output["DBClusterEndpointIdentifier"]);
   }
   if (output["DBClusterIdentifier"] !== undefined) {
-    contents.DBClusterIdentifier = output["DBClusterIdentifier"];
+    contents.DBClusterIdentifier = __expectString(output["DBClusterIdentifier"]);
   }
   if (output["DBClusterEndpointResourceIdentifier"] !== undefined) {
-    contents.DBClusterEndpointResourceIdentifier = output["DBClusterEndpointResourceIdentifier"];
+    contents.DBClusterEndpointResourceIdentifier = __expectString(output["DBClusterEndpointResourceIdentifier"]);
   }
   if (output["Endpoint"] !== undefined) {
-    contents.Endpoint = output["Endpoint"];
+    contents.Endpoint = __expectString(output["Endpoint"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["EndpointType"] !== undefined) {
-    contents.EndpointType = output["EndpointType"];
+    contents.EndpointType = __expectString(output["EndpointType"]);
   }
   if (output["CustomEndpointType"] !== undefined) {
-    contents.CustomEndpointType = output["CustomEndpointType"];
+    contents.CustomEndpointType = __expectString(output["CustomEndpointType"]);
   }
   if (output.StaticMembers === "") {
     contents.StaticMembers = [];
@@ -11308,7 +11309,7 @@ const deserializeAws_queryDeleteDBClusterEndpointOutput = (
     );
   }
   if (output["DBClusterEndpointArn"] !== undefined) {
-    contents.DBClusterEndpointArn = output["DBClusterEndpointArn"];
+    contents.DBClusterEndpointArn = __expectString(output["DBClusterEndpointArn"]);
   }
   return contents;
 };
@@ -11425,16 +11426,16 @@ const deserializeAws_queryDomainMembership = (output: any, context: __SerdeConte
     IAMRoleName: undefined,
   };
   if (output["Domain"] !== undefined) {
-    contents.Domain = output["Domain"];
+    contents.Domain = __expectString(output["Domain"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["FQDN"] !== undefined) {
-    contents.FQDN = output["FQDN"];
+    contents.FQDN = __expectString(output["FQDN"]);
   }
   if (output["IAMRoleName"] !== undefined) {
-    contents.IAMRoleName = output["IAMRoleName"];
+    contents.IAMRoleName = __expectString(output["IAMRoleName"]);
   }
   return contents;
 };
@@ -11455,7 +11456,7 @@ const deserializeAws_queryDomainNotFoundFault = (output: any, context: __SerdeCo
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -11492,13 +11493,13 @@ const deserializeAws_queryEndpoint = (output: any, context: __SerdeContext): End
     HostedZoneId: undefined,
   };
   if (output["Address"] !== undefined) {
-    contents.Address = output["Address"];
+    contents.Address = __expectString(output["Address"]);
   }
   if (output["Port"] !== undefined) {
     contents.Port = parseInt(output["Port"]);
   }
   if (output["HostedZoneId"] !== undefined) {
-    contents.HostedZoneId = output["HostedZoneId"];
+    contents.HostedZoneId = __expectString(output["HostedZoneId"]);
   }
   return contents;
 };
@@ -11510,10 +11511,10 @@ const deserializeAws_queryEngineDefaults = (output: any, context: __SerdeContext
     Parameters: undefined,
   };
   if (output["DBParameterGroupFamily"] !== undefined) {
-    contents.DBParameterGroupFamily = output["DBParameterGroupFamily"];
+    contents.DBParameterGroupFamily = __expectString(output["DBParameterGroupFamily"]);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.Parameters === "") {
     contents.Parameters = [];
@@ -11537,13 +11538,13 @@ const deserializeAws_queryEvent = (output: any, context: __SerdeContext): Event 
     SourceArn: undefined,
   };
   if (output["SourceIdentifier"] !== undefined) {
-    contents.SourceIdentifier = output["SourceIdentifier"];
+    contents.SourceIdentifier = __expectString(output["SourceIdentifier"]);
   }
   if (output["SourceType"] !== undefined) {
-    contents.SourceType = output["SourceType"];
+    contents.SourceType = __expectString(output["SourceType"]);
   }
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   if (output.EventCategories === "") {
     contents.EventCategories = [];
@@ -11558,7 +11559,7 @@ const deserializeAws_queryEvent = (output: any, context: __SerdeContext): Event 
     contents.Date = new Date(output["Date"]);
   }
   if (output["SourceArn"] !== undefined) {
-    contents.SourceArn = output["SourceArn"];
+    contents.SourceArn = __expectString(output["SourceArn"]);
   }
   return contents;
 };
@@ -11570,7 +11571,7 @@ const deserializeAws_queryEventCategoriesList = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -11580,7 +11581,7 @@ const deserializeAws_queryEventCategoriesMap = (output: any, context: __SerdeCon
     EventCategories: undefined,
   };
   if (output["SourceType"] !== undefined) {
-    contents.SourceType = output["SourceType"];
+    contents.SourceType = __expectString(output["SourceType"]);
   }
   if (output.EventCategories === "") {
     contents.EventCategories = [];
@@ -11641,7 +11642,7 @@ const deserializeAws_queryEventsMessage = (output: any, context: __SerdeContext)
     Events: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.Events === "") {
     contents.Events = [];
@@ -11666,22 +11667,22 @@ const deserializeAws_queryEventSubscription = (output: any, context: __SerdeCont
     EventSubscriptionArn: undefined,
   };
   if (output["CustomerAwsId"] !== undefined) {
-    contents.CustomerAwsId = output["CustomerAwsId"];
+    contents.CustomerAwsId = __expectString(output["CustomerAwsId"]);
   }
   if (output["CustSubscriptionId"] !== undefined) {
-    contents.CustSubscriptionId = output["CustSubscriptionId"];
+    contents.CustSubscriptionId = __expectString(output["CustSubscriptionId"]);
   }
   if (output["SnsTopicArn"] !== undefined) {
-    contents.SnsTopicArn = output["SnsTopicArn"];
+    contents.SnsTopicArn = __expectString(output["SnsTopicArn"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["SubscriptionCreationTime"] !== undefined) {
-    contents.SubscriptionCreationTime = output["SubscriptionCreationTime"];
+    contents.SubscriptionCreationTime = __expectString(output["SubscriptionCreationTime"]);
   }
   if (output["SourceType"] !== undefined) {
-    contents.SourceType = output["SourceType"];
+    contents.SourceType = __expectString(output["SourceType"]);
   }
   if (output.SourceIdsList === "") {
     contents.SourceIdsList = [];
@@ -11705,7 +11706,7 @@ const deserializeAws_queryEventSubscription = (output: any, context: __SerdeCont
     contents.Enabled = __parseBoolean(output["Enabled"]);
   }
   if (output["EventSubscriptionArn"] !== undefined) {
-    contents.EventSubscriptionArn = output["EventSubscriptionArn"];
+    contents.EventSubscriptionArn = __expectString(output["EventSubscriptionArn"]);
   }
   return contents;
 };
@@ -11718,7 +11719,7 @@ const deserializeAws_queryEventSubscriptionQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -11743,7 +11744,7 @@ const deserializeAws_queryEventSubscriptionsMessage = (
     EventSubscriptionsList: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.EventSubscriptionsList === "") {
     contents.EventSubscriptionsList = [];
@@ -11778,7 +11779,7 @@ const deserializeAws_queryInstanceQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -11791,7 +11792,7 @@ const deserializeAws_queryInsufficientDBClusterCapacityFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -11804,7 +11805,7 @@ const deserializeAws_queryInsufficientDBInstanceCapacityFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -11817,7 +11818,7 @@ const deserializeAws_queryInsufficientStorageClusterCapacityFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -11830,7 +11831,7 @@ const deserializeAws_queryInvalidDBClusterEndpointStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -11843,7 +11844,7 @@ const deserializeAws_queryInvalidDBClusterSnapshotStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -11856,7 +11857,7 @@ const deserializeAws_queryInvalidDBClusterStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -11869,7 +11870,7 @@ const deserializeAws_queryInvalidDBInstanceStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -11882,7 +11883,7 @@ const deserializeAws_queryInvalidDBParameterGroupStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -11895,7 +11896,7 @@ const deserializeAws_queryInvalidDBSecurityGroupStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -11908,7 +11909,7 @@ const deserializeAws_queryInvalidDBSnapshotStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -11921,7 +11922,7 @@ const deserializeAws_queryInvalidDBSubnetGroupStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -11934,7 +11935,7 @@ const deserializeAws_queryInvalidDBSubnetStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -11947,7 +11948,7 @@ const deserializeAws_queryInvalidEventSubscriptionStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -11957,7 +11958,7 @@ const deserializeAws_queryInvalidRestoreFault = (output: any, context: __SerdeCo
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -11967,7 +11968,7 @@ const deserializeAws_queryInvalidSubnet = (output: any, context: __SerdeContext)
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -11980,7 +11981,7 @@ const deserializeAws_queryInvalidVPCNetworkStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -11993,7 +11994,7 @@ const deserializeAws_queryKMSKeyNotAccessibleFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -12005,7 +12006,7 @@ const deserializeAws_queryLogTypeList = (output: any, context: __SerdeContext): 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -12026,25 +12027,25 @@ const deserializeAws_queryModifyDBClusterEndpointOutput = (
     DBClusterEndpointArn: undefined,
   };
   if (output["DBClusterEndpointIdentifier"] !== undefined) {
-    contents.DBClusterEndpointIdentifier = output["DBClusterEndpointIdentifier"];
+    contents.DBClusterEndpointIdentifier = __expectString(output["DBClusterEndpointIdentifier"]);
   }
   if (output["DBClusterIdentifier"] !== undefined) {
-    contents.DBClusterIdentifier = output["DBClusterIdentifier"];
+    contents.DBClusterIdentifier = __expectString(output["DBClusterIdentifier"]);
   }
   if (output["DBClusterEndpointResourceIdentifier"] !== undefined) {
-    contents.DBClusterEndpointResourceIdentifier = output["DBClusterEndpointResourceIdentifier"];
+    contents.DBClusterEndpointResourceIdentifier = __expectString(output["DBClusterEndpointResourceIdentifier"]);
   }
   if (output["Endpoint"] !== undefined) {
-    contents.Endpoint = output["Endpoint"];
+    contents.Endpoint = __expectString(output["Endpoint"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["EndpointType"] !== undefined) {
-    contents.EndpointType = output["EndpointType"];
+    contents.EndpointType = __expectString(output["EndpointType"]);
   }
   if (output["CustomEndpointType"] !== undefined) {
-    contents.CustomEndpointType = output["CustomEndpointType"];
+    contents.CustomEndpointType = __expectString(output["CustomEndpointType"]);
   }
   if (output.StaticMembers === "") {
     contents.StaticMembers = [];
@@ -12065,7 +12066,7 @@ const deserializeAws_queryModifyDBClusterEndpointOutput = (
     );
   }
   if (output["DBClusterEndpointArn"] !== undefined) {
-    contents.DBClusterEndpointArn = output["DBClusterEndpointArn"];
+    contents.DBClusterEndpointArn = __expectString(output["DBClusterEndpointArn"]);
   }
   return contents;
 };
@@ -12138,10 +12139,10 @@ const deserializeAws_queryOptionGroupMembership = (output: any, context: __Serde
     Status: undefined,
   };
   if (output["OptionGroupName"] !== undefined) {
-    contents.OptionGroupName = output["OptionGroupName"];
+    contents.OptionGroupName = __expectString(output["OptionGroupName"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   return contents;
 };
@@ -12168,7 +12169,7 @@ const deserializeAws_queryOptionGroupNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -12200,16 +12201,16 @@ const deserializeAws_queryOrderableDBInstanceOption = (
     MaxIopsPerGib: undefined,
   };
   if (output["Engine"] !== undefined) {
-    contents.Engine = output["Engine"];
+    contents.Engine = __expectString(output["Engine"]);
   }
   if (output["EngineVersion"] !== undefined) {
-    contents.EngineVersion = output["EngineVersion"];
+    contents.EngineVersion = __expectString(output["EngineVersion"]);
   }
   if (output["DBInstanceClass"] !== undefined) {
-    contents.DBInstanceClass = output["DBInstanceClass"];
+    contents.DBInstanceClass = __expectString(output["DBInstanceClass"]);
   }
   if (output["LicenseModel"] !== undefined) {
-    contents.LicenseModel = output["LicenseModel"];
+    contents.LicenseModel = __expectString(output["LicenseModel"]);
   }
   if (output.AvailabilityZones === "") {
     contents.AvailabilityZones = [];
@@ -12233,7 +12234,7 @@ const deserializeAws_queryOrderableDBInstanceOption = (
     contents.SupportsStorageEncryption = __parseBoolean(output["SupportsStorageEncryption"]);
   }
   if (output["StorageType"] !== undefined) {
-    contents.StorageType = output["StorageType"];
+    contents.StorageType = __expectString(output["StorageType"]);
   }
   if (output["SupportsIops"] !== undefined) {
     contents.SupportsIops = __parseBoolean(output["SupportsIops"]);
@@ -12303,7 +12304,7 @@ const deserializeAws_queryOrderableDBInstanceOptionsMessage = (
     );
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -12322,34 +12323,34 @@ const deserializeAws_queryParameter = (output: any, context: __SerdeContext): Pa
     ApplyMethod: undefined,
   };
   if (output["ParameterName"] !== undefined) {
-    contents.ParameterName = output["ParameterName"];
+    contents.ParameterName = __expectString(output["ParameterName"]);
   }
   if (output["ParameterValue"] !== undefined) {
-    contents.ParameterValue = output["ParameterValue"];
+    contents.ParameterValue = __expectString(output["ParameterValue"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output["Source"] !== undefined) {
-    contents.Source = output["Source"];
+    contents.Source = __expectString(output["Source"]);
   }
   if (output["ApplyType"] !== undefined) {
-    contents.ApplyType = output["ApplyType"];
+    contents.ApplyType = __expectString(output["ApplyType"]);
   }
   if (output["DataType"] !== undefined) {
-    contents.DataType = output["DataType"];
+    contents.DataType = __expectString(output["DataType"]);
   }
   if (output["AllowedValues"] !== undefined) {
-    contents.AllowedValues = output["AllowedValues"];
+    contents.AllowedValues = __expectString(output["AllowedValues"]);
   }
   if (output["IsModifiable"] !== undefined) {
     contents.IsModifiable = __parseBoolean(output["IsModifiable"]);
   }
   if (output["MinimumEngineVersion"] !== undefined) {
-    contents.MinimumEngineVersion = output["MinimumEngineVersion"];
+    contents.MinimumEngineVersion = __expectString(output["MinimumEngineVersion"]);
   }
   if (output["ApplyMethod"] !== undefined) {
-    contents.ApplyMethod = output["ApplyMethod"];
+    contents.ApplyMethod = __expectString(output["ApplyMethod"]);
   }
   return contents;
 };
@@ -12407,7 +12408,7 @@ const deserializeAws_queryPendingMaintenanceAction = (
     Description: undefined,
   };
   if (output["Action"] !== undefined) {
-    contents.Action = output["Action"];
+    contents.Action = __expectString(output["Action"]);
   }
   if (output["AutoAppliedAfterDate"] !== undefined) {
     contents.AutoAppliedAfterDate = new Date(output["AutoAppliedAfterDate"]);
@@ -12416,13 +12417,13 @@ const deserializeAws_queryPendingMaintenanceAction = (
     contents.ForcedApplyDate = new Date(output["ForcedApplyDate"]);
   }
   if (output["OptInStatus"] !== undefined) {
-    contents.OptInStatus = output["OptInStatus"];
+    contents.OptInStatus = __expectString(output["OptInStatus"]);
   }
   if (output["CurrentApplyDate"] !== undefined) {
     contents.CurrentApplyDate = new Date(output["CurrentApplyDate"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   return contents;
 };
@@ -12476,7 +12477,7 @@ const deserializeAws_queryPendingMaintenanceActionsMessage = (
     );
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -12499,13 +12500,13 @@ const deserializeAws_queryPendingModifiedValues = (output: any, context: __Serde
     PendingCloudwatchLogsExports: undefined,
   };
   if (output["DBInstanceClass"] !== undefined) {
-    contents.DBInstanceClass = output["DBInstanceClass"];
+    contents.DBInstanceClass = __expectString(output["DBInstanceClass"]);
   }
   if (output["AllocatedStorage"] !== undefined) {
     contents.AllocatedStorage = parseInt(output["AllocatedStorage"]);
   }
   if (output["MasterUserPassword"] !== undefined) {
-    contents.MasterUserPassword = output["MasterUserPassword"];
+    contents.MasterUserPassword = __expectString(output["MasterUserPassword"]);
   }
   if (output["Port"] !== undefined) {
     contents.Port = parseInt(output["Port"]);
@@ -12517,25 +12518,25 @@ const deserializeAws_queryPendingModifiedValues = (output: any, context: __Serde
     contents.MultiAZ = __parseBoolean(output["MultiAZ"]);
   }
   if (output["EngineVersion"] !== undefined) {
-    contents.EngineVersion = output["EngineVersion"];
+    contents.EngineVersion = __expectString(output["EngineVersion"]);
   }
   if (output["LicenseModel"] !== undefined) {
-    contents.LicenseModel = output["LicenseModel"];
+    contents.LicenseModel = __expectString(output["LicenseModel"]);
   }
   if (output["Iops"] !== undefined) {
     contents.Iops = parseInt(output["Iops"]);
   }
   if (output["DBInstanceIdentifier"] !== undefined) {
-    contents.DBInstanceIdentifier = output["DBInstanceIdentifier"];
+    contents.DBInstanceIdentifier = __expectString(output["DBInstanceIdentifier"]);
   }
   if (output["StorageType"] !== undefined) {
-    contents.StorageType = output["StorageType"];
+    contents.StorageType = __expectString(output["StorageType"]);
   }
   if (output["CACertificateIdentifier"] !== undefined) {
-    contents.CACertificateIdentifier = output["CACertificateIdentifier"];
+    contents.CACertificateIdentifier = __expectString(output["CACertificateIdentifier"]);
   }
   if (output["DBSubnetGroupName"] !== undefined) {
-    contents.DBSubnetGroupName = output["DBSubnetGroupName"];
+    contents.DBSubnetGroupName = __expectString(output["DBSubnetGroupName"]);
   }
   if (output["PendingCloudwatchLogsExports"] !== undefined) {
     contents.PendingCloudwatchLogsExports = deserializeAws_queryPendingCloudwatchLogsExports(
@@ -12567,7 +12568,7 @@ const deserializeAws_queryProvisionedIopsNotAvailableInAZFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -12608,7 +12609,7 @@ const deserializeAws_queryReadReplicaDBClusterIdentifierList = (output: any, con
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -12619,7 +12620,7 @@ const deserializeAws_queryReadReplicaDBInstanceIdentifierList = (output: any, co
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -12630,7 +12631,7 @@ const deserializeAws_queryReadReplicaIdentifierList = (output: any, context: __S
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -12662,7 +12663,7 @@ const deserializeAws_queryResourceNotFoundFault = (output: any, context: __Serde
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -12676,7 +12677,7 @@ const deserializeAws_queryResourcePendingMaintenanceActions = (
     PendingMaintenanceActionDetails: undefined,
   };
   if (output["ResourceIdentifier"] !== undefined) {
-    contents.ResourceIdentifier = output["ResourceIdentifier"];
+    contents.ResourceIdentifier = __expectString(output["ResourceIdentifier"]);
   }
   if (output.PendingMaintenanceActionDetails === "") {
     contents.PendingMaintenanceActionDetails = [];
@@ -12727,7 +12728,7 @@ const deserializeAws_querySharedSnapshotQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -12740,7 +12741,7 @@ const deserializeAws_querySnapshotQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -12750,7 +12751,7 @@ const deserializeAws_querySNSInvalidTopicFault = (output: any, context: __SerdeC
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -12760,7 +12761,7 @@ const deserializeAws_querySNSNoAuthorizationFault = (output: any, context: __Ser
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -12773,7 +12774,7 @@ const deserializeAws_querySNSTopicArnNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -12785,7 +12786,7 @@ const deserializeAws_querySourceIdsList = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -12794,7 +12795,7 @@ const deserializeAws_querySourceNotFoundFault = (output: any, context: __SerdeCo
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -12827,7 +12828,7 @@ const deserializeAws_queryStorageQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -12840,7 +12841,7 @@ const deserializeAws_queryStorageTypeNotSupportedFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -12852,7 +12853,7 @@ const deserializeAws_queryStringList = (output: any, context: __SerdeContext): s
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -12863,13 +12864,13 @@ const deserializeAws_querySubnet = (output: any, context: __SerdeContext): Subne
     SubnetStatus: undefined,
   };
   if (output["SubnetIdentifier"] !== undefined) {
-    contents.SubnetIdentifier = output["SubnetIdentifier"];
+    contents.SubnetIdentifier = __expectString(output["SubnetIdentifier"]);
   }
   if (output["SubnetAvailabilityZone"] !== undefined) {
     contents.SubnetAvailabilityZone = deserializeAws_queryAvailabilityZone(output["SubnetAvailabilityZone"], context);
   }
   if (output["SubnetStatus"] !== undefined) {
-    contents.SubnetStatus = output["SubnetStatus"];
+    contents.SubnetStatus = __expectString(output["SubnetStatus"]);
   }
   return contents;
 };
@@ -12879,7 +12880,7 @@ const deserializeAws_querySubnetAlreadyInUse = (output: any, context: __SerdeCon
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -12903,7 +12904,7 @@ const deserializeAws_querySubscriptionAlreadyExistFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -12916,7 +12917,7 @@ const deserializeAws_querySubscriptionCategoryNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -12929,7 +12930,7 @@ const deserializeAws_querySubscriptionNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -12962,10 +12963,10 @@ const deserializeAws_queryTag = (output: any, context: __SerdeContext): Tag => {
     Value: undefined,
   };
   if (output["Key"] !== undefined) {
-    contents.Key = output["Key"];
+    contents.Key = __expectString(output["Key"]);
   }
   if (output["Value"] !== undefined) {
-    contents.Value = output["Value"];
+    contents.Value = __expectString(output["Value"]);
   }
   return contents;
 };
@@ -12999,7 +13000,7 @@ const deserializeAws_queryTimezone = (output: any, context: __SerdeContext): Tim
     TimezoneName: undefined,
   };
   if (output["TimezoneName"] !== undefined) {
-    contents.TimezoneName = output["TimezoneName"];
+    contents.TimezoneName = __expectString(output["TimezoneName"]);
   }
   return contents;
 };
@@ -13013,13 +13014,13 @@ const deserializeAws_queryUpgradeTarget = (output: any, context: __SerdeContext)
     IsMajorVersionUpgrade: undefined,
   };
   if (output["Engine"] !== undefined) {
-    contents.Engine = output["Engine"];
+    contents.Engine = __expectString(output["Engine"]);
   }
   if (output["EngineVersion"] !== undefined) {
-    contents.EngineVersion = output["EngineVersion"];
+    contents.EngineVersion = __expectString(output["EngineVersion"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output["AutoUpgrade"] !== undefined) {
     contents.AutoUpgrade = __parseBoolean(output["AutoUpgrade"]);
@@ -13057,7 +13058,7 @@ const deserializeAws_queryValidStorageOptions = (output: any, context: __SerdeCo
     IopsToStorageRatio: undefined,
   };
   if (output["StorageType"] !== undefined) {
-    contents.StorageType = output["StorageType"];
+    contents.StorageType = __expectString(output["StorageType"]);
   }
   if (output.StorageSize === "") {
     contents.StorageSize = [];
@@ -13120,10 +13121,10 @@ const deserializeAws_queryVpcSecurityGroupMembership = (
     Status: undefined,
   };
   if (output["VpcSecurityGroupId"] !== undefined) {
-    contents.VpcSecurityGroupId = output["VpcSecurityGroupId"];
+    contents.VpcSecurityGroupId = __expectString(output["VpcSecurityGroupId"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   return contents;
 };

--- a/clients/client-network-firewall/protocols/Aws_json1_0.ts
+++ b/clients/client-network-firewall/protocols/Aws_json1_0.ts
@@ -187,7 +187,12 @@ import {
   UpdateSubnetChangeProtectionResponse,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -4118,10 +4123,7 @@ const deserializeAws_json1_0ActionDefinition = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_0Address = (output: any, context: __SerdeContext): Address => {
   return {
-    AddressDefinition:
-      output.AddressDefinition !== undefined && output.AddressDefinition !== null
-        ? output.AddressDefinition
-        : undefined,
+    AddressDefinition: __expectString(output.AddressDefinition),
   } as any;
 };
 
@@ -4141,13 +4143,10 @@ const deserializeAws_json1_0AssociateFirewallPolicyResponse = (
   context: __SerdeContext
 ): AssociateFirewallPolicyResponse => {
   return {
-    FirewallArn: output.FirewallArn !== undefined && output.FirewallArn !== null ? output.FirewallArn : undefined,
-    FirewallName: output.FirewallName !== undefined && output.FirewallName !== null ? output.FirewallName : undefined,
-    FirewallPolicyArn:
-      output.FirewallPolicyArn !== undefined && output.FirewallPolicyArn !== null
-        ? output.FirewallPolicyArn
-        : undefined,
-    UpdateToken: output.UpdateToken !== undefined && output.UpdateToken !== null ? output.UpdateToken : undefined,
+    FirewallArn: __expectString(output.FirewallArn),
+    FirewallName: __expectString(output.FirewallName),
+    FirewallPolicyArn: __expectString(output.FirewallPolicyArn),
+    UpdateToken: __expectString(output.UpdateToken),
   } as any;
 };
 
@@ -4156,21 +4155,21 @@ const deserializeAws_json1_0AssociateSubnetsResponse = (
   context: __SerdeContext
 ): AssociateSubnetsResponse => {
   return {
-    FirewallArn: output.FirewallArn !== undefined && output.FirewallArn !== null ? output.FirewallArn : undefined,
-    FirewallName: output.FirewallName !== undefined && output.FirewallName !== null ? output.FirewallName : undefined,
+    FirewallArn: __expectString(output.FirewallArn),
+    FirewallName: __expectString(output.FirewallName),
     SubnetMappings:
       output.SubnetMappings !== undefined && output.SubnetMappings !== null
         ? deserializeAws_json1_0SubnetMappings(output.SubnetMappings, context)
         : undefined,
-    UpdateToken: output.UpdateToken !== undefined && output.UpdateToken !== null ? output.UpdateToken : undefined,
+    UpdateToken: __expectString(output.UpdateToken),
   } as any;
 };
 
 const deserializeAws_json1_0Attachment = (output: any, context: __SerdeContext): Attachment => {
   return {
-    EndpointId: output.EndpointId !== undefined && output.EndpointId !== null ? output.EndpointId : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    SubnetId: output.SubnetId !== undefined && output.SubnetId !== null ? output.SubnetId : undefined,
+    EndpointId: __expectString(output.EndpointId),
+    Status: __expectString(output.Status),
+    SubnetId: __expectString(output.SubnetId),
   } as any;
 };
 
@@ -4183,7 +4182,7 @@ const deserializeAws_json1_0CreateFirewallPolicyResponse = (
       output.FirewallPolicyResponse !== undefined && output.FirewallPolicyResponse !== null
         ? deserializeAws_json1_0FirewallPolicyResponse(output.FirewallPolicyResponse, context)
         : undefined,
-    UpdateToken: output.UpdateToken !== undefined && output.UpdateToken !== null ? output.UpdateToken : undefined,
+    UpdateToken: __expectString(output.UpdateToken),
   } as any;
 };
 
@@ -4209,7 +4208,7 @@ const deserializeAws_json1_0CreateRuleGroupResponse = (
       output.RuleGroupResponse !== undefined && output.RuleGroupResponse !== null
         ? deserializeAws_json1_0RuleGroupResponse(output.RuleGroupResponse, context)
         : undefined,
-    UpdateToken: output.UpdateToken !== undefined && output.UpdateToken !== null ? output.UpdateToken : undefined,
+    UpdateToken: __expectString(output.UpdateToken),
   } as any;
 };
 
@@ -4219,7 +4218,7 @@ const deserializeAws_json1_0CustomAction = (output: any, context: __SerdeContext
       output.ActionDefinition !== undefined && output.ActionDefinition !== null
         ? deserializeAws_json1_0ActionDefinition(output.ActionDefinition, context)
         : undefined,
-    ActionName: output.ActionName !== undefined && output.ActionName !== null ? output.ActionName : undefined,
+    ActionName: __expectString(output.ActionName),
   } as any;
 };
 
@@ -4291,7 +4290,7 @@ const deserializeAws_json1_0DescribeFirewallPolicyResponse = (
       output.FirewallPolicyResponse !== undefined && output.FirewallPolicyResponse !== null
         ? deserializeAws_json1_0FirewallPolicyResponse(output.FirewallPolicyResponse, context)
         : undefined,
-    UpdateToken: output.UpdateToken !== undefined && output.UpdateToken !== null ? output.UpdateToken : undefined,
+    UpdateToken: __expectString(output.UpdateToken),
   } as any;
 };
 
@@ -4308,7 +4307,7 @@ const deserializeAws_json1_0DescribeFirewallResponse = (
       output.FirewallStatus !== undefined && output.FirewallStatus !== null
         ? deserializeAws_json1_0FirewallStatus(output.FirewallStatus, context)
         : undefined,
-    UpdateToken: output.UpdateToken !== undefined && output.UpdateToken !== null ? output.UpdateToken : undefined,
+    UpdateToken: __expectString(output.UpdateToken),
   } as any;
 };
 
@@ -4317,7 +4316,7 @@ const deserializeAws_json1_0DescribeLoggingConfigurationResponse = (
   context: __SerdeContext
 ): DescribeLoggingConfigurationResponse => {
   return {
-    FirewallArn: output.FirewallArn !== undefined && output.FirewallArn !== null ? output.FirewallArn : undefined,
+    FirewallArn: __expectString(output.FirewallArn),
     LoggingConfiguration:
       output.LoggingConfiguration !== undefined && output.LoggingConfiguration !== null
         ? deserializeAws_json1_0LoggingConfiguration(output.LoggingConfiguration, context)
@@ -4330,7 +4329,7 @@ const deserializeAws_json1_0DescribeResourcePolicyResponse = (
   context: __SerdeContext
 ): DescribeResourcePolicyResponse => {
   return {
-    Policy: output.Policy !== undefined && output.Policy !== null ? output.Policy : undefined,
+    Policy: __expectString(output.Policy),
   } as any;
 };
 
@@ -4347,13 +4346,13 @@ const deserializeAws_json1_0DescribeRuleGroupResponse = (
       output.RuleGroupResponse !== undefined && output.RuleGroupResponse !== null
         ? deserializeAws_json1_0RuleGroupResponse(output.RuleGroupResponse, context)
         : undefined,
-    UpdateToken: output.UpdateToken !== undefined && output.UpdateToken !== null ? output.UpdateToken : undefined,
+    UpdateToken: __expectString(output.UpdateToken),
   } as any;
 };
 
 const deserializeAws_json1_0Dimension = (output: any, context: __SerdeContext): Dimension => {
   return {
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -4373,36 +4372,26 @@ const deserializeAws_json1_0DisassociateSubnetsResponse = (
   context: __SerdeContext
 ): DisassociateSubnetsResponse => {
   return {
-    FirewallArn: output.FirewallArn !== undefined && output.FirewallArn !== null ? output.FirewallArn : undefined,
-    FirewallName: output.FirewallName !== undefined && output.FirewallName !== null ? output.FirewallName : undefined,
+    FirewallArn: __expectString(output.FirewallArn),
+    FirewallName: __expectString(output.FirewallName),
     SubnetMappings:
       output.SubnetMappings !== undefined && output.SubnetMappings !== null
         ? deserializeAws_json1_0SubnetMappings(output.SubnetMappings, context)
         : undefined,
-    UpdateToken: output.UpdateToken !== undefined && output.UpdateToken !== null ? output.UpdateToken : undefined,
+    UpdateToken: __expectString(output.UpdateToken),
   } as any;
 };
 
 const deserializeAws_json1_0Firewall = (output: any, context: __SerdeContext): Firewall => {
   return {
-    DeleteProtection:
-      output.DeleteProtection !== undefined && output.DeleteProtection !== null ? output.DeleteProtection : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    FirewallArn: output.FirewallArn !== undefined && output.FirewallArn !== null ? output.FirewallArn : undefined,
-    FirewallId: output.FirewallId !== undefined && output.FirewallId !== null ? output.FirewallId : undefined,
-    FirewallName: output.FirewallName !== undefined && output.FirewallName !== null ? output.FirewallName : undefined,
-    FirewallPolicyArn:
-      output.FirewallPolicyArn !== undefined && output.FirewallPolicyArn !== null
-        ? output.FirewallPolicyArn
-        : undefined,
-    FirewallPolicyChangeProtection:
-      output.FirewallPolicyChangeProtection !== undefined && output.FirewallPolicyChangeProtection !== null
-        ? output.FirewallPolicyChangeProtection
-        : undefined,
-    SubnetChangeProtection:
-      output.SubnetChangeProtection !== undefined && output.SubnetChangeProtection !== null
-        ? output.SubnetChangeProtection
-        : undefined,
+    DeleteProtection: __expectBoolean(output.DeleteProtection),
+    Description: __expectString(output.Description),
+    FirewallArn: __expectString(output.FirewallArn),
+    FirewallId: __expectString(output.FirewallId),
+    FirewallName: __expectString(output.FirewallName),
+    FirewallPolicyArn: __expectString(output.FirewallPolicyArn),
+    FirewallPolicyChangeProtection: __expectBoolean(output.FirewallPolicyChangeProtection),
+    SubnetChangeProtection: __expectBoolean(output.SubnetChangeProtection),
     SubnetMappings:
       output.SubnetMappings !== undefined && output.SubnetMappings !== null
         ? deserializeAws_json1_0SubnetMappings(output.SubnetMappings, context)
@@ -4411,14 +4400,14 @@ const deserializeAws_json1_0Firewall = (output: any, context: __SerdeContext): F
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_0TagList(output.Tags, context)
         : undefined,
-    VpcId: output.VpcId !== undefined && output.VpcId !== null ? output.VpcId : undefined,
+    VpcId: __expectString(output.VpcId),
   } as any;
 };
 
 const deserializeAws_json1_0FirewallMetadata = (output: any, context: __SerdeContext): FirewallMetadata => {
   return {
-    FirewallArn: output.FirewallArn !== undefined && output.FirewallArn !== null ? output.FirewallArn : undefined,
-    FirewallName: output.FirewallName !== undefined && output.FirewallName !== null ? output.FirewallName : undefined,
+    FirewallArn: __expectString(output.FirewallArn),
+    FirewallName: __expectString(output.FirewallName),
   } as any;
 };
 
@@ -4460,28 +4449,18 @@ const deserializeAws_json1_0FirewallPolicy = (output: any, context: __SerdeConte
 
 const deserializeAws_json1_0FirewallPolicyMetadata = (output: any, context: __SerdeContext): FirewallPolicyMetadata => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Arn: __expectString(output.Arn),
+    Name: __expectString(output.Name),
   } as any;
 };
 
 const deserializeAws_json1_0FirewallPolicyResponse = (output: any, context: __SerdeContext): FirewallPolicyResponse => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    FirewallPolicyArn:
-      output.FirewallPolicyArn !== undefined && output.FirewallPolicyArn !== null
-        ? output.FirewallPolicyArn
-        : undefined,
-    FirewallPolicyId:
-      output.FirewallPolicyId !== undefined && output.FirewallPolicyId !== null ? output.FirewallPolicyId : undefined,
-    FirewallPolicyName:
-      output.FirewallPolicyName !== undefined && output.FirewallPolicyName !== null
-        ? output.FirewallPolicyName
-        : undefined,
-    FirewallPolicyStatus:
-      output.FirewallPolicyStatus !== undefined && output.FirewallPolicyStatus !== null
-        ? output.FirewallPolicyStatus
-        : undefined,
+    Description: __expectString(output.Description),
+    FirewallPolicyArn: __expectString(output.FirewallPolicyArn),
+    FirewallPolicyId: __expectString(output.FirewallPolicyId),
+    FirewallPolicyName: __expectString(output.FirewallPolicyName),
+    FirewallPolicyStatus: __expectString(output.FirewallPolicyStatus),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_0TagList(output.Tags, context)
@@ -4502,11 +4481,8 @@ const deserializeAws_json1_0Firewalls = (output: any, context: __SerdeContext): 
 
 const deserializeAws_json1_0FirewallStatus = (output: any, context: __SerdeContext): FirewallStatus => {
   return {
-    ConfigurationSyncStateSummary:
-      output.ConfigurationSyncStateSummary !== undefined && output.ConfigurationSyncStateSummary !== null
-        ? output.ConfigurationSyncStateSummary
-        : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    ConfigurationSyncStateSummary: __expectString(output.ConfigurationSyncStateSummary),
+    Status: __expectString(output.Status),
     SyncStates:
       output.SyncStates !== undefined && output.SyncStates !== null
         ? deserializeAws_json1_0SyncStates(output.SyncStates, context)
@@ -4521,19 +4497,18 @@ const deserializeAws_json1_0Flags = (output: any, context: __SerdeContext): (TCP
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_0Header = (output: any, context: __SerdeContext): Header => {
   return {
-    Destination: output.Destination !== undefined && output.Destination !== null ? output.Destination : undefined,
-    DestinationPort:
-      output.DestinationPort !== undefined && output.DestinationPort !== null ? output.DestinationPort : undefined,
-    Direction: output.Direction !== undefined && output.Direction !== null ? output.Direction : undefined,
-    Protocol: output.Protocol !== undefined && output.Protocol !== null ? output.Protocol : undefined,
-    Source: output.Source !== undefined && output.Source !== null ? output.Source : undefined,
-    SourcePort: output.SourcePort !== undefined && output.SourcePort !== null ? output.SourcePort : undefined,
+    Destination: __expectString(output.Destination),
+    DestinationPort: __expectString(output.DestinationPort),
+    Direction: __expectString(output.Direction),
+    Protocol: __expectString(output.Protocol),
+    Source: __expectString(output.Source),
+    SourcePort: __expectString(output.SourcePort),
   } as any;
 };
 
@@ -4542,13 +4517,13 @@ const deserializeAws_json1_0InsufficientCapacityException = (
   context: __SerdeContext
 ): InsufficientCapacityException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_0InternalServerError = (output: any, context: __SerdeContext): InternalServerError => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -4557,7 +4532,7 @@ const deserializeAws_json1_0InvalidOperationException = (
   context: __SerdeContext
 ): InvalidOperationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -4566,7 +4541,7 @@ const deserializeAws_json1_0InvalidRequestException = (
   context: __SerdeContext
 ): InvalidRequestException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -4575,13 +4550,13 @@ const deserializeAws_json1_0InvalidResourcePolicyException = (
   context: __SerdeContext
 ): InvalidResourcePolicyException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_0InvalidTokenException = (output: any, context: __SerdeContext): InvalidTokenException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -4608,7 +4583,7 @@ const deserializeAws_json1_0IPSets = (output: any, context: __SerdeContext): { [
 
 const deserializeAws_json1_0LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -4621,7 +4596,7 @@ const deserializeAws_json1_0ListFirewallPoliciesResponse = (
       output.FirewallPolicies !== undefined && output.FirewallPolicies !== null
         ? deserializeAws_json1_0FirewallPolicies(output.FirewallPolicies, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -4631,13 +4606,13 @@ const deserializeAws_json1_0ListFirewallsResponse = (output: any, context: __Ser
       output.Firewalls !== undefined && output.Firewalls !== null
         ? deserializeAws_json1_0Firewalls(output.Firewalls, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
 const deserializeAws_json1_0ListRuleGroupsResponse = (output: any, context: __SerdeContext): ListRuleGroupsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     RuleGroups:
       output.RuleGroups !== undefined && output.RuleGroups !== null
         ? deserializeAws_json1_0RuleGroups(output.RuleGroups, context)
@@ -4650,7 +4625,7 @@ const deserializeAws_json1_0ListTagsForResourceResponse = (
   context: __SerdeContext
 ): ListTagsForResourceResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_0TagList(output.Tags, context)
@@ -4664,11 +4639,8 @@ const deserializeAws_json1_0LogDestinationConfig = (output: any, context: __Serd
       output.LogDestination !== undefined && output.LogDestination !== null
         ? deserializeAws_json1_0LogDestinationMap(output.LogDestination, context)
         : undefined,
-    LogDestinationType:
-      output.LogDestinationType !== undefined && output.LogDestinationType !== null
-        ? output.LogDestinationType
-        : undefined,
-    LogType: output.LogType !== undefined && output.LogType !== null ? output.LogType : undefined,
+    LogDestinationType: __expectString(output.LogDestinationType),
+    LogType: __expectString(output.LogType),
   } as any;
 };
 
@@ -4690,7 +4662,7 @@ const deserializeAws_json1_0LogDestinationMap = (output: any, context: __SerdeCo
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -4700,7 +4672,7 @@ const deserializeAws_json1_0LogDestinationPermissionException = (
   context: __SerdeContext
 ): LogDestinationPermissionException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -4744,15 +4716,15 @@ const deserializeAws_json1_0MatchAttributes = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_0PerObjectStatus = (output: any, context: __SerdeContext): PerObjectStatus => {
   return {
-    SyncStatus: output.SyncStatus !== undefined && output.SyncStatus !== null ? output.SyncStatus : undefined,
-    UpdateToken: output.UpdateToken !== undefined && output.UpdateToken !== null ? output.UpdateToken : undefined,
+    SyncStatus: __expectString(output.SyncStatus),
+    UpdateToken: __expectString(output.UpdateToken),
   } as any;
 };
 
 const deserializeAws_json1_0PortRange = (output: any, context: __SerdeContext): PortRange => {
   return {
-    FromPort: output.FromPort !== undefined && output.FromPort !== null ? output.FromPort : undefined,
-    ToPort: output.ToPort !== undefined && output.ToPort !== null ? output.ToPort : undefined,
+    FromPort: __expectNumber(output.FromPort),
+    ToPort: __expectNumber(output.ToPort),
   } as any;
 };
 
@@ -4795,7 +4767,7 @@ const deserializeAws_json1_0ProtocolNumbers = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectNumber(entry) as any;
     });
 };
 
@@ -4820,7 +4792,7 @@ const deserializeAws_json1_0ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -4829,7 +4801,7 @@ const deserializeAws_json1_0ResourceOwnerCheckException = (
   context: __SerdeContext
 ): ResourceOwnerCheckException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -4861,26 +4833,24 @@ const deserializeAws_json1_0RuleGroup = (output: any, context: __SerdeContext): 
 
 const deserializeAws_json1_0RuleGroupMetadata = (output: any, context: __SerdeContext): RuleGroupMetadata => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Arn: __expectString(output.Arn),
+    Name: __expectString(output.Name),
   } as any;
 };
 
 const deserializeAws_json1_0RuleGroupResponse = (output: any, context: __SerdeContext): RuleGroupResponse => {
   return {
-    Capacity: output.Capacity !== undefined && output.Capacity !== null ? output.Capacity : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    RuleGroupArn: output.RuleGroupArn !== undefined && output.RuleGroupArn !== null ? output.RuleGroupArn : undefined,
-    RuleGroupId: output.RuleGroupId !== undefined && output.RuleGroupId !== null ? output.RuleGroupId : undefined,
-    RuleGroupName:
-      output.RuleGroupName !== undefined && output.RuleGroupName !== null ? output.RuleGroupName : undefined,
-    RuleGroupStatus:
-      output.RuleGroupStatus !== undefined && output.RuleGroupStatus !== null ? output.RuleGroupStatus : undefined,
+    Capacity: __expectNumber(output.Capacity),
+    Description: __expectString(output.Description),
+    RuleGroupArn: __expectString(output.RuleGroupArn),
+    RuleGroupId: __expectString(output.RuleGroupId),
+    RuleGroupName: __expectString(output.RuleGroupName),
+    RuleGroupStatus: __expectString(output.RuleGroupStatus),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_0TagList(output.Tags, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -4897,7 +4867,7 @@ const deserializeAws_json1_0RuleGroups = (output: any, context: __SerdeContext):
 
 const deserializeAws_json1_0RuleOption = (output: any, context: __SerdeContext): RuleOption => {
   return {
-    Keyword: output.Keyword !== undefined && output.Keyword !== null ? output.Keyword : undefined,
+    Keyword: __expectString(output.Keyword),
     Settings:
       output.Settings !== undefined && output.Settings !== null
         ? deserializeAws_json1_0Settings(output.Settings, context)
@@ -4922,7 +4892,7 @@ const deserializeAws_json1_0RulesSource = (output: any, context: __SerdeContext)
       output.RulesSourceList !== undefined && output.RulesSourceList !== null
         ? deserializeAws_json1_0RulesSourceList(output.RulesSourceList, context)
         : undefined,
-    RulesString: output.RulesString !== undefined && output.RulesString !== null ? output.RulesString : undefined,
+    RulesString: __expectString(output.RulesString),
     StatefulRules:
       output.StatefulRules !== undefined && output.StatefulRules !== null
         ? deserializeAws_json1_0StatefulRules(output.StatefulRules, context)
@@ -4936,10 +4906,7 @@ const deserializeAws_json1_0RulesSource = (output: any, context: __SerdeContext)
 
 const deserializeAws_json1_0RulesSourceList = (output: any, context: __SerdeContext): RulesSourceList => {
   return {
-    GeneratedRulesType:
-      output.GeneratedRulesType !== undefined && output.GeneratedRulesType !== null
-        ? output.GeneratedRulesType
-        : undefined,
+    GeneratedRulesType: __expectString(output.GeneratedRulesType),
     TargetTypes:
       output.TargetTypes !== undefined && output.TargetTypes !== null
         ? deserializeAws_json1_0TargetTypes(output.TargetTypes, context)
@@ -4958,7 +4925,7 @@ const deserializeAws_json1_0RuleTargets = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4982,13 +4949,13 @@ const deserializeAws_json1_0Settings = (output: any, context: __SerdeContext): s
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_0StatefulRule = (output: any, context: __SerdeContext): StatefulRule => {
   return {
-    Action: output.Action !== undefined && output.Action !== null ? output.Action : undefined,
+    Action: __expectString(output.Action),
     Header:
       output.Header !== undefined && output.Header !== null
         ? deserializeAws_json1_0Header(output.Header, context)
@@ -5005,7 +4972,7 @@ const deserializeAws_json1_0StatefulRuleGroupReference = (
   context: __SerdeContext
 ): StatefulRuleGroupReference => {
   return {
-    ResourceArn: output.ResourceArn !== undefined && output.ResourceArn !== null ? output.ResourceArn : undefined,
+    ResourceArn: __expectString(output.ResourceArn),
   } as any;
 };
 
@@ -5041,13 +5008,13 @@ const deserializeAws_json1_0StatelessActions = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_0StatelessRule = (output: any, context: __SerdeContext): StatelessRule => {
   return {
-    Priority: output.Priority !== undefined && output.Priority !== null ? output.Priority : undefined,
+    Priority: __expectNumber(output.Priority),
     RuleDefinition:
       output.RuleDefinition !== undefined && output.RuleDefinition !== null
         ? deserializeAws_json1_0RuleDefinition(output.RuleDefinition, context)
@@ -5060,8 +5027,8 @@ const deserializeAws_json1_0StatelessRuleGroupReference = (
   context: __SerdeContext
 ): StatelessRuleGroupReference => {
   return {
-    Priority: output.Priority !== undefined && output.Priority !== null ? output.Priority : undefined,
-    ResourceArn: output.ResourceArn !== undefined && output.ResourceArn !== null ? output.ResourceArn : undefined,
+    Priority: __expectNumber(output.Priority),
+    ResourceArn: __expectString(output.ResourceArn),
   } as any;
 };
 
@@ -5108,7 +5075,7 @@ const deserializeAws_json1_0StatelessRulesAndCustomActions = (
 
 const deserializeAws_json1_0SubnetMapping = (output: any, context: __SerdeContext): SubnetMapping => {
   return {
-    SubnetId: output.SubnetId !== undefined && output.SubnetId !== null ? output.SubnetId : undefined,
+    SubnetId: __expectString(output.SubnetId),
   } as any;
 };
 
@@ -5165,8 +5132,8 @@ const deserializeAws_json1_0SyncStates = (output: any, context: __SerdeContext):
 
 const deserializeAws_json1_0Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -5192,7 +5159,7 @@ const deserializeAws_json1_0TargetTypes = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -5222,7 +5189,7 @@ const deserializeAws_json1_0TCPFlags = (output: any, context: __SerdeContext): T
 
 const deserializeAws_json1_0ThrottlingException = (output: any, context: __SerdeContext): ThrottlingException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -5231,7 +5198,7 @@ const deserializeAws_json1_0UnsupportedOperationException = (
   context: __SerdeContext
 ): UnsupportedOperationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -5244,11 +5211,10 @@ const deserializeAws_json1_0UpdateFirewallDeleteProtectionResponse = (
   context: __SerdeContext
 ): UpdateFirewallDeleteProtectionResponse => {
   return {
-    DeleteProtection:
-      output.DeleteProtection !== undefined && output.DeleteProtection !== null ? output.DeleteProtection : undefined,
-    FirewallArn: output.FirewallArn !== undefined && output.FirewallArn !== null ? output.FirewallArn : undefined,
-    FirewallName: output.FirewallName !== undefined && output.FirewallName !== null ? output.FirewallName : undefined,
-    UpdateToken: output.UpdateToken !== undefined && output.UpdateToken !== null ? output.UpdateToken : undefined,
+    DeleteProtection: __expectBoolean(output.DeleteProtection),
+    FirewallArn: __expectString(output.FirewallArn),
+    FirewallName: __expectString(output.FirewallName),
+    UpdateToken: __expectString(output.UpdateToken),
   } as any;
 };
 
@@ -5257,10 +5223,10 @@ const deserializeAws_json1_0UpdateFirewallDescriptionResponse = (
   context: __SerdeContext
 ): UpdateFirewallDescriptionResponse => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    FirewallArn: output.FirewallArn !== undefined && output.FirewallArn !== null ? output.FirewallArn : undefined,
-    FirewallName: output.FirewallName !== undefined && output.FirewallName !== null ? output.FirewallName : undefined,
-    UpdateToken: output.UpdateToken !== undefined && output.UpdateToken !== null ? output.UpdateToken : undefined,
+    Description: __expectString(output.Description),
+    FirewallArn: __expectString(output.FirewallArn),
+    FirewallName: __expectString(output.FirewallName),
+    UpdateToken: __expectString(output.UpdateToken),
   } as any;
 };
 
@@ -5269,13 +5235,10 @@ const deserializeAws_json1_0UpdateFirewallPolicyChangeProtectionResponse = (
   context: __SerdeContext
 ): UpdateFirewallPolicyChangeProtectionResponse => {
   return {
-    FirewallArn: output.FirewallArn !== undefined && output.FirewallArn !== null ? output.FirewallArn : undefined,
-    FirewallName: output.FirewallName !== undefined && output.FirewallName !== null ? output.FirewallName : undefined,
-    FirewallPolicyChangeProtection:
-      output.FirewallPolicyChangeProtection !== undefined && output.FirewallPolicyChangeProtection !== null
-        ? output.FirewallPolicyChangeProtection
-        : undefined,
-    UpdateToken: output.UpdateToken !== undefined && output.UpdateToken !== null ? output.UpdateToken : undefined,
+    FirewallArn: __expectString(output.FirewallArn),
+    FirewallName: __expectString(output.FirewallName),
+    FirewallPolicyChangeProtection: __expectBoolean(output.FirewallPolicyChangeProtection),
+    UpdateToken: __expectString(output.UpdateToken),
   } as any;
 };
 
@@ -5288,7 +5251,7 @@ const deserializeAws_json1_0UpdateFirewallPolicyResponse = (
       output.FirewallPolicyResponse !== undefined && output.FirewallPolicyResponse !== null
         ? deserializeAws_json1_0FirewallPolicyResponse(output.FirewallPolicyResponse, context)
         : undefined,
-    UpdateToken: output.UpdateToken !== undefined && output.UpdateToken !== null ? output.UpdateToken : undefined,
+    UpdateToken: __expectString(output.UpdateToken),
   } as any;
 };
 
@@ -5297,8 +5260,8 @@ const deserializeAws_json1_0UpdateLoggingConfigurationResponse = (
   context: __SerdeContext
 ): UpdateLoggingConfigurationResponse => {
   return {
-    FirewallArn: output.FirewallArn !== undefined && output.FirewallArn !== null ? output.FirewallArn : undefined,
-    FirewallName: output.FirewallName !== undefined && output.FirewallName !== null ? output.FirewallName : undefined,
+    FirewallArn: __expectString(output.FirewallArn),
+    FirewallName: __expectString(output.FirewallName),
     LoggingConfiguration:
       output.LoggingConfiguration !== undefined && output.LoggingConfiguration !== null
         ? deserializeAws_json1_0LoggingConfiguration(output.LoggingConfiguration, context)
@@ -5315,7 +5278,7 @@ const deserializeAws_json1_0UpdateRuleGroupResponse = (
       output.RuleGroupResponse !== undefined && output.RuleGroupResponse !== null
         ? deserializeAws_json1_0RuleGroupResponse(output.RuleGroupResponse, context)
         : undefined,
-    UpdateToken: output.UpdateToken !== undefined && output.UpdateToken !== null ? output.UpdateToken : undefined,
+    UpdateToken: __expectString(output.UpdateToken),
   } as any;
 };
 
@@ -5324,13 +5287,10 @@ const deserializeAws_json1_0UpdateSubnetChangeProtectionResponse = (
   context: __SerdeContext
 ): UpdateSubnetChangeProtectionResponse => {
   return {
-    FirewallArn: output.FirewallArn !== undefined && output.FirewallArn !== null ? output.FirewallArn : undefined,
-    FirewallName: output.FirewallName !== undefined && output.FirewallName !== null ? output.FirewallName : undefined,
-    SubnetChangeProtection:
-      output.SubnetChangeProtection !== undefined && output.SubnetChangeProtection !== null
-        ? output.SubnetChangeProtection
-        : undefined,
-    UpdateToken: output.UpdateToken !== undefined && output.UpdateToken !== null ? output.UpdateToken : undefined,
+    FirewallArn: __expectString(output.FirewallArn),
+    FirewallName: __expectString(output.FirewallName),
+    SubnetChangeProtection: __expectBoolean(output.SubnetChangeProtection),
+    UpdateToken: __expectString(output.UpdateToken),
   } as any;
 };
 
@@ -5341,7 +5301,7 @@ const deserializeAws_json1_0VariableDefinitionList = (output: any, context: __Se
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 

--- a/clients/client-networkmanager/protocols/Aws_restJson1.ts
+++ b/clients/client-networkmanager/protocols/Aws_restJson1.ts
@@ -105,6 +105,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -2793,7 +2795,7 @@ export const deserializeAws_restJson1DescribeGlobalNetworksCommand = async (
     contents.GlobalNetworks = deserializeAws_restJson1GlobalNetworkList(data.GlobalNetworks, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3175,7 +3177,7 @@ export const deserializeAws_restJson1GetConnectionsCommand = async (
     contents.Connections = deserializeAws_restJson1ConnectionList(data.Connections, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3269,7 +3271,7 @@ export const deserializeAws_restJson1GetCustomerGatewayAssociationsCommand = asy
     );
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3368,7 +3370,7 @@ export const deserializeAws_restJson1GetDevicesCommand = async (
     contents.Devices = deserializeAws_restJson1DeviceList(data.Devices, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3459,7 +3461,7 @@ export const deserializeAws_restJson1GetLinkAssociationsCommand = async (
     contents.LinkAssociations = deserializeAws_restJson1LinkAssociationList(data.LinkAssociations, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3550,7 +3552,7 @@ export const deserializeAws_restJson1GetLinksCommand = async (
     contents.Links = deserializeAws_restJson1LinkList(data.Links, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3638,7 +3640,7 @@ export const deserializeAws_restJson1GetSitesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Sites !== undefined && data.Sites !== null) {
     contents.Sites = deserializeAws_restJson1SiteList(data.Sites, context);
@@ -3729,7 +3731,7 @@ export const deserializeAws_restJson1GetTransitGatewayConnectPeerAssociationsCom
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.TransitGatewayConnectPeerAssociations !== undefined && data.TransitGatewayConnectPeerAssociations !== null) {
     contents.TransitGatewayConnectPeerAssociations = deserializeAws_restJson1TransitGatewayConnectPeerAssociationList(
@@ -3831,7 +3833,7 @@ export const deserializeAws_restJson1GetTransitGatewayRegistrationsCommand = asy
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.TransitGatewayRegistrations !== undefined && data.TransitGatewayRegistrations !== null) {
     contents.TransitGatewayRegistrations = deserializeAws_restJson1TransitGatewayRegistrationList(
@@ -4781,7 +4783,7 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -4800,13 +4802,13 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.ResourceId !== undefined && data.ResourceId !== null) {
-    contents.ResourceId = data.ResourceId;
+    contents.ResourceId = __expectString(data.ResourceId);
   }
   if (data.ResourceType !== undefined && data.ResourceType !== null) {
-    contents.ResourceType = data.ResourceType;
+    contents.ResourceType = __expectString(data.ResourceType);
   }
   return contents;
 };
@@ -4827,7 +4829,7 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   }
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -4846,13 +4848,13 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.ResourceId !== undefined && data.ResourceId !== null) {
-    contents.ResourceId = data.ResourceId;
+    contents.ResourceId = __expectString(data.ResourceId);
   }
   if (data.ResourceType !== undefined && data.ResourceType !== null) {
-    contents.ResourceType = data.ResourceType;
+    contents.ResourceType = __expectString(data.ResourceType);
   }
   return contents;
 };
@@ -4873,19 +4875,19 @@ const deserializeAws_restJson1ServiceQuotaExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.LimitCode !== undefined && data.LimitCode !== null) {
-    contents.LimitCode = data.LimitCode;
+    contents.LimitCode = __expectString(data.LimitCode);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.ResourceId !== undefined && data.ResourceId !== null) {
-    contents.ResourceId = data.ResourceId;
+    contents.ResourceId = __expectString(data.ResourceId);
   }
   if (data.ResourceType !== undefined && data.ResourceType !== null) {
-    contents.ResourceType = data.ResourceType;
+    contents.ResourceType = __expectString(data.ResourceType);
   }
   if (data.ServiceCode !== undefined && data.ServiceCode !== null) {
-    contents.ServiceCode = data.ServiceCode;
+    contents.ServiceCode = __expectString(data.ServiceCode);
   }
   return contents;
 };
@@ -4906,7 +4908,7 @@ const deserializeAws_restJson1ThrottlingExceptionResponse = async (
   }
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -4928,10 +4930,10 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
     contents.Fields = deserializeAws_restJson1ValidationExceptionFieldList(data.Fields, context);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.Reason !== undefined && data.Reason !== null) {
-    contents.Reason = data.Reason;
+    contents.Reason = __expectString(data.Reason);
   }
   return contents;
 };
@@ -4978,40 +4980,33 @@ const serializeAws_restJson1TagList = (input: Tag[], context: __SerdeContext): a
 
 const deserializeAws_restJson1AWSLocation = (output: any, context: __SerdeContext): AWSLocation => {
   return {
-    SubnetArn: output.SubnetArn !== undefined && output.SubnetArn !== null ? output.SubnetArn : undefined,
-    Zone: output.Zone !== undefined && output.Zone !== null ? output.Zone : undefined,
+    SubnetArn: __expectString(output.SubnetArn),
+    Zone: __expectString(output.Zone),
   } as any;
 };
 
 const deserializeAws_restJson1Bandwidth = (output: any, context: __SerdeContext): Bandwidth => {
   return {
-    DownloadSpeed:
-      output.DownloadSpeed !== undefined && output.DownloadSpeed !== null ? output.DownloadSpeed : undefined,
-    UploadSpeed: output.UploadSpeed !== undefined && output.UploadSpeed !== null ? output.UploadSpeed : undefined,
+    DownloadSpeed: __expectNumber(output.DownloadSpeed),
+    UploadSpeed: __expectNumber(output.UploadSpeed),
   } as any;
 };
 
 const deserializeAws_restJson1Connection = (output: any, context: __SerdeContext): Connection => {
   return {
-    ConnectedDeviceId:
-      output.ConnectedDeviceId !== undefined && output.ConnectedDeviceId !== null
-        ? output.ConnectedDeviceId
-        : undefined,
-    ConnectedLinkId:
-      output.ConnectedLinkId !== undefined && output.ConnectedLinkId !== null ? output.ConnectedLinkId : undefined,
-    ConnectionArn:
-      output.ConnectionArn !== undefined && output.ConnectionArn !== null ? output.ConnectionArn : undefined,
-    ConnectionId: output.ConnectionId !== undefined && output.ConnectionId !== null ? output.ConnectionId : undefined,
+    ConnectedDeviceId: __expectString(output.ConnectedDeviceId),
+    ConnectedLinkId: __expectString(output.ConnectedLinkId),
+    ConnectionArn: __expectString(output.ConnectionArn),
+    ConnectionId: __expectString(output.ConnectionId),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    DeviceId: output.DeviceId !== undefined && output.DeviceId !== null ? output.DeviceId : undefined,
-    GlobalNetworkId:
-      output.GlobalNetworkId !== undefined && output.GlobalNetworkId !== null ? output.GlobalNetworkId : undefined,
-    LinkId: output.LinkId !== undefined && output.LinkId !== null ? output.LinkId : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    Description: __expectString(output.Description),
+    DeviceId: __expectString(output.DeviceId),
+    GlobalNetworkId: __expectString(output.GlobalNetworkId),
+    LinkId: __expectString(output.LinkId),
+    State: __expectString(output.State),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_restJson1TagList(output.Tags, context)
@@ -5035,15 +5030,11 @@ const deserializeAws_restJson1CustomerGatewayAssociation = (
   context: __SerdeContext
 ): CustomerGatewayAssociation => {
   return {
-    CustomerGatewayArn:
-      output.CustomerGatewayArn !== undefined && output.CustomerGatewayArn !== null
-        ? output.CustomerGatewayArn
-        : undefined,
-    DeviceId: output.DeviceId !== undefined && output.DeviceId !== null ? output.DeviceId : undefined,
-    GlobalNetworkId:
-      output.GlobalNetworkId !== undefined && output.GlobalNetworkId !== null ? output.GlobalNetworkId : undefined,
-    LinkId: output.LinkId !== undefined && output.LinkId !== null ? output.LinkId : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    CustomerGatewayArn: __expectString(output.CustomerGatewayArn),
+    DeviceId: __expectString(output.DeviceId),
+    GlobalNetworkId: __expectString(output.GlobalNetworkId),
+    LinkId: __expectString(output.LinkId),
+    State: __expectString(output.State),
   } as any;
 };
 
@@ -5071,25 +5062,24 @@ const deserializeAws_restJson1Device = (output: any, context: __SerdeContext): D
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    DeviceArn: output.DeviceArn !== undefined && output.DeviceArn !== null ? output.DeviceArn : undefined,
-    DeviceId: output.DeviceId !== undefined && output.DeviceId !== null ? output.DeviceId : undefined,
-    GlobalNetworkId:
-      output.GlobalNetworkId !== undefined && output.GlobalNetworkId !== null ? output.GlobalNetworkId : undefined,
+    Description: __expectString(output.Description),
+    DeviceArn: __expectString(output.DeviceArn),
+    DeviceId: __expectString(output.DeviceId),
+    GlobalNetworkId: __expectString(output.GlobalNetworkId),
     Location:
       output.Location !== undefined && output.Location !== null
         ? deserializeAws_restJson1Location(output.Location, context)
         : undefined,
-    Model: output.Model !== undefined && output.Model !== null ? output.Model : undefined,
-    SerialNumber: output.SerialNumber !== undefined && output.SerialNumber !== null ? output.SerialNumber : undefined,
-    SiteId: output.SiteId !== undefined && output.SiteId !== null ? output.SiteId : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    Model: __expectString(output.Model),
+    SerialNumber: __expectString(output.SerialNumber),
+    SiteId: __expectString(output.SiteId),
+    State: __expectString(output.State),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_restJson1TagList(output.Tags, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    Vendor: output.Vendor !== undefined && output.Vendor !== null ? output.Vendor : undefined,
+    Type: __expectString(output.Type),
+    Vendor: __expectString(output.Vendor),
   } as any;
 };
 
@@ -5110,12 +5100,10 @@ const deserializeAws_restJson1GlobalNetwork = (output: any, context: __SerdeCont
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    GlobalNetworkArn:
-      output.GlobalNetworkArn !== undefined && output.GlobalNetworkArn !== null ? output.GlobalNetworkArn : undefined,
-    GlobalNetworkId:
-      output.GlobalNetworkId !== undefined && output.GlobalNetworkId !== null ? output.GlobalNetworkId : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    Description: __expectString(output.Description),
+    GlobalNetworkArn: __expectString(output.GlobalNetworkArn),
+    GlobalNetworkId: __expectString(output.GlobalNetworkId),
+    State: __expectString(output.State),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_restJson1TagList(output.Tags, context)
@@ -5144,32 +5132,27 @@ const deserializeAws_restJson1Link = (output: any, context: __SerdeContext): Lin
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    GlobalNetworkId:
-      output.GlobalNetworkId !== undefined && output.GlobalNetworkId !== null ? output.GlobalNetworkId : undefined,
-    LinkArn: output.LinkArn !== undefined && output.LinkArn !== null ? output.LinkArn : undefined,
-    LinkId: output.LinkId !== undefined && output.LinkId !== null ? output.LinkId : undefined,
-    Provider: output.Provider !== undefined && output.Provider !== null ? output.Provider : undefined,
-    SiteId: output.SiteId !== undefined && output.SiteId !== null ? output.SiteId : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    Description: __expectString(output.Description),
+    GlobalNetworkId: __expectString(output.GlobalNetworkId),
+    LinkArn: __expectString(output.LinkArn),
+    LinkId: __expectString(output.LinkId),
+    Provider: __expectString(output.Provider),
+    SiteId: __expectString(output.SiteId),
+    State: __expectString(output.State),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_restJson1TagList(output.Tags, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
 const deserializeAws_restJson1LinkAssociation = (output: any, context: __SerdeContext): LinkAssociation => {
   return {
-    DeviceId: output.DeviceId !== undefined && output.DeviceId !== null ? output.DeviceId : undefined,
-    GlobalNetworkId:
-      output.GlobalNetworkId !== undefined && output.GlobalNetworkId !== null ? output.GlobalNetworkId : undefined,
-    LinkAssociationState:
-      output.LinkAssociationState !== undefined && output.LinkAssociationState !== null
-        ? output.LinkAssociationState
-        : undefined,
-    LinkId: output.LinkId !== undefined && output.LinkId !== null ? output.LinkId : undefined,
+    DeviceId: __expectString(output.DeviceId),
+    GlobalNetworkId: __expectString(output.GlobalNetworkId),
+    LinkAssociationState: __expectString(output.LinkAssociationState),
+    LinkId: __expectString(output.LinkId),
   } as any;
 };
 
@@ -5197,9 +5180,9 @@ const deserializeAws_restJson1LinkList = (output: any, context: __SerdeContext):
 
 const deserializeAws_restJson1Location = (output: any, context: __SerdeContext): Location => {
   return {
-    Address: output.Address !== undefined && output.Address !== null ? output.Address : undefined,
-    Latitude: output.Latitude !== undefined && output.Latitude !== null ? output.Latitude : undefined,
-    Longitude: output.Longitude !== undefined && output.Longitude !== null ? output.Longitude : undefined,
+    Address: __expectString(output.Address),
+    Latitude: __expectString(output.Latitude),
+    Longitude: __expectString(output.Longitude),
   } as any;
 };
 
@@ -5209,16 +5192,15 @@ const deserializeAws_restJson1Site = (output: any, context: __SerdeContext): Sit
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    GlobalNetworkId:
-      output.GlobalNetworkId !== undefined && output.GlobalNetworkId !== null ? output.GlobalNetworkId : undefined,
+    Description: __expectString(output.Description),
+    GlobalNetworkId: __expectString(output.GlobalNetworkId),
     Location:
       output.Location !== undefined && output.Location !== null
         ? deserializeAws_restJson1Location(output.Location, context)
         : undefined,
-    SiteArn: output.SiteArn !== undefined && output.SiteArn !== null ? output.SiteArn : undefined,
-    SiteId: output.SiteId !== undefined && output.SiteId !== null ? output.SiteId : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    SiteArn: __expectString(output.SiteArn),
+    SiteId: __expectString(output.SiteId),
+    State: __expectString(output.State),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_restJson1TagList(output.Tags, context)
@@ -5239,8 +5221,8 @@ const deserializeAws_restJson1SiteList = (output: any, context: __SerdeContext):
 
 const deserializeAws_restJson1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -5260,15 +5242,11 @@ const deserializeAws_restJson1TransitGatewayConnectPeerAssociation = (
   context: __SerdeContext
 ): TransitGatewayConnectPeerAssociation => {
   return {
-    DeviceId: output.DeviceId !== undefined && output.DeviceId !== null ? output.DeviceId : undefined,
-    GlobalNetworkId:
-      output.GlobalNetworkId !== undefined && output.GlobalNetworkId !== null ? output.GlobalNetworkId : undefined,
-    LinkId: output.LinkId !== undefined && output.LinkId !== null ? output.LinkId : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    TransitGatewayConnectPeerArn:
-      output.TransitGatewayConnectPeerArn !== undefined && output.TransitGatewayConnectPeerArn !== null
-        ? output.TransitGatewayConnectPeerArn
-        : undefined,
+    DeviceId: __expectString(output.DeviceId),
+    GlobalNetworkId: __expectString(output.GlobalNetworkId),
+    LinkId: __expectString(output.LinkId),
+    State: __expectString(output.State),
+    TransitGatewayConnectPeerArn: __expectString(output.TransitGatewayConnectPeerArn),
   } as any;
 };
 
@@ -5291,16 +5269,12 @@ const deserializeAws_restJson1TransitGatewayRegistration = (
   context: __SerdeContext
 ): TransitGatewayRegistration => {
   return {
-    GlobalNetworkId:
-      output.GlobalNetworkId !== undefined && output.GlobalNetworkId !== null ? output.GlobalNetworkId : undefined,
+    GlobalNetworkId: __expectString(output.GlobalNetworkId),
     State:
       output.State !== undefined && output.State !== null
         ? deserializeAws_restJson1TransitGatewayRegistrationStateReason(output.State, context)
         : undefined,
-    TransitGatewayArn:
-      output.TransitGatewayArn !== undefined && output.TransitGatewayArn !== null
-        ? output.TransitGatewayArn
-        : undefined,
+    TransitGatewayArn: __expectString(output.TransitGatewayArn),
   } as any;
 };
 
@@ -5323,8 +5297,8 @@ const deserializeAws_restJson1TransitGatewayRegistrationStateReason = (
   context: __SerdeContext
 ): TransitGatewayRegistrationStateReason => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -5333,8 +5307,8 @@ const deserializeAws_restJson1ValidationExceptionField = (
   context: __SerdeContext
 ): ValidationExceptionField => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Message: __expectString(output.Message),
+    Name: __expectString(output.Name),
   } as any;
 };
 

--- a/clients/client-nimble/protocols/Aws_restJson1.ts
+++ b/clients/client-nimble/protocols/Aws_restJson1.ts
@@ -165,6 +165,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -4531,7 +4533,7 @@ export const deserializeAws_restJson1ListEulaAcceptancesCommand = async (
     contents.eulaAcceptances = deserializeAws_restJson1EulaAcceptanceList(data.eulaAcceptances, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -4638,7 +4640,7 @@ export const deserializeAws_restJson1ListEulasCommand = async (
     contents.eulas = deserializeAws_restJson1EulaList(data.eulas, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -4745,7 +4747,7 @@ export const deserializeAws_restJson1ListLaunchProfileMembersCommand = async (
     contents.members = deserializeAws_restJson1LaunchProfileMembershipList(data.members, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -4852,7 +4854,7 @@ export const deserializeAws_restJson1ListLaunchProfilesCommand = async (
     contents.launchProfiles = deserializeAws_restJson1LaunchProfileList(data.launchProfiles, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -4956,7 +4958,7 @@ export const deserializeAws_restJson1ListStreamingImagesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.streamingImages !== undefined && data.streamingImages !== null) {
     contents.streamingImages = deserializeAws_restJson1StreamingImageList(data.streamingImages, context);
@@ -5063,7 +5065,7 @@ export const deserializeAws_restJson1ListStreamingSessionsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.sessions !== undefined && data.sessions !== null) {
     contents.sessions = deserializeAws_restJson1StreamingSessionList(data.sessions, context);
@@ -5170,7 +5172,7 @@ export const deserializeAws_restJson1ListStudioComponentsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.studioComponents !== undefined && data.studioComponents !== null) {
     contents.studioComponents = deserializeAws_restJson1StudioComponentList(data.studioComponents, context);
@@ -5280,7 +5282,7 @@ export const deserializeAws_restJson1ListStudioMembersCommand = async (
     contents.members = deserializeAws_restJson1StudioMembershipList(data.members, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -5384,7 +5386,7 @@ export const deserializeAws_restJson1ListStudiosCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.studios !== undefined && data.studios !== null) {
     contents.studios = deserializeAws_restJson1StudioList(data.studios, context);
@@ -6608,13 +6610,13 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.code !== undefined && data.code !== null) {
-    contents.code = data.code;
+    contents.code = __expectString(data.code);
   }
   if (data.context !== undefined && data.context !== null) {
     contents.context = deserializeAws_restJson1ExceptionContext(data.context, context);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -6633,13 +6635,13 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.code !== undefined && data.code !== null) {
-    contents.code = data.code;
+    contents.code = __expectString(data.code);
   }
   if (data.context !== undefined && data.context !== null) {
     contents.context = deserializeAws_restJson1ExceptionContext(data.context, context);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -6658,13 +6660,13 @@ const deserializeAws_restJson1InternalServerErrorExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.code !== undefined && data.code !== null) {
-    contents.code = data.code;
+    contents.code = __expectString(data.code);
   }
   if (data.context !== undefined && data.context !== null) {
     contents.context = deserializeAws_restJson1ExceptionContext(data.context, context);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -6683,13 +6685,13 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.code !== undefined && data.code !== null) {
-    contents.code = data.code;
+    contents.code = __expectString(data.code);
   }
   if (data.context !== undefined && data.context !== null) {
     contents.context = deserializeAws_restJson1ExceptionContext(data.context, context);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -6708,13 +6710,13 @@ const deserializeAws_restJson1ServiceQuotaExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.code !== undefined && data.code !== null) {
-    contents.code = data.code;
+    contents.code = __expectString(data.code);
   }
   if (data.context !== undefined && data.context !== null) {
     contents.context = deserializeAws_restJson1ExceptionContext(data.context, context);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -6733,13 +6735,13 @@ const deserializeAws_restJson1ThrottlingExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.code !== undefined && data.code !== null) {
-    contents.code = data.code;
+    contents.code = __expectString(data.code);
   }
   if (data.context !== undefined && data.context !== null) {
     contents.context = deserializeAws_restJson1ExceptionContext(data.context, context);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -6758,13 +6760,13 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.code !== undefined && data.code !== null) {
-    contents.code = data.code;
+    contents.code = __expectString(data.code);
   }
   if (data.context !== undefined && data.context !== null) {
     contents.context = deserializeAws_restJson1ExceptionContext(data.context, context);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -7102,8 +7104,8 @@ const deserializeAws_restJson1ActiveDirectoryComputerAttribute = (
   context: __SerdeContext
 ): ActiveDirectoryComputerAttribute => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    name: __expectString(output.name),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -7130,11 +7132,8 @@ const deserializeAws_restJson1ActiveDirectoryConfiguration = (
       output.computerAttributes !== undefined && output.computerAttributes !== null
         ? deserializeAws_restJson1ActiveDirectoryComputerAttributeList(output.computerAttributes, context)
         : undefined,
-    directoryId: output.directoryId !== undefined && output.directoryId !== null ? output.directoryId : undefined,
-    organizationalUnitDistinguishedName:
-      output.organizationalUnitDistinguishedName !== undefined && output.organizationalUnitDistinguishedName !== null
-        ? output.organizationalUnitDistinguishedName
-        : undefined,
+    directoryId: __expectString(output.directoryId),
+    organizationalUnitDistinguishedName: __expectString(output.organizationalUnitDistinguishedName),
   } as any;
 };
 
@@ -7145,7 +7144,7 @@ const deserializeAws_restJson1ActiveDirectoryDnsIpAddressList = (output: any, co
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7154,11 +7153,8 @@ const deserializeAws_restJson1ComputeFarmConfiguration = (
   context: __SerdeContext
 ): ComputeFarmConfiguration => {
   return {
-    activeDirectoryUser:
-      output.activeDirectoryUser !== undefined && output.activeDirectoryUser !== null
-        ? output.activeDirectoryUser
-        : undefined,
-    endpoint: output.endpoint !== undefined && output.endpoint !== null ? output.endpoint : undefined,
+    activeDirectoryUser: __expectString(output.activeDirectoryUser),
+    endpoint: __expectString(output.endpoint),
   } as any;
 };
 
@@ -7169,16 +7165,16 @@ const deserializeAws_restJson1EC2SubnetIdList = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1Eula = (output: any, context: __SerdeContext): Eula => {
   return {
-    content: output.content !== undefined && output.content !== null ? output.content : undefined,
+    content: __expectString(output.content),
     createdAt: output.createdAt !== undefined && output.createdAt !== null ? new Date(output.createdAt) : undefined,
-    eulaId: output.eulaId !== undefined && output.eulaId !== null ? output.eulaId : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    eulaId: __expectString(output.eulaId),
+    name: __expectString(output.name),
     updatedAt: output.updatedAt !== undefined && output.updatedAt !== null ? new Date(output.updatedAt) : undefined,
   } as any;
 };
@@ -7186,11 +7182,10 @@ const deserializeAws_restJson1Eula = (output: any, context: __SerdeContext): Eul
 const deserializeAws_restJson1EulaAcceptance = (output: any, context: __SerdeContext): EulaAcceptance => {
   return {
     acceptedAt: output.acceptedAt !== undefined && output.acceptedAt !== null ? new Date(output.acceptedAt) : undefined,
-    acceptedBy: output.acceptedBy !== undefined && output.acceptedBy !== null ? output.acceptedBy : undefined,
-    accepteeId: output.accepteeId !== undefined && output.accepteeId !== null ? output.accepteeId : undefined,
-    eulaAcceptanceId:
-      output.eulaAcceptanceId !== undefined && output.eulaAcceptanceId !== null ? output.eulaAcceptanceId : undefined,
-    eulaId: output.eulaId !== undefined && output.eulaId !== null ? output.eulaId : undefined,
+    acceptedBy: __expectString(output.acceptedBy),
+    accepteeId: __expectString(output.accepteeId),
+    eulaAcceptanceId: __expectString(output.eulaAcceptanceId),
+    eulaId: __expectString(output.eulaId),
   } as any;
 };
 
@@ -7212,7 +7207,7 @@ const deserializeAws_restJson1EulaIdList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7234,32 +7229,30 @@ const deserializeAws_restJson1ExceptionContext = (output: any, context: __SerdeC
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1LaunchProfile = (output: any, context: __SerdeContext): LaunchProfile => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt: output.createdAt !== undefined && output.createdAt !== null ? new Date(output.createdAt) : undefined,
-    createdBy: output.createdBy !== undefined && output.createdBy !== null ? output.createdBy : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    createdBy: __expectString(output.createdBy),
+    description: __expectString(output.description),
     ec2SubnetIds:
       output.ec2SubnetIds !== undefined && output.ec2SubnetIds !== null
         ? deserializeAws_restJson1EC2SubnetIdList(output.ec2SubnetIds, context)
         : undefined,
-    launchProfileId:
-      output.launchProfileId !== undefined && output.launchProfileId !== null ? output.launchProfileId : undefined,
+    launchProfileId: __expectString(output.launchProfileId),
     launchProfileProtocolVersions:
       output.launchProfileProtocolVersions !== undefined && output.launchProfileProtocolVersions !== null
         ? deserializeAws_restJson1LaunchProfileProtocolVersionList(output.launchProfileProtocolVersions, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    state: output.state !== undefined && output.state !== null ? output.state : undefined,
-    statusCode: output.statusCode !== undefined && output.statusCode !== null ? output.statusCode : undefined,
-    statusMessage:
-      output.statusMessage !== undefined && output.statusMessage !== null ? output.statusMessage : undefined,
+    name: __expectString(output.name),
+    state: __expectString(output.state),
+    statusCode: __expectString(output.statusCode),
+    statusMessage: __expectString(output.statusMessage),
     streamConfiguration:
       output.streamConfiguration !== undefined && output.streamConfiguration !== null
         ? deserializeAws_restJson1StreamConfiguration(output.streamConfiguration, context)
@@ -7273,7 +7266,7 @@ const deserializeAws_restJson1LaunchProfile = (output: any, context: __SerdeCont
         ? deserializeAws_restJson1Tags(output.tags, context)
         : undefined,
     updatedAt: output.updatedAt !== undefined && output.updatedAt !== null ? new Date(output.updatedAt) : undefined,
-    updatedBy: output.updatedBy !== undefined && output.updatedBy !== null ? output.updatedBy : undefined,
+    updatedBy: __expectString(output.updatedBy),
   } as any;
 };
 
@@ -7290,16 +7283,11 @@ const deserializeAws_restJson1LaunchProfileInitialization = (
       output.ec2SecurityGroupIds !== undefined && output.ec2SecurityGroupIds !== null
         ? deserializeAws_restJson1LaunchProfileSecurityGroupIdList(output.ec2SecurityGroupIds, context)
         : undefined,
-    launchProfileId:
-      output.launchProfileId !== undefined && output.launchProfileId !== null ? output.launchProfileId : undefined,
-    launchProfileProtocolVersion:
-      output.launchProfileProtocolVersion !== undefined && output.launchProfileProtocolVersion !== null
-        ? output.launchProfileProtocolVersion
-        : undefined,
-    launchPurpose:
-      output.launchPurpose !== undefined && output.launchPurpose !== null ? output.launchPurpose : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    platform: output.platform !== undefined && output.platform !== null ? output.platform : undefined,
+    launchProfileId: __expectString(output.launchProfileId),
+    launchProfileProtocolVersion: __expectString(output.launchProfileProtocolVersion),
+    launchPurpose: __expectString(output.launchPurpose),
+    name: __expectString(output.name),
+    platform: __expectString(output.platform),
     systemInitializationScripts:
       output.systemInitializationScripts !== undefined && output.systemInitializationScripts !== null
         ? deserializeAws_restJson1LaunchProfileInitializationScriptList(output.systemInitializationScripts, context)
@@ -7320,25 +7308,15 @@ const deserializeAws_restJson1LaunchProfileInitializationActiveDirectory = (
       output.computerAttributes !== undefined && output.computerAttributes !== null
         ? deserializeAws_restJson1ActiveDirectoryComputerAttributeList(output.computerAttributes, context)
         : undefined,
-    directoryId: output.directoryId !== undefined && output.directoryId !== null ? output.directoryId : undefined,
-    directoryName:
-      output.directoryName !== undefined && output.directoryName !== null ? output.directoryName : undefined,
+    directoryId: __expectString(output.directoryId),
+    directoryName: __expectString(output.directoryName),
     dnsIpAddresses:
       output.dnsIpAddresses !== undefined && output.dnsIpAddresses !== null
         ? deserializeAws_restJson1ActiveDirectoryDnsIpAddressList(output.dnsIpAddresses, context)
         : undefined,
-    organizationalUnitDistinguishedName:
-      output.organizationalUnitDistinguishedName !== undefined && output.organizationalUnitDistinguishedName !== null
-        ? output.organizationalUnitDistinguishedName
-        : undefined,
-    studioComponentId:
-      output.studioComponentId !== undefined && output.studioComponentId !== null
-        ? output.studioComponentId
-        : undefined,
-    studioComponentName:
-      output.studioComponentName !== undefined && output.studioComponentName !== null
-        ? output.studioComponentName
-        : undefined,
+    organizationalUnitDistinguishedName: __expectString(output.organizationalUnitDistinguishedName),
+    studioComponentId: __expectString(output.studioComponentId),
+    studioComponentName: __expectString(output.studioComponentName),
   } as any;
 };
 
@@ -7347,15 +7325,9 @@ const deserializeAws_restJson1LaunchProfileInitializationScript = (
   context: __SerdeContext
 ): LaunchProfileInitializationScript => {
   return {
-    script: output.script !== undefined && output.script !== null ? output.script : undefined,
-    studioComponentId:
-      output.studioComponentId !== undefined && output.studioComponentId !== null
-        ? output.studioComponentId
-        : undefined,
-    studioComponentName:
-      output.studioComponentName !== undefined && output.studioComponentName !== null
-        ? output.studioComponentName
-        : undefined,
+    script: __expectString(output.script),
+    studioComponentId: __expectString(output.studioComponentId),
+    studioComponentName: __expectString(output.studioComponentName),
   } as any;
 };
 
@@ -7389,10 +7361,9 @@ const deserializeAws_restJson1LaunchProfileMembership = (
   context: __SerdeContext
 ): LaunchProfileMembership => {
   return {
-    identityStoreId:
-      output.identityStoreId !== undefined && output.identityStoreId !== null ? output.identityStoreId : undefined,
-    persona: output.persona !== undefined && output.persona !== null ? output.persona : undefined,
-    principalId: output.principalId !== undefined && output.principalId !== null ? output.principalId : undefined,
+    identityStoreId: __expectString(output.identityStoreId),
+    persona: __expectString(output.persona),
+    principalId: __expectString(output.principalId),
   } as any;
 };
 
@@ -7417,7 +7388,7 @@ const deserializeAws_restJson1LaunchProfileProtocolVersionList = (output: any, c
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7428,7 +7399,7 @@ const deserializeAws_restJson1LaunchProfileSecurityGroupIdList = (output: any, c
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7439,7 +7410,7 @@ const deserializeAws_restJson1LaunchProfileStudioComponentIdList = (output: any,
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7448,7 +7419,7 @@ const deserializeAws_restJson1LicenseServiceConfiguration = (
   context: __SerdeContext
 ): LicenseServiceConfiguration => {
   return {
-    endpoint: output.endpoint !== undefined && output.endpoint !== null ? output.endpoint : undefined,
+    endpoint: __expectString(output.endpoint),
   } as any;
 };
 
@@ -7457,8 +7428,8 @@ const deserializeAws_restJson1ScriptParameterKeyValue = (
   context: __SerdeContext
 ): ScriptParameterKeyValue => {
   return {
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    key: __expectString(output.key),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -7467,30 +7438,22 @@ const deserializeAws_restJson1SharedFileSystemConfiguration = (
   context: __SerdeContext
 ): SharedFileSystemConfiguration => {
   return {
-    endpoint: output.endpoint !== undefined && output.endpoint !== null ? output.endpoint : undefined,
-    fileSystemId: output.fileSystemId !== undefined && output.fileSystemId !== null ? output.fileSystemId : undefined,
-    linuxMountPoint:
-      output.linuxMountPoint !== undefined && output.linuxMountPoint !== null ? output.linuxMountPoint : undefined,
-    shareName: output.shareName !== undefined && output.shareName !== null ? output.shareName : undefined,
-    windowsMountDrive:
-      output.windowsMountDrive !== undefined && output.windowsMountDrive !== null
-        ? output.windowsMountDrive
-        : undefined,
+    endpoint: __expectString(output.endpoint),
+    fileSystemId: __expectString(output.fileSystemId),
+    linuxMountPoint: __expectString(output.linuxMountPoint),
+    shareName: __expectString(output.shareName),
+    windowsMountDrive: __expectString(output.windowsMountDrive),
   } as any;
 };
 
 const deserializeAws_restJson1StreamConfiguration = (output: any, context: __SerdeContext): StreamConfiguration => {
   return {
-    clipboardMode:
-      output.clipboardMode !== undefined && output.clipboardMode !== null ? output.clipboardMode : undefined,
+    clipboardMode: __expectString(output.clipboardMode),
     ec2InstanceTypes:
       output.ec2InstanceTypes !== undefined && output.ec2InstanceTypes !== null
         ? deserializeAws_restJson1StreamingInstanceTypeList(output.ec2InstanceTypes, context)
         : undefined,
-    maxSessionLengthInMinutes:
-      output.maxSessionLengthInMinutes !== undefined && output.maxSessionLengthInMinutes !== null
-        ? output.maxSessionLengthInMinutes
-        : undefined,
+    maxSessionLengthInMinutes: __expectNumber(output.maxSessionLengthInMinutes),
     streamingImageIds:
       output.streamingImageIds !== undefined && output.streamingImageIds !== null
         ? deserializeAws_restJson1StreamingImageIdList(output.streamingImageIds, context)
@@ -7500,9 +7463,9 @@ const deserializeAws_restJson1StreamConfiguration = (output: any, context: __Ser
 
 const deserializeAws_restJson1StreamingImage = (output: any, context: __SerdeContext): StreamingImage => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    ec2ImageId: output.ec2ImageId !== undefined && output.ec2ImageId !== null ? output.ec2ImageId : undefined,
+    arn: __expectString(output.arn),
+    description: __expectString(output.description),
+    ec2ImageId: __expectString(output.ec2ImageId),
     encryptionConfiguration:
       output.encryptionConfiguration !== undefined && output.encryptionConfiguration !== null
         ? deserializeAws_restJson1StreamingImageEncryptionConfiguration(output.encryptionConfiguration, context)
@@ -7511,15 +7474,13 @@ const deserializeAws_restJson1StreamingImage = (output: any, context: __SerdeCon
       output.eulaIds !== undefined && output.eulaIds !== null
         ? deserializeAws_restJson1EulaIdList(output.eulaIds, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    owner: output.owner !== undefined && output.owner !== null ? output.owner : undefined,
-    platform: output.platform !== undefined && output.platform !== null ? output.platform : undefined,
-    state: output.state !== undefined && output.state !== null ? output.state : undefined,
-    statusCode: output.statusCode !== undefined && output.statusCode !== null ? output.statusCode : undefined,
-    statusMessage:
-      output.statusMessage !== undefined && output.statusMessage !== null ? output.statusMessage : undefined,
-    streamingImageId:
-      output.streamingImageId !== undefined && output.streamingImageId !== null ? output.streamingImageId : undefined,
+    name: __expectString(output.name),
+    owner: __expectString(output.owner),
+    platform: __expectString(output.platform),
+    state: __expectString(output.state),
+    statusCode: __expectString(output.statusCode),
+    statusMessage: __expectString(output.statusMessage),
+    streamingImageId: __expectString(output.streamingImageId),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1Tags(output.tags, context)
@@ -7532,8 +7493,8 @@ const deserializeAws_restJson1StreamingImageEncryptionConfiguration = (
   context: __SerdeContext
 ): StreamingImageEncryptionConfiguration => {
   return {
-    keyArn: output.keyArn !== undefined && output.keyArn !== null ? output.keyArn : undefined,
-    keyType: output.keyType !== undefined && output.keyType !== null ? output.keyType : undefined,
+    keyArn: __expectString(output.keyArn),
+    keyType: __expectString(output.keyType),
   } as any;
 };
 
@@ -7544,7 +7505,7 @@ const deserializeAws_restJson1StreamingImageIdList = (output: any, context: __Se
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7569,26 +7530,22 @@ const deserializeAws_restJson1StreamingInstanceTypeList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1StreamingSession = (output: any, context: __SerdeContext): StreamingSession => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt: output.createdAt !== undefined && output.createdAt !== null ? new Date(output.createdAt) : undefined,
-    createdBy: output.createdBy !== undefined && output.createdBy !== null ? output.createdBy : undefined,
-    ec2InstanceType:
-      output.ec2InstanceType !== undefined && output.ec2InstanceType !== null ? output.ec2InstanceType : undefined,
-    launchProfileId:
-      output.launchProfileId !== undefined && output.launchProfileId !== null ? output.launchProfileId : undefined,
-    sessionId: output.sessionId !== undefined && output.sessionId !== null ? output.sessionId : undefined,
-    state: output.state !== undefined && output.state !== null ? output.state : undefined,
-    statusCode: output.statusCode !== undefined && output.statusCode !== null ? output.statusCode : undefined,
-    statusMessage:
-      output.statusMessage !== undefined && output.statusMessage !== null ? output.statusMessage : undefined,
-    streamingImageId:
-      output.streamingImageId !== undefined && output.streamingImageId !== null ? output.streamingImageId : undefined,
+    createdBy: __expectString(output.createdBy),
+    ec2InstanceType: __expectString(output.ec2InstanceType),
+    launchProfileId: __expectString(output.launchProfileId),
+    sessionId: __expectString(output.sessionId),
+    state: __expectString(output.state),
+    statusCode: __expectString(output.statusCode),
+    statusMessage: __expectString(output.statusMessage),
+    streamingImageId: __expectString(output.streamingImageId),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1Tags(output.tags, context)
@@ -7596,7 +7553,7 @@ const deserializeAws_restJson1StreamingSession = (output: any, context: __SerdeC
     terminateAt:
       output.terminateAt !== undefined && output.terminateAt !== null ? new Date(output.terminateAt) : undefined,
     updatedAt: output.updatedAt !== undefined && output.updatedAt !== null ? new Date(output.updatedAt) : undefined,
-    updatedBy: output.updatedBy !== undefined && output.updatedBy !== null ? output.updatedBy : undefined,
+    updatedBy: __expectString(output.updatedBy),
   } as any;
 };
 
@@ -7617,53 +7574,52 @@ const deserializeAws_restJson1StreamingSessionStream = (
 ): StreamingSessionStream => {
   return {
     createdAt: output.createdAt !== undefined && output.createdAt !== null ? new Date(output.createdAt) : undefined,
-    createdBy: output.createdBy !== undefined && output.createdBy !== null ? output.createdBy : undefined,
+    createdBy: __expectString(output.createdBy),
     expiresAt: output.expiresAt !== undefined && output.expiresAt !== null ? new Date(output.expiresAt) : undefined,
-    state: output.state !== undefined && output.state !== null ? output.state : undefined,
-    statusCode: output.statusCode !== undefined && output.statusCode !== null ? output.statusCode : undefined,
-    streamId: output.streamId !== undefined && output.streamId !== null ? output.streamId : undefined,
-    url: output.url !== undefined && output.url !== null ? output.url : undefined,
+    state: __expectString(output.state),
+    statusCode: __expectString(output.statusCode),
+    streamId: __expectString(output.streamId),
+    url: __expectString(output.url),
   } as any;
 };
 
 const deserializeAws_restJson1Studio = (output: any, context: __SerdeContext): Studio => {
   return {
-    adminRoleArn: output.adminRoleArn !== undefined && output.adminRoleArn !== null ? output.adminRoleArn : undefined,
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    adminRoleArn: __expectString(output.adminRoleArn),
+    arn: __expectString(output.arn),
     createdAt: output.createdAt !== undefined && output.createdAt !== null ? new Date(output.createdAt) : undefined,
-    displayName: output.displayName !== undefined && output.displayName !== null ? output.displayName : undefined,
-    homeRegion: output.homeRegion !== undefined && output.homeRegion !== null ? output.homeRegion : undefined,
-    ssoClientId: output.ssoClientId !== undefined && output.ssoClientId !== null ? output.ssoClientId : undefined,
-    state: output.state !== undefined && output.state !== null ? output.state : undefined,
-    statusCode: output.statusCode !== undefined && output.statusCode !== null ? output.statusCode : undefined,
-    statusMessage:
-      output.statusMessage !== undefined && output.statusMessage !== null ? output.statusMessage : undefined,
+    displayName: __expectString(output.displayName),
+    homeRegion: __expectString(output.homeRegion),
+    ssoClientId: __expectString(output.ssoClientId),
+    state: __expectString(output.state),
+    statusCode: __expectString(output.statusCode),
+    statusMessage: __expectString(output.statusMessage),
     studioEncryptionConfiguration:
       output.studioEncryptionConfiguration !== undefined && output.studioEncryptionConfiguration !== null
         ? deserializeAws_restJson1StudioEncryptionConfiguration(output.studioEncryptionConfiguration, context)
         : undefined,
-    studioId: output.studioId !== undefined && output.studioId !== null ? output.studioId : undefined,
-    studioName: output.studioName !== undefined && output.studioName !== null ? output.studioName : undefined,
-    studioUrl: output.studioUrl !== undefined && output.studioUrl !== null ? output.studioUrl : undefined,
+    studioId: __expectString(output.studioId),
+    studioName: __expectString(output.studioName),
+    studioUrl: __expectString(output.studioUrl),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1Tags(output.tags, context)
         : undefined,
     updatedAt: output.updatedAt !== undefined && output.updatedAt !== null ? new Date(output.updatedAt) : undefined,
-    userRoleArn: output.userRoleArn !== undefined && output.userRoleArn !== null ? output.userRoleArn : undefined,
+    userRoleArn: __expectString(output.userRoleArn),
   } as any;
 };
 
 const deserializeAws_restJson1StudioComponent = (output: any, context: __SerdeContext): StudioComponent => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     configuration:
       output.configuration !== undefined && output.configuration !== null
         ? deserializeAws_restJson1StudioComponentConfiguration(output.configuration, context)
         : undefined,
     createdAt: output.createdAt !== undefined && output.createdAt !== null ? new Date(output.createdAt) : undefined,
-    createdBy: output.createdBy !== undefined && output.createdBy !== null ? output.createdBy : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    createdBy: __expectString(output.createdBy),
+    description: __expectString(output.description),
     ec2SecurityGroupIds:
       output.ec2SecurityGroupIds !== undefined && output.ec2SecurityGroupIds !== null
         ? deserializeAws_restJson1StudioComponentSecurityGroupIdList(output.ec2SecurityGroupIds, context)
@@ -7672,27 +7628,23 @@ const deserializeAws_restJson1StudioComponent = (output: any, context: __SerdeCo
       output.initializationScripts !== undefined && output.initializationScripts !== null
         ? deserializeAws_restJson1StudioComponentInitializationScriptList(output.initializationScripts, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
     scriptParameters:
       output.scriptParameters !== undefined && output.scriptParameters !== null
         ? deserializeAws_restJson1StudioComponentScriptParameterKeyValueList(output.scriptParameters, context)
         : undefined,
-    state: output.state !== undefined && output.state !== null ? output.state : undefined,
-    statusCode: output.statusCode !== undefined && output.statusCode !== null ? output.statusCode : undefined,
-    statusMessage:
-      output.statusMessage !== undefined && output.statusMessage !== null ? output.statusMessage : undefined,
-    studioComponentId:
-      output.studioComponentId !== undefined && output.studioComponentId !== null
-        ? output.studioComponentId
-        : undefined,
-    subtype: output.subtype !== undefined && output.subtype !== null ? output.subtype : undefined,
+    state: __expectString(output.state),
+    statusCode: __expectString(output.statusCode),
+    statusMessage: __expectString(output.statusMessage),
+    studioComponentId: __expectString(output.studioComponentId),
+    subtype: __expectString(output.subtype),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1Tags(output.tags, context)
         : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    type: __expectString(output.type),
     updatedAt: output.updatedAt !== undefined && output.updatedAt !== null ? new Date(output.updatedAt) : undefined,
-    updatedBy: output.updatedBy !== undefined && output.updatedBy !== null ? output.updatedBy : undefined,
+    updatedBy: __expectString(output.updatedBy),
   } as any;
 };
 
@@ -7725,13 +7677,10 @@ const deserializeAws_restJson1StudioComponentInitializationScript = (
   context: __SerdeContext
 ): StudioComponentInitializationScript => {
   return {
-    launchProfileProtocolVersion:
-      output.launchProfileProtocolVersion !== undefined && output.launchProfileProtocolVersion !== null
-        ? output.launchProfileProtocolVersion
-        : undefined,
-    platform: output.platform !== undefined && output.platform !== null ? output.platform : undefined,
-    runContext: output.runContext !== undefined && output.runContext !== null ? output.runContext : undefined,
-    script: output.script !== undefined && output.script !== null ? output.script : undefined,
+    launchProfileProtocolVersion: __expectString(output.launchProfileProtocolVersion),
+    platform: __expectString(output.platform),
+    runContext: __expectString(output.runContext),
+    script: __expectString(output.script),
   } as any;
 };
 
@@ -7781,7 +7730,7 @@ const deserializeAws_restJson1StudioComponentSecurityGroupIdList = (output: any,
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7791,17 +7740,14 @@ const deserializeAws_restJson1StudioComponentSummary = (
 ): StudioComponentSummary => {
   return {
     createdAt: output.createdAt !== undefined && output.createdAt !== null ? new Date(output.createdAt) : undefined,
-    createdBy: output.createdBy !== undefined && output.createdBy !== null ? output.createdBy : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    studioComponentId:
-      output.studioComponentId !== undefined && output.studioComponentId !== null
-        ? output.studioComponentId
-        : undefined,
-    subtype: output.subtype !== undefined && output.subtype !== null ? output.subtype : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    createdBy: __expectString(output.createdBy),
+    description: __expectString(output.description),
+    name: __expectString(output.name),
+    studioComponentId: __expectString(output.studioComponentId),
+    subtype: __expectString(output.subtype),
+    type: __expectString(output.type),
     updatedAt: output.updatedAt !== undefined && output.updatedAt !== null ? new Date(output.updatedAt) : undefined,
-    updatedBy: output.updatedBy !== undefined && output.updatedBy !== null ? output.updatedBy : undefined,
+    updatedBy: __expectString(output.updatedBy),
   } as any;
 };
 
@@ -7824,8 +7770,8 @@ const deserializeAws_restJson1StudioEncryptionConfiguration = (
   context: __SerdeContext
 ): StudioEncryptionConfiguration => {
   return {
-    keyArn: output.keyArn !== undefined && output.keyArn !== null ? output.keyArn : undefined,
-    keyType: output.keyType !== undefined && output.keyType !== null ? output.keyType : undefined,
+    keyArn: __expectString(output.keyArn),
+    keyType: __expectString(output.keyType),
   } as any;
 };
 
@@ -7842,10 +7788,9 @@ const deserializeAws_restJson1StudioList = (output: any, context: __SerdeContext
 
 const deserializeAws_restJson1StudioMembership = (output: any, context: __SerdeContext): StudioMembership => {
   return {
-    identityStoreId:
-      output.identityStoreId !== undefined && output.identityStoreId !== null ? output.identityStoreId : undefined,
-    persona: output.persona !== undefined && output.persona !== null ? output.persona : undefined,
-    principalId: output.principalId !== undefined && output.principalId !== null ? output.principalId : undefined,
+    identityStoreId: __expectString(output.identityStoreId),
+    persona: __expectString(output.persona),
+    principalId: __expectString(output.principalId),
   } as any;
 };
 
@@ -7867,7 +7812,7 @@ const deserializeAws_restJson1Tags = (output: any, context: __SerdeContext): { [
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };

--- a/clients/client-opsworks/protocols/Aws_json1_1.ts
+++ b/clients/client-opsworks/protocols/Aws_json1_1.ts
@@ -309,7 +309,12 @@ import {
   WeeklyAutoScalingSchedule,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -7041,7 +7046,7 @@ const deserializeAws_json1_1AgentVersion = (output: any, context: __SerdeContext
       output.ConfigurationManager !== undefined && output.ConfigurationManager !== null
         ? deserializeAws_json1_1StackConfigurationManager(output.ConfigurationManager, context)
         : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    Version: __expectString(output.Version),
   } as any;
 };
 
@@ -7058,7 +7063,7 @@ const deserializeAws_json1_1AgentVersions = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1App = (output: any, context: __SerdeContext): App => {
   return {
-    AppId: output.AppId !== undefined && output.AppId !== null ? output.AppId : undefined,
+    AppId: __expectString(output.AppId),
     AppSource:
       output.AppSource !== undefined && output.AppSource !== null
         ? deserializeAws_json1_1Source(output.AppSource, context)
@@ -7067,29 +7072,29 @@ const deserializeAws_json1_1App = (output: any, context: __SerdeContext): App =>
       output.Attributes !== undefined && output.Attributes !== null
         ? deserializeAws_json1_1AppAttributes(output.Attributes, context)
         : undefined,
-    CreatedAt: output.CreatedAt !== undefined && output.CreatedAt !== null ? output.CreatedAt : undefined,
+    CreatedAt: __expectString(output.CreatedAt),
     DataSources:
       output.DataSources !== undefined && output.DataSources !== null
         ? deserializeAws_json1_1DataSources(output.DataSources, context)
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     Domains:
       output.Domains !== undefined && output.Domains !== null
         ? deserializeAws_json1_1Strings(output.Domains, context)
         : undefined,
-    EnableSsl: output.EnableSsl !== undefined && output.EnableSsl !== null ? output.EnableSsl : undefined,
+    EnableSsl: __expectBoolean(output.EnableSsl),
     Environment:
       output.Environment !== undefined && output.Environment !== null
         ? deserializeAws_json1_1EnvironmentVariables(output.Environment, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Shortname: output.Shortname !== undefined && output.Shortname !== null ? output.Shortname : undefined,
+    Name: __expectString(output.Name),
+    Shortname: __expectString(output.Shortname),
     SslConfiguration:
       output.SslConfiguration !== undefined && output.SslConfiguration !== null
         ? deserializeAws_json1_1SslConfiguration(output.SslConfiguration, context)
         : undefined,
-    StackId: output.StackId !== undefined && output.StackId !== null ? output.StackId : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    StackId: __expectString(output.StackId),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -7101,7 +7106,7 @@ const deserializeAws_json1_1AppAttributes = (output: any, context: __SerdeContex
       }
       return {
         ...acc,
-        [key]: value,
+        [key]: __expectString(value) as any,
       };
     },
     {}
@@ -7125,33 +7130,24 @@ const deserializeAws_json1_1AutoScalingThresholds = (output: any, context: __Ser
       output.Alarms !== undefined && output.Alarms !== null
         ? deserializeAws_json1_1Strings(output.Alarms, context)
         : undefined,
-    CpuThreshold: output.CpuThreshold !== undefined && output.CpuThreshold !== null ? output.CpuThreshold : undefined,
-    IgnoreMetricsTime:
-      output.IgnoreMetricsTime !== undefined && output.IgnoreMetricsTime !== null
-        ? output.IgnoreMetricsTime
-        : undefined,
-    InstanceCount:
-      output.InstanceCount !== undefined && output.InstanceCount !== null ? output.InstanceCount : undefined,
-    LoadThreshold:
-      output.LoadThreshold !== undefined && output.LoadThreshold !== null ? output.LoadThreshold : undefined,
-    MemoryThreshold:
-      output.MemoryThreshold !== undefined && output.MemoryThreshold !== null ? output.MemoryThreshold : undefined,
-    ThresholdsWaitTime:
-      output.ThresholdsWaitTime !== undefined && output.ThresholdsWaitTime !== null
-        ? output.ThresholdsWaitTime
-        : undefined,
+    CpuThreshold: __expectNumber(output.CpuThreshold),
+    IgnoreMetricsTime: __expectNumber(output.IgnoreMetricsTime),
+    InstanceCount: __expectNumber(output.InstanceCount),
+    LoadThreshold: __expectNumber(output.LoadThreshold),
+    MemoryThreshold: __expectNumber(output.MemoryThreshold),
+    ThresholdsWaitTime: __expectNumber(output.ThresholdsWaitTime),
   } as any;
 };
 
 const deserializeAws_json1_1BlockDeviceMapping = (output: any, context: __SerdeContext): BlockDeviceMapping => {
   return {
-    DeviceName: output.DeviceName !== undefined && output.DeviceName !== null ? output.DeviceName : undefined,
+    DeviceName: __expectString(output.DeviceName),
     Ebs:
       output.Ebs !== undefined && output.Ebs !== null
         ? deserializeAws_json1_1EbsBlockDevice(output.Ebs, context)
         : undefined,
-    NoDevice: output.NoDevice !== undefined && output.NoDevice !== null ? output.NoDevice : undefined,
-    VirtualName: output.VirtualName !== undefined && output.VirtualName !== null ? output.VirtualName : undefined,
+    NoDevice: __expectString(output.NoDevice),
+    VirtualName: __expectString(output.VirtualName),
   } as any;
 };
 
@@ -7168,16 +7164,14 @@ const deserializeAws_json1_1BlockDeviceMappings = (output: any, context: __Serde
 
 const deserializeAws_json1_1ChefConfiguration = (output: any, context: __SerdeContext): ChefConfiguration => {
   return {
-    BerkshelfVersion:
-      output.BerkshelfVersion !== undefined && output.BerkshelfVersion !== null ? output.BerkshelfVersion : undefined,
-    ManageBerkshelf:
-      output.ManageBerkshelf !== undefined && output.ManageBerkshelf !== null ? output.ManageBerkshelf : undefined,
+    BerkshelfVersion: __expectString(output.BerkshelfVersion),
+    ManageBerkshelf: __expectBoolean(output.ManageBerkshelf),
   } as any;
 };
 
 const deserializeAws_json1_1CloneStackResult = (output: any, context: __SerdeContext): CloneStackResult => {
   return {
-    StackId: output.StackId !== undefined && output.StackId !== null ? output.StackId : undefined,
+    StackId: __expectString(output.StackId),
   } as any;
 };
 
@@ -7186,7 +7180,7 @@ const deserializeAws_json1_1CloudWatchLogsConfiguration = (
   context: __SerdeContext
 ): CloudWatchLogsConfiguration => {
   return {
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
+    Enabled: __expectBoolean(output.Enabled),
     LogStreams:
       output.LogStreams !== undefined && output.LogStreams !== null
         ? deserializeAws_json1_1CloudWatchLogsLogStreams(output.LogStreams, context)
@@ -7199,26 +7193,17 @@ const deserializeAws_json1_1CloudWatchLogsLogStream = (
   context: __SerdeContext
 ): CloudWatchLogsLogStream => {
   return {
-    BatchCount: output.BatchCount !== undefined && output.BatchCount !== null ? output.BatchCount : undefined,
-    BatchSize: output.BatchSize !== undefined && output.BatchSize !== null ? output.BatchSize : undefined,
-    BufferDuration:
-      output.BufferDuration !== undefined && output.BufferDuration !== null ? output.BufferDuration : undefined,
-    DatetimeFormat:
-      output.DatetimeFormat !== undefined && output.DatetimeFormat !== null ? output.DatetimeFormat : undefined,
-    Encoding: output.Encoding !== undefined && output.Encoding !== null ? output.Encoding : undefined,
-    File: output.File !== undefined && output.File !== null ? output.File : undefined,
-    FileFingerprintLines:
-      output.FileFingerprintLines !== undefined && output.FileFingerprintLines !== null
-        ? output.FileFingerprintLines
-        : undefined,
-    InitialPosition:
-      output.InitialPosition !== undefined && output.InitialPosition !== null ? output.InitialPosition : undefined,
-    LogGroupName: output.LogGroupName !== undefined && output.LogGroupName !== null ? output.LogGroupName : undefined,
-    MultiLineStartPattern:
-      output.MultiLineStartPattern !== undefined && output.MultiLineStartPattern !== null
-        ? output.MultiLineStartPattern
-        : undefined,
-    TimeZone: output.TimeZone !== undefined && output.TimeZone !== null ? output.TimeZone : undefined,
+    BatchCount: __expectNumber(output.BatchCount),
+    BatchSize: __expectNumber(output.BatchSize),
+    BufferDuration: __expectNumber(output.BufferDuration),
+    DatetimeFormat: __expectString(output.DatetimeFormat),
+    Encoding: __expectString(output.Encoding),
+    File: __expectString(output.File),
+    FileFingerprintLines: __expectString(output.FileFingerprintLines),
+    InitialPosition: __expectString(output.InitialPosition),
+    LogGroupName: __expectString(output.LogGroupName),
+    MultiLineStartPattern: __expectString(output.MultiLineStartPattern),
+    TimeZone: __expectString(output.TimeZone),
   } as any;
 };
 
@@ -7238,17 +7223,16 @@ const deserializeAws_json1_1CloudWatchLogsLogStreams = (
 
 const deserializeAws_json1_1Command = (output: any, context: __SerdeContext): Command => {
   return {
-    AcknowledgedAt:
-      output.AcknowledgedAt !== undefined && output.AcknowledgedAt !== null ? output.AcknowledgedAt : undefined,
-    CommandId: output.CommandId !== undefined && output.CommandId !== null ? output.CommandId : undefined,
-    CompletedAt: output.CompletedAt !== undefined && output.CompletedAt !== null ? output.CompletedAt : undefined,
-    CreatedAt: output.CreatedAt !== undefined && output.CreatedAt !== null ? output.CreatedAt : undefined,
-    DeploymentId: output.DeploymentId !== undefined && output.DeploymentId !== null ? output.DeploymentId : undefined,
-    ExitCode: output.ExitCode !== undefined && output.ExitCode !== null ? output.ExitCode : undefined,
-    InstanceId: output.InstanceId !== undefined && output.InstanceId !== null ? output.InstanceId : undefined,
-    LogUrl: output.LogUrl !== undefined && output.LogUrl !== null ? output.LogUrl : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    AcknowledgedAt: __expectString(output.AcknowledgedAt),
+    CommandId: __expectString(output.CommandId),
+    CompletedAt: __expectString(output.CompletedAt),
+    CreatedAt: __expectString(output.CreatedAt),
+    DeploymentId: __expectString(output.DeploymentId),
+    ExitCode: __expectNumber(output.ExitCode),
+    InstanceId: __expectString(output.InstanceId),
+    LogUrl: __expectString(output.LogUrl),
+    Status: __expectString(output.Status),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -7265,31 +7249,31 @@ const deserializeAws_json1_1Commands = (output: any, context: __SerdeContext): C
 
 const deserializeAws_json1_1CreateAppResult = (output: any, context: __SerdeContext): CreateAppResult => {
   return {
-    AppId: output.AppId !== undefined && output.AppId !== null ? output.AppId : undefined,
+    AppId: __expectString(output.AppId),
   } as any;
 };
 
 const deserializeAws_json1_1CreateDeploymentResult = (output: any, context: __SerdeContext): CreateDeploymentResult => {
   return {
-    DeploymentId: output.DeploymentId !== undefined && output.DeploymentId !== null ? output.DeploymentId : undefined,
+    DeploymentId: __expectString(output.DeploymentId),
   } as any;
 };
 
 const deserializeAws_json1_1CreateInstanceResult = (output: any, context: __SerdeContext): CreateInstanceResult => {
   return {
-    InstanceId: output.InstanceId !== undefined && output.InstanceId !== null ? output.InstanceId : undefined,
+    InstanceId: __expectString(output.InstanceId),
   } as any;
 };
 
 const deserializeAws_json1_1CreateLayerResult = (output: any, context: __SerdeContext): CreateLayerResult => {
   return {
-    LayerId: output.LayerId !== undefined && output.LayerId !== null ? output.LayerId : undefined,
+    LayerId: __expectString(output.LayerId),
   } as any;
 };
 
 const deserializeAws_json1_1CreateStackResult = (output: any, context: __SerdeContext): CreateStackResult => {
   return {
-    StackId: output.StackId !== undefined && output.StackId !== null ? output.StackId : undefined,
+    StackId: __expectString(output.StackId),
   } as any;
 };
 
@@ -7298,7 +7282,7 @@ const deserializeAws_json1_1CreateUserProfileResult = (
   context: __SerdeContext
 ): CreateUserProfileResult => {
   return {
-    IamUserArn: output.IamUserArn !== undefined && output.IamUserArn !== null ? output.IamUserArn : undefined,
+    IamUserArn: __expectString(output.IamUserArn),
   } as any;
 };
 
@@ -7312,16 +7296,16 @@ const deserializeAws_json1_1DailyAutoScalingSchedule = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_json1_1DataSource = (output: any, context: __SerdeContext): DataSource => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    DatabaseName: output.DatabaseName !== undefined && output.DatabaseName !== null ? output.DatabaseName : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Arn: __expectString(output.Arn),
+    DatabaseName: __expectString(output.DatabaseName),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -7338,24 +7322,24 @@ const deserializeAws_json1_1DataSources = (output: any, context: __SerdeContext)
 
 const deserializeAws_json1_1Deployment = (output: any, context: __SerdeContext): Deployment => {
   return {
-    AppId: output.AppId !== undefined && output.AppId !== null ? output.AppId : undefined,
+    AppId: __expectString(output.AppId),
     Command:
       output.Command !== undefined && output.Command !== null
         ? deserializeAws_json1_1DeploymentCommand(output.Command, context)
         : undefined,
-    Comment: output.Comment !== undefined && output.Comment !== null ? output.Comment : undefined,
-    CompletedAt: output.CompletedAt !== undefined && output.CompletedAt !== null ? output.CompletedAt : undefined,
-    CreatedAt: output.CreatedAt !== undefined && output.CreatedAt !== null ? output.CreatedAt : undefined,
-    CustomJson: output.CustomJson !== undefined && output.CustomJson !== null ? output.CustomJson : undefined,
-    DeploymentId: output.DeploymentId !== undefined && output.DeploymentId !== null ? output.DeploymentId : undefined,
-    Duration: output.Duration !== undefined && output.Duration !== null ? output.Duration : undefined,
-    IamUserArn: output.IamUserArn !== undefined && output.IamUserArn !== null ? output.IamUserArn : undefined,
+    Comment: __expectString(output.Comment),
+    CompletedAt: __expectString(output.CompletedAt),
+    CreatedAt: __expectString(output.CreatedAt),
+    CustomJson: __expectString(output.CustomJson),
+    DeploymentId: __expectString(output.DeploymentId),
+    Duration: __expectNumber(output.Duration),
+    IamUserArn: __expectString(output.IamUserArn),
     InstanceIds:
       output.InstanceIds !== undefined && output.InstanceIds !== null
         ? deserializeAws_json1_1Strings(output.InstanceIds, context)
         : undefined,
-    StackId: output.StackId !== undefined && output.StackId !== null ? output.StackId : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    StackId: __expectString(output.StackId),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -7365,7 +7349,7 @@ const deserializeAws_json1_1DeploymentCommand = (output: any, context: __SerdeCo
       output.Args !== undefined && output.Args !== null
         ? deserializeAws_json1_1DeploymentCommandArgs(output.Args, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -7444,7 +7428,7 @@ const deserializeAws_json1_1DescribeEcsClustersResult = (
       output.EcsClusters !== undefined && output.EcsClusters !== null
         ? deserializeAws_json1_1EcsClusters(output.EcsClusters, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -7582,10 +7566,7 @@ const deserializeAws_json1_1DescribeStackProvisioningParametersResult = (
   context: __SerdeContext
 ): DescribeStackProvisioningParametersResult => {
   return {
-    AgentInstallerUrl:
-      output.AgentInstallerUrl !== undefined && output.AgentInstallerUrl !== null
-        ? output.AgentInstallerUrl
-        : undefined,
+    AgentInstallerUrl: __expectString(output.AgentInstallerUrl),
     Parameters:
       output.Parameters !== undefined && output.Parameters !== null
         ? deserializeAws_json1_1Parameters(output.Parameters, context)
@@ -7649,25 +7630,20 @@ const deserializeAws_json1_1DescribeVolumesResult = (output: any, context: __Ser
 
 const deserializeAws_json1_1EbsBlockDevice = (output: any, context: __SerdeContext): EbsBlockDevice => {
   return {
-    DeleteOnTermination:
-      output.DeleteOnTermination !== undefined && output.DeleteOnTermination !== null
-        ? output.DeleteOnTermination
-        : undefined,
-    Iops: output.Iops !== undefined && output.Iops !== null ? output.Iops : undefined,
-    SnapshotId: output.SnapshotId !== undefined && output.SnapshotId !== null ? output.SnapshotId : undefined,
-    VolumeSize: output.VolumeSize !== undefined && output.VolumeSize !== null ? output.VolumeSize : undefined,
-    VolumeType: output.VolumeType !== undefined && output.VolumeType !== null ? output.VolumeType : undefined,
+    DeleteOnTermination: __expectBoolean(output.DeleteOnTermination),
+    Iops: __expectNumber(output.Iops),
+    SnapshotId: __expectString(output.SnapshotId),
+    VolumeSize: __expectNumber(output.VolumeSize),
+    VolumeType: __expectString(output.VolumeType),
   } as any;
 };
 
 const deserializeAws_json1_1EcsCluster = (output: any, context: __SerdeContext): EcsCluster => {
   return {
-    EcsClusterArn:
-      output.EcsClusterArn !== undefined && output.EcsClusterArn !== null ? output.EcsClusterArn : undefined,
-    EcsClusterName:
-      output.EcsClusterName !== undefined && output.EcsClusterName !== null ? output.EcsClusterName : undefined,
-    RegisteredAt: output.RegisteredAt !== undefined && output.RegisteredAt !== null ? output.RegisteredAt : undefined,
-    StackId: output.StackId !== undefined && output.StackId !== null ? output.StackId : undefined,
+    EcsClusterArn: __expectString(output.EcsClusterArn),
+    EcsClusterName: __expectString(output.EcsClusterName),
+    RegisteredAt: __expectString(output.RegisteredAt),
+    StackId: __expectString(output.StackId),
   } as any;
 };
 
@@ -7684,11 +7660,11 @@ const deserializeAws_json1_1EcsClusters = (output: any, context: __SerdeContext)
 
 const deserializeAws_json1_1ElasticIp = (output: any, context: __SerdeContext): ElasticIp => {
   return {
-    Domain: output.Domain !== undefined && output.Domain !== null ? output.Domain : undefined,
-    InstanceId: output.InstanceId !== undefined && output.InstanceId !== null ? output.InstanceId : undefined,
-    Ip: output.Ip !== undefined && output.Ip !== null ? output.Ip : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Region: output.Region !== undefined && output.Region !== null ? output.Region : undefined,
+    Domain: __expectString(output.Domain),
+    InstanceId: __expectString(output.InstanceId),
+    Ip: __expectString(output.Ip),
+    Name: __expectString(output.Name),
+    Region: __expectString(output.Region),
   } as any;
 };
 
@@ -7709,23 +7685,20 @@ const deserializeAws_json1_1ElasticLoadBalancer = (output: any, context: __Serde
       output.AvailabilityZones !== undefined && output.AvailabilityZones !== null
         ? deserializeAws_json1_1Strings(output.AvailabilityZones, context)
         : undefined,
-    DnsName: output.DnsName !== undefined && output.DnsName !== null ? output.DnsName : undefined,
+    DnsName: __expectString(output.DnsName),
     Ec2InstanceIds:
       output.Ec2InstanceIds !== undefined && output.Ec2InstanceIds !== null
         ? deserializeAws_json1_1Strings(output.Ec2InstanceIds, context)
         : undefined,
-    ElasticLoadBalancerName:
-      output.ElasticLoadBalancerName !== undefined && output.ElasticLoadBalancerName !== null
-        ? output.ElasticLoadBalancerName
-        : undefined,
-    LayerId: output.LayerId !== undefined && output.LayerId !== null ? output.LayerId : undefined,
-    Region: output.Region !== undefined && output.Region !== null ? output.Region : undefined,
-    StackId: output.StackId !== undefined && output.StackId !== null ? output.StackId : undefined,
+    ElasticLoadBalancerName: __expectString(output.ElasticLoadBalancerName),
+    LayerId: __expectString(output.LayerId),
+    Region: __expectString(output.Region),
+    StackId: __expectString(output.StackId),
     SubnetIds:
       output.SubnetIds !== undefined && output.SubnetIds !== null
         ? deserializeAws_json1_1Strings(output.SubnetIds, context)
         : undefined,
-    VpcId: output.VpcId !== undefined && output.VpcId !== null ? output.VpcId : undefined,
+    VpcId: __expectString(output.VpcId),
   } as any;
 };
 
@@ -7742,9 +7715,9 @@ const deserializeAws_json1_1ElasticLoadBalancers = (output: any, context: __Serd
 
 const deserializeAws_json1_1EnvironmentVariable = (output: any, context: __SerdeContext): EnvironmentVariable => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Secure: output.Secure !== undefined && output.Secure !== null ? output.Secure : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Secure: __expectBoolean(output.Secure),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -7764,8 +7737,8 @@ const deserializeAws_json1_1GetHostnameSuggestionResult = (
   context: __SerdeContext
 ): GetHostnameSuggestionResult => {
   return {
-    Hostname: output.Hostname !== undefined && output.Hostname !== null ? output.Hostname : undefined,
-    LayerId: output.LayerId !== undefined && output.LayerId !== null ? output.LayerId : undefined,
+    Hostname: __expectString(output.Hostname),
+    LayerId: __expectString(output.LayerId),
   } as any;
 };
 
@@ -7780,94 +7753,59 @@ const deserializeAws_json1_1GrantAccessResult = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1Instance = (output: any, context: __SerdeContext): Instance => {
   return {
-    AgentVersion: output.AgentVersion !== undefined && output.AgentVersion !== null ? output.AgentVersion : undefined,
-    AmiId: output.AmiId !== undefined && output.AmiId !== null ? output.AmiId : undefined,
-    Architecture: output.Architecture !== undefined && output.Architecture !== null ? output.Architecture : undefined,
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    AutoScalingType:
-      output.AutoScalingType !== undefined && output.AutoScalingType !== null ? output.AutoScalingType : undefined,
-    AvailabilityZone:
-      output.AvailabilityZone !== undefined && output.AvailabilityZone !== null ? output.AvailabilityZone : undefined,
+    AgentVersion: __expectString(output.AgentVersion),
+    AmiId: __expectString(output.AmiId),
+    Architecture: __expectString(output.Architecture),
+    Arn: __expectString(output.Arn),
+    AutoScalingType: __expectString(output.AutoScalingType),
+    AvailabilityZone: __expectString(output.AvailabilityZone),
     BlockDeviceMappings:
       output.BlockDeviceMappings !== undefined && output.BlockDeviceMappings !== null
         ? deserializeAws_json1_1BlockDeviceMappings(output.BlockDeviceMappings, context)
         : undefined,
-    CreatedAt: output.CreatedAt !== undefined && output.CreatedAt !== null ? output.CreatedAt : undefined,
-    EbsOptimized: output.EbsOptimized !== undefined && output.EbsOptimized !== null ? output.EbsOptimized : undefined,
-    Ec2InstanceId:
-      output.Ec2InstanceId !== undefined && output.Ec2InstanceId !== null ? output.Ec2InstanceId : undefined,
-    EcsClusterArn:
-      output.EcsClusterArn !== undefined && output.EcsClusterArn !== null ? output.EcsClusterArn : undefined,
-    EcsContainerInstanceArn:
-      output.EcsContainerInstanceArn !== undefined && output.EcsContainerInstanceArn !== null
-        ? output.EcsContainerInstanceArn
-        : undefined,
-    ElasticIp: output.ElasticIp !== undefined && output.ElasticIp !== null ? output.ElasticIp : undefined,
-    Hostname: output.Hostname !== undefined && output.Hostname !== null ? output.Hostname : undefined,
-    InfrastructureClass:
-      output.InfrastructureClass !== undefined && output.InfrastructureClass !== null
-        ? output.InfrastructureClass
-        : undefined,
-    InstallUpdatesOnBoot:
-      output.InstallUpdatesOnBoot !== undefined && output.InstallUpdatesOnBoot !== null
-        ? output.InstallUpdatesOnBoot
-        : undefined,
-    InstanceId: output.InstanceId !== undefined && output.InstanceId !== null ? output.InstanceId : undefined,
-    InstanceProfileArn:
-      output.InstanceProfileArn !== undefined && output.InstanceProfileArn !== null
-        ? output.InstanceProfileArn
-        : undefined,
-    InstanceType: output.InstanceType !== undefined && output.InstanceType !== null ? output.InstanceType : undefined,
-    LastServiceErrorId:
-      output.LastServiceErrorId !== undefined && output.LastServiceErrorId !== null
-        ? output.LastServiceErrorId
-        : undefined,
+    CreatedAt: __expectString(output.CreatedAt),
+    EbsOptimized: __expectBoolean(output.EbsOptimized),
+    Ec2InstanceId: __expectString(output.Ec2InstanceId),
+    EcsClusterArn: __expectString(output.EcsClusterArn),
+    EcsContainerInstanceArn: __expectString(output.EcsContainerInstanceArn),
+    ElasticIp: __expectString(output.ElasticIp),
+    Hostname: __expectString(output.Hostname),
+    InfrastructureClass: __expectString(output.InfrastructureClass),
+    InstallUpdatesOnBoot: __expectBoolean(output.InstallUpdatesOnBoot),
+    InstanceId: __expectString(output.InstanceId),
+    InstanceProfileArn: __expectString(output.InstanceProfileArn),
+    InstanceType: __expectString(output.InstanceType),
+    LastServiceErrorId: __expectString(output.LastServiceErrorId),
     LayerIds:
       output.LayerIds !== undefined && output.LayerIds !== null
         ? deserializeAws_json1_1Strings(output.LayerIds, context)
         : undefined,
-    Os: output.Os !== undefined && output.Os !== null ? output.Os : undefined,
-    Platform: output.Platform !== undefined && output.Platform !== null ? output.Platform : undefined,
-    PrivateDns: output.PrivateDns !== undefined && output.PrivateDns !== null ? output.PrivateDns : undefined,
-    PrivateIp: output.PrivateIp !== undefined && output.PrivateIp !== null ? output.PrivateIp : undefined,
-    PublicDns: output.PublicDns !== undefined && output.PublicDns !== null ? output.PublicDns : undefined,
-    PublicIp: output.PublicIp !== undefined && output.PublicIp !== null ? output.PublicIp : undefined,
-    RegisteredBy: output.RegisteredBy !== undefined && output.RegisteredBy !== null ? output.RegisteredBy : undefined,
-    ReportedAgentVersion:
-      output.ReportedAgentVersion !== undefined && output.ReportedAgentVersion !== null
-        ? output.ReportedAgentVersion
-        : undefined,
+    Os: __expectString(output.Os),
+    Platform: __expectString(output.Platform),
+    PrivateDns: __expectString(output.PrivateDns),
+    PrivateIp: __expectString(output.PrivateIp),
+    PublicDns: __expectString(output.PublicDns),
+    PublicIp: __expectString(output.PublicIp),
+    RegisteredBy: __expectString(output.RegisteredBy),
+    ReportedAgentVersion: __expectString(output.ReportedAgentVersion),
     ReportedOs:
       output.ReportedOs !== undefined && output.ReportedOs !== null
         ? deserializeAws_json1_1ReportedOs(output.ReportedOs, context)
         : undefined,
-    RootDeviceType:
-      output.RootDeviceType !== undefined && output.RootDeviceType !== null ? output.RootDeviceType : undefined,
-    RootDeviceVolumeId:
-      output.RootDeviceVolumeId !== undefined && output.RootDeviceVolumeId !== null
-        ? output.RootDeviceVolumeId
-        : undefined,
+    RootDeviceType: __expectString(output.RootDeviceType),
+    RootDeviceVolumeId: __expectString(output.RootDeviceVolumeId),
     SecurityGroupIds:
       output.SecurityGroupIds !== undefined && output.SecurityGroupIds !== null
         ? deserializeAws_json1_1Strings(output.SecurityGroupIds, context)
         : undefined,
-    SshHostDsaKeyFingerprint:
-      output.SshHostDsaKeyFingerprint !== undefined && output.SshHostDsaKeyFingerprint !== null
-        ? output.SshHostDsaKeyFingerprint
-        : undefined,
-    SshHostRsaKeyFingerprint:
-      output.SshHostRsaKeyFingerprint !== undefined && output.SshHostRsaKeyFingerprint !== null
-        ? output.SshHostRsaKeyFingerprint
-        : undefined,
-    SshKeyName: output.SshKeyName !== undefined && output.SshKeyName !== null ? output.SshKeyName : undefined,
-    StackId: output.StackId !== undefined && output.StackId !== null ? output.StackId : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    SubnetId: output.SubnetId !== undefined && output.SubnetId !== null ? output.SubnetId : undefined,
-    Tenancy: output.Tenancy !== undefined && output.Tenancy !== null ? output.Tenancy : undefined,
-    VirtualizationType:
-      output.VirtualizationType !== undefined && output.VirtualizationType !== null
-        ? output.VirtualizationType
-        : undefined,
+    SshHostDsaKeyFingerprint: __expectString(output.SshHostDsaKeyFingerprint),
+    SshHostRsaKeyFingerprint: __expectString(output.SshHostRsaKeyFingerprint),
+    SshKeyName: __expectString(output.SshKeyName),
+    StackId: __expectString(output.StackId),
+    Status: __expectString(output.Status),
+    SubnetId: __expectString(output.SubnetId),
+    Tenancy: __expectString(output.Tenancy),
+    VirtualizationType: __expectString(output.VirtualizationType),
   } as any;
 };
 
@@ -7884,56 +7822,45 @@ const deserializeAws_json1_1Instances = (output: any, context: __SerdeContext): 
 
 const deserializeAws_json1_1InstancesCount = (output: any, context: __SerdeContext): InstancesCount => {
   return {
-    Assigning: output.Assigning !== undefined && output.Assigning !== null ? output.Assigning : undefined,
-    Booting: output.Booting !== undefined && output.Booting !== null ? output.Booting : undefined,
-    ConnectionLost:
-      output.ConnectionLost !== undefined && output.ConnectionLost !== null ? output.ConnectionLost : undefined,
-    Deregistering:
-      output.Deregistering !== undefined && output.Deregistering !== null ? output.Deregistering : undefined,
-    Online: output.Online !== undefined && output.Online !== null ? output.Online : undefined,
-    Pending: output.Pending !== undefined && output.Pending !== null ? output.Pending : undefined,
-    Rebooting: output.Rebooting !== undefined && output.Rebooting !== null ? output.Rebooting : undefined,
-    Registered: output.Registered !== undefined && output.Registered !== null ? output.Registered : undefined,
-    Registering: output.Registering !== undefined && output.Registering !== null ? output.Registering : undefined,
-    Requested: output.Requested !== undefined && output.Requested !== null ? output.Requested : undefined,
-    RunningSetup: output.RunningSetup !== undefined && output.RunningSetup !== null ? output.RunningSetup : undefined,
-    SetupFailed: output.SetupFailed !== undefined && output.SetupFailed !== null ? output.SetupFailed : undefined,
-    ShuttingDown: output.ShuttingDown !== undefined && output.ShuttingDown !== null ? output.ShuttingDown : undefined,
-    StartFailed: output.StartFailed !== undefined && output.StartFailed !== null ? output.StartFailed : undefined,
-    StopFailed: output.StopFailed !== undefined && output.StopFailed !== null ? output.StopFailed : undefined,
-    Stopped: output.Stopped !== undefined && output.Stopped !== null ? output.Stopped : undefined,
-    Stopping: output.Stopping !== undefined && output.Stopping !== null ? output.Stopping : undefined,
-    Terminated: output.Terminated !== undefined && output.Terminated !== null ? output.Terminated : undefined,
-    Terminating: output.Terminating !== undefined && output.Terminating !== null ? output.Terminating : undefined,
-    Unassigning: output.Unassigning !== undefined && output.Unassigning !== null ? output.Unassigning : undefined,
+    Assigning: __expectNumber(output.Assigning),
+    Booting: __expectNumber(output.Booting),
+    ConnectionLost: __expectNumber(output.ConnectionLost),
+    Deregistering: __expectNumber(output.Deregistering),
+    Online: __expectNumber(output.Online),
+    Pending: __expectNumber(output.Pending),
+    Rebooting: __expectNumber(output.Rebooting),
+    Registered: __expectNumber(output.Registered),
+    Registering: __expectNumber(output.Registering),
+    Requested: __expectNumber(output.Requested),
+    RunningSetup: __expectNumber(output.RunningSetup),
+    SetupFailed: __expectNumber(output.SetupFailed),
+    ShuttingDown: __expectNumber(output.ShuttingDown),
+    StartFailed: __expectNumber(output.StartFailed),
+    StopFailed: __expectNumber(output.StopFailed),
+    Stopped: __expectNumber(output.Stopped),
+    Stopping: __expectNumber(output.Stopping),
+    Terminated: __expectNumber(output.Terminated),
+    Terminating: __expectNumber(output.Terminating),
+    Unassigning: __expectNumber(output.Unassigning),
   } as any;
 };
 
 const deserializeAws_json1_1Layer = (output: any, context: __SerdeContext): Layer => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     Attributes:
       output.Attributes !== undefined && output.Attributes !== null
         ? deserializeAws_json1_1LayerAttributes(output.Attributes, context)
         : undefined,
-    AutoAssignElasticIps:
-      output.AutoAssignElasticIps !== undefined && output.AutoAssignElasticIps !== null
-        ? output.AutoAssignElasticIps
-        : undefined,
-    AutoAssignPublicIps:
-      output.AutoAssignPublicIps !== undefined && output.AutoAssignPublicIps !== null
-        ? output.AutoAssignPublicIps
-        : undefined,
+    AutoAssignElasticIps: __expectBoolean(output.AutoAssignElasticIps),
+    AutoAssignPublicIps: __expectBoolean(output.AutoAssignPublicIps),
     CloudWatchLogsConfiguration:
       output.CloudWatchLogsConfiguration !== undefined && output.CloudWatchLogsConfiguration !== null
         ? deserializeAws_json1_1CloudWatchLogsConfiguration(output.CloudWatchLogsConfiguration, context)
         : undefined,
-    CreatedAt: output.CreatedAt !== undefined && output.CreatedAt !== null ? output.CreatedAt : undefined,
-    CustomInstanceProfileArn:
-      output.CustomInstanceProfileArn !== undefined && output.CustomInstanceProfileArn !== null
-        ? output.CustomInstanceProfileArn
-        : undefined,
-    CustomJson: output.CustomJson !== undefined && output.CustomJson !== null ? output.CustomJson : undefined,
+    CreatedAt: __expectString(output.CreatedAt),
+    CustomInstanceProfileArn: __expectString(output.CustomInstanceProfileArn),
+    CustomJson: __expectString(output.CustomJson),
     CustomRecipes:
       output.CustomRecipes !== undefined && output.CustomRecipes !== null
         ? deserializeAws_json1_1Recipes(output.CustomRecipes, context)
@@ -7950,31 +7877,22 @@ const deserializeAws_json1_1Layer = (output: any, context: __SerdeContext): Laye
       output.DefaultSecurityGroupNames !== undefined && output.DefaultSecurityGroupNames !== null
         ? deserializeAws_json1_1Strings(output.DefaultSecurityGroupNames, context)
         : undefined,
-    EnableAutoHealing:
-      output.EnableAutoHealing !== undefined && output.EnableAutoHealing !== null
-        ? output.EnableAutoHealing
-        : undefined,
-    InstallUpdatesOnBoot:
-      output.InstallUpdatesOnBoot !== undefined && output.InstallUpdatesOnBoot !== null
-        ? output.InstallUpdatesOnBoot
-        : undefined,
-    LayerId: output.LayerId !== undefined && output.LayerId !== null ? output.LayerId : undefined,
+    EnableAutoHealing: __expectBoolean(output.EnableAutoHealing),
+    InstallUpdatesOnBoot: __expectBoolean(output.InstallUpdatesOnBoot),
+    LayerId: __expectString(output.LayerId),
     LifecycleEventConfiguration:
       output.LifecycleEventConfiguration !== undefined && output.LifecycleEventConfiguration !== null
         ? deserializeAws_json1_1LifecycleEventConfiguration(output.LifecycleEventConfiguration, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     Packages:
       output.Packages !== undefined && output.Packages !== null
         ? deserializeAws_json1_1Strings(output.Packages, context)
         : undefined,
-    Shortname: output.Shortname !== undefined && output.Shortname !== null ? output.Shortname : undefined,
-    StackId: output.StackId !== undefined && output.StackId !== null ? output.StackId : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    UseEbsOptimizedInstances:
-      output.UseEbsOptimizedInstances !== undefined && output.UseEbsOptimizedInstances !== null
-        ? output.UseEbsOptimizedInstances
-        : undefined,
+    Shortname: __expectString(output.Shortname),
+    StackId: __expectString(output.StackId),
+    Type: __expectString(output.Type),
+    UseEbsOptimizedInstances: __expectBoolean(output.UseEbsOptimizedInstances),
     VolumeConfigurations:
       output.VolumeConfigurations !== undefined && output.VolumeConfigurations !== null
         ? deserializeAws_json1_1VolumeConfigurations(output.VolumeConfigurations, context)
@@ -7990,7 +7908,7 @@ const deserializeAws_json1_1LayerAttributes = (output: any, context: __SerdeCont
       }
       return {
         ...acc,
-        [key]: value,
+        [key]: __expectString(value) as any,
       };
     },
     {}
@@ -8022,7 +7940,7 @@ const deserializeAws_json1_1LifecycleEventConfiguration = (
 
 const deserializeAws_json1_1ListTagsResult = (output: any, context: __SerdeContext): ListTagsResult => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Tags:
       output.Tags !== undefined && output.Tags !== null ? deserializeAws_json1_1Tags(output.Tags, context) : undefined,
   } as any;
@@ -8037,8 +7955,8 @@ const deserializeAws_json1_1LoadBasedAutoScalingConfiguration = (
       output.DownScaling !== undefined && output.DownScaling !== null
         ? deserializeAws_json1_1AutoScalingThresholds(output.DownScaling, context)
         : undefined,
-    Enable: output.Enable !== undefined && output.Enable !== null ? output.Enable : undefined,
-    LayerId: output.LayerId !== undefined && output.LayerId !== null ? output.LayerId : undefined,
+    Enable: __expectBoolean(output.Enable),
+    LayerId: __expectString(output.LayerId),
     UpScaling:
       output.UpScaling !== undefined && output.UpScaling !== null
         ? deserializeAws_json1_1AutoScalingThresholds(output.UpScaling, context)
@@ -8066,13 +7984,12 @@ const deserializeAws_json1_1OperatingSystem = (output: any, context: __SerdeCont
       output.ConfigurationManagers !== undefined && output.ConfigurationManagers !== null
         ? deserializeAws_json1_1OperatingSystemConfigurationManagers(output.ConfigurationManagers, context)
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    ReportedName: output.ReportedName !== undefined && output.ReportedName !== null ? output.ReportedName : undefined,
-    ReportedVersion:
-      output.ReportedVersion !== undefined && output.ReportedVersion !== null ? output.ReportedVersion : undefined,
-    Supported: output.Supported !== undefined && output.Supported !== null ? output.Supported : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
+    ReportedName: __expectString(output.ReportedName),
+    ReportedVersion: __expectString(output.ReportedVersion),
+    Supported: __expectBoolean(output.Supported),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -8081,8 +7998,8 @@ const deserializeAws_json1_1OperatingSystemConfigurationManager = (
   context: __SerdeContext
 ): OperatingSystemConfigurationManager => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    Name: __expectString(output.Name),
+    Version: __expectString(output.Version),
   } as any;
 };
 
@@ -8118,18 +8035,18 @@ const deserializeAws_json1_1Parameters = (output: any, context: __SerdeContext):
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_json1_1Permission = (output: any, context: __SerdeContext): Permission => {
   return {
-    AllowSsh: output.AllowSsh !== undefined && output.AllowSsh !== null ? output.AllowSsh : undefined,
-    AllowSudo: output.AllowSudo !== undefined && output.AllowSudo !== null ? output.AllowSudo : undefined,
-    IamUserArn: output.IamUserArn !== undefined && output.IamUserArn !== null ? output.IamUserArn : undefined,
-    Level: output.Level !== undefined && output.Level !== null ? output.Level : undefined,
-    StackId: output.StackId !== undefined && output.StackId !== null ? output.StackId : undefined,
+    AllowSsh: __expectBoolean(output.AllowSsh),
+    AllowSudo: __expectBoolean(output.AllowSudo),
+    IamUserArn: __expectString(output.IamUserArn),
+    Level: __expectString(output.Level),
+    StackId: __expectString(output.StackId),
   } as any;
 };
 
@@ -8146,21 +8063,19 @@ const deserializeAws_json1_1Permissions = (output: any, context: __SerdeContext)
 
 const deserializeAws_json1_1RaidArray = (output: any, context: __SerdeContext): RaidArray => {
   return {
-    AvailabilityZone:
-      output.AvailabilityZone !== undefined && output.AvailabilityZone !== null ? output.AvailabilityZone : undefined,
-    CreatedAt: output.CreatedAt !== undefined && output.CreatedAt !== null ? output.CreatedAt : undefined,
-    Device: output.Device !== undefined && output.Device !== null ? output.Device : undefined,
-    InstanceId: output.InstanceId !== undefined && output.InstanceId !== null ? output.InstanceId : undefined,
-    Iops: output.Iops !== undefined && output.Iops !== null ? output.Iops : undefined,
-    MountPoint: output.MountPoint !== undefined && output.MountPoint !== null ? output.MountPoint : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    NumberOfDisks:
-      output.NumberOfDisks !== undefined && output.NumberOfDisks !== null ? output.NumberOfDisks : undefined,
-    RaidArrayId: output.RaidArrayId !== undefined && output.RaidArrayId !== null ? output.RaidArrayId : undefined,
-    RaidLevel: output.RaidLevel !== undefined && output.RaidLevel !== null ? output.RaidLevel : undefined,
-    Size: output.Size !== undefined && output.Size !== null ? output.Size : undefined,
-    StackId: output.StackId !== undefined && output.StackId !== null ? output.StackId : undefined,
-    VolumeType: output.VolumeType !== undefined && output.VolumeType !== null ? output.VolumeType : undefined,
+    AvailabilityZone: __expectString(output.AvailabilityZone),
+    CreatedAt: __expectString(output.CreatedAt),
+    Device: __expectString(output.Device),
+    InstanceId: __expectString(output.InstanceId),
+    Iops: __expectNumber(output.Iops),
+    MountPoint: __expectString(output.MountPoint),
+    Name: __expectString(output.Name),
+    NumberOfDisks: __expectNumber(output.NumberOfDisks),
+    RaidArrayId: __expectString(output.RaidArrayId),
+    RaidLevel: __expectNumber(output.RaidLevel),
+    Size: __expectNumber(output.Size),
+    StackId: __expectString(output.StackId),
+    VolumeType: __expectString(output.VolumeType),
   } as any;
 };
 
@@ -8177,19 +8092,15 @@ const deserializeAws_json1_1RaidArrays = (output: any, context: __SerdeContext):
 
 const deserializeAws_json1_1RdsDbInstance = (output: any, context: __SerdeContext): RdsDbInstance => {
   return {
-    Address: output.Address !== undefined && output.Address !== null ? output.Address : undefined,
-    DbInstanceIdentifier:
-      output.DbInstanceIdentifier !== undefined && output.DbInstanceIdentifier !== null
-        ? output.DbInstanceIdentifier
-        : undefined,
-    DbPassword: output.DbPassword !== undefined && output.DbPassword !== null ? output.DbPassword : undefined,
-    DbUser: output.DbUser !== undefined && output.DbUser !== null ? output.DbUser : undefined,
-    Engine: output.Engine !== undefined && output.Engine !== null ? output.Engine : undefined,
-    MissingOnRds: output.MissingOnRds !== undefined && output.MissingOnRds !== null ? output.MissingOnRds : undefined,
-    RdsDbInstanceArn:
-      output.RdsDbInstanceArn !== undefined && output.RdsDbInstanceArn !== null ? output.RdsDbInstanceArn : undefined,
-    Region: output.Region !== undefined && output.Region !== null ? output.Region : undefined,
-    StackId: output.StackId !== undefined && output.StackId !== null ? output.StackId : undefined,
+    Address: __expectString(output.Address),
+    DbInstanceIdentifier: __expectString(output.DbInstanceIdentifier),
+    DbPassword: __expectString(output.DbPassword),
+    DbUser: __expectString(output.DbUser),
+    Engine: __expectString(output.Engine),
+    MissingOnRds: __expectBoolean(output.MissingOnRds),
+    RdsDbInstanceArn: __expectString(output.RdsDbInstanceArn),
+    Region: __expectString(output.Region),
+    StackId: __expectString(output.StackId),
   } as any;
 };
 
@@ -8234,8 +8145,7 @@ const deserializeAws_json1_1RegisterEcsClusterResult = (
   context: __SerdeContext
 ): RegisterEcsClusterResult => {
   return {
-    EcsClusterArn:
-      output.EcsClusterArn !== undefined && output.EcsClusterArn !== null ? output.EcsClusterArn : undefined,
+    EcsClusterArn: __expectString(output.EcsClusterArn),
   } as any;
 };
 
@@ -8244,27 +8154,27 @@ const deserializeAws_json1_1RegisterElasticIpResult = (
   context: __SerdeContext
 ): RegisterElasticIpResult => {
   return {
-    ElasticIp: output.ElasticIp !== undefined && output.ElasticIp !== null ? output.ElasticIp : undefined,
+    ElasticIp: __expectString(output.ElasticIp),
   } as any;
 };
 
 const deserializeAws_json1_1RegisterInstanceResult = (output: any, context: __SerdeContext): RegisterInstanceResult => {
   return {
-    InstanceId: output.InstanceId !== undefined && output.InstanceId !== null ? output.InstanceId : undefined,
+    InstanceId: __expectString(output.InstanceId),
   } as any;
 };
 
 const deserializeAws_json1_1RegisterVolumeResult = (output: any, context: __SerdeContext): RegisterVolumeResult => {
   return {
-    VolumeId: output.VolumeId !== undefined && output.VolumeId !== null ? output.VolumeId : undefined,
+    VolumeId: __expectString(output.VolumeId),
   } as any;
 };
 
 const deserializeAws_json1_1ReportedOs = (output: any, context: __SerdeContext): ReportedOs => {
   return {
-    Family: output.Family !== undefined && output.Family !== null ? output.Family : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    Family: __expectString(output.Family),
+    Name: __expectString(output.Name),
+    Version: __expectString(output.Version),
   } as any;
 };
 
@@ -8273,28 +8183,27 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1SelfUserProfile = (output: any, context: __SerdeContext): SelfUserProfile => {
   return {
-    IamUserArn: output.IamUserArn !== undefined && output.IamUserArn !== null ? output.IamUserArn : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    SshPublicKey: output.SshPublicKey !== undefined && output.SshPublicKey !== null ? output.SshPublicKey : undefined,
-    SshUsername: output.SshUsername !== undefined && output.SshUsername !== null ? output.SshUsername : undefined,
+    IamUserArn: __expectString(output.IamUserArn),
+    Name: __expectString(output.Name),
+    SshPublicKey: __expectString(output.SshPublicKey),
+    SshUsername: __expectString(output.SshUsername),
   } as any;
 };
 
 const deserializeAws_json1_1ServiceError = (output: any, context: __SerdeContext): ServiceError => {
   return {
-    CreatedAt: output.CreatedAt !== undefined && output.CreatedAt !== null ? output.CreatedAt : undefined,
-    InstanceId: output.InstanceId !== undefined && output.InstanceId !== null ? output.InstanceId : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    ServiceErrorId:
-      output.ServiceErrorId !== undefined && output.ServiceErrorId !== null ? output.ServiceErrorId : undefined,
-    StackId: output.StackId !== undefined && output.StackId !== null ? output.StackId : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    CreatedAt: __expectString(output.CreatedAt),
+    InstanceId: __expectString(output.InstanceId),
+    Message: __expectString(output.Message),
+    ServiceErrorId: __expectString(output.ServiceErrorId),
+    StackId: __expectString(output.StackId),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -8314,38 +8223,34 @@ const deserializeAws_json1_1ShutdownEventConfiguration = (
   context: __SerdeContext
 ): ShutdownEventConfiguration => {
   return {
-    DelayUntilElbConnectionsDrained:
-      output.DelayUntilElbConnectionsDrained !== undefined && output.DelayUntilElbConnectionsDrained !== null
-        ? output.DelayUntilElbConnectionsDrained
-        : undefined,
-    ExecutionTimeout:
-      output.ExecutionTimeout !== undefined && output.ExecutionTimeout !== null ? output.ExecutionTimeout : undefined,
+    DelayUntilElbConnectionsDrained: __expectBoolean(output.DelayUntilElbConnectionsDrained),
+    ExecutionTimeout: __expectNumber(output.ExecutionTimeout),
   } as any;
 };
 
 const deserializeAws_json1_1Source = (output: any, context: __SerdeContext): Source => {
   return {
-    Password: output.Password !== undefined && output.Password !== null ? output.Password : undefined,
-    Revision: output.Revision !== undefined && output.Revision !== null ? output.Revision : undefined,
-    SshKey: output.SshKey !== undefined && output.SshKey !== null ? output.SshKey : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    Url: output.Url !== undefined && output.Url !== null ? output.Url : undefined,
-    Username: output.Username !== undefined && output.Username !== null ? output.Username : undefined,
+    Password: __expectString(output.Password),
+    Revision: __expectString(output.Revision),
+    SshKey: __expectString(output.SshKey),
+    Type: __expectString(output.Type),
+    Url: __expectString(output.Url),
+    Username: __expectString(output.Username),
   } as any;
 };
 
 const deserializeAws_json1_1SslConfiguration = (output: any, context: __SerdeContext): SslConfiguration => {
   return {
-    Certificate: output.Certificate !== undefined && output.Certificate !== null ? output.Certificate : undefined,
-    Chain: output.Chain !== undefined && output.Chain !== null ? output.Chain : undefined,
-    PrivateKey: output.PrivateKey !== undefined && output.PrivateKey !== null ? output.PrivateKey : undefined,
+    Certificate: __expectString(output.Certificate),
+    Chain: __expectString(output.Chain),
+    PrivateKey: __expectString(output.PrivateKey),
   } as any;
 };
 
 const deserializeAws_json1_1Stack = (output: any, context: __SerdeContext): Stack => {
   return {
-    AgentVersion: output.AgentVersion !== undefined && output.AgentVersion !== null ? output.AgentVersion : undefined,
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    AgentVersion: __expectString(output.AgentVersion),
+    Arn: __expectString(output.Arn),
     Attributes:
       output.Attributes !== undefined && output.Attributes !== null
         ? deserializeAws_json1_1StackAttributes(output.Attributes, context)
@@ -8358,47 +8263,26 @@ const deserializeAws_json1_1Stack = (output: any, context: __SerdeContext): Stac
       output.ConfigurationManager !== undefined && output.ConfigurationManager !== null
         ? deserializeAws_json1_1StackConfigurationManager(output.ConfigurationManager, context)
         : undefined,
-    CreatedAt: output.CreatedAt !== undefined && output.CreatedAt !== null ? output.CreatedAt : undefined,
+    CreatedAt: __expectString(output.CreatedAt),
     CustomCookbooksSource:
       output.CustomCookbooksSource !== undefined && output.CustomCookbooksSource !== null
         ? deserializeAws_json1_1Source(output.CustomCookbooksSource, context)
         : undefined,
-    CustomJson: output.CustomJson !== undefined && output.CustomJson !== null ? output.CustomJson : undefined,
-    DefaultAvailabilityZone:
-      output.DefaultAvailabilityZone !== undefined && output.DefaultAvailabilityZone !== null
-        ? output.DefaultAvailabilityZone
-        : undefined,
-    DefaultInstanceProfileArn:
-      output.DefaultInstanceProfileArn !== undefined && output.DefaultInstanceProfileArn !== null
-        ? output.DefaultInstanceProfileArn
-        : undefined,
-    DefaultOs: output.DefaultOs !== undefined && output.DefaultOs !== null ? output.DefaultOs : undefined,
-    DefaultRootDeviceType:
-      output.DefaultRootDeviceType !== undefined && output.DefaultRootDeviceType !== null
-        ? output.DefaultRootDeviceType
-        : undefined,
-    DefaultSshKeyName:
-      output.DefaultSshKeyName !== undefined && output.DefaultSshKeyName !== null
-        ? output.DefaultSshKeyName
-        : undefined,
-    DefaultSubnetId:
-      output.DefaultSubnetId !== undefined && output.DefaultSubnetId !== null ? output.DefaultSubnetId : undefined,
-    HostnameTheme:
-      output.HostnameTheme !== undefined && output.HostnameTheme !== null ? output.HostnameTheme : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Region: output.Region !== undefined && output.Region !== null ? output.Region : undefined,
-    ServiceRoleArn:
-      output.ServiceRoleArn !== undefined && output.ServiceRoleArn !== null ? output.ServiceRoleArn : undefined,
-    StackId: output.StackId !== undefined && output.StackId !== null ? output.StackId : undefined,
-    UseCustomCookbooks:
-      output.UseCustomCookbooks !== undefined && output.UseCustomCookbooks !== null
-        ? output.UseCustomCookbooks
-        : undefined,
-    UseOpsworksSecurityGroups:
-      output.UseOpsworksSecurityGroups !== undefined && output.UseOpsworksSecurityGroups !== null
-        ? output.UseOpsworksSecurityGroups
-        : undefined,
-    VpcId: output.VpcId !== undefined && output.VpcId !== null ? output.VpcId : undefined,
+    CustomJson: __expectString(output.CustomJson),
+    DefaultAvailabilityZone: __expectString(output.DefaultAvailabilityZone),
+    DefaultInstanceProfileArn: __expectString(output.DefaultInstanceProfileArn),
+    DefaultOs: __expectString(output.DefaultOs),
+    DefaultRootDeviceType: __expectString(output.DefaultRootDeviceType),
+    DefaultSshKeyName: __expectString(output.DefaultSshKeyName),
+    DefaultSubnetId: __expectString(output.DefaultSubnetId),
+    HostnameTheme: __expectString(output.HostnameTheme),
+    Name: __expectString(output.Name),
+    Region: __expectString(output.Region),
+    ServiceRoleArn: __expectString(output.ServiceRoleArn),
+    StackId: __expectString(output.StackId),
+    UseCustomCookbooks: __expectBoolean(output.UseCustomCookbooks),
+    UseOpsworksSecurityGroups: __expectBoolean(output.UseOpsworksSecurityGroups),
+    VpcId: __expectString(output.VpcId),
   } as any;
 };
 
@@ -8410,7 +8294,7 @@ const deserializeAws_json1_1StackAttributes = (output: any, context: __SerdeCont
       }
       return {
         ...acc,
-        [key]: value,
+        [key]: __expectString(value) as any,
       };
     },
     {}
@@ -8422,8 +8306,8 @@ const deserializeAws_json1_1StackConfigurationManager = (
   context: __SerdeContext
 ): StackConfigurationManager => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    Name: __expectString(output.Name),
+    Version: __expectString(output.Version),
   } as any;
 };
 
@@ -8440,15 +8324,15 @@ const deserializeAws_json1_1Stacks = (output: any, context: __SerdeContext): Sta
 
 const deserializeAws_json1_1StackSummary = (output: any, context: __SerdeContext): StackSummary => {
   return {
-    AppsCount: output.AppsCount !== undefined && output.AppsCount !== null ? output.AppsCount : undefined,
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    AppsCount: __expectNumber(output.AppsCount),
+    Arn: __expectString(output.Arn),
     InstancesCount:
       output.InstancesCount !== undefined && output.InstancesCount !== null
         ? deserializeAws_json1_1InstancesCount(output.InstancesCount, context)
         : undefined,
-    LayersCount: output.LayersCount !== undefined && output.LayersCount !== null ? output.LayersCount : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    StackId: output.StackId !== undefined && output.StackId !== null ? output.StackId : undefined,
+    LayersCount: __expectNumber(output.LayersCount),
+    Name: __expectString(output.Name),
+    StackId: __expectString(output.StackId),
   } as any;
 };
 
@@ -8459,7 +8343,7 @@ const deserializeAws_json1_1Strings = (output: any, context: __SerdeContext): st
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -8470,20 +8354,17 @@ const deserializeAws_json1_1Tags = (output: any, context: __SerdeContext): { [ke
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_json1_1TemporaryCredential = (output: any, context: __SerdeContext): TemporaryCredential => {
   return {
-    InstanceId: output.InstanceId !== undefined && output.InstanceId !== null ? output.InstanceId : undefined,
-    Password: output.Password !== undefined && output.Password !== null ? output.Password : undefined,
-    Username: output.Username !== undefined && output.Username !== null ? output.Username : undefined,
-    ValidForInMinutes:
-      output.ValidForInMinutes !== undefined && output.ValidForInMinutes !== null
-        ? output.ValidForInMinutes
-        : undefined,
+    InstanceId: __expectString(output.InstanceId),
+    Password: __expectString(output.Password),
+    Username: __expectString(output.Username),
+    ValidForInMinutes: __expectNumber(output.ValidForInMinutes),
   } as any;
 };
 
@@ -8496,7 +8377,7 @@ const deserializeAws_json1_1TimeBasedAutoScalingConfiguration = (
       output.AutoScalingSchedule !== undefined && output.AutoScalingSchedule !== null
         ? deserializeAws_json1_1WeeklyAutoScalingSchedule(output.AutoScalingSchedule, context)
         : undefined,
-    InstanceId: output.InstanceId !== undefined && output.InstanceId !== null ? output.InstanceId : undefined,
+    InstanceId: __expectString(output.InstanceId),
   } as any;
 };
 
@@ -8516,14 +8397,11 @@ const deserializeAws_json1_1TimeBasedAutoScalingConfigurations = (
 
 const deserializeAws_json1_1UserProfile = (output: any, context: __SerdeContext): UserProfile => {
   return {
-    AllowSelfManagement:
-      output.AllowSelfManagement !== undefined && output.AllowSelfManagement !== null
-        ? output.AllowSelfManagement
-        : undefined,
-    IamUserArn: output.IamUserArn !== undefined && output.IamUserArn !== null ? output.IamUserArn : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    SshPublicKey: output.SshPublicKey !== undefined && output.SshPublicKey !== null ? output.SshPublicKey : undefined,
-    SshUsername: output.SshUsername !== undefined && output.SshUsername !== null ? output.SshUsername : undefined,
+    AllowSelfManagement: __expectBoolean(output.AllowSelfManagement),
+    IamUserArn: __expectString(output.IamUserArn),
+    Name: __expectString(output.Name),
+    SshPublicKey: __expectString(output.SshPublicKey),
+    SshUsername: __expectString(output.SshUsername),
   } as any;
 };
 
@@ -8540,40 +8418,38 @@ const deserializeAws_json1_1UserProfiles = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_1ValidationException = (output: any, context: __SerdeContext): ValidationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1Volume = (output: any, context: __SerdeContext): Volume => {
   return {
-    AvailabilityZone:
-      output.AvailabilityZone !== undefined && output.AvailabilityZone !== null ? output.AvailabilityZone : undefined,
-    Device: output.Device !== undefined && output.Device !== null ? output.Device : undefined,
-    Ec2VolumeId: output.Ec2VolumeId !== undefined && output.Ec2VolumeId !== null ? output.Ec2VolumeId : undefined,
-    Encrypted: output.Encrypted !== undefined && output.Encrypted !== null ? output.Encrypted : undefined,
-    InstanceId: output.InstanceId !== undefined && output.InstanceId !== null ? output.InstanceId : undefined,
-    Iops: output.Iops !== undefined && output.Iops !== null ? output.Iops : undefined,
-    MountPoint: output.MountPoint !== undefined && output.MountPoint !== null ? output.MountPoint : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    RaidArrayId: output.RaidArrayId !== undefined && output.RaidArrayId !== null ? output.RaidArrayId : undefined,
-    Region: output.Region !== undefined && output.Region !== null ? output.Region : undefined,
-    Size: output.Size !== undefined && output.Size !== null ? output.Size : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    VolumeId: output.VolumeId !== undefined && output.VolumeId !== null ? output.VolumeId : undefined,
-    VolumeType: output.VolumeType !== undefined && output.VolumeType !== null ? output.VolumeType : undefined,
+    AvailabilityZone: __expectString(output.AvailabilityZone),
+    Device: __expectString(output.Device),
+    Ec2VolumeId: __expectString(output.Ec2VolumeId),
+    Encrypted: __expectBoolean(output.Encrypted),
+    InstanceId: __expectString(output.InstanceId),
+    Iops: __expectNumber(output.Iops),
+    MountPoint: __expectString(output.MountPoint),
+    Name: __expectString(output.Name),
+    RaidArrayId: __expectString(output.RaidArrayId),
+    Region: __expectString(output.Region),
+    Size: __expectNumber(output.Size),
+    Status: __expectString(output.Status),
+    VolumeId: __expectString(output.VolumeId),
+    VolumeType: __expectString(output.VolumeType),
   } as any;
 };
 
 const deserializeAws_json1_1VolumeConfiguration = (output: any, context: __SerdeContext): VolumeConfiguration => {
   return {
-    Encrypted: output.Encrypted !== undefined && output.Encrypted !== null ? output.Encrypted : undefined,
-    Iops: output.Iops !== undefined && output.Iops !== null ? output.Iops : undefined,
-    MountPoint: output.MountPoint !== undefined && output.MountPoint !== null ? output.MountPoint : undefined,
-    NumberOfDisks:
-      output.NumberOfDisks !== undefined && output.NumberOfDisks !== null ? output.NumberOfDisks : undefined,
-    RaidLevel: output.RaidLevel !== undefined && output.RaidLevel !== null ? output.RaidLevel : undefined,
-    Size: output.Size !== undefined && output.Size !== null ? output.Size : undefined,
-    VolumeType: output.VolumeType !== undefined && output.VolumeType !== null ? output.VolumeType : undefined,
+    Encrypted: __expectBoolean(output.Encrypted),
+    Iops: __expectNumber(output.Iops),
+    MountPoint: __expectString(output.MountPoint),
+    NumberOfDisks: __expectNumber(output.NumberOfDisks),
+    RaidLevel: __expectNumber(output.RaidLevel),
+    Size: __expectNumber(output.Size),
+    VolumeType: __expectString(output.VolumeType),
   } as any;
 };
 

--- a/clients/client-opsworkscm/protocols/Aws_json1_1.ts
+++ b/clients/client-opsworkscm/protocols/Aws_json1_1.ts
@@ -85,7 +85,12 @@ import {
   ValidationException,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -2010,9 +2015,9 @@ const serializeAws_json1_1UpdateServerRequest = (input: UpdateServerRequest, con
 
 const deserializeAws_json1_1AccountAttribute = (output: any, context: __SerdeContext): AccountAttribute => {
   return {
-    Maximum: output.Maximum !== undefined && output.Maximum !== null ? output.Maximum : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Used: output.Used !== undefined && output.Used !== null ? output.Used : undefined,
+    Maximum: __expectNumber(output.Maximum),
+    Name: __expectString(output.Name),
+    Used: __expectNumber(output.Used),
   } as any;
 };
 
@@ -2029,62 +2034,45 @@ const deserializeAws_json1_1AccountAttributes = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1AssociateNodeResponse = (output: any, context: __SerdeContext): AssociateNodeResponse => {
   return {
-    NodeAssociationStatusToken:
-      output.NodeAssociationStatusToken !== undefined && output.NodeAssociationStatusToken !== null
-        ? output.NodeAssociationStatusToken
-        : undefined,
+    NodeAssociationStatusToken: __expectString(output.NodeAssociationStatusToken),
   } as any;
 };
 
 const deserializeAws_json1_1Backup = (output: any, context: __SerdeContext): Backup => {
   return {
-    BackupArn: output.BackupArn !== undefined && output.BackupArn !== null ? output.BackupArn : undefined,
-    BackupId: output.BackupId !== undefined && output.BackupId !== null ? output.BackupId : undefined,
-    BackupType: output.BackupType !== undefined && output.BackupType !== null ? output.BackupType : undefined,
+    BackupArn: __expectString(output.BackupArn),
+    BackupId: __expectString(output.BackupId),
+    BackupType: __expectString(output.BackupType),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Engine: output.Engine !== undefined && output.Engine !== null ? output.Engine : undefined,
-    EngineModel: output.EngineModel !== undefined && output.EngineModel !== null ? output.EngineModel : undefined,
-    EngineVersion:
-      output.EngineVersion !== undefined && output.EngineVersion !== null ? output.EngineVersion : undefined,
-    InstanceProfileArn:
-      output.InstanceProfileArn !== undefined && output.InstanceProfileArn !== null
-        ? output.InstanceProfileArn
-        : undefined,
-    InstanceType: output.InstanceType !== undefined && output.InstanceType !== null ? output.InstanceType : undefined,
-    KeyPair: output.KeyPair !== undefined && output.KeyPair !== null ? output.KeyPair : undefined,
-    PreferredBackupWindow:
-      output.PreferredBackupWindow !== undefined && output.PreferredBackupWindow !== null
-        ? output.PreferredBackupWindow
-        : undefined,
-    PreferredMaintenanceWindow:
-      output.PreferredMaintenanceWindow !== undefined && output.PreferredMaintenanceWindow !== null
-        ? output.PreferredMaintenanceWindow
-        : undefined,
-    S3DataSize: output.S3DataSize !== undefined && output.S3DataSize !== null ? output.S3DataSize : undefined,
-    S3DataUrl: output.S3DataUrl !== undefined && output.S3DataUrl !== null ? output.S3DataUrl : undefined,
-    S3LogUrl: output.S3LogUrl !== undefined && output.S3LogUrl !== null ? output.S3LogUrl : undefined,
+    Description: __expectString(output.Description),
+    Engine: __expectString(output.Engine),
+    EngineModel: __expectString(output.EngineModel),
+    EngineVersion: __expectString(output.EngineVersion),
+    InstanceProfileArn: __expectString(output.InstanceProfileArn),
+    InstanceType: __expectString(output.InstanceType),
+    KeyPair: __expectString(output.KeyPair),
+    PreferredBackupWindow: __expectString(output.PreferredBackupWindow),
+    PreferredMaintenanceWindow: __expectString(output.PreferredMaintenanceWindow),
+    S3DataSize: __expectNumber(output.S3DataSize),
+    S3DataUrl: __expectString(output.S3DataUrl),
+    S3LogUrl: __expectString(output.S3LogUrl),
     SecurityGroupIds:
       output.SecurityGroupIds !== undefined && output.SecurityGroupIds !== null
         ? deserializeAws_json1_1Strings(output.SecurityGroupIds, context)
         : undefined,
-    ServerName: output.ServerName !== undefined && output.ServerName !== null ? output.ServerName : undefined,
-    ServiceRoleArn:
-      output.ServiceRoleArn !== undefined && output.ServiceRoleArn !== null ? output.ServiceRoleArn : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusDescription:
-      output.StatusDescription !== undefined && output.StatusDescription !== null
-        ? output.StatusDescription
-        : undefined,
+    ServerName: __expectString(output.ServerName),
+    ServiceRoleArn: __expectString(output.ServiceRoleArn),
+    Status: __expectString(output.Status),
+    StatusDescription: __expectString(output.StatusDescription),
     SubnetIds:
       output.SubnetIds !== undefined && output.SubnetIds !== null
         ? deserializeAws_json1_1Strings(output.SubnetIds, context)
         : undefined,
-    ToolsVersion: output.ToolsVersion !== undefined && output.ToolsVersion !== null ? output.ToolsVersion : undefined,
-    UserArn: output.UserArn !== undefined && output.UserArn !== null ? output.UserArn : undefined,
+    ToolsVersion: __expectString(output.ToolsVersion),
+    UserArn: __expectString(output.UserArn),
   } as any;
 };
 
@@ -2146,13 +2134,13 @@ const deserializeAws_json1_1DescribeBackupsResponse = (
       output.Backups !== undefined && output.Backups !== null
         ? deserializeAws_json1_1Backups(output.Backups, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
 const deserializeAws_json1_1DescribeEventsResponse = (output: any, context: __SerdeContext): DescribeEventsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     ServerEvents:
       output.ServerEvents !== undefined && output.ServerEvents !== null
         ? deserializeAws_json1_1ServerEvents(output.ServerEvents, context)
@@ -2169,10 +2157,7 @@ const deserializeAws_json1_1DescribeNodeAssociationStatusResponse = (
       output.EngineAttributes !== undefined && output.EngineAttributes !== null
         ? deserializeAws_json1_1EngineAttributes(output.EngineAttributes, context)
         : undefined,
-    NodeAssociationStatus:
-      output.NodeAssociationStatus !== undefined && output.NodeAssociationStatus !== null
-        ? output.NodeAssociationStatus
-        : undefined,
+    NodeAssociationStatus: __expectString(output.NodeAssociationStatus),
   } as any;
 };
 
@@ -2181,7 +2166,7 @@ const deserializeAws_json1_1DescribeServersResponse = (
   context: __SerdeContext
 ): DescribeServersResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Servers:
       output.Servers !== undefined && output.Servers !== null
         ? deserializeAws_json1_1Servers(output.Servers, context)
@@ -2194,17 +2179,14 @@ const deserializeAws_json1_1DisassociateNodeResponse = (
   context: __SerdeContext
 ): DisassociateNodeResponse => {
   return {
-    NodeAssociationStatusToken:
-      output.NodeAssociationStatusToken !== undefined && output.NodeAssociationStatusToken !== null
-        ? output.NodeAssociationStatusToken
-        : undefined,
+    NodeAssociationStatusToken: __expectString(output.NodeAssociationStatusToken),
   } as any;
 };
 
 const deserializeAws_json1_1EngineAttribute = (output: any, context: __SerdeContext): EngineAttribute => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Name: __expectString(output.Name),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -2228,7 +2210,7 @@ const deserializeAws_json1_1ExportServerEngineAttributeResponse = (
       output.EngineAttribute !== undefined && output.EngineAttribute !== null
         ? deserializeAws_json1_1EngineAttribute(output.EngineAttribute, context)
         : undefined,
-    ServerName: output.ServerName !== undefined && output.ServerName !== null ? output.ServerName : undefined,
+    ServerName: __expectString(output.ServerName),
   } as any;
 };
 
@@ -2237,19 +2219,19 @@ const deserializeAws_json1_1InvalidNextTokenException = (
   context: __SerdeContext
 ): InvalidNextTokenException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidStateException = (output: any, context: __SerdeContext): InvalidStateException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2258,7 +2240,7 @@ const deserializeAws_json1_1ListTagsForResourceResponse = (
   context: __SerdeContext
 ): ListTagsForResourceResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_1TagList(output.Tags, context)
@@ -2271,7 +2253,7 @@ const deserializeAws_json1_1ResourceAlreadyExistsException = (
   context: __SerdeContext
 ): ResourceAlreadyExistsException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2280,7 +2262,7 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2295,64 +2277,38 @@ const deserializeAws_json1_1RestoreServerResponse = (output: any, context: __Ser
 
 const deserializeAws_json1_1Server = (output: any, context: __SerdeContext): Server => {
   return {
-    AssociatePublicIpAddress:
-      output.AssociatePublicIpAddress !== undefined && output.AssociatePublicIpAddress !== null
-        ? output.AssociatePublicIpAddress
-        : undefined,
-    BackupRetentionCount:
-      output.BackupRetentionCount !== undefined && output.BackupRetentionCount !== null
-        ? output.BackupRetentionCount
-        : undefined,
-    CloudFormationStackArn:
-      output.CloudFormationStackArn !== undefined && output.CloudFormationStackArn !== null
-        ? output.CloudFormationStackArn
-        : undefined,
+    AssociatePublicIpAddress: __expectBoolean(output.AssociatePublicIpAddress),
+    BackupRetentionCount: __expectNumber(output.BackupRetentionCount),
+    CloudFormationStackArn: __expectString(output.CloudFormationStackArn),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    CustomDomain: output.CustomDomain !== undefined && output.CustomDomain !== null ? output.CustomDomain : undefined,
-    DisableAutomatedBackup:
-      output.DisableAutomatedBackup !== undefined && output.DisableAutomatedBackup !== null
-        ? output.DisableAutomatedBackup
-        : undefined,
-    Endpoint: output.Endpoint !== undefined && output.Endpoint !== null ? output.Endpoint : undefined,
-    Engine: output.Engine !== undefined && output.Engine !== null ? output.Engine : undefined,
+    CustomDomain: __expectString(output.CustomDomain),
+    DisableAutomatedBackup: __expectBoolean(output.DisableAutomatedBackup),
+    Endpoint: __expectString(output.Endpoint),
+    Engine: __expectString(output.Engine),
     EngineAttributes:
       output.EngineAttributes !== undefined && output.EngineAttributes !== null
         ? deserializeAws_json1_1EngineAttributes(output.EngineAttributes, context)
         : undefined,
-    EngineModel: output.EngineModel !== undefined && output.EngineModel !== null ? output.EngineModel : undefined,
-    EngineVersion:
-      output.EngineVersion !== undefined && output.EngineVersion !== null ? output.EngineVersion : undefined,
-    InstanceProfileArn:
-      output.InstanceProfileArn !== undefined && output.InstanceProfileArn !== null
-        ? output.InstanceProfileArn
-        : undefined,
-    InstanceType: output.InstanceType !== undefined && output.InstanceType !== null ? output.InstanceType : undefined,
-    KeyPair: output.KeyPair !== undefined && output.KeyPair !== null ? output.KeyPair : undefined,
-    MaintenanceStatus:
-      output.MaintenanceStatus !== undefined && output.MaintenanceStatus !== null
-        ? output.MaintenanceStatus
-        : undefined,
-    PreferredBackupWindow:
-      output.PreferredBackupWindow !== undefined && output.PreferredBackupWindow !== null
-        ? output.PreferredBackupWindow
-        : undefined,
-    PreferredMaintenanceWindow:
-      output.PreferredMaintenanceWindow !== undefined && output.PreferredMaintenanceWindow !== null
-        ? output.PreferredMaintenanceWindow
-        : undefined,
+    EngineModel: __expectString(output.EngineModel),
+    EngineVersion: __expectString(output.EngineVersion),
+    InstanceProfileArn: __expectString(output.InstanceProfileArn),
+    InstanceType: __expectString(output.InstanceType),
+    KeyPair: __expectString(output.KeyPair),
+    MaintenanceStatus: __expectString(output.MaintenanceStatus),
+    PreferredBackupWindow: __expectString(output.PreferredBackupWindow),
+    PreferredMaintenanceWindow: __expectString(output.PreferredMaintenanceWindow),
     SecurityGroupIds:
       output.SecurityGroupIds !== undefined && output.SecurityGroupIds !== null
         ? deserializeAws_json1_1Strings(output.SecurityGroupIds, context)
         : undefined,
-    ServerArn: output.ServerArn !== undefined && output.ServerArn !== null ? output.ServerArn : undefined,
-    ServerName: output.ServerName !== undefined && output.ServerName !== null ? output.ServerName : undefined,
-    ServiceRoleArn:
-      output.ServiceRoleArn !== undefined && output.ServiceRoleArn !== null ? output.ServiceRoleArn : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusReason: output.StatusReason !== undefined && output.StatusReason !== null ? output.StatusReason : undefined,
+    ServerArn: __expectString(output.ServerArn),
+    ServerName: __expectString(output.ServerName),
+    ServiceRoleArn: __expectString(output.ServiceRoleArn),
+    Status: __expectString(output.Status),
+    StatusReason: __expectString(output.StatusReason),
     SubnetIds:
       output.SubnetIds !== undefined && output.SubnetIds !== null
         ? deserializeAws_json1_1Strings(output.SubnetIds, context)
@@ -2366,9 +2322,9 @@ const deserializeAws_json1_1ServerEvent = (output: any, context: __SerdeContext)
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    LogUrl: output.LogUrl !== undefined && output.LogUrl !== null ? output.LogUrl : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    ServerName: output.ServerName !== undefined && output.ServerName !== null ? output.ServerName : undefined,
+    LogUrl: __expectString(output.LogUrl),
+    Message: __expectString(output.Message),
+    ServerName: __expectString(output.ServerName),
   } as any;
 };
 
@@ -2413,14 +2369,14 @@ const deserializeAws_json1_1Strings = (output: any, context: __SerdeContext): st
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -2466,7 +2422,7 @@ const deserializeAws_json1_1UpdateServerResponse = (output: any, context: __Serd
 
 const deserializeAws_json1_1ValidationException = (output: any, context: __SerdeContext): ValidationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 

--- a/clients/client-organizations/protocols/Aws_json1_1.ts
+++ b/clients/client-organizations/protocols/Aws_json1_1.ts
@@ -277,7 +277,11 @@ import {
   UpdatePolicyResponse,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -7703,7 +7707,7 @@ const deserializeAws_json1_1AcceptHandshakeResponse = (
 
 const deserializeAws_json1_1AccessDeniedException = (output: any, context: __SerdeContext): AccessDeniedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7712,23 +7716,23 @@ const deserializeAws_json1_1AccessDeniedForDependencyException = (
   context: __SerdeContext
 ): AccessDeniedForDependencyException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Reason: output.Reason !== undefined && output.Reason !== null ? output.Reason : undefined,
+    Message: __expectString(output.Message),
+    Reason: __expectString(output.Reason),
   } as any;
 };
 
 const deserializeAws_json1_1Account = (output: any, context: __SerdeContext): Account => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Email: output.Email !== undefined && output.Email !== null ? output.Email : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    JoinedMethod: output.JoinedMethod !== undefined && output.JoinedMethod !== null ? output.JoinedMethod : undefined,
+    Arn: __expectString(output.Arn),
+    Email: __expectString(output.Email),
+    Id: __expectString(output.Id),
+    JoinedMethod: __expectString(output.JoinedMethod),
     JoinedTimestamp:
       output.JoinedTimestamp !== undefined && output.JoinedTimestamp !== null
         ? new Date(Math.round(output.JoinedTimestamp * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Name: __expectString(output.Name),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -7737,7 +7741,7 @@ const deserializeAws_json1_1AccountAlreadyRegisteredException = (
   context: __SerdeContext
 ): AccountAlreadyRegisteredException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7746,7 +7750,7 @@ const deserializeAws_json1_1AccountNotFoundException = (
   context: __SerdeContext
 ): AccountNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7755,7 +7759,7 @@ const deserializeAws_json1_1AccountNotRegisteredException = (
   context: __SerdeContext
 ): AccountNotRegisteredException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7764,7 +7768,7 @@ const deserializeAws_json1_1AccountOwnerNotVerifiedException = (
   context: __SerdeContext
 ): AccountOwnerNotVerifiedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7784,7 +7788,7 @@ const deserializeAws_json1_1AlreadyInOrganizationException = (
   context: __SerdeContext
 ): AlreadyInOrganizationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7793,7 +7797,7 @@ const deserializeAws_json1_1AWSOrganizationsNotInUseException = (
   context: __SerdeContext
 ): AWSOrganizationsNotInUseException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7811,14 +7815,14 @@ const deserializeAws_json1_1CancelHandshakeResponse = (
 
 const deserializeAws_json1_1Child = (output: any, context: __SerdeContext): Child => {
   return {
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Id: __expectString(output.Id),
+    Type: __expectString(output.Type),
   } as any;
 };
 
 const deserializeAws_json1_1ChildNotFoundException = (output: any, context: __SerdeContext): ChildNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7838,7 +7842,7 @@ const deserializeAws_json1_1ConcurrentModificationException = (
   context: __SerdeContext
 ): ConcurrentModificationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7847,8 +7851,8 @@ const deserializeAws_json1_1ConstraintViolationException = (
   context: __SerdeContext
 ): ConstraintViolationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Reason: output.Reason !== undefined && output.Reason !== null ? output.Reason : undefined,
+    Message: __expectString(output.Message),
+    Reason: __expectString(output.Reason),
   } as any;
 };
 
@@ -7863,24 +7867,20 @@ const deserializeAws_json1_1CreateAccountResponse = (output: any, context: __Ser
 
 const deserializeAws_json1_1CreateAccountStatus = (output: any, context: __SerdeContext): CreateAccountStatus => {
   return {
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
-    AccountName: output.AccountName !== undefined && output.AccountName !== null ? output.AccountName : undefined,
+    AccountId: __expectString(output.AccountId),
+    AccountName: __expectString(output.AccountName),
     CompletedTimestamp:
       output.CompletedTimestamp !== undefined && output.CompletedTimestamp !== null
         ? new Date(Math.round(output.CompletedTimestamp * 1000))
         : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
-    GovCloudAccountId:
-      output.GovCloudAccountId !== undefined && output.GovCloudAccountId !== null
-        ? output.GovCloudAccountId
-        : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    FailureReason: __expectString(output.FailureReason),
+    GovCloudAccountId: __expectString(output.GovCloudAccountId),
+    Id: __expectString(output.Id),
     RequestedTimestamp:
       output.RequestedTimestamp !== undefined && output.RequestedTimestamp !== null
         ? new Date(Math.round(output.RequestedTimestamp * 1000))
         : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    State: __expectString(output.State),
   } as any;
 };
 
@@ -7900,7 +7900,7 @@ const deserializeAws_json1_1CreateAccountStatusNotFoundException = (
   context: __SerdeContext
 ): CreateAccountStatusNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7963,20 +7963,20 @@ const deserializeAws_json1_1DeclineHandshakeResponse = (
 
 const deserializeAws_json1_1DelegatedAdministrator = (output: any, context: __SerdeContext): DelegatedAdministrator => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     DelegationEnabledDate:
       output.DelegationEnabledDate !== undefined && output.DelegationEnabledDate !== null
         ? new Date(Math.round(output.DelegationEnabledDate * 1000))
         : undefined,
-    Email: output.Email !== undefined && output.Email !== null ? output.Email : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    JoinedMethod: output.JoinedMethod !== undefined && output.JoinedMethod !== null ? output.JoinedMethod : undefined,
+    Email: __expectString(output.Email),
+    Id: __expectString(output.Id),
+    JoinedMethod: __expectString(output.JoinedMethod),
     JoinedTimestamp:
       output.JoinedTimestamp !== undefined && output.JoinedTimestamp !== null
         ? new Date(Math.round(output.JoinedTimestamp * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Name: __expectString(output.Name),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -8000,8 +8000,7 @@ const deserializeAws_json1_1DelegatedService = (output: any, context: __SerdeCon
       output.DelegationEnabledDate !== undefined && output.DelegationEnabledDate !== null
         ? new Date(Math.round(output.DelegationEnabledDate * 1000))
         : undefined,
-    ServicePrincipal:
-      output.ServicePrincipal !== undefined && output.ServicePrincipal !== null ? output.ServicePrincipal : undefined,
+    ServicePrincipal: __expectString(output.ServicePrincipal),
   } as any;
 };
 
@@ -8102,7 +8101,7 @@ const deserializeAws_json1_1DestinationParentNotFoundException = (
   context: __SerdeContext
 ): DestinationParentNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -8121,7 +8120,7 @@ const deserializeAws_json1_1DuplicateAccountException = (
   context: __SerdeContext
 ): DuplicateAccountException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -8130,7 +8129,7 @@ const deserializeAws_json1_1DuplicateHandshakeException = (
   context: __SerdeContext
 ): DuplicateHandshakeException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -8139,7 +8138,7 @@ const deserializeAws_json1_1DuplicateOrganizationalUnitException = (
   context: __SerdeContext
 ): DuplicateOrganizationalUnitException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -8148,7 +8147,7 @@ const deserializeAws_json1_1DuplicatePolicyAttachmentException = (
   context: __SerdeContext
 ): DuplicatePolicyAttachmentException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -8157,7 +8156,7 @@ const deserializeAws_json1_1DuplicatePolicyException = (
   context: __SerdeContext
 ): DuplicatePolicyException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -8167,10 +8166,9 @@ const deserializeAws_json1_1EffectivePolicy = (output: any, context: __SerdeCont
       output.LastUpdatedTimestamp !== undefined && output.LastUpdatedTimestamp !== null
         ? new Date(Math.round(output.LastUpdatedTimestamp * 1000))
         : undefined,
-    PolicyContent:
-      output.PolicyContent !== undefined && output.PolicyContent !== null ? output.PolicyContent : undefined,
-    PolicyType: output.PolicyType !== undefined && output.PolicyType !== null ? output.PolicyType : undefined,
-    TargetId: output.TargetId !== undefined && output.TargetId !== null ? output.TargetId : undefined,
+    PolicyContent: __expectString(output.PolicyContent),
+    PolicyType: __expectString(output.PolicyType),
+    TargetId: __expectString(output.TargetId),
   } as any;
 };
 
@@ -8179,7 +8177,7 @@ const deserializeAws_json1_1EffectivePolicyNotFoundException = (
   context: __SerdeContext
 ): EffectivePolicyNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -8204,8 +8202,7 @@ const deserializeAws_json1_1EnabledServicePrincipal = (
       output.DateEnabled !== undefined && output.DateEnabled !== null
         ? new Date(Math.round(output.DateEnabled * 1000))
         : undefined,
-    ServicePrincipal:
-      output.ServicePrincipal !== undefined && output.ServicePrincipal !== null ? output.ServicePrincipal : undefined,
+    ServicePrincipal: __expectString(output.ServicePrincipal),
   } as any;
 };
 
@@ -8238,19 +8235,19 @@ const deserializeAws_json1_1FinalizingOrganizationException = (
   context: __SerdeContext
 ): FinalizingOrganizationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1Handshake = (output: any, context: __SerdeContext): Handshake => {
   return {
-    Action: output.Action !== undefined && output.Action !== null ? output.Action : undefined,
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Action: __expectString(output.Action),
+    Arn: __expectString(output.Arn),
     ExpirationTimestamp:
       output.ExpirationTimestamp !== undefined && output.ExpirationTimestamp !== null
         ? new Date(Math.round(output.ExpirationTimestamp * 1000))
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    Id: __expectString(output.Id),
     Parties:
       output.Parties !== undefined && output.Parties !== null
         ? deserializeAws_json1_1HandshakeParties(output.Parties, context)
@@ -8263,7 +8260,7 @@ const deserializeAws_json1_1Handshake = (output: any, context: __SerdeContext): 
       output.Resources !== undefined && output.Resources !== null
         ? deserializeAws_json1_1HandshakeResources(output.Resources, context)
         : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    State: __expectString(output.State),
   } as any;
 };
 
@@ -8272,7 +8269,7 @@ const deserializeAws_json1_1HandshakeAlreadyInStateException = (
   context: __SerdeContext
 ): HandshakeAlreadyInStateException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -8281,8 +8278,8 @@ const deserializeAws_json1_1HandshakeConstraintViolationException = (
   context: __SerdeContext
 ): HandshakeConstraintViolationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Reason: output.Reason !== undefined && output.Reason !== null ? output.Reason : undefined,
+    Message: __expectString(output.Message),
+    Reason: __expectString(output.Reason),
   } as any;
 };
 
@@ -8291,7 +8288,7 @@ const deserializeAws_json1_1HandshakeNotFoundException = (
   context: __SerdeContext
 ): HandshakeNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -8308,8 +8305,8 @@ const deserializeAws_json1_1HandshakeParties = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1HandshakeParty = (output: any, context: __SerdeContext): HandshakeParty => {
   return {
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Id: __expectString(output.Id),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -8319,8 +8316,8 @@ const deserializeAws_json1_1HandshakeResource = (output: any, context: __SerdeCo
       output.Resources !== undefined && output.Resources !== null
         ? deserializeAws_json1_1HandshakeResources(output.Resources, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Type: __expectString(output.Type),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -8351,14 +8348,14 @@ const deserializeAws_json1_1InvalidHandshakeTransitionException = (
   context: __SerdeContext
 ): InvalidHandshakeTransitionException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidInputException = (output: any, context: __SerdeContext): InvalidInputException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Reason: output.Reason !== undefined && output.Reason !== null ? output.Reason : undefined,
+    Message: __expectString(output.Message),
+    Reason: __expectString(output.Reason),
   } as any;
 };
 
@@ -8383,7 +8380,7 @@ const deserializeAws_json1_1ListAccountsForParentResponse = (
       output.Accounts !== undefined && output.Accounts !== null
         ? deserializeAws_json1_1Accounts(output.Accounts, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -8393,7 +8390,7 @@ const deserializeAws_json1_1ListAccountsResponse = (output: any, context: __Serd
       output.Accounts !== undefined && output.Accounts !== null
         ? deserializeAws_json1_1Accounts(output.Accounts, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -8406,7 +8403,7 @@ const deserializeAws_json1_1ListAWSServiceAccessForOrganizationResponse = (
       output.EnabledServicePrincipals !== undefined && output.EnabledServicePrincipals !== null
         ? deserializeAws_json1_1EnabledServicePrincipals(output.EnabledServicePrincipals, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -8416,7 +8413,7 @@ const deserializeAws_json1_1ListChildrenResponse = (output: any, context: __Serd
       output.Children !== undefined && output.Children !== null
         ? deserializeAws_json1_1Children(output.Children, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -8429,7 +8426,7 @@ const deserializeAws_json1_1ListCreateAccountStatusResponse = (
       output.CreateAccountStatuses !== undefined && output.CreateAccountStatuses !== null
         ? deserializeAws_json1_1CreateAccountStatuses(output.CreateAccountStatuses, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -8442,7 +8439,7 @@ const deserializeAws_json1_1ListDelegatedAdministratorsResponse = (
       output.DelegatedAdministrators !== undefined && output.DelegatedAdministrators !== null
         ? deserializeAws_json1_1DelegatedAdministrators(output.DelegatedAdministrators, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -8455,7 +8452,7 @@ const deserializeAws_json1_1ListDelegatedServicesForAccountResponse = (
       output.DelegatedServices !== undefined && output.DelegatedServices !== null
         ? deserializeAws_json1_1DelegatedServices(output.DelegatedServices, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -8468,7 +8465,7 @@ const deserializeAws_json1_1ListHandshakesForAccountResponse = (
       output.Handshakes !== undefined && output.Handshakes !== null
         ? deserializeAws_json1_1Handshakes(output.Handshakes, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -8481,7 +8478,7 @@ const deserializeAws_json1_1ListHandshakesForOrganizationResponse = (
       output.Handshakes !== undefined && output.Handshakes !== null
         ? deserializeAws_json1_1Handshakes(output.Handshakes, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -8490,7 +8487,7 @@ const deserializeAws_json1_1ListOrganizationalUnitsForParentResponse = (
   context: __SerdeContext
 ): ListOrganizationalUnitsForParentResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     OrganizationalUnits:
       output.OrganizationalUnits !== undefined && output.OrganizationalUnits !== null
         ? deserializeAws_json1_1OrganizationalUnits(output.OrganizationalUnits, context)
@@ -8500,7 +8497,7 @@ const deserializeAws_json1_1ListOrganizationalUnitsForParentResponse = (
 
 const deserializeAws_json1_1ListParentsResponse = (output: any, context: __SerdeContext): ListParentsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Parents:
       output.Parents !== undefined && output.Parents !== null
         ? deserializeAws_json1_1Parents(output.Parents, context)
@@ -8513,7 +8510,7 @@ const deserializeAws_json1_1ListPoliciesForTargetResponse = (
   context: __SerdeContext
 ): ListPoliciesForTargetResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Policies:
       output.Policies !== undefined && output.Policies !== null
         ? deserializeAws_json1_1Policies(output.Policies, context)
@@ -8523,7 +8520,7 @@ const deserializeAws_json1_1ListPoliciesForTargetResponse = (
 
 const deserializeAws_json1_1ListPoliciesResponse = (output: any, context: __SerdeContext): ListPoliciesResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Policies:
       output.Policies !== undefined && output.Policies !== null
         ? deserializeAws_json1_1Policies(output.Policies, context)
@@ -8533,7 +8530,7 @@ const deserializeAws_json1_1ListPoliciesResponse = (output: any, context: __Serd
 
 const deserializeAws_json1_1ListRootsResponse = (output: any, context: __SerdeContext): ListRootsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Roots:
       output.Roots !== undefined && output.Roots !== null
         ? deserializeAws_json1_1Roots(output.Roots, context)
@@ -8546,7 +8543,7 @@ const deserializeAws_json1_1ListTagsForResourceResponse = (
   context: __SerdeContext
 ): ListTagsForResourceResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Tags:
       output.Tags !== undefined && output.Tags !== null ? deserializeAws_json1_1Tags(output.Tags, context) : undefined,
   } as any;
@@ -8557,7 +8554,7 @@ const deserializeAws_json1_1ListTargetsForPolicyResponse = (
   context: __SerdeContext
 ): ListTargetsForPolicyResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Targets:
       output.Targets !== undefined && output.Targets !== null
         ? deserializeAws_json1_1PolicyTargets(output.Targets, context)
@@ -8570,7 +8567,7 @@ const deserializeAws_json1_1MalformedPolicyDocumentException = (
   context: __SerdeContext
 ): MalformedPolicyDocumentException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -8579,35 +8576,30 @@ const deserializeAws_json1_1MasterCannotLeaveOrganizationException = (
   context: __SerdeContext
 ): MasterCannotLeaveOrganizationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1Organization = (output: any, context: __SerdeContext): Organization => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     AvailablePolicyTypes:
       output.AvailablePolicyTypes !== undefined && output.AvailablePolicyTypes !== null
         ? deserializeAws_json1_1PolicyTypes(output.AvailablePolicyTypes, context)
         : undefined,
-    FeatureSet: output.FeatureSet !== undefined && output.FeatureSet !== null ? output.FeatureSet : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    MasterAccountArn:
-      output.MasterAccountArn !== undefined && output.MasterAccountArn !== null ? output.MasterAccountArn : undefined,
-    MasterAccountEmail:
-      output.MasterAccountEmail !== undefined && output.MasterAccountEmail !== null
-        ? output.MasterAccountEmail
-        : undefined,
-    MasterAccountId:
-      output.MasterAccountId !== undefined && output.MasterAccountId !== null ? output.MasterAccountId : undefined,
+    FeatureSet: __expectString(output.FeatureSet),
+    Id: __expectString(output.Id),
+    MasterAccountArn: __expectString(output.MasterAccountArn),
+    MasterAccountEmail: __expectString(output.MasterAccountEmail),
+    MasterAccountId: __expectString(output.MasterAccountId),
   } as any;
 };
 
 const deserializeAws_json1_1OrganizationalUnit = (output: any, context: __SerdeContext): OrganizationalUnit => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Arn: __expectString(output.Arn),
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -8616,7 +8608,7 @@ const deserializeAws_json1_1OrganizationalUnitNotEmptyException = (
   context: __SerdeContext
 ): OrganizationalUnitNotEmptyException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -8625,7 +8617,7 @@ const deserializeAws_json1_1OrganizationalUnitNotFoundException = (
   context: __SerdeContext
 ): OrganizationalUnitNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -8645,14 +8637,14 @@ const deserializeAws_json1_1OrganizationNotEmptyException = (
   context: __SerdeContext
 ): OrganizationNotEmptyException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1Parent = (output: any, context: __SerdeContext): Parent => {
   return {
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Id: __expectString(output.Id),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -8661,7 +8653,7 @@ const deserializeAws_json1_1ParentNotFoundException = (
   context: __SerdeContext
 ): ParentNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -8689,7 +8681,7 @@ const deserializeAws_json1_1Policies = (output: any, context: __SerdeContext): P
 
 const deserializeAws_json1_1Policy = (output: any, context: __SerdeContext): Policy => {
   return {
-    Content: output.Content !== undefined && output.Content !== null ? output.Content : undefined,
+    Content: __expectString(output.Content),
     PolicySummary:
       output.PolicySummary !== undefined && output.PolicySummary !== null
         ? deserializeAws_json1_1PolicySummary(output.PolicySummary, context)
@@ -8702,13 +8694,13 @@ const deserializeAws_json1_1PolicyChangesInProgressException = (
   context: __SerdeContext
 ): PolicyChangesInProgressException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1PolicyInUseException = (output: any, context: __SerdeContext): PolicyInUseException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -8717,7 +8709,7 @@ const deserializeAws_json1_1PolicyNotAttachedException = (
   context: __SerdeContext
 ): PolicyNotAttachedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -8726,18 +8718,18 @@ const deserializeAws_json1_1PolicyNotFoundException = (
   context: __SerdeContext
 ): PolicyNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1PolicySummary = (output: any, context: __SerdeContext): PolicySummary => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    AwsManaged: output.AwsManaged !== undefined && output.AwsManaged !== null ? output.AwsManaged : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Arn: __expectString(output.Arn),
+    AwsManaged: __expectBoolean(output.AwsManaged),
+    Description: __expectString(output.Description),
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -8754,10 +8746,10 @@ const deserializeAws_json1_1PolicyTargets = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1PolicyTargetSummary = (output: any, context: __SerdeContext): PolicyTargetSummary => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    TargetId: output.TargetId !== undefined && output.TargetId !== null ? output.TargetId : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Arn: __expectString(output.Arn),
+    Name: __expectString(output.Name),
+    TargetId: __expectString(output.TargetId),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -8766,7 +8758,7 @@ const deserializeAws_json1_1PolicyTypeAlreadyEnabledException = (
   context: __SerdeContext
 ): PolicyTypeAlreadyEnabledException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -8775,7 +8767,7 @@ const deserializeAws_json1_1PolicyTypeNotAvailableForOrganizationException = (
   context: __SerdeContext
 ): PolicyTypeNotAvailableForOrganizationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -8784,7 +8776,7 @@ const deserializeAws_json1_1PolicyTypeNotEnabledException = (
   context: __SerdeContext
 ): PolicyTypeNotEnabledException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -8801,16 +8793,16 @@ const deserializeAws_json1_1PolicyTypes = (output: any, context: __SerdeContext)
 
 const deserializeAws_json1_1PolicyTypeSummary = (output: any, context: __SerdeContext): PolicyTypeSummary => {
   return {
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Status: __expectString(output.Status),
+    Type: __expectString(output.Type),
   } as any;
 };
 
 const deserializeAws_json1_1Root = (output: any, context: __SerdeContext): Root => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Arn: __expectString(output.Arn),
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
     PolicyTypes:
       output.PolicyTypes !== undefined && output.PolicyTypes !== null
         ? deserializeAws_json1_1PolicyTypes(output.PolicyTypes, context)
@@ -8820,7 +8812,7 @@ const deserializeAws_json1_1Root = (output: any, context: __SerdeContext): Root 
 
 const deserializeAws_json1_1RootNotFoundException = (output: any, context: __SerdeContext): RootNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -8837,7 +8829,7 @@ const deserializeAws_json1_1Roots = (output: any, context: __SerdeContext): Root
 
 const deserializeAws_json1_1ServiceException = (output: any, context: __SerdeContext): ServiceException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -8846,14 +8838,14 @@ const deserializeAws_json1_1SourceParentNotFoundException = (
   context: __SerdeContext
 ): SourceParentNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -8873,7 +8865,7 @@ const deserializeAws_json1_1TargetNotFoundException = (
   context: __SerdeContext
 ): TargetNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -8882,8 +8874,8 @@ const deserializeAws_json1_1TooManyRequestsException = (
   context: __SerdeContext
 ): TooManyRequestsException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Message: __expectString(output.Message),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -8892,7 +8884,7 @@ const deserializeAws_json1_1UnsupportedAPIEndpointException = (
   context: __SerdeContext
 ): UnsupportedAPIEndpointException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 

--- a/clients/client-outposts/protocols/Aws_restJson1.ts
+++ b/clients/client-outposts/protocols/Aws_restJson1.ts
@@ -28,6 +28,7 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -685,13 +686,13 @@ export const deserializeAws_restJson1GetOutpostInstanceTypesCommand = async (
     contents.InstanceTypes = deserializeAws_restJson1InstanceTypeListDefinition(data.InstanceTypes, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.OutpostArn !== undefined && data.OutpostArn !== null) {
-    contents.OutpostArn = data.OutpostArn;
+    contents.OutpostArn = __expectString(data.OutpostArn);
   }
   if (data.OutpostId !== undefined && data.OutpostId !== null) {
-    contents.OutpostId = data.OutpostId;
+    contents.OutpostId = __expectString(data.OutpostId);
   }
   return Promise.resolve(contents);
 };
@@ -771,7 +772,7 @@ export const deserializeAws_restJson1ListOutpostsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Outposts !== undefined && data.Outposts !== null) {
     contents.Outposts = deserializeAws_restJson1outpostListDefinition(data.Outposts, context);
@@ -846,7 +847,7 @@ export const deserializeAws_restJson1ListSitesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Sites !== undefined && data.Sites !== null) {
     contents.Sites = deserializeAws_restJson1siteListDefinition(data.Sites, context);
@@ -1124,7 +1125,7 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1143,13 +1144,13 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.ResourceId !== undefined && data.ResourceId !== null) {
-    contents.ResourceId = data.ResourceId;
+    contents.ResourceId = __expectString(data.ResourceId);
   }
   if (data.ResourceType !== undefined && data.ResourceType !== null) {
-    contents.ResourceType = data.ResourceType;
+    contents.ResourceType = __expectString(data.ResourceType);
   }
   return contents;
 };
@@ -1166,7 +1167,7 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1183,7 +1184,7 @@ const deserializeAws_restJson1NotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1200,7 +1201,7 @@ const deserializeAws_restJson1ServiceQuotaExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1217,7 +1218,7 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1236,7 +1237,7 @@ const serializeAws_restJson1TagMap = (input: { [key: string]: string }, context:
 
 const deserializeAws_restJson1InstanceTypeItem = (output: any, context: __SerdeContext): InstanceTypeItem => {
   return {
-    InstanceType: output.InstanceType !== undefined && output.InstanceType !== null ? output.InstanceType : undefined,
+    InstanceType: __expectString(output.InstanceType),
   } as any;
 };
 
@@ -1256,21 +1257,16 @@ const deserializeAws_restJson1InstanceTypeListDefinition = (
 
 const deserializeAws_restJson1Outpost = (output: any, context: __SerdeContext): Outpost => {
   return {
-    AvailabilityZone:
-      output.AvailabilityZone !== undefined && output.AvailabilityZone !== null ? output.AvailabilityZone : undefined,
-    AvailabilityZoneId:
-      output.AvailabilityZoneId !== undefined && output.AvailabilityZoneId !== null
-        ? output.AvailabilityZoneId
-        : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    LifeCycleStatus:
-      output.LifeCycleStatus !== undefined && output.LifeCycleStatus !== null ? output.LifeCycleStatus : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    OutpostArn: output.OutpostArn !== undefined && output.OutpostArn !== null ? output.OutpostArn : undefined,
-    OutpostId: output.OutpostId !== undefined && output.OutpostId !== null ? output.OutpostId : undefined,
-    OwnerId: output.OwnerId !== undefined && output.OwnerId !== null ? output.OwnerId : undefined,
-    SiteArn: output.SiteArn !== undefined && output.SiteArn !== null ? output.SiteArn : undefined,
-    SiteId: output.SiteId !== undefined && output.SiteId !== null ? output.SiteId : undefined,
+    AvailabilityZone: __expectString(output.AvailabilityZone),
+    AvailabilityZoneId: __expectString(output.AvailabilityZoneId),
+    Description: __expectString(output.Description),
+    LifeCycleStatus: __expectString(output.LifeCycleStatus),
+    Name: __expectString(output.Name),
+    OutpostArn: __expectString(output.OutpostArn),
+    OutpostId: __expectString(output.OutpostId),
+    OwnerId: __expectString(output.OwnerId),
+    SiteArn: __expectString(output.SiteArn),
+    SiteId: __expectString(output.SiteId),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_restJson1TagMap(output.Tags, context)
@@ -1291,11 +1287,11 @@ const deserializeAws_restJson1outpostListDefinition = (output: any, context: __S
 
 const deserializeAws_restJson1Site = (output: any, context: __SerdeContext): Site => {
   return {
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    SiteArn: output.SiteArn !== undefined && output.SiteArn !== null ? output.SiteArn : undefined,
-    SiteId: output.SiteId !== undefined && output.SiteId !== null ? output.SiteId : undefined,
+    AccountId: __expectString(output.AccountId),
+    Description: __expectString(output.Description),
+    Name: __expectString(output.Name),
+    SiteArn: __expectString(output.SiteArn),
+    SiteId: __expectString(output.SiteId),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_restJson1TagMap(output.Tags, context)
@@ -1321,7 +1317,7 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };

--- a/clients/client-personalize-events/protocols/Aws_restJson1.ts
+++ b/clients/client-personalize-events/protocols/Aws_restJson1.ts
@@ -10,7 +10,11 @@ import {
   User,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { LazyJsonString as __LazyJsonString, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  LazyJsonString as __LazyJsonString,
+  SmithyException as __SmithyException,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -295,7 +299,7 @@ const deserializeAws_restJson1InvalidInputExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -312,7 +316,7 @@ const deserializeAws_restJson1ResourceInUseExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -329,7 +333,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };

--- a/clients/client-personalize-runtime/protocols/Aws_restJson1.ts
+++ b/clients/client-personalize-runtime/protocols/Aws_restJson1.ts
@@ -5,7 +5,11 @@ import {
 import { GetRecommendationsCommandInput, GetRecommendationsCommandOutput } from "../commands/GetRecommendationsCommand";
 import { InvalidInputException, PredictedItem, ResourceNotFoundException } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -94,7 +98,7 @@ export const deserializeAws_restJson1GetPersonalizedRankingCommand = async (
     contents.personalizedRanking = deserializeAws_restJson1ItemList(data.personalizedRanking, context);
   }
   if (data.recommendationId !== undefined && data.recommendationId !== null) {
-    contents.recommendationId = data.recommendationId;
+    contents.recommendationId = __expectString(data.recommendationId);
   }
   return Promise.resolve(contents);
 };
@@ -161,7 +165,7 @@ export const deserializeAws_restJson1GetRecommendationsCommand = async (
     contents.itemList = deserializeAws_restJson1ItemList(data.itemList, context);
   }
   if (data.recommendationId !== undefined && data.recommendationId !== null) {
-    contents.recommendationId = data.recommendationId;
+    contents.recommendationId = __expectString(data.recommendationId);
   }
   return Promise.resolve(contents);
 };
@@ -223,7 +227,7 @@ const deserializeAws_restJson1InvalidInputExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -240,7 +244,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -293,8 +297,8 @@ const deserializeAws_restJson1ItemList = (output: any, context: __SerdeContext):
 
 const deserializeAws_restJson1PredictedItem = (output: any, context: __SerdeContext): PredictedItem => {
   return {
-    itemId: output.itemId !== undefined && output.itemId !== null ? output.itemId : undefined,
-    score: output.score !== undefined && output.score !== null ? output.score : undefined,
+    itemId: __expectString(output.itemId),
+    score: __expectNumber(output.score),
   } as any;
 };
 

--- a/clients/client-personalize/protocols/Aws_json1_1.ts
+++ b/clients/client-personalize/protocols/Aws_json1_1.ts
@@ -239,7 +239,12 @@ import {
   UpdateCampaignResponse,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -4859,7 +4864,7 @@ const serializeAws_json1_1UpdateCampaignRequest = (input: UpdateCampaignRequest,
 
 const deserializeAws_json1_1Algorithm = (output: any, context: __SerdeContext): Algorithm => {
   return {
-    algorithmArn: output.algorithmArn !== undefined && output.algorithmArn !== null ? output.algorithmArn : undefined,
+    algorithmArn: __expectString(output.algorithmArn),
     algorithmImage:
       output.algorithmImage !== undefined && output.algorithmImage !== null
         ? deserializeAws_json1_1AlgorithmImage(output.algorithmImage, context)
@@ -4884,19 +4889,16 @@ const deserializeAws_json1_1Algorithm = (output: any, context: __SerdeContext): 
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
         ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
-    trainingInputMode:
-      output.trainingInputMode !== undefined && output.trainingInputMode !== null
-        ? output.trainingInputMode
-        : undefined,
+    name: __expectString(output.name),
+    roleArn: __expectString(output.roleArn),
+    trainingInputMode: __expectString(output.trainingInputMode),
   } as any;
 };
 
 const deserializeAws_json1_1AlgorithmImage = (output: any, context: __SerdeContext): AlgorithmImage => {
   return {
-    dockerURI: output.dockerURI !== undefined && output.dockerURI !== null ? output.dockerURI : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    dockerURI: __expectString(output.dockerURI),
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -4907,13 +4909,13 @@ const deserializeAws_json1_1ArnList = (output: any, context: __SerdeContext): st
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1AutoMLConfig = (output: any, context: __SerdeContext): AutoMLConfig => {
   return {
-    metricName: output.metricName !== undefined && output.metricName !== null ? output.metricName : undefined,
+    metricName: __expectString(output.metricName),
     recipeList:
       output.recipeList !== undefined && output.recipeList !== null
         ? deserializeAws_json1_1ArnList(output.recipeList, context)
@@ -4923,17 +4925,13 @@ const deserializeAws_json1_1AutoMLConfig = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_1AutoMLResult = (output: any, context: __SerdeContext): AutoMLResult => {
   return {
-    bestRecipeArn:
-      output.bestRecipeArn !== undefined && output.bestRecipeArn !== null ? output.bestRecipeArn : undefined,
+    bestRecipeArn: __expectString(output.bestRecipeArn),
   } as any;
 };
 
 const deserializeAws_json1_1BatchInferenceJob = (output: any, context: __SerdeContext): BatchInferenceJob => {
   return {
-    batchInferenceJobArn:
-      output.batchInferenceJobArn !== undefined && output.batchInferenceJobArn !== null
-        ? output.batchInferenceJobArn
-        : undefined,
+    batchInferenceJobArn: __expectString(output.batchInferenceJobArn),
     batchInferenceJobConfig:
       output.batchInferenceJobConfig !== undefined && output.batchInferenceJobConfig !== null
         ? deserializeAws_json1_1BatchInferenceJobConfig(output.batchInferenceJobConfig, context)
@@ -4942,14 +4940,13 @@ const deserializeAws_json1_1BatchInferenceJob = (output: any, context: __SerdeCo
       output.creationDateTime !== undefined && output.creationDateTime !== null
         ? new Date(Math.round(output.creationDateTime * 1000))
         : undefined,
-    failureReason:
-      output.failureReason !== undefined && output.failureReason !== null ? output.failureReason : undefined,
-    filterArn: output.filterArn !== undefined && output.filterArn !== null ? output.filterArn : undefined,
+    failureReason: __expectString(output.failureReason),
+    filterArn: __expectString(output.filterArn),
     jobInput:
       output.jobInput !== undefined && output.jobInput !== null
         ? deserializeAws_json1_1BatchInferenceJobInput(output.jobInput, context)
         : undefined,
-    jobName: output.jobName !== undefined && output.jobName !== null ? output.jobName : undefined,
+    jobName: __expectString(output.jobName),
     jobOutput:
       output.jobOutput !== undefined && output.jobOutput !== null
         ? deserializeAws_json1_1BatchInferenceJobOutput(output.jobOutput, context)
@@ -4958,13 +4955,10 @@ const deserializeAws_json1_1BatchInferenceJob = (output: any, context: __SerdeCo
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
         ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
         : undefined,
-    numResults: output.numResults !== undefined && output.numResults !== null ? output.numResults : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
-    solutionVersionArn:
-      output.solutionVersionArn !== undefined && output.solutionVersionArn !== null
-        ? output.solutionVersionArn
-        : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    numResults: __expectNumber(output.numResults),
+    roleArn: __expectString(output.roleArn),
+    solutionVersionArn: __expectString(output.solutionVersionArn),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -5017,32 +5011,25 @@ const deserializeAws_json1_1BatchInferenceJobSummary = (
   context: __SerdeContext
 ): BatchInferenceJobSummary => {
   return {
-    batchInferenceJobArn:
-      output.batchInferenceJobArn !== undefined && output.batchInferenceJobArn !== null
-        ? output.batchInferenceJobArn
-        : undefined,
+    batchInferenceJobArn: __expectString(output.batchInferenceJobArn),
     creationDateTime:
       output.creationDateTime !== undefined && output.creationDateTime !== null
         ? new Date(Math.round(output.creationDateTime * 1000))
         : undefined,
-    failureReason:
-      output.failureReason !== undefined && output.failureReason !== null ? output.failureReason : undefined,
-    jobName: output.jobName !== undefined && output.jobName !== null ? output.jobName : undefined,
+    failureReason: __expectString(output.failureReason),
+    jobName: __expectString(output.jobName),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
         ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
         : undefined,
-    solutionVersionArn:
-      output.solutionVersionArn !== undefined && output.solutionVersionArn !== null
-        ? output.solutionVersionArn
-        : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    solutionVersionArn: __expectString(output.solutionVersionArn),
+    status: __expectString(output.status),
   } as any;
 };
 
 const deserializeAws_json1_1Campaign = (output: any, context: __SerdeContext): Campaign => {
   return {
-    campaignArn: output.campaignArn !== undefined && output.campaignArn !== null ? output.campaignArn : undefined,
+    campaignArn: __expectString(output.campaignArn),
     campaignConfig:
       output.campaignConfig !== undefined && output.campaignConfig !== null
         ? deserializeAws_json1_1CampaignConfig(output.campaignConfig, context)
@@ -5051,8 +5038,7 @@ const deserializeAws_json1_1Campaign = (output: any, context: __SerdeContext): C
       output.creationDateTime !== undefined && output.creationDateTime !== null
         ? new Date(Math.round(output.creationDateTime * 1000))
         : undefined,
-    failureReason:
-      output.failureReason !== undefined && output.failureReason !== null ? output.failureReason : undefined,
+    failureReason: __expectString(output.failureReason),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
         ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
@@ -5061,16 +5047,10 @@ const deserializeAws_json1_1Campaign = (output: any, context: __SerdeContext): C
       output.latestCampaignUpdate !== undefined && output.latestCampaignUpdate !== null
         ? deserializeAws_json1_1CampaignUpdateSummary(output.latestCampaignUpdate, context)
         : undefined,
-    minProvisionedTPS:
-      output.minProvisionedTPS !== undefined && output.minProvisionedTPS !== null
-        ? output.minProvisionedTPS
-        : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    solutionVersionArn:
-      output.solutionVersionArn !== undefined && output.solutionVersionArn !== null
-        ? output.solutionVersionArn
-        : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    minProvisionedTPS: __expectNumber(output.minProvisionedTPS),
+    name: __expectString(output.name),
+    solutionVersionArn: __expectString(output.solutionVersionArn),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -5096,19 +5076,18 @@ const deserializeAws_json1_1Campaigns = (output: any, context: __SerdeContext): 
 
 const deserializeAws_json1_1CampaignSummary = (output: any, context: __SerdeContext): CampaignSummary => {
   return {
-    campaignArn: output.campaignArn !== undefined && output.campaignArn !== null ? output.campaignArn : undefined,
+    campaignArn: __expectString(output.campaignArn),
     creationDateTime:
       output.creationDateTime !== undefined && output.creationDateTime !== null
         ? new Date(Math.round(output.creationDateTime * 1000))
         : undefined,
-    failureReason:
-      output.failureReason !== undefined && output.failureReason !== null ? output.failureReason : undefined,
+    failureReason: __expectString(output.failureReason),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
         ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    name: __expectString(output.name),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -5122,21 +5101,14 @@ const deserializeAws_json1_1CampaignUpdateSummary = (output: any, context: __Ser
       output.creationDateTime !== undefined && output.creationDateTime !== null
         ? new Date(Math.round(output.creationDateTime * 1000))
         : undefined,
-    failureReason:
-      output.failureReason !== undefined && output.failureReason !== null ? output.failureReason : undefined,
+    failureReason: __expectString(output.failureReason),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
         ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
         : undefined,
-    minProvisionedTPS:
-      output.minProvisionedTPS !== undefined && output.minProvisionedTPS !== null
-        ? output.minProvisionedTPS
-        : undefined,
-    solutionVersionArn:
-      output.solutionVersionArn !== undefined && output.solutionVersionArn !== null
-        ? output.solutionVersionArn
-        : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    minProvisionedTPS: __expectNumber(output.minProvisionedTPS),
+    solutionVersionArn: __expectString(output.solutionVersionArn),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -5145,7 +5117,7 @@ const deserializeAws_json1_1CategoricalHyperParameterRange = (
   context: __SerdeContext
 ): CategoricalHyperParameterRange => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
     values:
       output.values !== undefined && output.values !== null
         ? deserializeAws_json1_1CategoricalValues(output.values, context)
@@ -5174,7 +5146,7 @@ const deserializeAws_json1_1CategoricalValues = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -5183,9 +5155,9 @@ const deserializeAws_json1_1ContinuousHyperParameterRange = (
   context: __SerdeContext
 ): ContinuousHyperParameterRange => {
   return {
-    maxValue: output.maxValue !== undefined && output.maxValue !== null ? output.maxValue : undefined,
-    minValue: output.minValue !== undefined && output.minValue !== null ? output.minValue : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    maxValue: __expectNumber(output.maxValue),
+    minValue: __expectNumber(output.minValue),
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -5208,16 +5180,13 @@ const deserializeAws_json1_1CreateBatchInferenceJobResponse = (
   context: __SerdeContext
 ): CreateBatchInferenceJobResponse => {
   return {
-    batchInferenceJobArn:
-      output.batchInferenceJobArn !== undefined && output.batchInferenceJobArn !== null
-        ? output.batchInferenceJobArn
-        : undefined,
+    batchInferenceJobArn: __expectString(output.batchInferenceJobArn),
   } as any;
 };
 
 const deserializeAws_json1_1CreateCampaignResponse = (output: any, context: __SerdeContext): CreateCampaignResponse => {
   return {
-    campaignArn: output.campaignArn !== undefined && output.campaignArn !== null ? output.campaignArn : undefined,
+    campaignArn: __expectString(output.campaignArn),
   } as any;
 };
 
@@ -5226,10 +5195,7 @@ const deserializeAws_json1_1CreateDatasetExportJobResponse = (
   context: __SerdeContext
 ): CreateDatasetExportJobResponse => {
   return {
-    datasetExportJobArn:
-      output.datasetExportJobArn !== undefined && output.datasetExportJobArn !== null
-        ? output.datasetExportJobArn
-        : undefined,
+    datasetExportJobArn: __expectString(output.datasetExportJobArn),
   } as any;
 };
 
@@ -5238,8 +5204,7 @@ const deserializeAws_json1_1CreateDatasetGroupResponse = (
   context: __SerdeContext
 ): CreateDatasetGroupResponse => {
   return {
-    datasetGroupArn:
-      output.datasetGroupArn !== undefined && output.datasetGroupArn !== null ? output.datasetGroupArn : undefined,
+    datasetGroupArn: __expectString(output.datasetGroupArn),
   } as any;
 };
 
@@ -5248,16 +5213,13 @@ const deserializeAws_json1_1CreateDatasetImportJobResponse = (
   context: __SerdeContext
 ): CreateDatasetImportJobResponse => {
   return {
-    datasetImportJobArn:
-      output.datasetImportJobArn !== undefined && output.datasetImportJobArn !== null
-        ? output.datasetImportJobArn
-        : undefined,
+    datasetImportJobArn: __expectString(output.datasetImportJobArn),
   } as any;
 };
 
 const deserializeAws_json1_1CreateDatasetResponse = (output: any, context: __SerdeContext): CreateDatasetResponse => {
   return {
-    datasetArn: output.datasetArn !== undefined && output.datasetArn !== null ? output.datasetArn : undefined,
+    datasetArn: __expectString(output.datasetArn),
   } as any;
 };
 
@@ -5266,27 +5228,26 @@ const deserializeAws_json1_1CreateEventTrackerResponse = (
   context: __SerdeContext
 ): CreateEventTrackerResponse => {
   return {
-    eventTrackerArn:
-      output.eventTrackerArn !== undefined && output.eventTrackerArn !== null ? output.eventTrackerArn : undefined,
-    trackingId: output.trackingId !== undefined && output.trackingId !== null ? output.trackingId : undefined,
+    eventTrackerArn: __expectString(output.eventTrackerArn),
+    trackingId: __expectString(output.trackingId),
   } as any;
 };
 
 const deserializeAws_json1_1CreateFilterResponse = (output: any, context: __SerdeContext): CreateFilterResponse => {
   return {
-    filterArn: output.filterArn !== undefined && output.filterArn !== null ? output.filterArn : undefined,
+    filterArn: __expectString(output.filterArn),
   } as any;
 };
 
 const deserializeAws_json1_1CreateSchemaResponse = (output: any, context: __SerdeContext): CreateSchemaResponse => {
   return {
-    schemaArn: output.schemaArn !== undefined && output.schemaArn !== null ? output.schemaArn : undefined,
+    schemaArn: __expectString(output.schemaArn),
   } as any;
 };
 
 const deserializeAws_json1_1CreateSolutionResponse = (output: any, context: __SerdeContext): CreateSolutionResponse => {
   return {
-    solutionArn: output.solutionArn !== undefined && output.solutionArn !== null ? output.solutionArn : undefined,
+    solutionArn: __expectString(output.solutionArn),
   } as any;
 };
 
@@ -5295,10 +5256,7 @@ const deserializeAws_json1_1CreateSolutionVersionResponse = (
   context: __SerdeContext
 ): CreateSolutionVersionResponse => {
   return {
-    solutionVersionArn:
-      output.solutionVersionArn !== undefined && output.solutionVersionArn !== null
-        ? output.solutionVersionArn
-        : undefined,
+    solutionVersionArn: __expectString(output.solutionVersionArn),
   } as any;
 };
 
@@ -5308,17 +5266,16 @@ const deserializeAws_json1_1Dataset = (output: any, context: __SerdeContext): Da
       output.creationDateTime !== undefined && output.creationDateTime !== null
         ? new Date(Math.round(output.creationDateTime * 1000))
         : undefined,
-    datasetArn: output.datasetArn !== undefined && output.datasetArn !== null ? output.datasetArn : undefined,
-    datasetGroupArn:
-      output.datasetGroupArn !== undefined && output.datasetGroupArn !== null ? output.datasetGroupArn : undefined,
-    datasetType: output.datasetType !== undefined && output.datasetType !== null ? output.datasetType : undefined,
+    datasetArn: __expectString(output.datasetArn),
+    datasetGroupArn: __expectString(output.datasetGroupArn),
+    datasetType: __expectString(output.datasetType),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
         ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    schemaArn: output.schemaArn !== undefined && output.schemaArn !== null ? output.schemaArn : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    name: __expectString(output.name),
+    schemaArn: __expectString(output.schemaArn),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -5328,16 +5285,11 @@ const deserializeAws_json1_1DatasetExportJob = (output: any, context: __SerdeCon
       output.creationDateTime !== undefined && output.creationDateTime !== null
         ? new Date(Math.round(output.creationDateTime * 1000))
         : undefined,
-    datasetArn: output.datasetArn !== undefined && output.datasetArn !== null ? output.datasetArn : undefined,
-    datasetExportJobArn:
-      output.datasetExportJobArn !== undefined && output.datasetExportJobArn !== null
-        ? output.datasetExportJobArn
-        : undefined,
-    failureReason:
-      output.failureReason !== undefined && output.failureReason !== null ? output.failureReason : undefined,
-    ingestionMode:
-      output.ingestionMode !== undefined && output.ingestionMode !== null ? output.ingestionMode : undefined,
-    jobName: output.jobName !== undefined && output.jobName !== null ? output.jobName : undefined,
+    datasetArn: __expectString(output.datasetArn),
+    datasetExportJobArn: __expectString(output.datasetExportJobArn),
+    failureReason: __expectString(output.failureReason),
+    ingestionMode: __expectString(output.ingestionMode),
+    jobName: __expectString(output.jobName),
     jobOutput:
       output.jobOutput !== undefined && output.jobOutput !== null
         ? deserializeAws_json1_1DatasetExportJobOutput(output.jobOutput, context)
@@ -5346,8 +5298,8 @@ const deserializeAws_json1_1DatasetExportJob = (output: any, context: __SerdeCon
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
         ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
         : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    roleArn: __expectString(output.roleArn),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -5380,18 +5332,14 @@ const deserializeAws_json1_1DatasetExportJobSummary = (
       output.creationDateTime !== undefined && output.creationDateTime !== null
         ? new Date(Math.round(output.creationDateTime * 1000))
         : undefined,
-    datasetExportJobArn:
-      output.datasetExportJobArn !== undefined && output.datasetExportJobArn !== null
-        ? output.datasetExportJobArn
-        : undefined,
-    failureReason:
-      output.failureReason !== undefined && output.failureReason !== null ? output.failureReason : undefined,
-    jobName: output.jobName !== undefined && output.jobName !== null ? output.jobName : undefined,
+    datasetExportJobArn: __expectString(output.datasetExportJobArn),
+    failureReason: __expectString(output.failureReason),
+    jobName: __expectString(output.jobName),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
         ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -5401,18 +5349,16 @@ const deserializeAws_json1_1DatasetGroup = (output: any, context: __SerdeContext
       output.creationDateTime !== undefined && output.creationDateTime !== null
         ? new Date(Math.round(output.creationDateTime * 1000))
         : undefined,
-    datasetGroupArn:
-      output.datasetGroupArn !== undefined && output.datasetGroupArn !== null ? output.datasetGroupArn : undefined,
-    failureReason:
-      output.failureReason !== undefined && output.failureReason !== null ? output.failureReason : undefined,
-    kmsKeyArn: output.kmsKeyArn !== undefined && output.kmsKeyArn !== null ? output.kmsKeyArn : undefined,
+    datasetGroupArn: __expectString(output.datasetGroupArn),
+    failureReason: __expectString(output.failureReason),
+    kmsKeyArn: __expectString(output.kmsKeyArn),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
         ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    name: __expectString(output.name),
+    roleArn: __expectString(output.roleArn),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -5433,16 +5379,14 @@ const deserializeAws_json1_1DatasetGroupSummary = (output: any, context: __Serde
       output.creationDateTime !== undefined && output.creationDateTime !== null
         ? new Date(Math.round(output.creationDateTime * 1000))
         : undefined,
-    datasetGroupArn:
-      output.datasetGroupArn !== undefined && output.datasetGroupArn !== null ? output.datasetGroupArn : undefined,
-    failureReason:
-      output.failureReason !== undefined && output.failureReason !== null ? output.failureReason : undefined,
+    datasetGroupArn: __expectString(output.datasetGroupArn),
+    failureReason: __expectString(output.failureReason),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
         ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    name: __expectString(output.name),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -5456,20 +5400,16 @@ const deserializeAws_json1_1DatasetImportJob = (output: any, context: __SerdeCon
       output.dataSource !== undefined && output.dataSource !== null
         ? deserializeAws_json1_1DataSource(output.dataSource, context)
         : undefined,
-    datasetArn: output.datasetArn !== undefined && output.datasetArn !== null ? output.datasetArn : undefined,
-    datasetImportJobArn:
-      output.datasetImportJobArn !== undefined && output.datasetImportJobArn !== null
-        ? output.datasetImportJobArn
-        : undefined,
-    failureReason:
-      output.failureReason !== undefined && output.failureReason !== null ? output.failureReason : undefined,
-    jobName: output.jobName !== undefined && output.jobName !== null ? output.jobName : undefined,
+    datasetArn: __expectString(output.datasetArn),
+    datasetImportJobArn: __expectString(output.datasetImportJobArn),
+    failureReason: __expectString(output.failureReason),
+    jobName: __expectString(output.jobName),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
         ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
         : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    roleArn: __expectString(output.roleArn),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -5493,18 +5433,14 @@ const deserializeAws_json1_1DatasetImportJobSummary = (
       output.creationDateTime !== undefined && output.creationDateTime !== null
         ? new Date(Math.round(output.creationDateTime * 1000))
         : undefined,
-    datasetImportJobArn:
-      output.datasetImportJobArn !== undefined && output.datasetImportJobArn !== null
-        ? output.datasetImportJobArn
-        : undefined,
-    failureReason:
-      output.failureReason !== undefined && output.failureReason !== null ? output.failureReason : undefined,
-    jobName: output.jobName !== undefined && output.jobName !== null ? output.jobName : undefined,
+    datasetImportJobArn: __expectString(output.datasetImportJobArn),
+    failureReason: __expectString(output.failureReason),
+    jobName: __expectString(output.jobName),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
         ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -5529,9 +5465,9 @@ const deserializeAws_json1_1DatasetSchema = (output: any, context: __SerdeContex
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
         ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    schema: output.schema !== undefined && output.schema !== null ? output.schema : undefined,
-    schemaArn: output.schemaArn !== undefined && output.schemaArn !== null ? output.schemaArn : undefined,
+    name: __expectString(output.name),
+    schema: __expectString(output.schema),
+    schemaArn: __expectString(output.schemaArn),
   } as any;
 };
 
@@ -5545,8 +5481,8 @@ const deserializeAws_json1_1DatasetSchemaSummary = (output: any, context: __Serd
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
         ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    schemaArn: output.schemaArn !== undefined && output.schemaArn !== null ? output.schemaArn : undefined,
+    name: __expectString(output.name),
+    schemaArn: __expectString(output.schemaArn),
   } as any;
 };
 
@@ -5556,20 +5492,20 @@ const deserializeAws_json1_1DatasetSummary = (output: any, context: __SerdeConte
       output.creationDateTime !== undefined && output.creationDateTime !== null
         ? new Date(Math.round(output.creationDateTime * 1000))
         : undefined,
-    datasetArn: output.datasetArn !== undefined && output.datasetArn !== null ? output.datasetArn : undefined,
-    datasetType: output.datasetType !== undefined && output.datasetType !== null ? output.datasetType : undefined,
+    datasetArn: __expectString(output.datasetArn),
+    datasetType: __expectString(output.datasetType),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
         ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    name: __expectString(output.name),
+    status: __expectString(output.status),
   } as any;
 };
 
 const deserializeAws_json1_1DataSource = (output: any, context: __SerdeContext): DataSource => {
   return {
-    dataLocation: output.dataLocation !== undefined && output.dataLocation !== null ? output.dataLocation : undefined,
+    dataLocation: __expectString(output.dataLocation),
   } as any;
 };
 
@@ -5578,8 +5514,8 @@ const deserializeAws_json1_1DefaultCategoricalHyperParameterRange = (
   context: __SerdeContext
 ): DefaultCategoricalHyperParameterRange => {
   return {
-    isTunable: output.isTunable !== undefined && output.isTunable !== null ? output.isTunable : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    isTunable: __expectBoolean(output.isTunable),
+    name: __expectString(output.name),
     values:
       output.values !== undefined && output.values !== null
         ? deserializeAws_json1_1CategoricalValues(output.values, context)
@@ -5606,10 +5542,10 @@ const deserializeAws_json1_1DefaultContinuousHyperParameterRange = (
   context: __SerdeContext
 ): DefaultContinuousHyperParameterRange => {
   return {
-    isTunable: output.isTunable !== undefined && output.isTunable !== null ? output.isTunable : undefined,
-    maxValue: output.maxValue !== undefined && output.maxValue !== null ? output.maxValue : undefined,
-    minValue: output.minValue !== undefined && output.minValue !== null ? output.minValue : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    isTunable: __expectBoolean(output.isTunable),
+    maxValue: __expectNumber(output.maxValue),
+    minValue: __expectNumber(output.minValue),
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -5652,10 +5588,10 @@ const deserializeAws_json1_1DefaultIntegerHyperParameterRange = (
   context: __SerdeContext
 ): DefaultIntegerHyperParameterRange => {
   return {
-    isTunable: output.isTunable !== undefined && output.isTunable !== null ? output.isTunable : undefined,
-    maxValue: output.maxValue !== undefined && output.maxValue !== null ? output.maxValue : undefined,
-    minValue: output.minValue !== undefined && output.minValue !== null ? output.minValue : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    isTunable: __expectBoolean(output.isTunable),
+    maxValue: __expectNumber(output.maxValue),
+    minValue: __expectNumber(output.minValue),
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -5834,22 +5770,20 @@ const deserializeAws_json1_1DescribeSolutionVersionResponse = (
 
 const deserializeAws_json1_1EventTracker = (output: any, context: __SerdeContext): EventTracker => {
   return {
-    accountId: output.accountId !== undefined && output.accountId !== null ? output.accountId : undefined,
+    accountId: __expectString(output.accountId),
     creationDateTime:
       output.creationDateTime !== undefined && output.creationDateTime !== null
         ? new Date(Math.round(output.creationDateTime * 1000))
         : undefined,
-    datasetGroupArn:
-      output.datasetGroupArn !== undefined && output.datasetGroupArn !== null ? output.datasetGroupArn : undefined,
-    eventTrackerArn:
-      output.eventTrackerArn !== undefined && output.eventTrackerArn !== null ? output.eventTrackerArn : undefined,
+    datasetGroupArn: __expectString(output.datasetGroupArn),
+    eventTrackerArn: __expectString(output.eventTrackerArn),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
         ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    trackingId: output.trackingId !== undefined && output.trackingId !== null ? output.trackingId : undefined,
+    name: __expectString(output.name),
+    status: __expectString(output.status),
+    trackingId: __expectString(output.trackingId),
   } as any;
 };
 
@@ -5870,14 +5804,13 @@ const deserializeAws_json1_1EventTrackerSummary = (output: any, context: __Serde
       output.creationDateTime !== undefined && output.creationDateTime !== null
         ? new Date(Math.round(output.creationDateTime * 1000))
         : undefined,
-    eventTrackerArn:
-      output.eventTrackerArn !== undefined && output.eventTrackerArn !== null ? output.eventTrackerArn : undefined,
+    eventTrackerArn: __expectString(output.eventTrackerArn),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
         ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    name: __expectString(output.name),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -5891,16 +5824,13 @@ const deserializeAws_json1_1FeatureTransformation = (output: any, context: __Ser
       output.defaultParameters !== undefined && output.defaultParameters !== null
         ? deserializeAws_json1_1FeaturizationParameters(output.defaultParameters, context)
         : undefined,
-    featureTransformationArn:
-      output.featureTransformationArn !== undefined && output.featureTransformationArn !== null
-        ? output.featureTransformationArn
-        : undefined,
+    featureTransformationArn: __expectString(output.featureTransformationArn),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
         ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    name: __expectString(output.name),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -5914,7 +5844,7 @@ const deserializeAws_json1_1FeatureTransformationParameters = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -5929,7 +5859,7 @@ const deserializeAws_json1_1FeaturizationParameters = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -5940,19 +5870,16 @@ const deserializeAws_json1_1Filter = (output: any, context: __SerdeContext): Fil
       output.creationDateTime !== undefined && output.creationDateTime !== null
         ? new Date(Math.round(output.creationDateTime * 1000))
         : undefined,
-    datasetGroupArn:
-      output.datasetGroupArn !== undefined && output.datasetGroupArn !== null ? output.datasetGroupArn : undefined,
-    failureReason:
-      output.failureReason !== undefined && output.failureReason !== null ? output.failureReason : undefined,
-    filterArn: output.filterArn !== undefined && output.filterArn !== null ? output.filterArn : undefined,
-    filterExpression:
-      output.filterExpression !== undefined && output.filterExpression !== null ? output.filterExpression : undefined,
+    datasetGroupArn: __expectString(output.datasetGroupArn),
+    failureReason: __expectString(output.failureReason),
+    filterArn: __expectString(output.filterArn),
+    filterExpression: __expectString(output.filterExpression),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
         ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    name: __expectString(output.name),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -5973,17 +5900,15 @@ const deserializeAws_json1_1FilterSummary = (output: any, context: __SerdeContex
       output.creationDateTime !== undefined && output.creationDateTime !== null
         ? new Date(Math.round(output.creationDateTime * 1000))
         : undefined,
-    datasetGroupArn:
-      output.datasetGroupArn !== undefined && output.datasetGroupArn !== null ? output.datasetGroupArn : undefined,
-    failureReason:
-      output.failureReason !== undefined && output.failureReason !== null ? output.failureReason : undefined,
-    filterArn: output.filterArn !== undefined && output.filterArn !== null ? output.filterArn : undefined,
+    datasetGroupArn: __expectString(output.datasetGroupArn),
+    failureReason: __expectString(output.failureReason),
+    filterArn: __expectString(output.filterArn),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
         ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    name: __expectString(output.name),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -5996,10 +5921,7 @@ const deserializeAws_json1_1GetSolutionMetricsResponse = (
       output.metrics !== undefined && output.metrics !== null
         ? deserializeAws_json1_1Metrics(output.metrics, context)
         : undefined,
-    solutionVersionArn:
-      output.solutionVersionArn !== undefined && output.solutionVersionArn !== null
-        ? output.solutionVersionArn
-        : undefined,
+    solutionVersionArn: __expectString(output.solutionVersionArn),
   } as any;
 };
 
@@ -6022,22 +5944,16 @@ const deserializeAws_json1_1HPOConfig = (output: any, context: __SerdeContext): 
 
 const deserializeAws_json1_1HPOObjective = (output: any, context: __SerdeContext): HPOObjective => {
   return {
-    metricName: output.metricName !== undefined && output.metricName !== null ? output.metricName : undefined,
-    metricRegex: output.metricRegex !== undefined && output.metricRegex !== null ? output.metricRegex : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    metricName: __expectString(output.metricName),
+    metricRegex: __expectString(output.metricRegex),
+    type: __expectString(output.type),
   } as any;
 };
 
 const deserializeAws_json1_1HPOResourceConfig = (output: any, context: __SerdeContext): HPOResourceConfig => {
   return {
-    maxNumberOfTrainingJobs:
-      output.maxNumberOfTrainingJobs !== undefined && output.maxNumberOfTrainingJobs !== null
-        ? output.maxNumberOfTrainingJobs
-        : undefined,
-    maxParallelTrainingJobs:
-      output.maxParallelTrainingJobs !== undefined && output.maxParallelTrainingJobs !== null
-        ? output.maxParallelTrainingJobs
-        : undefined,
+    maxNumberOfTrainingJobs: __expectString(output.maxNumberOfTrainingJobs),
+    maxParallelTrainingJobs: __expectString(output.maxParallelTrainingJobs),
   } as any;
 };
 
@@ -6065,7 +5981,7 @@ const deserializeAws_json1_1HyperParameters = (output: any, context: __SerdeCont
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -6075,9 +5991,9 @@ const deserializeAws_json1_1IntegerHyperParameterRange = (
   context: __SerdeContext
 ): IntegerHyperParameterRange => {
   return {
-    maxValue: output.maxValue !== undefined && output.maxValue !== null ? output.maxValue : undefined,
-    minValue: output.minValue !== undefined && output.minValue !== null ? output.minValue : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    maxValue: __expectNumber(output.maxValue),
+    minValue: __expectNumber(output.minValue),
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -6097,7 +6013,7 @@ const deserializeAws_json1_1IntegerHyperParameterRanges = (
 
 const deserializeAws_json1_1InvalidInputException = (output: any, context: __SerdeContext): InvalidInputException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6106,13 +6022,13 @@ const deserializeAws_json1_1InvalidNextTokenException = (
   context: __SerdeContext
 ): InvalidNextTokenException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6125,7 +6041,7 @@ const deserializeAws_json1_1ListBatchInferenceJobsResponse = (
       output.batchInferenceJobs !== undefined && output.batchInferenceJobs !== null
         ? deserializeAws_json1_1BatchInferenceJobs(output.batchInferenceJobs, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -6135,7 +6051,7 @@ const deserializeAws_json1_1ListCampaignsResponse = (output: any, context: __Ser
       output.campaigns !== undefined && output.campaigns !== null
         ? deserializeAws_json1_1Campaigns(output.campaigns, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -6148,7 +6064,7 @@ const deserializeAws_json1_1ListDatasetExportJobsResponse = (
       output.datasetExportJobs !== undefined && output.datasetExportJobs !== null
         ? deserializeAws_json1_1DatasetExportJobs(output.datasetExportJobs, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -6161,7 +6077,7 @@ const deserializeAws_json1_1ListDatasetGroupsResponse = (
       output.datasetGroups !== undefined && output.datasetGroups !== null
         ? deserializeAws_json1_1DatasetGroups(output.datasetGroups, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -6174,7 +6090,7 @@ const deserializeAws_json1_1ListDatasetImportJobsResponse = (
       output.datasetImportJobs !== undefined && output.datasetImportJobs !== null
         ? deserializeAws_json1_1DatasetImportJobs(output.datasetImportJobs, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -6184,7 +6100,7 @@ const deserializeAws_json1_1ListDatasetsResponse = (output: any, context: __Serd
       output.datasets !== undefined && output.datasets !== null
         ? deserializeAws_json1_1Datasets(output.datasets, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -6197,7 +6113,7 @@ const deserializeAws_json1_1ListEventTrackersResponse = (
       output.eventTrackers !== undefined && output.eventTrackers !== null
         ? deserializeAws_json1_1EventTrackers(output.eventTrackers, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -6207,13 +6123,13 @@ const deserializeAws_json1_1ListFiltersResponse = (output: any, context: __Serde
       output.Filters !== undefined && output.Filters !== null
         ? deserializeAws_json1_1Filters(output.Filters, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
 const deserializeAws_json1_1ListRecipesResponse = (output: any, context: __SerdeContext): ListRecipesResponse => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     recipes:
       output.recipes !== undefined && output.recipes !== null
         ? deserializeAws_json1_1Recipes(output.recipes, context)
@@ -6223,7 +6139,7 @@ const deserializeAws_json1_1ListRecipesResponse = (output: any, context: __Serde
 
 const deserializeAws_json1_1ListSchemasResponse = (output: any, context: __SerdeContext): ListSchemasResponse => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     schemas:
       output.schemas !== undefined && output.schemas !== null
         ? deserializeAws_json1_1Schemas(output.schemas, context)
@@ -6233,7 +6149,7 @@ const deserializeAws_json1_1ListSchemasResponse = (output: any, context: __Serde
 
 const deserializeAws_json1_1ListSolutionsResponse = (output: any, context: __SerdeContext): ListSolutionsResponse => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     solutions:
       output.solutions !== undefined && output.solutions !== null
         ? deserializeAws_json1_1Solutions(output.solutions, context)
@@ -6246,7 +6162,7 @@ const deserializeAws_json1_1ListSolutionVersionsResponse = (
   context: __SerdeContext
 ): ListSolutionVersionsResponse => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     solutionVersions:
       output.solutionVersions !== undefined && output.solutionVersions !== null
         ? deserializeAws_json1_1SolutionVersions(output.solutionVersions, context)
@@ -6261,42 +6177,35 @@ const deserializeAws_json1_1Metrics = (output: any, context: __SerdeContext): { 
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectNumber(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_json1_1OptimizationObjective = (output: any, context: __SerdeContext): OptimizationObjective => {
   return {
-    itemAttribute:
-      output.itemAttribute !== undefined && output.itemAttribute !== null ? output.itemAttribute : undefined,
-    objectiveSensitivity:
-      output.objectiveSensitivity !== undefined && output.objectiveSensitivity !== null
-        ? output.objectiveSensitivity
-        : undefined,
+    itemAttribute: __expectString(output.itemAttribute),
+    objectiveSensitivity: __expectString(output.objectiveSensitivity),
   } as any;
 };
 
 const deserializeAws_json1_1Recipe = (output: any, context: __SerdeContext): Recipe => {
   return {
-    algorithmArn: output.algorithmArn !== undefined && output.algorithmArn !== null ? output.algorithmArn : undefined,
+    algorithmArn: __expectString(output.algorithmArn),
     creationDateTime:
       output.creationDateTime !== undefined && output.creationDateTime !== null
         ? new Date(Math.round(output.creationDateTime * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    featureTransformationArn:
-      output.featureTransformationArn !== undefined && output.featureTransformationArn !== null
-        ? output.featureTransformationArn
-        : undefined,
+    description: __expectString(output.description),
+    featureTransformationArn: __expectString(output.featureTransformationArn),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
         ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    recipeArn: output.recipeArn !== undefined && output.recipeArn !== null ? output.recipeArn : undefined,
-    recipeType: output.recipeType !== undefined && output.recipeType !== null ? output.recipeType : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    name: __expectString(output.name),
+    recipeArn: __expectString(output.recipeArn),
+    recipeType: __expectString(output.recipeType),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -6321,9 +6230,9 @@ const deserializeAws_json1_1RecipeSummary = (output: any, context: __SerdeContex
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
         ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    recipeArn: output.recipeArn !== undefined && output.recipeArn !== null ? output.recipeArn : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    name: __expectString(output.name),
+    recipeArn: __expectString(output.recipeArn),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -6332,7 +6241,7 @@ const deserializeAws_json1_1ResourceAlreadyExistsException = (
   context: __SerdeContext
 ): ResourceAlreadyExistsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6343,14 +6252,14 @@ const deserializeAws_json1_1ResourceConfig = (output: any, context: __SerdeConte
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_json1_1ResourceInUseException = (output: any, context: __SerdeContext): ResourceInUseException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6359,14 +6268,14 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1S3DataConfig = (output: any, context: __SerdeContext): S3DataConfig => {
   return {
-    kmsKeyArn: output.kmsKeyArn !== undefined && output.kmsKeyArn !== null ? output.kmsKeyArn : undefined,
-    path: output.path !== undefined && output.path !== null ? output.path : undefined,
+    kmsKeyArn: __expectString(output.kmsKeyArn),
+    path: __expectString(output.path),
   } as any;
 };
 
@@ -6391,9 +6300,8 @@ const deserializeAws_json1_1Solution = (output: any, context: __SerdeContext): S
       output.creationDateTime !== undefined && output.creationDateTime !== null
         ? new Date(Math.round(output.creationDateTime * 1000))
         : undefined,
-    datasetGroupArn:
-      output.datasetGroupArn !== undefined && output.datasetGroupArn !== null ? output.datasetGroupArn : undefined,
-    eventType: output.eventType !== undefined && output.eventType !== null ? output.eventType : undefined,
+    datasetGroupArn: __expectString(output.datasetGroupArn),
+    eventType: __expectString(output.eventType),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
         ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
@@ -6402,17 +6310,16 @@ const deserializeAws_json1_1Solution = (output: any, context: __SerdeContext): S
       output.latestSolutionVersion !== undefined && output.latestSolutionVersion !== null
         ? deserializeAws_json1_1SolutionVersionSummary(output.latestSolutionVersion, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    performAutoML:
-      output.performAutoML !== undefined && output.performAutoML !== null ? output.performAutoML : undefined,
-    performHPO: output.performHPO !== undefined && output.performHPO !== null ? output.performHPO : undefined,
-    recipeArn: output.recipeArn !== undefined && output.recipeArn !== null ? output.recipeArn : undefined,
-    solutionArn: output.solutionArn !== undefined && output.solutionArn !== null ? output.solutionArn : undefined,
+    name: __expectString(output.name),
+    performAutoML: __expectBoolean(output.performAutoML),
+    performHPO: __expectBoolean(output.performHPO),
+    recipeArn: __expectString(output.recipeArn),
+    solutionArn: __expectString(output.solutionArn),
     solutionConfig:
       output.solutionConfig !== undefined && output.solutionConfig !== null
         ? deserializeAws_json1_1SolutionConfig(output.solutionConfig, context)
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -6426,10 +6333,7 @@ const deserializeAws_json1_1SolutionConfig = (output: any, context: __SerdeConte
       output.autoMLConfig !== undefined && output.autoMLConfig !== null
         ? deserializeAws_json1_1AutoMLConfig(output.autoMLConfig, context)
         : undefined,
-    eventValueThreshold:
-      output.eventValueThreshold !== undefined && output.eventValueThreshold !== null
-        ? output.eventValueThreshold
-        : undefined,
+    eventValueThreshold: __expectString(output.eventValueThreshold),
     featureTransformationParameters:
       output.featureTransformationParameters !== undefined && output.featureTransformationParameters !== null
         ? deserializeAws_json1_1FeatureTransformationParameters(output.featureTransformationParameters, context)
@@ -6466,9 +6370,9 @@ const deserializeAws_json1_1SolutionSummary = (output: any, context: __SerdeCont
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
         ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    solutionArn: output.solutionArn !== undefined && output.solutionArn !== null ? output.solutionArn : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    name: __expectString(output.name),
+    solutionArn: __expectString(output.solutionArn),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -6478,32 +6382,25 @@ const deserializeAws_json1_1SolutionVersion = (output: any, context: __SerdeCont
       output.creationDateTime !== undefined && output.creationDateTime !== null
         ? new Date(Math.round(output.creationDateTime * 1000))
         : undefined,
-    datasetGroupArn:
-      output.datasetGroupArn !== undefined && output.datasetGroupArn !== null ? output.datasetGroupArn : undefined,
-    eventType: output.eventType !== undefined && output.eventType !== null ? output.eventType : undefined,
-    failureReason:
-      output.failureReason !== undefined && output.failureReason !== null ? output.failureReason : undefined,
+    datasetGroupArn: __expectString(output.datasetGroupArn),
+    eventType: __expectString(output.eventType),
+    failureReason: __expectString(output.failureReason),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
         ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
         : undefined,
-    performAutoML:
-      output.performAutoML !== undefined && output.performAutoML !== null ? output.performAutoML : undefined,
-    performHPO: output.performHPO !== undefined && output.performHPO !== null ? output.performHPO : undefined,
-    recipeArn: output.recipeArn !== undefined && output.recipeArn !== null ? output.recipeArn : undefined,
-    solutionArn: output.solutionArn !== undefined && output.solutionArn !== null ? output.solutionArn : undefined,
+    performAutoML: __expectBoolean(output.performAutoML),
+    performHPO: __expectBoolean(output.performHPO),
+    recipeArn: __expectString(output.recipeArn),
+    solutionArn: __expectString(output.solutionArn),
     solutionConfig:
       output.solutionConfig !== undefined && output.solutionConfig !== null
         ? deserializeAws_json1_1SolutionConfig(output.solutionConfig, context)
         : undefined,
-    solutionVersionArn:
-      output.solutionVersionArn !== undefined && output.solutionVersionArn !== null
-        ? output.solutionVersionArn
-        : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    trainingHours:
-      output.trainingHours !== undefined && output.trainingHours !== null ? output.trainingHours : undefined,
-    trainingMode: output.trainingMode !== undefined && output.trainingMode !== null ? output.trainingMode : undefined,
+    solutionVersionArn: __expectString(output.solutionVersionArn),
+    status: __expectString(output.status),
+    trainingHours: __expectNumber(output.trainingHours),
+    trainingMode: __expectString(output.trainingMode),
     tunedHPOParams:
       output.tunedHPOParams !== undefined && output.tunedHPOParams !== null
         ? deserializeAws_json1_1TunedHPOParams(output.tunedHPOParams, context)
@@ -6528,17 +6425,13 @@ const deserializeAws_json1_1SolutionVersionSummary = (output: any, context: __Se
       output.creationDateTime !== undefined && output.creationDateTime !== null
         ? new Date(Math.round(output.creationDateTime * 1000))
         : undefined,
-    failureReason:
-      output.failureReason !== undefined && output.failureReason !== null ? output.failureReason : undefined,
+    failureReason: __expectString(output.failureReason),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
         ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
         : undefined,
-    solutionVersionArn:
-      output.solutionVersionArn !== undefined && output.solutionVersionArn !== null
-        ? output.solutionVersionArn
-        : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    solutionVersionArn: __expectString(output.solutionVersionArn),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -6553,7 +6446,7 @@ const deserializeAws_json1_1TunedHPOParams = (output: any, context: __SerdeConte
 
 const deserializeAws_json1_1UpdateCampaignResponse = (output: any, context: __SerdeContext): UpdateCampaignResponse => {
   return {
-    campaignArn: output.campaignArn !== undefined && output.campaignArn !== null ? output.campaignArn : undefined,
+    campaignArn: __expectString(output.campaignArn),
   } as any;
 };
 

--- a/clients/client-pi/protocols/Aws_json1_1.ts
+++ b/clients/client-pi/protocols/Aws_json1_1.ts
@@ -27,7 +27,11 @@ import {
   ResponseResourceMetricKey,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -464,7 +468,7 @@ const deserializeAws_json1_1DataPoint = (output: any, context: __SerdeContext): 
       output.Timestamp !== undefined && output.Timestamp !== null
         ? new Date(Math.round(output.Timestamp * 1000))
         : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Value: __expectNumber(output.Value),
   } as any;
 };
 
@@ -496,7 +500,7 @@ const deserializeAws_json1_1DescribeDimensionKeysResponse = (
       output.Keys !== undefined && output.Keys !== null
         ? deserializeAws_json1_1DimensionKeyDescriptionList(output.Keys, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     PartitionKeys:
       output.PartitionKeys !== undefined && output.PartitionKeys !== null
         ? deserializeAws_json1_1ResponsePartitionKeyList(output.PartitionKeys, context)
@@ -517,7 +521,7 @@ const deserializeAws_json1_1DimensionKeyDescription = (
       output.Partitions !== undefined && output.Partitions !== null
         ? deserializeAws_json1_1MetricValuesList(output.Partitions, context)
         : undefined,
-    Total: output.Total !== undefined && output.Total !== null ? output.Total : undefined,
+    Total: __expectNumber(output.Total),
   } as any;
 };
 
@@ -537,9 +541,9 @@ const deserializeAws_json1_1DimensionKeyDescriptionList = (
 
 const deserializeAws_json1_1DimensionKeyDetail = (output: any, context: __SerdeContext): DimensionKeyDetail => {
   return {
-    Dimension: output.Dimension !== undefined && output.Dimension !== null ? output.Dimension : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Dimension: __expectString(output.Dimension),
+    Status: __expectString(output.Status),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -561,7 +565,7 @@ const deserializeAws_json1_1DimensionMap = (output: any, context: __SerdeContext
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -591,18 +595,18 @@ const deserializeAws_json1_1GetResourceMetricsResponse = (
       output.AlignedStartTime !== undefined && output.AlignedStartTime !== null
         ? new Date(Math.round(output.AlignedStartTime * 1000))
         : undefined,
-    Identifier: output.Identifier !== undefined && output.Identifier !== null ? output.Identifier : undefined,
+    Identifier: __expectString(output.Identifier),
     MetricList:
       output.MetricList !== undefined && output.MetricList !== null
         ? deserializeAws_json1_1MetricKeyDataPointsList(output.MetricList, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
 const deserializeAws_json1_1InternalServiceError = (output: any, context: __SerdeContext): InternalServiceError => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -611,7 +615,7 @@ const deserializeAws_json1_1InvalidArgumentException = (
   context: __SerdeContext
 ): InvalidArgumentException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -646,13 +650,13 @@ const deserializeAws_json1_1MetricValuesList = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectNumber(entry) as any;
     });
 };
 
 const deserializeAws_json1_1NotAuthorizedException = (output: any, context: __SerdeContext): NotAuthorizedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -688,7 +692,7 @@ const deserializeAws_json1_1ResponseResourceMetricKey = (
       output.Dimensions !== undefined && output.Dimensions !== null
         ? deserializeAws_json1_1DimensionMap(output.Dimensions, context)
         : undefined,
-    Metric: output.Metric !== undefined && output.Metric !== null ? output.Metric : undefined,
+    Metric: __expectString(output.Metric),
   } as any;
 };
 

--- a/clients/client-pinpoint-email/protocols/Aws_restJson1.ts
+++ b/clients/client-pinpoint-email/protocols/Aws_restJson1.ts
@@ -197,6 +197,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -1734,10 +1737,10 @@ export const deserializeAws_restJson1CreateDeliverabilityTestReportCommand = asy
   };
   const data: any = await parseBody(output.body, context);
   if (data.DeliverabilityTestStatus !== undefined && data.DeliverabilityTestStatus !== null) {
-    contents.DeliverabilityTestStatus = data.DeliverabilityTestStatus;
+    contents.DeliverabilityTestStatus = __expectString(data.DeliverabilityTestStatus);
   }
   if (data.ReportId !== undefined && data.ReportId !== null) {
-    contents.ReportId = data.ReportId;
+    contents.ReportId = __expectString(data.ReportId);
   }
   return Promise.resolve(contents);
 };
@@ -1861,10 +1864,10 @@ export const deserializeAws_restJson1CreateEmailIdentityCommand = async (
     contents.DkimAttributes = deserializeAws_restJson1DkimAttributes(data.DkimAttributes, context);
   }
   if (data.IdentityType !== undefined && data.IdentityType !== null) {
-    contents.IdentityType = data.IdentityType;
+    contents.IdentityType = __expectString(data.IdentityType);
   }
   if (data.VerifiedForSendingStatus !== undefined && data.VerifiedForSendingStatus !== null) {
-    contents.VerifiedForSendingStatus = data.VerifiedForSendingStatus;
+    contents.VerifiedForSendingStatus = __expectBoolean(data.VerifiedForSendingStatus);
   }
   return Promise.resolve(contents);
 };
@@ -2239,19 +2242,19 @@ export const deserializeAws_restJson1GetAccountCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.DedicatedIpAutoWarmupEnabled !== undefined && data.DedicatedIpAutoWarmupEnabled !== null) {
-    contents.DedicatedIpAutoWarmupEnabled = data.DedicatedIpAutoWarmupEnabled;
+    contents.DedicatedIpAutoWarmupEnabled = __expectBoolean(data.DedicatedIpAutoWarmupEnabled);
   }
   if (data.EnforcementStatus !== undefined && data.EnforcementStatus !== null) {
-    contents.EnforcementStatus = data.EnforcementStatus;
+    contents.EnforcementStatus = __expectString(data.EnforcementStatus);
   }
   if (data.ProductionAccessEnabled !== undefined && data.ProductionAccessEnabled !== null) {
-    contents.ProductionAccessEnabled = data.ProductionAccessEnabled;
+    contents.ProductionAccessEnabled = __expectBoolean(data.ProductionAccessEnabled);
   }
   if (data.SendQuota !== undefined && data.SendQuota !== null) {
     contents.SendQuota = deserializeAws_restJson1SendQuota(data.SendQuota, context);
   }
   if (data.SendingEnabled !== undefined && data.SendingEnabled !== null) {
-    contents.SendingEnabled = data.SendingEnabled;
+    contents.SendingEnabled = __expectBoolean(data.SendingEnabled);
   }
   return Promise.resolve(contents);
 };
@@ -2390,7 +2393,7 @@ export const deserializeAws_restJson1GetConfigurationSetCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ConfigurationSetName !== undefined && data.ConfigurationSetName !== null) {
-    contents.ConfigurationSetName = data.ConfigurationSetName;
+    contents.ConfigurationSetName = __expectString(data.ConfigurationSetName);
   }
   if (data.DeliveryOptions !== undefined && data.DeliveryOptions !== null) {
     contents.DeliveryOptions = deserializeAws_restJson1DeliveryOptions(data.DeliveryOptions, context);
@@ -2622,7 +2625,7 @@ export const deserializeAws_restJson1GetDedicatedIpsCommand = async (
     contents.DedicatedIps = deserializeAws_restJson1DedicatedIpList(data.DedicatedIps, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2697,7 +2700,7 @@ export const deserializeAws_restJson1GetDeliverabilityDashboardOptionsCommand = 
   };
   const data: any = await parseBody(output.body, context);
   if (data.AccountStatus !== undefined && data.AccountStatus !== null) {
-    contents.AccountStatus = data.AccountStatus;
+    contents.AccountStatus = __expectString(data.AccountStatus);
   }
   if (data.ActiveSubscribedDomains !== undefined && data.ActiveSubscribedDomains !== null) {
     contents.ActiveSubscribedDomains = deserializeAws_restJson1DomainDeliverabilityTrackingOptions(
@@ -2706,7 +2709,7 @@ export const deserializeAws_restJson1GetDeliverabilityDashboardOptionsCommand = 
     );
   }
   if (data.DashboardEnabled !== undefined && data.DashboardEnabled !== null) {
-    contents.DashboardEnabled = data.DashboardEnabled;
+    contents.DashboardEnabled = __expectBoolean(data.DashboardEnabled);
   }
   if (data.PendingExpirationSubscribedDomains !== undefined && data.PendingExpirationSubscribedDomains !== null) {
     contents.PendingExpirationSubscribedDomains = deserializeAws_restJson1DomainDeliverabilityTrackingOptions(
@@ -2799,7 +2802,7 @@ export const deserializeAws_restJson1GetDeliverabilityTestReportCommand = async 
     contents.IspPlacements = deserializeAws_restJson1IspPlacements(data.IspPlacements, context);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.OverallPlacement !== undefined && data.OverallPlacement !== null) {
     contents.OverallPlacement = deserializeAws_restJson1PlacementStatistics(data.OverallPlacement, context);
@@ -3033,10 +3036,10 @@ export const deserializeAws_restJson1GetEmailIdentityCommand = async (
     contents.DkimAttributes = deserializeAws_restJson1DkimAttributes(data.DkimAttributes, context);
   }
   if (data.FeedbackForwardingStatus !== undefined && data.FeedbackForwardingStatus !== null) {
-    contents.FeedbackForwardingStatus = data.FeedbackForwardingStatus;
+    contents.FeedbackForwardingStatus = __expectBoolean(data.FeedbackForwardingStatus);
   }
   if (data.IdentityType !== undefined && data.IdentityType !== null) {
-    contents.IdentityType = data.IdentityType;
+    contents.IdentityType = __expectString(data.IdentityType);
   }
   if (data.MailFromAttributes !== undefined && data.MailFromAttributes !== null) {
     contents.MailFromAttributes = deserializeAws_restJson1MailFromAttributes(data.MailFromAttributes, context);
@@ -3045,7 +3048,7 @@ export const deserializeAws_restJson1GetEmailIdentityCommand = async (
     contents.Tags = deserializeAws_restJson1TagList(data.Tags, context);
   }
   if (data.VerifiedForSendingStatus !== undefined && data.VerifiedForSendingStatus !== null) {
-    contents.VerifiedForSendingStatus = data.VerifiedForSendingStatus;
+    contents.VerifiedForSendingStatus = __expectBoolean(data.VerifiedForSendingStatus);
   }
   return Promise.resolve(contents);
 };
@@ -3120,7 +3123,7 @@ export const deserializeAws_restJson1ListConfigurationSetsCommand = async (
     contents.ConfigurationSets = deserializeAws_restJson1ConfigurationSetNameList(data.ConfigurationSets, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3187,7 +3190,7 @@ export const deserializeAws_restJson1ListDedicatedIpPoolsCommand = async (
     contents.DedicatedIpPools = deserializeAws_restJson1ListOfDedicatedIpPools(data.DedicatedIpPools, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3257,7 +3260,7 @@ export const deserializeAws_restJson1ListDeliverabilityTestReportsCommand = asyn
     );
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3335,7 +3338,7 @@ export const deserializeAws_restJson1ListDomainDeliverabilityCampaignsCommand = 
     );
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3410,7 +3413,7 @@ export const deserializeAws_restJson1ListEmailIdentitiesCommand = async (
     contents.EmailIdentities = deserializeAws_restJson1IdentityInfoList(data.EmailIdentities, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -4348,7 +4351,7 @@ export const deserializeAws_restJson1SendEmailCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.MessageId !== undefined && data.MessageId !== null) {
-    contents.MessageId = data.MessageId;
+    contents.MessageId = __expectString(data.MessageId);
   }
   return Promise.resolve(contents);
 };
@@ -4675,7 +4678,7 @@ const deserializeAws_restJson1AccountSuspendedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -4692,7 +4695,7 @@ const deserializeAws_restJson1AlreadyExistsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -4709,7 +4712,7 @@ const deserializeAws_restJson1BadRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -4726,7 +4729,7 @@ const deserializeAws_restJson1ConcurrentModificationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -4743,7 +4746,7 @@ const deserializeAws_restJson1LimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -4760,7 +4763,7 @@ const deserializeAws_restJson1MailFromDomainNotVerifiedExceptionResponse = async
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -4777,7 +4780,7 @@ const deserializeAws_restJson1MessageRejectedResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -4794,7 +4797,7 @@ const deserializeAws_restJson1NotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -4811,7 +4814,7 @@ const deserializeAws_restJson1SendingPausedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -4828,7 +4831,7 @@ const deserializeAws_restJson1TooManyRequestsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -5150,12 +5153,12 @@ const deserializeAws_restJson1BlacklistEntries = (output: any, context: __SerdeC
 
 const deserializeAws_restJson1BlacklistEntry = (output: any, context: __SerdeContext): BlacklistEntry => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     ListingTime:
       output.ListingTime !== undefined && output.ListingTime !== null
         ? new Date(Math.round(output.ListingTime * 1000))
         : undefined,
-    RblName: output.RblName !== undefined && output.RblName !== null ? output.RblName : undefined,
+    RblName: __expectString(output.RblName),
   } as any;
 };
 
@@ -5188,16 +5191,9 @@ const deserializeAws_restJson1CloudWatchDimensionConfiguration = (
   context: __SerdeContext
 ): CloudWatchDimensionConfiguration => {
   return {
-    DefaultDimensionValue:
-      output.DefaultDimensionValue !== undefined && output.DefaultDimensionValue !== null
-        ? output.DefaultDimensionValue
-        : undefined,
-    DimensionName:
-      output.DimensionName !== undefined && output.DimensionName !== null ? output.DimensionName : undefined,
-    DimensionValueSource:
-      output.DimensionValueSource !== undefined && output.DimensionValueSource !== null
-        ? output.DimensionValueSource
-        : undefined,
+    DefaultDimensionValue: __expectString(output.DefaultDimensionValue),
+    DimensionName: __expectString(output.DimensionName),
+    DimensionValueSource: __expectString(output.DimensionValueSource),
   } as any;
 };
 
@@ -5222,7 +5218,7 @@ const deserializeAws_restJson1ConfigurationSetNameList = (output: any, context: 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -5256,11 +5252,10 @@ const deserializeAws_restJson1DailyVolumes = (output: any, context: __SerdeConte
 
 const deserializeAws_restJson1DedicatedIp = (output: any, context: __SerdeContext): DedicatedIp => {
   return {
-    Ip: output.Ip !== undefined && output.Ip !== null ? output.Ip : undefined,
-    PoolName: output.PoolName !== undefined && output.PoolName !== null ? output.PoolName : undefined,
-    WarmupPercentage:
-      output.WarmupPercentage !== undefined && output.WarmupPercentage !== null ? output.WarmupPercentage : undefined,
-    WarmupStatus: output.WarmupStatus !== undefined && output.WarmupStatus !== null ? output.WarmupStatus : undefined,
+    Ip: __expectString(output.Ip),
+    PoolName: __expectString(output.PoolName),
+    WarmupPercentage: __expectNumber(output.WarmupPercentage),
+    WarmupStatus: __expectString(output.WarmupStatus),
   } as any;
 };
 
@@ -5284,15 +5279,11 @@ const deserializeAws_restJson1DeliverabilityTestReport = (
       output.CreateDate !== undefined && output.CreateDate !== null
         ? new Date(Math.round(output.CreateDate * 1000))
         : undefined,
-    DeliverabilityTestStatus:
-      output.DeliverabilityTestStatus !== undefined && output.DeliverabilityTestStatus !== null
-        ? output.DeliverabilityTestStatus
-        : undefined,
-    FromEmailAddress:
-      output.FromEmailAddress !== undefined && output.FromEmailAddress !== null ? output.FromEmailAddress : undefined,
-    ReportId: output.ReportId !== undefined && output.ReportId !== null ? output.ReportId : undefined,
-    ReportName: output.ReportName !== undefined && output.ReportName !== null ? output.ReportName : undefined,
-    Subject: output.Subject !== undefined && output.Subject !== null ? output.Subject : undefined,
+    DeliverabilityTestStatus: __expectString(output.DeliverabilityTestStatus),
+    FromEmailAddress: __expectString(output.FromEmailAddress),
+    ReportId: __expectString(output.ReportId),
+    ReportName: __expectString(output.ReportName),
+    Subject: __expectString(output.Subject),
   } as any;
 };
 
@@ -5312,17 +5303,15 @@ const deserializeAws_restJson1DeliverabilityTestReports = (
 
 const deserializeAws_restJson1DeliveryOptions = (output: any, context: __SerdeContext): DeliveryOptions => {
   return {
-    SendingPoolName:
-      output.SendingPoolName !== undefined && output.SendingPoolName !== null ? output.SendingPoolName : undefined,
-    TlsPolicy: output.TlsPolicy !== undefined && output.TlsPolicy !== null ? output.TlsPolicy : undefined,
+    SendingPoolName: __expectString(output.SendingPoolName),
+    TlsPolicy: __expectString(output.TlsPolicy),
   } as any;
 };
 
 const deserializeAws_restJson1DkimAttributes = (output: any, context: __SerdeContext): DkimAttributes => {
   return {
-    SigningEnabled:
-      output.SigningEnabled !== undefined && output.SigningEnabled !== null ? output.SigningEnabled : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    SigningEnabled: __expectBoolean(output.SigningEnabled),
+    Status: __expectString(output.Status),
     Tokens:
       output.Tokens !== undefined && output.Tokens !== null
         ? deserializeAws_restJson1DnsTokenList(output.Tokens, context)
@@ -5337,7 +5326,7 @@ const deserializeAws_restJson1DnsTokenList = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -5346,8 +5335,8 @@ const deserializeAws_restJson1DomainDeliverabilityCampaign = (
   context: __SerdeContext
 ): DomainDeliverabilityCampaign => {
   return {
-    CampaignId: output.CampaignId !== undefined && output.CampaignId !== null ? output.CampaignId : undefined,
-    DeleteRate: output.DeleteRate !== undefined && output.DeleteRate !== null ? output.DeleteRate : undefined,
+    CampaignId: __expectString(output.CampaignId),
+    DeleteRate: __expectNumber(output.DeleteRate),
     Esps:
       output.Esps !== undefined && output.Esps !== null
         ? deserializeAws_restJson1Esps(output.Esps, context)
@@ -5356,24 +5345,22 @@ const deserializeAws_restJson1DomainDeliverabilityCampaign = (
       output.FirstSeenDateTime !== undefined && output.FirstSeenDateTime !== null
         ? new Date(Math.round(output.FirstSeenDateTime * 1000))
         : undefined,
-    FromAddress: output.FromAddress !== undefined && output.FromAddress !== null ? output.FromAddress : undefined,
-    ImageUrl: output.ImageUrl !== undefined && output.ImageUrl !== null ? output.ImageUrl : undefined,
-    InboxCount: output.InboxCount !== undefined && output.InboxCount !== null ? output.InboxCount : undefined,
+    FromAddress: __expectString(output.FromAddress),
+    ImageUrl: __expectString(output.ImageUrl),
+    InboxCount: __expectNumber(output.InboxCount),
     LastSeenDateTime:
       output.LastSeenDateTime !== undefined && output.LastSeenDateTime !== null
         ? new Date(Math.round(output.LastSeenDateTime * 1000))
         : undefined,
-    ProjectedVolume:
-      output.ProjectedVolume !== undefined && output.ProjectedVolume !== null ? output.ProjectedVolume : undefined,
-    ReadDeleteRate:
-      output.ReadDeleteRate !== undefined && output.ReadDeleteRate !== null ? output.ReadDeleteRate : undefined,
-    ReadRate: output.ReadRate !== undefined && output.ReadRate !== null ? output.ReadRate : undefined,
+    ProjectedVolume: __expectNumber(output.ProjectedVolume),
+    ReadDeleteRate: __expectNumber(output.ReadDeleteRate),
+    ReadRate: __expectNumber(output.ReadRate),
     SendingIps:
       output.SendingIps !== undefined && output.SendingIps !== null
         ? deserializeAws_restJson1IpList(output.SendingIps, context)
         : undefined,
-    SpamCount: output.SpamCount !== undefined && output.SpamCount !== null ? output.SpamCount : undefined,
-    Subject: output.Subject !== undefined && output.Subject !== null ? output.Subject : undefined,
+    SpamCount: __expectNumber(output.SpamCount),
+    Subject: __expectString(output.Subject),
   } as any;
 };
 
@@ -5396,7 +5383,7 @@ const deserializeAws_restJson1DomainDeliverabilityTrackingOption = (
   context: __SerdeContext
 ): DomainDeliverabilityTrackingOption => {
   return {
-    Domain: output.Domain !== undefined && output.Domain !== null ? output.Domain : undefined,
+    Domain: __expectString(output.Domain),
     InboxPlacementTrackingOption:
       output.InboxPlacementTrackingOption !== undefined && output.InboxPlacementTrackingOption !== null
         ? deserializeAws_restJson1InboxPlacementTrackingOption(output.InboxPlacementTrackingOption, context)
@@ -5424,14 +5411,11 @@ const deserializeAws_restJson1DomainDeliverabilityTrackingOptions = (
 
 const deserializeAws_restJson1DomainIspPlacement = (output: any, context: __SerdeContext): DomainIspPlacement => {
   return {
-    InboxPercentage:
-      output.InboxPercentage !== undefined && output.InboxPercentage !== null ? output.InboxPercentage : undefined,
-    InboxRawCount:
-      output.InboxRawCount !== undefined && output.InboxRawCount !== null ? output.InboxRawCount : undefined,
-    IspName: output.IspName !== undefined && output.IspName !== null ? output.IspName : undefined,
-    SpamPercentage:
-      output.SpamPercentage !== undefined && output.SpamPercentage !== null ? output.SpamPercentage : undefined,
-    SpamRawCount: output.SpamRawCount !== undefined && output.SpamRawCount !== null ? output.SpamRawCount : undefined,
+    InboxPercentage: __expectNumber(output.InboxPercentage),
+    InboxRawCount: __expectNumber(output.InboxRawCount),
+    IspName: __expectString(output.IspName),
+    SpamPercentage: __expectNumber(output.SpamPercentage),
+    SpamRawCount: __expectNumber(output.SpamRawCount),
   } as any;
 };
 
@@ -5453,7 +5437,7 @@ const deserializeAws_restJson1Esps = (output: any, context: __SerdeContext): str
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -5463,7 +5447,7 @@ const deserializeAws_restJson1EventDestination = (output: any, context: __SerdeC
       output.CloudWatchDestination !== undefined && output.CloudWatchDestination !== null
         ? deserializeAws_restJson1CloudWatchDestination(output.CloudWatchDestination, context)
         : undefined,
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
+    Enabled: __expectBoolean(output.Enabled),
     KinesisFirehoseDestination:
       output.KinesisFirehoseDestination !== undefined && output.KinesisFirehoseDestination !== null
         ? deserializeAws_restJson1KinesisFirehoseDestination(output.KinesisFirehoseDestination, context)
@@ -5472,7 +5456,7 @@ const deserializeAws_restJson1EventDestination = (output: any, context: __SerdeC
       output.MatchingEventTypes !== undefined && output.MatchingEventTypes !== null
         ? deserializeAws_restJson1EventTypes(output.MatchingEventTypes, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     PinpointDestination:
       output.PinpointDestination !== undefined && output.PinpointDestination !== null
         ? deserializeAws_restJson1PinpointDestination(output.PinpointDestination, context)
@@ -5502,16 +5486,15 @@ const deserializeAws_restJson1EventTypes = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1IdentityInfo = (output: any, context: __SerdeContext): IdentityInfo => {
   return {
-    IdentityName: output.IdentityName !== undefined && output.IdentityName !== null ? output.IdentityName : undefined,
-    IdentityType: output.IdentityType !== undefined && output.IdentityType !== null ? output.IdentityType : undefined,
-    SendingEnabled:
-      output.SendingEnabled !== undefined && output.SendingEnabled !== null ? output.SendingEnabled : undefined,
+    IdentityName: __expectString(output.IdentityName),
+    IdentityType: __expectString(output.IdentityType),
+    SendingEnabled: __expectBoolean(output.SendingEnabled),
   } as any;
 };
 
@@ -5531,7 +5514,7 @@ const deserializeAws_restJson1InboxPlacementTrackingOption = (
   context: __SerdeContext
 ): InboxPlacementTrackingOption => {
   return {
-    Global: output.Global !== undefined && output.Global !== null ? output.Global : undefined,
+    Global: __expectBoolean(output.Global),
     TrackedIsps:
       output.TrackedIsps !== undefined && output.TrackedIsps !== null
         ? deserializeAws_restJson1IspNameList(output.TrackedIsps, context)
@@ -5546,7 +5529,7 @@ const deserializeAws_restJson1IpList = (output: any, context: __SerdeContext): s
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -5557,13 +5540,13 @@ const deserializeAws_restJson1IspNameList = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1IspPlacement = (output: any, context: __SerdeContext): IspPlacement => {
   return {
-    IspName: output.IspName !== undefined && output.IspName !== null ? output.IspName : undefined,
+    IspName: __expectString(output.IspName),
     PlacementStatistics:
       output.PlacementStatistics !== undefined && output.PlacementStatistics !== null
         ? deserializeAws_restJson1PlacementStatistics(output.PlacementStatistics, context)
@@ -5587,11 +5570,8 @@ const deserializeAws_restJson1KinesisFirehoseDestination = (
   context: __SerdeContext
 ): KinesisFirehoseDestination => {
   return {
-    DeliveryStreamArn:
-      output.DeliveryStreamArn !== undefined && output.DeliveryStreamArn !== null
-        ? output.DeliveryStreamArn
-        : undefined,
-    IamRoleArn: output.IamRoleArn !== undefined && output.IamRoleArn !== null ? output.IamRoleArn : undefined,
+    DeliveryStreamArn: __expectString(output.DeliveryStreamArn),
+    IamRoleArn: __expectString(output.IamRoleArn),
   } as any;
 };
 
@@ -5602,22 +5582,15 @@ const deserializeAws_restJson1ListOfDedicatedIpPools = (output: any, context: __
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1MailFromAttributes = (output: any, context: __SerdeContext): MailFromAttributes => {
   return {
-    BehaviorOnMxFailure:
-      output.BehaviorOnMxFailure !== undefined && output.BehaviorOnMxFailure !== null
-        ? output.BehaviorOnMxFailure
-        : undefined,
-    MailFromDomain:
-      output.MailFromDomain !== undefined && output.MailFromDomain !== null ? output.MailFromDomain : undefined,
-    MailFromDomainStatus:
-      output.MailFromDomainStatus !== undefined && output.MailFromDomainStatus !== null
-        ? output.MailFromDomainStatus
-        : undefined,
+    BehaviorOnMxFailure: __expectString(output.BehaviorOnMxFailure),
+    MailFromDomain: __expectString(output.MailFromDomain),
+    MailFromDomainStatus: __expectString(output.MailFromDomainStatus),
   } as any;
 };
 
@@ -5627,8 +5600,7 @@ const deserializeAws_restJson1OverallVolume = (output: any, context: __SerdeCont
       output.DomainIspPlacements !== undefined && output.DomainIspPlacements !== null
         ? deserializeAws_restJson1DomainIspPlacements(output.DomainIspPlacements, context)
         : undefined,
-    ReadRatePercent:
-      output.ReadRatePercent !== undefined && output.ReadRatePercent !== null ? output.ReadRatePercent : undefined,
+    ReadRatePercent: __expectNumber(output.ReadRatePercent),
     VolumeStatistics:
       output.VolumeStatistics !== undefined && output.VolumeStatistics !== null
         ? deserializeAws_restJson1VolumeStatistics(output.VolumeStatistics, context)
@@ -5638,25 +5610,17 @@ const deserializeAws_restJson1OverallVolume = (output: any, context: __SerdeCont
 
 const deserializeAws_restJson1PinpointDestination = (output: any, context: __SerdeContext): PinpointDestination => {
   return {
-    ApplicationArn:
-      output.ApplicationArn !== undefined && output.ApplicationArn !== null ? output.ApplicationArn : undefined,
+    ApplicationArn: __expectString(output.ApplicationArn),
   } as any;
 };
 
 const deserializeAws_restJson1PlacementStatistics = (output: any, context: __SerdeContext): PlacementStatistics => {
   return {
-    DkimPercentage:
-      output.DkimPercentage !== undefined && output.DkimPercentage !== null ? output.DkimPercentage : undefined,
-    InboxPercentage:
-      output.InboxPercentage !== undefined && output.InboxPercentage !== null ? output.InboxPercentage : undefined,
-    MissingPercentage:
-      output.MissingPercentage !== undefined && output.MissingPercentage !== null
-        ? output.MissingPercentage
-        : undefined,
-    SpamPercentage:
-      output.SpamPercentage !== undefined && output.SpamPercentage !== null ? output.SpamPercentage : undefined,
-    SpfPercentage:
-      output.SpfPercentage !== undefined && output.SpfPercentage !== null ? output.SpfPercentage : undefined,
+    DkimPercentage: __expectNumber(output.DkimPercentage),
+    InboxPercentage: __expectNumber(output.InboxPercentage),
+    MissingPercentage: __expectNumber(output.MissingPercentage),
+    SpamPercentage: __expectNumber(output.SpamPercentage),
+    SpfPercentage: __expectNumber(output.SpfPercentage),
   } as any;
 };
 
@@ -5666,40 +5630,34 @@ const deserializeAws_restJson1ReputationOptions = (output: any, context: __Serde
       output.LastFreshStart !== undefined && output.LastFreshStart !== null
         ? new Date(Math.round(output.LastFreshStart * 1000))
         : undefined,
-    ReputationMetricsEnabled:
-      output.ReputationMetricsEnabled !== undefined && output.ReputationMetricsEnabled !== null
-        ? output.ReputationMetricsEnabled
-        : undefined,
+    ReputationMetricsEnabled: __expectBoolean(output.ReputationMetricsEnabled),
   } as any;
 };
 
 const deserializeAws_restJson1SendingOptions = (output: any, context: __SerdeContext): SendingOptions => {
   return {
-    SendingEnabled:
-      output.SendingEnabled !== undefined && output.SendingEnabled !== null ? output.SendingEnabled : undefined,
+    SendingEnabled: __expectBoolean(output.SendingEnabled),
   } as any;
 };
 
 const deserializeAws_restJson1SendQuota = (output: any, context: __SerdeContext): SendQuota => {
   return {
-    Max24HourSend:
-      output.Max24HourSend !== undefined && output.Max24HourSend !== null ? output.Max24HourSend : undefined,
-    MaxSendRate: output.MaxSendRate !== undefined && output.MaxSendRate !== null ? output.MaxSendRate : undefined,
-    SentLast24Hours:
-      output.SentLast24Hours !== undefined && output.SentLast24Hours !== null ? output.SentLast24Hours : undefined,
+    Max24HourSend: __expectNumber(output.Max24HourSend),
+    MaxSendRate: __expectNumber(output.MaxSendRate),
+    SentLast24Hours: __expectNumber(output.SentLast24Hours),
   } as any;
 };
 
 const deserializeAws_restJson1SnsDestination = (output: any, context: __SerdeContext): SnsDestination => {
   return {
-    TopicArn: output.TopicArn !== undefined && output.TopicArn !== null ? output.TopicArn : undefined,
+    TopicArn: __expectString(output.TopicArn),
   } as any;
 };
 
 const deserializeAws_restJson1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -5716,22 +5674,16 @@ const deserializeAws_restJson1TagList = (output: any, context: __SerdeContext): 
 
 const deserializeAws_restJson1TrackingOptions = (output: any, context: __SerdeContext): TrackingOptions => {
   return {
-    CustomRedirectDomain:
-      output.CustomRedirectDomain !== undefined && output.CustomRedirectDomain !== null
-        ? output.CustomRedirectDomain
-        : undefined,
+    CustomRedirectDomain: __expectString(output.CustomRedirectDomain),
   } as any;
 };
 
 const deserializeAws_restJson1VolumeStatistics = (output: any, context: __SerdeContext): VolumeStatistics => {
   return {
-    InboxRawCount:
-      output.InboxRawCount !== undefined && output.InboxRawCount !== null ? output.InboxRawCount : undefined,
-    ProjectedInbox:
-      output.ProjectedInbox !== undefined && output.ProjectedInbox !== null ? output.ProjectedInbox : undefined,
-    ProjectedSpam:
-      output.ProjectedSpam !== undefined && output.ProjectedSpam !== null ? output.ProjectedSpam : undefined,
-    SpamRawCount: output.SpamRawCount !== undefined && output.SpamRawCount !== null ? output.SpamRawCount : undefined,
+    InboxRawCount: __expectNumber(output.InboxRawCount),
+    ProjectedInbox: __expectNumber(output.ProjectedInbox),
+    ProjectedSpam: __expectNumber(output.ProjectedSpam),
+    SpamRawCount: __expectNumber(output.SpamRawCount),
   } as any;
 };
 

--- a/clients/client-pinpoint-sms-voice/protocols/Aws_restJson1.ts
+++ b/clients/client-pinpoint-sms-voice/protocols/Aws_restJson1.ts
@@ -48,6 +48,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -736,7 +738,7 @@ export const deserializeAws_restJson1ListConfigurationSetsCommand = async (
     contents.ConfigurationSets = deserializeAws_restJson1ConfigurationSets(data.ConfigurationSets, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -807,7 +809,7 @@ export const deserializeAws_restJson1SendVoiceMessageCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.MessageId !== undefined && data.MessageId !== null) {
-    contents.MessageId = data.MessageId;
+    contents.MessageId = __expectString(data.MessageId);
   }
   return Promise.resolve(contents);
 };
@@ -952,7 +954,7 @@ const deserializeAws_restJson1AlreadyExistsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -969,7 +971,7 @@ const deserializeAws_restJson1BadRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -986,7 +988,7 @@ const deserializeAws_restJson1InternalServiceErrorExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1003,7 +1005,7 @@ const deserializeAws_restJson1LimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1020,7 +1022,7 @@ const deserializeAws_restJson1NotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1037,7 +1039,7 @@ const deserializeAws_restJson1TooManyRequestsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1159,8 +1161,8 @@ const deserializeAws_restJson1CloudWatchLogsDestination = (
   context: __SerdeContext
 ): CloudWatchLogsDestination => {
   return {
-    IamRoleArn: output.IamRoleArn !== undefined && output.IamRoleArn !== null ? output.IamRoleArn : undefined,
-    LogGroupArn: output.LogGroupArn !== undefined && output.LogGroupArn !== null ? output.LogGroupArn : undefined,
+    IamRoleArn: __expectString(output.IamRoleArn),
+    LogGroupArn: __expectString(output.LogGroupArn),
   } as any;
 };
 
@@ -1171,7 +1173,7 @@ const deserializeAws_restJson1ConfigurationSets = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -1181,7 +1183,7 @@ const deserializeAws_restJson1EventDestination = (output: any, context: __SerdeC
       output.CloudWatchLogsDestination !== undefined && output.CloudWatchLogsDestination !== null
         ? deserializeAws_restJson1CloudWatchLogsDestination(output.CloudWatchLogsDestination, context)
         : undefined,
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
+    Enabled: __expectBoolean(output.Enabled),
     KinesisFirehoseDestination:
       output.KinesisFirehoseDestination !== undefined && output.KinesisFirehoseDestination !== null
         ? deserializeAws_restJson1KinesisFirehoseDestination(output.KinesisFirehoseDestination, context)
@@ -1190,7 +1192,7 @@ const deserializeAws_restJson1EventDestination = (output: any, context: __SerdeC
       output.MatchingEventTypes !== undefined && output.MatchingEventTypes !== null
         ? deserializeAws_restJson1EventTypes(output.MatchingEventTypes, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     SnsDestination:
       output.SnsDestination !== undefined && output.SnsDestination !== null
         ? deserializeAws_restJson1SnsDestination(output.SnsDestination, context)
@@ -1216,7 +1218,7 @@ const deserializeAws_restJson1EventTypes = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -1225,17 +1227,14 @@ const deserializeAws_restJson1KinesisFirehoseDestination = (
   context: __SerdeContext
 ): KinesisFirehoseDestination => {
   return {
-    DeliveryStreamArn:
-      output.DeliveryStreamArn !== undefined && output.DeliveryStreamArn !== null
-        ? output.DeliveryStreamArn
-        : undefined,
-    IamRoleArn: output.IamRoleArn !== undefined && output.IamRoleArn !== null ? output.IamRoleArn : undefined,
+    DeliveryStreamArn: __expectString(output.DeliveryStreamArn),
+    IamRoleArn: __expectString(output.IamRoleArn),
   } as any;
 };
 
 const deserializeAws_restJson1SnsDestination = (output: any, context: __SerdeContext): SnsDestination => {
   return {
-    TopicArn: output.TopicArn !== undefined && output.TopicArn !== null ? output.TopicArn : undefined,
+    TopicArn: __expectString(output.TopicArn),
   } as any;
 };
 

--- a/clients/client-pinpoint/protocols/Aws_restJson1.ts
+++ b/clients/client-pinpoint/protocols/Aws_restJson1.ts
@@ -413,6 +413,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -15458,10 +15461,10 @@ const deserializeAws_restJson1BadRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.RequestID !== undefined && data.RequestID !== null) {
-    contents.RequestID = data.RequestID;
+    contents.RequestID = __expectString(data.RequestID);
   }
   return contents;
 };
@@ -15479,10 +15482,10 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.RequestID !== undefined && data.RequestID !== null) {
-    contents.RequestID = data.RequestID;
+    contents.RequestID = __expectString(data.RequestID);
   }
   return contents;
 };
@@ -15500,10 +15503,10 @@ const deserializeAws_restJson1ForbiddenExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.RequestID !== undefined && data.RequestID !== null) {
-    contents.RequestID = data.RequestID;
+    contents.RequestID = __expectString(data.RequestID);
   }
   return contents;
 };
@@ -15521,10 +15524,10 @@ const deserializeAws_restJson1InternalServerErrorExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.RequestID !== undefined && data.RequestID !== null) {
-    contents.RequestID = data.RequestID;
+    contents.RequestID = __expectString(data.RequestID);
   }
   return contents;
 };
@@ -15542,10 +15545,10 @@ const deserializeAws_restJson1MethodNotAllowedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.RequestID !== undefined && data.RequestID !== null) {
-    contents.RequestID = data.RequestID;
+    contents.RequestID = __expectString(data.RequestID);
   }
   return contents;
 };
@@ -15563,10 +15566,10 @@ const deserializeAws_restJson1NotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.RequestID !== undefined && data.RequestID !== null) {
-    contents.RequestID = data.RequestID;
+    contents.RequestID = __expectString(data.RequestID);
   }
   return contents;
 };
@@ -15584,10 +15587,10 @@ const deserializeAws_restJson1PayloadTooLargeExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.RequestID !== undefined && data.RequestID !== null) {
-    contents.RequestID = data.RequestID;
+    contents.RequestID = __expectString(data.RequestID);
   }
   return contents;
 };
@@ -15605,10 +15608,10 @@ const deserializeAws_restJson1TooManyRequestsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.RequestID !== undefined && data.RequestID !== null) {
-    contents.RequestID = data.RequestID;
+    contents.RequestID = __expectString(data.RequestID);
   }
   return contents;
 };
@@ -17461,7 +17464,7 @@ const deserializeAws_restJson1ActivitiesResponse = (output: any, context: __Serd
       output.Item !== undefined && output.Item !== null
         ? deserializeAws_restJson1ListOfActivityResponse(output.Item, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -17475,7 +17478,7 @@ const deserializeAws_restJson1Activity = (output: any, context: __SerdeContext):
       output.ConditionalSplit !== undefined && output.ConditionalSplit !== null
         ? deserializeAws_restJson1ConditionalSplitActivity(output.ConditionalSplit, context)
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     EMAIL:
       output.EMAIL !== undefined && output.EMAIL !== null
         ? deserializeAws_restJson1EmailMessageActivity(output.EMAIL, context)
@@ -17509,52 +17512,34 @@ const deserializeAws_restJson1Activity = (output: any, context: __SerdeContext):
 
 const deserializeAws_restJson1ActivityResponse = (output: any, context: __SerdeContext): ActivityResponse => {
   return {
-    ApplicationId:
-      output.ApplicationId !== undefined && output.ApplicationId !== null ? output.ApplicationId : undefined,
-    CampaignId: output.CampaignId !== undefined && output.CampaignId !== null ? output.CampaignId : undefined,
-    End: output.End !== undefined && output.End !== null ? output.End : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Result: output.Result !== undefined && output.Result !== null ? output.Result : undefined,
-    ScheduledStart:
-      output.ScheduledStart !== undefined && output.ScheduledStart !== null ? output.ScheduledStart : undefined,
-    Start: output.Start !== undefined && output.Start !== null ? output.Start : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    SuccessfulEndpointCount:
-      output.SuccessfulEndpointCount !== undefined && output.SuccessfulEndpointCount !== null
-        ? output.SuccessfulEndpointCount
-        : undefined,
-    TimezonesCompletedCount:
-      output.TimezonesCompletedCount !== undefined && output.TimezonesCompletedCount !== null
-        ? output.TimezonesCompletedCount
-        : undefined,
-    TimezonesTotalCount:
-      output.TimezonesTotalCount !== undefined && output.TimezonesTotalCount !== null
-        ? output.TimezonesTotalCount
-        : undefined,
-    TotalEndpointCount:
-      output.TotalEndpointCount !== undefined && output.TotalEndpointCount !== null
-        ? output.TotalEndpointCount
-        : undefined,
-    TreatmentId: output.TreatmentId !== undefined && output.TreatmentId !== null ? output.TreatmentId : undefined,
+    ApplicationId: __expectString(output.ApplicationId),
+    CampaignId: __expectString(output.CampaignId),
+    End: __expectString(output.End),
+    Id: __expectString(output.Id),
+    Result: __expectString(output.Result),
+    ScheduledStart: __expectString(output.ScheduledStart),
+    Start: __expectString(output.Start),
+    State: __expectString(output.State),
+    SuccessfulEndpointCount: __expectNumber(output.SuccessfulEndpointCount),
+    TimezonesCompletedCount: __expectNumber(output.TimezonesCompletedCount),
+    TimezonesTotalCount: __expectNumber(output.TimezonesTotalCount),
+    TotalEndpointCount: __expectNumber(output.TotalEndpointCount),
+    TreatmentId: __expectString(output.TreatmentId),
   } as any;
 };
 
 const deserializeAws_restJson1ADMChannelResponse = (output: any, context: __SerdeContext): ADMChannelResponse => {
   return {
-    ApplicationId:
-      output.ApplicationId !== undefined && output.ApplicationId !== null ? output.ApplicationId : undefined,
-    CreationDate: output.CreationDate !== undefined && output.CreationDate !== null ? output.CreationDate : undefined,
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
-    HasCredential:
-      output.HasCredential !== undefined && output.HasCredential !== null ? output.HasCredential : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    IsArchived: output.IsArchived !== undefined && output.IsArchived !== null ? output.IsArchived : undefined,
-    LastModifiedBy:
-      output.LastModifiedBy !== undefined && output.LastModifiedBy !== null ? output.LastModifiedBy : undefined,
-    LastModifiedDate:
-      output.LastModifiedDate !== undefined && output.LastModifiedDate !== null ? output.LastModifiedDate : undefined,
-    Platform: output.Platform !== undefined && output.Platform !== null ? output.Platform : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    ApplicationId: __expectString(output.ApplicationId),
+    CreationDate: __expectString(output.CreationDate),
+    Enabled: __expectBoolean(output.Enabled),
+    HasCredential: __expectBoolean(output.HasCredential),
+    Id: __expectString(output.Id),
+    IsArchived: __expectBoolean(output.IsArchived),
+    LastModifiedBy: __expectString(output.LastModifiedBy),
+    LastModifiedDate: __expectString(output.LastModifiedDate),
+    Platform: __expectString(output.Platform),
+    Version: __expectNumber(output.Version),
   } as any;
 };
 
@@ -17563,42 +17548,32 @@ const deserializeAws_restJson1AndroidPushNotificationTemplate = (
   context: __SerdeContext
 ): AndroidPushNotificationTemplate => {
   return {
-    Action: output.Action !== undefined && output.Action !== null ? output.Action : undefined,
-    Body: output.Body !== undefined && output.Body !== null ? output.Body : undefined,
-    ImageIconUrl: output.ImageIconUrl !== undefined && output.ImageIconUrl !== null ? output.ImageIconUrl : undefined,
-    ImageUrl: output.ImageUrl !== undefined && output.ImageUrl !== null ? output.ImageUrl : undefined,
-    RawContent: output.RawContent !== undefined && output.RawContent !== null ? output.RawContent : undefined,
-    SmallImageIconUrl:
-      output.SmallImageIconUrl !== undefined && output.SmallImageIconUrl !== null
-        ? output.SmallImageIconUrl
-        : undefined,
-    Sound: output.Sound !== undefined && output.Sound !== null ? output.Sound : undefined,
-    Title: output.Title !== undefined && output.Title !== null ? output.Title : undefined,
-    Url: output.Url !== undefined && output.Url !== null ? output.Url : undefined,
+    Action: __expectString(output.Action),
+    Body: __expectString(output.Body),
+    ImageIconUrl: __expectString(output.ImageIconUrl),
+    ImageUrl: __expectString(output.ImageUrl),
+    RawContent: __expectString(output.RawContent),
+    SmallImageIconUrl: __expectString(output.SmallImageIconUrl),
+    Sound: __expectString(output.Sound),
+    Title: __expectString(output.Title),
+    Url: __expectString(output.Url),
   } as any;
 };
 
 const deserializeAws_restJson1APNSChannelResponse = (output: any, context: __SerdeContext): APNSChannelResponse => {
   return {
-    ApplicationId:
-      output.ApplicationId !== undefined && output.ApplicationId !== null ? output.ApplicationId : undefined,
-    CreationDate: output.CreationDate !== undefined && output.CreationDate !== null ? output.CreationDate : undefined,
-    DefaultAuthenticationMethod:
-      output.DefaultAuthenticationMethod !== undefined && output.DefaultAuthenticationMethod !== null
-        ? output.DefaultAuthenticationMethod
-        : undefined,
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
-    HasCredential:
-      output.HasCredential !== undefined && output.HasCredential !== null ? output.HasCredential : undefined,
-    HasTokenKey: output.HasTokenKey !== undefined && output.HasTokenKey !== null ? output.HasTokenKey : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    IsArchived: output.IsArchived !== undefined && output.IsArchived !== null ? output.IsArchived : undefined,
-    LastModifiedBy:
-      output.LastModifiedBy !== undefined && output.LastModifiedBy !== null ? output.LastModifiedBy : undefined,
-    LastModifiedDate:
-      output.LastModifiedDate !== undefined && output.LastModifiedDate !== null ? output.LastModifiedDate : undefined,
-    Platform: output.Platform !== undefined && output.Platform !== null ? output.Platform : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    ApplicationId: __expectString(output.ApplicationId),
+    CreationDate: __expectString(output.CreationDate),
+    DefaultAuthenticationMethod: __expectString(output.DefaultAuthenticationMethod),
+    Enabled: __expectBoolean(output.Enabled),
+    HasCredential: __expectBoolean(output.HasCredential),
+    HasTokenKey: __expectBoolean(output.HasTokenKey),
+    Id: __expectString(output.Id),
+    IsArchived: __expectBoolean(output.IsArchived),
+    LastModifiedBy: __expectString(output.LastModifiedBy),
+    LastModifiedDate: __expectString(output.LastModifiedDate),
+    Platform: __expectString(output.Platform),
+    Version: __expectNumber(output.Version),
   } as any;
 };
 
@@ -17607,13 +17582,13 @@ const deserializeAws_restJson1APNSPushNotificationTemplate = (
   context: __SerdeContext
 ): APNSPushNotificationTemplate => {
   return {
-    Action: output.Action !== undefined && output.Action !== null ? output.Action : undefined,
-    Body: output.Body !== undefined && output.Body !== null ? output.Body : undefined,
-    MediaUrl: output.MediaUrl !== undefined && output.MediaUrl !== null ? output.MediaUrl : undefined,
-    RawContent: output.RawContent !== undefined && output.RawContent !== null ? output.RawContent : undefined,
-    Sound: output.Sound !== undefined && output.Sound !== null ? output.Sound : undefined,
-    Title: output.Title !== undefined && output.Title !== null ? output.Title : undefined,
-    Url: output.Url !== undefined && output.Url !== null ? output.Url : undefined,
+    Action: __expectString(output.Action),
+    Body: __expectString(output.Body),
+    MediaUrl: __expectString(output.MediaUrl),
+    RawContent: __expectString(output.RawContent),
+    Sound: __expectString(output.Sound),
+    Title: __expectString(output.Title),
+    Url: __expectString(output.Url),
   } as any;
 };
 
@@ -17622,25 +17597,18 @@ const deserializeAws_restJson1APNSSandboxChannelResponse = (
   context: __SerdeContext
 ): APNSSandboxChannelResponse => {
   return {
-    ApplicationId:
-      output.ApplicationId !== undefined && output.ApplicationId !== null ? output.ApplicationId : undefined,
-    CreationDate: output.CreationDate !== undefined && output.CreationDate !== null ? output.CreationDate : undefined,
-    DefaultAuthenticationMethod:
-      output.DefaultAuthenticationMethod !== undefined && output.DefaultAuthenticationMethod !== null
-        ? output.DefaultAuthenticationMethod
-        : undefined,
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
-    HasCredential:
-      output.HasCredential !== undefined && output.HasCredential !== null ? output.HasCredential : undefined,
-    HasTokenKey: output.HasTokenKey !== undefined && output.HasTokenKey !== null ? output.HasTokenKey : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    IsArchived: output.IsArchived !== undefined && output.IsArchived !== null ? output.IsArchived : undefined,
-    LastModifiedBy:
-      output.LastModifiedBy !== undefined && output.LastModifiedBy !== null ? output.LastModifiedBy : undefined,
-    LastModifiedDate:
-      output.LastModifiedDate !== undefined && output.LastModifiedDate !== null ? output.LastModifiedDate : undefined,
-    Platform: output.Platform !== undefined && output.Platform !== null ? output.Platform : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    ApplicationId: __expectString(output.ApplicationId),
+    CreationDate: __expectString(output.CreationDate),
+    DefaultAuthenticationMethod: __expectString(output.DefaultAuthenticationMethod),
+    Enabled: __expectBoolean(output.Enabled),
+    HasCredential: __expectBoolean(output.HasCredential),
+    HasTokenKey: __expectBoolean(output.HasTokenKey),
+    Id: __expectString(output.Id),
+    IsArchived: __expectBoolean(output.IsArchived),
+    LastModifiedBy: __expectString(output.LastModifiedBy),
+    LastModifiedDate: __expectString(output.LastModifiedDate),
+    Platform: __expectString(output.Platform),
+    Version: __expectNumber(output.Version),
   } as any;
 };
 
@@ -17649,25 +17617,18 @@ const deserializeAws_restJson1APNSVoipChannelResponse = (
   context: __SerdeContext
 ): APNSVoipChannelResponse => {
   return {
-    ApplicationId:
-      output.ApplicationId !== undefined && output.ApplicationId !== null ? output.ApplicationId : undefined,
-    CreationDate: output.CreationDate !== undefined && output.CreationDate !== null ? output.CreationDate : undefined,
-    DefaultAuthenticationMethod:
-      output.DefaultAuthenticationMethod !== undefined && output.DefaultAuthenticationMethod !== null
-        ? output.DefaultAuthenticationMethod
-        : undefined,
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
-    HasCredential:
-      output.HasCredential !== undefined && output.HasCredential !== null ? output.HasCredential : undefined,
-    HasTokenKey: output.HasTokenKey !== undefined && output.HasTokenKey !== null ? output.HasTokenKey : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    IsArchived: output.IsArchived !== undefined && output.IsArchived !== null ? output.IsArchived : undefined,
-    LastModifiedBy:
-      output.LastModifiedBy !== undefined && output.LastModifiedBy !== null ? output.LastModifiedBy : undefined,
-    LastModifiedDate:
-      output.LastModifiedDate !== undefined && output.LastModifiedDate !== null ? output.LastModifiedDate : undefined,
-    Platform: output.Platform !== undefined && output.Platform !== null ? output.Platform : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    ApplicationId: __expectString(output.ApplicationId),
+    CreationDate: __expectString(output.CreationDate),
+    DefaultAuthenticationMethod: __expectString(output.DefaultAuthenticationMethod),
+    Enabled: __expectBoolean(output.Enabled),
+    HasCredential: __expectBoolean(output.HasCredential),
+    HasTokenKey: __expectBoolean(output.HasTokenKey),
+    Id: __expectString(output.Id),
+    IsArchived: __expectBoolean(output.IsArchived),
+    LastModifiedBy: __expectString(output.LastModifiedBy),
+    LastModifiedDate: __expectString(output.LastModifiedDate),
+    Platform: __expectString(output.Platform),
+    Version: __expectNumber(output.Version),
   } as any;
 };
 
@@ -17676,25 +17637,18 @@ const deserializeAws_restJson1APNSVoipSandboxChannelResponse = (
   context: __SerdeContext
 ): APNSVoipSandboxChannelResponse => {
   return {
-    ApplicationId:
-      output.ApplicationId !== undefined && output.ApplicationId !== null ? output.ApplicationId : undefined,
-    CreationDate: output.CreationDate !== undefined && output.CreationDate !== null ? output.CreationDate : undefined,
-    DefaultAuthenticationMethod:
-      output.DefaultAuthenticationMethod !== undefined && output.DefaultAuthenticationMethod !== null
-        ? output.DefaultAuthenticationMethod
-        : undefined,
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
-    HasCredential:
-      output.HasCredential !== undefined && output.HasCredential !== null ? output.HasCredential : undefined,
-    HasTokenKey: output.HasTokenKey !== undefined && output.HasTokenKey !== null ? output.HasTokenKey : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    IsArchived: output.IsArchived !== undefined && output.IsArchived !== null ? output.IsArchived : undefined,
-    LastModifiedBy:
-      output.LastModifiedBy !== undefined && output.LastModifiedBy !== null ? output.LastModifiedBy : undefined,
-    LastModifiedDate:
-      output.LastModifiedDate !== undefined && output.LastModifiedDate !== null ? output.LastModifiedDate : undefined,
-    Platform: output.Platform !== undefined && output.Platform !== null ? output.Platform : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    ApplicationId: __expectString(output.ApplicationId),
+    CreationDate: __expectString(output.CreationDate),
+    DefaultAuthenticationMethod: __expectString(output.DefaultAuthenticationMethod),
+    Enabled: __expectBoolean(output.Enabled),
+    HasCredential: __expectBoolean(output.HasCredential),
+    HasTokenKey: __expectBoolean(output.HasTokenKey),
+    Id: __expectString(output.Id),
+    IsArchived: __expectBoolean(output.IsArchived),
+    LastModifiedBy: __expectString(output.LastModifiedBy),
+    LastModifiedDate: __expectString(output.LastModifiedDate),
+    Platform: __expectString(output.Platform),
+    Version: __expectNumber(output.Version),
   } as any;
 };
 
@@ -17703,24 +17657,23 @@ const deserializeAws_restJson1ApplicationDateRangeKpiResponse = (
   context: __SerdeContext
 ): ApplicationDateRangeKpiResponse => {
   return {
-    ApplicationId:
-      output.ApplicationId !== undefined && output.ApplicationId !== null ? output.ApplicationId : undefined,
+    ApplicationId: __expectString(output.ApplicationId),
     EndTime: output.EndTime !== undefined && output.EndTime !== null ? new Date(output.EndTime) : undefined,
-    KpiName: output.KpiName !== undefined && output.KpiName !== null ? output.KpiName : undefined,
+    KpiName: __expectString(output.KpiName),
     KpiResult:
       output.KpiResult !== undefined && output.KpiResult !== null
         ? deserializeAws_restJson1BaseKpiResult(output.KpiResult, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     StartTime: output.StartTime !== undefined && output.StartTime !== null ? new Date(output.StartTime) : undefined,
   } as any;
 };
 
 const deserializeAws_restJson1ApplicationResponse = (output: any, context: __SerdeContext): ApplicationResponse => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Arn: __expectString(output.Arn),
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1MapOf__string(output.tags, context)
@@ -17733,14 +17686,12 @@ const deserializeAws_restJson1ApplicationSettingsResource = (
   context: __SerdeContext
 ): ApplicationSettingsResource => {
   return {
-    ApplicationId:
-      output.ApplicationId !== undefined && output.ApplicationId !== null ? output.ApplicationId : undefined,
+    ApplicationId: __expectString(output.ApplicationId),
     CampaignHook:
       output.CampaignHook !== undefined && output.CampaignHook !== null
         ? deserializeAws_restJson1CampaignHook(output.CampaignHook, context)
         : undefined,
-    LastModifiedDate:
-      output.LastModifiedDate !== undefined && output.LastModifiedDate !== null ? output.LastModifiedDate : undefined,
+    LastModifiedDate: __expectString(output.LastModifiedDate),
     Limits:
       output.Limits !== undefined && output.Limits !== null
         ? deserializeAws_restJson1CampaignLimits(output.Limits, context)
@@ -17758,14 +17709,13 @@ const deserializeAws_restJson1ApplicationsResponse = (output: any, context: __Se
       output.Item !== undefined && output.Item !== null
         ? deserializeAws_restJson1ListOfApplicationResponse(output.Item, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
 const deserializeAws_restJson1AttributeDimension = (output: any, context: __SerdeContext): AttributeDimension => {
   return {
-    AttributeType:
-      output.AttributeType !== undefined && output.AttributeType !== null ? output.AttributeType : undefined,
+    AttributeType: __expectString(output.AttributeType),
     Values:
       output.Values !== undefined && output.Values !== null
         ? deserializeAws_restJson1ListOf__string(output.Values, context)
@@ -17775,10 +17725,8 @@ const deserializeAws_restJson1AttributeDimension = (output: any, context: __Serd
 
 const deserializeAws_restJson1AttributesResource = (output: any, context: __SerdeContext): AttributesResource => {
   return {
-    ApplicationId:
-      output.ApplicationId !== undefined && output.ApplicationId !== null ? output.ApplicationId : undefined,
-    AttributeType:
-      output.AttributeType !== undefined && output.AttributeType !== null ? output.AttributeType : undefined,
+    ApplicationId: __expectString(output.ApplicationId),
+    AttributeType: __expectString(output.AttributeType),
     Attributes:
       output.Attributes !== undefined && output.Attributes !== null
         ? deserializeAws_restJson1ListOf__string(output.Attributes, context)
@@ -17788,21 +17736,17 @@ const deserializeAws_restJson1AttributesResource = (output: any, context: __Serd
 
 const deserializeAws_restJson1BaiduChannelResponse = (output: any, context: __SerdeContext): BaiduChannelResponse => {
   return {
-    ApplicationId:
-      output.ApplicationId !== undefined && output.ApplicationId !== null ? output.ApplicationId : undefined,
-    CreationDate: output.CreationDate !== undefined && output.CreationDate !== null ? output.CreationDate : undefined,
-    Credential: output.Credential !== undefined && output.Credential !== null ? output.Credential : undefined,
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
-    HasCredential:
-      output.HasCredential !== undefined && output.HasCredential !== null ? output.HasCredential : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    IsArchived: output.IsArchived !== undefined && output.IsArchived !== null ? output.IsArchived : undefined,
-    LastModifiedBy:
-      output.LastModifiedBy !== undefined && output.LastModifiedBy !== null ? output.LastModifiedBy : undefined,
-    LastModifiedDate:
-      output.LastModifiedDate !== undefined && output.LastModifiedDate !== null ? output.LastModifiedDate : undefined,
-    Platform: output.Platform !== undefined && output.Platform !== null ? output.Platform : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    ApplicationId: __expectString(output.ApplicationId),
+    CreationDate: __expectString(output.CreationDate),
+    Credential: __expectString(output.Credential),
+    Enabled: __expectBoolean(output.Enabled),
+    HasCredential: __expectBoolean(output.HasCredential),
+    Id: __expectString(output.Id),
+    IsArchived: __expectBoolean(output.IsArchived),
+    LastModifiedBy: __expectString(output.LastModifiedBy),
+    LastModifiedDate: __expectString(output.LastModifiedDate),
+    Platform: __expectString(output.Platform),
+    Version: __expectNumber(output.Version),
   } as any;
 };
 
@@ -17817,7 +17761,7 @@ const deserializeAws_restJson1BaseKpiResult = (output: any, context: __SerdeCont
 
 const deserializeAws_restJson1CampaignCustomMessage = (output: any, context: __SerdeContext): CampaignCustomMessage => {
   return {
-    Data: output.Data !== undefined && output.Data !== null ? output.Data : undefined,
+    Data: __expectString(output.Data),
   } as any;
 };
 
@@ -17826,26 +17770,25 @@ const deserializeAws_restJson1CampaignDateRangeKpiResponse = (
   context: __SerdeContext
 ): CampaignDateRangeKpiResponse => {
   return {
-    ApplicationId:
-      output.ApplicationId !== undefined && output.ApplicationId !== null ? output.ApplicationId : undefined,
-    CampaignId: output.CampaignId !== undefined && output.CampaignId !== null ? output.CampaignId : undefined,
+    ApplicationId: __expectString(output.ApplicationId),
+    CampaignId: __expectString(output.CampaignId),
     EndTime: output.EndTime !== undefined && output.EndTime !== null ? new Date(output.EndTime) : undefined,
-    KpiName: output.KpiName !== undefined && output.KpiName !== null ? output.KpiName : undefined,
+    KpiName: __expectString(output.KpiName),
     KpiResult:
       output.KpiResult !== undefined && output.KpiResult !== null
         ? deserializeAws_restJson1BaseKpiResult(output.KpiResult, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     StartTime: output.StartTime !== undefined && output.StartTime !== null ? new Date(output.StartTime) : undefined,
   } as any;
 };
 
 const deserializeAws_restJson1CampaignEmailMessage = (output: any, context: __SerdeContext): CampaignEmailMessage => {
   return {
-    Body: output.Body !== undefined && output.Body !== null ? output.Body : undefined,
-    FromAddress: output.FromAddress !== undefined && output.FromAddress !== null ? output.FromAddress : undefined,
-    HtmlBody: output.HtmlBody !== undefined && output.HtmlBody !== null ? output.HtmlBody : undefined,
-    Title: output.Title !== undefined && output.Title !== null ? output.Title : undefined,
+    Body: __expectString(output.Body),
+    FromAddress: __expectString(output.FromAddress),
+    HtmlBody: __expectString(output.HtmlBody),
+    Title: __expectString(output.Title),
   } as any;
 };
 
@@ -17855,31 +17798,24 @@ const deserializeAws_restJson1CampaignEventFilter = (output: any, context: __Ser
       output.Dimensions !== undefined && output.Dimensions !== null
         ? deserializeAws_restJson1EventDimensions(output.Dimensions, context)
         : undefined,
-    FilterType: output.FilterType !== undefined && output.FilterType !== null ? output.FilterType : undefined,
+    FilterType: __expectString(output.FilterType),
   } as any;
 };
 
 const deserializeAws_restJson1CampaignHook = (output: any, context: __SerdeContext): CampaignHook => {
   return {
-    LambdaFunctionName:
-      output.LambdaFunctionName !== undefined && output.LambdaFunctionName !== null
-        ? output.LambdaFunctionName
-        : undefined,
-    Mode: output.Mode !== undefined && output.Mode !== null ? output.Mode : undefined,
-    WebUrl: output.WebUrl !== undefined && output.WebUrl !== null ? output.WebUrl : undefined,
+    LambdaFunctionName: __expectString(output.LambdaFunctionName),
+    Mode: __expectString(output.Mode),
+    WebUrl: __expectString(output.WebUrl),
   } as any;
 };
 
 const deserializeAws_restJson1CampaignLimits = (output: any, context: __SerdeContext): CampaignLimits => {
   return {
-    Daily: output.Daily !== undefined && output.Daily !== null ? output.Daily : undefined,
-    MaximumDuration:
-      output.MaximumDuration !== undefined && output.MaximumDuration !== null ? output.MaximumDuration : undefined,
-    MessagesPerSecond:
-      output.MessagesPerSecond !== undefined && output.MessagesPerSecond !== null
-        ? output.MessagesPerSecond
-        : undefined,
-    Total: output.Total !== undefined && output.Total !== null ? output.Total : undefined,
+    Daily: __expectNumber(output.Daily),
+    MaximumDuration: __expectNumber(output.MaximumDuration),
+    MessagesPerSecond: __expectNumber(output.MessagesPerSecond),
+    Total: __expectNumber(output.Total),
   } as any;
 };
 
@@ -17889,10 +17825,9 @@ const deserializeAws_restJson1CampaignResponse = (output: any, context: __SerdeC
       output.AdditionalTreatments !== undefined && output.AdditionalTreatments !== null
         ? deserializeAws_restJson1ListOfTreatmentResource(output.AdditionalTreatments, context)
         : undefined,
-    ApplicationId:
-      output.ApplicationId !== undefined && output.ApplicationId !== null ? output.ApplicationId : undefined,
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    CreationDate: output.CreationDate !== undefined && output.CreationDate !== null ? output.CreationDate : undefined,
+    ApplicationId: __expectString(output.ApplicationId),
+    Arn: __expectString(output.Arn),
+    CreationDate: __expectString(output.CreationDate),
     CustomDeliveryConfiguration:
       output.CustomDeliveryConfiguration !== undefined && output.CustomDeliveryConfiguration !== null
         ? deserializeAws_restJson1CustomDeliveryConfiguration(output.CustomDeliveryConfiguration, context)
@@ -17901,17 +17836,15 @@ const deserializeAws_restJson1CampaignResponse = (output: any, context: __SerdeC
       output.DefaultState !== undefined && output.DefaultState !== null
         ? deserializeAws_restJson1CampaignState(output.DefaultState, context)
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    HoldoutPercent:
-      output.HoldoutPercent !== undefined && output.HoldoutPercent !== null ? output.HoldoutPercent : undefined,
+    Description: __expectString(output.Description),
+    HoldoutPercent: __expectNumber(output.HoldoutPercent),
     Hook:
       output.Hook !== undefined && output.Hook !== null
         ? deserializeAws_restJson1CampaignHook(output.Hook, context)
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    IsPaused: output.IsPaused !== undefined && output.IsPaused !== null ? output.IsPaused : undefined,
-    LastModifiedDate:
-      output.LastModifiedDate !== undefined && output.LastModifiedDate !== null ? output.LastModifiedDate : undefined,
+    Id: __expectString(output.Id),
+    IsPaused: __expectBoolean(output.IsPaused),
+    LastModifiedDate: __expectString(output.LastModifiedDate),
     Limits:
       output.Limits !== undefined && output.Limits !== null
         ? deserializeAws_restJson1CampaignLimits(output.Limits, context)
@@ -17920,14 +17853,13 @@ const deserializeAws_restJson1CampaignResponse = (output: any, context: __SerdeC
       output.MessageConfiguration !== undefined && output.MessageConfiguration !== null
         ? deserializeAws_restJson1MessageConfiguration(output.MessageConfiguration, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     Schedule:
       output.Schedule !== undefined && output.Schedule !== null
         ? deserializeAws_restJson1Schedule(output.Schedule, context)
         : undefined,
-    SegmentId: output.SegmentId !== undefined && output.SegmentId !== null ? output.SegmentId : undefined,
-    SegmentVersion:
-      output.SegmentVersion !== undefined && output.SegmentVersion !== null ? output.SegmentVersion : undefined,
+    SegmentId: __expectString(output.SegmentId),
+    SegmentVersion: __expectNumber(output.SegmentVersion),
     State:
       output.State !== undefined && output.State !== null
         ? deserializeAws_restJson1CampaignState(output.State, context)
@@ -17936,13 +17868,9 @@ const deserializeAws_restJson1CampaignResponse = (output: any, context: __SerdeC
       output.TemplateConfiguration !== undefined && output.TemplateConfiguration !== null
         ? deserializeAws_restJson1TemplateConfiguration(output.TemplateConfiguration, context)
         : undefined,
-    TreatmentDescription:
-      output.TreatmentDescription !== undefined && output.TreatmentDescription !== null
-        ? output.TreatmentDescription
-        : undefined,
-    TreatmentName:
-      output.TreatmentName !== undefined && output.TreatmentName !== null ? output.TreatmentName : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    TreatmentDescription: __expectString(output.TreatmentDescription),
+    TreatmentName: __expectString(output.TreatmentName),
+    Version: __expectNumber(output.Version),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1MapOf__string(output.tags, context)
@@ -17952,15 +17880,12 @@ const deserializeAws_restJson1CampaignResponse = (output: any, context: __SerdeC
 
 const deserializeAws_restJson1CampaignSmsMessage = (output: any, context: __SerdeContext): CampaignSmsMessage => {
   return {
-    Body: output.Body !== undefined && output.Body !== null ? output.Body : undefined,
-    EntityId: output.EntityId !== undefined && output.EntityId !== null ? output.EntityId : undefined,
-    MessageType: output.MessageType !== undefined && output.MessageType !== null ? output.MessageType : undefined,
-    OriginationNumber:
-      output.OriginationNumber !== undefined && output.OriginationNumber !== null
-        ? output.OriginationNumber
-        : undefined,
-    SenderId: output.SenderId !== undefined && output.SenderId !== null ? output.SenderId : undefined,
-    TemplateId: output.TemplateId !== undefined && output.TemplateId !== null ? output.TemplateId : undefined,
+    Body: __expectString(output.Body),
+    EntityId: __expectString(output.EntityId),
+    MessageType: __expectString(output.MessageType),
+    OriginationNumber: __expectString(output.OriginationNumber),
+    SenderId: __expectString(output.SenderId),
+    TemplateId: __expectString(output.TemplateId),
   } as any;
 };
 
@@ -17970,32 +17895,27 @@ const deserializeAws_restJson1CampaignsResponse = (output: any, context: __Serde
       output.Item !== undefined && output.Item !== null
         ? deserializeAws_restJson1ListOfCampaignResponse(output.Item, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
 const deserializeAws_restJson1CampaignState = (output: any, context: __SerdeContext): CampaignState => {
   return {
-    CampaignStatus:
-      output.CampaignStatus !== undefined && output.CampaignStatus !== null ? output.CampaignStatus : undefined,
+    CampaignStatus: __expectString(output.CampaignStatus),
   } as any;
 };
 
 const deserializeAws_restJson1ChannelResponse = (output: any, context: __SerdeContext): ChannelResponse => {
   return {
-    ApplicationId:
-      output.ApplicationId !== undefined && output.ApplicationId !== null ? output.ApplicationId : undefined,
-    CreationDate: output.CreationDate !== undefined && output.CreationDate !== null ? output.CreationDate : undefined,
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
-    HasCredential:
-      output.HasCredential !== undefined && output.HasCredential !== null ? output.HasCredential : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    IsArchived: output.IsArchived !== undefined && output.IsArchived !== null ? output.IsArchived : undefined,
-    LastModifiedBy:
-      output.LastModifiedBy !== undefined && output.LastModifiedBy !== null ? output.LastModifiedBy : undefined,
-    LastModifiedDate:
-      output.LastModifiedDate !== undefined && output.LastModifiedDate !== null ? output.LastModifiedDate : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    ApplicationId: __expectString(output.ApplicationId),
+    CreationDate: __expectString(output.CreationDate),
+    Enabled: __expectBoolean(output.Enabled),
+    HasCredential: __expectBoolean(output.HasCredential),
+    Id: __expectString(output.Id),
+    IsArchived: __expectBoolean(output.IsArchived),
+    LastModifiedBy: __expectString(output.LastModifiedBy),
+    LastModifiedDate: __expectString(output.LastModifiedDate),
+    Version: __expectNumber(output.Version),
   } as any;
 };
 
@@ -18014,7 +17934,7 @@ const deserializeAws_restJson1Condition = (output: any, context: __SerdeContext)
       output.Conditions !== undefined && output.Conditions !== null
         ? deserializeAws_restJson1ListOfSimpleCondition(output.Conditions, context)
         : undefined,
-    Operator: output.Operator !== undefined && output.Operator !== null ? output.Operator : undefined,
+    Operator: __expectString(output.Operator),
   } as any;
 };
 
@@ -18031,9 +17951,8 @@ const deserializeAws_restJson1ConditionalSplitActivity = (
       output.EvaluationWaitTime !== undefined && output.EvaluationWaitTime !== null
         ? deserializeAws_restJson1WaitTime(output.EvaluationWaitTime, context)
         : undefined,
-    FalseActivity:
-      output.FalseActivity !== undefined && output.FalseActivity !== null ? output.FalseActivity : undefined,
-    TrueActivity: output.TrueActivity !== undefined && output.TrueActivity !== null ? output.TrueActivity : undefined,
+    FalseActivity: __expectString(output.FalseActivity),
+    TrueActivity: __expectString(output.TrueActivity),
   } as any;
 };
 
@@ -18042,9 +17961,9 @@ const deserializeAws_restJson1CreateTemplateMessageBody = (
   context: __SerdeContext
 ): CreateTemplateMessageBody => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RequestID: output.RequestID !== undefined && output.RequestID !== null ? output.RequestID : undefined,
+    Arn: __expectString(output.Arn),
+    Message: __expectString(output.Message),
+    RequestID: __expectString(output.RequestID),
   } as any;
 };
 
@@ -18053,7 +17972,7 @@ const deserializeAws_restJson1CustomDeliveryConfiguration = (
   context: __SerdeContext
 ): CustomDeliveryConfiguration => {
   return {
-    DeliveryUri: output.DeliveryUri !== undefined && output.DeliveryUri !== null ? output.DeliveryUri : undefined,
+    DeliveryUri: __expectString(output.DeliveryUri),
     EndpointTypes:
       output.EndpointTypes !== undefined && output.EndpointTypes !== null
         ? deserializeAws_restJson1ListOf__EndpointTypesElement(output.EndpointTypes, context)
@@ -18063,7 +17982,7 @@ const deserializeAws_restJson1CustomDeliveryConfiguration = (
 
 const deserializeAws_restJson1CustomMessageActivity = (output: any, context: __SerdeContext): CustomMessageActivity => {
   return {
-    DeliveryUri: output.DeliveryUri !== undefined && output.DeliveryUri !== null ? output.DeliveryUri : undefined,
+    DeliveryUri: __expectString(output.DeliveryUri),
     EndpointTypes:
       output.EndpointTypes !== undefined && output.EndpointTypes !== null
         ? deserializeAws_restJson1ListOf__EndpointTypesElement(output.EndpointTypes, context)
@@ -18072,10 +17991,9 @@ const deserializeAws_restJson1CustomMessageActivity = (output: any, context: __S
       output.MessageConfig !== undefined && output.MessageConfig !== null
         ? deserializeAws_restJson1JourneyCustomMessage(output.MessageConfig, context)
         : undefined,
-    NextActivity: output.NextActivity !== undefined && output.NextActivity !== null ? output.NextActivity : undefined,
-    TemplateName: output.TemplateName !== undefined && output.TemplateName !== null ? output.TemplateName : undefined,
-    TemplateVersion:
-      output.TemplateVersion !== undefined && output.TemplateVersion !== null ? output.TemplateVersion : undefined,
+    NextActivity: __expectString(output.NextActivity),
+    TemplateName: __expectString(output.TemplateName),
+    TemplateVersion: __expectString(output.TemplateVersion),
   } as any;
 };
 
@@ -18084,39 +18002,31 @@ const deserializeAws_restJson1DefaultPushNotificationTemplate = (
   context: __SerdeContext
 ): DefaultPushNotificationTemplate => {
   return {
-    Action: output.Action !== undefined && output.Action !== null ? output.Action : undefined,
-    Body: output.Body !== undefined && output.Body !== null ? output.Body : undefined,
-    Sound: output.Sound !== undefined && output.Sound !== null ? output.Sound : undefined,
-    Title: output.Title !== undefined && output.Title !== null ? output.Title : undefined,
-    Url: output.Url !== undefined && output.Url !== null ? output.Url : undefined,
+    Action: __expectString(output.Action),
+    Body: __expectString(output.Body),
+    Sound: __expectString(output.Sound),
+    Title: __expectString(output.Title),
+    Url: __expectString(output.Url),
   } as any;
 };
 
 const deserializeAws_restJson1EmailChannelResponse = (output: any, context: __SerdeContext): EmailChannelResponse => {
   return {
-    ApplicationId:
-      output.ApplicationId !== undefined && output.ApplicationId !== null ? output.ApplicationId : undefined,
-    ConfigurationSet:
-      output.ConfigurationSet !== undefined && output.ConfigurationSet !== null ? output.ConfigurationSet : undefined,
-    CreationDate: output.CreationDate !== undefined && output.CreationDate !== null ? output.CreationDate : undefined,
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
-    FromAddress: output.FromAddress !== undefined && output.FromAddress !== null ? output.FromAddress : undefined,
-    HasCredential:
-      output.HasCredential !== undefined && output.HasCredential !== null ? output.HasCredential : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Identity: output.Identity !== undefined && output.Identity !== null ? output.Identity : undefined,
-    IsArchived: output.IsArchived !== undefined && output.IsArchived !== null ? output.IsArchived : undefined,
-    LastModifiedBy:
-      output.LastModifiedBy !== undefined && output.LastModifiedBy !== null ? output.LastModifiedBy : undefined,
-    LastModifiedDate:
-      output.LastModifiedDate !== undefined && output.LastModifiedDate !== null ? output.LastModifiedDate : undefined,
-    MessagesPerSecond:
-      output.MessagesPerSecond !== undefined && output.MessagesPerSecond !== null
-        ? output.MessagesPerSecond
-        : undefined,
-    Platform: output.Platform !== undefined && output.Platform !== null ? output.Platform : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    ApplicationId: __expectString(output.ApplicationId),
+    ConfigurationSet: __expectString(output.ConfigurationSet),
+    CreationDate: __expectString(output.CreationDate),
+    Enabled: __expectBoolean(output.Enabled),
+    FromAddress: __expectString(output.FromAddress),
+    HasCredential: __expectBoolean(output.HasCredential),
+    Id: __expectString(output.Id),
+    Identity: __expectString(output.Identity),
+    IsArchived: __expectBoolean(output.IsArchived),
+    LastModifiedBy: __expectString(output.LastModifiedBy),
+    LastModifiedDate: __expectString(output.LastModifiedDate),
+    MessagesPerSecond: __expectNumber(output.MessagesPerSecond),
+    Platform: __expectString(output.Platform),
+    RoleArn: __expectString(output.RoleArn),
+    Version: __expectNumber(output.Version),
   } as any;
 };
 
@@ -18126,35 +18036,26 @@ const deserializeAws_restJson1EmailMessageActivity = (output: any, context: __Se
       output.MessageConfig !== undefined && output.MessageConfig !== null
         ? deserializeAws_restJson1JourneyEmailMessage(output.MessageConfig, context)
         : undefined,
-    NextActivity: output.NextActivity !== undefined && output.NextActivity !== null ? output.NextActivity : undefined,
-    TemplateName: output.TemplateName !== undefined && output.TemplateName !== null ? output.TemplateName : undefined,
-    TemplateVersion:
-      output.TemplateVersion !== undefined && output.TemplateVersion !== null ? output.TemplateVersion : undefined,
+    NextActivity: __expectString(output.NextActivity),
+    TemplateName: __expectString(output.TemplateName),
+    TemplateVersion: __expectString(output.TemplateVersion),
   } as any;
 };
 
 const deserializeAws_restJson1EmailTemplateResponse = (output: any, context: __SerdeContext): EmailTemplateResponse => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    CreationDate: output.CreationDate !== undefined && output.CreationDate !== null ? output.CreationDate : undefined,
-    DefaultSubstitutions:
-      output.DefaultSubstitutions !== undefined && output.DefaultSubstitutions !== null
-        ? output.DefaultSubstitutions
-        : undefined,
-    HtmlPart: output.HtmlPart !== undefined && output.HtmlPart !== null ? output.HtmlPart : undefined,
-    LastModifiedDate:
-      output.LastModifiedDate !== undefined && output.LastModifiedDate !== null ? output.LastModifiedDate : undefined,
-    RecommenderId:
-      output.RecommenderId !== undefined && output.RecommenderId !== null ? output.RecommenderId : undefined,
-    Subject: output.Subject !== undefined && output.Subject !== null ? output.Subject : undefined,
-    TemplateDescription:
-      output.TemplateDescription !== undefined && output.TemplateDescription !== null
-        ? output.TemplateDescription
-        : undefined,
-    TemplateName: output.TemplateName !== undefined && output.TemplateName !== null ? output.TemplateName : undefined,
-    TemplateType: output.TemplateType !== undefined && output.TemplateType !== null ? output.TemplateType : undefined,
-    TextPart: output.TextPart !== undefined && output.TextPart !== null ? output.TextPart : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    Arn: __expectString(output.Arn),
+    CreationDate: __expectString(output.CreationDate),
+    DefaultSubstitutions: __expectString(output.DefaultSubstitutions),
+    HtmlPart: __expectString(output.HtmlPart),
+    LastModifiedDate: __expectString(output.LastModifiedDate),
+    RecommenderId: __expectString(output.RecommenderId),
+    Subject: __expectString(output.Subject),
+    TemplateDescription: __expectString(output.TemplateDescription),
+    TemplateName: __expectString(output.TemplateName),
+    TemplateType: __expectString(output.TemplateType),
+    TextPart: __expectString(output.TextPart),
+    Version: __expectString(output.Version),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1MapOf__string(output.tags, context)
@@ -18164,70 +18065,64 @@ const deserializeAws_restJson1EmailTemplateResponse = (output: any, context: __S
 
 const deserializeAws_restJson1EndpointDemographic = (output: any, context: __SerdeContext): EndpointDemographic => {
   return {
-    AppVersion: output.AppVersion !== undefined && output.AppVersion !== null ? output.AppVersion : undefined,
-    Locale: output.Locale !== undefined && output.Locale !== null ? output.Locale : undefined,
-    Make: output.Make !== undefined && output.Make !== null ? output.Make : undefined,
-    Model: output.Model !== undefined && output.Model !== null ? output.Model : undefined,
-    ModelVersion: output.ModelVersion !== undefined && output.ModelVersion !== null ? output.ModelVersion : undefined,
-    Platform: output.Platform !== undefined && output.Platform !== null ? output.Platform : undefined,
-    PlatformVersion:
-      output.PlatformVersion !== undefined && output.PlatformVersion !== null ? output.PlatformVersion : undefined,
-    Timezone: output.Timezone !== undefined && output.Timezone !== null ? output.Timezone : undefined,
+    AppVersion: __expectString(output.AppVersion),
+    Locale: __expectString(output.Locale),
+    Make: __expectString(output.Make),
+    Model: __expectString(output.Model),
+    ModelVersion: __expectString(output.ModelVersion),
+    Platform: __expectString(output.Platform),
+    PlatformVersion: __expectString(output.PlatformVersion),
+    Timezone: __expectString(output.Timezone),
   } as any;
 };
 
 const deserializeAws_restJson1EndpointItemResponse = (output: any, context: __SerdeContext): EndpointItemResponse => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    StatusCode: output.StatusCode !== undefined && output.StatusCode !== null ? output.StatusCode : undefined,
+    Message: __expectString(output.Message),
+    StatusCode: __expectNumber(output.StatusCode),
   } as any;
 };
 
 const deserializeAws_restJson1EndpointLocation = (output: any, context: __SerdeContext): EndpointLocation => {
   return {
-    City: output.City !== undefined && output.City !== null ? output.City : undefined,
-    Country: output.Country !== undefined && output.Country !== null ? output.Country : undefined,
-    Latitude: output.Latitude !== undefined && output.Latitude !== null ? output.Latitude : undefined,
-    Longitude: output.Longitude !== undefined && output.Longitude !== null ? output.Longitude : undefined,
-    PostalCode: output.PostalCode !== undefined && output.PostalCode !== null ? output.PostalCode : undefined,
-    Region: output.Region !== undefined && output.Region !== null ? output.Region : undefined,
+    City: __expectString(output.City),
+    Country: __expectString(output.Country),
+    Latitude: __expectNumber(output.Latitude),
+    Longitude: __expectNumber(output.Longitude),
+    PostalCode: __expectString(output.PostalCode),
+    Region: __expectString(output.Region),
   } as any;
 };
 
 const deserializeAws_restJson1EndpointMessageResult = (output: any, context: __SerdeContext): EndpointMessageResult => {
   return {
-    Address: output.Address !== undefined && output.Address !== null ? output.Address : undefined,
-    DeliveryStatus:
-      output.DeliveryStatus !== undefined && output.DeliveryStatus !== null ? output.DeliveryStatus : undefined,
-    MessageId: output.MessageId !== undefined && output.MessageId !== null ? output.MessageId : undefined,
-    StatusCode: output.StatusCode !== undefined && output.StatusCode !== null ? output.StatusCode : undefined,
-    StatusMessage:
-      output.StatusMessage !== undefined && output.StatusMessage !== null ? output.StatusMessage : undefined,
-    UpdatedToken: output.UpdatedToken !== undefined && output.UpdatedToken !== null ? output.UpdatedToken : undefined,
+    Address: __expectString(output.Address),
+    DeliveryStatus: __expectString(output.DeliveryStatus),
+    MessageId: __expectString(output.MessageId),
+    StatusCode: __expectNumber(output.StatusCode),
+    StatusMessage: __expectString(output.StatusMessage),
+    UpdatedToken: __expectString(output.UpdatedToken),
   } as any;
 };
 
 const deserializeAws_restJson1EndpointResponse = (output: any, context: __SerdeContext): EndpointResponse => {
   return {
-    Address: output.Address !== undefined && output.Address !== null ? output.Address : undefined,
-    ApplicationId:
-      output.ApplicationId !== undefined && output.ApplicationId !== null ? output.ApplicationId : undefined,
+    Address: __expectString(output.Address),
+    ApplicationId: __expectString(output.ApplicationId),
     Attributes:
       output.Attributes !== undefined && output.Attributes !== null
         ? deserializeAws_restJson1MapOfListOf__string(output.Attributes, context)
         : undefined,
-    ChannelType: output.ChannelType !== undefined && output.ChannelType !== null ? output.ChannelType : undefined,
-    CohortId: output.CohortId !== undefined && output.CohortId !== null ? output.CohortId : undefined,
-    CreationDate: output.CreationDate !== undefined && output.CreationDate !== null ? output.CreationDate : undefined,
+    ChannelType: __expectString(output.ChannelType),
+    CohortId: __expectString(output.CohortId),
+    CreationDate: __expectString(output.CreationDate),
     Demographic:
       output.Demographic !== undefined && output.Demographic !== null
         ? deserializeAws_restJson1EndpointDemographic(output.Demographic, context)
         : undefined,
-    EffectiveDate:
-      output.EffectiveDate !== undefined && output.EffectiveDate !== null ? output.EffectiveDate : undefined,
-    EndpointStatus:
-      output.EndpointStatus !== undefined && output.EndpointStatus !== null ? output.EndpointStatus : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    EffectiveDate: __expectString(output.EffectiveDate),
+    EndpointStatus: __expectString(output.EndpointStatus),
+    Id: __expectString(output.Id),
     Location:
       output.Location !== undefined && output.Location !== null
         ? deserializeAws_restJson1EndpointLocation(output.Location, context)
@@ -18236,8 +18131,8 @@ const deserializeAws_restJson1EndpointResponse = (output: any, context: __SerdeC
       output.Metrics !== undefined && output.Metrics !== null
         ? deserializeAws_restJson1MapOf__double(output.Metrics, context)
         : undefined,
-    OptOut: output.OptOut !== undefined && output.OptOut !== null ? output.OptOut : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
+    OptOut: __expectString(output.OptOut),
+    RequestId: __expectString(output.RequestId),
     User:
       output.User !== undefined && output.User !== null
         ? deserializeAws_restJson1EndpointUser(output.User, context)
@@ -18260,7 +18155,7 @@ const deserializeAws_restJson1EndpointUser = (output: any, context: __SerdeConte
       output.UserAttributes !== undefined && output.UserAttributes !== null
         ? deserializeAws_restJson1MapOfListOf__string(output.UserAttributes, context)
         : undefined,
-    UserId: output.UserId !== undefined && output.UserId !== null ? output.UserId : undefined,
+    UserId: __expectString(output.UserId),
   } as any;
 };
 
@@ -18270,8 +18165,7 @@ const deserializeAws_restJson1EventCondition = (output: any, context: __SerdeCon
       output.Dimensions !== undefined && output.Dimensions !== null
         ? deserializeAws_restJson1EventDimensions(output.Dimensions, context)
         : undefined,
-    MessageActivity:
-      output.MessageActivity !== undefined && output.MessageActivity !== null ? output.MessageActivity : undefined,
+    MessageActivity: __expectString(output.MessageActivity),
   } as any;
 };
 
@@ -18298,14 +18192,14 @@ const deserializeAws_restJson1EventFilter = (output: any, context: __SerdeContex
       output.Dimensions !== undefined && output.Dimensions !== null
         ? deserializeAws_restJson1EventDimensions(output.Dimensions, context)
         : undefined,
-    FilterType: output.FilterType !== undefined && output.FilterType !== null ? output.FilterType : undefined,
+    FilterType: __expectString(output.FilterType),
   } as any;
 };
 
 const deserializeAws_restJson1EventItemResponse = (output: any, context: __SerdeContext): EventItemResponse => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    StatusCode: output.StatusCode !== undefined && output.StatusCode !== null ? output.StatusCode : undefined,
+    Message: __expectString(output.Message),
+    StatusCode: __expectNumber(output.StatusCode),
   } as any;
 };
 
@@ -18324,63 +18218,51 @@ const deserializeAws_restJson1EventStartCondition = (output: any, context: __Ser
       output.EventFilter !== undefined && output.EventFilter !== null
         ? deserializeAws_restJson1EventFilter(output.EventFilter, context)
         : undefined,
-    SegmentId: output.SegmentId !== undefined && output.SegmentId !== null ? output.SegmentId : undefined,
+    SegmentId: __expectString(output.SegmentId),
   } as any;
 };
 
 const deserializeAws_restJson1EventStream = (output: any, context: __SerdeContext): EventStream => {
   return {
-    ApplicationId:
-      output.ApplicationId !== undefined && output.ApplicationId !== null ? output.ApplicationId : undefined,
-    DestinationStreamArn:
-      output.DestinationStreamArn !== undefined && output.DestinationStreamArn !== null
-        ? output.DestinationStreamArn
-        : undefined,
-    ExternalId: output.ExternalId !== undefined && output.ExternalId !== null ? output.ExternalId : undefined,
-    LastModifiedDate:
-      output.LastModifiedDate !== undefined && output.LastModifiedDate !== null ? output.LastModifiedDate : undefined,
-    LastUpdatedBy:
-      output.LastUpdatedBy !== undefined && output.LastUpdatedBy !== null ? output.LastUpdatedBy : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
+    ApplicationId: __expectString(output.ApplicationId),
+    DestinationStreamArn: __expectString(output.DestinationStreamArn),
+    ExternalId: __expectString(output.ExternalId),
+    LastModifiedDate: __expectString(output.LastModifiedDate),
+    LastUpdatedBy: __expectString(output.LastUpdatedBy),
+    RoleArn: __expectString(output.RoleArn),
   } as any;
 };
 
 const deserializeAws_restJson1ExportJobResource = (output: any, context: __SerdeContext): ExportJobResource => {
   return {
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
-    S3UrlPrefix: output.S3UrlPrefix !== undefined && output.S3UrlPrefix !== null ? output.S3UrlPrefix : undefined,
-    SegmentId: output.SegmentId !== undefined && output.SegmentId !== null ? output.SegmentId : undefined,
-    SegmentVersion:
-      output.SegmentVersion !== undefined && output.SegmentVersion !== null ? output.SegmentVersion : undefined,
+    RoleArn: __expectString(output.RoleArn),
+    S3UrlPrefix: __expectString(output.S3UrlPrefix),
+    SegmentId: __expectString(output.SegmentId),
+    SegmentVersion: __expectNumber(output.SegmentVersion),
   } as any;
 };
 
 const deserializeAws_restJson1ExportJobResponse = (output: any, context: __SerdeContext): ExportJobResponse => {
   return {
-    ApplicationId:
-      output.ApplicationId !== undefined && output.ApplicationId !== null ? output.ApplicationId : undefined,
-    CompletedPieces:
-      output.CompletedPieces !== undefined && output.CompletedPieces !== null ? output.CompletedPieces : undefined,
-    CompletionDate:
-      output.CompletionDate !== undefined && output.CompletionDate !== null ? output.CompletionDate : undefined,
-    CreationDate: output.CreationDate !== undefined && output.CreationDate !== null ? output.CreationDate : undefined,
+    ApplicationId: __expectString(output.ApplicationId),
+    CompletedPieces: __expectNumber(output.CompletedPieces),
+    CompletionDate: __expectString(output.CompletionDate),
+    CreationDate: __expectString(output.CreationDate),
     Definition:
       output.Definition !== undefined && output.Definition !== null
         ? deserializeAws_restJson1ExportJobResource(output.Definition, context)
         : undefined,
-    FailedPieces: output.FailedPieces !== undefined && output.FailedPieces !== null ? output.FailedPieces : undefined,
+    FailedPieces: __expectNumber(output.FailedPieces),
     Failures:
       output.Failures !== undefined && output.Failures !== null
         ? deserializeAws_restJson1ListOf__string(output.Failures, context)
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    JobStatus: output.JobStatus !== undefined && output.JobStatus !== null ? output.JobStatus : undefined,
-    TotalFailures:
-      output.TotalFailures !== undefined && output.TotalFailures !== null ? output.TotalFailures : undefined,
-    TotalPieces: output.TotalPieces !== undefined && output.TotalPieces !== null ? output.TotalPieces : undefined,
-    TotalProcessed:
-      output.TotalProcessed !== undefined && output.TotalProcessed !== null ? output.TotalProcessed : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Id: __expectString(output.Id),
+    JobStatus: __expectString(output.JobStatus),
+    TotalFailures: __expectNumber(output.TotalFailures),
+    TotalPieces: __expectNumber(output.TotalPieces),
+    TotalProcessed: __expectNumber(output.TotalProcessed),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -18390,34 +18272,30 @@ const deserializeAws_restJson1ExportJobsResponse = (output: any, context: __Serd
       output.Item !== undefined && output.Item !== null
         ? deserializeAws_restJson1ListOfExportJobResponse(output.Item, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
 const deserializeAws_restJson1GCMChannelResponse = (output: any, context: __SerdeContext): GCMChannelResponse => {
   return {
-    ApplicationId:
-      output.ApplicationId !== undefined && output.ApplicationId !== null ? output.ApplicationId : undefined,
-    CreationDate: output.CreationDate !== undefined && output.CreationDate !== null ? output.CreationDate : undefined,
-    Credential: output.Credential !== undefined && output.Credential !== null ? output.Credential : undefined,
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
-    HasCredential:
-      output.HasCredential !== undefined && output.HasCredential !== null ? output.HasCredential : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    IsArchived: output.IsArchived !== undefined && output.IsArchived !== null ? output.IsArchived : undefined,
-    LastModifiedBy:
-      output.LastModifiedBy !== undefined && output.LastModifiedBy !== null ? output.LastModifiedBy : undefined,
-    LastModifiedDate:
-      output.LastModifiedDate !== undefined && output.LastModifiedDate !== null ? output.LastModifiedDate : undefined,
-    Platform: output.Platform !== undefined && output.Platform !== null ? output.Platform : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    ApplicationId: __expectString(output.ApplicationId),
+    CreationDate: __expectString(output.CreationDate),
+    Credential: __expectString(output.Credential),
+    Enabled: __expectBoolean(output.Enabled),
+    HasCredential: __expectBoolean(output.HasCredential),
+    Id: __expectString(output.Id),
+    IsArchived: __expectBoolean(output.IsArchived),
+    LastModifiedBy: __expectString(output.LastModifiedBy),
+    LastModifiedDate: __expectString(output.LastModifiedDate),
+    Platform: __expectString(output.Platform),
+    Version: __expectNumber(output.Version),
   } as any;
 };
 
 const deserializeAws_restJson1GPSCoordinates = (output: any, context: __SerdeContext): GPSCoordinates => {
   return {
-    Latitude: output.Latitude !== undefined && output.Latitude !== null ? output.Latitude : undefined,
-    Longitude: output.Longitude !== undefined && output.Longitude !== null ? output.Longitude : undefined,
+    Latitude: __expectNumber(output.Latitude),
+    Longitude: __expectNumber(output.Longitude),
   } as any;
 };
 
@@ -18427,63 +18305,51 @@ const deserializeAws_restJson1GPSPointDimension = (output: any, context: __Serde
       output.Coordinates !== undefined && output.Coordinates !== null
         ? deserializeAws_restJson1GPSCoordinates(output.Coordinates, context)
         : undefined,
-    RangeInKilometers:
-      output.RangeInKilometers !== undefined && output.RangeInKilometers !== null
-        ? output.RangeInKilometers
-        : undefined,
+    RangeInKilometers: __expectNumber(output.RangeInKilometers),
   } as any;
 };
 
 const deserializeAws_restJson1HoldoutActivity = (output: any, context: __SerdeContext): HoldoutActivity => {
   return {
-    NextActivity: output.NextActivity !== undefined && output.NextActivity !== null ? output.NextActivity : undefined,
-    Percentage: output.Percentage !== undefined && output.Percentage !== null ? output.Percentage : undefined,
+    NextActivity: __expectString(output.NextActivity),
+    Percentage: __expectNumber(output.Percentage),
   } as any;
 };
 
 const deserializeAws_restJson1ImportJobResource = (output: any, context: __SerdeContext): ImportJobResource => {
   return {
-    DefineSegment:
-      output.DefineSegment !== undefined && output.DefineSegment !== null ? output.DefineSegment : undefined,
-    ExternalId: output.ExternalId !== undefined && output.ExternalId !== null ? output.ExternalId : undefined,
-    Format: output.Format !== undefined && output.Format !== null ? output.Format : undefined,
-    RegisterEndpoints:
-      output.RegisterEndpoints !== undefined && output.RegisterEndpoints !== null
-        ? output.RegisterEndpoints
-        : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
-    S3Url: output.S3Url !== undefined && output.S3Url !== null ? output.S3Url : undefined,
-    SegmentId: output.SegmentId !== undefined && output.SegmentId !== null ? output.SegmentId : undefined,
-    SegmentName: output.SegmentName !== undefined && output.SegmentName !== null ? output.SegmentName : undefined,
+    DefineSegment: __expectBoolean(output.DefineSegment),
+    ExternalId: __expectString(output.ExternalId),
+    Format: __expectString(output.Format),
+    RegisterEndpoints: __expectBoolean(output.RegisterEndpoints),
+    RoleArn: __expectString(output.RoleArn),
+    S3Url: __expectString(output.S3Url),
+    SegmentId: __expectString(output.SegmentId),
+    SegmentName: __expectString(output.SegmentName),
   } as any;
 };
 
 const deserializeAws_restJson1ImportJobResponse = (output: any, context: __SerdeContext): ImportJobResponse => {
   return {
-    ApplicationId:
-      output.ApplicationId !== undefined && output.ApplicationId !== null ? output.ApplicationId : undefined,
-    CompletedPieces:
-      output.CompletedPieces !== undefined && output.CompletedPieces !== null ? output.CompletedPieces : undefined,
-    CompletionDate:
-      output.CompletionDate !== undefined && output.CompletionDate !== null ? output.CompletionDate : undefined,
-    CreationDate: output.CreationDate !== undefined && output.CreationDate !== null ? output.CreationDate : undefined,
+    ApplicationId: __expectString(output.ApplicationId),
+    CompletedPieces: __expectNumber(output.CompletedPieces),
+    CompletionDate: __expectString(output.CompletionDate),
+    CreationDate: __expectString(output.CreationDate),
     Definition:
       output.Definition !== undefined && output.Definition !== null
         ? deserializeAws_restJson1ImportJobResource(output.Definition, context)
         : undefined,
-    FailedPieces: output.FailedPieces !== undefined && output.FailedPieces !== null ? output.FailedPieces : undefined,
+    FailedPieces: __expectNumber(output.FailedPieces),
     Failures:
       output.Failures !== undefined && output.Failures !== null
         ? deserializeAws_restJson1ListOf__string(output.Failures, context)
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    JobStatus: output.JobStatus !== undefined && output.JobStatus !== null ? output.JobStatus : undefined,
-    TotalFailures:
-      output.TotalFailures !== undefined && output.TotalFailures !== null ? output.TotalFailures : undefined,
-    TotalPieces: output.TotalPieces !== undefined && output.TotalPieces !== null ? output.TotalPieces : undefined,
-    TotalProcessed:
-      output.TotalProcessed !== undefined && output.TotalProcessed !== null ? output.TotalProcessed : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Id: __expectString(output.Id),
+    JobStatus: __expectString(output.JobStatus),
+    TotalFailures: __expectNumber(output.TotalFailures),
+    TotalPieces: __expectNumber(output.TotalPieces),
+    TotalProcessed: __expectNumber(output.TotalProcessed),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -18493,7 +18359,7 @@ const deserializeAws_restJson1ImportJobsResponse = (output: any, context: __Serd
       output.Item !== undefined && output.Item !== null
         ? deserializeAws_restJson1ListOfImportJobResponse(output.Item, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -18512,7 +18378,7 @@ const deserializeAws_restJson1ItemResponse = (output: any, context: __SerdeConte
 
 const deserializeAws_restJson1JourneyCustomMessage = (output: any, context: __SerdeContext): JourneyCustomMessage => {
   return {
-    Data: output.Data !== undefined && output.Data !== null ? output.Data : undefined,
+    Data: __expectString(output.Data),
   } as any;
 };
 
@@ -18521,23 +18387,22 @@ const deserializeAws_restJson1JourneyDateRangeKpiResponse = (
   context: __SerdeContext
 ): JourneyDateRangeKpiResponse => {
   return {
-    ApplicationId:
-      output.ApplicationId !== undefined && output.ApplicationId !== null ? output.ApplicationId : undefined,
+    ApplicationId: __expectString(output.ApplicationId),
     EndTime: output.EndTime !== undefined && output.EndTime !== null ? new Date(output.EndTime) : undefined,
-    JourneyId: output.JourneyId !== undefined && output.JourneyId !== null ? output.JourneyId : undefined,
-    KpiName: output.KpiName !== undefined && output.KpiName !== null ? output.KpiName : undefined,
+    JourneyId: __expectString(output.JourneyId),
+    KpiName: __expectString(output.KpiName),
     KpiResult:
       output.KpiResult !== undefined && output.KpiResult !== null
         ? deserializeAws_restJson1BaseKpiResult(output.KpiResult, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     StartTime: output.StartTime !== undefined && output.StartTime !== null ? new Date(output.StartTime) : undefined,
   } as any;
 };
 
 const deserializeAws_restJson1JourneyEmailMessage = (output: any, context: __SerdeContext): JourneyEmailMessage => {
   return {
-    FromAddress: output.FromAddress !== undefined && output.FromAddress !== null ? output.FromAddress : undefined,
+    FromAddress: __expectString(output.FromAddress),
   } as any;
 };
 
@@ -18546,18 +18411,11 @@ const deserializeAws_restJson1JourneyExecutionActivityMetricsResponse = (
   context: __SerdeContext
 ): JourneyExecutionActivityMetricsResponse => {
   return {
-    ActivityType: output.ActivityType !== undefined && output.ActivityType !== null ? output.ActivityType : undefined,
-    ApplicationId:
-      output.ApplicationId !== undefined && output.ApplicationId !== null ? output.ApplicationId : undefined,
-    JourneyActivityId:
-      output.JourneyActivityId !== undefined && output.JourneyActivityId !== null
-        ? output.JourneyActivityId
-        : undefined,
-    JourneyId: output.JourneyId !== undefined && output.JourneyId !== null ? output.JourneyId : undefined,
-    LastEvaluatedTime:
-      output.LastEvaluatedTime !== undefined && output.LastEvaluatedTime !== null
-        ? output.LastEvaluatedTime
-        : undefined,
+    ActivityType: __expectString(output.ActivityType),
+    ApplicationId: __expectString(output.ApplicationId),
+    JourneyActivityId: __expectString(output.JourneyActivityId),
+    JourneyId: __expectString(output.JourneyId),
+    LastEvaluatedTime: __expectString(output.LastEvaluatedTime),
     Metrics:
       output.Metrics !== undefined && output.Metrics !== null
         ? deserializeAws_restJson1MapOf__string(output.Metrics, context)
@@ -18570,13 +18428,9 @@ const deserializeAws_restJson1JourneyExecutionMetricsResponse = (
   context: __SerdeContext
 ): JourneyExecutionMetricsResponse => {
   return {
-    ApplicationId:
-      output.ApplicationId !== undefined && output.ApplicationId !== null ? output.ApplicationId : undefined,
-    JourneyId: output.JourneyId !== undefined && output.JourneyId !== null ? output.JourneyId : undefined,
-    LastEvaluatedTime:
-      output.LastEvaluatedTime !== undefined && output.LastEvaluatedTime !== null
-        ? output.LastEvaluatedTime
-        : undefined,
+    ApplicationId: __expectString(output.ApplicationId),
+    JourneyId: __expectString(output.JourneyId),
+    LastEvaluatedTime: __expectString(output.LastEvaluatedTime),
     Metrics:
       output.Metrics !== undefined && output.Metrics !== null
         ? deserializeAws_restJson1MapOf__string(output.Metrics, context)
@@ -18586,25 +18440,16 @@ const deserializeAws_restJson1JourneyExecutionMetricsResponse = (
 
 const deserializeAws_restJson1JourneyLimits = (output: any, context: __SerdeContext): JourneyLimits => {
   return {
-    DailyCap: output.DailyCap !== undefined && output.DailyCap !== null ? output.DailyCap : undefined,
-    EndpointReentryCap:
-      output.EndpointReentryCap !== undefined && output.EndpointReentryCap !== null
-        ? output.EndpointReentryCap
-        : undefined,
-    EndpointReentryInterval:
-      output.EndpointReentryInterval !== undefined && output.EndpointReentryInterval !== null
-        ? output.EndpointReentryInterval
-        : undefined,
-    MessagesPerSecond:
-      output.MessagesPerSecond !== undefined && output.MessagesPerSecond !== null
-        ? output.MessagesPerSecond
-        : undefined,
+    DailyCap: __expectNumber(output.DailyCap),
+    EndpointReentryCap: __expectNumber(output.EndpointReentryCap),
+    EndpointReentryInterval: __expectString(output.EndpointReentryInterval),
+    MessagesPerSecond: __expectNumber(output.MessagesPerSecond),
   } as any;
 };
 
 const deserializeAws_restJson1JourneyPushMessage = (output: any, context: __SerdeContext): JourneyPushMessage => {
   return {
-    TimeToLive: output.TimeToLive !== undefined && output.TimeToLive !== null ? output.TimeToLive : undefined,
+    TimeToLive: __expectString(output.TimeToLive),
   } as any;
 };
 
@@ -18614,41 +18459,33 @@ const deserializeAws_restJson1JourneyResponse = (output: any, context: __SerdeCo
       output.Activities !== undefined && output.Activities !== null
         ? deserializeAws_restJson1MapOfActivity(output.Activities, context)
         : undefined,
-    ApplicationId:
-      output.ApplicationId !== undefined && output.ApplicationId !== null ? output.ApplicationId : undefined,
-    CreationDate: output.CreationDate !== undefined && output.CreationDate !== null ? output.CreationDate : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    LastModifiedDate:
-      output.LastModifiedDate !== undefined && output.LastModifiedDate !== null ? output.LastModifiedDate : undefined,
+    ApplicationId: __expectString(output.ApplicationId),
+    CreationDate: __expectString(output.CreationDate),
+    Id: __expectString(output.Id),
+    LastModifiedDate: __expectString(output.LastModifiedDate),
     Limits:
       output.Limits !== undefined && output.Limits !== null
         ? deserializeAws_restJson1JourneyLimits(output.Limits, context)
         : undefined,
-    LocalTime: output.LocalTime !== undefined && output.LocalTime !== null ? output.LocalTime : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    LocalTime: __expectBoolean(output.LocalTime),
+    Name: __expectString(output.Name),
     QuietTime:
       output.QuietTime !== undefined && output.QuietTime !== null
         ? deserializeAws_restJson1QuietTime(output.QuietTime, context)
         : undefined,
-    RefreshFrequency:
-      output.RefreshFrequency !== undefined && output.RefreshFrequency !== null ? output.RefreshFrequency : undefined,
-    RefreshOnSegmentUpdate:
-      output.RefreshOnSegmentUpdate !== undefined && output.RefreshOnSegmentUpdate !== null
-        ? output.RefreshOnSegmentUpdate
-        : undefined,
+    RefreshFrequency: __expectString(output.RefreshFrequency),
+    RefreshOnSegmentUpdate: __expectBoolean(output.RefreshOnSegmentUpdate),
     Schedule:
       output.Schedule !== undefined && output.Schedule !== null
         ? deserializeAws_restJson1JourneySchedule(output.Schedule, context)
         : undefined,
-    StartActivity:
-      output.StartActivity !== undefined && output.StartActivity !== null ? output.StartActivity : undefined,
+    StartActivity: __expectString(output.StartActivity),
     StartCondition:
       output.StartCondition !== undefined && output.StartCondition !== null
         ? deserializeAws_restJson1StartCondition(output.StartCondition, context)
         : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    WaitForQuietTime:
-      output.WaitForQuietTime !== undefined && output.WaitForQuietTime !== null ? output.WaitForQuietTime : undefined,
+    State: __expectString(output.State),
+    WaitForQuietTime: __expectBoolean(output.WaitForQuietTime),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1MapOf__string(output.tags, context)
@@ -18660,20 +18497,17 @@ const deserializeAws_restJson1JourneySchedule = (output: any, context: __SerdeCo
   return {
     EndTime: output.EndTime !== undefined && output.EndTime !== null ? new Date(output.EndTime) : undefined,
     StartTime: output.StartTime !== undefined && output.StartTime !== null ? new Date(output.StartTime) : undefined,
-    Timezone: output.Timezone !== undefined && output.Timezone !== null ? output.Timezone : undefined,
+    Timezone: __expectString(output.Timezone),
   } as any;
 };
 
 const deserializeAws_restJson1JourneySMSMessage = (output: any, context: __SerdeContext): JourneySMSMessage => {
   return {
-    EntityId: output.EntityId !== undefined && output.EntityId !== null ? output.EntityId : undefined,
-    MessageType: output.MessageType !== undefined && output.MessageType !== null ? output.MessageType : undefined,
-    OriginationNumber:
-      output.OriginationNumber !== undefined && output.OriginationNumber !== null
-        ? output.OriginationNumber
-        : undefined,
-    SenderId: output.SenderId !== undefined && output.SenderId !== null ? output.SenderId : undefined,
-    TemplateId: output.TemplateId !== undefined && output.TemplateId !== null ? output.TemplateId : undefined,
+    EntityId: __expectString(output.EntityId),
+    MessageType: __expectString(output.MessageType),
+    OriginationNumber: __expectString(output.OriginationNumber),
+    SenderId: __expectString(output.SenderId),
+    TemplateId: __expectString(output.TemplateId),
   } as any;
 };
 
@@ -18683,7 +18517,7 @@ const deserializeAws_restJson1JourneysResponse = (output: any, context: __SerdeC
       output.Item !== undefined && output.Item !== null
         ? deserializeAws_restJson1ListOfJourneyResponse(output.Item, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -18697,7 +18531,7 @@ const deserializeAws_restJson1ListOf__EndpointTypesElement = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -18708,7 +18542,7 @@ const deserializeAws_restJson1ListOf__string = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -18953,7 +18787,7 @@ const deserializeAws_restJson1ListRecommenderConfigurationsResponse = (
       output.Item !== undefined && output.Item !== null
         ? deserializeAws_restJson1ListOfRecommenderConfigurationResponse(output.Item, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -18964,7 +18798,7 @@ const deserializeAws_restJson1MapOf__double = (output: any, context: __SerdeCont
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectNumber(value) as any,
     };
   }, {});
 };
@@ -18976,7 +18810,7 @@ const deserializeAws_restJson1MapOf__integer = (output: any, context: __SerdeCon
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectNumber(value) as any,
     };
   }, {});
 };
@@ -18988,7 +18822,7 @@ const deserializeAws_restJson1MapOf__string = (output: any, context: __SerdeCont
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -19145,28 +18979,25 @@ const deserializeAws_restJson1MapOfMetricDimension = (
 
 const deserializeAws_restJson1Message = (output: any, context: __SerdeContext): Message => {
   return {
-    Action: output.Action !== undefined && output.Action !== null ? output.Action : undefined,
-    Body: output.Body !== undefined && output.Body !== null ? output.Body : undefined,
-    ImageIconUrl: output.ImageIconUrl !== undefined && output.ImageIconUrl !== null ? output.ImageIconUrl : undefined,
-    ImageSmallIconUrl:
-      output.ImageSmallIconUrl !== undefined && output.ImageSmallIconUrl !== null
-        ? output.ImageSmallIconUrl
-        : undefined,
-    ImageUrl: output.ImageUrl !== undefined && output.ImageUrl !== null ? output.ImageUrl : undefined,
-    JsonBody: output.JsonBody !== undefined && output.JsonBody !== null ? output.JsonBody : undefined,
-    MediaUrl: output.MediaUrl !== undefined && output.MediaUrl !== null ? output.MediaUrl : undefined,
-    RawContent: output.RawContent !== undefined && output.RawContent !== null ? output.RawContent : undefined,
-    SilentPush: output.SilentPush !== undefined && output.SilentPush !== null ? output.SilentPush : undefined,
-    TimeToLive: output.TimeToLive !== undefined && output.TimeToLive !== null ? output.TimeToLive : undefined,
-    Title: output.Title !== undefined && output.Title !== null ? output.Title : undefined,
-    Url: output.Url !== undefined && output.Url !== null ? output.Url : undefined,
+    Action: __expectString(output.Action),
+    Body: __expectString(output.Body),
+    ImageIconUrl: __expectString(output.ImageIconUrl),
+    ImageSmallIconUrl: __expectString(output.ImageSmallIconUrl),
+    ImageUrl: __expectString(output.ImageUrl),
+    JsonBody: __expectString(output.JsonBody),
+    MediaUrl: __expectString(output.MediaUrl),
+    RawContent: __expectString(output.RawContent),
+    SilentPush: __expectBoolean(output.SilentPush),
+    TimeToLive: __expectNumber(output.TimeToLive),
+    Title: __expectString(output.Title),
+    Url: __expectString(output.Url),
   } as any;
 };
 
 const deserializeAws_restJson1MessageBody = (output: any, context: __SerdeContext): MessageBody => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RequestID: output.RequestID !== undefined && output.RequestID !== null ? output.RequestID : undefined,
+    Message: __expectString(output.Message),
+    RequestID: __expectString(output.RequestID),
   } as any;
 };
 
@@ -19209,13 +19040,12 @@ const deserializeAws_restJson1MessageConfiguration = (output: any, context: __Se
 
 const deserializeAws_restJson1MessageResponse = (output: any, context: __SerdeContext): MessageResponse => {
   return {
-    ApplicationId:
-      output.ApplicationId !== undefined && output.ApplicationId !== null ? output.ApplicationId : undefined,
+    ApplicationId: __expectString(output.ApplicationId),
     EndpointResult:
       output.EndpointResult !== undefined && output.EndpointResult !== null
         ? deserializeAws_restJson1MapOfEndpointMessageResult(output.EndpointResult, context)
         : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
+    RequestId: __expectString(output.RequestId),
     Result:
       output.Result !== undefined && output.Result !== null
         ? deserializeAws_restJson1MapOfMessageResult(output.Result, context)
@@ -19225,23 +19055,18 @@ const deserializeAws_restJson1MessageResponse = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1MessageResult = (output: any, context: __SerdeContext): MessageResult => {
   return {
-    DeliveryStatus:
-      output.DeliveryStatus !== undefined && output.DeliveryStatus !== null ? output.DeliveryStatus : undefined,
-    MessageId: output.MessageId !== undefined && output.MessageId !== null ? output.MessageId : undefined,
-    StatusCode: output.StatusCode !== undefined && output.StatusCode !== null ? output.StatusCode : undefined,
-    StatusMessage:
-      output.StatusMessage !== undefined && output.StatusMessage !== null ? output.StatusMessage : undefined,
-    UpdatedToken: output.UpdatedToken !== undefined && output.UpdatedToken !== null ? output.UpdatedToken : undefined,
+    DeliveryStatus: __expectString(output.DeliveryStatus),
+    MessageId: __expectString(output.MessageId),
+    StatusCode: __expectNumber(output.StatusCode),
+    StatusMessage: __expectString(output.StatusMessage),
+    UpdatedToken: __expectString(output.UpdatedToken),
   } as any;
 };
 
 const deserializeAws_restJson1MetricDimension = (output: any, context: __SerdeContext): MetricDimension => {
   return {
-    ComparisonOperator:
-      output.ComparisonOperator !== undefined && output.ComparisonOperator !== null
-        ? output.ComparisonOperator
-        : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    ComparisonOperator: __expectString(output.ComparisonOperator),
+    Value: __expectNumber(output.Value),
   } as any;
 };
 
@@ -19254,7 +19079,7 @@ const deserializeAws_restJson1MultiConditionalBranch = (
       output.Condition !== undefined && output.Condition !== null
         ? deserializeAws_restJson1SimpleCondition(output.Condition, context)
         : undefined,
-    NextActivity: output.NextActivity !== undefined && output.NextActivity !== null ? output.NextActivity : undefined,
+    NextActivity: __expectString(output.NextActivity),
   } as any;
 };
 
@@ -19267,8 +19092,7 @@ const deserializeAws_restJson1MultiConditionalSplitActivity = (
       output.Branches !== undefined && output.Branches !== null
         ? deserializeAws_restJson1ListOfMultiConditionalBranch(output.Branches, context)
         : undefined,
-    DefaultActivity:
-      output.DefaultActivity !== undefined && output.DefaultActivity !== null ? output.DefaultActivity : undefined,
+    DefaultActivity: __expectString(output.DefaultActivity),
     EvaluationWaitTime:
       output.EvaluationWaitTime !== undefined && output.EvaluationWaitTime !== null
         ? deserializeAws_restJson1WaitTime(output.EvaluationWaitTime, context)
@@ -19281,37 +19105,20 @@ const deserializeAws_restJson1NumberValidateResponse = (
   context: __SerdeContext
 ): NumberValidateResponse => {
   return {
-    Carrier: output.Carrier !== undefined && output.Carrier !== null ? output.Carrier : undefined,
-    City: output.City !== undefined && output.City !== null ? output.City : undefined,
-    CleansedPhoneNumberE164:
-      output.CleansedPhoneNumberE164 !== undefined && output.CleansedPhoneNumberE164 !== null
-        ? output.CleansedPhoneNumberE164
-        : undefined,
-    CleansedPhoneNumberNational:
-      output.CleansedPhoneNumberNational !== undefined && output.CleansedPhoneNumberNational !== null
-        ? output.CleansedPhoneNumberNational
-        : undefined,
-    Country: output.Country !== undefined && output.Country !== null ? output.Country : undefined,
-    CountryCodeIso2:
-      output.CountryCodeIso2 !== undefined && output.CountryCodeIso2 !== null ? output.CountryCodeIso2 : undefined,
-    CountryCodeNumeric:
-      output.CountryCodeNumeric !== undefined && output.CountryCodeNumeric !== null
-        ? output.CountryCodeNumeric
-        : undefined,
-    County: output.County !== undefined && output.County !== null ? output.County : undefined,
-    OriginalCountryCodeIso2:
-      output.OriginalCountryCodeIso2 !== undefined && output.OriginalCountryCodeIso2 !== null
-        ? output.OriginalCountryCodeIso2
-        : undefined,
-    OriginalPhoneNumber:
-      output.OriginalPhoneNumber !== undefined && output.OriginalPhoneNumber !== null
-        ? output.OriginalPhoneNumber
-        : undefined,
-    PhoneType: output.PhoneType !== undefined && output.PhoneType !== null ? output.PhoneType : undefined,
-    PhoneTypeCode:
-      output.PhoneTypeCode !== undefined && output.PhoneTypeCode !== null ? output.PhoneTypeCode : undefined,
-    Timezone: output.Timezone !== undefined && output.Timezone !== null ? output.Timezone : undefined,
-    ZipCode: output.ZipCode !== undefined && output.ZipCode !== null ? output.ZipCode : undefined,
+    Carrier: __expectString(output.Carrier),
+    City: __expectString(output.City),
+    CleansedPhoneNumberE164: __expectString(output.CleansedPhoneNumberE164),
+    CleansedPhoneNumberNational: __expectString(output.CleansedPhoneNumberNational),
+    Country: __expectString(output.Country),
+    CountryCodeIso2: __expectString(output.CountryCodeIso2),
+    CountryCodeNumeric: __expectString(output.CountryCodeNumeric),
+    County: __expectString(output.County),
+    OriginalCountryCodeIso2: __expectString(output.OriginalCountryCodeIso2),
+    OriginalPhoneNumber: __expectString(output.OriginalPhoneNumber),
+    PhoneType: __expectString(output.PhoneType),
+    PhoneTypeCode: __expectNumber(output.PhoneTypeCode),
+    Timezone: __expectString(output.Timezone),
+    ZipCode: __expectString(output.ZipCode),
   } as any;
 };
 
@@ -19321,10 +19128,9 @@ const deserializeAws_restJson1PushMessageActivity = (output: any, context: __Ser
       output.MessageConfig !== undefined && output.MessageConfig !== null
         ? deserializeAws_restJson1JourneyPushMessage(output.MessageConfig, context)
         : undefined,
-    NextActivity: output.NextActivity !== undefined && output.NextActivity !== null ? output.NextActivity : undefined,
-    TemplateName: output.TemplateName !== undefined && output.TemplateName !== null ? output.TemplateName : undefined,
-    TemplateVersion:
-      output.TemplateVersion !== undefined && output.TemplateVersion !== null ? output.TemplateVersion : undefined,
+    NextActivity: __expectString(output.NextActivity),
+    TemplateName: __expectString(output.TemplateName),
+    TemplateVersion: __expectString(output.TemplateVersion),
   } as any;
 };
 
@@ -19341,35 +19147,27 @@ const deserializeAws_restJson1PushNotificationTemplateResponse = (
       output.APNS !== undefined && output.APNS !== null
         ? deserializeAws_restJson1APNSPushNotificationTemplate(output.APNS, context)
         : undefined,
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     Baidu:
       output.Baidu !== undefined && output.Baidu !== null
         ? deserializeAws_restJson1AndroidPushNotificationTemplate(output.Baidu, context)
         : undefined,
-    CreationDate: output.CreationDate !== undefined && output.CreationDate !== null ? output.CreationDate : undefined,
+    CreationDate: __expectString(output.CreationDate),
     Default:
       output.Default !== undefined && output.Default !== null
         ? deserializeAws_restJson1DefaultPushNotificationTemplate(output.Default, context)
         : undefined,
-    DefaultSubstitutions:
-      output.DefaultSubstitutions !== undefined && output.DefaultSubstitutions !== null
-        ? output.DefaultSubstitutions
-        : undefined,
+    DefaultSubstitutions: __expectString(output.DefaultSubstitutions),
     GCM:
       output.GCM !== undefined && output.GCM !== null
         ? deserializeAws_restJson1AndroidPushNotificationTemplate(output.GCM, context)
         : undefined,
-    LastModifiedDate:
-      output.LastModifiedDate !== undefined && output.LastModifiedDate !== null ? output.LastModifiedDate : undefined,
-    RecommenderId:
-      output.RecommenderId !== undefined && output.RecommenderId !== null ? output.RecommenderId : undefined,
-    TemplateDescription:
-      output.TemplateDescription !== undefined && output.TemplateDescription !== null
-        ? output.TemplateDescription
-        : undefined,
-    TemplateName: output.TemplateName !== undefined && output.TemplateName !== null ? output.TemplateName : undefined,
-    TemplateType: output.TemplateType !== undefined && output.TemplateType !== null ? output.TemplateType : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    LastModifiedDate: __expectString(output.LastModifiedDate),
+    RecommenderId: __expectString(output.RecommenderId),
+    TemplateDescription: __expectString(output.TemplateDescription),
+    TemplateName: __expectString(output.TemplateName),
+    TemplateType: __expectString(output.TemplateType),
+    Version: __expectString(output.Version),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1MapOf__string(output.tags, context)
@@ -19379,8 +19177,8 @@ const deserializeAws_restJson1PushNotificationTemplateResponse = (
 
 const deserializeAws_restJson1QuietTime = (output: any, context: __SerdeContext): QuietTime => {
   return {
-    End: output.End !== undefined && output.End !== null ? output.End : undefined,
-    Start: output.Start !== undefined && output.Start !== null ? output.Start : undefined,
+    End: __expectString(output.End),
+    Start: __expectString(output.Start),
   } as any;
 };
 
@@ -19395,15 +19193,15 @@ const deserializeAws_restJson1RandomSplitActivity = (output: any, context: __Ser
 
 const deserializeAws_restJson1RandomSplitEntry = (output: any, context: __SerdeContext): RandomSplitEntry => {
   return {
-    NextActivity: output.NextActivity !== undefined && output.NextActivity !== null ? output.NextActivity : undefined,
-    Percentage: output.Percentage !== undefined && output.Percentage !== null ? output.Percentage : undefined,
+    NextActivity: __expectString(output.NextActivity),
+    Percentage: __expectNumber(output.Percentage),
   } as any;
 };
 
 const deserializeAws_restJson1RecencyDimension = (output: any, context: __SerdeContext): RecencyDimension => {
   return {
-    Duration: output.Duration !== undefined && output.Duration !== null ? output.Duration : undefined,
-    RecencyType: output.RecencyType !== undefined && output.RecencyType !== null ? output.RecencyType : undefined,
+    Duration: __expectString(output.Duration),
+    RecencyType: __expectString(output.RecencyType),
   } as any;
 };
 
@@ -19416,36 +19214,17 @@ const deserializeAws_restJson1RecommenderConfigurationResponse = (
       output.Attributes !== undefined && output.Attributes !== null
         ? deserializeAws_restJson1MapOf__string(output.Attributes, context)
         : undefined,
-    CreationDate: output.CreationDate !== undefined && output.CreationDate !== null ? output.CreationDate : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    LastModifiedDate:
-      output.LastModifiedDate !== undefined && output.LastModifiedDate !== null ? output.LastModifiedDate : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    RecommendationProviderIdType:
-      output.RecommendationProviderIdType !== undefined && output.RecommendationProviderIdType !== null
-        ? output.RecommendationProviderIdType
-        : undefined,
-    RecommendationProviderRoleArn:
-      output.RecommendationProviderRoleArn !== undefined && output.RecommendationProviderRoleArn !== null
-        ? output.RecommendationProviderRoleArn
-        : undefined,
-    RecommendationProviderUri:
-      output.RecommendationProviderUri !== undefined && output.RecommendationProviderUri !== null
-        ? output.RecommendationProviderUri
-        : undefined,
-    RecommendationTransformerUri:
-      output.RecommendationTransformerUri !== undefined && output.RecommendationTransformerUri !== null
-        ? output.RecommendationTransformerUri
-        : undefined,
-    RecommendationsDisplayName:
-      output.RecommendationsDisplayName !== undefined && output.RecommendationsDisplayName !== null
-        ? output.RecommendationsDisplayName
-        : undefined,
-    RecommendationsPerMessage:
-      output.RecommendationsPerMessage !== undefined && output.RecommendationsPerMessage !== null
-        ? output.RecommendationsPerMessage
-        : undefined,
+    CreationDate: __expectString(output.CreationDate),
+    Description: __expectString(output.Description),
+    Id: __expectString(output.Id),
+    LastModifiedDate: __expectString(output.LastModifiedDate),
+    Name: __expectString(output.Name),
+    RecommendationProviderIdType: __expectString(output.RecommendationProviderIdType),
+    RecommendationProviderRoleArn: __expectString(output.RecommendationProviderRoleArn),
+    RecommendationProviderUri: __expectString(output.RecommendationProviderUri),
+    RecommendationTransformerUri: __expectString(output.RecommendationTransformerUri),
+    RecommendationsDisplayName: __expectString(output.RecommendationsDisplayName),
+    RecommendationsPerMessage: __expectNumber(output.RecommendationsPerMessage),
   } as any;
 };
 
@@ -19464,27 +19243,27 @@ const deserializeAws_restJson1ResultRow = (output: any, context: __SerdeContext)
 
 const deserializeAws_restJson1ResultRowValue = (output: any, context: __SerdeContext): ResultRowValue => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Type: __expectString(output.Type),
+    Value: __expectString(output.Value),
   } as any;
 };
 
 const deserializeAws_restJson1Schedule = (output: any, context: __SerdeContext): Schedule => {
   return {
-    EndTime: output.EndTime !== undefined && output.EndTime !== null ? output.EndTime : undefined,
+    EndTime: __expectString(output.EndTime),
     EventFilter:
       output.EventFilter !== undefined && output.EventFilter !== null
         ? deserializeAws_restJson1CampaignEventFilter(output.EventFilter, context)
         : undefined,
-    Frequency: output.Frequency !== undefined && output.Frequency !== null ? output.Frequency : undefined,
-    IsLocalTime: output.IsLocalTime !== undefined && output.IsLocalTime !== null ? output.IsLocalTime : undefined,
+    Frequency: __expectString(output.Frequency),
+    IsLocalTime: __expectBoolean(output.IsLocalTime),
     QuietTime:
       output.QuietTime !== undefined && output.QuietTime !== null
         ? deserializeAws_restJson1QuietTime(output.QuietTime, context)
         : undefined,
-    StartTime: output.StartTime !== undefined && output.StartTime !== null ? output.StartTime : undefined,
-    Timezone: output.Timezone !== undefined && output.Timezone !== null ? output.Timezone : undefined,
+    StartTime: __expectString(output.StartTime),
+    Timezone: __expectString(output.Timezone),
   } as any;
 };
 
@@ -19499,7 +19278,7 @@ const deserializeAws_restJson1SegmentBehaviors = (output: any, context: __SerdeC
 
 const deserializeAws_restJson1SegmentCondition = (output: any, context: __SerdeContext): SegmentCondition => {
   return {
-    SegmentId: output.SegmentId !== undefined && output.SegmentId !== null ? output.SegmentId : undefined,
+    SegmentId: __expectString(output.SegmentId),
   } as any;
 };
 
@@ -19571,8 +19350,8 @@ const deserializeAws_restJson1SegmentGroup = (output: any, context: __SerdeConte
       output.SourceSegments !== undefined && output.SourceSegments !== null
         ? deserializeAws_restJson1ListOfSegmentReference(output.SourceSegments, context)
         : undefined,
-    SourceType: output.SourceType !== undefined && output.SourceType !== null ? output.SourceType : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    SourceType: __expectString(output.SourceType),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -19582,7 +19361,7 @@ const deserializeAws_restJson1SegmentGroupList = (output: any, context: __SerdeC
       output.Groups !== undefined && output.Groups !== null
         ? deserializeAws_restJson1ListOfSegmentGroup(output.Groups, context)
         : undefined,
-    Include: output.Include !== undefined && output.Include !== null ? output.Include : undefined,
+    Include: __expectString(output.Include),
   } as any;
 };
 
@@ -19592,11 +19371,11 @@ const deserializeAws_restJson1SegmentImportResource = (output: any, context: __S
       output.ChannelCounts !== undefined && output.ChannelCounts !== null
         ? deserializeAws_restJson1MapOf__integer(output.ChannelCounts, context)
         : undefined,
-    ExternalId: output.ExternalId !== undefined && output.ExternalId !== null ? output.ExternalId : undefined,
-    Format: output.Format !== undefined && output.Format !== null ? output.Format : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
-    S3Url: output.S3Url !== undefined && output.S3Url !== null ? output.S3Url : undefined,
-    Size: output.Size !== undefined && output.Size !== null ? output.Size : undefined,
+    ExternalId: __expectString(output.ExternalId),
+    Format: __expectString(output.Format),
+    RoleArn: __expectString(output.RoleArn),
+    S3Url: __expectString(output.S3Url),
+    Size: __expectNumber(output.Size),
   } as any;
 };
 
@@ -19615,35 +19394,33 @@ const deserializeAws_restJson1SegmentLocation = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1SegmentReference = (output: any, context: __SerdeContext): SegmentReference => {
   return {
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    Id: __expectString(output.Id),
+    Version: __expectNumber(output.Version),
   } as any;
 };
 
 const deserializeAws_restJson1SegmentResponse = (output: any, context: __SerdeContext): SegmentResponse => {
   return {
-    ApplicationId:
-      output.ApplicationId !== undefined && output.ApplicationId !== null ? output.ApplicationId : undefined,
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    CreationDate: output.CreationDate !== undefined && output.CreationDate !== null ? output.CreationDate : undefined,
+    ApplicationId: __expectString(output.ApplicationId),
+    Arn: __expectString(output.Arn),
+    CreationDate: __expectString(output.CreationDate),
     Dimensions:
       output.Dimensions !== undefined && output.Dimensions !== null
         ? deserializeAws_restJson1SegmentDimensions(output.Dimensions, context)
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    Id: __expectString(output.Id),
     ImportDefinition:
       output.ImportDefinition !== undefined && output.ImportDefinition !== null
         ? deserializeAws_restJson1SegmentImportResource(output.ImportDefinition, context)
         : undefined,
-    LastModifiedDate:
-      output.LastModifiedDate !== undefined && output.LastModifiedDate !== null ? output.LastModifiedDate : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    LastModifiedDate: __expectString(output.LastModifiedDate),
+    Name: __expectString(output.Name),
     SegmentGroups:
       output.SegmentGroups !== undefined && output.SegmentGroups !== null
         ? deserializeAws_restJson1SegmentGroupList(output.SegmentGroups, context)
         : undefined,
-    SegmentType: output.SegmentType !== undefined && output.SegmentType !== null ? output.SegmentType : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    SegmentType: __expectString(output.SegmentType),
+    Version: __expectNumber(output.Version),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1MapOf__string(output.tags, context)
@@ -19657,7 +19434,7 @@ const deserializeAws_restJson1SegmentsResponse = (output: any, context: __SerdeC
       output.Item !== undefined && output.Item !== null
         ? deserializeAws_restJson1ListOfSegmentResponse(output.Item, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -19666,9 +19443,8 @@ const deserializeAws_restJson1SendUsersMessageResponse = (
   context: __SerdeContext
 ): SendUsersMessageResponse => {
   return {
-    ApplicationId:
-      output.ApplicationId !== undefined && output.ApplicationId !== null ? output.ApplicationId : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
+    ApplicationId: __expectString(output.ApplicationId),
+    RequestId: __expectString(output.RequestId),
     Result:
       output.Result !== undefined && output.Result !== null
         ? deserializeAws_restJson1MapOfMapOfEndpointMessageResult(output.Result, context)
@@ -19678,8 +19454,7 @@ const deserializeAws_restJson1SendUsersMessageResponse = (
 
 const deserializeAws_restJson1SetDimension = (output: any, context: __SerdeContext): SetDimension => {
   return {
-    DimensionType:
-      output.DimensionType !== undefined && output.DimensionType !== null ? output.DimensionType : undefined,
+    DimensionType: __expectString(output.DimensionType),
     Values:
       output.Values !== undefined && output.Values !== null
         ? deserializeAws_restJson1ListOf__string(output.Values, context)
@@ -19706,30 +19481,20 @@ const deserializeAws_restJson1SimpleCondition = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1SMSChannelResponse = (output: any, context: __SerdeContext): SMSChannelResponse => {
   return {
-    ApplicationId:
-      output.ApplicationId !== undefined && output.ApplicationId !== null ? output.ApplicationId : undefined,
-    CreationDate: output.CreationDate !== undefined && output.CreationDate !== null ? output.CreationDate : undefined,
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
-    HasCredential:
-      output.HasCredential !== undefined && output.HasCredential !== null ? output.HasCredential : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    IsArchived: output.IsArchived !== undefined && output.IsArchived !== null ? output.IsArchived : undefined,
-    LastModifiedBy:
-      output.LastModifiedBy !== undefined && output.LastModifiedBy !== null ? output.LastModifiedBy : undefined,
-    LastModifiedDate:
-      output.LastModifiedDate !== undefined && output.LastModifiedDate !== null ? output.LastModifiedDate : undefined,
-    Platform: output.Platform !== undefined && output.Platform !== null ? output.Platform : undefined,
-    PromotionalMessagesPerSecond:
-      output.PromotionalMessagesPerSecond !== undefined && output.PromotionalMessagesPerSecond !== null
-        ? output.PromotionalMessagesPerSecond
-        : undefined,
-    SenderId: output.SenderId !== undefined && output.SenderId !== null ? output.SenderId : undefined,
-    ShortCode: output.ShortCode !== undefined && output.ShortCode !== null ? output.ShortCode : undefined,
-    TransactionalMessagesPerSecond:
-      output.TransactionalMessagesPerSecond !== undefined && output.TransactionalMessagesPerSecond !== null
-        ? output.TransactionalMessagesPerSecond
-        : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    ApplicationId: __expectString(output.ApplicationId),
+    CreationDate: __expectString(output.CreationDate),
+    Enabled: __expectBoolean(output.Enabled),
+    HasCredential: __expectBoolean(output.HasCredential),
+    Id: __expectString(output.Id),
+    IsArchived: __expectBoolean(output.IsArchived),
+    LastModifiedBy: __expectString(output.LastModifiedBy),
+    LastModifiedDate: __expectString(output.LastModifiedDate),
+    Platform: __expectString(output.Platform),
+    PromotionalMessagesPerSecond: __expectNumber(output.PromotionalMessagesPerSecond),
+    SenderId: __expectString(output.SenderId),
+    ShortCode: __expectString(output.ShortCode),
+    TransactionalMessagesPerSecond: __expectNumber(output.TransactionalMessagesPerSecond),
+    Version: __expectNumber(output.Version),
   } as any;
 };
 
@@ -19739,33 +19504,24 @@ const deserializeAws_restJson1SMSMessageActivity = (output: any, context: __Serd
       output.MessageConfig !== undefined && output.MessageConfig !== null
         ? deserializeAws_restJson1JourneySMSMessage(output.MessageConfig, context)
         : undefined,
-    NextActivity: output.NextActivity !== undefined && output.NextActivity !== null ? output.NextActivity : undefined,
-    TemplateName: output.TemplateName !== undefined && output.TemplateName !== null ? output.TemplateName : undefined,
-    TemplateVersion:
-      output.TemplateVersion !== undefined && output.TemplateVersion !== null ? output.TemplateVersion : undefined,
+    NextActivity: __expectString(output.NextActivity),
+    TemplateName: __expectString(output.TemplateName),
+    TemplateVersion: __expectString(output.TemplateVersion),
   } as any;
 };
 
 const deserializeAws_restJson1SMSTemplateResponse = (output: any, context: __SerdeContext): SMSTemplateResponse => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Body: output.Body !== undefined && output.Body !== null ? output.Body : undefined,
-    CreationDate: output.CreationDate !== undefined && output.CreationDate !== null ? output.CreationDate : undefined,
-    DefaultSubstitutions:
-      output.DefaultSubstitutions !== undefined && output.DefaultSubstitutions !== null
-        ? output.DefaultSubstitutions
-        : undefined,
-    LastModifiedDate:
-      output.LastModifiedDate !== undefined && output.LastModifiedDate !== null ? output.LastModifiedDate : undefined,
-    RecommenderId:
-      output.RecommenderId !== undefined && output.RecommenderId !== null ? output.RecommenderId : undefined,
-    TemplateDescription:
-      output.TemplateDescription !== undefined && output.TemplateDescription !== null
-        ? output.TemplateDescription
-        : undefined,
-    TemplateName: output.TemplateName !== undefined && output.TemplateName !== null ? output.TemplateName : undefined,
-    TemplateType: output.TemplateType !== undefined && output.TemplateType !== null ? output.TemplateType : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    Arn: __expectString(output.Arn),
+    Body: __expectString(output.Body),
+    CreationDate: __expectString(output.CreationDate),
+    DefaultSubstitutions: __expectString(output.DefaultSubstitutions),
+    LastModifiedDate: __expectString(output.LastModifiedDate),
+    RecommenderId: __expectString(output.RecommenderId),
+    TemplateDescription: __expectString(output.TemplateDescription),
+    TemplateName: __expectString(output.TemplateName),
+    TemplateType: __expectString(output.TemplateType),
+    Version: __expectString(output.Version),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1MapOf__string(output.tags, context)
@@ -19775,7 +19531,7 @@ const deserializeAws_restJson1SMSTemplateResponse = (output: any, context: __Ser
 
 const deserializeAws_restJson1StartCondition = (output: any, context: __SerdeContext): StartCondition => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     EventStartCondition:
       output.EventStartCondition !== undefined && output.EventStartCondition !== null
         ? deserializeAws_restJson1EventStartCondition(output.EventStartCondition, context)
@@ -19798,8 +19554,8 @@ const deserializeAws_restJson1TagsModel = (output: any, context: __SerdeContext)
 
 const deserializeAws_restJson1Template = (output: any, context: __SerdeContext): Template => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    Name: __expectString(output.Name),
+    Version: __expectString(output.Version),
   } as any;
 };
 
@@ -19826,21 +19582,14 @@ const deserializeAws_restJson1TemplateConfiguration = (output: any, context: __S
 
 const deserializeAws_restJson1TemplateResponse = (output: any, context: __SerdeContext): TemplateResponse => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    CreationDate: output.CreationDate !== undefined && output.CreationDate !== null ? output.CreationDate : undefined,
-    DefaultSubstitutions:
-      output.DefaultSubstitutions !== undefined && output.DefaultSubstitutions !== null
-        ? output.DefaultSubstitutions
-        : undefined,
-    LastModifiedDate:
-      output.LastModifiedDate !== undefined && output.LastModifiedDate !== null ? output.LastModifiedDate : undefined,
-    TemplateDescription:
-      output.TemplateDescription !== undefined && output.TemplateDescription !== null
-        ? output.TemplateDescription
-        : undefined,
-    TemplateName: output.TemplateName !== undefined && output.TemplateName !== null ? output.TemplateName : undefined,
-    TemplateType: output.TemplateType !== undefined && output.TemplateType !== null ? output.TemplateType : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    Arn: __expectString(output.Arn),
+    CreationDate: __expectString(output.CreationDate),
+    DefaultSubstitutions: __expectString(output.DefaultSubstitutions),
+    LastModifiedDate: __expectString(output.LastModifiedDate),
+    TemplateDescription: __expectString(output.TemplateDescription),
+    TemplateName: __expectString(output.TemplateName),
+    TemplateType: __expectString(output.TemplateType),
+    Version: __expectString(output.Version),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1MapOf__string(output.tags, context)
@@ -19854,7 +19603,7 @@ const deserializeAws_restJson1TemplatesResponse = (output: any, context: __Serde
       output.Item !== undefined && output.Item !== null
         ? deserializeAws_restJson1ListOfTemplateResponse(output.Item, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -19863,20 +19612,13 @@ const deserializeAws_restJson1TemplateVersionResponse = (
   context: __SerdeContext
 ): TemplateVersionResponse => {
   return {
-    CreationDate: output.CreationDate !== undefined && output.CreationDate !== null ? output.CreationDate : undefined,
-    DefaultSubstitutions:
-      output.DefaultSubstitutions !== undefined && output.DefaultSubstitutions !== null
-        ? output.DefaultSubstitutions
-        : undefined,
-    LastModifiedDate:
-      output.LastModifiedDate !== undefined && output.LastModifiedDate !== null ? output.LastModifiedDate : undefined,
-    TemplateDescription:
-      output.TemplateDescription !== undefined && output.TemplateDescription !== null
-        ? output.TemplateDescription
-        : undefined,
-    TemplateName: output.TemplateName !== undefined && output.TemplateName !== null ? output.TemplateName : undefined,
-    TemplateType: output.TemplateType !== undefined && output.TemplateType !== null ? output.TemplateType : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    CreationDate: __expectString(output.CreationDate),
+    DefaultSubstitutions: __expectString(output.DefaultSubstitutions),
+    LastModifiedDate: __expectString(output.LastModifiedDate),
+    TemplateDescription: __expectString(output.TemplateDescription),
+    TemplateName: __expectString(output.TemplateName),
+    TemplateType: __expectString(output.TemplateType),
+    Version: __expectString(output.Version),
   } as any;
 };
 
@@ -19889,9 +19631,9 @@ const deserializeAws_restJson1TemplateVersionsResponse = (
       output.Item !== undefined && output.Item !== null
         ? deserializeAws_restJson1ListOfTemplateVersionResponse(output.Item, context)
         : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
-    RequestID: output.RequestID !== undefined && output.RequestID !== null ? output.RequestID : undefined,
+    Message: __expectString(output.Message),
+    NextToken: __expectString(output.NextToken),
+    RequestID: __expectString(output.RequestID),
   } as any;
 };
 
@@ -19901,7 +19643,7 @@ const deserializeAws_restJson1TreatmentResource = (output: any, context: __Serde
       output.CustomDeliveryConfiguration !== undefined && output.CustomDeliveryConfiguration !== null
         ? deserializeAws_restJson1CustomDeliveryConfiguration(output.CustomDeliveryConfiguration, context)
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    Id: __expectString(output.Id),
     MessageConfiguration:
       output.MessageConfiguration !== undefined && output.MessageConfiguration !== null
         ? deserializeAws_restJson1MessageConfiguration(output.MessageConfiguration, context)
@@ -19910,7 +19652,7 @@ const deserializeAws_restJson1TreatmentResource = (output: any, context: __Serde
       output.Schedule !== undefined && output.Schedule !== null
         ? deserializeAws_restJson1Schedule(output.Schedule, context)
         : undefined,
-    SizePercent: output.SizePercent !== undefined && output.SizePercent !== null ? output.SizePercent : undefined,
+    SizePercent: __expectNumber(output.SizePercent),
     State:
       output.State !== undefined && output.State !== null
         ? deserializeAws_restJson1CampaignState(output.State, context)
@@ -19919,54 +19661,39 @@ const deserializeAws_restJson1TreatmentResource = (output: any, context: __Serde
       output.TemplateConfiguration !== undefined && output.TemplateConfiguration !== null
         ? deserializeAws_restJson1TemplateConfiguration(output.TemplateConfiguration, context)
         : undefined,
-    TreatmentDescription:
-      output.TreatmentDescription !== undefined && output.TreatmentDescription !== null
-        ? output.TreatmentDescription
-        : undefined,
-    TreatmentName:
-      output.TreatmentName !== undefined && output.TreatmentName !== null ? output.TreatmentName : undefined,
+    TreatmentDescription: __expectString(output.TreatmentDescription),
+    TreatmentName: __expectString(output.TreatmentName),
   } as any;
 };
 
 const deserializeAws_restJson1VoiceChannelResponse = (output: any, context: __SerdeContext): VoiceChannelResponse => {
   return {
-    ApplicationId:
-      output.ApplicationId !== undefined && output.ApplicationId !== null ? output.ApplicationId : undefined,
-    CreationDate: output.CreationDate !== undefined && output.CreationDate !== null ? output.CreationDate : undefined,
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
-    HasCredential:
-      output.HasCredential !== undefined && output.HasCredential !== null ? output.HasCredential : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    IsArchived: output.IsArchived !== undefined && output.IsArchived !== null ? output.IsArchived : undefined,
-    LastModifiedBy:
-      output.LastModifiedBy !== undefined && output.LastModifiedBy !== null ? output.LastModifiedBy : undefined,
-    LastModifiedDate:
-      output.LastModifiedDate !== undefined && output.LastModifiedDate !== null ? output.LastModifiedDate : undefined,
-    Platform: output.Platform !== undefined && output.Platform !== null ? output.Platform : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    ApplicationId: __expectString(output.ApplicationId),
+    CreationDate: __expectString(output.CreationDate),
+    Enabled: __expectBoolean(output.Enabled),
+    HasCredential: __expectBoolean(output.HasCredential),
+    Id: __expectString(output.Id),
+    IsArchived: __expectBoolean(output.IsArchived),
+    LastModifiedBy: __expectString(output.LastModifiedBy),
+    LastModifiedDate: __expectString(output.LastModifiedDate),
+    Platform: __expectString(output.Platform),
+    Version: __expectNumber(output.Version),
   } as any;
 };
 
 const deserializeAws_restJson1VoiceTemplateResponse = (output: any, context: __SerdeContext): VoiceTemplateResponse => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Body: output.Body !== undefined && output.Body !== null ? output.Body : undefined,
-    CreationDate: output.CreationDate !== undefined && output.CreationDate !== null ? output.CreationDate : undefined,
-    DefaultSubstitutions:
-      output.DefaultSubstitutions !== undefined && output.DefaultSubstitutions !== null
-        ? output.DefaultSubstitutions
-        : undefined,
-    LanguageCode: output.LanguageCode !== undefined && output.LanguageCode !== null ? output.LanguageCode : undefined,
-    LastModifiedDate:
-      output.LastModifiedDate !== undefined && output.LastModifiedDate !== null ? output.LastModifiedDate : undefined,
-    TemplateDescription:
-      output.TemplateDescription !== undefined && output.TemplateDescription !== null
-        ? output.TemplateDescription
-        : undefined,
-    TemplateName: output.TemplateName !== undefined && output.TemplateName !== null ? output.TemplateName : undefined,
-    TemplateType: output.TemplateType !== undefined && output.TemplateType !== null ? output.TemplateType : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
-    VoiceId: output.VoiceId !== undefined && output.VoiceId !== null ? output.VoiceId : undefined,
+    Arn: __expectString(output.Arn),
+    Body: __expectString(output.Body),
+    CreationDate: __expectString(output.CreationDate),
+    DefaultSubstitutions: __expectString(output.DefaultSubstitutions),
+    LanguageCode: __expectString(output.LanguageCode),
+    LastModifiedDate: __expectString(output.LastModifiedDate),
+    TemplateDescription: __expectString(output.TemplateDescription),
+    TemplateName: __expectString(output.TemplateName),
+    TemplateType: __expectString(output.TemplateType),
+    Version: __expectString(output.Version),
+    VoiceId: __expectString(output.VoiceId),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1MapOf__string(output.tags, context)
@@ -19976,7 +19703,7 @@ const deserializeAws_restJson1VoiceTemplateResponse = (output: any, context: __S
 
 const deserializeAws_restJson1WaitActivity = (output: any, context: __SerdeContext): WaitActivity => {
   return {
-    NextActivity: output.NextActivity !== undefined && output.NextActivity !== null ? output.NextActivity : undefined,
+    NextActivity: __expectString(output.NextActivity),
     WaitTime:
       output.WaitTime !== undefined && output.WaitTime !== null
         ? deserializeAws_restJson1WaitTime(output.WaitTime, context)
@@ -19986,8 +19713,8 @@ const deserializeAws_restJson1WaitActivity = (output: any, context: __SerdeConte
 
 const deserializeAws_restJson1WaitTime = (output: any, context: __SerdeContext): WaitTime => {
   return {
-    WaitFor: output.WaitFor !== undefined && output.WaitFor !== null ? output.WaitFor : undefined,
-    WaitUntil: output.WaitUntil !== undefined && output.WaitUntil !== null ? output.WaitUntil : undefined,
+    WaitFor: __expectString(output.WaitFor),
+    WaitUntil: __expectString(output.WaitUntil),
   } as any;
 };
 

--- a/clients/client-polly/protocols/Aws_restJson1.ts
+++ b/clients/client-polly/protocols/Aws_restJson1.ts
@@ -50,6 +50,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -406,7 +408,7 @@ export const deserializeAws_restJson1DescribeVoicesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Voices !== undefined && data.Voices !== null) {
     contents.Voices = deserializeAws_restJson1VoiceList(data.Voices, context);
@@ -614,7 +616,7 @@ export const deserializeAws_restJson1ListLexiconsCommand = async (
     contents.Lexicons = deserializeAws_restJson1LexiconDescriptionList(data.Lexicons, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -678,7 +680,7 @@ export const deserializeAws_restJson1ListSpeechSynthesisTasksCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.SynthesisTasks !== undefined && data.SynthesisTasks !== null) {
     contents.SynthesisTasks = deserializeAws_restJson1SynthesisTasks(data.SynthesisTasks, context);
@@ -1110,7 +1112,7 @@ const deserializeAws_restJson1EngineNotSupportedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1127,7 +1129,7 @@ const deserializeAws_restJson1InvalidLexiconExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1144,7 +1146,7 @@ const deserializeAws_restJson1InvalidNextTokenExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1161,7 +1163,7 @@ const deserializeAws_restJson1InvalidS3BucketExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1178,7 +1180,7 @@ const deserializeAws_restJson1InvalidS3KeyExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1195,7 +1197,7 @@ const deserializeAws_restJson1InvalidSampleRateExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1212,7 +1214,7 @@ const deserializeAws_restJson1InvalidSnsTopicArnExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1229,7 +1231,7 @@ const deserializeAws_restJson1InvalidSsmlExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1246,7 +1248,7 @@ const deserializeAws_restJson1InvalidTaskIdExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1263,7 +1265,7 @@ const deserializeAws_restJson1LanguageNotSupportedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1280,7 +1282,7 @@ const deserializeAws_restJson1LexiconNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1297,7 +1299,7 @@ const deserializeAws_restJson1LexiconSizeExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1314,7 +1316,7 @@ const deserializeAws_restJson1MarksNotSupportedForFormatExceptionResponse = asyn
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1331,7 +1333,7 @@ const deserializeAws_restJson1MaxLexemeLengthExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1348,7 +1350,7 @@ const deserializeAws_restJson1MaxLexiconsNumberExceededExceptionResponse = async
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1365,7 +1367,7 @@ const deserializeAws_restJson1ServiceFailureExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1382,7 +1384,7 @@ const deserializeAws_restJson1SsmlMarksNotSupportedForTextTypeExceptionResponse 
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1399,7 +1401,7 @@ const deserializeAws_restJson1SynthesisTaskNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1416,7 +1418,7 @@ const deserializeAws_restJson1TextLengthExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1433,7 +1435,7 @@ const deserializeAws_restJson1UnsupportedPlsAlphabetExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1450,7 +1452,7 @@ const deserializeAws_restJson1UnsupportedPlsLanguageExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1484,7 +1486,7 @@ const deserializeAws_restJson1EngineList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -1495,28 +1497,28 @@ const deserializeAws_restJson1LanguageCodeList = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1Lexicon = (output: any, context: __SerdeContext): Lexicon => {
   return {
-    Content: output.Content !== undefined && output.Content !== null ? output.Content : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Content: __expectString(output.Content),
+    Name: __expectString(output.Name),
   } as any;
 };
 
 const deserializeAws_restJson1LexiconAttributes = (output: any, context: __SerdeContext): LexiconAttributes => {
   return {
-    Alphabet: output.Alphabet !== undefined && output.Alphabet !== null ? output.Alphabet : undefined,
-    LanguageCode: output.LanguageCode !== undefined && output.LanguageCode !== null ? output.LanguageCode : undefined,
+    Alphabet: __expectString(output.Alphabet),
+    LanguageCode: __expectString(output.LanguageCode),
     LastModified:
       output.LastModified !== undefined && output.LastModified !== null
         ? new Date(Math.round(output.LastModified * 1000))
         : undefined,
-    LexemesCount: output.LexemesCount !== undefined && output.LexemesCount !== null ? output.LexemesCount : undefined,
-    LexiconArn: output.LexiconArn !== undefined && output.LexiconArn !== null ? output.LexiconArn : undefined,
-    Size: output.Size !== undefined && output.Size !== null ? output.Size : undefined,
+    LexemesCount: __expectNumber(output.LexemesCount),
+    LexiconArn: __expectString(output.LexiconArn),
+    Size: __expectNumber(output.Size),
   } as any;
 };
 
@@ -1526,7 +1528,7 @@ const deserializeAws_restJson1LexiconDescription = (output: any, context: __Serd
       output.Attributes !== undefined && output.Attributes !== null
         ? deserializeAws_restJson1LexiconAttributes(output.Attributes, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -1548,7 +1550,7 @@ const deserializeAws_restJson1LexiconNameList = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -1562,7 +1564,7 @@ const deserializeAws_restJson1SpeechMarkTypeList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -1572,30 +1574,26 @@ const deserializeAws_restJson1SynthesisTask = (output: any, context: __SerdeCont
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    Engine: output.Engine !== undefined && output.Engine !== null ? output.Engine : undefined,
-    LanguageCode: output.LanguageCode !== undefined && output.LanguageCode !== null ? output.LanguageCode : undefined,
+    Engine: __expectString(output.Engine),
+    LanguageCode: __expectString(output.LanguageCode),
     LexiconNames:
       output.LexiconNames !== undefined && output.LexiconNames !== null
         ? deserializeAws_restJson1LexiconNameList(output.LexiconNames, context)
         : undefined,
-    OutputFormat: output.OutputFormat !== undefined && output.OutputFormat !== null ? output.OutputFormat : undefined,
-    OutputUri: output.OutputUri !== undefined && output.OutputUri !== null ? output.OutputUri : undefined,
-    RequestCharacters:
-      output.RequestCharacters !== undefined && output.RequestCharacters !== null
-        ? output.RequestCharacters
-        : undefined,
-    SampleRate: output.SampleRate !== undefined && output.SampleRate !== null ? output.SampleRate : undefined,
-    SnsTopicArn: output.SnsTopicArn !== undefined && output.SnsTopicArn !== null ? output.SnsTopicArn : undefined,
+    OutputFormat: __expectString(output.OutputFormat),
+    OutputUri: __expectString(output.OutputUri),
+    RequestCharacters: __expectNumber(output.RequestCharacters),
+    SampleRate: __expectString(output.SampleRate),
+    SnsTopicArn: __expectString(output.SnsTopicArn),
     SpeechMarkTypes:
       output.SpeechMarkTypes !== undefined && output.SpeechMarkTypes !== null
         ? deserializeAws_restJson1SpeechMarkTypeList(output.SpeechMarkTypes, context)
         : undefined,
-    TaskId: output.TaskId !== undefined && output.TaskId !== null ? output.TaskId : undefined,
-    TaskStatus: output.TaskStatus !== undefined && output.TaskStatus !== null ? output.TaskStatus : undefined,
-    TaskStatusReason:
-      output.TaskStatusReason !== undefined && output.TaskStatusReason !== null ? output.TaskStatusReason : undefined,
-    TextType: output.TextType !== undefined && output.TextType !== null ? output.TextType : undefined,
-    VoiceId: output.VoiceId !== undefined && output.VoiceId !== null ? output.VoiceId : undefined,
+    TaskId: __expectString(output.TaskId),
+    TaskStatus: __expectString(output.TaskStatus),
+    TaskStatusReason: __expectString(output.TaskStatusReason),
+    TextType: __expectString(output.TextType),
+    VoiceId: __expectString(output.VoiceId),
   } as any;
 };
 
@@ -1616,11 +1614,11 @@ const deserializeAws_restJson1Voice = (output: any, context: __SerdeContext): Vo
       output.AdditionalLanguageCodes !== undefined && output.AdditionalLanguageCodes !== null
         ? deserializeAws_restJson1LanguageCodeList(output.AdditionalLanguageCodes, context)
         : undefined,
-    Gender: output.Gender !== undefined && output.Gender !== null ? output.Gender : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    LanguageCode: output.LanguageCode !== undefined && output.LanguageCode !== null ? output.LanguageCode : undefined,
-    LanguageName: output.LanguageName !== undefined && output.LanguageName !== null ? output.LanguageName : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Gender: __expectString(output.Gender),
+    Id: __expectString(output.Id),
+    LanguageCode: __expectString(output.LanguageCode),
+    LanguageName: __expectString(output.LanguageName),
+    Name: __expectString(output.Name),
     SupportedEngines:
       output.SupportedEngines !== undefined && output.SupportedEngines !== null
         ? deserializeAws_restJson1EngineList(output.SupportedEngines, context)

--- a/clients/client-pricing/protocols/Aws_json1_1.ts
+++ b/clients/client-pricing/protocols/Aws_json1_1.ts
@@ -18,7 +18,11 @@ import {
   Service,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { LazyJsonString as __LazyJsonString, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  LazyJsonString as __LazyJsonString,
+  SmithyException as __SmithyException,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -457,13 +461,13 @@ const deserializeAws_json1_1AttributeNameList = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1AttributeValue = (output: any, context: __SerdeContext): AttributeValue => {
   return {
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -483,9 +487,8 @@ const deserializeAws_json1_1DescribeServicesResponse = (
   context: __SerdeContext
 ): DescribeServicesResponse => {
   return {
-    FormatVersion:
-      output.FormatVersion !== undefined && output.FormatVersion !== null ? output.FormatVersion : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    FormatVersion: __expectString(output.FormatVersion),
+    NextToken: __expectString(output.NextToken),
     Services:
       output.Services !== undefined && output.Services !== null
         ? deserializeAws_json1_1ServiceList(output.Services, context)
@@ -498,7 +501,7 @@ const deserializeAws_json1_1ExpiredNextTokenException = (
   context: __SerdeContext
 ): ExpiredNextTokenException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -511,15 +514,14 @@ const deserializeAws_json1_1GetAttributeValuesResponse = (
       output.AttributeValues !== undefined && output.AttributeValues !== null
         ? deserializeAws_json1_1AttributeValueList(output.AttributeValues, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
 const deserializeAws_json1_1GetProductsResponse = (output: any, context: __SerdeContext): GetProductsResponse => {
   return {
-    FormatVersion:
-      output.FormatVersion !== undefined && output.FormatVersion !== null ? output.FormatVersion : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    FormatVersion: __expectString(output.FormatVersion),
+    NextToken: __expectString(output.NextToken),
     PriceList:
       output.PriceList !== undefined && output.PriceList !== null
         ? deserializeAws_json1_1PriceList(output.PriceList, context)
@@ -529,7 +531,7 @@ const deserializeAws_json1_1GetProductsResponse = (output: any, context: __Serde
 
 const deserializeAws_json1_1InternalErrorException = (output: any, context: __SerdeContext): InternalErrorException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -538,7 +540,7 @@ const deserializeAws_json1_1InvalidNextTokenException = (
   context: __SerdeContext
 ): InvalidNextTokenException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -547,13 +549,13 @@ const deserializeAws_json1_1InvalidParameterException = (
   context: __SerdeContext
 ): InvalidParameterException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1NotFoundException = (output: any, context: __SerdeContext): NotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -574,7 +576,7 @@ const deserializeAws_json1_1Service = (output: any, context: __SerdeContext): Se
       output.AttributeNames !== undefined && output.AttributeNames !== null
         ? deserializeAws_json1_1AttributeNameList(output.AttributeNames, context)
         : undefined,
-    ServiceCode: output.ServiceCode !== undefined && output.ServiceCode !== null ? output.ServiceCode : undefined,
+    ServiceCode: __expectString(output.ServiceCode),
   } as any;
 };
 

--- a/clients/client-proton/protocols/Aws_json1_0.ts
+++ b/clients/client-proton/protocols/Aws_json1_0.ts
@@ -282,7 +282,7 @@ import {
   ValidationException,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException, expectString as __expectString } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -6170,16 +6170,13 @@ const deserializeAws_json1_0AcceptEnvironmentAccountConnectionOutput = (
 
 const deserializeAws_json1_0AccessDeniedException = (output: any, context: __SerdeContext): AccessDeniedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_0AccountSettings = (output: any, context: __SerdeContext): AccountSettings => {
   return {
-    pipelineServiceRoleArn:
-      output.pipelineServiceRoleArn !== undefined && output.pipelineServiceRoleArn !== null
-        ? output.pipelineServiceRoleArn
-        : undefined,
+    pipelineServiceRoleArn: __expectString(output.pipelineServiceRoleArn),
   } as any;
 };
 
@@ -6224,8 +6221,8 @@ const deserializeAws_json1_0CompatibleEnvironmentTemplate = (
   context: __SerdeContext
 ): CompatibleEnvironmentTemplate => {
   return {
-    majorVersion: output.majorVersion !== undefined && output.majorVersion !== null ? output.majorVersion : undefined,
-    templateName: output.templateName !== undefined && output.templateName !== null ? output.templateName : undefined,
+    majorVersion: __expectString(output.majorVersion),
+    templateName: __expectString(output.templateName),
   } as any;
 };
 
@@ -6245,7 +6242,7 @@ const deserializeAws_json1_0CompatibleEnvironmentTemplateList = (
 
 const deserializeAws_json1_0ConflictException = (output: any, context: __SerdeContext): ConflictException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6413,26 +6410,16 @@ const deserializeAws_json1_0DeleteServiceTemplateVersionOutput = (
 
 const deserializeAws_json1_0Environment = (output: any, context: __SerdeContext): Environment => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    deploymentStatus:
-      output.deploymentStatus !== undefined && output.deploymentStatus !== null ? output.deploymentStatus : undefined,
-    deploymentStatusMessage:
-      output.deploymentStatusMessage !== undefined && output.deploymentStatusMessage !== null
-        ? output.deploymentStatusMessage
-        : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    environmentAccountConnectionId:
-      output.environmentAccountConnectionId !== undefined && output.environmentAccountConnectionId !== null
-        ? output.environmentAccountConnectionId
-        : undefined,
-    environmentAccountId:
-      output.environmentAccountId !== undefined && output.environmentAccountId !== null
-        ? output.environmentAccountId
-        : undefined,
+    deploymentStatus: __expectString(output.deploymentStatus),
+    deploymentStatusMessage: __expectString(output.deploymentStatusMessage),
+    description: __expectString(output.description),
+    environmentAccountConnectionId: __expectString(output.environmentAccountConnectionId),
+    environmentAccountId: __expectString(output.environmentAccountId),
     lastDeploymentAttemptedAt:
       output.lastDeploymentAttemptedAt !== undefined && output.lastDeploymentAttemptedAt !== null
         ? new Date(Math.round(output.lastDeploymentAttemptedAt * 1000))
@@ -6441,22 +6428,13 @@ const deserializeAws_json1_0Environment = (output: any, context: __SerdeContext)
       output.lastDeploymentSucceededAt !== undefined && output.lastDeploymentSucceededAt !== null
         ? new Date(Math.round(output.lastDeploymentSucceededAt * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    protonServiceRoleArn:
-      output.protonServiceRoleArn !== undefined && output.protonServiceRoleArn !== null
-        ? output.protonServiceRoleArn
-        : undefined,
-    provisioning: output.provisioning !== undefined && output.provisioning !== null ? output.provisioning : undefined,
-    spec: output.spec !== undefined && output.spec !== null ? output.spec : undefined,
-    templateMajorVersion:
-      output.templateMajorVersion !== undefined && output.templateMajorVersion !== null
-        ? output.templateMajorVersion
-        : undefined,
-    templateMinorVersion:
-      output.templateMinorVersion !== undefined && output.templateMinorVersion !== null
-        ? output.templateMinorVersion
-        : undefined,
-    templateName: output.templateName !== undefined && output.templateName !== null ? output.templateName : undefined,
+    name: __expectString(output.name),
+    protonServiceRoleArn: __expectString(output.protonServiceRoleArn),
+    provisioning: __expectString(output.provisioning),
+    spec: __expectString(output.spec),
+    templateMajorVersion: __expectString(output.templateMajorVersion),
+    templateMinorVersion: __expectString(output.templateMinorVersion),
+    templateName: __expectString(output.templateName),
   } as any;
 };
 
@@ -6465,28 +6443,21 @@ const deserializeAws_json1_0EnvironmentAccountConnection = (
   context: __SerdeContext
 ): EnvironmentAccountConnection => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    environmentAccountId:
-      output.environmentAccountId !== undefined && output.environmentAccountId !== null
-        ? output.environmentAccountId
-        : undefined,
-    environmentName:
-      output.environmentName !== undefined && output.environmentName !== null ? output.environmentName : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    arn: __expectString(output.arn),
+    environmentAccountId: __expectString(output.environmentAccountId),
+    environmentName: __expectString(output.environmentName),
+    id: __expectString(output.id),
     lastModifiedAt:
       output.lastModifiedAt !== undefined && output.lastModifiedAt !== null
         ? new Date(Math.round(output.lastModifiedAt * 1000))
         : undefined,
-    managementAccountId:
-      output.managementAccountId !== undefined && output.managementAccountId !== null
-        ? output.managementAccountId
-        : undefined,
+    managementAccountId: __expectString(output.managementAccountId),
     requestedAt:
       output.requestedAt !== undefined && output.requestedAt !== null
         ? new Date(Math.round(output.requestedAt * 1000))
         : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    roleArn: __expectString(output.roleArn),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -6495,28 +6466,21 @@ const deserializeAws_json1_0EnvironmentAccountConnectionSummary = (
   context: __SerdeContext
 ): EnvironmentAccountConnectionSummary => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    environmentAccountId:
-      output.environmentAccountId !== undefined && output.environmentAccountId !== null
-        ? output.environmentAccountId
-        : undefined,
-    environmentName:
-      output.environmentName !== undefined && output.environmentName !== null ? output.environmentName : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    arn: __expectString(output.arn),
+    environmentAccountId: __expectString(output.environmentAccountId),
+    environmentName: __expectString(output.environmentName),
+    id: __expectString(output.id),
     lastModifiedAt:
       output.lastModifiedAt !== undefined && output.lastModifiedAt !== null
         ? new Date(Math.round(output.lastModifiedAt * 1000))
         : undefined,
-    managementAccountId:
-      output.managementAccountId !== undefined && output.managementAccountId !== null
-        ? output.managementAccountId
-        : undefined,
+    managementAccountId: __expectString(output.managementAccountId),
     requestedAt:
       output.requestedAt !== undefined && output.requestedAt !== null
         ? new Date(Math.round(output.requestedAt * 1000))
         : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    roleArn: __expectString(output.roleArn),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -6536,26 +6500,16 @@ const deserializeAws_json1_0EnvironmentAccountConnectionSummaryList = (
 
 const deserializeAws_json1_0EnvironmentSummary = (output: any, context: __SerdeContext): EnvironmentSummary => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    deploymentStatus:
-      output.deploymentStatus !== undefined && output.deploymentStatus !== null ? output.deploymentStatus : undefined,
-    deploymentStatusMessage:
-      output.deploymentStatusMessage !== undefined && output.deploymentStatusMessage !== null
-        ? output.deploymentStatusMessage
-        : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    environmentAccountConnectionId:
-      output.environmentAccountConnectionId !== undefined && output.environmentAccountConnectionId !== null
-        ? output.environmentAccountConnectionId
-        : undefined,
-    environmentAccountId:
-      output.environmentAccountId !== undefined && output.environmentAccountId !== null
-        ? output.environmentAccountId
-        : undefined,
+    deploymentStatus: __expectString(output.deploymentStatus),
+    deploymentStatusMessage: __expectString(output.deploymentStatusMessage),
+    description: __expectString(output.description),
+    environmentAccountConnectionId: __expectString(output.environmentAccountConnectionId),
+    environmentAccountId: __expectString(output.environmentAccountId),
     lastDeploymentAttemptedAt:
       output.lastDeploymentAttemptedAt !== undefined && output.lastDeploymentAttemptedAt !== null
         ? new Date(Math.round(output.lastDeploymentAttemptedAt * 1000))
@@ -6564,21 +6518,12 @@ const deserializeAws_json1_0EnvironmentSummary = (output: any, context: __SerdeC
       output.lastDeploymentSucceededAt !== undefined && output.lastDeploymentSucceededAt !== null
         ? new Date(Math.round(output.lastDeploymentSucceededAt * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    protonServiceRoleArn:
-      output.protonServiceRoleArn !== undefined && output.protonServiceRoleArn !== null
-        ? output.protonServiceRoleArn
-        : undefined,
-    provisioning: output.provisioning !== undefined && output.provisioning !== null ? output.provisioning : undefined,
-    templateMajorVersion:
-      output.templateMajorVersion !== undefined && output.templateMajorVersion !== null
-        ? output.templateMajorVersion
-        : undefined,
-    templateMinorVersion:
-      output.templateMinorVersion !== undefined && output.templateMinorVersion !== null
-        ? output.templateMinorVersion
-        : undefined,
-    templateName: output.templateName !== undefined && output.templateName !== null ? output.templateName : undefined,
+    name: __expectString(output.name),
+    protonServiceRoleArn: __expectString(output.protonServiceRoleArn),
+    provisioning: __expectString(output.provisioning),
+    templateMajorVersion: __expectString(output.templateMajorVersion),
+    templateMinorVersion: __expectString(output.templateMinorVersion),
+    templateName: __expectString(output.templateName),
   } as any;
 };
 
@@ -6595,25 +6540,21 @@ const deserializeAws_json1_0EnvironmentSummaryList = (output: any, context: __Se
 
 const deserializeAws_json1_0EnvironmentTemplate = (output: any, context: __SerdeContext): EnvironmentTemplate => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    displayName: output.displayName !== undefined && output.displayName !== null ? output.displayName : undefined,
-    encryptionKey:
-      output.encryptionKey !== undefined && output.encryptionKey !== null ? output.encryptionKey : undefined,
+    description: __expectString(output.description),
+    displayName: __expectString(output.displayName),
+    encryptionKey: __expectString(output.encryptionKey),
     lastModifiedAt:
       output.lastModifiedAt !== undefined && output.lastModifiedAt !== null
         ? new Date(Math.round(output.lastModifiedAt * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    provisioning: output.provisioning !== undefined && output.provisioning !== null ? output.provisioning : undefined,
-    recommendedVersion:
-      output.recommendedVersion !== undefined && output.recommendedVersion !== null
-        ? output.recommendedVersion
-        : undefined,
+    name: __expectString(output.name),
+    provisioning: __expectString(output.provisioning),
+    recommendedVersion: __expectString(output.recommendedVersion),
   } as any;
 };
 
@@ -6622,23 +6563,20 @@ const deserializeAws_json1_0EnvironmentTemplateSummary = (
   context: __SerdeContext
 ): EnvironmentTemplateSummary => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    displayName: output.displayName !== undefined && output.displayName !== null ? output.displayName : undefined,
+    description: __expectString(output.description),
+    displayName: __expectString(output.displayName),
     lastModifiedAt:
       output.lastModifiedAt !== undefined && output.lastModifiedAt !== null
         ? new Date(Math.round(output.lastModifiedAt * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    provisioning: output.provisioning !== undefined && output.provisioning !== null ? output.provisioning : undefined,
-    recommendedVersion:
-      output.recommendedVersion !== undefined && output.recommendedVersion !== null
-        ? output.recommendedVersion
-        : undefined,
+    name: __expectString(output.name),
+    provisioning: __expectString(output.provisioning),
+    recommendedVersion: __expectString(output.recommendedVersion),
   } as any;
 };
 
@@ -6661,27 +6599,23 @@ const deserializeAws_json1_0EnvironmentTemplateVersion = (
   context: __SerdeContext
 ): EnvironmentTemplateVersion => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    description: __expectString(output.description),
     lastModifiedAt:
       output.lastModifiedAt !== undefined && output.lastModifiedAt !== null
         ? new Date(Math.round(output.lastModifiedAt * 1000))
         : undefined,
-    majorVersion: output.majorVersion !== undefined && output.majorVersion !== null ? output.majorVersion : undefined,
-    minorVersion: output.minorVersion !== undefined && output.minorVersion !== null ? output.minorVersion : undefined,
-    recommendedMinorVersion:
-      output.recommendedMinorVersion !== undefined && output.recommendedMinorVersion !== null
-        ? output.recommendedMinorVersion
-        : undefined,
-    schema: output.schema !== undefined && output.schema !== null ? output.schema : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    statusMessage:
-      output.statusMessage !== undefined && output.statusMessage !== null ? output.statusMessage : undefined,
-    templateName: output.templateName !== undefined && output.templateName !== null ? output.templateName : undefined,
+    majorVersion: __expectString(output.majorVersion),
+    minorVersion: __expectString(output.minorVersion),
+    recommendedMinorVersion: __expectString(output.recommendedMinorVersion),
+    schema: __expectString(output.schema),
+    status: __expectString(output.status),
+    statusMessage: __expectString(output.statusMessage),
+    templateName: __expectString(output.templateName),
   } as any;
 };
 
@@ -6690,26 +6624,22 @@ const deserializeAws_json1_0EnvironmentTemplateVersionSummary = (
   context: __SerdeContext
 ): EnvironmentTemplateVersionSummary => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    description: __expectString(output.description),
     lastModifiedAt:
       output.lastModifiedAt !== undefined && output.lastModifiedAt !== null
         ? new Date(Math.round(output.lastModifiedAt * 1000))
         : undefined,
-    majorVersion: output.majorVersion !== undefined && output.majorVersion !== null ? output.majorVersion : undefined,
-    minorVersion: output.minorVersion !== undefined && output.minorVersion !== null ? output.minorVersion : undefined,
-    recommendedMinorVersion:
-      output.recommendedMinorVersion !== undefined && output.recommendedMinorVersion !== null
-        ? output.recommendedMinorVersion
-        : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    statusMessage:
-      output.statusMessage !== undefined && output.statusMessage !== null ? output.statusMessage : undefined,
-    templateName: output.templateName !== undefined && output.templateName !== null ? output.templateName : undefined,
+    majorVersion: __expectString(output.majorVersion),
+    minorVersion: __expectString(output.minorVersion),
+    recommendedMinorVersion: __expectString(output.recommendedMinorVersion),
+    status: __expectString(output.status),
+    statusMessage: __expectString(output.statusMessage),
+    templateName: __expectString(output.templateName),
   } as any;
 };
 
@@ -6834,7 +6764,7 @@ const deserializeAws_json1_0InternalServerException = (
   context: __SerdeContext
 ): InternalServerException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6847,7 +6777,7 @@ const deserializeAws_json1_0ListEnvironmentAccountConnectionsOutput = (
       output.environmentAccountConnections !== undefined && output.environmentAccountConnections !== null
         ? deserializeAws_json1_0EnvironmentAccountConnectionSummaryList(output.environmentAccountConnections, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -6857,7 +6787,7 @@ const deserializeAws_json1_0ListEnvironmentsOutput = (output: any, context: __Se
       output.environments !== undefined && output.environments !== null
         ? deserializeAws_json1_0EnvironmentSummaryList(output.environments, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -6866,7 +6796,7 @@ const deserializeAws_json1_0ListEnvironmentTemplatesOutput = (
   context: __SerdeContext
 ): ListEnvironmentTemplatesOutput => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     templates:
       output.templates !== undefined && output.templates !== null
         ? deserializeAws_json1_0EnvironmentTemplateSummaryList(output.templates, context)
@@ -6879,7 +6809,7 @@ const deserializeAws_json1_0ListEnvironmentTemplateVersionsOutput = (
   context: __SerdeContext
 ): ListEnvironmentTemplateVersionsOutput => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     templateVersions:
       output.templateVersions !== undefined && output.templateVersions !== null
         ? deserializeAws_json1_0EnvironmentTemplateVersionSummaryList(output.templateVersions, context)
@@ -6892,7 +6822,7 @@ const deserializeAws_json1_0ListServiceInstancesOutput = (
   context: __SerdeContext
 ): ListServiceInstancesOutput => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     serviceInstances:
       output.serviceInstances !== undefined && output.serviceInstances !== null
         ? deserializeAws_json1_0ServiceInstanceSummaryList(output.serviceInstances, context)
@@ -6902,7 +6832,7 @@ const deserializeAws_json1_0ListServiceInstancesOutput = (
 
 const deserializeAws_json1_0ListServicesOutput = (output: any, context: __SerdeContext): ListServicesOutput => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     services:
       output.services !== undefined && output.services !== null
         ? deserializeAws_json1_0ServiceSummaryList(output.services, context)
@@ -6915,7 +6845,7 @@ const deserializeAws_json1_0ListServiceTemplatesOutput = (
   context: __SerdeContext
 ): ListServiceTemplatesOutput => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     templates:
       output.templates !== undefined && output.templates !== null
         ? deserializeAws_json1_0ServiceTemplateSummaryList(output.templates, context)
@@ -6928,7 +6858,7 @@ const deserializeAws_json1_0ListServiceTemplateVersionsOutput = (
   context: __SerdeContext
 ): ListServiceTemplateVersionsOutput => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     templateVersions:
       output.templateVersions !== undefined && output.templateVersions !== null
         ? deserializeAws_json1_0ServiceTemplateVersionSummaryList(output.templateVersions, context)
@@ -6941,7 +6871,7 @@ const deserializeAws_json1_0ListTagsForResourceOutput = (
   context: __SerdeContext
 ): ListTagsForResourceOutput => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_json1_0TagList(output.tags, context)
@@ -6966,56 +6896,47 @@ const deserializeAws_json1_0ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_0Service = (output: any, context: __SerdeContext): Service => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    branchName: output.branchName !== undefined && output.branchName !== null ? output.branchName : undefined,
+    arn: __expectString(output.arn),
+    branchName: __expectString(output.branchName),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    description: __expectString(output.description),
     lastModifiedAt:
       output.lastModifiedAt !== undefined && output.lastModifiedAt !== null
         ? new Date(Math.round(output.lastModifiedAt * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
     pipeline:
       output.pipeline !== undefined && output.pipeline !== null
         ? deserializeAws_json1_0ServicePipeline(output.pipeline, context)
         : undefined,
-    repositoryConnectionArn:
-      output.repositoryConnectionArn !== undefined && output.repositoryConnectionArn !== null
-        ? output.repositoryConnectionArn
-        : undefined,
-    repositoryId: output.repositoryId !== undefined && output.repositoryId !== null ? output.repositoryId : undefined,
-    spec: output.spec !== undefined && output.spec !== null ? output.spec : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    statusMessage:
-      output.statusMessage !== undefined && output.statusMessage !== null ? output.statusMessage : undefined,
-    templateName: output.templateName !== undefined && output.templateName !== null ? output.templateName : undefined,
+    repositoryConnectionArn: __expectString(output.repositoryConnectionArn),
+    repositoryId: __expectString(output.repositoryId),
+    spec: __expectString(output.spec),
+    status: __expectString(output.status),
+    statusMessage: __expectString(output.statusMessage),
+    templateName: __expectString(output.templateName),
   } as any;
 };
 
 const deserializeAws_json1_0ServiceInstance = (output: any, context: __SerdeContext): ServiceInstance => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    deploymentStatus:
-      output.deploymentStatus !== undefined && output.deploymentStatus !== null ? output.deploymentStatus : undefined,
-    deploymentStatusMessage:
-      output.deploymentStatusMessage !== undefined && output.deploymentStatusMessage !== null
-        ? output.deploymentStatusMessage
-        : undefined,
-    environmentName:
-      output.environmentName !== undefined && output.environmentName !== null ? output.environmentName : undefined,
+    deploymentStatus: __expectString(output.deploymentStatus),
+    deploymentStatusMessage: __expectString(output.deploymentStatusMessage),
+    environmentName: __expectString(output.environmentName),
     lastDeploymentAttemptedAt:
       output.lastDeploymentAttemptedAt !== undefined && output.lastDeploymentAttemptedAt !== null
         ? new Date(Math.round(output.lastDeploymentAttemptedAt * 1000))
@@ -7024,36 +6945,25 @@ const deserializeAws_json1_0ServiceInstance = (output: any, context: __SerdeCont
       output.lastDeploymentSucceededAt !== undefined && output.lastDeploymentSucceededAt !== null
         ? new Date(Math.round(output.lastDeploymentSucceededAt * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    serviceName: output.serviceName !== undefined && output.serviceName !== null ? output.serviceName : undefined,
-    spec: output.spec !== undefined && output.spec !== null ? output.spec : undefined,
-    templateMajorVersion:
-      output.templateMajorVersion !== undefined && output.templateMajorVersion !== null
-        ? output.templateMajorVersion
-        : undefined,
-    templateMinorVersion:
-      output.templateMinorVersion !== undefined && output.templateMinorVersion !== null
-        ? output.templateMinorVersion
-        : undefined,
-    templateName: output.templateName !== undefined && output.templateName !== null ? output.templateName : undefined,
+    name: __expectString(output.name),
+    serviceName: __expectString(output.serviceName),
+    spec: __expectString(output.spec),
+    templateMajorVersion: __expectString(output.templateMajorVersion),
+    templateMinorVersion: __expectString(output.templateMinorVersion),
+    templateName: __expectString(output.templateName),
   } as any;
 };
 
 const deserializeAws_json1_0ServiceInstanceSummary = (output: any, context: __SerdeContext): ServiceInstanceSummary => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    deploymentStatus:
-      output.deploymentStatus !== undefined && output.deploymentStatus !== null ? output.deploymentStatus : undefined,
-    deploymentStatusMessage:
-      output.deploymentStatusMessage !== undefined && output.deploymentStatusMessage !== null
-        ? output.deploymentStatusMessage
-        : undefined,
-    environmentName:
-      output.environmentName !== undefined && output.environmentName !== null ? output.environmentName : undefined,
+    deploymentStatus: __expectString(output.deploymentStatus),
+    deploymentStatusMessage: __expectString(output.deploymentStatusMessage),
+    environmentName: __expectString(output.environmentName),
     lastDeploymentAttemptedAt:
       output.lastDeploymentAttemptedAt !== undefined && output.lastDeploymentAttemptedAt !== null
         ? new Date(Math.round(output.lastDeploymentAttemptedAt * 1000))
@@ -7062,17 +6972,11 @@ const deserializeAws_json1_0ServiceInstanceSummary = (output: any, context: __Se
       output.lastDeploymentSucceededAt !== undefined && output.lastDeploymentSucceededAt !== null
         ? new Date(Math.round(output.lastDeploymentSucceededAt * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    serviceName: output.serviceName !== undefined && output.serviceName !== null ? output.serviceName : undefined,
-    templateMajorVersion:
-      output.templateMajorVersion !== undefined && output.templateMajorVersion !== null
-        ? output.templateMajorVersion
-        : undefined,
-    templateMinorVersion:
-      output.templateMinorVersion !== undefined && output.templateMinorVersion !== null
-        ? output.templateMinorVersion
-        : undefined,
-    templateName: output.templateName !== undefined && output.templateName !== null ? output.templateName : undefined,
+    name: __expectString(output.name),
+    serviceName: __expectString(output.serviceName),
+    templateMajorVersion: __expectString(output.templateMajorVersion),
+    templateMinorVersion: __expectString(output.templateMinorVersion),
+    templateName: __expectString(output.templateName),
   } as any;
 };
 
@@ -7092,17 +6996,13 @@ const deserializeAws_json1_0ServiceInstanceSummaryList = (
 
 const deserializeAws_json1_0ServicePipeline = (output: any, context: __SerdeContext): ServicePipeline => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    deploymentStatus:
-      output.deploymentStatus !== undefined && output.deploymentStatus !== null ? output.deploymentStatus : undefined,
-    deploymentStatusMessage:
-      output.deploymentStatusMessage !== undefined && output.deploymentStatusMessage !== null
-        ? output.deploymentStatusMessage
-        : undefined,
+    deploymentStatus: __expectString(output.deploymentStatus),
+    deploymentStatusMessage: __expectString(output.deploymentStatusMessage),
     lastDeploymentAttemptedAt:
       output.lastDeploymentAttemptedAt !== undefined && output.lastDeploymentAttemptedAt !== null
         ? new Date(Math.round(output.lastDeploymentAttemptedAt * 1000))
@@ -7111,16 +7011,10 @@ const deserializeAws_json1_0ServicePipeline = (output: any, context: __SerdeCont
       output.lastDeploymentSucceededAt !== undefined && output.lastDeploymentSucceededAt !== null
         ? new Date(Math.round(output.lastDeploymentSucceededAt * 1000))
         : undefined,
-    spec: output.spec !== undefined && output.spec !== null ? output.spec : undefined,
-    templateMajorVersion:
-      output.templateMajorVersion !== undefined && output.templateMajorVersion !== null
-        ? output.templateMajorVersion
-        : undefined,
-    templateMinorVersion:
-      output.templateMinorVersion !== undefined && output.templateMinorVersion !== null
-        ? output.templateMinorVersion
-        : undefined,
-    templateName: output.templateName !== undefined && output.templateName !== null ? output.templateName : undefined,
+    spec: __expectString(output.spec),
+    templateMajorVersion: __expectString(output.templateMajorVersion),
+    templateMinorVersion: __expectString(output.templateMinorVersion),
+    templateName: __expectString(output.templateName),
   } as any;
 };
 
@@ -7129,27 +7023,26 @@ const deserializeAws_json1_0ServiceQuotaExceededException = (
   context: __SerdeContext
 ): ServiceQuotaExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_0ServiceSummary = (output: any, context: __SerdeContext): ServiceSummary => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    description: __expectString(output.description),
     lastModifiedAt:
       output.lastModifiedAt !== undefined && output.lastModifiedAt !== null
         ? new Date(Math.round(output.lastModifiedAt * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    statusMessage:
-      output.statusMessage !== undefined && output.statusMessage !== null ? output.statusMessage : undefined,
-    templateName: output.templateName !== undefined && output.templateName !== null ? output.templateName : undefined,
+    name: __expectString(output.name),
+    status: __expectString(output.status),
+    statusMessage: __expectString(output.statusMessage),
+    templateName: __expectString(output.templateName),
   } as any;
 };
 
@@ -7166,53 +7059,40 @@ const deserializeAws_json1_0ServiceSummaryList = (output: any, context: __SerdeC
 
 const deserializeAws_json1_0ServiceTemplate = (output: any, context: __SerdeContext): ServiceTemplate => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    displayName: output.displayName !== undefined && output.displayName !== null ? output.displayName : undefined,
-    encryptionKey:
-      output.encryptionKey !== undefined && output.encryptionKey !== null ? output.encryptionKey : undefined,
+    description: __expectString(output.description),
+    displayName: __expectString(output.displayName),
+    encryptionKey: __expectString(output.encryptionKey),
     lastModifiedAt:
       output.lastModifiedAt !== undefined && output.lastModifiedAt !== null
         ? new Date(Math.round(output.lastModifiedAt * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    pipelineProvisioning:
-      output.pipelineProvisioning !== undefined && output.pipelineProvisioning !== null
-        ? output.pipelineProvisioning
-        : undefined,
-    recommendedVersion:
-      output.recommendedVersion !== undefined && output.recommendedVersion !== null
-        ? output.recommendedVersion
-        : undefined,
+    name: __expectString(output.name),
+    pipelineProvisioning: __expectString(output.pipelineProvisioning),
+    recommendedVersion: __expectString(output.recommendedVersion),
   } as any;
 };
 
 const deserializeAws_json1_0ServiceTemplateSummary = (output: any, context: __SerdeContext): ServiceTemplateSummary => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    displayName: output.displayName !== undefined && output.displayName !== null ? output.displayName : undefined,
+    description: __expectString(output.description),
+    displayName: __expectString(output.displayName),
     lastModifiedAt:
       output.lastModifiedAt !== undefined && output.lastModifiedAt !== null
         ? new Date(Math.round(output.lastModifiedAt * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    pipelineProvisioning:
-      output.pipelineProvisioning !== undefined && output.pipelineProvisioning !== null
-        ? output.pipelineProvisioning
-        : undefined,
-    recommendedVersion:
-      output.recommendedVersion !== undefined && output.recommendedVersion !== null
-        ? output.recommendedVersion
-        : undefined,
+    name: __expectString(output.name),
+    pipelineProvisioning: __expectString(output.pipelineProvisioning),
+    recommendedVersion: __expectString(output.recommendedVersion),
   } as any;
 };
 
@@ -7232,7 +7112,7 @@ const deserializeAws_json1_0ServiceTemplateSummaryList = (
 
 const deserializeAws_json1_0ServiceTemplateVersion = (output: any, context: __SerdeContext): ServiceTemplateVersion => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     compatibleEnvironmentTemplates:
       output.compatibleEnvironmentTemplates !== undefined && output.compatibleEnvironmentTemplates !== null
         ? deserializeAws_json1_0CompatibleEnvironmentTemplateList(output.compatibleEnvironmentTemplates, context)
@@ -7241,22 +7121,18 @@ const deserializeAws_json1_0ServiceTemplateVersion = (output: any, context: __Se
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    description: __expectString(output.description),
     lastModifiedAt:
       output.lastModifiedAt !== undefined && output.lastModifiedAt !== null
         ? new Date(Math.round(output.lastModifiedAt * 1000))
         : undefined,
-    majorVersion: output.majorVersion !== undefined && output.majorVersion !== null ? output.majorVersion : undefined,
-    minorVersion: output.minorVersion !== undefined && output.minorVersion !== null ? output.minorVersion : undefined,
-    recommendedMinorVersion:
-      output.recommendedMinorVersion !== undefined && output.recommendedMinorVersion !== null
-        ? output.recommendedMinorVersion
-        : undefined,
-    schema: output.schema !== undefined && output.schema !== null ? output.schema : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    statusMessage:
-      output.statusMessage !== undefined && output.statusMessage !== null ? output.statusMessage : undefined,
-    templateName: output.templateName !== undefined && output.templateName !== null ? output.templateName : undefined,
+    majorVersion: __expectString(output.majorVersion),
+    minorVersion: __expectString(output.minorVersion),
+    recommendedMinorVersion: __expectString(output.recommendedMinorVersion),
+    schema: __expectString(output.schema),
+    status: __expectString(output.status),
+    statusMessage: __expectString(output.statusMessage),
+    templateName: __expectString(output.templateName),
   } as any;
 };
 
@@ -7265,26 +7141,22 @@ const deserializeAws_json1_0ServiceTemplateVersionSummary = (
   context: __SerdeContext
 ): ServiceTemplateVersionSummary => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    description: __expectString(output.description),
     lastModifiedAt:
       output.lastModifiedAt !== undefined && output.lastModifiedAt !== null
         ? new Date(Math.round(output.lastModifiedAt * 1000))
         : undefined,
-    majorVersion: output.majorVersion !== undefined && output.majorVersion !== null ? output.majorVersion : undefined,
-    minorVersion: output.minorVersion !== undefined && output.minorVersion !== null ? output.minorVersion : undefined,
-    recommendedMinorVersion:
-      output.recommendedMinorVersion !== undefined && output.recommendedMinorVersion !== null
-        ? output.recommendedMinorVersion
-        : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    statusMessage:
-      output.statusMessage !== undefined && output.statusMessage !== null ? output.statusMessage : undefined,
-    templateName: output.templateName !== undefined && output.templateName !== null ? output.templateName : undefined,
+    majorVersion: __expectString(output.majorVersion),
+    minorVersion: __expectString(output.minorVersion),
+    recommendedMinorVersion: __expectString(output.recommendedMinorVersion),
+    status: __expectString(output.status),
+    statusMessage: __expectString(output.statusMessage),
+    templateName: __expectString(output.templateName),
   } as any;
 };
 
@@ -7304,8 +7176,8 @@ const deserializeAws_json1_0ServiceTemplateVersionSummaryList = (
 
 const deserializeAws_json1_0Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    key: __expectString(output.key),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -7326,7 +7198,7 @@ const deserializeAws_json1_0TagResourceOutput = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_0ThrottlingException = (output: any, context: __SerdeContext): ThrottlingException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -7453,7 +7325,7 @@ const deserializeAws_json1_0UpdateServiceTemplateVersionOutput = (
 
 const deserializeAws_json1_0ValidationException = (output: any, context: __SerdeContext): ValidationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 

--- a/clients/client-qldb-session/protocols/Aws_json1_0.ts
+++ b/clients/client-qldb-session/protocols/Aws_json1_0.ts
@@ -28,7 +28,11 @@ import {
   ValueHolder,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -339,8 +343,8 @@ const deserializeAws_json1_0AbortTransactionResult = (output: any, context: __Se
 
 const deserializeAws_json1_0BadRequestException = (output: any, context: __SerdeContext): BadRequestException => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -349,7 +353,7 @@ const deserializeAws_json1_0CapacityExceededException = (
   context: __SerdeContext
 ): CapacityExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -370,8 +374,7 @@ const deserializeAws_json1_0CommitTransactionResult = (
       output.TimingInformation !== undefined && output.TimingInformation !== null
         ? deserializeAws_json1_0TimingInformation(output.TimingInformation, context)
         : undefined,
-    TransactionId:
-      output.TransactionId !== undefined && output.TransactionId !== null ? output.TransactionId : undefined,
+    TransactionId: __expectString(output.TransactionId),
   } as any;
 };
 
@@ -421,34 +424,33 @@ const deserializeAws_json1_0InvalidSessionException = (
   context: __SerdeContext
 ): InvalidSessionException => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_0IOUsage = (output: any, context: __SerdeContext): IOUsage => {
   return {
-    ReadIOs: output.ReadIOs !== undefined && output.ReadIOs !== null ? output.ReadIOs : undefined,
-    WriteIOs: output.WriteIOs !== undefined && output.WriteIOs !== null ? output.WriteIOs : undefined,
+    ReadIOs: __expectNumber(output.ReadIOs),
+    WriteIOs: __expectNumber(output.WriteIOs),
   } as any;
 };
 
 const deserializeAws_json1_0LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_0OccConflictException = (output: any, context: __SerdeContext): OccConflictException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_0Page = (output: any, context: __SerdeContext): Page => {
   return {
-    NextPageToken:
-      output.NextPageToken !== undefined && output.NextPageToken !== null ? output.NextPageToken : undefined,
+    NextPageToken: __expectString(output.NextPageToken),
     Values:
       output.Values !== undefined && output.Values !== null
         ? deserializeAws_json1_0ValueHolders(output.Values, context)
@@ -458,7 +460,7 @@ const deserializeAws_json1_0Page = (output: any, context: __SerdeContext): Page 
 
 const deserializeAws_json1_0RateExceededException = (output: any, context: __SerdeContext): RateExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -497,7 +499,7 @@ const deserializeAws_json1_0SendCommandResult = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_0StartSessionResult = (output: any, context: __SerdeContext): StartSessionResult => {
   return {
-    SessionToken: output.SessionToken !== undefined && output.SessionToken !== null ? output.SessionToken : undefined,
+    SessionToken: __expectString(output.SessionToken),
     TimingInformation:
       output.TimingInformation !== undefined && output.TimingInformation !== null
         ? deserializeAws_json1_0TimingInformation(output.TimingInformation, context)
@@ -511,17 +513,13 @@ const deserializeAws_json1_0StartTransactionResult = (output: any, context: __Se
       output.TimingInformation !== undefined && output.TimingInformation !== null
         ? deserializeAws_json1_0TimingInformation(output.TimingInformation, context)
         : undefined,
-    TransactionId:
-      output.TransactionId !== undefined && output.TransactionId !== null ? output.TransactionId : undefined,
+    TransactionId: __expectString(output.TransactionId),
   } as any;
 };
 
 const deserializeAws_json1_0TimingInformation = (output: any, context: __SerdeContext): TimingInformation => {
   return {
-    ProcessingTimeMilliseconds:
-      output.ProcessingTimeMilliseconds !== undefined && output.ProcessingTimeMilliseconds !== null
-        ? output.ProcessingTimeMilliseconds
-        : undefined,
+    ProcessingTimeMilliseconds: __expectNumber(output.ProcessingTimeMilliseconds),
   } as any;
 };
 
@@ -529,7 +527,7 @@ const deserializeAws_json1_0ValueHolder = (output: any, context: __SerdeContext)
   return {
     IonBinary:
       output.IonBinary !== undefined && output.IonBinary !== null ? context.base64Decoder(output.IonBinary) : undefined,
-    IonText: output.IonText !== undefined && output.IonText !== null ? output.IonText : undefined,
+    IonText: __expectString(output.IonText),
   } as any;
 };
 

--- a/clients/client-qldb/protocols/Aws_restJson1.ts
+++ b/clients/client-qldb/protocols/Aws_restJson1.ts
@@ -63,6 +63,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -749,7 +751,7 @@ export const deserializeAws_restJson1CancelJournalKinesisStreamCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.StreamId !== undefined && data.StreamId !== null) {
-    contents.StreamId = data.StreamId;
+    contents.StreamId = __expectString(data.StreamId);
   }
   return Promise.resolve(contents);
 };
@@ -825,22 +827,22 @@ export const deserializeAws_restJson1CreateLedgerCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationDateTime !== undefined && data.CreationDateTime !== null) {
     contents.CreationDateTime = new Date(Math.round(data.CreationDateTime * 1000));
   }
   if (data.DeletionProtection !== undefined && data.DeletionProtection !== null) {
-    contents.DeletionProtection = data.DeletionProtection;
+    contents.DeletionProtection = __expectBoolean(data.DeletionProtection);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.PermissionsMode !== undefined && data.PermissionsMode !== null) {
-    contents.PermissionsMode = data.PermissionsMode;
+    contents.PermissionsMode = __expectString(data.PermissionsMode);
   }
   if (data.State !== undefined && data.State !== null) {
-    contents.State = data.State;
+    contents.State = __expectString(data.State);
   }
   return Promise.resolve(contents);
 };
@@ -1125,22 +1127,22 @@ export const deserializeAws_restJson1DescribeLedgerCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationDateTime !== undefined && data.CreationDateTime !== null) {
     contents.CreationDateTime = new Date(Math.round(data.CreationDateTime * 1000));
   }
   if (data.DeletionProtection !== undefined && data.DeletionProtection !== null) {
-    contents.DeletionProtection = data.DeletionProtection;
+    contents.DeletionProtection = __expectBoolean(data.DeletionProtection);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.PermissionsMode !== undefined && data.PermissionsMode !== null) {
-    contents.PermissionsMode = data.PermissionsMode;
+    contents.PermissionsMode = __expectString(data.PermissionsMode);
   }
   if (data.State !== undefined && data.State !== null) {
-    contents.State = data.State;
+    contents.State = __expectString(data.State);
   }
   return Promise.resolve(contents);
 };
@@ -1203,7 +1205,7 @@ export const deserializeAws_restJson1ExportJournalToS3Command = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ExportId !== undefined && data.ExportId !== null) {
-    contents.ExportId = data.ExportId;
+    contents.ExportId = __expectString(data.ExportId);
   }
   return Promise.resolve(contents);
 };
@@ -1492,7 +1494,7 @@ export const deserializeAws_restJson1ListJournalKinesisStreamsForLedgerCommand =
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Streams !== undefined && data.Streams !== null) {
     contents.Streams = deserializeAws_restJson1JournalKinesisStreamDescriptionList(data.Streams, context);
@@ -1570,7 +1572,7 @@ export const deserializeAws_restJson1ListJournalS3ExportsCommand = async (
     contents.JournalS3Exports = deserializeAws_restJson1JournalS3ExportList(data.JournalS3Exports, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1621,7 +1623,7 @@ export const deserializeAws_restJson1ListJournalS3ExportsForLedgerCommand = asyn
     contents.JournalS3Exports = deserializeAws_restJson1JournalS3ExportList(data.JournalS3Exports, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1672,7 +1674,7 @@ export const deserializeAws_restJson1ListLedgersCommand = async (
     contents.Ledgers = deserializeAws_restJson1LedgerList(data.Ledgers, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1782,7 +1784,7 @@ export const deserializeAws_restJson1StreamJournalToKinesisCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.StreamId !== undefined && data.StreamId !== null) {
-    contents.StreamId = data.StreamId;
+    contents.StreamId = __expectString(data.StreamId);
   }
   return Promise.resolve(contents);
 };
@@ -1975,19 +1977,19 @@ export const deserializeAws_restJson1UpdateLedgerCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationDateTime !== undefined && data.CreationDateTime !== null) {
     contents.CreationDateTime = new Date(Math.round(data.CreationDateTime * 1000));
   }
   if (data.DeletionProtection !== undefined && data.DeletionProtection !== null) {
-    contents.DeletionProtection = data.DeletionProtection;
+    contents.DeletionProtection = __expectBoolean(data.DeletionProtection);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.State !== undefined && data.State !== null) {
-    contents.State = data.State;
+    contents.State = __expectString(data.State);
   }
   return Promise.resolve(contents);
 };
@@ -2052,13 +2054,13 @@ export const deserializeAws_restJson1UpdateLedgerPermissionsModeCommand = async 
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.PermissionsMode !== undefined && data.PermissionsMode !== null) {
-    contents.PermissionsMode = data.PermissionsMode;
+    contents.PermissionsMode = __expectString(data.PermissionsMode);
   }
   return Promise.resolve(contents);
 };
@@ -2121,10 +2123,10 @@ const deserializeAws_restJson1InvalidParameterExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.ParameterName !== undefined && data.ParameterName !== null) {
-    contents.ParameterName = data.ParameterName;
+    contents.ParameterName = __expectString(data.ParameterName);
   }
   return contents;
 };
@@ -2142,10 +2144,10 @@ const deserializeAws_restJson1LimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.ResourceType !== undefined && data.ResourceType !== null) {
-    contents.ResourceType = data.ResourceType;
+    contents.ResourceType = __expectString(data.ResourceType);
   }
   return contents;
 };
@@ -2164,13 +2166,13 @@ const deserializeAws_restJson1ResourceAlreadyExistsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.ResourceName !== undefined && data.ResourceName !== null) {
-    contents.ResourceName = data.ResourceName;
+    contents.ResourceName = __expectString(data.ResourceName);
   }
   if (data.ResourceType !== undefined && data.ResourceType !== null) {
-    contents.ResourceType = data.ResourceType;
+    contents.ResourceType = __expectString(data.ResourceType);
   }
   return contents;
 };
@@ -2189,13 +2191,13 @@ const deserializeAws_restJson1ResourceInUseExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.ResourceName !== undefined && data.ResourceName !== null) {
-    contents.ResourceName = data.ResourceName;
+    contents.ResourceName = __expectString(data.ResourceName);
   }
   if (data.ResourceType !== undefined && data.ResourceType !== null) {
-    contents.ResourceType = data.ResourceType;
+    contents.ResourceType = __expectString(data.ResourceType);
   }
   return contents;
 };
@@ -2214,13 +2216,13 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.ResourceName !== undefined && data.ResourceName !== null) {
-    contents.ResourceName = data.ResourceName;
+    contents.ResourceName = __expectString(data.ResourceName);
   }
   if (data.ResourceType !== undefined && data.ResourceType !== null) {
-    contents.ResourceType = data.ResourceType;
+    contents.ResourceType = __expectString(data.ResourceType);
   }
   return contents;
 };
@@ -2239,13 +2241,13 @@ const deserializeAws_restJson1ResourcePreconditionNotMetExceptionResponse = asyn
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.ResourceName !== undefined && data.ResourceName !== null) {
-    contents.ResourceName = data.ResourceName;
+    contents.ResourceName = __expectString(data.ResourceName);
   }
   if (data.ResourceType !== undefined && data.ResourceType !== null) {
-    contents.ResourceType = data.ResourceType;
+    contents.ResourceType = __expectString(data.ResourceType);
   }
   return contents;
 };
@@ -2306,12 +2308,12 @@ const deserializeAws_restJson1JournalKinesisStreamDescription = (
   context: __SerdeContext
 ): JournalKinesisStreamDescription => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    ErrorCause: output.ErrorCause !== undefined && output.ErrorCause !== null ? output.ErrorCause : undefined,
+    ErrorCause: __expectString(output.ErrorCause),
     ExclusiveEndTime:
       output.ExclusiveEndTime !== undefined && output.ExclusiveEndTime !== null
         ? new Date(Math.round(output.ExclusiveEndTime * 1000))
@@ -2324,11 +2326,11 @@ const deserializeAws_restJson1JournalKinesisStreamDescription = (
       output.KinesisConfiguration !== undefined && output.KinesisConfiguration !== null
         ? deserializeAws_restJson1KinesisConfiguration(output.KinesisConfiguration, context)
         : undefined,
-    LedgerName: output.LedgerName !== undefined && output.LedgerName !== null ? output.LedgerName : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StreamId: output.StreamId !== undefined && output.StreamId !== null ? output.StreamId : undefined,
-    StreamName: output.StreamName !== undefined && output.StreamName !== null ? output.StreamName : undefined,
+    LedgerName: __expectString(output.LedgerName),
+    RoleArn: __expectString(output.RoleArn),
+    Status: __expectString(output.Status),
+    StreamId: __expectString(output.StreamId),
+    StreamName: __expectString(output.StreamName),
   } as any;
 };
 
@@ -2359,18 +2361,18 @@ const deserializeAws_restJson1JournalS3ExportDescription = (
       output.ExportCreationTime !== undefined && output.ExportCreationTime !== null
         ? new Date(Math.round(output.ExportCreationTime * 1000))
         : undefined,
-    ExportId: output.ExportId !== undefined && output.ExportId !== null ? output.ExportId : undefined,
+    ExportId: __expectString(output.ExportId),
     InclusiveStartTime:
       output.InclusiveStartTime !== undefined && output.InclusiveStartTime !== null
         ? new Date(Math.round(output.InclusiveStartTime * 1000))
         : undefined,
-    LedgerName: output.LedgerName !== undefined && output.LedgerName !== null ? output.LedgerName : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
+    LedgerName: __expectString(output.LedgerName),
+    RoleArn: __expectString(output.RoleArn),
     S3ExportConfiguration:
       output.S3ExportConfiguration !== undefined && output.S3ExportConfiguration !== null
         ? deserializeAws_restJson1S3ExportConfiguration(output.S3ExportConfiguration, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -2390,11 +2392,8 @@ const deserializeAws_restJson1JournalS3ExportList = (
 
 const deserializeAws_restJson1KinesisConfiguration = (output: any, context: __SerdeContext): KinesisConfiguration => {
   return {
-    AggregationEnabled:
-      output.AggregationEnabled !== undefined && output.AggregationEnabled !== null
-        ? output.AggregationEnabled
-        : undefined,
-    StreamArn: output.StreamArn !== undefined && output.StreamArn !== null ? output.StreamArn : undefined,
+    AggregationEnabled: __expectBoolean(output.AggregationEnabled),
+    StreamArn: __expectString(output.StreamArn),
   } as any;
 };
 
@@ -2415,8 +2414,8 @@ const deserializeAws_restJson1LedgerSummary = (output: any, context: __SerdeCont
       output.CreationDateTime !== undefined && output.CreationDateTime !== null
         ? new Date(Math.round(output.CreationDateTime * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    Name: __expectString(output.Name),
+    State: __expectString(output.State),
   } as any;
 };
 
@@ -2425,22 +2424,19 @@ const deserializeAws_restJson1S3EncryptionConfiguration = (
   context: __SerdeContext
 ): S3EncryptionConfiguration => {
   return {
-    KmsKeyArn: output.KmsKeyArn !== undefined && output.KmsKeyArn !== null ? output.KmsKeyArn : undefined,
-    ObjectEncryptionType:
-      output.ObjectEncryptionType !== undefined && output.ObjectEncryptionType !== null
-        ? output.ObjectEncryptionType
-        : undefined,
+    KmsKeyArn: __expectString(output.KmsKeyArn),
+    ObjectEncryptionType: __expectString(output.ObjectEncryptionType),
   } as any;
 };
 
 const deserializeAws_restJson1S3ExportConfiguration = (output: any, context: __SerdeContext): S3ExportConfiguration => {
   return {
-    Bucket: output.Bucket !== undefined && output.Bucket !== null ? output.Bucket : undefined,
+    Bucket: __expectString(output.Bucket),
     EncryptionConfiguration:
       output.EncryptionConfiguration !== undefined && output.EncryptionConfiguration !== null
         ? deserializeAws_restJson1S3EncryptionConfiguration(output.EncryptionConfiguration, context)
         : undefined,
-    Prefix: output.Prefix !== undefined && output.Prefix !== null ? output.Prefix : undefined,
+    Prefix: __expectString(output.Prefix),
   } as any;
 };
 
@@ -2451,14 +2447,14 @@ const deserializeAws_restJson1Tags = (output: any, context: __SerdeContext): { [
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1ValueHolder = (output: any, context: __SerdeContext): ValueHolder => {
   return {
-    IonText: output.IonText !== undefined && output.IonText !== null ? output.IonText : undefined,
+    IonText: __expectString(output.IonText),
   } as any;
 };
 

--- a/clients/client-quicksight/protocols/Aws_restJson1.ts
+++ b/clients/client-quicksight/protocols/Aws_restJson1.ts
@@ -357,6 +357,9 @@ import { TemplateSummary, TemplateVersionSummary, ThemeSummary, ThemeVersionSumm
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -4772,13 +4775,13 @@ export const deserializeAws_restJson1CancelIngestionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.IngestionId !== undefined && data.IngestionId !== null) {
-    contents.IngestionId = data.IngestionId;
+    contents.IngestionId = __expectString(data.IngestionId);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -4884,16 +4887,16 @@ export const deserializeAws_restJson1CreateAccountCustomizationCommand = async (
     contents.AccountCustomization = deserializeAws_restJson1AccountCustomization(data.AccountCustomization, context);
   }
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.AwsAccountId !== undefined && data.AwsAccountId !== null) {
-    contents.AwsAccountId = data.AwsAccountId;
+    contents.AwsAccountId = __expectString(data.AwsAccountId);
   }
   if (data.Namespace !== undefined && data.Namespace !== null) {
-    contents.Namespace = data.Namespace;
+    contents.Namespace = __expectString(data.Namespace);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -5003,16 +5006,16 @@ export const deserializeAws_restJson1CreateAnalysisCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AnalysisId !== undefined && data.AnalysisId !== null) {
-    contents.AnalysisId = data.AnalysisId;
+    contents.AnalysisId = __expectString(data.AnalysisId);
   }
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationStatus !== undefined && data.CreationStatus !== null) {
-    contents.CreationStatus = data.CreationStatus;
+    contents.CreationStatus = __expectString(data.CreationStatus);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -5123,19 +5126,19 @@ export const deserializeAws_restJson1CreateDashboardCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationStatus !== undefined && data.CreationStatus !== null) {
-    contents.CreationStatus = data.CreationStatus;
+    contents.CreationStatus = __expectString(data.CreationStatus);
   }
   if (data.DashboardId !== undefined && data.DashboardId !== null) {
-    contents.DashboardId = data.DashboardId;
+    contents.DashboardId = __expectString(data.DashboardId);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (data.VersionArn !== undefined && data.VersionArn !== null) {
-    contents.VersionArn = data.VersionArn;
+    contents.VersionArn = __expectString(data.VersionArn);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -5246,19 +5249,19 @@ export const deserializeAws_restJson1CreateDataSetCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.DataSetId !== undefined && data.DataSetId !== null) {
-    contents.DataSetId = data.DataSetId;
+    contents.DataSetId = __expectString(data.DataSetId);
   }
   if (data.IngestionArn !== undefined && data.IngestionArn !== null) {
-    contents.IngestionArn = data.IngestionArn;
+    contents.IngestionArn = __expectString(data.IngestionArn);
   }
   if (data.IngestionId !== undefined && data.IngestionId !== null) {
-    contents.IngestionId = data.IngestionId;
+    contents.IngestionId = __expectString(data.IngestionId);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -5384,16 +5387,16 @@ export const deserializeAws_restJson1CreateDataSourceCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationStatus !== undefined && data.CreationStatus !== null) {
-    contents.CreationStatus = data.CreationStatus;
+    contents.CreationStatus = __expectString(data.CreationStatus);
   }
   if (data.DataSourceId !== undefined && data.DataSourceId !== null) {
-    contents.DataSourceId = data.DataSourceId;
+    contents.DataSourceId = __expectString(data.DataSourceId);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -5512,7 +5515,7 @@ export const deserializeAws_restJson1CreateGroupCommand = async (
     contents.Group = deserializeAws_restJson1Group(data.Group, context);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -5639,7 +5642,7 @@ export const deserializeAws_restJson1CreateGroupMembershipCommand = async (
     contents.GroupMember = deserializeAws_restJson1GroupMember(data.GroupMember, context);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -5751,22 +5754,22 @@ export const deserializeAws_restJson1CreateIAMPolicyAssignmentCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AssignmentId !== undefined && data.AssignmentId !== null) {
-    contents.AssignmentId = data.AssignmentId;
+    contents.AssignmentId = __expectString(data.AssignmentId);
   }
   if (data.AssignmentName !== undefined && data.AssignmentName !== null) {
-    contents.AssignmentName = data.AssignmentName;
+    contents.AssignmentName = __expectString(data.AssignmentName);
   }
   if (data.AssignmentStatus !== undefined && data.AssignmentStatus !== null) {
-    contents.AssignmentStatus = data.AssignmentStatus;
+    contents.AssignmentStatus = __expectString(data.AssignmentStatus);
   }
   if (data.Identities !== undefined && data.Identities !== null) {
     contents.Identities = deserializeAws_restJson1IdentityMap(data.Identities, context);
   }
   if (data.PolicyArn !== undefined && data.PolicyArn !== null) {
-    contents.PolicyArn = data.PolicyArn;
+    contents.PolicyArn = __expectString(data.PolicyArn);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -5876,16 +5879,16 @@ export const deserializeAws_restJson1CreateIngestionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.IngestionId !== undefined && data.IngestionId !== null) {
-    contents.IngestionId = data.IngestionId;
+    contents.IngestionId = __expectString(data.IngestionId);
   }
   if (data.IngestionStatus !== undefined && data.IngestionStatus !== null) {
-    contents.IngestionStatus = data.IngestionStatus;
+    contents.IngestionStatus = __expectString(data.IngestionStatus);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -5997,22 +6000,22 @@ export const deserializeAws_restJson1CreateNamespaceCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CapacityRegion !== undefined && data.CapacityRegion !== null) {
-    contents.CapacityRegion = data.CapacityRegion;
+    contents.CapacityRegion = __expectString(data.CapacityRegion);
   }
   if (data.CreationStatus !== undefined && data.CreationStatus !== null) {
-    contents.CreationStatus = data.CreationStatus;
+    contents.CreationStatus = __expectString(data.CreationStatus);
   }
   if (data.IdentityStore !== undefined && data.IdentityStore !== null) {
-    contents.IdentityStore = data.IdentityStore;
+    contents.IdentityStore = __expectString(data.IdentityStore);
   }
   if (data.Name !== undefined && data.Name !== null) {
-    contents.Name = data.Name;
+    contents.Name = __expectString(data.Name);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -6147,19 +6150,19 @@ export const deserializeAws_restJson1CreateTemplateCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationStatus !== undefined && data.CreationStatus !== null) {
-    contents.CreationStatus = data.CreationStatus;
+    contents.CreationStatus = __expectString(data.CreationStatus);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (data.TemplateId !== undefined && data.TemplateId !== null) {
-    contents.TemplateId = data.TemplateId;
+    contents.TemplateId = __expectString(data.TemplateId);
   }
   if (data.VersionArn !== undefined && data.VersionArn !== null) {
-    contents.VersionArn = data.VersionArn;
+    contents.VersionArn = __expectString(data.VersionArn);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -6283,7 +6286,7 @@ export const deserializeAws_restJson1CreateTemplateAliasCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (data.TemplateAlias !== undefined && data.TemplateAlias !== null) {
     contents.TemplateAlias = deserializeAws_restJson1TemplateAlias(data.TemplateAlias, context);
@@ -6397,19 +6400,19 @@ export const deserializeAws_restJson1CreateThemeCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationStatus !== undefined && data.CreationStatus !== null) {
-    contents.CreationStatus = data.CreationStatus;
+    contents.CreationStatus = __expectString(data.CreationStatus);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (data.ThemeId !== undefined && data.ThemeId !== null) {
-    contents.ThemeId = data.ThemeId;
+    contents.ThemeId = __expectString(data.ThemeId);
   }
   if (data.VersionArn !== undefined && data.VersionArn !== null) {
-    contents.VersionArn = data.VersionArn;
+    contents.VersionArn = __expectString(data.VersionArn);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -6525,7 +6528,7 @@ export const deserializeAws_restJson1CreateThemeAliasCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (data.ThemeAlias !== undefined && data.ThemeAlias !== null) {
     contents.ThemeAlias = deserializeAws_restJson1ThemeAlias(data.ThemeAlias, context);
@@ -6643,7 +6646,7 @@ export const deserializeAws_restJson1DeleteAccountCustomizationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -6745,16 +6748,16 @@ export const deserializeAws_restJson1DeleteAnalysisCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AnalysisId !== undefined && data.AnalysisId !== null) {
-    contents.AnalysisId = data.AnalysisId;
+    contents.AnalysisId = __expectString(data.AnalysisId);
   }
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.DeletionTime !== undefined && data.DeletionTime !== null) {
     contents.DeletionTime = new Date(Math.round(data.DeletionTime * 1000));
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -6855,13 +6858,13 @@ export const deserializeAws_restJson1DeleteDashboardCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.DashboardId !== undefined && data.DashboardId !== null) {
-    contents.DashboardId = data.DashboardId;
+    contents.DashboardId = __expectString(data.DashboardId);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -6962,13 +6965,13 @@ export const deserializeAws_restJson1DeleteDataSetCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.DataSetId !== undefined && data.DataSetId !== null) {
-    contents.DataSetId = data.DataSetId;
+    contents.DataSetId = __expectString(data.DataSetId);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -7061,13 +7064,13 @@ export const deserializeAws_restJson1DeleteDataSourceCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.DataSourceId !== undefined && data.DataSourceId !== null) {
-    contents.DataSourceId = data.DataSourceId;
+    contents.DataSourceId = __expectString(data.DataSourceId);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -7158,7 +7161,7 @@ export const deserializeAws_restJson1DeleteGroupCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -7265,7 +7268,7 @@ export const deserializeAws_restJson1DeleteGroupMembershipCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -7373,10 +7376,10 @@ export const deserializeAws_restJson1DeleteIAMPolicyAssignmentCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AssignmentName !== undefined && data.AssignmentName !== null) {
-    contents.AssignmentName = data.AssignmentName;
+    contents.AssignmentName = __expectString(data.AssignmentName);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -7483,7 +7486,7 @@ export const deserializeAws_restJson1DeleteNamespaceCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -7592,13 +7595,13 @@ export const deserializeAws_restJson1DeleteTemplateCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (data.TemplateId !== undefined && data.TemplateId !== null) {
-    contents.TemplateId = data.TemplateId;
+    contents.TemplateId = __expectString(data.TemplateId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -7708,16 +7711,16 @@ export const deserializeAws_restJson1DeleteTemplateAliasCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AliasName !== undefined && data.AliasName !== null) {
-    contents.AliasName = data.AliasName;
+    contents.AliasName = __expectString(data.AliasName);
   }
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (data.TemplateId !== undefined && data.TemplateId !== null) {
-    contents.TemplateId = data.TemplateId;
+    contents.TemplateId = __expectString(data.TemplateId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -7810,13 +7813,13 @@ export const deserializeAws_restJson1DeleteThemeCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (data.ThemeId !== undefined && data.ThemeId !== null) {
-    contents.ThemeId = data.ThemeId;
+    contents.ThemeId = __expectString(data.ThemeId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -7926,16 +7929,16 @@ export const deserializeAws_restJson1DeleteThemeAliasCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AliasName !== undefined && data.AliasName !== null) {
-    contents.AliasName = data.AliasName;
+    contents.AliasName = __expectString(data.AliasName);
   }
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (data.ThemeId !== undefined && data.ThemeId !== null) {
-    contents.ThemeId = data.ThemeId;
+    contents.ThemeId = __expectString(data.ThemeId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -8034,7 +8037,7 @@ export const deserializeAws_restJson1DeleteUserCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -8141,7 +8144,7 @@ export const deserializeAws_restJson1DeleteUserByPrincipalIdCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -8255,16 +8258,16 @@ export const deserializeAws_restJson1DescribeAccountCustomizationCommand = async
     contents.AccountCustomization = deserializeAws_restJson1AccountCustomization(data.AccountCustomization, context);
   }
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.AwsAccountId !== undefined && data.AwsAccountId !== null) {
-    contents.AwsAccountId = data.AwsAccountId;
+    contents.AwsAccountId = __expectString(data.AwsAccountId);
   }
   if (data.Namespace !== undefined && data.Namespace !== null) {
-    contents.Namespace = data.Namespace;
+    contents.Namespace = __expectString(data.Namespace);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -8367,7 +8370,7 @@ export const deserializeAws_restJson1DescribeAccountSettingsCommand = async (
     contents.AccountSettings = deserializeAws_restJson1AccountSettings(data.AccountSettings, context);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -8470,7 +8473,7 @@ export const deserializeAws_restJson1DescribeAnalysisCommand = async (
     contents.Analysis = deserializeAws_restJson1Analysis(data.Analysis, context);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -8572,16 +8575,16 @@ export const deserializeAws_restJson1DescribeAnalysisPermissionsCommand = async 
   };
   const data: any = await parseBody(output.body, context);
   if (data.AnalysisArn !== undefined && data.AnalysisArn !== null) {
-    contents.AnalysisArn = data.AnalysisArn;
+    contents.AnalysisArn = __expectString(data.AnalysisArn);
   }
   if (data.AnalysisId !== undefined && data.AnalysisId !== null) {
-    contents.AnalysisId = data.AnalysisId;
+    contents.AnalysisId = __expectString(data.AnalysisId);
   }
   if (data.Permissions !== undefined && data.Permissions !== null) {
     contents.Permissions = deserializeAws_restJson1ResourcePermissionList(data.Permissions, context);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -8676,7 +8679,7 @@ export const deserializeAws_restJson1DescribeDashboardCommand = async (
     contents.Dashboard = deserializeAws_restJson1Dashboard(data.Dashboard, context);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -8778,16 +8781,16 @@ export const deserializeAws_restJson1DescribeDashboardPermissionsCommand = async
   };
   const data: any = await parseBody(output.body, context);
   if (data.DashboardArn !== undefined && data.DashboardArn !== null) {
-    contents.DashboardArn = data.DashboardArn;
+    contents.DashboardArn = __expectString(data.DashboardArn);
   }
   if (data.DashboardId !== undefined && data.DashboardId !== null) {
-    contents.DashboardId = data.DashboardId;
+    contents.DashboardId = __expectString(data.DashboardId);
   }
   if (data.Permissions !== undefined && data.Permissions !== null) {
     contents.Permissions = deserializeAws_restJson1ResourcePermissionList(data.Permissions, context);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -8882,7 +8885,7 @@ export const deserializeAws_restJson1DescribeDataSetCommand = async (
     contents.DataSet = deserializeAws_restJson1DataSet(data.DataSet, context);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -8976,16 +8979,16 @@ export const deserializeAws_restJson1DescribeDataSetPermissionsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.DataSetArn !== undefined && data.DataSetArn !== null) {
-    contents.DataSetArn = data.DataSetArn;
+    contents.DataSetArn = __expectString(data.DataSetArn);
   }
   if (data.DataSetId !== undefined && data.DataSetId !== null) {
-    contents.DataSetId = data.DataSetId;
+    contents.DataSetId = __expectString(data.DataSetId);
   }
   if (data.Permissions !== undefined && data.Permissions !== null) {
     contents.Permissions = deserializeAws_restJson1ResourcePermissionList(data.Permissions, context);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -9080,7 +9083,7 @@ export const deserializeAws_restJson1DescribeDataSourceCommand = async (
     contents.DataSource = deserializeAws_restJson1DataSource(data.DataSource, context);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -9174,16 +9177,16 @@ export const deserializeAws_restJson1DescribeDataSourcePermissionsCommand = asyn
   };
   const data: any = await parseBody(output.body, context);
   if (data.DataSourceArn !== undefined && data.DataSourceArn !== null) {
-    contents.DataSourceArn = data.DataSourceArn;
+    contents.DataSourceArn = __expectString(data.DataSourceArn);
   }
   if (data.DataSourceId !== undefined && data.DataSourceId !== null) {
-    contents.DataSourceId = data.DataSourceId;
+    contents.DataSourceId = __expectString(data.DataSourceId);
   }
   if (data.Permissions !== undefined && data.Permissions !== null) {
     contents.Permissions = deserializeAws_restJson1ResourcePermissionList(data.Permissions, context);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -9278,7 +9281,7 @@ export const deserializeAws_restJson1DescribeGroupCommand = async (
     contents.Group = deserializeAws_restJson1Group(data.Group, context);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -9389,7 +9392,7 @@ export const deserializeAws_restJson1DescribeIAMPolicyAssignmentCommand = async 
     contents.IAMPolicyAssignment = deserializeAws_restJson1IAMPolicyAssignment(data.IAMPolicyAssignment, context);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -9492,7 +9495,7 @@ export const deserializeAws_restJson1DescribeIngestionCommand = async (
     contents.Ingestion = deserializeAws_restJson1Ingestion(data.Ingestion, context);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -9595,7 +9598,7 @@ export const deserializeAws_restJson1DescribeNamespaceCommand = async (
     contents.Namespace = deserializeAws_restJson1NamespaceInfoV2(data.Namespace, context);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -9695,7 +9698,7 @@ export const deserializeAws_restJson1DescribeTemplateCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (data.Template !== undefined && data.Template !== null) {
     contents.Template = deserializeAws_restJson1Template(data.Template, context);
@@ -9814,7 +9817,7 @@ export const deserializeAws_restJson1DescribeTemplateAliasCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (data.TemplateAlias !== undefined && data.TemplateAlias !== null) {
     contents.TemplateAlias = deserializeAws_restJson1TemplateAlias(data.TemplateAlias, context);
@@ -9906,13 +9909,13 @@ export const deserializeAws_restJson1DescribeTemplatePermissionsCommand = async 
     contents.Permissions = deserializeAws_restJson1ResourcePermissionList(data.Permissions, context);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (data.TemplateArn !== undefined && data.TemplateArn !== null) {
-    contents.TemplateArn = data.TemplateArn;
+    contents.TemplateArn = __expectString(data.TemplateArn);
   }
   if (data.TemplateId !== undefined && data.TemplateId !== null) {
-    contents.TemplateId = data.TemplateId;
+    contents.TemplateId = __expectString(data.TemplateId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -10012,7 +10015,7 @@ export const deserializeAws_restJson1DescribeThemeCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (data.Theme !== undefined && data.Theme !== null) {
     contents.Theme = deserializeAws_restJson1Theme(data.Theme, context);
@@ -10123,7 +10126,7 @@ export const deserializeAws_restJson1DescribeThemeAliasCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (data.ThemeAlias !== undefined && data.ThemeAlias !== null) {
     contents.ThemeAlias = deserializeAws_restJson1ThemeAlias(data.ThemeAlias, context);
@@ -10231,13 +10234,13 @@ export const deserializeAws_restJson1DescribeThemePermissionsCommand = async (
     contents.Permissions = deserializeAws_restJson1ResourcePermissionList(data.Permissions, context);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (data.ThemeArn !== undefined && data.ThemeArn !== null) {
-    contents.ThemeArn = data.ThemeArn;
+    contents.ThemeArn = __expectString(data.ThemeArn);
   }
   if (data.ThemeId !== undefined && data.ThemeId !== null) {
-    contents.ThemeId = data.ThemeId;
+    contents.ThemeId = __expectString(data.ThemeId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -10337,7 +10340,7 @@ export const deserializeAws_restJson1DescribeUserCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (data.User !== undefined && data.User !== null) {
     contents.User = deserializeAws_restJson1User(data.User, context);
@@ -10448,10 +10451,10 @@ export const deserializeAws_restJson1GetDashboardEmbedUrlCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.EmbedUrl !== undefined && data.EmbedUrl !== null) {
-    contents.EmbedUrl = data.EmbedUrl;
+    contents.EmbedUrl = __expectString(data.EmbedUrl);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -10599,10 +10602,10 @@ export const deserializeAws_restJson1GetSessionEmbedUrlCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.EmbedUrl !== undefined && data.EmbedUrl !== null) {
-    contents.EmbedUrl = data.EmbedUrl;
+    contents.EmbedUrl = __expectString(data.EmbedUrl);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -10730,10 +10733,10 @@ export const deserializeAws_restJson1ListAnalysesCommand = async (
     contents.AnalysisSummaryList = deserializeAws_restJson1AnalysisSummaryList(data.AnalysisSummaryList, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -10821,10 +10824,10 @@ export const deserializeAws_restJson1ListDashboardsCommand = async (
     contents.DashboardSummaryList = deserializeAws_restJson1DashboardSummaryList(data.DashboardSummaryList, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -10915,10 +10918,10 @@ export const deserializeAws_restJson1ListDashboardVersionsCommand = async (
     );
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -11022,10 +11025,10 @@ export const deserializeAws_restJson1ListDataSetsCommand = async (
     contents.DataSetSummaries = deserializeAws_restJson1DataSetSummaryList(data.DataSetSummaries, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -11121,10 +11124,10 @@ export const deserializeAws_restJson1ListDataSourcesCommand = async (
     contents.DataSources = deserializeAws_restJson1DataSourceList(data.DataSources, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -11220,10 +11223,10 @@ export const deserializeAws_restJson1ListGroupMembershipsCommand = async (
     contents.GroupMemberList = deserializeAws_restJson1GroupMemberList(data.GroupMemberList, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -11343,10 +11346,10 @@ export const deserializeAws_restJson1ListGroupsCommand = async (
     contents.GroupList = deserializeAws_restJson1GroupList(data.GroupList, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -11469,10 +11472,10 @@ export const deserializeAws_restJson1ListIAMPolicyAssignmentsCommand = async (
     );
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -11576,10 +11579,10 @@ export const deserializeAws_restJson1ListIAMPolicyAssignmentsForUserCommand = as
     contents.ActiveAssignments = deserializeAws_restJson1ActiveIAMPolicyAssignmentList(data.ActiveAssignments, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -11691,10 +11694,10 @@ export const deserializeAws_restJson1ListIngestionsCommand = async (
     contents.Ingestions = deserializeAws_restJson1Ingestions(data.Ingestions, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -11806,10 +11809,10 @@ export const deserializeAws_restJson1ListNamespacesCommand = async (
     contents.Namespaces = deserializeAws_restJson1Namespaces(data.Namespaces, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -11925,7 +11928,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagList(data.Tags, context);
@@ -12021,10 +12024,10 @@ export const deserializeAws_restJson1ListTemplateAliasesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (data.TemplateAliasList !== undefined && data.TemplateAliasList !== null) {
     contents.TemplateAliasList = deserializeAws_restJson1TemplateAliasList(data.TemplateAliasList, context);
@@ -12120,10 +12123,10 @@ export const deserializeAws_restJson1ListTemplatesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (data.TemplateSummaryList !== undefined && data.TemplateSummaryList !== null) {
     contents.TemplateSummaryList = deserializeAws_restJson1TemplateSummaryList(data.TemplateSummaryList, context);
@@ -12227,10 +12230,10 @@ export const deserializeAws_restJson1ListTemplateVersionsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (data.TemplateVersionSummaryList !== undefined && data.TemplateVersionSummaryList !== null) {
     contents.TemplateVersionSummaryList = deserializeAws_restJson1TemplateVersionSummaryList(
@@ -12337,10 +12340,10 @@ export const deserializeAws_restJson1ListThemeAliasesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (data.ThemeAliasList !== undefined && data.ThemeAliasList !== null) {
     contents.ThemeAliasList = deserializeAws_restJson1ThemeAliasList(data.ThemeAliasList, context);
@@ -12452,10 +12455,10 @@ export const deserializeAws_restJson1ListThemesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (data.ThemeSummaryList !== undefined && data.ThemeSummaryList !== null) {
     contents.ThemeSummaryList = deserializeAws_restJson1ThemeSummaryList(data.ThemeSummaryList, context);
@@ -12567,10 +12570,10 @@ export const deserializeAws_restJson1ListThemeVersionsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (data.ThemeVersionSummaryList !== undefined && data.ThemeVersionSummaryList !== null) {
     contents.ThemeVersionSummaryList = deserializeAws_restJson1ThemeVersionSummaryList(
@@ -12688,10 +12691,10 @@ export const deserializeAws_restJson1ListUserGroupsCommand = async (
     contents.GroupList = deserializeAws_restJson1GroupList(data.GroupList, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -12800,10 +12803,10 @@ export const deserializeAws_restJson1ListUsersCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (data.UserList !== undefined && data.UserList !== null) {
     contents.UserList = deserializeAws_restJson1UserList(data.UserList, context);
@@ -12923,13 +12926,13 @@ export const deserializeAws_restJson1RegisterUserCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (data.User !== undefined && data.User !== null) {
     contents.User = deserializeAws_restJson1User(data.User, context);
   }
   if (data.UserInvitationUrl !== undefined && data.UserInvitationUrl !== null) {
-    contents.UserInvitationUrl = data.UserInvitationUrl;
+    contents.UserInvitationUrl = __expectString(data.UserInvitationUrl);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -13054,13 +13057,13 @@ export const deserializeAws_restJson1RestoreAnalysisCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AnalysisId !== undefined && data.AnalysisId !== null) {
-    contents.AnalysisId = data.AnalysisId;
+    contents.AnalysisId = __expectString(data.AnalysisId);
   }
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -13164,10 +13167,10 @@ export const deserializeAws_restJson1SearchAnalysesCommand = async (
     contents.AnalysisSummaryList = deserializeAws_restJson1AnalysisSummaryList(data.AnalysisSummaryList, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -13271,10 +13274,10 @@ export const deserializeAws_restJson1SearchDashboardsCommand = async (
     contents.DashboardSummaryList = deserializeAws_restJson1DashboardSummaryList(data.DashboardSummaryList, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -13373,7 +13376,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -13472,7 +13475,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -13570,16 +13573,16 @@ export const deserializeAws_restJson1UpdateAccountCustomizationCommand = async (
     contents.AccountCustomization = deserializeAws_restJson1AccountCustomization(data.AccountCustomization, context);
   }
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.AwsAccountId !== undefined && data.AwsAccountId !== null) {
-    contents.AwsAccountId = data.AwsAccountId;
+    contents.AwsAccountId = __expectString(data.AwsAccountId);
   }
   if (data.Namespace !== undefined && data.Namespace !== null) {
-    contents.Namespace = data.Namespace;
+    contents.Namespace = __expectString(data.Namespace);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -13678,7 +13681,7 @@ export const deserializeAws_restJson1UpdateAccountSettingsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -13780,16 +13783,16 @@ export const deserializeAws_restJson1UpdateAnalysisCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AnalysisId !== undefined && data.AnalysisId !== null) {
-    contents.AnalysisId = data.AnalysisId;
+    contents.AnalysisId = __expectString(data.AnalysisId);
   }
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (data.UpdateStatus !== undefined && data.UpdateStatus !== null) {
-    contents.UpdateStatus = data.UpdateStatus;
+    contents.UpdateStatus = __expectString(data.UpdateStatus);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -13899,16 +13902,16 @@ export const deserializeAws_restJson1UpdateAnalysisPermissionsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AnalysisArn !== undefined && data.AnalysisArn !== null) {
-    contents.AnalysisArn = data.AnalysisArn;
+    contents.AnalysisArn = __expectString(data.AnalysisArn);
   }
   if (data.AnalysisId !== undefined && data.AnalysisId !== null) {
-    contents.AnalysisId = data.AnalysisId;
+    contents.AnalysisId = __expectString(data.AnalysisId);
   }
   if (data.Permissions !== undefined && data.Permissions !== null) {
     contents.Permissions = deserializeAws_restJson1ResourcePermissionList(data.Permissions, context);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -14011,22 +14014,22 @@ export const deserializeAws_restJson1UpdateDashboardCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationStatus !== undefined && data.CreationStatus !== null) {
-    contents.CreationStatus = data.CreationStatus;
+    contents.CreationStatus = __expectString(data.CreationStatus);
   }
   if (data.DashboardId !== undefined && data.DashboardId !== null) {
-    contents.DashboardId = data.DashboardId;
+    contents.DashboardId = __expectString(data.DashboardId);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (data.Status !== undefined && data.Status !== null) {
-    contents.Status = data.Status;
+    contents.Status = __expectNumber(data.Status);
   }
   if (data.VersionArn !== undefined && data.VersionArn !== null) {
-    contents.VersionArn = data.VersionArn;
+    contents.VersionArn = __expectString(data.VersionArn);
   }
   return Promise.resolve(contents);
 };
@@ -14133,16 +14136,16 @@ export const deserializeAws_restJson1UpdateDashboardPermissionsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.DashboardArn !== undefined && data.DashboardArn !== null) {
-    contents.DashboardArn = data.DashboardArn;
+    contents.DashboardArn = __expectString(data.DashboardArn);
   }
   if (data.DashboardId !== undefined && data.DashboardId !== null) {
-    contents.DashboardId = data.DashboardId;
+    contents.DashboardId = __expectString(data.DashboardId);
   }
   if (data.Permissions !== undefined && data.Permissions !== null) {
     contents.Permissions = deserializeAws_restJson1ResourcePermissionList(data.Permissions, context);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -14243,13 +14246,13 @@ export const deserializeAws_restJson1UpdateDashboardPublishedVersionCommand = as
   };
   const data: any = await parseBody(output.body, context);
   if (data.DashboardArn !== undefined && data.DashboardArn !== null) {
-    contents.DashboardArn = data.DashboardArn;
+    contents.DashboardArn = __expectString(data.DashboardArn);
   }
   if (data.DashboardId !== undefined && data.DashboardId !== null) {
-    contents.DashboardId = data.DashboardId;
+    contents.DashboardId = __expectString(data.DashboardId);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -14352,19 +14355,19 @@ export const deserializeAws_restJson1UpdateDataSetCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.DataSetId !== undefined && data.DataSetId !== null) {
-    contents.DataSetId = data.DataSetId;
+    contents.DataSetId = __expectString(data.DataSetId);
   }
   if (data.IngestionArn !== undefined && data.IngestionArn !== null) {
-    contents.IngestionArn = data.IngestionArn;
+    contents.IngestionArn = __expectString(data.IngestionArn);
   }
   if (data.IngestionId !== undefined && data.IngestionId !== null) {
-    contents.IngestionId = data.IngestionId;
+    contents.IngestionId = __expectString(data.IngestionId);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -14481,13 +14484,13 @@ export const deserializeAws_restJson1UpdateDataSetPermissionsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.DataSetArn !== undefined && data.DataSetArn !== null) {
-    contents.DataSetArn = data.DataSetArn;
+    contents.DataSetArn = __expectString(data.DataSetArn);
   }
   if (data.DataSetId !== undefined && data.DataSetId !== null) {
-    contents.DataSetId = data.DataSetId;
+    contents.DataSetId = __expectString(data.DataSetId);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -14589,16 +14592,16 @@ export const deserializeAws_restJson1UpdateDataSourceCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.DataSourceId !== undefined && data.DataSourceId !== null) {
-    contents.DataSourceId = data.DataSourceId;
+    contents.DataSourceId = __expectString(data.DataSourceId);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (data.UpdateStatus !== undefined && data.UpdateStatus !== null) {
-    contents.UpdateStatus = data.UpdateStatus;
+    contents.UpdateStatus = __expectString(data.UpdateStatus);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -14699,13 +14702,13 @@ export const deserializeAws_restJson1UpdateDataSourcePermissionsCommand = async 
   };
   const data: any = await parseBody(output.body, context);
   if (data.DataSourceArn !== undefined && data.DataSourceArn !== null) {
-    contents.DataSourceArn = data.DataSourceArn;
+    contents.DataSourceArn = __expectString(data.DataSourceArn);
   }
   if (data.DataSourceId !== undefined && data.DataSourceId !== null) {
-    contents.DataSourceId = data.DataSourceId;
+    contents.DataSourceId = __expectString(data.DataSourceId);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -14808,7 +14811,7 @@ export const deserializeAws_restJson1UpdateGroupCommand = async (
     contents.Group = deserializeAws_restJson1Group(data.Group, context);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -14920,22 +14923,22 @@ export const deserializeAws_restJson1UpdateIAMPolicyAssignmentCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AssignmentId !== undefined && data.AssignmentId !== null) {
-    contents.AssignmentId = data.AssignmentId;
+    contents.AssignmentId = __expectString(data.AssignmentId);
   }
   if (data.AssignmentName !== undefined && data.AssignmentName !== null) {
-    contents.AssignmentName = data.AssignmentName;
+    contents.AssignmentName = __expectString(data.AssignmentName);
   }
   if (data.AssignmentStatus !== undefined && data.AssignmentStatus !== null) {
-    contents.AssignmentStatus = data.AssignmentStatus;
+    contents.AssignmentStatus = __expectString(data.AssignmentStatus);
   }
   if (data.Identities !== undefined && data.Identities !== null) {
     contents.Identities = deserializeAws_restJson1IdentityMap(data.Identities, context);
   }
   if (data.PolicyArn !== undefined && data.PolicyArn !== null) {
-    contents.PolicyArn = data.PolicyArn;
+    contents.PolicyArn = __expectString(data.PolicyArn);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -15046,19 +15049,19 @@ export const deserializeAws_restJson1UpdateTemplateCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationStatus !== undefined && data.CreationStatus !== null) {
-    contents.CreationStatus = data.CreationStatus;
+    contents.CreationStatus = __expectString(data.CreationStatus);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (data.TemplateId !== undefined && data.TemplateId !== null) {
-    contents.TemplateId = data.TemplateId;
+    contents.TemplateId = __expectString(data.TemplateId);
   }
   if (data.VersionArn !== undefined && data.VersionArn !== null) {
-    contents.VersionArn = data.VersionArn;
+    contents.VersionArn = __expectString(data.VersionArn);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -15174,7 +15177,7 @@ export const deserializeAws_restJson1UpdateTemplateAliasCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (data.TemplateAlias !== undefined && data.TemplateAlias !== null) {
     contents.TemplateAlias = deserializeAws_restJson1TemplateAlias(data.TemplateAlias, context);
@@ -15274,13 +15277,13 @@ export const deserializeAws_restJson1UpdateTemplatePermissionsCommand = async (
     contents.Permissions = deserializeAws_restJson1ResourcePermissionList(data.Permissions, context);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (data.TemplateArn !== undefined && data.TemplateArn !== null) {
-    contents.TemplateArn = data.TemplateArn;
+    contents.TemplateArn = __expectString(data.TemplateArn);
   }
   if (data.TemplateId !== undefined && data.TemplateId !== null) {
-    contents.TemplateId = data.TemplateId;
+    contents.TemplateId = __expectString(data.TemplateId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -15383,19 +15386,19 @@ export const deserializeAws_restJson1UpdateThemeCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationStatus !== undefined && data.CreationStatus !== null) {
-    contents.CreationStatus = data.CreationStatus;
+    contents.CreationStatus = __expectString(data.CreationStatus);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (data.ThemeId !== undefined && data.ThemeId !== null) {
-    contents.ThemeId = data.ThemeId;
+    contents.ThemeId = __expectString(data.ThemeId);
   }
   if (data.VersionArn !== undefined && data.VersionArn !== null) {
-    contents.VersionArn = data.VersionArn;
+    contents.VersionArn = __expectString(data.VersionArn);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -15511,7 +15514,7 @@ export const deserializeAws_restJson1UpdateThemeAliasCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (data.ThemeAlias !== undefined && data.ThemeAlias !== null) {
     contents.ThemeAlias = deserializeAws_restJson1ThemeAlias(data.ThemeAlias, context);
@@ -15627,13 +15630,13 @@ export const deserializeAws_restJson1UpdateThemePermissionsCommand = async (
     contents.Permissions = deserializeAws_restJson1ResourcePermissionList(data.Permissions, context);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (data.ThemeArn !== undefined && data.ThemeArn !== null) {
-    contents.ThemeArn = data.ThemeArn;
+    contents.ThemeArn = __expectString(data.ThemeArn);
   }
   if (data.ThemeId !== undefined && data.ThemeId !== null) {
-    contents.ThemeId = data.ThemeId;
+    contents.ThemeId = __expectString(data.ThemeId);
   }
   if (contents.Status === undefined) {
     contents.Status = output.statusCode;
@@ -15733,7 +15736,7 @@ export const deserializeAws_restJson1UpdateUserCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (data.User !== undefined && data.User !== null) {
     contents.User = deserializeAws_restJson1User(data.User, context);
@@ -15842,10 +15845,10 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   return contents;
 };
@@ -15863,10 +15866,10 @@ const deserializeAws_restJson1ConcurrentUpdatingExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   return contents;
 };
@@ -15884,10 +15887,10 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   return contents;
 };
@@ -15905,10 +15908,10 @@ const deserializeAws_restJson1DomainNotWhitelistedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   return contents;
 };
@@ -15926,10 +15929,10 @@ const deserializeAws_restJson1IdentityTypeNotSupportedExceptionResponse = async 
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   return contents;
 };
@@ -15947,10 +15950,10 @@ const deserializeAws_restJson1InternalFailureExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   return contents;
 };
@@ -15968,10 +15971,10 @@ const deserializeAws_restJson1InvalidNextTokenExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   return contents;
 };
@@ -15989,10 +15992,10 @@ const deserializeAws_restJson1InvalidParameterValueExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   return contents;
 };
@@ -16011,13 +16014,13 @@ const deserializeAws_restJson1LimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (data.ResourceType !== undefined && data.ResourceType !== null) {
-    contents.ResourceType = data.ResourceType;
+    contents.ResourceType = __expectString(data.ResourceType);
   }
   return contents;
 };
@@ -16035,10 +16038,10 @@ const deserializeAws_restJson1PreconditionNotMetExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   return contents;
 };
@@ -16056,10 +16059,10 @@ const deserializeAws_restJson1QuickSightUserNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   return contents;
 };
@@ -16078,13 +16081,13 @@ const deserializeAws_restJson1ResourceExistsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (data.ResourceType !== undefined && data.ResourceType !== null) {
-    contents.ResourceType = data.ResourceType;
+    contents.ResourceType = __expectString(data.ResourceType);
   }
   return contents;
 };
@@ -16103,13 +16106,13 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (data.ResourceType !== undefined && data.ResourceType !== null) {
-    contents.ResourceType = data.ResourceType;
+    contents.ResourceType = __expectString(data.ResourceType);
   }
   return contents;
 };
@@ -16128,13 +16131,13 @@ const deserializeAws_restJson1ResourceUnavailableExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   if (data.ResourceType !== undefined && data.ResourceType !== null) {
-    contents.ResourceType = data.ResourceType;
+    contents.ResourceType = __expectString(data.ResourceType);
   }
   return contents;
 };
@@ -16152,10 +16155,10 @@ const deserializeAws_restJson1SessionLifetimeInMinutesInvalidExceptionResponse =
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   return contents;
 };
@@ -16173,10 +16176,10 @@ const deserializeAws_restJson1ThrottlingExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   return contents;
 };
@@ -16194,10 +16197,10 @@ const deserializeAws_restJson1UnsupportedPricingPlanExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   return contents;
 };
@@ -16215,10 +16218,10 @@ const deserializeAws_restJson1UnsupportedUserEditionExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
-    contents.RequestId = data.RequestId;
+    contents.RequestId = __expectString(data.RequestId);
   }
   return contents;
 };
@@ -17422,20 +17425,16 @@ const serializeAws_restJson1VpcConnectionProperties = (
 
 const deserializeAws_restJson1AccountCustomization = (output: any, context: __SerdeContext): AccountCustomization => {
   return {
-    DefaultTheme: output.DefaultTheme !== undefined && output.DefaultTheme !== null ? output.DefaultTheme : undefined,
+    DefaultTheme: __expectString(output.DefaultTheme),
   } as any;
 };
 
 const deserializeAws_restJson1AccountSettings = (output: any, context: __SerdeContext): AccountSettings => {
   return {
-    AccountName: output.AccountName !== undefined && output.AccountName !== null ? output.AccountName : undefined,
-    DefaultNamespace:
-      output.DefaultNamespace !== undefined && output.DefaultNamespace !== null ? output.DefaultNamespace : undefined,
-    Edition: output.Edition !== undefined && output.Edition !== null ? output.Edition : undefined,
-    NotificationEmail:
-      output.NotificationEmail !== undefined && output.NotificationEmail !== null
-        ? output.NotificationEmail
-        : undefined,
+    AccountName: __expectString(output.AccountName),
+    DefaultNamespace: __expectString(output.DefaultNamespace),
+    Edition: __expectString(output.Edition),
+    NotificationEmail: __expectString(output.NotificationEmail),
   } as any;
 };
 
@@ -17446,7 +17445,7 @@ const deserializeAws_restJson1ActionList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -17455,9 +17454,8 @@ const deserializeAws_restJson1ActiveIAMPolicyAssignment = (
   context: __SerdeContext
 ): ActiveIAMPolicyAssignment => {
   return {
-    AssignmentName:
-      output.AssignmentName !== undefined && output.AssignmentName !== null ? output.AssignmentName : undefined,
-    PolicyArn: output.PolicyArn !== undefined && output.PolicyArn !== null ? output.PolicyArn : undefined,
+    AssignmentName: __expectString(output.AssignmentName),
+    PolicyArn: __expectString(output.PolicyArn),
   } as any;
 };
 
@@ -17480,14 +17478,14 @@ const deserializeAws_restJson1AmazonElasticsearchParameters = (
   context: __SerdeContext
 ): AmazonElasticsearchParameters => {
   return {
-    Domain: output.Domain !== undefined && output.Domain !== null ? output.Domain : undefined,
+    Domain: __expectString(output.Domain),
   } as any;
 };
 
 const deserializeAws_restJson1Analysis = (output: any, context: __SerdeContext): Analysis => {
   return {
-    AnalysisId: output.AnalysisId !== undefined && output.AnalysisId !== null ? output.AnalysisId : undefined,
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    AnalysisId: __expectString(output.AnalysisId),
+    Arn: __expectString(output.Arn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
@@ -17504,20 +17502,20 @@ const deserializeAws_restJson1Analysis = (output: any, context: __SerdeContext):
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
         ? new Date(Math.round(output.LastUpdatedTime * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     Sheets:
       output.Sheets !== undefined && output.Sheets !== null
         ? deserializeAws_restJson1SheetList(output.Sheets, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    ThemeArn: output.ThemeArn !== undefined && output.ThemeArn !== null ? output.ThemeArn : undefined,
+    Status: __expectString(output.Status),
+    ThemeArn: __expectString(output.ThemeArn),
   } as any;
 };
 
 const deserializeAws_restJson1AnalysisError = (output: any, context: __SerdeContext): AnalysisError => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Message: __expectString(output.Message),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -17534,8 +17532,8 @@ const deserializeAws_restJson1AnalysisErrorList = (output: any, context: __Serde
 
 const deserializeAws_restJson1AnalysisSummary = (output: any, context: __SerdeContext): AnalysisSummary => {
   return {
-    AnalysisId: output.AnalysisId !== undefined && output.AnalysisId !== null ? output.AnalysisId : undefined,
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    AnalysisId: __expectString(output.AnalysisId),
+    Arn: __expectString(output.Arn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
@@ -17544,8 +17542,8 @@ const deserializeAws_restJson1AnalysisSummary = (output: any, context: __SerdeCo
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
         ? new Date(Math.round(output.LastUpdatedTime * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Name: __expectString(output.Name),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -17562,15 +17560,15 @@ const deserializeAws_restJson1AnalysisSummaryList = (output: any, context: __Ser
 
 const deserializeAws_restJson1AthenaParameters = (output: any, context: __SerdeContext): AthenaParameters => {
   return {
-    WorkGroup: output.WorkGroup !== undefined && output.WorkGroup !== null ? output.WorkGroup : undefined,
+    WorkGroup: __expectString(output.WorkGroup),
   } as any;
 };
 
 const deserializeAws_restJson1AuroraParameters = (output: any, context: __SerdeContext): AuroraParameters => {
   return {
-    Database: output.Database !== undefined && output.Database !== null ? output.Database : undefined,
-    Host: output.Host !== undefined && output.Host !== null ? output.Host : undefined,
-    Port: output.Port !== undefined && output.Port !== null ? output.Port : undefined,
+    Database: __expectString(output.Database),
+    Host: __expectString(output.Host),
+    Port: __expectNumber(output.Port),
   } as any;
 };
 
@@ -17579,9 +17577,9 @@ const deserializeAws_restJson1AuroraPostgreSqlParameters = (
   context: __SerdeContext
 ): AuroraPostgreSqlParameters => {
   return {
-    Database: output.Database !== undefined && output.Database !== null ? output.Database : undefined,
-    Host: output.Host !== undefined && output.Host !== null ? output.Host : undefined,
-    Port: output.Port !== undefined && output.Port !== null ? output.Port : undefined,
+    Database: __expectString(output.Database),
+    Host: __expectString(output.Host),
+    Port: __expectNumber(output.Port),
   } as any;
 };
 
@@ -17590,21 +17588,21 @@ const deserializeAws_restJson1AwsIotAnalyticsParameters = (
   context: __SerdeContext
 ): AwsIotAnalyticsParameters => {
   return {
-    DataSetName: output.DataSetName !== undefined && output.DataSetName !== null ? output.DataSetName : undefined,
+    DataSetName: __expectString(output.DataSetName),
   } as any;
 };
 
 const deserializeAws_restJson1BorderStyle = (output: any, context: __SerdeContext): BorderStyle => {
   return {
-    Show: output.Show !== undefined && output.Show !== null ? output.Show : undefined,
+    Show: __expectBoolean(output.Show),
   } as any;
 };
 
 const deserializeAws_restJson1CalculatedColumn = (output: any, context: __SerdeContext): CalculatedColumn => {
   return {
-    ColumnId: output.ColumnId !== undefined && output.ColumnId !== null ? output.ColumnId : undefined,
-    ColumnName: output.ColumnName !== undefined && output.ColumnName !== null ? output.ColumnName : undefined,
-    Expression: output.Expression !== undefined && output.Expression !== null ? output.Expression : undefined,
+    ColumnId: __expectString(output.ColumnId),
+    ColumnName: __expectString(output.ColumnName),
+    Expression: __expectString(output.Expression),
   } as any;
 };
 
@@ -17624,10 +17622,9 @@ const deserializeAws_restJson1CastColumnTypeOperation = (
   context: __SerdeContext
 ): CastColumnTypeOperation => {
   return {
-    ColumnName: output.ColumnName !== undefined && output.ColumnName !== null ? output.ColumnName : undefined,
-    Format: output.Format !== undefined && output.Format !== null ? output.Format : undefined,
-    NewColumnType:
-      output.NewColumnType !== undefined && output.NewColumnType !== null ? output.NewColumnType : undefined,
+    ColumnName: __expectString(output.ColumnName),
+    Format: __expectString(output.Format),
+    NewColumnType: __expectString(output.NewColumnType),
   } as any;
 };
 
@@ -17638,13 +17635,13 @@ const deserializeAws_restJson1ColorList = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1ColumnDescription = (output: any, context: __SerdeContext): ColumnDescription => {
   return {
-    Text: output.Text !== undefined && output.Text !== null ? output.Text : undefined,
+    Text: __expectString(output.Text),
   } as any;
 };
 
@@ -17662,7 +17659,7 @@ const deserializeAws_restJson1ColumnGroupColumnSchema = (
   context: __SerdeContext
 ): ColumnGroupColumnSchema => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -17697,7 +17694,7 @@ const deserializeAws_restJson1ColumnGroupSchema = (output: any, context: __Serde
       output.ColumnGroupColumnSchemaList !== undefined && output.ColumnGroupColumnSchemaList !== null
         ? deserializeAws_restJson1ColumnGroupColumnSchemaList(output.ColumnGroupColumnSchemaList, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -17749,7 +17746,7 @@ const deserializeAws_restJson1ColumnList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -17760,16 +17757,15 @@ const deserializeAws_restJson1ColumnNameList = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1ColumnSchema = (output: any, context: __SerdeContext): ColumnSchema => {
   return {
-    DataType: output.DataType !== undefined && output.DataType !== null ? output.DataType : undefined,
-    GeographicRole:
-      output.GeographicRole !== undefined && output.GeographicRole !== null ? output.GeographicRole : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    DataType: __expectString(output.DataType),
+    GeographicRole: __expectString(output.GeographicRole),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -17790,10 +17786,7 @@ const deserializeAws_restJson1ColumnTag = (output: any, context: __SerdeContext)
       output.ColumnDescription !== undefined && output.ColumnDescription !== null
         ? deserializeAws_restJson1ColumnDescription(output.ColumnDescription, context)
         : undefined,
-    ColumnGeographicRole:
-      output.ColumnGeographicRole !== undefined && output.ColumnGeographicRole !== null
-        ? output.ColumnGeographicRole
-        : undefined,
+    ColumnGeographicRole: __expectString(output.ColumnGeographicRole),
   } as any;
 };
 
@@ -17826,21 +17819,20 @@ const deserializeAws_restJson1CustomSql = (output: any, context: __SerdeContext)
       output.Columns !== undefined && output.Columns !== null
         ? deserializeAws_restJson1InputColumnList(output.Columns, context)
         : undefined,
-    DataSourceArn:
-      output.DataSourceArn !== undefined && output.DataSourceArn !== null ? output.DataSourceArn : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    SqlQuery: output.SqlQuery !== undefined && output.SqlQuery !== null ? output.SqlQuery : undefined,
+    DataSourceArn: __expectString(output.DataSourceArn),
+    Name: __expectString(output.Name),
+    SqlQuery: __expectString(output.SqlQuery),
   } as any;
 };
 
 const deserializeAws_restJson1Dashboard = (output: any, context: __SerdeContext): Dashboard => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
         : undefined,
-    DashboardId: output.DashboardId !== undefined && output.DashboardId !== null ? output.DashboardId : undefined,
+    DashboardId: __expectString(output.DashboardId),
     LastPublishedTime:
       output.LastPublishedTime !== undefined && output.LastPublishedTime !== null
         ? new Date(Math.round(output.LastPublishedTime * 1000))
@@ -17849,7 +17841,7 @@ const deserializeAws_restJson1Dashboard = (output: any, context: __SerdeContext)
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
         ? new Date(Math.round(output.LastUpdatedTime * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     Version:
       output.Version !== undefined && output.Version !== null
         ? deserializeAws_restJson1DashboardVersion(output.Version, context)
@@ -17859,8 +17851,8 @@ const deserializeAws_restJson1Dashboard = (output: any, context: __SerdeContext)
 
 const deserializeAws_restJson1DashboardError = (output: any, context: __SerdeContext): DashboardError => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Message: __expectString(output.Message),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -17877,12 +17869,12 @@ const deserializeAws_restJson1DashboardErrorList = (output: any, context: __Serd
 
 const deserializeAws_restJson1DashboardSummary = (output: any, context: __SerdeContext): DashboardSummary => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
         : undefined,
-    DashboardId: output.DashboardId !== undefined && output.DashboardId !== null ? output.DashboardId : undefined,
+    DashboardId: __expectString(output.DashboardId),
     LastPublishedTime:
       output.LastPublishedTime !== undefined && output.LastPublishedTime !== null
         ? new Date(Math.round(output.LastPublishedTime * 1000))
@@ -17891,11 +17883,8 @@ const deserializeAws_restJson1DashboardSummary = (output: any, context: __SerdeC
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
         ? new Date(Math.round(output.LastUpdatedTime * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    PublishedVersionNumber:
-      output.PublishedVersionNumber !== undefined && output.PublishedVersionNumber !== null
-        ? output.PublishedVersionNumber
-        : undefined,
+    Name: __expectString(output.Name),
+    PublishedVersionNumber: __expectNumber(output.PublishedVersionNumber),
   } as any;
 };
 
@@ -17912,7 +17901,7 @@ const deserializeAws_restJson1DashboardSummaryList = (output: any, context: __Se
 
 const deserializeAws_restJson1DashboardVersion = (output: any, context: __SerdeContext): DashboardVersion => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
@@ -17921,7 +17910,7 @@ const deserializeAws_restJson1DashboardVersion = (output: any, context: __SerdeC
       output.DataSetArns !== undefined && output.DataSetArns !== null
         ? deserializeAws_restJson1DataSetArnsList(output.DataSetArns, context)
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     Errors:
       output.Errors !== undefined && output.Errors !== null
         ? deserializeAws_restJson1DashboardErrorList(output.Errors, context)
@@ -17930,12 +17919,10 @@ const deserializeAws_restJson1DashboardVersion = (output: any, context: __SerdeC
       output.Sheets !== undefined && output.Sheets !== null
         ? deserializeAws_restJson1SheetList(output.Sheets, context)
         : undefined,
-    SourceEntityArn:
-      output.SourceEntityArn !== undefined && output.SourceEntityArn !== null ? output.SourceEntityArn : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    ThemeArn: output.ThemeArn !== undefined && output.ThemeArn !== null ? output.ThemeArn : undefined,
-    VersionNumber:
-      output.VersionNumber !== undefined && output.VersionNumber !== null ? output.VersionNumber : undefined,
+    SourceEntityArn: __expectString(output.SourceEntityArn),
+    Status: __expectString(output.Status),
+    ThemeArn: __expectString(output.ThemeArn),
+    VersionNumber: __expectNumber(output.VersionNumber),
   } as any;
 };
 
@@ -17944,17 +17931,15 @@ const deserializeAws_restJson1DashboardVersionSummary = (
   context: __SerdeContext
 ): DashboardVersionSummary => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    SourceEntityArn:
-      output.SourceEntityArn !== undefined && output.SourceEntityArn !== null ? output.SourceEntityArn : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    VersionNumber:
-      output.VersionNumber !== undefined && output.VersionNumber !== null ? output.VersionNumber : undefined,
+    Description: __expectString(output.Description),
+    SourceEntityArn: __expectString(output.SourceEntityArn),
+    Status: __expectString(output.Status),
+    VersionNumber: __expectNumber(output.VersionNumber),
   } as any;
 };
 
@@ -17978,8 +17963,7 @@ const deserializeAws_restJson1DataColorPalette = (output: any, context: __SerdeC
       output.Colors !== undefined && output.Colors !== null
         ? deserializeAws_restJson1ColorList(output.Colors, context)
         : undefined,
-    EmptyFillColor:
-      output.EmptyFillColor !== undefined && output.EmptyFillColor !== null ? output.EmptyFillColor : undefined,
+    EmptyFillColor: __expectString(output.EmptyFillColor),
     MinMaxGradient:
       output.MinMaxGradient !== undefined && output.MinMaxGradient !== null
         ? deserializeAws_restJson1ColorList(output.MinMaxGradient, context)
@@ -17989,7 +17973,7 @@ const deserializeAws_restJson1DataColorPalette = (output: any, context: __SerdeC
 
 const deserializeAws_restJson1DataSet = (output: any, context: __SerdeContext): DataSet => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     ColumnGroups:
       output.ColumnGroups !== undefined && output.ColumnGroups !== null
         ? deserializeAws_restJson1ColumnGroupList(output.ColumnGroups, context)
@@ -17998,20 +17982,17 @@ const deserializeAws_restJson1DataSet = (output: any, context: __SerdeContext): 
       output.ColumnLevelPermissionRules !== undefined && output.ColumnLevelPermissionRules !== null
         ? deserializeAws_restJson1ColumnLevelPermissionRuleList(output.ColumnLevelPermissionRules, context)
         : undefined,
-    ConsumedSpiceCapacityInBytes:
-      output.ConsumedSpiceCapacityInBytes !== undefined && output.ConsumedSpiceCapacityInBytes !== null
-        ? output.ConsumedSpiceCapacityInBytes
-        : undefined,
+    ConsumedSpiceCapacityInBytes: __expectNumber(output.ConsumedSpiceCapacityInBytes),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
         : undefined,
-    DataSetId: output.DataSetId !== undefined && output.DataSetId !== null ? output.DataSetId : undefined,
+    DataSetId: __expectString(output.DataSetId),
     FieldFolders:
       output.FieldFolders !== undefined && output.FieldFolders !== null
         ? deserializeAws_restJson1FieldFolderMap(output.FieldFolders, context)
         : undefined,
-    ImportMode: output.ImportMode !== undefined && output.ImportMode !== null ? output.ImportMode : undefined,
+    ImportMode: __expectString(output.ImportMode),
     LastUpdatedTime:
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
         ? new Date(Math.round(output.LastUpdatedTime * 1000))
@@ -18020,7 +18001,7 @@ const deserializeAws_restJson1DataSet = (output: any, context: __SerdeContext): 
       output.LogicalTableMap !== undefined && output.LogicalTableMap !== null
         ? deserializeAws_restJson1LogicalTableMap(output.LogicalTableMap, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     OutputColumns:
       output.OutputColumns !== undefined && output.OutputColumns !== null
         ? deserializeAws_restJson1OutputColumnList(output.OutputColumns, context)
@@ -18043,7 +18024,7 @@ const deserializeAws_restJson1DataSetArnsList = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -18057,7 +18038,7 @@ const deserializeAws_restJson1DataSetConfiguration = (output: any, context: __Se
       output.DataSetSchema !== undefined && output.DataSetSchema !== null
         ? deserializeAws_restJson1DataSetSchema(output.DataSetSchema, context)
         : undefined,
-    Placeholder: output.Placeholder !== undefined && output.Placeholder !== null ? output.Placeholder : undefined,
+    Placeholder: __expectString(output.Placeholder),
   } as any;
 };
 
@@ -18086,22 +18067,19 @@ const deserializeAws_restJson1DataSetSchema = (output: any, context: __SerdeCont
 
 const deserializeAws_restJson1DataSetSummary = (output: any, context: __SerdeContext): DataSetSummary => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    ColumnLevelPermissionRulesApplied:
-      output.ColumnLevelPermissionRulesApplied !== undefined && output.ColumnLevelPermissionRulesApplied !== null
-        ? output.ColumnLevelPermissionRulesApplied
-        : undefined,
+    Arn: __expectString(output.Arn),
+    ColumnLevelPermissionRulesApplied: __expectBoolean(output.ColumnLevelPermissionRulesApplied),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
         : undefined,
-    DataSetId: output.DataSetId !== undefined && output.DataSetId !== null ? output.DataSetId : undefined,
-    ImportMode: output.ImportMode !== undefined && output.ImportMode !== null ? output.ImportMode : undefined,
+    DataSetId: __expectString(output.DataSetId),
+    ImportMode: __expectString(output.ImportMode),
     LastUpdatedTime:
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
         ? new Date(Math.round(output.LastUpdatedTime * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     RowLevelPermissionDataSet:
       output.RowLevelPermissionDataSet !== undefined && output.RowLevelPermissionDataSet !== null
         ? deserializeAws_restJson1RowLevelPermissionDataSet(output.RowLevelPermissionDataSet, context)
@@ -18126,12 +18104,12 @@ const deserializeAws_restJson1DataSource = (output: any, context: __SerdeContext
       output.AlternateDataSourceParameters !== undefined && output.AlternateDataSourceParameters !== null
         ? deserializeAws_restJson1DataSourceParametersList(output.AlternateDataSourceParameters, context)
         : undefined,
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
         : undefined,
-    DataSourceId: output.DataSourceId !== undefined && output.DataSourceId !== null ? output.DataSourceId : undefined,
+    DataSourceId: __expectString(output.DataSourceId),
     DataSourceParameters:
       output.DataSourceParameters !== undefined && output.DataSourceParameters !== null
         ? deserializeAws_restJson1DataSourceParameters(output.DataSourceParameters, context)
@@ -18144,13 +18122,13 @@ const deserializeAws_restJson1DataSource = (output: any, context: __SerdeContext
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
         ? new Date(Math.round(output.LastUpdatedTime * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     SslProperties:
       output.SslProperties !== undefined && output.SslProperties !== null
         ? deserializeAws_restJson1SslProperties(output.SslProperties, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Status: __expectString(output.Status),
+    Type: __expectString(output.Type),
     VpcConnectionProperties:
       output.VpcConnectionProperties !== undefined && output.VpcConnectionProperties !== null
         ? deserializeAws_restJson1VpcConnectionProperties(output.VpcConnectionProperties, context)
@@ -18160,8 +18138,8 @@ const deserializeAws_restJson1DataSource = (output: any, context: __SerdeContext
 
 const deserializeAws_restJson1DataSourceErrorInfo = (output: any, context: __SerdeContext): DataSourceErrorInfo => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Message: __expectString(output.Message),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -18305,8 +18283,8 @@ const deserializeAws_restJson1DataSourceParametersList = (
 
 const deserializeAws_restJson1ErrorInfo = (output: any, context: __SerdeContext): ErrorInfo => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Message: __expectString(output.Message),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -18316,7 +18294,7 @@ const deserializeAws_restJson1FieldFolder = (output: any, context: __SerdeContex
       output.columns !== undefined && output.columns !== null
         ? deserializeAws_restJson1FolderColumnList(output.columns, context)
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
+    description: __expectString(output.description),
   } as any;
 };
 
@@ -18337,10 +18315,7 @@ const deserializeAws_restJson1FieldFolderMap = (
 
 const deserializeAws_restJson1FilterOperation = (output: any, context: __SerdeContext): FilterOperation => {
   return {
-    ConditionExpression:
-      output.ConditionExpression !== undefined && output.ConditionExpression !== null
-        ? output.ConditionExpression
-        : undefined,
+    ConditionExpression: __expectString(output.ConditionExpression),
   } as any;
 };
 
@@ -18351,7 +18326,7 @@ const deserializeAws_restJson1FolderColumnList = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -18361,17 +18336,17 @@ const deserializeAws_restJson1GeoSpatialColumnGroup = (output: any, context: __S
       output.Columns !== undefined && output.Columns !== null
         ? deserializeAws_restJson1ColumnList(output.Columns, context)
         : undefined,
-    CountryCode: output.CountryCode !== undefined && output.CountryCode !== null ? output.CountryCode : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    CountryCode: __expectString(output.CountryCode),
+    Name: __expectString(output.Name),
   } as any;
 };
 
 const deserializeAws_restJson1Group = (output: any, context: __SerdeContext): Group => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    GroupName: output.GroupName !== undefined && output.GroupName !== null ? output.GroupName : undefined,
-    PrincipalId: output.PrincipalId !== undefined && output.PrincipalId !== null ? output.PrincipalId : undefined,
+    Arn: __expectString(output.Arn),
+    Description: __expectString(output.Description),
+    GroupName: __expectString(output.GroupName),
+    PrincipalId: __expectString(output.PrincipalId),
   } as any;
 };
 
@@ -18388,8 +18363,8 @@ const deserializeAws_restJson1GroupList = (output: any, context: __SerdeContext)
 
 const deserializeAws_restJson1GroupMember = (output: any, context: __SerdeContext): GroupMember => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    MemberName: output.MemberName !== undefined && output.MemberName !== null ? output.MemberName : undefined,
+    Arn: __expectString(output.Arn),
+    MemberName: __expectString(output.MemberName),
   } as any;
 };
 
@@ -18406,23 +18381,21 @@ const deserializeAws_restJson1GroupMemberList = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1GutterStyle = (output: any, context: __SerdeContext): GutterStyle => {
   return {
-    Show: output.Show !== undefined && output.Show !== null ? output.Show : undefined,
+    Show: __expectBoolean(output.Show),
   } as any;
 };
 
 const deserializeAws_restJson1IAMPolicyAssignment = (output: any, context: __SerdeContext): IAMPolicyAssignment => {
   return {
-    AssignmentId: output.AssignmentId !== undefined && output.AssignmentId !== null ? output.AssignmentId : undefined,
-    AssignmentName:
-      output.AssignmentName !== undefined && output.AssignmentName !== null ? output.AssignmentName : undefined,
-    AssignmentStatus:
-      output.AssignmentStatus !== undefined && output.AssignmentStatus !== null ? output.AssignmentStatus : undefined,
-    AwsAccountId: output.AwsAccountId !== undefined && output.AwsAccountId !== null ? output.AwsAccountId : undefined,
+    AssignmentId: __expectString(output.AssignmentId),
+    AssignmentName: __expectString(output.AssignmentName),
+    AssignmentStatus: __expectString(output.AssignmentStatus),
+    AwsAccountId: __expectString(output.AwsAccountId),
     Identities:
       output.Identities !== undefined && output.Identities !== null
         ? deserializeAws_restJson1IdentityMap(output.Identities, context)
         : undefined,
-    PolicyArn: output.PolicyArn !== undefined && output.PolicyArn !== null ? output.PolicyArn : undefined,
+    PolicyArn: __expectString(output.PolicyArn),
   } as any;
 };
 
@@ -18431,10 +18404,8 @@ const deserializeAws_restJson1IAMPolicyAssignmentSummary = (
   context: __SerdeContext
 ): IAMPolicyAssignmentSummary => {
   return {
-    AssignmentName:
-      output.AssignmentName !== undefined && output.AssignmentName !== null ? output.AssignmentName : undefined,
-    AssignmentStatus:
-      output.AssignmentStatus !== undefined && output.AssignmentStatus !== null ? output.AssignmentStatus : undefined,
+    AssignmentName: __expectString(output.AssignmentName),
+    AssignmentStatus: __expectString(output.AssignmentStatus),
   } as any;
 };
 
@@ -18471,13 +18442,13 @@ const deserializeAws_restJson1IdentityNameList = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1Ingestion = (output: any, context: __SerdeContext): Ingestion => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
@@ -18486,24 +18457,16 @@ const deserializeAws_restJson1Ingestion = (output: any, context: __SerdeContext)
       output.ErrorInfo !== undefined && output.ErrorInfo !== null
         ? deserializeAws_restJson1ErrorInfo(output.ErrorInfo, context)
         : undefined,
-    IngestionId: output.IngestionId !== undefined && output.IngestionId !== null ? output.IngestionId : undefined,
-    IngestionSizeInBytes:
-      output.IngestionSizeInBytes !== undefined && output.IngestionSizeInBytes !== null
-        ? output.IngestionSizeInBytes
-        : undefined,
-    IngestionStatus:
-      output.IngestionStatus !== undefined && output.IngestionStatus !== null ? output.IngestionStatus : undefined,
-    IngestionTimeInSeconds:
-      output.IngestionTimeInSeconds !== undefined && output.IngestionTimeInSeconds !== null
-        ? output.IngestionTimeInSeconds
-        : undefined,
+    IngestionId: __expectString(output.IngestionId),
+    IngestionSizeInBytes: __expectNumber(output.IngestionSizeInBytes),
+    IngestionStatus: __expectString(output.IngestionStatus),
+    IngestionTimeInSeconds: __expectNumber(output.IngestionTimeInSeconds),
     QueueInfo:
       output.QueueInfo !== undefined && output.QueueInfo !== null
         ? deserializeAws_restJson1QueueInfo(output.QueueInfo, context)
         : undefined,
-    RequestSource:
-      output.RequestSource !== undefined && output.RequestSource !== null ? output.RequestSource : undefined,
-    RequestType: output.RequestType !== undefined && output.RequestType !== null ? output.RequestType : undefined,
+    RequestSource: __expectString(output.RequestSource),
+    RequestType: __expectString(output.RequestType),
     RowInfo:
       output.RowInfo !== undefined && output.RowInfo !== null
         ? deserializeAws_restJson1RowInfo(output.RowInfo, context)
@@ -18524,8 +18487,8 @@ const deserializeAws_restJson1Ingestions = (output: any, context: __SerdeContext
 
 const deserializeAws_restJson1InputColumn = (output: any, context: __SerdeContext): InputColumn => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Name: __expectString(output.Name),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -18542,7 +18505,7 @@ const deserializeAws_restJson1InputColumnList = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1JiraParameters = (output: any, context: __SerdeContext): JiraParameters => {
   return {
-    SiteBaseUrl: output.SiteBaseUrl !== undefined && output.SiteBaseUrl !== null ? output.SiteBaseUrl : undefined,
+    SiteBaseUrl: __expectString(output.SiteBaseUrl),
   } as any;
 };
 
@@ -18552,26 +18515,26 @@ const deserializeAws_restJson1JoinInstruction = (output: any, context: __SerdeCo
       output.LeftJoinKeyProperties !== undefined && output.LeftJoinKeyProperties !== null
         ? deserializeAws_restJson1JoinKeyProperties(output.LeftJoinKeyProperties, context)
         : undefined,
-    LeftOperand: output.LeftOperand !== undefined && output.LeftOperand !== null ? output.LeftOperand : undefined,
-    OnClause: output.OnClause !== undefined && output.OnClause !== null ? output.OnClause : undefined,
+    LeftOperand: __expectString(output.LeftOperand),
+    OnClause: __expectString(output.OnClause),
     RightJoinKeyProperties:
       output.RightJoinKeyProperties !== undefined && output.RightJoinKeyProperties !== null
         ? deserializeAws_restJson1JoinKeyProperties(output.RightJoinKeyProperties, context)
         : undefined,
-    RightOperand: output.RightOperand !== undefined && output.RightOperand !== null ? output.RightOperand : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    RightOperand: __expectString(output.RightOperand),
+    Type: __expectString(output.Type),
   } as any;
 };
 
 const deserializeAws_restJson1JoinKeyProperties = (output: any, context: __SerdeContext): JoinKeyProperties => {
   return {
-    UniqueKey: output.UniqueKey !== undefined && output.UniqueKey !== null ? output.UniqueKey : undefined,
+    UniqueKey: __expectBoolean(output.UniqueKey),
   } as any;
 };
 
 const deserializeAws_restJson1LogicalTable = (output: any, context: __SerdeContext): LogicalTable => {
   return {
-    Alias: output.Alias !== undefined && output.Alias !== null ? output.Alias : undefined,
+    Alias: __expectString(output.Alias),
     DataTransforms:
       output.DataTransforms !== undefined && output.DataTransforms !== null
         ? deserializeAws_restJson1TransformOperationList(output.DataTransforms, context)
@@ -18604,57 +18567,53 @@ const deserializeAws_restJson1LogicalTableSource = (output: any, context: __Serd
       output.JoinInstruction !== undefined && output.JoinInstruction !== null
         ? deserializeAws_restJson1JoinInstruction(output.JoinInstruction, context)
         : undefined,
-    PhysicalTableId:
-      output.PhysicalTableId !== undefined && output.PhysicalTableId !== null ? output.PhysicalTableId : undefined,
+    PhysicalTableId: __expectString(output.PhysicalTableId),
   } as any;
 };
 
 const deserializeAws_restJson1ManifestFileLocation = (output: any, context: __SerdeContext): ManifestFileLocation => {
   return {
-    Bucket: output.Bucket !== undefined && output.Bucket !== null ? output.Bucket : undefined,
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
+    Bucket: __expectString(output.Bucket),
+    Key: __expectString(output.Key),
   } as any;
 };
 
 const deserializeAws_restJson1MarginStyle = (output: any, context: __SerdeContext): MarginStyle => {
   return {
-    Show: output.Show !== undefined && output.Show !== null ? output.Show : undefined,
+    Show: __expectBoolean(output.Show),
   } as any;
 };
 
 const deserializeAws_restJson1MariaDbParameters = (output: any, context: __SerdeContext): MariaDbParameters => {
   return {
-    Database: output.Database !== undefined && output.Database !== null ? output.Database : undefined,
-    Host: output.Host !== undefined && output.Host !== null ? output.Host : undefined,
-    Port: output.Port !== undefined && output.Port !== null ? output.Port : undefined,
+    Database: __expectString(output.Database),
+    Host: __expectString(output.Host),
+    Port: __expectNumber(output.Port),
   } as any;
 };
 
 const deserializeAws_restJson1MySqlParameters = (output: any, context: __SerdeContext): MySqlParameters => {
   return {
-    Database: output.Database !== undefined && output.Database !== null ? output.Database : undefined,
-    Host: output.Host !== undefined && output.Host !== null ? output.Host : undefined,
-    Port: output.Port !== undefined && output.Port !== null ? output.Port : undefined,
+    Database: __expectString(output.Database),
+    Host: __expectString(output.Host),
+    Port: __expectNumber(output.Port),
   } as any;
 };
 
 const deserializeAws_restJson1NamespaceError = (output: any, context: __SerdeContext): NamespaceError => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Message: __expectString(output.Message),
+    Type: __expectString(output.Type),
   } as any;
 };
 
 const deserializeAws_restJson1NamespaceInfoV2 = (output: any, context: __SerdeContext): NamespaceInfoV2 => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    CapacityRegion:
-      output.CapacityRegion !== undefined && output.CapacityRegion !== null ? output.CapacityRegion : undefined,
-    CreationStatus:
-      output.CreationStatus !== undefined && output.CreationStatus !== null ? output.CreationStatus : undefined,
-    IdentityStore:
-      output.IdentityStore !== undefined && output.IdentityStore !== null ? output.IdentityStore : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Arn: __expectString(output.Arn),
+    CapacityRegion: __expectString(output.CapacityRegion),
+    CreationStatus: __expectString(output.CreationStatus),
+    IdentityStore: __expectString(output.IdentityStore),
+    Name: __expectString(output.Name),
     NamespaceError:
       output.NamespaceError !== undefined && output.NamespaceError !== null
         ? deserializeAws_restJson1NamespaceError(output.NamespaceError, context)
@@ -18675,17 +18634,17 @@ const deserializeAws_restJson1Namespaces = (output: any, context: __SerdeContext
 
 const deserializeAws_restJson1OracleParameters = (output: any, context: __SerdeContext): OracleParameters => {
   return {
-    Database: output.Database !== undefined && output.Database !== null ? output.Database : undefined,
-    Host: output.Host !== undefined && output.Host !== null ? output.Host : undefined,
-    Port: output.Port !== undefined && output.Port !== null ? output.Port : undefined,
+    Database: __expectString(output.Database),
+    Host: __expectString(output.Host),
+    Port: __expectNumber(output.Port),
   } as any;
 };
 
 const deserializeAws_restJson1OutputColumn = (output: any, context: __SerdeContext): OutputColumn => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Description: __expectString(output.Description),
+    Name: __expectString(output.Name),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -18736,17 +18695,17 @@ const deserializeAws_restJson1PhysicalTableMap = (
 
 const deserializeAws_restJson1PostgreSqlParameters = (output: any, context: __SerdeContext): PostgreSqlParameters => {
   return {
-    Database: output.Database !== undefined && output.Database !== null ? output.Database : undefined,
-    Host: output.Host !== undefined && output.Host !== null ? output.Host : undefined,
-    Port: output.Port !== undefined && output.Port !== null ? output.Port : undefined,
+    Database: __expectString(output.Database),
+    Host: __expectString(output.Host),
+    Port: __expectNumber(output.Port),
   } as any;
 };
 
 const deserializeAws_restJson1PrestoParameters = (output: any, context: __SerdeContext): PrestoParameters => {
   return {
-    Catalog: output.Catalog !== undefined && output.Catalog !== null ? output.Catalog : undefined,
-    Host: output.Host !== undefined && output.Host !== null ? output.Host : undefined,
-    Port: output.Port !== undefined && output.Port !== null ? output.Port : undefined,
+    Catalog: __expectString(output.Catalog),
+    Host: __expectString(output.Host),
+    Port: __expectNumber(output.Port),
   } as any;
 };
 
@@ -18757,7 +18716,7 @@ const deserializeAws_restJson1PrincipalList = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -18768,7 +18727,7 @@ const deserializeAws_restJson1ProjectedColumnList = (output: any, context: __Ser
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -18783,50 +18742,44 @@ const deserializeAws_restJson1ProjectOperation = (output: any, context: __SerdeC
 
 const deserializeAws_restJson1QueueInfo = (output: any, context: __SerdeContext): QueueInfo => {
   return {
-    QueuedIngestion:
-      output.QueuedIngestion !== undefined && output.QueuedIngestion !== null ? output.QueuedIngestion : undefined,
-    WaitingOnIngestion:
-      output.WaitingOnIngestion !== undefined && output.WaitingOnIngestion !== null
-        ? output.WaitingOnIngestion
-        : undefined,
+    QueuedIngestion: __expectString(output.QueuedIngestion),
+    WaitingOnIngestion: __expectString(output.WaitingOnIngestion),
   } as any;
 };
 
 const deserializeAws_restJson1RdsParameters = (output: any, context: __SerdeContext): RdsParameters => {
   return {
-    Database: output.Database !== undefined && output.Database !== null ? output.Database : undefined,
-    InstanceId: output.InstanceId !== undefined && output.InstanceId !== null ? output.InstanceId : undefined,
+    Database: __expectString(output.Database),
+    InstanceId: __expectString(output.InstanceId),
   } as any;
 };
 
 const deserializeAws_restJson1RedshiftParameters = (output: any, context: __SerdeContext): RedshiftParameters => {
   return {
-    ClusterId: output.ClusterId !== undefined && output.ClusterId !== null ? output.ClusterId : undefined,
-    Database: output.Database !== undefined && output.Database !== null ? output.Database : undefined,
-    Host: output.Host !== undefined && output.Host !== null ? output.Host : undefined,
-    Port: output.Port !== undefined && output.Port !== null ? output.Port : undefined,
+    ClusterId: __expectString(output.ClusterId),
+    Database: __expectString(output.Database),
+    Host: __expectString(output.Host),
+    Port: __expectNumber(output.Port),
   } as any;
 };
 
 const deserializeAws_restJson1RelationalTable = (output: any, context: __SerdeContext): RelationalTable => {
   return {
-    Catalog: output.Catalog !== undefined && output.Catalog !== null ? output.Catalog : undefined,
-    DataSourceArn:
-      output.DataSourceArn !== undefined && output.DataSourceArn !== null ? output.DataSourceArn : undefined,
+    Catalog: __expectString(output.Catalog),
+    DataSourceArn: __expectString(output.DataSourceArn),
     InputColumns:
       output.InputColumns !== undefined && output.InputColumns !== null
         ? deserializeAws_restJson1InputColumnList(output.InputColumns, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Schema: output.Schema !== undefined && output.Schema !== null ? output.Schema : undefined,
+    Name: __expectString(output.Name),
+    Schema: __expectString(output.Schema),
   } as any;
 };
 
 const deserializeAws_restJson1RenameColumnOperation = (output: any, context: __SerdeContext): RenameColumnOperation => {
   return {
-    ColumnName: output.ColumnName !== undefined && output.ColumnName !== null ? output.ColumnName : undefined,
-    NewColumnName:
-      output.NewColumnName !== undefined && output.NewColumnName !== null ? output.NewColumnName : undefined,
+    ColumnName: __expectString(output.ColumnName),
+    NewColumnName: __expectString(output.NewColumnName),
   } as any;
 };
 
@@ -18836,7 +18789,7 @@ const deserializeAws_restJson1ResourcePermission = (output: any, context: __Serd
       output.Actions !== undefined && output.Actions !== null
         ? deserializeAws_restJson1ActionList(output.Actions, context)
         : undefined,
-    Principal: output.Principal !== undefined && output.Principal !== null ? output.Principal : undefined,
+    Principal: __expectString(output.Principal),
   } as any;
 };
 
@@ -18853,8 +18806,8 @@ const deserializeAws_restJson1ResourcePermissionList = (output: any, context: __
 
 const deserializeAws_restJson1RowInfo = (output: any, context: __SerdeContext): RowInfo => {
   return {
-    RowsDropped: output.RowsDropped !== undefined && output.RowsDropped !== null ? output.RowsDropped : undefined,
-    RowsIngested: output.RowsIngested !== undefined && output.RowsIngested !== null ? output.RowsIngested : undefined,
+    RowsDropped: __expectNumber(output.RowsDropped),
+    RowsIngested: __expectNumber(output.RowsIngested),
   } as any;
 };
 
@@ -18863,12 +18816,10 @@ const deserializeAws_restJson1RowLevelPermissionDataSet = (
   context: __SerdeContext
 ): RowLevelPermissionDataSet => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    FormatVersion:
-      output.FormatVersion !== undefined && output.FormatVersion !== null ? output.FormatVersion : undefined,
-    Namespace: output.Namespace !== undefined && output.Namespace !== null ? output.Namespace : undefined,
-    PermissionPolicy:
-      output.PermissionPolicy !== undefined && output.PermissionPolicy !== null ? output.PermissionPolicy : undefined,
+    Arn: __expectString(output.Arn),
+    FormatVersion: __expectString(output.FormatVersion),
+    Namespace: __expectString(output.Namespace),
+    PermissionPolicy: __expectString(output.PermissionPolicy),
   } as any;
 };
 
@@ -18883,8 +18834,7 @@ const deserializeAws_restJson1S3Parameters = (output: any, context: __SerdeConte
 
 const deserializeAws_restJson1S3Source = (output: any, context: __SerdeContext): S3Source => {
   return {
-    DataSourceArn:
-      output.DataSourceArn !== undefined && output.DataSourceArn !== null ? output.DataSourceArn : undefined,
+    DataSourceArn: __expectString(output.DataSourceArn),
     InputColumns:
       output.InputColumns !== undefined && output.InputColumns !== null
         ? deserializeAws_restJson1InputColumnList(output.InputColumns, context)
@@ -18898,14 +18848,14 @@ const deserializeAws_restJson1S3Source = (output: any, context: __SerdeContext):
 
 const deserializeAws_restJson1ServiceNowParameters = (output: any, context: __SerdeContext): ServiceNowParameters => {
   return {
-    SiteBaseUrl: output.SiteBaseUrl !== undefined && output.SiteBaseUrl !== null ? output.SiteBaseUrl : undefined,
+    SiteBaseUrl: __expectString(output.SiteBaseUrl),
   } as any;
 };
 
 const deserializeAws_restJson1Sheet = (output: any, context: __SerdeContext): Sheet => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    SheetId: output.SheetId !== undefined && output.SheetId !== null ? output.SheetId : undefined,
+    Name: __expectString(output.Name),
+    SheetId: __expectString(output.SheetId),
   } as any;
 };
 
@@ -18935,43 +18885,43 @@ const deserializeAws_restJson1SheetStyle = (output: any, context: __SerdeContext
 
 const deserializeAws_restJson1SnowflakeParameters = (output: any, context: __SerdeContext): SnowflakeParameters => {
   return {
-    Database: output.Database !== undefined && output.Database !== null ? output.Database : undefined,
-    Host: output.Host !== undefined && output.Host !== null ? output.Host : undefined,
-    Warehouse: output.Warehouse !== undefined && output.Warehouse !== null ? output.Warehouse : undefined,
+    Database: __expectString(output.Database),
+    Host: __expectString(output.Host),
+    Warehouse: __expectString(output.Warehouse),
   } as any;
 };
 
 const deserializeAws_restJson1SparkParameters = (output: any, context: __SerdeContext): SparkParameters => {
   return {
-    Host: output.Host !== undefined && output.Host !== null ? output.Host : undefined,
-    Port: output.Port !== undefined && output.Port !== null ? output.Port : undefined,
+    Host: __expectString(output.Host),
+    Port: __expectNumber(output.Port),
   } as any;
 };
 
 const deserializeAws_restJson1SqlServerParameters = (output: any, context: __SerdeContext): SqlServerParameters => {
   return {
-    Database: output.Database !== undefined && output.Database !== null ? output.Database : undefined,
-    Host: output.Host !== undefined && output.Host !== null ? output.Host : undefined,
-    Port: output.Port !== undefined && output.Port !== null ? output.Port : undefined,
+    Database: __expectString(output.Database),
+    Host: __expectString(output.Host),
+    Port: __expectNumber(output.Port),
   } as any;
 };
 
 const deserializeAws_restJson1SslProperties = (output: any, context: __SerdeContext): SslProperties => {
   return {
-    DisableSsl: output.DisableSsl !== undefined && output.DisableSsl !== null ? output.DisableSsl : undefined,
+    DisableSsl: __expectBoolean(output.DisableSsl),
   } as any;
 };
 
 const deserializeAws_restJson1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
 const deserializeAws_restJson1TagColumnOperation = (output: any, context: __SerdeContext): TagColumnOperation => {
   return {
-    ColumnName: output.ColumnName !== undefined && output.ColumnName !== null ? output.ColumnName : undefined,
+    ColumnName: __expectString(output.ColumnName),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_restJson1ColumnTagList(output.Tags, context)
@@ -18992,7 +18942,7 @@ const deserializeAws_restJson1TagList = (output: any, context: __SerdeContext): 
 
 const deserializeAws_restJson1Template = (output: any, context: __SerdeContext): Template => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
@@ -19001,8 +18951,8 @@ const deserializeAws_restJson1Template = (output: any, context: __SerdeContext):
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
         ? new Date(Math.round(output.LastUpdatedTime * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    TemplateId: output.TemplateId !== undefined && output.TemplateId !== null ? output.TemplateId : undefined,
+    Name: __expectString(output.Name),
+    TemplateId: __expectString(output.TemplateId),
     Version:
       output.Version !== undefined && output.Version !== null
         ? deserializeAws_restJson1TemplateVersion(output.Version, context)
@@ -19012,12 +18962,9 @@ const deserializeAws_restJson1Template = (output: any, context: __SerdeContext):
 
 const deserializeAws_restJson1TemplateAlias = (output: any, context: __SerdeContext): TemplateAlias => {
   return {
-    AliasName: output.AliasName !== undefined && output.AliasName !== null ? output.AliasName : undefined,
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    TemplateVersionNumber:
-      output.TemplateVersionNumber !== undefined && output.TemplateVersionNumber !== null
-        ? output.TemplateVersionNumber
-        : undefined,
+    AliasName: __expectString(output.AliasName),
+    Arn: __expectString(output.Arn),
+    TemplateVersionNumber: __expectNumber(output.TemplateVersionNumber),
   } as any;
 };
 
@@ -19034,8 +18981,8 @@ const deserializeAws_restJson1TemplateAliasList = (output: any, context: __Serde
 
 const deserializeAws_restJson1TemplateError = (output: any, context: __SerdeContext): TemplateError => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Message: __expectString(output.Message),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -19052,7 +18999,7 @@ const deserializeAws_restJson1TemplateErrorList = (output: any, context: __Serde
 
 const deserializeAws_restJson1TemplateSummary = (output: any, context: __SerdeContext): TemplateSummary => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
@@ -19061,12 +19008,9 @@ const deserializeAws_restJson1TemplateSummary = (output: any, context: __SerdeCo
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
         ? new Date(Math.round(output.LastUpdatedTime * 1000))
         : undefined,
-    LatestVersionNumber:
-      output.LatestVersionNumber !== undefined && output.LatestVersionNumber !== null
-        ? output.LatestVersionNumber
-        : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    TemplateId: output.TemplateId !== undefined && output.TemplateId !== null ? output.TemplateId : undefined,
+    LatestVersionNumber: __expectNumber(output.LatestVersionNumber),
+    Name: __expectString(output.Name),
+    TemplateId: __expectString(output.TemplateId),
   } as any;
 };
 
@@ -19091,7 +19035,7 @@ const deserializeAws_restJson1TemplateVersion = (output: any, context: __SerdeCo
       output.DataSetConfigurations !== undefined && output.DataSetConfigurations !== null
         ? deserializeAws_restJson1DataSetConfigurationList(output.DataSetConfigurations, context)
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     Errors:
       output.Errors !== undefined && output.Errors !== null
         ? deserializeAws_restJson1TemplateErrorList(output.Errors, context)
@@ -19100,12 +19044,10 @@ const deserializeAws_restJson1TemplateVersion = (output: any, context: __SerdeCo
       output.Sheets !== undefined && output.Sheets !== null
         ? deserializeAws_restJson1SheetList(output.Sheets, context)
         : undefined,
-    SourceEntityArn:
-      output.SourceEntityArn !== undefined && output.SourceEntityArn !== null ? output.SourceEntityArn : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    ThemeArn: output.ThemeArn !== undefined && output.ThemeArn !== null ? output.ThemeArn : undefined,
-    VersionNumber:
-      output.VersionNumber !== undefined && output.VersionNumber !== null ? output.VersionNumber : undefined,
+    SourceEntityArn: __expectString(output.SourceEntityArn),
+    Status: __expectString(output.Status),
+    ThemeArn: __expectString(output.ThemeArn),
+    VersionNumber: __expectNumber(output.VersionNumber),
   } as any;
 };
 
@@ -19114,15 +19056,14 @@ const deserializeAws_restJson1TemplateVersionSummary = (
   context: __SerdeContext
 ): TemplateVersionSummary => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    VersionNumber:
-      output.VersionNumber !== undefined && output.VersionNumber !== null ? output.VersionNumber : undefined,
+    Description: __expectString(output.Description),
+    Status: __expectString(output.Status),
+    VersionNumber: __expectNumber(output.VersionNumber),
   } as any;
 };
 
@@ -19142,15 +19083,15 @@ const deserializeAws_restJson1TemplateVersionSummaryList = (
 
 const deserializeAws_restJson1TeradataParameters = (output: any, context: __SerdeContext): TeradataParameters => {
   return {
-    Database: output.Database !== undefined && output.Database !== null ? output.Database : undefined,
-    Host: output.Host !== undefined && output.Host !== null ? output.Host : undefined,
-    Port: output.Port !== undefined && output.Port !== null ? output.Port : undefined,
+    Database: __expectString(output.Database),
+    Host: __expectString(output.Host),
+    Port: __expectNumber(output.Port),
   } as any;
 };
 
 const deserializeAws_restJson1Theme = (output: any, context: __SerdeContext): Theme => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
@@ -19159,9 +19100,9 @@ const deserializeAws_restJson1Theme = (output: any, context: __SerdeContext): Th
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
         ? new Date(Math.round(output.LastUpdatedTime * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    ThemeId: output.ThemeId !== undefined && output.ThemeId !== null ? output.ThemeId : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Name: __expectString(output.Name),
+    ThemeId: __expectString(output.ThemeId),
+    Type: __expectString(output.Type),
     Version:
       output.Version !== undefined && output.Version !== null
         ? deserializeAws_restJson1ThemeVersion(output.Version, context)
@@ -19171,12 +19112,9 @@ const deserializeAws_restJson1Theme = (output: any, context: __SerdeContext): Th
 
 const deserializeAws_restJson1ThemeAlias = (output: any, context: __SerdeContext): ThemeAlias => {
   return {
-    AliasName: output.AliasName !== undefined && output.AliasName !== null ? output.AliasName : undefined,
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    ThemeVersionNumber:
-      output.ThemeVersionNumber !== undefined && output.ThemeVersionNumber !== null
-        ? output.ThemeVersionNumber
-        : undefined,
+    AliasName: __expectString(output.AliasName),
+    Arn: __expectString(output.Arn),
+    ThemeVersionNumber: __expectNumber(output.ThemeVersionNumber),
   } as any;
 };
 
@@ -19210,8 +19148,8 @@ const deserializeAws_restJson1ThemeConfiguration = (output: any, context: __Serd
 
 const deserializeAws_restJson1ThemeError = (output: any, context: __SerdeContext): ThemeError => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Message: __expectString(output.Message),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -19228,7 +19166,7 @@ const deserializeAws_restJson1ThemeErrorList = (output: any, context: __SerdeCon
 
 const deserializeAws_restJson1ThemeSummary = (output: any, context: __SerdeContext): ThemeSummary => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
@@ -19237,12 +19175,9 @@ const deserializeAws_restJson1ThemeSummary = (output: any, context: __SerdeConte
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
         ? new Date(Math.round(output.LastUpdatedTime * 1000))
         : undefined,
-    LatestVersionNumber:
-      output.LatestVersionNumber !== undefined && output.LatestVersionNumber !== null
-        ? output.LatestVersionNumber
-        : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    ThemeId: output.ThemeId !== undefined && output.ThemeId !== null ? output.ThemeId : undefined,
+    LatestVersionNumber: __expectNumber(output.LatestVersionNumber),
+    Name: __expectString(output.Name),
+    ThemeId: __expectString(output.ThemeId),
   } as any;
 };
 
@@ -19259,8 +19194,8 @@ const deserializeAws_restJson1ThemeSummaryList = (output: any, context: __SerdeC
 
 const deserializeAws_restJson1ThemeVersion = (output: any, context: __SerdeContext): ThemeVersion => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    BaseThemeId: output.BaseThemeId !== undefined && output.BaseThemeId !== null ? output.BaseThemeId : undefined,
+    Arn: __expectString(output.Arn),
+    BaseThemeId: __expectString(output.BaseThemeId),
     Configuration:
       output.Configuration !== undefined && output.Configuration !== null
         ? deserializeAws_restJson1ThemeConfiguration(output.Configuration, context)
@@ -19269,28 +19204,26 @@ const deserializeAws_restJson1ThemeVersion = (output: any, context: __SerdeConte
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     Errors:
       output.Errors !== undefined && output.Errors !== null
         ? deserializeAws_restJson1ThemeErrorList(output.Errors, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    VersionNumber:
-      output.VersionNumber !== undefined && output.VersionNumber !== null ? output.VersionNumber : undefined,
+    Status: __expectString(output.Status),
+    VersionNumber: __expectNumber(output.VersionNumber),
   } as any;
 };
 
 const deserializeAws_restJson1ThemeVersionSummary = (output: any, context: __SerdeContext): ThemeVersionSummary => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    VersionNumber:
-      output.VersionNumber !== undefined && output.VersionNumber !== null ? output.VersionNumber : undefined,
+    Description: __expectString(output.Description),
+    Status: __expectString(output.Status),
+    VersionNumber: __expectNumber(output.VersionNumber),
   } as any;
 };
 
@@ -19377,93 +19310,55 @@ const deserializeAws_restJson1TransformOperationList = (output: any, context: __
 
 const deserializeAws_restJson1TwitterParameters = (output: any, context: __SerdeContext): TwitterParameters => {
   return {
-    MaxRows: output.MaxRows !== undefined && output.MaxRows !== null ? output.MaxRows : undefined,
-    Query: output.Query !== undefined && output.Query !== null ? output.Query : undefined,
+    MaxRows: __expectNumber(output.MaxRows),
+    Query: __expectString(output.Query),
   } as any;
 };
 
 const deserializeAws_restJson1UIColorPalette = (output: any, context: __SerdeContext): UIColorPalette => {
   return {
-    Accent: output.Accent !== undefined && output.Accent !== null ? output.Accent : undefined,
-    AccentForeground:
-      output.AccentForeground !== undefined && output.AccentForeground !== null ? output.AccentForeground : undefined,
-    Danger: output.Danger !== undefined && output.Danger !== null ? output.Danger : undefined,
-    DangerForeground:
-      output.DangerForeground !== undefined && output.DangerForeground !== null ? output.DangerForeground : undefined,
-    Dimension: output.Dimension !== undefined && output.Dimension !== null ? output.Dimension : undefined,
-    DimensionForeground:
-      output.DimensionForeground !== undefined && output.DimensionForeground !== null
-        ? output.DimensionForeground
-        : undefined,
-    Measure: output.Measure !== undefined && output.Measure !== null ? output.Measure : undefined,
-    MeasureForeground:
-      output.MeasureForeground !== undefined && output.MeasureForeground !== null
-        ? output.MeasureForeground
-        : undefined,
-    PrimaryBackground:
-      output.PrimaryBackground !== undefined && output.PrimaryBackground !== null
-        ? output.PrimaryBackground
-        : undefined,
-    PrimaryForeground:
-      output.PrimaryForeground !== undefined && output.PrimaryForeground !== null
-        ? output.PrimaryForeground
-        : undefined,
-    SecondaryBackground:
-      output.SecondaryBackground !== undefined && output.SecondaryBackground !== null
-        ? output.SecondaryBackground
-        : undefined,
-    SecondaryForeground:
-      output.SecondaryForeground !== undefined && output.SecondaryForeground !== null
-        ? output.SecondaryForeground
-        : undefined,
-    Success: output.Success !== undefined && output.Success !== null ? output.Success : undefined,
-    SuccessForeground:
-      output.SuccessForeground !== undefined && output.SuccessForeground !== null
-        ? output.SuccessForeground
-        : undefined,
-    Warning: output.Warning !== undefined && output.Warning !== null ? output.Warning : undefined,
-    WarningForeground:
-      output.WarningForeground !== undefined && output.WarningForeground !== null
-        ? output.WarningForeground
-        : undefined,
+    Accent: __expectString(output.Accent),
+    AccentForeground: __expectString(output.AccentForeground),
+    Danger: __expectString(output.Danger),
+    DangerForeground: __expectString(output.DangerForeground),
+    Dimension: __expectString(output.Dimension),
+    DimensionForeground: __expectString(output.DimensionForeground),
+    Measure: __expectString(output.Measure),
+    MeasureForeground: __expectString(output.MeasureForeground),
+    PrimaryBackground: __expectString(output.PrimaryBackground),
+    PrimaryForeground: __expectString(output.PrimaryForeground),
+    SecondaryBackground: __expectString(output.SecondaryBackground),
+    SecondaryForeground: __expectString(output.SecondaryForeground),
+    Success: __expectString(output.Success),
+    SuccessForeground: __expectString(output.SuccessForeground),
+    Warning: __expectString(output.Warning),
+    WarningForeground: __expectString(output.WarningForeground),
   } as any;
 };
 
 const deserializeAws_restJson1UploadSettings = (output: any, context: __SerdeContext): UploadSettings => {
   return {
-    ContainsHeader:
-      output.ContainsHeader !== undefined && output.ContainsHeader !== null ? output.ContainsHeader : undefined,
-    Delimiter: output.Delimiter !== undefined && output.Delimiter !== null ? output.Delimiter : undefined,
-    Format: output.Format !== undefined && output.Format !== null ? output.Format : undefined,
-    StartFromRow: output.StartFromRow !== undefined && output.StartFromRow !== null ? output.StartFromRow : undefined,
-    TextQualifier:
-      output.TextQualifier !== undefined && output.TextQualifier !== null ? output.TextQualifier : undefined,
+    ContainsHeader: __expectBoolean(output.ContainsHeader),
+    Delimiter: __expectString(output.Delimiter),
+    Format: __expectString(output.Format),
+    StartFromRow: __expectNumber(output.StartFromRow),
+    TextQualifier: __expectString(output.TextQualifier),
   } as any;
 };
 
 const deserializeAws_restJson1User = (output: any, context: __SerdeContext): User => {
   return {
-    Active: output.Active !== undefined && output.Active !== null ? output.Active : undefined,
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    CustomPermissionsName:
-      output.CustomPermissionsName !== undefined && output.CustomPermissionsName !== null
-        ? output.CustomPermissionsName
-        : undefined,
-    Email: output.Email !== undefined && output.Email !== null ? output.Email : undefined,
-    ExternalLoginFederationProviderType:
-      output.ExternalLoginFederationProviderType !== undefined && output.ExternalLoginFederationProviderType !== null
-        ? output.ExternalLoginFederationProviderType
-        : undefined,
-    ExternalLoginFederationProviderUrl:
-      output.ExternalLoginFederationProviderUrl !== undefined && output.ExternalLoginFederationProviderUrl !== null
-        ? output.ExternalLoginFederationProviderUrl
-        : undefined,
-    ExternalLoginId:
-      output.ExternalLoginId !== undefined && output.ExternalLoginId !== null ? output.ExternalLoginId : undefined,
-    IdentityType: output.IdentityType !== undefined && output.IdentityType !== null ? output.IdentityType : undefined,
-    PrincipalId: output.PrincipalId !== undefined && output.PrincipalId !== null ? output.PrincipalId : undefined,
-    Role: output.Role !== undefined && output.Role !== null ? output.Role : undefined,
-    UserName: output.UserName !== undefined && output.UserName !== null ? output.UserName : undefined,
+    Active: __expectBoolean(output.Active),
+    Arn: __expectString(output.Arn),
+    CustomPermissionsName: __expectString(output.CustomPermissionsName),
+    Email: __expectString(output.Email),
+    ExternalLoginFederationProviderType: __expectString(output.ExternalLoginFederationProviderType),
+    ExternalLoginFederationProviderUrl: __expectString(output.ExternalLoginFederationProviderUrl),
+    ExternalLoginId: __expectString(output.ExternalLoginId),
+    IdentityType: __expectString(output.IdentityType),
+    PrincipalId: __expectString(output.PrincipalId),
+    Role: __expectString(output.Role),
+    UserName: __expectString(output.UserName),
   } as any;
 };
 
@@ -19483,8 +19378,7 @@ const deserializeAws_restJson1VpcConnectionProperties = (
   context: __SerdeContext
 ): VpcConnectionProperties => {
   return {
-    VpcConnectionArn:
-      output.VpcConnectionArn !== undefined && output.VpcConnectionArn !== null ? output.VpcConnectionArn : undefined,
+    VpcConnectionArn: __expectString(output.VpcConnectionArn),
   } as any;
 };
 

--- a/clients/client-ram/protocols/Aws_restJson1.ts
+++ b/clients/client-ram/protocols/Aws_restJson1.ts
@@ -106,6 +106,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -839,7 +841,7 @@ export const deserializeAws_restJson1AcceptResourceShareInvitationCommand = asyn
   };
   const data: any = await parseBody(output.body, context);
   if (data.clientToken !== undefined && data.clientToken !== null) {
-    contents.clientToken = data.clientToken;
+    contents.clientToken = __expectString(data.clientToken);
   }
   if (data.resourceShareInvitation !== undefined && data.resourceShareInvitation !== null) {
     contents.resourceShareInvitation = deserializeAws_restJson1ResourceShareInvitation(
@@ -979,7 +981,7 @@ export const deserializeAws_restJson1AssociateResourceShareCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.clientToken !== undefined && data.clientToken !== null) {
-    contents.clientToken = data.clientToken;
+    contents.clientToken = __expectString(data.clientToken);
   }
   if (data.resourceShareAssociations !== undefined && data.resourceShareAssociations !== null) {
     contents.resourceShareAssociations = deserializeAws_restJson1ResourceShareAssociationList(
@@ -1113,10 +1115,10 @@ export const deserializeAws_restJson1AssociateResourceSharePermissionCommand = a
   };
   const data: any = await parseBody(output.body, context);
   if (data.clientToken !== undefined && data.clientToken !== null) {
-    contents.clientToken = data.clientToken;
+    contents.clientToken = __expectString(data.clientToken);
   }
   if (data.returnValue !== undefined && data.returnValue !== null) {
-    contents.returnValue = data.returnValue;
+    contents.returnValue = __expectBoolean(data.returnValue);
   }
   return Promise.resolve(contents);
 };
@@ -1220,7 +1222,7 @@ export const deserializeAws_restJson1CreateResourceShareCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.clientToken !== undefined && data.clientToken !== null) {
-    contents.clientToken = data.clientToken;
+    contents.clientToken = __expectString(data.clientToken);
   }
   if (data.resourceShare !== undefined && data.resourceShare !== null) {
     contents.resourceShare = deserializeAws_restJson1ResourceShare(data.resourceShare, context);
@@ -1359,10 +1361,10 @@ export const deserializeAws_restJson1DeleteResourceShareCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.clientToken !== undefined && data.clientToken !== null) {
-    contents.clientToken = data.clientToken;
+    contents.clientToken = __expectString(data.clientToken);
   }
   if (data.returnValue !== undefined && data.returnValue !== null) {
-    contents.returnValue = data.returnValue;
+    contents.returnValue = __expectBoolean(data.returnValue);
   }
   return Promise.resolve(contents);
 };
@@ -1482,7 +1484,7 @@ export const deserializeAws_restJson1DisassociateResourceShareCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.clientToken !== undefined && data.clientToken !== null) {
-    contents.clientToken = data.clientToken;
+    contents.clientToken = __expectString(data.clientToken);
   }
   if (data.resourceShareAssociations !== undefined && data.resourceShareAssociations !== null) {
     contents.resourceShareAssociations = deserializeAws_restJson1ResourceShareAssociationList(
@@ -1616,10 +1618,10 @@ export const deserializeAws_restJson1DisassociateResourceSharePermissionCommand 
   };
   const data: any = await parseBody(output.body, context);
   if (data.clientToken !== undefined && data.clientToken !== null) {
-    contents.clientToken = data.clientToken;
+    contents.clientToken = __expectString(data.clientToken);
   }
   if (data.returnValue !== undefined && data.returnValue !== null) {
-    contents.returnValue = data.returnValue;
+    contents.returnValue = __expectBoolean(data.returnValue);
   }
   return Promise.resolve(contents);
 };
@@ -1730,7 +1732,7 @@ export const deserializeAws_restJson1EnableSharingWithAwsOrganizationCommand = a
   };
   const data: any = await parseBody(output.body, context);
   if (data.returnValue !== undefined && data.returnValue !== null) {
-    contents.returnValue = data.returnValue;
+    contents.returnValue = __expectBoolean(data.returnValue);
   }
   return Promise.resolve(contents);
 };
@@ -1897,7 +1899,7 @@ export const deserializeAws_restJson1GetResourcePoliciesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.policies !== undefined && data.policies !== null) {
     contents.policies = deserializeAws_restJson1PolicyList(data.policies, context);
@@ -1996,7 +1998,7 @@ export const deserializeAws_restJson1GetResourceShareAssociationsCommand = async
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.resourceShareAssociations !== undefined && data.resourceShareAssociations !== null) {
     contents.resourceShareAssociations = deserializeAws_restJson1ResourceShareAssociationList(
@@ -2106,7 +2108,7 @@ export const deserializeAws_restJson1GetResourceShareInvitationsCommand = async 
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.resourceShareInvitations !== undefined && data.resourceShareInvitations !== null) {
     contents.resourceShareInvitations = deserializeAws_restJson1ResourceShareInvitationList(
@@ -2224,7 +2226,7 @@ export const deserializeAws_restJson1GetResourceSharesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.resourceShares !== undefined && data.resourceShares !== null) {
     contents.resourceShares = deserializeAws_restJson1ResourceShareList(data.resourceShares, context);
@@ -2323,7 +2325,7 @@ export const deserializeAws_restJson1ListPendingInvitationResourcesCommand = asy
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.resources !== undefined && data.resources !== null) {
     contents.resources = deserializeAws_restJson1ResourceList(data.resources, context);
@@ -2449,7 +2451,7 @@ export const deserializeAws_restJson1ListPermissionsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.permissions !== undefined && data.permissions !== null) {
     contents.permissions = deserializeAws_restJson1ResourceSharePermissionList(data.permissions, context);
@@ -2540,7 +2542,7 @@ export const deserializeAws_restJson1ListPrincipalsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.principals !== undefined && data.principals !== null) {
     contents.principals = deserializeAws_restJson1PrincipalList(data.principals, context);
@@ -2639,7 +2641,7 @@ export const deserializeAws_restJson1ListResourcesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.resources !== undefined && data.resources !== null) {
     contents.resources = deserializeAws_restJson1ResourceList(data.resources, context);
@@ -2746,7 +2748,7 @@ export const deserializeAws_restJson1ListResourceSharePermissionsCommand = async
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.permissions !== undefined && data.permissions !== null) {
     contents.permissions = deserializeAws_restJson1ResourceSharePermissionList(data.permissions, context);
@@ -2853,7 +2855,7 @@ export const deserializeAws_restJson1ListResourceTypesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.resourceTypes !== undefined && data.resourceTypes !== null) {
     contents.resourceTypes = deserializeAws_restJson1ServiceNameAndResourceTypeList(data.resourceTypes, context);
@@ -2935,7 +2937,7 @@ export const deserializeAws_restJson1PromoteResourceShareCreatedFromPolicyComman
   };
   const data: any = await parseBody(output.body, context);
   if (data.returnValue !== undefined && data.returnValue !== null) {
-    contents.returnValue = data.returnValue;
+    contents.returnValue = __expectBoolean(data.returnValue);
   }
   return Promise.resolve(contents);
 };
@@ -3047,7 +3049,7 @@ export const deserializeAws_restJson1RejectResourceShareInvitationCommand = asyn
   };
   const data: any = await parseBody(output.body, context);
   if (data.clientToken !== undefined && data.clientToken !== null) {
-    contents.clientToken = data.clientToken;
+    contents.clientToken = __expectString(data.clientToken);
   }
   if (data.resourceShareInvitation !== undefined && data.resourceShareInvitation !== null) {
     contents.resourceShareInvitation = deserializeAws_restJson1ResourceShareInvitation(
@@ -3361,7 +3363,7 @@ export const deserializeAws_restJson1UpdateResourceShareCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.clientToken !== undefined && data.clientToken !== null) {
-    contents.clientToken = data.clientToken;
+    contents.clientToken = __expectString(data.clientToken);
   }
   if (data.resourceShare !== undefined && data.resourceShare !== null) {
     contents.resourceShare = deserializeAws_restJson1ResourceShare(data.resourceShare, context);
@@ -3482,7 +3484,7 @@ const deserializeAws_restJson1IdempotentParameterMismatchExceptionResponse = asy
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -3499,7 +3501,7 @@ const deserializeAws_restJson1InvalidClientTokenExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -3516,7 +3518,7 @@ const deserializeAws_restJson1InvalidMaxResultsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -3533,7 +3535,7 @@ const deserializeAws_restJson1InvalidNextTokenExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -3550,7 +3552,7 @@ const deserializeAws_restJson1InvalidParameterExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -3567,7 +3569,7 @@ const deserializeAws_restJson1InvalidResourceTypeExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -3584,7 +3586,7 @@ const deserializeAws_restJson1InvalidStateTransitionExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -3601,7 +3603,7 @@ const deserializeAws_restJson1MalformedArnExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -3618,7 +3620,7 @@ const deserializeAws_restJson1MissingRequiredParameterExceptionResponse = async 
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -3635,7 +3637,7 @@ const deserializeAws_restJson1OperationNotPermittedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -3652,7 +3654,7 @@ const deserializeAws_restJson1ResourceArnNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -3669,7 +3671,7 @@ const deserializeAws_restJson1ResourceShareInvitationAlreadyAcceptedExceptionRes
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -3686,7 +3688,7 @@ const deserializeAws_restJson1ResourceShareInvitationAlreadyRejectedExceptionRes
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -3703,7 +3705,7 @@ const deserializeAws_restJson1ResourceShareInvitationArnNotFoundExceptionRespons
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -3720,7 +3722,7 @@ const deserializeAws_restJson1ResourceShareInvitationExpiredExceptionResponse = 
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -3737,7 +3739,7 @@ const deserializeAws_restJson1ResourceShareLimitExceededExceptionResponse = asyn
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -3754,7 +3756,7 @@ const deserializeAws_restJson1ServerInternalExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -3771,7 +3773,7 @@ const deserializeAws_restJson1ServiceUnavailableExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -3788,7 +3790,7 @@ const deserializeAws_restJson1TagLimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -3805,7 +3807,7 @@ const deserializeAws_restJson1TagPolicyViolationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -3822,7 +3824,7 @@ const deserializeAws_restJson1UnknownResourceExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -3948,7 +3950,7 @@ const deserializeAws_restJson1PolicyList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3958,14 +3960,13 @@ const deserializeAws_restJson1Principal = (output: any, context: __SerdeContext)
       output.creationTime !== undefined && output.creationTime !== null
         ? new Date(Math.round(output.creationTime * 1000))
         : undefined,
-    external: output.external !== undefined && output.external !== null ? output.external : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    external: __expectBoolean(output.external),
+    id: __expectString(output.id),
     lastUpdatedTime:
       output.lastUpdatedTime !== undefined && output.lastUpdatedTime !== null
         ? new Date(Math.round(output.lastUpdatedTime * 1000))
         : undefined,
-    resourceShareArn:
-      output.resourceShareArn !== undefined && output.resourceShareArn !== null ? output.resourceShareArn : undefined,
+    resourceShareArn: __expectString(output.resourceShareArn),
   } as any;
 };
 
@@ -3982,7 +3983,7 @@ const deserializeAws_restJson1PrincipalList = (output: any, context: __SerdeCont
 
 const deserializeAws_restJson1Resource = (output: any, context: __SerdeContext): Resource => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
         ? new Date(Math.round(output.creationTime * 1000))
@@ -3991,14 +3992,11 @@ const deserializeAws_restJson1Resource = (output: any, context: __SerdeContext):
       output.lastUpdatedTime !== undefined && output.lastUpdatedTime !== null
         ? new Date(Math.round(output.lastUpdatedTime * 1000))
         : undefined,
-    resourceGroupArn:
-      output.resourceGroupArn !== undefined && output.resourceGroupArn !== null ? output.resourceGroupArn : undefined,
-    resourceShareArn:
-      output.resourceShareArn !== undefined && output.resourceShareArn !== null ? output.resourceShareArn : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    statusMessage:
-      output.statusMessage !== undefined && output.statusMessage !== null ? output.statusMessage : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    resourceGroupArn: __expectString(output.resourceGroupArn),
+    resourceShareArn: __expectString(output.resourceShareArn),
+    status: __expectString(output.status),
+    statusMessage: __expectString(output.statusMessage),
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -4015,27 +4013,21 @@ const deserializeAws_restJson1ResourceList = (output: any, context: __SerdeConte
 
 const deserializeAws_restJson1ResourceShare = (output: any, context: __SerdeContext): ResourceShare => {
   return {
-    allowExternalPrincipals:
-      output.allowExternalPrincipals !== undefined && output.allowExternalPrincipals !== null
-        ? output.allowExternalPrincipals
-        : undefined,
+    allowExternalPrincipals: __expectBoolean(output.allowExternalPrincipals),
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
         ? new Date(Math.round(output.creationTime * 1000))
         : undefined,
-    featureSet: output.featureSet !== undefined && output.featureSet !== null ? output.featureSet : undefined,
+    featureSet: __expectString(output.featureSet),
     lastUpdatedTime:
       output.lastUpdatedTime !== undefined && output.lastUpdatedTime !== null
         ? new Date(Math.round(output.lastUpdatedTime * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    owningAccountId:
-      output.owningAccountId !== undefined && output.owningAccountId !== null ? output.owningAccountId : undefined,
-    resourceShareArn:
-      output.resourceShareArn !== undefined && output.resourceShareArn !== null ? output.resourceShareArn : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    statusMessage:
-      output.statusMessage !== undefined && output.statusMessage !== null ? output.statusMessage : undefined,
+    name: __expectString(output.name),
+    owningAccountId: __expectString(output.owningAccountId),
+    resourceShareArn: __expectString(output.resourceShareArn),
+    status: __expectString(output.status),
+    statusMessage: __expectString(output.statusMessage),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1TagList(output.tags, context)
@@ -4048,28 +4040,21 @@ const deserializeAws_restJson1ResourceShareAssociation = (
   context: __SerdeContext
 ): ResourceShareAssociation => {
   return {
-    associatedEntity:
-      output.associatedEntity !== undefined && output.associatedEntity !== null ? output.associatedEntity : undefined,
-    associationType:
-      output.associationType !== undefined && output.associationType !== null ? output.associationType : undefined,
+    associatedEntity: __expectString(output.associatedEntity),
+    associationType: __expectString(output.associationType),
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
         ? new Date(Math.round(output.creationTime * 1000))
         : undefined,
-    external: output.external !== undefined && output.external !== null ? output.external : undefined,
+    external: __expectBoolean(output.external),
     lastUpdatedTime:
       output.lastUpdatedTime !== undefined && output.lastUpdatedTime !== null
         ? new Date(Math.round(output.lastUpdatedTime * 1000))
         : undefined,
-    resourceShareArn:
-      output.resourceShareArn !== undefined && output.resourceShareArn !== null ? output.resourceShareArn : undefined,
-    resourceShareName:
-      output.resourceShareName !== undefined && output.resourceShareName !== null
-        ? output.resourceShareName
-        : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    statusMessage:
-      output.statusMessage !== undefined && output.statusMessage !== null ? output.statusMessage : undefined,
+    resourceShareArn: __expectString(output.resourceShareArn),
+    resourceShareName: __expectString(output.resourceShareName),
+    status: __expectString(output.status),
+    statusMessage: __expectString(output.statusMessage),
   } as any;
 };
 
@@ -4096,28 +4081,17 @@ const deserializeAws_restJson1ResourceShareInvitation = (
       output.invitationTimestamp !== undefined && output.invitationTimestamp !== null
         ? new Date(Math.round(output.invitationTimestamp * 1000))
         : undefined,
-    receiverAccountId:
-      output.receiverAccountId !== undefined && output.receiverAccountId !== null
-        ? output.receiverAccountId
-        : undefined,
-    receiverArn: output.receiverArn !== undefined && output.receiverArn !== null ? output.receiverArn : undefined,
-    resourceShareArn:
-      output.resourceShareArn !== undefined && output.resourceShareArn !== null ? output.resourceShareArn : undefined,
+    receiverAccountId: __expectString(output.receiverAccountId),
+    receiverArn: __expectString(output.receiverArn),
+    resourceShareArn: __expectString(output.resourceShareArn),
     resourceShareAssociations:
       output.resourceShareAssociations !== undefined && output.resourceShareAssociations !== null
         ? deserializeAws_restJson1ResourceShareAssociationList(output.resourceShareAssociations, context)
         : undefined,
-    resourceShareInvitationArn:
-      output.resourceShareInvitationArn !== undefined && output.resourceShareInvitationArn !== null
-        ? output.resourceShareInvitationArn
-        : undefined,
-    resourceShareName:
-      output.resourceShareName !== undefined && output.resourceShareName !== null
-        ? output.resourceShareName
-        : undefined,
-    senderAccountId:
-      output.senderAccountId !== undefined && output.senderAccountId !== null ? output.senderAccountId : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    resourceShareInvitationArn: __expectString(output.resourceShareInvitationArn),
+    resourceShareName: __expectString(output.resourceShareName),
+    senderAccountId: __expectString(output.senderAccountId),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -4151,25 +4125,21 @@ const deserializeAws_restJson1ResourceSharePermissionDetail = (
   context: __SerdeContext
 ): ResourceSharePermissionDetail => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
         ? new Date(Math.round(output.creationTime * 1000))
         : undefined,
-    defaultVersion:
-      output.defaultVersion !== undefined && output.defaultVersion !== null ? output.defaultVersion : undefined,
-    isResourceTypeDefault:
-      output.isResourceTypeDefault !== undefined && output.isResourceTypeDefault !== null
-        ? output.isResourceTypeDefault
-        : undefined,
+    defaultVersion: __expectBoolean(output.defaultVersion),
+    isResourceTypeDefault: __expectBoolean(output.isResourceTypeDefault),
     lastUpdatedTime:
       output.lastUpdatedTime !== undefined && output.lastUpdatedTime !== null
         ? new Date(Math.round(output.lastUpdatedTime * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    permission: output.permission !== undefined && output.permission !== null ? output.permission : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    name: __expectString(output.name),
+    permission: __expectString(output.permission),
+    resourceType: __expectString(output.resourceType),
+    version: __expectString(output.version),
   } as any;
 };
 
@@ -4192,25 +4162,21 @@ const deserializeAws_restJson1ResourceSharePermissionSummary = (
   context: __SerdeContext
 ): ResourceSharePermissionSummary => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
         ? new Date(Math.round(output.creationTime * 1000))
         : undefined,
-    defaultVersion:
-      output.defaultVersion !== undefined && output.defaultVersion !== null ? output.defaultVersion : undefined,
-    isResourceTypeDefault:
-      output.isResourceTypeDefault !== undefined && output.isResourceTypeDefault !== null
-        ? output.isResourceTypeDefault
-        : undefined,
+    defaultVersion: __expectBoolean(output.defaultVersion),
+    isResourceTypeDefault: __expectBoolean(output.isResourceTypeDefault),
     lastUpdatedTime:
       output.lastUpdatedTime !== undefined && output.lastUpdatedTime !== null
         ? new Date(Math.round(output.lastUpdatedTime * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    name: __expectString(output.name),
+    resourceType: __expectString(output.resourceType),
+    status: __expectString(output.status),
+    version: __expectString(output.version),
   } as any;
 };
 
@@ -4219,8 +4185,8 @@ const deserializeAws_restJson1ServiceNameAndResourceType = (
   context: __SerdeContext
 ): ServiceNameAndResourceType => {
   return {
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
-    serviceName: output.serviceName !== undefined && output.serviceName !== null ? output.serviceName : undefined,
+    resourceType: __expectString(output.resourceType),
+    serviceName: __expectString(output.serviceName),
   } as any;
 };
 
@@ -4240,8 +4206,8 @@ const deserializeAws_restJson1ServiceNameAndResourceTypeList = (
 
 const deserializeAws_restJson1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    key: __expectString(output.key),
+    value: __expectString(output.value),
   } as any;
 };
 

--- a/clients/client-rds-data/protocols/Aws_restJson1.ts
+++ b/clients/client-rds-data/protocols/Aws_restJson1.ts
@@ -31,7 +31,12 @@ import {
   _Record,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -320,7 +325,7 @@ export const deserializeAws_restJson1BeginTransactionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.transactionId !== undefined && data.transactionId !== null) {
-    contents.transactionId = data.transactionId;
+    contents.transactionId = __expectString(data.transactionId);
   }
   return Promise.resolve(contents);
 };
@@ -407,7 +412,7 @@ export const deserializeAws_restJson1CommitTransactionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.transactionStatus !== undefined && data.transactionStatus !== null) {
-    contents.transactionStatus = data.transactionStatus;
+    contents.transactionStatus = __expectString(data.transactionStatus);
   }
   return Promise.resolve(contents);
 };
@@ -590,7 +595,7 @@ export const deserializeAws_restJson1ExecuteStatementCommand = async (
     contents.generatedFields = deserializeAws_restJson1FieldList(data.generatedFields, context);
   }
   if (data.numberOfRecordsUpdated !== undefined && data.numberOfRecordsUpdated !== null) {
-    contents.numberOfRecordsUpdated = data.numberOfRecordsUpdated;
+    contents.numberOfRecordsUpdated = __expectNumber(data.numberOfRecordsUpdated);
   }
   if (data.records !== undefined && data.records !== null) {
     contents.records = deserializeAws_restJson1SqlRecords(data.records, context);
@@ -680,7 +685,7 @@ export const deserializeAws_restJson1RollbackTransactionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.transactionStatus !== undefined && data.transactionStatus !== null) {
-    contents.transactionStatus = data.transactionStatus;
+    contents.transactionStatus = __expectString(data.transactionStatus);
   }
   return Promise.resolve(contents);
 };
@@ -774,7 +779,7 @@ const deserializeAws_restJson1BadRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -791,7 +796,7 @@ const deserializeAws_restJson1ForbiddenExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -821,7 +826,7 @@ const deserializeAws_restJson1NotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -852,10 +857,10 @@ const deserializeAws_restJson1StatementTimeoutExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.dbConnectionId !== undefined && data.dbConnectionId !== null) {
-    contents.dbConnectionId = data.dbConnectionId;
+    contents.dbConnectionId = __expectNumber(data.dbConnectionId);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1035,31 +1040,26 @@ const deserializeAws_restJson1BooleanArray = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectBoolean(entry) as any;
     });
 };
 
 const deserializeAws_restJson1ColumnMetadata = (output: any, context: __SerdeContext): ColumnMetadata => {
   return {
-    arrayBaseColumnType:
-      output.arrayBaseColumnType !== undefined && output.arrayBaseColumnType !== null
-        ? output.arrayBaseColumnType
-        : undefined,
-    isAutoIncrement:
-      output.isAutoIncrement !== undefined && output.isAutoIncrement !== null ? output.isAutoIncrement : undefined,
-    isCaseSensitive:
-      output.isCaseSensitive !== undefined && output.isCaseSensitive !== null ? output.isCaseSensitive : undefined,
-    isCurrency: output.isCurrency !== undefined && output.isCurrency !== null ? output.isCurrency : undefined,
-    isSigned: output.isSigned !== undefined && output.isSigned !== null ? output.isSigned : undefined,
-    label: output.label !== undefined && output.label !== null ? output.label : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    nullable: output.nullable !== undefined && output.nullable !== null ? output.nullable : undefined,
-    precision: output.precision !== undefined && output.precision !== null ? output.precision : undefined,
-    scale: output.scale !== undefined && output.scale !== null ? output.scale : undefined,
-    schemaName: output.schemaName !== undefined && output.schemaName !== null ? output.schemaName : undefined,
-    tableName: output.tableName !== undefined && output.tableName !== null ? output.tableName : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
-    typeName: output.typeName !== undefined && output.typeName !== null ? output.typeName : undefined,
+    arrayBaseColumnType: __expectNumber(output.arrayBaseColumnType),
+    isAutoIncrement: __expectBoolean(output.isAutoIncrement),
+    isCaseSensitive: __expectBoolean(output.isCaseSensitive),
+    isCurrency: __expectBoolean(output.isCurrency),
+    isSigned: __expectBoolean(output.isSigned),
+    label: __expectString(output.label),
+    name: __expectString(output.name),
+    nullable: __expectNumber(output.nullable),
+    precision: __expectNumber(output.precision),
+    scale: __expectNumber(output.scale),
+    schemaName: __expectString(output.schemaName),
+    tableName: __expectString(output.tableName),
+    type: __expectNumber(output.type),
+    typeName: __expectString(output.typeName),
   } as any;
 };
 
@@ -1070,7 +1070,7 @@ const deserializeAws_restJson1DoubleArray = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectNumber(entry) as any;
     });
 };
 
@@ -1085,30 +1085,20 @@ const deserializeAws_restJson1Field = (output: any, context: __SerdeContext): Fi
       blobValue: context.base64Decoder(output.blobValue),
     };
   }
-  if (output.booleanValue !== undefined && output.booleanValue !== null) {
-    return {
-      booleanValue: output.booleanValue,
-    };
+  if (__expectBoolean(output.booleanValue) !== undefined) {
+    return { booleanValue: __expectBoolean(output.booleanValue) as any };
   }
-  if (output.doubleValue !== undefined && output.doubleValue !== null) {
-    return {
-      doubleValue: output.doubleValue,
-    };
+  if (__expectNumber(output.doubleValue) !== undefined) {
+    return { doubleValue: __expectNumber(output.doubleValue) as any };
   }
-  if (output.isNull !== undefined && output.isNull !== null) {
-    return {
-      isNull: output.isNull,
-    };
+  if (__expectBoolean(output.isNull) !== undefined) {
+    return { isNull: __expectBoolean(output.isNull) as any };
   }
-  if (output.longValue !== undefined && output.longValue !== null) {
-    return {
-      longValue: output.longValue,
-    };
+  if (__expectNumber(output.longValue) !== undefined) {
+    return { longValue: __expectNumber(output.longValue) as any };
   }
-  if (output.stringValue !== undefined && output.stringValue !== null) {
-    return {
-      stringValue: output.stringValue,
-    };
+  if (__expectString(output.stringValue) !== undefined) {
+    return { stringValue: __expectString(output.stringValue) as any };
   }
   return { $unknown: Object.entries(output)[0] };
 };
@@ -1131,7 +1121,7 @@ const deserializeAws_restJson1LongArray = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectNumber(entry) as any;
     });
 };
 
@@ -1181,7 +1171,7 @@ const deserializeAws_restJson1ResultFrame = (output: any, context: __SerdeContex
 
 const deserializeAws_restJson1ResultSetMetadata = (output: any, context: __SerdeContext): ResultSetMetadata => {
   return {
-    columnCount: output.columnCount !== undefined && output.columnCount !== null ? output.columnCount : undefined,
+    columnCount: __expectNumber(output.columnCount),
     columnMetadata:
       output.columnMetadata !== undefined && output.columnMetadata !== null
         ? deserializeAws_restJson1Metadata(output.columnMetadata, context)
@@ -1213,10 +1203,7 @@ const deserializeAws_restJson1SqlRecords = (output: any, context: __SerdeContext
 
 const deserializeAws_restJson1SqlStatementResult = (output: any, context: __SerdeContext): SqlStatementResult => {
   return {
-    numberOfRecordsUpdated:
-      output.numberOfRecordsUpdated !== undefined && output.numberOfRecordsUpdated !== null
-        ? output.numberOfRecordsUpdated
-        : undefined,
+    numberOfRecordsUpdated: __expectNumber(output.numberOfRecordsUpdated),
     resultFrame:
       output.resultFrame !== undefined && output.resultFrame !== null
         ? deserializeAws_restJson1ResultFrame(output.resultFrame, context)
@@ -1242,7 +1229,7 @@ const deserializeAws_restJson1StringArray = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -1281,45 +1268,31 @@ const deserializeAws_restJson1Value = (output: any, context: __SerdeContext): Va
       arrayValues: deserializeAws_restJson1ArrayValueList(output.arrayValues, context),
     };
   }
-  if (output.bigIntValue !== undefined && output.bigIntValue !== null) {
-    return {
-      bigIntValue: output.bigIntValue,
-    };
+  if (__expectNumber(output.bigIntValue) !== undefined) {
+    return { bigIntValue: __expectNumber(output.bigIntValue) as any };
   }
-  if (output.bitValue !== undefined && output.bitValue !== null) {
-    return {
-      bitValue: output.bitValue,
-    };
+  if (__expectBoolean(output.bitValue) !== undefined) {
+    return { bitValue: __expectBoolean(output.bitValue) as any };
   }
   if (output.blobValue !== undefined && output.blobValue !== null) {
     return {
       blobValue: context.base64Decoder(output.blobValue),
     };
   }
-  if (output.doubleValue !== undefined && output.doubleValue !== null) {
-    return {
-      doubleValue: output.doubleValue,
-    };
+  if (__expectNumber(output.doubleValue) !== undefined) {
+    return { doubleValue: __expectNumber(output.doubleValue) as any };
   }
-  if (output.intValue !== undefined && output.intValue !== null) {
-    return {
-      intValue: output.intValue,
-    };
+  if (__expectNumber(output.intValue) !== undefined) {
+    return { intValue: __expectNumber(output.intValue) as any };
   }
-  if (output.isNull !== undefined && output.isNull !== null) {
-    return {
-      isNull: output.isNull,
-    };
+  if (__expectBoolean(output.isNull) !== undefined) {
+    return { isNull: __expectBoolean(output.isNull) as any };
   }
-  if (output.realValue !== undefined && output.realValue !== null) {
-    return {
-      realValue: output.realValue,
-    };
+  if (__expectNumber(output.realValue) !== undefined) {
+    return { realValue: __expectNumber(output.realValue) as any };
   }
-  if (output.stringValue !== undefined && output.stringValue !== null) {
-    return {
-      stringValue: output.stringValue,
-    };
+  if (__expectString(output.stringValue) !== undefined) {
+    return { stringValue: __expectString(output.stringValue) as any };
   }
   if (output.structValue !== undefined && output.structValue !== null) {
     return {

--- a/clients/client-rds/protocols/Aws_query.ts
+++ b/clients/client-rds/protocols/Aws_query.ts
@@ -909,6 +909,7 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
@@ -20073,7 +20074,7 @@ const deserializeAws_queryAccountQuota = (output: any, context: __SerdeContext):
     Max: undefined,
   };
   if (output["AccountQuotaName"] !== undefined) {
-    contents.AccountQuotaName = output["AccountQuotaName"];
+    contents.AccountQuotaName = __expectString(output["AccountQuotaName"]);
   }
   if (output["Used"] !== undefined) {
     contents.Used = parseInt(output["Used"]);
@@ -20102,7 +20103,7 @@ const deserializeAws_queryActivityStreamModeList = (output: any, context: __Serd
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -20142,7 +20143,7 @@ const deserializeAws_queryAttributeValueList = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -20154,7 +20155,7 @@ const deserializeAws_queryAuthorizationAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -20167,7 +20168,7 @@ const deserializeAws_queryAuthorizationNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -20180,7 +20181,7 @@ const deserializeAws_queryAuthorizationQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -20203,7 +20204,7 @@ const deserializeAws_queryAvailabilityZone = (output: any, context: __SerdeConte
     Name: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   return contents;
 };
@@ -20226,7 +20227,7 @@ const deserializeAws_queryAvailabilityZones = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -20240,13 +20241,13 @@ const deserializeAws_queryAvailableProcessorFeature = (
     AllowedValues: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["DefaultValue"] !== undefined) {
-    contents.DefaultValue = output["DefaultValue"];
+    contents.DefaultValue = __expectString(output["DefaultValue"]);
   }
   if (output["AllowedValues"] !== undefined) {
-    contents.AllowedValues = output["AllowedValues"];
+    contents.AllowedValues = __expectString(output["AllowedValues"]);
   }
   return contents;
 };
@@ -20273,7 +20274,7 @@ const deserializeAws_queryBackupPolicyNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -20290,13 +20291,13 @@ const deserializeAws_queryCertificate = (output: any, context: __SerdeContext): 
     CustomerOverrideValidTill: undefined,
   };
   if (output["CertificateIdentifier"] !== undefined) {
-    contents.CertificateIdentifier = output["CertificateIdentifier"];
+    contents.CertificateIdentifier = __expectString(output["CertificateIdentifier"]);
   }
   if (output["CertificateType"] !== undefined) {
-    contents.CertificateType = output["CertificateType"];
+    contents.CertificateType = __expectString(output["CertificateType"]);
   }
   if (output["Thumbprint"] !== undefined) {
-    contents.Thumbprint = output["Thumbprint"];
+    contents.Thumbprint = __expectString(output["Thumbprint"]);
   }
   if (output["ValidFrom"] !== undefined) {
     contents.ValidFrom = new Date(output["ValidFrom"]);
@@ -20305,7 +20306,7 @@ const deserializeAws_queryCertificate = (output: any, context: __SerdeContext): 
     contents.ValidTill = new Date(output["ValidTill"]);
   }
   if (output["CertificateArn"] !== undefined) {
-    contents.CertificateArn = output["CertificateArn"];
+    contents.CertificateArn = __expectString(output["CertificateArn"]);
   }
   if (output["CustomerOverride"] !== undefined) {
     contents.CustomerOverride = __parseBoolean(output["CustomerOverride"]);
@@ -20342,7 +20343,7 @@ const deserializeAws_queryCertificateMessage = (output: any, context: __SerdeCon
     );
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -20355,7 +20356,7 @@ const deserializeAws_queryCertificateNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -20366,10 +20367,10 @@ const deserializeAws_queryCharacterSet = (output: any, context: __SerdeContext):
     CharacterSetDescription: undefined,
   };
   if (output["CharacterSetName"] !== undefined) {
-    contents.CharacterSetName = output["CharacterSetName"];
+    contents.CharacterSetName = __expectString(output["CharacterSetName"]);
   }
   if (output["CharacterSetDescription"] !== undefined) {
-    contents.CharacterSetDescription = output["CharacterSetDescription"];
+    contents.CharacterSetDescription = __expectString(output["CharacterSetDescription"]);
   }
   return contents;
 };
@@ -20392,16 +20393,16 @@ const deserializeAws_queryClusterPendingModifiedValues = (
     );
   }
   if (output["DBClusterIdentifier"] !== undefined) {
-    contents.DBClusterIdentifier = output["DBClusterIdentifier"];
+    contents.DBClusterIdentifier = __expectString(output["DBClusterIdentifier"]);
   }
   if (output["MasterUserPassword"] !== undefined) {
-    contents.MasterUserPassword = output["MasterUserPassword"];
+    contents.MasterUserPassword = __expectString(output["MasterUserPassword"]);
   }
   if (output["IAMDatabaseAuthenticationEnabled"] !== undefined) {
     contents.IAMDatabaseAuthenticationEnabled = __parseBoolean(output["IAMDatabaseAuthenticationEnabled"]);
   }
   if (output["EngineVersion"] !== undefined) {
-    contents.EngineVersion = output["EngineVersion"];
+    contents.EngineVersion = __expectString(output["EngineVersion"]);
   }
   return contents;
 };
@@ -20436,7 +20437,7 @@ const deserializeAws_queryConnectionPoolConfigurationInfo = (
     );
   }
   if (output["InitQuery"] !== undefined) {
-    contents.InitQuery = output["InitQuery"];
+    contents.InitQuery = __expectString(output["InitQuery"]);
   }
   return contents;
 };
@@ -20697,13 +20698,13 @@ const deserializeAws_queryCustomAvailabilityZone = (output: any, context: __Serd
     VpnDetails: undefined,
   };
   if (output["CustomAvailabilityZoneId"] !== undefined) {
-    contents.CustomAvailabilityZoneId = output["CustomAvailabilityZoneId"];
+    contents.CustomAvailabilityZoneId = __expectString(output["CustomAvailabilityZoneId"]);
   }
   if (output["CustomAvailabilityZoneName"] !== undefined) {
-    contents.CustomAvailabilityZoneName = output["CustomAvailabilityZoneName"];
+    contents.CustomAvailabilityZoneName = __expectString(output["CustomAvailabilityZoneName"]);
   }
   if (output["CustomAvailabilityZoneStatus"] !== undefined) {
-    contents.CustomAvailabilityZoneStatus = output["CustomAvailabilityZoneStatus"];
+    contents.CustomAvailabilityZoneStatus = __expectString(output["CustomAvailabilityZoneStatus"]);
   }
   if (output["VpnDetails"] !== undefined) {
     contents.VpnDetails = deserializeAws_queryVpnDetails(output["VpnDetails"], context);
@@ -20719,7 +20720,7 @@ const deserializeAws_queryCustomAvailabilityZoneAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -20747,7 +20748,7 @@ const deserializeAws_queryCustomAvailabilityZoneMessage = (
     CustomAvailabilityZones: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.CustomAvailabilityZones === "") {
     contents.CustomAvailabilityZones = [];
@@ -20772,7 +20773,7 @@ const deserializeAws_queryCustomAvailabilityZoneNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -20785,7 +20786,7 @@ const deserializeAws_queryCustomAvailabilityZoneQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -20865,34 +20866,34 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
     contents.BackupRetentionPeriod = parseInt(output["BackupRetentionPeriod"]);
   }
   if (output["CharacterSetName"] !== undefined) {
-    contents.CharacterSetName = output["CharacterSetName"];
+    contents.CharacterSetName = __expectString(output["CharacterSetName"]);
   }
   if (output["DatabaseName"] !== undefined) {
-    contents.DatabaseName = output["DatabaseName"];
+    contents.DatabaseName = __expectString(output["DatabaseName"]);
   }
   if (output["DBClusterIdentifier"] !== undefined) {
-    contents.DBClusterIdentifier = output["DBClusterIdentifier"];
+    contents.DBClusterIdentifier = __expectString(output["DBClusterIdentifier"]);
   }
   if (output["DBClusterParameterGroup"] !== undefined) {
-    contents.DBClusterParameterGroup = output["DBClusterParameterGroup"];
+    contents.DBClusterParameterGroup = __expectString(output["DBClusterParameterGroup"]);
   }
   if (output["DBSubnetGroup"] !== undefined) {
-    contents.DBSubnetGroup = output["DBSubnetGroup"];
+    contents.DBSubnetGroup = __expectString(output["DBSubnetGroup"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["PercentProgress"] !== undefined) {
-    contents.PercentProgress = output["PercentProgress"];
+    contents.PercentProgress = __expectString(output["PercentProgress"]);
   }
   if (output["EarliestRestorableTime"] !== undefined) {
     contents.EarliestRestorableTime = new Date(output["EarliestRestorableTime"]);
   }
   if (output["Endpoint"] !== undefined) {
-    contents.Endpoint = output["Endpoint"];
+    contents.Endpoint = __expectString(output["Endpoint"]);
   }
   if (output["ReaderEndpoint"] !== undefined) {
-    contents.ReaderEndpoint = output["ReaderEndpoint"];
+    contents.ReaderEndpoint = __expectString(output["ReaderEndpoint"]);
   }
   if (output.CustomEndpoints === "") {
     contents.CustomEndpoints = [];
@@ -20907,10 +20908,10 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
     contents.MultiAZ = __parseBoolean(output["MultiAZ"]);
   }
   if (output["Engine"] !== undefined) {
-    contents.Engine = output["Engine"];
+    contents.Engine = __expectString(output["Engine"]);
   }
   if (output["EngineVersion"] !== undefined) {
-    contents.EngineVersion = output["EngineVersion"];
+    contents.EngineVersion = __expectString(output["EngineVersion"]);
   }
   if (output["LatestRestorableTime"] !== undefined) {
     contents.LatestRestorableTime = new Date(output["LatestRestorableTime"]);
@@ -20919,7 +20920,7 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
     contents.Port = parseInt(output["Port"]);
   }
   if (output["MasterUsername"] !== undefined) {
-    contents.MasterUsername = output["MasterUsername"];
+    contents.MasterUsername = __expectString(output["MasterUsername"]);
   }
   if (output.DBClusterOptionGroupMemberships === "") {
     contents.DBClusterOptionGroupMemberships = [];
@@ -20934,13 +20935,13 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
     );
   }
   if (output["PreferredBackupWindow"] !== undefined) {
-    contents.PreferredBackupWindow = output["PreferredBackupWindow"];
+    contents.PreferredBackupWindow = __expectString(output["PreferredBackupWindow"]);
   }
   if (output["PreferredMaintenanceWindow"] !== undefined) {
-    contents.PreferredMaintenanceWindow = output["PreferredMaintenanceWindow"];
+    contents.PreferredMaintenanceWindow = __expectString(output["PreferredMaintenanceWindow"]);
   }
   if (output["ReplicationSourceIdentifier"] !== undefined) {
-    contents.ReplicationSourceIdentifier = output["ReplicationSourceIdentifier"];
+    contents.ReplicationSourceIdentifier = __expectString(output["ReplicationSourceIdentifier"]);
   }
   if (output.ReadReplicaIdentifiers === "") {
     contents.ReadReplicaIdentifiers = [];
@@ -20976,19 +20977,19 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
     );
   }
   if (output["HostedZoneId"] !== undefined) {
-    contents.HostedZoneId = output["HostedZoneId"];
+    contents.HostedZoneId = __expectString(output["HostedZoneId"]);
   }
   if (output["StorageEncrypted"] !== undefined) {
     contents.StorageEncrypted = __parseBoolean(output["StorageEncrypted"]);
   }
   if (output["KmsKeyId"] !== undefined) {
-    contents.KmsKeyId = output["KmsKeyId"];
+    contents.KmsKeyId = __expectString(output["KmsKeyId"]);
   }
   if (output["DbClusterResourceId"] !== undefined) {
-    contents.DbClusterResourceId = output["DbClusterResourceId"];
+    contents.DbClusterResourceId = __expectString(output["DbClusterResourceId"]);
   }
   if (output["DBClusterArn"] !== undefined) {
-    contents.DBClusterArn = output["DBClusterArn"];
+    contents.DBClusterArn = __expectString(output["DBClusterArn"]);
   }
   if (output.AssociatedRoles === "") {
     contents.AssociatedRoles = [];
@@ -21003,7 +21004,7 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
     contents.IAMDatabaseAuthenticationEnabled = __parseBoolean(output["IAMDatabaseAuthenticationEnabled"]);
   }
   if (output["CloneGroupId"] !== undefined) {
-    contents.CloneGroupId = output["CloneGroupId"];
+    contents.CloneGroupId = __expectString(output["CloneGroupId"]);
   }
   if (output["ClusterCreateTime"] !== undefined) {
     contents.ClusterCreateTime = new Date(output["ClusterCreateTime"]);
@@ -21033,7 +21034,7 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
     contents.Capacity = parseInt(output["Capacity"]);
   }
   if (output["EngineMode"] !== undefined) {
-    contents.EngineMode = output["EngineMode"];
+    contents.EngineMode = __expectString(output["EngineMode"]);
   }
   if (output["ScalingConfigurationInfo"] !== undefined) {
     contents.ScalingConfigurationInfo = deserializeAws_queryScalingConfigurationInfo(
@@ -21048,16 +21049,16 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
     contents.HttpEndpointEnabled = __parseBoolean(output["HttpEndpointEnabled"]);
   }
   if (output["ActivityStreamMode"] !== undefined) {
-    contents.ActivityStreamMode = output["ActivityStreamMode"];
+    contents.ActivityStreamMode = __expectString(output["ActivityStreamMode"]);
   }
   if (output["ActivityStreamStatus"] !== undefined) {
-    contents.ActivityStreamStatus = output["ActivityStreamStatus"];
+    contents.ActivityStreamStatus = __expectString(output["ActivityStreamStatus"]);
   }
   if (output["ActivityStreamKmsKeyId"] !== undefined) {
-    contents.ActivityStreamKmsKeyId = output["ActivityStreamKmsKeyId"];
+    contents.ActivityStreamKmsKeyId = __expectString(output["ActivityStreamKmsKeyId"]);
   }
   if (output["ActivityStreamKinesisStreamName"] !== undefined) {
-    contents.ActivityStreamKinesisStreamName = output["ActivityStreamKinesisStreamName"];
+    contents.ActivityStreamKinesisStreamName = __expectString(output["ActivityStreamKinesisStreamName"]);
   }
   if (output["CopyTagsToSnapshot"] !== undefined) {
     contents.CopyTagsToSnapshot = __parseBoolean(output["CopyTagsToSnapshot"]);
@@ -21081,7 +21082,7 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
     contents.TagList = deserializeAws_queryTagList(__getArrayIfSingleItem(output["TagList"]["Tag"]), context);
   }
   if (output["GlobalWriteForwardingStatus"] !== undefined) {
-    contents.GlobalWriteForwardingStatus = output["GlobalWriteForwardingStatus"];
+    contents.GlobalWriteForwardingStatus = __expectString(output["GlobalWriteForwardingStatus"]);
   }
   if (output["GlobalWriteForwardingRequested"] !== undefined) {
     contents.GlobalWriteForwardingRequested = __parseBoolean(output["GlobalWriteForwardingRequested"]);
@@ -21103,7 +21104,7 @@ const deserializeAws_queryDBClusterAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -21118,10 +21119,10 @@ const deserializeAws_queryDBClusterBacktrack = (output: any, context: __SerdeCon
     Status: undefined,
   };
   if (output["DBClusterIdentifier"] !== undefined) {
-    contents.DBClusterIdentifier = output["DBClusterIdentifier"];
+    contents.DBClusterIdentifier = __expectString(output["DBClusterIdentifier"]);
   }
   if (output["BacktrackIdentifier"] !== undefined) {
-    contents.BacktrackIdentifier = output["BacktrackIdentifier"];
+    contents.BacktrackIdentifier = __expectString(output["BacktrackIdentifier"]);
   }
   if (output["BacktrackTo"] !== undefined) {
     contents.BacktrackTo = new Date(output["BacktrackTo"]);
@@ -21133,7 +21134,7 @@ const deserializeAws_queryDBClusterBacktrack = (output: any, context: __SerdeCon
     contents.BacktrackRequestCreationTime = new Date(output["BacktrackRequestCreationTime"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   return contents;
 };
@@ -21158,7 +21159,7 @@ const deserializeAws_queryDBClusterBacktrackMessage = (
     DBClusterBacktracks: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.DBClusterBacktracks === "") {
     contents.DBClusterBacktracks = [];
@@ -21183,7 +21184,7 @@ const deserializeAws_queryDBClusterBacktrackNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -21197,7 +21198,7 @@ const deserializeAws_queryDBClusterCapacityInfo = (output: any, context: __Serde
     TimeoutAction: undefined,
   };
   if (output["DBClusterIdentifier"] !== undefined) {
-    contents.DBClusterIdentifier = output["DBClusterIdentifier"];
+    contents.DBClusterIdentifier = __expectString(output["DBClusterIdentifier"]);
   }
   if (output["PendingCapacity"] !== undefined) {
     contents.PendingCapacity = parseInt(output["PendingCapacity"]);
@@ -21209,7 +21210,7 @@ const deserializeAws_queryDBClusterCapacityInfo = (output: any, context: __Serde
     contents.SecondsBeforeTimeout = parseInt(output["SecondsBeforeTimeout"]);
   }
   if (output["TimeoutAction"] !== undefined) {
-    contents.TimeoutAction = output["TimeoutAction"];
+    contents.TimeoutAction = __expectString(output["TimeoutAction"]);
   }
   return contents;
 };
@@ -21228,25 +21229,25 @@ const deserializeAws_queryDBClusterEndpoint = (output: any, context: __SerdeCont
     DBClusterEndpointArn: undefined,
   };
   if (output["DBClusterEndpointIdentifier"] !== undefined) {
-    contents.DBClusterEndpointIdentifier = output["DBClusterEndpointIdentifier"];
+    contents.DBClusterEndpointIdentifier = __expectString(output["DBClusterEndpointIdentifier"]);
   }
   if (output["DBClusterIdentifier"] !== undefined) {
-    contents.DBClusterIdentifier = output["DBClusterIdentifier"];
+    contents.DBClusterIdentifier = __expectString(output["DBClusterIdentifier"]);
   }
   if (output["DBClusterEndpointResourceIdentifier"] !== undefined) {
-    contents.DBClusterEndpointResourceIdentifier = output["DBClusterEndpointResourceIdentifier"];
+    contents.DBClusterEndpointResourceIdentifier = __expectString(output["DBClusterEndpointResourceIdentifier"]);
   }
   if (output["Endpoint"] !== undefined) {
-    contents.Endpoint = output["Endpoint"];
+    contents.Endpoint = __expectString(output["Endpoint"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["EndpointType"] !== undefined) {
-    contents.EndpointType = output["EndpointType"];
+    contents.EndpointType = __expectString(output["EndpointType"]);
   }
   if (output["CustomEndpointType"] !== undefined) {
-    contents.CustomEndpointType = output["CustomEndpointType"];
+    contents.CustomEndpointType = __expectString(output["CustomEndpointType"]);
   }
   if (output.StaticMembers === "") {
     contents.StaticMembers = [];
@@ -21267,7 +21268,7 @@ const deserializeAws_queryDBClusterEndpoint = (output: any, context: __SerdeCont
     );
   }
   if (output["DBClusterEndpointArn"] !== undefined) {
-    contents.DBClusterEndpointArn = output["DBClusterEndpointArn"];
+    contents.DBClusterEndpointArn = __expectString(output["DBClusterEndpointArn"]);
   }
   return contents;
 };
@@ -21280,7 +21281,7 @@ const deserializeAws_queryDBClusterEndpointAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -21305,7 +21306,7 @@ const deserializeAws_queryDBClusterEndpointMessage = (
     DBClusterEndpoints: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.DBClusterEndpoints === "") {
     contents.DBClusterEndpoints = [];
@@ -21330,7 +21331,7 @@ const deserializeAws_queryDBClusterEndpointNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -21343,7 +21344,7 @@ const deserializeAws_queryDBClusterEndpointQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -21367,13 +21368,13 @@ const deserializeAws_queryDBClusterMember = (output: any, context: __SerdeContex
     PromotionTier: undefined,
   };
   if (output["DBInstanceIdentifier"] !== undefined) {
-    contents.DBInstanceIdentifier = output["DBInstanceIdentifier"];
+    contents.DBInstanceIdentifier = __expectString(output["DBInstanceIdentifier"]);
   }
   if (output["IsClusterWriter"] !== undefined) {
     contents.IsClusterWriter = __parseBoolean(output["IsClusterWriter"]);
   }
   if (output["DBClusterParameterGroupStatus"] !== undefined) {
-    contents.DBClusterParameterGroupStatus = output["DBClusterParameterGroupStatus"];
+    contents.DBClusterParameterGroupStatus = __expectString(output["DBClusterParameterGroupStatus"]);
   }
   if (output["PromotionTier"] !== undefined) {
     contents.PromotionTier = parseInt(output["PromotionTier"]);
@@ -21398,7 +21399,7 @@ const deserializeAws_queryDBClusterMessage = (output: any, context: __SerdeConte
     DBClusters: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.DBClusters === "") {
     contents.DBClusters = [];
@@ -21417,7 +21418,7 @@ const deserializeAws_queryDBClusterNotFoundFault = (output: any, context: __Serd
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -21445,10 +21446,10 @@ const deserializeAws_queryDBClusterOptionGroupStatus = (
     Status: undefined,
   };
   if (output["DBClusterOptionGroupName"] !== undefined) {
-    contents.DBClusterOptionGroupName = output["DBClusterOptionGroupName"];
+    contents.DBClusterOptionGroupName = __expectString(output["DBClusterOptionGroupName"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   return contents;
 };
@@ -21461,16 +21462,16 @@ const deserializeAws_queryDBClusterParameterGroup = (output: any, context: __Ser
     DBClusterParameterGroupArn: undefined,
   };
   if (output["DBClusterParameterGroupName"] !== undefined) {
-    contents.DBClusterParameterGroupName = output["DBClusterParameterGroupName"];
+    contents.DBClusterParameterGroupName = __expectString(output["DBClusterParameterGroupName"]);
   }
   if (output["DBParameterGroupFamily"] !== undefined) {
-    contents.DBParameterGroupFamily = output["DBParameterGroupFamily"];
+    contents.DBParameterGroupFamily = __expectString(output["DBParameterGroupFamily"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output["DBClusterParameterGroupArn"] !== undefined) {
-    contents.DBClusterParameterGroupArn = output["DBClusterParameterGroupArn"];
+    contents.DBClusterParameterGroupArn = __expectString(output["DBClusterParameterGroupArn"]);
   }
   return contents;
 };
@@ -21493,7 +21494,7 @@ const deserializeAws_queryDBClusterParameterGroupDetails = (
     );
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -21520,7 +21521,7 @@ const deserializeAws_queryDBClusterParameterGroupNameMessage = (
     DBClusterParameterGroupName: undefined,
   };
   if (output["DBClusterParameterGroupName"] !== undefined) {
-    contents.DBClusterParameterGroupName = output["DBClusterParameterGroupName"];
+    contents.DBClusterParameterGroupName = __expectString(output["DBClusterParameterGroupName"]);
   }
   return contents;
 };
@@ -21533,7 +21534,7 @@ const deserializeAws_queryDBClusterParameterGroupNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -21547,7 +21548,7 @@ const deserializeAws_queryDBClusterParameterGroupsMessage = (
     DBClusterParameterGroups: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.DBClusterParameterGroups === "") {
     contents.DBClusterParameterGroups = [];
@@ -21572,7 +21573,7 @@ const deserializeAws_queryDBClusterQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -21584,13 +21585,13 @@ const deserializeAws_queryDBClusterRole = (output: any, context: __SerdeContext)
     FeatureName: undefined,
   };
   if (output["RoleArn"] !== undefined) {
-    contents.RoleArn = output["RoleArn"];
+    contents.RoleArn = __expectString(output["RoleArn"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["FeatureName"] !== undefined) {
-    contents.FeatureName = output["FeatureName"];
+    contents.FeatureName = __expectString(output["FeatureName"]);
   }
   return contents;
 };
@@ -21603,7 +21604,7 @@ const deserializeAws_queryDBClusterRoleAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -21616,7 +21617,7 @@ const deserializeAws_queryDBClusterRoleNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -21629,7 +21630,7 @@ const deserializeAws_queryDBClusterRoleQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -21680,46 +21681,46 @@ const deserializeAws_queryDBClusterSnapshot = (output: any, context: __SerdeCont
     );
   }
   if (output["DBClusterSnapshotIdentifier"] !== undefined) {
-    contents.DBClusterSnapshotIdentifier = output["DBClusterSnapshotIdentifier"];
+    contents.DBClusterSnapshotIdentifier = __expectString(output["DBClusterSnapshotIdentifier"]);
   }
   if (output["DBClusterIdentifier"] !== undefined) {
-    contents.DBClusterIdentifier = output["DBClusterIdentifier"];
+    contents.DBClusterIdentifier = __expectString(output["DBClusterIdentifier"]);
   }
   if (output["SnapshotCreateTime"] !== undefined) {
     contents.SnapshotCreateTime = new Date(output["SnapshotCreateTime"]);
   }
   if (output["Engine"] !== undefined) {
-    contents.Engine = output["Engine"];
+    contents.Engine = __expectString(output["Engine"]);
   }
   if (output["EngineMode"] !== undefined) {
-    contents.EngineMode = output["EngineMode"];
+    contents.EngineMode = __expectString(output["EngineMode"]);
   }
   if (output["AllocatedStorage"] !== undefined) {
     contents.AllocatedStorage = parseInt(output["AllocatedStorage"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["Port"] !== undefined) {
     contents.Port = parseInt(output["Port"]);
   }
   if (output["VpcId"] !== undefined) {
-    contents.VpcId = output["VpcId"];
+    contents.VpcId = __expectString(output["VpcId"]);
   }
   if (output["ClusterCreateTime"] !== undefined) {
     contents.ClusterCreateTime = new Date(output["ClusterCreateTime"]);
   }
   if (output["MasterUsername"] !== undefined) {
-    contents.MasterUsername = output["MasterUsername"];
+    contents.MasterUsername = __expectString(output["MasterUsername"]);
   }
   if (output["EngineVersion"] !== undefined) {
-    contents.EngineVersion = output["EngineVersion"];
+    contents.EngineVersion = __expectString(output["EngineVersion"]);
   }
   if (output["LicenseModel"] !== undefined) {
-    contents.LicenseModel = output["LicenseModel"];
+    contents.LicenseModel = __expectString(output["LicenseModel"]);
   }
   if (output["SnapshotType"] !== undefined) {
-    contents.SnapshotType = output["SnapshotType"];
+    contents.SnapshotType = __expectString(output["SnapshotType"]);
   }
   if (output["PercentProgress"] !== undefined) {
     contents.PercentProgress = parseInt(output["PercentProgress"]);
@@ -21728,13 +21729,13 @@ const deserializeAws_queryDBClusterSnapshot = (output: any, context: __SerdeCont
     contents.StorageEncrypted = __parseBoolean(output["StorageEncrypted"]);
   }
   if (output["KmsKeyId"] !== undefined) {
-    contents.KmsKeyId = output["KmsKeyId"];
+    contents.KmsKeyId = __expectString(output["KmsKeyId"]);
   }
   if (output["DBClusterSnapshotArn"] !== undefined) {
-    contents.DBClusterSnapshotArn = output["DBClusterSnapshotArn"];
+    contents.DBClusterSnapshotArn = __expectString(output["DBClusterSnapshotArn"]);
   }
   if (output["SourceDBClusterSnapshotArn"] !== undefined) {
-    contents.SourceDBClusterSnapshotArn = output["SourceDBClusterSnapshotArn"];
+    contents.SourceDBClusterSnapshotArn = __expectString(output["SourceDBClusterSnapshotArn"]);
   }
   if (output["IAMDatabaseAuthenticationEnabled"] !== undefined) {
     contents.IAMDatabaseAuthenticationEnabled = __parseBoolean(output["IAMDatabaseAuthenticationEnabled"]);
@@ -21756,7 +21757,7 @@ const deserializeAws_queryDBClusterSnapshotAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -21770,7 +21771,7 @@ const deserializeAws_queryDBClusterSnapshotAttribute = (
     AttributeValues: undefined,
   };
   if (output["AttributeName"] !== undefined) {
-    contents.AttributeName = output["AttributeName"];
+    contents.AttributeName = __expectString(output["AttributeName"]);
   }
   if (output.AttributeValues === "") {
     contents.AttributeValues = [];
@@ -21807,7 +21808,7 @@ const deserializeAws_queryDBClusterSnapshotAttributesResult = (
     DBClusterSnapshotAttributes: undefined,
   };
   if (output["DBClusterSnapshotIdentifier"] !== undefined) {
-    contents.DBClusterSnapshotIdentifier = output["DBClusterSnapshotIdentifier"];
+    contents.DBClusterSnapshotIdentifier = __expectString(output["DBClusterSnapshotIdentifier"]);
   }
   if (output.DBClusterSnapshotAttributes === "") {
     contents.DBClusterSnapshotAttributes = [];
@@ -21844,7 +21845,7 @@ const deserializeAws_queryDBClusterSnapshotMessage = (
     DBClusterSnapshots: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.DBClusterSnapshots === "") {
     contents.DBClusterSnapshots = [];
@@ -21866,7 +21867,7 @@ const deserializeAws_queryDBClusterSnapshotNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -21893,19 +21894,19 @@ const deserializeAws_queryDBEngineVersion = (output: any, context: __SerdeContex
     SupportsGlobalDatabases: undefined,
   };
   if (output["Engine"] !== undefined) {
-    contents.Engine = output["Engine"];
+    contents.Engine = __expectString(output["Engine"]);
   }
   if (output["EngineVersion"] !== undefined) {
-    contents.EngineVersion = output["EngineVersion"];
+    contents.EngineVersion = __expectString(output["EngineVersion"]);
   }
   if (output["DBParameterGroupFamily"] !== undefined) {
-    contents.DBParameterGroupFamily = output["DBParameterGroupFamily"];
+    contents.DBParameterGroupFamily = __expectString(output["DBParameterGroupFamily"]);
   }
   if (output["DBEngineDescription"] !== undefined) {
-    contents.DBEngineDescription = output["DBEngineDescription"];
+    contents.DBEngineDescription = __expectString(output["DBEngineDescription"]);
   }
   if (output["DBEngineVersionDescription"] !== undefined) {
-    contents.DBEngineVersionDescription = output["DBEngineVersionDescription"];
+    contents.DBEngineVersionDescription = __expectString(output["DBEngineVersionDescription"]);
   }
   if (output["DefaultCharacterSet"] !== undefined) {
     contents.DefaultCharacterSet = deserializeAws_queryCharacterSet(output["DefaultCharacterSet"], context);
@@ -21986,7 +21987,7 @@ const deserializeAws_queryDBEngineVersion = (output: any, context: __SerdeContex
     );
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["SupportsParallelQuery"] !== undefined) {
     contents.SupportsParallelQuery = __parseBoolean(output["SupportsParallelQuery"]);
@@ -22014,7 +22015,7 @@ const deserializeAws_queryDBEngineVersionMessage = (output: any, context: __Serd
     DBEngineVersions: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.DBEngineVersions === "") {
     contents.DBEngineVersions = [];
@@ -22101,22 +22102,22 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
     ActivityStreamEngineNativeAuditFieldsIncluded: undefined,
   };
   if (output["DBInstanceIdentifier"] !== undefined) {
-    contents.DBInstanceIdentifier = output["DBInstanceIdentifier"];
+    contents.DBInstanceIdentifier = __expectString(output["DBInstanceIdentifier"]);
   }
   if (output["DBInstanceClass"] !== undefined) {
-    contents.DBInstanceClass = output["DBInstanceClass"];
+    contents.DBInstanceClass = __expectString(output["DBInstanceClass"]);
   }
   if (output["Engine"] !== undefined) {
-    contents.Engine = output["Engine"];
+    contents.Engine = __expectString(output["Engine"]);
   }
   if (output["DBInstanceStatus"] !== undefined) {
-    contents.DBInstanceStatus = output["DBInstanceStatus"];
+    contents.DBInstanceStatus = __expectString(output["DBInstanceStatus"]);
   }
   if (output["MasterUsername"] !== undefined) {
-    contents.MasterUsername = output["MasterUsername"];
+    contents.MasterUsername = __expectString(output["MasterUsername"]);
   }
   if (output["DBName"] !== undefined) {
-    contents.DBName = output["DBName"];
+    contents.DBName = __expectString(output["DBName"]);
   }
   if (output["Endpoint"] !== undefined) {
     contents.Endpoint = deserializeAws_queryEndpoint(output["Endpoint"], context);
@@ -22128,7 +22129,7 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
     contents.InstanceCreateTime = new Date(output["InstanceCreateTime"]);
   }
   if (output["PreferredBackupWindow"] !== undefined) {
-    contents.PreferredBackupWindow = output["PreferredBackupWindow"];
+    contents.PreferredBackupWindow = __expectString(output["PreferredBackupWindow"]);
   }
   if (output["BackupRetentionPeriod"] !== undefined) {
     contents.BackupRetentionPeriod = parseInt(output["BackupRetentionPeriod"]);
@@ -22164,13 +22165,13 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
     );
   }
   if (output["AvailabilityZone"] !== undefined) {
-    contents.AvailabilityZone = output["AvailabilityZone"];
+    contents.AvailabilityZone = __expectString(output["AvailabilityZone"]);
   }
   if (output["DBSubnetGroup"] !== undefined) {
     contents.DBSubnetGroup = deserializeAws_queryDBSubnetGroup(output["DBSubnetGroup"], context);
   }
   if (output["PreferredMaintenanceWindow"] !== undefined) {
-    contents.PreferredMaintenanceWindow = output["PreferredMaintenanceWindow"];
+    contents.PreferredMaintenanceWindow = __expectString(output["PreferredMaintenanceWindow"]);
   }
   if (output["PendingModifiedValues"] !== undefined) {
     contents.PendingModifiedValues = deserializeAws_queryPendingModifiedValues(
@@ -22185,13 +22186,13 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
     contents.MultiAZ = __parseBoolean(output["MultiAZ"]);
   }
   if (output["EngineVersion"] !== undefined) {
-    contents.EngineVersion = output["EngineVersion"];
+    contents.EngineVersion = __expectString(output["EngineVersion"]);
   }
   if (output["AutoMinorVersionUpgrade"] !== undefined) {
     contents.AutoMinorVersionUpgrade = __parseBoolean(output["AutoMinorVersionUpgrade"]);
   }
   if (output["ReadReplicaSourceDBInstanceIdentifier"] !== undefined) {
-    contents.ReadReplicaSourceDBInstanceIdentifier = output["ReadReplicaSourceDBInstanceIdentifier"];
+    contents.ReadReplicaSourceDBInstanceIdentifier = __expectString(output["ReadReplicaSourceDBInstanceIdentifier"]);
   }
   if (output.ReadReplicaDBInstanceIdentifiers === "") {
     contents.ReadReplicaDBInstanceIdentifiers = [];
@@ -22218,10 +22219,10 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
     );
   }
   if (output["ReplicaMode"] !== undefined) {
-    contents.ReplicaMode = output["ReplicaMode"];
+    contents.ReplicaMode = __expectString(output["ReplicaMode"]);
   }
   if (output["LicenseModel"] !== undefined) {
-    contents.LicenseModel = output["LicenseModel"];
+    contents.LicenseModel = __expectString(output["LicenseModel"]);
   }
   if (output["Iops"] !== undefined) {
     contents.Iops = parseInt(output["Iops"]);
@@ -22239,13 +22240,13 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
     );
   }
   if (output["CharacterSetName"] !== undefined) {
-    contents.CharacterSetName = output["CharacterSetName"];
+    contents.CharacterSetName = __expectString(output["CharacterSetName"]);
   }
   if (output["NcharCharacterSetName"] !== undefined) {
-    contents.NcharCharacterSetName = output["NcharCharacterSetName"];
+    contents.NcharCharacterSetName = __expectString(output["NcharCharacterSetName"]);
   }
   if (output["SecondaryAvailabilityZone"] !== undefined) {
-    contents.SecondaryAvailabilityZone = output["SecondaryAvailabilityZone"];
+    contents.SecondaryAvailabilityZone = __expectString(output["SecondaryAvailabilityZone"]);
   }
   if (output["PubliclyAccessible"] !== undefined) {
     contents.PubliclyAccessible = __parseBoolean(output["PubliclyAccessible"]);
@@ -22260,28 +22261,28 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
     );
   }
   if (output["StorageType"] !== undefined) {
-    contents.StorageType = output["StorageType"];
+    contents.StorageType = __expectString(output["StorageType"]);
   }
   if (output["TdeCredentialArn"] !== undefined) {
-    contents.TdeCredentialArn = output["TdeCredentialArn"];
+    contents.TdeCredentialArn = __expectString(output["TdeCredentialArn"]);
   }
   if (output["DbInstancePort"] !== undefined) {
     contents.DbInstancePort = parseInt(output["DbInstancePort"]);
   }
   if (output["DBClusterIdentifier"] !== undefined) {
-    contents.DBClusterIdentifier = output["DBClusterIdentifier"];
+    contents.DBClusterIdentifier = __expectString(output["DBClusterIdentifier"]);
   }
   if (output["StorageEncrypted"] !== undefined) {
     contents.StorageEncrypted = __parseBoolean(output["StorageEncrypted"]);
   }
   if (output["KmsKeyId"] !== undefined) {
-    contents.KmsKeyId = output["KmsKeyId"];
+    contents.KmsKeyId = __expectString(output["KmsKeyId"]);
   }
   if (output["DbiResourceId"] !== undefined) {
-    contents.DbiResourceId = output["DbiResourceId"];
+    contents.DbiResourceId = __expectString(output["DbiResourceId"]);
   }
   if (output["CACertificateIdentifier"] !== undefined) {
-    contents.CACertificateIdentifier = output["CACertificateIdentifier"];
+    contents.CACertificateIdentifier = __expectString(output["CACertificateIdentifier"]);
   }
   if (output.DomainMemberships === "") {
     contents.DomainMemberships = [];
@@ -22299,19 +22300,19 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
     contents.MonitoringInterval = parseInt(output["MonitoringInterval"]);
   }
   if (output["EnhancedMonitoringResourceArn"] !== undefined) {
-    contents.EnhancedMonitoringResourceArn = output["EnhancedMonitoringResourceArn"];
+    contents.EnhancedMonitoringResourceArn = __expectString(output["EnhancedMonitoringResourceArn"]);
   }
   if (output["MonitoringRoleArn"] !== undefined) {
-    contents.MonitoringRoleArn = output["MonitoringRoleArn"];
+    contents.MonitoringRoleArn = __expectString(output["MonitoringRoleArn"]);
   }
   if (output["PromotionTier"] !== undefined) {
     contents.PromotionTier = parseInt(output["PromotionTier"]);
   }
   if (output["DBInstanceArn"] !== undefined) {
-    contents.DBInstanceArn = output["DBInstanceArn"];
+    contents.DBInstanceArn = __expectString(output["DBInstanceArn"]);
   }
   if (output["Timezone"] !== undefined) {
-    contents.Timezone = output["Timezone"];
+    contents.Timezone = __expectString(output["Timezone"]);
   }
   if (output["IAMDatabaseAuthenticationEnabled"] !== undefined) {
     contents.IAMDatabaseAuthenticationEnabled = __parseBoolean(output["IAMDatabaseAuthenticationEnabled"]);
@@ -22320,7 +22321,7 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
     contents.PerformanceInsightsEnabled = __parseBoolean(output["PerformanceInsightsEnabled"]);
   }
   if (output["PerformanceInsightsKMSKeyId"] !== undefined) {
-    contents.PerformanceInsightsKMSKeyId = output["PerformanceInsightsKMSKeyId"];
+    contents.PerformanceInsightsKMSKeyId = __expectString(output["PerformanceInsightsKMSKeyId"]);
   }
   if (output["PerformanceInsightsRetentionPeriod"] !== undefined) {
     contents.PerformanceInsightsRetentionPeriod = parseInt(output["PerformanceInsightsRetentionPeriod"]);
@@ -22386,19 +22387,19 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
     contents.CustomerOwnedIpEnabled = __parseBoolean(output["CustomerOwnedIpEnabled"]);
   }
   if (output["AwsBackupRecoveryPointArn"] !== undefined) {
-    contents.AwsBackupRecoveryPointArn = output["AwsBackupRecoveryPointArn"];
+    contents.AwsBackupRecoveryPointArn = __expectString(output["AwsBackupRecoveryPointArn"]);
   }
   if (output["ActivityStreamStatus"] !== undefined) {
-    contents.ActivityStreamStatus = output["ActivityStreamStatus"];
+    contents.ActivityStreamStatus = __expectString(output["ActivityStreamStatus"]);
   }
   if (output["ActivityStreamKmsKeyId"] !== undefined) {
-    contents.ActivityStreamKmsKeyId = output["ActivityStreamKmsKeyId"];
+    contents.ActivityStreamKmsKeyId = __expectString(output["ActivityStreamKmsKeyId"]);
   }
   if (output["ActivityStreamKinesisStreamName"] !== undefined) {
-    contents.ActivityStreamKinesisStreamName = output["ActivityStreamKinesisStreamName"];
+    contents.ActivityStreamKinesisStreamName = __expectString(output["ActivityStreamKinesisStreamName"]);
   }
   if (output["ActivityStreamMode"] !== undefined) {
-    contents.ActivityStreamMode = output["ActivityStreamMode"];
+    contents.ActivityStreamMode = __expectString(output["ActivityStreamMode"]);
   }
   if (output["ActivityStreamEngineNativeAuditFieldsIncluded"] !== undefined) {
     contents.ActivityStreamEngineNativeAuditFieldsIncluded = __parseBoolean(
@@ -22416,7 +22417,7 @@ const deserializeAws_queryDBInstanceAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -22454,16 +22455,16 @@ const deserializeAws_queryDBInstanceAutomatedBackup = (
     DBInstanceAutomatedBackupsReplications: undefined,
   };
   if (output["DBInstanceArn"] !== undefined) {
-    contents.DBInstanceArn = output["DBInstanceArn"];
+    contents.DBInstanceArn = __expectString(output["DBInstanceArn"]);
   }
   if (output["DbiResourceId"] !== undefined) {
-    contents.DbiResourceId = output["DbiResourceId"];
+    contents.DbiResourceId = __expectString(output["DbiResourceId"]);
   }
   if (output["Region"] !== undefined) {
-    contents.Region = output["Region"];
+    contents.Region = __expectString(output["Region"]);
   }
   if (output["DBInstanceIdentifier"] !== undefined) {
-    contents.DBInstanceIdentifier = output["DBInstanceIdentifier"];
+    contents.DBInstanceIdentifier = __expectString(output["DBInstanceIdentifier"]);
   }
   if (output["RestoreWindow"] !== undefined) {
     contents.RestoreWindow = deserializeAws_queryRestoreWindow(output["RestoreWindow"], context);
@@ -22472,52 +22473,52 @@ const deserializeAws_queryDBInstanceAutomatedBackup = (
     contents.AllocatedStorage = parseInt(output["AllocatedStorage"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["Port"] !== undefined) {
     contents.Port = parseInt(output["Port"]);
   }
   if (output["AvailabilityZone"] !== undefined) {
-    contents.AvailabilityZone = output["AvailabilityZone"];
+    contents.AvailabilityZone = __expectString(output["AvailabilityZone"]);
   }
   if (output["VpcId"] !== undefined) {
-    contents.VpcId = output["VpcId"];
+    contents.VpcId = __expectString(output["VpcId"]);
   }
   if (output["InstanceCreateTime"] !== undefined) {
     contents.InstanceCreateTime = new Date(output["InstanceCreateTime"]);
   }
   if (output["MasterUsername"] !== undefined) {
-    contents.MasterUsername = output["MasterUsername"];
+    contents.MasterUsername = __expectString(output["MasterUsername"]);
   }
   if (output["Engine"] !== undefined) {
-    contents.Engine = output["Engine"];
+    contents.Engine = __expectString(output["Engine"]);
   }
   if (output["EngineVersion"] !== undefined) {
-    contents.EngineVersion = output["EngineVersion"];
+    contents.EngineVersion = __expectString(output["EngineVersion"]);
   }
   if (output["LicenseModel"] !== undefined) {
-    contents.LicenseModel = output["LicenseModel"];
+    contents.LicenseModel = __expectString(output["LicenseModel"]);
   }
   if (output["Iops"] !== undefined) {
     contents.Iops = parseInt(output["Iops"]);
   }
   if (output["OptionGroupName"] !== undefined) {
-    contents.OptionGroupName = output["OptionGroupName"];
+    contents.OptionGroupName = __expectString(output["OptionGroupName"]);
   }
   if (output["TdeCredentialArn"] !== undefined) {
-    contents.TdeCredentialArn = output["TdeCredentialArn"];
+    contents.TdeCredentialArn = __expectString(output["TdeCredentialArn"]);
   }
   if (output["Encrypted"] !== undefined) {
     contents.Encrypted = __parseBoolean(output["Encrypted"]);
   }
   if (output["StorageType"] !== undefined) {
-    contents.StorageType = output["StorageType"];
+    contents.StorageType = __expectString(output["StorageType"]);
   }
   if (output["KmsKeyId"] !== undefined) {
-    contents.KmsKeyId = output["KmsKeyId"];
+    contents.KmsKeyId = __expectString(output["KmsKeyId"]);
   }
   if (output["Timezone"] !== undefined) {
-    contents.Timezone = output["Timezone"];
+    contents.Timezone = __expectString(output["Timezone"]);
   }
   if (output["IAMDatabaseAuthenticationEnabled"] !== undefined) {
     contents.IAMDatabaseAuthenticationEnabled = __parseBoolean(output["IAMDatabaseAuthenticationEnabled"]);
@@ -22526,7 +22527,7 @@ const deserializeAws_queryDBInstanceAutomatedBackup = (
     contents.BackupRetentionPeriod = parseInt(output["BackupRetentionPeriod"]);
   }
   if (output["DBInstanceAutomatedBackupsArn"] !== undefined) {
-    contents.DBInstanceAutomatedBackupsArn = output["DBInstanceAutomatedBackupsArn"];
+    contents.DBInstanceAutomatedBackupsArn = __expectString(output["DBInstanceAutomatedBackupsArn"]);
   }
   if (output.DBInstanceAutomatedBackupsReplications === "") {
     contents.DBInstanceAutomatedBackupsReplications = [];
@@ -22566,7 +22567,7 @@ const deserializeAws_queryDBInstanceAutomatedBackupMessage = (
     DBInstanceAutomatedBackups: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.DBInstanceAutomatedBackups === "") {
     contents.DBInstanceAutomatedBackups = [];
@@ -22591,7 +22592,7 @@ const deserializeAws_queryDBInstanceAutomatedBackupNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -22604,7 +22605,7 @@ const deserializeAws_queryDBInstanceAutomatedBackupQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -22617,7 +22618,7 @@ const deserializeAws_queryDBInstanceAutomatedBackupsReplication = (
     DBInstanceAutomatedBackupsArn: undefined,
   };
   if (output["DBInstanceAutomatedBackupsArn"] !== undefined) {
-    contents.DBInstanceAutomatedBackupsArn = output["DBInstanceAutomatedBackupsArn"];
+    contents.DBInstanceAutomatedBackupsArn = __expectString(output["DBInstanceAutomatedBackupsArn"]);
   }
   return contents;
 };
@@ -22653,7 +22654,7 @@ const deserializeAws_queryDBInstanceMessage = (output: any, context: __SerdeCont
     DBInstances: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.DBInstances === "") {
     contents.DBInstances = [];
@@ -22672,7 +22673,7 @@ const deserializeAws_queryDBInstanceNotFoundFault = (output: any, context: __Ser
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -22684,13 +22685,13 @@ const deserializeAws_queryDBInstanceRole = (output: any, context: __SerdeContext
     Status: undefined,
   };
   if (output["RoleArn"] !== undefined) {
-    contents.RoleArn = output["RoleArn"];
+    contents.RoleArn = __expectString(output["RoleArn"]);
   }
   if (output["FeatureName"] !== undefined) {
-    contents.FeatureName = output["FeatureName"];
+    contents.FeatureName = __expectString(output["FeatureName"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   return contents;
 };
@@ -22703,7 +22704,7 @@ const deserializeAws_queryDBInstanceRoleAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -22716,7 +22717,7 @@ const deserializeAws_queryDBInstanceRoleNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -22729,7 +22730,7 @@ const deserializeAws_queryDBInstanceRoleQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -22753,16 +22754,16 @@ const deserializeAws_queryDBInstanceStatusInfo = (output: any, context: __SerdeC
     Message: undefined,
   };
   if (output["StatusType"] !== undefined) {
-    contents.StatusType = output["StatusType"];
+    contents.StatusType = __expectString(output["StatusType"]);
   }
   if (output["Normal"] !== undefined) {
     contents.Normal = __parseBoolean(output["Normal"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -22783,7 +22784,7 @@ const deserializeAws_queryDBLogFileNotFoundFault = (output: any, context: __Serd
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -22796,16 +22797,16 @@ const deserializeAws_queryDBParameterGroup = (output: any, context: __SerdeConte
     DBParameterGroupArn: undefined,
   };
   if (output["DBParameterGroupName"] !== undefined) {
-    contents.DBParameterGroupName = output["DBParameterGroupName"];
+    contents.DBParameterGroupName = __expectString(output["DBParameterGroupName"]);
   }
   if (output["DBParameterGroupFamily"] !== undefined) {
-    contents.DBParameterGroupFamily = output["DBParameterGroupFamily"];
+    contents.DBParameterGroupFamily = __expectString(output["DBParameterGroupFamily"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output["DBParameterGroupArn"] !== undefined) {
-    contents.DBParameterGroupArn = output["DBParameterGroupArn"];
+    contents.DBParameterGroupArn = __expectString(output["DBParameterGroupArn"]);
   }
   return contents;
 };
@@ -22818,7 +22819,7 @@ const deserializeAws_queryDBParameterGroupAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -22838,7 +22839,7 @@ const deserializeAws_queryDBParameterGroupDetails = (output: any, context: __Ser
     );
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -22862,7 +22863,7 @@ const deserializeAws_queryDBParameterGroupNameMessage = (
     DBParameterGroupName: undefined,
   };
   if (output["DBParameterGroupName"] !== undefined) {
-    contents.DBParameterGroupName = output["DBParameterGroupName"];
+    contents.DBParameterGroupName = __expectString(output["DBParameterGroupName"]);
   }
   return contents;
 };
@@ -22875,7 +22876,7 @@ const deserializeAws_queryDBParameterGroupNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -22888,7 +22889,7 @@ const deserializeAws_queryDBParameterGroupQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -22902,7 +22903,7 @@ const deserializeAws_queryDBParameterGroupsMessage = (
     DBParameterGroups: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.DBParameterGroups === "") {
     contents.DBParameterGroups = [];
@@ -22922,10 +22923,10 @@ const deserializeAws_queryDBParameterGroupStatus = (output: any, context: __Serd
     ParameterApplyStatus: undefined,
   };
   if (output["DBParameterGroupName"] !== undefined) {
-    contents.DBParameterGroupName = output["DBParameterGroupName"];
+    contents.DBParameterGroupName = __expectString(output["DBParameterGroupName"]);
   }
   if (output["ParameterApplyStatus"] !== undefined) {
-    contents.ParameterApplyStatus = output["ParameterApplyStatus"];
+    contents.ParameterApplyStatus = __expectString(output["ParameterApplyStatus"]);
   }
   return contents;
 };
@@ -22963,19 +22964,19 @@ const deserializeAws_queryDBProxy = (output: any, context: __SerdeContext): DBPr
     UpdatedDate: undefined,
   };
   if (output["DBProxyName"] !== undefined) {
-    contents.DBProxyName = output["DBProxyName"];
+    contents.DBProxyName = __expectString(output["DBProxyName"]);
   }
   if (output["DBProxyArn"] !== undefined) {
-    contents.DBProxyArn = output["DBProxyArn"];
+    contents.DBProxyArn = __expectString(output["DBProxyArn"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["EngineFamily"] !== undefined) {
-    contents.EngineFamily = output["EngineFamily"];
+    contents.EngineFamily = __expectString(output["EngineFamily"]);
   }
   if (output["VpcId"] !== undefined) {
-    contents.VpcId = output["VpcId"];
+    contents.VpcId = __expectString(output["VpcId"]);
   }
   if (output.VpcSecurityGroupIds === "") {
     contents.VpcSecurityGroupIds = [];
@@ -23005,10 +23006,10 @@ const deserializeAws_queryDBProxy = (output: any, context: __SerdeContext): DBPr
     );
   }
   if (output["RoleArn"] !== undefined) {
-    contents.RoleArn = output["RoleArn"];
+    contents.RoleArn = __expectString(output["RoleArn"]);
   }
   if (output["Endpoint"] !== undefined) {
-    contents.Endpoint = output["Endpoint"];
+    contents.Endpoint = __expectString(output["Endpoint"]);
   }
   if (output["RequireTLS"] !== undefined) {
     contents.RequireTLS = __parseBoolean(output["RequireTLS"]);
@@ -23036,7 +23037,7 @@ const deserializeAws_queryDBProxyAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -23056,19 +23057,19 @@ const deserializeAws_queryDBProxyEndpoint = (output: any, context: __SerdeContex
     IsDefault: undefined,
   };
   if (output["DBProxyEndpointName"] !== undefined) {
-    contents.DBProxyEndpointName = output["DBProxyEndpointName"];
+    contents.DBProxyEndpointName = __expectString(output["DBProxyEndpointName"]);
   }
   if (output["DBProxyEndpointArn"] !== undefined) {
-    contents.DBProxyEndpointArn = output["DBProxyEndpointArn"];
+    contents.DBProxyEndpointArn = __expectString(output["DBProxyEndpointArn"]);
   }
   if (output["DBProxyName"] !== undefined) {
-    contents.DBProxyName = output["DBProxyName"];
+    contents.DBProxyName = __expectString(output["DBProxyName"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["VpcId"] !== undefined) {
-    contents.VpcId = output["VpcId"];
+    contents.VpcId = __expectString(output["VpcId"]);
   }
   if (output.VpcSecurityGroupIds === "") {
     contents.VpcSecurityGroupIds = [];
@@ -23089,13 +23090,13 @@ const deserializeAws_queryDBProxyEndpoint = (output: any, context: __SerdeContex
     );
   }
   if (output["Endpoint"] !== undefined) {
-    contents.Endpoint = output["Endpoint"];
+    contents.Endpoint = __expectString(output["Endpoint"]);
   }
   if (output["CreatedDate"] !== undefined) {
     contents.CreatedDate = new Date(output["CreatedDate"]);
   }
   if (output["TargetRole"] !== undefined) {
-    contents.TargetRole = output["TargetRole"];
+    contents.TargetRole = __expectString(output["TargetRole"]);
   }
   if (output["IsDefault"] !== undefined) {
     contents.IsDefault = __parseBoolean(output["IsDefault"]);
@@ -23111,7 +23112,7 @@ const deserializeAws_queryDBProxyEndpointAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -23135,7 +23136,7 @@ const deserializeAws_queryDBProxyEndpointNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -23148,7 +23149,7 @@ const deserializeAws_queryDBProxyEndpointQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -23169,7 +23170,7 @@ const deserializeAws_queryDBProxyNotFoundFault = (output: any, context: __SerdeC
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -23182,7 +23183,7 @@ const deserializeAws_queryDBProxyQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -23199,25 +23200,25 @@ const deserializeAws_queryDBProxyTarget = (output: any, context: __SerdeContext)
     TargetHealth: undefined,
   };
   if (output["TargetArn"] !== undefined) {
-    contents.TargetArn = output["TargetArn"];
+    contents.TargetArn = __expectString(output["TargetArn"]);
   }
   if (output["Endpoint"] !== undefined) {
-    contents.Endpoint = output["Endpoint"];
+    contents.Endpoint = __expectString(output["Endpoint"]);
   }
   if (output["TrackedClusterId"] !== undefined) {
-    contents.TrackedClusterId = output["TrackedClusterId"];
+    contents.TrackedClusterId = __expectString(output["TrackedClusterId"]);
   }
   if (output["RdsResourceId"] !== undefined) {
-    contents.RdsResourceId = output["RdsResourceId"];
+    contents.RdsResourceId = __expectString(output["RdsResourceId"]);
   }
   if (output["Port"] !== undefined) {
     contents.Port = parseInt(output["Port"]);
   }
   if (output["Type"] !== undefined) {
-    contents.Type = output["Type"];
+    contents.Type = __expectString(output["Type"]);
   }
   if (output["Role"] !== undefined) {
-    contents.Role = output["Role"];
+    contents.Role = __expectString(output["Role"]);
   }
   if (output["TargetHealth"] !== undefined) {
     contents.TargetHealth = deserializeAws_queryTargetHealth(output["TargetHealth"], context);
@@ -23233,7 +23234,7 @@ const deserializeAws_queryDBProxyTargetAlreadyRegisteredFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -23250,19 +23251,19 @@ const deserializeAws_queryDBProxyTargetGroup = (output: any, context: __SerdeCon
     UpdatedDate: undefined,
   };
   if (output["DBProxyName"] !== undefined) {
-    contents.DBProxyName = output["DBProxyName"];
+    contents.DBProxyName = __expectString(output["DBProxyName"]);
   }
   if (output["TargetGroupName"] !== undefined) {
-    contents.TargetGroupName = output["TargetGroupName"];
+    contents.TargetGroupName = __expectString(output["TargetGroupName"]);
   }
   if (output["TargetGroupArn"] !== undefined) {
-    contents.TargetGroupArn = output["TargetGroupArn"];
+    contents.TargetGroupArn = __expectString(output["TargetGroupArn"]);
   }
   if (output["IsDefault"] !== undefined) {
     contents.IsDefault = __parseBoolean(output["IsDefault"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["ConnectionPoolConfig"] !== undefined) {
     contents.ConnectionPoolConfig = deserializeAws_queryConnectionPoolConfigurationInfo(
@@ -23287,7 +23288,7 @@ const deserializeAws_queryDBProxyTargetGroupNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -23300,7 +23301,7 @@ const deserializeAws_queryDBProxyTargetNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -23316,16 +23317,16 @@ const deserializeAws_queryDBSecurityGroup = (output: any, context: __SerdeContex
     DBSecurityGroupArn: undefined,
   };
   if (output["OwnerId"] !== undefined) {
-    contents.OwnerId = output["OwnerId"];
+    contents.OwnerId = __expectString(output["OwnerId"]);
   }
   if (output["DBSecurityGroupName"] !== undefined) {
-    contents.DBSecurityGroupName = output["DBSecurityGroupName"];
+    contents.DBSecurityGroupName = __expectString(output["DBSecurityGroupName"]);
   }
   if (output["DBSecurityGroupDescription"] !== undefined) {
-    contents.DBSecurityGroupDescription = output["DBSecurityGroupDescription"];
+    contents.DBSecurityGroupDescription = __expectString(output["DBSecurityGroupDescription"]);
   }
   if (output["VpcId"] !== undefined) {
-    contents.VpcId = output["VpcId"];
+    contents.VpcId = __expectString(output["VpcId"]);
   }
   if (output.EC2SecurityGroups === "") {
     contents.EC2SecurityGroups = [];
@@ -23343,7 +23344,7 @@ const deserializeAws_queryDBSecurityGroup = (output: any, context: __SerdeContex
     contents.IPRanges = deserializeAws_queryIPRangeList(__getArrayIfSingleItem(output["IPRanges"]["IPRange"]), context);
   }
   if (output["DBSecurityGroupArn"] !== undefined) {
-    contents.DBSecurityGroupArn = output["DBSecurityGroupArn"];
+    contents.DBSecurityGroupArn = __expectString(output["DBSecurityGroupArn"]);
   }
   return contents;
 };
@@ -23356,7 +23357,7 @@ const deserializeAws_queryDBSecurityGroupAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -23370,10 +23371,10 @@ const deserializeAws_queryDBSecurityGroupMembership = (
     Status: undefined,
   };
   if (output["DBSecurityGroupName"] !== undefined) {
-    contents.DBSecurityGroupName = output["DBSecurityGroupName"];
+    contents.DBSecurityGroupName = __expectString(output["DBSecurityGroupName"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   return contents;
 };
@@ -23398,7 +23399,7 @@ const deserializeAws_queryDBSecurityGroupMessage = (output: any, context: __Serd
     DBSecurityGroups: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.DBSecurityGroups === "") {
     contents.DBSecurityGroups = [];
@@ -23420,7 +23421,7 @@ const deserializeAws_queryDBSecurityGroupNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -23433,7 +23434,7 @@ const deserializeAws_queryDBSecurityGroupNotSupportedFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -23446,7 +23447,7 @@ const deserializeAws_queryDBSecurityGroupQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -23495,79 +23496,79 @@ const deserializeAws_queryDBSnapshot = (output: any, context: __SerdeContext): D
     TagList: undefined,
   };
   if (output["DBSnapshotIdentifier"] !== undefined) {
-    contents.DBSnapshotIdentifier = output["DBSnapshotIdentifier"];
+    contents.DBSnapshotIdentifier = __expectString(output["DBSnapshotIdentifier"]);
   }
   if (output["DBInstanceIdentifier"] !== undefined) {
-    contents.DBInstanceIdentifier = output["DBInstanceIdentifier"];
+    contents.DBInstanceIdentifier = __expectString(output["DBInstanceIdentifier"]);
   }
   if (output["SnapshotCreateTime"] !== undefined) {
     contents.SnapshotCreateTime = new Date(output["SnapshotCreateTime"]);
   }
   if (output["Engine"] !== undefined) {
-    contents.Engine = output["Engine"];
+    contents.Engine = __expectString(output["Engine"]);
   }
   if (output["AllocatedStorage"] !== undefined) {
     contents.AllocatedStorage = parseInt(output["AllocatedStorage"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["Port"] !== undefined) {
     contents.Port = parseInt(output["Port"]);
   }
   if (output["AvailabilityZone"] !== undefined) {
-    contents.AvailabilityZone = output["AvailabilityZone"];
+    contents.AvailabilityZone = __expectString(output["AvailabilityZone"]);
   }
   if (output["VpcId"] !== undefined) {
-    contents.VpcId = output["VpcId"];
+    contents.VpcId = __expectString(output["VpcId"]);
   }
   if (output["InstanceCreateTime"] !== undefined) {
     contents.InstanceCreateTime = new Date(output["InstanceCreateTime"]);
   }
   if (output["MasterUsername"] !== undefined) {
-    contents.MasterUsername = output["MasterUsername"];
+    contents.MasterUsername = __expectString(output["MasterUsername"]);
   }
   if (output["EngineVersion"] !== undefined) {
-    contents.EngineVersion = output["EngineVersion"];
+    contents.EngineVersion = __expectString(output["EngineVersion"]);
   }
   if (output["LicenseModel"] !== undefined) {
-    contents.LicenseModel = output["LicenseModel"];
+    contents.LicenseModel = __expectString(output["LicenseModel"]);
   }
   if (output["SnapshotType"] !== undefined) {
-    contents.SnapshotType = output["SnapshotType"];
+    contents.SnapshotType = __expectString(output["SnapshotType"]);
   }
   if (output["Iops"] !== undefined) {
     contents.Iops = parseInt(output["Iops"]);
   }
   if (output["OptionGroupName"] !== undefined) {
-    contents.OptionGroupName = output["OptionGroupName"];
+    contents.OptionGroupName = __expectString(output["OptionGroupName"]);
   }
   if (output["PercentProgress"] !== undefined) {
     contents.PercentProgress = parseInt(output["PercentProgress"]);
   }
   if (output["SourceRegion"] !== undefined) {
-    contents.SourceRegion = output["SourceRegion"];
+    contents.SourceRegion = __expectString(output["SourceRegion"]);
   }
   if (output["SourceDBSnapshotIdentifier"] !== undefined) {
-    contents.SourceDBSnapshotIdentifier = output["SourceDBSnapshotIdentifier"];
+    contents.SourceDBSnapshotIdentifier = __expectString(output["SourceDBSnapshotIdentifier"]);
   }
   if (output["StorageType"] !== undefined) {
-    contents.StorageType = output["StorageType"];
+    contents.StorageType = __expectString(output["StorageType"]);
   }
   if (output["TdeCredentialArn"] !== undefined) {
-    contents.TdeCredentialArn = output["TdeCredentialArn"];
+    contents.TdeCredentialArn = __expectString(output["TdeCredentialArn"]);
   }
   if (output["Encrypted"] !== undefined) {
     contents.Encrypted = __parseBoolean(output["Encrypted"]);
   }
   if (output["KmsKeyId"] !== undefined) {
-    contents.KmsKeyId = output["KmsKeyId"];
+    contents.KmsKeyId = __expectString(output["KmsKeyId"]);
   }
   if (output["DBSnapshotArn"] !== undefined) {
-    contents.DBSnapshotArn = output["DBSnapshotArn"];
+    contents.DBSnapshotArn = __expectString(output["DBSnapshotArn"]);
   }
   if (output["Timezone"] !== undefined) {
-    contents.Timezone = output["Timezone"];
+    contents.Timezone = __expectString(output["Timezone"]);
   }
   if (output["IAMDatabaseAuthenticationEnabled"] !== undefined) {
     contents.IAMDatabaseAuthenticationEnabled = __parseBoolean(output["IAMDatabaseAuthenticationEnabled"]);
@@ -23582,7 +23583,7 @@ const deserializeAws_queryDBSnapshot = (output: any, context: __SerdeContext): D
     );
   }
   if (output["DbiResourceId"] !== undefined) {
-    contents.DbiResourceId = output["DbiResourceId"];
+    contents.DbiResourceId = __expectString(output["DbiResourceId"]);
   }
   if (output.TagList === "") {
     contents.TagList = [];
@@ -23601,7 +23602,7 @@ const deserializeAws_queryDBSnapshotAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -23612,7 +23613,7 @@ const deserializeAws_queryDBSnapshotAttribute = (output: any, context: __SerdeCo
     AttributeValues: undefined,
   };
   if (output["AttributeName"] !== undefined) {
-    contents.AttributeName = output["AttributeName"];
+    contents.AttributeName = __expectString(output["AttributeName"]);
   }
   if (output.AttributeValues === "") {
     contents.AttributeValues = [];
@@ -23646,7 +23647,7 @@ const deserializeAws_queryDBSnapshotAttributesResult = (
     DBSnapshotAttributes: undefined,
   };
   if (output["DBSnapshotIdentifier"] !== undefined) {
-    contents.DBSnapshotIdentifier = output["DBSnapshotIdentifier"];
+    contents.DBSnapshotIdentifier = __expectString(output["DBSnapshotIdentifier"]);
   }
   if (output.DBSnapshotAttributes === "") {
     contents.DBSnapshotAttributes = [];
@@ -23680,7 +23681,7 @@ const deserializeAws_queryDBSnapshotMessage = (output: any, context: __SerdeCont
     DBSnapshots: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.DBSnapshots === "") {
     contents.DBSnapshots = [];
@@ -23699,7 +23700,7 @@ const deserializeAws_queryDBSnapshotNotFoundFault = (output: any, context: __Ser
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -23714,16 +23715,16 @@ const deserializeAws_queryDBSubnetGroup = (output: any, context: __SerdeContext)
     DBSubnetGroupArn: undefined,
   };
   if (output["DBSubnetGroupName"] !== undefined) {
-    contents.DBSubnetGroupName = output["DBSubnetGroupName"];
+    contents.DBSubnetGroupName = __expectString(output["DBSubnetGroupName"]);
   }
   if (output["DBSubnetGroupDescription"] !== undefined) {
-    contents.DBSubnetGroupDescription = output["DBSubnetGroupDescription"];
+    contents.DBSubnetGroupDescription = __expectString(output["DBSubnetGroupDescription"]);
   }
   if (output["VpcId"] !== undefined) {
-    contents.VpcId = output["VpcId"];
+    contents.VpcId = __expectString(output["VpcId"]);
   }
   if (output["SubnetGroupStatus"] !== undefined) {
-    contents.SubnetGroupStatus = output["SubnetGroupStatus"];
+    contents.SubnetGroupStatus = __expectString(output["SubnetGroupStatus"]);
   }
   if (output.Subnets === "") {
     contents.Subnets = [];
@@ -23732,7 +23733,7 @@ const deserializeAws_queryDBSubnetGroup = (output: any, context: __SerdeContext)
     contents.Subnets = deserializeAws_querySubnetList(__getArrayIfSingleItem(output["Subnets"]["Subnet"]), context);
   }
   if (output["DBSubnetGroupArn"] !== undefined) {
-    contents.DBSubnetGroupArn = output["DBSubnetGroupArn"];
+    contents.DBSubnetGroupArn = __expectString(output["DBSubnetGroupArn"]);
   }
   return contents;
 };
@@ -23745,7 +23746,7 @@ const deserializeAws_queryDBSubnetGroupAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -23758,7 +23759,7 @@ const deserializeAws_queryDBSubnetGroupDoesNotCoverEnoughAZs = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -23769,7 +23770,7 @@ const deserializeAws_queryDBSubnetGroupMessage = (output: any, context: __SerdeC
     DBSubnetGroups: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.DBSubnetGroups === "") {
     contents.DBSubnetGroups = [];
@@ -23791,7 +23792,7 @@ const deserializeAws_queryDBSubnetGroupNotAllowedFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -23804,7 +23805,7 @@ const deserializeAws_queryDBSubnetGroupNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -23817,7 +23818,7 @@ const deserializeAws_queryDBSubnetGroupQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -23841,7 +23842,7 @@ const deserializeAws_queryDBSubnetQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -23854,7 +23855,7 @@ const deserializeAws_queryDBUpgradeDependencyFailureFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -24017,7 +24018,7 @@ const deserializeAws_queryDescribeDBLogFilesDetails = (
     Size: undefined,
   };
   if (output["LogFileName"] !== undefined) {
-    contents.LogFileName = output["LogFileName"];
+    contents.LogFileName = __expectString(output["LogFileName"]);
   }
   if (output["LastWritten"] !== undefined) {
     contents.LastWritten = parseInt(output["LastWritten"]);
@@ -24063,7 +24064,7 @@ const deserializeAws_queryDescribeDBLogFilesResponse = (
     );
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -24086,7 +24087,7 @@ const deserializeAws_queryDescribeDBProxiesResponse = (
     );
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -24109,7 +24110,7 @@ const deserializeAws_queryDescribeDBProxyEndpointsResponse = (
     );
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -24132,7 +24133,7 @@ const deserializeAws_queryDescribeDBProxyTargetGroupsResponse = (
     );
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -24152,7 +24153,7 @@ const deserializeAws_queryDescribeDBProxyTargetsResponse = (
     contents.Targets = deserializeAws_queryTargetList(__getArrayIfSingleItem(output["Targets"]["member"]), context);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -24223,16 +24224,16 @@ const deserializeAws_queryDomainMembership = (output: any, context: __SerdeConte
     IAMRoleName: undefined,
   };
   if (output["Domain"] !== undefined) {
-    contents.Domain = output["Domain"];
+    contents.Domain = __expectString(output["Domain"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["FQDN"] !== undefined) {
-    contents.FQDN = output["FQDN"];
+    contents.FQDN = __expectString(output["FQDN"]);
   }
   if (output["IAMRoleName"] !== undefined) {
-    contents.IAMRoleName = output["IAMRoleName"];
+    contents.IAMRoleName = __expectString(output["IAMRoleName"]);
   }
   return contents;
 };
@@ -24253,7 +24254,7 @@ const deserializeAws_queryDomainNotFoundFault = (output: any, context: __SerdeCo
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -24293,10 +24294,10 @@ const deserializeAws_queryDownloadDBLogFilePortionDetails = (
     AdditionalDataPending: undefined,
   };
   if (output["LogFileData"] !== undefined) {
-    contents.LogFileData = output["LogFileData"];
+    contents.LogFileData = __expectString(output["LogFileData"]);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output["AdditionalDataPending"] !== undefined) {
     contents.AdditionalDataPending = __parseBoolean(output["AdditionalDataPending"]);
@@ -24312,16 +24313,16 @@ const deserializeAws_queryEC2SecurityGroup = (output: any, context: __SerdeConte
     EC2SecurityGroupOwnerId: undefined,
   };
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["EC2SecurityGroupName"] !== undefined) {
-    contents.EC2SecurityGroupName = output["EC2SecurityGroupName"];
+    contents.EC2SecurityGroupName = __expectString(output["EC2SecurityGroupName"]);
   }
   if (output["EC2SecurityGroupId"] !== undefined) {
-    contents.EC2SecurityGroupId = output["EC2SecurityGroupId"];
+    contents.EC2SecurityGroupId = __expectString(output["EC2SecurityGroupId"]);
   }
   if (output["EC2SecurityGroupOwnerId"] !== undefined) {
-    contents.EC2SecurityGroupOwnerId = output["EC2SecurityGroupOwnerId"];
+    contents.EC2SecurityGroupOwnerId = __expectString(output["EC2SecurityGroupOwnerId"]);
   }
   return contents;
 };
@@ -24344,13 +24345,13 @@ const deserializeAws_queryEndpoint = (output: any, context: __SerdeContext): End
     HostedZoneId: undefined,
   };
   if (output["Address"] !== undefined) {
-    contents.Address = output["Address"];
+    contents.Address = __expectString(output["Address"]);
   }
   if (output["Port"] !== undefined) {
     contents.Port = parseInt(output["Port"]);
   }
   if (output["HostedZoneId"] !== undefined) {
-    contents.HostedZoneId = output["HostedZoneId"];
+    contents.HostedZoneId = __expectString(output["HostedZoneId"]);
   }
   return contents;
 };
@@ -24362,10 +24363,10 @@ const deserializeAws_queryEngineDefaults = (output: any, context: __SerdeContext
     Parameters: undefined,
   };
   if (output["DBParameterGroupFamily"] !== undefined) {
-    contents.DBParameterGroupFamily = output["DBParameterGroupFamily"];
+    contents.DBParameterGroupFamily = __expectString(output["DBParameterGroupFamily"]);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.Parameters === "") {
     contents.Parameters = [];
@@ -24386,7 +24387,7 @@ const deserializeAws_queryEngineModeList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -24400,13 +24401,13 @@ const deserializeAws_queryEvent = (output: any, context: __SerdeContext): Event 
     SourceArn: undefined,
   };
   if (output["SourceIdentifier"] !== undefined) {
-    contents.SourceIdentifier = output["SourceIdentifier"];
+    contents.SourceIdentifier = __expectString(output["SourceIdentifier"]);
   }
   if (output["SourceType"] !== undefined) {
-    contents.SourceType = output["SourceType"];
+    contents.SourceType = __expectString(output["SourceType"]);
   }
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   if (output.EventCategories === "") {
     contents.EventCategories = [];
@@ -24421,7 +24422,7 @@ const deserializeAws_queryEvent = (output: any, context: __SerdeContext): Event 
     contents.Date = new Date(output["Date"]);
   }
   if (output["SourceArn"] !== undefined) {
-    contents.SourceArn = output["SourceArn"];
+    contents.SourceArn = __expectString(output["SourceArn"]);
   }
   return contents;
 };
@@ -24433,7 +24434,7 @@ const deserializeAws_queryEventCategoriesList = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -24443,7 +24444,7 @@ const deserializeAws_queryEventCategoriesMap = (output: any, context: __SerdeCon
     EventCategories: undefined,
   };
   if (output["SourceType"] !== undefined) {
-    contents.SourceType = output["SourceType"];
+    contents.SourceType = __expectString(output["SourceType"]);
   }
   if (output.EventCategories === "") {
     contents.EventCategories = [];
@@ -24504,7 +24505,7 @@ const deserializeAws_queryEventsMessage = (output: any, context: __SerdeContext)
     Events: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.Events === "") {
     contents.Events = [];
@@ -24529,22 +24530,22 @@ const deserializeAws_queryEventSubscription = (output: any, context: __SerdeCont
     EventSubscriptionArn: undefined,
   };
   if (output["CustomerAwsId"] !== undefined) {
-    contents.CustomerAwsId = output["CustomerAwsId"];
+    contents.CustomerAwsId = __expectString(output["CustomerAwsId"]);
   }
   if (output["CustSubscriptionId"] !== undefined) {
-    contents.CustSubscriptionId = output["CustSubscriptionId"];
+    contents.CustSubscriptionId = __expectString(output["CustSubscriptionId"]);
   }
   if (output["SnsTopicArn"] !== undefined) {
-    contents.SnsTopicArn = output["SnsTopicArn"];
+    contents.SnsTopicArn = __expectString(output["SnsTopicArn"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["SubscriptionCreationTime"] !== undefined) {
-    contents.SubscriptionCreationTime = output["SubscriptionCreationTime"];
+    contents.SubscriptionCreationTime = __expectString(output["SubscriptionCreationTime"]);
   }
   if (output["SourceType"] !== undefined) {
-    contents.SourceType = output["SourceType"];
+    contents.SourceType = __expectString(output["SourceType"]);
   }
   if (output.SourceIdsList === "") {
     contents.SourceIdsList = [];
@@ -24568,7 +24569,7 @@ const deserializeAws_queryEventSubscription = (output: any, context: __SerdeCont
     contents.Enabled = __parseBoolean(output["Enabled"]);
   }
   if (output["EventSubscriptionArn"] !== undefined) {
-    contents.EventSubscriptionArn = output["EventSubscriptionArn"];
+    contents.EventSubscriptionArn = __expectString(output["EventSubscriptionArn"]);
   }
   return contents;
 };
@@ -24581,7 +24582,7 @@ const deserializeAws_queryEventSubscriptionQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -24606,7 +24607,7 @@ const deserializeAws_queryEventSubscriptionsMessage = (
     EventSubscriptionsList: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.EventSubscriptionsList === "") {
     contents.EventSubscriptionsList = [];
@@ -24642,10 +24643,10 @@ const deserializeAws_queryExportTask = (output: any, context: __SerdeContext): E
     WarningMessage: undefined,
   };
   if (output["ExportTaskIdentifier"] !== undefined) {
-    contents.ExportTaskIdentifier = output["ExportTaskIdentifier"];
+    contents.ExportTaskIdentifier = __expectString(output["ExportTaskIdentifier"]);
   }
   if (output["SourceArn"] !== undefined) {
-    contents.SourceArn = output["SourceArn"];
+    contents.SourceArn = __expectString(output["SourceArn"]);
   }
   if (output.ExportOnly === "") {
     contents.ExportOnly = [];
@@ -24666,19 +24667,19 @@ const deserializeAws_queryExportTask = (output: any, context: __SerdeContext): E
     contents.TaskEndTime = new Date(output["TaskEndTime"]);
   }
   if (output["S3Bucket"] !== undefined) {
-    contents.S3Bucket = output["S3Bucket"];
+    contents.S3Bucket = __expectString(output["S3Bucket"]);
   }
   if (output["S3Prefix"] !== undefined) {
-    contents.S3Prefix = output["S3Prefix"];
+    contents.S3Prefix = __expectString(output["S3Prefix"]);
   }
   if (output["IamRoleArn"] !== undefined) {
-    contents.IamRoleArn = output["IamRoleArn"];
+    contents.IamRoleArn = __expectString(output["IamRoleArn"]);
   }
   if (output["KmsKeyId"] !== undefined) {
-    contents.KmsKeyId = output["KmsKeyId"];
+    contents.KmsKeyId = __expectString(output["KmsKeyId"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["PercentProgress"] !== undefined) {
     contents.PercentProgress = parseInt(output["PercentProgress"]);
@@ -24687,10 +24688,10 @@ const deserializeAws_queryExportTask = (output: any, context: __SerdeContext): E
     contents.TotalExtractedDataInGB = parseInt(output["TotalExtractedDataInGB"]);
   }
   if (output["FailureCause"] !== undefined) {
-    contents.FailureCause = output["FailureCause"];
+    contents.FailureCause = __expectString(output["FailureCause"]);
   }
   if (output["WarningMessage"] !== undefined) {
-    contents.WarningMessage = output["WarningMessage"];
+    contents.WarningMessage = __expectString(output["WarningMessage"]);
   }
   return contents;
 };
@@ -24703,7 +24704,7 @@ const deserializeAws_queryExportTaskAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -24713,7 +24714,7 @@ const deserializeAws_queryExportTaskNotFoundFault = (output: any, context: __Ser
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -24735,7 +24736,7 @@ const deserializeAws_queryExportTasksMessage = (output: any, context: __SerdeCon
     ExportTasks: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.ExportTasks === "") {
     contents.ExportTasks = [];
@@ -24779,13 +24780,13 @@ const deserializeAws_queryFailoverState = (output: any, context: __SerdeContext)
     ToDbClusterArn: undefined,
   };
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["FromDbClusterArn"] !== undefined) {
-    contents.FromDbClusterArn = output["FromDbClusterArn"];
+    contents.FromDbClusterArn = __expectString(output["FromDbClusterArn"]);
   }
   if (output["ToDbClusterArn"] !== undefined) {
-    contents.ToDbClusterArn = output["ToDbClusterArn"];
+    contents.ToDbClusterArn = __expectString(output["ToDbClusterArn"]);
   }
   return contents;
 };
@@ -24797,7 +24798,7 @@ const deserializeAws_queryFeatureNameList = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -24816,25 +24817,25 @@ const deserializeAws_queryGlobalCluster = (output: any, context: __SerdeContext)
     FailoverState: undefined,
   };
   if (output["GlobalClusterIdentifier"] !== undefined) {
-    contents.GlobalClusterIdentifier = output["GlobalClusterIdentifier"];
+    contents.GlobalClusterIdentifier = __expectString(output["GlobalClusterIdentifier"]);
   }
   if (output["GlobalClusterResourceId"] !== undefined) {
-    contents.GlobalClusterResourceId = output["GlobalClusterResourceId"];
+    contents.GlobalClusterResourceId = __expectString(output["GlobalClusterResourceId"]);
   }
   if (output["GlobalClusterArn"] !== undefined) {
-    contents.GlobalClusterArn = output["GlobalClusterArn"];
+    contents.GlobalClusterArn = __expectString(output["GlobalClusterArn"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["Engine"] !== undefined) {
-    contents.Engine = output["Engine"];
+    contents.Engine = __expectString(output["Engine"]);
   }
   if (output["EngineVersion"] !== undefined) {
-    contents.EngineVersion = output["EngineVersion"];
+    contents.EngineVersion = __expectString(output["EngineVersion"]);
   }
   if (output["DatabaseName"] !== undefined) {
-    contents.DatabaseName = output["DatabaseName"];
+    contents.DatabaseName = __expectString(output["DatabaseName"]);
   }
   if (output["StorageEncrypted"] !== undefined) {
     contents.StorageEncrypted = __parseBoolean(output["StorageEncrypted"]);
@@ -24868,7 +24869,7 @@ const deserializeAws_queryGlobalClusterAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -24892,7 +24893,7 @@ const deserializeAws_queryGlobalClusterMember = (output: any, context: __SerdeCo
     GlobalWriteForwardingStatus: undefined,
   };
   if (output["DBClusterArn"] !== undefined) {
-    contents.DBClusterArn = output["DBClusterArn"];
+    contents.DBClusterArn = __expectString(output["DBClusterArn"]);
   }
   if (output.Readers === "") {
     contents.Readers = [];
@@ -24904,7 +24905,7 @@ const deserializeAws_queryGlobalClusterMember = (output: any, context: __SerdeCo
     contents.IsWriter = __parseBoolean(output["IsWriter"]);
   }
   if (output["GlobalWriteForwardingStatus"] !== undefined) {
-    contents.GlobalWriteForwardingStatus = output["GlobalWriteForwardingStatus"];
+    contents.GlobalWriteForwardingStatus = __expectString(output["GlobalWriteForwardingStatus"]);
   }
   return contents;
 };
@@ -24928,7 +24929,7 @@ const deserializeAws_queryGlobalClusterNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -24941,7 +24942,7 @@ const deserializeAws_queryGlobalClusterQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -24952,7 +24953,7 @@ const deserializeAws_queryGlobalClustersMessage = (output: any, context: __Serde
     GlobalClusters: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.GlobalClusters === "") {
     contents.GlobalClusters = [];
@@ -24974,7 +24975,7 @@ const deserializeAws_queryIamRoleMissingPermissionsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -24984,7 +24985,7 @@ const deserializeAws_queryIamRoleNotFoundFault = (output: any, context: __SerdeC
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -25001,25 +25002,25 @@ const deserializeAws_queryInstallationMedia = (output: any, context: __SerdeCont
     FailureCause: undefined,
   };
   if (output["InstallationMediaId"] !== undefined) {
-    contents.InstallationMediaId = output["InstallationMediaId"];
+    contents.InstallationMediaId = __expectString(output["InstallationMediaId"]);
   }
   if (output["CustomAvailabilityZoneId"] !== undefined) {
-    contents.CustomAvailabilityZoneId = output["CustomAvailabilityZoneId"];
+    contents.CustomAvailabilityZoneId = __expectString(output["CustomAvailabilityZoneId"]);
   }
   if (output["Engine"] !== undefined) {
-    contents.Engine = output["Engine"];
+    contents.Engine = __expectString(output["Engine"]);
   }
   if (output["EngineVersion"] !== undefined) {
-    contents.EngineVersion = output["EngineVersion"];
+    contents.EngineVersion = __expectString(output["EngineVersion"]);
   }
   if (output["EngineInstallationMediaPath"] !== undefined) {
-    contents.EngineInstallationMediaPath = output["EngineInstallationMediaPath"];
+    contents.EngineInstallationMediaPath = __expectString(output["EngineInstallationMediaPath"]);
   }
   if (output["OSInstallationMediaPath"] !== undefined) {
-    contents.OSInstallationMediaPath = output["OSInstallationMediaPath"];
+    contents.OSInstallationMediaPath = __expectString(output["OSInstallationMediaPath"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["FailureCause"] !== undefined) {
     contents.FailureCause = deserializeAws_queryInstallationMediaFailureCause(output["FailureCause"], context);
@@ -25035,7 +25036,7 @@ const deserializeAws_queryInstallationMediaAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -25048,7 +25049,7 @@ const deserializeAws_queryInstallationMediaFailureCause = (
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -25073,7 +25074,7 @@ const deserializeAws_queryInstallationMediaMessage = (
     InstallationMedia: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.InstallationMedia === "") {
     contents.InstallationMedia = [];
@@ -25095,7 +25096,7 @@ const deserializeAws_queryInstallationMediaNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -25108,7 +25109,7 @@ const deserializeAws_queryInstanceQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -25121,7 +25122,7 @@ const deserializeAws_queryInsufficientAvailableIPsInSubnetFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -25134,7 +25135,7 @@ const deserializeAws_queryInsufficientDBClusterCapacityFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -25147,7 +25148,7 @@ const deserializeAws_queryInsufficientDBInstanceCapacityFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -25160,7 +25161,7 @@ const deserializeAws_queryInsufficientStorageClusterCapacityFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -25173,7 +25174,7 @@ const deserializeAws_queryInvalidDBClusterCapacityFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -25186,7 +25187,7 @@ const deserializeAws_queryInvalidDBClusterEndpointStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -25199,7 +25200,7 @@ const deserializeAws_queryInvalidDBClusterSnapshotStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -25212,7 +25213,7 @@ const deserializeAws_queryInvalidDBClusterStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -25225,7 +25226,7 @@ const deserializeAws_queryInvalidDBInstanceAutomatedBackupStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -25238,7 +25239,7 @@ const deserializeAws_queryInvalidDBInstanceStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -25251,7 +25252,7 @@ const deserializeAws_queryInvalidDBParameterGroupStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -25264,7 +25265,7 @@ const deserializeAws_queryInvalidDBProxyEndpointStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -25277,7 +25278,7 @@ const deserializeAws_queryInvalidDBProxyStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -25290,7 +25291,7 @@ const deserializeAws_queryInvalidDBSecurityGroupStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -25303,7 +25304,7 @@ const deserializeAws_queryInvalidDBSnapshotStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -25316,7 +25317,7 @@ const deserializeAws_queryInvalidDBSubnetGroupFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -25329,7 +25330,7 @@ const deserializeAws_queryInvalidDBSubnetGroupStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -25342,7 +25343,7 @@ const deserializeAws_queryInvalidDBSubnetStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -25355,7 +25356,7 @@ const deserializeAws_queryInvalidEventSubscriptionStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -25365,7 +25366,7 @@ const deserializeAws_queryInvalidExportOnlyFault = (output: any, context: __Serd
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -25378,7 +25379,7 @@ const deserializeAws_queryInvalidExportSourceStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -25391,7 +25392,7 @@ const deserializeAws_queryInvalidExportTaskStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -25404,7 +25405,7 @@ const deserializeAws_queryInvalidGlobalClusterStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -25417,7 +25418,7 @@ const deserializeAws_queryInvalidOptionGroupStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -25427,7 +25428,7 @@ const deserializeAws_queryInvalidRestoreFault = (output: any, context: __SerdeCo
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -25437,7 +25438,7 @@ const deserializeAws_queryInvalidS3BucketFault = (output: any, context: __SerdeC
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -25447,7 +25448,7 @@ const deserializeAws_queryInvalidSubnet = (output: any, context: __SerdeContext)
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -25460,7 +25461,7 @@ const deserializeAws_queryInvalidVPCNetworkStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -25471,10 +25472,10 @@ const deserializeAws_queryIPRange = (output: any, context: __SerdeContext): IPRa
     CIDRIP: undefined,
   };
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["CIDRIP"] !== undefined) {
-    contents.CIDRIP = output["CIDRIP"];
+    contents.CIDRIP = __expectString(output["CIDRIP"]);
   }
   return contents;
 };
@@ -25498,7 +25499,7 @@ const deserializeAws_queryKMSKeyNotAccessibleFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -25510,7 +25511,7 @@ const deserializeAws_queryLogTypeList = (output: any, context: __SerdeContext): 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -25523,10 +25524,10 @@ const deserializeAws_queryMinimumEngineVersionPerAllowedValue = (
     MinimumEngineVersion: undefined,
   };
   if (output["AllowedValue"] !== undefined) {
-    contents.AllowedValue = output["AllowedValue"];
+    contents.AllowedValue = __expectString(output["AllowedValue"]);
   }
   if (output["MinimumEngineVersion"] !== undefined) {
-    contents.MinimumEngineVersion = output["MinimumEngineVersion"];
+    contents.MinimumEngineVersion = __expectString(output["MinimumEngineVersion"]);
   }
   return contents;
 };
@@ -25718,10 +25719,10 @@ const deserializeAws_queryOption = (output: any, context: __SerdeContext): Optio
     VpcSecurityGroupMemberships: undefined,
   };
   if (output["OptionName"] !== undefined) {
-    contents.OptionName = output["OptionName"];
+    contents.OptionName = __expectString(output["OptionName"]);
   }
   if (output["OptionDescription"] !== undefined) {
-    contents.OptionDescription = output["OptionDescription"];
+    contents.OptionDescription = __expectString(output["OptionDescription"]);
   }
   if (output["Persistent"] !== undefined) {
     contents.Persistent = __parseBoolean(output["Persistent"]);
@@ -25733,7 +25734,7 @@ const deserializeAws_queryOption = (output: any, context: __SerdeContext): Optio
     contents.Port = parseInt(output["Port"]);
   }
   if (output["OptionVersion"] !== undefined) {
-    contents.OptionVersion = output["OptionVersion"];
+    contents.OptionVersion = __expectString(output["OptionVersion"]);
   }
   if (output.OptionSettings === "") {
     contents.OptionSettings = [];
@@ -25783,16 +25784,16 @@ const deserializeAws_queryOptionGroup = (output: any, context: __SerdeContext): 
     OptionGroupArn: undefined,
   };
   if (output["OptionGroupName"] !== undefined) {
-    contents.OptionGroupName = output["OptionGroupName"];
+    contents.OptionGroupName = __expectString(output["OptionGroupName"]);
   }
   if (output["OptionGroupDescription"] !== undefined) {
-    contents.OptionGroupDescription = output["OptionGroupDescription"];
+    contents.OptionGroupDescription = __expectString(output["OptionGroupDescription"]);
   }
   if (output["EngineName"] !== undefined) {
-    contents.EngineName = output["EngineName"];
+    contents.EngineName = __expectString(output["EngineName"]);
   }
   if (output["MajorEngineVersion"] !== undefined) {
-    contents.MajorEngineVersion = output["MajorEngineVersion"];
+    contents.MajorEngineVersion = __expectString(output["MajorEngineVersion"]);
   }
   if (output.Options === "") {
     contents.Options = [];
@@ -25804,10 +25805,10 @@ const deserializeAws_queryOptionGroup = (output: any, context: __SerdeContext): 
     contents.AllowsVpcAndNonVpcInstanceMemberships = __parseBoolean(output["AllowsVpcAndNonVpcInstanceMemberships"]);
   }
   if (output["VpcId"] !== undefined) {
-    contents.VpcId = output["VpcId"];
+    contents.VpcId = __expectString(output["VpcId"]);
   }
   if (output["OptionGroupArn"] !== undefined) {
-    contents.OptionGroupArn = output["OptionGroupArn"];
+    contents.OptionGroupArn = __expectString(output["OptionGroupArn"]);
   }
   return contents;
 };
@@ -25820,7 +25821,7 @@ const deserializeAws_queryOptionGroupAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -25831,10 +25832,10 @@ const deserializeAws_queryOptionGroupMembership = (output: any, context: __Serde
     Status: undefined,
   };
   if (output["OptionGroupName"] !== undefined) {
-    contents.OptionGroupName = output["OptionGroupName"];
+    contents.OptionGroupName = __expectString(output["OptionGroupName"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   return contents;
 };
@@ -25861,7 +25862,7 @@ const deserializeAws_queryOptionGroupNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -25886,19 +25887,19 @@ const deserializeAws_queryOptionGroupOption = (output: any, context: __SerdeCont
     OptionGroupOptionVersions: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output["EngineName"] !== undefined) {
-    contents.EngineName = output["EngineName"];
+    contents.EngineName = __expectString(output["EngineName"]);
   }
   if (output["MajorEngineVersion"] !== undefined) {
-    contents.MajorEngineVersion = output["MajorEngineVersion"];
+    contents.MajorEngineVersion = __expectString(output["MajorEngineVersion"]);
   }
   if (output["MinimumRequiredMinorEngineVersion"] !== undefined) {
-    contents.MinimumRequiredMinorEngineVersion = output["MinimumRequiredMinorEngineVersion"];
+    contents.MinimumRequiredMinorEngineVersion = __expectString(output["MinimumRequiredMinorEngineVersion"]);
   }
   if (output["PortRequired"] !== undefined) {
     contents.PortRequired = __parseBoolean(output["PortRequired"]);
@@ -25984,19 +25985,19 @@ const deserializeAws_queryOptionGroupOptionSetting = (
     MinimumEngineVersionPerAllowedValue: undefined,
   };
   if (output["SettingName"] !== undefined) {
-    contents.SettingName = output["SettingName"];
+    contents.SettingName = __expectString(output["SettingName"]);
   }
   if (output["SettingDescription"] !== undefined) {
-    contents.SettingDescription = output["SettingDescription"];
+    contents.SettingDescription = __expectString(output["SettingDescription"]);
   }
   if (output["DefaultValue"] !== undefined) {
-    contents.DefaultValue = output["DefaultValue"];
+    contents.DefaultValue = __expectString(output["DefaultValue"]);
   }
   if (output["ApplyType"] !== undefined) {
-    contents.ApplyType = output["ApplyType"];
+    contents.ApplyType = __expectString(output["ApplyType"]);
   }
   if (output["AllowedValues"] !== undefined) {
-    contents.AllowedValues = output["AllowedValues"];
+    contents.AllowedValues = __expectString(output["AllowedValues"]);
   }
   if (output["IsModifiable"] !== undefined) {
     contents.IsModifiable = __parseBoolean(output["IsModifiable"]);
@@ -26062,7 +26063,7 @@ const deserializeAws_queryOptionGroupOptionsMessage = (
     );
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -26086,7 +26087,7 @@ const deserializeAws_queryOptionGroupQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -26106,7 +26107,7 @@ const deserializeAws_queryOptionGroups = (output: any, context: __SerdeContext):
     );
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -26129,7 +26130,7 @@ const deserializeAws_queryOptionsConflictsWith = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -26140,7 +26141,7 @@ const deserializeAws_queryOptionsDependedOn = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -26157,25 +26158,25 @@ const deserializeAws_queryOptionSetting = (output: any, context: __SerdeContext)
     IsCollection: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["Value"] !== undefined) {
-    contents.Value = output["Value"];
+    contents.Value = __expectString(output["Value"]);
   }
   if (output["DefaultValue"] !== undefined) {
-    contents.DefaultValue = output["DefaultValue"];
+    contents.DefaultValue = __expectString(output["DefaultValue"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output["ApplyType"] !== undefined) {
-    contents.ApplyType = output["ApplyType"];
+    contents.ApplyType = __expectString(output["ApplyType"]);
   }
   if (output["DataType"] !== undefined) {
-    contents.DataType = output["DataType"];
+    contents.DataType = __expectString(output["DataType"]);
   }
   if (output["AllowedValues"] !== undefined) {
-    contents.AllowedValues = output["AllowedValues"];
+    contents.AllowedValues = __expectString(output["AllowedValues"]);
   }
   if (output["IsModifiable"] !== undefined) {
     contents.IsModifiable = __parseBoolean(output["IsModifiable"]);
@@ -26214,7 +26215,7 @@ const deserializeAws_queryOptionVersion = (output: any, context: __SerdeContext)
     IsDefault: undefined,
   };
   if (output["Version"] !== undefined) {
-    contents.Version = output["Version"];
+    contents.Version = __expectString(output["Version"]);
   }
   if (output["IsDefault"] !== undefined) {
     contents.IsDefault = __parseBoolean(output["IsDefault"]);
@@ -26257,19 +26258,19 @@ const deserializeAws_queryOrderableDBInstanceOption = (
     SupportsGlobalDatabases: undefined,
   };
   if (output["Engine"] !== undefined) {
-    contents.Engine = output["Engine"];
+    contents.Engine = __expectString(output["Engine"]);
   }
   if (output["EngineVersion"] !== undefined) {
-    contents.EngineVersion = output["EngineVersion"];
+    contents.EngineVersion = __expectString(output["EngineVersion"]);
   }
   if (output["DBInstanceClass"] !== undefined) {
-    contents.DBInstanceClass = output["DBInstanceClass"];
+    contents.DBInstanceClass = __expectString(output["DBInstanceClass"]);
   }
   if (output["LicenseModel"] !== undefined) {
-    contents.LicenseModel = output["LicenseModel"];
+    contents.LicenseModel = __expectString(output["LicenseModel"]);
   }
   if (output["AvailabilityZoneGroup"] !== undefined) {
-    contents.AvailabilityZoneGroup = output["AvailabilityZoneGroup"];
+    contents.AvailabilityZoneGroup = __expectString(output["AvailabilityZoneGroup"]);
   }
   if (output.AvailabilityZones === "") {
     contents.AvailabilityZones = [];
@@ -26293,7 +26294,7 @@ const deserializeAws_queryOrderableDBInstanceOption = (
     contents.SupportsStorageEncryption = __parseBoolean(output["SupportsStorageEncryption"]);
   }
   if (output["StorageType"] !== undefined) {
-    contents.StorageType = output["StorageType"];
+    contents.StorageType = __expectString(output["StorageType"]);
   }
   if (output["SupportsIops"] !== undefined) {
     contents.SupportsIops = __parseBoolean(output["SupportsIops"]);
@@ -26408,7 +26409,7 @@ const deserializeAws_queryOrderableDBInstanceOptionsMessage = (
     );
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -26418,7 +26419,7 @@ const deserializeAws_queryOutpost = (output: any, context: __SerdeContext): Outp
     Arn: undefined,
   };
   if (output["Arn"] !== undefined) {
-    contents.Arn = output["Arn"];
+    contents.Arn = __expectString(output["Arn"]);
   }
   return contents;
 };
@@ -26438,34 +26439,34 @@ const deserializeAws_queryParameter = (output: any, context: __SerdeContext): Pa
     SupportedEngineModes: undefined,
   };
   if (output["ParameterName"] !== undefined) {
-    contents.ParameterName = output["ParameterName"];
+    contents.ParameterName = __expectString(output["ParameterName"]);
   }
   if (output["ParameterValue"] !== undefined) {
-    contents.ParameterValue = output["ParameterValue"];
+    contents.ParameterValue = __expectString(output["ParameterValue"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output["Source"] !== undefined) {
-    contents.Source = output["Source"];
+    contents.Source = __expectString(output["Source"]);
   }
   if (output["ApplyType"] !== undefined) {
-    contents.ApplyType = output["ApplyType"];
+    contents.ApplyType = __expectString(output["ApplyType"]);
   }
   if (output["DataType"] !== undefined) {
-    contents.DataType = output["DataType"];
+    contents.DataType = __expectString(output["DataType"]);
   }
   if (output["AllowedValues"] !== undefined) {
-    contents.AllowedValues = output["AllowedValues"];
+    contents.AllowedValues = __expectString(output["AllowedValues"]);
   }
   if (output["IsModifiable"] !== undefined) {
     contents.IsModifiable = __parseBoolean(output["IsModifiable"]);
   }
   if (output["MinimumEngineVersion"] !== undefined) {
-    contents.MinimumEngineVersion = output["MinimumEngineVersion"];
+    contents.MinimumEngineVersion = __expectString(output["MinimumEngineVersion"]);
   }
   if (output["ApplyMethod"] !== undefined) {
-    contents.ApplyMethod = output["ApplyMethod"];
+    contents.ApplyMethod = __expectString(output["ApplyMethod"]);
   }
   if (output.SupportedEngineModes === "") {
     contents.SupportedEngineModes = [];
@@ -26532,7 +26533,7 @@ const deserializeAws_queryPendingMaintenanceAction = (
     Description: undefined,
   };
   if (output["Action"] !== undefined) {
-    contents.Action = output["Action"];
+    contents.Action = __expectString(output["Action"]);
   }
   if (output["AutoAppliedAfterDate"] !== undefined) {
     contents.AutoAppliedAfterDate = new Date(output["AutoAppliedAfterDate"]);
@@ -26541,13 +26542,13 @@ const deserializeAws_queryPendingMaintenanceAction = (
     contents.ForcedApplyDate = new Date(output["ForcedApplyDate"]);
   }
   if (output["OptInStatus"] !== undefined) {
-    contents.OptInStatus = output["OptInStatus"];
+    contents.OptInStatus = __expectString(output["OptInStatus"]);
   }
   if (output["CurrentApplyDate"] !== undefined) {
     contents.CurrentApplyDate = new Date(output["CurrentApplyDate"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   return contents;
 };
@@ -26601,7 +26602,7 @@ const deserializeAws_queryPendingMaintenanceActionsMessage = (
     );
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -26626,13 +26627,13 @@ const deserializeAws_queryPendingModifiedValues = (output: any, context: __Serde
     IAMDatabaseAuthenticationEnabled: undefined,
   };
   if (output["DBInstanceClass"] !== undefined) {
-    contents.DBInstanceClass = output["DBInstanceClass"];
+    contents.DBInstanceClass = __expectString(output["DBInstanceClass"]);
   }
   if (output["AllocatedStorage"] !== undefined) {
     contents.AllocatedStorage = parseInt(output["AllocatedStorage"]);
   }
   if (output["MasterUserPassword"] !== undefined) {
-    contents.MasterUserPassword = output["MasterUserPassword"];
+    contents.MasterUserPassword = __expectString(output["MasterUserPassword"]);
   }
   if (output["Port"] !== undefined) {
     contents.Port = parseInt(output["Port"]);
@@ -26644,25 +26645,25 @@ const deserializeAws_queryPendingModifiedValues = (output: any, context: __Serde
     contents.MultiAZ = __parseBoolean(output["MultiAZ"]);
   }
   if (output["EngineVersion"] !== undefined) {
-    contents.EngineVersion = output["EngineVersion"];
+    contents.EngineVersion = __expectString(output["EngineVersion"]);
   }
   if (output["LicenseModel"] !== undefined) {
-    contents.LicenseModel = output["LicenseModel"];
+    contents.LicenseModel = __expectString(output["LicenseModel"]);
   }
   if (output["Iops"] !== undefined) {
     contents.Iops = parseInt(output["Iops"]);
   }
   if (output["DBInstanceIdentifier"] !== undefined) {
-    contents.DBInstanceIdentifier = output["DBInstanceIdentifier"];
+    contents.DBInstanceIdentifier = __expectString(output["DBInstanceIdentifier"]);
   }
   if (output["StorageType"] !== undefined) {
-    contents.StorageType = output["StorageType"];
+    contents.StorageType = __expectString(output["StorageType"]);
   }
   if (output["CACertificateIdentifier"] !== undefined) {
-    contents.CACertificateIdentifier = output["CACertificateIdentifier"];
+    contents.CACertificateIdentifier = __expectString(output["CACertificateIdentifier"]);
   }
   if (output["DBSubnetGroupName"] !== undefined) {
-    contents.DBSubnetGroupName = output["DBSubnetGroupName"];
+    contents.DBSubnetGroupName = __expectString(output["DBSubnetGroupName"]);
   }
   if (output["PendingCloudwatchLogsExports"] !== undefined) {
     contents.PendingCloudwatchLogsExports = deserializeAws_queryPendingCloudwatchLogsExports(
@@ -26693,7 +26694,7 @@ const deserializeAws_queryPointInTimeRestoreNotEnabledFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -26704,10 +26705,10 @@ const deserializeAws_queryProcessorFeature = (output: any, context: __SerdeConte
     Value: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["Value"] !== undefined) {
-    contents.Value = output["Value"];
+    contents.Value = __expectString(output["Value"]);
   }
   return contents;
 };
@@ -26757,7 +26758,7 @@ const deserializeAws_queryProvisionedIopsNotAvailableInAZFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -26811,7 +26812,7 @@ const deserializeAws_queryReadersArnList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -26822,7 +26823,7 @@ const deserializeAws_queryReadReplicaDBClusterIdentifierList = (output: any, con
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -26833,7 +26834,7 @@ const deserializeAws_queryReadReplicaDBInstanceIdentifierList = (output: any, co
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -26844,7 +26845,7 @@ const deserializeAws_queryReadReplicaIdentifierList = (output: any, context: __S
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -26867,7 +26868,7 @@ const deserializeAws_queryRecurringCharge = (output: any, context: __SerdeContex
     contents.RecurringChargeAmount = parseFloat(output["RecurringChargeAmount"]);
   }
   if (output["RecurringChargeFrequency"] !== undefined) {
-    contents.RecurringChargeFrequency = output["RecurringChargeFrequency"];
+    contents.RecurringChargeFrequency = __expectString(output["RecurringChargeFrequency"]);
   }
   return contents;
 };
@@ -26948,13 +26949,13 @@ const deserializeAws_queryReservedDBInstance = (output: any, context: __SerdeCon
     LeaseId: undefined,
   };
   if (output["ReservedDBInstanceId"] !== undefined) {
-    contents.ReservedDBInstanceId = output["ReservedDBInstanceId"];
+    contents.ReservedDBInstanceId = __expectString(output["ReservedDBInstanceId"]);
   }
   if (output["ReservedDBInstancesOfferingId"] !== undefined) {
-    contents.ReservedDBInstancesOfferingId = output["ReservedDBInstancesOfferingId"];
+    contents.ReservedDBInstancesOfferingId = __expectString(output["ReservedDBInstancesOfferingId"]);
   }
   if (output["DBInstanceClass"] !== undefined) {
-    contents.DBInstanceClass = output["DBInstanceClass"];
+    contents.DBInstanceClass = __expectString(output["DBInstanceClass"]);
   }
   if (output["StartTime"] !== undefined) {
     contents.StartTime = new Date(output["StartTime"]);
@@ -26969,22 +26970,22 @@ const deserializeAws_queryReservedDBInstance = (output: any, context: __SerdeCon
     contents.UsagePrice = parseFloat(output["UsagePrice"]);
   }
   if (output["CurrencyCode"] !== undefined) {
-    contents.CurrencyCode = output["CurrencyCode"];
+    contents.CurrencyCode = __expectString(output["CurrencyCode"]);
   }
   if (output["DBInstanceCount"] !== undefined) {
     contents.DBInstanceCount = parseInt(output["DBInstanceCount"]);
   }
   if (output["ProductDescription"] !== undefined) {
-    contents.ProductDescription = output["ProductDescription"];
+    contents.ProductDescription = __expectString(output["ProductDescription"]);
   }
   if (output["OfferingType"] !== undefined) {
-    contents.OfferingType = output["OfferingType"];
+    contents.OfferingType = __expectString(output["OfferingType"]);
   }
   if (output["MultiAZ"] !== undefined) {
     contents.MultiAZ = __parseBoolean(output["MultiAZ"]);
   }
   if (output["State"] !== undefined) {
-    contents.State = output["State"];
+    contents.State = __expectString(output["State"]);
   }
   if (output.RecurringCharges === "") {
     contents.RecurringCharges = [];
@@ -26996,10 +26997,10 @@ const deserializeAws_queryReservedDBInstance = (output: any, context: __SerdeCon
     );
   }
   if (output["ReservedDBInstanceArn"] !== undefined) {
-    contents.ReservedDBInstanceArn = output["ReservedDBInstanceArn"];
+    contents.ReservedDBInstanceArn = __expectString(output["ReservedDBInstanceArn"]);
   }
   if (output["LeaseId"] !== undefined) {
-    contents.LeaseId = output["LeaseId"];
+    contents.LeaseId = __expectString(output["LeaseId"]);
   }
   return contents;
 };
@@ -27012,7 +27013,7 @@ const deserializeAws_queryReservedDBInstanceAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -27037,7 +27038,7 @@ const deserializeAws_queryReservedDBInstanceMessage = (
     ReservedDBInstances: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.ReservedDBInstances === "") {
     contents.ReservedDBInstances = [];
@@ -27062,7 +27063,7 @@ const deserializeAws_queryReservedDBInstanceNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -27075,7 +27076,7 @@ const deserializeAws_queryReservedDBInstanceQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -27097,10 +27098,10 @@ const deserializeAws_queryReservedDBInstancesOffering = (
     RecurringCharges: undefined,
   };
   if (output["ReservedDBInstancesOfferingId"] !== undefined) {
-    contents.ReservedDBInstancesOfferingId = output["ReservedDBInstancesOfferingId"];
+    contents.ReservedDBInstancesOfferingId = __expectString(output["ReservedDBInstancesOfferingId"]);
   }
   if (output["DBInstanceClass"] !== undefined) {
-    contents.DBInstanceClass = output["DBInstanceClass"];
+    contents.DBInstanceClass = __expectString(output["DBInstanceClass"]);
   }
   if (output["Duration"] !== undefined) {
     contents.Duration = parseInt(output["Duration"]);
@@ -27112,13 +27113,13 @@ const deserializeAws_queryReservedDBInstancesOffering = (
     contents.UsagePrice = parseFloat(output["UsagePrice"]);
   }
   if (output["CurrencyCode"] !== undefined) {
-    contents.CurrencyCode = output["CurrencyCode"];
+    contents.CurrencyCode = __expectString(output["CurrencyCode"]);
   }
   if (output["ProductDescription"] !== undefined) {
-    contents.ProductDescription = output["ProductDescription"];
+    contents.ProductDescription = __expectString(output["ProductDescription"]);
   }
   if (output["OfferingType"] !== undefined) {
-    contents.OfferingType = output["OfferingType"];
+    contents.OfferingType = __expectString(output["OfferingType"]);
   }
   if (output["MultiAZ"] !== undefined) {
     contents.MultiAZ = __parseBoolean(output["MultiAZ"]);
@@ -27158,7 +27159,7 @@ const deserializeAws_queryReservedDBInstancesOfferingMessage = (
     ReservedDBInstancesOfferings: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.ReservedDBInstancesOfferings === "") {
     contents.ReservedDBInstancesOfferings = [];
@@ -27183,7 +27184,7 @@ const deserializeAws_queryReservedDBInstancesOfferingNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -27193,7 +27194,7 @@ const deserializeAws_queryResourceNotFoundFault = (output: any, context: __Serde
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -27207,7 +27208,7 @@ const deserializeAws_queryResourcePendingMaintenanceActions = (
     PendingMaintenanceActionDetails: undefined,
   };
   if (output["ResourceIdentifier"] !== undefined) {
-    contents.ResourceIdentifier = output["ResourceIdentifier"];
+    contents.ResourceIdentifier = __expectString(output["ResourceIdentifier"]);
   }
   if (output.PendingMaintenanceActionDetails === "") {
     contents.PendingMaintenanceActionDetails = [];
@@ -27353,7 +27354,7 @@ const deserializeAws_queryScalingConfigurationInfo = (
     contents.SecondsUntilAutoPause = parseInt(output["SecondsUntilAutoPause"]);
   }
   if (output["TimeoutAction"] !== undefined) {
-    contents.TimeoutAction = output["TimeoutAction"];
+    contents.TimeoutAction = __expectString(output["TimeoutAction"]);
   }
   return contents;
 };
@@ -27366,7 +27367,7 @@ const deserializeAws_querySharedSnapshotQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -27379,7 +27380,7 @@ const deserializeAws_querySnapshotQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -27389,7 +27390,7 @@ const deserializeAws_querySNSInvalidTopicFault = (output: any, context: __SerdeC
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -27399,7 +27400,7 @@ const deserializeAws_querySNSNoAuthorizationFault = (output: any, context: __Ser
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -27412,7 +27413,7 @@ const deserializeAws_querySNSTopicArnNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -27424,7 +27425,7 @@ const deserializeAws_querySourceIdsList = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -27433,7 +27434,7 @@ const deserializeAws_querySourceNotFoundFault = (output: any, context: __SerdeCo
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -27446,13 +27447,13 @@ const deserializeAws_querySourceRegion = (output: any, context: __SerdeContext):
     SupportsDBInstanceAutomatedBackupsReplication: undefined,
   };
   if (output["RegionName"] !== undefined) {
-    contents.RegionName = output["RegionName"];
+    contents.RegionName = __expectString(output["RegionName"]);
   }
   if (output["Endpoint"] !== undefined) {
-    contents.Endpoint = output["Endpoint"];
+    contents.Endpoint = __expectString(output["Endpoint"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["SupportsDBInstanceAutomatedBackupsReplication"] !== undefined) {
     contents.SupportsDBInstanceAutomatedBackupsReplication = __parseBoolean(
@@ -27479,7 +27480,7 @@ const deserializeAws_querySourceRegionMessage = (output: any, context: __SerdeCo
     SourceRegions: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.SourceRegions === "") {
     contents.SourceRegions = [];
@@ -27506,16 +27507,16 @@ const deserializeAws_queryStartActivityStreamResponse = (
     EngineNativeAuditFieldsIncluded: undefined,
   };
   if (output["KmsKeyId"] !== undefined) {
-    contents.KmsKeyId = output["KmsKeyId"];
+    contents.KmsKeyId = __expectString(output["KmsKeyId"]);
   }
   if (output["KinesisStreamName"] !== undefined) {
-    contents.KinesisStreamName = output["KinesisStreamName"];
+    contents.KinesisStreamName = __expectString(output["KinesisStreamName"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["Mode"] !== undefined) {
-    contents.Mode = output["Mode"];
+    contents.Mode = __expectString(output["Mode"]);
   }
   if (output["ApplyImmediately"] !== undefined) {
     contents.ApplyImmediately = __parseBoolean(output["ApplyImmediately"]);
@@ -27572,13 +27573,13 @@ const deserializeAws_queryStopActivityStreamResponse = (
     Status: undefined,
   };
   if (output["KmsKeyId"] !== undefined) {
-    contents.KmsKeyId = output["KmsKeyId"];
+    contents.KmsKeyId = __expectString(output["KmsKeyId"]);
   }
   if (output["KinesisStreamName"] !== undefined) {
-    contents.KinesisStreamName = output["KinesisStreamName"];
+    contents.KinesisStreamName = __expectString(output["KinesisStreamName"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   return contents;
 };
@@ -27627,7 +27628,7 @@ const deserializeAws_queryStorageQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -27640,7 +27641,7 @@ const deserializeAws_queryStorageTypeNotSupportedFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -27652,7 +27653,7 @@ const deserializeAws_queryStringList = (output: any, context: __SerdeContext): s
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -27664,7 +27665,7 @@ const deserializeAws_querySubnet = (output: any, context: __SerdeContext): Subne
     SubnetStatus: undefined,
   };
   if (output["SubnetIdentifier"] !== undefined) {
-    contents.SubnetIdentifier = output["SubnetIdentifier"];
+    contents.SubnetIdentifier = __expectString(output["SubnetIdentifier"]);
   }
   if (output["SubnetAvailabilityZone"] !== undefined) {
     contents.SubnetAvailabilityZone = deserializeAws_queryAvailabilityZone(output["SubnetAvailabilityZone"], context);
@@ -27673,7 +27674,7 @@ const deserializeAws_querySubnet = (output: any, context: __SerdeContext): Subne
     contents.SubnetOutpost = deserializeAws_queryOutpost(output["SubnetOutpost"], context);
   }
   if (output["SubnetStatus"] !== undefined) {
-    contents.SubnetStatus = output["SubnetStatus"];
+    contents.SubnetStatus = __expectString(output["SubnetStatus"]);
   }
   return contents;
 };
@@ -27683,7 +27684,7 @@ const deserializeAws_querySubnetAlreadyInUse = (output: any, context: __SerdeCon
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -27707,7 +27708,7 @@ const deserializeAws_querySubscriptionAlreadyExistFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -27720,7 +27721,7 @@ const deserializeAws_querySubscriptionCategoryNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -27733,7 +27734,7 @@ const deserializeAws_querySubscriptionNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -27766,10 +27767,10 @@ const deserializeAws_queryTag = (output: any, context: __SerdeContext): Tag => {
     Value: undefined,
   };
   if (output["Key"] !== undefined) {
-    contents.Key = output["Key"];
+    contents.Key = __expectString(output["Key"]);
   }
   if (output["Value"] !== undefined) {
-    contents.Value = output["Value"];
+    contents.Value = __expectString(output["Value"]);
   }
   return contents;
 };
@@ -27816,13 +27817,13 @@ const deserializeAws_queryTargetHealth = (output: any, context: __SerdeContext):
     Description: undefined,
   };
   if (output["State"] !== undefined) {
-    contents.State = output["State"];
+    contents.State = __expectString(output["State"]);
   }
   if (output["Reason"] !== undefined) {
-    contents.Reason = output["Reason"];
+    contents.Reason = __expectString(output["Reason"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   return contents;
 };
@@ -27843,7 +27844,7 @@ const deserializeAws_queryTimezone = (output: any, context: __SerdeContext): Tim
     TimezoneName: undefined,
   };
   if (output["TimezoneName"] !== undefined) {
-    contents.TimezoneName = output["TimezoneName"];
+    contents.TimezoneName = __expectString(output["TimezoneName"]);
   }
   return contents;
 };
@@ -27860,13 +27861,13 @@ const deserializeAws_queryUpgradeTarget = (output: any, context: __SerdeContext)
     SupportsGlobalDatabases: undefined,
   };
   if (output["Engine"] !== undefined) {
-    contents.Engine = output["Engine"];
+    contents.Engine = __expectString(output["Engine"]);
   }
   if (output["EngineVersion"] !== undefined) {
-    contents.EngineVersion = output["EngineVersion"];
+    contents.EngineVersion = __expectString(output["EngineVersion"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output["AutoUpgrade"] !== undefined) {
     contents.AutoUpgrade = __parseBoolean(output["AutoUpgrade"]);
@@ -27901,19 +27902,19 @@ const deserializeAws_queryUserAuthConfigInfo = (output: any, context: __SerdeCon
     IAMAuth: undefined,
   };
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output["UserName"] !== undefined) {
-    contents.UserName = output["UserName"];
+    contents.UserName = __expectString(output["UserName"]);
   }
   if (output["AuthScheme"] !== undefined) {
-    contents.AuthScheme = output["AuthScheme"];
+    contents.AuthScheme = __expectString(output["AuthScheme"]);
   }
   if (output["SecretArn"] !== undefined) {
-    contents.SecretArn = output["SecretArn"];
+    contents.SecretArn = __expectString(output["SecretArn"]);
   }
   if (output["IAMAuth"] !== undefined) {
-    contents.IAMAuth = output["IAMAuth"];
+    contents.IAMAuth = __expectString(output["IAMAuth"]);
   }
   return contents;
 };
@@ -27970,7 +27971,7 @@ const deserializeAws_queryValidStorageOptions = (output: any, context: __SerdeCo
     SupportsStorageAutoscaling: undefined,
   };
   if (output["StorageType"] !== undefined) {
-    contents.StorageType = output["StorageType"];
+    contents.StorageType = __expectString(output["StorageType"]);
   }
   if (output.StorageSize === "") {
     contents.StorageSize = [];
@@ -28036,10 +28037,10 @@ const deserializeAws_queryVpcSecurityGroupMembership = (
     Status: undefined,
   };
   if (output["VpcSecurityGroupId"] !== undefined) {
-    contents.VpcSecurityGroupId = output["VpcSecurityGroupId"];
+    contents.VpcSecurityGroupId = __expectString(output["VpcSecurityGroupId"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   return contents;
 };
@@ -28068,22 +28069,22 @@ const deserializeAws_queryVpnDetails = (output: any, context: __SerdeContext): V
     VpnState: undefined,
   };
   if (output["VpnId"] !== undefined) {
-    contents.VpnId = output["VpnId"];
+    contents.VpnId = __expectString(output["VpnId"]);
   }
   if (output["VpnTunnelOriginatorIP"] !== undefined) {
-    contents.VpnTunnelOriginatorIP = output["VpnTunnelOriginatorIP"];
+    contents.VpnTunnelOriginatorIP = __expectString(output["VpnTunnelOriginatorIP"]);
   }
   if (output["VpnGatewayIp"] !== undefined) {
-    contents.VpnGatewayIp = output["VpnGatewayIp"];
+    contents.VpnGatewayIp = __expectString(output["VpnGatewayIp"]);
   }
   if (output["VpnPSK"] !== undefined) {
-    contents.VpnPSK = output["VpnPSK"];
+    contents.VpnPSK = __expectString(output["VpnPSK"]);
   }
   if (output["VpnName"] !== undefined) {
-    contents.VpnName = output["VpnName"];
+    contents.VpnName = __expectString(output["VpnName"]);
   }
   if (output["VpnState"] !== undefined) {
-    contents.VpnState = output["VpnState"];
+    contents.VpnState = __expectString(output["VpnState"]);
   }
   return contents;
 };

--- a/clients/client-redshift-data/protocols/Aws_json1_1.ts
+++ b/clients/client-redshift-data/protocols/Aws_json1_1.ts
@@ -38,7 +38,12 @@ import {
   ValidationException,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -953,7 +958,7 @@ const deserializeAws_json1_1ActiveStatementsExceededException = (
   context: __SerdeContext
 ): ActiveStatementsExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -962,7 +967,7 @@ const deserializeAws_json1_1CancelStatementResponse = (
   context: __SerdeContext
 ): CancelStatementResponse => {
   return {
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectBoolean(output.Status),
   } as any;
 };
 
@@ -979,21 +984,19 @@ const deserializeAws_json1_1ColumnList = (output: any, context: __SerdeContext):
 
 const deserializeAws_json1_1ColumnMetadata = (output: any, context: __SerdeContext): ColumnMetadata => {
   return {
-    columnDefault:
-      output.columnDefault !== undefined && output.columnDefault !== null ? output.columnDefault : undefined,
-    isCaseSensitive:
-      output.isCaseSensitive !== undefined && output.isCaseSensitive !== null ? output.isCaseSensitive : undefined,
-    isCurrency: output.isCurrency !== undefined && output.isCurrency !== null ? output.isCurrency : undefined,
-    isSigned: output.isSigned !== undefined && output.isSigned !== null ? output.isSigned : undefined,
-    label: output.label !== undefined && output.label !== null ? output.label : undefined,
-    length: output.length !== undefined && output.length !== null ? output.length : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    nullable: output.nullable !== undefined && output.nullable !== null ? output.nullable : undefined,
-    precision: output.precision !== undefined && output.precision !== null ? output.precision : undefined,
-    scale: output.scale !== undefined && output.scale !== null ? output.scale : undefined,
-    schemaName: output.schemaName !== undefined && output.schemaName !== null ? output.schemaName : undefined,
-    tableName: output.tableName !== undefined && output.tableName !== null ? output.tableName : undefined,
-    typeName: output.typeName !== undefined && output.typeName !== null ? output.typeName : undefined,
+    columnDefault: __expectString(output.columnDefault),
+    isCaseSensitive: __expectBoolean(output.isCaseSensitive),
+    isCurrency: __expectBoolean(output.isCurrency),
+    isSigned: __expectBoolean(output.isSigned),
+    label: __expectString(output.label),
+    length: __expectNumber(output.length),
+    name: __expectString(output.name),
+    nullable: __expectNumber(output.nullable),
+    precision: __expectNumber(output.precision),
+    scale: __expectNumber(output.scale),
+    schemaName: __expectString(output.schemaName),
+    tableName: __expectString(output.tableName),
+    typeName: __expectString(output.typeName),
   } as any;
 };
 
@@ -1015,7 +1018,7 @@ const deserializeAws_json1_1DatabaseList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -1024,32 +1027,28 @@ const deserializeAws_json1_1DescribeStatementResponse = (
   context: __SerdeContext
 ): DescribeStatementResponse => {
   return {
-    ClusterIdentifier:
-      output.ClusterIdentifier !== undefined && output.ClusterIdentifier !== null
-        ? output.ClusterIdentifier
-        : undefined,
+    ClusterIdentifier: __expectString(output.ClusterIdentifier),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    Database: output.Database !== undefined && output.Database !== null ? output.Database : undefined,
-    DbUser: output.DbUser !== undefined && output.DbUser !== null ? output.DbUser : undefined,
-    Duration: output.Duration !== undefined && output.Duration !== null ? output.Duration : undefined,
-    Error: output.Error !== undefined && output.Error !== null ? output.Error : undefined,
-    HasResultSet: output.HasResultSet !== undefined && output.HasResultSet !== null ? output.HasResultSet : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    Database: __expectString(output.Database),
+    DbUser: __expectString(output.DbUser),
+    Duration: __expectNumber(output.Duration),
+    Error: __expectString(output.Error),
+    HasResultSet: __expectBoolean(output.HasResultSet),
+    Id: __expectString(output.Id),
     QueryParameters:
       output.QueryParameters !== undefined && output.QueryParameters !== null
         ? deserializeAws_json1_1SqlParametersList(output.QueryParameters, context)
         : undefined,
-    QueryString: output.QueryString !== undefined && output.QueryString !== null ? output.QueryString : undefined,
-    RedshiftPid: output.RedshiftPid !== undefined && output.RedshiftPid !== null ? output.RedshiftPid : undefined,
-    RedshiftQueryId:
-      output.RedshiftQueryId !== undefined && output.RedshiftQueryId !== null ? output.RedshiftQueryId : undefined,
-    ResultRows: output.ResultRows !== undefined && output.ResultRows !== null ? output.ResultRows : undefined,
-    ResultSize: output.ResultSize !== undefined && output.ResultSize !== null ? output.ResultSize : undefined,
-    SecretArn: output.SecretArn !== undefined && output.SecretArn !== null ? output.SecretArn : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    QueryString: __expectString(output.QueryString),
+    RedshiftPid: __expectNumber(output.RedshiftPid),
+    RedshiftQueryId: __expectNumber(output.RedshiftQueryId),
+    ResultRows: __expectNumber(output.ResultRows),
+    ResultSize: __expectNumber(output.ResultSize),
+    SecretArn: __expectString(output.SecretArn),
+    Status: __expectString(output.Status),
     UpdatedAt:
       output.UpdatedAt !== undefined && output.UpdatedAt !== null
         ? new Date(Math.round(output.UpdatedAt * 1000))
@@ -1063,8 +1062,8 @@ const deserializeAws_json1_1DescribeTableResponse = (output: any, context: __Ser
       output.ColumnList !== undefined && output.ColumnList !== null
         ? deserializeAws_json1_1ColumnList(output.ColumnList, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
-    TableName: output.TableName !== undefined && output.TableName !== null ? output.TableName : undefined,
+    NextToken: __expectString(output.NextToken),
+    TableName: __expectString(output.TableName),
   } as any;
 };
 
@@ -1073,25 +1072,22 @@ const deserializeAws_json1_1ExecuteStatementException = (
   context: __SerdeContext
 ): ExecuteStatementException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    StatementId: output.StatementId !== undefined && output.StatementId !== null ? output.StatementId : undefined,
+    Message: __expectString(output.Message),
+    StatementId: __expectString(output.StatementId),
   } as any;
 };
 
 const deserializeAws_json1_1ExecuteStatementOutput = (output: any, context: __SerdeContext): ExecuteStatementOutput => {
   return {
-    ClusterIdentifier:
-      output.ClusterIdentifier !== undefined && output.ClusterIdentifier !== null
-        ? output.ClusterIdentifier
-        : undefined,
+    ClusterIdentifier: __expectString(output.ClusterIdentifier),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    Database: output.Database !== undefined && output.Database !== null ? output.Database : undefined,
-    DbUser: output.DbUser !== undefined && output.DbUser !== null ? output.DbUser : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    SecretArn: output.SecretArn !== undefined && output.SecretArn !== null ? output.SecretArn : undefined,
+    Database: __expectString(output.Database),
+    DbUser: __expectString(output.DbUser),
+    Id: __expectString(output.Id),
+    SecretArn: __expectString(output.SecretArn),
   } as any;
 };
 
@@ -1101,30 +1097,20 @@ const deserializeAws_json1_1Field = (output: any, context: __SerdeContext): Fiel
       blobValue: context.base64Decoder(output.blobValue),
     };
   }
-  if (output.booleanValue !== undefined && output.booleanValue !== null) {
-    return {
-      booleanValue: output.booleanValue,
-    };
+  if (__expectBoolean(output.booleanValue) !== undefined) {
+    return { booleanValue: __expectBoolean(output.booleanValue) as any };
   }
-  if (output.doubleValue !== undefined && output.doubleValue !== null) {
-    return {
-      doubleValue: output.doubleValue,
-    };
+  if (__expectNumber(output.doubleValue) !== undefined) {
+    return { doubleValue: __expectNumber(output.doubleValue) as any };
   }
-  if (output.isNull !== undefined && output.isNull !== null) {
-    return {
-      isNull: output.isNull,
-    };
+  if (__expectBoolean(output.isNull) !== undefined) {
+    return { isNull: __expectBoolean(output.isNull) as any };
   }
-  if (output.longValue !== undefined && output.longValue !== null) {
-    return {
-      longValue: output.longValue,
-    };
+  if (__expectNumber(output.longValue) !== undefined) {
+    return { longValue: __expectNumber(output.longValue) as any };
   }
-  if (output.stringValue !== undefined && output.stringValue !== null) {
-    return {
-      stringValue: output.stringValue,
-    };
+  if (__expectString(output.stringValue) !== undefined) {
+    return { stringValue: __expectString(output.stringValue) as any };
   }
   return { $unknown: Object.entries(output)[0] };
 };
@@ -1149,12 +1135,12 @@ const deserializeAws_json1_1GetStatementResultResponse = (
       output.ColumnMetadata !== undefined && output.ColumnMetadata !== null
         ? deserializeAws_json1_1ColumnMetadataList(output.ColumnMetadata, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Records:
       output.Records !== undefined && output.Records !== null
         ? deserializeAws_json1_1SqlRecords(output.Records, context)
         : undefined,
-    TotalNumRows: output.TotalNumRows !== undefined && output.TotalNumRows !== null ? output.TotalNumRows : undefined,
+    TotalNumRows: __expectNumber(output.TotalNumRows),
   } as any;
 };
 
@@ -1163,7 +1149,7 @@ const deserializeAws_json1_1InternalServerException = (
   context: __SerdeContext
 ): InternalServerException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -1173,13 +1159,13 @@ const deserializeAws_json1_1ListDatabasesResponse = (output: any, context: __Ser
       output.Databases !== undefined && output.Databases !== null
         ? deserializeAws_json1_1DatabaseList(output.Databases, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
 const deserializeAws_json1_1ListSchemasResponse = (output: any, context: __SerdeContext): ListSchemasResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Schemas:
       output.Schemas !== undefined && output.Schemas !== null
         ? deserializeAws_json1_1SchemaList(output.Schemas, context)
@@ -1189,7 +1175,7 @@ const deserializeAws_json1_1ListSchemasResponse = (output: any, context: __Serde
 
 const deserializeAws_json1_1ListStatementsResponse = (output: any, context: __SerdeContext): ListStatementsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Statements:
       output.Statements !== undefined && output.Statements !== null
         ? deserializeAws_json1_1StatementList(output.Statements, context)
@@ -1199,7 +1185,7 @@ const deserializeAws_json1_1ListStatementsResponse = (output: any, context: __Se
 
 const deserializeAws_json1_1ListTablesResponse = (output: any, context: __SerdeContext): ListTablesResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Tables:
       output.Tables !== undefined && output.Tables !== null
         ? deserializeAws_json1_1TableList(output.Tables, context)
@@ -1212,8 +1198,8 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    ResourceId: output.ResourceId !== undefined && output.ResourceId !== null ? output.ResourceId : undefined,
+    Message: __expectString(output.Message),
+    ResourceId: __expectString(output.ResourceId),
   } as any;
 };
 
@@ -1224,14 +1210,14 @@ const deserializeAws_json1_1SchemaList = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1SqlParameter = (output: any, context: __SerdeContext): SqlParameter => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    name: __expectString(output.name),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -1263,16 +1249,15 @@ const deserializeAws_json1_1StatementData = (output: any, context: __SerdeContex
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    Id: __expectString(output.Id),
     QueryParameters:
       output.QueryParameters !== undefined && output.QueryParameters !== null
         ? deserializeAws_json1_1SqlParametersList(output.QueryParameters, context)
         : undefined,
-    QueryString: output.QueryString !== undefined && output.QueryString !== null ? output.QueryString : undefined,
-    SecretArn: output.SecretArn !== undefined && output.SecretArn !== null ? output.SecretArn : undefined,
-    StatementName:
-      output.StatementName !== undefined && output.StatementName !== null ? output.StatementName : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    QueryString: __expectString(output.QueryString),
+    SecretArn: __expectString(output.SecretArn),
+    StatementName: __expectString(output.StatementName),
+    Status: __expectString(output.Status),
     UpdatedAt:
       output.UpdatedAt !== undefined && output.UpdatedAt !== null
         ? new Date(Math.round(output.UpdatedAt * 1000))
@@ -1304,15 +1289,15 @@ const deserializeAws_json1_1TableList = (output: any, context: __SerdeContext): 
 
 const deserializeAws_json1_1TableMember = (output: any, context: __SerdeContext): TableMember => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    schema: output.schema !== undefined && output.schema !== null ? output.schema : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    name: __expectString(output.name),
+    schema: __expectString(output.schema),
+    type: __expectString(output.type),
   } as any;
 };
 
 const deserializeAws_json1_1ValidationException = (output: any, context: __SerdeContext): ValidationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 

--- a/clients/client-redshift/protocols/Aws_query.ts
+++ b/clients/client-redshift/protocols/Aws_query.ts
@@ -710,6 +710,7 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
@@ -14986,7 +14987,7 @@ const deserializeAws_queryAccessToClusterDeniedFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -14999,7 +15000,7 @@ const deserializeAws_queryAccessToSnapshotDeniedFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -15010,7 +15011,7 @@ const deserializeAws_queryAccountAttribute = (output: any, context: __SerdeConte
     AttributeValues: undefined,
   };
   if (output["AttributeName"] !== undefined) {
-    contents.AttributeName = output["AttributeName"];
+    contents.AttributeName = __expectString(output["AttributeName"]);
   }
   if (output.AttributeValues === "") {
     contents.AttributeValues = [];
@@ -15063,10 +15064,10 @@ const deserializeAws_queryAccountWithRestoreAccess = (
     AccountAlias: undefined,
   };
   if (output["AccountId"] !== undefined) {
-    contents.AccountId = output["AccountId"];
+    contents.AccountId = __expectString(output["AccountId"]);
   }
   if (output["AccountAlias"] !== undefined) {
-    contents.AccountAlias = output["AccountAlias"];
+    contents.AccountAlias = __expectString(output["AccountAlias"]);
   }
   return contents;
 };
@@ -15077,10 +15078,10 @@ const deserializeAws_queryAquaConfiguration = (output: any, context: __SerdeCont
     AquaConfigurationStatus: undefined,
   };
   if (output["AquaStatus"] !== undefined) {
-    contents.AquaStatus = output["AquaStatus"];
+    contents.AquaStatus = __expectString(output["AquaStatus"]);
   }
   if (output["AquaConfigurationStatus"] !== undefined) {
-    contents.AquaConfigurationStatus = output["AquaConfigurationStatus"];
+    contents.AquaConfigurationStatus = __expectString(output["AquaConfigurationStatus"]);
   }
   return contents;
 };
@@ -15126,7 +15127,7 @@ const deserializeAws_queryAttributeValueTarget = (output: any, context: __SerdeC
     AttributeValue: undefined,
   };
   if (output["AttributeValue"] !== undefined) {
-    contents.AttributeValue = output["AttributeValue"];
+    contents.AttributeValue = __expectString(output["AttributeValue"]);
   }
   return contents;
 };
@@ -15139,7 +15140,7 @@ const deserializeAws_queryAuthorizationAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -15152,7 +15153,7 @@ const deserializeAws_queryAuthorizationNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -15165,7 +15166,7 @@ const deserializeAws_queryAuthorizationQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -15202,7 +15203,7 @@ const deserializeAws_queryAvailabilityZone = (output: any, context: __SerdeConte
     SupportedPlatforms: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output.SupportedPlatforms === "") {
     contents.SupportedPlatforms = [];
@@ -15264,7 +15265,7 @@ const deserializeAws_queryBatchDeleteRequestSizeExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -15277,7 +15278,7 @@ const deserializeAws_queryBatchModifyClusterSnapshotsLimitExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -15344,7 +15345,7 @@ const deserializeAws_queryBucketNotFoundFault = (output: any, context: __SerdeCo
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -15403,25 +15404,25 @@ const deserializeAws_queryCluster = (output: any, context: __SerdeContext): Clus
     AquaConfiguration: undefined,
   };
   if (output["ClusterIdentifier"] !== undefined) {
-    contents.ClusterIdentifier = output["ClusterIdentifier"];
+    contents.ClusterIdentifier = __expectString(output["ClusterIdentifier"]);
   }
   if (output["NodeType"] !== undefined) {
-    contents.NodeType = output["NodeType"];
+    contents.NodeType = __expectString(output["NodeType"]);
   }
   if (output["ClusterStatus"] !== undefined) {
-    contents.ClusterStatus = output["ClusterStatus"];
+    contents.ClusterStatus = __expectString(output["ClusterStatus"]);
   }
   if (output["ClusterAvailabilityStatus"] !== undefined) {
-    contents.ClusterAvailabilityStatus = output["ClusterAvailabilityStatus"];
+    contents.ClusterAvailabilityStatus = __expectString(output["ClusterAvailabilityStatus"]);
   }
   if (output["ModifyStatus"] !== undefined) {
-    contents.ModifyStatus = output["ModifyStatus"];
+    contents.ModifyStatus = __expectString(output["ModifyStatus"]);
   }
   if (output["MasterUsername"] !== undefined) {
-    contents.MasterUsername = output["MasterUsername"];
+    contents.MasterUsername = __expectString(output["MasterUsername"]);
   }
   if (output["DBName"] !== undefined) {
-    contents.DBName = output["DBName"];
+    contents.DBName = __expectString(output["DBName"]);
   }
   if (output["Endpoint"] !== undefined) {
     contents.Endpoint = deserializeAws_queryEndpoint(output["Endpoint"], context);
@@ -15469,16 +15470,16 @@ const deserializeAws_queryCluster = (output: any, context: __SerdeContext): Clus
     );
   }
   if (output["ClusterSubnetGroupName"] !== undefined) {
-    contents.ClusterSubnetGroupName = output["ClusterSubnetGroupName"];
+    contents.ClusterSubnetGroupName = __expectString(output["ClusterSubnetGroupName"]);
   }
   if (output["VpcId"] !== undefined) {
-    contents.VpcId = output["VpcId"];
+    contents.VpcId = __expectString(output["VpcId"]);
   }
   if (output["AvailabilityZone"] !== undefined) {
-    contents.AvailabilityZone = output["AvailabilityZone"];
+    contents.AvailabilityZone = __expectString(output["AvailabilityZone"]);
   }
   if (output["PreferredMaintenanceWindow"] !== undefined) {
-    contents.PreferredMaintenanceWindow = output["PreferredMaintenanceWindow"];
+    contents.PreferredMaintenanceWindow = __expectString(output["PreferredMaintenanceWindow"]);
   }
   if (output["PendingModifiedValues"] !== undefined) {
     contents.PendingModifiedValues = deserializeAws_queryPendingModifiedValues(
@@ -15487,7 +15488,7 @@ const deserializeAws_queryCluster = (output: any, context: __SerdeContext): Clus
     );
   }
   if (output["ClusterVersion"] !== undefined) {
-    contents.ClusterVersion = output["ClusterVersion"];
+    contents.ClusterVersion = __expectString(output["ClusterVersion"]);
   }
   if (output["AllowVersionUpgrade"] !== undefined) {
     contents.AllowVersionUpgrade = __parseBoolean(output["AllowVersionUpgrade"]);
@@ -15517,7 +15518,7 @@ const deserializeAws_queryCluster = (output: any, context: __SerdeContext): Clus
     );
   }
   if (output["ClusterPublicKey"] !== undefined) {
-    contents.ClusterPublicKey = output["ClusterPublicKey"];
+    contents.ClusterPublicKey = __expectString(output["ClusterPublicKey"]);
   }
   if (output.ClusterNodes === "") {
     contents.ClusterNodes = [];
@@ -15532,7 +15533,7 @@ const deserializeAws_queryCluster = (output: any, context: __SerdeContext): Clus
     contents.ElasticIpStatus = deserializeAws_queryElasticIpStatus(output["ElasticIpStatus"], context);
   }
   if (output["ClusterRevisionNumber"] !== undefined) {
-    contents.ClusterRevisionNumber = output["ClusterRevisionNumber"];
+    contents.ClusterRevisionNumber = __expectString(output["ClusterRevisionNumber"]);
   }
   if (output.Tags === "") {
     contents.Tags = [];
@@ -15541,7 +15542,7 @@ const deserializeAws_queryCluster = (output: any, context: __SerdeContext): Clus
     contents.Tags = deserializeAws_queryTagList(__getArrayIfSingleItem(output["Tags"]["Tag"]), context);
   }
   if (output["KmsKeyId"] !== undefined) {
-    contents.KmsKeyId = output["KmsKeyId"];
+    contents.KmsKeyId = __expectString(output["KmsKeyId"]);
   }
   if (output["EnhancedVpcRouting"] !== undefined) {
     contents.EnhancedVpcRouting = __parseBoolean(output["EnhancedVpcRouting"]);
@@ -15565,10 +15566,10 @@ const deserializeAws_queryCluster = (output: any, context: __SerdeContext): Clus
     );
   }
   if (output["MaintenanceTrackName"] !== undefined) {
-    contents.MaintenanceTrackName = output["MaintenanceTrackName"];
+    contents.MaintenanceTrackName = __expectString(output["MaintenanceTrackName"]);
   }
   if (output["ElasticResizeNumberOfNodeOptions"] !== undefined) {
-    contents.ElasticResizeNumberOfNodeOptions = output["ElasticResizeNumberOfNodeOptions"];
+    contents.ElasticResizeNumberOfNodeOptions = __expectString(output["ElasticResizeNumberOfNodeOptions"]);
   }
   if (output.DeferredMaintenanceWindows === "") {
     contents.DeferredMaintenanceWindows = [];
@@ -15583,16 +15584,16 @@ const deserializeAws_queryCluster = (output: any, context: __SerdeContext): Clus
     );
   }
   if (output["SnapshotScheduleIdentifier"] !== undefined) {
-    contents.SnapshotScheduleIdentifier = output["SnapshotScheduleIdentifier"];
+    contents.SnapshotScheduleIdentifier = __expectString(output["SnapshotScheduleIdentifier"]);
   }
   if (output["SnapshotScheduleState"] !== undefined) {
-    contents.SnapshotScheduleState = output["SnapshotScheduleState"];
+    contents.SnapshotScheduleState = __expectString(output["SnapshotScheduleState"]);
   }
   if (output["ExpectedNextSnapshotScheduleTime"] !== undefined) {
     contents.ExpectedNextSnapshotScheduleTime = new Date(output["ExpectedNextSnapshotScheduleTime"]);
   }
   if (output["ExpectedNextSnapshotScheduleTimeStatus"] !== undefined) {
-    contents.ExpectedNextSnapshotScheduleTimeStatus = output["ExpectedNextSnapshotScheduleTimeStatus"];
+    contents.ExpectedNextSnapshotScheduleTimeStatus = __expectString(output["ExpectedNextSnapshotScheduleTimeStatus"]);
   }
   if (output["NextMaintenanceWindowStartTime"] !== undefined) {
     contents.NextMaintenanceWindowStartTime = new Date(output["NextMaintenanceWindowStartTime"]);
@@ -15601,10 +15602,10 @@ const deserializeAws_queryCluster = (output: any, context: __SerdeContext): Clus
     contents.ResizeInfo = deserializeAws_queryResizeInfo(output["ResizeInfo"], context);
   }
   if (output["AvailabilityZoneRelocationStatus"] !== undefined) {
-    contents.AvailabilityZoneRelocationStatus = output["AvailabilityZoneRelocationStatus"];
+    contents.AvailabilityZoneRelocationStatus = __expectString(output["AvailabilityZoneRelocationStatus"]);
   }
   if (output["ClusterNamespaceArn"] !== undefined) {
-    contents.ClusterNamespaceArn = output["ClusterNamespaceArn"];
+    contents.ClusterNamespaceArn = __expectString(output["ClusterNamespaceArn"]);
   }
   if (output["TotalStorageCapacityInMegaBytes"] !== undefined) {
     contents.TotalStorageCapacityInMegaBytes = parseInt(output["TotalStorageCapacityInMegaBytes"]);
@@ -15623,7 +15624,7 @@ const deserializeAws_queryClusterAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -15637,10 +15638,10 @@ const deserializeAws_queryClusterAssociatedToSchedule = (
     ScheduleAssociationState: undefined,
   };
   if (output["ClusterIdentifier"] !== undefined) {
-    contents.ClusterIdentifier = output["ClusterIdentifier"];
+    contents.ClusterIdentifier = __expectString(output["ClusterIdentifier"]);
   }
   if (output["ScheduleAssociationState"] !== undefined) {
-    contents.ScheduleAssociationState = output["ScheduleAssociationState"];
+    contents.ScheduleAssociationState = __expectString(output["ScheduleAssociationState"]);
   }
   return contents;
 };
@@ -15652,10 +15653,10 @@ const deserializeAws_queryClusterCredentials = (output: any, context: __SerdeCon
     Expiration: undefined,
   };
   if (output["DbUser"] !== undefined) {
-    contents.DbUser = output["DbUser"];
+    contents.DbUser = __expectString(output["DbUser"]);
   }
   if (output["DbPassword"] !== undefined) {
-    contents.DbPassword = output["DbPassword"];
+    contents.DbPassword = __expectString(output["DbPassword"]);
   }
   if (output["Expiration"] !== undefined) {
     contents.Expiration = new Date(output["Expiration"]);
@@ -15671,10 +15672,10 @@ const deserializeAws_queryClusterDbRevision = (output: any, context: __SerdeCont
     RevisionTargets: undefined,
   };
   if (output["ClusterIdentifier"] !== undefined) {
-    contents.ClusterIdentifier = output["ClusterIdentifier"];
+    contents.ClusterIdentifier = __expectString(output["ClusterIdentifier"]);
   }
   if (output["CurrentDatabaseRevision"] !== undefined) {
-    contents.CurrentDatabaseRevision = output["CurrentDatabaseRevision"];
+    contents.CurrentDatabaseRevision = __expectString(output["CurrentDatabaseRevision"]);
   }
   if (output["DatabaseRevisionReleaseDate"] !== undefined) {
     contents.DatabaseRevisionReleaseDate = new Date(output["DatabaseRevisionReleaseDate"]);
@@ -15711,7 +15712,7 @@ const deserializeAws_queryClusterDbRevisionsMessage = (
     ClusterDbRevisions: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.ClusterDbRevisions === "") {
     contents.ClusterDbRevisions = [];
@@ -15731,10 +15732,10 @@ const deserializeAws_queryClusterIamRole = (output: any, context: __SerdeContext
     ApplyStatus: undefined,
   };
   if (output["IamRoleArn"] !== undefined) {
-    contents.IamRoleArn = output["IamRoleArn"];
+    contents.IamRoleArn = __expectString(output["IamRoleArn"]);
   }
   if (output["ApplyStatus"] !== undefined) {
-    contents.ApplyStatus = output["ApplyStatus"];
+    contents.ApplyStatus = __expectString(output["ApplyStatus"]);
   }
   return contents;
 };
@@ -15768,13 +15769,13 @@ const deserializeAws_queryClusterNode = (output: any, context: __SerdeContext): 
     PublicIPAddress: undefined,
   };
   if (output["NodeRole"] !== undefined) {
-    contents.NodeRole = output["NodeRole"];
+    contents.NodeRole = __expectString(output["NodeRole"]);
   }
   if (output["PrivateIPAddress"] !== undefined) {
-    contents.PrivateIPAddress = output["PrivateIPAddress"];
+    contents.PrivateIPAddress = __expectString(output["PrivateIPAddress"]);
   }
   if (output["PublicIPAddress"] !== undefined) {
-    contents.PublicIPAddress = output["PublicIPAddress"];
+    contents.PublicIPAddress = __expectString(output["PublicIPAddress"]);
   }
   return contents;
 };
@@ -15795,7 +15796,7 @@ const deserializeAws_queryClusterNotFoundFault = (output: any, context: __SerdeC
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -15808,7 +15809,7 @@ const deserializeAws_queryClusterOnLatestRevisionFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -15821,13 +15822,13 @@ const deserializeAws_queryClusterParameterGroup = (output: any, context: __Serde
     Tags: undefined,
   };
   if (output["ParameterGroupName"] !== undefined) {
-    contents.ParameterGroupName = output["ParameterGroupName"];
+    contents.ParameterGroupName = __expectString(output["ParameterGroupName"]);
   }
   if (output["ParameterGroupFamily"] !== undefined) {
-    contents.ParameterGroupFamily = output["ParameterGroupFamily"];
+    contents.ParameterGroupFamily = __expectString(output["ParameterGroupFamily"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output.Tags === "") {
     contents.Tags = [];
@@ -15846,7 +15847,7 @@ const deserializeAws_queryClusterParameterGroupAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -15869,7 +15870,7 @@ const deserializeAws_queryClusterParameterGroupDetails = (
     );
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -15883,10 +15884,10 @@ const deserializeAws_queryClusterParameterGroupNameMessage = (
     ParameterGroupStatus: undefined,
   };
   if (output["ParameterGroupName"] !== undefined) {
-    contents.ParameterGroupName = output["ParameterGroupName"];
+    contents.ParameterGroupName = __expectString(output["ParameterGroupName"]);
   }
   if (output["ParameterGroupStatus"] !== undefined) {
-    contents.ParameterGroupStatus = output["ParameterGroupStatus"];
+    contents.ParameterGroupStatus = __expectString(output["ParameterGroupStatus"]);
   }
   return contents;
 };
@@ -15899,7 +15900,7 @@ const deserializeAws_queryClusterParameterGroupNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -15912,7 +15913,7 @@ const deserializeAws_queryClusterParameterGroupQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -15926,7 +15927,7 @@ const deserializeAws_queryClusterParameterGroupsMessage = (
     ParameterGroups: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.ParameterGroups === "") {
     contents.ParameterGroups = [];
@@ -15950,10 +15951,10 @@ const deserializeAws_queryClusterParameterGroupStatus = (
     ClusterParameterStatusList: undefined,
   };
   if (output["ParameterGroupName"] !== undefined) {
-    contents.ParameterGroupName = output["ParameterGroupName"];
+    contents.ParameterGroupName = __expectString(output["ParameterGroupName"]);
   }
   if (output["ParameterApplyStatus"] !== undefined) {
-    contents.ParameterApplyStatus = output["ParameterApplyStatus"];
+    contents.ParameterApplyStatus = __expectString(output["ParameterApplyStatus"]);
   }
   if (output.ClusterParameterStatusList === "") {
     contents.ClusterParameterStatusList = [];
@@ -15991,13 +15992,13 @@ const deserializeAws_queryClusterParameterStatus = (output: any, context: __Serd
     ParameterApplyErrorDescription: undefined,
   };
   if (output["ParameterName"] !== undefined) {
-    contents.ParameterName = output["ParameterName"];
+    contents.ParameterName = __expectString(output["ParameterName"]);
   }
   if (output["ParameterApplyStatus"] !== undefined) {
-    contents.ParameterApplyStatus = output["ParameterApplyStatus"];
+    contents.ParameterApplyStatus = __expectString(output["ParameterApplyStatus"]);
   }
   if (output["ParameterApplyErrorDescription"] !== undefined) {
-    contents.ParameterApplyErrorDescription = output["ParameterApplyErrorDescription"];
+    contents.ParameterApplyErrorDescription = __expectString(output["ParameterApplyErrorDescription"]);
   }
   return contents;
 };
@@ -16024,7 +16025,7 @@ const deserializeAws_queryClusterQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -16038,10 +16039,10 @@ const deserializeAws_queryClusterSecurityGroup = (output: any, context: __SerdeC
     Tags: undefined,
   };
   if (output["ClusterSecurityGroupName"] !== undefined) {
-    contents.ClusterSecurityGroupName = output["ClusterSecurityGroupName"];
+    contents.ClusterSecurityGroupName = __expectString(output["ClusterSecurityGroupName"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output.EC2SecurityGroups === "") {
     contents.EC2SecurityGroups = [];
@@ -16075,7 +16076,7 @@ const deserializeAws_queryClusterSecurityGroupAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -16089,10 +16090,10 @@ const deserializeAws_queryClusterSecurityGroupMembership = (
     Status: undefined,
   };
   if (output["ClusterSecurityGroupName"] !== undefined) {
-    contents.ClusterSecurityGroupName = output["ClusterSecurityGroupName"];
+    contents.ClusterSecurityGroupName = __expectString(output["ClusterSecurityGroupName"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   return contents;
 };
@@ -16120,7 +16121,7 @@ const deserializeAws_queryClusterSecurityGroupMessage = (
     ClusterSecurityGroups: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.ClusterSecurityGroups === "") {
     contents.ClusterSecurityGroups = [];
@@ -16145,7 +16146,7 @@ const deserializeAws_queryClusterSecurityGroupNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -16158,7 +16159,7 @@ const deserializeAws_queryClusterSecurityGroupQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -16180,7 +16181,7 @@ const deserializeAws_queryClustersMessage = (output: any, context: __SerdeContex
     Clusters: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.Clusters === "") {
     contents.Clusters = [];
@@ -16199,7 +16200,7 @@ const deserializeAws_queryClusterSnapshotAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -16215,7 +16216,7 @@ const deserializeAws_queryClusterSnapshotCopyStatus = (
     SnapshotCopyGrantName: undefined,
   };
   if (output["DestinationRegion"] !== undefined) {
-    contents.DestinationRegion = output["DestinationRegion"];
+    contents.DestinationRegion = __expectString(output["DestinationRegion"]);
   }
   if (output["RetentionPeriod"] !== undefined) {
     contents.RetentionPeriod = parseInt(output["RetentionPeriod"]);
@@ -16224,7 +16225,7 @@ const deserializeAws_queryClusterSnapshotCopyStatus = (
     contents.ManualSnapshotRetentionPeriod = parseInt(output["ManualSnapshotRetentionPeriod"]);
   }
   if (output["SnapshotCopyGrantName"] !== undefined) {
-    contents.SnapshotCopyGrantName = output["SnapshotCopyGrantName"];
+    contents.SnapshotCopyGrantName = __expectString(output["SnapshotCopyGrantName"]);
   }
   return contents;
 };
@@ -16237,7 +16238,7 @@ const deserializeAws_queryClusterSnapshotNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -16250,7 +16251,7 @@ const deserializeAws_queryClusterSnapshotQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -16265,16 +16266,16 @@ const deserializeAws_queryClusterSubnetGroup = (output: any, context: __SerdeCon
     Tags: undefined,
   };
   if (output["ClusterSubnetGroupName"] !== undefined) {
-    contents.ClusterSubnetGroupName = output["ClusterSubnetGroupName"];
+    contents.ClusterSubnetGroupName = __expectString(output["ClusterSubnetGroupName"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output["VpcId"] !== undefined) {
-    contents.VpcId = output["VpcId"];
+    contents.VpcId = __expectString(output["VpcId"]);
   }
   if (output["SubnetGroupStatus"] !== undefined) {
-    contents.SubnetGroupStatus = output["SubnetGroupStatus"];
+    contents.SubnetGroupStatus = __expectString(output["SubnetGroupStatus"]);
   }
   if (output.Subnets === "") {
     contents.Subnets = [];
@@ -16299,7 +16300,7 @@ const deserializeAws_queryClusterSubnetGroupAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -16313,7 +16314,7 @@ const deserializeAws_queryClusterSubnetGroupMessage = (
     ClusterSubnetGroups: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.ClusterSubnetGroups === "") {
     contents.ClusterSubnetGroups = [];
@@ -16338,7 +16339,7 @@ const deserializeAws_queryClusterSubnetGroupNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -16351,7 +16352,7 @@ const deserializeAws_queryClusterSubnetGroupQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -16375,7 +16376,7 @@ const deserializeAws_queryClusterSubnetQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -16387,13 +16388,13 @@ const deserializeAws_queryClusterVersion = (output: any, context: __SerdeContext
     Description: undefined,
   };
   if (output["ClusterVersion"] !== undefined) {
-    contents.ClusterVersion = output["ClusterVersion"];
+    contents.ClusterVersion = __expectString(output["ClusterVersion"]);
   }
   if (output["ClusterParameterGroupFamily"] !== undefined) {
-    contents.ClusterParameterGroupFamily = output["ClusterParameterGroupFamily"];
+    contents.ClusterParameterGroupFamily = __expectString(output["ClusterParameterGroupFamily"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   return contents;
 };
@@ -16415,7 +16416,7 @@ const deserializeAws_queryClusterVersionsMessage = (output: any, context: __Serd
     ClusterVersions: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.ClusterVersions === "") {
     contents.ClusterVersions = [];
@@ -16450,7 +16451,7 @@ const deserializeAws_queryCopyToRegionDisabledFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -16596,7 +16597,7 @@ const deserializeAws_queryDataTransferProgress = (output: any, context: __SerdeC
     ElapsedTimeInSeconds: undefined,
   };
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["CurrentRateInMegaBytesPerSecond"] !== undefined) {
     contents.CurrentRateInMegaBytesPerSecond = parseFloat(output["CurrentRateInMegaBytesPerSecond"]);
@@ -16626,10 +16627,10 @@ const deserializeAws_queryDefaultClusterParameters = (
     Parameters: undefined,
   };
   if (output["ParameterGroupFamily"] !== undefined) {
-    contents.ParameterGroupFamily = output["ParameterGroupFamily"];
+    contents.ParameterGroupFamily = __expectString(output["ParameterGroupFamily"]);
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.Parameters === "") {
     contents.Parameters = [];
@@ -16653,7 +16654,7 @@ const deserializeAws_queryDeferredMaintenanceWindow = (
     DeferMaintenanceEndTime: undefined,
   };
   if (output["DeferMaintenanceIdentifier"] !== undefined) {
-    contents.DeferMaintenanceIdentifier = output["DeferMaintenanceIdentifier"];
+    contents.DeferMaintenanceIdentifier = __expectString(output["DeferMaintenanceIdentifier"]);
   }
   if (output["DeferMaintenanceStartTime"] !== undefined) {
     contents.DeferMaintenanceStartTime = new Date(output["DeferMaintenanceStartTime"]);
@@ -16709,7 +16710,7 @@ const deserializeAws_queryDependentServiceRequestThrottlingFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -16722,7 +16723,7 @@ const deserializeAws_queryDependentServiceUnavailableFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -16783,7 +16784,7 @@ const deserializeAws_queryDescribeSnapshotSchedulesOutputMessage = (
     );
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -16809,13 +16810,13 @@ const deserializeAws_queryEC2SecurityGroup = (output: any, context: __SerdeConte
     Tags: undefined,
   };
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["EC2SecurityGroupName"] !== undefined) {
-    contents.EC2SecurityGroupName = output["EC2SecurityGroupName"];
+    contents.EC2SecurityGroupName = __expectString(output["EC2SecurityGroupName"]);
   }
   if (output["EC2SecurityGroupOwnerId"] !== undefined) {
-    contents.EC2SecurityGroupOwnerId = output["EC2SecurityGroupOwnerId"];
+    contents.EC2SecurityGroupOwnerId = __expectString(output["EC2SecurityGroupOwnerId"]);
   }
   if (output.Tags === "") {
     contents.Tags = [];
@@ -16843,10 +16844,10 @@ const deserializeAws_queryElasticIpStatus = (output: any, context: __SerdeContex
     Status: undefined,
   };
   if (output["ElasticIp"] !== undefined) {
-    contents.ElasticIp = output["ElasticIp"];
+    contents.ElasticIp = __expectString(output["ElasticIp"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   return contents;
 };
@@ -16882,7 +16883,7 @@ const deserializeAws_queryEndpoint = (output: any, context: __SerdeContext): End
     VpcEndpoints: undefined,
   };
   if (output["Address"] !== undefined) {
-    contents.Address = output["Address"];
+    contents.Address = __expectString(output["Address"]);
   }
   if (output["Port"] !== undefined) {
     contents.Port = parseInt(output["Port"]);
@@ -16913,19 +16914,19 @@ const deserializeAws_queryEndpointAccess = (output: any, context: __SerdeContext
     VpcEndpoint: undefined,
   };
   if (output["ClusterIdentifier"] !== undefined) {
-    contents.ClusterIdentifier = output["ClusterIdentifier"];
+    contents.ClusterIdentifier = __expectString(output["ClusterIdentifier"]);
   }
   if (output["ResourceOwner"] !== undefined) {
-    contents.ResourceOwner = output["ResourceOwner"];
+    contents.ResourceOwner = __expectString(output["ResourceOwner"]);
   }
   if (output["SubnetGroupName"] !== undefined) {
-    contents.SubnetGroupName = output["SubnetGroupName"];
+    contents.SubnetGroupName = __expectString(output["SubnetGroupName"]);
   }
   if (output["EndpointStatus"] !== undefined) {
-    contents.EndpointStatus = output["EndpointStatus"];
+    contents.EndpointStatus = __expectString(output["EndpointStatus"]);
   }
   if (output["EndpointName"] !== undefined) {
-    contents.EndpointName = output["EndpointName"];
+    contents.EndpointName = __expectString(output["EndpointName"]);
   }
   if (output["EndpointCreateTime"] !== undefined) {
     contents.EndpointCreateTime = new Date(output["EndpointCreateTime"]);
@@ -16934,7 +16935,7 @@ const deserializeAws_queryEndpointAccess = (output: any, context: __SerdeContext
     contents.Port = parseInt(output["Port"]);
   }
   if (output["Address"] !== undefined) {
-    contents.Address = output["Address"];
+    contents.Address = __expectString(output["Address"]);
   }
   if (output.VpcSecurityGroups === "") {
     contents.VpcSecurityGroups = [];
@@ -16977,7 +16978,7 @@ const deserializeAws_queryEndpointAccessList = (output: any, context: __SerdeCon
     );
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -16990,7 +16991,7 @@ const deserializeAws_queryEndpointAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17008,22 +17009,22 @@ const deserializeAws_queryEndpointAuthorization = (output: any, context: __Serde
     EndpointCount: undefined,
   };
   if (output["Grantor"] !== undefined) {
-    contents.Grantor = output["Grantor"];
+    contents.Grantor = __expectString(output["Grantor"]);
   }
   if (output["Grantee"] !== undefined) {
-    contents.Grantee = output["Grantee"];
+    contents.Grantee = __expectString(output["Grantee"]);
   }
   if (output["ClusterIdentifier"] !== undefined) {
-    contents.ClusterIdentifier = output["ClusterIdentifier"];
+    contents.ClusterIdentifier = __expectString(output["ClusterIdentifier"]);
   }
   if (output["AuthorizeTime"] !== undefined) {
     contents.AuthorizeTime = new Date(output["AuthorizeTime"]);
   }
   if (output["ClusterStatus"] !== undefined) {
-    contents.ClusterStatus = output["ClusterStatus"];
+    contents.ClusterStatus = __expectString(output["ClusterStatus"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["AllowedAllVPCs"] !== undefined) {
     contents.AllowedAllVPCs = __parseBoolean(output["AllowedAllVPCs"]);
@@ -17051,7 +17052,7 @@ const deserializeAws_queryEndpointAuthorizationAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17077,7 +17078,7 @@ const deserializeAws_queryEndpointAuthorizationList = (
     );
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -17090,7 +17091,7 @@ const deserializeAws_queryEndpointAuthorizationNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17114,7 +17115,7 @@ const deserializeAws_queryEndpointAuthorizationsPerClusterLimitExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17124,7 +17125,7 @@ const deserializeAws_queryEndpointNotFoundFault = (output: any, context: __Serde
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17137,7 +17138,7 @@ const deserializeAws_queryEndpointsPerAuthorizationLimitExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17150,7 +17151,7 @@ const deserializeAws_queryEndpointsPerClusterLimitExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17166,13 +17167,13 @@ const deserializeAws_queryEvent = (output: any, context: __SerdeContext): Event 
     EventId: undefined,
   };
   if (output["SourceIdentifier"] !== undefined) {
-    contents.SourceIdentifier = output["SourceIdentifier"];
+    contents.SourceIdentifier = __expectString(output["SourceIdentifier"]);
   }
   if (output["SourceType"] !== undefined) {
-    contents.SourceType = output["SourceType"];
+    contents.SourceType = __expectString(output["SourceType"]);
   }
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   if (output.EventCategories === "") {
     contents.EventCategories = [];
@@ -17184,13 +17185,13 @@ const deserializeAws_queryEvent = (output: any, context: __SerdeContext): Event 
     );
   }
   if (output["Severity"] !== undefined) {
-    contents.Severity = output["Severity"];
+    contents.Severity = __expectString(output["Severity"]);
   }
   if (output["Date"] !== undefined) {
     contents.Date = new Date(output["Date"]);
   }
   if (output["EventId"] !== undefined) {
-    contents.EventId = output["EventId"];
+    contents.EventId = __expectString(output["EventId"]);
   }
   return contents;
 };
@@ -17202,7 +17203,7 @@ const deserializeAws_queryEventCategoriesList = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -17212,7 +17213,7 @@ const deserializeAws_queryEventCategoriesMap = (output: any, context: __SerdeCon
     Events: undefined,
   };
   if (output["SourceType"] !== undefined) {
-    contents.SourceType = output["SourceType"];
+    contents.SourceType = __expectString(output["SourceType"]);
   }
   if (output.Events === "") {
     contents.Events = [];
@@ -17264,7 +17265,7 @@ const deserializeAws_queryEventInfoMap = (output: any, context: __SerdeContext):
     Severity: undefined,
   };
   if (output["EventId"] !== undefined) {
-    contents.EventId = output["EventId"];
+    contents.EventId = __expectString(output["EventId"]);
   }
   if (output.EventCategories === "") {
     contents.EventCategories = [];
@@ -17276,10 +17277,10 @@ const deserializeAws_queryEventInfoMap = (output: any, context: __SerdeContext):
     );
   }
   if (output["EventDescription"] !== undefined) {
-    contents.EventDescription = output["EventDescription"];
+    contents.EventDescription = __expectString(output["EventDescription"]);
   }
   if (output["Severity"] !== undefined) {
-    contents.Severity = output["Severity"];
+    contents.Severity = __expectString(output["Severity"]);
   }
   return contents;
 };
@@ -17312,7 +17313,7 @@ const deserializeAws_queryEventsMessage = (output: any, context: __SerdeContext)
     Events: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.Events === "") {
     contents.Events = [];
@@ -17338,22 +17339,22 @@ const deserializeAws_queryEventSubscription = (output: any, context: __SerdeCont
     Tags: undefined,
   };
   if (output["CustomerAwsId"] !== undefined) {
-    contents.CustomerAwsId = output["CustomerAwsId"];
+    contents.CustomerAwsId = __expectString(output["CustomerAwsId"]);
   }
   if (output["CustSubscriptionId"] !== undefined) {
-    contents.CustSubscriptionId = output["CustSubscriptionId"];
+    contents.CustSubscriptionId = __expectString(output["CustSubscriptionId"]);
   }
   if (output["SnsTopicArn"] !== undefined) {
-    contents.SnsTopicArn = output["SnsTopicArn"];
+    contents.SnsTopicArn = __expectString(output["SnsTopicArn"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["SubscriptionCreationTime"] !== undefined) {
     contents.SubscriptionCreationTime = new Date(output["SubscriptionCreationTime"]);
   }
   if (output["SourceType"] !== undefined) {
-    contents.SourceType = output["SourceType"];
+    contents.SourceType = __expectString(output["SourceType"]);
   }
   if (output.SourceIdsList === "") {
     contents.SourceIdsList = [];
@@ -17374,7 +17375,7 @@ const deserializeAws_queryEventSubscription = (output: any, context: __SerdeCont
     );
   }
   if (output["Severity"] !== undefined) {
-    contents.Severity = output["Severity"];
+    contents.Severity = __expectString(output["Severity"]);
   }
   if (output["Enabled"] !== undefined) {
     contents.Enabled = __parseBoolean(output["Enabled"]);
@@ -17396,7 +17397,7 @@ const deserializeAws_queryEventSubscriptionQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17421,7 +17422,7 @@ const deserializeAws_queryEventSubscriptionsMessage = (
     EventSubscriptionsList: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.EventSubscriptionsList === "") {
     contents.EventSubscriptionsList = [];
@@ -17447,7 +17448,7 @@ const deserializeAws_queryGetReservedNodeExchangeOfferingsOutputMessage = (
     ReservedNodeOfferings: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.ReservedNodeOfferings === "") {
     contents.ReservedNodeOfferings = [];
@@ -17471,10 +17472,10 @@ const deserializeAws_queryHsmClientCertificate = (output: any, context: __SerdeC
     Tags: undefined,
   };
   if (output["HsmClientCertificateIdentifier"] !== undefined) {
-    contents.HsmClientCertificateIdentifier = output["HsmClientCertificateIdentifier"];
+    contents.HsmClientCertificateIdentifier = __expectString(output["HsmClientCertificateIdentifier"]);
   }
   if (output["HsmClientCertificatePublicKey"] !== undefined) {
-    contents.HsmClientCertificatePublicKey = output["HsmClientCertificatePublicKey"];
+    contents.HsmClientCertificatePublicKey = __expectString(output["HsmClientCertificatePublicKey"]);
   }
   if (output.Tags === "") {
     contents.Tags = [];
@@ -17493,7 +17494,7 @@ const deserializeAws_queryHsmClientCertificateAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17518,7 +17519,7 @@ const deserializeAws_queryHsmClientCertificateMessage = (
     HsmClientCertificates: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.HsmClientCertificates === "") {
     contents.HsmClientCertificates = [];
@@ -17543,7 +17544,7 @@ const deserializeAws_queryHsmClientCertificateNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17556,7 +17557,7 @@ const deserializeAws_queryHsmClientCertificateQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17570,16 +17571,16 @@ const deserializeAws_queryHsmConfiguration = (output: any, context: __SerdeConte
     Tags: undefined,
   };
   if (output["HsmConfigurationIdentifier"] !== undefined) {
-    contents.HsmConfigurationIdentifier = output["HsmConfigurationIdentifier"];
+    contents.HsmConfigurationIdentifier = __expectString(output["HsmConfigurationIdentifier"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output["HsmIpAddress"] !== undefined) {
-    contents.HsmIpAddress = output["HsmIpAddress"];
+    contents.HsmIpAddress = __expectString(output["HsmIpAddress"]);
   }
   if (output["HsmPartitionName"] !== undefined) {
-    contents.HsmPartitionName = output["HsmPartitionName"];
+    contents.HsmPartitionName = __expectString(output["HsmPartitionName"]);
   }
   if (output.Tags === "") {
     contents.Tags = [];
@@ -17598,7 +17599,7 @@ const deserializeAws_queryHsmConfigurationAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17620,7 +17621,7 @@ const deserializeAws_queryHsmConfigurationMessage = (output: any, context: __Ser
     HsmConfigurations: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.HsmConfigurations === "") {
     contents.HsmConfigurations = [];
@@ -17642,7 +17643,7 @@ const deserializeAws_queryHsmConfigurationNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17655,7 +17656,7 @@ const deserializeAws_queryHsmConfigurationQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17667,13 +17668,13 @@ const deserializeAws_queryHsmStatus = (output: any, context: __SerdeContext): Hs
     Status: undefined,
   };
   if (output["HsmClientCertificateIdentifier"] !== undefined) {
-    contents.HsmClientCertificateIdentifier = output["HsmClientCertificateIdentifier"];
+    contents.HsmClientCertificateIdentifier = __expectString(output["HsmClientCertificateIdentifier"]);
   }
   if (output["HsmConfigurationIdentifier"] !== undefined) {
-    contents.HsmConfigurationIdentifier = output["HsmConfigurationIdentifier"];
+    contents.HsmConfigurationIdentifier = __expectString(output["HsmConfigurationIdentifier"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   return contents;
 };
@@ -17685,7 +17686,7 @@ const deserializeAws_queryImportTablesCompleted = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -17696,7 +17697,7 @@ const deserializeAws_queryImportTablesInProgress = (output: any, context: __Serd
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -17707,7 +17708,7 @@ const deserializeAws_queryImportTablesNotStarted = (output: any, context: __Serd
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -17719,7 +17720,7 @@ const deserializeAws_queryIncompatibleOrderableOptions = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17732,7 +17733,7 @@ const deserializeAws_queryInProgressTableRestoreQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17745,7 +17746,7 @@ const deserializeAws_queryInsufficientClusterCapacityFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17758,7 +17759,7 @@ const deserializeAws_queryInsufficientS3BucketPolicyFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17771,7 +17772,7 @@ const deserializeAws_queryInvalidAuthorizationStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17784,7 +17785,7 @@ const deserializeAws_queryInvalidClusterParameterGroupStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17797,7 +17798,7 @@ const deserializeAws_queryInvalidClusterSecurityGroupStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17810,7 +17811,7 @@ const deserializeAws_queryInvalidClusterSnapshotScheduleStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17823,7 +17824,7 @@ const deserializeAws_queryInvalidClusterSnapshotStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17836,7 +17837,7 @@ const deserializeAws_queryInvalidClusterStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17849,7 +17850,7 @@ const deserializeAws_queryInvalidClusterSubnetGroupStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17862,7 +17863,7 @@ const deserializeAws_queryInvalidClusterSubnetStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17875,7 +17876,7 @@ const deserializeAws_queryInvalidClusterTrackFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17885,7 +17886,7 @@ const deserializeAws_queryInvalidElasticIpFault = (output: any, context: __Serde
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17898,7 +17899,7 @@ const deserializeAws_queryInvalidEndpointStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17911,7 +17912,7 @@ const deserializeAws_queryInvalidHsmClientCertificateStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17924,7 +17925,7 @@ const deserializeAws_queryInvalidHsmConfigurationStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17937,7 +17938,7 @@ const deserializeAws_queryInvalidReservedNodeStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17947,7 +17948,7 @@ const deserializeAws_queryInvalidRestoreFault = (output: any, context: __SerdeCo
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17960,7 +17961,7 @@ const deserializeAws_queryInvalidRetentionPeriodFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17973,7 +17974,7 @@ const deserializeAws_queryInvalidS3BucketNameFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17983,7 +17984,7 @@ const deserializeAws_queryInvalidS3KeyPrefixFault = (output: any, context: __Ser
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -17996,7 +17997,7 @@ const deserializeAws_queryInvalidScheduledActionFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -18006,7 +18007,7 @@ const deserializeAws_queryInvalidScheduleFault = (output: any, context: __SerdeC
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -18019,7 +18020,7 @@ const deserializeAws_queryInvalidSnapshotCopyGrantStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -18029,7 +18030,7 @@ const deserializeAws_queryInvalidSubnet = (output: any, context: __SerdeContext)
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -18042,7 +18043,7 @@ const deserializeAws_queryInvalidSubscriptionStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -18055,7 +18056,7 @@ const deserializeAws_queryInvalidTableRestoreArgumentFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -18065,7 +18066,7 @@ const deserializeAws_queryInvalidTagFault = (output: any, context: __SerdeContex
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -18075,7 +18076,7 @@ const deserializeAws_queryInvalidUsageLimitFault = (output: any, context: __Serd
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -18088,7 +18089,7 @@ const deserializeAws_queryInvalidVPCNetworkStateFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -18100,10 +18101,10 @@ const deserializeAws_queryIPRange = (output: any, context: __SerdeContext): IPRa
     Tags: undefined,
   };
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["CIDRIP"] !== undefined) {
-    contents.CIDRIP = output["CIDRIP"];
+    contents.CIDRIP = __expectString(output["CIDRIP"]);
   }
   if (output.Tags === "") {
     contents.Tags = [];
@@ -18130,7 +18131,7 @@ const deserializeAws_queryLimitExceededFault = (output: any, context: __SerdeCon
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -18148,10 +18149,10 @@ const deserializeAws_queryLoggingStatus = (output: any, context: __SerdeContext)
     contents.LoggingEnabled = __parseBoolean(output["LoggingEnabled"]);
   }
   if (output["BucketName"] !== undefined) {
-    contents.BucketName = output["BucketName"];
+    contents.BucketName = __expectString(output["BucketName"]);
   }
   if (output["S3KeyPrefix"] !== undefined) {
-    contents.S3KeyPrefix = output["S3KeyPrefix"];
+    contents.S3KeyPrefix = __expectString(output["S3KeyPrefix"]);
   }
   if (output["LastSuccessfulDeliveryTime"] !== undefined) {
     contents.LastSuccessfulDeliveryTime = new Date(output["LastSuccessfulDeliveryTime"]);
@@ -18160,7 +18161,7 @@ const deserializeAws_queryLoggingStatus = (output: any, context: __SerdeContext)
     contents.LastFailureTime = new Date(output["LastFailureTime"]);
   }
   if (output["LastFailureMessage"] !== undefined) {
-    contents.LastFailureMessage = output["LastFailureMessage"];
+    contents.LastFailureMessage = __expectString(output["LastFailureMessage"]);
   }
   return contents;
 };
@@ -18172,10 +18173,10 @@ const deserializeAws_queryMaintenanceTrack = (output: any, context: __SerdeConte
     UpdateTargets: undefined,
   };
   if (output["MaintenanceTrackName"] !== undefined) {
-    contents.MaintenanceTrackName = output["MaintenanceTrackName"];
+    contents.MaintenanceTrackName = __expectString(output["MaintenanceTrackName"]);
   }
   if (output["DatabaseVersion"] !== undefined) {
-    contents.DatabaseVersion = output["DatabaseVersion"];
+    contents.DatabaseVersion = __expectString(output["DatabaseVersion"]);
   }
   if (output.UpdateTargets === "") {
     contents.UpdateTargets = [];
@@ -18308,16 +18309,16 @@ const deserializeAws_queryNetworkInterface = (output: any, context: __SerdeConte
     AvailabilityZone: undefined,
   };
   if (output["NetworkInterfaceId"] !== undefined) {
-    contents.NetworkInterfaceId = output["NetworkInterfaceId"];
+    contents.NetworkInterfaceId = __expectString(output["NetworkInterfaceId"]);
   }
   if (output["SubnetId"] !== undefined) {
-    contents.SubnetId = output["SubnetId"];
+    contents.SubnetId = __expectString(output["SubnetId"]);
   }
   if (output["PrivateIpAddress"] !== undefined) {
-    contents.PrivateIpAddress = output["PrivateIpAddress"];
+    contents.PrivateIpAddress = __expectString(output["PrivateIpAddress"]);
   }
   if (output["AvailabilityZone"] !== undefined) {
-    contents.AvailabilityZone = output["AvailabilityZone"];
+    contents.AvailabilityZone = __expectString(output["AvailabilityZone"]);
   }
   return contents;
 };
@@ -18341,7 +18342,7 @@ const deserializeAws_queryNodeConfigurationOption = (output: any, context: __Ser
     Mode: undefined,
   };
   if (output["NodeType"] !== undefined) {
-    contents.NodeType = output["NodeType"];
+    contents.NodeType = __expectString(output["NodeType"]);
   }
   if (output["NumberOfNodes"] !== undefined) {
     contents.NumberOfNodes = parseInt(output["NumberOfNodes"]);
@@ -18350,7 +18351,7 @@ const deserializeAws_queryNodeConfigurationOption = (output: any, context: __Ser
     contents.EstimatedDiskUtilizationPercent = parseFloat(output["EstimatedDiskUtilizationPercent"]);
   }
   if (output["Mode"] !== undefined) {
-    contents.Mode = output["Mode"];
+    contents.Mode = __expectString(output["Mode"]);
   }
   return contents;
 };
@@ -18390,7 +18391,7 @@ const deserializeAws_queryNodeConfigurationOptionsMessage = (
     );
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -18403,7 +18404,7 @@ const deserializeAws_queryNumberOfNodesPerClusterLimitExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -18416,7 +18417,7 @@ const deserializeAws_queryNumberOfNodesQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -18429,13 +18430,13 @@ const deserializeAws_queryOrderableClusterOption = (output: any, context: __Serd
     AvailabilityZones: undefined,
   };
   if (output["ClusterVersion"] !== undefined) {
-    contents.ClusterVersion = output["ClusterVersion"];
+    contents.ClusterVersion = __expectString(output["ClusterVersion"]);
   }
   if (output["ClusterType"] !== undefined) {
-    contents.ClusterType = output["ClusterType"];
+    contents.ClusterType = __expectString(output["ClusterType"]);
   }
   if (output["NodeType"] !== undefined) {
-    contents.NodeType = output["NodeType"];
+    contents.NodeType = __expectString(output["NodeType"]);
   }
   if (output.AvailabilityZones === "") {
     contents.AvailabilityZones = [];
@@ -18484,7 +18485,7 @@ const deserializeAws_queryOrderableClusterOptionsMessage = (
     );
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -18502,31 +18503,31 @@ const deserializeAws_queryParameter = (output: any, context: __SerdeContext): Pa
     MinimumEngineVersion: undefined,
   };
   if (output["ParameterName"] !== undefined) {
-    contents.ParameterName = output["ParameterName"];
+    contents.ParameterName = __expectString(output["ParameterName"]);
   }
   if (output["ParameterValue"] !== undefined) {
-    contents.ParameterValue = output["ParameterValue"];
+    contents.ParameterValue = __expectString(output["ParameterValue"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output["Source"] !== undefined) {
-    contents.Source = output["Source"];
+    contents.Source = __expectString(output["Source"]);
   }
   if (output["DataType"] !== undefined) {
-    contents.DataType = output["DataType"];
+    contents.DataType = __expectString(output["DataType"]);
   }
   if (output["AllowedValues"] !== undefined) {
-    contents.AllowedValues = output["AllowedValues"];
+    contents.AllowedValues = __expectString(output["AllowedValues"]);
   }
   if (output["ApplyType"] !== undefined) {
-    contents.ApplyType = output["ApplyType"];
+    contents.ApplyType = __expectString(output["ApplyType"]);
   }
   if (output["IsModifiable"] !== undefined) {
     contents.IsModifiable = __parseBoolean(output["IsModifiable"]);
   }
   if (output["MinimumEngineVersion"] !== undefined) {
-    contents.MinimumEngineVersion = output["MinimumEngineVersion"];
+    contents.MinimumEngineVersion = __expectString(output["MinimumEngineVersion"]);
   }
   return contents;
 };
@@ -18563,16 +18564,16 @@ const deserializeAws_queryPartnerIntegrationInfo = (output: any, context: __Serd
     UpdatedAt: undefined,
   };
   if (output["DatabaseName"] !== undefined) {
-    contents.DatabaseName = output["DatabaseName"];
+    contents.DatabaseName = __expectString(output["DatabaseName"]);
   }
   if (output["PartnerName"] !== undefined) {
-    contents.PartnerName = output["PartnerName"];
+    contents.PartnerName = __expectString(output["PartnerName"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["StatusMessage"] !== undefined) {
-    contents.StatusMessage = output["StatusMessage"];
+    contents.StatusMessage = __expectString(output["StatusMessage"]);
   }
   if (output["CreatedAt"] !== undefined) {
     contents.CreatedAt = new Date(output["CreatedAt"]);
@@ -18606,10 +18607,10 @@ const deserializeAws_queryPartnerIntegrationOutputMessage = (
     PartnerName: undefined,
   };
   if (output["DatabaseName"] !== undefined) {
-    contents.DatabaseName = output["DatabaseName"];
+    contents.DatabaseName = __expectString(output["DatabaseName"]);
   }
   if (output["PartnerName"] !== undefined) {
-    contents.PartnerName = output["PartnerName"];
+    contents.PartnerName = __expectString(output["PartnerName"]);
   }
   return contents;
 };
@@ -18619,7 +18620,7 @@ const deserializeAws_queryPartnerNotFoundFault = (output: any, context: __SerdeC
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -18629,7 +18630,7 @@ const deserializeAws_queryPauseClusterMessage = (output: any, context: __SerdeCo
     ClusterIdentifier: undefined,
   };
   if (output["ClusterIdentifier"] !== undefined) {
-    contents.ClusterIdentifier = output["ClusterIdentifier"];
+    contents.ClusterIdentifier = __expectString(output["ClusterIdentifier"]);
   }
   return contents;
 };
@@ -18651,7 +18652,7 @@ const deserializeAws_queryPendingActionsList = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -18670,25 +18671,25 @@ const deserializeAws_queryPendingModifiedValues = (output: any, context: __Serde
     EncryptionType: undefined,
   };
   if (output["MasterUserPassword"] !== undefined) {
-    contents.MasterUserPassword = output["MasterUserPassword"];
+    contents.MasterUserPassword = __expectString(output["MasterUserPassword"]);
   }
   if (output["NodeType"] !== undefined) {
-    contents.NodeType = output["NodeType"];
+    contents.NodeType = __expectString(output["NodeType"]);
   }
   if (output["NumberOfNodes"] !== undefined) {
     contents.NumberOfNodes = parseInt(output["NumberOfNodes"]);
   }
   if (output["ClusterType"] !== undefined) {
-    contents.ClusterType = output["ClusterType"];
+    contents.ClusterType = __expectString(output["ClusterType"]);
   }
   if (output["ClusterVersion"] !== undefined) {
-    contents.ClusterVersion = output["ClusterVersion"];
+    contents.ClusterVersion = __expectString(output["ClusterVersion"]);
   }
   if (output["AutomatedSnapshotRetentionPeriod"] !== undefined) {
     contents.AutomatedSnapshotRetentionPeriod = parseInt(output["AutomatedSnapshotRetentionPeriod"]);
   }
   if (output["ClusterIdentifier"] !== undefined) {
-    contents.ClusterIdentifier = output["ClusterIdentifier"];
+    contents.ClusterIdentifier = __expectString(output["ClusterIdentifier"]);
   }
   if (output["PubliclyAccessible"] !== undefined) {
     contents.PubliclyAccessible = __parseBoolean(output["PubliclyAccessible"]);
@@ -18697,10 +18698,10 @@ const deserializeAws_queryPendingModifiedValues = (output: any, context: __Serde
     contents.EnhancedVpcRouting = __parseBoolean(output["EnhancedVpcRouting"]);
   }
   if (output["MaintenanceTrackName"] !== undefined) {
-    contents.MaintenanceTrackName = output["MaintenanceTrackName"];
+    contents.MaintenanceTrackName = __expectString(output["MaintenanceTrackName"]);
   }
   if (output["EncryptionType"] !== undefined) {
-    contents.EncryptionType = output["EncryptionType"];
+    contents.EncryptionType = __expectString(output["EncryptionType"]);
   }
   return contents;
 };
@@ -18737,7 +18738,7 @@ const deserializeAws_queryRecurringCharge = (output: any, context: __SerdeContex
     contents.RecurringChargeAmount = parseFloat(output["RecurringChargeAmount"]);
   }
   if (output["RecurringChargeFrequency"] !== undefined) {
-    contents.RecurringChargeFrequency = output["RecurringChargeFrequency"];
+    contents.RecurringChargeFrequency = __expectString(output["RecurringChargeFrequency"]);
   }
   return contents;
 };
@@ -18770,13 +18771,13 @@ const deserializeAws_queryReservedNode = (output: any, context: __SerdeContext):
     ReservedNodeOfferingType: undefined,
   };
   if (output["ReservedNodeId"] !== undefined) {
-    contents.ReservedNodeId = output["ReservedNodeId"];
+    contents.ReservedNodeId = __expectString(output["ReservedNodeId"]);
   }
   if (output["ReservedNodeOfferingId"] !== undefined) {
-    contents.ReservedNodeOfferingId = output["ReservedNodeOfferingId"];
+    contents.ReservedNodeOfferingId = __expectString(output["ReservedNodeOfferingId"]);
   }
   if (output["NodeType"] !== undefined) {
-    contents.NodeType = output["NodeType"];
+    contents.NodeType = __expectString(output["NodeType"]);
   }
   if (output["StartTime"] !== undefined) {
     contents.StartTime = new Date(output["StartTime"]);
@@ -18791,16 +18792,16 @@ const deserializeAws_queryReservedNode = (output: any, context: __SerdeContext):
     contents.UsagePrice = parseFloat(output["UsagePrice"]);
   }
   if (output["CurrencyCode"] !== undefined) {
-    contents.CurrencyCode = output["CurrencyCode"];
+    contents.CurrencyCode = __expectString(output["CurrencyCode"]);
   }
   if (output["NodeCount"] !== undefined) {
     contents.NodeCount = parseInt(output["NodeCount"]);
   }
   if (output["State"] !== undefined) {
-    contents.State = output["State"];
+    contents.State = __expectString(output["State"]);
   }
   if (output["OfferingType"] !== undefined) {
-    contents.OfferingType = output["OfferingType"];
+    contents.OfferingType = __expectString(output["OfferingType"]);
   }
   if (output.RecurringCharges === "") {
     contents.RecurringCharges = [];
@@ -18812,7 +18813,7 @@ const deserializeAws_queryReservedNode = (output: any, context: __SerdeContext):
     );
   }
   if (output["ReservedNodeOfferingType"] !== undefined) {
-    contents.ReservedNodeOfferingType = output["ReservedNodeOfferingType"];
+    contents.ReservedNodeOfferingType = __expectString(output["ReservedNodeOfferingType"]);
   }
   return contents;
 };
@@ -18825,7 +18826,7 @@ const deserializeAws_queryReservedNodeAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -18838,7 +18839,7 @@ const deserializeAws_queryReservedNodeAlreadyMigratedFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -18862,7 +18863,7 @@ const deserializeAws_queryReservedNodeNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -18880,10 +18881,10 @@ const deserializeAws_queryReservedNodeOffering = (output: any, context: __SerdeC
     ReservedNodeOfferingType: undefined,
   };
   if (output["ReservedNodeOfferingId"] !== undefined) {
-    contents.ReservedNodeOfferingId = output["ReservedNodeOfferingId"];
+    contents.ReservedNodeOfferingId = __expectString(output["ReservedNodeOfferingId"]);
   }
   if (output["NodeType"] !== undefined) {
-    contents.NodeType = output["NodeType"];
+    contents.NodeType = __expectString(output["NodeType"]);
   }
   if (output["Duration"] !== undefined) {
     contents.Duration = parseInt(output["Duration"]);
@@ -18895,10 +18896,10 @@ const deserializeAws_queryReservedNodeOffering = (output: any, context: __SerdeC
     contents.UsagePrice = parseFloat(output["UsagePrice"]);
   }
   if (output["CurrencyCode"] !== undefined) {
-    contents.CurrencyCode = output["CurrencyCode"];
+    contents.CurrencyCode = __expectString(output["CurrencyCode"]);
   }
   if (output["OfferingType"] !== undefined) {
-    contents.OfferingType = output["OfferingType"];
+    contents.OfferingType = __expectString(output["OfferingType"]);
   }
   if (output.RecurringCharges === "") {
     contents.RecurringCharges = [];
@@ -18910,7 +18911,7 @@ const deserializeAws_queryReservedNodeOffering = (output: any, context: __SerdeC
     );
   }
   if (output["ReservedNodeOfferingType"] !== undefined) {
-    contents.ReservedNodeOfferingType = output["ReservedNodeOfferingType"];
+    contents.ReservedNodeOfferingType = __expectString(output["ReservedNodeOfferingType"]);
   }
   return contents;
 };
@@ -18934,7 +18935,7 @@ const deserializeAws_queryReservedNodeOfferingNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -18948,7 +18949,7 @@ const deserializeAws_queryReservedNodeOfferingsMessage = (
     ReservedNodeOfferings: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.ReservedNodeOfferings === "") {
     contents.ReservedNodeOfferings = [];
@@ -18973,7 +18974,7 @@ const deserializeAws_queryReservedNodeQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -18984,7 +18985,7 @@ const deserializeAws_queryReservedNodesMessage = (output: any, context: __SerdeC
     ReservedNodes: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.ReservedNodes === "") {
     contents.ReservedNodes = [];
@@ -19007,13 +19008,13 @@ const deserializeAws_queryResizeClusterMessage = (output: any, context: __SerdeC
     Classic: undefined,
   };
   if (output["ClusterIdentifier"] !== undefined) {
-    contents.ClusterIdentifier = output["ClusterIdentifier"];
+    contents.ClusterIdentifier = __expectString(output["ClusterIdentifier"]);
   }
   if (output["ClusterType"] !== undefined) {
-    contents.ClusterType = output["ClusterType"];
+    contents.ClusterType = __expectString(output["ClusterType"]);
   }
   if (output["NodeType"] !== undefined) {
-    contents.NodeType = output["NodeType"];
+    contents.NodeType = __expectString(output["NodeType"]);
   }
   if (output["NumberOfNodes"] !== undefined) {
     contents.NumberOfNodes = parseInt(output["NumberOfNodes"]);
@@ -19040,7 +19041,7 @@ const deserializeAws_queryResizeInfo = (output: any, context: __SerdeContext): R
     AllowCancelResize: undefined,
   };
   if (output["ResizeType"] !== undefined) {
-    contents.ResizeType = output["ResizeType"];
+    contents.ResizeType = __expectString(output["ResizeType"]);
   }
   if (output["AllowCancelResize"] !== undefined) {
     contents.AllowCancelResize = __parseBoolean(output["AllowCancelResize"]);
@@ -19053,7 +19054,7 @@ const deserializeAws_queryResizeNotFoundFault = (output: any, context: __SerdeCo
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -19078,16 +19079,16 @@ const deserializeAws_queryResizeProgressMessage = (output: any, context: __Serde
     DataTransferProgressPercent: undefined,
   };
   if (output["TargetNodeType"] !== undefined) {
-    contents.TargetNodeType = output["TargetNodeType"];
+    contents.TargetNodeType = __expectString(output["TargetNodeType"]);
   }
   if (output["TargetNumberOfNodes"] !== undefined) {
     contents.TargetNumberOfNodes = parseInt(output["TargetNumberOfNodes"]);
   }
   if (output["TargetClusterType"] !== undefined) {
-    contents.TargetClusterType = output["TargetClusterType"];
+    contents.TargetClusterType = __expectString(output["TargetClusterType"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output.ImportTablesCompleted === "") {
     contents.ImportTablesCompleted = [];
@@ -19132,13 +19133,13 @@ const deserializeAws_queryResizeProgressMessage = (output: any, context: __Serde
     contents.EstimatedTimeToCompletionInSeconds = parseInt(output["EstimatedTimeToCompletionInSeconds"]);
   }
   if (output["ResizeType"] !== undefined) {
-    contents.ResizeType = output["ResizeType"];
+    contents.ResizeType = __expectString(output["ResizeType"]);
   }
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   if (output["TargetEncryptionType"] !== undefined) {
-    contents.TargetEncryptionType = output["TargetEncryptionType"];
+    contents.TargetEncryptionType = __expectString(output["TargetEncryptionType"]);
   }
   if (output["DataTransferProgressPercent"] !== undefined) {
     contents.DataTransferProgressPercent = parseFloat(output["DataTransferProgressPercent"]);
@@ -19151,7 +19152,7 @@ const deserializeAws_queryResourceNotFoundFault = (output: any, context: __Serde
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -19163,7 +19164,7 @@ const deserializeAws_queryRestorableNodeTypeList = (output: any, context: __Serd
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -19190,7 +19191,7 @@ const deserializeAws_queryRestoreStatus = (output: any, context: __SerdeContext)
     EstimatedTimeToCompletionInSeconds: undefined,
   };
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["CurrentRestoreRateInMegaBytesPerSecond"] !== undefined) {
     contents.CurrentRestoreRateInMegaBytesPerSecond = parseFloat(output["CurrentRestoreRateInMegaBytesPerSecond"]);
@@ -19228,7 +19229,7 @@ const deserializeAws_queryResumeClusterMessage = (output: any, context: __SerdeC
     ClusterIdentifier: undefined,
   };
   if (output["ClusterIdentifier"] !== undefined) {
-    contents.ClusterIdentifier = output["ClusterIdentifier"];
+    contents.ClusterIdentifier = __expectString(output["ClusterIdentifier"]);
   }
   return contents;
 };
@@ -19250,10 +19251,10 @@ const deserializeAws_queryRevisionTarget = (output: any, context: __SerdeContext
     DatabaseRevisionReleaseDate: undefined,
   };
   if (output["DatabaseRevision"] !== undefined) {
-    contents.DatabaseRevision = output["DatabaseRevision"];
+    contents.DatabaseRevision = __expectString(output["DatabaseRevision"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output["DatabaseRevisionReleaseDate"] !== undefined) {
     contents.DatabaseRevisionReleaseDate = new Date(output["DatabaseRevisionReleaseDate"]);
@@ -19324,22 +19325,22 @@ const deserializeAws_queryScheduledAction = (output: any, context: __SerdeContex
     EndTime: undefined,
   };
   if (output["ScheduledActionName"] !== undefined) {
-    contents.ScheduledActionName = output["ScheduledActionName"];
+    contents.ScheduledActionName = __expectString(output["ScheduledActionName"]);
   }
   if (output["TargetAction"] !== undefined) {
     contents.TargetAction = deserializeAws_queryScheduledActionType(output["TargetAction"], context);
   }
   if (output["Schedule"] !== undefined) {
-    contents.Schedule = output["Schedule"];
+    contents.Schedule = __expectString(output["Schedule"]);
   }
   if (output["IamRole"] !== undefined) {
-    contents.IamRole = output["IamRole"];
+    contents.IamRole = __expectString(output["IamRole"]);
   }
   if (output["ScheduledActionDescription"] !== undefined) {
-    contents.ScheduledActionDescription = output["ScheduledActionDescription"];
+    contents.ScheduledActionDescription = __expectString(output["ScheduledActionDescription"]);
   }
   if (output["State"] !== undefined) {
-    contents.State = output["State"];
+    contents.State = __expectString(output["State"]);
   }
   if (output.NextInvocations === "") {
     contents.NextInvocations = [];
@@ -19367,7 +19368,7 @@ const deserializeAws_queryScheduledActionAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -19391,7 +19392,7 @@ const deserializeAws_queryScheduledActionNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -19404,7 +19405,7 @@ const deserializeAws_queryScheduledActionQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -19415,7 +19416,7 @@ const deserializeAws_queryScheduledActionsMessage = (output: any, context: __Ser
     ScheduledActions: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.ScheduledActions === "") {
     contents.ScheduledActions = [];
@@ -19466,7 +19467,7 @@ const deserializeAws_queryScheduledActionTypeUnsupportedFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -19478,7 +19479,7 @@ const deserializeAws_queryScheduleDefinitionList = (output: any, context: __Serd
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -19490,7 +19491,7 @@ const deserializeAws_queryScheduleDefinitionTypeUnsupportedFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -19544,55 +19545,55 @@ const deserializeAws_querySnapshot = (output: any, context: __SerdeContext): Sna
     SnapshotRetentionStartTime: undefined,
   };
   if (output["SnapshotIdentifier"] !== undefined) {
-    contents.SnapshotIdentifier = output["SnapshotIdentifier"];
+    contents.SnapshotIdentifier = __expectString(output["SnapshotIdentifier"]);
   }
   if (output["ClusterIdentifier"] !== undefined) {
-    contents.ClusterIdentifier = output["ClusterIdentifier"];
+    contents.ClusterIdentifier = __expectString(output["ClusterIdentifier"]);
   }
   if (output["SnapshotCreateTime"] !== undefined) {
     contents.SnapshotCreateTime = new Date(output["SnapshotCreateTime"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["Port"] !== undefined) {
     contents.Port = parseInt(output["Port"]);
   }
   if (output["AvailabilityZone"] !== undefined) {
-    contents.AvailabilityZone = output["AvailabilityZone"];
+    contents.AvailabilityZone = __expectString(output["AvailabilityZone"]);
   }
   if (output["ClusterCreateTime"] !== undefined) {
     contents.ClusterCreateTime = new Date(output["ClusterCreateTime"]);
   }
   if (output["MasterUsername"] !== undefined) {
-    contents.MasterUsername = output["MasterUsername"];
+    contents.MasterUsername = __expectString(output["MasterUsername"]);
   }
   if (output["ClusterVersion"] !== undefined) {
-    contents.ClusterVersion = output["ClusterVersion"];
+    contents.ClusterVersion = __expectString(output["ClusterVersion"]);
   }
   if (output["EngineFullVersion"] !== undefined) {
-    contents.EngineFullVersion = output["EngineFullVersion"];
+    contents.EngineFullVersion = __expectString(output["EngineFullVersion"]);
   }
   if (output["SnapshotType"] !== undefined) {
-    contents.SnapshotType = output["SnapshotType"];
+    contents.SnapshotType = __expectString(output["SnapshotType"]);
   }
   if (output["NodeType"] !== undefined) {
-    contents.NodeType = output["NodeType"];
+    contents.NodeType = __expectString(output["NodeType"]);
   }
   if (output["NumberOfNodes"] !== undefined) {
     contents.NumberOfNodes = parseInt(output["NumberOfNodes"]);
   }
   if (output["DBName"] !== undefined) {
-    contents.DBName = output["DBName"];
+    contents.DBName = __expectString(output["DBName"]);
   }
   if (output["VpcId"] !== undefined) {
-    contents.VpcId = output["VpcId"];
+    contents.VpcId = __expectString(output["VpcId"]);
   }
   if (output["Encrypted"] !== undefined) {
     contents.Encrypted = __parseBoolean(output["Encrypted"]);
   }
   if (output["KmsKeyId"] !== undefined) {
-    contents.KmsKeyId = output["KmsKeyId"];
+    contents.KmsKeyId = __expectString(output["KmsKeyId"]);
   }
   if (output["EncryptedWithHSM"] !== undefined) {
     contents.EncryptedWithHSM = __parseBoolean(output["EncryptedWithHSM"]);
@@ -19610,7 +19611,7 @@ const deserializeAws_querySnapshot = (output: any, context: __SerdeContext): Sna
     );
   }
   if (output["OwnerAccount"] !== undefined) {
-    contents.OwnerAccount = output["OwnerAccount"];
+    contents.OwnerAccount = __expectString(output["OwnerAccount"]);
   }
   if (output["TotalBackupSizeInMegaBytes"] !== undefined) {
     contents.TotalBackupSizeInMegaBytes = parseFloat(output["TotalBackupSizeInMegaBytes"]);
@@ -19631,7 +19632,7 @@ const deserializeAws_querySnapshot = (output: any, context: __SerdeContext): Sna
     contents.ElapsedTimeInSeconds = parseInt(output["ElapsedTimeInSeconds"]);
   }
   if (output["SourceRegion"] !== undefined) {
-    contents.SourceRegion = output["SourceRegion"];
+    contents.SourceRegion = __expectString(output["SourceRegion"]);
   }
   if (output.Tags === "") {
     contents.Tags = [];
@@ -19652,7 +19653,7 @@ const deserializeAws_querySnapshot = (output: any, context: __SerdeContext): Sna
     contents.EnhancedVpcRouting = __parseBoolean(output["EnhancedVpcRouting"]);
   }
   if (output["MaintenanceTrackName"] !== undefined) {
-    contents.MaintenanceTrackName = output["MaintenanceTrackName"];
+    contents.MaintenanceTrackName = __expectString(output["MaintenanceTrackName"]);
   }
   if (output["ManualSnapshotRetentionPeriod"] !== undefined) {
     contents.ManualSnapshotRetentionPeriod = parseInt(output["ManualSnapshotRetentionPeriod"]);
@@ -19674,7 +19675,7 @@ const deserializeAws_querySnapshotCopyAlreadyDisabledFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -19687,7 +19688,7 @@ const deserializeAws_querySnapshotCopyAlreadyEnabledFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -19700,7 +19701,7 @@ const deserializeAws_querySnapshotCopyDisabledFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -19712,10 +19713,10 @@ const deserializeAws_querySnapshotCopyGrant = (output: any, context: __SerdeCont
     Tags: undefined,
   };
   if (output["SnapshotCopyGrantName"] !== undefined) {
-    contents.SnapshotCopyGrantName = output["SnapshotCopyGrantName"];
+    contents.SnapshotCopyGrantName = __expectString(output["SnapshotCopyGrantName"]);
   }
   if (output["KmsKeyId"] !== undefined) {
-    contents.KmsKeyId = output["KmsKeyId"];
+    contents.KmsKeyId = __expectString(output["KmsKeyId"]);
   }
   if (output.Tags === "") {
     contents.Tags = [];
@@ -19734,7 +19735,7 @@ const deserializeAws_querySnapshotCopyGrantAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -19759,7 +19760,7 @@ const deserializeAws_querySnapshotCopyGrantMessage = (
     SnapshotCopyGrants: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.SnapshotCopyGrants === "") {
     contents.SnapshotCopyGrants = [];
@@ -19781,7 +19782,7 @@ const deserializeAws_querySnapshotCopyGrantNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -19794,7 +19795,7 @@ const deserializeAws_querySnapshotCopyGrantQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -19807,16 +19808,16 @@ const deserializeAws_querySnapshotErrorMessage = (output: any, context: __SerdeC
     FailureReason: undefined,
   };
   if (output["SnapshotIdentifier"] !== undefined) {
-    contents.SnapshotIdentifier = output["SnapshotIdentifier"];
+    contents.SnapshotIdentifier = __expectString(output["SnapshotIdentifier"]);
   }
   if (output["SnapshotClusterIdentifier"] !== undefined) {
-    contents.SnapshotClusterIdentifier = output["SnapshotClusterIdentifier"];
+    contents.SnapshotClusterIdentifier = __expectString(output["SnapshotClusterIdentifier"]);
   }
   if (output["FailureCode"] !== undefined) {
-    contents.FailureCode = output["FailureCode"];
+    contents.FailureCode = __expectString(output["FailureCode"]);
   }
   if (output["FailureReason"] !== undefined) {
-    contents.FailureReason = output["FailureReason"];
+    contents.FailureReason = __expectString(output["FailureReason"]);
   }
   return contents;
 };
@@ -19828,7 +19829,7 @@ const deserializeAws_querySnapshotIdentifierList = (output: any, context: __Serd
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -19849,7 +19850,7 @@ const deserializeAws_querySnapshotMessage = (output: any, context: __SerdeContex
     Snapshots: undefined,
   };
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   if (output.Snapshots === "") {
     contents.Snapshots = [];
@@ -19886,10 +19887,10 @@ const deserializeAws_querySnapshotSchedule = (output: any, context: __SerdeConte
     );
   }
   if (output["ScheduleIdentifier"] !== undefined) {
-    contents.ScheduleIdentifier = output["ScheduleIdentifier"];
+    contents.ScheduleIdentifier = __expectString(output["ScheduleIdentifier"]);
   }
   if (output["ScheduleDescription"] !== undefined) {
-    contents.ScheduleDescription = output["ScheduleDescription"];
+    contents.ScheduleDescription = __expectString(output["ScheduleDescription"]);
   }
   if (output.Tags === "") {
     contents.Tags = [];
@@ -19932,7 +19933,7 @@ const deserializeAws_querySnapshotScheduleAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -19956,7 +19957,7 @@ const deserializeAws_querySnapshotScheduleNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -19969,7 +19970,7 @@ const deserializeAws_querySnapshotScheduleQuotaExceededFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -19982,7 +19983,7 @@ const deserializeAws_querySnapshotScheduleUpdateInProgressFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -19992,7 +19993,7 @@ const deserializeAws_querySNSInvalidTopicFault = (output: any, context: __SerdeC
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -20002,7 +20003,7 @@ const deserializeAws_querySNSNoAuthorizationFault = (output: any, context: __Ser
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -20015,7 +20016,7 @@ const deserializeAws_querySNSTopicArnNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -20027,7 +20028,7 @@ const deserializeAws_querySourceIdsList = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -20036,7 +20037,7 @@ const deserializeAws_querySourceNotFoundFault = (output: any, context: __SerdeCo
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -20048,13 +20049,13 @@ const deserializeAws_querySubnet = (output: any, context: __SerdeContext): Subne
     SubnetStatus: undefined,
   };
   if (output["SubnetIdentifier"] !== undefined) {
-    contents.SubnetIdentifier = output["SubnetIdentifier"];
+    contents.SubnetIdentifier = __expectString(output["SubnetIdentifier"]);
   }
   if (output["SubnetAvailabilityZone"] !== undefined) {
     contents.SubnetAvailabilityZone = deserializeAws_queryAvailabilityZone(output["SubnetAvailabilityZone"], context);
   }
   if (output["SubnetStatus"] !== undefined) {
-    contents.SubnetStatus = output["SubnetStatus"];
+    contents.SubnetStatus = __expectString(output["SubnetStatus"]);
   }
   return contents;
 };
@@ -20064,7 +20065,7 @@ const deserializeAws_querySubnetAlreadyInUse = (output: any, context: __SerdeCon
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -20088,7 +20089,7 @@ const deserializeAws_querySubscriptionAlreadyExistFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -20101,7 +20102,7 @@ const deserializeAws_querySubscriptionCategoryNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -20114,7 +20115,7 @@ const deserializeAws_querySubscriptionEventIdNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -20127,7 +20128,7 @@ const deserializeAws_querySubscriptionNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -20140,7 +20141,7 @@ const deserializeAws_querySubscriptionSeverityNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -20150,7 +20151,7 @@ const deserializeAws_querySupportedOperation = (output: any, context: __SerdeCon
     OperationName: undefined,
   };
   if (output["OperationName"] !== undefined) {
-    contents.OperationName = output["OperationName"];
+    contents.OperationName = __expectString(output["OperationName"]);
   }
   return contents;
 };
@@ -20171,7 +20172,7 @@ const deserializeAws_querySupportedPlatform = (output: any, context: __SerdeCont
     Name: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   return contents;
 };
@@ -20192,7 +20193,7 @@ const deserializeAws_queryTableLimitExceededFault = (output: any, context: __Ser
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -20205,7 +20206,7 @@ const deserializeAws_queryTableRestoreNotFoundFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -20228,13 +20229,13 @@ const deserializeAws_queryTableRestoreStatus = (output: any, context: __SerdeCon
     NewTableName: undefined,
   };
   if (output["TableRestoreRequestId"] !== undefined) {
-    contents.TableRestoreRequestId = output["TableRestoreRequestId"];
+    contents.TableRestoreRequestId = __expectString(output["TableRestoreRequestId"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   if (output["RequestTime"] !== undefined) {
     contents.RequestTime = new Date(output["RequestTime"]);
@@ -20246,28 +20247,28 @@ const deserializeAws_queryTableRestoreStatus = (output: any, context: __SerdeCon
     contents.TotalDataInMegaBytes = parseInt(output["TotalDataInMegaBytes"]);
   }
   if (output["ClusterIdentifier"] !== undefined) {
-    contents.ClusterIdentifier = output["ClusterIdentifier"];
+    contents.ClusterIdentifier = __expectString(output["ClusterIdentifier"]);
   }
   if (output["SnapshotIdentifier"] !== undefined) {
-    contents.SnapshotIdentifier = output["SnapshotIdentifier"];
+    contents.SnapshotIdentifier = __expectString(output["SnapshotIdentifier"]);
   }
   if (output["SourceDatabaseName"] !== undefined) {
-    contents.SourceDatabaseName = output["SourceDatabaseName"];
+    contents.SourceDatabaseName = __expectString(output["SourceDatabaseName"]);
   }
   if (output["SourceSchemaName"] !== undefined) {
-    contents.SourceSchemaName = output["SourceSchemaName"];
+    contents.SourceSchemaName = __expectString(output["SourceSchemaName"]);
   }
   if (output["SourceTableName"] !== undefined) {
-    contents.SourceTableName = output["SourceTableName"];
+    contents.SourceTableName = __expectString(output["SourceTableName"]);
   }
   if (output["TargetDatabaseName"] !== undefined) {
-    contents.TargetDatabaseName = output["TargetDatabaseName"];
+    contents.TargetDatabaseName = __expectString(output["TargetDatabaseName"]);
   }
   if (output["TargetSchemaName"] !== undefined) {
-    contents.TargetSchemaName = output["TargetSchemaName"];
+    contents.TargetSchemaName = __expectString(output["TargetSchemaName"]);
   }
   if (output["NewTableName"] !== undefined) {
-    contents.NewTableName = output["NewTableName"];
+    contents.NewTableName = __expectString(output["NewTableName"]);
   }
   return contents;
 };
@@ -20304,7 +20305,7 @@ const deserializeAws_queryTableRestoreStatusMessage = (
     );
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -20315,10 +20316,10 @@ const deserializeAws_queryTag = (output: any, context: __SerdeContext): Tag => {
     Value: undefined,
   };
   if (output["Key"] !== undefined) {
-    contents.Key = output["Key"];
+    contents.Key = __expectString(output["Key"]);
   }
   if (output["Value"] !== undefined) {
-    contents.Value = output["Value"];
+    contents.Value = __expectString(output["Value"]);
   }
   return contents;
 };
@@ -20333,10 +20334,10 @@ const deserializeAws_queryTaggedResource = (output: any, context: __SerdeContext
     contents.Tag = deserializeAws_queryTag(output["Tag"], context);
   }
   if (output["ResourceName"] !== undefined) {
-    contents.ResourceName = output["ResourceName"];
+    contents.ResourceName = __expectString(output["ResourceName"]);
   }
   if (output["ResourceType"] !== undefined) {
-    contents.ResourceType = output["ResourceType"];
+    contents.ResourceType = __expectString(output["ResourceType"]);
   }
   return contents;
 };
@@ -20370,7 +20371,7 @@ const deserializeAws_queryTaggedResourceListMessage = (
     );
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -20380,7 +20381,7 @@ const deserializeAws_queryTagLimitExceededFault = (output: any, context: __Serde
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -20422,7 +20423,7 @@ const deserializeAws_queryTrackListMessage = (output: any, context: __SerdeConte
     );
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -20432,7 +20433,7 @@ const deserializeAws_queryUnauthorizedOperation = (output: any, context: __Serde
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -20445,7 +20446,7 @@ const deserializeAws_queryUnauthorizedPartnerIntegrationFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -20458,7 +20459,7 @@ const deserializeAws_queryUnknownSnapshotCopyRegionFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -20471,7 +20472,7 @@ const deserializeAws_queryUnsupportedOperationFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -20481,7 +20482,7 @@ const deserializeAws_queryUnsupportedOptionFault = (output: any, context: __Serd
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -20493,10 +20494,10 @@ const deserializeAws_queryUpdateTarget = (output: any, context: __SerdeContext):
     SupportedOperations: undefined,
   };
   if (output["MaintenanceTrackName"] !== undefined) {
-    contents.MaintenanceTrackName = output["MaintenanceTrackName"];
+    contents.MaintenanceTrackName = __expectString(output["MaintenanceTrackName"]);
   }
   if (output["DatabaseVersion"] !== undefined) {
-    contents.DatabaseVersion = output["DatabaseVersion"];
+    contents.DatabaseVersion = __expectString(output["DatabaseVersion"]);
   }
   if (output.SupportedOperations === "") {
     contents.SupportedOperations = [];
@@ -20525,25 +20526,25 @@ const deserializeAws_queryUsageLimit = (output: any, context: __SerdeContext): U
     Tags: undefined,
   };
   if (output["UsageLimitId"] !== undefined) {
-    contents.UsageLimitId = output["UsageLimitId"];
+    contents.UsageLimitId = __expectString(output["UsageLimitId"]);
   }
   if (output["ClusterIdentifier"] !== undefined) {
-    contents.ClusterIdentifier = output["ClusterIdentifier"];
+    contents.ClusterIdentifier = __expectString(output["ClusterIdentifier"]);
   }
   if (output["FeatureType"] !== undefined) {
-    contents.FeatureType = output["FeatureType"];
+    contents.FeatureType = __expectString(output["FeatureType"]);
   }
   if (output["LimitType"] !== undefined) {
-    contents.LimitType = output["LimitType"];
+    contents.LimitType = __expectString(output["LimitType"]);
   }
   if (output["Amount"] !== undefined) {
     contents.Amount = parseInt(output["Amount"]);
   }
   if (output["Period"] !== undefined) {
-    contents.Period = output["Period"];
+    contents.Period = __expectString(output["Period"]);
   }
   if (output["BreachAction"] !== undefined) {
-    contents.BreachAction = output["BreachAction"];
+    contents.BreachAction = __expectString(output["BreachAction"]);
   }
   if (output.Tags === "") {
     contents.Tags = [];
@@ -20562,7 +20563,7 @@ const deserializeAws_queryUsageLimitAlreadyExistsFault = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -20582,7 +20583,7 @@ const deserializeAws_queryUsageLimitList = (output: any, context: __SerdeContext
     );
   }
   if (output["Marker"] !== undefined) {
-    contents.Marker = output["Marker"];
+    contents.Marker = __expectString(output["Marker"]);
   }
   return contents;
 };
@@ -20592,7 +20593,7 @@ const deserializeAws_queryUsageLimitNotFoundFault = (output: any, context: __Ser
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -20615,10 +20616,10 @@ const deserializeAws_queryVpcEndpoint = (output: any, context: __SerdeContext): 
     NetworkInterfaces: undefined,
   };
   if (output["VpcEndpointId"] !== undefined) {
-    contents.VpcEndpointId = output["VpcEndpointId"];
+    contents.VpcEndpointId = __expectString(output["VpcEndpointId"]);
   }
   if (output["VpcId"] !== undefined) {
-    contents.VpcId = output["VpcId"];
+    contents.VpcId = __expectString(output["VpcId"]);
   }
   if (output.NetworkInterfaces === "") {
     contents.NetworkInterfaces = [];
@@ -20650,7 +20651,7 @@ const deserializeAws_queryVpcIdentifierList = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -20663,10 +20664,10 @@ const deserializeAws_queryVpcSecurityGroupMembership = (
     Status: undefined,
   };
   if (output["VpcSecurityGroupId"] !== undefined) {
-    contents.VpcSecurityGroupId = output["VpcSecurityGroupId"];
+    contents.VpcSecurityGroupId = __expectString(output["VpcSecurityGroupId"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   return contents;
 };

--- a/clients/client-rekognition/protocols/Aws_json1_1.ts
+++ b/clients/client-rekognition/protocols/Aws_json1_1.ts
@@ -328,7 +328,13 @@ import {
   VideoTooLargeException,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { LazyJsonString as __LazyJsonString, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  LazyJsonString as __LazyJsonString,
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -7635,16 +7641,16 @@ const serializeAws_json1_1Video = (input: Video, context: __SerdeContext): any =
 
 const deserializeAws_json1_1AccessDeniedException = (output: any, context: __SerdeContext): AccessDeniedException => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Logref: output.Logref !== undefined && output.Logref !== null ? output.Logref : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Logref: __expectString(output.Logref),
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1AgeRange = (output: any, context: __SerdeContext): AgeRange => {
   return {
-    High: output.High !== undefined && output.High !== null ? output.High : undefined,
-    Low: output.Low !== undefined && output.Low !== null ? output.Low : undefined,
+    High: __expectNumber(output.High),
+    Low: __expectNumber(output.Low),
   } as any;
 };
 
@@ -7670,12 +7676,10 @@ const deserializeAws_json1_1Assets = (output: any, context: __SerdeContext): Ass
 
 const deserializeAws_json1_1AudioMetadata = (output: any, context: __SerdeContext): AudioMetadata => {
   return {
-    Codec: output.Codec !== undefined && output.Codec !== null ? output.Codec : undefined,
-    DurationMillis:
-      output.DurationMillis !== undefined && output.DurationMillis !== null ? output.DurationMillis : undefined,
-    NumberOfChannels:
-      output.NumberOfChannels !== undefined && output.NumberOfChannels !== null ? output.NumberOfChannels : undefined,
-    SampleRate: output.SampleRate !== undefined && output.SampleRate !== null ? output.SampleRate : undefined,
+    Codec: __expectString(output.Codec),
+    DurationMillis: __expectNumber(output.DurationMillis),
+    NumberOfChannels: __expectNumber(output.NumberOfChannels),
+    SampleRate: __expectNumber(output.SampleRate),
   } as any;
 };
 
@@ -7692,8 +7696,8 @@ const deserializeAws_json1_1AudioMetadataList = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1Beard = (output: any, context: __SerdeContext): Beard => {
   return {
-    Confidence: output.Confidence !== undefined && output.Confidence !== null ? output.Confidence : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Confidence: __expectNumber(output.Confidence),
+    Value: __expectBoolean(output.Value),
   } as any;
 };
 
@@ -7710,10 +7714,10 @@ const deserializeAws_json1_1BodyParts = (output: any, context: __SerdeContext): 
 
 const deserializeAws_json1_1BoundingBox = (output: any, context: __SerdeContext): BoundingBox => {
   return {
-    Height: output.Height !== undefined && output.Height !== null ? output.Height : undefined,
-    Left: output.Left !== undefined && output.Left !== null ? output.Left : undefined,
-    Top: output.Top !== undefined && output.Top !== null ? output.Top : undefined,
-    Width: output.Width !== undefined && output.Width !== null ? output.Width : undefined,
+    Height: __expectNumber(output.Height),
+    Left: __expectNumber(output.Left),
+    Top: __expectNumber(output.Top),
+    Width: __expectNumber(output.Width),
   } as any;
 };
 
@@ -7723,10 +7727,9 @@ const deserializeAws_json1_1Celebrity = (output: any, context: __SerdeContext): 
       output.Face !== undefined && output.Face !== null
         ? deserializeAws_json1_1ComparedFace(output.Face, context)
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    MatchConfidence:
-      output.MatchConfidence !== undefined && output.MatchConfidence !== null ? output.MatchConfidence : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Id: __expectString(output.Id),
+    MatchConfidence: __expectNumber(output.MatchConfidence),
+    Name: __expectString(output.Name),
     Urls:
       output.Urls !== undefined && output.Urls !== null ? deserializeAws_json1_1Urls(output.Urls, context) : undefined,
   } as any;
@@ -7738,13 +7741,13 @@ const deserializeAws_json1_1CelebrityDetail = (output: any, context: __SerdeCont
       output.BoundingBox !== undefined && output.BoundingBox !== null
         ? deserializeAws_json1_1BoundingBox(output.BoundingBox, context)
         : undefined,
-    Confidence: output.Confidence !== undefined && output.Confidence !== null ? output.Confidence : undefined,
+    Confidence: __expectNumber(output.Confidence),
     Face:
       output.Face !== undefined && output.Face !== null
         ? deserializeAws_json1_1FaceDetail(output.Face, context)
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
     Urls:
       output.Urls !== undefined && output.Urls !== null ? deserializeAws_json1_1Urls(output.Urls, context) : undefined,
   } as any;
@@ -7767,7 +7770,7 @@ const deserializeAws_json1_1CelebrityRecognition = (output: any, context: __Serd
       output.Celebrity !== undefined && output.Celebrity !== null
         ? deserializeAws_json1_1CelebrityDetail(output.Celebrity, context)
         : undefined,
-    Timestamp: output.Timestamp !== undefined && output.Timestamp !== null ? output.Timestamp : undefined,
+    Timestamp: __expectNumber(output.Timestamp),
   } as any;
 };
 
@@ -7789,7 +7792,7 @@ const deserializeAws_json1_1CollectionIdList = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7799,7 +7802,7 @@ const deserializeAws_json1_1ComparedFace = (output: any, context: __SerdeContext
       output.BoundingBox !== undefined && output.BoundingBox !== null
         ? deserializeAws_json1_1BoundingBox(output.BoundingBox, context)
         : undefined,
-    Confidence: output.Confidence !== undefined && output.Confidence !== null ? output.Confidence : undefined,
+    Confidence: __expectNumber(output.Confidence),
     Landmarks:
       output.Landmarks !== undefined && output.Landmarks !== null
         ? deserializeAws_json1_1Landmarks(output.Landmarks, context)
@@ -7833,7 +7836,7 @@ const deserializeAws_json1_1ComparedSourceImageFace = (
       output.BoundingBox !== undefined && output.BoundingBox !== null
         ? deserializeAws_json1_1BoundingBox(output.BoundingBox, context)
         : undefined,
-    Confidence: output.Confidence !== undefined && output.Confidence !== null ? output.Confidence : undefined,
+    Confidence: __expectNumber(output.Confidence),
   } as any;
 };
 
@@ -7843,7 +7846,7 @@ const deserializeAws_json1_1CompareFacesMatch = (output: any, context: __SerdeCo
       output.Face !== undefined && output.Face !== null
         ? deserializeAws_json1_1ComparedFace(output.Face, context)
         : undefined,
-    Similarity: output.Similarity !== undefined && output.Similarity !== null ? output.Similarity : undefined,
+    Similarity: __expectNumber(output.Similarity),
   } as any;
 };
 
@@ -7868,14 +7871,8 @@ const deserializeAws_json1_1CompareFacesResponse = (output: any, context: __Serd
       output.SourceImageFace !== undefined && output.SourceImageFace !== null
         ? deserializeAws_json1_1ComparedSourceImageFace(output.SourceImageFace, context)
         : undefined,
-    SourceImageOrientationCorrection:
-      output.SourceImageOrientationCorrection !== undefined && output.SourceImageOrientationCorrection !== null
-        ? output.SourceImageOrientationCorrection
-        : undefined,
-    TargetImageOrientationCorrection:
-      output.TargetImageOrientationCorrection !== undefined && output.TargetImageOrientationCorrection !== null
-        ? output.TargetImageOrientationCorrection
-        : undefined,
+    SourceImageOrientationCorrection: __expectString(output.SourceImageOrientationCorrection),
+    TargetImageOrientationCorrection: __expectString(output.TargetImageOrientationCorrection),
     UnmatchedFaces:
       output.UnmatchedFaces !== undefined && output.UnmatchedFaces !== null
         ? deserializeAws_json1_1CompareFacesUnmatchList(output.UnmatchedFaces, context)
@@ -7903,7 +7900,7 @@ const deserializeAws_json1_1ContentModerationDetection = (
       output.ModerationLabel !== undefined && output.ModerationLabel !== null
         ? deserializeAws_json1_1ModerationLabel(output.ModerationLabel, context)
         : undefined,
-    Timestamp: output.Timestamp !== undefined && output.Timestamp !== null ? output.Timestamp : undefined,
+    Timestamp: __expectNumber(output.Timestamp),
   } as any;
 };
 
@@ -7923,8 +7920,8 @@ const deserializeAws_json1_1ContentModerationDetections = (
 
 const deserializeAws_json1_1CoversBodyPart = (output: any, context: __SerdeContext): CoversBodyPart => {
   return {
-    Confidence: output.Confidence !== undefined && output.Confidence !== null ? output.Confidence : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Confidence: __expectNumber(output.Confidence),
+    Value: __expectBoolean(output.Value),
   } as any;
 };
 
@@ -7933,17 +7930,15 @@ const deserializeAws_json1_1CreateCollectionResponse = (
   context: __SerdeContext
 ): CreateCollectionResponse => {
   return {
-    CollectionArn:
-      output.CollectionArn !== undefined && output.CollectionArn !== null ? output.CollectionArn : undefined,
-    FaceModelVersion:
-      output.FaceModelVersion !== undefined && output.FaceModelVersion !== null ? output.FaceModelVersion : undefined,
-    StatusCode: output.StatusCode !== undefined && output.StatusCode !== null ? output.StatusCode : undefined,
+    CollectionArn: __expectString(output.CollectionArn),
+    FaceModelVersion: __expectString(output.FaceModelVersion),
+    StatusCode: __expectNumber(output.StatusCode),
   } as any;
 };
 
 const deserializeAws_json1_1CreateProjectResponse = (output: any, context: __SerdeContext): CreateProjectResponse => {
   return {
-    ProjectArn: output.ProjectArn !== undefined && output.ProjectArn !== null ? output.ProjectArn : undefined,
+    ProjectArn: __expectString(output.ProjectArn),
   } as any;
 };
 
@@ -7952,10 +7947,7 @@ const deserializeAws_json1_1CreateProjectVersionResponse = (
   context: __SerdeContext
 ): CreateProjectVersionResponse => {
   return {
-    ProjectVersionArn:
-      output.ProjectVersionArn !== undefined && output.ProjectVersionArn !== null
-        ? output.ProjectVersionArn
-        : undefined,
+    ProjectVersionArn: __expectString(output.ProjectVersionArn),
   } as any;
 };
 
@@ -7964,21 +7956,18 @@ const deserializeAws_json1_1CreateStreamProcessorResponse = (
   context: __SerdeContext
 ): CreateStreamProcessorResponse => {
   return {
-    StreamProcessorArn:
-      output.StreamProcessorArn !== undefined && output.StreamProcessorArn !== null
-        ? output.StreamProcessorArn
-        : undefined,
+    StreamProcessorArn: __expectString(output.StreamProcessorArn),
   } as any;
 };
 
 const deserializeAws_json1_1CustomLabel = (output: any, context: __SerdeContext): CustomLabel => {
   return {
-    Confidence: output.Confidence !== undefined && output.Confidence !== null ? output.Confidence : undefined,
+    Confidence: __expectNumber(output.Confidence),
     Geometry:
       output.Geometry !== undefined && output.Geometry !== null
         ? deserializeAws_json1_1Geometry(output.Geometry, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -7998,7 +7987,7 @@ const deserializeAws_json1_1DeleteCollectionResponse = (
   context: __SerdeContext
 ): DeleteCollectionResponse => {
   return {
-    StatusCode: output.StatusCode !== undefined && output.StatusCode !== null ? output.StatusCode : undefined,
+    StatusCode: __expectNumber(output.StatusCode),
   } as any;
 };
 
@@ -8013,7 +8002,7 @@ const deserializeAws_json1_1DeleteFacesResponse = (output: any, context: __Serde
 
 const deserializeAws_json1_1DeleteProjectResponse = (output: any, context: __SerdeContext): DeleteProjectResponse => {
   return {
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -8022,7 +8011,7 @@ const deserializeAws_json1_1DeleteProjectVersionResponse = (
   context: __SerdeContext
 ): DeleteProjectVersionResponse => {
   return {
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -8038,15 +8027,13 @@ const deserializeAws_json1_1DescribeCollectionResponse = (
   context: __SerdeContext
 ): DescribeCollectionResponse => {
   return {
-    CollectionARN:
-      output.CollectionARN !== undefined && output.CollectionARN !== null ? output.CollectionARN : undefined,
+    CollectionARN: __expectString(output.CollectionARN),
     CreationTimestamp:
       output.CreationTimestamp !== undefined && output.CreationTimestamp !== null
         ? new Date(Math.round(output.CreationTimestamp * 1000))
         : undefined,
-    FaceCount: output.FaceCount !== undefined && output.FaceCount !== null ? output.FaceCount : undefined,
-    FaceModelVersion:
-      output.FaceModelVersion !== undefined && output.FaceModelVersion !== null ? output.FaceModelVersion : undefined,
+    FaceCount: __expectNumber(output.FaceCount),
+    FaceModelVersion: __expectString(output.FaceModelVersion),
   } as any;
 };
 
@@ -8055,7 +8042,7 @@ const deserializeAws_json1_1DescribeProjectsResponse = (
   context: __SerdeContext
 ): DescribeProjectsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     ProjectDescriptions:
       output.ProjectDescriptions !== undefined && output.ProjectDescriptions !== null
         ? deserializeAws_json1_1ProjectDescriptions(output.ProjectDescriptions, context)
@@ -8068,7 +8055,7 @@ const deserializeAws_json1_1DescribeProjectVersionsResponse = (
   context: __SerdeContext
 ): DescribeProjectVersionsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     ProjectVersionDescriptions:
       output.ProjectVersionDescriptions !== undefined && output.ProjectVersionDescriptions !== null
         ? deserializeAws_json1_1ProjectVersionDescriptions(output.ProjectVersionDescriptions, context)
@@ -8093,23 +8080,19 @@ const deserializeAws_json1_1DescribeStreamProcessorResponse = (
       output.LastUpdateTimestamp !== undefined && output.LastUpdateTimestamp !== null
         ? new Date(Math.round(output.LastUpdateTimestamp * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     Output:
       output.Output !== undefined && output.Output !== null
         ? deserializeAws_json1_1StreamProcessorOutput(output.Output, context)
         : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
+    RoleArn: __expectString(output.RoleArn),
     Settings:
       output.Settings !== undefined && output.Settings !== null
         ? deserializeAws_json1_1StreamProcessorSettings(output.Settings, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusMessage:
-      output.StatusMessage !== undefined && output.StatusMessage !== null ? output.StatusMessage : undefined,
-    StreamProcessorArn:
-      output.StreamProcessorArn !== undefined && output.StreamProcessorArn !== null
-        ? output.StreamProcessorArn
-        : undefined,
+    Status: __expectString(output.Status),
+    StatusMessage: __expectString(output.StatusMessage),
+    StreamProcessorArn: __expectString(output.StreamProcessorArn),
   } as any;
 };
 
@@ -8131,27 +8114,18 @@ const deserializeAws_json1_1DetectFacesResponse = (output: any, context: __Serde
       output.FaceDetails !== undefined && output.FaceDetails !== null
         ? deserializeAws_json1_1FaceDetailList(output.FaceDetails, context)
         : undefined,
-    OrientationCorrection:
-      output.OrientationCorrection !== undefined && output.OrientationCorrection !== null
-        ? output.OrientationCorrection
-        : undefined,
+    OrientationCorrection: __expectString(output.OrientationCorrection),
   } as any;
 };
 
 const deserializeAws_json1_1DetectLabelsResponse = (output: any, context: __SerdeContext): DetectLabelsResponse => {
   return {
-    LabelModelVersion:
-      output.LabelModelVersion !== undefined && output.LabelModelVersion !== null
-        ? output.LabelModelVersion
-        : undefined,
+    LabelModelVersion: __expectString(output.LabelModelVersion),
     Labels:
       output.Labels !== undefined && output.Labels !== null
         ? deserializeAws_json1_1Labels(output.Labels, context)
         : undefined,
-    OrientationCorrection:
-      output.OrientationCorrection !== undefined && output.OrientationCorrection !== null
-        ? output.OrientationCorrection
-        : undefined,
+    OrientationCorrection: __expectString(output.OrientationCorrection),
   } as any;
 };
 
@@ -8168,10 +8142,7 @@ const deserializeAws_json1_1DetectModerationLabelsResponse = (
       output.ModerationLabels !== undefined && output.ModerationLabels !== null
         ? deserializeAws_json1_1ModerationLabels(output.ModerationLabels, context)
         : undefined,
-    ModerationModelVersion:
-      output.ModerationModelVersion !== undefined && output.ModerationModelVersion !== null
-        ? output.ModerationModelVersion
-        : undefined,
+    ModerationModelVersion: __expectString(output.ModerationModelVersion),
   } as any;
 };
 
@@ -8184,10 +8155,7 @@ const deserializeAws_json1_1DetectProtectiveEquipmentResponse = (
       output.Persons !== undefined && output.Persons !== null
         ? deserializeAws_json1_1ProtectiveEquipmentPersons(output.Persons, context)
         : undefined,
-    ProtectiveEquipmentModelVersion:
-      output.ProtectiveEquipmentModelVersion !== undefined && output.ProtectiveEquipmentModelVersion !== null
-        ? output.ProtectiveEquipmentModelVersion
-        : undefined,
+    ProtectiveEquipmentModelVersion: __expectString(output.ProtectiveEquipmentModelVersion),
     Summary:
       output.Summary !== undefined && output.Summary !== null
         ? deserializeAws_json1_1ProtectiveEquipmentSummary(output.Summary, context)
@@ -8201,15 +8169,14 @@ const deserializeAws_json1_1DetectTextResponse = (output: any, context: __SerdeC
       output.TextDetections !== undefined && output.TextDetections !== null
         ? deserializeAws_json1_1TextDetectionList(output.TextDetections, context)
         : undefined,
-    TextModelVersion:
-      output.TextModelVersion !== undefined && output.TextModelVersion !== null ? output.TextModelVersion : undefined,
+    TextModelVersion: __expectString(output.TextModelVersion),
   } as any;
 };
 
 const deserializeAws_json1_1Emotion = (output: any, context: __SerdeContext): Emotion => {
   return {
-    Confidence: output.Confidence !== undefined && output.Confidence !== null ? output.Confidence : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Confidence: __expectNumber(output.Confidence),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -8230,12 +8197,12 @@ const deserializeAws_json1_1EquipmentDetection = (output: any, context: __SerdeC
       output.BoundingBox !== undefined && output.BoundingBox !== null
         ? deserializeAws_json1_1BoundingBox(output.BoundingBox, context)
         : undefined,
-    Confidence: output.Confidence !== undefined && output.Confidence !== null ? output.Confidence : undefined,
+    Confidence: __expectNumber(output.Confidence),
     CoversBodyPart:
       output.CoversBodyPart !== undefined && output.CoversBodyPart !== null
         ? deserializeAws_json1_1CoversBodyPart(output.CoversBodyPart, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -8252,7 +8219,7 @@ const deserializeAws_json1_1EquipmentDetections = (output: any, context: __Serde
 
 const deserializeAws_json1_1EvaluationResult = (output: any, context: __SerdeContext): EvaluationResult => {
   return {
-    F1Score: output.F1Score !== undefined && output.F1Score !== null ? output.F1Score : undefined,
+    F1Score: __expectNumber(output.F1Score),
     Summary:
       output.Summary !== undefined && output.Summary !== null
         ? deserializeAws_json1_1Summary(output.Summary, context)
@@ -8262,15 +8229,15 @@ const deserializeAws_json1_1EvaluationResult = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1Eyeglasses = (output: any, context: __SerdeContext): Eyeglasses => {
   return {
-    Confidence: output.Confidence !== undefined && output.Confidence !== null ? output.Confidence : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Confidence: __expectNumber(output.Confidence),
+    Value: __expectBoolean(output.Value),
   } as any;
 };
 
 const deserializeAws_json1_1EyeOpen = (output: any, context: __SerdeContext): EyeOpen => {
   return {
-    Confidence: output.Confidence !== undefined && output.Confidence !== null ? output.Confidence : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Confidence: __expectNumber(output.Confidence),
+    Value: __expectBoolean(output.Value),
   } as any;
 };
 
@@ -8280,11 +8247,10 @@ const deserializeAws_json1_1Face = (output: any, context: __SerdeContext): Face 
       output.BoundingBox !== undefined && output.BoundingBox !== null
         ? deserializeAws_json1_1BoundingBox(output.BoundingBox, context)
         : undefined,
-    Confidence: output.Confidence !== undefined && output.Confidence !== null ? output.Confidence : undefined,
-    ExternalImageId:
-      output.ExternalImageId !== undefined && output.ExternalImageId !== null ? output.ExternalImageId : undefined,
-    FaceId: output.FaceId !== undefined && output.FaceId !== null ? output.FaceId : undefined,
-    ImageId: output.ImageId !== undefined && output.ImageId !== null ? output.ImageId : undefined,
+    Confidence: __expectNumber(output.Confidence),
+    ExternalImageId: __expectString(output.ExternalImageId),
+    FaceId: __expectString(output.FaceId),
+    ImageId: __expectString(output.ImageId),
   } as any;
 };
 
@@ -8302,7 +8268,7 @@ const deserializeAws_json1_1FaceDetail = (output: any, context: __SerdeContext):
       output.BoundingBox !== undefined && output.BoundingBox !== null
         ? deserializeAws_json1_1BoundingBox(output.BoundingBox, context)
         : undefined,
-    Confidence: output.Confidence !== undefined && output.Confidence !== null ? output.Confidence : undefined,
+    Confidence: __expectNumber(output.Confidence),
     Emotions:
       output.Emotions !== undefined && output.Emotions !== null
         ? deserializeAws_json1_1Emotions(output.Emotions, context)
@@ -8365,7 +8331,7 @@ const deserializeAws_json1_1FaceDetection = (output: any, context: __SerdeContex
       output.Face !== undefined && output.Face !== null
         ? deserializeAws_json1_1FaceDetail(output.Face, context)
         : undefined,
-    Timestamp: output.Timestamp !== undefined && output.Timestamp !== null ? output.Timestamp : undefined,
+    Timestamp: __expectNumber(output.Timestamp),
   } as any;
 };
 
@@ -8387,7 +8353,7 @@ const deserializeAws_json1_1FaceIdList = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -8406,7 +8372,7 @@ const deserializeAws_json1_1FaceMatch = (output: any, context: __SerdeContext): 
   return {
     Face:
       output.Face !== undefined && output.Face !== null ? deserializeAws_json1_1Face(output.Face, context) : undefined,
-    Similarity: output.Similarity !== undefined && output.Similarity !== null ? output.Similarity : undefined,
+    Similarity: __expectNumber(output.Similarity),
   } as any;
 };
 
@@ -8428,7 +8394,7 @@ const deserializeAws_json1_1FaceModelVersionList = (output: any, context: __Serd
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -8456,18 +8422,15 @@ const deserializeAws_json1_1FaceRecordList = (output: any, context: __SerdeConte
 
 const deserializeAws_json1_1FaceSearchSettings = (output: any, context: __SerdeContext): FaceSearchSettings => {
   return {
-    CollectionId: output.CollectionId !== undefined && output.CollectionId !== null ? output.CollectionId : undefined,
-    FaceMatchThreshold:
-      output.FaceMatchThreshold !== undefined && output.FaceMatchThreshold !== null
-        ? output.FaceMatchThreshold
-        : undefined,
+    CollectionId: __expectString(output.CollectionId),
+    FaceMatchThreshold: __expectNumber(output.FaceMatchThreshold),
   } as any;
 };
 
 const deserializeAws_json1_1Gender = (output: any, context: __SerdeContext): Gender => {
   return {
-    Confidence: output.Confidence !== undefined && output.Confidence !== null ? output.Confidence : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Confidence: __expectNumber(output.Confidence),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -8489,7 +8452,7 @@ const deserializeAws_json1_1GetCelebrityInfoResponse = (
   context: __SerdeContext
 ): GetCelebrityInfoResponse => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     Urls:
       output.Urls !== undefined && output.Urls !== null ? deserializeAws_json1_1Urls(output.Urls, context) : undefined,
   } as any;
@@ -8504,10 +8467,9 @@ const deserializeAws_json1_1GetCelebrityRecognitionResponse = (
       output.Celebrities !== undefined && output.Celebrities !== null
         ? deserializeAws_json1_1CelebrityRecognitions(output.Celebrities, context)
         : undefined,
-    JobStatus: output.JobStatus !== undefined && output.JobStatus !== null ? output.JobStatus : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
-    StatusMessage:
-      output.StatusMessage !== undefined && output.StatusMessage !== null ? output.StatusMessage : undefined,
+    JobStatus: __expectString(output.JobStatus),
+    NextToken: __expectString(output.NextToken),
+    StatusMessage: __expectString(output.StatusMessage),
     VideoMetadata:
       output.VideoMetadata !== undefined && output.VideoMetadata !== null
         ? deserializeAws_json1_1VideoMetadata(output.VideoMetadata, context)
@@ -8520,18 +8482,14 @@ const deserializeAws_json1_1GetContentModerationResponse = (
   context: __SerdeContext
 ): GetContentModerationResponse => {
   return {
-    JobStatus: output.JobStatus !== undefined && output.JobStatus !== null ? output.JobStatus : undefined,
+    JobStatus: __expectString(output.JobStatus),
     ModerationLabels:
       output.ModerationLabels !== undefined && output.ModerationLabels !== null
         ? deserializeAws_json1_1ContentModerationDetections(output.ModerationLabels, context)
         : undefined,
-    ModerationModelVersion:
-      output.ModerationModelVersion !== undefined && output.ModerationModelVersion !== null
-        ? output.ModerationModelVersion
-        : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
-    StatusMessage:
-      output.StatusMessage !== undefined && output.StatusMessage !== null ? output.StatusMessage : undefined,
+    ModerationModelVersion: __expectString(output.ModerationModelVersion),
+    NextToken: __expectString(output.NextToken),
+    StatusMessage: __expectString(output.StatusMessage),
     VideoMetadata:
       output.VideoMetadata !== undefined && output.VideoMetadata !== null
         ? deserializeAws_json1_1VideoMetadata(output.VideoMetadata, context)
@@ -8548,10 +8506,9 @@ const deserializeAws_json1_1GetFaceDetectionResponse = (
       output.Faces !== undefined && output.Faces !== null
         ? deserializeAws_json1_1FaceDetections(output.Faces, context)
         : undefined,
-    JobStatus: output.JobStatus !== undefined && output.JobStatus !== null ? output.JobStatus : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
-    StatusMessage:
-      output.StatusMessage !== undefined && output.StatusMessage !== null ? output.StatusMessage : undefined,
+    JobStatus: __expectString(output.JobStatus),
+    NextToken: __expectString(output.NextToken),
+    StatusMessage: __expectString(output.StatusMessage),
     VideoMetadata:
       output.VideoMetadata !== undefined && output.VideoMetadata !== null
         ? deserializeAws_json1_1VideoMetadata(output.VideoMetadata, context)
@@ -8561,14 +8518,13 @@ const deserializeAws_json1_1GetFaceDetectionResponse = (
 
 const deserializeAws_json1_1GetFaceSearchResponse = (output: any, context: __SerdeContext): GetFaceSearchResponse => {
   return {
-    JobStatus: output.JobStatus !== undefined && output.JobStatus !== null ? output.JobStatus : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    JobStatus: __expectString(output.JobStatus),
+    NextToken: __expectString(output.NextToken),
     Persons:
       output.Persons !== undefined && output.Persons !== null
         ? deserializeAws_json1_1PersonMatches(output.Persons, context)
         : undefined,
-    StatusMessage:
-      output.StatusMessage !== undefined && output.StatusMessage !== null ? output.StatusMessage : undefined,
+    StatusMessage: __expectString(output.StatusMessage),
     VideoMetadata:
       output.VideoMetadata !== undefined && output.VideoMetadata !== null
         ? deserializeAws_json1_1VideoMetadata(output.VideoMetadata, context)
@@ -8581,18 +8537,14 @@ const deserializeAws_json1_1GetLabelDetectionResponse = (
   context: __SerdeContext
 ): GetLabelDetectionResponse => {
   return {
-    JobStatus: output.JobStatus !== undefined && output.JobStatus !== null ? output.JobStatus : undefined,
-    LabelModelVersion:
-      output.LabelModelVersion !== undefined && output.LabelModelVersion !== null
-        ? output.LabelModelVersion
-        : undefined,
+    JobStatus: __expectString(output.JobStatus),
+    LabelModelVersion: __expectString(output.LabelModelVersion),
     Labels:
       output.Labels !== undefined && output.Labels !== null
         ? deserializeAws_json1_1LabelDetections(output.Labels, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
-    StatusMessage:
-      output.StatusMessage !== undefined && output.StatusMessage !== null ? output.StatusMessage : undefined,
+    NextToken: __expectString(output.NextToken),
+    StatusMessage: __expectString(output.StatusMessage),
     VideoMetadata:
       output.VideoMetadata !== undefined && output.VideoMetadata !== null
         ? deserializeAws_json1_1VideoMetadata(output.VideoMetadata, context)
@@ -8605,14 +8557,13 @@ const deserializeAws_json1_1GetPersonTrackingResponse = (
   context: __SerdeContext
 ): GetPersonTrackingResponse => {
   return {
-    JobStatus: output.JobStatus !== undefined && output.JobStatus !== null ? output.JobStatus : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    JobStatus: __expectString(output.JobStatus),
+    NextToken: __expectString(output.NextToken),
     Persons:
       output.Persons !== undefined && output.Persons !== null
         ? deserializeAws_json1_1PersonDetections(output.Persons, context)
         : undefined,
-    StatusMessage:
-      output.StatusMessage !== undefined && output.StatusMessage !== null ? output.StatusMessage : undefined,
+    StatusMessage: __expectString(output.StatusMessage),
     VideoMetadata:
       output.VideoMetadata !== undefined && output.VideoMetadata !== null
         ? deserializeAws_json1_1VideoMetadata(output.VideoMetadata, context)
@@ -8629,8 +8580,8 @@ const deserializeAws_json1_1GetSegmentDetectionResponse = (
       output.AudioMetadata !== undefined && output.AudioMetadata !== null
         ? deserializeAws_json1_1AudioMetadataList(output.AudioMetadata, context)
         : undefined,
-    JobStatus: output.JobStatus !== undefined && output.JobStatus !== null ? output.JobStatus : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    JobStatus: __expectString(output.JobStatus),
+    NextToken: __expectString(output.NextToken),
     Segments:
       output.Segments !== undefined && output.Segments !== null
         ? deserializeAws_json1_1SegmentDetections(output.Segments, context)
@@ -8639,8 +8590,7 @@ const deserializeAws_json1_1GetSegmentDetectionResponse = (
       output.SelectedSegmentTypes !== undefined && output.SelectedSegmentTypes !== null
         ? deserializeAws_json1_1SegmentTypesInfo(output.SelectedSegmentTypes, context)
         : undefined,
-    StatusMessage:
-      output.StatusMessage !== undefined && output.StatusMessage !== null ? output.StatusMessage : undefined,
+    StatusMessage: __expectString(output.StatusMessage),
     VideoMetadata:
       output.VideoMetadata !== undefined && output.VideoMetadata !== null
         ? deserializeAws_json1_1VideoMetadataList(output.VideoMetadata, context)
@@ -8653,16 +8603,14 @@ const deserializeAws_json1_1GetTextDetectionResponse = (
   context: __SerdeContext
 ): GetTextDetectionResponse => {
   return {
-    JobStatus: output.JobStatus !== undefined && output.JobStatus !== null ? output.JobStatus : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
-    StatusMessage:
-      output.StatusMessage !== undefined && output.StatusMessage !== null ? output.StatusMessage : undefined,
+    JobStatus: __expectString(output.JobStatus),
+    NextToken: __expectString(output.NextToken),
+    StatusMessage: __expectString(output.StatusMessage),
     TextDetections:
       output.TextDetections !== undefined && output.TextDetections !== null
         ? deserializeAws_json1_1TextDetectionResults(output.TextDetections, context)
         : undefined,
-    TextModelVersion:
-      output.TextModelVersion !== undefined && output.TextModelVersion !== null ? output.TextModelVersion : undefined,
+    TextModelVersion: __expectString(output.TextModelVersion),
     VideoMetadata:
       output.VideoMetadata !== undefined && output.VideoMetadata !== null
         ? deserializeAws_json1_1VideoMetadata(output.VideoMetadata, context)
@@ -8693,7 +8641,7 @@ const deserializeAws_json1_1HumanLoopActivationOutput = (
       output.HumanLoopActivationReasons !== undefined && output.HumanLoopActivationReasons !== null
         ? deserializeAws_json1_1HumanLoopActivationReasons(output.HumanLoopActivationReasons, context)
         : undefined,
-    HumanLoopArn: output.HumanLoopArn !== undefined && output.HumanLoopArn !== null ? output.HumanLoopArn : undefined,
+    HumanLoopArn: __expectString(output.HumanLoopArn),
   } as any;
 };
 
@@ -8704,7 +8652,7 @@ const deserializeAws_json1_1HumanLoopActivationReasons = (output: any, context: 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -8713,12 +8661,12 @@ const deserializeAws_json1_1HumanLoopQuotaExceededException = (
   context: __SerdeContext
 ): HumanLoopQuotaExceededException => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Logref: output.Logref !== undefined && output.Logref !== null ? output.Logref : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    QuotaCode: output.QuotaCode !== undefined && output.QuotaCode !== null ? output.QuotaCode : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
-    ServiceCode: output.ServiceCode !== undefined && output.ServiceCode !== null ? output.ServiceCode : undefined,
+    Code: __expectString(output.Code),
+    Logref: __expectString(output.Logref),
+    Message: __expectString(output.Message),
+    QuotaCode: __expectString(output.QuotaCode),
+    ResourceType: __expectString(output.ResourceType),
+    ServiceCode: __expectString(output.ServiceCode),
   } as any;
 };
 
@@ -8727,39 +8675,35 @@ const deserializeAws_json1_1IdempotentParameterMismatchException = (
   context: __SerdeContext
 ): IdempotentParameterMismatchException => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Logref: output.Logref !== undefined && output.Logref !== null ? output.Logref : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Logref: __expectString(output.Logref),
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1ImageQuality = (output: any, context: __SerdeContext): ImageQuality => {
   return {
-    Brightness: output.Brightness !== undefined && output.Brightness !== null ? output.Brightness : undefined,
-    Sharpness: output.Sharpness !== undefined && output.Sharpness !== null ? output.Sharpness : undefined,
+    Brightness: __expectNumber(output.Brightness),
+    Sharpness: __expectNumber(output.Sharpness),
   } as any;
 };
 
 const deserializeAws_json1_1ImageTooLargeException = (output: any, context: __SerdeContext): ImageTooLargeException => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Logref: output.Logref !== undefined && output.Logref !== null ? output.Logref : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Logref: __expectString(output.Logref),
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1IndexFacesResponse = (output: any, context: __SerdeContext): IndexFacesResponse => {
   return {
-    FaceModelVersion:
-      output.FaceModelVersion !== undefined && output.FaceModelVersion !== null ? output.FaceModelVersion : undefined,
+    FaceModelVersion: __expectString(output.FaceModelVersion),
     FaceRecords:
       output.FaceRecords !== undefined && output.FaceRecords !== null
         ? deserializeAws_json1_1FaceRecordList(output.FaceRecords, context)
         : undefined,
-    OrientationCorrection:
-      output.OrientationCorrection !== undefined && output.OrientationCorrection !== null
-        ? output.OrientationCorrection
-        : undefined,
+    OrientationCorrection: __expectString(output.OrientationCorrection),
     UnindexedFaces:
       output.UnindexedFaces !== undefined && output.UnindexedFaces !== null
         ? deserializeAws_json1_1UnindexedFaces(output.UnindexedFaces, context)
@@ -8773,7 +8717,7 @@ const deserializeAws_json1_1Instance = (output: any, context: __SerdeContext): I
       output.BoundingBox !== undefined && output.BoundingBox !== null
         ? deserializeAws_json1_1BoundingBox(output.BoundingBox, context)
         : undefined,
-    Confidence: output.Confidence !== undefined && output.Confidence !== null ? output.Confidence : undefined,
+    Confidence: __expectNumber(output.Confidence),
   } as any;
 };
 
@@ -8790,9 +8734,9 @@ const deserializeAws_json1_1Instances = (output: any, context: __SerdeContext): 
 
 const deserializeAws_json1_1InternalServerError = (output: any, context: __SerdeContext): InternalServerError => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Logref: output.Logref !== undefined && output.Logref !== null ? output.Logref : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Logref: __expectString(output.Logref),
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -8801,9 +8745,9 @@ const deserializeAws_json1_1InvalidImageFormatException = (
   context: __SerdeContext
 ): InvalidImageFormatException => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Logref: output.Logref !== undefined && output.Logref !== null ? output.Logref : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Logref: __expectString(output.Logref),
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -8812,9 +8756,9 @@ const deserializeAws_json1_1InvalidPaginationTokenException = (
   context: __SerdeContext
 ): InvalidPaginationTokenException => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Logref: output.Logref !== undefined && output.Logref !== null ? output.Logref : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Logref: __expectString(output.Logref),
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -8823,9 +8767,9 @@ const deserializeAws_json1_1InvalidParameterException = (
   context: __SerdeContext
 ): InvalidParameterException => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Logref: output.Logref !== undefined && output.Logref !== null ? output.Logref : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Logref: __expectString(output.Logref),
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -8834,32 +8778,32 @@ const deserializeAws_json1_1InvalidS3ObjectException = (
   context: __SerdeContext
 ): InvalidS3ObjectException => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Logref: output.Logref !== undefined && output.Logref !== null ? output.Logref : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Logref: __expectString(output.Logref),
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1KinesisDataStream = (output: any, context: __SerdeContext): KinesisDataStream => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
   } as any;
 };
 
 const deserializeAws_json1_1KinesisVideoStream = (output: any, context: __SerdeContext): KinesisVideoStream => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
   } as any;
 };
 
 const deserializeAws_json1_1Label = (output: any, context: __SerdeContext): Label => {
   return {
-    Confidence: output.Confidence !== undefined && output.Confidence !== null ? output.Confidence : undefined,
+    Confidence: __expectNumber(output.Confidence),
     Instances:
       output.Instances !== undefined && output.Instances !== null
         ? deserializeAws_json1_1Instances(output.Instances, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     Parents:
       output.Parents !== undefined && output.Parents !== null
         ? deserializeAws_json1_1Parents(output.Parents, context)
@@ -8873,7 +8817,7 @@ const deserializeAws_json1_1LabelDetection = (output: any, context: __SerdeConte
       output.Label !== undefined && output.Label !== null
         ? deserializeAws_json1_1Label(output.Label, context)
         : undefined,
-    Timestamp: output.Timestamp !== undefined && output.Timestamp !== null ? output.Timestamp : undefined,
+    Timestamp: __expectNumber(output.Timestamp),
   } as any;
 };
 
@@ -8901,9 +8845,9 @@ const deserializeAws_json1_1Labels = (output: any, context: __SerdeContext): Lab
 
 const deserializeAws_json1_1Landmark = (output: any, context: __SerdeContext): Landmark => {
   return {
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    X: output.X !== undefined && output.X !== null ? output.X : undefined,
-    Y: output.Y !== undefined && output.Y !== null ? output.Y : undefined,
+    Type: __expectString(output.Type),
+    X: __expectNumber(output.X),
+    Y: __expectNumber(output.Y),
   } as any;
 };
 
@@ -8920,9 +8864,9 @@ const deserializeAws_json1_1Landmarks = (output: any, context: __SerdeContext): 
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Logref: output.Logref !== undefined && output.Logref !== null ? output.Logref : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Logref: __expectString(output.Logref),
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -8939,19 +8883,18 @@ const deserializeAws_json1_1ListCollectionsResponse = (
       output.FaceModelVersions !== undefined && output.FaceModelVersions !== null
         ? deserializeAws_json1_1FaceModelVersionList(output.FaceModelVersions, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
 const deserializeAws_json1_1ListFacesResponse = (output: any, context: __SerdeContext): ListFacesResponse => {
   return {
-    FaceModelVersion:
-      output.FaceModelVersion !== undefined && output.FaceModelVersion !== null ? output.FaceModelVersion : undefined,
+    FaceModelVersion: __expectString(output.FaceModelVersion),
     Faces:
       output.Faces !== undefined && output.Faces !== null
         ? deserializeAws_json1_1FaceList(output.Faces, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -8960,7 +8903,7 @@ const deserializeAws_json1_1ListStreamProcessorsResponse = (
   context: __SerdeContext
 ): ListStreamProcessorsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     StreamProcessors:
       output.StreamProcessors !== undefined && output.StreamProcessors !== null
         ? deserializeAws_json1_1StreamProcessorList(output.StreamProcessors, context)
@@ -8982,9 +8925,9 @@ const deserializeAws_json1_1ListTagsForResourceResponse = (
 
 const deserializeAws_json1_1ModerationLabel = (output: any, context: __SerdeContext): ModerationLabel => {
   return {
-    Confidence: output.Confidence !== undefined && output.Confidence !== null ? output.Confidence : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    ParentName: output.ParentName !== undefined && output.ParentName !== null ? output.ParentName : undefined,
+    Confidence: __expectNumber(output.Confidence),
+    Name: __expectString(output.Name),
+    ParentName: __expectString(output.ParentName),
   } as any;
 };
 
@@ -9001,28 +8944,28 @@ const deserializeAws_json1_1ModerationLabels = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1MouthOpen = (output: any, context: __SerdeContext): MouthOpen => {
   return {
-    Confidence: output.Confidence !== undefined && output.Confidence !== null ? output.Confidence : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Confidence: __expectNumber(output.Confidence),
+    Value: __expectBoolean(output.Value),
   } as any;
 };
 
 const deserializeAws_json1_1Mustache = (output: any, context: __SerdeContext): Mustache => {
   return {
-    Confidence: output.Confidence !== undefined && output.Confidence !== null ? output.Confidence : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Confidence: __expectNumber(output.Confidence),
+    Value: __expectBoolean(output.Value),
   } as any;
 };
 
 const deserializeAws_json1_1OutputConfig = (output: any, context: __SerdeContext): OutputConfig => {
   return {
-    S3Bucket: output.S3Bucket !== undefined && output.S3Bucket !== null ? output.S3Bucket : undefined,
-    S3KeyPrefix: output.S3KeyPrefix !== undefined && output.S3KeyPrefix !== null ? output.S3KeyPrefix : undefined,
+    S3Bucket: __expectString(output.S3Bucket),
+    S3KeyPrefix: __expectString(output.S3KeyPrefix),
   } as any;
 };
 
 const deserializeAws_json1_1Parent = (output: any, context: __SerdeContext): Parent => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -9047,7 +8990,7 @@ const deserializeAws_json1_1PersonDetail = (output: any, context: __SerdeContext
       output.Face !== undefined && output.Face !== null
         ? deserializeAws_json1_1FaceDetail(output.Face, context)
         : undefined,
-    Index: output.Index !== undefined && output.Index !== null ? output.Index : undefined,
+    Index: __expectNumber(output.Index),
   } as any;
 };
 
@@ -9057,7 +9000,7 @@ const deserializeAws_json1_1PersonDetection = (output: any, context: __SerdeCont
       output.Person !== undefined && output.Person !== null
         ? deserializeAws_json1_1PersonDetail(output.Person, context)
         : undefined,
-    Timestamp: output.Timestamp !== undefined && output.Timestamp !== null ? output.Timestamp : undefined,
+    Timestamp: __expectNumber(output.Timestamp),
   } as any;
 };
 
@@ -9082,7 +9025,7 @@ const deserializeAws_json1_1PersonMatch = (output: any, context: __SerdeContext)
       output.Person !== undefined && output.Person !== null
         ? deserializeAws_json1_1PersonDetail(output.Person, context)
         : undefined,
-    Timestamp: output.Timestamp !== undefined && output.Timestamp !== null ? output.Timestamp : undefined,
+    Timestamp: __expectNumber(output.Timestamp),
   } as any;
 };
 
@@ -9099,8 +9042,8 @@ const deserializeAws_json1_1PersonMatches = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1Point = (output: any, context: __SerdeContext): Point => {
   return {
-    X: output.X !== undefined && output.X !== null ? output.X : undefined,
-    Y: output.Y !== undefined && output.Y !== null ? output.Y : undefined,
+    X: __expectNumber(output.X),
+    Y: __expectNumber(output.Y),
   } as any;
 };
 
@@ -9117,9 +9060,9 @@ const deserializeAws_json1_1Polygon = (output: any, context: __SerdeContext): Po
 
 const deserializeAws_json1_1Pose = (output: any, context: __SerdeContext): Pose => {
   return {
-    Pitch: output.Pitch !== undefined && output.Pitch !== null ? output.Pitch : undefined,
-    Roll: output.Roll !== undefined && output.Roll !== null ? output.Roll : undefined,
-    Yaw: output.Yaw !== undefined && output.Yaw !== null ? output.Yaw : undefined,
+    Pitch: __expectNumber(output.Pitch),
+    Roll: __expectNumber(output.Roll),
+    Yaw: __expectNumber(output.Yaw),
   } as any;
 };
 
@@ -9129,8 +9072,8 @@ const deserializeAws_json1_1ProjectDescription = (output: any, context: __SerdeC
       output.CreationTimestamp !== undefined && output.CreationTimestamp !== null
         ? new Date(Math.round(output.CreationTimestamp * 1000))
         : undefined,
-    ProjectArn: output.ProjectArn !== undefined && output.ProjectArn !== null ? output.ProjectArn : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    ProjectArn: __expectString(output.ProjectArn),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -9150,10 +9093,7 @@ const deserializeAws_json1_1ProjectVersionDescription = (
   context: __SerdeContext
 ): ProjectVersionDescription => {
   return {
-    BillableTrainingTimeInSeconds:
-      output.BillableTrainingTimeInSeconds !== undefined && output.BillableTrainingTimeInSeconds !== null
-        ? output.BillableTrainingTimeInSeconds
-        : undefined,
+    BillableTrainingTimeInSeconds: __expectNumber(output.BillableTrainingTimeInSeconds),
     CreationTimestamp:
       output.CreationTimestamp !== undefined && output.CreationTimestamp !== null
         ? new Date(Math.round(output.CreationTimestamp * 1000))
@@ -9162,26 +9102,19 @@ const deserializeAws_json1_1ProjectVersionDescription = (
       output.EvaluationResult !== undefined && output.EvaluationResult !== null
         ? deserializeAws_json1_1EvaluationResult(output.EvaluationResult, context)
         : undefined,
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
+    KmsKeyId: __expectString(output.KmsKeyId),
     ManifestSummary:
       output.ManifestSummary !== undefined && output.ManifestSummary !== null
         ? deserializeAws_json1_1GroundTruthManifest(output.ManifestSummary, context)
         : undefined,
-    MinInferenceUnits:
-      output.MinInferenceUnits !== undefined && output.MinInferenceUnits !== null
-        ? output.MinInferenceUnits
-        : undefined,
+    MinInferenceUnits: __expectNumber(output.MinInferenceUnits),
     OutputConfig:
       output.OutputConfig !== undefined && output.OutputConfig !== null
         ? deserializeAws_json1_1OutputConfig(output.OutputConfig, context)
         : undefined,
-    ProjectVersionArn:
-      output.ProjectVersionArn !== undefined && output.ProjectVersionArn !== null
-        ? output.ProjectVersionArn
-        : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusMessage:
-      output.StatusMessage !== undefined && output.StatusMessage !== null ? output.StatusMessage : undefined,
+    ProjectVersionArn: __expectString(output.ProjectVersionArn),
+    Status: __expectString(output.Status),
+    StatusMessage: __expectString(output.StatusMessage),
     TestingDataResult:
       output.TestingDataResult !== undefined && output.TestingDataResult !== null
         ? deserializeAws_json1_1TestingDataResult(output.TestingDataResult, context)
@@ -9216,12 +9149,12 @@ const deserializeAws_json1_1ProtectiveEquipmentBodyPart = (
   context: __SerdeContext
 ): ProtectiveEquipmentBodyPart => {
   return {
-    Confidence: output.Confidence !== undefined && output.Confidence !== null ? output.Confidence : undefined,
+    Confidence: __expectNumber(output.Confidence),
     EquipmentDetections:
       output.EquipmentDetections !== undefined && output.EquipmentDetections !== null
         ? deserializeAws_json1_1EquipmentDetections(output.EquipmentDetections, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -9238,8 +9171,8 @@ const deserializeAws_json1_1ProtectiveEquipmentPerson = (
       output.BoundingBox !== undefined && output.BoundingBox !== null
         ? deserializeAws_json1_1BoundingBox(output.BoundingBox, context)
         : undefined,
-    Confidence: output.Confidence !== undefined && output.Confidence !== null ? output.Confidence : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    Confidence: __expectNumber(output.Confidence),
+    Id: __expectNumber(output.Id),
   } as any;
 };
 
@@ -9250,7 +9183,7 @@ const deserializeAws_json1_1ProtectiveEquipmentPersonIds = (output: any, context
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectNumber(entry) as any;
     });
 };
 
@@ -9293,9 +9226,9 @@ const deserializeAws_json1_1ProvisionedThroughputExceededException = (
   context: __SerdeContext
 ): ProvisionedThroughputExceededException => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Logref: output.Logref !== undefined && output.Logref !== null ? output.Logref : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Logref: __expectString(output.Logref),
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -9306,7 +9239,7 @@ const deserializeAws_json1_1Reasons = (output: any, context: __SerdeContext): (R
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -9319,10 +9252,7 @@ const deserializeAws_json1_1RecognizeCelebritiesResponse = (
       output.CelebrityFaces !== undefined && output.CelebrityFaces !== null
         ? deserializeAws_json1_1CelebrityList(output.CelebrityFaces, context)
         : undefined,
-    OrientationCorrection:
-      output.OrientationCorrection !== undefined && output.OrientationCorrection !== null
-        ? output.OrientationCorrection
-        : undefined,
+    OrientationCorrection: __expectString(output.OrientationCorrection),
     UnrecognizedFaces:
       output.UnrecognizedFaces !== undefined && output.UnrecognizedFaces !== null
         ? deserializeAws_json1_1ComparedFaceList(output.UnrecognizedFaces, context)
@@ -9335,17 +9265,17 @@ const deserializeAws_json1_1ResourceAlreadyExistsException = (
   context: __SerdeContext
 ): ResourceAlreadyExistsException => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Logref: output.Logref !== undefined && output.Logref !== null ? output.Logref : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Logref: __expectString(output.Logref),
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1ResourceInUseException = (output: any, context: __SerdeContext): ResourceInUseException => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Logref: output.Logref !== undefined && output.Logref !== null ? output.Logref : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Logref: __expectString(output.Logref),
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -9354,9 +9284,9 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Logref: output.Logref !== undefined && output.Logref !== null ? output.Logref : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Logref: __expectString(output.Logref),
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -9365,17 +9295,17 @@ const deserializeAws_json1_1ResourceNotReadyException = (
   context: __SerdeContext
 ): ResourceNotReadyException => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Logref: output.Logref !== undefined && output.Logref !== null ? output.Logref : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Logref: __expectString(output.Logref),
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1S3Object = (output: any, context: __SerdeContext): S3Object => {
   return {
-    Bucket: output.Bucket !== undefined && output.Bucket !== null ? output.Bucket : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    Bucket: __expectString(output.Bucket),
+    Name: __expectString(output.Name),
+    Version: __expectString(output.Version),
   } as any;
 };
 
@@ -9388,16 +9318,12 @@ const deserializeAws_json1_1SearchFacesByImageResponse = (
       output.FaceMatches !== undefined && output.FaceMatches !== null
         ? deserializeAws_json1_1FaceMatchList(output.FaceMatches, context)
         : undefined,
-    FaceModelVersion:
-      output.FaceModelVersion !== undefined && output.FaceModelVersion !== null ? output.FaceModelVersion : undefined,
+    FaceModelVersion: __expectString(output.FaceModelVersion),
     SearchedFaceBoundingBox:
       output.SearchedFaceBoundingBox !== undefined && output.SearchedFaceBoundingBox !== null
         ? deserializeAws_json1_1BoundingBox(output.SearchedFaceBoundingBox, context)
         : undefined,
-    SearchedFaceConfidence:
-      output.SearchedFaceConfidence !== undefined && output.SearchedFaceConfidence !== null
-        ? output.SearchedFaceConfidence
-        : undefined,
+    SearchedFaceConfidence: __expectNumber(output.SearchedFaceConfidence),
   } as any;
 };
 
@@ -9407,42 +9333,28 @@ const deserializeAws_json1_1SearchFacesResponse = (output: any, context: __Serde
       output.FaceMatches !== undefined && output.FaceMatches !== null
         ? deserializeAws_json1_1FaceMatchList(output.FaceMatches, context)
         : undefined,
-    FaceModelVersion:
-      output.FaceModelVersion !== undefined && output.FaceModelVersion !== null ? output.FaceModelVersion : undefined,
-    SearchedFaceId:
-      output.SearchedFaceId !== undefined && output.SearchedFaceId !== null ? output.SearchedFaceId : undefined,
+    FaceModelVersion: __expectString(output.FaceModelVersion),
+    SearchedFaceId: __expectString(output.SearchedFaceId),
   } as any;
 };
 
 const deserializeAws_json1_1SegmentDetection = (output: any, context: __SerdeContext): SegmentDetection => {
   return {
-    DurationMillis:
-      output.DurationMillis !== undefined && output.DurationMillis !== null ? output.DurationMillis : undefined,
-    DurationSMPTE:
-      output.DurationSMPTE !== undefined && output.DurationSMPTE !== null ? output.DurationSMPTE : undefined,
-    EndTimecodeSMPTE:
-      output.EndTimecodeSMPTE !== undefined && output.EndTimecodeSMPTE !== null ? output.EndTimecodeSMPTE : undefined,
-    EndTimestampMillis:
-      output.EndTimestampMillis !== undefined && output.EndTimestampMillis !== null
-        ? output.EndTimestampMillis
-        : undefined,
+    DurationMillis: __expectNumber(output.DurationMillis),
+    DurationSMPTE: __expectString(output.DurationSMPTE),
+    EndTimecodeSMPTE: __expectString(output.EndTimecodeSMPTE),
+    EndTimestampMillis: __expectNumber(output.EndTimestampMillis),
     ShotSegment:
       output.ShotSegment !== undefined && output.ShotSegment !== null
         ? deserializeAws_json1_1ShotSegment(output.ShotSegment, context)
         : undefined,
-    StartTimecodeSMPTE:
-      output.StartTimecodeSMPTE !== undefined && output.StartTimecodeSMPTE !== null
-        ? output.StartTimecodeSMPTE
-        : undefined,
-    StartTimestampMillis:
-      output.StartTimestampMillis !== undefined && output.StartTimestampMillis !== null
-        ? output.StartTimestampMillis
-        : undefined,
+    StartTimecodeSMPTE: __expectString(output.StartTimecodeSMPTE),
+    StartTimestampMillis: __expectNumber(output.StartTimestampMillis),
     TechnicalCueSegment:
       output.TechnicalCueSegment !== undefined && output.TechnicalCueSegment !== null
         ? deserializeAws_json1_1TechnicalCueSegment(output.TechnicalCueSegment, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -9459,8 +9371,8 @@ const deserializeAws_json1_1SegmentDetections = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1SegmentTypeInfo = (output: any, context: __SerdeContext): SegmentTypeInfo => {
   return {
-    ModelVersion: output.ModelVersion !== undefined && output.ModelVersion !== null ? output.ModelVersion : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    ModelVersion: __expectString(output.ModelVersion),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -9480,23 +9392,23 @@ const deserializeAws_json1_1ServiceQuotaExceededException = (
   context: __SerdeContext
 ): ServiceQuotaExceededException => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Logref: output.Logref !== undefined && output.Logref !== null ? output.Logref : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Logref: __expectString(output.Logref),
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1ShotSegment = (output: any, context: __SerdeContext): ShotSegment => {
   return {
-    Confidence: output.Confidence !== undefined && output.Confidence !== null ? output.Confidence : undefined,
-    Index: output.Index !== undefined && output.Index !== null ? output.Index : undefined,
+    Confidence: __expectNumber(output.Confidence),
+    Index: __expectNumber(output.Index),
   } as any;
 };
 
 const deserializeAws_json1_1Smile = (output: any, context: __SerdeContext): Smile => {
   return {
-    Confidence: output.Confidence !== undefined && output.Confidence !== null ? output.Confidence : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Confidence: __expectNumber(output.Confidence),
+    Value: __expectBoolean(output.Value),
   } as any;
 };
 
@@ -9505,7 +9417,7 @@ const deserializeAws_json1_1StartCelebrityRecognitionResponse = (
   context: __SerdeContext
 ): StartCelebrityRecognitionResponse => {
   return {
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
+    JobId: __expectString(output.JobId),
   } as any;
 };
 
@@ -9514,7 +9426,7 @@ const deserializeAws_json1_1StartContentModerationResponse = (
   context: __SerdeContext
 ): StartContentModerationResponse => {
   return {
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
+    JobId: __expectString(output.JobId),
   } as any;
 };
 
@@ -9523,7 +9435,7 @@ const deserializeAws_json1_1StartFaceDetectionResponse = (
   context: __SerdeContext
 ): StartFaceDetectionResponse => {
   return {
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
+    JobId: __expectString(output.JobId),
   } as any;
 };
 
@@ -9532,7 +9444,7 @@ const deserializeAws_json1_1StartFaceSearchResponse = (
   context: __SerdeContext
 ): StartFaceSearchResponse => {
   return {
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
+    JobId: __expectString(output.JobId),
   } as any;
 };
 
@@ -9541,7 +9453,7 @@ const deserializeAws_json1_1StartLabelDetectionResponse = (
   context: __SerdeContext
 ): StartLabelDetectionResponse => {
   return {
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
+    JobId: __expectString(output.JobId),
   } as any;
 };
 
@@ -9550,7 +9462,7 @@ const deserializeAws_json1_1StartPersonTrackingResponse = (
   context: __SerdeContext
 ): StartPersonTrackingResponse => {
   return {
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
+    JobId: __expectString(output.JobId),
   } as any;
 };
 
@@ -9559,7 +9471,7 @@ const deserializeAws_json1_1StartProjectVersionResponse = (
   context: __SerdeContext
 ): StartProjectVersionResponse => {
   return {
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -9568,7 +9480,7 @@ const deserializeAws_json1_1StartSegmentDetectionResponse = (
   context: __SerdeContext
 ): StartSegmentDetectionResponse => {
   return {
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
+    JobId: __expectString(output.JobId),
   } as any;
 };
 
@@ -9584,7 +9496,7 @@ const deserializeAws_json1_1StartTextDetectionResponse = (
   context: __SerdeContext
 ): StartTextDetectionResponse => {
   return {
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
+    JobId: __expectString(output.JobId),
   } as any;
 };
 
@@ -9593,7 +9505,7 @@ const deserializeAws_json1_1StopProjectVersionResponse = (
   context: __SerdeContext
 ): StopProjectVersionResponse => {
   return {
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -9606,8 +9518,8 @@ const deserializeAws_json1_1StopStreamProcessorResponse = (
 
 const deserializeAws_json1_1StreamProcessor = (output: any, context: __SerdeContext): StreamProcessor => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Name: __expectString(output.Name),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -9663,8 +9575,8 @@ const deserializeAws_json1_1Summary = (output: any, context: __SerdeContext): Su
 
 const deserializeAws_json1_1Sunglasses = (output: any, context: __SerdeContext): Sunglasses => {
   return {
-    Confidence: output.Confidence !== undefined && output.Confidence !== null ? output.Confidence : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Confidence: __expectNumber(output.Confidence),
+    Value: __expectBoolean(output.Value),
   } as any;
 };
 
@@ -9675,7 +9587,7 @@ const deserializeAws_json1_1TagMap = (output: any, context: __SerdeContext): { [
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -9686,8 +9598,8 @@ const deserializeAws_json1_1TagResourceResponse = (output: any, context: __Serde
 
 const deserializeAws_json1_1TechnicalCueSegment = (output: any, context: __SerdeContext): TechnicalCueSegment => {
   return {
-    Confidence: output.Confidence !== undefined && output.Confidence !== null ? output.Confidence : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Confidence: __expectNumber(output.Confidence),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -9697,7 +9609,7 @@ const deserializeAws_json1_1TestingData = (output: any, context: __SerdeContext)
       output.Assets !== undefined && output.Assets !== null
         ? deserializeAws_json1_1Assets(output.Assets, context)
         : undefined,
-    AutoCreate: output.AutoCreate !== undefined && output.AutoCreate !== null ? output.AutoCreate : undefined,
+    AutoCreate: __expectBoolean(output.AutoCreate),
   } as any;
 };
 
@@ -9720,15 +9632,15 @@ const deserializeAws_json1_1TestingDataResult = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1TextDetection = (output: any, context: __SerdeContext): TextDetection => {
   return {
-    Confidence: output.Confidence !== undefined && output.Confidence !== null ? output.Confidence : undefined,
-    DetectedText: output.DetectedText !== undefined && output.DetectedText !== null ? output.DetectedText : undefined,
+    Confidence: __expectNumber(output.Confidence),
+    DetectedText: __expectString(output.DetectedText),
     Geometry:
       output.Geometry !== undefined && output.Geometry !== null
         ? deserializeAws_json1_1Geometry(output.Geometry, context)
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    ParentId: output.ParentId !== undefined && output.ParentId !== null ? output.ParentId : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Id: __expectNumber(output.Id),
+    ParentId: __expectNumber(output.ParentId),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -9749,7 +9661,7 @@ const deserializeAws_json1_1TextDetectionResult = (output: any, context: __Serde
       output.TextDetection !== undefined && output.TextDetection !== null
         ? deserializeAws_json1_1TextDetection(output.TextDetection, context)
         : undefined,
-    Timestamp: output.Timestamp !== undefined && output.Timestamp !== null ? output.Timestamp : undefined,
+    Timestamp: __expectNumber(output.Timestamp),
   } as any;
 };
 
@@ -9766,9 +9678,9 @@ const deserializeAws_json1_1TextDetectionResults = (output: any, context: __Serd
 
 const deserializeAws_json1_1ThrottlingException = (output: any, context: __SerdeContext): ThrottlingException => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Logref: output.Logref !== undefined && output.Logref !== null ? output.Logref : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Logref: __expectString(output.Logref),
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -9833,7 +9745,7 @@ const deserializeAws_json1_1Urls = (output: any, context: __SerdeContext): strin
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -9848,13 +9760,12 @@ const deserializeAws_json1_1ValidationData = (output: any, context: __SerdeConte
 
 const deserializeAws_json1_1VideoMetadata = (output: any, context: __SerdeContext): VideoMetadata => {
   return {
-    Codec: output.Codec !== undefined && output.Codec !== null ? output.Codec : undefined,
-    DurationMillis:
-      output.DurationMillis !== undefined && output.DurationMillis !== null ? output.DurationMillis : undefined,
-    Format: output.Format !== undefined && output.Format !== null ? output.Format : undefined,
-    FrameHeight: output.FrameHeight !== undefined && output.FrameHeight !== null ? output.FrameHeight : undefined,
-    FrameRate: output.FrameRate !== undefined && output.FrameRate !== null ? output.FrameRate : undefined,
-    FrameWidth: output.FrameWidth !== undefined && output.FrameWidth !== null ? output.FrameWidth : undefined,
+    Codec: __expectString(output.Codec),
+    DurationMillis: __expectNumber(output.DurationMillis),
+    Format: __expectString(output.Format),
+    FrameHeight: __expectNumber(output.FrameHeight),
+    FrameRate: __expectNumber(output.FrameRate),
+    FrameWidth: __expectNumber(output.FrameWidth),
   } as any;
 };
 
@@ -9871,9 +9782,9 @@ const deserializeAws_json1_1VideoMetadataList = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1VideoTooLargeException = (output: any, context: __SerdeContext): VideoTooLargeException => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Logref: output.Logref !== undefined && output.Logref !== null ? output.Logref : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Logref: __expectString(output.Logref),
+    Message: __expectString(output.Message),
   } as any;
 };
 

--- a/clients/client-resource-groups-tagging-api/protocols/Aws_json1_1.ts
+++ b/clients/client-resource-groups-tagging-api/protocols/Aws_json1_1.ts
@@ -47,7 +47,12 @@ import {
   UntagResourcesOutput,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -1103,8 +1108,7 @@ const serializeAws_json1_1UntagResourcesInput = (input: UntagResourcesInput, con
 
 const deserializeAws_json1_1ComplianceDetails = (output: any, context: __SerdeContext): ComplianceDetails => {
   return {
-    ComplianceStatus:
-      output.ComplianceStatus !== undefined && output.ComplianceStatus !== null ? output.ComplianceStatus : undefined,
+    ComplianceStatus: __expectBoolean(output.ComplianceStatus),
     KeysWithNoncompliantValues:
       output.KeysWithNoncompliantValues !== undefined && output.KeysWithNoncompliantValues !== null
         ? deserializeAws_json1_1TagKeyList(output.KeysWithNoncompliantValues, context)
@@ -1121,7 +1125,7 @@ const deserializeAws_json1_1ConcurrentModificationException = (
   context: __SerdeContext
 ): ConcurrentModificationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -1130,7 +1134,7 @@ const deserializeAws_json1_1ConstraintViolationException = (
   context: __SerdeContext
 ): ConstraintViolationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -1139,10 +1143,10 @@ const deserializeAws_json1_1DescribeReportCreationOutput = (
   context: __SerdeContext
 ): DescribeReportCreationOutput => {
   return {
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    S3Location: output.S3Location !== undefined && output.S3Location !== null ? output.S3Location : undefined,
-    StartDate: output.StartDate !== undefined && output.StartDate !== null ? output.StartDate : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    ErrorMessage: __expectString(output.ErrorMessage),
+    S3Location: __expectString(output.S3Location),
+    StartDate: __expectString(output.StartDate),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -1163,9 +1167,9 @@ const deserializeAws_json1_1FailedResourcesMap = (
 
 const deserializeAws_json1_1FailureInfo = (output: any, context: __SerdeContext): FailureInfo => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    StatusCode: output.StatusCode !== undefined && output.StatusCode !== null ? output.StatusCode : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
+    StatusCode: __expectNumber(output.StatusCode),
   } as any;
 };
 
@@ -1174,8 +1178,7 @@ const deserializeAws_json1_1GetComplianceSummaryOutput = (
   context: __SerdeContext
 ): GetComplianceSummaryOutput => {
   return {
-    PaginationToken:
-      output.PaginationToken !== undefined && output.PaginationToken !== null ? output.PaginationToken : undefined,
+    PaginationToken: __expectString(output.PaginationToken),
     SummaryList:
       output.SummaryList !== undefined && output.SummaryList !== null
         ? deserializeAws_json1_1SummaryList(output.SummaryList, context)
@@ -1185,8 +1188,7 @@ const deserializeAws_json1_1GetComplianceSummaryOutput = (
 
 const deserializeAws_json1_1GetResourcesOutput = (output: any, context: __SerdeContext): GetResourcesOutput => {
   return {
-    PaginationToken:
-      output.PaginationToken !== undefined && output.PaginationToken !== null ? output.PaginationToken : undefined,
+    PaginationToken: __expectString(output.PaginationToken),
     ResourceTagMappingList:
       output.ResourceTagMappingList !== undefined && output.ResourceTagMappingList !== null
         ? deserializeAws_json1_1ResourceTagMappingList(output.ResourceTagMappingList, context)
@@ -1196,8 +1198,7 @@ const deserializeAws_json1_1GetResourcesOutput = (output: any, context: __SerdeC
 
 const deserializeAws_json1_1GetTagKeysOutput = (output: any, context: __SerdeContext): GetTagKeysOutput => {
   return {
-    PaginationToken:
-      output.PaginationToken !== undefined && output.PaginationToken !== null ? output.PaginationToken : undefined,
+    PaginationToken: __expectString(output.PaginationToken),
     TagKeys:
       output.TagKeys !== undefined && output.TagKeys !== null
         ? deserializeAws_json1_1TagKeyList(output.TagKeys, context)
@@ -1207,8 +1208,7 @@ const deserializeAws_json1_1GetTagKeysOutput = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1GetTagValuesOutput = (output: any, context: __SerdeContext): GetTagValuesOutput => {
   return {
-    PaginationToken:
-      output.PaginationToken !== undefined && output.PaginationToken !== null ? output.PaginationToken : undefined,
+    PaginationToken: __expectString(output.PaginationToken),
     TagValues:
       output.TagValues !== undefined && output.TagValues !== null
         ? deserializeAws_json1_1TagValuesOutputList(output.TagValues, context)
@@ -1221,7 +1221,7 @@ const deserializeAws_json1_1InternalServiceException = (
   context: __SerdeContext
 ): InternalServiceException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -1230,7 +1230,7 @@ const deserializeAws_json1_1InvalidParameterException = (
   context: __SerdeContext
 ): InvalidParameterException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -1239,7 +1239,7 @@ const deserializeAws_json1_1PaginationTokenExpiredException = (
   context: __SerdeContext
 ): PaginationTokenExpiredException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -1249,7 +1249,7 @@ const deserializeAws_json1_1ResourceTagMapping = (output: any, context: __SerdeC
       output.ComplianceDetails !== undefined && output.ComplianceDetails !== null
         ? deserializeAws_json1_1ComplianceDetails(output.ComplianceDetails, context)
         : undefined,
-    ResourceARN: output.ResourceARN !== undefined && output.ResourceARN !== null ? output.ResourceARN : undefined,
+    ResourceARN: __expectString(output.ResourceARN),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_1TagList(output.Tags, context)
@@ -1277,15 +1277,12 @@ const deserializeAws_json1_1StartReportCreationOutput = (
 
 const deserializeAws_json1_1Summary = (output: any, context: __SerdeContext): Summary => {
   return {
-    LastUpdated: output.LastUpdated !== undefined && output.LastUpdated !== null ? output.LastUpdated : undefined,
-    NonCompliantResources:
-      output.NonCompliantResources !== undefined && output.NonCompliantResources !== null
-        ? output.NonCompliantResources
-        : undefined,
-    Region: output.Region !== undefined && output.Region !== null ? output.Region : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
-    TargetId: output.TargetId !== undefined && output.TargetId !== null ? output.TargetId : undefined,
-    TargetIdType: output.TargetIdType !== undefined && output.TargetIdType !== null ? output.TargetIdType : undefined,
+    LastUpdated: __expectString(output.LastUpdated),
+    NonCompliantResources: __expectNumber(output.NonCompliantResources),
+    Region: __expectString(output.Region),
+    ResourceType: __expectString(output.ResourceType),
+    TargetId: __expectString(output.TargetId),
+    TargetIdType: __expectString(output.TargetIdType),
   } as any;
 };
 
@@ -1302,8 +1299,8 @@ const deserializeAws_json1_1SummaryList = (output: any, context: __SerdeContext)
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -1314,7 +1311,7 @@ const deserializeAws_json1_1TagKeyList = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -1345,13 +1342,13 @@ const deserializeAws_json1_1TagValuesOutputList = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1ThrottledException = (output: any, context: __SerdeContext): ThrottledException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 

--- a/clients/client-resource-groups/protocols/Aws_restJson1.ts
+++ b/clients/client-resource-groups/protocols/Aws_restJson1.ts
@@ -47,6 +47,7 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -1004,7 +1005,7 @@ export const deserializeAws_restJson1GetTagsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.Tags, context);
@@ -1208,7 +1209,7 @@ export const deserializeAws_restJson1ListGroupResourcesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.QueryErrors !== undefined && data.QueryErrors !== null) {
     contents.QueryErrors = deserializeAws_restJson1QueryErrorList(data.QueryErrors, context);
@@ -1328,7 +1329,7 @@ export const deserializeAws_restJson1ListGroupsCommand = async (
     contents.Groups = deserializeAws_restJson1GroupList(data.Groups, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1508,7 +1509,7 @@ export const deserializeAws_restJson1SearchResourcesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.QueryErrors !== undefined && data.QueryErrors !== null) {
     contents.QueryErrors = deserializeAws_restJson1QueryErrorList(data.QueryErrors, context);
@@ -1610,7 +1611,7 @@ export const deserializeAws_restJson1TagCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.Tags, context);
@@ -1812,7 +1813,7 @@ export const deserializeAws_restJson1UntagCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Arn !== undefined && data.Arn !== null) {
-    contents.Arn = data.Arn;
+    contents.Arn = __expectString(data.Arn);
   }
   if (data.Keys !== undefined && data.Keys !== null) {
     contents.Keys = deserializeAws_restJson1TagKeyList(data.Keys, context);
@@ -2099,7 +2100,7 @@ const deserializeAws_restJson1BadRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -2116,7 +2117,7 @@ const deserializeAws_restJson1ForbiddenExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -2133,7 +2134,7 @@ const deserializeAws_restJson1InternalServerErrorExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -2150,7 +2151,7 @@ const deserializeAws_restJson1MethodNotAllowedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -2167,7 +2168,7 @@ const deserializeAws_restJson1NotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -2184,7 +2185,7 @@ const deserializeAws_restJson1TooManyRequestsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -2201,7 +2202,7 @@ const deserializeAws_restJson1UnauthorizedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -2369,9 +2370,9 @@ const serializeAws_restJson1Tags = (input: { [key: string]: string }, context: _
 
 const deserializeAws_restJson1FailedResource = (output: any, context: __SerdeContext): FailedResource => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    ResourceArn: output.ResourceArn !== undefined && output.ResourceArn !== null ? output.ResourceArn : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
+    ResourceArn: __expectString(output.ResourceArn),
   } as any;
 };
 
@@ -2388,9 +2389,9 @@ const deserializeAws_restJson1FailedResourceList = (output: any, context: __Serd
 
 const deserializeAws_restJson1Group = (output: any, context: __SerdeContext): Group => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    GroupArn: output.GroupArn !== undefined && output.GroupArn !== null ? output.GroupArn : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Description: __expectString(output.Description),
+    GroupArn: __expectString(output.GroupArn),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -2400,13 +2401,12 @@ const deserializeAws_restJson1GroupConfiguration = (output: any, context: __Serd
       output.Configuration !== undefined && output.Configuration !== null
         ? deserializeAws_restJson1GroupConfigurationList(output.Configuration, context)
         : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
+    FailureReason: __expectString(output.FailureReason),
     ProposedConfiguration:
       output.ProposedConfiguration !== undefined && output.ProposedConfiguration !== null
         ? deserializeAws_restJson1GroupConfigurationList(output.ProposedConfiguration, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -2419,7 +2419,7 @@ const deserializeAws_restJson1GroupConfigurationItem = (
       output.Parameters !== undefined && output.Parameters !== null
         ? deserializeAws_restJson1GroupParameterList(output.Parameters, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -2442,7 +2442,7 @@ const deserializeAws_restJson1GroupConfigurationParameter = (
   context: __SerdeContext
 ): GroupConfigurationParameter => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     Values:
       output.Values !== undefined && output.Values !== null
         ? deserializeAws_restJson1GroupConfigurationParameterValueList(output.Values, context)
@@ -2460,14 +2460,14 @@ const deserializeAws_restJson1GroupConfigurationParameterValueList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1GroupIdentifier = (output: any, context: __SerdeContext): GroupIdentifier => {
   return {
-    GroupArn: output.GroupArn !== undefined && output.GroupArn !== null ? output.GroupArn : undefined,
-    GroupName: output.GroupName !== undefined && output.GroupName !== null ? output.GroupName : undefined,
+    GroupArn: __expectString(output.GroupArn),
+    GroupName: __expectString(output.GroupName),
   } as any;
 };
 
@@ -2509,7 +2509,7 @@ const deserializeAws_restJson1GroupParameterList = (
 
 const deserializeAws_restJson1GroupQuery = (output: any, context: __SerdeContext): GroupQuery => {
   return {
-    GroupName: output.GroupName !== undefined && output.GroupName !== null ? output.GroupName : undefined,
+    GroupName: __expectString(output.GroupName),
     ResourceQuery:
       output.ResourceQuery !== undefined && output.ResourceQuery !== null
         ? deserializeAws_restJson1ResourceQuery(output.ResourceQuery, context)
@@ -2549,7 +2549,7 @@ const deserializeAws_restJson1ListGroupResourcesItemList = (
 
 const deserializeAws_restJson1PendingResource = (output: any, context: __SerdeContext): PendingResource => {
   return {
-    ResourceArn: output.ResourceArn !== undefined && output.ResourceArn !== null ? output.ResourceArn : undefined,
+    ResourceArn: __expectString(output.ResourceArn),
   } as any;
 };
 
@@ -2566,8 +2566,8 @@ const deserializeAws_restJson1PendingResourceList = (output: any, context: __Ser
 
 const deserializeAws_restJson1QueryError = (output: any, context: __SerdeContext): QueryError => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2589,14 +2589,14 @@ const deserializeAws_restJson1ResourceArnList = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1ResourceIdentifier = (output: any, context: __SerdeContext): ResourceIdentifier => {
   return {
-    ResourceArn: output.ResourceArn !== undefined && output.ResourceArn !== null ? output.ResourceArn : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
+    ResourceArn: __expectString(output.ResourceArn),
+    ResourceType: __expectString(output.ResourceType),
   } as any;
 };
 
@@ -2613,14 +2613,14 @@ const deserializeAws_restJson1ResourceIdentifierList = (output: any, context: __
 
 const deserializeAws_restJson1ResourceQuery = (output: any, context: __SerdeContext): ResourceQuery => {
   return {
-    Query: output.Query !== undefined && output.Query !== null ? output.Query : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Query: __expectString(output.Query),
+    Type: __expectString(output.Type),
   } as any;
 };
 
 const deserializeAws_restJson1ResourceStatus = (output: any, context: __SerdeContext): ResourceStatus => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -2631,7 +2631,7 @@ const deserializeAws_restJson1TagKeyList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2642,7 +2642,7 @@ const deserializeAws_restJson1Tags = (output: any, context: __SerdeContext): { [
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };

--- a/clients/client-robomaker/protocols/Aws_restJson1.ts
+++ b/clients/client-robomaker/protocols/Aws_restJson1.ts
@@ -233,6 +233,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -2369,7 +2372,7 @@ export const deserializeAws_restJson1CreateDeploymentJobCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
     contents.createdAt = new Date(Math.round(data.createdAt * 1000));
@@ -2384,16 +2387,16 @@ export const deserializeAws_restJson1CreateDeploymentJobCommand = async (
     contents.deploymentConfig = deserializeAws_restJson1DeploymentConfig(data.deploymentConfig, context);
   }
   if (data.failureCode !== undefined && data.failureCode !== null) {
-    contents.failureCode = data.failureCode;
+    contents.failureCode = __expectString(data.failureCode);
   }
   if (data.failureReason !== undefined && data.failureReason !== null) {
-    contents.failureReason = data.failureReason;
+    contents.failureReason = __expectString(data.failureReason);
   }
   if (data.fleet !== undefined && data.fleet !== null) {
-    contents.fleet = data.fleet;
+    contents.fleet = __expectString(data.fleet);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.status = data.status;
+    contents.status = __expectString(data.status);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
@@ -2502,13 +2505,13 @@ export const deserializeAws_restJson1CreateFleetCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
     contents.createdAt = new Date(Math.round(data.createdAt * 1000));
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
@@ -2595,19 +2598,19 @@ export const deserializeAws_restJson1CreateRobotCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.architecture !== undefined && data.architecture !== null) {
-    contents.architecture = data.architecture;
+    contents.architecture = __expectString(data.architecture);
   }
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
     contents.createdAt = new Date(Math.round(data.createdAt * 1000));
   }
   if (data.greengrassGroupId !== undefined && data.greengrassGroupId !== null) {
-    contents.greengrassGroupId = data.greengrassGroupId;
+    contents.greengrassGroupId = __expectString(data.greengrassGroupId);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
@@ -2704,16 +2707,16 @@ export const deserializeAws_restJson1CreateRobotApplicationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.lastUpdatedAt !== undefined && data.lastUpdatedAt !== null) {
     contents.lastUpdatedAt = new Date(Math.round(data.lastUpdatedAt * 1000));
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.revisionId !== undefined && data.revisionId !== null) {
-    contents.revisionId = data.revisionId;
+    contents.revisionId = __expectString(data.revisionId);
   }
   if (data.robotSoftwareSuite !== undefined && data.robotSoftwareSuite !== null) {
     contents.robotSoftwareSuite = deserializeAws_restJson1RobotSoftwareSuite(data.robotSoftwareSuite, context);
@@ -2725,7 +2728,7 @@ export const deserializeAws_restJson1CreateRobotApplicationCommand = async (
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
   if (data.version !== undefined && data.version !== null) {
-    contents.version = data.version;
+    contents.version = __expectString(data.version);
   }
   return Promise.resolve(contents);
 };
@@ -2826,16 +2829,16 @@ export const deserializeAws_restJson1CreateRobotApplicationVersionCommand = asyn
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.lastUpdatedAt !== undefined && data.lastUpdatedAt !== null) {
     contents.lastUpdatedAt = new Date(Math.round(data.lastUpdatedAt * 1000));
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.revisionId !== undefined && data.revisionId !== null) {
-    contents.revisionId = data.revisionId;
+    contents.revisionId = __expectString(data.revisionId);
   }
   if (data.robotSoftwareSuite !== undefined && data.robotSoftwareSuite !== null) {
     contents.robotSoftwareSuite = deserializeAws_restJson1RobotSoftwareSuite(data.robotSoftwareSuite, context);
@@ -2844,7 +2847,7 @@ export const deserializeAws_restJson1CreateRobotApplicationVersionCommand = asyn
     contents.sources = deserializeAws_restJson1Sources(data.sources, context);
   }
   if (data.version !== undefined && data.version !== null) {
-    contents.version = data.version;
+    contents.version = __expectString(data.version);
   }
   return Promise.resolve(contents);
 };
@@ -2940,19 +2943,19 @@ export const deserializeAws_restJson1CreateSimulationApplicationCommand = async 
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.lastUpdatedAt !== undefined && data.lastUpdatedAt !== null) {
     contents.lastUpdatedAt = new Date(Math.round(data.lastUpdatedAt * 1000));
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.renderingEngine !== undefined && data.renderingEngine !== null) {
     contents.renderingEngine = deserializeAws_restJson1RenderingEngine(data.renderingEngine, context);
   }
   if (data.revisionId !== undefined && data.revisionId !== null) {
-    contents.revisionId = data.revisionId;
+    contents.revisionId = __expectString(data.revisionId);
   }
   if (data.robotSoftwareSuite !== undefined && data.robotSoftwareSuite !== null) {
     contents.robotSoftwareSuite = deserializeAws_restJson1RobotSoftwareSuite(data.robotSoftwareSuite, context);
@@ -2970,7 +2973,7 @@ export const deserializeAws_restJson1CreateSimulationApplicationCommand = async 
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
   if (data.version !== undefined && data.version !== null) {
-    contents.version = data.version;
+    contents.version = __expectString(data.version);
   }
   return Promise.resolve(contents);
 };
@@ -3073,19 +3076,19 @@ export const deserializeAws_restJson1CreateSimulationApplicationVersionCommand =
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.lastUpdatedAt !== undefined && data.lastUpdatedAt !== null) {
     contents.lastUpdatedAt = new Date(Math.round(data.lastUpdatedAt * 1000));
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.renderingEngine !== undefined && data.renderingEngine !== null) {
     contents.renderingEngine = deserializeAws_restJson1RenderingEngine(data.renderingEngine, context);
   }
   if (data.revisionId !== undefined && data.revisionId !== null) {
-    contents.revisionId = data.revisionId;
+    contents.revisionId = __expectString(data.revisionId);
   }
   if (data.robotSoftwareSuite !== undefined && data.robotSoftwareSuite !== null) {
     contents.robotSoftwareSuite = deserializeAws_restJson1RobotSoftwareSuite(data.robotSoftwareSuite, context);
@@ -3100,7 +3103,7 @@ export const deserializeAws_restJson1CreateSimulationApplicationVersionCommand =
     contents.sources = deserializeAws_restJson1Sources(data.sources, context);
   }
   if (data.version !== undefined && data.version !== null) {
-    contents.version = data.version;
+    contents.version = __expectString(data.version);
   }
   return Promise.resolve(contents);
 };
@@ -3204,10 +3207,10 @@ export const deserializeAws_restJson1CreateSimulationJobCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.clientRequestToken !== undefined && data.clientRequestToken !== null) {
-    contents.clientRequestToken = data.clientRequestToken;
+    contents.clientRequestToken = __expectString(data.clientRequestToken);
   }
   if (data.compute !== undefined && data.compute !== null) {
     contents.compute = deserializeAws_restJson1ComputeResponse(data.compute, context);
@@ -3216,13 +3219,13 @@ export const deserializeAws_restJson1CreateSimulationJobCommand = async (
     contents.dataSources = deserializeAws_restJson1DataSources(data.dataSources, context);
   }
   if (data.failureBehavior !== undefined && data.failureBehavior !== null) {
-    contents.failureBehavior = data.failureBehavior;
+    contents.failureBehavior = __expectString(data.failureBehavior);
   }
   if (data.failureCode !== undefined && data.failureCode !== null) {
-    contents.failureCode = data.failureCode;
+    contents.failureCode = __expectString(data.failureCode);
   }
   if (data.iamRole !== undefined && data.iamRole !== null) {
-    contents.iamRole = data.iamRole;
+    contents.iamRole = __expectString(data.iamRole);
   }
   if (data.lastStartedAt !== undefined && data.lastStartedAt !== null) {
     contents.lastStartedAt = new Date(Math.round(data.lastStartedAt * 1000));
@@ -3234,7 +3237,7 @@ export const deserializeAws_restJson1CreateSimulationJobCommand = async (
     contents.loggingConfig = deserializeAws_restJson1LoggingConfig(data.loggingConfig, context);
   }
   if (data.maxJobDurationInSeconds !== undefined && data.maxJobDurationInSeconds !== null) {
-    contents.maxJobDurationInSeconds = data.maxJobDurationInSeconds;
+    contents.maxJobDurationInSeconds = __expectNumber(data.maxJobDurationInSeconds);
   }
   if (data.outputLocation !== undefined && data.outputLocation !== null) {
     contents.outputLocation = deserializeAws_restJson1OutputLocation(data.outputLocation, context);
@@ -3249,10 +3252,10 @@ export const deserializeAws_restJson1CreateSimulationJobCommand = async (
     );
   }
   if (data.simulationTimeMillis !== undefined && data.simulationTimeMillis !== null) {
-    contents.simulationTimeMillis = data.simulationTimeMillis;
+    contents.simulationTimeMillis = __expectNumber(data.simulationTimeMillis);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.status = data.status;
+    contents.status = __expectString(data.status);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
@@ -3368,25 +3371,25 @@ export const deserializeAws_restJson1CreateWorldExportJobCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.clientRequestToken !== undefined && data.clientRequestToken !== null) {
-    contents.clientRequestToken = data.clientRequestToken;
+    contents.clientRequestToken = __expectString(data.clientRequestToken);
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
     contents.createdAt = new Date(Math.round(data.createdAt * 1000));
   }
   if (data.failureCode !== undefined && data.failureCode !== null) {
-    contents.failureCode = data.failureCode;
+    contents.failureCode = __expectString(data.failureCode);
   }
   if (data.iamRole !== undefined && data.iamRole !== null) {
-    contents.iamRole = data.iamRole;
+    contents.iamRole = __expectString(data.iamRole);
   }
   if (data.outputLocation !== undefined && data.outputLocation !== null) {
     contents.outputLocation = deserializeAws_restJson1OutputLocation(data.outputLocation, context);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.status = data.status;
+    contents.status = __expectString(data.status);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
@@ -3492,25 +3495,25 @@ export const deserializeAws_restJson1CreateWorldGenerationJobCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.clientRequestToken !== undefined && data.clientRequestToken !== null) {
-    contents.clientRequestToken = data.clientRequestToken;
+    contents.clientRequestToken = __expectString(data.clientRequestToken);
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
     contents.createdAt = new Date(Math.round(data.createdAt * 1000));
   }
   if (data.failureCode !== undefined && data.failureCode !== null) {
-    contents.failureCode = data.failureCode;
+    contents.failureCode = __expectString(data.failureCode);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.status = data.status;
+    contents.status = __expectString(data.status);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
   if (data.template !== undefined && data.template !== null) {
-    contents.template = data.template;
+    contents.template = __expectString(data.template);
   }
   if (data.worldCount !== undefined && data.worldCount !== null) {
     contents.worldCount = deserializeAws_restJson1WorldCount(data.worldCount, context);
@@ -3623,16 +3626,16 @@ export const deserializeAws_restJson1CreateWorldTemplateCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.clientRequestToken !== undefined && data.clientRequestToken !== null) {
-    contents.clientRequestToken = data.clientRequestToken;
+    contents.clientRequestToken = __expectString(data.clientRequestToken);
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
     contents.createdAt = new Date(Math.round(data.createdAt * 1000));
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
@@ -4074,10 +4077,10 @@ export const deserializeAws_restJson1DeregisterRobotCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.fleet !== undefined && data.fleet !== null) {
-    contents.fleet = data.fleet;
+    contents.fleet = __expectString(data.fleet);
   }
   if (data.robot !== undefined && data.robot !== null) {
-    contents.robot = data.robot;
+    contents.robot = __expectString(data.robot);
   }
   return Promise.resolve(contents);
 };
@@ -4165,7 +4168,7 @@ export const deserializeAws_restJson1DescribeDeploymentJobCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
     contents.createdAt = new Date(Math.round(data.createdAt * 1000));
@@ -4180,13 +4183,13 @@ export const deserializeAws_restJson1DescribeDeploymentJobCommand = async (
     contents.deploymentConfig = deserializeAws_restJson1DeploymentConfig(data.deploymentConfig, context);
   }
   if (data.failureCode !== undefined && data.failureCode !== null) {
-    contents.failureCode = data.failureCode;
+    contents.failureCode = __expectString(data.failureCode);
   }
   if (data.failureReason !== undefined && data.failureReason !== null) {
-    contents.failureReason = data.failureReason;
+    contents.failureReason = __expectString(data.failureReason);
   }
   if (data.fleet !== undefined && data.fleet !== null) {
-    contents.fleet = data.fleet;
+    contents.fleet = __expectString(data.fleet);
   }
   if (data.robotDeploymentSummary !== undefined && data.robotDeploymentSummary !== null) {
     contents.robotDeploymentSummary = deserializeAws_restJson1RobotDeploymentSummary(
@@ -4195,7 +4198,7 @@ export const deserializeAws_restJson1DescribeDeploymentJobCommand = async (
     );
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.status = data.status;
+    contents.status = __expectString(data.status);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
@@ -4284,22 +4287,22 @@ export const deserializeAws_restJson1DescribeFleetCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
     contents.createdAt = new Date(Math.round(data.createdAt * 1000));
   }
   if (data.lastDeploymentJob !== undefined && data.lastDeploymentJob !== null) {
-    contents.lastDeploymentJob = data.lastDeploymentJob;
+    contents.lastDeploymentJob = __expectString(data.lastDeploymentJob);
   }
   if (data.lastDeploymentStatus !== undefined && data.lastDeploymentStatus !== null) {
-    contents.lastDeploymentStatus = data.lastDeploymentStatus;
+    contents.lastDeploymentStatus = __expectString(data.lastDeploymentStatus);
   }
   if (data.lastDeploymentTime !== undefined && data.lastDeploymentTime !== null) {
     contents.lastDeploymentTime = new Date(Math.round(data.lastDeploymentTime * 1000));
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.robots !== undefined && data.robots !== null) {
     contents.robots = deserializeAws_restJson1Robots(data.robots, context);
@@ -4393,31 +4396,31 @@ export const deserializeAws_restJson1DescribeRobotCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.architecture !== undefined && data.architecture !== null) {
-    contents.architecture = data.architecture;
+    contents.architecture = __expectString(data.architecture);
   }
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
     contents.createdAt = new Date(Math.round(data.createdAt * 1000));
   }
   if (data.fleetArn !== undefined && data.fleetArn !== null) {
-    contents.fleetArn = data.fleetArn;
+    contents.fleetArn = __expectString(data.fleetArn);
   }
   if (data.greengrassGroupId !== undefined && data.greengrassGroupId !== null) {
-    contents.greengrassGroupId = data.greengrassGroupId;
+    contents.greengrassGroupId = __expectString(data.greengrassGroupId);
   }
   if (data.lastDeploymentJob !== undefined && data.lastDeploymentJob !== null) {
-    contents.lastDeploymentJob = data.lastDeploymentJob;
+    contents.lastDeploymentJob = __expectString(data.lastDeploymentJob);
   }
   if (data.lastDeploymentTime !== undefined && data.lastDeploymentTime !== null) {
     contents.lastDeploymentTime = new Date(Math.round(data.lastDeploymentTime * 1000));
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.status = data.status;
+    contents.status = __expectString(data.status);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
@@ -4506,16 +4509,16 @@ export const deserializeAws_restJson1DescribeRobotApplicationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.lastUpdatedAt !== undefined && data.lastUpdatedAt !== null) {
     contents.lastUpdatedAt = new Date(Math.round(data.lastUpdatedAt * 1000));
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.revisionId !== undefined && data.revisionId !== null) {
-    contents.revisionId = data.revisionId;
+    contents.revisionId = __expectString(data.revisionId);
   }
   if (data.robotSoftwareSuite !== undefined && data.robotSoftwareSuite !== null) {
     contents.robotSoftwareSuite = deserializeAws_restJson1RobotSoftwareSuite(data.robotSoftwareSuite, context);
@@ -4527,7 +4530,7 @@ export const deserializeAws_restJson1DescribeRobotApplicationCommand = async (
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
   if (data.version !== undefined && data.version !== null) {
-    contents.version = data.version;
+    contents.version = __expectString(data.version);
   }
   return Promise.resolve(contents);
 };
@@ -4615,19 +4618,19 @@ export const deserializeAws_restJson1DescribeSimulationApplicationCommand = asyn
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.lastUpdatedAt !== undefined && data.lastUpdatedAt !== null) {
     contents.lastUpdatedAt = new Date(Math.round(data.lastUpdatedAt * 1000));
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.renderingEngine !== undefined && data.renderingEngine !== null) {
     contents.renderingEngine = deserializeAws_restJson1RenderingEngine(data.renderingEngine, context);
   }
   if (data.revisionId !== undefined && data.revisionId !== null) {
-    contents.revisionId = data.revisionId;
+    contents.revisionId = __expectString(data.revisionId);
   }
   if (data.robotSoftwareSuite !== undefined && data.robotSoftwareSuite !== null) {
     contents.robotSoftwareSuite = deserializeAws_restJson1RobotSoftwareSuite(data.robotSoftwareSuite, context);
@@ -4645,7 +4648,7 @@ export const deserializeAws_restJson1DescribeSimulationApplicationCommand = asyn
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
   if (data.version !== undefined && data.version !== null) {
-    contents.version = data.version;
+    contents.version = __expectString(data.version);
   }
   return Promise.resolve(contents);
 };
@@ -4744,10 +4747,10 @@ export const deserializeAws_restJson1DescribeSimulationJobCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.clientRequestToken !== undefined && data.clientRequestToken !== null) {
-    contents.clientRequestToken = data.clientRequestToken;
+    contents.clientRequestToken = __expectString(data.clientRequestToken);
   }
   if (data.compute !== undefined && data.compute !== null) {
     contents.compute = deserializeAws_restJson1ComputeResponse(data.compute, context);
@@ -4756,16 +4759,16 @@ export const deserializeAws_restJson1DescribeSimulationJobCommand = async (
     contents.dataSources = deserializeAws_restJson1DataSources(data.dataSources, context);
   }
   if (data.failureBehavior !== undefined && data.failureBehavior !== null) {
-    contents.failureBehavior = data.failureBehavior;
+    contents.failureBehavior = __expectString(data.failureBehavior);
   }
   if (data.failureCode !== undefined && data.failureCode !== null) {
-    contents.failureCode = data.failureCode;
+    contents.failureCode = __expectString(data.failureCode);
   }
   if (data.failureReason !== undefined && data.failureReason !== null) {
-    contents.failureReason = data.failureReason;
+    contents.failureReason = __expectString(data.failureReason);
   }
   if (data.iamRole !== undefined && data.iamRole !== null) {
-    contents.iamRole = data.iamRole;
+    contents.iamRole = __expectString(data.iamRole);
   }
   if (data.lastStartedAt !== undefined && data.lastStartedAt !== null) {
     contents.lastStartedAt = new Date(Math.round(data.lastStartedAt * 1000));
@@ -4777,10 +4780,10 @@ export const deserializeAws_restJson1DescribeSimulationJobCommand = async (
     contents.loggingConfig = deserializeAws_restJson1LoggingConfig(data.loggingConfig, context);
   }
   if (data.maxJobDurationInSeconds !== undefined && data.maxJobDurationInSeconds !== null) {
-    contents.maxJobDurationInSeconds = data.maxJobDurationInSeconds;
+    contents.maxJobDurationInSeconds = __expectNumber(data.maxJobDurationInSeconds);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.networkInterface !== undefined && data.networkInterface !== null) {
     contents.networkInterface = deserializeAws_restJson1NetworkInterface(data.networkInterface, context);
@@ -4798,10 +4801,10 @@ export const deserializeAws_restJson1DescribeSimulationJobCommand = async (
     );
   }
   if (data.simulationTimeMillis !== undefined && data.simulationTimeMillis !== null) {
-    contents.simulationTimeMillis = data.simulationTimeMillis;
+    contents.simulationTimeMillis = __expectNumber(data.simulationTimeMillis);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.status = data.status;
+    contents.status = __expectString(data.status);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
@@ -4897,13 +4900,13 @@ export const deserializeAws_restJson1DescribeSimulationJobBatchCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.batchPolicy !== undefined && data.batchPolicy !== null) {
     contents.batchPolicy = deserializeAws_restJson1BatchPolicy(data.batchPolicy, context);
   }
   if (data.clientRequestToken !== undefined && data.clientRequestToken !== null) {
-    contents.clientRequestToken = data.clientRequestToken;
+    contents.clientRequestToken = __expectString(data.clientRequestToken);
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
     contents.createdAt = new Date(Math.round(data.createdAt * 1000));
@@ -4915,10 +4918,10 @@ export const deserializeAws_restJson1DescribeSimulationJobBatchCommand = async (
     contents.failedRequests = deserializeAws_restJson1FailedCreateSimulationJobRequests(data.failedRequests, context);
   }
   if (data.failureCode !== undefined && data.failureCode !== null) {
-    contents.failureCode = data.failureCode;
+    contents.failureCode = __expectString(data.failureCode);
   }
   if (data.failureReason !== undefined && data.failureReason !== null) {
-    contents.failureReason = data.failureReason;
+    contents.failureReason = __expectString(data.failureReason);
   }
   if (data.lastUpdatedAt !== undefined && data.lastUpdatedAt !== null) {
     contents.lastUpdatedAt = new Date(Math.round(data.lastUpdatedAt * 1000));
@@ -4927,7 +4930,7 @@ export const deserializeAws_restJson1DescribeSimulationJobBatchCommand = async (
     contents.pendingRequests = deserializeAws_restJson1CreateSimulationJobRequests(data.pendingRequests, context);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.status = data.status;
+    contents.status = __expectString(data.status);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
@@ -5005,19 +5008,19 @@ export const deserializeAws_restJson1DescribeWorldCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
     contents.createdAt = new Date(Math.round(data.createdAt * 1000));
   }
   if (data.generationJob !== undefined && data.generationJob !== null) {
-    contents.generationJob = data.generationJob;
+    contents.generationJob = __expectString(data.generationJob);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
   if (data.template !== undefined && data.template !== null) {
-    contents.template = data.template;
+    contents.template = __expectString(data.template);
   }
   return Promise.resolve(contents);
 };
@@ -5105,28 +5108,28 @@ export const deserializeAws_restJson1DescribeWorldExportJobCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.clientRequestToken !== undefined && data.clientRequestToken !== null) {
-    contents.clientRequestToken = data.clientRequestToken;
+    contents.clientRequestToken = __expectString(data.clientRequestToken);
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
     contents.createdAt = new Date(Math.round(data.createdAt * 1000));
   }
   if (data.failureCode !== undefined && data.failureCode !== null) {
-    contents.failureCode = data.failureCode;
+    contents.failureCode = __expectString(data.failureCode);
   }
   if (data.failureReason !== undefined && data.failureReason !== null) {
-    contents.failureReason = data.failureReason;
+    contents.failureReason = __expectString(data.failureReason);
   }
   if (data.iamRole !== undefined && data.iamRole !== null) {
-    contents.iamRole = data.iamRole;
+    contents.iamRole = __expectString(data.iamRole);
   }
   if (data.outputLocation !== undefined && data.outputLocation !== null) {
     contents.outputLocation = deserializeAws_restJson1OutputLocation(data.outputLocation, context);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.status = data.status;
+    contents.status = __expectString(data.status);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
@@ -5221,31 +5224,31 @@ export const deserializeAws_restJson1DescribeWorldGenerationJobCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.clientRequestToken !== undefined && data.clientRequestToken !== null) {
-    contents.clientRequestToken = data.clientRequestToken;
+    contents.clientRequestToken = __expectString(data.clientRequestToken);
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
     contents.createdAt = new Date(Math.round(data.createdAt * 1000));
   }
   if (data.failureCode !== undefined && data.failureCode !== null) {
-    contents.failureCode = data.failureCode;
+    contents.failureCode = __expectString(data.failureCode);
   }
   if (data.failureReason !== undefined && data.failureReason !== null) {
-    contents.failureReason = data.failureReason;
+    contents.failureReason = __expectString(data.failureReason);
   }
   if (data.finishedWorldsSummary !== undefined && data.finishedWorldsSummary !== null) {
     contents.finishedWorldsSummary = deserializeAws_restJson1FinishedWorldsSummary(data.finishedWorldsSummary, context);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.status = data.status;
+    contents.status = __expectString(data.status);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
   if (data.template !== undefined && data.template !== null) {
-    contents.template = data.template;
+    contents.template = __expectString(data.template);
   }
   if (data.worldCount !== undefined && data.worldCount !== null) {
     contents.worldCount = deserializeAws_restJson1WorldCount(data.worldCount, context);
@@ -5335,10 +5338,10 @@ export const deserializeAws_restJson1DescribeWorldTemplateCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.clientRequestToken !== undefined && data.clientRequestToken !== null) {
-    contents.clientRequestToken = data.clientRequestToken;
+    contents.clientRequestToken = __expectString(data.clientRequestToken);
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
     contents.createdAt = new Date(Math.round(data.createdAt * 1000));
@@ -5347,7 +5350,7 @@ export const deserializeAws_restJson1DescribeWorldTemplateCommand = async (
     contents.lastUpdatedAt = new Date(Math.round(data.lastUpdatedAt * 1000));
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
@@ -5429,7 +5432,7 @@ export const deserializeAws_restJson1GetWorldTemplateBodyCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.templateBody !== undefined && data.templateBody !== null) {
-    contents.templateBody = data.templateBody;
+    contents.templateBody = __expectString(data.templateBody);
   }
   return Promise.resolve(contents);
 };
@@ -5512,7 +5515,7 @@ export const deserializeAws_restJson1ListDeploymentJobsCommand = async (
     contents.deploymentJobs = deserializeAws_restJson1DeploymentJobs(data.deploymentJobs, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -5595,7 +5598,7 @@ export const deserializeAws_restJson1ListFleetsCommand = async (
     contents.fleetDetails = deserializeAws_restJson1Fleets(data.fleetDetails, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -5675,7 +5678,7 @@ export const deserializeAws_restJson1ListRobotApplicationsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.robotApplicationSummaries !== undefined && data.robotApplicationSummaries !== null) {
     contents.robotApplicationSummaries = deserializeAws_restJson1RobotApplicationSummaries(
@@ -5753,7 +5756,7 @@ export const deserializeAws_restJson1ListRobotsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.robots !== undefined && data.robots !== null) {
     contents.robots = deserializeAws_restJson1Robots(data.robots, context);
@@ -5836,7 +5839,7 @@ export const deserializeAws_restJson1ListSimulationApplicationsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.simulationApplicationSummaries !== undefined && data.simulationApplicationSummaries !== null) {
     contents.simulationApplicationSummaries = deserializeAws_restJson1SimulationApplicationSummaries(
@@ -5914,7 +5917,7 @@ export const deserializeAws_restJson1ListSimulationJobBatchesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.simulationJobBatchSummaries !== undefined && data.simulationJobBatchSummaries !== null) {
     contents.simulationJobBatchSummaries = deserializeAws_restJson1SimulationJobBatchSummaries(
@@ -5984,7 +5987,7 @@ export const deserializeAws_restJson1ListSimulationJobsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.simulationJobSummaries !== undefined && data.simulationJobSummaries !== null) {
     contents.simulationJobSummaries = deserializeAws_restJson1SimulationJobSummaries(
@@ -6141,7 +6144,7 @@ export const deserializeAws_restJson1ListWorldExportJobsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.worldExportJobSummaries !== undefined && data.worldExportJobSummaries !== null) {
     contents.worldExportJobSummaries = deserializeAws_restJson1WorldExportJobSummaries(
@@ -6219,7 +6222,7 @@ export const deserializeAws_restJson1ListWorldGenerationJobsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.worldGenerationJobSummaries !== undefined && data.worldGenerationJobSummaries !== null) {
     contents.worldGenerationJobSummaries = deserializeAws_restJson1WorldGenerationJobSummaries(
@@ -6297,7 +6300,7 @@ export const deserializeAws_restJson1ListWorldsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.worldSummaries !== undefined && data.worldSummaries !== null) {
     contents.worldSummaries = deserializeAws_restJson1WorldSummaries(data.worldSummaries, context);
@@ -6372,7 +6375,7 @@ export const deserializeAws_restJson1ListWorldTemplatesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.templateSummaries !== undefined && data.templateSummaries !== null) {
     contents.templateSummaries = deserializeAws_restJson1TemplateSummaries(data.templateSummaries, context);
@@ -6447,10 +6450,10 @@ export const deserializeAws_restJson1RegisterRobotCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.fleet !== undefined && data.fleet !== null) {
-    contents.fleet = data.fleet;
+    contents.fleet = __expectString(data.fleet);
   }
   if (data.robot !== undefined && data.robot !== null) {
-    contents.robot = data.robot;
+    contents.robot = __expectString(data.robot);
   }
   return Promise.resolve(contents);
 };
@@ -6630,13 +6633,13 @@ export const deserializeAws_restJson1StartSimulationJobBatchCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.batchPolicy !== undefined && data.batchPolicy !== null) {
     contents.batchPolicy = deserializeAws_restJson1BatchPolicy(data.batchPolicy, context);
   }
   if (data.clientRequestToken !== undefined && data.clientRequestToken !== null) {
-    contents.clientRequestToken = data.clientRequestToken;
+    contents.clientRequestToken = __expectString(data.clientRequestToken);
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
     contents.createdAt = new Date(Math.round(data.createdAt * 1000));
@@ -6648,16 +6651,16 @@ export const deserializeAws_restJson1StartSimulationJobBatchCommand = async (
     contents.failedRequests = deserializeAws_restJson1FailedCreateSimulationJobRequests(data.failedRequests, context);
   }
   if (data.failureCode !== undefined && data.failureCode !== null) {
-    contents.failureCode = data.failureCode;
+    contents.failureCode = __expectString(data.failureCode);
   }
   if (data.failureReason !== undefined && data.failureReason !== null) {
-    contents.failureReason = data.failureReason;
+    contents.failureReason = __expectString(data.failureReason);
   }
   if (data.pendingRequests !== undefined && data.pendingRequests !== null) {
     contents.pendingRequests = deserializeAws_restJson1CreateSimulationJobRequests(data.pendingRequests, context);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.status = data.status;
+    contents.status = __expectString(data.status);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
@@ -6754,7 +6757,7 @@ export const deserializeAws_restJson1SyncDeploymentJobCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
     contents.createdAt = new Date(Math.round(data.createdAt * 1000));
@@ -6769,16 +6772,16 @@ export const deserializeAws_restJson1SyncDeploymentJobCommand = async (
     contents.deploymentConfig = deserializeAws_restJson1DeploymentConfig(data.deploymentConfig, context);
   }
   if (data.failureCode !== undefined && data.failureCode !== null) {
-    contents.failureCode = data.failureCode;
+    contents.failureCode = __expectString(data.failureCode);
   }
   if (data.failureReason !== undefined && data.failureReason !== null) {
-    contents.failureReason = data.failureReason;
+    contents.failureReason = __expectString(data.failureReason);
   }
   if (data.fleet !== undefined && data.fleet !== null) {
-    contents.fleet = data.fleet;
+    contents.fleet = __expectString(data.fleet);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.status = data.status;
+    contents.status = __expectString(data.status);
   }
   return Promise.resolve(contents);
 };
@@ -7037,16 +7040,16 @@ export const deserializeAws_restJson1UpdateRobotApplicationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.lastUpdatedAt !== undefined && data.lastUpdatedAt !== null) {
     contents.lastUpdatedAt = new Date(Math.round(data.lastUpdatedAt * 1000));
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.revisionId !== undefined && data.revisionId !== null) {
-    contents.revisionId = data.revisionId;
+    contents.revisionId = __expectString(data.revisionId);
   }
   if (data.robotSoftwareSuite !== undefined && data.robotSoftwareSuite !== null) {
     contents.robotSoftwareSuite = deserializeAws_restJson1RobotSoftwareSuite(data.robotSoftwareSuite, context);
@@ -7055,7 +7058,7 @@ export const deserializeAws_restJson1UpdateRobotApplicationCommand = async (
     contents.sources = deserializeAws_restJson1Sources(data.sources, context);
   }
   if (data.version !== undefined && data.version !== null) {
-    contents.version = data.version;
+    contents.version = __expectString(data.version);
   }
   return Promise.resolve(contents);
 };
@@ -7150,19 +7153,19 @@ export const deserializeAws_restJson1UpdateSimulationApplicationCommand = async 
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.lastUpdatedAt !== undefined && data.lastUpdatedAt !== null) {
     contents.lastUpdatedAt = new Date(Math.round(data.lastUpdatedAt * 1000));
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.renderingEngine !== undefined && data.renderingEngine !== null) {
     contents.renderingEngine = deserializeAws_restJson1RenderingEngine(data.renderingEngine, context);
   }
   if (data.revisionId !== undefined && data.revisionId !== null) {
-    contents.revisionId = data.revisionId;
+    contents.revisionId = __expectString(data.revisionId);
   }
   if (data.robotSoftwareSuite !== undefined && data.robotSoftwareSuite !== null) {
     contents.robotSoftwareSuite = deserializeAws_restJson1RobotSoftwareSuite(data.robotSoftwareSuite, context);
@@ -7177,7 +7180,7 @@ export const deserializeAws_restJson1UpdateSimulationApplicationCommand = async 
     contents.sources = deserializeAws_restJson1Sources(data.sources, context);
   }
   if (data.version !== undefined && data.version !== null) {
-    contents.version = data.version;
+    contents.version = __expectString(data.version);
   }
   return Promise.resolve(contents);
 };
@@ -7267,7 +7270,7 @@ export const deserializeAws_restJson1UpdateWorldTemplateCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
     contents.createdAt = new Date(Math.round(data.createdAt * 1000));
@@ -7276,7 +7279,7 @@ export const deserializeAws_restJson1UpdateWorldTemplateCommand = async (
     contents.lastUpdatedAt = new Date(Math.round(data.lastUpdatedAt * 1000));
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   return Promise.resolve(contents);
 };
@@ -7354,7 +7357,7 @@ const deserializeAws_restJson1ConcurrentDeploymentExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -7371,7 +7374,7 @@ const deserializeAws_restJson1IdempotentParameterMismatchExceptionResponse = asy
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -7388,7 +7391,7 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -7405,7 +7408,7 @@ const deserializeAws_restJson1InvalidParameterExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -7422,7 +7425,7 @@ const deserializeAws_restJson1LimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -7439,7 +7442,7 @@ const deserializeAws_restJson1ResourceAlreadyExistsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -7456,7 +7459,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -7473,7 +7476,7 @@ const deserializeAws_restJson1ServiceUnavailableExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -7490,7 +7493,7 @@ const deserializeAws_restJson1ThrottlingExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -8031,34 +8034,26 @@ const deserializeAws_restJson1Arns = (output: any, context: __SerdeContext): str
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1BatchPolicy = (output: any, context: __SerdeContext): BatchPolicy => {
   return {
-    maxConcurrency:
-      output.maxConcurrency !== undefined && output.maxConcurrency !== null ? output.maxConcurrency : undefined,
-    timeoutInSeconds:
-      output.timeoutInSeconds !== undefined && output.timeoutInSeconds !== null ? output.timeoutInSeconds : undefined,
+    maxConcurrency: __expectNumber(output.maxConcurrency),
+    timeoutInSeconds: __expectNumber(output.timeoutInSeconds),
   } as any;
 };
 
 const deserializeAws_restJson1Compute = (output: any, context: __SerdeContext): Compute => {
   return {
-    simulationUnitLimit:
-      output.simulationUnitLimit !== undefined && output.simulationUnitLimit !== null
-        ? output.simulationUnitLimit
-        : undefined,
+    simulationUnitLimit: __expectNumber(output.simulationUnitLimit),
   } as any;
 };
 
 const deserializeAws_restJson1ComputeResponse = (output: any, context: __SerdeContext): ComputeResponse => {
   return {
-    simulationUnitLimit:
-      output.simulationUnitLimit !== undefined && output.simulationUnitLimit !== null
-        ? output.simulationUnitLimit
-        : undefined,
+    simulationUnitLimit: __expectNumber(output.simulationUnitLimit),
   } as any;
 };
 
@@ -8078,8 +8073,8 @@ const deserializeAws_restJson1CreateSimulationJobRequests = (
 
 const deserializeAws_restJson1DataSource = (output: any, context: __SerdeContext): DataSource => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    s3Bucket: output.s3Bucket !== undefined && output.s3Bucket !== null ? output.s3Bucket : undefined,
+    name: __expectString(output.name),
+    s3Bucket: __expectString(output.s3Bucket),
     s3Keys:
       output.s3Keys !== undefined && output.s3Keys !== null
         ? deserializeAws_restJson1S3KeyOutputs(output.s3Keys, context)
@@ -8089,8 +8084,8 @@ const deserializeAws_restJson1DataSource = (output: any, context: __SerdeContext
 
 const deserializeAws_restJson1DataSourceConfig = (output: any, context: __SerdeContext): DataSourceConfig => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    s3Bucket: output.s3Bucket !== undefined && output.s3Bucket !== null ? output.s3Bucket : undefined,
+    name: __expectString(output.name),
+    s3Bucket: __expectString(output.s3Bucket),
     s3Keys:
       output.s3Keys !== undefined && output.s3Keys !== null
         ? deserializeAws_restJson1S3Keys(output.s3Keys, context)
@@ -8116,7 +8111,7 @@ const deserializeAws_restJson1DataSourceNames = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -8136,11 +8131,8 @@ const deserializeAws_restJson1DeploymentApplicationConfig = (
   context: __SerdeContext
 ): DeploymentApplicationConfig => {
   return {
-    application: output.application !== undefined && output.application !== null ? output.application : undefined,
-    applicationVersion:
-      output.applicationVersion !== undefined && output.applicationVersion !== null
-        ? output.applicationVersion
-        : undefined,
+    application: __expectString(output.application),
+    applicationVersion: __expectString(output.applicationVersion),
     launchConfig:
       output.launchConfig !== undefined && output.launchConfig !== null
         ? deserializeAws_restJson1DeploymentLaunchConfig(output.launchConfig, context)
@@ -8164,28 +8156,19 @@ const deserializeAws_restJson1DeploymentApplicationConfigs = (
 
 const deserializeAws_restJson1DeploymentConfig = (output: any, context: __SerdeContext): DeploymentConfig => {
   return {
-    concurrentDeploymentPercentage:
-      output.concurrentDeploymentPercentage !== undefined && output.concurrentDeploymentPercentage !== null
-        ? output.concurrentDeploymentPercentage
-        : undefined,
+    concurrentDeploymentPercentage: __expectNumber(output.concurrentDeploymentPercentage),
     downloadConditionFile:
       output.downloadConditionFile !== undefined && output.downloadConditionFile !== null
         ? deserializeAws_restJson1S3Object(output.downloadConditionFile, context)
         : undefined,
-    failureThresholdPercentage:
-      output.failureThresholdPercentage !== undefined && output.failureThresholdPercentage !== null
-        ? output.failureThresholdPercentage
-        : undefined,
-    robotDeploymentTimeoutInSeconds:
-      output.robotDeploymentTimeoutInSeconds !== undefined && output.robotDeploymentTimeoutInSeconds !== null
-        ? output.robotDeploymentTimeoutInSeconds
-        : undefined,
+    failureThresholdPercentage: __expectNumber(output.failureThresholdPercentage),
+    robotDeploymentTimeoutInSeconds: __expectNumber(output.robotDeploymentTimeoutInSeconds),
   } as any;
 };
 
 const deserializeAws_restJson1DeploymentJob = (output: any, context: __SerdeContext): DeploymentJob => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
@@ -8198,11 +8181,10 @@ const deserializeAws_restJson1DeploymentJob = (output: any, context: __SerdeCont
       output.deploymentConfig !== undefined && output.deploymentConfig !== null
         ? deserializeAws_restJson1DeploymentConfig(output.deploymentConfig, context)
         : undefined,
-    failureCode: output.failureCode !== undefined && output.failureCode !== null ? output.failureCode : undefined,
-    failureReason:
-      output.failureReason !== undefined && output.failureReason !== null ? output.failureReason : undefined,
-    fleet: output.fleet !== undefined && output.fleet !== null ? output.fleet : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    failureCode: __expectString(output.failureCode),
+    failureReason: __expectString(output.failureReason),
+    fleet: __expectString(output.fleet),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -8226,12 +8208,10 @@ const deserializeAws_restJson1DeploymentLaunchConfig = (
       output.environmentVariables !== undefined && output.environmentVariables !== null
         ? deserializeAws_restJson1EnvironmentVariableMap(output.environmentVariables, context)
         : undefined,
-    launchFile: output.launchFile !== undefined && output.launchFile !== null ? output.launchFile : undefined,
-    packageName: output.packageName !== undefined && output.packageName !== null ? output.packageName : undefined,
-    postLaunchFile:
-      output.postLaunchFile !== undefined && output.postLaunchFile !== null ? output.postLaunchFile : undefined,
-    preLaunchFile:
-      output.preLaunchFile !== undefined && output.preLaunchFile !== null ? output.preLaunchFile : undefined,
+    launchFile: __expectString(output.launchFile),
+    packageName: __expectString(output.packageName),
+    postLaunchFile: __expectString(output.postLaunchFile),
+    preLaunchFile: __expectString(output.preLaunchFile),
   } as any;
 };
 
@@ -8245,7 +8225,7 @@ const deserializeAws_restJson1EnvironmentVariableMap = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -8259,9 +8239,8 @@ const deserializeAws_restJson1FailedCreateSimulationJobRequest = (
       output.failedAt !== undefined && output.failedAt !== null
         ? new Date(Math.round(output.failedAt * 1000))
         : undefined,
-    failureCode: output.failureCode !== undefined && output.failureCode !== null ? output.failureCode : undefined,
-    failureReason:
-      output.failureReason !== undefined && output.failureReason !== null ? output.failureReason : undefined,
+    failureCode: __expectString(output.failureCode),
+    failureReason: __expectString(output.failureReason),
     request:
       output.request !== undefined && output.request !== null
         ? deserializeAws_restJson1SimulationJobRequest(output.request, context)
@@ -8289,10 +8268,7 @@ const deserializeAws_restJson1FailureSummary = (output: any, context: __SerdeCon
       output.failures !== undefined && output.failures !== null
         ? deserializeAws_restJson1WorldFailures(output.failures, context)
         : undefined,
-    totalFailureCount:
-      output.totalFailureCount !== undefined && output.totalFailureCount !== null
-        ? output.totalFailureCount
-        : undefined,
+    totalFailureCount: __expectNumber(output.totalFailureCount),
   } as any;
 };
 
@@ -8302,8 +8278,7 @@ const deserializeAws_restJson1FinishedWorldsSummary = (output: any, context: __S
       output.failureSummary !== undefined && output.failureSummary !== null
         ? deserializeAws_restJson1FailureSummary(output.failureSummary, context)
         : undefined,
-    finishedCount:
-      output.finishedCount !== undefined && output.finishedCount !== null ? output.finishedCount : undefined,
+    finishedCount: __expectNumber(output.finishedCount),
     succeededWorlds:
       output.succeededWorlds !== undefined && output.succeededWorlds !== null
         ? deserializeAws_restJson1Arns(output.succeededWorlds, context)
@@ -8313,24 +8288,18 @@ const deserializeAws_restJson1FinishedWorldsSummary = (output: any, context: __S
 
 const deserializeAws_restJson1Fleet = (output: any, context: __SerdeContext): Fleet => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    lastDeploymentJob:
-      output.lastDeploymentJob !== undefined && output.lastDeploymentJob !== null
-        ? output.lastDeploymentJob
-        : undefined,
-    lastDeploymentStatus:
-      output.lastDeploymentStatus !== undefined && output.lastDeploymentStatus !== null
-        ? output.lastDeploymentStatus
-        : undefined,
+    lastDeploymentJob: __expectString(output.lastDeploymentJob),
+    lastDeploymentStatus: __expectString(output.lastDeploymentStatus),
     lastDeploymentTime:
       output.lastDeploymentTime !== undefined && output.lastDeploymentTime !== null
         ? new Date(Math.round(output.lastDeploymentTime * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -8351,42 +8320,34 @@ const deserializeAws_restJson1LaunchConfig = (output: any, context: __SerdeConte
       output.environmentVariables !== undefined && output.environmentVariables !== null
         ? deserializeAws_restJson1EnvironmentVariableMap(output.environmentVariables, context)
         : undefined,
-    launchFile: output.launchFile !== undefined && output.launchFile !== null ? output.launchFile : undefined,
-    packageName: output.packageName !== undefined && output.packageName !== null ? output.packageName : undefined,
+    launchFile: __expectString(output.launchFile),
+    packageName: __expectString(output.packageName),
     portForwardingConfig:
       output.portForwardingConfig !== undefined && output.portForwardingConfig !== null
         ? deserializeAws_restJson1PortForwardingConfig(output.portForwardingConfig, context)
         : undefined,
-    streamUI: output.streamUI !== undefined && output.streamUI !== null ? output.streamUI : undefined,
+    streamUI: __expectBoolean(output.streamUI),
   } as any;
 };
 
 const deserializeAws_restJson1LoggingConfig = (output: any, context: __SerdeContext): LoggingConfig => {
   return {
-    recordAllRosTopics:
-      output.recordAllRosTopics !== undefined && output.recordAllRosTopics !== null
-        ? output.recordAllRosTopics
-        : undefined,
+    recordAllRosTopics: __expectBoolean(output.recordAllRosTopics),
   } as any;
 };
 
 const deserializeAws_restJson1NetworkInterface = (output: any, context: __SerdeContext): NetworkInterface => {
   return {
-    networkInterfaceId:
-      output.networkInterfaceId !== undefined && output.networkInterfaceId !== null
-        ? output.networkInterfaceId
-        : undefined,
-    privateIpAddress:
-      output.privateIpAddress !== undefined && output.privateIpAddress !== null ? output.privateIpAddress : undefined,
-    publicIpAddress:
-      output.publicIpAddress !== undefined && output.publicIpAddress !== null ? output.publicIpAddress : undefined,
+    networkInterfaceId: __expectString(output.networkInterfaceId),
+    privateIpAddress: __expectString(output.privateIpAddress),
+    publicIpAddress: __expectString(output.publicIpAddress),
   } as any;
 };
 
 const deserializeAws_restJson1OutputLocation = (output: any, context: __SerdeContext): OutputLocation => {
   return {
-    s3Bucket: output.s3Bucket !== undefined && output.s3Bucket !== null ? output.s3Bucket : undefined,
-    s3Prefix: output.s3Prefix !== undefined && output.s3Prefix !== null ? output.s3Prefix : undefined,
+    s3Bucket: __expectString(output.s3Bucket),
+    s3Prefix: __expectString(output.s3Prefix),
   } as any;
 };
 
@@ -8401,11 +8362,9 @@ const deserializeAws_restJson1PortForwardingConfig = (output: any, context: __Se
 
 const deserializeAws_restJson1PortMapping = (output: any, context: __SerdeContext): PortMapping => {
   return {
-    applicationPort:
-      output.applicationPort !== undefined && output.applicationPort !== null ? output.applicationPort : undefined,
-    enableOnPublicIp:
-      output.enableOnPublicIp !== undefined && output.enableOnPublicIp !== null ? output.enableOnPublicIp : undefined,
-    jobPort: output.jobPort !== undefined && output.jobPort !== null ? output.jobPort : undefined,
+    applicationPort: __expectNumber(output.applicationPort),
+    enableOnPublicIp: __expectBoolean(output.enableOnPublicIp),
+    jobPort: __expectNumber(output.jobPort),
   } as any;
 };
 
@@ -8422,48 +8381,37 @@ const deserializeAws_restJson1PortMappingList = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1ProgressDetail = (output: any, context: __SerdeContext): ProgressDetail => {
   return {
-    currentProgress:
-      output.currentProgress !== undefined && output.currentProgress !== null ? output.currentProgress : undefined,
-    estimatedTimeRemainingSeconds:
-      output.estimatedTimeRemainingSeconds !== undefined && output.estimatedTimeRemainingSeconds !== null
-        ? output.estimatedTimeRemainingSeconds
-        : undefined,
-    percentDone: output.percentDone !== undefined && output.percentDone !== null ? output.percentDone : undefined,
-    targetResource:
-      output.targetResource !== undefined && output.targetResource !== null ? output.targetResource : undefined,
+    currentProgress: __expectString(output.currentProgress),
+    estimatedTimeRemainingSeconds: __expectNumber(output.estimatedTimeRemainingSeconds),
+    percentDone: __expectNumber(output.percentDone),
+    targetResource: __expectString(output.targetResource),
   } as any;
 };
 
 const deserializeAws_restJson1RenderingEngine = (output: any, context: __SerdeContext): RenderingEngine => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    name: __expectString(output.name),
+    version: __expectString(output.version),
   } as any;
 };
 
 const deserializeAws_restJson1Robot = (output: any, context: __SerdeContext): Robot => {
   return {
-    architecture: output.architecture !== undefined && output.architecture !== null ? output.architecture : undefined,
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    architecture: __expectString(output.architecture),
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    fleetArn: output.fleetArn !== undefined && output.fleetArn !== null ? output.fleetArn : undefined,
-    greenGrassGroupId:
-      output.greenGrassGroupId !== undefined && output.greenGrassGroupId !== null
-        ? output.greenGrassGroupId
-        : undefined,
-    lastDeploymentJob:
-      output.lastDeploymentJob !== undefined && output.lastDeploymentJob !== null
-        ? output.lastDeploymentJob
-        : undefined,
+    fleetArn: __expectString(output.fleetArn),
+    greenGrassGroupId: __expectString(output.greenGrassGroupId),
+    lastDeploymentJob: __expectString(output.lastDeploymentJob),
     lastDeploymentTime:
       output.lastDeploymentTime !== undefined && output.lastDeploymentTime !== null
         ? new Date(Math.round(output.lastDeploymentTime * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    name: __expectString(output.name),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -8472,11 +8420,8 @@ const deserializeAws_restJson1RobotApplicationConfig = (
   context: __SerdeContext
 ): RobotApplicationConfig => {
   return {
-    application: output.application !== undefined && output.application !== null ? output.application : undefined,
-    applicationVersion:
-      output.applicationVersion !== undefined && output.applicationVersion !== null
-        ? output.applicationVersion
-        : undefined,
+    application: __expectString(output.application),
+    applicationVersion: __expectString(output.applicationVersion),
     launchConfig:
       output.launchConfig !== undefined && output.launchConfig !== null
         ? deserializeAws_restJson1LaunchConfig(output.launchConfig, context)
@@ -8489,12 +8434,8 @@ const deserializeAws_restJson1RobotApplicationConfig = (
       output.uploadConfigurations !== undefined && output.uploadConfigurations !== null
         ? deserializeAws_restJson1UploadConfigurations(output.uploadConfigurations, context)
         : undefined,
-    useDefaultTools:
-      output.useDefaultTools !== undefined && output.useDefaultTools !== null ? output.useDefaultTools : undefined,
-    useDefaultUploadConfigurations:
-      output.useDefaultUploadConfigurations !== undefined && output.useDefaultUploadConfigurations !== null
-        ? output.useDefaultUploadConfigurations
-        : undefined,
+    useDefaultTools: __expectBoolean(output.useDefaultTools),
+    useDefaultUploadConfigurations: __expectBoolean(output.useDefaultUploadConfigurations),
   } as any;
 };
 
@@ -8519,7 +8460,7 @@ const deserializeAws_restJson1RobotApplicationNames = (output: any, context: __S
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -8542,23 +8483,23 @@ const deserializeAws_restJson1RobotApplicationSummary = (
   context: __SerdeContext
 ): RobotApplicationSummary => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
         ? new Date(Math.round(output.lastUpdatedAt * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
     robotSoftwareSuite:
       output.robotSoftwareSuite !== undefined && output.robotSoftwareSuite !== null
         ? deserializeAws_restJson1RobotSoftwareSuite(output.robotSoftwareSuite, context)
         : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    version: __expectString(output.version),
   } as any;
 };
 
 const deserializeAws_restJson1RobotDeployment = (output: any, context: __SerdeContext): RobotDeployment => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     deploymentFinishTime:
       output.deploymentFinishTime !== undefined && output.deploymentFinishTime !== null
         ? new Date(Math.round(output.deploymentFinishTime * 1000))
@@ -8567,14 +8508,13 @@ const deserializeAws_restJson1RobotDeployment = (output: any, context: __SerdeCo
       output.deploymentStartTime !== undefined && output.deploymentStartTime !== null
         ? new Date(Math.round(output.deploymentStartTime * 1000))
         : undefined,
-    failureCode: output.failureCode !== undefined && output.failureCode !== null ? output.failureCode : undefined,
-    failureReason:
-      output.failureReason !== undefined && output.failureReason !== null ? output.failureReason : undefined,
+    failureCode: __expectString(output.failureCode),
+    failureReason: __expectString(output.failureReason),
     progressDetail:
       output.progressDetail !== undefined && output.progressDetail !== null
         ? deserializeAws_restJson1ProgressDetail(output.progressDetail, context)
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -8602,15 +8542,15 @@ const deserializeAws_restJson1Robots = (output: any, context: __SerdeContext): R
 
 const deserializeAws_restJson1RobotSoftwareSuite = (output: any, context: __SerdeContext): RobotSoftwareSuite => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    name: __expectString(output.name),
+    version: __expectString(output.version),
   } as any;
 };
 
 const deserializeAws_restJson1S3KeyOutput = (output: any, context: __SerdeContext): S3KeyOutput => {
   return {
-    etag: output.etag !== undefined && output.etag !== null ? output.etag : undefined,
-    s3Key: output.s3Key !== undefined && output.s3Key !== null ? output.s3Key : undefined,
+    etag: __expectString(output.etag),
+    s3Key: __expectString(output.s3Key),
   } as any;
 };
 
@@ -8632,15 +8572,15 @@ const deserializeAws_restJson1S3Keys = (output: any, context: __SerdeContext): s
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1S3Object = (output: any, context: __SerdeContext): S3Object => {
   return {
-    bucket: output.bucket !== undefined && output.bucket !== null ? output.bucket : undefined,
-    etag: output.etag !== undefined && output.etag !== null ? output.etag : undefined,
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
+    bucket: __expectString(output.bucket),
+    etag: __expectString(output.etag),
+    key: __expectString(output.key),
   } as any;
 };
 
@@ -8651,7 +8591,7 @@ const deserializeAws_restJson1SecurityGroups = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -8660,11 +8600,8 @@ const deserializeAws_restJson1SimulationApplicationConfig = (
   context: __SerdeContext
 ): SimulationApplicationConfig => {
   return {
-    application: output.application !== undefined && output.application !== null ? output.application : undefined,
-    applicationVersion:
-      output.applicationVersion !== undefined && output.applicationVersion !== null
-        ? output.applicationVersion
-        : undefined,
+    application: __expectString(output.application),
+    applicationVersion: __expectString(output.applicationVersion),
     launchConfig:
       output.launchConfig !== undefined && output.launchConfig !== null
         ? deserializeAws_restJson1LaunchConfig(output.launchConfig, context)
@@ -8677,12 +8614,8 @@ const deserializeAws_restJson1SimulationApplicationConfig = (
       output.uploadConfigurations !== undefined && output.uploadConfigurations !== null
         ? deserializeAws_restJson1UploadConfigurations(output.uploadConfigurations, context)
         : undefined,
-    useDefaultTools:
-      output.useDefaultTools !== undefined && output.useDefaultTools !== null ? output.useDefaultTools : undefined,
-    useDefaultUploadConfigurations:
-      output.useDefaultUploadConfigurations !== undefined && output.useDefaultUploadConfigurations !== null
-        ? output.useDefaultUploadConfigurations
-        : undefined,
+    useDefaultTools: __expectBoolean(output.useDefaultTools),
+    useDefaultUploadConfigurations: __expectBoolean(output.useDefaultUploadConfigurations),
     worldConfigs:
       output.worldConfigs !== undefined && output.worldConfigs !== null
         ? deserializeAws_restJson1WorldConfigs(output.worldConfigs, context)
@@ -8711,7 +8644,7 @@ const deserializeAws_restJson1SimulationApplicationNames = (output: any, context
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -8734,12 +8667,12 @@ const deserializeAws_restJson1SimulationApplicationSummary = (
   context: __SerdeContext
 ): SimulationApplicationSummary => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
         ? new Date(Math.round(output.lastUpdatedAt * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
     robotSoftwareSuite:
       output.robotSoftwareSuite !== undefined && output.robotSoftwareSuite !== null
         ? deserializeAws_restJson1RobotSoftwareSuite(output.robotSoftwareSuite, context)
@@ -8748,17 +8681,14 @@ const deserializeAws_restJson1SimulationApplicationSummary = (
       output.simulationSoftwareSuite !== undefined && output.simulationSoftwareSuite !== null
         ? deserializeAws_restJson1SimulationSoftwareSuite(output.simulationSoftwareSuite, context)
         : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    version: __expectString(output.version),
   } as any;
 };
 
 const deserializeAws_restJson1SimulationJob = (output: any, context: __SerdeContext): SimulationJob => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    clientRequestToken:
-      output.clientRequestToken !== undefined && output.clientRequestToken !== null
-        ? output.clientRequestToken
-        : undefined,
+    arn: __expectString(output.arn),
+    clientRequestToken: __expectString(output.clientRequestToken),
     compute:
       output.compute !== undefined && output.compute !== null
         ? deserializeAws_restJson1ComputeResponse(output.compute, context)
@@ -8767,12 +8697,10 @@ const deserializeAws_restJson1SimulationJob = (output: any, context: __SerdeCont
       output.dataSources !== undefined && output.dataSources !== null
         ? deserializeAws_restJson1DataSources(output.dataSources, context)
         : undefined,
-    failureBehavior:
-      output.failureBehavior !== undefined && output.failureBehavior !== null ? output.failureBehavior : undefined,
-    failureCode: output.failureCode !== undefined && output.failureCode !== null ? output.failureCode : undefined,
-    failureReason:
-      output.failureReason !== undefined && output.failureReason !== null ? output.failureReason : undefined,
-    iamRole: output.iamRole !== undefined && output.iamRole !== null ? output.iamRole : undefined,
+    failureBehavior: __expectString(output.failureBehavior),
+    failureCode: __expectString(output.failureCode),
+    failureReason: __expectString(output.failureReason),
+    iamRole: __expectString(output.iamRole),
     lastStartedAt:
       output.lastStartedAt !== undefined && output.lastStartedAt !== null
         ? new Date(Math.round(output.lastStartedAt * 1000))
@@ -8785,11 +8713,8 @@ const deserializeAws_restJson1SimulationJob = (output: any, context: __SerdeCont
       output.loggingConfig !== undefined && output.loggingConfig !== null
         ? deserializeAws_restJson1LoggingConfig(output.loggingConfig, context)
         : undefined,
-    maxJobDurationInSeconds:
-      output.maxJobDurationInSeconds !== undefined && output.maxJobDurationInSeconds !== null
-        ? output.maxJobDurationInSeconds
-        : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    maxJobDurationInSeconds: __expectNumber(output.maxJobDurationInSeconds),
+    name: __expectString(output.name),
     networkInterface:
       output.networkInterface !== undefined && output.networkInterface !== null
         ? deserializeAws_restJson1NetworkInterface(output.networkInterface, context)
@@ -8806,11 +8731,8 @@ const deserializeAws_restJson1SimulationJob = (output: any, context: __SerdeCont
       output.simulationApplications !== undefined && output.simulationApplications !== null
         ? deserializeAws_restJson1SimulationApplicationConfigs(output.simulationApplications, context)
         : undefined,
-    simulationTimeMillis:
-      output.simulationTimeMillis !== undefined && output.simulationTimeMillis !== null
-        ? output.simulationTimeMillis
-        : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    simulationTimeMillis: __expectNumber(output.simulationTimeMillis),
+    status: __expectString(output.status),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1TagMap(output.tags, context)
@@ -8841,28 +8763,19 @@ const deserializeAws_restJson1SimulationJobBatchSummary = (
   context: __SerdeContext
 ): SimulationJobBatchSummary => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    createdRequestCount:
-      output.createdRequestCount !== undefined && output.createdRequestCount !== null
-        ? output.createdRequestCount
-        : undefined,
-    failedRequestCount:
-      output.failedRequestCount !== undefined && output.failedRequestCount !== null
-        ? output.failedRequestCount
-        : undefined,
+    createdRequestCount: __expectNumber(output.createdRequestCount),
+    failedRequestCount: __expectNumber(output.failedRequestCount),
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
         ? new Date(Math.round(output.lastUpdatedAt * 1000))
         : undefined,
-    pendingRequestCount:
-      output.pendingRequestCount !== undefined && output.pendingRequestCount !== null
-        ? output.pendingRequestCount
-        : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    pendingRequestCount: __expectNumber(output.pendingRequestCount),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -8876,17 +8789,13 @@ const deserializeAws_restJson1SimulationJobRequest = (output: any, context: __Se
       output.dataSources !== undefined && output.dataSources !== null
         ? deserializeAws_restJson1DataSourceConfigs(output.dataSources, context)
         : undefined,
-    failureBehavior:
-      output.failureBehavior !== undefined && output.failureBehavior !== null ? output.failureBehavior : undefined,
-    iamRole: output.iamRole !== undefined && output.iamRole !== null ? output.iamRole : undefined,
+    failureBehavior: __expectString(output.failureBehavior),
+    iamRole: __expectString(output.iamRole),
     loggingConfig:
       output.loggingConfig !== undefined && output.loggingConfig !== null
         ? deserializeAws_restJson1LoggingConfig(output.loggingConfig, context)
         : undefined,
-    maxJobDurationInSeconds:
-      output.maxJobDurationInSeconds !== undefined && output.maxJobDurationInSeconds !== null
-        ? output.maxJobDurationInSeconds
-        : undefined,
+    maxJobDurationInSeconds: __expectNumber(output.maxJobDurationInSeconds),
     outputLocation:
       output.outputLocation !== undefined && output.outputLocation !== null
         ? deserializeAws_restJson1OutputLocation(output.outputLocation, context)
@@ -8903,10 +8812,7 @@ const deserializeAws_restJson1SimulationJobRequest = (output: any, context: __Se
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1TagMap(output.tags, context)
         : undefined,
-    useDefaultApplications:
-      output.useDefaultApplications !== undefined && output.useDefaultApplications !== null
-        ? output.useDefaultApplications
-        : undefined,
+    useDefaultApplications: __expectBoolean(output.useDefaultApplications),
     vpcConfig:
       output.vpcConfig !== undefined && output.vpcConfig !== null
         ? deserializeAws_restJson1VPCConfig(output.vpcConfig, context)
@@ -8941,7 +8847,7 @@ const deserializeAws_restJson1SimulationJobSummaries = (
 
 const deserializeAws_restJson1SimulationJobSummary = (output: any, context: __SerdeContext): SimulationJobSummary => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     dataSourceNames:
       output.dataSourceNames !== undefined && output.dataSourceNames !== null
         ? deserializeAws_restJson1DataSourceNames(output.dataSourceNames, context)
@@ -8950,7 +8856,7 @@ const deserializeAws_restJson1SimulationJobSummary = (output: any, context: __Se
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
         ? new Date(Math.round(output.lastUpdatedAt * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
     robotApplicationNames:
       output.robotApplicationNames !== undefined && output.robotApplicationNames !== null
         ? deserializeAws_restJson1RobotApplicationNames(output.robotApplicationNames, context)
@@ -8959,7 +8865,7 @@ const deserializeAws_restJson1SimulationJobSummary = (output: any, context: __Se
       output.simulationApplicationNames !== undefined && output.simulationApplicationNames !== null
         ? deserializeAws_restJson1SimulationApplicationNames(output.simulationApplicationNames, context)
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -8968,17 +8874,17 @@ const deserializeAws_restJson1SimulationSoftwareSuite = (
   context: __SerdeContext
 ): SimulationSoftwareSuite => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    name: __expectString(output.name),
+    version: __expectString(output.version),
   } as any;
 };
 
 const deserializeAws_restJson1Source = (output: any, context: __SerdeContext): Source => {
   return {
-    architecture: output.architecture !== undefined && output.architecture !== null ? output.architecture : undefined,
-    etag: output.etag !== undefined && output.etag !== null ? output.etag : undefined,
-    s3Bucket: output.s3Bucket !== undefined && output.s3Bucket !== null ? output.s3Bucket : undefined,
-    s3Key: output.s3Key !== undefined && output.s3Key !== null ? output.s3Key : undefined,
+    architecture: __expectString(output.architecture),
+    etag: __expectString(output.etag),
+    s3Bucket: __expectString(output.s3Bucket),
+    s3Key: __expectString(output.s3Key),
   } as any;
 };
 
@@ -9000,7 +8906,7 @@ const deserializeAws_restJson1Subnets = (output: any, context: __SerdeContext): 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -9011,7 +8917,7 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -9029,7 +8935,7 @@ const deserializeAws_restJson1TemplateSummaries = (output: any, context: __Serde
 
 const deserializeAws_restJson1TemplateSummary = (output: any, context: __SerdeContext): TemplateSummary => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
@@ -9038,20 +8944,17 @@ const deserializeAws_restJson1TemplateSummary = (output: any, context: __SerdeCo
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
         ? new Date(Math.round(output.lastUpdatedAt * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
   } as any;
 };
 
 const deserializeAws_restJson1Tool = (output: any, context: __SerdeContext): Tool => {
   return {
-    command: output.command !== undefined && output.command !== null ? output.command : undefined,
-    exitBehavior: output.exitBehavior !== undefined && output.exitBehavior !== null ? output.exitBehavior : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    streamOutputToCloudWatch:
-      output.streamOutputToCloudWatch !== undefined && output.streamOutputToCloudWatch !== null
-        ? output.streamOutputToCloudWatch
-        : undefined,
-    streamUI: output.streamUI !== undefined && output.streamUI !== null ? output.streamUI : undefined,
+    command: __expectString(output.command),
+    exitBehavior: __expectString(output.exitBehavior),
+    name: __expectString(output.name),
+    streamOutputToCloudWatch: __expectBoolean(output.streamOutputToCloudWatch),
+    streamUI: __expectBoolean(output.streamUI),
   } as any;
 };
 
@@ -9068,10 +8971,9 @@ const deserializeAws_restJson1Tools = (output: any, context: __SerdeContext): To
 
 const deserializeAws_restJson1UploadConfiguration = (output: any, context: __SerdeContext): UploadConfiguration => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    path: output.path !== undefined && output.path !== null ? output.path : undefined,
-    uploadBehavior:
-      output.uploadBehavior !== undefined && output.uploadBehavior !== null ? output.uploadBehavior : undefined,
+    name: __expectString(output.name),
+    path: __expectString(output.path),
+    uploadBehavior: __expectString(output.uploadBehavior),
   } as any;
 };
 
@@ -9088,8 +8990,7 @@ const deserializeAws_restJson1UploadConfigurations = (output: any, context: __Se
 
 const deserializeAws_restJson1VPCConfig = (output: any, context: __SerdeContext): VPCConfig => {
   return {
-    assignPublicIp:
-      output.assignPublicIp !== undefined && output.assignPublicIp !== null ? output.assignPublicIp : undefined,
+    assignPublicIp: __expectBoolean(output.assignPublicIp),
     securityGroups:
       output.securityGroups !== undefined && output.securityGroups !== null
         ? deserializeAws_restJson1SecurityGroups(output.securityGroups, context)
@@ -9103,8 +9004,7 @@ const deserializeAws_restJson1VPCConfig = (output: any, context: __SerdeContext)
 
 const deserializeAws_restJson1VPCConfigResponse = (output: any, context: __SerdeContext): VPCConfigResponse => {
   return {
-    assignPublicIp:
-      output.assignPublicIp !== undefined && output.assignPublicIp !== null ? output.assignPublicIp : undefined,
+    assignPublicIp: __expectBoolean(output.assignPublicIp),
     securityGroups:
       output.securityGroups !== undefined && output.securityGroups !== null
         ? deserializeAws_restJson1SecurityGroups(output.securityGroups, context)
@@ -9113,13 +9013,13 @@ const deserializeAws_restJson1VPCConfigResponse = (output: any, context: __Serde
       output.subnets !== undefined && output.subnets !== null
         ? deserializeAws_restJson1Subnets(output.subnets, context)
         : undefined,
-    vpcId: output.vpcId !== undefined && output.vpcId !== null ? output.vpcId : undefined,
+    vpcId: __expectString(output.vpcId),
   } as any;
 };
 
 const deserializeAws_restJson1WorldConfig = (output: any, context: __SerdeContext): WorldConfig => {
   return {
-    world: output.world !== undefined && output.world !== null ? output.world : undefined,
+    world: __expectString(output.world),
   } as any;
 };
 
@@ -9136,12 +9036,8 @@ const deserializeAws_restJson1WorldConfigs = (output: any, context: __SerdeConte
 
 const deserializeAws_restJson1WorldCount = (output: any, context: __SerdeContext): WorldCount => {
   return {
-    floorplanCount:
-      output.floorplanCount !== undefined && output.floorplanCount !== null ? output.floorplanCount : undefined,
-    interiorCountPerFloorplan:
-      output.interiorCountPerFloorplan !== undefined && output.interiorCountPerFloorplan !== null
-        ? output.interiorCountPerFloorplan
-        : undefined,
+    floorplanCount: __expectNumber(output.floorplanCount),
+    interiorCountPerFloorplan: __expectNumber(output.interiorCountPerFloorplan),
   } as any;
 };
 
@@ -9161,12 +9057,12 @@ const deserializeAws_restJson1WorldExportJobSummaries = (
 
 const deserializeAws_restJson1WorldExportJobSummary = (output: any, context: __SerdeContext): WorldExportJobSummary => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
     worlds:
       output.worlds !== undefined && output.worlds !== null
         ? deserializeAws_restJson1Arns(output.worlds, context)
@@ -9176,12 +9072,9 @@ const deserializeAws_restJson1WorldExportJobSummary = (output: any, context: __S
 
 const deserializeAws_restJson1WorldFailure = (output: any, context: __SerdeContext): WorldFailure => {
   return {
-    failureCode: output.failureCode !== undefined && output.failureCode !== null ? output.failureCode : undefined,
-    failureCount: output.failureCount !== undefined && output.failureCount !== null ? output.failureCount : undefined,
-    sampleFailureReason:
-      output.sampleFailureReason !== undefined && output.sampleFailureReason !== null
-        ? output.sampleFailureReason
-        : undefined,
+    failureCode: __expectString(output.failureCode),
+    failureCount: __expectNumber(output.failureCount),
+    sampleFailureReason: __expectString(output.sampleFailureReason),
   } as any;
 };
 
@@ -9215,19 +9108,15 @@ const deserializeAws_restJson1WorldGenerationJobSummary = (
   context: __SerdeContext
 ): WorldGenerationJobSummary => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    failedWorldCount:
-      output.failedWorldCount !== undefined && output.failedWorldCount !== null ? output.failedWorldCount : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    succeededWorldCount:
-      output.succeededWorldCount !== undefined && output.succeededWorldCount !== null
-        ? output.succeededWorldCount
-        : undefined,
-    template: output.template !== undefined && output.template !== null ? output.template : undefined,
+    failedWorldCount: __expectNumber(output.failedWorldCount),
+    status: __expectString(output.status),
+    succeededWorldCount: __expectNumber(output.succeededWorldCount),
+    template: __expectString(output.template),
     worldCount:
       output.worldCount !== undefined && output.worldCount !== null
         ? deserializeAws_restJson1WorldCount(output.worldCount, context)
@@ -9248,14 +9137,13 @@ const deserializeAws_restJson1WorldSummaries = (output: any, context: __SerdeCon
 
 const deserializeAws_restJson1WorldSummary = (output: any, context: __SerdeContext): WorldSummary => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    generationJob:
-      output.generationJob !== undefined && output.generationJob !== null ? output.generationJob : undefined,
-    template: output.template !== undefined && output.template !== null ? output.template : undefined,
+    generationJob: __expectString(output.generationJob),
+    template: __expectString(output.template),
   } as any;
 };
 

--- a/clients/client-route-53-domains/protocols/Aws_json1_1.ts
+++ b/clients/client-route-53-domains/protocols/Aws_json1_1.ts
@@ -157,7 +157,12 @@ import {
   ViewBillingResponse,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -3010,7 +3015,7 @@ const deserializeAws_json1_1AcceptDomainTransferFromAnotherAwsAccountResponse = 
   context: __SerdeContext
 ): AcceptDomainTransferFromAnotherAwsAccountResponse => {
   return {
-    OperationId: output.OperationId !== undefined && output.OperationId !== null ? output.OperationId : undefined,
+    OperationId: __expectString(output.OperationId),
   } as any;
 };
 
@@ -3020,10 +3025,10 @@ const deserializeAws_json1_1BillingRecord = (output: any, context: __SerdeContex
       output.BillDate !== undefined && output.BillDate !== null
         ? new Date(Math.round(output.BillDate * 1000))
         : undefined,
-    DomainName: output.DomainName !== undefined && output.DomainName !== null ? output.DomainName : undefined,
-    InvoiceId: output.InvoiceId !== undefined && output.InvoiceId !== null ? output.InvoiceId : undefined,
-    Operation: output.Operation !== undefined && output.Operation !== null ? output.Operation : undefined,
-    Price: output.Price !== undefined && output.Price !== null ? output.Price : undefined,
+    DomainName: __expectString(output.DomainName),
+    InvoiceId: __expectString(output.InvoiceId),
+    Operation: __expectString(output.Operation),
+    Price: __expectNumber(output.Price),
   } as any;
 };
 
@@ -3043,7 +3048,7 @@ const deserializeAws_json1_1CancelDomainTransferToAnotherAwsAccountResponse = (
   context: __SerdeContext
 ): CancelDomainTransferToAnotherAwsAccountResponse => {
   return {
-    OperationId: output.OperationId !== undefined && output.OperationId !== null ? output.OperationId : undefined,
+    OperationId: __expectString(output.OperationId),
   } as any;
 };
 
@@ -3052,7 +3057,7 @@ const deserializeAws_json1_1CheckDomainAvailabilityResponse = (
   context: __SerdeContext
 ): CheckDomainAvailabilityResponse => {
   return {
-    Availability: output.Availability !== undefined && output.Availability !== null ? output.Availability : undefined,
+    Availability: __expectString(output.Availability),
   } as any;
 };
 
@@ -3070,24 +3075,23 @@ const deserializeAws_json1_1CheckDomainTransferabilityResponse = (
 
 const deserializeAws_json1_1ContactDetail = (output: any, context: __SerdeContext): ContactDetail => {
   return {
-    AddressLine1: output.AddressLine1 !== undefined && output.AddressLine1 !== null ? output.AddressLine1 : undefined,
-    AddressLine2: output.AddressLine2 !== undefined && output.AddressLine2 !== null ? output.AddressLine2 : undefined,
-    City: output.City !== undefined && output.City !== null ? output.City : undefined,
-    ContactType: output.ContactType !== undefined && output.ContactType !== null ? output.ContactType : undefined,
-    CountryCode: output.CountryCode !== undefined && output.CountryCode !== null ? output.CountryCode : undefined,
-    Email: output.Email !== undefined && output.Email !== null ? output.Email : undefined,
+    AddressLine1: __expectString(output.AddressLine1),
+    AddressLine2: __expectString(output.AddressLine2),
+    City: __expectString(output.City),
+    ContactType: __expectString(output.ContactType),
+    CountryCode: __expectString(output.CountryCode),
+    Email: __expectString(output.Email),
     ExtraParams:
       output.ExtraParams !== undefined && output.ExtraParams !== null
         ? deserializeAws_json1_1ExtraParamList(output.ExtraParams, context)
         : undefined,
-    Fax: output.Fax !== undefined && output.Fax !== null ? output.Fax : undefined,
-    FirstName: output.FirstName !== undefined && output.FirstName !== null ? output.FirstName : undefined,
-    LastName: output.LastName !== undefined && output.LastName !== null ? output.LastName : undefined,
-    OrganizationName:
-      output.OrganizationName !== undefined && output.OrganizationName !== null ? output.OrganizationName : undefined,
-    PhoneNumber: output.PhoneNumber !== undefined && output.PhoneNumber !== null ? output.PhoneNumber : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    ZipCode: output.ZipCode !== undefined && output.ZipCode !== null ? output.ZipCode : undefined,
+    Fax: __expectString(output.Fax),
+    FirstName: __expectString(output.FirstName),
+    LastName: __expectString(output.LastName),
+    OrganizationName: __expectString(output.OrganizationName),
+    PhoneNumber: __expectString(output.PhoneNumber),
+    State: __expectString(output.State),
+    ZipCode: __expectString(output.ZipCode),
   } as any;
 };
 
@@ -3110,13 +3114,13 @@ const deserializeAws_json1_1DisableDomainTransferLockResponse = (
   context: __SerdeContext
 ): DisableDomainTransferLockResponse => {
   return {
-    OperationId: output.OperationId !== undefined && output.OperationId !== null ? output.OperationId : undefined,
+    OperationId: __expectString(output.OperationId),
   } as any;
 };
 
 const deserializeAws_json1_1DomainLimitExceeded = (output: any, context: __SerdeContext): DomainLimitExceeded => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3127,14 +3131,14 @@ const deserializeAws_json1_1DomainStatusList = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1DomainSuggestion = (output: any, context: __SerdeContext): DomainSuggestion => {
   return {
-    Availability: output.Availability !== undefined && output.Availability !== null ? output.Availability : undefined,
-    DomainName: output.DomainName !== undefined && output.DomainName !== null ? output.DomainName : undefined,
+    Availability: __expectString(output.Availability),
+    DomainName: __expectString(output.DomainName),
   } as any;
 };
 
@@ -3151,11 +3155,11 @@ const deserializeAws_json1_1DomainSuggestionsList = (output: any, context: __Ser
 
 const deserializeAws_json1_1DomainSummary = (output: any, context: __SerdeContext): DomainSummary => {
   return {
-    AutoRenew: output.AutoRenew !== undefined && output.AutoRenew !== null ? output.AutoRenew : undefined,
-    DomainName: output.DomainName !== undefined && output.DomainName !== null ? output.DomainName : undefined,
+    AutoRenew: __expectBoolean(output.AutoRenew),
+    DomainName: __expectString(output.DomainName),
     Expiry:
       output.Expiry !== undefined && output.Expiry !== null ? new Date(Math.round(output.Expiry * 1000)) : undefined,
-    TransferLock: output.TransferLock !== undefined && output.TransferLock !== null ? output.TransferLock : undefined,
+    TransferLock: __expectBoolean(output.TransferLock),
   } as any;
 };
 
@@ -3172,13 +3176,13 @@ const deserializeAws_json1_1DomainSummaryList = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1DomainTransferability = (output: any, context: __SerdeContext): DomainTransferability => {
   return {
-    Transferable: output.Transferable !== undefined && output.Transferable !== null ? output.Transferable : undefined,
+    Transferable: __expectString(output.Transferable),
   } as any;
 };
 
 const deserializeAws_json1_1DuplicateRequest = (output: any, context: __SerdeContext): DuplicateRequest => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3194,14 +3198,14 @@ const deserializeAws_json1_1EnableDomainTransferLockResponse = (
   context: __SerdeContext
 ): EnableDomainTransferLockResponse => {
   return {
-    OperationId: output.OperationId !== undefined && output.OperationId !== null ? output.OperationId : undefined,
+    OperationId: __expectString(output.OperationId),
   } as any;
 };
 
 const deserializeAws_json1_1ExtraParam = (output: any, context: __SerdeContext): ExtraParam => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Name: __expectString(output.Name),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -3221,8 +3225,8 @@ const deserializeAws_json1_1GetContactReachabilityStatusResponse = (
   context: __SerdeContext
 ): GetContactReachabilityStatusResponse => {
   return {
-    domainName: output.domainName !== undefined && output.domainName !== null ? output.domainName : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    domainName: __expectString(output.domainName),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -3231,26 +3235,20 @@ const deserializeAws_json1_1GetDomainDetailResponse = (
   context: __SerdeContext
 ): GetDomainDetailResponse => {
   return {
-    AbuseContactEmail:
-      output.AbuseContactEmail !== undefined && output.AbuseContactEmail !== null
-        ? output.AbuseContactEmail
-        : undefined,
-    AbuseContactPhone:
-      output.AbuseContactPhone !== undefined && output.AbuseContactPhone !== null
-        ? output.AbuseContactPhone
-        : undefined,
+    AbuseContactEmail: __expectString(output.AbuseContactEmail),
+    AbuseContactPhone: __expectString(output.AbuseContactPhone),
     AdminContact:
       output.AdminContact !== undefined && output.AdminContact !== null
         ? deserializeAws_json1_1ContactDetail(output.AdminContact, context)
         : undefined,
-    AdminPrivacy: output.AdminPrivacy !== undefined && output.AdminPrivacy !== null ? output.AdminPrivacy : undefined,
-    AutoRenew: output.AutoRenew !== undefined && output.AutoRenew !== null ? output.AutoRenew : undefined,
+    AdminPrivacy: __expectBoolean(output.AdminPrivacy),
+    AutoRenew: __expectBoolean(output.AutoRenew),
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
         ? new Date(Math.round(output.CreationDate * 1000))
         : undefined,
-    DnsSec: output.DnsSec !== undefined && output.DnsSec !== null ? output.DnsSec : undefined,
-    DomainName: output.DomainName !== undefined && output.DomainName !== null ? output.DomainName : undefined,
+    DnsSec: __expectString(output.DnsSec),
+    DomainName: __expectString(output.DomainName),
     ExpirationDate:
       output.ExpirationDate !== undefined && output.ExpirationDate !== null
         ? new Date(Math.round(output.ExpirationDate * 1000))
@@ -3263,16 +3261,11 @@ const deserializeAws_json1_1GetDomainDetailResponse = (
       output.RegistrantContact !== undefined && output.RegistrantContact !== null
         ? deserializeAws_json1_1ContactDetail(output.RegistrantContact, context)
         : undefined,
-    RegistrantPrivacy:
-      output.RegistrantPrivacy !== undefined && output.RegistrantPrivacy !== null
-        ? output.RegistrantPrivacy
-        : undefined,
-    RegistrarName:
-      output.RegistrarName !== undefined && output.RegistrarName !== null ? output.RegistrarName : undefined,
-    RegistrarUrl: output.RegistrarUrl !== undefined && output.RegistrarUrl !== null ? output.RegistrarUrl : undefined,
-    RegistryDomainId:
-      output.RegistryDomainId !== undefined && output.RegistryDomainId !== null ? output.RegistryDomainId : undefined,
-    Reseller: output.Reseller !== undefined && output.Reseller !== null ? output.Reseller : undefined,
+    RegistrantPrivacy: __expectBoolean(output.RegistrantPrivacy),
+    RegistrarName: __expectString(output.RegistrarName),
+    RegistrarUrl: __expectString(output.RegistrarUrl),
+    RegistryDomainId: __expectString(output.RegistryDomainId),
+    Reseller: __expectString(output.Reseller),
     StatusList:
       output.StatusList !== undefined && output.StatusList !== null
         ? deserializeAws_json1_1DomainStatusList(output.StatusList, context)
@@ -3281,12 +3274,12 @@ const deserializeAws_json1_1GetDomainDetailResponse = (
       output.TechContact !== undefined && output.TechContact !== null
         ? deserializeAws_json1_1ContactDetail(output.TechContact, context)
         : undefined,
-    TechPrivacy: output.TechPrivacy !== undefined && output.TechPrivacy !== null ? output.TechPrivacy : undefined,
+    TechPrivacy: __expectBoolean(output.TechPrivacy),
     UpdatedDate:
       output.UpdatedDate !== undefined && output.UpdatedDate !== null
         ? new Date(Math.round(output.UpdatedDate * 1000))
         : undefined,
-    WhoIsServer: output.WhoIsServer !== undefined && output.WhoIsServer !== null ? output.WhoIsServer : undefined,
+    WhoIsServer: __expectString(output.WhoIsServer),
   } as any;
 };
 
@@ -3307,15 +3300,15 @@ const deserializeAws_json1_1GetOperationDetailResponse = (
   context: __SerdeContext
 ): GetOperationDetailResponse => {
   return {
-    DomainName: output.DomainName !== undefined && output.DomainName !== null ? output.DomainName : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    OperationId: output.OperationId !== undefined && output.OperationId !== null ? output.OperationId : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    DomainName: __expectString(output.DomainName),
+    Message: __expectString(output.Message),
+    OperationId: __expectString(output.OperationId),
+    Status: __expectString(output.Status),
     SubmittedDate:
       output.SubmittedDate !== undefined && output.SubmittedDate !== null
         ? new Date(Math.round(output.SubmittedDate * 1000))
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -3326,13 +3319,13 @@ const deserializeAws_json1_1GlueIpList = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1InvalidInput = (output: any, context: __SerdeContext): InvalidInput => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3342,15 +3335,13 @@ const deserializeAws_json1_1ListDomainsResponse = (output: any, context: __Serde
       output.Domains !== undefined && output.Domains !== null
         ? deserializeAws_json1_1DomainSummaryList(output.Domains, context)
         : undefined,
-    NextPageMarker:
-      output.NextPageMarker !== undefined && output.NextPageMarker !== null ? output.NextPageMarker : undefined,
+    NextPageMarker: __expectString(output.NextPageMarker),
   } as any;
 };
 
 const deserializeAws_json1_1ListOperationsResponse = (output: any, context: __SerdeContext): ListOperationsResponse => {
   return {
-    NextPageMarker:
-      output.NextPageMarker !== undefined && output.NextPageMarker !== null ? output.NextPageMarker : undefined,
+    NextPageMarker: __expectString(output.NextPageMarker),
     Operations:
       output.Operations !== undefined && output.Operations !== null
         ? deserializeAws_json1_1OperationSummaryList(output.Operations, context)
@@ -3376,7 +3367,7 @@ const deserializeAws_json1_1Nameserver = (output: any, context: __SerdeContext):
       output.GlueIps !== undefined && output.GlueIps !== null
         ? deserializeAws_json1_1GlueIpList(output.GlueIps, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -3393,19 +3384,19 @@ const deserializeAws_json1_1NameserverList = (output: any, context: __SerdeConte
 
 const deserializeAws_json1_1OperationLimitExceeded = (output: any, context: __SerdeContext): OperationLimitExceeded => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1OperationSummary = (output: any, context: __SerdeContext): OperationSummary => {
   return {
-    OperationId: output.OperationId !== undefined && output.OperationId !== null ? output.OperationId : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    OperationId: __expectString(output.OperationId),
+    Status: __expectString(output.Status),
     SubmittedDate:
       output.SubmittedDate !== undefined && output.SubmittedDate !== null
         ? new Date(Math.round(output.SubmittedDate * 1000))
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -3422,7 +3413,7 @@ const deserializeAws_json1_1OperationSummaryList = (output: any, context: __Serd
 
 const deserializeAws_json1_1RegisterDomainResponse = (output: any, context: __SerdeContext): RegisterDomainResponse => {
   return {
-    OperationId: output.OperationId !== undefined && output.OperationId !== null ? output.OperationId : undefined,
+    OperationId: __expectString(output.OperationId),
   } as any;
 };
 
@@ -3431,13 +3422,13 @@ const deserializeAws_json1_1RejectDomainTransferFromAnotherAwsAccountResponse = 
   context: __SerdeContext
 ): RejectDomainTransferFromAnotherAwsAccountResponse => {
   return {
-    OperationId: output.OperationId !== undefined && output.OperationId !== null ? output.OperationId : undefined,
+    OperationId: __expectString(output.OperationId),
   } as any;
 };
 
 const deserializeAws_json1_1RenewDomainResponse = (output: any, context: __SerdeContext): RenewDomainResponse => {
   return {
-    OperationId: output.OperationId !== undefined && output.OperationId !== null ? output.OperationId : undefined,
+    OperationId: __expectString(output.OperationId),
   } as any;
 };
 
@@ -3446,12 +3437,9 @@ const deserializeAws_json1_1ResendContactReachabilityEmailResponse = (
   context: __SerdeContext
 ): ResendContactReachabilityEmailResponse => {
   return {
-    domainName: output.domainName !== undefined && output.domainName !== null ? output.domainName : undefined,
-    emailAddress: output.emailAddress !== undefined && output.emailAddress !== null ? output.emailAddress : undefined,
-    isAlreadyVerified:
-      output.isAlreadyVerified !== undefined && output.isAlreadyVerified !== null
-        ? output.isAlreadyVerified
-        : undefined,
+    domainName: __expectString(output.domainName),
+    emailAddress: __expectString(output.emailAddress),
+    isAlreadyVerified: __expectBoolean(output.isAlreadyVerified),
   } as any;
 };
 
@@ -3460,14 +3448,14 @@ const deserializeAws_json1_1RetrieveDomainAuthCodeResponse = (
   context: __SerdeContext
 ): RetrieveDomainAuthCodeResponse => {
   return {
-    AuthCode: output.AuthCode !== undefined && output.AuthCode !== null ? output.AuthCode : undefined,
+    AuthCode: __expectString(output.AuthCode),
   } as any;
 };
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -3484,13 +3472,13 @@ const deserializeAws_json1_1TagList = (output: any, context: __SerdeContext): Ta
 
 const deserializeAws_json1_1TLDRulesViolation = (output: any, context: __SerdeContext): TLDRulesViolation => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1TransferDomainResponse = (output: any, context: __SerdeContext): TransferDomainResponse => {
   return {
-    OperationId: output.OperationId !== undefined && output.OperationId !== null ? output.OperationId : undefined,
+    OperationId: __expectString(output.OperationId),
   } as any;
 };
 
@@ -3499,14 +3487,14 @@ const deserializeAws_json1_1TransferDomainToAnotherAwsAccountResponse = (
   context: __SerdeContext
 ): TransferDomainToAnotherAwsAccountResponse => {
   return {
-    OperationId: output.OperationId !== undefined && output.OperationId !== null ? output.OperationId : undefined,
-    Password: output.Password !== undefined && output.Password !== null ? output.Password : undefined,
+    OperationId: __expectString(output.OperationId),
+    Password: __expectString(output.Password),
   } as any;
 };
 
 const deserializeAws_json1_1UnsupportedTLD = (output: any, context: __SerdeContext): UnsupportedTLD => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3515,7 +3503,7 @@ const deserializeAws_json1_1UpdateDomainContactPrivacyResponse = (
   context: __SerdeContext
 ): UpdateDomainContactPrivacyResponse => {
   return {
-    OperationId: output.OperationId !== undefined && output.OperationId !== null ? output.OperationId : undefined,
+    OperationId: __expectString(output.OperationId),
   } as any;
 };
 
@@ -3524,7 +3512,7 @@ const deserializeAws_json1_1UpdateDomainContactResponse = (
   context: __SerdeContext
 ): UpdateDomainContactResponse => {
   return {
-    OperationId: output.OperationId !== undefined && output.OperationId !== null ? output.OperationId : undefined,
+    OperationId: __expectString(output.OperationId),
   } as any;
 };
 
@@ -3533,7 +3521,7 @@ const deserializeAws_json1_1UpdateDomainNameserversResponse = (
   context: __SerdeContext
 ): UpdateDomainNameserversResponse => {
   return {
-    OperationId: output.OperationId !== undefined && output.OperationId !== null ? output.OperationId : undefined,
+    OperationId: __expectString(output.OperationId),
   } as any;
 };
 
@@ -3550,8 +3538,7 @@ const deserializeAws_json1_1ViewBillingResponse = (output: any, context: __Serde
       output.BillingRecords !== undefined && output.BillingRecords !== null
         ? deserializeAws_json1_1BillingRecords(output.BillingRecords, context)
         : undefined,
-    NextPageMarker:
-      output.NextPageMarker !== undefined && output.NextPageMarker !== null ? output.NextPageMarker : undefined,
+    NextPageMarker: __expectString(output.NextPageMarker),
   } as any;
 };
 

--- a/clients/client-route-53/protocols/Aws_restXml.ts
+++ b/clients/client-route-53/protocols/Aws_restXml.ts
@@ -300,6 +300,7 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
@@ -3704,7 +3705,7 @@ export const deserializeAws_restXmlCreateVPCAssociationAuthorizationCommand = as
   };
   const data: any = await parseBody(output.body, context);
   if (data["HostedZoneId"] !== undefined) {
-    contents.HostedZoneId = data["HostedZoneId"];
+    contents.HostedZoneId = __expectString(data["HostedZoneId"]);
   }
   if (data["VPC"] !== undefined) {
     contents.VPC = deserializeAws_restXmlVPC(data["VPC"], context);
@@ -5975,13 +5976,13 @@ export const deserializeAws_restXmlListGeoLocationsCommand = async (
     contents.MaxItems = parseInt(data["MaxItems"]);
   }
   if (data["NextContinentCode"] !== undefined) {
-    contents.NextContinentCode = data["NextContinentCode"];
+    contents.NextContinentCode = __expectString(data["NextContinentCode"]);
   }
   if (data["NextCountryCode"] !== undefined) {
-    contents.NextCountryCode = data["NextCountryCode"];
+    contents.NextCountryCode = __expectString(data["NextCountryCode"]);
   }
   if (data["NextSubdivisionCode"] !== undefined) {
-    contents.NextSubdivisionCode = data["NextSubdivisionCode"];
+    contents.NextSubdivisionCode = __expectString(data["NextSubdivisionCode"]);
   }
   return Promise.resolve(contents);
 };
@@ -6052,13 +6053,13 @@ export const deserializeAws_restXmlListHealthChecksCommand = async (
     contents.IsTruncated = __parseBoolean(data["IsTruncated"]);
   }
   if (data["Marker"] !== undefined) {
-    contents.Marker = data["Marker"];
+    contents.Marker = __expectString(data["Marker"]);
   }
   if (data["MaxItems"] !== undefined) {
     contents.MaxItems = parseInt(data["MaxItems"]);
   }
   if (data["NextMarker"] !== undefined) {
-    contents.NextMarker = data["NextMarker"];
+    contents.NextMarker = __expectString(data["NextMarker"]);
   }
   return Promise.resolve(contents);
 };
@@ -6137,13 +6138,13 @@ export const deserializeAws_restXmlListHostedZonesCommand = async (
     contents.IsTruncated = __parseBoolean(data["IsTruncated"]);
   }
   if (data["Marker"] !== undefined) {
-    contents.Marker = data["Marker"];
+    contents.Marker = __expectString(data["Marker"]);
   }
   if (data["MaxItems"] !== undefined) {
     contents.MaxItems = parseInt(data["MaxItems"]);
   }
   if (data["NextMarker"] !== undefined) {
-    contents.NextMarker = data["NextMarker"];
+    contents.NextMarker = __expectString(data["NextMarker"]);
   }
   return Promise.resolve(contents);
 };
@@ -6220,10 +6221,10 @@ export const deserializeAws_restXmlListHostedZonesByNameCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data["DNSName"] !== undefined) {
-    contents.DNSName = data["DNSName"];
+    contents.DNSName = __expectString(data["DNSName"]);
   }
   if (data["HostedZoneId"] !== undefined) {
-    contents.HostedZoneId = data["HostedZoneId"];
+    contents.HostedZoneId = __expectString(data["HostedZoneId"]);
   }
   if (data.HostedZones === "") {
     contents.HostedZones = [];
@@ -6241,10 +6242,10 @@ export const deserializeAws_restXmlListHostedZonesByNameCommand = async (
     contents.MaxItems = parseInt(data["MaxItems"]);
   }
   if (data["NextDNSName"] !== undefined) {
-    contents.NextDNSName = data["NextDNSName"];
+    contents.NextDNSName = __expectString(data["NextDNSName"]);
   }
   if (data["NextHostedZoneId"] !== undefined) {
-    contents.NextHostedZoneId = data["NextHostedZoneId"];
+    contents.NextHostedZoneId = __expectString(data["NextHostedZoneId"]);
   }
   return Promise.resolve(contents);
 };
@@ -6321,7 +6322,7 @@ export const deserializeAws_restXmlListHostedZonesByVPCCommand = async (
     contents.MaxItems = parseInt(data["MaxItems"]);
   }
   if (data["NextToken"] !== undefined) {
-    contents.NextToken = data["NextToken"];
+    contents.NextToken = __expectString(data["NextToken"]);
   }
   return Promise.resolve(contents);
 };
@@ -6385,7 +6386,7 @@ export const deserializeAws_restXmlListQueryLoggingConfigsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data["NextToken"] !== undefined) {
-    contents.NextToken = data["NextToken"];
+    contents.NextToken = __expectString(data["NextToken"]);
   }
   if (data.QueryLoggingConfigs === "") {
     contents.QueryLoggingConfigs = [];
@@ -6476,13 +6477,13 @@ export const deserializeAws_restXmlListResourceRecordSetsCommand = async (
     contents.MaxItems = parseInt(data["MaxItems"]);
   }
   if (data["NextRecordIdentifier"] !== undefined) {
-    contents.NextRecordIdentifier = data["NextRecordIdentifier"];
+    contents.NextRecordIdentifier = __expectString(data["NextRecordIdentifier"]);
   }
   if (data["NextRecordName"] !== undefined) {
-    contents.NextRecordName = data["NextRecordName"];
+    contents.NextRecordName = __expectString(data["NextRecordName"]);
   }
   if (data["NextRecordType"] !== undefined) {
-    contents.NextRecordType = data["NextRecordType"];
+    contents.NextRecordType = __expectString(data["NextRecordType"]);
   }
   if (data.ResourceRecordSets === "") {
     contents.ResourceRecordSets = [];
@@ -6570,13 +6571,13 @@ export const deserializeAws_restXmlListReusableDelegationSetsCommand = async (
     contents.IsTruncated = __parseBoolean(data["IsTruncated"]);
   }
   if (data["Marker"] !== undefined) {
-    contents.Marker = data["Marker"];
+    contents.Marker = __expectString(data["Marker"]);
   }
   if (data["MaxItems"] !== undefined) {
     contents.MaxItems = parseInt(data["MaxItems"]);
   }
   if (data["NextMarker"] !== undefined) {
-    contents.NextMarker = data["NextMarker"];
+    contents.NextMarker = __expectString(data["NextMarker"]);
   }
   return Promise.resolve(contents);
 };
@@ -6820,7 +6821,7 @@ export const deserializeAws_restXmlListTrafficPoliciesCommand = async (
     contents.MaxItems = parseInt(data["MaxItems"]);
   }
   if (data["TrafficPolicyIdMarker"] !== undefined) {
-    contents.TrafficPolicyIdMarker = data["TrafficPolicyIdMarker"];
+    contents.TrafficPolicyIdMarker = __expectString(data["TrafficPolicyIdMarker"]);
   }
   if (data.TrafficPolicySummaries === "") {
     contents.TrafficPolicySummaries = [];
@@ -6892,7 +6893,7 @@ export const deserializeAws_restXmlListTrafficPolicyInstancesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data["HostedZoneIdMarker"] !== undefined) {
-    contents.HostedZoneIdMarker = data["HostedZoneIdMarker"];
+    contents.HostedZoneIdMarker = __expectString(data["HostedZoneIdMarker"]);
   }
   if (data["IsTruncated"] !== undefined) {
     contents.IsTruncated = __parseBoolean(data["IsTruncated"]);
@@ -6901,10 +6902,10 @@ export const deserializeAws_restXmlListTrafficPolicyInstancesCommand = async (
     contents.MaxItems = parseInt(data["MaxItems"]);
   }
   if (data["TrafficPolicyInstanceNameMarker"] !== undefined) {
-    contents.TrafficPolicyInstanceNameMarker = data["TrafficPolicyInstanceNameMarker"];
+    contents.TrafficPolicyInstanceNameMarker = __expectString(data["TrafficPolicyInstanceNameMarker"]);
   }
   if (data["TrafficPolicyInstanceTypeMarker"] !== undefined) {
-    contents.TrafficPolicyInstanceTypeMarker = data["TrafficPolicyInstanceTypeMarker"];
+    contents.TrafficPolicyInstanceTypeMarker = __expectString(data["TrafficPolicyInstanceTypeMarker"]);
   }
   if (data.TrafficPolicyInstances === "") {
     contents.TrafficPolicyInstances = [];
@@ -6989,10 +6990,10 @@ export const deserializeAws_restXmlListTrafficPolicyInstancesByHostedZoneCommand
     contents.MaxItems = parseInt(data["MaxItems"]);
   }
   if (data["TrafficPolicyInstanceNameMarker"] !== undefined) {
-    contents.TrafficPolicyInstanceNameMarker = data["TrafficPolicyInstanceNameMarker"];
+    contents.TrafficPolicyInstanceNameMarker = __expectString(data["TrafficPolicyInstanceNameMarker"]);
   }
   if (data["TrafficPolicyInstanceTypeMarker"] !== undefined) {
-    contents.TrafficPolicyInstanceTypeMarker = data["TrafficPolicyInstanceTypeMarker"];
+    contents.TrafficPolicyInstanceTypeMarker = __expectString(data["TrafficPolicyInstanceTypeMarker"]);
   }
   if (data.TrafficPolicyInstances === "") {
     contents.TrafficPolicyInstances = [];
@@ -7080,7 +7081,7 @@ export const deserializeAws_restXmlListTrafficPolicyInstancesByPolicyCommand = a
   };
   const data: any = await parseBody(output.body, context);
   if (data["HostedZoneIdMarker"] !== undefined) {
-    contents.HostedZoneIdMarker = data["HostedZoneIdMarker"];
+    contents.HostedZoneIdMarker = __expectString(data["HostedZoneIdMarker"]);
   }
   if (data["IsTruncated"] !== undefined) {
     contents.IsTruncated = __parseBoolean(data["IsTruncated"]);
@@ -7089,10 +7090,10 @@ export const deserializeAws_restXmlListTrafficPolicyInstancesByPolicyCommand = a
     contents.MaxItems = parseInt(data["MaxItems"]);
   }
   if (data["TrafficPolicyInstanceNameMarker"] !== undefined) {
-    contents.TrafficPolicyInstanceNameMarker = data["TrafficPolicyInstanceNameMarker"];
+    contents.TrafficPolicyInstanceNameMarker = __expectString(data["TrafficPolicyInstanceNameMarker"]);
   }
   if (data["TrafficPolicyInstanceTypeMarker"] !== undefined) {
-    contents.TrafficPolicyInstanceTypeMarker = data["TrafficPolicyInstanceTypeMarker"];
+    contents.TrafficPolicyInstanceTypeMarker = __expectString(data["TrafficPolicyInstanceTypeMarker"]);
   }
   if (data.TrafficPolicyInstances === "") {
     contents.TrafficPolicyInstances = [];
@@ -7193,7 +7194,7 @@ export const deserializeAws_restXmlListTrafficPolicyVersionsCommand = async (
     );
   }
   if (data["TrafficPolicyVersionMarker"] !== undefined) {
-    contents.TrafficPolicyVersionMarker = data["TrafficPolicyVersionMarker"];
+    contents.TrafficPolicyVersionMarker = __expectString(data["TrafficPolicyVersionMarker"]);
   }
   return Promise.resolve(contents);
 };
@@ -7258,10 +7259,10 @@ export const deserializeAws_restXmlListVPCAssociationAuthorizationsCommand = asy
   };
   const data: any = await parseBody(output.body, context);
   if (data["HostedZoneId"] !== undefined) {
-    contents.HostedZoneId = data["HostedZoneId"];
+    contents.HostedZoneId = __expectString(data["HostedZoneId"]);
   }
   if (data["NextToken"] !== undefined) {
-    contents.NextToken = data["NextToken"];
+    contents.NextToken = __expectString(data["NextToken"]);
   }
   if (data.VPCs === "") {
     contents.VPCs = [];
@@ -7343,10 +7344,10 @@ export const deserializeAws_restXmlTestDNSAnswerCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data["Nameserver"] !== undefined) {
-    contents.Nameserver = data["Nameserver"];
+    contents.Nameserver = __expectString(data["Nameserver"]);
   }
   if (data["Protocol"] !== undefined) {
-    contents.Protocol = data["Protocol"];
+    contents.Protocol = __expectString(data["Protocol"]);
   }
   if (data.RecordData === "") {
     contents.RecordData = [];
@@ -7358,13 +7359,13 @@ export const deserializeAws_restXmlTestDNSAnswerCommand = async (
     );
   }
   if (data["RecordName"] !== undefined) {
-    contents.RecordName = data["RecordName"];
+    contents.RecordName = __expectString(data["RecordName"]);
   }
   if (data["RecordType"] !== undefined) {
-    contents.RecordType = data["RecordType"];
+    contents.RecordType = __expectString(data["RecordType"]);
   }
   if (data["ResponseCode"] !== undefined) {
-    contents.ResponseCode = data["ResponseCode"];
+    contents.ResponseCode = __expectString(data["ResponseCode"]);
   }
   return Promise.resolve(contents);
 };
@@ -7721,7 +7722,7 @@ const deserializeAws_restXmlConcurrentModificationResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -7738,7 +7739,7 @@ const deserializeAws_restXmlConflictingDomainExistsResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -7755,7 +7756,7 @@ const deserializeAws_restXmlConflictingTypesResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -7772,7 +7773,7 @@ const deserializeAws_restXmlDelegationSetAlreadyCreatedResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -7789,7 +7790,7 @@ const deserializeAws_restXmlDelegationSetAlreadyReusableResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -7806,7 +7807,7 @@ const deserializeAws_restXmlDelegationSetInUseResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -7823,7 +7824,7 @@ const deserializeAws_restXmlDelegationSetNotAvailableResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -7840,7 +7841,7 @@ const deserializeAws_restXmlDelegationSetNotReusableResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -7857,7 +7858,7 @@ const deserializeAws_restXmlDNSSECNotFoundResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -7874,7 +7875,7 @@ const deserializeAws_restXmlHealthCheckAlreadyExistsResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -7891,7 +7892,7 @@ const deserializeAws_restXmlHealthCheckInUseResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -7908,7 +7909,7 @@ const deserializeAws_restXmlHealthCheckVersionMismatchResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -7925,7 +7926,7 @@ const deserializeAws_restXmlHostedZoneAlreadyExistsResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -7942,7 +7943,7 @@ const deserializeAws_restXmlHostedZoneNotEmptyResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -7959,7 +7960,7 @@ const deserializeAws_restXmlHostedZoneNotFoundResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -7976,7 +7977,7 @@ const deserializeAws_restXmlHostedZoneNotPrivateResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -7993,7 +7994,7 @@ const deserializeAws_restXmlHostedZonePartiallyDelegatedResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8010,7 +8011,7 @@ const deserializeAws_restXmlIncompatibleVersionResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8027,7 +8028,7 @@ const deserializeAws_restXmlInsufficientCloudWatchLogsResourcePolicyResponse = a
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8044,7 +8045,7 @@ const deserializeAws_restXmlInvalidArgumentResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8062,7 +8063,7 @@ const deserializeAws_restXmlInvalidChangeBatchResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   if (data.messages === "") {
     contents.messages = [];
@@ -8088,7 +8089,7 @@ const deserializeAws_restXmlInvalidDomainNameResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8105,7 +8106,7 @@ const deserializeAws_restXmlInvalidInputResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8122,7 +8123,7 @@ const deserializeAws_restXmlInvalidKeySigningKeyNameResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8139,7 +8140,7 @@ const deserializeAws_restXmlInvalidKeySigningKeyStatusResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8156,7 +8157,7 @@ const deserializeAws_restXmlInvalidKMSArnResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8173,7 +8174,7 @@ const deserializeAws_restXmlInvalidPaginationTokenResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8190,7 +8191,7 @@ const deserializeAws_restXmlInvalidSigningStatusResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8207,7 +8208,7 @@ const deserializeAws_restXmlInvalidTrafficPolicyDocumentResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8224,7 +8225,7 @@ const deserializeAws_restXmlInvalidVPCIdResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8241,7 +8242,7 @@ const deserializeAws_restXmlKeySigningKeyAlreadyExistsResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8258,7 +8259,7 @@ const deserializeAws_restXmlKeySigningKeyInParentDSRecordResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8275,7 +8276,7 @@ const deserializeAws_restXmlKeySigningKeyInUseResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8292,7 +8293,7 @@ const deserializeAws_restXmlKeySigningKeyWithActiveStatusNotFoundResponse = asyn
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8309,7 +8310,7 @@ const deserializeAws_restXmlLastVPCAssociationResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8326,7 +8327,7 @@ const deserializeAws_restXmlLimitsExceededResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8343,7 +8344,7 @@ const deserializeAws_restXmlNoSuchChangeResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8360,7 +8361,7 @@ const deserializeAws_restXmlNoSuchCloudWatchLogsLogGroupResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8377,7 +8378,7 @@ const deserializeAws_restXmlNoSuchDelegationSetResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8394,7 +8395,7 @@ const deserializeAws_restXmlNoSuchGeoLocationResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8411,7 +8412,7 @@ const deserializeAws_restXmlNoSuchHealthCheckResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8428,7 +8429,7 @@ const deserializeAws_restXmlNoSuchHostedZoneResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8445,7 +8446,7 @@ const deserializeAws_restXmlNoSuchKeySigningKeyResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8462,7 +8463,7 @@ const deserializeAws_restXmlNoSuchQueryLoggingConfigResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8479,7 +8480,7 @@ const deserializeAws_restXmlNoSuchTrafficPolicyResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8496,7 +8497,7 @@ const deserializeAws_restXmlNoSuchTrafficPolicyInstanceResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8513,7 +8514,7 @@ const deserializeAws_restXmlNotAuthorizedExceptionResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8530,7 +8531,7 @@ const deserializeAws_restXmlPriorRequestNotCompleteResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8547,7 +8548,7 @@ const deserializeAws_restXmlPublicZoneVPCAssociationResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8564,7 +8565,7 @@ const deserializeAws_restXmlQueryLoggingConfigAlreadyExistsResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8581,7 +8582,7 @@ const deserializeAws_restXmlThrottlingExceptionResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8598,7 +8599,7 @@ const deserializeAws_restXmlTooManyHealthChecksResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8615,7 +8616,7 @@ const deserializeAws_restXmlTooManyHostedZonesResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8632,7 +8633,7 @@ const deserializeAws_restXmlTooManyKeySigningKeysResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8649,7 +8650,7 @@ const deserializeAws_restXmlTooManyTrafficPoliciesResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8666,7 +8667,7 @@ const deserializeAws_restXmlTooManyTrafficPolicyInstancesResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8683,7 +8684,7 @@ const deserializeAws_restXmlTooManyTrafficPolicyVersionsForCurrentPolicyResponse
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8700,7 +8701,7 @@ const deserializeAws_restXmlTooManyVPCAssociationAuthorizationsResponse = async 
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8717,7 +8718,7 @@ const deserializeAws_restXmlTrafficPolicyAlreadyExistsResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8734,7 +8735,7 @@ const deserializeAws_restXmlTrafficPolicyInstanceAlreadyExistsResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8751,7 +8752,7 @@ const deserializeAws_restXmlTrafficPolicyInUseResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8768,7 +8769,7 @@ const deserializeAws_restXmlVPCAssociationAuthorizationNotFoundResponse = async 
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -8785,7 +8786,7 @@ const deserializeAws_restXmlVPCAssociationNotFoundResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["message"] !== undefined) {
-    contents.message = data["message"];
+    contents.message = __expectString(data["message"]);
   }
   return contents;
 };
@@ -9199,7 +9200,7 @@ const deserializeAws_restXmlAccountLimit = (output: any, context: __SerdeContext
     Value: undefined,
   };
   if (output["Type"] !== undefined) {
-    contents.Type = output["Type"];
+    contents.Type = __expectString(output["Type"]);
   }
   if (output["Value"] !== undefined) {
     contents.Value = parseInt(output["Value"]);
@@ -9213,10 +9214,10 @@ const deserializeAws_restXmlAlarmIdentifier = (output: any, context: __SerdeCont
     Name: undefined,
   };
   if (output["Region"] !== undefined) {
-    contents.Region = output["Region"];
+    contents.Region = __expectString(output["Region"]);
   }
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   return contents;
 };
@@ -9228,10 +9229,10 @@ const deserializeAws_restXmlAliasTarget = (output: any, context: __SerdeContext)
     EvaluateTargetHealth: undefined,
   };
   if (output["HostedZoneId"] !== undefined) {
-    contents.HostedZoneId = output["HostedZoneId"];
+    contents.HostedZoneId = __expectString(output["HostedZoneId"]);
   }
   if (output["DNSName"] !== undefined) {
-    contents.DNSName = output["DNSName"];
+    contents.DNSName = __expectString(output["DNSName"]);
   }
   if (output["EvaluateTargetHealth"] !== undefined) {
     contents.EvaluateTargetHealth = __parseBoolean(output["EvaluateTargetHealth"]);
@@ -9247,16 +9248,16 @@ const deserializeAws_restXmlChangeInfo = (output: any, context: __SerdeContext):
     Comment: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["SubmittedAt"] !== undefined) {
     contents.SubmittedAt = new Date(output["SubmittedAt"]);
   }
   if (output["Comment"] !== undefined) {
-    contents.Comment = output["Comment"];
+    contents.Comment = __expectString(output["Comment"]);
   }
   return contents;
 };
@@ -9268,7 +9269,7 @@ const deserializeAws_restXmlCheckerIpRanges = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -9279,7 +9280,7 @@ const deserializeAws_restXmlChildHealthCheckList = (output: any, context: __Serd
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -9304,19 +9305,19 @@ const deserializeAws_restXmlCloudWatchAlarmConfiguration = (
     contents.Threshold = parseFloat(output["Threshold"]);
   }
   if (output["ComparisonOperator"] !== undefined) {
-    contents.ComparisonOperator = output["ComparisonOperator"];
+    contents.ComparisonOperator = __expectString(output["ComparisonOperator"]);
   }
   if (output["Period"] !== undefined) {
     contents.Period = parseInt(output["Period"]);
   }
   if (output["MetricName"] !== undefined) {
-    contents.MetricName = output["MetricName"];
+    contents.MetricName = __expectString(output["MetricName"]);
   }
   if (output["Namespace"] !== undefined) {
-    contents.Namespace = output["Namespace"];
+    contents.Namespace = __expectString(output["Namespace"]);
   }
   if (output["Statistic"] !== undefined) {
-    contents.Statistic = output["Statistic"];
+    contents.Statistic = __expectString(output["Statistic"]);
   }
   if (output.Dimensions === "") {
     contents.Dimensions = [];
@@ -9337,10 +9338,10 @@ const deserializeAws_restXmlDelegationSet = (output: any, context: __SerdeContex
     NameServers: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   if (output["CallerReference"] !== undefined) {
-    contents.CallerReference = output["CallerReference"];
+    contents.CallerReference = __expectString(output["CallerReference"]);
   }
   if (output.NameServers === "") {
     contents.NameServers = [];
@@ -9361,7 +9362,7 @@ const deserializeAws_restXmlDelegationSetNameServers = (output: any, context: __
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -9382,10 +9383,10 @@ const deserializeAws_restXmlDimension = (output: any, context: __SerdeContext): 
     Value: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["Value"] !== undefined) {
-    contents.Value = output["Value"];
+    contents.Value = __expectString(output["Value"]);
   }
   return contents;
 };
@@ -9407,10 +9408,10 @@ const deserializeAws_restXmlDNSSECStatus = (output: any, context: __SerdeContext
     StatusMessage: undefined,
   };
   if (output["ServeSignature"] !== undefined) {
-    contents.ServeSignature = output["ServeSignature"];
+    contents.ServeSignature = __expectString(output["ServeSignature"]);
   }
   if (output["StatusMessage"] !== undefined) {
-    contents.StatusMessage = output["StatusMessage"];
+    contents.StatusMessage = __expectString(output["StatusMessage"]);
   }
   return contents;
 };
@@ -9422,7 +9423,7 @@ const deserializeAws_restXmlErrorMessages = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -9433,13 +9434,13 @@ const deserializeAws_restXmlGeoLocation = (output: any, context: __SerdeContext)
     SubdivisionCode: undefined,
   };
   if (output["ContinentCode"] !== undefined) {
-    contents.ContinentCode = output["ContinentCode"];
+    contents.ContinentCode = __expectString(output["ContinentCode"]);
   }
   if (output["CountryCode"] !== undefined) {
-    contents.CountryCode = output["CountryCode"];
+    contents.CountryCode = __expectString(output["CountryCode"]);
   }
   if (output["SubdivisionCode"] !== undefined) {
-    contents.SubdivisionCode = output["SubdivisionCode"];
+    contents.SubdivisionCode = __expectString(output["SubdivisionCode"]);
   }
   return contents;
 };
@@ -9454,22 +9455,22 @@ const deserializeAws_restXmlGeoLocationDetails = (output: any, context: __SerdeC
     SubdivisionName: undefined,
   };
   if (output["ContinentCode"] !== undefined) {
-    contents.ContinentCode = output["ContinentCode"];
+    contents.ContinentCode = __expectString(output["ContinentCode"]);
   }
   if (output["ContinentName"] !== undefined) {
-    contents.ContinentName = output["ContinentName"];
+    contents.ContinentName = __expectString(output["ContinentName"]);
   }
   if (output["CountryCode"] !== undefined) {
-    contents.CountryCode = output["CountryCode"];
+    contents.CountryCode = __expectString(output["CountryCode"]);
   }
   if (output["CountryName"] !== undefined) {
-    contents.CountryName = output["CountryName"];
+    contents.CountryName = __expectString(output["CountryName"]);
   }
   if (output["SubdivisionCode"] !== undefined) {
-    contents.SubdivisionCode = output["SubdivisionCode"];
+    contents.SubdivisionCode = __expectString(output["SubdivisionCode"]);
   }
   if (output["SubdivisionName"] !== undefined) {
-    contents.SubdivisionName = output["SubdivisionName"];
+    contents.SubdivisionName = __expectString(output["SubdivisionName"]);
   }
   return contents;
 };
@@ -9495,10 +9496,10 @@ const deserializeAws_restXmlHealthCheck = (output: any, context: __SerdeContext)
     CloudWatchAlarmConfiguration: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   if (output["CallerReference"] !== undefined) {
-    contents.CallerReference = output["CallerReference"];
+    contents.CallerReference = __expectString(output["CallerReference"]);
   }
   if (output["LinkedService"] !== undefined) {
     contents.LinkedService = deserializeAws_restXmlLinkedService(output["LinkedService"], context);
@@ -9539,22 +9540,22 @@ const deserializeAws_restXmlHealthCheckConfig = (output: any, context: __SerdeCo
     InsufficientDataHealthStatus: undefined,
   };
   if (output["IPAddress"] !== undefined) {
-    contents.IPAddress = output["IPAddress"];
+    contents.IPAddress = __expectString(output["IPAddress"]);
   }
   if (output["Port"] !== undefined) {
     contents.Port = parseInt(output["Port"]);
   }
   if (output["Type"] !== undefined) {
-    contents.Type = output["Type"];
+    contents.Type = __expectString(output["Type"]);
   }
   if (output["ResourcePath"] !== undefined) {
-    contents.ResourcePath = output["ResourcePath"];
+    contents.ResourcePath = __expectString(output["ResourcePath"]);
   }
   if (output["FullyQualifiedDomainName"] !== undefined) {
-    contents.FullyQualifiedDomainName = output["FullyQualifiedDomainName"];
+    contents.FullyQualifiedDomainName = __expectString(output["FullyQualifiedDomainName"]);
   }
   if (output["SearchString"] !== undefined) {
-    contents.SearchString = output["SearchString"];
+    contents.SearchString = __expectString(output["SearchString"]);
   }
   if (output["RequestInterval"] !== undefined) {
     contents.RequestInterval = parseInt(output["RequestInterval"]);
@@ -9599,7 +9600,7 @@ const deserializeAws_restXmlHealthCheckConfig = (output: any, context: __SerdeCo
     contents.AlarmIdentifier = deserializeAws_restXmlAlarmIdentifier(output["AlarmIdentifier"], context);
   }
   if (output["InsufficientDataHealthStatus"] !== undefined) {
-    contents.InsufficientDataHealthStatus = output["InsufficientDataHealthStatus"];
+    contents.InsufficientDataHealthStatus = __expectString(output["InsufficientDataHealthStatus"]);
   }
   return contents;
 };
@@ -9611,10 +9612,10 @@ const deserializeAws_restXmlHealthCheckObservation = (output: any, context: __Se
     StatusReport: undefined,
   };
   if (output["Region"] !== undefined) {
-    contents.Region = output["Region"];
+    contents.Region = __expectString(output["Region"]);
   }
   if (output["IPAddress"] !== undefined) {
-    contents.IPAddress = output["IPAddress"];
+    contents.IPAddress = __expectString(output["IPAddress"]);
   }
   if (output["StatusReport"] !== undefined) {
     contents.StatusReport = deserializeAws_restXmlStatusReport(output["StatusReport"], context);
@@ -9646,7 +9647,7 @@ const deserializeAws_restXmlHealthCheckRegionList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -9671,13 +9672,13 @@ const deserializeAws_restXmlHostedZone = (output: any, context: __SerdeContext):
     LinkedService: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["CallerReference"] !== undefined) {
-    contents.CallerReference = output["CallerReference"];
+    contents.CallerReference = __expectString(output["CallerReference"]);
   }
   if (output["Config"] !== undefined) {
     contents.Config = deserializeAws_restXmlHostedZoneConfig(output["Config"], context);
@@ -9697,7 +9698,7 @@ const deserializeAws_restXmlHostedZoneConfig = (output: any, context: __SerdeCon
     PrivateZone: undefined,
   };
   if (output["Comment"] !== undefined) {
-    contents.Comment = output["Comment"];
+    contents.Comment = __expectString(output["Comment"]);
   }
   if (output["PrivateZone"] !== undefined) {
     contents.PrivateZone = __parseBoolean(output["PrivateZone"]);
@@ -9711,7 +9712,7 @@ const deserializeAws_restXmlHostedZoneLimit = (output: any, context: __SerdeCont
     Value: undefined,
   };
   if (output["Type"] !== undefined) {
-    contents.Type = output["Type"];
+    contents.Type = __expectString(output["Type"]);
   }
   if (output["Value"] !== undefined) {
     contents.Value = parseInt(output["Value"]);
@@ -9725,10 +9726,10 @@ const deserializeAws_restXmlHostedZoneOwner = (output: any, context: __SerdeCont
     OwningService: undefined,
   };
   if (output["OwningAccount"] !== undefined) {
-    contents.OwningAccount = output["OwningAccount"];
+    contents.OwningAccount = __expectString(output["OwningAccount"]);
   }
   if (output["OwningService"] !== undefined) {
-    contents.OwningService = output["OwningService"];
+    contents.OwningService = __expectString(output["OwningService"]);
   }
   return contents;
 };
@@ -9762,10 +9763,10 @@ const deserializeAws_restXmlHostedZoneSummary = (output: any, context: __SerdeCo
     Owner: undefined,
   };
   if (output["HostedZoneId"] !== undefined) {
-    contents.HostedZoneId = output["HostedZoneId"];
+    contents.HostedZoneId = __expectString(output["HostedZoneId"]);
   }
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["Owner"] !== undefined) {
     contents.Owner = deserializeAws_restXmlHostedZoneOwner(output["Owner"], context);
@@ -9793,22 +9794,22 @@ const deserializeAws_restXmlKeySigningKey = (output: any, context: __SerdeContex
     LastModifiedDate: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["KmsArn"] !== undefined) {
-    contents.KmsArn = output["KmsArn"];
+    contents.KmsArn = __expectString(output["KmsArn"]);
   }
   if (output["Flag"] !== undefined) {
     contents.Flag = parseInt(output["Flag"]);
   }
   if (output["SigningAlgorithmMnemonic"] !== undefined) {
-    contents.SigningAlgorithmMnemonic = output["SigningAlgorithmMnemonic"];
+    contents.SigningAlgorithmMnemonic = __expectString(output["SigningAlgorithmMnemonic"]);
   }
   if (output["SigningAlgorithmType"] !== undefined) {
     contents.SigningAlgorithmType = parseInt(output["SigningAlgorithmType"]);
   }
   if (output["DigestAlgorithmMnemonic"] !== undefined) {
-    contents.DigestAlgorithmMnemonic = output["DigestAlgorithmMnemonic"];
+    contents.DigestAlgorithmMnemonic = __expectString(output["DigestAlgorithmMnemonic"]);
   }
   if (output["DigestAlgorithmType"] !== undefined) {
     contents.DigestAlgorithmType = parseInt(output["DigestAlgorithmType"]);
@@ -9817,22 +9818,22 @@ const deserializeAws_restXmlKeySigningKey = (output: any, context: __SerdeContex
     contents.KeyTag = parseInt(output["KeyTag"]);
   }
   if (output["DigestValue"] !== undefined) {
-    contents.DigestValue = output["DigestValue"];
+    contents.DigestValue = __expectString(output["DigestValue"]);
   }
   if (output["PublicKey"] !== undefined) {
-    contents.PublicKey = output["PublicKey"];
+    contents.PublicKey = __expectString(output["PublicKey"]);
   }
   if (output["DSRecord"] !== undefined) {
-    contents.DSRecord = output["DSRecord"];
+    contents.DSRecord = __expectString(output["DSRecord"]);
   }
   if (output["DNSKEYRecord"] !== undefined) {
-    contents.DNSKEYRecord = output["DNSKEYRecord"];
+    contents.DNSKEYRecord = __expectString(output["DNSKEYRecord"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["StatusMessage"] !== undefined) {
-    contents.StatusMessage = output["StatusMessage"];
+    contents.StatusMessage = __expectString(output["StatusMessage"]);
   }
   if (output["CreatedDate"] !== undefined) {
     contents.CreatedDate = new Date(output["CreatedDate"]);
@@ -9860,10 +9861,10 @@ const deserializeAws_restXmlLinkedService = (output: any, context: __SerdeContex
     Description: undefined,
   };
   if (output["ServicePrincipal"] !== undefined) {
-    contents.ServicePrincipal = output["ServicePrincipal"];
+    contents.ServicePrincipal = __expectString(output["ServicePrincipal"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   return contents;
 };
@@ -9875,13 +9876,13 @@ const deserializeAws_restXmlQueryLoggingConfig = (output: any, context: __SerdeC
     CloudWatchLogsLogGroupArn: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   if (output["HostedZoneId"] !== undefined) {
-    contents.HostedZoneId = output["HostedZoneId"];
+    contents.HostedZoneId = __expectString(output["HostedZoneId"]);
   }
   if (output["CloudWatchLogsLogGroupArn"] !== undefined) {
-    contents.CloudWatchLogsLogGroupArn = output["CloudWatchLogsLogGroupArn"];
+    contents.CloudWatchLogsLogGroupArn = __expectString(output["CloudWatchLogsLogGroupArn"]);
   }
   return contents;
 };
@@ -9904,7 +9905,7 @@ const deserializeAws_restXmlRecordData = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -9913,7 +9914,7 @@ const deserializeAws_restXmlResourceRecord = (output: any, context: __SerdeConte
     Value: undefined,
   };
   if (output["Value"] !== undefined) {
-    contents.Value = output["Value"];
+    contents.Value = __expectString(output["Value"]);
   }
   return contents;
 };
@@ -9946,25 +9947,25 @@ const deserializeAws_restXmlResourceRecordSet = (output: any, context: __SerdeCo
     TrafficPolicyInstanceId: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["Type"] !== undefined) {
-    contents.Type = output["Type"];
+    contents.Type = __expectString(output["Type"]);
   }
   if (output["SetIdentifier"] !== undefined) {
-    contents.SetIdentifier = output["SetIdentifier"];
+    contents.SetIdentifier = __expectString(output["SetIdentifier"]);
   }
   if (output["Weight"] !== undefined) {
     contents.Weight = parseInt(output["Weight"]);
   }
   if (output["Region"] !== undefined) {
-    contents.Region = output["Region"];
+    contents.Region = __expectString(output["Region"]);
   }
   if (output["GeoLocation"] !== undefined) {
     contents.GeoLocation = deserializeAws_restXmlGeoLocation(output["GeoLocation"], context);
   }
   if (output["Failover"] !== undefined) {
-    contents.Failover = output["Failover"];
+    contents.Failover = __expectString(output["Failover"]);
   }
   if (output["MultiValueAnswer"] !== undefined) {
     contents.MultiValueAnswer = __parseBoolean(output["MultiValueAnswer"]);
@@ -9985,10 +9986,10 @@ const deserializeAws_restXmlResourceRecordSet = (output: any, context: __SerdeCo
     contents.AliasTarget = deserializeAws_restXmlAliasTarget(output["AliasTarget"], context);
   }
   if (output["HealthCheckId"] !== undefined) {
-    contents.HealthCheckId = output["HealthCheckId"];
+    contents.HealthCheckId = __expectString(output["HealthCheckId"]);
   }
   if (output["TrafficPolicyInstanceId"] !== undefined) {
-    contents.TrafficPolicyInstanceId = output["TrafficPolicyInstanceId"];
+    contents.TrafficPolicyInstanceId = __expectString(output["TrafficPolicyInstanceId"]);
   }
   return contents;
 };
@@ -10011,10 +10012,10 @@ const deserializeAws_restXmlResourceTagSet = (output: any, context: __SerdeConte
     Tags: undefined,
   };
   if (output["ResourceType"] !== undefined) {
-    contents.ResourceType = output["ResourceType"];
+    contents.ResourceType = __expectString(output["ResourceType"]);
   }
   if (output["ResourceId"] !== undefined) {
-    contents.ResourceId = output["ResourceId"];
+    contents.ResourceId = __expectString(output["ResourceId"]);
   }
   if (output.Tags === "") {
     contents.Tags = [];
@@ -10045,7 +10046,7 @@ const deserializeAws_restXmlReusableDelegationSetLimit = (
     Value: undefined,
   };
   if (output["Type"] !== undefined) {
-    contents.Type = output["Type"];
+    contents.Type = __expectString(output["Type"]);
   }
   if (output["Value"] !== undefined) {
     contents.Value = parseInt(output["Value"]);
@@ -10059,7 +10060,7 @@ const deserializeAws_restXmlStatusReport = (output: any, context: __SerdeContext
     CheckedTime: undefined,
   };
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["CheckedTime"] !== undefined) {
     contents.CheckedTime = new Date(output["CheckedTime"]);
@@ -10073,10 +10074,10 @@ const deserializeAws_restXmlTag = (output: any, context: __SerdeContext): Tag =>
     Value: undefined,
   };
   if (output["Key"] !== undefined) {
-    contents.Key = output["Key"];
+    contents.Key = __expectString(output["Key"]);
   }
   if (output["Value"] !== undefined) {
-    contents.Value = output["Value"];
+    contents.Value = __expectString(output["Value"]);
   }
   return contents;
 };
@@ -10113,22 +10114,22 @@ const deserializeAws_restXmlTrafficPolicy = (output: any, context: __SerdeContex
     Comment: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   if (output["Version"] !== undefined) {
     contents.Version = parseInt(output["Version"]);
   }
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["Type"] !== undefined) {
-    contents.Type = output["Type"];
+    contents.Type = __expectString(output["Type"]);
   }
   if (output["Document"] !== undefined) {
-    contents.Document = output["Document"];
+    contents.Document = __expectString(output["Document"]);
   }
   if (output["Comment"] !== undefined) {
-    contents.Comment = output["Comment"];
+    contents.Comment = __expectString(output["Comment"]);
   }
   return contents;
 };
@@ -10146,31 +10147,31 @@ const deserializeAws_restXmlTrafficPolicyInstance = (output: any, context: __Ser
     TrafficPolicyType: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   if (output["HostedZoneId"] !== undefined) {
-    contents.HostedZoneId = output["HostedZoneId"];
+    contents.HostedZoneId = __expectString(output["HostedZoneId"]);
   }
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["TTL"] !== undefined) {
     contents.TTL = parseInt(output["TTL"]);
   }
   if (output["State"] !== undefined) {
-    contents.State = output["State"];
+    contents.State = __expectString(output["State"]);
   }
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   if (output["TrafficPolicyId"] !== undefined) {
-    contents.TrafficPolicyId = output["TrafficPolicyId"];
+    contents.TrafficPolicyId = __expectString(output["TrafficPolicyId"]);
   }
   if (output["TrafficPolicyVersion"] !== undefined) {
     contents.TrafficPolicyVersion = parseInt(output["TrafficPolicyVersion"]);
   }
   if (output["TrafficPolicyType"] !== undefined) {
-    contents.TrafficPolicyType = output["TrafficPolicyType"];
+    contents.TrafficPolicyType = __expectString(output["TrafficPolicyType"]);
   }
   return contents;
 };
@@ -10209,13 +10210,13 @@ const deserializeAws_restXmlTrafficPolicySummary = (output: any, context: __Serd
     TrafficPolicyCount: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["Type"] !== undefined) {
-    contents.Type = output["Type"];
+    contents.Type = __expectString(output["Type"]);
   }
   if (output["LatestVersion"] !== undefined) {
     contents.LatestVersion = parseInt(output["LatestVersion"]);
@@ -10232,10 +10233,10 @@ const deserializeAws_restXmlVPC = (output: any, context: __SerdeContext): VPC =>
     VPCId: undefined,
   };
   if (output["VPCRegion"] !== undefined) {
-    contents.VPCRegion = output["VPCRegion"];
+    contents.VPCRegion = __expectString(output["VPCRegion"]);
   }
   if (output["VPCId"] !== undefined) {
-    contents.VPCId = output["VPCId"];
+    contents.VPCId = __expectString(output["VPCId"]);
   }
   return contents;
 };

--- a/clients/client-route53resolver/protocols/Aws_json1_1.ts
+++ b/clients/client-route53resolver/protocols/Aws_json1_1.ts
@@ -361,7 +361,12 @@ import {
   ValidationException,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -7622,7 +7627,7 @@ const serializeAws_json1_1UpdateResolverRuleRequest = (
 
 const deserializeAws_json1_1AccessDeniedException = (output: any, context: __SerdeContext): AccessDeniedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7676,7 +7681,7 @@ const deserializeAws_json1_1AssociateResolverRuleResponse = (
 
 const deserializeAws_json1_1ConflictException = (output: any, context: __SerdeContext): ConflictException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7874,11 +7879,10 @@ const deserializeAws_json1_1DisassociateResolverRuleResponse = (
 
 const deserializeAws_json1_1FirewallConfig = (output: any, context: __SerdeContext): FirewallConfig => {
   return {
-    FirewallFailOpen:
-      output.FirewallFailOpen !== undefined && output.FirewallFailOpen !== null ? output.FirewallFailOpen : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    OwnerId: output.OwnerId !== undefined && output.OwnerId !== null ? output.OwnerId : undefined,
-    ResourceId: output.ResourceId !== undefined && output.ResourceId !== null ? output.ResourceId : undefined,
+    FirewallFailOpen: __expectString(output.FirewallFailOpen),
+    Id: __expectString(output.Id),
+    OwnerId: __expectString(output.OwnerId),
+    ResourceId: __expectString(output.ResourceId),
   } as any;
 };
 
@@ -7895,20 +7899,16 @@ const deserializeAws_json1_1FirewallConfigList = (output: any, context: __SerdeC
 
 const deserializeAws_json1_1FirewallDomainList = (output: any, context: __SerdeContext): FirewallDomainList => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    CreationTime: output.CreationTime !== undefined && output.CreationTime !== null ? output.CreationTime : undefined,
-    CreatorRequestId:
-      output.CreatorRequestId !== undefined && output.CreatorRequestId !== null ? output.CreatorRequestId : undefined,
-    DomainCount: output.DomainCount !== undefined && output.DomainCount !== null ? output.DomainCount : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    ManagedOwnerName:
-      output.ManagedOwnerName !== undefined && output.ManagedOwnerName !== null ? output.ManagedOwnerName : undefined,
-    ModificationTime:
-      output.ModificationTime !== undefined && output.ModificationTime !== null ? output.ModificationTime : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusMessage:
-      output.StatusMessage !== undefined && output.StatusMessage !== null ? output.StatusMessage : undefined,
+    Arn: __expectString(output.Arn),
+    CreationTime: __expectString(output.CreationTime),
+    CreatorRequestId: __expectString(output.CreatorRequestId),
+    DomainCount: __expectNumber(output.DomainCount),
+    Id: __expectString(output.Id),
+    ManagedOwnerName: __expectString(output.ManagedOwnerName),
+    ModificationTime: __expectString(output.ModificationTime),
+    Name: __expectString(output.Name),
+    Status: __expectString(output.Status),
+    StatusMessage: __expectString(output.StatusMessage),
   } as any;
 };
 
@@ -7917,13 +7917,11 @@ const deserializeAws_json1_1FirewallDomainListMetadata = (
   context: __SerdeContext
 ): FirewallDomainListMetadata => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    CreatorRequestId:
-      output.CreatorRequestId !== undefined && output.CreatorRequestId !== null ? output.CreatorRequestId : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    ManagedOwnerName:
-      output.ManagedOwnerName !== undefined && output.ManagedOwnerName !== null ? output.ManagedOwnerName : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Arn: __expectString(output.Arn),
+    CreatorRequestId: __expectString(output.CreatorRequestId),
+    Id: __expectString(output.Id),
+    ManagedOwnerName: __expectString(output.ManagedOwnerName),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -7948,59 +7946,40 @@ const deserializeAws_json1_1FirewallDomains = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1FirewallRule = (output: any, context: __SerdeContext): FirewallRule => {
   return {
-    Action: output.Action !== undefined && output.Action !== null ? output.Action : undefined,
-    BlockOverrideDnsType:
-      output.BlockOverrideDnsType !== undefined && output.BlockOverrideDnsType !== null
-        ? output.BlockOverrideDnsType
-        : undefined,
-    BlockOverrideDomain:
-      output.BlockOverrideDomain !== undefined && output.BlockOverrideDomain !== null
-        ? output.BlockOverrideDomain
-        : undefined,
-    BlockOverrideTtl:
-      output.BlockOverrideTtl !== undefined && output.BlockOverrideTtl !== null ? output.BlockOverrideTtl : undefined,
-    BlockResponse:
-      output.BlockResponse !== undefined && output.BlockResponse !== null ? output.BlockResponse : undefined,
-    CreationTime: output.CreationTime !== undefined && output.CreationTime !== null ? output.CreationTime : undefined,
-    CreatorRequestId:
-      output.CreatorRequestId !== undefined && output.CreatorRequestId !== null ? output.CreatorRequestId : undefined,
-    FirewallDomainListId:
-      output.FirewallDomainListId !== undefined && output.FirewallDomainListId !== null
-        ? output.FirewallDomainListId
-        : undefined,
-    FirewallRuleGroupId:
-      output.FirewallRuleGroupId !== undefined && output.FirewallRuleGroupId !== null
-        ? output.FirewallRuleGroupId
-        : undefined,
-    ModificationTime:
-      output.ModificationTime !== undefined && output.ModificationTime !== null ? output.ModificationTime : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Priority: output.Priority !== undefined && output.Priority !== null ? output.Priority : undefined,
+    Action: __expectString(output.Action),
+    BlockOverrideDnsType: __expectString(output.BlockOverrideDnsType),
+    BlockOverrideDomain: __expectString(output.BlockOverrideDomain),
+    BlockOverrideTtl: __expectNumber(output.BlockOverrideTtl),
+    BlockResponse: __expectString(output.BlockResponse),
+    CreationTime: __expectString(output.CreationTime),
+    CreatorRequestId: __expectString(output.CreatorRequestId),
+    FirewallDomainListId: __expectString(output.FirewallDomainListId),
+    FirewallRuleGroupId: __expectString(output.FirewallRuleGroupId),
+    ModificationTime: __expectString(output.ModificationTime),
+    Name: __expectString(output.Name),
+    Priority: __expectNumber(output.Priority),
   } as any;
 };
 
 const deserializeAws_json1_1FirewallRuleGroup = (output: any, context: __SerdeContext): FirewallRuleGroup => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    CreationTime: output.CreationTime !== undefined && output.CreationTime !== null ? output.CreationTime : undefined,
-    CreatorRequestId:
-      output.CreatorRequestId !== undefined && output.CreatorRequestId !== null ? output.CreatorRequestId : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    ModificationTime:
-      output.ModificationTime !== undefined && output.ModificationTime !== null ? output.ModificationTime : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    OwnerId: output.OwnerId !== undefined && output.OwnerId !== null ? output.OwnerId : undefined,
-    RuleCount: output.RuleCount !== undefined && output.RuleCount !== null ? output.RuleCount : undefined,
-    ShareStatus: output.ShareStatus !== undefined && output.ShareStatus !== null ? output.ShareStatus : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusMessage:
-      output.StatusMessage !== undefined && output.StatusMessage !== null ? output.StatusMessage : undefined,
+    Arn: __expectString(output.Arn),
+    CreationTime: __expectString(output.CreationTime),
+    CreatorRequestId: __expectString(output.CreatorRequestId),
+    Id: __expectString(output.Id),
+    ModificationTime: __expectString(output.ModificationTime),
+    Name: __expectString(output.Name),
+    OwnerId: __expectString(output.OwnerId),
+    RuleCount: __expectNumber(output.RuleCount),
+    ShareStatus: __expectString(output.ShareStatus),
+    Status: __expectString(output.Status),
+    StatusMessage: __expectString(output.StatusMessage),
   } as any;
 };
 
@@ -8009,29 +7988,19 @@ const deserializeAws_json1_1FirewallRuleGroupAssociation = (
   context: __SerdeContext
 ): FirewallRuleGroupAssociation => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    CreationTime: output.CreationTime !== undefined && output.CreationTime !== null ? output.CreationTime : undefined,
-    CreatorRequestId:
-      output.CreatorRequestId !== undefined && output.CreatorRequestId !== null ? output.CreatorRequestId : undefined,
-    FirewallRuleGroupId:
-      output.FirewallRuleGroupId !== undefined && output.FirewallRuleGroupId !== null
-        ? output.FirewallRuleGroupId
-        : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    ManagedOwnerName:
-      output.ManagedOwnerName !== undefined && output.ManagedOwnerName !== null ? output.ManagedOwnerName : undefined,
-    ModificationTime:
-      output.ModificationTime !== undefined && output.ModificationTime !== null ? output.ModificationTime : undefined,
-    MutationProtection:
-      output.MutationProtection !== undefined && output.MutationProtection !== null
-        ? output.MutationProtection
-        : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Priority: output.Priority !== undefined && output.Priority !== null ? output.Priority : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusMessage:
-      output.StatusMessage !== undefined && output.StatusMessage !== null ? output.StatusMessage : undefined,
-    VpcId: output.VpcId !== undefined && output.VpcId !== null ? output.VpcId : undefined,
+    Arn: __expectString(output.Arn),
+    CreationTime: __expectString(output.CreationTime),
+    CreatorRequestId: __expectString(output.CreatorRequestId),
+    FirewallRuleGroupId: __expectString(output.FirewallRuleGroupId),
+    Id: __expectString(output.Id),
+    ManagedOwnerName: __expectString(output.ManagedOwnerName),
+    ModificationTime: __expectString(output.ModificationTime),
+    MutationProtection: __expectString(output.MutationProtection),
+    Name: __expectString(output.Name),
+    Priority: __expectNumber(output.Priority),
+    Status: __expectString(output.Status),
+    StatusMessage: __expectString(output.StatusMessage),
+    VpcId: __expectString(output.VpcId),
   } as any;
 };
 
@@ -8054,13 +8023,12 @@ const deserializeAws_json1_1FirewallRuleGroupMetadata = (
   context: __SerdeContext
 ): FirewallRuleGroupMetadata => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    CreatorRequestId:
-      output.CreatorRequestId !== undefined && output.CreatorRequestId !== null ? output.CreatorRequestId : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    OwnerId: output.OwnerId !== undefined && output.OwnerId !== null ? output.OwnerId : undefined,
-    ShareStatus: output.ShareStatus !== undefined && output.ShareStatus !== null ? output.ShareStatus : undefined,
+    Arn: __expectString(output.Arn),
+    CreatorRequestId: __expectString(output.CreatorRequestId),
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
+    OwnerId: __expectString(output.OwnerId),
+    ShareStatus: __expectString(output.ShareStatus),
   } as any;
 };
 
@@ -8130,10 +8098,7 @@ const deserializeAws_json1_1GetFirewallRuleGroupPolicyResponse = (
   context: __SerdeContext
 ): GetFirewallRuleGroupPolicyResponse => {
   return {
-    FirewallRuleGroupPolicy:
-      output.FirewallRuleGroupPolicy !== undefined && output.FirewallRuleGroupPolicy !== null
-        ? output.FirewallRuleGroupPolicy
-        : undefined,
+    FirewallRuleGroupPolicy: __expectString(output.FirewallRuleGroupPolicy),
   } as any;
 };
 
@@ -8190,10 +8155,7 @@ const deserializeAws_json1_1GetResolverQueryLogConfigPolicyResponse = (
   context: __SerdeContext
 ): GetResolverQueryLogConfigPolicyResponse => {
   return {
-    ResolverQueryLogConfigPolicy:
-      output.ResolverQueryLogConfigPolicy !== undefined && output.ResolverQueryLogConfigPolicy !== null
-        ? output.ResolverQueryLogConfigPolicy
-        : undefined,
+    ResolverQueryLogConfigPolicy: __expectString(output.ResolverQueryLogConfigPolicy),
   } as any;
 };
 
@@ -8226,10 +8188,7 @@ const deserializeAws_json1_1GetResolverRulePolicyResponse = (
   context: __SerdeContext
 ): GetResolverRulePolicyResponse => {
   return {
-    ResolverRulePolicy:
-      output.ResolverRulePolicy !== undefined && output.ResolverRulePolicy !== null
-        ? output.ResolverRulePolicy
-        : undefined,
+    ResolverRulePolicy: __expectString(output.ResolverRulePolicy),
   } as any;
 };
 
@@ -8250,11 +8209,10 @@ const deserializeAws_json1_1ImportFirewallDomainsResponse = (
   context: __SerdeContext
 ): ImportFirewallDomainsResponse => {
   return {
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusMessage:
-      output.StatusMessage !== undefined && output.StatusMessage !== null ? output.StatusMessage : undefined,
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
+    Status: __expectString(output.Status),
+    StatusMessage: __expectString(output.StatusMessage),
   } as any;
 };
 
@@ -8263,7 +8221,7 @@ const deserializeAws_json1_1InternalServiceErrorException = (
   context: __SerdeContext
 ): InternalServiceErrorException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -8272,7 +8230,7 @@ const deserializeAws_json1_1InvalidNextTokenException = (
   context: __SerdeContext
 ): InvalidNextTokenException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -8281,14 +8239,14 @@ const deserializeAws_json1_1InvalidParameterException = (
   context: __SerdeContext
 ): InvalidParameterException => {
   return {
-    FieldName: output.FieldName !== undefined && output.FieldName !== null ? output.FieldName : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    FieldName: __expectString(output.FieldName),
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidPolicyDocument = (output: any, context: __SerdeContext): InvalidPolicyDocument => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -8297,13 +8255,13 @@ const deserializeAws_json1_1InvalidRequestException = (
   context: __SerdeContext
 ): InvalidRequestException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidTagException = (output: any, context: __SerdeContext): InvalidTagException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -8320,22 +8278,20 @@ const deserializeAws_json1_1IpAddressesResponse = (output: any, context: __Serde
 
 const deserializeAws_json1_1IpAddressResponse = (output: any, context: __SerdeContext): IpAddressResponse => {
   return {
-    CreationTime: output.CreationTime !== undefined && output.CreationTime !== null ? output.CreationTime : undefined,
-    Ip: output.Ip !== undefined && output.Ip !== null ? output.Ip : undefined,
-    IpId: output.IpId !== undefined && output.IpId !== null ? output.IpId : undefined,
-    ModificationTime:
-      output.ModificationTime !== undefined && output.ModificationTime !== null ? output.ModificationTime : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusMessage:
-      output.StatusMessage !== undefined && output.StatusMessage !== null ? output.StatusMessage : undefined,
-    SubnetId: output.SubnetId !== undefined && output.SubnetId !== null ? output.SubnetId : undefined,
+    CreationTime: __expectString(output.CreationTime),
+    Ip: __expectString(output.Ip),
+    IpId: __expectString(output.IpId),
+    ModificationTime: __expectString(output.ModificationTime),
+    Status: __expectString(output.Status),
+    StatusMessage: __expectString(output.StatusMessage),
+    SubnetId: __expectString(output.SubnetId),
   } as any;
 };
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
+    Message: __expectString(output.Message),
+    ResourceType: __expectString(output.ResourceType),
   } as any;
 };
 
@@ -8348,7 +8304,7 @@ const deserializeAws_json1_1ListFirewallConfigsResponse = (
       output.FirewallConfigs !== undefined && output.FirewallConfigs !== null
         ? deserializeAws_json1_1FirewallConfigList(output.FirewallConfigs, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -8361,7 +8317,7 @@ const deserializeAws_json1_1ListFirewallDomainListsResponse = (
       output.FirewallDomainLists !== undefined && output.FirewallDomainLists !== null
         ? deserializeAws_json1_1FirewallDomainListMetadataList(output.FirewallDomainLists, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -8374,7 +8330,7 @@ const deserializeAws_json1_1ListFirewallDomainsResponse = (
       output.Domains !== undefined && output.Domains !== null
         ? deserializeAws_json1_1FirewallDomains(output.Domains, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -8387,7 +8343,7 @@ const deserializeAws_json1_1ListFirewallRuleGroupAssociationsResponse = (
       output.FirewallRuleGroupAssociations !== undefined && output.FirewallRuleGroupAssociations !== null
         ? deserializeAws_json1_1FirewallRuleGroupAssociations(output.FirewallRuleGroupAssociations, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -8400,7 +8356,7 @@ const deserializeAws_json1_1ListFirewallRuleGroupsResponse = (
       output.FirewallRuleGroups !== undefined && output.FirewallRuleGroups !== null
         ? deserializeAws_json1_1FirewallRuleGroupMetadataList(output.FirewallRuleGroups, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -8413,7 +8369,7 @@ const deserializeAws_json1_1ListFirewallRulesResponse = (
       output.FirewallRules !== undefined && output.FirewallRules !== null
         ? deserializeAws_json1_1FirewallRules(output.FirewallRules, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -8422,7 +8378,7 @@ const deserializeAws_json1_1ListResolverDnssecConfigsResponse = (
   context: __SerdeContext
 ): ListResolverDnssecConfigsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     ResolverDnssecConfigs:
       output.ResolverDnssecConfigs !== undefined && output.ResolverDnssecConfigs !== null
         ? deserializeAws_json1_1ResolverDnssecConfigList(output.ResolverDnssecConfigs, context)
@@ -8439,8 +8395,8 @@ const deserializeAws_json1_1ListResolverEndpointIpAddressesResponse = (
       output.IpAddresses !== undefined && output.IpAddresses !== null
         ? deserializeAws_json1_1IpAddressesResponse(output.IpAddresses, context)
         : undefined,
-    MaxResults: output.MaxResults !== undefined && output.MaxResults !== null ? output.MaxResults : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    MaxResults: __expectNumber(output.MaxResults),
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -8449,8 +8405,8 @@ const deserializeAws_json1_1ListResolverEndpointsResponse = (
   context: __SerdeContext
 ): ListResolverEndpointsResponse => {
   return {
-    MaxResults: output.MaxResults !== undefined && output.MaxResults !== null ? output.MaxResults : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    MaxResults: __expectNumber(output.MaxResults),
+    NextToken: __expectString(output.NextToken),
     ResolverEndpoints:
       output.ResolverEndpoints !== undefined && output.ResolverEndpoints !== null
         ? deserializeAws_json1_1ResolverEndpoints(output.ResolverEndpoints, context)
@@ -8463,7 +8419,7 @@ const deserializeAws_json1_1ListResolverQueryLogConfigAssociationsResponse = (
   context: __SerdeContext
 ): ListResolverQueryLogConfigAssociationsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     ResolverQueryLogConfigAssociations:
       output.ResolverQueryLogConfigAssociations !== undefined && output.ResolverQueryLogConfigAssociations !== null
         ? deserializeAws_json1_1ResolverQueryLogConfigAssociationList(
@@ -8471,11 +8427,8 @@ const deserializeAws_json1_1ListResolverQueryLogConfigAssociationsResponse = (
             context
           )
         : undefined,
-    TotalCount: output.TotalCount !== undefined && output.TotalCount !== null ? output.TotalCount : undefined,
-    TotalFilteredCount:
-      output.TotalFilteredCount !== undefined && output.TotalFilteredCount !== null
-        ? output.TotalFilteredCount
-        : undefined,
+    TotalCount: __expectNumber(output.TotalCount),
+    TotalFilteredCount: __expectNumber(output.TotalFilteredCount),
   } as any;
 };
 
@@ -8484,16 +8437,13 @@ const deserializeAws_json1_1ListResolverQueryLogConfigsResponse = (
   context: __SerdeContext
 ): ListResolverQueryLogConfigsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     ResolverQueryLogConfigs:
       output.ResolverQueryLogConfigs !== undefined && output.ResolverQueryLogConfigs !== null
         ? deserializeAws_json1_1ResolverQueryLogConfigList(output.ResolverQueryLogConfigs, context)
         : undefined,
-    TotalCount: output.TotalCount !== undefined && output.TotalCount !== null ? output.TotalCount : undefined,
-    TotalFilteredCount:
-      output.TotalFilteredCount !== undefined && output.TotalFilteredCount !== null
-        ? output.TotalFilteredCount
-        : undefined,
+    TotalCount: __expectNumber(output.TotalCount),
+    TotalFilteredCount: __expectNumber(output.TotalFilteredCount),
   } as any;
 };
 
@@ -8502,8 +8452,8 @@ const deserializeAws_json1_1ListResolverRuleAssociationsResponse = (
   context: __SerdeContext
 ): ListResolverRuleAssociationsResponse => {
   return {
-    MaxResults: output.MaxResults !== undefined && output.MaxResults !== null ? output.MaxResults : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    MaxResults: __expectNumber(output.MaxResults),
+    NextToken: __expectString(output.NextToken),
     ResolverRuleAssociations:
       output.ResolverRuleAssociations !== undefined && output.ResolverRuleAssociations !== null
         ? deserializeAws_json1_1ResolverRuleAssociations(output.ResolverRuleAssociations, context)
@@ -8516,8 +8466,8 @@ const deserializeAws_json1_1ListResolverRulesResponse = (
   context: __SerdeContext
 ): ListResolverRulesResponse => {
   return {
-    MaxResults: output.MaxResults !== undefined && output.MaxResults !== null ? output.MaxResults : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    MaxResults: __expectNumber(output.MaxResults),
+    NextToken: __expectString(output.NextToken),
     ResolverRules:
       output.ResolverRules !== undefined && output.ResolverRules !== null
         ? deserializeAws_json1_1ResolverRules(output.ResolverRules, context)
@@ -8530,7 +8480,7 @@ const deserializeAws_json1_1ListTagsForResourceResponse = (
   context: __SerdeContext
 ): ListTagsForResourceResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_1TagList(output.Tags, context)
@@ -8543,7 +8493,7 @@ const deserializeAws_json1_1PutFirewallRuleGroupPolicyResponse = (
   context: __SerdeContext
 ): PutFirewallRuleGroupPolicyResponse => {
   return {
-    ReturnValue: output.ReturnValue !== undefined && output.ReturnValue !== null ? output.ReturnValue : undefined,
+    ReturnValue: __expectBoolean(output.ReturnValue),
   } as any;
 };
 
@@ -8552,7 +8502,7 @@ const deserializeAws_json1_1PutResolverQueryLogConfigPolicyResponse = (
   context: __SerdeContext
 ): PutResolverQueryLogConfigPolicyResponse => {
   return {
-    ReturnValue: output.ReturnValue !== undefined && output.ReturnValue !== null ? output.ReturnValue : undefined,
+    ReturnValue: __expectBoolean(output.ReturnValue),
   } as any;
 };
 
@@ -8561,17 +8511,16 @@ const deserializeAws_json1_1PutResolverRulePolicyResponse = (
   context: __SerdeContext
 ): PutResolverRulePolicyResponse => {
   return {
-    ReturnValue: output.ReturnValue !== undefined && output.ReturnValue !== null ? output.ReturnValue : undefined,
+    ReturnValue: __expectBoolean(output.ReturnValue),
   } as any;
 };
 
 const deserializeAws_json1_1ResolverDnssecConfig = (output: any, context: __SerdeContext): ResolverDnssecConfig => {
   return {
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    OwnerId: output.OwnerId !== undefined && output.OwnerId !== null ? output.OwnerId : undefined,
-    ResourceId: output.ResourceId !== undefined && output.ResourceId !== null ? output.ResourceId : undefined,
-    ValidationStatus:
-      output.ValidationStatus !== undefined && output.ValidationStatus !== null ? output.ValidationStatus : undefined,
+    Id: __expectString(output.Id),
+    OwnerId: __expectString(output.OwnerId),
+    ResourceId: __expectString(output.ResourceId),
+    ValidationStatus: __expectString(output.ValidationStatus),
   } as any;
 };
 
@@ -8591,25 +8540,21 @@ const deserializeAws_json1_1ResolverDnssecConfigList = (
 
 const deserializeAws_json1_1ResolverEndpoint = (output: any, context: __SerdeContext): ResolverEndpoint => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    CreationTime: output.CreationTime !== undefined && output.CreationTime !== null ? output.CreationTime : undefined,
-    CreatorRequestId:
-      output.CreatorRequestId !== undefined && output.CreatorRequestId !== null ? output.CreatorRequestId : undefined,
-    Direction: output.Direction !== undefined && output.Direction !== null ? output.Direction : undefined,
-    HostVPCId: output.HostVPCId !== undefined && output.HostVPCId !== null ? output.HostVPCId : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    IpAddressCount:
-      output.IpAddressCount !== undefined && output.IpAddressCount !== null ? output.IpAddressCount : undefined,
-    ModificationTime:
-      output.ModificationTime !== undefined && output.ModificationTime !== null ? output.ModificationTime : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Arn: __expectString(output.Arn),
+    CreationTime: __expectString(output.CreationTime),
+    CreatorRequestId: __expectString(output.CreatorRequestId),
+    Direction: __expectString(output.Direction),
+    HostVPCId: __expectString(output.HostVPCId),
+    Id: __expectString(output.Id),
+    IpAddressCount: __expectNumber(output.IpAddressCount),
+    ModificationTime: __expectString(output.ModificationTime),
+    Name: __expectString(output.Name),
     SecurityGroupIds:
       output.SecurityGroupIds !== undefined && output.SecurityGroupIds !== null
         ? deserializeAws_json1_1SecurityGroupIds(output.SecurityGroupIds, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusMessage:
-      output.StatusMessage !== undefined && output.StatusMessage !== null ? output.StatusMessage : undefined,
+    Status: __expectString(output.Status),
+    StatusMessage: __expectString(output.StatusMessage),
   } as any;
 };
 
@@ -8626,19 +8571,16 @@ const deserializeAws_json1_1ResolverEndpoints = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1ResolverQueryLogConfig = (output: any, context: __SerdeContext): ResolverQueryLogConfig => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    AssociationCount:
-      output.AssociationCount !== undefined && output.AssociationCount !== null ? output.AssociationCount : undefined,
-    CreationTime: output.CreationTime !== undefined && output.CreationTime !== null ? output.CreationTime : undefined,
-    CreatorRequestId:
-      output.CreatorRequestId !== undefined && output.CreatorRequestId !== null ? output.CreatorRequestId : undefined,
-    DestinationArn:
-      output.DestinationArn !== undefined && output.DestinationArn !== null ? output.DestinationArn : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    OwnerId: output.OwnerId !== undefined && output.OwnerId !== null ? output.OwnerId : undefined,
-    ShareStatus: output.ShareStatus !== undefined && output.ShareStatus !== null ? output.ShareStatus : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Arn: __expectString(output.Arn),
+    AssociationCount: __expectNumber(output.AssociationCount),
+    CreationTime: __expectString(output.CreationTime),
+    CreatorRequestId: __expectString(output.CreatorRequestId),
+    DestinationArn: __expectString(output.DestinationArn),
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
+    OwnerId: __expectString(output.OwnerId),
+    ShareStatus: __expectString(output.ShareStatus),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -8647,16 +8589,13 @@ const deserializeAws_json1_1ResolverQueryLogConfigAssociation = (
   context: __SerdeContext
 ): ResolverQueryLogConfigAssociation => {
   return {
-    CreationTime: output.CreationTime !== undefined && output.CreationTime !== null ? output.CreationTime : undefined,
-    Error: output.Error !== undefined && output.Error !== null ? output.Error : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    ResolverQueryLogConfigId:
-      output.ResolverQueryLogConfigId !== undefined && output.ResolverQueryLogConfigId !== null
-        ? output.ResolverQueryLogConfigId
-        : undefined,
-    ResourceId: output.ResourceId !== undefined && output.ResourceId !== null ? output.ResourceId : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    CreationTime: __expectString(output.CreationTime),
+    Error: __expectString(output.Error),
+    ErrorMessage: __expectString(output.ErrorMessage),
+    Id: __expectString(output.Id),
+    ResolverQueryLogConfigId: __expectString(output.ResolverQueryLogConfigId),
+    ResourceId: __expectString(output.ResourceId),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -8690,25 +8629,19 @@ const deserializeAws_json1_1ResolverQueryLogConfigList = (
 
 const deserializeAws_json1_1ResolverRule = (output: any, context: __SerdeContext): ResolverRule => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    CreationTime: output.CreationTime !== undefined && output.CreationTime !== null ? output.CreationTime : undefined,
-    CreatorRequestId:
-      output.CreatorRequestId !== undefined && output.CreatorRequestId !== null ? output.CreatorRequestId : undefined,
-    DomainName: output.DomainName !== undefined && output.DomainName !== null ? output.DomainName : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    ModificationTime:
-      output.ModificationTime !== undefined && output.ModificationTime !== null ? output.ModificationTime : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    OwnerId: output.OwnerId !== undefined && output.OwnerId !== null ? output.OwnerId : undefined,
-    ResolverEndpointId:
-      output.ResolverEndpointId !== undefined && output.ResolverEndpointId !== null
-        ? output.ResolverEndpointId
-        : undefined,
-    RuleType: output.RuleType !== undefined && output.RuleType !== null ? output.RuleType : undefined,
-    ShareStatus: output.ShareStatus !== undefined && output.ShareStatus !== null ? output.ShareStatus : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusMessage:
-      output.StatusMessage !== undefined && output.StatusMessage !== null ? output.StatusMessage : undefined,
+    Arn: __expectString(output.Arn),
+    CreationTime: __expectString(output.CreationTime),
+    CreatorRequestId: __expectString(output.CreatorRequestId),
+    DomainName: __expectString(output.DomainName),
+    Id: __expectString(output.Id),
+    ModificationTime: __expectString(output.ModificationTime),
+    Name: __expectString(output.Name),
+    OwnerId: __expectString(output.OwnerId),
+    ResolverEndpointId: __expectString(output.ResolverEndpointId),
+    RuleType: __expectString(output.RuleType),
+    ShareStatus: __expectString(output.ShareStatus),
+    Status: __expectString(output.Status),
+    StatusMessage: __expectString(output.StatusMessage),
     TargetIps:
       output.TargetIps !== undefined && output.TargetIps !== null
         ? deserializeAws_json1_1TargetList(output.TargetIps, context)
@@ -8721,14 +8654,12 @@ const deserializeAws_json1_1ResolverRuleAssociation = (
   context: __SerdeContext
 ): ResolverRuleAssociation => {
   return {
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    ResolverRuleId:
-      output.ResolverRuleId !== undefined && output.ResolverRuleId !== null ? output.ResolverRuleId : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusMessage:
-      output.StatusMessage !== undefined && output.StatusMessage !== null ? output.StatusMessage : undefined,
-    VPCId: output.VPCId !== undefined && output.VPCId !== null ? output.VPCId : undefined,
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
+    ResolverRuleId: __expectString(output.ResolverRuleId),
+    Status: __expectString(output.Status),
+    StatusMessage: __expectString(output.StatusMessage),
+    VPCId: __expectString(output.VPCId),
   } as any;
 };
 
@@ -8762,15 +8693,15 @@ const deserializeAws_json1_1ResourceExistsException = (
   context: __SerdeContext
 ): ResourceExistsException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
+    Message: __expectString(output.Message),
+    ResourceType: __expectString(output.ResourceType),
   } as any;
 };
 
 const deserializeAws_json1_1ResourceInUseException = (output: any, context: __SerdeContext): ResourceInUseException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
+    Message: __expectString(output.Message),
+    ResourceType: __expectString(output.ResourceType),
   } as any;
 };
 
@@ -8779,8 +8710,8 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
+    Message: __expectString(output.Message),
+    ResourceType: __expectString(output.ResourceType),
   } as any;
 };
 
@@ -8789,8 +8720,8 @@ const deserializeAws_json1_1ResourceUnavailableException = (
   context: __SerdeContext
 ): ResourceUnavailableException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
+    Message: __expectString(output.Message),
+    ResourceType: __expectString(output.ResourceType),
   } as any;
 };
 
@@ -8801,14 +8732,14 @@ const deserializeAws_json1_1SecurityGroupIds = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -8829,8 +8760,8 @@ const deserializeAws_json1_1TagResourceResponse = (output: any, context: __Serde
 
 const deserializeAws_json1_1TargetAddress = (output: any, context: __SerdeContext): TargetAddress => {
   return {
-    Ip: output.Ip !== undefined && output.Ip !== null ? output.Ip : undefined,
-    Port: output.Port !== undefined && output.Port !== null ? output.Port : undefined,
+    Ip: __expectString(output.Ip),
+    Port: __expectNumber(output.Port),
   } as any;
 };
 
@@ -8847,7 +8778,7 @@ const deserializeAws_json1_1TargetList = (output: any, context: __SerdeContext):
 
 const deserializeAws_json1_1ThrottlingException = (output: any, context: __SerdeContext): ThrottlingException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -8856,7 +8787,7 @@ const deserializeAws_json1_1UnknownResourceException = (
   context: __SerdeContext
 ): UnknownResourceException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -8881,11 +8812,10 @@ const deserializeAws_json1_1UpdateFirewallDomainsResponse = (
   context: __SerdeContext
 ): UpdateFirewallDomainsResponse => {
   return {
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusMessage:
-      output.StatusMessage !== undefined && output.StatusMessage !== null ? output.StatusMessage : undefined,
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
+    Status: __expectString(output.Status),
+    StatusMessage: __expectString(output.StatusMessage),
   } as any;
 };
 
@@ -8951,7 +8881,7 @@ const deserializeAws_json1_1UpdateResolverRuleResponse = (
 
 const deserializeAws_json1_1ValidationException = (output: any, context: __SerdeContext): ValidationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 

--- a/clients/client-s3-control/protocols/Aws_restXml.ts
+++ b/clients/client-s3-control/protocols/Aws_restXml.ts
@@ -222,6 +222,7 @@ import {
 } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
@@ -2424,7 +2425,7 @@ export const deserializeAws_restXmlCreateAccessPointCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data["AccessPointArn"] !== undefined) {
-    contents.AccessPointArn = data["AccessPointArn"];
+    contents.AccessPointArn = __expectString(data["AccessPointArn"]);
   }
   return Promise.resolve(contents);
 };
@@ -2471,7 +2472,7 @@ export const deserializeAws_restXmlCreateAccessPointForObjectLambdaCommand = asy
   };
   const data: any = await parseBody(output.body, context);
   if (data["ObjectLambdaAccessPointArn"] !== undefined) {
-    contents.ObjectLambdaAccessPointArn = data["ObjectLambdaAccessPointArn"];
+    contents.ObjectLambdaAccessPointArn = __expectString(data["ObjectLambdaAccessPointArn"]);
   }
   return Promise.resolve(contents);
 };
@@ -2522,7 +2523,7 @@ export const deserializeAws_restXmlCreateBucketCommand = async (
   }
   const data: any = await parseBody(output.body, context);
   if (data["BucketArn"] !== undefined) {
-    contents.BucketArn = data["BucketArn"];
+    contents.BucketArn = __expectString(data["BucketArn"]);
   }
   return Promise.resolve(contents);
 };
@@ -2585,7 +2586,7 @@ export const deserializeAws_restXmlCreateJobCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data["JobId"] !== undefined) {
-    contents.JobId = data["JobId"];
+    contents.JobId = __expectString(data["JobId"]);
   }
   return Promise.resolve(contents);
 };
@@ -3288,16 +3289,16 @@ export const deserializeAws_restXmlGetAccessPointCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data["Bucket"] !== undefined) {
-    contents.Bucket = data["Bucket"];
+    contents.Bucket = __expectString(data["Bucket"]);
   }
   if (data["CreationDate"] !== undefined) {
     contents.CreationDate = new Date(data["CreationDate"]);
   }
   if (data["Name"] !== undefined) {
-    contents.Name = data["Name"];
+    contents.Name = __expectString(data["Name"]);
   }
   if (data["NetworkOrigin"] !== undefined) {
-    contents.NetworkOrigin = data["NetworkOrigin"];
+    contents.NetworkOrigin = __expectString(data["NetworkOrigin"]);
   }
   if (data["PublicAccessBlockConfiguration"] !== undefined) {
     contents.PublicAccessBlockConfiguration = deserializeAws_restXmlPublicAccessBlockConfiguration(
@@ -3405,7 +3406,7 @@ export const deserializeAws_restXmlGetAccessPointForObjectLambdaCommand = async 
     contents.CreationDate = new Date(data["CreationDate"]);
   }
   if (data["Name"] !== undefined) {
-    contents.Name = data["Name"];
+    contents.Name = __expectString(data["Name"]);
   }
   if (data["PublicAccessBlockConfiguration"] !== undefined) {
     contents.PublicAccessBlockConfiguration = deserializeAws_restXmlPublicAccessBlockConfiguration(
@@ -3458,7 +3459,7 @@ export const deserializeAws_restXmlGetAccessPointPolicyCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data["Policy"] !== undefined) {
-    contents.Policy = data["Policy"];
+    contents.Policy = __expectString(data["Policy"]);
   }
   return Promise.resolve(contents);
 };
@@ -3505,7 +3506,7 @@ export const deserializeAws_restXmlGetAccessPointPolicyForObjectLambdaCommand = 
   };
   const data: any = await parseBody(output.body, context);
   if (data["Policy"] !== undefined) {
-    contents.Policy = data["Policy"];
+    contents.Policy = __expectString(data["Policy"]);
   }
   return Promise.resolve(contents);
 };
@@ -3648,7 +3649,7 @@ export const deserializeAws_restXmlGetBucketCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data["Bucket"] !== undefined) {
-    contents.Bucket = data["Bucket"];
+    contents.Bucket = __expectString(data["Bucket"]);
   }
   if (data["CreationDate"] !== undefined) {
     contents.CreationDate = new Date(data["CreationDate"]);
@@ -3751,7 +3752,7 @@ export const deserializeAws_restXmlGetBucketPolicyCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data["Policy"] !== undefined) {
-    contents.Policy = data["Policy"];
+    contents.Policy = __expectString(data["Policy"]);
   }
   return Promise.resolve(contents);
 };
@@ -4080,7 +4081,7 @@ export const deserializeAws_restXmlListAccessPointsCommand = async (
     );
   }
   if (data["NextToken"] !== undefined) {
-    contents.NextToken = data["NextToken"];
+    contents.NextToken = __expectString(data["NextToken"]);
   }
   return Promise.resolve(contents);
 };
@@ -4128,7 +4129,7 @@ export const deserializeAws_restXmlListAccessPointsForObjectLambdaCommand = asyn
   };
   const data: any = await parseBody(output.body, context);
   if (data["NextToken"] !== undefined) {
-    contents.NextToken = data["NextToken"];
+    contents.NextToken = __expectString(data["NextToken"]);
   }
   if (data.ObjectLambdaAccessPointList === "") {
     contents.ObjectLambdaAccessPointList = [];
@@ -4197,7 +4198,7 @@ export const deserializeAws_restXmlListJobsCommand = async (
     );
   }
   if (data["NextToken"] !== undefined) {
-    contents.NextToken = data["NextToken"];
+    contents.NextToken = __expectString(data["NextToken"]);
   }
   return Promise.resolve(contents);
 };
@@ -4269,7 +4270,7 @@ export const deserializeAws_restXmlListRegionalBucketsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data["NextToken"] !== undefined) {
-    contents.NextToken = data["NextToken"];
+    contents.NextToken = __expectString(data["NextToken"]);
   }
   if (data.RegionalBucketList === "") {
     contents.RegionalBucketList = [];
@@ -4326,7 +4327,7 @@ export const deserializeAws_restXmlListStorageLensConfigurationsCommand = async 
   };
   const data: any = await parseBody(output.body, context);
   if (data["NextToken"] !== undefined) {
-    contents.NextToken = data["NextToken"];
+    contents.NextToken = __expectString(data["NextToken"]);
   }
   if (data.StorageLensConfigurationList === "") {
     contents.StorageLensConfigurationList = [];
@@ -4845,7 +4846,7 @@ export const deserializeAws_restXmlUpdateJobPriorityCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data["JobId"] !== undefined) {
-    contents.JobId = data["JobId"];
+    contents.JobId = __expectString(data["JobId"]);
   }
   if (data["Priority"] !== undefined) {
     contents.Priority = parseInt(data["Priority"]);
@@ -4929,13 +4930,13 @@ export const deserializeAws_restXmlUpdateJobStatusCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data["JobId"] !== undefined) {
-    contents.JobId = data["JobId"];
+    contents.JobId = __expectString(data["JobId"]);
   }
   if (data["Status"] !== undefined) {
-    contents.Status = data["Status"];
+    contents.Status = __expectString(data["Status"]);
   }
   if (data["StatusUpdateReason"] !== undefined) {
-    contents.StatusUpdateReason = data["StatusUpdateReason"];
+    contents.StatusUpdateReason = __expectString(data["StatusUpdateReason"]);
   }
   return Promise.resolve(contents);
 };
@@ -5021,7 +5022,7 @@ const deserializeAws_restXmlBadRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -5064,7 +5065,7 @@ const deserializeAws_restXmlIdempotencyExceptionResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -5081,7 +5082,7 @@ const deserializeAws_restXmlInternalServiceExceptionResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -5098,7 +5099,7 @@ const deserializeAws_restXmlInvalidNextTokenExceptionResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -5115,7 +5116,7 @@ const deserializeAws_restXmlInvalidRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -5132,7 +5133,7 @@ const deserializeAws_restXmlJobStatusExceptionResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -5149,7 +5150,7 @@ const deserializeAws_restXmlNoSuchPublicAccessBlockConfigurationResponse = async
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -5166,7 +5167,7 @@ const deserializeAws_restXmlNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -5183,7 +5184,7 @@ const deserializeAws_restXmlTooManyRequestsExceptionResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -5200,7 +5201,7 @@ const deserializeAws_restXmlTooManyTagsExceptionResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -6542,19 +6543,19 @@ const deserializeAws_restXmlAccessPoint = (output: any, context: __SerdeContext)
     AccessPointArn: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["NetworkOrigin"] !== undefined) {
-    contents.NetworkOrigin = output["NetworkOrigin"];
+    contents.NetworkOrigin = __expectString(output["NetworkOrigin"]);
   }
   if (output["VpcConfiguration"] !== undefined) {
     contents.VpcConfiguration = deserializeAws_restXmlVpcConfiguration(output["VpcConfiguration"], context);
   }
   if (output["Bucket"] !== undefined) {
-    contents.Bucket = output["Bucket"];
+    contents.Bucket = __expectString(output["Bucket"]);
   }
   if (output["AccessPointArn"] !== undefined) {
-    contents.AccessPointArn = output["AccessPointArn"];
+    contents.AccessPointArn = __expectString(output["AccessPointArn"]);
   }
   return contents;
 };
@@ -6603,10 +6604,10 @@ const deserializeAws_restXmlAwsLambdaTransformation = (
     FunctionPayload: undefined,
   };
   if (output["FunctionArn"] !== undefined) {
-    contents.FunctionArn = output["FunctionArn"];
+    contents.FunctionArn = __expectString(output["FunctionArn"]);
   }
   if (output["FunctionPayload"] !== undefined) {
-    contents.FunctionPayload = output["FunctionPayload"];
+    contents.FunctionPayload = __expectString(output["FunctionPayload"]);
   }
   return contents;
 };
@@ -6632,7 +6633,7 @@ const deserializeAws_restXmlBuckets = (output: any, context: __SerdeContext): st
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6697,19 +6698,19 @@ const deserializeAws_restXmlJobDescriptor = (output: any, context: __SerdeContex
     SuspendedCause: undefined,
   };
   if (output["JobId"] !== undefined) {
-    contents.JobId = output["JobId"];
+    contents.JobId = __expectString(output["JobId"]);
   }
   if (output["ConfirmationRequired"] !== undefined) {
     contents.ConfirmationRequired = __parseBoolean(output["ConfirmationRequired"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output["JobArn"] !== undefined) {
-    contents.JobArn = output["JobArn"];
+    contents.JobArn = __expectString(output["JobArn"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["Manifest"] !== undefined) {
     contents.Manifest = deserializeAws_restXmlJobManifest(output["Manifest"], context);
@@ -6724,7 +6725,7 @@ const deserializeAws_restXmlJobDescriptor = (output: any, context: __SerdeContex
     contents.ProgressSummary = deserializeAws_restXmlJobProgressSummary(output["ProgressSummary"], context);
   }
   if (output["StatusUpdateReason"] !== undefined) {
-    contents.StatusUpdateReason = output["StatusUpdateReason"];
+    contents.StatusUpdateReason = __expectString(output["StatusUpdateReason"]);
   }
   if (output.FailureReasons === "") {
     contents.FailureReasons = [];
@@ -6745,13 +6746,13 @@ const deserializeAws_restXmlJobDescriptor = (output: any, context: __SerdeContex
     contents.TerminationDate = new Date(output["TerminationDate"]);
   }
   if (output["RoleArn"] !== undefined) {
-    contents.RoleArn = output["RoleArn"];
+    contents.RoleArn = __expectString(output["RoleArn"]);
   }
   if (output["SuspendedDate"] !== undefined) {
     contents.SuspendedDate = new Date(output["SuspendedDate"]);
   }
   if (output["SuspendedCause"] !== undefined) {
-    contents.SuspendedCause = output["SuspendedCause"];
+    contents.SuspendedCause = __expectString(output["SuspendedCause"]);
   }
   return contents;
 };
@@ -6762,10 +6763,10 @@ const deserializeAws_restXmlJobFailure = (output: any, context: __SerdeContext):
     FailureReason: undefined,
   };
   if (output["FailureCode"] !== undefined) {
-    contents.FailureCode = output["FailureCode"];
+    contents.FailureCode = __expectString(output["FailureCode"]);
   }
   if (output["FailureReason"] !== undefined) {
-    contents.FailureReason = output["FailureReason"];
+    contents.FailureReason = __expectString(output["FailureReason"]);
   }
   return contents;
 };
@@ -6793,19 +6794,19 @@ const deserializeAws_restXmlJobListDescriptor = (output: any, context: __SerdeCo
     ProgressSummary: undefined,
   };
   if (output["JobId"] !== undefined) {
-    contents.JobId = output["JobId"];
+    contents.JobId = __expectString(output["JobId"]);
   }
   if (output["Description"] !== undefined) {
-    contents.Description = output["Description"];
+    contents.Description = __expectString(output["Description"]);
   }
   if (output["Operation"] !== undefined) {
-    contents.Operation = output["Operation"];
+    contents.Operation = __expectString(output["Operation"]);
   }
   if (output["Priority"] !== undefined) {
     contents.Priority = parseInt(output["Priority"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["CreationTime"] !== undefined) {
     contents.CreationTime = new Date(output["CreationTime"]);
@@ -6854,7 +6855,7 @@ const deserializeAws_restXmlJobManifestFieldList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6865,13 +6866,13 @@ const deserializeAws_restXmlJobManifestLocation = (output: any, context: __Serde
     ETag: undefined,
   };
   if (output["ObjectArn"] !== undefined) {
-    contents.ObjectArn = output["ObjectArn"];
+    contents.ObjectArn = __expectString(output["ObjectArn"]);
   }
   if (output["ObjectVersionId"] !== undefined) {
-    contents.ObjectVersionId = output["ObjectVersionId"];
+    contents.ObjectVersionId = __expectString(output["ObjectVersionId"]);
   }
   if (output["ETag"] !== undefined) {
-    contents.ETag = output["ETag"];
+    contents.ETag = __expectString(output["ETag"]);
   }
   return contents;
 };
@@ -6882,7 +6883,7 @@ const deserializeAws_restXmlJobManifestSpec = (output: any, context: __SerdeCont
     Fields: undefined,
   };
   if (output["Format"] !== undefined) {
-    contents.Format = output["Format"];
+    contents.Format = __expectString(output["Format"]);
   }
   if (output.Fields === "") {
     contents.Fields = [];
@@ -6976,19 +6977,19 @@ const deserializeAws_restXmlJobReport = (output: any, context: __SerdeContext): 
     ReportScope: undefined,
   };
   if (output["Bucket"] !== undefined) {
-    contents.Bucket = output["Bucket"];
+    contents.Bucket = __expectString(output["Bucket"]);
   }
   if (output["Format"] !== undefined) {
-    contents.Format = output["Format"];
+    contents.Format = __expectString(output["Format"]);
   }
   if (output["Enabled"] !== undefined) {
     contents.Enabled = __parseBoolean(output["Enabled"]);
   }
   if (output["Prefix"] !== undefined) {
-    contents.Prefix = output["Prefix"];
+    contents.Prefix = __expectString(output["Prefix"]);
   }
   if (output["ReportScope"] !== undefined) {
-    contents.ReportScope = output["ReportScope"];
+    contents.ReportScope = __expectString(output["ReportScope"]);
   }
   return contents;
 };
@@ -6998,7 +6999,7 @@ const deserializeAws_restXmlLambdaInvokeOperation = (output: any, context: __Ser
     FunctionArn: undefined,
   };
   if (output["FunctionArn"] !== undefined) {
-    contents.FunctionArn = output["FunctionArn"];
+    contents.FunctionArn = __expectString(output["FunctionArn"]);
   }
   return contents;
 };
@@ -7036,13 +7037,13 @@ const deserializeAws_restXmlLifecycleRule = (output: any, context: __SerdeContex
     contents.Expiration = deserializeAws_restXmlLifecycleExpiration(output["Expiration"], context);
   }
   if (output["ID"] !== undefined) {
-    contents.ID = output["ID"];
+    contents.ID = __expectString(output["ID"]);
   }
   if (output["Filter"] !== undefined) {
     contents.Filter = deserializeAws_restXmlLifecycleRuleFilter(output["Filter"], context);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output.Transitions === "") {
     contents.Transitions = [];
@@ -7089,7 +7090,7 @@ const deserializeAws_restXmlLifecycleRuleAndOperator = (
     Tags: undefined,
   };
   if (output["Prefix"] !== undefined) {
-    contents.Prefix = output["Prefix"];
+    contents.Prefix = __expectString(output["Prefix"]);
   }
   if (output.Tags === "") {
     contents.Tags = [];
@@ -7107,7 +7108,7 @@ const deserializeAws_restXmlLifecycleRuleFilter = (output: any, context: __Serde
     And: undefined,
   };
   if (output["Prefix"] !== undefined) {
-    contents.Prefix = output["Prefix"];
+    contents.Prefix = __expectString(output["Prefix"]);
   }
   if (output["Tag"] !== undefined) {
     contents.Tag = deserializeAws_restXmlS3Tag(output["Tag"], context);
@@ -7140,13 +7141,13 @@ const deserializeAws_restXmlListStorageLensConfigurationEntry = (
     IsEnabled: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   if (output["StorageLensArn"] !== undefined) {
-    contents.StorageLensArn = output["StorageLensArn"];
+    contents.StorageLensArn = __expectString(output["StorageLensArn"]);
   }
   if (output["HomeRegion"] !== undefined) {
-    contents.HomeRegion = output["HomeRegion"];
+    contents.HomeRegion = __expectString(output["HomeRegion"]);
   }
   if (output["IsEnabled"] !== undefined) {
     contents.IsEnabled = __parseBoolean(output["IsEnabled"]);
@@ -7179,7 +7180,7 @@ const deserializeAws_restXmlNoncurrentVersionTransition = (
     contents.NoncurrentDays = parseInt(output["NoncurrentDays"]);
   }
   if (output["StorageClass"] !== undefined) {
-    contents.StorageClass = output["StorageClass"];
+    contents.StorageClass = __expectString(output["StorageClass"]);
   }
   return contents;
 };
@@ -7207,10 +7208,10 @@ const deserializeAws_restXmlObjectLambdaAccessPoint = (
     ObjectLambdaAccessPointArn: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["ObjectLambdaAccessPointArn"] !== undefined) {
-    contents.ObjectLambdaAccessPointArn = output["ObjectLambdaAccessPointArn"];
+    contents.ObjectLambdaAccessPointArn = __expectString(output["ObjectLambdaAccessPointArn"]);
   }
   return contents;
 };
@@ -7239,7 +7240,7 @@ const deserializeAws_restXmlObjectLambdaAllowedFeaturesList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7254,7 +7255,7 @@ const deserializeAws_restXmlObjectLambdaConfiguration = (
     TransformationConfigurations: undefined,
   };
   if (output["SupportingAccessPoint"] !== undefined) {
-    contents.SupportingAccessPoint = output["SupportingAccessPoint"];
+    contents.SupportingAccessPoint = __expectString(output["SupportingAccessPoint"]);
   }
   if (output["CloudWatchMetricsEnabled"] !== undefined) {
     contents.CloudWatchMetricsEnabled = __parseBoolean(output["CloudWatchMetricsEnabled"]);
@@ -7331,7 +7332,7 @@ const deserializeAws_restXmlObjectLambdaTransformationConfigurationActionsList =
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7420,10 +7421,10 @@ const deserializeAws_restXmlRegionalBucket = (output: any, context: __SerdeConte
     OutpostId: undefined,
   };
   if (output["Bucket"] !== undefined) {
-    contents.Bucket = output["Bucket"];
+    contents.Bucket = __expectString(output["Bucket"]);
   }
   if (output["BucketArn"] !== undefined) {
-    contents.BucketArn = output["BucketArn"];
+    contents.BucketArn = __expectString(output["BucketArn"]);
   }
   if (output["PublicAccessBlockEnabled"] !== undefined) {
     contents.PublicAccessBlockEnabled = __parseBoolean(output["PublicAccessBlockEnabled"]);
@@ -7432,7 +7433,7 @@ const deserializeAws_restXmlRegionalBucket = (output: any, context: __SerdeConte
     contents.CreationDate = new Date(output["CreationDate"]);
   }
   if (output["OutpostId"] !== undefined) {
-    contents.OutpostId = output["OutpostId"];
+    contents.OutpostId = __expectString(output["OutpostId"]);
   }
   return contents;
 };
@@ -7455,7 +7456,7 @@ const deserializeAws_restXmlRegions = (output: any, context: __SerdeContext): st
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7485,7 +7486,7 @@ const deserializeAws_restXmlS3AccessControlPolicy = (output: any, context: __Ser
     contents.AccessControlList = deserializeAws_restXmlS3AccessControlList(output["AccessControlList"], context);
   }
   if (output["CannedAccessControlList"] !== undefined) {
-    contents.CannedAccessControlList = output["CannedAccessControlList"];
+    contents.CannedAccessControlList = __expectString(output["CannedAccessControlList"]);
   }
   return contents;
 };
@@ -7500,19 +7501,19 @@ const deserializeAws_restXmlS3BucketDestination = (output: any, context: __Serde
     Encryption: undefined,
   };
   if (output["Format"] !== undefined) {
-    contents.Format = output["Format"];
+    contents.Format = __expectString(output["Format"]);
   }
   if (output["OutputSchemaVersion"] !== undefined) {
-    contents.OutputSchemaVersion = output["OutputSchemaVersion"];
+    contents.OutputSchemaVersion = __expectString(output["OutputSchemaVersion"]);
   }
   if (output["AccountId"] !== undefined) {
-    contents.AccountId = output["AccountId"];
+    contents.AccountId = __expectString(output["AccountId"]);
   }
   if (output["Arn"] !== undefined) {
-    contents.Arn = output["Arn"];
+    contents.Arn = __expectString(output["Arn"]);
   }
   if (output["Prefix"] !== undefined) {
-    contents.Prefix = output["Prefix"];
+    contents.Prefix = __expectString(output["Prefix"]);
   }
   if (output["Encryption"] !== undefined) {
     contents.Encryption = deserializeAws_restXmlStorageLensDataExportEncryption(output["Encryption"], context);
@@ -7541,10 +7542,10 @@ const deserializeAws_restXmlS3CopyObjectOperation = (output: any, context: __Ser
     BucketKeyEnabled: undefined,
   };
   if (output["TargetResource"] !== undefined) {
-    contents.TargetResource = output["TargetResource"];
+    contents.TargetResource = __expectString(output["TargetResource"]);
   }
   if (output["CannedAccessControlList"] !== undefined) {
-    contents.CannedAccessControlList = output["CannedAccessControlList"];
+    contents.CannedAccessControlList = __expectString(output["CannedAccessControlList"]);
   }
   if (output.AccessControlGrants === "") {
     contents.AccessControlGrants = [];
@@ -7556,7 +7557,7 @@ const deserializeAws_restXmlS3CopyObjectOperation = (output: any, context: __Ser
     );
   }
   if (output["MetadataDirective"] !== undefined) {
-    contents.MetadataDirective = output["MetadataDirective"];
+    contents.MetadataDirective = __expectString(output["MetadataDirective"]);
   }
   if (output["ModifiedSinceConstraint"] !== undefined) {
     contents.ModifiedSinceConstraint = new Date(output["ModifiedSinceConstraint"]);
@@ -7574,28 +7575,28 @@ const deserializeAws_restXmlS3CopyObjectOperation = (output: any, context: __Ser
     );
   }
   if (output["RedirectLocation"] !== undefined) {
-    contents.RedirectLocation = output["RedirectLocation"];
+    contents.RedirectLocation = __expectString(output["RedirectLocation"]);
   }
   if (output["RequesterPays"] !== undefined) {
     contents.RequesterPays = __parseBoolean(output["RequesterPays"]);
   }
   if (output["StorageClass"] !== undefined) {
-    contents.StorageClass = output["StorageClass"];
+    contents.StorageClass = __expectString(output["StorageClass"]);
   }
   if (output["UnModifiedSinceConstraint"] !== undefined) {
     contents.UnModifiedSinceConstraint = new Date(output["UnModifiedSinceConstraint"]);
   }
   if (output["SSEAwsKmsKeyId"] !== undefined) {
-    contents.SSEAwsKmsKeyId = output["SSEAwsKmsKeyId"];
+    contents.SSEAwsKmsKeyId = __expectString(output["SSEAwsKmsKeyId"]);
   }
   if (output["TargetKeyPrefix"] !== undefined) {
-    contents.TargetKeyPrefix = output["TargetKeyPrefix"];
+    contents.TargetKeyPrefix = __expectString(output["TargetKeyPrefix"]);
   }
   if (output["ObjectLockLegalHoldStatus"] !== undefined) {
-    contents.ObjectLockLegalHoldStatus = output["ObjectLockLegalHoldStatus"];
+    contents.ObjectLockLegalHoldStatus = __expectString(output["ObjectLockLegalHoldStatus"]);
   }
   if (output["ObjectLockMode"] !== undefined) {
-    contents.ObjectLockMode = output["ObjectLockMode"];
+    contents.ObjectLockMode = __expectString(output["ObjectLockMode"]);
   }
   if (output["ObjectLockRetainUntilDate"] !== undefined) {
     contents.ObjectLockRetainUntilDate = new Date(output["ObjectLockRetainUntilDate"]);
@@ -7623,7 +7624,7 @@ const deserializeAws_restXmlS3Grant = (output: any, context: __SerdeContext): S3
     contents.Grantee = deserializeAws_restXmlS3Grantee(output["Grantee"], context);
   }
   if (output["Permission"] !== undefined) {
-    contents.Permission = output["Permission"];
+    contents.Permission = __expectString(output["Permission"]);
   }
   return contents;
 };
@@ -7635,13 +7636,13 @@ const deserializeAws_restXmlS3Grantee = (output: any, context: __SerdeContext): 
     DisplayName: undefined,
   };
   if (output["TypeIdentifier"] !== undefined) {
-    contents.TypeIdentifier = output["TypeIdentifier"];
+    contents.TypeIdentifier = __expectString(output["TypeIdentifier"]);
   }
   if (output["Identifier"] !== undefined) {
-    contents.Identifier = output["Identifier"];
+    contents.Identifier = __expectString(output["Identifier"]);
   }
   if (output["DisplayName"] !== undefined) {
-    contents.DisplayName = output["DisplayName"];
+    contents.DisplayName = __expectString(output["DisplayName"]);
   }
   return contents;
 };
@@ -7669,7 +7670,7 @@ const deserializeAws_restXmlS3InitiateRestoreObjectOperation = (
     contents.ExpirationInDays = parseInt(output["ExpirationInDays"]);
   }
   if (output["GlacierJobTier"] !== undefined) {
-    contents.GlacierJobTier = output["GlacierJobTier"];
+    contents.GlacierJobTier = __expectString(output["GlacierJobTier"]);
   }
   return contents;
 };
@@ -7679,7 +7680,7 @@ const deserializeAws_restXmlS3ObjectLockLegalHold = (output: any, context: __Ser
     Status: undefined,
   };
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   return contents;
 };
@@ -7699,16 +7700,16 @@ const deserializeAws_restXmlS3ObjectMetadata = (output: any, context: __SerdeCon
     SSEAlgorithm: undefined,
   };
   if (output["CacheControl"] !== undefined) {
-    contents.CacheControl = output["CacheControl"];
+    contents.CacheControl = __expectString(output["CacheControl"]);
   }
   if (output["ContentDisposition"] !== undefined) {
-    contents.ContentDisposition = output["ContentDisposition"];
+    contents.ContentDisposition = __expectString(output["ContentDisposition"]);
   }
   if (output["ContentEncoding"] !== undefined) {
-    contents.ContentEncoding = output["ContentEncoding"];
+    contents.ContentEncoding = __expectString(output["ContentEncoding"]);
   }
   if (output["ContentLanguage"] !== undefined) {
-    contents.ContentLanguage = output["ContentLanguage"];
+    contents.ContentLanguage = __expectString(output["ContentLanguage"]);
   }
   if (output.UserMetadata === "") {
     contents.UserMetadata = {};
@@ -7723,10 +7724,10 @@ const deserializeAws_restXmlS3ObjectMetadata = (output: any, context: __SerdeCon
     contents.ContentLength = parseInt(output["ContentLength"]);
   }
   if (output["ContentMD5"] !== undefined) {
-    contents.ContentMD5 = output["ContentMD5"];
+    contents.ContentMD5 = __expectString(output["ContentMD5"]);
   }
   if (output["ContentType"] !== undefined) {
-    contents.ContentType = output["ContentType"];
+    contents.ContentType = __expectString(output["ContentType"]);
   }
   if (output["HttpExpiresDate"] !== undefined) {
     contents.HttpExpiresDate = new Date(output["HttpExpiresDate"]);
@@ -7735,7 +7736,7 @@ const deserializeAws_restXmlS3ObjectMetadata = (output: any, context: __SerdeCon
     contents.RequesterCharged = __parseBoolean(output["RequesterCharged"]);
   }
   if (output["SSEAlgorithm"] !== undefined) {
-    contents.SSEAlgorithm = output["SSEAlgorithm"];
+    contents.SSEAlgorithm = __expectString(output["SSEAlgorithm"]);
   }
   return contents;
 };
@@ -7746,10 +7747,10 @@ const deserializeAws_restXmlS3ObjectOwner = (output: any, context: __SerdeContex
     DisplayName: undefined,
   };
   if (output["ID"] !== undefined) {
-    contents.ID = output["ID"];
+    contents.ID = __expectString(output["ID"]);
   }
   if (output["DisplayName"] !== undefined) {
-    contents.DisplayName = output["DisplayName"];
+    contents.DisplayName = __expectString(output["DisplayName"]);
   }
   return contents;
 };
@@ -7763,7 +7764,7 @@ const deserializeAws_restXmlS3Retention = (output: any, context: __SerdeContext)
     contents.RetainUntilDate = new Date(output["RetainUntilDate"]);
   }
   if (output["Mode"] !== undefined) {
-    contents.Mode = output["Mode"];
+    contents.Mode = __expectString(output["Mode"]);
   }
   return contents;
 };
@@ -7833,10 +7834,10 @@ const deserializeAws_restXmlS3Tag = (output: any, context: __SerdeContext): S3Ta
     Value: undefined,
   };
   if (output["Key"] !== undefined) {
-    contents.Key = output["Key"];
+    contents.Key = __expectString(output["Key"]);
   }
   if (output["Value"] !== undefined) {
-    contents.Value = output["Value"];
+    contents.Value = __expectString(output["Value"]);
   }
   return contents;
 };
@@ -7859,7 +7860,7 @@ const deserializeAws_restXmlS3UserMetadata = (output: any, context: __SerdeConte
     }
     return {
       ...acc,
-      [pair["key"]]: pair["value"],
+      [pair["key"]]: __expectString(pair["value"]) as any,
     };
   }, {});
 };
@@ -7871,7 +7872,7 @@ const deserializeAws_restXmlSelectionCriteria = (output: any, context: __SerdeCo
     MinStorageBytesPercentage: undefined,
   };
   if (output["Delimiter"] !== undefined) {
-    contents.Delimiter = output["Delimiter"];
+    contents.Delimiter = __expectString(output["Delimiter"]);
   }
   if (output["MaxDepth"] !== undefined) {
     contents.MaxDepth = parseInt(output["MaxDepth"]);
@@ -7887,7 +7888,7 @@ const deserializeAws_restXmlSSEKMS = (output: any, context: __SerdeContext): SSE
     KeyId: undefined,
   };
   if (output["KeyId"] !== undefined) {
-    contents.KeyId = output["KeyId"];
+    contents.KeyId = __expectString(output["KeyId"]);
   }
   return contents;
 };
@@ -7902,7 +7903,7 @@ const deserializeAws_restXmlStorageLensAwsOrg = (output: any, context: __SerdeCo
     Arn: undefined,
   };
   if (output["Arn"] !== undefined) {
-    contents.Arn = output["Arn"];
+    contents.Arn = __expectString(output["Arn"]);
   }
   return contents;
 };
@@ -7922,7 +7923,7 @@ const deserializeAws_restXmlStorageLensConfiguration = (
     StorageLensArn: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   if (output["AccountLevel"] !== undefined) {
     contents.AccountLevel = deserializeAws_restXmlAccountLevel(output["AccountLevel"], context);
@@ -7943,7 +7944,7 @@ const deserializeAws_restXmlStorageLensConfiguration = (
     contents.AwsOrg = deserializeAws_restXmlStorageLensAwsOrg(output["AwsOrg"], context);
   }
   if (output["StorageLensArn"] !== undefined) {
-    contents.StorageLensArn = output["StorageLensArn"];
+    contents.StorageLensArn = __expectString(output["StorageLensArn"]);
   }
   return contents;
 };
@@ -7995,10 +7996,10 @@ const deserializeAws_restXmlStorageLensTag = (output: any, context: __SerdeConte
     Value: undefined,
   };
   if (output["Key"] !== undefined) {
-    contents.Key = output["Key"];
+    contents.Key = __expectString(output["Key"]);
   }
   if (output["Value"] !== undefined) {
-    contents.Value = output["Value"];
+    contents.Value = __expectString(output["Value"]);
   }
   return contents;
 };
@@ -8027,7 +8028,7 @@ const deserializeAws_restXmlTransition = (output: any, context: __SerdeContext):
     contents.Days = parseInt(output["Days"]);
   }
   if (output["StorageClass"] !== undefined) {
-    contents.StorageClass = output["StorageClass"];
+    contents.StorageClass = __expectString(output["StorageClass"]);
   }
   return contents;
 };
@@ -8048,7 +8049,7 @@ const deserializeAws_restXmlVpcConfiguration = (output: any, context: __SerdeCon
     VpcId: undefined,
   };
   if (output["VpcId"] !== undefined) {
-    contents.VpcId = output["VpcId"];
+    contents.VpcId = __expectString(output["VpcId"]);
   }
   return contents;
 };

--- a/clients/client-s3/protocols/Aws_restXml.ts
+++ b/clients/client-s3/protocols/Aws_restXml.ts
@@ -393,6 +393,7 @@ import {
 import {
   SmithyException as __SmithyException,
   dateToUtcString as __dateToUtcString,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
@@ -5016,16 +5017,16 @@ export const deserializeAws_restXmlCompleteMultipartUploadCommand = async (
   }
   const data: any = await parseBody(output.body, context);
   if (data["Bucket"] !== undefined) {
-    contents.Bucket = data["Bucket"];
+    contents.Bucket = __expectString(data["Bucket"]);
   }
   if (data["ETag"] !== undefined) {
-    contents.ETag = data["ETag"];
+    contents.ETag = __expectString(data["ETag"]);
   }
   if (data["Key"] !== undefined) {
-    contents.Key = data["Key"];
+    contents.Key = __expectString(data["Key"]);
   }
   if (data["Location"] !== undefined) {
-    contents.Location = data["Location"];
+    contents.Location = __expectString(data["Location"]);
   }
   return Promise.resolve(contents);
 };
@@ -5266,13 +5267,13 @@ export const deserializeAws_restXmlCreateMultipartUploadCommand = async (
   }
   const data: any = await parseBody(output.body, context);
   if (data["Bucket"] !== undefined) {
-    contents.Bucket = data["Bucket"];
+    contents.Bucket = __expectString(data["Bucket"]);
   }
   if (data["Key"] !== undefined) {
-    contents.Key = data["Key"];
+    contents.Key = __expectString(data["Key"]);
   }
   if (data["UploadId"] !== undefined) {
-    contents.UploadId = data["UploadId"];
+    contents.UploadId = __expectString(data["UploadId"]);
   }
   return Promise.resolve(contents);
 };
@@ -6084,7 +6085,7 @@ export const deserializeAws_restXmlGetBucketAccelerateConfigurationCommand = asy
   };
   const data: any = await parseBody(output.body, context);
   if (data["Status"] !== undefined) {
-    contents.Status = data["Status"];
+    contents.Status = __expectString(data["Status"]);
   }
   return Promise.resolve(contents);
 };
@@ -6465,7 +6466,7 @@ export const deserializeAws_restXmlGetBucketLocationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data["LocationConstraint"] !== undefined) {
-    contents.LocationConstraint = data["LocationConstraint"];
+    contents.LocationConstraint = __expectString(data["LocationConstraint"]);
   }
   return Promise.resolve(contents);
 };
@@ -6721,7 +6722,7 @@ export const deserializeAws_restXmlGetBucketPolicyCommand = async (
     Policy: undefined,
   };
   const data: any = await collectBodyString(output.body, context);
-  contents.Policy = data;
+  contents.Policy = __expectString(data);
   return Promise.resolve(contents);
 };
 
@@ -6857,7 +6858,7 @@ export const deserializeAws_restXmlGetBucketRequestPaymentCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data["Payer"] !== undefined) {
-    contents.Payer = data["Payer"];
+    contents.Payer = __expectString(data["Payer"]);
   }
   return Promise.resolve(contents);
 };
@@ -6955,10 +6956,10 @@ export const deserializeAws_restXmlGetBucketVersioningCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data["MfaDelete"] !== undefined) {
-    contents.MFADelete = data["MfaDelete"];
+    contents.MFADelete = __expectString(data["MfaDelete"]);
   }
   if (data["Status"] !== undefined) {
-    contents.Status = data["Status"];
+    contents.Status = __expectString(data["Status"]);
   }
   return Promise.resolve(contents);
 };
@@ -7851,13 +7852,13 @@ export const deserializeAws_restXmlListBucketAnalyticsConfigurationsCommand = as
     );
   }
   if (data["ContinuationToken"] !== undefined) {
-    contents.ContinuationToken = data["ContinuationToken"];
+    contents.ContinuationToken = __expectString(data["ContinuationToken"]);
   }
   if (data["IsTruncated"] !== undefined) {
     contents.IsTruncated = __parseBoolean(data["IsTruncated"]);
   }
   if (data["NextContinuationToken"] !== undefined) {
-    contents.NextContinuationToken = data["NextContinuationToken"];
+    contents.NextContinuationToken = __expectString(data["NextContinuationToken"]);
   }
   return Promise.resolve(contents);
 };
@@ -7907,7 +7908,7 @@ export const deserializeAws_restXmlListBucketIntelligentTieringConfigurationsCom
   };
   const data: any = await parseBody(output.body, context);
   if (data["ContinuationToken"] !== undefined) {
-    contents.ContinuationToken = data["ContinuationToken"];
+    contents.ContinuationToken = __expectString(data["ContinuationToken"]);
   }
   if (data.IntelligentTieringConfiguration === "") {
     contents.IntelligentTieringConfigurationList = [];
@@ -7922,7 +7923,7 @@ export const deserializeAws_restXmlListBucketIntelligentTieringConfigurationsCom
     contents.IsTruncated = __parseBoolean(data["IsTruncated"]);
   }
   if (data["NextContinuationToken"] !== undefined) {
-    contents.NextContinuationToken = data["NextContinuationToken"];
+    contents.NextContinuationToken = __expectString(data["NextContinuationToken"]);
   }
   return Promise.resolve(contents);
 };
@@ -7972,7 +7973,7 @@ export const deserializeAws_restXmlListBucketInventoryConfigurationsCommand = as
   };
   const data: any = await parseBody(output.body, context);
   if (data["ContinuationToken"] !== undefined) {
-    contents.ContinuationToken = data["ContinuationToken"];
+    contents.ContinuationToken = __expectString(data["ContinuationToken"]);
   }
   if (data.InventoryConfiguration === "") {
     contents.InventoryConfigurationList = [];
@@ -7987,7 +7988,7 @@ export const deserializeAws_restXmlListBucketInventoryConfigurationsCommand = as
     contents.IsTruncated = __parseBoolean(data["IsTruncated"]);
   }
   if (data["NextContinuationToken"] !== undefined) {
-    contents.NextContinuationToken = data["NextContinuationToken"];
+    contents.NextContinuationToken = __expectString(data["NextContinuationToken"]);
   }
   return Promise.resolve(contents);
 };
@@ -8037,7 +8038,7 @@ export const deserializeAws_restXmlListBucketMetricsConfigurationsCommand = asyn
   };
   const data: any = await parseBody(output.body, context);
   if (data["ContinuationToken"] !== undefined) {
-    contents.ContinuationToken = data["ContinuationToken"];
+    contents.ContinuationToken = __expectString(data["ContinuationToken"]);
   }
   if (data["IsTruncated"] !== undefined) {
     contents.IsTruncated = __parseBoolean(data["IsTruncated"]);
@@ -8052,7 +8053,7 @@ export const deserializeAws_restXmlListBucketMetricsConfigurationsCommand = asyn
     );
   }
   if (data["NextContinuationToken"] !== undefined) {
-    contents.NextContinuationToken = data["NextContinuationToken"];
+    contents.NextContinuationToken = __expectString(data["NextContinuationToken"]);
   }
   return Promise.resolve(contents);
 };
@@ -8164,7 +8165,7 @@ export const deserializeAws_restXmlListMultipartUploadsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data["Bucket"] !== undefined) {
-    contents.Bucket = data["Bucket"];
+    contents.Bucket = __expectString(data["Bucket"]);
   }
   if (data.CommonPrefixes === "") {
     contents.CommonPrefixes = [];
@@ -8176,31 +8177,31 @@ export const deserializeAws_restXmlListMultipartUploadsCommand = async (
     );
   }
   if (data["Delimiter"] !== undefined) {
-    contents.Delimiter = data["Delimiter"];
+    contents.Delimiter = __expectString(data["Delimiter"]);
   }
   if (data["EncodingType"] !== undefined) {
-    contents.EncodingType = data["EncodingType"];
+    contents.EncodingType = __expectString(data["EncodingType"]);
   }
   if (data["IsTruncated"] !== undefined) {
     contents.IsTruncated = __parseBoolean(data["IsTruncated"]);
   }
   if (data["KeyMarker"] !== undefined) {
-    contents.KeyMarker = data["KeyMarker"];
+    contents.KeyMarker = __expectString(data["KeyMarker"]);
   }
   if (data["MaxUploads"] !== undefined) {
     contents.MaxUploads = parseInt(data["MaxUploads"]);
   }
   if (data["NextKeyMarker"] !== undefined) {
-    contents.NextKeyMarker = data["NextKeyMarker"];
+    contents.NextKeyMarker = __expectString(data["NextKeyMarker"]);
   }
   if (data["NextUploadIdMarker"] !== undefined) {
-    contents.NextUploadIdMarker = data["NextUploadIdMarker"];
+    contents.NextUploadIdMarker = __expectString(data["NextUploadIdMarker"]);
   }
   if (data["Prefix"] !== undefined) {
-    contents.Prefix = data["Prefix"];
+    contents.Prefix = __expectString(data["Prefix"]);
   }
   if (data["UploadIdMarker"] !== undefined) {
-    contents.UploadIdMarker = data["UploadIdMarker"];
+    contents.UploadIdMarker = __expectString(data["UploadIdMarker"]);
   }
   if (data.Upload === "") {
     contents.Uploads = [];
@@ -8277,28 +8278,28 @@ export const deserializeAws_restXmlListObjectsCommand = async (
     contents.Contents = deserializeAws_restXmlObjectList(__getArrayIfSingleItem(data["Contents"]), context);
   }
   if (data["Delimiter"] !== undefined) {
-    contents.Delimiter = data["Delimiter"];
+    contents.Delimiter = __expectString(data["Delimiter"]);
   }
   if (data["EncodingType"] !== undefined) {
-    contents.EncodingType = data["EncodingType"];
+    contents.EncodingType = __expectString(data["EncodingType"]);
   }
   if (data["IsTruncated"] !== undefined) {
     contents.IsTruncated = __parseBoolean(data["IsTruncated"]);
   }
   if (data["Marker"] !== undefined) {
-    contents.Marker = data["Marker"];
+    contents.Marker = __expectString(data["Marker"]);
   }
   if (data["MaxKeys"] !== undefined) {
     contents.MaxKeys = parseInt(data["MaxKeys"]);
   }
   if (data["Name"] !== undefined) {
-    contents.Name = data["Name"];
+    contents.Name = __expectString(data["Name"]);
   }
   if (data["NextMarker"] !== undefined) {
-    contents.NextMarker = data["NextMarker"];
+    contents.NextMarker = __expectString(data["NextMarker"]);
   }
   if (data["Prefix"] !== undefined) {
-    contents.Prefix = data["Prefix"];
+    contents.Prefix = __expectString(data["Prefix"]);
   }
   return Promise.resolve(contents);
 };
@@ -8379,13 +8380,13 @@ export const deserializeAws_restXmlListObjectsV2Command = async (
     contents.Contents = deserializeAws_restXmlObjectList(__getArrayIfSingleItem(data["Contents"]), context);
   }
   if (data["ContinuationToken"] !== undefined) {
-    contents.ContinuationToken = data["ContinuationToken"];
+    contents.ContinuationToken = __expectString(data["ContinuationToken"]);
   }
   if (data["Delimiter"] !== undefined) {
-    contents.Delimiter = data["Delimiter"];
+    contents.Delimiter = __expectString(data["Delimiter"]);
   }
   if (data["EncodingType"] !== undefined) {
-    contents.EncodingType = data["EncodingType"];
+    contents.EncodingType = __expectString(data["EncodingType"]);
   }
   if (data["IsTruncated"] !== undefined) {
     contents.IsTruncated = __parseBoolean(data["IsTruncated"]);
@@ -8397,16 +8398,16 @@ export const deserializeAws_restXmlListObjectsV2Command = async (
     contents.MaxKeys = parseInt(data["MaxKeys"]);
   }
   if (data["Name"] !== undefined) {
-    contents.Name = data["Name"];
+    contents.Name = __expectString(data["Name"]);
   }
   if (data["NextContinuationToken"] !== undefined) {
-    contents.NextContinuationToken = data["NextContinuationToken"];
+    contents.NextContinuationToken = __expectString(data["NextContinuationToken"]);
   }
   if (data["Prefix"] !== undefined) {
-    contents.Prefix = data["Prefix"];
+    contents.Prefix = __expectString(data["Prefix"]);
   }
   if (data["StartAfter"] !== undefined) {
-    contents.StartAfter = data["StartAfter"];
+    contents.StartAfter = __expectString(data["StartAfter"]);
   }
   return Promise.resolve(contents);
 };
@@ -8488,34 +8489,34 @@ export const deserializeAws_restXmlListObjectVersionsCommand = async (
     contents.DeleteMarkers = deserializeAws_restXmlDeleteMarkers(__getArrayIfSingleItem(data["DeleteMarker"]), context);
   }
   if (data["Delimiter"] !== undefined) {
-    contents.Delimiter = data["Delimiter"];
+    contents.Delimiter = __expectString(data["Delimiter"]);
   }
   if (data["EncodingType"] !== undefined) {
-    contents.EncodingType = data["EncodingType"];
+    contents.EncodingType = __expectString(data["EncodingType"]);
   }
   if (data["IsTruncated"] !== undefined) {
     contents.IsTruncated = __parseBoolean(data["IsTruncated"]);
   }
   if (data["KeyMarker"] !== undefined) {
-    contents.KeyMarker = data["KeyMarker"];
+    contents.KeyMarker = __expectString(data["KeyMarker"]);
   }
   if (data["MaxKeys"] !== undefined) {
     contents.MaxKeys = parseInt(data["MaxKeys"]);
   }
   if (data["Name"] !== undefined) {
-    contents.Name = data["Name"];
+    contents.Name = __expectString(data["Name"]);
   }
   if (data["NextKeyMarker"] !== undefined) {
-    contents.NextKeyMarker = data["NextKeyMarker"];
+    contents.NextKeyMarker = __expectString(data["NextKeyMarker"]);
   }
   if (data["NextVersionIdMarker"] !== undefined) {
-    contents.NextVersionIdMarker = data["NextVersionIdMarker"];
+    contents.NextVersionIdMarker = __expectString(data["NextVersionIdMarker"]);
   }
   if (data["Prefix"] !== undefined) {
-    contents.Prefix = data["Prefix"];
+    contents.Prefix = __expectString(data["Prefix"]);
   }
   if (data["VersionIdMarker"] !== undefined) {
-    contents.VersionIdMarker = data["VersionIdMarker"];
+    contents.VersionIdMarker = __expectString(data["VersionIdMarker"]);
   }
   if (data.Version === "") {
     contents.Versions = [];
@@ -8590,7 +8591,7 @@ export const deserializeAws_restXmlListPartsCommand = async (
   }
   const data: any = await parseBody(output.body, context);
   if (data["Bucket"] !== undefined) {
-    contents.Bucket = data["Bucket"];
+    contents.Bucket = __expectString(data["Bucket"]);
   }
   if (data["Initiator"] !== undefined) {
     contents.Initiator = deserializeAws_restXmlInitiator(data["Initiator"], context);
@@ -8599,19 +8600,19 @@ export const deserializeAws_restXmlListPartsCommand = async (
     contents.IsTruncated = __parseBoolean(data["IsTruncated"]);
   }
   if (data["Key"] !== undefined) {
-    contents.Key = data["Key"];
+    contents.Key = __expectString(data["Key"]);
   }
   if (data["MaxParts"] !== undefined) {
     contents.MaxParts = parseInt(data["MaxParts"]);
   }
   if (data["NextPartNumberMarker"] !== undefined) {
-    contents.NextPartNumberMarker = data["NextPartNumberMarker"];
+    contents.NextPartNumberMarker = __expectString(data["NextPartNumberMarker"]);
   }
   if (data["Owner"] !== undefined) {
     contents.Owner = deserializeAws_restXmlOwner(data["Owner"], context);
   }
   if (data["PartNumberMarker"] !== undefined) {
-    contents.PartNumberMarker = data["PartNumberMarker"];
+    contents.PartNumberMarker = __expectString(data["PartNumberMarker"]);
   }
   if (data.Part === "") {
     contents.Parts = [];
@@ -8620,10 +8621,10 @@ export const deserializeAws_restXmlListPartsCommand = async (
     contents.Parts = deserializeAws_restXmlParts(__getArrayIfSingleItem(data["Part"]), context);
   }
   if (data["StorageClass"] !== undefined) {
-    contents.StorageClass = data["StorageClass"];
+    contents.StorageClass = __expectString(data["StorageClass"]);
   }
   if (data["UploadId"] !== undefined) {
-    contents.UploadId = data["UploadId"];
+    contents.UploadId = __expectString(data["UploadId"]);
   }
   return Promise.resolve(contents);
 };
@@ -10207,10 +10208,10 @@ const deserializeAws_restXmlInvalidObjectStateResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data["AccessTier"] !== undefined) {
-    contents.AccessTier = data["AccessTier"];
+    contents.AccessTier = __expectString(data["AccessTier"]);
   }
   if (data["StorageClass"] !== undefined) {
-    contents.StorageClass = data["StorageClass"];
+    contents.StorageClass = __expectString(data["StorageClass"]);
   }
   return contents;
 };
@@ -12547,7 +12548,7 @@ const deserializeAws_restXmlAccessControlTranslation = (
     Owner: undefined,
   };
   if (output["Owner"] !== undefined) {
-    contents.Owner = output["Owner"];
+    contents.Owner = __expectString(output["Owner"]);
   }
   return contents;
 };
@@ -12559,7 +12560,7 @@ const deserializeAws_restXmlAllowedHeaders = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -12570,7 +12571,7 @@ const deserializeAws_restXmlAllowedMethods = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -12581,7 +12582,7 @@ const deserializeAws_restXmlAllowedOrigins = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -12591,7 +12592,7 @@ const deserializeAws_restXmlAnalyticsAndOperator = (output: any, context: __Serd
     Tags: undefined,
   };
   if (output["Prefix"] !== undefined) {
-    contents.Prefix = output["Prefix"];
+    contents.Prefix = __expectString(output["Prefix"]);
   }
   if (output.Tag === "") {
     contents.Tags = [];
@@ -12609,7 +12610,7 @@ const deserializeAws_restXmlAnalyticsConfiguration = (output: any, context: __Se
     StorageClassAnalysis: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   if (output["Filter"] !== undefined) {
     contents.Filter = deserializeAws_restXmlAnalyticsFilter(output["Filter"], context);
@@ -12653,7 +12654,7 @@ const deserializeAws_restXmlAnalyticsExportDestination = (
 const deserializeAws_restXmlAnalyticsFilter = (output: any, context: __SerdeContext): AnalyticsFilter => {
   if (output["Prefix"] !== undefined) {
     return {
-      Prefix: output["Prefix"],
+      Prefix: __expectString(output["Prefix"]) as any,
     };
   }
   if (output["Tag"] !== undefined) {
@@ -12680,16 +12681,16 @@ const deserializeAws_restXmlAnalyticsS3BucketDestination = (
     Prefix: undefined,
   };
   if (output["Format"] !== undefined) {
-    contents.Format = output["Format"];
+    contents.Format = __expectString(output["Format"]);
   }
   if (output["BucketAccountId"] !== undefined) {
-    contents.BucketAccountId = output["BucketAccountId"];
+    contents.BucketAccountId = __expectString(output["BucketAccountId"]);
   }
   if (output["Bucket"] !== undefined) {
-    contents.Bucket = output["Bucket"];
+    contents.Bucket = __expectString(output["Bucket"]);
   }
   if (output["Prefix"] !== undefined) {
-    contents.Prefix = output["Prefix"];
+    contents.Prefix = __expectString(output["Prefix"]);
   }
   return contents;
 };
@@ -12700,7 +12701,7 @@ const deserializeAws_restXmlBucket = (output: any, context: __SerdeContext): Buc
     CreationDate: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["CreationDate"] !== undefined) {
     contents.CreationDate = new Date(output["CreationDate"]);
@@ -12724,7 +12725,7 @@ const deserializeAws_restXmlCommonPrefix = (output: any, context: __SerdeContext
     Prefix: undefined,
   };
   if (output["Prefix"] !== undefined) {
-    contents.Prefix = output["Prefix"];
+    contents.Prefix = __expectString(output["Prefix"]);
   }
   return contents;
 };
@@ -12746,10 +12747,10 @@ const deserializeAws_restXmlCondition = (output: any, context: __SerdeContext): 
     KeyPrefixEquals: undefined,
   };
   if (output["HttpErrorCodeReturnedEquals"] !== undefined) {
-    contents.HttpErrorCodeReturnedEquals = output["HttpErrorCodeReturnedEquals"];
+    contents.HttpErrorCodeReturnedEquals = __expectString(output["HttpErrorCodeReturnedEquals"]);
   }
   if (output["KeyPrefixEquals"] !== undefined) {
-    contents.KeyPrefixEquals = output["KeyPrefixEquals"];
+    contents.KeyPrefixEquals = __expectString(output["KeyPrefixEquals"]);
   }
   return contents;
 };
@@ -12765,7 +12766,7 @@ const deserializeAws_restXmlCopyObjectResult = (output: any, context: __SerdeCon
     LastModified: undefined,
   };
   if (output["ETag"] !== undefined) {
-    contents.ETag = output["ETag"];
+    contents.ETag = __expectString(output["ETag"]);
   }
   if (output["LastModified"] !== undefined) {
     contents.LastModified = new Date(output["LastModified"]);
@@ -12779,7 +12780,7 @@ const deserializeAws_restXmlCopyPartResult = (output: any, context: __SerdeConte
     LastModified: undefined,
   };
   if (output["ETag"] !== undefined) {
-    contents.ETag = output["ETag"];
+    contents.ETag = __expectString(output["ETag"]);
   }
   if (output["LastModified"] !== undefined) {
     contents.LastModified = new Date(output["LastModified"]);
@@ -12797,7 +12798,7 @@ const deserializeAws_restXmlCORSRule = (output: any, context: __SerdeContext): C
     MaxAgeSeconds: undefined,
   };
   if (output["ID"] !== undefined) {
-    contents.ID = output["ID"];
+    contents.ID = __expectString(output["ID"]);
   }
   if (output.AllowedHeader === "") {
     contents.AllowedHeaders = [];
@@ -12859,7 +12860,7 @@ const deserializeAws_restXmlDefaultRetention = (output: any, context: __SerdeCon
     Years: undefined,
   };
   if (output["Mode"] !== undefined) {
-    contents.Mode = output["Mode"];
+    contents.Mode = __expectString(output["Mode"]);
   }
   if (output["Days"] !== undefined) {
     contents.Days = parseInt(output["Days"]);
@@ -12878,16 +12879,16 @@ const deserializeAws_restXmlDeletedObject = (output: any, context: __SerdeContex
     DeleteMarkerVersionId: undefined,
   };
   if (output["Key"] !== undefined) {
-    contents.Key = output["Key"];
+    contents.Key = __expectString(output["Key"]);
   }
   if (output["VersionId"] !== undefined) {
-    contents.VersionId = output["VersionId"];
+    contents.VersionId = __expectString(output["VersionId"]);
   }
   if (output["DeleteMarker"] !== undefined) {
     contents.DeleteMarker = __parseBoolean(output["DeleteMarker"]);
   }
   if (output["DeleteMarkerVersionId"] !== undefined) {
-    contents.DeleteMarkerVersionId = output["DeleteMarkerVersionId"];
+    contents.DeleteMarkerVersionId = __expectString(output["DeleteMarkerVersionId"]);
   }
   return contents;
 };
@@ -12915,10 +12916,10 @@ const deserializeAws_restXmlDeleteMarkerEntry = (output: any, context: __SerdeCo
     contents.Owner = deserializeAws_restXmlOwner(output["Owner"], context);
   }
   if (output["Key"] !== undefined) {
-    contents.Key = output["Key"];
+    contents.Key = __expectString(output["Key"]);
   }
   if (output["VersionId"] !== undefined) {
-    contents.VersionId = output["VersionId"];
+    contents.VersionId = __expectString(output["VersionId"]);
   }
   if (output["IsLatest"] !== undefined) {
     contents.IsLatest = __parseBoolean(output["IsLatest"]);
@@ -12937,7 +12938,7 @@ const deserializeAws_restXmlDeleteMarkerReplication = (
     Status: undefined,
   };
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   return contents;
 };
@@ -12964,13 +12965,13 @@ const deserializeAws_restXmlDestination = (output: any, context: __SerdeContext)
     Metrics: undefined,
   };
   if (output["Bucket"] !== undefined) {
-    contents.Bucket = output["Bucket"];
+    contents.Bucket = __expectString(output["Bucket"]);
   }
   if (output["Account"] !== undefined) {
-    contents.Account = output["Account"];
+    contents.Account = __expectString(output["Account"]);
   }
   if (output["StorageClass"] !== undefined) {
-    contents.StorageClass = output["StorageClass"];
+    contents.StorageClass = __expectString(output["StorageClass"]);
   }
   if (output["AccessControlTranslation"] !== undefined) {
     contents.AccessControlTranslation = deserializeAws_restXmlAccessControlTranslation(
@@ -13001,7 +13002,7 @@ const deserializeAws_restXmlEncryptionConfiguration = (
     ReplicaKmsKeyID: undefined,
   };
   if (output["ReplicaKmsKeyID"] !== undefined) {
-    contents.ReplicaKmsKeyID = output["ReplicaKmsKeyID"];
+    contents.ReplicaKmsKeyID = __expectString(output["ReplicaKmsKeyID"]);
   }
   return contents;
 };
@@ -13019,16 +13020,16 @@ const deserializeAws_restXml_Error = (output: any, context: __SerdeContext): _Er
     Message: undefined,
   };
   if (output["Key"] !== undefined) {
-    contents.Key = output["Key"];
+    contents.Key = __expectString(output["Key"]);
   }
   if (output["VersionId"] !== undefined) {
-    contents.VersionId = output["VersionId"];
+    contents.VersionId = __expectString(output["VersionId"]);
   }
   if (output["Code"] !== undefined) {
-    contents.Code = output["Code"];
+    contents.Code = __expectString(output["Code"]);
   }
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -13038,7 +13039,7 @@ const deserializeAws_restXmlErrorDocument = (output: any, context: __SerdeContex
     Key: undefined,
   };
   if (output["Key"] !== undefined) {
-    contents.Key = output["Key"];
+    contents.Key = __expectString(output["Key"]);
   }
   return contents;
 };
@@ -13061,7 +13062,7 @@ const deserializeAws_restXmlEventList = (output: any, context: __SerdeContext): 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -13073,7 +13074,7 @@ const deserializeAws_restXmlExistingObjectReplication = (
     Status: undefined,
   };
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   return contents;
 };
@@ -13085,7 +13086,7 @@ const deserializeAws_restXmlExposeHeaders = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -13095,10 +13096,10 @@ const deserializeAws_restXmlFilterRule = (output: any, context: __SerdeContext):
     Value: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["Value"] !== undefined) {
-    contents.Value = output["Value"];
+    contents.Value = __expectString(output["Value"]);
   }
   return contents;
 };
@@ -13123,7 +13124,7 @@ const deserializeAws_restXmlGrant = (output: any, context: __SerdeContext): Gran
     contents.Grantee = deserializeAws_restXmlGrantee(output["Grantee"], context);
   }
   if (output["Permission"] !== undefined) {
-    contents.Permission = output["Permission"];
+    contents.Permission = __expectString(output["Permission"]);
   }
   return contents;
 };
@@ -13137,19 +13138,19 @@ const deserializeAws_restXmlGrantee = (output: any, context: __SerdeContext): Gr
     Type: undefined,
   };
   if (output["DisplayName"] !== undefined) {
-    contents.DisplayName = output["DisplayName"];
+    contents.DisplayName = __expectString(output["DisplayName"]);
   }
   if (output["EmailAddress"] !== undefined) {
-    contents.EmailAddress = output["EmailAddress"];
+    contents.EmailAddress = __expectString(output["EmailAddress"]);
   }
   if (output["ID"] !== undefined) {
-    contents.ID = output["ID"];
+    contents.ID = __expectString(output["ID"]);
   }
   if (output["URI"] !== undefined) {
-    contents.URI = output["URI"];
+    contents.URI = __expectString(output["URI"]);
   }
   if (output["xsi:type"] !== undefined) {
-    contents.Type = output["xsi:type"];
+    contents.Type = __expectString(output["xsi:type"]);
   }
   return contents;
 };
@@ -13170,7 +13171,7 @@ const deserializeAws_restXmlIndexDocument = (output: any, context: __SerdeContex
     Suffix: undefined,
   };
   if (output["Suffix"] !== undefined) {
-    contents.Suffix = output["Suffix"];
+    contents.Suffix = __expectString(output["Suffix"]);
   }
   return contents;
 };
@@ -13181,10 +13182,10 @@ const deserializeAws_restXmlInitiator = (output: any, context: __SerdeContext): 
     DisplayName: undefined,
   };
   if (output["ID"] !== undefined) {
-    contents.ID = output["ID"];
+    contents.ID = __expectString(output["ID"]);
   }
   if (output["DisplayName"] !== undefined) {
-    contents.DisplayName = output["DisplayName"];
+    contents.DisplayName = __expectString(output["DisplayName"]);
   }
   return contents;
 };
@@ -13198,7 +13199,7 @@ const deserializeAws_restXmlIntelligentTieringAndOperator = (
     Tags: undefined,
   };
   if (output["Prefix"] !== undefined) {
-    contents.Prefix = output["Prefix"];
+    contents.Prefix = __expectString(output["Prefix"]);
   }
   if (output.Tag === "") {
     contents.Tags = [];
@@ -13220,13 +13221,13 @@ const deserializeAws_restXmlIntelligentTieringConfiguration = (
     Tierings: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   if (output["Filter"] !== undefined) {
     contents.Filter = deserializeAws_restXmlIntelligentTieringFilter(output["Filter"], context);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output.Tiering === "") {
     contents.Tierings = [];
@@ -13261,7 +13262,7 @@ const deserializeAws_restXmlIntelligentTieringFilter = (
     And: undefined,
   };
   if (output["Prefix"] !== undefined) {
-    contents.Prefix = output["Prefix"];
+    contents.Prefix = __expectString(output["Prefix"]);
   }
   if (output["Tag"] !== undefined) {
     contents.Tag = deserializeAws_restXmlTag(output["Tag"], context);
@@ -13292,10 +13293,10 @@ const deserializeAws_restXmlInventoryConfiguration = (output: any, context: __Se
     contents.Filter = deserializeAws_restXmlInventoryFilter(output["Filter"], context);
   }
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   if (output["IncludedObjectVersions"] !== undefined) {
-    contents.IncludedObjectVersions = output["IncludedObjectVersions"];
+    contents.IncludedObjectVersions = __expectString(output["IncludedObjectVersions"]);
   }
   if (output.OptionalFields === "") {
     contents.OptionalFields = [];
@@ -13358,7 +13359,7 @@ const deserializeAws_restXmlInventoryFilter = (output: any, context: __SerdeCont
     Prefix: undefined,
   };
   if (output["Prefix"] !== undefined) {
-    contents.Prefix = output["Prefix"];
+    contents.Prefix = __expectString(output["Prefix"]);
   }
   return contents;
 };
@@ -13373,7 +13374,7 @@ const deserializeAws_restXmlInventoryOptionalFields = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -13389,16 +13390,16 @@ const deserializeAws_restXmlInventoryS3BucketDestination = (
     Encryption: undefined,
   };
   if (output["AccountId"] !== undefined) {
-    contents.AccountId = output["AccountId"];
+    contents.AccountId = __expectString(output["AccountId"]);
   }
   if (output["Bucket"] !== undefined) {
-    contents.Bucket = output["Bucket"];
+    contents.Bucket = __expectString(output["Bucket"]);
   }
   if (output["Format"] !== undefined) {
-    contents.Format = output["Format"];
+    contents.Format = __expectString(output["Format"]);
   }
   if (output["Prefix"] !== undefined) {
-    contents.Prefix = output["Prefix"];
+    contents.Prefix = __expectString(output["Prefix"]);
   }
   if (output["Encryption"] !== undefined) {
     contents.Encryption = deserializeAws_restXmlInventoryEncryption(output["Encryption"], context);
@@ -13411,7 +13412,7 @@ const deserializeAws_restXmlInventorySchedule = (output: any, context: __SerdeCo
     Frequency: undefined,
   };
   if (output["Frequency"] !== undefined) {
-    contents.Frequency = output["Frequency"];
+    contents.Frequency = __expectString(output["Frequency"]);
   }
   return contents;
 };
@@ -13427,10 +13428,10 @@ const deserializeAws_restXmlLambdaFunctionConfiguration = (
     Filter: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   if (output["CloudFunction"] !== undefined) {
-    contents.LambdaFunctionArn = output["CloudFunction"];
+    contents.LambdaFunctionArn = __expectString(output["CloudFunction"]);
   }
   if (output.Event === "") {
     contents.Events = [];
@@ -13492,16 +13493,16 @@ const deserializeAws_restXmlLifecycleRule = (output: any, context: __SerdeContex
     contents.Expiration = deserializeAws_restXmlLifecycleExpiration(output["Expiration"], context);
   }
   if (output["ID"] !== undefined) {
-    contents.ID = output["ID"];
+    contents.ID = __expectString(output["ID"]);
   }
   if (output["Prefix"] !== undefined) {
-    contents.Prefix = output["Prefix"];
+    contents.Prefix = __expectString(output["Prefix"]);
   }
   if (output["Filter"] !== undefined) {
     contents.Filter = deserializeAws_restXmlLifecycleRuleFilter(output["Filter"], context);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output.Transition === "") {
     contents.Transitions = [];
@@ -13542,7 +13543,7 @@ const deserializeAws_restXmlLifecycleRuleAndOperator = (
     Tags: undefined,
   };
   if (output["Prefix"] !== undefined) {
-    contents.Prefix = output["Prefix"];
+    contents.Prefix = __expectString(output["Prefix"]);
   }
   if (output.Tag === "") {
     contents.Tags = [];
@@ -13556,7 +13557,7 @@ const deserializeAws_restXmlLifecycleRuleAndOperator = (
 const deserializeAws_restXmlLifecycleRuleFilter = (output: any, context: __SerdeContext): LifecycleRuleFilter => {
   if (output["Prefix"] !== undefined) {
     return {
-      Prefix: output["Prefix"],
+      Prefix: __expectString(output["Prefix"]) as any,
     };
   }
   if (output["Tag"] !== undefined) {
@@ -13590,7 +13591,7 @@ const deserializeAws_restXmlLoggingEnabled = (output: any, context: __SerdeConte
     TargetPrefix: undefined,
   };
   if (output["TargetBucket"] !== undefined) {
-    contents.TargetBucket = output["TargetBucket"];
+    contents.TargetBucket = __expectString(output["TargetBucket"]);
   }
   if (output.TargetGrants === "") {
     contents.TargetGrants = [];
@@ -13602,7 +13603,7 @@ const deserializeAws_restXmlLoggingEnabled = (output: any, context: __SerdeConte
     );
   }
   if (output["TargetPrefix"] !== undefined) {
-    contents.TargetPrefix = output["TargetPrefix"];
+    contents.TargetPrefix = __expectString(output["TargetPrefix"]);
   }
   return contents;
 };
@@ -13613,7 +13614,7 @@ const deserializeAws_restXmlMetrics = (output: any, context: __SerdeContext): Me
     EventThreshold: undefined,
   };
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["EventThreshold"] !== undefined) {
     contents.EventThreshold = deserializeAws_restXmlReplicationTimeValue(output["EventThreshold"], context);
@@ -13627,7 +13628,7 @@ const deserializeAws_restXmlMetricsAndOperator = (output: any, context: __SerdeC
     Tags: undefined,
   };
   if (output["Prefix"] !== undefined) {
-    contents.Prefix = output["Prefix"];
+    contents.Prefix = __expectString(output["Prefix"]);
   }
   if (output.Tag === "") {
     contents.Tags = [];
@@ -13644,7 +13645,7 @@ const deserializeAws_restXmlMetricsConfiguration = (output: any, context: __Serd
     Filter: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   if (output["Filter"] !== undefined) {
     contents.Filter = deserializeAws_restXmlMetricsFilter(output["Filter"], context);
@@ -13669,7 +13670,7 @@ const deserializeAws_restXmlMetricsConfigurationList = (
 const deserializeAws_restXmlMetricsFilter = (output: any, context: __SerdeContext): MetricsFilter => {
   if (output["Prefix"] !== undefined) {
     return {
-      Prefix: output["Prefix"],
+      Prefix: __expectString(output["Prefix"]) as any,
     };
   }
   if (output["Tag"] !== undefined) {
@@ -13695,16 +13696,16 @@ const deserializeAws_restXmlMultipartUpload = (output: any, context: __SerdeCont
     Initiator: undefined,
   };
   if (output["UploadId"] !== undefined) {
-    contents.UploadId = output["UploadId"];
+    contents.UploadId = __expectString(output["UploadId"]);
   }
   if (output["Key"] !== undefined) {
-    contents.Key = output["Key"];
+    contents.Key = __expectString(output["Key"]);
   }
   if (output["Initiated"] !== undefined) {
     contents.Initiated = new Date(output["Initiated"]);
   }
   if (output["StorageClass"] !== undefined) {
-    contents.StorageClass = output["StorageClass"];
+    contents.StorageClass = __expectString(output["StorageClass"]);
   }
   if (output["Owner"] !== undefined) {
     contents.Owner = deserializeAws_restXmlOwner(output["Owner"], context);
@@ -13751,7 +13752,7 @@ const deserializeAws_restXmlNoncurrentVersionTransition = (
     contents.NoncurrentDays = parseInt(output["NoncurrentDays"]);
   }
   if (output["StorageClass"] !== undefined) {
-    contents.StorageClass = output["StorageClass"];
+    contents.StorageClass = __expectString(output["StorageClass"]);
   }
   return contents;
 };
@@ -13793,19 +13794,19 @@ const deserializeAws_restXml_Object = (output: any, context: __SerdeContext): _O
     Owner: undefined,
   };
   if (output["Key"] !== undefined) {
-    contents.Key = output["Key"];
+    contents.Key = __expectString(output["Key"]);
   }
   if (output["LastModified"] !== undefined) {
     contents.LastModified = new Date(output["LastModified"]);
   }
   if (output["ETag"] !== undefined) {
-    contents.ETag = output["ETag"];
+    contents.ETag = __expectString(output["ETag"]);
   }
   if (output["Size"] !== undefined) {
     contents.Size = parseInt(output["Size"]);
   }
   if (output["StorageClass"] !== undefined) {
-    contents.StorageClass = output["StorageClass"];
+    contents.StorageClass = __expectString(output["StorageClass"]);
   }
   if (output["Owner"] !== undefined) {
     contents.Owner = deserializeAws_restXmlOwner(output["Owner"], context);
@@ -13833,7 +13834,7 @@ const deserializeAws_restXmlObjectLockConfiguration = (
     Rule: undefined,
   };
   if (output["ObjectLockEnabled"] !== undefined) {
-    contents.ObjectLockEnabled = output["ObjectLockEnabled"];
+    contents.ObjectLockEnabled = __expectString(output["ObjectLockEnabled"]);
   }
   if (output["Rule"] !== undefined) {
     contents.Rule = deserializeAws_restXmlObjectLockRule(output["Rule"], context);
@@ -13846,7 +13847,7 @@ const deserializeAws_restXmlObjectLockLegalHold = (output: any, context: __Serde
     Status: undefined,
   };
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   return contents;
 };
@@ -13857,7 +13858,7 @@ const deserializeAws_restXmlObjectLockRetention = (output: any, context: __Serde
     RetainUntilDate: undefined,
   };
   if (output["Mode"] !== undefined) {
-    contents.Mode = output["Mode"];
+    contents.Mode = __expectString(output["Mode"]);
   }
   if (output["RetainUntilDate"] !== undefined) {
     contents.RetainUntilDate = new Date(output["RetainUntilDate"]);
@@ -13887,19 +13888,19 @@ const deserializeAws_restXmlObjectVersion = (output: any, context: __SerdeContex
     Owner: undefined,
   };
   if (output["ETag"] !== undefined) {
-    contents.ETag = output["ETag"];
+    contents.ETag = __expectString(output["ETag"]);
   }
   if (output["Size"] !== undefined) {
     contents.Size = parseInt(output["Size"]);
   }
   if (output["StorageClass"] !== undefined) {
-    contents.StorageClass = output["StorageClass"];
+    contents.StorageClass = __expectString(output["StorageClass"]);
   }
   if (output["Key"] !== undefined) {
-    contents.Key = output["Key"];
+    contents.Key = __expectString(output["Key"]);
   }
   if (output["VersionId"] !== undefined) {
-    contents.VersionId = output["VersionId"];
+    contents.VersionId = __expectString(output["VersionId"]);
   }
   if (output["IsLatest"] !== undefined) {
     contents.IsLatest = __parseBoolean(output["IsLatest"]);
@@ -13930,10 +13931,10 @@ const deserializeAws_restXmlOwner = (output: any, context: __SerdeContext): Owne
     ID: undefined,
   };
   if (output["DisplayName"] !== undefined) {
-    contents.DisplayName = output["DisplayName"];
+    contents.DisplayName = __expectString(output["DisplayName"]);
   }
   if (output["ID"] !== undefined) {
-    contents.ID = output["ID"];
+    contents.ID = __expectString(output["ID"]);
   }
   return contents;
 };
@@ -13956,7 +13957,7 @@ const deserializeAws_restXmlOwnershipControlsRule = (output: any, context: __Ser
     ObjectOwnership: undefined,
   };
   if (output["ObjectOwnership"] !== undefined) {
-    contents.ObjectOwnership = output["ObjectOwnership"];
+    contents.ObjectOwnership = __expectString(output["ObjectOwnership"]);
   }
   return contents;
 };
@@ -13989,7 +13990,7 @@ const deserializeAws_restXmlPart = (output: any, context: __SerdeContext): Part 
     contents.LastModified = new Date(output["LastModified"]);
   }
   if (output["ETag"] !== undefined) {
-    contents.ETag = output["ETag"];
+    contents.ETag = __expectString(output["ETag"]);
   }
   if (output["Size"] !== undefined) {
     contents.Size = parseInt(output["Size"]);
@@ -14079,10 +14080,10 @@ const deserializeAws_restXmlQueueConfiguration = (output: any, context: __SerdeC
     Filter: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   if (output["Queue"] !== undefined) {
-    contents.QueueArn = output["Queue"];
+    contents.QueueArn = __expectString(output["Queue"]);
   }
   if (output.Event === "") {
     contents.Events = [];
@@ -14126,19 +14127,19 @@ const deserializeAws_restXmlRedirect = (output: any, context: __SerdeContext): R
     ReplaceKeyWith: undefined,
   };
   if (output["HostName"] !== undefined) {
-    contents.HostName = output["HostName"];
+    contents.HostName = __expectString(output["HostName"]);
   }
   if (output["HttpRedirectCode"] !== undefined) {
-    contents.HttpRedirectCode = output["HttpRedirectCode"];
+    contents.HttpRedirectCode = __expectString(output["HttpRedirectCode"]);
   }
   if (output["Protocol"] !== undefined) {
-    contents.Protocol = output["Protocol"];
+    contents.Protocol = __expectString(output["Protocol"]);
   }
   if (output["ReplaceKeyPrefixWith"] !== undefined) {
-    contents.ReplaceKeyPrefixWith = output["ReplaceKeyPrefixWith"];
+    contents.ReplaceKeyPrefixWith = __expectString(output["ReplaceKeyPrefixWith"]);
   }
   if (output["ReplaceKeyWith"] !== undefined) {
-    contents.ReplaceKeyWith = output["ReplaceKeyWith"];
+    contents.ReplaceKeyWith = __expectString(output["ReplaceKeyWith"]);
   }
   return contents;
 };
@@ -14149,10 +14150,10 @@ const deserializeAws_restXmlRedirectAllRequestsTo = (output: any, context: __Ser
     Protocol: undefined,
   };
   if (output["HostName"] !== undefined) {
-    contents.HostName = output["HostName"];
+    contents.HostName = __expectString(output["HostName"]);
   }
   if (output["Protocol"] !== undefined) {
-    contents.Protocol = output["Protocol"];
+    contents.Protocol = __expectString(output["Protocol"]);
   }
   return contents;
 };
@@ -14162,7 +14163,7 @@ const deserializeAws_restXmlReplicaModifications = (output: any, context: __Serd
     Status: undefined,
   };
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   return contents;
 };
@@ -14176,7 +14177,7 @@ const deserializeAws_restXmlReplicationConfiguration = (
     Rules: undefined,
   };
   if (output["Role"] !== undefined) {
-    contents.Role = output["Role"];
+    contents.Role = __expectString(output["Role"]);
   }
   if (output.Rule === "") {
     contents.Rules = [];
@@ -14200,19 +14201,19 @@ const deserializeAws_restXmlReplicationRule = (output: any, context: __SerdeCont
     DeleteMarkerReplication: undefined,
   };
   if (output["ID"] !== undefined) {
-    contents.ID = output["ID"];
+    contents.ID = __expectString(output["ID"]);
   }
   if (output["Priority"] !== undefined) {
     contents.Priority = parseInt(output["Priority"]);
   }
   if (output["Prefix"] !== undefined) {
-    contents.Prefix = output["Prefix"];
+    contents.Prefix = __expectString(output["Prefix"]);
   }
   if (output["Filter"] !== undefined) {
     contents.Filter = deserializeAws_restXmlReplicationRuleFilter(output["Filter"], context);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["SourceSelectionCriteria"] !== undefined) {
     contents.SourceSelectionCriteria = deserializeAws_restXmlSourceSelectionCriteria(
@@ -14247,7 +14248,7 @@ const deserializeAws_restXmlReplicationRuleAndOperator = (
     Tags: undefined,
   };
   if (output["Prefix"] !== undefined) {
-    contents.Prefix = output["Prefix"];
+    contents.Prefix = __expectString(output["Prefix"]);
   }
   if (output.Tag === "") {
     contents.Tags = [];
@@ -14261,7 +14262,7 @@ const deserializeAws_restXmlReplicationRuleAndOperator = (
 const deserializeAws_restXmlReplicationRuleFilter = (output: any, context: __SerdeContext): ReplicationRuleFilter => {
   if (output["Prefix"] !== undefined) {
     return {
-      Prefix: output["Prefix"],
+      Prefix: __expectString(output["Prefix"]) as any,
     };
   }
   if (output["Tag"] !== undefined) {
@@ -14294,7 +14295,7 @@ const deserializeAws_restXmlReplicationTime = (output: any, context: __SerdeCont
     Time: undefined,
   };
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["Time"] !== undefined) {
     contents.Time = deserializeAws_restXmlReplicationTimeValue(output["Time"], context);
@@ -14391,10 +14392,10 @@ const deserializeAws_restXmlServerSideEncryptionByDefault = (
     KMSMasterKeyID: undefined,
   };
   if (output["SSEAlgorithm"] !== undefined) {
-    contents.SSEAlgorithm = output["SSEAlgorithm"];
+    contents.SSEAlgorithm = __expectString(output["SSEAlgorithm"]);
   }
   if (output["KMSMasterKeyID"] !== undefined) {
-    contents.KMSMasterKeyID = output["KMSMasterKeyID"];
+    contents.KMSMasterKeyID = __expectString(output["KMSMasterKeyID"]);
   }
   return contents;
 };
@@ -14474,7 +14475,7 @@ const deserializeAws_restXmlSSEKMS = (output: any, context: __SerdeContext): SSE
     KeyId: undefined,
   };
   if (output["KeyId"] !== undefined) {
-    contents.KeyId = output["KeyId"];
+    contents.KeyId = __expectString(output["KeyId"]);
   }
   return contents;
 };
@@ -14484,7 +14485,7 @@ const deserializeAws_restXmlSseKmsEncryptedObjects = (output: any, context: __Se
     Status: undefined,
   };
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   return contents;
 };
@@ -14541,7 +14542,7 @@ const deserializeAws_restXmlStorageClassAnalysisDataExport = (
     Destination: undefined,
   };
   if (output["OutputSchemaVersion"] !== undefined) {
-    contents.OutputSchemaVersion = output["OutputSchemaVersion"];
+    contents.OutputSchemaVersion = __expectString(output["OutputSchemaVersion"]);
   }
   if (output["Destination"] !== undefined) {
     contents.Destination = deserializeAws_restXmlAnalyticsExportDestination(output["Destination"], context);
@@ -14555,10 +14556,10 @@ const deserializeAws_restXmlTag = (output: any, context: __SerdeContext): Tag =>
     Value: undefined,
   };
   if (output["Key"] !== undefined) {
-    contents.Key = output["Key"];
+    contents.Key = __expectString(output["Key"]);
   }
   if (output["Value"] !== undefined) {
-    contents.Value = output["Value"];
+    contents.Value = __expectString(output["Value"]);
   }
   return contents;
 };
@@ -14583,7 +14584,7 @@ const deserializeAws_restXmlTargetGrant = (output: any, context: __SerdeContext)
     contents.Grantee = deserializeAws_restXmlGrantee(output["Grantee"], context);
   }
   if (output["Permission"] !== undefined) {
-    contents.Permission = output["Permission"];
+    contents.Permission = __expectString(output["Permission"]);
   }
   return contents;
 };
@@ -14608,7 +14609,7 @@ const deserializeAws_restXmlTiering = (output: any, context: __SerdeContext): Ti
     contents.Days = parseInt(output["Days"]);
   }
   if (output["AccessTier"] !== undefined) {
-    contents.AccessTier = output["AccessTier"];
+    contents.AccessTier = __expectString(output["AccessTier"]);
   }
   return contents;
 };
@@ -14632,10 +14633,10 @@ const deserializeAws_restXmlTopicConfiguration = (output: any, context: __SerdeC
     Filter: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   if (output["Topic"] !== undefined) {
-    contents.TopicArn = output["Topic"];
+    contents.TopicArn = __expectString(output["Topic"]);
   }
   if (output.Event === "") {
     contents.Events = [];
@@ -14673,7 +14674,7 @@ const deserializeAws_restXmlTransition = (output: any, context: __SerdeContext):
     contents.Days = parseInt(output["Days"]);
   }
   if (output["StorageClass"] !== undefined) {
-    contents.StorageClass = output["StorageClass"];
+    contents.StorageClass = __expectString(output["StorageClass"]);
   }
   return contents;
 };

--- a/clients/client-s3outposts/protocols/Aws_restJson1.ts
+++ b/clients/client-s3outposts/protocols/Aws_restJson1.ts
@@ -13,6 +13,7 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -110,7 +111,7 @@ export const deserializeAws_restJson1CreateEndpointCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.EndpointArn !== undefined && data.EndpointArn !== null) {
-    contents.EndpointArn = data.EndpointArn;
+    contents.EndpointArn = __expectString(data.EndpointArn);
   }
   return Promise.resolve(contents);
 };
@@ -276,7 +277,7 @@ export const deserializeAws_restJson1ListEndpointsCommand = async (
     contents.Endpoints = deserializeAws_restJson1Endpoints(data.Endpoints, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -354,7 +355,7 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -371,7 +372,7 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -388,7 +389,7 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -405,7 +406,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -422,25 +423,25 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
 
 const deserializeAws_restJson1Endpoint = (output: any, context: __SerdeContext): Endpoint => {
   return {
-    CidrBlock: output.CidrBlock !== undefined && output.CidrBlock !== null ? output.CidrBlock : undefined,
+    CidrBlock: __expectString(output.CidrBlock),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    EndpointArn: output.EndpointArn !== undefined && output.EndpointArn !== null ? output.EndpointArn : undefined,
+    EndpointArn: __expectString(output.EndpointArn),
     NetworkInterfaces:
       output.NetworkInterfaces !== undefined && output.NetworkInterfaces !== null
         ? deserializeAws_restJson1NetworkInterfaces(output.NetworkInterfaces, context)
         : undefined,
-    OutpostsId: output.OutpostsId !== undefined && output.OutpostsId !== null ? output.OutpostsId : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    OutpostsId: __expectString(output.OutpostsId),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -457,10 +458,7 @@ const deserializeAws_restJson1Endpoints = (output: any, context: __SerdeContext)
 
 const deserializeAws_restJson1NetworkInterface = (output: any, context: __SerdeContext): NetworkInterface => {
   return {
-    NetworkInterfaceId:
-      output.NetworkInterfaceId !== undefined && output.NetworkInterfaceId !== null
-        ? output.NetworkInterfaceId
-        : undefined,
+    NetworkInterfaceId: __expectString(output.NetworkInterfaceId),
   } as any;
 };
 

--- a/clients/client-sagemaker-a2i-runtime/protocols/Aws_restJson1.ts
+++ b/clients/client-sagemaker-a2i-runtime/protocols/Aws_restJson1.ts
@@ -19,6 +19,7 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -272,25 +273,25 @@ export const deserializeAws_restJson1DescribeHumanLoopCommand = async (
     contents.CreationTime = new Date(Math.round(data.CreationTime * 1000));
   }
   if (data.FailureCode !== undefined && data.FailureCode !== null) {
-    contents.FailureCode = data.FailureCode;
+    contents.FailureCode = __expectString(data.FailureCode);
   }
   if (data.FailureReason !== undefined && data.FailureReason !== null) {
-    contents.FailureReason = data.FailureReason;
+    contents.FailureReason = __expectString(data.FailureReason);
   }
   if (data.FlowDefinitionArn !== undefined && data.FlowDefinitionArn !== null) {
-    contents.FlowDefinitionArn = data.FlowDefinitionArn;
+    contents.FlowDefinitionArn = __expectString(data.FlowDefinitionArn);
   }
   if (data.HumanLoopArn !== undefined && data.HumanLoopArn !== null) {
-    contents.HumanLoopArn = data.HumanLoopArn;
+    contents.HumanLoopArn = __expectString(data.HumanLoopArn);
   }
   if (data.HumanLoopName !== undefined && data.HumanLoopName !== null) {
-    contents.HumanLoopName = data.HumanLoopName;
+    contents.HumanLoopName = __expectString(data.HumanLoopName);
   }
   if (data.HumanLoopOutput !== undefined && data.HumanLoopOutput !== null) {
     contents.HumanLoopOutput = deserializeAws_restJson1HumanLoopOutput(data.HumanLoopOutput, context);
   }
   if (data.HumanLoopStatus !== undefined && data.HumanLoopStatus !== null) {
-    contents.HumanLoopStatus = data.HumanLoopStatus;
+    contents.HumanLoopStatus = __expectString(data.HumanLoopStatus);
   }
   return Promise.resolve(contents);
 };
@@ -373,7 +374,7 @@ export const deserializeAws_restJson1ListHumanLoopsCommand = async (
     contents.HumanLoopSummaries = deserializeAws_restJson1HumanLoopSummaries(data.HumanLoopSummaries, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -452,7 +453,7 @@ export const deserializeAws_restJson1StartHumanLoopCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.HumanLoopArn !== undefined && data.HumanLoopArn !== null) {
-    contents.HumanLoopArn = data.HumanLoopArn;
+    contents.HumanLoopArn = __expectString(data.HumanLoopArn);
   }
   return Promise.resolve(contents);
 };
@@ -613,7 +614,7 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -630,7 +631,7 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -647,7 +648,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -664,7 +665,7 @@ const deserializeAws_restJson1ServiceQuotaExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -681,7 +682,7 @@ const deserializeAws_restJson1ThrottlingExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -698,7 +699,7 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -737,7 +738,7 @@ const serializeAws_restJson1HumanLoopInput = (input: HumanLoopInput, context: __
 
 const deserializeAws_restJson1HumanLoopOutput = (output: any, context: __SerdeContext): HumanLoopOutput => {
   return {
-    OutputS3Uri: output.OutputS3Uri !== undefined && output.OutputS3Uri !== null ? output.OutputS3Uri : undefined,
+    OutputS3Uri: __expectString(output.OutputS3Uri),
   } as any;
 };
 
@@ -758,16 +759,10 @@ const deserializeAws_restJson1HumanLoopSummary = (output: any, context: __SerdeC
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
-    FlowDefinitionArn:
-      output.FlowDefinitionArn !== undefined && output.FlowDefinitionArn !== null
-        ? output.FlowDefinitionArn
-        : undefined,
-    HumanLoopName:
-      output.HumanLoopName !== undefined && output.HumanLoopName !== null ? output.HumanLoopName : undefined,
-    HumanLoopStatus:
-      output.HumanLoopStatus !== undefined && output.HumanLoopStatus !== null ? output.HumanLoopStatus : undefined,
+    FailureReason: __expectString(output.FailureReason),
+    FlowDefinitionArn: __expectString(output.FlowDefinitionArn),
+    HumanLoopName: __expectString(output.HumanLoopName),
+    HumanLoopStatus: __expectString(output.HumanLoopStatus),
   } as any;
 };
 

--- a/clients/client-sagemaker-edge/protocols/Aws_restJson1.ts
+++ b/clients/client-sagemaker-edge/protocols/Aws_restJson1.ts
@@ -5,7 +5,7 @@ import {
 import { SendHeartbeatCommandInput, SendHeartbeatCommandOutput } from "../commands/SendHeartbeatCommand";
 import { EdgeMetric, InternalServiceException, Model } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException, expectString as __expectString } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -84,10 +84,10 @@ export const deserializeAws_restJson1GetDeviceRegistrationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.CacheTTL !== undefined && data.CacheTTL !== null) {
-    contents.CacheTTL = data.CacheTTL;
+    contents.CacheTTL = __expectString(data.CacheTTL);
   }
   if (data.DeviceRegistration !== undefined && data.DeviceRegistration !== null) {
-    contents.DeviceRegistration = data.DeviceRegistration;
+    contents.DeviceRegistration = __expectString(data.DeviceRegistration);
   }
   return Promise.resolve(contents);
 };
@@ -192,7 +192,7 @@ const deserializeAws_restJson1InternalServiceExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };

--- a/clients/client-sagemaker-featurestore-runtime/protocols/Aws_restJson1.ts
+++ b/clients/client-sagemaker-featurestore-runtime/protocols/Aws_restJson1.ts
@@ -16,6 +16,7 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -495,7 +496,7 @@ const deserializeAws_restJson1AccessForbiddenResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -512,7 +513,7 @@ const deserializeAws_restJson1InternalFailureResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -529,7 +530,7 @@ const deserializeAws_restJson1ResourceNotFoundResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -546,7 +547,7 @@ const deserializeAws_restJson1ServiceUnavailableResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -563,7 +564,7 @@ const deserializeAws_restJson1ValidationErrorResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -643,14 +644,10 @@ const serializeAws_restJson1RecordIdentifiers = (input: string[], context: __Ser
 
 const deserializeAws_restJson1BatchGetRecordError = (output: any, context: __SerdeContext): BatchGetRecordError => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    FeatureGroupName:
-      output.FeatureGroupName !== undefined && output.FeatureGroupName !== null ? output.FeatureGroupName : undefined,
-    RecordIdentifierValueAsString:
-      output.RecordIdentifierValueAsString !== undefined && output.RecordIdentifierValueAsString !== null
-        ? output.RecordIdentifierValueAsString
-        : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
+    FeatureGroupName: __expectString(output.FeatureGroupName),
+    RecordIdentifierValueAsString: __expectString(output.RecordIdentifierValueAsString),
   } as any;
 };
 
@@ -670,8 +667,7 @@ const deserializeAws_restJson1BatchGetRecordIdentifier = (
   context: __SerdeContext
 ): BatchGetRecordIdentifier => {
   return {
-    FeatureGroupName:
-      output.FeatureGroupName !== undefined && output.FeatureGroupName !== null ? output.FeatureGroupName : undefined,
+    FeatureGroupName: __expectString(output.FeatureGroupName),
     FeatureNames:
       output.FeatureNames !== undefined && output.FeatureNames !== null
         ? deserializeAws_restJson1FeatureNames(output.FeatureNames, context)
@@ -688,16 +684,12 @@ const deserializeAws_restJson1BatchGetRecordResultDetail = (
   context: __SerdeContext
 ): BatchGetRecordResultDetail => {
   return {
-    FeatureGroupName:
-      output.FeatureGroupName !== undefined && output.FeatureGroupName !== null ? output.FeatureGroupName : undefined,
+    FeatureGroupName: __expectString(output.FeatureGroupName),
     Record:
       output.Record !== undefined && output.Record !== null
         ? deserializeAws_restJson1Record(output.Record, context)
         : undefined,
-    RecordIdentifierValueAsString:
-      output.RecordIdentifierValueAsString !== undefined && output.RecordIdentifierValueAsString !== null
-        ? output.RecordIdentifierValueAsString
-        : undefined,
+    RecordIdentifierValueAsString: __expectString(output.RecordIdentifierValueAsString),
   } as any;
 };
 
@@ -722,15 +714,14 @@ const deserializeAws_restJson1FeatureNames = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1FeatureValue = (output: any, context: __SerdeContext): FeatureValue => {
   return {
-    FeatureName: output.FeatureName !== undefined && output.FeatureName !== null ? output.FeatureName : undefined,
-    ValueAsString:
-      output.ValueAsString !== undefined && output.ValueAsString !== null ? output.ValueAsString : undefined,
+    FeatureName: __expectString(output.FeatureName),
+    ValueAsString: __expectString(output.ValueAsString),
   } as any;
 };
 
@@ -752,7 +743,7 @@ const deserializeAws_restJson1RecordIdentifiers = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 

--- a/clients/client-sagemaker-runtime/protocols/Aws_restJson1.ts
+++ b/clients/client-sagemaker-runtime/protocols/Aws_restJson1.ts
@@ -3,6 +3,8 @@ import { InternalFailure, ModelError, ServiceUnavailable, ValidationError } from
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -157,7 +159,7 @@ const deserializeAws_restJson1InternalFailureResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -177,16 +179,16 @@ const deserializeAws_restJson1ModelErrorResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.LogStreamArn !== undefined && data.LogStreamArn !== null) {
-    contents.LogStreamArn = data.LogStreamArn;
+    contents.LogStreamArn = __expectString(data.LogStreamArn);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.OriginalMessage !== undefined && data.OriginalMessage !== null) {
-    contents.OriginalMessage = data.OriginalMessage;
+    contents.OriginalMessage = __expectString(data.OriginalMessage);
   }
   if (data.OriginalStatusCode !== undefined && data.OriginalStatusCode !== null) {
-    contents.OriginalStatusCode = data.OriginalStatusCode;
+    contents.OriginalStatusCode = __expectNumber(data.OriginalStatusCode);
   }
   return contents;
 };
@@ -203,7 +205,7 @@ const deserializeAws_restJson1ServiceUnavailableResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -220,7 +222,7 @@ const deserializeAws_restJson1ValidationErrorResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };

--- a/clients/client-sagemaker/protocols/Aws_json1_1.ts
+++ b/clients/client-sagemaker/protocols/Aws_json1_1.ts
@@ -1346,7 +1346,13 @@ import {
   UpdateWorkteamResponse,
 } from "../models/models_3";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { LazyJsonString as __LazyJsonString, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  LazyJsonString as __LazyJsonString,
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -23985,9 +23991,9 @@ const serializeAws_json1_1VpcSecurityGroupIds = (input: string[], context: __Ser
 
 const deserializeAws_json1_1ActionSource = (output: any, context: __SerdeContext): ActionSource => {
   return {
-    SourceId: output.SourceId !== undefined && output.SourceId !== null ? output.SourceId : undefined,
-    SourceType: output.SourceType !== undefined && output.SourceType !== null ? output.SourceType : undefined,
-    SourceUri: output.SourceUri !== undefined && output.SourceUri !== null ? output.SourceUri : undefined,
+    SourceId: __expectString(output.SourceId),
+    SourceType: __expectString(output.SourceType),
+    SourceUri: __expectString(output.SourceUri),
   } as any;
 };
 
@@ -24004,9 +24010,9 @@ const deserializeAws_json1_1ActionSummaries = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_1ActionSummary = (output: any, context: __SerdeContext): ActionSummary => {
   return {
-    ActionArn: output.ActionArn !== undefined && output.ActionArn !== null ? output.ActionArn : undefined,
-    ActionName: output.ActionName !== undefined && output.ActionName !== null ? output.ActionName : undefined,
-    ActionType: output.ActionType !== undefined && output.ActionType !== null ? output.ActionType : undefined,
+    ActionArn: __expectString(output.ActionArn),
+    ActionName: __expectString(output.ActionName),
+    ActionType: __expectString(output.ActionType),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -24019,15 +24025,14 @@ const deserializeAws_json1_1ActionSummary = (output: any, context: __SerdeContex
       output.Source !== undefined && output.Source !== null
         ? deserializeAws_json1_1ActionSource(output.Source, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
 const deserializeAws_json1_1AddAssociationResponse = (output: any, context: __SerdeContext): AddAssociationResponse => {
   return {
-    DestinationArn:
-      output.DestinationArn !== undefined && output.DestinationArn !== null ? output.DestinationArn : undefined,
-    SourceArn: output.SourceArn !== undefined && output.SourceArn !== null ? output.SourceArn : undefined,
+    DestinationArn: __expectString(output.DestinationArn),
+    SourceArn: __expectString(output.SourceArn),
   } as any;
 };
 
@@ -24038,7 +24043,7 @@ const deserializeAws_json1_1AdditionalCodeRepositoryNamesOrUrls = (output: any, 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -24053,8 +24058,8 @@ const deserializeAws_json1_1AddTagsOutput = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1AgentVersion = (output: any, context: __SerdeContext): AgentVersion => {
   return {
-    AgentCount: output.AgentCount !== undefined && output.AgentCount !== null ? output.AgentCount : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    AgentCount: __expectNumber(output.AgentCount),
+    Version: __expectString(output.Version),
   } as any;
 };
 
@@ -24071,7 +24076,7 @@ const deserializeAws_json1_1AgentVersions = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1Alarm = (output: any, context: __SerdeContext): Alarm => {
   return {
-    AlarmName: output.AlarmName !== undefined && output.AlarmName !== null ? output.AlarmName : undefined,
+    AlarmName: __expectString(output.AlarmName),
   } as any;
 };
 
@@ -24088,22 +24093,14 @@ const deserializeAws_json1_1AlarmList = (output: any, context: __SerdeContext): 
 
 const deserializeAws_json1_1AlgorithmSpecification = (output: any, context: __SerdeContext): AlgorithmSpecification => {
   return {
-    AlgorithmName:
-      output.AlgorithmName !== undefined && output.AlgorithmName !== null ? output.AlgorithmName : undefined,
-    EnableSageMakerMetricsTimeSeries:
-      output.EnableSageMakerMetricsTimeSeries !== undefined && output.EnableSageMakerMetricsTimeSeries !== null
-        ? output.EnableSageMakerMetricsTimeSeries
-        : undefined,
+    AlgorithmName: __expectString(output.AlgorithmName),
+    EnableSageMakerMetricsTimeSeries: __expectBoolean(output.EnableSageMakerMetricsTimeSeries),
     MetricDefinitions:
       output.MetricDefinitions !== undefined && output.MetricDefinitions !== null
         ? deserializeAws_json1_1MetricDefinitionList(output.MetricDefinitions, context)
         : undefined,
-    TrainingImage:
-      output.TrainingImage !== undefined && output.TrainingImage !== null ? output.TrainingImage : undefined,
-    TrainingInputMode:
-      output.TrainingInputMode !== undefined && output.TrainingInputMode !== null
-        ? output.TrainingInputMode
-        : undefined,
+    TrainingImage: __expectString(output.TrainingImage),
+    TrainingInputMode: __expectString(output.TrainingInputMode),
   } as any;
 };
 
@@ -24122,10 +24119,9 @@ const deserializeAws_json1_1AlgorithmStatusDetails = (output: any, context: __Se
 
 const deserializeAws_json1_1AlgorithmStatusItem = (output: any, context: __SerdeContext): AlgorithmStatusItem => {
   return {
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    FailureReason: __expectString(output.FailureReason),
+    Name: __expectString(output.Name),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -24142,15 +24138,10 @@ const deserializeAws_json1_1AlgorithmStatusItemList = (output: any, context: __S
 
 const deserializeAws_json1_1AlgorithmSummary = (output: any, context: __SerdeContext): AlgorithmSummary => {
   return {
-    AlgorithmArn: output.AlgorithmArn !== undefined && output.AlgorithmArn !== null ? output.AlgorithmArn : undefined,
-    AlgorithmDescription:
-      output.AlgorithmDescription !== undefined && output.AlgorithmDescription !== null
-        ? output.AlgorithmDescription
-        : undefined,
-    AlgorithmName:
-      output.AlgorithmName !== undefined && output.AlgorithmName !== null ? output.AlgorithmName : undefined,
-    AlgorithmStatus:
-      output.AlgorithmStatus !== undefined && output.AlgorithmStatus !== null ? output.AlgorithmStatus : undefined,
+    AlgorithmArn: __expectString(output.AlgorithmArn),
+    AlgorithmDescription: __expectString(output.AlgorithmDescription),
+    AlgorithmName: __expectString(output.AlgorithmName),
+    AlgorithmStatus: __expectString(output.AlgorithmStatus),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -24174,7 +24165,7 @@ const deserializeAws_json1_1AlgorithmValidationProfile = (
   context: __SerdeContext
 ): AlgorithmValidationProfile => {
   return {
-    ProfileName: output.ProfileName !== undefined && output.ProfileName !== null ? output.ProfileName : undefined,
+    ProfileName: __expectString(output.ProfileName),
     TrainingJobDefinition:
       output.TrainingJobDefinition !== undefined && output.TrainingJobDefinition !== null
         ? deserializeAws_json1_1TrainingJobDefinition(output.TrainingJobDefinition, context)
@@ -24209,8 +24200,7 @@ const deserializeAws_json1_1AlgorithmValidationSpecification = (
       output.ValidationProfiles !== undefined && output.ValidationProfiles !== null
         ? deserializeAws_json1_1AlgorithmValidationProfiles(output.ValidationProfiles, context)
         : undefined,
-    ValidationRole:
-      output.ValidationRole !== undefined && output.ValidationRole !== null ? output.ValidationRole : undefined,
+    ValidationRole: __expectString(output.ValidationRole),
   } as any;
 };
 
@@ -24219,38 +24209,28 @@ const deserializeAws_json1_1AnnotationConsolidationConfig = (
   context: __SerdeContext
 ): AnnotationConsolidationConfig => {
   return {
-    AnnotationConsolidationLambdaArn:
-      output.AnnotationConsolidationLambdaArn !== undefined && output.AnnotationConsolidationLambdaArn !== null
-        ? output.AnnotationConsolidationLambdaArn
-        : undefined,
+    AnnotationConsolidationLambdaArn: __expectString(output.AnnotationConsolidationLambdaArn),
   } as any;
 };
 
 const deserializeAws_json1_1AppDetails = (output: any, context: __SerdeContext): AppDetails => {
   return {
-    AppName: output.AppName !== undefined && output.AppName !== null ? output.AppName : undefined,
-    AppType: output.AppType !== undefined && output.AppType !== null ? output.AppType : undefined,
+    AppName: __expectString(output.AppName),
+    AppType: __expectString(output.AppType),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    DomainId: output.DomainId !== undefined && output.DomainId !== null ? output.DomainId : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    UserProfileName:
-      output.UserProfileName !== undefined && output.UserProfileName !== null ? output.UserProfileName : undefined,
+    DomainId: __expectString(output.DomainId),
+    Status: __expectString(output.Status),
+    UserProfileName: __expectString(output.UserProfileName),
   } as any;
 };
 
 const deserializeAws_json1_1AppImageConfigDetails = (output: any, context: __SerdeContext): AppImageConfigDetails => {
   return {
-    AppImageConfigArn:
-      output.AppImageConfigArn !== undefined && output.AppImageConfigArn !== null
-        ? output.AppImageConfigArn
-        : undefined,
-    AppImageConfigName:
-      output.AppImageConfigName !== undefined && output.AppImageConfigName !== null
-        ? output.AppImageConfigName
-        : undefined,
+    AppImageConfigArn: __expectString(output.AppImageConfigArn),
+    AppImageConfigName: __expectString(output.AppImageConfigName),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -24298,7 +24278,7 @@ const deserializeAws_json1_1AppSpecification = (output: any, context: __SerdeCon
       output.ContainerEntrypoint !== undefined && output.ContainerEntrypoint !== null
         ? deserializeAws_json1_1ContainerEntrypoint(output.ContainerEntrypoint, context)
         : undefined,
-    ImageUri: output.ImageUri !== undefined && output.ImageUri !== null ? output.ImageUri : undefined,
+    ImageUri: __expectString(output.ImageUri),
   } as any;
 };
 
@@ -24308,14 +24288,14 @@ const deserializeAws_json1_1ArtifactSource = (output: any, context: __SerdeConte
       output.SourceTypes !== undefined && output.SourceTypes !== null
         ? deserializeAws_json1_1ArtifactSourceTypes(output.SourceTypes, context)
         : undefined,
-    SourceUri: output.SourceUri !== undefined && output.SourceUri !== null ? output.SourceUri : undefined,
+    SourceUri: __expectString(output.SourceUri),
   } as any;
 };
 
 const deserializeAws_json1_1ArtifactSourceType = (output: any, context: __SerdeContext): ArtifactSourceType => {
   return {
-    SourceIdType: output.SourceIdType !== undefined && output.SourceIdType !== null ? output.SourceIdType : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    SourceIdType: __expectString(output.SourceIdType),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -24343,9 +24323,9 @@ const deserializeAws_json1_1ArtifactSummaries = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1ArtifactSummary = (output: any, context: __SerdeContext): ArtifactSummary => {
   return {
-    ArtifactArn: output.ArtifactArn !== undefined && output.ArtifactArn !== null ? output.ArtifactArn : undefined,
-    ArtifactName: output.ArtifactName !== undefined && output.ArtifactName !== null ? output.ArtifactName : undefined,
-    ArtifactType: output.ArtifactType !== undefined && output.ArtifactType !== null ? output.ArtifactType : undefined,
+    ArtifactArn: __expectString(output.ArtifactArn),
+    ArtifactName: __expectString(output.ArtifactName),
+    ArtifactType: __expectString(output.ArtifactType),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -24366,11 +24346,8 @@ const deserializeAws_json1_1AssociateTrialComponentResponse = (
   context: __SerdeContext
 ): AssociateTrialComponentResponse => {
   return {
-    TrialArn: output.TrialArn !== undefined && output.TrialArn !== null ? output.TrialArn : undefined,
-    TrialComponentArn:
-      output.TrialComponentArn !== undefined && output.TrialComponentArn !== null
-        ? output.TrialComponentArn
-        : undefined,
+    TrialArn: __expectString(output.TrialArn),
+    TrialComponentArn: __expectString(output.TrialComponentArn),
   } as any;
 };
 
@@ -24387,8 +24364,7 @@ const deserializeAws_json1_1AssociationSummaries = (output: any, context: __Serd
 
 const deserializeAws_json1_1AssociationSummary = (output: any, context: __SerdeContext): AssociationSummary => {
   return {
-    AssociationType:
-      output.AssociationType !== undefined && output.AssociationType !== null ? output.AssociationType : undefined,
+    AssociationType: __expectString(output.AssociationType),
     CreatedBy:
       output.CreatedBy !== undefined && output.CreatedBy !== null
         ? deserializeAws_json1_1UserContext(output.CreatedBy, context)
@@ -24397,15 +24373,12 @@ const deserializeAws_json1_1AssociationSummary = (output: any, context: __SerdeC
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    DestinationArn:
-      output.DestinationArn !== undefined && output.DestinationArn !== null ? output.DestinationArn : undefined,
-    DestinationName:
-      output.DestinationName !== undefined && output.DestinationName !== null ? output.DestinationName : undefined,
-    DestinationType:
-      output.DestinationType !== undefined && output.DestinationType !== null ? output.DestinationType : undefined,
-    SourceArn: output.SourceArn !== undefined && output.SourceArn !== null ? output.SourceArn : undefined,
-    SourceName: output.SourceName !== undefined && output.SourceName !== null ? output.SourceName : undefined,
-    SourceType: output.SourceType !== undefined && output.SourceType !== null ? output.SourceType : undefined,
+    DestinationArn: __expectString(output.DestinationArn),
+    DestinationName: __expectString(output.DestinationName),
+    DestinationType: __expectString(output.DestinationType),
+    SourceArn: __expectString(output.SourceArn),
+    SourceName: __expectString(output.SourceName),
+    SourceType: __expectString(output.SourceType),
   } as any;
 };
 
@@ -24414,17 +24387,14 @@ const deserializeAws_json1_1AthenaDatasetDefinition = (
   context: __SerdeContext
 ): AthenaDatasetDefinition => {
   return {
-    Catalog: output.Catalog !== undefined && output.Catalog !== null ? output.Catalog : undefined,
-    Database: output.Database !== undefined && output.Database !== null ? output.Database : undefined,
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
-    OutputCompression:
-      output.OutputCompression !== undefined && output.OutputCompression !== null
-        ? output.OutputCompression
-        : undefined,
-    OutputFormat: output.OutputFormat !== undefined && output.OutputFormat !== null ? output.OutputFormat : undefined,
-    OutputS3Uri: output.OutputS3Uri !== undefined && output.OutputS3Uri !== null ? output.OutputS3Uri : undefined,
-    QueryString: output.QueryString !== undefined && output.QueryString !== null ? output.QueryString : undefined,
-    WorkGroup: output.WorkGroup !== undefined && output.WorkGroup !== null ? output.WorkGroup : undefined,
+    Catalog: __expectString(output.Catalog),
+    Database: __expectString(output.Database),
+    KmsKeyId: __expectString(output.KmsKeyId),
+    OutputCompression: __expectString(output.OutputCompression),
+    OutputFormat: __expectString(output.OutputFormat),
+    OutputS3Uri: __expectString(output.OutputS3Uri),
+    QueryString: __expectString(output.QueryString),
+    WorkGroup: __expectString(output.WorkGroup),
   } as any;
 };
 
@@ -24435,20 +24405,18 @@ const deserializeAws_json1_1AttributeNames = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1AutoMLCandidate = (output: any, context: __SerdeContext): AutoMLCandidate => {
   return {
-    CandidateName:
-      output.CandidateName !== undefined && output.CandidateName !== null ? output.CandidateName : undefined,
+    CandidateName: __expectString(output.CandidateName),
     CandidateProperties:
       output.CandidateProperties !== undefined && output.CandidateProperties !== null
         ? deserializeAws_json1_1CandidateProperties(output.CandidateProperties, context)
         : undefined,
-    CandidateStatus:
-      output.CandidateStatus !== undefined && output.CandidateStatus !== null ? output.CandidateStatus : undefined,
+    CandidateStatus: __expectString(output.CandidateStatus),
     CandidateSteps:
       output.CandidateSteps !== undefined && output.CandidateSteps !== null
         ? deserializeAws_json1_1CandidateSteps(output.CandidateSteps, context)
@@ -24459,8 +24427,7 @@ const deserializeAws_json1_1AutoMLCandidate = (output: any, context: __SerdeCont
         : undefined,
     EndTime:
       output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
+    FailureReason: __expectString(output.FailureReason),
     FinalAutoMLJobObjectiveMetric:
       output.FinalAutoMLJobObjectiveMetric !== undefined && output.FinalAutoMLJobObjectiveMetric !== null
         ? deserializeAws_json1_1FinalAutoMLJobObjectiveMetric(output.FinalAutoMLJobObjectiveMetric, context)
@@ -24473,8 +24440,7 @@ const deserializeAws_json1_1AutoMLCandidate = (output: any, context: __SerdeCont
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    ObjectiveStatus:
-      output.ObjectiveStatus !== undefined && output.ObjectiveStatus !== null ? output.ObjectiveStatus : undefined,
+    ObjectiveStatus: __expectString(output.ObjectiveStatus),
   } as any;
 };
 
@@ -24491,31 +24457,20 @@ const deserializeAws_json1_1AutoMLCandidates = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1AutoMLCandidateStep = (output: any, context: __SerdeContext): AutoMLCandidateStep => {
   return {
-    CandidateStepArn:
-      output.CandidateStepArn !== undefined && output.CandidateStepArn !== null ? output.CandidateStepArn : undefined,
-    CandidateStepName:
-      output.CandidateStepName !== undefined && output.CandidateStepName !== null
-        ? output.CandidateStepName
-        : undefined,
-    CandidateStepType:
-      output.CandidateStepType !== undefined && output.CandidateStepType !== null
-        ? output.CandidateStepType
-        : undefined,
+    CandidateStepArn: __expectString(output.CandidateStepArn),
+    CandidateStepName: __expectString(output.CandidateStepName),
+    CandidateStepType: __expectString(output.CandidateStepType),
   } as any;
 };
 
 const deserializeAws_json1_1AutoMLChannel = (output: any, context: __SerdeContext): AutoMLChannel => {
   return {
-    CompressionType:
-      output.CompressionType !== undefined && output.CompressionType !== null ? output.CompressionType : undefined,
+    CompressionType: __expectString(output.CompressionType),
     DataSource:
       output.DataSource !== undefined && output.DataSource !== null
         ? deserializeAws_json1_1AutoMLDataSource(output.DataSource, context)
         : undefined,
-    TargetAttributeName:
-      output.TargetAttributeName !== undefined && output.TargetAttributeName !== null
-        ? output.TargetAttributeName
-        : undefined,
+    TargetAttributeName: __expectString(output.TargetAttributeName),
   } as any;
 };
 
@@ -24528,8 +24483,8 @@ const deserializeAws_json1_1AutoMLContainerDefinition = (
       output.Environment !== undefined && output.Environment !== null
         ? deserializeAws_json1_1EnvironmentMap(output.Environment, context)
         : undefined,
-    Image: output.Image !== undefined && output.Image !== null ? output.Image : undefined,
-    ModelDataUrl: output.ModelDataUrl !== undefined && output.ModelDataUrl !== null ? output.ModelDataUrl : undefined,
+    Image: __expectString(output.Image),
+    ModelDataUrl: __expectString(output.ModelDataUrl),
   } as any;
 };
 
@@ -24569,14 +24524,8 @@ const deserializeAws_json1_1AutoMLInputDataConfig = (output: any, context: __Ser
 
 const deserializeAws_json1_1AutoMLJobArtifacts = (output: any, context: __SerdeContext): AutoMLJobArtifacts => {
   return {
-    CandidateDefinitionNotebookLocation:
-      output.CandidateDefinitionNotebookLocation !== undefined && output.CandidateDefinitionNotebookLocation !== null
-        ? output.CandidateDefinitionNotebookLocation
-        : undefined,
-    DataExplorationNotebookLocation:
-      output.DataExplorationNotebookLocation !== undefined && output.DataExplorationNotebookLocation !== null
-        ? output.DataExplorationNotebookLocation
-        : undefined,
+    CandidateDefinitionNotebookLocation: __expectString(output.CandidateDefinitionNotebookLocation),
+    DataExplorationNotebookLocation: __expectString(output.DataExplorationNotebookLocation),
   } as any;
 };
 
@@ -24585,16 +24534,9 @@ const deserializeAws_json1_1AutoMLJobCompletionCriteria = (
   context: __SerdeContext
 ): AutoMLJobCompletionCriteria => {
   return {
-    MaxAutoMLJobRuntimeInSeconds:
-      output.MaxAutoMLJobRuntimeInSeconds !== undefined && output.MaxAutoMLJobRuntimeInSeconds !== null
-        ? output.MaxAutoMLJobRuntimeInSeconds
-        : undefined,
-    MaxCandidates:
-      output.MaxCandidates !== undefined && output.MaxCandidates !== null ? output.MaxCandidates : undefined,
-    MaxRuntimePerTrainingJobInSeconds:
-      output.MaxRuntimePerTrainingJobInSeconds !== undefined && output.MaxRuntimePerTrainingJobInSeconds !== null
-        ? output.MaxRuntimePerTrainingJobInSeconds
-        : undefined,
+    MaxAutoMLJobRuntimeInSeconds: __expectNumber(output.MaxAutoMLJobRuntimeInSeconds),
+    MaxCandidates: __expectNumber(output.MaxCandidates),
+    MaxRuntimePerTrainingJobInSeconds: __expectNumber(output.MaxRuntimePerTrainingJobInSeconds),
   } as any;
 };
 
@@ -24613,7 +24555,7 @@ const deserializeAws_json1_1AutoMLJobConfig = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_1AutoMLJobObjective = (output: any, context: __SerdeContext): AutoMLJobObjective => {
   return {
-    MetricName: output.MetricName !== undefined && output.MetricName !== null ? output.MetricName : undefined,
+    MetricName: __expectString(output.MetricName),
   } as any;
 };
 
@@ -24630,23 +24572,17 @@ const deserializeAws_json1_1AutoMLJobSummaries = (output: any, context: __SerdeC
 
 const deserializeAws_json1_1AutoMLJobSummary = (output: any, context: __SerdeContext): AutoMLJobSummary => {
   return {
-    AutoMLJobArn: output.AutoMLJobArn !== undefined && output.AutoMLJobArn !== null ? output.AutoMLJobArn : undefined,
-    AutoMLJobName:
-      output.AutoMLJobName !== undefined && output.AutoMLJobName !== null ? output.AutoMLJobName : undefined,
-    AutoMLJobSecondaryStatus:
-      output.AutoMLJobSecondaryStatus !== undefined && output.AutoMLJobSecondaryStatus !== null
-        ? output.AutoMLJobSecondaryStatus
-        : undefined,
-    AutoMLJobStatus:
-      output.AutoMLJobStatus !== undefined && output.AutoMLJobStatus !== null ? output.AutoMLJobStatus : undefined,
+    AutoMLJobArn: __expectString(output.AutoMLJobArn),
+    AutoMLJobName: __expectString(output.AutoMLJobName),
+    AutoMLJobSecondaryStatus: __expectString(output.AutoMLJobSecondaryStatus),
+    AutoMLJobStatus: __expectString(output.AutoMLJobStatus),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
     EndTime:
       output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
+    FailureReason: __expectString(output.FailureReason),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
@@ -24660,8 +24596,8 @@ const deserializeAws_json1_1AutoMLJobSummary = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1AutoMLOutputDataConfig = (output: any, context: __SerdeContext): AutoMLOutputDataConfig => {
   return {
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
-    S3OutputPath: output.S3OutputPath !== undefined && output.S3OutputPath !== null ? output.S3OutputPath : undefined,
+    KmsKeyId: __expectString(output.KmsKeyId),
+    S3OutputPath: __expectString(output.S3OutputPath),
   } as any;
 };
 
@@ -24670,10 +24606,7 @@ const deserializeAws_json1_1AutoMLPartialFailureReason = (
   context: __SerdeContext
 ): AutoMLPartialFailureReason => {
   return {
-    PartialFailureMessage:
-      output.PartialFailureMessage !== undefined && output.PartialFailureMessage !== null
-        ? output.PartialFailureMessage
-        : undefined,
+    PartialFailureMessage: __expectString(output.PartialFailureMessage),
   } as any;
 };
 
@@ -24693,20 +24626,15 @@ const deserializeAws_json1_1AutoMLPartialFailureReasons = (
 
 const deserializeAws_json1_1AutoMLS3DataSource = (output: any, context: __SerdeContext): AutoMLS3DataSource => {
   return {
-    S3DataType: output.S3DataType !== undefined && output.S3DataType !== null ? output.S3DataType : undefined,
-    S3Uri: output.S3Uri !== undefined && output.S3Uri !== null ? output.S3Uri : undefined,
+    S3DataType: __expectString(output.S3DataType),
+    S3Uri: __expectString(output.S3Uri),
   } as any;
 };
 
 const deserializeAws_json1_1AutoMLSecurityConfig = (output: any, context: __SerdeContext): AutoMLSecurityConfig => {
   return {
-    EnableInterContainerTrafficEncryption:
-      output.EnableInterContainerTrafficEncryption !== undefined &&
-      output.EnableInterContainerTrafficEncryption !== null
-        ? output.EnableInterContainerTrafficEncryption
-        : undefined,
-    VolumeKmsKeyId:
-      output.VolumeKmsKeyId !== undefined && output.VolumeKmsKeyId !== null ? output.VolumeKmsKeyId : undefined,
+    EnableInterContainerTrafficEncryption: __expectBoolean(output.EnableInterContainerTrafficEncryption),
+    VolumeKmsKeyId: __expectString(output.VolumeKmsKeyId),
     VpcConfig:
       output.VpcConfig !== undefined && output.VpcConfig !== null
         ? deserializeAws_json1_1VpcConfig(output.VpcConfig, context)
@@ -24734,14 +24662,8 @@ const deserializeAws_json1_1Bias = (output: any, context: __SerdeContext): Bias 
 
 const deserializeAws_json1_1BlueGreenUpdatePolicy = (output: any, context: __SerdeContext): BlueGreenUpdatePolicy => {
   return {
-    MaximumExecutionTimeoutInSeconds:
-      output.MaximumExecutionTimeoutInSeconds !== undefined && output.MaximumExecutionTimeoutInSeconds !== null
-        ? output.MaximumExecutionTimeoutInSeconds
-        : undefined,
-    TerminationWaitInSeconds:
-      output.TerminationWaitInSeconds !== undefined && output.TerminationWaitInSeconds !== null
-        ? output.TerminationWaitInSeconds
-        : undefined,
+    MaximumExecutionTimeoutInSeconds: __expectNumber(output.MaximumExecutionTimeoutInSeconds),
+    TerminationWaitInSeconds: __expectNumber(output.TerminationWaitInSeconds),
     TrafficRoutingConfiguration:
       output.TrafficRoutingConfiguration !== undefined && output.TrafficRoutingConfiguration !== null
         ? deserializeAws_json1_1TrafficRoutingConfig(output.TrafficRoutingConfiguration, context)
@@ -24751,22 +24673,18 @@ const deserializeAws_json1_1BlueGreenUpdatePolicy = (output: any, context: __Ser
 
 const deserializeAws_json1_1CacheHitResult = (output: any, context: __SerdeContext): CacheHitResult => {
   return {
-    SourcePipelineExecutionArn:
-      output.SourcePipelineExecutionArn !== undefined && output.SourcePipelineExecutionArn !== null
-        ? output.SourcePipelineExecutionArn
-        : undefined,
+    SourcePipelineExecutionArn: __expectString(output.SourcePipelineExecutionArn),
   } as any;
 };
 
 const deserializeAws_json1_1CallbackStepMetadata = (output: any, context: __SerdeContext): CallbackStepMetadata => {
   return {
-    CallbackToken:
-      output.CallbackToken !== undefined && output.CallbackToken !== null ? output.CallbackToken : undefined,
+    CallbackToken: __expectString(output.CallbackToken),
     OutputParameters:
       output.OutputParameters !== undefined && output.OutputParameters !== null
         ? deserializeAws_json1_1OutputParameterList(output.OutputParameters, context)
         : undefined,
-    SqsQueueUrl: output.SqsQueueUrl !== undefined && output.SqsQueueUrl !== null ? output.SqsQueueUrl : undefined,
+    SqsQueueUrl: __expectString(output.SqsQueueUrl),
   } as any;
 };
 
@@ -24775,8 +24693,7 @@ const deserializeAws_json1_1CandidateArtifactLocations = (
   context: __SerdeContext
 ): CandidateArtifactLocations => {
   return {
-    Explainability:
-      output.Explainability !== undefined && output.Explainability !== null ? output.Explainability : undefined,
+    Explainability: __expectString(output.Explainability),
   } as any;
 };
 
@@ -24802,8 +24719,8 @@ const deserializeAws_json1_1CandidateSteps = (output: any, context: __SerdeConte
 
 const deserializeAws_json1_1CapacitySize = (output: any, context: __SerdeContext): CapacitySize => {
   return {
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Type: __expectString(output.Type),
+    Value: __expectNumber(output.Value),
   } as any;
 };
 
@@ -24825,7 +24742,7 @@ const deserializeAws_json1_1CaptureContentTypeHeader = (
 
 const deserializeAws_json1_1CaptureOption = (output: any, context: __SerdeContext): CaptureOption => {
   return {
-    CaptureMode: output.CaptureMode !== undefined && output.CaptureMode !== null ? output.CaptureMode : undefined,
+    CaptureMode: __expectString(output.CaptureMode),
   } as any;
 };
 
@@ -24845,7 +24762,7 @@ const deserializeAws_json1_1CategoricalParameterRange = (
   context: __SerdeContext
 ): CategoricalParameterRange => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     Values:
       output.Values !== undefined && output.Values !== null
         ? deserializeAws_json1_1ParameterValues(output.Values, context)
@@ -24881,19 +24798,15 @@ const deserializeAws_json1_1CategoricalParameterRangeSpecification = (
 
 const deserializeAws_json1_1Channel = (output: any, context: __SerdeContext): Channel => {
   return {
-    ChannelName: output.ChannelName !== undefined && output.ChannelName !== null ? output.ChannelName : undefined,
-    CompressionType:
-      output.CompressionType !== undefined && output.CompressionType !== null ? output.CompressionType : undefined,
-    ContentType: output.ContentType !== undefined && output.ContentType !== null ? output.ContentType : undefined,
+    ChannelName: __expectString(output.ChannelName),
+    CompressionType: __expectString(output.CompressionType),
+    ContentType: __expectString(output.ContentType),
     DataSource:
       output.DataSource !== undefined && output.DataSource !== null
         ? deserializeAws_json1_1DataSource(output.DataSource, context)
         : undefined,
-    InputMode: output.InputMode !== undefined && output.InputMode !== null ? output.InputMode : undefined,
-    RecordWrapperType:
-      output.RecordWrapperType !== undefined && output.RecordWrapperType !== null
-        ? output.RecordWrapperType
-        : undefined,
+    InputMode: __expectString(output.InputMode),
+    RecordWrapperType: __expectString(output.RecordWrapperType),
     ShuffleConfig:
       output.ShuffleConfig !== undefined && output.ShuffleConfig !== null
         ? deserializeAws_json1_1ShuffleConfig(output.ShuffleConfig, context)
@@ -24903,9 +24816,9 @@ const deserializeAws_json1_1Channel = (output: any, context: __SerdeContext): Ch
 
 const deserializeAws_json1_1ChannelSpecification = (output: any, context: __SerdeContext): ChannelSpecification => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    IsRequired: output.IsRequired !== undefined && output.IsRequired !== null ? output.IsRequired : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Description: __expectString(output.Description),
+    IsRequired: __expectBoolean(output.IsRequired),
+    Name: __expectString(output.Name),
     SupportedCompressionTypes:
       output.SupportedCompressionTypes !== undefined && output.SupportedCompressionTypes !== null
         ? deserializeAws_json1_1CompressionTypes(output.SupportedCompressionTypes, context)
@@ -24934,8 +24847,8 @@ const deserializeAws_json1_1ChannelSpecifications = (output: any, context: __Ser
 
 const deserializeAws_json1_1CheckpointConfig = (output: any, context: __SerdeContext): CheckpointConfig => {
   return {
-    LocalPath: output.LocalPath !== undefined && output.LocalPath !== null ? output.LocalPath : undefined,
-    S3Uri: output.S3Uri !== undefined && output.S3Uri !== null ? output.S3Uri : undefined,
+    LocalPath: __expectString(output.LocalPath),
+    S3Uri: __expectString(output.S3Uri),
   } as any;
 };
 
@@ -24946,20 +24859,14 @@ const deserializeAws_json1_1Cidrs = (output: any, context: __SerdeContext): stri
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1CodeRepositorySummary = (output: any, context: __SerdeContext): CodeRepositorySummary => {
   return {
-    CodeRepositoryArn:
-      output.CodeRepositoryArn !== undefined && output.CodeRepositoryArn !== null
-        ? output.CodeRepositoryArn
-        : undefined,
-    CodeRepositoryName:
-      output.CodeRepositoryName !== undefined && output.CodeRepositoryName !== null
-        ? output.CodeRepositoryName
-        : undefined,
+    CodeRepositoryArn: __expectString(output.CodeRepositoryArn),
+    CodeRepositoryName: __expectString(output.CodeRepositoryName),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -24991,8 +24898,8 @@ const deserializeAws_json1_1CodeRepositorySummaryList = (
 
 const deserializeAws_json1_1CognitoConfig = (output: any, context: __SerdeContext): CognitoConfig => {
   return {
-    ClientId: output.ClientId !== undefined && output.ClientId !== null ? output.ClientId : undefined,
-    UserPool: output.UserPool !== undefined && output.UserPool !== null ? output.UserPool : undefined,
+    ClientId: __expectString(output.ClientId),
+    UserPool: __expectString(output.UserPool),
   } as any;
 };
 
@@ -25001,9 +24908,9 @@ const deserializeAws_json1_1CognitoMemberDefinition = (
   context: __SerdeContext
 ): CognitoMemberDefinition => {
   return {
-    ClientId: output.ClientId !== undefined && output.ClientId !== null ? output.ClientId : undefined,
-    UserGroup: output.UserGroup !== undefined && output.UserGroup !== null ? output.UserGroup : undefined,
-    UserPool: output.UserPool !== undefined && output.UserPool !== null ? output.UserPool : undefined,
+    ClientId: __expectString(output.ClientId),
+    UserGroup: __expectString(output.UserGroup),
+    UserPool: __expectString(output.UserPool),
   } as any;
 };
 
@@ -25012,8 +24919,7 @@ const deserializeAws_json1_1CollectionConfiguration = (
   context: __SerdeContext
 ): CollectionConfiguration => {
   return {
-    CollectionName:
-      output.CollectionName !== undefined && output.CollectionName !== null ? output.CollectionName : undefined,
+    CollectionName: __expectString(output.CollectionName),
     CollectionParameters:
       output.CollectionParameters !== undefined && output.CollectionParameters !== null
         ? deserializeAws_json1_1CollectionParameters(output.CollectionParameters, context)
@@ -25045,7 +24951,7 @@ const deserializeAws_json1_1CollectionParameters = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -25070,38 +24976,17 @@ const deserializeAws_json1_1CompilationJobSummary = (output: any, context: __Ser
       output.CompilationEndTime !== undefined && output.CompilationEndTime !== null
         ? new Date(Math.round(output.CompilationEndTime * 1000))
         : undefined,
-    CompilationJobArn:
-      output.CompilationJobArn !== undefined && output.CompilationJobArn !== null
-        ? output.CompilationJobArn
-        : undefined,
-    CompilationJobName:
-      output.CompilationJobName !== undefined && output.CompilationJobName !== null
-        ? output.CompilationJobName
-        : undefined,
-    CompilationJobStatus:
-      output.CompilationJobStatus !== undefined && output.CompilationJobStatus !== null
-        ? output.CompilationJobStatus
-        : undefined,
+    CompilationJobArn: __expectString(output.CompilationJobArn),
+    CompilationJobName: __expectString(output.CompilationJobName),
+    CompilationJobStatus: __expectString(output.CompilationJobStatus),
     CompilationStartTime:
       output.CompilationStartTime !== undefined && output.CompilationStartTime !== null
         ? new Date(Math.round(output.CompilationStartTime * 1000))
         : undefined,
-    CompilationTargetDevice:
-      output.CompilationTargetDevice !== undefined && output.CompilationTargetDevice !== null
-        ? output.CompilationTargetDevice
-        : undefined,
-    CompilationTargetPlatformAccelerator:
-      output.CompilationTargetPlatformAccelerator !== undefined && output.CompilationTargetPlatformAccelerator !== null
-        ? output.CompilationTargetPlatformAccelerator
-        : undefined,
-    CompilationTargetPlatformArch:
-      output.CompilationTargetPlatformArch !== undefined && output.CompilationTargetPlatformArch !== null
-        ? output.CompilationTargetPlatformArch
-        : undefined,
-    CompilationTargetPlatformOs:
-      output.CompilationTargetPlatformOs !== undefined && output.CompilationTargetPlatformOs !== null
-        ? output.CompilationTargetPlatformOs
-        : undefined,
+    CompilationTargetDevice: __expectString(output.CompilationTargetDevice),
+    CompilationTargetPlatformAccelerator: __expectString(output.CompilationTargetPlatformAccelerator),
+    CompilationTargetPlatformArch: __expectString(output.CompilationTargetPlatformArch),
+    CompilationTargetPlatformOs: __expectString(output.CompilationTargetPlatformOs),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -25120,19 +25005,19 @@ const deserializeAws_json1_1CompressionTypes = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1ConditionStepMetadata = (output: any, context: __SerdeContext): ConditionStepMetadata => {
   return {
-    Outcome: output.Outcome !== undefined && output.Outcome !== null ? output.Outcome : undefined,
+    Outcome: __expectString(output.Outcome),
   } as any;
 };
 
 const deserializeAws_json1_1ConflictException = (output: any, context: __SerdeContext): ConflictException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -25143,29 +25028,25 @@ const deserializeAws_json1_1ContainerArguments = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1ContainerDefinition = (output: any, context: __SerdeContext): ContainerDefinition => {
   return {
-    ContainerHostname:
-      output.ContainerHostname !== undefined && output.ContainerHostname !== null
-        ? output.ContainerHostname
-        : undefined,
+    ContainerHostname: __expectString(output.ContainerHostname),
     Environment:
       output.Environment !== undefined && output.Environment !== null
         ? deserializeAws_json1_1EnvironmentMap(output.Environment, context)
         : undefined,
-    Image: output.Image !== undefined && output.Image !== null ? output.Image : undefined,
+    Image: __expectString(output.Image),
     ImageConfig:
       output.ImageConfig !== undefined && output.ImageConfig !== null
         ? deserializeAws_json1_1ImageConfig(output.ImageConfig, context)
         : undefined,
-    Mode: output.Mode !== undefined && output.Mode !== null ? output.Mode : undefined,
-    ModelDataUrl: output.ModelDataUrl !== undefined && output.ModelDataUrl !== null ? output.ModelDataUrl : undefined,
-    ModelPackageName:
-      output.ModelPackageName !== undefined && output.ModelPackageName !== null ? output.ModelPackageName : undefined,
+    Mode: __expectString(output.Mode),
+    ModelDataUrl: __expectString(output.ModelDataUrl),
+    ModelPackageName: __expectString(output.ModelPackageName),
     MultiModelConfig:
       output.MultiModelConfig !== undefined && output.MultiModelConfig !== null
         ? deserializeAws_json1_1MultiModelConfig(output.MultiModelConfig, context)
@@ -25191,7 +25072,7 @@ const deserializeAws_json1_1ContainerEntrypoint = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -25205,7 +25086,7 @@ const deserializeAws_json1_1ContentClassifiers = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -25216,15 +25097,15 @@ const deserializeAws_json1_1ContentTypes = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1ContextSource = (output: any, context: __SerdeContext): ContextSource => {
   return {
-    SourceId: output.SourceId !== undefined && output.SourceId !== null ? output.SourceId : undefined,
-    SourceType: output.SourceType !== undefined && output.SourceType !== null ? output.SourceType : undefined,
-    SourceUri: output.SourceUri !== undefined && output.SourceUri !== null ? output.SourceUri : undefined,
+    SourceId: __expectString(output.SourceId),
+    SourceType: __expectString(output.SourceType),
+    SourceUri: __expectString(output.SourceUri),
   } as any;
 };
 
@@ -25241,9 +25122,9 @@ const deserializeAws_json1_1ContextSummaries = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1ContextSummary = (output: any, context: __SerdeContext): ContextSummary => {
   return {
-    ContextArn: output.ContextArn !== undefined && output.ContextArn !== null ? output.ContextArn : undefined,
-    ContextName: output.ContextName !== undefined && output.ContextName !== null ? output.ContextName : undefined,
-    ContextType: output.ContextType !== undefined && output.ContextType !== null ? output.ContextType : undefined,
+    ContextArn: __expectString(output.ContextArn),
+    ContextName: __expectString(output.ContextName),
+    ContextType: __expectString(output.ContextType),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -25264,10 +25145,10 @@ const deserializeAws_json1_1ContinuousParameterRange = (
   context: __SerdeContext
 ): ContinuousParameterRange => {
   return {
-    MaxValue: output.MaxValue !== undefined && output.MaxValue !== null ? output.MaxValue : undefined,
-    MinValue: output.MinValue !== undefined && output.MinValue !== null ? output.MinValue : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    ScalingType: output.ScalingType !== undefined && output.ScalingType !== null ? output.ScalingType : undefined,
+    MaxValue: __expectString(output.MaxValue),
+    MinValue: __expectString(output.MinValue),
+    Name: __expectString(output.Name),
+    ScalingType: __expectString(output.ScalingType),
   } as any;
 };
 
@@ -25290,20 +25171,20 @@ const deserializeAws_json1_1ContinuousParameterRangeSpecification = (
   context: __SerdeContext
 ): ContinuousParameterRangeSpecification => {
   return {
-    MaxValue: output.MaxValue !== undefined && output.MaxValue !== null ? output.MaxValue : undefined,
-    MinValue: output.MinValue !== undefined && output.MinValue !== null ? output.MinValue : undefined,
+    MaxValue: __expectString(output.MaxValue),
+    MinValue: __expectString(output.MinValue),
   } as any;
 };
 
 const deserializeAws_json1_1CreateActionResponse = (output: any, context: __SerdeContext): CreateActionResponse => {
   return {
-    ActionArn: output.ActionArn !== undefined && output.ActionArn !== null ? output.ActionArn : undefined,
+    ActionArn: __expectString(output.ActionArn),
   } as any;
 };
 
 const deserializeAws_json1_1CreateAlgorithmOutput = (output: any, context: __SerdeContext): CreateAlgorithmOutput => {
   return {
-    AlgorithmArn: output.AlgorithmArn !== undefined && output.AlgorithmArn !== null ? output.AlgorithmArn : undefined,
+    AlgorithmArn: __expectString(output.AlgorithmArn),
   } as any;
 };
 
@@ -25312,22 +25193,19 @@ const deserializeAws_json1_1CreateAppImageConfigResponse = (
   context: __SerdeContext
 ): CreateAppImageConfigResponse => {
   return {
-    AppImageConfigArn:
-      output.AppImageConfigArn !== undefined && output.AppImageConfigArn !== null
-        ? output.AppImageConfigArn
-        : undefined,
+    AppImageConfigArn: __expectString(output.AppImageConfigArn),
   } as any;
 };
 
 const deserializeAws_json1_1CreateAppResponse = (output: any, context: __SerdeContext): CreateAppResponse => {
   return {
-    AppArn: output.AppArn !== undefined && output.AppArn !== null ? output.AppArn : undefined,
+    AppArn: __expectString(output.AppArn),
   } as any;
 };
 
 const deserializeAws_json1_1CreateArtifactResponse = (output: any, context: __SerdeContext): CreateArtifactResponse => {
   return {
-    ArtifactArn: output.ArtifactArn !== undefined && output.ArtifactArn !== null ? output.ArtifactArn : undefined,
+    ArtifactArn: __expectString(output.ArtifactArn),
   } as any;
 };
 
@@ -25336,7 +25214,7 @@ const deserializeAws_json1_1CreateAutoMLJobResponse = (
   context: __SerdeContext
 ): CreateAutoMLJobResponse => {
   return {
-    AutoMLJobArn: output.AutoMLJobArn !== undefined && output.AutoMLJobArn !== null ? output.AutoMLJobArn : undefined,
+    AutoMLJobArn: __expectString(output.AutoMLJobArn),
   } as any;
 };
 
@@ -25345,10 +25223,7 @@ const deserializeAws_json1_1CreateCodeRepositoryOutput = (
   context: __SerdeContext
 ): CreateCodeRepositoryOutput => {
   return {
-    CodeRepositoryArn:
-      output.CodeRepositoryArn !== undefined && output.CodeRepositoryArn !== null
-        ? output.CodeRepositoryArn
-        : undefined,
+    CodeRepositoryArn: __expectString(output.CodeRepositoryArn),
   } as any;
 };
 
@@ -25357,16 +25232,13 @@ const deserializeAws_json1_1CreateCompilationJobResponse = (
   context: __SerdeContext
 ): CreateCompilationJobResponse => {
   return {
-    CompilationJobArn:
-      output.CompilationJobArn !== undefined && output.CompilationJobArn !== null
-        ? output.CompilationJobArn
-        : undefined,
+    CompilationJobArn: __expectString(output.CompilationJobArn),
   } as any;
 };
 
 const deserializeAws_json1_1CreateContextResponse = (output: any, context: __SerdeContext): CreateContextResponse => {
   return {
-    ContextArn: output.ContextArn !== undefined && output.ContextArn !== null ? output.ContextArn : undefined,
+    ContextArn: __expectString(output.ContextArn),
   } as any;
 };
 
@@ -25375,15 +25247,14 @@ const deserializeAws_json1_1CreateDataQualityJobDefinitionResponse = (
   context: __SerdeContext
 ): CreateDataQualityJobDefinitionResponse => {
   return {
-    JobDefinitionArn:
-      output.JobDefinitionArn !== undefined && output.JobDefinitionArn !== null ? output.JobDefinitionArn : undefined,
+    JobDefinitionArn: __expectString(output.JobDefinitionArn),
   } as any;
 };
 
 const deserializeAws_json1_1CreateDomainResponse = (output: any, context: __SerdeContext): CreateDomainResponse => {
   return {
-    DomainArn: output.DomainArn !== undefined && output.DomainArn !== null ? output.DomainArn : undefined,
-    Url: output.Url !== undefined && output.Url !== null ? output.Url : undefined,
+    DomainArn: __expectString(output.DomainArn),
+    Url: __expectString(output.Url),
   } as any;
 };
 
@@ -25392,16 +25263,13 @@ const deserializeAws_json1_1CreateEndpointConfigOutput = (
   context: __SerdeContext
 ): CreateEndpointConfigOutput => {
   return {
-    EndpointConfigArn:
-      output.EndpointConfigArn !== undefined && output.EndpointConfigArn !== null
-        ? output.EndpointConfigArn
-        : undefined,
+    EndpointConfigArn: __expectString(output.EndpointConfigArn),
   } as any;
 };
 
 const deserializeAws_json1_1CreateEndpointOutput = (output: any, context: __SerdeContext): CreateEndpointOutput => {
   return {
-    EndpointArn: output.EndpointArn !== undefined && output.EndpointArn !== null ? output.EndpointArn : undefined,
+    EndpointArn: __expectString(output.EndpointArn),
   } as any;
 };
 
@@ -25410,8 +25278,7 @@ const deserializeAws_json1_1CreateExperimentResponse = (
   context: __SerdeContext
 ): CreateExperimentResponse => {
   return {
-    ExperimentArn:
-      output.ExperimentArn !== undefined && output.ExperimentArn !== null ? output.ExperimentArn : undefined,
+    ExperimentArn: __expectString(output.ExperimentArn),
   } as any;
 };
 
@@ -25420,8 +25287,7 @@ const deserializeAws_json1_1CreateFeatureGroupResponse = (
   context: __SerdeContext
 ): CreateFeatureGroupResponse => {
   return {
-    FeatureGroupArn:
-      output.FeatureGroupArn !== undefined && output.FeatureGroupArn !== null ? output.FeatureGroupArn : undefined,
+    FeatureGroupArn: __expectString(output.FeatureGroupArn),
   } as any;
 };
 
@@ -25430,10 +25296,7 @@ const deserializeAws_json1_1CreateFlowDefinitionResponse = (
   context: __SerdeContext
 ): CreateFlowDefinitionResponse => {
   return {
-    FlowDefinitionArn:
-      output.FlowDefinitionArn !== undefined && output.FlowDefinitionArn !== null
-        ? output.FlowDefinitionArn
-        : undefined,
+    FlowDefinitionArn: __expectString(output.FlowDefinitionArn),
   } as any;
 };
 
@@ -25442,8 +25305,7 @@ const deserializeAws_json1_1CreateHumanTaskUiResponse = (
   context: __SerdeContext
 ): CreateHumanTaskUiResponse => {
   return {
-    HumanTaskUiArn:
-      output.HumanTaskUiArn !== undefined && output.HumanTaskUiArn !== null ? output.HumanTaskUiArn : undefined,
+    HumanTaskUiArn: __expectString(output.HumanTaskUiArn),
   } as any;
 };
 
@@ -25452,16 +25314,13 @@ const deserializeAws_json1_1CreateHyperParameterTuningJobResponse = (
   context: __SerdeContext
 ): CreateHyperParameterTuningJobResponse => {
   return {
-    HyperParameterTuningJobArn:
-      output.HyperParameterTuningJobArn !== undefined && output.HyperParameterTuningJobArn !== null
-        ? output.HyperParameterTuningJobArn
-        : undefined,
+    HyperParameterTuningJobArn: __expectString(output.HyperParameterTuningJobArn),
   } as any;
 };
 
 const deserializeAws_json1_1CreateImageResponse = (output: any, context: __SerdeContext): CreateImageResponse => {
   return {
-    ImageArn: output.ImageArn !== undefined && output.ImageArn !== null ? output.ImageArn : undefined,
+    ImageArn: __expectString(output.ImageArn),
   } as any;
 };
 
@@ -25470,8 +25329,7 @@ const deserializeAws_json1_1CreateImageVersionResponse = (
   context: __SerdeContext
 ): CreateImageVersionResponse => {
   return {
-    ImageVersionArn:
-      output.ImageVersionArn !== undefined && output.ImageVersionArn !== null ? output.ImageVersionArn : undefined,
+    ImageVersionArn: __expectString(output.ImageVersionArn),
   } as any;
 };
 
@@ -25480,8 +25338,7 @@ const deserializeAws_json1_1CreateLabelingJobResponse = (
   context: __SerdeContext
 ): CreateLabelingJobResponse => {
   return {
-    LabelingJobArn:
-      output.LabelingJobArn !== undefined && output.LabelingJobArn !== null ? output.LabelingJobArn : undefined,
+    LabelingJobArn: __expectString(output.LabelingJobArn),
   } as any;
 };
 
@@ -25490,8 +25347,7 @@ const deserializeAws_json1_1CreateModelBiasJobDefinitionResponse = (
   context: __SerdeContext
 ): CreateModelBiasJobDefinitionResponse => {
   return {
-    JobDefinitionArn:
-      output.JobDefinitionArn !== undefined && output.JobDefinitionArn !== null ? output.JobDefinitionArn : undefined,
+    JobDefinitionArn: __expectString(output.JobDefinitionArn),
   } as any;
 };
 
@@ -25500,14 +25356,13 @@ const deserializeAws_json1_1CreateModelExplainabilityJobDefinitionResponse = (
   context: __SerdeContext
 ): CreateModelExplainabilityJobDefinitionResponse => {
   return {
-    JobDefinitionArn:
-      output.JobDefinitionArn !== undefined && output.JobDefinitionArn !== null ? output.JobDefinitionArn : undefined,
+    JobDefinitionArn: __expectString(output.JobDefinitionArn),
   } as any;
 };
 
 const deserializeAws_json1_1CreateModelOutput = (output: any, context: __SerdeContext): CreateModelOutput => {
   return {
-    ModelArn: output.ModelArn !== undefined && output.ModelArn !== null ? output.ModelArn : undefined,
+    ModelArn: __expectString(output.ModelArn),
   } as any;
 };
 
@@ -25516,10 +25371,7 @@ const deserializeAws_json1_1CreateModelPackageGroupOutput = (
   context: __SerdeContext
 ): CreateModelPackageGroupOutput => {
   return {
-    ModelPackageGroupArn:
-      output.ModelPackageGroupArn !== undefined && output.ModelPackageGroupArn !== null
-        ? output.ModelPackageGroupArn
-        : undefined,
+    ModelPackageGroupArn: __expectString(output.ModelPackageGroupArn),
   } as any;
 };
 
@@ -25528,8 +25380,7 @@ const deserializeAws_json1_1CreateModelPackageOutput = (
   context: __SerdeContext
 ): CreateModelPackageOutput => {
   return {
-    ModelPackageArn:
-      output.ModelPackageArn !== undefined && output.ModelPackageArn !== null ? output.ModelPackageArn : undefined,
+    ModelPackageArn: __expectString(output.ModelPackageArn),
   } as any;
 };
 
@@ -25538,8 +25389,7 @@ const deserializeAws_json1_1CreateModelQualityJobDefinitionResponse = (
   context: __SerdeContext
 ): CreateModelQualityJobDefinitionResponse => {
   return {
-    JobDefinitionArn:
-      output.JobDefinitionArn !== undefined && output.JobDefinitionArn !== null ? output.JobDefinitionArn : undefined,
+    JobDefinitionArn: __expectString(output.JobDefinitionArn),
   } as any;
 };
 
@@ -25548,10 +25398,7 @@ const deserializeAws_json1_1CreateMonitoringScheduleResponse = (
   context: __SerdeContext
 ): CreateMonitoringScheduleResponse => {
   return {
-    MonitoringScheduleArn:
-      output.MonitoringScheduleArn !== undefined && output.MonitoringScheduleArn !== null
-        ? output.MonitoringScheduleArn
-        : undefined,
+    MonitoringScheduleArn: __expectString(output.MonitoringScheduleArn),
   } as any;
 };
 
@@ -25560,10 +25407,7 @@ const deserializeAws_json1_1CreateNotebookInstanceLifecycleConfigOutput = (
   context: __SerdeContext
 ): CreateNotebookInstanceLifecycleConfigOutput => {
   return {
-    NotebookInstanceLifecycleConfigArn:
-      output.NotebookInstanceLifecycleConfigArn !== undefined && output.NotebookInstanceLifecycleConfigArn !== null
-        ? output.NotebookInstanceLifecycleConfigArn
-        : undefined,
+    NotebookInstanceLifecycleConfigArn: __expectString(output.NotebookInstanceLifecycleConfigArn),
   } as any;
 };
 
@@ -25572,16 +25416,13 @@ const deserializeAws_json1_1CreateNotebookInstanceOutput = (
   context: __SerdeContext
 ): CreateNotebookInstanceOutput => {
   return {
-    NotebookInstanceArn:
-      output.NotebookInstanceArn !== undefined && output.NotebookInstanceArn !== null
-        ? output.NotebookInstanceArn
-        : undefined,
+    NotebookInstanceArn: __expectString(output.NotebookInstanceArn),
   } as any;
 };
 
 const deserializeAws_json1_1CreatePipelineResponse = (output: any, context: __SerdeContext): CreatePipelineResponse => {
   return {
-    PipelineArn: output.PipelineArn !== undefined && output.PipelineArn !== null ? output.PipelineArn : undefined,
+    PipelineArn: __expectString(output.PipelineArn),
   } as any;
 };
 
@@ -25590,8 +25431,7 @@ const deserializeAws_json1_1CreatePresignedDomainUrlResponse = (
   context: __SerdeContext
 ): CreatePresignedDomainUrlResponse => {
   return {
-    AuthorizedUrl:
-      output.AuthorizedUrl !== undefined && output.AuthorizedUrl !== null ? output.AuthorizedUrl : undefined,
+    AuthorizedUrl: __expectString(output.AuthorizedUrl),
   } as any;
 };
 
@@ -25600,8 +25440,7 @@ const deserializeAws_json1_1CreatePresignedNotebookInstanceUrlOutput = (
   context: __SerdeContext
 ): CreatePresignedNotebookInstanceUrlOutput => {
   return {
-    AuthorizedUrl:
-      output.AuthorizedUrl !== undefined && output.AuthorizedUrl !== null ? output.AuthorizedUrl : undefined,
+    AuthorizedUrl: __expectString(output.AuthorizedUrl),
   } as any;
 };
 
@@ -25610,15 +25449,14 @@ const deserializeAws_json1_1CreateProcessingJobResponse = (
   context: __SerdeContext
 ): CreateProcessingJobResponse => {
   return {
-    ProcessingJobArn:
-      output.ProcessingJobArn !== undefined && output.ProcessingJobArn !== null ? output.ProcessingJobArn : undefined,
+    ProcessingJobArn: __expectString(output.ProcessingJobArn),
   } as any;
 };
 
 const deserializeAws_json1_1CreateProjectOutput = (output: any, context: __SerdeContext): CreateProjectOutput => {
   return {
-    ProjectArn: output.ProjectArn !== undefined && output.ProjectArn !== null ? output.ProjectArn : undefined,
-    ProjectId: output.ProjectId !== undefined && output.ProjectId !== null ? output.ProjectId : undefined,
+    ProjectArn: __expectString(output.ProjectArn),
+    ProjectId: __expectString(output.ProjectId),
   } as any;
 };
 
@@ -25627,8 +25465,7 @@ const deserializeAws_json1_1CreateTrainingJobResponse = (
   context: __SerdeContext
 ): CreateTrainingJobResponse => {
   return {
-    TrainingJobArn:
-      output.TrainingJobArn !== undefined && output.TrainingJobArn !== null ? output.TrainingJobArn : undefined,
+    TrainingJobArn: __expectString(output.TrainingJobArn),
   } as any;
 };
 
@@ -25637,8 +25474,7 @@ const deserializeAws_json1_1CreateTransformJobResponse = (
   context: __SerdeContext
 ): CreateTransformJobResponse => {
   return {
-    TransformJobArn:
-      output.TransformJobArn !== undefined && output.TransformJobArn !== null ? output.TransformJobArn : undefined,
+    TransformJobArn: __expectString(output.TransformJobArn),
   } as any;
 };
 
@@ -25647,16 +25483,13 @@ const deserializeAws_json1_1CreateTrialComponentResponse = (
   context: __SerdeContext
 ): CreateTrialComponentResponse => {
   return {
-    TrialComponentArn:
-      output.TrialComponentArn !== undefined && output.TrialComponentArn !== null
-        ? output.TrialComponentArn
-        : undefined,
+    TrialComponentArn: __expectString(output.TrialComponentArn),
   } as any;
 };
 
 const deserializeAws_json1_1CreateTrialResponse = (output: any, context: __SerdeContext): CreateTrialResponse => {
   return {
-    TrialArn: output.TrialArn !== undefined && output.TrialArn !== null ? output.TrialArn : undefined,
+    TrialArn: __expectString(output.TrialArn),
   } as any;
 };
 
@@ -25665,8 +25498,7 @@ const deserializeAws_json1_1CreateUserProfileResponse = (
   context: __SerdeContext
 ): CreateUserProfileResponse => {
   return {
-    UserProfileArn:
-      output.UserProfileArn !== undefined && output.UserProfileArn !== null ? output.UserProfileArn : undefined,
+    UserProfileArn: __expectString(output.UserProfileArn),
   } as any;
 };
 
@@ -25675,13 +25507,13 @@ const deserializeAws_json1_1CreateWorkforceResponse = (
   context: __SerdeContext
 ): CreateWorkforceResponse => {
   return {
-    WorkforceArn: output.WorkforceArn !== undefined && output.WorkforceArn !== null ? output.WorkforceArn : undefined,
+    WorkforceArn: __expectString(output.WorkforceArn),
   } as any;
 };
 
 const deserializeAws_json1_1CreateWorkteamResponse = (output: any, context: __SerdeContext): CreateWorkteamResponse => {
   return {
-    WorkteamArn: output.WorkteamArn !== undefined && output.WorkteamArn !== null ? output.WorkteamArn : undefined,
+    WorkteamArn: __expectString(output.WorkteamArn),
   } as any;
 };
 
@@ -25692,21 +25524,15 @@ const deserializeAws_json1_1CsvContentTypes = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1CustomImage = (output: any, context: __SerdeContext): CustomImage => {
   return {
-    AppImageConfigName:
-      output.AppImageConfigName !== undefined && output.AppImageConfigName !== null
-        ? output.AppImageConfigName
-        : undefined,
-    ImageName: output.ImageName !== undefined && output.ImageName !== null ? output.ImageName : undefined,
-    ImageVersionNumber:
-      output.ImageVersionNumber !== undefined && output.ImageVersionNumber !== null
-        ? output.ImageVersionNumber
-        : undefined,
+    AppImageConfigName: __expectString(output.AppImageConfigName),
+    ImageName: __expectString(output.ImageName),
+    ImageVersionNumber: __expectNumber(output.ImageVersionNumber),
   } as any;
 };
 
@@ -25731,15 +25557,10 @@ const deserializeAws_json1_1DataCaptureConfig = (output: any, context: __SerdeCo
       output.CaptureOptions !== undefined && output.CaptureOptions !== null
         ? deserializeAws_json1_1CaptureOptionList(output.CaptureOptions, context)
         : undefined,
-    DestinationS3Uri:
-      output.DestinationS3Uri !== undefined && output.DestinationS3Uri !== null ? output.DestinationS3Uri : undefined,
-    EnableCapture:
-      output.EnableCapture !== undefined && output.EnableCapture !== null ? output.EnableCapture : undefined,
-    InitialSamplingPercentage:
-      output.InitialSamplingPercentage !== undefined && output.InitialSamplingPercentage !== null
-        ? output.InitialSamplingPercentage
-        : undefined,
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
+    DestinationS3Uri: __expectString(output.DestinationS3Uri),
+    EnableCapture: __expectBoolean(output.EnableCapture),
+    InitialSamplingPercentage: __expectNumber(output.InitialSamplingPercentage),
+    KmsKeyId: __expectString(output.KmsKeyId),
   } as any;
 };
 
@@ -25748,33 +25569,27 @@ const deserializeAws_json1_1DataCaptureConfigSummary = (
   context: __SerdeContext
 ): DataCaptureConfigSummary => {
   return {
-    CaptureStatus:
-      output.CaptureStatus !== undefined && output.CaptureStatus !== null ? output.CaptureStatus : undefined,
-    CurrentSamplingPercentage:
-      output.CurrentSamplingPercentage !== undefined && output.CurrentSamplingPercentage !== null
-        ? output.CurrentSamplingPercentage
-        : undefined,
-    DestinationS3Uri:
-      output.DestinationS3Uri !== undefined && output.DestinationS3Uri !== null ? output.DestinationS3Uri : undefined,
-    EnableCapture:
-      output.EnableCapture !== undefined && output.EnableCapture !== null ? output.EnableCapture : undefined,
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
+    CaptureStatus: __expectString(output.CaptureStatus),
+    CurrentSamplingPercentage: __expectNumber(output.CurrentSamplingPercentage),
+    DestinationS3Uri: __expectString(output.DestinationS3Uri),
+    EnableCapture: __expectBoolean(output.EnableCapture),
+    KmsKeyId: __expectString(output.KmsKeyId),
   } as any;
 };
 
 const deserializeAws_json1_1DataCatalogConfig = (output: any, context: __SerdeContext): DataCatalogConfig => {
   return {
-    Catalog: output.Catalog !== undefined && output.Catalog !== null ? output.Catalog : undefined,
-    Database: output.Database !== undefined && output.Database !== null ? output.Database : undefined,
-    TableName: output.TableName !== undefined && output.TableName !== null ? output.TableName : undefined,
+    Catalog: __expectString(output.Catalog),
+    Database: __expectString(output.Database),
+    TableName: __expectString(output.TableName),
   } as any;
 };
 
 const deserializeAws_json1_1DataProcessing = (output: any, context: __SerdeContext): DataProcessing => {
   return {
-    InputFilter: output.InputFilter !== undefined && output.InputFilter !== null ? output.InputFilter : undefined,
-    JoinSource: output.JoinSource !== undefined && output.JoinSource !== null ? output.JoinSource : undefined,
-    OutputFilter: output.OutputFilter !== undefined && output.OutputFilter !== null ? output.OutputFilter : undefined,
+    InputFilter: __expectString(output.InputFilter),
+    JoinSource: __expectString(output.JoinSource),
+    OutputFilter: __expectString(output.OutputFilter),
   } as any;
 };
 
@@ -25795,15 +25610,9 @@ const deserializeAws_json1_1DataQualityAppSpecification = (
       output.Environment !== undefined && output.Environment !== null
         ? deserializeAws_json1_1MonitoringEnvironmentMap(output.Environment, context)
         : undefined,
-    ImageUri: output.ImageUri !== undefined && output.ImageUri !== null ? output.ImageUri : undefined,
-    PostAnalyticsProcessorSourceUri:
-      output.PostAnalyticsProcessorSourceUri !== undefined && output.PostAnalyticsProcessorSourceUri !== null
-        ? output.PostAnalyticsProcessorSourceUri
-        : undefined,
-    RecordPreprocessorSourceUri:
-      output.RecordPreprocessorSourceUri !== undefined && output.RecordPreprocessorSourceUri !== null
-        ? output.RecordPreprocessorSourceUri
-        : undefined,
+    ImageUri: __expectString(output.ImageUri),
+    PostAnalyticsProcessorSourceUri: __expectString(output.PostAnalyticsProcessorSourceUri),
+    RecordPreprocessorSourceUri: __expectString(output.RecordPreprocessorSourceUri),
   } as any;
 };
 
@@ -25812,10 +25621,7 @@ const deserializeAws_json1_1DataQualityBaselineConfig = (
   context: __SerdeContext
 ): DataQualityBaselineConfig => {
   return {
-    BaseliningJobName:
-      output.BaseliningJobName !== undefined && output.BaseliningJobName !== null
-        ? output.BaseliningJobName
-        : undefined,
+    BaseliningJobName: __expectString(output.BaseliningJobName),
     ConstraintsResource:
       output.ConstraintsResource !== undefined && output.ConstraintsResource !== null
         ? deserializeAws_json1_1MonitoringConstraintsResource(output.ConstraintsResource, context)
@@ -25842,12 +25648,9 @@ const deserializeAws_json1_1DatasetDefinition = (output: any, context: __SerdeCo
       output.AthenaDatasetDefinition !== undefined && output.AthenaDatasetDefinition !== null
         ? deserializeAws_json1_1AthenaDatasetDefinition(output.AthenaDatasetDefinition, context)
         : undefined,
-    DataDistributionType:
-      output.DataDistributionType !== undefined && output.DataDistributionType !== null
-        ? output.DataDistributionType
-        : undefined,
-    InputMode: output.InputMode !== undefined && output.InputMode !== null ? output.InputMode : undefined,
-    LocalPath: output.LocalPath !== undefined && output.LocalPath !== null ? output.LocalPath : undefined,
+    DataDistributionType: __expectString(output.DataDistributionType),
+    InputMode: __expectString(output.InputMode),
+    LocalPath: __expectString(output.LocalPath),
     RedshiftDatasetDefinition:
       output.RedshiftDatasetDefinition !== undefined && output.RedshiftDatasetDefinition !== null
         ? deserializeAws_json1_1RedshiftDatasetDefinition(output.RedshiftDatasetDefinition, context)
@@ -25878,30 +25681,23 @@ const deserializeAws_json1_1DebugHookConfig = (output: any, context: __SerdeCont
       output.HookParameters !== undefined && output.HookParameters !== null
         ? deserializeAws_json1_1HookParameters(output.HookParameters, context)
         : undefined,
-    LocalPath: output.LocalPath !== undefined && output.LocalPath !== null ? output.LocalPath : undefined,
-    S3OutputPath: output.S3OutputPath !== undefined && output.S3OutputPath !== null ? output.S3OutputPath : undefined,
+    LocalPath: __expectString(output.LocalPath),
+    S3OutputPath: __expectString(output.S3OutputPath),
   } as any;
 };
 
 const deserializeAws_json1_1DebugRuleConfiguration = (output: any, context: __SerdeContext): DebugRuleConfiguration => {
   return {
-    InstanceType: output.InstanceType !== undefined && output.InstanceType !== null ? output.InstanceType : undefined,
-    LocalPath: output.LocalPath !== undefined && output.LocalPath !== null ? output.LocalPath : undefined,
-    RuleConfigurationName:
-      output.RuleConfigurationName !== undefined && output.RuleConfigurationName !== null
-        ? output.RuleConfigurationName
-        : undefined,
-    RuleEvaluatorImage:
-      output.RuleEvaluatorImage !== undefined && output.RuleEvaluatorImage !== null
-        ? output.RuleEvaluatorImage
-        : undefined,
+    InstanceType: __expectString(output.InstanceType),
+    LocalPath: __expectString(output.LocalPath),
+    RuleConfigurationName: __expectString(output.RuleConfigurationName),
+    RuleEvaluatorImage: __expectString(output.RuleEvaluatorImage),
     RuleParameters:
       output.RuleParameters !== undefined && output.RuleParameters !== null
         ? deserializeAws_json1_1RuleParameters(output.RuleParameters, context)
         : undefined,
-    S3OutputPath: output.S3OutputPath !== undefined && output.S3OutputPath !== null ? output.S3OutputPath : undefined,
-    VolumeSizeInGB:
-      output.VolumeSizeInGB !== undefined && output.VolumeSizeInGB !== null ? output.VolumeSizeInGB : undefined,
+    S3OutputPath: __expectString(output.S3OutputPath),
+    VolumeSizeInGB: __expectNumber(output.VolumeSizeInGB),
   } as any;
 };
 
@@ -25928,20 +25724,10 @@ const deserializeAws_json1_1DebugRuleEvaluationStatus = (
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    RuleConfigurationName:
-      output.RuleConfigurationName !== undefined && output.RuleConfigurationName !== null
-        ? output.RuleConfigurationName
-        : undefined,
-    RuleEvaluationJobArn:
-      output.RuleEvaluationJobArn !== undefined && output.RuleEvaluationJobArn !== null
-        ? output.RuleEvaluationJobArn
-        : undefined,
-    RuleEvaluationStatus:
-      output.RuleEvaluationStatus !== undefined && output.RuleEvaluationStatus !== null
-        ? output.RuleEvaluationStatus
-        : undefined,
-    StatusDetails:
-      output.StatusDetails !== undefined && output.StatusDetails !== null ? output.StatusDetails : undefined,
+    RuleConfigurationName: __expectString(output.RuleConfigurationName),
+    RuleEvaluationJobArn: __expectString(output.RuleEvaluationJobArn),
+    RuleEvaluationStatus: __expectString(output.RuleEvaluationStatus),
+    StatusDetails: __expectString(output.StatusDetails),
   } as any;
 };
 
@@ -25961,13 +25747,13 @@ const deserializeAws_json1_1DebugRuleEvaluationStatuses = (
 
 const deserializeAws_json1_1DeleteActionResponse = (output: any, context: __SerdeContext): DeleteActionResponse => {
   return {
-    ActionArn: output.ActionArn !== undefined && output.ActionArn !== null ? output.ActionArn : undefined,
+    ActionArn: __expectString(output.ActionArn),
   } as any;
 };
 
 const deserializeAws_json1_1DeleteArtifactResponse = (output: any, context: __SerdeContext): DeleteArtifactResponse => {
   return {
-    ArtifactArn: output.ArtifactArn !== undefined && output.ArtifactArn !== null ? output.ArtifactArn : undefined,
+    ArtifactArn: __expectString(output.ArtifactArn),
   } as any;
 };
 
@@ -25976,15 +25762,14 @@ const deserializeAws_json1_1DeleteAssociationResponse = (
   context: __SerdeContext
 ): DeleteAssociationResponse => {
   return {
-    DestinationArn:
-      output.DestinationArn !== undefined && output.DestinationArn !== null ? output.DestinationArn : undefined,
-    SourceArn: output.SourceArn !== undefined && output.SourceArn !== null ? output.SourceArn : undefined,
+    DestinationArn: __expectString(output.DestinationArn),
+    SourceArn: __expectString(output.SourceArn),
   } as any;
 };
 
 const deserializeAws_json1_1DeleteContextResponse = (output: any, context: __SerdeContext): DeleteContextResponse => {
   return {
-    ContextArn: output.ContextArn !== undefined && output.ContextArn !== null ? output.ContextArn : undefined,
+    ContextArn: __expectString(output.ContextArn),
   } as any;
 };
 
@@ -25993,8 +25778,7 @@ const deserializeAws_json1_1DeleteExperimentResponse = (
   context: __SerdeContext
 ): DeleteExperimentResponse => {
   return {
-    ExperimentArn:
-      output.ExperimentArn !== undefined && output.ExperimentArn !== null ? output.ExperimentArn : undefined,
+    ExperimentArn: __expectString(output.ExperimentArn),
   } as any;
 };
 
@@ -26025,7 +25809,7 @@ const deserializeAws_json1_1DeleteImageVersionResponse = (
 
 const deserializeAws_json1_1DeletePipelineResponse = (output: any, context: __SerdeContext): DeletePipelineResponse => {
   return {
-    PipelineArn: output.PipelineArn !== undefined && output.PipelineArn !== null ? output.PipelineArn : undefined,
+    PipelineArn: __expectString(output.PipelineArn),
   } as any;
 };
 
@@ -26038,16 +25822,13 @@ const deserializeAws_json1_1DeleteTrialComponentResponse = (
   context: __SerdeContext
 ): DeleteTrialComponentResponse => {
   return {
-    TrialComponentArn:
-      output.TrialComponentArn !== undefined && output.TrialComponentArn !== null
-        ? output.TrialComponentArn
-        : undefined,
+    TrialComponentArn: __expectString(output.TrialComponentArn),
   } as any;
 };
 
 const deserializeAws_json1_1DeleteTrialResponse = (output: any, context: __SerdeContext): DeleteTrialResponse => {
   return {
-    TrialArn: output.TrialArn !== undefined && output.TrialArn !== null ? output.TrialArn : undefined,
+    TrialArn: __expectString(output.TrialArn),
   } as any;
 };
 
@@ -26060,7 +25841,7 @@ const deserializeAws_json1_1DeleteWorkforceResponse = (
 
 const deserializeAws_json1_1DeleteWorkteamResponse = (output: any, context: __SerdeContext): DeleteWorkteamResponse => {
   return {
-    Success: output.Success !== undefined && output.Success !== null ? output.Success : undefined,
+    Success: __expectBoolean(output.Success),
   } as any;
 };
 
@@ -26070,10 +25851,8 @@ const deserializeAws_json1_1DeployedImage = (output: any, context: __SerdeContex
       output.ResolutionTime !== undefined && output.ResolutionTime !== null
         ? new Date(Math.round(output.ResolutionTime * 1000))
         : undefined,
-    ResolvedImage:
-      output.ResolvedImage !== undefined && output.ResolvedImage !== null ? output.ResolvedImage : undefined,
-    SpecifiedImage:
-      output.SpecifiedImage !== undefined && output.SpecifiedImage !== null ? output.SpecifiedImage : undefined,
+    ResolvedImage: __expectString(output.ResolvedImage),
+    SpecifiedImage: __expectString(output.SpecifiedImage),
   } as any;
 };
 
@@ -26103,9 +25882,9 @@ const deserializeAws_json1_1DeploymentConfig = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1DescribeActionResponse = (output: any, context: __SerdeContext): DescribeActionResponse => {
   return {
-    ActionArn: output.ActionArn !== undefined && output.ActionArn !== null ? output.ActionArn : undefined,
-    ActionName: output.ActionName !== undefined && output.ActionName !== null ? output.ActionName : undefined,
-    ActionType: output.ActionType !== undefined && output.ActionType !== null ? output.ActionType : undefined,
+    ActionArn: __expectString(output.ActionArn),
+    ActionName: __expectString(output.ActionName),
+    ActionType: __expectString(output.ActionType),
     CreatedBy:
       output.CreatedBy !== undefined && output.CreatedBy !== null
         ? deserializeAws_json1_1UserContext(output.CreatedBy, context)
@@ -26114,7 +25893,7 @@ const deserializeAws_json1_1DescribeActionResponse = (output: any, context: __Se
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     LastModifiedBy:
       output.LastModifiedBy !== undefined && output.LastModifiedBy !== null
         ? deserializeAws_json1_1UserContext(output.LastModifiedBy, context)
@@ -26135,7 +25914,7 @@ const deserializeAws_json1_1DescribeActionResponse = (output: any, context: __Se
       output.Source !== undefined && output.Source !== null
         ? deserializeAws_json1_1ActionSource(output.Source, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -26144,23 +25923,15 @@ const deserializeAws_json1_1DescribeAlgorithmOutput = (
   context: __SerdeContext
 ): DescribeAlgorithmOutput => {
   return {
-    AlgorithmArn: output.AlgorithmArn !== undefined && output.AlgorithmArn !== null ? output.AlgorithmArn : undefined,
-    AlgorithmDescription:
-      output.AlgorithmDescription !== undefined && output.AlgorithmDescription !== null
-        ? output.AlgorithmDescription
-        : undefined,
-    AlgorithmName:
-      output.AlgorithmName !== undefined && output.AlgorithmName !== null ? output.AlgorithmName : undefined,
-    AlgorithmStatus:
-      output.AlgorithmStatus !== undefined && output.AlgorithmStatus !== null ? output.AlgorithmStatus : undefined,
+    AlgorithmArn: __expectString(output.AlgorithmArn),
+    AlgorithmDescription: __expectString(output.AlgorithmDescription),
+    AlgorithmName: __expectString(output.AlgorithmName),
+    AlgorithmStatus: __expectString(output.AlgorithmStatus),
     AlgorithmStatusDetails:
       output.AlgorithmStatusDetails !== undefined && output.AlgorithmStatusDetails !== null
         ? deserializeAws_json1_1AlgorithmStatusDetails(output.AlgorithmStatusDetails, context)
         : undefined,
-    CertifyForMarketplace:
-      output.CertifyForMarketplace !== undefined && output.CertifyForMarketplace !== null
-        ? output.CertifyForMarketplace
-        : undefined,
+    CertifyForMarketplace: __expectBoolean(output.CertifyForMarketplace),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -26169,7 +25940,7 @@ const deserializeAws_json1_1DescribeAlgorithmOutput = (
       output.InferenceSpecification !== undefined && output.InferenceSpecification !== null
         ? deserializeAws_json1_1InferenceSpecification(output.InferenceSpecification, context)
         : undefined,
-    ProductId: output.ProductId !== undefined && output.ProductId !== null ? output.ProductId : undefined,
+    ProductId: __expectString(output.ProductId),
     TrainingSpecification:
       output.TrainingSpecification !== undefined && output.TrainingSpecification !== null
         ? deserializeAws_json1_1TrainingSpecification(output.TrainingSpecification, context)
@@ -26186,14 +25957,8 @@ const deserializeAws_json1_1DescribeAppImageConfigResponse = (
   context: __SerdeContext
 ): DescribeAppImageConfigResponse => {
   return {
-    AppImageConfigArn:
-      output.AppImageConfigArn !== undefined && output.AppImageConfigArn !== null
-        ? output.AppImageConfigArn
-        : undefined,
-    AppImageConfigName:
-      output.AppImageConfigName !== undefined && output.AppImageConfigName !== null
-        ? output.AppImageConfigName
-        : undefined,
+    AppImageConfigArn: __expectString(output.AppImageConfigArn),
+    AppImageConfigName: __expectString(output.AppImageConfigName),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -26211,16 +25976,15 @@ const deserializeAws_json1_1DescribeAppImageConfigResponse = (
 
 const deserializeAws_json1_1DescribeAppResponse = (output: any, context: __SerdeContext): DescribeAppResponse => {
   return {
-    AppArn: output.AppArn !== undefined && output.AppArn !== null ? output.AppArn : undefined,
-    AppName: output.AppName !== undefined && output.AppName !== null ? output.AppName : undefined,
-    AppType: output.AppType !== undefined && output.AppType !== null ? output.AppType : undefined,
+    AppArn: __expectString(output.AppArn),
+    AppName: __expectString(output.AppName),
+    AppType: __expectString(output.AppType),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    DomainId: output.DomainId !== undefined && output.DomainId !== null ? output.DomainId : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
+    DomainId: __expectString(output.DomainId),
+    FailureReason: __expectString(output.FailureReason),
     LastHealthCheckTimestamp:
       output.LastHealthCheckTimestamp !== undefined && output.LastHealthCheckTimestamp !== null
         ? new Date(Math.round(output.LastHealthCheckTimestamp * 1000))
@@ -26233,9 +25997,8 @@ const deserializeAws_json1_1DescribeAppResponse = (output: any, context: __Serde
       output.ResourceSpec !== undefined && output.ResourceSpec !== null
         ? deserializeAws_json1_1ResourceSpec(output.ResourceSpec, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    UserProfileName:
-      output.UserProfileName !== undefined && output.UserProfileName !== null ? output.UserProfileName : undefined,
+    Status: __expectString(output.Status),
+    UserProfileName: __expectString(output.UserProfileName),
   } as any;
 };
 
@@ -26244,9 +26007,9 @@ const deserializeAws_json1_1DescribeArtifactResponse = (
   context: __SerdeContext
 ): DescribeArtifactResponse => {
   return {
-    ArtifactArn: output.ArtifactArn !== undefined && output.ArtifactArn !== null ? output.ArtifactArn : undefined,
-    ArtifactName: output.ArtifactName !== undefined && output.ArtifactName !== null ? output.ArtifactName : undefined,
-    ArtifactType: output.ArtifactType !== undefined && output.ArtifactType !== null ? output.ArtifactType : undefined,
+    ArtifactArn: __expectString(output.ArtifactArn),
+    ArtifactName: __expectString(output.ArtifactName),
+    ArtifactType: __expectString(output.ArtifactType),
     CreatedBy:
       output.CreatedBy !== undefined && output.CreatedBy !== null
         ? deserializeAws_json1_1UserContext(output.CreatedBy, context)
@@ -26283,7 +26046,7 @@ const deserializeAws_json1_1DescribeAutoMLJobResponse = (
   context: __SerdeContext
 ): DescribeAutoMLJobResponse => {
   return {
-    AutoMLJobArn: output.AutoMLJobArn !== undefined && output.AutoMLJobArn !== null ? output.AutoMLJobArn : undefined,
+    AutoMLJobArn: __expectString(output.AutoMLJobArn),
     AutoMLJobArtifacts:
       output.AutoMLJobArtifacts !== undefined && output.AutoMLJobArtifacts !== null
         ? deserializeAws_json1_1AutoMLJobArtifacts(output.AutoMLJobArtifacts, context)
@@ -26292,18 +26055,13 @@ const deserializeAws_json1_1DescribeAutoMLJobResponse = (
       output.AutoMLJobConfig !== undefined && output.AutoMLJobConfig !== null
         ? deserializeAws_json1_1AutoMLJobConfig(output.AutoMLJobConfig, context)
         : undefined,
-    AutoMLJobName:
-      output.AutoMLJobName !== undefined && output.AutoMLJobName !== null ? output.AutoMLJobName : undefined,
+    AutoMLJobName: __expectString(output.AutoMLJobName),
     AutoMLJobObjective:
       output.AutoMLJobObjective !== undefined && output.AutoMLJobObjective !== null
         ? deserializeAws_json1_1AutoMLJobObjective(output.AutoMLJobObjective, context)
         : undefined,
-    AutoMLJobSecondaryStatus:
-      output.AutoMLJobSecondaryStatus !== undefined && output.AutoMLJobSecondaryStatus !== null
-        ? output.AutoMLJobSecondaryStatus
-        : undefined,
-    AutoMLJobStatus:
-      output.AutoMLJobStatus !== undefined && output.AutoMLJobStatus !== null ? output.AutoMLJobStatus : undefined,
+    AutoMLJobSecondaryStatus: __expectString(output.AutoMLJobSecondaryStatus),
+    AutoMLJobStatus: __expectString(output.AutoMLJobStatus),
     BestCandidate:
       output.BestCandidate !== undefined && output.BestCandidate !== null
         ? deserializeAws_json1_1AutoMLCandidate(output.BestCandidate, context)
@@ -26314,12 +26072,8 @@ const deserializeAws_json1_1DescribeAutoMLJobResponse = (
         : undefined,
     EndTime:
       output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
-    GenerateCandidateDefinitionsOnly:
-      output.GenerateCandidateDefinitionsOnly !== undefined && output.GenerateCandidateDefinitionsOnly !== null
-        ? output.GenerateCandidateDefinitionsOnly
-        : undefined,
+    FailureReason: __expectString(output.FailureReason),
+    GenerateCandidateDefinitionsOnly: __expectBoolean(output.GenerateCandidateDefinitionsOnly),
     InputDataConfig:
       output.InputDataConfig !== undefined && output.InputDataConfig !== null
         ? deserializeAws_json1_1AutoMLInputDataConfig(output.InputDataConfig, context)
@@ -26344,12 +26098,12 @@ const deserializeAws_json1_1DescribeAutoMLJobResponse = (
       output.PartialFailureReasons !== undefined && output.PartialFailureReasons !== null
         ? deserializeAws_json1_1AutoMLPartialFailureReasons(output.PartialFailureReasons, context)
         : undefined,
-    ProblemType: output.ProblemType !== undefined && output.ProblemType !== null ? output.ProblemType : undefined,
+    ProblemType: __expectString(output.ProblemType),
     ResolvedAttributes:
       output.ResolvedAttributes !== undefined && output.ResolvedAttributes !== null
         ? deserializeAws_json1_1ResolvedAttributes(output.ResolvedAttributes, context)
         : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
+    RoleArn: __expectString(output.RoleArn),
   } as any;
 };
 
@@ -26358,14 +26112,8 @@ const deserializeAws_json1_1DescribeCodeRepositoryOutput = (
   context: __SerdeContext
 ): DescribeCodeRepositoryOutput => {
   return {
-    CodeRepositoryArn:
-      output.CodeRepositoryArn !== undefined && output.CodeRepositoryArn !== null
-        ? output.CodeRepositoryArn
-        : undefined,
-    CodeRepositoryName:
-      output.CodeRepositoryName !== undefined && output.CodeRepositoryName !== null
-        ? output.CodeRepositoryName
-        : undefined,
+    CodeRepositoryArn: __expectString(output.CodeRepositoryArn),
+    CodeRepositoryName: __expectString(output.CodeRepositoryName),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -26390,18 +26138,9 @@ const deserializeAws_json1_1DescribeCompilationJobResponse = (
       output.CompilationEndTime !== undefined && output.CompilationEndTime !== null
         ? new Date(Math.round(output.CompilationEndTime * 1000))
         : undefined,
-    CompilationJobArn:
-      output.CompilationJobArn !== undefined && output.CompilationJobArn !== null
-        ? output.CompilationJobArn
-        : undefined,
-    CompilationJobName:
-      output.CompilationJobName !== undefined && output.CompilationJobName !== null
-        ? output.CompilationJobName
-        : undefined,
-    CompilationJobStatus:
-      output.CompilationJobStatus !== undefined && output.CompilationJobStatus !== null
-        ? output.CompilationJobStatus
-        : undefined,
+    CompilationJobArn: __expectString(output.CompilationJobArn),
+    CompilationJobName: __expectString(output.CompilationJobName),
+    CompilationJobStatus: __expectString(output.CompilationJobStatus),
     CompilationStartTime:
       output.CompilationStartTime !== undefined && output.CompilationStartTime !== null
         ? new Date(Math.round(output.CompilationStartTime * 1000))
@@ -26410,8 +26149,7 @@ const deserializeAws_json1_1DescribeCompilationJobResponse = (
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
+    FailureReason: __expectString(output.FailureReason),
     InputConfig:
       output.InputConfig !== undefined && output.InputConfig !== null
         ? deserializeAws_json1_1InputConfig(output.InputConfig, context)
@@ -26432,7 +26170,7 @@ const deserializeAws_json1_1DescribeCompilationJobResponse = (
       output.OutputConfig !== undefined && output.OutputConfig !== null
         ? deserializeAws_json1_1OutputConfig(output.OutputConfig, context)
         : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
+    RoleArn: __expectString(output.RoleArn),
     StoppingCondition:
       output.StoppingCondition !== undefined && output.StoppingCondition !== null
         ? deserializeAws_json1_1StoppingCondition(output.StoppingCondition, context)
@@ -26445,9 +26183,9 @@ const deserializeAws_json1_1DescribeContextResponse = (
   context: __SerdeContext
 ): DescribeContextResponse => {
   return {
-    ContextArn: output.ContextArn !== undefined && output.ContextArn !== null ? output.ContextArn : undefined,
-    ContextName: output.ContextName !== undefined && output.ContextName !== null ? output.ContextName : undefined,
-    ContextType: output.ContextType !== undefined && output.ContextType !== null ? output.ContextType : undefined,
+    ContextArn: __expectString(output.ContextArn),
+    ContextName: __expectString(output.ContextName),
+    ContextType: __expectString(output.ContextType),
     CreatedBy:
       output.CreatedBy !== undefined && output.CreatedBy !== null
         ? deserializeAws_json1_1UserContext(output.CreatedBy, context)
@@ -26456,7 +26194,7 @@ const deserializeAws_json1_1DescribeContextResponse = (
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     LastModifiedBy:
       output.LastModifiedBy !== undefined && output.LastModifiedBy !== null
         ? deserializeAws_json1_1UserContext(output.LastModifiedBy, context)
@@ -26501,12 +26239,8 @@ const deserializeAws_json1_1DescribeDataQualityJobDefinitionResponse = (
       output.DataQualityJobOutputConfig !== undefined && output.DataQualityJobOutputConfig !== null
         ? deserializeAws_json1_1MonitoringOutputConfig(output.DataQualityJobOutputConfig, context)
         : undefined,
-    JobDefinitionArn:
-      output.JobDefinitionArn !== undefined && output.JobDefinitionArn !== null ? output.JobDefinitionArn : undefined,
-    JobDefinitionName:
-      output.JobDefinitionName !== undefined && output.JobDefinitionName !== null
-        ? output.JobDefinitionName
-        : undefined,
+    JobDefinitionArn: __expectString(output.JobDefinitionArn),
+    JobDefinitionName: __expectString(output.JobDefinitionName),
     JobResources:
       output.JobResources !== undefined && output.JobResources !== null
         ? deserializeAws_json1_1MonitoringResources(output.JobResources, context)
@@ -26515,7 +26249,7 @@ const deserializeAws_json1_1DescribeDataQualityJobDefinitionResponse = (
       output.NetworkConfig !== undefined && output.NetworkConfig !== null
         ? deserializeAws_json1_1MonitoringNetworkConfig(output.NetworkConfig, context)
         : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
+    RoleArn: __expectString(output.RoleArn),
     StoppingCondition:
       output.StoppingCondition !== undefined && output.StoppingCondition !== null
         ? deserializeAws_json1_1MonitoringStoppingCondition(output.StoppingCondition, context)
@@ -26532,12 +26266,10 @@ const deserializeAws_json1_1DescribeDeviceFleetResponse = (
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    DeviceFleetArn:
-      output.DeviceFleetArn !== undefined && output.DeviceFleetArn !== null ? output.DeviceFleetArn : undefined,
-    DeviceFleetName:
-      output.DeviceFleetName !== undefined && output.DeviceFleetName !== null ? output.DeviceFleetName : undefined,
-    IotRoleAlias: output.IotRoleAlias !== undefined && output.IotRoleAlias !== null ? output.IotRoleAlias : undefined,
+    Description: __expectString(output.Description),
+    DeviceFleetArn: __expectString(output.DeviceFleetArn),
+    DeviceFleetName: __expectString(output.DeviceFleetName),
+    IotRoleAlias: __expectString(output.IotRoleAlias),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
@@ -26546,28 +26278,27 @@ const deserializeAws_json1_1DescribeDeviceFleetResponse = (
       output.OutputConfig !== undefined && output.OutputConfig !== null
         ? deserializeAws_json1_1EdgeOutputConfig(output.OutputConfig, context)
         : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
+    RoleArn: __expectString(output.RoleArn),
   } as any;
 };
 
 const deserializeAws_json1_1DescribeDeviceResponse = (output: any, context: __SerdeContext): DescribeDeviceResponse => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    DeviceArn: output.DeviceArn !== undefined && output.DeviceArn !== null ? output.DeviceArn : undefined,
-    DeviceFleetName:
-      output.DeviceFleetName !== undefined && output.DeviceFleetName !== null ? output.DeviceFleetName : undefined,
-    DeviceName: output.DeviceName !== undefined && output.DeviceName !== null ? output.DeviceName : undefined,
-    IotThingName: output.IotThingName !== undefined && output.IotThingName !== null ? output.IotThingName : undefined,
+    Description: __expectString(output.Description),
+    DeviceArn: __expectString(output.DeviceArn),
+    DeviceFleetName: __expectString(output.DeviceFleetName),
+    DeviceName: __expectString(output.DeviceName),
+    IotThingName: __expectString(output.IotThingName),
     LatestHeartbeat:
       output.LatestHeartbeat !== undefined && output.LatestHeartbeat !== null
         ? new Date(Math.round(output.LatestHeartbeat * 1000))
         : undefined,
-    MaxModels: output.MaxModels !== undefined && output.MaxModels !== null ? output.MaxModels : undefined,
+    MaxModels: __expectNumber(output.MaxModels),
     Models:
       output.Models !== undefined && output.Models !== null
         ? deserializeAws_json1_1EdgeModels(output.Models, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     RegistrationTime:
       output.RegistrationTime !== undefined && output.RegistrationTime !== null
         ? new Date(Math.round(output.RegistrationTime * 1000))
@@ -26577,11 +26308,8 @@ const deserializeAws_json1_1DescribeDeviceResponse = (output: any, context: __Se
 
 const deserializeAws_json1_1DescribeDomainResponse = (output: any, context: __SerdeContext): DescribeDomainResponse => {
   return {
-    AppNetworkAccessType:
-      output.AppNetworkAccessType !== undefined && output.AppNetworkAccessType !== null
-        ? output.AppNetworkAccessType
-        : undefined,
-    AuthMode: output.AuthMode !== undefined && output.AuthMode !== null ? output.AuthMode : undefined,
+    AppNetworkAccessType: __expectString(output.AppNetworkAccessType),
+    AuthMode: __expectString(output.AuthMode),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -26590,36 +26318,25 @@ const deserializeAws_json1_1DescribeDomainResponse = (output: any, context: __Se
       output.DefaultUserSettings !== undefined && output.DefaultUserSettings !== null
         ? deserializeAws_json1_1UserSettings(output.DefaultUserSettings, context)
         : undefined,
-    DomainArn: output.DomainArn !== undefined && output.DomainArn !== null ? output.DomainArn : undefined,
-    DomainId: output.DomainId !== undefined && output.DomainId !== null ? output.DomainId : undefined,
-    DomainName: output.DomainName !== undefined && output.DomainName !== null ? output.DomainName : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
-    HomeEfsFileSystemId:
-      output.HomeEfsFileSystemId !== undefined && output.HomeEfsFileSystemId !== null
-        ? output.HomeEfsFileSystemId
-        : undefined,
-    HomeEfsFileSystemKmsKeyId:
-      output.HomeEfsFileSystemKmsKeyId !== undefined && output.HomeEfsFileSystemKmsKeyId !== null
-        ? output.HomeEfsFileSystemKmsKeyId
-        : undefined,
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
+    DomainArn: __expectString(output.DomainArn),
+    DomainId: __expectString(output.DomainId),
+    DomainName: __expectString(output.DomainName),
+    FailureReason: __expectString(output.FailureReason),
+    HomeEfsFileSystemId: __expectString(output.HomeEfsFileSystemId),
+    HomeEfsFileSystemKmsKeyId: __expectString(output.HomeEfsFileSystemKmsKeyId),
+    KmsKeyId: __expectString(output.KmsKeyId),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    SingleSignOnManagedApplicationInstanceId:
-      output.SingleSignOnManagedApplicationInstanceId !== undefined &&
-      output.SingleSignOnManagedApplicationInstanceId !== null
-        ? output.SingleSignOnManagedApplicationInstanceId
-        : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    SingleSignOnManagedApplicationInstanceId: __expectString(output.SingleSignOnManagedApplicationInstanceId),
+    Status: __expectString(output.Status),
     SubnetIds:
       output.SubnetIds !== undefined && output.SubnetIds !== null
         ? deserializeAws_json1_1Subnets(output.SubnetIds, context)
         : undefined,
-    Url: output.Url !== undefined && output.Url !== null ? output.Url : undefined,
-    VpcId: output.VpcId !== undefined && output.VpcId !== null ? output.VpcId : undefined,
+    Url: __expectString(output.Url),
+    VpcId: __expectString(output.VpcId),
   } as any;
 };
 
@@ -26628,40 +26345,23 @@ const deserializeAws_json1_1DescribeEdgePackagingJobResponse = (
   context: __SerdeContext
 ): DescribeEdgePackagingJobResponse => {
   return {
-    CompilationJobName:
-      output.CompilationJobName !== undefined && output.CompilationJobName !== null
-        ? output.CompilationJobName
-        : undefined,
+    CompilationJobName: __expectString(output.CompilationJobName),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    EdgePackagingJobArn:
-      output.EdgePackagingJobArn !== undefined && output.EdgePackagingJobArn !== null
-        ? output.EdgePackagingJobArn
-        : undefined,
-    EdgePackagingJobName:
-      output.EdgePackagingJobName !== undefined && output.EdgePackagingJobName !== null
-        ? output.EdgePackagingJobName
-        : undefined,
-    EdgePackagingJobStatus:
-      output.EdgePackagingJobStatus !== undefined && output.EdgePackagingJobStatus !== null
-        ? output.EdgePackagingJobStatus
-        : undefined,
-    EdgePackagingJobStatusMessage:
-      output.EdgePackagingJobStatusMessage !== undefined && output.EdgePackagingJobStatusMessage !== null
-        ? output.EdgePackagingJobStatusMessage
-        : undefined,
+    EdgePackagingJobArn: __expectString(output.EdgePackagingJobArn),
+    EdgePackagingJobName: __expectString(output.EdgePackagingJobName),
+    EdgePackagingJobStatus: __expectString(output.EdgePackagingJobStatus),
+    EdgePackagingJobStatusMessage: __expectString(output.EdgePackagingJobStatusMessage),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    ModelArtifact:
-      output.ModelArtifact !== undefined && output.ModelArtifact !== null ? output.ModelArtifact : undefined,
-    ModelName: output.ModelName !== undefined && output.ModelName !== null ? output.ModelName : undefined,
-    ModelSignature:
-      output.ModelSignature !== undefined && output.ModelSignature !== null ? output.ModelSignature : undefined,
-    ModelVersion: output.ModelVersion !== undefined && output.ModelVersion !== null ? output.ModelVersion : undefined,
+    ModelArtifact: __expectString(output.ModelArtifact),
+    ModelName: __expectString(output.ModelName),
+    ModelSignature: __expectString(output.ModelSignature),
+    ModelVersion: __expectString(output.ModelVersion),
     OutputConfig:
       output.OutputConfig !== undefined && output.OutputConfig !== null
         ? deserializeAws_json1_1EdgeOutputConfig(output.OutputConfig, context)
@@ -26670,8 +26370,8 @@ const deserializeAws_json1_1DescribeEdgePackagingJobResponse = (
       output.PresetDeploymentOutput !== undefined && output.PresetDeploymentOutput !== null
         ? deserializeAws_json1_1EdgePresetDeploymentOutput(output.PresetDeploymentOutput, context)
         : undefined,
-    ResourceKey: output.ResourceKey !== undefined && output.ResourceKey !== null ? output.ResourceKey : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
+    ResourceKey: __expectString(output.ResourceKey),
+    RoleArn: __expectString(output.RoleArn),
   } as any;
 };
 
@@ -26688,15 +26388,9 @@ const deserializeAws_json1_1DescribeEndpointConfigOutput = (
       output.DataCaptureConfig !== undefined && output.DataCaptureConfig !== null
         ? deserializeAws_json1_1DataCaptureConfig(output.DataCaptureConfig, context)
         : undefined,
-    EndpointConfigArn:
-      output.EndpointConfigArn !== undefined && output.EndpointConfigArn !== null
-        ? output.EndpointConfigArn
-        : undefined,
-    EndpointConfigName:
-      output.EndpointConfigName !== undefined && output.EndpointConfigName !== null
-        ? output.EndpointConfigName
-        : undefined,
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
+    EndpointConfigArn: __expectString(output.EndpointConfigArn),
+    EndpointConfigName: __expectString(output.EndpointConfigName),
+    KmsKeyId: __expectString(output.KmsKeyId),
     ProductionVariants:
       output.ProductionVariants !== undefined && output.ProductionVariants !== null
         ? deserializeAws_json1_1ProductionVariantList(output.ProductionVariants, context)
@@ -26714,16 +26408,11 @@ const deserializeAws_json1_1DescribeEndpointOutput = (output: any, context: __Se
       output.DataCaptureConfig !== undefined && output.DataCaptureConfig !== null
         ? deserializeAws_json1_1DataCaptureConfigSummary(output.DataCaptureConfig, context)
         : undefined,
-    EndpointArn: output.EndpointArn !== undefined && output.EndpointArn !== null ? output.EndpointArn : undefined,
-    EndpointConfigName:
-      output.EndpointConfigName !== undefined && output.EndpointConfigName !== null
-        ? output.EndpointConfigName
-        : undefined,
-    EndpointName: output.EndpointName !== undefined && output.EndpointName !== null ? output.EndpointName : undefined,
-    EndpointStatus:
-      output.EndpointStatus !== undefined && output.EndpointStatus !== null ? output.EndpointStatus : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
+    EndpointArn: __expectString(output.EndpointArn),
+    EndpointConfigName: __expectString(output.EndpointConfigName),
+    EndpointName: __expectString(output.EndpointName),
+    EndpointStatus: __expectString(output.EndpointStatus),
+    FailureReason: __expectString(output.FailureReason),
     LastDeploymentConfig:
       output.LastDeploymentConfig !== undefined && output.LastDeploymentConfig !== null
         ? deserializeAws_json1_1DeploymentConfig(output.LastDeploymentConfig, context)
@@ -26752,12 +26441,10 @@ const deserializeAws_json1_1DescribeExperimentResponse = (
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    DisplayName: output.DisplayName !== undefined && output.DisplayName !== null ? output.DisplayName : undefined,
-    ExperimentArn:
-      output.ExperimentArn !== undefined && output.ExperimentArn !== null ? output.ExperimentArn : undefined,
-    ExperimentName:
-      output.ExperimentName !== undefined && output.ExperimentName !== null ? output.ExperimentName : undefined,
+    Description: __expectString(output.Description),
+    DisplayName: __expectString(output.DisplayName),
+    ExperimentArn: __expectString(output.ExperimentArn),
+    ExperimentName: __expectString(output.ExperimentName),
     LastModifiedBy:
       output.LastModifiedBy !== undefined && output.LastModifiedBy !== null
         ? deserializeAws_json1_1UserContext(output.LastModifiedBy, context)
@@ -26782,26 +26469,17 @@ const deserializeAws_json1_1DescribeFeatureGroupResponse = (
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    EventTimeFeatureName:
-      output.EventTimeFeatureName !== undefined && output.EventTimeFeatureName !== null
-        ? output.EventTimeFeatureName
-        : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
+    Description: __expectString(output.Description),
+    EventTimeFeatureName: __expectString(output.EventTimeFeatureName),
+    FailureReason: __expectString(output.FailureReason),
     FeatureDefinitions:
       output.FeatureDefinitions !== undefined && output.FeatureDefinitions !== null
         ? deserializeAws_json1_1FeatureDefinitions(output.FeatureDefinitions, context)
         : undefined,
-    FeatureGroupArn:
-      output.FeatureGroupArn !== undefined && output.FeatureGroupArn !== null ? output.FeatureGroupArn : undefined,
-    FeatureGroupName:
-      output.FeatureGroupName !== undefined && output.FeatureGroupName !== null ? output.FeatureGroupName : undefined,
-    FeatureGroupStatus:
-      output.FeatureGroupStatus !== undefined && output.FeatureGroupStatus !== null
-        ? output.FeatureGroupStatus
-        : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    FeatureGroupArn: __expectString(output.FeatureGroupArn),
+    FeatureGroupName: __expectString(output.FeatureGroupName),
+    FeatureGroupStatus: __expectString(output.FeatureGroupStatus),
+    NextToken: __expectString(output.NextToken),
     OfflineStoreConfig:
       output.OfflineStoreConfig !== undefined && output.OfflineStoreConfig !== null
         ? deserializeAws_json1_1OfflineStoreConfig(output.OfflineStoreConfig, context)
@@ -26814,11 +26492,8 @@ const deserializeAws_json1_1DescribeFeatureGroupResponse = (
       output.OnlineStoreConfig !== undefined && output.OnlineStoreConfig !== null
         ? deserializeAws_json1_1OnlineStoreConfig(output.OnlineStoreConfig, context)
         : undefined,
-    RecordIdentifierFeatureName:
-      output.RecordIdentifierFeatureName !== undefined && output.RecordIdentifierFeatureName !== null
-        ? output.RecordIdentifierFeatureName
-        : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
+    RecordIdentifierFeatureName: __expectString(output.RecordIdentifierFeatureName),
+    RoleArn: __expectString(output.RoleArn),
   } as any;
 };
 
@@ -26831,20 +26506,10 @@ const deserializeAws_json1_1DescribeFlowDefinitionResponse = (
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
-    FlowDefinitionArn:
-      output.FlowDefinitionArn !== undefined && output.FlowDefinitionArn !== null
-        ? output.FlowDefinitionArn
-        : undefined,
-    FlowDefinitionName:
-      output.FlowDefinitionName !== undefined && output.FlowDefinitionName !== null
-        ? output.FlowDefinitionName
-        : undefined,
-    FlowDefinitionStatus:
-      output.FlowDefinitionStatus !== undefined && output.FlowDefinitionStatus !== null
-        ? output.FlowDefinitionStatus
-        : undefined,
+    FailureReason: __expectString(output.FailureReason),
+    FlowDefinitionArn: __expectString(output.FlowDefinitionArn),
+    FlowDefinitionName: __expectString(output.FlowDefinitionName),
+    FlowDefinitionStatus: __expectString(output.FlowDefinitionStatus),
     HumanLoopActivationConfig:
       output.HumanLoopActivationConfig !== undefined && output.HumanLoopActivationConfig !== null
         ? deserializeAws_json1_1HumanLoopActivationConfig(output.HumanLoopActivationConfig, context)
@@ -26861,7 +26526,7 @@ const deserializeAws_json1_1DescribeFlowDefinitionResponse = (
       output.OutputConfig !== undefined && output.OutputConfig !== null
         ? deserializeAws_json1_1FlowDefinitionOutputConfig(output.OutputConfig, context)
         : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
+    RoleArn: __expectString(output.RoleArn),
   } as any;
 };
 
@@ -26874,14 +26539,9 @@ const deserializeAws_json1_1DescribeHumanTaskUiResponse = (
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    HumanTaskUiArn:
-      output.HumanTaskUiArn !== undefined && output.HumanTaskUiArn !== null ? output.HumanTaskUiArn : undefined,
-    HumanTaskUiName:
-      output.HumanTaskUiName !== undefined && output.HumanTaskUiName !== null ? output.HumanTaskUiName : undefined,
-    HumanTaskUiStatus:
-      output.HumanTaskUiStatus !== undefined && output.HumanTaskUiStatus !== null
-        ? output.HumanTaskUiStatus
-        : undefined,
+    HumanTaskUiArn: __expectString(output.HumanTaskUiArn),
+    HumanTaskUiName: __expectString(output.HumanTaskUiName),
+    HumanTaskUiStatus: __expectString(output.HumanTaskUiStatus),
     UiTemplate:
       output.UiTemplate !== undefined && output.UiTemplate !== null
         ? deserializeAws_json1_1UiTemplateInfo(output.UiTemplate, context)
@@ -26902,28 +26562,18 @@ const deserializeAws_json1_1DescribeHyperParameterTuningJobResponse = (
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
+    FailureReason: __expectString(output.FailureReason),
     HyperParameterTuningEndTime:
       output.HyperParameterTuningEndTime !== undefined && output.HyperParameterTuningEndTime !== null
         ? new Date(Math.round(output.HyperParameterTuningEndTime * 1000))
         : undefined,
-    HyperParameterTuningJobArn:
-      output.HyperParameterTuningJobArn !== undefined && output.HyperParameterTuningJobArn !== null
-        ? output.HyperParameterTuningJobArn
-        : undefined,
+    HyperParameterTuningJobArn: __expectString(output.HyperParameterTuningJobArn),
     HyperParameterTuningJobConfig:
       output.HyperParameterTuningJobConfig !== undefined && output.HyperParameterTuningJobConfig !== null
         ? deserializeAws_json1_1HyperParameterTuningJobConfig(output.HyperParameterTuningJobConfig, context)
         : undefined,
-    HyperParameterTuningJobName:
-      output.HyperParameterTuningJobName !== undefined && output.HyperParameterTuningJobName !== null
-        ? output.HyperParameterTuningJobName
-        : undefined,
-    HyperParameterTuningJobStatus:
-      output.HyperParameterTuningJobStatus !== undefined && output.HyperParameterTuningJobStatus !== null
-        ? output.HyperParameterTuningJobStatus
-        : undefined,
+    HyperParameterTuningJobName: __expectString(output.HyperParameterTuningJobName),
+    HyperParameterTuningJobStatus: __expectString(output.HyperParameterTuningJobStatus),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
@@ -26961,18 +26611,17 @@ const deserializeAws_json1_1DescribeImageResponse = (output: any, context: __Ser
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    DisplayName: output.DisplayName !== undefined && output.DisplayName !== null ? output.DisplayName : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
-    ImageArn: output.ImageArn !== undefined && output.ImageArn !== null ? output.ImageArn : undefined,
-    ImageName: output.ImageName !== undefined && output.ImageName !== null ? output.ImageName : undefined,
-    ImageStatus: output.ImageStatus !== undefined && output.ImageStatus !== null ? output.ImageStatus : undefined,
+    Description: __expectString(output.Description),
+    DisplayName: __expectString(output.DisplayName),
+    FailureReason: __expectString(output.FailureReason),
+    ImageArn: __expectString(output.ImageArn),
+    ImageName: __expectString(output.ImageName),
+    ImageStatus: __expectString(output.ImageStatus),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
+    RoleArn: __expectString(output.RoleArn),
   } as any;
 };
 
@@ -26981,27 +26630,21 @@ const deserializeAws_json1_1DescribeImageVersionResponse = (
   context: __SerdeContext
 ): DescribeImageVersionResponse => {
   return {
-    BaseImage: output.BaseImage !== undefined && output.BaseImage !== null ? output.BaseImage : undefined,
-    ContainerImage:
-      output.ContainerImage !== undefined && output.ContainerImage !== null ? output.ContainerImage : undefined,
+    BaseImage: __expectString(output.BaseImage),
+    ContainerImage: __expectString(output.ContainerImage),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
-    ImageArn: output.ImageArn !== undefined && output.ImageArn !== null ? output.ImageArn : undefined,
-    ImageVersionArn:
-      output.ImageVersionArn !== undefined && output.ImageVersionArn !== null ? output.ImageVersionArn : undefined,
-    ImageVersionStatus:
-      output.ImageVersionStatus !== undefined && output.ImageVersionStatus !== null
-        ? output.ImageVersionStatus
-        : undefined,
+    FailureReason: __expectString(output.FailureReason),
+    ImageArn: __expectString(output.ImageArn),
+    ImageVersionArn: __expectString(output.ImageVersionArn),
+    ImageVersionStatus: __expectString(output.ImageVersionStatus),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    Version: __expectNumber(output.Version),
   } as any;
 };
 
@@ -27014,8 +26657,7 @@ const deserializeAws_json1_1DescribeLabelingJobResponse = (
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
+    FailureReason: __expectString(output.FailureReason),
     HumanTaskConfig:
       output.HumanTaskConfig !== undefined && output.HumanTaskConfig !== null
         ? deserializeAws_json1_1HumanTaskConfig(output.HumanTaskConfig, context)
@@ -27024,16 +26666,9 @@ const deserializeAws_json1_1DescribeLabelingJobResponse = (
       output.InputConfig !== undefined && output.InputConfig !== null
         ? deserializeAws_json1_1LabelingJobInputConfig(output.InputConfig, context)
         : undefined,
-    JobReferenceCode:
-      output.JobReferenceCode !== undefined && output.JobReferenceCode !== null ? output.JobReferenceCode : undefined,
-    LabelAttributeName:
-      output.LabelAttributeName !== undefined && output.LabelAttributeName !== null
-        ? output.LabelAttributeName
-        : undefined,
-    LabelCategoryConfigS3Uri:
-      output.LabelCategoryConfigS3Uri !== undefined && output.LabelCategoryConfigS3Uri !== null
-        ? output.LabelCategoryConfigS3Uri
-        : undefined,
+    JobReferenceCode: __expectString(output.JobReferenceCode),
+    LabelAttributeName: __expectString(output.LabelAttributeName),
+    LabelCategoryConfigS3Uri: __expectString(output.LabelCategoryConfigS3Uri),
     LabelCounters:
       output.LabelCounters !== undefined && output.LabelCounters !== null
         ? deserializeAws_json1_1LabelCounters(output.LabelCounters, context)
@@ -27042,18 +26677,13 @@ const deserializeAws_json1_1DescribeLabelingJobResponse = (
       output.LabelingJobAlgorithmsConfig !== undefined && output.LabelingJobAlgorithmsConfig !== null
         ? deserializeAws_json1_1LabelingJobAlgorithmsConfig(output.LabelingJobAlgorithmsConfig, context)
         : undefined,
-    LabelingJobArn:
-      output.LabelingJobArn !== undefined && output.LabelingJobArn !== null ? output.LabelingJobArn : undefined,
-    LabelingJobName:
-      output.LabelingJobName !== undefined && output.LabelingJobName !== null ? output.LabelingJobName : undefined,
+    LabelingJobArn: __expectString(output.LabelingJobArn),
+    LabelingJobName: __expectString(output.LabelingJobName),
     LabelingJobOutput:
       output.LabelingJobOutput !== undefined && output.LabelingJobOutput !== null
         ? deserializeAws_json1_1LabelingJobOutput(output.LabelingJobOutput, context)
         : undefined,
-    LabelingJobStatus:
-      output.LabelingJobStatus !== undefined && output.LabelingJobStatus !== null
-        ? output.LabelingJobStatus
-        : undefined,
+    LabelingJobStatus: __expectString(output.LabelingJobStatus),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
@@ -27062,7 +26692,7 @@ const deserializeAws_json1_1DescribeLabelingJobResponse = (
       output.OutputConfig !== undefined && output.OutputConfig !== null
         ? deserializeAws_json1_1LabelingJobOutputConfig(output.OutputConfig, context)
         : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
+    RoleArn: __expectString(output.RoleArn),
     StoppingConditions:
       output.StoppingConditions !== undefined && output.StoppingConditions !== null
         ? deserializeAws_json1_1LabelingJobStoppingConditions(output.StoppingConditions, context)
@@ -27083,12 +26713,8 @@ const deserializeAws_json1_1DescribeModelBiasJobDefinitionResponse = (
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    JobDefinitionArn:
-      output.JobDefinitionArn !== undefined && output.JobDefinitionArn !== null ? output.JobDefinitionArn : undefined,
-    JobDefinitionName:
-      output.JobDefinitionName !== undefined && output.JobDefinitionName !== null
-        ? output.JobDefinitionName
-        : undefined,
+    JobDefinitionArn: __expectString(output.JobDefinitionArn),
+    JobDefinitionName: __expectString(output.JobDefinitionName),
     JobResources:
       output.JobResources !== undefined && output.JobResources !== null
         ? deserializeAws_json1_1MonitoringResources(output.JobResources, context)
@@ -27113,7 +26739,7 @@ const deserializeAws_json1_1DescribeModelBiasJobDefinitionResponse = (
       output.NetworkConfig !== undefined && output.NetworkConfig !== null
         ? deserializeAws_json1_1MonitoringNetworkConfig(output.NetworkConfig, context)
         : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
+    RoleArn: __expectString(output.RoleArn),
     StoppingCondition:
       output.StoppingCondition !== undefined && output.StoppingCondition !== null
         ? deserializeAws_json1_1MonitoringStoppingCondition(output.StoppingCondition, context)
@@ -27130,12 +26756,8 @@ const deserializeAws_json1_1DescribeModelExplainabilityJobDefinitionResponse = (
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    JobDefinitionArn:
-      output.JobDefinitionArn !== undefined && output.JobDefinitionArn !== null ? output.JobDefinitionArn : undefined,
-    JobDefinitionName:
-      output.JobDefinitionName !== undefined && output.JobDefinitionName !== null
-        ? output.JobDefinitionName
-        : undefined,
+    JobDefinitionArn: __expectString(output.JobDefinitionArn),
+    JobDefinitionName: __expectString(output.JobDefinitionName),
     JobResources:
       output.JobResources !== undefined && output.JobResources !== null
         ? deserializeAws_json1_1MonitoringResources(output.JobResources, context)
@@ -27160,7 +26782,7 @@ const deserializeAws_json1_1DescribeModelExplainabilityJobDefinitionResponse = (
       output.NetworkConfig !== undefined && output.NetworkConfig !== null
         ? deserializeAws_json1_1MonitoringNetworkConfig(output.NetworkConfig, context)
         : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
+    RoleArn: __expectString(output.RoleArn),
     StoppingCondition:
       output.StoppingCondition !== undefined && output.StoppingCondition !== null
         ? deserializeAws_json1_1MonitoringStoppingCondition(output.StoppingCondition, context)
@@ -27178,18 +26800,14 @@ const deserializeAws_json1_1DescribeModelOutput = (output: any, context: __Serde
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    EnableNetworkIsolation:
-      output.EnableNetworkIsolation !== undefined && output.EnableNetworkIsolation !== null
-        ? output.EnableNetworkIsolation
-        : undefined,
-    ExecutionRoleArn:
-      output.ExecutionRoleArn !== undefined && output.ExecutionRoleArn !== null ? output.ExecutionRoleArn : undefined,
+    EnableNetworkIsolation: __expectBoolean(output.EnableNetworkIsolation),
+    ExecutionRoleArn: __expectString(output.ExecutionRoleArn),
     InferenceExecutionConfig:
       output.InferenceExecutionConfig !== undefined && output.InferenceExecutionConfig !== null
         ? deserializeAws_json1_1InferenceExecutionConfig(output.InferenceExecutionConfig, context)
         : undefined,
-    ModelArn: output.ModelArn !== undefined && output.ModelArn !== null ? output.ModelArn : undefined,
-    ModelName: output.ModelName !== undefined && output.ModelName !== null ? output.ModelName : undefined,
+    ModelArn: __expectString(output.ModelArn),
+    ModelName: __expectString(output.ModelName),
     PrimaryContainer:
       output.PrimaryContainer !== undefined && output.PrimaryContainer !== null
         ? deserializeAws_json1_1ContainerDefinition(output.PrimaryContainer, context)
@@ -27214,22 +26832,10 @@ const deserializeAws_json1_1DescribeModelPackageGroupOutput = (
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    ModelPackageGroupArn:
-      output.ModelPackageGroupArn !== undefined && output.ModelPackageGroupArn !== null
-        ? output.ModelPackageGroupArn
-        : undefined,
-    ModelPackageGroupDescription:
-      output.ModelPackageGroupDescription !== undefined && output.ModelPackageGroupDescription !== null
-        ? output.ModelPackageGroupDescription
-        : undefined,
-    ModelPackageGroupName:
-      output.ModelPackageGroupName !== undefined && output.ModelPackageGroupName !== null
-        ? output.ModelPackageGroupName
-        : undefined,
-    ModelPackageGroupStatus:
-      output.ModelPackageGroupStatus !== undefined && output.ModelPackageGroupStatus !== null
-        ? output.ModelPackageGroupStatus
-        : undefined,
+    ModelPackageGroupArn: __expectString(output.ModelPackageGroupArn),
+    ModelPackageGroupDescription: __expectString(output.ModelPackageGroupDescription),
+    ModelPackageGroupName: __expectString(output.ModelPackageGroupName),
+    ModelPackageGroupStatus: __expectString(output.ModelPackageGroupStatus),
   } as any;
 };
 
@@ -27238,14 +26844,8 @@ const deserializeAws_json1_1DescribeModelPackageOutput = (
   context: __SerdeContext
 ): DescribeModelPackageOutput => {
   return {
-    ApprovalDescription:
-      output.ApprovalDescription !== undefined && output.ApprovalDescription !== null
-        ? output.ApprovalDescription
-        : undefined,
-    CertifyForMarketplace:
-      output.CertifyForMarketplace !== undefined && output.CertifyForMarketplace !== null
-        ? output.CertifyForMarketplace
-        : undefined,
+    ApprovalDescription: __expectString(output.ApprovalDescription),
+    CertifyForMarketplace: __expectBoolean(output.CertifyForMarketplace),
     CreatedBy:
       output.CreatedBy !== undefined && output.CreatedBy !== null
         ? deserializeAws_json1_1UserContext(output.CreatedBy, context)
@@ -27270,38 +26870,21 @@ const deserializeAws_json1_1DescribeModelPackageOutput = (
       output.MetadataProperties !== undefined && output.MetadataProperties !== null
         ? deserializeAws_json1_1MetadataProperties(output.MetadataProperties, context)
         : undefined,
-    ModelApprovalStatus:
-      output.ModelApprovalStatus !== undefined && output.ModelApprovalStatus !== null
-        ? output.ModelApprovalStatus
-        : undefined,
+    ModelApprovalStatus: __expectString(output.ModelApprovalStatus),
     ModelMetrics:
       output.ModelMetrics !== undefined && output.ModelMetrics !== null
         ? deserializeAws_json1_1ModelMetrics(output.ModelMetrics, context)
         : undefined,
-    ModelPackageArn:
-      output.ModelPackageArn !== undefined && output.ModelPackageArn !== null ? output.ModelPackageArn : undefined,
-    ModelPackageDescription:
-      output.ModelPackageDescription !== undefined && output.ModelPackageDescription !== null
-        ? output.ModelPackageDescription
-        : undefined,
-    ModelPackageGroupName:
-      output.ModelPackageGroupName !== undefined && output.ModelPackageGroupName !== null
-        ? output.ModelPackageGroupName
-        : undefined,
-    ModelPackageName:
-      output.ModelPackageName !== undefined && output.ModelPackageName !== null ? output.ModelPackageName : undefined,
-    ModelPackageStatus:
-      output.ModelPackageStatus !== undefined && output.ModelPackageStatus !== null
-        ? output.ModelPackageStatus
-        : undefined,
+    ModelPackageArn: __expectString(output.ModelPackageArn),
+    ModelPackageDescription: __expectString(output.ModelPackageDescription),
+    ModelPackageGroupName: __expectString(output.ModelPackageGroupName),
+    ModelPackageName: __expectString(output.ModelPackageName),
+    ModelPackageStatus: __expectString(output.ModelPackageStatus),
     ModelPackageStatusDetails:
       output.ModelPackageStatusDetails !== undefined && output.ModelPackageStatusDetails !== null
         ? deserializeAws_json1_1ModelPackageStatusDetails(output.ModelPackageStatusDetails, context)
         : undefined,
-    ModelPackageVersion:
-      output.ModelPackageVersion !== undefined && output.ModelPackageVersion !== null
-        ? output.ModelPackageVersion
-        : undefined,
+    ModelPackageVersion: __expectNumber(output.ModelPackageVersion),
     SourceAlgorithmSpecification:
       output.SourceAlgorithmSpecification !== undefined && output.SourceAlgorithmSpecification !== null
         ? deserializeAws_json1_1SourceAlgorithmSpecification(output.SourceAlgorithmSpecification, context)
@@ -27322,12 +26905,8 @@ const deserializeAws_json1_1DescribeModelQualityJobDefinitionResponse = (
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    JobDefinitionArn:
-      output.JobDefinitionArn !== undefined && output.JobDefinitionArn !== null ? output.JobDefinitionArn : undefined,
-    JobDefinitionName:
-      output.JobDefinitionName !== undefined && output.JobDefinitionName !== null
-        ? output.JobDefinitionName
-        : undefined,
+    JobDefinitionArn: __expectString(output.JobDefinitionArn),
+    JobDefinitionName: __expectString(output.JobDefinitionName),
     JobResources:
       output.JobResources !== undefined && output.JobResources !== null
         ? deserializeAws_json1_1MonitoringResources(output.JobResources, context)
@@ -27352,7 +26931,7 @@ const deserializeAws_json1_1DescribeModelQualityJobDefinitionResponse = (
       output.NetworkConfig !== undefined && output.NetworkConfig !== null
         ? deserializeAws_json1_1MonitoringNetworkConfig(output.NetworkConfig, context)
         : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
+    RoleArn: __expectString(output.RoleArn),
     StoppingCondition:
       output.StoppingCondition !== undefined && output.StoppingCondition !== null
         ? deserializeAws_json1_1MonitoringStoppingCondition(output.StoppingCondition, context)
@@ -27369,9 +26948,8 @@ const deserializeAws_json1_1DescribeMonitoringScheduleResponse = (
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    EndpointName: output.EndpointName !== undefined && output.EndpointName !== null ? output.EndpointName : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
+    EndpointName: __expectString(output.EndpointName),
+    FailureReason: __expectString(output.FailureReason),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
@@ -27380,24 +26958,14 @@ const deserializeAws_json1_1DescribeMonitoringScheduleResponse = (
       output.LastMonitoringExecutionSummary !== undefined && output.LastMonitoringExecutionSummary !== null
         ? deserializeAws_json1_1MonitoringExecutionSummary(output.LastMonitoringExecutionSummary, context)
         : undefined,
-    MonitoringScheduleArn:
-      output.MonitoringScheduleArn !== undefined && output.MonitoringScheduleArn !== null
-        ? output.MonitoringScheduleArn
-        : undefined,
+    MonitoringScheduleArn: __expectString(output.MonitoringScheduleArn),
     MonitoringScheduleConfig:
       output.MonitoringScheduleConfig !== undefined && output.MonitoringScheduleConfig !== null
         ? deserializeAws_json1_1MonitoringScheduleConfig(output.MonitoringScheduleConfig, context)
         : undefined,
-    MonitoringScheduleName:
-      output.MonitoringScheduleName !== undefined && output.MonitoringScheduleName !== null
-        ? output.MonitoringScheduleName
-        : undefined,
-    MonitoringScheduleStatus:
-      output.MonitoringScheduleStatus !== undefined && output.MonitoringScheduleStatus !== null
-        ? output.MonitoringScheduleStatus
-        : undefined,
-    MonitoringType:
-      output.MonitoringType !== undefined && output.MonitoringType !== null ? output.MonitoringType : undefined,
+    MonitoringScheduleName: __expectString(output.MonitoringScheduleName),
+    MonitoringScheduleStatus: __expectString(output.MonitoringScheduleStatus),
+    MonitoringType: __expectString(output.MonitoringType),
   } as any;
 };
 
@@ -27414,14 +26982,8 @@ const deserializeAws_json1_1DescribeNotebookInstanceLifecycleConfigOutput = (
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    NotebookInstanceLifecycleConfigArn:
-      output.NotebookInstanceLifecycleConfigArn !== undefined && output.NotebookInstanceLifecycleConfigArn !== null
-        ? output.NotebookInstanceLifecycleConfigArn
-        : undefined,
-    NotebookInstanceLifecycleConfigName:
-      output.NotebookInstanceLifecycleConfigName !== undefined && output.NotebookInstanceLifecycleConfigName !== null
-        ? output.NotebookInstanceLifecycleConfigName
-        : undefined,
+    NotebookInstanceLifecycleConfigArn: __expectString(output.NotebookInstanceLifecycleConfigArn),
+    NotebookInstanceLifecycleConfigName: __expectString(output.NotebookInstanceLifecycleConfigName),
     OnCreate:
       output.OnCreate !== undefined && output.OnCreate !== null
         ? deserializeAws_json1_1NotebookInstanceLifecycleConfigList(output.OnCreate, context)
@@ -27450,52 +27012,29 @@ const deserializeAws_json1_1DescribeNotebookInstanceOutput = (
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    DefaultCodeRepository:
-      output.DefaultCodeRepository !== undefined && output.DefaultCodeRepository !== null
-        ? output.DefaultCodeRepository
-        : undefined,
-    DirectInternetAccess:
-      output.DirectInternetAccess !== undefined && output.DirectInternetAccess !== null
-        ? output.DirectInternetAccess
-        : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
-    InstanceType: output.InstanceType !== undefined && output.InstanceType !== null ? output.InstanceType : undefined,
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
+    DefaultCodeRepository: __expectString(output.DefaultCodeRepository),
+    DirectInternetAccess: __expectString(output.DirectInternetAccess),
+    FailureReason: __expectString(output.FailureReason),
+    InstanceType: __expectString(output.InstanceType),
+    KmsKeyId: __expectString(output.KmsKeyId),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    NetworkInterfaceId:
-      output.NetworkInterfaceId !== undefined && output.NetworkInterfaceId !== null
-        ? output.NetworkInterfaceId
-        : undefined,
-    NotebookInstanceArn:
-      output.NotebookInstanceArn !== undefined && output.NotebookInstanceArn !== null
-        ? output.NotebookInstanceArn
-        : undefined,
-    NotebookInstanceLifecycleConfigName:
-      output.NotebookInstanceLifecycleConfigName !== undefined && output.NotebookInstanceLifecycleConfigName !== null
-        ? output.NotebookInstanceLifecycleConfigName
-        : undefined,
-    NotebookInstanceName:
-      output.NotebookInstanceName !== undefined && output.NotebookInstanceName !== null
-        ? output.NotebookInstanceName
-        : undefined,
-    NotebookInstanceStatus:
-      output.NotebookInstanceStatus !== undefined && output.NotebookInstanceStatus !== null
-        ? output.NotebookInstanceStatus
-        : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
-    RootAccess: output.RootAccess !== undefined && output.RootAccess !== null ? output.RootAccess : undefined,
+    NetworkInterfaceId: __expectString(output.NetworkInterfaceId),
+    NotebookInstanceArn: __expectString(output.NotebookInstanceArn),
+    NotebookInstanceLifecycleConfigName: __expectString(output.NotebookInstanceLifecycleConfigName),
+    NotebookInstanceName: __expectString(output.NotebookInstanceName),
+    NotebookInstanceStatus: __expectString(output.NotebookInstanceStatus),
+    RoleArn: __expectString(output.RoleArn),
+    RootAccess: __expectString(output.RootAccess),
     SecurityGroups:
       output.SecurityGroups !== undefined && output.SecurityGroups !== null
         ? deserializeAws_json1_1SecurityGroupIds(output.SecurityGroups, context)
         : undefined,
-    SubnetId: output.SubnetId !== undefined && output.SubnetId !== null ? output.SubnetId : undefined,
-    Url: output.Url !== undefined && output.Url !== null ? output.Url : undefined,
-    VolumeSizeInGB:
-      output.VolumeSizeInGB !== undefined && output.VolumeSizeInGB !== null ? output.VolumeSizeInGB : undefined,
+    SubnetId: __expectString(output.SubnetId),
+    Url: __expectString(output.Url),
+    VolumeSizeInGB: __expectNumber(output.VolumeSizeInGB),
   } as any;
 };
 
@@ -27508,10 +27047,7 @@ const deserializeAws_json1_1DescribePipelineDefinitionForExecutionResponse = (
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    PipelineDefinition:
-      output.PipelineDefinition !== undefined && output.PipelineDefinition !== null
-        ? output.PipelineDefinition
-        : undefined,
+    PipelineDefinition: __expectString(output.PipelineDefinition),
   } as any;
 };
 
@@ -27528,8 +27064,7 @@ const deserializeAws_json1_1DescribePipelineExecutionResponse = (
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
+    FailureReason: __expectString(output.FailureReason),
     LastModifiedBy:
       output.LastModifiedBy !== undefined && output.LastModifiedBy !== null
         ? deserializeAws_json1_1UserContext(output.LastModifiedBy, context)
@@ -27538,23 +27073,11 @@ const deserializeAws_json1_1DescribePipelineExecutionResponse = (
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    PipelineArn: output.PipelineArn !== undefined && output.PipelineArn !== null ? output.PipelineArn : undefined,
-    PipelineExecutionArn:
-      output.PipelineExecutionArn !== undefined && output.PipelineExecutionArn !== null
-        ? output.PipelineExecutionArn
-        : undefined,
-    PipelineExecutionDescription:
-      output.PipelineExecutionDescription !== undefined && output.PipelineExecutionDescription !== null
-        ? output.PipelineExecutionDescription
-        : undefined,
-    PipelineExecutionDisplayName:
-      output.PipelineExecutionDisplayName !== undefined && output.PipelineExecutionDisplayName !== null
-        ? output.PipelineExecutionDisplayName
-        : undefined,
-    PipelineExecutionStatus:
-      output.PipelineExecutionStatus !== undefined && output.PipelineExecutionStatus !== null
-        ? output.PipelineExecutionStatus
-        : undefined,
+    PipelineArn: __expectString(output.PipelineArn),
+    PipelineExecutionArn: __expectString(output.PipelineExecutionArn),
+    PipelineExecutionDescription: __expectString(output.PipelineExecutionDescription),
+    PipelineExecutionDisplayName: __expectString(output.PipelineExecutionDisplayName),
+    PipelineExecutionStatus: __expectString(output.PipelineExecutionStatus),
     PipelineExperimentConfig:
       output.PipelineExperimentConfig !== undefined && output.PipelineExperimentConfig !== null
         ? deserializeAws_json1_1PipelineExperimentConfig(output.PipelineExperimentConfig, context)
@@ -27587,23 +27110,13 @@ const deserializeAws_json1_1DescribePipelineResponse = (
       output.LastRunTime !== undefined && output.LastRunTime !== null
         ? new Date(Math.round(output.LastRunTime * 1000))
         : undefined,
-    PipelineArn: output.PipelineArn !== undefined && output.PipelineArn !== null ? output.PipelineArn : undefined,
-    PipelineDefinition:
-      output.PipelineDefinition !== undefined && output.PipelineDefinition !== null
-        ? output.PipelineDefinition
-        : undefined,
-    PipelineDescription:
-      output.PipelineDescription !== undefined && output.PipelineDescription !== null
-        ? output.PipelineDescription
-        : undefined,
-    PipelineDisplayName:
-      output.PipelineDisplayName !== undefined && output.PipelineDisplayName !== null
-        ? output.PipelineDisplayName
-        : undefined,
-    PipelineName: output.PipelineName !== undefined && output.PipelineName !== null ? output.PipelineName : undefined,
-    PipelineStatus:
-      output.PipelineStatus !== undefined && output.PipelineStatus !== null ? output.PipelineStatus : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
+    PipelineArn: __expectString(output.PipelineArn),
+    PipelineDefinition: __expectString(output.PipelineDefinition),
+    PipelineDescription: __expectString(output.PipelineDescription),
+    PipelineDisplayName: __expectString(output.PipelineDisplayName),
+    PipelineName: __expectString(output.PipelineName),
+    PipelineStatus: __expectString(output.PipelineStatus),
+    RoleArn: __expectString(output.RoleArn),
   } as any;
 };
 
@@ -27616,7 +27129,7 @@ const deserializeAws_json1_1DescribeProcessingJobResponse = (
       output.AppSpecification !== undefined && output.AppSpecification !== null
         ? deserializeAws_json1_1AppSpecification(output.AppSpecification, context)
         : undefined,
-    AutoMLJobArn: output.AutoMLJobArn !== undefined && output.AutoMLJobArn !== null ? output.AutoMLJobArn : undefined,
+    AutoMLJobArn: __expectString(output.AutoMLJobArn),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -27625,21 +27138,17 @@ const deserializeAws_json1_1DescribeProcessingJobResponse = (
       output.Environment !== undefined && output.Environment !== null
         ? deserializeAws_json1_1ProcessingEnvironmentMap(output.Environment, context)
         : undefined,
-    ExitMessage: output.ExitMessage !== undefined && output.ExitMessage !== null ? output.ExitMessage : undefined,
+    ExitMessage: __expectString(output.ExitMessage),
     ExperimentConfig:
       output.ExperimentConfig !== undefined && output.ExperimentConfig !== null
         ? deserializeAws_json1_1ExperimentConfig(output.ExperimentConfig, context)
         : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
+    FailureReason: __expectString(output.FailureReason),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    MonitoringScheduleArn:
-      output.MonitoringScheduleArn !== undefined && output.MonitoringScheduleArn !== null
-        ? output.MonitoringScheduleArn
-        : undefined,
+    MonitoringScheduleArn: __expectString(output.MonitoringScheduleArn),
     NetworkConfig:
       output.NetworkConfig !== undefined && output.NetworkConfig !== null
         ? deserializeAws_json1_1NetworkConfig(output.NetworkConfig, context)
@@ -27652,16 +27161,9 @@ const deserializeAws_json1_1DescribeProcessingJobResponse = (
       output.ProcessingInputs !== undefined && output.ProcessingInputs !== null
         ? deserializeAws_json1_1ProcessingInputs(output.ProcessingInputs, context)
         : undefined,
-    ProcessingJobArn:
-      output.ProcessingJobArn !== undefined && output.ProcessingJobArn !== null ? output.ProcessingJobArn : undefined,
-    ProcessingJobName:
-      output.ProcessingJobName !== undefined && output.ProcessingJobName !== null
-        ? output.ProcessingJobName
-        : undefined,
-    ProcessingJobStatus:
-      output.ProcessingJobStatus !== undefined && output.ProcessingJobStatus !== null
-        ? output.ProcessingJobStatus
-        : undefined,
+    ProcessingJobArn: __expectString(output.ProcessingJobArn),
+    ProcessingJobName: __expectString(output.ProcessingJobName),
+    ProcessingJobStatus: __expectString(output.ProcessingJobStatus),
     ProcessingOutputConfig:
       output.ProcessingOutputConfig !== undefined && output.ProcessingOutputConfig !== null
         ? deserializeAws_json1_1ProcessingOutputConfig(output.ProcessingOutputConfig, context)
@@ -27674,13 +27176,12 @@ const deserializeAws_json1_1DescribeProcessingJobResponse = (
       output.ProcessingStartTime !== undefined && output.ProcessingStartTime !== null
         ? new Date(Math.round(output.ProcessingStartTime * 1000))
         : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
+    RoleArn: __expectString(output.RoleArn),
     StoppingCondition:
       output.StoppingCondition !== undefined && output.StoppingCondition !== null
         ? deserializeAws_json1_1ProcessingStoppingCondition(output.StoppingCondition, context)
         : undefined,
-    TrainingJobArn:
-      output.TrainingJobArn !== undefined && output.TrainingJobArn !== null ? output.TrainingJobArn : undefined,
+    TrainingJobArn: __expectString(output.TrainingJobArn),
   } as any;
 };
 
@@ -27694,15 +27195,11 @@ const deserializeAws_json1_1DescribeProjectOutput = (output: any, context: __Ser
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    ProjectArn: output.ProjectArn !== undefined && output.ProjectArn !== null ? output.ProjectArn : undefined,
-    ProjectDescription:
-      output.ProjectDescription !== undefined && output.ProjectDescription !== null
-        ? output.ProjectDescription
-        : undefined,
-    ProjectId: output.ProjectId !== undefined && output.ProjectId !== null ? output.ProjectId : undefined,
-    ProjectName: output.ProjectName !== undefined && output.ProjectName !== null ? output.ProjectName : undefined,
-    ProjectStatus:
-      output.ProjectStatus !== undefined && output.ProjectStatus !== null ? output.ProjectStatus : undefined,
+    ProjectArn: __expectString(output.ProjectArn),
+    ProjectDescription: __expectString(output.ProjectDescription),
+    ProjectId: __expectString(output.ProjectId),
+    ProjectName: __expectString(output.ProjectName),
+    ProjectStatus: __expectString(output.ProjectStatus),
     ServiceCatalogProvisionedProductDetails:
       output.ServiceCatalogProvisionedProductDetails !== undefined &&
       output.ServiceCatalogProvisionedProductDetails !== null
@@ -27739,11 +27236,8 @@ const deserializeAws_json1_1DescribeTrainingJobResponse = (
       output.AlgorithmSpecification !== undefined && output.AlgorithmSpecification !== null
         ? deserializeAws_json1_1AlgorithmSpecification(output.AlgorithmSpecification, context)
         : undefined,
-    AutoMLJobArn: output.AutoMLJobArn !== undefined && output.AutoMLJobArn !== null ? output.AutoMLJobArn : undefined,
-    BillableTimeInSeconds:
-      output.BillableTimeInSeconds !== undefined && output.BillableTimeInSeconds !== null
-        ? output.BillableTimeInSeconds
-        : undefined,
+    AutoMLJobArn: __expectString(output.AutoMLJobArn),
+    BillableTimeInSeconds: __expectNumber(output.BillableTimeInSeconds),
     CheckpointConfig:
       output.CheckpointConfig !== undefined && output.CheckpointConfig !== null
         ? deserializeAws_json1_1CheckpointConfig(output.CheckpointConfig, context)
@@ -27764,19 +27258,9 @@ const deserializeAws_json1_1DescribeTrainingJobResponse = (
       output.DebugRuleEvaluationStatuses !== undefined && output.DebugRuleEvaluationStatuses !== null
         ? deserializeAws_json1_1DebugRuleEvaluationStatuses(output.DebugRuleEvaluationStatuses, context)
         : undefined,
-    EnableInterContainerTrafficEncryption:
-      output.EnableInterContainerTrafficEncryption !== undefined &&
-      output.EnableInterContainerTrafficEncryption !== null
-        ? output.EnableInterContainerTrafficEncryption
-        : undefined,
-    EnableManagedSpotTraining:
-      output.EnableManagedSpotTraining !== undefined && output.EnableManagedSpotTraining !== null
-        ? output.EnableManagedSpotTraining
-        : undefined,
-    EnableNetworkIsolation:
-      output.EnableNetworkIsolation !== undefined && output.EnableNetworkIsolation !== null
-        ? output.EnableNetworkIsolation
-        : undefined,
+    EnableInterContainerTrafficEncryption: __expectBoolean(output.EnableInterContainerTrafficEncryption),
+    EnableManagedSpotTraining: __expectBoolean(output.EnableManagedSpotTraining),
+    EnableNetworkIsolation: __expectBoolean(output.EnableNetworkIsolation),
     Environment:
       output.Environment !== undefined && output.Environment !== null
         ? deserializeAws_json1_1TrainingEnvironmentMap(output.Environment, context)
@@ -27785,8 +27269,7 @@ const deserializeAws_json1_1DescribeTrainingJobResponse = (
       output.ExperimentConfig !== undefined && output.ExperimentConfig !== null
         ? deserializeAws_json1_1ExperimentConfig(output.ExperimentConfig, context)
         : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
+    FailureReason: __expectString(output.FailureReason),
     FinalMetricDataList:
       output.FinalMetricDataList !== undefined && output.FinalMetricDataList !== null
         ? deserializeAws_json1_1FinalMetricDataList(output.FinalMetricDataList, context)
@@ -27799,8 +27282,7 @@ const deserializeAws_json1_1DescribeTrainingJobResponse = (
       output.InputDataConfig !== undefined && output.InputDataConfig !== null
         ? deserializeAws_json1_1InputDataConfig(output.InputDataConfig, context)
         : undefined,
-    LabelingJobArn:
-      output.LabelingJobArn !== undefined && output.LabelingJobArn !== null ? output.LabelingJobArn : undefined,
+    LabelingJobArn: __expectString(output.LabelingJobArn),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
@@ -27825,8 +27307,7 @@ const deserializeAws_json1_1DescribeTrainingJobResponse = (
       output.ProfilerRuleEvaluationStatuses !== undefined && output.ProfilerRuleEvaluationStatuses !== null
         ? deserializeAws_json1_1ProfilerRuleEvaluationStatuses(output.ProfilerRuleEvaluationStatuses, context)
         : undefined,
-    ProfilingStatus:
-      output.ProfilingStatus !== undefined && output.ProfilingStatus !== null ? output.ProfilingStatus : undefined,
+    ProfilingStatus: __expectString(output.ProfilingStatus),
     ResourceConfig:
       output.ResourceConfig !== undefined && output.ResourceConfig !== null
         ? deserializeAws_json1_1ResourceConfig(output.ResourceConfig, context)
@@ -27835,9 +27316,8 @@ const deserializeAws_json1_1DescribeTrainingJobResponse = (
       output.RetryStrategy !== undefined && output.RetryStrategy !== null
         ? deserializeAws_json1_1RetryStrategy(output.RetryStrategy, context)
         : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
-    SecondaryStatus:
-      output.SecondaryStatus !== undefined && output.SecondaryStatus !== null ? output.SecondaryStatus : undefined,
+    RoleArn: __expectString(output.RoleArn),
+    SecondaryStatus: __expectString(output.SecondaryStatus),
     SecondaryStatusTransitions:
       output.SecondaryStatusTransitions !== undefined && output.SecondaryStatusTransitions !== null
         ? deserializeAws_json1_1SecondaryStatusTransitions(output.SecondaryStatusTransitions, context)
@@ -27854,23 +27334,15 @@ const deserializeAws_json1_1DescribeTrainingJobResponse = (
       output.TrainingEndTime !== undefined && output.TrainingEndTime !== null
         ? new Date(Math.round(output.TrainingEndTime * 1000))
         : undefined,
-    TrainingJobArn:
-      output.TrainingJobArn !== undefined && output.TrainingJobArn !== null ? output.TrainingJobArn : undefined,
-    TrainingJobName:
-      output.TrainingJobName !== undefined && output.TrainingJobName !== null ? output.TrainingJobName : undefined,
-    TrainingJobStatus:
-      output.TrainingJobStatus !== undefined && output.TrainingJobStatus !== null
-        ? output.TrainingJobStatus
-        : undefined,
+    TrainingJobArn: __expectString(output.TrainingJobArn),
+    TrainingJobName: __expectString(output.TrainingJobName),
+    TrainingJobStatus: __expectString(output.TrainingJobStatus),
     TrainingStartTime:
       output.TrainingStartTime !== undefined && output.TrainingStartTime !== null
         ? new Date(Math.round(output.TrainingStartTime * 1000))
         : undefined,
-    TrainingTimeInSeconds:
-      output.TrainingTimeInSeconds !== undefined && output.TrainingTimeInSeconds !== null
-        ? output.TrainingTimeInSeconds
-        : undefined,
-    TuningJobArn: output.TuningJobArn !== undefined && output.TuningJobArn !== null ? output.TuningJobArn : undefined,
+    TrainingTimeInSeconds: __expectNumber(output.TrainingTimeInSeconds),
+    TuningJobArn: __expectString(output.TuningJobArn),
     VpcConfig:
       output.VpcConfig !== undefined && output.VpcConfig !== null
         ? deserializeAws_json1_1VpcConfig(output.VpcConfig, context)
@@ -27883,9 +27355,8 @@ const deserializeAws_json1_1DescribeTransformJobResponse = (
   context: __SerdeContext
 ): DescribeTransformJobResponse => {
   return {
-    AutoMLJobArn: output.AutoMLJobArn !== undefined && output.AutoMLJobArn !== null ? output.AutoMLJobArn : undefined,
-    BatchStrategy:
-      output.BatchStrategy !== undefined && output.BatchStrategy !== null ? output.BatchStrategy : undefined,
+    AutoMLJobArn: __expectString(output.AutoMLJobArn),
+    BatchStrategy: __expectString(output.BatchStrategy),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -27902,21 +27373,15 @@ const deserializeAws_json1_1DescribeTransformJobResponse = (
       output.ExperimentConfig !== undefined && output.ExperimentConfig !== null
         ? deserializeAws_json1_1ExperimentConfig(output.ExperimentConfig, context)
         : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
-    LabelingJobArn:
-      output.LabelingJobArn !== undefined && output.LabelingJobArn !== null ? output.LabelingJobArn : undefined,
-    MaxConcurrentTransforms:
-      output.MaxConcurrentTransforms !== undefined && output.MaxConcurrentTransforms !== null
-        ? output.MaxConcurrentTransforms
-        : undefined,
-    MaxPayloadInMB:
-      output.MaxPayloadInMB !== undefined && output.MaxPayloadInMB !== null ? output.MaxPayloadInMB : undefined,
+    FailureReason: __expectString(output.FailureReason),
+    LabelingJobArn: __expectString(output.LabelingJobArn),
+    MaxConcurrentTransforms: __expectNumber(output.MaxConcurrentTransforms),
+    MaxPayloadInMB: __expectNumber(output.MaxPayloadInMB),
     ModelClientConfig:
       output.ModelClientConfig !== undefined && output.ModelClientConfig !== null
         ? deserializeAws_json1_1ModelClientConfig(output.ModelClientConfig, context)
         : undefined,
-    ModelName: output.ModelName !== undefined && output.ModelName !== null ? output.ModelName : undefined,
+    ModelName: __expectString(output.ModelName),
     TransformEndTime:
       output.TransformEndTime !== undefined && output.TransformEndTime !== null
         ? new Date(Math.round(output.TransformEndTime * 1000))
@@ -27925,14 +27390,9 @@ const deserializeAws_json1_1DescribeTransformJobResponse = (
       output.TransformInput !== undefined && output.TransformInput !== null
         ? deserializeAws_json1_1TransformInput(output.TransformInput, context)
         : undefined,
-    TransformJobArn:
-      output.TransformJobArn !== undefined && output.TransformJobArn !== null ? output.TransformJobArn : undefined,
-    TransformJobName:
-      output.TransformJobName !== undefined && output.TransformJobName !== null ? output.TransformJobName : undefined,
-    TransformJobStatus:
-      output.TransformJobStatus !== undefined && output.TransformJobStatus !== null
-        ? output.TransformJobStatus
-        : undefined,
+    TransformJobArn: __expectString(output.TransformJobArn),
+    TransformJobName: __expectString(output.TransformJobName),
+    TransformJobStatus: __expectString(output.TransformJobStatus),
     TransformOutput:
       output.TransformOutput !== undefined && output.TransformOutput !== null
         ? deserializeAws_json1_1TransformOutput(output.TransformOutput, context)
@@ -27961,7 +27421,7 @@ const deserializeAws_json1_1DescribeTrialComponentResponse = (
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    DisplayName: output.DisplayName !== undefined && output.DisplayName !== null ? output.DisplayName : undefined,
+    DisplayName: __expectString(output.DisplayName),
     EndTime:
       output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
     InputArtifacts:
@@ -28004,14 +27464,8 @@ const deserializeAws_json1_1DescribeTrialComponentResponse = (
       output.Status !== undefined && output.Status !== null
         ? deserializeAws_json1_1TrialComponentStatus(output.Status, context)
         : undefined,
-    TrialComponentArn:
-      output.TrialComponentArn !== undefined && output.TrialComponentArn !== null
-        ? output.TrialComponentArn
-        : undefined,
-    TrialComponentName:
-      output.TrialComponentName !== undefined && output.TrialComponentName !== null
-        ? output.TrialComponentName
-        : undefined,
+    TrialComponentArn: __expectString(output.TrialComponentArn),
+    TrialComponentName: __expectString(output.TrialComponentName),
   } as any;
 };
 
@@ -28025,9 +27479,8 @@ const deserializeAws_json1_1DescribeTrialResponse = (output: any, context: __Ser
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    DisplayName: output.DisplayName !== undefined && output.DisplayName !== null ? output.DisplayName : undefined,
-    ExperimentName:
-      output.ExperimentName !== undefined && output.ExperimentName !== null ? output.ExperimentName : undefined,
+    DisplayName: __expectString(output.DisplayName),
+    ExperimentName: __expectString(output.ExperimentName),
     LastModifiedBy:
       output.LastModifiedBy !== undefined && output.LastModifiedBy !== null
         ? deserializeAws_json1_1UserContext(output.LastModifiedBy, context)
@@ -28044,8 +27497,8 @@ const deserializeAws_json1_1DescribeTrialResponse = (output: any, context: __Ser
       output.Source !== undefined && output.Source !== null
         ? deserializeAws_json1_1TrialSource(output.Source, context)
         : undefined,
-    TrialArn: output.TrialArn !== undefined && output.TrialArn !== null ? output.TrialArn : undefined,
-    TrialName: output.TrialName !== undefined && output.TrialName !== null ? output.TrialName : undefined,
+    TrialArn: __expectString(output.TrialArn),
+    TrialName: __expectString(output.TrialName),
   } as any;
 };
 
@@ -28058,30 +27511,18 @@ const deserializeAws_json1_1DescribeUserProfileResponse = (
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    DomainId: output.DomainId !== undefined && output.DomainId !== null ? output.DomainId : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
-    HomeEfsFileSystemUid:
-      output.HomeEfsFileSystemUid !== undefined && output.HomeEfsFileSystemUid !== null
-        ? output.HomeEfsFileSystemUid
-        : undefined,
+    DomainId: __expectString(output.DomainId),
+    FailureReason: __expectString(output.FailureReason),
+    HomeEfsFileSystemUid: __expectString(output.HomeEfsFileSystemUid),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    SingleSignOnUserIdentifier:
-      output.SingleSignOnUserIdentifier !== undefined && output.SingleSignOnUserIdentifier !== null
-        ? output.SingleSignOnUserIdentifier
-        : undefined,
-    SingleSignOnUserValue:
-      output.SingleSignOnUserValue !== undefined && output.SingleSignOnUserValue !== null
-        ? output.SingleSignOnUserValue
-        : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    UserProfileArn:
-      output.UserProfileArn !== undefined && output.UserProfileArn !== null ? output.UserProfileArn : undefined,
-    UserProfileName:
-      output.UserProfileName !== undefined && output.UserProfileName !== null ? output.UserProfileName : undefined,
+    SingleSignOnUserIdentifier: __expectString(output.SingleSignOnUserIdentifier),
+    SingleSignOnUserValue: __expectString(output.SingleSignOnUserValue),
+    Status: __expectString(output.Status),
+    UserProfileArn: __expectString(output.UserProfileArn),
+    UserProfileName: __expectString(output.UserProfileName),
     UserSettings:
       output.UserSettings !== undefined && output.UserSettings !== null
         ? deserializeAws_json1_1UserSettings(output.UserSettings, context)
@@ -28130,10 +27571,8 @@ const deserializeAws_json1_1DeviceFleetSummary = (output: any, context: __SerdeC
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    DeviceFleetArn:
-      output.DeviceFleetArn !== undefined && output.DeviceFleetArn !== null ? output.DeviceFleetArn : undefined,
-    DeviceFleetName:
-      output.DeviceFleetName !== undefined && output.DeviceFleetName !== null ? output.DeviceFleetName : undefined,
+    DeviceFleetArn: __expectString(output.DeviceFleetArn),
+    DeviceFleetName: __expectString(output.DeviceFleetName),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
@@ -28143,14 +27582,8 @@ const deserializeAws_json1_1DeviceFleetSummary = (output: any, context: __SerdeC
 
 const deserializeAws_json1_1DeviceStats = (output: any, context: __SerdeContext): DeviceStats => {
   return {
-    ConnectedDeviceCount:
-      output.ConnectedDeviceCount !== undefined && output.ConnectedDeviceCount !== null
-        ? output.ConnectedDeviceCount
-        : undefined,
-    RegisteredDeviceCount:
-      output.RegisteredDeviceCount !== undefined && output.RegisteredDeviceCount !== null
-        ? output.RegisteredDeviceCount
-        : undefined,
+    ConnectedDeviceCount: __expectNumber(output.ConnectedDeviceCount),
+    RegisteredDeviceCount: __expectNumber(output.RegisteredDeviceCount),
   } as any;
 };
 
@@ -28167,12 +27600,11 @@ const deserializeAws_json1_1DeviceSummaries = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_1DeviceSummary = (output: any, context: __SerdeContext): DeviceSummary => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    DeviceArn: output.DeviceArn !== undefined && output.DeviceArn !== null ? output.DeviceArn : undefined,
-    DeviceFleetName:
-      output.DeviceFleetName !== undefined && output.DeviceFleetName !== null ? output.DeviceFleetName : undefined,
-    DeviceName: output.DeviceName !== undefined && output.DeviceName !== null ? output.DeviceName : undefined,
-    IotThingName: output.IotThingName !== undefined && output.IotThingName !== null ? output.IotThingName : undefined,
+    Description: __expectString(output.Description),
+    DeviceArn: __expectString(output.DeviceArn),
+    DeviceFleetName: __expectString(output.DeviceFleetName),
+    DeviceName: __expectString(output.DeviceName),
+    IotThingName: __expectString(output.IotThingName),
     LatestHeartbeat:
       output.LatestHeartbeat !== undefined && output.LatestHeartbeat !== null
         ? new Date(Math.round(output.LatestHeartbeat * 1000))
@@ -28200,11 +27632,8 @@ const deserializeAws_json1_1DisassociateTrialComponentResponse = (
   context: __SerdeContext
 ): DisassociateTrialComponentResponse => {
   return {
-    TrialArn: output.TrialArn !== undefined && output.TrialArn !== null ? output.TrialArn : undefined,
-    TrialComponentArn:
-      output.TrialComponentArn !== undefined && output.TrialComponentArn !== null
-        ? output.TrialComponentArn
-        : undefined,
+    TrialArn: __expectString(output.TrialArn),
+    TrialComponentArn: __expectString(output.TrialComponentArn),
   } as any;
 };
 
@@ -28214,15 +27643,15 @@ const deserializeAws_json1_1DomainDetails = (output: any, context: __SerdeContex
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    DomainArn: output.DomainArn !== undefined && output.DomainArn !== null ? output.DomainArn : undefined,
-    DomainId: output.DomainId !== undefined && output.DomainId !== null ? output.DomainId : undefined,
-    DomainName: output.DomainName !== undefined && output.DomainName !== null ? output.DomainName : undefined,
+    DomainArn: __expectString(output.DomainArn),
+    DomainId: __expectString(output.DomainId),
+    DomainName: __expectString(output.DomainName),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    Url: output.Url !== undefined && output.Url !== null ? output.Url : undefined,
+    Status: __expectString(output.Status),
+    Url: __expectString(output.Url),
   } as any;
 };
 
@@ -28247,8 +27676,8 @@ const deserializeAws_json1_1EdgeModel = (output: any, context: __SerdeContext): 
       output.LatestSampleTime !== undefined && output.LatestSampleTime !== null
         ? new Date(Math.round(output.LatestSampleTime * 1000))
         : undefined,
-    ModelName: output.ModelName !== undefined && output.ModelName !== null ? output.ModelName : undefined,
-    ModelVersion: output.ModelVersion !== undefined && output.ModelVersion !== null ? output.ModelVersion : undefined,
+    ModelName: __expectString(output.ModelName),
+    ModelVersion: __expectString(output.ModelVersion),
   } as any;
 };
 
@@ -28265,24 +27694,12 @@ const deserializeAws_json1_1EdgeModels = (output: any, context: __SerdeContext):
 
 const deserializeAws_json1_1EdgeModelStat = (output: any, context: __SerdeContext): EdgeModelStat => {
   return {
-    ActiveDeviceCount:
-      output.ActiveDeviceCount !== undefined && output.ActiveDeviceCount !== null
-        ? output.ActiveDeviceCount
-        : undefined,
-    ConnectedDeviceCount:
-      output.ConnectedDeviceCount !== undefined && output.ConnectedDeviceCount !== null
-        ? output.ConnectedDeviceCount
-        : undefined,
-    ModelName: output.ModelName !== undefined && output.ModelName !== null ? output.ModelName : undefined,
-    ModelVersion: output.ModelVersion !== undefined && output.ModelVersion !== null ? output.ModelVersion : undefined,
-    OfflineDeviceCount:
-      output.OfflineDeviceCount !== undefined && output.OfflineDeviceCount !== null
-        ? output.OfflineDeviceCount
-        : undefined,
-    SamplingDeviceCount:
-      output.SamplingDeviceCount !== undefined && output.SamplingDeviceCount !== null
-        ? output.SamplingDeviceCount
-        : undefined,
+    ActiveDeviceCount: __expectNumber(output.ActiveDeviceCount),
+    ConnectedDeviceCount: __expectNumber(output.ConnectedDeviceCount),
+    ModelName: __expectString(output.ModelName),
+    ModelVersion: __expectString(output.ModelVersion),
+    OfflineDeviceCount: __expectNumber(output.OfflineDeviceCount),
+    SamplingDeviceCount: __expectNumber(output.SamplingDeviceCount),
   } as any;
 };
 
@@ -28310,24 +27727,17 @@ const deserializeAws_json1_1EdgeModelSummaries = (output: any, context: __SerdeC
 
 const deserializeAws_json1_1EdgeModelSummary = (output: any, context: __SerdeContext): EdgeModelSummary => {
   return {
-    ModelName: output.ModelName !== undefined && output.ModelName !== null ? output.ModelName : undefined,
-    ModelVersion: output.ModelVersion !== undefined && output.ModelVersion !== null ? output.ModelVersion : undefined,
+    ModelName: __expectString(output.ModelName),
+    ModelVersion: __expectString(output.ModelVersion),
   } as any;
 };
 
 const deserializeAws_json1_1EdgeOutputConfig = (output: any, context: __SerdeContext): EdgeOutputConfig => {
   return {
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
-    PresetDeploymentConfig:
-      output.PresetDeploymentConfig !== undefined && output.PresetDeploymentConfig !== null
-        ? output.PresetDeploymentConfig
-        : undefined,
-    PresetDeploymentType:
-      output.PresetDeploymentType !== undefined && output.PresetDeploymentType !== null
-        ? output.PresetDeploymentType
-        : undefined,
-    S3OutputLocation:
-      output.S3OutputLocation !== undefined && output.S3OutputLocation !== null ? output.S3OutputLocation : undefined,
+    KmsKeyId: __expectString(output.KmsKeyId),
+    PresetDeploymentConfig: __expectString(output.PresetDeploymentConfig),
+    PresetDeploymentType: __expectString(output.PresetDeploymentType),
+    S3OutputLocation: __expectString(output.S3OutputLocation),
   } as any;
 };
 
@@ -28350,32 +27760,20 @@ const deserializeAws_json1_1EdgePackagingJobSummary = (
   context: __SerdeContext
 ): EdgePackagingJobSummary => {
   return {
-    CompilationJobName:
-      output.CompilationJobName !== undefined && output.CompilationJobName !== null
-        ? output.CompilationJobName
-        : undefined,
+    CompilationJobName: __expectString(output.CompilationJobName),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    EdgePackagingJobArn:
-      output.EdgePackagingJobArn !== undefined && output.EdgePackagingJobArn !== null
-        ? output.EdgePackagingJobArn
-        : undefined,
-    EdgePackagingJobName:
-      output.EdgePackagingJobName !== undefined && output.EdgePackagingJobName !== null
-        ? output.EdgePackagingJobName
-        : undefined,
-    EdgePackagingJobStatus:
-      output.EdgePackagingJobStatus !== undefined && output.EdgePackagingJobStatus !== null
-        ? output.EdgePackagingJobStatus
-        : undefined,
+    EdgePackagingJobArn: __expectString(output.EdgePackagingJobArn),
+    EdgePackagingJobName: __expectString(output.EdgePackagingJobName),
+    EdgePackagingJobStatus: __expectString(output.EdgePackagingJobStatus),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    ModelName: output.ModelName !== undefined && output.ModelName !== null ? output.ModelName : undefined,
-    ModelVersion: output.ModelVersion !== undefined && output.ModelVersion !== null ? output.ModelVersion : undefined,
+    ModelName: __expectString(output.ModelName),
+    ModelVersion: __expectString(output.ModelVersion),
   } as any;
 };
 
@@ -28384,11 +27782,10 @@ const deserializeAws_json1_1EdgePresetDeploymentOutput = (
   context: __SerdeContext
 ): EdgePresetDeploymentOutput => {
   return {
-    Artifact: output.Artifact !== undefined && output.Artifact !== null ? output.Artifact : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusMessage:
-      output.StatusMessage !== undefined && output.StatusMessage !== null ? output.StatusMessage : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Artifact: __expectString(output.Artifact),
+    Status: __expectString(output.Status),
+    StatusMessage: __expectString(output.StatusMessage),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -28409,16 +27806,11 @@ const deserializeAws_json1_1Endpoint = (output: any, context: __SerdeContext): E
       output.DataCaptureConfig !== undefined && output.DataCaptureConfig !== null
         ? deserializeAws_json1_1DataCaptureConfigSummary(output.DataCaptureConfig, context)
         : undefined,
-    EndpointArn: output.EndpointArn !== undefined && output.EndpointArn !== null ? output.EndpointArn : undefined,
-    EndpointConfigName:
-      output.EndpointConfigName !== undefined && output.EndpointConfigName !== null
-        ? output.EndpointConfigName
-        : undefined,
-    EndpointName: output.EndpointName !== undefined && output.EndpointName !== null ? output.EndpointName : undefined,
-    EndpointStatus:
-      output.EndpointStatus !== undefined && output.EndpointStatus !== null ? output.EndpointStatus : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
+    EndpointArn: __expectString(output.EndpointArn),
+    EndpointConfigName: __expectString(output.EndpointConfigName),
+    EndpointName: __expectString(output.EndpointName),
+    EndpointStatus: __expectString(output.EndpointStatus),
+    FailureReason: __expectString(output.FailureReason),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
@@ -28444,14 +27836,8 @@ const deserializeAws_json1_1EndpointConfigSummary = (output: any, context: __Ser
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    EndpointConfigArn:
-      output.EndpointConfigArn !== undefined && output.EndpointConfigArn !== null
-        ? output.EndpointConfigArn
-        : undefined,
-    EndpointConfigName:
-      output.EndpointConfigName !== undefined && output.EndpointConfigName !== null
-        ? output.EndpointConfigName
-        : undefined,
+    EndpointConfigArn: __expectString(output.EndpointConfigArn),
+    EndpointConfigName: __expectString(output.EndpointConfigName),
   } as any;
 };
 
@@ -28471,33 +27857,16 @@ const deserializeAws_json1_1EndpointConfigSummaryList = (
 
 const deserializeAws_json1_1EndpointInput = (output: any, context: __SerdeContext): EndpointInput => {
   return {
-    EndTimeOffset:
-      output.EndTimeOffset !== undefined && output.EndTimeOffset !== null ? output.EndTimeOffset : undefined,
-    EndpointName: output.EndpointName !== undefined && output.EndpointName !== null ? output.EndpointName : undefined,
-    FeaturesAttribute:
-      output.FeaturesAttribute !== undefined && output.FeaturesAttribute !== null
-        ? output.FeaturesAttribute
-        : undefined,
-    InferenceAttribute:
-      output.InferenceAttribute !== undefined && output.InferenceAttribute !== null
-        ? output.InferenceAttribute
-        : undefined,
-    LocalPath: output.LocalPath !== undefined && output.LocalPath !== null ? output.LocalPath : undefined,
-    ProbabilityAttribute:
-      output.ProbabilityAttribute !== undefined && output.ProbabilityAttribute !== null
-        ? output.ProbabilityAttribute
-        : undefined,
-    ProbabilityThresholdAttribute:
-      output.ProbabilityThresholdAttribute !== undefined && output.ProbabilityThresholdAttribute !== null
-        ? output.ProbabilityThresholdAttribute
-        : undefined,
-    S3DataDistributionType:
-      output.S3DataDistributionType !== undefined && output.S3DataDistributionType !== null
-        ? output.S3DataDistributionType
-        : undefined,
-    S3InputMode: output.S3InputMode !== undefined && output.S3InputMode !== null ? output.S3InputMode : undefined,
-    StartTimeOffset:
-      output.StartTimeOffset !== undefined && output.StartTimeOffset !== null ? output.StartTimeOffset : undefined,
+    EndTimeOffset: __expectString(output.EndTimeOffset),
+    EndpointName: __expectString(output.EndpointName),
+    FeaturesAttribute: __expectString(output.FeaturesAttribute),
+    InferenceAttribute: __expectString(output.InferenceAttribute),
+    LocalPath: __expectString(output.LocalPath),
+    ProbabilityAttribute: __expectString(output.ProbabilityAttribute),
+    ProbabilityThresholdAttribute: __expectNumber(output.ProbabilityThresholdAttribute),
+    S3DataDistributionType: __expectString(output.S3DataDistributionType),
+    S3InputMode: __expectString(output.S3InputMode),
+    StartTimeOffset: __expectString(output.StartTimeOffset),
   } as any;
 };
 
@@ -28507,10 +27876,9 @@ const deserializeAws_json1_1EndpointSummary = (output: any, context: __SerdeCont
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    EndpointArn: output.EndpointArn !== undefined && output.EndpointArn !== null ? output.EndpointArn : undefined,
-    EndpointName: output.EndpointName !== undefined && output.EndpointName !== null ? output.EndpointName : undefined,
-    EndpointStatus:
-      output.EndpointStatus !== undefined && output.EndpointStatus !== null ? output.EndpointStatus : undefined,
+    EndpointArn: __expectString(output.EndpointArn),
+    EndpointName: __expectString(output.EndpointName),
+    EndpointStatus: __expectString(output.EndpointStatus),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
@@ -28536,7 +27904,7 @@ const deserializeAws_json1_1EnvironmentMap = (output: any, context: __SerdeConte
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -28551,12 +27919,10 @@ const deserializeAws_json1_1Experiment = (output: any, context: __SerdeContext):
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    DisplayName: output.DisplayName !== undefined && output.DisplayName !== null ? output.DisplayName : undefined,
-    ExperimentArn:
-      output.ExperimentArn !== undefined && output.ExperimentArn !== null ? output.ExperimentArn : undefined,
-    ExperimentName:
-      output.ExperimentName !== undefined && output.ExperimentName !== null ? output.ExperimentName : undefined,
+    Description: __expectString(output.Description),
+    DisplayName: __expectString(output.DisplayName),
+    ExperimentArn: __expectString(output.ExperimentArn),
+    ExperimentName: __expectString(output.ExperimentName),
     LastModifiedBy:
       output.LastModifiedBy !== undefined && output.LastModifiedBy !== null
         ? deserializeAws_json1_1UserContext(output.LastModifiedBy, context)
@@ -28578,20 +27944,16 @@ const deserializeAws_json1_1Experiment = (output: any, context: __SerdeContext):
 
 const deserializeAws_json1_1ExperimentConfig = (output: any, context: __SerdeContext): ExperimentConfig => {
   return {
-    ExperimentName:
-      output.ExperimentName !== undefined && output.ExperimentName !== null ? output.ExperimentName : undefined,
-    TrialComponentDisplayName:
-      output.TrialComponentDisplayName !== undefined && output.TrialComponentDisplayName !== null
-        ? output.TrialComponentDisplayName
-        : undefined,
-    TrialName: output.TrialName !== undefined && output.TrialName !== null ? output.TrialName : undefined,
+    ExperimentName: __expectString(output.ExperimentName),
+    TrialComponentDisplayName: __expectString(output.TrialComponentDisplayName),
+    TrialName: __expectString(output.TrialName),
   } as any;
 };
 
 const deserializeAws_json1_1ExperimentSource = (output: any, context: __SerdeContext): ExperimentSource => {
   return {
-    SourceArn: output.SourceArn !== undefined && output.SourceArn !== null ? output.SourceArn : undefined,
-    SourceType: output.SourceType !== undefined && output.SourceType !== null ? output.SourceType : undefined,
+    SourceArn: __expectString(output.SourceArn),
+    SourceType: __expectString(output.SourceType),
   } as any;
 };
 
@@ -28612,11 +27974,9 @@ const deserializeAws_json1_1ExperimentSummary = (output: any, context: __SerdeCo
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    DisplayName: output.DisplayName !== undefined && output.DisplayName !== null ? output.DisplayName : undefined,
-    ExperimentArn:
-      output.ExperimentArn !== undefined && output.ExperimentArn !== null ? output.ExperimentArn : undefined,
-    ExperimentName:
-      output.ExperimentName !== undefined && output.ExperimentName !== null ? output.ExperimentName : undefined,
+    DisplayName: __expectString(output.DisplayName),
+    ExperimentArn: __expectString(output.ExperimentArn),
+    ExperimentName: __expectString(output.ExperimentName),
     ExperimentSource:
       output.ExperimentSource !== undefined && output.ExperimentSource !== null
         ? deserializeAws_json1_1ExperimentSource(output.ExperimentSource, context)
@@ -28639,8 +27999,8 @@ const deserializeAws_json1_1Explainability = (output: any, context: __SerdeConte
 
 const deserializeAws_json1_1FeatureDefinition = (output: any, context: __SerdeContext): FeatureDefinition => {
   return {
-    FeatureName: output.FeatureName !== undefined && output.FeatureName !== null ? output.FeatureName : undefined,
-    FeatureType: output.FeatureType !== undefined && output.FeatureType !== null ? output.FeatureType : undefined,
+    FeatureName: __expectString(output.FeatureName),
+    FeatureType: __expectString(output.FeatureType),
   } as any;
 };
 
@@ -28661,25 +28021,16 @@ const deserializeAws_json1_1FeatureGroup = (output: any, context: __SerdeContext
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    EventTimeFeatureName:
-      output.EventTimeFeatureName !== undefined && output.EventTimeFeatureName !== null
-        ? output.EventTimeFeatureName
-        : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
+    Description: __expectString(output.Description),
+    EventTimeFeatureName: __expectString(output.EventTimeFeatureName),
+    FailureReason: __expectString(output.FailureReason),
     FeatureDefinitions:
       output.FeatureDefinitions !== undefined && output.FeatureDefinitions !== null
         ? deserializeAws_json1_1FeatureDefinitions(output.FeatureDefinitions, context)
         : undefined,
-    FeatureGroupArn:
-      output.FeatureGroupArn !== undefined && output.FeatureGroupArn !== null ? output.FeatureGroupArn : undefined,
-    FeatureGroupName:
-      output.FeatureGroupName !== undefined && output.FeatureGroupName !== null ? output.FeatureGroupName : undefined,
-    FeatureGroupStatus:
-      output.FeatureGroupStatus !== undefined && output.FeatureGroupStatus !== null
-        ? output.FeatureGroupStatus
-        : undefined,
+    FeatureGroupArn: __expectString(output.FeatureGroupArn),
+    FeatureGroupName: __expectString(output.FeatureGroupName),
+    FeatureGroupStatus: __expectString(output.FeatureGroupStatus),
     OfflineStoreConfig:
       output.OfflineStoreConfig !== undefined && output.OfflineStoreConfig !== null
         ? deserializeAws_json1_1OfflineStoreConfig(output.OfflineStoreConfig, context)
@@ -28692,11 +28043,8 @@ const deserializeAws_json1_1FeatureGroup = (output: any, context: __SerdeContext
       output.OnlineStoreConfig !== undefined && output.OnlineStoreConfig !== null
         ? deserializeAws_json1_1OnlineStoreConfig(output.OnlineStoreConfig, context)
         : undefined,
-    RecordIdentifierFeatureName:
-      output.RecordIdentifierFeatureName !== undefined && output.RecordIdentifierFeatureName !== null
-        ? output.RecordIdentifierFeatureName
-        : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
+    RecordIdentifierFeatureName: __expectString(output.RecordIdentifierFeatureName),
+    RoleArn: __expectString(output.RoleArn),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_1TagList(output.Tags, context)
@@ -28721,14 +28069,9 @@ const deserializeAws_json1_1FeatureGroupSummary = (output: any, context: __Serde
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    FeatureGroupArn:
-      output.FeatureGroupArn !== undefined && output.FeatureGroupArn !== null ? output.FeatureGroupArn : undefined,
-    FeatureGroupName:
-      output.FeatureGroupName !== undefined && output.FeatureGroupName !== null ? output.FeatureGroupName : undefined,
-    FeatureGroupStatus:
-      output.FeatureGroupStatus !== undefined && output.FeatureGroupStatus !== null
-        ? output.FeatureGroupStatus
-        : undefined,
+    FeatureGroupArn: __expectString(output.FeatureGroupArn),
+    FeatureGroupName: __expectString(output.FeatureGroupName),
+    FeatureGroupStatus: __expectString(output.FeatureGroupStatus),
     OfflineStoreStatus:
       output.OfflineStoreStatus !== undefined && output.OfflineStoreStatus !== null
         ? deserializeAws_json1_1OfflineStoreStatus(output.OfflineStoreStatus, context)
@@ -28738,23 +28081,18 @@ const deserializeAws_json1_1FeatureGroupSummary = (output: any, context: __Serde
 
 const deserializeAws_json1_1FileSystemConfig = (output: any, context: __SerdeContext): FileSystemConfig => {
   return {
-    DefaultGid: output.DefaultGid !== undefined && output.DefaultGid !== null ? output.DefaultGid : undefined,
-    DefaultUid: output.DefaultUid !== undefined && output.DefaultUid !== null ? output.DefaultUid : undefined,
-    MountPath: output.MountPath !== undefined && output.MountPath !== null ? output.MountPath : undefined,
+    DefaultGid: __expectNumber(output.DefaultGid),
+    DefaultUid: __expectNumber(output.DefaultUid),
+    MountPath: __expectString(output.MountPath),
   } as any;
 };
 
 const deserializeAws_json1_1FileSystemDataSource = (output: any, context: __SerdeContext): FileSystemDataSource => {
   return {
-    DirectoryPath:
-      output.DirectoryPath !== undefined && output.DirectoryPath !== null ? output.DirectoryPath : undefined,
-    FileSystemAccessMode:
-      output.FileSystemAccessMode !== undefined && output.FileSystemAccessMode !== null
-        ? output.FileSystemAccessMode
-        : undefined,
-    FileSystemId: output.FileSystemId !== undefined && output.FileSystemId !== null ? output.FileSystemId : undefined,
-    FileSystemType:
-      output.FileSystemType !== undefined && output.FileSystemType !== null ? output.FileSystemType : undefined,
+    DirectoryPath: __expectString(output.DirectoryPath),
+    FileSystemAccessMode: __expectString(output.FileSystemAccessMode),
+    FileSystemId: __expectString(output.FileSystemId),
+    FileSystemType: __expectString(output.FileSystemType),
   } as any;
 };
 
@@ -28763,9 +28101,9 @@ const deserializeAws_json1_1FinalAutoMLJobObjectiveMetric = (
   context: __SerdeContext
 ): FinalAutoMLJobObjectiveMetric => {
   return {
-    MetricName: output.MetricName !== undefined && output.MetricName !== null ? output.MetricName : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    MetricName: __expectString(output.MetricName),
+    Type: __expectString(output.Type),
+    Value: __expectNumber(output.Value),
   } as any;
 };
 
@@ -28774,9 +28112,9 @@ const deserializeAws_json1_1FinalHyperParameterTuningJobObjectiveMetric = (
   context: __SerdeContext
 ): FinalHyperParameterTuningJobObjectiveMetric => {
   return {
-    MetricName: output.MetricName !== undefined && output.MetricName !== null ? output.MetricName : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    MetricName: __expectString(output.MetricName),
+    Type: __expectString(output.Type),
+    Value: __expectNumber(output.Value),
   } as any;
 };
 
@@ -28796,8 +28134,8 @@ const deserializeAws_json1_1FlowDefinitionOutputConfig = (
   context: __SerdeContext
 ): FlowDefinitionOutputConfig => {
   return {
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
-    S3OutputPath: output.S3OutputPath !== undefined && output.S3OutputPath !== null ? output.S3OutputPath : undefined,
+    KmsKeyId: __expectString(output.KmsKeyId),
+    S3OutputPath: __expectString(output.S3OutputPath),
   } as any;
 };
 
@@ -28821,20 +28159,10 @@ const deserializeAws_json1_1FlowDefinitionSummary = (output: any, context: __Ser
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
-    FlowDefinitionArn:
-      output.FlowDefinitionArn !== undefined && output.FlowDefinitionArn !== null
-        ? output.FlowDefinitionArn
-        : undefined,
-    FlowDefinitionName:
-      output.FlowDefinitionName !== undefined && output.FlowDefinitionName !== null
-        ? output.FlowDefinitionName
-        : undefined,
-    FlowDefinitionStatus:
-      output.FlowDefinitionStatus !== undefined && output.FlowDefinitionStatus !== null
-        ? output.FlowDefinitionStatus
-        : undefined,
+    FailureReason: __expectString(output.FailureReason),
+    FlowDefinitionArn: __expectString(output.FlowDefinitionArn),
+    FlowDefinitionName: __expectString(output.FlowDefinitionName),
+    FlowDefinitionStatus: __expectString(output.FlowDefinitionStatus),
   } as any;
 };
 
@@ -28845,7 +28173,7 @@ const deserializeAws_json1_1FlowDefinitionTaskKeywords = (output: any, context: 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -28858,11 +28186,9 @@ const deserializeAws_json1_1GetDeviceFleetReportResponse = (
       output.AgentVersions !== undefined && output.AgentVersions !== null
         ? deserializeAws_json1_1AgentVersions(output.AgentVersions, context)
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    DeviceFleetArn:
-      output.DeviceFleetArn !== undefined && output.DeviceFleetArn !== null ? output.DeviceFleetArn : undefined,
-    DeviceFleetName:
-      output.DeviceFleetName !== undefined && output.DeviceFleetName !== null ? output.DeviceFleetName : undefined,
+    Description: __expectString(output.Description),
+    DeviceFleetArn: __expectString(output.DeviceFleetArn),
+    DeviceFleetName: __expectString(output.DeviceFleetName),
     DeviceStats:
       output.DeviceStats !== undefined && output.DeviceStats !== null
         ? deserializeAws_json1_1DeviceStats(output.DeviceStats, context)
@@ -28887,8 +28213,7 @@ const deserializeAws_json1_1GetModelPackageGroupPolicyOutput = (
   context: __SerdeContext
 ): GetModelPackageGroupPolicyOutput => {
   return {
-    ResourcePolicy:
-      output.ResourcePolicy !== undefined && output.ResourcePolicy !== null ? output.ResourcePolicy : undefined,
+    ResourcePolicy: __expectString(output.ResourcePolicy),
   } as any;
 };
 
@@ -28897,7 +28222,7 @@ const deserializeAws_json1_1GetSagemakerServicecatalogPortfolioStatusOutput = (
   context: __SerdeContext
 ): GetSagemakerServicecatalogPortfolioStatusOutput => {
   return {
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -28915,10 +28240,9 @@ const deserializeAws_json1_1GetSearchSuggestionsResponse = (
 
 const deserializeAws_json1_1GitConfig = (output: any, context: __SerdeContext): GitConfig => {
   return {
-    Branch: output.Branch !== undefined && output.Branch !== null ? output.Branch : undefined,
-    RepositoryUrl:
-      output.RepositoryUrl !== undefined && output.RepositoryUrl !== null ? output.RepositoryUrl : undefined,
-    SecretArn: output.SecretArn !== undefined && output.SecretArn !== null ? output.SecretArn : undefined,
+    Branch: __expectString(output.Branch),
+    RepositoryUrl: __expectString(output.RepositoryUrl),
+    SecretArn: __expectString(output.SecretArn),
   } as any;
 };
 
@@ -28929,7 +28253,7 @@ const deserializeAws_json1_1Groups = (output: any, context: __SerdeContext): str
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -28940,7 +28264,7 @@ const deserializeAws_json1_1HookParameters = (output: any, context: __SerdeConte
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -28971,38 +28295,27 @@ const deserializeAws_json1_1HumanLoopActivationConfig = (
 
 const deserializeAws_json1_1HumanLoopConfig = (output: any, context: __SerdeContext): HumanLoopConfig => {
   return {
-    HumanTaskUiArn:
-      output.HumanTaskUiArn !== undefined && output.HumanTaskUiArn !== null ? output.HumanTaskUiArn : undefined,
+    HumanTaskUiArn: __expectString(output.HumanTaskUiArn),
     PublicWorkforceTaskPrice:
       output.PublicWorkforceTaskPrice !== undefined && output.PublicWorkforceTaskPrice !== null
         ? deserializeAws_json1_1PublicWorkforceTaskPrice(output.PublicWorkforceTaskPrice, context)
         : undefined,
-    TaskAvailabilityLifetimeInSeconds:
-      output.TaskAvailabilityLifetimeInSeconds !== undefined && output.TaskAvailabilityLifetimeInSeconds !== null
-        ? output.TaskAvailabilityLifetimeInSeconds
-        : undefined,
-    TaskCount: output.TaskCount !== undefined && output.TaskCount !== null ? output.TaskCount : undefined,
-    TaskDescription:
-      output.TaskDescription !== undefined && output.TaskDescription !== null ? output.TaskDescription : undefined,
+    TaskAvailabilityLifetimeInSeconds: __expectNumber(output.TaskAvailabilityLifetimeInSeconds),
+    TaskCount: __expectNumber(output.TaskCount),
+    TaskDescription: __expectString(output.TaskDescription),
     TaskKeywords:
       output.TaskKeywords !== undefined && output.TaskKeywords !== null
         ? deserializeAws_json1_1FlowDefinitionTaskKeywords(output.TaskKeywords, context)
         : undefined,
-    TaskTimeLimitInSeconds:
-      output.TaskTimeLimitInSeconds !== undefined && output.TaskTimeLimitInSeconds !== null
-        ? output.TaskTimeLimitInSeconds
-        : undefined,
-    TaskTitle: output.TaskTitle !== undefined && output.TaskTitle !== null ? output.TaskTitle : undefined,
-    WorkteamArn: output.WorkteamArn !== undefined && output.WorkteamArn !== null ? output.WorkteamArn : undefined,
+    TaskTimeLimitInSeconds: __expectNumber(output.TaskTimeLimitInSeconds),
+    TaskTitle: __expectString(output.TaskTitle),
+    WorkteamArn: __expectString(output.WorkteamArn),
   } as any;
 };
 
 const deserializeAws_json1_1HumanLoopRequestSource = (output: any, context: __SerdeContext): HumanLoopRequestSource => {
   return {
-    AwsManagedHumanLoopRequestSource:
-      output.AwsManagedHumanLoopRequestSource !== undefined && output.AwsManagedHumanLoopRequestSource !== null
-        ? output.AwsManagedHumanLoopRequestSource
-        : undefined,
+    AwsManagedHumanLoopRequestSource: __expectString(output.AwsManagedHumanLoopRequestSource),
   } as any;
 };
 
@@ -29012,42 +28325,26 @@ const deserializeAws_json1_1HumanTaskConfig = (output: any, context: __SerdeCont
       output.AnnotationConsolidationConfig !== undefined && output.AnnotationConsolidationConfig !== null
         ? deserializeAws_json1_1AnnotationConsolidationConfig(output.AnnotationConsolidationConfig, context)
         : undefined,
-    MaxConcurrentTaskCount:
-      output.MaxConcurrentTaskCount !== undefined && output.MaxConcurrentTaskCount !== null
-        ? output.MaxConcurrentTaskCount
-        : undefined,
-    NumberOfHumanWorkersPerDataObject:
-      output.NumberOfHumanWorkersPerDataObject !== undefined && output.NumberOfHumanWorkersPerDataObject !== null
-        ? output.NumberOfHumanWorkersPerDataObject
-        : undefined,
-    PreHumanTaskLambdaArn:
-      output.PreHumanTaskLambdaArn !== undefined && output.PreHumanTaskLambdaArn !== null
-        ? output.PreHumanTaskLambdaArn
-        : undefined,
+    MaxConcurrentTaskCount: __expectNumber(output.MaxConcurrentTaskCount),
+    NumberOfHumanWorkersPerDataObject: __expectNumber(output.NumberOfHumanWorkersPerDataObject),
+    PreHumanTaskLambdaArn: __expectString(output.PreHumanTaskLambdaArn),
     PublicWorkforceTaskPrice:
       output.PublicWorkforceTaskPrice !== undefined && output.PublicWorkforceTaskPrice !== null
         ? deserializeAws_json1_1PublicWorkforceTaskPrice(output.PublicWorkforceTaskPrice, context)
         : undefined,
-    TaskAvailabilityLifetimeInSeconds:
-      output.TaskAvailabilityLifetimeInSeconds !== undefined && output.TaskAvailabilityLifetimeInSeconds !== null
-        ? output.TaskAvailabilityLifetimeInSeconds
-        : undefined,
-    TaskDescription:
-      output.TaskDescription !== undefined && output.TaskDescription !== null ? output.TaskDescription : undefined,
+    TaskAvailabilityLifetimeInSeconds: __expectNumber(output.TaskAvailabilityLifetimeInSeconds),
+    TaskDescription: __expectString(output.TaskDescription),
     TaskKeywords:
       output.TaskKeywords !== undefined && output.TaskKeywords !== null
         ? deserializeAws_json1_1TaskKeywords(output.TaskKeywords, context)
         : undefined,
-    TaskTimeLimitInSeconds:
-      output.TaskTimeLimitInSeconds !== undefined && output.TaskTimeLimitInSeconds !== null
-        ? output.TaskTimeLimitInSeconds
-        : undefined,
-    TaskTitle: output.TaskTitle !== undefined && output.TaskTitle !== null ? output.TaskTitle : undefined,
+    TaskTimeLimitInSeconds: __expectNumber(output.TaskTimeLimitInSeconds),
+    TaskTitle: __expectString(output.TaskTitle),
     UiConfig:
       output.UiConfig !== undefined && output.UiConfig !== null
         ? deserializeAws_json1_1UiConfig(output.UiConfig, context)
         : undefined,
-    WorkteamArn: output.WorkteamArn !== undefined && output.WorkteamArn !== null ? output.WorkteamArn : undefined,
+    WorkteamArn: __expectString(output.WorkteamArn),
   } as any;
 };
 
@@ -29068,10 +28365,8 @@ const deserializeAws_json1_1HumanTaskUiSummary = (output: any, context: __SerdeC
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    HumanTaskUiArn:
-      output.HumanTaskUiArn !== undefined && output.HumanTaskUiArn !== null ? output.HumanTaskUiArn : undefined,
-    HumanTaskUiName:
-      output.HumanTaskUiName !== undefined && output.HumanTaskUiName !== null ? output.HumanTaskUiName : undefined,
+    HumanTaskUiArn: __expectString(output.HumanTaskUiArn),
+    HumanTaskUiName: __expectString(output.HumanTaskUiName),
   } as any;
 };
 
@@ -29080,18 +28375,13 @@ const deserializeAws_json1_1HyperParameterAlgorithmSpecification = (
   context: __SerdeContext
 ): HyperParameterAlgorithmSpecification => {
   return {
-    AlgorithmName:
-      output.AlgorithmName !== undefined && output.AlgorithmName !== null ? output.AlgorithmName : undefined,
+    AlgorithmName: __expectString(output.AlgorithmName),
     MetricDefinitions:
       output.MetricDefinitions !== undefined && output.MetricDefinitions !== null
         ? deserializeAws_json1_1MetricDefinitionList(output.MetricDefinitions, context)
         : undefined,
-    TrainingImage:
-      output.TrainingImage !== undefined && output.TrainingImage !== null ? output.TrainingImage : undefined,
-    TrainingInputMode:
-      output.TrainingInputMode !== undefined && output.TrainingInputMode !== null
-        ? output.TrainingInputMode
-        : undefined,
+    TrainingImage: __expectString(output.TrainingImage),
+    TrainingInputMode: __expectString(output.TrainingInputMode),
   } as any;
 };
 
@@ -29102,7 +28392,7 @@ const deserializeAws_json1_1HyperParameters = (output: any, context: __SerdeCont
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -29112,16 +28402,16 @@ const deserializeAws_json1_1HyperParameterSpecification = (
   context: __SerdeContext
 ): HyperParameterSpecification => {
   return {
-    DefaultValue: output.DefaultValue !== undefined && output.DefaultValue !== null ? output.DefaultValue : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    IsRequired: output.IsRequired !== undefined && output.IsRequired !== null ? output.IsRequired : undefined,
-    IsTunable: output.IsTunable !== undefined && output.IsTunable !== null ? output.IsTunable : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    DefaultValue: __expectString(output.DefaultValue),
+    Description: __expectString(output.Description),
+    IsRequired: __expectBoolean(output.IsRequired),
+    IsTunable: __expectBoolean(output.IsTunable),
+    Name: __expectString(output.Name),
     Range:
       output.Range !== undefined && output.Range !== null
         ? deserializeAws_json1_1ParameterRange(output.Range, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -29152,21 +28442,10 @@ const deserializeAws_json1_1HyperParameterTrainingJobDefinition = (
       output.CheckpointConfig !== undefined && output.CheckpointConfig !== null
         ? deserializeAws_json1_1CheckpointConfig(output.CheckpointConfig, context)
         : undefined,
-    DefinitionName:
-      output.DefinitionName !== undefined && output.DefinitionName !== null ? output.DefinitionName : undefined,
-    EnableInterContainerTrafficEncryption:
-      output.EnableInterContainerTrafficEncryption !== undefined &&
-      output.EnableInterContainerTrafficEncryption !== null
-        ? output.EnableInterContainerTrafficEncryption
-        : undefined,
-    EnableManagedSpotTraining:
-      output.EnableManagedSpotTraining !== undefined && output.EnableManagedSpotTraining !== null
-        ? output.EnableManagedSpotTraining
-        : undefined,
-    EnableNetworkIsolation:
-      output.EnableNetworkIsolation !== undefined && output.EnableNetworkIsolation !== null
-        ? output.EnableNetworkIsolation
-        : undefined,
+    DefinitionName: __expectString(output.DefinitionName),
+    EnableInterContainerTrafficEncryption: __expectBoolean(output.EnableInterContainerTrafficEncryption),
+    EnableManagedSpotTraining: __expectBoolean(output.EnableManagedSpotTraining),
+    EnableNetworkIsolation: __expectBoolean(output.EnableNetworkIsolation),
     HyperParameterRanges:
       output.HyperParameterRanges !== undefined && output.HyperParameterRanges !== null
         ? deserializeAws_json1_1ParameterRanges(output.HyperParameterRanges, context)
@@ -29187,7 +28466,7 @@ const deserializeAws_json1_1HyperParameterTrainingJobDefinition = (
       output.RetryStrategy !== undefined && output.RetryStrategy !== null
         ? deserializeAws_json1_1RetryStrategy(output.RetryStrategy, context)
         : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
+    RoleArn: __expectString(output.RoleArn),
     StaticHyperParameters:
       output.StaticHyperParameters !== undefined && output.StaticHyperParameters !== null
         ? deserializeAws_json1_1HyperParameters(output.StaticHyperParameters, context)
@@ -29244,8 +28523,7 @@ const deserializeAws_json1_1HyperParameterTrainingJobSummary = (
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
+    FailureReason: __expectString(output.FailureReason),
     FinalHyperParameterTuningJobObjectiveMetric:
       output.FinalHyperParameterTuningJobObjectiveMetric !== undefined &&
       output.FinalHyperParameterTuningJobObjectiveMetric !== null
@@ -29254,24 +28532,15 @@ const deserializeAws_json1_1HyperParameterTrainingJobSummary = (
             context
           )
         : undefined,
-    ObjectiveStatus:
-      output.ObjectiveStatus !== undefined && output.ObjectiveStatus !== null ? output.ObjectiveStatus : undefined,
+    ObjectiveStatus: __expectString(output.ObjectiveStatus),
     TrainingEndTime:
       output.TrainingEndTime !== undefined && output.TrainingEndTime !== null
         ? new Date(Math.round(output.TrainingEndTime * 1000))
         : undefined,
-    TrainingJobArn:
-      output.TrainingJobArn !== undefined && output.TrainingJobArn !== null ? output.TrainingJobArn : undefined,
-    TrainingJobDefinitionName:
-      output.TrainingJobDefinitionName !== undefined && output.TrainingJobDefinitionName !== null
-        ? output.TrainingJobDefinitionName
-        : undefined,
-    TrainingJobName:
-      output.TrainingJobName !== undefined && output.TrainingJobName !== null ? output.TrainingJobName : undefined,
-    TrainingJobStatus:
-      output.TrainingJobStatus !== undefined && output.TrainingJobStatus !== null
-        ? output.TrainingJobStatus
-        : undefined,
+    TrainingJobArn: __expectString(output.TrainingJobArn),
+    TrainingJobDefinitionName: __expectString(output.TrainingJobDefinitionName),
+    TrainingJobName: __expectString(output.TrainingJobName),
+    TrainingJobStatus: __expectString(output.TrainingJobStatus),
     TrainingStartTime:
       output.TrainingStartTime !== undefined && output.TrainingStartTime !== null
         ? new Date(Math.round(output.TrainingStartTime * 1000))
@@ -29280,8 +28549,7 @@ const deserializeAws_json1_1HyperParameterTrainingJobSummary = (
       output.TunedHyperParameters !== undefined && output.TunedHyperParameters !== null
         ? deserializeAws_json1_1HyperParameters(output.TunedHyperParameters, context)
         : undefined,
-    TuningJobName:
-      output.TuningJobName !== undefined && output.TuningJobName !== null ? output.TuningJobName : undefined,
+    TuningJobName: __expectString(output.TuningJobName),
   } as any;
 };
 
@@ -29302,11 +28570,8 @@ const deserializeAws_json1_1HyperParameterTuningJobConfig = (
       output.ResourceLimits !== undefined && output.ResourceLimits !== null
         ? deserializeAws_json1_1ResourceLimits(output.ResourceLimits, context)
         : undefined,
-    Strategy: output.Strategy !== undefined && output.Strategy !== null ? output.Strategy : undefined,
-    TrainingJobEarlyStoppingType:
-      output.TrainingJobEarlyStoppingType !== undefined && output.TrainingJobEarlyStoppingType !== null
-        ? output.TrainingJobEarlyStoppingType
-        : undefined,
+    Strategy: __expectString(output.Strategy),
+    TrainingJobEarlyStoppingType: __expectString(output.TrainingJobEarlyStoppingType),
     TuningJobCompletionCriteria:
       output.TuningJobCompletionCriteria !== undefined && output.TuningJobCompletionCriteria !== null
         ? deserializeAws_json1_1TuningJobCompletionCriteria(output.TuningJobCompletionCriteria, context)
@@ -29319,8 +28584,8 @@ const deserializeAws_json1_1HyperParameterTuningJobObjective = (
   context: __SerdeContext
 ): HyperParameterTuningJobObjective => {
   return {
-    MetricName: output.MetricName !== undefined && output.MetricName !== null ? output.MetricName : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    MetricName: __expectString(output.MetricName),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -29365,18 +28630,9 @@ const deserializeAws_json1_1HyperParameterTuningJobSummary = (
       output.HyperParameterTuningEndTime !== undefined && output.HyperParameterTuningEndTime !== null
         ? new Date(Math.round(output.HyperParameterTuningEndTime * 1000))
         : undefined,
-    HyperParameterTuningJobArn:
-      output.HyperParameterTuningJobArn !== undefined && output.HyperParameterTuningJobArn !== null
-        ? output.HyperParameterTuningJobArn
-        : undefined,
-    HyperParameterTuningJobName:
-      output.HyperParameterTuningJobName !== undefined && output.HyperParameterTuningJobName !== null
-        ? output.HyperParameterTuningJobName
-        : undefined,
-    HyperParameterTuningJobStatus:
-      output.HyperParameterTuningJobStatus !== undefined && output.HyperParameterTuningJobStatus !== null
-        ? output.HyperParameterTuningJobStatus
-        : undefined,
+    HyperParameterTuningJobArn: __expectString(output.HyperParameterTuningJobArn),
+    HyperParameterTuningJobName: __expectString(output.HyperParameterTuningJobName),
+    HyperParameterTuningJobStatus: __expectString(output.HyperParameterTuningJobStatus),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
@@ -29389,7 +28645,7 @@ const deserializeAws_json1_1HyperParameterTuningJobSummary = (
       output.ResourceLimits !== undefined && output.ResourceLimits !== null
         ? deserializeAws_json1_1ResourceLimits(output.ResourceLimits, context)
         : undefined,
-    Strategy: output.Strategy !== undefined && output.Strategy !== null ? output.Strategy : undefined,
+    Strategy: __expectString(output.Strategy),
     TrainingJobStatusCounters:
       output.TrainingJobStatusCounters !== undefined && output.TrainingJobStatusCounters !== null
         ? deserializeAws_json1_1TrainingJobStatusCounters(output.TrainingJobStatusCounters, context)
@@ -29406,8 +28662,7 @@ const deserializeAws_json1_1HyperParameterTuningJobWarmStartConfig = (
       output.ParentHyperParameterTuningJobs !== undefined && output.ParentHyperParameterTuningJobs !== null
         ? deserializeAws_json1_1ParentHyperParameterTuningJobs(output.ParentHyperParameterTuningJobs, context)
         : undefined,
-    WarmStartType:
-      output.WarmStartType !== undefined && output.WarmStartType !== null ? output.WarmStartType : undefined,
+    WarmStartType: __expectString(output.WarmStartType),
   } as any;
 };
 
@@ -29417,13 +28672,12 @@ const deserializeAws_json1_1Image = (output: any, context: __SerdeContext): Imag
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    DisplayName: output.DisplayName !== undefined && output.DisplayName !== null ? output.DisplayName : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
-    ImageArn: output.ImageArn !== undefined && output.ImageArn !== null ? output.ImageArn : undefined,
-    ImageName: output.ImageName !== undefined && output.ImageName !== null ? output.ImageName : undefined,
-    ImageStatus: output.ImageStatus !== undefined && output.ImageStatus !== null ? output.ImageStatus : undefined,
+    Description: __expectString(output.Description),
+    DisplayName: __expectString(output.DisplayName),
+    FailureReason: __expectString(output.FailureReason),
+    ImageArn: __expectString(output.ImageArn),
+    ImageName: __expectString(output.ImageName),
+    ImageStatus: __expectString(output.ImageStatus),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
@@ -29433,10 +28687,7 @@ const deserializeAws_json1_1Image = (output: any, context: __SerdeContext): Imag
 
 const deserializeAws_json1_1ImageConfig = (output: any, context: __SerdeContext): ImageConfig => {
   return {
-    RepositoryAccessMode:
-      output.RepositoryAccessMode !== undefined && output.RepositoryAccessMode !== null
-        ? output.RepositoryAccessMode
-        : undefined,
+    RepositoryAccessMode: __expectString(output.RepositoryAccessMode),
     RepositoryAuthConfig:
       output.RepositoryAuthConfig !== undefined && output.RepositoryAuthConfig !== null
         ? deserializeAws_json1_1RepositoryAuthConfig(output.RepositoryAuthConfig, context)
@@ -29461,20 +28712,15 @@ const deserializeAws_json1_1ImageVersion = (output: any, context: __SerdeContext
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
-    ImageArn: output.ImageArn !== undefined && output.ImageArn !== null ? output.ImageArn : undefined,
-    ImageVersionArn:
-      output.ImageVersionArn !== undefined && output.ImageVersionArn !== null ? output.ImageVersionArn : undefined,
-    ImageVersionStatus:
-      output.ImageVersionStatus !== undefined && output.ImageVersionStatus !== null
-        ? output.ImageVersionStatus
-        : undefined,
+    FailureReason: __expectString(output.FailureReason),
+    ImageArn: __expectString(output.ImageArn),
+    ImageVersionArn: __expectString(output.ImageVersionArn),
+    ImageVersionStatus: __expectString(output.ImageVersionStatus),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    Version: __expectNumber(output.Version),
   } as any;
 };
 
@@ -29494,7 +28740,7 @@ const deserializeAws_json1_1InferenceExecutionConfig = (
   context: __SerdeContext
 ): InferenceExecutionConfig => {
   return {
-    Mode: output.Mode !== undefined && output.Mode !== null ? output.Mode : undefined,
+    Mode: __expectString(output.Mode),
   } as any;
 };
 
@@ -29526,12 +28772,10 @@ const deserializeAws_json1_1InferenceSpecification = (output: any, context: __Se
 
 const deserializeAws_json1_1InputConfig = (output: any, context: __SerdeContext): InputConfig => {
   return {
-    DataInputConfig:
-      output.DataInputConfig !== undefined && output.DataInputConfig !== null ? output.DataInputConfig : undefined,
-    Framework: output.Framework !== undefined && output.Framework !== null ? output.Framework : undefined,
-    FrameworkVersion:
-      output.FrameworkVersion !== undefined && output.FrameworkVersion !== null ? output.FrameworkVersion : undefined,
-    S3Uri: output.S3Uri !== undefined && output.S3Uri !== null ? output.S3Uri : undefined,
+    DataInputConfig: __expectString(output.DataInputConfig),
+    Framework: __expectString(output.Framework),
+    FrameworkVersion: __expectString(output.FrameworkVersion),
+    S3Uri: __expectString(output.S3Uri),
   } as any;
 };
 
@@ -29553,16 +28797,16 @@ const deserializeAws_json1_1InputModes = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1IntegerParameterRange = (output: any, context: __SerdeContext): IntegerParameterRange => {
   return {
-    MaxValue: output.MaxValue !== undefined && output.MaxValue !== null ? output.MaxValue : undefined,
-    MinValue: output.MinValue !== undefined && output.MinValue !== null ? output.MinValue : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    ScalingType: output.ScalingType !== undefined && output.ScalingType !== null ? output.ScalingType : undefined,
+    MaxValue: __expectString(output.MaxValue),
+    MinValue: __expectString(output.MinValue),
+    Name: __expectString(output.Name),
+    ScalingType: __expectString(output.ScalingType),
   } as any;
 };
 
@@ -29585,8 +28829,8 @@ const deserializeAws_json1_1IntegerParameterRangeSpecification = (
   context: __SerdeContext
 ): IntegerParameterRangeSpecification => {
   return {
-    MaxValue: output.MaxValue !== undefined && output.MaxValue !== null ? output.MaxValue : undefined,
-    MinValue: output.MinValue !== undefined && output.MinValue !== null ? output.MinValue : undefined,
+    MaxValue: __expectString(output.MaxValue),
+    MinValue: __expectString(output.MinValue),
   } as any;
 };
 
@@ -29597,7 +28841,7 @@ const deserializeAws_json1_1JsonContentTypes = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -29647,8 +28891,8 @@ const deserializeAws_json1_1KernelGatewayImageConfig = (
 
 const deserializeAws_json1_1KernelSpec = (output: any, context: __SerdeContext): KernelSpec => {
   return {
-    DisplayName: output.DisplayName !== undefined && output.DisplayName !== null ? output.DisplayName : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    DisplayName: __expectString(output.DisplayName),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -29665,15 +28909,11 @@ const deserializeAws_json1_1KernelSpecs = (output: any, context: __SerdeContext)
 
 const deserializeAws_json1_1LabelCounters = (output: any, context: __SerdeContext): LabelCounters => {
   return {
-    FailedNonRetryableError:
-      output.FailedNonRetryableError !== undefined && output.FailedNonRetryableError !== null
-        ? output.FailedNonRetryableError
-        : undefined,
-    HumanLabeled: output.HumanLabeled !== undefined && output.HumanLabeled !== null ? output.HumanLabeled : undefined,
-    MachineLabeled:
-      output.MachineLabeled !== undefined && output.MachineLabeled !== null ? output.MachineLabeled : undefined,
-    TotalLabeled: output.TotalLabeled !== undefined && output.TotalLabeled !== null ? output.TotalLabeled : undefined,
-    Unlabeled: output.Unlabeled !== undefined && output.Unlabeled !== null ? output.Unlabeled : undefined,
+    FailedNonRetryableError: __expectNumber(output.FailedNonRetryableError),
+    HumanLabeled: __expectNumber(output.HumanLabeled),
+    MachineLabeled: __expectNumber(output.MachineLabeled),
+    TotalLabeled: __expectNumber(output.TotalLabeled),
+    Unlabeled: __expectNumber(output.Unlabeled),
   } as any;
 };
 
@@ -29682,9 +28922,9 @@ const deserializeAws_json1_1LabelCountersForWorkteam = (
   context: __SerdeContext
 ): LabelCountersForWorkteam => {
   return {
-    HumanLabeled: output.HumanLabeled !== undefined && output.HumanLabeled !== null ? output.HumanLabeled : undefined,
-    PendingHuman: output.PendingHuman !== undefined && output.PendingHuman !== null ? output.PendingHuman : undefined,
-    Total: output.Total !== undefined && output.Total !== null ? output.Total : undefined,
+    HumanLabeled: __expectNumber(output.HumanLabeled),
+    PendingHuman: __expectNumber(output.PendingHuman),
+    Total: __expectNumber(output.Total),
   } as any;
 };
 
@@ -29693,14 +28933,8 @@ const deserializeAws_json1_1LabelingJobAlgorithmsConfig = (
   context: __SerdeContext
 ): LabelingJobAlgorithmsConfig => {
   return {
-    InitialActiveLearningModelArn:
-      output.InitialActiveLearningModelArn !== undefined && output.InitialActiveLearningModelArn !== null
-        ? output.InitialActiveLearningModelArn
-        : undefined,
-    LabelingJobAlgorithmSpecificationArn:
-      output.LabelingJobAlgorithmSpecificationArn !== undefined && output.LabelingJobAlgorithmSpecificationArn !== null
-        ? output.LabelingJobAlgorithmSpecificationArn
-        : undefined,
+    InitialActiveLearningModelArn: __expectString(output.InitialActiveLearningModelArn),
+    LabelingJobAlgorithmSpecificationArn: __expectString(output.LabelingJobAlgorithmSpecificationArn),
     LabelingJobResourceConfig:
       output.LabelingJobResourceConfig !== undefined && output.LabelingJobResourceConfig !== null
         ? deserializeAws_json1_1LabelingJobResourceConfig(output.LabelingJobResourceConfig, context)
@@ -29742,22 +28976,14 @@ const deserializeAws_json1_1LabelingJobForWorkteamSummary = (
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    JobReferenceCode:
-      output.JobReferenceCode !== undefined && output.JobReferenceCode !== null ? output.JobReferenceCode : undefined,
+    JobReferenceCode: __expectString(output.JobReferenceCode),
     LabelCounters:
       output.LabelCounters !== undefined && output.LabelCounters !== null
         ? deserializeAws_json1_1LabelCountersForWorkteam(output.LabelCounters, context)
         : undefined,
-    LabelingJobName:
-      output.LabelingJobName !== undefined && output.LabelingJobName !== null ? output.LabelingJobName : undefined,
-    NumberOfHumanWorkersPerDataObject:
-      output.NumberOfHumanWorkersPerDataObject !== undefined && output.NumberOfHumanWorkersPerDataObject !== null
-        ? output.NumberOfHumanWorkersPerDataObject
-        : undefined,
-    WorkRequesterAccountId:
-      output.WorkRequesterAccountId !== undefined && output.WorkRequesterAccountId !== null
-        ? output.WorkRequesterAccountId
-        : undefined,
+    LabelingJobName: __expectString(output.LabelingJobName),
+    NumberOfHumanWorkersPerDataObject: __expectNumber(output.NumberOfHumanWorkersPerDataObject),
+    WorkRequesterAccountId: __expectString(output.WorkRequesterAccountId),
   } as any;
 };
 
@@ -29790,14 +29016,8 @@ const deserializeAws_json1_1LabelingJobInputConfig = (output: any, context: __Se
 
 const deserializeAws_json1_1LabelingJobOutput = (output: any, context: __SerdeContext): LabelingJobOutput => {
   return {
-    FinalActiveLearningModelArn:
-      output.FinalActiveLearningModelArn !== undefined && output.FinalActiveLearningModelArn !== null
-        ? output.FinalActiveLearningModelArn
-        : undefined,
-    OutputDatasetS3Uri:
-      output.OutputDatasetS3Uri !== undefined && output.OutputDatasetS3Uri !== null
-        ? output.OutputDatasetS3Uri
-        : undefined,
+    FinalActiveLearningModelArn: __expectString(output.FinalActiveLearningModelArn),
+    OutputDatasetS3Uri: __expectString(output.OutputDatasetS3Uri),
   } as any;
 };
 
@@ -29806,9 +29026,9 @@ const deserializeAws_json1_1LabelingJobOutputConfig = (
   context: __SerdeContext
 ): LabelingJobOutputConfig => {
   return {
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
-    S3OutputPath: output.S3OutputPath !== undefined && output.S3OutputPath !== null ? output.S3OutputPath : undefined,
-    SnsTopicArn: output.SnsTopicArn !== undefined && output.SnsTopicArn !== null ? output.SnsTopicArn : undefined,
+    KmsKeyId: __expectString(output.KmsKeyId),
+    S3OutputPath: __expectString(output.S3OutputPath),
+    SnsTopicArn: __expectString(output.SnsTopicArn),
   } as any;
 };
 
@@ -29817,8 +29037,7 @@ const deserializeAws_json1_1LabelingJobResourceConfig = (
   context: __SerdeContext
 ): LabelingJobResourceConfig => {
   return {
-    VolumeKmsKeyId:
-      output.VolumeKmsKeyId !== undefined && output.VolumeKmsKeyId !== null ? output.VolumeKmsKeyId : undefined,
+    VolumeKmsKeyId: __expectString(output.VolumeKmsKeyId),
   } as any;
 };
 
@@ -29827,8 +29046,7 @@ const deserializeAws_json1_1LabelingJobS3DataSource = (
   context: __SerdeContext
 ): LabelingJobS3DataSource => {
   return {
-    ManifestS3Uri:
-      output.ManifestS3Uri !== undefined && output.ManifestS3Uri !== null ? output.ManifestS3Uri : undefined,
+    ManifestS3Uri: __expectString(output.ManifestS3Uri),
   } as any;
 };
 
@@ -29837,7 +29055,7 @@ const deserializeAws_json1_1LabelingJobSnsDataSource = (
   context: __SerdeContext
 ): LabelingJobSnsDataSource => {
   return {
-    SnsTopicArn: output.SnsTopicArn !== undefined && output.SnsTopicArn !== null ? output.SnsTopicArn : undefined,
+    SnsTopicArn: __expectString(output.SnsTopicArn),
   } as any;
 };
 
@@ -29846,29 +29064,19 @@ const deserializeAws_json1_1LabelingJobStoppingConditions = (
   context: __SerdeContext
 ): LabelingJobStoppingConditions => {
   return {
-    MaxHumanLabeledObjectCount:
-      output.MaxHumanLabeledObjectCount !== undefined && output.MaxHumanLabeledObjectCount !== null
-        ? output.MaxHumanLabeledObjectCount
-        : undefined,
-    MaxPercentageOfInputDatasetLabeled:
-      output.MaxPercentageOfInputDatasetLabeled !== undefined && output.MaxPercentageOfInputDatasetLabeled !== null
-        ? output.MaxPercentageOfInputDatasetLabeled
-        : undefined,
+    MaxHumanLabeledObjectCount: __expectNumber(output.MaxHumanLabeledObjectCount),
+    MaxPercentageOfInputDatasetLabeled: __expectNumber(output.MaxPercentageOfInputDatasetLabeled),
   } as any;
 };
 
 const deserializeAws_json1_1LabelingJobSummary = (output: any, context: __SerdeContext): LabelingJobSummary => {
   return {
-    AnnotationConsolidationLambdaArn:
-      output.AnnotationConsolidationLambdaArn !== undefined && output.AnnotationConsolidationLambdaArn !== null
-        ? output.AnnotationConsolidationLambdaArn
-        : undefined,
+    AnnotationConsolidationLambdaArn: __expectString(output.AnnotationConsolidationLambdaArn),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
+    FailureReason: __expectString(output.FailureReason),
     InputConfig:
       output.InputConfig !== undefined && output.InputConfig !== null
         ? deserializeAws_json1_1LabelingJobInputConfig(output.InputConfig, context)
@@ -29877,27 +29085,19 @@ const deserializeAws_json1_1LabelingJobSummary = (output: any, context: __SerdeC
       output.LabelCounters !== undefined && output.LabelCounters !== null
         ? deserializeAws_json1_1LabelCounters(output.LabelCounters, context)
         : undefined,
-    LabelingJobArn:
-      output.LabelingJobArn !== undefined && output.LabelingJobArn !== null ? output.LabelingJobArn : undefined,
-    LabelingJobName:
-      output.LabelingJobName !== undefined && output.LabelingJobName !== null ? output.LabelingJobName : undefined,
+    LabelingJobArn: __expectString(output.LabelingJobArn),
+    LabelingJobName: __expectString(output.LabelingJobName),
     LabelingJobOutput:
       output.LabelingJobOutput !== undefined && output.LabelingJobOutput !== null
         ? deserializeAws_json1_1LabelingJobOutput(output.LabelingJobOutput, context)
         : undefined,
-    LabelingJobStatus:
-      output.LabelingJobStatus !== undefined && output.LabelingJobStatus !== null
-        ? output.LabelingJobStatus
-        : undefined,
+    LabelingJobStatus: __expectString(output.LabelingJobStatus),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    PreHumanTaskLambdaArn:
-      output.PreHumanTaskLambdaArn !== undefined && output.PreHumanTaskLambdaArn !== null
-        ? output.PreHumanTaskLambdaArn
-        : undefined,
-    WorkteamArn: output.WorkteamArn !== undefined && output.WorkteamArn !== null ? output.WorkteamArn : undefined,
+    PreHumanTaskLambdaArn: __expectString(output.PreHumanTaskLambdaArn),
+    WorkteamArn: __expectString(output.WorkteamArn),
   } as any;
 };
 
@@ -29922,7 +29122,7 @@ const deserializeAws_json1_1LineageEntityParameters = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -29933,7 +29133,7 @@ const deserializeAws_json1_1ListActionsResponse = (output: any, context: __Serde
       output.ActionSummaries !== undefined && output.ActionSummaries !== null
         ? deserializeAws_json1_1ActionSummaries(output.ActionSummaries, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -29943,7 +29143,7 @@ const deserializeAws_json1_1ListAlgorithmsOutput = (output: any, context: __Serd
       output.AlgorithmSummaryList !== undefined && output.AlgorithmSummaryList !== null
         ? deserializeAws_json1_1AlgorithmSummaryList(output.AlgorithmSummaryList, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -29956,7 +29156,7 @@ const deserializeAws_json1_1ListAppImageConfigsResponse = (
       output.AppImageConfigs !== undefined && output.AppImageConfigs !== null
         ? deserializeAws_json1_1AppImageConfigList(output.AppImageConfigs, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -29966,7 +29166,7 @@ const deserializeAws_json1_1ListAppsResponse = (output: any, context: __SerdeCon
       output.Apps !== undefined && output.Apps !== null
         ? deserializeAws_json1_1AppList(output.Apps, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -29976,7 +29176,7 @@ const deserializeAws_json1_1ListArtifactsResponse = (output: any, context: __Ser
       output.ArtifactSummaries !== undefined && output.ArtifactSummaries !== null
         ? deserializeAws_json1_1ArtifactSummaries(output.ArtifactSummaries, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -29989,7 +29189,7 @@ const deserializeAws_json1_1ListAssociationsResponse = (
       output.AssociationSummaries !== undefined && output.AssociationSummaries !== null
         ? deserializeAws_json1_1AssociationSummaries(output.AssociationSummaries, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -29999,7 +29199,7 @@ const deserializeAws_json1_1ListAutoMLJobsResponse = (output: any, context: __Se
       output.AutoMLJobSummaries !== undefined && output.AutoMLJobSummaries !== null
         ? deserializeAws_json1_1AutoMLJobSummaries(output.AutoMLJobSummaries, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -30012,7 +29212,7 @@ const deserializeAws_json1_1ListCandidatesForAutoMLJobResponse = (
       output.Candidates !== undefined && output.Candidates !== null
         ? deserializeAws_json1_1AutoMLCandidates(output.Candidates, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -30025,7 +29225,7 @@ const deserializeAws_json1_1ListCodeRepositoriesOutput = (
       output.CodeRepositorySummaryList !== undefined && output.CodeRepositorySummaryList !== null
         ? deserializeAws_json1_1CodeRepositorySummaryList(output.CodeRepositorySummaryList, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -30038,7 +29238,7 @@ const deserializeAws_json1_1ListCompilationJobsResponse = (
       output.CompilationJobSummaries !== undefined && output.CompilationJobSummaries !== null
         ? deserializeAws_json1_1CompilationJobSummaries(output.CompilationJobSummaries, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -30048,7 +29248,7 @@ const deserializeAws_json1_1ListContextsResponse = (output: any, context: __Serd
       output.ContextSummaries !== undefined && output.ContextSummaries !== null
         ? deserializeAws_json1_1ContextSummaries(output.ContextSummaries, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -30061,7 +29261,7 @@ const deserializeAws_json1_1ListDataQualityJobDefinitionsResponse = (
       output.JobDefinitionSummaries !== undefined && output.JobDefinitionSummaries !== null
         ? deserializeAws_json1_1MonitoringJobDefinitionSummaryList(output.JobDefinitionSummaries, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -30074,7 +29274,7 @@ const deserializeAws_json1_1ListDeviceFleetsResponse = (
       output.DeviceFleetSummaries !== undefined && output.DeviceFleetSummaries !== null
         ? deserializeAws_json1_1DeviceFleetSummaries(output.DeviceFleetSummaries, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -30084,7 +29284,7 @@ const deserializeAws_json1_1ListDevicesResponse = (output: any, context: __Serde
       output.DeviceSummaries !== undefined && output.DeviceSummaries !== null
         ? deserializeAws_json1_1DeviceSummaries(output.DeviceSummaries, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -30094,7 +29294,7 @@ const deserializeAws_json1_1ListDomainsResponse = (output: any, context: __Serde
       output.Domains !== undefined && output.Domains !== null
         ? deserializeAws_json1_1DomainList(output.Domains, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -30107,7 +29307,7 @@ const deserializeAws_json1_1ListEdgePackagingJobsResponse = (
       output.EdgePackagingJobSummaries !== undefined && output.EdgePackagingJobSummaries !== null
         ? deserializeAws_json1_1EdgePackagingJobSummaries(output.EdgePackagingJobSummaries, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -30120,7 +29320,7 @@ const deserializeAws_json1_1ListEndpointConfigsOutput = (
       output.EndpointConfigs !== undefined && output.EndpointConfigs !== null
         ? deserializeAws_json1_1EndpointConfigSummaryList(output.EndpointConfigs, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -30130,7 +29330,7 @@ const deserializeAws_json1_1ListEndpointsOutput = (output: any, context: __Serde
       output.Endpoints !== undefined && output.Endpoints !== null
         ? deserializeAws_json1_1EndpointSummaryList(output.Endpoints, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -30143,7 +29343,7 @@ const deserializeAws_json1_1ListExperimentsResponse = (
       output.ExperimentSummaries !== undefined && output.ExperimentSummaries !== null
         ? deserializeAws_json1_1ExperimentSummaries(output.ExperimentSummaries, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -30156,7 +29356,7 @@ const deserializeAws_json1_1ListFeatureGroupsResponse = (
       output.FeatureGroupSummaries !== undefined && output.FeatureGroupSummaries !== null
         ? deserializeAws_json1_1FeatureGroupSummaries(output.FeatureGroupSummaries, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -30169,7 +29369,7 @@ const deserializeAws_json1_1ListFlowDefinitionsResponse = (
       output.FlowDefinitionSummaries !== undefined && output.FlowDefinitionSummaries !== null
         ? deserializeAws_json1_1FlowDefinitionSummaries(output.FlowDefinitionSummaries, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -30182,7 +29382,7 @@ const deserializeAws_json1_1ListHumanTaskUisResponse = (
       output.HumanTaskUiSummaries !== undefined && output.HumanTaskUiSummaries !== null
         ? deserializeAws_json1_1HumanTaskUiSummaries(output.HumanTaskUiSummaries, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -30195,7 +29395,7 @@ const deserializeAws_json1_1ListHyperParameterTuningJobsResponse = (
       output.HyperParameterTuningJobSummaries !== undefined && output.HyperParameterTuningJobSummaries !== null
         ? deserializeAws_json1_1HyperParameterTuningJobSummaries(output.HyperParameterTuningJobSummaries, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -30205,7 +29405,7 @@ const deserializeAws_json1_1ListImagesResponse = (output: any, context: __SerdeC
       output.Images !== undefined && output.Images !== null
         ? deserializeAws_json1_1Images(output.Images, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -30218,7 +29418,7 @@ const deserializeAws_json1_1ListImageVersionsResponse = (
       output.ImageVersions !== undefined && output.ImageVersions !== null
         ? deserializeAws_json1_1ImageVersions(output.ImageVersions, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -30231,7 +29431,7 @@ const deserializeAws_json1_1ListLabelingJobsForWorkteamResponse = (
       output.LabelingJobSummaryList !== undefined && output.LabelingJobSummaryList !== null
         ? deserializeAws_json1_1LabelingJobForWorkteamSummaryList(output.LabelingJobSummaryList, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -30244,7 +29444,7 @@ const deserializeAws_json1_1ListLabelingJobsResponse = (
       output.LabelingJobSummaryList !== undefined && output.LabelingJobSummaryList !== null
         ? deserializeAws_json1_1LabelingJobSummaryList(output.LabelingJobSummaryList, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -30257,7 +29457,7 @@ const deserializeAws_json1_1ListModelBiasJobDefinitionsResponse = (
       output.JobDefinitionSummaries !== undefined && output.JobDefinitionSummaries !== null
         ? deserializeAws_json1_1MonitoringJobDefinitionSummaryList(output.JobDefinitionSummaries, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -30270,7 +29470,7 @@ const deserializeAws_json1_1ListModelExplainabilityJobDefinitionsResponse = (
       output.JobDefinitionSummaries !== undefined && output.JobDefinitionSummaries !== null
         ? deserializeAws_json1_1MonitoringJobDefinitionSummaryList(output.JobDefinitionSummaries, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -30283,7 +29483,7 @@ const deserializeAws_json1_1ListModelPackageGroupsOutput = (
       output.ModelPackageGroupSummaryList !== undefined && output.ModelPackageGroupSummaryList !== null
         ? deserializeAws_json1_1ModelPackageGroupSummaryList(output.ModelPackageGroupSummaryList, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -30296,7 +29496,7 @@ const deserializeAws_json1_1ListModelPackagesOutput = (
       output.ModelPackageSummaryList !== undefined && output.ModelPackageSummaryList !== null
         ? deserializeAws_json1_1ModelPackageSummaryList(output.ModelPackageSummaryList, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -30309,7 +29509,7 @@ const deserializeAws_json1_1ListModelQualityJobDefinitionsResponse = (
       output.JobDefinitionSummaries !== undefined && output.JobDefinitionSummaries !== null
         ? deserializeAws_json1_1MonitoringJobDefinitionSummaryList(output.JobDefinitionSummaries, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -30319,7 +29519,7 @@ const deserializeAws_json1_1ListModelsOutput = (output: any, context: __SerdeCon
       output.Models !== undefined && output.Models !== null
         ? deserializeAws_json1_1ModelSummaryList(output.Models, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -30332,7 +29532,7 @@ const deserializeAws_json1_1ListMonitoringExecutionsResponse = (
       output.MonitoringExecutionSummaries !== undefined && output.MonitoringExecutionSummaries !== null
         ? deserializeAws_json1_1MonitoringExecutionSummaryList(output.MonitoringExecutionSummaries, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -30345,7 +29545,7 @@ const deserializeAws_json1_1ListMonitoringSchedulesResponse = (
       output.MonitoringScheduleSummaries !== undefined && output.MonitoringScheduleSummaries !== null
         ? deserializeAws_json1_1MonitoringScheduleSummaryList(output.MonitoringScheduleSummaries, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -30354,7 +29554,7 @@ const deserializeAws_json1_1ListNotebookInstanceLifecycleConfigsOutput = (
   context: __SerdeContext
 ): ListNotebookInstanceLifecycleConfigsOutput => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     NotebookInstanceLifecycleConfigs:
       output.NotebookInstanceLifecycleConfigs !== undefined && output.NotebookInstanceLifecycleConfigs !== null
         ? deserializeAws_json1_1NotebookInstanceLifecycleConfigSummaryList(
@@ -30370,7 +29570,7 @@ const deserializeAws_json1_1ListNotebookInstancesOutput = (
   context: __SerdeContext
 ): ListNotebookInstancesOutput => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     NotebookInstances:
       output.NotebookInstances !== undefined && output.NotebookInstances !== null
         ? deserializeAws_json1_1NotebookInstanceSummaryList(output.NotebookInstances, context)
@@ -30383,7 +29583,7 @@ const deserializeAws_json1_1ListPipelineExecutionsResponse = (
   context: __SerdeContext
 ): ListPipelineExecutionsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     PipelineExecutionSummaries:
       output.PipelineExecutionSummaries !== undefined && output.PipelineExecutionSummaries !== null
         ? deserializeAws_json1_1PipelineExecutionSummaryList(output.PipelineExecutionSummaries, context)
@@ -30396,7 +29596,7 @@ const deserializeAws_json1_1ListPipelineExecutionStepsResponse = (
   context: __SerdeContext
 ): ListPipelineExecutionStepsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     PipelineExecutionSteps:
       output.PipelineExecutionSteps !== undefined && output.PipelineExecutionSteps !== null
         ? deserializeAws_json1_1PipelineExecutionStepList(output.PipelineExecutionSteps, context)
@@ -30409,7 +29609,7 @@ const deserializeAws_json1_1ListPipelineParametersForExecutionResponse = (
   context: __SerdeContext
 ): ListPipelineParametersForExecutionResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     PipelineParameters:
       output.PipelineParameters !== undefined && output.PipelineParameters !== null
         ? deserializeAws_json1_1ParameterList(output.PipelineParameters, context)
@@ -30419,7 +29619,7 @@ const deserializeAws_json1_1ListPipelineParametersForExecutionResponse = (
 
 const deserializeAws_json1_1ListPipelinesResponse = (output: any, context: __SerdeContext): ListPipelinesResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     PipelineSummaries:
       output.PipelineSummaries !== undefined && output.PipelineSummaries !== null
         ? deserializeAws_json1_1PipelineSummaryList(output.PipelineSummaries, context)
@@ -30432,7 +29632,7 @@ const deserializeAws_json1_1ListProcessingJobsResponse = (
   context: __SerdeContext
 ): ListProcessingJobsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     ProcessingJobSummaries:
       output.ProcessingJobSummaries !== undefined && output.ProcessingJobSummaries !== null
         ? deserializeAws_json1_1ProcessingJobSummaries(output.ProcessingJobSummaries, context)
@@ -30442,7 +29642,7 @@ const deserializeAws_json1_1ListProcessingJobsResponse = (
 
 const deserializeAws_json1_1ListProjectsOutput = (output: any, context: __SerdeContext): ListProjectsOutput => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     ProjectSummaryList:
       output.ProjectSummaryList !== undefined && output.ProjectSummaryList !== null
         ? deserializeAws_json1_1ProjectSummaryList(output.ProjectSummaryList, context)
@@ -30455,7 +29655,7 @@ const deserializeAws_json1_1ListSubscribedWorkteamsResponse = (
   context: __SerdeContext
 ): ListSubscribedWorkteamsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     SubscribedWorkteams:
       output.SubscribedWorkteams !== undefined && output.SubscribedWorkteams !== null
         ? deserializeAws_json1_1SubscribedWorkteams(output.SubscribedWorkteams, context)
@@ -30465,7 +29665,7 @@ const deserializeAws_json1_1ListSubscribedWorkteamsResponse = (
 
 const deserializeAws_json1_1ListTagsOutput = (output: any, context: __SerdeContext): ListTagsOutput => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_1TagList(output.Tags, context)
@@ -30478,7 +29678,7 @@ const deserializeAws_json1_1ListTrainingJobsForHyperParameterTuningJobResponse =
   context: __SerdeContext
 ): ListTrainingJobsForHyperParameterTuningJobResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     TrainingJobSummaries:
       output.TrainingJobSummaries !== undefined && output.TrainingJobSummaries !== null
         ? deserializeAws_json1_1HyperParameterTrainingJobSummaries(output.TrainingJobSummaries, context)
@@ -30491,7 +29691,7 @@ const deserializeAws_json1_1ListTrainingJobsResponse = (
   context: __SerdeContext
 ): ListTrainingJobsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     TrainingJobSummaries:
       output.TrainingJobSummaries !== undefined && output.TrainingJobSummaries !== null
         ? deserializeAws_json1_1TrainingJobSummaries(output.TrainingJobSummaries, context)
@@ -30504,7 +29704,7 @@ const deserializeAws_json1_1ListTransformJobsResponse = (
   context: __SerdeContext
 ): ListTransformJobsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     TransformJobSummaries:
       output.TransformJobSummaries !== undefined && output.TransformJobSummaries !== null
         ? deserializeAws_json1_1TransformJobSummaries(output.TransformJobSummaries, context)
@@ -30517,7 +29717,7 @@ const deserializeAws_json1_1ListTrialComponentsResponse = (
   context: __SerdeContext
 ): ListTrialComponentsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     TrialComponentSummaries:
       output.TrialComponentSummaries !== undefined && output.TrialComponentSummaries !== null
         ? deserializeAws_json1_1TrialComponentSummaries(output.TrialComponentSummaries, context)
@@ -30527,7 +29727,7 @@ const deserializeAws_json1_1ListTrialComponentsResponse = (
 
 const deserializeAws_json1_1ListTrialsResponse = (output: any, context: __SerdeContext): ListTrialsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     TrialSummaries:
       output.TrialSummaries !== undefined && output.TrialSummaries !== null
         ? deserializeAws_json1_1TrialSummaries(output.TrialSummaries, context)
@@ -30540,7 +29740,7 @@ const deserializeAws_json1_1ListUserProfilesResponse = (
   context: __SerdeContext
 ): ListUserProfilesResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     UserProfiles:
       output.UserProfiles !== undefined && output.UserProfiles !== null
         ? deserializeAws_json1_1UserProfileList(output.UserProfiles, context)
@@ -30550,7 +29750,7 @@ const deserializeAws_json1_1ListUserProfilesResponse = (
 
 const deserializeAws_json1_1ListWorkforcesResponse = (output: any, context: __SerdeContext): ListWorkforcesResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Workforces:
       output.Workforces !== undefined && output.Workforces !== null
         ? deserializeAws_json1_1Workforces(output.Workforces, context)
@@ -30560,7 +29760,7 @@ const deserializeAws_json1_1ListWorkforcesResponse = (output: any, context: __Se
 
 const deserializeAws_json1_1ListWorkteamsResponse = (output: any, context: __SerdeContext): ListWorkteamsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Workteams:
       output.Workteams !== undefined && output.Workteams !== null
         ? deserializeAws_json1_1Workteams(output.Workteams, context)
@@ -30594,28 +29794,28 @@ const deserializeAws_json1_1MemberDefinitions = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1MetadataProperties = (output: any, context: __SerdeContext): MetadataProperties => {
   return {
-    CommitId: output.CommitId !== undefined && output.CommitId !== null ? output.CommitId : undefined,
-    GeneratedBy: output.GeneratedBy !== undefined && output.GeneratedBy !== null ? output.GeneratedBy : undefined,
-    ProjectId: output.ProjectId !== undefined && output.ProjectId !== null ? output.ProjectId : undefined,
-    Repository: output.Repository !== undefined && output.Repository !== null ? output.Repository : undefined,
+    CommitId: __expectString(output.CommitId),
+    GeneratedBy: __expectString(output.GeneratedBy),
+    ProjectId: __expectString(output.ProjectId),
+    Repository: __expectString(output.Repository),
   } as any;
 };
 
 const deserializeAws_json1_1MetricData = (output: any, context: __SerdeContext): MetricData => {
   return {
-    MetricName: output.MetricName !== undefined && output.MetricName !== null ? output.MetricName : undefined,
+    MetricName: __expectString(output.MetricName),
     Timestamp:
       output.Timestamp !== undefined && output.Timestamp !== null
         ? new Date(Math.round(output.Timestamp * 1000))
         : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Value: __expectNumber(output.Value),
   } as any;
 };
 
 const deserializeAws_json1_1MetricDefinition = (output: any, context: __SerdeContext): MetricDefinition => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Regex: output.Regex !== undefined && output.Regex !== null ? output.Regex : undefined,
+    Name: __expectString(output.Name),
+    Regex: __expectString(output.Regex),
   } as any;
 };
 
@@ -30632,17 +29832,15 @@ const deserializeAws_json1_1MetricDefinitionList = (output: any, context: __Serd
 
 const deserializeAws_json1_1MetricsSource = (output: any, context: __SerdeContext): MetricsSource => {
   return {
-    ContentDigest:
-      output.ContentDigest !== undefined && output.ContentDigest !== null ? output.ContentDigest : undefined,
-    ContentType: output.ContentType !== undefined && output.ContentType !== null ? output.ContentType : undefined,
-    S3Uri: output.S3Uri !== undefined && output.S3Uri !== null ? output.S3Uri : undefined,
+    ContentDigest: __expectString(output.ContentDigest),
+    ContentType: __expectString(output.ContentType),
+    S3Uri: __expectString(output.S3Uri),
   } as any;
 };
 
 const deserializeAws_json1_1ModelArtifacts = (output: any, context: __SerdeContext): ModelArtifacts => {
   return {
-    S3ModelArtifacts:
-      output.S3ModelArtifacts !== undefined && output.S3ModelArtifacts !== null ? output.S3ModelArtifacts : undefined,
+    S3ModelArtifacts: __expectString(output.S3ModelArtifacts),
   } as any;
 };
 
@@ -30651,12 +29849,12 @@ const deserializeAws_json1_1ModelBiasAppSpecification = (
   context: __SerdeContext
 ): ModelBiasAppSpecification => {
   return {
-    ConfigUri: output.ConfigUri !== undefined && output.ConfigUri !== null ? output.ConfigUri : undefined,
+    ConfigUri: __expectString(output.ConfigUri),
     Environment:
       output.Environment !== undefined && output.Environment !== null
         ? deserializeAws_json1_1MonitoringEnvironmentMap(output.Environment, context)
         : undefined,
-    ImageUri: output.ImageUri !== undefined && output.ImageUri !== null ? output.ImageUri : undefined,
+    ImageUri: __expectString(output.ImageUri),
   } as any;
 };
 
@@ -30665,10 +29863,7 @@ const deserializeAws_json1_1ModelBiasBaselineConfig = (
   context: __SerdeContext
 ): ModelBiasBaselineConfig => {
   return {
-    BaseliningJobName:
-      output.BaseliningJobName !== undefined && output.BaseliningJobName !== null
-        ? output.BaseliningJobName
-        : undefined,
+    BaseliningJobName: __expectString(output.BaseliningJobName),
     ConstraintsResource:
       output.ConstraintsResource !== undefined && output.ConstraintsResource !== null
         ? deserializeAws_json1_1MonitoringConstraintsResource(output.ConstraintsResource, context)
@@ -30691,14 +29886,8 @@ const deserializeAws_json1_1ModelBiasJobInput = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1ModelClientConfig = (output: any, context: __SerdeContext): ModelClientConfig => {
   return {
-    InvocationsMaxRetries:
-      output.InvocationsMaxRetries !== undefined && output.InvocationsMaxRetries !== null
-        ? output.InvocationsMaxRetries
-        : undefined,
-    InvocationsTimeoutInSeconds:
-      output.InvocationsTimeoutInSeconds !== undefined && output.InvocationsTimeoutInSeconds !== null
-        ? output.InvocationsTimeoutInSeconds
-        : undefined,
+    InvocationsMaxRetries: __expectNumber(output.InvocationsMaxRetries),
+    InvocationsTimeoutInSeconds: __expectNumber(output.InvocationsTimeoutInSeconds),
   } as any;
 };
 
@@ -30717,24 +29906,20 @@ const deserializeAws_json1_1ModelDataQuality = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1ModelDeployConfig = (output: any, context: __SerdeContext): ModelDeployConfig => {
   return {
-    AutoGenerateEndpointName:
-      output.AutoGenerateEndpointName !== undefined && output.AutoGenerateEndpointName !== null
-        ? output.AutoGenerateEndpointName
-        : undefined,
-    EndpointName: output.EndpointName !== undefined && output.EndpointName !== null ? output.EndpointName : undefined,
+    AutoGenerateEndpointName: __expectBoolean(output.AutoGenerateEndpointName),
+    EndpointName: __expectString(output.EndpointName),
   } as any;
 };
 
 const deserializeAws_json1_1ModelDeployResult = (output: any, context: __SerdeContext): ModelDeployResult => {
   return {
-    EndpointName: output.EndpointName !== undefined && output.EndpointName !== null ? output.EndpointName : undefined,
+    EndpointName: __expectString(output.EndpointName),
   } as any;
 };
 
 const deserializeAws_json1_1ModelDigests = (output: any, context: __SerdeContext): ModelDigests => {
   return {
-    ArtifactDigest:
-      output.ArtifactDigest !== undefined && output.ArtifactDigest !== null ? output.ArtifactDigest : undefined,
+    ArtifactDigest: __expectString(output.ArtifactDigest),
   } as any;
 };
 
@@ -30743,12 +29928,12 @@ const deserializeAws_json1_1ModelExplainabilityAppSpecification = (
   context: __SerdeContext
 ): ModelExplainabilityAppSpecification => {
   return {
-    ConfigUri: output.ConfigUri !== undefined && output.ConfigUri !== null ? output.ConfigUri : undefined,
+    ConfigUri: __expectString(output.ConfigUri),
     Environment:
       output.Environment !== undefined && output.Environment !== null
         ? deserializeAws_json1_1MonitoringEnvironmentMap(output.Environment, context)
         : undefined,
-    ImageUri: output.ImageUri !== undefined && output.ImageUri !== null ? output.ImageUri : undefined,
+    ImageUri: __expectString(output.ImageUri),
   } as any;
 };
 
@@ -30757,10 +29942,7 @@ const deserializeAws_json1_1ModelExplainabilityBaselineConfig = (
   context: __SerdeContext
 ): ModelExplainabilityBaselineConfig => {
   return {
-    BaseliningJobName:
-      output.BaseliningJobName !== undefined && output.BaseliningJobName !== null
-        ? output.BaseliningJobName
-        : undefined,
+    BaseliningJobName: __expectString(output.BaseliningJobName),
     ConstraintsResource:
       output.ConstraintsResource !== undefined && output.ConstraintsResource !== null
         ? deserializeAws_json1_1MonitoringConstraintsResource(output.ConstraintsResource, context)
@@ -30801,14 +29983,8 @@ const deserializeAws_json1_1ModelMetrics = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_1ModelPackage = (output: any, context: __SerdeContext): ModelPackage => {
   return {
-    ApprovalDescription:
-      output.ApprovalDescription !== undefined && output.ApprovalDescription !== null
-        ? output.ApprovalDescription
-        : undefined,
-    CertifyForMarketplace:
-      output.CertifyForMarketplace !== undefined && output.CertifyForMarketplace !== null
-        ? output.CertifyForMarketplace
-        : undefined,
+    ApprovalDescription: __expectString(output.ApprovalDescription),
+    CertifyForMarketplace: __expectBoolean(output.CertifyForMarketplace),
     CreatedBy:
       output.CreatedBy !== undefined && output.CreatedBy !== null
         ? deserializeAws_json1_1UserContext(output.CreatedBy, context)
@@ -30833,38 +30009,21 @@ const deserializeAws_json1_1ModelPackage = (output: any, context: __SerdeContext
       output.MetadataProperties !== undefined && output.MetadataProperties !== null
         ? deserializeAws_json1_1MetadataProperties(output.MetadataProperties, context)
         : undefined,
-    ModelApprovalStatus:
-      output.ModelApprovalStatus !== undefined && output.ModelApprovalStatus !== null
-        ? output.ModelApprovalStatus
-        : undefined,
+    ModelApprovalStatus: __expectString(output.ModelApprovalStatus),
     ModelMetrics:
       output.ModelMetrics !== undefined && output.ModelMetrics !== null
         ? deserializeAws_json1_1ModelMetrics(output.ModelMetrics, context)
         : undefined,
-    ModelPackageArn:
-      output.ModelPackageArn !== undefined && output.ModelPackageArn !== null ? output.ModelPackageArn : undefined,
-    ModelPackageDescription:
-      output.ModelPackageDescription !== undefined && output.ModelPackageDescription !== null
-        ? output.ModelPackageDescription
-        : undefined,
-    ModelPackageGroupName:
-      output.ModelPackageGroupName !== undefined && output.ModelPackageGroupName !== null
-        ? output.ModelPackageGroupName
-        : undefined,
-    ModelPackageName:
-      output.ModelPackageName !== undefined && output.ModelPackageName !== null ? output.ModelPackageName : undefined,
-    ModelPackageStatus:
-      output.ModelPackageStatus !== undefined && output.ModelPackageStatus !== null
-        ? output.ModelPackageStatus
-        : undefined,
+    ModelPackageArn: __expectString(output.ModelPackageArn),
+    ModelPackageDescription: __expectString(output.ModelPackageDescription),
+    ModelPackageGroupName: __expectString(output.ModelPackageGroupName),
+    ModelPackageName: __expectString(output.ModelPackageName),
+    ModelPackageStatus: __expectString(output.ModelPackageStatus),
     ModelPackageStatusDetails:
       output.ModelPackageStatusDetails !== undefined && output.ModelPackageStatusDetails !== null
         ? deserializeAws_json1_1ModelPackageStatusDetails(output.ModelPackageStatusDetails, context)
         : undefined,
-    ModelPackageVersion:
-      output.ModelPackageVersion !== undefined && output.ModelPackageVersion !== null
-        ? output.ModelPackageVersion
-        : undefined,
+    ModelPackageVersion: __expectNumber(output.ModelPackageVersion),
     SourceAlgorithmSpecification:
       output.SourceAlgorithmSpecification !== undefined && output.SourceAlgorithmSpecification !== null
         ? deserializeAws_json1_1SourceAlgorithmSpecification(output.SourceAlgorithmSpecification, context)
@@ -30885,14 +30044,11 @@ const deserializeAws_json1_1ModelPackageContainerDefinition = (
   context: __SerdeContext
 ): ModelPackageContainerDefinition => {
   return {
-    ContainerHostname:
-      output.ContainerHostname !== undefined && output.ContainerHostname !== null
-        ? output.ContainerHostname
-        : undefined,
-    Image: output.Image !== undefined && output.Image !== null ? output.Image : undefined,
-    ImageDigest: output.ImageDigest !== undefined && output.ImageDigest !== null ? output.ImageDigest : undefined,
-    ModelDataUrl: output.ModelDataUrl !== undefined && output.ModelDataUrl !== null ? output.ModelDataUrl : undefined,
-    ProductId: output.ProductId !== undefined && output.ProductId !== null ? output.ProductId : undefined,
+    ContainerHostname: __expectString(output.ContainerHostname),
+    Image: __expectString(output.Image),
+    ImageDigest: __expectString(output.ImageDigest),
+    ModelDataUrl: __expectString(output.ModelDataUrl),
+    ProductId: __expectString(output.ProductId),
   } as any;
 };
 
@@ -30920,22 +30076,10 @@ const deserializeAws_json1_1ModelPackageGroup = (output: any, context: __SerdeCo
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    ModelPackageGroupArn:
-      output.ModelPackageGroupArn !== undefined && output.ModelPackageGroupArn !== null
-        ? output.ModelPackageGroupArn
-        : undefined,
-    ModelPackageGroupDescription:
-      output.ModelPackageGroupDescription !== undefined && output.ModelPackageGroupDescription !== null
-        ? output.ModelPackageGroupDescription
-        : undefined,
-    ModelPackageGroupName:
-      output.ModelPackageGroupName !== undefined && output.ModelPackageGroupName !== null
-        ? output.ModelPackageGroupName
-        : undefined,
-    ModelPackageGroupStatus:
-      output.ModelPackageGroupStatus !== undefined && output.ModelPackageGroupStatus !== null
-        ? output.ModelPackageGroupStatus
-        : undefined,
+    ModelPackageGroupArn: __expectString(output.ModelPackageGroupArn),
+    ModelPackageGroupDescription: __expectString(output.ModelPackageGroupDescription),
+    ModelPackageGroupName: __expectString(output.ModelPackageGroupName),
+    ModelPackageGroupStatus: __expectString(output.ModelPackageGroupStatus),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_1TagList(output.Tags, context)
@@ -30952,22 +30096,10 @@ const deserializeAws_json1_1ModelPackageGroupSummary = (
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    ModelPackageGroupArn:
-      output.ModelPackageGroupArn !== undefined && output.ModelPackageGroupArn !== null
-        ? output.ModelPackageGroupArn
-        : undefined,
-    ModelPackageGroupDescription:
-      output.ModelPackageGroupDescription !== undefined && output.ModelPackageGroupDescription !== null
-        ? output.ModelPackageGroupDescription
-        : undefined,
-    ModelPackageGroupName:
-      output.ModelPackageGroupName !== undefined && output.ModelPackageGroupName !== null
-        ? output.ModelPackageGroupName
-        : undefined,
-    ModelPackageGroupStatus:
-      output.ModelPackageGroupStatus !== undefined && output.ModelPackageGroupStatus !== null
-        ? output.ModelPackageGroupStatus
-        : undefined,
+    ModelPackageGroupArn: __expectString(output.ModelPackageGroupArn),
+    ModelPackageGroupDescription: __expectString(output.ModelPackageGroupDescription),
+    ModelPackageGroupName: __expectString(output.ModelPackageGroupName),
+    ModelPackageGroupStatus: __expectString(output.ModelPackageGroupStatus),
   } as any;
 };
 
@@ -31003,10 +30135,9 @@ const deserializeAws_json1_1ModelPackageStatusDetails = (
 
 const deserializeAws_json1_1ModelPackageStatusItem = (output: any, context: __SerdeContext): ModelPackageStatusItem => {
   return {
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    FailureReason: __expectString(output.FailureReason),
+    Name: __expectString(output.Name),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -31030,30 +30161,13 @@ const deserializeAws_json1_1ModelPackageSummary = (output: any, context: __Serde
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    ModelApprovalStatus:
-      output.ModelApprovalStatus !== undefined && output.ModelApprovalStatus !== null
-        ? output.ModelApprovalStatus
-        : undefined,
-    ModelPackageArn:
-      output.ModelPackageArn !== undefined && output.ModelPackageArn !== null ? output.ModelPackageArn : undefined,
-    ModelPackageDescription:
-      output.ModelPackageDescription !== undefined && output.ModelPackageDescription !== null
-        ? output.ModelPackageDescription
-        : undefined,
-    ModelPackageGroupName:
-      output.ModelPackageGroupName !== undefined && output.ModelPackageGroupName !== null
-        ? output.ModelPackageGroupName
-        : undefined,
-    ModelPackageName:
-      output.ModelPackageName !== undefined && output.ModelPackageName !== null ? output.ModelPackageName : undefined,
-    ModelPackageStatus:
-      output.ModelPackageStatus !== undefined && output.ModelPackageStatus !== null
-        ? output.ModelPackageStatus
-        : undefined,
-    ModelPackageVersion:
-      output.ModelPackageVersion !== undefined && output.ModelPackageVersion !== null
-        ? output.ModelPackageVersion
-        : undefined,
+    ModelApprovalStatus: __expectString(output.ModelApprovalStatus),
+    ModelPackageArn: __expectString(output.ModelPackageArn),
+    ModelPackageDescription: __expectString(output.ModelPackageDescription),
+    ModelPackageGroupName: __expectString(output.ModelPackageGroupName),
+    ModelPackageName: __expectString(output.ModelPackageName),
+    ModelPackageStatus: __expectString(output.ModelPackageStatus),
+    ModelPackageVersion: __expectNumber(output.ModelPackageVersion),
   } as any;
 };
 
@@ -31073,7 +30187,7 @@ const deserializeAws_json1_1ModelPackageValidationProfile = (
   context: __SerdeContext
 ): ModelPackageValidationProfile => {
   return {
-    ProfileName: output.ProfileName !== undefined && output.ProfileName !== null ? output.ProfileName : undefined,
+    ProfileName: __expectString(output.ProfileName),
     TransformJobDefinition:
       output.TransformJobDefinition !== undefined && output.TransformJobDefinition !== null
         ? deserializeAws_json1_1TransformJobDefinition(output.TransformJobDefinition, context)
@@ -31104,8 +30218,7 @@ const deserializeAws_json1_1ModelPackageValidationSpecification = (
       output.ValidationProfiles !== undefined && output.ValidationProfiles !== null
         ? deserializeAws_json1_1ModelPackageValidationProfiles(output.ValidationProfiles, context)
         : undefined,
-    ValidationRole:
-      output.ValidationRole !== undefined && output.ValidationRole !== null ? output.ValidationRole : undefined,
+    ValidationRole: __expectString(output.ValidationRole),
   } as any;
 };
 
@@ -31139,16 +30252,10 @@ const deserializeAws_json1_1ModelQualityAppSpecification = (
       output.Environment !== undefined && output.Environment !== null
         ? deserializeAws_json1_1MonitoringEnvironmentMap(output.Environment, context)
         : undefined,
-    ImageUri: output.ImageUri !== undefined && output.ImageUri !== null ? output.ImageUri : undefined,
-    PostAnalyticsProcessorSourceUri:
-      output.PostAnalyticsProcessorSourceUri !== undefined && output.PostAnalyticsProcessorSourceUri !== null
-        ? output.PostAnalyticsProcessorSourceUri
-        : undefined,
-    ProblemType: output.ProblemType !== undefined && output.ProblemType !== null ? output.ProblemType : undefined,
-    RecordPreprocessorSourceUri:
-      output.RecordPreprocessorSourceUri !== undefined && output.RecordPreprocessorSourceUri !== null
-        ? output.RecordPreprocessorSourceUri
-        : undefined,
+    ImageUri: __expectString(output.ImageUri),
+    PostAnalyticsProcessorSourceUri: __expectString(output.PostAnalyticsProcessorSourceUri),
+    ProblemType: __expectString(output.ProblemType),
+    RecordPreprocessorSourceUri: __expectString(output.RecordPreprocessorSourceUri),
   } as any;
 };
 
@@ -31157,10 +30264,7 @@ const deserializeAws_json1_1ModelQualityBaselineConfig = (
   context: __SerdeContext
 ): ModelQualityBaselineConfig => {
   return {
-    BaseliningJobName:
-      output.BaseliningJobName !== undefined && output.BaseliningJobName !== null
-        ? output.BaseliningJobName
-        : undefined,
+    BaseliningJobName: __expectString(output.BaseliningJobName),
     ConstraintsResource:
       output.ConstraintsResource !== undefined && output.ConstraintsResource !== null
         ? deserializeAws_json1_1MonitoringConstraintsResource(output.ConstraintsResource, context)
@@ -31183,7 +30287,7 @@ const deserializeAws_json1_1ModelQualityJobInput = (output: any, context: __Serd
 
 const deserializeAws_json1_1ModelStepMetadata = (output: any, context: __SerdeContext): ModelStepMetadata => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
   } as any;
 };
 
@@ -31193,8 +30297,8 @@ const deserializeAws_json1_1ModelSummary = (output: any, context: __SerdeContext
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    ModelArn: output.ModelArn !== undefined && output.ModelArn !== null ? output.ModelArn : undefined,
-    ModelName: output.ModelName !== undefined && output.ModelName !== null ? output.ModelName : undefined,
+    ModelArn: __expectString(output.ModelArn),
+    ModelName: __expectString(output.ModelName),
   } as any;
 };
 
@@ -31222,15 +30326,9 @@ const deserializeAws_json1_1MonitoringAppSpecification = (
       output.ContainerEntrypoint !== undefined && output.ContainerEntrypoint !== null
         ? deserializeAws_json1_1ContainerEntrypoint(output.ContainerEntrypoint, context)
         : undefined,
-    ImageUri: output.ImageUri !== undefined && output.ImageUri !== null ? output.ImageUri : undefined,
-    PostAnalyticsProcessorSourceUri:
-      output.PostAnalyticsProcessorSourceUri !== undefined && output.PostAnalyticsProcessorSourceUri !== null
-        ? output.PostAnalyticsProcessorSourceUri
-        : undefined,
-    RecordPreprocessorSourceUri:
-      output.RecordPreprocessorSourceUri !== undefined && output.RecordPreprocessorSourceUri !== null
-        ? output.RecordPreprocessorSourceUri
-        : undefined,
+    ImageUri: __expectString(output.ImageUri),
+    PostAnalyticsProcessorSourceUri: __expectString(output.PostAnalyticsProcessorSourceUri),
+    RecordPreprocessorSourceUri: __expectString(output.RecordPreprocessorSourceUri),
   } as any;
 };
 
@@ -31239,10 +30337,7 @@ const deserializeAws_json1_1MonitoringBaselineConfig = (
   context: __SerdeContext
 ): MonitoringBaselineConfig => {
   return {
-    BaseliningJobName:
-      output.BaseliningJobName !== undefined && output.BaseliningJobName !== null
-        ? output.BaseliningJobName
-        : undefined,
+    BaseliningJobName: __expectString(output.BaseliningJobName),
     ConstraintsResource:
       output.ConstraintsResource !== undefined && output.ConstraintsResource !== null
         ? deserializeAws_json1_1MonitoringConstraintsResource(output.ConstraintsResource, context)
@@ -31259,13 +30354,10 @@ const deserializeAws_json1_1MonitoringClusterConfig = (
   context: __SerdeContext
 ): MonitoringClusterConfig => {
   return {
-    InstanceCount:
-      output.InstanceCount !== undefined && output.InstanceCount !== null ? output.InstanceCount : undefined,
-    InstanceType: output.InstanceType !== undefined && output.InstanceType !== null ? output.InstanceType : undefined,
-    VolumeKmsKeyId:
-      output.VolumeKmsKeyId !== undefined && output.VolumeKmsKeyId !== null ? output.VolumeKmsKeyId : undefined,
-    VolumeSizeInGB:
-      output.VolumeSizeInGB !== undefined && output.VolumeSizeInGB !== null ? output.VolumeSizeInGB : undefined,
+    InstanceCount: __expectNumber(output.InstanceCount),
+    InstanceType: __expectString(output.InstanceType),
+    VolumeKmsKeyId: __expectString(output.VolumeKmsKeyId),
+    VolumeSizeInGB: __expectNumber(output.VolumeSizeInGB),
   } as any;
 };
 
@@ -31274,7 +30366,7 @@ const deserializeAws_json1_1MonitoringConstraintsResource = (
   context: __SerdeContext
 ): MonitoringConstraintsResource => {
   return {
-    S3Uri: output.S3Uri !== undefined && output.S3Uri !== null ? output.S3Uri : undefined,
+    S3Uri: __expectString(output.S3Uri),
   } as any;
 };
 
@@ -31285,7 +30377,7 @@ const deserializeAws_json1_1MonitoringContainerArguments = (output: any, context
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -31299,7 +30391,7 @@ const deserializeAws_json1_1MonitoringEnvironmentMap = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -31313,29 +30405,17 @@ const deserializeAws_json1_1MonitoringExecutionSummary = (
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    EndpointName: output.EndpointName !== undefined && output.EndpointName !== null ? output.EndpointName : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
+    EndpointName: __expectString(output.EndpointName),
+    FailureReason: __expectString(output.FailureReason),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    MonitoringExecutionStatus:
-      output.MonitoringExecutionStatus !== undefined && output.MonitoringExecutionStatus !== null
-        ? output.MonitoringExecutionStatus
-        : undefined,
-    MonitoringJobDefinitionName:
-      output.MonitoringJobDefinitionName !== undefined && output.MonitoringJobDefinitionName !== null
-        ? output.MonitoringJobDefinitionName
-        : undefined,
-    MonitoringScheduleName:
-      output.MonitoringScheduleName !== undefined && output.MonitoringScheduleName !== null
-        ? output.MonitoringScheduleName
-        : undefined,
-    MonitoringType:
-      output.MonitoringType !== undefined && output.MonitoringType !== null ? output.MonitoringType : undefined,
-    ProcessingJobArn:
-      output.ProcessingJobArn !== undefined && output.ProcessingJobArn !== null ? output.ProcessingJobArn : undefined,
+    MonitoringExecutionStatus: __expectString(output.MonitoringExecutionStatus),
+    MonitoringJobDefinitionName: __expectString(output.MonitoringJobDefinitionName),
+    MonitoringScheduleName: __expectString(output.MonitoringScheduleName),
+    MonitoringType: __expectString(output.MonitoringType),
+    ProcessingJobArn: __expectString(output.ProcessingJobArn),
     ScheduledTime:
       output.ScheduledTime !== undefined && output.ScheduledTime !== null
         ? new Date(Math.round(output.ScheduledTime * 1000))
@@ -31362,7 +30442,7 @@ const deserializeAws_json1_1MonitoringGroundTruthS3Input = (
   context: __SerdeContext
 ): MonitoringGroundTruthS3Input => {
   return {
-    S3Uri: output.S3Uri !== undefined && output.S3Uri !== null ? output.S3Uri : undefined,
+    S3Uri: __expectString(output.S3Uri),
   } as any;
 };
 
@@ -31419,7 +30499,7 @@ const deserializeAws_json1_1MonitoringJobDefinition = (
       output.NetworkConfig !== undefined && output.NetworkConfig !== null
         ? deserializeAws_json1_1NetworkConfig(output.NetworkConfig, context)
         : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
+    RoleArn: __expectString(output.RoleArn),
     StoppingCondition:
       output.StoppingCondition !== undefined && output.StoppingCondition !== null
         ? deserializeAws_json1_1MonitoringStoppingCondition(output.StoppingCondition, context)
@@ -31436,15 +30516,9 @@ const deserializeAws_json1_1MonitoringJobDefinitionSummary = (
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    EndpointName: output.EndpointName !== undefined && output.EndpointName !== null ? output.EndpointName : undefined,
-    MonitoringJobDefinitionArn:
-      output.MonitoringJobDefinitionArn !== undefined && output.MonitoringJobDefinitionArn !== null
-        ? output.MonitoringJobDefinitionArn
-        : undefined,
-    MonitoringJobDefinitionName:
-      output.MonitoringJobDefinitionName !== undefined && output.MonitoringJobDefinitionName !== null
-        ? output.MonitoringJobDefinitionName
-        : undefined,
+    EndpointName: __expectString(output.EndpointName),
+    MonitoringJobDefinitionArn: __expectString(output.MonitoringJobDefinitionArn),
+    MonitoringJobDefinitionName: __expectString(output.MonitoringJobDefinitionName),
   } as any;
 };
 
@@ -31467,15 +30541,8 @@ const deserializeAws_json1_1MonitoringNetworkConfig = (
   context: __SerdeContext
 ): MonitoringNetworkConfig => {
   return {
-    EnableInterContainerTrafficEncryption:
-      output.EnableInterContainerTrafficEncryption !== undefined &&
-      output.EnableInterContainerTrafficEncryption !== null
-        ? output.EnableInterContainerTrafficEncryption
-        : undefined,
-    EnableNetworkIsolation:
-      output.EnableNetworkIsolation !== undefined && output.EnableNetworkIsolation !== null
-        ? output.EnableNetworkIsolation
-        : undefined,
+    EnableInterContainerTrafficEncryption: __expectBoolean(output.EnableInterContainerTrafficEncryption),
+    EnableNetworkIsolation: __expectBoolean(output.EnableNetworkIsolation),
     VpcConfig:
       output.VpcConfig !== undefined && output.VpcConfig !== null
         ? deserializeAws_json1_1VpcConfig(output.VpcConfig, context)
@@ -31494,7 +30561,7 @@ const deserializeAws_json1_1MonitoringOutput = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1MonitoringOutputConfig = (output: any, context: __SerdeContext): MonitoringOutputConfig => {
   return {
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
+    KmsKeyId: __expectString(output.KmsKeyId),
     MonitoringOutputs:
       output.MonitoringOutputs !== undefined && output.MonitoringOutputs !== null
         ? deserializeAws_json1_1MonitoringOutputs(output.MonitoringOutputs, context)
@@ -31524,9 +30591,9 @@ const deserializeAws_json1_1MonitoringResources = (output: any, context: __Serde
 
 const deserializeAws_json1_1MonitoringS3Output = (output: any, context: __SerdeContext): MonitoringS3Output => {
   return {
-    LocalPath: output.LocalPath !== undefined && output.LocalPath !== null ? output.LocalPath : undefined,
-    S3UploadMode: output.S3UploadMode !== undefined && output.S3UploadMode !== null ? output.S3UploadMode : undefined,
-    S3Uri: output.S3Uri !== undefined && output.S3Uri !== null ? output.S3Uri : undefined,
+    LocalPath: __expectString(output.LocalPath),
+    S3UploadMode: __expectString(output.S3UploadMode),
+    S3Uri: __expectString(output.S3Uri),
   } as any;
 };
 
@@ -31536,9 +30603,8 @@ const deserializeAws_json1_1MonitoringSchedule = (output: any, context: __SerdeC
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    EndpointName: output.EndpointName !== undefined && output.EndpointName !== null ? output.EndpointName : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
+    EndpointName: __expectString(output.EndpointName),
+    FailureReason: __expectString(output.FailureReason),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
@@ -31547,24 +30613,14 @@ const deserializeAws_json1_1MonitoringSchedule = (output: any, context: __SerdeC
       output.LastMonitoringExecutionSummary !== undefined && output.LastMonitoringExecutionSummary !== null
         ? deserializeAws_json1_1MonitoringExecutionSummary(output.LastMonitoringExecutionSummary, context)
         : undefined,
-    MonitoringScheduleArn:
-      output.MonitoringScheduleArn !== undefined && output.MonitoringScheduleArn !== null
-        ? output.MonitoringScheduleArn
-        : undefined,
+    MonitoringScheduleArn: __expectString(output.MonitoringScheduleArn),
     MonitoringScheduleConfig:
       output.MonitoringScheduleConfig !== undefined && output.MonitoringScheduleConfig !== null
         ? deserializeAws_json1_1MonitoringScheduleConfig(output.MonitoringScheduleConfig, context)
         : undefined,
-    MonitoringScheduleName:
-      output.MonitoringScheduleName !== undefined && output.MonitoringScheduleName !== null
-        ? output.MonitoringScheduleName
-        : undefined,
-    MonitoringScheduleStatus:
-      output.MonitoringScheduleStatus !== undefined && output.MonitoringScheduleStatus !== null
-        ? output.MonitoringScheduleStatus
-        : undefined,
-    MonitoringType:
-      output.MonitoringType !== undefined && output.MonitoringType !== null ? output.MonitoringType : undefined,
+    MonitoringScheduleName: __expectString(output.MonitoringScheduleName),
+    MonitoringScheduleStatus: __expectString(output.MonitoringScheduleStatus),
+    MonitoringType: __expectString(output.MonitoringType),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_1TagList(output.Tags, context)
@@ -31581,12 +30637,8 @@ const deserializeAws_json1_1MonitoringScheduleConfig = (
       output.MonitoringJobDefinition !== undefined && output.MonitoringJobDefinition !== null
         ? deserializeAws_json1_1MonitoringJobDefinition(output.MonitoringJobDefinition, context)
         : undefined,
-    MonitoringJobDefinitionName:
-      output.MonitoringJobDefinitionName !== undefined && output.MonitoringJobDefinitionName !== null
-        ? output.MonitoringJobDefinitionName
-        : undefined,
-    MonitoringType:
-      output.MonitoringType !== undefined && output.MonitoringType !== null ? output.MonitoringType : undefined,
+    MonitoringJobDefinitionName: __expectString(output.MonitoringJobDefinitionName),
+    MonitoringType: __expectString(output.MonitoringType),
     ScheduleConfig:
       output.ScheduleConfig !== undefined && output.ScheduleConfig !== null
         ? deserializeAws_json1_1ScheduleConfig(output.ScheduleConfig, context)
@@ -31614,29 +30666,16 @@ const deserializeAws_json1_1MonitoringScheduleSummary = (
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    EndpointName: output.EndpointName !== undefined && output.EndpointName !== null ? output.EndpointName : undefined,
+    EndpointName: __expectString(output.EndpointName),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    MonitoringJobDefinitionName:
-      output.MonitoringJobDefinitionName !== undefined && output.MonitoringJobDefinitionName !== null
-        ? output.MonitoringJobDefinitionName
-        : undefined,
-    MonitoringScheduleArn:
-      output.MonitoringScheduleArn !== undefined && output.MonitoringScheduleArn !== null
-        ? output.MonitoringScheduleArn
-        : undefined,
-    MonitoringScheduleName:
-      output.MonitoringScheduleName !== undefined && output.MonitoringScheduleName !== null
-        ? output.MonitoringScheduleName
-        : undefined,
-    MonitoringScheduleStatus:
-      output.MonitoringScheduleStatus !== undefined && output.MonitoringScheduleStatus !== null
-        ? output.MonitoringScheduleStatus
-        : undefined,
-    MonitoringType:
-      output.MonitoringType !== undefined && output.MonitoringType !== null ? output.MonitoringType : undefined,
+    MonitoringJobDefinitionName: __expectString(output.MonitoringJobDefinitionName),
+    MonitoringScheduleArn: __expectString(output.MonitoringScheduleArn),
+    MonitoringScheduleName: __expectString(output.MonitoringScheduleName),
+    MonitoringScheduleStatus: __expectString(output.MonitoringScheduleStatus),
+    MonitoringType: __expectString(output.MonitoringType),
   } as any;
 };
 
@@ -31659,7 +30698,7 @@ const deserializeAws_json1_1MonitoringStatisticsResource = (
   context: __SerdeContext
 ): MonitoringStatisticsResource => {
   return {
-    S3Uri: output.S3Uri !== undefined && output.S3Uri !== null ? output.S3Uri : undefined,
+    S3Uri: __expectString(output.S3Uri),
   } as any;
 };
 
@@ -31668,33 +30707,20 @@ const deserializeAws_json1_1MonitoringStoppingCondition = (
   context: __SerdeContext
 ): MonitoringStoppingCondition => {
   return {
-    MaxRuntimeInSeconds:
-      output.MaxRuntimeInSeconds !== undefined && output.MaxRuntimeInSeconds !== null
-        ? output.MaxRuntimeInSeconds
-        : undefined,
+    MaxRuntimeInSeconds: __expectNumber(output.MaxRuntimeInSeconds),
   } as any;
 };
 
 const deserializeAws_json1_1MultiModelConfig = (output: any, context: __SerdeContext): MultiModelConfig => {
   return {
-    ModelCacheSetting:
-      output.ModelCacheSetting !== undefined && output.ModelCacheSetting !== null
-        ? output.ModelCacheSetting
-        : undefined,
+    ModelCacheSetting: __expectString(output.ModelCacheSetting),
   } as any;
 };
 
 const deserializeAws_json1_1NetworkConfig = (output: any, context: __SerdeContext): NetworkConfig => {
   return {
-    EnableInterContainerTrafficEncryption:
-      output.EnableInterContainerTrafficEncryption !== undefined &&
-      output.EnableInterContainerTrafficEncryption !== null
-        ? output.EnableInterContainerTrafficEncryption
-        : undefined,
-    EnableNetworkIsolation:
-      output.EnableNetworkIsolation !== undefined && output.EnableNetworkIsolation !== null
-        ? output.EnableNetworkIsolation
-        : undefined,
+    EnableInterContainerTrafficEncryption: __expectBoolean(output.EnableInterContainerTrafficEncryption),
+    EnableNetworkIsolation: __expectBoolean(output.EnableNetworkIsolation),
     VpcConfig:
       output.VpcConfig !== undefined && output.VpcConfig !== null
         ? deserializeAws_json1_1VpcConfig(output.VpcConfig, context)
@@ -31712,7 +30738,7 @@ const deserializeAws_json1_1NotebookInstanceAcceleratorTypes = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -31743,14 +30769,8 @@ const deserializeAws_json1_1NotebookInstanceLifecycleConfigSummary = (
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    NotebookInstanceLifecycleConfigArn:
-      output.NotebookInstanceLifecycleConfigArn !== undefined && output.NotebookInstanceLifecycleConfigArn !== null
-        ? output.NotebookInstanceLifecycleConfigArn
-        : undefined,
-    NotebookInstanceLifecycleConfigName:
-      output.NotebookInstanceLifecycleConfigName !== undefined && output.NotebookInstanceLifecycleConfigName !== null
-        ? output.NotebookInstanceLifecycleConfigName
-        : undefined,
+    NotebookInstanceLifecycleConfigArn: __expectString(output.NotebookInstanceLifecycleConfigArn),
+    NotebookInstanceLifecycleConfigName: __expectString(output.NotebookInstanceLifecycleConfigName),
   } as any;
 };
 
@@ -31773,7 +30793,7 @@ const deserializeAws_json1_1NotebookInstanceLifecycleHook = (
   context: __SerdeContext
 ): NotebookInstanceLifecycleHook => {
   return {
-    Content: output.Content !== undefined && output.Content !== null ? output.Content : undefined,
+    Content: __expectString(output.Content),
   } as any;
 };
 
@@ -31790,32 +30810,17 @@ const deserializeAws_json1_1NotebookInstanceSummary = (
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    DefaultCodeRepository:
-      output.DefaultCodeRepository !== undefined && output.DefaultCodeRepository !== null
-        ? output.DefaultCodeRepository
-        : undefined,
-    InstanceType: output.InstanceType !== undefined && output.InstanceType !== null ? output.InstanceType : undefined,
+    DefaultCodeRepository: __expectString(output.DefaultCodeRepository),
+    InstanceType: __expectString(output.InstanceType),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    NotebookInstanceArn:
-      output.NotebookInstanceArn !== undefined && output.NotebookInstanceArn !== null
-        ? output.NotebookInstanceArn
-        : undefined,
-    NotebookInstanceLifecycleConfigName:
-      output.NotebookInstanceLifecycleConfigName !== undefined && output.NotebookInstanceLifecycleConfigName !== null
-        ? output.NotebookInstanceLifecycleConfigName
-        : undefined,
-    NotebookInstanceName:
-      output.NotebookInstanceName !== undefined && output.NotebookInstanceName !== null
-        ? output.NotebookInstanceName
-        : undefined,
-    NotebookInstanceStatus:
-      output.NotebookInstanceStatus !== undefined && output.NotebookInstanceStatus !== null
-        ? output.NotebookInstanceStatus
-        : undefined,
-    Url: output.Url !== undefined && output.Url !== null ? output.Url : undefined,
+    NotebookInstanceArn: __expectString(output.NotebookInstanceArn),
+    NotebookInstanceLifecycleConfigName: __expectString(output.NotebookInstanceLifecycleConfigName),
+    NotebookInstanceName: __expectString(output.NotebookInstanceName),
+    NotebookInstanceStatus: __expectString(output.NotebookInstanceStatus),
+    Url: __expectString(output.Url),
   } as any;
 };
 
@@ -31838,10 +30843,7 @@ const deserializeAws_json1_1NotificationConfiguration = (
   context: __SerdeContext
 ): NotificationConfiguration => {
   return {
-    NotificationTopicArn:
-      output.NotificationTopicArn !== undefined && output.NotificationTopicArn !== null
-        ? output.NotificationTopicArn
-        : undefined,
+    NotificationTopicArn: __expectString(output.NotificationTopicArn),
   } as any;
 };
 
@@ -31850,9 +30852,9 @@ const deserializeAws_json1_1ObjectiveStatusCounters = (
   context: __SerdeContext
 ): ObjectiveStatusCounters => {
   return {
-    Failed: output.Failed !== undefined && output.Failed !== null ? output.Failed : undefined,
-    Pending: output.Pending !== undefined && output.Pending !== null ? output.Pending : undefined,
-    Succeeded: output.Succeeded !== undefined && output.Succeeded !== null ? output.Succeeded : undefined,
+    Failed: __expectNumber(output.Failed),
+    Pending: __expectNumber(output.Pending),
+    Succeeded: __expectNumber(output.Succeeded),
   } as any;
 };
 
@@ -31862,10 +30864,7 @@ const deserializeAws_json1_1OfflineStoreConfig = (output: any, context: __SerdeC
       output.DataCatalogConfig !== undefined && output.DataCatalogConfig !== null
         ? deserializeAws_json1_1DataCatalogConfig(output.DataCatalogConfig, context)
         : undefined,
-    DisableGlueTableCreation:
-      output.DisableGlueTableCreation !== undefined && output.DisableGlueTableCreation !== null
-        ? output.DisableGlueTableCreation
-        : undefined,
+    DisableGlueTableCreation: __expectBoolean(output.DisableGlueTableCreation),
     S3StorageConfig:
       output.S3StorageConfig !== undefined && output.S3StorageConfig !== null
         ? deserializeAws_json1_1S3StorageConfig(output.S3StorageConfig, context)
@@ -31875,27 +30874,20 @@ const deserializeAws_json1_1OfflineStoreConfig = (output: any, context: __SerdeC
 
 const deserializeAws_json1_1OfflineStoreStatus = (output: any, context: __SerdeContext): OfflineStoreStatus => {
   return {
-    BlockedReason:
-      output.BlockedReason !== undefined && output.BlockedReason !== null ? output.BlockedReason : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    BlockedReason: __expectString(output.BlockedReason),
+    Status: __expectString(output.Status),
   } as any;
 };
 
 const deserializeAws_json1_1OidcConfigForResponse = (output: any, context: __SerdeContext): OidcConfigForResponse => {
   return {
-    AuthorizationEndpoint:
-      output.AuthorizationEndpoint !== undefined && output.AuthorizationEndpoint !== null
-        ? output.AuthorizationEndpoint
-        : undefined,
-    ClientId: output.ClientId !== undefined && output.ClientId !== null ? output.ClientId : undefined,
-    Issuer: output.Issuer !== undefined && output.Issuer !== null ? output.Issuer : undefined,
-    JwksUri: output.JwksUri !== undefined && output.JwksUri !== null ? output.JwksUri : undefined,
-    LogoutEndpoint:
-      output.LogoutEndpoint !== undefined && output.LogoutEndpoint !== null ? output.LogoutEndpoint : undefined,
-    TokenEndpoint:
-      output.TokenEndpoint !== undefined && output.TokenEndpoint !== null ? output.TokenEndpoint : undefined,
-    UserInfoEndpoint:
-      output.UserInfoEndpoint !== undefined && output.UserInfoEndpoint !== null ? output.UserInfoEndpoint : undefined,
+    AuthorizationEndpoint: __expectString(output.AuthorizationEndpoint),
+    ClientId: __expectString(output.ClientId),
+    Issuer: __expectString(output.Issuer),
+    JwksUri: __expectString(output.JwksUri),
+    LogoutEndpoint: __expectString(output.LogoutEndpoint),
+    TokenEndpoint: __expectString(output.TokenEndpoint),
+    UserInfoEndpoint: __expectString(output.UserInfoEndpoint),
   } as any;
 };
 
@@ -31910,10 +30902,7 @@ const deserializeAws_json1_1OidcMemberDefinition = (output: any, context: __Serd
 
 const deserializeAws_json1_1OnlineStoreConfig = (output: any, context: __SerdeContext): OnlineStoreConfig => {
   return {
-    EnableOnlineStore:
-      output.EnableOnlineStore !== undefined && output.EnableOnlineStore !== null
-        ? output.EnableOnlineStore
-        : undefined,
+    EnableOnlineStore: __expectBoolean(output.EnableOnlineStore),
     SecurityConfig:
       output.SecurityConfig !== undefined && output.SecurityConfig !== null
         ? deserializeAws_json1_1OnlineStoreSecurityConfig(output.SecurityConfig, context)
@@ -31926,18 +30915,16 @@ const deserializeAws_json1_1OnlineStoreSecurityConfig = (
   context: __SerdeContext
 ): OnlineStoreSecurityConfig => {
   return {
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
+    KmsKeyId: __expectString(output.KmsKeyId),
   } as any;
 };
 
 const deserializeAws_json1_1OutputConfig = (output: any, context: __SerdeContext): OutputConfig => {
   return {
-    CompilerOptions:
-      output.CompilerOptions !== undefined && output.CompilerOptions !== null ? output.CompilerOptions : undefined,
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
-    S3OutputLocation:
-      output.S3OutputLocation !== undefined && output.S3OutputLocation !== null ? output.S3OutputLocation : undefined,
-    TargetDevice: output.TargetDevice !== undefined && output.TargetDevice !== null ? output.TargetDevice : undefined,
+    CompilerOptions: __expectString(output.CompilerOptions),
+    KmsKeyId: __expectString(output.KmsKeyId),
+    S3OutputLocation: __expectString(output.S3OutputLocation),
+    TargetDevice: __expectString(output.TargetDevice),
     TargetPlatform:
       output.TargetPlatform !== undefined && output.TargetPlatform !== null
         ? deserializeAws_json1_1TargetPlatform(output.TargetPlatform, context)
@@ -31947,15 +30934,15 @@ const deserializeAws_json1_1OutputConfig = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_1OutputDataConfig = (output: any, context: __SerdeContext): OutputDataConfig => {
   return {
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
-    S3OutputPath: output.S3OutputPath !== undefined && output.S3OutputPath !== null ? output.S3OutputPath : undefined,
+    KmsKeyId: __expectString(output.KmsKeyId),
+    S3OutputPath: __expectString(output.S3OutputPath),
   } as any;
 };
 
 const deserializeAws_json1_1OutputParameter = (output: any, context: __SerdeContext): OutputParameter => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Name: __expectString(output.Name),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -31972,8 +30959,8 @@ const deserializeAws_json1_1OutputParameterList = (output: any, context: __Serde
 
 const deserializeAws_json1_1Parameter = (output: any, context: __SerdeContext): Parameter => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Name: __expectString(output.Name),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -32037,15 +31024,14 @@ const deserializeAws_json1_1ParameterValues = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1Parent = (output: any, context: __SerdeContext): Parent => {
   return {
-    ExperimentName:
-      output.ExperimentName !== undefined && output.ExperimentName !== null ? output.ExperimentName : undefined,
-    TrialName: output.TrialName !== undefined && output.TrialName !== null ? output.TrialName : undefined,
+    ExperimentName: __expectString(output.ExperimentName),
+    TrialName: __expectString(output.TrialName),
   } as any;
 };
 
@@ -32054,10 +31040,7 @@ const deserializeAws_json1_1ParentHyperParameterTuningJob = (
   context: __SerdeContext
 ): ParentHyperParameterTuningJob => {
   return {
-    HyperParameterTuningJobName:
-      output.HyperParameterTuningJobName !== undefined && output.HyperParameterTuningJobName !== null
-        ? output.HyperParameterTuningJobName
-        : undefined,
+    HyperParameterTuningJobName: __expectString(output.HyperParameterTuningJobName),
   } as any;
 };
 
@@ -32108,19 +31091,12 @@ const deserializeAws_json1_1Pipeline = (output: any, context: __SerdeContext): P
       output.LastRunTime !== undefined && output.LastRunTime !== null
         ? new Date(Math.round(output.LastRunTime * 1000))
         : undefined,
-    PipelineArn: output.PipelineArn !== undefined && output.PipelineArn !== null ? output.PipelineArn : undefined,
-    PipelineDescription:
-      output.PipelineDescription !== undefined && output.PipelineDescription !== null
-        ? output.PipelineDescription
-        : undefined,
-    PipelineDisplayName:
-      output.PipelineDisplayName !== undefined && output.PipelineDisplayName !== null
-        ? output.PipelineDisplayName
-        : undefined,
-    PipelineName: output.PipelineName !== undefined && output.PipelineName !== null ? output.PipelineName : undefined,
-    PipelineStatus:
-      output.PipelineStatus !== undefined && output.PipelineStatus !== null ? output.PipelineStatus : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
+    PipelineArn: __expectString(output.PipelineArn),
+    PipelineDescription: __expectString(output.PipelineDescription),
+    PipelineDisplayName: __expectString(output.PipelineDisplayName),
+    PipelineName: __expectString(output.PipelineName),
+    PipelineStatus: __expectString(output.PipelineStatus),
+    RoleArn: __expectString(output.RoleArn),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_1TagList(output.Tags, context)
@@ -32138,8 +31114,7 @@ const deserializeAws_json1_1PipelineExecution = (output: any, context: __SerdeCo
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
+    FailureReason: __expectString(output.FailureReason),
     LastModifiedBy:
       output.LastModifiedBy !== undefined && output.LastModifiedBy !== null
         ? deserializeAws_json1_1UserContext(output.LastModifiedBy, context)
@@ -32148,23 +31123,11 @@ const deserializeAws_json1_1PipelineExecution = (output: any, context: __SerdeCo
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    PipelineArn: output.PipelineArn !== undefined && output.PipelineArn !== null ? output.PipelineArn : undefined,
-    PipelineExecutionArn:
-      output.PipelineExecutionArn !== undefined && output.PipelineExecutionArn !== null
-        ? output.PipelineExecutionArn
-        : undefined,
-    PipelineExecutionDescription:
-      output.PipelineExecutionDescription !== undefined && output.PipelineExecutionDescription !== null
-        ? output.PipelineExecutionDescription
-        : undefined,
-    PipelineExecutionDisplayName:
-      output.PipelineExecutionDisplayName !== undefined && output.PipelineExecutionDisplayName !== null
-        ? output.PipelineExecutionDisplayName
-        : undefined,
-    PipelineExecutionStatus:
-      output.PipelineExecutionStatus !== undefined && output.PipelineExecutionStatus !== null
-        ? output.PipelineExecutionStatus
-        : undefined,
+    PipelineArn: __expectString(output.PipelineArn),
+    PipelineExecutionArn: __expectString(output.PipelineExecutionArn),
+    PipelineExecutionDescription: __expectString(output.PipelineExecutionDescription),
+    PipelineExecutionDisplayName: __expectString(output.PipelineExecutionDisplayName),
+    PipelineExecutionStatus: __expectString(output.PipelineExecutionStatus),
     PipelineExperimentConfig:
       output.PipelineExperimentConfig !== undefined && output.PipelineExperimentConfig !== null
         ? deserializeAws_json1_1PipelineExperimentConfig(output.PipelineExperimentConfig, context)
@@ -32184,8 +31147,7 @@ const deserializeAws_json1_1PipelineExecutionStep = (output: any, context: __Ser
         : undefined,
     EndTime:
       output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
+    FailureReason: __expectString(output.FailureReason),
     Metadata:
       output.Metadata !== undefined && output.Metadata !== null
         ? deserializeAws_json1_1PipelineExecutionStepMetadata(output.Metadata, context)
@@ -32194,8 +31156,8 @@ const deserializeAws_json1_1PipelineExecutionStep = (output: any, context: __Ser
       output.StartTime !== undefined && output.StartTime !== null
         ? new Date(Math.round(output.StartTime * 1000))
         : undefined,
-    StepName: output.StepName !== undefined && output.StepName !== null ? output.StepName : undefined,
-    StepStatus: output.StepStatus !== undefined && output.StepStatus !== null ? output.StepStatus : undefined,
+    StepName: __expectString(output.StepName),
+    StepStatus: __expectString(output.StepStatus),
   } as any;
 };
 
@@ -32254,22 +31216,10 @@ const deserializeAws_json1_1PipelineExecutionSummary = (
   context: __SerdeContext
 ): PipelineExecutionSummary => {
   return {
-    PipelineExecutionArn:
-      output.PipelineExecutionArn !== undefined && output.PipelineExecutionArn !== null
-        ? output.PipelineExecutionArn
-        : undefined,
-    PipelineExecutionDescription:
-      output.PipelineExecutionDescription !== undefined && output.PipelineExecutionDescription !== null
-        ? output.PipelineExecutionDescription
-        : undefined,
-    PipelineExecutionDisplayName:
-      output.PipelineExecutionDisplayName !== undefined && output.PipelineExecutionDisplayName !== null
-        ? output.PipelineExecutionDisplayName
-        : undefined,
-    PipelineExecutionStatus:
-      output.PipelineExecutionStatus !== undefined && output.PipelineExecutionStatus !== null
-        ? output.PipelineExecutionStatus
-        : undefined,
+    PipelineExecutionArn: __expectString(output.PipelineExecutionArn),
+    PipelineExecutionDescription: __expectString(output.PipelineExecutionDescription),
+    PipelineExecutionDisplayName: __expectString(output.PipelineExecutionDisplayName),
+    PipelineExecutionStatus: __expectString(output.PipelineExecutionStatus),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
         ? new Date(Math.round(output.StartTime * 1000))
@@ -32296,9 +31246,8 @@ const deserializeAws_json1_1PipelineExperimentConfig = (
   context: __SerdeContext
 ): PipelineExperimentConfig => {
   return {
-    ExperimentName:
-      output.ExperimentName !== undefined && output.ExperimentName !== null ? output.ExperimentName : undefined,
-    TrialName: output.TrialName !== undefined && output.TrialName !== null ? output.TrialName : undefined,
+    ExperimentName: __expectString(output.ExperimentName),
+    TrialName: __expectString(output.TrialName),
   } as any;
 };
 
@@ -32316,17 +31265,11 @@ const deserializeAws_json1_1PipelineSummary = (output: any, context: __SerdeCont
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    PipelineArn: output.PipelineArn !== undefined && output.PipelineArn !== null ? output.PipelineArn : undefined,
-    PipelineDescription:
-      output.PipelineDescription !== undefined && output.PipelineDescription !== null
-        ? output.PipelineDescription
-        : undefined,
-    PipelineDisplayName:
-      output.PipelineDisplayName !== undefined && output.PipelineDisplayName !== null
-        ? output.PipelineDisplayName
-        : undefined,
-    PipelineName: output.PipelineName !== undefined && output.PipelineName !== null ? output.PipelineName : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
+    PipelineArn: __expectString(output.PipelineArn),
+    PipelineDescription: __expectString(output.PipelineDescription),
+    PipelineDisplayName: __expectString(output.PipelineDisplayName),
+    PipelineName: __expectString(output.PipelineName),
+    RoleArn: __expectString(output.RoleArn),
   } as any;
 };
 
@@ -32346,13 +31289,10 @@ const deserializeAws_json1_1ProcessingClusterConfig = (
   context: __SerdeContext
 ): ProcessingClusterConfig => {
   return {
-    InstanceCount:
-      output.InstanceCount !== undefined && output.InstanceCount !== null ? output.InstanceCount : undefined,
-    InstanceType: output.InstanceType !== undefined && output.InstanceType !== null ? output.InstanceType : undefined,
-    VolumeKmsKeyId:
-      output.VolumeKmsKeyId !== undefined && output.VolumeKmsKeyId !== null ? output.VolumeKmsKeyId : undefined,
-    VolumeSizeInGB:
-      output.VolumeSizeInGB !== undefined && output.VolumeSizeInGB !== null ? output.VolumeSizeInGB : undefined,
+    InstanceCount: __expectNumber(output.InstanceCount),
+    InstanceType: __expectString(output.InstanceType),
+    VolumeKmsKeyId: __expectString(output.VolumeKmsKeyId),
+    VolumeSizeInGB: __expectNumber(output.VolumeSizeInGB),
   } as any;
 };
 
@@ -32366,7 +31306,7 @@ const deserializeAws_json1_1ProcessingEnvironmentMap = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -32376,19 +31316,18 @@ const deserializeAws_json1_1ProcessingFeatureStoreOutput = (
   context: __SerdeContext
 ): ProcessingFeatureStoreOutput => {
   return {
-    FeatureGroupName:
-      output.FeatureGroupName !== undefined && output.FeatureGroupName !== null ? output.FeatureGroupName : undefined,
+    FeatureGroupName: __expectString(output.FeatureGroupName),
   } as any;
 };
 
 const deserializeAws_json1_1ProcessingInput = (output: any, context: __SerdeContext): ProcessingInput => {
   return {
-    AppManaged: output.AppManaged !== undefined && output.AppManaged !== null ? output.AppManaged : undefined,
+    AppManaged: __expectBoolean(output.AppManaged),
     DatasetDefinition:
       output.DatasetDefinition !== undefined && output.DatasetDefinition !== null
         ? deserializeAws_json1_1DatasetDefinition(output.DatasetDefinition, context)
         : undefined,
-    InputName: output.InputName !== undefined && output.InputName !== null ? output.InputName : undefined,
+    InputName: __expectString(output.InputName),
     S3Input:
       output.S3Input !== undefined && output.S3Input !== null
         ? deserializeAws_json1_1ProcessingS3Input(output.S3Input, context)
@@ -32413,7 +31352,7 @@ const deserializeAws_json1_1ProcessingJob = (output: any, context: __SerdeContex
       output.AppSpecification !== undefined && output.AppSpecification !== null
         ? deserializeAws_json1_1AppSpecification(output.AppSpecification, context)
         : undefined,
-    AutoMLJobArn: output.AutoMLJobArn !== undefined && output.AutoMLJobArn !== null ? output.AutoMLJobArn : undefined,
+    AutoMLJobArn: __expectString(output.AutoMLJobArn),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -32422,21 +31361,17 @@ const deserializeAws_json1_1ProcessingJob = (output: any, context: __SerdeContex
       output.Environment !== undefined && output.Environment !== null
         ? deserializeAws_json1_1ProcessingEnvironmentMap(output.Environment, context)
         : undefined,
-    ExitMessage: output.ExitMessage !== undefined && output.ExitMessage !== null ? output.ExitMessage : undefined,
+    ExitMessage: __expectString(output.ExitMessage),
     ExperimentConfig:
       output.ExperimentConfig !== undefined && output.ExperimentConfig !== null
         ? deserializeAws_json1_1ExperimentConfig(output.ExperimentConfig, context)
         : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
+    FailureReason: __expectString(output.FailureReason),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    MonitoringScheduleArn:
-      output.MonitoringScheduleArn !== undefined && output.MonitoringScheduleArn !== null
-        ? output.MonitoringScheduleArn
-        : undefined,
+    MonitoringScheduleArn: __expectString(output.MonitoringScheduleArn),
     NetworkConfig:
       output.NetworkConfig !== undefined && output.NetworkConfig !== null
         ? deserializeAws_json1_1NetworkConfig(output.NetworkConfig, context)
@@ -32449,16 +31384,9 @@ const deserializeAws_json1_1ProcessingJob = (output: any, context: __SerdeContex
       output.ProcessingInputs !== undefined && output.ProcessingInputs !== null
         ? deserializeAws_json1_1ProcessingInputs(output.ProcessingInputs, context)
         : undefined,
-    ProcessingJobArn:
-      output.ProcessingJobArn !== undefined && output.ProcessingJobArn !== null ? output.ProcessingJobArn : undefined,
-    ProcessingJobName:
-      output.ProcessingJobName !== undefined && output.ProcessingJobName !== null
-        ? output.ProcessingJobName
-        : undefined,
-    ProcessingJobStatus:
-      output.ProcessingJobStatus !== undefined && output.ProcessingJobStatus !== null
-        ? output.ProcessingJobStatus
-        : undefined,
+    ProcessingJobArn: __expectString(output.ProcessingJobArn),
+    ProcessingJobName: __expectString(output.ProcessingJobName),
+    ProcessingJobStatus: __expectString(output.ProcessingJobStatus),
     ProcessingOutputConfig:
       output.ProcessingOutputConfig !== undefined && output.ProcessingOutputConfig !== null
         ? deserializeAws_json1_1ProcessingOutputConfig(output.ProcessingOutputConfig, context)
@@ -32471,7 +31399,7 @@ const deserializeAws_json1_1ProcessingJob = (output: any, context: __SerdeContex
       output.ProcessingStartTime !== undefined && output.ProcessingStartTime !== null
         ? new Date(Math.round(output.ProcessingStartTime * 1000))
         : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
+    RoleArn: __expectString(output.RoleArn),
     StoppingCondition:
       output.StoppingCondition !== undefined && output.StoppingCondition !== null
         ? deserializeAws_json1_1ProcessingStoppingCondition(output.StoppingCondition, context)
@@ -32480,8 +31408,7 @@ const deserializeAws_json1_1ProcessingJob = (output: any, context: __SerdeContex
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_1TagList(output.Tags, context)
         : undefined,
-    TrainingJobArn:
-      output.TrainingJobArn !== undefined && output.TrainingJobArn !== null ? output.TrainingJobArn : undefined,
+    TrainingJobArn: __expectString(output.TrainingJobArn),
   } as any;
 };
 
@@ -32490,7 +31417,7 @@ const deserializeAws_json1_1ProcessingJobStepMetadata = (
   context: __SerdeContext
 ): ProcessingJobStepMetadata => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
   } as any;
 };
 
@@ -32511,9 +31438,8 @@ const deserializeAws_json1_1ProcessingJobSummary = (output: any, context: __Serd
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    ExitMessage: output.ExitMessage !== undefined && output.ExitMessage !== null ? output.ExitMessage : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
+    ExitMessage: __expectString(output.ExitMessage),
+    FailureReason: __expectString(output.FailureReason),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
@@ -32522,27 +31448,20 @@ const deserializeAws_json1_1ProcessingJobSummary = (output: any, context: __Serd
       output.ProcessingEndTime !== undefined && output.ProcessingEndTime !== null
         ? new Date(Math.round(output.ProcessingEndTime * 1000))
         : undefined,
-    ProcessingJobArn:
-      output.ProcessingJobArn !== undefined && output.ProcessingJobArn !== null ? output.ProcessingJobArn : undefined,
-    ProcessingJobName:
-      output.ProcessingJobName !== undefined && output.ProcessingJobName !== null
-        ? output.ProcessingJobName
-        : undefined,
-    ProcessingJobStatus:
-      output.ProcessingJobStatus !== undefined && output.ProcessingJobStatus !== null
-        ? output.ProcessingJobStatus
-        : undefined,
+    ProcessingJobArn: __expectString(output.ProcessingJobArn),
+    ProcessingJobName: __expectString(output.ProcessingJobName),
+    ProcessingJobStatus: __expectString(output.ProcessingJobStatus),
   } as any;
 };
 
 const deserializeAws_json1_1ProcessingOutput = (output: any, context: __SerdeContext): ProcessingOutput => {
   return {
-    AppManaged: output.AppManaged !== undefined && output.AppManaged !== null ? output.AppManaged : undefined,
+    AppManaged: __expectBoolean(output.AppManaged),
     FeatureStoreOutput:
       output.FeatureStoreOutput !== undefined && output.FeatureStoreOutput !== null
         ? deserializeAws_json1_1ProcessingFeatureStoreOutput(output.FeatureStoreOutput, context)
         : undefined,
-    OutputName: output.OutputName !== undefined && output.OutputName !== null ? output.OutputName : undefined,
+    OutputName: __expectString(output.OutputName),
     S3Output:
       output.S3Output !== undefined && output.S3Output !== null
         ? deserializeAws_json1_1ProcessingS3Output(output.S3Output, context)
@@ -32552,7 +31471,7 @@ const deserializeAws_json1_1ProcessingOutput = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1ProcessingOutputConfig = (output: any, context: __SerdeContext): ProcessingOutputConfig => {
   return {
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
+    KmsKeyId: __expectString(output.KmsKeyId),
     Outputs:
       output.Outputs !== undefined && output.Outputs !== null
         ? deserializeAws_json1_1ProcessingOutputs(output.Outputs, context)
@@ -32582,26 +31501,20 @@ const deserializeAws_json1_1ProcessingResources = (output: any, context: __Serde
 
 const deserializeAws_json1_1ProcessingS3Input = (output: any, context: __SerdeContext): ProcessingS3Input => {
   return {
-    LocalPath: output.LocalPath !== undefined && output.LocalPath !== null ? output.LocalPath : undefined,
-    S3CompressionType:
-      output.S3CompressionType !== undefined && output.S3CompressionType !== null
-        ? output.S3CompressionType
-        : undefined,
-    S3DataDistributionType:
-      output.S3DataDistributionType !== undefined && output.S3DataDistributionType !== null
-        ? output.S3DataDistributionType
-        : undefined,
-    S3DataType: output.S3DataType !== undefined && output.S3DataType !== null ? output.S3DataType : undefined,
-    S3InputMode: output.S3InputMode !== undefined && output.S3InputMode !== null ? output.S3InputMode : undefined,
-    S3Uri: output.S3Uri !== undefined && output.S3Uri !== null ? output.S3Uri : undefined,
+    LocalPath: __expectString(output.LocalPath),
+    S3CompressionType: __expectString(output.S3CompressionType),
+    S3DataDistributionType: __expectString(output.S3DataDistributionType),
+    S3DataType: __expectString(output.S3DataType),
+    S3InputMode: __expectString(output.S3InputMode),
+    S3Uri: __expectString(output.S3Uri),
   } as any;
 };
 
 const deserializeAws_json1_1ProcessingS3Output = (output: any, context: __SerdeContext): ProcessingS3Output => {
   return {
-    LocalPath: output.LocalPath !== undefined && output.LocalPath !== null ? output.LocalPath : undefined,
-    S3UploadMode: output.S3UploadMode !== undefined && output.S3UploadMode !== null ? output.S3UploadMode : undefined,
-    S3Uri: output.S3Uri !== undefined && output.S3Uri !== null ? output.S3Uri : undefined,
+    LocalPath: __expectString(output.LocalPath),
+    S3UploadMode: __expectString(output.S3UploadMode),
+    S3Uri: __expectString(output.S3Uri),
   } as any;
 };
 
@@ -32610,32 +31523,22 @@ const deserializeAws_json1_1ProcessingStoppingCondition = (
   context: __SerdeContext
 ): ProcessingStoppingCondition => {
   return {
-    MaxRuntimeInSeconds:
-      output.MaxRuntimeInSeconds !== undefined && output.MaxRuntimeInSeconds !== null
-        ? output.MaxRuntimeInSeconds
-        : undefined,
+    MaxRuntimeInSeconds: __expectNumber(output.MaxRuntimeInSeconds),
   } as any;
 };
 
 const deserializeAws_json1_1ProductionVariant = (output: any, context: __SerdeContext): ProductionVariant => {
   return {
-    AcceleratorType:
-      output.AcceleratorType !== undefined && output.AcceleratorType !== null ? output.AcceleratorType : undefined,
+    AcceleratorType: __expectString(output.AcceleratorType),
     CoreDumpConfig:
       output.CoreDumpConfig !== undefined && output.CoreDumpConfig !== null
         ? deserializeAws_json1_1ProductionVariantCoreDumpConfig(output.CoreDumpConfig, context)
         : undefined,
-    InitialInstanceCount:
-      output.InitialInstanceCount !== undefined && output.InitialInstanceCount !== null
-        ? output.InitialInstanceCount
-        : undefined,
-    InitialVariantWeight:
-      output.InitialVariantWeight !== undefined && output.InitialVariantWeight !== null
-        ? output.InitialVariantWeight
-        : undefined,
-    InstanceType: output.InstanceType !== undefined && output.InstanceType !== null ? output.InstanceType : undefined,
-    ModelName: output.ModelName !== undefined && output.ModelName !== null ? output.ModelName : undefined,
-    VariantName: output.VariantName !== undefined && output.VariantName !== null ? output.VariantName : undefined,
+    InitialInstanceCount: __expectNumber(output.InitialInstanceCount),
+    InitialVariantWeight: __expectNumber(output.InitialVariantWeight),
+    InstanceType: __expectString(output.InstanceType),
+    ModelName: __expectString(output.ModelName),
+    VariantName: __expectString(output.VariantName),
   } as any;
 };
 
@@ -32644,9 +31547,8 @@ const deserializeAws_json1_1ProductionVariantCoreDumpConfig = (
   context: __SerdeContext
 ): ProductionVariantCoreDumpConfig => {
   return {
-    DestinationS3Uri:
-      output.DestinationS3Uri !== undefined && output.DestinationS3Uri !== null ? output.DestinationS3Uri : undefined,
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
+    DestinationS3Uri: __expectString(output.DestinationS3Uri),
+    KmsKeyId: __expectString(output.KmsKeyId),
   } as any;
 };
 
@@ -32666,23 +31568,15 @@ const deserializeAws_json1_1ProductionVariantSummary = (
   context: __SerdeContext
 ): ProductionVariantSummary => {
   return {
-    CurrentInstanceCount:
-      output.CurrentInstanceCount !== undefined && output.CurrentInstanceCount !== null
-        ? output.CurrentInstanceCount
-        : undefined,
-    CurrentWeight:
-      output.CurrentWeight !== undefined && output.CurrentWeight !== null ? output.CurrentWeight : undefined,
+    CurrentInstanceCount: __expectNumber(output.CurrentInstanceCount),
+    CurrentWeight: __expectNumber(output.CurrentWeight),
     DeployedImages:
       output.DeployedImages !== undefined && output.DeployedImages !== null
         ? deserializeAws_json1_1DeployedImages(output.DeployedImages, context)
         : undefined,
-    DesiredInstanceCount:
-      output.DesiredInstanceCount !== undefined && output.DesiredInstanceCount !== null
-        ? output.DesiredInstanceCount
-        : undefined,
-    DesiredWeight:
-      output.DesiredWeight !== undefined && output.DesiredWeight !== null ? output.DesiredWeight : undefined,
-    VariantName: output.VariantName !== undefined && output.VariantName !== null ? output.VariantName : undefined,
+    DesiredInstanceCount: __expectNumber(output.DesiredInstanceCount),
+    DesiredWeight: __expectNumber(output.DesiredWeight),
+    VariantName: __expectString(output.VariantName),
   } as any;
 };
 
@@ -32707,21 +31601,18 @@ const deserializeAws_json1_1ProductListings = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1ProfilerConfig = (output: any, context: __SerdeContext): ProfilerConfig => {
   return {
-    ProfilingIntervalInMilliseconds:
-      output.ProfilingIntervalInMilliseconds !== undefined && output.ProfilingIntervalInMilliseconds !== null
-        ? output.ProfilingIntervalInMilliseconds
-        : undefined,
+    ProfilingIntervalInMilliseconds: __expectNumber(output.ProfilingIntervalInMilliseconds),
     ProfilingParameters:
       output.ProfilingParameters !== undefined && output.ProfilingParameters !== null
         ? deserializeAws_json1_1ProfilingParameters(output.ProfilingParameters, context)
         : undefined,
-    S3OutputPath: output.S3OutputPath !== undefined && output.S3OutputPath !== null ? output.S3OutputPath : undefined,
+    S3OutputPath: __expectString(output.S3OutputPath),
   } as any;
 };
 
@@ -32730,23 +31621,16 @@ const deserializeAws_json1_1ProfilerRuleConfiguration = (
   context: __SerdeContext
 ): ProfilerRuleConfiguration => {
   return {
-    InstanceType: output.InstanceType !== undefined && output.InstanceType !== null ? output.InstanceType : undefined,
-    LocalPath: output.LocalPath !== undefined && output.LocalPath !== null ? output.LocalPath : undefined,
-    RuleConfigurationName:
-      output.RuleConfigurationName !== undefined && output.RuleConfigurationName !== null
-        ? output.RuleConfigurationName
-        : undefined,
-    RuleEvaluatorImage:
-      output.RuleEvaluatorImage !== undefined && output.RuleEvaluatorImage !== null
-        ? output.RuleEvaluatorImage
-        : undefined,
+    InstanceType: __expectString(output.InstanceType),
+    LocalPath: __expectString(output.LocalPath),
+    RuleConfigurationName: __expectString(output.RuleConfigurationName),
+    RuleEvaluatorImage: __expectString(output.RuleEvaluatorImage),
     RuleParameters:
       output.RuleParameters !== undefined && output.RuleParameters !== null
         ? deserializeAws_json1_1RuleParameters(output.RuleParameters, context)
         : undefined,
-    S3OutputPath: output.S3OutputPath !== undefined && output.S3OutputPath !== null ? output.S3OutputPath : undefined,
-    VolumeSizeInGB:
-      output.VolumeSizeInGB !== undefined && output.VolumeSizeInGB !== null ? output.VolumeSizeInGB : undefined,
+    S3OutputPath: __expectString(output.S3OutputPath),
+    VolumeSizeInGB: __expectNumber(output.VolumeSizeInGB),
   } as any;
 };
 
@@ -32773,20 +31657,10 @@ const deserializeAws_json1_1ProfilerRuleEvaluationStatus = (
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    RuleConfigurationName:
-      output.RuleConfigurationName !== undefined && output.RuleConfigurationName !== null
-        ? output.RuleConfigurationName
-        : undefined,
-    RuleEvaluationJobArn:
-      output.RuleEvaluationJobArn !== undefined && output.RuleEvaluationJobArn !== null
-        ? output.RuleEvaluationJobArn
-        : undefined,
-    RuleEvaluationStatus:
-      output.RuleEvaluationStatus !== undefined && output.RuleEvaluationStatus !== null
-        ? output.RuleEvaluationStatus
-        : undefined,
-    StatusDetails:
-      output.StatusDetails !== undefined && output.StatusDetails !== null ? output.StatusDetails : undefined,
+    RuleConfigurationName: __expectString(output.RuleConfigurationName),
+    RuleEvaluationJobArn: __expectString(output.RuleEvaluationJobArn),
+    RuleEvaluationStatus: __expectString(output.RuleEvaluationStatus),
+    StatusDetails: __expectString(output.StatusDetails),
   } as any;
 };
 
@@ -32811,7 +31685,7 @@ const deserializeAws_json1_1ProfilingParameters = (output: any, context: __Serde
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -32822,15 +31696,11 @@ const deserializeAws_json1_1ProjectSummary = (output: any, context: __SerdeConte
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    ProjectArn: output.ProjectArn !== undefined && output.ProjectArn !== null ? output.ProjectArn : undefined,
-    ProjectDescription:
-      output.ProjectDescription !== undefined && output.ProjectDescription !== null
-        ? output.ProjectDescription
-        : undefined,
-    ProjectId: output.ProjectId !== undefined && output.ProjectId !== null ? output.ProjectId : undefined,
-    ProjectName: output.ProjectName !== undefined && output.ProjectName !== null ? output.ProjectName : undefined,
-    ProjectStatus:
-      output.ProjectStatus !== undefined && output.ProjectStatus !== null ? output.ProjectStatus : undefined,
+    ProjectArn: __expectString(output.ProjectArn),
+    ProjectDescription: __expectString(output.ProjectDescription),
+    ProjectId: __expectString(output.ProjectId),
+    ProjectName: __expectString(output.ProjectName),
+    ProjectStatus: __expectString(output.ProjectStatus),
   } as any;
 };
 
@@ -32847,7 +31717,7 @@ const deserializeAws_json1_1ProjectSummaryList = (output: any, context: __SerdeC
 
 const deserializeAws_json1_1PropertyNameSuggestion = (output: any, context: __SerdeContext): PropertyNameSuggestion => {
   return {
-    PropertyName: output.PropertyName !== undefined && output.PropertyName !== null ? output.PropertyName : undefined,
+    PropertyName: __expectString(output.PropertyName),
   } as any;
 };
 
@@ -32867,8 +31737,8 @@ const deserializeAws_json1_1PropertyNameSuggestionList = (
 
 const deserializeAws_json1_1ProvisioningParameter = (output: any, context: __SerdeContext): ProvisioningParameter => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -32903,10 +31773,7 @@ const deserializeAws_json1_1PutModelPackageGroupPolicyOutput = (
   context: __SerdeContext
 ): PutModelPackageGroupPolicyOutput => {
   return {
-    ModelPackageGroupArn:
-      output.ModelPackageGroupArn !== undefined && output.ModelPackageGroupArn !== null
-        ? output.ModelPackageGroupArn
-        : undefined,
+    ModelPackageGroupArn: __expectString(output.ModelPackageGroupArn),
   } as any;
 };
 
@@ -32920,7 +31787,7 @@ const deserializeAws_json1_1RealtimeInferenceInstanceTypes = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -32929,19 +31796,15 @@ const deserializeAws_json1_1RedshiftDatasetDefinition = (
   context: __SerdeContext
 ): RedshiftDatasetDefinition => {
   return {
-    ClusterId: output.ClusterId !== undefined && output.ClusterId !== null ? output.ClusterId : undefined,
-    ClusterRoleArn:
-      output.ClusterRoleArn !== undefined && output.ClusterRoleArn !== null ? output.ClusterRoleArn : undefined,
-    Database: output.Database !== undefined && output.Database !== null ? output.Database : undefined,
-    DbUser: output.DbUser !== undefined && output.DbUser !== null ? output.DbUser : undefined,
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
-    OutputCompression:
-      output.OutputCompression !== undefined && output.OutputCompression !== null
-        ? output.OutputCompression
-        : undefined,
-    OutputFormat: output.OutputFormat !== undefined && output.OutputFormat !== null ? output.OutputFormat : undefined,
-    OutputS3Uri: output.OutputS3Uri !== undefined && output.OutputS3Uri !== null ? output.OutputS3Uri : undefined,
-    QueryString: output.QueryString !== undefined && output.QueryString !== null ? output.QueryString : undefined,
+    ClusterId: __expectString(output.ClusterId),
+    ClusterRoleArn: __expectString(output.ClusterRoleArn),
+    Database: __expectString(output.Database),
+    DbUser: __expectString(output.DbUser),
+    KmsKeyId: __expectString(output.KmsKeyId),
+    OutputCompression: __expectString(output.OutputCompression),
+    OutputFormat: __expectString(output.OutputFormat),
+    OutputS3Uri: __expectString(output.OutputS3Uri),
+    QueryString: __expectString(output.QueryString),
   } as any;
 };
 
@@ -32950,14 +31813,14 @@ const deserializeAws_json1_1RegisterModelStepMetadata = (
   context: __SerdeContext
 ): RegisterModelStepMetadata => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
   } as any;
 };
 
 const deserializeAws_json1_1RenderingError = (output: any, context: __SerdeContext): RenderingError => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -32981,17 +31844,13 @@ const deserializeAws_json1_1RenderUiTemplateResponse = (
       output.Errors !== undefined && output.Errors !== null
         ? deserializeAws_json1_1RenderingErrorList(output.Errors, context)
         : undefined,
-    RenderedContent:
-      output.RenderedContent !== undefined && output.RenderedContent !== null ? output.RenderedContent : undefined,
+    RenderedContent: __expectString(output.RenderedContent),
   } as any;
 };
 
 const deserializeAws_json1_1RepositoryAuthConfig = (output: any, context: __SerdeContext): RepositoryAuthConfig => {
   return {
-    RepositoryCredentialsProviderArn:
-      output.RepositoryCredentialsProviderArn !== undefined && output.RepositoryCredentialsProviderArn !== null
-        ? output.RepositoryCredentialsProviderArn
-        : undefined,
+    RepositoryCredentialsProviderArn: __expectString(output.RepositoryCredentialsProviderArn),
   } as any;
 };
 
@@ -33005,64 +31864,49 @@ const deserializeAws_json1_1ResolvedAttributes = (output: any, context: __SerdeC
       output.CompletionCriteria !== undefined && output.CompletionCriteria !== null
         ? deserializeAws_json1_1AutoMLJobCompletionCriteria(output.CompletionCriteria, context)
         : undefined,
-    ProblemType: output.ProblemType !== undefined && output.ProblemType !== null ? output.ProblemType : undefined,
+    ProblemType: __expectString(output.ProblemType),
   } as any;
 };
 
 const deserializeAws_json1_1ResourceConfig = (output: any, context: __SerdeContext): ResourceConfig => {
   return {
-    InstanceCount:
-      output.InstanceCount !== undefined && output.InstanceCount !== null ? output.InstanceCount : undefined,
-    InstanceType: output.InstanceType !== undefined && output.InstanceType !== null ? output.InstanceType : undefined,
-    VolumeKmsKeyId:
-      output.VolumeKmsKeyId !== undefined && output.VolumeKmsKeyId !== null ? output.VolumeKmsKeyId : undefined,
-    VolumeSizeInGB:
-      output.VolumeSizeInGB !== undefined && output.VolumeSizeInGB !== null ? output.VolumeSizeInGB : undefined,
+    InstanceCount: __expectNumber(output.InstanceCount),
+    InstanceType: __expectString(output.InstanceType),
+    VolumeKmsKeyId: __expectString(output.VolumeKmsKeyId),
+    VolumeSizeInGB: __expectNumber(output.VolumeSizeInGB),
   } as any;
 };
 
 const deserializeAws_json1_1ResourceInUse = (output: any, context: __SerdeContext): ResourceInUse => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1ResourceLimitExceeded = (output: any, context: __SerdeContext): ResourceLimitExceeded => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1ResourceLimits = (output: any, context: __SerdeContext): ResourceLimits => {
   return {
-    MaxNumberOfTrainingJobs:
-      output.MaxNumberOfTrainingJobs !== undefined && output.MaxNumberOfTrainingJobs !== null
-        ? output.MaxNumberOfTrainingJobs
-        : undefined,
-    MaxParallelTrainingJobs:
-      output.MaxParallelTrainingJobs !== undefined && output.MaxParallelTrainingJobs !== null
-        ? output.MaxParallelTrainingJobs
-        : undefined,
+    MaxNumberOfTrainingJobs: __expectNumber(output.MaxNumberOfTrainingJobs),
+    MaxParallelTrainingJobs: __expectNumber(output.MaxParallelTrainingJobs),
   } as any;
 };
 
 const deserializeAws_json1_1ResourceNotFound = (output: any, context: __SerdeContext): ResourceNotFound => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1ResourceSpec = (output: any, context: __SerdeContext): ResourceSpec => {
   return {
-    InstanceType: output.InstanceType !== undefined && output.InstanceType !== null ? output.InstanceType : undefined,
-    SageMakerImageArn:
-      output.SageMakerImageArn !== undefined && output.SageMakerImageArn !== null
-        ? output.SageMakerImageArn
-        : undefined,
-    SageMakerImageVersionArn:
-      output.SageMakerImageVersionArn !== undefined && output.SageMakerImageVersionArn !== null
-        ? output.SageMakerImageVersionArn
-        : undefined,
+    InstanceType: __expectString(output.InstanceType),
+    SageMakerImageArn: __expectString(output.SageMakerImageArn),
+    SageMakerImageVersionArn: __expectString(output.SageMakerImageVersionArn),
   } as any;
 };
 
@@ -33073,16 +31917,13 @@ const deserializeAws_json1_1ResponseMIMETypes = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1RetryStrategy = (output: any, context: __SerdeContext): RetryStrategy => {
   return {
-    MaximumRetryAttempts:
-      output.MaximumRetryAttempts !== undefined && output.MaximumRetryAttempts !== null
-        ? output.MaximumRetryAttempts
-        : undefined,
+    MaximumRetryAttempts: __expectNumber(output.MaximumRetryAttempts),
   } as any;
 };
 
@@ -33093,7 +31934,7 @@ const deserializeAws_json1_1RuleParameters = (output: any, context: __SerdeConte
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -33104,32 +31945,23 @@ const deserializeAws_json1_1S3DataSource = (output: any, context: __SerdeContext
       output.AttributeNames !== undefined && output.AttributeNames !== null
         ? deserializeAws_json1_1AttributeNames(output.AttributeNames, context)
         : undefined,
-    S3DataDistributionType:
-      output.S3DataDistributionType !== undefined && output.S3DataDistributionType !== null
-        ? output.S3DataDistributionType
-        : undefined,
-    S3DataType: output.S3DataType !== undefined && output.S3DataType !== null ? output.S3DataType : undefined,
-    S3Uri: output.S3Uri !== undefined && output.S3Uri !== null ? output.S3Uri : undefined,
+    S3DataDistributionType: __expectString(output.S3DataDistributionType),
+    S3DataType: __expectString(output.S3DataType),
+    S3Uri: __expectString(output.S3Uri),
   } as any;
 };
 
 const deserializeAws_json1_1S3StorageConfig = (output: any, context: __SerdeContext): S3StorageConfig => {
   return {
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
-    ResolvedOutputS3Uri:
-      output.ResolvedOutputS3Uri !== undefined && output.ResolvedOutputS3Uri !== null
-        ? output.ResolvedOutputS3Uri
-        : undefined,
-    S3Uri: output.S3Uri !== undefined && output.S3Uri !== null ? output.S3Uri : undefined,
+    KmsKeyId: __expectString(output.KmsKeyId),
+    ResolvedOutputS3Uri: __expectString(output.ResolvedOutputS3Uri),
+    S3Uri: __expectString(output.S3Uri),
   } as any;
 };
 
 const deserializeAws_json1_1ScheduleConfig = (output: any, context: __SerdeContext): ScheduleConfig => {
   return {
-    ScheduleExpression:
-      output.ScheduleExpression !== undefined && output.ScheduleExpression !== null
-        ? output.ScheduleExpression
-        : undefined,
+    ScheduleExpression: __expectString(output.ScheduleExpression),
   } as any;
 };
 
@@ -33180,7 +32012,7 @@ const deserializeAws_json1_1SearchRecord = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_1SearchResponse = (output: any, context: __SerdeContext): SearchResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Results:
       output.Results !== undefined && output.Results !== null
         ? deserializeAws_json1_1SearchResultsList(output.Results, context)
@@ -33210,9 +32042,8 @@ const deserializeAws_json1_1SecondaryStatusTransition = (
       output.StartTime !== undefined && output.StartTime !== null
         ? new Date(Math.round(output.StartTime * 1000))
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusMessage:
-      output.StatusMessage !== undefined && output.StatusMessage !== null ? output.StatusMessage : undefined,
+    Status: __expectString(output.Status),
+    StatusMessage: __expectString(output.StatusMessage),
   } as any;
 };
 
@@ -33237,7 +32068,7 @@ const deserializeAws_json1_1SecurityGroupIds = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -33246,10 +32077,7 @@ const deserializeAws_json1_1SendPipelineExecutionStepFailureResponse = (
   context: __SerdeContext
 ): SendPipelineExecutionStepFailureResponse => {
   return {
-    PipelineExecutionArn:
-      output.PipelineExecutionArn !== undefined && output.PipelineExecutionArn !== null
-        ? output.PipelineExecutionArn
-        : undefined,
+    PipelineExecutionArn: __expectString(output.PipelineExecutionArn),
   } as any;
 };
 
@@ -33258,10 +32086,7 @@ const deserializeAws_json1_1SendPipelineExecutionStepSuccessResponse = (
   context: __SerdeContext
 ): SendPipelineExecutionStepSuccessResponse => {
   return {
-    PipelineExecutionArn:
-      output.PipelineExecutionArn !== undefined && output.PipelineExecutionArn !== null
-        ? output.PipelineExecutionArn
-        : undefined,
+    PipelineExecutionArn: __expectString(output.PipelineExecutionArn),
   } as any;
 };
 
@@ -33270,14 +32095,8 @@ const deserializeAws_json1_1ServiceCatalogProvisionedProductDetails = (
   context: __SerdeContext
 ): ServiceCatalogProvisionedProductDetails => {
   return {
-    ProvisionedProductId:
-      output.ProvisionedProductId !== undefined && output.ProvisionedProductId !== null
-        ? output.ProvisionedProductId
-        : undefined,
-    ProvisionedProductStatusMessage:
-      output.ProvisionedProductStatusMessage !== undefined && output.ProvisionedProductStatusMessage !== null
-        ? output.ProvisionedProductStatusMessage
-        : undefined,
+    ProvisionedProductId: __expectString(output.ProvisionedProductId),
+    ProvisionedProductStatusMessage: __expectString(output.ProvisionedProductStatusMessage),
   } as any;
 };
 
@@ -33286,12 +32105,9 @@ const deserializeAws_json1_1ServiceCatalogProvisioningDetails = (
   context: __SerdeContext
 ): ServiceCatalogProvisioningDetails => {
   return {
-    PathId: output.PathId !== undefined && output.PathId !== null ? output.PathId : undefined,
-    ProductId: output.ProductId !== undefined && output.ProductId !== null ? output.ProductId : undefined,
-    ProvisioningArtifactId:
-      output.ProvisioningArtifactId !== undefined && output.ProvisioningArtifactId !== null
-        ? output.ProvisioningArtifactId
-        : undefined,
+    PathId: __expectString(output.PathId),
+    ProductId: __expectString(output.ProductId),
+    ProvisioningArtifactId: __expectString(output.ProvisioningArtifactId),
     ProvisioningParameters:
       output.ProvisioningParameters !== undefined && output.ProvisioningParameters !== null
         ? deserializeAws_json1_1ProvisioningParameters(output.ProvisioningParameters, context)
@@ -33301,26 +32117,22 @@ const deserializeAws_json1_1ServiceCatalogProvisioningDetails = (
 
 const deserializeAws_json1_1SharingSettings = (output: any, context: __SerdeContext): SharingSettings => {
   return {
-    NotebookOutputOption:
-      output.NotebookOutputOption !== undefined && output.NotebookOutputOption !== null
-        ? output.NotebookOutputOption
-        : undefined,
-    S3KmsKeyId: output.S3KmsKeyId !== undefined && output.S3KmsKeyId !== null ? output.S3KmsKeyId : undefined,
-    S3OutputPath: output.S3OutputPath !== undefined && output.S3OutputPath !== null ? output.S3OutputPath : undefined,
+    NotebookOutputOption: __expectString(output.NotebookOutputOption),
+    S3KmsKeyId: __expectString(output.S3KmsKeyId),
+    S3OutputPath: __expectString(output.S3OutputPath),
   } as any;
 };
 
 const deserializeAws_json1_1ShuffleConfig = (output: any, context: __SerdeContext): ShuffleConfig => {
   return {
-    Seed: output.Seed !== undefined && output.Seed !== null ? output.Seed : undefined,
+    Seed: __expectNumber(output.Seed),
   } as any;
 };
 
 const deserializeAws_json1_1SourceAlgorithm = (output: any, context: __SerdeContext): SourceAlgorithm => {
   return {
-    AlgorithmName:
-      output.AlgorithmName !== undefined && output.AlgorithmName !== null ? output.AlgorithmName : undefined,
-    ModelDataUrl: output.ModelDataUrl !== undefined && output.ModelDataUrl !== null ? output.ModelDataUrl : undefined,
+    AlgorithmName: __expectString(output.AlgorithmName),
+    ModelDataUrl: __expectString(output.ModelDataUrl),
   } as any;
 };
 
@@ -33361,23 +32173,14 @@ const deserializeAws_json1_1StartPipelineExecutionResponse = (
   context: __SerdeContext
 ): StartPipelineExecutionResponse => {
   return {
-    PipelineExecutionArn:
-      output.PipelineExecutionArn !== undefined && output.PipelineExecutionArn !== null
-        ? output.PipelineExecutionArn
-        : undefined,
+    PipelineExecutionArn: __expectString(output.PipelineExecutionArn),
   } as any;
 };
 
 const deserializeAws_json1_1StoppingCondition = (output: any, context: __SerdeContext): StoppingCondition => {
   return {
-    MaxRuntimeInSeconds:
-      output.MaxRuntimeInSeconds !== undefined && output.MaxRuntimeInSeconds !== null
-        ? output.MaxRuntimeInSeconds
-        : undefined,
-    MaxWaitTimeInSeconds:
-      output.MaxWaitTimeInSeconds !== undefined && output.MaxWaitTimeInSeconds !== null
-        ? output.MaxWaitTimeInSeconds
-        : undefined,
+    MaxRuntimeInSeconds: __expectNumber(output.MaxRuntimeInSeconds),
+    MaxWaitTimeInSeconds: __expectNumber(output.MaxWaitTimeInSeconds),
   } as any;
 };
 
@@ -33386,10 +32189,7 @@ const deserializeAws_json1_1StopPipelineExecutionResponse = (
   context: __SerdeContext
 ): StopPipelineExecutionResponse => {
   return {
-    PipelineExecutionArn:
-      output.PipelineExecutionArn !== undefined && output.PipelineExecutionArn !== null
-        ? output.PipelineExecutionArn
-        : undefined,
+    PipelineExecutionArn: __expectString(output.PipelineExecutionArn),
   } as any;
 };
 
@@ -33400,21 +32200,17 @@ const deserializeAws_json1_1Subnets = (output: any, context: __SerdeContext): st
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1SubscribedWorkteam = (output: any, context: __SerdeContext): SubscribedWorkteam => {
   return {
-    ListingId: output.ListingId !== undefined && output.ListingId !== null ? output.ListingId : undefined,
-    MarketplaceDescription:
-      output.MarketplaceDescription !== undefined && output.MarketplaceDescription !== null
-        ? output.MarketplaceDescription
-        : undefined,
-    MarketplaceTitle:
-      output.MarketplaceTitle !== undefined && output.MarketplaceTitle !== null ? output.MarketplaceTitle : undefined,
-    SellerName: output.SellerName !== undefined && output.SellerName !== null ? output.SellerName : undefined,
-    WorkteamArn: output.WorkteamArn !== undefined && output.WorkteamArn !== null ? output.WorkteamArn : undefined,
+    ListingId: __expectString(output.ListingId),
+    MarketplaceDescription: __expectString(output.MarketplaceDescription),
+    MarketplaceTitle: __expectString(output.MarketplaceTitle),
+    SellerName: __expectString(output.SellerName),
+    WorkteamArn: __expectString(output.WorkteamArn),
   } as any;
 };
 
@@ -33431,8 +32227,8 @@ const deserializeAws_json1_1SubscribedWorkteams = (output: any, context: __Serde
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -33449,9 +32245,9 @@ const deserializeAws_json1_1TagList = (output: any, context: __SerdeContext): Ta
 
 const deserializeAws_json1_1TargetPlatform = (output: any, context: __SerdeContext): TargetPlatform => {
   return {
-    Accelerator: output.Accelerator !== undefined && output.Accelerator !== null ? output.Accelerator : undefined,
-    Arch: output.Arch !== undefined && output.Arch !== null ? output.Arch : undefined,
-    Os: output.Os !== undefined && output.Os !== null ? output.Os : undefined,
+    Accelerator: __expectString(output.Accelerator),
+    Arch: __expectString(output.Arch),
+    Os: __expectString(output.Os),
   } as any;
 };
 
@@ -33462,7 +32258,7 @@ const deserializeAws_json1_1TaskKeywords = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -33480,8 +32276,8 @@ const deserializeAws_json1_1TensorBoardOutputConfig = (
   context: __SerdeContext
 ): TensorBoardOutputConfig => {
   return {
-    LocalPath: output.LocalPath !== undefined && output.LocalPath !== null ? output.LocalPath : undefined,
-    S3OutputPath: output.S3OutputPath !== undefined && output.S3OutputPath !== null ? output.S3OutputPath : undefined,
+    LocalPath: __expectString(output.LocalPath),
+    S3OutputPath: __expectString(output.S3OutputPath),
   } as any;
 };
 
@@ -33491,11 +32287,8 @@ const deserializeAws_json1_1TrafficRoutingConfig = (output: any, context: __Serd
       output.CanarySize !== undefined && output.CanarySize !== null
         ? deserializeAws_json1_1CapacitySize(output.CanarySize, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    WaitIntervalInSeconds:
-      output.WaitIntervalInSeconds !== undefined && output.WaitIntervalInSeconds !== null
-        ? output.WaitIntervalInSeconds
-        : undefined,
+    Type: __expectString(output.Type),
+    WaitIntervalInSeconds: __expectNumber(output.WaitIntervalInSeconds),
   } as any;
 };
 
@@ -33509,7 +32302,7 @@ const deserializeAws_json1_1TrainingEnvironmentMap = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -33524,7 +32317,7 @@ const deserializeAws_json1_1TrainingInstanceTypes = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -33534,11 +32327,8 @@ const deserializeAws_json1_1TrainingJob = (output: any, context: __SerdeContext)
       output.AlgorithmSpecification !== undefined && output.AlgorithmSpecification !== null
         ? deserializeAws_json1_1AlgorithmSpecification(output.AlgorithmSpecification, context)
         : undefined,
-    AutoMLJobArn: output.AutoMLJobArn !== undefined && output.AutoMLJobArn !== null ? output.AutoMLJobArn : undefined,
-    BillableTimeInSeconds:
-      output.BillableTimeInSeconds !== undefined && output.BillableTimeInSeconds !== null
-        ? output.BillableTimeInSeconds
-        : undefined,
+    AutoMLJobArn: __expectString(output.AutoMLJobArn),
+    BillableTimeInSeconds: __expectNumber(output.BillableTimeInSeconds),
     CheckpointConfig:
       output.CheckpointConfig !== undefined && output.CheckpointConfig !== null
         ? deserializeAws_json1_1CheckpointConfig(output.CheckpointConfig, context)
@@ -33559,19 +32349,9 @@ const deserializeAws_json1_1TrainingJob = (output: any, context: __SerdeContext)
       output.DebugRuleEvaluationStatuses !== undefined && output.DebugRuleEvaluationStatuses !== null
         ? deserializeAws_json1_1DebugRuleEvaluationStatuses(output.DebugRuleEvaluationStatuses, context)
         : undefined,
-    EnableInterContainerTrafficEncryption:
-      output.EnableInterContainerTrafficEncryption !== undefined &&
-      output.EnableInterContainerTrafficEncryption !== null
-        ? output.EnableInterContainerTrafficEncryption
-        : undefined,
-    EnableManagedSpotTraining:
-      output.EnableManagedSpotTraining !== undefined && output.EnableManagedSpotTraining !== null
-        ? output.EnableManagedSpotTraining
-        : undefined,
-    EnableNetworkIsolation:
-      output.EnableNetworkIsolation !== undefined && output.EnableNetworkIsolation !== null
-        ? output.EnableNetworkIsolation
-        : undefined,
+    EnableInterContainerTrafficEncryption: __expectBoolean(output.EnableInterContainerTrafficEncryption),
+    EnableManagedSpotTraining: __expectBoolean(output.EnableManagedSpotTraining),
+    EnableNetworkIsolation: __expectBoolean(output.EnableNetworkIsolation),
     Environment:
       output.Environment !== undefined && output.Environment !== null
         ? deserializeAws_json1_1TrainingEnvironmentMap(output.Environment, context)
@@ -33580,8 +32360,7 @@ const deserializeAws_json1_1TrainingJob = (output: any, context: __SerdeContext)
       output.ExperimentConfig !== undefined && output.ExperimentConfig !== null
         ? deserializeAws_json1_1ExperimentConfig(output.ExperimentConfig, context)
         : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
+    FailureReason: __expectString(output.FailureReason),
     FinalMetricDataList:
       output.FinalMetricDataList !== undefined && output.FinalMetricDataList !== null
         ? deserializeAws_json1_1FinalMetricDataList(output.FinalMetricDataList, context)
@@ -33594,8 +32373,7 @@ const deserializeAws_json1_1TrainingJob = (output: any, context: __SerdeContext)
       output.InputDataConfig !== undefined && output.InputDataConfig !== null
         ? deserializeAws_json1_1InputDataConfig(output.InputDataConfig, context)
         : undefined,
-    LabelingJobArn:
-      output.LabelingJobArn !== undefined && output.LabelingJobArn !== null ? output.LabelingJobArn : undefined,
+    LabelingJobArn: __expectString(output.LabelingJobArn),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
@@ -33616,9 +32394,8 @@ const deserializeAws_json1_1TrainingJob = (output: any, context: __SerdeContext)
       output.RetryStrategy !== undefined && output.RetryStrategy !== null
         ? deserializeAws_json1_1RetryStrategy(output.RetryStrategy, context)
         : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
-    SecondaryStatus:
-      output.SecondaryStatus !== undefined && output.SecondaryStatus !== null ? output.SecondaryStatus : undefined,
+    RoleArn: __expectString(output.RoleArn),
+    SecondaryStatus: __expectString(output.SecondaryStatus),
     SecondaryStatusTransitions:
       output.SecondaryStatusTransitions !== undefined && output.SecondaryStatusTransitions !== null
         ? deserializeAws_json1_1SecondaryStatusTransitions(output.SecondaryStatusTransitions, context)
@@ -33639,23 +32416,15 @@ const deserializeAws_json1_1TrainingJob = (output: any, context: __SerdeContext)
       output.TrainingEndTime !== undefined && output.TrainingEndTime !== null
         ? new Date(Math.round(output.TrainingEndTime * 1000))
         : undefined,
-    TrainingJobArn:
-      output.TrainingJobArn !== undefined && output.TrainingJobArn !== null ? output.TrainingJobArn : undefined,
-    TrainingJobName:
-      output.TrainingJobName !== undefined && output.TrainingJobName !== null ? output.TrainingJobName : undefined,
-    TrainingJobStatus:
-      output.TrainingJobStatus !== undefined && output.TrainingJobStatus !== null
-        ? output.TrainingJobStatus
-        : undefined,
+    TrainingJobArn: __expectString(output.TrainingJobArn),
+    TrainingJobName: __expectString(output.TrainingJobName),
+    TrainingJobStatus: __expectString(output.TrainingJobStatus),
     TrainingStartTime:
       output.TrainingStartTime !== undefined && output.TrainingStartTime !== null
         ? new Date(Math.round(output.TrainingStartTime * 1000))
         : undefined,
-    TrainingTimeInSeconds:
-      output.TrainingTimeInSeconds !== undefined && output.TrainingTimeInSeconds !== null
-        ? output.TrainingTimeInSeconds
-        : undefined,
-    TuningJobArn: output.TuningJobArn !== undefined && output.TuningJobArn !== null ? output.TuningJobArn : undefined,
+    TrainingTimeInSeconds: __expectNumber(output.TrainingTimeInSeconds),
+    TuningJobArn: __expectString(output.TuningJobArn),
     VpcConfig:
       output.VpcConfig !== undefined && output.VpcConfig !== null
         ? deserializeAws_json1_1VpcConfig(output.VpcConfig, context)
@@ -33685,10 +32454,7 @@ const deserializeAws_json1_1TrainingJobDefinition = (output: any, context: __Ser
       output.StoppingCondition !== undefined && output.StoppingCondition !== null
         ? deserializeAws_json1_1StoppingCondition(output.StoppingCondition, context)
         : undefined,
-    TrainingInputMode:
-      output.TrainingInputMode !== undefined && output.TrainingInputMode !== null
-        ? output.TrainingInputMode
-        : undefined,
+    TrainingInputMode: __expectString(output.TrainingInputMode),
   } as any;
 };
 
@@ -33697,15 +32463,11 @@ const deserializeAws_json1_1TrainingJobStatusCounters = (
   context: __SerdeContext
 ): TrainingJobStatusCounters => {
   return {
-    Completed: output.Completed !== undefined && output.Completed !== null ? output.Completed : undefined,
-    InProgress: output.InProgress !== undefined && output.InProgress !== null ? output.InProgress : undefined,
-    NonRetryableError:
-      output.NonRetryableError !== undefined && output.NonRetryableError !== null
-        ? output.NonRetryableError
-        : undefined,
-    RetryableError:
-      output.RetryableError !== undefined && output.RetryableError !== null ? output.RetryableError : undefined,
-    Stopped: output.Stopped !== undefined && output.Stopped !== null ? output.Stopped : undefined,
+    Completed: __expectNumber(output.Completed),
+    InProgress: __expectNumber(output.InProgress),
+    NonRetryableError: __expectNumber(output.NonRetryableError),
+    RetryableError: __expectNumber(output.RetryableError),
+    Stopped: __expectNumber(output.Stopped),
   } as any;
 };
 
@@ -33714,7 +32476,7 @@ const deserializeAws_json1_1TrainingJobStepMetadata = (
   context: __SerdeContext
 ): TrainingJobStepMetadata => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
   } as any;
 };
 
@@ -33743,14 +32505,9 @@ const deserializeAws_json1_1TrainingJobSummary = (output: any, context: __SerdeC
       output.TrainingEndTime !== undefined && output.TrainingEndTime !== null
         ? new Date(Math.round(output.TrainingEndTime * 1000))
         : undefined,
-    TrainingJobArn:
-      output.TrainingJobArn !== undefined && output.TrainingJobArn !== null ? output.TrainingJobArn : undefined,
-    TrainingJobName:
-      output.TrainingJobName !== undefined && output.TrainingJobName !== null ? output.TrainingJobName : undefined,
-    TrainingJobStatus:
-      output.TrainingJobStatus !== undefined && output.TrainingJobStatus !== null
-        ? output.TrainingJobStatus
-        : undefined,
+    TrainingJobArn: __expectString(output.TrainingJobArn),
+    TrainingJobName: __expectString(output.TrainingJobName),
+    TrainingJobStatus: __expectString(output.TrainingJobStatus),
   } as any;
 };
 
@@ -33772,20 +32529,13 @@ const deserializeAws_json1_1TrainingSpecification = (output: any, context: __Ser
       output.SupportedTuningJobObjectiveMetrics !== undefined && output.SupportedTuningJobObjectiveMetrics !== null
         ? deserializeAws_json1_1HyperParameterTuningJobObjectives(output.SupportedTuningJobObjectiveMetrics, context)
         : undefined,
-    SupportsDistributedTraining:
-      output.SupportsDistributedTraining !== undefined && output.SupportsDistributedTraining !== null
-        ? output.SupportsDistributedTraining
-        : undefined,
+    SupportsDistributedTraining: __expectBoolean(output.SupportsDistributedTraining),
     TrainingChannels:
       output.TrainingChannels !== undefined && output.TrainingChannels !== null
         ? deserializeAws_json1_1ChannelSpecifications(output.TrainingChannels, context)
         : undefined,
-    TrainingImage:
-      output.TrainingImage !== undefined && output.TrainingImage !== null ? output.TrainingImage : undefined,
-    TrainingImageDigest:
-      output.TrainingImageDigest !== undefined && output.TrainingImageDigest !== null
-        ? output.TrainingImageDigest
-        : undefined,
+    TrainingImage: __expectString(output.TrainingImage),
+    TrainingImageDigest: __expectString(output.TrainingImageDigest),
   } as any;
 };
 
@@ -33808,21 +32558,20 @@ const deserializeAws_json1_1TransformEnvironmentMap = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_json1_1TransformInput = (output: any, context: __SerdeContext): TransformInput => {
   return {
-    CompressionType:
-      output.CompressionType !== undefined && output.CompressionType !== null ? output.CompressionType : undefined,
-    ContentType: output.ContentType !== undefined && output.ContentType !== null ? output.ContentType : undefined,
+    CompressionType: __expectString(output.CompressionType),
+    ContentType: __expectString(output.ContentType),
     DataSource:
       output.DataSource !== undefined && output.DataSource !== null
         ? deserializeAws_json1_1TransformDataSource(output.DataSource, context)
         : undefined,
-    SplitType: output.SplitType !== undefined && output.SplitType !== null ? output.SplitType : undefined,
+    SplitType: __expectString(output.SplitType),
   } as any;
 };
 
@@ -33836,15 +32585,14 @@ const deserializeAws_json1_1TransformInstanceTypes = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1TransformJob = (output: any, context: __SerdeContext): TransformJob => {
   return {
-    AutoMLJobArn: output.AutoMLJobArn !== undefined && output.AutoMLJobArn !== null ? output.AutoMLJobArn : undefined,
-    BatchStrategy:
-      output.BatchStrategy !== undefined && output.BatchStrategy !== null ? output.BatchStrategy : undefined,
+    AutoMLJobArn: __expectString(output.AutoMLJobArn),
+    BatchStrategy: __expectString(output.BatchStrategy),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
@@ -33861,21 +32609,15 @@ const deserializeAws_json1_1TransformJob = (output: any, context: __SerdeContext
       output.ExperimentConfig !== undefined && output.ExperimentConfig !== null
         ? deserializeAws_json1_1ExperimentConfig(output.ExperimentConfig, context)
         : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
-    LabelingJobArn:
-      output.LabelingJobArn !== undefined && output.LabelingJobArn !== null ? output.LabelingJobArn : undefined,
-    MaxConcurrentTransforms:
-      output.MaxConcurrentTransforms !== undefined && output.MaxConcurrentTransforms !== null
-        ? output.MaxConcurrentTransforms
-        : undefined,
-    MaxPayloadInMB:
-      output.MaxPayloadInMB !== undefined && output.MaxPayloadInMB !== null ? output.MaxPayloadInMB : undefined,
+    FailureReason: __expectString(output.FailureReason),
+    LabelingJobArn: __expectString(output.LabelingJobArn),
+    MaxConcurrentTransforms: __expectNumber(output.MaxConcurrentTransforms),
+    MaxPayloadInMB: __expectNumber(output.MaxPayloadInMB),
     ModelClientConfig:
       output.ModelClientConfig !== undefined && output.ModelClientConfig !== null
         ? deserializeAws_json1_1ModelClientConfig(output.ModelClientConfig, context)
         : undefined,
-    ModelName: output.ModelName !== undefined && output.ModelName !== null ? output.ModelName : undefined,
+    ModelName: __expectString(output.ModelName),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_1TagList(output.Tags, context)
@@ -33888,14 +32630,9 @@ const deserializeAws_json1_1TransformJob = (output: any, context: __SerdeContext
       output.TransformInput !== undefined && output.TransformInput !== null
         ? deserializeAws_json1_1TransformInput(output.TransformInput, context)
         : undefined,
-    TransformJobArn:
-      output.TransformJobArn !== undefined && output.TransformJobArn !== null ? output.TransformJobArn : undefined,
-    TransformJobName:
-      output.TransformJobName !== undefined && output.TransformJobName !== null ? output.TransformJobName : undefined,
-    TransformJobStatus:
-      output.TransformJobStatus !== undefined && output.TransformJobStatus !== null
-        ? output.TransformJobStatus
-        : undefined,
+    TransformJobArn: __expectString(output.TransformJobArn),
+    TransformJobName: __expectString(output.TransformJobName),
+    TransformJobStatus: __expectString(output.TransformJobStatus),
     TransformOutput:
       output.TransformOutput !== undefined && output.TransformOutput !== null
         ? deserializeAws_json1_1TransformOutput(output.TransformOutput, context)
@@ -33913,18 +32650,13 @@ const deserializeAws_json1_1TransformJob = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_1TransformJobDefinition = (output: any, context: __SerdeContext): TransformJobDefinition => {
   return {
-    BatchStrategy:
-      output.BatchStrategy !== undefined && output.BatchStrategy !== null ? output.BatchStrategy : undefined,
+    BatchStrategy: __expectString(output.BatchStrategy),
     Environment:
       output.Environment !== undefined && output.Environment !== null
         ? deserializeAws_json1_1TransformEnvironmentMap(output.Environment, context)
         : undefined,
-    MaxConcurrentTransforms:
-      output.MaxConcurrentTransforms !== undefined && output.MaxConcurrentTransforms !== null
-        ? output.MaxConcurrentTransforms
-        : undefined,
-    MaxPayloadInMB:
-      output.MaxPayloadInMB !== undefined && output.MaxPayloadInMB !== null ? output.MaxPayloadInMB : undefined,
+    MaxConcurrentTransforms: __expectNumber(output.MaxConcurrentTransforms),
+    MaxPayloadInMB: __expectNumber(output.MaxPayloadInMB),
     TransformInput:
       output.TransformInput !== undefined && output.TransformInput !== null
         ? deserializeAws_json1_1TransformInput(output.TransformInput, context)
@@ -33945,7 +32677,7 @@ const deserializeAws_json1_1TransformJobStepMetadata = (
   context: __SerdeContext
 ): TransformJobStepMetadata => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
   } as any;
 };
 
@@ -33966,8 +32698,7 @@ const deserializeAws_json1_1TransformJobSummary = (output: any, context: __Serde
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
+    FailureReason: __expectString(output.FailureReason),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
@@ -33976,40 +32707,33 @@ const deserializeAws_json1_1TransformJobSummary = (output: any, context: __Serde
       output.TransformEndTime !== undefined && output.TransformEndTime !== null
         ? new Date(Math.round(output.TransformEndTime * 1000))
         : undefined,
-    TransformJobArn:
-      output.TransformJobArn !== undefined && output.TransformJobArn !== null ? output.TransformJobArn : undefined,
-    TransformJobName:
-      output.TransformJobName !== undefined && output.TransformJobName !== null ? output.TransformJobName : undefined,
-    TransformJobStatus:
-      output.TransformJobStatus !== undefined && output.TransformJobStatus !== null
-        ? output.TransformJobStatus
-        : undefined,
+    TransformJobArn: __expectString(output.TransformJobArn),
+    TransformJobName: __expectString(output.TransformJobName),
+    TransformJobStatus: __expectString(output.TransformJobStatus),
   } as any;
 };
 
 const deserializeAws_json1_1TransformOutput = (output: any, context: __SerdeContext): TransformOutput => {
   return {
-    Accept: output.Accept !== undefined && output.Accept !== null ? output.Accept : undefined,
-    AssembleWith: output.AssembleWith !== undefined && output.AssembleWith !== null ? output.AssembleWith : undefined,
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
-    S3OutputPath: output.S3OutputPath !== undefined && output.S3OutputPath !== null ? output.S3OutputPath : undefined,
+    Accept: __expectString(output.Accept),
+    AssembleWith: __expectString(output.AssembleWith),
+    KmsKeyId: __expectString(output.KmsKeyId),
+    S3OutputPath: __expectString(output.S3OutputPath),
   } as any;
 };
 
 const deserializeAws_json1_1TransformResources = (output: any, context: __SerdeContext): TransformResources => {
   return {
-    InstanceCount:
-      output.InstanceCount !== undefined && output.InstanceCount !== null ? output.InstanceCount : undefined,
-    InstanceType: output.InstanceType !== undefined && output.InstanceType !== null ? output.InstanceType : undefined,
-    VolumeKmsKeyId:
-      output.VolumeKmsKeyId !== undefined && output.VolumeKmsKeyId !== null ? output.VolumeKmsKeyId : undefined,
+    InstanceCount: __expectNumber(output.InstanceCount),
+    InstanceType: __expectString(output.InstanceType),
+    VolumeKmsKeyId: __expectString(output.VolumeKmsKeyId),
   } as any;
 };
 
 const deserializeAws_json1_1TransformS3DataSource = (output: any, context: __SerdeContext): TransformS3DataSource => {
   return {
-    S3DataType: output.S3DataType !== undefined && output.S3DataType !== null ? output.S3DataType : undefined,
-    S3Uri: output.S3Uri !== undefined && output.S3Uri !== null ? output.S3Uri : undefined,
+    S3DataType: __expectString(output.S3DataType),
+    S3Uri: __expectString(output.S3Uri),
   } as any;
 };
 
@@ -34023,9 +32747,8 @@ const deserializeAws_json1_1Trial = (output: any, context: __SerdeContext): Tria
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    DisplayName: output.DisplayName !== undefined && output.DisplayName !== null ? output.DisplayName : undefined,
-    ExperimentName:
-      output.ExperimentName !== undefined && output.ExperimentName !== null ? output.ExperimentName : undefined,
+    DisplayName: __expectString(output.DisplayName),
+    ExperimentName: __expectString(output.ExperimentName),
     LastModifiedBy:
       output.LastModifiedBy !== undefined && output.LastModifiedBy !== null
         ? deserializeAws_json1_1UserContext(output.LastModifiedBy, context)
@@ -34046,12 +32769,12 @@ const deserializeAws_json1_1Trial = (output: any, context: __SerdeContext): Tria
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_1TagList(output.Tags, context)
         : undefined,
-    TrialArn: output.TrialArn !== undefined && output.TrialArn !== null ? output.TrialArn : undefined,
+    TrialArn: __expectString(output.TrialArn),
     TrialComponentSummaries:
       output.TrialComponentSummaries !== undefined && output.TrialComponentSummaries !== null
         ? deserializeAws_json1_1TrialComponentSimpleSummaries(output.TrialComponentSummaries, context)
         : undefined,
-    TrialName: output.TrialName !== undefined && output.TrialName !== null ? output.TrialName : undefined,
+    TrialName: __expectString(output.TrialName),
   } as any;
 };
 
@@ -34065,7 +32788,7 @@ const deserializeAws_json1_1TrialComponent = (output: any, context: __SerdeConte
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    DisplayName: output.DisplayName !== undefined && output.DisplayName !== null ? output.DisplayName : undefined,
+    DisplayName: __expectString(output.DisplayName),
     EndTime:
       output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
     InputArtifacts:
@@ -34120,21 +32843,15 @@ const deserializeAws_json1_1TrialComponent = (output: any, context: __SerdeConte
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_1TagList(output.Tags, context)
         : undefined,
-    TrialComponentArn:
-      output.TrialComponentArn !== undefined && output.TrialComponentArn !== null
-        ? output.TrialComponentArn
-        : undefined,
-    TrialComponentName:
-      output.TrialComponentName !== undefined && output.TrialComponentName !== null
-        ? output.TrialComponentName
-        : undefined,
+    TrialComponentArn: __expectString(output.TrialComponentArn),
+    TrialComponentName: __expectString(output.TrialComponentName),
   } as any;
 };
 
 const deserializeAws_json1_1TrialComponentArtifact = (output: any, context: __SerdeContext): TrialComponentArtifact => {
   return {
-    MediaType: output.MediaType !== undefined && output.MediaType !== null ? output.MediaType : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    MediaType: __expectString(output.MediaType),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -34175,14 +32892,14 @@ const deserializeAws_json1_1TrialComponentMetricSummary = (
   context: __SerdeContext
 ): TrialComponentMetricSummary => {
   return {
-    Avg: output.Avg !== undefined && output.Avg !== null ? output.Avg : undefined,
-    Count: output.Count !== undefined && output.Count !== null ? output.Count : undefined,
-    Last: output.Last !== undefined && output.Last !== null ? output.Last : undefined,
-    Max: output.Max !== undefined && output.Max !== null ? output.Max : undefined,
-    MetricName: output.MetricName !== undefined && output.MetricName !== null ? output.MetricName : undefined,
-    Min: output.Min !== undefined && output.Min !== null ? output.Min : undefined,
-    SourceArn: output.SourceArn !== undefined && output.SourceArn !== null ? output.SourceArn : undefined,
-    StdDev: output.StdDev !== undefined && output.StdDev !== null ? output.StdDev : undefined,
+    Avg: __expectNumber(output.Avg),
+    Count: __expectNumber(output.Count),
+    Last: __expectNumber(output.Last),
+    Max: __expectNumber(output.Max),
+    MetricName: __expectString(output.MetricName),
+    Min: __expectNumber(output.Min),
+    SourceArn: __expectString(output.SourceArn),
+    StdDev: __expectNumber(output.StdDev),
     TimeStamp:
       output.TimeStamp !== undefined && output.TimeStamp !== null
         ? new Date(Math.round(output.TimeStamp * 1000))
@@ -34212,15 +32929,11 @@ const deserializeAws_json1_1TrialComponentParameterValue = (
   output: any,
   context: __SerdeContext
 ): TrialComponentParameterValue => {
-  if (output.NumberValue !== undefined && output.NumberValue !== null) {
-    return {
-      NumberValue: output.NumberValue,
-    };
+  if (__expectNumber(output.NumberValue) !== undefined) {
+    return { NumberValue: __expectNumber(output.NumberValue) as any };
   }
-  if (output.StringValue !== undefined && output.StringValue !== null) {
-    return {
-      StringValue: output.StringValue,
-    };
+  if (__expectString(output.StringValue) !== undefined) {
+    return { StringValue: __expectString(output.StringValue) as any };
   }
   return { $unknown: Object.entries(output)[0] };
 };
@@ -34252,14 +32965,8 @@ const deserializeAws_json1_1TrialComponentSimpleSummary = (
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    TrialComponentArn:
-      output.TrialComponentArn !== undefined && output.TrialComponentArn !== null
-        ? output.TrialComponentArn
-        : undefined,
-    TrialComponentName:
-      output.TrialComponentName !== undefined && output.TrialComponentName !== null
-        ? output.TrialComponentName
-        : undefined,
+    TrialComponentArn: __expectString(output.TrialComponentArn),
+    TrialComponentName: __expectString(output.TrialComponentName),
     TrialComponentSource:
       output.TrialComponentSource !== undefined && output.TrialComponentSource !== null
         ? deserializeAws_json1_1TrialComponentSource(output.TrialComponentSource, context)
@@ -34269,8 +32976,8 @@ const deserializeAws_json1_1TrialComponentSimpleSummary = (
 
 const deserializeAws_json1_1TrialComponentSource = (output: any, context: __SerdeContext): TrialComponentSource => {
   return {
-    SourceArn: output.SourceArn !== undefined && output.SourceArn !== null ? output.SourceArn : undefined,
-    SourceType: output.SourceType !== undefined && output.SourceType !== null ? output.SourceType : undefined,
+    SourceArn: __expectString(output.SourceArn),
+    SourceType: __expectString(output.SourceType),
   } as any;
 };
 
@@ -34283,7 +32990,7 @@ const deserializeAws_json1_1TrialComponentSourceDetail = (
       output.ProcessingJob !== undefined && output.ProcessingJob !== null
         ? deserializeAws_json1_1ProcessingJob(output.ProcessingJob, context)
         : undefined,
-    SourceArn: output.SourceArn !== undefined && output.SourceArn !== null ? output.SourceArn : undefined,
+    SourceArn: __expectString(output.SourceArn),
     TrainingJob:
       output.TrainingJob !== undefined && output.TrainingJob !== null
         ? deserializeAws_json1_1TrainingJob(output.TrainingJob, context)
@@ -34297,9 +33004,8 @@ const deserializeAws_json1_1TrialComponentSourceDetail = (
 
 const deserializeAws_json1_1TrialComponentStatus = (output: any, context: __SerdeContext): TrialComponentStatus => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    PrimaryStatus:
-      output.PrimaryStatus !== undefined && output.PrimaryStatus !== null ? output.PrimaryStatus : undefined,
+    Message: __expectString(output.Message),
+    PrimaryStatus: __expectString(output.PrimaryStatus),
   } as any;
 };
 
@@ -34327,7 +33033,7 @@ const deserializeAws_json1_1TrialComponentSummary = (output: any, context: __Ser
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    DisplayName: output.DisplayName !== undefined && output.DisplayName !== null ? output.DisplayName : undefined,
+    DisplayName: __expectString(output.DisplayName),
     EndTime:
       output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
     LastModifiedBy:
@@ -34346,14 +33052,8 @@ const deserializeAws_json1_1TrialComponentSummary = (output: any, context: __Ser
       output.Status !== undefined && output.Status !== null
         ? deserializeAws_json1_1TrialComponentStatus(output.Status, context)
         : undefined,
-    TrialComponentArn:
-      output.TrialComponentArn !== undefined && output.TrialComponentArn !== null
-        ? output.TrialComponentArn
-        : undefined,
-    TrialComponentName:
-      output.TrialComponentName !== undefined && output.TrialComponentName !== null
-        ? output.TrialComponentName
-        : undefined,
+    TrialComponentArn: __expectString(output.TrialComponentArn),
+    TrialComponentName: __expectString(output.TrialComponentName),
     TrialComponentSource:
       output.TrialComponentSource !== undefined && output.TrialComponentSource !== null
         ? deserializeAws_json1_1TrialComponentSource(output.TrialComponentSource, context)
@@ -34363,8 +33063,8 @@ const deserializeAws_json1_1TrialComponentSummary = (output: any, context: __Ser
 
 const deserializeAws_json1_1TrialSource = (output: any, context: __SerdeContext): TrialSource => {
   return {
-    SourceArn: output.SourceArn !== undefined && output.SourceArn !== null ? output.SourceArn : undefined,
-    SourceType: output.SourceType !== undefined && output.SourceType !== null ? output.SourceType : undefined,
+    SourceArn: __expectString(output.SourceArn),
+    SourceType: __expectString(output.SourceType),
   } as any;
 };
 
@@ -34385,13 +33085,13 @@ const deserializeAws_json1_1TrialSummary = (output: any, context: __SerdeContext
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    DisplayName: output.DisplayName !== undefined && output.DisplayName !== null ? output.DisplayName : undefined,
+    DisplayName: __expectString(output.DisplayName),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    TrialArn: output.TrialArn !== undefined && output.TrialArn !== null ? output.TrialArn : undefined,
-    TrialName: output.TrialName !== undefined && output.TrialName !== null ? output.TrialName : undefined,
+    TrialArn: __expectString(output.TrialArn),
+    TrialName: __expectString(output.TrialName),
     TrialSource:
       output.TrialSource !== undefined && output.TrialSource !== null
         ? deserializeAws_json1_1TrialSource(output.TrialSource, context)
@@ -34404,33 +33104,27 @@ const deserializeAws_json1_1TuningJobCompletionCriteria = (
   context: __SerdeContext
 ): TuningJobCompletionCriteria => {
   return {
-    TargetObjectiveMetricValue:
-      output.TargetObjectiveMetricValue !== undefined && output.TargetObjectiveMetricValue !== null
-        ? output.TargetObjectiveMetricValue
-        : undefined,
+    TargetObjectiveMetricValue: __expectNumber(output.TargetObjectiveMetricValue),
   } as any;
 };
 
 const deserializeAws_json1_1UiConfig = (output: any, context: __SerdeContext): UiConfig => {
   return {
-    HumanTaskUiArn:
-      output.HumanTaskUiArn !== undefined && output.HumanTaskUiArn !== null ? output.HumanTaskUiArn : undefined,
-    UiTemplateS3Uri:
-      output.UiTemplateS3Uri !== undefined && output.UiTemplateS3Uri !== null ? output.UiTemplateS3Uri : undefined,
+    HumanTaskUiArn: __expectString(output.HumanTaskUiArn),
+    UiTemplateS3Uri: __expectString(output.UiTemplateS3Uri),
   } as any;
 };
 
 const deserializeAws_json1_1UiTemplateInfo = (output: any, context: __SerdeContext): UiTemplateInfo => {
   return {
-    ContentSha256:
-      output.ContentSha256 !== undefined && output.ContentSha256 !== null ? output.ContentSha256 : undefined,
-    Url: output.Url !== undefined && output.Url !== null ? output.Url : undefined,
+    ContentSha256: __expectString(output.ContentSha256),
+    Url: __expectString(output.Url),
   } as any;
 };
 
 const deserializeAws_json1_1UpdateActionResponse = (output: any, context: __SerdeContext): UpdateActionResponse => {
   return {
-    ActionArn: output.ActionArn !== undefined && output.ActionArn !== null ? output.ActionArn : undefined,
+    ActionArn: __expectString(output.ActionArn),
   } as any;
 };
 
@@ -34439,16 +33133,13 @@ const deserializeAws_json1_1UpdateAppImageConfigResponse = (
   context: __SerdeContext
 ): UpdateAppImageConfigResponse => {
   return {
-    AppImageConfigArn:
-      output.AppImageConfigArn !== undefined && output.AppImageConfigArn !== null
-        ? output.AppImageConfigArn
-        : undefined,
+    AppImageConfigArn: __expectString(output.AppImageConfigArn),
   } as any;
 };
 
 const deserializeAws_json1_1UpdateArtifactResponse = (output: any, context: __SerdeContext): UpdateArtifactResponse => {
   return {
-    ArtifactArn: output.ArtifactArn !== undefined && output.ArtifactArn !== null ? output.ArtifactArn : undefined,
+    ArtifactArn: __expectString(output.ArtifactArn),
   } as any;
 };
 
@@ -34457,28 +33148,25 @@ const deserializeAws_json1_1UpdateCodeRepositoryOutput = (
   context: __SerdeContext
 ): UpdateCodeRepositoryOutput => {
   return {
-    CodeRepositoryArn:
-      output.CodeRepositoryArn !== undefined && output.CodeRepositoryArn !== null
-        ? output.CodeRepositoryArn
-        : undefined,
+    CodeRepositoryArn: __expectString(output.CodeRepositoryArn),
   } as any;
 };
 
 const deserializeAws_json1_1UpdateContextResponse = (output: any, context: __SerdeContext): UpdateContextResponse => {
   return {
-    ContextArn: output.ContextArn !== undefined && output.ContextArn !== null ? output.ContextArn : undefined,
+    ContextArn: __expectString(output.ContextArn),
   } as any;
 };
 
 const deserializeAws_json1_1UpdateDomainResponse = (output: any, context: __SerdeContext): UpdateDomainResponse => {
   return {
-    DomainArn: output.DomainArn !== undefined && output.DomainArn !== null ? output.DomainArn : undefined,
+    DomainArn: __expectString(output.DomainArn),
   } as any;
 };
 
 const deserializeAws_json1_1UpdateEndpointOutput = (output: any, context: __SerdeContext): UpdateEndpointOutput => {
   return {
-    EndpointArn: output.EndpointArn !== undefined && output.EndpointArn !== null ? output.EndpointArn : undefined,
+    EndpointArn: __expectString(output.EndpointArn),
   } as any;
 };
 
@@ -34487,7 +33175,7 @@ const deserializeAws_json1_1UpdateEndpointWeightsAndCapacitiesOutput = (
   context: __SerdeContext
 ): UpdateEndpointWeightsAndCapacitiesOutput => {
   return {
-    EndpointArn: output.EndpointArn !== undefined && output.EndpointArn !== null ? output.EndpointArn : undefined,
+    EndpointArn: __expectString(output.EndpointArn),
   } as any;
 };
 
@@ -34496,14 +33184,13 @@ const deserializeAws_json1_1UpdateExperimentResponse = (
   context: __SerdeContext
 ): UpdateExperimentResponse => {
   return {
-    ExperimentArn:
-      output.ExperimentArn !== undefined && output.ExperimentArn !== null ? output.ExperimentArn : undefined,
+    ExperimentArn: __expectString(output.ExperimentArn),
   } as any;
 };
 
 const deserializeAws_json1_1UpdateImageResponse = (output: any, context: __SerdeContext): UpdateImageResponse => {
   return {
-    ImageArn: output.ImageArn !== undefined && output.ImageArn !== null ? output.ImageArn : undefined,
+    ImageArn: __expectString(output.ImageArn),
   } as any;
 };
 
@@ -34512,8 +33199,7 @@ const deserializeAws_json1_1UpdateModelPackageOutput = (
   context: __SerdeContext
 ): UpdateModelPackageOutput => {
   return {
-    ModelPackageArn:
-      output.ModelPackageArn !== undefined && output.ModelPackageArn !== null ? output.ModelPackageArn : undefined,
+    ModelPackageArn: __expectString(output.ModelPackageArn),
   } as any;
 };
 
@@ -34522,10 +33208,7 @@ const deserializeAws_json1_1UpdateMonitoringScheduleResponse = (
   context: __SerdeContext
 ): UpdateMonitoringScheduleResponse => {
   return {
-    MonitoringScheduleArn:
-      output.MonitoringScheduleArn !== undefined && output.MonitoringScheduleArn !== null
-        ? output.MonitoringScheduleArn
-        : undefined,
+    MonitoringScheduleArn: __expectString(output.MonitoringScheduleArn),
   } as any;
 };
 
@@ -34548,16 +33231,13 @@ const deserializeAws_json1_1UpdatePipelineExecutionResponse = (
   context: __SerdeContext
 ): UpdatePipelineExecutionResponse => {
   return {
-    PipelineExecutionArn:
-      output.PipelineExecutionArn !== undefined && output.PipelineExecutionArn !== null
-        ? output.PipelineExecutionArn
-        : undefined,
+    PipelineExecutionArn: __expectString(output.PipelineExecutionArn),
   } as any;
 };
 
 const deserializeAws_json1_1UpdatePipelineResponse = (output: any, context: __SerdeContext): UpdatePipelineResponse => {
   return {
-    PipelineArn: output.PipelineArn !== undefined && output.PipelineArn !== null ? output.PipelineArn : undefined,
+    PipelineArn: __expectString(output.PipelineArn),
   } as any;
 };
 
@@ -34566,8 +33246,7 @@ const deserializeAws_json1_1UpdateTrainingJobResponse = (
   context: __SerdeContext
 ): UpdateTrainingJobResponse => {
   return {
-    TrainingJobArn:
-      output.TrainingJobArn !== undefined && output.TrainingJobArn !== null ? output.TrainingJobArn : undefined,
+    TrainingJobArn: __expectString(output.TrainingJobArn),
   } as any;
 };
 
@@ -34576,16 +33255,13 @@ const deserializeAws_json1_1UpdateTrialComponentResponse = (
   context: __SerdeContext
 ): UpdateTrialComponentResponse => {
   return {
-    TrialComponentArn:
-      output.TrialComponentArn !== undefined && output.TrialComponentArn !== null
-        ? output.TrialComponentArn
-        : undefined,
+    TrialComponentArn: __expectString(output.TrialComponentArn),
   } as any;
 };
 
 const deserializeAws_json1_1UpdateTrialResponse = (output: any, context: __SerdeContext): UpdateTrialResponse => {
   return {
-    TrialArn: output.TrialArn !== undefined && output.TrialArn !== null ? output.TrialArn : undefined,
+    TrialArn: __expectString(output.TrialArn),
   } as any;
 };
 
@@ -34594,8 +33270,7 @@ const deserializeAws_json1_1UpdateUserProfileResponse = (
   context: __SerdeContext
 ): UpdateUserProfileResponse => {
   return {
-    UserProfileArn:
-      output.UserProfileArn !== undefined && output.UserProfileArn !== null ? output.UserProfileArn : undefined,
+    UserProfileArn: __expectString(output.UserProfileArn),
   } as any;
 };
 
@@ -34622,22 +33297,17 @@ const deserializeAws_json1_1UpdateWorkteamResponse = (output: any, context: __Se
 
 const deserializeAws_json1_1USD = (output: any, context: __SerdeContext): USD => {
   return {
-    Cents: output.Cents !== undefined && output.Cents !== null ? output.Cents : undefined,
-    Dollars: output.Dollars !== undefined && output.Dollars !== null ? output.Dollars : undefined,
-    TenthFractionsOfACent:
-      output.TenthFractionsOfACent !== undefined && output.TenthFractionsOfACent !== null
-        ? output.TenthFractionsOfACent
-        : undefined,
+    Cents: __expectNumber(output.Cents),
+    Dollars: __expectNumber(output.Dollars),
+    TenthFractionsOfACent: __expectNumber(output.TenthFractionsOfACent),
   } as any;
 };
 
 const deserializeAws_json1_1UserContext = (output: any, context: __SerdeContext): UserContext => {
   return {
-    DomainId: output.DomainId !== undefined && output.DomainId !== null ? output.DomainId : undefined,
-    UserProfileArn:
-      output.UserProfileArn !== undefined && output.UserProfileArn !== null ? output.UserProfileArn : undefined,
-    UserProfileName:
-      output.UserProfileName !== undefined && output.UserProfileName !== null ? output.UserProfileName : undefined,
+    DomainId: __expectString(output.DomainId),
+    UserProfileArn: __expectString(output.UserProfileArn),
+    UserProfileName: __expectString(output.UserProfileName),
   } as any;
 };
 
@@ -34647,14 +33317,13 @@ const deserializeAws_json1_1UserProfileDetails = (output: any, context: __SerdeC
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    DomainId: output.DomainId !== undefined && output.DomainId !== null ? output.DomainId : undefined,
+    DomainId: __expectString(output.DomainId),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    UserProfileName:
-      output.UserProfileName !== undefined && output.UserProfileName !== null ? output.UserProfileName : undefined,
+    Status: __expectString(output.Status),
+    UserProfileName: __expectString(output.UserProfileName),
   } as any;
 };
 
@@ -34671,8 +33340,7 @@ const deserializeAws_json1_1UserProfileList = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_1UserSettings = (output: any, context: __SerdeContext): UserSettings => {
   return {
-    ExecutionRole:
-      output.ExecutionRole !== undefined && output.ExecutionRole !== null ? output.ExecutionRole : undefined,
+    ExecutionRole: __expectString(output.ExecutionRole),
     JupyterServerAppSettings:
       output.JupyterServerAppSettings !== undefined && output.JupyterServerAppSettings !== null
         ? deserializeAws_json1_1JupyterServerAppSettings(output.JupyterServerAppSettings, context)
@@ -34716,7 +33384,7 @@ const deserializeAws_json1_1VpcSecurityGroupIds = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -34742,10 +33410,9 @@ const deserializeAws_json1_1Workforce = (output: any, context: __SerdeContext): 
       output.SourceIpConfig !== undefined && output.SourceIpConfig !== null
         ? deserializeAws_json1_1SourceIpConfig(output.SourceIpConfig, context)
         : undefined,
-    SubDomain: output.SubDomain !== undefined && output.SubDomain !== null ? output.SubDomain : undefined,
-    WorkforceArn: output.WorkforceArn !== undefined && output.WorkforceArn !== null ? output.WorkforceArn : undefined,
-    WorkforceName:
-      output.WorkforceName !== undefined && output.WorkforceName !== null ? output.WorkforceName : undefined,
+    SubDomain: __expectString(output.SubDomain),
+    WorkforceArn: __expectString(output.WorkforceArn),
+    WorkforceName: __expectString(output.WorkforceName),
   } as any;
 };
 
@@ -34766,7 +33433,7 @@ const deserializeAws_json1_1Workteam = (output: any, context: __SerdeContext): W
       output.CreateDate !== undefined && output.CreateDate !== null
         ? new Date(Math.round(output.CreateDate * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     LastUpdatedDate:
       output.LastUpdatedDate !== undefined && output.LastUpdatedDate !== null
         ? new Date(Math.round(output.LastUpdatedDate * 1000))
@@ -34783,10 +33450,10 @@ const deserializeAws_json1_1Workteam = (output: any, context: __SerdeContext): W
       output.ProductListingIds !== undefined && output.ProductListingIds !== null
         ? deserializeAws_json1_1ProductListings(output.ProductListingIds, context)
         : undefined,
-    SubDomain: output.SubDomain !== undefined && output.SubDomain !== null ? output.SubDomain : undefined,
-    WorkforceArn: output.WorkforceArn !== undefined && output.WorkforceArn !== null ? output.WorkforceArn : undefined,
-    WorkteamArn: output.WorkteamArn !== undefined && output.WorkteamArn !== null ? output.WorkteamArn : undefined,
-    WorkteamName: output.WorkteamName !== undefined && output.WorkteamName !== null ? output.WorkteamName : undefined,
+    SubDomain: __expectString(output.SubDomain),
+    WorkforceArn: __expectString(output.WorkforceArn),
+    WorkteamArn: __expectString(output.WorkteamArn),
+    WorkteamName: __expectString(output.WorkteamName),
   } as any;
 };
 

--- a/clients/client-savingsplans/protocols/Aws_restJson1.ts
+++ b/clients/client-savingsplans/protocols/Aws_restJson1.ts
@@ -50,7 +50,11 @@ import {
   ValidationException,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -386,7 +390,7 @@ export const deserializeAws_restJson1CreateSavingsPlanCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.savingsPlanId !== undefined && data.savingsPlanId !== null) {
-    contents.savingsPlanId = data.savingsPlanId;
+    contents.savingsPlanId = __expectString(data.savingsPlanId);
   }
   return Promise.resolve(contents);
 };
@@ -542,10 +546,10 @@ export const deserializeAws_restJson1DescribeSavingsPlanRatesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.savingsPlanId !== undefined && data.savingsPlanId !== null) {
-    contents.savingsPlanId = data.savingsPlanId;
+    contents.savingsPlanId = __expectString(data.savingsPlanId);
   }
   if (data.searchResults !== undefined && data.searchResults !== null) {
     contents.searchResults = deserializeAws_restJson1SavingsPlanRateList(data.searchResults, context);
@@ -612,7 +616,7 @@ export const deserializeAws_restJson1DescribeSavingsPlansCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.savingsPlans !== undefined && data.savingsPlans !== null) {
     contents.savingsPlans = deserializeAws_restJson1SavingsPlanList(data.savingsPlans, context);
@@ -679,7 +683,7 @@ export const deserializeAws_restJson1DescribeSavingsPlansOfferingRatesCommand = 
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.searchResults !== undefined && data.searchResults !== null) {
     contents.searchResults = deserializeAws_restJson1SavingsPlanOfferingRatesList(data.searchResults, context);
@@ -746,7 +750,7 @@ export const deserializeAws_restJson1DescribeSavingsPlansOfferingsCommand = asyn
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.searchResults !== undefined && data.searchResults !== null) {
     contents.searchResults = deserializeAws_restJson1SavingsPlanOfferingsList(data.searchResults, context);
@@ -1024,7 +1028,7 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1041,7 +1045,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1058,7 +1062,7 @@ const deserializeAws_restJson1ServiceQuotaExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1075,7 +1079,7 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -1412,60 +1416,41 @@ const deserializeAws_restJson1ParentSavingsPlanOffering = (
   context: __SerdeContext
 ): ParentSavingsPlanOffering => {
   return {
-    currency: output.currency !== undefined && output.currency !== null ? output.currency : undefined,
-    durationSeconds:
-      output.durationSeconds !== undefined && output.durationSeconds !== null ? output.durationSeconds : undefined,
-    offeringId: output.offeringId !== undefined && output.offeringId !== null ? output.offeringId : undefined,
-    paymentOption:
-      output.paymentOption !== undefined && output.paymentOption !== null ? output.paymentOption : undefined,
-    planDescription:
-      output.planDescription !== undefined && output.planDescription !== null ? output.planDescription : undefined,
-    planType: output.planType !== undefined && output.planType !== null ? output.planType : undefined,
+    currency: __expectString(output.currency),
+    durationSeconds: __expectNumber(output.durationSeconds),
+    offeringId: __expectString(output.offeringId),
+    paymentOption: __expectString(output.paymentOption),
+    planDescription: __expectString(output.planDescription),
+    planType: __expectString(output.planType),
   } as any;
 };
 
 const deserializeAws_restJson1SavingsPlan = (output: any, context: __SerdeContext): SavingsPlan => {
   return {
-    commitment: output.commitment !== undefined && output.commitment !== null ? output.commitment : undefined,
-    currency: output.currency !== undefined && output.currency !== null ? output.currency : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    ec2InstanceFamily:
-      output.ec2InstanceFamily !== undefined && output.ec2InstanceFamily !== null
-        ? output.ec2InstanceFamily
-        : undefined,
-    end: output.end !== undefined && output.end !== null ? output.end : undefined,
-    offeringId: output.offeringId !== undefined && output.offeringId !== null ? output.offeringId : undefined,
-    paymentOption:
-      output.paymentOption !== undefined && output.paymentOption !== null ? output.paymentOption : undefined,
+    commitment: __expectString(output.commitment),
+    currency: __expectString(output.currency),
+    description: __expectString(output.description),
+    ec2InstanceFamily: __expectString(output.ec2InstanceFamily),
+    end: __expectString(output.end),
+    offeringId: __expectString(output.offeringId),
+    paymentOption: __expectString(output.paymentOption),
     productTypes:
       output.productTypes !== undefined && output.productTypes !== null
         ? deserializeAws_restJson1SavingsPlanProductTypeList(output.productTypes, context)
         : undefined,
-    recurringPaymentAmount:
-      output.recurringPaymentAmount !== undefined && output.recurringPaymentAmount !== null
-        ? output.recurringPaymentAmount
-        : undefined,
-    region: output.region !== undefined && output.region !== null ? output.region : undefined,
-    savingsPlanArn:
-      output.savingsPlanArn !== undefined && output.savingsPlanArn !== null ? output.savingsPlanArn : undefined,
-    savingsPlanId:
-      output.savingsPlanId !== undefined && output.savingsPlanId !== null ? output.savingsPlanId : undefined,
-    savingsPlanType:
-      output.savingsPlanType !== undefined && output.savingsPlanType !== null ? output.savingsPlanType : undefined,
-    start: output.start !== undefined && output.start !== null ? output.start : undefined,
-    state: output.state !== undefined && output.state !== null ? output.state : undefined,
+    recurringPaymentAmount: __expectString(output.recurringPaymentAmount),
+    region: __expectString(output.region),
+    savingsPlanArn: __expectString(output.savingsPlanArn),
+    savingsPlanId: __expectString(output.savingsPlanId),
+    savingsPlanType: __expectString(output.savingsPlanType),
+    start: __expectString(output.start),
+    state: __expectString(output.state),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1TagMap(output.tags, context)
         : undefined,
-    termDurationInSeconds:
-      output.termDurationInSeconds !== undefined && output.termDurationInSeconds !== null
-        ? output.termDurationInSeconds
-        : undefined,
-    upfrontPaymentAmount:
-      output.upfrontPaymentAmount !== undefined && output.upfrontPaymentAmount !== null
-        ? output.upfrontPaymentAmount
-        : undefined,
+    termDurationInSeconds: __expectNumber(output.termDurationInSeconds),
+    upfrontPaymentAmount: __expectString(output.upfrontPaymentAmount),
   } as any;
 };
 
@@ -1482,15 +1467,13 @@ const deserializeAws_restJson1SavingsPlanList = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1SavingsPlanOffering = (output: any, context: __SerdeContext): SavingsPlanOffering => {
   return {
-    currency: output.currency !== undefined && output.currency !== null ? output.currency : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    durationSeconds:
-      output.durationSeconds !== undefined && output.durationSeconds !== null ? output.durationSeconds : undefined,
-    offeringId: output.offeringId !== undefined && output.offeringId !== null ? output.offeringId : undefined,
-    operation: output.operation !== undefined && output.operation !== null ? output.operation : undefined,
-    paymentOption:
-      output.paymentOption !== undefined && output.paymentOption !== null ? output.paymentOption : undefined,
-    planType: output.planType !== undefined && output.planType !== null ? output.planType : undefined,
+    currency: __expectString(output.currency),
+    description: __expectString(output.description),
+    durationSeconds: __expectNumber(output.durationSeconds),
+    offeringId: __expectString(output.offeringId),
+    operation: __expectString(output.operation),
+    paymentOption: __expectString(output.paymentOption),
+    planType: __expectString(output.planType),
     productTypes:
       output.productTypes !== undefined && output.productTypes !== null
         ? deserializeAws_restJson1SavingsPlanProductTypeList(output.productTypes, context)
@@ -1499,8 +1482,8 @@ const deserializeAws_restJson1SavingsPlanOffering = (output: any, context: __Ser
       output.properties !== undefined && output.properties !== null
         ? deserializeAws_restJson1SavingsPlanOfferingPropertyList(output.properties, context)
         : undefined,
-    serviceCode: output.serviceCode !== undefined && output.serviceCode !== null ? output.serviceCode : undefined,
-    usageType: output.usageType !== undefined && output.usageType !== null ? output.usageType : undefined,
+    serviceCode: __expectString(output.serviceCode),
+    usageType: __expectString(output.usageType),
   } as any;
 };
 
@@ -1509,8 +1492,8 @@ const deserializeAws_restJson1SavingsPlanOfferingProperty = (
   context: __SerdeContext
 ): SavingsPlanOfferingProperty => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    name: __expectString(output.name),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -1533,20 +1516,20 @@ const deserializeAws_restJson1SavingsPlanOfferingRate = (
   context: __SerdeContext
 ): SavingsPlanOfferingRate => {
   return {
-    operation: output.operation !== undefined && output.operation !== null ? output.operation : undefined,
-    productType: output.productType !== undefined && output.productType !== null ? output.productType : undefined,
+    operation: __expectString(output.operation),
+    productType: __expectString(output.productType),
     properties:
       output.properties !== undefined && output.properties !== null
         ? deserializeAws_restJson1SavingsPlanOfferingRatePropertyList(output.properties, context)
         : undefined,
-    rate: output.rate !== undefined && output.rate !== null ? output.rate : undefined,
+    rate: __expectString(output.rate),
     savingsPlanOffering:
       output.savingsPlanOffering !== undefined && output.savingsPlanOffering !== null
         ? deserializeAws_restJson1ParentSavingsPlanOffering(output.savingsPlanOffering, context)
         : undefined,
-    serviceCode: output.serviceCode !== undefined && output.serviceCode !== null ? output.serviceCode : undefined,
-    unit: output.unit !== undefined && output.unit !== null ? output.unit : undefined,
-    usageType: output.usageType !== undefined && output.usageType !== null ? output.usageType : undefined,
+    serviceCode: __expectString(output.serviceCode),
+    unit: __expectString(output.unit),
+    usageType: __expectString(output.usageType),
   } as any;
 };
 
@@ -1555,8 +1538,8 @@ const deserializeAws_restJson1SavingsPlanOfferingRateProperty = (
   context: __SerdeContext
 ): SavingsPlanOfferingRateProperty => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    name: __expectString(output.name),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -1612,23 +1595,23 @@ const deserializeAws_restJson1SavingsPlanProductTypeList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1SavingsPlanRate = (output: any, context: __SerdeContext): SavingsPlanRate => {
   return {
-    currency: output.currency !== undefined && output.currency !== null ? output.currency : undefined,
-    operation: output.operation !== undefined && output.operation !== null ? output.operation : undefined,
-    productType: output.productType !== undefined && output.productType !== null ? output.productType : undefined,
+    currency: __expectString(output.currency),
+    operation: __expectString(output.operation),
+    productType: __expectString(output.productType),
     properties:
       output.properties !== undefined && output.properties !== null
         ? deserializeAws_restJson1SavingsPlanRatePropertyList(output.properties, context)
         : undefined,
-    rate: output.rate !== undefined && output.rate !== null ? output.rate : undefined,
-    serviceCode: output.serviceCode !== undefined && output.serviceCode !== null ? output.serviceCode : undefined,
-    unit: output.unit !== undefined && output.unit !== null ? output.unit : undefined,
-    usageType: output.usageType !== undefined && output.usageType !== null ? output.usageType : undefined,
+    rate: __expectString(output.rate),
+    serviceCode: __expectString(output.serviceCode),
+    unit: __expectString(output.unit),
+    usageType: __expectString(output.usageType),
   } as any;
 };
 
@@ -1648,8 +1631,8 @@ const deserializeAws_restJson1SavingsPlanRateProperty = (
   context: __SerdeContext
 ): SavingsPlanRateProperty => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    name: __expectString(output.name),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -1674,7 +1657,7 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };

--- a/clients/client-schemas/protocols/Aws_restJson1.ts
+++ b/clients/client-schemas/protocols/Aws_restJson1.ts
@@ -69,6 +69,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   LazyJsonString as __LazyJsonString,
   SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -1155,19 +1157,19 @@ export const deserializeAws_restJson1CreateDiscovererCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.DiscovererArn !== undefined && data.DiscovererArn !== null) {
-    contents.DiscovererArn = data.DiscovererArn;
+    contents.DiscovererArn = __expectString(data.DiscovererArn);
   }
   if (data.DiscovererId !== undefined && data.DiscovererId !== null) {
-    contents.DiscovererId = data.DiscovererId;
+    contents.DiscovererId = __expectString(data.DiscovererId);
   }
   if (data.SourceArn !== undefined && data.SourceArn !== null) {
-    contents.SourceArn = data.SourceArn;
+    contents.SourceArn = __expectString(data.SourceArn);
   }
   if (data.State !== undefined && data.State !== null) {
-    contents.State = data.State;
+    contents.State = __expectString(data.State);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
@@ -1268,13 +1270,13 @@ export const deserializeAws_restJson1CreateRegistryCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.RegistryArn !== undefined && data.RegistryArn !== null) {
-    contents.RegistryArn = data.RegistryArn;
+    contents.RegistryArn = __expectString(data.RegistryArn);
   }
   if (data.RegistryName !== undefined && data.RegistryName !== null) {
-    contents.RegistryName = data.RegistryName;
+    contents.RegistryName = __expectString(data.RegistryName);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
@@ -1379,25 +1381,25 @@ export const deserializeAws_restJson1CreateSchemaCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.LastModified !== undefined && data.LastModified !== null) {
     contents.LastModified = new Date(data.LastModified);
   }
   if (data.SchemaArn !== undefined && data.SchemaArn !== null) {
-    contents.SchemaArn = data.SchemaArn;
+    contents.SchemaArn = __expectString(data.SchemaArn);
   }
   if (data.SchemaName !== undefined && data.SchemaName !== null) {
-    contents.SchemaName = data.SchemaName;
+    contents.SchemaName = __expectString(data.SchemaName);
   }
   if (data.SchemaVersion !== undefined && data.SchemaVersion !== null) {
-    contents.SchemaVersion = data.SchemaVersion;
+    contents.SchemaVersion = __expectString(data.SchemaVersion);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
   }
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   if (data.VersionCreatedDate !== undefined && data.VersionCreatedDate !== null) {
     contents.VersionCreatedDate = new Date(data.VersionCreatedDate);
@@ -1943,10 +1945,10 @@ export const deserializeAws_restJson1DescribeCodeBindingCommand = async (
     contents.LastModified = new Date(data.LastModified);
   }
   if (data.SchemaVersion !== undefined && data.SchemaVersion !== null) {
-    contents.SchemaVersion = data.SchemaVersion;
+    contents.SchemaVersion = __expectString(data.SchemaVersion);
   }
   if (data.Status !== undefined && data.Status !== null) {
-    contents.Status = data.Status;
+    contents.Status = __expectString(data.Status);
   }
   return Promise.resolve(contents);
 };
@@ -2046,19 +2048,19 @@ export const deserializeAws_restJson1DescribeDiscovererCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.DiscovererArn !== undefined && data.DiscovererArn !== null) {
-    contents.DiscovererArn = data.DiscovererArn;
+    contents.DiscovererArn = __expectString(data.DiscovererArn);
   }
   if (data.DiscovererId !== undefined && data.DiscovererId !== null) {
-    contents.DiscovererId = data.DiscovererId;
+    contents.DiscovererId = __expectString(data.DiscovererId);
   }
   if (data.SourceArn !== undefined && data.SourceArn !== null) {
-    contents.SourceArn = data.SourceArn;
+    contents.SourceArn = __expectString(data.SourceArn);
   }
   if (data.State !== undefined && data.State !== null) {
-    contents.State = data.State;
+    contents.State = __expectString(data.State);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
@@ -2159,13 +2161,13 @@ export const deserializeAws_restJson1DescribeRegistryCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.RegistryArn !== undefined && data.RegistryArn !== null) {
-    contents.RegistryArn = data.RegistryArn;
+    contents.RegistryArn = __expectString(data.RegistryArn);
   }
   if (data.RegistryName !== undefined && data.RegistryName !== null) {
-    contents.RegistryName = data.RegistryName;
+    contents.RegistryName = __expectString(data.RegistryName);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
@@ -2271,28 +2273,28 @@ export const deserializeAws_restJson1DescribeSchemaCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Content !== undefined && data.Content !== null) {
-    contents.Content = data.Content;
+    contents.Content = __expectString(data.Content);
   }
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.LastModified !== undefined && data.LastModified !== null) {
     contents.LastModified = new Date(data.LastModified);
   }
   if (data.SchemaArn !== undefined && data.SchemaArn !== null) {
-    contents.SchemaArn = data.SchemaArn;
+    contents.SchemaArn = __expectString(data.SchemaArn);
   }
   if (data.SchemaName !== undefined && data.SchemaName !== null) {
-    contents.SchemaName = data.SchemaName;
+    contents.SchemaName = __expectString(data.SchemaName);
   }
   if (data.SchemaVersion !== undefined && data.SchemaVersion !== null) {
-    contents.SchemaVersion = data.SchemaVersion;
+    contents.SchemaVersion = __expectString(data.SchemaVersion);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
   }
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   if (data.VersionCreatedDate !== undefined && data.VersionCreatedDate !== null) {
     contents.VersionCreatedDate = new Date(data.VersionCreatedDate);
@@ -2394,19 +2396,19 @@ export const deserializeAws_restJson1ExportSchemaCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Content !== undefined && data.Content !== null) {
-    contents.Content = data.Content;
+    contents.Content = __expectString(data.Content);
   }
   if (data.SchemaArn !== undefined && data.SchemaArn !== null) {
-    contents.SchemaArn = data.SchemaArn;
+    contents.SchemaArn = __expectString(data.SchemaArn);
   }
   if (data.SchemaName !== undefined && data.SchemaName !== null) {
-    contents.SchemaName = data.SchemaName;
+    contents.SchemaName = __expectString(data.SchemaName);
   }
   if (data.SchemaVersion !== undefined && data.SchemaVersion !== null) {
-    contents.SchemaVersion = data.SchemaVersion;
+    contents.SchemaVersion = __expectString(data.SchemaVersion);
   }
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   return Promise.resolve(contents);
 };
@@ -2602,7 +2604,7 @@ export const deserializeAws_restJson1GetDiscoveredSchemaCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Content !== undefined && data.Content !== null) {
-    contents.Content = data.Content;
+    contents.Content = __expectString(data.Content);
   }
   return Promise.resolve(contents);
 };
@@ -2693,7 +2695,7 @@ export const deserializeAws_restJson1GetResourcePolicyCommand = async (
     contents.Policy = new __LazyJsonString(data.Policy);
   }
   if (data.RevisionId !== undefined && data.RevisionId !== null) {
-    contents.RevisionId = data.RevisionId;
+    contents.RevisionId = __expectString(data.RevisionId);
   }
   return Promise.resolve(contents);
 };
@@ -2792,7 +2794,7 @@ export const deserializeAws_restJson1ListDiscoverersCommand = async (
     contents.Discoverers = deserializeAws_restJson1__listOfDiscovererSummary(data.Discoverers, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2880,7 +2882,7 @@ export const deserializeAws_restJson1ListRegistriesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Registries !== undefined && data.Registries !== null) {
     contents.Registries = deserializeAws_restJson1__listOfRegistrySummary(data.Registries, context);
@@ -2971,7 +2973,7 @@ export const deserializeAws_restJson1ListSchemasCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Schemas !== undefined && data.Schemas !== null) {
     contents.Schemas = deserializeAws_restJson1__listOfSchemaSummary(data.Schemas, context);
@@ -3062,7 +3064,7 @@ export const deserializeAws_restJson1ListSchemaVersionsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.SchemaVersions !== undefined && data.SchemaVersions !== null) {
     contents.SchemaVersions = deserializeAws_restJson1__listOfSchemaVersionSummary(data.SchemaVersions, context);
@@ -3248,10 +3250,10 @@ export const deserializeAws_restJson1PutCodeBindingCommand = async (
     contents.LastModified = new Date(data.LastModified);
   }
   if (data.SchemaVersion !== undefined && data.SchemaVersion !== null) {
-    contents.SchemaVersion = data.SchemaVersion;
+    contents.SchemaVersion = __expectString(data.SchemaVersion);
   }
   if (data.Status !== undefined && data.Status !== null) {
-    contents.Status = data.Status;
+    contents.Status = __expectString(data.Status);
   }
   return Promise.resolve(contents);
 };
@@ -3358,7 +3360,7 @@ export const deserializeAws_restJson1PutResourcePolicyCommand = async (
     contents.Policy = new __LazyJsonString(data.Policy);
   }
   if (data.RevisionId !== undefined && data.RevisionId !== null) {
-    contents.RevisionId = data.RevisionId;
+    contents.RevisionId = __expectString(data.RevisionId);
   }
   return Promise.resolve(contents);
 };
@@ -3462,7 +3464,7 @@ export const deserializeAws_restJson1SearchSchemasCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Schemas !== undefined && data.Schemas !== null) {
     contents.Schemas = deserializeAws_restJson1__listOfSearchSchemaSummary(data.Schemas, context);
@@ -3553,10 +3555,10 @@ export const deserializeAws_restJson1StartDiscovererCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.DiscovererId !== undefined && data.DiscovererId !== null) {
-    contents.DiscovererId = data.DiscovererId;
+    contents.DiscovererId = __expectString(data.DiscovererId);
   }
   if (data.State !== undefined && data.State !== null) {
-    contents.State = data.State;
+    contents.State = __expectString(data.State);
   }
   return Promise.resolve(contents);
 };
@@ -3652,10 +3654,10 @@ export const deserializeAws_restJson1StopDiscovererCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.DiscovererId !== undefined && data.DiscovererId !== null) {
-    contents.DiscovererId = data.DiscovererId;
+    contents.DiscovererId = __expectString(data.DiscovererId);
   }
   if (data.State !== undefined && data.State !== null) {
-    contents.State = data.State;
+    contents.State = __expectString(data.State);
   }
   return Promise.resolve(contents);
 };
@@ -3905,19 +3907,19 @@ export const deserializeAws_restJson1UpdateDiscovererCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.DiscovererArn !== undefined && data.DiscovererArn !== null) {
-    contents.DiscovererArn = data.DiscovererArn;
+    contents.DiscovererArn = __expectString(data.DiscovererArn);
   }
   if (data.DiscovererId !== undefined && data.DiscovererId !== null) {
-    contents.DiscovererId = data.DiscovererId;
+    contents.DiscovererId = __expectString(data.DiscovererId);
   }
   if (data.SourceArn !== undefined && data.SourceArn !== null) {
-    contents.SourceArn = data.SourceArn;
+    contents.SourceArn = __expectString(data.SourceArn);
   }
   if (data.State !== undefined && data.State !== null) {
-    contents.State = data.State;
+    contents.State = __expectString(data.State);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
@@ -4018,13 +4020,13 @@ export const deserializeAws_restJson1UpdateRegistryCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.RegistryArn !== undefined && data.RegistryArn !== null) {
-    contents.RegistryArn = data.RegistryArn;
+    contents.RegistryArn = __expectString(data.RegistryArn);
   }
   if (data.RegistryName !== undefined && data.RegistryName !== null) {
-    contents.RegistryName = data.RegistryName;
+    contents.RegistryName = __expectString(data.RegistryName);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
@@ -4129,25 +4131,25 @@ export const deserializeAws_restJson1UpdateSchemaCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.LastModified !== undefined && data.LastModified !== null) {
     contents.LastModified = new Date(data.LastModified);
   }
   if (data.SchemaArn !== undefined && data.SchemaArn !== null) {
-    contents.SchemaArn = data.SchemaArn;
+    contents.SchemaArn = __expectString(data.SchemaArn);
   }
   if (data.SchemaName !== undefined && data.SchemaName !== null) {
-    contents.SchemaName = data.SchemaName;
+    contents.SchemaName = __expectString(data.SchemaName);
   }
   if (data.SchemaVersion !== undefined && data.SchemaVersion !== null) {
-    contents.SchemaVersion = data.SchemaVersion;
+    contents.SchemaVersion = __expectString(data.SchemaVersion);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
   }
   if (data.Type !== undefined && data.Type !== null) {
-    contents.Type = data.Type;
+    contents.Type = __expectString(data.Type);
   }
   if (data.VersionCreatedDate !== undefined && data.VersionCreatedDate !== null) {
     contents.VersionCreatedDate = new Date(data.VersionCreatedDate);
@@ -4237,10 +4239,10 @@ const deserializeAws_restJson1BadRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Code !== undefined && data.Code !== null) {
-    contents.Code = data.Code;
+    contents.Code = __expectString(data.Code);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -4258,10 +4260,10 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Code !== undefined && data.Code !== null) {
-    contents.Code = data.Code;
+    contents.Code = __expectString(data.Code);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -4279,10 +4281,10 @@ const deserializeAws_restJson1ForbiddenExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Code !== undefined && data.Code !== null) {
-    contents.Code = data.Code;
+    contents.Code = __expectString(data.Code);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -4300,10 +4302,10 @@ const deserializeAws_restJson1GoneExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Code !== undefined && data.Code !== null) {
-    contents.Code = data.Code;
+    contents.Code = __expectString(data.Code);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -4321,10 +4323,10 @@ const deserializeAws_restJson1InternalServerErrorExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Code !== undefined && data.Code !== null) {
-    contents.Code = data.Code;
+    contents.Code = __expectString(data.Code);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -4342,10 +4344,10 @@ const deserializeAws_restJson1NotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Code !== undefined && data.Code !== null) {
-    contents.Code = data.Code;
+    contents.Code = __expectString(data.Code);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -4363,10 +4365,10 @@ const deserializeAws_restJson1PreconditionFailedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Code !== undefined && data.Code !== null) {
-    contents.Code = data.Code;
+    contents.Code = __expectString(data.Code);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -4384,10 +4386,10 @@ const deserializeAws_restJson1ServiceUnavailableExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Code !== undefined && data.Code !== null) {
-    contents.Code = data.Code;
+    contents.Code = __expectString(data.Code);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -4405,10 +4407,10 @@ const deserializeAws_restJson1TooManyRequestsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Code !== undefined && data.Code !== null) {
-    contents.Code = data.Code;
+    contents.Code = __expectString(data.Code);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -4426,10 +4428,10 @@ const deserializeAws_restJson1UnauthorizedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Code !== undefined && data.Code !== null) {
-    contents.Code = data.Code;
+    contents.Code = __expectString(data.Code);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -4540,11 +4542,10 @@ const deserializeAws_restJson1__listOfSearchSchemaVersionSummary = (
 
 const deserializeAws_restJson1DiscovererSummary = (output: any, context: __SerdeContext): DiscovererSummary => {
   return {
-    DiscovererArn:
-      output.DiscovererArn !== undefined && output.DiscovererArn !== null ? output.DiscovererArn : undefined,
-    DiscovererId: output.DiscovererId !== undefined && output.DiscovererId !== null ? output.DiscovererId : undefined,
-    SourceArn: output.SourceArn !== undefined && output.SourceArn !== null ? output.SourceArn : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    DiscovererArn: __expectString(output.DiscovererArn),
+    DiscovererId: __expectString(output.DiscovererId),
+    SourceArn: __expectString(output.SourceArn),
+    State: __expectString(output.State),
     Tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1Tags(output.tags, context)
@@ -4554,8 +4555,8 @@ const deserializeAws_restJson1DiscovererSummary = (output: any, context: __Serde
 
 const deserializeAws_restJson1RegistrySummary = (output: any, context: __SerdeContext): RegistrySummary => {
   return {
-    RegistryArn: output.RegistryArn !== undefined && output.RegistryArn !== null ? output.RegistryArn : undefined,
-    RegistryName: output.RegistryName !== undefined && output.RegistryName !== null ? output.RegistryName : undefined,
+    RegistryArn: __expectString(output.RegistryArn),
+    RegistryName: __expectString(output.RegistryName),
     Tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1Tags(output.tags, context)
@@ -4567,31 +4568,30 @@ const deserializeAws_restJson1SchemaSummary = (output: any, context: __SerdeCont
   return {
     LastModified:
       output.LastModified !== undefined && output.LastModified !== null ? new Date(output.LastModified) : undefined,
-    SchemaArn: output.SchemaArn !== undefined && output.SchemaArn !== null ? output.SchemaArn : undefined,
-    SchemaName: output.SchemaName !== undefined && output.SchemaName !== null ? output.SchemaName : undefined,
+    SchemaArn: __expectString(output.SchemaArn),
+    SchemaName: __expectString(output.SchemaName),
     Tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1Tags(output.tags, context)
         : undefined,
-    VersionCount: output.VersionCount !== undefined && output.VersionCount !== null ? output.VersionCount : undefined,
+    VersionCount: __expectNumber(output.VersionCount),
   } as any;
 };
 
 const deserializeAws_restJson1SchemaVersionSummary = (output: any, context: __SerdeContext): SchemaVersionSummary => {
   return {
-    SchemaArn: output.SchemaArn !== undefined && output.SchemaArn !== null ? output.SchemaArn : undefined,
-    SchemaName: output.SchemaName !== undefined && output.SchemaName !== null ? output.SchemaName : undefined,
-    SchemaVersion:
-      output.SchemaVersion !== undefined && output.SchemaVersion !== null ? output.SchemaVersion : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    SchemaArn: __expectString(output.SchemaArn),
+    SchemaName: __expectString(output.SchemaName),
+    SchemaVersion: __expectString(output.SchemaVersion),
+    Type: __expectString(output.Type),
   } as any;
 };
 
 const deserializeAws_restJson1SearchSchemaSummary = (output: any, context: __SerdeContext): SearchSchemaSummary => {
   return {
-    RegistryName: output.RegistryName !== undefined && output.RegistryName !== null ? output.RegistryName : undefined,
-    SchemaArn: output.SchemaArn !== undefined && output.SchemaArn !== null ? output.SchemaArn : undefined,
-    SchemaName: output.SchemaName !== undefined && output.SchemaName !== null ? output.SchemaName : undefined,
+    RegistryName: __expectString(output.RegistryName),
+    SchemaArn: __expectString(output.SchemaArn),
+    SchemaName: __expectString(output.SchemaName),
     SchemaVersions:
       output.SchemaVersions !== undefined && output.SchemaVersions !== null
         ? deserializeAws_restJson1__listOfSearchSchemaVersionSummary(output.SchemaVersions, context)
@@ -4606,9 +4606,8 @@ const deserializeAws_restJson1SearchSchemaVersionSummary = (
   return {
     CreatedDate:
       output.CreatedDate !== undefined && output.CreatedDate !== null ? new Date(output.CreatedDate) : undefined,
-    SchemaVersion:
-      output.SchemaVersion !== undefined && output.SchemaVersion !== null ? output.SchemaVersion : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    SchemaVersion: __expectString(output.SchemaVersion),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -4619,7 +4618,7 @@ const deserializeAws_restJson1Tags = (output: any, context: __SerdeContext): { [
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };

--- a/clients/client-secrets-manager/protocols/Aws_json1_1.ts
+++ b/clients/client-secrets-manager/protocols/Aws_json1_1.ts
@@ -106,7 +106,12 @@ import {
   ValidationErrorsEntry,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -2752,27 +2757,27 @@ const deserializeAws_json1_1CancelRotateSecretResponse = (
   context: __SerdeContext
 ): CancelRotateSecretResponse => {
   return {
-    ARN: output.ARN !== undefined && output.ARN !== null ? output.ARN : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    VersionId: output.VersionId !== undefined && output.VersionId !== null ? output.VersionId : undefined,
+    ARN: __expectString(output.ARN),
+    Name: __expectString(output.Name),
+    VersionId: __expectString(output.VersionId),
   } as any;
 };
 
 const deserializeAws_json1_1CreateSecretResponse = (output: any, context: __SerdeContext): CreateSecretResponse => {
   return {
-    ARN: output.ARN !== undefined && output.ARN !== null ? output.ARN : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    ARN: __expectString(output.ARN),
+    Name: __expectString(output.Name),
     ReplicationStatus:
       output.ReplicationStatus !== undefined && output.ReplicationStatus !== null
         ? deserializeAws_json1_1ReplicationStatusListType(output.ReplicationStatus, context)
         : undefined,
-    VersionId: output.VersionId !== undefined && output.VersionId !== null ? output.VersionId : undefined,
+    VersionId: __expectString(output.VersionId),
   } as any;
 };
 
 const deserializeAws_json1_1DecryptionFailure = (output: any, context: __SerdeContext): DecryptionFailure => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2781,25 +2786,25 @@ const deserializeAws_json1_1DeleteResourcePolicyResponse = (
   context: __SerdeContext
 ): DeleteResourcePolicyResponse => {
   return {
-    ARN: output.ARN !== undefined && output.ARN !== null ? output.ARN : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    ARN: __expectString(output.ARN),
+    Name: __expectString(output.Name),
   } as any;
 };
 
 const deserializeAws_json1_1DeleteSecretResponse = (output: any, context: __SerdeContext): DeleteSecretResponse => {
   return {
-    ARN: output.ARN !== undefined && output.ARN !== null ? output.ARN : undefined,
+    ARN: __expectString(output.ARN),
     DeletionDate:
       output.DeletionDate !== undefined && output.DeletionDate !== null
         ? new Date(Math.round(output.DeletionDate * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
 const deserializeAws_json1_1DescribeSecretResponse = (output: any, context: __SerdeContext): DescribeSecretResponse => {
   return {
-    ARN: output.ARN !== undefined && output.ARN !== null ? output.ARN : undefined,
+    ARN: __expectString(output.ARN),
     CreatedDate:
       output.CreatedDate !== undefined && output.CreatedDate !== null
         ? new Date(Math.round(output.CreatedDate * 1000))
@@ -2808,8 +2813,8 @@ const deserializeAws_json1_1DescribeSecretResponse = (output: any, context: __Se
       output.DeletedDate !== undefined && output.DeletedDate !== null
         ? new Date(Math.round(output.DeletedDate * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
+    Description: __expectString(output.Description),
+    KmsKeyId: __expectString(output.KmsKeyId),
     LastAccessedDate:
       output.LastAccessedDate !== undefined && output.LastAccessedDate !== null
         ? new Date(Math.round(output.LastAccessedDate * 1000))
@@ -2822,21 +2827,15 @@ const deserializeAws_json1_1DescribeSecretResponse = (output: any, context: __Se
       output.LastRotatedDate !== undefined && output.LastRotatedDate !== null
         ? new Date(Math.round(output.LastRotatedDate * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    OwningService:
-      output.OwningService !== undefined && output.OwningService !== null ? output.OwningService : undefined,
-    PrimaryRegion:
-      output.PrimaryRegion !== undefined && output.PrimaryRegion !== null ? output.PrimaryRegion : undefined,
+    Name: __expectString(output.Name),
+    OwningService: __expectString(output.OwningService),
+    PrimaryRegion: __expectString(output.PrimaryRegion),
     ReplicationStatus:
       output.ReplicationStatus !== undefined && output.ReplicationStatus !== null
         ? deserializeAws_json1_1ReplicationStatusListType(output.ReplicationStatus, context)
         : undefined,
-    RotationEnabled:
-      output.RotationEnabled !== undefined && output.RotationEnabled !== null ? output.RotationEnabled : undefined,
-    RotationLambdaARN:
-      output.RotationLambdaARN !== undefined && output.RotationLambdaARN !== null
-        ? output.RotationLambdaARN
-        : undefined,
+    RotationEnabled: __expectBoolean(output.RotationEnabled),
+    RotationLambdaARN: __expectString(output.RotationLambdaARN),
     RotationRules:
       output.RotationRules !== undefined && output.RotationRules !== null
         ? deserializeAws_json1_1RotationRulesType(output.RotationRules, context)
@@ -2854,7 +2853,7 @@ const deserializeAws_json1_1DescribeSecretResponse = (output: any, context: __Se
 
 const deserializeAws_json1_1EncryptionFailure = (output: any, context: __SerdeContext): EncryptionFailure => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2863,8 +2862,7 @@ const deserializeAws_json1_1GetRandomPasswordResponse = (
   context: __SerdeContext
 ): GetRandomPasswordResponse => {
   return {
-    RandomPassword:
-      output.RandomPassword !== undefined && output.RandomPassword !== null ? output.RandomPassword : undefined,
+    RandomPassword: __expectString(output.RandomPassword),
   } as any;
 };
 
@@ -2873,27 +2871,26 @@ const deserializeAws_json1_1GetResourcePolicyResponse = (
   context: __SerdeContext
 ): GetResourcePolicyResponse => {
   return {
-    ARN: output.ARN !== undefined && output.ARN !== null ? output.ARN : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    ResourcePolicy:
-      output.ResourcePolicy !== undefined && output.ResourcePolicy !== null ? output.ResourcePolicy : undefined,
+    ARN: __expectString(output.ARN),
+    Name: __expectString(output.Name),
+    ResourcePolicy: __expectString(output.ResourcePolicy),
   } as any;
 };
 
 const deserializeAws_json1_1GetSecretValueResponse = (output: any, context: __SerdeContext): GetSecretValueResponse => {
   return {
-    ARN: output.ARN !== undefined && output.ARN !== null ? output.ARN : undefined,
+    ARN: __expectString(output.ARN),
     CreatedDate:
       output.CreatedDate !== undefined && output.CreatedDate !== null
         ? new Date(Math.round(output.CreatedDate * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     SecretBinary:
       output.SecretBinary !== undefined && output.SecretBinary !== null
         ? context.base64Decoder(output.SecretBinary)
         : undefined,
-    SecretString: output.SecretString !== undefined && output.SecretString !== null ? output.SecretString : undefined,
-    VersionId: output.VersionId !== undefined && output.VersionId !== null ? output.VersionId : undefined,
+    SecretString: __expectString(output.SecretString),
+    VersionId: __expectString(output.VersionId),
     VersionStages:
       output.VersionStages !== undefined && output.VersionStages !== null
         ? deserializeAws_json1_1SecretVersionStagesType(output.VersionStages, context)
@@ -2903,7 +2900,7 @@ const deserializeAws_json1_1GetSecretValueResponse = (output: any, context: __Se
 
 const deserializeAws_json1_1InternalServiceError = (output: any, context: __SerdeContext): InternalServiceError => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2912,7 +2909,7 @@ const deserializeAws_json1_1InvalidNextTokenException = (
   context: __SerdeContext
 ): InvalidNextTokenException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2921,7 +2918,7 @@ const deserializeAws_json1_1InvalidParameterException = (
   context: __SerdeContext
 ): InvalidParameterException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2930,19 +2927,19 @@ const deserializeAws_json1_1InvalidRequestException = (
   context: __SerdeContext
 ): InvalidRequestException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1ListSecretsResponse = (output: any, context: __SerdeContext): ListSecretsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     SecretList:
       output.SecretList !== undefined && output.SecretList !== null
         ? deserializeAws_json1_1SecretListType(output.SecretList, context)
@@ -2955,9 +2952,9 @@ const deserializeAws_json1_1ListSecretVersionIdsResponse = (
   context: __SerdeContext
 ): ListSecretVersionIdsResponse => {
   return {
-    ARN: output.ARN !== undefined && output.ARN !== null ? output.ARN : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    ARN: __expectString(output.ARN),
+    Name: __expectString(output.Name),
+    NextToken: __expectString(output.NextToken),
     Versions:
       output.Versions !== undefined && output.Versions !== null
         ? deserializeAws_json1_1SecretVersionsListType(output.Versions, context)
@@ -2970,7 +2967,7 @@ const deserializeAws_json1_1MalformedPolicyDocumentException = (
   context: __SerdeContext
 ): MalformedPolicyDocumentException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2979,13 +2976,13 @@ const deserializeAws_json1_1PreconditionNotMetException = (
   context: __SerdeContext
 ): PreconditionNotMetException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1PublicPolicyException = (output: any, context: __SerdeContext): PublicPolicyException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2994,16 +2991,16 @@ const deserializeAws_json1_1PutResourcePolicyResponse = (
   context: __SerdeContext
 ): PutResourcePolicyResponse => {
   return {
-    ARN: output.ARN !== undefined && output.ARN !== null ? output.ARN : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    ARN: __expectString(output.ARN),
+    Name: __expectString(output.Name),
   } as any;
 };
 
 const deserializeAws_json1_1PutSecretValueResponse = (output: any, context: __SerdeContext): PutSecretValueResponse => {
   return {
-    ARN: output.ARN !== undefined && output.ARN !== null ? output.ARN : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    VersionId: output.VersionId !== undefined && output.VersionId !== null ? output.VersionId : undefined,
+    ARN: __expectString(output.ARN),
+    Name: __expectString(output.Name),
+    VersionId: __expectString(output.VersionId),
     VersionStages:
       output.VersionStages !== undefined && output.VersionStages !== null
         ? deserializeAws_json1_1SecretVersionStagesType(output.VersionStages, context)
@@ -3016,7 +3013,7 @@ const deserializeAws_json1_1RemoveRegionsFromReplicationResponse = (
   context: __SerdeContext
 ): RemoveRegionsFromReplicationResponse => {
   return {
-    ARN: output.ARN !== undefined && output.ARN !== null ? output.ARN : undefined,
+    ARN: __expectString(output.ARN),
     ReplicationStatus:
       output.ReplicationStatus !== undefined && output.ReplicationStatus !== null
         ? deserializeAws_json1_1ReplicationStatusListType(output.ReplicationStatus, context)
@@ -3029,7 +3026,7 @@ const deserializeAws_json1_1ReplicateSecretToRegionsResponse = (
   context: __SerdeContext
 ): ReplicateSecretToRegionsResponse => {
   return {
-    ARN: output.ARN !== undefined && output.ARN !== null ? output.ARN : undefined,
+    ARN: __expectString(output.ARN),
     ReplicationStatus:
       output.ReplicationStatus !== undefined && output.ReplicationStatus !== null
         ? deserializeAws_json1_1ReplicationStatusListType(output.ReplicationStatus, context)
@@ -3053,15 +3050,14 @@ const deserializeAws_json1_1ReplicationStatusListType = (
 
 const deserializeAws_json1_1ReplicationStatusType = (output: any, context: __SerdeContext): ReplicationStatusType => {
   return {
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
+    KmsKeyId: __expectString(output.KmsKeyId),
     LastAccessedDate:
       output.LastAccessedDate !== undefined && output.LastAccessedDate !== null
         ? new Date(Math.round(output.LastAccessedDate * 1000))
         : undefined,
-    Region: output.Region !== undefined && output.Region !== null ? output.Region : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusMessage:
-      output.StatusMessage !== undefined && output.StatusMessage !== null ? output.StatusMessage : undefined,
+    Region: __expectString(output.Region),
+    Status: __expectString(output.Status),
+    StatusMessage: __expectString(output.StatusMessage),
   } as any;
 };
 
@@ -3070,7 +3066,7 @@ const deserializeAws_json1_1ResourceExistsException = (
   context: __SerdeContext
 ): ResourceExistsException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3079,37 +3075,34 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1RestoreSecretResponse = (output: any, context: __SerdeContext): RestoreSecretResponse => {
   return {
-    ARN: output.ARN !== undefined && output.ARN !== null ? output.ARN : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    ARN: __expectString(output.ARN),
+    Name: __expectString(output.Name),
   } as any;
 };
 
 const deserializeAws_json1_1RotateSecretResponse = (output: any, context: __SerdeContext): RotateSecretResponse => {
   return {
-    ARN: output.ARN !== undefined && output.ARN !== null ? output.ARN : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    VersionId: output.VersionId !== undefined && output.VersionId !== null ? output.VersionId : undefined,
+    ARN: __expectString(output.ARN),
+    Name: __expectString(output.Name),
+    VersionId: __expectString(output.VersionId),
   } as any;
 };
 
 const deserializeAws_json1_1RotationRulesType = (output: any, context: __SerdeContext): RotationRulesType => {
   return {
-    AutomaticallyAfterDays:
-      output.AutomaticallyAfterDays !== undefined && output.AutomaticallyAfterDays !== null
-        ? output.AutomaticallyAfterDays
-        : undefined,
+    AutomaticallyAfterDays: __expectNumber(output.AutomaticallyAfterDays),
   } as any;
 };
 
 const deserializeAws_json1_1SecretListEntry = (output: any, context: __SerdeContext): SecretListEntry => {
   return {
-    ARN: output.ARN !== undefined && output.ARN !== null ? output.ARN : undefined,
+    ARN: __expectString(output.ARN),
     CreatedDate:
       output.CreatedDate !== undefined && output.CreatedDate !== null
         ? new Date(Math.round(output.CreatedDate * 1000))
@@ -3118,8 +3111,8 @@ const deserializeAws_json1_1SecretListEntry = (output: any, context: __SerdeCont
       output.DeletedDate !== undefined && output.DeletedDate !== null
         ? new Date(Math.round(output.DeletedDate * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
+    Description: __expectString(output.Description),
+    KmsKeyId: __expectString(output.KmsKeyId),
     LastAccessedDate:
       output.LastAccessedDate !== undefined && output.LastAccessedDate !== null
         ? new Date(Math.round(output.LastAccessedDate * 1000))
@@ -3132,17 +3125,11 @@ const deserializeAws_json1_1SecretListEntry = (output: any, context: __SerdeCont
       output.LastRotatedDate !== undefined && output.LastRotatedDate !== null
         ? new Date(Math.round(output.LastRotatedDate * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    OwningService:
-      output.OwningService !== undefined && output.OwningService !== null ? output.OwningService : undefined,
-    PrimaryRegion:
-      output.PrimaryRegion !== undefined && output.PrimaryRegion !== null ? output.PrimaryRegion : undefined,
-    RotationEnabled:
-      output.RotationEnabled !== undefined && output.RotationEnabled !== null ? output.RotationEnabled : undefined,
-    RotationLambdaARN:
-      output.RotationLambdaARN !== undefined && output.RotationLambdaARN !== null
-        ? output.RotationLambdaARN
-        : undefined,
+    Name: __expectString(output.Name),
+    OwningService: __expectString(output.OwningService),
+    PrimaryRegion: __expectString(output.PrimaryRegion),
+    RotationEnabled: __expectBoolean(output.RotationEnabled),
+    RotationLambdaARN: __expectString(output.RotationLambdaARN),
     RotationRules:
       output.RotationRules !== undefined && output.RotationRules !== null
         ? deserializeAws_json1_1RotationRulesType(output.RotationRules, context)
@@ -3182,7 +3169,7 @@ const deserializeAws_json1_1SecretVersionsListEntry = (
       output.LastAccessedDate !== undefined && output.LastAccessedDate !== null
         ? new Date(Math.round(output.LastAccessedDate * 1000))
         : undefined,
-    VersionId: output.VersionId !== undefined && output.VersionId !== null ? output.VersionId : undefined,
+    VersionId: __expectString(output.VersionId),
     VersionStages:
       output.VersionStages !== undefined && output.VersionStages !== null
         ? deserializeAws_json1_1SecretVersionStagesType(output.VersionStages, context)
@@ -3211,7 +3198,7 @@ const deserializeAws_json1_1SecretVersionStagesType = (output: any, context: __S
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3235,14 +3222,14 @@ const deserializeAws_json1_1StopReplicationToReplicaResponse = (
   context: __SerdeContext
 ): StopReplicationToReplicaResponse => {
   return {
-    ARN: output.ARN !== undefined && output.ARN !== null ? output.ARN : undefined,
+    ARN: __expectString(output.ARN),
   } as any;
 };
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -3259,9 +3246,9 @@ const deserializeAws_json1_1TagListType = (output: any, context: __SerdeContext)
 
 const deserializeAws_json1_1UpdateSecretResponse = (output: any, context: __SerdeContext): UpdateSecretResponse => {
   return {
-    ARN: output.ARN !== undefined && output.ARN !== null ? output.ARN : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    VersionId: output.VersionId !== undefined && output.VersionId !== null ? output.VersionId : undefined,
+    ARN: __expectString(output.ARN),
+    Name: __expectString(output.Name),
+    VersionId: __expectString(output.VersionId),
   } as any;
 };
 
@@ -3270,8 +3257,8 @@ const deserializeAws_json1_1UpdateSecretVersionStageResponse = (
   context: __SerdeContext
 ): UpdateSecretVersionStageResponse => {
   return {
-    ARN: output.ARN !== undefined && output.ARN !== null ? output.ARN : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    ARN: __expectString(output.ARN),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -3280,10 +3267,7 @@ const deserializeAws_json1_1ValidateResourcePolicyResponse = (
   context: __SerdeContext
 ): ValidateResourcePolicyResponse => {
   return {
-    PolicyValidationPassed:
-      output.PolicyValidationPassed !== undefined && output.PolicyValidationPassed !== null
-        ? output.PolicyValidationPassed
-        : undefined,
+    PolicyValidationPassed: __expectBoolean(output.PolicyValidationPassed),
     ValidationErrors:
       output.ValidationErrors !== undefined && output.ValidationErrors !== null
         ? deserializeAws_json1_1ValidationErrorsType(output.ValidationErrors, context)
@@ -3293,8 +3277,8 @@ const deserializeAws_json1_1ValidateResourcePolicyResponse = (
 
 const deserializeAws_json1_1ValidationErrorsEntry = (output: any, context: __SerdeContext): ValidationErrorsEntry => {
   return {
-    CheckName: output.CheckName !== undefined && output.CheckName !== null ? output.CheckName : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
+    CheckName: __expectString(output.CheckName),
+    ErrorMessage: __expectString(output.ErrorMessage),
   } as any;
 };
 

--- a/clients/client-securityhub/protocols/Aws_restJson1.ts
+++ b/clients/client-securityhub/protocols/Aws_restJson1.ts
@@ -400,6 +400,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -2179,13 +2182,13 @@ export const deserializeAws_restJson1BatchImportFindingsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.FailedCount !== undefined && data.FailedCount !== null) {
-    contents.FailedCount = data.FailedCount;
+    contents.FailedCount = __expectNumber(data.FailedCount);
   }
   if (data.FailedFindings !== undefined && data.FailedFindings !== null) {
     contents.FailedFindings = deserializeAws_restJson1ImportFindingsErrorList(data.FailedFindings, context);
   }
   if (data.SuccessCount !== undefined && data.SuccessCount !== null) {
-    contents.SuccessCount = data.SuccessCount;
+    contents.SuccessCount = __expectNumber(data.SuccessCount);
   }
   return Promise.resolve(contents);
 };
@@ -2353,7 +2356,7 @@ export const deserializeAws_restJson1CreateActionTargetCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ActionTargetArn !== undefined && data.ActionTargetArn !== null) {
-    contents.ActionTargetArn = data.ActionTargetArn;
+    contents.ActionTargetArn = __expectString(data.ActionTargetArn);
   }
   return Promise.resolve(contents);
 };
@@ -2440,7 +2443,7 @@ export const deserializeAws_restJson1CreateInsightCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.InsightArn !== undefined && data.InsightArn !== null) {
-    contents.InsightArn = data.InsightArn;
+    contents.InsightArn = __expectString(data.InsightArn);
   }
   return Promise.resolve(contents);
 };
@@ -2693,7 +2696,7 @@ export const deserializeAws_restJson1DeleteActionTargetCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ActionTargetArn !== undefined && data.ActionTargetArn !== null) {
-    contents.ActionTargetArn = data.ActionTargetArn;
+    contents.ActionTargetArn = __expectString(data.ActionTargetArn);
   }
   return Promise.resolve(contents);
 };
@@ -2772,7 +2775,7 @@ export const deserializeAws_restJson1DeleteInsightCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.InsightArn !== undefined && data.InsightArn !== null) {
-    contents.InsightArn = data.InsightArn;
+    contents.InsightArn = __expectString(data.InsightArn);
   }
   return Promise.resolve(contents);
 };
@@ -3037,7 +3040,7 @@ export const deserializeAws_restJson1DescribeActionTargetsCommand = async (
     contents.ActionTargets = deserializeAws_restJson1ActionTargetList(data.ActionTargets, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -3118,13 +3121,13 @@ export const deserializeAws_restJson1DescribeHubCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AutoEnableControls !== undefined && data.AutoEnableControls !== null) {
-    contents.AutoEnableControls = data.AutoEnableControls;
+    contents.AutoEnableControls = __expectBoolean(data.AutoEnableControls);
   }
   if (data.HubArn !== undefined && data.HubArn !== null) {
-    contents.HubArn = data.HubArn;
+    contents.HubArn = __expectString(data.HubArn);
   }
   if (data.SubscribedAt !== undefined && data.SubscribedAt !== null) {
-    contents.SubscribedAt = data.SubscribedAt;
+    contents.SubscribedAt = __expectString(data.SubscribedAt);
   }
   return Promise.resolve(contents);
 };
@@ -3212,10 +3215,10 @@ export const deserializeAws_restJson1DescribeOrganizationConfigurationCommand = 
   };
   const data: any = await parseBody(output.body, context);
   if (data.AutoEnable !== undefined && data.AutoEnable !== null) {
-    contents.AutoEnable = data.AutoEnable;
+    contents.AutoEnable = __expectBoolean(data.AutoEnable);
   }
   if (data.MemberAccountLimitReached !== undefined && data.MemberAccountLimitReached !== null) {
-    contents.MemberAccountLimitReached = data.MemberAccountLimitReached;
+    contents.MemberAccountLimitReached = __expectBoolean(data.MemberAccountLimitReached);
   }
   return Promise.resolve(contents);
 };
@@ -3295,7 +3298,7 @@ export const deserializeAws_restJson1DescribeProductsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Products !== undefined && data.Products !== null) {
     contents.Products = deserializeAws_restJson1ProductsList(data.Products, context);
@@ -3378,7 +3381,7 @@ export const deserializeAws_restJson1DescribeStandardsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Standards !== undefined && data.Standards !== null) {
     contents.Standards = deserializeAws_restJson1Standards(data.Standards, context);
@@ -3456,7 +3459,7 @@ export const deserializeAws_restJson1DescribeStandardsControlsCommand = async (
     contents.Controls = deserializeAws_restJson1StandardsControls(data.Controls, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -4017,7 +4020,7 @@ export const deserializeAws_restJson1EnableImportFindingsForProductCommand = asy
   };
   const data: any = await parseBody(output.body, context);
   if (data.ProductSubscriptionArn !== undefined && data.ProductSubscriptionArn !== null) {
-    contents.ProductSubscriptionArn = data.ProductSubscriptionArn;
+    contents.ProductSubscriptionArn = __expectString(data.ProductSubscriptionArn);
   }
   return Promise.resolve(contents);
 };
@@ -4350,7 +4353,7 @@ export const deserializeAws_restJson1GetEnabledStandardsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.StandardsSubscriptions !== undefined && data.StandardsSubscriptions !== null) {
     contents.StandardsSubscriptions = deserializeAws_restJson1StandardsSubscriptions(
@@ -4439,7 +4442,7 @@ export const deserializeAws_restJson1GetFindingsCommand = async (
     contents.Findings = deserializeAws_restJson1AwsSecurityFindingList(data.Findings, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -4609,7 +4612,7 @@ export const deserializeAws_restJson1GetInsightsCommand = async (
     contents.Insights = deserializeAws_restJson1InsightList(data.Insights, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -4696,7 +4699,7 @@ export const deserializeAws_restJson1GetInvitationsCountCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.InvitationsCount !== undefined && data.InvitationsCount !== null) {
-    contents.InvitationsCount = data.InvitationsCount;
+    contents.InvitationsCount = __expectNumber(data.InvitationsCount);
   }
   return Promise.resolve(contents);
 };
@@ -5041,7 +5044,7 @@ export const deserializeAws_restJson1ListEnabledProductsForImportCommand = async
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.ProductSubscriptions !== undefined && data.ProductSubscriptions !== null) {
     contents.ProductSubscriptions = deserializeAws_restJson1ProductSubscriptionArnList(
@@ -5122,7 +5125,7 @@ export const deserializeAws_restJson1ListInvitationsCommand = async (
     contents.Invitations = deserializeAws_restJson1InvitationList(data.Invitations, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -5205,7 +5208,7 @@ export const deserializeAws_restJson1ListMembersCommand = async (
     contents.Members = deserializeAws_restJson1MemberList(data.Members, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -5288,7 +5291,7 @@ export const deserializeAws_restJson1ListOrganizationAdminAccountsCommand = asyn
     contents.AdminAccounts = deserializeAws_restJson1AdminAccounts(data.AdminAccounts, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -6046,10 +6049,10 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Code !== undefined && data.Code !== null) {
-    contents.Code = data.Code;
+    contents.Code = __expectString(data.Code);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -6067,10 +6070,10 @@ const deserializeAws_restJson1InternalExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Code !== undefined && data.Code !== null) {
-    contents.Code = data.Code;
+    contents.Code = __expectString(data.Code);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -6088,10 +6091,10 @@ const deserializeAws_restJson1InvalidAccessExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Code !== undefined && data.Code !== null) {
-    contents.Code = data.Code;
+    contents.Code = __expectString(data.Code);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -6109,10 +6112,10 @@ const deserializeAws_restJson1InvalidInputExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Code !== undefined && data.Code !== null) {
-    contents.Code = data.Code;
+    contents.Code = __expectString(data.Code);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -6130,10 +6133,10 @@ const deserializeAws_restJson1LimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Code !== undefined && data.Code !== null) {
-    contents.Code = data.Code;
+    contents.Code = __expectString(data.Code);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -6151,10 +6154,10 @@ const deserializeAws_restJson1ResourceConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Code !== undefined && data.Code !== null) {
-    contents.Code = data.Code;
+    contents.Code = __expectString(data.Code);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -6172,10 +6175,10 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Code !== undefined && data.Code !== null) {
-    contents.Code = data.Code;
+    contents.Code = __expectString(data.Code);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -12294,7 +12297,7 @@ const serializeAws_restJson1WorkflowUpdate = (input: WorkflowUpdate, context: __
 
 const deserializeAws_restJson1Action = (output: any, context: __SerdeContext): Action => {
   return {
-    ActionType: output.ActionType !== undefined && output.ActionType !== null ? output.ActionType : undefined,
+    ActionType: __expectString(output.ActionType),
     AwsApiCallAction:
       output.AwsApiCallAction !== undefined && output.AwsApiCallAction !== null
         ? deserializeAws_restJson1AwsApiCallAction(output.AwsApiCallAction, context)
@@ -12316,7 +12319,7 @@ const deserializeAws_restJson1Action = (output: any, context: __SerdeContext): A
 
 const deserializeAws_restJson1ActionLocalIpDetails = (output: any, context: __SerdeContext): ActionLocalIpDetails => {
   return {
-    IpAddressV4: output.IpAddressV4 !== undefined && output.IpAddressV4 !== null ? output.IpAddressV4 : undefined,
+    IpAddressV4: __expectString(output.IpAddressV4),
   } as any;
 };
 
@@ -12325,8 +12328,8 @@ const deserializeAws_restJson1ActionLocalPortDetails = (
   context: __SerdeContext
 ): ActionLocalPortDetails => {
   return {
-    Port: output.Port !== undefined && output.Port !== null ? output.Port : undefined,
-    PortName: output.PortName !== undefined && output.PortName !== null ? output.PortName : undefined,
+    Port: __expectNumber(output.Port),
+    PortName: __expectString(output.PortName),
   } as any;
 };
 
@@ -12344,7 +12347,7 @@ const deserializeAws_restJson1ActionRemoteIpDetails = (output: any, context: __S
       output.GeoLocation !== undefined && output.GeoLocation !== null
         ? deserializeAws_restJson1GeoLocation(output.GeoLocation, context)
         : undefined,
-    IpAddressV4: output.IpAddressV4 !== undefined && output.IpAddressV4 !== null ? output.IpAddressV4 : undefined,
+    IpAddressV4: __expectString(output.IpAddressV4),
     Organization:
       output.Organization !== undefined && output.Organization !== null
         ? deserializeAws_restJson1IpOrganizationDetails(output.Organization, context)
@@ -12357,17 +12360,16 @@ const deserializeAws_restJson1ActionRemotePortDetails = (
   context: __SerdeContext
 ): ActionRemotePortDetails => {
   return {
-    Port: output.Port !== undefined && output.Port !== null ? output.Port : undefined,
-    PortName: output.PortName !== undefined && output.PortName !== null ? output.PortName : undefined,
+    Port: __expectNumber(output.Port),
+    PortName: __expectString(output.PortName),
   } as any;
 };
 
 const deserializeAws_restJson1ActionTarget = (output: any, context: __SerdeContext): ActionTarget => {
   return {
-    ActionTargetArn:
-      output.ActionTargetArn !== undefined && output.ActionTargetArn !== null ? output.ActionTargetArn : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    ActionTargetArn: __expectString(output.ActionTargetArn),
+    Description: __expectString(output.Description),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -12384,8 +12386,8 @@ const deserializeAws_restJson1ActionTargetList = (output: any, context: __SerdeC
 
 const deserializeAws_restJson1AdminAccount = (output: any, context: __SerdeContext): AdminAccount => {
   return {
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    AccountId: __expectString(output.AccountId),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -12402,8 +12404,8 @@ const deserializeAws_restJson1AdminAccounts = (output: any, context: __SerdeCont
 
 const deserializeAws_restJson1AvailabilityZone = (output: any, context: __SerdeContext): AvailabilityZone => {
   return {
-    SubnetId: output.SubnetId !== undefined && output.SubnetId !== null ? output.SubnetId : undefined,
-    ZoneName: output.ZoneName !== undefined && output.ZoneName !== null ? output.ZoneName : undefined,
+    SubnetId: __expectString(output.SubnetId),
+    ZoneName: __expectString(output.ZoneName),
   } as any;
 };
 
@@ -12424,19 +12426,19 @@ const deserializeAws_restJson1AwsApiCallAction = (output: any, context: __SerdeC
       output.AffectedResources !== undefined && output.AffectedResources !== null
         ? deserializeAws_restJson1FieldMap(output.AffectedResources, context)
         : undefined,
-    Api: output.Api !== undefined && output.Api !== null ? output.Api : undefined,
-    CallerType: output.CallerType !== undefined && output.CallerType !== null ? output.CallerType : undefined,
+    Api: __expectString(output.Api),
+    CallerType: __expectString(output.CallerType),
     DomainDetails:
       output.DomainDetails !== undefined && output.DomainDetails !== null
         ? deserializeAws_restJson1AwsApiCallActionDomainDetails(output.DomainDetails, context)
         : undefined,
-    FirstSeen: output.FirstSeen !== undefined && output.FirstSeen !== null ? output.FirstSeen : undefined,
-    LastSeen: output.LastSeen !== undefined && output.LastSeen !== null ? output.LastSeen : undefined,
+    FirstSeen: __expectString(output.FirstSeen),
+    LastSeen: __expectString(output.LastSeen),
     RemoteIpDetails:
       output.RemoteIpDetails !== undefined && output.RemoteIpDetails !== null
         ? deserializeAws_restJson1ActionRemoteIpDetails(output.RemoteIpDetails, context)
         : undefined,
-    ServiceName: output.ServiceName !== undefined && output.ServiceName !== null ? output.ServiceName : undefined,
+    ServiceName: __expectString(output.ServiceName),
   } as any;
 };
 
@@ -12445,7 +12447,7 @@ const deserializeAws_restJson1AwsApiCallActionDomainDetails = (
   context: __SerdeContext
 ): AwsApiCallActionDomainDetails => {
   return {
-    Domain: output.Domain !== undefined && output.Domain !== null ? output.Domain : undefined,
+    Domain: __expectString(output.Domain),
   } as any;
 };
 
@@ -12454,9 +12456,8 @@ const deserializeAws_restJson1AwsApiGatewayAccessLogSettings = (
   context: __SerdeContext
 ): AwsApiGatewayAccessLogSettings => {
   return {
-    DestinationArn:
-      output.DestinationArn !== undefined && output.DestinationArn !== null ? output.DestinationArn : undefined,
-    Format: output.Format !== undefined && output.Format !== null ? output.Format : undefined,
+    DestinationArn: __expectString(output.DestinationArn),
+    Format: __expectString(output.Format),
   } as any;
 };
 
@@ -12465,15 +12466,13 @@ const deserializeAws_restJson1AwsApiGatewayCanarySettings = (
   context: __SerdeContext
 ): AwsApiGatewayCanarySettings => {
   return {
-    DeploymentId: output.DeploymentId !== undefined && output.DeploymentId !== null ? output.DeploymentId : undefined,
-    PercentTraffic:
-      output.PercentTraffic !== undefined && output.PercentTraffic !== null ? output.PercentTraffic : undefined,
+    DeploymentId: __expectString(output.DeploymentId),
+    PercentTraffic: __expectNumber(output.PercentTraffic),
     StageVariableOverrides:
       output.StageVariableOverrides !== undefined && output.StageVariableOverrides !== null
         ? deserializeAws_restJson1FieldMap(output.StageVariableOverrides, context)
         : undefined,
-    UseStageCache:
-      output.UseStageCache !== undefined && output.UseStageCache !== null ? output.UseStageCache : undefined,
+    UseStageCache: __expectBoolean(output.UseStageCache),
   } as any;
 };
 
@@ -12494,40 +12493,18 @@ const deserializeAws_restJson1AwsApiGatewayMethodSettings = (
   context: __SerdeContext
 ): AwsApiGatewayMethodSettings => {
   return {
-    CacheDataEncrypted:
-      output.CacheDataEncrypted !== undefined && output.CacheDataEncrypted !== null
-        ? output.CacheDataEncrypted
-        : undefined,
-    CacheTtlInSeconds:
-      output.CacheTtlInSeconds !== undefined && output.CacheTtlInSeconds !== null
-        ? output.CacheTtlInSeconds
-        : undefined,
-    CachingEnabled:
-      output.CachingEnabled !== undefined && output.CachingEnabled !== null ? output.CachingEnabled : undefined,
-    DataTraceEnabled:
-      output.DataTraceEnabled !== undefined && output.DataTraceEnabled !== null ? output.DataTraceEnabled : undefined,
-    HttpMethod: output.HttpMethod !== undefined && output.HttpMethod !== null ? output.HttpMethod : undefined,
-    LoggingLevel: output.LoggingLevel !== undefined && output.LoggingLevel !== null ? output.LoggingLevel : undefined,
-    MetricsEnabled:
-      output.MetricsEnabled !== undefined && output.MetricsEnabled !== null ? output.MetricsEnabled : undefined,
-    RequireAuthorizationForCacheControl:
-      output.RequireAuthorizationForCacheControl !== undefined && output.RequireAuthorizationForCacheControl !== null
-        ? output.RequireAuthorizationForCacheControl
-        : undefined,
-    ResourcePath: output.ResourcePath !== undefined && output.ResourcePath !== null ? output.ResourcePath : undefined,
-    ThrottlingBurstLimit:
-      output.ThrottlingBurstLimit !== undefined && output.ThrottlingBurstLimit !== null
-        ? output.ThrottlingBurstLimit
-        : undefined,
-    ThrottlingRateLimit:
-      output.ThrottlingRateLimit !== undefined && output.ThrottlingRateLimit !== null
-        ? output.ThrottlingRateLimit
-        : undefined,
-    UnauthorizedCacheControlHeaderStrategy:
-      output.UnauthorizedCacheControlHeaderStrategy !== undefined &&
-      output.UnauthorizedCacheControlHeaderStrategy !== null
-        ? output.UnauthorizedCacheControlHeaderStrategy
-        : undefined,
+    CacheDataEncrypted: __expectBoolean(output.CacheDataEncrypted),
+    CacheTtlInSeconds: __expectNumber(output.CacheTtlInSeconds),
+    CachingEnabled: __expectBoolean(output.CachingEnabled),
+    DataTraceEnabled: __expectBoolean(output.DataTraceEnabled),
+    HttpMethod: __expectString(output.HttpMethod),
+    LoggingLevel: __expectString(output.LoggingLevel),
+    MetricsEnabled: __expectBoolean(output.MetricsEnabled),
+    RequireAuthorizationForCacheControl: __expectBoolean(output.RequireAuthorizationForCacheControl),
+    ResourcePath: __expectString(output.ResourcePath),
+    ThrottlingBurstLimit: __expectNumber(output.ThrottlingBurstLimit),
+    ThrottlingRateLimit: __expectNumber(output.ThrottlingRateLimit),
+    UnauthorizedCacheControlHeaderStrategy: __expectString(output.UnauthorizedCacheControlHeaderStrategy),
   } as any;
 };
 
@@ -12550,24 +12527,21 @@ const deserializeAws_restJson1AwsApiGatewayRestApiDetails = (
   context: __SerdeContext
 ): AwsApiGatewayRestApiDetails => {
   return {
-    ApiKeySource: output.ApiKeySource !== undefined && output.ApiKeySource !== null ? output.ApiKeySource : undefined,
+    ApiKeySource: __expectString(output.ApiKeySource),
     BinaryMediaTypes:
       output.BinaryMediaTypes !== undefined && output.BinaryMediaTypes !== null
         ? deserializeAws_restJson1NonEmptyStringList(output.BinaryMediaTypes, context)
         : undefined,
-    CreatedDate: output.CreatedDate !== undefined && output.CreatedDate !== null ? output.CreatedDate : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    CreatedDate: __expectString(output.CreatedDate),
+    Description: __expectString(output.Description),
     EndpointConfiguration:
       output.EndpointConfiguration !== undefined && output.EndpointConfiguration !== null
         ? deserializeAws_restJson1AwsApiGatewayEndpointConfiguration(output.EndpointConfiguration, context)
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    MinimumCompressionSize:
-      output.MinimumCompressionSize !== undefined && output.MinimumCompressionSize !== null
-        ? output.MinimumCompressionSize
-        : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    Id: __expectString(output.Id),
+    MinimumCompressionSize: __expectNumber(output.MinimumCompressionSize),
+    Name: __expectString(output.Name),
+    Version: __expectString(output.Version),
   } as any;
 };
 
@@ -12580,45 +12554,30 @@ const deserializeAws_restJson1AwsApiGatewayStageDetails = (
       output.AccessLogSettings !== undefined && output.AccessLogSettings !== null
         ? deserializeAws_restJson1AwsApiGatewayAccessLogSettings(output.AccessLogSettings, context)
         : undefined,
-    CacheClusterEnabled:
-      output.CacheClusterEnabled !== undefined && output.CacheClusterEnabled !== null
-        ? output.CacheClusterEnabled
-        : undefined,
-    CacheClusterSize:
-      output.CacheClusterSize !== undefined && output.CacheClusterSize !== null ? output.CacheClusterSize : undefined,
-    CacheClusterStatus:
-      output.CacheClusterStatus !== undefined && output.CacheClusterStatus !== null
-        ? output.CacheClusterStatus
-        : undefined,
+    CacheClusterEnabled: __expectBoolean(output.CacheClusterEnabled),
+    CacheClusterSize: __expectString(output.CacheClusterSize),
+    CacheClusterStatus: __expectString(output.CacheClusterStatus),
     CanarySettings:
       output.CanarySettings !== undefined && output.CanarySettings !== null
         ? deserializeAws_restJson1AwsApiGatewayCanarySettings(output.CanarySettings, context)
         : undefined,
-    ClientCertificateId:
-      output.ClientCertificateId !== undefined && output.ClientCertificateId !== null
-        ? output.ClientCertificateId
-        : undefined,
-    CreatedDate: output.CreatedDate !== undefined && output.CreatedDate !== null ? output.CreatedDate : undefined,
-    DeploymentId: output.DeploymentId !== undefined && output.DeploymentId !== null ? output.DeploymentId : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    DocumentationVersion:
-      output.DocumentationVersion !== undefined && output.DocumentationVersion !== null
-        ? output.DocumentationVersion
-        : undefined,
-    LastUpdatedDate:
-      output.LastUpdatedDate !== undefined && output.LastUpdatedDate !== null ? output.LastUpdatedDate : undefined,
+    ClientCertificateId: __expectString(output.ClientCertificateId),
+    CreatedDate: __expectString(output.CreatedDate),
+    DeploymentId: __expectString(output.DeploymentId),
+    Description: __expectString(output.Description),
+    DocumentationVersion: __expectString(output.DocumentationVersion),
+    LastUpdatedDate: __expectString(output.LastUpdatedDate),
     MethodSettings:
       output.MethodSettings !== undefined && output.MethodSettings !== null
         ? deserializeAws_restJson1AwsApiGatewayMethodSettingsList(output.MethodSettings, context)
         : undefined,
-    StageName: output.StageName !== undefined && output.StageName !== null ? output.StageName : undefined,
-    TracingEnabled:
-      output.TracingEnabled !== undefined && output.TracingEnabled !== null ? output.TracingEnabled : undefined,
+    StageName: __expectString(output.StageName),
+    TracingEnabled: __expectBoolean(output.TracingEnabled),
     Variables:
       output.Variables !== undefined && output.Variables !== null
         ? deserializeAws_restJson1FieldMap(output.Variables, context)
         : undefined,
-    WebAclArn: output.WebAclArn !== undefined && output.WebAclArn !== null ? output.WebAclArn : undefined,
+    WebAclArn: __expectString(output.WebAclArn),
   } as any;
 };
 
@@ -12627,25 +12586,19 @@ const deserializeAws_restJson1AwsApiGatewayV2ApiDetails = (
   context: __SerdeContext
 ): AwsApiGatewayV2ApiDetails => {
   return {
-    ApiEndpoint: output.ApiEndpoint !== undefined && output.ApiEndpoint !== null ? output.ApiEndpoint : undefined,
-    ApiId: output.ApiId !== undefined && output.ApiId !== null ? output.ApiId : undefined,
-    ApiKeySelectionExpression:
-      output.ApiKeySelectionExpression !== undefined && output.ApiKeySelectionExpression !== null
-        ? output.ApiKeySelectionExpression
-        : undefined,
+    ApiEndpoint: __expectString(output.ApiEndpoint),
+    ApiId: __expectString(output.ApiId),
+    ApiKeySelectionExpression: __expectString(output.ApiKeySelectionExpression),
     CorsConfiguration:
       output.CorsConfiguration !== undefined && output.CorsConfiguration !== null
         ? deserializeAws_restJson1AwsCorsConfiguration(output.CorsConfiguration, context)
         : undefined,
-    CreatedDate: output.CreatedDate !== undefined && output.CreatedDate !== null ? output.CreatedDate : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    ProtocolType: output.ProtocolType !== undefined && output.ProtocolType !== null ? output.ProtocolType : undefined,
-    RouteSelectionExpression:
-      output.RouteSelectionExpression !== undefined && output.RouteSelectionExpression !== null
-        ? output.RouteSelectionExpression
-        : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    CreatedDate: __expectString(output.CreatedDate),
+    Description: __expectString(output.Description),
+    Name: __expectString(output.Name),
+    ProtocolType: __expectString(output.ProtocolType),
+    RouteSelectionExpression: __expectString(output.RouteSelectionExpression),
+    Version: __expectString(output.Version),
   } as any;
 };
 
@@ -12654,21 +12607,11 @@ const deserializeAws_restJson1AwsApiGatewayV2RouteSettings = (
   context: __SerdeContext
 ): AwsApiGatewayV2RouteSettings => {
   return {
-    DataTraceEnabled:
-      output.DataTraceEnabled !== undefined && output.DataTraceEnabled !== null ? output.DataTraceEnabled : undefined,
-    DetailedMetricsEnabled:
-      output.DetailedMetricsEnabled !== undefined && output.DetailedMetricsEnabled !== null
-        ? output.DetailedMetricsEnabled
-        : undefined,
-    LoggingLevel: output.LoggingLevel !== undefined && output.LoggingLevel !== null ? output.LoggingLevel : undefined,
-    ThrottlingBurstLimit:
-      output.ThrottlingBurstLimit !== undefined && output.ThrottlingBurstLimit !== null
-        ? output.ThrottlingBurstLimit
-        : undefined,
-    ThrottlingRateLimit:
-      output.ThrottlingRateLimit !== undefined && output.ThrottlingRateLimit !== null
-        ? output.ThrottlingRateLimit
-        : undefined,
+    DataTraceEnabled: __expectBoolean(output.DataTraceEnabled),
+    DetailedMetricsEnabled: __expectBoolean(output.DetailedMetricsEnabled),
+    LoggingLevel: __expectString(output.LoggingLevel),
+    ThrottlingBurstLimit: __expectNumber(output.ThrottlingBurstLimit),
+    ThrottlingRateLimit: __expectNumber(output.ThrottlingRateLimit),
   } as any;
 };
 
@@ -12681,29 +12624,22 @@ const deserializeAws_restJson1AwsApiGatewayV2StageDetails = (
       output.AccessLogSettings !== undefined && output.AccessLogSettings !== null
         ? deserializeAws_restJson1AwsApiGatewayAccessLogSettings(output.AccessLogSettings, context)
         : undefined,
-    ApiGatewayManaged:
-      output.ApiGatewayManaged !== undefined && output.ApiGatewayManaged !== null
-        ? output.ApiGatewayManaged
-        : undefined,
-    AutoDeploy: output.AutoDeploy !== undefined && output.AutoDeploy !== null ? output.AutoDeploy : undefined,
-    CreatedDate: output.CreatedDate !== undefined && output.CreatedDate !== null ? output.CreatedDate : undefined,
+    ApiGatewayManaged: __expectBoolean(output.ApiGatewayManaged),
+    AutoDeploy: __expectBoolean(output.AutoDeploy),
+    CreatedDate: __expectString(output.CreatedDate),
     DefaultRouteSettings:
       output.DefaultRouteSettings !== undefined && output.DefaultRouteSettings !== null
         ? deserializeAws_restJson1AwsApiGatewayV2RouteSettings(output.DefaultRouteSettings, context)
         : undefined,
-    DeploymentId: output.DeploymentId !== undefined && output.DeploymentId !== null ? output.DeploymentId : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    LastDeploymentStatusMessage:
-      output.LastDeploymentStatusMessage !== undefined && output.LastDeploymentStatusMessage !== null
-        ? output.LastDeploymentStatusMessage
-        : undefined,
-    LastUpdatedDate:
-      output.LastUpdatedDate !== undefined && output.LastUpdatedDate !== null ? output.LastUpdatedDate : undefined,
+    DeploymentId: __expectString(output.DeploymentId),
+    Description: __expectString(output.Description),
+    LastDeploymentStatusMessage: __expectString(output.LastDeploymentStatusMessage),
+    LastUpdatedDate: __expectString(output.LastUpdatedDate),
     RouteSettings:
       output.RouteSettings !== undefined && output.RouteSettings !== null
         ? deserializeAws_restJson1AwsApiGatewayV2RouteSettings(output.RouteSettings, context)
         : undefined,
-    StageName: output.StageName !== undefined && output.StageName !== null ? output.StageName : undefined,
+    StageName: __expectString(output.StageName),
     StageVariables:
       output.StageVariables !== undefined && output.StageVariables !== null
         ? deserializeAws_restJson1FieldMap(output.StageVariables, context)
@@ -12716,17 +12652,10 @@ const deserializeAws_restJson1AwsAutoScalingAutoScalingGroupDetails = (
   context: __SerdeContext
 ): AwsAutoScalingAutoScalingGroupDetails => {
   return {
-    CreatedTime: output.CreatedTime !== undefined && output.CreatedTime !== null ? output.CreatedTime : undefined,
-    HealthCheckGracePeriod:
-      output.HealthCheckGracePeriod !== undefined && output.HealthCheckGracePeriod !== null
-        ? output.HealthCheckGracePeriod
-        : undefined,
-    HealthCheckType:
-      output.HealthCheckType !== undefined && output.HealthCheckType !== null ? output.HealthCheckType : undefined,
-    LaunchConfigurationName:
-      output.LaunchConfigurationName !== undefined && output.LaunchConfigurationName !== null
-        ? output.LaunchConfigurationName
-        : undefined,
+    CreatedTime: __expectString(output.CreatedTime),
+    HealthCheckGracePeriod: __expectNumber(output.HealthCheckGracePeriod),
+    HealthCheckType: __expectString(output.HealthCheckType),
+    LaunchConfigurationName: __expectString(output.LaunchConfigurationName),
     LoadBalancerNames:
       output.LoadBalancerNames !== undefined && output.LoadBalancerNames !== null
         ? deserializeAws_restJson1StringList(output.LoadBalancerNames, context)
@@ -12739,12 +12668,9 @@ const deserializeAws_restJson1AwsCertificateManagerCertificateDetails = (
   context: __SerdeContext
 ): AwsCertificateManagerCertificateDetails => {
   return {
-    CertificateAuthorityArn:
-      output.CertificateAuthorityArn !== undefined && output.CertificateAuthorityArn !== null
-        ? output.CertificateAuthorityArn
-        : undefined,
-    CreatedAt: output.CreatedAt !== undefined && output.CreatedAt !== null ? output.CreatedAt : undefined,
-    DomainName: output.DomainName !== undefined && output.DomainName !== null ? output.DomainName : undefined,
+    CertificateAuthorityArn: __expectString(output.CertificateAuthorityArn),
+    CreatedAt: __expectString(output.CreatedAt),
+    DomainName: __expectString(output.DomainName),
     DomainValidationOptions:
       output.DomainValidationOptions !== undefined && output.DomainValidationOptions !== null
         ? deserializeAws_restJson1AwsCertificateManagerCertificateDomainValidationOptions(
@@ -12756,46 +12682,39 @@ const deserializeAws_restJson1AwsCertificateManagerCertificateDetails = (
       output.ExtendedKeyUsages !== undefined && output.ExtendedKeyUsages !== null
         ? deserializeAws_restJson1AwsCertificateManagerCertificateExtendedKeyUsages(output.ExtendedKeyUsages, context)
         : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
-    ImportedAt: output.ImportedAt !== undefined && output.ImportedAt !== null ? output.ImportedAt : undefined,
+    FailureReason: __expectString(output.FailureReason),
+    ImportedAt: __expectString(output.ImportedAt),
     InUseBy:
       output.InUseBy !== undefined && output.InUseBy !== null
         ? deserializeAws_restJson1StringList(output.InUseBy, context)
         : undefined,
-    IssuedAt: output.IssuedAt !== undefined && output.IssuedAt !== null ? output.IssuedAt : undefined,
-    Issuer: output.Issuer !== undefined && output.Issuer !== null ? output.Issuer : undefined,
-    KeyAlgorithm: output.KeyAlgorithm !== undefined && output.KeyAlgorithm !== null ? output.KeyAlgorithm : undefined,
+    IssuedAt: __expectString(output.IssuedAt),
+    Issuer: __expectString(output.Issuer),
+    KeyAlgorithm: __expectString(output.KeyAlgorithm),
     KeyUsages:
       output.KeyUsages !== undefined && output.KeyUsages !== null
         ? deserializeAws_restJson1AwsCertificateManagerCertificateKeyUsages(output.KeyUsages, context)
         : undefined,
-    NotAfter: output.NotAfter !== undefined && output.NotAfter !== null ? output.NotAfter : undefined,
-    NotBefore: output.NotBefore !== undefined && output.NotBefore !== null ? output.NotBefore : undefined,
+    NotAfter: __expectString(output.NotAfter),
+    NotBefore: __expectString(output.NotBefore),
     Options:
       output.Options !== undefined && output.Options !== null
         ? deserializeAws_restJson1AwsCertificateManagerCertificateOptions(output.Options, context)
         : undefined,
-    RenewalEligibility:
-      output.RenewalEligibility !== undefined && output.RenewalEligibility !== null
-        ? output.RenewalEligibility
-        : undefined,
+    RenewalEligibility: __expectString(output.RenewalEligibility),
     RenewalSummary:
       output.RenewalSummary !== undefined && output.RenewalSummary !== null
         ? deserializeAws_restJson1AwsCertificateManagerCertificateRenewalSummary(output.RenewalSummary, context)
         : undefined,
-    Serial: output.Serial !== undefined && output.Serial !== null ? output.Serial : undefined,
-    SignatureAlgorithm:
-      output.SignatureAlgorithm !== undefined && output.SignatureAlgorithm !== null
-        ? output.SignatureAlgorithm
-        : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    Subject: output.Subject !== undefined && output.Subject !== null ? output.Subject : undefined,
+    Serial: __expectString(output.Serial),
+    SignatureAlgorithm: __expectString(output.SignatureAlgorithm),
+    Status: __expectString(output.Status),
+    Subject: __expectString(output.Subject),
     SubjectAlternativeNames:
       output.SubjectAlternativeNames !== undefined && output.SubjectAlternativeNames !== null
         ? deserializeAws_restJson1StringList(output.SubjectAlternativeNames, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -12804,21 +12723,18 @@ const deserializeAws_restJson1AwsCertificateManagerCertificateDomainValidationOp
   context: __SerdeContext
 ): AwsCertificateManagerCertificateDomainValidationOption => {
   return {
-    DomainName: output.DomainName !== undefined && output.DomainName !== null ? output.DomainName : undefined,
+    DomainName: __expectString(output.DomainName),
     ResourceRecord:
       output.ResourceRecord !== undefined && output.ResourceRecord !== null
         ? deserializeAws_restJson1AwsCertificateManagerCertificateResourceRecord(output.ResourceRecord, context)
         : undefined,
-    ValidationDomain:
-      output.ValidationDomain !== undefined && output.ValidationDomain !== null ? output.ValidationDomain : undefined,
+    ValidationDomain: __expectString(output.ValidationDomain),
     ValidationEmails:
       output.ValidationEmails !== undefined && output.ValidationEmails !== null
         ? deserializeAws_restJson1StringList(output.ValidationEmails, context)
         : undefined,
-    ValidationMethod:
-      output.ValidationMethod !== undefined && output.ValidationMethod !== null ? output.ValidationMethod : undefined,
-    ValidationStatus:
-      output.ValidationStatus !== undefined && output.ValidationStatus !== null ? output.ValidationStatus : undefined,
+    ValidationMethod: __expectString(output.ValidationMethod),
+    ValidationStatus: __expectString(output.ValidationStatus),
   } as any;
 };
 
@@ -12841,8 +12757,8 @@ const deserializeAws_restJson1AwsCertificateManagerCertificateExtendedKeyUsage =
   context: __SerdeContext
 ): AwsCertificateManagerCertificateExtendedKeyUsage => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    OId: output.OId !== undefined && output.OId !== null ? output.OId : undefined,
+    Name: __expectString(output.Name),
+    OId: __expectString(output.OId),
   } as any;
 };
 
@@ -12865,7 +12781,7 @@ const deserializeAws_restJson1AwsCertificateManagerCertificateKeyUsage = (
   context: __SerdeContext
 ): AwsCertificateManagerCertificateKeyUsage => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -12888,11 +12804,7 @@ const deserializeAws_restJson1AwsCertificateManagerCertificateOptions = (
   context: __SerdeContext
 ): AwsCertificateManagerCertificateOptions => {
   return {
-    CertificateTransparencyLoggingPreference:
-      output.CertificateTransparencyLoggingPreference !== undefined &&
-      output.CertificateTransparencyLoggingPreference !== null
-        ? output.CertificateTransparencyLoggingPreference
-        : undefined,
+    CertificateTransparencyLoggingPreference: __expectString(output.CertificateTransparencyLoggingPreference),
   } as any;
 };
 
@@ -12908,13 +12820,9 @@ const deserializeAws_restJson1AwsCertificateManagerCertificateRenewalSummary = (
             context
           )
         : undefined,
-    RenewalStatus:
-      output.RenewalStatus !== undefined && output.RenewalStatus !== null ? output.RenewalStatus : undefined,
-    RenewalStatusReason:
-      output.RenewalStatusReason !== undefined && output.RenewalStatusReason !== null
-        ? output.RenewalStatusReason
-        : undefined,
-    UpdatedAt: output.UpdatedAt !== undefined && output.UpdatedAt !== null ? output.UpdatedAt : undefined,
+    RenewalStatus: __expectString(output.RenewalStatus),
+    RenewalStatusReason: __expectString(output.RenewalStatusReason),
+    UpdatedAt: __expectString(output.UpdatedAt),
   } as any;
 };
 
@@ -12923,9 +12831,9 @@ const deserializeAws_restJson1AwsCertificateManagerCertificateResourceRecord = (
   context: __SerdeContext
 ): AwsCertificateManagerCertificateResourceRecord => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Name: __expectString(output.Name),
+    Type: __expectString(output.Type),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -12934,10 +12842,7 @@ const deserializeAws_restJson1AwsCloudFrontDistributionCacheBehavior = (
   context: __SerdeContext
 ): AwsCloudFrontDistributionCacheBehavior => {
   return {
-    ViewerProtocolPolicy:
-      output.ViewerProtocolPolicy !== undefined && output.ViewerProtocolPolicy !== null
-        ? output.ViewerProtocolPolicy
-        : undefined,
+    ViewerProtocolPolicy: __expectString(output.ViewerProtocolPolicy),
   } as any;
 };
 
@@ -12972,10 +12877,7 @@ const deserializeAws_restJson1AwsCloudFrontDistributionDefaultCacheBehavior = (
   context: __SerdeContext
 ): AwsCloudFrontDistributionDefaultCacheBehavior => {
   return {
-    ViewerProtocolPolicy:
-      output.ViewerProtocolPolicy !== undefined && output.ViewerProtocolPolicy !== null
-        ? output.ViewerProtocolPolicy
-        : undefined,
+    ViewerProtocolPolicy: __expectString(output.ViewerProtocolPolicy),
   } as any;
 };
 
@@ -12992,14 +12894,10 @@ const deserializeAws_restJson1AwsCloudFrontDistributionDetails = (
       output.DefaultCacheBehavior !== undefined && output.DefaultCacheBehavior !== null
         ? deserializeAws_restJson1AwsCloudFrontDistributionDefaultCacheBehavior(output.DefaultCacheBehavior, context)
         : undefined,
-    DefaultRootObject:
-      output.DefaultRootObject !== undefined && output.DefaultRootObject !== null
-        ? output.DefaultRootObject
-        : undefined,
-    DomainName: output.DomainName !== undefined && output.DomainName !== null ? output.DomainName : undefined,
-    ETag: output.ETag !== undefined && output.ETag !== null ? output.ETag : undefined,
-    LastModifiedTime:
-      output.LastModifiedTime !== undefined && output.LastModifiedTime !== null ? output.LastModifiedTime : undefined,
+    DefaultRootObject: __expectString(output.DefaultRootObject),
+    DomainName: __expectString(output.DomainName),
+    ETag: __expectString(output.ETag),
+    LastModifiedTime: __expectString(output.LastModifiedTime),
     Logging:
       output.Logging !== undefined && output.Logging !== null
         ? deserializeAws_restJson1AwsCloudFrontDistributionLogging(output.Logging, context)
@@ -13012,8 +12910,8 @@ const deserializeAws_restJson1AwsCloudFrontDistributionDetails = (
       output.Origins !== undefined && output.Origins !== null
         ? deserializeAws_restJson1AwsCloudFrontDistributionOrigins(output.Origins, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    WebAclId: output.WebAclId !== undefined && output.WebAclId !== null ? output.WebAclId : undefined,
+    Status: __expectString(output.Status),
+    WebAclId: __expectString(output.WebAclId),
   } as any;
 };
 
@@ -13022,11 +12920,10 @@ const deserializeAws_restJson1AwsCloudFrontDistributionLogging = (
   context: __SerdeContext
 ): AwsCloudFrontDistributionLogging => {
   return {
-    Bucket: output.Bucket !== undefined && output.Bucket !== null ? output.Bucket : undefined,
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
-    IncludeCookies:
-      output.IncludeCookies !== undefined && output.IncludeCookies !== null ? output.IncludeCookies : undefined,
-    Prefix: output.Prefix !== undefined && output.Prefix !== null ? output.Prefix : undefined,
+    Bucket: __expectString(output.Bucket),
+    Enabled: __expectBoolean(output.Enabled),
+    IncludeCookies: __expectBoolean(output.IncludeCookies),
+    Prefix: __expectString(output.Prefix),
   } as any;
 };
 
@@ -13063,7 +12960,7 @@ const deserializeAws_restJson1AwsCloudFrontDistributionOriginGroupFailoverStatus
       output.Items !== undefined && output.Items !== null
         ? deserializeAws_restJson1AwsCloudFrontDistributionOriginGroupFailoverStatusCodesItemList(output.Items, context)
         : undefined,
-    Quantity: output.Quantity !== undefined && output.Quantity !== null ? output.Quantity : undefined,
+    Quantity: __expectNumber(output.Quantity),
   } as any;
 };
 
@@ -13077,7 +12974,7 @@ const deserializeAws_restJson1AwsCloudFrontDistributionOriginGroupFailoverStatus
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectNumber(entry) as any;
     });
 };
 
@@ -13112,9 +13009,9 @@ const deserializeAws_restJson1AwsCloudFrontDistributionOriginItem = (
   context: __SerdeContext
 ): AwsCloudFrontDistributionOriginItem => {
   return {
-    DomainName: output.DomainName !== undefined && output.DomainName !== null ? output.DomainName : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    OriginPath: output.OriginPath !== undefined && output.OriginPath !== null ? output.OriginPath : undefined,
+    DomainName: __expectString(output.DomainName),
+    Id: __expectString(output.Id),
+    OriginPath: __expectString(output.OriginPath),
     S3OriginConfig:
       output.S3OriginConfig !== undefined && output.S3OriginConfig !== null
         ? deserializeAws_restJson1AwsCloudFrontDistributionOriginS3OriginConfig(output.S3OriginConfig, context)
@@ -13153,10 +13050,7 @@ const deserializeAws_restJson1AwsCloudFrontDistributionOriginS3OriginConfig = (
   context: __SerdeContext
 ): AwsCloudFrontDistributionOriginS3OriginConfig => {
   return {
-    OriginAccessIdentity:
-      output.OriginAccessIdentity !== undefined && output.OriginAccessIdentity !== null
-        ? output.OriginAccessIdentity
-        : undefined,
+    OriginAccessIdentity: __expectString(output.OriginAccessIdentity),
   } as any;
 };
 
@@ -13165,42 +13059,21 @@ const deserializeAws_restJson1AwsCloudTrailTrailDetails = (
   context: __SerdeContext
 ): AwsCloudTrailTrailDetails => {
   return {
-    CloudWatchLogsLogGroupArn:
-      output.CloudWatchLogsLogGroupArn !== undefined && output.CloudWatchLogsLogGroupArn !== null
-        ? output.CloudWatchLogsLogGroupArn
-        : undefined,
-    CloudWatchLogsRoleArn:
-      output.CloudWatchLogsRoleArn !== undefined && output.CloudWatchLogsRoleArn !== null
-        ? output.CloudWatchLogsRoleArn
-        : undefined,
-    HasCustomEventSelectors:
-      output.HasCustomEventSelectors !== undefined && output.HasCustomEventSelectors !== null
-        ? output.HasCustomEventSelectors
-        : undefined,
-    HomeRegion: output.HomeRegion !== undefined && output.HomeRegion !== null ? output.HomeRegion : undefined,
-    IncludeGlobalServiceEvents:
-      output.IncludeGlobalServiceEvents !== undefined && output.IncludeGlobalServiceEvents !== null
-        ? output.IncludeGlobalServiceEvents
-        : undefined,
-    IsMultiRegionTrail:
-      output.IsMultiRegionTrail !== undefined && output.IsMultiRegionTrail !== null
-        ? output.IsMultiRegionTrail
-        : undefined,
-    IsOrganizationTrail:
-      output.IsOrganizationTrail !== undefined && output.IsOrganizationTrail !== null
-        ? output.IsOrganizationTrail
-        : undefined,
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
-    LogFileValidationEnabled:
-      output.LogFileValidationEnabled !== undefined && output.LogFileValidationEnabled !== null
-        ? output.LogFileValidationEnabled
-        : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    S3BucketName: output.S3BucketName !== undefined && output.S3BucketName !== null ? output.S3BucketName : undefined,
-    S3KeyPrefix: output.S3KeyPrefix !== undefined && output.S3KeyPrefix !== null ? output.S3KeyPrefix : undefined,
-    SnsTopicArn: output.SnsTopicArn !== undefined && output.SnsTopicArn !== null ? output.SnsTopicArn : undefined,
-    SnsTopicName: output.SnsTopicName !== undefined && output.SnsTopicName !== null ? output.SnsTopicName : undefined,
-    TrailArn: output.TrailArn !== undefined && output.TrailArn !== null ? output.TrailArn : undefined,
+    CloudWatchLogsLogGroupArn: __expectString(output.CloudWatchLogsLogGroupArn),
+    CloudWatchLogsRoleArn: __expectString(output.CloudWatchLogsRoleArn),
+    HasCustomEventSelectors: __expectBoolean(output.HasCustomEventSelectors),
+    HomeRegion: __expectString(output.HomeRegion),
+    IncludeGlobalServiceEvents: __expectBoolean(output.IncludeGlobalServiceEvents),
+    IsMultiRegionTrail: __expectBoolean(output.IsMultiRegionTrail),
+    IsOrganizationTrail: __expectBoolean(output.IsOrganizationTrail),
+    KmsKeyId: __expectString(output.KmsKeyId),
+    LogFileValidationEnabled: __expectBoolean(output.LogFileValidationEnabled),
+    Name: __expectString(output.Name),
+    S3BucketName: __expectString(output.S3BucketName),
+    S3KeyPrefix: __expectString(output.S3KeyPrefix),
+    SnsTopicArn: __expectString(output.SnsTopicArn),
+    SnsTopicName: __expectString(output.SnsTopicName),
+    TrailArn: __expectString(output.TrailArn),
   } as any;
 };
 
@@ -13209,14 +13082,13 @@ const deserializeAws_restJson1AwsCodeBuildProjectDetails = (
   context: __SerdeContext
 ): AwsCodeBuildProjectDetails => {
   return {
-    EncryptionKey:
-      output.EncryptionKey !== undefined && output.EncryptionKey !== null ? output.EncryptionKey : undefined,
+    EncryptionKey: __expectString(output.EncryptionKey),
     Environment:
       output.Environment !== undefined && output.Environment !== null
         ? deserializeAws_restJson1AwsCodeBuildProjectEnvironment(output.Environment, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    ServiceRole: output.ServiceRole !== undefined && output.ServiceRole !== null ? output.ServiceRole : undefined,
+    Name: __expectString(output.Name),
+    ServiceRole: __expectString(output.ServiceRole),
     Source:
       output.Source !== undefined && output.Source !== null
         ? deserializeAws_restJson1AwsCodeBuildProjectSource(output.Source, context)
@@ -13233,16 +13105,13 @@ const deserializeAws_restJson1AwsCodeBuildProjectEnvironment = (
   context: __SerdeContext
 ): AwsCodeBuildProjectEnvironment => {
   return {
-    Certificate: output.Certificate !== undefined && output.Certificate !== null ? output.Certificate : undefined,
-    ImagePullCredentialsType:
-      output.ImagePullCredentialsType !== undefined && output.ImagePullCredentialsType !== null
-        ? output.ImagePullCredentialsType
-        : undefined,
+    Certificate: __expectString(output.Certificate),
+    ImagePullCredentialsType: __expectString(output.ImagePullCredentialsType),
     RegistryCredential:
       output.RegistryCredential !== undefined && output.RegistryCredential !== null
         ? deserializeAws_restJson1AwsCodeBuildProjectEnvironmentRegistryCredential(output.RegistryCredential, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -13251,11 +13120,8 @@ const deserializeAws_restJson1AwsCodeBuildProjectEnvironmentRegistryCredential =
   context: __SerdeContext
 ): AwsCodeBuildProjectEnvironmentRegistryCredential => {
   return {
-    Credential: output.Credential !== undefined && output.Credential !== null ? output.Credential : undefined,
-    CredentialProvider:
-      output.CredentialProvider !== undefined && output.CredentialProvider !== null
-        ? output.CredentialProvider
-        : undefined,
+    Credential: __expectString(output.Credential),
+    CredentialProvider: __expectString(output.CredentialProvider),
   } as any;
 };
 
@@ -13264,11 +13130,10 @@ const deserializeAws_restJson1AwsCodeBuildProjectSource = (
   context: __SerdeContext
 ): AwsCodeBuildProjectSource => {
   return {
-    GitCloneDepth:
-      output.GitCloneDepth !== undefined && output.GitCloneDepth !== null ? output.GitCloneDepth : undefined,
-    InsecureSsl: output.InsecureSsl !== undefined && output.InsecureSsl !== null ? output.InsecureSsl : undefined,
-    Location: output.Location !== undefined && output.Location !== null ? output.Location : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    GitCloneDepth: __expectNumber(output.GitCloneDepth),
+    InsecureSsl: __expectBoolean(output.InsecureSsl),
+    Location: __expectString(output.Location),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -13285,14 +13150,13 @@ const deserializeAws_restJson1AwsCodeBuildProjectVpcConfig = (
       output.Subnets !== undefined && output.Subnets !== null
         ? deserializeAws_restJson1NonEmptyStringList(output.Subnets, context)
         : undefined,
-    VpcId: output.VpcId !== undefined && output.VpcId !== null ? output.VpcId : undefined,
+    VpcId: __expectString(output.VpcId),
   } as any;
 };
 
 const deserializeAws_restJson1AwsCorsConfiguration = (output: any, context: __SerdeContext): AwsCorsConfiguration => {
   return {
-    AllowCredentials:
-      output.AllowCredentials !== undefined && output.AllowCredentials !== null ? output.AllowCredentials : undefined,
+    AllowCredentials: __expectBoolean(output.AllowCredentials),
     AllowHeaders:
       output.AllowHeaders !== undefined && output.AllowHeaders !== null
         ? deserializeAws_restJson1NonEmptyStringList(output.AllowHeaders, context)
@@ -13309,7 +13173,7 @@ const deserializeAws_restJson1AwsCorsConfiguration = (output: any, context: __Se
       output.ExposeHeaders !== undefined && output.ExposeHeaders !== null
         ? deserializeAws_restJson1NonEmptyStringList(output.ExposeHeaders, context)
         : undefined,
-    MaxAge: output.MaxAge !== undefined && output.MaxAge !== null ? output.MaxAge : undefined,
+    MaxAge: __expectNumber(output.MaxAge),
   } as any;
 };
 
@@ -13318,10 +13182,8 @@ const deserializeAws_restJson1AwsDynamoDbTableAttributeDefinition = (
   context: __SerdeContext
 ): AwsDynamoDbTableAttributeDefinition => {
   return {
-    AttributeName:
-      output.AttributeName !== undefined && output.AttributeName !== null ? output.AttributeName : undefined,
-    AttributeType:
-      output.AttributeType !== undefined && output.AttributeType !== null ? output.AttributeType : undefined,
+    AttributeName: __expectString(output.AttributeName),
+    AttributeType: __expectString(output.AttributeType),
   } as any;
 };
 
@@ -13344,11 +13206,8 @@ const deserializeAws_restJson1AwsDynamoDbTableBillingModeSummary = (
   context: __SerdeContext
 ): AwsDynamoDbTableBillingModeSummary => {
   return {
-    BillingMode: output.BillingMode !== undefined && output.BillingMode !== null ? output.BillingMode : undefined,
-    LastUpdateToPayPerRequestDateTime:
-      output.LastUpdateToPayPerRequestDateTime !== undefined && output.LastUpdateToPayPerRequestDateTime !== null
-        ? output.LastUpdateToPayPerRequestDateTime
-        : undefined,
+    BillingMode: __expectString(output.BillingMode),
+    LastUpdateToPayPerRequestDateTime: __expectString(output.LastUpdateToPayPerRequestDateTime),
   } as any;
 };
 
@@ -13365,27 +13224,19 @@ const deserializeAws_restJson1AwsDynamoDbTableDetails = (
       output.BillingModeSummary !== undefined && output.BillingModeSummary !== null
         ? deserializeAws_restJson1AwsDynamoDbTableBillingModeSummary(output.BillingModeSummary, context)
         : undefined,
-    CreationDateTime:
-      output.CreationDateTime !== undefined && output.CreationDateTime !== null ? output.CreationDateTime : undefined,
+    CreationDateTime: __expectString(output.CreationDateTime),
     GlobalSecondaryIndexes:
       output.GlobalSecondaryIndexes !== undefined && output.GlobalSecondaryIndexes !== null
         ? deserializeAws_restJson1AwsDynamoDbTableGlobalSecondaryIndexList(output.GlobalSecondaryIndexes, context)
         : undefined,
-    GlobalTableVersion:
-      output.GlobalTableVersion !== undefined && output.GlobalTableVersion !== null
-        ? output.GlobalTableVersion
-        : undefined,
-    ItemCount: output.ItemCount !== undefined && output.ItemCount !== null ? output.ItemCount : undefined,
+    GlobalTableVersion: __expectString(output.GlobalTableVersion),
+    ItemCount: __expectNumber(output.ItemCount),
     KeySchema:
       output.KeySchema !== undefined && output.KeySchema !== null
         ? deserializeAws_restJson1AwsDynamoDbTableKeySchemaList(output.KeySchema, context)
         : undefined,
-    LatestStreamArn:
-      output.LatestStreamArn !== undefined && output.LatestStreamArn !== null ? output.LatestStreamArn : undefined,
-    LatestStreamLabel:
-      output.LatestStreamLabel !== undefined && output.LatestStreamLabel !== null
-        ? output.LatestStreamLabel
-        : undefined,
+    LatestStreamArn: __expectString(output.LatestStreamArn),
+    LatestStreamLabel: __expectString(output.LatestStreamLabel),
     LocalSecondaryIndexes:
       output.LocalSecondaryIndexes !== undefined && output.LocalSecondaryIndexes !== null
         ? deserializeAws_restJson1AwsDynamoDbTableLocalSecondaryIndexList(output.LocalSecondaryIndexes, context)
@@ -13410,11 +13261,10 @@ const deserializeAws_restJson1AwsDynamoDbTableDetails = (
       output.StreamSpecification !== undefined && output.StreamSpecification !== null
         ? deserializeAws_restJson1AwsDynamoDbTableStreamSpecification(output.StreamSpecification, context)
         : undefined,
-    TableId: output.TableId !== undefined && output.TableId !== null ? output.TableId : undefined,
-    TableName: output.TableName !== undefined && output.TableName !== null ? output.TableName : undefined,
-    TableSizeBytes:
-      output.TableSizeBytes !== undefined && output.TableSizeBytes !== null ? output.TableSizeBytes : undefined,
-    TableStatus: output.TableStatus !== undefined && output.TableStatus !== null ? output.TableStatus : undefined,
+    TableId: __expectString(output.TableId),
+    TableName: __expectString(output.TableName),
+    TableSizeBytes: __expectNumber(output.TableSizeBytes),
+    TableStatus: __expectString(output.TableStatus),
   } as any;
 };
 
@@ -13423,13 +13273,12 @@ const deserializeAws_restJson1AwsDynamoDbTableGlobalSecondaryIndex = (
   context: __SerdeContext
 ): AwsDynamoDbTableGlobalSecondaryIndex => {
   return {
-    Backfilling: output.Backfilling !== undefined && output.Backfilling !== null ? output.Backfilling : undefined,
-    IndexArn: output.IndexArn !== undefined && output.IndexArn !== null ? output.IndexArn : undefined,
-    IndexName: output.IndexName !== undefined && output.IndexName !== null ? output.IndexName : undefined,
-    IndexSizeBytes:
-      output.IndexSizeBytes !== undefined && output.IndexSizeBytes !== null ? output.IndexSizeBytes : undefined,
-    IndexStatus: output.IndexStatus !== undefined && output.IndexStatus !== null ? output.IndexStatus : undefined,
-    ItemCount: output.ItemCount !== undefined && output.ItemCount !== null ? output.ItemCount : undefined,
+    Backfilling: __expectBoolean(output.Backfilling),
+    IndexArn: __expectString(output.IndexArn),
+    IndexName: __expectString(output.IndexName),
+    IndexSizeBytes: __expectNumber(output.IndexSizeBytes),
+    IndexStatus: __expectString(output.IndexStatus),
+    ItemCount: __expectNumber(output.ItemCount),
     KeySchema:
       output.KeySchema !== undefined && output.KeySchema !== null
         ? deserializeAws_restJson1AwsDynamoDbTableKeySchemaList(output.KeySchema, context)
@@ -13464,9 +13313,8 @@ const deserializeAws_restJson1AwsDynamoDbTableKeySchema = (
   context: __SerdeContext
 ): AwsDynamoDbTableKeySchema => {
   return {
-    AttributeName:
-      output.AttributeName !== undefined && output.AttributeName !== null ? output.AttributeName : undefined,
-    KeyType: output.KeyType !== undefined && output.KeyType !== null ? output.KeyType : undefined,
+    AttributeName: __expectString(output.AttributeName),
+    KeyType: __expectString(output.KeyType),
   } as any;
 };
 
@@ -13489,8 +13337,8 @@ const deserializeAws_restJson1AwsDynamoDbTableLocalSecondaryIndex = (
   context: __SerdeContext
 ): AwsDynamoDbTableLocalSecondaryIndex => {
   return {
-    IndexArn: output.IndexArn !== undefined && output.IndexArn !== null ? output.IndexArn : undefined,
-    IndexName: output.IndexName !== undefined && output.IndexName !== null ? output.IndexName : undefined,
+    IndexArn: __expectString(output.IndexArn),
+    IndexName: __expectString(output.IndexName),
     KeySchema:
       output.KeySchema !== undefined && output.KeySchema !== null
         ? deserializeAws_restJson1AwsDynamoDbTableKeySchemaList(output.KeySchema, context)
@@ -13525,8 +13373,7 @@ const deserializeAws_restJson1AwsDynamoDbTableProjection = (
       output.NonKeyAttributes !== undefined && output.NonKeyAttributes !== null
         ? deserializeAws_restJson1StringList(output.NonKeyAttributes, context)
         : undefined,
-    ProjectionType:
-      output.ProjectionType !== undefined && output.ProjectionType !== null ? output.ProjectionType : undefined,
+    ProjectionType: __expectString(output.ProjectionType),
   } as any;
 };
 
@@ -13535,26 +13382,11 @@ const deserializeAws_restJson1AwsDynamoDbTableProvisionedThroughput = (
   context: __SerdeContext
 ): AwsDynamoDbTableProvisionedThroughput => {
   return {
-    LastDecreaseDateTime:
-      output.LastDecreaseDateTime !== undefined && output.LastDecreaseDateTime !== null
-        ? output.LastDecreaseDateTime
-        : undefined,
-    LastIncreaseDateTime:
-      output.LastIncreaseDateTime !== undefined && output.LastIncreaseDateTime !== null
-        ? output.LastIncreaseDateTime
-        : undefined,
-    NumberOfDecreasesToday:
-      output.NumberOfDecreasesToday !== undefined && output.NumberOfDecreasesToday !== null
-        ? output.NumberOfDecreasesToday
-        : undefined,
-    ReadCapacityUnits:
-      output.ReadCapacityUnits !== undefined && output.ReadCapacityUnits !== null
-        ? output.ReadCapacityUnits
-        : undefined,
-    WriteCapacityUnits:
-      output.WriteCapacityUnits !== undefined && output.WriteCapacityUnits !== null
-        ? output.WriteCapacityUnits
-        : undefined,
+    LastDecreaseDateTime: __expectString(output.LastDecreaseDateTime),
+    LastIncreaseDateTime: __expectString(output.LastIncreaseDateTime),
+    NumberOfDecreasesToday: __expectNumber(output.NumberOfDecreasesToday),
+    ReadCapacityUnits: __expectNumber(output.ReadCapacityUnits),
+    WriteCapacityUnits: __expectNumber(output.WriteCapacityUnits),
   } as any;
 };
 
@@ -13563,10 +13395,7 @@ const deserializeAws_restJson1AwsDynamoDbTableProvisionedThroughputOverride = (
   context: __SerdeContext
 ): AwsDynamoDbTableProvisionedThroughputOverride => {
   return {
-    ReadCapacityUnits:
-      output.ReadCapacityUnits !== undefined && output.ReadCapacityUnits !== null
-        ? output.ReadCapacityUnits
-        : undefined,
+    ReadCapacityUnits: __expectNumber(output.ReadCapacityUnits),
   } as any;
 };
 
@@ -13582,8 +13411,7 @@ const deserializeAws_restJson1AwsDynamoDbTableReplica = (
             context
           )
         : undefined,
-    KmsMasterKeyId:
-      output.KmsMasterKeyId !== undefined && output.KmsMasterKeyId !== null ? output.KmsMasterKeyId : undefined,
+    KmsMasterKeyId: __expectString(output.KmsMasterKeyId),
     ProvisionedThroughputOverride:
       output.ProvisionedThroughputOverride !== undefined && output.ProvisionedThroughputOverride !== null
         ? deserializeAws_restJson1AwsDynamoDbTableProvisionedThroughputOverride(
@@ -13591,13 +13419,9 @@ const deserializeAws_restJson1AwsDynamoDbTableReplica = (
             context
           )
         : undefined,
-    RegionName: output.RegionName !== undefined && output.RegionName !== null ? output.RegionName : undefined,
-    ReplicaStatus:
-      output.ReplicaStatus !== undefined && output.ReplicaStatus !== null ? output.ReplicaStatus : undefined,
-    ReplicaStatusDescription:
-      output.ReplicaStatusDescription !== undefined && output.ReplicaStatusDescription !== null
-        ? output.ReplicaStatusDescription
-        : undefined,
+    RegionName: __expectString(output.RegionName),
+    ReplicaStatus: __expectString(output.ReplicaStatus),
+    ReplicaStatusDescription: __expectString(output.ReplicaStatusDescription),
   } as any;
 };
 
@@ -13606,7 +13430,7 @@ const deserializeAws_restJson1AwsDynamoDbTableReplicaGlobalSecondaryIndex = (
   context: __SerdeContext
 ): AwsDynamoDbTableReplicaGlobalSecondaryIndex => {
   return {
-    IndexName: output.IndexName !== undefined && output.IndexName !== null ? output.IndexName : undefined,
+    IndexName: __expectString(output.IndexName),
     ProvisionedThroughputOverride:
       output.ProvisionedThroughputOverride !== undefined && output.ProvisionedThroughputOverride !== null
         ? deserializeAws_restJson1AwsDynamoDbTableProvisionedThroughputOverride(
@@ -13650,16 +13474,10 @@ const deserializeAws_restJson1AwsDynamoDbTableRestoreSummary = (
   context: __SerdeContext
 ): AwsDynamoDbTableRestoreSummary => {
   return {
-    RestoreDateTime:
-      output.RestoreDateTime !== undefined && output.RestoreDateTime !== null ? output.RestoreDateTime : undefined,
-    RestoreInProgress:
-      output.RestoreInProgress !== undefined && output.RestoreInProgress !== null
-        ? output.RestoreInProgress
-        : undefined,
-    SourceBackupArn:
-      output.SourceBackupArn !== undefined && output.SourceBackupArn !== null ? output.SourceBackupArn : undefined,
-    SourceTableArn:
-      output.SourceTableArn !== undefined && output.SourceTableArn !== null ? output.SourceTableArn : undefined,
+    RestoreDateTime: __expectString(output.RestoreDateTime),
+    RestoreInProgress: __expectBoolean(output.RestoreInProgress),
+    SourceBackupArn: __expectString(output.SourceBackupArn),
+    SourceTableArn: __expectString(output.SourceTableArn),
   } as any;
 };
 
@@ -13668,14 +13486,10 @@ const deserializeAws_restJson1AwsDynamoDbTableSseDescription = (
   context: __SerdeContext
 ): AwsDynamoDbTableSseDescription => {
   return {
-    InaccessibleEncryptionDateTime:
-      output.InaccessibleEncryptionDateTime !== undefined && output.InaccessibleEncryptionDateTime !== null
-        ? output.InaccessibleEncryptionDateTime
-        : undefined,
-    KmsMasterKeyArn:
-      output.KmsMasterKeyArn !== undefined && output.KmsMasterKeyArn !== null ? output.KmsMasterKeyArn : undefined,
-    SseType: output.SseType !== undefined && output.SseType !== null ? output.SseType : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    InaccessibleEncryptionDateTime: __expectString(output.InaccessibleEncryptionDateTime),
+    KmsMasterKeyArn: __expectString(output.KmsMasterKeyArn),
+    SseType: __expectString(output.SseType),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -13684,47 +13498,30 @@ const deserializeAws_restJson1AwsDynamoDbTableStreamSpecification = (
   context: __SerdeContext
 ): AwsDynamoDbTableStreamSpecification => {
   return {
-    StreamEnabled:
-      output.StreamEnabled !== undefined && output.StreamEnabled !== null ? output.StreamEnabled : undefined,
-    StreamViewType:
-      output.StreamViewType !== undefined && output.StreamViewType !== null ? output.StreamViewType : undefined,
+    StreamEnabled: __expectBoolean(output.StreamEnabled),
+    StreamViewType: __expectString(output.StreamViewType),
   } as any;
 };
 
 const deserializeAws_restJson1AwsEc2EipDetails = (output: any, context: __SerdeContext): AwsEc2EipDetails => {
   return {
-    AllocationId: output.AllocationId !== undefined && output.AllocationId !== null ? output.AllocationId : undefined,
-    AssociationId:
-      output.AssociationId !== undefined && output.AssociationId !== null ? output.AssociationId : undefined,
-    Domain: output.Domain !== undefined && output.Domain !== null ? output.Domain : undefined,
-    InstanceId: output.InstanceId !== undefined && output.InstanceId !== null ? output.InstanceId : undefined,
-    NetworkBorderGroup:
-      output.NetworkBorderGroup !== undefined && output.NetworkBorderGroup !== null
-        ? output.NetworkBorderGroup
-        : undefined,
-    NetworkInterfaceId:
-      output.NetworkInterfaceId !== undefined && output.NetworkInterfaceId !== null
-        ? output.NetworkInterfaceId
-        : undefined,
-    NetworkInterfaceOwnerId:
-      output.NetworkInterfaceOwnerId !== undefined && output.NetworkInterfaceOwnerId !== null
-        ? output.NetworkInterfaceOwnerId
-        : undefined,
-    PrivateIpAddress:
-      output.PrivateIpAddress !== undefined && output.PrivateIpAddress !== null ? output.PrivateIpAddress : undefined,
-    PublicIp: output.PublicIp !== undefined && output.PublicIp !== null ? output.PublicIp : undefined,
-    PublicIpv4Pool:
-      output.PublicIpv4Pool !== undefined && output.PublicIpv4Pool !== null ? output.PublicIpv4Pool : undefined,
+    AllocationId: __expectString(output.AllocationId),
+    AssociationId: __expectString(output.AssociationId),
+    Domain: __expectString(output.Domain),
+    InstanceId: __expectString(output.InstanceId),
+    NetworkBorderGroup: __expectString(output.NetworkBorderGroup),
+    NetworkInterfaceId: __expectString(output.NetworkInterfaceId),
+    NetworkInterfaceOwnerId: __expectString(output.NetworkInterfaceOwnerId),
+    PrivateIpAddress: __expectString(output.PrivateIpAddress),
+    PublicIp: __expectString(output.PublicIp),
+    PublicIpv4Pool: __expectString(output.PublicIpv4Pool),
   } as any;
 };
 
 const deserializeAws_restJson1AwsEc2InstanceDetails = (output: any, context: __SerdeContext): AwsEc2InstanceDetails => {
   return {
-    IamInstanceProfileArn:
-      output.IamInstanceProfileArn !== undefined && output.IamInstanceProfileArn !== null
-        ? output.IamInstanceProfileArn
-        : undefined,
-    ImageId: output.ImageId !== undefined && output.ImageId !== null ? output.ImageId : undefined,
+    IamInstanceProfileArn: __expectString(output.IamInstanceProfileArn),
+    ImageId: __expectString(output.ImageId),
     IpV4Addresses:
       output.IpV4Addresses !== undefined && output.IpV4Addresses !== null
         ? deserializeAws_restJson1StringList(output.IpV4Addresses, context)
@@ -13733,11 +13530,11 @@ const deserializeAws_restJson1AwsEc2InstanceDetails = (output: any, context: __S
       output.IpV6Addresses !== undefined && output.IpV6Addresses !== null
         ? deserializeAws_restJson1StringList(output.IpV6Addresses, context)
         : undefined,
-    KeyName: output.KeyName !== undefined && output.KeyName !== null ? output.KeyName : undefined,
-    LaunchedAt: output.LaunchedAt !== undefined && output.LaunchedAt !== null ? output.LaunchedAt : undefined,
-    SubnetId: output.SubnetId !== undefined && output.SubnetId !== null ? output.SubnetId : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    VpcId: output.VpcId !== undefined && output.VpcId !== null ? output.VpcId : undefined,
+    KeyName: __expectString(output.KeyName),
+    LaunchedAt: __expectString(output.LaunchedAt),
+    SubnetId: __expectString(output.SubnetId),
+    Type: __expectString(output.Type),
+    VpcId: __expectString(output.VpcId),
   } as any;
 };
 
@@ -13746,12 +13543,9 @@ const deserializeAws_restJson1AwsEc2NetworkAclAssociation = (
   context: __SerdeContext
 ): AwsEc2NetworkAclAssociation => {
   return {
-    NetworkAclAssociationId:
-      output.NetworkAclAssociationId !== undefined && output.NetworkAclAssociationId !== null
-        ? output.NetworkAclAssociationId
-        : undefined,
-    NetworkAclId: output.NetworkAclId !== undefined && output.NetworkAclId !== null ? output.NetworkAclId : undefined,
-    SubnetId: output.SubnetId !== undefined && output.SubnetId !== null ? output.SubnetId : undefined,
+    NetworkAclAssociationId: __expectString(output.NetworkAclAssociationId),
+    NetworkAclId: __expectString(output.NetworkAclId),
+    SubnetId: __expectString(output.SubnetId),
   } as any;
 };
 
@@ -13782,30 +13576,29 @@ const deserializeAws_restJson1AwsEc2NetworkAclDetails = (
       output.Entries !== undefined && output.Entries !== null
         ? deserializeAws_restJson1AwsEc2NetworkAclEntryList(output.Entries, context)
         : undefined,
-    IsDefault: output.IsDefault !== undefined && output.IsDefault !== null ? output.IsDefault : undefined,
-    NetworkAclId: output.NetworkAclId !== undefined && output.NetworkAclId !== null ? output.NetworkAclId : undefined,
-    OwnerId: output.OwnerId !== undefined && output.OwnerId !== null ? output.OwnerId : undefined,
-    VpcId: output.VpcId !== undefined && output.VpcId !== null ? output.VpcId : undefined,
+    IsDefault: __expectBoolean(output.IsDefault),
+    NetworkAclId: __expectString(output.NetworkAclId),
+    OwnerId: __expectString(output.OwnerId),
+    VpcId: __expectString(output.VpcId),
   } as any;
 };
 
 const deserializeAws_restJson1AwsEc2NetworkAclEntry = (output: any, context: __SerdeContext): AwsEc2NetworkAclEntry => {
   return {
-    CidrBlock: output.CidrBlock !== undefined && output.CidrBlock !== null ? output.CidrBlock : undefined,
-    Egress: output.Egress !== undefined && output.Egress !== null ? output.Egress : undefined,
+    CidrBlock: __expectString(output.CidrBlock),
+    Egress: __expectBoolean(output.Egress),
     IcmpTypeCode:
       output.IcmpTypeCode !== undefined && output.IcmpTypeCode !== null
         ? deserializeAws_restJson1IcmpTypeCode(output.IcmpTypeCode, context)
         : undefined,
-    Ipv6CidrBlock:
-      output.Ipv6CidrBlock !== undefined && output.Ipv6CidrBlock !== null ? output.Ipv6CidrBlock : undefined,
+    Ipv6CidrBlock: __expectString(output.Ipv6CidrBlock),
     PortRange:
       output.PortRange !== undefined && output.PortRange !== null
         ? deserializeAws_restJson1PortRangeFromTo(output.PortRange, context)
         : undefined,
-    Protocol: output.Protocol !== undefined && output.Protocol !== null ? output.Protocol : undefined,
-    RuleAction: output.RuleAction !== undefined && output.RuleAction !== null ? output.RuleAction : undefined,
-    RuleNumber: output.RuleNumber !== undefined && output.RuleNumber !== null ? output.RuleNumber : undefined,
+    Protocol: __expectString(output.Protocol),
+    RuleAction: __expectString(output.RuleAction),
+    RuleNumber: __expectNumber(output.RuleNumber),
   } as any;
 };
 
@@ -13828,17 +13621,13 @@ const deserializeAws_restJson1AwsEc2NetworkInterfaceAttachment = (
   context: __SerdeContext
 ): AwsEc2NetworkInterfaceAttachment => {
   return {
-    AttachTime: output.AttachTime !== undefined && output.AttachTime !== null ? output.AttachTime : undefined,
-    AttachmentId: output.AttachmentId !== undefined && output.AttachmentId !== null ? output.AttachmentId : undefined,
-    DeleteOnTermination:
-      output.DeleteOnTermination !== undefined && output.DeleteOnTermination !== null
-        ? output.DeleteOnTermination
-        : undefined,
-    DeviceIndex: output.DeviceIndex !== undefined && output.DeviceIndex !== null ? output.DeviceIndex : undefined,
-    InstanceId: output.InstanceId !== undefined && output.InstanceId !== null ? output.InstanceId : undefined,
-    InstanceOwnerId:
-      output.InstanceOwnerId !== undefined && output.InstanceOwnerId !== null ? output.InstanceOwnerId : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    AttachTime: __expectString(output.AttachTime),
+    AttachmentId: __expectString(output.AttachmentId),
+    DeleteOnTermination: __expectBoolean(output.DeleteOnTermination),
+    DeviceIndex: __expectNumber(output.DeviceIndex),
+    InstanceId: __expectString(output.InstanceId),
+    InstanceOwnerId: __expectString(output.InstanceOwnerId),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -13855,23 +13644,18 @@ const deserializeAws_restJson1AwsEc2NetworkInterfaceDetails = (
       output.IpV6Addresses !== undefined && output.IpV6Addresses !== null
         ? deserializeAws_restJson1AwsEc2NetworkInterfaceIpV6AddressList(output.IpV6Addresses, context)
         : undefined,
-    NetworkInterfaceId:
-      output.NetworkInterfaceId !== undefined && output.NetworkInterfaceId !== null
-        ? output.NetworkInterfaceId
-        : undefined,
+    NetworkInterfaceId: __expectString(output.NetworkInterfaceId),
     PrivateIpAddresses:
       output.PrivateIpAddresses !== undefined && output.PrivateIpAddresses !== null
         ? deserializeAws_restJson1AwsEc2NetworkInterfacePrivateIpAddressList(output.PrivateIpAddresses, context)
         : undefined,
-    PublicDnsName:
-      output.PublicDnsName !== undefined && output.PublicDnsName !== null ? output.PublicDnsName : undefined,
-    PublicIp: output.PublicIp !== undefined && output.PublicIp !== null ? output.PublicIp : undefined,
+    PublicDnsName: __expectString(output.PublicDnsName),
+    PublicIp: __expectString(output.PublicIp),
     SecurityGroups:
       output.SecurityGroups !== undefined && output.SecurityGroups !== null
         ? deserializeAws_restJson1AwsEc2NetworkInterfaceSecurityGroupList(output.SecurityGroups, context)
         : undefined,
-    SourceDestCheck:
-      output.SourceDestCheck !== undefined && output.SourceDestCheck !== null ? output.SourceDestCheck : undefined,
+    SourceDestCheck: __expectBoolean(output.SourceDestCheck),
   } as any;
 };
 
@@ -13880,7 +13664,7 @@ const deserializeAws_restJson1AwsEc2NetworkInterfaceIpV6AddressDetail = (
   context: __SerdeContext
 ): AwsEc2NetworkInterfaceIpV6AddressDetail => {
   return {
-    IpV6Address: output.IpV6Address !== undefined && output.IpV6Address !== null ? output.IpV6Address : undefined,
+    IpV6Address: __expectString(output.IpV6Address),
   } as any;
 };
 
@@ -13903,10 +13687,8 @@ const deserializeAws_restJson1AwsEc2NetworkInterfacePrivateIpAddressDetail = (
   context: __SerdeContext
 ): AwsEc2NetworkInterfacePrivateIpAddressDetail => {
   return {
-    PrivateDnsName:
-      output.PrivateDnsName !== undefined && output.PrivateDnsName !== null ? output.PrivateDnsName : undefined,
-    PrivateIpAddress:
-      output.PrivateIpAddress !== undefined && output.PrivateIpAddress !== null ? output.PrivateIpAddress : undefined,
+    PrivateDnsName: __expectString(output.PrivateDnsName),
+    PrivateIpAddress: __expectString(output.PrivateIpAddress),
   } as any;
 };
 
@@ -13929,8 +13711,8 @@ const deserializeAws_restJson1AwsEc2NetworkInterfaceSecurityGroup = (
   context: __SerdeContext
 ): AwsEc2NetworkInterfaceSecurityGroup => {
   return {
-    GroupId: output.GroupId !== undefined && output.GroupId !== null ? output.GroupId : undefined,
-    GroupName: output.GroupName !== undefined && output.GroupName !== null ? output.GroupName : undefined,
+    GroupId: __expectString(output.GroupId),
+    GroupName: __expectString(output.GroupName),
   } as any;
 };
 
@@ -13953,8 +13735,8 @@ const deserializeAws_restJson1AwsEc2SecurityGroupDetails = (
   context: __SerdeContext
 ): AwsEc2SecurityGroupDetails => {
   return {
-    GroupId: output.GroupId !== undefined && output.GroupId !== null ? output.GroupId : undefined,
-    GroupName: output.GroupName !== undefined && output.GroupName !== null ? output.GroupName : undefined,
+    GroupId: __expectString(output.GroupId),
+    GroupName: __expectString(output.GroupName),
     IpPermissions:
       output.IpPermissions !== undefined && output.IpPermissions !== null
         ? deserializeAws_restJson1AwsEc2SecurityGroupIpPermissionList(output.IpPermissions, context)
@@ -13963,8 +13745,8 @@ const deserializeAws_restJson1AwsEc2SecurityGroupDetails = (
       output.IpPermissionsEgress !== undefined && output.IpPermissionsEgress !== null
         ? deserializeAws_restJson1AwsEc2SecurityGroupIpPermissionList(output.IpPermissionsEgress, context)
         : undefined,
-    OwnerId: output.OwnerId !== undefined && output.OwnerId !== null ? output.OwnerId : undefined,
-    VpcId: output.VpcId !== undefined && output.VpcId !== null ? output.VpcId : undefined,
+    OwnerId: __expectString(output.OwnerId),
+    VpcId: __expectString(output.VpcId),
   } as any;
 };
 
@@ -13973,8 +13755,8 @@ const deserializeAws_restJson1AwsEc2SecurityGroupIpPermission = (
   context: __SerdeContext
 ): AwsEc2SecurityGroupIpPermission => {
   return {
-    FromPort: output.FromPort !== undefined && output.FromPort !== null ? output.FromPort : undefined,
-    IpProtocol: output.IpProtocol !== undefined && output.IpProtocol !== null ? output.IpProtocol : undefined,
+    FromPort: __expectNumber(output.FromPort),
+    IpProtocol: __expectString(output.IpProtocol),
     IpRanges:
       output.IpRanges !== undefined && output.IpRanges !== null
         ? deserializeAws_restJson1AwsEc2SecurityGroupIpRangeList(output.IpRanges, context)
@@ -13987,7 +13769,7 @@ const deserializeAws_restJson1AwsEc2SecurityGroupIpPermission = (
       output.PrefixListIds !== undefined && output.PrefixListIds !== null
         ? deserializeAws_restJson1AwsEc2SecurityGroupPrefixListIdList(output.PrefixListIds, context)
         : undefined,
-    ToPort: output.ToPort !== undefined && output.ToPort !== null ? output.ToPort : undefined,
+    ToPort: __expectNumber(output.ToPort),
     UserIdGroupPairs:
       output.UserIdGroupPairs !== undefined && output.UserIdGroupPairs !== null
         ? deserializeAws_restJson1AwsEc2SecurityGroupUserIdGroupPairList(output.UserIdGroupPairs, context)
@@ -14014,7 +13796,7 @@ const deserializeAws_restJson1AwsEc2SecurityGroupIpRange = (
   context: __SerdeContext
 ): AwsEc2SecurityGroupIpRange => {
   return {
-    CidrIp: output.CidrIp !== undefined && output.CidrIp !== null ? output.CidrIp : undefined,
+    CidrIp: __expectString(output.CidrIp),
   } as any;
 };
 
@@ -14037,7 +13819,7 @@ const deserializeAws_restJson1AwsEc2SecurityGroupIpv6Range = (
   context: __SerdeContext
 ): AwsEc2SecurityGroupIpv6Range => {
   return {
-    CidrIpv6: output.CidrIpv6 !== undefined && output.CidrIpv6 !== null ? output.CidrIpv6 : undefined,
+    CidrIpv6: __expectString(output.CidrIpv6),
   } as any;
 };
 
@@ -14060,7 +13842,7 @@ const deserializeAws_restJson1AwsEc2SecurityGroupPrefixListId = (
   context: __SerdeContext
 ): AwsEc2SecurityGroupPrefixListId => {
   return {
-    PrefixListId: output.PrefixListId !== undefined && output.PrefixListId !== null ? output.PrefixListId : undefined,
+    PrefixListId: __expectString(output.PrefixListId),
   } as any;
 };
 
@@ -14083,16 +13865,12 @@ const deserializeAws_restJson1AwsEc2SecurityGroupUserIdGroupPair = (
   context: __SerdeContext
 ): AwsEc2SecurityGroupUserIdGroupPair => {
   return {
-    GroupId: output.GroupId !== undefined && output.GroupId !== null ? output.GroupId : undefined,
-    GroupName: output.GroupName !== undefined && output.GroupName !== null ? output.GroupName : undefined,
-    PeeringStatus:
-      output.PeeringStatus !== undefined && output.PeeringStatus !== null ? output.PeeringStatus : undefined,
-    UserId: output.UserId !== undefined && output.UserId !== null ? output.UserId : undefined,
-    VpcId: output.VpcId !== undefined && output.VpcId !== null ? output.VpcId : undefined,
-    VpcPeeringConnectionId:
-      output.VpcPeeringConnectionId !== undefined && output.VpcPeeringConnectionId !== null
-        ? output.VpcPeeringConnectionId
-        : undefined,
+    GroupId: __expectString(output.GroupId),
+    GroupName: __expectString(output.GroupName),
+    PeeringStatus: __expectString(output.PeeringStatus),
+    UserId: __expectString(output.UserId),
+    VpcId: __expectString(output.VpcId),
+    VpcPeeringConnectionId: __expectString(output.VpcPeeringConnectionId),
   } as any;
 };
 
@@ -14112,35 +13890,22 @@ const deserializeAws_restJson1AwsEc2SecurityGroupUserIdGroupPairList = (
 
 const deserializeAws_restJson1AwsEc2SubnetDetails = (output: any, context: __SerdeContext): AwsEc2SubnetDetails => {
   return {
-    AssignIpv6AddressOnCreation:
-      output.AssignIpv6AddressOnCreation !== undefined && output.AssignIpv6AddressOnCreation !== null
-        ? output.AssignIpv6AddressOnCreation
-        : undefined,
-    AvailabilityZone:
-      output.AvailabilityZone !== undefined && output.AvailabilityZone !== null ? output.AvailabilityZone : undefined,
-    AvailabilityZoneId:
-      output.AvailabilityZoneId !== undefined && output.AvailabilityZoneId !== null
-        ? output.AvailabilityZoneId
-        : undefined,
-    AvailableIpAddressCount:
-      output.AvailableIpAddressCount !== undefined && output.AvailableIpAddressCount !== null
-        ? output.AvailableIpAddressCount
-        : undefined,
-    CidrBlock: output.CidrBlock !== undefined && output.CidrBlock !== null ? output.CidrBlock : undefined,
-    DefaultForAz: output.DefaultForAz !== undefined && output.DefaultForAz !== null ? output.DefaultForAz : undefined,
+    AssignIpv6AddressOnCreation: __expectBoolean(output.AssignIpv6AddressOnCreation),
+    AvailabilityZone: __expectString(output.AvailabilityZone),
+    AvailabilityZoneId: __expectString(output.AvailabilityZoneId),
+    AvailableIpAddressCount: __expectNumber(output.AvailableIpAddressCount),
+    CidrBlock: __expectString(output.CidrBlock),
+    DefaultForAz: __expectBoolean(output.DefaultForAz),
     Ipv6CidrBlockAssociationSet:
       output.Ipv6CidrBlockAssociationSet !== undefined && output.Ipv6CidrBlockAssociationSet !== null
         ? deserializeAws_restJson1Ipv6CidrBlockAssociationList(output.Ipv6CidrBlockAssociationSet, context)
         : undefined,
-    MapPublicIpOnLaunch:
-      output.MapPublicIpOnLaunch !== undefined && output.MapPublicIpOnLaunch !== null
-        ? output.MapPublicIpOnLaunch
-        : undefined,
-    OwnerId: output.OwnerId !== undefined && output.OwnerId !== null ? output.OwnerId : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    SubnetArn: output.SubnetArn !== undefined && output.SubnetArn !== null ? output.SubnetArn : undefined,
-    SubnetId: output.SubnetId !== undefined && output.SubnetId !== null ? output.SubnetId : undefined,
-    VpcId: output.VpcId !== undefined && output.VpcId !== null ? output.VpcId : undefined,
+    MapPublicIpOnLaunch: __expectBoolean(output.MapPublicIpOnLaunch),
+    OwnerId: __expectString(output.OwnerId),
+    State: __expectString(output.State),
+    SubnetArn: __expectString(output.SubnetArn),
+    SubnetId: __expectString(output.SubnetId),
+    VpcId: __expectString(output.VpcId),
   } as any;
 };
 
@@ -14149,13 +13914,10 @@ const deserializeAws_restJson1AwsEc2VolumeAttachment = (
   context: __SerdeContext
 ): AwsEc2VolumeAttachment => {
   return {
-    AttachTime: output.AttachTime !== undefined && output.AttachTime !== null ? output.AttachTime : undefined,
-    DeleteOnTermination:
-      output.DeleteOnTermination !== undefined && output.DeleteOnTermination !== null
-        ? output.DeleteOnTermination
-        : undefined,
-    InstanceId: output.InstanceId !== undefined && output.InstanceId !== null ? output.InstanceId : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    AttachTime: __expectString(output.AttachTime),
+    DeleteOnTermination: __expectBoolean(output.DeleteOnTermination),
+    InstanceId: __expectString(output.InstanceId),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -14179,12 +13941,12 @@ const deserializeAws_restJson1AwsEc2VolumeDetails = (output: any, context: __Ser
       output.Attachments !== undefined && output.Attachments !== null
         ? deserializeAws_restJson1AwsEc2VolumeAttachmentList(output.Attachments, context)
         : undefined,
-    CreateTime: output.CreateTime !== undefined && output.CreateTime !== null ? output.CreateTime : undefined,
-    Encrypted: output.Encrypted !== undefined && output.Encrypted !== null ? output.Encrypted : undefined,
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
-    Size: output.Size !== undefined && output.Size !== null ? output.Size : undefined,
-    SnapshotId: output.SnapshotId !== undefined && output.SnapshotId !== null ? output.SnapshotId : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    CreateTime: __expectString(output.CreateTime),
+    Encrypted: __expectBoolean(output.Encrypted),
+    KmsKeyId: __expectString(output.KmsKeyId),
+    Size: __expectNumber(output.Size),
+    SnapshotId: __expectString(output.SnapshotId),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -14194,13 +13956,12 @@ const deserializeAws_restJson1AwsEc2VpcDetails = (output: any, context: __SerdeC
       output.CidrBlockAssociationSet !== undefined && output.CidrBlockAssociationSet !== null
         ? deserializeAws_restJson1CidrBlockAssociationList(output.CidrBlockAssociationSet, context)
         : undefined,
-    DhcpOptionsId:
-      output.DhcpOptionsId !== undefined && output.DhcpOptionsId !== null ? output.DhcpOptionsId : undefined,
+    DhcpOptionsId: __expectString(output.DhcpOptionsId),
     Ipv6CidrBlockAssociationSet:
       output.Ipv6CidrBlockAssociationSet !== undefined && output.Ipv6CidrBlockAssociationSet !== null
         ? deserializeAws_restJson1Ipv6CidrBlockAssociationList(output.Ipv6CidrBlockAssociationSet, context)
         : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    State: __expectString(output.State),
   } as any;
 };
 
@@ -14209,38 +13970,31 @@ const deserializeAws_restJson1AwsElasticBeanstalkEnvironmentDetails = (
   context: __SerdeContext
 ): AwsElasticBeanstalkEnvironmentDetails => {
   return {
-    ApplicationName:
-      output.ApplicationName !== undefined && output.ApplicationName !== null ? output.ApplicationName : undefined,
-    Cname: output.Cname !== undefined && output.Cname !== null ? output.Cname : undefined,
-    DateCreated: output.DateCreated !== undefined && output.DateCreated !== null ? output.DateCreated : undefined,
-    DateUpdated: output.DateUpdated !== undefined && output.DateUpdated !== null ? output.DateUpdated : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    EndpointUrl: output.EndpointUrl !== undefined && output.EndpointUrl !== null ? output.EndpointUrl : undefined,
-    EnvironmentArn:
-      output.EnvironmentArn !== undefined && output.EnvironmentArn !== null ? output.EnvironmentArn : undefined,
-    EnvironmentId:
-      output.EnvironmentId !== undefined && output.EnvironmentId !== null ? output.EnvironmentId : undefined,
+    ApplicationName: __expectString(output.ApplicationName),
+    Cname: __expectString(output.Cname),
+    DateCreated: __expectString(output.DateCreated),
+    DateUpdated: __expectString(output.DateUpdated),
+    Description: __expectString(output.Description),
+    EndpointUrl: __expectString(output.EndpointUrl),
+    EnvironmentArn: __expectString(output.EnvironmentArn),
+    EnvironmentId: __expectString(output.EnvironmentId),
     EnvironmentLinks:
       output.EnvironmentLinks !== undefined && output.EnvironmentLinks !== null
         ? deserializeAws_restJson1AwsElasticBeanstalkEnvironmentEnvironmentLinks(output.EnvironmentLinks, context)
         : undefined,
-    EnvironmentName:
-      output.EnvironmentName !== undefined && output.EnvironmentName !== null ? output.EnvironmentName : undefined,
+    EnvironmentName: __expectString(output.EnvironmentName),
     OptionSettings:
       output.OptionSettings !== undefined && output.OptionSettings !== null
         ? deserializeAws_restJson1AwsElasticBeanstalkEnvironmentOptionSettings(output.OptionSettings, context)
         : undefined,
-    PlatformArn: output.PlatformArn !== undefined && output.PlatformArn !== null ? output.PlatformArn : undefined,
-    SolutionStackName:
-      output.SolutionStackName !== undefined && output.SolutionStackName !== null
-        ? output.SolutionStackName
-        : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    PlatformArn: __expectString(output.PlatformArn),
+    SolutionStackName: __expectString(output.SolutionStackName),
+    Status: __expectString(output.Status),
     Tier:
       output.Tier !== undefined && output.Tier !== null
         ? deserializeAws_restJson1AwsElasticBeanstalkEnvironmentTier(output.Tier, context)
         : undefined,
-    VersionLabel: output.VersionLabel !== undefined && output.VersionLabel !== null ? output.VersionLabel : undefined,
+    VersionLabel: __expectString(output.VersionLabel),
   } as any;
 };
 
@@ -14249,9 +14003,8 @@ const deserializeAws_restJson1AwsElasticBeanstalkEnvironmentEnvironmentLink = (
   context: __SerdeContext
 ): AwsElasticBeanstalkEnvironmentEnvironmentLink => {
   return {
-    EnvironmentName:
-      output.EnvironmentName !== undefined && output.EnvironmentName !== null ? output.EnvironmentName : undefined,
-    LinkName: output.LinkName !== undefined && output.LinkName !== null ? output.LinkName : undefined,
+    EnvironmentName: __expectString(output.EnvironmentName),
+    LinkName: __expectString(output.LinkName),
   } as any;
 };
 
@@ -14274,10 +14027,10 @@ const deserializeAws_restJson1AwsElasticBeanstalkEnvironmentOptionSetting = (
   context: __SerdeContext
 ): AwsElasticBeanstalkEnvironmentOptionSetting => {
   return {
-    Namespace: output.Namespace !== undefined && output.Namespace !== null ? output.Namespace : undefined,
-    OptionName: output.OptionName !== undefined && output.OptionName !== null ? output.OptionName : undefined,
-    ResourceName: output.ResourceName !== undefined && output.ResourceName !== null ? output.ResourceName : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Namespace: __expectString(output.Namespace),
+    OptionName: __expectString(output.OptionName),
+    ResourceName: __expectString(output.ResourceName),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -14300,9 +14053,9 @@ const deserializeAws_restJson1AwsElasticBeanstalkEnvironmentTier = (
   context: __SerdeContext
 ): AwsElasticBeanstalkEnvironmentTier => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    Name: __expectString(output.Name),
+    Type: __expectString(output.Type),
+    Version: __expectString(output.Version),
   } as any;
 };
 
@@ -14311,23 +14064,19 @@ const deserializeAws_restJson1AwsElasticsearchDomainDetails = (
   context: __SerdeContext
 ): AwsElasticsearchDomainDetails => {
   return {
-    AccessPolicies:
-      output.AccessPolicies !== undefined && output.AccessPolicies !== null ? output.AccessPolicies : undefined,
+    AccessPolicies: __expectString(output.AccessPolicies),
     DomainEndpointOptions:
       output.DomainEndpointOptions !== undefined && output.DomainEndpointOptions !== null
         ? deserializeAws_restJson1AwsElasticsearchDomainDomainEndpointOptions(output.DomainEndpointOptions, context)
         : undefined,
-    DomainId: output.DomainId !== undefined && output.DomainId !== null ? output.DomainId : undefined,
-    DomainName: output.DomainName !== undefined && output.DomainName !== null ? output.DomainName : undefined,
-    ElasticsearchVersion:
-      output.ElasticsearchVersion !== undefined && output.ElasticsearchVersion !== null
-        ? output.ElasticsearchVersion
-        : undefined,
+    DomainId: __expectString(output.DomainId),
+    DomainName: __expectString(output.DomainName),
+    ElasticsearchVersion: __expectString(output.ElasticsearchVersion),
     EncryptionAtRestOptions:
       output.EncryptionAtRestOptions !== undefined && output.EncryptionAtRestOptions !== null
         ? deserializeAws_restJson1AwsElasticsearchDomainEncryptionAtRestOptions(output.EncryptionAtRestOptions, context)
         : undefined,
-    Endpoint: output.Endpoint !== undefined && output.Endpoint !== null ? output.Endpoint : undefined,
+    Endpoint: __expectString(output.Endpoint),
     Endpoints:
       output.Endpoints !== undefined && output.Endpoints !== null
         ? deserializeAws_restJson1FieldMap(output.Endpoints, context)
@@ -14351,11 +14100,8 @@ const deserializeAws_restJson1AwsElasticsearchDomainDomainEndpointOptions = (
   context: __SerdeContext
 ): AwsElasticsearchDomainDomainEndpointOptions => {
   return {
-    EnforceHTTPS: output.EnforceHTTPS !== undefined && output.EnforceHTTPS !== null ? output.EnforceHTTPS : undefined,
-    TLSSecurityPolicy:
-      output.TLSSecurityPolicy !== undefined && output.TLSSecurityPolicy !== null
-        ? output.TLSSecurityPolicy
-        : undefined,
+    EnforceHTTPS: __expectBoolean(output.EnforceHTTPS),
+    TLSSecurityPolicy: __expectString(output.TLSSecurityPolicy),
   } as any;
 };
 
@@ -14364,8 +14110,8 @@ const deserializeAws_restJson1AwsElasticsearchDomainEncryptionAtRestOptions = (
   context: __SerdeContext
 ): AwsElasticsearchDomainEncryptionAtRestOptions => {
   return {
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
+    Enabled: __expectBoolean(output.Enabled),
+    KmsKeyId: __expectString(output.KmsKeyId),
   } as any;
 };
 
@@ -14374,7 +14120,7 @@ const deserializeAws_restJson1AwsElasticsearchDomainNodeToNodeEncryptionOptions 
   context: __SerdeContext
 ): AwsElasticsearchDomainNodeToNodeEncryptionOptions => {
   return {
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
+    Enabled: __expectBoolean(output.Enabled),
   } as any;
 };
 
@@ -14395,7 +14141,7 @@ const deserializeAws_restJson1AwsElasticsearchDomainVPCOptions = (
       output.SubnetIds !== undefined && output.SubnetIds !== null
         ? deserializeAws_restJson1NonEmptyStringList(output.SubnetIds, context)
         : undefined,
-    VPCId: output.VPCId !== undefined && output.VPCId !== null ? output.VPCId : undefined,
+    VPCId: __expectString(output.VPCId),
   } as any;
 };
 
@@ -14418,8 +14164,8 @@ const deserializeAws_restJson1AwsElbAppCookieStickinessPolicy = (
   context: __SerdeContext
 ): AwsElbAppCookieStickinessPolicy => {
   return {
-    CookieName: output.CookieName !== undefined && output.CookieName !== null ? output.CookieName : undefined,
-    PolicyName: output.PolicyName !== undefined && output.PolicyName !== null ? output.PolicyName : undefined,
+    CookieName: __expectString(output.CookieName),
+    PolicyName: __expectString(output.PolicyName),
   } as any;
 };
 
@@ -14442,11 +14188,8 @@ const deserializeAws_restJson1AwsElbLbCookieStickinessPolicy = (
   context: __SerdeContext
 ): AwsElbLbCookieStickinessPolicy => {
   return {
-    CookieExpirationPeriod:
-      output.CookieExpirationPeriod !== undefined && output.CookieExpirationPeriod !== null
-        ? output.CookieExpirationPeriod
-        : undefined,
-    PolicyName: output.PolicyName !== undefined && output.PolicyName !== null ? output.PolicyName : undefined,
+    CookieExpirationPeriod: __expectNumber(output.CookieExpirationPeriod),
+    PolicyName: __expectString(output.PolicyName),
   } as any;
 };
 
@@ -14455,11 +14198,10 @@ const deserializeAws_restJson1AwsElbLoadBalancerAccessLog = (
   context: __SerdeContext
 ): AwsElbLoadBalancerAccessLog => {
   return {
-    EmitInterval: output.EmitInterval !== undefined && output.EmitInterval !== null ? output.EmitInterval : undefined,
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
-    S3BucketName: output.S3BucketName !== undefined && output.S3BucketName !== null ? output.S3BucketName : undefined,
-    S3BucketPrefix:
-      output.S3BucketPrefix !== undefined && output.S3BucketPrefix !== null ? output.S3BucketPrefix : undefined,
+    EmitInterval: __expectNumber(output.EmitInterval),
+    Enabled: __expectBoolean(output.Enabled),
+    S3BucketName: __expectString(output.S3BucketName),
+    S3BucketPrefix: __expectString(output.S3BucketPrefix),
   } as any;
 };
 
@@ -14492,7 +14234,7 @@ const deserializeAws_restJson1AwsElbLoadBalancerBackendServerDescription = (
   context: __SerdeContext
 ): AwsElbLoadBalancerBackendServerDescription => {
   return {
-    InstancePort: output.InstancePort !== undefined && output.InstancePort !== null ? output.InstancePort : undefined,
+    InstancePort: __expectNumber(output.InstancePort),
     PolicyNames:
       output.PolicyNames !== undefined && output.PolicyNames !== null
         ? deserializeAws_restJson1StringList(output.PolicyNames, context)
@@ -14519,8 +14261,8 @@ const deserializeAws_restJson1AwsElbLoadBalancerConnectionDraining = (
   context: __SerdeContext
 ): AwsElbLoadBalancerConnectionDraining => {
   return {
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
-    Timeout: output.Timeout !== undefined && output.Timeout !== null ? output.Timeout : undefined,
+    Enabled: __expectBoolean(output.Enabled),
+    Timeout: __expectNumber(output.Timeout),
   } as any;
 };
 
@@ -14529,7 +14271,7 @@ const deserializeAws_restJson1AwsElbLoadBalancerConnectionSettings = (
   context: __SerdeContext
 ): AwsElbLoadBalancerConnectionSettings => {
   return {
-    IdleTimeout: output.IdleTimeout !== undefined && output.IdleTimeout !== null ? output.IdleTimeout : undefined,
+    IdleTimeout: __expectNumber(output.IdleTimeout),
   } as any;
 };
 
@@ -14538,7 +14280,7 @@ const deserializeAws_restJson1AwsElbLoadBalancerCrossZoneLoadBalancing = (
   context: __SerdeContext
 ): AwsElbLoadBalancerCrossZoneLoadBalancing => {
   return {
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
+    Enabled: __expectBoolean(output.Enabled),
   } as any;
 };
 
@@ -14555,16 +14297,10 @@ const deserializeAws_restJson1AwsElbLoadBalancerDetails = (
       output.BackendServerDescriptions !== undefined && output.BackendServerDescriptions !== null
         ? deserializeAws_restJson1AwsElbLoadBalancerBackendServerDescriptions(output.BackendServerDescriptions, context)
         : undefined,
-    CanonicalHostedZoneName:
-      output.CanonicalHostedZoneName !== undefined && output.CanonicalHostedZoneName !== null
-        ? output.CanonicalHostedZoneName
-        : undefined,
-    CanonicalHostedZoneNameID:
-      output.CanonicalHostedZoneNameID !== undefined && output.CanonicalHostedZoneNameID !== null
-        ? output.CanonicalHostedZoneNameID
-        : undefined,
-    CreatedTime: output.CreatedTime !== undefined && output.CreatedTime !== null ? output.CreatedTime : undefined,
-    DnsName: output.DnsName !== undefined && output.DnsName !== null ? output.DnsName : undefined,
+    CanonicalHostedZoneName: __expectString(output.CanonicalHostedZoneName),
+    CanonicalHostedZoneNameID: __expectString(output.CanonicalHostedZoneNameID),
+    CreatedTime: __expectString(output.CreatedTime),
+    DnsName: __expectString(output.DnsName),
     HealthCheck:
       output.HealthCheck !== undefined && output.HealthCheck !== null
         ? deserializeAws_restJson1AwsElbLoadBalancerHealthCheck(output.HealthCheck, context)
@@ -14581,13 +14317,12 @@ const deserializeAws_restJson1AwsElbLoadBalancerDetails = (
       output.LoadBalancerAttributes !== undefined && output.LoadBalancerAttributes !== null
         ? deserializeAws_restJson1AwsElbLoadBalancerAttributes(output.LoadBalancerAttributes, context)
         : undefined,
-    LoadBalancerName:
-      output.LoadBalancerName !== undefined && output.LoadBalancerName !== null ? output.LoadBalancerName : undefined,
+    LoadBalancerName: __expectString(output.LoadBalancerName),
     Policies:
       output.Policies !== undefined && output.Policies !== null
         ? deserializeAws_restJson1AwsElbLoadBalancerPolicies(output.Policies, context)
         : undefined,
-    Scheme: output.Scheme !== undefined && output.Scheme !== null ? output.Scheme : undefined,
+    Scheme: __expectString(output.Scheme),
     SecurityGroups:
       output.SecurityGroups !== undefined && output.SecurityGroups !== null
         ? deserializeAws_restJson1StringList(output.SecurityGroups, context)
@@ -14600,7 +14335,7 @@ const deserializeAws_restJson1AwsElbLoadBalancerDetails = (
       output.Subnets !== undefined && output.Subnets !== null
         ? deserializeAws_restJson1StringList(output.Subnets, context)
         : undefined,
-    VpcId: output.VpcId !== undefined && output.VpcId !== null ? output.VpcId : undefined,
+    VpcId: __expectString(output.VpcId),
   } as any;
 };
 
@@ -14609,15 +14344,11 @@ const deserializeAws_restJson1AwsElbLoadBalancerHealthCheck = (
   context: __SerdeContext
 ): AwsElbLoadBalancerHealthCheck => {
   return {
-    HealthyThreshold:
-      output.HealthyThreshold !== undefined && output.HealthyThreshold !== null ? output.HealthyThreshold : undefined,
-    Interval: output.Interval !== undefined && output.Interval !== null ? output.Interval : undefined,
-    Target: output.Target !== undefined && output.Target !== null ? output.Target : undefined,
-    Timeout: output.Timeout !== undefined && output.Timeout !== null ? output.Timeout : undefined,
-    UnhealthyThreshold:
-      output.UnhealthyThreshold !== undefined && output.UnhealthyThreshold !== null
-        ? output.UnhealthyThreshold
-        : undefined,
+    HealthyThreshold: __expectNumber(output.HealthyThreshold),
+    Interval: __expectNumber(output.Interval),
+    Target: __expectString(output.Target),
+    Timeout: __expectNumber(output.Timeout),
+    UnhealthyThreshold: __expectNumber(output.UnhealthyThreshold),
   } as any;
 };
 
@@ -14626,7 +14357,7 @@ const deserializeAws_restJson1AwsElbLoadBalancerInstance = (
   context: __SerdeContext
 ): AwsElbLoadBalancerInstance => {
   return {
-    InstanceId: output.InstanceId !== undefined && output.InstanceId !== null ? output.InstanceId : undefined,
+    InstanceId: __expectString(output.InstanceId),
   } as any;
 };
 
@@ -14649,14 +14380,11 @@ const deserializeAws_restJson1AwsElbLoadBalancerListener = (
   context: __SerdeContext
 ): AwsElbLoadBalancerListener => {
   return {
-    InstancePort: output.InstancePort !== undefined && output.InstancePort !== null ? output.InstancePort : undefined,
-    InstanceProtocol:
-      output.InstanceProtocol !== undefined && output.InstanceProtocol !== null ? output.InstanceProtocol : undefined,
-    LoadBalancerPort:
-      output.LoadBalancerPort !== undefined && output.LoadBalancerPort !== null ? output.LoadBalancerPort : undefined,
-    Protocol: output.Protocol !== undefined && output.Protocol !== null ? output.Protocol : undefined,
-    SslCertificateId:
-      output.SslCertificateId !== undefined && output.SslCertificateId !== null ? output.SslCertificateId : undefined,
+    InstancePort: __expectNumber(output.InstancePort),
+    InstanceProtocol: __expectString(output.InstanceProtocol),
+    LoadBalancerPort: __expectNumber(output.LoadBalancerPort),
+    Protocol: __expectString(output.Protocol),
+    SslCertificateId: __expectString(output.SslCertificateId),
   } as any;
 };
 
@@ -14715,8 +14443,8 @@ const deserializeAws_restJson1AwsElbLoadBalancerSourceSecurityGroup = (
   context: __SerdeContext
 ): AwsElbLoadBalancerSourceSecurityGroup => {
   return {
-    GroupName: output.GroupName !== undefined && output.GroupName !== null ? output.GroupName : undefined,
-    OwnerAlias: output.OwnerAlias !== undefined && output.OwnerAlias !== null ? output.OwnerAlias : undefined,
+    GroupName: __expectString(output.GroupName),
+    OwnerAlias: __expectString(output.OwnerAlias),
   } as any;
 };
 
@@ -14729,15 +14457,11 @@ const deserializeAws_restJson1AwsElbv2LoadBalancerDetails = (
       output.AvailabilityZones !== undefined && output.AvailabilityZones !== null
         ? deserializeAws_restJson1AvailabilityZones(output.AvailabilityZones, context)
         : undefined,
-    CanonicalHostedZoneId:
-      output.CanonicalHostedZoneId !== undefined && output.CanonicalHostedZoneId !== null
-        ? output.CanonicalHostedZoneId
-        : undefined,
-    CreatedTime: output.CreatedTime !== undefined && output.CreatedTime !== null ? output.CreatedTime : undefined,
-    DNSName: output.DNSName !== undefined && output.DNSName !== null ? output.DNSName : undefined,
-    IpAddressType:
-      output.IpAddressType !== undefined && output.IpAddressType !== null ? output.IpAddressType : undefined,
-    Scheme: output.Scheme !== undefined && output.Scheme !== null ? output.Scheme : undefined,
+    CanonicalHostedZoneId: __expectString(output.CanonicalHostedZoneId),
+    CreatedTime: __expectString(output.CreatedTime),
+    DNSName: __expectString(output.DNSName),
+    IpAddressType: __expectString(output.IpAddressType),
+    Scheme: __expectString(output.Scheme),
     SecurityGroups:
       output.SecurityGroups !== undefined && output.SecurityGroups !== null
         ? deserializeAws_restJson1SecurityGroups(output.SecurityGroups, context)
@@ -14746,8 +14470,8 @@ const deserializeAws_restJson1AwsElbv2LoadBalancerDetails = (
       output.State !== undefined && output.State !== null
         ? deserializeAws_restJson1LoadBalancerState(output.State, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    VpcId: output.VpcId !== undefined && output.VpcId !== null ? output.VpcId : undefined,
+    Type: __expectString(output.Type),
+    VpcId: __expectString(output.VpcId),
   } as any;
 };
 
@@ -14756,20 +14480,18 @@ const deserializeAws_restJson1AwsIamAccessKeyDetails = (
   context: __SerdeContext
 ): AwsIamAccessKeyDetails => {
   return {
-    AccessKeyId: output.AccessKeyId !== undefined && output.AccessKeyId !== null ? output.AccessKeyId : undefined,
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
-    CreatedAt: output.CreatedAt !== undefined && output.CreatedAt !== null ? output.CreatedAt : undefined,
-    PrincipalId: output.PrincipalId !== undefined && output.PrincipalId !== null ? output.PrincipalId : undefined,
-    PrincipalName:
-      output.PrincipalName !== undefined && output.PrincipalName !== null ? output.PrincipalName : undefined,
-    PrincipalType:
-      output.PrincipalType !== undefined && output.PrincipalType !== null ? output.PrincipalType : undefined,
+    AccessKeyId: __expectString(output.AccessKeyId),
+    AccountId: __expectString(output.AccountId),
+    CreatedAt: __expectString(output.CreatedAt),
+    PrincipalId: __expectString(output.PrincipalId),
+    PrincipalName: __expectString(output.PrincipalName),
+    PrincipalType: __expectString(output.PrincipalType),
     SessionContext:
       output.SessionContext !== undefined && output.SessionContext !== null
         ? deserializeAws_restJson1AwsIamAccessKeySessionContext(output.SessionContext, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    UserName: output.UserName !== undefined && output.UserName !== null ? output.UserName : undefined,
+    Status: __expectString(output.Status),
+    UserName: __expectString(output.UserName),
   } as any;
 };
 
@@ -14794,9 +14516,8 @@ const deserializeAws_restJson1AwsIamAccessKeySessionContextAttributes = (
   context: __SerdeContext
 ): AwsIamAccessKeySessionContextAttributes => {
   return {
-    CreationDate: output.CreationDate !== undefined && output.CreationDate !== null ? output.CreationDate : undefined,
-    MfaAuthenticated:
-      output.MfaAuthenticated !== undefined && output.MfaAuthenticated !== null ? output.MfaAuthenticated : undefined,
+    CreationDate: __expectString(output.CreationDate),
+    MfaAuthenticated: __expectBoolean(output.MfaAuthenticated),
   } as any;
 };
 
@@ -14805,11 +14526,11 @@ const deserializeAws_restJson1AwsIamAccessKeySessionContextSessionIssuer = (
   context: __SerdeContext
 ): AwsIamAccessKeySessionContextSessionIssuer => {
   return {
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    PrincipalId: output.PrincipalId !== undefined && output.PrincipalId !== null ? output.PrincipalId : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    UserName: output.UserName !== undefined && output.UserName !== null ? output.UserName : undefined,
+    AccountId: __expectString(output.AccountId),
+    Arn: __expectString(output.Arn),
+    PrincipalId: __expectString(output.PrincipalId),
+    Type: __expectString(output.Type),
+    UserName: __expectString(output.UserName),
   } as any;
 };
 
@@ -14818,8 +14539,8 @@ const deserializeAws_restJson1AwsIamAttachedManagedPolicy = (
   context: __SerdeContext
 ): AwsIamAttachedManagedPolicy => {
   return {
-    PolicyArn: output.PolicyArn !== undefined && output.PolicyArn !== null ? output.PolicyArn : undefined,
-    PolicyName: output.PolicyName !== undefined && output.PolicyName !== null ? output.PolicyName : undefined,
+    PolicyArn: __expectString(output.PolicyArn),
+    PolicyName: __expectString(output.PolicyName),
   } as any;
 };
 
@@ -14843,20 +14564,20 @@ const deserializeAws_restJson1AwsIamGroupDetails = (output: any, context: __Serd
       output.AttachedManagedPolicies !== undefined && output.AttachedManagedPolicies !== null
         ? deserializeAws_restJson1AwsIamAttachedManagedPolicyList(output.AttachedManagedPolicies, context)
         : undefined,
-    CreateDate: output.CreateDate !== undefined && output.CreateDate !== null ? output.CreateDate : undefined,
-    GroupId: output.GroupId !== undefined && output.GroupId !== null ? output.GroupId : undefined,
-    GroupName: output.GroupName !== undefined && output.GroupName !== null ? output.GroupName : undefined,
+    CreateDate: __expectString(output.CreateDate),
+    GroupId: __expectString(output.GroupId),
+    GroupName: __expectString(output.GroupName),
     GroupPolicyList:
       output.GroupPolicyList !== undefined && output.GroupPolicyList !== null
         ? deserializeAws_restJson1AwsIamGroupPolicyList(output.GroupPolicyList, context)
         : undefined,
-    Path: output.Path !== undefined && output.Path !== null ? output.Path : undefined,
+    Path: __expectString(output.Path),
   } as any;
 };
 
 const deserializeAws_restJson1AwsIamGroupPolicy = (output: any, context: __SerdeContext): AwsIamGroupPolicy => {
   return {
-    PolicyName: output.PolicyName !== undefined && output.PolicyName !== null ? output.PolicyName : undefined,
+    PolicyName: __expectString(output.PolicyName),
   } as any;
 };
 
@@ -14873,17 +14594,11 @@ const deserializeAws_restJson1AwsIamGroupPolicyList = (output: any, context: __S
 
 const deserializeAws_restJson1AwsIamInstanceProfile = (output: any, context: __SerdeContext): AwsIamInstanceProfile => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    CreateDate: output.CreateDate !== undefined && output.CreateDate !== null ? output.CreateDate : undefined,
-    InstanceProfileId:
-      output.InstanceProfileId !== undefined && output.InstanceProfileId !== null
-        ? output.InstanceProfileId
-        : undefined,
-    InstanceProfileName:
-      output.InstanceProfileName !== undefined && output.InstanceProfileName !== null
-        ? output.InstanceProfileName
-        : undefined,
-    Path: output.Path !== undefined && output.Path !== null ? output.Path : undefined,
+    Arn: __expectString(output.Arn),
+    CreateDate: __expectString(output.CreateDate),
+    InstanceProfileId: __expectString(output.InstanceProfileId),
+    InstanceProfileName: __expectString(output.InstanceProfileName),
+    Path: __expectString(output.Path),
     Roles:
       output.Roles !== undefined && output.Roles !== null
         ? deserializeAws_restJson1AwsIamInstanceProfileRoles(output.Roles, context)
@@ -14910,15 +14625,12 @@ const deserializeAws_restJson1AwsIamInstanceProfileRole = (
   context: __SerdeContext
 ): AwsIamInstanceProfileRole => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    AssumeRolePolicyDocument:
-      output.AssumeRolePolicyDocument !== undefined && output.AssumeRolePolicyDocument !== null
-        ? output.AssumeRolePolicyDocument
-        : undefined,
-    CreateDate: output.CreateDate !== undefined && output.CreateDate !== null ? output.CreateDate : undefined,
-    Path: output.Path !== undefined && output.Path !== null ? output.Path : undefined,
-    RoleId: output.RoleId !== undefined && output.RoleId !== null ? output.RoleId : undefined,
-    RoleName: output.RoleName !== undefined && output.RoleName !== null ? output.RoleName : undefined,
+    Arn: __expectString(output.Arn),
+    AssumeRolePolicyDocument: __expectString(output.AssumeRolePolicyDocument),
+    CreateDate: __expectString(output.CreateDate),
+    Path: __expectString(output.Path),
+    RoleId: __expectString(output.RoleId),
+    RoleName: __expectString(output.RoleName),
   } as any;
 };
 
@@ -14941,47 +14653,35 @@ const deserializeAws_restJson1AwsIamPermissionsBoundary = (
   context: __SerdeContext
 ): AwsIamPermissionsBoundary => {
   return {
-    PermissionsBoundaryArn:
-      output.PermissionsBoundaryArn !== undefined && output.PermissionsBoundaryArn !== null
-        ? output.PermissionsBoundaryArn
-        : undefined,
-    PermissionsBoundaryType:
-      output.PermissionsBoundaryType !== undefined && output.PermissionsBoundaryType !== null
-        ? output.PermissionsBoundaryType
-        : undefined,
+    PermissionsBoundaryArn: __expectString(output.PermissionsBoundaryArn),
+    PermissionsBoundaryType: __expectString(output.PermissionsBoundaryType),
   } as any;
 };
 
 const deserializeAws_restJson1AwsIamPolicyDetails = (output: any, context: __SerdeContext): AwsIamPolicyDetails => {
   return {
-    AttachmentCount:
-      output.AttachmentCount !== undefined && output.AttachmentCount !== null ? output.AttachmentCount : undefined,
-    CreateDate: output.CreateDate !== undefined && output.CreateDate !== null ? output.CreateDate : undefined,
-    DefaultVersionId:
-      output.DefaultVersionId !== undefined && output.DefaultVersionId !== null ? output.DefaultVersionId : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    IsAttachable: output.IsAttachable !== undefined && output.IsAttachable !== null ? output.IsAttachable : undefined,
-    Path: output.Path !== undefined && output.Path !== null ? output.Path : undefined,
-    PermissionsBoundaryUsageCount:
-      output.PermissionsBoundaryUsageCount !== undefined && output.PermissionsBoundaryUsageCount !== null
-        ? output.PermissionsBoundaryUsageCount
-        : undefined,
-    PolicyId: output.PolicyId !== undefined && output.PolicyId !== null ? output.PolicyId : undefined,
-    PolicyName: output.PolicyName !== undefined && output.PolicyName !== null ? output.PolicyName : undefined,
+    AttachmentCount: __expectNumber(output.AttachmentCount),
+    CreateDate: __expectString(output.CreateDate),
+    DefaultVersionId: __expectString(output.DefaultVersionId),
+    Description: __expectString(output.Description),
+    IsAttachable: __expectBoolean(output.IsAttachable),
+    Path: __expectString(output.Path),
+    PermissionsBoundaryUsageCount: __expectNumber(output.PermissionsBoundaryUsageCount),
+    PolicyId: __expectString(output.PolicyId),
+    PolicyName: __expectString(output.PolicyName),
     PolicyVersionList:
       output.PolicyVersionList !== undefined && output.PolicyVersionList !== null
         ? deserializeAws_restJson1AwsIamPolicyVersionList(output.PolicyVersionList, context)
         : undefined,
-    UpdateDate: output.UpdateDate !== undefined && output.UpdateDate !== null ? output.UpdateDate : undefined,
+    UpdateDate: __expectString(output.UpdateDate),
   } as any;
 };
 
 const deserializeAws_restJson1AwsIamPolicyVersion = (output: any, context: __SerdeContext): AwsIamPolicyVersion => {
   return {
-    CreateDate: output.CreateDate !== undefined && output.CreateDate !== null ? output.CreateDate : undefined,
-    IsDefaultVersion:
-      output.IsDefaultVersion !== undefined && output.IsDefaultVersion !== null ? output.IsDefaultVersion : undefined,
-    VersionId: output.VersionId !== undefined && output.VersionId !== null ? output.VersionId : undefined,
+    CreateDate: __expectString(output.CreateDate),
+    IsDefaultVersion: __expectBoolean(output.IsDefaultVersion),
+    VersionId: __expectString(output.VersionId),
   } as any;
 };
 
@@ -15001,30 +14701,24 @@ const deserializeAws_restJson1AwsIamPolicyVersionList = (
 
 const deserializeAws_restJson1AwsIamRoleDetails = (output: any, context: __SerdeContext): AwsIamRoleDetails => {
   return {
-    AssumeRolePolicyDocument:
-      output.AssumeRolePolicyDocument !== undefined && output.AssumeRolePolicyDocument !== null
-        ? output.AssumeRolePolicyDocument
-        : undefined,
+    AssumeRolePolicyDocument: __expectString(output.AssumeRolePolicyDocument),
     AttachedManagedPolicies:
       output.AttachedManagedPolicies !== undefined && output.AttachedManagedPolicies !== null
         ? deserializeAws_restJson1AwsIamAttachedManagedPolicyList(output.AttachedManagedPolicies, context)
         : undefined,
-    CreateDate: output.CreateDate !== undefined && output.CreateDate !== null ? output.CreateDate : undefined,
+    CreateDate: __expectString(output.CreateDate),
     InstanceProfileList:
       output.InstanceProfileList !== undefined && output.InstanceProfileList !== null
         ? deserializeAws_restJson1AwsIamInstanceProfileList(output.InstanceProfileList, context)
         : undefined,
-    MaxSessionDuration:
-      output.MaxSessionDuration !== undefined && output.MaxSessionDuration !== null
-        ? output.MaxSessionDuration
-        : undefined,
-    Path: output.Path !== undefined && output.Path !== null ? output.Path : undefined,
+    MaxSessionDuration: __expectNumber(output.MaxSessionDuration),
+    Path: __expectString(output.Path),
     PermissionsBoundary:
       output.PermissionsBoundary !== undefined && output.PermissionsBoundary !== null
         ? deserializeAws_restJson1AwsIamPermissionsBoundary(output.PermissionsBoundary, context)
         : undefined,
-    RoleId: output.RoleId !== undefined && output.RoleId !== null ? output.RoleId : undefined,
-    RoleName: output.RoleName !== undefined && output.RoleName !== null ? output.RoleName : undefined,
+    RoleId: __expectString(output.RoleId),
+    RoleName: __expectString(output.RoleName),
     RolePolicyList:
       output.RolePolicyList !== undefined && output.RolePolicyList !== null
         ? deserializeAws_restJson1AwsIamRolePolicyList(output.RolePolicyList, context)
@@ -15034,7 +14728,7 @@ const deserializeAws_restJson1AwsIamRoleDetails = (output: any, context: __Serde
 
 const deserializeAws_restJson1AwsIamRolePolicy = (output: any, context: __SerdeContext): AwsIamRolePolicy => {
   return {
-    PolicyName: output.PolicyName !== undefined && output.PolicyName !== null ? output.PolicyName : undefined,
+    PolicyName: __expectString(output.PolicyName),
   } as any;
 };
 
@@ -15055,18 +14749,18 @@ const deserializeAws_restJson1AwsIamUserDetails = (output: any, context: __Serde
       output.AttachedManagedPolicies !== undefined && output.AttachedManagedPolicies !== null
         ? deserializeAws_restJson1AwsIamAttachedManagedPolicyList(output.AttachedManagedPolicies, context)
         : undefined,
-    CreateDate: output.CreateDate !== undefined && output.CreateDate !== null ? output.CreateDate : undefined,
+    CreateDate: __expectString(output.CreateDate),
     GroupList:
       output.GroupList !== undefined && output.GroupList !== null
         ? deserializeAws_restJson1StringList(output.GroupList, context)
         : undefined,
-    Path: output.Path !== undefined && output.Path !== null ? output.Path : undefined,
+    Path: __expectString(output.Path),
     PermissionsBoundary:
       output.PermissionsBoundary !== undefined && output.PermissionsBoundary !== null
         ? deserializeAws_restJson1AwsIamPermissionsBoundary(output.PermissionsBoundary, context)
         : undefined,
-    UserId: output.UserId !== undefined && output.UserId !== null ? output.UserId : undefined,
-    UserName: output.UserName !== undefined && output.UserName !== null ? output.UserName : undefined,
+    UserId: __expectString(output.UserId),
+    UserName: __expectString(output.UserName),
     UserPolicyList:
       output.UserPolicyList !== undefined && output.UserPolicyList !== null
         ? deserializeAws_restJson1AwsIamUserPolicyList(output.UserPolicyList, context)
@@ -15076,7 +14770,7 @@ const deserializeAws_restJson1AwsIamUserDetails = (output: any, context: __Serde
 
 const deserializeAws_restJson1AwsIamUserPolicy = (output: any, context: __SerdeContext): AwsIamUserPolicy => {
   return {
-    PolicyName: output.PolicyName !== undefined && output.PolicyName !== null ? output.PolicyName : undefined,
+    PolicyName: __expectString(output.PolicyName),
   } as any;
 };
 
@@ -15093,23 +14787,22 @@ const deserializeAws_restJson1AwsIamUserPolicyList = (output: any, context: __Se
 
 const deserializeAws_restJson1AwsKmsKeyDetails = (output: any, context: __SerdeContext): AwsKmsKeyDetails => {
   return {
-    AWSAccountId: output.AWSAccountId !== undefined && output.AWSAccountId !== null ? output.AWSAccountId : undefined,
-    CreationDate: output.CreationDate !== undefined && output.CreationDate !== null ? output.CreationDate : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    KeyId: output.KeyId !== undefined && output.KeyId !== null ? output.KeyId : undefined,
-    KeyManager: output.KeyManager !== undefined && output.KeyManager !== null ? output.KeyManager : undefined,
-    KeyState: output.KeyState !== undefined && output.KeyState !== null ? output.KeyState : undefined,
-    Origin: output.Origin !== undefined && output.Origin !== null ? output.Origin : undefined,
+    AWSAccountId: __expectString(output.AWSAccountId),
+    CreationDate: __expectNumber(output.CreationDate),
+    Description: __expectString(output.Description),
+    KeyId: __expectString(output.KeyId),
+    KeyManager: __expectString(output.KeyManager),
+    KeyState: __expectString(output.KeyState),
+    Origin: __expectString(output.Origin),
   } as any;
 };
 
 const deserializeAws_restJson1AwsLambdaFunctionCode = (output: any, context: __SerdeContext): AwsLambdaFunctionCode => {
   return {
-    S3Bucket: output.S3Bucket !== undefined && output.S3Bucket !== null ? output.S3Bucket : undefined,
-    S3Key: output.S3Key !== undefined && output.S3Key !== null ? output.S3Key : undefined,
-    S3ObjectVersion:
-      output.S3ObjectVersion !== undefined && output.S3ObjectVersion !== null ? output.S3ObjectVersion : undefined,
-    ZipFile: output.ZipFile !== undefined && output.ZipFile !== null ? output.ZipFile : undefined,
+    S3Bucket: __expectString(output.S3Bucket),
+    S3Key: __expectString(output.S3Key),
+    S3ObjectVersion: __expectString(output.S3ObjectVersion),
+    ZipFile: __expectString(output.ZipFile),
   } as any;
 };
 
@@ -15118,7 +14811,7 @@ const deserializeAws_restJson1AwsLambdaFunctionDeadLetterConfig = (
   context: __SerdeContext
 ): AwsLambdaFunctionDeadLetterConfig => {
   return {
-    TargetArn: output.TargetArn !== undefined && output.TargetArn !== null ? output.TargetArn : undefined,
+    TargetArn: __expectString(output.TargetArn),
   } as any;
 };
 
@@ -15131,7 +14824,7 @@ const deserializeAws_restJson1AwsLambdaFunctionDetails = (
       output.Code !== undefined && output.Code !== null
         ? deserializeAws_restJson1AwsLambdaFunctionCode(output.Code, context)
         : undefined,
-    CodeSha256: output.CodeSha256 !== undefined && output.CodeSha256 !== null ? output.CodeSha256 : undefined,
+    CodeSha256: __expectString(output.CodeSha256),
     DeadLetterConfig:
       output.DeadLetterConfig !== undefined && output.DeadLetterConfig !== null
         ? deserializeAws_restJson1AwsLambdaFunctionDeadLetterConfig(output.DeadLetterConfig, context)
@@ -15140,25 +14833,25 @@ const deserializeAws_restJson1AwsLambdaFunctionDetails = (
       output.Environment !== undefined && output.Environment !== null
         ? deserializeAws_restJson1AwsLambdaFunctionEnvironment(output.Environment, context)
         : undefined,
-    FunctionName: output.FunctionName !== undefined && output.FunctionName !== null ? output.FunctionName : undefined,
-    Handler: output.Handler !== undefined && output.Handler !== null ? output.Handler : undefined,
-    KmsKeyArn: output.KmsKeyArn !== undefined && output.KmsKeyArn !== null ? output.KmsKeyArn : undefined,
-    LastModified: output.LastModified !== undefined && output.LastModified !== null ? output.LastModified : undefined,
+    FunctionName: __expectString(output.FunctionName),
+    Handler: __expectString(output.Handler),
+    KmsKeyArn: __expectString(output.KmsKeyArn),
+    LastModified: __expectString(output.LastModified),
     Layers:
       output.Layers !== undefined && output.Layers !== null
         ? deserializeAws_restJson1AwsLambdaFunctionLayerList(output.Layers, context)
         : undefined,
-    MasterArn: output.MasterArn !== undefined && output.MasterArn !== null ? output.MasterArn : undefined,
-    MemorySize: output.MemorySize !== undefined && output.MemorySize !== null ? output.MemorySize : undefined,
-    RevisionId: output.RevisionId !== undefined && output.RevisionId !== null ? output.RevisionId : undefined,
-    Role: output.Role !== undefined && output.Role !== null ? output.Role : undefined,
-    Runtime: output.Runtime !== undefined && output.Runtime !== null ? output.Runtime : undefined,
-    Timeout: output.Timeout !== undefined && output.Timeout !== null ? output.Timeout : undefined,
+    MasterArn: __expectString(output.MasterArn),
+    MemorySize: __expectNumber(output.MemorySize),
+    RevisionId: __expectString(output.RevisionId),
+    Role: __expectString(output.Role),
+    Runtime: __expectString(output.Runtime),
+    Timeout: __expectNumber(output.Timeout),
     TracingConfig:
       output.TracingConfig !== undefined && output.TracingConfig !== null
         ? deserializeAws_restJson1AwsLambdaFunctionTracingConfig(output.TracingConfig, context)
         : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    Version: __expectString(output.Version),
     VpcConfig:
       output.VpcConfig !== undefined && output.VpcConfig !== null
         ? deserializeAws_restJson1AwsLambdaFunctionVpcConfig(output.VpcConfig, context)
@@ -15187,8 +14880,8 @@ const deserializeAws_restJson1AwsLambdaFunctionEnvironmentError = (
   context: __SerdeContext
 ): AwsLambdaFunctionEnvironmentError => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -15197,8 +14890,8 @@ const deserializeAws_restJson1AwsLambdaFunctionLayer = (
   context: __SerdeContext
 ): AwsLambdaFunctionLayer => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    CodeSize: output.CodeSize !== undefined && output.CodeSize !== null ? output.CodeSize : undefined,
+    Arn: __expectString(output.Arn),
+    CodeSize: __expectNumber(output.CodeSize),
   } as any;
 };
 
@@ -15221,7 +14914,7 @@ const deserializeAws_restJson1AwsLambdaFunctionTracingConfig = (
   context: __SerdeContext
 ): AwsLambdaFunctionTracingConfig => {
   return {
-    Mode: output.Mode !== undefined && output.Mode !== null ? output.Mode : undefined,
+    Mode: __expectString(output.Mode),
   } as any;
 };
 
@@ -15238,7 +14931,7 @@ const deserializeAws_restJson1AwsLambdaFunctionVpcConfig = (
       output.SubnetIds !== undefined && output.SubnetIds !== null
         ? deserializeAws_restJson1NonEmptyStringList(output.SubnetIds, context)
         : undefined,
-    VpcId: output.VpcId !== undefined && output.VpcId !== null ? output.VpcId : undefined,
+    VpcId: __expectString(output.VpcId),
   } as any;
 };
 
@@ -15251,8 +14944,8 @@ const deserializeAws_restJson1AwsLambdaLayerVersionDetails = (
       output.CompatibleRuntimes !== undefined && output.CompatibleRuntimes !== null
         ? deserializeAws_restJson1NonEmptyStringList(output.CompatibleRuntimes, context)
         : undefined,
-    CreatedDate: output.CreatedDate !== undefined && output.CreatedDate !== null ? output.CreatedDate : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    CreatedDate: __expectString(output.CreatedDate),
+    Version: __expectNumber(output.Version),
   } as any;
 };
 
@@ -15261,8 +14954,8 @@ const deserializeAws_restJson1AwsRdsDbClusterAssociatedRole = (
   context: __SerdeContext
 ): AwsRdsDbClusterAssociatedRole => {
   return {
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    RoleArn: __expectString(output.RoleArn),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -15285,12 +14978,8 @@ const deserializeAws_restJson1AwsRdsDbClusterDetails = (
   context: __SerdeContext
 ): AwsRdsDbClusterDetails => {
   return {
-    ActivityStreamStatus:
-      output.ActivityStreamStatus !== undefined && output.ActivityStreamStatus !== null
-        ? output.ActivityStreamStatus
-        : undefined,
-    AllocatedStorage:
-      output.AllocatedStorage !== undefined && output.AllocatedStorage !== null ? output.AllocatedStorage : undefined,
+    ActivityStreamStatus: __expectString(output.ActivityStreamStatus),
+    AllocatedStorage: __expectNumber(output.AllocatedStorage),
     AssociatedRoles:
       output.AssociatedRoles !== undefined && output.AssociatedRoles !== null
         ? deserializeAws_restJson1AwsRdsDbClusterAssociatedRoles(output.AssociatedRoles, context)
@@ -15299,31 +14988,16 @@ const deserializeAws_restJson1AwsRdsDbClusterDetails = (
       output.AvailabilityZones !== undefined && output.AvailabilityZones !== null
         ? deserializeAws_restJson1StringList(output.AvailabilityZones, context)
         : undefined,
-    BackupRetentionPeriod:
-      output.BackupRetentionPeriod !== undefined && output.BackupRetentionPeriod !== null
-        ? output.BackupRetentionPeriod
-        : undefined,
-    ClusterCreateTime:
-      output.ClusterCreateTime !== undefined && output.ClusterCreateTime !== null
-        ? output.ClusterCreateTime
-        : undefined,
-    CopyTagsToSnapshot:
-      output.CopyTagsToSnapshot !== undefined && output.CopyTagsToSnapshot !== null
-        ? output.CopyTagsToSnapshot
-        : undefined,
-    CrossAccountClone:
-      output.CrossAccountClone !== undefined && output.CrossAccountClone !== null
-        ? output.CrossAccountClone
-        : undefined,
+    BackupRetentionPeriod: __expectNumber(output.BackupRetentionPeriod),
+    ClusterCreateTime: __expectString(output.ClusterCreateTime),
+    CopyTagsToSnapshot: __expectBoolean(output.CopyTagsToSnapshot),
+    CrossAccountClone: __expectBoolean(output.CrossAccountClone),
     CustomEndpoints:
       output.CustomEndpoints !== undefined && output.CustomEndpoints !== null
         ? deserializeAws_restJson1StringList(output.CustomEndpoints, context)
         : undefined,
-    DatabaseName: output.DatabaseName !== undefined && output.DatabaseName !== null ? output.DatabaseName : undefined,
-    DbClusterIdentifier:
-      output.DbClusterIdentifier !== undefined && output.DbClusterIdentifier !== null
-        ? output.DbClusterIdentifier
-        : undefined,
+    DatabaseName: __expectString(output.DatabaseName),
+    DbClusterIdentifier: __expectString(output.DbClusterIdentifier),
     DbClusterMembers:
       output.DbClusterMembers !== undefined && output.DbClusterMembers !== null
         ? deserializeAws_restJson1AwsRdsDbClusterMembers(output.DbClusterMembers, context)
@@ -15332,20 +15006,10 @@ const deserializeAws_restJson1AwsRdsDbClusterDetails = (
       output.DbClusterOptionGroupMemberships !== undefined && output.DbClusterOptionGroupMemberships !== null
         ? deserializeAws_restJson1AwsRdsDbClusterOptionGroupMemberships(output.DbClusterOptionGroupMemberships, context)
         : undefined,
-    DbClusterParameterGroup:
-      output.DbClusterParameterGroup !== undefined && output.DbClusterParameterGroup !== null
-        ? output.DbClusterParameterGroup
-        : undefined,
-    DbClusterResourceId:
-      output.DbClusterResourceId !== undefined && output.DbClusterResourceId !== null
-        ? output.DbClusterResourceId
-        : undefined,
-    DbSubnetGroup:
-      output.DbSubnetGroup !== undefined && output.DbSubnetGroup !== null ? output.DbSubnetGroup : undefined,
-    DeletionProtection:
-      output.DeletionProtection !== undefined && output.DeletionProtection !== null
-        ? output.DeletionProtection
-        : undefined,
+    DbClusterParameterGroup: __expectString(output.DbClusterParameterGroup),
+    DbClusterResourceId: __expectString(output.DbClusterResourceId),
+    DbSubnetGroup: __expectString(output.DbSubnetGroup),
+    DeletionProtection: __expectBoolean(output.DeletionProtection),
     DomainMemberships:
       output.DomainMemberships !== undefined && output.DomainMemberships !== null
         ? deserializeAws_restJson1AwsRdsDbDomainMemberships(output.DomainMemberships, context)
@@ -15354,42 +15018,26 @@ const deserializeAws_restJson1AwsRdsDbClusterDetails = (
       output.EnabledCloudWatchLogsExports !== undefined && output.EnabledCloudWatchLogsExports !== null
         ? deserializeAws_restJson1StringList(output.EnabledCloudWatchLogsExports, context)
         : undefined,
-    Endpoint: output.Endpoint !== undefined && output.Endpoint !== null ? output.Endpoint : undefined,
-    Engine: output.Engine !== undefined && output.Engine !== null ? output.Engine : undefined,
-    EngineMode: output.EngineMode !== undefined && output.EngineMode !== null ? output.EngineMode : undefined,
-    EngineVersion:
-      output.EngineVersion !== undefined && output.EngineVersion !== null ? output.EngineVersion : undefined,
-    HostedZoneId: output.HostedZoneId !== undefined && output.HostedZoneId !== null ? output.HostedZoneId : undefined,
-    HttpEndpointEnabled:
-      output.HttpEndpointEnabled !== undefined && output.HttpEndpointEnabled !== null
-        ? output.HttpEndpointEnabled
-        : undefined,
-    IamDatabaseAuthenticationEnabled:
-      output.IamDatabaseAuthenticationEnabled !== undefined && output.IamDatabaseAuthenticationEnabled !== null
-        ? output.IamDatabaseAuthenticationEnabled
-        : undefined,
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
-    MasterUsername:
-      output.MasterUsername !== undefined && output.MasterUsername !== null ? output.MasterUsername : undefined,
-    MultiAz: output.MultiAz !== undefined && output.MultiAz !== null ? output.MultiAz : undefined,
-    Port: output.Port !== undefined && output.Port !== null ? output.Port : undefined,
-    PreferredBackupWindow:
-      output.PreferredBackupWindow !== undefined && output.PreferredBackupWindow !== null
-        ? output.PreferredBackupWindow
-        : undefined,
-    PreferredMaintenanceWindow:
-      output.PreferredMaintenanceWindow !== undefined && output.PreferredMaintenanceWindow !== null
-        ? output.PreferredMaintenanceWindow
-        : undefined,
+    Endpoint: __expectString(output.Endpoint),
+    Engine: __expectString(output.Engine),
+    EngineMode: __expectString(output.EngineMode),
+    EngineVersion: __expectString(output.EngineVersion),
+    HostedZoneId: __expectString(output.HostedZoneId),
+    HttpEndpointEnabled: __expectBoolean(output.HttpEndpointEnabled),
+    IamDatabaseAuthenticationEnabled: __expectBoolean(output.IamDatabaseAuthenticationEnabled),
+    KmsKeyId: __expectString(output.KmsKeyId),
+    MasterUsername: __expectString(output.MasterUsername),
+    MultiAz: __expectBoolean(output.MultiAz),
+    Port: __expectNumber(output.Port),
+    PreferredBackupWindow: __expectString(output.PreferredBackupWindow),
+    PreferredMaintenanceWindow: __expectString(output.PreferredMaintenanceWindow),
     ReadReplicaIdentifiers:
       output.ReadReplicaIdentifiers !== undefined && output.ReadReplicaIdentifiers !== null
         ? deserializeAws_restJson1StringList(output.ReadReplicaIdentifiers, context)
         : undefined,
-    ReaderEndpoint:
-      output.ReaderEndpoint !== undefined && output.ReaderEndpoint !== null ? output.ReaderEndpoint : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StorageEncrypted:
-      output.StorageEncrypted !== undefined && output.StorageEncrypted !== null ? output.StorageEncrypted : undefined,
+    ReaderEndpoint: __expectString(output.ReaderEndpoint),
+    Status: __expectString(output.Status),
+    StorageEncrypted: __expectBoolean(output.StorageEncrypted),
     VpcSecurityGroups:
       output.VpcSecurityGroups !== undefined && output.VpcSecurityGroups !== null
         ? deserializeAws_restJson1AwsRdsDbInstanceVpcSecurityGroups(output.VpcSecurityGroups, context)
@@ -15399,18 +15047,10 @@ const deserializeAws_restJson1AwsRdsDbClusterDetails = (
 
 const deserializeAws_restJson1AwsRdsDbClusterMember = (output: any, context: __SerdeContext): AwsRdsDbClusterMember => {
   return {
-    DbClusterParameterGroupStatus:
-      output.DbClusterParameterGroupStatus !== undefined && output.DbClusterParameterGroupStatus !== null
-        ? output.DbClusterParameterGroupStatus
-        : undefined,
-    DbInstanceIdentifier:
-      output.DbInstanceIdentifier !== undefined && output.DbInstanceIdentifier !== null
-        ? output.DbInstanceIdentifier
-        : undefined,
-    IsClusterWriter:
-      output.IsClusterWriter !== undefined && output.IsClusterWriter !== null ? output.IsClusterWriter : undefined,
-    PromotionTier:
-      output.PromotionTier !== undefined && output.PromotionTier !== null ? output.PromotionTier : undefined,
+    DbClusterParameterGroupStatus: __expectString(output.DbClusterParameterGroupStatus),
+    DbInstanceIdentifier: __expectString(output.DbInstanceIdentifier),
+    IsClusterWriter: __expectBoolean(output.IsClusterWriter),
+    PromotionTier: __expectNumber(output.PromotionTier),
   } as any;
 };
 
@@ -15433,11 +15073,8 @@ const deserializeAws_restJson1AwsRdsDbClusterOptionGroupMembership = (
   context: __SerdeContext
 ): AwsRdsDbClusterOptionGroupMembership => {
   return {
-    DbClusterOptionGroupName:
-      output.DbClusterOptionGroupName !== undefined && output.DbClusterOptionGroupName !== null
-        ? output.DbClusterOptionGroupName
-        : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    DbClusterOptionGroupName: __expectString(output.DbClusterOptionGroupName),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -15460,47 +15097,27 @@ const deserializeAws_restJson1AwsRdsDbClusterSnapshotDetails = (
   context: __SerdeContext
 ): AwsRdsDbClusterSnapshotDetails => {
   return {
-    AllocatedStorage:
-      output.AllocatedStorage !== undefined && output.AllocatedStorage !== null ? output.AllocatedStorage : undefined,
+    AllocatedStorage: __expectNumber(output.AllocatedStorage),
     AvailabilityZones:
       output.AvailabilityZones !== undefined && output.AvailabilityZones !== null
         ? deserializeAws_restJson1StringList(output.AvailabilityZones, context)
         : undefined,
-    ClusterCreateTime:
-      output.ClusterCreateTime !== undefined && output.ClusterCreateTime !== null
-        ? output.ClusterCreateTime
-        : undefined,
-    DbClusterIdentifier:
-      output.DbClusterIdentifier !== undefined && output.DbClusterIdentifier !== null
-        ? output.DbClusterIdentifier
-        : undefined,
-    DbClusterSnapshotIdentifier:
-      output.DbClusterSnapshotIdentifier !== undefined && output.DbClusterSnapshotIdentifier !== null
-        ? output.DbClusterSnapshotIdentifier
-        : undefined,
-    Engine: output.Engine !== undefined && output.Engine !== null ? output.Engine : undefined,
-    EngineVersion:
-      output.EngineVersion !== undefined && output.EngineVersion !== null ? output.EngineVersion : undefined,
-    IamDatabaseAuthenticationEnabled:
-      output.IamDatabaseAuthenticationEnabled !== undefined && output.IamDatabaseAuthenticationEnabled !== null
-        ? output.IamDatabaseAuthenticationEnabled
-        : undefined,
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
-    LicenseModel: output.LicenseModel !== undefined && output.LicenseModel !== null ? output.LicenseModel : undefined,
-    MasterUsername:
-      output.MasterUsername !== undefined && output.MasterUsername !== null ? output.MasterUsername : undefined,
-    PercentProgress:
-      output.PercentProgress !== undefined && output.PercentProgress !== null ? output.PercentProgress : undefined,
-    Port: output.Port !== undefined && output.Port !== null ? output.Port : undefined,
-    SnapshotCreateTime:
-      output.SnapshotCreateTime !== undefined && output.SnapshotCreateTime !== null
-        ? output.SnapshotCreateTime
-        : undefined,
-    SnapshotType: output.SnapshotType !== undefined && output.SnapshotType !== null ? output.SnapshotType : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StorageEncrypted:
-      output.StorageEncrypted !== undefined && output.StorageEncrypted !== null ? output.StorageEncrypted : undefined,
-    VpcId: output.VpcId !== undefined && output.VpcId !== null ? output.VpcId : undefined,
+    ClusterCreateTime: __expectString(output.ClusterCreateTime),
+    DbClusterIdentifier: __expectString(output.DbClusterIdentifier),
+    DbClusterSnapshotIdentifier: __expectString(output.DbClusterSnapshotIdentifier),
+    Engine: __expectString(output.Engine),
+    EngineVersion: __expectString(output.EngineVersion),
+    IamDatabaseAuthenticationEnabled: __expectBoolean(output.IamDatabaseAuthenticationEnabled),
+    KmsKeyId: __expectString(output.KmsKeyId),
+    LicenseModel: __expectString(output.LicenseModel),
+    MasterUsername: __expectString(output.MasterUsername),
+    PercentProgress: __expectNumber(output.PercentProgress),
+    Port: __expectNumber(output.Port),
+    SnapshotCreateTime: __expectString(output.SnapshotCreateTime),
+    SnapshotType: __expectString(output.SnapshotType),
+    Status: __expectString(output.Status),
+    StorageEncrypted: __expectBoolean(output.StorageEncrypted),
+    VpcId: __expectString(output.VpcId),
   } as any;
 };
 
@@ -15509,10 +15126,10 @@ const deserializeAws_restJson1AwsRdsDbDomainMembership = (
   context: __SerdeContext
 ): AwsRdsDbDomainMembership => {
   return {
-    Domain: output.Domain !== undefined && output.Domain !== null ? output.Domain : undefined,
-    Fqdn: output.Fqdn !== undefined && output.Fqdn !== null ? output.Fqdn : undefined,
-    IamRoleName: output.IamRoleName !== undefined && output.IamRoleName !== null ? output.IamRoleName : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Domain: __expectString(output.Domain),
+    Fqdn: __expectString(output.Fqdn),
+    IamRoleName: __expectString(output.IamRoleName),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -15535,9 +15152,9 @@ const deserializeAws_restJson1AwsRdsDbInstanceAssociatedRole = (
   context: __SerdeContext
 ): AwsRdsDbInstanceAssociatedRole => {
   return {
-    FeatureName: output.FeatureName !== undefined && output.FeatureName !== null ? output.FeatureName : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    FeatureName: __expectString(output.FeatureName),
+    RoleArn: __expectString(output.RoleArn),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -15560,47 +15177,23 @@ const deserializeAws_restJson1AwsRdsDbInstanceDetails = (
   context: __SerdeContext
 ): AwsRdsDbInstanceDetails => {
   return {
-    AllocatedStorage:
-      output.AllocatedStorage !== undefined && output.AllocatedStorage !== null ? output.AllocatedStorage : undefined,
+    AllocatedStorage: __expectNumber(output.AllocatedStorage),
     AssociatedRoles:
       output.AssociatedRoles !== undefined && output.AssociatedRoles !== null
         ? deserializeAws_restJson1AwsRdsDbInstanceAssociatedRoles(output.AssociatedRoles, context)
         : undefined,
-    AutoMinorVersionUpgrade:
-      output.AutoMinorVersionUpgrade !== undefined && output.AutoMinorVersionUpgrade !== null
-        ? output.AutoMinorVersionUpgrade
-        : undefined,
-    AvailabilityZone:
-      output.AvailabilityZone !== undefined && output.AvailabilityZone !== null ? output.AvailabilityZone : undefined,
-    BackupRetentionPeriod:
-      output.BackupRetentionPeriod !== undefined && output.BackupRetentionPeriod !== null
-        ? output.BackupRetentionPeriod
-        : undefined,
-    CACertificateIdentifier:
-      output.CACertificateIdentifier !== undefined && output.CACertificateIdentifier !== null
-        ? output.CACertificateIdentifier
-        : undefined,
-    CharacterSetName:
-      output.CharacterSetName !== undefined && output.CharacterSetName !== null ? output.CharacterSetName : undefined,
-    CopyTagsToSnapshot:
-      output.CopyTagsToSnapshot !== undefined && output.CopyTagsToSnapshot !== null
-        ? output.CopyTagsToSnapshot
-        : undefined,
-    DBClusterIdentifier:
-      output.DBClusterIdentifier !== undefined && output.DBClusterIdentifier !== null
-        ? output.DBClusterIdentifier
-        : undefined,
-    DBInstanceClass:
-      output.DBInstanceClass !== undefined && output.DBInstanceClass !== null ? output.DBInstanceClass : undefined,
-    DBInstanceIdentifier:
-      output.DBInstanceIdentifier !== undefined && output.DBInstanceIdentifier !== null
-        ? output.DBInstanceIdentifier
-        : undefined,
-    DBName: output.DBName !== undefined && output.DBName !== null ? output.DBName : undefined,
-    DbInstancePort:
-      output.DbInstancePort !== undefined && output.DbInstancePort !== null ? output.DbInstancePort : undefined,
-    DbInstanceStatus:
-      output.DbInstanceStatus !== undefined && output.DbInstanceStatus !== null ? output.DbInstanceStatus : undefined,
+    AutoMinorVersionUpgrade: __expectBoolean(output.AutoMinorVersionUpgrade),
+    AvailabilityZone: __expectString(output.AvailabilityZone),
+    BackupRetentionPeriod: __expectNumber(output.BackupRetentionPeriod),
+    CACertificateIdentifier: __expectString(output.CACertificateIdentifier),
+    CharacterSetName: __expectString(output.CharacterSetName),
+    CopyTagsToSnapshot: __expectBoolean(output.CopyTagsToSnapshot),
+    DBClusterIdentifier: __expectString(output.DBClusterIdentifier),
+    DBInstanceClass: __expectString(output.DBInstanceClass),
+    DBInstanceIdentifier: __expectString(output.DBInstanceIdentifier),
+    DBName: __expectString(output.DBName),
+    DbInstancePort: __expectNumber(output.DbInstancePort),
+    DbInstanceStatus: __expectString(output.DbInstanceStatus),
     DbParameterGroups:
       output.DbParameterGroups !== undefined && output.DbParameterGroups !== null
         ? deserializeAws_restJson1AwsRdsDbParameterGroups(output.DbParameterGroups, context)
@@ -15613,12 +15206,8 @@ const deserializeAws_restJson1AwsRdsDbInstanceDetails = (
       output.DbSubnetGroup !== undefined && output.DbSubnetGroup !== null
         ? deserializeAws_restJson1AwsRdsDbSubnetGroup(output.DbSubnetGroup, context)
         : undefined,
-    DbiResourceId:
-      output.DbiResourceId !== undefined && output.DbiResourceId !== null ? output.DbiResourceId : undefined,
-    DeletionProtection:
-      output.DeletionProtection !== undefined && output.DeletionProtection !== null
-        ? output.DeletionProtection
-        : undefined,
+    DbiResourceId: __expectString(output.DbiResourceId),
+    DeletionProtection: __expectBoolean(output.DeletionProtection),
     DomainMemberships:
       output.DomainMemberships !== undefined && output.DomainMemberships !== null
         ? deserializeAws_restJson1AwsRdsDbDomainMemberships(output.DomainMemberships, context)
@@ -15631,47 +15220,24 @@ const deserializeAws_restJson1AwsRdsDbInstanceDetails = (
       output.Endpoint !== undefined && output.Endpoint !== null
         ? deserializeAws_restJson1AwsRdsDbInstanceEndpoint(output.Endpoint, context)
         : undefined,
-    Engine: output.Engine !== undefined && output.Engine !== null ? output.Engine : undefined,
-    EngineVersion:
-      output.EngineVersion !== undefined && output.EngineVersion !== null ? output.EngineVersion : undefined,
-    EnhancedMonitoringResourceArn:
-      output.EnhancedMonitoringResourceArn !== undefined && output.EnhancedMonitoringResourceArn !== null
-        ? output.EnhancedMonitoringResourceArn
-        : undefined,
-    IAMDatabaseAuthenticationEnabled:
-      output.IAMDatabaseAuthenticationEnabled !== undefined && output.IAMDatabaseAuthenticationEnabled !== null
-        ? output.IAMDatabaseAuthenticationEnabled
-        : undefined,
-    InstanceCreateTime:
-      output.InstanceCreateTime !== undefined && output.InstanceCreateTime !== null
-        ? output.InstanceCreateTime
-        : undefined,
-    Iops: output.Iops !== undefined && output.Iops !== null ? output.Iops : undefined,
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
-    LatestRestorableTime:
-      output.LatestRestorableTime !== undefined && output.LatestRestorableTime !== null
-        ? output.LatestRestorableTime
-        : undefined,
-    LicenseModel: output.LicenseModel !== undefined && output.LicenseModel !== null ? output.LicenseModel : undefined,
+    Engine: __expectString(output.Engine),
+    EngineVersion: __expectString(output.EngineVersion),
+    EnhancedMonitoringResourceArn: __expectString(output.EnhancedMonitoringResourceArn),
+    IAMDatabaseAuthenticationEnabled: __expectBoolean(output.IAMDatabaseAuthenticationEnabled),
+    InstanceCreateTime: __expectString(output.InstanceCreateTime),
+    Iops: __expectNumber(output.Iops),
+    KmsKeyId: __expectString(output.KmsKeyId),
+    LatestRestorableTime: __expectString(output.LatestRestorableTime),
+    LicenseModel: __expectString(output.LicenseModel),
     ListenerEndpoint:
       output.ListenerEndpoint !== undefined && output.ListenerEndpoint !== null
         ? deserializeAws_restJson1AwsRdsDbInstanceEndpoint(output.ListenerEndpoint, context)
         : undefined,
-    MasterUsername:
-      output.MasterUsername !== undefined && output.MasterUsername !== null ? output.MasterUsername : undefined,
-    MaxAllocatedStorage:
-      output.MaxAllocatedStorage !== undefined && output.MaxAllocatedStorage !== null
-        ? output.MaxAllocatedStorage
-        : undefined,
-    MonitoringInterval:
-      output.MonitoringInterval !== undefined && output.MonitoringInterval !== null
-        ? output.MonitoringInterval
-        : undefined,
-    MonitoringRoleArn:
-      output.MonitoringRoleArn !== undefined && output.MonitoringRoleArn !== null
-        ? output.MonitoringRoleArn
-        : undefined,
-    MultiAz: output.MultiAz !== undefined && output.MultiAz !== null ? output.MultiAz : undefined,
+    MasterUsername: __expectString(output.MasterUsername),
+    MaxAllocatedStorage: __expectNumber(output.MaxAllocatedStorage),
+    MonitoringInterval: __expectNumber(output.MonitoringInterval),
+    MonitoringRoleArn: __expectString(output.MonitoringRoleArn),
+    MultiAz: __expectBoolean(output.MultiAz),
     OptionGroupMemberships:
       output.OptionGroupMemberships !== undefined && output.OptionGroupMemberships !== null
         ? deserializeAws_restJson1AwsRdsDbOptionGroupMemberships(output.OptionGroupMemberships, context)
@@ -15680,36 +15246,17 @@ const deserializeAws_restJson1AwsRdsDbInstanceDetails = (
       output.PendingModifiedValues !== undefined && output.PendingModifiedValues !== null
         ? deserializeAws_restJson1AwsRdsDbPendingModifiedValues(output.PendingModifiedValues, context)
         : undefined,
-    PerformanceInsightsEnabled:
-      output.PerformanceInsightsEnabled !== undefined && output.PerformanceInsightsEnabled !== null
-        ? output.PerformanceInsightsEnabled
-        : undefined,
-    PerformanceInsightsKmsKeyId:
-      output.PerformanceInsightsKmsKeyId !== undefined && output.PerformanceInsightsKmsKeyId !== null
-        ? output.PerformanceInsightsKmsKeyId
-        : undefined,
-    PerformanceInsightsRetentionPeriod:
-      output.PerformanceInsightsRetentionPeriod !== undefined && output.PerformanceInsightsRetentionPeriod !== null
-        ? output.PerformanceInsightsRetentionPeriod
-        : undefined,
-    PreferredBackupWindow:
-      output.PreferredBackupWindow !== undefined && output.PreferredBackupWindow !== null
-        ? output.PreferredBackupWindow
-        : undefined,
-    PreferredMaintenanceWindow:
-      output.PreferredMaintenanceWindow !== undefined && output.PreferredMaintenanceWindow !== null
-        ? output.PreferredMaintenanceWindow
-        : undefined,
+    PerformanceInsightsEnabled: __expectBoolean(output.PerformanceInsightsEnabled),
+    PerformanceInsightsKmsKeyId: __expectString(output.PerformanceInsightsKmsKeyId),
+    PerformanceInsightsRetentionPeriod: __expectNumber(output.PerformanceInsightsRetentionPeriod),
+    PreferredBackupWindow: __expectString(output.PreferredBackupWindow),
+    PreferredMaintenanceWindow: __expectString(output.PreferredMaintenanceWindow),
     ProcessorFeatures:
       output.ProcessorFeatures !== undefined && output.ProcessorFeatures !== null
         ? deserializeAws_restJson1AwsRdsDbProcessorFeatures(output.ProcessorFeatures, context)
         : undefined,
-    PromotionTier:
-      output.PromotionTier !== undefined && output.PromotionTier !== null ? output.PromotionTier : undefined,
-    PubliclyAccessible:
-      output.PubliclyAccessible !== undefined && output.PubliclyAccessible !== null
-        ? output.PubliclyAccessible
-        : undefined,
+    PromotionTier: __expectNumber(output.PromotionTier),
+    PubliclyAccessible: __expectBoolean(output.PubliclyAccessible),
     ReadReplicaDBClusterIdentifiers:
       output.ReadReplicaDBClusterIdentifiers !== undefined && output.ReadReplicaDBClusterIdentifiers !== null
         ? deserializeAws_restJson1StringList(output.ReadReplicaDBClusterIdentifiers, context)
@@ -15718,25 +15265,16 @@ const deserializeAws_restJson1AwsRdsDbInstanceDetails = (
       output.ReadReplicaDBInstanceIdentifiers !== undefined && output.ReadReplicaDBInstanceIdentifiers !== null
         ? deserializeAws_restJson1StringList(output.ReadReplicaDBInstanceIdentifiers, context)
         : undefined,
-    ReadReplicaSourceDBInstanceIdentifier:
-      output.ReadReplicaSourceDBInstanceIdentifier !== undefined &&
-      output.ReadReplicaSourceDBInstanceIdentifier !== null
-        ? output.ReadReplicaSourceDBInstanceIdentifier
-        : undefined,
-    SecondaryAvailabilityZone:
-      output.SecondaryAvailabilityZone !== undefined && output.SecondaryAvailabilityZone !== null
-        ? output.SecondaryAvailabilityZone
-        : undefined,
+    ReadReplicaSourceDBInstanceIdentifier: __expectString(output.ReadReplicaSourceDBInstanceIdentifier),
+    SecondaryAvailabilityZone: __expectString(output.SecondaryAvailabilityZone),
     StatusInfos:
       output.StatusInfos !== undefined && output.StatusInfos !== null
         ? deserializeAws_restJson1AwsRdsDbStatusInfos(output.StatusInfos, context)
         : undefined,
-    StorageEncrypted:
-      output.StorageEncrypted !== undefined && output.StorageEncrypted !== null ? output.StorageEncrypted : undefined,
-    StorageType: output.StorageType !== undefined && output.StorageType !== null ? output.StorageType : undefined,
-    TdeCredentialArn:
-      output.TdeCredentialArn !== undefined && output.TdeCredentialArn !== null ? output.TdeCredentialArn : undefined,
-    Timezone: output.Timezone !== undefined && output.Timezone !== null ? output.Timezone : undefined,
+    StorageEncrypted: __expectBoolean(output.StorageEncrypted),
+    StorageType: __expectString(output.StorageType),
+    TdeCredentialArn: __expectString(output.TdeCredentialArn),
+    Timezone: __expectString(output.Timezone),
     VpcSecurityGroups:
       output.VpcSecurityGroups !== undefined && output.VpcSecurityGroups !== null
         ? deserializeAws_restJson1AwsRdsDbInstanceVpcSecurityGroups(output.VpcSecurityGroups, context)
@@ -15749,9 +15287,9 @@ const deserializeAws_restJson1AwsRdsDbInstanceEndpoint = (
   context: __SerdeContext
 ): AwsRdsDbInstanceEndpoint => {
   return {
-    Address: output.Address !== undefined && output.Address !== null ? output.Address : undefined,
-    HostedZoneId: output.HostedZoneId !== undefined && output.HostedZoneId !== null ? output.HostedZoneId : undefined,
-    Port: output.Port !== undefined && output.Port !== null ? output.Port : undefined,
+    Address: __expectString(output.Address),
+    HostedZoneId: __expectString(output.HostedZoneId),
+    Port: __expectNumber(output.Port),
   } as any;
 };
 
@@ -15760,11 +15298,8 @@ const deserializeAws_restJson1AwsRdsDbInstanceVpcSecurityGroup = (
   context: __SerdeContext
 ): AwsRdsDbInstanceVpcSecurityGroup => {
   return {
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    VpcSecurityGroupId:
-      output.VpcSecurityGroupId !== undefined && output.VpcSecurityGroupId !== null
-        ? output.VpcSecurityGroupId
-        : undefined,
+    Status: __expectString(output.Status),
+    VpcSecurityGroupId: __expectString(output.VpcSecurityGroupId),
   } as any;
 };
 
@@ -15787,9 +15322,8 @@ const deserializeAws_restJson1AwsRdsDbOptionGroupMembership = (
   context: __SerdeContext
 ): AwsRdsDbOptionGroupMembership => {
   return {
-    OptionGroupName:
-      output.OptionGroupName !== undefined && output.OptionGroupName !== null ? output.OptionGroupName : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    OptionGroupName: __expectString(output.OptionGroupName),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -15812,14 +15346,8 @@ const deserializeAws_restJson1AwsRdsDbParameterGroup = (
   context: __SerdeContext
 ): AwsRdsDbParameterGroup => {
   return {
-    DbParameterGroupName:
-      output.DbParameterGroupName !== undefined && output.DbParameterGroupName !== null
-        ? output.DbParameterGroupName
-        : undefined,
-    ParameterApplyStatus:
-      output.ParameterApplyStatus !== undefined && output.ParameterApplyStatus !== null
-        ? output.ParameterApplyStatus
-        : undefined,
+    DbParameterGroupName: __expectString(output.DbParameterGroupName),
+    ParameterApplyStatus: __expectString(output.ParameterApplyStatus),
   } as any;
 };
 
@@ -15842,45 +15370,27 @@ const deserializeAws_restJson1AwsRdsDbPendingModifiedValues = (
   context: __SerdeContext
 ): AwsRdsDbPendingModifiedValues => {
   return {
-    AllocatedStorage:
-      output.AllocatedStorage !== undefined && output.AllocatedStorage !== null ? output.AllocatedStorage : undefined,
-    BackupRetentionPeriod:
-      output.BackupRetentionPeriod !== undefined && output.BackupRetentionPeriod !== null
-        ? output.BackupRetentionPeriod
-        : undefined,
-    CaCertificateIdentifier:
-      output.CaCertificateIdentifier !== undefined && output.CaCertificateIdentifier !== null
-        ? output.CaCertificateIdentifier
-        : undefined,
-    DbInstanceClass:
-      output.DbInstanceClass !== undefined && output.DbInstanceClass !== null ? output.DbInstanceClass : undefined,
-    DbInstanceIdentifier:
-      output.DbInstanceIdentifier !== undefined && output.DbInstanceIdentifier !== null
-        ? output.DbInstanceIdentifier
-        : undefined,
-    DbSubnetGroupName:
-      output.DbSubnetGroupName !== undefined && output.DbSubnetGroupName !== null
-        ? output.DbSubnetGroupName
-        : undefined,
-    EngineVersion:
-      output.EngineVersion !== undefined && output.EngineVersion !== null ? output.EngineVersion : undefined,
-    Iops: output.Iops !== undefined && output.Iops !== null ? output.Iops : undefined,
-    LicenseModel: output.LicenseModel !== undefined && output.LicenseModel !== null ? output.LicenseModel : undefined,
-    MasterUserPassword:
-      output.MasterUserPassword !== undefined && output.MasterUserPassword !== null
-        ? output.MasterUserPassword
-        : undefined,
-    MultiAZ: output.MultiAZ !== undefined && output.MultiAZ !== null ? output.MultiAZ : undefined,
+    AllocatedStorage: __expectNumber(output.AllocatedStorage),
+    BackupRetentionPeriod: __expectNumber(output.BackupRetentionPeriod),
+    CaCertificateIdentifier: __expectString(output.CaCertificateIdentifier),
+    DbInstanceClass: __expectString(output.DbInstanceClass),
+    DbInstanceIdentifier: __expectString(output.DbInstanceIdentifier),
+    DbSubnetGroupName: __expectString(output.DbSubnetGroupName),
+    EngineVersion: __expectString(output.EngineVersion),
+    Iops: __expectNumber(output.Iops),
+    LicenseModel: __expectString(output.LicenseModel),
+    MasterUserPassword: __expectString(output.MasterUserPassword),
+    MultiAZ: __expectBoolean(output.MultiAZ),
     PendingCloudWatchLogsExports:
       output.PendingCloudWatchLogsExports !== undefined && output.PendingCloudWatchLogsExports !== null
         ? deserializeAws_restJson1AwsRdsPendingCloudWatchLogsExports(output.PendingCloudWatchLogsExports, context)
         : undefined,
-    Port: output.Port !== undefined && output.Port !== null ? output.Port : undefined,
+    Port: __expectNumber(output.Port),
     ProcessorFeatures:
       output.ProcessorFeatures !== undefined && output.ProcessorFeatures !== null
         ? deserializeAws_restJson1AwsRdsDbProcessorFeatures(output.ProcessorFeatures, context)
         : undefined,
-    StorageType: output.StorageType !== undefined && output.StorageType !== null ? output.StorageType : undefined,
+    StorageType: __expectString(output.StorageType),
   } as any;
 };
 
@@ -15889,8 +15399,8 @@ const deserializeAws_restJson1AwsRdsDbProcessorFeature = (
   context: __SerdeContext
 ): AwsRdsDbProcessorFeature => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Name: __expectString(output.Name),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -15913,71 +15423,45 @@ const deserializeAws_restJson1AwsRdsDbSnapshotDetails = (
   context: __SerdeContext
 ): AwsRdsDbSnapshotDetails => {
   return {
-    AllocatedStorage:
-      output.AllocatedStorage !== undefined && output.AllocatedStorage !== null ? output.AllocatedStorage : undefined,
-    AvailabilityZone:
-      output.AvailabilityZone !== undefined && output.AvailabilityZone !== null ? output.AvailabilityZone : undefined,
-    DbInstanceIdentifier:
-      output.DbInstanceIdentifier !== undefined && output.DbInstanceIdentifier !== null
-        ? output.DbInstanceIdentifier
-        : undefined,
-    DbSnapshotIdentifier:
-      output.DbSnapshotIdentifier !== undefined && output.DbSnapshotIdentifier !== null
-        ? output.DbSnapshotIdentifier
-        : undefined,
-    DbiResourceId:
-      output.DbiResourceId !== undefined && output.DbiResourceId !== null ? output.DbiResourceId : undefined,
-    Encrypted: output.Encrypted !== undefined && output.Encrypted !== null ? output.Encrypted : undefined,
-    Engine: output.Engine !== undefined && output.Engine !== null ? output.Engine : undefined,
-    EngineVersion:
-      output.EngineVersion !== undefined && output.EngineVersion !== null ? output.EngineVersion : undefined,
-    IamDatabaseAuthenticationEnabled:
-      output.IamDatabaseAuthenticationEnabled !== undefined && output.IamDatabaseAuthenticationEnabled !== null
-        ? output.IamDatabaseAuthenticationEnabled
-        : undefined,
-    InstanceCreateTime:
-      output.InstanceCreateTime !== undefined && output.InstanceCreateTime !== null
-        ? output.InstanceCreateTime
-        : undefined,
-    Iops: output.Iops !== undefined && output.Iops !== null ? output.Iops : undefined,
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
-    LicenseModel: output.LicenseModel !== undefined && output.LicenseModel !== null ? output.LicenseModel : undefined,
-    MasterUsername:
-      output.MasterUsername !== undefined && output.MasterUsername !== null ? output.MasterUsername : undefined,
-    OptionGroupName:
-      output.OptionGroupName !== undefined && output.OptionGroupName !== null ? output.OptionGroupName : undefined,
-    PercentProgress:
-      output.PercentProgress !== undefined && output.PercentProgress !== null ? output.PercentProgress : undefined,
-    Port: output.Port !== undefined && output.Port !== null ? output.Port : undefined,
+    AllocatedStorage: __expectNumber(output.AllocatedStorage),
+    AvailabilityZone: __expectString(output.AvailabilityZone),
+    DbInstanceIdentifier: __expectString(output.DbInstanceIdentifier),
+    DbSnapshotIdentifier: __expectString(output.DbSnapshotIdentifier),
+    DbiResourceId: __expectString(output.DbiResourceId),
+    Encrypted: __expectBoolean(output.Encrypted),
+    Engine: __expectString(output.Engine),
+    EngineVersion: __expectString(output.EngineVersion),
+    IamDatabaseAuthenticationEnabled: __expectBoolean(output.IamDatabaseAuthenticationEnabled),
+    InstanceCreateTime: __expectString(output.InstanceCreateTime),
+    Iops: __expectNumber(output.Iops),
+    KmsKeyId: __expectString(output.KmsKeyId),
+    LicenseModel: __expectString(output.LicenseModel),
+    MasterUsername: __expectString(output.MasterUsername),
+    OptionGroupName: __expectString(output.OptionGroupName),
+    PercentProgress: __expectNumber(output.PercentProgress),
+    Port: __expectNumber(output.Port),
     ProcessorFeatures:
       output.ProcessorFeatures !== undefined && output.ProcessorFeatures !== null
         ? deserializeAws_restJson1AwsRdsDbProcessorFeatures(output.ProcessorFeatures, context)
         : undefined,
-    SnapshotCreateTime:
-      output.SnapshotCreateTime !== undefined && output.SnapshotCreateTime !== null
-        ? output.SnapshotCreateTime
-        : undefined,
-    SnapshotType: output.SnapshotType !== undefined && output.SnapshotType !== null ? output.SnapshotType : undefined,
-    SourceDbSnapshotIdentifier:
-      output.SourceDbSnapshotIdentifier !== undefined && output.SourceDbSnapshotIdentifier !== null
-        ? output.SourceDbSnapshotIdentifier
-        : undefined,
-    SourceRegion: output.SourceRegion !== undefined && output.SourceRegion !== null ? output.SourceRegion : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StorageType: output.StorageType !== undefined && output.StorageType !== null ? output.StorageType : undefined,
-    TdeCredentialArn:
-      output.TdeCredentialArn !== undefined && output.TdeCredentialArn !== null ? output.TdeCredentialArn : undefined,
-    Timezone: output.Timezone !== undefined && output.Timezone !== null ? output.Timezone : undefined,
-    VpcId: output.VpcId !== undefined && output.VpcId !== null ? output.VpcId : undefined,
+    SnapshotCreateTime: __expectString(output.SnapshotCreateTime),
+    SnapshotType: __expectString(output.SnapshotType),
+    SourceDbSnapshotIdentifier: __expectString(output.SourceDbSnapshotIdentifier),
+    SourceRegion: __expectString(output.SourceRegion),
+    Status: __expectString(output.Status),
+    StorageType: __expectString(output.StorageType),
+    TdeCredentialArn: __expectString(output.TdeCredentialArn),
+    Timezone: __expectString(output.Timezone),
+    VpcId: __expectString(output.VpcId),
   } as any;
 };
 
 const deserializeAws_restJson1AwsRdsDbStatusInfo = (output: any, context: __SerdeContext): AwsRdsDbStatusInfo => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Normal: output.Normal !== undefined && output.Normal !== null ? output.Normal : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusType: output.StatusType !== undefined && output.StatusType !== null ? output.StatusType : undefined,
+    Message: __expectString(output.Message),
+    Normal: __expectBoolean(output.Normal),
+    Status: __expectString(output.Status),
+    StatusType: __expectString(output.StatusType),
   } as any;
 };
 
@@ -15994,25 +15478,15 @@ const deserializeAws_restJson1AwsRdsDbStatusInfos = (output: any, context: __Ser
 
 const deserializeAws_restJson1AwsRdsDbSubnetGroup = (output: any, context: __SerdeContext): AwsRdsDbSubnetGroup => {
   return {
-    DbSubnetGroupArn:
-      output.DbSubnetGroupArn !== undefined && output.DbSubnetGroupArn !== null ? output.DbSubnetGroupArn : undefined,
-    DbSubnetGroupDescription:
-      output.DbSubnetGroupDescription !== undefined && output.DbSubnetGroupDescription !== null
-        ? output.DbSubnetGroupDescription
-        : undefined,
-    DbSubnetGroupName:
-      output.DbSubnetGroupName !== undefined && output.DbSubnetGroupName !== null
-        ? output.DbSubnetGroupName
-        : undefined,
-    SubnetGroupStatus:
-      output.SubnetGroupStatus !== undefined && output.SubnetGroupStatus !== null
-        ? output.SubnetGroupStatus
-        : undefined,
+    DbSubnetGroupArn: __expectString(output.DbSubnetGroupArn),
+    DbSubnetGroupDescription: __expectString(output.DbSubnetGroupDescription),
+    DbSubnetGroupName: __expectString(output.DbSubnetGroupName),
+    SubnetGroupStatus: __expectString(output.SubnetGroupStatus),
     Subnets:
       output.Subnets !== undefined && output.Subnets !== null
         ? deserializeAws_restJson1AwsRdsDbSubnetGroupSubnets(output.Subnets, context)
         : undefined,
-    VpcId: output.VpcId !== undefined && output.VpcId !== null ? output.VpcId : undefined,
+    VpcId: __expectString(output.VpcId),
   } as any;
 };
 
@@ -16025,9 +15499,8 @@ const deserializeAws_restJson1AwsRdsDbSubnetGroupSubnet = (
       output.SubnetAvailabilityZone !== undefined && output.SubnetAvailabilityZone !== null
         ? deserializeAws_restJson1AwsRdsDbSubnetGroupSubnetAvailabilityZone(output.SubnetAvailabilityZone, context)
         : undefined,
-    SubnetIdentifier:
-      output.SubnetIdentifier !== undefined && output.SubnetIdentifier !== null ? output.SubnetIdentifier : undefined,
-    SubnetStatus: output.SubnetStatus !== undefined && output.SubnetStatus !== null ? output.SubnetStatus : undefined,
+    SubnetIdentifier: __expectString(output.SubnetIdentifier),
+    SubnetStatus: __expectString(output.SubnetStatus),
   } as any;
 };
 
@@ -16036,7 +15509,7 @@ const deserializeAws_restJson1AwsRdsDbSubnetGroupSubnetAvailabilityZone = (
   context: __SerdeContext
 ): AwsRdsDbSubnetGroupSubnetAvailabilityZone => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -16075,11 +15548,9 @@ const deserializeAws_restJson1AwsRedshiftClusterClusterNode = (
   context: __SerdeContext
 ): AwsRedshiftClusterClusterNode => {
   return {
-    NodeRole: output.NodeRole !== undefined && output.NodeRole !== null ? output.NodeRole : undefined,
-    PrivateIpAddress:
-      output.PrivateIpAddress !== undefined && output.PrivateIpAddress !== null ? output.PrivateIpAddress : undefined,
-    PublicIpAddress:
-      output.PublicIpAddress !== undefined && output.PublicIpAddress !== null ? output.PublicIpAddress : undefined,
+    NodeRole: __expectString(output.NodeRole),
+    PrivateIpAddress: __expectString(output.PrivateIpAddress),
+    PublicIpAddress: __expectString(output.PublicIpAddress),
   } as any;
 };
 
@@ -16109,14 +15580,8 @@ const deserializeAws_restJson1AwsRedshiftClusterClusterParameterGroup = (
             context
           )
         : undefined,
-    ParameterApplyStatus:
-      output.ParameterApplyStatus !== undefined && output.ParameterApplyStatus !== null
-        ? output.ParameterApplyStatus
-        : undefined,
-    ParameterGroupName:
-      output.ParameterGroupName !== undefined && output.ParameterGroupName !== null
-        ? output.ParameterGroupName
-        : undefined,
+    ParameterApplyStatus: __expectString(output.ParameterApplyStatus),
+    ParameterGroupName: __expectString(output.ParameterGroupName),
   } as any;
 };
 
@@ -16139,16 +15604,9 @@ const deserializeAws_restJson1AwsRedshiftClusterClusterParameterStatus = (
   context: __SerdeContext
 ): AwsRedshiftClusterClusterParameterStatus => {
   return {
-    ParameterApplyErrorDescription:
-      output.ParameterApplyErrorDescription !== undefined && output.ParameterApplyErrorDescription !== null
-        ? output.ParameterApplyErrorDescription
-        : undefined,
-    ParameterApplyStatus:
-      output.ParameterApplyStatus !== undefined && output.ParameterApplyStatus !== null
-        ? output.ParameterApplyStatus
-        : undefined,
-    ParameterName:
-      output.ParameterName !== undefined && output.ParameterName !== null ? output.ParameterName : undefined,
+    ParameterApplyErrorDescription: __expectString(output.ParameterApplyErrorDescription),
+    ParameterApplyStatus: __expectString(output.ParameterApplyStatus),
+    ParameterName: __expectString(output.ParameterName),
   } as any;
 };
 
@@ -16171,11 +15629,8 @@ const deserializeAws_restJson1AwsRedshiftClusterClusterSecurityGroup = (
   context: __SerdeContext
 ): AwsRedshiftClusterClusterSecurityGroup => {
   return {
-    ClusterSecurityGroupName:
-      output.ClusterSecurityGroupName !== undefined && output.ClusterSecurityGroupName !== null
-        ? output.ClusterSecurityGroupName
-        : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    ClusterSecurityGroupName: __expectString(output.ClusterSecurityGroupName),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -16198,20 +15653,10 @@ const deserializeAws_restJson1AwsRedshiftClusterClusterSnapshotCopyStatus = (
   context: __SerdeContext
 ): AwsRedshiftClusterClusterSnapshotCopyStatus => {
   return {
-    DestinationRegion:
-      output.DestinationRegion !== undefined && output.DestinationRegion !== null
-        ? output.DestinationRegion
-        : undefined,
-    ManualSnapshotRetentionPeriod:
-      output.ManualSnapshotRetentionPeriod !== undefined && output.ManualSnapshotRetentionPeriod !== null
-        ? output.ManualSnapshotRetentionPeriod
-        : undefined,
-    RetentionPeriod:
-      output.RetentionPeriod !== undefined && output.RetentionPeriod !== null ? output.RetentionPeriod : undefined,
-    SnapshotCopyGrantName:
-      output.SnapshotCopyGrantName !== undefined && output.SnapshotCopyGrantName !== null
-        ? output.SnapshotCopyGrantName
-        : undefined,
+    DestinationRegion: __expectString(output.DestinationRegion),
+    ManualSnapshotRetentionPeriod: __expectNumber(output.ManualSnapshotRetentionPeriod),
+    RetentionPeriod: __expectNumber(output.RetentionPeriod),
+    SnapshotCopyGrantName: __expectString(output.SnapshotCopyGrantName),
   } as any;
 };
 
@@ -16220,18 +15665,9 @@ const deserializeAws_restJson1AwsRedshiftClusterDeferredMaintenanceWindow = (
   context: __SerdeContext
 ): AwsRedshiftClusterDeferredMaintenanceWindow => {
   return {
-    DeferMaintenanceEndTime:
-      output.DeferMaintenanceEndTime !== undefined && output.DeferMaintenanceEndTime !== null
-        ? output.DeferMaintenanceEndTime
-        : undefined,
-    DeferMaintenanceIdentifier:
-      output.DeferMaintenanceIdentifier !== undefined && output.DeferMaintenanceIdentifier !== null
-        ? output.DeferMaintenanceIdentifier
-        : undefined,
-    DeferMaintenanceStartTime:
-      output.DeferMaintenanceStartTime !== undefined && output.DeferMaintenanceStartTime !== null
-        ? output.DeferMaintenanceStartTime
-        : undefined,
+    DeferMaintenanceEndTime: __expectString(output.DeferMaintenanceEndTime),
+    DeferMaintenanceIdentifier: __expectString(output.DeferMaintenanceIdentifier),
+    DeferMaintenanceStartTime: __expectString(output.DeferMaintenanceStartTime),
   } as any;
 };
 
@@ -16254,28 +15690,12 @@ const deserializeAws_restJson1AwsRedshiftClusterDetails = (
   context: __SerdeContext
 ): AwsRedshiftClusterDetails => {
   return {
-    AllowVersionUpgrade:
-      output.AllowVersionUpgrade !== undefined && output.AllowVersionUpgrade !== null
-        ? output.AllowVersionUpgrade
-        : undefined,
-    AutomatedSnapshotRetentionPeriod:
-      output.AutomatedSnapshotRetentionPeriod !== undefined && output.AutomatedSnapshotRetentionPeriod !== null
-        ? output.AutomatedSnapshotRetentionPeriod
-        : undefined,
-    AvailabilityZone:
-      output.AvailabilityZone !== undefined && output.AvailabilityZone !== null ? output.AvailabilityZone : undefined,
-    ClusterAvailabilityStatus:
-      output.ClusterAvailabilityStatus !== undefined && output.ClusterAvailabilityStatus !== null
-        ? output.ClusterAvailabilityStatus
-        : undefined,
-    ClusterCreateTime:
-      output.ClusterCreateTime !== undefined && output.ClusterCreateTime !== null
-        ? output.ClusterCreateTime
-        : undefined,
-    ClusterIdentifier:
-      output.ClusterIdentifier !== undefined && output.ClusterIdentifier !== null
-        ? output.ClusterIdentifier
-        : undefined,
+    AllowVersionUpgrade: __expectBoolean(output.AllowVersionUpgrade),
+    AutomatedSnapshotRetentionPeriod: __expectNumber(output.AutomatedSnapshotRetentionPeriod),
+    AvailabilityZone: __expectString(output.AvailabilityZone),
+    ClusterAvailabilityStatus: __expectString(output.ClusterAvailabilityStatus),
+    ClusterCreateTime: __expectString(output.ClusterCreateTime),
+    ClusterIdentifier: __expectString(output.ClusterIdentifier),
     ClusterNodes:
       output.ClusterNodes !== undefined && output.ClusterNodes !== null
         ? deserializeAws_restJson1AwsRedshiftClusterClusterNodes(output.ClusterNodes, context)
@@ -16284,12 +15704,8 @@ const deserializeAws_restJson1AwsRedshiftClusterDetails = (
       output.ClusterParameterGroups !== undefined && output.ClusterParameterGroups !== null
         ? deserializeAws_restJson1AwsRedshiftClusterClusterParameterGroups(output.ClusterParameterGroups, context)
         : undefined,
-    ClusterPublicKey:
-      output.ClusterPublicKey !== undefined && output.ClusterPublicKey !== null ? output.ClusterPublicKey : undefined,
-    ClusterRevisionNumber:
-      output.ClusterRevisionNumber !== undefined && output.ClusterRevisionNumber !== null
-        ? output.ClusterRevisionNumber
-        : undefined,
+    ClusterPublicKey: __expectString(output.ClusterPublicKey),
+    ClusterRevisionNumber: __expectString(output.ClusterRevisionNumber),
     ClusterSecurityGroups:
       output.ClusterSecurityGroups !== undefined && output.ClusterSecurityGroups !== null
         ? deserializeAws_restJson1AwsRedshiftClusterClusterSecurityGroups(output.ClusterSecurityGroups, context)
@@ -16298,15 +15714,10 @@ const deserializeAws_restJson1AwsRedshiftClusterDetails = (
       output.ClusterSnapshotCopyStatus !== undefined && output.ClusterSnapshotCopyStatus !== null
         ? deserializeAws_restJson1AwsRedshiftClusterClusterSnapshotCopyStatus(output.ClusterSnapshotCopyStatus, context)
         : undefined,
-    ClusterStatus:
-      output.ClusterStatus !== undefined && output.ClusterStatus !== null ? output.ClusterStatus : undefined,
-    ClusterSubnetGroupName:
-      output.ClusterSubnetGroupName !== undefined && output.ClusterSubnetGroupName !== null
-        ? output.ClusterSubnetGroupName
-        : undefined,
-    ClusterVersion:
-      output.ClusterVersion !== undefined && output.ClusterVersion !== null ? output.ClusterVersion : undefined,
-    DBName: output.DBName !== undefined && output.DBName !== null ? output.DBName : undefined,
+    ClusterStatus: __expectString(output.ClusterStatus),
+    ClusterSubnetGroupName: __expectString(output.ClusterSubnetGroupName),
+    ClusterVersion: __expectString(output.ClusterVersion),
+    DBName: __expectString(output.DBName),
     DeferredMaintenanceWindows:
       output.DeferredMaintenanceWindows !== undefined && output.DeferredMaintenanceWindows !== null
         ? deserializeAws_restJson1AwsRedshiftClusterDeferredMaintenanceWindows(
@@ -16318,28 +15729,15 @@ const deserializeAws_restJson1AwsRedshiftClusterDetails = (
       output.ElasticIpStatus !== undefined && output.ElasticIpStatus !== null
         ? deserializeAws_restJson1AwsRedshiftClusterElasticIpStatus(output.ElasticIpStatus, context)
         : undefined,
-    ElasticResizeNumberOfNodeOptions:
-      output.ElasticResizeNumberOfNodeOptions !== undefined && output.ElasticResizeNumberOfNodeOptions !== null
-        ? output.ElasticResizeNumberOfNodeOptions
-        : undefined,
-    Encrypted: output.Encrypted !== undefined && output.Encrypted !== null ? output.Encrypted : undefined,
+    ElasticResizeNumberOfNodeOptions: __expectString(output.ElasticResizeNumberOfNodeOptions),
+    Encrypted: __expectBoolean(output.Encrypted),
     Endpoint:
       output.Endpoint !== undefined && output.Endpoint !== null
         ? deserializeAws_restJson1AwsRedshiftClusterEndpoint(output.Endpoint, context)
         : undefined,
-    EnhancedVpcRouting:
-      output.EnhancedVpcRouting !== undefined && output.EnhancedVpcRouting !== null
-        ? output.EnhancedVpcRouting
-        : undefined,
-    ExpectedNextSnapshotScheduleTime:
-      output.ExpectedNextSnapshotScheduleTime !== undefined && output.ExpectedNextSnapshotScheduleTime !== null
-        ? output.ExpectedNextSnapshotScheduleTime
-        : undefined,
-    ExpectedNextSnapshotScheduleTimeStatus:
-      output.ExpectedNextSnapshotScheduleTimeStatus !== undefined &&
-      output.ExpectedNextSnapshotScheduleTimeStatus !== null
-        ? output.ExpectedNextSnapshotScheduleTimeStatus
-        : undefined,
+    EnhancedVpcRouting: __expectBoolean(output.EnhancedVpcRouting),
+    ExpectedNextSnapshotScheduleTime: __expectString(output.ExpectedNextSnapshotScheduleTime),
+    ExpectedNextSnapshotScheduleTimeStatus: __expectString(output.ExpectedNextSnapshotScheduleTimeStatus),
     HsmStatus:
       output.HsmStatus !== undefined && output.HsmStatus !== null
         ? deserializeAws_restJson1AwsRedshiftClusterHsmStatus(output.HsmStatus, context)
@@ -16348,24 +15746,13 @@ const deserializeAws_restJson1AwsRedshiftClusterDetails = (
       output.IamRoles !== undefined && output.IamRoles !== null
         ? deserializeAws_restJson1AwsRedshiftClusterIamRoles(output.IamRoles, context)
         : undefined,
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
-    MaintenanceTrackName:
-      output.MaintenanceTrackName !== undefined && output.MaintenanceTrackName !== null
-        ? output.MaintenanceTrackName
-        : undefined,
-    ManualSnapshotRetentionPeriod:
-      output.ManualSnapshotRetentionPeriod !== undefined && output.ManualSnapshotRetentionPeriod !== null
-        ? output.ManualSnapshotRetentionPeriod
-        : undefined,
-    MasterUsername:
-      output.MasterUsername !== undefined && output.MasterUsername !== null ? output.MasterUsername : undefined,
-    NextMaintenanceWindowStartTime:
-      output.NextMaintenanceWindowStartTime !== undefined && output.NextMaintenanceWindowStartTime !== null
-        ? output.NextMaintenanceWindowStartTime
-        : undefined,
-    NodeType: output.NodeType !== undefined && output.NodeType !== null ? output.NodeType : undefined,
-    NumberOfNodes:
-      output.NumberOfNodes !== undefined && output.NumberOfNodes !== null ? output.NumberOfNodes : undefined,
+    KmsKeyId: __expectString(output.KmsKeyId),
+    MaintenanceTrackName: __expectString(output.MaintenanceTrackName),
+    ManualSnapshotRetentionPeriod: __expectNumber(output.ManualSnapshotRetentionPeriod),
+    MasterUsername: __expectString(output.MasterUsername),
+    NextMaintenanceWindowStartTime: __expectString(output.NextMaintenanceWindowStartTime),
+    NodeType: __expectString(output.NodeType),
+    NumberOfNodes: __expectNumber(output.NumberOfNodes),
     PendingActions:
       output.PendingActions !== undefined && output.PendingActions !== null
         ? deserializeAws_restJson1StringList(output.PendingActions, context)
@@ -16374,14 +15761,8 @@ const deserializeAws_restJson1AwsRedshiftClusterDetails = (
       output.PendingModifiedValues !== undefined && output.PendingModifiedValues !== null
         ? deserializeAws_restJson1AwsRedshiftClusterPendingModifiedValues(output.PendingModifiedValues, context)
         : undefined,
-    PreferredMaintenanceWindow:
-      output.PreferredMaintenanceWindow !== undefined && output.PreferredMaintenanceWindow !== null
-        ? output.PreferredMaintenanceWindow
-        : undefined,
-    PubliclyAccessible:
-      output.PubliclyAccessible !== undefined && output.PubliclyAccessible !== null
-        ? output.PubliclyAccessible
-        : undefined,
+    PreferredMaintenanceWindow: __expectString(output.PreferredMaintenanceWindow),
+    PubliclyAccessible: __expectBoolean(output.PubliclyAccessible),
     ResizeInfo:
       output.ResizeInfo !== undefined && output.ResizeInfo !== null
         ? deserializeAws_restJson1AwsRedshiftClusterResizeInfo(output.ResizeInfo, context)
@@ -16390,15 +15771,9 @@ const deserializeAws_restJson1AwsRedshiftClusterDetails = (
       output.RestoreStatus !== undefined && output.RestoreStatus !== null
         ? deserializeAws_restJson1AwsRedshiftClusterRestoreStatus(output.RestoreStatus, context)
         : undefined,
-    SnapshotScheduleIdentifier:
-      output.SnapshotScheduleIdentifier !== undefined && output.SnapshotScheduleIdentifier !== null
-        ? output.SnapshotScheduleIdentifier
-        : undefined,
-    SnapshotScheduleState:
-      output.SnapshotScheduleState !== undefined && output.SnapshotScheduleState !== null
-        ? output.SnapshotScheduleState
-        : undefined,
-    VpcId: output.VpcId !== undefined && output.VpcId !== null ? output.VpcId : undefined,
+    SnapshotScheduleIdentifier: __expectString(output.SnapshotScheduleIdentifier),
+    SnapshotScheduleState: __expectString(output.SnapshotScheduleState),
+    VpcId: __expectString(output.VpcId),
     VpcSecurityGroups:
       output.VpcSecurityGroups !== undefined && output.VpcSecurityGroups !== null
         ? deserializeAws_restJson1AwsRedshiftClusterVpcSecurityGroups(output.VpcSecurityGroups, context)
@@ -16411,8 +15786,8 @@ const deserializeAws_restJson1AwsRedshiftClusterElasticIpStatus = (
   context: __SerdeContext
 ): AwsRedshiftClusterElasticIpStatus => {
   return {
-    ElasticIp: output.ElasticIp !== undefined && output.ElasticIp !== null ? output.ElasticIp : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    ElasticIp: __expectString(output.ElasticIp),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -16421,8 +15796,8 @@ const deserializeAws_restJson1AwsRedshiftClusterEndpoint = (
   context: __SerdeContext
 ): AwsRedshiftClusterEndpoint => {
   return {
-    Address: output.Address !== undefined && output.Address !== null ? output.Address : undefined,
-    Port: output.Port !== undefined && output.Port !== null ? output.Port : undefined,
+    Address: __expectString(output.Address),
+    Port: __expectNumber(output.Port),
   } as any;
 };
 
@@ -16431,15 +15806,9 @@ const deserializeAws_restJson1AwsRedshiftClusterHsmStatus = (
   context: __SerdeContext
 ): AwsRedshiftClusterHsmStatus => {
   return {
-    HsmClientCertificateIdentifier:
-      output.HsmClientCertificateIdentifier !== undefined && output.HsmClientCertificateIdentifier !== null
-        ? output.HsmClientCertificateIdentifier
-        : undefined,
-    HsmConfigurationIdentifier:
-      output.HsmConfigurationIdentifier !== undefined && output.HsmConfigurationIdentifier !== null
-        ? output.HsmConfigurationIdentifier
-        : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    HsmClientCertificateIdentifier: __expectString(output.HsmClientCertificateIdentifier),
+    HsmConfigurationIdentifier: __expectString(output.HsmConfigurationIdentifier),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -16448,8 +15817,8 @@ const deserializeAws_restJson1AwsRedshiftClusterIamRole = (
   context: __SerdeContext
 ): AwsRedshiftClusterIamRole => {
   return {
-    ApplyStatus: output.ApplyStatus !== undefined && output.ApplyStatus !== null ? output.ApplyStatus : undefined,
-    IamRoleArn: output.IamRoleArn !== undefined && output.IamRoleArn !== null ? output.IamRoleArn : undefined,
+    ApplyStatus: __expectString(output.ApplyStatus),
+    IamRoleArn: __expectString(output.IamRoleArn),
   } as any;
 };
 
@@ -16472,38 +15841,17 @@ const deserializeAws_restJson1AwsRedshiftClusterPendingModifiedValues = (
   context: __SerdeContext
 ): AwsRedshiftClusterPendingModifiedValues => {
   return {
-    AutomatedSnapshotRetentionPeriod:
-      output.AutomatedSnapshotRetentionPeriod !== undefined && output.AutomatedSnapshotRetentionPeriod !== null
-        ? output.AutomatedSnapshotRetentionPeriod
-        : undefined,
-    ClusterIdentifier:
-      output.ClusterIdentifier !== undefined && output.ClusterIdentifier !== null
-        ? output.ClusterIdentifier
-        : undefined,
-    ClusterType: output.ClusterType !== undefined && output.ClusterType !== null ? output.ClusterType : undefined,
-    ClusterVersion:
-      output.ClusterVersion !== undefined && output.ClusterVersion !== null ? output.ClusterVersion : undefined,
-    EncryptionType:
-      output.EncryptionType !== undefined && output.EncryptionType !== null ? output.EncryptionType : undefined,
-    EnhancedVpcRouting:
-      output.EnhancedVpcRouting !== undefined && output.EnhancedVpcRouting !== null
-        ? output.EnhancedVpcRouting
-        : undefined,
-    MaintenanceTrackName:
-      output.MaintenanceTrackName !== undefined && output.MaintenanceTrackName !== null
-        ? output.MaintenanceTrackName
-        : undefined,
-    MasterUserPassword:
-      output.MasterUserPassword !== undefined && output.MasterUserPassword !== null
-        ? output.MasterUserPassword
-        : undefined,
-    NodeType: output.NodeType !== undefined && output.NodeType !== null ? output.NodeType : undefined,
-    NumberOfNodes:
-      output.NumberOfNodes !== undefined && output.NumberOfNodes !== null ? output.NumberOfNodes : undefined,
-    PubliclyAccessible:
-      output.PubliclyAccessible !== undefined && output.PubliclyAccessible !== null
-        ? output.PubliclyAccessible
-        : undefined,
+    AutomatedSnapshotRetentionPeriod: __expectNumber(output.AutomatedSnapshotRetentionPeriod),
+    ClusterIdentifier: __expectString(output.ClusterIdentifier),
+    ClusterType: __expectString(output.ClusterType),
+    ClusterVersion: __expectString(output.ClusterVersion),
+    EncryptionType: __expectString(output.EncryptionType),
+    EnhancedVpcRouting: __expectBoolean(output.EnhancedVpcRouting),
+    MaintenanceTrackName: __expectString(output.MaintenanceTrackName),
+    MasterUserPassword: __expectString(output.MasterUserPassword),
+    NodeType: __expectString(output.NodeType),
+    NumberOfNodes: __expectNumber(output.NumberOfNodes),
+    PubliclyAccessible: __expectBoolean(output.PubliclyAccessible),
   } as any;
 };
 
@@ -16512,11 +15860,8 @@ const deserializeAws_restJson1AwsRedshiftClusterResizeInfo = (
   context: __SerdeContext
 ): AwsRedshiftClusterResizeInfo => {
   return {
-    AllowCancelResize:
-      output.AllowCancelResize !== undefined && output.AllowCancelResize !== null
-        ? output.AllowCancelResize
-        : undefined,
-    ResizeType: output.ResizeType !== undefined && output.ResizeType !== null ? output.ResizeType : undefined,
+    AllowCancelResize: __expectBoolean(output.AllowCancelResize),
+    ResizeType: __expectString(output.ResizeType),
   } as any;
 };
 
@@ -16525,28 +15870,12 @@ const deserializeAws_restJson1AwsRedshiftClusterRestoreStatus = (
   context: __SerdeContext
 ): AwsRedshiftClusterRestoreStatus => {
   return {
-    CurrentRestoreRateInMegaBytesPerSecond:
-      output.CurrentRestoreRateInMegaBytesPerSecond !== undefined &&
-      output.CurrentRestoreRateInMegaBytesPerSecond !== null
-        ? output.CurrentRestoreRateInMegaBytesPerSecond
-        : undefined,
-    ElapsedTimeInSeconds:
-      output.ElapsedTimeInSeconds !== undefined && output.ElapsedTimeInSeconds !== null
-        ? output.ElapsedTimeInSeconds
-        : undefined,
-    EstimatedTimeToCompletionInSeconds:
-      output.EstimatedTimeToCompletionInSeconds !== undefined && output.EstimatedTimeToCompletionInSeconds !== null
-        ? output.EstimatedTimeToCompletionInSeconds
-        : undefined,
-    ProgressInMegaBytes:
-      output.ProgressInMegaBytes !== undefined && output.ProgressInMegaBytes !== null
-        ? output.ProgressInMegaBytes
-        : undefined,
-    SnapshotSizeInMegaBytes:
-      output.SnapshotSizeInMegaBytes !== undefined && output.SnapshotSizeInMegaBytes !== null
-        ? output.SnapshotSizeInMegaBytes
-        : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    CurrentRestoreRateInMegaBytesPerSecond: __expectNumber(output.CurrentRestoreRateInMegaBytesPerSecond),
+    ElapsedTimeInSeconds: __expectNumber(output.ElapsedTimeInSeconds),
+    EstimatedTimeToCompletionInSeconds: __expectNumber(output.EstimatedTimeToCompletionInSeconds),
+    ProgressInMegaBytes: __expectNumber(output.ProgressInMegaBytes),
+    SnapshotSizeInMegaBytes: __expectNumber(output.SnapshotSizeInMegaBytes),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -16555,11 +15884,8 @@ const deserializeAws_restJson1AwsRedshiftClusterVpcSecurityGroup = (
   context: __SerdeContext
 ): AwsRedshiftClusterVpcSecurityGroup => {
   return {
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    VpcSecurityGroupId:
-      output.VpcSecurityGroupId !== undefined && output.VpcSecurityGroupId !== null
-        ? output.VpcSecurityGroupId
-        : undefined,
+    Status: __expectString(output.Status),
+    VpcSecurityGroupId: __expectString(output.VpcSecurityGroupId),
   } as any;
 };
 
@@ -16582,26 +15908,18 @@ const deserializeAws_restJson1AwsS3AccountPublicAccessBlockDetails = (
   context: __SerdeContext
 ): AwsS3AccountPublicAccessBlockDetails => {
   return {
-    BlockPublicAcls:
-      output.BlockPublicAcls !== undefined && output.BlockPublicAcls !== null ? output.BlockPublicAcls : undefined,
-    BlockPublicPolicy:
-      output.BlockPublicPolicy !== undefined && output.BlockPublicPolicy !== null
-        ? output.BlockPublicPolicy
-        : undefined,
-    IgnorePublicAcls:
-      output.IgnorePublicAcls !== undefined && output.IgnorePublicAcls !== null ? output.IgnorePublicAcls : undefined,
-    RestrictPublicBuckets:
-      output.RestrictPublicBuckets !== undefined && output.RestrictPublicBuckets !== null
-        ? output.RestrictPublicBuckets
-        : undefined,
+    BlockPublicAcls: __expectBoolean(output.BlockPublicAcls),
+    BlockPublicPolicy: __expectBoolean(output.BlockPublicPolicy),
+    IgnorePublicAcls: __expectBoolean(output.IgnorePublicAcls),
+    RestrictPublicBuckets: __expectBoolean(output.RestrictPublicBuckets),
   } as any;
 };
 
 const deserializeAws_restJson1AwsS3BucketDetails = (output: any, context: __SerdeContext): AwsS3BucketDetails => {
   return {
-    CreatedAt: output.CreatedAt !== undefined && output.CreatedAt !== null ? output.CreatedAt : undefined,
-    OwnerId: output.OwnerId !== undefined && output.OwnerId !== null ? output.OwnerId : undefined,
-    OwnerName: output.OwnerName !== undefined && output.OwnerName !== null ? output.OwnerName : undefined,
+    CreatedAt: __expectString(output.CreatedAt),
+    OwnerId: __expectString(output.OwnerId),
+    OwnerName: __expectString(output.OwnerName),
     PublicAccessBlockConfiguration:
       output.PublicAccessBlockConfiguration !== undefined && output.PublicAccessBlockConfiguration !== null
         ? deserializeAws_restJson1AwsS3AccountPublicAccessBlockDetails(output.PublicAccessBlockConfiguration, context)
@@ -16621,9 +15939,8 @@ const deserializeAws_restJson1AwsS3BucketServerSideEncryptionByDefault = (
   context: __SerdeContext
 ): AwsS3BucketServerSideEncryptionByDefault => {
   return {
-    KMSMasterKeyID:
-      output.KMSMasterKeyID !== undefined && output.KMSMasterKeyID !== null ? output.KMSMasterKeyID : undefined,
-    SSEAlgorithm: output.SSEAlgorithm !== undefined && output.SSEAlgorithm !== null ? output.SSEAlgorithm : undefined,
+    KMSMasterKeyID: __expectString(output.KMSMasterKeyID),
+    SSEAlgorithm: __expectString(output.SSEAlgorithm),
   } as any;
 };
 
@@ -16670,15 +15987,12 @@ const deserializeAws_restJson1AwsS3BucketServerSideEncryptionRules = (
 
 const deserializeAws_restJson1AwsS3ObjectDetails = (output: any, context: __SerdeContext): AwsS3ObjectDetails => {
   return {
-    ContentType: output.ContentType !== undefined && output.ContentType !== null ? output.ContentType : undefined,
-    ETag: output.ETag !== undefined && output.ETag !== null ? output.ETag : undefined,
-    LastModified: output.LastModified !== undefined && output.LastModified !== null ? output.LastModified : undefined,
-    SSEKMSKeyId: output.SSEKMSKeyId !== undefined && output.SSEKMSKeyId !== null ? output.SSEKMSKeyId : undefined,
-    ServerSideEncryption:
-      output.ServerSideEncryption !== undefined && output.ServerSideEncryption !== null
-        ? output.ServerSideEncryption
-        : undefined,
-    VersionId: output.VersionId !== undefined && output.VersionId !== null ? output.VersionId : undefined,
+    ContentType: __expectString(output.ContentType),
+    ETag: __expectString(output.ETag),
+    LastModified: __expectString(output.LastModified),
+    SSEKMSKeyId: __expectString(output.SSEKMSKeyId),
+    ServerSideEncryption: __expectString(output.ServerSideEncryption),
+    VersionId: __expectString(output.VersionId),
   } as any;
 };
 
@@ -16687,20 +16001,13 @@ const deserializeAws_restJson1AwsSecretsManagerSecretDetails = (
   context: __SerdeContext
 ): AwsSecretsManagerSecretDetails => {
   return {
-    Deleted: output.Deleted !== undefined && output.Deleted !== null ? output.Deleted : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    RotationEnabled:
-      output.RotationEnabled !== undefined && output.RotationEnabled !== null ? output.RotationEnabled : undefined,
-    RotationLambdaArn:
-      output.RotationLambdaArn !== undefined && output.RotationLambdaArn !== null
-        ? output.RotationLambdaArn
-        : undefined,
-    RotationOccurredWithinFrequency:
-      output.RotationOccurredWithinFrequency !== undefined && output.RotationOccurredWithinFrequency !== null
-        ? output.RotationOccurredWithinFrequency
-        : undefined,
+    Deleted: __expectBoolean(output.Deleted),
+    Description: __expectString(output.Description),
+    KmsKeyId: __expectString(output.KmsKeyId),
+    Name: __expectString(output.Name),
+    RotationEnabled: __expectBoolean(output.RotationEnabled),
+    RotationLambdaArn: __expectString(output.RotationLambdaArn),
+    RotationOccurredWithinFrequency: __expectBoolean(output.RotationOccurredWithinFrequency),
     RotationRules:
       output.RotationRules !== undefined && output.RotationRules !== null
         ? deserializeAws_restJson1AwsSecretsManagerSecretRotationRules(output.RotationRules, context)
@@ -16713,10 +16020,7 @@ const deserializeAws_restJson1AwsSecretsManagerSecretRotationRules = (
   context: __SerdeContext
 ): AwsSecretsManagerSecretRotationRules => {
   return {
-    AutomaticallyAfterDays:
-      output.AutomaticallyAfterDays !== undefined && output.AutomaticallyAfterDays !== null
-        ? output.AutomaticallyAfterDays
-        : undefined,
+    AutomaticallyAfterDays: __expectNumber(output.AutomaticallyAfterDays),
   } as any;
 };
 
@@ -16726,25 +16030,23 @@ const deserializeAws_restJson1AwsSecurityFinding = (output: any, context: __Serd
       output.Action !== undefined && output.Action !== null
         ? deserializeAws_restJson1Action(output.Action, context)
         : undefined,
-    AwsAccountId: output.AwsAccountId !== undefined && output.AwsAccountId !== null ? output.AwsAccountId : undefined,
+    AwsAccountId: __expectString(output.AwsAccountId),
     Compliance:
       output.Compliance !== undefined && output.Compliance !== null
         ? deserializeAws_restJson1Compliance(output.Compliance, context)
         : undefined,
-    Confidence: output.Confidence !== undefined && output.Confidence !== null ? output.Confidence : undefined,
-    CreatedAt: output.CreatedAt !== undefined && output.CreatedAt !== null ? output.CreatedAt : undefined,
-    Criticality: output.Criticality !== undefined && output.Criticality !== null ? output.Criticality : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Confidence: __expectNumber(output.Confidence),
+    CreatedAt: __expectString(output.CreatedAt),
+    Criticality: __expectNumber(output.Criticality),
+    Description: __expectString(output.Description),
     FindingProviderFields:
       output.FindingProviderFields !== undefined && output.FindingProviderFields !== null
         ? deserializeAws_restJson1FindingProviderFields(output.FindingProviderFields, context)
         : undefined,
-    FirstObservedAt:
-      output.FirstObservedAt !== undefined && output.FirstObservedAt !== null ? output.FirstObservedAt : undefined,
-    GeneratorId: output.GeneratorId !== undefined && output.GeneratorId !== null ? output.GeneratorId : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    LastObservedAt:
-      output.LastObservedAt !== undefined && output.LastObservedAt !== null ? output.LastObservedAt : undefined,
+    FirstObservedAt: __expectString(output.FirstObservedAt),
+    GeneratorId: __expectString(output.GeneratorId),
+    Id: __expectString(output.Id),
+    LastObservedAt: __expectString(output.LastObservedAt),
     Malware:
       output.Malware !== undefined && output.Malware !== null
         ? deserializeAws_restJson1MalwareList(output.Malware, context)
@@ -16769,12 +16071,12 @@ const deserializeAws_restJson1AwsSecurityFinding = (output: any, context: __Serd
       output.Process !== undefined && output.Process !== null
         ? deserializeAws_restJson1ProcessDetails(output.Process, context)
         : undefined,
-    ProductArn: output.ProductArn !== undefined && output.ProductArn !== null ? output.ProductArn : undefined,
+    ProductArn: __expectString(output.ProductArn),
     ProductFields:
       output.ProductFields !== undefined && output.ProductFields !== null
         ? deserializeAws_restJson1FieldMap(output.ProductFields, context)
         : undefined,
-    RecordState: output.RecordState !== undefined && output.RecordState !== null ? output.RecordState : undefined,
+    RecordState: __expectString(output.RecordState),
     RelatedFindings:
       output.RelatedFindings !== undefined && output.RelatedFindings !== null
         ? deserializeAws_restJson1RelatedFindingList(output.RelatedFindings, context)
@@ -16787,31 +16089,27 @@ const deserializeAws_restJson1AwsSecurityFinding = (output: any, context: __Serd
       output.Resources !== undefined && output.Resources !== null
         ? deserializeAws_restJson1ResourceList(output.Resources, context)
         : undefined,
-    SchemaVersion:
-      output.SchemaVersion !== undefined && output.SchemaVersion !== null ? output.SchemaVersion : undefined,
+    SchemaVersion: __expectString(output.SchemaVersion),
     Severity:
       output.Severity !== undefined && output.Severity !== null
         ? deserializeAws_restJson1Severity(output.Severity, context)
         : undefined,
-    SourceUrl: output.SourceUrl !== undefined && output.SourceUrl !== null ? output.SourceUrl : undefined,
+    SourceUrl: __expectString(output.SourceUrl),
     ThreatIntelIndicators:
       output.ThreatIntelIndicators !== undefined && output.ThreatIntelIndicators !== null
         ? deserializeAws_restJson1ThreatIntelIndicatorList(output.ThreatIntelIndicators, context)
         : undefined,
-    Title: output.Title !== undefined && output.Title !== null ? output.Title : undefined,
+    Title: __expectString(output.Title),
     Types:
       output.Types !== undefined && output.Types !== null
         ? deserializeAws_restJson1TypeList(output.Types, context)
         : undefined,
-    UpdatedAt: output.UpdatedAt !== undefined && output.UpdatedAt !== null ? output.UpdatedAt : undefined,
+    UpdatedAt: __expectString(output.UpdatedAt),
     UserDefinedFields:
       output.UserDefinedFields !== undefined && output.UserDefinedFields !== null
         ? deserializeAws_restJson1FieldMap(output.UserDefinedFields, context)
         : undefined,
-    VerificationState:
-      output.VerificationState !== undefined && output.VerificationState !== null
-        ? output.VerificationState
-        : undefined,
+    VerificationState: __expectString(output.VerificationState),
     Vulnerabilities:
       output.Vulnerabilities !== undefined && output.Vulnerabilities !== null
         ? deserializeAws_restJson1VulnerabilityList(output.Vulnerabilities, context)
@@ -16820,8 +16118,7 @@ const deserializeAws_restJson1AwsSecurityFinding = (output: any, context: __Serd
       output.Workflow !== undefined && output.Workflow !== null
         ? deserializeAws_restJson1Workflow(output.Workflow, context)
         : undefined,
-    WorkflowState:
-      output.WorkflowState !== undefined && output.WorkflowState !== null ? output.WorkflowState : undefined,
+    WorkflowState: __expectString(output.WorkflowState),
   } as any;
 };
 
@@ -17206,8 +16503,8 @@ const deserializeAws_restJson1AwsSecurityFindingIdentifier = (
   context: __SerdeContext
 ): AwsSecurityFindingIdentifier => {
   return {
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    ProductArn: output.ProductArn !== undefined && output.ProductArn !== null ? output.ProductArn : undefined,
+    Id: __expectString(output.Id),
+    ProductArn: __expectString(output.ProductArn),
   } as any;
 };
 
@@ -17238,14 +16535,13 @@ const deserializeAws_restJson1AwsSecurityFindingList = (output: any, context: __
 
 const deserializeAws_restJson1AwsSnsTopicDetails = (output: any, context: __SerdeContext): AwsSnsTopicDetails => {
   return {
-    KmsMasterKeyId:
-      output.KmsMasterKeyId !== undefined && output.KmsMasterKeyId !== null ? output.KmsMasterKeyId : undefined,
-    Owner: output.Owner !== undefined && output.Owner !== null ? output.Owner : undefined,
+    KmsMasterKeyId: __expectString(output.KmsMasterKeyId),
+    Owner: __expectString(output.Owner),
     Subscription:
       output.Subscription !== undefined && output.Subscription !== null
         ? deserializeAws_restJson1AwsSnsTopicSubscriptionList(output.Subscription, context)
         : undefined,
-    TopicName: output.TopicName !== undefined && output.TopicName !== null ? output.TopicName : undefined,
+    TopicName: __expectString(output.TopicName),
   } as any;
 };
 
@@ -17254,8 +16550,8 @@ const deserializeAws_restJson1AwsSnsTopicSubscription = (
   context: __SerdeContext
 ): AwsSnsTopicSubscription => {
   return {
-    Endpoint: output.Endpoint !== undefined && output.Endpoint !== null ? output.Endpoint : undefined,
-    Protocol: output.Protocol !== undefined && output.Protocol !== null ? output.Protocol : undefined,
+    Endpoint: __expectString(output.Endpoint),
+    Protocol: __expectString(output.Protocol),
   } as any;
 };
 
@@ -17275,17 +16571,10 @@ const deserializeAws_restJson1AwsSnsTopicSubscriptionList = (
 
 const deserializeAws_restJson1AwsSqsQueueDetails = (output: any, context: __SerdeContext): AwsSqsQueueDetails => {
   return {
-    DeadLetterTargetArn:
-      output.DeadLetterTargetArn !== undefined && output.DeadLetterTargetArn !== null
-        ? output.DeadLetterTargetArn
-        : undefined,
-    KmsDataKeyReusePeriodSeconds:
-      output.KmsDataKeyReusePeriodSeconds !== undefined && output.KmsDataKeyReusePeriodSeconds !== null
-        ? output.KmsDataKeyReusePeriodSeconds
-        : undefined,
-    KmsMasterKeyId:
-      output.KmsMasterKeyId !== undefined && output.KmsMasterKeyId !== null ? output.KmsMasterKeyId : undefined,
-    QueueName: output.QueueName !== undefined && output.QueueName !== null ? output.QueueName : undefined,
+    DeadLetterTargetArn: __expectString(output.DeadLetterTargetArn),
+    KmsDataKeyReusePeriodSeconds: __expectNumber(output.KmsDataKeyReusePeriodSeconds),
+    KmsMasterKeyId: __expectString(output.KmsMasterKeyId),
+    QueueName: __expectString(output.QueueName),
   } as any;
 };
 
@@ -17294,64 +16583,24 @@ const deserializeAws_restJson1AwsSsmComplianceSummary = (
   context: __SerdeContext
 ): AwsSsmComplianceSummary => {
   return {
-    ComplianceType:
-      output.ComplianceType !== undefined && output.ComplianceType !== null ? output.ComplianceType : undefined,
-    CompliantCriticalCount:
-      output.CompliantCriticalCount !== undefined && output.CompliantCriticalCount !== null
-        ? output.CompliantCriticalCount
-        : undefined,
-    CompliantHighCount:
-      output.CompliantHighCount !== undefined && output.CompliantHighCount !== null
-        ? output.CompliantHighCount
-        : undefined,
-    CompliantInformationalCount:
-      output.CompliantInformationalCount !== undefined && output.CompliantInformationalCount !== null
-        ? output.CompliantInformationalCount
-        : undefined,
-    CompliantLowCount:
-      output.CompliantLowCount !== undefined && output.CompliantLowCount !== null
-        ? output.CompliantLowCount
-        : undefined,
-    CompliantMediumCount:
-      output.CompliantMediumCount !== undefined && output.CompliantMediumCount !== null
-        ? output.CompliantMediumCount
-        : undefined,
-    CompliantUnspecifiedCount:
-      output.CompliantUnspecifiedCount !== undefined && output.CompliantUnspecifiedCount !== null
-        ? output.CompliantUnspecifiedCount
-        : undefined,
-    ExecutionType:
-      output.ExecutionType !== undefined && output.ExecutionType !== null ? output.ExecutionType : undefined,
-    NonCompliantCriticalCount:
-      output.NonCompliantCriticalCount !== undefined && output.NonCompliantCriticalCount !== null
-        ? output.NonCompliantCriticalCount
-        : undefined,
-    NonCompliantHighCount:
-      output.NonCompliantHighCount !== undefined && output.NonCompliantHighCount !== null
-        ? output.NonCompliantHighCount
-        : undefined,
-    NonCompliantInformationalCount:
-      output.NonCompliantInformationalCount !== undefined && output.NonCompliantInformationalCount !== null
-        ? output.NonCompliantInformationalCount
-        : undefined,
-    NonCompliantLowCount:
-      output.NonCompliantLowCount !== undefined && output.NonCompliantLowCount !== null
-        ? output.NonCompliantLowCount
-        : undefined,
-    NonCompliantMediumCount:
-      output.NonCompliantMediumCount !== undefined && output.NonCompliantMediumCount !== null
-        ? output.NonCompliantMediumCount
-        : undefined,
-    NonCompliantUnspecifiedCount:
-      output.NonCompliantUnspecifiedCount !== undefined && output.NonCompliantUnspecifiedCount !== null
-        ? output.NonCompliantUnspecifiedCount
-        : undefined,
-    OverallSeverity:
-      output.OverallSeverity !== undefined && output.OverallSeverity !== null ? output.OverallSeverity : undefined,
-    PatchBaselineId:
-      output.PatchBaselineId !== undefined && output.PatchBaselineId !== null ? output.PatchBaselineId : undefined,
-    PatchGroup: output.PatchGroup !== undefined && output.PatchGroup !== null ? output.PatchGroup : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    ComplianceType: __expectString(output.ComplianceType),
+    CompliantCriticalCount: __expectNumber(output.CompliantCriticalCount),
+    CompliantHighCount: __expectNumber(output.CompliantHighCount),
+    CompliantInformationalCount: __expectNumber(output.CompliantInformationalCount),
+    CompliantLowCount: __expectNumber(output.CompliantLowCount),
+    CompliantMediumCount: __expectNumber(output.CompliantMediumCount),
+    CompliantUnspecifiedCount: __expectNumber(output.CompliantUnspecifiedCount),
+    ExecutionType: __expectString(output.ExecutionType),
+    NonCompliantCriticalCount: __expectNumber(output.NonCompliantCriticalCount),
+    NonCompliantHighCount: __expectNumber(output.NonCompliantHighCount),
+    NonCompliantInformationalCount: __expectNumber(output.NonCompliantInformationalCount),
+    NonCompliantLowCount: __expectNumber(output.NonCompliantLowCount),
+    NonCompliantMediumCount: __expectNumber(output.NonCompliantMediumCount),
+    NonCompliantUnspecifiedCount: __expectNumber(output.NonCompliantUnspecifiedCount),
+    OverallSeverity: __expectString(output.OverallSeverity),
+    PatchBaselineId: __expectString(output.PatchBaselineId),
+    PatchGroup: __expectString(output.PatchGroup),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -17378,14 +16627,13 @@ const deserializeAws_restJson1AwsSsmPatchComplianceDetails = (
 
 const deserializeAws_restJson1AwsWafWebAclDetails = (output: any, context: __SerdeContext): AwsWafWebAclDetails => {
   return {
-    DefaultAction:
-      output.DefaultAction !== undefined && output.DefaultAction !== null ? output.DefaultAction : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    DefaultAction: __expectString(output.DefaultAction),
+    Name: __expectString(output.Name),
     Rules:
       output.Rules !== undefined && output.Rules !== null
         ? deserializeAws_restJson1AwsWafWebAclRuleList(output.Rules, context)
         : undefined,
-    WebAclId: output.WebAclId !== undefined && output.WebAclId !== null ? output.WebAclId : undefined,
+    WebAclId: __expectString(output.WebAclId),
   } as any;
 };
 
@@ -17403,9 +16651,9 @@ const deserializeAws_restJson1AwsWafWebAclRule = (output: any, context: __SerdeC
       output.OverrideAction !== undefined && output.OverrideAction !== null
         ? deserializeAws_restJson1WafOverrideAction(output.OverrideAction, context)
         : undefined,
-    Priority: output.Priority !== undefined && output.Priority !== null ? output.Priority : undefined,
-    RuleId: output.RuleId !== undefined && output.RuleId !== null ? output.RuleId : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Priority: __expectNumber(output.Priority),
+    RuleId: __expectString(output.RuleId),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -17425,8 +16673,8 @@ const deserializeAws_restJson1BatchUpdateFindingsUnprocessedFinding = (
   context: __SerdeContext
 ): BatchUpdateFindingsUnprocessedFinding => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
     FindingIdentifier:
       output.FindingIdentifier !== undefined && output.FindingIdentifier !== null
         ? deserializeAws_restJson1AwsSecurityFindingIdentifier(output.FindingIdentifier, context)
@@ -17455,17 +16703,16 @@ const deserializeAws_restJson1CategoryList = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1Cell = (output: any, context: __SerdeContext): Cell => {
   return {
-    CellReference:
-      output.CellReference !== undefined && output.CellReference !== null ? output.CellReference : undefined,
-    Column: output.Column !== undefined && output.Column !== null ? output.Column : undefined,
-    ColumnName: output.ColumnName !== undefined && output.ColumnName !== null ? output.ColumnName : undefined,
-    Row: output.Row !== undefined && output.Row !== null ? output.Row : undefined,
+    CellReference: __expectString(output.CellReference),
+    Column: __expectNumber(output.Column),
+    ColumnName: __expectString(output.ColumnName),
+    Row: __expectNumber(output.Row),
   } as any;
 };
 
@@ -17482,11 +16729,9 @@ const deserializeAws_restJson1Cells = (output: any, context: __SerdeContext): Ce
 
 const deserializeAws_restJson1CidrBlockAssociation = (output: any, context: __SerdeContext): CidrBlockAssociation => {
   return {
-    AssociationId:
-      output.AssociationId !== undefined && output.AssociationId !== null ? output.AssociationId : undefined,
-    CidrBlock: output.CidrBlock !== undefined && output.CidrBlock !== null ? output.CidrBlock : undefined,
-    CidrBlockState:
-      output.CidrBlockState !== undefined && output.CidrBlockState !== null ? output.CidrBlockState : undefined,
+    AssociationId: __expectString(output.AssociationId),
+    CidrBlock: __expectString(output.CidrBlock),
+    CidrBlockState: __expectString(output.CidrBlockState),
   } as any;
 };
 
@@ -17506,27 +16751,23 @@ const deserializeAws_restJson1CidrBlockAssociationList = (
 
 const deserializeAws_restJson1City = (output: any, context: __SerdeContext): City => {
   return {
-    CityName: output.CityName !== undefined && output.CityName !== null ? output.CityName : undefined,
+    CityName: __expectString(output.CityName),
   } as any;
 };
 
 const deserializeAws_restJson1ClassificationResult = (output: any, context: __SerdeContext): ClassificationResult => {
   return {
-    AdditionalOccurrences:
-      output.AdditionalOccurrences !== undefined && output.AdditionalOccurrences !== null
-        ? output.AdditionalOccurrences
-        : undefined,
+    AdditionalOccurrences: __expectBoolean(output.AdditionalOccurrences),
     CustomDataIdentifiers:
       output.CustomDataIdentifiers !== undefined && output.CustomDataIdentifiers !== null
         ? deserializeAws_restJson1CustomDataIdentifiersResult(output.CustomDataIdentifiers, context)
         : undefined,
-    MimeType: output.MimeType !== undefined && output.MimeType !== null ? output.MimeType : undefined,
+    MimeType: __expectString(output.MimeType),
     SensitiveData:
       output.SensitiveData !== undefined && output.SensitiveData !== null
         ? deserializeAws_restJson1SensitiveDataResultList(output.SensitiveData, context)
         : undefined,
-    SizeClassified:
-      output.SizeClassified !== undefined && output.SizeClassified !== null ? output.SizeClassified : undefined,
+    SizeClassified: __expectNumber(output.SizeClassified),
     Status:
       output.Status !== undefined && output.Status !== null
         ? deserializeAws_restJson1ClassificationStatus(output.Status, context)
@@ -17536,8 +16777,8 @@ const deserializeAws_restJson1ClassificationResult = (output: any, context: __Se
 
 const deserializeAws_restJson1ClassificationStatus = (output: any, context: __SerdeContext): ClassificationStatus => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Reason: output.Reason !== undefined && output.Reason !== null ? output.Reason : undefined,
+    Code: __expectString(output.Code),
+    Reason: __expectString(output.Reason),
   } as any;
 };
 
@@ -17547,7 +16788,7 @@ const deserializeAws_restJson1Compliance = (output: any, context: __SerdeContext
       output.RelatedRequirements !== undefined && output.RelatedRequirements !== null
         ? deserializeAws_restJson1RelatedRequirementsList(output.RelatedRequirements, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
     StatusReasons:
       output.StatusReasons !== undefined && output.StatusReasons !== null
         ? deserializeAws_restJson1StatusReasonsList(output.StatusReasons, context)
@@ -17557,17 +16798,17 @@ const deserializeAws_restJson1Compliance = (output: any, context: __SerdeContext
 
 const deserializeAws_restJson1ContainerDetails = (output: any, context: __SerdeContext): ContainerDetails => {
   return {
-    ImageId: output.ImageId !== undefined && output.ImageId !== null ? output.ImageId : undefined,
-    ImageName: output.ImageName !== undefined && output.ImageName !== null ? output.ImageName : undefined,
-    LaunchedAt: output.LaunchedAt !== undefined && output.LaunchedAt !== null ? output.LaunchedAt : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    ImageId: __expectString(output.ImageId),
+    ImageName: __expectString(output.ImageName),
+    LaunchedAt: __expectString(output.LaunchedAt),
+    Name: __expectString(output.Name),
   } as any;
 };
 
 const deserializeAws_restJson1Country = (output: any, context: __SerdeContext): Country => {
   return {
-    CountryCode: output.CountryCode !== undefined && output.CountryCode !== null ? output.CountryCode : undefined,
-    CountryName: output.CountryName !== undefined && output.CountryName !== null ? output.CountryName : undefined,
+    CountryCode: __expectString(output.CountryCode),
+    CountryName: __expectString(output.CountryName),
   } as any;
 };
 
@@ -17576,9 +16817,9 @@ const deserializeAws_restJson1CustomDataIdentifiersDetections = (
   context: __SerdeContext
 ): CustomDataIdentifiersDetections => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Count: output.Count !== undefined && output.Count !== null ? output.Count : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Arn: __expectString(output.Arn),
+    Count: __expectNumber(output.Count),
+    Name: __expectString(output.Name),
     Occurrences:
       output.Occurrences !== undefined && output.Occurrences !== null
         ? deserializeAws_restJson1Occurrences(output.Occurrences, context)
@@ -17609,15 +16850,15 @@ const deserializeAws_restJson1CustomDataIdentifiersResult = (
       output.Detections !== undefined && output.Detections !== null
         ? deserializeAws_restJson1CustomDataIdentifiersDetectionsList(output.Detections, context)
         : undefined,
-    TotalCount: output.TotalCount !== undefined && output.TotalCount !== null ? output.TotalCount : undefined,
+    TotalCount: __expectNumber(output.TotalCount),
   } as any;
 };
 
 const deserializeAws_restJson1Cvss = (output: any, context: __SerdeContext): Cvss => {
   return {
-    BaseScore: output.BaseScore !== undefined && output.BaseScore !== null ? output.BaseScore : undefined,
-    BaseVector: output.BaseVector !== undefined && output.BaseVector !== null ? output.BaseVector : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    BaseScore: __expectNumber(output.BaseScore),
+    BaseVector: __expectString(output.BaseVector),
+    Version: __expectString(output.Version),
   } as any;
 };
 
@@ -17637,10 +16878,7 @@ const deserializeAws_restJson1DataClassificationDetails = (
   context: __SerdeContext
 ): DataClassificationDetails => {
   return {
-    DetailedResultsLocation:
-      output.DetailedResultsLocation !== undefined && output.DetailedResultsLocation !== null
-        ? output.DetailedResultsLocation
-        : undefined,
+    DetailedResultsLocation: __expectString(output.DetailedResultsLocation),
     Result:
       output.Result !== undefined && output.Result !== null
         ? deserializeAws_restJson1ClassificationResult(output.Result, context)
@@ -17654,8 +16892,8 @@ const deserializeAws_restJson1DateFilter = (output: any, context: __SerdeContext
       output.DateRange !== undefined && output.DateRange !== null
         ? deserializeAws_restJson1DateRange(output.DateRange, context)
         : undefined,
-    End: output.End !== undefined && output.End !== null ? output.End : undefined,
-    Start: output.Start !== undefined && output.Start !== null ? output.Start : undefined,
+    End: __expectString(output.End),
+    Start: __expectString(output.Start),
   } as any;
 };
 
@@ -17672,16 +16910,16 @@ const deserializeAws_restJson1DateFilterList = (output: any, context: __SerdeCon
 
 const deserializeAws_restJson1DateRange = (output: any, context: __SerdeContext): DateRange => {
   return {
-    Unit: output.Unit !== undefined && output.Unit !== null ? output.Unit : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Unit: __expectString(output.Unit),
+    Value: __expectNumber(output.Value),
   } as any;
 };
 
 const deserializeAws_restJson1DnsRequestAction = (output: any, context: __SerdeContext): DnsRequestAction => {
   return {
-    Blocked: output.Blocked !== undefined && output.Blocked !== null ? output.Blocked : undefined,
-    Domain: output.Domain !== undefined && output.Domain !== null ? output.Domain : undefined,
-    Protocol: output.Protocol !== undefined && output.Protocol !== null ? output.Protocol : undefined,
+    Blocked: __expectBoolean(output.Blocked),
+    Domain: __expectString(output.Domain),
+    Protocol: __expectString(output.Protocol),
   } as any;
 };
 
@@ -17692,15 +16930,15 @@ const deserializeAws_restJson1FieldMap = (output: any, context: __SerdeContext):
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1FindingProviderFields = (output: any, context: __SerdeContext): FindingProviderFields => {
   return {
-    Confidence: output.Confidence !== undefined && output.Confidence !== null ? output.Confidence : undefined,
-    Criticality: output.Criticality !== undefined && output.Criticality !== null ? output.Criticality : undefined,
+    Confidence: __expectNumber(output.Confidence),
+    Criticality: __expectNumber(output.Criticality),
     RelatedFindings:
       output.RelatedFindings !== undefined && output.RelatedFindings !== null
         ? deserializeAws_restJson1RelatedFindingList(output.RelatedFindings, context)
@@ -17721,30 +16959,30 @@ const deserializeAws_restJson1FindingProviderSeverity = (
   context: __SerdeContext
 ): FindingProviderSeverity => {
   return {
-    Label: output.Label !== undefined && output.Label !== null ? output.Label : undefined,
-    Original: output.Original !== undefined && output.Original !== null ? output.Original : undefined,
+    Label: __expectString(output.Label),
+    Original: __expectString(output.Original),
   } as any;
 };
 
 const deserializeAws_restJson1GeoLocation = (output: any, context: __SerdeContext): GeoLocation => {
   return {
-    Lat: output.Lat !== undefined && output.Lat !== null ? output.Lat : undefined,
-    Lon: output.Lon !== undefined && output.Lon !== null ? output.Lon : undefined,
+    Lat: __expectNumber(output.Lat),
+    Lon: __expectNumber(output.Lon),
   } as any;
 };
 
 const deserializeAws_restJson1IcmpTypeCode = (output: any, context: __SerdeContext): IcmpTypeCode => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Code: __expectNumber(output.Code),
+    Type: __expectNumber(output.Type),
   } as any;
 };
 
 const deserializeAws_restJson1ImportFindingsError = (output: any, context: __SerdeContext): ImportFindingsError => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
+    Id: __expectString(output.Id),
   } as any;
 };
 
@@ -17768,10 +17006,9 @@ const deserializeAws_restJson1Insight = (output: any, context: __SerdeContext): 
       output.Filters !== undefined && output.Filters !== null
         ? deserializeAws_restJson1AwsSecurityFindingFilters(output.Filters, context)
         : undefined,
-    GroupByAttribute:
-      output.GroupByAttribute !== undefined && output.GroupByAttribute !== null ? output.GroupByAttribute : undefined,
-    InsightArn: output.InsightArn !== undefined && output.InsightArn !== null ? output.InsightArn : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    GroupByAttribute: __expectString(output.GroupByAttribute),
+    InsightArn: __expectString(output.InsightArn),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -17788,9 +17025,8 @@ const deserializeAws_restJson1InsightList = (output: any, context: __SerdeContex
 
 const deserializeAws_restJson1InsightResults = (output: any, context: __SerdeContext): InsightResults => {
   return {
-    GroupByAttribute:
-      output.GroupByAttribute !== undefined && output.GroupByAttribute !== null ? output.GroupByAttribute : undefined,
-    InsightArn: output.InsightArn !== undefined && output.InsightArn !== null ? output.InsightArn : undefined,
+    GroupByAttribute: __expectString(output.GroupByAttribute),
+    InsightArn: __expectString(output.InsightArn),
     ResultValues:
       output.ResultValues !== undefined && output.ResultValues !== null
         ? deserializeAws_restJson1InsightResultValueList(output.ResultValues, context)
@@ -17800,11 +17036,8 @@ const deserializeAws_restJson1InsightResults = (output: any, context: __SerdeCon
 
 const deserializeAws_restJson1InsightResultValue = (output: any, context: __SerdeContext): InsightResultValue => {
   return {
-    Count: output.Count !== undefined && output.Count !== null ? output.Count : undefined,
-    GroupByAttributeValue:
-      output.GroupByAttributeValue !== undefined && output.GroupByAttributeValue !== null
-        ? output.GroupByAttributeValue
-        : undefined,
+    Count: __expectNumber(output.Count),
+    GroupByAttributeValue: __expectString(output.GroupByAttributeValue),
   } as any;
 };
 
@@ -17829,16 +17062,16 @@ const deserializeAws_restJson1IntegrationTypeList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1Invitation = (output: any, context: __SerdeContext): Invitation => {
   return {
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
-    InvitationId: output.InvitationId !== undefined && output.InvitationId !== null ? output.InvitationId : undefined,
+    AccountId: __expectString(output.AccountId),
+    InvitationId: __expectString(output.InvitationId),
     InvitedAt: output.InvitedAt !== undefined && output.InvitedAt !== null ? new Date(output.InvitedAt) : undefined,
-    MemberStatus: output.MemberStatus !== undefined && output.MemberStatus !== null ? output.MemberStatus : undefined,
+    MemberStatus: __expectString(output.MemberStatus),
   } as any;
 };
 
@@ -17855,7 +17088,7 @@ const deserializeAws_restJson1InvitationList = (output: any, context: __SerdeCon
 
 const deserializeAws_restJson1IpFilter = (output: any, context: __SerdeContext): IpFilter => {
   return {
-    Cidr: output.Cidr !== undefined && output.Cidr !== null ? output.Cidr : undefined,
+    Cidr: __expectString(output.Cidr),
   } as any;
 };
 
@@ -17872,10 +17105,10 @@ const deserializeAws_restJson1IpFilterList = (output: any, context: __SerdeConte
 
 const deserializeAws_restJson1IpOrganizationDetails = (output: any, context: __SerdeContext): IpOrganizationDetails => {
   return {
-    Asn: output.Asn !== undefined && output.Asn !== null ? output.Asn : undefined,
-    AsnOrg: output.AsnOrg !== undefined && output.AsnOrg !== null ? output.AsnOrg : undefined,
-    Isp: output.Isp !== undefined && output.Isp !== null ? output.Isp : undefined,
-    Org: output.Org !== undefined && output.Org !== null ? output.Org : undefined,
+    Asn: __expectNumber(output.Asn),
+    AsnOrg: __expectString(output.AsnOrg),
+    Isp: __expectString(output.Isp),
+    Org: __expectString(output.Org),
   } as any;
 };
 
@@ -17884,12 +17117,9 @@ const deserializeAws_restJson1Ipv6CidrBlockAssociation = (
   context: __SerdeContext
 ): Ipv6CidrBlockAssociation => {
   return {
-    AssociationId:
-      output.AssociationId !== undefined && output.AssociationId !== null ? output.AssociationId : undefined,
-    CidrBlockState:
-      output.CidrBlockState !== undefined && output.CidrBlockState !== null ? output.CidrBlockState : undefined,
-    Ipv6CidrBlock:
-      output.Ipv6CidrBlock !== undefined && output.Ipv6CidrBlock !== null ? output.Ipv6CidrBlock : undefined,
+    AssociationId: __expectString(output.AssociationId),
+    CidrBlockState: __expectString(output.CidrBlockState),
+    Ipv6CidrBlock: __expectString(output.Ipv6CidrBlock),
   } as any;
 };
 
@@ -17909,7 +17139,7 @@ const deserializeAws_restJson1Ipv6CidrBlockAssociationList = (
 
 const deserializeAws_restJson1KeywordFilter = (output: any, context: __SerdeContext): KeywordFilter => {
   return {
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -17926,17 +17156,17 @@ const deserializeAws_restJson1KeywordFilterList = (output: any, context: __Serde
 
 const deserializeAws_restJson1LoadBalancerState = (output: any, context: __SerdeContext): LoadBalancerState => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Reason: output.Reason !== undefined && output.Reason !== null ? output.Reason : undefined,
+    Code: __expectString(output.Code),
+    Reason: __expectString(output.Reason),
   } as any;
 };
 
 const deserializeAws_restJson1Malware = (output: any, context: __SerdeContext): Malware => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Path: output.Path !== undefined && output.Path !== null ? output.Path : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Name: __expectString(output.Name),
+    Path: __expectString(output.Path),
+    State: __expectString(output.State),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -17953,9 +17183,9 @@ const deserializeAws_restJson1MalwareList = (output: any, context: __SerdeContex
 
 const deserializeAws_restJson1MapFilter = (output: any, context: __SerdeContext): MapFilter => {
   return {
-    Comparison: output.Comparison !== undefined && output.Comparison !== null ? output.Comparison : undefined,
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Comparison: __expectString(output.Comparison),
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -17972,13 +17202,12 @@ const deserializeAws_restJson1MapFilterList = (output: any, context: __SerdeCont
 
 const deserializeAws_restJson1Member = (output: any, context: __SerdeContext): Member => {
   return {
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
-    AdministratorId:
-      output.AdministratorId !== undefined && output.AdministratorId !== null ? output.AdministratorId : undefined,
-    Email: output.Email !== undefined && output.Email !== null ? output.Email : undefined,
+    AccountId: __expectString(output.AccountId),
+    AdministratorId: __expectString(output.AdministratorId),
+    Email: __expectString(output.Email),
     InvitedAt: output.InvitedAt !== undefined && output.InvitedAt !== null ? new Date(output.InvitedAt) : undefined,
-    MasterId: output.MasterId !== undefined && output.MasterId !== null ? output.MasterId : undefined,
-    MemberStatus: output.MemberStatus !== undefined && output.MemberStatus !== null ? output.MemberStatus : undefined,
+    MasterId: __expectString(output.MasterId),
+    MemberStatus: __expectString(output.MemberStatus),
     UpdatedAt: output.UpdatedAt !== undefined && output.UpdatedAt !== null ? new Date(output.UpdatedAt) : undefined,
   } as any;
 };
@@ -17996,27 +17225,21 @@ const deserializeAws_restJson1MemberList = (output: any, context: __SerdeContext
 
 const deserializeAws_restJson1Network = (output: any, context: __SerdeContext): Network => {
   return {
-    DestinationDomain:
-      output.DestinationDomain !== undefined && output.DestinationDomain !== null
-        ? output.DestinationDomain
-        : undefined,
-    DestinationIpV4:
-      output.DestinationIpV4 !== undefined && output.DestinationIpV4 !== null ? output.DestinationIpV4 : undefined,
-    DestinationIpV6:
-      output.DestinationIpV6 !== undefined && output.DestinationIpV6 !== null ? output.DestinationIpV6 : undefined,
-    DestinationPort:
-      output.DestinationPort !== undefined && output.DestinationPort !== null ? output.DestinationPort : undefined,
-    Direction: output.Direction !== undefined && output.Direction !== null ? output.Direction : undefined,
+    DestinationDomain: __expectString(output.DestinationDomain),
+    DestinationIpV4: __expectString(output.DestinationIpV4),
+    DestinationIpV6: __expectString(output.DestinationIpV6),
+    DestinationPort: __expectNumber(output.DestinationPort),
+    Direction: __expectString(output.Direction),
     OpenPortRange:
       output.OpenPortRange !== undefined && output.OpenPortRange !== null
         ? deserializeAws_restJson1PortRange(output.OpenPortRange, context)
         : undefined,
-    Protocol: output.Protocol !== undefined && output.Protocol !== null ? output.Protocol : undefined,
-    SourceDomain: output.SourceDomain !== undefined && output.SourceDomain !== null ? output.SourceDomain : undefined,
-    SourceIpV4: output.SourceIpV4 !== undefined && output.SourceIpV4 !== null ? output.SourceIpV4 : undefined,
-    SourceIpV6: output.SourceIpV6 !== undefined && output.SourceIpV6 !== null ? output.SourceIpV6 : undefined,
-    SourceMac: output.SourceMac !== undefined && output.SourceMac !== null ? output.SourceMac : undefined,
-    SourcePort: output.SourcePort !== undefined && output.SourcePort !== null ? output.SourcePort : undefined,
+    Protocol: __expectString(output.Protocol),
+    SourceDomain: __expectString(output.SourceDomain),
+    SourceIpV4: __expectString(output.SourceIpV4),
+    SourceIpV6: __expectString(output.SourceIpV6),
+    SourceMac: __expectString(output.SourceMac),
+    SourcePort: __expectNumber(output.SourcePort),
   } as any;
 };
 
@@ -18025,16 +17248,13 @@ const deserializeAws_restJson1NetworkConnectionAction = (
   context: __SerdeContext
 ): NetworkConnectionAction => {
   return {
-    Blocked: output.Blocked !== undefined && output.Blocked !== null ? output.Blocked : undefined,
-    ConnectionDirection:
-      output.ConnectionDirection !== undefined && output.ConnectionDirection !== null
-        ? output.ConnectionDirection
-        : undefined,
+    Blocked: __expectBoolean(output.Blocked),
+    ConnectionDirection: __expectString(output.ConnectionDirection),
     LocalPortDetails:
       output.LocalPortDetails !== undefined && output.LocalPortDetails !== null
         ? deserializeAws_restJson1ActionLocalPortDetails(output.LocalPortDetails, context)
         : undefined,
-    Protocol: output.Protocol !== undefined && output.Protocol !== null ? output.Protocol : undefined,
+    Protocol: __expectString(output.Protocol),
     RemoteIpDetails:
       output.RemoteIpDetails !== undefined && output.RemoteIpDetails !== null
         ? deserializeAws_restJson1ActionRemoteIpDetails(output.RemoteIpDetails, context)
@@ -18052,7 +17272,7 @@ const deserializeAws_restJson1NetworkHeader = (output: any, context: __SerdeCont
       output.Destination !== undefined && output.Destination !== null
         ? deserializeAws_restJson1NetworkPathComponentDetails(output.Destination, context)
         : undefined,
-    Protocol: output.Protocol !== undefined && output.Protocol !== null ? output.Protocol : undefined,
+    Protocol: __expectString(output.Protocol),
     Source:
       output.Source !== undefined && output.Source !== null
         ? deserializeAws_restJson1NetworkPathComponentDetails(output.Source, context)
@@ -18062,9 +17282,8 @@ const deserializeAws_restJson1NetworkHeader = (output: any, context: __SerdeCont
 
 const deserializeAws_restJson1NetworkPathComponent = (output: any, context: __SerdeContext): NetworkPathComponent => {
   return {
-    ComponentId: output.ComponentId !== undefined && output.ComponentId !== null ? output.ComponentId : undefined,
-    ComponentType:
-      output.ComponentType !== undefined && output.ComponentType !== null ? output.ComponentType : undefined,
+    ComponentId: __expectString(output.ComponentId),
+    ComponentType: __expectString(output.ComponentType),
     Egress:
       output.Egress !== undefined && output.Egress !== null
         ? deserializeAws_restJson1NetworkHeader(output.Egress, context)
@@ -18110,23 +17329,23 @@ const deserializeAws_restJson1NonEmptyStringList = (output: any, context: __Serd
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1Note = (output: any, context: __SerdeContext): Note => {
   return {
-    Text: output.Text !== undefined && output.Text !== null ? output.Text : undefined,
-    UpdatedAt: output.UpdatedAt !== undefined && output.UpdatedAt !== null ? output.UpdatedAt : undefined,
-    UpdatedBy: output.UpdatedBy !== undefined && output.UpdatedBy !== null ? output.UpdatedBy : undefined,
+    Text: __expectString(output.Text),
+    UpdatedAt: __expectString(output.UpdatedAt),
+    UpdatedBy: __expectString(output.UpdatedBy),
   } as any;
 };
 
 const deserializeAws_restJson1NumberFilter = (output: any, context: __SerdeContext): NumberFilter => {
   return {
-    Eq: output.Eq !== undefined && output.Eq !== null ? output.Eq : undefined,
-    Gte: output.Gte !== undefined && output.Gte !== null ? output.Gte : undefined,
-    Lte: output.Lte !== undefined && output.Lte !== null ? output.Lte : undefined,
+    Eq: __expectNumber(output.Eq),
+    Gte: __expectNumber(output.Gte),
+    Lte: __expectNumber(output.Lte),
   } as any;
 };
 
@@ -18176,7 +17395,7 @@ const deserializeAws_restJson1Page = (output: any, context: __SerdeContext): Pag
       output.OffsetRange !== undefined && output.OffsetRange !== null
         ? deserializeAws_restJson1Range(output.OffsetRange, context)
         : undefined,
-    PageNumber: output.PageNumber !== undefined && output.PageNumber !== null ? output.PageNumber : undefined,
+    PageNumber: __expectNumber(output.PageNumber),
   } as any;
 };
 
@@ -18193,37 +17412,23 @@ const deserializeAws_restJson1Pages = (output: any, context: __SerdeContext): Pa
 
 const deserializeAws_restJson1PatchSummary = (output: any, context: __SerdeContext): PatchSummary => {
   return {
-    FailedCount: output.FailedCount !== undefined && output.FailedCount !== null ? output.FailedCount : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    InstalledCount:
-      output.InstalledCount !== undefined && output.InstalledCount !== null ? output.InstalledCount : undefined,
-    InstalledOtherCount:
-      output.InstalledOtherCount !== undefined && output.InstalledOtherCount !== null
-        ? output.InstalledOtherCount
-        : undefined,
-    InstalledPendingReboot:
-      output.InstalledPendingReboot !== undefined && output.InstalledPendingReboot !== null
-        ? output.InstalledPendingReboot
-        : undefined,
-    InstalledRejectedCount:
-      output.InstalledRejectedCount !== undefined && output.InstalledRejectedCount !== null
-        ? output.InstalledRejectedCount
-        : undefined,
-    MissingCount: output.MissingCount !== undefined && output.MissingCount !== null ? output.MissingCount : undefined,
-    Operation: output.Operation !== undefined && output.Operation !== null ? output.Operation : undefined,
-    OperationEndTime:
-      output.OperationEndTime !== undefined && output.OperationEndTime !== null ? output.OperationEndTime : undefined,
-    OperationStartTime:
-      output.OperationStartTime !== undefined && output.OperationStartTime !== null
-        ? output.OperationStartTime
-        : undefined,
-    RebootOption: output.RebootOption !== undefined && output.RebootOption !== null ? output.RebootOption : undefined,
+    FailedCount: __expectNumber(output.FailedCount),
+    Id: __expectString(output.Id),
+    InstalledCount: __expectNumber(output.InstalledCount),
+    InstalledOtherCount: __expectNumber(output.InstalledOtherCount),
+    InstalledPendingReboot: __expectNumber(output.InstalledPendingReboot),
+    InstalledRejectedCount: __expectNumber(output.InstalledRejectedCount),
+    MissingCount: __expectNumber(output.MissingCount),
+    Operation: __expectString(output.Operation),
+    OperationEndTime: __expectString(output.OperationEndTime),
+    OperationStartTime: __expectString(output.OperationStartTime),
+    RebootOption: __expectString(output.RebootOption),
   } as any;
 };
 
 const deserializeAws_restJson1PortProbeAction = (output: any, context: __SerdeContext): PortProbeAction => {
   return {
-    Blocked: output.Blocked !== undefined && output.Blocked !== null ? output.Blocked : undefined,
+    Blocked: __expectBoolean(output.Blocked),
     PortProbeDetails:
       output.PortProbeDetails !== undefined && output.PortProbeDetails !== null
         ? deserializeAws_restJson1PortProbeDetailList(output.PortProbeDetails, context)
@@ -18261,15 +17466,15 @@ const deserializeAws_restJson1PortProbeDetailList = (output: any, context: __Ser
 
 const deserializeAws_restJson1PortRange = (output: any, context: __SerdeContext): PortRange => {
   return {
-    Begin: output.Begin !== undefined && output.Begin !== null ? output.Begin : undefined,
-    End: output.End !== undefined && output.End !== null ? output.End : undefined,
+    Begin: __expectNumber(output.Begin),
+    End: __expectNumber(output.End),
   } as any;
 };
 
 const deserializeAws_restJson1PortRangeFromTo = (output: any, context: __SerdeContext): PortRangeFromTo => {
   return {
-    From: output.From !== undefined && output.From !== null ? output.From : undefined,
-    To: output.To !== undefined && output.To !== null ? output.To : undefined,
+    From: __expectNumber(output.From),
+    To: __expectNumber(output.To),
   } as any;
 };
 
@@ -18286,37 +17491,32 @@ const deserializeAws_restJson1PortRangeList = (output: any, context: __SerdeCont
 
 const deserializeAws_restJson1ProcessDetails = (output: any, context: __SerdeContext): ProcessDetails => {
   return {
-    LaunchedAt: output.LaunchedAt !== undefined && output.LaunchedAt !== null ? output.LaunchedAt : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    ParentPid: output.ParentPid !== undefined && output.ParentPid !== null ? output.ParentPid : undefined,
-    Path: output.Path !== undefined && output.Path !== null ? output.Path : undefined,
-    Pid: output.Pid !== undefined && output.Pid !== null ? output.Pid : undefined,
-    TerminatedAt: output.TerminatedAt !== undefined && output.TerminatedAt !== null ? output.TerminatedAt : undefined,
+    LaunchedAt: __expectString(output.LaunchedAt),
+    Name: __expectString(output.Name),
+    ParentPid: __expectNumber(output.ParentPid),
+    Path: __expectString(output.Path),
+    Pid: __expectNumber(output.Pid),
+    TerminatedAt: __expectString(output.TerminatedAt),
   } as any;
 };
 
 const deserializeAws_restJson1Product = (output: any, context: __SerdeContext): Product => {
   return {
-    ActivationUrl:
-      output.ActivationUrl !== undefined && output.ActivationUrl !== null ? output.ActivationUrl : undefined,
+    ActivationUrl: __expectString(output.ActivationUrl),
     Categories:
       output.Categories !== undefined && output.Categories !== null
         ? deserializeAws_restJson1CategoryList(output.Categories, context)
         : undefined,
-    CompanyName: output.CompanyName !== undefined && output.CompanyName !== null ? output.CompanyName : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    CompanyName: __expectString(output.CompanyName),
+    Description: __expectString(output.Description),
     IntegrationTypes:
       output.IntegrationTypes !== undefined && output.IntegrationTypes !== null
         ? deserializeAws_restJson1IntegrationTypeList(output.IntegrationTypes, context)
         : undefined,
-    MarketplaceUrl:
-      output.MarketplaceUrl !== undefined && output.MarketplaceUrl !== null ? output.MarketplaceUrl : undefined,
-    ProductArn: output.ProductArn !== undefined && output.ProductArn !== null ? output.ProductArn : undefined,
-    ProductName: output.ProductName !== undefined && output.ProductName !== null ? output.ProductName : undefined,
-    ProductSubscriptionResourcePolicy:
-      output.ProductSubscriptionResourcePolicy !== undefined && output.ProductSubscriptionResourcePolicy !== null
-        ? output.ProductSubscriptionResourcePolicy
-        : undefined,
+    MarketplaceUrl: __expectString(output.MarketplaceUrl),
+    ProductArn: __expectString(output.ProductArn),
+    ProductName: __expectString(output.ProductName),
+    ProductSubscriptionResourcePolicy: __expectString(output.ProductSubscriptionResourcePolicy),
   } as any;
 };
 
@@ -18338,15 +17538,15 @@ const deserializeAws_restJson1ProductSubscriptionArnList = (output: any, context
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1Range = (output: any, context: __SerdeContext): Range => {
   return {
-    End: output.End !== undefined && output.End !== null ? output.End : undefined,
-    Start: output.Start !== undefined && output.Start !== null ? output.Start : undefined,
-    StartColumn: output.StartColumn !== undefined && output.StartColumn !== null ? output.StartColumn : undefined,
+    End: __expectNumber(output.End),
+    Start: __expectNumber(output.Start),
+    StartColumn: __expectNumber(output.StartColumn),
   } as any;
 };
 
@@ -18363,15 +17563,15 @@ const deserializeAws_restJson1Ranges = (output: any, context: __SerdeContext): R
 
 const deserializeAws_restJson1Recommendation = (output: any, context: __SerdeContext): Recommendation => {
   return {
-    Text: output.Text !== undefined && output.Text !== null ? output.Text : undefined,
-    Url: output.Url !== undefined && output.Url !== null ? output.Url : undefined,
+    Text: __expectString(output.Text),
+    Url: __expectString(output.Url),
   } as any;
 };
 
 const deserializeAws_restJson1_Record = (output: any, context: __SerdeContext): _Record => {
   return {
-    JsonPath: output.JsonPath !== undefined && output.JsonPath !== null ? output.JsonPath : undefined,
-    RecordIndex: output.RecordIndex !== undefined && output.RecordIndex !== null ? output.RecordIndex : undefined,
+    JsonPath: __expectString(output.JsonPath),
+    RecordIndex: __expectNumber(output.RecordIndex),
   } as any;
 };
 
@@ -18388,8 +17588,8 @@ const deserializeAws_restJson1Records = (output: any, context: __SerdeContext): 
 
 const deserializeAws_restJson1RelatedFinding = (output: any, context: __SerdeContext): RelatedFinding => {
   return {
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    ProductArn: output.ProductArn !== undefined && output.ProductArn !== null ? output.ProductArn : undefined,
+    Id: __expectString(output.Id),
+    ProductArn: __expectString(output.ProductArn),
   } as any;
 };
 
@@ -18411,7 +17611,7 @@ const deserializeAws_restJson1RelatedRequirementsList = (output: any, context: _
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -18434,15 +17634,15 @@ const deserializeAws_restJson1Resource = (output: any, context: __SerdeContext):
       output.Details !== undefined && output.Details !== null
         ? deserializeAws_restJson1ResourceDetails(output.Details, context)
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Partition: output.Partition !== undefined && output.Partition !== null ? output.Partition : undefined,
-    Region: output.Region !== undefined && output.Region !== null ? output.Region : undefined,
-    ResourceRole: output.ResourceRole !== undefined && output.ResourceRole !== null ? output.ResourceRole : undefined,
+    Id: __expectString(output.Id),
+    Partition: __expectString(output.Partition),
+    Region: __expectString(output.Region),
+    ResourceRole: __expectString(output.ResourceRole),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_restJson1FieldMap(output.Tags, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -18647,9 +17847,8 @@ const deserializeAws_restJson1ResourceList = (output: any, context: __SerdeConte
 
 const deserializeAws_restJson1Result = (output: any, context: __SerdeContext): Result => {
   return {
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
-    ProcessingResult:
-      output.ProcessingResult !== undefined && output.ProcessingResult !== null ? output.ProcessingResult : undefined,
+    AccountId: __expectString(output.AccountId),
+    ProcessingResult: __expectString(output.ProcessingResult),
   } as any;
 };
 
@@ -18671,7 +17870,7 @@ const deserializeAws_restJson1SecurityGroups = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -18680,12 +17879,12 @@ const deserializeAws_restJson1SensitiveDataDetections = (
   context: __SerdeContext
 ): SensitiveDataDetections => {
   return {
-    Count: output.Count !== undefined && output.Count !== null ? output.Count : undefined,
+    Count: __expectNumber(output.Count),
     Occurrences:
       output.Occurrences !== undefined && output.Occurrences !== null
         ? deserializeAws_restJson1Occurrences(output.Occurrences, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -18705,12 +17904,12 @@ const deserializeAws_restJson1SensitiveDataDetectionsList = (
 
 const deserializeAws_restJson1SensitiveDataResult = (output: any, context: __SerdeContext): SensitiveDataResult => {
   return {
-    Category: output.Category !== undefined && output.Category !== null ? output.Category : undefined,
+    Category: __expectString(output.Category),
     Detections:
       output.Detections !== undefined && output.Detections !== null
         ? deserializeAws_restJson1SensitiveDataDetectionsList(output.Detections, context)
         : undefined,
-    TotalCount: output.TotalCount !== undefined && output.TotalCount !== null ? output.TotalCount : undefined,
+    TotalCount: __expectNumber(output.TotalCount),
   } as any;
 };
 
@@ -18730,20 +17929,20 @@ const deserializeAws_restJson1SensitiveDataResultList = (
 
 const deserializeAws_restJson1Severity = (output: any, context: __SerdeContext): Severity => {
   return {
-    Label: output.Label !== undefined && output.Label !== null ? output.Label : undefined,
-    Normalized: output.Normalized !== undefined && output.Normalized !== null ? output.Normalized : undefined,
-    Original: output.Original !== undefined && output.Original !== null ? output.Original : undefined,
-    Product: output.Product !== undefined && output.Product !== null ? output.Product : undefined,
+    Label: __expectString(output.Label),
+    Normalized: __expectNumber(output.Normalized),
+    Original: __expectString(output.Original),
+    Product: __expectNumber(output.Product),
   } as any;
 };
 
 const deserializeAws_restJson1SoftwarePackage = (output: any, context: __SerdeContext): SoftwarePackage => {
   return {
-    Architecture: output.Architecture !== undefined && output.Architecture !== null ? output.Architecture : undefined,
-    Epoch: output.Epoch !== undefined && output.Epoch !== null ? output.Epoch : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Release: output.Release !== undefined && output.Release !== null ? output.Release : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    Architecture: __expectString(output.Architecture),
+    Epoch: __expectString(output.Epoch),
+    Name: __expectString(output.Name),
+    Release: __expectString(output.Release),
+    Version: __expectString(output.Version),
   } as any;
 };
 
@@ -18760,11 +17959,10 @@ const deserializeAws_restJson1SoftwarePackageList = (output: any, context: __Ser
 
 const deserializeAws_restJson1Standard = (output: any, context: __SerdeContext): Standard => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    EnabledByDefault:
-      output.EnabledByDefault !== undefined && output.EnabledByDefault !== null ? output.EnabledByDefault : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    StandardsArn: output.StandardsArn !== undefined && output.StandardsArn !== null ? output.StandardsArn : undefined,
+    Description: __expectString(output.Description),
+    EnabledByDefault: __expectBoolean(output.EnabledByDefault),
+    Name: __expectString(output.Name),
+    StandardsArn: __expectString(output.StandardsArn),
   } as any;
 };
 
@@ -18781,29 +17979,22 @@ const deserializeAws_restJson1Standards = (output: any, context: __SerdeContext)
 
 const deserializeAws_restJson1StandardsControl = (output: any, context: __SerdeContext): StandardsControl => {
   return {
-    ControlId: output.ControlId !== undefined && output.ControlId !== null ? output.ControlId : undefined,
-    ControlStatus:
-      output.ControlStatus !== undefined && output.ControlStatus !== null ? output.ControlStatus : undefined,
+    ControlId: __expectString(output.ControlId),
+    ControlStatus: __expectString(output.ControlStatus),
     ControlStatusUpdatedAt:
       output.ControlStatusUpdatedAt !== undefined && output.ControlStatusUpdatedAt !== null
         ? new Date(output.ControlStatusUpdatedAt)
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    DisabledReason:
-      output.DisabledReason !== undefined && output.DisabledReason !== null ? output.DisabledReason : undefined,
+    Description: __expectString(output.Description),
+    DisabledReason: __expectString(output.DisabledReason),
     RelatedRequirements:
       output.RelatedRequirements !== undefined && output.RelatedRequirements !== null
         ? deserializeAws_restJson1RelatedRequirementsList(output.RelatedRequirements, context)
         : undefined,
-    RemediationUrl:
-      output.RemediationUrl !== undefined && output.RemediationUrl !== null ? output.RemediationUrl : undefined,
-    SeverityRating:
-      output.SeverityRating !== undefined && output.SeverityRating !== null ? output.SeverityRating : undefined,
-    StandardsControlArn:
-      output.StandardsControlArn !== undefined && output.StandardsControlArn !== null
-        ? output.StandardsControlArn
-        : undefined,
-    Title: output.Title !== undefined && output.Title !== null ? output.Title : undefined,
+    RemediationUrl: __expectString(output.RemediationUrl),
+    SeverityRating: __expectString(output.SeverityRating),
+    StandardsControlArn: __expectString(output.StandardsControlArn),
+    Title: __expectString(output.Title),
   } as any;
 };
 
@@ -18828,24 +18019,20 @@ const deserializeAws_restJson1StandardsInputParameterMap = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1StandardsSubscription = (output: any, context: __SerdeContext): StandardsSubscription => {
   return {
-    StandardsArn: output.StandardsArn !== undefined && output.StandardsArn !== null ? output.StandardsArn : undefined,
+    StandardsArn: __expectString(output.StandardsArn),
     StandardsInput:
       output.StandardsInput !== undefined && output.StandardsInput !== null
         ? deserializeAws_restJson1StandardsInputParameterMap(output.StandardsInput, context)
         : undefined,
-    StandardsStatus:
-      output.StandardsStatus !== undefined && output.StandardsStatus !== null ? output.StandardsStatus : undefined,
-    StandardsSubscriptionArn:
-      output.StandardsSubscriptionArn !== undefined && output.StandardsSubscriptionArn !== null
-        ? output.StandardsSubscriptionArn
-        : undefined,
+    StandardsStatus: __expectString(output.StandardsStatus),
+    StandardsSubscriptionArn: __expectString(output.StandardsSubscriptionArn),
   } as any;
 };
 
@@ -18865,8 +18052,8 @@ const deserializeAws_restJson1StandardsSubscriptions = (
 
 const deserializeAws_restJson1StatusReason = (output: any, context: __SerdeContext): StatusReason => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    ReasonCode: output.ReasonCode !== undefined && output.ReasonCode !== null ? output.ReasonCode : undefined,
+    Description: __expectString(output.Description),
+    ReasonCode: __expectString(output.ReasonCode),
   } as any;
 };
 
@@ -18883,8 +18070,8 @@ const deserializeAws_restJson1StatusReasonsList = (output: any, context: __Serde
 
 const deserializeAws_restJson1StringFilter = (output: any, context: __SerdeContext): StringFilter => {
   return {
-    Comparison: output.Comparison !== undefined && output.Comparison !== null ? output.Comparison : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Comparison: __expectString(output.Comparison),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -18906,7 +18093,7 @@ const deserializeAws_restJson1StringList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -18917,20 +18104,19 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1ThreatIntelIndicator = (output: any, context: __SerdeContext): ThreatIntelIndicator => {
   return {
-    Category: output.Category !== undefined && output.Category !== null ? output.Category : undefined,
-    LastObservedAt:
-      output.LastObservedAt !== undefined && output.LastObservedAt !== null ? output.LastObservedAt : undefined,
-    Source: output.Source !== undefined && output.Source !== null ? output.Source : undefined,
-    SourceUrl: output.SourceUrl !== undefined && output.SourceUrl !== null ? output.SourceUrl : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Category: __expectString(output.Category),
+    LastObservedAt: __expectString(output.LastObservedAt),
+    Source: __expectString(output.Source),
+    SourceUrl: __expectString(output.SourceUrl),
+    Type: __expectString(output.Type),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -18955,7 +18141,7 @@ const deserializeAws_restJson1TypeList = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -18965,7 +18151,7 @@ const deserializeAws_restJson1Vulnerability = (output: any, context: __SerdeCont
       output.Cvss !== undefined && output.Cvss !== null
         ? deserializeAws_restJson1CvssList(output.Cvss, context)
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    Id: __expectString(output.Id),
     ReferenceUrls:
       output.ReferenceUrls !== undefined && output.ReferenceUrls !== null
         ? deserializeAws_restJson1StringList(output.ReferenceUrls, context)
@@ -18998,26 +18184,23 @@ const deserializeAws_restJson1VulnerabilityList = (output: any, context: __Serde
 
 const deserializeAws_restJson1VulnerabilityVendor = (output: any, context: __SerdeContext): VulnerabilityVendor => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Url: output.Url !== undefined && output.Url !== null ? output.Url : undefined,
-    VendorCreatedAt:
-      output.VendorCreatedAt !== undefined && output.VendorCreatedAt !== null ? output.VendorCreatedAt : undefined,
-    VendorSeverity:
-      output.VendorSeverity !== undefined && output.VendorSeverity !== null ? output.VendorSeverity : undefined,
-    VendorUpdatedAt:
-      output.VendorUpdatedAt !== undefined && output.VendorUpdatedAt !== null ? output.VendorUpdatedAt : undefined,
+    Name: __expectString(output.Name),
+    Url: __expectString(output.Url),
+    VendorCreatedAt: __expectString(output.VendorCreatedAt),
+    VendorSeverity: __expectString(output.VendorSeverity),
+    VendorUpdatedAt: __expectString(output.VendorUpdatedAt),
   } as any;
 };
 
 const deserializeAws_restJson1WafAction = (output: any, context: __SerdeContext): WafAction => {
   return {
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
 const deserializeAws_restJson1WafExcludedRule = (output: any, context: __SerdeContext): WafExcludedRule => {
   return {
-    RuleId: output.RuleId !== undefined && output.RuleId !== null ? output.RuleId : undefined,
+    RuleId: __expectString(output.RuleId),
   } as any;
 };
 
@@ -19034,13 +18217,13 @@ const deserializeAws_restJson1WafExcludedRuleList = (output: any, context: __Ser
 
 const deserializeAws_restJson1WafOverrideAction = (output: any, context: __SerdeContext): WafOverrideAction => {
   return {
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
 const deserializeAws_restJson1Workflow = (output: any, context: __SerdeContext): Workflow => {
   return {
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 

--- a/clients/client-serverlessapplicationrepository/protocols/Aws_restJson1.ts
+++ b/clients/client-serverlessapplicationrepository/protocols/Aws_restJson1.ts
@@ -58,6 +58,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -599,40 +602,40 @@ export const deserializeAws_restJson1CreateApplicationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.applicationId !== undefined && data.applicationId !== null) {
-    contents.ApplicationId = data.applicationId;
+    contents.ApplicationId = __expectString(data.applicationId);
   }
   if (data.author !== undefined && data.author !== null) {
-    contents.Author = data.author;
+    contents.Author = __expectString(data.author);
   }
   if (data.creationTime !== undefined && data.creationTime !== null) {
-    contents.CreationTime = data.creationTime;
+    contents.CreationTime = __expectString(data.creationTime);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.Description = data.description;
+    contents.Description = __expectString(data.description);
   }
   if (data.homePageUrl !== undefined && data.homePageUrl !== null) {
-    contents.HomePageUrl = data.homePageUrl;
+    contents.HomePageUrl = __expectString(data.homePageUrl);
   }
   if (data.isVerifiedAuthor !== undefined && data.isVerifiedAuthor !== null) {
-    contents.IsVerifiedAuthor = data.isVerifiedAuthor;
+    contents.IsVerifiedAuthor = __expectBoolean(data.isVerifiedAuthor);
   }
   if (data.labels !== undefined && data.labels !== null) {
     contents.Labels = deserializeAws_restJson1__listOf__string(data.labels, context);
   }
   if (data.licenseUrl !== undefined && data.licenseUrl !== null) {
-    contents.LicenseUrl = data.licenseUrl;
+    contents.LicenseUrl = __expectString(data.licenseUrl);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.Name = data.name;
+    contents.Name = __expectString(data.name);
   }
   if (data.readmeUrl !== undefined && data.readmeUrl !== null) {
-    contents.ReadmeUrl = data.readmeUrl;
+    contents.ReadmeUrl = __expectString(data.readmeUrl);
   }
   if (data.spdxLicenseId !== undefined && data.spdxLicenseId !== null) {
-    contents.SpdxLicenseId = data.spdxLicenseId;
+    contents.SpdxLicenseId = __expectString(data.spdxLicenseId);
   }
   if (data.verifiedAuthorUrl !== undefined && data.verifiedAuthorUrl !== null) {
-    contents.VerifiedAuthorUrl = data.verifiedAuthorUrl;
+    contents.VerifiedAuthorUrl = __expectString(data.verifiedAuthorUrl);
   }
   if (data.version !== undefined && data.version !== null) {
     contents.Version = deserializeAws_restJson1Version(data.version, context);
@@ -730,10 +733,10 @@ export const deserializeAws_restJson1CreateApplicationVersionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.applicationId !== undefined && data.applicationId !== null) {
-    contents.ApplicationId = data.applicationId;
+    contents.ApplicationId = __expectString(data.applicationId);
   }
   if (data.creationTime !== undefined && data.creationTime !== null) {
-    contents.CreationTime = data.creationTime;
+    contents.CreationTime = __expectString(data.creationTime);
   }
   if (data.parameterDefinitions !== undefined && data.parameterDefinitions !== null) {
     contents.ParameterDefinitions = deserializeAws_restJson1__listOfParameterDefinition(
@@ -745,19 +748,19 @@ export const deserializeAws_restJson1CreateApplicationVersionCommand = async (
     contents.RequiredCapabilities = deserializeAws_restJson1__listOfCapability(data.requiredCapabilities, context);
   }
   if (data.resourcesSupported !== undefined && data.resourcesSupported !== null) {
-    contents.ResourcesSupported = data.resourcesSupported;
+    contents.ResourcesSupported = __expectBoolean(data.resourcesSupported);
   }
   if (data.semanticVersion !== undefined && data.semanticVersion !== null) {
-    contents.SemanticVersion = data.semanticVersion;
+    contents.SemanticVersion = __expectString(data.semanticVersion);
   }
   if (data.sourceCodeArchiveUrl !== undefined && data.sourceCodeArchiveUrl !== null) {
-    contents.SourceCodeArchiveUrl = data.sourceCodeArchiveUrl;
+    contents.SourceCodeArchiveUrl = __expectString(data.sourceCodeArchiveUrl);
   }
   if (data.sourceCodeUrl !== undefined && data.sourceCodeUrl !== null) {
-    contents.SourceCodeUrl = data.sourceCodeUrl;
+    contents.SourceCodeUrl = __expectString(data.sourceCodeUrl);
   }
   if (data.templateUrl !== undefined && data.templateUrl !== null) {
-    contents.TemplateUrl = data.templateUrl;
+    contents.TemplateUrl = __expectString(data.templateUrl);
   }
   return Promise.resolve(contents);
 };
@@ -847,16 +850,16 @@ export const deserializeAws_restJson1CreateCloudFormationChangeSetCommand = asyn
   };
   const data: any = await parseBody(output.body, context);
   if (data.applicationId !== undefined && data.applicationId !== null) {
-    contents.ApplicationId = data.applicationId;
+    contents.ApplicationId = __expectString(data.applicationId);
   }
   if (data.changeSetId !== undefined && data.changeSetId !== null) {
-    contents.ChangeSetId = data.changeSetId;
+    contents.ChangeSetId = __expectString(data.changeSetId);
   }
   if (data.semanticVersion !== undefined && data.semanticVersion !== null) {
-    contents.SemanticVersion = data.semanticVersion;
+    contents.SemanticVersion = __expectString(data.semanticVersion);
   }
   if (data.stackId !== undefined && data.stackId !== null) {
-    contents.StackId = data.stackId;
+    contents.StackId = __expectString(data.stackId);
   }
   return Promise.resolve(contents);
 };
@@ -941,25 +944,25 @@ export const deserializeAws_restJson1CreateCloudFormationTemplateCommand = async
   };
   const data: any = await parseBody(output.body, context);
   if (data.applicationId !== undefined && data.applicationId !== null) {
-    contents.ApplicationId = data.applicationId;
+    contents.ApplicationId = __expectString(data.applicationId);
   }
   if (data.creationTime !== undefined && data.creationTime !== null) {
-    contents.CreationTime = data.creationTime;
+    contents.CreationTime = __expectString(data.creationTime);
   }
   if (data.expirationTime !== undefined && data.expirationTime !== null) {
-    contents.ExpirationTime = data.expirationTime;
+    contents.ExpirationTime = __expectString(data.expirationTime);
   }
   if (data.semanticVersion !== undefined && data.semanticVersion !== null) {
-    contents.SemanticVersion = data.semanticVersion;
+    contents.SemanticVersion = __expectString(data.semanticVersion);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.Status = data.status;
+    contents.Status = __expectString(data.status);
   }
   if (data.templateId !== undefined && data.templateId !== null) {
-    contents.TemplateId = data.templateId;
+    contents.TemplateId = __expectString(data.templateId);
   }
   if (data.templateUrl !== undefined && data.templateUrl !== null) {
-    contents.TemplateUrl = data.templateUrl;
+    contents.TemplateUrl = __expectString(data.templateUrl);
   }
   return Promise.resolve(contents);
 };
@@ -1149,40 +1152,40 @@ export const deserializeAws_restJson1GetApplicationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.applicationId !== undefined && data.applicationId !== null) {
-    contents.ApplicationId = data.applicationId;
+    contents.ApplicationId = __expectString(data.applicationId);
   }
   if (data.author !== undefined && data.author !== null) {
-    contents.Author = data.author;
+    contents.Author = __expectString(data.author);
   }
   if (data.creationTime !== undefined && data.creationTime !== null) {
-    contents.CreationTime = data.creationTime;
+    contents.CreationTime = __expectString(data.creationTime);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.Description = data.description;
+    contents.Description = __expectString(data.description);
   }
   if (data.homePageUrl !== undefined && data.homePageUrl !== null) {
-    contents.HomePageUrl = data.homePageUrl;
+    contents.HomePageUrl = __expectString(data.homePageUrl);
   }
   if (data.isVerifiedAuthor !== undefined && data.isVerifiedAuthor !== null) {
-    contents.IsVerifiedAuthor = data.isVerifiedAuthor;
+    contents.IsVerifiedAuthor = __expectBoolean(data.isVerifiedAuthor);
   }
   if (data.labels !== undefined && data.labels !== null) {
     contents.Labels = deserializeAws_restJson1__listOf__string(data.labels, context);
   }
   if (data.licenseUrl !== undefined && data.licenseUrl !== null) {
-    contents.LicenseUrl = data.licenseUrl;
+    contents.LicenseUrl = __expectString(data.licenseUrl);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.Name = data.name;
+    contents.Name = __expectString(data.name);
   }
   if (data.readmeUrl !== undefined && data.readmeUrl !== null) {
-    contents.ReadmeUrl = data.readmeUrl;
+    contents.ReadmeUrl = __expectString(data.readmeUrl);
   }
   if (data.spdxLicenseId !== undefined && data.spdxLicenseId !== null) {
-    contents.SpdxLicenseId = data.spdxLicenseId;
+    contents.SpdxLicenseId = __expectString(data.spdxLicenseId);
   }
   if (data.verifiedAuthorUrl !== undefined && data.verifiedAuthorUrl !== null) {
-    contents.VerifiedAuthorUrl = data.verifiedAuthorUrl;
+    contents.VerifiedAuthorUrl = __expectString(data.verifiedAuthorUrl);
   }
   if (data.version !== undefined && data.version !== null) {
     contents.Version = deserializeAws_restJson1Version(data.version, context);
@@ -1365,25 +1368,25 @@ export const deserializeAws_restJson1GetCloudFormationTemplateCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.applicationId !== undefined && data.applicationId !== null) {
-    contents.ApplicationId = data.applicationId;
+    contents.ApplicationId = __expectString(data.applicationId);
   }
   if (data.creationTime !== undefined && data.creationTime !== null) {
-    contents.CreationTime = data.creationTime;
+    contents.CreationTime = __expectString(data.creationTime);
   }
   if (data.expirationTime !== undefined && data.expirationTime !== null) {
-    contents.ExpirationTime = data.expirationTime;
+    contents.ExpirationTime = __expectString(data.expirationTime);
   }
   if (data.semanticVersion !== undefined && data.semanticVersion !== null) {
-    contents.SemanticVersion = data.semanticVersion;
+    contents.SemanticVersion = __expectString(data.semanticVersion);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.Status = data.status;
+    contents.Status = __expectString(data.status);
   }
   if (data.templateId !== undefined && data.templateId !== null) {
-    contents.TemplateId = data.templateId;
+    contents.TemplateId = __expectString(data.templateId);
   }
   if (data.templateUrl !== undefined && data.templateUrl !== null) {
-    contents.TemplateUrl = data.templateUrl;
+    contents.TemplateUrl = __expectString(data.templateUrl);
   }
   return Promise.resolve(contents);
 };
@@ -1474,7 +1477,7 @@ export const deserializeAws_restJson1ListApplicationDependenciesCommand = async 
     contents.Dependencies = deserializeAws_restJson1__listOfApplicationDependencySummary(data.dependencies, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1565,7 +1568,7 @@ export const deserializeAws_restJson1ListApplicationsCommand = async (
     contents.Applications = deserializeAws_restJson1__listOfApplicationSummary(data.applications, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1645,7 +1648,7 @@ export const deserializeAws_restJson1ListApplicationVersionsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.NextToken = data.nextToken;
+    contents.NextToken = __expectString(data.nextToken);
   }
   if (data.versions !== undefined && data.versions !== null) {
     contents.Versions = deserializeAws_restJson1__listOfVersionSummary(data.versions, context);
@@ -1917,40 +1920,40 @@ export const deserializeAws_restJson1UpdateApplicationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.applicationId !== undefined && data.applicationId !== null) {
-    contents.ApplicationId = data.applicationId;
+    contents.ApplicationId = __expectString(data.applicationId);
   }
   if (data.author !== undefined && data.author !== null) {
-    contents.Author = data.author;
+    contents.Author = __expectString(data.author);
   }
   if (data.creationTime !== undefined && data.creationTime !== null) {
-    contents.CreationTime = data.creationTime;
+    contents.CreationTime = __expectString(data.creationTime);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.Description = data.description;
+    contents.Description = __expectString(data.description);
   }
   if (data.homePageUrl !== undefined && data.homePageUrl !== null) {
-    contents.HomePageUrl = data.homePageUrl;
+    contents.HomePageUrl = __expectString(data.homePageUrl);
   }
   if (data.isVerifiedAuthor !== undefined && data.isVerifiedAuthor !== null) {
-    contents.IsVerifiedAuthor = data.isVerifiedAuthor;
+    contents.IsVerifiedAuthor = __expectBoolean(data.isVerifiedAuthor);
   }
   if (data.labels !== undefined && data.labels !== null) {
     contents.Labels = deserializeAws_restJson1__listOf__string(data.labels, context);
   }
   if (data.licenseUrl !== undefined && data.licenseUrl !== null) {
-    contents.LicenseUrl = data.licenseUrl;
+    contents.LicenseUrl = __expectString(data.licenseUrl);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.Name = data.name;
+    contents.Name = __expectString(data.name);
   }
   if (data.readmeUrl !== undefined && data.readmeUrl !== null) {
-    contents.ReadmeUrl = data.readmeUrl;
+    contents.ReadmeUrl = __expectString(data.readmeUrl);
   }
   if (data.spdxLicenseId !== undefined && data.spdxLicenseId !== null) {
-    contents.SpdxLicenseId = data.spdxLicenseId;
+    contents.SpdxLicenseId = __expectString(data.spdxLicenseId);
   }
   if (data.verifiedAuthorUrl !== undefined && data.verifiedAuthorUrl !== null) {
-    contents.VerifiedAuthorUrl = data.verifiedAuthorUrl;
+    contents.VerifiedAuthorUrl = __expectString(data.verifiedAuthorUrl);
   }
   if (data.version !== undefined && data.version !== null) {
     contents.Version = deserializeAws_restJson1Version(data.version, context);
@@ -2048,10 +2051,10 @@ const deserializeAws_restJson1BadRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.errorCode !== undefined && data.errorCode !== null) {
-    contents.ErrorCode = data.errorCode;
+    contents.ErrorCode = __expectString(data.errorCode);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -2069,10 +2072,10 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.errorCode !== undefined && data.errorCode !== null) {
-    contents.ErrorCode = data.errorCode;
+    contents.ErrorCode = __expectString(data.errorCode);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -2090,10 +2093,10 @@ const deserializeAws_restJson1ForbiddenExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.errorCode !== undefined && data.errorCode !== null) {
-    contents.ErrorCode = data.errorCode;
+    contents.ErrorCode = __expectString(data.errorCode);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -2111,10 +2114,10 @@ const deserializeAws_restJson1InternalServerErrorExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.errorCode !== undefined && data.errorCode !== null) {
-    contents.ErrorCode = data.errorCode;
+    contents.ErrorCode = __expectString(data.errorCode);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -2132,10 +2135,10 @@ const deserializeAws_restJson1NotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.errorCode !== undefined && data.errorCode !== null) {
-    contents.ErrorCode = data.errorCode;
+    contents.ErrorCode = __expectString(data.errorCode);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -2153,10 +2156,10 @@ const deserializeAws_restJson1TooManyRequestsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.errorCode !== undefined && data.errorCode !== null) {
-    contents.ErrorCode = data.errorCode;
+    contents.ErrorCode = __expectString(data.errorCode);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.Message = data.message;
+    contents.Message = __expectString(data.message);
   }
   return contents;
 };
@@ -2275,7 +2278,7 @@ const deserializeAws_restJson1__listOf__string = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2328,7 +2331,7 @@ const deserializeAws_restJson1__listOfCapability = (output: any, context: __Serd
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2362,10 +2365,8 @@ const deserializeAws_restJson1ApplicationDependencySummary = (
   context: __SerdeContext
 ): ApplicationDependencySummary => {
   return {
-    ApplicationId:
-      output.applicationId !== undefined && output.applicationId !== null ? output.applicationId : undefined,
-    SemanticVersion:
-      output.semanticVersion !== undefined && output.semanticVersion !== null ? output.semanticVersion : undefined,
+    ApplicationId: __expectString(output.applicationId),
+    SemanticVersion: __expectString(output.semanticVersion),
   } as any;
 };
 
@@ -2386,61 +2387,54 @@ const deserializeAws_restJson1ApplicationPolicyStatement = (
       output.principals !== undefined && output.principals !== null
         ? deserializeAws_restJson1__listOf__string(output.principals, context)
         : undefined,
-    StatementId: output.statementId !== undefined && output.statementId !== null ? output.statementId : undefined,
+    StatementId: __expectString(output.statementId),
   } as any;
 };
 
 const deserializeAws_restJson1ApplicationSummary = (output: any, context: __SerdeContext): ApplicationSummary => {
   return {
-    ApplicationId:
-      output.applicationId !== undefined && output.applicationId !== null ? output.applicationId : undefined,
-    Author: output.author !== undefined && output.author !== null ? output.author : undefined,
-    CreationTime: output.creationTime !== undefined && output.creationTime !== null ? output.creationTime : undefined,
-    Description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    HomePageUrl: output.homePageUrl !== undefined && output.homePageUrl !== null ? output.homePageUrl : undefined,
+    ApplicationId: __expectString(output.applicationId),
+    Author: __expectString(output.author),
+    CreationTime: __expectString(output.creationTime),
+    Description: __expectString(output.description),
+    HomePageUrl: __expectString(output.homePageUrl),
     Labels:
       output.labels !== undefined && output.labels !== null
         ? deserializeAws_restJson1__listOf__string(output.labels, context)
         : undefined,
-    Name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    SpdxLicenseId:
-      output.spdxLicenseId !== undefined && output.spdxLicenseId !== null ? output.spdxLicenseId : undefined,
+    Name: __expectString(output.name),
+    SpdxLicenseId: __expectString(output.spdxLicenseId),
   } as any;
 };
 
 const deserializeAws_restJson1ParameterDefinition = (output: any, context: __SerdeContext): ParameterDefinition => {
   return {
-    AllowedPattern:
-      output.allowedPattern !== undefined && output.allowedPattern !== null ? output.allowedPattern : undefined,
+    AllowedPattern: __expectString(output.allowedPattern),
     AllowedValues:
       output.allowedValues !== undefined && output.allowedValues !== null
         ? deserializeAws_restJson1__listOf__string(output.allowedValues, context)
         : undefined,
-    ConstraintDescription:
-      output.constraintDescription !== undefined && output.constraintDescription !== null
-        ? output.constraintDescription
-        : undefined,
-    DefaultValue: output.defaultValue !== undefined && output.defaultValue !== null ? output.defaultValue : undefined,
-    Description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    MaxLength: output.maxLength !== undefined && output.maxLength !== null ? output.maxLength : undefined,
-    MaxValue: output.maxValue !== undefined && output.maxValue !== null ? output.maxValue : undefined,
-    MinLength: output.minLength !== undefined && output.minLength !== null ? output.minLength : undefined,
-    MinValue: output.minValue !== undefined && output.minValue !== null ? output.minValue : undefined,
-    Name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    NoEcho: output.noEcho !== undefined && output.noEcho !== null ? output.noEcho : undefined,
+    ConstraintDescription: __expectString(output.constraintDescription),
+    DefaultValue: __expectString(output.defaultValue),
+    Description: __expectString(output.description),
+    MaxLength: __expectNumber(output.maxLength),
+    MaxValue: __expectNumber(output.maxValue),
+    MinLength: __expectNumber(output.minLength),
+    MinValue: __expectNumber(output.minValue),
+    Name: __expectString(output.name),
+    NoEcho: __expectBoolean(output.noEcho),
     ReferencedByResources:
       output.referencedByResources !== undefined && output.referencedByResources !== null
         ? deserializeAws_restJson1__listOf__string(output.referencedByResources, context)
         : undefined,
-    Type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    Type: __expectString(output.type),
   } as any;
 };
 
 const deserializeAws_restJson1Version = (output: any, context: __SerdeContext): Version => {
   return {
-    ApplicationId:
-      output.applicationId !== undefined && output.applicationId !== null ? output.applicationId : undefined,
-    CreationTime: output.creationTime !== undefined && output.creationTime !== null ? output.creationTime : undefined,
+    ApplicationId: __expectString(output.applicationId),
+    CreationTime: __expectString(output.creationTime),
     ParameterDefinitions:
       output.parameterDefinitions !== undefined && output.parameterDefinitions !== null
         ? deserializeAws_restJson1__listOfParameterDefinition(output.parameterDefinitions, context)
@@ -2449,31 +2443,20 @@ const deserializeAws_restJson1Version = (output: any, context: __SerdeContext): 
       output.requiredCapabilities !== undefined && output.requiredCapabilities !== null
         ? deserializeAws_restJson1__listOfCapability(output.requiredCapabilities, context)
         : undefined,
-    ResourcesSupported:
-      output.resourcesSupported !== undefined && output.resourcesSupported !== null
-        ? output.resourcesSupported
-        : undefined,
-    SemanticVersion:
-      output.semanticVersion !== undefined && output.semanticVersion !== null ? output.semanticVersion : undefined,
-    SourceCodeArchiveUrl:
-      output.sourceCodeArchiveUrl !== undefined && output.sourceCodeArchiveUrl !== null
-        ? output.sourceCodeArchiveUrl
-        : undefined,
-    SourceCodeUrl:
-      output.sourceCodeUrl !== undefined && output.sourceCodeUrl !== null ? output.sourceCodeUrl : undefined,
-    TemplateUrl: output.templateUrl !== undefined && output.templateUrl !== null ? output.templateUrl : undefined,
+    ResourcesSupported: __expectBoolean(output.resourcesSupported),
+    SemanticVersion: __expectString(output.semanticVersion),
+    SourceCodeArchiveUrl: __expectString(output.sourceCodeArchiveUrl),
+    SourceCodeUrl: __expectString(output.sourceCodeUrl),
+    TemplateUrl: __expectString(output.templateUrl),
   } as any;
 };
 
 const deserializeAws_restJson1VersionSummary = (output: any, context: __SerdeContext): VersionSummary => {
   return {
-    ApplicationId:
-      output.applicationId !== undefined && output.applicationId !== null ? output.applicationId : undefined,
-    CreationTime: output.creationTime !== undefined && output.creationTime !== null ? output.creationTime : undefined,
-    SemanticVersion:
-      output.semanticVersion !== undefined && output.semanticVersion !== null ? output.semanticVersion : undefined,
-    SourceCodeUrl:
-      output.sourceCodeUrl !== undefined && output.sourceCodeUrl !== null ? output.sourceCodeUrl : undefined,
+    ApplicationId: __expectString(output.applicationId),
+    CreationTime: __expectString(output.creationTime),
+    SemanticVersion: __expectString(output.semanticVersion),
+    SourceCodeUrl: __expectString(output.sourceCodeUrl),
   } as any;
 };
 

--- a/clients/client-service-catalog-appregistry/protocols/Aws_restJson1.ts
+++ b/clients/client-service-catalog-appregistry/protocols/Aws_restJson1.ts
@@ -63,6 +63,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -733,10 +735,10 @@ export const deserializeAws_restJson1AssociateAttributeGroupCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.applicationArn !== undefined && data.applicationArn !== null) {
-    contents.applicationArn = data.applicationArn;
+    contents.applicationArn = __expectString(data.applicationArn);
   }
   if (data.attributeGroupArn !== undefined && data.attributeGroupArn !== null) {
-    contents.attributeGroupArn = data.attributeGroupArn;
+    contents.attributeGroupArn = __expectString(data.attributeGroupArn);
   }
   return Promise.resolve(contents);
 };
@@ -816,10 +818,10 @@ export const deserializeAws_restJson1AssociateResourceCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.applicationArn !== undefined && data.applicationArn !== null) {
-    contents.applicationArn = data.applicationArn;
+    contents.applicationArn = __expectString(data.applicationArn);
   }
   if (data.resourceArn !== undefined && data.resourceArn !== null) {
-    contents.resourceArn = data.resourceArn;
+    contents.resourceArn = __expectString(data.resourceArn);
   }
   return Promise.resolve(contents);
 };
@@ -1191,10 +1193,10 @@ export const deserializeAws_restJson1DisassociateAttributeGroupCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.applicationArn !== undefined && data.applicationArn !== null) {
-    contents.applicationArn = data.applicationArn;
+    contents.applicationArn = __expectString(data.applicationArn);
   }
   if (data.attributeGroupArn !== undefined && data.attributeGroupArn !== null) {
-    contents.attributeGroupArn = data.attributeGroupArn;
+    contents.attributeGroupArn = __expectString(data.attributeGroupArn);
   }
   return Promise.resolve(contents);
 };
@@ -1266,10 +1268,10 @@ export const deserializeAws_restJson1DisassociateResourceCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.applicationArn !== undefined && data.applicationArn !== null) {
-    contents.applicationArn = data.applicationArn;
+    contents.applicationArn = __expectString(data.applicationArn);
   }
   if (data.resourceArn !== undefined && data.resourceArn !== null) {
-    contents.resourceArn = data.resourceArn;
+    contents.resourceArn = __expectString(data.resourceArn);
   }
   return Promise.resolve(contents);
 };
@@ -1339,25 +1341,25 @@ export const deserializeAws_restJson1GetApplicationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.associatedResourceCount !== undefined && data.associatedResourceCount !== null) {
-    contents.associatedResourceCount = data.associatedResourceCount;
+    contents.associatedResourceCount = __expectNumber(data.associatedResourceCount);
   }
   if (data.creationTime !== undefined && data.creationTime !== null) {
     contents.creationTime = new Date(data.creationTime);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   if (data.lastUpdateTime !== undefined && data.lastUpdateTime !== null) {
     contents.lastUpdateTime = new Date(data.lastUpdateTime);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1Tags(data.tags, context);
@@ -1438,25 +1440,25 @@ export const deserializeAws_restJson1GetAttributeGroupCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.attributes !== undefined && data.attributes !== null) {
-    contents.attributes = data.attributes;
+    contents.attributes = __expectString(data.attributes);
   }
   if (data.creationTime !== undefined && data.creationTime !== null) {
     contents.creationTime = new Date(data.creationTime);
   }
   if (data.description !== undefined && data.description !== null) {
-    contents.description = data.description;
+    contents.description = __expectString(data.description);
   }
   if (data.id !== undefined && data.id !== null) {
-    contents.id = data.id;
+    contents.id = __expectString(data.id);
   }
   if (data.lastUpdateTime !== undefined && data.lastUpdateTime !== null) {
     contents.lastUpdateTime = new Date(data.lastUpdateTime);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1Tags(data.tags, context);
@@ -1534,7 +1536,7 @@ export const deserializeAws_restJson1ListApplicationsCommand = async (
     contents.applications = deserializeAws_restJson1ApplicationSummaries(data.applications, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1601,7 +1603,7 @@ export const deserializeAws_restJson1ListAssociatedAttributeGroupsCommand = asyn
     contents.attributeGroups = deserializeAws_restJson1AttributeGroupIds(data.attributeGroups, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1673,7 +1675,7 @@ export const deserializeAws_restJson1ListAssociatedResourcesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.resources !== undefined && data.resources !== null) {
     contents.resources = deserializeAws_restJson1Resources(data.resources, context);
@@ -1751,7 +1753,7 @@ export const deserializeAws_restJson1ListAttributeGroupsCommand = async (
     contents.attributeGroups = deserializeAws_restJson1AttributeGroupSummaries(data.attributeGroups, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1887,13 +1889,13 @@ export const deserializeAws_restJson1SyncResourceCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.actionTaken !== undefined && data.actionTaken !== null) {
-    contents.actionTaken = data.actionTaken;
+    contents.actionTaken = __expectString(data.actionTaken);
   }
   if (data.applicationArn !== undefined && data.applicationArn !== null) {
-    contents.applicationArn = data.applicationArn;
+    contents.applicationArn = __expectString(data.applicationArn);
   }
   if (data.resourceArn !== undefined && data.resourceArn !== null) {
-    contents.resourceArn = data.resourceArn;
+    contents.resourceArn = __expectString(data.resourceArn);
   }
   return Promise.resolve(contents);
 };
@@ -2247,7 +2249,7 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2264,7 +2266,7 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2281,7 +2283,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2298,7 +2300,7 @@ const deserializeAws_restJson1ServiceQuotaExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2315,7 +2317,7 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2334,16 +2336,16 @@ const serializeAws_restJson1Tags = (input: { [key: string]: string }, context: _
 
 const deserializeAws_restJson1Application = (output: any, context: __SerdeContext): Application => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null ? new Date(output.creationTime) : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    description: __expectString(output.description),
+    id: __expectString(output.id),
     lastUpdateTime:
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
         ? new Date(output.lastUpdateTime)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1Tags(output.tags, context)
@@ -2364,31 +2366,31 @@ const deserializeAws_restJson1ApplicationSummaries = (output: any, context: __Se
 
 const deserializeAws_restJson1ApplicationSummary = (output: any, context: __SerdeContext): ApplicationSummary => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null ? new Date(output.creationTime) : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    description: __expectString(output.description),
+    id: __expectString(output.id),
     lastUpdateTime:
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
         ? new Date(output.lastUpdateTime)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
   } as any;
 };
 
 const deserializeAws_restJson1AttributeGroup = (output: any, context: __SerdeContext): AttributeGroup => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null ? new Date(output.creationTime) : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    description: __expectString(output.description),
+    id: __expectString(output.id),
     lastUpdateTime:
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
         ? new Date(output.lastUpdateTime)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1Tags(output.tags, context)
@@ -2403,7 +2405,7 @@ const deserializeAws_restJson1AttributeGroupIds = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2423,23 +2425,23 @@ const deserializeAws_restJson1AttributeGroupSummaries = (
 
 const deserializeAws_restJson1AttributeGroupSummary = (output: any, context: __SerdeContext): AttributeGroupSummary => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null ? new Date(output.creationTime) : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    description: __expectString(output.description),
+    id: __expectString(output.id),
     lastUpdateTime:
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
         ? new Date(output.lastUpdateTime)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
   } as any;
 };
 
 const deserializeAws_restJson1ResourceInfo = (output: any, context: __SerdeContext): ResourceInfo => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    arn: __expectString(output.arn),
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -2461,7 +2463,7 @@ const deserializeAws_restJson1Tags = (output: any, context: __SerdeContext): { [
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };

--- a/clients/client-service-catalog/protocols/Aws_json1_1.ts
+++ b/clients/client-service-catalog/protocols/Aws_json1_1.ts
@@ -516,7 +516,12 @@ import {
   UsageInstruction,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -9067,7 +9072,7 @@ const deserializeAws_json1_1AccountIds = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -9078,7 +9083,7 @@ const deserializeAws_json1_1AllowedValues = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -9143,7 +9148,7 @@ const deserializeAws_json1_1BatchDisassociateServiceActionFromProvisioningArtifa
 
 const deserializeAws_json1_1BudgetDetail = (output: any, context: __SerdeContext): BudgetDetail => {
   return {
-    BudgetName: output.BudgetName !== undefined && output.BudgetName !== null ? output.BudgetName : undefined,
+    BudgetName: __expectString(output.BudgetName),
   } as any;
 };
 
@@ -9160,7 +9165,7 @@ const deserializeAws_json1_1Budgets = (output: any, context: __SerdeContext): Bu
 
 const deserializeAws_json1_1CloudWatchDashboard = (output: any, context: __SerdeContext): CloudWatchDashboard => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -9177,12 +9182,12 @@ const deserializeAws_json1_1CloudWatchDashboards = (output: any, context: __Serd
 
 const deserializeAws_json1_1ConstraintDetail = (output: any, context: __SerdeContext): ConstraintDetail => {
   return {
-    ConstraintId: output.ConstraintId !== undefined && output.ConstraintId !== null ? output.ConstraintId : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Owner: output.Owner !== undefined && output.Owner !== null ? output.Owner : undefined,
-    PortfolioId: output.PortfolioId !== undefined && output.PortfolioId !== null ? output.PortfolioId : undefined,
-    ProductId: output.ProductId !== undefined && output.ProductId !== null ? output.ProductId : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    ConstraintId: __expectString(output.ConstraintId),
+    Description: __expectString(output.Description),
+    Owner: __expectString(output.Owner),
+    PortfolioId: __expectString(output.PortfolioId),
+    ProductId: __expectString(output.ProductId),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -9210,15 +9215,14 @@ const deserializeAws_json1_1ConstraintSummaries = (output: any, context: __Serde
 
 const deserializeAws_json1_1ConstraintSummary = (output: any, context: __SerdeContext): ConstraintSummary => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Description: __expectString(output.Description),
+    Type: __expectString(output.Type),
   } as any;
 };
 
 const deserializeAws_json1_1CopyProductOutput = (output: any, context: __SerdeContext): CopyProductOutput => {
   return {
-    CopyProductToken:
-      output.CopyProductToken !== undefined && output.CopyProductToken !== null ? output.CopyProductToken : undefined,
+    CopyProductToken: __expectString(output.CopyProductToken),
   } as any;
 };
 
@@ -9228,11 +9232,8 @@ const deserializeAws_json1_1CreateConstraintOutput = (output: any, context: __Se
       output.ConstraintDetail !== undefined && output.ConstraintDetail !== null
         ? deserializeAws_json1_1ConstraintDetail(output.ConstraintDetail, context)
         : undefined,
-    ConstraintParameters:
-      output.ConstraintParameters !== undefined && output.ConstraintParameters !== null
-        ? output.ConstraintParameters
-        : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    ConstraintParameters: __expectString(output.ConstraintParameters),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -9252,10 +9253,7 @@ const deserializeAws_json1_1CreatePortfolioShareOutput = (
   context: __SerdeContext
 ): CreatePortfolioShareOutput => {
   return {
-    PortfolioShareToken:
-      output.PortfolioShareToken !== undefined && output.PortfolioShareToken !== null
-        ? output.PortfolioShareToken
-        : undefined,
+    PortfolioShareToken: __expectString(output.PortfolioShareToken),
   } as any;
 };
 
@@ -9279,20 +9277,11 @@ const deserializeAws_json1_1CreateProvisionedProductPlanOutput = (
   context: __SerdeContext
 ): CreateProvisionedProductPlanOutput => {
   return {
-    PlanId: output.PlanId !== undefined && output.PlanId !== null ? output.PlanId : undefined,
-    PlanName: output.PlanName !== undefined && output.PlanName !== null ? output.PlanName : undefined,
-    ProvisionProductId:
-      output.ProvisionProductId !== undefined && output.ProvisionProductId !== null
-        ? output.ProvisionProductId
-        : undefined,
-    ProvisionedProductName:
-      output.ProvisionedProductName !== undefined && output.ProvisionedProductName !== null
-        ? output.ProvisionedProductName
-        : undefined,
-    ProvisioningArtifactId:
-      output.ProvisioningArtifactId !== undefined && output.ProvisioningArtifactId !== null
-        ? output.ProvisioningArtifactId
-        : undefined,
+    PlanId: __expectString(output.PlanId),
+    PlanName: __expectString(output.PlanName),
+    ProvisionProductId: __expectString(output.ProvisionProductId),
+    ProvisionedProductName: __expectString(output.ProvisionedProductName),
+    ProvisioningArtifactId: __expectString(output.ProvisioningArtifactId),
   } as any;
 };
 
@@ -9309,7 +9298,7 @@ const deserializeAws_json1_1CreateProvisioningArtifactOutput = (
       output.ProvisioningArtifactDetail !== undefined && output.ProvisioningArtifactDetail !== null
         ? deserializeAws_json1_1ProvisioningArtifactDetail(output.ProvisioningArtifactDetail, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -9347,10 +9336,7 @@ const deserializeAws_json1_1DeletePortfolioShareOutput = (
   context: __SerdeContext
 ): DeletePortfolioShareOutput => {
   return {
-    PortfolioShareToken:
-      output.PortfolioShareToken !== undefined && output.PortfolioShareToken !== null
-        ? output.PortfolioShareToken
-        : undefined,
+    PortfolioShareToken: __expectString(output.PortfolioShareToken),
   } as any;
 };
 
@@ -9392,11 +9378,8 @@ const deserializeAws_json1_1DescribeConstraintOutput = (
       output.ConstraintDetail !== undefined && output.ConstraintDetail !== null
         ? deserializeAws_json1_1ConstraintDetail(output.ConstraintDetail, context)
         : undefined,
-    ConstraintParameters:
-      output.ConstraintParameters !== undefined && output.ConstraintParameters !== null
-        ? output.ConstraintParameters
-        : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    ConstraintParameters: __expectString(output.ConstraintParameters),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -9405,13 +9388,9 @@ const deserializeAws_json1_1DescribeCopyProductStatusOutput = (
   context: __SerdeContext
 ): DescribeCopyProductStatusOutput => {
   return {
-    CopyProductStatus:
-      output.CopyProductStatus !== undefined && output.CopyProductStatus !== null
-        ? output.CopyProductStatus
-        : undefined,
-    StatusDetail: output.StatusDetail !== undefined && output.StatusDetail !== null ? output.StatusDetail : undefined,
-    TargetProductId:
-      output.TargetProductId !== undefined && output.TargetProductId !== null ? output.TargetProductId : undefined,
+    CopyProductStatus: __expectString(output.CopyProductStatus),
+    StatusDetail: __expectString(output.StatusDetail),
+    TargetProductId: __expectString(output.TargetProductId),
   } as any;
 };
 
@@ -9442,8 +9421,7 @@ const deserializeAws_json1_1DescribePortfolioSharesOutput = (
   context: __SerdeContext
 ): DescribePortfolioSharesOutput => {
   return {
-    NextPageToken:
-      output.NextPageToken !== undefined && output.NextPageToken !== null ? output.NextPageToken : undefined,
+    NextPageToken: __expectString(output.NextPageToken),
     PortfolioShareDetails:
       output.PortfolioShareDetails !== undefined && output.PortfolioShareDetails !== null
         ? deserializeAws_json1_1PortfolioShareDetails(output.PortfolioShareDetails, context)
@@ -9456,20 +9434,14 @@ const deserializeAws_json1_1DescribePortfolioShareStatusOutput = (
   context: __SerdeContext
 ): DescribePortfolioShareStatusOutput => {
   return {
-    OrganizationNodeValue:
-      output.OrganizationNodeValue !== undefined && output.OrganizationNodeValue !== null
-        ? output.OrganizationNodeValue
-        : undefined,
-    PortfolioId: output.PortfolioId !== undefined && output.PortfolioId !== null ? output.PortfolioId : undefined,
-    PortfolioShareToken:
-      output.PortfolioShareToken !== undefined && output.PortfolioShareToken !== null
-        ? output.PortfolioShareToken
-        : undefined,
+    OrganizationNodeValue: __expectString(output.OrganizationNodeValue),
+    PortfolioId: __expectString(output.PortfolioId),
+    PortfolioShareToken: __expectString(output.PortfolioShareToken),
     ShareDetails:
       output.ShareDetails !== undefined && output.ShareDetails !== null
         ? deserializeAws_json1_1ShareDetails(output.ShareDetails, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -9557,8 +9529,7 @@ const deserializeAws_json1_1DescribeProvisionedProductPlanOutput = (
   context: __SerdeContext
 ): DescribeProvisionedProductPlanOutput => {
   return {
-    NextPageToken:
-      output.NextPageToken !== undefined && output.NextPageToken !== null ? output.NextPageToken : undefined,
+    NextPageToken: __expectString(output.NextPageToken),
     ProvisionedProductPlanDetails:
       output.ProvisionedProductPlanDetails !== undefined && output.ProvisionedProductPlanDetails !== null
         ? deserializeAws_json1_1ProvisionedProductPlanDetails(output.ProvisionedProductPlanDetails, context)
@@ -9583,7 +9554,7 @@ const deserializeAws_json1_1DescribeProvisioningArtifactOutput = (
       output.ProvisioningArtifactDetail !== undefined && output.ProvisioningArtifactDetail !== null
         ? deserializeAws_json1_1ProvisioningArtifactDetail(output.ProvisioningArtifactDetail, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -9621,8 +9592,7 @@ const deserializeAws_json1_1DescribeProvisioningParametersOutput = (
 
 const deserializeAws_json1_1DescribeRecordOutput = (output: any, context: __SerdeContext): DescribeRecordOutput => {
   return {
-    NextPageToken:
-      output.NextPageToken !== undefined && output.NextPageToken !== null ? output.NextPageToken : undefined,
+    NextPageToken: __expectString(output.NextPageToken),
     RecordDetail:
       output.RecordDetail !== undefined && output.RecordDetail !== null
         ? deserializeAws_json1_1RecordDetail(output.RecordDetail, context)
@@ -9717,7 +9687,7 @@ const deserializeAws_json1_1DuplicateResourceException = (
   context: __SerdeContext
 ): DuplicateResourceException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -9758,8 +9728,8 @@ const deserializeAws_json1_1ExecutionParameter = (output: any, context: __SerdeC
       output.DefaultValues !== undefined && output.DefaultValues !== null
         ? deserializeAws_json1_1ExecutionParameterValueList(output.DefaultValues, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Name: __expectString(output.Name),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -9781,7 +9751,7 @@ const deserializeAws_json1_1ExecutionParameterValueList = (output: any, context:
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -9790,15 +9760,11 @@ const deserializeAws_json1_1FailedServiceActionAssociation = (
   context: __SerdeContext
 ): FailedServiceActionAssociation => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    ProductId: output.ProductId !== undefined && output.ProductId !== null ? output.ProductId : undefined,
-    ProvisioningArtifactId:
-      output.ProvisioningArtifactId !== undefined && output.ProvisioningArtifactId !== null
-        ? output.ProvisioningArtifactId
-        : undefined,
-    ServiceActionId:
-      output.ServiceActionId !== undefined && output.ServiceActionId !== null ? output.ServiceActionId : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
+    ProductId: __expectString(output.ProductId),
+    ProvisioningArtifactId: __expectString(output.ProvisioningArtifactId),
+    ServiceActionId: __expectString(output.ServiceActionId),
   } as any;
 };
 
@@ -9821,7 +9787,7 @@ const deserializeAws_json1_1GetAWSOrganizationsAccessStatusOutput = (
   context: __SerdeContext
 ): GetAWSOrganizationsAccessStatusOutput => {
   return {
-    AccessStatus: output.AccessStatus !== undefined && output.AccessStatus !== null ? output.AccessStatus : undefined,
+    AccessStatus: __expectString(output.AccessStatus),
   } as any;
 };
 
@@ -9830,8 +9796,7 @@ const deserializeAws_json1_1GetProvisionedProductOutputsOutput = (
   context: __SerdeContext
 ): GetProvisionedProductOutputsOutput => {
   return {
-    NextPageToken:
-      output.NextPageToken !== undefined && output.NextPageToken !== null ? output.NextPageToken : undefined,
+    NextPageToken: __expectString(output.NextPageToken),
     Outputs:
       output.Outputs !== undefined && output.Outputs !== null
         ? deserializeAws_json1_1RecordOutputs(output.Outputs, context)
@@ -9856,20 +9821,20 @@ const deserializeAws_json1_1InvalidParametersException = (
   context: __SerdeContext
 ): InvalidParametersException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidStateException = (output: any, context: __SerdeContext): InvalidStateException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1LaunchPath = (output: any, context: __SerdeContext): LaunchPath => {
   return {
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -9901,8 +9866,8 @@ const deserializeAws_json1_1LaunchPathSummary = (output: any, context: __SerdeCo
       output.ConstraintSummaries !== undefined && output.ConstraintSummaries !== null
         ? deserializeAws_json1_1ConstraintSummaries(output.ConstraintSummaries, context)
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
     Tags:
       output.Tags !== undefined && output.Tags !== null ? deserializeAws_json1_1Tags(output.Tags, context) : undefined,
   } as any;
@@ -9910,7 +9875,7 @@ const deserializeAws_json1_1LaunchPathSummary = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -9919,8 +9884,7 @@ const deserializeAws_json1_1ListAcceptedPortfolioSharesOutput = (
   context: __SerdeContext
 ): ListAcceptedPortfolioSharesOutput => {
   return {
-    NextPageToken:
-      output.NextPageToken !== undefined && output.NextPageToken !== null ? output.NextPageToken : undefined,
+    NextPageToken: __expectString(output.NextPageToken),
     PortfolioDetails:
       output.PortfolioDetails !== undefined && output.PortfolioDetails !== null
         ? deserializeAws_json1_1PortfolioDetails(output.PortfolioDetails, context)
@@ -9937,8 +9901,7 @@ const deserializeAws_json1_1ListBudgetsForResourceOutput = (
       output.Budgets !== undefined && output.Budgets !== null
         ? deserializeAws_json1_1Budgets(output.Budgets, context)
         : undefined,
-    NextPageToken:
-      output.NextPageToken !== undefined && output.NextPageToken !== null ? output.NextPageToken : undefined,
+    NextPageToken: __expectString(output.NextPageToken),
   } as any;
 };
 
@@ -9951,8 +9914,7 @@ const deserializeAws_json1_1ListConstraintsForPortfolioOutput = (
       output.ConstraintDetails !== undefined && output.ConstraintDetails !== null
         ? deserializeAws_json1_1ConstraintDetails(output.ConstraintDetails, context)
         : undefined,
-    NextPageToken:
-      output.NextPageToken !== undefined && output.NextPageToken !== null ? output.NextPageToken : undefined,
+    NextPageToken: __expectString(output.NextPageToken),
   } as any;
 };
 
@@ -9962,8 +9924,7 @@ const deserializeAws_json1_1ListLaunchPathsOutput = (output: any, context: __Ser
       output.LaunchPathSummaries !== undefined && output.LaunchPathSummaries !== null
         ? deserializeAws_json1_1LaunchPathSummaries(output.LaunchPathSummaries, context)
         : undefined,
-    NextPageToken:
-      output.NextPageToken !== undefined && output.NextPageToken !== null ? output.NextPageToken : undefined,
+    NextPageToken: __expectString(output.NextPageToken),
   } as any;
 };
 
@@ -9972,8 +9933,7 @@ const deserializeAws_json1_1ListOrganizationPortfolioAccessOutput = (
   context: __SerdeContext
 ): ListOrganizationPortfolioAccessOutput => {
   return {
-    NextPageToken:
-      output.NextPageToken !== undefined && output.NextPageToken !== null ? output.NextPageToken : undefined,
+    NextPageToken: __expectString(output.NextPageToken),
     OrganizationNodes:
       output.OrganizationNodes !== undefined && output.OrganizationNodes !== null
         ? deserializeAws_json1_1OrganizationNodes(output.OrganizationNodes, context)
@@ -9990,8 +9950,7 @@ const deserializeAws_json1_1ListPortfolioAccessOutput = (
       output.AccountIds !== undefined && output.AccountIds !== null
         ? deserializeAws_json1_1AccountIds(output.AccountIds, context)
         : undefined,
-    NextPageToken:
-      output.NextPageToken !== undefined && output.NextPageToken !== null ? output.NextPageToken : undefined,
+    NextPageToken: __expectString(output.NextPageToken),
   } as any;
 };
 
@@ -10000,8 +9959,7 @@ const deserializeAws_json1_1ListPortfoliosForProductOutput = (
   context: __SerdeContext
 ): ListPortfoliosForProductOutput => {
   return {
-    NextPageToken:
-      output.NextPageToken !== undefined && output.NextPageToken !== null ? output.NextPageToken : undefined,
+    NextPageToken: __expectString(output.NextPageToken),
     PortfolioDetails:
       output.PortfolioDetails !== undefined && output.PortfolioDetails !== null
         ? deserializeAws_json1_1PortfolioDetails(output.PortfolioDetails, context)
@@ -10011,8 +9969,7 @@ const deserializeAws_json1_1ListPortfoliosForProductOutput = (
 
 const deserializeAws_json1_1ListPortfoliosOutput = (output: any, context: __SerdeContext): ListPortfoliosOutput => {
   return {
-    NextPageToken:
-      output.NextPageToken !== undefined && output.NextPageToken !== null ? output.NextPageToken : undefined,
+    NextPageToken: __expectString(output.NextPageToken),
     PortfolioDetails:
       output.PortfolioDetails !== undefined && output.PortfolioDetails !== null
         ? deserializeAws_json1_1PortfolioDetails(output.PortfolioDetails, context)
@@ -10025,8 +9982,7 @@ const deserializeAws_json1_1ListPrincipalsForPortfolioOutput = (
   context: __SerdeContext
 ): ListPrincipalsForPortfolioOutput => {
   return {
-    NextPageToken:
-      output.NextPageToken !== undefined && output.NextPageToken !== null ? output.NextPageToken : undefined,
+    NextPageToken: __expectString(output.NextPageToken),
     Principals:
       output.Principals !== undefined && output.Principals !== null
         ? deserializeAws_json1_1Principals(output.Principals, context)
@@ -10039,8 +9995,7 @@ const deserializeAws_json1_1ListProvisionedProductPlansOutput = (
   context: __SerdeContext
 ): ListProvisionedProductPlansOutput => {
   return {
-    NextPageToken:
-      output.NextPageToken !== undefined && output.NextPageToken !== null ? output.NextPageToken : undefined,
+    NextPageToken: __expectString(output.NextPageToken),
     ProvisionedProductPlans:
       output.ProvisionedProductPlans !== undefined && output.ProvisionedProductPlans !== null
         ? deserializeAws_json1_1ProvisionedProductPlans(output.ProvisionedProductPlans, context)
@@ -10053,8 +10008,7 @@ const deserializeAws_json1_1ListProvisioningArtifactsForServiceActionOutput = (
   context: __SerdeContext
 ): ListProvisioningArtifactsForServiceActionOutput => {
   return {
-    NextPageToken:
-      output.NextPageToken !== undefined && output.NextPageToken !== null ? output.NextPageToken : undefined,
+    NextPageToken: __expectString(output.NextPageToken),
     ProvisioningArtifactViews:
       output.ProvisioningArtifactViews !== undefined && output.ProvisioningArtifactViews !== null
         ? deserializeAws_json1_1ProvisioningArtifactViews(output.ProvisioningArtifactViews, context)
@@ -10067,8 +10021,7 @@ const deserializeAws_json1_1ListProvisioningArtifactsOutput = (
   context: __SerdeContext
 ): ListProvisioningArtifactsOutput => {
   return {
-    NextPageToken:
-      output.NextPageToken !== undefined && output.NextPageToken !== null ? output.NextPageToken : undefined,
+    NextPageToken: __expectString(output.NextPageToken),
     ProvisioningArtifactDetails:
       output.ProvisioningArtifactDetails !== undefined && output.ProvisioningArtifactDetails !== null
         ? deserializeAws_json1_1ProvisioningArtifactDetails(output.ProvisioningArtifactDetails, context)
@@ -10081,8 +10034,7 @@ const deserializeAws_json1_1ListRecordHistoryOutput = (
   context: __SerdeContext
 ): ListRecordHistoryOutput => {
   return {
-    NextPageToken:
-      output.NextPageToken !== undefined && output.NextPageToken !== null ? output.NextPageToken : undefined,
+    NextPageToken: __expectString(output.NextPageToken),
     RecordDetails:
       output.RecordDetails !== undefined && output.RecordDetails !== null
         ? deserializeAws_json1_1RecordDetails(output.RecordDetails, context)
@@ -10095,7 +10047,7 @@ const deserializeAws_json1_1ListResourcesForTagOptionOutput = (
   context: __SerdeContext
 ): ListResourcesForTagOptionOutput => {
   return {
-    PageToken: output.PageToken !== undefined && output.PageToken !== null ? output.PageToken : undefined,
+    PageToken: __expectString(output.PageToken),
     ResourceDetails:
       output.ResourceDetails !== undefined && output.ResourceDetails !== null
         ? deserializeAws_json1_1ResourceDetails(output.ResourceDetails, context)
@@ -10108,8 +10060,7 @@ const deserializeAws_json1_1ListServiceActionsForProvisioningArtifactOutput = (
   context: __SerdeContext
 ): ListServiceActionsForProvisioningArtifactOutput => {
   return {
-    NextPageToken:
-      output.NextPageToken !== undefined && output.NextPageToken !== null ? output.NextPageToken : undefined,
+    NextPageToken: __expectString(output.NextPageToken),
     ServiceActionSummaries:
       output.ServiceActionSummaries !== undefined && output.ServiceActionSummaries !== null
         ? deserializeAws_json1_1ServiceActionSummaries(output.ServiceActionSummaries, context)
@@ -10122,8 +10073,7 @@ const deserializeAws_json1_1ListServiceActionsOutput = (
   context: __SerdeContext
 ): ListServiceActionsOutput => {
   return {
-    NextPageToken:
-      output.NextPageToken !== undefined && output.NextPageToken !== null ? output.NextPageToken : undefined,
+    NextPageToken: __expectString(output.NextPageToken),
     ServiceActionSummaries:
       output.ServiceActionSummaries !== undefined && output.ServiceActionSummaries !== null
         ? deserializeAws_json1_1ServiceActionSummaries(output.ServiceActionSummaries, context)
@@ -10136,8 +10086,7 @@ const deserializeAws_json1_1ListStackInstancesForProvisionedProductOutput = (
   context: __SerdeContext
 ): ListStackInstancesForProvisionedProductOutput => {
   return {
-    NextPageToken:
-      output.NextPageToken !== undefined && output.NextPageToken !== null ? output.NextPageToken : undefined,
+    NextPageToken: __expectString(output.NextPageToken),
     StackInstances:
       output.StackInstances !== undefined && output.StackInstances !== null
         ? deserializeAws_json1_1StackInstances(output.StackInstances, context)
@@ -10147,7 +10096,7 @@ const deserializeAws_json1_1ListStackInstancesForProvisionedProductOutput = (
 
 const deserializeAws_json1_1ListTagOptionsOutput = (output: any, context: __SerdeContext): ListTagOptionsOutput => {
   return {
-    PageToken: output.PageToken !== undefined && output.PageToken !== null ? output.PageToken : undefined,
+    PageToken: __expectString(output.PageToken),
     TagOptionDetails:
       output.TagOptionDetails !== undefined && output.TagOptionDetails !== null
         ? deserializeAws_json1_1TagOptionDetails(output.TagOptionDetails, context)
@@ -10162,7 +10111,7 @@ const deserializeAws_json1_1Namespaces = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -10173,7 +10122,7 @@ const deserializeAws_json1_1NotificationArns = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -10182,14 +10131,14 @@ const deserializeAws_json1_1OperationNotSupportedException = (
   context: __SerdeContext
 ): OperationNotSupportedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1OrganizationNode = (output: any, context: __SerdeContext): OrganizationNode => {
   return {
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Type: __expectString(output.Type),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -10206,34 +10155,30 @@ const deserializeAws_json1_1OrganizationNodes = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1ParameterConstraints = (output: any, context: __SerdeContext): ParameterConstraints => {
   return {
-    AllowedPattern:
-      output.AllowedPattern !== undefined && output.AllowedPattern !== null ? output.AllowedPattern : undefined,
+    AllowedPattern: __expectString(output.AllowedPattern),
     AllowedValues:
       output.AllowedValues !== undefined && output.AllowedValues !== null
         ? deserializeAws_json1_1AllowedValues(output.AllowedValues, context)
         : undefined,
-    ConstraintDescription:
-      output.ConstraintDescription !== undefined && output.ConstraintDescription !== null
-        ? output.ConstraintDescription
-        : undefined,
-    MaxLength: output.MaxLength !== undefined && output.MaxLength !== null ? output.MaxLength : undefined,
-    MaxValue: output.MaxValue !== undefined && output.MaxValue !== null ? output.MaxValue : undefined,
-    MinLength: output.MinLength !== undefined && output.MinLength !== null ? output.MinLength : undefined,
-    MinValue: output.MinValue !== undefined && output.MinValue !== null ? output.MinValue : undefined,
+    ConstraintDescription: __expectString(output.ConstraintDescription),
+    MaxLength: __expectString(output.MaxLength),
+    MaxValue: __expectString(output.MaxValue),
+    MinLength: __expectString(output.MinLength),
+    MinValue: __expectString(output.MinValue),
   } as any;
 };
 
 const deserializeAws_json1_1PortfolioDetail = (output: any, context: __SerdeContext): PortfolioDetail => {
   return {
-    ARN: output.ARN !== undefined && output.ARN !== null ? output.ARN : undefined,
+    ARN: __expectString(output.ARN),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    DisplayName: output.DisplayName !== undefined && output.DisplayName !== null ? output.DisplayName : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    ProviderName: output.ProviderName !== undefined && output.ProviderName !== null ? output.ProviderName : undefined,
+    Description: __expectString(output.Description),
+    DisplayName: __expectString(output.DisplayName),
+    Id: __expectString(output.Id),
+    ProviderName: __expectString(output.ProviderName),
   } as any;
 };
 
@@ -10250,11 +10195,10 @@ const deserializeAws_json1_1PortfolioDetails = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1PortfolioShareDetail = (output: any, context: __SerdeContext): PortfolioShareDetail => {
   return {
-    Accepted: output.Accepted !== undefined && output.Accepted !== null ? output.Accepted : undefined,
-    PrincipalId: output.PrincipalId !== undefined && output.PrincipalId !== null ? output.PrincipalId : undefined,
-    ShareTagOptions:
-      output.ShareTagOptions !== undefined && output.ShareTagOptions !== null ? output.ShareTagOptions : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Accepted: __expectBoolean(output.Accepted),
+    PrincipalId: __expectString(output.PrincipalId),
+    ShareTagOptions: __expectBoolean(output.ShareTagOptions),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -10271,9 +10215,8 @@ const deserializeAws_json1_1PortfolioShareDetails = (output: any, context: __Ser
 
 const deserializeAws_json1_1Principal = (output: any, context: __SerdeContext): Principal => {
   return {
-    PrincipalARN: output.PrincipalARN !== undefined && output.PrincipalARN !== null ? output.PrincipalARN : undefined,
-    PrincipalType:
-      output.PrincipalType !== undefined && output.PrincipalType !== null ? output.PrincipalType : undefined,
+    PrincipalARN: __expectString(output.PrincipalARN),
+    PrincipalType: __expectString(output.PrincipalType),
   } as any;
 };
 
@@ -10311,9 +10254,8 @@ const deserializeAws_json1_1ProductViewAggregationValue = (
   context: __SerdeContext
 ): ProductViewAggregationValue => {
   return {
-    ApproximateCount:
-      output.ApproximateCount !== undefined && output.ApproximateCount !== null ? output.ApproximateCount : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    ApproximateCount: __expectNumber(output.ApproximateCount),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -10337,12 +10279,12 @@ const deserializeAws_json1_1ProductViewDetail = (output: any, context: __SerdeCo
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
         : undefined,
-    ProductARN: output.ProductARN !== undefined && output.ProductARN !== null ? output.ProductARN : undefined,
+    ProductARN: __expectString(output.ProductARN),
     ProductViewSummary:
       output.ProductViewSummary !== undefined && output.ProductViewSummary !== null
         ? deserializeAws_json1_1ProductViewSummary(output.ProductViewSummary, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -10370,22 +10312,17 @@ const deserializeAws_json1_1ProductViewSummaries = (output: any, context: __Serd
 
 const deserializeAws_json1_1ProductViewSummary = (output: any, context: __SerdeContext): ProductViewSummary => {
   return {
-    Distributor: output.Distributor !== undefined && output.Distributor !== null ? output.Distributor : undefined,
-    HasDefaultPath:
-      output.HasDefaultPath !== undefined && output.HasDefaultPath !== null ? output.HasDefaultPath : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Owner: output.Owner !== undefined && output.Owner !== null ? output.Owner : undefined,
-    ProductId: output.ProductId !== undefined && output.ProductId !== null ? output.ProductId : undefined,
-    ShortDescription:
-      output.ShortDescription !== undefined && output.ShortDescription !== null ? output.ShortDescription : undefined,
-    SupportDescription:
-      output.SupportDescription !== undefined && output.SupportDescription !== null
-        ? output.SupportDescription
-        : undefined,
-    SupportEmail: output.SupportEmail !== undefined && output.SupportEmail !== null ? output.SupportEmail : undefined,
-    SupportUrl: output.SupportUrl !== undefined && output.SupportUrl !== null ? output.SupportUrl : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Distributor: __expectString(output.Distributor),
+    HasDefaultPath: __expectBoolean(output.HasDefaultPath),
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
+    Owner: __expectString(output.Owner),
+    ProductId: __expectString(output.ProductId),
+    ShortDescription: __expectString(output.ShortDescription),
+    SupportDescription: __expectString(output.SupportDescription),
+    SupportEmail: __expectString(output.SupportEmail),
+    SupportUrl: __expectString(output.SupportUrl),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -10394,44 +10331,29 @@ const deserializeAws_json1_1ProvisionedProductAttribute = (
   context: __SerdeContext
 ): ProvisionedProductAttribute => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    IdempotencyToken:
-      output.IdempotencyToken !== undefined && output.IdempotencyToken !== null ? output.IdempotencyToken : undefined,
-    LastProvisioningRecordId:
-      output.LastProvisioningRecordId !== undefined && output.LastProvisioningRecordId !== null
-        ? output.LastProvisioningRecordId
-        : undefined,
-    LastRecordId: output.LastRecordId !== undefined && output.LastRecordId !== null ? output.LastRecordId : undefined,
-    LastSuccessfulProvisioningRecordId:
-      output.LastSuccessfulProvisioningRecordId !== undefined && output.LastSuccessfulProvisioningRecordId !== null
-        ? output.LastSuccessfulProvisioningRecordId
-        : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    PhysicalId: output.PhysicalId !== undefined && output.PhysicalId !== null ? output.PhysicalId : undefined,
-    ProductId: output.ProductId !== undefined && output.ProductId !== null ? output.ProductId : undefined,
-    ProductName: output.ProductName !== undefined && output.ProductName !== null ? output.ProductName : undefined,
-    ProvisioningArtifactId:
-      output.ProvisioningArtifactId !== undefined && output.ProvisioningArtifactId !== null
-        ? output.ProvisioningArtifactId
-        : undefined,
-    ProvisioningArtifactName:
-      output.ProvisioningArtifactName !== undefined && output.ProvisioningArtifactName !== null
-        ? output.ProvisioningArtifactName
-        : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusMessage:
-      output.StatusMessage !== undefined && output.StatusMessage !== null ? output.StatusMessage : undefined,
+    Id: __expectString(output.Id),
+    IdempotencyToken: __expectString(output.IdempotencyToken),
+    LastProvisioningRecordId: __expectString(output.LastProvisioningRecordId),
+    LastRecordId: __expectString(output.LastRecordId),
+    LastSuccessfulProvisioningRecordId: __expectString(output.LastSuccessfulProvisioningRecordId),
+    Name: __expectString(output.Name),
+    PhysicalId: __expectString(output.PhysicalId),
+    ProductId: __expectString(output.ProductId),
+    ProductName: __expectString(output.ProductName),
+    ProvisioningArtifactId: __expectString(output.ProvisioningArtifactId),
+    ProvisioningArtifactName: __expectString(output.ProvisioningArtifactName),
+    Status: __expectString(output.Status),
+    StatusMessage: __expectString(output.StatusMessage),
     Tags:
       output.Tags !== undefined && output.Tags !== null ? deserializeAws_json1_1Tags(output.Tags, context) : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    UserArn: output.UserArn !== undefined && output.UserArn !== null ? output.UserArn : undefined,
-    UserArnSession:
-      output.UserArnSession !== undefined && output.UserArnSession !== null ? output.UserArnSession : undefined,
+    Type: __expectString(output.Type),
+    UserArn: __expectString(output.UserArn),
+    UserArnSession: __expectString(output.UserArnSession),
   } as any;
 };
 
@@ -10454,35 +10376,23 @@ const deserializeAws_json1_1ProvisionedProductDetail = (
   context: __SerdeContext
 ): ProvisionedProductDetail => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    IdempotencyToken:
-      output.IdempotencyToken !== undefined && output.IdempotencyToken !== null ? output.IdempotencyToken : undefined,
-    LastProvisioningRecordId:
-      output.LastProvisioningRecordId !== undefined && output.LastProvisioningRecordId !== null
-        ? output.LastProvisioningRecordId
-        : undefined,
-    LastRecordId: output.LastRecordId !== undefined && output.LastRecordId !== null ? output.LastRecordId : undefined,
-    LastSuccessfulProvisioningRecordId:
-      output.LastSuccessfulProvisioningRecordId !== undefined && output.LastSuccessfulProvisioningRecordId !== null
-        ? output.LastSuccessfulProvisioningRecordId
-        : undefined,
-    LaunchRoleArn:
-      output.LaunchRoleArn !== undefined && output.LaunchRoleArn !== null ? output.LaunchRoleArn : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    ProductId: output.ProductId !== undefined && output.ProductId !== null ? output.ProductId : undefined,
-    ProvisioningArtifactId:
-      output.ProvisioningArtifactId !== undefined && output.ProvisioningArtifactId !== null
-        ? output.ProvisioningArtifactId
-        : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusMessage:
-      output.StatusMessage !== undefined && output.StatusMessage !== null ? output.StatusMessage : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Id: __expectString(output.Id),
+    IdempotencyToken: __expectString(output.IdempotencyToken),
+    LastProvisioningRecordId: __expectString(output.LastProvisioningRecordId),
+    LastRecordId: __expectString(output.LastRecordId),
+    LastSuccessfulProvisioningRecordId: __expectString(output.LastSuccessfulProvisioningRecordId),
+    LaunchRoleArn: __expectString(output.LaunchRoleArn),
+    Name: __expectString(output.Name),
+    ProductId: __expectString(output.ProductId),
+    ProvisioningArtifactId: __expectString(output.ProvisioningArtifactId),
+    Status: __expectString(output.Status),
+    StatusMessage: __expectString(output.StatusMessage),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -10513,30 +10423,20 @@ const deserializeAws_json1_1ProvisionedProductPlanDetails = (
       output.NotificationArns !== undefined && output.NotificationArns !== null
         ? deserializeAws_json1_1NotificationArns(output.NotificationArns, context)
         : undefined,
-    PathId: output.PathId !== undefined && output.PathId !== null ? output.PathId : undefined,
-    PlanId: output.PlanId !== undefined && output.PlanId !== null ? output.PlanId : undefined,
-    PlanName: output.PlanName !== undefined && output.PlanName !== null ? output.PlanName : undefined,
-    PlanType: output.PlanType !== undefined && output.PlanType !== null ? output.PlanType : undefined,
-    ProductId: output.ProductId !== undefined && output.ProductId !== null ? output.ProductId : undefined,
-    ProvisionProductId:
-      output.ProvisionProductId !== undefined && output.ProvisionProductId !== null
-        ? output.ProvisionProductId
-        : undefined,
-    ProvisionProductName:
-      output.ProvisionProductName !== undefined && output.ProvisionProductName !== null
-        ? output.ProvisionProductName
-        : undefined,
-    ProvisioningArtifactId:
-      output.ProvisioningArtifactId !== undefined && output.ProvisioningArtifactId !== null
-        ? output.ProvisioningArtifactId
-        : undefined,
+    PathId: __expectString(output.PathId),
+    PlanId: __expectString(output.PlanId),
+    PlanName: __expectString(output.PlanName),
+    PlanType: __expectString(output.PlanType),
+    ProductId: __expectString(output.ProductId),
+    ProvisionProductId: __expectString(output.ProvisionProductId),
+    ProvisionProductName: __expectString(output.ProvisionProductName),
+    ProvisioningArtifactId: __expectString(output.ProvisioningArtifactId),
     ProvisioningParameters:
       output.ProvisioningParameters !== undefined && output.ProvisioningParameters !== null
         ? deserializeAws_json1_1UpdateProvisioningParameters(output.ProvisioningParameters, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusMessage:
-      output.StatusMessage !== undefined && output.StatusMessage !== null ? output.StatusMessage : undefined,
+    Status: __expectString(output.Status),
+    StatusMessage: __expectString(output.StatusMessage),
     Tags:
       output.Tags !== undefined && output.Tags !== null ? deserializeAws_json1_1Tags(output.Tags, context) : undefined,
     UpdatedTime:
@@ -10565,21 +10465,12 @@ const deserializeAws_json1_1ProvisionedProductPlanSummary = (
   context: __SerdeContext
 ): ProvisionedProductPlanSummary => {
   return {
-    PlanId: output.PlanId !== undefined && output.PlanId !== null ? output.PlanId : undefined,
-    PlanName: output.PlanName !== undefined && output.PlanName !== null ? output.PlanName : undefined,
-    PlanType: output.PlanType !== undefined && output.PlanType !== null ? output.PlanType : undefined,
-    ProvisionProductId:
-      output.ProvisionProductId !== undefined && output.ProvisionProductId !== null
-        ? output.ProvisionProductId
-        : undefined,
-    ProvisionProductName:
-      output.ProvisionProductName !== undefined && output.ProvisionProductName !== null
-        ? output.ProvisionProductName
-        : undefined,
-    ProvisioningArtifactId:
-      output.ProvisioningArtifactId !== undefined && output.ProvisioningArtifactId !== null
-        ? output.ProvisioningArtifactId
-        : undefined,
+    PlanId: __expectString(output.PlanId),
+    PlanName: __expectString(output.PlanName),
+    PlanType: __expectString(output.PlanType),
+    ProvisionProductId: __expectString(output.ProvisionProductId),
+    ProvisionProductName: __expectString(output.ProvisionProductName),
+    ProvisioningArtifactId: __expectString(output.ProvisioningArtifactId),
   } as any;
 };
 
@@ -10593,7 +10484,7 @@ const deserializeAws_json1_1ProvisionedProductProperties = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -10604,10 +10495,10 @@ const deserializeAws_json1_1ProvisioningArtifact = (output: any, context: __Serd
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Guidance: output.Guidance !== undefined && output.Guidance !== null ? output.Guidance : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Description: __expectString(output.Description),
+    Guidance: __expectString(output.Guidance),
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -10616,16 +10507,16 @@ const deserializeAws_json1_1ProvisioningArtifactDetail = (
   context: __SerdeContext
 ): ProvisioningArtifactDetail => {
   return {
-    Active: output.Active !== undefined && output.Active !== null ? output.Active : undefined,
+    Active: __expectBoolean(output.Active),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Guidance: output.Guidance !== undefined && output.Guidance !== null ? output.Guidance : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Description: __expectString(output.Description),
+    Guidance: __expectString(output.Guidance),
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -10653,7 +10544,7 @@ const deserializeAws_json1_1ProvisioningArtifactInfo = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -10663,8 +10554,8 @@ const deserializeAws_json1_1ProvisioningArtifactOutput = (
   context: __SerdeContext
 ): ProvisioningArtifactOutput => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
+    Description: __expectString(output.Description),
+    Key: __expectString(output.Key),
   } as any;
 };
 
@@ -10687,16 +10578,15 @@ const deserializeAws_json1_1ProvisioningArtifactParameter = (
   context: __SerdeContext
 ): ProvisioningArtifactParameter => {
   return {
-    DefaultValue: output.DefaultValue !== undefined && output.DefaultValue !== null ? output.DefaultValue : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    IsNoEcho: output.IsNoEcho !== undefined && output.IsNoEcho !== null ? output.IsNoEcho : undefined,
+    DefaultValue: __expectString(output.DefaultValue),
+    Description: __expectString(output.Description),
+    IsNoEcho: __expectBoolean(output.IsNoEcho),
     ParameterConstraints:
       output.ParameterConstraints !== undefined && output.ParameterConstraints !== null
         ? deserializeAws_json1_1ParameterConstraints(output.ParameterConstraints, context)
         : undefined,
-    ParameterKey: output.ParameterKey !== undefined && output.ParameterKey !== null ? output.ParameterKey : undefined,
-    ParameterType:
-      output.ParameterType !== undefined && output.ParameterType !== null ? output.ParameterType : undefined,
+    ParameterKey: __expectString(output.ParameterKey),
+    ParameterType: __expectString(output.ParameterType),
   } as any;
 };
 
@@ -10764,9 +10654,9 @@ const deserializeAws_json1_1ProvisioningArtifactSummary = (
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Description: __expectString(output.Description),
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
     ProvisioningArtifactMetadata:
       output.ProvisioningArtifactMetadata !== undefined && output.ProvisioningArtifactMetadata !== null
         ? deserializeAws_json1_1ProvisioningArtifactInfo(output.ProvisioningArtifactMetadata, context)
@@ -10819,37 +10709,24 @@ const deserializeAws_json1_1RecordDetail = (output: any, context: __SerdeContext
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
         : undefined,
-    LaunchRoleArn:
-      output.LaunchRoleArn !== undefined && output.LaunchRoleArn !== null ? output.LaunchRoleArn : undefined,
-    PathId: output.PathId !== undefined && output.PathId !== null ? output.PathId : undefined,
-    ProductId: output.ProductId !== undefined && output.ProductId !== null ? output.ProductId : undefined,
-    ProvisionedProductId:
-      output.ProvisionedProductId !== undefined && output.ProvisionedProductId !== null
-        ? output.ProvisionedProductId
-        : undefined,
-    ProvisionedProductName:
-      output.ProvisionedProductName !== undefined && output.ProvisionedProductName !== null
-        ? output.ProvisionedProductName
-        : undefined,
-    ProvisionedProductType:
-      output.ProvisionedProductType !== undefined && output.ProvisionedProductType !== null
-        ? output.ProvisionedProductType
-        : undefined,
-    ProvisioningArtifactId:
-      output.ProvisioningArtifactId !== undefined && output.ProvisioningArtifactId !== null
-        ? output.ProvisioningArtifactId
-        : undefined,
+    LaunchRoleArn: __expectString(output.LaunchRoleArn),
+    PathId: __expectString(output.PathId),
+    ProductId: __expectString(output.ProductId),
+    ProvisionedProductId: __expectString(output.ProvisionedProductId),
+    ProvisionedProductName: __expectString(output.ProvisionedProductName),
+    ProvisionedProductType: __expectString(output.ProvisionedProductType),
+    ProvisioningArtifactId: __expectString(output.ProvisioningArtifactId),
     RecordErrors:
       output.RecordErrors !== undefined && output.RecordErrors !== null
         ? deserializeAws_json1_1RecordErrors(output.RecordErrors, context)
         : undefined,
-    RecordId: output.RecordId !== undefined && output.RecordId !== null ? output.RecordId : undefined,
+    RecordId: __expectString(output.RecordId),
     RecordTags:
       output.RecordTags !== undefined && output.RecordTags !== null
         ? deserializeAws_json1_1RecordTags(output.RecordTags, context)
         : undefined,
-    RecordType: output.RecordType !== undefined && output.RecordType !== null ? output.RecordType : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    RecordType: __expectString(output.RecordType),
+    Status: __expectString(output.Status),
     UpdatedTime:
       output.UpdatedTime !== undefined && output.UpdatedTime !== null
         ? new Date(Math.round(output.UpdatedTime * 1000))
@@ -10870,8 +10747,8 @@ const deserializeAws_json1_1RecordDetails = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1RecordError = (output: any, context: __SerdeContext): RecordError => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Code: __expectString(output.Code),
+    Description: __expectString(output.Description),
   } as any;
 };
 
@@ -10888,9 +10765,9 @@ const deserializeAws_json1_1RecordErrors = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_1RecordOutput = (output: any, context: __SerdeContext): RecordOutput => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    OutputKey: output.OutputKey !== undefined && output.OutputKey !== null ? output.OutputKey : undefined,
-    OutputValue: output.OutputValue !== undefined && output.OutputValue !== null ? output.OutputValue : undefined,
+    Description: __expectString(output.Description),
+    OutputKey: __expectString(output.OutputKey),
+    OutputValue: __expectString(output.OutputValue),
   } as any;
 };
 
@@ -10907,8 +10784,8 @@ const deserializeAws_json1_1RecordOutputs = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1RecordTag = (output: any, context: __SerdeContext): RecordTag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -10932,21 +10809,15 @@ const deserializeAws_json1_1RejectPortfolioShareOutput = (
 
 const deserializeAws_json1_1ResourceChange = (output: any, context: __SerdeContext): ResourceChange => {
   return {
-    Action: output.Action !== undefined && output.Action !== null ? output.Action : undefined,
+    Action: __expectString(output.Action),
     Details:
       output.Details !== undefined && output.Details !== null
         ? deserializeAws_json1_1ResourceChangeDetails(output.Details, context)
         : undefined,
-    LogicalResourceId:
-      output.LogicalResourceId !== undefined && output.LogicalResourceId !== null
-        ? output.LogicalResourceId
-        : undefined,
-    PhysicalResourceId:
-      output.PhysicalResourceId !== undefined && output.PhysicalResourceId !== null
-        ? output.PhysicalResourceId
-        : undefined,
-    Replacement: output.Replacement !== undefined && output.Replacement !== null ? output.Replacement : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
+    LogicalResourceId: __expectString(output.LogicalResourceId),
+    PhysicalResourceId: __expectString(output.PhysicalResourceId),
+    Replacement: __expectString(output.Replacement),
+    ResourceType: __expectString(output.ResourceType),
     Scope:
       output.Scope !== undefined && output.Scope !== null
         ? deserializeAws_json1_1Scope(output.Scope, context)
@@ -10956,9 +10827,8 @@ const deserializeAws_json1_1ResourceChange = (output: any, context: __SerdeConte
 
 const deserializeAws_json1_1ResourceChangeDetail = (output: any, context: __SerdeContext): ResourceChangeDetail => {
   return {
-    CausingEntity:
-      output.CausingEntity !== undefined && output.CausingEntity !== null ? output.CausingEntity : undefined,
-    Evaluation: output.Evaluation !== undefined && output.Evaluation !== null ? output.Evaluation : undefined,
+    CausingEntity: __expectString(output.CausingEntity),
+    Evaluation: __expectString(output.Evaluation),
     Target:
       output.Target !== undefined && output.Target !== null
         ? deserializeAws_json1_1ResourceTargetDefinition(output.Target, context)
@@ -10990,14 +10860,14 @@ const deserializeAws_json1_1ResourceChanges = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_1ResourceDetail = (output: any, context: __SerdeContext): ResourceDetail => {
   return {
-    ARN: output.ARN !== undefined && output.ARN !== null ? output.ARN : undefined,
+    ARN: __expectString(output.ARN),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Description: __expectString(output.Description),
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -11014,7 +10884,7 @@ const deserializeAws_json1_1ResourceDetails = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_1ResourceInUseException = (output: any, context: __SerdeContext): ResourceInUseException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -11023,7 +10893,7 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -11032,12 +10902,9 @@ const deserializeAws_json1_1ResourceTargetDefinition = (
   context: __SerdeContext
 ): ResourceTargetDefinition => {
   return {
-    Attribute: output.Attribute !== undefined && output.Attribute !== null ? output.Attribute : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    RequiresRecreation:
-      output.RequiresRecreation !== undefined && output.RequiresRecreation !== null
-        ? output.RequiresRecreation
-        : undefined,
+    Attribute: __expectString(output.Attribute),
+    Name: __expectString(output.Name),
+    RequiresRecreation: __expectString(output.RequiresRecreation),
   } as any;
 };
 
@@ -11046,8 +10913,7 @@ const deserializeAws_json1_1ScanProvisionedProductsOutput = (
   context: __SerdeContext
 ): ScanProvisionedProductsOutput => {
   return {
-    NextPageToken:
-      output.NextPageToken !== undefined && output.NextPageToken !== null ? output.NextPageToken : undefined,
+    NextPageToken: __expectString(output.NextPageToken),
     ProvisionedProducts:
       output.ProvisionedProducts !== undefined && output.ProvisionedProducts !== null
         ? deserializeAws_json1_1ProvisionedProductDetails(output.ProvisionedProducts, context)
@@ -11062,7 +10928,7 @@ const deserializeAws_json1_1Scope = (output: any, context: __SerdeContext): (Res
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -11071,8 +10937,7 @@ const deserializeAws_json1_1SearchProductsAsAdminOutput = (
   context: __SerdeContext
 ): SearchProductsAsAdminOutput => {
   return {
-    NextPageToken:
-      output.NextPageToken !== undefined && output.NextPageToken !== null ? output.NextPageToken : undefined,
+    NextPageToken: __expectString(output.NextPageToken),
     ProductViewDetails:
       output.ProductViewDetails !== undefined && output.ProductViewDetails !== null
         ? deserializeAws_json1_1ProductViewDetails(output.ProductViewDetails, context)
@@ -11082,8 +10947,7 @@ const deserializeAws_json1_1SearchProductsAsAdminOutput = (
 
 const deserializeAws_json1_1SearchProductsOutput = (output: any, context: __SerdeContext): SearchProductsOutput => {
   return {
-    NextPageToken:
-      output.NextPageToken !== undefined && output.NextPageToken !== null ? output.NextPageToken : undefined,
+    NextPageToken: __expectString(output.NextPageToken),
     ProductViewAggregations:
       output.ProductViewAggregations !== undefined && output.ProductViewAggregations !== null
         ? deserializeAws_json1_1ProductViewAggregations(output.ProductViewAggregations, context)
@@ -11100,16 +10964,12 @@ const deserializeAws_json1_1SearchProvisionedProductsOutput = (
   context: __SerdeContext
 ): SearchProvisionedProductsOutput => {
   return {
-    NextPageToken:
-      output.NextPageToken !== undefined && output.NextPageToken !== null ? output.NextPageToken : undefined,
+    NextPageToken: __expectString(output.NextPageToken),
     ProvisionedProducts:
       output.ProvisionedProducts !== undefined && output.ProvisionedProducts !== null
         ? deserializeAws_json1_1ProvisionedProductAttributes(output.ProvisionedProducts, context)
         : undefined,
-    TotalResultsCount:
-      output.TotalResultsCount !== undefined && output.TotalResultsCount !== null
-        ? output.TotalResultsCount
-        : undefined,
+    TotalResultsCount: __expectNumber(output.TotalResultsCount),
   } as any;
 };
 
@@ -11124,7 +10984,7 @@ const deserializeAws_json1_1ServiceActionDefinitionMap = (
       }
       return {
         ...acc,
-        [key]: value,
+        [key]: __expectString(value) as any,
       };
     },
     {}
@@ -11157,11 +11017,10 @@ const deserializeAws_json1_1ServiceActionSummaries = (output: any, context: __Se
 
 const deserializeAws_json1_1ServiceActionSummary = (output: any, context: __SerdeContext): ServiceActionSummary => {
   return {
-    DefinitionType:
-      output.DefinitionType !== undefined && output.DefinitionType !== null ? output.DefinitionType : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    DefinitionType: __expectString(output.DefinitionType),
+    Description: __expectString(output.Description),
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -11184,8 +11043,8 @@ const deserializeAws_json1_1ShareError = (output: any, context: __SerdeContext):
       output.Accounts !== undefined && output.Accounts !== null
         ? deserializeAws_json1_1Namespaces(output.Accounts, context)
         : undefined,
-    Error: output.Error !== undefined && output.Error !== null ? output.Error : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Error: __expectString(output.Error),
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -11202,12 +11061,9 @@ const deserializeAws_json1_1ShareErrors = (output: any, context: __SerdeContext)
 
 const deserializeAws_json1_1StackInstance = (output: any, context: __SerdeContext): StackInstance => {
   return {
-    Account: output.Account !== undefined && output.Account !== null ? output.Account : undefined,
-    Region: output.Region !== undefined && output.Region !== null ? output.Region : undefined,
-    StackInstanceStatus:
-      output.StackInstanceStatus !== undefined && output.StackInstanceStatus !== null
-        ? output.StackInstanceStatus
-        : undefined,
+    Account: __expectString(output.Account),
+    Region: __expectString(output.Region),
+    StackInstanceStatus: __expectString(output.StackInstanceStatus),
   } as any;
 };
 
@@ -11229,7 +11085,7 @@ const deserializeAws_json1_1StackSetAccounts = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -11240,7 +11096,7 @@ const deserializeAws_json1_1StackSetRegions = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -11251,24 +11107,24 @@ const deserializeAws_json1_1SuccessfulShares = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
 const deserializeAws_json1_1TagOptionDetail = (output: any, context: __SerdeContext): TagOptionDetail => {
   return {
-    Active: output.Active !== undefined && output.Active !== null ? output.Active : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Owner: output.Owner !== undefined && output.Owner !== null ? output.Owner : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Active: __expectBoolean(output.Active),
+    Id: __expectString(output.Id),
+    Key: __expectString(output.Key),
+    Owner: __expectString(output.Owner),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -11288,7 +11144,7 @@ const deserializeAws_json1_1TagOptionNotMigratedException = (
   context: __SerdeContext
 ): TagOptionNotMigratedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -11305,7 +11161,7 @@ const deserializeAws_json1_1TagOptionSummaries = (output: any, context: __SerdeC
 
 const deserializeAws_json1_1TagOptionSummary = (output: any, context: __SerdeContext): TagOptionSummary => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
+    Key: __expectString(output.Key),
     Values:
       output.Values !== undefined && output.Values !== null
         ? deserializeAws_json1_1TagOptionValues(output.Values, context)
@@ -11320,7 +11176,7 @@ const deserializeAws_json1_1TagOptionValues = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -11353,11 +11209,8 @@ const deserializeAws_json1_1UpdateConstraintOutput = (output: any, context: __Se
       output.ConstraintDetail !== undefined && output.ConstraintDetail !== null
         ? deserializeAws_json1_1ConstraintDetail(output.ConstraintDetail, context)
         : undefined,
-    ConstraintParameters:
-      output.ConstraintParameters !== undefined && output.ConstraintParameters !== null
-        ? output.ConstraintParameters
-        : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    ConstraintParameters: __expectString(output.ConstraintParameters),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -11377,11 +11230,8 @@ const deserializeAws_json1_1UpdatePortfolioShareOutput = (
   context: __SerdeContext
 ): UpdatePortfolioShareOutput => {
   return {
-    PortfolioShareToken:
-      output.PortfolioShareToken !== undefined && output.PortfolioShareToken !== null
-        ? output.PortfolioShareToken
-        : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    PortfolioShareToken: __expectString(output.PortfolioShareToken),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -11413,16 +11263,13 @@ const deserializeAws_json1_1UpdateProvisionedProductPropertiesOutput = (
   context: __SerdeContext
 ): UpdateProvisionedProductPropertiesOutput => {
   return {
-    ProvisionedProductId:
-      output.ProvisionedProductId !== undefined && output.ProvisionedProductId !== null
-        ? output.ProvisionedProductId
-        : undefined,
+    ProvisionedProductId: __expectString(output.ProvisionedProductId),
     ProvisionedProductProperties:
       output.ProvisionedProductProperties !== undefined && output.ProvisionedProductProperties !== null
         ? deserializeAws_json1_1ProvisionedProductProperties(output.ProvisionedProductProperties, context)
         : undefined,
-    RecordId: output.RecordId !== undefined && output.RecordId !== null ? output.RecordId : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    RecordId: __expectString(output.RecordId),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -11439,7 +11286,7 @@ const deserializeAws_json1_1UpdateProvisioningArtifactOutput = (
       output.ProvisioningArtifactDetail !== undefined && output.ProvisioningArtifactDetail !== null
         ? deserializeAws_json1_1ProvisioningArtifactDetail(output.ProvisioningArtifactDetail, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -11448,10 +11295,9 @@ const deserializeAws_json1_1UpdateProvisioningParameter = (
   context: __SerdeContext
 ): UpdateProvisioningParameter => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    UsePreviousValue:
-      output.UsePreviousValue !== undefined && output.UsePreviousValue !== null ? output.UsePreviousValue : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    UsePreviousValue: __expectBoolean(output.UsePreviousValue),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -11492,8 +11338,8 @@ const deserializeAws_json1_1UpdateTagOptionOutput = (output: any, context: __Ser
 
 const deserializeAws_json1_1UsageInstruction = (output: any, context: __SerdeContext): UsageInstruction => {
   return {
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Type: __expectString(output.Type),
+    Value: __expectString(output.Value),
   } as any;
 };
 

--- a/clients/client-service-quotas/protocols/Aws_json1_1.ts
+++ b/clients/client-service-quotas/protocols/Aws_json1_1.ts
@@ -125,7 +125,12 @@ import {
   UntagResourceResponse,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -2764,7 +2769,7 @@ const serializeAws_json1_1UntagResourceRequest = (input: UntagResourceRequest, c
 
 const deserializeAws_json1_1AccessDeniedException = (output: any, context: __SerdeContext): AccessDeniedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2780,7 +2785,7 @@ const deserializeAws_json1_1AWSServiceAccessNotEnabledException = (
   context: __SerdeContext
 ): AWSServiceAccessNotEnabledException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2796,7 +2801,7 @@ const deserializeAws_json1_1DependencyAccessDeniedException = (
   context: __SerdeContext
 ): DependencyAccessDeniedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2809,8 +2814,8 @@ const deserializeAws_json1_1DisassociateServiceQuotaTemplateResponse = (
 
 const deserializeAws_json1_1ErrorReason = (output: any, context: __SerdeContext): ErrorReason => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
   } as any;
 };
 
@@ -2819,11 +2824,7 @@ const deserializeAws_json1_1GetAssociationForServiceQuotaTemplateResponse = (
   context: __SerdeContext
 ): GetAssociationForServiceQuotaTemplateResponse => {
   return {
-    ServiceQuotaTemplateAssociationStatus:
-      output.ServiceQuotaTemplateAssociationStatus !== undefined &&
-      output.ServiceQuotaTemplateAssociationStatus !== null
-        ? output.ServiceQuotaTemplateAssociationStatus
-        : undefined,
+    ServiceQuotaTemplateAssociationStatus: __expectString(output.ServiceQuotaTemplateAssociationStatus),
   } as any;
 };
 
@@ -2884,7 +2885,7 @@ const deserializeAws_json1_1IllegalArgumentException = (
   context: __SerdeContext
 ): IllegalArgumentException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2893,7 +2894,7 @@ const deserializeAws_json1_1InvalidPaginationTokenException = (
   context: __SerdeContext
 ): InvalidPaginationTokenException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2902,7 +2903,7 @@ const deserializeAws_json1_1InvalidResourceStateException = (
   context: __SerdeContext
 ): InvalidResourceStateException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2911,7 +2912,7 @@ const deserializeAws_json1_1ListAWSDefaultServiceQuotasResponse = (
   context: __SerdeContext
 ): ListAWSDefaultServiceQuotasResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Quotas:
       output.Quotas !== undefined && output.Quotas !== null
         ? deserializeAws_json1_1ServiceQuotaListDefinition(output.Quotas, context)
@@ -2924,7 +2925,7 @@ const deserializeAws_json1_1ListRequestedServiceQuotaChangeHistoryByQuotaRespons
   context: __SerdeContext
 ): ListRequestedServiceQuotaChangeHistoryByQuotaResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     RequestedQuotas:
       output.RequestedQuotas !== undefined && output.RequestedQuotas !== null
         ? deserializeAws_json1_1RequestedServiceQuotaChangeHistoryListDefinition(output.RequestedQuotas, context)
@@ -2937,7 +2938,7 @@ const deserializeAws_json1_1ListRequestedServiceQuotaChangeHistoryResponse = (
   context: __SerdeContext
 ): ListRequestedServiceQuotaChangeHistoryResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     RequestedQuotas:
       output.RequestedQuotas !== undefined && output.RequestedQuotas !== null
         ? deserializeAws_json1_1RequestedServiceQuotaChangeHistoryListDefinition(output.RequestedQuotas, context)
@@ -2950,7 +2951,7 @@ const deserializeAws_json1_1ListServiceQuotaIncreaseRequestsInTemplateResponse =
   context: __SerdeContext
 ): ListServiceQuotaIncreaseRequestsInTemplateResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     ServiceQuotaIncreaseRequestInTemplateList:
       output.ServiceQuotaIncreaseRequestInTemplateList !== undefined &&
       output.ServiceQuotaIncreaseRequestInTemplateList !== null
@@ -2967,7 +2968,7 @@ const deserializeAws_json1_1ListServiceQuotasResponse = (
   context: __SerdeContext
 ): ListServiceQuotasResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Quotas:
       output.Quotas !== undefined && output.Quotas !== null
         ? deserializeAws_json1_1ServiceQuotaListDefinition(output.Quotas, context)
@@ -2977,7 +2978,7 @@ const deserializeAws_json1_1ListServiceQuotasResponse = (
 
 const deserializeAws_json1_1ListServicesResponse = (output: any, context: __SerdeContext): ListServicesResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Services:
       output.Services !== undefined && output.Services !== null
         ? deserializeAws_json1_1ServiceInfoListDefinition(output.Services, context)
@@ -3007,7 +3008,7 @@ const deserializeAws_json1_1MetricDimensionsMapDefinition = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -3018,13 +3019,9 @@ const deserializeAws_json1_1MetricInfo = (output: any, context: __SerdeContext):
       output.MetricDimensions !== undefined && output.MetricDimensions !== null
         ? deserializeAws_json1_1MetricDimensionsMapDefinition(output.MetricDimensions, context)
         : undefined,
-    MetricName: output.MetricName !== undefined && output.MetricName !== null ? output.MetricName : undefined,
-    MetricNamespace:
-      output.MetricNamespace !== undefined && output.MetricNamespace !== null ? output.MetricNamespace : undefined,
-    MetricStatisticRecommendation:
-      output.MetricStatisticRecommendation !== undefined && output.MetricStatisticRecommendation !== null
-        ? output.MetricStatisticRecommendation
-        : undefined,
+    MetricName: __expectString(output.MetricName),
+    MetricNamespace: __expectString(output.MetricNamespace),
+    MetricStatisticRecommendation: __expectString(output.MetricStatisticRecommendation),
   } as any;
 };
 
@@ -3033,7 +3030,7 @@ const deserializeAws_json1_1NoAvailableOrganizationException = (
   context: __SerdeContext
 ): NoAvailableOrganizationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3042,7 +3039,7 @@ const deserializeAws_json1_1NoSuchResourceException = (
   context: __SerdeContext
 ): NoSuchResourceException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3051,7 +3048,7 @@ const deserializeAws_json1_1OrganizationNotInAllFeaturesModeException = (
   context: __SerdeContext
 ): OrganizationNotInAllFeaturesModeException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3084,14 +3081,14 @@ const deserializeAws_json1_1PutServiceQuotaIncreaseRequestIntoTemplateResponse =
 
 const deserializeAws_json1_1QuotaExceededException = (output: any, context: __SerdeContext): QuotaExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1QuotaPeriod = (output: any, context: __SerdeContext): QuotaPeriod => {
   return {
-    PeriodUnit: output.PeriodUnit !== undefined && output.PeriodUnit !== null ? output.PeriodUnit : undefined,
-    PeriodValue: output.PeriodValue !== undefined && output.PeriodValue !== null ? output.PeriodValue : undefined,
+    PeriodUnit: __expectString(output.PeriodUnit),
+    PeriodValue: __expectNumber(output.PeriodValue),
   } as any;
 };
 
@@ -3100,24 +3097,24 @@ const deserializeAws_json1_1RequestedServiceQuotaChange = (
   context: __SerdeContext
 ): RequestedServiceQuotaChange => {
   return {
-    CaseId: output.CaseId !== undefined && output.CaseId !== null ? output.CaseId : undefined,
+    CaseId: __expectString(output.CaseId),
     Created:
       output.Created !== undefined && output.Created !== null ? new Date(Math.round(output.Created * 1000)) : undefined,
-    DesiredValue: output.DesiredValue !== undefined && output.DesiredValue !== null ? output.DesiredValue : undefined,
-    GlobalQuota: output.GlobalQuota !== undefined && output.GlobalQuota !== null ? output.GlobalQuota : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    DesiredValue: __expectNumber(output.DesiredValue),
+    GlobalQuota: __expectBoolean(output.GlobalQuota),
+    Id: __expectString(output.Id),
     LastUpdated:
       output.LastUpdated !== undefined && output.LastUpdated !== null
         ? new Date(Math.round(output.LastUpdated * 1000))
         : undefined,
-    QuotaArn: output.QuotaArn !== undefined && output.QuotaArn !== null ? output.QuotaArn : undefined,
-    QuotaCode: output.QuotaCode !== undefined && output.QuotaCode !== null ? output.QuotaCode : undefined,
-    QuotaName: output.QuotaName !== undefined && output.QuotaName !== null ? output.QuotaName : undefined,
-    Requester: output.Requester !== undefined && output.Requester !== null ? output.Requester : undefined,
-    ServiceCode: output.ServiceCode !== undefined && output.ServiceCode !== null ? output.ServiceCode : undefined,
-    ServiceName: output.ServiceName !== undefined && output.ServiceName !== null ? output.ServiceName : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    Unit: output.Unit !== undefined && output.Unit !== null ? output.Unit : undefined,
+    QuotaArn: __expectString(output.QuotaArn),
+    QuotaCode: __expectString(output.QuotaCode),
+    QuotaName: __expectString(output.QuotaName),
+    Requester: __expectString(output.Requester),
+    ServiceCode: __expectString(output.ServiceCode),
+    ServiceName: __expectString(output.ServiceName),
+    Status: __expectString(output.Status),
+    Unit: __expectString(output.Unit),
   } as any;
 };
 
@@ -3152,20 +3149,20 @@ const deserializeAws_json1_1ResourceAlreadyExistsException = (
   context: __SerdeContext
 ): ResourceAlreadyExistsException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1ServiceException = (output: any, context: __SerdeContext): ServiceException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1ServiceInfo = (output: any, context: __SerdeContext): ServiceInfo => {
   return {
-    ServiceCode: output.ServiceCode !== undefined && output.ServiceCode !== null ? output.ServiceCode : undefined,
-    ServiceName: output.ServiceName !== undefined && output.ServiceName !== null ? output.ServiceName : undefined,
+    ServiceCode: __expectString(output.ServiceCode),
+    ServiceName: __expectString(output.ServiceName),
   } as any;
 };
 
@@ -3182,27 +3179,27 @@ const deserializeAws_json1_1ServiceInfoListDefinition = (output: any, context: _
 
 const deserializeAws_json1_1ServiceQuota = (output: any, context: __SerdeContext): ServiceQuota => {
   return {
-    Adjustable: output.Adjustable !== undefined && output.Adjustable !== null ? output.Adjustable : undefined,
+    Adjustable: __expectBoolean(output.Adjustable),
     ErrorReason:
       output.ErrorReason !== undefined && output.ErrorReason !== null
         ? deserializeAws_json1_1ErrorReason(output.ErrorReason, context)
         : undefined,
-    GlobalQuota: output.GlobalQuota !== undefined && output.GlobalQuota !== null ? output.GlobalQuota : undefined,
+    GlobalQuota: __expectBoolean(output.GlobalQuota),
     Period:
       output.Period !== undefined && output.Period !== null
         ? deserializeAws_json1_1QuotaPeriod(output.Period, context)
         : undefined,
-    QuotaArn: output.QuotaArn !== undefined && output.QuotaArn !== null ? output.QuotaArn : undefined,
-    QuotaCode: output.QuotaCode !== undefined && output.QuotaCode !== null ? output.QuotaCode : undefined,
-    QuotaName: output.QuotaName !== undefined && output.QuotaName !== null ? output.QuotaName : undefined,
-    ServiceCode: output.ServiceCode !== undefined && output.ServiceCode !== null ? output.ServiceCode : undefined,
-    ServiceName: output.ServiceName !== undefined && output.ServiceName !== null ? output.ServiceName : undefined,
-    Unit: output.Unit !== undefined && output.Unit !== null ? output.Unit : undefined,
+    QuotaArn: __expectString(output.QuotaArn),
+    QuotaCode: __expectString(output.QuotaCode),
+    QuotaName: __expectString(output.QuotaName),
+    ServiceCode: __expectString(output.ServiceCode),
+    ServiceName: __expectString(output.ServiceName),
+    Unit: __expectString(output.Unit),
     UsageMetric:
       output.UsageMetric !== undefined && output.UsageMetric !== null
         ? deserializeAws_json1_1MetricInfo(output.UsageMetric, context)
         : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Value: __expectNumber(output.Value),
   } as any;
 };
 
@@ -3211,14 +3208,14 @@ const deserializeAws_json1_1ServiceQuotaIncreaseRequestInTemplate = (
   context: __SerdeContext
 ): ServiceQuotaIncreaseRequestInTemplate => {
   return {
-    AwsRegion: output.AwsRegion !== undefined && output.AwsRegion !== null ? output.AwsRegion : undefined,
-    DesiredValue: output.DesiredValue !== undefined && output.DesiredValue !== null ? output.DesiredValue : undefined,
-    GlobalQuota: output.GlobalQuota !== undefined && output.GlobalQuota !== null ? output.GlobalQuota : undefined,
-    QuotaCode: output.QuotaCode !== undefined && output.QuotaCode !== null ? output.QuotaCode : undefined,
-    QuotaName: output.QuotaName !== undefined && output.QuotaName !== null ? output.QuotaName : undefined,
-    ServiceCode: output.ServiceCode !== undefined && output.ServiceCode !== null ? output.ServiceCode : undefined,
-    ServiceName: output.ServiceName !== undefined && output.ServiceName !== null ? output.ServiceName : undefined,
-    Unit: output.Unit !== undefined && output.Unit !== null ? output.Unit : undefined,
+    AwsRegion: __expectString(output.AwsRegion),
+    DesiredValue: __expectNumber(output.DesiredValue),
+    GlobalQuota: __expectBoolean(output.GlobalQuota),
+    QuotaCode: __expectString(output.QuotaCode),
+    QuotaName: __expectString(output.QuotaName),
+    ServiceCode: __expectString(output.ServiceCode),
+    ServiceName: __expectString(output.ServiceName),
+    Unit: __expectString(output.Unit),
   } as any;
 };
 
@@ -3252,14 +3249,14 @@ const deserializeAws_json1_1ServiceQuotaTemplateNotInUseException = (
   context: __SerdeContext
 ): ServiceQuotaTemplateNotInUseException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -3268,7 +3265,7 @@ const deserializeAws_json1_1TagPolicyViolationException = (
   context: __SerdeContext
 ): TagPolicyViolationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3281,7 +3278,7 @@ const deserializeAws_json1_1TemplatesNotAvailableInRegionException = (
   context: __SerdeContext
 ): TemplatesNotAvailableInRegionException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3290,13 +3287,13 @@ const deserializeAws_json1_1TooManyRequestsException = (
   context: __SerdeContext
 ): TooManyRequestsException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1TooManyTagsException = (output: any, context: __SerdeContext): TooManyTagsException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 

--- a/clients/client-servicediscovery/protocols/Aws_json1_1.ts
+++ b/clients/client-servicediscovery/protocols/Aws_json1_1.ts
@@ -129,7 +129,11 @@ import {
   HttpResponse as __HttpResponse,
   isValidHostname as __isValidHostname,
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -2704,7 +2708,7 @@ const deserializeAws_json1_1Attributes = (output: any, context: __SerdeContext):
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -2714,7 +2718,7 @@ const deserializeAws_json1_1CreateHttpNamespaceResponse = (
   context: __SerdeContext
 ): CreateHttpNamespaceResponse => {
   return {
-    OperationId: output.OperationId !== undefined && output.OperationId !== null ? output.OperationId : undefined,
+    OperationId: __expectString(output.OperationId),
   } as any;
 };
 
@@ -2723,7 +2727,7 @@ const deserializeAws_json1_1CreatePrivateDnsNamespaceResponse = (
   context: __SerdeContext
 ): CreatePrivateDnsNamespaceResponse => {
   return {
-    OperationId: output.OperationId !== undefined && output.OperationId !== null ? output.OperationId : undefined,
+    OperationId: __expectString(output.OperationId),
   } as any;
 };
 
@@ -2732,7 +2736,7 @@ const deserializeAws_json1_1CreatePublicDnsNamespaceResponse = (
   context: __SerdeContext
 ): CreatePublicDnsNamespaceResponse => {
   return {
-    OperationId: output.OperationId !== undefined && output.OperationId !== null ? output.OperationId : undefined,
+    OperationId: __expectString(output.OperationId),
   } as any;
 };
 
@@ -2747,7 +2751,7 @@ const deserializeAws_json1_1CreateServiceResponse = (output: any, context: __Ser
 
 const deserializeAws_json1_1CustomHealthNotFound = (output: any, context: __SerdeContext): CustomHealthNotFound => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2756,7 +2760,7 @@ const deserializeAws_json1_1DeleteNamespaceResponse = (
   context: __SerdeContext
 ): DeleteNamespaceResponse => {
   return {
-    OperationId: output.OperationId !== undefined && output.OperationId !== null ? output.OperationId : undefined,
+    OperationId: __expectString(output.OperationId),
   } as any;
 };
 
@@ -2769,7 +2773,7 @@ const deserializeAws_json1_1DeregisterInstanceResponse = (
   context: __SerdeContext
 ): DeregisterInstanceResponse => {
   return {
-    OperationId: output.OperationId !== undefined && output.OperationId !== null ? output.OperationId : undefined,
+    OperationId: __expectString(output.OperationId),
   } as any;
 };
 
@@ -2791,22 +2795,21 @@ const deserializeAws_json1_1DnsConfig = (output: any, context: __SerdeContext): 
       output.DnsRecords !== undefined && output.DnsRecords !== null
         ? deserializeAws_json1_1DnsRecordList(output.DnsRecords, context)
         : undefined,
-    NamespaceId: output.NamespaceId !== undefined && output.NamespaceId !== null ? output.NamespaceId : undefined,
-    RoutingPolicy:
-      output.RoutingPolicy !== undefined && output.RoutingPolicy !== null ? output.RoutingPolicy : undefined,
+    NamespaceId: __expectString(output.NamespaceId),
+    RoutingPolicy: __expectString(output.RoutingPolicy),
   } as any;
 };
 
 const deserializeAws_json1_1DnsProperties = (output: any, context: __SerdeContext): DnsProperties => {
   return {
-    HostedZoneId: output.HostedZoneId !== undefined && output.HostedZoneId !== null ? output.HostedZoneId : undefined,
+    HostedZoneId: __expectString(output.HostedZoneId),
   } as any;
 };
 
 const deserializeAws_json1_1DnsRecord = (output: any, context: __SerdeContext): DnsRecord => {
   return {
-    TTL: output.TTL !== undefined && output.TTL !== null ? output.TTL : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    TTL: __expectNumber(output.TTL),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -2823,11 +2826,8 @@ const deserializeAws_json1_1DnsRecordList = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1DuplicateRequest = (output: any, context: __SerdeContext): DuplicateRequest => {
   return {
-    DuplicateOperationId:
-      output.DuplicateOperationId !== undefined && output.DuplicateOperationId !== null
-        ? output.DuplicateOperationId
-        : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    DuplicateOperationId: __expectString(output.DuplicateOperationId),
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2845,7 +2845,7 @@ const deserializeAws_json1_1GetInstancesHealthStatusResponse = (
   context: __SerdeContext
 ): GetInstancesHealthStatusResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Status:
       output.Status !== undefined && output.Status !== null
         ? deserializeAws_json1_1InstanceHealthStatusMap(output.Status, context)
@@ -2882,10 +2882,9 @@ const deserializeAws_json1_1GetServiceResponse = (output: any, context: __SerdeC
 
 const deserializeAws_json1_1HealthCheckConfig = (output: any, context: __SerdeContext): HealthCheckConfig => {
   return {
-    FailureThreshold:
-      output.FailureThreshold !== undefined && output.FailureThreshold !== null ? output.FailureThreshold : undefined,
-    ResourcePath: output.ResourcePath !== undefined && output.ResourcePath !== null ? output.ResourcePath : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    FailureThreshold: __expectNumber(output.FailureThreshold),
+    ResourcePath: __expectString(output.ResourcePath),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -2894,8 +2893,7 @@ const deserializeAws_json1_1HealthCheckCustomConfig = (
   context: __SerdeContext
 ): HealthCheckCustomConfig => {
   return {
-    FailureThreshold:
-      output.FailureThreshold !== undefined && output.FailureThreshold !== null ? output.FailureThreshold : undefined,
+    FailureThreshold: __expectNumber(output.FailureThreshold),
   } as any;
 };
 
@@ -2905,11 +2903,10 @@ const deserializeAws_json1_1HttpInstanceSummary = (output: any, context: __Serde
       output.Attributes !== undefined && output.Attributes !== null
         ? deserializeAws_json1_1Attributes(output.Attributes, context)
         : undefined,
-    HealthStatus: output.HealthStatus !== undefined && output.HealthStatus !== null ? output.HealthStatus : undefined,
-    InstanceId: output.InstanceId !== undefined && output.InstanceId !== null ? output.InstanceId : undefined,
-    NamespaceName:
-      output.NamespaceName !== undefined && output.NamespaceName !== null ? output.NamespaceName : undefined,
-    ServiceName: output.ServiceName !== undefined && output.ServiceName !== null ? output.ServiceName : undefined,
+    HealthStatus: __expectString(output.HealthStatus),
+    InstanceId: __expectString(output.InstanceId),
+    NamespaceName: __expectString(output.NamespaceName),
+    ServiceName: __expectString(output.ServiceName),
   } as any;
 };
 
@@ -2926,7 +2923,7 @@ const deserializeAws_json1_1HttpInstanceSummaryList = (output: any, context: __S
 
 const deserializeAws_json1_1HttpProperties = (output: any, context: __SerdeContext): HttpProperties => {
   return {
-    HttpName: output.HttpName !== undefined && output.HttpName !== null ? output.HttpName : undefined,
+    HttpName: __expectString(output.HttpName),
   } as any;
 };
 
@@ -2936,9 +2933,8 @@ const deserializeAws_json1_1Instance = (output: any, context: __SerdeContext): I
       output.Attributes !== undefined && output.Attributes !== null
         ? deserializeAws_json1_1Attributes(output.Attributes, context)
         : undefined,
-    CreatorRequestId:
-      output.CreatorRequestId !== undefined && output.CreatorRequestId !== null ? output.CreatorRequestId : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    CreatorRequestId: __expectString(output.CreatorRequestId),
+    Id: __expectString(output.Id),
   } as any;
 };
 
@@ -2952,14 +2948,14 @@ const deserializeAws_json1_1InstanceHealthStatusMap = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_json1_1InstanceNotFound = (output: any, context: __SerdeContext): InstanceNotFound => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2969,7 +2965,7 @@ const deserializeAws_json1_1InstanceSummary = (output: any, context: __SerdeCont
       output.Attributes !== undefined && output.Attributes !== null
         ? deserializeAws_json1_1Attributes(output.Attributes, context)
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    Id: __expectString(output.Id),
   } as any;
 };
 
@@ -2986,7 +2982,7 @@ const deserializeAws_json1_1InstanceSummaryList = (output: any, context: __Serde
 
 const deserializeAws_json1_1InvalidInput = (output: any, context: __SerdeContext): InvalidInput => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2996,7 +2992,7 @@ const deserializeAws_json1_1ListInstancesResponse = (output: any, context: __Ser
       output.Instances !== undefined && output.Instances !== null
         ? deserializeAws_json1_1InstanceSummaryList(output.Instances, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -3006,13 +3002,13 @@ const deserializeAws_json1_1ListNamespacesResponse = (output: any, context: __Se
       output.Namespaces !== undefined && output.Namespaces !== null
         ? deserializeAws_json1_1NamespaceSummariesList(output.Namespaces, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
 const deserializeAws_json1_1ListOperationsResponse = (output: any, context: __SerdeContext): ListOperationsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Operations:
       output.Operations !== undefined && output.Operations !== null
         ? deserializeAws_json1_1OperationSummaryList(output.Operations, context)
@@ -3022,7 +3018,7 @@ const deserializeAws_json1_1ListOperationsResponse = (output: any, context: __Se
 
 const deserializeAws_json1_1ListServicesResponse = (output: any, context: __SerdeContext): ListServicesResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Services:
       output.Services !== undefined && output.Services !== null
         ? deserializeAws_json1_1ServiceSummariesList(output.Services, context)
@@ -3044,37 +3040,35 @@ const deserializeAws_json1_1ListTagsForResourceResponse = (
 
 const deserializeAws_json1_1Namespace = (output: any, context: __SerdeContext): Namespace => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     CreateDate:
       output.CreateDate !== undefined && output.CreateDate !== null
         ? new Date(Math.round(output.CreateDate * 1000))
         : undefined,
-    CreatorRequestId:
-      output.CreatorRequestId !== undefined && output.CreatorRequestId !== null ? output.CreatorRequestId : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    CreatorRequestId: __expectString(output.CreatorRequestId),
+    Description: __expectString(output.Description),
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
     Properties:
       output.Properties !== undefined && output.Properties !== null
         ? deserializeAws_json1_1NamespaceProperties(output.Properties, context)
         : undefined,
-    ServiceCount: output.ServiceCount !== undefined && output.ServiceCount !== null ? output.ServiceCount : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    ServiceCount: __expectNumber(output.ServiceCount),
+    Type: __expectString(output.Type),
   } as any;
 };
 
 const deserializeAws_json1_1NamespaceAlreadyExists = (output: any, context: __SerdeContext): NamespaceAlreadyExists => {
   return {
-    CreatorRequestId:
-      output.CreatorRequestId !== undefined && output.CreatorRequestId !== null ? output.CreatorRequestId : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    NamespaceId: output.NamespaceId !== undefined && output.NamespaceId !== null ? output.NamespaceId : undefined,
+    CreatorRequestId: __expectString(output.CreatorRequestId),
+    Message: __expectString(output.Message),
+    NamespaceId: __expectString(output.NamespaceId),
   } as any;
 };
 
 const deserializeAws_json1_1NamespaceNotFound = (output: any, context: __SerdeContext): NamespaceNotFound => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3104,20 +3098,20 @@ const deserializeAws_json1_1NamespaceSummariesList = (output: any, context: __Se
 
 const deserializeAws_json1_1NamespaceSummary = (output: any, context: __SerdeContext): NamespaceSummary => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     CreateDate:
       output.CreateDate !== undefined && output.CreateDate !== null
         ? new Date(Math.round(output.CreateDate * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Description: __expectString(output.Description),
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
     Properties:
       output.Properties !== undefined && output.Properties !== null
         ? deserializeAws_json1_1NamespaceProperties(output.Properties, context)
         : undefined,
-    ServiceCount: output.ServiceCount !== undefined && output.ServiceCount !== null ? output.ServiceCount : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    ServiceCount: __expectNumber(output.ServiceCount),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -3127,15 +3121,15 @@ const deserializeAws_json1_1Operation = (output: any, context: __SerdeContext): 
       output.CreateDate !== undefined && output.CreateDate !== null
         ? new Date(Math.round(output.CreateDate * 1000))
         : undefined,
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
+    Id: __expectString(output.Id),
+    Status: __expectString(output.Status),
     Targets:
       output.Targets !== undefined && output.Targets !== null
         ? deserializeAws_json1_1OperationTargetsMap(output.Targets, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
     UpdateDate:
       output.UpdateDate !== undefined && output.UpdateDate !== null
         ? new Date(Math.round(output.UpdateDate * 1000))
@@ -3145,14 +3139,14 @@ const deserializeAws_json1_1Operation = (output: any, context: __SerdeContext): 
 
 const deserializeAws_json1_1OperationNotFound = (output: any, context: __SerdeContext): OperationNotFound => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1OperationSummary = (output: any, context: __SerdeContext): OperationSummary => {
   return {
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Id: __expectString(output.Id),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -3175,7 +3169,7 @@ const deserializeAws_json1_1OperationTargetsMap = (output: any, context: __Serde
       }
       return {
         ...acc,
-        [key]: value,
+        [key]: __expectString(value) as any,
       };
     },
     {}
@@ -3187,25 +3181,25 @@ const deserializeAws_json1_1RegisterInstanceResponse = (
   context: __SerdeContext
 ): RegisterInstanceResponse => {
   return {
-    OperationId: output.OperationId !== undefined && output.OperationId !== null ? output.OperationId : undefined,
+    OperationId: __expectString(output.OperationId),
   } as any;
 };
 
 const deserializeAws_json1_1RequestLimitExceeded = (output: any, context: __SerdeContext): RequestLimitExceeded => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1ResourceInUse = (output: any, context: __SerdeContext): ResourceInUse => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1ResourceLimitExceeded = (output: any, context: __SerdeContext): ResourceLimitExceeded => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3214,20 +3208,19 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1Service = (output: any, context: __SerdeContext): Service => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     CreateDate:
       output.CreateDate !== undefined && output.CreateDate !== null
         ? new Date(Math.round(output.CreateDate * 1000))
         : undefined,
-    CreatorRequestId:
-      output.CreatorRequestId !== undefined && output.CreatorRequestId !== null ? output.CreatorRequestId : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    CreatorRequestId: __expectString(output.CreatorRequestId),
+    Description: __expectString(output.Description),
     DnsConfig:
       output.DnsConfig !== undefined && output.DnsConfig !== null
         ? deserializeAws_json1_1DnsConfig(output.DnsConfig, context)
@@ -3240,27 +3233,25 @@ const deserializeAws_json1_1Service = (output: any, context: __SerdeContext): Se
       output.HealthCheckCustomConfig !== undefined && output.HealthCheckCustomConfig !== null
         ? deserializeAws_json1_1HealthCheckCustomConfig(output.HealthCheckCustomConfig, context)
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    InstanceCount:
-      output.InstanceCount !== undefined && output.InstanceCount !== null ? output.InstanceCount : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    NamespaceId: output.NamespaceId !== undefined && output.NamespaceId !== null ? output.NamespaceId : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Id: __expectString(output.Id),
+    InstanceCount: __expectNumber(output.InstanceCount),
+    Name: __expectString(output.Name),
+    NamespaceId: __expectString(output.NamespaceId),
+    Type: __expectString(output.Type),
   } as any;
 };
 
 const deserializeAws_json1_1ServiceAlreadyExists = (output: any, context: __SerdeContext): ServiceAlreadyExists => {
   return {
-    CreatorRequestId:
-      output.CreatorRequestId !== undefined && output.CreatorRequestId !== null ? output.CreatorRequestId : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    ServiceId: output.ServiceId !== undefined && output.ServiceId !== null ? output.ServiceId : undefined,
+    CreatorRequestId: __expectString(output.CreatorRequestId),
+    Message: __expectString(output.Message),
+    ServiceId: __expectString(output.ServiceId),
   } as any;
 };
 
 const deserializeAws_json1_1ServiceNotFound = (output: any, context: __SerdeContext): ServiceNotFound => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3277,12 +3268,12 @@ const deserializeAws_json1_1ServiceSummariesList = (output: any, context: __Serd
 
 const deserializeAws_json1_1ServiceSummary = (output: any, context: __SerdeContext): ServiceSummary => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     CreateDate:
       output.CreateDate !== undefined && output.CreateDate !== null
         ? new Date(Math.round(output.CreateDate * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     DnsConfig:
       output.DnsConfig !== undefined && output.DnsConfig !== null
         ? deserializeAws_json1_1DnsConfig(output.DnsConfig, context)
@@ -3295,18 +3286,17 @@ const deserializeAws_json1_1ServiceSummary = (output: any, context: __SerdeConte
       output.HealthCheckCustomConfig !== undefined && output.HealthCheckCustomConfig !== null
         ? deserializeAws_json1_1HealthCheckCustomConfig(output.HealthCheckCustomConfig, context)
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    InstanceCount:
-      output.InstanceCount !== undefined && output.InstanceCount !== null ? output.InstanceCount : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Id: __expectString(output.Id),
+    InstanceCount: __expectNumber(output.InstanceCount),
+    Name: __expectString(output.Name),
+    Type: __expectString(output.Type),
   } as any;
 };
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -3327,8 +3317,8 @@ const deserializeAws_json1_1TagResourceResponse = (output: any, context: __Serde
 
 const deserializeAws_json1_1TooManyTagsException = (output: any, context: __SerdeContext): TooManyTagsException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    ResourceName: output.ResourceName !== undefined && output.ResourceName !== null ? output.ResourceName : undefined,
+    Message: __expectString(output.Message),
+    ResourceName: __expectString(output.ResourceName),
   } as any;
 };
 
@@ -3338,7 +3328,7 @@ const deserializeAws_json1_1UntagResourceResponse = (output: any, context: __Ser
 
 const deserializeAws_json1_1UpdateServiceResponse = (output: any, context: __SerdeContext): UpdateServiceResponse => {
   return {
-    OperationId: output.OperationId !== undefined && output.OperationId !== null ? output.OperationId : undefined,
+    OperationId: __expectString(output.OperationId),
   } as any;
 };
 

--- a/clients/client-ses/protocols/Aws_query.ts
+++ b/clients/client-ses/protocols/Aws_query.ts
@@ -431,6 +431,7 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
@@ -8053,7 +8054,7 @@ const deserializeAws_queryAccountSendingPausedException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -8064,10 +8065,10 @@ const deserializeAws_queryAddHeaderAction = (output: any, context: __SerdeContex
     HeaderValue: undefined,
   };
   if (output["HeaderName"] !== undefined) {
-    contents.HeaderName = output["HeaderName"];
+    contents.HeaderName = __expectString(output["HeaderName"]);
   }
   if (output["HeaderValue"] !== undefined) {
-    contents.HeaderValue = output["HeaderValue"];
+    contents.HeaderValue = __expectString(output["HeaderValue"]);
   }
   return contents;
 };
@@ -8079,7 +8080,7 @@ const deserializeAws_queryAddressList = (output: any, context: __SerdeContext): 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -8089,10 +8090,10 @@ const deserializeAws_queryAlreadyExistsException = (output: any, context: __Serd
     message: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -8106,19 +8107,19 @@ const deserializeAws_queryBounceAction = (output: any, context: __SerdeContext):
     Sender: undefined,
   };
   if (output["TopicArn"] !== undefined) {
-    contents.TopicArn = output["TopicArn"];
+    contents.TopicArn = __expectString(output["TopicArn"]);
   }
   if (output["SmtpReplyCode"] !== undefined) {
-    contents.SmtpReplyCode = output["SmtpReplyCode"];
+    contents.SmtpReplyCode = __expectString(output["SmtpReplyCode"]);
   }
   if (output["StatusCode"] !== undefined) {
-    contents.StatusCode = output["StatusCode"];
+    contents.StatusCode = __expectString(output["StatusCode"]);
   }
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   if (output["Sender"] !== undefined) {
-    contents.Sender = output["Sender"];
+    contents.Sender = __expectString(output["Sender"]);
   }
   return contents;
 };
@@ -8133,13 +8134,13 @@ const deserializeAws_queryBulkEmailDestinationStatus = (
     MessageId: undefined,
   };
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["Error"] !== undefined) {
-    contents.Error = output["Error"];
+    contents.Error = __expectString(output["Error"]);
   }
   if (output["MessageId"] !== undefined) {
-    contents.MessageId = output["MessageId"];
+    contents.MessageId = __expectString(output["MessageId"]);
   }
   return contents;
 };
@@ -8164,10 +8165,10 @@ const deserializeAws_queryCannotDeleteException = (output: any, context: __Serde
     message: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -8206,13 +8207,13 @@ const deserializeAws_queryCloudWatchDimensionConfiguration = (
     DefaultDimensionValue: undefined,
   };
   if (output["DimensionName"] !== undefined) {
-    contents.DimensionName = output["DimensionName"];
+    contents.DimensionName = __expectString(output["DimensionName"]);
   }
   if (output["DimensionValueSource"] !== undefined) {
-    contents.DimensionValueSource = output["DimensionValueSource"];
+    contents.DimensionValueSource = __expectString(output["DimensionValueSource"]);
   }
   if (output["DefaultDimensionValue"] !== undefined) {
-    contents.DefaultDimensionValue = output["DefaultDimensionValue"];
+    contents.DefaultDimensionValue = __expectString(output["DefaultDimensionValue"]);
   }
   return contents;
 };
@@ -8236,7 +8237,7 @@ const deserializeAws_queryConfigurationSet = (output: any, context: __SerdeConte
     Name: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   return contents;
 };
@@ -8250,10 +8251,10 @@ const deserializeAws_queryConfigurationSetAlreadyExistsException = (
     message: undefined,
   };
   if (output["ConfigurationSetName"] !== undefined) {
-    contents.ConfigurationSetName = output["ConfigurationSetName"];
+    contents.ConfigurationSetName = __expectString(output["ConfigurationSetName"]);
   }
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -8267,10 +8268,10 @@ const deserializeAws_queryConfigurationSetDoesNotExistException = (
     message: undefined,
   };
   if (output["ConfigurationSetName"] !== undefined) {
-    contents.ConfigurationSetName = output["ConfigurationSetName"];
+    contents.ConfigurationSetName = __expectString(output["ConfigurationSetName"]);
   }
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -8295,10 +8296,10 @@ const deserializeAws_queryConfigurationSetSendingPausedException = (
     message: undefined,
   };
   if (output["ConfigurationSetName"] !== undefined) {
-    contents.ConfigurationSetName = output["ConfigurationSetName"];
+    contents.ConfigurationSetName = __expectString(output["ConfigurationSetName"]);
   }
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -8364,7 +8365,7 @@ const deserializeAws_queryCustomVerificationEmailInvalidContentException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -8381,19 +8382,19 @@ const deserializeAws_queryCustomVerificationEmailTemplate = (
     FailureRedirectionURL: undefined,
   };
   if (output["TemplateName"] !== undefined) {
-    contents.TemplateName = output["TemplateName"];
+    contents.TemplateName = __expectString(output["TemplateName"]);
   }
   if (output["FromEmailAddress"] !== undefined) {
-    contents.FromEmailAddress = output["FromEmailAddress"];
+    contents.FromEmailAddress = __expectString(output["FromEmailAddress"]);
   }
   if (output["TemplateSubject"] !== undefined) {
-    contents.TemplateSubject = output["TemplateSubject"];
+    contents.TemplateSubject = __expectString(output["TemplateSubject"]);
   }
   if (output["SuccessRedirectionURL"] !== undefined) {
-    contents.SuccessRedirectionURL = output["SuccessRedirectionURL"];
+    contents.SuccessRedirectionURL = __expectString(output["SuccessRedirectionURL"]);
   }
   if (output["FailureRedirectionURL"] !== undefined) {
-    contents.FailureRedirectionURL = output["FailureRedirectionURL"];
+    contents.FailureRedirectionURL = __expectString(output["FailureRedirectionURL"]);
   }
   return contents;
 };
@@ -8407,10 +8408,10 @@ const deserializeAws_queryCustomVerificationEmailTemplateAlreadyExistsException 
     message: undefined,
   };
   if (output["CustomVerificationEmailTemplateName"] !== undefined) {
-    contents.CustomVerificationEmailTemplateName = output["CustomVerificationEmailTemplateName"];
+    contents.CustomVerificationEmailTemplateName = __expectString(output["CustomVerificationEmailTemplateName"]);
   }
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -8424,10 +8425,10 @@ const deserializeAws_queryCustomVerificationEmailTemplateDoesNotExistException =
     message: undefined,
   };
   if (output["CustomVerificationEmailTemplateName"] !== undefined) {
-    contents.CustomVerificationEmailTemplateName = output["CustomVerificationEmailTemplateName"];
+    contents.CustomVerificationEmailTemplateName = __expectString(output["CustomVerificationEmailTemplateName"]);
   }
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -8517,7 +8518,7 @@ const deserializeAws_queryDeliveryOptions = (output: any, context: __SerdeContex
     TlsPolicy: undefined,
   };
   if (output["TlsPolicy"] !== undefined) {
-    contents.TlsPolicy = output["TlsPolicy"];
+    contents.TlsPolicy = __expectString(output["TlsPolicy"]);
   }
   return contents;
 };
@@ -8635,7 +8636,7 @@ const deserializeAws_queryEventDestination = (output: any, context: __SerdeConte
     SNSDestination: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["Enabled"] !== undefined) {
     contents.Enabled = __parseBoolean(output["Enabled"]);
@@ -8677,13 +8678,13 @@ const deserializeAws_queryEventDestinationAlreadyExistsException = (
     message: undefined,
   };
   if (output["ConfigurationSetName"] !== undefined) {
-    contents.ConfigurationSetName = output["ConfigurationSetName"];
+    contents.ConfigurationSetName = __expectString(output["ConfigurationSetName"]);
   }
   if (output["EventDestinationName"] !== undefined) {
-    contents.EventDestinationName = output["EventDestinationName"];
+    contents.EventDestinationName = __expectString(output["EventDestinationName"]);
   }
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -8698,13 +8699,13 @@ const deserializeAws_queryEventDestinationDoesNotExistException = (
     message: undefined,
   };
   if (output["ConfigurationSetName"] !== undefined) {
-    contents.ConfigurationSetName = output["ConfigurationSetName"];
+    contents.ConfigurationSetName = __expectString(output["ConfigurationSetName"]);
   }
   if (output["EventDestinationName"] !== undefined) {
-    contents.EventDestinationName = output["EventDestinationName"];
+    contents.EventDestinationName = __expectString(output["EventDestinationName"]);
   }
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -8727,7 +8728,7 @@ const deserializeAws_queryEventTypes = (output: any, context: __SerdeContext): (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -8740,10 +8741,10 @@ const deserializeAws_queryFromEmailAddressNotVerifiedException = (
     message: undefined,
   };
   if (output["FromEmailAddress"] !== undefined) {
-    contents.FromEmailAddress = output["FromEmailAddress"];
+    contents.FromEmailAddress = __expectString(output["FromEmailAddress"]);
   }
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -8774,22 +8775,22 @@ const deserializeAws_queryGetCustomVerificationEmailTemplateResponse = (
     FailureRedirectionURL: undefined,
   };
   if (output["TemplateName"] !== undefined) {
-    contents.TemplateName = output["TemplateName"];
+    contents.TemplateName = __expectString(output["TemplateName"]);
   }
   if (output["FromEmailAddress"] !== undefined) {
-    contents.FromEmailAddress = output["FromEmailAddress"];
+    contents.FromEmailAddress = __expectString(output["FromEmailAddress"]);
   }
   if (output["TemplateSubject"] !== undefined) {
-    contents.TemplateSubject = output["TemplateSubject"];
+    contents.TemplateSubject = __expectString(output["TemplateSubject"]);
   }
   if (output["TemplateContent"] !== undefined) {
-    contents.TemplateContent = output["TemplateContent"];
+    contents.TemplateContent = __expectString(output["TemplateContent"]);
   }
   if (output["SuccessRedirectionURL"] !== undefined) {
-    contents.SuccessRedirectionURL = output["SuccessRedirectionURL"];
+    contents.SuccessRedirectionURL = __expectString(output["SuccessRedirectionURL"]);
   }
   if (output["FailureRedirectionURL"] !== undefined) {
-    contents.FailureRedirectionURL = output["FailureRedirectionURL"];
+    contents.FailureRedirectionURL = __expectString(output["FailureRedirectionURL"]);
   }
   return contents;
 };
@@ -8943,7 +8944,7 @@ const deserializeAws_queryIdentityDkimAttributes = (output: any, context: __Serd
     contents.DkimEnabled = __parseBoolean(output["DkimEnabled"]);
   }
   if (output["DkimVerificationStatus"] !== undefined) {
-    contents.DkimVerificationStatus = output["DkimVerificationStatus"];
+    contents.DkimVerificationStatus = __expectString(output["DkimVerificationStatus"]);
   }
   if (output.DkimTokens === "") {
     contents.DkimTokens = [];
@@ -8964,7 +8965,7 @@ const deserializeAws_queryIdentityList = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -8978,13 +8979,13 @@ const deserializeAws_queryIdentityMailFromDomainAttributes = (
     BehaviorOnMXFailure: undefined,
   };
   if (output["MailFromDomain"] !== undefined) {
-    contents.MailFromDomain = output["MailFromDomain"];
+    contents.MailFromDomain = __expectString(output["MailFromDomain"]);
   }
   if (output["MailFromDomainStatus"] !== undefined) {
-    contents.MailFromDomainStatus = output["MailFromDomainStatus"];
+    contents.MailFromDomainStatus = __expectString(output["MailFromDomainStatus"]);
   }
   if (output["BehaviorOnMXFailure"] !== undefined) {
-    contents.BehaviorOnMXFailure = output["BehaviorOnMXFailure"];
+    contents.BehaviorOnMXFailure = __expectString(output["BehaviorOnMXFailure"]);
   }
   return contents;
 };
@@ -9003,13 +9004,13 @@ const deserializeAws_queryIdentityNotificationAttributes = (
     HeadersInDeliveryNotificationsEnabled: undefined,
   };
   if (output["BounceTopic"] !== undefined) {
-    contents.BounceTopic = output["BounceTopic"];
+    contents.BounceTopic = __expectString(output["BounceTopic"]);
   }
   if (output["ComplaintTopic"] !== undefined) {
-    contents.ComplaintTopic = output["ComplaintTopic"];
+    contents.ComplaintTopic = __expectString(output["ComplaintTopic"]);
   }
   if (output["DeliveryTopic"] !== undefined) {
-    contents.DeliveryTopic = output["DeliveryTopic"];
+    contents.DeliveryTopic = __expectString(output["DeliveryTopic"]);
   }
   if (output["ForwardingEnabled"] !== undefined) {
     contents.ForwardingEnabled = __parseBoolean(output["ForwardingEnabled"]);
@@ -9035,10 +9036,10 @@ const deserializeAws_queryIdentityVerificationAttributes = (
     VerificationToken: undefined,
   };
   if (output["VerificationStatus"] !== undefined) {
-    contents.VerificationStatus = output["VerificationStatus"];
+    contents.VerificationStatus = __expectString(output["VerificationStatus"]);
   }
   if (output["VerificationToken"] !== undefined) {
-    contents.VerificationToken = output["VerificationToken"];
+    contents.VerificationToken = __expectString(output["VerificationToken"]);
   }
   return contents;
 };
@@ -9053,13 +9054,13 @@ const deserializeAws_queryInvalidCloudWatchDestinationException = (
     message: undefined,
   };
   if (output["ConfigurationSetName"] !== undefined) {
-    contents.ConfigurationSetName = output["ConfigurationSetName"];
+    contents.ConfigurationSetName = __expectString(output["ConfigurationSetName"]);
   }
   if (output["EventDestinationName"] !== undefined) {
-    contents.EventDestinationName = output["EventDestinationName"];
+    contents.EventDestinationName = __expectString(output["EventDestinationName"]);
   }
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -9072,7 +9073,7 @@ const deserializeAws_queryInvalidConfigurationSetException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -9085,7 +9086,7 @@ const deserializeAws_queryInvalidDeliveryOptionsException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -9100,13 +9101,13 @@ const deserializeAws_queryInvalidFirehoseDestinationException = (
     message: undefined,
   };
   if (output["ConfigurationSetName"] !== undefined) {
-    contents.ConfigurationSetName = output["ConfigurationSetName"];
+    contents.ConfigurationSetName = __expectString(output["ConfigurationSetName"]);
   }
   if (output["EventDestinationName"] !== undefined) {
-    contents.EventDestinationName = output["EventDestinationName"];
+    contents.EventDestinationName = __expectString(output["EventDestinationName"]);
   }
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -9120,10 +9121,10 @@ const deserializeAws_queryInvalidLambdaFunctionException = (
     message: undefined,
   };
   if (output["FunctionArn"] !== undefined) {
-    contents.FunctionArn = output["FunctionArn"];
+    contents.FunctionArn = __expectString(output["FunctionArn"]);
   }
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -9133,7 +9134,7 @@ const deserializeAws_queryInvalidPolicyException = (output: any, context: __Serd
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -9147,10 +9148,10 @@ const deserializeAws_queryInvalidRenderingParameterException = (
     message: undefined,
   };
   if (output["TemplateName"] !== undefined) {
-    contents.TemplateName = output["TemplateName"];
+    contents.TemplateName = __expectString(output["TemplateName"]);
   }
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -9164,10 +9165,10 @@ const deserializeAws_queryInvalidS3ConfigurationException = (
     message: undefined,
   };
   if (output["Bucket"] !== undefined) {
-    contents.Bucket = output["Bucket"];
+    contents.Bucket = __expectString(output["Bucket"]);
   }
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -9182,13 +9183,13 @@ const deserializeAws_queryInvalidSNSDestinationException = (
     message: undefined,
   };
   if (output["ConfigurationSetName"] !== undefined) {
-    contents.ConfigurationSetName = output["ConfigurationSetName"];
+    contents.ConfigurationSetName = __expectString(output["ConfigurationSetName"]);
   }
   if (output["EventDestinationName"] !== undefined) {
-    contents.EventDestinationName = output["EventDestinationName"];
+    contents.EventDestinationName = __expectString(output["EventDestinationName"]);
   }
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -9202,10 +9203,10 @@ const deserializeAws_queryInvalidSnsTopicException = (
     message: undefined,
   };
   if (output["Topic"] !== undefined) {
-    contents.Topic = output["Topic"];
+    contents.Topic = __expectString(output["Topic"]);
   }
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -9219,10 +9220,10 @@ const deserializeAws_queryInvalidTemplateException = (
     message: undefined,
   };
   if (output["TemplateName"] !== undefined) {
-    contents.TemplateName = output["TemplateName"];
+    contents.TemplateName = __expectString(output["TemplateName"]);
   }
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -9235,7 +9236,7 @@ const deserializeAws_queryInvalidTrackingOptionsException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -9249,10 +9250,10 @@ const deserializeAws_queryKinesisFirehoseDestination = (
     DeliveryStreamARN: undefined,
   };
   if (output["IAMRoleARN"] !== undefined) {
-    contents.IAMRoleARN = output["IAMRoleARN"];
+    contents.IAMRoleARN = __expectString(output["IAMRoleARN"]);
   }
   if (output["DeliveryStreamARN"] !== undefined) {
-    contents.DeliveryStreamARN = output["DeliveryStreamARN"];
+    contents.DeliveryStreamARN = __expectString(output["DeliveryStreamARN"]);
   }
   return contents;
 };
@@ -9264,13 +9265,13 @@ const deserializeAws_queryLambdaAction = (output: any, context: __SerdeContext):
     InvocationType: undefined,
   };
   if (output["TopicArn"] !== undefined) {
-    contents.TopicArn = output["TopicArn"];
+    contents.TopicArn = __expectString(output["TopicArn"]);
   }
   if (output["FunctionArn"] !== undefined) {
-    contents.FunctionArn = output["FunctionArn"];
+    contents.FunctionArn = __expectString(output["FunctionArn"]);
   }
   if (output["InvocationType"] !== undefined) {
-    contents.InvocationType = output["InvocationType"];
+    contents.InvocationType = __expectString(output["InvocationType"]);
   }
   return contents;
 };
@@ -9280,7 +9281,7 @@ const deserializeAws_queryLimitExceededException = (output: any, context: __Serd
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -9303,7 +9304,7 @@ const deserializeAws_queryListConfigurationSetsResponse = (
     );
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -9329,7 +9330,7 @@ const deserializeAws_queryListCustomVerificationEmailTemplatesResponse = (
     );
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -9349,7 +9350,7 @@ const deserializeAws_queryListIdentitiesResponse = (output: any, context: __Serd
     );
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -9410,7 +9411,7 @@ const deserializeAws_queryListReceiptRuleSetsResponse = (
     );
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -9430,7 +9431,7 @@ const deserializeAws_queryListTemplatesResponse = (output: any, context: __Serde
     );
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -9477,7 +9478,7 @@ const deserializeAws_queryMailFromDomainNotVerifiedException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -9487,7 +9488,7 @@ const deserializeAws_queryMessageRejected = (output: any, context: __SerdeContex
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -9501,10 +9502,10 @@ const deserializeAws_queryMissingRenderingAttributeException = (
     message: undefined,
   };
   if (output["TemplateName"] !== undefined) {
-    contents.TemplateName = output["TemplateName"];
+    contents.TemplateName = __expectString(output["TemplateName"]);
   }
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -9531,7 +9532,7 @@ const deserializeAws_queryPolicyMap = (output: any, context: __SerdeContext): { 
     }
     return {
       ...acc,
-      [pair["key"]]: pair["value"],
+      [pair["key"]]: __expectString(pair["value"]) as any,
     };
   }, {});
 };
@@ -9543,7 +9544,7 @@ const deserializeAws_queryPolicyNameList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -9555,7 +9556,7 @@ const deserializeAws_queryProductionAccessNotGrantedException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -9627,7 +9628,7 @@ const deserializeAws_queryReceiptFilter = (output: any, context: __SerdeContext)
     IpFilter: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["IpFilter"] !== undefined) {
     contents.IpFilter = deserializeAws_queryReceiptIpFilter(output["IpFilter"], context);
@@ -9652,10 +9653,10 @@ const deserializeAws_queryReceiptIpFilter = (output: any, context: __SerdeContex
     Cidr: undefined,
   };
   if (output["Policy"] !== undefined) {
-    contents.Policy = output["Policy"];
+    contents.Policy = __expectString(output["Policy"]);
   }
   if (output["Cidr"] !== undefined) {
-    contents.Cidr = output["Cidr"];
+    contents.Cidr = __expectString(output["Cidr"]);
   }
   return contents;
 };
@@ -9670,13 +9671,13 @@ const deserializeAws_queryReceiptRule = (output: any, context: __SerdeContext): 
     ScanEnabled: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["Enabled"] !== undefined) {
     contents.Enabled = __parseBoolean(output["Enabled"]);
   }
   if (output["TlsPolicy"] !== undefined) {
-    contents.TlsPolicy = output["TlsPolicy"];
+    contents.TlsPolicy = __expectString(output["TlsPolicy"]);
   }
   if (output.Recipients === "") {
     contents.Recipients = [];
@@ -9708,7 +9709,7 @@ const deserializeAws_queryReceiptRuleSetMetadata = (output: any, context: __Serd
     CreatedTimestamp: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["CreatedTimestamp"] !== undefined) {
     contents.CreatedTimestamp = new Date(output["CreatedTimestamp"]);
@@ -9745,7 +9746,7 @@ const deserializeAws_queryRecipientsList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -9784,10 +9785,10 @@ const deserializeAws_queryRuleDoesNotExistException = (
     message: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -9801,10 +9802,10 @@ const deserializeAws_queryRuleSetDoesNotExistException = (
     message: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -9817,16 +9818,16 @@ const deserializeAws_queryS3Action = (output: any, context: __SerdeContext): S3A
     KmsKeyArn: undefined,
   };
   if (output["TopicArn"] !== undefined) {
-    contents.TopicArn = output["TopicArn"];
+    contents.TopicArn = __expectString(output["TopicArn"]);
   }
   if (output["BucketName"] !== undefined) {
-    contents.BucketName = output["BucketName"];
+    contents.BucketName = __expectString(output["BucketName"]);
   }
   if (output["ObjectKeyPrefix"] !== undefined) {
-    contents.ObjectKeyPrefix = output["ObjectKeyPrefix"];
+    contents.ObjectKeyPrefix = __expectString(output["ObjectKeyPrefix"]);
   }
   if (output["KmsKeyArn"] !== undefined) {
-    contents.KmsKeyArn = output["KmsKeyArn"];
+    contents.KmsKeyArn = __expectString(output["KmsKeyArn"]);
   }
   return contents;
 };
@@ -9836,7 +9837,7 @@ const deserializeAws_querySendBounceResponse = (output: any, context: __SerdeCon
     MessageId: undefined,
   };
   if (output["MessageId"] !== undefined) {
-    contents.MessageId = output["MessageId"];
+    contents.MessageId = __expectString(output["MessageId"]);
   }
   return contents;
 };
@@ -9868,7 +9869,7 @@ const deserializeAws_querySendCustomVerificationEmailResponse = (
     MessageId: undefined,
   };
   if (output["MessageId"] !== undefined) {
-    contents.MessageId = output["MessageId"];
+    contents.MessageId = __expectString(output["MessageId"]);
   }
   return contents;
 };
@@ -9915,7 +9916,7 @@ const deserializeAws_querySendEmailResponse = (output: any, context: __SerdeCont
     MessageId: undefined,
   };
   if (output["MessageId"] !== undefined) {
-    contents.MessageId = output["MessageId"];
+    contents.MessageId = __expectString(output["MessageId"]);
   }
   return contents;
 };
@@ -9925,7 +9926,7 @@ const deserializeAws_querySendRawEmailResponse = (output: any, context: __SerdeC
     MessageId: undefined,
   };
   if (output["MessageId"] !== undefined) {
-    contents.MessageId = output["MessageId"];
+    contents.MessageId = __expectString(output["MessageId"]);
   }
   return contents;
 };
@@ -9938,7 +9939,7 @@ const deserializeAws_querySendTemplatedEmailResponse = (
     MessageId: undefined,
   };
   if (output["MessageId"] !== undefined) {
-    contents.MessageId = output["MessageId"];
+    contents.MessageId = __expectString(output["MessageId"]);
   }
   return contents;
 };
@@ -10005,10 +10006,10 @@ const deserializeAws_querySNSAction = (output: any, context: __SerdeContext): SN
     Encoding: undefined,
   };
   if (output["TopicArn"] !== undefined) {
-    contents.TopicArn = output["TopicArn"];
+    contents.TopicArn = __expectString(output["TopicArn"]);
   }
   if (output["Encoding"] !== undefined) {
-    contents.Encoding = output["Encoding"];
+    contents.Encoding = __expectString(output["Encoding"]);
   }
   return contents;
 };
@@ -10018,7 +10019,7 @@ const deserializeAws_querySNSDestination = (output: any, context: __SerdeContext
     TopicARN: undefined,
   };
   if (output["TopicARN"] !== undefined) {
-    contents.TopicARN = output["TopicARN"];
+    contents.TopicARN = __expectString(output["TopicARN"]);
   }
   return contents;
 };
@@ -10029,10 +10030,10 @@ const deserializeAws_queryStopAction = (output: any, context: __SerdeContext): S
     TopicArn: undefined,
   };
   if (output["Scope"] !== undefined) {
-    contents.Scope = output["Scope"];
+    contents.Scope = __expectString(output["Scope"]);
   }
   if (output["TopicArn"] !== undefined) {
-    contents.TopicArn = output["TopicArn"];
+    contents.TopicArn = __expectString(output["TopicArn"]);
   }
   return contents;
 };
@@ -10045,16 +10046,16 @@ const deserializeAws_queryTemplate = (output: any, context: __SerdeContext): Tem
     HtmlPart: undefined,
   };
   if (output["TemplateName"] !== undefined) {
-    contents.TemplateName = output["TemplateName"];
+    contents.TemplateName = __expectString(output["TemplateName"]);
   }
   if (output["SubjectPart"] !== undefined) {
-    contents.SubjectPart = output["SubjectPart"];
+    contents.SubjectPart = __expectString(output["SubjectPart"]);
   }
   if (output["TextPart"] !== undefined) {
-    contents.TextPart = output["TextPart"];
+    contents.TextPart = __expectString(output["TextPart"]);
   }
   if (output["HtmlPart"] !== undefined) {
-    contents.HtmlPart = output["HtmlPart"];
+    contents.HtmlPart = __expectString(output["HtmlPart"]);
   }
   return contents;
 };
@@ -10068,10 +10069,10 @@ const deserializeAws_queryTemplateDoesNotExistException = (
     message: undefined,
   };
   if (output["TemplateName"] !== undefined) {
-    contents.TemplateName = output["TemplateName"];
+    contents.TemplateName = __expectString(output["TemplateName"]);
   }
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -10082,7 +10083,7 @@ const deserializeAws_queryTemplateMetadata = (output: any, context: __SerdeConte
     CreatedTimestamp: undefined,
   };
   if (output["Name"] !== undefined) {
-    contents.Name = output["Name"];
+    contents.Name = __expectString(output["Name"]);
   }
   if (output["CreatedTimestamp"] !== undefined) {
     contents.CreatedTimestamp = new Date(output["CreatedTimestamp"]);
@@ -10109,7 +10110,7 @@ const deserializeAws_queryTestRenderTemplateResponse = (
     RenderedTemplate: undefined,
   };
   if (output["RenderedTemplate"] !== undefined) {
-    contents.RenderedTemplate = output["RenderedTemplate"];
+    contents.RenderedTemplate = __expectString(output["RenderedTemplate"]);
   }
   return contents;
 };
@@ -10119,7 +10120,7 @@ const deserializeAws_queryTrackingOptions = (output: any, context: __SerdeContex
     CustomRedirectDomain: undefined,
   };
   if (output["CustomRedirectDomain"] !== undefined) {
-    contents.CustomRedirectDomain = output["CustomRedirectDomain"];
+    contents.CustomRedirectDomain = __expectString(output["CustomRedirectDomain"]);
   }
   return contents;
 };
@@ -10133,10 +10134,10 @@ const deserializeAws_queryTrackingOptionsAlreadyExistsException = (
     message: undefined,
   };
   if (output["ConfigurationSetName"] !== undefined) {
-    contents.ConfigurationSetName = output["ConfigurationSetName"];
+    contents.ConfigurationSetName = __expectString(output["ConfigurationSetName"]);
   }
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -10150,10 +10151,10 @@ const deserializeAws_queryTrackingOptionsDoesNotExistException = (
     message: undefined,
   };
   if (output["ConfigurationSetName"] !== undefined) {
-    contents.ConfigurationSetName = output["ConfigurationSetName"];
+    contents.ConfigurationSetName = __expectString(output["ConfigurationSetName"]);
   }
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -10209,7 +10210,7 @@ const deserializeAws_queryVerificationTokenList = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -10240,7 +10241,7 @@ const deserializeAws_queryVerifyDomainIdentityResponse = (
     VerificationToken: undefined,
   };
   if (output["VerificationToken"] !== undefined) {
-    contents.VerificationToken = output["VerificationToken"];
+    contents.VerificationToken = __expectString(output["VerificationToken"]);
   }
   return contents;
 };
@@ -10259,10 +10260,10 @@ const deserializeAws_queryWorkmailAction = (output: any, context: __SerdeContext
     OrganizationArn: undefined,
   };
   if (output["TopicArn"] !== undefined) {
-    contents.TopicArn = output["TopicArn"];
+    contents.TopicArn = __expectString(output["TopicArn"]);
   }
   if (output["OrganizationArn"] !== undefined) {
-    contents.OrganizationArn = output["OrganizationArn"];
+    contents.OrganizationArn = __expectString(output["OrganizationArn"]);
   }
   return contents;
 };

--- a/clients/client-sesv2/protocols/Aws_restJson1.ts
+++ b/clients/client-sesv2/protocols/Aws_restJson1.ts
@@ -334,6 +334,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -3404,10 +3407,10 @@ export const deserializeAws_restJson1CreateDeliverabilityTestReportCommand = asy
   };
   const data: any = await parseBody(output.body, context);
   if (data.DeliverabilityTestStatus !== undefined && data.DeliverabilityTestStatus !== null) {
-    contents.DeliverabilityTestStatus = data.DeliverabilityTestStatus;
+    contents.DeliverabilityTestStatus = __expectString(data.DeliverabilityTestStatus);
   }
   if (data.ReportId !== undefined && data.ReportId !== null) {
-    contents.ReportId = data.ReportId;
+    contents.ReportId = __expectString(data.ReportId);
   }
   return Promise.resolve(contents);
 };
@@ -3531,10 +3534,10 @@ export const deserializeAws_restJson1CreateEmailIdentityCommand = async (
     contents.DkimAttributes = deserializeAws_restJson1DkimAttributes(data.DkimAttributes, context);
   }
   if (data.IdentityType !== undefined && data.IdentityType !== null) {
-    contents.IdentityType = data.IdentityType;
+    contents.IdentityType = __expectString(data.IdentityType);
   }
   if (data.VerifiedForSendingStatus !== undefined && data.VerifiedForSendingStatus !== null) {
-    contents.VerifiedForSendingStatus = data.VerifiedForSendingStatus;
+    contents.VerifiedForSendingStatus = __expectBoolean(data.VerifiedForSendingStatus);
   }
   return Promise.resolve(contents);
 };
@@ -3787,7 +3790,7 @@ export const deserializeAws_restJson1CreateImportJobCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.JobId !== undefined && data.JobId !== null) {
-    contents.JobId = data.JobId;
+    contents.JobId = __expectString(data.JobId);
   }
   return Promise.resolve(contents);
 };
@@ -4566,22 +4569,22 @@ export const deserializeAws_restJson1GetAccountCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.DedicatedIpAutoWarmupEnabled !== undefined && data.DedicatedIpAutoWarmupEnabled !== null) {
-    contents.DedicatedIpAutoWarmupEnabled = data.DedicatedIpAutoWarmupEnabled;
+    contents.DedicatedIpAutoWarmupEnabled = __expectBoolean(data.DedicatedIpAutoWarmupEnabled);
   }
   if (data.Details !== undefined && data.Details !== null) {
     contents.Details = deserializeAws_restJson1AccountDetails(data.Details, context);
   }
   if (data.EnforcementStatus !== undefined && data.EnforcementStatus !== null) {
-    contents.EnforcementStatus = data.EnforcementStatus;
+    contents.EnforcementStatus = __expectString(data.EnforcementStatus);
   }
   if (data.ProductionAccessEnabled !== undefined && data.ProductionAccessEnabled !== null) {
-    contents.ProductionAccessEnabled = data.ProductionAccessEnabled;
+    contents.ProductionAccessEnabled = __expectBoolean(data.ProductionAccessEnabled);
   }
   if (data.SendQuota !== undefined && data.SendQuota !== null) {
     contents.SendQuota = deserializeAws_restJson1SendQuota(data.SendQuota, context);
   }
   if (data.SendingEnabled !== undefined && data.SendingEnabled !== null) {
-    contents.SendingEnabled = data.SendingEnabled;
+    contents.SendingEnabled = __expectBoolean(data.SendingEnabled);
   }
   if (data.SuppressionAttributes !== undefined && data.SuppressionAttributes !== null) {
     contents.SuppressionAttributes = deserializeAws_restJson1SuppressionAttributes(data.SuppressionAttributes, context);
@@ -4724,7 +4727,7 @@ export const deserializeAws_restJson1GetConfigurationSetCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ConfigurationSetName !== undefined && data.ConfigurationSetName !== null) {
-    contents.ConfigurationSetName = data.ConfigurationSetName;
+    contents.ConfigurationSetName = __expectString(data.ConfigurationSetName);
   }
   if (data.DeliveryOptions !== undefined && data.DeliveryOptions !== null) {
     contents.DeliveryOptions = deserializeAws_restJson1DeliveryOptions(data.DeliveryOptions, context);
@@ -4891,16 +4894,16 @@ export const deserializeAws_restJson1GetContactCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AttributesData !== undefined && data.AttributesData !== null) {
-    contents.AttributesData = data.AttributesData;
+    contents.AttributesData = __expectString(data.AttributesData);
   }
   if (data.ContactListName !== undefined && data.ContactListName !== null) {
-    contents.ContactListName = data.ContactListName;
+    contents.ContactListName = __expectString(data.ContactListName);
   }
   if (data.CreatedTimestamp !== undefined && data.CreatedTimestamp !== null) {
     contents.CreatedTimestamp = new Date(Math.round(data.CreatedTimestamp * 1000));
   }
   if (data.EmailAddress !== undefined && data.EmailAddress !== null) {
-    contents.EmailAddress = data.EmailAddress;
+    contents.EmailAddress = __expectString(data.EmailAddress);
   }
   if (data.LastUpdatedTimestamp !== undefined && data.LastUpdatedTimestamp !== null) {
     contents.LastUpdatedTimestamp = new Date(Math.round(data.LastUpdatedTimestamp * 1000));
@@ -4915,7 +4918,7 @@ export const deserializeAws_restJson1GetContactCommand = async (
     contents.TopicPreferences = deserializeAws_restJson1TopicPreferenceList(data.TopicPreferences, context);
   }
   if (data.UnsubscribeAll !== undefined && data.UnsubscribeAll !== null) {
-    contents.UnsubscribeAll = data.UnsubscribeAll;
+    contents.UnsubscribeAll = __expectBoolean(data.UnsubscribeAll);
   }
   return Promise.resolve(contents);
 };
@@ -4991,13 +4994,13 @@ export const deserializeAws_restJson1GetContactListCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ContactListName !== undefined && data.ContactListName !== null) {
-    contents.ContactListName = data.ContactListName;
+    contents.ContactListName = __expectString(data.ContactListName);
   }
   if (data.CreatedTimestamp !== undefined && data.CreatedTimestamp !== null) {
     contents.CreatedTimestamp = new Date(Math.round(data.CreatedTimestamp * 1000));
   }
   if (data.Description !== undefined && data.Description !== null) {
-    contents.Description = data.Description;
+    contents.Description = __expectString(data.Description);
   }
   if (data.LastUpdatedTimestamp !== undefined && data.LastUpdatedTimestamp !== null) {
     contents.LastUpdatedTimestamp = new Date(Math.round(data.LastUpdatedTimestamp * 1000));
@@ -5082,22 +5085,22 @@ export const deserializeAws_restJson1GetCustomVerificationEmailTemplateCommand =
   };
   const data: any = await parseBody(output.body, context);
   if (data.FailureRedirectionURL !== undefined && data.FailureRedirectionURL !== null) {
-    contents.FailureRedirectionURL = data.FailureRedirectionURL;
+    contents.FailureRedirectionURL = __expectString(data.FailureRedirectionURL);
   }
   if (data.FromEmailAddress !== undefined && data.FromEmailAddress !== null) {
-    contents.FromEmailAddress = data.FromEmailAddress;
+    contents.FromEmailAddress = __expectString(data.FromEmailAddress);
   }
   if (data.SuccessRedirectionURL !== undefined && data.SuccessRedirectionURL !== null) {
-    contents.SuccessRedirectionURL = data.SuccessRedirectionURL;
+    contents.SuccessRedirectionURL = __expectString(data.SuccessRedirectionURL);
   }
   if (data.TemplateContent !== undefined && data.TemplateContent !== null) {
-    contents.TemplateContent = data.TemplateContent;
+    contents.TemplateContent = __expectString(data.TemplateContent);
   }
   if (data.TemplateName !== undefined && data.TemplateName !== null) {
-    contents.TemplateName = data.TemplateName;
+    contents.TemplateName = __expectString(data.TemplateName);
   }
   if (data.TemplateSubject !== undefined && data.TemplateSubject !== null) {
-    contents.TemplateSubject = data.TemplateSubject;
+    contents.TemplateSubject = __expectString(data.TemplateSubject);
   }
   return Promise.resolve(contents);
 };
@@ -5243,7 +5246,7 @@ export const deserializeAws_restJson1GetDedicatedIpsCommand = async (
     contents.DedicatedIps = deserializeAws_restJson1DedicatedIpList(data.DedicatedIps, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -5318,7 +5321,7 @@ export const deserializeAws_restJson1GetDeliverabilityDashboardOptionsCommand = 
   };
   const data: any = await parseBody(output.body, context);
   if (data.AccountStatus !== undefined && data.AccountStatus !== null) {
-    contents.AccountStatus = data.AccountStatus;
+    contents.AccountStatus = __expectString(data.AccountStatus);
   }
   if (data.ActiveSubscribedDomains !== undefined && data.ActiveSubscribedDomains !== null) {
     contents.ActiveSubscribedDomains = deserializeAws_restJson1DomainDeliverabilityTrackingOptions(
@@ -5327,7 +5330,7 @@ export const deserializeAws_restJson1GetDeliverabilityDashboardOptionsCommand = 
     );
   }
   if (data.DashboardEnabled !== undefined && data.DashboardEnabled !== null) {
-    contents.DashboardEnabled = data.DashboardEnabled;
+    contents.DashboardEnabled = __expectBoolean(data.DashboardEnabled);
   }
   if (data.PendingExpirationSubscribedDomains !== undefined && data.PendingExpirationSubscribedDomains !== null) {
     contents.PendingExpirationSubscribedDomains = deserializeAws_restJson1DomainDeliverabilityTrackingOptions(
@@ -5420,7 +5423,7 @@ export const deserializeAws_restJson1GetDeliverabilityTestReportCommand = async 
     contents.IspPlacements = deserializeAws_restJson1IspPlacements(data.IspPlacements, context);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.OverallPlacement !== undefined && data.OverallPlacement !== null) {
     contents.OverallPlacement = deserializeAws_restJson1PlacementStatistics(data.OverallPlacement, context);
@@ -5653,16 +5656,16 @@ export const deserializeAws_restJson1GetEmailIdentityCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ConfigurationSetName !== undefined && data.ConfigurationSetName !== null) {
-    contents.ConfigurationSetName = data.ConfigurationSetName;
+    contents.ConfigurationSetName = __expectString(data.ConfigurationSetName);
   }
   if (data.DkimAttributes !== undefined && data.DkimAttributes !== null) {
     contents.DkimAttributes = deserializeAws_restJson1DkimAttributes(data.DkimAttributes, context);
   }
   if (data.FeedbackForwardingStatus !== undefined && data.FeedbackForwardingStatus !== null) {
-    contents.FeedbackForwardingStatus = data.FeedbackForwardingStatus;
+    contents.FeedbackForwardingStatus = __expectBoolean(data.FeedbackForwardingStatus);
   }
   if (data.IdentityType !== undefined && data.IdentityType !== null) {
-    contents.IdentityType = data.IdentityType;
+    contents.IdentityType = __expectString(data.IdentityType);
   }
   if (data.MailFromAttributes !== undefined && data.MailFromAttributes !== null) {
     contents.MailFromAttributes = deserializeAws_restJson1MailFromAttributes(data.MailFromAttributes, context);
@@ -5674,7 +5677,7 @@ export const deserializeAws_restJson1GetEmailIdentityCommand = async (
     contents.Tags = deserializeAws_restJson1TagList(data.Tags, context);
   }
   if (data.VerifiedForSendingStatus !== undefined && data.VerifiedForSendingStatus !== null) {
-    contents.VerifiedForSendingStatus = data.VerifiedForSendingStatus;
+    contents.VerifiedForSendingStatus = __expectBoolean(data.VerifiedForSendingStatus);
   }
   return Promise.resolve(contents);
 };
@@ -5820,7 +5823,7 @@ export const deserializeAws_restJson1GetEmailTemplateCommand = async (
     contents.TemplateContent = deserializeAws_restJson1EmailTemplateContent(data.TemplateContent, context);
   }
   if (data.TemplateName !== undefined && data.TemplateName !== null) {
-    contents.TemplateName = data.TemplateName;
+    contents.TemplateName = __expectString(data.TemplateName);
   }
   return Promise.resolve(contents);
 };
@@ -5905,7 +5908,7 @@ export const deserializeAws_restJson1GetImportJobCommand = async (
     contents.CreatedTimestamp = new Date(Math.round(data.CreatedTimestamp * 1000));
   }
   if (data.FailedRecordsCount !== undefined && data.FailedRecordsCount !== null) {
-    contents.FailedRecordsCount = data.FailedRecordsCount;
+    contents.FailedRecordsCount = __expectNumber(data.FailedRecordsCount);
   }
   if (data.FailureInfo !== undefined && data.FailureInfo !== null) {
     contents.FailureInfo = deserializeAws_restJson1FailureInfo(data.FailureInfo, context);
@@ -5917,13 +5920,13 @@ export const deserializeAws_restJson1GetImportJobCommand = async (
     contents.ImportDestination = deserializeAws_restJson1ImportDestination(data.ImportDestination, context);
   }
   if (data.JobId !== undefined && data.JobId !== null) {
-    contents.JobId = data.JobId;
+    contents.JobId = __expectString(data.JobId);
   }
   if (data.JobStatus !== undefined && data.JobStatus !== null) {
-    contents.JobStatus = data.JobStatus;
+    contents.JobStatus = __expectString(data.JobStatus);
   }
   if (data.ProcessedRecordsCount !== undefined && data.ProcessedRecordsCount !== null) {
-    contents.ProcessedRecordsCount = data.ProcessedRecordsCount;
+    contents.ProcessedRecordsCount = __expectNumber(data.ProcessedRecordsCount);
   }
   return Promise.resolve(contents);
 };
@@ -6069,7 +6072,7 @@ export const deserializeAws_restJson1ListConfigurationSetsCommand = async (
     contents.ConfigurationSets = deserializeAws_restJson1ConfigurationSetNameList(data.ConfigurationSets, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -6136,7 +6139,7 @@ export const deserializeAws_restJson1ListContactListsCommand = async (
     contents.ContactLists = deserializeAws_restJson1ListOfContactLists(data.ContactLists, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -6203,7 +6206,7 @@ export const deserializeAws_restJson1ListContactsCommand = async (
     contents.Contacts = deserializeAws_restJson1ListOfContacts(data.Contacts, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -6281,7 +6284,7 @@ export const deserializeAws_restJson1ListCustomVerificationEmailTemplatesCommand
     );
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -6348,7 +6351,7 @@ export const deserializeAws_restJson1ListDedicatedIpPoolsCommand = async (
     contents.DedicatedIpPools = deserializeAws_restJson1ListOfDedicatedIpPools(data.DedicatedIpPools, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -6418,7 +6421,7 @@ export const deserializeAws_restJson1ListDeliverabilityTestReportsCommand = asyn
     );
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -6496,7 +6499,7 @@ export const deserializeAws_restJson1ListDomainDeliverabilityCampaignsCommand = 
     );
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -6571,7 +6574,7 @@ export const deserializeAws_restJson1ListEmailIdentitiesCommand = async (
     contents.EmailIdentities = deserializeAws_restJson1IdentityInfoList(data.EmailIdentities, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -6635,7 +6638,7 @@ export const deserializeAws_restJson1ListEmailTemplatesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.TemplatesMetadata !== undefined && data.TemplatesMetadata !== null) {
     contents.TemplatesMetadata = deserializeAws_restJson1EmailTemplateMetadataList(data.TemplatesMetadata, context);
@@ -6705,7 +6708,7 @@ export const deserializeAws_restJson1ListImportJobsCommand = async (
     contents.ImportJobs = deserializeAws_restJson1ImportJobSummaryList(data.ImportJobs, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -6769,7 +6772,7 @@ export const deserializeAws_restJson1ListSuppressedDestinationsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.SuppressedDestinationSummaries !== undefined && data.SuppressedDestinationSummaries !== null) {
     contents.SuppressedDestinationSummaries = deserializeAws_restJson1SuppressedDestinationSummaries(
@@ -7848,7 +7851,7 @@ export const deserializeAws_restJson1PutEmailIdentityDkimSigningAttributesComman
   };
   const data: any = await parseBody(output.body, context);
   if (data.DkimStatus !== undefined && data.DkimStatus !== null) {
-    contents.DkimStatus = data.DkimStatus;
+    contents.DkimStatus = __expectString(data.DkimStatus);
   }
   if (data.DkimTokens !== undefined && data.DkimTokens !== null) {
     contents.DkimTokens = deserializeAws_restJson1DnsTokenList(data.DkimTokens, context);
@@ -8229,7 +8232,7 @@ export const deserializeAws_restJson1SendCustomVerificationEmailCommand = async 
   };
   const data: any = await parseBody(output.body, context);
   if (data.MessageId !== undefined && data.MessageId !== null) {
-    contents.MessageId = data.MessageId;
+    contents.MessageId = __expectString(data.MessageId);
   }
   return Promise.resolve(contents);
 };
@@ -8332,7 +8335,7 @@ export const deserializeAws_restJson1SendEmailCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.MessageId !== undefined && data.MessageId !== null) {
-    contents.MessageId = data.MessageId;
+    contents.MessageId = __expectString(data.MessageId);
   }
   return Promise.resolve(contents);
 };
@@ -8518,7 +8521,7 @@ export const deserializeAws_restJson1TestRenderEmailTemplateCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.RenderedTemplate !== undefined && data.RenderedTemplate !== null) {
-    contents.RenderedTemplate = data.RenderedTemplate;
+    contents.RenderedTemplate = __expectString(data.RenderedTemplate);
   }
   return Promise.resolve(contents);
 };
@@ -9081,7 +9084,7 @@ const deserializeAws_restJson1AccountSuspendedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -9098,7 +9101,7 @@ const deserializeAws_restJson1AlreadyExistsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -9115,7 +9118,7 @@ const deserializeAws_restJson1BadRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -9132,7 +9135,7 @@ const deserializeAws_restJson1ConcurrentModificationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -9149,7 +9152,7 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -9166,7 +9169,7 @@ const deserializeAws_restJson1InvalidNextTokenExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -9183,7 +9186,7 @@ const deserializeAws_restJson1LimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -9200,7 +9203,7 @@ const deserializeAws_restJson1MailFromDomainNotVerifiedExceptionResponse = async
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -9217,7 +9220,7 @@ const deserializeAws_restJson1MessageRejectedResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -9234,7 +9237,7 @@ const deserializeAws_restJson1NotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -9251,7 +9254,7 @@ const deserializeAws_restJson1SendingPausedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -9268,7 +9271,7 @@ const deserializeAws_restJson1TooManyRequestsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -9796,18 +9799,14 @@ const deserializeAws_restJson1AccountDetails = (output: any, context: __SerdeCon
       output.AdditionalContactEmailAddresses !== undefined && output.AdditionalContactEmailAddresses !== null
         ? deserializeAws_restJson1AdditionalContactEmailAddresses(output.AdditionalContactEmailAddresses, context)
         : undefined,
-    ContactLanguage:
-      output.ContactLanguage !== undefined && output.ContactLanguage !== null ? output.ContactLanguage : undefined,
-    MailType: output.MailType !== undefined && output.MailType !== null ? output.MailType : undefined,
+    ContactLanguage: __expectString(output.ContactLanguage),
+    MailType: __expectString(output.MailType),
     ReviewDetails:
       output.ReviewDetails !== undefined && output.ReviewDetails !== null
         ? deserializeAws_restJson1ReviewDetails(output.ReviewDetails, context)
         : undefined,
-    UseCaseDescription:
-      output.UseCaseDescription !== undefined && output.UseCaseDescription !== null
-        ? output.UseCaseDescription
-        : undefined,
-    WebsiteURL: output.WebsiteURL !== undefined && output.WebsiteURL !== null ? output.WebsiteURL : undefined,
+    UseCaseDescription: __expectString(output.UseCaseDescription),
+    WebsiteURL: __expectString(output.WebsiteURL),
   } as any;
 };
 
@@ -9818,7 +9817,7 @@ const deserializeAws_restJson1AdditionalContactEmailAddresses = (output: any, co
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -9835,12 +9834,12 @@ const deserializeAws_restJson1BlacklistEntries = (output: any, context: __SerdeC
 
 const deserializeAws_restJson1BlacklistEntry = (output: any, context: __SerdeContext): BlacklistEntry => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     ListingTime:
       output.ListingTime !== undefined && output.ListingTime !== null
         ? new Date(Math.round(output.ListingTime * 1000))
         : undefined,
-    RblName: output.RblName !== undefined && output.RblName !== null ? output.RblName : undefined,
+    RblName: __expectString(output.RblName),
   } as any;
 };
 
@@ -9861,9 +9860,9 @@ const deserializeAws_restJson1BlacklistReport = (
 
 const deserializeAws_restJson1BulkEmailEntryResult = (output: any, context: __SerdeContext): BulkEmailEntryResult => {
   return {
-    Error: output.Error !== undefined && output.Error !== null ? output.Error : undefined,
-    MessageId: output.MessageId !== undefined && output.MessageId !== null ? output.MessageId : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Error: __expectString(output.Error),
+    MessageId: __expectString(output.MessageId),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -9895,16 +9894,9 @@ const deserializeAws_restJson1CloudWatchDimensionConfiguration = (
   context: __SerdeContext
 ): CloudWatchDimensionConfiguration => {
   return {
-    DefaultDimensionValue:
-      output.DefaultDimensionValue !== undefined && output.DefaultDimensionValue !== null
-        ? output.DefaultDimensionValue
-        : undefined,
-    DimensionName:
-      output.DimensionName !== undefined && output.DimensionName !== null ? output.DimensionName : undefined,
-    DimensionValueSource:
-      output.DimensionValueSource !== undefined && output.DimensionValueSource !== null
-        ? output.DimensionValueSource
-        : undefined,
+    DefaultDimensionValue: __expectString(output.DefaultDimensionValue),
+    DimensionName: __expectString(output.DimensionName),
+    DimensionValueSource: __expectString(output.DimensionValueSource),
   } as any;
 };
 
@@ -9929,13 +9921,13 @@ const deserializeAws_restJson1ConfigurationSetNameList = (output: any, context: 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1Contact = (output: any, context: __SerdeContext): Contact => {
   return {
-    EmailAddress: output.EmailAddress !== undefined && output.EmailAddress !== null ? output.EmailAddress : undefined,
+    EmailAddress: __expectString(output.EmailAddress),
     LastUpdatedTimestamp:
       output.LastUpdatedTimestamp !== undefined && output.LastUpdatedTimestamp !== null
         ? new Date(Math.round(output.LastUpdatedTimestamp * 1000))
@@ -9948,15 +9940,13 @@ const deserializeAws_restJson1Contact = (output: any, context: __SerdeContext): 
       output.TopicPreferences !== undefined && output.TopicPreferences !== null
         ? deserializeAws_restJson1TopicPreferenceList(output.TopicPreferences, context)
         : undefined,
-    UnsubscribeAll:
-      output.UnsubscribeAll !== undefined && output.UnsubscribeAll !== null ? output.UnsubscribeAll : undefined,
+    UnsubscribeAll: __expectBoolean(output.UnsubscribeAll),
   } as any;
 };
 
 const deserializeAws_restJson1ContactList = (output: any, context: __SerdeContext): ContactList => {
   return {
-    ContactListName:
-      output.ContactListName !== undefined && output.ContactListName !== null ? output.ContactListName : undefined,
+    ContactListName: __expectString(output.ContactListName),
     LastUpdatedTimestamp:
       output.LastUpdatedTimestamp !== undefined && output.LastUpdatedTimestamp !== null
         ? new Date(Math.round(output.LastUpdatedTimestamp * 1000))
@@ -9969,12 +9959,8 @@ const deserializeAws_restJson1ContactListDestination = (
   context: __SerdeContext
 ): ContactListDestination => {
   return {
-    ContactListImportAction:
-      output.ContactListImportAction !== undefined && output.ContactListImportAction !== null
-        ? output.ContactListImportAction
-        : undefined,
-    ContactListName:
-      output.ContactListName !== undefined && output.ContactListName !== null ? output.ContactListName : undefined,
+    ContactListImportAction: __expectString(output.ContactListImportAction),
+    ContactListName: __expectString(output.ContactListName),
   } as any;
 };
 
@@ -9983,19 +9969,11 @@ const deserializeAws_restJson1CustomVerificationEmailTemplateMetadata = (
   context: __SerdeContext
 ): CustomVerificationEmailTemplateMetadata => {
   return {
-    FailureRedirectionURL:
-      output.FailureRedirectionURL !== undefined && output.FailureRedirectionURL !== null
-        ? output.FailureRedirectionURL
-        : undefined,
-    FromEmailAddress:
-      output.FromEmailAddress !== undefined && output.FromEmailAddress !== null ? output.FromEmailAddress : undefined,
-    SuccessRedirectionURL:
-      output.SuccessRedirectionURL !== undefined && output.SuccessRedirectionURL !== null
-        ? output.SuccessRedirectionURL
-        : undefined,
-    TemplateName: output.TemplateName !== undefined && output.TemplateName !== null ? output.TemplateName : undefined,
-    TemplateSubject:
-      output.TemplateSubject !== undefined && output.TemplateSubject !== null ? output.TemplateSubject : undefined,
+    FailureRedirectionURL: __expectString(output.FailureRedirectionURL),
+    FromEmailAddress: __expectString(output.FromEmailAddress),
+    SuccessRedirectionURL: __expectString(output.SuccessRedirectionURL),
+    TemplateName: __expectString(output.TemplateName),
+    TemplateSubject: __expectString(output.TemplateSubject),
   } as any;
 };
 
@@ -10043,11 +10021,10 @@ const deserializeAws_restJson1DailyVolumes = (output: any, context: __SerdeConte
 
 const deserializeAws_restJson1DedicatedIp = (output: any, context: __SerdeContext): DedicatedIp => {
   return {
-    Ip: output.Ip !== undefined && output.Ip !== null ? output.Ip : undefined,
-    PoolName: output.PoolName !== undefined && output.PoolName !== null ? output.PoolName : undefined,
-    WarmupPercentage:
-      output.WarmupPercentage !== undefined && output.WarmupPercentage !== null ? output.WarmupPercentage : undefined,
-    WarmupStatus: output.WarmupStatus !== undefined && output.WarmupStatus !== null ? output.WarmupStatus : undefined,
+    Ip: __expectString(output.Ip),
+    PoolName: __expectString(output.PoolName),
+    WarmupPercentage: __expectNumber(output.WarmupPercentage),
+    WarmupStatus: __expectString(output.WarmupStatus),
   } as any;
 };
 
@@ -10071,15 +10048,11 @@ const deserializeAws_restJson1DeliverabilityTestReport = (
       output.CreateDate !== undefined && output.CreateDate !== null
         ? new Date(Math.round(output.CreateDate * 1000))
         : undefined,
-    DeliverabilityTestStatus:
-      output.DeliverabilityTestStatus !== undefined && output.DeliverabilityTestStatus !== null
-        ? output.DeliverabilityTestStatus
-        : undefined,
-    FromEmailAddress:
-      output.FromEmailAddress !== undefined && output.FromEmailAddress !== null ? output.FromEmailAddress : undefined,
-    ReportId: output.ReportId !== undefined && output.ReportId !== null ? output.ReportId : undefined,
-    ReportName: output.ReportName !== undefined && output.ReportName !== null ? output.ReportName : undefined,
-    Subject: output.Subject !== undefined && output.Subject !== null ? output.Subject : undefined,
+    DeliverabilityTestStatus: __expectString(output.DeliverabilityTestStatus),
+    FromEmailAddress: __expectString(output.FromEmailAddress),
+    ReportId: __expectString(output.ReportId),
+    ReportName: __expectString(output.ReportName),
+    Subject: __expectString(output.Subject),
   } as any;
 };
 
@@ -10099,21 +10072,16 @@ const deserializeAws_restJson1DeliverabilityTestReports = (
 
 const deserializeAws_restJson1DeliveryOptions = (output: any, context: __SerdeContext): DeliveryOptions => {
   return {
-    SendingPoolName:
-      output.SendingPoolName !== undefined && output.SendingPoolName !== null ? output.SendingPoolName : undefined,
-    TlsPolicy: output.TlsPolicy !== undefined && output.TlsPolicy !== null ? output.TlsPolicy : undefined,
+    SendingPoolName: __expectString(output.SendingPoolName),
+    TlsPolicy: __expectString(output.TlsPolicy),
   } as any;
 };
 
 const deserializeAws_restJson1DkimAttributes = (output: any, context: __SerdeContext): DkimAttributes => {
   return {
-    SigningAttributesOrigin:
-      output.SigningAttributesOrigin !== undefined && output.SigningAttributesOrigin !== null
-        ? output.SigningAttributesOrigin
-        : undefined,
-    SigningEnabled:
-      output.SigningEnabled !== undefined && output.SigningEnabled !== null ? output.SigningEnabled : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    SigningAttributesOrigin: __expectString(output.SigningAttributesOrigin),
+    SigningEnabled: __expectBoolean(output.SigningEnabled),
+    Status: __expectString(output.Status),
     Tokens:
       output.Tokens !== undefined && output.Tokens !== null
         ? deserializeAws_restJson1DnsTokenList(output.Tokens, context)
@@ -10128,7 +10096,7 @@ const deserializeAws_restJson1DnsTokenList = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -10137,8 +10105,8 @@ const deserializeAws_restJson1DomainDeliverabilityCampaign = (
   context: __SerdeContext
 ): DomainDeliverabilityCampaign => {
   return {
-    CampaignId: output.CampaignId !== undefined && output.CampaignId !== null ? output.CampaignId : undefined,
-    DeleteRate: output.DeleteRate !== undefined && output.DeleteRate !== null ? output.DeleteRate : undefined,
+    CampaignId: __expectString(output.CampaignId),
+    DeleteRate: __expectNumber(output.DeleteRate),
     Esps:
       output.Esps !== undefined && output.Esps !== null
         ? deserializeAws_restJson1Esps(output.Esps, context)
@@ -10147,24 +10115,22 @@ const deserializeAws_restJson1DomainDeliverabilityCampaign = (
       output.FirstSeenDateTime !== undefined && output.FirstSeenDateTime !== null
         ? new Date(Math.round(output.FirstSeenDateTime * 1000))
         : undefined,
-    FromAddress: output.FromAddress !== undefined && output.FromAddress !== null ? output.FromAddress : undefined,
-    ImageUrl: output.ImageUrl !== undefined && output.ImageUrl !== null ? output.ImageUrl : undefined,
-    InboxCount: output.InboxCount !== undefined && output.InboxCount !== null ? output.InboxCount : undefined,
+    FromAddress: __expectString(output.FromAddress),
+    ImageUrl: __expectString(output.ImageUrl),
+    InboxCount: __expectNumber(output.InboxCount),
     LastSeenDateTime:
       output.LastSeenDateTime !== undefined && output.LastSeenDateTime !== null
         ? new Date(Math.round(output.LastSeenDateTime * 1000))
         : undefined,
-    ProjectedVolume:
-      output.ProjectedVolume !== undefined && output.ProjectedVolume !== null ? output.ProjectedVolume : undefined,
-    ReadDeleteRate:
-      output.ReadDeleteRate !== undefined && output.ReadDeleteRate !== null ? output.ReadDeleteRate : undefined,
-    ReadRate: output.ReadRate !== undefined && output.ReadRate !== null ? output.ReadRate : undefined,
+    ProjectedVolume: __expectNumber(output.ProjectedVolume),
+    ReadDeleteRate: __expectNumber(output.ReadDeleteRate),
+    ReadRate: __expectNumber(output.ReadRate),
     SendingIps:
       output.SendingIps !== undefined && output.SendingIps !== null
         ? deserializeAws_restJson1IpList(output.SendingIps, context)
         : undefined,
-    SpamCount: output.SpamCount !== undefined && output.SpamCount !== null ? output.SpamCount : undefined,
-    Subject: output.Subject !== undefined && output.Subject !== null ? output.Subject : undefined,
+    SpamCount: __expectNumber(output.SpamCount),
+    Subject: __expectString(output.Subject),
   } as any;
 };
 
@@ -10187,7 +10153,7 @@ const deserializeAws_restJson1DomainDeliverabilityTrackingOption = (
   context: __SerdeContext
 ): DomainDeliverabilityTrackingOption => {
   return {
-    Domain: output.Domain !== undefined && output.Domain !== null ? output.Domain : undefined,
+    Domain: __expectString(output.Domain),
     InboxPlacementTrackingOption:
       output.InboxPlacementTrackingOption !== undefined && output.InboxPlacementTrackingOption !== null
         ? deserializeAws_restJson1InboxPlacementTrackingOption(output.InboxPlacementTrackingOption, context)
@@ -10215,14 +10181,11 @@ const deserializeAws_restJson1DomainDeliverabilityTrackingOptions = (
 
 const deserializeAws_restJson1DomainIspPlacement = (output: any, context: __SerdeContext): DomainIspPlacement => {
   return {
-    InboxPercentage:
-      output.InboxPercentage !== undefined && output.InboxPercentage !== null ? output.InboxPercentage : undefined,
-    InboxRawCount:
-      output.InboxRawCount !== undefined && output.InboxRawCount !== null ? output.InboxRawCount : undefined,
-    IspName: output.IspName !== undefined && output.IspName !== null ? output.IspName : undefined,
-    SpamPercentage:
-      output.SpamPercentage !== undefined && output.SpamPercentage !== null ? output.SpamPercentage : undefined,
-    SpamRawCount: output.SpamRawCount !== undefined && output.SpamRawCount !== null ? output.SpamRawCount : undefined,
+    InboxPercentage: __expectNumber(output.InboxPercentage),
+    InboxRawCount: __expectNumber(output.InboxRawCount),
+    IspName: __expectString(output.IspName),
+    SpamPercentage: __expectNumber(output.SpamPercentage),
+    SpamRawCount: __expectNumber(output.SpamRawCount),
   } as any;
 };
 
@@ -10239,9 +10202,9 @@ const deserializeAws_restJson1DomainIspPlacements = (output: any, context: __Ser
 
 const deserializeAws_restJson1EmailTemplateContent = (output: any, context: __SerdeContext): EmailTemplateContent => {
   return {
-    Html: output.Html !== undefined && output.Html !== null ? output.Html : undefined,
-    Subject: output.Subject !== undefined && output.Subject !== null ? output.Subject : undefined,
-    Text: output.Text !== undefined && output.Text !== null ? output.Text : undefined,
+    Html: __expectString(output.Html),
+    Subject: __expectString(output.Subject),
+    Text: __expectString(output.Text),
   } as any;
 };
 
@@ -10251,7 +10214,7 @@ const deserializeAws_restJson1EmailTemplateMetadata = (output: any, context: __S
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
         ? new Date(Math.round(output.CreatedTimestamp * 1000))
         : undefined,
-    TemplateName: output.TemplateName !== undefined && output.TemplateName !== null ? output.TemplateName : undefined,
+    TemplateName: __expectString(output.TemplateName),
   } as any;
 };
 
@@ -10276,7 +10239,7 @@ const deserializeAws_restJson1Esps = (output: any, context: __SerdeContext): str
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -10286,7 +10249,7 @@ const deserializeAws_restJson1EventDestination = (output: any, context: __SerdeC
       output.CloudWatchDestination !== undefined && output.CloudWatchDestination !== null
         ? deserializeAws_restJson1CloudWatchDestination(output.CloudWatchDestination, context)
         : undefined,
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
+    Enabled: __expectBoolean(output.Enabled),
     KinesisFirehoseDestination:
       output.KinesisFirehoseDestination !== undefined && output.KinesisFirehoseDestination !== null
         ? deserializeAws_restJson1KinesisFirehoseDestination(output.KinesisFirehoseDestination, context)
@@ -10295,7 +10258,7 @@ const deserializeAws_restJson1EventDestination = (output: any, context: __SerdeC
       output.MatchingEventTypes !== undefined && output.MatchingEventTypes !== null
         ? deserializeAws_restJson1EventTypes(output.MatchingEventTypes, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     PinpointDestination:
       output.PinpointDestination !== undefined && output.PinpointDestination !== null
         ? deserializeAws_restJson1PinpointDestination(output.PinpointDestination, context)
@@ -10325,26 +10288,22 @@ const deserializeAws_restJson1EventTypes = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1FailureInfo = (output: any, context: __SerdeContext): FailureInfo => {
   return {
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    FailedRecordsS3Url:
-      output.FailedRecordsS3Url !== undefined && output.FailedRecordsS3Url !== null
-        ? output.FailedRecordsS3Url
-        : undefined,
+    ErrorMessage: __expectString(output.ErrorMessage),
+    FailedRecordsS3Url: __expectString(output.FailedRecordsS3Url),
   } as any;
 };
 
 const deserializeAws_restJson1IdentityInfo = (output: any, context: __SerdeContext): IdentityInfo => {
   return {
-    IdentityName: output.IdentityName !== undefined && output.IdentityName !== null ? output.IdentityName : undefined,
-    IdentityType: output.IdentityType !== undefined && output.IdentityType !== null ? output.IdentityType : undefined,
-    SendingEnabled:
-      output.SendingEnabled !== undefined && output.SendingEnabled !== null ? output.SendingEnabled : undefined,
+    IdentityName: __expectString(output.IdentityName),
+    IdentityType: __expectString(output.IdentityType),
+    SendingEnabled: __expectBoolean(output.SendingEnabled),
   } as any;
 };
 
@@ -10361,8 +10320,8 @@ const deserializeAws_restJson1IdentityInfoList = (output: any, context: __SerdeC
 
 const deserializeAws_restJson1ImportDataSource = (output: any, context: __SerdeContext): ImportDataSource => {
   return {
-    DataFormat: output.DataFormat !== undefined && output.DataFormat !== null ? output.DataFormat : undefined,
-    S3Url: output.S3Url !== undefined && output.S3Url !== null ? output.S3Url : undefined,
+    DataFormat: __expectString(output.DataFormat),
+    S3Url: __expectString(output.S3Url),
   } as any;
 };
 
@@ -10389,8 +10348,8 @@ const deserializeAws_restJson1ImportJobSummary = (output: any, context: __SerdeC
       output.ImportDestination !== undefined && output.ImportDestination !== null
         ? deserializeAws_restJson1ImportDestination(output.ImportDestination, context)
         : undefined,
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
-    JobStatus: output.JobStatus !== undefined && output.JobStatus !== null ? output.JobStatus : undefined,
+    JobId: __expectString(output.JobId),
+    JobStatus: __expectString(output.JobStatus),
   } as any;
 };
 
@@ -10410,7 +10369,7 @@ const deserializeAws_restJson1InboxPlacementTrackingOption = (
   context: __SerdeContext
 ): InboxPlacementTrackingOption => {
   return {
-    Global: output.Global !== undefined && output.Global !== null ? output.Global : undefined,
+    Global: __expectBoolean(output.Global),
     TrackedIsps:
       output.TrackedIsps !== undefined && output.TrackedIsps !== null
         ? deserializeAws_restJson1IspNameList(output.TrackedIsps, context)
@@ -10425,7 +10384,7 @@ const deserializeAws_restJson1IpList = (output: any, context: __SerdeContext): s
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -10436,13 +10395,13 @@ const deserializeAws_restJson1IspNameList = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1IspPlacement = (output: any, context: __SerdeContext): IspPlacement => {
   return {
-    IspName: output.IspName !== undefined && output.IspName !== null ? output.IspName : undefined,
+    IspName: __expectString(output.IspName),
     PlacementStatistics:
       output.PlacementStatistics !== undefined && output.PlacementStatistics !== null
         ? deserializeAws_restJson1PlacementStatistics(output.PlacementStatistics, context)
@@ -10466,11 +10425,8 @@ const deserializeAws_restJson1KinesisFirehoseDestination = (
   context: __SerdeContext
 ): KinesisFirehoseDestination => {
   return {
-    DeliveryStreamArn:
-      output.DeliveryStreamArn !== undefined && output.DeliveryStreamArn !== null
-        ? output.DeliveryStreamArn
-        : undefined,
-    IamRoleArn: output.IamRoleArn !== undefined && output.IamRoleArn !== null ? output.IamRoleArn : undefined,
+    DeliveryStreamArn: __expectString(output.DeliveryStreamArn),
+    IamRoleArn: __expectString(output.IamRoleArn),
   } as any;
 };
 
@@ -10503,22 +10459,15 @@ const deserializeAws_restJson1ListOfDedicatedIpPools = (output: any, context: __
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1MailFromAttributes = (output: any, context: __SerdeContext): MailFromAttributes => {
   return {
-    BehaviorOnMxFailure:
-      output.BehaviorOnMxFailure !== undefined && output.BehaviorOnMxFailure !== null
-        ? output.BehaviorOnMxFailure
-        : undefined,
-    MailFromDomain:
-      output.MailFromDomain !== undefined && output.MailFromDomain !== null ? output.MailFromDomain : undefined,
-    MailFromDomainStatus:
-      output.MailFromDomainStatus !== undefined && output.MailFromDomainStatus !== null
-        ? output.MailFromDomainStatus
-        : undefined,
+    BehaviorOnMxFailure: __expectString(output.BehaviorOnMxFailure),
+    MailFromDomain: __expectString(output.MailFromDomain),
+    MailFromDomainStatus: __expectString(output.MailFromDomainStatus),
   } as any;
 };
 
@@ -10528,8 +10477,7 @@ const deserializeAws_restJson1OverallVolume = (output: any, context: __SerdeCont
       output.DomainIspPlacements !== undefined && output.DomainIspPlacements !== null
         ? deserializeAws_restJson1DomainIspPlacements(output.DomainIspPlacements, context)
         : undefined,
-    ReadRatePercent:
-      output.ReadRatePercent !== undefined && output.ReadRatePercent !== null ? output.ReadRatePercent : undefined,
+    ReadRatePercent: __expectNumber(output.ReadRatePercent),
     VolumeStatistics:
       output.VolumeStatistics !== undefined && output.VolumeStatistics !== null
         ? deserializeAws_restJson1VolumeStatistics(output.VolumeStatistics, context)
@@ -10539,25 +10487,17 @@ const deserializeAws_restJson1OverallVolume = (output: any, context: __SerdeCont
 
 const deserializeAws_restJson1PinpointDestination = (output: any, context: __SerdeContext): PinpointDestination => {
   return {
-    ApplicationArn:
-      output.ApplicationArn !== undefined && output.ApplicationArn !== null ? output.ApplicationArn : undefined,
+    ApplicationArn: __expectString(output.ApplicationArn),
   } as any;
 };
 
 const deserializeAws_restJson1PlacementStatistics = (output: any, context: __SerdeContext): PlacementStatistics => {
   return {
-    DkimPercentage:
-      output.DkimPercentage !== undefined && output.DkimPercentage !== null ? output.DkimPercentage : undefined,
-    InboxPercentage:
-      output.InboxPercentage !== undefined && output.InboxPercentage !== null ? output.InboxPercentage : undefined,
-    MissingPercentage:
-      output.MissingPercentage !== undefined && output.MissingPercentage !== null
-        ? output.MissingPercentage
-        : undefined,
-    SpamPercentage:
-      output.SpamPercentage !== undefined && output.SpamPercentage !== null ? output.SpamPercentage : undefined,
-    SpfPercentage:
-      output.SpfPercentage !== undefined && output.SpfPercentage !== null ? output.SpfPercentage : undefined,
+    DkimPercentage: __expectNumber(output.DkimPercentage),
+    InboxPercentage: __expectNumber(output.InboxPercentage),
+    MissingPercentage: __expectNumber(output.MissingPercentage),
+    SpamPercentage: __expectNumber(output.SpamPercentage),
+    SpfPercentage: __expectNumber(output.SpfPercentage),
   } as any;
 };
 
@@ -10568,7 +10508,7 @@ const deserializeAws_restJson1PolicyMap = (output: any, context: __SerdeContext)
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -10579,40 +10519,34 @@ const deserializeAws_restJson1ReputationOptions = (output: any, context: __Serde
       output.LastFreshStart !== undefined && output.LastFreshStart !== null
         ? new Date(Math.round(output.LastFreshStart * 1000))
         : undefined,
-    ReputationMetricsEnabled:
-      output.ReputationMetricsEnabled !== undefined && output.ReputationMetricsEnabled !== null
-        ? output.ReputationMetricsEnabled
-        : undefined,
+    ReputationMetricsEnabled: __expectBoolean(output.ReputationMetricsEnabled),
   } as any;
 };
 
 const deserializeAws_restJson1ReviewDetails = (output: any, context: __SerdeContext): ReviewDetails => {
   return {
-    CaseId: output.CaseId !== undefined && output.CaseId !== null ? output.CaseId : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    CaseId: __expectString(output.CaseId),
+    Status: __expectString(output.Status),
   } as any;
 };
 
 const deserializeAws_restJson1SendingOptions = (output: any, context: __SerdeContext): SendingOptions => {
   return {
-    SendingEnabled:
-      output.SendingEnabled !== undefined && output.SendingEnabled !== null ? output.SendingEnabled : undefined,
+    SendingEnabled: __expectBoolean(output.SendingEnabled),
   } as any;
 };
 
 const deserializeAws_restJson1SendQuota = (output: any, context: __SerdeContext): SendQuota => {
   return {
-    Max24HourSend:
-      output.Max24HourSend !== undefined && output.Max24HourSend !== null ? output.Max24HourSend : undefined,
-    MaxSendRate: output.MaxSendRate !== undefined && output.MaxSendRate !== null ? output.MaxSendRate : undefined,
-    SentLast24Hours:
-      output.SentLast24Hours !== undefined && output.SentLast24Hours !== null ? output.SentLast24Hours : undefined,
+    Max24HourSend: __expectNumber(output.Max24HourSend),
+    MaxSendRate: __expectNumber(output.MaxSendRate),
+    SentLast24Hours: __expectNumber(output.SentLast24Hours),
   } as any;
 };
 
 const deserializeAws_restJson1SnsDestination = (output: any, context: __SerdeContext): SnsDestination => {
   return {
-    TopicArn: output.TopicArn !== undefined && output.TopicArn !== null ? output.TopicArn : undefined,
+    TopicArn: __expectString(output.TopicArn),
   } as any;
 };
 
@@ -10622,12 +10556,12 @@ const deserializeAws_restJson1SuppressedDestination = (output: any, context: __S
       output.Attributes !== undefined && output.Attributes !== null
         ? deserializeAws_restJson1SuppressedDestinationAttributes(output.Attributes, context)
         : undefined,
-    EmailAddress: output.EmailAddress !== undefined && output.EmailAddress !== null ? output.EmailAddress : undefined,
+    EmailAddress: __expectString(output.EmailAddress),
     LastUpdateTime:
       output.LastUpdateTime !== undefined && output.LastUpdateTime !== null
         ? new Date(Math.round(output.LastUpdateTime * 1000))
         : undefined,
-    Reason: output.Reason !== undefined && output.Reason !== null ? output.Reason : undefined,
+    Reason: __expectString(output.Reason),
   } as any;
 };
 
@@ -10636,8 +10570,8 @@ const deserializeAws_restJson1SuppressedDestinationAttributes = (
   context: __SerdeContext
 ): SuppressedDestinationAttributes => {
   return {
-    FeedbackId: output.FeedbackId !== undefined && output.FeedbackId !== null ? output.FeedbackId : undefined,
-    MessageId: output.MessageId !== undefined && output.MessageId !== null ? output.MessageId : undefined,
+    FeedbackId: __expectString(output.FeedbackId),
+    MessageId: __expectString(output.MessageId),
   } as any;
 };
 
@@ -10660,12 +10594,12 @@ const deserializeAws_restJson1SuppressedDestinationSummary = (
   context: __SerdeContext
 ): SuppressedDestinationSummary => {
   return {
-    EmailAddress: output.EmailAddress !== undefined && output.EmailAddress !== null ? output.EmailAddress : undefined,
+    EmailAddress: __expectString(output.EmailAddress),
     LastUpdateTime:
       output.LastUpdateTime !== undefined && output.LastUpdateTime !== null
         ? new Date(Math.round(output.LastUpdateTime * 1000))
         : undefined,
-    Reason: output.Reason !== undefined && output.Reason !== null ? output.Reason : undefined,
+    Reason: __expectString(output.Reason),
   } as any;
 };
 
@@ -10683,10 +10617,7 @@ const deserializeAws_restJson1SuppressionListDestination = (
   context: __SerdeContext
 ): SuppressionListDestination => {
   return {
-    SuppressionListImportAction:
-      output.SuppressionListImportAction !== undefined && output.SuppressionListImportAction !== null
-        ? output.SuppressionListImportAction
-        : undefined,
+    SuppressionListImportAction: __expectString(output.SuppressionListImportAction),
   } as any;
 };
 
@@ -10700,7 +10631,7 @@ const deserializeAws_restJson1SuppressionListReasons = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -10715,8 +10646,8 @@ const deserializeAws_restJson1SuppressionOptions = (output: any, context: __Serd
 
 const deserializeAws_restJson1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -10733,23 +10664,17 @@ const deserializeAws_restJson1TagList = (output: any, context: __SerdeContext): 
 
 const deserializeAws_restJson1Topic = (output: any, context: __SerdeContext): Topic => {
   return {
-    DefaultSubscriptionStatus:
-      output.DefaultSubscriptionStatus !== undefined && output.DefaultSubscriptionStatus !== null
-        ? output.DefaultSubscriptionStatus
-        : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    DisplayName: output.DisplayName !== undefined && output.DisplayName !== null ? output.DisplayName : undefined,
-    TopicName: output.TopicName !== undefined && output.TopicName !== null ? output.TopicName : undefined,
+    DefaultSubscriptionStatus: __expectString(output.DefaultSubscriptionStatus),
+    Description: __expectString(output.Description),
+    DisplayName: __expectString(output.DisplayName),
+    TopicName: __expectString(output.TopicName),
   } as any;
 };
 
 const deserializeAws_restJson1TopicPreference = (output: any, context: __SerdeContext): TopicPreference => {
   return {
-    SubscriptionStatus:
-      output.SubscriptionStatus !== undefined && output.SubscriptionStatus !== null
-        ? output.SubscriptionStatus
-        : undefined,
-    TopicName: output.TopicName !== undefined && output.TopicName !== null ? output.TopicName : undefined,
+    SubscriptionStatus: __expectString(output.SubscriptionStatus),
+    TopicName: __expectString(output.TopicName),
   } as any;
 };
 
@@ -10777,22 +10702,16 @@ const deserializeAws_restJson1Topics = (output: any, context: __SerdeContext): T
 
 const deserializeAws_restJson1TrackingOptions = (output: any, context: __SerdeContext): TrackingOptions => {
   return {
-    CustomRedirectDomain:
-      output.CustomRedirectDomain !== undefined && output.CustomRedirectDomain !== null
-        ? output.CustomRedirectDomain
-        : undefined,
+    CustomRedirectDomain: __expectString(output.CustomRedirectDomain),
   } as any;
 };
 
 const deserializeAws_restJson1VolumeStatistics = (output: any, context: __SerdeContext): VolumeStatistics => {
   return {
-    InboxRawCount:
-      output.InboxRawCount !== undefined && output.InboxRawCount !== null ? output.InboxRawCount : undefined,
-    ProjectedInbox:
-      output.ProjectedInbox !== undefined && output.ProjectedInbox !== null ? output.ProjectedInbox : undefined,
-    ProjectedSpam:
-      output.ProjectedSpam !== undefined && output.ProjectedSpam !== null ? output.ProjectedSpam : undefined,
-    SpamRawCount: output.SpamRawCount !== undefined && output.SpamRawCount !== null ? output.SpamRawCount : undefined,
+    InboxRawCount: __expectNumber(output.InboxRawCount),
+    ProjectedInbox: __expectNumber(output.ProjectedInbox),
+    ProjectedSpam: __expectNumber(output.ProjectedSpam),
+    SpamRawCount: __expectNumber(output.SpamRawCount),
   } as any;
 };
 

--- a/clients/client-sfn/protocols/Aws_json1_0.ts
+++ b/clients/client-sfn/protocols/Aws_json1_0.ts
@@ -151,7 +151,12 @@ import {
   HttpResponse as __HttpResponse,
   isValidHostname as __isValidHostname,
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -2755,7 +2760,7 @@ const serializeAws_json1_0UpdateStateMachineInput = (input: UpdateStateMachineIn
 
 const deserializeAws_json1_0ActivityDoesNotExist = (output: any, context: __SerdeContext): ActivityDoesNotExist => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -2764,14 +2769,14 @@ const deserializeAws_json1_0ActivityFailedEventDetails = (
   context: __SerdeContext
 ): ActivityFailedEventDetails => {
   return {
-    cause: output.cause !== undefined && output.cause !== null ? output.cause : undefined,
-    error: output.error !== undefined && output.error !== null ? output.error : undefined,
+    cause: __expectString(output.cause),
+    error: __expectString(output.error),
   } as any;
 };
 
 const deserializeAws_json1_0ActivityLimitExceeded = (output: any, context: __SerdeContext): ActivityLimitExceeded => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -2788,12 +2793,12 @@ const deserializeAws_json1_0ActivityList = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_0ActivityListItem = (output: any, context: __SerdeContext): ActivityListItem => {
   return {
-    activityArn: output.activityArn !== undefined && output.activityArn !== null ? output.activityArn : undefined,
+    activityArn: __expectString(output.activityArn),
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
         ? new Date(Math.round(output.creationDate * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -2802,18 +2807,14 @@ const deserializeAws_json1_0ActivityScheduledEventDetails = (
   context: __SerdeContext
 ): ActivityScheduledEventDetails => {
   return {
-    heartbeatInSeconds:
-      output.heartbeatInSeconds !== undefined && output.heartbeatInSeconds !== null
-        ? output.heartbeatInSeconds
-        : undefined,
-    input: output.input !== undefined && output.input !== null ? output.input : undefined,
+    heartbeatInSeconds: __expectNumber(output.heartbeatInSeconds),
+    input: __expectString(output.input),
     inputDetails:
       output.inputDetails !== undefined && output.inputDetails !== null
         ? deserializeAws_json1_0HistoryEventExecutionDataDetails(output.inputDetails, context)
         : undefined,
-    resource: output.resource !== undefined && output.resource !== null ? output.resource : undefined,
-    timeoutInSeconds:
-      output.timeoutInSeconds !== undefined && output.timeoutInSeconds !== null ? output.timeoutInSeconds : undefined,
+    resource: __expectString(output.resource),
+    timeoutInSeconds: __expectNumber(output.timeoutInSeconds),
   } as any;
 };
 
@@ -2822,8 +2823,8 @@ const deserializeAws_json1_0ActivityScheduleFailedEventDetails = (
   context: __SerdeContext
 ): ActivityScheduleFailedEventDetails => {
   return {
-    cause: output.cause !== undefined && output.cause !== null ? output.cause : undefined,
-    error: output.error !== undefined && output.error !== null ? output.error : undefined,
+    cause: __expectString(output.cause),
+    error: __expectString(output.error),
   } as any;
 };
 
@@ -2832,7 +2833,7 @@ const deserializeAws_json1_0ActivityStartedEventDetails = (
   context: __SerdeContext
 ): ActivityStartedEventDetails => {
   return {
-    workerName: output.workerName !== undefined && output.workerName !== null ? output.workerName : undefined,
+    workerName: __expectString(output.workerName),
   } as any;
 };
 
@@ -2841,7 +2842,7 @@ const deserializeAws_json1_0ActivitySucceededEventDetails = (
   context: __SerdeContext
 ): ActivitySucceededEventDetails => {
   return {
-    output: output.output !== undefined && output.output !== null ? output.output : undefined,
+    output: __expectString(output.output),
     outputDetails:
       output.outputDetails !== undefined && output.outputDetails !== null
         ? deserializeAws_json1_0HistoryEventExecutionDataDetails(output.outputDetails, context)
@@ -2854,8 +2855,8 @@ const deserializeAws_json1_0ActivityTimedOutEventDetails = (
   context: __SerdeContext
 ): ActivityTimedOutEventDetails => {
   return {
-    cause: output.cause !== undefined && output.cause !== null ? output.cause : undefined,
-    error: output.error !== undefined && output.error !== null ? output.error : undefined,
+    cause: __expectString(output.cause),
+    error: __expectString(output.error),
   } as any;
 };
 
@@ -2864,20 +2865,14 @@ const deserializeAws_json1_0ActivityWorkerLimitExceeded = (
   context: __SerdeContext
 ): ActivityWorkerLimitExceeded => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_0BillingDetails = (output: any, context: __SerdeContext): BillingDetails => {
   return {
-    billedDurationInMilliseconds:
-      output.billedDurationInMilliseconds !== undefined && output.billedDurationInMilliseconds !== null
-        ? output.billedDurationInMilliseconds
-        : undefined,
-    billedMemoryUsedInMB:
-      output.billedMemoryUsedInMB !== undefined && output.billedMemoryUsedInMB !== null
-        ? output.billedMemoryUsedInMB
-        : undefined,
+    billedDurationInMilliseconds: __expectNumber(output.billedDurationInMilliseconds),
+    billedMemoryUsedInMB: __expectNumber(output.billedMemoryUsedInMB),
   } as any;
 };
 
@@ -2886,19 +2881,19 @@ const deserializeAws_json1_0CloudWatchEventsExecutionDataDetails = (
   context: __SerdeContext
 ): CloudWatchEventsExecutionDataDetails => {
   return {
-    included: output.included !== undefined && output.included !== null ? output.included : undefined,
+    included: __expectBoolean(output.included),
   } as any;
 };
 
 const deserializeAws_json1_0CloudWatchLogsLogGroup = (output: any, context: __SerdeContext): CloudWatchLogsLogGroup => {
   return {
-    logGroupArn: output.logGroupArn !== undefined && output.logGroupArn !== null ? output.logGroupArn : undefined,
+    logGroupArn: __expectString(output.logGroupArn),
   } as any;
 };
 
 const deserializeAws_json1_0CreateActivityOutput = (output: any, context: __SerdeContext): CreateActivityOutput => {
   return {
-    activityArn: output.activityArn !== undefined && output.activityArn !== null ? output.activityArn : undefined,
+    activityArn: __expectString(output.activityArn),
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
         ? new Date(Math.round(output.creationDate * 1000))
@@ -2915,8 +2910,7 @@ const deserializeAws_json1_0CreateStateMachineOutput = (
       output.creationDate !== undefined && output.creationDate !== null
         ? new Date(Math.round(output.creationDate * 1000))
         : undefined,
-    stateMachineArn:
-      output.stateMachineArn !== undefined && output.stateMachineArn !== null ? output.stateMachineArn : undefined,
+    stateMachineArn: __expectString(output.stateMachineArn),
   } as any;
 };
 
@@ -2933,12 +2927,12 @@ const deserializeAws_json1_0DeleteStateMachineOutput = (
 
 const deserializeAws_json1_0DescribeActivityOutput = (output: any, context: __SerdeContext): DescribeActivityOutput => {
   return {
-    activityArn: output.activityArn !== undefined && output.activityArn !== null ? output.activityArn : undefined,
+    activityArn: __expectString(output.activityArn),
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
         ? new Date(Math.round(output.creationDate * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -2947,14 +2941,14 @@ const deserializeAws_json1_0DescribeExecutionOutput = (
   context: __SerdeContext
 ): DescribeExecutionOutput => {
   return {
-    executionArn: output.executionArn !== undefined && output.executionArn !== null ? output.executionArn : undefined,
-    input: output.input !== undefined && output.input !== null ? output.input : undefined,
+    executionArn: __expectString(output.executionArn),
+    input: __expectString(output.input),
     inputDetails:
       output.inputDetails !== undefined && output.inputDetails !== null
         ? deserializeAws_json1_0CloudWatchEventsExecutionDataDetails(output.inputDetails, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    output: output.output !== undefined && output.output !== null ? output.output : undefined,
+    name: __expectString(output.name),
+    output: __expectString(output.output),
     outputDetails:
       output.outputDetails !== undefined && output.outputDetails !== null
         ? deserializeAws_json1_0CloudWatchEventsExecutionDataDetails(output.outputDetails, context)
@@ -2963,14 +2957,13 @@ const deserializeAws_json1_0DescribeExecutionOutput = (
       output.startDate !== undefined && output.startDate !== null
         ? new Date(Math.round(output.startDate * 1000))
         : undefined,
-    stateMachineArn:
-      output.stateMachineArn !== undefined && output.stateMachineArn !== null ? output.stateMachineArn : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    stateMachineArn: __expectString(output.stateMachineArn),
+    status: __expectString(output.status),
     stopDate:
       output.stopDate !== undefined && output.stopDate !== null
         ? new Date(Math.round(output.stopDate * 1000))
         : undefined,
-    traceHeader: output.traceHeader !== undefined && output.traceHeader !== null ? output.traceHeader : undefined,
+    traceHeader: __expectString(output.traceHeader),
   } as any;
 };
 
@@ -2979,15 +2972,14 @@ const deserializeAws_json1_0DescribeStateMachineForExecutionOutput = (
   context: __SerdeContext
 ): DescribeStateMachineForExecutionOutput => {
   return {
-    definition: output.definition !== undefined && output.definition !== null ? output.definition : undefined,
+    definition: __expectString(output.definition),
     loggingConfiguration:
       output.loggingConfiguration !== undefined && output.loggingConfiguration !== null
         ? deserializeAws_json1_0LoggingConfiguration(output.loggingConfiguration, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
-    stateMachineArn:
-      output.stateMachineArn !== undefined && output.stateMachineArn !== null ? output.stateMachineArn : undefined,
+    name: __expectString(output.name),
+    roleArn: __expectString(output.roleArn),
+    stateMachineArn: __expectString(output.stateMachineArn),
     tracingConfiguration:
       output.tracingConfiguration !== undefined && output.tracingConfiguration !== null
         ? deserializeAws_json1_0TracingConfiguration(output.tracingConfiguration, context)
@@ -3008,21 +3000,20 @@ const deserializeAws_json1_0DescribeStateMachineOutput = (
       output.creationDate !== undefined && output.creationDate !== null
         ? new Date(Math.round(output.creationDate * 1000))
         : undefined,
-    definition: output.definition !== undefined && output.definition !== null ? output.definition : undefined,
+    definition: __expectString(output.definition),
     loggingConfiguration:
       output.loggingConfiguration !== undefined && output.loggingConfiguration !== null
         ? deserializeAws_json1_0LoggingConfiguration(output.loggingConfiguration, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
-    stateMachineArn:
-      output.stateMachineArn !== undefined && output.stateMachineArn !== null ? output.stateMachineArn : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    name: __expectString(output.name),
+    roleArn: __expectString(output.roleArn),
+    stateMachineArn: __expectString(output.stateMachineArn),
+    status: __expectString(output.status),
     tracingConfiguration:
       output.tracingConfiguration !== undefined && output.tracingConfiguration !== null
         ? deserializeAws_json1_0TracingConfiguration(output.tracingConfiguration, context)
         : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -3031,20 +3022,20 @@ const deserializeAws_json1_0ExecutionAbortedEventDetails = (
   context: __SerdeContext
 ): ExecutionAbortedEventDetails => {
   return {
-    cause: output.cause !== undefined && output.cause !== null ? output.cause : undefined,
-    error: output.error !== undefined && output.error !== null ? output.error : undefined,
+    cause: __expectString(output.cause),
+    error: __expectString(output.error),
   } as any;
 };
 
 const deserializeAws_json1_0ExecutionAlreadyExists = (output: any, context: __SerdeContext): ExecutionAlreadyExists => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_0ExecutionDoesNotExist = (output: any, context: __SerdeContext): ExecutionDoesNotExist => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3053,14 +3044,14 @@ const deserializeAws_json1_0ExecutionFailedEventDetails = (
   context: __SerdeContext
 ): ExecutionFailedEventDetails => {
   return {
-    cause: output.cause !== undefined && output.cause !== null ? output.cause : undefined,
-    error: output.error !== undefined && output.error !== null ? output.error : undefined,
+    cause: __expectString(output.cause),
+    error: __expectString(output.error),
   } as any;
 };
 
 const deserializeAws_json1_0ExecutionLimitExceeded = (output: any, context: __SerdeContext): ExecutionLimitExceeded => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3077,15 +3068,14 @@ const deserializeAws_json1_0ExecutionList = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_0ExecutionListItem = (output: any, context: __SerdeContext): ExecutionListItem => {
   return {
-    executionArn: output.executionArn !== undefined && output.executionArn !== null ? output.executionArn : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    executionArn: __expectString(output.executionArn),
+    name: __expectString(output.name),
     startDate:
       output.startDate !== undefined && output.startDate !== null
         ? new Date(Math.round(output.startDate * 1000))
         : undefined,
-    stateMachineArn:
-      output.stateMachineArn !== undefined && output.stateMachineArn !== null ? output.stateMachineArn : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    stateMachineArn: __expectString(output.stateMachineArn),
+    status: __expectString(output.status),
     stopDate:
       output.stopDate !== undefined && output.stopDate !== null
         ? new Date(Math.round(output.stopDate * 1000))
@@ -3098,12 +3088,12 @@ const deserializeAws_json1_0ExecutionStartedEventDetails = (
   context: __SerdeContext
 ): ExecutionStartedEventDetails => {
   return {
-    input: output.input !== undefined && output.input !== null ? output.input : undefined,
+    input: __expectString(output.input),
     inputDetails:
       output.inputDetails !== undefined && output.inputDetails !== null
         ? deserializeAws_json1_0HistoryEventExecutionDataDetails(output.inputDetails, context)
         : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
+    roleArn: __expectString(output.roleArn),
   } as any;
 };
 
@@ -3112,7 +3102,7 @@ const deserializeAws_json1_0ExecutionSucceededEventDetails = (
   context: __SerdeContext
 ): ExecutionSucceededEventDetails => {
   return {
-    output: output.output !== undefined && output.output !== null ? output.output : undefined,
+    output: __expectString(output.output),
     outputDetails:
       output.outputDetails !== undefined && output.outputDetails !== null
         ? deserializeAws_json1_0HistoryEventExecutionDataDetails(output.outputDetails, context)
@@ -3125,15 +3115,15 @@ const deserializeAws_json1_0ExecutionTimedOutEventDetails = (
   context: __SerdeContext
 ): ExecutionTimedOutEventDetails => {
   return {
-    cause: output.cause !== undefined && output.cause !== null ? output.cause : undefined,
-    error: output.error !== undefined && output.error !== null ? output.error : undefined,
+    cause: __expectString(output.cause),
+    error: __expectString(output.error),
   } as any;
 };
 
 const deserializeAws_json1_0GetActivityTaskOutput = (output: any, context: __SerdeContext): GetActivityTaskOutput => {
   return {
-    input: output.input !== undefined && output.input !== null ? output.input : undefined,
-    taskToken: output.taskToken !== undefined && output.taskToken !== null ? output.taskToken : undefined,
+    input: __expectString(output.input),
+    taskToken: __expectString(output.taskToken),
   } as any;
 };
 
@@ -3146,7 +3136,7 @@ const deserializeAws_json1_0GetExecutionHistoryOutput = (
       output.events !== undefined && output.events !== null
         ? deserializeAws_json1_0HistoryEventList(output.events, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -3196,7 +3186,7 @@ const deserializeAws_json1_0HistoryEvent = (output: any, context: __SerdeContext
       output.executionTimedOutEventDetails !== undefined && output.executionTimedOutEventDetails !== null
         ? deserializeAws_json1_0ExecutionTimedOutEventDetails(output.executionTimedOutEventDetails, context)
         : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    id: __expectNumber(output.id),
     lambdaFunctionFailedEventDetails:
       output.lambdaFunctionFailedEventDetails !== undefined && output.lambdaFunctionFailedEventDetails !== null
         ? deserializeAws_json1_0LambdaFunctionFailedEventDetails(output.lambdaFunctionFailedEventDetails, context)
@@ -3249,8 +3239,7 @@ const deserializeAws_json1_0HistoryEvent = (output: any, context: __SerdeContext
       output.mapStateStartedEventDetails !== undefined && output.mapStateStartedEventDetails !== null
         ? deserializeAws_json1_0MapStateStartedEventDetails(output.mapStateStartedEventDetails, context)
         : undefined,
-    previousEventId:
-      output.previousEventId !== undefined && output.previousEventId !== null ? output.previousEventId : undefined,
+    previousEventId: __expectNumber(output.previousEventId),
     stateEnteredEventDetails:
       output.stateEnteredEventDetails !== undefined && output.stateEnteredEventDetails !== null
         ? deserializeAws_json1_0StateEnteredEventDetails(output.stateEnteredEventDetails, context)
@@ -3295,7 +3284,7 @@ const deserializeAws_json1_0HistoryEvent = (output: any, context: __SerdeContext
       output.timestamp !== undefined && output.timestamp !== null
         ? new Date(Math.round(output.timestamp * 1000))
         : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -3304,7 +3293,7 @@ const deserializeAws_json1_0HistoryEventExecutionDataDetails = (
   context: __SerdeContext
 ): HistoryEventExecutionDataDetails => {
   return {
-    truncated: output.truncated !== undefined && output.truncated !== null ? output.truncated : undefined,
+    truncated: __expectBoolean(output.truncated),
   } as any;
 };
 
@@ -3321,19 +3310,19 @@ const deserializeAws_json1_0HistoryEventList = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_0InvalidArn = (output: any, context: __SerdeContext): InvalidArn => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_0InvalidDefinition = (output: any, context: __SerdeContext): InvalidDefinition => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_0InvalidExecutionInput = (output: any, context: __SerdeContext): InvalidExecutionInput => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3342,25 +3331,25 @@ const deserializeAws_json1_0InvalidLoggingConfiguration = (
   context: __SerdeContext
 ): InvalidLoggingConfiguration => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_0InvalidName = (output: any, context: __SerdeContext): InvalidName => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_0InvalidOutput = (output: any, context: __SerdeContext): InvalidOutput => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_0InvalidToken = (output: any, context: __SerdeContext): InvalidToken => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3369,7 +3358,7 @@ const deserializeAws_json1_0InvalidTracingConfiguration = (
   context: __SerdeContext
 ): InvalidTracingConfiguration => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3378,8 +3367,8 @@ const deserializeAws_json1_0LambdaFunctionFailedEventDetails = (
   context: __SerdeContext
 ): LambdaFunctionFailedEventDetails => {
   return {
-    cause: output.cause !== undefined && output.cause !== null ? output.cause : undefined,
-    error: output.error !== undefined && output.error !== null ? output.error : undefined,
+    cause: __expectString(output.cause),
+    error: __expectString(output.error),
   } as any;
 };
 
@@ -3388,14 +3377,13 @@ const deserializeAws_json1_0LambdaFunctionScheduledEventDetails = (
   context: __SerdeContext
 ): LambdaFunctionScheduledEventDetails => {
   return {
-    input: output.input !== undefined && output.input !== null ? output.input : undefined,
+    input: __expectString(output.input),
     inputDetails:
       output.inputDetails !== undefined && output.inputDetails !== null
         ? deserializeAws_json1_0HistoryEventExecutionDataDetails(output.inputDetails, context)
         : undefined,
-    resource: output.resource !== undefined && output.resource !== null ? output.resource : undefined,
-    timeoutInSeconds:
-      output.timeoutInSeconds !== undefined && output.timeoutInSeconds !== null ? output.timeoutInSeconds : undefined,
+    resource: __expectString(output.resource),
+    timeoutInSeconds: __expectNumber(output.timeoutInSeconds),
   } as any;
 };
 
@@ -3404,8 +3392,8 @@ const deserializeAws_json1_0LambdaFunctionScheduleFailedEventDetails = (
   context: __SerdeContext
 ): LambdaFunctionScheduleFailedEventDetails => {
   return {
-    cause: output.cause !== undefined && output.cause !== null ? output.cause : undefined,
-    error: output.error !== undefined && output.error !== null ? output.error : undefined,
+    cause: __expectString(output.cause),
+    error: __expectString(output.error),
   } as any;
 };
 
@@ -3414,8 +3402,8 @@ const deserializeAws_json1_0LambdaFunctionStartFailedEventDetails = (
   context: __SerdeContext
 ): LambdaFunctionStartFailedEventDetails => {
   return {
-    cause: output.cause !== undefined && output.cause !== null ? output.cause : undefined,
-    error: output.error !== undefined && output.error !== null ? output.error : undefined,
+    cause: __expectString(output.cause),
+    error: __expectString(output.error),
   } as any;
 };
 
@@ -3424,7 +3412,7 @@ const deserializeAws_json1_0LambdaFunctionSucceededEventDetails = (
   context: __SerdeContext
 ): LambdaFunctionSucceededEventDetails => {
   return {
-    output: output.output !== undefined && output.output !== null ? output.output : undefined,
+    output: __expectString(output.output),
     outputDetails:
       output.outputDetails !== undefined && output.outputDetails !== null
         ? deserializeAws_json1_0HistoryEventExecutionDataDetails(output.outputDetails, context)
@@ -3437,8 +3425,8 @@ const deserializeAws_json1_0LambdaFunctionTimedOutEventDetails = (
   context: __SerdeContext
 ): LambdaFunctionTimedOutEventDetails => {
   return {
-    cause: output.cause !== undefined && output.cause !== null ? output.cause : undefined,
-    error: output.error !== undefined && output.error !== null ? output.error : undefined,
+    cause: __expectString(output.cause),
+    error: __expectString(output.error),
   } as any;
 };
 
@@ -3448,7 +3436,7 @@ const deserializeAws_json1_0ListActivitiesOutput = (output: any, context: __Serd
       output.activities !== undefined && output.activities !== null
         ? deserializeAws_json1_0ActivityList(output.activities, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -3458,7 +3446,7 @@ const deserializeAws_json1_0ListExecutionsOutput = (output: any, context: __Serd
       output.executions !== undefined && output.executions !== null
         ? deserializeAws_json1_0ExecutionList(output.executions, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -3467,7 +3455,7 @@ const deserializeAws_json1_0ListStateMachinesOutput = (
   context: __SerdeContext
 ): ListStateMachinesOutput => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     stateMachines:
       output.stateMachines !== undefined && output.stateMachines !== null
         ? deserializeAws_json1_0StateMachineList(output.stateMachines, context)
@@ -3513,11 +3501,8 @@ const deserializeAws_json1_0LoggingConfiguration = (output: any, context: __Serd
       output.destinations !== undefined && output.destinations !== null
         ? deserializeAws_json1_0LogDestinationList(output.destinations, context)
         : undefined,
-    includeExecutionData:
-      output.includeExecutionData !== undefined && output.includeExecutionData !== null
-        ? output.includeExecutionData
-        : undefined,
-    level: output.level !== undefined && output.level !== null ? output.level : undefined,
+    includeExecutionData: __expectBoolean(output.includeExecutionData),
+    level: __expectString(output.level),
   } as any;
 };
 
@@ -3526,8 +3511,8 @@ const deserializeAws_json1_0MapIterationEventDetails = (
   context: __SerdeContext
 ): MapIterationEventDetails => {
   return {
-    index: output.index !== undefined && output.index !== null ? output.index : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    index: __expectNumber(output.index),
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -3536,7 +3521,7 @@ const deserializeAws_json1_0MapStateStartedEventDetails = (
   context: __SerdeContext
 ): MapStateStartedEventDetails => {
   return {
-    length: output.length !== undefined && output.length !== null ? output.length : undefined,
+    length: __expectNumber(output.length),
   } as any;
 };
 
@@ -3545,14 +3530,14 @@ const deserializeAws_json1_0MissingRequiredParameter = (
   context: __SerdeContext
 ): MissingRequiredParameter => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_0ResourceNotFound = (output: any, context: __SerdeContext): ResourceNotFound => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    resourceName: output.resourceName !== undefined && output.resourceName !== null ? output.resourceName : undefined,
+    message: __expectString(output.message),
+    resourceName: __expectString(output.resourceName),
   } as any;
 };
 
@@ -3573,7 +3558,7 @@ const deserializeAws_json1_0SendTaskSuccessOutput = (output: any, context: __Ser
 
 const deserializeAws_json1_0StartExecutionOutput = (output: any, context: __SerdeContext): StartExecutionOutput => {
   return {
-    executionArn: output.executionArn !== undefined && output.executionArn !== null ? output.executionArn : undefined,
+    executionArn: __expectString(output.executionArn),
     startDate:
       output.startDate !== undefined && output.startDate !== null
         ? new Date(Math.round(output.startDate * 1000))
@@ -3590,16 +3575,16 @@ const deserializeAws_json1_0StartSyncExecutionOutput = (
       output.billingDetails !== undefined && output.billingDetails !== null
         ? deserializeAws_json1_0BillingDetails(output.billingDetails, context)
         : undefined,
-    cause: output.cause !== undefined && output.cause !== null ? output.cause : undefined,
-    error: output.error !== undefined && output.error !== null ? output.error : undefined,
-    executionArn: output.executionArn !== undefined && output.executionArn !== null ? output.executionArn : undefined,
-    input: output.input !== undefined && output.input !== null ? output.input : undefined,
+    cause: __expectString(output.cause),
+    error: __expectString(output.error),
+    executionArn: __expectString(output.executionArn),
+    input: __expectString(output.input),
     inputDetails:
       output.inputDetails !== undefined && output.inputDetails !== null
         ? deserializeAws_json1_0CloudWatchEventsExecutionDataDetails(output.inputDetails, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    output: output.output !== undefined && output.output !== null ? output.output : undefined,
+    name: __expectString(output.name),
+    output: __expectString(output.output),
     outputDetails:
       output.outputDetails !== undefined && output.outputDetails !== null
         ? deserializeAws_json1_0CloudWatchEventsExecutionDataDetails(output.outputDetails, context)
@@ -3608,14 +3593,13 @@ const deserializeAws_json1_0StartSyncExecutionOutput = (
       output.startDate !== undefined && output.startDate !== null
         ? new Date(Math.round(output.startDate * 1000))
         : undefined,
-    stateMachineArn:
-      output.stateMachineArn !== undefined && output.stateMachineArn !== null ? output.stateMachineArn : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    stateMachineArn: __expectString(output.stateMachineArn),
+    status: __expectString(output.status),
     stopDate:
       output.stopDate !== undefined && output.stopDate !== null
         ? new Date(Math.round(output.stopDate * 1000))
         : undefined,
-    traceHeader: output.traceHeader !== undefined && output.traceHeader !== null ? output.traceHeader : undefined,
+    traceHeader: __expectString(output.traceHeader),
   } as any;
 };
 
@@ -3624,12 +3608,12 @@ const deserializeAws_json1_0StateEnteredEventDetails = (
   context: __SerdeContext
 ): StateEnteredEventDetails => {
   return {
-    input: output.input !== undefined && output.input !== null ? output.input : undefined,
+    input: __expectString(output.input),
     inputDetails:
       output.inputDetails !== undefined && output.inputDetails !== null
         ? deserializeAws_json1_0HistoryEventExecutionDataDetails(output.inputDetails, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -3638,8 +3622,8 @@ const deserializeAws_json1_0StateExitedEventDetails = (
   context: __SerdeContext
 ): StateExitedEventDetails => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    output: output.output !== undefined && output.output !== null ? output.output : undefined,
+    name: __expectString(output.name),
+    output: __expectString(output.output),
     outputDetails:
       output.outputDetails !== undefined && output.outputDetails !== null
         ? deserializeAws_json1_0HistoryEventExecutionDataDetails(output.outputDetails, context)
@@ -3652,13 +3636,13 @@ const deserializeAws_json1_0StateMachineAlreadyExists = (
   context: __SerdeContext
 ): StateMachineAlreadyExists => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_0StateMachineDeleting = (output: any, context: __SerdeContext): StateMachineDeleting => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3667,7 +3651,7 @@ const deserializeAws_json1_0StateMachineDoesNotExist = (
   context: __SerdeContext
 ): StateMachineDoesNotExist => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3676,7 +3660,7 @@ const deserializeAws_json1_0StateMachineLimitExceeded = (
   context: __SerdeContext
 ): StateMachineLimitExceeded => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3697,10 +3681,9 @@ const deserializeAws_json1_0StateMachineListItem = (output: any, context: __Serd
       output.creationDate !== undefined && output.creationDate !== null
         ? new Date(Math.round(output.creationDate * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    stateMachineArn:
-      output.stateMachineArn !== undefined && output.stateMachineArn !== null ? output.stateMachineArn : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    name: __expectString(output.name),
+    stateMachineArn: __expectString(output.stateMachineArn),
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -3709,7 +3692,7 @@ const deserializeAws_json1_0StateMachineTypeNotSupported = (
   context: __SerdeContext
 ): StateMachineTypeNotSupported => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3724,8 +3707,8 @@ const deserializeAws_json1_0StopExecutionOutput = (output: any, context: __Serde
 
 const deserializeAws_json1_0Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    key: __expectString(output.key),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -3746,16 +3729,16 @@ const deserializeAws_json1_0TagResourceOutput = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_0TaskDoesNotExist = (output: any, context: __SerdeContext): TaskDoesNotExist => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_0TaskFailedEventDetails = (output: any, context: __SerdeContext): TaskFailedEventDetails => {
   return {
-    cause: output.cause !== undefined && output.cause !== null ? output.cause : undefined,
-    error: output.error !== undefined && output.error !== null ? output.error : undefined,
-    resource: output.resource !== undefined && output.resource !== null ? output.resource : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
+    cause: __expectString(output.cause),
+    error: __expectString(output.error),
+    resource: __expectString(output.resource),
+    resourceType: __expectString(output.resourceType),
   } as any;
 };
 
@@ -3764,16 +3747,12 @@ const deserializeAws_json1_0TaskScheduledEventDetails = (
   context: __SerdeContext
 ): TaskScheduledEventDetails => {
   return {
-    heartbeatInSeconds:
-      output.heartbeatInSeconds !== undefined && output.heartbeatInSeconds !== null
-        ? output.heartbeatInSeconds
-        : undefined,
-    parameters: output.parameters !== undefined && output.parameters !== null ? output.parameters : undefined,
-    region: output.region !== undefined && output.region !== null ? output.region : undefined,
-    resource: output.resource !== undefined && output.resource !== null ? output.resource : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
-    timeoutInSeconds:
-      output.timeoutInSeconds !== undefined && output.timeoutInSeconds !== null ? output.timeoutInSeconds : undefined,
+    heartbeatInSeconds: __expectNumber(output.heartbeatInSeconds),
+    parameters: __expectString(output.parameters),
+    region: __expectString(output.region),
+    resource: __expectString(output.resource),
+    resourceType: __expectString(output.resourceType),
+    timeoutInSeconds: __expectNumber(output.timeoutInSeconds),
   } as any;
 };
 
@@ -3782,8 +3761,8 @@ const deserializeAws_json1_0TaskStartedEventDetails = (
   context: __SerdeContext
 ): TaskStartedEventDetails => {
   return {
-    resource: output.resource !== undefined && output.resource !== null ? output.resource : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
+    resource: __expectString(output.resource),
+    resourceType: __expectString(output.resourceType),
   } as any;
 };
 
@@ -3792,10 +3771,10 @@ const deserializeAws_json1_0TaskStartFailedEventDetails = (
   context: __SerdeContext
 ): TaskStartFailedEventDetails => {
   return {
-    cause: output.cause !== undefined && output.cause !== null ? output.cause : undefined,
-    error: output.error !== undefined && output.error !== null ? output.error : undefined,
-    resource: output.resource !== undefined && output.resource !== null ? output.resource : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
+    cause: __expectString(output.cause),
+    error: __expectString(output.error),
+    resource: __expectString(output.resource),
+    resourceType: __expectString(output.resourceType),
   } as any;
 };
 
@@ -3804,10 +3783,10 @@ const deserializeAws_json1_0TaskSubmitFailedEventDetails = (
   context: __SerdeContext
 ): TaskSubmitFailedEventDetails => {
   return {
-    cause: output.cause !== undefined && output.cause !== null ? output.cause : undefined,
-    error: output.error !== undefined && output.error !== null ? output.error : undefined,
-    resource: output.resource !== undefined && output.resource !== null ? output.resource : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
+    cause: __expectString(output.cause),
+    error: __expectString(output.error),
+    resource: __expectString(output.resource),
+    resourceType: __expectString(output.resourceType),
   } as any;
 };
 
@@ -3816,13 +3795,13 @@ const deserializeAws_json1_0TaskSubmittedEventDetails = (
   context: __SerdeContext
 ): TaskSubmittedEventDetails => {
   return {
-    output: output.output !== undefined && output.output !== null ? output.output : undefined,
+    output: __expectString(output.output),
     outputDetails:
       output.outputDetails !== undefined && output.outputDetails !== null
         ? deserializeAws_json1_0HistoryEventExecutionDataDetails(output.outputDetails, context)
         : undefined,
-    resource: output.resource !== undefined && output.resource !== null ? output.resource : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
+    resource: __expectString(output.resource),
+    resourceType: __expectString(output.resourceType),
   } as any;
 };
 
@@ -3831,19 +3810,19 @@ const deserializeAws_json1_0TaskSucceededEventDetails = (
   context: __SerdeContext
 ): TaskSucceededEventDetails => {
   return {
-    output: output.output !== undefined && output.output !== null ? output.output : undefined,
+    output: __expectString(output.output),
     outputDetails:
       output.outputDetails !== undefined && output.outputDetails !== null
         ? deserializeAws_json1_0HistoryEventExecutionDataDetails(output.outputDetails, context)
         : undefined,
-    resource: output.resource !== undefined && output.resource !== null ? output.resource : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
+    resource: __expectString(output.resource),
+    resourceType: __expectString(output.resourceType),
   } as any;
 };
 
 const deserializeAws_json1_0TaskTimedOut = (output: any, context: __SerdeContext): TaskTimedOut => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3852,23 +3831,23 @@ const deserializeAws_json1_0TaskTimedOutEventDetails = (
   context: __SerdeContext
 ): TaskTimedOutEventDetails => {
   return {
-    cause: output.cause !== undefined && output.cause !== null ? output.cause : undefined,
-    error: output.error !== undefined && output.error !== null ? output.error : undefined,
-    resource: output.resource !== undefined && output.resource !== null ? output.resource : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
+    cause: __expectString(output.cause),
+    error: __expectString(output.error),
+    resource: __expectString(output.resource),
+    resourceType: __expectString(output.resourceType),
   } as any;
 };
 
 const deserializeAws_json1_0TooManyTags = (output: any, context: __SerdeContext): TooManyTags => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    resourceName: output.resourceName !== undefined && output.resourceName !== null ? output.resourceName : undefined,
+    message: __expectString(output.message),
+    resourceName: __expectString(output.resourceName),
   } as any;
 };
 
 const deserializeAws_json1_0TracingConfiguration = (output: any, context: __SerdeContext): TracingConfiguration => {
   return {
-    enabled: output.enabled !== undefined && output.enabled !== null ? output.enabled : undefined,
+    enabled: __expectBoolean(output.enabled),
   } as any;
 };
 

--- a/clients/client-shield/protocols/Aws_json1_1.ts
+++ b/clients/client-shield/protocols/Aws_json1_1.ts
@@ -198,7 +198,11 @@ import {
   ValidationExceptionField,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -3720,7 +3724,7 @@ const serializeAws_json1_1UpdateSubscriptionRequest = (
 
 const deserializeAws_json1_1AccessDeniedException = (output: any, context: __SerdeContext): AccessDeniedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3729,7 +3733,7 @@ const deserializeAws_json1_1AccessDeniedForDependencyException = (
   context: __SerdeContext
 ): AccessDeniedForDependencyException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -3767,7 +3771,7 @@ const deserializeAws_json1_1AttackDetail = (output: any, context: __SerdeContext
       output.AttackCounters !== undefined && output.AttackCounters !== null
         ? deserializeAws_json1_1SummarizedCounterList(output.AttackCounters, context)
         : undefined,
-    AttackId: output.AttackId !== undefined && output.AttackId !== null ? output.AttackId : undefined,
+    AttackId: __expectString(output.AttackId),
     AttackProperties:
       output.AttackProperties !== undefined && output.AttackProperties !== null
         ? deserializeAws_json1_1AttackProperties(output.AttackProperties, context)
@@ -3778,7 +3782,7 @@ const deserializeAws_json1_1AttackDetail = (output: any, context: __SerdeContext
       output.Mitigations !== undefined && output.Mitigations !== null
         ? deserializeAws_json1_1MitigationList(output.Mitigations, context)
         : undefined,
-    ResourceArn: output.ResourceArn !== undefined && output.ResourceArn !== null ? output.ResourceArn : undefined,
+    ResourceArn: __expectString(output.ResourceArn),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
         ? new Date(Math.round(output.StartTime * 1000))
@@ -3803,17 +3807,14 @@ const deserializeAws_json1_1AttackProperties = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1AttackProperty = (output: any, context: __SerdeContext): AttackProperty => {
   return {
-    AttackLayer: output.AttackLayer !== undefined && output.AttackLayer !== null ? output.AttackLayer : undefined,
-    AttackPropertyIdentifier:
-      output.AttackPropertyIdentifier !== undefined && output.AttackPropertyIdentifier !== null
-        ? output.AttackPropertyIdentifier
-        : undefined,
+    AttackLayer: __expectString(output.AttackLayer),
+    AttackPropertyIdentifier: __expectString(output.AttackPropertyIdentifier),
     TopContributors:
       output.TopContributors !== undefined && output.TopContributors !== null
         ? deserializeAws_json1_1TopContributors(output.TopContributors, context)
         : undefined,
-    Total: output.Total !== undefined && output.Total !== null ? output.Total : undefined,
-    Unit: output.Unit !== undefined && output.Unit !== null ? output.Unit : undefined,
+    Total: __expectNumber(output.Total),
+    Unit: __expectString(output.Unit),
   } as any;
 };
 
@@ -3822,7 +3823,7 @@ const deserializeAws_json1_1AttackStatisticsDataItem = (
   context: __SerdeContext
 ): AttackStatisticsDataItem => {
   return {
-    AttackCount: output.AttackCount !== undefined && output.AttackCount !== null ? output.AttackCount : undefined,
+    AttackCount: __expectNumber(output.AttackCount),
     AttackVolume:
       output.AttackVolume !== undefined && output.AttackVolume !== null
         ? deserializeAws_json1_1AttackVolume(output.AttackVolume, context)
@@ -3857,14 +3858,14 @@ const deserializeAws_json1_1AttackSummaries = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_1AttackSummary = (output: any, context: __SerdeContext): AttackSummary => {
   return {
-    AttackId: output.AttackId !== undefined && output.AttackId !== null ? output.AttackId : undefined,
+    AttackId: __expectString(output.AttackId),
     AttackVectors:
       output.AttackVectors !== undefined && output.AttackVectors !== null
         ? deserializeAws_json1_1AttackVectorDescriptionList(output.AttackVectors, context)
         : undefined,
     EndTime:
       output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
-    ResourceArn: output.ResourceArn !== undefined && output.ResourceArn !== null ? output.ResourceArn : undefined,
+    ResourceArn: __expectString(output.ResourceArn),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
         ? new Date(Math.round(output.StartTime * 1000))
@@ -3877,7 +3878,7 @@ const deserializeAws_json1_1AttackVectorDescription = (
   context: __SerdeContext
 ): AttackVectorDescription => {
   return {
-    VectorType: output.VectorType !== undefined && output.VectorType !== null ? output.VectorType : undefined,
+    VectorType: __expectString(output.VectorType),
   } as any;
 };
 
@@ -3914,14 +3915,14 @@ const deserializeAws_json1_1AttackVolume = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_1AttackVolumeStatistics = (output: any, context: __SerdeContext): AttackVolumeStatistics => {
   return {
-    Max: output.Max !== undefined && output.Max !== null ? output.Max : undefined,
+    Max: __expectNumber(output.Max),
   } as any;
 };
 
 const deserializeAws_json1_1Contributor = (output: any, context: __SerdeContext): Contributor => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Name: __expectString(output.Name),
+    Value: __expectNumber(output.Value),
   } as any;
 };
 
@@ -3937,7 +3938,7 @@ const deserializeAws_json1_1CreateProtectionResponse = (
   context: __SerdeContext
 ): CreateProtectionResponse => {
   return {
-    ProtectionId: output.ProtectionId !== undefined && output.ProtectionId !== null ? output.ProtectionId : undefined,
+    ProtectionId: __expectString(output.ProtectionId),
   } as any;
 };
 
@@ -4003,7 +4004,7 @@ const deserializeAws_json1_1DescribeDRTAccessResponse = (
       output.LogBucketList !== undefined && output.LogBucketList !== null
         ? deserializeAws_json1_1LogBucketList(output.LogBucketList, context)
         : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
+    RoleArn: __expectString(output.RoleArn),
   } as any;
 };
 
@@ -4085,9 +4086,9 @@ const deserializeAws_json1_1DisassociateHealthCheckResponse = (
 
 const deserializeAws_json1_1EmergencyContact = (output: any, context: __SerdeContext): EmergencyContact => {
   return {
-    ContactNotes: output.ContactNotes !== undefined && output.ContactNotes !== null ? output.ContactNotes : undefined,
-    EmailAddress: output.EmailAddress !== undefined && output.EmailAddress !== null ? output.EmailAddress : undefined,
-    PhoneNumber: output.PhoneNumber !== undefined && output.PhoneNumber !== null ? output.PhoneNumber : undefined,
+    ContactNotes: __expectString(output.ContactNotes),
+    EmailAddress: __expectString(output.EmailAddress),
+    PhoneNumber: __expectString(output.PhoneNumber),
   } as any;
 };
 
@@ -4114,10 +4115,7 @@ const deserializeAws_json1_1GetSubscriptionStateResponse = (
   context: __SerdeContext
 ): GetSubscriptionStateResponse => {
   return {
-    SubscriptionState:
-      output.SubscriptionState !== undefined && output.SubscriptionState !== null
-        ? output.SubscriptionState
-        : undefined,
+    SubscriptionState: __expectString(output.SubscriptionState),
   } as any;
 };
 
@@ -4128,13 +4126,13 @@ const deserializeAws_json1_1HealthCheckIds = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1InternalErrorException = (output: any, context: __SerdeContext): InternalErrorException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -4143,7 +4141,7 @@ const deserializeAws_json1_1InvalidOperationException = (
   context: __SerdeContext
 ): InvalidOperationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -4152,7 +4150,7 @@ const deserializeAws_json1_1InvalidPaginationTokenException = (
   context: __SerdeContext
 ): InvalidPaginationTokenException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -4165,8 +4163,8 @@ const deserializeAws_json1_1InvalidParameterException = (
       output.fields !== undefined && output.fields !== null
         ? deserializeAws_json1_1ValidationExceptionFieldList(output.fields, context)
         : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    reason: output.reason !== undefined && output.reason !== null ? output.reason : undefined,
+    message: __expectString(output.message),
+    reason: __expectString(output.reason),
   } as any;
 };
 
@@ -4175,14 +4173,14 @@ const deserializeAws_json1_1InvalidResourceException = (
   context: __SerdeContext
 ): InvalidResourceException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1Limit = (output: any, context: __SerdeContext): Limit => {
   return {
-    Max: output.Max !== undefined && output.Max !== null ? output.Max : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Max: __expectNumber(output.Max),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -4202,9 +4200,9 @@ const deserializeAws_json1_1LimitsExceededException = (
   context: __SerdeContext
 ): LimitsExceededException => {
   return {
-    Limit: output.Limit !== undefined && output.Limit !== null ? output.Limit : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    Limit: __expectNumber(output.Limit),
+    Type: __expectString(output.Type),
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -4214,7 +4212,7 @@ const deserializeAws_json1_1ListAttacksResponse = (output: any, context: __Serde
       output.AttackSummaries !== undefined && output.AttackSummaries !== null
         ? deserializeAws_json1_1AttackSummaries(output.AttackSummaries, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -4223,7 +4221,7 @@ const deserializeAws_json1_1ListProtectionGroupsResponse = (
   context: __SerdeContext
 ): ListProtectionGroupsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     ProtectionGroups:
       output.ProtectionGroups !== undefined && output.ProtectionGroups !== null
         ? deserializeAws_json1_1ProtectionGroups(output.ProtectionGroups, context)
@@ -4236,7 +4234,7 @@ const deserializeAws_json1_1ListProtectionsResponse = (
   context: __SerdeContext
 ): ListProtectionsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Protections:
       output.Protections !== undefined && output.Protections !== null
         ? deserializeAws_json1_1Protections(output.Protections, context)
@@ -4249,7 +4247,7 @@ const deserializeAws_json1_1ListResourcesInProtectionGroupResponse = (
   context: __SerdeContext
 ): ListResourcesInProtectionGroupResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     ResourceArns:
       output.ResourceArns !== undefined && output.ResourceArns !== null
         ? deserializeAws_json1_1ResourceArnList(output.ResourceArns, context)
@@ -4274,7 +4272,7 @@ const deserializeAws_json1_1LockedSubscriptionException = (
   context: __SerdeContext
 ): LockedSubscriptionException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -4285,14 +4283,13 @@ const deserializeAws_json1_1LogBucketList = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1Mitigation = (output: any, context: __SerdeContext): Mitigation => {
   return {
-    MitigationName:
-      output.MitigationName !== undefined && output.MitigationName !== null ? output.MitigationName : undefined,
+    MitigationName: __expectString(output.MitigationName),
   } as any;
 };
 
@@ -4312,7 +4309,7 @@ const deserializeAws_json1_1NoAssociatedRoleException = (
   context: __SerdeContext
 ): NoAssociatedRoleException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -4321,7 +4318,7 @@ const deserializeAws_json1_1OptimisticLockException = (
   context: __SerdeContext
 ): OptimisticLockException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -4331,31 +4328,24 @@ const deserializeAws_json1_1Protection = (output: any, context: __SerdeContext):
       output.HealthCheckIds !== undefined && output.HealthCheckIds !== null
         ? deserializeAws_json1_1HealthCheckIds(output.HealthCheckIds, context)
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    ProtectionArn:
-      output.ProtectionArn !== undefined && output.ProtectionArn !== null ? output.ProtectionArn : undefined,
-    ResourceArn: output.ResourceArn !== undefined && output.ResourceArn !== null ? output.ResourceArn : undefined,
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
+    ProtectionArn: __expectString(output.ProtectionArn),
+    ResourceArn: __expectString(output.ResourceArn),
   } as any;
 };
 
 const deserializeAws_json1_1ProtectionGroup = (output: any, context: __SerdeContext): ProtectionGroup => {
   return {
-    Aggregation: output.Aggregation !== undefined && output.Aggregation !== null ? output.Aggregation : undefined,
+    Aggregation: __expectString(output.Aggregation),
     Members:
       output.Members !== undefined && output.Members !== null
         ? deserializeAws_json1_1ProtectionGroupMembers(output.Members, context)
         : undefined,
-    Pattern: output.Pattern !== undefined && output.Pattern !== null ? output.Pattern : undefined,
-    ProtectionGroupArn:
-      output.ProtectionGroupArn !== undefined && output.ProtectionGroupArn !== null
-        ? output.ProtectionGroupArn
-        : undefined,
-    ProtectionGroupId:
-      output.ProtectionGroupId !== undefined && output.ProtectionGroupId !== null
-        ? output.ProtectionGroupId
-        : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
+    Pattern: __expectString(output.Pattern),
+    ProtectionGroupArn: __expectString(output.ProtectionGroupArn),
+    ProtectionGroupId: __expectString(output.ProtectionGroupId),
+    ResourceType: __expectString(output.ResourceType),
   } as any;
 };
 
@@ -4364,16 +4354,13 @@ const deserializeAws_json1_1ProtectionGroupArbitraryPatternLimits = (
   context: __SerdeContext
 ): ProtectionGroupArbitraryPatternLimits => {
   return {
-    MaxMembers: output.MaxMembers !== undefined && output.MaxMembers !== null ? output.MaxMembers : undefined,
+    MaxMembers: __expectNumber(output.MaxMembers),
   } as any;
 };
 
 const deserializeAws_json1_1ProtectionGroupLimits = (output: any, context: __SerdeContext): ProtectionGroupLimits => {
   return {
-    MaxProtectionGroups:
-      output.MaxProtectionGroups !== undefined && output.MaxProtectionGroups !== null
-        ? output.MaxProtectionGroups
-        : undefined,
+    MaxProtectionGroups: __expectNumber(output.MaxProtectionGroups),
     PatternTypeLimits:
       output.PatternTypeLimits !== undefined && output.PatternTypeLimits !== null
         ? deserializeAws_json1_1ProtectionGroupPatternTypeLimits(output.PatternTypeLimits, context)
@@ -4388,7 +4375,7 @@ const deserializeAws_json1_1ProtectionGroupMembers = (output: any, context: __Se
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4440,8 +4427,8 @@ const deserializeAws_json1_1ResourceAlreadyExistsException = (
   context: __SerdeContext
 ): ResourceAlreadyExistsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
+    message: __expectString(output.message),
+    resourceType: __expectString(output.resourceType),
   } as any;
 };
 
@@ -4452,7 +4439,7 @@ const deserializeAws_json1_1ResourceArnList = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4461,8 +4448,8 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    resourceType: output.resourceType !== undefined && output.resourceType !== null ? output.resourceType : undefined,
+    message: __expectString(output.message),
+    resourceType: __expectString(output.resourceType),
   } as any;
 };
 
@@ -4476,8 +4463,8 @@ const deserializeAws_json1_1SubResourceSummary = (output: any, context: __SerdeC
       output.Counters !== undefined && output.Counters !== null
         ? deserializeAws_json1_1SummarizedCounterList(output.Counters, context)
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Id: __expectString(output.Id),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -4494,31 +4481,24 @@ const deserializeAws_json1_1SubResourceSummaryList = (output: any, context: __Se
 
 const deserializeAws_json1_1Subscription = (output: any, context: __SerdeContext): Subscription => {
   return {
-    AutoRenew: output.AutoRenew !== undefined && output.AutoRenew !== null ? output.AutoRenew : undefined,
+    AutoRenew: __expectString(output.AutoRenew),
     EndTime:
       output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
     Limits:
       output.Limits !== undefined && output.Limits !== null
         ? deserializeAws_json1_1Limits(output.Limits, context)
         : undefined,
-    ProactiveEngagementStatus:
-      output.ProactiveEngagementStatus !== undefined && output.ProactiveEngagementStatus !== null
-        ? output.ProactiveEngagementStatus
-        : undefined,
+    ProactiveEngagementStatus: __expectString(output.ProactiveEngagementStatus),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
         ? new Date(Math.round(output.StartTime * 1000))
         : undefined,
-    SubscriptionArn:
-      output.SubscriptionArn !== undefined && output.SubscriptionArn !== null ? output.SubscriptionArn : undefined,
+    SubscriptionArn: __expectString(output.SubscriptionArn),
     SubscriptionLimits:
       output.SubscriptionLimits !== undefined && output.SubscriptionLimits !== null
         ? deserializeAws_json1_1SubscriptionLimits(output.SubscriptionLimits, context)
         : undefined,
-    TimeCommitmentInSeconds:
-      output.TimeCommitmentInSeconds !== undefined && output.TimeCommitmentInSeconds !== null
-        ? output.TimeCommitmentInSeconds
-        : undefined,
+    TimeCommitmentInSeconds: __expectNumber(output.TimeCommitmentInSeconds),
   } as any;
 };
 
@@ -4541,7 +4521,7 @@ const deserializeAws_json1_1SummarizedAttackVector = (output: any, context: __Se
       output.VectorCounters !== undefined && output.VectorCounters !== null
         ? deserializeAws_json1_1SummarizedCounterList(output.VectorCounters, context)
         : undefined,
-    VectorType: output.VectorType !== undefined && output.VectorType !== null ? output.VectorType : undefined,
+    VectorType: __expectString(output.VectorType),
   } as any;
 };
 
@@ -4561,12 +4541,12 @@ const deserializeAws_json1_1SummarizedAttackVectorList = (
 
 const deserializeAws_json1_1SummarizedCounter = (output: any, context: __SerdeContext): SummarizedCounter => {
   return {
-    Average: output.Average !== undefined && output.Average !== null ? output.Average : undefined,
-    Max: output.Max !== undefined && output.Max !== null ? output.Max : undefined,
-    N: output.N !== undefined && output.N !== null ? output.N : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Sum: output.Sum !== undefined && output.Sum !== null ? output.Sum : undefined,
-    Unit: output.Unit !== undefined && output.Unit !== null ? output.Unit : undefined,
+    Average: __expectNumber(output.Average),
+    Max: __expectNumber(output.Max),
+    N: __expectNumber(output.N),
+    Name: __expectString(output.Name),
+    Sum: __expectNumber(output.Sum),
+    Unit: __expectString(output.Unit),
   } as any;
 };
 
@@ -4583,8 +4563,8 @@ const deserializeAws_json1_1SummarizedCounterList = (output: any, context: __Ser
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -4657,8 +4637,8 @@ const deserializeAws_json1_1ValidationExceptionField = (
   context: __SerdeContext
 ): ValidationExceptionField => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    message: __expectString(output.message),
+    name: __expectString(output.name),
   } as any;
 };
 

--- a/clients/client-signer/protocols/Aws_restJson1.ts
+++ b/clients/client-signer/protocols/Aws_restJson1.ts
@@ -77,6 +77,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -660,7 +663,7 @@ export const deserializeAws_restJson1AddProfilePermissionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.revisionId !== undefined && data.revisionId !== null) {
-    contents.revisionId = data.revisionId;
+    contents.revisionId = __expectString(data.revisionId);
   }
   return Promise.resolve(contents);
 };
@@ -862,31 +865,31 @@ export const deserializeAws_restJson1DescribeSigningJobCommand = async (
     contents.createdAt = new Date(Math.round(data.createdAt * 1000));
   }
   if (data.jobId !== undefined && data.jobId !== null) {
-    contents.jobId = data.jobId;
+    contents.jobId = __expectString(data.jobId);
   }
   if (data.jobInvoker !== undefined && data.jobInvoker !== null) {
-    contents.jobInvoker = data.jobInvoker;
+    contents.jobInvoker = __expectString(data.jobInvoker);
   }
   if (data.jobOwner !== undefined && data.jobOwner !== null) {
-    contents.jobOwner = data.jobOwner;
+    contents.jobOwner = __expectString(data.jobOwner);
   }
   if (data.overrides !== undefined && data.overrides !== null) {
     contents.overrides = deserializeAws_restJson1SigningPlatformOverrides(data.overrides, context);
   }
   if (data.platformDisplayName !== undefined && data.platformDisplayName !== null) {
-    contents.platformDisplayName = data.platformDisplayName;
+    contents.platformDisplayName = __expectString(data.platformDisplayName);
   }
   if (data.platformId !== undefined && data.platformId !== null) {
-    contents.platformId = data.platformId;
+    contents.platformId = __expectString(data.platformId);
   }
   if (data.profileName !== undefined && data.profileName !== null) {
-    contents.profileName = data.profileName;
+    contents.profileName = __expectString(data.profileName);
   }
   if (data.profileVersion !== undefined && data.profileVersion !== null) {
-    contents.profileVersion = data.profileVersion;
+    contents.profileVersion = __expectString(data.profileVersion);
   }
   if (data.requestedBy !== undefined && data.requestedBy !== null) {
-    contents.requestedBy = data.requestedBy;
+    contents.requestedBy = __expectString(data.requestedBy);
   }
   if (data.revocationRecord !== undefined && data.revocationRecord !== null) {
     contents.revocationRecord = deserializeAws_restJson1SigningJobRevocationRecord(data.revocationRecord, context);
@@ -907,10 +910,10 @@ export const deserializeAws_restJson1DescribeSigningJobCommand = async (
     contents.source = deserializeAws_restJson1Source(data.source, context);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.status = data.status;
+    contents.status = __expectString(data.status);
   }
   if (data.statusReason !== undefined && data.statusReason !== null) {
-    contents.statusReason = data.statusReason;
+    contents.statusReason = __expectString(data.statusReason);
   }
   return Promise.resolve(contents);
 };
@@ -997,22 +1000,22 @@ export const deserializeAws_restJson1GetSigningPlatformCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.category !== undefined && data.category !== null) {
-    contents.category = data.category;
+    contents.category = __expectString(data.category);
   }
   if (data.displayName !== undefined && data.displayName !== null) {
-    contents.displayName = data.displayName;
+    contents.displayName = __expectString(data.displayName);
   }
   if (data.maxSizeInMB !== undefined && data.maxSizeInMB !== null) {
-    contents.maxSizeInMB = data.maxSizeInMB;
+    contents.maxSizeInMB = __expectNumber(data.maxSizeInMB);
   }
   if (data.partner !== undefined && data.partner !== null) {
-    contents.partner = data.partner;
+    contents.partner = __expectString(data.partner);
   }
   if (data.platformId !== undefined && data.platformId !== null) {
-    contents.platformId = data.platformId;
+    contents.platformId = __expectString(data.platformId);
   }
   if (data.revocationSupported !== undefined && data.revocationSupported !== null) {
-    contents.revocationSupported = data.revocationSupported;
+    contents.revocationSupported = __expectBoolean(data.revocationSupported);
   }
   if (data.signingConfiguration !== undefined && data.signingConfiguration !== null) {
     contents.signingConfiguration = deserializeAws_restJson1SigningConfiguration(data.signingConfiguration, context);
@@ -1021,7 +1024,7 @@ export const deserializeAws_restJson1GetSigningPlatformCommand = async (
     contents.signingImageFormat = deserializeAws_restJson1SigningImageFormat(data.signingImageFormat, context);
   }
   if (data.target !== undefined && data.target !== null) {
-    contents.target = data.target;
+    contents.target = __expectString(data.target);
   }
   return Promise.resolve(contents);
 };
@@ -1113,25 +1116,25 @@ export const deserializeAws_restJson1GetSigningProfileCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.overrides !== undefined && data.overrides !== null) {
     contents.overrides = deserializeAws_restJson1SigningPlatformOverrides(data.overrides, context);
   }
   if (data.platformDisplayName !== undefined && data.platformDisplayName !== null) {
-    contents.platformDisplayName = data.platformDisplayName;
+    contents.platformDisplayName = __expectString(data.platformDisplayName);
   }
   if (data.platformId !== undefined && data.platformId !== null) {
-    contents.platformId = data.platformId;
+    contents.platformId = __expectString(data.platformId);
   }
   if (data.profileName !== undefined && data.profileName !== null) {
-    contents.profileName = data.profileName;
+    contents.profileName = __expectString(data.profileName);
   }
   if (data.profileVersion !== undefined && data.profileVersion !== null) {
-    contents.profileVersion = data.profileVersion;
+    contents.profileVersion = __expectString(data.profileVersion);
   }
   if (data.profileVersionArn !== undefined && data.profileVersionArn !== null) {
-    contents.profileVersionArn = data.profileVersionArn;
+    contents.profileVersionArn = __expectString(data.profileVersionArn);
   }
   if (data.revocationRecord !== undefined && data.revocationRecord !== null) {
     contents.revocationRecord = deserializeAws_restJson1SigningProfileRevocationRecord(data.revocationRecord, context);
@@ -1149,10 +1152,10 @@ export const deserializeAws_restJson1GetSigningProfileCommand = async (
     contents.signingParameters = deserializeAws_restJson1SigningParameters(data.signingParameters, context);
   }
   if (data.status !== undefined && data.status !== null) {
-    contents.status = data.status;
+    contents.status = __expectString(data.status);
   }
   if (data.statusReason !== undefined && data.statusReason !== null) {
-    contents.statusReason = data.statusReason;
+    contents.statusReason = __expectString(data.statusReason);
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
@@ -1237,16 +1240,16 @@ export const deserializeAws_restJson1ListProfilePermissionsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.permissions !== undefined && data.permissions !== null) {
     contents.permissions = deserializeAws_restJson1Permissions(data.permissions, context);
   }
   if (data.policySizeBytes !== undefined && data.policySizeBytes !== null) {
-    contents.policySizeBytes = data.policySizeBytes;
+    contents.policySizeBytes = __expectNumber(data.policySizeBytes);
   }
   if (data.revisionId !== undefined && data.revisionId !== null) {
-    contents.revisionId = data.revisionId;
+    contents.revisionId = __expectString(data.revisionId);
   }
   return Promise.resolve(contents);
 };
@@ -1337,7 +1340,7 @@ export const deserializeAws_restJson1ListSigningJobsCommand = async (
     contents.jobs = deserializeAws_restJson1SigningJobs(data.jobs, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1417,7 +1420,7 @@ export const deserializeAws_restJson1ListSigningPlatformsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.platforms !== undefined && data.platforms !== null) {
     contents.platforms = deserializeAws_restJson1SigningPlatforms(data.platforms, context);
@@ -1500,7 +1503,7 @@ export const deserializeAws_restJson1ListSigningProfilesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.profiles !== undefined && data.profiles !== null) {
     contents.profiles = deserializeAws_restJson1SigningProfiles(data.profiles, context);
@@ -1655,13 +1658,13 @@ export const deserializeAws_restJson1PutSigningProfileCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.profileVersion !== undefined && data.profileVersion !== null) {
-    contents.profileVersion = data.profileVersion;
+    contents.profileVersion = __expectString(data.profileVersion);
   }
   if (data.profileVersionArn !== undefined && data.profileVersionArn !== null) {
-    contents.profileVersionArn = data.profileVersionArn;
+    contents.profileVersionArn = __expectString(data.profileVersionArn);
   }
   return Promise.resolve(contents);
 };
@@ -1748,7 +1751,7 @@ export const deserializeAws_restJson1RemoveProfilePermissionCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.revisionId !== undefined && data.revisionId !== null) {
-    contents.revisionId = data.revisionId;
+    contents.revisionId = __expectString(data.revisionId);
   }
   return Promise.resolve(contents);
 };
@@ -2010,10 +2013,10 @@ export const deserializeAws_restJson1StartSigningJobCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.jobId !== undefined && data.jobId !== null) {
-    contents.jobId = data.jobId;
+    contents.jobId = __expectString(data.jobId);
   }
   if (data.jobOwner !== undefined && data.jobOwner !== null) {
-    contents.jobOwner = data.jobOwner;
+    contents.jobOwner = __expectString(data.jobOwner);
   }
   return Promise.resolve(contents);
 };
@@ -2258,10 +2261,10 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.code !== undefined && data.code !== null) {
-    contents.code = data.code;
+    contents.code = __expectString(data.code);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2279,10 +2282,10 @@ const deserializeAws_restJson1BadRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.code !== undefined && data.code !== null) {
-    contents.code = data.code;
+    contents.code = __expectString(data.code);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2300,10 +2303,10 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.code !== undefined && data.code !== null) {
-    contents.code = data.code;
+    contents.code = __expectString(data.code);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2321,10 +2324,10 @@ const deserializeAws_restJson1InternalServiceErrorExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.code !== undefined && data.code !== null) {
-    contents.code = data.code;
+    contents.code = __expectString(data.code);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2342,10 +2345,10 @@ const deserializeAws_restJson1NotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.code !== undefined && data.code !== null) {
-    contents.code = data.code;
+    contents.code = __expectString(data.code);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2363,10 +2366,10 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.code !== undefined && data.code !== null) {
-    contents.code = data.code;
+    contents.code = __expectString(data.code);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2384,10 +2387,10 @@ const deserializeAws_restJson1ServiceLimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.code !== undefined && data.code !== null) {
-    contents.code = data.code;
+    contents.code = __expectString(data.code);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2405,10 +2408,10 @@ const deserializeAws_restJson1ThrottlingExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.code !== undefined && data.code !== null) {
-    contents.code = data.code;
+    contents.code = __expectString(data.code);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2426,10 +2429,10 @@ const deserializeAws_restJson1TooManyRequestsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.code !== undefined && data.code !== null) {
-    contents.code = data.code;
+    contents.code = __expectString(data.code);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2447,10 +2450,10 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.code !== undefined && data.code !== null) {
-    contents.code = data.code;
+    contents.code = __expectString(data.code);
   }
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -2557,7 +2560,7 @@ const deserializeAws_restJson1EncryptionAlgorithmOptions = (
       output.allowedValues !== undefined && output.allowedValues !== null
         ? deserializeAws_restJson1EncryptionAlgorithms(output.allowedValues, context)
         : undefined,
-    defaultValue: output.defaultValue !== undefined && output.defaultValue !== null ? output.defaultValue : undefined,
+    defaultValue: __expectString(output.defaultValue),
   } as any;
 };
 
@@ -2571,7 +2574,7 @@ const deserializeAws_restJson1EncryptionAlgorithms = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2581,7 +2584,7 @@ const deserializeAws_restJson1HashAlgorithmOptions = (output: any, context: __Se
       output.allowedValues !== undefined && output.allowedValues !== null
         ? deserializeAws_restJson1HashAlgorithms(output.allowedValues, context)
         : undefined,
-    defaultValue: output.defaultValue !== undefined && output.defaultValue !== null ? output.defaultValue : undefined,
+    defaultValue: __expectString(output.defaultValue),
   } as any;
 };
 
@@ -2592,7 +2595,7 @@ const deserializeAws_restJson1HashAlgorithms = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2603,17 +2606,16 @@ const deserializeAws_restJson1ImageFormats = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1Permission = (output: any, context: __SerdeContext): Permission => {
   return {
-    action: output.action !== undefined && output.action !== null ? output.action : undefined,
-    principal: output.principal !== undefined && output.principal !== null ? output.principal : undefined,
-    profileVersion:
-      output.profileVersion !== undefined && output.profileVersion !== null ? output.profileVersion : undefined,
-    statementId: output.statementId !== undefined && output.statementId !== null ? output.statementId : undefined,
+    action: __expectString(output.action),
+    principal: __expectString(output.principal),
+    profileVersion: __expectString(output.profileVersion),
+    statementId: __expectString(output.statementId),
   } as any;
 };
 
@@ -2630,16 +2632,16 @@ const deserializeAws_restJson1Permissions = (output: any, context: __SerdeContex
 
 const deserializeAws_restJson1S3SignedObject = (output: any, context: __SerdeContext): S3SignedObject => {
   return {
-    bucketName: output.bucketName !== undefined && output.bucketName !== null ? output.bucketName : undefined,
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
+    bucketName: __expectString(output.bucketName),
+    key: __expectString(output.key),
   } as any;
 };
 
 const deserializeAws_restJson1S3Source = (output: any, context: __SerdeContext): S3Source => {
   return {
-    bucketName: output.bucketName !== undefined && output.bucketName !== null ? output.bucketName : undefined,
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    bucketName: __expectString(output.bucketName),
+    key: __expectString(output.key),
+    version: __expectString(output.version),
   } as any;
 };
 
@@ -2648,8 +2650,8 @@ const deserializeAws_restJson1SignatureValidityPeriod = (
   context: __SerdeContext
 ): SignatureValidityPeriod => {
   return {
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    type: __expectString(output.type),
+    value: __expectNumber(output.value),
   } as any;
 };
 
@@ -2680,19 +2682,14 @@ const deserializeAws_restJson1SigningConfigurationOverrides = (
   context: __SerdeContext
 ): SigningConfigurationOverrides => {
   return {
-    encryptionAlgorithm:
-      output.encryptionAlgorithm !== undefined && output.encryptionAlgorithm !== null
-        ? output.encryptionAlgorithm
-        : undefined,
-    hashAlgorithm:
-      output.hashAlgorithm !== undefined && output.hashAlgorithm !== null ? output.hashAlgorithm : undefined,
+    encryptionAlgorithm: __expectString(output.encryptionAlgorithm),
+    hashAlgorithm: __expectString(output.hashAlgorithm),
   } as any;
 };
 
 const deserializeAws_restJson1SigningImageFormat = (output: any, context: __SerdeContext): SigningImageFormat => {
   return {
-    defaultFormat:
-      output.defaultFormat !== undefined && output.defaultFormat !== null ? output.defaultFormat : undefined,
+    defaultFormat: __expectString(output.defaultFormat),
     supportedFormats:
       output.supportedFormats !== undefined && output.supportedFormats !== null
         ? deserializeAws_restJson1ImageFormats(output.supportedFormats, context)
@@ -2706,18 +2703,14 @@ const deserializeAws_restJson1SigningJob = (output: any, context: __SerdeContext
       output.createdAt !== undefined && output.createdAt !== null
         ? new Date(Math.round(output.createdAt * 1000))
         : undefined,
-    isRevoked: output.isRevoked !== undefined && output.isRevoked !== null ? output.isRevoked : undefined,
-    jobId: output.jobId !== undefined && output.jobId !== null ? output.jobId : undefined,
-    jobInvoker: output.jobInvoker !== undefined && output.jobInvoker !== null ? output.jobInvoker : undefined,
-    jobOwner: output.jobOwner !== undefined && output.jobOwner !== null ? output.jobOwner : undefined,
-    platformDisplayName:
-      output.platformDisplayName !== undefined && output.platformDisplayName !== null
-        ? output.platformDisplayName
-        : undefined,
-    platformId: output.platformId !== undefined && output.platformId !== null ? output.platformId : undefined,
-    profileName: output.profileName !== undefined && output.profileName !== null ? output.profileName : undefined,
-    profileVersion:
-      output.profileVersion !== undefined && output.profileVersion !== null ? output.profileVersion : undefined,
+    isRevoked: __expectBoolean(output.isRevoked),
+    jobId: __expectString(output.jobId),
+    jobInvoker: __expectString(output.jobInvoker),
+    jobOwner: __expectString(output.jobOwner),
+    platformDisplayName: __expectString(output.platformDisplayName),
+    platformId: __expectString(output.platformId),
+    profileName: __expectString(output.profileName),
+    profileVersion: __expectString(output.profileVersion),
     signatureExpiresAt:
       output.signatureExpiresAt !== undefined && output.signatureExpiresAt !== null
         ? new Date(Math.round(output.signatureExpiresAt * 1000))
@@ -2734,7 +2727,7 @@ const deserializeAws_restJson1SigningJob = (output: any, context: __SerdeContext
       output.source !== undefined && output.source !== null
         ? deserializeAws_restJson1Source(output.source, context)
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -2743,12 +2736,12 @@ const deserializeAws_restJson1SigningJobRevocationRecord = (
   context: __SerdeContext
 ): SigningJobRevocationRecord => {
   return {
-    reason: output.reason !== undefined && output.reason !== null ? output.reason : undefined,
+    reason: __expectString(output.reason),
     revokedAt:
       output.revokedAt !== undefined && output.revokedAt !== null
         ? new Date(Math.round(output.revokedAt * 1000))
         : undefined,
-    revokedBy: output.revokedBy !== undefined && output.revokedBy !== null ? output.revokedBy : undefined,
+    revokedBy: __expectString(output.revokedBy),
   } as any;
 };
 
@@ -2765,8 +2758,7 @@ const deserializeAws_restJson1SigningJobs = (output: any, context: __SerdeContex
 
 const deserializeAws_restJson1SigningMaterial = (output: any, context: __SerdeContext): SigningMaterial => {
   return {
-    certificateArn:
-      output.certificateArn !== undefined && output.certificateArn !== null ? output.certificateArn : undefined,
+    certificateArn: __expectString(output.certificateArn),
   } as any;
 };
 
@@ -2777,22 +2769,19 @@ const deserializeAws_restJson1SigningParameters = (output: any, context: __Serde
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1SigningPlatform = (output: any, context: __SerdeContext): SigningPlatform => {
   return {
-    category: output.category !== undefined && output.category !== null ? output.category : undefined,
-    displayName: output.displayName !== undefined && output.displayName !== null ? output.displayName : undefined,
-    maxSizeInMB: output.maxSizeInMB !== undefined && output.maxSizeInMB !== null ? output.maxSizeInMB : undefined,
-    partner: output.partner !== undefined && output.partner !== null ? output.partner : undefined,
-    platformId: output.platformId !== undefined && output.platformId !== null ? output.platformId : undefined,
-    revocationSupported:
-      output.revocationSupported !== undefined && output.revocationSupported !== null
-        ? output.revocationSupported
-        : undefined,
+    category: __expectString(output.category),
+    displayName: __expectString(output.displayName),
+    maxSizeInMB: __expectNumber(output.maxSizeInMB),
+    partner: __expectString(output.partner),
+    platformId: __expectString(output.platformId),
+    revocationSupported: __expectBoolean(output.revocationSupported),
     signingConfiguration:
       output.signingConfiguration !== undefined && output.signingConfiguration !== null
         ? deserializeAws_restJson1SigningConfiguration(output.signingConfiguration, context)
@@ -2801,7 +2790,7 @@ const deserializeAws_restJson1SigningPlatform = (output: any, context: __SerdeCo
       output.signingImageFormat !== undefined && output.signingImageFormat !== null
         ? deserializeAws_restJson1SigningImageFormat(output.signingImageFormat, context)
         : undefined,
-    target: output.target !== undefined && output.target !== null ? output.target : undefined,
+    target: __expectString(output.target),
   } as any;
 };
 
@@ -2814,10 +2803,7 @@ const deserializeAws_restJson1SigningPlatformOverrides = (
       output.signingConfiguration !== undefined && output.signingConfiguration !== null
         ? deserializeAws_restJson1SigningConfigurationOverrides(output.signingConfiguration, context)
         : undefined,
-    signingImageFormat:
-      output.signingImageFormat !== undefined && output.signingImageFormat !== null
-        ? output.signingImageFormat
-        : undefined,
+    signingImageFormat: __expectString(output.signingImageFormat),
   } as any;
 };
 
@@ -2834,19 +2820,12 @@ const deserializeAws_restJson1SigningPlatforms = (output: any, context: __SerdeC
 
 const deserializeAws_restJson1SigningProfile = (output: any, context: __SerdeContext): SigningProfile => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    platformDisplayName:
-      output.platformDisplayName !== undefined && output.platformDisplayName !== null
-        ? output.platformDisplayName
-        : undefined,
-    platformId: output.platformId !== undefined && output.platformId !== null ? output.platformId : undefined,
-    profileName: output.profileName !== undefined && output.profileName !== null ? output.profileName : undefined,
-    profileVersion:
-      output.profileVersion !== undefined && output.profileVersion !== null ? output.profileVersion : undefined,
-    profileVersionArn:
-      output.profileVersionArn !== undefined && output.profileVersionArn !== null
-        ? output.profileVersionArn
-        : undefined,
+    arn: __expectString(output.arn),
+    platformDisplayName: __expectString(output.platformDisplayName),
+    platformId: __expectString(output.platformId),
+    profileName: __expectString(output.profileName),
+    profileVersion: __expectString(output.profileVersion),
+    profileVersionArn: __expectString(output.profileVersionArn),
     signatureValidityPeriod:
       output.signatureValidityPeriod !== undefined && output.signatureValidityPeriod !== null
         ? deserializeAws_restJson1SignatureValidityPeriod(output.signatureValidityPeriod, context)
@@ -2859,7 +2838,7 @@ const deserializeAws_restJson1SigningProfile = (output: any, context: __SerdeCon
       output.signingParameters !== undefined && output.signingParameters !== null
         ? deserializeAws_restJson1SigningParameters(output.signingParameters, context)
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1TagMap(output.tags, context)
@@ -2880,7 +2859,7 @@ const deserializeAws_restJson1SigningProfileRevocationRecord = (
       output.revokedAt !== undefined && output.revokedAt !== null
         ? new Date(Math.round(output.revokedAt * 1000))
         : undefined,
-    revokedBy: output.revokedBy !== undefined && output.revokedBy !== null ? output.revokedBy : undefined,
+    revokedBy: __expectString(output.revokedBy),
   } as any;
 };
 
@@ -2909,7 +2888,7 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };

--- a/clients/client-sms/protocols/Aws_json1_1.ts
+++ b/clients/client-sms/protocols/Aws_json1_1.ts
@@ -208,7 +208,12 @@ import {
   VmServerAddress,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -4632,14 +4637,13 @@ const deserializeAws_json1_1Apps = (output: any, context: __SerdeContext): AppSu
 
 const deserializeAws_json1_1AppSummary = (output: any, context: __SerdeContext): AppSummary => {
   return {
-    appId: output.appId !== undefined && output.appId !== null ? output.appId : undefined,
+    appId: __expectString(output.appId),
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
         ? new Date(Math.round(output.creationTime * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    importedAppId:
-      output.importedAppId !== undefined && output.importedAppId !== null ? output.importedAppId : undefined,
+    description: __expectString(output.description),
+    importedAppId: __expectString(output.importedAppId),
     lastModified:
       output.lastModified !== undefined && output.lastModified !== null
         ? new Date(Math.round(output.lastModified * 1000))
@@ -4648,41 +4652,22 @@ const deserializeAws_json1_1AppSummary = (output: any, context: __SerdeContext):
       output.latestReplicationTime !== undefined && output.latestReplicationTime !== null
         ? new Date(Math.round(output.latestReplicationTime * 1000))
         : undefined,
-    launchConfigurationStatus:
-      output.launchConfigurationStatus !== undefined && output.launchConfigurationStatus !== null
-        ? output.launchConfigurationStatus
-        : undefined,
+    launchConfigurationStatus: __expectString(output.launchConfigurationStatus),
     launchDetails:
       output.launchDetails !== undefined && output.launchDetails !== null
         ? deserializeAws_json1_1LaunchDetails(output.launchDetails, context)
         : undefined,
-    launchStatus: output.launchStatus !== undefined && output.launchStatus !== null ? output.launchStatus : undefined,
-    launchStatusMessage:
-      output.launchStatusMessage !== undefined && output.launchStatusMessage !== null
-        ? output.launchStatusMessage
-        : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    replicationConfigurationStatus:
-      output.replicationConfigurationStatus !== undefined && output.replicationConfigurationStatus !== null
-        ? output.replicationConfigurationStatus
-        : undefined,
-    replicationStatus:
-      output.replicationStatus !== undefined && output.replicationStatus !== null
-        ? output.replicationStatus
-        : undefined,
-    replicationStatusMessage:
-      output.replicationStatusMessage !== undefined && output.replicationStatusMessage !== null
-        ? output.replicationStatusMessage
-        : undefined,
-    roleName: output.roleName !== undefined && output.roleName !== null ? output.roleName : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    statusMessage:
-      output.statusMessage !== undefined && output.statusMessage !== null ? output.statusMessage : undefined,
-    totalServerGroups:
-      output.totalServerGroups !== undefined && output.totalServerGroups !== null
-        ? output.totalServerGroups
-        : undefined,
-    totalServers: output.totalServers !== undefined && output.totalServers !== null ? output.totalServers : undefined,
+    launchStatus: __expectString(output.launchStatus),
+    launchStatusMessage: __expectString(output.launchStatusMessage),
+    name: __expectString(output.name),
+    replicationConfigurationStatus: __expectString(output.replicationConfigurationStatus),
+    replicationStatus: __expectString(output.replicationStatus),
+    replicationStatusMessage: __expectString(output.replicationStatusMessage),
+    roleName: __expectString(output.roleName),
+    status: __expectString(output.status),
+    statusMessage: __expectString(output.statusMessage),
+    totalServerGroups: __expectNumber(output.totalServerGroups),
+    totalServers: __expectNumber(output.totalServers),
   } as any;
 };
 
@@ -4691,16 +4676,13 @@ const deserializeAws_json1_1AppValidationConfiguration = (
   context: __SerdeContext
 ): AppValidationConfiguration => {
   return {
-    appValidationStrategy:
-      output.appValidationStrategy !== undefined && output.appValidationStrategy !== null
-        ? output.appValidationStrategy
-        : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    appValidationStrategy: __expectString(output.appValidationStrategy),
+    name: __expectString(output.name),
     ssmValidationParameters:
       output.ssmValidationParameters !== undefined && output.ssmValidationParameters !== null
         ? deserializeAws_json1_1SSMValidationParameters(output.ssmValidationParameters, context)
         : undefined,
-    validationId: output.validationId !== undefined && output.validationId !== null ? output.validationId : undefined,
+    validationId: __expectString(output.validationId),
   } as any;
 };
 
@@ -4737,16 +4719,14 @@ const deserializeAws_json1_1Connector = (output: any, context: __SerdeContext): 
       output.capabilityList !== undefined && output.capabilityList !== null
         ? deserializeAws_json1_1ConnectorCapabilityList(output.capabilityList, context)
         : undefined,
-    connectorId: output.connectorId !== undefined && output.connectorId !== null ? output.connectorId : undefined,
-    ipAddress: output.ipAddress !== undefined && output.ipAddress !== null ? output.ipAddress : undefined,
-    macAddress: output.macAddress !== undefined && output.macAddress !== null ? output.macAddress : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
-    vmManagerId: output.vmManagerId !== undefined && output.vmManagerId !== null ? output.vmManagerId : undefined,
-    vmManagerName:
-      output.vmManagerName !== undefined && output.vmManagerName !== null ? output.vmManagerName : undefined,
-    vmManagerType:
-      output.vmManagerType !== undefined && output.vmManagerType !== null ? output.vmManagerType : undefined,
+    connectorId: __expectString(output.connectorId),
+    ipAddress: __expectString(output.ipAddress),
+    macAddress: __expectString(output.macAddress),
+    status: __expectString(output.status),
+    version: __expectString(output.version),
+    vmManagerId: __expectString(output.vmManagerId),
+    vmManagerName: __expectString(output.vmManagerName),
+    vmManagerType: __expectString(output.vmManagerType),
   } as any;
 };
 
@@ -4760,7 +4740,7 @@ const deserializeAws_json1_1ConnectorCapabilityList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4795,8 +4775,7 @@ const deserializeAws_json1_1CreateReplicationJobResponse = (
   context: __SerdeContext
 ): CreateReplicationJobResponse => {
   return {
-    replicationJobId:
-      output.replicationJobId !== undefined && output.replicationJobId !== null ? output.replicationJobId : undefined,
+    replicationJobId: __expectString(output.replicationJobId),
   } as any;
 };
 
@@ -4851,7 +4830,7 @@ const deserializeAws_json1_1DryRunOperationException = (
   context: __SerdeContext
 ): DryRunOperationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -4884,9 +4863,9 @@ const deserializeAws_json1_1GetAppLaunchConfigurationResponse = (
   context: __SerdeContext
 ): GetAppLaunchConfigurationResponse => {
   return {
-    appId: output.appId !== undefined && output.appId !== null ? output.appId : undefined,
-    autoLaunch: output.autoLaunch !== undefined && output.autoLaunch !== null ? output.autoLaunch : undefined,
-    roleName: output.roleName !== undefined && output.roleName !== null ? output.roleName : undefined,
+    appId: __expectString(output.appId),
+    autoLaunch: __expectBoolean(output.autoLaunch),
+    roleName: __expectString(output.roleName),
     serverGroupLaunchConfigurations:
       output.serverGroupLaunchConfigurations !== undefined && output.serverGroupLaunchConfigurations !== null
         ? deserializeAws_json1_1ServerGroupLaunchConfigurations(output.serverGroupLaunchConfigurations, context)
@@ -4958,7 +4937,7 @@ const deserializeAws_json1_1GetConnectorsResponse = (output: any, context: __Ser
       output.connectorList !== undefined && output.connectorList !== null
         ? deserializeAws_json1_1ConnectorList(output.connectorList, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -4967,7 +4946,7 @@ const deserializeAws_json1_1GetReplicationJobsResponse = (
   context: __SerdeContext
 ): GetReplicationJobsResponse => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     replicationJobList:
       output.replicationJobList !== undefined && output.replicationJobList !== null
         ? deserializeAws_json1_1ReplicationJobList(output.replicationJobList, context)
@@ -4980,7 +4959,7 @@ const deserializeAws_json1_1GetReplicationRunsResponse = (
   context: __SerdeContext
 ): GetReplicationRunsResponse => {
   return {
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
     replicationJob:
       output.replicationJob !== undefined && output.replicationJob !== null
         ? deserializeAws_json1_1ReplicationJob(output.replicationJob, context)
@@ -4998,11 +4977,8 @@ const deserializeAws_json1_1GetServersResponse = (output: any, context: __SerdeC
       output.lastModifiedOn !== undefined && output.lastModifiedOn !== null
         ? new Date(Math.round(output.lastModifiedOn * 1000))
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
-    serverCatalogStatus:
-      output.serverCatalogStatus !== undefined && output.serverCatalogStatus !== null
-        ? output.serverCatalogStatus
-        : undefined,
+    nextToken: __expectString(output.nextToken),
+    serverCatalogStatus: __expectString(output.serverCatalogStatus),
     serverList:
       output.serverList !== undefined && output.serverList !== null
         ? deserializeAws_json1_1ServerList(output.serverList, context)
@@ -5026,7 +5002,7 @@ const deserializeAws_json1_1ImportServerCatalogResponse = (
 
 const deserializeAws_json1_1InternalError = (output: any, context: __SerdeContext): InternalError => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -5035,7 +5011,7 @@ const deserializeAws_json1_1InvalidParameterException = (
   context: __SerdeContext
 ): InvalidParameterException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -5049,8 +5025,8 @@ const deserializeAws_json1_1LaunchDetails = (output: any, context: __SerdeContex
       output.latestLaunchTime !== undefined && output.latestLaunchTime !== null
         ? new Date(Math.round(output.latestLaunchTime * 1000))
         : undefined,
-    stackId: output.stackId !== undefined && output.stackId !== null ? output.stackId : undefined,
-    stackName: output.stackName !== undefined && output.stackName !== null ? output.stackName : undefined,
+    stackId: __expectString(output.stackId),
+    stackName: __expectString(output.stackName),
   } as any;
 };
 
@@ -5058,7 +5034,7 @@ const deserializeAws_json1_1ListAppsResponse = (output: any, context: __SerdeCon
   return {
     apps:
       output.apps !== undefined && output.apps !== null ? deserializeAws_json1_1Apps(output.apps, context) : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -5067,7 +5043,7 @@ const deserializeAws_json1_1MissingRequiredParameterException = (
   context: __SerdeContext
 ): MissingRequiredParameterException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -5076,7 +5052,7 @@ const deserializeAws_json1_1NoConnectorsAvailableException = (
   context: __SerdeContext
 ): NoConnectorsAvailableException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -5092,7 +5068,7 @@ const deserializeAws_json1_1OperationNotPermittedException = (
   context: __SerdeContext
 ): OperationNotPermittedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -5119,37 +5095,32 @@ const deserializeAws_json1_1PutAppValidationConfigurationResponse = (
 
 const deserializeAws_json1_1ReplicationJob = (output: any, context: __SerdeContext): ReplicationJob => {
   return {
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    encrypted: output.encrypted !== undefined && output.encrypted !== null ? output.encrypted : undefined,
-    frequency: output.frequency !== undefined && output.frequency !== null ? output.frequency : undefined,
-    kmsKeyId: output.kmsKeyId !== undefined && output.kmsKeyId !== null ? output.kmsKeyId : undefined,
-    latestAmiId: output.latestAmiId !== undefined && output.latestAmiId !== null ? output.latestAmiId : undefined,
-    licenseType: output.licenseType !== undefined && output.licenseType !== null ? output.licenseType : undefined,
+    description: __expectString(output.description),
+    encrypted: __expectBoolean(output.encrypted),
+    frequency: __expectNumber(output.frequency),
+    kmsKeyId: __expectString(output.kmsKeyId),
+    latestAmiId: __expectString(output.latestAmiId),
+    licenseType: __expectString(output.licenseType),
     nextReplicationRunStartTime:
       output.nextReplicationRunStartTime !== undefined && output.nextReplicationRunStartTime !== null
         ? new Date(Math.round(output.nextReplicationRunStartTime * 1000))
         : undefined,
-    numberOfRecentAmisToKeep:
-      output.numberOfRecentAmisToKeep !== undefined && output.numberOfRecentAmisToKeep !== null
-        ? output.numberOfRecentAmisToKeep
-        : undefined,
-    replicationJobId:
-      output.replicationJobId !== undefined && output.replicationJobId !== null ? output.replicationJobId : undefined,
+    numberOfRecentAmisToKeep: __expectNumber(output.numberOfRecentAmisToKeep),
+    replicationJobId: __expectString(output.replicationJobId),
     replicationRunList:
       output.replicationRunList !== undefined && output.replicationRunList !== null
         ? deserializeAws_json1_1ReplicationRunList(output.replicationRunList, context)
         : undefined,
-    roleName: output.roleName !== undefined && output.roleName !== null ? output.roleName : undefined,
-    runOnce: output.runOnce !== undefined && output.runOnce !== null ? output.runOnce : undefined,
+    roleName: __expectString(output.roleName),
+    runOnce: __expectBoolean(output.runOnce),
     seedReplicationTime:
       output.seedReplicationTime !== undefined && output.seedReplicationTime !== null
         ? new Date(Math.round(output.seedReplicationTime * 1000))
         : undefined,
-    serverId: output.serverId !== undefined && output.serverId !== null ? output.serverId : undefined,
-    serverType: output.serverType !== undefined && output.serverType !== null ? output.serverType : undefined,
-    state: output.state !== undefined && output.state !== null ? output.state : undefined,
-    statusMessage:
-      output.statusMessage !== undefined && output.statusMessage !== null ? output.statusMessage : undefined,
+    serverId: __expectString(output.serverId),
+    serverType: __expectString(output.serverType),
+    state: __expectString(output.state),
+    statusMessage: __expectString(output.statusMessage),
     vmServer:
       output.vmServer !== undefined && output.vmServer !== null
         ? deserializeAws_json1_1VmServer(output.vmServer, context)
@@ -5162,7 +5133,7 @@ const deserializeAws_json1_1ReplicationJobAlreadyExistsException = (
   context: __SerdeContext
 ): ReplicationJobAlreadyExistsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -5182,22 +5153,21 @@ const deserializeAws_json1_1ReplicationJobNotFoundException = (
   context: __SerdeContext
 ): ReplicationJobNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1ReplicationRun = (output: any, context: __SerdeContext): ReplicationRun => {
   return {
-    amiId: output.amiId !== undefined && output.amiId !== null ? output.amiId : undefined,
+    amiId: __expectString(output.amiId),
     completedTime:
       output.completedTime !== undefined && output.completedTime !== null
         ? new Date(Math.round(output.completedTime * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    encrypted: output.encrypted !== undefined && output.encrypted !== null ? output.encrypted : undefined,
-    kmsKeyId: output.kmsKeyId !== undefined && output.kmsKeyId !== null ? output.kmsKeyId : undefined,
-    replicationRunId:
-      output.replicationRunId !== undefined && output.replicationRunId !== null ? output.replicationRunId : undefined,
+    description: __expectString(output.description),
+    encrypted: __expectBoolean(output.encrypted),
+    kmsKeyId: __expectString(output.kmsKeyId),
+    replicationRunId: __expectString(output.replicationRunId),
     scheduledStartTime:
       output.scheduledStartTime !== undefined && output.scheduledStartTime !== null
         ? new Date(Math.round(output.scheduledStartTime * 1000))
@@ -5206,10 +5176,9 @@ const deserializeAws_json1_1ReplicationRun = (output: any, context: __SerdeConte
       output.stageDetails !== undefined && output.stageDetails !== null
         ? deserializeAws_json1_1ReplicationRunStageDetails(output.stageDetails, context)
         : undefined,
-    state: output.state !== undefined && output.state !== null ? output.state : undefined,
-    statusMessage:
-      output.statusMessage !== undefined && output.statusMessage !== null ? output.statusMessage : undefined,
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    state: __expectString(output.state),
+    statusMessage: __expectString(output.statusMessage),
+    type: __expectString(output.type),
   } as any;
 };
 
@@ -5218,7 +5187,7 @@ const deserializeAws_json1_1ReplicationRunLimitExceededException = (
   context: __SerdeContext
 ): ReplicationRunLimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -5238,29 +5207,24 @@ const deserializeAws_json1_1ReplicationRunStageDetails = (
   context: __SerdeContext
 ): ReplicationRunStageDetails => {
   return {
-    stage: output.stage !== undefined && output.stage !== null ? output.stage : undefined,
-    stageProgress:
-      output.stageProgress !== undefined && output.stageProgress !== null ? output.stageProgress : undefined,
+    stage: __expectString(output.stage),
+    stageProgress: __expectString(output.stageProgress),
   } as any;
 };
 
 const deserializeAws_json1_1S3Location = (output: any, context: __SerdeContext): S3Location => {
   return {
-    bucket: output.bucket !== undefined && output.bucket !== null ? output.bucket : undefined,
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
+    bucket: __expectString(output.bucket),
+    key: __expectString(output.key),
   } as any;
 };
 
 const deserializeAws_json1_1Server = (output: any, context: __SerdeContext): Server => {
   return {
-    replicationJobId:
-      output.replicationJobId !== undefined && output.replicationJobId !== null ? output.replicationJobId : undefined,
-    replicationJobTerminated:
-      output.replicationJobTerminated !== undefined && output.replicationJobTerminated !== null
-        ? output.replicationJobTerminated
-        : undefined,
-    serverId: output.serverId !== undefined && output.serverId !== null ? output.serverId : undefined,
-    serverType: output.serverType !== undefined && output.serverType !== null ? output.serverType : undefined,
+    replicationJobId: __expectString(output.replicationJobId),
+    replicationJobTerminated: __expectBoolean(output.replicationJobTerminated),
+    serverId: __expectString(output.serverId),
+    serverType: __expectString(output.serverType),
     vmServer:
       output.vmServer !== undefined && output.vmServer !== null
         ? deserializeAws_json1_1VmServer(output.vmServer, context)
@@ -5273,15 +5237,14 @@ const deserializeAws_json1_1ServerCannotBeReplicatedException = (
   context: __SerdeContext
 ): ServerCannotBeReplicatedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1ServerGroup = (output: any, context: __SerdeContext): ServerGroup => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    serverGroupId:
-      output.serverGroupId !== undefined && output.serverGroupId !== null ? output.serverGroupId : undefined,
+    name: __expectString(output.name),
+    serverGroupId: __expectString(output.serverGroupId),
     serverList:
       output.serverList !== undefined && output.serverList !== null
         ? deserializeAws_json1_1ServerList(output.serverList, context)
@@ -5294,9 +5257,8 @@ const deserializeAws_json1_1ServerGroupLaunchConfiguration = (
   context: __SerdeContext
 ): ServerGroupLaunchConfiguration => {
   return {
-    launchOrder: output.launchOrder !== undefined && output.launchOrder !== null ? output.launchOrder : undefined,
-    serverGroupId:
-      output.serverGroupId !== undefined && output.serverGroupId !== null ? output.serverGroupId : undefined,
+    launchOrder: __expectNumber(output.launchOrder),
+    serverGroupId: __expectString(output.serverGroupId),
     serverLaunchConfigurations:
       output.serverLaunchConfigurations !== undefined && output.serverLaunchConfigurations !== null
         ? deserializeAws_json1_1ServerLaunchConfigurations(output.serverLaunchConfigurations, context)
@@ -5323,8 +5285,7 @@ const deserializeAws_json1_1ServerGroupReplicationConfiguration = (
   context: __SerdeContext
 ): ServerGroupReplicationConfiguration => {
   return {
-    serverGroupId:
-      output.serverGroupId !== undefined && output.serverGroupId !== null ? output.serverGroupId : undefined,
+    serverGroupId: __expectString(output.serverGroupId),
     serverReplicationConfigurations:
       output.serverReplicationConfigurations !== undefined && output.serverReplicationConfigurations !== null
         ? deserializeAws_json1_1ServerReplicationConfigurations(output.serverReplicationConfigurations, context)
@@ -5362,8 +5323,7 @@ const deserializeAws_json1_1ServerGroupValidationConfiguration = (
   context: __SerdeContext
 ): ServerGroupValidationConfiguration => {
   return {
-    serverGroupId:
-      output.serverGroupId !== undefined && output.serverGroupId !== null ? output.serverGroupId : undefined,
+    serverGroupId: __expectString(output.serverGroupId),
     serverValidationConfigurations:
       output.serverValidationConfigurations !== undefined && output.serverValidationConfigurations !== null
         ? deserializeAws_json1_1ServerValidationConfigurations(output.serverValidationConfigurations, context)
@@ -5390,37 +5350,27 @@ const deserializeAws_json1_1ServerLaunchConfiguration = (
   context: __SerdeContext
 ): ServerLaunchConfiguration => {
   return {
-    associatePublicIpAddress:
-      output.associatePublicIpAddress !== undefined && output.associatePublicIpAddress !== null
-        ? output.associatePublicIpAddress
-        : undefined,
+    associatePublicIpAddress: __expectBoolean(output.associatePublicIpAddress),
     configureScript:
       output.configureScript !== undefined && output.configureScript !== null
         ? deserializeAws_json1_1S3Location(output.configureScript, context)
         : undefined,
-    configureScriptType:
-      output.configureScriptType !== undefined && output.configureScriptType !== null
-        ? output.configureScriptType
-        : undefined,
-    ec2KeyName: output.ec2KeyName !== undefined && output.ec2KeyName !== null ? output.ec2KeyName : undefined,
-    iamInstanceProfileName:
-      output.iamInstanceProfileName !== undefined && output.iamInstanceProfileName !== null
-        ? output.iamInstanceProfileName
-        : undefined,
-    instanceType: output.instanceType !== undefined && output.instanceType !== null ? output.instanceType : undefined,
-    logicalId: output.logicalId !== undefined && output.logicalId !== null ? output.logicalId : undefined,
-    securityGroup:
-      output.securityGroup !== undefined && output.securityGroup !== null ? output.securityGroup : undefined,
+    configureScriptType: __expectString(output.configureScriptType),
+    ec2KeyName: __expectString(output.ec2KeyName),
+    iamInstanceProfileName: __expectString(output.iamInstanceProfileName),
+    instanceType: __expectString(output.instanceType),
+    logicalId: __expectString(output.logicalId),
+    securityGroup: __expectString(output.securityGroup),
     server:
       output.server !== undefined && output.server !== null
         ? deserializeAws_json1_1Server(output.server, context)
         : undefined,
-    subnet: output.subnet !== undefined && output.subnet !== null ? output.subnet : undefined,
+    subnet: __expectString(output.subnet),
     userData:
       output.userData !== undefined && output.userData !== null
         ? deserializeAws_json1_1UserData(output.userData, context)
         : undefined,
-    vpc: output.vpc !== undefined && output.vpc !== null ? output.vpc : undefined,
+    vpc: __expectString(output.vpc),
   } as any;
 };
 
@@ -5484,15 +5434,12 @@ const deserializeAws_json1_1ServerReplicationParameters = (
   context: __SerdeContext
 ): ServerReplicationParameters => {
   return {
-    encrypted: output.encrypted !== undefined && output.encrypted !== null ? output.encrypted : undefined,
-    frequency: output.frequency !== undefined && output.frequency !== null ? output.frequency : undefined,
-    kmsKeyId: output.kmsKeyId !== undefined && output.kmsKeyId !== null ? output.kmsKeyId : undefined,
-    licenseType: output.licenseType !== undefined && output.licenseType !== null ? output.licenseType : undefined,
-    numberOfRecentAmisToKeep:
-      output.numberOfRecentAmisToKeep !== undefined && output.numberOfRecentAmisToKeep !== null
-        ? output.numberOfRecentAmisToKeep
-        : undefined,
-    runOnce: output.runOnce !== undefined && output.runOnce !== null ? output.runOnce : undefined,
+    encrypted: __expectBoolean(output.encrypted),
+    frequency: __expectNumber(output.frequency),
+    kmsKeyId: __expectString(output.kmsKeyId),
+    licenseType: __expectString(output.licenseType),
+    numberOfRecentAmisToKeep: __expectNumber(output.numberOfRecentAmisToKeep),
+    runOnce: __expectBoolean(output.runOnce),
     seedTime:
       output.seedTime !== undefined && output.seedTime !== null
         ? new Date(Math.round(output.seedTime * 1000))
@@ -5505,20 +5452,17 @@ const deserializeAws_json1_1ServerValidationConfiguration = (
   context: __SerdeContext
 ): ServerValidationConfiguration => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
     server:
       output.server !== undefined && output.server !== null
         ? deserializeAws_json1_1Server(output.server, context)
         : undefined,
-    serverValidationStrategy:
-      output.serverValidationStrategy !== undefined && output.serverValidationStrategy !== null
-        ? output.serverValidationStrategy
-        : undefined,
+    serverValidationStrategy: __expectString(output.serverValidationStrategy),
     userDataValidationParameters:
       output.userDataValidationParameters !== undefined && output.userDataValidationParameters !== null
         ? deserializeAws_json1_1UserDataValidationParameters(output.userDataValidationParameters, context)
         : undefined,
-    validationId: output.validationId !== undefined && output.validationId !== null ? output.validationId : undefined,
+    validationId: __expectString(output.validationId),
   } as any;
 };
 
@@ -5568,17 +5512,11 @@ const deserializeAws_json1_1SSMValidationParameters = (
   context: __SerdeContext
 ): SSMValidationParameters => {
   return {
-    command: output.command !== undefined && output.command !== null ? output.command : undefined,
-    executionTimeoutSeconds:
-      output.executionTimeoutSeconds !== undefined && output.executionTimeoutSeconds !== null
-        ? output.executionTimeoutSeconds
-        : undefined,
-    instanceId: output.instanceId !== undefined && output.instanceId !== null ? output.instanceId : undefined,
-    outputS3BucketName:
-      output.outputS3BucketName !== undefined && output.outputS3BucketName !== null
-        ? output.outputS3BucketName
-        : undefined,
-    scriptType: output.scriptType !== undefined && output.scriptType !== null ? output.scriptType : undefined,
+    command: __expectString(output.command),
+    executionTimeoutSeconds: __expectNumber(output.executionTimeoutSeconds),
+    instanceId: __expectString(output.instanceId),
+    outputS3BucketName: __expectString(output.outputS3BucketName),
+    scriptType: __expectString(output.scriptType),
     source:
       output.source !== undefined && output.source !== null
         ? deserializeAws_json1_1Source(output.source, context)
@@ -5605,8 +5543,7 @@ const deserializeAws_json1_1StartOnDemandReplicationRunResponse = (
   context: __SerdeContext
 ): StartOnDemandReplicationRunResponse => {
   return {
-    replicationRunId:
-      output.replicationRunId !== undefined && output.replicationRunId !== null ? output.replicationRunId : undefined,
+    replicationRunId: __expectString(output.replicationRunId),
   } as any;
 };
 
@@ -5619,8 +5556,8 @@ const deserializeAws_json1_1StopAppReplicationResponse = (
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    key: __expectString(output.key),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -5651,7 +5588,7 @@ const deserializeAws_json1_1UnauthorizedOperationException = (
   context: __SerdeContext
 ): UnauthorizedOperationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -5691,7 +5628,7 @@ const deserializeAws_json1_1UserDataValidationParameters = (
   context: __SerdeContext
 ): UserDataValidationParameters => {
   return {
-    scriptType: output.scriptType !== undefined && output.scriptType !== null ? output.scriptType : undefined,
+    scriptType: __expectString(output.scriptType),
     source:
       output.source !== undefined && output.source !== null
         ? deserializeAws_json1_1Source(output.source, context)
@@ -5709,15 +5646,14 @@ const deserializeAws_json1_1ValidationOutput = (output: any, context: __SerdeCon
       output.latestValidationTime !== undefined && output.latestValidationTime !== null
         ? new Date(Math.round(output.latestValidationTime * 1000))
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
     serverValidationOutput:
       output.serverValidationOutput !== undefined && output.serverValidationOutput !== null
         ? deserializeAws_json1_1ServerValidationOutput(output.serverValidationOutput, context)
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    statusMessage:
-      output.statusMessage !== undefined && output.statusMessage !== null ? output.statusMessage : undefined,
-    validationId: output.validationId !== undefined && output.validationId !== null ? output.validationId : undefined,
+    status: __expectString(output.status),
+    statusMessage: __expectString(output.statusMessage),
+    validationId: __expectString(output.validationId),
   } as any;
 };
 
@@ -5734,12 +5670,10 @@ const deserializeAws_json1_1ValidationOutputList = (output: any, context: __Serd
 
 const deserializeAws_json1_1VmServer = (output: any, context: __SerdeContext): VmServer => {
   return {
-    vmManagerName:
-      output.vmManagerName !== undefined && output.vmManagerName !== null ? output.vmManagerName : undefined,
-    vmManagerType:
-      output.vmManagerType !== undefined && output.vmManagerType !== null ? output.vmManagerType : undefined,
-    vmName: output.vmName !== undefined && output.vmName !== null ? output.vmName : undefined,
-    vmPath: output.vmPath !== undefined && output.vmPath !== null ? output.vmPath : undefined,
+    vmManagerName: __expectString(output.vmManagerName),
+    vmManagerType: __expectString(output.vmManagerType),
+    vmName: __expectString(output.vmName),
+    vmPath: __expectString(output.vmPath),
     vmServerAddress:
       output.vmServerAddress !== undefined && output.vmServerAddress !== null
         ? deserializeAws_json1_1VmServerAddress(output.vmServerAddress, context)
@@ -5749,8 +5683,8 @@ const deserializeAws_json1_1VmServer = (output: any, context: __SerdeContext): V
 
 const deserializeAws_json1_1VmServerAddress = (output: any, context: __SerdeContext): VmServerAddress => {
   return {
-    vmId: output.vmId !== undefined && output.vmId !== null ? output.vmId : undefined,
-    vmManagerId: output.vmManagerId !== undefined && output.vmManagerId !== null ? output.vmManagerId : undefined,
+    vmId: __expectString(output.vmId),
+    vmManagerId: __expectString(output.vmManagerId),
   } as any;
 };
 

--- a/clients/client-snowball/protocols/Aws_json1_1.ts
+++ b/clients/client-snowball/protocols/Aws_json1_1.ts
@@ -132,7 +132,12 @@ import {
   WirelessConnection,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -2700,24 +2705,20 @@ const serializeAws_json1_1WirelessConnection = (input: WirelessConnection, conte
 
 const deserializeAws_json1_1Address = (output: any, context: __SerdeContext): Address => {
   return {
-    AddressId: output.AddressId !== undefined && output.AddressId !== null ? output.AddressId : undefined,
-    City: output.City !== undefined && output.City !== null ? output.City : undefined,
-    Company: output.Company !== undefined && output.Company !== null ? output.Company : undefined,
-    Country: output.Country !== undefined && output.Country !== null ? output.Country : undefined,
-    IsRestricted: output.IsRestricted !== undefined && output.IsRestricted !== null ? output.IsRestricted : undefined,
-    Landmark: output.Landmark !== undefined && output.Landmark !== null ? output.Landmark : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    PhoneNumber: output.PhoneNumber !== undefined && output.PhoneNumber !== null ? output.PhoneNumber : undefined,
-    PostalCode: output.PostalCode !== undefined && output.PostalCode !== null ? output.PostalCode : undefined,
-    PrefectureOrDistrict:
-      output.PrefectureOrDistrict !== undefined && output.PrefectureOrDistrict !== null
-        ? output.PrefectureOrDistrict
-        : undefined,
-    StateOrProvince:
-      output.StateOrProvince !== undefined && output.StateOrProvince !== null ? output.StateOrProvince : undefined,
-    Street1: output.Street1 !== undefined && output.Street1 !== null ? output.Street1 : undefined,
-    Street2: output.Street2 !== undefined && output.Street2 !== null ? output.Street2 : undefined,
-    Street3: output.Street3 !== undefined && output.Street3 !== null ? output.Street3 : undefined,
+    AddressId: __expectString(output.AddressId),
+    City: __expectString(output.City),
+    Company: __expectString(output.Company),
+    Country: __expectString(output.Country),
+    IsRestricted: __expectBoolean(output.IsRestricted),
+    Landmark: __expectString(output.Landmark),
+    Name: __expectString(output.Name),
+    PhoneNumber: __expectString(output.PhoneNumber),
+    PostalCode: __expectString(output.PostalCode),
+    PrefectureOrDistrict: __expectString(output.PrefectureOrDistrict),
+    StateOrProvince: __expectString(output.StateOrProvince),
+    Street1: __expectString(output.Street1),
+    Street2: __expectString(output.Street2),
+    Street3: __expectString(output.Street3),
   } as any;
 };
 
@@ -2745,19 +2746,19 @@ const deserializeAws_json1_1ClusterLimitExceededException = (
   context: __SerdeContext
 ): ClusterLimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1ClusterListEntry = (output: any, context: __SerdeContext): ClusterListEntry => {
   return {
-    ClusterId: output.ClusterId !== undefined && output.ClusterId !== null ? output.ClusterId : undefined,
-    ClusterState: output.ClusterState !== undefined && output.ClusterState !== null ? output.ClusterState : undefined,
+    ClusterId: __expectString(output.ClusterId),
+    ClusterState: __expectString(output.ClusterState),
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
         ? new Date(Math.round(output.CreationDate * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
   } as any;
 };
 
@@ -2774,20 +2775,17 @@ const deserializeAws_json1_1ClusterListEntryList = (output: any, context: __Serd
 
 const deserializeAws_json1_1ClusterMetadata = (output: any, context: __SerdeContext): ClusterMetadata => {
   return {
-    AddressId: output.AddressId !== undefined && output.AddressId !== null ? output.AddressId : undefined,
-    ClusterId: output.ClusterId !== undefined && output.ClusterId !== null ? output.ClusterId : undefined,
-    ClusterState: output.ClusterState !== undefined && output.ClusterState !== null ? output.ClusterState : undefined,
+    AddressId: __expectString(output.AddressId),
+    ClusterId: __expectString(output.ClusterId),
+    ClusterState: __expectString(output.ClusterState),
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
         ? new Date(Math.round(output.CreationDate * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    ForwardingAddressId:
-      output.ForwardingAddressId !== undefined && output.ForwardingAddressId !== null
-        ? output.ForwardingAddressId
-        : undefined,
-    JobType: output.JobType !== undefined && output.JobType !== null ? output.JobType : undefined,
-    KmsKeyARN: output.KmsKeyARN !== undefined && output.KmsKeyARN !== null ? output.KmsKeyARN : undefined,
+    Description: __expectString(output.Description),
+    ForwardingAddressId: __expectString(output.ForwardingAddressId),
+    JobType: __expectString(output.JobType),
+    KmsKeyARN: __expectString(output.KmsKeyARN),
     Notification:
       output.Notification !== undefined && output.Notification !== null
         ? deserializeAws_json1_1Notification(output.Notification, context)
@@ -2796,10 +2794,9 @@ const deserializeAws_json1_1ClusterMetadata = (output: any, context: __SerdeCont
       output.Resources !== undefined && output.Resources !== null
         ? deserializeAws_json1_1JobResource(output.Resources, context)
         : undefined,
-    RoleARN: output.RoleARN !== undefined && output.RoleARN !== null ? output.RoleARN : undefined,
-    ShippingOption:
-      output.ShippingOption !== undefined && output.ShippingOption !== null ? output.ShippingOption : undefined,
-    SnowballType: output.SnowballType !== undefined && output.SnowballType !== null ? output.SnowballType : undefined,
+    RoleARN: __expectString(output.RoleARN),
+    ShippingOption: __expectString(output.ShippingOption),
+    SnowballType: __expectString(output.SnowballType),
     TaxDocuments:
       output.TaxDocuments !== undefined && output.TaxDocuments !== null
         ? deserializeAws_json1_1TaxDocuments(output.TaxDocuments, context)
@@ -2809,8 +2806,8 @@ const deserializeAws_json1_1ClusterMetadata = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_1CompatibleImage = (output: any, context: __SerdeContext): CompatibleImage => {
   return {
-    AmiId: output.AmiId !== undefined && output.AmiId !== null ? output.AmiId : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    AmiId: __expectString(output.AmiId),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -2827,27 +2824,26 @@ const deserializeAws_json1_1CompatibleImageList = (output: any, context: __Serde
 
 const deserializeAws_json1_1ConflictException = (output: any, context: __SerdeContext): ConflictException => {
   return {
-    ConflictResource:
-      output.ConflictResource !== undefined && output.ConflictResource !== null ? output.ConflictResource : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    ConflictResource: __expectString(output.ConflictResource),
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1CreateAddressResult = (output: any, context: __SerdeContext): CreateAddressResult => {
   return {
-    AddressId: output.AddressId !== undefined && output.AddressId !== null ? output.AddressId : undefined,
+    AddressId: __expectString(output.AddressId),
   } as any;
 };
 
 const deserializeAws_json1_1CreateClusterResult = (output: any, context: __SerdeContext): CreateClusterResult => {
   return {
-    ClusterId: output.ClusterId !== undefined && output.ClusterId !== null ? output.ClusterId : undefined,
+    ClusterId: __expectString(output.ClusterId),
   } as any;
 };
 
 const deserializeAws_json1_1CreateJobResult = (output: any, context: __SerdeContext): CreateJobResult => {
   return {
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
+    JobId: __expectString(output.JobId),
   } as any;
 };
 
@@ -2856,10 +2852,7 @@ const deserializeAws_json1_1CreateLongTermPricingResult = (
   context: __SerdeContext
 ): CreateLongTermPricingResult => {
   return {
-    LongTermPricingId:
-      output.LongTermPricingId !== undefined && output.LongTermPricingId !== null
-        ? output.LongTermPricingId
-        : undefined,
+    LongTermPricingId: __expectString(output.LongTermPricingId),
   } as any;
 };
 
@@ -2868,20 +2861,16 @@ const deserializeAws_json1_1CreateReturnShippingLabelResult = (
   context: __SerdeContext
 ): CreateReturnShippingLabelResult => {
   return {
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
 const deserializeAws_json1_1DataTransfer = (output: any, context: __SerdeContext): DataTransfer => {
   return {
-    BytesTransferred:
-      output.BytesTransferred !== undefined && output.BytesTransferred !== null ? output.BytesTransferred : undefined,
-    ObjectsTransferred:
-      output.ObjectsTransferred !== undefined && output.ObjectsTransferred !== null
-        ? output.ObjectsTransferred
-        : undefined,
-    TotalBytes: output.TotalBytes !== undefined && output.TotalBytes !== null ? output.TotalBytes : undefined,
-    TotalObjects: output.TotalObjects !== undefined && output.TotalObjects !== null ? output.TotalObjects : undefined,
+    BytesTransferred: __expectNumber(output.BytesTransferred),
+    ObjectsTransferred: __expectNumber(output.ObjectsTransferred),
+    TotalBytes: __expectNumber(output.TotalBytes),
+    TotalObjects: __expectNumber(output.TotalObjects),
   } as any;
 };
 
@@ -2894,7 +2883,7 @@ const deserializeAws_json1_1DescribeAddressesResult = (
       output.Addresses !== undefined && output.Addresses !== null
         ? deserializeAws_json1_1AddressList(output.Addresses, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -2938,7 +2927,7 @@ const deserializeAws_json1_1DescribeReturnShippingLabelResult = (
       output.ExpirationDate !== undefined && output.ExpirationDate !== null
         ? new Date(Math.round(output.ExpirationDate * 1000))
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -2953,9 +2942,8 @@ const deserializeAws_json1_1DeviceConfiguration = (output: any, context: __Serde
 
 const deserializeAws_json1_1Ec2AmiResource = (output: any, context: __SerdeContext): Ec2AmiResource => {
   return {
-    AmiId: output.AmiId !== undefined && output.AmiId !== null ? output.AmiId : undefined,
-    SnowballAmiId:
-      output.SnowballAmiId !== undefined && output.SnowballAmiId !== null ? output.SnowballAmiId : undefined,
+    AmiId: __expectString(output.AmiId),
+    SnowballAmiId: __expectString(output.SnowballAmiId),
   } as any;
 };
 
@@ -2975,14 +2963,13 @@ const deserializeAws_json1_1Ec2RequestFailedException = (
   context: __SerdeContext
 ): Ec2RequestFailedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1EventTriggerDefinition = (output: any, context: __SerdeContext): EventTriggerDefinition => {
   return {
-    EventResourceARN:
-      output.EventResourceARN !== undefined && output.EventResourceARN !== null ? output.EventResourceARN : undefined,
+    EventResourceARN: __expectString(output.EventResourceARN),
   } as any;
 };
 
@@ -3002,22 +2989,20 @@ const deserializeAws_json1_1EventTriggerDefinitionList = (
 
 const deserializeAws_json1_1GetJobManifestResult = (output: any, context: __SerdeContext): GetJobManifestResult => {
   return {
-    ManifestURI: output.ManifestURI !== undefined && output.ManifestURI !== null ? output.ManifestURI : undefined,
+    ManifestURI: __expectString(output.ManifestURI),
   } as any;
 };
 
 const deserializeAws_json1_1GetJobUnlockCodeResult = (output: any, context: __SerdeContext): GetJobUnlockCodeResult => {
   return {
-    UnlockCode: output.UnlockCode !== undefined && output.UnlockCode !== null ? output.UnlockCode : undefined,
+    UnlockCode: __expectString(output.UnlockCode),
   } as any;
 };
 
 const deserializeAws_json1_1GetSnowballUsageResult = (output: any, context: __SerdeContext): GetSnowballUsageResult => {
   return {
-    SnowballLimit:
-      output.SnowballLimit !== undefined && output.SnowballLimit !== null ? output.SnowballLimit : undefined,
-    SnowballsInUse:
-      output.SnowballsInUse !== undefined && output.SnowballsInUse !== null ? output.SnowballsInUse : undefined,
+    SnowballLimit: __expectNumber(output.SnowballLimit),
+    SnowballsInUse: __expectNumber(output.SnowballsInUse),
   } as any;
 };
 
@@ -3026,13 +3011,13 @@ const deserializeAws_json1_1GetSoftwareUpdatesResult = (
   context: __SerdeContext
 ): GetSoftwareUpdatesResult => {
   return {
-    UpdatesURI: output.UpdatesURI !== undefined && output.UpdatesURI !== null ? output.UpdatesURI : undefined,
+    UpdatesURI: __expectString(output.UpdatesURI),
   } as any;
 };
 
 const deserializeAws_json1_1INDTaxDocuments = (output: any, context: __SerdeContext): INDTaxDocuments => {
   return {
-    GSTIN: output.GSTIN !== undefined && output.GSTIN !== null ? output.GSTIN : undefined,
+    GSTIN: __expectString(output.GSTIN),
   } as any;
 };
 
@@ -3041,7 +3026,7 @@ const deserializeAws_json1_1InvalidAddressException = (
   context: __SerdeContext
 ): InvalidAddressException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3050,7 +3035,7 @@ const deserializeAws_json1_1InvalidInputCombinationException = (
   context: __SerdeContext
 ): InvalidInputCombinationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3059,7 +3044,7 @@ const deserializeAws_json1_1InvalidJobStateException = (
   context: __SerdeContext
 ): InvalidJobStateException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3068,7 +3053,7 @@ const deserializeAws_json1_1InvalidNextTokenException = (
   context: __SerdeContext
 ): InvalidNextTokenException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3077,8 +3062,8 @@ const deserializeAws_json1_1InvalidResourceException = (
   context: __SerdeContext
 ): InvalidResourceException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
+    Message: __expectString(output.Message),
+    ResourceType: __expectString(output.ResourceType),
   } as any;
 };
 
@@ -3088,12 +3073,12 @@ const deserializeAws_json1_1JobListEntry = (output: any, context: __SerdeContext
       output.CreationDate !== undefined && output.CreationDate !== null
         ? new Date(Math.round(output.CreationDate * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    IsMaster: output.IsMaster !== undefined && output.IsMaster !== null ? output.IsMaster : undefined,
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
-    JobState: output.JobState !== undefined && output.JobState !== null ? output.JobState : undefined,
-    JobType: output.JobType !== undefined && output.JobType !== null ? output.JobType : undefined,
-    SnowballType: output.SnowballType !== undefined && output.SnowballType !== null ? output.SnowballType : undefined,
+    Description: __expectString(output.Description),
+    IsMaster: __expectBoolean(output.IsMaster),
+    JobId: __expectString(output.JobId),
+    JobState: __expectString(output.JobState),
+    JobType: __expectString(output.JobType),
+    SnowballType: __expectString(output.SnowballType),
   } as any;
 };
 
@@ -3110,21 +3095,16 @@ const deserializeAws_json1_1JobListEntryList = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1JobLogs = (output: any, context: __SerdeContext): JobLogs => {
   return {
-    JobCompletionReportURI:
-      output.JobCompletionReportURI !== undefined && output.JobCompletionReportURI !== null
-        ? output.JobCompletionReportURI
-        : undefined,
-    JobFailureLogURI:
-      output.JobFailureLogURI !== undefined && output.JobFailureLogURI !== null ? output.JobFailureLogURI : undefined,
-    JobSuccessLogURI:
-      output.JobSuccessLogURI !== undefined && output.JobSuccessLogURI !== null ? output.JobSuccessLogURI : undefined,
+    JobCompletionReportURI: __expectString(output.JobCompletionReportURI),
+    JobFailureLogURI: __expectString(output.JobFailureLogURI),
+    JobSuccessLogURI: __expectString(output.JobSuccessLogURI),
   } as any;
 };
 
 const deserializeAws_json1_1JobMetadata = (output: any, context: __SerdeContext): JobMetadata => {
   return {
-    AddressId: output.AddressId !== undefined && output.AddressId !== null ? output.AddressId : undefined,
-    ClusterId: output.ClusterId !== undefined && output.ClusterId !== null ? output.ClusterId : undefined,
+    AddressId: __expectString(output.AddressId),
+    ClusterId: __expectString(output.ClusterId),
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
         ? new Date(Math.round(output.CreationDate * 1000))
@@ -3133,27 +3113,21 @@ const deserializeAws_json1_1JobMetadata = (output: any, context: __SerdeContext)
       output.DataTransferProgress !== undefined && output.DataTransferProgress !== null
         ? deserializeAws_json1_1DataTransfer(output.DataTransferProgress, context)
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     DeviceConfiguration:
       output.DeviceConfiguration !== undefined && output.DeviceConfiguration !== null
         ? deserializeAws_json1_1DeviceConfiguration(output.DeviceConfiguration, context)
         : undefined,
-    ForwardingAddressId:
-      output.ForwardingAddressId !== undefined && output.ForwardingAddressId !== null
-        ? output.ForwardingAddressId
-        : undefined,
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
+    ForwardingAddressId: __expectString(output.ForwardingAddressId),
+    JobId: __expectString(output.JobId),
     JobLogInfo:
       output.JobLogInfo !== undefined && output.JobLogInfo !== null
         ? deserializeAws_json1_1JobLogs(output.JobLogInfo, context)
         : undefined,
-    JobState: output.JobState !== undefined && output.JobState !== null ? output.JobState : undefined,
-    JobType: output.JobType !== undefined && output.JobType !== null ? output.JobType : undefined,
-    KmsKeyARN: output.KmsKeyARN !== undefined && output.KmsKeyARN !== null ? output.KmsKeyARN : undefined,
-    LongTermPricingId:
-      output.LongTermPricingId !== undefined && output.LongTermPricingId !== null
-        ? output.LongTermPricingId
-        : undefined,
+    JobState: __expectString(output.JobState),
+    JobType: __expectString(output.JobType),
+    KmsKeyARN: __expectString(output.KmsKeyARN),
+    LongTermPricingId: __expectString(output.LongTermPricingId),
     Notification:
       output.Notification !== undefined && output.Notification !== null
         ? deserializeAws_json1_1Notification(output.Notification, context)
@@ -3162,16 +3136,13 @@ const deserializeAws_json1_1JobMetadata = (output: any, context: __SerdeContext)
       output.Resources !== undefined && output.Resources !== null
         ? deserializeAws_json1_1JobResource(output.Resources, context)
         : undefined,
-    RoleARN: output.RoleARN !== undefined && output.RoleARN !== null ? output.RoleARN : undefined,
+    RoleARN: __expectString(output.RoleARN),
     ShippingDetails:
       output.ShippingDetails !== undefined && output.ShippingDetails !== null
         ? deserializeAws_json1_1ShippingDetails(output.ShippingDetails, context)
         : undefined,
-    SnowballCapacityPreference:
-      output.SnowballCapacityPreference !== undefined && output.SnowballCapacityPreference !== null
-        ? output.SnowballCapacityPreference
-        : undefined,
-    SnowballType: output.SnowballType !== undefined && output.SnowballType !== null ? output.SnowballType : undefined,
+    SnowballCapacityPreference: __expectString(output.SnowballCapacityPreference),
+    SnowballType: __expectString(output.SnowballType),
     TaxDocuments:
       output.TaxDocuments !== undefined && output.TaxDocuments !== null
         ? deserializeAws_json1_1TaxDocuments(output.TaxDocuments, context)
@@ -3214,14 +3185,14 @@ const deserializeAws_json1_1JobStateList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1KeyRange = (output: any, context: __SerdeContext): KeyRange => {
   return {
-    BeginMarker: output.BeginMarker !== undefined && output.BeginMarker !== null ? output.BeginMarker : undefined,
-    EndMarker: output.EndMarker !== undefined && output.EndMarker !== null ? output.EndMarker : undefined,
+    BeginMarker: __expectString(output.BeginMarker),
+    EndMarker: __expectString(output.EndMarker),
   } as any;
 };
 
@@ -3230,7 +3201,7 @@ const deserializeAws_json1_1KMSRequestFailedException = (
   context: __SerdeContext
 ): KMSRequestFailedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3240,7 +3211,7 @@ const deserializeAws_json1_1LambdaResource = (output: any, context: __SerdeConte
       output.EventTriggers !== undefined && output.EventTriggers !== null
         ? deserializeAws_json1_1EventTriggerDefinitionList(output.EventTriggers, context)
         : undefined,
-    LambdaArn: output.LambdaArn !== undefined && output.LambdaArn !== null ? output.LambdaArn : undefined,
+    LambdaArn: __expectString(output.LambdaArn),
   } as any;
 };
 
@@ -3261,7 +3232,7 @@ const deserializeAws_json1_1ListClusterJobsResult = (output: any, context: __Ser
       output.JobListEntries !== undefined && output.JobListEntries !== null
         ? deserializeAws_json1_1JobListEntryList(output.JobListEntries, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -3271,7 +3242,7 @@ const deserializeAws_json1_1ListClustersResult = (output: any, context: __SerdeC
       output.ClusterListEntries !== undefined && output.ClusterListEntries !== null
         ? deserializeAws_json1_1ClusterListEntryList(output.ClusterListEntries, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -3284,7 +3255,7 @@ const deserializeAws_json1_1ListCompatibleImagesResult = (
       output.CompatibleImages !== undefined && output.CompatibleImages !== null
         ? deserializeAws_json1_1CompatibleImageList(output.CompatibleImages, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -3294,7 +3265,7 @@ const deserializeAws_json1_1ListJobsResult = (output: any, context: __SerdeConte
       output.JobListEntries !== undefined && output.JobListEntries !== null
         ? deserializeAws_json1_1JobListEntryList(output.JobListEntries, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -3307,7 +3278,7 @@ const deserializeAws_json1_1ListLongTermPricingResult = (
       output.LongTermPricingEntries !== undefined && output.LongTermPricingEntries !== null
         ? deserializeAws_json1_1LongTermPricingEntryList(output.LongTermPricingEntries, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -3318,7 +3289,7 @@ const deserializeAws_json1_1LongTermPricingAssociatedJobIdList = (output: any, c
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3341,12 +3312,8 @@ const deserializeAws_json1_1LongTermPricingListEntry = (
   context: __SerdeContext
 ): LongTermPricingListEntry => {
   return {
-    CurrentActiveJob:
-      output.CurrentActiveJob !== undefined && output.CurrentActiveJob !== null ? output.CurrentActiveJob : undefined,
-    IsLongTermPricingAutoRenew:
-      output.IsLongTermPricingAutoRenew !== undefined && output.IsLongTermPricingAutoRenew !== null
-        ? output.IsLongTermPricingAutoRenew
-        : undefined,
+    CurrentActiveJob: __expectString(output.CurrentActiveJob),
+    IsLongTermPricingAutoRenew: __expectBoolean(output.IsLongTermPricingAutoRenew),
     JobIds:
       output.JobIds !== undefined && output.JobIds !== null
         ? deserializeAws_json1_1LongTermPricingAssociatedJobIdList(output.JobIds, context)
@@ -3355,25 +3322,15 @@ const deserializeAws_json1_1LongTermPricingListEntry = (
       output.LongTermPricingEndDate !== undefined && output.LongTermPricingEndDate !== null
         ? new Date(Math.round(output.LongTermPricingEndDate * 1000))
         : undefined,
-    LongTermPricingId:
-      output.LongTermPricingId !== undefined && output.LongTermPricingId !== null
-        ? output.LongTermPricingId
-        : undefined,
+    LongTermPricingId: __expectString(output.LongTermPricingId),
     LongTermPricingStartDate:
       output.LongTermPricingStartDate !== undefined && output.LongTermPricingStartDate !== null
         ? new Date(Math.round(output.LongTermPricingStartDate * 1000))
         : undefined,
-    LongTermPricingStatus:
-      output.LongTermPricingStatus !== undefined && output.LongTermPricingStatus !== null
-        ? output.LongTermPricingStatus
-        : undefined,
-    LongTermPricingType:
-      output.LongTermPricingType !== undefined && output.LongTermPricingType !== null
-        ? output.LongTermPricingType
-        : undefined,
-    ReplacementJob:
-      output.ReplacementJob !== undefined && output.ReplacementJob !== null ? output.ReplacementJob : undefined,
-    SnowballType: output.SnowballType !== undefined && output.SnowballType !== null ? output.SnowballType : undefined,
+    LongTermPricingStatus: __expectString(output.LongTermPricingStatus),
+    LongTermPricingType: __expectString(output.LongTermPricingType),
+    ReplacementJob: __expectString(output.ReplacementJob),
+    SnowballType: __expectString(output.SnowballType),
   } as any;
 };
 
@@ -3383,8 +3340,8 @@ const deserializeAws_json1_1Notification = (output: any, context: __SerdeContext
       output.JobStatesToNotify !== undefined && output.JobStatesToNotify !== null
         ? deserializeAws_json1_1JobStateList(output.JobStatesToNotify, context)
         : undefined,
-    NotifyAll: output.NotifyAll !== undefined && output.NotifyAll !== null ? output.NotifyAll : undefined,
-    SnsTopicARN: output.SnsTopicARN !== undefined && output.SnsTopicARN !== null ? output.SnsTopicARN : undefined,
+    NotifyAll: __expectBoolean(output.NotifyAll),
+    SnsTopicARN: __expectString(output.SnsTopicARN),
   } as any;
 };
 
@@ -3393,13 +3350,13 @@ const deserializeAws_json1_1ReturnShippingLabelAlreadyExistsException = (
   context: __SerdeContext
 ): ReturnShippingLabelAlreadyExistsException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1S3Resource = (output: any, context: __SerdeContext): S3Resource => {
   return {
-    BucketArn: output.BucketArn !== undefined && output.BucketArn !== null ? output.BucketArn : undefined,
+    BucketArn: __expectString(output.BucketArn),
     KeyRange:
       output.KeyRange !== undefined && output.KeyRange !== null
         ? deserializeAws_json1_1KeyRange(output.KeyRange, context)
@@ -3420,9 +3377,8 @@ const deserializeAws_json1_1S3ResourceList = (output: any, context: __SerdeConte
 
 const deserializeAws_json1_1Shipment = (output: any, context: __SerdeContext): Shipment => {
   return {
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    TrackingNumber:
-      output.TrackingNumber !== undefined && output.TrackingNumber !== null ? output.TrackingNumber : undefined,
+    Status: __expectString(output.Status),
+    TrackingNumber: __expectString(output.TrackingNumber),
   } as any;
 };
 
@@ -3436,8 +3392,7 @@ const deserializeAws_json1_1ShippingDetails = (output: any, context: __SerdeCont
       output.OutboundShipment !== undefined && output.OutboundShipment !== null
         ? deserializeAws_json1_1Shipment(output.OutboundShipment, context)
         : undefined,
-    ShippingOption:
-      output.ShippingOption !== undefined && output.ShippingOption !== null ? output.ShippingOption : undefined,
+    ShippingOption: __expectString(output.ShippingOption),
   } as any;
 };
 
@@ -3467,7 +3422,7 @@ const deserializeAws_json1_1UnsupportedAddressException = (
   context: __SerdeContext
 ): UnsupportedAddressException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3495,8 +3450,7 @@ const deserializeAws_json1_1UpdateLongTermPricingResult = (
 
 const deserializeAws_json1_1WirelessConnection = (output: any, context: __SerdeContext): WirelessConnection => {
   return {
-    IsWifiEnabled:
-      output.IsWifiEnabled !== undefined && output.IsWifiEnabled !== null ? output.IsWifiEnabled : undefined,
+    IsWifiEnabled: __expectBoolean(output.IsWifiEnabled),
   } as any;
 };
 

--- a/clients/client-sns/protocols/Aws_query.ts
+++ b/clients/client-sns/protocols/Aws_query.ts
@@ -212,6 +212,7 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
@@ -5261,7 +5262,7 @@ const deserializeAws_queryAuthorizationErrorException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -5287,7 +5288,7 @@ const deserializeAws_queryConcurrentAccessException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -5300,7 +5301,7 @@ const deserializeAws_queryConfirmSubscriptionResponse = (
     SubscriptionArn: undefined,
   };
   if (output["SubscriptionArn"] !== undefined) {
-    contents.SubscriptionArn = output["SubscriptionArn"];
+    contents.SubscriptionArn = __expectString(output["SubscriptionArn"]);
   }
   return contents;
 };
@@ -5310,7 +5311,7 @@ const deserializeAws_queryCreateEndpointResponse = (output: any, context: __Serd
     EndpointArn: undefined,
   };
   if (output["EndpointArn"] !== undefined) {
-    contents.EndpointArn = output["EndpointArn"];
+    contents.EndpointArn = __expectString(output["EndpointArn"]);
   }
   return contents;
 };
@@ -5323,7 +5324,7 @@ const deserializeAws_queryCreatePlatformApplicationResponse = (
     PlatformApplicationArn: undefined,
   };
   if (output["PlatformApplicationArn"] !== undefined) {
-    contents.PlatformApplicationArn = output["PlatformApplicationArn"];
+    contents.PlatformApplicationArn = __expectString(output["PlatformApplicationArn"]);
   }
   return contents;
 };
@@ -5341,7 +5342,7 @@ const deserializeAws_queryCreateTopicResponse = (output: any, context: __SerdeCo
     TopicArn: undefined,
   };
   if (output["TopicArn"] !== undefined) {
-    contents.TopicArn = output["TopicArn"];
+    contents.TopicArn = __expectString(output["TopicArn"]);
   }
   return contents;
 };
@@ -5360,7 +5361,7 @@ const deserializeAws_queryEndpoint = (output: any, context: __SerdeContext): End
     Attributes: undefined,
   };
   if (output["EndpointArn"] !== undefined) {
-    contents.EndpointArn = output["EndpointArn"];
+    contents.EndpointArn = __expectString(output["EndpointArn"]);
   }
   if (output.Attributes === "") {
     contents.Attributes = {};
@@ -5382,7 +5383,7 @@ const deserializeAws_queryEndpointDisabledException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -5395,7 +5396,7 @@ const deserializeAws_queryFilterPolicyLimitExceededException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -5513,7 +5514,7 @@ const deserializeAws_queryInternalErrorException = (output: any, context: __Serd
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -5526,7 +5527,7 @@ const deserializeAws_queryInvalidParameterException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -5539,7 +5540,7 @@ const deserializeAws_queryInvalidParameterValueException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -5552,7 +5553,7 @@ const deserializeAws_queryInvalidSecurityException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -5565,7 +5566,7 @@ const deserializeAws_queryKMSAccessDeniedException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -5575,7 +5576,7 @@ const deserializeAws_queryKMSDisabledException = (output: any, context: __SerdeC
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -5588,7 +5589,7 @@ const deserializeAws_queryKMSInvalidStateException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -5598,7 +5599,7 @@ const deserializeAws_queryKMSNotFoundException = (output: any, context: __SerdeC
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -5608,7 +5609,7 @@ const deserializeAws_queryKMSOptInRequired = (output: any, context: __SerdeConte
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -5618,7 +5619,7 @@ const deserializeAws_queryKMSThrottlingException = (output: any, context: __Serd
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -5641,7 +5642,7 @@ const deserializeAws_queryListEndpointsByPlatformApplicationResponse = (
     );
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -5680,7 +5681,7 @@ const deserializeAws_queryListOriginationNumbersResult = (
     PhoneNumbers: undefined,
   };
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   if (output.PhoneNumbers === "") {
     contents.PhoneNumbers = [];
@@ -5712,7 +5713,7 @@ const deserializeAws_queryListPhoneNumbersOptedOutResponse = (
     );
   }
   if (output["nextToken"] !== undefined) {
-    contents.nextToken = output["nextToken"];
+    contents.nextToken = __expectString(output["nextToken"]);
   }
   return contents;
 };
@@ -5735,7 +5736,7 @@ const deserializeAws_queryListPlatformApplicationsResponse = (
     );
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -5758,7 +5759,7 @@ const deserializeAws_queryListSMSSandboxPhoneNumbersResult = (
     );
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -5781,7 +5782,7 @@ const deserializeAws_queryListSubscriptionsByTopicResponse = (
     );
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -5804,7 +5805,7 @@ const deserializeAws_queryListSubscriptionsResponse = (
     );
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -5837,7 +5838,7 @@ const deserializeAws_queryListTopicsResponse = (output: any, context: __SerdeCon
     contents.Topics = deserializeAws_queryTopicsList(__getArrayIfSingleItem(output["Topics"]["member"]), context);
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -5849,7 +5850,7 @@ const deserializeAws_queryMapStringToString = (output: any, context: __SerdeCont
     }
     return {
       ...acc,
-      [pair["key"]]: pair["value"],
+      [pair["key"]]: __expectString(pair["value"]) as any,
     };
   }, {});
 };
@@ -5859,7 +5860,7 @@ const deserializeAws_queryNotFoundException = (output: any, context: __SerdeCont
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -5874,7 +5875,7 @@ const deserializeAws_queryNumberCapabilityList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -5883,7 +5884,7 @@ const deserializeAws_queryOptedOutException = (output: any, context: __SerdeCont
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -5909,16 +5910,16 @@ const deserializeAws_queryPhoneNumberInformation = (output: any, context: __Serd
     contents.CreatedAt = new Date(output["CreatedAt"]);
   }
   if (output["PhoneNumber"] !== undefined) {
-    contents.PhoneNumber = output["PhoneNumber"];
+    contents.PhoneNumber = __expectString(output["PhoneNumber"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   if (output["Iso2CountryCode"] !== undefined) {
-    contents.Iso2CountryCode = output["Iso2CountryCode"];
+    contents.Iso2CountryCode = __expectString(output["Iso2CountryCode"]);
   }
   if (output["RouteType"] !== undefined) {
-    contents.RouteType = output["RouteType"];
+    contents.RouteType = __expectString(output["RouteType"]);
   }
   if (output.NumberCapabilities === "") {
     contents.NumberCapabilities = [];
@@ -5953,7 +5954,7 @@ const deserializeAws_queryPhoneNumberList = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -5963,7 +5964,7 @@ const deserializeAws_queryPlatformApplication = (output: any, context: __SerdeCo
     Attributes: undefined,
   };
   if (output["PlatformApplicationArn"] !== undefined) {
-    contents.PlatformApplicationArn = output["PlatformApplicationArn"];
+    contents.PlatformApplicationArn = __expectString(output["PlatformApplicationArn"]);
   }
   if (output.Attributes === "") {
     contents.Attributes = {};
@@ -5985,7 +5986,7 @@ const deserializeAws_queryPlatformApplicationDisabledException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -5996,10 +5997,10 @@ const deserializeAws_queryPublishResponse = (output: any, context: __SerdeContex
     SequenceNumber: undefined,
   };
   if (output["MessageId"] !== undefined) {
-    contents.MessageId = output["MessageId"];
+    contents.MessageId = __expectString(output["MessageId"]);
   }
   if (output["SequenceNumber"] !== undefined) {
-    contents.SequenceNumber = output["SequenceNumber"];
+    contents.SequenceNumber = __expectString(output["SequenceNumber"]);
   }
   return contents;
 };
@@ -6012,7 +6013,7 @@ const deserializeAws_queryResourceNotFoundException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -6031,10 +6032,10 @@ const deserializeAws_querySMSSandboxPhoneNumber = (output: any, context: __Serde
     Status: undefined,
   };
   if (output["PhoneNumber"] !== undefined) {
-    contents.PhoneNumber = output["PhoneNumber"];
+    contents.PhoneNumber = __expectString(output["PhoneNumber"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   return contents;
 };
@@ -6058,7 +6059,7 @@ const deserializeAws_queryStaleTagException = (output: any, context: __SerdeCont
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -6068,7 +6069,7 @@ const deserializeAws_querySubscribeResponse = (output: any, context: __SerdeCont
     SubscriptionArn: undefined,
   };
   if (output["SubscriptionArn"] !== undefined) {
-    contents.SubscriptionArn = output["SubscriptionArn"];
+    contents.SubscriptionArn = __expectString(output["SubscriptionArn"]);
   }
   return contents;
 };
@@ -6082,19 +6083,19 @@ const deserializeAws_querySubscription = (output: any, context: __SerdeContext):
     TopicArn: undefined,
   };
   if (output["SubscriptionArn"] !== undefined) {
-    contents.SubscriptionArn = output["SubscriptionArn"];
+    contents.SubscriptionArn = __expectString(output["SubscriptionArn"]);
   }
   if (output["Owner"] !== undefined) {
-    contents.Owner = output["Owner"];
+    contents.Owner = __expectString(output["Owner"]);
   }
   if (output["Protocol"] !== undefined) {
-    contents.Protocol = output["Protocol"];
+    contents.Protocol = __expectString(output["Protocol"]);
   }
   if (output["Endpoint"] !== undefined) {
-    contents.Endpoint = output["Endpoint"];
+    contents.Endpoint = __expectString(output["Endpoint"]);
   }
   if (output["TopicArn"] !== undefined) {
-    contents.TopicArn = output["TopicArn"];
+    contents.TopicArn = __expectString(output["TopicArn"]);
   }
   return contents;
 };
@@ -6109,7 +6110,7 @@ const deserializeAws_querySubscriptionAttributesMap = (
     }
     return {
       ...acc,
-      [pair["key"]]: pair["value"],
+      [pair["key"]]: __expectString(pair["value"]) as any,
     };
   }, {});
 };
@@ -6122,7 +6123,7 @@ const deserializeAws_querySubscriptionLimitExceededException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -6144,10 +6145,10 @@ const deserializeAws_queryTag = (output: any, context: __SerdeContext): Tag => {
     Value: undefined,
   };
   if (output["Key"] !== undefined) {
-    contents.Key = output["Key"];
+    contents.Key = __expectString(output["Key"]);
   }
   if (output["Value"] !== undefined) {
-    contents.Value = output["Value"];
+    contents.Value = __expectString(output["Value"]);
   }
   return contents;
 };
@@ -6160,7 +6161,7 @@ const deserializeAws_queryTagLimitExceededException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -6181,7 +6182,7 @@ const deserializeAws_queryTagPolicyException = (output: any, context: __SerdeCon
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -6196,7 +6197,7 @@ const deserializeAws_queryThrottledException = (output: any, context: __SerdeCon
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -6206,7 +6207,7 @@ const deserializeAws_queryTopic = (output: any, context: __SerdeContext): Topic 
     TopicArn: undefined,
   };
   if (output["TopicArn"] !== undefined) {
-    contents.TopicArn = output["TopicArn"];
+    contents.TopicArn = __expectString(output["TopicArn"]);
   }
   return contents;
 };
@@ -6218,7 +6219,7 @@ const deserializeAws_queryTopicAttributesMap = (output: any, context: __SerdeCon
     }
     return {
       ...acc,
-      [pair["key"]]: pair["value"],
+      [pair["key"]]: __expectString(pair["value"]) as any,
     };
   }, {});
 };
@@ -6231,7 +6232,7 @@ const deserializeAws_queryTopicLimitExceededException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -6257,7 +6258,7 @@ const deserializeAws_queryUserErrorException = (output: any, context: __SerdeCon
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -6267,7 +6268,7 @@ const deserializeAws_queryValidationException = (output: any, context: __SerdeCo
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -6278,10 +6279,10 @@ const deserializeAws_queryVerificationException = (output: any, context: __Serde
     Status: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   if (output["Status"] !== undefined) {
-    contents.Status = output["Status"];
+    contents.Status = __expectString(output["Status"]);
   }
   return contents;
 };

--- a/clients/client-sqs/protocols/Aws_query.ts
+++ b/clients/client-sqs/protocols/Aws_query.ts
@@ -90,6 +90,7 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
@@ -2495,16 +2496,16 @@ const deserializeAws_queryBatchResultErrorEntry = (output: any, context: __Serde
     Message: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   if (output["SenderFault"] !== undefined) {
     contents.SenderFault = __parseBoolean(output["SenderFault"]);
   }
   if (output["Code"] !== undefined) {
-    contents.Code = output["Code"];
+    contents.Code = __expectString(output["Code"]);
   }
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -2571,7 +2572,7 @@ const deserializeAws_queryChangeMessageVisibilityBatchResultEntry = (
     Id: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   return contents;
 };
@@ -2595,7 +2596,7 @@ const deserializeAws_queryCreateQueueResult = (output: any, context: __SerdeCont
     QueueUrl: undefined,
   };
   if (output["QueueUrl"] !== undefined) {
-    contents.QueueUrl = output["QueueUrl"];
+    contents.QueueUrl = __expectString(output["QueueUrl"]);
   }
   return contents;
 };
@@ -2637,7 +2638,7 @@ const deserializeAws_queryDeleteMessageBatchResultEntry = (
     Id: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   return contents;
 };
@@ -2682,7 +2683,7 @@ const deserializeAws_queryGetQueueUrlResult = (output: any, context: __SerdeCont
     QueueUrl: undefined,
   };
   if (output["QueueUrl"] !== undefined) {
-    contents.QueueUrl = output["QueueUrl"];
+    contents.QueueUrl = __expectString(output["QueueUrl"]);
   }
   return contents;
 };
@@ -2722,7 +2723,7 @@ const deserializeAws_queryListDeadLetterSourceQueuesResult = (
     contents.queueUrls = deserializeAws_queryQueueUrlList(__getArrayIfSingleItem(output["QueueUrl"]), context);
   }
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   return contents;
 };
@@ -2733,7 +2734,7 @@ const deserializeAws_queryListQueuesResult = (output: any, context: __SerdeConte
     QueueUrls: undefined,
   };
   if (output["NextToken"] !== undefined) {
-    contents.NextToken = output["NextToken"];
+    contents.NextToken = __expectString(output["NextToken"]);
   }
   if (output.QueueUrl === "") {
     contents.QueueUrls = [];
@@ -2768,16 +2769,16 @@ const deserializeAws_queryMessage = (output: any, context: __SerdeContext): Mess
     MessageAttributes: undefined,
   };
   if (output["MessageId"] !== undefined) {
-    contents.MessageId = output["MessageId"];
+    contents.MessageId = __expectString(output["MessageId"]);
   }
   if (output["ReceiptHandle"] !== undefined) {
-    contents.ReceiptHandle = output["ReceiptHandle"];
+    contents.ReceiptHandle = __expectString(output["ReceiptHandle"]);
   }
   if (output["MD5OfBody"] !== undefined) {
-    contents.MD5OfBody = output["MD5OfBody"];
+    contents.MD5OfBody = __expectString(output["MD5OfBody"]);
   }
   if (output["Body"] !== undefined) {
-    contents.Body = output["Body"];
+    contents.Body = __expectString(output["Body"]);
   }
   if (output.Attribute === "") {
     contents.Attributes = {};
@@ -2789,7 +2790,7 @@ const deserializeAws_queryMessage = (output: any, context: __SerdeContext): Mess
     );
   }
   if (output["MD5OfMessageAttributes"] !== undefined) {
-    contents.MD5OfMessageAttributes = output["MD5OfMessageAttributes"];
+    contents.MD5OfMessageAttributes = __expectString(output["MD5OfMessageAttributes"]);
   }
   if (output.MessageAttribute === "") {
     contents.MessageAttributes = {};
@@ -2812,7 +2813,7 @@ const deserializeAws_queryMessageAttributeValue = (output: any, context: __Serde
     DataType: undefined,
   };
   if (output["StringValue"] !== undefined) {
-    contents.StringValue = output["StringValue"];
+    contents.StringValue = __expectString(output["StringValue"]);
   }
   if (output["BinaryValue"] !== undefined) {
     contents.BinaryValue = context.base64Decoder(output["BinaryValue"]);
@@ -2836,7 +2837,7 @@ const deserializeAws_queryMessageAttributeValue = (output: any, context: __Serde
     );
   }
   if (output["DataType"] !== undefined) {
-    contents.DataType = output["DataType"];
+    contents.DataType = __expectString(output["DataType"]);
   }
   return contents;
 };
@@ -2882,7 +2883,7 @@ const deserializeAws_queryMessageSystemAttributeMap = (
     }
     return {
       ...acc,
-      [pair["Name"]]: pair["Value"],
+      [pair["Name"]]: __expectString(pair["Value"]) as any,
     };
   }, {});
 };
@@ -2904,7 +2905,7 @@ const deserializeAws_queryQueueAttributeMap = (output: any, context: __SerdeCont
     }
     return {
       ...acc,
-      [pair["Name"]]: pair["Value"],
+      [pair["Name"]]: __expectString(pair["Value"]) as any,
     };
   }, {});
 };
@@ -2931,7 +2932,7 @@ const deserializeAws_queryQueueUrlList = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2992,22 +2993,22 @@ const deserializeAws_querySendMessageBatchResultEntry = (
     SequenceNumber: undefined,
   };
   if (output["Id"] !== undefined) {
-    contents.Id = output["Id"];
+    contents.Id = __expectString(output["Id"]);
   }
   if (output["MessageId"] !== undefined) {
-    contents.MessageId = output["MessageId"];
+    contents.MessageId = __expectString(output["MessageId"]);
   }
   if (output["MD5OfMessageBody"] !== undefined) {
-    contents.MD5OfMessageBody = output["MD5OfMessageBody"];
+    contents.MD5OfMessageBody = __expectString(output["MD5OfMessageBody"]);
   }
   if (output["MD5OfMessageAttributes"] !== undefined) {
-    contents.MD5OfMessageAttributes = output["MD5OfMessageAttributes"];
+    contents.MD5OfMessageAttributes = __expectString(output["MD5OfMessageAttributes"]);
   }
   if (output["MD5OfMessageSystemAttributes"] !== undefined) {
-    contents.MD5OfMessageSystemAttributes = output["MD5OfMessageSystemAttributes"];
+    contents.MD5OfMessageSystemAttributes = __expectString(output["MD5OfMessageSystemAttributes"]);
   }
   if (output["SequenceNumber"] !== undefined) {
-    contents.SequenceNumber = output["SequenceNumber"];
+    contents.SequenceNumber = __expectString(output["SequenceNumber"]);
   }
   return contents;
 };
@@ -3035,19 +3036,19 @@ const deserializeAws_querySendMessageResult = (output: any, context: __SerdeCont
     SequenceNumber: undefined,
   };
   if (output["MD5OfMessageBody"] !== undefined) {
-    contents.MD5OfMessageBody = output["MD5OfMessageBody"];
+    contents.MD5OfMessageBody = __expectString(output["MD5OfMessageBody"]);
   }
   if (output["MD5OfMessageAttributes"] !== undefined) {
-    contents.MD5OfMessageAttributes = output["MD5OfMessageAttributes"];
+    contents.MD5OfMessageAttributes = __expectString(output["MD5OfMessageAttributes"]);
   }
   if (output["MD5OfMessageSystemAttributes"] !== undefined) {
-    contents.MD5OfMessageSystemAttributes = output["MD5OfMessageSystemAttributes"];
+    contents.MD5OfMessageSystemAttributes = __expectString(output["MD5OfMessageSystemAttributes"]);
   }
   if (output["MessageId"] !== undefined) {
-    contents.MessageId = output["MessageId"];
+    contents.MessageId = __expectString(output["MessageId"]);
   }
   if (output["SequenceNumber"] !== undefined) {
-    contents.SequenceNumber = output["SequenceNumber"];
+    contents.SequenceNumber = __expectString(output["SequenceNumber"]);
   }
   return contents;
 };
@@ -3059,7 +3060,7 @@ const deserializeAws_queryStringList = (output: any, context: __SerdeContext): s
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3070,7 +3071,7 @@ const deserializeAws_queryTagMap = (output: any, context: __SerdeContext): { [ke
     }
     return {
       ...acc,
-      [pair["Key"]]: pair["Value"],
+      [pair["Key"]]: __expectString(pair["Value"]) as any,
     };
   }, {});
 };

--- a/clients/client-ssm-contacts/protocols/Aws_json1_1.ts
+++ b/clients/client-ssm-contacts/protocols/Aws_json1_1.ts
@@ -128,7 +128,12 @@ import {
   ValidationExceptionField,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -3405,7 +3410,7 @@ const deserializeAws_json1_1AcceptPageResult = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1AccessDeniedException = (output: any, context: __SerdeContext): AccessDeniedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3418,54 +3423,45 @@ const deserializeAws_json1_1ActivateContactChannelResult = (
 
 const deserializeAws_json1_1ChannelTargetInfo = (output: any, context: __SerdeContext): ChannelTargetInfo => {
   return {
-    ContactChannelId:
-      output.ContactChannelId !== undefined && output.ContactChannelId !== null ? output.ContactChannelId : undefined,
-    RetryIntervalInMinutes:
-      output.RetryIntervalInMinutes !== undefined && output.RetryIntervalInMinutes !== null
-        ? output.RetryIntervalInMinutes
-        : undefined,
+    ContactChannelId: __expectString(output.ContactChannelId),
+    RetryIntervalInMinutes: __expectNumber(output.RetryIntervalInMinutes),
   } as any;
 };
 
 const deserializeAws_json1_1ConflictException = (output: any, context: __SerdeContext): ConflictException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    ResourceId: output.ResourceId !== undefined && output.ResourceId !== null ? output.ResourceId : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
+    Message: __expectString(output.Message),
+    ResourceId: __expectString(output.ResourceId),
+    ResourceType: __expectString(output.ResourceType),
   } as any;
 };
 
 const deserializeAws_json1_1Contact = (output: any, context: __SerdeContext): Contact => {
   return {
-    Alias: output.Alias !== undefined && output.Alias !== null ? output.Alias : undefined,
-    ContactArn: output.ContactArn !== undefined && output.ContactArn !== null ? output.ContactArn : undefined,
-    DisplayName: output.DisplayName !== undefined && output.DisplayName !== null ? output.DisplayName : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Alias: __expectString(output.Alias),
+    ContactArn: __expectString(output.ContactArn),
+    DisplayName: __expectString(output.DisplayName),
+    Type: __expectString(output.Type),
   } as any;
 };
 
 const deserializeAws_json1_1ContactChannel = (output: any, context: __SerdeContext): ContactChannel => {
   return {
-    ActivationStatus:
-      output.ActivationStatus !== undefined && output.ActivationStatus !== null ? output.ActivationStatus : undefined,
-    ContactArn: output.ContactArn !== undefined && output.ContactArn !== null ? output.ContactArn : undefined,
-    ContactChannelArn:
-      output.ContactChannelArn !== undefined && output.ContactChannelArn !== null
-        ? output.ContactChannelArn
-        : undefined,
+    ActivationStatus: __expectString(output.ActivationStatus),
+    ContactArn: __expectString(output.ContactArn),
+    ContactChannelArn: __expectString(output.ContactChannelArn),
     DeliveryAddress:
       output.DeliveryAddress !== undefined && output.DeliveryAddress !== null
         ? deserializeAws_json1_1ContactChannelAddress(output.DeliveryAddress, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Name: __expectString(output.Name),
+    Type: __expectString(output.Type),
   } as any;
 };
 
 const deserializeAws_json1_1ContactChannelAddress = (output: any, context: __SerdeContext): ContactChannelAddress => {
   return {
-    SimpleAddress:
-      output.SimpleAddress !== undefined && output.SimpleAddress !== null ? output.SimpleAddress : undefined,
+    SimpleAddress: __expectString(output.SimpleAddress),
   } as any;
 };
 
@@ -3493,8 +3489,8 @@ const deserializeAws_json1_1ContactsList = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_1ContactTargetInfo = (output: any, context: __SerdeContext): ContactTargetInfo => {
   return {
-    ContactId: output.ContactId !== undefined && output.ContactId !== null ? output.ContactId : undefined,
-    IsEssential: output.IsEssential !== undefined && output.IsEssential !== null ? output.IsEssential : undefined,
+    ContactId: __expectString(output.ContactId),
+    IsEssential: __expectBoolean(output.IsEssential),
   } as any;
 };
 
@@ -3503,16 +3499,13 @@ const deserializeAws_json1_1CreateContactChannelResult = (
   context: __SerdeContext
 ): CreateContactChannelResult => {
   return {
-    ContactChannelArn:
-      output.ContactChannelArn !== undefined && output.ContactChannelArn !== null
-        ? output.ContactChannelArn
-        : undefined,
+    ContactChannelArn: __expectString(output.ContactChannelArn),
   } as any;
 };
 
 const deserializeAws_json1_1CreateContactResult = (output: any, context: __SerdeContext): CreateContactResult => {
   return {
-    ContactArn: output.ContactArn !== undefined && output.ContactArn !== null ? output.ContactArn : undefined,
+    ContactArn: __expectString(output.ContactArn),
   } as any;
 };
 
@@ -3521,7 +3514,7 @@ const deserializeAws_json1_1DataEncryptionException = (
   context: __SerdeContext
 ): DataEncryptionException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3548,16 +3541,13 @@ const deserializeAws_json1_1DescribeEngagementResult = (
   context: __SerdeContext
 ): DescribeEngagementResult => {
   return {
-    ContactArn: output.ContactArn !== undefined && output.ContactArn !== null ? output.ContactArn : undefined,
-    Content: output.Content !== undefined && output.Content !== null ? output.Content : undefined,
-    EngagementArn:
-      output.EngagementArn !== undefined && output.EngagementArn !== null ? output.EngagementArn : undefined,
-    IncidentId: output.IncidentId !== undefined && output.IncidentId !== null ? output.IncidentId : undefined,
-    PublicContent:
-      output.PublicContent !== undefined && output.PublicContent !== null ? output.PublicContent : undefined,
-    PublicSubject:
-      output.PublicSubject !== undefined && output.PublicSubject !== null ? output.PublicSubject : undefined,
-    Sender: output.Sender !== undefined && output.Sender !== null ? output.Sender : undefined,
+    ContactArn: __expectString(output.ContactArn),
+    Content: __expectString(output.Content),
+    EngagementArn: __expectString(output.EngagementArn),
+    IncidentId: __expectString(output.IncidentId),
+    PublicContent: __expectString(output.PublicContent),
+    PublicSubject: __expectString(output.PublicSubject),
+    Sender: __expectString(output.Sender),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
         ? new Date(Math.round(output.StartTime * 1000))
@@ -3566,46 +3556,42 @@ const deserializeAws_json1_1DescribeEngagementResult = (
       output.StopTime !== undefined && output.StopTime !== null
         ? new Date(Math.round(output.StopTime * 1000))
         : undefined,
-    Subject: output.Subject !== undefined && output.Subject !== null ? output.Subject : undefined,
+    Subject: __expectString(output.Subject),
   } as any;
 };
 
 const deserializeAws_json1_1DescribePageResult = (output: any, context: __SerdeContext): DescribePageResult => {
   return {
-    ContactArn: output.ContactArn !== undefined && output.ContactArn !== null ? output.ContactArn : undefined,
-    Content: output.Content !== undefined && output.Content !== null ? output.Content : undefined,
+    ContactArn: __expectString(output.ContactArn),
+    Content: __expectString(output.Content),
     DeliveryTime:
       output.DeliveryTime !== undefined && output.DeliveryTime !== null
         ? new Date(Math.round(output.DeliveryTime * 1000))
         : undefined,
-    EngagementArn:
-      output.EngagementArn !== undefined && output.EngagementArn !== null ? output.EngagementArn : undefined,
-    IncidentId: output.IncidentId !== undefined && output.IncidentId !== null ? output.IncidentId : undefined,
-    PageArn: output.PageArn !== undefined && output.PageArn !== null ? output.PageArn : undefined,
-    PublicContent:
-      output.PublicContent !== undefined && output.PublicContent !== null ? output.PublicContent : undefined,
-    PublicSubject:
-      output.PublicSubject !== undefined && output.PublicSubject !== null ? output.PublicSubject : undefined,
+    EngagementArn: __expectString(output.EngagementArn),
+    IncidentId: __expectString(output.IncidentId),
+    PageArn: __expectString(output.PageArn),
+    PublicContent: __expectString(output.PublicContent),
+    PublicSubject: __expectString(output.PublicSubject),
     ReadTime:
       output.ReadTime !== undefined && output.ReadTime !== null
         ? new Date(Math.round(output.ReadTime * 1000))
         : undefined,
-    Sender: output.Sender !== undefined && output.Sender !== null ? output.Sender : undefined,
+    Sender: __expectString(output.Sender),
     SentTime:
       output.SentTime !== undefined && output.SentTime !== null
         ? new Date(Math.round(output.SentTime * 1000))
         : undefined,
-    Subject: output.Subject !== undefined && output.Subject !== null ? output.Subject : undefined,
+    Subject: __expectString(output.Subject),
   } as any;
 };
 
 const deserializeAws_json1_1Engagement = (output: any, context: __SerdeContext): Engagement => {
   return {
-    ContactArn: output.ContactArn !== undefined && output.ContactArn !== null ? output.ContactArn : undefined,
-    EngagementArn:
-      output.EngagementArn !== undefined && output.EngagementArn !== null ? output.EngagementArn : undefined,
-    IncidentId: output.IncidentId !== undefined && output.IncidentId !== null ? output.IncidentId : undefined,
-    Sender: output.Sender !== undefined && output.Sender !== null ? output.Sender : undefined,
+    ContactArn: __expectString(output.ContactArn),
+    EngagementArn: __expectString(output.EngagementArn),
+    IncidentId: __expectString(output.IncidentId),
+    Sender: __expectString(output.Sender),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
         ? new Date(Math.round(output.StartTime * 1000))
@@ -3633,37 +3619,33 @@ const deserializeAws_json1_1GetContactChannelResult = (
   context: __SerdeContext
 ): GetContactChannelResult => {
   return {
-    ActivationStatus:
-      output.ActivationStatus !== undefined && output.ActivationStatus !== null ? output.ActivationStatus : undefined,
-    ContactArn: output.ContactArn !== undefined && output.ContactArn !== null ? output.ContactArn : undefined,
-    ContactChannelArn:
-      output.ContactChannelArn !== undefined && output.ContactChannelArn !== null
-        ? output.ContactChannelArn
-        : undefined,
+    ActivationStatus: __expectString(output.ActivationStatus),
+    ContactArn: __expectString(output.ContactArn),
+    ContactChannelArn: __expectString(output.ContactChannelArn),
     DeliveryAddress:
       output.DeliveryAddress !== undefined && output.DeliveryAddress !== null
         ? deserializeAws_json1_1ContactChannelAddress(output.DeliveryAddress, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Name: __expectString(output.Name),
+    Type: __expectString(output.Type),
   } as any;
 };
 
 const deserializeAws_json1_1GetContactPolicyResult = (output: any, context: __SerdeContext): GetContactPolicyResult => {
   return {
-    ContactArn: output.ContactArn !== undefined && output.ContactArn !== null ? output.ContactArn : undefined,
-    Policy: output.Policy !== undefined && output.Policy !== null ? output.Policy : undefined,
+    ContactArn: __expectString(output.ContactArn),
+    Policy: __expectString(output.Policy),
   } as any;
 };
 
 const deserializeAws_json1_1GetContactResult = (output: any, context: __SerdeContext): GetContactResult => {
   return {
-    Alias: output.Alias !== undefined && output.Alias !== null ? output.Alias : undefined,
-    ContactArn: output.ContactArn !== undefined && output.ContactArn !== null ? output.ContactArn : undefined,
-    DisplayName: output.DisplayName !== undefined && output.DisplayName !== null ? output.DisplayName : undefined,
+    Alias: __expectString(output.Alias),
+    ContactArn: __expectString(output.ContactArn),
+    DisplayName: __expectString(output.DisplayName),
     Plan:
       output.Plan !== undefined && output.Plan !== null ? deserializeAws_json1_1Plan(output.Plan, context) : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -3672,11 +3654,8 @@ const deserializeAws_json1_1InternalServerException = (
   context: __SerdeContext
 ): InternalServerException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RetryAfterSeconds:
-      output.RetryAfterSeconds !== undefined && output.RetryAfterSeconds !== null
-        ? output.RetryAfterSeconds
-        : undefined,
+    Message: __expectString(output.Message),
+    RetryAfterSeconds: __expectNumber(output.RetryAfterSeconds),
   } as any;
 };
 
@@ -3689,7 +3668,7 @@ const deserializeAws_json1_1ListContactChannelsResult = (
       output.ContactChannels !== undefined && output.ContactChannels !== null
         ? deserializeAws_json1_1ContactChannelList(output.ContactChannels, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -3699,7 +3678,7 @@ const deserializeAws_json1_1ListContactsResult = (output: any, context: __SerdeC
       output.Contacts !== undefined && output.Contacts !== null
         ? deserializeAws_json1_1ContactsList(output.Contacts, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -3709,13 +3688,13 @@ const deserializeAws_json1_1ListEngagementsResult = (output: any, context: __Ser
       output.Engagements !== undefined && output.Engagements !== null
         ? deserializeAws_json1_1EngagementsList(output.Engagements, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
 const deserializeAws_json1_1ListPageReceiptsResult = (output: any, context: __SerdeContext): ListPageReceiptsResult => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Receipts:
       output.Receipts !== undefined && output.Receipts !== null
         ? deserializeAws_json1_1ReceiptsList(output.Receipts, context)
@@ -3728,7 +3707,7 @@ const deserializeAws_json1_1ListPagesByContactResult = (
   context: __SerdeContext
 ): ListPagesByContactResult => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Pages:
       output.Pages !== undefined && output.Pages !== null
         ? deserializeAws_json1_1PagesList(output.Pages, context)
@@ -3741,7 +3720,7 @@ const deserializeAws_json1_1ListPagesByEngagementResult = (
   context: __SerdeContext
 ): ListPagesByEngagementResult => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Pages:
       output.Pages !== undefined && output.Pages !== null
         ? deserializeAws_json1_1PagesList(output.Pages, context)
@@ -3763,20 +3742,19 @@ const deserializeAws_json1_1ListTagsForResourceResult = (
 
 const deserializeAws_json1_1Page = (output: any, context: __SerdeContext): Page => {
   return {
-    ContactArn: output.ContactArn !== undefined && output.ContactArn !== null ? output.ContactArn : undefined,
+    ContactArn: __expectString(output.ContactArn),
     DeliveryTime:
       output.DeliveryTime !== undefined && output.DeliveryTime !== null
         ? new Date(Math.round(output.DeliveryTime * 1000))
         : undefined,
-    EngagementArn:
-      output.EngagementArn !== undefined && output.EngagementArn !== null ? output.EngagementArn : undefined,
-    IncidentId: output.IncidentId !== undefined && output.IncidentId !== null ? output.IncidentId : undefined,
-    PageArn: output.PageArn !== undefined && output.PageArn !== null ? output.PageArn : undefined,
+    EngagementArn: __expectString(output.EngagementArn),
+    IncidentId: __expectString(output.IncidentId),
+    PageArn: __expectString(output.PageArn),
     ReadTime:
       output.ReadTime !== undefined && output.ReadTime !== null
         ? new Date(Math.round(output.ReadTime * 1000))
         : undefined,
-    Sender: output.Sender !== undefined && output.Sender !== null ? output.Sender : undefined,
+    Sender: __expectString(output.Sender),
     SentTime:
       output.SentTime !== undefined && output.SentTime !== null
         ? new Date(Math.round(output.SentTime * 1000))
@@ -3810,16 +3788,13 @@ const deserializeAws_json1_1PutContactPolicyResult = (output: any, context: __Se
 
 const deserializeAws_json1_1Receipt = (output: any, context: __SerdeContext): Receipt => {
   return {
-    ContactChannelArn:
-      output.ContactChannelArn !== undefined && output.ContactChannelArn !== null
-        ? output.ContactChannelArn
-        : undefined,
-    ReceiptInfo: output.ReceiptInfo !== undefined && output.ReceiptInfo !== null ? output.ReceiptInfo : undefined,
+    ContactChannelArn: __expectString(output.ContactChannelArn),
+    ReceiptInfo: __expectString(output.ReceiptInfo),
     ReceiptTime:
       output.ReceiptTime !== undefined && output.ReceiptTime !== null
         ? new Date(Math.round(output.ReceiptTime * 1000))
         : undefined,
-    ReceiptType: output.ReceiptType !== undefined && output.ReceiptType !== null ? output.ReceiptType : undefined,
+    ReceiptType: __expectString(output.ReceiptType),
   } as any;
 };
 
@@ -3839,9 +3814,9 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    ResourceId: output.ResourceId !== undefined && output.ResourceId !== null ? output.ResourceId : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
+    Message: __expectString(output.Message),
+    ResourceId: __expectString(output.ResourceId),
+    ResourceType: __expectString(output.ResourceType),
   } as any;
 };
 
@@ -3857,20 +3832,17 @@ const deserializeAws_json1_1ServiceQuotaExceededException = (
   context: __SerdeContext
 ): ServiceQuotaExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    QuotaCode: output.QuotaCode !== undefined && output.QuotaCode !== null ? output.QuotaCode : undefined,
-    ResourceId: output.ResourceId !== undefined && output.ResourceId !== null ? output.ResourceId : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
-    ServiceCode: output.ServiceCode !== undefined && output.ServiceCode !== null ? output.ServiceCode : undefined,
+    Message: __expectString(output.Message),
+    QuotaCode: __expectString(output.QuotaCode),
+    ResourceId: __expectString(output.ResourceId),
+    ResourceType: __expectString(output.ResourceType),
+    ServiceCode: __expectString(output.ServiceCode),
   } as any;
 };
 
 const deserializeAws_json1_1Stage = (output: any, context: __SerdeContext): Stage => {
   return {
-    DurationInMinutes:
-      output.DurationInMinutes !== undefined && output.DurationInMinutes !== null
-        ? output.DurationInMinutes
-        : undefined,
+    DurationInMinutes: __expectNumber(output.DurationInMinutes),
     Targets:
       output.Targets !== undefined && output.Targets !== null
         ? deserializeAws_json1_1TargetsList(output.Targets, context)
@@ -3891,8 +3863,7 @@ const deserializeAws_json1_1StagesList = (output: any, context: __SerdeContext):
 
 const deserializeAws_json1_1StartEngagementResult = (output: any, context: __SerdeContext): StartEngagementResult => {
   return {
-    EngagementArn:
-      output.EngagementArn !== undefined && output.EngagementArn !== null ? output.EngagementArn : undefined,
+    EngagementArn: __expectString(output.EngagementArn),
   } as any;
 };
 
@@ -3902,8 +3873,8 @@ const deserializeAws_json1_1StopEngagementResult = (output: any, context: __Serd
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -3948,13 +3919,10 @@ const deserializeAws_json1_1TargetsList = (output: any, context: __SerdeContext)
 
 const deserializeAws_json1_1ThrottlingException = (output: any, context: __SerdeContext): ThrottlingException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    QuotaCode: output.QuotaCode !== undefined && output.QuotaCode !== null ? output.QuotaCode : undefined,
-    RetryAfterSeconds:
-      output.RetryAfterSeconds !== undefined && output.RetryAfterSeconds !== null
-        ? output.RetryAfterSeconds
-        : undefined,
-    ServiceCode: output.ServiceCode !== undefined && output.ServiceCode !== null ? output.ServiceCode : undefined,
+    Message: __expectString(output.Message),
+    QuotaCode: __expectString(output.QuotaCode),
+    RetryAfterSeconds: __expectNumber(output.RetryAfterSeconds),
+    ServiceCode: __expectString(output.ServiceCode),
   } as any;
 };
 
@@ -3979,8 +3947,8 @@ const deserializeAws_json1_1ValidationException = (output: any, context: __Serde
       output.Fields !== undefined && output.Fields !== null
         ? deserializeAws_json1_1ValidationExceptionFieldList(output.Fields, context)
         : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Reason: output.Reason !== undefined && output.Reason !== null ? output.Reason : undefined,
+    Message: __expectString(output.Message),
+    Reason: __expectString(output.Reason),
   } as any;
 };
 
@@ -3989,8 +3957,8 @@ const deserializeAws_json1_1ValidationExceptionField = (
   context: __SerdeContext
 ): ValidationExceptionField => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Message: __expectString(output.Message),
+    Name: __expectString(output.Name),
   } as any;
 };
 

--- a/clients/client-ssm-incidents/protocols/Aws_restJson1.ts
+++ b/clients/client-ssm-incidents/protocols/Aws_restJson1.ts
@@ -109,6 +109,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -957,7 +960,7 @@ export const deserializeAws_restJson1CreateReplicationSetCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   return Promise.resolve(contents);
 };
@@ -1052,7 +1055,7 @@ export const deserializeAws_restJson1CreateResponsePlanCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   return Promise.resolve(contents);
 };
@@ -1148,10 +1151,10 @@ export const deserializeAws_restJson1CreateTimelineEventCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.eventId !== undefined && data.eventId !== null) {
-    contents.eventId = data.eventId;
+    contents.eventId = __expectString(data.eventId);
   }
   if (data.incidentRecordArn !== undefined && data.incidentRecordArn !== null) {
-    contents.incidentRecordArn = data.incidentRecordArn;
+    contents.incidentRecordArn = __expectString(data.incidentRecordArn);
   }
   return Promise.resolve(contents);
 };
@@ -1812,7 +1815,7 @@ export const deserializeAws_restJson1GetResourcePoliciesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.resourcePolicies !== undefined && data.resourcePolicies !== null) {
     contents.resourcePolicies = deserializeAws_restJson1ResourcePolicyList(data.resourcePolicies, context);
@@ -1911,13 +1914,13 @@ export const deserializeAws_restJson1GetResponsePlanCommand = async (
     contents.actions = deserializeAws_restJson1ActionsList(data.actions, context);
   }
   if (data.arn !== undefined && data.arn !== null) {
-    contents.arn = data.arn;
+    contents.arn = __expectString(data.arn);
   }
   if (data.chatChannel !== undefined && data.chatChannel !== null) {
     contents.chatChannel = deserializeAws_restJson1ChatChannel(data.chatChannel, context);
   }
   if (data.displayName !== undefined && data.displayName !== null) {
-    contents.displayName = data.displayName;
+    contents.displayName = __expectString(data.displayName);
   }
   if (data.engagements !== undefined && data.engagements !== null) {
     contents.engagements = deserializeAws_restJson1EngagementSet(data.engagements, context);
@@ -1926,7 +1929,7 @@ export const deserializeAws_restJson1GetResponsePlanCommand = async (
     contents.incidentTemplate = deserializeAws_restJson1IncidentTemplate(data.incidentTemplate, context);
   }
   if (data.name !== undefined && data.name !== null) {
-    contents.name = data.name;
+    contents.name = __expectString(data.name);
   }
   return Promise.resolve(contents);
 };
@@ -2107,7 +2110,7 @@ export const deserializeAws_restJson1ListIncidentRecordsCommand = async (
     );
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2187,7 +2190,7 @@ export const deserializeAws_restJson1ListRelatedItemsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.relatedItems !== undefined && data.relatedItems !== null) {
     contents.relatedItems = deserializeAws_restJson1RelatedItemList(data.relatedItems, context);
@@ -2270,7 +2273,7 @@ export const deserializeAws_restJson1ListReplicationSetsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.replicationSetArns !== undefined && data.replicationSetArns !== null) {
     contents.replicationSetArns = deserializeAws_restJson1ReplicationSetArnList(data.replicationSetArns, context);
@@ -2353,7 +2356,7 @@ export const deserializeAws_restJson1ListResponsePlansCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.responsePlanSummaries !== undefined && data.responsePlanSummaries !== null) {
     contents.responsePlanSummaries = deserializeAws_restJson1ResponsePlanSummaryList(
@@ -2529,7 +2532,7 @@ export const deserializeAws_restJson1ListTimelineEventsCommand = async (
     contents.eventSummaries = deserializeAws_restJson1EventSummaryList(data.eventSummaries, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2608,7 +2611,7 @@ export const deserializeAws_restJson1PutResourcePolicyCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.policyId !== undefined && data.policyId !== null) {
-    contents.policyId = data.policyId;
+    contents.policyId = __expectString(data.policyId);
   }
   return Promise.resolve(contents);
 };
@@ -2695,7 +2698,7 @@ export const deserializeAws_restJson1StartIncidentCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.incidentRecordArn !== undefined && data.incidentRecordArn !== null) {
-    contents.incidentRecordArn = data.incidentRecordArn;
+    contents.incidentRecordArn = __expectString(data.incidentRecordArn);
   }
   return Promise.resolve(contents);
 };
@@ -3509,7 +3512,7 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -3528,13 +3531,13 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.resourceIdentifier !== undefined && data.resourceIdentifier !== null) {
-    contents.resourceIdentifier = data.resourceIdentifier;
+    contents.resourceIdentifier = __expectString(data.resourceIdentifier);
   }
   if (data.resourceType !== undefined && data.resourceType !== null) {
-    contents.resourceType = data.resourceType;
+    contents.resourceType = __expectString(data.resourceType);
   }
   return contents;
 };
@@ -3551,7 +3554,7 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -3570,13 +3573,13 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.resourceIdentifier !== undefined && data.resourceIdentifier !== null) {
-    contents.resourceIdentifier = data.resourceIdentifier;
+    contents.resourceIdentifier = __expectString(data.resourceIdentifier);
   }
   if (data.resourceType !== undefined && data.resourceType !== null) {
-    contents.resourceType = data.resourceType;
+    contents.resourceType = __expectString(data.resourceType);
   }
   return contents;
 };
@@ -3597,19 +3600,19 @@ const deserializeAws_restJson1ServiceQuotaExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.quotaCode !== undefined && data.quotaCode !== null) {
-    contents.quotaCode = data.quotaCode;
+    contents.quotaCode = __expectString(data.quotaCode);
   }
   if (data.resourceIdentifier !== undefined && data.resourceIdentifier !== null) {
-    contents.resourceIdentifier = data.resourceIdentifier;
+    contents.resourceIdentifier = __expectString(data.resourceIdentifier);
   }
   if (data.resourceType !== undefined && data.resourceType !== null) {
-    contents.resourceType = data.resourceType;
+    contents.resourceType = __expectString(data.resourceType);
   }
   if (data.serviceCode !== undefined && data.serviceCode !== null) {
-    contents.serviceCode = data.serviceCode;
+    contents.serviceCode = __expectString(data.serviceCode);
   }
   return contents;
 };
@@ -3628,13 +3631,13 @@ const deserializeAws_restJson1ThrottlingExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   if (data.quotaCode !== undefined && data.quotaCode !== null) {
-    contents.quotaCode = data.quotaCode;
+    contents.quotaCode = __expectString(data.quotaCode);
   }
   if (data.serviceCode !== undefined && data.serviceCode !== null) {
-    contents.serviceCode = data.serviceCode;
+    contents.serviceCode = __expectString(data.serviceCode);
   }
   return contents;
 };
@@ -3651,7 +3654,7 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -3975,10 +3978,8 @@ const deserializeAws_restJson1ActionsList = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_restJson1AutomationExecution = (output: any, context: __SerdeContext): AutomationExecution => {
-  if (output.ssmExecutionArn !== undefined && output.ssmExecutionArn !== null) {
-    return {
-      ssmExecutionArn: output.ssmExecutionArn,
-    };
+  if (__expectString(output.ssmExecutionArn) !== undefined) {
+    return { ssmExecutionArn: __expectString(output.ssmExecutionArn) as any };
   }
   return { $unknown: Object.entries(output)[0] };
 };
@@ -4004,7 +4005,7 @@ const deserializeAws_restJson1ChatbotSnsConfigurationSet = (output: any, context
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4033,26 +4034,23 @@ const deserializeAws_restJson1EngagementSet = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1EventSummary = (output: any, context: __SerdeContext): EventSummary => {
   return {
-    eventId: output.eventId !== undefined && output.eventId !== null ? output.eventId : undefined,
+    eventId: __expectString(output.eventId),
     eventTime:
       output.eventTime !== undefined && output.eventTime !== null
         ? new Date(Math.round(output.eventTime * 1000))
         : undefined,
-    eventType: output.eventType !== undefined && output.eventType !== null ? output.eventType : undefined,
+    eventType: __expectString(output.eventType),
     eventUpdatedTime:
       output.eventUpdatedTime !== undefined && output.eventUpdatedTime !== null
         ? new Date(Math.round(output.eventUpdatedTime * 1000))
         : undefined,
-    incidentRecordArn:
-      output.incidentRecordArn !== undefined && output.incidentRecordArn !== null
-        ? output.incidentRecordArn
-        : undefined,
+    incidentRecordArn: __expectString(output.incidentRecordArn),
   } as any;
 };
 
@@ -4069,7 +4067,7 @@ const deserializeAws_restJson1EventSummaryList = (output: any, context: __SerdeC
 
 const deserializeAws_restJson1IncidentRecord = (output: any, context: __SerdeContext): IncidentRecord => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     automationExecutions:
       output.automationExecutions !== undefined && output.automationExecutions !== null
         ? deserializeAws_restJson1AutomationExecutionSet(output.automationExecutions, context)
@@ -4082,14 +4080,13 @@ const deserializeAws_restJson1IncidentRecord = (output: any, context: __SerdeCon
       output.creationTime !== undefined && output.creationTime !== null
         ? new Date(Math.round(output.creationTime * 1000))
         : undefined,
-    dedupeString: output.dedupeString !== undefined && output.dedupeString !== null ? output.dedupeString : undefined,
-    impact: output.impact !== undefined && output.impact !== null ? output.impact : undefined,
+    dedupeString: __expectString(output.dedupeString),
+    impact: __expectNumber(output.impact),
     incidentRecordSource:
       output.incidentRecordSource !== undefined && output.incidentRecordSource !== null
         ? deserializeAws_restJson1IncidentRecordSource(output.incidentRecordSource, context)
         : undefined,
-    lastModifiedBy:
-      output.lastModifiedBy !== undefined && output.lastModifiedBy !== null ? output.lastModifiedBy : undefined,
+    lastModifiedBy: __expectString(output.lastModifiedBy),
     lastModifiedTime:
       output.lastModifiedTime !== undefined && output.lastModifiedTime !== null
         ? new Date(Math.round(output.lastModifiedTime * 1000))
@@ -4102,29 +4099,29 @@ const deserializeAws_restJson1IncidentRecord = (output: any, context: __SerdeCon
       output.resolvedTime !== undefined && output.resolvedTime !== null
         ? new Date(Math.round(output.resolvedTime * 1000))
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    summary: output.summary !== undefined && output.summary !== null ? output.summary : undefined,
-    title: output.title !== undefined && output.title !== null ? output.title : undefined,
+    status: __expectString(output.status),
+    summary: __expectString(output.summary),
+    title: __expectString(output.title),
   } as any;
 };
 
 const deserializeAws_restJson1IncidentRecordSource = (output: any, context: __SerdeContext): IncidentRecordSource => {
   return {
-    createdBy: output.createdBy !== undefined && output.createdBy !== null ? output.createdBy : undefined,
-    invokedBy: output.invokedBy !== undefined && output.invokedBy !== null ? output.invokedBy : undefined,
-    resourceArn: output.resourceArn !== undefined && output.resourceArn !== null ? output.resourceArn : undefined,
-    source: output.source !== undefined && output.source !== null ? output.source : undefined,
+    createdBy: __expectString(output.createdBy),
+    invokedBy: __expectString(output.invokedBy),
+    resourceArn: __expectString(output.resourceArn),
+    source: __expectString(output.source),
   } as any;
 };
 
 const deserializeAws_restJson1IncidentRecordSummary = (output: any, context: __SerdeContext): IncidentRecordSummary => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
+    arn: __expectString(output.arn),
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
         ? new Date(Math.round(output.creationTime * 1000))
         : undefined,
-    impact: output.impact !== undefined && output.impact !== null ? output.impact : undefined,
+    impact: __expectNumber(output.impact),
     incidentRecordSource:
       output.incidentRecordSource !== undefined && output.incidentRecordSource !== null
         ? deserializeAws_restJson1IncidentRecordSource(output.incidentRecordSource, context)
@@ -4133,8 +4130,8 @@ const deserializeAws_restJson1IncidentRecordSummary = (output: any, context: __S
       output.resolvedTime !== undefined && output.resolvedTime !== null
         ? new Date(Math.round(output.resolvedTime * 1000))
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    title: output.title !== undefined && output.title !== null ? output.title : undefined,
+    status: __expectString(output.status),
+    title: __expectString(output.title),
   } as any;
 };
 
@@ -4154,20 +4151,20 @@ const deserializeAws_restJson1IncidentRecordSummaryList = (
 
 const deserializeAws_restJson1IncidentTemplate = (output: any, context: __SerdeContext): IncidentTemplate => {
   return {
-    dedupeString: output.dedupeString !== undefined && output.dedupeString !== null ? output.dedupeString : undefined,
-    impact: output.impact !== undefined && output.impact !== null ? output.impact : undefined,
+    dedupeString: __expectString(output.dedupeString),
+    impact: __expectNumber(output.impact),
     notificationTargets:
       output.notificationTargets !== undefined && output.notificationTargets !== null
         ? deserializeAws_restJson1NotificationTargetSet(output.notificationTargets, context)
         : undefined,
-    summary: output.summary !== undefined && output.summary !== null ? output.summary : undefined,
-    title: output.title !== undefined && output.title !== null ? output.title : undefined,
+    summary: __expectString(output.summary),
+    title: __expectString(output.title),
   } as any;
 };
 
 const deserializeAws_restJson1ItemIdentifier = (output: any, context: __SerdeContext): ItemIdentifier => {
   return {
-    type: output.type !== undefined && output.type !== null ? output.type : undefined,
+    type: __expectString(output.type),
     value:
       output.value !== undefined && output.value !== null
         ? deserializeAws_restJson1ItemValue(output.value, context)
@@ -4176,20 +4173,14 @@ const deserializeAws_restJson1ItemIdentifier = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_restJson1ItemValue = (output: any, context: __SerdeContext): ItemValue => {
-  if (output.arn !== undefined && output.arn !== null) {
-    return {
-      arn: output.arn,
-    };
+  if (__expectString(output.arn) !== undefined) {
+    return { arn: __expectString(output.arn) as any };
   }
-  if (output.metricDefinition !== undefined && output.metricDefinition !== null) {
-    return {
-      metricDefinition: output.metricDefinition,
-    };
+  if (__expectString(output.metricDefinition) !== undefined) {
+    return { metricDefinition: __expectString(output.metricDefinition) as any };
   }
-  if (output.url !== undefined && output.url !== null) {
-    return {
-      url: output.url,
-    };
+  if (__expectString(output.url) !== undefined) {
+    return { url: __expectString(output.url) as any };
   }
   return { $unknown: Object.entries(output)[0] };
 };
@@ -4198,10 +4189,8 @@ const deserializeAws_restJson1NotificationTargetItem = (
   output: any,
   context: __SerdeContext
 ): NotificationTargetItem => {
-  if (output.snsTopicArn !== undefined && output.snsTopicArn !== null) {
-    return {
-      snsTopicArn: output.snsTopicArn,
-    };
+  if (__expectString(output.snsTopicArn) !== undefined) {
+    return { snsTopicArn: __expectString(output.snsTopicArn) as any };
   }
   return { $unknown: Object.entries(output)[0] };
 };
@@ -4222,10 +4211,9 @@ const deserializeAws_restJson1NotificationTargetSet = (
 
 const deserializeAws_restJson1RegionInfo = (output: any, context: __SerdeContext): RegionInfo => {
   return {
-    sseKmsKeyId: output.sseKmsKeyId !== undefined && output.sseKmsKeyId !== null ? output.sseKmsKeyId : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    statusMessage:
-      output.statusMessage !== undefined && output.statusMessage !== null ? output.statusMessage : undefined,
+    sseKmsKeyId: __expectString(output.sseKmsKeyId),
+    status: __expectString(output.status),
+    statusMessage: __expectString(output.statusMessage),
     statusUpdateDateTime:
       output.statusUpdateDateTime !== undefined && output.statusUpdateDateTime !== null
         ? new Date(Math.round(output.statusUpdateDateTime * 1000))
@@ -4251,7 +4239,7 @@ const deserializeAws_restJson1RelatedItem = (output: any, context: __SerdeContex
       output.identifier !== undefined && output.identifier !== null
         ? deserializeAws_restJson1ItemIdentifier(output.identifier, context)
         : undefined,
-    title: output.title !== undefined && output.title !== null ? output.title : undefined,
+    title: __expectString(output.title),
   } as any;
 };
 
@@ -4268,17 +4256,13 @@ const deserializeAws_restJson1RelatedItemList = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1ReplicationSet = (output: any, context: __SerdeContext): ReplicationSet => {
   return {
-    createdBy: output.createdBy !== undefined && output.createdBy !== null ? output.createdBy : undefined,
+    createdBy: __expectString(output.createdBy),
     createdTime:
       output.createdTime !== undefined && output.createdTime !== null
         ? new Date(Math.round(output.createdTime * 1000))
         : undefined,
-    deletionProtected:
-      output.deletionProtected !== undefined && output.deletionProtected !== null
-        ? output.deletionProtected
-        : undefined,
-    lastModifiedBy:
-      output.lastModifiedBy !== undefined && output.lastModifiedBy !== null ? output.lastModifiedBy : undefined,
+    deletionProtected: __expectBoolean(output.deletionProtected),
+    lastModifiedBy: __expectString(output.lastModifiedBy),
     lastModifiedTime:
       output.lastModifiedTime !== undefined && output.lastModifiedTime !== null
         ? new Date(Math.round(output.lastModifiedTime * 1000))
@@ -4287,7 +4271,7 @@ const deserializeAws_restJson1ReplicationSet = (output: any, context: __SerdeCon
       output.regionMap !== undefined && output.regionMap !== null
         ? deserializeAws_restJson1RegionInfoMap(output.regionMap, context)
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -4298,19 +4282,15 @@ const deserializeAws_restJson1ReplicationSetArnList = (output: any, context: __S
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1ResourcePolicy = (output: any, context: __SerdeContext): ResourcePolicy => {
   return {
-    policyDocument:
-      output.policyDocument !== undefined && output.policyDocument !== null ? output.policyDocument : undefined,
-    policyId: output.policyId !== undefined && output.policyId !== null ? output.policyId : undefined,
-    ramResourceShareRegion:
-      output.ramResourceShareRegion !== undefined && output.ramResourceShareRegion !== null
-        ? output.ramResourceShareRegion
-        : undefined,
+    policyDocument: __expectString(output.policyDocument),
+    policyId: __expectString(output.policyId),
+    ramResourceShareRegion: __expectString(output.ramResourceShareRegion),
   } as any;
 };
 
@@ -4327,9 +4307,9 @@ const deserializeAws_restJson1ResourcePolicyList = (output: any, context: __Serd
 
 const deserializeAws_restJson1ResponsePlanSummary = (output: any, context: __SerdeContext): ResponsePlanSummary => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    displayName: output.displayName !== undefined && output.displayName !== null ? output.displayName : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    arn: __expectString(output.arn),
+    displayName: __expectString(output.displayName),
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -4349,16 +4329,14 @@ const deserializeAws_restJson1ResponsePlanSummaryList = (
 
 const deserializeAws_restJson1SsmAutomation = (output: any, context: __SerdeContext): SsmAutomation => {
   return {
-    documentName: output.documentName !== undefined && output.documentName !== null ? output.documentName : undefined,
-    documentVersion:
-      output.documentVersion !== undefined && output.documentVersion !== null ? output.documentVersion : undefined,
+    documentName: __expectString(output.documentName),
+    documentVersion: __expectString(output.documentVersion),
     parameters:
       output.parameters !== undefined && output.parameters !== null
         ? deserializeAws_restJson1SsmParameters(output.parameters, context)
         : undefined,
-    roleArn: output.roleArn !== undefined && output.roleArn !== null ? output.roleArn : undefined,
-    targetAccount:
-      output.targetAccount !== undefined && output.targetAccount !== null ? output.targetAccount : undefined,
+    roleArn: __expectString(output.roleArn),
+    targetAccount: __expectString(output.targetAccount),
   } as any;
 };
 
@@ -4381,7 +4359,7 @@ const deserializeAws_restJson1SsmParameterValues = (output: any, context: __Serd
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4392,28 +4370,25 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1TimelineEvent = (output: any, context: __SerdeContext): TimelineEvent => {
   return {
-    eventData: output.eventData !== undefined && output.eventData !== null ? output.eventData : undefined,
-    eventId: output.eventId !== undefined && output.eventId !== null ? output.eventId : undefined,
+    eventData: __expectString(output.eventData),
+    eventId: __expectString(output.eventId),
     eventTime:
       output.eventTime !== undefined && output.eventTime !== null
         ? new Date(Math.round(output.eventTime * 1000))
         : undefined,
-    eventType: output.eventType !== undefined && output.eventType !== null ? output.eventType : undefined,
+    eventType: __expectString(output.eventType),
     eventUpdatedTime:
       output.eventUpdatedTime !== undefined && output.eventUpdatedTime !== null
         ? new Date(Math.round(output.eventUpdatedTime * 1000))
         : undefined,
-    incidentRecordArn:
-      output.incidentRecordArn !== undefined && output.incidentRecordArn !== null
-        ? output.incidentRecordArn
-        : undefined,
+    incidentRecordArn: __expectString(output.incidentRecordArn),
   } as any;
 };
 

--- a/clients/client-ssm/protocols/Aws_json1_1.ts
+++ b/clients/client-ssm/protocols/Aws_json1_1.ts
@@ -952,7 +952,12 @@ import {
   UpdateServiceSettingResult,
 } from "../models/models_2";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -18641,7 +18646,7 @@ const deserializeAws_json1_1AccountIdList = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -18652,17 +18657,14 @@ const deserializeAws_json1_1Accounts = (output: any, context: __SerdeContext): s
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1AccountSharingInfo = (output: any, context: __SerdeContext): AccountSharingInfo => {
   return {
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
-    SharedDocumentVersion:
-      output.SharedDocumentVersion !== undefined && output.SharedDocumentVersion !== null
-        ? output.SharedDocumentVersion
-        : undefined,
+    AccountId: __expectString(output.AccountId),
+    SharedDocumentVersion: __expectString(output.SharedDocumentVersion),
   } as any;
 };
 
@@ -18679,30 +18681,21 @@ const deserializeAws_json1_1AccountSharingInfoList = (output: any, context: __Se
 
 const deserializeAws_json1_1Activation = (output: any, context: __SerdeContext): Activation => {
   return {
-    ActivationId: output.ActivationId !== undefined && output.ActivationId !== null ? output.ActivationId : undefined,
+    ActivationId: __expectString(output.ActivationId),
     CreatedDate:
       output.CreatedDate !== undefined && output.CreatedDate !== null
         ? new Date(Math.round(output.CreatedDate * 1000))
         : undefined,
-    DefaultInstanceName:
-      output.DefaultInstanceName !== undefined && output.DefaultInstanceName !== null
-        ? output.DefaultInstanceName
-        : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    DefaultInstanceName: __expectString(output.DefaultInstanceName),
+    Description: __expectString(output.Description),
     ExpirationDate:
       output.ExpirationDate !== undefined && output.ExpirationDate !== null
         ? new Date(Math.round(output.ExpirationDate * 1000))
         : undefined,
-    Expired: output.Expired !== undefined && output.Expired !== null ? output.Expired : undefined,
-    IamRole: output.IamRole !== undefined && output.IamRole !== null ? output.IamRole : undefined,
-    RegistrationLimit:
-      output.RegistrationLimit !== undefined && output.RegistrationLimit !== null
-        ? output.RegistrationLimit
-        : undefined,
-    RegistrationsCount:
-      output.RegistrationsCount !== undefined && output.RegistrationsCount !== null
-        ? output.RegistrationsCount
-        : undefined,
+    Expired: __expectBoolean(output.Expired),
+    IamRole: __expectString(output.IamRole),
+    RegistrationLimit: __expectNumber(output.RegistrationLimit),
+    RegistrationsCount: __expectNumber(output.RegistrationsCount),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_1TagList(output.Tags, context)
@@ -18730,7 +18723,7 @@ const deserializeAws_json1_1AddTagsToResourceResult = (
 
 const deserializeAws_json1_1AlreadyExistsException = (output: any, context: __SerdeContext): AlreadyExistsException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -18743,37 +18736,27 @@ const deserializeAws_json1_1AssociateOpsItemRelatedItemResponse = (
   context: __SerdeContext
 ): AssociateOpsItemRelatedItemResponse => {
   return {
-    AssociationId:
-      output.AssociationId !== undefined && output.AssociationId !== null ? output.AssociationId : undefined,
+    AssociationId: __expectString(output.AssociationId),
   } as any;
 };
 
 const deserializeAws_json1_1Association = (output: any, context: __SerdeContext): Association => {
   return {
-    AssociationId:
-      output.AssociationId !== undefined && output.AssociationId !== null ? output.AssociationId : undefined,
-    AssociationName:
-      output.AssociationName !== undefined && output.AssociationName !== null ? output.AssociationName : undefined,
-    AssociationVersion:
-      output.AssociationVersion !== undefined && output.AssociationVersion !== null
-        ? output.AssociationVersion
-        : undefined,
-    DocumentVersion:
-      output.DocumentVersion !== undefined && output.DocumentVersion !== null ? output.DocumentVersion : undefined,
-    InstanceId: output.InstanceId !== undefined && output.InstanceId !== null ? output.InstanceId : undefined,
+    AssociationId: __expectString(output.AssociationId),
+    AssociationName: __expectString(output.AssociationName),
+    AssociationVersion: __expectString(output.AssociationVersion),
+    DocumentVersion: __expectString(output.DocumentVersion),
+    InstanceId: __expectString(output.InstanceId),
     LastExecutionDate:
       output.LastExecutionDate !== undefined && output.LastExecutionDate !== null
         ? new Date(Math.round(output.LastExecutionDate * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     Overview:
       output.Overview !== undefined && output.Overview !== null
         ? deserializeAws_json1_1AssociationOverview(output.Overview, context)
         : undefined,
-    ScheduleExpression:
-      output.ScheduleExpression !== undefined && output.ScheduleExpression !== null
-        ? output.ScheduleExpression
-        : undefined,
+    ScheduleExpression: __expectString(output.ScheduleExpression),
     Targets:
       output.Targets !== undefined && output.Targets !== null
         ? deserializeAws_json1_1Targets(output.Targets, context)
@@ -18790,34 +18773,19 @@ const deserializeAws_json1_1AssociationAlreadyExists = (
 
 const deserializeAws_json1_1AssociationDescription = (output: any, context: __SerdeContext): AssociationDescription => {
   return {
-    ApplyOnlyAtCronInterval:
-      output.ApplyOnlyAtCronInterval !== undefined && output.ApplyOnlyAtCronInterval !== null
-        ? output.ApplyOnlyAtCronInterval
-        : undefined,
-    AssociationId:
-      output.AssociationId !== undefined && output.AssociationId !== null ? output.AssociationId : undefined,
-    AssociationName:
-      output.AssociationName !== undefined && output.AssociationName !== null ? output.AssociationName : undefined,
-    AssociationVersion:
-      output.AssociationVersion !== undefined && output.AssociationVersion !== null
-        ? output.AssociationVersion
-        : undefined,
-    AutomationTargetParameterName:
-      output.AutomationTargetParameterName !== undefined && output.AutomationTargetParameterName !== null
-        ? output.AutomationTargetParameterName
-        : undefined,
+    ApplyOnlyAtCronInterval: __expectBoolean(output.ApplyOnlyAtCronInterval),
+    AssociationId: __expectString(output.AssociationId),
+    AssociationName: __expectString(output.AssociationName),
+    AssociationVersion: __expectString(output.AssociationVersion),
+    AutomationTargetParameterName: __expectString(output.AutomationTargetParameterName),
     CalendarNames:
       output.CalendarNames !== undefined && output.CalendarNames !== null
         ? deserializeAws_json1_1CalendarNameOrARNList(output.CalendarNames, context)
         : undefined,
-    ComplianceSeverity:
-      output.ComplianceSeverity !== undefined && output.ComplianceSeverity !== null
-        ? output.ComplianceSeverity
-        : undefined,
+    ComplianceSeverity: __expectString(output.ComplianceSeverity),
     Date: output.Date !== undefined && output.Date !== null ? new Date(Math.round(output.Date * 1000)) : undefined,
-    DocumentVersion:
-      output.DocumentVersion !== undefined && output.DocumentVersion !== null ? output.DocumentVersion : undefined,
-    InstanceId: output.InstanceId !== undefined && output.InstanceId !== null ? output.InstanceId : undefined,
+    DocumentVersion: __expectString(output.DocumentVersion),
+    InstanceId: __expectString(output.InstanceId),
     LastExecutionDate:
       output.LastExecutionDate !== undefined && output.LastExecutionDate !== null
         ? new Date(Math.round(output.LastExecutionDate * 1000))
@@ -18830,10 +18798,9 @@ const deserializeAws_json1_1AssociationDescription = (output: any, context: __Se
       output.LastUpdateAssociationDate !== undefined && output.LastUpdateAssociationDate !== null
         ? new Date(Math.round(output.LastUpdateAssociationDate * 1000))
         : undefined,
-    MaxConcurrency:
-      output.MaxConcurrency !== undefined && output.MaxConcurrency !== null ? output.MaxConcurrency : undefined,
-    MaxErrors: output.MaxErrors !== undefined && output.MaxErrors !== null ? output.MaxErrors : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    MaxConcurrency: __expectString(output.MaxConcurrency),
+    MaxErrors: __expectString(output.MaxErrors),
+    Name: __expectString(output.Name),
     OutputLocation:
       output.OutputLocation !== undefined && output.OutputLocation !== null
         ? deserializeAws_json1_1InstanceAssociationOutputLocation(output.OutputLocation, context)
@@ -18846,16 +18813,12 @@ const deserializeAws_json1_1AssociationDescription = (output: any, context: __Se
       output.Parameters !== undefined && output.Parameters !== null
         ? deserializeAws_json1_1Parameters(output.Parameters, context)
         : undefined,
-    ScheduleExpression:
-      output.ScheduleExpression !== undefined && output.ScheduleExpression !== null
-        ? output.ScheduleExpression
-        : undefined,
+    ScheduleExpression: __expectString(output.ScheduleExpression),
     Status:
       output.Status !== undefined && output.Status !== null
         ? deserializeAws_json1_1AssociationStatus(output.Status, context)
         : undefined,
-    SyncCompliance:
-      output.SyncCompliance !== undefined && output.SyncCompliance !== null ? output.SyncCompliance : undefined,
+    SyncCompliance: __expectString(output.SyncCompliance),
     TargetLocations:
       output.TargetLocations !== undefined && output.TargetLocations !== null
         ? deserializeAws_json1_1TargetLocations(output.TargetLocations, context)
@@ -18886,34 +18849,26 @@ const deserializeAws_json1_1AssociationDoesNotExist = (
   context: __SerdeContext
 ): AssociationDoesNotExist => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1AssociationExecution = (output: any, context: __SerdeContext): AssociationExecution => {
   return {
-    AssociationId:
-      output.AssociationId !== undefined && output.AssociationId !== null ? output.AssociationId : undefined,
-    AssociationVersion:
-      output.AssociationVersion !== undefined && output.AssociationVersion !== null
-        ? output.AssociationVersion
-        : undefined,
+    AssociationId: __expectString(output.AssociationId),
+    AssociationVersion: __expectString(output.AssociationVersion),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
         : undefined,
-    DetailedStatus:
-      output.DetailedStatus !== undefined && output.DetailedStatus !== null ? output.DetailedStatus : undefined,
-    ExecutionId: output.ExecutionId !== undefined && output.ExecutionId !== null ? output.ExecutionId : undefined,
+    DetailedStatus: __expectString(output.DetailedStatus),
+    ExecutionId: __expectString(output.ExecutionId),
     LastExecutionDate:
       output.LastExecutionDate !== undefined && output.LastExecutionDate !== null
         ? new Date(Math.round(output.LastExecutionDate * 1000))
         : undefined,
-    ResourceCountByStatus:
-      output.ResourceCountByStatus !== undefined && output.ResourceCountByStatus !== null
-        ? output.ResourceCountByStatus
-        : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    ResourceCountByStatus: __expectString(output.ResourceCountByStatus),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -18922,7 +18877,7 @@ const deserializeAws_json1_1AssociationExecutionDoesNotExist = (
   context: __SerdeContext
 ): AssociationExecutionDoesNotExist => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -18945,15 +18900,10 @@ const deserializeAws_json1_1AssociationExecutionTarget = (
   context: __SerdeContext
 ): AssociationExecutionTarget => {
   return {
-    AssociationId:
-      output.AssociationId !== undefined && output.AssociationId !== null ? output.AssociationId : undefined,
-    AssociationVersion:
-      output.AssociationVersion !== undefined && output.AssociationVersion !== null
-        ? output.AssociationVersion
-        : undefined,
-    DetailedStatus:
-      output.DetailedStatus !== undefined && output.DetailedStatus !== null ? output.DetailedStatus : undefined,
-    ExecutionId: output.ExecutionId !== undefined && output.ExecutionId !== null ? output.ExecutionId : undefined,
+    AssociationId: __expectString(output.AssociationId),
+    AssociationVersion: __expectString(output.AssociationVersion),
+    DetailedStatus: __expectString(output.DetailedStatus),
+    ExecutionId: __expectString(output.ExecutionId),
     LastExecutionDate:
       output.LastExecutionDate !== undefined && output.LastExecutionDate !== null
         ? new Date(Math.round(output.LastExecutionDate * 1000))
@@ -18962,9 +18912,9 @@ const deserializeAws_json1_1AssociationExecutionTarget = (
       output.OutputSource !== undefined && output.OutputSource !== null
         ? deserializeAws_json1_1OutputSource(output.OutputSource, context)
         : undefined,
-    ResourceId: output.ResourceId !== undefined && output.ResourceId !== null ? output.ResourceId : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    ResourceId: __expectString(output.ResourceId),
+    ResourceType: __expectString(output.ResourceType),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -19006,19 +18956,17 @@ const deserializeAws_json1_1AssociationOverview = (output: any, context: __Serde
       output.AssociationStatusAggregatedCount !== undefined && output.AssociationStatusAggregatedCount !== null
         ? deserializeAws_json1_1AssociationStatusAggregatedCount(output.AssociationStatusAggregatedCount, context)
         : undefined,
-    DetailedStatus:
-      output.DetailedStatus !== undefined && output.DetailedStatus !== null ? output.DetailedStatus : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    DetailedStatus: __expectString(output.DetailedStatus),
+    Status: __expectString(output.Status),
   } as any;
 };
 
 const deserializeAws_json1_1AssociationStatus = (output: any, context: __SerdeContext): AssociationStatus => {
   return {
-    AdditionalInfo:
-      output.AdditionalInfo !== undefined && output.AdditionalInfo !== null ? output.AdditionalInfo : undefined,
+    AdditionalInfo: __expectString(output.AdditionalInfo),
     Date: output.Date !== undefined && output.Date !== null ? new Date(Math.round(output.Date * 1000)) : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Message: __expectString(output.Message),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -19032,43 +18980,30 @@ const deserializeAws_json1_1AssociationStatusAggregatedCount = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectNumber(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_json1_1AssociationVersionInfo = (output: any, context: __SerdeContext): AssociationVersionInfo => {
   return {
-    ApplyOnlyAtCronInterval:
-      output.ApplyOnlyAtCronInterval !== undefined && output.ApplyOnlyAtCronInterval !== null
-        ? output.ApplyOnlyAtCronInterval
-        : undefined,
-    AssociationId:
-      output.AssociationId !== undefined && output.AssociationId !== null ? output.AssociationId : undefined,
-    AssociationName:
-      output.AssociationName !== undefined && output.AssociationName !== null ? output.AssociationName : undefined,
-    AssociationVersion:
-      output.AssociationVersion !== undefined && output.AssociationVersion !== null
-        ? output.AssociationVersion
-        : undefined,
+    ApplyOnlyAtCronInterval: __expectBoolean(output.ApplyOnlyAtCronInterval),
+    AssociationId: __expectString(output.AssociationId),
+    AssociationName: __expectString(output.AssociationName),
+    AssociationVersion: __expectString(output.AssociationVersion),
     CalendarNames:
       output.CalendarNames !== undefined && output.CalendarNames !== null
         ? deserializeAws_json1_1CalendarNameOrARNList(output.CalendarNames, context)
         : undefined,
-    ComplianceSeverity:
-      output.ComplianceSeverity !== undefined && output.ComplianceSeverity !== null
-        ? output.ComplianceSeverity
-        : undefined,
+    ComplianceSeverity: __expectString(output.ComplianceSeverity),
     CreatedDate:
       output.CreatedDate !== undefined && output.CreatedDate !== null
         ? new Date(Math.round(output.CreatedDate * 1000))
         : undefined,
-    DocumentVersion:
-      output.DocumentVersion !== undefined && output.DocumentVersion !== null ? output.DocumentVersion : undefined,
-    MaxConcurrency:
-      output.MaxConcurrency !== undefined && output.MaxConcurrency !== null ? output.MaxConcurrency : undefined,
-    MaxErrors: output.MaxErrors !== undefined && output.MaxErrors !== null ? output.MaxErrors : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    DocumentVersion: __expectString(output.DocumentVersion),
+    MaxConcurrency: __expectString(output.MaxConcurrency),
+    MaxErrors: __expectString(output.MaxErrors),
+    Name: __expectString(output.Name),
     OutputLocation:
       output.OutputLocation !== undefined && output.OutputLocation !== null
         ? deserializeAws_json1_1InstanceAssociationOutputLocation(output.OutputLocation, context)
@@ -19077,12 +19012,8 @@ const deserializeAws_json1_1AssociationVersionInfo = (output: any, context: __Se
       output.Parameters !== undefined && output.Parameters !== null
         ? deserializeAws_json1_1Parameters(output.Parameters, context)
         : undefined,
-    ScheduleExpression:
-      output.ScheduleExpression !== undefined && output.ScheduleExpression !== null
-        ? output.ScheduleExpression
-        : undefined,
-    SyncCompliance:
-      output.SyncCompliance !== undefined && output.SyncCompliance !== null ? output.SyncCompliance : undefined,
+    ScheduleExpression: __expectString(output.ScheduleExpression),
+    SyncCompliance: __expectString(output.SyncCompliance),
     TargetLocations:
       output.TargetLocations !== undefined && output.TargetLocations !== null
         ? deserializeAws_json1_1TargetLocations(output.TargetLocations, context)
@@ -19099,7 +19030,7 @@ const deserializeAws_json1_1AssociationVersionLimitExceeded = (
   context: __SerdeContext
 ): AssociationVersionLimitExceeded => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -19119,11 +19050,11 @@ const deserializeAws_json1_1AssociationVersionList = (
 
 const deserializeAws_json1_1AttachmentContent = (output: any, context: __SerdeContext): AttachmentContent => {
   return {
-    Hash: output.Hash !== undefined && output.Hash !== null ? output.Hash : undefined,
-    HashType: output.HashType !== undefined && output.HashType !== null ? output.HashType : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Size: output.Size !== undefined && output.Size !== null ? output.Size : undefined,
-    Url: output.Url !== undefined && output.Url !== null ? output.Url : undefined,
+    Hash: __expectString(output.Hash),
+    HashType: __expectString(output.HashType),
+    Name: __expectString(output.Name),
+    Size: __expectNumber(output.Size),
+    Url: __expectString(output.Url),
   } as any;
 };
 
@@ -19140,7 +19071,7 @@ const deserializeAws_json1_1AttachmentContentList = (output: any, context: __Ser
 
 const deserializeAws_json1_1AttachmentInformation = (output: any, context: __SerdeContext): AttachmentInformation => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -19163,7 +19094,7 @@ const deserializeAws_json1_1AutomationDefinitionNotApprovedException = (
   context: __SerdeContext
 ): AutomationDefinitionNotApprovedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -19172,7 +19103,7 @@ const deserializeAws_json1_1AutomationDefinitionNotFoundException = (
   context: __SerdeContext
 ): AutomationDefinitionNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -19181,38 +19112,22 @@ const deserializeAws_json1_1AutomationDefinitionVersionNotFoundException = (
   context: __SerdeContext
 ): AutomationDefinitionVersionNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1AutomationExecution = (output: any, context: __SerdeContext): AutomationExecution => {
   return {
-    AssociationId:
-      output.AssociationId !== undefined && output.AssociationId !== null ? output.AssociationId : undefined,
-    AutomationExecutionId:
-      output.AutomationExecutionId !== undefined && output.AutomationExecutionId !== null
-        ? output.AutomationExecutionId
-        : undefined,
-    AutomationExecutionStatus:
-      output.AutomationExecutionStatus !== undefined && output.AutomationExecutionStatus !== null
-        ? output.AutomationExecutionStatus
-        : undefined,
-    AutomationSubtype:
-      output.AutomationSubtype !== undefined && output.AutomationSubtype !== null
-        ? output.AutomationSubtype
-        : undefined,
-    ChangeRequestName:
-      output.ChangeRequestName !== undefined && output.ChangeRequestName !== null
-        ? output.ChangeRequestName
-        : undefined,
-    CurrentAction:
-      output.CurrentAction !== undefined && output.CurrentAction !== null ? output.CurrentAction : undefined,
-    CurrentStepName:
-      output.CurrentStepName !== undefined && output.CurrentStepName !== null ? output.CurrentStepName : undefined,
-    DocumentName: output.DocumentName !== undefined && output.DocumentName !== null ? output.DocumentName : undefined,
-    DocumentVersion:
-      output.DocumentVersion !== undefined && output.DocumentVersion !== null ? output.DocumentVersion : undefined,
-    ExecutedBy: output.ExecutedBy !== undefined && output.ExecutedBy !== null ? output.ExecutedBy : undefined,
+    AssociationId: __expectString(output.AssociationId),
+    AutomationExecutionId: __expectString(output.AutomationExecutionId),
+    AutomationExecutionStatus: __expectString(output.AutomationExecutionStatus),
+    AutomationSubtype: __expectString(output.AutomationSubtype),
+    ChangeRequestName: __expectString(output.ChangeRequestName),
+    CurrentAction: __expectString(output.CurrentAction),
+    CurrentStepName: __expectString(output.CurrentStepName),
+    DocumentName: __expectString(output.DocumentName),
+    DocumentVersion: __expectString(output.DocumentVersion),
+    ExecutedBy: __expectString(output.ExecutedBy),
     ExecutionEndTime:
       output.ExecutionEndTime !== undefined && output.ExecutionEndTime !== null
         ? new Date(Math.round(output.ExecutionEndTime * 1000))
@@ -19221,13 +19136,11 @@ const deserializeAws_json1_1AutomationExecution = (output: any, context: __Serde
       output.ExecutionStartTime !== undefined && output.ExecutionStartTime !== null
         ? new Date(Math.round(output.ExecutionStartTime * 1000))
         : undefined,
-    FailureMessage:
-      output.FailureMessage !== undefined && output.FailureMessage !== null ? output.FailureMessage : undefined,
-    MaxConcurrency:
-      output.MaxConcurrency !== undefined && output.MaxConcurrency !== null ? output.MaxConcurrency : undefined,
-    MaxErrors: output.MaxErrors !== undefined && output.MaxErrors !== null ? output.MaxErrors : undefined,
-    Mode: output.Mode !== undefined && output.Mode !== null ? output.Mode : undefined,
-    OpsItemId: output.OpsItemId !== undefined && output.OpsItemId !== null ? output.OpsItemId : undefined,
+    FailureMessage: __expectString(output.FailureMessage),
+    MaxConcurrency: __expectString(output.MaxConcurrency),
+    MaxErrors: __expectString(output.MaxErrors),
+    Mode: __expectString(output.Mode),
+    OpsItemId: __expectString(output.OpsItemId),
     Outputs:
       output.Outputs !== undefined && output.Outputs !== null
         ? deserializeAws_json1_1AutomationParameterMap(output.Outputs, context)
@@ -19236,10 +19149,7 @@ const deserializeAws_json1_1AutomationExecution = (output: any, context: __Serde
       output.Parameters !== undefined && output.Parameters !== null
         ? deserializeAws_json1_1AutomationParameterMap(output.Parameters, context)
         : undefined,
-    ParentAutomationExecutionId:
-      output.ParentAutomationExecutionId !== undefined && output.ParentAutomationExecutionId !== null
-        ? output.ParentAutomationExecutionId
-        : undefined,
+    ParentAutomationExecutionId: __expectString(output.ParentAutomationExecutionId),
     ProgressCounters:
       output.ProgressCounters !== undefined && output.ProgressCounters !== null
         ? deserializeAws_json1_1ProgressCounters(output.ProgressCounters, context)
@@ -19260,11 +19170,8 @@ const deserializeAws_json1_1AutomationExecution = (output: any, context: __Serde
       output.StepExecutions !== undefined && output.StepExecutions !== null
         ? deserializeAws_json1_1StepExecutionList(output.StepExecutions, context)
         : undefined,
-    StepExecutionsTruncated:
-      output.StepExecutionsTruncated !== undefined && output.StepExecutionsTruncated !== null
-        ? output.StepExecutionsTruncated
-        : undefined,
-    Target: output.Target !== undefined && output.Target !== null ? output.Target : undefined,
+    StepExecutionsTruncated: __expectBoolean(output.StepExecutionsTruncated),
+    Target: __expectString(output.Target),
     TargetLocations:
       output.TargetLocations !== undefined && output.TargetLocations !== null
         ? deserializeAws_json1_1TargetLocations(output.TargetLocations, context)
@@ -19273,10 +19180,7 @@ const deserializeAws_json1_1AutomationExecution = (output: any, context: __Serde
       output.TargetMaps !== undefined && output.TargetMaps !== null
         ? deserializeAws_json1_1TargetMaps(output.TargetMaps, context)
         : undefined,
-    TargetParameterName:
-      output.TargetParameterName !== undefined && output.TargetParameterName !== null
-        ? output.TargetParameterName
-        : undefined,
+    TargetParameterName: __expectString(output.TargetParameterName),
     Targets:
       output.Targets !== undefined && output.Targets !== null
         ? deserializeAws_json1_1Targets(output.Targets, context)
@@ -19289,7 +19193,7 @@ const deserializeAws_json1_1AutomationExecutionLimitExceededException = (
   context: __SerdeContext
 ): AutomationExecutionLimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -19298,34 +19202,17 @@ const deserializeAws_json1_1AutomationExecutionMetadata = (
   context: __SerdeContext
 ): AutomationExecutionMetadata => {
   return {
-    AssociationId:
-      output.AssociationId !== undefined && output.AssociationId !== null ? output.AssociationId : undefined,
-    AutomationExecutionId:
-      output.AutomationExecutionId !== undefined && output.AutomationExecutionId !== null
-        ? output.AutomationExecutionId
-        : undefined,
-    AutomationExecutionStatus:
-      output.AutomationExecutionStatus !== undefined && output.AutomationExecutionStatus !== null
-        ? output.AutomationExecutionStatus
-        : undefined,
-    AutomationSubtype:
-      output.AutomationSubtype !== undefined && output.AutomationSubtype !== null
-        ? output.AutomationSubtype
-        : undefined,
-    AutomationType:
-      output.AutomationType !== undefined && output.AutomationType !== null ? output.AutomationType : undefined,
-    ChangeRequestName:
-      output.ChangeRequestName !== undefined && output.ChangeRequestName !== null
-        ? output.ChangeRequestName
-        : undefined,
-    CurrentAction:
-      output.CurrentAction !== undefined && output.CurrentAction !== null ? output.CurrentAction : undefined,
-    CurrentStepName:
-      output.CurrentStepName !== undefined && output.CurrentStepName !== null ? output.CurrentStepName : undefined,
-    DocumentName: output.DocumentName !== undefined && output.DocumentName !== null ? output.DocumentName : undefined,
-    DocumentVersion:
-      output.DocumentVersion !== undefined && output.DocumentVersion !== null ? output.DocumentVersion : undefined,
-    ExecutedBy: output.ExecutedBy !== undefined && output.ExecutedBy !== null ? output.ExecutedBy : undefined,
+    AssociationId: __expectString(output.AssociationId),
+    AutomationExecutionId: __expectString(output.AutomationExecutionId),
+    AutomationExecutionStatus: __expectString(output.AutomationExecutionStatus),
+    AutomationSubtype: __expectString(output.AutomationSubtype),
+    AutomationType: __expectString(output.AutomationType),
+    ChangeRequestName: __expectString(output.ChangeRequestName),
+    CurrentAction: __expectString(output.CurrentAction),
+    CurrentStepName: __expectString(output.CurrentStepName),
+    DocumentName: __expectString(output.DocumentName),
+    DocumentVersion: __expectString(output.DocumentVersion),
+    ExecutedBy: __expectString(output.ExecutedBy),
     ExecutionEndTime:
       output.ExecutionEndTime !== undefined && output.ExecutionEndTime !== null
         ? new Date(Math.round(output.ExecutionEndTime * 1000))
@@ -19334,22 +19221,17 @@ const deserializeAws_json1_1AutomationExecutionMetadata = (
       output.ExecutionStartTime !== undefined && output.ExecutionStartTime !== null
         ? new Date(Math.round(output.ExecutionStartTime * 1000))
         : undefined,
-    FailureMessage:
-      output.FailureMessage !== undefined && output.FailureMessage !== null ? output.FailureMessage : undefined,
-    LogFile: output.LogFile !== undefined && output.LogFile !== null ? output.LogFile : undefined,
-    MaxConcurrency:
-      output.MaxConcurrency !== undefined && output.MaxConcurrency !== null ? output.MaxConcurrency : undefined,
-    MaxErrors: output.MaxErrors !== undefined && output.MaxErrors !== null ? output.MaxErrors : undefined,
-    Mode: output.Mode !== undefined && output.Mode !== null ? output.Mode : undefined,
-    OpsItemId: output.OpsItemId !== undefined && output.OpsItemId !== null ? output.OpsItemId : undefined,
+    FailureMessage: __expectString(output.FailureMessage),
+    LogFile: __expectString(output.LogFile),
+    MaxConcurrency: __expectString(output.MaxConcurrency),
+    MaxErrors: __expectString(output.MaxErrors),
+    Mode: __expectString(output.Mode),
+    OpsItemId: __expectString(output.OpsItemId),
     Outputs:
       output.Outputs !== undefined && output.Outputs !== null
         ? deserializeAws_json1_1AutomationParameterMap(output.Outputs, context)
         : undefined,
-    ParentAutomationExecutionId:
-      output.ParentAutomationExecutionId !== undefined && output.ParentAutomationExecutionId !== null
-        ? output.ParentAutomationExecutionId
-        : undefined,
+    ParentAutomationExecutionId: __expectString(output.ParentAutomationExecutionId),
     ResolvedTargets:
       output.ResolvedTargets !== undefined && output.ResolvedTargets !== null
         ? deserializeAws_json1_1ResolvedTargets(output.ResolvedTargets, context)
@@ -19362,15 +19244,12 @@ const deserializeAws_json1_1AutomationExecutionMetadata = (
       output.ScheduledTime !== undefined && output.ScheduledTime !== null
         ? new Date(Math.round(output.ScheduledTime * 1000))
         : undefined,
-    Target: output.Target !== undefined && output.Target !== null ? output.Target : undefined,
+    Target: __expectString(output.Target),
     TargetMaps:
       output.TargetMaps !== undefined && output.TargetMaps !== null
         ? deserializeAws_json1_1TargetMaps(output.TargetMaps, context)
         : undefined,
-    TargetParameterName:
-      output.TargetParameterName !== undefined && output.TargetParameterName !== null
-        ? output.TargetParameterName
-        : undefined,
+    TargetParameterName: __expectString(output.TargetParameterName),
     Targets:
       output.Targets !== undefined && output.Targets !== null
         ? deserializeAws_json1_1Targets(output.Targets, context)
@@ -19397,7 +19276,7 @@ const deserializeAws_json1_1AutomationExecutionNotFoundException = (
   context: __SerdeContext
 ): AutomationExecutionNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -19423,7 +19302,7 @@ const deserializeAws_json1_1AutomationParameterValueList = (output: any, context
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -19432,7 +19311,7 @@ const deserializeAws_json1_1AutomationStepNotFoundException = (
   context: __SerdeContext
 ): AutomationStepNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -19443,7 +19322,7 @@ const deserializeAws_json1_1CalendarNameOrARNList = (output: any, context: __Ser
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -19456,23 +19335,14 @@ const deserializeAws_json1_1CancelMaintenanceWindowExecutionResult = (
   context: __SerdeContext
 ): CancelMaintenanceWindowExecutionResult => {
   return {
-    WindowExecutionId:
-      output.WindowExecutionId !== undefined && output.WindowExecutionId !== null
-        ? output.WindowExecutionId
-        : undefined,
+    WindowExecutionId: __expectString(output.WindowExecutionId),
   } as any;
 };
 
 const deserializeAws_json1_1CloudWatchOutputConfig = (output: any, context: __SerdeContext): CloudWatchOutputConfig => {
   return {
-    CloudWatchLogGroupName:
-      output.CloudWatchLogGroupName !== undefined && output.CloudWatchLogGroupName !== null
-        ? output.CloudWatchLogGroupName
-        : undefined,
-    CloudWatchOutputEnabled:
-      output.CloudWatchOutputEnabled !== undefined && output.CloudWatchOutputEnabled !== null
-        ? output.CloudWatchOutputEnabled
-        : undefined,
+    CloudWatchLogGroupName: __expectString(output.CloudWatchLogGroupName),
+    CloudWatchOutputEnabled: __expectBoolean(output.CloudWatchOutputEnabled),
   } as any;
 };
 
@@ -19482,18 +19352,13 @@ const deserializeAws_json1_1Command = (output: any, context: __SerdeContext): Co
       output.CloudWatchOutputConfig !== undefined && output.CloudWatchOutputConfig !== null
         ? deserializeAws_json1_1CloudWatchOutputConfig(output.CloudWatchOutputConfig, context)
         : undefined,
-    CommandId: output.CommandId !== undefined && output.CommandId !== null ? output.CommandId : undefined,
-    Comment: output.Comment !== undefined && output.Comment !== null ? output.Comment : undefined,
-    CompletedCount:
-      output.CompletedCount !== undefined && output.CompletedCount !== null ? output.CompletedCount : undefined,
-    DeliveryTimedOutCount:
-      output.DeliveryTimedOutCount !== undefined && output.DeliveryTimedOutCount !== null
-        ? output.DeliveryTimedOutCount
-        : undefined,
-    DocumentName: output.DocumentName !== undefined && output.DocumentName !== null ? output.DocumentName : undefined,
-    DocumentVersion:
-      output.DocumentVersion !== undefined && output.DocumentVersion !== null ? output.DocumentVersion : undefined,
-    ErrorCount: output.ErrorCount !== undefined && output.ErrorCount !== null ? output.ErrorCount : undefined,
+    CommandId: __expectString(output.CommandId),
+    Comment: __expectString(output.Comment),
+    CompletedCount: __expectNumber(output.CompletedCount),
+    DeliveryTimedOutCount: __expectNumber(output.DeliveryTimedOutCount),
+    DocumentName: __expectString(output.DocumentName),
+    DocumentVersion: __expectString(output.DocumentVersion),
+    ErrorCount: __expectNumber(output.ErrorCount),
     ExpiresAfter:
       output.ExpiresAfter !== undefined && output.ExpiresAfter !== null
         ? new Date(Math.round(output.ExpiresAfter * 1000))
@@ -19502,23 +19367,15 @@ const deserializeAws_json1_1Command = (output: any, context: __SerdeContext): Co
       output.InstanceIds !== undefined && output.InstanceIds !== null
         ? deserializeAws_json1_1InstanceIdList(output.InstanceIds, context)
         : undefined,
-    MaxConcurrency:
-      output.MaxConcurrency !== undefined && output.MaxConcurrency !== null ? output.MaxConcurrency : undefined,
-    MaxErrors: output.MaxErrors !== undefined && output.MaxErrors !== null ? output.MaxErrors : undefined,
+    MaxConcurrency: __expectString(output.MaxConcurrency),
+    MaxErrors: __expectString(output.MaxErrors),
     NotificationConfig:
       output.NotificationConfig !== undefined && output.NotificationConfig !== null
         ? deserializeAws_json1_1NotificationConfig(output.NotificationConfig, context)
         : undefined,
-    OutputS3BucketName:
-      output.OutputS3BucketName !== undefined && output.OutputS3BucketName !== null
-        ? output.OutputS3BucketName
-        : undefined,
-    OutputS3KeyPrefix:
-      output.OutputS3KeyPrefix !== undefined && output.OutputS3KeyPrefix !== null
-        ? output.OutputS3KeyPrefix
-        : undefined,
-    OutputS3Region:
-      output.OutputS3Region !== undefined && output.OutputS3Region !== null ? output.OutputS3Region : undefined,
+    OutputS3BucketName: __expectString(output.OutputS3BucketName),
+    OutputS3KeyPrefix: __expectString(output.OutputS3KeyPrefix),
+    OutputS3Region: __expectString(output.OutputS3Region),
     Parameters:
       output.Parameters !== undefined && output.Parameters !== null
         ? deserializeAws_json1_1Parameters(output.Parameters, context)
@@ -19527,17 +19384,15 @@ const deserializeAws_json1_1Command = (output: any, context: __SerdeContext): Co
       output.RequestedDateTime !== undefined && output.RequestedDateTime !== null
         ? new Date(Math.round(output.RequestedDateTime * 1000))
         : undefined,
-    ServiceRole: output.ServiceRole !== undefined && output.ServiceRole !== null ? output.ServiceRole : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusDetails:
-      output.StatusDetails !== undefined && output.StatusDetails !== null ? output.StatusDetails : undefined,
-    TargetCount: output.TargetCount !== undefined && output.TargetCount !== null ? output.TargetCount : undefined,
+    ServiceRole: __expectString(output.ServiceRole),
+    Status: __expectString(output.Status),
+    StatusDetails: __expectString(output.StatusDetails),
+    TargetCount: __expectNumber(output.TargetCount),
     Targets:
       output.Targets !== undefined && output.Targets !== null
         ? deserializeAws_json1_1Targets(output.Targets, context)
         : undefined,
-    TimeoutSeconds:
-      output.TimeoutSeconds !== undefined && output.TimeoutSeconds !== null ? output.TimeoutSeconds : undefined,
+    TimeoutSeconds: __expectNumber(output.TimeoutSeconds),
   } as any;
 };
 
@@ -19547,17 +19402,16 @@ const deserializeAws_json1_1CommandInvocation = (output: any, context: __SerdeCo
       output.CloudWatchOutputConfig !== undefined && output.CloudWatchOutputConfig !== null
         ? deserializeAws_json1_1CloudWatchOutputConfig(output.CloudWatchOutputConfig, context)
         : undefined,
-    CommandId: output.CommandId !== undefined && output.CommandId !== null ? output.CommandId : undefined,
+    CommandId: __expectString(output.CommandId),
     CommandPlugins:
       output.CommandPlugins !== undefined && output.CommandPlugins !== null
         ? deserializeAws_json1_1CommandPluginList(output.CommandPlugins, context)
         : undefined,
-    Comment: output.Comment !== undefined && output.Comment !== null ? output.Comment : undefined,
-    DocumentName: output.DocumentName !== undefined && output.DocumentName !== null ? output.DocumentName : undefined,
-    DocumentVersion:
-      output.DocumentVersion !== undefined && output.DocumentVersion !== null ? output.DocumentVersion : undefined,
-    InstanceId: output.InstanceId !== undefined && output.InstanceId !== null ? output.InstanceId : undefined,
-    InstanceName: output.InstanceName !== undefined && output.InstanceName !== null ? output.InstanceName : undefined,
+    Comment: __expectString(output.Comment),
+    DocumentName: __expectString(output.DocumentName),
+    DocumentVersion: __expectString(output.DocumentVersion),
+    InstanceId: __expectString(output.InstanceId),
+    InstanceName: __expectString(output.InstanceName),
     NotificationConfig:
       output.NotificationConfig !== undefined && output.NotificationConfig !== null
         ? deserializeAws_json1_1NotificationConfig(output.NotificationConfig, context)
@@ -19566,17 +19420,12 @@ const deserializeAws_json1_1CommandInvocation = (output: any, context: __SerdeCo
       output.RequestedDateTime !== undefined && output.RequestedDateTime !== null
         ? new Date(Math.round(output.RequestedDateTime * 1000))
         : undefined,
-    ServiceRole: output.ServiceRole !== undefined && output.ServiceRole !== null ? output.ServiceRole : undefined,
-    StandardErrorUrl:
-      output.StandardErrorUrl !== undefined && output.StandardErrorUrl !== null ? output.StandardErrorUrl : undefined,
-    StandardOutputUrl:
-      output.StandardOutputUrl !== undefined && output.StandardOutputUrl !== null
-        ? output.StandardOutputUrl
-        : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusDetails:
-      output.StatusDetails !== undefined && output.StatusDetails !== null ? output.StatusDetails : undefined,
-    TraceOutput: output.TraceOutput !== undefined && output.TraceOutput !== null ? output.TraceOutput : undefined,
+    ServiceRole: __expectString(output.ServiceRole),
+    StandardErrorUrl: __expectString(output.StandardErrorUrl),
+    StandardOutputUrl: __expectString(output.StandardOutputUrl),
+    Status: __expectString(output.Status),
+    StatusDetails: __expectString(output.StatusDetails),
+    TraceOutput: __expectString(output.TraceOutput),
   } as any;
 };
 
@@ -19604,19 +19453,12 @@ const deserializeAws_json1_1CommandList = (output: any, context: __SerdeContext)
 
 const deserializeAws_json1_1CommandPlugin = (output: any, context: __SerdeContext): CommandPlugin => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Output: output.Output !== undefined && output.Output !== null ? output.Output : undefined,
-    OutputS3BucketName:
-      output.OutputS3BucketName !== undefined && output.OutputS3BucketName !== null
-        ? output.OutputS3BucketName
-        : undefined,
-    OutputS3KeyPrefix:
-      output.OutputS3KeyPrefix !== undefined && output.OutputS3KeyPrefix !== null
-        ? output.OutputS3KeyPrefix
-        : undefined,
-    OutputS3Region:
-      output.OutputS3Region !== undefined && output.OutputS3Region !== null ? output.OutputS3Region : undefined,
-    ResponseCode: output.ResponseCode !== undefined && output.ResponseCode !== null ? output.ResponseCode : undefined,
+    Name: __expectString(output.Name),
+    Output: __expectString(output.Output),
+    OutputS3BucketName: __expectString(output.OutputS3BucketName),
+    OutputS3KeyPrefix: __expectString(output.OutputS3KeyPrefix),
+    OutputS3Region: __expectString(output.OutputS3Region),
+    ResponseCode: __expectNumber(output.ResponseCode),
     ResponseFinishDateTime:
       output.ResponseFinishDateTime !== undefined && output.ResponseFinishDateTime !== null
         ? new Date(Math.round(output.ResponseFinishDateTime * 1000))
@@ -19625,15 +19467,10 @@ const deserializeAws_json1_1CommandPlugin = (output: any, context: __SerdeContex
       output.ResponseStartDateTime !== undefined && output.ResponseStartDateTime !== null
         ? new Date(Math.round(output.ResponseStartDateTime * 1000))
         : undefined,
-    StandardErrorUrl:
-      output.StandardErrorUrl !== undefined && output.StandardErrorUrl !== null ? output.StandardErrorUrl : undefined,
-    StandardOutputUrl:
-      output.StandardOutputUrl !== undefined && output.StandardOutputUrl !== null
-        ? output.StandardOutputUrl
-        : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusDetails:
-      output.StatusDetails !== undefined && output.StatusDetails !== null ? output.StatusDetails : undefined,
+    StandardErrorUrl: __expectString(output.StandardErrorUrl),
+    StandardOutputUrl: __expectString(output.StandardOutputUrl),
+    Status: __expectString(output.Status),
+    StatusDetails: __expectString(output.StatusDetails),
   } as any;
 };
 
@@ -19653,20 +19490,18 @@ const deserializeAws_json1_1ComplianceExecutionSummary = (
   context: __SerdeContext
 ): ComplianceExecutionSummary => {
   return {
-    ExecutionId: output.ExecutionId !== undefined && output.ExecutionId !== null ? output.ExecutionId : undefined,
+    ExecutionId: __expectString(output.ExecutionId),
     ExecutionTime:
       output.ExecutionTime !== undefined && output.ExecutionTime !== null
         ? new Date(Math.round(output.ExecutionTime * 1000))
         : undefined,
-    ExecutionType:
-      output.ExecutionType !== undefined && output.ExecutionType !== null ? output.ExecutionType : undefined,
+    ExecutionType: __expectString(output.ExecutionType),
   } as any;
 };
 
 const deserializeAws_json1_1ComplianceItem = (output: any, context: __SerdeContext): ComplianceItem => {
   return {
-    ComplianceType:
-      output.ComplianceType !== undefined && output.ComplianceType !== null ? output.ComplianceType : undefined,
+    ComplianceType: __expectString(output.ComplianceType),
     Details:
       output.Details !== undefined && output.Details !== null
         ? deserializeAws_json1_1ComplianceItemDetails(output.Details, context)
@@ -19675,12 +19510,12 @@ const deserializeAws_json1_1ComplianceItem = (output: any, context: __SerdeConte
       output.ExecutionSummary !== undefined && output.ExecutionSummary !== null
         ? deserializeAws_json1_1ComplianceExecutionSummary(output.ExecutionSummary, context)
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    ResourceId: output.ResourceId !== undefined && output.ResourceId !== null ? output.ResourceId : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
-    Severity: output.Severity !== undefined && output.Severity !== null ? output.Severity : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    Title: output.Title !== undefined && output.Title !== null ? output.Title : undefined,
+    Id: __expectString(output.Id),
+    ResourceId: __expectString(output.ResourceId),
+    ResourceType: __expectString(output.ResourceType),
+    Severity: __expectString(output.Severity),
+    Status: __expectString(output.Status),
+    Title: __expectString(output.Title),
   } as any;
 };
 
@@ -19694,7 +19529,7 @@ const deserializeAws_json1_1ComplianceItemDetails = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -19712,8 +19547,7 @@ const deserializeAws_json1_1ComplianceItemList = (output: any, context: __SerdeC
 
 const deserializeAws_json1_1ComplianceSummaryItem = (output: any, context: __SerdeContext): ComplianceSummaryItem => {
   return {
-    ComplianceType:
-      output.ComplianceType !== undefined && output.ComplianceType !== null ? output.ComplianceType : undefined,
+    ComplianceType: __expectString(output.ComplianceType),
     CompliantSummary:
       output.CompliantSummary !== undefined && output.CompliantSummary !== null
         ? deserializeAws_json1_1CompliantSummary(output.CompliantSummary, context)
@@ -19744,14 +19578,13 @@ const deserializeAws_json1_1ComplianceTypeCountLimitExceededException = (
   context: __SerdeContext
 ): ComplianceTypeCountLimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1CompliantSummary = (output: any, context: __SerdeContext): CompliantSummary => {
   return {
-    CompliantCount:
-      output.CompliantCount !== undefined && output.CompliantCount !== null ? output.CompliantCount : undefined,
+    CompliantCount: __expectNumber(output.CompliantCount),
     SeveritySummary:
       output.SeveritySummary !== undefined && output.SeveritySummary !== null
         ? deserializeAws_json1_1SeveritySummary(output.SeveritySummary, context)
@@ -19761,9 +19594,8 @@ const deserializeAws_json1_1CompliantSummary = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1CreateActivationResult = (output: any, context: __SerdeContext): CreateActivationResult => {
   return {
-    ActivationCode:
-      output.ActivationCode !== undefined && output.ActivationCode !== null ? output.ActivationCode : undefined,
-    ActivationId: output.ActivationId !== undefined && output.ActivationId !== null ? output.ActivationId : undefined,
+    ActivationCode: __expectString(output.ActivationCode),
+    ActivationId: __expectString(output.ActivationId),
   } as any;
 };
 
@@ -19772,31 +19604,19 @@ const deserializeAws_json1_1CreateAssociationBatchRequestEntry = (
   context: __SerdeContext
 ): CreateAssociationBatchRequestEntry => {
   return {
-    ApplyOnlyAtCronInterval:
-      output.ApplyOnlyAtCronInterval !== undefined && output.ApplyOnlyAtCronInterval !== null
-        ? output.ApplyOnlyAtCronInterval
-        : undefined,
-    AssociationName:
-      output.AssociationName !== undefined && output.AssociationName !== null ? output.AssociationName : undefined,
-    AutomationTargetParameterName:
-      output.AutomationTargetParameterName !== undefined && output.AutomationTargetParameterName !== null
-        ? output.AutomationTargetParameterName
-        : undefined,
+    ApplyOnlyAtCronInterval: __expectBoolean(output.ApplyOnlyAtCronInterval),
+    AssociationName: __expectString(output.AssociationName),
+    AutomationTargetParameterName: __expectString(output.AutomationTargetParameterName),
     CalendarNames:
       output.CalendarNames !== undefined && output.CalendarNames !== null
         ? deserializeAws_json1_1CalendarNameOrARNList(output.CalendarNames, context)
         : undefined,
-    ComplianceSeverity:
-      output.ComplianceSeverity !== undefined && output.ComplianceSeverity !== null
-        ? output.ComplianceSeverity
-        : undefined,
-    DocumentVersion:
-      output.DocumentVersion !== undefined && output.DocumentVersion !== null ? output.DocumentVersion : undefined,
-    InstanceId: output.InstanceId !== undefined && output.InstanceId !== null ? output.InstanceId : undefined,
-    MaxConcurrency:
-      output.MaxConcurrency !== undefined && output.MaxConcurrency !== null ? output.MaxConcurrency : undefined,
-    MaxErrors: output.MaxErrors !== undefined && output.MaxErrors !== null ? output.MaxErrors : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    ComplianceSeverity: __expectString(output.ComplianceSeverity),
+    DocumentVersion: __expectString(output.DocumentVersion),
+    InstanceId: __expectString(output.InstanceId),
+    MaxConcurrency: __expectString(output.MaxConcurrency),
+    MaxErrors: __expectString(output.MaxErrors),
+    Name: __expectString(output.Name),
     OutputLocation:
       output.OutputLocation !== undefined && output.OutputLocation !== null
         ? deserializeAws_json1_1InstanceAssociationOutputLocation(output.OutputLocation, context)
@@ -19805,12 +19625,8 @@ const deserializeAws_json1_1CreateAssociationBatchRequestEntry = (
       output.Parameters !== undefined && output.Parameters !== null
         ? deserializeAws_json1_1Parameters(output.Parameters, context)
         : undefined,
-    ScheduleExpression:
-      output.ScheduleExpression !== undefined && output.ScheduleExpression !== null
-        ? output.ScheduleExpression
-        : undefined,
-    SyncCompliance:
-      output.SyncCompliance !== undefined && output.SyncCompliance !== null ? output.SyncCompliance : undefined,
+    ScheduleExpression: __expectString(output.ScheduleExpression),
+    SyncCompliance: __expectString(output.SyncCompliance),
     TargetLocations:
       output.TargetLocations !== undefined && output.TargetLocations !== null
         ? deserializeAws_json1_1TargetLocations(output.TargetLocations, context)
@@ -19864,13 +19680,13 @@ const deserializeAws_json1_1CreateMaintenanceWindowResult = (
   context: __SerdeContext
 ): CreateMaintenanceWindowResult => {
   return {
-    WindowId: output.WindowId !== undefined && output.WindowId !== null ? output.WindowId : undefined,
+    WindowId: __expectString(output.WindowId),
   } as any;
 };
 
 const deserializeAws_json1_1CreateOpsItemResponse = (output: any, context: __SerdeContext): CreateOpsItemResponse => {
   return {
-    OpsItemId: output.OpsItemId !== undefined && output.OpsItemId !== null ? output.OpsItemId : undefined,
+    OpsItemId: __expectString(output.OpsItemId),
   } as any;
 };
 
@@ -19879,8 +19695,7 @@ const deserializeAws_json1_1CreateOpsMetadataResult = (
   context: __SerdeContext
 ): CreateOpsMetadataResult => {
   return {
-    OpsMetadataArn:
-      output.OpsMetadataArn !== undefined && output.OpsMetadataArn !== null ? output.OpsMetadataArn : undefined,
+    OpsMetadataArn: __expectString(output.OpsMetadataArn),
   } as any;
 };
 
@@ -19889,7 +19704,7 @@ const deserializeAws_json1_1CreatePatchBaselineResult = (
   context: __SerdeContext
 ): CreatePatchBaselineResult => {
   return {
-    BaselineId: output.BaselineId !== undefined && output.BaselineId !== null ? output.BaselineId : undefined,
+    BaselineId: __expectString(output.BaselineId),
   } as any;
 };
 
@@ -19905,7 +19720,7 @@ const deserializeAws_json1_1CustomSchemaCountLimitExceededException = (
   context: __SerdeContext
 ): CustomSchemaCountLimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -19926,12 +19741,12 @@ const deserializeAws_json1_1DeleteDocumentResult = (output: any, context: __Serd
 
 const deserializeAws_json1_1DeleteInventoryResult = (output: any, context: __SerdeContext): DeleteInventoryResult => {
   return {
-    DeletionId: output.DeletionId !== undefined && output.DeletionId !== null ? output.DeletionId : undefined,
+    DeletionId: __expectString(output.DeletionId),
     DeletionSummary:
       output.DeletionSummary !== undefined && output.DeletionSummary !== null
         ? deserializeAws_json1_1InventoryDeletionSummary(output.DeletionSummary, context)
         : undefined,
-    TypeName: output.TypeName !== undefined && output.TypeName !== null ? output.TypeName : undefined,
+    TypeName: __expectString(output.TypeName),
   } as any;
 };
 
@@ -19940,7 +19755,7 @@ const deserializeAws_json1_1DeleteMaintenanceWindowResult = (
   context: __SerdeContext
 ): DeleteMaintenanceWindowResult => {
   return {
-    WindowId: output.WindowId !== undefined && output.WindowId !== null ? output.WindowId : undefined,
+    WindowId: __expectString(output.WindowId),
   } as any;
 };
 
@@ -19973,7 +19788,7 @@ const deserializeAws_json1_1DeletePatchBaselineResult = (
   context: __SerdeContext
 ): DeletePatchBaselineResult => {
   return {
-    BaselineId: output.BaselineId !== undefined && output.BaselineId !== null ? output.BaselineId : undefined,
+    BaselineId: __expectString(output.BaselineId),
   } as any;
 };
 
@@ -19996,8 +19811,8 @@ const deserializeAws_json1_1DeregisterPatchBaselineForPatchGroupResult = (
   context: __SerdeContext
 ): DeregisterPatchBaselineForPatchGroupResult => {
   return {
-    BaselineId: output.BaselineId !== undefined && output.BaselineId !== null ? output.BaselineId : undefined,
-    PatchGroup: output.PatchGroup !== undefined && output.PatchGroup !== null ? output.PatchGroup : undefined,
+    BaselineId: __expectString(output.BaselineId),
+    PatchGroup: __expectString(output.PatchGroup),
   } as any;
 };
 
@@ -20006,9 +19821,8 @@ const deserializeAws_json1_1DeregisterTargetFromMaintenanceWindowResult = (
   context: __SerdeContext
 ): DeregisterTargetFromMaintenanceWindowResult => {
   return {
-    WindowId: output.WindowId !== undefined && output.WindowId !== null ? output.WindowId : undefined,
-    WindowTargetId:
-      output.WindowTargetId !== undefined && output.WindowTargetId !== null ? output.WindowTargetId : undefined,
+    WindowId: __expectString(output.WindowId),
+    WindowTargetId: __expectString(output.WindowTargetId),
   } as any;
 };
 
@@ -20017,8 +19831,8 @@ const deserializeAws_json1_1DeregisterTaskFromMaintenanceWindowResult = (
   context: __SerdeContext
 ): DeregisterTaskFromMaintenanceWindowResult => {
   return {
-    WindowId: output.WindowId !== undefined && output.WindowId !== null ? output.WindowId : undefined,
-    WindowTaskId: output.WindowTaskId !== undefined && output.WindowTaskId !== null ? output.WindowTaskId : undefined,
+    WindowId: __expectString(output.WindowId),
+    WindowTaskId: __expectString(output.WindowTaskId),
   } as any;
 };
 
@@ -20031,7 +19845,7 @@ const deserializeAws_json1_1DescribeActivationsResult = (
       output.ActivationList !== undefined && output.ActivationList !== null
         ? deserializeAws_json1_1ActivationList(output.ActivationList, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -20044,7 +19858,7 @@ const deserializeAws_json1_1DescribeAssociationExecutionsResult = (
       output.AssociationExecutions !== undefined && output.AssociationExecutions !== null
         ? deserializeAws_json1_1AssociationExecutionsList(output.AssociationExecutions, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -20057,7 +19871,7 @@ const deserializeAws_json1_1DescribeAssociationExecutionTargetsResult = (
       output.AssociationExecutionTargets !== undefined && output.AssociationExecutionTargets !== null
         ? deserializeAws_json1_1AssociationExecutionTargetsList(output.AssociationExecutionTargets, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -20082,7 +19896,7 @@ const deserializeAws_json1_1DescribeAutomationExecutionsResult = (
       output.AutomationExecutionMetadataList !== undefined && output.AutomationExecutionMetadataList !== null
         ? deserializeAws_json1_1AutomationExecutionMetadataList(output.AutomationExecutionMetadataList, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -20091,7 +19905,7 @@ const deserializeAws_json1_1DescribeAutomationStepExecutionsResult = (
   context: __SerdeContext
 ): DescribeAutomationStepExecutionsResult => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     StepExecutions:
       output.StepExecutions !== undefined && output.StepExecutions !== null
         ? deserializeAws_json1_1StepExecutionList(output.StepExecutions, context)
@@ -20104,7 +19918,7 @@ const deserializeAws_json1_1DescribeAvailablePatchesResult = (
   context: __SerdeContext
 ): DescribeAvailablePatchesResult => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Patches:
       output.Patches !== undefined && output.Patches !== null
         ? deserializeAws_json1_1PatchList(output.Patches, context)
@@ -20125,7 +19939,7 @@ const deserializeAws_json1_1DescribeDocumentPermissionResponse = (
       output.AccountSharingInfoList !== undefined && output.AccountSharingInfoList !== null
         ? deserializeAws_json1_1AccountSharingInfoList(output.AccountSharingInfoList, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -20147,7 +19961,7 @@ const deserializeAws_json1_1DescribeEffectiveInstanceAssociationsResult = (
       output.Associations !== undefined && output.Associations !== null
         ? deserializeAws_json1_1InstanceAssociationList(output.Associations, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -20160,7 +19974,7 @@ const deserializeAws_json1_1DescribeEffectivePatchesForPatchBaselineResult = (
       output.EffectivePatches !== undefined && output.EffectivePatches !== null
         ? deserializeAws_json1_1EffectivePatchList(output.EffectivePatches, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -20173,7 +19987,7 @@ const deserializeAws_json1_1DescribeInstanceAssociationsStatusResult = (
       output.InstanceAssociationStatusInfos !== undefined && output.InstanceAssociationStatusInfos !== null
         ? deserializeAws_json1_1InstanceAssociationStatusInfos(output.InstanceAssociationStatusInfos, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -20186,7 +20000,7 @@ const deserializeAws_json1_1DescribeInstanceInformationResult = (
       output.InstanceInformationList !== undefined && output.InstanceInformationList !== null
         ? deserializeAws_json1_1InstanceInformationList(output.InstanceInformationList, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -20195,7 +20009,7 @@ const deserializeAws_json1_1DescribeInstancePatchesResult = (
   context: __SerdeContext
 ): DescribeInstancePatchesResult => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Patches:
       output.Patches !== undefined && output.Patches !== null
         ? deserializeAws_json1_1PatchComplianceDataList(output.Patches, context)
@@ -20212,7 +20026,7 @@ const deserializeAws_json1_1DescribeInstancePatchStatesForPatchGroupResult = (
       output.InstancePatchStates !== undefined && output.InstancePatchStates !== null
         ? deserializeAws_json1_1InstancePatchStatesList(output.InstancePatchStates, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -20225,7 +20039,7 @@ const deserializeAws_json1_1DescribeInstancePatchStatesResult = (
       output.InstancePatchStates !== undefined && output.InstancePatchStates !== null
         ? deserializeAws_json1_1InstancePatchStateList(output.InstancePatchStates, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -20238,7 +20052,7 @@ const deserializeAws_json1_1DescribeInventoryDeletionsResult = (
       output.InventoryDeletions !== undefined && output.InventoryDeletions !== null
         ? deserializeAws_json1_1InventoryDeletionsList(output.InventoryDeletions, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -20247,7 +20061,7 @@ const deserializeAws_json1_1DescribeMaintenanceWindowExecutionsResult = (
   context: __SerdeContext
 ): DescribeMaintenanceWindowExecutionsResult => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     WindowExecutions:
       output.WindowExecutions !== undefined && output.WindowExecutions !== null
         ? deserializeAws_json1_1MaintenanceWindowExecutionList(output.WindowExecutions, context)
@@ -20260,7 +20074,7 @@ const deserializeAws_json1_1DescribeMaintenanceWindowExecutionTaskInvocationsRes
   context: __SerdeContext
 ): DescribeMaintenanceWindowExecutionTaskInvocationsResult => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     WindowExecutionTaskInvocationIdentities:
       output.WindowExecutionTaskInvocationIdentities !== undefined &&
       output.WindowExecutionTaskInvocationIdentities !== null
@@ -20277,7 +20091,7 @@ const deserializeAws_json1_1DescribeMaintenanceWindowExecutionTasksResult = (
   context: __SerdeContext
 ): DescribeMaintenanceWindowExecutionTasksResult => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     WindowExecutionTaskIdentities:
       output.WindowExecutionTaskIdentities !== undefined && output.WindowExecutionTaskIdentities !== null
         ? deserializeAws_json1_1MaintenanceWindowExecutionTaskIdentityList(
@@ -20293,7 +20107,7 @@ const deserializeAws_json1_1DescribeMaintenanceWindowScheduleResult = (
   context: __SerdeContext
 ): DescribeMaintenanceWindowScheduleResult => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     ScheduledWindowExecutions:
       output.ScheduledWindowExecutions !== undefined && output.ScheduledWindowExecutions !== null
         ? deserializeAws_json1_1ScheduledWindowExecutionList(output.ScheduledWindowExecutions, context)
@@ -20306,7 +20120,7 @@ const deserializeAws_json1_1DescribeMaintenanceWindowsForTargetResult = (
   context: __SerdeContext
 ): DescribeMaintenanceWindowsForTargetResult => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     WindowIdentities:
       output.WindowIdentities !== undefined && output.WindowIdentities !== null
         ? deserializeAws_json1_1MaintenanceWindowsForTargetList(output.WindowIdentities, context)
@@ -20319,7 +20133,7 @@ const deserializeAws_json1_1DescribeMaintenanceWindowsResult = (
   context: __SerdeContext
 ): DescribeMaintenanceWindowsResult => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     WindowIdentities:
       output.WindowIdentities !== undefined && output.WindowIdentities !== null
         ? deserializeAws_json1_1MaintenanceWindowIdentityList(output.WindowIdentities, context)
@@ -20332,7 +20146,7 @@ const deserializeAws_json1_1DescribeMaintenanceWindowTargetsResult = (
   context: __SerdeContext
 ): DescribeMaintenanceWindowTargetsResult => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Targets:
       output.Targets !== undefined && output.Targets !== null
         ? deserializeAws_json1_1MaintenanceWindowTargetList(output.Targets, context)
@@ -20345,7 +20159,7 @@ const deserializeAws_json1_1DescribeMaintenanceWindowTasksResult = (
   context: __SerdeContext
 ): DescribeMaintenanceWindowTasksResult => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Tasks:
       output.Tasks !== undefined && output.Tasks !== null
         ? deserializeAws_json1_1MaintenanceWindowTaskList(output.Tasks, context)
@@ -20358,7 +20172,7 @@ const deserializeAws_json1_1DescribeOpsItemsResponse = (
   context: __SerdeContext
 ): DescribeOpsItemsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     OpsItemSummaries:
       output.OpsItemSummaries !== undefined && output.OpsItemSummaries !== null
         ? deserializeAws_json1_1OpsItemSummaries(output.OpsItemSummaries, context)
@@ -20371,7 +20185,7 @@ const deserializeAws_json1_1DescribeParametersResult = (
   context: __SerdeContext
 ): DescribeParametersResult => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Parameters:
       output.Parameters !== undefined && output.Parameters !== null
         ? deserializeAws_json1_1ParameterMetadataList(output.Parameters, context)
@@ -20388,7 +20202,7 @@ const deserializeAws_json1_1DescribePatchBaselinesResult = (
       output.BaselineIdentities !== undefined && output.BaselineIdentities !== null
         ? deserializeAws_json1_1PatchBaselineIdentityList(output.BaselineIdentities, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -20401,7 +20215,7 @@ const deserializeAws_json1_1DescribePatchGroupsResult = (
       output.Mappings !== undefined && output.Mappings !== null
         ? deserializeAws_json1_1PatchGroupPatchBaselineMappingList(output.Mappings, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -20410,57 +20224,18 @@ const deserializeAws_json1_1DescribePatchGroupStateResult = (
   context: __SerdeContext
 ): DescribePatchGroupStateResult => {
   return {
-    Instances: output.Instances !== undefined && output.Instances !== null ? output.Instances : undefined,
-    InstancesWithCriticalNonCompliantPatches:
-      output.InstancesWithCriticalNonCompliantPatches !== undefined &&
-      output.InstancesWithCriticalNonCompliantPatches !== null
-        ? output.InstancesWithCriticalNonCompliantPatches
-        : undefined,
-    InstancesWithFailedPatches:
-      output.InstancesWithFailedPatches !== undefined && output.InstancesWithFailedPatches !== null
-        ? output.InstancesWithFailedPatches
-        : undefined,
-    InstancesWithInstalledOtherPatches:
-      output.InstancesWithInstalledOtherPatches !== undefined && output.InstancesWithInstalledOtherPatches !== null
-        ? output.InstancesWithInstalledOtherPatches
-        : undefined,
-    InstancesWithInstalledPatches:
-      output.InstancesWithInstalledPatches !== undefined && output.InstancesWithInstalledPatches !== null
-        ? output.InstancesWithInstalledPatches
-        : undefined,
-    InstancesWithInstalledPendingRebootPatches:
-      output.InstancesWithInstalledPendingRebootPatches !== undefined &&
-      output.InstancesWithInstalledPendingRebootPatches !== null
-        ? output.InstancesWithInstalledPendingRebootPatches
-        : undefined,
-    InstancesWithInstalledRejectedPatches:
-      output.InstancesWithInstalledRejectedPatches !== undefined &&
-      output.InstancesWithInstalledRejectedPatches !== null
-        ? output.InstancesWithInstalledRejectedPatches
-        : undefined,
-    InstancesWithMissingPatches:
-      output.InstancesWithMissingPatches !== undefined && output.InstancesWithMissingPatches !== null
-        ? output.InstancesWithMissingPatches
-        : undefined,
-    InstancesWithNotApplicablePatches:
-      output.InstancesWithNotApplicablePatches !== undefined && output.InstancesWithNotApplicablePatches !== null
-        ? output.InstancesWithNotApplicablePatches
-        : undefined,
-    InstancesWithOtherNonCompliantPatches:
-      output.InstancesWithOtherNonCompliantPatches !== undefined &&
-      output.InstancesWithOtherNonCompliantPatches !== null
-        ? output.InstancesWithOtherNonCompliantPatches
-        : undefined,
-    InstancesWithSecurityNonCompliantPatches:
-      output.InstancesWithSecurityNonCompliantPatches !== undefined &&
-      output.InstancesWithSecurityNonCompliantPatches !== null
-        ? output.InstancesWithSecurityNonCompliantPatches
-        : undefined,
-    InstancesWithUnreportedNotApplicablePatches:
-      output.InstancesWithUnreportedNotApplicablePatches !== undefined &&
-      output.InstancesWithUnreportedNotApplicablePatches !== null
-        ? output.InstancesWithUnreportedNotApplicablePatches
-        : undefined,
+    Instances: __expectNumber(output.Instances),
+    InstancesWithCriticalNonCompliantPatches: __expectNumber(output.InstancesWithCriticalNonCompliantPatches),
+    InstancesWithFailedPatches: __expectNumber(output.InstancesWithFailedPatches),
+    InstancesWithInstalledOtherPatches: __expectNumber(output.InstancesWithInstalledOtherPatches),
+    InstancesWithInstalledPatches: __expectNumber(output.InstancesWithInstalledPatches),
+    InstancesWithInstalledPendingRebootPatches: __expectNumber(output.InstancesWithInstalledPendingRebootPatches),
+    InstancesWithInstalledRejectedPatches: __expectNumber(output.InstancesWithInstalledRejectedPatches),
+    InstancesWithMissingPatches: __expectNumber(output.InstancesWithMissingPatches),
+    InstancesWithNotApplicablePatches: __expectNumber(output.InstancesWithNotApplicablePatches),
+    InstancesWithOtherNonCompliantPatches: __expectNumber(output.InstancesWithOtherNonCompliantPatches),
+    InstancesWithSecurityNonCompliantPatches: __expectNumber(output.InstancesWithSecurityNonCompliantPatches),
+    InstancesWithUnreportedNotApplicablePatches: __expectNumber(output.InstancesWithUnreportedNotApplicablePatches),
   } as any;
 };
 
@@ -20469,7 +20244,7 @@ const deserializeAws_json1_1DescribePatchPropertiesResult = (
   context: __SerdeContext
 ): DescribePatchPropertiesResult => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Properties:
       output.Properties !== undefined && output.Properties !== null
         ? deserializeAws_json1_1PatchPropertiesList(output.Properties, context)
@@ -20482,7 +20257,7 @@ const deserializeAws_json1_1DescribeSessionsResponse = (
   context: __SerdeContext
 ): DescribeSessionsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Sessions:
       output.Sessions !== undefined && output.Sessions !== null
         ? deserializeAws_json1_1SessionList(output.Sessions, context)
@@ -20499,7 +20274,7 @@ const deserializeAws_json1_1DisassociateOpsItemRelatedItemResponse = (
 
 const deserializeAws_json1_1DocumentAlreadyExists = (output: any, context: __SerdeContext): DocumentAlreadyExists => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -20508,52 +20283,40 @@ const deserializeAws_json1_1DocumentDefaultVersionDescription = (
   context: __SerdeContext
 ): DocumentDefaultVersionDescription => {
   return {
-    DefaultVersion:
-      output.DefaultVersion !== undefined && output.DefaultVersion !== null ? output.DefaultVersion : undefined,
-    DefaultVersionName:
-      output.DefaultVersionName !== undefined && output.DefaultVersionName !== null
-        ? output.DefaultVersionName
-        : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    DefaultVersion: __expectString(output.DefaultVersion),
+    DefaultVersionName: __expectString(output.DefaultVersionName),
+    Name: __expectString(output.Name),
   } as any;
 };
 
 const deserializeAws_json1_1DocumentDescription = (output: any, context: __SerdeContext): DocumentDescription => {
   return {
-    ApprovedVersion:
-      output.ApprovedVersion !== undefined && output.ApprovedVersion !== null ? output.ApprovedVersion : undefined,
+    ApprovedVersion: __expectString(output.ApprovedVersion),
     AttachmentsInformation:
       output.AttachmentsInformation !== undefined && output.AttachmentsInformation !== null
         ? deserializeAws_json1_1AttachmentInformationList(output.AttachmentsInformation, context)
         : undefined,
-    Author: output.Author !== undefined && output.Author !== null ? output.Author : undefined,
+    Author: __expectString(output.Author),
     CreatedDate:
       output.CreatedDate !== undefined && output.CreatedDate !== null
         ? new Date(Math.round(output.CreatedDate * 1000))
         : undefined,
-    DefaultVersion:
-      output.DefaultVersion !== undefined && output.DefaultVersion !== null ? output.DefaultVersion : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    DisplayName: output.DisplayName !== undefined && output.DisplayName !== null ? output.DisplayName : undefined,
-    DocumentFormat:
-      output.DocumentFormat !== undefined && output.DocumentFormat !== null ? output.DocumentFormat : undefined,
-    DocumentType: output.DocumentType !== undefined && output.DocumentType !== null ? output.DocumentType : undefined,
-    DocumentVersion:
-      output.DocumentVersion !== undefined && output.DocumentVersion !== null ? output.DocumentVersion : undefined,
-    Hash: output.Hash !== undefined && output.Hash !== null ? output.Hash : undefined,
-    HashType: output.HashType !== undefined && output.HashType !== null ? output.HashType : undefined,
-    LatestVersion:
-      output.LatestVersion !== undefined && output.LatestVersion !== null ? output.LatestVersion : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Owner: output.Owner !== undefined && output.Owner !== null ? output.Owner : undefined,
+    DefaultVersion: __expectString(output.DefaultVersion),
+    Description: __expectString(output.Description),
+    DisplayName: __expectString(output.DisplayName),
+    DocumentFormat: __expectString(output.DocumentFormat),
+    DocumentType: __expectString(output.DocumentType),
+    DocumentVersion: __expectString(output.DocumentVersion),
+    Hash: __expectString(output.Hash),
+    HashType: __expectString(output.HashType),
+    LatestVersion: __expectString(output.LatestVersion),
+    Name: __expectString(output.Name),
+    Owner: __expectString(output.Owner),
     Parameters:
       output.Parameters !== undefined && output.Parameters !== null
         ? deserializeAws_json1_1DocumentParameterList(output.Parameters, context)
         : undefined,
-    PendingReviewVersion:
-      output.PendingReviewVersion !== undefined && output.PendingReviewVersion !== null
-        ? output.PendingReviewVersion
-        : undefined,
+    PendingReviewVersion: __expectString(output.PendingReviewVersion),
     PlatformTypes:
       output.PlatformTypes !== undefined && output.PlatformTypes !== null
         ? deserializeAws_json1_1PlatformTypeList(output.PlatformTypes, context)
@@ -20566,39 +20329,33 @@ const deserializeAws_json1_1DocumentDescription = (output: any, context: __Serde
       output.ReviewInformation !== undefined && output.ReviewInformation !== null
         ? deserializeAws_json1_1ReviewInformationList(output.ReviewInformation, context)
         : undefined,
-    ReviewStatus: output.ReviewStatus !== undefined && output.ReviewStatus !== null ? output.ReviewStatus : undefined,
-    SchemaVersion:
-      output.SchemaVersion !== undefined && output.SchemaVersion !== null ? output.SchemaVersion : undefined,
-    Sha1: output.Sha1 !== undefined && output.Sha1 !== null ? output.Sha1 : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusInformation:
-      output.StatusInformation !== undefined && output.StatusInformation !== null
-        ? output.StatusInformation
-        : undefined,
+    ReviewStatus: __expectString(output.ReviewStatus),
+    SchemaVersion: __expectString(output.SchemaVersion),
+    Sha1: __expectString(output.Sha1),
+    Status: __expectString(output.Status),
+    StatusInformation: __expectString(output.StatusInformation),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_1TagList(output.Tags, context)
         : undefined,
-    TargetType: output.TargetType !== undefined && output.TargetType !== null ? output.TargetType : undefined,
-    VersionName: output.VersionName !== undefined && output.VersionName !== null ? output.VersionName : undefined,
+    TargetType: __expectString(output.TargetType),
+    VersionName: __expectString(output.VersionName),
   } as any;
 };
 
 const deserializeAws_json1_1DocumentIdentifier = (output: any, context: __SerdeContext): DocumentIdentifier => {
   return {
-    Author: output.Author !== undefined && output.Author !== null ? output.Author : undefined,
+    Author: __expectString(output.Author),
     CreatedDate:
       output.CreatedDate !== undefined && output.CreatedDate !== null
         ? new Date(Math.round(output.CreatedDate * 1000))
         : undefined,
-    DisplayName: output.DisplayName !== undefined && output.DisplayName !== null ? output.DisplayName : undefined,
-    DocumentFormat:
-      output.DocumentFormat !== undefined && output.DocumentFormat !== null ? output.DocumentFormat : undefined,
-    DocumentType: output.DocumentType !== undefined && output.DocumentType !== null ? output.DocumentType : undefined,
-    DocumentVersion:
-      output.DocumentVersion !== undefined && output.DocumentVersion !== null ? output.DocumentVersion : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Owner: output.Owner !== undefined && output.Owner !== null ? output.Owner : undefined,
+    DisplayName: __expectString(output.DisplayName),
+    DocumentFormat: __expectString(output.DocumentFormat),
+    DocumentType: __expectString(output.DocumentType),
+    DocumentVersion: __expectString(output.DocumentVersion),
+    Name: __expectString(output.Name),
+    Owner: __expectString(output.Owner),
     PlatformTypes:
       output.PlatformTypes !== undefined && output.PlatformTypes !== null
         ? deserializeAws_json1_1PlatformTypeList(output.PlatformTypes, context)
@@ -20607,15 +20364,14 @@ const deserializeAws_json1_1DocumentIdentifier = (output: any, context: __SerdeC
       output.Requires !== undefined && output.Requires !== null
         ? deserializeAws_json1_1DocumentRequiresList(output.Requires, context)
         : undefined,
-    ReviewStatus: output.ReviewStatus !== undefined && output.ReviewStatus !== null ? output.ReviewStatus : undefined,
-    SchemaVersion:
-      output.SchemaVersion !== undefined && output.SchemaVersion !== null ? output.SchemaVersion : undefined,
+    ReviewStatus: __expectString(output.ReviewStatus),
+    SchemaVersion: __expectString(output.SchemaVersion),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_1TagList(output.Tags, context)
         : undefined,
-    TargetType: output.TargetType !== undefined && output.TargetType !== null ? output.TargetType : undefined,
-    VersionName: output.VersionName !== undefined && output.VersionName !== null ? output.VersionName : undefined,
+    TargetType: __expectString(output.TargetType),
+    VersionName: __expectString(output.VersionName),
   } as any;
 };
 
@@ -20632,7 +20388,7 @@ const deserializeAws_json1_1DocumentIdentifierList = (output: any, context: __Se
 
 const deserializeAws_json1_1DocumentLimitExceeded = (output: any, context: __SerdeContext): DocumentLimitExceeded => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -20650,10 +20406,10 @@ const deserializeAws_json1_1DocumentMetadataResponseInfo = (
 
 const deserializeAws_json1_1DocumentParameter = (output: any, context: __SerdeContext): DocumentParameter => {
   return {
-    DefaultValue: output.DefaultValue !== undefined && output.DefaultValue !== null ? output.DefaultValue : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    DefaultValue: __expectString(output.DefaultValue),
+    Description: __expectString(output.Description),
+    Name: __expectString(output.Name),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -20673,14 +20429,14 @@ const deserializeAws_json1_1DocumentPermissionLimit = (
   context: __SerdeContext
 ): DocumentPermissionLimit => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1DocumentRequires = (output: any, context: __SerdeContext): DocumentRequires => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    Name: __expectString(output.Name),
+    Version: __expectString(output.Version),
   } as any;
 };
 
@@ -20714,8 +20470,8 @@ const deserializeAws_json1_1DocumentReviewCommentSource = (
   context: __SerdeContext
 ): DocumentReviewCommentSource => {
   return {
-    Content: output.Content !== undefined && output.Content !== null ? output.Content : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Content: __expectString(output.Content),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -20746,8 +20502,8 @@ const deserializeAws_json1_1DocumentReviewerResponseSource = (
       output.CreateTime !== undefined && output.CreateTime !== null
         ? new Date(Math.round(output.CreateTime * 1000))
         : undefined,
-    ReviewStatus: output.ReviewStatus !== undefined && output.ReviewStatus !== null ? output.ReviewStatus : undefined,
-    Reviewer: output.Reviewer !== undefined && output.Reviewer !== null ? output.Reviewer : undefined,
+    ReviewStatus: __expectString(output.ReviewStatus),
+    Reviewer: __expectString(output.Reviewer),
     UpdatedTime:
       output.UpdatedTime !== undefined && output.UpdatedTime !== null
         ? new Date(Math.round(output.UpdatedTime * 1000))
@@ -20761,21 +20517,15 @@ const deserializeAws_json1_1DocumentVersionInfo = (output: any, context: __Serde
       output.CreatedDate !== undefined && output.CreatedDate !== null
         ? new Date(Math.round(output.CreatedDate * 1000))
         : undefined,
-    DisplayName: output.DisplayName !== undefined && output.DisplayName !== null ? output.DisplayName : undefined,
-    DocumentFormat:
-      output.DocumentFormat !== undefined && output.DocumentFormat !== null ? output.DocumentFormat : undefined,
-    DocumentVersion:
-      output.DocumentVersion !== undefined && output.DocumentVersion !== null ? output.DocumentVersion : undefined,
-    IsDefaultVersion:
-      output.IsDefaultVersion !== undefined && output.IsDefaultVersion !== null ? output.IsDefaultVersion : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    ReviewStatus: output.ReviewStatus !== undefined && output.ReviewStatus !== null ? output.ReviewStatus : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusInformation:
-      output.StatusInformation !== undefined && output.StatusInformation !== null
-        ? output.StatusInformation
-        : undefined,
-    VersionName: output.VersionName !== undefined && output.VersionName !== null ? output.VersionName : undefined,
+    DisplayName: __expectString(output.DisplayName),
+    DocumentFormat: __expectString(output.DocumentFormat),
+    DocumentVersion: __expectString(output.DocumentVersion),
+    IsDefaultVersion: __expectBoolean(output.IsDefaultVersion),
+    Name: __expectString(output.Name),
+    ReviewStatus: __expectString(output.ReviewStatus),
+    Status: __expectString(output.Status),
+    StatusInformation: __expectString(output.StatusInformation),
+    VersionName: __expectString(output.VersionName),
   } as any;
 };
 
@@ -20784,7 +20534,7 @@ const deserializeAws_json1_1DocumentVersionLimitExceeded = (
   context: __SerdeContext
 ): DocumentVersionLimitExceeded => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -20801,7 +20551,7 @@ const deserializeAws_json1_1DocumentVersionList = (output: any, context: __Serde
 
 const deserializeAws_json1_1DoesNotExistException = (output: any, context: __SerdeContext): DoesNotExistException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -20810,7 +20560,7 @@ const deserializeAws_json1_1DuplicateDocumentContent = (
   context: __SerdeContext
 ): DuplicateDocumentContent => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -20819,7 +20569,7 @@ const deserializeAws_json1_1DuplicateDocumentVersionName = (
   context: __SerdeContext
 ): DuplicateDocumentVersionName => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -20860,8 +20610,8 @@ const deserializeAws_json1_1FailedCreateAssociation = (
       output.Entry !== undefined && output.Entry !== null
         ? deserializeAws_json1_1CreateAssociationBatchRequestEntry(output.Entry, context)
         : undefined,
-    Fault: output.Fault !== undefined && output.Fault !== null ? output.Fault : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Fault: __expectString(output.Fault),
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -20885,8 +20635,8 @@ const deserializeAws_json1_1FailureDetails = (output: any, context: __SerdeConte
       output.Details !== undefined && output.Details !== null
         ? deserializeAws_json1_1AutomationParameterMap(output.Details, context)
         : undefined,
-    FailureStage: output.FailureStage !== undefined && output.FailureStage !== null ? output.FailureStage : undefined,
-    FailureType: output.FailureType !== undefined && output.FailureType !== null ? output.FailureType : undefined,
+    FailureStage: __expectString(output.FailureStage),
+    FailureType: __expectString(output.FailureType),
   } as any;
 };
 
@@ -20895,7 +20645,7 @@ const deserializeAws_json1_1FeatureNotAvailableException = (
   context: __SerdeContext
 ): FeatureNotAvailableException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -20916,12 +20666,9 @@ const deserializeAws_json1_1GetCalendarStateResponse = (
   context: __SerdeContext
 ): GetCalendarStateResponse => {
   return {
-    AtTime: output.AtTime !== undefined && output.AtTime !== null ? output.AtTime : undefined,
-    NextTransitionTime:
-      output.NextTransitionTime !== undefined && output.NextTransitionTime !== null
-        ? output.NextTransitionTime
-        : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    AtTime: __expectString(output.AtTime),
+    NextTransitionTime: __expectString(output.NextTransitionTime),
+    State: __expectString(output.State),
   } as any;
 };
 
@@ -20934,43 +20681,22 @@ const deserializeAws_json1_1GetCommandInvocationResult = (
       output.CloudWatchOutputConfig !== undefined && output.CloudWatchOutputConfig !== null
         ? deserializeAws_json1_1CloudWatchOutputConfig(output.CloudWatchOutputConfig, context)
         : undefined,
-    CommandId: output.CommandId !== undefined && output.CommandId !== null ? output.CommandId : undefined,
-    Comment: output.Comment !== undefined && output.Comment !== null ? output.Comment : undefined,
-    DocumentName: output.DocumentName !== undefined && output.DocumentName !== null ? output.DocumentName : undefined,
-    DocumentVersion:
-      output.DocumentVersion !== undefined && output.DocumentVersion !== null ? output.DocumentVersion : undefined,
-    ExecutionElapsedTime:
-      output.ExecutionElapsedTime !== undefined && output.ExecutionElapsedTime !== null
-        ? output.ExecutionElapsedTime
-        : undefined,
-    ExecutionEndDateTime:
-      output.ExecutionEndDateTime !== undefined && output.ExecutionEndDateTime !== null
-        ? output.ExecutionEndDateTime
-        : undefined,
-    ExecutionStartDateTime:
-      output.ExecutionStartDateTime !== undefined && output.ExecutionStartDateTime !== null
-        ? output.ExecutionStartDateTime
-        : undefined,
-    InstanceId: output.InstanceId !== undefined && output.InstanceId !== null ? output.InstanceId : undefined,
-    PluginName: output.PluginName !== undefined && output.PluginName !== null ? output.PluginName : undefined,
-    ResponseCode: output.ResponseCode !== undefined && output.ResponseCode !== null ? output.ResponseCode : undefined,
-    StandardErrorContent:
-      output.StandardErrorContent !== undefined && output.StandardErrorContent !== null
-        ? output.StandardErrorContent
-        : undefined,
-    StandardErrorUrl:
-      output.StandardErrorUrl !== undefined && output.StandardErrorUrl !== null ? output.StandardErrorUrl : undefined,
-    StandardOutputContent:
-      output.StandardOutputContent !== undefined && output.StandardOutputContent !== null
-        ? output.StandardOutputContent
-        : undefined,
-    StandardOutputUrl:
-      output.StandardOutputUrl !== undefined && output.StandardOutputUrl !== null
-        ? output.StandardOutputUrl
-        : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusDetails:
-      output.StatusDetails !== undefined && output.StatusDetails !== null ? output.StatusDetails : undefined,
+    CommandId: __expectString(output.CommandId),
+    Comment: __expectString(output.Comment),
+    DocumentName: __expectString(output.DocumentName),
+    DocumentVersion: __expectString(output.DocumentVersion),
+    ExecutionElapsedTime: __expectString(output.ExecutionElapsedTime),
+    ExecutionEndDateTime: __expectString(output.ExecutionEndDateTime),
+    ExecutionStartDateTime: __expectString(output.ExecutionStartDateTime),
+    InstanceId: __expectString(output.InstanceId),
+    PluginName: __expectString(output.PluginName),
+    ResponseCode: __expectNumber(output.ResponseCode),
+    StandardErrorContent: __expectString(output.StandardErrorContent),
+    StandardErrorUrl: __expectString(output.StandardErrorUrl),
+    StandardOutputContent: __expectString(output.StandardOutputContent),
+    StandardOutputUrl: __expectString(output.StandardOutputUrl),
+    Status: __expectString(output.Status),
+    StatusDetails: __expectString(output.StatusDetails),
   } as any;
 };
 
@@ -20979,8 +20705,8 @@ const deserializeAws_json1_1GetConnectionStatusResponse = (
   context: __SerdeContext
 ): GetConnectionStatusResponse => {
   return {
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    Target: output.Target !== undefined && output.Target !== null ? output.Target : undefined,
+    Status: __expectString(output.Status),
+    Target: __expectString(output.Target),
   } as any;
 };
 
@@ -20989,9 +20715,8 @@ const deserializeAws_json1_1GetDefaultPatchBaselineResult = (
   context: __SerdeContext
 ): GetDefaultPatchBaselineResult => {
   return {
-    BaselineId: output.BaselineId !== undefined && output.BaselineId !== null ? output.BaselineId : undefined,
-    OperatingSystem:
-      output.OperatingSystem !== undefined && output.OperatingSystem !== null ? output.OperatingSystem : undefined,
+    BaselineId: __expectString(output.BaselineId),
+    OperatingSystem: __expectString(output.OperatingSystem),
   } as any;
 };
 
@@ -21000,13 +20725,10 @@ const deserializeAws_json1_1GetDeployablePatchSnapshotForInstanceResult = (
   context: __SerdeContext
 ): GetDeployablePatchSnapshotForInstanceResult => {
   return {
-    InstanceId: output.InstanceId !== undefined && output.InstanceId !== null ? output.InstanceId : undefined,
-    Product: output.Product !== undefined && output.Product !== null ? output.Product : undefined,
-    SnapshotDownloadUrl:
-      output.SnapshotDownloadUrl !== undefined && output.SnapshotDownloadUrl !== null
-        ? output.SnapshotDownloadUrl
-        : undefined,
-    SnapshotId: output.SnapshotId !== undefined && output.SnapshotId !== null ? output.SnapshotId : undefined,
+    InstanceId: __expectString(output.InstanceId),
+    Product: __expectString(output.Product),
+    SnapshotDownloadUrl: __expectString(output.SnapshotDownloadUrl),
+    SnapshotId: __expectString(output.SnapshotId),
   } as any;
 };
 
@@ -21016,29 +20738,24 @@ const deserializeAws_json1_1GetDocumentResult = (output: any, context: __SerdeCo
       output.AttachmentsContent !== undefined && output.AttachmentsContent !== null
         ? deserializeAws_json1_1AttachmentContentList(output.AttachmentsContent, context)
         : undefined,
-    Content: output.Content !== undefined && output.Content !== null ? output.Content : undefined,
+    Content: __expectString(output.Content),
     CreatedDate:
       output.CreatedDate !== undefined && output.CreatedDate !== null
         ? new Date(Math.round(output.CreatedDate * 1000))
         : undefined,
-    DisplayName: output.DisplayName !== undefined && output.DisplayName !== null ? output.DisplayName : undefined,
-    DocumentFormat:
-      output.DocumentFormat !== undefined && output.DocumentFormat !== null ? output.DocumentFormat : undefined,
-    DocumentType: output.DocumentType !== undefined && output.DocumentType !== null ? output.DocumentType : undefined,
-    DocumentVersion:
-      output.DocumentVersion !== undefined && output.DocumentVersion !== null ? output.DocumentVersion : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    DisplayName: __expectString(output.DisplayName),
+    DocumentFormat: __expectString(output.DocumentFormat),
+    DocumentType: __expectString(output.DocumentType),
+    DocumentVersion: __expectString(output.DocumentVersion),
+    Name: __expectString(output.Name),
     Requires:
       output.Requires !== undefined && output.Requires !== null
         ? deserializeAws_json1_1DocumentRequiresList(output.Requires, context)
         : undefined,
-    ReviewStatus: output.ReviewStatus !== undefined && output.ReviewStatus !== null ? output.ReviewStatus : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusInformation:
-      output.StatusInformation !== undefined && output.StatusInformation !== null
-        ? output.StatusInformation
-        : undefined,
-    VersionName: output.VersionName !== undefined && output.VersionName !== null ? output.VersionName : undefined,
+    ReviewStatus: __expectString(output.ReviewStatus),
+    Status: __expectString(output.Status),
+    StatusInformation: __expectString(output.StatusInformation),
+    VersionName: __expectString(output.VersionName),
   } as any;
 };
 
@@ -21048,7 +20765,7 @@ const deserializeAws_json1_1GetInventoryResult = (output: any, context: __SerdeC
       output.Entities !== undefined && output.Entities !== null
         ? deserializeAws_json1_1InventoryResultEntityList(output.Entities, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -21057,7 +20774,7 @@ const deserializeAws_json1_1GetInventorySchemaResult = (
   context: __SerdeContext
 ): GetInventorySchemaResult => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Schemas:
       output.Schemas !== undefined && output.Schemas !== null
         ? deserializeAws_json1_1InventoryItemSchemaResultList(output.Schemas, context)
@@ -21076,17 +20793,13 @@ const deserializeAws_json1_1GetMaintenanceWindowExecutionResult = (
       output.StartTime !== undefined && output.StartTime !== null
         ? new Date(Math.round(output.StartTime * 1000))
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusDetails:
-      output.StatusDetails !== undefined && output.StatusDetails !== null ? output.StatusDetails : undefined,
+    Status: __expectString(output.Status),
+    StatusDetails: __expectString(output.StatusDetails),
     TaskIds:
       output.TaskIds !== undefined && output.TaskIds !== null
         ? deserializeAws_json1_1MaintenanceWindowExecutionTaskIdList(output.TaskIds, context)
         : undefined,
-    WindowExecutionId:
-      output.WindowExecutionId !== undefined && output.WindowExecutionId !== null
-        ? output.WindowExecutionId
-        : undefined,
+    WindowExecutionId: __expectString(output.WindowExecutionId),
   } as any;
 };
 
@@ -21097,27 +20810,20 @@ const deserializeAws_json1_1GetMaintenanceWindowExecutionTaskInvocationResult = 
   return {
     EndTime:
       output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
-    ExecutionId: output.ExecutionId !== undefined && output.ExecutionId !== null ? output.ExecutionId : undefined,
-    InvocationId: output.InvocationId !== undefined && output.InvocationId !== null ? output.InvocationId : undefined,
-    OwnerInformation:
-      output.OwnerInformation !== undefined && output.OwnerInformation !== null ? output.OwnerInformation : undefined,
-    Parameters: output.Parameters !== undefined && output.Parameters !== null ? output.Parameters : undefined,
+    ExecutionId: __expectString(output.ExecutionId),
+    InvocationId: __expectString(output.InvocationId),
+    OwnerInformation: __expectString(output.OwnerInformation),
+    Parameters: __expectString(output.Parameters),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
         ? new Date(Math.round(output.StartTime * 1000))
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusDetails:
-      output.StatusDetails !== undefined && output.StatusDetails !== null ? output.StatusDetails : undefined,
-    TaskExecutionId:
-      output.TaskExecutionId !== undefined && output.TaskExecutionId !== null ? output.TaskExecutionId : undefined,
-    TaskType: output.TaskType !== undefined && output.TaskType !== null ? output.TaskType : undefined,
-    WindowExecutionId:
-      output.WindowExecutionId !== undefined && output.WindowExecutionId !== null
-        ? output.WindowExecutionId
-        : undefined,
-    WindowTargetId:
-      output.WindowTargetId !== undefined && output.WindowTargetId !== null ? output.WindowTargetId : undefined,
+    Status: __expectString(output.Status),
+    StatusDetails: __expectString(output.StatusDetails),
+    TaskExecutionId: __expectString(output.TaskExecutionId),
+    TaskType: __expectString(output.TaskType),
+    WindowExecutionId: __expectString(output.WindowExecutionId),
+    WindowTargetId: __expectString(output.WindowTargetId),
   } as any;
 };
 
@@ -21128,30 +20834,24 @@ const deserializeAws_json1_1GetMaintenanceWindowExecutionTaskResult = (
   return {
     EndTime:
       output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
-    MaxConcurrency:
-      output.MaxConcurrency !== undefined && output.MaxConcurrency !== null ? output.MaxConcurrency : undefined,
-    MaxErrors: output.MaxErrors !== undefined && output.MaxErrors !== null ? output.MaxErrors : undefined,
-    Priority: output.Priority !== undefined && output.Priority !== null ? output.Priority : undefined,
-    ServiceRole: output.ServiceRole !== undefined && output.ServiceRole !== null ? output.ServiceRole : undefined,
+    MaxConcurrency: __expectString(output.MaxConcurrency),
+    MaxErrors: __expectString(output.MaxErrors),
+    Priority: __expectNumber(output.Priority),
+    ServiceRole: __expectString(output.ServiceRole),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
         ? new Date(Math.round(output.StartTime * 1000))
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusDetails:
-      output.StatusDetails !== undefined && output.StatusDetails !== null ? output.StatusDetails : undefined,
-    TaskArn: output.TaskArn !== undefined && output.TaskArn !== null ? output.TaskArn : undefined,
-    TaskExecutionId:
-      output.TaskExecutionId !== undefined && output.TaskExecutionId !== null ? output.TaskExecutionId : undefined,
+    Status: __expectString(output.Status),
+    StatusDetails: __expectString(output.StatusDetails),
+    TaskArn: __expectString(output.TaskArn),
+    TaskExecutionId: __expectString(output.TaskExecutionId),
     TaskParameters:
       output.TaskParameters !== undefined && output.TaskParameters !== null
         ? deserializeAws_json1_1MaintenanceWindowTaskParametersList(output.TaskParameters, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    WindowExecutionId:
-      output.WindowExecutionId !== undefined && output.WindowExecutionId !== null
-        ? output.WindowExecutionId
-        : undefined,
+    Type: __expectString(output.Type),
+    WindowExecutionId: __expectString(output.WindowExecutionId),
   } as any;
 };
 
@@ -21160,35 +20860,27 @@ const deserializeAws_json1_1GetMaintenanceWindowResult = (
   context: __SerdeContext
 ): GetMaintenanceWindowResult => {
   return {
-    AllowUnassociatedTargets:
-      output.AllowUnassociatedTargets !== undefined && output.AllowUnassociatedTargets !== null
-        ? output.AllowUnassociatedTargets
-        : undefined,
+    AllowUnassociatedTargets: __expectBoolean(output.AllowUnassociatedTargets),
     CreatedDate:
       output.CreatedDate !== undefined && output.CreatedDate !== null
         ? new Date(Math.round(output.CreatedDate * 1000))
         : undefined,
-    Cutoff: output.Cutoff !== undefined && output.Cutoff !== null ? output.Cutoff : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Duration: output.Duration !== undefined && output.Duration !== null ? output.Duration : undefined,
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
-    EndDate: output.EndDate !== undefined && output.EndDate !== null ? output.EndDate : undefined,
+    Cutoff: __expectNumber(output.Cutoff),
+    Description: __expectString(output.Description),
+    Duration: __expectNumber(output.Duration),
+    Enabled: __expectBoolean(output.Enabled),
+    EndDate: __expectString(output.EndDate),
     ModifiedDate:
       output.ModifiedDate !== undefined && output.ModifiedDate !== null
         ? new Date(Math.round(output.ModifiedDate * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    NextExecutionTime:
-      output.NextExecutionTime !== undefined && output.NextExecutionTime !== null
-        ? output.NextExecutionTime
-        : undefined,
-    Schedule: output.Schedule !== undefined && output.Schedule !== null ? output.Schedule : undefined,
-    ScheduleOffset:
-      output.ScheduleOffset !== undefined && output.ScheduleOffset !== null ? output.ScheduleOffset : undefined,
-    ScheduleTimezone:
-      output.ScheduleTimezone !== undefined && output.ScheduleTimezone !== null ? output.ScheduleTimezone : undefined,
-    StartDate: output.StartDate !== undefined && output.StartDate !== null ? output.StartDate : undefined,
-    WindowId: output.WindowId !== undefined && output.WindowId !== null ? output.WindowId : undefined,
+    Name: __expectString(output.Name),
+    NextExecutionTime: __expectString(output.NextExecutionTime),
+    Schedule: __expectString(output.Schedule),
+    ScheduleOffset: __expectNumber(output.ScheduleOffset),
+    ScheduleTimezone: __expectString(output.ScheduleTimezone),
+    StartDate: __expectString(output.StartDate),
+    WindowId: __expectString(output.WindowId),
   } as any;
 };
 
@@ -21197,23 +20889,21 @@ const deserializeAws_json1_1GetMaintenanceWindowTaskResult = (
   context: __SerdeContext
 ): GetMaintenanceWindowTaskResult => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     LoggingInfo:
       output.LoggingInfo !== undefined && output.LoggingInfo !== null
         ? deserializeAws_json1_1LoggingInfo(output.LoggingInfo, context)
         : undefined,
-    MaxConcurrency:
-      output.MaxConcurrency !== undefined && output.MaxConcurrency !== null ? output.MaxConcurrency : undefined,
-    MaxErrors: output.MaxErrors !== undefined && output.MaxErrors !== null ? output.MaxErrors : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Priority: output.Priority !== undefined && output.Priority !== null ? output.Priority : undefined,
-    ServiceRoleArn:
-      output.ServiceRoleArn !== undefined && output.ServiceRoleArn !== null ? output.ServiceRoleArn : undefined,
+    MaxConcurrency: __expectString(output.MaxConcurrency),
+    MaxErrors: __expectString(output.MaxErrors),
+    Name: __expectString(output.Name),
+    Priority: __expectNumber(output.Priority),
+    ServiceRoleArn: __expectString(output.ServiceRoleArn),
     Targets:
       output.Targets !== undefined && output.Targets !== null
         ? deserializeAws_json1_1Targets(output.Targets, context)
         : undefined,
-    TaskArn: output.TaskArn !== undefined && output.TaskArn !== null ? output.TaskArn : undefined,
+    TaskArn: __expectString(output.TaskArn),
     TaskInvocationParameters:
       output.TaskInvocationParameters !== undefined && output.TaskInvocationParameters !== null
         ? deserializeAws_json1_1MaintenanceWindowTaskInvocationParameters(output.TaskInvocationParameters, context)
@@ -21222,9 +20912,9 @@ const deserializeAws_json1_1GetMaintenanceWindowTaskResult = (
       output.TaskParameters !== undefined && output.TaskParameters !== null
         ? deserializeAws_json1_1MaintenanceWindowTaskParameters(output.TaskParameters, context)
         : undefined,
-    TaskType: output.TaskType !== undefined && output.TaskType !== null ? output.TaskType : undefined,
-    WindowId: output.WindowId !== undefined && output.WindowId !== null ? output.WindowId : undefined,
-    WindowTaskId: output.WindowTaskId !== undefined && output.WindowTaskId !== null ? output.WindowTaskId : undefined,
+    TaskType: __expectString(output.TaskType),
+    WindowId: __expectString(output.WindowId),
+    WindowTaskId: __expectString(output.WindowTaskId),
   } as any;
 };
 
@@ -21243,8 +20933,8 @@ const deserializeAws_json1_1GetOpsMetadataResult = (output: any, context: __Serd
       output.Metadata !== undefined && output.Metadata !== null
         ? deserializeAws_json1_1MetadataMap(output.Metadata, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
-    ResourceId: output.ResourceId !== undefined && output.ResourceId !== null ? output.ResourceId : undefined,
+    NextToken: __expectString(output.NextToken),
+    ResourceId: __expectString(output.ResourceId),
   } as any;
 };
 
@@ -21254,7 +20944,7 @@ const deserializeAws_json1_1GetOpsSummaryResult = (output: any, context: __Serde
       output.Entities !== undefined && output.Entities !== null
         ? deserializeAws_json1_1OpsEntityList(output.Entities, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -21263,7 +20953,7 @@ const deserializeAws_json1_1GetParameterHistoryResult = (
   context: __SerdeContext
 ): GetParameterHistoryResult => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Parameters:
       output.Parameters !== undefined && output.Parameters !== null
         ? deserializeAws_json1_1ParameterHistoryList(output.Parameters, context)
@@ -21285,7 +20975,7 @@ const deserializeAws_json1_1GetParametersByPathResult = (
   context: __SerdeContext
 ): GetParametersByPathResult => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Parameters:
       output.Parameters !== undefined && output.Parameters !== null
         ? deserializeAws_json1_1ParameterList(output.Parameters, context)
@@ -21311,10 +21001,9 @@ const deserializeAws_json1_1GetPatchBaselineForPatchGroupResult = (
   context: __SerdeContext
 ): GetPatchBaselineForPatchGroupResult => {
   return {
-    BaselineId: output.BaselineId !== undefined && output.BaselineId !== null ? output.BaselineId : undefined,
-    OperatingSystem:
-      output.OperatingSystem !== undefined && output.OperatingSystem !== null ? output.OperatingSystem : undefined,
-    PatchGroup: output.PatchGroup !== undefined && output.PatchGroup !== null ? output.PatchGroup : undefined,
+    BaselineId: __expectString(output.BaselineId),
+    OperatingSystem: __expectString(output.OperatingSystem),
+    PatchGroup: __expectString(output.PatchGroup),
   } as any;
 };
 
@@ -21328,20 +21017,14 @@ const deserializeAws_json1_1GetPatchBaselineResult = (output: any, context: __Se
       output.ApprovedPatches !== undefined && output.ApprovedPatches !== null
         ? deserializeAws_json1_1PatchIdList(output.ApprovedPatches, context)
         : undefined,
-    ApprovedPatchesComplianceLevel:
-      output.ApprovedPatchesComplianceLevel !== undefined && output.ApprovedPatchesComplianceLevel !== null
-        ? output.ApprovedPatchesComplianceLevel
-        : undefined,
-    ApprovedPatchesEnableNonSecurity:
-      output.ApprovedPatchesEnableNonSecurity !== undefined && output.ApprovedPatchesEnableNonSecurity !== null
-        ? output.ApprovedPatchesEnableNonSecurity
-        : undefined,
-    BaselineId: output.BaselineId !== undefined && output.BaselineId !== null ? output.BaselineId : undefined,
+    ApprovedPatchesComplianceLevel: __expectString(output.ApprovedPatchesComplianceLevel),
+    ApprovedPatchesEnableNonSecurity: __expectBoolean(output.ApprovedPatchesEnableNonSecurity),
+    BaselineId: __expectString(output.BaselineId),
     CreatedDate:
       output.CreatedDate !== undefined && output.CreatedDate !== null
         ? new Date(Math.round(output.CreatedDate * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     GlobalFilters:
       output.GlobalFilters !== undefined && output.GlobalFilters !== null
         ? deserializeAws_json1_1PatchFilterGroup(output.GlobalFilters, context)
@@ -21350,9 +21033,8 @@ const deserializeAws_json1_1GetPatchBaselineResult = (output: any, context: __Se
       output.ModifiedDate !== undefined && output.ModifiedDate !== null
         ? new Date(Math.round(output.ModifiedDate * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    OperatingSystem:
-      output.OperatingSystem !== undefined && output.OperatingSystem !== null ? output.OperatingSystem : undefined,
+    Name: __expectString(output.Name),
+    OperatingSystem: __expectString(output.OperatingSystem),
     PatchGroups:
       output.PatchGroups !== undefined && output.PatchGroups !== null
         ? deserializeAws_json1_1PatchGroupList(output.PatchGroups, context)
@@ -21361,10 +21043,7 @@ const deserializeAws_json1_1GetPatchBaselineResult = (output: any, context: __Se
       output.RejectedPatches !== undefined && output.RejectedPatches !== null
         ? deserializeAws_json1_1PatchIdList(output.RejectedPatches, context)
         : undefined,
-    RejectedPatchesAction:
-      output.RejectedPatchesAction !== undefined && output.RejectedPatchesAction !== null
-        ? output.RejectedPatchesAction
-        : undefined,
+    RejectedPatchesAction: __expectString(output.RejectedPatchesAction),
     Sources:
       output.Sources !== undefined && output.Sources !== null
         ? deserializeAws_json1_1PatchSourceList(output.Sources, context)
@@ -21389,7 +21068,7 @@ const deserializeAws_json1_1HierarchyLevelLimitExceededException = (
   context: __SerdeContext
 ): HierarchyLevelLimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -21398,7 +21077,7 @@ const deserializeAws_json1_1HierarchyTypeMismatchException = (
   context: __SerdeContext
 ): HierarchyTypeMismatchException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -21407,7 +21086,7 @@ const deserializeAws_json1_1IdempotentParameterMismatch = (
   context: __SerdeContext
 ): IdempotentParameterMismatch => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -21416,7 +21095,7 @@ const deserializeAws_json1_1IncompatiblePolicyException = (
   context: __SerdeContext
 ): IncompatiblePolicyException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -21425,8 +21104,7 @@ const deserializeAws_json1_1InstanceAggregatedAssociationOverview = (
   context: __SerdeContext
 ): InstanceAggregatedAssociationOverview => {
   return {
-    DetailedStatus:
-      output.DetailedStatus !== undefined && output.DetailedStatus !== null ? output.DetailedStatus : undefined,
+    DetailedStatus: __expectString(output.DetailedStatus),
     InstanceAssociationStatusAggregatedCount:
       output.InstanceAssociationStatusAggregatedCount !== undefined &&
       output.InstanceAssociationStatusAggregatedCount !== null
@@ -21440,14 +21118,10 @@ const deserializeAws_json1_1InstanceAggregatedAssociationOverview = (
 
 const deserializeAws_json1_1InstanceAssociation = (output: any, context: __SerdeContext): InstanceAssociation => {
   return {
-    AssociationId:
-      output.AssociationId !== undefined && output.AssociationId !== null ? output.AssociationId : undefined,
-    AssociationVersion:
-      output.AssociationVersion !== undefined && output.AssociationVersion !== null
-        ? output.AssociationVersion
-        : undefined,
-    Content: output.Content !== undefined && output.Content !== null ? output.Content : undefined,
-    InstanceId: output.InstanceId !== undefined && output.InstanceId !== null ? output.InstanceId : undefined,
+    AssociationId: __expectString(output.AssociationId),
+    AssociationVersion: __expectString(output.AssociationVersion),
+    Content: __expectString(output.Content),
+    InstanceId: __expectString(output.InstanceId),
   } as any;
 };
 
@@ -21496,7 +21170,7 @@ const deserializeAws_json1_1InstanceAssociationStatusAggregatedCount = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectNumber(value) as any,
     };
   }, {});
 };
@@ -21506,32 +21180,24 @@ const deserializeAws_json1_1InstanceAssociationStatusInfo = (
   context: __SerdeContext
 ): InstanceAssociationStatusInfo => {
   return {
-    AssociationId:
-      output.AssociationId !== undefined && output.AssociationId !== null ? output.AssociationId : undefined,
-    AssociationName:
-      output.AssociationName !== undefined && output.AssociationName !== null ? output.AssociationName : undefined,
-    AssociationVersion:
-      output.AssociationVersion !== undefined && output.AssociationVersion !== null
-        ? output.AssociationVersion
-        : undefined,
-    DetailedStatus:
-      output.DetailedStatus !== undefined && output.DetailedStatus !== null ? output.DetailedStatus : undefined,
-    DocumentVersion:
-      output.DocumentVersion !== undefined && output.DocumentVersion !== null ? output.DocumentVersion : undefined,
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
+    AssociationId: __expectString(output.AssociationId),
+    AssociationName: __expectString(output.AssociationName),
+    AssociationVersion: __expectString(output.AssociationVersion),
+    DetailedStatus: __expectString(output.DetailedStatus),
+    DocumentVersion: __expectString(output.DocumentVersion),
+    ErrorCode: __expectString(output.ErrorCode),
     ExecutionDate:
       output.ExecutionDate !== undefined && output.ExecutionDate !== null
         ? new Date(Math.round(output.ExecutionDate * 1000))
         : undefined,
-    ExecutionSummary:
-      output.ExecutionSummary !== undefined && output.ExecutionSummary !== null ? output.ExecutionSummary : undefined,
-    InstanceId: output.InstanceId !== undefined && output.InstanceId !== null ? output.InstanceId : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    ExecutionSummary: __expectString(output.ExecutionSummary),
+    InstanceId: __expectString(output.InstanceId),
+    Name: __expectString(output.Name),
     OutputUrl:
       output.OutputUrl !== undefined && output.OutputUrl !== null
         ? deserializeAws_json1_1InstanceAssociationOutputUrl(output.OutputUrl, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -21556,28 +21222,24 @@ const deserializeAws_json1_1InstanceIdList = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1InstanceInformation = (output: any, context: __SerdeContext): InstanceInformation => {
   return {
-    ActivationId: output.ActivationId !== undefined && output.ActivationId !== null ? output.ActivationId : undefined,
-    AgentVersion: output.AgentVersion !== undefined && output.AgentVersion !== null ? output.AgentVersion : undefined,
+    ActivationId: __expectString(output.ActivationId),
+    AgentVersion: __expectString(output.AgentVersion),
     AssociationOverview:
       output.AssociationOverview !== undefined && output.AssociationOverview !== null
         ? deserializeAws_json1_1InstanceAggregatedAssociationOverview(output.AssociationOverview, context)
         : undefined,
-    AssociationStatus:
-      output.AssociationStatus !== undefined && output.AssociationStatus !== null
-        ? output.AssociationStatus
-        : undefined,
-    ComputerName: output.ComputerName !== undefined && output.ComputerName !== null ? output.ComputerName : undefined,
-    IPAddress: output.IPAddress !== undefined && output.IPAddress !== null ? output.IPAddress : undefined,
-    IamRole: output.IamRole !== undefined && output.IamRole !== null ? output.IamRole : undefined,
-    InstanceId: output.InstanceId !== undefined && output.InstanceId !== null ? output.InstanceId : undefined,
-    IsLatestVersion:
-      output.IsLatestVersion !== undefined && output.IsLatestVersion !== null ? output.IsLatestVersion : undefined,
+    AssociationStatus: __expectString(output.AssociationStatus),
+    ComputerName: __expectString(output.ComputerName),
+    IPAddress: __expectString(output.IPAddress),
+    IamRole: __expectString(output.IamRole),
+    InstanceId: __expectString(output.InstanceId),
+    IsLatestVersion: __expectBoolean(output.IsLatestVersion),
     LastAssociationExecutionDate:
       output.LastAssociationExecutionDate !== undefined && output.LastAssociationExecutionDate !== null
         ? new Date(Math.round(output.LastAssociationExecutionDate * 1000))
@@ -21591,17 +21253,16 @@ const deserializeAws_json1_1InstanceInformation = (output: any, context: __Serde
       output.LastSuccessfulAssociationExecutionDate !== null
         ? new Date(Math.round(output.LastSuccessfulAssociationExecutionDate * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    PingStatus: output.PingStatus !== undefined && output.PingStatus !== null ? output.PingStatus : undefined,
-    PlatformName: output.PlatformName !== undefined && output.PlatformName !== null ? output.PlatformName : undefined,
-    PlatformType: output.PlatformType !== undefined && output.PlatformType !== null ? output.PlatformType : undefined,
-    PlatformVersion:
-      output.PlatformVersion !== undefined && output.PlatformVersion !== null ? output.PlatformVersion : undefined,
+    Name: __expectString(output.Name),
+    PingStatus: __expectString(output.PingStatus),
+    PlatformName: __expectString(output.PlatformName),
+    PlatformType: __expectString(output.PlatformType),
+    PlatformVersion: __expectString(output.PlatformVersion),
     RegistrationDate:
       output.RegistrationDate !== undefined && output.RegistrationDate !== null
         ? new Date(Math.round(output.RegistrationDate * 1000))
         : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
+    ResourceType: __expectString(output.ResourceType),
   } as any;
 };
 
@@ -21618,41 +21279,22 @@ const deserializeAws_json1_1InstanceInformationList = (output: any, context: __S
 
 const deserializeAws_json1_1InstancePatchState = (output: any, context: __SerdeContext): InstancePatchState => {
   return {
-    BaselineId: output.BaselineId !== undefined && output.BaselineId !== null ? output.BaselineId : undefined,
-    CriticalNonCompliantCount:
-      output.CriticalNonCompliantCount !== undefined && output.CriticalNonCompliantCount !== null
-        ? output.CriticalNonCompliantCount
-        : undefined,
-    FailedCount: output.FailedCount !== undefined && output.FailedCount !== null ? output.FailedCount : undefined,
-    InstallOverrideList:
-      output.InstallOverrideList !== undefined && output.InstallOverrideList !== null
-        ? output.InstallOverrideList
-        : undefined,
-    InstalledCount:
-      output.InstalledCount !== undefined && output.InstalledCount !== null ? output.InstalledCount : undefined,
-    InstalledOtherCount:
-      output.InstalledOtherCount !== undefined && output.InstalledOtherCount !== null
-        ? output.InstalledOtherCount
-        : undefined,
-    InstalledPendingRebootCount:
-      output.InstalledPendingRebootCount !== undefined && output.InstalledPendingRebootCount !== null
-        ? output.InstalledPendingRebootCount
-        : undefined,
-    InstalledRejectedCount:
-      output.InstalledRejectedCount !== undefined && output.InstalledRejectedCount !== null
-        ? output.InstalledRejectedCount
-        : undefined,
-    InstanceId: output.InstanceId !== undefined && output.InstanceId !== null ? output.InstanceId : undefined,
+    BaselineId: __expectString(output.BaselineId),
+    CriticalNonCompliantCount: __expectNumber(output.CriticalNonCompliantCount),
+    FailedCount: __expectNumber(output.FailedCount),
+    InstallOverrideList: __expectString(output.InstallOverrideList),
+    InstalledCount: __expectNumber(output.InstalledCount),
+    InstalledOtherCount: __expectNumber(output.InstalledOtherCount),
+    InstalledPendingRebootCount: __expectNumber(output.InstalledPendingRebootCount),
+    InstalledRejectedCount: __expectNumber(output.InstalledRejectedCount),
+    InstanceId: __expectString(output.InstanceId),
     LastNoRebootInstallOperationTime:
       output.LastNoRebootInstallOperationTime !== undefined && output.LastNoRebootInstallOperationTime !== null
         ? new Date(Math.round(output.LastNoRebootInstallOperationTime * 1000))
         : undefined,
-    MissingCount: output.MissingCount !== undefined && output.MissingCount !== null ? output.MissingCount : undefined,
-    NotApplicableCount:
-      output.NotApplicableCount !== undefined && output.NotApplicableCount !== null
-        ? output.NotApplicableCount
-        : undefined,
-    Operation: output.Operation !== undefined && output.Operation !== null ? output.Operation : undefined,
+    MissingCount: __expectNumber(output.MissingCount),
+    NotApplicableCount: __expectNumber(output.NotApplicableCount),
+    Operation: __expectString(output.Operation),
     OperationEndTime:
       output.OperationEndTime !== undefined && output.OperationEndTime !== null
         ? new Date(Math.round(output.OperationEndTime * 1000))
@@ -21661,23 +21303,13 @@ const deserializeAws_json1_1InstancePatchState = (output: any, context: __SerdeC
       output.OperationStartTime !== undefined && output.OperationStartTime !== null
         ? new Date(Math.round(output.OperationStartTime * 1000))
         : undefined,
-    OtherNonCompliantCount:
-      output.OtherNonCompliantCount !== undefined && output.OtherNonCompliantCount !== null
-        ? output.OtherNonCompliantCount
-        : undefined,
-    OwnerInformation:
-      output.OwnerInformation !== undefined && output.OwnerInformation !== null ? output.OwnerInformation : undefined,
-    PatchGroup: output.PatchGroup !== undefined && output.PatchGroup !== null ? output.PatchGroup : undefined,
-    RebootOption: output.RebootOption !== undefined && output.RebootOption !== null ? output.RebootOption : undefined,
-    SecurityNonCompliantCount:
-      output.SecurityNonCompliantCount !== undefined && output.SecurityNonCompliantCount !== null
-        ? output.SecurityNonCompliantCount
-        : undefined,
-    SnapshotId: output.SnapshotId !== undefined && output.SnapshotId !== null ? output.SnapshotId : undefined,
-    UnreportedNotApplicableCount:
-      output.UnreportedNotApplicableCount !== undefined && output.UnreportedNotApplicableCount !== null
-        ? output.UnreportedNotApplicableCount
-        : undefined,
+    OtherNonCompliantCount: __expectNumber(output.OtherNonCompliantCount),
+    OwnerInformation: __expectString(output.OwnerInformation),
+    PatchGroup: __expectString(output.PatchGroup),
+    RebootOption: __expectString(output.RebootOption),
+    SecurityNonCompliantCount: __expectNumber(output.SecurityNonCompliantCount),
+    SnapshotId: __expectString(output.SnapshotId),
+    UnreportedNotApplicableCount: __expectNumber(output.UnreportedNotApplicableCount),
   } as any;
 };
 
@@ -21705,19 +21337,19 @@ const deserializeAws_json1_1InstancePatchStatesList = (output: any, context: __S
 
 const deserializeAws_json1_1InternalServerError = (output: any, context: __SerdeContext): InternalServerError => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidActivation = (output: any, context: __SerdeContext): InvalidActivation => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidActivationId = (output: any, context: __SerdeContext): InvalidActivationId => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -21726,7 +21358,7 @@ const deserializeAws_json1_1InvalidAggregatorException = (
   context: __SerdeContext
 ): InvalidAggregatorException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -21735,13 +21367,13 @@ const deserializeAws_json1_1InvalidAllowedPatternException = (
   context: __SerdeContext
 ): InvalidAllowedPatternException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidAssociation = (output: any, context: __SerdeContext): InvalidAssociation => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -21750,7 +21382,7 @@ const deserializeAws_json1_1InvalidAssociationVersion = (
   context: __SerdeContext
 ): InvalidAssociationVersion => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -21759,7 +21391,7 @@ const deserializeAws_json1_1InvalidAutomationExecutionParametersException = (
   context: __SerdeContext
 ): InvalidAutomationExecutionParametersException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -21768,7 +21400,7 @@ const deserializeAws_json1_1InvalidAutomationSignalException = (
   context: __SerdeContext
 ): InvalidAutomationSignalException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -21777,7 +21409,7 @@ const deserializeAws_json1_1InvalidAutomationStatusUpdateException = (
   context: __SerdeContext
 ): InvalidAutomationStatusUpdateException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -21790,7 +21422,7 @@ const deserializeAws_json1_1InvalidDeleteInventoryParametersException = (
   context: __SerdeContext
 ): InvalidDeleteInventoryParametersException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -21799,19 +21431,19 @@ const deserializeAws_json1_1InvalidDeletionIdException = (
   context: __SerdeContext
 ): InvalidDeletionIdException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidDocument = (output: any, context: __SerdeContext): InvalidDocument => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidDocumentContent = (output: any, context: __SerdeContext): InvalidDocumentContent => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -21820,7 +21452,7 @@ const deserializeAws_json1_1InvalidDocumentOperation = (
   context: __SerdeContext
 ): InvalidDocumentOperation => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -21829,25 +21461,25 @@ const deserializeAws_json1_1InvalidDocumentSchemaVersion = (
   context: __SerdeContext
 ): InvalidDocumentSchemaVersion => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidDocumentType = (output: any, context: __SerdeContext): InvalidDocumentType => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidDocumentVersion = (output: any, context: __SerdeContext): InvalidDocumentVersion => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidFilter = (output: any, context: __SerdeContext): InvalidFilter => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -21857,19 +21489,19 @@ const deserializeAws_json1_1InvalidFilterKey = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1InvalidFilterOption = (output: any, context: __SerdeContext): InvalidFilterOption => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidFilterValue = (output: any, context: __SerdeContext): InvalidFilterValue => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidInstanceId = (output: any, context: __SerdeContext): InvalidInstanceId => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -21878,7 +21510,7 @@ const deserializeAws_json1_1InvalidInstanceInformationFilterValue = (
   context: __SerdeContext
 ): InvalidInstanceInformationFilterValue => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -21887,7 +21519,7 @@ const deserializeAws_json1_1InvalidInventoryGroupException = (
   context: __SerdeContext
 ): InvalidInventoryGroupException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -21896,7 +21528,7 @@ const deserializeAws_json1_1InvalidInventoryItemContextException = (
   context: __SerdeContext
 ): InvalidInventoryItemContextException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -21905,7 +21537,7 @@ const deserializeAws_json1_1InvalidInventoryRequestException = (
   context: __SerdeContext
 ): InvalidInventoryRequestException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -21914,20 +21546,20 @@ const deserializeAws_json1_1InvalidItemContentException = (
   context: __SerdeContext
 ): InvalidItemContentException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    TypeName: output.TypeName !== undefined && output.TypeName !== null ? output.TypeName : undefined,
+    Message: __expectString(output.Message),
+    TypeName: __expectString(output.TypeName),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidKeyId = (output: any, context: __SerdeContext): InvalidKeyId => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidNextToken = (output: any, context: __SerdeContext): InvalidNextToken => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -21936,13 +21568,13 @@ const deserializeAws_json1_1InvalidNotificationConfig = (
   context: __SerdeContext
 ): InvalidNotificationConfig => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidOptionException = (output: any, context: __SerdeContext): InvalidOptionException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -21956,13 +21588,13 @@ const deserializeAws_json1_1InvalidOutputLocation = (output: any, context: __Ser
 
 const deserializeAws_json1_1InvalidParameters = (output: any, context: __SerdeContext): InvalidParameters => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidPermissionType = (output: any, context: __SerdeContext): InvalidPermissionType => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -21975,7 +21607,7 @@ const deserializeAws_json1_1InvalidPolicyAttributeException = (
   context: __SerdeContext
 ): InvalidPolicyAttributeException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -21984,7 +21616,7 @@ const deserializeAws_json1_1InvalidPolicyTypeException = (
   context: __SerdeContext
 ): InvalidPolicyTypeException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -22001,25 +21633,25 @@ const deserializeAws_json1_1InvalidResultAttributeException = (
   context: __SerdeContext
 ): InvalidResultAttributeException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidRole = (output: any, context: __SerdeContext): InvalidRole => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidSchedule = (output: any, context: __SerdeContext): InvalidSchedule => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidTarget = (output: any, context: __SerdeContext): InvalidTarget => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -22028,13 +21660,13 @@ const deserializeAws_json1_1InvalidTypeNameException = (
   context: __SerdeContext
 ): InvalidTypeNameException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidUpdate = (output: any, context: __SerdeContext): InvalidUpdate => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -22057,7 +21689,7 @@ const deserializeAws_json1_1InventoryDeletionStatusItem = (
   context: __SerdeContext
 ): InventoryDeletionStatusItem => {
   return {
-    DeletionId: output.DeletionId !== undefined && output.DeletionId !== null ? output.DeletionId : undefined,
+    DeletionId: __expectString(output.DeletionId),
     DeletionStartTime:
       output.DeletionStartTime !== undefined && output.DeletionStartTime !== null
         ? new Date(Math.round(output.DeletionStartTime * 1000))
@@ -22066,16 +21698,13 @@ const deserializeAws_json1_1InventoryDeletionStatusItem = (
       output.DeletionSummary !== undefined && output.DeletionSummary !== null
         ? deserializeAws_json1_1InventoryDeletionSummary(output.DeletionSummary, context)
         : undefined,
-    LastStatus: output.LastStatus !== undefined && output.LastStatus !== null ? output.LastStatus : undefined,
-    LastStatusMessage:
-      output.LastStatusMessage !== undefined && output.LastStatusMessage !== null
-        ? output.LastStatusMessage
-        : undefined,
+    LastStatus: __expectString(output.LastStatus),
+    LastStatusMessage: __expectString(output.LastStatusMessage),
     LastStatusUpdateTime:
       output.LastStatusUpdateTime !== undefined && output.LastStatusUpdateTime !== null
         ? new Date(Math.round(output.LastStatusUpdateTime * 1000))
         : undefined,
-    TypeName: output.TypeName !== undefined && output.TypeName !== null ? output.TypeName : undefined,
+    TypeName: __expectString(output.TypeName),
   } as any;
 };
 
@@ -22084,13 +21713,12 @@ const deserializeAws_json1_1InventoryDeletionSummary = (
   context: __SerdeContext
 ): InventoryDeletionSummary => {
   return {
-    RemainingCount:
-      output.RemainingCount !== undefined && output.RemainingCount !== null ? output.RemainingCount : undefined,
+    RemainingCount: __expectNumber(output.RemainingCount),
     SummaryItems:
       output.SummaryItems !== undefined && output.SummaryItems !== null
         ? deserializeAws_json1_1InventoryDeletionSummaryItems(output.SummaryItems, context)
         : undefined,
-    TotalCount: output.TotalCount !== undefined && output.TotalCount !== null ? output.TotalCount : undefined,
+    TotalCount: __expectNumber(output.TotalCount),
   } as any;
 };
 
@@ -22099,10 +21727,9 @@ const deserializeAws_json1_1InventoryDeletionSummaryItem = (
   context: __SerdeContext
 ): InventoryDeletionSummaryItem => {
   return {
-    Count: output.Count !== undefined && output.Count !== null ? output.Count : undefined,
-    RemainingCount:
-      output.RemainingCount !== undefined && output.RemainingCount !== null ? output.RemainingCount : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    Count: __expectNumber(output.Count),
+    RemainingCount: __expectNumber(output.RemainingCount),
+    Version: __expectString(output.Version),
   } as any;
 };
 
@@ -22122,8 +21749,8 @@ const deserializeAws_json1_1InventoryDeletionSummaryItems = (
 
 const deserializeAws_json1_1InventoryItemAttribute = (output: any, context: __SerdeContext): InventoryItemAttribute => {
   return {
-    DataType: output.DataType !== undefined && output.DataType !== null ? output.DataType : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    DataType: __expectString(output.DataType),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -22148,7 +21775,7 @@ const deserializeAws_json1_1InventoryItemEntry = (output: any, context: __SerdeC
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -22173,9 +21800,9 @@ const deserializeAws_json1_1InventoryItemSchema = (output: any, context: __Serde
       output.Attributes !== undefined && output.Attributes !== null
         ? deserializeAws_json1_1InventoryItemAttributeList(output.Attributes, context)
         : undefined,
-    DisplayName: output.DisplayName !== undefined && output.DisplayName !== null ? output.DisplayName : undefined,
-    TypeName: output.TypeName !== undefined && output.TypeName !== null ? output.TypeName : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    DisplayName: __expectString(output.DisplayName),
+    TypeName: __expectString(output.TypeName),
+    Version: __expectString(output.Version),
   } as any;
 };
 
@@ -22199,7 +21826,7 @@ const deserializeAws_json1_1InventoryResultEntity = (output: any, context: __Ser
       output.Data !== undefined && output.Data !== null
         ? deserializeAws_json1_1InventoryResultItemMap(output.Data, context)
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    Id: __expectString(output.Id),
   } as any;
 };
 
@@ -22219,15 +21846,14 @@ const deserializeAws_json1_1InventoryResultEntityList = (
 
 const deserializeAws_json1_1InventoryResultItem = (output: any, context: __SerdeContext): InventoryResultItem => {
   return {
-    CaptureTime: output.CaptureTime !== undefined && output.CaptureTime !== null ? output.CaptureTime : undefined,
+    CaptureTime: __expectString(output.CaptureTime),
     Content:
       output.Content !== undefined && output.Content !== null
         ? deserializeAws_json1_1InventoryItemEntryList(output.Content, context)
         : undefined,
-    ContentHash: output.ContentHash !== undefined && output.ContentHash !== null ? output.ContentHash : undefined,
-    SchemaVersion:
-      output.SchemaVersion !== undefined && output.SchemaVersion !== null ? output.SchemaVersion : undefined,
-    TypeName: output.TypeName !== undefined && output.TypeName !== null ? output.TypeName : undefined,
+    ContentHash: __expectString(output.ContentHash),
+    SchemaVersion: __expectString(output.SchemaVersion),
+    TypeName: __expectString(output.TypeName),
   } as any;
 };
 
@@ -22255,8 +21881,8 @@ const deserializeAws_json1_1ItemContentMismatchException = (
   context: __SerdeContext
 ): ItemContentMismatchException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    TypeName: output.TypeName !== undefined && output.TypeName !== null ? output.TypeName : undefined,
+    Message: __expectString(output.Message),
+    TypeName: __expectString(output.TypeName),
   } as any;
 };
 
@@ -22265,8 +21891,8 @@ const deserializeAws_json1_1ItemSizeLimitExceededException = (
   context: __SerdeContext
 ): ItemSizeLimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    TypeName: output.TypeName !== undefined && output.TypeName !== null ? output.TypeName : undefined,
+    Message: __expectString(output.Message),
+    TypeName: __expectString(output.TypeName),
   } as any;
 };
 
@@ -22279,8 +21905,7 @@ const deserializeAws_json1_1LabelParameterVersionResult = (
       output.InvalidLabels !== undefined && output.InvalidLabels !== null
         ? deserializeAws_json1_1ParameterLabelList(output.InvalidLabels, context)
         : undefined,
-    ParameterVersion:
-      output.ParameterVersion !== undefined && output.ParameterVersion !== null ? output.ParameterVersion : undefined,
+    ParameterVersion: __expectNumber(output.ParameterVersion),
   } as any;
 };
 
@@ -22290,7 +21915,7 @@ const deserializeAws_json1_1ListAssociationsResult = (output: any, context: __Se
       output.Associations !== undefined && output.Associations !== null
         ? deserializeAws_json1_1AssociationList(output.Associations, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -22303,7 +21928,7 @@ const deserializeAws_json1_1ListAssociationVersionsResult = (
       output.AssociationVersions !== undefined && output.AssociationVersions !== null
         ? deserializeAws_json1_1AssociationVersionList(output.AssociationVersions, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -22316,7 +21941,7 @@ const deserializeAws_json1_1ListCommandInvocationsResult = (
       output.CommandInvocations !== undefined && output.CommandInvocations !== null
         ? deserializeAws_json1_1CommandInvocationList(output.CommandInvocations, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -22326,7 +21951,7 @@ const deserializeAws_json1_1ListCommandsResult = (output: any, context: __SerdeC
       output.Commands !== undefined && output.Commands !== null
         ? deserializeAws_json1_1CommandList(output.Commands, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -22339,7 +21964,7 @@ const deserializeAws_json1_1ListComplianceItemsResult = (
       output.ComplianceItems !== undefined && output.ComplianceItems !== null
         ? deserializeAws_json1_1ComplianceItemList(output.ComplianceItems, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -22352,7 +21977,7 @@ const deserializeAws_json1_1ListComplianceSummariesResult = (
       output.ComplianceSummaryItems !== undefined && output.ComplianceSummaryItems !== null
         ? deserializeAws_json1_1ComplianceSummaryItemList(output.ComplianceSummaryItems, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -22361,15 +21986,14 @@ const deserializeAws_json1_1ListDocumentMetadataHistoryResponse = (
   context: __SerdeContext
 ): ListDocumentMetadataHistoryResponse => {
   return {
-    Author: output.Author !== undefined && output.Author !== null ? output.Author : undefined,
-    DocumentVersion:
-      output.DocumentVersion !== undefined && output.DocumentVersion !== null ? output.DocumentVersion : undefined,
+    Author: __expectString(output.Author),
+    DocumentVersion: __expectString(output.DocumentVersion),
     Metadata:
       output.Metadata !== undefined && output.Metadata !== null
         ? deserializeAws_json1_1DocumentMetadataResponseInfo(output.Metadata, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    Name: __expectString(output.Name),
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -22379,7 +22003,7 @@ const deserializeAws_json1_1ListDocumentsResult = (output: any, context: __Serde
       output.DocumentIdentifiers !== undefined && output.DocumentIdentifiers !== null
         ? deserializeAws_json1_1DocumentIdentifierList(output.DocumentIdentifiers, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -22392,7 +22016,7 @@ const deserializeAws_json1_1ListDocumentVersionsResult = (
       output.DocumentVersions !== undefined && output.DocumentVersions !== null
         ? deserializeAws_json1_1DocumentVersionList(output.DocumentVersions, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -22401,16 +22025,15 @@ const deserializeAws_json1_1ListInventoryEntriesResult = (
   context: __SerdeContext
 ): ListInventoryEntriesResult => {
   return {
-    CaptureTime: output.CaptureTime !== undefined && output.CaptureTime !== null ? output.CaptureTime : undefined,
+    CaptureTime: __expectString(output.CaptureTime),
     Entries:
       output.Entries !== undefined && output.Entries !== null
         ? deserializeAws_json1_1InventoryItemEntryList(output.Entries, context)
         : undefined,
-    InstanceId: output.InstanceId !== undefined && output.InstanceId !== null ? output.InstanceId : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
-    SchemaVersion:
-      output.SchemaVersion !== undefined && output.SchemaVersion !== null ? output.SchemaVersion : undefined,
-    TypeName: output.TypeName !== undefined && output.TypeName !== null ? output.TypeName : undefined,
+    InstanceId: __expectString(output.InstanceId),
+    NextToken: __expectString(output.NextToken),
+    SchemaVersion: __expectString(output.SchemaVersion),
+    TypeName: __expectString(output.TypeName),
   } as any;
 };
 
@@ -22419,7 +22042,7 @@ const deserializeAws_json1_1ListOpsItemEventsResponse = (
   context: __SerdeContext
 ): ListOpsItemEventsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Summaries:
       output.Summaries !== undefined && output.Summaries !== null
         ? deserializeAws_json1_1OpsItemEventSummaries(output.Summaries, context)
@@ -22432,7 +22055,7 @@ const deserializeAws_json1_1ListOpsItemRelatedItemsResponse = (
   context: __SerdeContext
 ): ListOpsItemRelatedItemsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Summaries:
       output.Summaries !== undefined && output.Summaries !== null
         ? deserializeAws_json1_1OpsItemRelatedItemSummaries(output.Summaries, context)
@@ -22442,7 +22065,7 @@ const deserializeAws_json1_1ListOpsItemRelatedItemsResponse = (
 
 const deserializeAws_json1_1ListOpsMetadataResult = (output: any, context: __SerdeContext): ListOpsMetadataResult => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     OpsMetadataList:
       output.OpsMetadataList !== undefined && output.OpsMetadataList !== null
         ? deserializeAws_json1_1OpsMetadataList(output.OpsMetadataList, context)
@@ -22455,7 +22078,7 @@ const deserializeAws_json1_1ListResourceComplianceSummariesResult = (
   context: __SerdeContext
 ): ListResourceComplianceSummariesResult => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     ResourceComplianceSummaryItems:
       output.ResourceComplianceSummaryItems !== undefined && output.ResourceComplianceSummaryItems !== null
         ? deserializeAws_json1_1ResourceComplianceSummaryItemList(output.ResourceComplianceSummaryItems, context)
@@ -22468,7 +22091,7 @@ const deserializeAws_json1_1ListResourceDataSyncResult = (
   context: __SerdeContext
 ): ListResourceDataSyncResult => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     ResourceDataSyncItems:
       output.ResourceDataSyncItems !== undefined && output.ResourceDataSyncItems !== null
         ? deserializeAws_json1_1ResourceDataSyncItemList(output.ResourceDataSyncItems, context)
@@ -22490,9 +22113,9 @@ const deserializeAws_json1_1ListTagsForResourceResult = (
 
 const deserializeAws_json1_1LoggingInfo = (output: any, context: __SerdeContext): LoggingInfo => {
   return {
-    S3BucketName: output.S3BucketName !== undefined && output.S3BucketName !== null ? output.S3BucketName : undefined,
-    S3KeyPrefix: output.S3KeyPrefix !== undefined && output.S3KeyPrefix !== null ? output.S3KeyPrefix : undefined,
-    S3Region: output.S3Region !== undefined && output.S3Region !== null ? output.S3Region : undefined,
+    S3BucketName: __expectString(output.S3BucketName),
+    S3KeyPrefix: __expectString(output.S3KeyPrefix),
+    S3Region: __expectString(output.S3Region),
   } as any;
 };
 
@@ -22501,8 +22124,7 @@ const deserializeAws_json1_1MaintenanceWindowAutomationParameters = (
   context: __SerdeContext
 ): MaintenanceWindowAutomationParameters => {
   return {
-    DocumentVersion:
-      output.DocumentVersion !== undefined && output.DocumentVersion !== null ? output.DocumentVersion : undefined,
+    DocumentVersion: __expectString(output.DocumentVersion),
     Parameters:
       output.Parameters !== undefined && output.Parameters !== null
         ? deserializeAws_json1_1AutomationParameterMap(output.Parameters, context)
@@ -22521,14 +22143,10 @@ const deserializeAws_json1_1MaintenanceWindowExecution = (
       output.StartTime !== undefined && output.StartTime !== null
         ? new Date(Math.round(output.StartTime * 1000))
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusDetails:
-      output.StatusDetails !== undefined && output.StatusDetails !== null ? output.StatusDetails : undefined,
-    WindowExecutionId:
-      output.WindowExecutionId !== undefined && output.WindowExecutionId !== null
-        ? output.WindowExecutionId
-        : undefined,
-    WindowId: output.WindowId !== undefined && output.WindowId !== null ? output.WindowId : undefined,
+    Status: __expectString(output.Status),
+    StatusDetails: __expectString(output.StatusDetails),
+    WindowExecutionId: __expectString(output.WindowExecutionId),
+    WindowId: __expectString(output.WindowId),
   } as any;
 };
 
@@ -22557,17 +22175,12 @@ const deserializeAws_json1_1MaintenanceWindowExecutionTaskIdentity = (
       output.StartTime !== undefined && output.StartTime !== null
         ? new Date(Math.round(output.StartTime * 1000))
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusDetails:
-      output.StatusDetails !== undefined && output.StatusDetails !== null ? output.StatusDetails : undefined,
-    TaskArn: output.TaskArn !== undefined && output.TaskArn !== null ? output.TaskArn : undefined,
-    TaskExecutionId:
-      output.TaskExecutionId !== undefined && output.TaskExecutionId !== null ? output.TaskExecutionId : undefined,
-    TaskType: output.TaskType !== undefined && output.TaskType !== null ? output.TaskType : undefined,
-    WindowExecutionId:
-      output.WindowExecutionId !== undefined && output.WindowExecutionId !== null
-        ? output.WindowExecutionId
-        : undefined,
+    Status: __expectString(output.Status),
+    StatusDetails: __expectString(output.StatusDetails),
+    TaskArn: __expectString(output.TaskArn),
+    TaskExecutionId: __expectString(output.TaskExecutionId),
+    TaskType: __expectString(output.TaskType),
+    WindowExecutionId: __expectString(output.WindowExecutionId),
   } as any;
 };
 
@@ -22592,7 +22205,7 @@ const deserializeAws_json1_1MaintenanceWindowExecutionTaskIdList = (output: any,
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -22603,27 +22216,20 @@ const deserializeAws_json1_1MaintenanceWindowExecutionTaskInvocationIdentity = (
   return {
     EndTime:
       output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
-    ExecutionId: output.ExecutionId !== undefined && output.ExecutionId !== null ? output.ExecutionId : undefined,
-    InvocationId: output.InvocationId !== undefined && output.InvocationId !== null ? output.InvocationId : undefined,
-    OwnerInformation:
-      output.OwnerInformation !== undefined && output.OwnerInformation !== null ? output.OwnerInformation : undefined,
-    Parameters: output.Parameters !== undefined && output.Parameters !== null ? output.Parameters : undefined,
+    ExecutionId: __expectString(output.ExecutionId),
+    InvocationId: __expectString(output.InvocationId),
+    OwnerInformation: __expectString(output.OwnerInformation),
+    Parameters: __expectString(output.Parameters),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
         ? new Date(Math.round(output.StartTime * 1000))
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusDetails:
-      output.StatusDetails !== undefined && output.StatusDetails !== null ? output.StatusDetails : undefined,
-    TaskExecutionId:
-      output.TaskExecutionId !== undefined && output.TaskExecutionId !== null ? output.TaskExecutionId : undefined,
-    TaskType: output.TaskType !== undefined && output.TaskType !== null ? output.TaskType : undefined,
-    WindowExecutionId:
-      output.WindowExecutionId !== undefined && output.WindowExecutionId !== null
-        ? output.WindowExecutionId
-        : undefined,
-    WindowTargetId:
-      output.WindowTargetId !== undefined && output.WindowTargetId !== null ? output.WindowTargetId : undefined,
+    Status: __expectString(output.Status),
+    StatusDetails: __expectString(output.StatusDetails),
+    TaskExecutionId: __expectString(output.TaskExecutionId),
+    TaskType: __expectString(output.TaskType),
+    WindowExecutionId: __expectString(output.WindowExecutionId),
+    WindowTargetId: __expectString(output.WindowTargetId),
   } as any;
 };
 
@@ -22646,23 +22252,18 @@ const deserializeAws_json1_1MaintenanceWindowIdentity = (
   context: __SerdeContext
 ): MaintenanceWindowIdentity => {
   return {
-    Cutoff: output.Cutoff !== undefined && output.Cutoff !== null ? output.Cutoff : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Duration: output.Duration !== undefined && output.Duration !== null ? output.Duration : undefined,
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
-    EndDate: output.EndDate !== undefined && output.EndDate !== null ? output.EndDate : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    NextExecutionTime:
-      output.NextExecutionTime !== undefined && output.NextExecutionTime !== null
-        ? output.NextExecutionTime
-        : undefined,
-    Schedule: output.Schedule !== undefined && output.Schedule !== null ? output.Schedule : undefined,
-    ScheduleOffset:
-      output.ScheduleOffset !== undefined && output.ScheduleOffset !== null ? output.ScheduleOffset : undefined,
-    ScheduleTimezone:
-      output.ScheduleTimezone !== undefined && output.ScheduleTimezone !== null ? output.ScheduleTimezone : undefined,
-    StartDate: output.StartDate !== undefined && output.StartDate !== null ? output.StartDate : undefined,
-    WindowId: output.WindowId !== undefined && output.WindowId !== null ? output.WindowId : undefined,
+    Cutoff: __expectNumber(output.Cutoff),
+    Description: __expectString(output.Description),
+    Duration: __expectNumber(output.Duration),
+    Enabled: __expectBoolean(output.Enabled),
+    EndDate: __expectString(output.EndDate),
+    Name: __expectString(output.Name),
+    NextExecutionTime: __expectString(output.NextExecutionTime),
+    Schedule: __expectString(output.Schedule),
+    ScheduleOffset: __expectNumber(output.ScheduleOffset),
+    ScheduleTimezone: __expectString(output.ScheduleTimezone),
+    StartDate: __expectString(output.StartDate),
+    WindowId: __expectString(output.WindowId),
   } as any;
 };
 
@@ -22671,8 +22272,8 @@ const deserializeAws_json1_1MaintenanceWindowIdentityForTarget = (
   context: __SerdeContext
 ): MaintenanceWindowIdentityForTarget => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    WindowId: output.WindowId !== undefined && output.WindowId !== null ? output.WindowId : undefined,
+    Name: __expectString(output.Name),
+    WindowId: __expectString(output.WindowId),
   } as any;
 };
 
@@ -22695,11 +22296,10 @@ const deserializeAws_json1_1MaintenanceWindowLambdaParameters = (
   context: __SerdeContext
 ): MaintenanceWindowLambdaParameters => {
   return {
-    ClientContext:
-      output.ClientContext !== undefined && output.ClientContext !== null ? output.ClientContext : undefined,
+    ClientContext: __expectString(output.ClientContext),
     Payload:
       output.Payload !== undefined && output.Payload !== null ? context.base64Decoder(output.Payload) : undefined,
-    Qualifier: output.Qualifier !== undefined && output.Qualifier !== null ? output.Qualifier : undefined,
+    Qualifier: __expectString(output.Qualifier),
   } as any;
 };
 
@@ -22712,32 +22312,22 @@ const deserializeAws_json1_1MaintenanceWindowRunCommandParameters = (
       output.CloudWatchOutputConfig !== undefined && output.CloudWatchOutputConfig !== null
         ? deserializeAws_json1_1CloudWatchOutputConfig(output.CloudWatchOutputConfig, context)
         : undefined,
-    Comment: output.Comment !== undefined && output.Comment !== null ? output.Comment : undefined,
-    DocumentHash: output.DocumentHash !== undefined && output.DocumentHash !== null ? output.DocumentHash : undefined,
-    DocumentHashType:
-      output.DocumentHashType !== undefined && output.DocumentHashType !== null ? output.DocumentHashType : undefined,
-    DocumentVersion:
-      output.DocumentVersion !== undefined && output.DocumentVersion !== null ? output.DocumentVersion : undefined,
+    Comment: __expectString(output.Comment),
+    DocumentHash: __expectString(output.DocumentHash),
+    DocumentHashType: __expectString(output.DocumentHashType),
+    DocumentVersion: __expectString(output.DocumentVersion),
     NotificationConfig:
       output.NotificationConfig !== undefined && output.NotificationConfig !== null
         ? deserializeAws_json1_1NotificationConfig(output.NotificationConfig, context)
         : undefined,
-    OutputS3BucketName:
-      output.OutputS3BucketName !== undefined && output.OutputS3BucketName !== null
-        ? output.OutputS3BucketName
-        : undefined,
-    OutputS3KeyPrefix:
-      output.OutputS3KeyPrefix !== undefined && output.OutputS3KeyPrefix !== null
-        ? output.OutputS3KeyPrefix
-        : undefined,
+    OutputS3BucketName: __expectString(output.OutputS3BucketName),
+    OutputS3KeyPrefix: __expectString(output.OutputS3KeyPrefix),
     Parameters:
       output.Parameters !== undefined && output.Parameters !== null
         ? deserializeAws_json1_1Parameters(output.Parameters, context)
         : undefined,
-    ServiceRoleArn:
-      output.ServiceRoleArn !== undefined && output.ServiceRoleArn !== null ? output.ServiceRoleArn : undefined,
-    TimeoutSeconds:
-      output.TimeoutSeconds !== undefined && output.TimeoutSeconds !== null ? output.TimeoutSeconds : undefined,
+    ServiceRoleArn: __expectString(output.ServiceRoleArn),
+    TimeoutSeconds: __expectNumber(output.TimeoutSeconds),
   } as any;
 };
 
@@ -22760,8 +22350,8 @@ const deserializeAws_json1_1MaintenanceWindowStepFunctionsParameters = (
   context: __SerdeContext
 ): MaintenanceWindowStepFunctionsParameters => {
   return {
-    Input: output.Input !== undefined && output.Input !== null ? output.Input : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Input: __expectString(output.Input),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -22770,18 +22360,16 @@ const deserializeAws_json1_1MaintenanceWindowTarget = (
   context: __SerdeContext
 ): MaintenanceWindowTarget => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    OwnerInformation:
-      output.OwnerInformation !== undefined && output.OwnerInformation !== null ? output.OwnerInformation : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
+    Description: __expectString(output.Description),
+    Name: __expectString(output.Name),
+    OwnerInformation: __expectString(output.OwnerInformation),
+    ResourceType: __expectString(output.ResourceType),
     Targets:
       output.Targets !== undefined && output.Targets !== null
         ? deserializeAws_json1_1Targets(output.Targets, context)
         : undefined,
-    WindowId: output.WindowId !== undefined && output.WindowId !== null ? output.WindowId : undefined,
-    WindowTargetId:
-      output.WindowTargetId !== undefined && output.WindowTargetId !== null ? output.WindowTargetId : undefined,
+    WindowId: __expectString(output.WindowId),
+    WindowTargetId: __expectString(output.WindowTargetId),
   } as any;
 };
 
@@ -22801,30 +22389,28 @@ const deserializeAws_json1_1MaintenanceWindowTargetList = (
 
 const deserializeAws_json1_1MaintenanceWindowTask = (output: any, context: __SerdeContext): MaintenanceWindowTask => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     LoggingInfo:
       output.LoggingInfo !== undefined && output.LoggingInfo !== null
         ? deserializeAws_json1_1LoggingInfo(output.LoggingInfo, context)
         : undefined,
-    MaxConcurrency:
-      output.MaxConcurrency !== undefined && output.MaxConcurrency !== null ? output.MaxConcurrency : undefined,
-    MaxErrors: output.MaxErrors !== undefined && output.MaxErrors !== null ? output.MaxErrors : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Priority: output.Priority !== undefined && output.Priority !== null ? output.Priority : undefined,
-    ServiceRoleArn:
-      output.ServiceRoleArn !== undefined && output.ServiceRoleArn !== null ? output.ServiceRoleArn : undefined,
+    MaxConcurrency: __expectString(output.MaxConcurrency),
+    MaxErrors: __expectString(output.MaxErrors),
+    Name: __expectString(output.Name),
+    Priority: __expectNumber(output.Priority),
+    ServiceRoleArn: __expectString(output.ServiceRoleArn),
     Targets:
       output.Targets !== undefined && output.Targets !== null
         ? deserializeAws_json1_1Targets(output.Targets, context)
         : undefined,
-    TaskArn: output.TaskArn !== undefined && output.TaskArn !== null ? output.TaskArn : undefined,
+    TaskArn: __expectString(output.TaskArn),
     TaskParameters:
       output.TaskParameters !== undefined && output.TaskParameters !== null
         ? deserializeAws_json1_1MaintenanceWindowTaskParameters(output.TaskParameters, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    WindowId: output.WindowId !== undefined && output.WindowId !== null ? output.WindowId : undefined,
-    WindowTaskId: output.WindowTaskId !== undefined && output.WindowTaskId !== null ? output.WindowTaskId : undefined,
+    Type: __expectString(output.Type),
+    WindowId: __expectString(output.WindowId),
+    WindowTaskId: __expectString(output.WindowTaskId),
   } as any;
 };
 
@@ -22920,7 +22506,7 @@ const deserializeAws_json1_1MaintenanceWindowTaskParameterValueList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -22929,7 +22515,7 @@ const deserializeAws_json1_1MaxDocumentSizeExceeded = (
   context: __SerdeContext
 ): MaxDocumentSizeExceeded => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -22947,7 +22533,7 @@ const deserializeAws_json1_1MetadataMap = (output: any, context: __SerdeContext)
 
 const deserializeAws_json1_1MetadataValue = (output: any, context: __SerdeContext): MetadataValue => {
   return {
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -22960,10 +22546,7 @@ const deserializeAws_json1_1ModifyDocumentPermissionResponse = (
 
 const deserializeAws_json1_1NonCompliantSummary = (output: any, context: __SerdeContext): NonCompliantSummary => {
   return {
-    NonCompliantCount:
-      output.NonCompliantCount !== undefined && output.NonCompliantCount !== null
-        ? output.NonCompliantCount
-        : undefined,
+    NonCompliantCount: __expectNumber(output.NonCompliantCount),
     SeveritySummary:
       output.SeveritySummary !== undefined && output.SeveritySummary !== null
         ? deserializeAws_json1_1SeveritySummary(output.SeveritySummary, context)
@@ -22978,21 +22561,19 @@ const deserializeAws_json1_1NormalStringMap = (output: any, context: __SerdeCont
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_json1_1NotificationConfig = (output: any, context: __SerdeContext): NotificationConfig => {
   return {
-    NotificationArn:
-      output.NotificationArn !== undefined && output.NotificationArn !== null ? output.NotificationArn : undefined,
+    NotificationArn: __expectString(output.NotificationArn),
     NotificationEvents:
       output.NotificationEvents !== undefined && output.NotificationEvents !== null
         ? deserializeAws_json1_1NotificationEventList(output.NotificationEvents, context)
         : undefined,
-    NotificationType:
-      output.NotificationType !== undefined && output.NotificationType !== null ? output.NotificationType : undefined,
+    NotificationType: __expectString(output.NotificationType),
   } as any;
 };
 
@@ -23006,7 +22587,7 @@ const deserializeAws_json1_1NotificationEventList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -23016,13 +22597,13 @@ const deserializeAws_json1_1OpsEntity = (output: any, context: __SerdeContext): 
       output.Data !== undefined && output.Data !== null
         ? deserializeAws_json1_1OpsEntityItemMap(output.Data, context)
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    Id: __expectString(output.Id),
   } as any;
 };
 
 const deserializeAws_json1_1OpsEntityItem = (output: any, context: __SerdeContext): OpsEntityItem => {
   return {
-    CaptureTime: output.CaptureTime !== undefined && output.CaptureTime !== null ? output.CaptureTime : undefined,
+    CaptureTime: __expectString(output.CaptureTime),
     Content:
       output.Content !== undefined && output.Content !== null
         ? deserializeAws_json1_1OpsEntityItemEntryList(output.Content, context)
@@ -23037,7 +22618,7 @@ const deserializeAws_json1_1OpsEntityItemEntry = (output: any, context: __SerdeC
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -23092,15 +22673,14 @@ const deserializeAws_json1_1OpsItem = (output: any, context: __SerdeContext): Op
       output.ActualStartTime !== undefined && output.ActualStartTime !== null
         ? new Date(Math.round(output.ActualStartTime * 1000))
         : undefined,
-    Category: output.Category !== undefined && output.Category !== null ? output.Category : undefined,
-    CreatedBy: output.CreatedBy !== undefined && output.CreatedBy !== null ? output.CreatedBy : undefined,
+    Category: __expectString(output.Category),
+    CreatedBy: __expectString(output.CreatedBy),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    LastModifiedBy:
-      output.LastModifiedBy !== undefined && output.LastModifiedBy !== null ? output.LastModifiedBy : undefined,
+    Description: __expectString(output.Description),
+    LastModifiedBy: __expectString(output.LastModifiedBy),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
@@ -23113,8 +22693,8 @@ const deserializeAws_json1_1OpsItem = (output: any, context: __SerdeContext): Op
       output.OperationalData !== undefined && output.OperationalData !== null
         ? deserializeAws_json1_1OpsItemOperationalData(output.OperationalData, context)
         : undefined,
-    OpsItemId: output.OpsItemId !== undefined && output.OpsItemId !== null ? output.OpsItemId : undefined,
-    OpsItemType: output.OpsItemType !== undefined && output.OpsItemType !== null ? output.OpsItemType : undefined,
+    OpsItemId: __expectString(output.OpsItemId),
+    OpsItemType: __expectString(output.OpsItemType),
     PlannedEndTime:
       output.PlannedEndTime !== undefined && output.PlannedEndTime !== null
         ? new Date(Math.round(output.PlannedEndTime * 1000))
@@ -23123,16 +22703,16 @@ const deserializeAws_json1_1OpsItem = (output: any, context: __SerdeContext): Op
       output.PlannedStartTime !== undefined && output.PlannedStartTime !== null
         ? new Date(Math.round(output.PlannedStartTime * 1000))
         : undefined,
-    Priority: output.Priority !== undefined && output.Priority !== null ? output.Priority : undefined,
+    Priority: __expectNumber(output.Priority),
     RelatedOpsItems:
       output.RelatedOpsItems !== undefined && output.RelatedOpsItems !== null
         ? deserializeAws_json1_1RelatedOpsItems(output.RelatedOpsItems, context)
         : undefined,
-    Severity: output.Severity !== undefined && output.Severity !== null ? output.Severity : undefined,
-    Source: output.Source !== undefined && output.Source !== null ? output.Source : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    Title: output.Title !== undefined && output.Title !== null ? output.Title : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    Severity: __expectString(output.Severity),
+    Source: __expectString(output.Source),
+    Status: __expectString(output.Status),
+    Title: __expectString(output.Title),
+    Version: __expectString(output.Version),
   } as any;
 };
 
@@ -23141,15 +22721,15 @@ const deserializeAws_json1_1OpsItemAlreadyExistsException = (
   context: __SerdeContext
 ): OpsItemAlreadyExistsException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    OpsItemId: output.OpsItemId !== undefined && output.OpsItemId !== null ? output.OpsItemId : undefined,
+    Message: __expectString(output.Message),
+    OpsItemId: __expectString(output.OpsItemId),
   } as any;
 };
 
 const deserializeAws_json1_1OpsItemDataValue = (output: any, context: __SerdeContext): OpsItemDataValue => {
   return {
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Type: __expectString(output.Type),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -23174,17 +22754,17 @@ const deserializeAws_json1_1OpsItemEventSummary = (output: any, context: __Serde
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
         : undefined,
-    Detail: output.Detail !== undefined && output.Detail !== null ? output.Detail : undefined,
-    DetailType: output.DetailType !== undefined && output.DetailType !== null ? output.DetailType : undefined,
-    EventId: output.EventId !== undefined && output.EventId !== null ? output.EventId : undefined,
-    OpsItemId: output.OpsItemId !== undefined && output.OpsItemId !== null ? output.OpsItemId : undefined,
-    Source: output.Source !== undefined && output.Source !== null ? output.Source : undefined,
+    Detail: __expectString(output.Detail),
+    DetailType: __expectString(output.DetailType),
+    EventId: __expectString(output.EventId),
+    OpsItemId: __expectString(output.OpsItemId),
+    Source: __expectString(output.Source),
   } as any;
 };
 
 const deserializeAws_json1_1OpsItemIdentity = (output: any, context: __SerdeContext): OpsItemIdentity => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
   } as any;
 };
 
@@ -23193,7 +22773,7 @@ const deserializeAws_json1_1OpsItemInvalidParameterException = (
   context: __SerdeContext
 ): OpsItemInvalidParameterException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
     ParameterNames:
       output.ParameterNames !== undefined && output.ParameterNames !== null
         ? deserializeAws_json1_1OpsItemParameterNamesList(output.ParameterNames, context)
@@ -23206,9 +22786,9 @@ const deserializeAws_json1_1OpsItemLimitExceededException = (
   context: __SerdeContext
 ): OpsItemLimitExceededException => {
   return {
-    Limit: output.Limit !== undefined && output.Limit !== null ? output.Limit : undefined,
-    LimitType: output.LimitType !== undefined && output.LimitType !== null ? output.LimitType : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Limit: __expectNumber(output.Limit),
+    LimitType: __expectString(output.LimitType),
+    Message: __expectString(output.Message),
     ResourceTypes:
       output.ResourceTypes !== undefined && output.ResourceTypes !== null
         ? deserializeAws_json1_1OpsItemParameterNamesList(output.ResourceTypes, context)
@@ -23221,13 +22801,13 @@ const deserializeAws_json1_1OpsItemNotFoundException = (
   context: __SerdeContext
 ): OpsItemNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1OpsItemNotification = (output: any, context: __SerdeContext): OpsItemNotification => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
   } as any;
 };
 
@@ -23264,7 +22844,7 @@ const deserializeAws_json1_1OpsItemParameterNamesList = (output: any, context: _
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -23273,9 +22853,9 @@ const deserializeAws_json1_1OpsItemRelatedItemAlreadyExistsException = (
   context: __SerdeContext
 ): OpsItemRelatedItemAlreadyExistsException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    OpsItemId: output.OpsItemId !== undefined && output.OpsItemId !== null ? output.OpsItemId : undefined,
-    ResourceUri: output.ResourceUri !== undefined && output.ResourceUri !== null ? output.ResourceUri : undefined,
+    Message: __expectString(output.Message),
+    OpsItemId: __expectString(output.OpsItemId),
+    ResourceUri: __expectString(output.ResourceUri),
   } as any;
 };
 
@@ -23284,7 +22864,7 @@ const deserializeAws_json1_1OpsItemRelatedItemAssociationNotFoundException = (
   context: __SerdeContext
 ): OpsItemRelatedItemAssociationNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -23307,10 +22887,8 @@ const deserializeAws_json1_1OpsItemRelatedItemSummary = (
   context: __SerdeContext
 ): OpsItemRelatedItemSummary => {
   return {
-    AssociationId:
-      output.AssociationId !== undefined && output.AssociationId !== null ? output.AssociationId : undefined,
-    AssociationType:
-      output.AssociationType !== undefined && output.AssociationType !== null ? output.AssociationType : undefined,
+    AssociationId: __expectString(output.AssociationId),
+    AssociationType: __expectString(output.AssociationType),
     CreatedBy:
       output.CreatedBy !== undefined && output.CreatedBy !== null
         ? deserializeAws_json1_1OpsItemIdentity(output.CreatedBy, context)
@@ -23327,9 +22905,9 @@ const deserializeAws_json1_1OpsItemRelatedItemSummary = (
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    OpsItemId: output.OpsItemId !== undefined && output.OpsItemId !== null ? output.OpsItemId : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
-    ResourceUri: output.ResourceUri !== undefined && output.ResourceUri !== null ? output.ResourceUri : undefined,
+    OpsItemId: __expectString(output.OpsItemId),
+    ResourceType: __expectString(output.ResourceType),
+    ResourceUri: __expectString(output.ResourceUri),
   } as any;
 };
 
@@ -23354,14 +22932,13 @@ const deserializeAws_json1_1OpsItemSummary = (output: any, context: __SerdeConte
       output.ActualStartTime !== undefined && output.ActualStartTime !== null
         ? new Date(Math.round(output.ActualStartTime * 1000))
         : undefined,
-    Category: output.Category !== undefined && output.Category !== null ? output.Category : undefined,
-    CreatedBy: output.CreatedBy !== undefined && output.CreatedBy !== null ? output.CreatedBy : undefined,
+    Category: __expectString(output.Category),
+    CreatedBy: __expectString(output.CreatedBy),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
         : undefined,
-    LastModifiedBy:
-      output.LastModifiedBy !== undefined && output.LastModifiedBy !== null ? output.LastModifiedBy : undefined,
+    LastModifiedBy: __expectString(output.LastModifiedBy),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
@@ -23370,8 +22947,8 @@ const deserializeAws_json1_1OpsItemSummary = (output: any, context: __SerdeConte
       output.OperationalData !== undefined && output.OperationalData !== null
         ? deserializeAws_json1_1OpsItemOperationalData(output.OperationalData, context)
         : undefined,
-    OpsItemId: output.OpsItemId !== undefined && output.OpsItemId !== null ? output.OpsItemId : undefined,
-    OpsItemType: output.OpsItemType !== undefined && output.OpsItemType !== null ? output.OpsItemType : undefined,
+    OpsItemId: __expectString(output.OpsItemId),
+    OpsItemType: __expectString(output.OpsItemType),
     PlannedEndTime:
       output.PlannedEndTime !== undefined && output.PlannedEndTime !== null
         ? new Date(Math.round(output.PlannedEndTime * 1000))
@@ -23380,11 +22957,11 @@ const deserializeAws_json1_1OpsItemSummary = (output: any, context: __SerdeConte
       output.PlannedStartTime !== undefined && output.PlannedStartTime !== null
         ? new Date(Math.round(output.PlannedStartTime * 1000))
         : undefined,
-    Priority: output.Priority !== undefined && output.Priority !== null ? output.Priority : undefined,
-    Severity: output.Severity !== undefined && output.Severity !== null ? output.Severity : undefined,
-    Source: output.Source !== undefined && output.Source !== null ? output.Source : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    Title: output.Title !== undefined && output.Title !== null ? output.Title : undefined,
+    Priority: __expectNumber(output.Priority),
+    Severity: __expectString(output.Severity),
+    Source: __expectString(output.Source),
+    Status: __expectString(output.Status),
+    Title: __expectString(output.Title),
   } as any;
 };
 
@@ -23398,11 +22975,9 @@ const deserializeAws_json1_1OpsMetadata = (output: any, context: __SerdeContext)
       output.LastModifiedDate !== undefined && output.LastModifiedDate !== null
         ? new Date(Math.round(output.LastModifiedDate * 1000))
         : undefined,
-    LastModifiedUser:
-      output.LastModifiedUser !== undefined && output.LastModifiedUser !== null ? output.LastModifiedUser : undefined,
-    OpsMetadataArn:
-      output.OpsMetadataArn !== undefined && output.OpsMetadataArn !== null ? output.OpsMetadataArn : undefined,
-    ResourceId: output.ResourceId !== undefined && output.ResourceId !== null ? output.ResourceId : undefined,
+    LastModifiedUser: __expectString(output.LastModifiedUser),
+    OpsMetadataArn: __expectString(output.OpsMetadataArn),
+    ResourceId: __expectString(output.ResourceId),
   } as any;
 };
 
@@ -23411,7 +22986,7 @@ const deserializeAws_json1_1OpsMetadataAlreadyExistsException = (
   context: __SerdeContext
 ): OpsMetadataAlreadyExistsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -23420,7 +22995,7 @@ const deserializeAws_json1_1OpsMetadataInvalidArgumentException = (
   context: __SerdeContext
 ): OpsMetadataInvalidArgumentException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -23429,7 +23004,7 @@ const deserializeAws_json1_1OpsMetadataKeyLimitExceededException = (
   context: __SerdeContext
 ): OpsMetadataKeyLimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -23438,7 +23013,7 @@ const deserializeAws_json1_1OpsMetadataLimitExceededException = (
   context: __SerdeContext
 ): OpsMetadataLimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -23458,7 +23033,7 @@ const deserializeAws_json1_1OpsMetadataNotFoundException = (
   context: __SerdeContext
 ): OpsMetadataNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -23467,49 +23042,46 @@ const deserializeAws_json1_1OpsMetadataTooManyUpdatesException = (
   context: __SerdeContext
 ): OpsMetadataTooManyUpdatesException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1OutputSource = (output: any, context: __SerdeContext): OutputSource => {
   return {
-    OutputSourceId:
-      output.OutputSourceId !== undefined && output.OutputSourceId !== null ? output.OutputSourceId : undefined,
-    OutputSourceType:
-      output.OutputSourceType !== undefined && output.OutputSourceType !== null ? output.OutputSourceType : undefined,
+    OutputSourceId: __expectString(output.OutputSourceId),
+    OutputSourceType: __expectString(output.OutputSourceType),
   } as any;
 };
 
 const deserializeAws_json1_1Parameter = (output: any, context: __SerdeContext): Parameter => {
   return {
-    ARN: output.ARN !== undefined && output.ARN !== null ? output.ARN : undefined,
-    DataType: output.DataType !== undefined && output.DataType !== null ? output.DataType : undefined,
+    ARN: __expectString(output.ARN),
+    DataType: __expectString(output.DataType),
     LastModifiedDate:
       output.LastModifiedDate !== undefined && output.LastModifiedDate !== null
         ? new Date(Math.round(output.LastModifiedDate * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Selector: output.Selector !== undefined && output.Selector !== null ? output.Selector : undefined,
-    SourceResult: output.SourceResult !== undefined && output.SourceResult !== null ? output.SourceResult : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    Name: __expectString(output.Name),
+    Selector: __expectString(output.Selector),
+    SourceResult: __expectString(output.SourceResult),
+    Type: __expectString(output.Type),
+    Value: __expectString(output.Value),
+    Version: __expectNumber(output.Version),
   } as any;
 };
 
 const deserializeAws_json1_1ParameterAlreadyExists = (output: any, context: __SerdeContext): ParameterAlreadyExists => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1ParameterHistory = (output: any, context: __SerdeContext): ParameterHistory => {
   return {
-    AllowedPattern:
-      output.AllowedPattern !== undefined && output.AllowedPattern !== null ? output.AllowedPattern : undefined,
-    DataType: output.DataType !== undefined && output.DataType !== null ? output.DataType : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    KeyId: output.KeyId !== undefined && output.KeyId !== null ? output.KeyId : undefined,
+    AllowedPattern: __expectString(output.AllowedPattern),
+    DataType: __expectString(output.DataType),
+    Description: __expectString(output.Description),
+    KeyId: __expectString(output.KeyId),
     Labels:
       output.Labels !== undefined && output.Labels !== null
         ? deserializeAws_json1_1ParameterLabelList(output.Labels, context)
@@ -23518,17 +23090,16 @@ const deserializeAws_json1_1ParameterHistory = (output: any, context: __SerdeCon
       output.LastModifiedDate !== undefined && output.LastModifiedDate !== null
         ? new Date(Math.round(output.LastModifiedDate * 1000))
         : undefined,
-    LastModifiedUser:
-      output.LastModifiedUser !== undefined && output.LastModifiedUser !== null ? output.LastModifiedUser : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    LastModifiedUser: __expectString(output.LastModifiedUser),
+    Name: __expectString(output.Name),
     Policies:
       output.Policies !== undefined && output.Policies !== null
         ? deserializeAws_json1_1ParameterPolicyList(output.Policies, context)
         : undefined,
-    Tier: output.Tier !== undefined && output.Tier !== null ? output.Tier : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    Tier: __expectString(output.Tier),
+    Type: __expectString(output.Type),
+    Value: __expectString(output.Value),
+    Version: __expectNumber(output.Version),
   } as any;
 };
 
@@ -23545,9 +23116,9 @@ const deserializeAws_json1_1ParameterHistoryList = (output: any, context: __Serd
 
 const deserializeAws_json1_1ParameterInlinePolicy = (output: any, context: __SerdeContext): ParameterInlinePolicy => {
   return {
-    PolicyStatus: output.PolicyStatus !== undefined && output.PolicyStatus !== null ? output.PolicyStatus : undefined,
-    PolicyText: output.PolicyText !== undefined && output.PolicyText !== null ? output.PolicyText : undefined,
-    PolicyType: output.PolicyType !== undefined && output.PolicyType !== null ? output.PolicyType : undefined,
+    PolicyStatus: __expectString(output.PolicyStatus),
+    PolicyText: __expectString(output.PolicyText),
+    PolicyType: __expectString(output.PolicyType),
   } as any;
 };
 
@@ -23558,13 +23129,13 @@ const deserializeAws_json1_1ParameterLabelList = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1ParameterLimitExceeded = (output: any, context: __SerdeContext): ParameterLimitExceeded => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -23584,31 +23155,29 @@ const deserializeAws_json1_1ParameterMaxVersionLimitExceeded = (
   context: __SerdeContext
 ): ParameterMaxVersionLimitExceeded => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1ParameterMetadata = (output: any, context: __SerdeContext): ParameterMetadata => {
   return {
-    AllowedPattern:
-      output.AllowedPattern !== undefined && output.AllowedPattern !== null ? output.AllowedPattern : undefined,
-    DataType: output.DataType !== undefined && output.DataType !== null ? output.DataType : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    KeyId: output.KeyId !== undefined && output.KeyId !== null ? output.KeyId : undefined,
+    AllowedPattern: __expectString(output.AllowedPattern),
+    DataType: __expectString(output.DataType),
+    Description: __expectString(output.Description),
+    KeyId: __expectString(output.KeyId),
     LastModifiedDate:
       output.LastModifiedDate !== undefined && output.LastModifiedDate !== null
         ? new Date(Math.round(output.LastModifiedDate * 1000))
         : undefined,
-    LastModifiedUser:
-      output.LastModifiedUser !== undefined && output.LastModifiedUser !== null ? output.LastModifiedUser : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    LastModifiedUser: __expectString(output.LastModifiedUser),
+    Name: __expectString(output.Name),
     Policies:
       output.Policies !== undefined && output.Policies !== null
         ? deserializeAws_json1_1ParameterPolicyList(output.Policies, context)
         : undefined,
-    Tier: output.Tier !== undefined && output.Tier !== null ? output.Tier : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    Tier: __expectString(output.Tier),
+    Type: __expectString(output.Type),
+    Version: __expectNumber(output.Version),
   } as any;
 };
 
@@ -23630,13 +23199,13 @@ const deserializeAws_json1_1ParameterNameList = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1ParameterNotFound = (output: any, context: __SerdeContext): ParameterNotFound => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -23645,7 +23214,7 @@ const deserializeAws_json1_1ParameterPatternMismatchException = (
   context: __SerdeContext
 ): ParameterPatternMismatchException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -23679,7 +23248,7 @@ const deserializeAws_json1_1ParameterValueList = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -23688,7 +23257,7 @@ const deserializeAws_json1_1ParameterVersionLabelLimitExceeded = (
   context: __SerdeContext
 ): ParameterVersionLabelLimitExceeded => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -23697,7 +23266,7 @@ const deserializeAws_json1_1ParameterVersionNotFound = (
   context: __SerdeContext
 ): ParameterVersionNotFound => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -23707,7 +23276,7 @@ const deserializeAws_json1_1Patch = (output: any, context: __SerdeContext): Patc
       output.AdvisoryIds !== undefined && output.AdvisoryIds !== null
         ? deserializeAws_json1_1PatchAdvisoryIdList(output.AdvisoryIds, context)
         : undefined,
-    Arch: output.Arch !== undefined && output.Arch !== null ? output.Arch : undefined,
+    Arch: __expectString(output.Arch),
     BugzillaIds:
       output.BugzillaIds !== undefined && output.BugzillaIds !== null
         ? deserializeAws_json1_1PatchBugzillaIdList(output.BugzillaIds, context)
@@ -23716,30 +23285,28 @@ const deserializeAws_json1_1Patch = (output: any, context: __SerdeContext): Patc
       output.CVEIds !== undefined && output.CVEIds !== null
         ? deserializeAws_json1_1PatchCVEIdList(output.CVEIds, context)
         : undefined,
-    Classification:
-      output.Classification !== undefined && output.Classification !== null ? output.Classification : undefined,
-    ContentUrl: output.ContentUrl !== undefined && output.ContentUrl !== null ? output.ContentUrl : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Epoch: output.Epoch !== undefined && output.Epoch !== null ? output.Epoch : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    KbNumber: output.KbNumber !== undefined && output.KbNumber !== null ? output.KbNumber : undefined,
-    Language: output.Language !== undefined && output.Language !== null ? output.Language : undefined,
-    MsrcNumber: output.MsrcNumber !== undefined && output.MsrcNumber !== null ? output.MsrcNumber : undefined,
-    MsrcSeverity: output.MsrcSeverity !== undefined && output.MsrcSeverity !== null ? output.MsrcSeverity : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Product: output.Product !== undefined && output.Product !== null ? output.Product : undefined,
-    ProductFamily:
-      output.ProductFamily !== undefined && output.ProductFamily !== null ? output.ProductFamily : undefined,
-    Release: output.Release !== undefined && output.Release !== null ? output.Release : undefined,
+    Classification: __expectString(output.Classification),
+    ContentUrl: __expectString(output.ContentUrl),
+    Description: __expectString(output.Description),
+    Epoch: __expectNumber(output.Epoch),
+    Id: __expectString(output.Id),
+    KbNumber: __expectString(output.KbNumber),
+    Language: __expectString(output.Language),
+    MsrcNumber: __expectString(output.MsrcNumber),
+    MsrcSeverity: __expectString(output.MsrcSeverity),
+    Name: __expectString(output.Name),
+    Product: __expectString(output.Product),
+    ProductFamily: __expectString(output.ProductFamily),
+    Release: __expectString(output.Release),
     ReleaseDate:
       output.ReleaseDate !== undefined && output.ReleaseDate !== null
         ? new Date(Math.round(output.ReleaseDate * 1000))
         : undefined,
-    Repository: output.Repository !== undefined && output.Repository !== null ? output.Repository : undefined,
-    Severity: output.Severity !== undefined && output.Severity !== null ? output.Severity : undefined,
-    Title: output.Title !== undefined && output.Title !== null ? output.Title : undefined,
-    Vendor: output.Vendor !== undefined && output.Vendor !== null ? output.Vendor : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    Repository: __expectString(output.Repository),
+    Severity: __expectString(output.Severity),
+    Title: __expectString(output.Title),
+    Vendor: __expectString(output.Vendor),
+    Version: __expectString(output.Version),
   } as any;
 };
 
@@ -23750,22 +23317,17 @@ const deserializeAws_json1_1PatchAdvisoryIdList = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1PatchBaselineIdentity = (output: any, context: __SerdeContext): PatchBaselineIdentity => {
   return {
-    BaselineDescription:
-      output.BaselineDescription !== undefined && output.BaselineDescription !== null
-        ? output.BaselineDescription
-        : undefined,
-    BaselineId: output.BaselineId !== undefined && output.BaselineId !== null ? output.BaselineId : undefined,
-    BaselineName: output.BaselineName !== undefined && output.BaselineName !== null ? output.BaselineName : undefined,
-    DefaultBaseline:
-      output.DefaultBaseline !== undefined && output.DefaultBaseline !== null ? output.DefaultBaseline : undefined,
-    OperatingSystem:
-      output.OperatingSystem !== undefined && output.OperatingSystem !== null ? output.OperatingSystem : undefined,
+    BaselineDescription: __expectString(output.BaselineDescription),
+    BaselineId: __expectString(output.BaselineId),
+    BaselineName: __expectString(output.BaselineName),
+    DefaultBaseline: __expectBoolean(output.DefaultBaseline),
+    OperatingSystem: __expectString(output.OperatingSystem),
   } as any;
 };
 
@@ -23790,23 +23352,22 @@ const deserializeAws_json1_1PatchBugzillaIdList = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1PatchComplianceData = (output: any, context: __SerdeContext): PatchComplianceData => {
   return {
-    CVEIds: output.CVEIds !== undefined && output.CVEIds !== null ? output.CVEIds : undefined,
-    Classification:
-      output.Classification !== undefined && output.Classification !== null ? output.Classification : undefined,
+    CVEIds: __expectString(output.CVEIds),
+    Classification: __expectString(output.Classification),
     InstalledTime:
       output.InstalledTime !== undefined && output.InstalledTime !== null
         ? new Date(Math.round(output.InstalledTime * 1000))
         : undefined,
-    KBId: output.KBId !== undefined && output.KBId !== null ? output.KBId : undefined,
-    Severity: output.Severity !== undefined && output.Severity !== null ? output.Severity : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    Title: output.Title !== undefined && output.Title !== null ? output.Title : undefined,
+    KBId: __expectString(output.KBId),
+    Severity: __expectString(output.Severity),
+    State: __expectString(output.State),
+    Title: __expectString(output.Title),
   } as any;
 };
 
@@ -23828,13 +23389,13 @@ const deserializeAws_json1_1PatchCVEIdList = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1PatchFilter = (output: any, context: __SerdeContext): PatchFilter => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
+    Key: __expectString(output.Key),
     Values:
       output.Values !== undefined && output.Values !== null
         ? deserializeAws_json1_1PatchFilterValueList(output.Values, context)
@@ -23869,7 +23430,7 @@ const deserializeAws_json1_1PatchFilterValueList = (output: any, context: __Serd
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -23880,7 +23441,7 @@ const deserializeAws_json1_1PatchGroupList = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -23893,7 +23454,7 @@ const deserializeAws_json1_1PatchGroupPatchBaselineMapping = (
       output.BaselineIdentity !== undefined && output.BaselineIdentity !== null
         ? deserializeAws_json1_1PatchBaselineIdentity(output.BaselineIdentity, context)
         : undefined,
-    PatchGroup: output.PatchGroup !== undefined && output.PatchGroup !== null ? output.PatchGroup : undefined,
+    PatchGroup: __expectString(output.PatchGroup),
   } as any;
 };
 
@@ -23918,7 +23479,7 @@ const deserializeAws_json1_1PatchIdList = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -23954,23 +23515,17 @@ const deserializeAws_json1_1PatchPropertyEntry = (output: any, context: __SerdeC
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_json1_1PatchRule = (output: any, context: __SerdeContext): PatchRule => {
   return {
-    ApproveAfterDays:
-      output.ApproveAfterDays !== undefined && output.ApproveAfterDays !== null ? output.ApproveAfterDays : undefined,
-    ApproveUntilDate:
-      output.ApproveUntilDate !== undefined && output.ApproveUntilDate !== null ? output.ApproveUntilDate : undefined,
-    ComplianceLevel:
-      output.ComplianceLevel !== undefined && output.ComplianceLevel !== null ? output.ComplianceLevel : undefined,
-    EnableNonSecurity:
-      output.EnableNonSecurity !== undefined && output.EnableNonSecurity !== null
-        ? output.EnableNonSecurity
-        : undefined,
+    ApproveAfterDays: __expectNumber(output.ApproveAfterDays),
+    ApproveUntilDate: __expectString(output.ApproveUntilDate),
+    ComplianceLevel: __expectString(output.ComplianceLevel),
+    EnableNonSecurity: __expectBoolean(output.EnableNonSecurity),
     PatchFilterGroup:
       output.PatchFilterGroup !== undefined && output.PatchFilterGroup !== null
         ? deserializeAws_json1_1PatchFilterGroup(output.PatchFilterGroup, context)
@@ -24000,9 +23555,8 @@ const deserializeAws_json1_1PatchRuleList = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1PatchSource = (output: any, context: __SerdeContext): PatchSource => {
   return {
-    Configuration:
-      output.Configuration !== undefined && output.Configuration !== null ? output.Configuration : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Configuration: __expectString(output.Configuration),
+    Name: __expectString(output.Name),
     Products:
       output.Products !== undefined && output.Products !== null
         ? deserializeAws_json1_1PatchSourceProductList(output.Products, context)
@@ -24028,7 +23582,7 @@ const deserializeAws_json1_1PatchSourceProductList = (output: any, context: __Se
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -24038,10 +23592,8 @@ const deserializeAws_json1_1PatchStatus = (output: any, context: __SerdeContext)
       output.ApprovalDate !== undefined && output.ApprovalDate !== null
         ? new Date(Math.round(output.ApprovalDate * 1000))
         : undefined,
-    ComplianceLevel:
-      output.ComplianceLevel !== undefined && output.ComplianceLevel !== null ? output.ComplianceLevel : undefined,
-    DeploymentStatus:
-      output.DeploymentStatus !== undefined && output.DeploymentStatus !== null ? output.DeploymentStatus : undefined,
+    ComplianceLevel: __expectString(output.ComplianceLevel),
+    DeploymentStatus: __expectString(output.DeploymentStatus),
   } as any;
 };
 
@@ -24052,7 +23604,7 @@ const deserializeAws_json1_1PlatformTypeList = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -24061,19 +23613,17 @@ const deserializeAws_json1_1PoliciesLimitExceededException = (
   context: __SerdeContext
 ): PoliciesLimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1ProgressCounters = (output: any, context: __SerdeContext): ProgressCounters => {
   return {
-    CancelledSteps:
-      output.CancelledSteps !== undefined && output.CancelledSteps !== null ? output.CancelledSteps : undefined,
-    FailedSteps: output.FailedSteps !== undefined && output.FailedSteps !== null ? output.FailedSteps : undefined,
-    SuccessSteps: output.SuccessSteps !== undefined && output.SuccessSteps !== null ? output.SuccessSteps : undefined,
-    TimedOutSteps:
-      output.TimedOutSteps !== undefined && output.TimedOutSteps !== null ? output.TimedOutSteps : undefined,
-    TotalSteps: output.TotalSteps !== undefined && output.TotalSteps !== null ? output.TotalSteps : undefined,
+    CancelledSteps: __expectNumber(output.CancelledSteps),
+    FailedSteps: __expectNumber(output.FailedSteps),
+    SuccessSteps: __expectNumber(output.SuccessSteps),
+    TimedOutSteps: __expectNumber(output.TimedOutSteps),
+    TotalSteps: __expectNumber(output.TotalSteps),
   } as any;
 };
 
@@ -24086,14 +23636,14 @@ const deserializeAws_json1_1PutComplianceItemsResult = (
 
 const deserializeAws_json1_1PutInventoryResult = (output: any, context: __SerdeContext): PutInventoryResult => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1PutParameterResult = (output: any, context: __SerdeContext): PutParameterResult => {
   return {
-    Tier: output.Tier !== undefined && output.Tier !== null ? output.Tier : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    Tier: __expectString(output.Tier),
+    Version: __expectNumber(output.Version),
   } as any;
 };
 
@@ -24104,7 +23654,7 @@ const deserializeAws_json1_1Regions = (output: any, context: __SerdeContext): st
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -24113,7 +23663,7 @@ const deserializeAws_json1_1RegisterDefaultPatchBaselineResult = (
   context: __SerdeContext
 ): RegisterDefaultPatchBaselineResult => {
   return {
-    BaselineId: output.BaselineId !== undefined && output.BaselineId !== null ? output.BaselineId : undefined,
+    BaselineId: __expectString(output.BaselineId),
   } as any;
 };
 
@@ -24122,8 +23672,8 @@ const deserializeAws_json1_1RegisterPatchBaselineForPatchGroupResult = (
   context: __SerdeContext
 ): RegisterPatchBaselineForPatchGroupResult => {
   return {
-    BaselineId: output.BaselineId !== undefined && output.BaselineId !== null ? output.BaselineId : undefined,
-    PatchGroup: output.PatchGroup !== undefined && output.PatchGroup !== null ? output.PatchGroup : undefined,
+    BaselineId: __expectString(output.BaselineId),
+    PatchGroup: __expectString(output.PatchGroup),
   } as any;
 };
 
@@ -24132,8 +23682,7 @@ const deserializeAws_json1_1RegisterTargetWithMaintenanceWindowResult = (
   context: __SerdeContext
 ): RegisterTargetWithMaintenanceWindowResult => {
   return {
-    WindowTargetId:
-      output.WindowTargetId !== undefined && output.WindowTargetId !== null ? output.WindowTargetId : undefined,
+    WindowTargetId: __expectString(output.WindowTargetId),
   } as any;
 };
 
@@ -24142,13 +23691,13 @@ const deserializeAws_json1_1RegisterTaskWithMaintenanceWindowResult = (
   context: __SerdeContext
 ): RegisterTaskWithMaintenanceWindowResult => {
   return {
-    WindowTaskId: output.WindowTaskId !== undefined && output.WindowTaskId !== null ? output.WindowTaskId : undefined,
+    WindowTaskId: __expectString(output.WindowTaskId),
   } as any;
 };
 
 const deserializeAws_json1_1RelatedOpsItem = (output: any, context: __SerdeContext): RelatedOpsItem => {
   return {
-    OpsItemId: output.OpsItemId !== undefined && output.OpsItemId !== null ? output.OpsItemId : undefined,
+    OpsItemId: __expectString(output.OpsItemId),
   } as any;
 };
 
@@ -24188,7 +23737,7 @@ const deserializeAws_json1_1ResolvedTargets = (output: any, context: __SerdeCont
       output.ParameterValues !== undefined && output.ParameterValues !== null
         ? deserializeAws_json1_1TargetParameterList(output.ParameterValues, context)
         : undefined,
-    Truncated: output.Truncated !== undefined && output.Truncated !== null ? output.Truncated : undefined,
+    Truncated: __expectBoolean(output.Truncated),
   } as any;
 };
 
@@ -24197,8 +23746,7 @@ const deserializeAws_json1_1ResourceComplianceSummaryItem = (
   context: __SerdeContext
 ): ResourceComplianceSummaryItem => {
   return {
-    ComplianceType:
-      output.ComplianceType !== undefined && output.ComplianceType !== null ? output.ComplianceType : undefined,
+    ComplianceType: __expectString(output.ComplianceType),
     CompliantSummary:
       output.CompliantSummary !== undefined && output.CompliantSummary !== null
         ? deserializeAws_json1_1CompliantSummary(output.CompliantSummary, context)
@@ -24211,11 +23759,10 @@ const deserializeAws_json1_1ResourceComplianceSummaryItem = (
       output.NonCompliantSummary !== undefined && output.NonCompliantSummary !== null
         ? deserializeAws_json1_1NonCompliantSummary(output.NonCompliantSummary, context)
         : undefined,
-    OverallSeverity:
-      output.OverallSeverity !== undefined && output.OverallSeverity !== null ? output.OverallSeverity : undefined,
-    ResourceId: output.ResourceId !== undefined && output.ResourceId !== null ? output.ResourceId : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    OverallSeverity: __expectString(output.OverallSeverity),
+    ResourceId: __expectString(output.ResourceId),
+    ResourceType: __expectString(output.ResourceType),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -24238,7 +23785,7 @@ const deserializeAws_json1_1ResourceDataSyncAlreadyExistsException = (
   context: __SerdeContext
 ): ResourceDataSyncAlreadyExistsException => {
   return {
-    SyncName: output.SyncName !== undefined && output.SyncName !== null ? output.SyncName : undefined,
+    SyncName: __expectString(output.SyncName),
   } as any;
 };
 
@@ -24247,10 +23794,7 @@ const deserializeAws_json1_1ResourceDataSyncAwsOrganizationsSource = (
   context: __SerdeContext
 ): ResourceDataSyncAwsOrganizationsSource => {
   return {
-    OrganizationSourceType:
-      output.OrganizationSourceType !== undefined && output.OrganizationSourceType !== null
-        ? output.OrganizationSourceType
-        : undefined,
+    OrganizationSourceType: __expectString(output.OrganizationSourceType),
     OrganizationalUnits:
       output.OrganizationalUnits !== undefined && output.OrganizationalUnits !== null
         ? deserializeAws_json1_1ResourceDataSyncOrganizationalUnitList(output.OrganizationalUnits, context)
@@ -24263,7 +23807,7 @@ const deserializeAws_json1_1ResourceDataSyncConflictException = (
   context: __SerdeContext
 ): ResourceDataSyncConflictException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -24272,7 +23816,7 @@ const deserializeAws_json1_1ResourceDataSyncCountExceededException = (
   context: __SerdeContext
 ): ResourceDataSyncCountExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -24281,10 +23825,7 @@ const deserializeAws_json1_1ResourceDataSyncDestinationDataSharing = (
   context: __SerdeContext
 ): ResourceDataSyncDestinationDataSharing => {
   return {
-    DestinationDataSharingType:
-      output.DestinationDataSharingType !== undefined && output.DestinationDataSharingType !== null
-        ? output.DestinationDataSharingType
-        : undefined,
+    DestinationDataSharingType: __expectString(output.DestinationDataSharingType),
   } as any;
 };
 
@@ -24293,21 +23834,18 @@ const deserializeAws_json1_1ResourceDataSyncInvalidConfigurationException = (
   context: __SerdeContext
 ): ResourceDataSyncInvalidConfigurationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1ResourceDataSyncItem = (output: any, context: __SerdeContext): ResourceDataSyncItem => {
   return {
-    LastStatus: output.LastStatus !== undefined && output.LastStatus !== null ? output.LastStatus : undefined,
+    LastStatus: __expectString(output.LastStatus),
     LastSuccessfulSyncTime:
       output.LastSuccessfulSyncTime !== undefined && output.LastSuccessfulSyncTime !== null
         ? new Date(Math.round(output.LastSuccessfulSyncTime * 1000))
         : undefined,
-    LastSyncStatusMessage:
-      output.LastSyncStatusMessage !== undefined && output.LastSyncStatusMessage !== null
-        ? output.LastSyncStatusMessage
-        : undefined,
+    LastSyncStatusMessage: __expectString(output.LastSyncStatusMessage),
     LastSyncTime:
       output.LastSyncTime !== undefined && output.LastSyncTime !== null
         ? new Date(Math.round(output.LastSyncTime * 1000))
@@ -24324,12 +23862,12 @@ const deserializeAws_json1_1ResourceDataSyncItem = (output: any, context: __Serd
       output.SyncLastModifiedTime !== undefined && output.SyncLastModifiedTime !== null
         ? new Date(Math.round(output.SyncLastModifiedTime * 1000))
         : undefined,
-    SyncName: output.SyncName !== undefined && output.SyncName !== null ? output.SyncName : undefined,
+    SyncName: __expectString(output.SyncName),
     SyncSource:
       output.SyncSource !== undefined && output.SyncSource !== null
         ? deserializeAws_json1_1ResourceDataSyncSourceWithState(output.SyncSource, context)
         : undefined,
-    SyncType: output.SyncType !== undefined && output.SyncType !== null ? output.SyncType : undefined,
+    SyncType: __expectString(output.SyncType),
   } as any;
 };
 
@@ -24352,9 +23890,9 @@ const deserializeAws_json1_1ResourceDataSyncNotFoundException = (
   context: __SerdeContext
 ): ResourceDataSyncNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    SyncName: output.SyncName !== undefined && output.SyncName !== null ? output.SyncName : undefined,
-    SyncType: output.SyncType !== undefined && output.SyncType !== null ? output.SyncType : undefined,
+    Message: __expectString(output.Message),
+    SyncName: __expectString(output.SyncName),
+    SyncType: __expectString(output.SyncType),
   } as any;
 };
 
@@ -24363,10 +23901,7 @@ const deserializeAws_json1_1ResourceDataSyncOrganizationalUnit = (
   context: __SerdeContext
 ): ResourceDataSyncOrganizationalUnit => {
   return {
-    OrganizationalUnitId:
-      output.OrganizationalUnitId !== undefined && output.OrganizationalUnitId !== null
-        ? output.OrganizationalUnitId
-        : undefined,
+    OrganizationalUnitId: __expectString(output.OrganizationalUnitId),
   } as any;
 };
 
@@ -24389,15 +23924,15 @@ const deserializeAws_json1_1ResourceDataSyncS3Destination = (
   context: __SerdeContext
 ): ResourceDataSyncS3Destination => {
   return {
-    AWSKMSKeyARN: output.AWSKMSKeyARN !== undefined && output.AWSKMSKeyARN !== null ? output.AWSKMSKeyARN : undefined,
-    BucketName: output.BucketName !== undefined && output.BucketName !== null ? output.BucketName : undefined,
+    AWSKMSKeyARN: __expectString(output.AWSKMSKeyARN),
+    BucketName: __expectString(output.BucketName),
     DestinationDataSharing:
       output.DestinationDataSharing !== undefined && output.DestinationDataSharing !== null
         ? deserializeAws_json1_1ResourceDataSyncDestinationDataSharing(output.DestinationDataSharing, context)
         : undefined,
-    Prefix: output.Prefix !== undefined && output.Prefix !== null ? output.Prefix : undefined,
-    Region: output.Region !== undefined && output.Region !== null ? output.Region : undefined,
-    SyncFormat: output.SyncFormat !== undefined && output.SyncFormat !== null ? output.SyncFormat : undefined,
+    Prefix: __expectString(output.Prefix),
+    Region: __expectString(output.Region),
+    SyncFormat: __expectString(output.SyncFormat),
   } as any;
 };
 
@@ -24408,7 +23943,7 @@ const deserializeAws_json1_1ResourceDataSyncSourceRegionList = (output: any, con
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -24421,26 +23956,20 @@ const deserializeAws_json1_1ResourceDataSyncSourceWithState = (
       output.AwsOrganizationsSource !== undefined && output.AwsOrganizationsSource !== null
         ? deserializeAws_json1_1ResourceDataSyncAwsOrganizationsSource(output.AwsOrganizationsSource, context)
         : undefined,
-    EnableAllOpsDataSources:
-      output.EnableAllOpsDataSources !== undefined && output.EnableAllOpsDataSources !== null
-        ? output.EnableAllOpsDataSources
-        : undefined,
-    IncludeFutureRegions:
-      output.IncludeFutureRegions !== undefined && output.IncludeFutureRegions !== null
-        ? output.IncludeFutureRegions
-        : undefined,
+    EnableAllOpsDataSources: __expectBoolean(output.EnableAllOpsDataSources),
+    IncludeFutureRegions: __expectBoolean(output.IncludeFutureRegions),
     SourceRegions:
       output.SourceRegions !== undefined && output.SourceRegions !== null
         ? deserializeAws_json1_1ResourceDataSyncSourceRegionList(output.SourceRegions, context)
         : undefined,
-    SourceType: output.SourceType !== undefined && output.SourceType !== null ? output.SourceType : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    SourceType: __expectString(output.SourceType),
+    State: __expectString(output.State),
   } as any;
 };
 
 const deserializeAws_json1_1ResourceInUseException = (output: any, context: __SerdeContext): ResourceInUseException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -24449,15 +23978,15 @@ const deserializeAws_json1_1ResourceLimitExceededException = (
   context: __SerdeContext
 ): ResourceLimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1ResumeSessionResponse = (output: any, context: __SerdeContext): ResumeSessionResponse => {
   return {
-    SessionId: output.SessionId !== undefined && output.SessionId !== null ? output.SessionId : undefined,
-    StreamUrl: output.StreamUrl !== undefined && output.StreamUrl !== null ? output.StreamUrl : undefined,
-    TokenValue: output.TokenValue !== undefined && output.TokenValue !== null ? output.TokenValue : undefined,
+    SessionId: __expectString(output.SessionId),
+    StreamUrl: __expectString(output.StreamUrl),
+    TokenValue: __expectString(output.TokenValue),
   } as any;
 };
 
@@ -24467,8 +23996,8 @@ const deserializeAws_json1_1ReviewInformation = (output: any, context: __SerdeCo
       output.ReviewedTime !== undefined && output.ReviewedTime !== null
         ? new Date(Math.round(output.ReviewedTime * 1000))
         : undefined,
-    Reviewer: output.Reviewer !== undefined && output.Reviewer !== null ? output.Reviewer : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Reviewer: __expectString(output.Reviewer),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -24485,12 +24014,10 @@ const deserializeAws_json1_1ReviewInformationList = (output: any, context: __Ser
 
 const deserializeAws_json1_1Runbook = (output: any, context: __SerdeContext): Runbook => {
   return {
-    DocumentName: output.DocumentName !== undefined && output.DocumentName !== null ? output.DocumentName : undefined,
-    DocumentVersion:
-      output.DocumentVersion !== undefined && output.DocumentVersion !== null ? output.DocumentVersion : undefined,
-    MaxConcurrency:
-      output.MaxConcurrency !== undefined && output.MaxConcurrency !== null ? output.MaxConcurrency : undefined,
-    MaxErrors: output.MaxErrors !== undefined && output.MaxErrors !== null ? output.MaxErrors : undefined,
+    DocumentName: __expectString(output.DocumentName),
+    DocumentVersion: __expectString(output.DocumentVersion),
+    MaxConcurrency: __expectString(output.MaxConcurrency),
+    MaxErrors: __expectString(output.MaxErrors),
     Parameters:
       output.Parameters !== undefined && output.Parameters !== null
         ? deserializeAws_json1_1AutomationParameterMap(output.Parameters, context)
@@ -24499,10 +24026,7 @@ const deserializeAws_json1_1Runbook = (output: any, context: __SerdeContext): Ru
       output.TargetLocations !== undefined && output.TargetLocations !== null
         ? deserializeAws_json1_1TargetLocations(output.TargetLocations, context)
         : undefined,
-    TargetParameterName:
-      output.TargetParameterName !== undefined && output.TargetParameterName !== null
-        ? output.TargetParameterName
-        : undefined,
+    TargetParameterName: __expectString(output.TargetParameterName),
     Targets:
       output.Targets !== undefined && output.Targets !== null
         ? deserializeAws_json1_1Targets(output.Targets, context)
@@ -24523,22 +24047,15 @@ const deserializeAws_json1_1Runbooks = (output: any, context: __SerdeContext): R
 
 const deserializeAws_json1_1S3OutputLocation = (output: any, context: __SerdeContext): S3OutputLocation => {
   return {
-    OutputS3BucketName:
-      output.OutputS3BucketName !== undefined && output.OutputS3BucketName !== null
-        ? output.OutputS3BucketName
-        : undefined,
-    OutputS3KeyPrefix:
-      output.OutputS3KeyPrefix !== undefined && output.OutputS3KeyPrefix !== null
-        ? output.OutputS3KeyPrefix
-        : undefined,
-    OutputS3Region:
-      output.OutputS3Region !== undefined && output.OutputS3Region !== null ? output.OutputS3Region : undefined,
+    OutputS3BucketName: __expectString(output.OutputS3BucketName),
+    OutputS3KeyPrefix: __expectString(output.OutputS3KeyPrefix),
+    OutputS3Region: __expectString(output.OutputS3Region),
   } as any;
 };
 
 const deserializeAws_json1_1S3OutputUrl = (output: any, context: __SerdeContext): S3OutputUrl => {
   return {
-    OutputUrl: output.OutputUrl !== undefined && output.OutputUrl !== null ? output.OutputUrl : undefined,
+    OutputUrl: __expectString(output.OutputUrl),
   } as any;
 };
 
@@ -24547,10 +24064,9 @@ const deserializeAws_json1_1ScheduledWindowExecution = (
   context: __SerdeContext
 ): ScheduledWindowExecution => {
   return {
-    ExecutionTime:
-      output.ExecutionTime !== undefined && output.ExecutionTime !== null ? output.ExecutionTime : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    WindowId: output.WindowId !== undefined && output.WindowId !== null ? output.WindowId : undefined,
+    ExecutionTime: __expectString(output.ExecutionTime),
+    Name: __expectString(output.Name),
+    WindowId: __expectString(output.WindowId),
   } as any;
 };
 
@@ -24586,43 +24102,42 @@ const deserializeAws_json1_1SendCommandResult = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1ServiceSetting = (output: any, context: __SerdeContext): ServiceSetting => {
   return {
-    ARN: output.ARN !== undefined && output.ARN !== null ? output.ARN : undefined,
+    ARN: __expectString(output.ARN),
     LastModifiedDate:
       output.LastModifiedDate !== undefined && output.LastModifiedDate !== null
         ? new Date(Math.round(output.LastModifiedDate * 1000))
         : undefined,
-    LastModifiedUser:
-      output.LastModifiedUser !== undefined && output.LastModifiedUser !== null ? output.LastModifiedUser : undefined,
-    SettingId: output.SettingId !== undefined && output.SettingId !== null ? output.SettingId : undefined,
-    SettingValue: output.SettingValue !== undefined && output.SettingValue !== null ? output.SettingValue : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    LastModifiedUser: __expectString(output.LastModifiedUser),
+    SettingId: __expectString(output.SettingId),
+    SettingValue: __expectString(output.SettingValue),
+    Status: __expectString(output.Status),
   } as any;
 };
 
 const deserializeAws_json1_1ServiceSettingNotFound = (output: any, context: __SerdeContext): ServiceSettingNotFound => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1Session = (output: any, context: __SerdeContext): Session => {
   return {
-    Details: output.Details !== undefined && output.Details !== null ? output.Details : undefined,
-    DocumentName: output.DocumentName !== undefined && output.DocumentName !== null ? output.DocumentName : undefined,
+    Details: __expectString(output.Details),
+    DocumentName: __expectString(output.DocumentName),
     EndDate:
       output.EndDate !== undefined && output.EndDate !== null ? new Date(Math.round(output.EndDate * 1000)) : undefined,
     OutputUrl:
       output.OutputUrl !== undefined && output.OutputUrl !== null
         ? deserializeAws_json1_1SessionManagerOutputUrl(output.OutputUrl, context)
         : undefined,
-    Owner: output.Owner !== undefined && output.Owner !== null ? output.Owner : undefined,
-    SessionId: output.SessionId !== undefined && output.SessionId !== null ? output.SessionId : undefined,
+    Owner: __expectString(output.Owner),
+    SessionId: __expectString(output.SessionId),
     StartDate:
       output.StartDate !== undefined && output.StartDate !== null
         ? new Date(Math.round(output.StartDate * 1000))
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    Target: output.Target !== undefined && output.Target !== null ? output.Target : undefined,
+    Status: __expectString(output.Status),
+    Target: __expectString(output.Target),
   } as any;
 };
 
@@ -24642,27 +24157,19 @@ const deserializeAws_json1_1SessionManagerOutputUrl = (
   context: __SerdeContext
 ): SessionManagerOutputUrl => {
   return {
-    CloudWatchOutputUrl:
-      output.CloudWatchOutputUrl !== undefined && output.CloudWatchOutputUrl !== null
-        ? output.CloudWatchOutputUrl
-        : undefined,
-    S3OutputUrl: output.S3OutputUrl !== undefined && output.S3OutputUrl !== null ? output.S3OutputUrl : undefined,
+    CloudWatchOutputUrl: __expectString(output.CloudWatchOutputUrl),
+    S3OutputUrl: __expectString(output.S3OutputUrl),
   } as any;
 };
 
 const deserializeAws_json1_1SeveritySummary = (output: any, context: __SerdeContext): SeveritySummary => {
   return {
-    CriticalCount:
-      output.CriticalCount !== undefined && output.CriticalCount !== null ? output.CriticalCount : undefined,
-    HighCount: output.HighCount !== undefined && output.HighCount !== null ? output.HighCount : undefined,
-    InformationalCount:
-      output.InformationalCount !== undefined && output.InformationalCount !== null
-        ? output.InformationalCount
-        : undefined,
-    LowCount: output.LowCount !== undefined && output.LowCount !== null ? output.LowCount : undefined,
-    MediumCount: output.MediumCount !== undefined && output.MediumCount !== null ? output.MediumCount : undefined,
-    UnspecifiedCount:
-      output.UnspecifiedCount !== undefined && output.UnspecifiedCount !== null ? output.UnspecifiedCount : undefined,
+    CriticalCount: __expectNumber(output.CriticalCount),
+    HighCount: __expectNumber(output.HighCount),
+    InformationalCount: __expectNumber(output.InformationalCount),
+    LowCount: __expectNumber(output.LowCount),
+    MediumCount: __expectNumber(output.MediumCount),
+    UnspecifiedCount: __expectNumber(output.UnspecifiedCount),
   } as any;
 };
 
@@ -24678,10 +24185,7 @@ const deserializeAws_json1_1StartAutomationExecutionResult = (
   context: __SerdeContext
 ): StartAutomationExecutionResult => {
   return {
-    AutomationExecutionId:
-      output.AutomationExecutionId !== undefined && output.AutomationExecutionId !== null
-        ? output.AutomationExecutionId
-        : undefined,
+    AutomationExecutionId: __expectString(output.AutomationExecutionId),
   } as any;
 };
 
@@ -24690,18 +24194,15 @@ const deserializeAws_json1_1StartChangeRequestExecutionResult = (
   context: __SerdeContext
 ): StartChangeRequestExecutionResult => {
   return {
-    AutomationExecutionId:
-      output.AutomationExecutionId !== undefined && output.AutomationExecutionId !== null
-        ? output.AutomationExecutionId
-        : undefined,
+    AutomationExecutionId: __expectString(output.AutomationExecutionId),
   } as any;
 };
 
 const deserializeAws_json1_1StartSessionResponse = (output: any, context: __SerdeContext): StartSessionResponse => {
   return {
-    SessionId: output.SessionId !== undefined && output.SessionId !== null ? output.SessionId : undefined,
-    StreamUrl: output.StreamUrl !== undefined && output.StreamUrl !== null ? output.StreamUrl : undefined,
-    TokenValue: output.TokenValue !== undefined && output.TokenValue !== null ? output.TokenValue : undefined,
+    SessionId: __expectString(output.SessionId),
+    StreamUrl: __expectString(output.StreamUrl),
+    TokenValue: __expectString(output.TokenValue),
   } as any;
 };
 
@@ -24711,7 +24212,7 @@ const deserializeAws_json1_1StatusUnchanged = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_1StepExecution = (output: any, context: __SerdeContext): StepExecution => {
   return {
-    Action: output.Action !== undefined && output.Action !== null ? output.Action : undefined,
+    Action: __expectString(output.Action),
     ExecutionEndTime:
       output.ExecutionEndTime !== undefined && output.ExecutionEndTime !== null
         ? new Date(Math.round(output.ExecutionEndTime * 1000))
@@ -24724,17 +24225,16 @@ const deserializeAws_json1_1StepExecution = (output: any, context: __SerdeContex
       output.FailureDetails !== undefined && output.FailureDetails !== null
         ? deserializeAws_json1_1FailureDetails(output.FailureDetails, context)
         : undefined,
-    FailureMessage:
-      output.FailureMessage !== undefined && output.FailureMessage !== null ? output.FailureMessage : undefined,
+    FailureMessage: __expectString(output.FailureMessage),
     Inputs:
       output.Inputs !== undefined && output.Inputs !== null
         ? deserializeAws_json1_1NormalStringMap(output.Inputs, context)
         : undefined,
-    IsCritical: output.IsCritical !== undefined && output.IsCritical !== null ? output.IsCritical : undefined,
-    IsEnd: output.IsEnd !== undefined && output.IsEnd !== null ? output.IsEnd : undefined,
-    MaxAttempts: output.MaxAttempts !== undefined && output.MaxAttempts !== null ? output.MaxAttempts : undefined,
-    NextStep: output.NextStep !== undefined && output.NextStep !== null ? output.NextStep : undefined,
-    OnFailure: output.OnFailure !== undefined && output.OnFailure !== null ? output.OnFailure : undefined,
+    IsCritical: __expectBoolean(output.IsCritical),
+    IsEnd: __expectBoolean(output.IsEnd),
+    MaxAttempts: __expectNumber(output.MaxAttempts),
+    NextStep: __expectString(output.NextStep),
+    OnFailure: __expectString(output.OnFailure),
     Outputs:
       output.Outputs !== undefined && output.Outputs !== null
         ? deserializeAws_json1_1AutomationParameterMap(output.Outputs, context)
@@ -24743,12 +24243,11 @@ const deserializeAws_json1_1StepExecution = (output: any, context: __SerdeContex
       output.OverriddenParameters !== undefined && output.OverriddenParameters !== null
         ? deserializeAws_json1_1AutomationParameterMap(output.OverriddenParameters, context)
         : undefined,
-    Response: output.Response !== undefined && output.Response !== null ? output.Response : undefined,
-    ResponseCode: output.ResponseCode !== undefined && output.ResponseCode !== null ? output.ResponseCode : undefined,
-    StepExecutionId:
-      output.StepExecutionId !== undefined && output.StepExecutionId !== null ? output.StepExecutionId : undefined,
-    StepName: output.StepName !== undefined && output.StepName !== null ? output.StepName : undefined,
-    StepStatus: output.StepStatus !== undefined && output.StepStatus !== null ? output.StepStatus : undefined,
+    Response: __expectString(output.Response),
+    ResponseCode: __expectString(output.ResponseCode),
+    StepExecutionId: __expectString(output.StepExecutionId),
+    StepName: __expectString(output.StepName),
+    StepStatus: __expectString(output.StepStatus),
     TargetLocation:
       output.TargetLocation !== undefined && output.TargetLocation !== null
         ? deserializeAws_json1_1TargetLocation(output.TargetLocation, context)
@@ -24757,8 +24256,7 @@ const deserializeAws_json1_1StepExecution = (output: any, context: __SerdeContex
       output.Targets !== undefined && output.Targets !== null
         ? deserializeAws_json1_1Targets(output.Targets, context)
         : undefined,
-    TimeoutSeconds:
-      output.TimeoutSeconds !== undefined && output.TimeoutSeconds !== null ? output.TimeoutSeconds : undefined,
+    TimeoutSeconds: __expectNumber(output.TimeoutSeconds),
     ValidNextSteps:
       output.ValidNextSteps !== undefined && output.ValidNextSteps !== null
         ? deserializeAws_json1_1ValidNextStepList(output.ValidNextSteps, context)
@@ -24789,14 +24287,14 @@ const deserializeAws_json1_1SubTypeCountLimitExceededException = (
   context: __SerdeContext
 ): SubTypeCountLimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -24813,7 +24311,7 @@ const deserializeAws_json1_1TagList = (output: any, context: __SerdeContext): Ta
 
 const deserializeAws_json1_1Target = (output: any, context: __SerdeContext): Target => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
+    Key: __expectString(output.Key),
     Values:
       output.Values !== undefined && output.Values !== null
         ? deserializeAws_json1_1TargetValues(output.Values, context)
@@ -24823,7 +24321,7 @@ const deserializeAws_json1_1Target = (output: any, context: __SerdeContext): Tar
 
 const deserializeAws_json1_1TargetInUseException = (output: any, context: __SerdeContext): TargetInUseException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -24833,22 +24331,13 @@ const deserializeAws_json1_1TargetLocation = (output: any, context: __SerdeConte
       output.Accounts !== undefined && output.Accounts !== null
         ? deserializeAws_json1_1Accounts(output.Accounts, context)
         : undefined,
-    ExecutionRoleName:
-      output.ExecutionRoleName !== undefined && output.ExecutionRoleName !== null
-        ? output.ExecutionRoleName
-        : undefined,
+    ExecutionRoleName: __expectString(output.ExecutionRoleName),
     Regions:
       output.Regions !== undefined && output.Regions !== null
         ? deserializeAws_json1_1Regions(output.Regions, context)
         : undefined,
-    TargetLocationMaxConcurrency:
-      output.TargetLocationMaxConcurrency !== undefined && output.TargetLocationMaxConcurrency !== null
-        ? output.TargetLocationMaxConcurrency
-        : undefined,
-    TargetLocationMaxErrors:
-      output.TargetLocationMaxErrors !== undefined && output.TargetLocationMaxErrors !== null
-        ? output.TargetLocationMaxErrors
-        : undefined,
+    TargetLocationMaxConcurrency: __expectString(output.TargetLocationMaxConcurrency),
+    TargetLocationMaxErrors: __expectString(output.TargetLocationMaxErrors),
   } as any;
 };
 
@@ -24893,13 +24382,13 @@ const deserializeAws_json1_1TargetMapValueList = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1TargetNotConnected = (output: any, context: __SerdeContext): TargetNotConnected => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -24910,7 +24399,7 @@ const deserializeAws_json1_1TargetParameterList = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -24932,7 +24421,7 @@ const deserializeAws_json1_1TargetValues = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -24941,7 +24430,7 @@ const deserializeAws_json1_1TerminateSessionResponse = (
   context: __SerdeContext
 ): TerminateSessionResponse => {
   return {
-    SessionId: output.SessionId !== undefined && output.SessionId !== null ? output.SessionId : undefined,
+    SessionId: __expectString(output.SessionId),
   } as any;
 };
 
@@ -24951,7 +24440,7 @@ const deserializeAws_json1_1TooManyTagsError = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1TooManyUpdates = (output: any, context: __SerdeContext): TooManyUpdates => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -24960,7 +24449,7 @@ const deserializeAws_json1_1TotalSizeLimitExceededException = (
   context: __SerdeContext
 ): TotalSizeLimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -24985,7 +24474,7 @@ const deserializeAws_json1_1UnsupportedCalendarException = (
   context: __SerdeContext
 ): UnsupportedCalendarException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -24994,7 +24483,7 @@ const deserializeAws_json1_1UnsupportedFeatureRequiredException = (
   context: __SerdeContext
 ): UnsupportedFeatureRequiredException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -25003,8 +24492,8 @@ const deserializeAws_json1_1UnsupportedInventoryItemContextException = (
   context: __SerdeContext
 ): UnsupportedInventoryItemContextException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    TypeName: output.TypeName !== undefined && output.TypeName !== null ? output.TypeName : undefined,
+    Message: __expectString(output.Message),
+    TypeName: __expectString(output.TypeName),
   } as any;
 };
 
@@ -25013,7 +24502,7 @@ const deserializeAws_json1_1UnsupportedInventorySchemaVersionException = (
   context: __SerdeContext
 ): UnsupportedInventorySchemaVersionException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -25022,7 +24511,7 @@ const deserializeAws_json1_1UnsupportedOperatingSystem = (
   context: __SerdeContext
 ): UnsupportedOperatingSystem => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -25031,7 +24520,7 @@ const deserializeAws_json1_1UnsupportedParameterType = (
   context: __SerdeContext
 ): UnsupportedParameterType => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -25040,7 +24529,7 @@ const deserializeAws_json1_1UnsupportedPlatformType = (
   context: __SerdeContext
 ): UnsupportedPlatformType => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -25101,23 +24590,18 @@ const deserializeAws_json1_1UpdateMaintenanceWindowResult = (
   context: __SerdeContext
 ): UpdateMaintenanceWindowResult => {
   return {
-    AllowUnassociatedTargets:
-      output.AllowUnassociatedTargets !== undefined && output.AllowUnassociatedTargets !== null
-        ? output.AllowUnassociatedTargets
-        : undefined,
-    Cutoff: output.Cutoff !== undefined && output.Cutoff !== null ? output.Cutoff : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Duration: output.Duration !== undefined && output.Duration !== null ? output.Duration : undefined,
-    Enabled: output.Enabled !== undefined && output.Enabled !== null ? output.Enabled : undefined,
-    EndDate: output.EndDate !== undefined && output.EndDate !== null ? output.EndDate : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Schedule: output.Schedule !== undefined && output.Schedule !== null ? output.Schedule : undefined,
-    ScheduleOffset:
-      output.ScheduleOffset !== undefined && output.ScheduleOffset !== null ? output.ScheduleOffset : undefined,
-    ScheduleTimezone:
-      output.ScheduleTimezone !== undefined && output.ScheduleTimezone !== null ? output.ScheduleTimezone : undefined,
-    StartDate: output.StartDate !== undefined && output.StartDate !== null ? output.StartDate : undefined,
-    WindowId: output.WindowId !== undefined && output.WindowId !== null ? output.WindowId : undefined,
+    AllowUnassociatedTargets: __expectBoolean(output.AllowUnassociatedTargets),
+    Cutoff: __expectNumber(output.Cutoff),
+    Description: __expectString(output.Description),
+    Duration: __expectNumber(output.Duration),
+    Enabled: __expectBoolean(output.Enabled),
+    EndDate: __expectString(output.EndDate),
+    Name: __expectString(output.Name),
+    Schedule: __expectString(output.Schedule),
+    ScheduleOffset: __expectNumber(output.ScheduleOffset),
+    ScheduleTimezone: __expectString(output.ScheduleTimezone),
+    StartDate: __expectString(output.StartDate),
+    WindowId: __expectString(output.WindowId),
   } as any;
 };
 
@@ -25126,17 +24610,15 @@ const deserializeAws_json1_1UpdateMaintenanceWindowTargetResult = (
   context: __SerdeContext
 ): UpdateMaintenanceWindowTargetResult => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    OwnerInformation:
-      output.OwnerInformation !== undefined && output.OwnerInformation !== null ? output.OwnerInformation : undefined,
+    Description: __expectString(output.Description),
+    Name: __expectString(output.Name),
+    OwnerInformation: __expectString(output.OwnerInformation),
     Targets:
       output.Targets !== undefined && output.Targets !== null
         ? deserializeAws_json1_1Targets(output.Targets, context)
         : undefined,
-    WindowId: output.WindowId !== undefined && output.WindowId !== null ? output.WindowId : undefined,
-    WindowTargetId:
-      output.WindowTargetId !== undefined && output.WindowTargetId !== null ? output.WindowTargetId : undefined,
+    WindowId: __expectString(output.WindowId),
+    WindowTargetId: __expectString(output.WindowTargetId),
   } as any;
 };
 
@@ -25145,23 +24627,21 @@ const deserializeAws_json1_1UpdateMaintenanceWindowTaskResult = (
   context: __SerdeContext
 ): UpdateMaintenanceWindowTaskResult => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     LoggingInfo:
       output.LoggingInfo !== undefined && output.LoggingInfo !== null
         ? deserializeAws_json1_1LoggingInfo(output.LoggingInfo, context)
         : undefined,
-    MaxConcurrency:
-      output.MaxConcurrency !== undefined && output.MaxConcurrency !== null ? output.MaxConcurrency : undefined,
-    MaxErrors: output.MaxErrors !== undefined && output.MaxErrors !== null ? output.MaxErrors : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Priority: output.Priority !== undefined && output.Priority !== null ? output.Priority : undefined,
-    ServiceRoleArn:
-      output.ServiceRoleArn !== undefined && output.ServiceRoleArn !== null ? output.ServiceRoleArn : undefined,
+    MaxConcurrency: __expectString(output.MaxConcurrency),
+    MaxErrors: __expectString(output.MaxErrors),
+    Name: __expectString(output.Name),
+    Priority: __expectNumber(output.Priority),
+    ServiceRoleArn: __expectString(output.ServiceRoleArn),
     Targets:
       output.Targets !== undefined && output.Targets !== null
         ? deserializeAws_json1_1Targets(output.Targets, context)
         : undefined,
-    TaskArn: output.TaskArn !== undefined && output.TaskArn !== null ? output.TaskArn : undefined,
+    TaskArn: __expectString(output.TaskArn),
     TaskInvocationParameters:
       output.TaskInvocationParameters !== undefined && output.TaskInvocationParameters !== null
         ? deserializeAws_json1_1MaintenanceWindowTaskInvocationParameters(output.TaskInvocationParameters, context)
@@ -25170,8 +24650,8 @@ const deserializeAws_json1_1UpdateMaintenanceWindowTaskResult = (
       output.TaskParameters !== undefined && output.TaskParameters !== null
         ? deserializeAws_json1_1MaintenanceWindowTaskParameters(output.TaskParameters, context)
         : undefined,
-    WindowId: output.WindowId !== undefined && output.WindowId !== null ? output.WindowId : undefined,
-    WindowTaskId: output.WindowTaskId !== undefined && output.WindowTaskId !== null ? output.WindowTaskId : undefined,
+    WindowId: __expectString(output.WindowId),
+    WindowTaskId: __expectString(output.WindowTaskId),
   } as any;
 };
 
@@ -25191,8 +24671,7 @@ const deserializeAws_json1_1UpdateOpsMetadataResult = (
   context: __SerdeContext
 ): UpdateOpsMetadataResult => {
   return {
-    OpsMetadataArn:
-      output.OpsMetadataArn !== undefined && output.OpsMetadataArn !== null ? output.OpsMetadataArn : undefined,
+    OpsMetadataArn: __expectString(output.OpsMetadataArn),
   } as any;
 };
 
@@ -25209,20 +24688,14 @@ const deserializeAws_json1_1UpdatePatchBaselineResult = (
       output.ApprovedPatches !== undefined && output.ApprovedPatches !== null
         ? deserializeAws_json1_1PatchIdList(output.ApprovedPatches, context)
         : undefined,
-    ApprovedPatchesComplianceLevel:
-      output.ApprovedPatchesComplianceLevel !== undefined && output.ApprovedPatchesComplianceLevel !== null
-        ? output.ApprovedPatchesComplianceLevel
-        : undefined,
-    ApprovedPatchesEnableNonSecurity:
-      output.ApprovedPatchesEnableNonSecurity !== undefined && output.ApprovedPatchesEnableNonSecurity !== null
-        ? output.ApprovedPatchesEnableNonSecurity
-        : undefined,
-    BaselineId: output.BaselineId !== undefined && output.BaselineId !== null ? output.BaselineId : undefined,
+    ApprovedPatchesComplianceLevel: __expectString(output.ApprovedPatchesComplianceLevel),
+    ApprovedPatchesEnableNonSecurity: __expectBoolean(output.ApprovedPatchesEnableNonSecurity),
+    BaselineId: __expectString(output.BaselineId),
     CreatedDate:
       output.CreatedDate !== undefined && output.CreatedDate !== null
         ? new Date(Math.round(output.CreatedDate * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     GlobalFilters:
       output.GlobalFilters !== undefined && output.GlobalFilters !== null
         ? deserializeAws_json1_1PatchFilterGroup(output.GlobalFilters, context)
@@ -25231,17 +24704,13 @@ const deserializeAws_json1_1UpdatePatchBaselineResult = (
       output.ModifiedDate !== undefined && output.ModifiedDate !== null
         ? new Date(Math.round(output.ModifiedDate * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    OperatingSystem:
-      output.OperatingSystem !== undefined && output.OperatingSystem !== null ? output.OperatingSystem : undefined,
+    Name: __expectString(output.Name),
+    OperatingSystem: __expectString(output.OperatingSystem),
     RejectedPatches:
       output.RejectedPatches !== undefined && output.RejectedPatches !== null
         ? deserializeAws_json1_1PatchIdList(output.RejectedPatches, context)
         : undefined,
-    RejectedPatchesAction:
-      output.RejectedPatchesAction !== undefined && output.RejectedPatchesAction !== null
-        ? output.RejectedPatchesAction
-        : undefined,
+    RejectedPatchesAction: __expectString(output.RejectedPatchesAction),
     Sources:
       output.Sources !== undefined && output.Sources !== null
         ? deserializeAws_json1_1PatchSourceList(output.Sources, context)
@@ -25270,7 +24739,7 @@ const deserializeAws_json1_1ValidNextStepList = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 

--- a/clients/client-sso-admin/protocols/Aws_json1_1.ts
+++ b/clients/client-sso-admin/protocols/Aws_json1_1.ts
@@ -195,7 +195,7 @@ import {
   ValidationException,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException, expectString as __expectString } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -4009,7 +4009,7 @@ const serializeAws_json1_1UpdatePermissionSetRequest = (
 
 const deserializeAws_json1_1AccessControlAttribute = (output: any, context: __SerdeContext): AccessControlAttribute => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
+    Key: __expectString(output.Key),
     Value:
       output.Value !== undefined && output.Value !== null
         ? deserializeAws_json1_1AccessControlAttributeValue(output.Value, context)
@@ -4053,24 +4053,22 @@ const deserializeAws_json1_1AccessControlAttributeValueSourceList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1AccessDeniedException = (output: any, context: __SerdeContext): AccessDeniedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1AccountAssignment = (output: any, context: __SerdeContext): AccountAssignment => {
   return {
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
-    PermissionSetArn:
-      output.PermissionSetArn !== undefined && output.PermissionSetArn !== null ? output.PermissionSetArn : undefined,
-    PrincipalId: output.PrincipalId !== undefined && output.PrincipalId !== null ? output.PrincipalId : undefined,
-    PrincipalType:
-      output.PrincipalType !== undefined && output.PrincipalType !== null ? output.PrincipalType : undefined,
+    AccountId: __expectString(output.AccountId),
+    PermissionSetArn: __expectString(output.PermissionSetArn),
+    PrincipalId: __expectString(output.PrincipalId),
+    PrincipalType: __expectString(output.PrincipalType),
   } as any;
 };
 
@@ -4094,17 +4092,14 @@ const deserializeAws_json1_1AccountAssignmentOperationStatus = (
       output.CreatedDate !== undefined && output.CreatedDate !== null
         ? new Date(Math.round(output.CreatedDate * 1000))
         : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
-    PermissionSetArn:
-      output.PermissionSetArn !== undefined && output.PermissionSetArn !== null ? output.PermissionSetArn : undefined,
-    PrincipalId: output.PrincipalId !== undefined && output.PrincipalId !== null ? output.PrincipalId : undefined,
-    PrincipalType:
-      output.PrincipalType !== undefined && output.PrincipalType !== null ? output.PrincipalType : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    TargetId: output.TargetId !== undefined && output.TargetId !== null ? output.TargetId : undefined,
-    TargetType: output.TargetType !== undefined && output.TargetType !== null ? output.TargetType : undefined,
+    FailureReason: __expectString(output.FailureReason),
+    PermissionSetArn: __expectString(output.PermissionSetArn),
+    PrincipalId: __expectString(output.PrincipalId),
+    PrincipalType: __expectString(output.PrincipalType),
+    RequestId: __expectString(output.RequestId),
+    Status: __expectString(output.Status),
+    TargetId: __expectString(output.TargetId),
+    TargetType: __expectString(output.TargetType),
   } as any;
 };
 
@@ -4131,8 +4126,8 @@ const deserializeAws_json1_1AccountAssignmentOperationStatusMetadata = (
       output.CreatedDate !== undefined && output.CreatedDate !== null
         ? new Date(Math.round(output.CreatedDate * 1000))
         : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    RequestId: __expectString(output.RequestId),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -4143,14 +4138,14 @@ const deserializeAws_json1_1AccountList = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1AttachedManagedPolicy = (output: any, context: __SerdeContext): AttachedManagedPolicy => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Arn: __expectString(output.Arn),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -4177,7 +4172,7 @@ const deserializeAws_json1_1AttachManagedPolicyToPermissionSetResponse = (
 
 const deserializeAws_json1_1ConflictException = (output: any, context: __SerdeContext): ConflictException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -4282,8 +4277,8 @@ const deserializeAws_json1_1DescribeInstanceAccessControlAttributeConfigurationR
             context
           )
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusReason: output.StatusReason !== undefined && output.StatusReason !== null ? output.StatusReason : undefined,
+    Status: __expectString(output.Status),
+    StatusReason: __expectString(output.StatusReason),
   } as any;
 };
 
@@ -4323,7 +4318,7 @@ const deserializeAws_json1_1GetInlinePolicyForPermissionSetResponse = (
   context: __SerdeContext
 ): GetInlinePolicyForPermissionSetResponse => {
   return {
-    InlinePolicy: output.InlinePolicy !== undefined && output.InlinePolicy !== null ? output.InlinePolicy : undefined,
+    InlinePolicy: __expectString(output.InlinePolicy),
   } as any;
 };
 
@@ -4352,9 +4347,8 @@ const deserializeAws_json1_1InstanceList = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_1InstanceMetadata = (output: any, context: __SerdeContext): InstanceMetadata => {
   return {
-    IdentityStoreId:
-      output.IdentityStoreId !== undefined && output.IdentityStoreId !== null ? output.IdentityStoreId : undefined,
-    InstanceArn: output.InstanceArn !== undefined && output.InstanceArn !== null ? output.InstanceArn : undefined,
+    IdentityStoreId: __expectString(output.IdentityStoreId),
+    InstanceArn: __expectString(output.InstanceArn),
   } as any;
 };
 
@@ -4363,7 +4357,7 @@ const deserializeAws_json1_1InternalServerException = (
   context: __SerdeContext
 ): InternalServerException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -4376,7 +4370,7 @@ const deserializeAws_json1_1ListAccountAssignmentCreationStatusResponse = (
       output.AccountAssignmentsCreationStatus !== undefined && output.AccountAssignmentsCreationStatus !== null
         ? deserializeAws_json1_1AccountAssignmentOperationStatusList(output.AccountAssignmentsCreationStatus, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -4389,7 +4383,7 @@ const deserializeAws_json1_1ListAccountAssignmentDeletionStatusResponse = (
       output.AccountAssignmentsDeletionStatus !== undefined && output.AccountAssignmentsDeletionStatus !== null
         ? deserializeAws_json1_1AccountAssignmentOperationStatusList(output.AccountAssignmentsDeletionStatus, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -4402,7 +4396,7 @@ const deserializeAws_json1_1ListAccountAssignmentsResponse = (
       output.AccountAssignments !== undefined && output.AccountAssignments !== null
         ? deserializeAws_json1_1AccountAssignmentList(output.AccountAssignments, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -4415,7 +4409,7 @@ const deserializeAws_json1_1ListAccountsForProvisionedPermissionSetResponse = (
       output.AccountIds !== undefined && output.AccountIds !== null
         ? deserializeAws_json1_1AccountList(output.AccountIds, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -4425,7 +4419,7 @@ const deserializeAws_json1_1ListInstancesResponse = (output: any, context: __Ser
       output.Instances !== undefined && output.Instances !== null
         ? deserializeAws_json1_1InstanceList(output.Instances, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -4438,7 +4432,7 @@ const deserializeAws_json1_1ListManagedPoliciesInPermissionSetResponse = (
       output.AttachedManagedPolicies !== undefined && output.AttachedManagedPolicies !== null
         ? deserializeAws_json1_1AttachedManagedPolicyList(output.AttachedManagedPolicies, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -4447,7 +4441,7 @@ const deserializeAws_json1_1ListPermissionSetProvisioningStatusResponse = (
   context: __SerdeContext
 ): ListPermissionSetProvisioningStatusResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     PermissionSetsProvisioningStatus:
       output.PermissionSetsProvisioningStatus !== undefined && output.PermissionSetsProvisioningStatus !== null
         ? deserializeAws_json1_1PermissionSetProvisioningStatusList(output.PermissionSetsProvisioningStatus, context)
@@ -4460,7 +4454,7 @@ const deserializeAws_json1_1ListPermissionSetsProvisionedToAccountResponse = (
   context: __SerdeContext
 ): ListPermissionSetsProvisionedToAccountResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     PermissionSets:
       output.PermissionSets !== undefined && output.PermissionSets !== null
         ? deserializeAws_json1_1PermissionSetList(output.PermissionSets, context)
@@ -4473,7 +4467,7 @@ const deserializeAws_json1_1ListPermissionSetsResponse = (
   context: __SerdeContext
 ): ListPermissionSetsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     PermissionSets:
       output.PermissionSets !== undefined && output.PermissionSets !== null
         ? deserializeAws_json1_1PermissionSetList(output.PermissionSets, context)
@@ -4486,7 +4480,7 @@ const deserializeAws_json1_1ListTagsForResourceResponse = (
   context: __SerdeContext
 ): ListTagsForResourceResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_1TagList(output.Tags, context)
@@ -4500,13 +4494,11 @@ const deserializeAws_json1_1PermissionSet = (output: any, context: __SerdeContex
       output.CreatedDate !== undefined && output.CreatedDate !== null
         ? new Date(Math.round(output.CreatedDate * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    PermissionSetArn:
-      output.PermissionSetArn !== undefined && output.PermissionSetArn !== null ? output.PermissionSetArn : undefined,
-    RelayState: output.RelayState !== undefined && output.RelayState !== null ? output.RelayState : undefined,
-    SessionDuration:
-      output.SessionDuration !== undefined && output.SessionDuration !== null ? output.SessionDuration : undefined,
+    Description: __expectString(output.Description),
+    Name: __expectString(output.Name),
+    PermissionSetArn: __expectString(output.PermissionSetArn),
+    RelayState: __expectString(output.RelayState),
+    SessionDuration: __expectString(output.SessionDuration),
   } as any;
 };
 
@@ -4517,7 +4509,7 @@ const deserializeAws_json1_1PermissionSetList = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4526,17 +4518,15 @@ const deserializeAws_json1_1PermissionSetProvisioningStatus = (
   context: __SerdeContext
 ): PermissionSetProvisioningStatus => {
   return {
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
+    AccountId: __expectString(output.AccountId),
     CreatedDate:
       output.CreatedDate !== undefined && output.CreatedDate !== null
         ? new Date(Math.round(output.CreatedDate * 1000))
         : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
-    PermissionSetArn:
-      output.PermissionSetArn !== undefined && output.PermissionSetArn !== null ? output.PermissionSetArn : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    FailureReason: __expectString(output.FailureReason),
+    PermissionSetArn: __expectString(output.PermissionSetArn),
+    RequestId: __expectString(output.RequestId),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -4563,8 +4553,8 @@ const deserializeAws_json1_1PermissionSetProvisioningStatusMetadata = (
       output.CreatedDate !== undefined && output.CreatedDate !== null
         ? new Date(Math.round(output.CreatedDate * 1000))
         : undefined,
-    RequestId: output.RequestId !== undefined && output.RequestId !== null ? output.RequestId : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    RequestId: __expectString(output.RequestId),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -4592,7 +4582,7 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -4601,14 +4591,14 @@ const deserializeAws_json1_1ServiceQuotaExceededException = (
   context: __SerdeContext
 ): ServiceQuotaExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -4629,7 +4619,7 @@ const deserializeAws_json1_1TagResourceResponse = (output: any, context: __Serde
 
 const deserializeAws_json1_1ThrottlingException = (output: any, context: __SerdeContext): ThrottlingException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -4653,7 +4643,7 @@ const deserializeAws_json1_1UpdatePermissionSetResponse = (
 
 const deserializeAws_json1_1ValidationException = (output: any, context: __SerdeContext): ValidationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 

--- a/clients/client-sso-oidc/protocols/Aws_restJson1.ts
+++ b/clients/client-sso-oidc/protocols/Aws_restJson1.ts
@@ -19,7 +19,11 @@ import {
   UnsupportedGrantTypeException,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -129,19 +133,19 @@ export const deserializeAws_restJson1CreateTokenCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.accessToken !== undefined && data.accessToken !== null) {
-    contents.accessToken = data.accessToken;
+    contents.accessToken = __expectString(data.accessToken);
   }
   if (data.expiresIn !== undefined && data.expiresIn !== null) {
-    contents.expiresIn = data.expiresIn;
+    contents.expiresIn = __expectNumber(data.expiresIn);
   }
   if (data.idToken !== undefined && data.idToken !== null) {
-    contents.idToken = data.idToken;
+    contents.idToken = __expectString(data.idToken);
   }
   if (data.refreshToken !== undefined && data.refreshToken !== null) {
-    contents.refreshToken = data.refreshToken;
+    contents.refreshToken = __expectString(data.refreshToken);
   }
   if (data.tokenType !== undefined && data.tokenType !== null) {
-    contents.tokenType = data.tokenType;
+    contents.tokenType = __expectString(data.tokenType);
   }
   return Promise.resolve(contents);
 };
@@ -281,22 +285,22 @@ export const deserializeAws_restJson1RegisterClientCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.authorizationEndpoint !== undefined && data.authorizationEndpoint !== null) {
-    contents.authorizationEndpoint = data.authorizationEndpoint;
+    contents.authorizationEndpoint = __expectString(data.authorizationEndpoint);
   }
   if (data.clientId !== undefined && data.clientId !== null) {
-    contents.clientId = data.clientId;
+    contents.clientId = __expectString(data.clientId);
   }
   if (data.clientIdIssuedAt !== undefined && data.clientIdIssuedAt !== null) {
-    contents.clientIdIssuedAt = data.clientIdIssuedAt;
+    contents.clientIdIssuedAt = __expectNumber(data.clientIdIssuedAt);
   }
   if (data.clientSecret !== undefined && data.clientSecret !== null) {
-    contents.clientSecret = data.clientSecret;
+    contents.clientSecret = __expectString(data.clientSecret);
   }
   if (data.clientSecretExpiresAt !== undefined && data.clientSecretExpiresAt !== null) {
-    contents.clientSecretExpiresAt = data.clientSecretExpiresAt;
+    contents.clientSecretExpiresAt = __expectNumber(data.clientSecretExpiresAt);
   }
   if (data.tokenEndpoint !== undefined && data.tokenEndpoint !== null) {
-    contents.tokenEndpoint = data.tokenEndpoint;
+    contents.tokenEndpoint = __expectString(data.tokenEndpoint);
   }
   return Promise.resolve(contents);
 };
@@ -380,22 +384,22 @@ export const deserializeAws_restJson1StartDeviceAuthorizationCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.deviceCode !== undefined && data.deviceCode !== null) {
-    contents.deviceCode = data.deviceCode;
+    contents.deviceCode = __expectString(data.deviceCode);
   }
   if (data.expiresIn !== undefined && data.expiresIn !== null) {
-    contents.expiresIn = data.expiresIn;
+    contents.expiresIn = __expectNumber(data.expiresIn);
   }
   if (data.interval !== undefined && data.interval !== null) {
-    contents.interval = data.interval;
+    contents.interval = __expectNumber(data.interval);
   }
   if (data.userCode !== undefined && data.userCode !== null) {
-    contents.userCode = data.userCode;
+    contents.userCode = __expectString(data.userCode);
   }
   if (data.verificationUri !== undefined && data.verificationUri !== null) {
-    contents.verificationUri = data.verificationUri;
+    contents.verificationUri = __expectString(data.verificationUri);
   }
   if (data.verificationUriComplete !== undefined && data.verificationUriComplete !== null) {
-    contents.verificationUriComplete = data.verificationUriComplete;
+    contents.verificationUriComplete = __expectString(data.verificationUriComplete);
   }
   return Promise.resolve(contents);
 };
@@ -482,10 +486,10 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.error !== undefined && data.error !== null) {
-    contents.error = data.error;
+    contents.error = __expectString(data.error);
   }
   if (data.error_description !== undefined && data.error_description !== null) {
-    contents.error_description = data.error_description;
+    contents.error_description = __expectString(data.error_description);
   }
   return contents;
 };
@@ -503,10 +507,10 @@ const deserializeAws_restJson1AuthorizationPendingExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.error !== undefined && data.error !== null) {
-    contents.error = data.error;
+    contents.error = __expectString(data.error);
   }
   if (data.error_description !== undefined && data.error_description !== null) {
-    contents.error_description = data.error_description;
+    contents.error_description = __expectString(data.error_description);
   }
   return contents;
 };
@@ -524,10 +528,10 @@ const deserializeAws_restJson1ExpiredTokenExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.error !== undefined && data.error !== null) {
-    contents.error = data.error;
+    contents.error = __expectString(data.error);
   }
   if (data.error_description !== undefined && data.error_description !== null) {
-    contents.error_description = data.error_description;
+    contents.error_description = __expectString(data.error_description);
   }
   return contents;
 };
@@ -545,10 +549,10 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.error !== undefined && data.error !== null) {
-    contents.error = data.error;
+    contents.error = __expectString(data.error);
   }
   if (data.error_description !== undefined && data.error_description !== null) {
-    contents.error_description = data.error_description;
+    contents.error_description = __expectString(data.error_description);
   }
   return contents;
 };
@@ -566,10 +570,10 @@ const deserializeAws_restJson1InvalidClientExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.error !== undefined && data.error !== null) {
-    contents.error = data.error;
+    contents.error = __expectString(data.error);
   }
   if (data.error_description !== undefined && data.error_description !== null) {
-    contents.error_description = data.error_description;
+    contents.error_description = __expectString(data.error_description);
   }
   return contents;
 };
@@ -587,10 +591,10 @@ const deserializeAws_restJson1InvalidClientMetadataExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.error !== undefined && data.error !== null) {
-    contents.error = data.error;
+    contents.error = __expectString(data.error);
   }
   if (data.error_description !== undefined && data.error_description !== null) {
-    contents.error_description = data.error_description;
+    contents.error_description = __expectString(data.error_description);
   }
   return contents;
 };
@@ -608,10 +612,10 @@ const deserializeAws_restJson1InvalidGrantExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.error !== undefined && data.error !== null) {
-    contents.error = data.error;
+    contents.error = __expectString(data.error);
   }
   if (data.error_description !== undefined && data.error_description !== null) {
-    contents.error_description = data.error_description;
+    contents.error_description = __expectString(data.error_description);
   }
   return contents;
 };
@@ -629,10 +633,10 @@ const deserializeAws_restJson1InvalidRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.error !== undefined && data.error !== null) {
-    contents.error = data.error;
+    contents.error = __expectString(data.error);
   }
   if (data.error_description !== undefined && data.error_description !== null) {
-    contents.error_description = data.error_description;
+    contents.error_description = __expectString(data.error_description);
   }
   return contents;
 };
@@ -650,10 +654,10 @@ const deserializeAws_restJson1InvalidScopeExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.error !== undefined && data.error !== null) {
-    contents.error = data.error;
+    contents.error = __expectString(data.error);
   }
   if (data.error_description !== undefined && data.error_description !== null) {
-    contents.error_description = data.error_description;
+    contents.error_description = __expectString(data.error_description);
   }
   return contents;
 };
@@ -671,10 +675,10 @@ const deserializeAws_restJson1SlowDownExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.error !== undefined && data.error !== null) {
-    contents.error = data.error;
+    contents.error = __expectString(data.error);
   }
   if (data.error_description !== undefined && data.error_description !== null) {
-    contents.error_description = data.error_description;
+    contents.error_description = __expectString(data.error_description);
   }
   return contents;
 };
@@ -692,10 +696,10 @@ const deserializeAws_restJson1UnauthorizedClientExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.error !== undefined && data.error !== null) {
-    contents.error = data.error;
+    contents.error = __expectString(data.error);
   }
   if (data.error_description !== undefined && data.error_description !== null) {
-    contents.error_description = data.error_description;
+    contents.error_description = __expectString(data.error_description);
   }
   return contents;
 };
@@ -713,10 +717,10 @@ const deserializeAws_restJson1UnsupportedGrantTypeExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.error !== undefined && data.error !== null) {
-    contents.error = data.error;
+    contents.error = __expectString(data.error);
   }
   if (data.error_description !== undefined && data.error_description !== null) {
-    contents.error_description = data.error_description;
+    contents.error_description = __expectString(data.error_description);
   }
   return contents;
 };

--- a/clients/client-sso/protocols/Aws_restJson1.ts
+++ b/clients/client-sso/protocols/Aws_restJson1.ts
@@ -14,6 +14,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -216,7 +218,7 @@ export const deserializeAws_restJson1ListAccountRolesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   if (data.roleList !== undefined && data.roleList !== null) {
     contents.roleList = deserializeAws_restJson1RoleListType(data.roleList, context);
@@ -302,7 +304,7 @@ export const deserializeAws_restJson1ListAccountsCommand = async (
     contents.accountList = deserializeAws_restJson1AccountListType(data.accountList, context);
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
-    contents.nextToken = data.nextToken;
+    contents.nextToken = __expectString(data.nextToken);
   }
   return Promise.resolve(contents);
 };
@@ -447,7 +449,7 @@ const deserializeAws_restJson1InvalidRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -464,7 +466,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -481,7 +483,7 @@ const deserializeAws_restJson1TooManyRequestsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -498,16 +500,16 @@ const deserializeAws_restJson1UnauthorizedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
 
 const deserializeAws_restJson1AccountInfo = (output: any, context: __SerdeContext): AccountInfo => {
   return {
-    accountId: output.accountId !== undefined && output.accountId !== null ? output.accountId : undefined,
-    accountName: output.accountName !== undefined && output.accountName !== null ? output.accountName : undefined,
-    emailAddress: output.emailAddress !== undefined && output.emailAddress !== null ? output.emailAddress : undefined,
+    accountId: __expectString(output.accountId),
+    accountName: __expectString(output.accountName),
+    emailAddress: __expectString(output.emailAddress),
   } as any;
 };
 
@@ -524,18 +526,17 @@ const deserializeAws_restJson1AccountListType = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1RoleCredentials = (output: any, context: __SerdeContext): RoleCredentials => {
   return {
-    accessKeyId: output.accessKeyId !== undefined && output.accessKeyId !== null ? output.accessKeyId : undefined,
-    expiration: output.expiration !== undefined && output.expiration !== null ? output.expiration : undefined,
-    secretAccessKey:
-      output.secretAccessKey !== undefined && output.secretAccessKey !== null ? output.secretAccessKey : undefined,
-    sessionToken: output.sessionToken !== undefined && output.sessionToken !== null ? output.sessionToken : undefined,
+    accessKeyId: __expectString(output.accessKeyId),
+    expiration: __expectNumber(output.expiration),
+    secretAccessKey: __expectString(output.secretAccessKey),
+    sessionToken: __expectString(output.sessionToken),
   } as any;
 };
 
 const deserializeAws_restJson1RoleInfo = (output: any, context: __SerdeContext): RoleInfo => {
   return {
-    accountId: output.accountId !== undefined && output.accountId !== null ? output.accountId : undefined,
-    roleName: output.roleName !== undefined && output.roleName !== null ? output.roleName : undefined,
+    accountId: __expectString(output.accountId),
+    roleName: __expectString(output.roleName),
   } as any;
 };
 

--- a/clients/client-storage-gateway/protocols/Aws_json1_1.ts
+++ b/clients/client-storage-gateway/protocols/Aws_json1_1.ts
@@ -449,7 +449,12 @@ import {
   VolumeiSCSIAttributes,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -8468,13 +8473,13 @@ const serializeAws_json1_1VTLDeviceARNs = (input: string[], context: __SerdeCont
 
 const deserializeAws_json1_1ActivateGatewayOutput = (output: any, context: __SerdeContext): ActivateGatewayOutput => {
   return {
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
+    GatewayARN: __expectString(output.GatewayARN),
   } as any;
 };
 
 const deserializeAws_json1_1AddCacheOutput = (output: any, context: __SerdeContext): AddCacheOutput => {
   return {
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
+    GatewayARN: __expectString(output.GatewayARN),
   } as any;
 };
 
@@ -8483,13 +8488,13 @@ const deserializeAws_json1_1AddTagsToResourceOutput = (
   context: __SerdeContext
 ): AddTagsToResourceOutput => {
   return {
-    ResourceARN: output.ResourceARN !== undefined && output.ResourceARN !== null ? output.ResourceARN : undefined,
+    ResourceARN: __expectString(output.ResourceARN),
   } as any;
 };
 
 const deserializeAws_json1_1AddUploadBufferOutput = (output: any, context: __SerdeContext): AddUploadBufferOutput => {
   return {
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
+    GatewayARN: __expectString(output.GatewayARN),
   } as any;
 };
 
@@ -8498,13 +8503,13 @@ const deserializeAws_json1_1AddWorkingStorageOutput = (
   context: __SerdeContext
 ): AddWorkingStorageOutput => {
   return {
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
+    GatewayARN: __expectString(output.GatewayARN),
   } as any;
 };
 
 const deserializeAws_json1_1AssignTapePoolOutput = (output: any, context: __SerdeContext): AssignTapePoolOutput => {
   return {
-    TapeARN: output.TapeARN !== undefined && output.TapeARN !== null ? output.TapeARN : undefined,
+    TapeARN: __expectString(output.TapeARN),
   } as any;
 };
 
@@ -8513,17 +8518,14 @@ const deserializeAws_json1_1AssociateFileSystemOutput = (
   context: __SerdeContext
 ): AssociateFileSystemOutput => {
   return {
-    FileSystemAssociationARN:
-      output.FileSystemAssociationARN !== undefined && output.FileSystemAssociationARN !== null
-        ? output.FileSystemAssociationARN
-        : undefined,
+    FileSystemAssociationARN: __expectString(output.FileSystemAssociationARN),
   } as any;
 };
 
 const deserializeAws_json1_1AttachVolumeOutput = (output: any, context: __SerdeContext): AttachVolumeOutput => {
   return {
-    TargetARN: output.TargetARN !== undefined && output.TargetARN !== null ? output.TargetARN : undefined,
-    VolumeARN: output.VolumeARN !== undefined && output.VolumeARN !== null ? output.VolumeARN : undefined,
+    TargetARN: __expectString(output.TargetARN),
+    VolumeARN: __expectString(output.VolumeARN),
   } as any;
 };
 
@@ -8536,7 +8538,7 @@ const deserializeAws_json1_1AutomaticTapeCreationPolicyInfo = (
       output.AutomaticTapeCreationRules !== undefined && output.AutomaticTapeCreationRules !== null
         ? deserializeAws_json1_1AutomaticTapeCreationRules(output.AutomaticTapeCreationRules, context)
         : undefined,
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
+    GatewayARN: __expectString(output.GatewayARN),
   } as any;
 };
 
@@ -8559,16 +8561,11 @@ const deserializeAws_json1_1AutomaticTapeCreationRule = (
   context: __SerdeContext
 ): AutomaticTapeCreationRule => {
   return {
-    MinimumNumTapes:
-      output.MinimumNumTapes !== undefined && output.MinimumNumTapes !== null ? output.MinimumNumTapes : undefined,
-    PoolId: output.PoolId !== undefined && output.PoolId !== null ? output.PoolId : undefined,
-    TapeBarcodePrefix:
-      output.TapeBarcodePrefix !== undefined && output.TapeBarcodePrefix !== null
-        ? output.TapeBarcodePrefix
-        : undefined,
-    TapeSizeInBytes:
-      output.TapeSizeInBytes !== undefined && output.TapeSizeInBytes !== null ? output.TapeSizeInBytes : undefined,
-    Worm: output.Worm !== undefined && output.Worm !== null ? output.Worm : undefined,
+    MinimumNumTapes: __expectNumber(output.MinimumNumTapes),
+    PoolId: __expectString(output.PoolId),
+    TapeBarcodePrefix: __expectString(output.TapeBarcodePrefix),
+    TapeSizeInBytes: __expectNumber(output.TapeSizeInBytes),
+    Worm: __expectBoolean(output.Worm),
   } as any;
 };
 
@@ -8591,27 +8588,16 @@ const deserializeAws_json1_1BandwidthRateLimitInterval = (
   context: __SerdeContext
 ): BandwidthRateLimitInterval => {
   return {
-    AverageDownloadRateLimitInBitsPerSec:
-      output.AverageDownloadRateLimitInBitsPerSec !== undefined && output.AverageDownloadRateLimitInBitsPerSec !== null
-        ? output.AverageDownloadRateLimitInBitsPerSec
-        : undefined,
-    AverageUploadRateLimitInBitsPerSec:
-      output.AverageUploadRateLimitInBitsPerSec !== undefined && output.AverageUploadRateLimitInBitsPerSec !== null
-        ? output.AverageUploadRateLimitInBitsPerSec
-        : undefined,
+    AverageDownloadRateLimitInBitsPerSec: __expectNumber(output.AverageDownloadRateLimitInBitsPerSec),
+    AverageUploadRateLimitInBitsPerSec: __expectNumber(output.AverageUploadRateLimitInBitsPerSec),
     DaysOfWeek:
       output.DaysOfWeek !== undefined && output.DaysOfWeek !== null
         ? deserializeAws_json1_1DaysOfWeek(output.DaysOfWeek, context)
         : undefined,
-    EndHourOfDay: output.EndHourOfDay !== undefined && output.EndHourOfDay !== null ? output.EndHourOfDay : undefined,
-    EndMinuteOfHour:
-      output.EndMinuteOfHour !== undefined && output.EndMinuteOfHour !== null ? output.EndMinuteOfHour : undefined,
-    StartHourOfDay:
-      output.StartHourOfDay !== undefined && output.StartHourOfDay !== null ? output.StartHourOfDay : undefined,
-    StartMinuteOfHour:
-      output.StartMinuteOfHour !== undefined && output.StartMinuteOfHour !== null
-        ? output.StartMinuteOfHour
-        : undefined,
+    EndHourOfDay: __expectNumber(output.EndHourOfDay),
+    EndMinuteOfHour: __expectNumber(output.EndMinuteOfHour),
+    StartHourOfDay: __expectNumber(output.StartHourOfDay),
+    StartMinuteOfHour: __expectNumber(output.StartMinuteOfHour),
   } as any;
 };
 
@@ -8631,10 +8617,7 @@ const deserializeAws_json1_1BandwidthRateLimitIntervals = (
 
 const deserializeAws_json1_1CacheAttributes = (output: any, context: __SerdeContext): CacheAttributes => {
   return {
-    CacheStaleTimeoutInSeconds:
-      output.CacheStaleTimeoutInSeconds !== undefined && output.CacheStaleTimeoutInSeconds !== null
-        ? output.CacheStaleTimeoutInSeconds
-        : undefined,
+    CacheStaleTimeoutInSeconds: __expectNumber(output.CacheStaleTimeoutInSeconds),
   } as any;
 };
 
@@ -8644,28 +8627,17 @@ const deserializeAws_json1_1CachediSCSIVolume = (output: any, context: __SerdeCo
       output.CreatedDate !== undefined && output.CreatedDate !== null
         ? new Date(Math.round(output.CreatedDate * 1000))
         : undefined,
-    KMSKey: output.KMSKey !== undefined && output.KMSKey !== null ? output.KMSKey : undefined,
-    SourceSnapshotId:
-      output.SourceSnapshotId !== undefined && output.SourceSnapshotId !== null ? output.SourceSnapshotId : undefined,
-    TargetName: output.TargetName !== undefined && output.TargetName !== null ? output.TargetName : undefined,
-    VolumeARN: output.VolumeARN !== undefined && output.VolumeARN !== null ? output.VolumeARN : undefined,
-    VolumeAttachmentStatus:
-      output.VolumeAttachmentStatus !== undefined && output.VolumeAttachmentStatus !== null
-        ? output.VolumeAttachmentStatus
-        : undefined,
-    VolumeId: output.VolumeId !== undefined && output.VolumeId !== null ? output.VolumeId : undefined,
-    VolumeProgress:
-      output.VolumeProgress !== undefined && output.VolumeProgress !== null ? output.VolumeProgress : undefined,
-    VolumeSizeInBytes:
-      output.VolumeSizeInBytes !== undefined && output.VolumeSizeInBytes !== null
-        ? output.VolumeSizeInBytes
-        : undefined,
-    VolumeStatus: output.VolumeStatus !== undefined && output.VolumeStatus !== null ? output.VolumeStatus : undefined,
-    VolumeType: output.VolumeType !== undefined && output.VolumeType !== null ? output.VolumeType : undefined,
-    VolumeUsedInBytes:
-      output.VolumeUsedInBytes !== undefined && output.VolumeUsedInBytes !== null
-        ? output.VolumeUsedInBytes
-        : undefined,
+    KMSKey: __expectString(output.KMSKey),
+    SourceSnapshotId: __expectString(output.SourceSnapshotId),
+    TargetName: __expectString(output.TargetName),
+    VolumeARN: __expectString(output.VolumeARN),
+    VolumeAttachmentStatus: __expectString(output.VolumeAttachmentStatus),
+    VolumeId: __expectString(output.VolumeId),
+    VolumeProgress: __expectNumber(output.VolumeProgress),
+    VolumeSizeInBytes: __expectNumber(output.VolumeSizeInBytes),
+    VolumeStatus: __expectString(output.VolumeStatus),
+    VolumeType: __expectString(output.VolumeType),
+    VolumeUsedInBytes: __expectNumber(output.VolumeUsedInBytes),
     VolumeiSCSIAttributes:
       output.VolumeiSCSIAttributes !== undefined && output.VolumeiSCSIAttributes !== null
         ? deserializeAws_json1_1VolumeiSCSIAttributes(output.VolumeiSCSIAttributes, context)
@@ -8686,13 +8658,13 @@ const deserializeAws_json1_1CachediSCSIVolumes = (output: any, context: __SerdeC
 
 const deserializeAws_json1_1CancelArchivalOutput = (output: any, context: __SerdeContext): CancelArchivalOutput => {
   return {
-    TapeARN: output.TapeARN !== undefined && output.TapeARN !== null ? output.TapeARN : undefined,
+    TapeARN: __expectString(output.TapeARN),
   } as any;
 };
 
 const deserializeAws_json1_1CancelRetrievalOutput = (output: any, context: __SerdeContext): CancelRetrievalOutput => {
   return {
-    TapeARN: output.TapeARN !== undefined && output.TapeARN !== null ? output.TapeARN : undefined,
+    TapeARN: __expectString(output.TapeARN),
   } as any;
 };
 
@@ -8709,17 +8681,10 @@ const deserializeAws_json1_1ChapCredentials = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_1ChapInfo = (output: any, context: __SerdeContext): ChapInfo => {
   return {
-    InitiatorName:
-      output.InitiatorName !== undefined && output.InitiatorName !== null ? output.InitiatorName : undefined,
-    SecretToAuthenticateInitiator:
-      output.SecretToAuthenticateInitiator !== undefined && output.SecretToAuthenticateInitiator !== null
-        ? output.SecretToAuthenticateInitiator
-        : undefined,
-    SecretToAuthenticateTarget:
-      output.SecretToAuthenticateTarget !== undefined && output.SecretToAuthenticateTarget !== null
-        ? output.SecretToAuthenticateTarget
-        : undefined,
-    TargetARN: output.TargetARN !== undefined && output.TargetARN !== null ? output.TargetARN : undefined,
+    InitiatorName: __expectString(output.InitiatorName),
+    SecretToAuthenticateInitiator: __expectString(output.SecretToAuthenticateInitiator),
+    SecretToAuthenticateTarget: __expectString(output.SecretToAuthenticateTarget),
+    TargetARN: __expectString(output.TargetARN),
   } as any;
 };
 
@@ -8728,8 +8693,8 @@ const deserializeAws_json1_1CreateCachediSCSIVolumeOutput = (
   context: __SerdeContext
 ): CreateCachediSCSIVolumeOutput => {
   return {
-    TargetARN: output.TargetARN !== undefined && output.TargetARN !== null ? output.TargetARN : undefined,
-    VolumeARN: output.VolumeARN !== undefined && output.VolumeARN !== null ? output.VolumeARN : undefined,
+    TargetARN: __expectString(output.TargetARN),
+    VolumeARN: __expectString(output.VolumeARN),
   } as any;
 };
 
@@ -8738,7 +8703,7 @@ const deserializeAws_json1_1CreateNFSFileShareOutput = (
   context: __SerdeContext
 ): CreateNFSFileShareOutput => {
   return {
-    FileShareARN: output.FileShareARN !== undefined && output.FileShareARN !== null ? output.FileShareARN : undefined,
+    FileShareARN: __expectString(output.FileShareARN),
   } as any;
 };
 
@@ -8747,7 +8712,7 @@ const deserializeAws_json1_1CreateSMBFileShareOutput = (
   context: __SerdeContext
 ): CreateSMBFileShareOutput => {
   return {
-    FileShareARN: output.FileShareARN !== undefined && output.FileShareARN !== null ? output.FileShareARN : undefined,
+    FileShareARN: __expectString(output.FileShareARN),
   } as any;
 };
 
@@ -8756,19 +8721,16 @@ const deserializeAws_json1_1CreateSnapshotFromVolumeRecoveryPointOutput = (
   context: __SerdeContext
 ): CreateSnapshotFromVolumeRecoveryPointOutput => {
   return {
-    SnapshotId: output.SnapshotId !== undefined && output.SnapshotId !== null ? output.SnapshotId : undefined,
-    VolumeARN: output.VolumeARN !== undefined && output.VolumeARN !== null ? output.VolumeARN : undefined,
-    VolumeRecoveryPointTime:
-      output.VolumeRecoveryPointTime !== undefined && output.VolumeRecoveryPointTime !== null
-        ? output.VolumeRecoveryPointTime
-        : undefined,
+    SnapshotId: __expectString(output.SnapshotId),
+    VolumeARN: __expectString(output.VolumeARN),
+    VolumeRecoveryPointTime: __expectString(output.VolumeRecoveryPointTime),
   } as any;
 };
 
 const deserializeAws_json1_1CreateSnapshotOutput = (output: any, context: __SerdeContext): CreateSnapshotOutput => {
   return {
-    SnapshotId: output.SnapshotId !== undefined && output.SnapshotId !== null ? output.SnapshotId : undefined,
-    VolumeARN: output.VolumeARN !== undefined && output.VolumeARN !== null ? output.VolumeARN : undefined,
+    SnapshotId: __expectString(output.SnapshotId),
+    VolumeARN: __expectString(output.VolumeARN),
   } as any;
 };
 
@@ -8777,18 +8739,15 @@ const deserializeAws_json1_1CreateStorediSCSIVolumeOutput = (
   context: __SerdeContext
 ): CreateStorediSCSIVolumeOutput => {
   return {
-    TargetARN: output.TargetARN !== undefined && output.TargetARN !== null ? output.TargetARN : undefined,
-    VolumeARN: output.VolumeARN !== undefined && output.VolumeARN !== null ? output.VolumeARN : undefined,
-    VolumeSizeInBytes:
-      output.VolumeSizeInBytes !== undefined && output.VolumeSizeInBytes !== null
-        ? output.VolumeSizeInBytes
-        : undefined,
+    TargetARN: __expectString(output.TargetARN),
+    VolumeARN: __expectString(output.VolumeARN),
+    VolumeSizeInBytes: __expectNumber(output.VolumeSizeInBytes),
   } as any;
 };
 
 const deserializeAws_json1_1CreateTapePoolOutput = (output: any, context: __SerdeContext): CreateTapePoolOutput => {
   return {
-    PoolARN: output.PoolARN !== undefined && output.PoolARN !== null ? output.PoolARN : undefined,
+    PoolARN: __expectString(output.PoolARN),
   } as any;
 };
 
@@ -8806,7 +8765,7 @@ const deserializeAws_json1_1CreateTapeWithBarcodeOutput = (
   context: __SerdeContext
 ): CreateTapeWithBarcodeOutput => {
   return {
-    TapeARN: output.TapeARN !== undefined && output.TapeARN !== null ? output.TapeARN : undefined,
+    TapeARN: __expectString(output.TapeARN),
   } as any;
 };
 
@@ -8817,7 +8776,7 @@ const deserializeAws_json1_1DaysOfWeek = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectNumber(entry) as any;
     });
 };
 
@@ -8826,7 +8785,7 @@ const deserializeAws_json1_1DeleteAutomaticTapeCreationPolicyOutput = (
   context: __SerdeContext
 ): DeleteAutomaticTapeCreationPolicyOutput => {
   return {
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
+    GatewayARN: __expectString(output.GatewayARN),
   } as any;
 };
 
@@ -8835,7 +8794,7 @@ const deserializeAws_json1_1DeleteBandwidthRateLimitOutput = (
   context: __SerdeContext
 ): DeleteBandwidthRateLimitOutput => {
   return {
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
+    GatewayARN: __expectString(output.GatewayARN),
   } as any;
 };
 
@@ -8844,21 +8803,20 @@ const deserializeAws_json1_1DeleteChapCredentialsOutput = (
   context: __SerdeContext
 ): DeleteChapCredentialsOutput => {
   return {
-    InitiatorName:
-      output.InitiatorName !== undefined && output.InitiatorName !== null ? output.InitiatorName : undefined,
-    TargetARN: output.TargetARN !== undefined && output.TargetARN !== null ? output.TargetARN : undefined,
+    InitiatorName: __expectString(output.InitiatorName),
+    TargetARN: __expectString(output.TargetARN),
   } as any;
 };
 
 const deserializeAws_json1_1DeleteFileShareOutput = (output: any, context: __SerdeContext): DeleteFileShareOutput => {
   return {
-    FileShareARN: output.FileShareARN !== undefined && output.FileShareARN !== null ? output.FileShareARN : undefined,
+    FileShareARN: __expectString(output.FileShareARN),
   } as any;
 };
 
 const deserializeAws_json1_1DeleteGatewayOutput = (output: any, context: __SerdeContext): DeleteGatewayOutput => {
   return {
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
+    GatewayARN: __expectString(output.GatewayARN),
   } as any;
 };
 
@@ -8867,7 +8825,7 @@ const deserializeAws_json1_1DeleteSnapshotScheduleOutput = (
   context: __SerdeContext
 ): DeleteSnapshotScheduleOutput => {
   return {
-    VolumeARN: output.VolumeARN !== undefined && output.VolumeARN !== null ? output.VolumeARN : undefined,
+    VolumeARN: __expectString(output.VolumeARN),
   } as any;
 };
 
@@ -8876,25 +8834,25 @@ const deserializeAws_json1_1DeleteTapeArchiveOutput = (
   context: __SerdeContext
 ): DeleteTapeArchiveOutput => {
   return {
-    TapeARN: output.TapeARN !== undefined && output.TapeARN !== null ? output.TapeARN : undefined,
+    TapeARN: __expectString(output.TapeARN),
   } as any;
 };
 
 const deserializeAws_json1_1DeleteTapeOutput = (output: any, context: __SerdeContext): DeleteTapeOutput => {
   return {
-    TapeARN: output.TapeARN !== undefined && output.TapeARN !== null ? output.TapeARN : undefined,
+    TapeARN: __expectString(output.TapeARN),
   } as any;
 };
 
 const deserializeAws_json1_1DeleteTapePoolOutput = (output: any, context: __SerdeContext): DeleteTapePoolOutput => {
   return {
-    PoolARN: output.PoolARN !== undefined && output.PoolARN !== null ? output.PoolARN : undefined,
+    PoolARN: __expectString(output.PoolARN),
   } as any;
 };
 
 const deserializeAws_json1_1DeleteVolumeOutput = (output: any, context: __SerdeContext): DeleteVolumeOutput => {
   return {
-    VolumeARN: output.VolumeARN !== undefined && output.VolumeARN !== null ? output.VolumeARN : undefined,
+    VolumeARN: __expectString(output.VolumeARN),
   } as any;
 };
 
@@ -8903,12 +8861,12 @@ const deserializeAws_json1_1DescribeAvailabilityMonitorTestOutput = (
   context: __SerdeContext
 ): DescribeAvailabilityMonitorTestOutput => {
   return {
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
+    GatewayARN: __expectString(output.GatewayARN),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
         ? new Date(Math.round(output.StartTime * 1000))
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -8917,15 +8875,9 @@ const deserializeAws_json1_1DescribeBandwidthRateLimitOutput = (
   context: __SerdeContext
 ): DescribeBandwidthRateLimitOutput => {
   return {
-    AverageDownloadRateLimitInBitsPerSec:
-      output.AverageDownloadRateLimitInBitsPerSec !== undefined && output.AverageDownloadRateLimitInBitsPerSec !== null
-        ? output.AverageDownloadRateLimitInBitsPerSec
-        : undefined,
-    AverageUploadRateLimitInBitsPerSec:
-      output.AverageUploadRateLimitInBitsPerSec !== undefined && output.AverageUploadRateLimitInBitsPerSec !== null
-        ? output.AverageUploadRateLimitInBitsPerSec
-        : undefined,
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
+    AverageDownloadRateLimitInBitsPerSec: __expectNumber(output.AverageDownloadRateLimitInBitsPerSec),
+    AverageUploadRateLimitInBitsPerSec: __expectNumber(output.AverageUploadRateLimitInBitsPerSec),
+    GatewayARN: __expectString(output.GatewayARN),
   } as any;
 };
 
@@ -8938,7 +8890,7 @@ const deserializeAws_json1_1DescribeBandwidthRateLimitScheduleOutput = (
       output.BandwidthRateLimitIntervals !== undefined && output.BandwidthRateLimitIntervals !== null
         ? deserializeAws_json1_1BandwidthRateLimitIntervals(output.BandwidthRateLimitIntervals, context)
         : undefined,
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
+    GatewayARN: __expectString(output.GatewayARN),
   } as any;
 };
 
@@ -8956,31 +8908,16 @@ const deserializeAws_json1_1DescribeCachediSCSIVolumesOutput = (
 
 const deserializeAws_json1_1DescribeCacheOutput = (output: any, context: __SerdeContext): DescribeCacheOutput => {
   return {
-    CacheAllocatedInBytes:
-      output.CacheAllocatedInBytes !== undefined && output.CacheAllocatedInBytes !== null
-        ? output.CacheAllocatedInBytes
-        : undefined,
-    CacheDirtyPercentage:
-      output.CacheDirtyPercentage !== undefined && output.CacheDirtyPercentage !== null
-        ? output.CacheDirtyPercentage
-        : undefined,
-    CacheHitPercentage:
-      output.CacheHitPercentage !== undefined && output.CacheHitPercentage !== null
-        ? output.CacheHitPercentage
-        : undefined,
-    CacheMissPercentage:
-      output.CacheMissPercentage !== undefined && output.CacheMissPercentage !== null
-        ? output.CacheMissPercentage
-        : undefined,
-    CacheUsedPercentage:
-      output.CacheUsedPercentage !== undefined && output.CacheUsedPercentage !== null
-        ? output.CacheUsedPercentage
-        : undefined,
+    CacheAllocatedInBytes: __expectNumber(output.CacheAllocatedInBytes),
+    CacheDirtyPercentage: __expectNumber(output.CacheDirtyPercentage),
+    CacheHitPercentage: __expectNumber(output.CacheHitPercentage),
+    CacheMissPercentage: __expectNumber(output.CacheMissPercentage),
+    CacheUsedPercentage: __expectNumber(output.CacheUsedPercentage),
     DiskIds:
       output.DiskIds !== undefined && output.DiskIds !== null
         ? deserializeAws_json1_1DiskIds(output.DiskIds, context)
         : undefined,
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
+    GatewayARN: __expectString(output.GatewayARN),
   } as any;
 };
 
@@ -9013,47 +8950,28 @@ const deserializeAws_json1_1DescribeGatewayInformationOutput = (
   context: __SerdeContext
 ): DescribeGatewayInformationOutput => {
   return {
-    CloudWatchLogGroupARN:
-      output.CloudWatchLogGroupARN !== undefined && output.CloudWatchLogGroupARN !== null
-        ? output.CloudWatchLogGroupARN
-        : undefined,
-    DeprecationDate:
-      output.DeprecationDate !== undefined && output.DeprecationDate !== null ? output.DeprecationDate : undefined,
-    Ec2InstanceId:
-      output.Ec2InstanceId !== undefined && output.Ec2InstanceId !== null ? output.Ec2InstanceId : undefined,
-    Ec2InstanceRegion:
-      output.Ec2InstanceRegion !== undefined && output.Ec2InstanceRegion !== null
-        ? output.Ec2InstanceRegion
-        : undefined,
-    EndpointType: output.EndpointType !== undefined && output.EndpointType !== null ? output.EndpointType : undefined,
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
-    GatewayId: output.GatewayId !== undefined && output.GatewayId !== null ? output.GatewayId : undefined,
-    GatewayName: output.GatewayName !== undefined && output.GatewayName !== null ? output.GatewayName : undefined,
+    CloudWatchLogGroupARN: __expectString(output.CloudWatchLogGroupARN),
+    DeprecationDate: __expectString(output.DeprecationDate),
+    Ec2InstanceId: __expectString(output.Ec2InstanceId),
+    Ec2InstanceRegion: __expectString(output.Ec2InstanceRegion),
+    EndpointType: __expectString(output.EndpointType),
+    GatewayARN: __expectString(output.GatewayARN),
+    GatewayId: __expectString(output.GatewayId),
+    GatewayName: __expectString(output.GatewayName),
     GatewayNetworkInterfaces:
       output.GatewayNetworkInterfaces !== undefined && output.GatewayNetworkInterfaces !== null
         ? deserializeAws_json1_1GatewayNetworkInterfaces(output.GatewayNetworkInterfaces, context)
         : undefined,
-    GatewayState: output.GatewayState !== undefined && output.GatewayState !== null ? output.GatewayState : undefined,
-    GatewayTimezone:
-      output.GatewayTimezone !== undefined && output.GatewayTimezone !== null ? output.GatewayTimezone : undefined,
-    GatewayType: output.GatewayType !== undefined && output.GatewayType !== null ? output.GatewayType : undefined,
-    HostEnvironment:
-      output.HostEnvironment !== undefined && output.HostEnvironment !== null ? output.HostEnvironment : undefined,
-    LastSoftwareUpdate:
-      output.LastSoftwareUpdate !== undefined && output.LastSoftwareUpdate !== null
-        ? output.LastSoftwareUpdate
-        : undefined,
-    NextUpdateAvailabilityDate:
-      output.NextUpdateAvailabilityDate !== undefined && output.NextUpdateAvailabilityDate !== null
-        ? output.NextUpdateAvailabilityDate
-        : undefined,
-    SoftwareUpdatesEndDate:
-      output.SoftwareUpdatesEndDate !== undefined && output.SoftwareUpdatesEndDate !== null
-        ? output.SoftwareUpdatesEndDate
-        : undefined,
+    GatewayState: __expectString(output.GatewayState),
+    GatewayTimezone: __expectString(output.GatewayTimezone),
+    GatewayType: __expectString(output.GatewayType),
+    HostEnvironment: __expectString(output.HostEnvironment),
+    LastSoftwareUpdate: __expectString(output.LastSoftwareUpdate),
+    NextUpdateAvailabilityDate: __expectString(output.NextUpdateAvailabilityDate),
+    SoftwareUpdatesEndDate: __expectString(output.SoftwareUpdatesEndDate),
     Tags:
       output.Tags !== undefined && output.Tags !== null ? deserializeAws_json1_1Tags(output.Tags, context) : undefined,
-    VPCEndpoint: output.VPCEndpoint !== undefined && output.VPCEndpoint !== null ? output.VPCEndpoint : undefined,
+    VPCEndpoint: __expectString(output.VPCEndpoint),
   } as any;
 };
 
@@ -9062,12 +8980,12 @@ const deserializeAws_json1_1DescribeMaintenanceStartTimeOutput = (
   context: __SerdeContext
 ): DescribeMaintenanceStartTimeOutput => {
   return {
-    DayOfMonth: output.DayOfMonth !== undefined && output.DayOfMonth !== null ? output.DayOfMonth : undefined,
-    DayOfWeek: output.DayOfWeek !== undefined && output.DayOfWeek !== null ? output.DayOfWeek : undefined,
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
-    HourOfDay: output.HourOfDay !== undefined && output.HourOfDay !== null ? output.HourOfDay : undefined,
-    MinuteOfHour: output.MinuteOfHour !== undefined && output.MinuteOfHour !== null ? output.MinuteOfHour : undefined,
-    Timezone: output.Timezone !== undefined && output.Timezone !== null ? output.Timezone : undefined,
+    DayOfMonth: __expectNumber(output.DayOfMonth),
+    DayOfWeek: __expectNumber(output.DayOfWeek),
+    GatewayARN: __expectString(output.GatewayARN),
+    HourOfDay: __expectNumber(output.HourOfDay),
+    MinuteOfHour: __expectNumber(output.MinuteOfHour),
+    Timezone: __expectString(output.Timezone),
   } as any;
 };
 
@@ -9100,24 +9018,12 @@ const deserializeAws_json1_1DescribeSMBSettingsOutput = (
   context: __SerdeContext
 ): DescribeSMBSettingsOutput => {
   return {
-    ActiveDirectoryStatus:
-      output.ActiveDirectoryStatus !== undefined && output.ActiveDirectoryStatus !== null
-        ? output.ActiveDirectoryStatus
-        : undefined,
-    DomainName: output.DomainName !== undefined && output.DomainName !== null ? output.DomainName : undefined,
-    FileSharesVisible:
-      output.FileSharesVisible !== undefined && output.FileSharesVisible !== null
-        ? output.FileSharesVisible
-        : undefined,
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
-    SMBGuestPasswordSet:
-      output.SMBGuestPasswordSet !== undefined && output.SMBGuestPasswordSet !== null
-        ? output.SMBGuestPasswordSet
-        : undefined,
-    SMBSecurityStrategy:
-      output.SMBSecurityStrategy !== undefined && output.SMBSecurityStrategy !== null
-        ? output.SMBSecurityStrategy
-        : undefined,
+    ActiveDirectoryStatus: __expectString(output.ActiveDirectoryStatus),
+    DomainName: __expectString(output.DomainName),
+    FileSharesVisible: __expectBoolean(output.FileSharesVisible),
+    GatewayARN: __expectString(output.GatewayARN),
+    SMBGuestPasswordSet: __expectBoolean(output.SMBGuestPasswordSet),
+    SMBSecurityStrategy: __expectString(output.SMBSecurityStrategy),
   } as any;
 };
 
@@ -9126,16 +9032,13 @@ const deserializeAws_json1_1DescribeSnapshotScheduleOutput = (
   context: __SerdeContext
 ): DescribeSnapshotScheduleOutput => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    RecurrenceInHours:
-      output.RecurrenceInHours !== undefined && output.RecurrenceInHours !== null
-        ? output.RecurrenceInHours
-        : undefined,
-    StartAt: output.StartAt !== undefined && output.StartAt !== null ? output.StartAt : undefined,
+    Description: __expectString(output.Description),
+    RecurrenceInHours: __expectNumber(output.RecurrenceInHours),
+    StartAt: __expectNumber(output.StartAt),
     Tags:
       output.Tags !== undefined && output.Tags !== null ? deserializeAws_json1_1Tags(output.Tags, context) : undefined,
-    Timezone: output.Timezone !== undefined && output.Timezone !== null ? output.Timezone : undefined,
-    VolumeARN: output.VolumeARN !== undefined && output.VolumeARN !== null ? output.VolumeARN : undefined,
+    Timezone: __expectString(output.Timezone),
+    VolumeARN: __expectString(output.VolumeARN),
   } as any;
 };
 
@@ -9156,7 +9059,7 @@ const deserializeAws_json1_1DescribeTapeArchivesOutput = (
   context: __SerdeContext
 ): DescribeTapeArchivesOutput => {
   return {
-    Marker: output.Marker !== undefined && output.Marker !== null ? output.Marker : undefined,
+    Marker: __expectString(output.Marker),
     TapeArchives:
       output.TapeArchives !== undefined && output.TapeArchives !== null
         ? deserializeAws_json1_1TapeArchives(output.TapeArchives, context)
@@ -9169,8 +9072,8 @@ const deserializeAws_json1_1DescribeTapeRecoveryPointsOutput = (
   context: __SerdeContext
 ): DescribeTapeRecoveryPointsOutput => {
   return {
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
-    Marker: output.Marker !== undefined && output.Marker !== null ? output.Marker : undefined,
+    GatewayARN: __expectString(output.GatewayARN),
+    Marker: __expectString(output.Marker),
     TapeRecoveryPointInfos:
       output.TapeRecoveryPointInfos !== undefined && output.TapeRecoveryPointInfos !== null
         ? deserializeAws_json1_1TapeRecoveryPointInfos(output.TapeRecoveryPointInfos, context)
@@ -9180,7 +9083,7 @@ const deserializeAws_json1_1DescribeTapeRecoveryPointsOutput = (
 
 const deserializeAws_json1_1DescribeTapesOutput = (output: any, context: __SerdeContext): DescribeTapesOutput => {
   return {
-    Marker: output.Marker !== undefined && output.Marker !== null ? output.Marker : undefined,
+    Marker: __expectString(output.Marker),
     Tapes:
       output.Tapes !== undefined && output.Tapes !== null
         ? deserializeAws_json1_1Tapes(output.Tapes, context)
@@ -9197,15 +9100,9 @@ const deserializeAws_json1_1DescribeUploadBufferOutput = (
       output.DiskIds !== undefined && output.DiskIds !== null
         ? deserializeAws_json1_1DiskIds(output.DiskIds, context)
         : undefined,
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
-    UploadBufferAllocatedInBytes:
-      output.UploadBufferAllocatedInBytes !== undefined && output.UploadBufferAllocatedInBytes !== null
-        ? output.UploadBufferAllocatedInBytes
-        : undefined,
-    UploadBufferUsedInBytes:
-      output.UploadBufferUsedInBytes !== undefined && output.UploadBufferUsedInBytes !== null
-        ? output.UploadBufferUsedInBytes
-        : undefined,
+    GatewayARN: __expectString(output.GatewayARN),
+    UploadBufferAllocatedInBytes: __expectNumber(output.UploadBufferAllocatedInBytes),
+    UploadBufferUsedInBytes: __expectNumber(output.UploadBufferUsedInBytes),
   } as any;
 };
 
@@ -9214,8 +9111,8 @@ const deserializeAws_json1_1DescribeVTLDevicesOutput = (
   context: __SerdeContext
 ): DescribeVTLDevicesOutput => {
   return {
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
-    Marker: output.Marker !== undefined && output.Marker !== null ? output.Marker : undefined,
+    GatewayARN: __expectString(output.GatewayARN),
+    Marker: __expectString(output.Marker),
     VTLDevices:
       output.VTLDevices !== undefined && output.VTLDevices !== null
         ? deserializeAws_json1_1VTLDevices(output.VTLDevices, context)
@@ -9232,42 +9129,30 @@ const deserializeAws_json1_1DescribeWorkingStorageOutput = (
       output.DiskIds !== undefined && output.DiskIds !== null
         ? deserializeAws_json1_1DiskIds(output.DiskIds, context)
         : undefined,
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
-    WorkingStorageAllocatedInBytes:
-      output.WorkingStorageAllocatedInBytes !== undefined && output.WorkingStorageAllocatedInBytes !== null
-        ? output.WorkingStorageAllocatedInBytes
-        : undefined,
-    WorkingStorageUsedInBytes:
-      output.WorkingStorageUsedInBytes !== undefined && output.WorkingStorageUsedInBytes !== null
-        ? output.WorkingStorageUsedInBytes
-        : undefined,
+    GatewayARN: __expectString(output.GatewayARN),
+    WorkingStorageAllocatedInBytes: __expectNumber(output.WorkingStorageAllocatedInBytes),
+    WorkingStorageUsedInBytes: __expectNumber(output.WorkingStorageUsedInBytes),
   } as any;
 };
 
 const deserializeAws_json1_1DetachVolumeOutput = (output: any, context: __SerdeContext): DetachVolumeOutput => {
   return {
-    VolumeARN: output.VolumeARN !== undefined && output.VolumeARN !== null ? output.VolumeARN : undefined,
+    VolumeARN: __expectString(output.VolumeARN),
   } as any;
 };
 
 const deserializeAws_json1_1DeviceiSCSIAttributes = (output: any, context: __SerdeContext): DeviceiSCSIAttributes => {
   return {
-    ChapEnabled: output.ChapEnabled !== undefined && output.ChapEnabled !== null ? output.ChapEnabled : undefined,
-    NetworkInterfaceId:
-      output.NetworkInterfaceId !== undefined && output.NetworkInterfaceId !== null
-        ? output.NetworkInterfaceId
-        : undefined,
-    NetworkInterfacePort:
-      output.NetworkInterfacePort !== undefined && output.NetworkInterfacePort !== null
-        ? output.NetworkInterfacePort
-        : undefined,
-    TargetARN: output.TargetARN !== undefined && output.TargetARN !== null ? output.TargetARN : undefined,
+    ChapEnabled: __expectBoolean(output.ChapEnabled),
+    NetworkInterfaceId: __expectString(output.NetworkInterfaceId),
+    NetworkInterfacePort: __expectNumber(output.NetworkInterfacePort),
+    TargetARN: __expectString(output.TargetARN),
   } as any;
 };
 
 const deserializeAws_json1_1DisableGatewayOutput = (output: any, context: __SerdeContext): DisableGatewayOutput => {
   return {
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
+    GatewayARN: __expectString(output.GatewayARN),
   } as any;
 };
 
@@ -9276,33 +9161,23 @@ const deserializeAws_json1_1DisassociateFileSystemOutput = (
   context: __SerdeContext
 ): DisassociateFileSystemOutput => {
   return {
-    FileSystemAssociationARN:
-      output.FileSystemAssociationARN !== undefined && output.FileSystemAssociationARN !== null
-        ? output.FileSystemAssociationARN
-        : undefined,
+    FileSystemAssociationARN: __expectString(output.FileSystemAssociationARN),
   } as any;
 };
 
 const deserializeAws_json1_1Disk = (output: any, context: __SerdeContext): Disk => {
   return {
-    DiskAllocationResource:
-      output.DiskAllocationResource !== undefined && output.DiskAllocationResource !== null
-        ? output.DiskAllocationResource
-        : undefined,
-    DiskAllocationType:
-      output.DiskAllocationType !== undefined && output.DiskAllocationType !== null
-        ? output.DiskAllocationType
-        : undefined,
+    DiskAllocationResource: __expectString(output.DiskAllocationResource),
+    DiskAllocationType: __expectString(output.DiskAllocationType),
     DiskAttributeList:
       output.DiskAttributeList !== undefined && output.DiskAttributeList !== null
         ? deserializeAws_json1_1DiskAttributeList(output.DiskAttributeList, context)
         : undefined,
-    DiskId: output.DiskId !== undefined && output.DiskId !== null ? output.DiskId : undefined,
-    DiskNode: output.DiskNode !== undefined && output.DiskNode !== null ? output.DiskNode : undefined,
-    DiskPath: output.DiskPath !== undefined && output.DiskPath !== null ? output.DiskPath : undefined,
-    DiskSizeInBytes:
-      output.DiskSizeInBytes !== undefined && output.DiskSizeInBytes !== null ? output.DiskSizeInBytes : undefined,
-    DiskStatus: output.DiskStatus !== undefined && output.DiskStatus !== null ? output.DiskStatus : undefined,
+    DiskId: __expectString(output.DiskId),
+    DiskNode: __expectString(output.DiskNode),
+    DiskPath: __expectString(output.DiskPath),
+    DiskSizeInBytes: __expectNumber(output.DiskSizeInBytes),
+    DiskStatus: __expectString(output.DiskStatus),
   } as any;
 };
 
@@ -9313,7 +9188,7 @@ const deserializeAws_json1_1DiskAttributeList = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -9324,7 +9199,7 @@ const deserializeAws_json1_1DiskIds = (output: any, context: __SerdeContext): st
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -9346,7 +9221,7 @@ const deserializeAws_json1_1errorDetails = (output: any, context: __SerdeContext
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -9358,19 +9233,17 @@ const deserializeAws_json1_1FileShareClientList = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1FileShareInfo = (output: any, context: __SerdeContext): FileShareInfo => {
   return {
-    FileShareARN: output.FileShareARN !== undefined && output.FileShareARN !== null ? output.FileShareARN : undefined,
-    FileShareId: output.FileShareId !== undefined && output.FileShareId !== null ? output.FileShareId : undefined,
-    FileShareStatus:
-      output.FileShareStatus !== undefined && output.FileShareStatus !== null ? output.FileShareStatus : undefined,
-    FileShareType:
-      output.FileShareType !== undefined && output.FileShareType !== null ? output.FileShareType : undefined,
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
+    FileShareARN: __expectString(output.FileShareARN),
+    FileShareId: __expectString(output.FileShareId),
+    FileShareStatus: __expectString(output.FileShareStatus),
+    FileShareType: __expectString(output.FileShareType),
+    GatewayARN: __expectString(output.GatewayARN),
   } as any;
 };
 
@@ -9390,24 +9263,15 @@ const deserializeAws_json1_1FileSystemAssociationInfo = (
   context: __SerdeContext
 ): FileSystemAssociationInfo => {
   return {
-    AuditDestinationARN:
-      output.AuditDestinationARN !== undefined && output.AuditDestinationARN !== null
-        ? output.AuditDestinationARN
-        : undefined,
+    AuditDestinationARN: __expectString(output.AuditDestinationARN),
     CacheAttributes:
       output.CacheAttributes !== undefined && output.CacheAttributes !== null
         ? deserializeAws_json1_1CacheAttributes(output.CacheAttributes, context)
         : undefined,
-    FileSystemAssociationARN:
-      output.FileSystemAssociationARN !== undefined && output.FileSystemAssociationARN !== null
-        ? output.FileSystemAssociationARN
-        : undefined,
-    FileSystemAssociationStatus:
-      output.FileSystemAssociationStatus !== undefined && output.FileSystemAssociationStatus !== null
-        ? output.FileSystemAssociationStatus
-        : undefined,
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
-    LocationARN: output.LocationARN !== undefined && output.LocationARN !== null ? output.LocationARN : undefined,
+    FileSystemAssociationARN: __expectString(output.FileSystemAssociationARN),
+    FileSystemAssociationStatus: __expectString(output.FileSystemAssociationStatus),
+    GatewayARN: __expectString(output.GatewayARN),
+    LocationARN: __expectString(output.LocationARN),
     Tags:
       output.Tags !== undefined && output.Tags !== null ? deserializeAws_json1_1Tags(output.Tags, context) : undefined,
   } as any;
@@ -9432,19 +9296,10 @@ const deserializeAws_json1_1FileSystemAssociationSummary = (
   context: __SerdeContext
 ): FileSystemAssociationSummary => {
   return {
-    FileSystemAssociationARN:
-      output.FileSystemAssociationARN !== undefined && output.FileSystemAssociationARN !== null
-        ? output.FileSystemAssociationARN
-        : undefined,
-    FileSystemAssociationId:
-      output.FileSystemAssociationId !== undefined && output.FileSystemAssociationId !== null
-        ? output.FileSystemAssociationId
-        : undefined,
-    FileSystemAssociationStatus:
-      output.FileSystemAssociationStatus !== undefined && output.FileSystemAssociationStatus !== null
-        ? output.FileSystemAssociationStatus
-        : undefined,
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
+    FileSystemAssociationARN: __expectString(output.FileSystemAssociationARN),
+    FileSystemAssociationId: __expectString(output.FileSystemAssociationId),
+    FileSystemAssociationStatus: __expectString(output.FileSystemAssociationStatus),
+    GatewayARN: __expectString(output.GatewayARN),
   } as any;
 };
 
@@ -9464,20 +9319,13 @@ const deserializeAws_json1_1FileSystemAssociationSummaryList = (
 
 const deserializeAws_json1_1GatewayInfo = (output: any, context: __SerdeContext): GatewayInfo => {
   return {
-    Ec2InstanceId:
-      output.Ec2InstanceId !== undefined && output.Ec2InstanceId !== null ? output.Ec2InstanceId : undefined,
-    Ec2InstanceRegion:
-      output.Ec2InstanceRegion !== undefined && output.Ec2InstanceRegion !== null
-        ? output.Ec2InstanceRegion
-        : undefined,
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
-    GatewayId: output.GatewayId !== undefined && output.GatewayId !== null ? output.GatewayId : undefined,
-    GatewayName: output.GatewayName !== undefined && output.GatewayName !== null ? output.GatewayName : undefined,
-    GatewayOperationalState:
-      output.GatewayOperationalState !== undefined && output.GatewayOperationalState !== null
-        ? output.GatewayOperationalState
-        : undefined,
-    GatewayType: output.GatewayType !== undefined && output.GatewayType !== null ? output.GatewayType : undefined,
+    Ec2InstanceId: __expectString(output.Ec2InstanceId),
+    Ec2InstanceRegion: __expectString(output.Ec2InstanceRegion),
+    GatewayARN: __expectString(output.GatewayARN),
+    GatewayId: __expectString(output.GatewayId),
+    GatewayName: __expectString(output.GatewayName),
+    GatewayOperationalState: __expectString(output.GatewayOperationalState),
+    GatewayType: __expectString(output.GatewayType),
   } as any;
 };
 
@@ -9510,7 +9358,7 @@ const deserializeAws_json1_1Initiators = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -9520,7 +9368,7 @@ const deserializeAws_json1_1InternalServerError = (output: any, context: __Serde
       output.error !== undefined && output.error !== null
         ? deserializeAws_json1_1StorageGatewayError(output.error, context)
         : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9533,17 +9381,14 @@ const deserializeAws_json1_1InvalidGatewayRequestException = (
       output.error !== undefined && output.error !== null
         ? deserializeAws_json1_1StorageGatewayError(output.error, context)
         : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1JoinDomainOutput = (output: any, context: __SerdeContext): JoinDomainOutput => {
   return {
-    ActiveDirectoryStatus:
-      output.ActiveDirectoryStatus !== undefined && output.ActiveDirectoryStatus !== null
-        ? output.ActiveDirectoryStatus
-        : undefined,
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
+    ActiveDirectoryStatus: __expectString(output.ActiveDirectoryStatus),
+    GatewayARN: __expectString(output.GatewayARN),
   } as any;
 };
 
@@ -9565,8 +9410,8 @@ const deserializeAws_json1_1ListFileSharesOutput = (output: any, context: __Serd
       output.FileShareInfoList !== undefined && output.FileShareInfoList !== null
         ? deserializeAws_json1_1FileShareInfoList(output.FileShareInfoList, context)
         : undefined,
-    Marker: output.Marker !== undefined && output.Marker !== null ? output.Marker : undefined,
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    Marker: __expectString(output.Marker),
+    NextMarker: __expectString(output.NextMarker),
   } as any;
 };
 
@@ -9579,8 +9424,8 @@ const deserializeAws_json1_1ListFileSystemAssociationsOutput = (
       output.FileSystemAssociationSummaryList !== undefined && output.FileSystemAssociationSummaryList !== null
         ? deserializeAws_json1_1FileSystemAssociationSummaryList(output.FileSystemAssociationSummaryList, context)
         : undefined,
-    Marker: output.Marker !== undefined && output.Marker !== null ? output.Marker : undefined,
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    Marker: __expectString(output.Marker),
+    NextMarker: __expectString(output.NextMarker),
   } as any;
 };
 
@@ -9590,7 +9435,7 @@ const deserializeAws_json1_1ListGatewaysOutput = (output: any, context: __SerdeC
       output.Gateways !== undefined && output.Gateways !== null
         ? deserializeAws_json1_1Gateways(output.Gateways, context)
         : undefined,
-    Marker: output.Marker !== undefined && output.Marker !== null ? output.Marker : undefined,
+    Marker: __expectString(output.Marker),
   } as any;
 };
 
@@ -9600,7 +9445,7 @@ const deserializeAws_json1_1ListLocalDisksOutput = (output: any, context: __Serd
       output.Disks !== undefined && output.Disks !== null
         ? deserializeAws_json1_1Disks(output.Disks, context)
         : undefined,
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
+    GatewayARN: __expectString(output.GatewayARN),
   } as any;
 };
 
@@ -9609,8 +9454,8 @@ const deserializeAws_json1_1ListTagsForResourceOutput = (
   context: __SerdeContext
 ): ListTagsForResourceOutput => {
   return {
-    Marker: output.Marker !== undefined && output.Marker !== null ? output.Marker : undefined,
-    ResourceARN: output.ResourceARN !== undefined && output.ResourceARN !== null ? output.ResourceARN : undefined,
+    Marker: __expectString(output.Marker),
+    ResourceARN: __expectString(output.ResourceARN),
     Tags:
       output.Tags !== undefined && output.Tags !== null ? deserializeAws_json1_1Tags(output.Tags, context) : undefined,
   } as any;
@@ -9618,7 +9463,7 @@ const deserializeAws_json1_1ListTagsForResourceOutput = (
 
 const deserializeAws_json1_1ListTapePoolsOutput = (output: any, context: __SerdeContext): ListTapePoolsOutput => {
   return {
-    Marker: output.Marker !== undefined && output.Marker !== null ? output.Marker : undefined,
+    Marker: __expectString(output.Marker),
     PoolInfos:
       output.PoolInfos !== undefined && output.PoolInfos !== null
         ? deserializeAws_json1_1PoolInfos(output.PoolInfos, context)
@@ -9628,7 +9473,7 @@ const deserializeAws_json1_1ListTapePoolsOutput = (output: any, context: __Serde
 
 const deserializeAws_json1_1ListTapesOutput = (output: any, context: __SerdeContext): ListTapesOutput => {
   return {
-    Marker: output.Marker !== undefined && output.Marker !== null ? output.Marker : undefined,
+    Marker: __expectString(output.Marker),
     TapeInfos:
       output.TapeInfos !== undefined && output.TapeInfos !== null
         ? deserializeAws_json1_1TapeInfos(output.TapeInfos, context)
@@ -9653,7 +9498,7 @@ const deserializeAws_json1_1ListVolumeRecoveryPointsOutput = (
   context: __SerdeContext
 ): ListVolumeRecoveryPointsOutput => {
   return {
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
+    GatewayARN: __expectString(output.GatewayARN),
     VolumeRecoveryPointInfos:
       output.VolumeRecoveryPointInfos !== undefined && output.VolumeRecoveryPointInfos !== null
         ? deserializeAws_json1_1VolumeRecoveryPointInfos(output.VolumeRecoveryPointInfos, context)
@@ -9663,8 +9508,8 @@ const deserializeAws_json1_1ListVolumeRecoveryPointsOutput = (
 
 const deserializeAws_json1_1ListVolumesOutput = (output: any, context: __SerdeContext): ListVolumesOutput => {
   return {
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
-    Marker: output.Marker !== undefined && output.Marker !== null ? output.Marker : undefined,
+    GatewayARN: __expectString(output.GatewayARN),
+    Marker: __expectString(output.Marker),
     VolumeInfos:
       output.VolumeInfos !== undefined && output.VolumeInfos !== null
         ? deserializeAws_json1_1VolumeInfos(output.VolumeInfos, context)
@@ -9674,19 +9519,18 @@ const deserializeAws_json1_1ListVolumesOutput = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1NetworkInterface = (output: any, context: __SerdeContext): NetworkInterface => {
   return {
-    Ipv4Address: output.Ipv4Address !== undefined && output.Ipv4Address !== null ? output.Ipv4Address : undefined,
-    Ipv6Address: output.Ipv6Address !== undefined && output.Ipv6Address !== null ? output.Ipv6Address : undefined,
-    MacAddress: output.MacAddress !== undefined && output.MacAddress !== null ? output.MacAddress : undefined,
+    Ipv4Address: __expectString(output.Ipv4Address),
+    Ipv6Address: __expectString(output.Ipv6Address),
+    MacAddress: __expectString(output.MacAddress),
   } as any;
 };
 
 const deserializeAws_json1_1NFSFileShareDefaults = (output: any, context: __SerdeContext): NFSFileShareDefaults => {
   return {
-    DirectoryMode:
-      output.DirectoryMode !== undefined && output.DirectoryMode !== null ? output.DirectoryMode : undefined,
-    FileMode: output.FileMode !== undefined && output.FileMode !== null ? output.FileMode : undefined,
-    GroupId: output.GroupId !== undefined && output.GroupId !== null ? output.GroupId : undefined,
-    OwnerId: output.OwnerId !== undefined && output.OwnerId !== null ? output.OwnerId : undefined,
+    DirectoryMode: __expectString(output.DirectoryMode),
+    FileMode: __expectString(output.FileMode),
+    GroupId: __expectNumber(output.GroupId),
+    OwnerId: __expectNumber(output.OwnerId),
   } as any;
 };
 
@@ -9700,39 +9544,27 @@ const deserializeAws_json1_1NFSFileShareInfo = (output: any, context: __SerdeCon
       output.ClientList !== undefined && output.ClientList !== null
         ? deserializeAws_json1_1FileShareClientList(output.ClientList, context)
         : undefined,
-    DefaultStorageClass:
-      output.DefaultStorageClass !== undefined && output.DefaultStorageClass !== null
-        ? output.DefaultStorageClass
-        : undefined,
-    FileShareARN: output.FileShareARN !== undefined && output.FileShareARN !== null ? output.FileShareARN : undefined,
-    FileShareId: output.FileShareId !== undefined && output.FileShareId !== null ? output.FileShareId : undefined,
-    FileShareName:
-      output.FileShareName !== undefined && output.FileShareName !== null ? output.FileShareName : undefined,
-    FileShareStatus:
-      output.FileShareStatus !== undefined && output.FileShareStatus !== null ? output.FileShareStatus : undefined,
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
-    GuessMIMETypeEnabled:
-      output.GuessMIMETypeEnabled !== undefined && output.GuessMIMETypeEnabled !== null
-        ? output.GuessMIMETypeEnabled
-        : undefined,
-    KMSEncrypted: output.KMSEncrypted !== undefined && output.KMSEncrypted !== null ? output.KMSEncrypted : undefined,
-    KMSKey: output.KMSKey !== undefined && output.KMSKey !== null ? output.KMSKey : undefined,
-    LocationARN: output.LocationARN !== undefined && output.LocationARN !== null ? output.LocationARN : undefined,
+    DefaultStorageClass: __expectString(output.DefaultStorageClass),
+    FileShareARN: __expectString(output.FileShareARN),
+    FileShareId: __expectString(output.FileShareId),
+    FileShareName: __expectString(output.FileShareName),
+    FileShareStatus: __expectString(output.FileShareStatus),
+    GatewayARN: __expectString(output.GatewayARN),
+    GuessMIMETypeEnabled: __expectBoolean(output.GuessMIMETypeEnabled),
+    KMSEncrypted: __expectBoolean(output.KMSEncrypted),
+    KMSKey: __expectString(output.KMSKey),
+    LocationARN: __expectString(output.LocationARN),
     NFSFileShareDefaults:
       output.NFSFileShareDefaults !== undefined && output.NFSFileShareDefaults !== null
         ? deserializeAws_json1_1NFSFileShareDefaults(output.NFSFileShareDefaults, context)
         : undefined,
-    NotificationPolicy:
-      output.NotificationPolicy !== undefined && output.NotificationPolicy !== null
-        ? output.NotificationPolicy
-        : undefined,
-    ObjectACL: output.ObjectACL !== undefined && output.ObjectACL !== null ? output.ObjectACL : undefined,
-    Path: output.Path !== undefined && output.Path !== null ? output.Path : undefined,
-    ReadOnly: output.ReadOnly !== undefined && output.ReadOnly !== null ? output.ReadOnly : undefined,
-    RequesterPays:
-      output.RequesterPays !== undefined && output.RequesterPays !== null ? output.RequesterPays : undefined,
-    Role: output.Role !== undefined && output.Role !== null ? output.Role : undefined,
-    Squash: output.Squash !== undefined && output.Squash !== null ? output.Squash : undefined,
+    NotificationPolicy: __expectString(output.NotificationPolicy),
+    ObjectACL: __expectString(output.ObjectACL),
+    Path: __expectString(output.Path),
+    ReadOnly: __expectBoolean(output.ReadOnly),
+    RequesterPays: __expectBoolean(output.RequesterPays),
+    Role: __expectString(output.Role),
+    Squash: __expectString(output.Squash),
     Tags:
       output.Tags !== undefined && output.Tags !== null ? deserializeAws_json1_1Tags(output.Tags, context) : undefined,
   } as any;
@@ -9754,26 +9586,19 @@ const deserializeAws_json1_1NotifyWhenUploadedOutput = (
   context: __SerdeContext
 ): NotifyWhenUploadedOutput => {
   return {
-    FileShareARN: output.FileShareARN !== undefined && output.FileShareARN !== null ? output.FileShareARN : undefined,
-    NotificationId:
-      output.NotificationId !== undefined && output.NotificationId !== null ? output.NotificationId : undefined,
+    FileShareARN: __expectString(output.FileShareARN),
+    NotificationId: __expectString(output.NotificationId),
   } as any;
 };
 
 const deserializeAws_json1_1PoolInfo = (output: any, context: __SerdeContext): PoolInfo => {
   return {
-    PoolARN: output.PoolARN !== undefined && output.PoolARN !== null ? output.PoolARN : undefined,
-    PoolName: output.PoolName !== undefined && output.PoolName !== null ? output.PoolName : undefined,
-    PoolStatus: output.PoolStatus !== undefined && output.PoolStatus !== null ? output.PoolStatus : undefined,
-    RetentionLockTimeInDays:
-      output.RetentionLockTimeInDays !== undefined && output.RetentionLockTimeInDays !== null
-        ? output.RetentionLockTimeInDays
-        : undefined,
-    RetentionLockType:
-      output.RetentionLockType !== undefined && output.RetentionLockType !== null
-        ? output.RetentionLockType
-        : undefined,
-    StorageClass: output.StorageClass !== undefined && output.StorageClass !== null ? output.StorageClass : undefined,
+    PoolARN: __expectString(output.PoolARN),
+    PoolName: __expectString(output.PoolName),
+    PoolStatus: __expectString(output.PoolStatus),
+    RetentionLockTimeInDays: __expectNumber(output.RetentionLockTimeInDays),
+    RetentionLockType: __expectString(output.RetentionLockType),
+    StorageClass: __expectString(output.StorageClass),
   } as any;
 };
 
@@ -9790,9 +9615,8 @@ const deserializeAws_json1_1PoolInfos = (output: any, context: __SerdeContext): 
 
 const deserializeAws_json1_1RefreshCacheOutput = (output: any, context: __SerdeContext): RefreshCacheOutput => {
   return {
-    FileShareARN: output.FileShareARN !== undefined && output.FileShareARN !== null ? output.FileShareARN : undefined,
-    NotificationId:
-      output.NotificationId !== undefined && output.NotificationId !== null ? output.NotificationId : undefined,
+    FileShareARN: __expectString(output.FileShareARN),
+    NotificationId: __expectString(output.NotificationId),
   } as any;
 };
 
@@ -9801,13 +9625,13 @@ const deserializeAws_json1_1RemoveTagsFromResourceOutput = (
   context: __SerdeContext
 ): RemoveTagsFromResourceOutput => {
   return {
-    ResourceARN: output.ResourceARN !== undefined && output.ResourceARN !== null ? output.ResourceARN : undefined,
+    ResourceARN: __expectString(output.ResourceARN),
   } as any;
 };
 
 const deserializeAws_json1_1ResetCacheOutput = (output: any, context: __SerdeContext): ResetCacheOutput => {
   return {
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
+    GatewayARN: __expectString(output.GatewayARN),
   } as any;
 };
 
@@ -9816,7 +9640,7 @@ const deserializeAws_json1_1RetrieveTapeArchiveOutput = (
   context: __SerdeContext
 ): RetrieveTapeArchiveOutput => {
   return {
-    TapeARN: output.TapeARN !== undefined && output.TapeARN !== null ? output.TapeARN : undefined,
+    TapeARN: __expectString(output.TapeARN),
   } as any;
 };
 
@@ -9825,7 +9649,7 @@ const deserializeAws_json1_1RetrieveTapeRecoveryPointOutput = (
   context: __SerdeContext
 ): RetrieveTapeRecoveryPointOutput => {
   return {
-    TapeARN: output.TapeARN !== undefined && output.TapeARN !== null ? output.TapeARN : undefined,
+    TapeARN: __expectString(output.TapeARN),
   } as any;
 };
 
@@ -9838,7 +9662,7 @@ const deserializeAws_json1_1ServiceUnavailableError = (
       output.error !== undefined && output.error !== null
         ? deserializeAws_json1_1StorageGatewayError(output.error, context)
         : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -9847,7 +9671,7 @@ const deserializeAws_json1_1SetLocalConsolePasswordOutput = (
   context: __SerdeContext
 ): SetLocalConsolePasswordOutput => {
   return {
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
+    GatewayARN: __expectString(output.GatewayARN),
   } as any;
 };
 
@@ -9856,72 +9680,51 @@ const deserializeAws_json1_1SetSMBGuestPasswordOutput = (
   context: __SerdeContext
 ): SetSMBGuestPasswordOutput => {
   return {
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
+    GatewayARN: __expectString(output.GatewayARN),
   } as any;
 };
 
 const deserializeAws_json1_1ShutdownGatewayOutput = (output: any, context: __SerdeContext): ShutdownGatewayOutput => {
   return {
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
+    GatewayARN: __expectString(output.GatewayARN),
   } as any;
 };
 
 const deserializeAws_json1_1SMBFileShareInfo = (output: any, context: __SerdeContext): SMBFileShareInfo => {
   return {
-    AccessBasedEnumeration:
-      output.AccessBasedEnumeration !== undefined && output.AccessBasedEnumeration !== null
-        ? output.AccessBasedEnumeration
-        : undefined,
+    AccessBasedEnumeration: __expectBoolean(output.AccessBasedEnumeration),
     AdminUserList:
       output.AdminUserList !== undefined && output.AdminUserList !== null
         ? deserializeAws_json1_1UserList(output.AdminUserList, context)
         : undefined,
-    AuditDestinationARN:
-      output.AuditDestinationARN !== undefined && output.AuditDestinationARN !== null
-        ? output.AuditDestinationARN
-        : undefined,
-    Authentication:
-      output.Authentication !== undefined && output.Authentication !== null ? output.Authentication : undefined,
+    AuditDestinationARN: __expectString(output.AuditDestinationARN),
+    Authentication: __expectString(output.Authentication),
     CacheAttributes:
       output.CacheAttributes !== undefined && output.CacheAttributes !== null
         ? deserializeAws_json1_1CacheAttributes(output.CacheAttributes, context)
         : undefined,
-    CaseSensitivity:
-      output.CaseSensitivity !== undefined && output.CaseSensitivity !== null ? output.CaseSensitivity : undefined,
-    DefaultStorageClass:
-      output.DefaultStorageClass !== undefined && output.DefaultStorageClass !== null
-        ? output.DefaultStorageClass
-        : undefined,
-    FileShareARN: output.FileShareARN !== undefined && output.FileShareARN !== null ? output.FileShareARN : undefined,
-    FileShareId: output.FileShareId !== undefined && output.FileShareId !== null ? output.FileShareId : undefined,
-    FileShareName:
-      output.FileShareName !== undefined && output.FileShareName !== null ? output.FileShareName : undefined,
-    FileShareStatus:
-      output.FileShareStatus !== undefined && output.FileShareStatus !== null ? output.FileShareStatus : undefined,
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
-    GuessMIMETypeEnabled:
-      output.GuessMIMETypeEnabled !== undefined && output.GuessMIMETypeEnabled !== null
-        ? output.GuessMIMETypeEnabled
-        : undefined,
+    CaseSensitivity: __expectString(output.CaseSensitivity),
+    DefaultStorageClass: __expectString(output.DefaultStorageClass),
+    FileShareARN: __expectString(output.FileShareARN),
+    FileShareId: __expectString(output.FileShareId),
+    FileShareName: __expectString(output.FileShareName),
+    FileShareStatus: __expectString(output.FileShareStatus),
+    GatewayARN: __expectString(output.GatewayARN),
+    GuessMIMETypeEnabled: __expectBoolean(output.GuessMIMETypeEnabled),
     InvalidUserList:
       output.InvalidUserList !== undefined && output.InvalidUserList !== null
         ? deserializeAws_json1_1UserList(output.InvalidUserList, context)
         : undefined,
-    KMSEncrypted: output.KMSEncrypted !== undefined && output.KMSEncrypted !== null ? output.KMSEncrypted : undefined,
-    KMSKey: output.KMSKey !== undefined && output.KMSKey !== null ? output.KMSKey : undefined,
-    LocationARN: output.LocationARN !== undefined && output.LocationARN !== null ? output.LocationARN : undefined,
-    NotificationPolicy:
-      output.NotificationPolicy !== undefined && output.NotificationPolicy !== null
-        ? output.NotificationPolicy
-        : undefined,
-    ObjectACL: output.ObjectACL !== undefined && output.ObjectACL !== null ? output.ObjectACL : undefined,
-    Path: output.Path !== undefined && output.Path !== null ? output.Path : undefined,
-    ReadOnly: output.ReadOnly !== undefined && output.ReadOnly !== null ? output.ReadOnly : undefined,
-    RequesterPays:
-      output.RequesterPays !== undefined && output.RequesterPays !== null ? output.RequesterPays : undefined,
-    Role: output.Role !== undefined && output.Role !== null ? output.Role : undefined,
-    SMBACLEnabled:
-      output.SMBACLEnabled !== undefined && output.SMBACLEnabled !== null ? output.SMBACLEnabled : undefined,
+    KMSEncrypted: __expectBoolean(output.KMSEncrypted),
+    KMSKey: __expectString(output.KMSKey),
+    LocationARN: __expectString(output.LocationARN),
+    NotificationPolicy: __expectString(output.NotificationPolicy),
+    ObjectACL: __expectString(output.ObjectACL),
+    Path: __expectString(output.Path),
+    ReadOnly: __expectBoolean(output.ReadOnly),
+    RequesterPays: __expectBoolean(output.RequesterPays),
+    Role: __expectString(output.Role),
+    SMBACLEnabled: __expectBoolean(output.SMBACLEnabled),
     Tags:
       output.Tags !== undefined && output.Tags !== null ? deserializeAws_json1_1Tags(output.Tags, context) : undefined,
     ValidUserList:
@@ -9947,19 +9750,19 @@ const deserializeAws_json1_1StartAvailabilityMonitorTestOutput = (
   context: __SerdeContext
 ): StartAvailabilityMonitorTestOutput => {
   return {
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
+    GatewayARN: __expectString(output.GatewayARN),
   } as any;
 };
 
 const deserializeAws_json1_1StartGatewayOutput = (output: any, context: __SerdeContext): StartGatewayOutput => {
   return {
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
+    GatewayARN: __expectString(output.GatewayARN),
   } as any;
 };
 
 const deserializeAws_json1_1StorageGatewayError = (output: any, context: __SerdeContext): StorageGatewayError => {
   return {
-    errorCode: output.errorCode !== undefined && output.errorCode !== null ? output.errorCode : undefined,
+    errorCode: __expectString(output.errorCode),
     errorDetails:
       output.errorDetails !== undefined && output.errorDetails !== null
         ? deserializeAws_json1_1errorDetails(output.errorDetails, context)
@@ -9973,33 +9776,19 @@ const deserializeAws_json1_1StorediSCSIVolume = (output: any, context: __SerdeCo
       output.CreatedDate !== undefined && output.CreatedDate !== null
         ? new Date(Math.round(output.CreatedDate * 1000))
         : undefined,
-    KMSKey: output.KMSKey !== undefined && output.KMSKey !== null ? output.KMSKey : undefined,
-    PreservedExistingData:
-      output.PreservedExistingData !== undefined && output.PreservedExistingData !== null
-        ? output.PreservedExistingData
-        : undefined,
-    SourceSnapshotId:
-      output.SourceSnapshotId !== undefined && output.SourceSnapshotId !== null ? output.SourceSnapshotId : undefined,
-    TargetName: output.TargetName !== undefined && output.TargetName !== null ? output.TargetName : undefined,
-    VolumeARN: output.VolumeARN !== undefined && output.VolumeARN !== null ? output.VolumeARN : undefined,
-    VolumeAttachmentStatus:
-      output.VolumeAttachmentStatus !== undefined && output.VolumeAttachmentStatus !== null
-        ? output.VolumeAttachmentStatus
-        : undefined,
-    VolumeDiskId: output.VolumeDiskId !== undefined && output.VolumeDiskId !== null ? output.VolumeDiskId : undefined,
-    VolumeId: output.VolumeId !== undefined && output.VolumeId !== null ? output.VolumeId : undefined,
-    VolumeProgress:
-      output.VolumeProgress !== undefined && output.VolumeProgress !== null ? output.VolumeProgress : undefined,
-    VolumeSizeInBytes:
-      output.VolumeSizeInBytes !== undefined && output.VolumeSizeInBytes !== null
-        ? output.VolumeSizeInBytes
-        : undefined,
-    VolumeStatus: output.VolumeStatus !== undefined && output.VolumeStatus !== null ? output.VolumeStatus : undefined,
-    VolumeType: output.VolumeType !== undefined && output.VolumeType !== null ? output.VolumeType : undefined,
-    VolumeUsedInBytes:
-      output.VolumeUsedInBytes !== undefined && output.VolumeUsedInBytes !== null
-        ? output.VolumeUsedInBytes
-        : undefined,
+    KMSKey: __expectString(output.KMSKey),
+    PreservedExistingData: __expectBoolean(output.PreservedExistingData),
+    SourceSnapshotId: __expectString(output.SourceSnapshotId),
+    TargetName: __expectString(output.TargetName),
+    VolumeARN: __expectString(output.VolumeARN),
+    VolumeAttachmentStatus: __expectString(output.VolumeAttachmentStatus),
+    VolumeDiskId: __expectString(output.VolumeDiskId),
+    VolumeId: __expectString(output.VolumeId),
+    VolumeProgress: __expectNumber(output.VolumeProgress),
+    VolumeSizeInBytes: __expectNumber(output.VolumeSizeInBytes),
+    VolumeStatus: __expectString(output.VolumeStatus),
+    VolumeType: __expectString(output.VolumeType),
+    VolumeUsedInBytes: __expectNumber(output.VolumeUsedInBytes),
     VolumeiSCSIAttributes:
       output.VolumeiSCSIAttributes !== undefined && output.VolumeiSCSIAttributes !== null
         ? deserializeAws_json1_1VolumeiSCSIAttributes(output.VolumeiSCSIAttributes, context)
@@ -10020,8 +9809,8 @@ const deserializeAws_json1_1StorediSCSIVolumes = (output: any, context: __SerdeC
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -10038,30 +9827,28 @@ const deserializeAws_json1_1Tags = (output: any, context: __SerdeContext): Tag[]
 
 const deserializeAws_json1_1Tape = (output: any, context: __SerdeContext): Tape => {
   return {
-    KMSKey: output.KMSKey !== undefined && output.KMSKey !== null ? output.KMSKey : undefined,
+    KMSKey: __expectString(output.KMSKey),
     PoolEntryDate:
       output.PoolEntryDate !== undefined && output.PoolEntryDate !== null
         ? new Date(Math.round(output.PoolEntryDate * 1000))
         : undefined,
-    PoolId: output.PoolId !== undefined && output.PoolId !== null ? output.PoolId : undefined,
-    Progress: output.Progress !== undefined && output.Progress !== null ? output.Progress : undefined,
+    PoolId: __expectString(output.PoolId),
+    Progress: __expectNumber(output.Progress),
     RetentionStartDate:
       output.RetentionStartDate !== undefined && output.RetentionStartDate !== null
         ? new Date(Math.round(output.RetentionStartDate * 1000))
         : undefined,
-    TapeARN: output.TapeARN !== undefined && output.TapeARN !== null ? output.TapeARN : undefined,
-    TapeBarcode: output.TapeBarcode !== undefined && output.TapeBarcode !== null ? output.TapeBarcode : undefined,
+    TapeARN: __expectString(output.TapeARN),
+    TapeBarcode: __expectString(output.TapeBarcode),
     TapeCreatedDate:
       output.TapeCreatedDate !== undefined && output.TapeCreatedDate !== null
         ? new Date(Math.round(output.TapeCreatedDate * 1000))
         : undefined,
-    TapeSizeInBytes:
-      output.TapeSizeInBytes !== undefined && output.TapeSizeInBytes !== null ? output.TapeSizeInBytes : undefined,
-    TapeStatus: output.TapeStatus !== undefined && output.TapeStatus !== null ? output.TapeStatus : undefined,
-    TapeUsedInBytes:
-      output.TapeUsedInBytes !== undefined && output.TapeUsedInBytes !== null ? output.TapeUsedInBytes : undefined,
-    VTLDevice: output.VTLDevice !== undefined && output.VTLDevice !== null ? output.VTLDevice : undefined,
-    Worm: output.Worm !== undefined && output.Worm !== null ? output.Worm : undefined,
+    TapeSizeInBytes: __expectNumber(output.TapeSizeInBytes),
+    TapeStatus: __expectString(output.TapeStatus),
+    TapeUsedInBytes: __expectNumber(output.TapeUsedInBytes),
+    VTLDevice: __expectString(output.VTLDevice),
+    Worm: __expectBoolean(output.Worm),
   } as any;
 };
 
@@ -10071,29 +9858,27 @@ const deserializeAws_json1_1TapeArchive = (output: any, context: __SerdeContext)
       output.CompletionTime !== undefined && output.CompletionTime !== null
         ? new Date(Math.round(output.CompletionTime * 1000))
         : undefined,
-    KMSKey: output.KMSKey !== undefined && output.KMSKey !== null ? output.KMSKey : undefined,
+    KMSKey: __expectString(output.KMSKey),
     PoolEntryDate:
       output.PoolEntryDate !== undefined && output.PoolEntryDate !== null
         ? new Date(Math.round(output.PoolEntryDate * 1000))
         : undefined,
-    PoolId: output.PoolId !== undefined && output.PoolId !== null ? output.PoolId : undefined,
+    PoolId: __expectString(output.PoolId),
     RetentionStartDate:
       output.RetentionStartDate !== undefined && output.RetentionStartDate !== null
         ? new Date(Math.round(output.RetentionStartDate * 1000))
         : undefined,
-    RetrievedTo: output.RetrievedTo !== undefined && output.RetrievedTo !== null ? output.RetrievedTo : undefined,
-    TapeARN: output.TapeARN !== undefined && output.TapeARN !== null ? output.TapeARN : undefined,
-    TapeBarcode: output.TapeBarcode !== undefined && output.TapeBarcode !== null ? output.TapeBarcode : undefined,
+    RetrievedTo: __expectString(output.RetrievedTo),
+    TapeARN: __expectString(output.TapeARN),
+    TapeBarcode: __expectString(output.TapeBarcode),
     TapeCreatedDate:
       output.TapeCreatedDate !== undefined && output.TapeCreatedDate !== null
         ? new Date(Math.round(output.TapeCreatedDate * 1000))
         : undefined,
-    TapeSizeInBytes:
-      output.TapeSizeInBytes !== undefined && output.TapeSizeInBytes !== null ? output.TapeSizeInBytes : undefined,
-    TapeStatus: output.TapeStatus !== undefined && output.TapeStatus !== null ? output.TapeStatus : undefined,
-    TapeUsedInBytes:
-      output.TapeUsedInBytes !== undefined && output.TapeUsedInBytes !== null ? output.TapeUsedInBytes : undefined,
-    Worm: output.Worm !== undefined && output.Worm !== null ? output.Worm : undefined,
+    TapeSizeInBytes: __expectNumber(output.TapeSizeInBytes),
+    TapeStatus: __expectString(output.TapeStatus),
+    TapeUsedInBytes: __expectNumber(output.TapeUsedInBytes),
+    Worm: __expectBoolean(output.Worm),
   } as any;
 };
 
@@ -10115,27 +9900,26 @@ const deserializeAws_json1_1TapeARNs = (output: any, context: __SerdeContext): s
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1TapeInfo = (output: any, context: __SerdeContext): TapeInfo => {
   return {
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
+    GatewayARN: __expectString(output.GatewayARN),
     PoolEntryDate:
       output.PoolEntryDate !== undefined && output.PoolEntryDate !== null
         ? new Date(Math.round(output.PoolEntryDate * 1000))
         : undefined,
-    PoolId: output.PoolId !== undefined && output.PoolId !== null ? output.PoolId : undefined,
+    PoolId: __expectString(output.PoolId),
     RetentionStartDate:
       output.RetentionStartDate !== undefined && output.RetentionStartDate !== null
         ? new Date(Math.round(output.RetentionStartDate * 1000))
         : undefined,
-    TapeARN: output.TapeARN !== undefined && output.TapeARN !== null ? output.TapeARN : undefined,
-    TapeBarcode: output.TapeBarcode !== undefined && output.TapeBarcode !== null ? output.TapeBarcode : undefined,
-    TapeSizeInBytes:
-      output.TapeSizeInBytes !== undefined && output.TapeSizeInBytes !== null ? output.TapeSizeInBytes : undefined,
-    TapeStatus: output.TapeStatus !== undefined && output.TapeStatus !== null ? output.TapeStatus : undefined,
+    TapeARN: __expectString(output.TapeARN),
+    TapeBarcode: __expectString(output.TapeBarcode),
+    TapeSizeInBytes: __expectNumber(output.TapeSizeInBytes),
+    TapeStatus: __expectString(output.TapeStatus),
   } as any;
 };
 
@@ -10152,14 +9936,13 @@ const deserializeAws_json1_1TapeInfos = (output: any, context: __SerdeContext): 
 
 const deserializeAws_json1_1TapeRecoveryPointInfo = (output: any, context: __SerdeContext): TapeRecoveryPointInfo => {
   return {
-    TapeARN: output.TapeARN !== undefined && output.TapeARN !== null ? output.TapeARN : undefined,
+    TapeARN: __expectString(output.TapeARN),
     TapeRecoveryPointTime:
       output.TapeRecoveryPointTime !== undefined && output.TapeRecoveryPointTime !== null
         ? new Date(Math.round(output.TapeRecoveryPointTime * 1000))
         : undefined,
-    TapeSizeInBytes:
-      output.TapeSizeInBytes !== undefined && output.TapeSizeInBytes !== null ? output.TapeSizeInBytes : undefined,
-    TapeStatus: output.TapeStatus !== undefined && output.TapeStatus !== null ? output.TapeStatus : undefined,
+    TapeSizeInBytes: __expectNumber(output.TapeSizeInBytes),
+    TapeStatus: __expectString(output.TapeStatus),
   } as any;
 };
 
@@ -10193,7 +9976,7 @@ const deserializeAws_json1_1UpdateAutomaticTapeCreationPolicyOutput = (
   context: __SerdeContext
 ): UpdateAutomaticTapeCreationPolicyOutput => {
   return {
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
+    GatewayARN: __expectString(output.GatewayARN),
   } as any;
 };
 
@@ -10202,7 +9985,7 @@ const deserializeAws_json1_1UpdateBandwidthRateLimitOutput = (
   context: __SerdeContext
 ): UpdateBandwidthRateLimitOutput => {
   return {
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
+    GatewayARN: __expectString(output.GatewayARN),
   } as any;
 };
 
@@ -10211,7 +9994,7 @@ const deserializeAws_json1_1UpdateBandwidthRateLimitScheduleOutput = (
   context: __SerdeContext
 ): UpdateBandwidthRateLimitScheduleOutput => {
   return {
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
+    GatewayARN: __expectString(output.GatewayARN),
   } as any;
 };
 
@@ -10220,9 +10003,8 @@ const deserializeAws_json1_1UpdateChapCredentialsOutput = (
   context: __SerdeContext
 ): UpdateChapCredentialsOutput => {
   return {
-    InitiatorName:
-      output.InitiatorName !== undefined && output.InitiatorName !== null ? output.InitiatorName : undefined,
-    TargetARN: output.TargetARN !== undefined && output.TargetARN !== null ? output.TargetARN : undefined,
+    InitiatorName: __expectString(output.InitiatorName),
+    TargetARN: __expectString(output.TargetARN),
   } as any;
 };
 
@@ -10231,10 +10013,7 @@ const deserializeAws_json1_1UpdateFileSystemAssociationOutput = (
   context: __SerdeContext
 ): UpdateFileSystemAssociationOutput => {
   return {
-    FileSystemAssociationARN:
-      output.FileSystemAssociationARN !== undefined && output.FileSystemAssociationARN !== null
-        ? output.FileSystemAssociationARN
-        : undefined,
+    FileSystemAssociationARN: __expectString(output.FileSystemAssociationARN),
   } as any;
 };
 
@@ -10243,8 +10022,8 @@ const deserializeAws_json1_1UpdateGatewayInformationOutput = (
   context: __SerdeContext
 ): UpdateGatewayInformationOutput => {
   return {
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
-    GatewayName: output.GatewayName !== undefined && output.GatewayName !== null ? output.GatewayName : undefined,
+    GatewayARN: __expectString(output.GatewayARN),
+    GatewayName: __expectString(output.GatewayName),
   } as any;
 };
 
@@ -10253,7 +10032,7 @@ const deserializeAws_json1_1UpdateGatewaySoftwareNowOutput = (
   context: __SerdeContext
 ): UpdateGatewaySoftwareNowOutput => {
   return {
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
+    GatewayARN: __expectString(output.GatewayARN),
   } as any;
 };
 
@@ -10262,7 +10041,7 @@ const deserializeAws_json1_1UpdateMaintenanceStartTimeOutput = (
   context: __SerdeContext
 ): UpdateMaintenanceStartTimeOutput => {
   return {
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
+    GatewayARN: __expectString(output.GatewayARN),
   } as any;
 };
 
@@ -10271,7 +10050,7 @@ const deserializeAws_json1_1UpdateNFSFileShareOutput = (
   context: __SerdeContext
 ): UpdateNFSFileShareOutput => {
   return {
-    FileShareARN: output.FileShareARN !== undefined && output.FileShareARN !== null ? output.FileShareARN : undefined,
+    FileShareARN: __expectString(output.FileShareARN),
   } as any;
 };
 
@@ -10280,7 +10059,7 @@ const deserializeAws_json1_1UpdateSMBFileShareOutput = (
   context: __SerdeContext
 ): UpdateSMBFileShareOutput => {
   return {
-    FileShareARN: output.FileShareARN !== undefined && output.FileShareARN !== null ? output.FileShareARN : undefined,
+    FileShareARN: __expectString(output.FileShareARN),
   } as any;
 };
 
@@ -10289,7 +10068,7 @@ const deserializeAws_json1_1UpdateSMBFileShareVisibilityOutput = (
   context: __SerdeContext
 ): UpdateSMBFileShareVisibilityOutput => {
   return {
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
+    GatewayARN: __expectString(output.GatewayARN),
   } as any;
 };
 
@@ -10298,7 +10077,7 @@ const deserializeAws_json1_1UpdateSMBSecurityStrategyOutput = (
   context: __SerdeContext
 ): UpdateSMBSecurityStrategyOutput => {
   return {
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
+    GatewayARN: __expectString(output.GatewayARN),
   } as any;
 };
 
@@ -10307,7 +10086,7 @@ const deserializeAws_json1_1UpdateSnapshotScheduleOutput = (
   context: __SerdeContext
 ): UpdateSnapshotScheduleOutput => {
   return {
-    VolumeARN: output.VolumeARN !== undefined && output.VolumeARN !== null ? output.VolumeARN : undefined,
+    VolumeARN: __expectString(output.VolumeARN),
   } as any;
 };
 
@@ -10316,7 +10095,7 @@ const deserializeAws_json1_1UpdateVTLDeviceTypeOutput = (
   context: __SerdeContext
 ): UpdateVTLDeviceTypeOutput => {
   return {
-    VTLDeviceARN: output.VTLDeviceARN !== undefined && output.VTLDeviceARN !== null ? output.VTLDeviceARN : undefined,
+    VTLDeviceARN: __expectString(output.VTLDeviceARN),
   } as any;
 };
 
@@ -10327,25 +10106,19 @@ const deserializeAws_json1_1UserList = (output: any, context: __SerdeContext): s
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1VolumeInfo = (output: any, context: __SerdeContext): VolumeInfo => {
   return {
-    GatewayARN: output.GatewayARN !== undefined && output.GatewayARN !== null ? output.GatewayARN : undefined,
-    GatewayId: output.GatewayId !== undefined && output.GatewayId !== null ? output.GatewayId : undefined,
-    VolumeARN: output.VolumeARN !== undefined && output.VolumeARN !== null ? output.VolumeARN : undefined,
-    VolumeAttachmentStatus:
-      output.VolumeAttachmentStatus !== undefined && output.VolumeAttachmentStatus !== null
-        ? output.VolumeAttachmentStatus
-        : undefined,
-    VolumeId: output.VolumeId !== undefined && output.VolumeId !== null ? output.VolumeId : undefined,
-    VolumeSizeInBytes:
-      output.VolumeSizeInBytes !== undefined && output.VolumeSizeInBytes !== null
-        ? output.VolumeSizeInBytes
-        : undefined,
-    VolumeType: output.VolumeType !== undefined && output.VolumeType !== null ? output.VolumeType : undefined,
+    GatewayARN: __expectString(output.GatewayARN),
+    GatewayId: __expectString(output.GatewayId),
+    VolumeARN: __expectString(output.VolumeARN),
+    VolumeAttachmentStatus: __expectString(output.VolumeAttachmentStatus),
+    VolumeId: __expectString(output.VolumeId),
+    VolumeSizeInBytes: __expectNumber(output.VolumeSizeInBytes),
+    VolumeType: __expectString(output.VolumeType),
   } as any;
 };
 
@@ -10362,17 +10135,11 @@ const deserializeAws_json1_1VolumeInfos = (output: any, context: __SerdeContext)
 
 const deserializeAws_json1_1VolumeiSCSIAttributes = (output: any, context: __SerdeContext): VolumeiSCSIAttributes => {
   return {
-    ChapEnabled: output.ChapEnabled !== undefined && output.ChapEnabled !== null ? output.ChapEnabled : undefined,
-    LunNumber: output.LunNumber !== undefined && output.LunNumber !== null ? output.LunNumber : undefined,
-    NetworkInterfaceId:
-      output.NetworkInterfaceId !== undefined && output.NetworkInterfaceId !== null
-        ? output.NetworkInterfaceId
-        : undefined,
-    NetworkInterfacePort:
-      output.NetworkInterfacePort !== undefined && output.NetworkInterfacePort !== null
-        ? output.NetworkInterfacePort
-        : undefined,
-    TargetARN: output.TargetARN !== undefined && output.TargetARN !== null ? output.TargetARN : undefined,
+    ChapEnabled: __expectBoolean(output.ChapEnabled),
+    LunNumber: __expectNumber(output.LunNumber),
+    NetworkInterfaceId: __expectString(output.NetworkInterfaceId),
+    NetworkInterfacePort: __expectNumber(output.NetworkInterfacePort),
+    TargetARN: __expectString(output.TargetARN),
   } as any;
 };
 
@@ -10381,19 +10148,10 @@ const deserializeAws_json1_1VolumeRecoveryPointInfo = (
   context: __SerdeContext
 ): VolumeRecoveryPointInfo => {
   return {
-    VolumeARN: output.VolumeARN !== undefined && output.VolumeARN !== null ? output.VolumeARN : undefined,
-    VolumeRecoveryPointTime:
-      output.VolumeRecoveryPointTime !== undefined && output.VolumeRecoveryPointTime !== null
-        ? output.VolumeRecoveryPointTime
-        : undefined,
-    VolumeSizeInBytes:
-      output.VolumeSizeInBytes !== undefined && output.VolumeSizeInBytes !== null
-        ? output.VolumeSizeInBytes
-        : undefined,
-    VolumeUsageInBytes:
-      output.VolumeUsageInBytes !== undefined && output.VolumeUsageInBytes !== null
-        ? output.VolumeUsageInBytes
-        : undefined,
+    VolumeARN: __expectString(output.VolumeARN),
+    VolumeRecoveryPointTime: __expectString(output.VolumeRecoveryPointTime),
+    VolumeSizeInBytes: __expectNumber(output.VolumeSizeInBytes),
+    VolumeUsageInBytes: __expectNumber(output.VolumeUsageInBytes),
   } as any;
 };
 
@@ -10417,15 +10175,10 @@ const deserializeAws_json1_1VTLDevice = (output: any, context: __SerdeContext): 
       output.DeviceiSCSIAttributes !== undefined && output.DeviceiSCSIAttributes !== null
         ? deserializeAws_json1_1DeviceiSCSIAttributes(output.DeviceiSCSIAttributes, context)
         : undefined,
-    VTLDeviceARN: output.VTLDeviceARN !== undefined && output.VTLDeviceARN !== null ? output.VTLDeviceARN : undefined,
-    VTLDeviceProductIdentifier:
-      output.VTLDeviceProductIdentifier !== undefined && output.VTLDeviceProductIdentifier !== null
-        ? output.VTLDeviceProductIdentifier
-        : undefined,
-    VTLDeviceType:
-      output.VTLDeviceType !== undefined && output.VTLDeviceType !== null ? output.VTLDeviceType : undefined,
-    VTLDeviceVendor:
-      output.VTLDeviceVendor !== undefined && output.VTLDeviceVendor !== null ? output.VTLDeviceVendor : undefined,
+    VTLDeviceARN: __expectString(output.VTLDeviceARN),
+    VTLDeviceProductIdentifier: __expectString(output.VTLDeviceProductIdentifier),
+    VTLDeviceType: __expectString(output.VTLDeviceType),
+    VTLDeviceVendor: __expectString(output.VTLDeviceVendor),
   } as any;
 };
 

--- a/clients/client-sts/protocols/Aws_query.ts
+++ b/clients/client-sts/protocols/Aws_query.ts
@@ -46,6 +46,7 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getValueFromTextNode as __getValueFromTextNode,
 } from "@aws-sdk/smithy-client";
@@ -1103,10 +1104,10 @@ const deserializeAws_queryAssumedRoleUser = (output: any, context: __SerdeContex
     Arn: undefined,
   };
   if (output["AssumedRoleId"] !== undefined) {
-    contents.AssumedRoleId = output["AssumedRoleId"];
+    contents.AssumedRoleId = __expectString(output["AssumedRoleId"]);
   }
   if (output["Arn"] !== undefined) {
-    contents.Arn = output["Arn"];
+    contents.Arn = __expectString(output["Arn"]);
   }
   return contents;
 };
@@ -1128,7 +1129,7 @@ const deserializeAws_queryAssumeRoleResponse = (output: any, context: __SerdeCon
     contents.PackedPolicySize = parseInt(output["PackedPolicySize"]);
   }
   if (output["SourceIdentity"] !== undefined) {
-    contents.SourceIdentity = output["SourceIdentity"];
+    contents.SourceIdentity = __expectString(output["SourceIdentity"]);
   }
   return contents;
 };
@@ -1158,22 +1159,22 @@ const deserializeAws_queryAssumeRoleWithSAMLResponse = (
     contents.PackedPolicySize = parseInt(output["PackedPolicySize"]);
   }
   if (output["Subject"] !== undefined) {
-    contents.Subject = output["Subject"];
+    contents.Subject = __expectString(output["Subject"]);
   }
   if (output["SubjectType"] !== undefined) {
-    contents.SubjectType = output["SubjectType"];
+    contents.SubjectType = __expectString(output["SubjectType"]);
   }
   if (output["Issuer"] !== undefined) {
-    contents.Issuer = output["Issuer"];
+    contents.Issuer = __expectString(output["Issuer"]);
   }
   if (output["Audience"] !== undefined) {
-    contents.Audience = output["Audience"];
+    contents.Audience = __expectString(output["Audience"]);
   }
   if (output["NameQualifier"] !== undefined) {
-    contents.NameQualifier = output["NameQualifier"];
+    contents.NameQualifier = __expectString(output["NameQualifier"]);
   }
   if (output["SourceIdentity"] !== undefined) {
-    contents.SourceIdentity = output["SourceIdentity"];
+    contents.SourceIdentity = __expectString(output["SourceIdentity"]);
   }
   return contents;
 };
@@ -1195,7 +1196,7 @@ const deserializeAws_queryAssumeRoleWithWebIdentityResponse = (
     contents.Credentials = deserializeAws_queryCredentials(output["Credentials"], context);
   }
   if (output["SubjectFromWebIdentityToken"] !== undefined) {
-    contents.SubjectFromWebIdentityToken = output["SubjectFromWebIdentityToken"];
+    contents.SubjectFromWebIdentityToken = __expectString(output["SubjectFromWebIdentityToken"]);
   }
   if (output["AssumedRoleUser"] !== undefined) {
     contents.AssumedRoleUser = deserializeAws_queryAssumedRoleUser(output["AssumedRoleUser"], context);
@@ -1204,13 +1205,13 @@ const deserializeAws_queryAssumeRoleWithWebIdentityResponse = (
     contents.PackedPolicySize = parseInt(output["PackedPolicySize"]);
   }
   if (output["Provider"] !== undefined) {
-    contents.Provider = output["Provider"];
+    contents.Provider = __expectString(output["Provider"]);
   }
   if (output["Audience"] !== undefined) {
-    contents.Audience = output["Audience"];
+    contents.Audience = __expectString(output["Audience"]);
   }
   if (output["SourceIdentity"] !== undefined) {
-    contents.SourceIdentity = output["SourceIdentity"];
+    contents.SourceIdentity = __expectString(output["SourceIdentity"]);
   }
   return contents;
 };
@@ -1223,13 +1224,13 @@ const deserializeAws_queryCredentials = (output: any, context: __SerdeContext): 
     Expiration: undefined,
   };
   if (output["AccessKeyId"] !== undefined) {
-    contents.AccessKeyId = output["AccessKeyId"];
+    contents.AccessKeyId = __expectString(output["AccessKeyId"]);
   }
   if (output["SecretAccessKey"] !== undefined) {
-    contents.SecretAccessKey = output["SecretAccessKey"];
+    contents.SecretAccessKey = __expectString(output["SecretAccessKey"]);
   }
   if (output["SessionToken"] !== undefined) {
-    contents.SessionToken = output["SessionToken"];
+    contents.SessionToken = __expectString(output["SessionToken"]);
   }
   if (output["Expiration"] !== undefined) {
     contents.Expiration = new Date(output["Expiration"]);
@@ -1245,7 +1246,7 @@ const deserializeAws_queryDecodeAuthorizationMessageResponse = (
     DecodedMessage: undefined,
   };
   if (output["DecodedMessage"] !== undefined) {
-    contents.DecodedMessage = output["DecodedMessage"];
+    contents.DecodedMessage = __expectString(output["DecodedMessage"]);
   }
   return contents;
 };
@@ -1255,7 +1256,7 @@ const deserializeAws_queryExpiredTokenException = (output: any, context: __Serde
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -1266,10 +1267,10 @@ const deserializeAws_queryFederatedUser = (output: any, context: __SerdeContext)
     Arn: undefined,
   };
   if (output["FederatedUserId"] !== undefined) {
-    contents.FederatedUserId = output["FederatedUserId"];
+    contents.FederatedUserId = __expectString(output["FederatedUserId"]);
   }
   if (output["Arn"] !== undefined) {
-    contents.Arn = output["Arn"];
+    contents.Arn = __expectString(output["Arn"]);
   }
   return contents;
 };
@@ -1282,7 +1283,7 @@ const deserializeAws_queryGetAccessKeyInfoResponse = (
     Account: undefined,
   };
   if (output["Account"] !== undefined) {
-    contents.Account = output["Account"];
+    contents.Account = __expectString(output["Account"]);
   }
   return contents;
 };
@@ -1297,13 +1298,13 @@ const deserializeAws_queryGetCallerIdentityResponse = (
     Arn: undefined,
   };
   if (output["UserId"] !== undefined) {
-    contents.UserId = output["UserId"];
+    contents.UserId = __expectString(output["UserId"]);
   }
   if (output["Account"] !== undefined) {
-    contents.Account = output["Account"];
+    contents.Account = __expectString(output["Account"]);
   }
   if (output["Arn"] !== undefined) {
-    contents.Arn = output["Arn"];
+    contents.Arn = __expectString(output["Arn"]);
   }
   return contents;
 };
@@ -1347,7 +1348,7 @@ const deserializeAws_queryIDPCommunicationErrorException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -1360,7 +1361,7 @@ const deserializeAws_queryIDPRejectedClaimException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -1373,7 +1374,7 @@ const deserializeAws_queryInvalidAuthorizationMessageException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -1386,7 +1387,7 @@ const deserializeAws_queryInvalidIdentityTokenException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -1399,7 +1400,7 @@ const deserializeAws_queryMalformedPolicyDocumentException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -1412,7 +1413,7 @@ const deserializeAws_queryPackedPolicyTooLargeException = (
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };
@@ -1422,7 +1423,7 @@ const deserializeAws_queryRegionDisabledException = (output: any, context: __Ser
     message: undefined,
   };
   if (output["message"] !== undefined) {
-    contents.message = output["message"];
+    contents.message = __expectString(output["message"]);
   }
   return contents;
 };

--- a/clients/client-support/protocols/Aws_json1_1.ts
+++ b/clients/client-support/protocols/Aws_json1_1.ts
@@ -95,7 +95,12 @@ import {
   TrustedAdvisorResourcesSummary,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -1524,9 +1529,8 @@ const deserializeAws_json1_1AddAttachmentsToSetResponse = (
   context: __SerdeContext
 ): AddAttachmentsToSetResponse => {
   return {
-    attachmentSetId:
-      output.attachmentSetId !== undefined && output.attachmentSetId !== null ? output.attachmentSetId : undefined,
-    expiryTime: output.expiryTime !== undefined && output.expiryTime !== null ? output.expiryTime : undefined,
+    attachmentSetId: __expectString(output.attachmentSetId),
+    expiryTime: __expectString(output.expiryTime),
   } as any;
 };
 
@@ -1535,27 +1539,27 @@ const deserializeAws_json1_1AddCommunicationToCaseResponse = (
   context: __SerdeContext
 ): AddCommunicationToCaseResponse => {
   return {
-    result: output.result !== undefined && output.result !== null ? output.result : undefined,
+    result: __expectBoolean(output.result),
   } as any;
 };
 
 const deserializeAws_json1_1Attachment = (output: any, context: __SerdeContext): Attachment => {
   return {
     data: output.data !== undefined && output.data !== null ? context.base64Decoder(output.data) : undefined,
-    fileName: output.fileName !== undefined && output.fileName !== null ? output.fileName : undefined,
+    fileName: __expectString(output.fileName),
   } as any;
 };
 
 const deserializeAws_json1_1AttachmentDetails = (output: any, context: __SerdeContext): AttachmentDetails => {
   return {
-    attachmentId: output.attachmentId !== undefined && output.attachmentId !== null ? output.attachmentId : undefined,
-    fileName: output.fileName !== undefined && output.fileName !== null ? output.fileName : undefined,
+    attachmentId: __expectString(output.attachmentId),
+    fileName: __expectString(output.fileName),
   } as any;
 };
 
 const deserializeAws_json1_1AttachmentIdNotFound = (output: any, context: __SerdeContext): AttachmentIdNotFound => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -1564,7 +1568,7 @@ const deserializeAws_json1_1AttachmentLimitExceeded = (
   context: __SerdeContext
 ): AttachmentLimitExceeded => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -1581,7 +1585,7 @@ const deserializeAws_json1_1AttachmentSet = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1AttachmentSetExpired = (output: any, context: __SerdeContext): AttachmentSetExpired => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -1590,7 +1594,7 @@ const deserializeAws_json1_1AttachmentSetIdNotFound = (
   context: __SerdeContext
 ): AttachmentSetIdNotFound => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -1599,7 +1603,7 @@ const deserializeAws_json1_1AttachmentSetSizeLimitExceeded = (
   context: __SerdeContext
 ): AttachmentSetSizeLimitExceeded => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -1608,36 +1612,36 @@ const deserializeAws_json1_1CaseCreationLimitExceeded = (
   context: __SerdeContext
 ): CaseCreationLimitExceeded => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1CaseDetails = (output: any, context: __SerdeContext): CaseDetails => {
   return {
-    caseId: output.caseId !== undefined && output.caseId !== null ? output.caseId : undefined,
-    categoryCode: output.categoryCode !== undefined && output.categoryCode !== null ? output.categoryCode : undefined,
+    caseId: __expectString(output.caseId),
+    categoryCode: __expectString(output.categoryCode),
     ccEmailAddresses:
       output.ccEmailAddresses !== undefined && output.ccEmailAddresses !== null
         ? deserializeAws_json1_1CcEmailAddressList(output.ccEmailAddresses, context)
         : undefined,
-    displayId: output.displayId !== undefined && output.displayId !== null ? output.displayId : undefined,
-    language: output.language !== undefined && output.language !== null ? output.language : undefined,
+    displayId: __expectString(output.displayId),
+    language: __expectString(output.language),
     recentCommunications:
       output.recentCommunications !== undefined && output.recentCommunications !== null
         ? deserializeAws_json1_1RecentCaseCommunications(output.recentCommunications, context)
         : undefined,
-    serviceCode: output.serviceCode !== undefined && output.serviceCode !== null ? output.serviceCode : undefined,
-    severityCode: output.severityCode !== undefined && output.severityCode !== null ? output.severityCode : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    subject: output.subject !== undefined && output.subject !== null ? output.subject : undefined,
-    submittedBy: output.submittedBy !== undefined && output.submittedBy !== null ? output.submittedBy : undefined,
-    timeCreated: output.timeCreated !== undefined && output.timeCreated !== null ? output.timeCreated : undefined,
+    serviceCode: __expectString(output.serviceCode),
+    severityCode: __expectString(output.severityCode),
+    status: __expectString(output.status),
+    subject: __expectString(output.subject),
+    submittedBy: __expectString(output.submittedBy),
+    timeCreated: __expectString(output.timeCreated),
   } as any;
 };
 
 const deserializeAws_json1_1CaseIdNotFound = (output: any, context: __SerdeContext): CaseIdNotFound => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -1654,8 +1658,8 @@ const deserializeAws_json1_1CaseList = (output: any, context: __SerdeContext): C
 
 const deserializeAws_json1_1Category = (output: any, context: __SerdeContext): Category => {
   return {
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    code: __expectString(output.code),
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -1677,7 +1681,7 @@ const deserializeAws_json1_1CcEmailAddressList = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -1687,10 +1691,10 @@ const deserializeAws_json1_1Communication = (output: any, context: __SerdeContex
       output.attachmentSet !== undefined && output.attachmentSet !== null
         ? deserializeAws_json1_1AttachmentSet(output.attachmentSet, context)
         : undefined,
-    body: output.body !== undefined && output.body !== null ? output.body : undefined,
-    caseId: output.caseId !== undefined && output.caseId !== null ? output.caseId : undefined,
-    submittedBy: output.submittedBy !== undefined && output.submittedBy !== null ? output.submittedBy : undefined,
-    timeCreated: output.timeCreated !== undefined && output.timeCreated !== null ? output.timeCreated : undefined,
+    body: __expectString(output.body),
+    caseId: __expectString(output.caseId),
+    submittedBy: __expectString(output.submittedBy),
+    timeCreated: __expectString(output.timeCreated),
   } as any;
 };
 
@@ -1707,7 +1711,7 @@ const deserializeAws_json1_1CommunicationList = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1CreateCaseResponse = (output: any, context: __SerdeContext): CreateCaseResponse => {
   return {
-    caseId: output.caseId !== undefined && output.caseId !== null ? output.caseId : undefined,
+    caseId: __expectString(output.caseId),
   } as any;
 };
 
@@ -1716,7 +1720,7 @@ const deserializeAws_json1_1DescribeAttachmentLimitExceeded = (
   context: __SerdeContext
 ): DescribeAttachmentLimitExceeded => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -1738,7 +1742,7 @@ const deserializeAws_json1_1DescribeCasesResponse = (output: any, context: __Ser
       output.cases !== undefined && output.cases !== null
         ? deserializeAws_json1_1CaseList(output.cases, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -1751,7 +1755,7 @@ const deserializeAws_json1_1DescribeCommunicationsResponse = (
       output.communications !== undefined && output.communications !== null
         ? deserializeAws_json1_1CommunicationList(output.communications, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -1829,7 +1833,7 @@ const deserializeAws_json1_1DescribeTrustedAdvisorCheckSummariesResponse = (
 
 const deserializeAws_json1_1InternalServerError = (output: any, context: __SerdeContext): InternalServerError => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -1842,7 +1846,7 @@ const deserializeAws_json1_1RecentCaseCommunications = (
       output.communications !== undefined && output.communications !== null
         ? deserializeAws_json1_1CommunicationList(output.communications, context)
         : undefined,
-    nextToken: output.nextToken !== undefined && output.nextToken !== null ? output.nextToken : undefined,
+    nextToken: __expectString(output.nextToken),
   } as any;
 };
 
@@ -1860,12 +1864,8 @@ const deserializeAws_json1_1RefreshTrustedAdvisorCheckResponse = (
 
 const deserializeAws_json1_1ResolveCaseResponse = (output: any, context: __SerdeContext): ResolveCaseResponse => {
   return {
-    finalCaseStatus:
-      output.finalCaseStatus !== undefined && output.finalCaseStatus !== null ? output.finalCaseStatus : undefined,
-    initialCaseStatus:
-      output.initialCaseStatus !== undefined && output.initialCaseStatus !== null
-        ? output.initialCaseStatus
-        : undefined,
+    finalCaseStatus: __expectString(output.finalCaseStatus),
+    initialCaseStatus: __expectString(output.initialCaseStatus),
   } as any;
 };
 
@@ -1875,8 +1875,8 @@ const deserializeAws_json1_1Service = (output: any, context: __SerdeContext): Se
       output.categories !== undefined && output.categories !== null
         ? deserializeAws_json1_1CategoryList(output.categories, context)
         : undefined,
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    code: __expectString(output.code),
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -1893,8 +1893,8 @@ const deserializeAws_json1_1ServiceList = (output: any, context: __SerdeContext)
 
 const deserializeAws_json1_1SeverityLevel = (output: any, context: __SerdeContext): SeverityLevel => {
   return {
-    code: output.code !== undefined && output.code !== null ? output.code : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    code: __expectString(output.code),
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -1916,7 +1916,7 @@ const deserializeAws_json1_1StringList = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -1937,14 +1937,14 @@ const deserializeAws_json1_1TrustedAdvisorCheckDescription = (
   context: __SerdeContext
 ): TrustedAdvisorCheckDescription => {
   return {
-    category: output.category !== undefined && output.category !== null ? output.category : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
+    category: __expectString(output.category),
+    description: __expectString(output.description),
+    id: __expectString(output.id),
     metadata:
       output.metadata !== undefined && output.metadata !== null
         ? deserializeAws_json1_1StringList(output.metadata, context)
         : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -1967,12 +1967,9 @@ const deserializeAws_json1_1TrustedAdvisorCheckRefreshStatus = (
   context: __SerdeContext
 ): TrustedAdvisorCheckRefreshStatus => {
   return {
-    checkId: output.checkId !== undefined && output.checkId !== null ? output.checkId : undefined,
-    millisUntilNextRefreshable:
-      output.millisUntilNextRefreshable !== undefined && output.millisUntilNextRefreshable !== null
-        ? output.millisUntilNextRefreshable
-        : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    checkId: __expectString(output.checkId),
+    millisUntilNextRefreshable: __expectNumber(output.millisUntilNextRefreshable),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -1999,7 +1996,7 @@ const deserializeAws_json1_1TrustedAdvisorCheckResult = (
       output.categorySpecificSummary !== undefined && output.categorySpecificSummary !== null
         ? deserializeAws_json1_1TrustedAdvisorCategorySpecificSummary(output.categorySpecificSummary, context)
         : undefined,
-    checkId: output.checkId !== undefined && output.checkId !== null ? output.checkId : undefined,
+    checkId: __expectString(output.checkId),
     flaggedResources:
       output.flaggedResources !== undefined && output.flaggedResources !== null
         ? deserializeAws_json1_1TrustedAdvisorResourceDetailList(output.flaggedResources, context)
@@ -2008,8 +2005,8 @@ const deserializeAws_json1_1TrustedAdvisorCheckResult = (
       output.resourcesSummary !== undefined && output.resourcesSummary !== null
         ? deserializeAws_json1_1TrustedAdvisorResourcesSummary(output.resourcesSummary, context)
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    timestamp: output.timestamp !== undefined && output.timestamp !== null ? output.timestamp : undefined,
+    status: __expectString(output.status),
+    timestamp: __expectString(output.timestamp),
   } as any;
 };
 
@@ -2022,17 +2019,14 @@ const deserializeAws_json1_1TrustedAdvisorCheckSummary = (
       output.categorySpecificSummary !== undefined && output.categorySpecificSummary !== null
         ? deserializeAws_json1_1TrustedAdvisorCategorySpecificSummary(output.categorySpecificSummary, context)
         : undefined,
-    checkId: output.checkId !== undefined && output.checkId !== null ? output.checkId : undefined,
-    hasFlaggedResources:
-      output.hasFlaggedResources !== undefined && output.hasFlaggedResources !== null
-        ? output.hasFlaggedResources
-        : undefined,
+    checkId: __expectString(output.checkId),
+    hasFlaggedResources: __expectBoolean(output.hasFlaggedResources),
     resourcesSummary:
       output.resourcesSummary !== undefined && output.resourcesSummary !== null
         ? deserializeAws_json1_1TrustedAdvisorResourcesSummary(output.resourcesSummary, context)
         : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
-    timestamp: output.timestamp !== undefined && output.timestamp !== null ? output.timestamp : undefined,
+    status: __expectString(output.status),
+    timestamp: __expectString(output.timestamp),
   } as any;
 };
 
@@ -2055,14 +2049,8 @@ const deserializeAws_json1_1TrustedAdvisorCostOptimizingSummary = (
   context: __SerdeContext
 ): TrustedAdvisorCostOptimizingSummary => {
   return {
-    estimatedMonthlySavings:
-      output.estimatedMonthlySavings !== undefined && output.estimatedMonthlySavings !== null
-        ? output.estimatedMonthlySavings
-        : undefined,
-    estimatedPercentMonthlySavings:
-      output.estimatedPercentMonthlySavings !== undefined && output.estimatedPercentMonthlySavings !== null
-        ? output.estimatedPercentMonthlySavings
-        : undefined,
+    estimatedMonthlySavings: __expectNumber(output.estimatedMonthlySavings),
+    estimatedPercentMonthlySavings: __expectNumber(output.estimatedPercentMonthlySavings),
   } as any;
 };
 
@@ -2071,14 +2059,14 @@ const deserializeAws_json1_1TrustedAdvisorResourceDetail = (
   context: __SerdeContext
 ): TrustedAdvisorResourceDetail => {
   return {
-    isSuppressed: output.isSuppressed !== undefined && output.isSuppressed !== null ? output.isSuppressed : undefined,
+    isSuppressed: __expectBoolean(output.isSuppressed),
     metadata:
       output.metadata !== undefined && output.metadata !== null
         ? deserializeAws_json1_1StringList(output.metadata, context)
         : undefined,
-    region: output.region !== undefined && output.region !== null ? output.region : undefined,
-    resourceId: output.resourceId !== undefined && output.resourceId !== null ? output.resourceId : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    region: __expectString(output.region),
+    resourceId: __expectString(output.resourceId),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -2101,18 +2089,10 @@ const deserializeAws_json1_1TrustedAdvisorResourcesSummary = (
   context: __SerdeContext
 ): TrustedAdvisorResourcesSummary => {
   return {
-    resourcesFlagged:
-      output.resourcesFlagged !== undefined && output.resourcesFlagged !== null ? output.resourcesFlagged : undefined,
-    resourcesIgnored:
-      output.resourcesIgnored !== undefined && output.resourcesIgnored !== null ? output.resourcesIgnored : undefined,
-    resourcesProcessed:
-      output.resourcesProcessed !== undefined && output.resourcesProcessed !== null
-        ? output.resourcesProcessed
-        : undefined,
-    resourcesSuppressed:
-      output.resourcesSuppressed !== undefined && output.resourcesSuppressed !== null
-        ? output.resourcesSuppressed
-        : undefined,
+    resourcesFlagged: __expectNumber(output.resourcesFlagged),
+    resourcesIgnored: __expectNumber(output.resourcesIgnored),
+    resourcesProcessed: __expectNumber(output.resourcesProcessed),
+    resourcesSuppressed: __expectNumber(output.resourcesSuppressed),
   } as any;
 };
 

--- a/clients/client-swf/protocols/Aws_json1_0.ts
+++ b/clients/client-swf/protocols/Aws_json1_0.ts
@@ -273,7 +273,12 @@ import {
   WorkflowTypeInfos,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -4239,15 +4244,14 @@ const serializeAws_json1_0WorkflowTypeFilter = (input: WorkflowTypeFilter, conte
 
 const deserializeAws_json1_0ActivityTask = (output: any, context: __SerdeContext): ActivityTask => {
   return {
-    activityId: output.activityId !== undefined && output.activityId !== null ? output.activityId : undefined,
+    activityId: __expectString(output.activityId),
     activityType:
       output.activityType !== undefined && output.activityType !== null
         ? deserializeAws_json1_0ActivityType(output.activityType, context)
         : undefined,
-    input: output.input !== undefined && output.input !== null ? output.input : undefined,
-    startedEventId:
-      output.startedEventId !== undefined && output.startedEventId !== null ? output.startedEventId : undefined,
-    taskToken: output.taskToken !== undefined && output.taskToken !== null ? output.taskToken : undefined,
+    input: __expectString(output.input),
+    startedEventId: __expectNumber(output.startedEventId),
+    taskToken: __expectString(output.taskToken),
     workflowExecution:
       output.workflowExecution !== undefined && output.workflowExecution !== null
         ? deserializeAws_json1_0WorkflowExecution(output.workflowExecution, context)
@@ -4260,15 +4264,10 @@ const deserializeAws_json1_0ActivityTaskCanceledEventAttributes = (
   context: __SerdeContext
 ): ActivityTaskCanceledEventAttributes => {
   return {
-    details: output.details !== undefined && output.details !== null ? output.details : undefined,
-    latestCancelRequestedEventId:
-      output.latestCancelRequestedEventId !== undefined && output.latestCancelRequestedEventId !== null
-        ? output.latestCancelRequestedEventId
-        : undefined,
-    scheduledEventId:
-      output.scheduledEventId !== undefined && output.scheduledEventId !== null ? output.scheduledEventId : undefined,
-    startedEventId:
-      output.startedEventId !== undefined && output.startedEventId !== null ? output.startedEventId : undefined,
+    details: __expectString(output.details),
+    latestCancelRequestedEventId: __expectNumber(output.latestCancelRequestedEventId),
+    scheduledEventId: __expectNumber(output.scheduledEventId),
+    startedEventId: __expectNumber(output.startedEventId),
   } as any;
 };
 
@@ -4277,11 +4276,8 @@ const deserializeAws_json1_0ActivityTaskCancelRequestedEventAttributes = (
   context: __SerdeContext
 ): ActivityTaskCancelRequestedEventAttributes => {
   return {
-    activityId: output.activityId !== undefined && output.activityId !== null ? output.activityId : undefined,
-    decisionTaskCompletedEventId:
-      output.decisionTaskCompletedEventId !== undefined && output.decisionTaskCompletedEventId !== null
-        ? output.decisionTaskCompletedEventId
-        : undefined,
+    activityId: __expectString(output.activityId),
+    decisionTaskCompletedEventId: __expectNumber(output.decisionTaskCompletedEventId),
   } as any;
 };
 
@@ -4290,11 +4286,9 @@ const deserializeAws_json1_0ActivityTaskCompletedEventAttributes = (
   context: __SerdeContext
 ): ActivityTaskCompletedEventAttributes => {
   return {
-    result: output.result !== undefined && output.result !== null ? output.result : undefined,
-    scheduledEventId:
-      output.scheduledEventId !== undefined && output.scheduledEventId !== null ? output.scheduledEventId : undefined,
-    startedEventId:
-      output.startedEventId !== undefined && output.startedEventId !== null ? output.startedEventId : undefined,
+    result: __expectString(output.result),
+    scheduledEventId: __expectNumber(output.scheduledEventId),
+    startedEventId: __expectNumber(output.startedEventId),
   } as any;
 };
 
@@ -4303,12 +4297,10 @@ const deserializeAws_json1_0ActivityTaskFailedEventAttributes = (
   context: __SerdeContext
 ): ActivityTaskFailedEventAttributes => {
   return {
-    details: output.details !== undefined && output.details !== null ? output.details : undefined,
-    reason: output.reason !== undefined && output.reason !== null ? output.reason : undefined,
-    scheduledEventId:
-      output.scheduledEventId !== undefined && output.scheduledEventId !== null ? output.scheduledEventId : undefined,
-    startedEventId:
-      output.startedEventId !== undefined && output.startedEventId !== null ? output.startedEventId : undefined,
+    details: __expectString(output.details),
+    reason: __expectString(output.reason),
+    scheduledEventId: __expectNumber(output.scheduledEventId),
+    startedEventId: __expectNumber(output.startedEventId),
   } as any;
 };
 
@@ -4317,36 +4309,23 @@ const deserializeAws_json1_0ActivityTaskScheduledEventAttributes = (
   context: __SerdeContext
 ): ActivityTaskScheduledEventAttributes => {
   return {
-    activityId: output.activityId !== undefined && output.activityId !== null ? output.activityId : undefined,
+    activityId: __expectString(output.activityId),
     activityType:
       output.activityType !== undefined && output.activityType !== null
         ? deserializeAws_json1_0ActivityType(output.activityType, context)
         : undefined,
-    control: output.control !== undefined && output.control !== null ? output.control : undefined,
-    decisionTaskCompletedEventId:
-      output.decisionTaskCompletedEventId !== undefined && output.decisionTaskCompletedEventId !== null
-        ? output.decisionTaskCompletedEventId
-        : undefined,
-    heartbeatTimeout:
-      output.heartbeatTimeout !== undefined && output.heartbeatTimeout !== null ? output.heartbeatTimeout : undefined,
-    input: output.input !== undefined && output.input !== null ? output.input : undefined,
-    scheduleToCloseTimeout:
-      output.scheduleToCloseTimeout !== undefined && output.scheduleToCloseTimeout !== null
-        ? output.scheduleToCloseTimeout
-        : undefined,
-    scheduleToStartTimeout:
-      output.scheduleToStartTimeout !== undefined && output.scheduleToStartTimeout !== null
-        ? output.scheduleToStartTimeout
-        : undefined,
-    startToCloseTimeout:
-      output.startToCloseTimeout !== undefined && output.startToCloseTimeout !== null
-        ? output.startToCloseTimeout
-        : undefined,
+    control: __expectString(output.control),
+    decisionTaskCompletedEventId: __expectNumber(output.decisionTaskCompletedEventId),
+    heartbeatTimeout: __expectString(output.heartbeatTimeout),
+    input: __expectString(output.input),
+    scheduleToCloseTimeout: __expectString(output.scheduleToCloseTimeout),
+    scheduleToStartTimeout: __expectString(output.scheduleToStartTimeout),
+    startToCloseTimeout: __expectString(output.startToCloseTimeout),
     taskList:
       output.taskList !== undefined && output.taskList !== null
         ? deserializeAws_json1_0TaskList(output.taskList, context)
         : undefined,
-    taskPriority: output.taskPriority !== undefined && output.taskPriority !== null ? output.taskPriority : undefined,
+    taskPriority: __expectString(output.taskPriority),
   } as any;
 };
 
@@ -4355,16 +4334,14 @@ const deserializeAws_json1_0ActivityTaskStartedEventAttributes = (
   context: __SerdeContext
 ): ActivityTaskStartedEventAttributes => {
   return {
-    identity: output.identity !== undefined && output.identity !== null ? output.identity : undefined,
-    scheduledEventId:
-      output.scheduledEventId !== undefined && output.scheduledEventId !== null ? output.scheduledEventId : undefined,
+    identity: __expectString(output.identity),
+    scheduledEventId: __expectNumber(output.scheduledEventId),
   } as any;
 };
 
 const deserializeAws_json1_0ActivityTaskStatus = (output: any, context: __SerdeContext): ActivityTaskStatus => {
   return {
-    cancelRequested:
-      output.cancelRequested !== undefined && output.cancelRequested !== null ? output.cancelRequested : undefined,
+    cancelRequested: __expectBoolean(output.cancelRequested),
   } as any;
 };
 
@@ -4373,19 +4350,17 @@ const deserializeAws_json1_0ActivityTaskTimedOutEventAttributes = (
   context: __SerdeContext
 ): ActivityTaskTimedOutEventAttributes => {
   return {
-    details: output.details !== undefined && output.details !== null ? output.details : undefined,
-    scheduledEventId:
-      output.scheduledEventId !== undefined && output.scheduledEventId !== null ? output.scheduledEventId : undefined,
-    startedEventId:
-      output.startedEventId !== undefined && output.startedEventId !== null ? output.startedEventId : undefined,
-    timeoutType: output.timeoutType !== undefined && output.timeoutType !== null ? output.timeoutType : undefined,
+    details: __expectString(output.details),
+    scheduledEventId: __expectNumber(output.scheduledEventId),
+    startedEventId: __expectNumber(output.startedEventId),
+    timeoutType: __expectString(output.timeoutType),
   } as any;
 };
 
 const deserializeAws_json1_0ActivityType = (output: any, context: __SerdeContext): ActivityType => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    name: __expectString(output.name),
+    version: __expectString(output.version),
   } as any;
 };
 
@@ -4394,30 +4369,15 @@ const deserializeAws_json1_0ActivityTypeConfiguration = (
   context: __SerdeContext
 ): ActivityTypeConfiguration => {
   return {
-    defaultTaskHeartbeatTimeout:
-      output.defaultTaskHeartbeatTimeout !== undefined && output.defaultTaskHeartbeatTimeout !== null
-        ? output.defaultTaskHeartbeatTimeout
-        : undefined,
+    defaultTaskHeartbeatTimeout: __expectString(output.defaultTaskHeartbeatTimeout),
     defaultTaskList:
       output.defaultTaskList !== undefined && output.defaultTaskList !== null
         ? deserializeAws_json1_0TaskList(output.defaultTaskList, context)
         : undefined,
-    defaultTaskPriority:
-      output.defaultTaskPriority !== undefined && output.defaultTaskPriority !== null
-        ? output.defaultTaskPriority
-        : undefined,
-    defaultTaskScheduleToCloseTimeout:
-      output.defaultTaskScheduleToCloseTimeout !== undefined && output.defaultTaskScheduleToCloseTimeout !== null
-        ? output.defaultTaskScheduleToCloseTimeout
-        : undefined,
-    defaultTaskScheduleToStartTimeout:
-      output.defaultTaskScheduleToStartTimeout !== undefined && output.defaultTaskScheduleToStartTimeout !== null
-        ? output.defaultTaskScheduleToStartTimeout
-        : undefined,
-    defaultTaskStartToCloseTimeout:
-      output.defaultTaskStartToCloseTimeout !== undefined && output.defaultTaskStartToCloseTimeout !== null
-        ? output.defaultTaskStartToCloseTimeout
-        : undefined,
+    defaultTaskPriority: __expectString(output.defaultTaskPriority),
+    defaultTaskScheduleToCloseTimeout: __expectString(output.defaultTaskScheduleToCloseTimeout),
+    defaultTaskScheduleToStartTimeout: __expectString(output.defaultTaskScheduleToStartTimeout),
+    defaultTaskStartToCloseTimeout: __expectString(output.defaultTaskStartToCloseTimeout),
   } as any;
 };
 
@@ -4448,8 +4408,8 @@ const deserializeAws_json1_0ActivityTypeInfo = (output: any, context: __SerdeCon
       output.deprecationDate !== undefined && output.deprecationDate !== null
         ? new Date(Math.round(output.deprecationDate * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    description: __expectString(output.description),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -4466,8 +4426,7 @@ const deserializeAws_json1_0ActivityTypeInfoList = (output: any, context: __Serd
 
 const deserializeAws_json1_0ActivityTypeInfos = (output: any, context: __SerdeContext): ActivityTypeInfos => {
   return {
-    nextPageToken:
-      output.nextPageToken !== undefined && output.nextPageToken !== null ? output.nextPageToken : undefined,
+    nextPageToken: __expectString(output.nextPageToken),
     typeInfos:
       output.typeInfos !== undefined && output.typeInfos !== null
         ? deserializeAws_json1_0ActivityTypeInfoList(output.typeInfos, context)
@@ -4480,12 +4439,9 @@ const deserializeAws_json1_0CancelTimerFailedEventAttributes = (
   context: __SerdeContext
 ): CancelTimerFailedEventAttributes => {
   return {
-    cause: output.cause !== undefined && output.cause !== null ? output.cause : undefined,
-    decisionTaskCompletedEventId:
-      output.decisionTaskCompletedEventId !== undefined && output.decisionTaskCompletedEventId !== null
-        ? output.decisionTaskCompletedEventId
-        : undefined,
-    timerId: output.timerId !== undefined && output.timerId !== null ? output.timerId : undefined,
+    cause: __expectString(output.cause),
+    decisionTaskCompletedEventId: __expectNumber(output.decisionTaskCompletedEventId),
+    timerId: __expectString(output.timerId),
   } as any;
 };
 
@@ -4494,11 +4450,8 @@ const deserializeAws_json1_0CancelWorkflowExecutionFailedEventAttributes = (
   context: __SerdeContext
 ): CancelWorkflowExecutionFailedEventAttributes => {
   return {
-    cause: output.cause !== undefined && output.cause !== null ? output.cause : undefined,
-    decisionTaskCompletedEventId:
-      output.decisionTaskCompletedEventId !== undefined && output.decisionTaskCompletedEventId !== null
-        ? output.decisionTaskCompletedEventId
-        : undefined,
+    cause: __expectString(output.cause),
+    decisionTaskCompletedEventId: __expectNumber(output.decisionTaskCompletedEventId),
   } as any;
 };
 
@@ -4507,11 +4460,9 @@ const deserializeAws_json1_0ChildWorkflowExecutionCanceledEventAttributes = (
   context: __SerdeContext
 ): ChildWorkflowExecutionCanceledEventAttributes => {
   return {
-    details: output.details !== undefined && output.details !== null ? output.details : undefined,
-    initiatedEventId:
-      output.initiatedEventId !== undefined && output.initiatedEventId !== null ? output.initiatedEventId : undefined,
-    startedEventId:
-      output.startedEventId !== undefined && output.startedEventId !== null ? output.startedEventId : undefined,
+    details: __expectString(output.details),
+    initiatedEventId: __expectNumber(output.initiatedEventId),
+    startedEventId: __expectNumber(output.startedEventId),
     workflowExecution:
       output.workflowExecution !== undefined && output.workflowExecution !== null
         ? deserializeAws_json1_0WorkflowExecution(output.workflowExecution, context)
@@ -4528,11 +4479,9 @@ const deserializeAws_json1_0ChildWorkflowExecutionCompletedEventAttributes = (
   context: __SerdeContext
 ): ChildWorkflowExecutionCompletedEventAttributes => {
   return {
-    initiatedEventId:
-      output.initiatedEventId !== undefined && output.initiatedEventId !== null ? output.initiatedEventId : undefined,
-    result: output.result !== undefined && output.result !== null ? output.result : undefined,
-    startedEventId:
-      output.startedEventId !== undefined && output.startedEventId !== null ? output.startedEventId : undefined,
+    initiatedEventId: __expectNumber(output.initiatedEventId),
+    result: __expectString(output.result),
+    startedEventId: __expectNumber(output.startedEventId),
     workflowExecution:
       output.workflowExecution !== undefined && output.workflowExecution !== null
         ? deserializeAws_json1_0WorkflowExecution(output.workflowExecution, context)
@@ -4549,12 +4498,10 @@ const deserializeAws_json1_0ChildWorkflowExecutionFailedEventAttributes = (
   context: __SerdeContext
 ): ChildWorkflowExecutionFailedEventAttributes => {
   return {
-    details: output.details !== undefined && output.details !== null ? output.details : undefined,
-    initiatedEventId:
-      output.initiatedEventId !== undefined && output.initiatedEventId !== null ? output.initiatedEventId : undefined,
-    reason: output.reason !== undefined && output.reason !== null ? output.reason : undefined,
-    startedEventId:
-      output.startedEventId !== undefined && output.startedEventId !== null ? output.startedEventId : undefined,
+    details: __expectString(output.details),
+    initiatedEventId: __expectNumber(output.initiatedEventId),
+    reason: __expectString(output.reason),
+    startedEventId: __expectNumber(output.startedEventId),
     workflowExecution:
       output.workflowExecution !== undefined && output.workflowExecution !== null
         ? deserializeAws_json1_0WorkflowExecution(output.workflowExecution, context)
@@ -4571,8 +4518,7 @@ const deserializeAws_json1_0ChildWorkflowExecutionStartedEventAttributes = (
   context: __SerdeContext
 ): ChildWorkflowExecutionStartedEventAttributes => {
   return {
-    initiatedEventId:
-      output.initiatedEventId !== undefined && output.initiatedEventId !== null ? output.initiatedEventId : undefined,
+    initiatedEventId: __expectNumber(output.initiatedEventId),
     workflowExecution:
       output.workflowExecution !== undefined && output.workflowExecution !== null
         ? deserializeAws_json1_0WorkflowExecution(output.workflowExecution, context)
@@ -4589,10 +4535,8 @@ const deserializeAws_json1_0ChildWorkflowExecutionTerminatedEventAttributes = (
   context: __SerdeContext
 ): ChildWorkflowExecutionTerminatedEventAttributes => {
   return {
-    initiatedEventId:
-      output.initiatedEventId !== undefined && output.initiatedEventId !== null ? output.initiatedEventId : undefined,
-    startedEventId:
-      output.startedEventId !== undefined && output.startedEventId !== null ? output.startedEventId : undefined,
+    initiatedEventId: __expectNumber(output.initiatedEventId),
+    startedEventId: __expectNumber(output.startedEventId),
     workflowExecution:
       output.workflowExecution !== undefined && output.workflowExecution !== null
         ? deserializeAws_json1_0WorkflowExecution(output.workflowExecution, context)
@@ -4609,11 +4553,9 @@ const deserializeAws_json1_0ChildWorkflowExecutionTimedOutEventAttributes = (
   context: __SerdeContext
 ): ChildWorkflowExecutionTimedOutEventAttributes => {
   return {
-    initiatedEventId:
-      output.initiatedEventId !== undefined && output.initiatedEventId !== null ? output.initiatedEventId : undefined,
-    startedEventId:
-      output.startedEventId !== undefined && output.startedEventId !== null ? output.startedEventId : undefined,
-    timeoutType: output.timeoutType !== undefined && output.timeoutType !== null ? output.timeoutType : undefined,
+    initiatedEventId: __expectNumber(output.initiatedEventId),
+    startedEventId: __expectNumber(output.startedEventId),
+    timeoutType: __expectString(output.timeoutType),
     workflowExecution:
       output.workflowExecution !== undefined && output.workflowExecution !== null
         ? deserializeAws_json1_0WorkflowExecution(output.workflowExecution, context)
@@ -4630,11 +4572,8 @@ const deserializeAws_json1_0CompleteWorkflowExecutionFailedEventAttributes = (
   context: __SerdeContext
 ): CompleteWorkflowExecutionFailedEventAttributes => {
   return {
-    cause: output.cause !== undefined && output.cause !== null ? output.cause : undefined,
-    decisionTaskCompletedEventId:
-      output.decisionTaskCompletedEventId !== undefined && output.decisionTaskCompletedEventId !== null
-        ? output.decisionTaskCompletedEventId
-        : undefined,
+    cause: __expectString(output.cause),
+    decisionTaskCompletedEventId: __expectNumber(output.decisionTaskCompletedEventId),
   } as any;
 };
 
@@ -4643,11 +4582,8 @@ const deserializeAws_json1_0ContinueAsNewWorkflowExecutionFailedEventAttributes 
   context: __SerdeContext
 ): ContinueAsNewWorkflowExecutionFailedEventAttributes => {
   return {
-    cause: output.cause !== undefined && output.cause !== null ? output.cause : undefined,
-    decisionTaskCompletedEventId:
-      output.decisionTaskCompletedEventId !== undefined && output.decisionTaskCompletedEventId !== null
-        ? output.decisionTaskCompletedEventId
-        : undefined,
+    cause: __expectString(output.cause),
+    decisionTaskCompletedEventId: __expectNumber(output.decisionTaskCompletedEventId),
   } as any;
 };
 
@@ -4657,15 +4593,10 @@ const deserializeAws_json1_0DecisionTask = (output: any, context: __SerdeContext
       output.events !== undefined && output.events !== null
         ? deserializeAws_json1_0HistoryEventList(output.events, context)
         : undefined,
-    nextPageToken:
-      output.nextPageToken !== undefined && output.nextPageToken !== null ? output.nextPageToken : undefined,
-    previousStartedEventId:
-      output.previousStartedEventId !== undefined && output.previousStartedEventId !== null
-        ? output.previousStartedEventId
-        : undefined,
-    startedEventId:
-      output.startedEventId !== undefined && output.startedEventId !== null ? output.startedEventId : undefined,
-    taskToken: output.taskToken !== undefined && output.taskToken !== null ? output.taskToken : undefined,
+    nextPageToken: __expectString(output.nextPageToken),
+    previousStartedEventId: __expectNumber(output.previousStartedEventId),
+    startedEventId: __expectNumber(output.startedEventId),
+    taskToken: __expectString(output.taskToken),
     workflowExecution:
       output.workflowExecution !== undefined && output.workflowExecution !== null
         ? deserializeAws_json1_0WorkflowExecution(output.workflowExecution, context)
@@ -4682,12 +4613,9 @@ const deserializeAws_json1_0DecisionTaskCompletedEventAttributes = (
   context: __SerdeContext
 ): DecisionTaskCompletedEventAttributes => {
   return {
-    executionContext:
-      output.executionContext !== undefined && output.executionContext !== null ? output.executionContext : undefined,
-    scheduledEventId:
-      output.scheduledEventId !== undefined && output.scheduledEventId !== null ? output.scheduledEventId : undefined,
-    startedEventId:
-      output.startedEventId !== undefined && output.startedEventId !== null ? output.startedEventId : undefined,
+    executionContext: __expectString(output.executionContext),
+    scheduledEventId: __expectNumber(output.scheduledEventId),
+    startedEventId: __expectNumber(output.startedEventId),
   } as any;
 };
 
@@ -4696,15 +4624,12 @@ const deserializeAws_json1_0DecisionTaskScheduledEventAttributes = (
   context: __SerdeContext
 ): DecisionTaskScheduledEventAttributes => {
   return {
-    startToCloseTimeout:
-      output.startToCloseTimeout !== undefined && output.startToCloseTimeout !== null
-        ? output.startToCloseTimeout
-        : undefined,
+    startToCloseTimeout: __expectString(output.startToCloseTimeout),
     taskList:
       output.taskList !== undefined && output.taskList !== null
         ? deserializeAws_json1_0TaskList(output.taskList, context)
         : undefined,
-    taskPriority: output.taskPriority !== undefined && output.taskPriority !== null ? output.taskPriority : undefined,
+    taskPriority: __expectString(output.taskPriority),
   } as any;
 };
 
@@ -4713,9 +4638,8 @@ const deserializeAws_json1_0DecisionTaskStartedEventAttributes = (
   context: __SerdeContext
 ): DecisionTaskStartedEventAttributes => {
   return {
-    identity: output.identity !== undefined && output.identity !== null ? output.identity : undefined,
-    scheduledEventId:
-      output.scheduledEventId !== undefined && output.scheduledEventId !== null ? output.scheduledEventId : undefined,
+    identity: __expectString(output.identity),
+    scheduledEventId: __expectNumber(output.scheduledEventId),
   } as any;
 };
 
@@ -4724,17 +4648,15 @@ const deserializeAws_json1_0DecisionTaskTimedOutEventAttributes = (
   context: __SerdeContext
 ): DecisionTaskTimedOutEventAttributes => {
   return {
-    scheduledEventId:
-      output.scheduledEventId !== undefined && output.scheduledEventId !== null ? output.scheduledEventId : undefined,
-    startedEventId:
-      output.startedEventId !== undefined && output.startedEventId !== null ? output.startedEventId : undefined,
-    timeoutType: output.timeoutType !== undefined && output.timeoutType !== null ? output.timeoutType : undefined,
+    scheduledEventId: __expectNumber(output.scheduledEventId),
+    startedEventId: __expectNumber(output.startedEventId),
+    timeoutType: __expectString(output.timeoutType),
   } as any;
 };
 
 const deserializeAws_json1_0DefaultUndefinedFault = (output: any, context: __SerdeContext): DefaultUndefinedFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -4743,23 +4665,19 @@ const deserializeAws_json1_0DomainAlreadyExistsFault = (
   context: __SerdeContext
 ): DomainAlreadyExistsFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_0DomainConfiguration = (output: any, context: __SerdeContext): DomainConfiguration => {
   return {
-    workflowExecutionRetentionPeriodInDays:
-      output.workflowExecutionRetentionPeriodInDays !== undefined &&
-      output.workflowExecutionRetentionPeriodInDays !== null
-        ? output.workflowExecutionRetentionPeriodInDays
-        : undefined,
+    workflowExecutionRetentionPeriodInDays: __expectString(output.workflowExecutionRetentionPeriodInDays),
   } as any;
 };
 
 const deserializeAws_json1_0DomainDeprecatedFault = (output: any, context: __SerdeContext): DomainDeprecatedFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -4778,10 +4696,10 @@ const deserializeAws_json1_0DomainDetail = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_0DomainInfo = (output: any, context: __SerdeContext): DomainInfo => {
   return {
-    arn: output.arn !== undefined && output.arn !== null ? output.arn : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    arn: __expectString(output.arn),
+    description: __expectString(output.description),
+    name: __expectString(output.name),
+    status: __expectString(output.status),
   } as any;
 };
 
@@ -4802,8 +4720,7 @@ const deserializeAws_json1_0DomainInfos = (output: any, context: __SerdeContext)
       output.domainInfos !== undefined && output.domainInfos !== null
         ? deserializeAws_json1_0DomainInfoList(output.domainInfos, context)
         : undefined,
-    nextPageToken:
-      output.nextPageToken !== undefined && output.nextPageToken !== null ? output.nextPageToken : undefined,
+    nextPageToken: __expectString(output.nextPageToken),
   } as any;
 };
 
@@ -4812,8 +4729,7 @@ const deserializeAws_json1_0ExternalWorkflowExecutionCancelRequestedEventAttribu
   context: __SerdeContext
 ): ExternalWorkflowExecutionCancelRequestedEventAttributes => {
   return {
-    initiatedEventId:
-      output.initiatedEventId !== undefined && output.initiatedEventId !== null ? output.initiatedEventId : undefined,
+    initiatedEventId: __expectNumber(output.initiatedEventId),
     workflowExecution:
       output.workflowExecution !== undefined && output.workflowExecution !== null
         ? deserializeAws_json1_0WorkflowExecution(output.workflowExecution, context)
@@ -4826,8 +4742,7 @@ const deserializeAws_json1_0ExternalWorkflowExecutionSignaledEventAttributes = (
   context: __SerdeContext
 ): ExternalWorkflowExecutionSignaledEventAttributes => {
   return {
-    initiatedEventId:
-      output.initiatedEventId !== undefined && output.initiatedEventId !== null ? output.initiatedEventId : undefined,
+    initiatedEventId: __expectNumber(output.initiatedEventId),
     workflowExecution:
       output.workflowExecution !== undefined && output.workflowExecution !== null
         ? deserializeAws_json1_0WorkflowExecution(output.workflowExecution, context)
@@ -4840,11 +4755,8 @@ const deserializeAws_json1_0FailWorkflowExecutionFailedEventAttributes = (
   context: __SerdeContext
 ): FailWorkflowExecutionFailedEventAttributes => {
   return {
-    cause: output.cause !== undefined && output.cause !== null ? output.cause : undefined,
-    decisionTaskCompletedEventId:
-      output.decisionTaskCompletedEventId !== undefined && output.decisionTaskCompletedEventId !== null
-        ? output.decisionTaskCompletedEventId
-        : undefined,
+    cause: __expectString(output.cause),
+    decisionTaskCompletedEventId: __expectNumber(output.decisionTaskCompletedEventId),
   } as any;
 };
 
@@ -4854,8 +4766,7 @@ const deserializeAws_json1_0History = (output: any, context: __SerdeContext): Hi
       output.events !== undefined && output.events !== null
         ? deserializeAws_json1_0HistoryEventList(output.events, context)
         : undefined,
-    nextPageToken:
-      output.nextPageToken !== undefined && output.nextPageToken !== null ? output.nextPageToken : undefined,
+    nextPageToken: __expectString(output.nextPageToken),
   } as any;
 };
 
@@ -4997,12 +4908,12 @@ const deserializeAws_json1_0HistoryEvent = (output: any, context: __SerdeContext
       output.decisionTaskTimedOutEventAttributes !== undefined && output.decisionTaskTimedOutEventAttributes !== null
         ? deserializeAws_json1_0DecisionTaskTimedOutEventAttributes(output.decisionTaskTimedOutEventAttributes, context)
         : undefined,
-    eventId: output.eventId !== undefined && output.eventId !== null ? output.eventId : undefined,
+    eventId: __expectNumber(output.eventId),
     eventTimestamp:
       output.eventTimestamp !== undefined && output.eventTimestamp !== null
         ? new Date(Math.round(output.eventTimestamp * 1000))
         : undefined,
-    eventType: output.eventType !== undefined && output.eventType !== null ? output.eventType : undefined,
+    eventType: __expectString(output.eventType),
     externalWorkflowExecutionCancelRequestedEventAttributes:
       output.externalWorkflowExecutionCancelRequestedEventAttributes !== undefined &&
       output.externalWorkflowExecutionCancelRequestedEventAttributes !== null
@@ -5257,11 +5168,9 @@ const deserializeAws_json1_0LambdaFunctionCompletedEventAttributes = (
   context: __SerdeContext
 ): LambdaFunctionCompletedEventAttributes => {
   return {
-    result: output.result !== undefined && output.result !== null ? output.result : undefined,
-    scheduledEventId:
-      output.scheduledEventId !== undefined && output.scheduledEventId !== null ? output.scheduledEventId : undefined,
-    startedEventId:
-      output.startedEventId !== undefined && output.startedEventId !== null ? output.startedEventId : undefined,
+    result: __expectString(output.result),
+    scheduledEventId: __expectNumber(output.scheduledEventId),
+    startedEventId: __expectNumber(output.startedEventId),
   } as any;
 };
 
@@ -5270,12 +5179,10 @@ const deserializeAws_json1_0LambdaFunctionFailedEventAttributes = (
   context: __SerdeContext
 ): LambdaFunctionFailedEventAttributes => {
   return {
-    details: output.details !== undefined && output.details !== null ? output.details : undefined,
-    reason: output.reason !== undefined && output.reason !== null ? output.reason : undefined,
-    scheduledEventId:
-      output.scheduledEventId !== undefined && output.scheduledEventId !== null ? output.scheduledEventId : undefined,
-    startedEventId:
-      output.startedEventId !== undefined && output.startedEventId !== null ? output.startedEventId : undefined,
+    details: __expectString(output.details),
+    reason: __expectString(output.reason),
+    scheduledEventId: __expectNumber(output.scheduledEventId),
+    startedEventId: __expectNumber(output.startedEventId),
   } as any;
 };
 
@@ -5284,18 +5191,12 @@ const deserializeAws_json1_0LambdaFunctionScheduledEventAttributes = (
   context: __SerdeContext
 ): LambdaFunctionScheduledEventAttributes => {
   return {
-    control: output.control !== undefined && output.control !== null ? output.control : undefined,
-    decisionTaskCompletedEventId:
-      output.decisionTaskCompletedEventId !== undefined && output.decisionTaskCompletedEventId !== null
-        ? output.decisionTaskCompletedEventId
-        : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    input: output.input !== undefined && output.input !== null ? output.input : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    startToCloseTimeout:
-      output.startToCloseTimeout !== undefined && output.startToCloseTimeout !== null
-        ? output.startToCloseTimeout
-        : undefined,
+    control: __expectString(output.control),
+    decisionTaskCompletedEventId: __expectNumber(output.decisionTaskCompletedEventId),
+    id: __expectString(output.id),
+    input: __expectString(output.input),
+    name: __expectString(output.name),
+    startToCloseTimeout: __expectString(output.startToCloseTimeout),
   } as any;
 };
 
@@ -5304,8 +5205,7 @@ const deserializeAws_json1_0LambdaFunctionStartedEventAttributes = (
   context: __SerdeContext
 ): LambdaFunctionStartedEventAttributes => {
   return {
-    scheduledEventId:
-      output.scheduledEventId !== undefined && output.scheduledEventId !== null ? output.scheduledEventId : undefined,
+    scheduledEventId: __expectNumber(output.scheduledEventId),
   } as any;
 };
 
@@ -5314,17 +5214,15 @@ const deserializeAws_json1_0LambdaFunctionTimedOutEventAttributes = (
   context: __SerdeContext
 ): LambdaFunctionTimedOutEventAttributes => {
   return {
-    scheduledEventId:
-      output.scheduledEventId !== undefined && output.scheduledEventId !== null ? output.scheduledEventId : undefined,
-    startedEventId:
-      output.startedEventId !== undefined && output.startedEventId !== null ? output.startedEventId : undefined,
-    timeoutType: output.timeoutType !== undefined && output.timeoutType !== null ? output.timeoutType : undefined,
+    scheduledEventId: __expectNumber(output.scheduledEventId),
+    startedEventId: __expectNumber(output.startedEventId),
+    timeoutType: __expectString(output.timeoutType),
   } as any;
 };
 
 const deserializeAws_json1_0LimitExceededFault = (output: any, context: __SerdeContext): LimitExceededFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -5345,12 +5243,9 @@ const deserializeAws_json1_0MarkerRecordedEventAttributes = (
   context: __SerdeContext
 ): MarkerRecordedEventAttributes => {
   return {
-    decisionTaskCompletedEventId:
-      output.decisionTaskCompletedEventId !== undefined && output.decisionTaskCompletedEventId !== null
-        ? output.decisionTaskCompletedEventId
-        : undefined,
-    details: output.details !== undefined && output.details !== null ? output.details : undefined,
-    markerName: output.markerName !== undefined && output.markerName !== null ? output.markerName : undefined,
+    decisionTaskCompletedEventId: __expectNumber(output.decisionTaskCompletedEventId),
+    details: __expectString(output.details),
+    markerName: __expectString(output.markerName),
   } as any;
 };
 
@@ -5359,14 +5254,14 @@ const deserializeAws_json1_0OperationNotPermittedFault = (
   context: __SerdeContext
 ): OperationNotPermittedFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_0PendingTaskCount = (output: any, context: __SerdeContext): PendingTaskCount => {
   return {
-    count: output.count !== undefined && output.count !== null ? output.count : undefined,
-    truncated: output.truncated !== undefined && output.truncated !== null ? output.truncated : undefined,
+    count: __expectNumber(output.count),
+    truncated: __expectBoolean(output.truncated),
   } as any;
 };
 
@@ -5375,12 +5270,9 @@ const deserializeAws_json1_0RecordMarkerFailedEventAttributes = (
   context: __SerdeContext
 ): RecordMarkerFailedEventAttributes => {
   return {
-    cause: output.cause !== undefined && output.cause !== null ? output.cause : undefined,
-    decisionTaskCompletedEventId:
-      output.decisionTaskCompletedEventId !== undefined && output.decisionTaskCompletedEventId !== null
-        ? output.decisionTaskCompletedEventId
-        : undefined,
-    markerName: output.markerName !== undefined && output.markerName !== null ? output.markerName : undefined,
+    cause: __expectString(output.cause),
+    decisionTaskCompletedEventId: __expectNumber(output.decisionTaskCompletedEventId),
+    markerName: __expectString(output.markerName),
   } as any;
 };
 
@@ -5389,12 +5281,9 @@ const deserializeAws_json1_0RequestCancelActivityTaskFailedEventAttributes = (
   context: __SerdeContext
 ): RequestCancelActivityTaskFailedEventAttributes => {
   return {
-    activityId: output.activityId !== undefined && output.activityId !== null ? output.activityId : undefined,
-    cause: output.cause !== undefined && output.cause !== null ? output.cause : undefined,
-    decisionTaskCompletedEventId:
-      output.decisionTaskCompletedEventId !== undefined && output.decisionTaskCompletedEventId !== null
-        ? output.decisionTaskCompletedEventId
-        : undefined,
+    activityId: __expectString(output.activityId),
+    cause: __expectString(output.cause),
+    decisionTaskCompletedEventId: __expectNumber(output.decisionTaskCompletedEventId),
   } as any;
 };
 
@@ -5403,16 +5292,12 @@ const deserializeAws_json1_0RequestCancelExternalWorkflowExecutionFailedEventAtt
   context: __SerdeContext
 ): RequestCancelExternalWorkflowExecutionFailedEventAttributes => {
   return {
-    cause: output.cause !== undefined && output.cause !== null ? output.cause : undefined,
-    control: output.control !== undefined && output.control !== null ? output.control : undefined,
-    decisionTaskCompletedEventId:
-      output.decisionTaskCompletedEventId !== undefined && output.decisionTaskCompletedEventId !== null
-        ? output.decisionTaskCompletedEventId
-        : undefined,
-    initiatedEventId:
-      output.initiatedEventId !== undefined && output.initiatedEventId !== null ? output.initiatedEventId : undefined,
-    runId: output.runId !== undefined && output.runId !== null ? output.runId : undefined,
-    workflowId: output.workflowId !== undefined && output.workflowId !== null ? output.workflowId : undefined,
+    cause: __expectString(output.cause),
+    control: __expectString(output.control),
+    decisionTaskCompletedEventId: __expectNumber(output.decisionTaskCompletedEventId),
+    initiatedEventId: __expectNumber(output.initiatedEventId),
+    runId: __expectString(output.runId),
+    workflowId: __expectString(output.workflowId),
   } as any;
 };
 
@@ -5421,20 +5306,17 @@ const deserializeAws_json1_0RequestCancelExternalWorkflowExecutionInitiatedEvent
   context: __SerdeContext
 ): RequestCancelExternalWorkflowExecutionInitiatedEventAttributes => {
   return {
-    control: output.control !== undefined && output.control !== null ? output.control : undefined,
-    decisionTaskCompletedEventId:
-      output.decisionTaskCompletedEventId !== undefined && output.decisionTaskCompletedEventId !== null
-        ? output.decisionTaskCompletedEventId
-        : undefined,
-    runId: output.runId !== undefined && output.runId !== null ? output.runId : undefined,
-    workflowId: output.workflowId !== undefined && output.workflowId !== null ? output.workflowId : undefined,
+    control: __expectString(output.control),
+    decisionTaskCompletedEventId: __expectNumber(output.decisionTaskCompletedEventId),
+    runId: __expectString(output.runId),
+    workflowId: __expectString(output.workflowId),
   } as any;
 };
 
 const deserializeAws_json1_0ResourceTag = (output: any, context: __SerdeContext): ResourceTag => {
   return {
-    key: output.key !== undefined && output.key !== null ? output.key : undefined,
-    value: output.value !== undefined && output.value !== null ? output.value : undefined,
+    key: __expectString(output.key),
+    value: __expectString(output.value),
   } as any;
 };
 
@@ -5451,7 +5333,7 @@ const deserializeAws_json1_0ResourceTagList = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_0Run = (output: any, context: __SerdeContext): Run => {
   return {
-    runId: output.runId !== undefined && output.runId !== null ? output.runId : undefined,
+    runId: __expectString(output.runId),
   } as any;
 };
 
@@ -5460,16 +5342,13 @@ const deserializeAws_json1_0ScheduleActivityTaskFailedEventAttributes = (
   context: __SerdeContext
 ): ScheduleActivityTaskFailedEventAttributes => {
   return {
-    activityId: output.activityId !== undefined && output.activityId !== null ? output.activityId : undefined,
+    activityId: __expectString(output.activityId),
     activityType:
       output.activityType !== undefined && output.activityType !== null
         ? deserializeAws_json1_0ActivityType(output.activityType, context)
         : undefined,
-    cause: output.cause !== undefined && output.cause !== null ? output.cause : undefined,
-    decisionTaskCompletedEventId:
-      output.decisionTaskCompletedEventId !== undefined && output.decisionTaskCompletedEventId !== null
-        ? output.decisionTaskCompletedEventId
-        : undefined,
+    cause: __expectString(output.cause),
+    decisionTaskCompletedEventId: __expectNumber(output.decisionTaskCompletedEventId),
   } as any;
 };
 
@@ -5478,13 +5357,10 @@ const deserializeAws_json1_0ScheduleLambdaFunctionFailedEventAttributes = (
   context: __SerdeContext
 ): ScheduleLambdaFunctionFailedEventAttributes => {
   return {
-    cause: output.cause !== undefined && output.cause !== null ? output.cause : undefined,
-    decisionTaskCompletedEventId:
-      output.decisionTaskCompletedEventId !== undefined && output.decisionTaskCompletedEventId !== null
-        ? output.decisionTaskCompletedEventId
-        : undefined,
-    id: output.id !== undefined && output.id !== null ? output.id : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    cause: __expectString(output.cause),
+    decisionTaskCompletedEventId: __expectNumber(output.decisionTaskCompletedEventId),
+    id: __expectString(output.id),
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -5493,16 +5369,12 @@ const deserializeAws_json1_0SignalExternalWorkflowExecutionFailedEventAttributes
   context: __SerdeContext
 ): SignalExternalWorkflowExecutionFailedEventAttributes => {
   return {
-    cause: output.cause !== undefined && output.cause !== null ? output.cause : undefined,
-    control: output.control !== undefined && output.control !== null ? output.control : undefined,
-    decisionTaskCompletedEventId:
-      output.decisionTaskCompletedEventId !== undefined && output.decisionTaskCompletedEventId !== null
-        ? output.decisionTaskCompletedEventId
-        : undefined,
-    initiatedEventId:
-      output.initiatedEventId !== undefined && output.initiatedEventId !== null ? output.initiatedEventId : undefined,
-    runId: output.runId !== undefined && output.runId !== null ? output.runId : undefined,
-    workflowId: output.workflowId !== undefined && output.workflowId !== null ? output.workflowId : undefined,
+    cause: __expectString(output.cause),
+    control: __expectString(output.control),
+    decisionTaskCompletedEventId: __expectNumber(output.decisionTaskCompletedEventId),
+    initiatedEventId: __expectNumber(output.initiatedEventId),
+    runId: __expectString(output.runId),
+    workflowId: __expectString(output.workflowId),
   } as any;
 };
 
@@ -5511,15 +5383,12 @@ const deserializeAws_json1_0SignalExternalWorkflowExecutionInitiatedEventAttribu
   context: __SerdeContext
 ): SignalExternalWorkflowExecutionInitiatedEventAttributes => {
   return {
-    control: output.control !== undefined && output.control !== null ? output.control : undefined,
-    decisionTaskCompletedEventId:
-      output.decisionTaskCompletedEventId !== undefined && output.decisionTaskCompletedEventId !== null
-        ? output.decisionTaskCompletedEventId
-        : undefined,
-    input: output.input !== undefined && output.input !== null ? output.input : undefined,
-    runId: output.runId !== undefined && output.runId !== null ? output.runId : undefined,
-    signalName: output.signalName !== undefined && output.signalName !== null ? output.signalName : undefined,
-    workflowId: output.workflowId !== undefined && output.workflowId !== null ? output.workflowId : undefined,
+    control: __expectString(output.control),
+    decisionTaskCompletedEventId: __expectNumber(output.decisionTaskCompletedEventId),
+    input: __expectString(output.input),
+    runId: __expectString(output.runId),
+    signalName: __expectString(output.signalName),
+    workflowId: __expectString(output.workflowId),
   } as any;
 };
 
@@ -5528,15 +5397,11 @@ const deserializeAws_json1_0StartChildWorkflowExecutionFailedEventAttributes = (
   context: __SerdeContext
 ): StartChildWorkflowExecutionFailedEventAttributes => {
   return {
-    cause: output.cause !== undefined && output.cause !== null ? output.cause : undefined,
-    control: output.control !== undefined && output.control !== null ? output.control : undefined,
-    decisionTaskCompletedEventId:
-      output.decisionTaskCompletedEventId !== undefined && output.decisionTaskCompletedEventId !== null
-        ? output.decisionTaskCompletedEventId
-        : undefined,
-    initiatedEventId:
-      output.initiatedEventId !== undefined && output.initiatedEventId !== null ? output.initiatedEventId : undefined,
-    workflowId: output.workflowId !== undefined && output.workflowId !== null ? output.workflowId : undefined,
+    cause: __expectString(output.cause),
+    control: __expectString(output.control),
+    decisionTaskCompletedEventId: __expectNumber(output.decisionTaskCompletedEventId),
+    initiatedEventId: __expectNumber(output.initiatedEventId),
+    workflowId: __expectString(output.workflowId),
     workflowType:
       output.workflowType !== undefined && output.workflowType !== null
         ? deserializeAws_json1_0WorkflowType(output.workflowType, context)
@@ -5549,18 +5414,12 @@ const deserializeAws_json1_0StartChildWorkflowExecutionInitiatedEventAttributes 
   context: __SerdeContext
 ): StartChildWorkflowExecutionInitiatedEventAttributes => {
   return {
-    childPolicy: output.childPolicy !== undefined && output.childPolicy !== null ? output.childPolicy : undefined,
-    control: output.control !== undefined && output.control !== null ? output.control : undefined,
-    decisionTaskCompletedEventId:
-      output.decisionTaskCompletedEventId !== undefined && output.decisionTaskCompletedEventId !== null
-        ? output.decisionTaskCompletedEventId
-        : undefined,
-    executionStartToCloseTimeout:
-      output.executionStartToCloseTimeout !== undefined && output.executionStartToCloseTimeout !== null
-        ? output.executionStartToCloseTimeout
-        : undefined,
-    input: output.input !== undefined && output.input !== null ? output.input : undefined,
-    lambdaRole: output.lambdaRole !== undefined && output.lambdaRole !== null ? output.lambdaRole : undefined,
+    childPolicy: __expectString(output.childPolicy),
+    control: __expectString(output.control),
+    decisionTaskCompletedEventId: __expectNumber(output.decisionTaskCompletedEventId),
+    executionStartToCloseTimeout: __expectString(output.executionStartToCloseTimeout),
+    input: __expectString(output.input),
+    lambdaRole: __expectString(output.lambdaRole),
     tagList:
       output.tagList !== undefined && output.tagList !== null
         ? deserializeAws_json1_0TagList(output.tagList, context)
@@ -5569,12 +5428,9 @@ const deserializeAws_json1_0StartChildWorkflowExecutionInitiatedEventAttributes 
       output.taskList !== undefined && output.taskList !== null
         ? deserializeAws_json1_0TaskList(output.taskList, context)
         : undefined,
-    taskPriority: output.taskPriority !== undefined && output.taskPriority !== null ? output.taskPriority : undefined,
-    taskStartToCloseTimeout:
-      output.taskStartToCloseTimeout !== undefined && output.taskStartToCloseTimeout !== null
-        ? output.taskStartToCloseTimeout
-        : undefined,
-    workflowId: output.workflowId !== undefined && output.workflowId !== null ? output.workflowId : undefined,
+    taskPriority: __expectString(output.taskPriority),
+    taskStartToCloseTimeout: __expectString(output.taskStartToCloseTimeout),
+    workflowId: __expectString(output.workflowId),
     workflowType:
       output.workflowType !== undefined && output.workflowType !== null
         ? deserializeAws_json1_0WorkflowType(output.workflowType, context)
@@ -5587,10 +5443,9 @@ const deserializeAws_json1_0StartLambdaFunctionFailedEventAttributes = (
   context: __SerdeContext
 ): StartLambdaFunctionFailedEventAttributes => {
   return {
-    cause: output.cause !== undefined && output.cause !== null ? output.cause : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
-    scheduledEventId:
-      output.scheduledEventId !== undefined && output.scheduledEventId !== null ? output.scheduledEventId : undefined,
+    cause: __expectString(output.cause),
+    message: __expectString(output.message),
+    scheduledEventId: __expectNumber(output.scheduledEventId),
   } as any;
 };
 
@@ -5599,12 +5454,9 @@ const deserializeAws_json1_0StartTimerFailedEventAttributes = (
   context: __SerdeContext
 ): StartTimerFailedEventAttributes => {
   return {
-    cause: output.cause !== undefined && output.cause !== null ? output.cause : undefined,
-    decisionTaskCompletedEventId:
-      output.decisionTaskCompletedEventId !== undefined && output.decisionTaskCompletedEventId !== null
-        ? output.decisionTaskCompletedEventId
-        : undefined,
-    timerId: output.timerId !== undefined && output.timerId !== null ? output.timerId : undefined,
+    cause: __expectString(output.cause),
+    decisionTaskCompletedEventId: __expectNumber(output.decisionTaskCompletedEventId),
+    timerId: __expectString(output.timerId),
   } as any;
 };
 
@@ -5615,13 +5467,13 @@ const deserializeAws_json1_0TagList = (output: any, context: __SerdeContext): st
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_0TaskList = (output: any, context: __SerdeContext): TaskList => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -5630,13 +5482,9 @@ const deserializeAws_json1_0TimerCanceledEventAttributes = (
   context: __SerdeContext
 ): TimerCanceledEventAttributes => {
   return {
-    decisionTaskCompletedEventId:
-      output.decisionTaskCompletedEventId !== undefined && output.decisionTaskCompletedEventId !== null
-        ? output.decisionTaskCompletedEventId
-        : undefined,
-    startedEventId:
-      output.startedEventId !== undefined && output.startedEventId !== null ? output.startedEventId : undefined,
-    timerId: output.timerId !== undefined && output.timerId !== null ? output.timerId : undefined,
+    decisionTaskCompletedEventId: __expectNumber(output.decisionTaskCompletedEventId),
+    startedEventId: __expectNumber(output.startedEventId),
+    timerId: __expectString(output.timerId),
   } as any;
 };
 
@@ -5645,9 +5493,8 @@ const deserializeAws_json1_0TimerFiredEventAttributes = (
   context: __SerdeContext
 ): TimerFiredEventAttributes => {
   return {
-    startedEventId:
-      output.startedEventId !== undefined && output.startedEventId !== null ? output.startedEventId : undefined,
-    timerId: output.timerId !== undefined && output.timerId !== null ? output.timerId : undefined,
+    startedEventId: __expectNumber(output.startedEventId),
+    timerId: __expectString(output.timerId),
   } as any;
 };
 
@@ -5656,47 +5503,41 @@ const deserializeAws_json1_0TimerStartedEventAttributes = (
   context: __SerdeContext
 ): TimerStartedEventAttributes => {
   return {
-    control: output.control !== undefined && output.control !== null ? output.control : undefined,
-    decisionTaskCompletedEventId:
-      output.decisionTaskCompletedEventId !== undefined && output.decisionTaskCompletedEventId !== null
-        ? output.decisionTaskCompletedEventId
-        : undefined,
-    startToFireTimeout:
-      output.startToFireTimeout !== undefined && output.startToFireTimeout !== null
-        ? output.startToFireTimeout
-        : undefined,
-    timerId: output.timerId !== undefined && output.timerId !== null ? output.timerId : undefined,
+    control: __expectString(output.control),
+    decisionTaskCompletedEventId: __expectNumber(output.decisionTaskCompletedEventId),
+    startToFireTimeout: __expectString(output.startToFireTimeout),
+    timerId: __expectString(output.timerId),
   } as any;
 };
 
 const deserializeAws_json1_0TooManyTagsFault = (output: any, context: __SerdeContext): TooManyTagsFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_0TypeAlreadyExistsFault = (output: any, context: __SerdeContext): TypeAlreadyExistsFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_0TypeDeprecatedFault = (output: any, context: __SerdeContext): TypeDeprecatedFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_0UnknownResourceFault = (output: any, context: __SerdeContext): UnknownResourceFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_0WorkflowExecution = (output: any, context: __SerdeContext): WorkflowExecution => {
   return {
-    runId: output.runId !== undefined && output.runId !== null ? output.runId : undefined,
-    workflowId: output.workflowId !== undefined && output.workflowId !== null ? output.workflowId : undefined,
+    runId: __expectString(output.runId),
+    workflowId: __expectString(output.workflowId),
   } as any;
 };
 
@@ -5705,7 +5546,7 @@ const deserializeAws_json1_0WorkflowExecutionAlreadyStartedFault = (
   context: __SerdeContext
 ): WorkflowExecutionAlreadyStartedFault => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -5714,11 +5555,8 @@ const deserializeAws_json1_0WorkflowExecutionCanceledEventAttributes = (
   context: __SerdeContext
 ): WorkflowExecutionCanceledEventAttributes => {
   return {
-    decisionTaskCompletedEventId:
-      output.decisionTaskCompletedEventId !== undefined && output.decisionTaskCompletedEventId !== null
-        ? output.decisionTaskCompletedEventId
-        : undefined,
-    details: output.details !== undefined && output.details !== null ? output.details : undefined,
+    decisionTaskCompletedEventId: __expectNumber(output.decisionTaskCompletedEventId),
+    details: __expectString(output.details),
   } as any;
 };
 
@@ -5727,11 +5565,8 @@ const deserializeAws_json1_0WorkflowExecutionCancelRequestedEventAttributes = (
   context: __SerdeContext
 ): WorkflowExecutionCancelRequestedEventAttributes => {
   return {
-    cause: output.cause !== undefined && output.cause !== null ? output.cause : undefined,
-    externalInitiatedEventId:
-      output.externalInitiatedEventId !== undefined && output.externalInitiatedEventId !== null
-        ? output.externalInitiatedEventId
-        : undefined,
+    cause: __expectString(output.cause),
+    externalInitiatedEventId: __expectNumber(output.externalInitiatedEventId),
     externalWorkflowExecution:
       output.externalWorkflowExecution !== undefined && output.externalWorkflowExecution !== null
         ? deserializeAws_json1_0WorkflowExecution(output.externalWorkflowExecution, context)
@@ -5744,11 +5579,8 @@ const deserializeAws_json1_0WorkflowExecutionCompletedEventAttributes = (
   context: __SerdeContext
 ): WorkflowExecutionCompletedEventAttributes => {
   return {
-    decisionTaskCompletedEventId:
-      output.decisionTaskCompletedEventId !== undefined && output.decisionTaskCompletedEventId !== null
-        ? output.decisionTaskCompletedEventId
-        : undefined,
-    result: output.result !== undefined && output.result !== null ? output.result : undefined,
+    decisionTaskCompletedEventId: __expectNumber(output.decisionTaskCompletedEventId),
+    result: __expectString(output.result),
   } as any;
 };
 
@@ -5757,21 +5589,15 @@ const deserializeAws_json1_0WorkflowExecutionConfiguration = (
   context: __SerdeContext
 ): WorkflowExecutionConfiguration => {
   return {
-    childPolicy: output.childPolicy !== undefined && output.childPolicy !== null ? output.childPolicy : undefined,
-    executionStartToCloseTimeout:
-      output.executionStartToCloseTimeout !== undefined && output.executionStartToCloseTimeout !== null
-        ? output.executionStartToCloseTimeout
-        : undefined,
-    lambdaRole: output.lambdaRole !== undefined && output.lambdaRole !== null ? output.lambdaRole : undefined,
+    childPolicy: __expectString(output.childPolicy),
+    executionStartToCloseTimeout: __expectString(output.executionStartToCloseTimeout),
+    lambdaRole: __expectString(output.lambdaRole),
     taskList:
       output.taskList !== undefined && output.taskList !== null
         ? deserializeAws_json1_0TaskList(output.taskList, context)
         : undefined,
-    taskPriority: output.taskPriority !== undefined && output.taskPriority !== null ? output.taskPriority : undefined,
-    taskStartToCloseTimeout:
-      output.taskStartToCloseTimeout !== undefined && output.taskStartToCloseTimeout !== null
-        ? output.taskStartToCloseTimeout
-        : undefined,
+    taskPriority: __expectString(output.taskPriority),
+    taskStartToCloseTimeout: __expectString(output.taskStartToCloseTimeout),
   } as any;
 };
 
@@ -5780,21 +5606,12 @@ const deserializeAws_json1_0WorkflowExecutionContinuedAsNewEventAttributes = (
   context: __SerdeContext
 ): WorkflowExecutionContinuedAsNewEventAttributes => {
   return {
-    childPolicy: output.childPolicy !== undefined && output.childPolicy !== null ? output.childPolicy : undefined,
-    decisionTaskCompletedEventId:
-      output.decisionTaskCompletedEventId !== undefined && output.decisionTaskCompletedEventId !== null
-        ? output.decisionTaskCompletedEventId
-        : undefined,
-    executionStartToCloseTimeout:
-      output.executionStartToCloseTimeout !== undefined && output.executionStartToCloseTimeout !== null
-        ? output.executionStartToCloseTimeout
-        : undefined,
-    input: output.input !== undefined && output.input !== null ? output.input : undefined,
-    lambdaRole: output.lambdaRole !== undefined && output.lambdaRole !== null ? output.lambdaRole : undefined,
-    newExecutionRunId:
-      output.newExecutionRunId !== undefined && output.newExecutionRunId !== null
-        ? output.newExecutionRunId
-        : undefined,
+    childPolicy: __expectString(output.childPolicy),
+    decisionTaskCompletedEventId: __expectNumber(output.decisionTaskCompletedEventId),
+    executionStartToCloseTimeout: __expectString(output.executionStartToCloseTimeout),
+    input: __expectString(output.input),
+    lambdaRole: __expectString(output.lambdaRole),
+    newExecutionRunId: __expectString(output.newExecutionRunId),
     tagList:
       output.tagList !== undefined && output.tagList !== null
         ? deserializeAws_json1_0TagList(output.tagList, context)
@@ -5803,11 +5620,8 @@ const deserializeAws_json1_0WorkflowExecutionContinuedAsNewEventAttributes = (
       output.taskList !== undefined && output.taskList !== null
         ? deserializeAws_json1_0TaskList(output.taskList, context)
         : undefined,
-    taskPriority: output.taskPriority !== undefined && output.taskPriority !== null ? output.taskPriority : undefined,
-    taskStartToCloseTimeout:
-      output.taskStartToCloseTimeout !== undefined && output.taskStartToCloseTimeout !== null
-        ? output.taskStartToCloseTimeout
-        : undefined,
+    taskPriority: __expectString(output.taskPriority),
+    taskStartToCloseTimeout: __expectString(output.taskStartToCloseTimeout),
     workflowType:
       output.workflowType !== undefined && output.workflowType !== null
         ? deserializeAws_json1_0WorkflowType(output.workflowType, context)
@@ -5817,8 +5631,8 @@ const deserializeAws_json1_0WorkflowExecutionContinuedAsNewEventAttributes = (
 
 const deserializeAws_json1_0WorkflowExecutionCount = (output: any, context: __SerdeContext): WorkflowExecutionCount => {
   return {
-    count: output.count !== undefined && output.count !== null ? output.count : undefined,
-    truncated: output.truncated !== undefined && output.truncated !== null ? output.truncated : undefined,
+    count: __expectNumber(output.count),
+    truncated: __expectBoolean(output.truncated),
   } as any;
 };
 
@@ -5839,10 +5653,7 @@ const deserializeAws_json1_0WorkflowExecutionDetail = (
       output.latestActivityTaskTimestamp !== undefined && output.latestActivityTaskTimestamp !== null
         ? new Date(Math.round(output.latestActivityTaskTimestamp * 1000))
         : undefined,
-    latestExecutionContext:
-      output.latestExecutionContext !== undefined && output.latestExecutionContext !== null
-        ? output.latestExecutionContext
-        : undefined,
+    latestExecutionContext: __expectString(output.latestExecutionContext),
     openCounts:
       output.openCounts !== undefined && output.openCounts !== null
         ? deserializeAws_json1_0WorkflowExecutionOpenCounts(output.openCounts, context)
@@ -5855,20 +5666,16 @@ const deserializeAws_json1_0WorkflowExecutionFailedEventAttributes = (
   context: __SerdeContext
 ): WorkflowExecutionFailedEventAttributes => {
   return {
-    decisionTaskCompletedEventId:
-      output.decisionTaskCompletedEventId !== undefined && output.decisionTaskCompletedEventId !== null
-        ? output.decisionTaskCompletedEventId
-        : undefined,
-    details: output.details !== undefined && output.details !== null ? output.details : undefined,
-    reason: output.reason !== undefined && output.reason !== null ? output.reason : undefined,
+    decisionTaskCompletedEventId: __expectNumber(output.decisionTaskCompletedEventId),
+    details: __expectString(output.details),
+    reason: __expectString(output.reason),
   } as any;
 };
 
 const deserializeAws_json1_0WorkflowExecutionInfo = (output: any, context: __SerdeContext): WorkflowExecutionInfo => {
   return {
-    cancelRequested:
-      output.cancelRequested !== undefined && output.cancelRequested !== null ? output.cancelRequested : undefined,
-    closeStatus: output.closeStatus !== undefined && output.closeStatus !== null ? output.closeStatus : undefined,
+    cancelRequested: __expectBoolean(output.cancelRequested),
+    closeStatus: __expectString(output.closeStatus),
     closeTimestamp:
       output.closeTimestamp !== undefined && output.closeTimestamp !== null
         ? new Date(Math.round(output.closeTimestamp * 1000))
@@ -5877,8 +5684,7 @@ const deserializeAws_json1_0WorkflowExecutionInfo = (output: any, context: __Ser
       output.execution !== undefined && output.execution !== null
         ? deserializeAws_json1_0WorkflowExecution(output.execution, context)
         : undefined,
-    executionStatus:
-      output.executionStatus !== undefined && output.executionStatus !== null ? output.executionStatus : undefined,
+    executionStatus: __expectString(output.executionStatus),
     parent:
       output.parent !== undefined && output.parent !== null
         ? deserializeAws_json1_0WorkflowExecution(output.parent, context)
@@ -5918,8 +5724,7 @@ const deserializeAws_json1_0WorkflowExecutionInfos = (output: any, context: __Se
       output.executionInfos !== undefined && output.executionInfos !== null
         ? deserializeAws_json1_0WorkflowExecutionInfoList(output.executionInfos, context)
         : undefined,
-    nextPageToken:
-      output.nextPageToken !== undefined && output.nextPageToken !== null ? output.nextPageToken : undefined,
+    nextPageToken: __expectString(output.nextPageToken),
   } as any;
 };
 
@@ -5928,23 +5733,11 @@ const deserializeAws_json1_0WorkflowExecutionOpenCounts = (
   context: __SerdeContext
 ): WorkflowExecutionOpenCounts => {
   return {
-    openActivityTasks:
-      output.openActivityTasks !== undefined && output.openActivityTasks !== null
-        ? output.openActivityTasks
-        : undefined,
-    openChildWorkflowExecutions:
-      output.openChildWorkflowExecutions !== undefined && output.openChildWorkflowExecutions !== null
-        ? output.openChildWorkflowExecutions
-        : undefined,
-    openDecisionTasks:
-      output.openDecisionTasks !== undefined && output.openDecisionTasks !== null
-        ? output.openDecisionTasks
-        : undefined,
-    openLambdaFunctions:
-      output.openLambdaFunctions !== undefined && output.openLambdaFunctions !== null
-        ? output.openLambdaFunctions
-        : undefined,
-    openTimers: output.openTimers !== undefined && output.openTimers !== null ? output.openTimers : undefined,
+    openActivityTasks: __expectNumber(output.openActivityTasks),
+    openChildWorkflowExecutions: __expectNumber(output.openChildWorkflowExecutions),
+    openDecisionTasks: __expectNumber(output.openDecisionTasks),
+    openLambdaFunctions: __expectNumber(output.openLambdaFunctions),
+    openTimers: __expectNumber(output.openTimers),
   } as any;
 };
 
@@ -5953,16 +5746,13 @@ const deserializeAws_json1_0WorkflowExecutionSignaledEventAttributes = (
   context: __SerdeContext
 ): WorkflowExecutionSignaledEventAttributes => {
   return {
-    externalInitiatedEventId:
-      output.externalInitiatedEventId !== undefined && output.externalInitiatedEventId !== null
-        ? output.externalInitiatedEventId
-        : undefined,
+    externalInitiatedEventId: __expectNumber(output.externalInitiatedEventId),
     externalWorkflowExecution:
       output.externalWorkflowExecution !== undefined && output.externalWorkflowExecution !== null
         ? deserializeAws_json1_0WorkflowExecution(output.externalWorkflowExecution, context)
         : undefined,
-    input: output.input !== undefined && output.input !== null ? output.input : undefined,
-    signalName: output.signalName !== undefined && output.signalName !== null ? output.signalName : undefined,
+    input: __expectString(output.input),
+    signalName: __expectString(output.signalName),
   } as any;
 };
 
@@ -5971,21 +5761,12 @@ const deserializeAws_json1_0WorkflowExecutionStartedEventAttributes = (
   context: __SerdeContext
 ): WorkflowExecutionStartedEventAttributes => {
   return {
-    childPolicy: output.childPolicy !== undefined && output.childPolicy !== null ? output.childPolicy : undefined,
-    continuedExecutionRunId:
-      output.continuedExecutionRunId !== undefined && output.continuedExecutionRunId !== null
-        ? output.continuedExecutionRunId
-        : undefined,
-    executionStartToCloseTimeout:
-      output.executionStartToCloseTimeout !== undefined && output.executionStartToCloseTimeout !== null
-        ? output.executionStartToCloseTimeout
-        : undefined,
-    input: output.input !== undefined && output.input !== null ? output.input : undefined,
-    lambdaRole: output.lambdaRole !== undefined && output.lambdaRole !== null ? output.lambdaRole : undefined,
-    parentInitiatedEventId:
-      output.parentInitiatedEventId !== undefined && output.parentInitiatedEventId !== null
-        ? output.parentInitiatedEventId
-        : undefined,
+    childPolicy: __expectString(output.childPolicy),
+    continuedExecutionRunId: __expectString(output.continuedExecutionRunId),
+    executionStartToCloseTimeout: __expectString(output.executionStartToCloseTimeout),
+    input: __expectString(output.input),
+    lambdaRole: __expectString(output.lambdaRole),
+    parentInitiatedEventId: __expectNumber(output.parentInitiatedEventId),
     parentWorkflowExecution:
       output.parentWorkflowExecution !== undefined && output.parentWorkflowExecution !== null
         ? deserializeAws_json1_0WorkflowExecution(output.parentWorkflowExecution, context)
@@ -5998,11 +5779,8 @@ const deserializeAws_json1_0WorkflowExecutionStartedEventAttributes = (
       output.taskList !== undefined && output.taskList !== null
         ? deserializeAws_json1_0TaskList(output.taskList, context)
         : undefined,
-    taskPriority: output.taskPriority !== undefined && output.taskPriority !== null ? output.taskPriority : undefined,
-    taskStartToCloseTimeout:
-      output.taskStartToCloseTimeout !== undefined && output.taskStartToCloseTimeout !== null
-        ? output.taskStartToCloseTimeout
-        : undefined,
+    taskPriority: __expectString(output.taskPriority),
+    taskStartToCloseTimeout: __expectString(output.taskStartToCloseTimeout),
     workflowType:
       output.workflowType !== undefined && output.workflowType !== null
         ? deserializeAws_json1_0WorkflowType(output.workflowType, context)
@@ -6015,10 +5793,10 @@ const deserializeAws_json1_0WorkflowExecutionTerminatedEventAttributes = (
   context: __SerdeContext
 ): WorkflowExecutionTerminatedEventAttributes => {
   return {
-    cause: output.cause !== undefined && output.cause !== null ? output.cause : undefined,
-    childPolicy: output.childPolicy !== undefined && output.childPolicy !== null ? output.childPolicy : undefined,
-    details: output.details !== undefined && output.details !== null ? output.details : undefined,
-    reason: output.reason !== undefined && output.reason !== null ? output.reason : undefined,
+    cause: __expectString(output.cause),
+    childPolicy: __expectString(output.childPolicy),
+    details: __expectString(output.details),
+    reason: __expectString(output.reason),
   } as any;
 };
 
@@ -6027,15 +5805,15 @@ const deserializeAws_json1_0WorkflowExecutionTimedOutEventAttributes = (
   context: __SerdeContext
 ): WorkflowExecutionTimedOutEventAttributes => {
   return {
-    childPolicy: output.childPolicy !== undefined && output.childPolicy !== null ? output.childPolicy : undefined,
-    timeoutType: output.timeoutType !== undefined && output.timeoutType !== null ? output.timeoutType : undefined,
+    childPolicy: __expectString(output.childPolicy),
+    timeoutType: __expectString(output.timeoutType),
   } as any;
 };
 
 const deserializeAws_json1_0WorkflowType = (output: any, context: __SerdeContext): WorkflowType => {
   return {
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
-    version: output.version !== undefined && output.version !== null ? output.version : undefined,
+    name: __expectString(output.name),
+    version: __expectString(output.version),
   } as any;
 };
 
@@ -6044,30 +5822,15 @@ const deserializeAws_json1_0WorkflowTypeConfiguration = (
   context: __SerdeContext
 ): WorkflowTypeConfiguration => {
   return {
-    defaultChildPolicy:
-      output.defaultChildPolicy !== undefined && output.defaultChildPolicy !== null
-        ? output.defaultChildPolicy
-        : undefined,
-    defaultExecutionStartToCloseTimeout:
-      output.defaultExecutionStartToCloseTimeout !== undefined && output.defaultExecutionStartToCloseTimeout !== null
-        ? output.defaultExecutionStartToCloseTimeout
-        : undefined,
-    defaultLambdaRole:
-      output.defaultLambdaRole !== undefined && output.defaultLambdaRole !== null
-        ? output.defaultLambdaRole
-        : undefined,
+    defaultChildPolicy: __expectString(output.defaultChildPolicy),
+    defaultExecutionStartToCloseTimeout: __expectString(output.defaultExecutionStartToCloseTimeout),
+    defaultLambdaRole: __expectString(output.defaultLambdaRole),
     defaultTaskList:
       output.defaultTaskList !== undefined && output.defaultTaskList !== null
         ? deserializeAws_json1_0TaskList(output.defaultTaskList, context)
         : undefined,
-    defaultTaskPriority:
-      output.defaultTaskPriority !== undefined && output.defaultTaskPriority !== null
-        ? output.defaultTaskPriority
-        : undefined,
-    defaultTaskStartToCloseTimeout:
-      output.defaultTaskStartToCloseTimeout !== undefined && output.defaultTaskStartToCloseTimeout !== null
-        ? output.defaultTaskStartToCloseTimeout
-        : undefined,
+    defaultTaskPriority: __expectString(output.defaultTaskPriority),
+    defaultTaskStartToCloseTimeout: __expectString(output.defaultTaskStartToCloseTimeout),
   } as any;
 };
 
@@ -6094,8 +5857,8 @@ const deserializeAws_json1_0WorkflowTypeInfo = (output: any, context: __SerdeCon
       output.deprecationDate !== undefined && output.deprecationDate !== null
         ? new Date(Math.round(output.deprecationDate * 1000))
         : undefined,
-    description: output.description !== undefined && output.description !== null ? output.description : undefined,
-    status: output.status !== undefined && output.status !== null ? output.status : undefined,
+    description: __expectString(output.description),
+    status: __expectString(output.status),
     workflowType:
       output.workflowType !== undefined && output.workflowType !== null
         ? deserializeAws_json1_0WorkflowType(output.workflowType, context)
@@ -6116,8 +5879,7 @@ const deserializeAws_json1_0WorkflowTypeInfoList = (output: any, context: __Serd
 
 const deserializeAws_json1_0WorkflowTypeInfos = (output: any, context: __SerdeContext): WorkflowTypeInfos => {
   return {
-    nextPageToken:
-      output.nextPageToken !== undefined && output.nextPageToken !== null ? output.nextPageToken : undefined,
+    nextPageToken: __expectString(output.nextPageToken),
     typeInfos:
       output.typeInfos !== undefined && output.typeInfos !== null
         ? deserializeAws_json1_0WorkflowTypeInfoList(output.typeInfos, context)

--- a/clients/client-synthetics/protocols/Aws_restJson1.ts
+++ b/clients/client-synthetics/protocols/Aws_restJson1.ts
@@ -45,6 +45,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -622,7 +625,7 @@ export const deserializeAws_restJson1DescribeCanariesCommand = async (
     contents.Canaries = deserializeAws_restJson1Canaries(data.Canaries, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -689,7 +692,7 @@ export const deserializeAws_restJson1DescribeCanariesLastRunCommand = async (
     contents.CanariesLastRun = deserializeAws_restJson1CanariesLastRun(data.CanariesLastRun, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -753,7 +756,7 @@ export const deserializeAws_restJson1DescribeRuntimeVersionsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.RuntimeVersions !== undefined && data.RuntimeVersions !== null) {
     contents.RuntimeVersions = deserializeAws_restJson1RuntimeVersionList(data.RuntimeVersions, context);
@@ -886,7 +889,7 @@ export const deserializeAws_restJson1GetCanaryRunsCommand = async (
     contents.CanaryRuns = deserializeAws_restJson1CanaryRuns(data.CanaryRuns, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1386,7 +1389,7 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1403,7 +1406,7 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1420,7 +1423,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1437,7 +1440,7 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -1557,29 +1560,21 @@ const deserializeAws_restJson1CanariesLastRun = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1Canary = (output: any, context: __SerdeContext): Canary => {
   return {
-    ArtifactS3Location:
-      output.ArtifactS3Location !== undefined && output.ArtifactS3Location !== null
-        ? output.ArtifactS3Location
-        : undefined,
+    ArtifactS3Location: __expectString(output.ArtifactS3Location),
     Code:
       output.Code !== undefined && output.Code !== null
         ? deserializeAws_restJson1CanaryCodeOutput(output.Code, context)
         : undefined,
-    EngineArn: output.EngineArn !== undefined && output.EngineArn !== null ? output.EngineArn : undefined,
-    ExecutionRoleArn:
-      output.ExecutionRoleArn !== undefined && output.ExecutionRoleArn !== null ? output.ExecutionRoleArn : undefined,
-    FailureRetentionPeriodInDays:
-      output.FailureRetentionPeriodInDays !== undefined && output.FailureRetentionPeriodInDays !== null
-        ? output.FailureRetentionPeriodInDays
-        : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    EngineArn: __expectString(output.EngineArn),
+    ExecutionRoleArn: __expectString(output.ExecutionRoleArn),
+    FailureRetentionPeriodInDays: __expectNumber(output.FailureRetentionPeriodInDays),
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
     RunConfig:
       output.RunConfig !== undefined && output.RunConfig !== null
         ? deserializeAws_restJson1CanaryRunConfigOutput(output.RunConfig, context)
         : undefined,
-    RuntimeVersion:
-      output.RuntimeVersion !== undefined && output.RuntimeVersion !== null ? output.RuntimeVersion : undefined,
+    RuntimeVersion: __expectString(output.RuntimeVersion),
     Schedule:
       output.Schedule !== undefined && output.Schedule !== null
         ? deserializeAws_restJson1CanaryScheduleOutput(output.Schedule, context)
@@ -1588,10 +1583,7 @@ const deserializeAws_restJson1Canary = (output: any, context: __SerdeContext): C
       output.Status !== undefined && output.Status !== null
         ? deserializeAws_restJson1CanaryStatus(output.Status, context)
         : undefined,
-    SuccessRetentionPeriodInDays:
-      output.SuccessRetentionPeriodInDays !== undefined && output.SuccessRetentionPeriodInDays !== null
-        ? output.SuccessRetentionPeriodInDays
-        : undefined,
+    SuccessRetentionPeriodInDays: __expectNumber(output.SuccessRetentionPeriodInDays),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_restJson1TagMap(output.Tags, context)
@@ -1609,17 +1601,14 @@ const deserializeAws_restJson1Canary = (output: any, context: __SerdeContext): C
 
 const deserializeAws_restJson1CanaryCodeOutput = (output: any, context: __SerdeContext): CanaryCodeOutput => {
   return {
-    Handler: output.Handler !== undefined && output.Handler !== null ? output.Handler : undefined,
-    SourceLocationArn:
-      output.SourceLocationArn !== undefined && output.SourceLocationArn !== null
-        ? output.SourceLocationArn
-        : undefined,
+    Handler: __expectString(output.Handler),
+    SourceLocationArn: __expectString(output.SourceLocationArn),
   } as any;
 };
 
 const deserializeAws_restJson1CanaryLastRun = (output: any, context: __SerdeContext): CanaryLastRun => {
   return {
-    CanaryName: output.CanaryName !== undefined && output.CanaryName !== null ? output.CanaryName : undefined,
+    CanaryName: __expectString(output.CanaryName),
     LastRun:
       output.LastRun !== undefined && output.LastRun !== null
         ? deserializeAws_restJson1CanaryRun(output.LastRun, context)
@@ -1629,12 +1618,9 @@ const deserializeAws_restJson1CanaryLastRun = (output: any, context: __SerdeCont
 
 const deserializeAws_restJson1CanaryRun = (output: any, context: __SerdeContext): CanaryRun => {
   return {
-    ArtifactS3Location:
-      output.ArtifactS3Location !== undefined && output.ArtifactS3Location !== null
-        ? output.ArtifactS3Location
-        : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    ArtifactS3Location: __expectString(output.ArtifactS3Location),
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
     Status:
       output.Status !== undefined && output.Status !== null
         ? deserializeAws_restJson1CanaryRunStatus(output.Status, context)
@@ -1648,11 +1634,9 @@ const deserializeAws_restJson1CanaryRun = (output: any, context: __SerdeContext)
 
 const deserializeAws_restJson1CanaryRunConfigOutput = (output: any, context: __SerdeContext): CanaryRunConfigOutput => {
   return {
-    ActiveTracing:
-      output.ActiveTracing !== undefined && output.ActiveTracing !== null ? output.ActiveTracing : undefined,
-    MemoryInMB: output.MemoryInMB !== undefined && output.MemoryInMB !== null ? output.MemoryInMB : undefined,
-    TimeoutInSeconds:
-      output.TimeoutInSeconds !== undefined && output.TimeoutInSeconds !== null ? output.TimeoutInSeconds : undefined,
+    ActiveTracing: __expectBoolean(output.ActiveTracing),
+    MemoryInMB: __expectNumber(output.MemoryInMB),
+    TimeoutInSeconds: __expectNumber(output.TimeoutInSeconds),
   } as any;
 };
 
@@ -1669,10 +1653,9 @@ const deserializeAws_restJson1CanaryRuns = (output: any, context: __SerdeContext
 
 const deserializeAws_restJson1CanaryRunStatus = (output: any, context: __SerdeContext): CanaryRunStatus => {
   return {
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    StateReason: output.StateReason !== undefined && output.StateReason !== null ? output.StateReason : undefined,
-    StateReasonCode:
-      output.StateReasonCode !== undefined && output.StateReasonCode !== null ? output.StateReasonCode : undefined,
+    State: __expectString(output.State),
+    StateReason: __expectString(output.StateReason),
+    StateReasonCode: __expectString(output.StateReasonCode),
   } as any;
 };
 
@@ -1689,20 +1672,16 @@ const deserializeAws_restJson1CanaryRunTimeline = (output: any, context: __Serde
 
 const deserializeAws_restJson1CanaryScheduleOutput = (output: any, context: __SerdeContext): CanaryScheduleOutput => {
   return {
-    DurationInSeconds:
-      output.DurationInSeconds !== undefined && output.DurationInSeconds !== null
-        ? output.DurationInSeconds
-        : undefined,
-    Expression: output.Expression !== undefined && output.Expression !== null ? output.Expression : undefined,
+    DurationInSeconds: __expectNumber(output.DurationInSeconds),
+    Expression: __expectString(output.Expression),
   } as any;
 };
 
 const deserializeAws_restJson1CanaryStatus = (output: any, context: __SerdeContext): CanaryStatus => {
   return {
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    StateReason: output.StateReason !== undefined && output.StateReason !== null ? output.StateReason : undefined,
-    StateReasonCode:
-      output.StateReasonCode !== undefined && output.StateReasonCode !== null ? output.StateReasonCode : undefined,
+    State: __expectString(output.State),
+    StateReason: __expectString(output.StateReason),
+    StateReasonCode: __expectString(output.StateReasonCode),
   } as any;
 };
 
@@ -1731,12 +1710,12 @@ const deserializeAws_restJson1RuntimeVersion = (output: any, context: __SerdeCon
       output.DeprecationDate !== undefined && output.DeprecationDate !== null
         ? new Date(Math.round(output.DeprecationDate * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     ReleaseDate:
       output.ReleaseDate !== undefined && output.ReleaseDate !== null
         ? new Date(Math.round(output.ReleaseDate * 1000))
         : undefined,
-    VersionName: output.VersionName !== undefined && output.VersionName !== null ? output.VersionName : undefined,
+    VersionName: __expectString(output.VersionName),
   } as any;
 };
 
@@ -1758,7 +1737,7 @@ const deserializeAws_restJson1SecurityGroupIds = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -1769,7 +1748,7 @@ const deserializeAws_restJson1SubnetIds = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -1780,7 +1759,7 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -1795,7 +1774,7 @@ const deserializeAws_restJson1VpcConfigOutput = (output: any, context: __SerdeCo
       output.SubnetIds !== undefined && output.SubnetIds !== null
         ? deserializeAws_restJson1SubnetIds(output.SubnetIds, context)
         : undefined,
-    VpcId: output.VpcId !== undefined && output.VpcId !== null ? output.VpcId : undefined,
+    VpcId: __expectString(output.VpcId),
   } as any;
 };
 

--- a/clients/client-textract/protocols/Aws_json1_1.ts
+++ b/clients/client-textract/protocols/Aws_json1_1.ts
@@ -63,7 +63,12 @@ import {
   Warning,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { LazyJsonString as __LazyJsonString, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  LazyJsonString as __LazyJsonString,
+  SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -1268,8 +1273,8 @@ const serializeAws_json1_1StartDocumentTextDetectionRequest = (
 
 const deserializeAws_json1_1AccessDeniedException = (output: any, context: __SerdeContext): AccessDeniedException => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -1278,10 +1283,7 @@ const deserializeAws_json1_1AnalyzeDocumentResponse = (
   context: __SerdeContext
 ): AnalyzeDocumentResponse => {
   return {
-    AnalyzeDocumentModelVersion:
-      output.AnalyzeDocumentModelVersion !== undefined && output.AnalyzeDocumentModelVersion !== null
-        ? output.AnalyzeDocumentModelVersion
-        : undefined,
+    AnalyzeDocumentModelVersion: __expectString(output.AnalyzeDocumentModelVersion),
     Blocks:
       output.Blocks !== undefined && output.Blocks !== null
         ? deserializeAws_json1_1BlockList(output.Blocks, context)
@@ -1299,17 +1301,17 @@ const deserializeAws_json1_1AnalyzeDocumentResponse = (
 
 const deserializeAws_json1_1BadDocumentException = (output: any, context: __SerdeContext): BadDocumentException => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1Block = (output: any, context: __SerdeContext): Block => {
   return {
-    BlockType: output.BlockType !== undefined && output.BlockType !== null ? output.BlockType : undefined,
-    ColumnIndex: output.ColumnIndex !== undefined && output.ColumnIndex !== null ? output.ColumnIndex : undefined,
-    ColumnSpan: output.ColumnSpan !== undefined && output.ColumnSpan !== null ? output.ColumnSpan : undefined,
-    Confidence: output.Confidence !== undefined && output.Confidence !== null ? output.Confidence : undefined,
+    BlockType: __expectString(output.BlockType),
+    ColumnIndex: __expectNumber(output.ColumnIndex),
+    ColumnSpan: __expectNumber(output.ColumnSpan),
+    Confidence: __expectNumber(output.Confidence),
     EntityTypes:
       output.EntityTypes !== undefined && output.EntityTypes !== null
         ? deserializeAws_json1_1EntityTypes(output.EntityTypes, context)
@@ -1318,18 +1320,17 @@ const deserializeAws_json1_1Block = (output: any, context: __SerdeContext): Bloc
       output.Geometry !== undefined && output.Geometry !== null
         ? deserializeAws_json1_1Geometry(output.Geometry, context)
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Page: output.Page !== undefined && output.Page !== null ? output.Page : undefined,
+    Id: __expectString(output.Id),
+    Page: __expectNumber(output.Page),
     Relationships:
       output.Relationships !== undefined && output.Relationships !== null
         ? deserializeAws_json1_1RelationshipList(output.Relationships, context)
         : undefined,
-    RowIndex: output.RowIndex !== undefined && output.RowIndex !== null ? output.RowIndex : undefined,
-    RowSpan: output.RowSpan !== undefined && output.RowSpan !== null ? output.RowSpan : undefined,
-    SelectionStatus:
-      output.SelectionStatus !== undefined && output.SelectionStatus !== null ? output.SelectionStatus : undefined,
-    Text: output.Text !== undefined && output.Text !== null ? output.Text : undefined,
-    TextType: output.TextType !== undefined && output.TextType !== null ? output.TextType : undefined,
+    RowIndex: __expectNumber(output.RowIndex),
+    RowSpan: __expectNumber(output.RowSpan),
+    SelectionStatus: __expectString(output.SelectionStatus),
+    Text: __expectString(output.Text),
+    TextType: __expectString(output.TextType),
   } as any;
 };
 
@@ -1346,10 +1347,10 @@ const deserializeAws_json1_1BlockList = (output: any, context: __SerdeContext): 
 
 const deserializeAws_json1_1BoundingBox = (output: any, context: __SerdeContext): BoundingBox => {
   return {
-    Height: output.Height !== undefined && output.Height !== null ? output.Height : undefined,
-    Left: output.Left !== undefined && output.Left !== null ? output.Left : undefined,
-    Top: output.Top !== undefined && output.Top !== null ? output.Top : undefined,
-    Width: output.Width !== undefined && output.Width !== null ? output.Width : undefined,
+    Height: __expectNumber(output.Height),
+    Left: __expectNumber(output.Left),
+    Top: __expectNumber(output.Top),
+    Width: __expectNumber(output.Width),
   } as any;
 };
 
@@ -1362,10 +1363,7 @@ const deserializeAws_json1_1DetectDocumentTextResponse = (
       output.Blocks !== undefined && output.Blocks !== null
         ? deserializeAws_json1_1BlockList(output.Blocks, context)
         : undefined,
-    DetectDocumentTextModelVersion:
-      output.DetectDocumentTextModelVersion !== undefined && output.DetectDocumentTextModelVersion !== null
-        ? output.DetectDocumentTextModelVersion
-        : undefined,
+    DetectDocumentTextModelVersion: __expectString(output.DetectDocumentTextModelVersion),
     DocumentMetadata:
       output.DocumentMetadata !== undefined && output.DocumentMetadata !== null
         ? deserializeAws_json1_1DocumentMetadata(output.DocumentMetadata, context)
@@ -1375,7 +1373,7 @@ const deserializeAws_json1_1DetectDocumentTextResponse = (
 
 const deserializeAws_json1_1DocumentMetadata = (output: any, context: __SerdeContext): DocumentMetadata => {
   return {
-    Pages: output.Pages !== undefined && output.Pages !== null ? output.Pages : undefined,
+    Pages: __expectNumber(output.Pages),
   } as any;
 };
 
@@ -1384,8 +1382,8 @@ const deserializeAws_json1_1DocumentTooLargeException = (
   context: __SerdeContext
 ): DocumentTooLargeException => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -1396,7 +1394,7 @@ const deserializeAws_json1_1EntityTypes = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -1418,10 +1416,7 @@ const deserializeAws_json1_1GetDocumentAnalysisResponse = (
   context: __SerdeContext
 ): GetDocumentAnalysisResponse => {
   return {
-    AnalyzeDocumentModelVersion:
-      output.AnalyzeDocumentModelVersion !== undefined && output.AnalyzeDocumentModelVersion !== null
-        ? output.AnalyzeDocumentModelVersion
-        : undefined,
+    AnalyzeDocumentModelVersion: __expectString(output.AnalyzeDocumentModelVersion),
     Blocks:
       output.Blocks !== undefined && output.Blocks !== null
         ? deserializeAws_json1_1BlockList(output.Blocks, context)
@@ -1430,10 +1425,9 @@ const deserializeAws_json1_1GetDocumentAnalysisResponse = (
       output.DocumentMetadata !== undefined && output.DocumentMetadata !== null
         ? deserializeAws_json1_1DocumentMetadata(output.DocumentMetadata, context)
         : undefined,
-    JobStatus: output.JobStatus !== undefined && output.JobStatus !== null ? output.JobStatus : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
-    StatusMessage:
-      output.StatusMessage !== undefined && output.StatusMessage !== null ? output.StatusMessage : undefined,
+    JobStatus: __expectString(output.JobStatus),
+    NextToken: __expectString(output.NextToken),
+    StatusMessage: __expectString(output.StatusMessage),
     Warnings:
       output.Warnings !== undefined && output.Warnings !== null
         ? deserializeAws_json1_1Warnings(output.Warnings, context)
@@ -1450,18 +1444,14 @@ const deserializeAws_json1_1GetDocumentTextDetectionResponse = (
       output.Blocks !== undefined && output.Blocks !== null
         ? deserializeAws_json1_1BlockList(output.Blocks, context)
         : undefined,
-    DetectDocumentTextModelVersion:
-      output.DetectDocumentTextModelVersion !== undefined && output.DetectDocumentTextModelVersion !== null
-        ? output.DetectDocumentTextModelVersion
-        : undefined,
+    DetectDocumentTextModelVersion: __expectString(output.DetectDocumentTextModelVersion),
     DocumentMetadata:
       output.DocumentMetadata !== undefined && output.DocumentMetadata !== null
         ? deserializeAws_json1_1DocumentMetadata(output.DocumentMetadata, context)
         : undefined,
-    JobStatus: output.JobStatus !== undefined && output.JobStatus !== null ? output.JobStatus : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
-    StatusMessage:
-      output.StatusMessage !== undefined && output.StatusMessage !== null ? output.StatusMessage : undefined,
+    JobStatus: __expectString(output.JobStatus),
+    NextToken: __expectString(output.NextToken),
+    StatusMessage: __expectString(output.StatusMessage),
     Warnings:
       output.Warnings !== undefined && output.Warnings !== null
         ? deserializeAws_json1_1Warnings(output.Warnings, context)
@@ -1483,7 +1473,7 @@ const deserializeAws_json1_1HumanLoopActivationOutput = (
       output.HumanLoopActivationReasons !== undefined && output.HumanLoopActivationReasons !== null
         ? deserializeAws_json1_1HumanLoopActivationReasons(output.HumanLoopActivationReasons, context)
         : undefined,
-    HumanLoopArn: output.HumanLoopArn !== undefined && output.HumanLoopArn !== null ? output.HumanLoopArn : undefined,
+    HumanLoopArn: __expectString(output.HumanLoopArn),
   } as any;
 };
 
@@ -1494,7 +1484,7 @@ const deserializeAws_json1_1HumanLoopActivationReasons = (output: any, context: 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -1503,11 +1493,11 @@ const deserializeAws_json1_1HumanLoopQuotaExceededException = (
   context: __SerdeContext
 ): HumanLoopQuotaExceededException => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    QuotaCode: output.QuotaCode !== undefined && output.QuotaCode !== null ? output.QuotaCode : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
-    ServiceCode: output.ServiceCode !== undefined && output.ServiceCode !== null ? output.ServiceCode : undefined,
+    Code: __expectString(output.Code),
+    Message: __expectString(output.Message),
+    QuotaCode: __expectString(output.QuotaCode),
+    ResourceType: __expectString(output.ResourceType),
+    ServiceCode: __expectString(output.ServiceCode),
   } as any;
 };
 
@@ -1516,8 +1506,8 @@ const deserializeAws_json1_1IdempotentParameterMismatchException = (
   context: __SerdeContext
 ): IdempotentParameterMismatchException => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -1528,28 +1518,28 @@ const deserializeAws_json1_1IdList = (output: any, context: __SerdeContext): str
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1InternalServerError = (output: any, context: __SerdeContext): InternalServerError => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidJobIdException = (output: any, context: __SerdeContext): InvalidJobIdException => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidKMSKeyException = (output: any, context: __SerdeContext): InvalidKMSKeyException => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -1558,8 +1548,8 @@ const deserializeAws_json1_1InvalidParameterException = (
   context: __SerdeContext
 ): InvalidParameterException => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -1568,15 +1558,15 @@ const deserializeAws_json1_1InvalidS3ObjectException = (
   context: __SerdeContext
 ): InvalidS3ObjectException => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -1587,14 +1577,14 @@ const deserializeAws_json1_1Pages = (output: any, context: __SerdeContext): numb
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectNumber(entry) as any;
     });
 };
 
 const deserializeAws_json1_1Point = (output: any, context: __SerdeContext): Point => {
   return {
-    X: output.X !== undefined && output.X !== null ? output.X : undefined,
-    Y: output.Y !== undefined && output.Y !== null ? output.Y : undefined,
+    X: __expectNumber(output.X),
+    Y: __expectNumber(output.Y),
   } as any;
 };
 
@@ -1614,8 +1604,8 @@ const deserializeAws_json1_1ProvisionedThroughputExceededException = (
   context: __SerdeContext
 ): ProvisionedThroughputExceededException => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -1623,7 +1613,7 @@ const deserializeAws_json1_1Relationship = (output: any, context: __SerdeContext
   return {
     Ids:
       output.Ids !== undefined && output.Ids !== null ? deserializeAws_json1_1IdList(output.Ids, context) : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -1643,7 +1633,7 @@ const deserializeAws_json1_1StartDocumentAnalysisResponse = (
   context: __SerdeContext
 ): StartDocumentAnalysisResponse => {
   return {
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
+    JobId: __expectString(output.JobId),
   } as any;
 };
 
@@ -1652,14 +1642,14 @@ const deserializeAws_json1_1StartDocumentTextDetectionResponse = (
   context: __SerdeContext
 ): StartDocumentTextDetectionResponse => {
   return {
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
+    JobId: __expectString(output.JobId),
   } as any;
 };
 
 const deserializeAws_json1_1ThrottlingException = (output: any, context: __SerdeContext): ThrottlingException => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -1668,14 +1658,14 @@ const deserializeAws_json1_1UnsupportedDocumentException = (
   context: __SerdeContext
 ): UnsupportedDocumentException => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Code: __expectString(output.Code),
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1Warning = (output: any, context: __SerdeContext): Warning => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
     Pages:
       output.Pages !== undefined && output.Pages !== null
         ? deserializeAws_json1_1Pages(output.Pages, context)

--- a/clients/client-timestream-query/protocols/Aws_json1_0.ts
+++ b/clients/client-timestream-query/protocols/Aws_json1_0.ts
@@ -24,7 +24,12 @@ import {
   ValidationException,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -460,22 +465,19 @@ const serializeAws_json1_0QueryRequest = (input: QueryRequest, context: __SerdeC
 
 const deserializeAws_json1_0AccessDeniedException = (output: any, context: __SerdeContext): AccessDeniedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_0CancelQueryResponse = (output: any, context: __SerdeContext): CancelQueryResponse => {
   return {
-    CancellationMessage:
-      output.CancellationMessage !== undefined && output.CancellationMessage !== null
-        ? output.CancellationMessage
-        : undefined,
+    CancellationMessage: __expectString(output.CancellationMessage),
   } as any;
 };
 
 const deserializeAws_json1_0ColumnInfo = (output: any, context: __SerdeContext): ColumnInfo => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     Type:
       output.Type !== undefined && output.Type !== null ? deserializeAws_json1_0Type(output.Type, context) : undefined,
   } as any;
@@ -494,7 +496,7 @@ const deserializeAws_json1_0ColumnInfoList = (output: any, context: __SerdeConte
 
 const deserializeAws_json1_0ConflictException = (output: any, context: __SerdeContext): ConflictException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -504,12 +506,12 @@ const deserializeAws_json1_0Datum = (output: any, context: __SerdeContext): Datu
       output.ArrayValue !== undefined && output.ArrayValue !== null
         ? deserializeAws_json1_0DatumList(output.ArrayValue, context)
         : undefined,
-    NullValue: output.NullValue !== undefined && output.NullValue !== null ? output.NullValue : undefined,
+    NullValue: __expectBoolean(output.NullValue),
     RowValue:
       output.RowValue !== undefined && output.RowValue !== null
         ? deserializeAws_json1_0Row(output.RowValue, context)
         : undefined,
-    ScalarValue: output.ScalarValue !== undefined && output.ScalarValue !== null ? output.ScalarValue : undefined,
+    ScalarValue: __expectString(output.ScalarValue),
     TimeSeriesValue:
       output.TimeSeriesValue !== undefined && output.TimeSeriesValue !== null
         ? deserializeAws_json1_0TimeSeriesDataPointList(output.TimeSeriesValue, context)
@@ -542,11 +544,8 @@ const deserializeAws_json1_0DescribeEndpointsResponse = (
 
 const deserializeAws_json1_0Endpoint = (output: any, context: __SerdeContext): Endpoint => {
   return {
-    Address: output.Address !== undefined && output.Address !== null ? output.Address : undefined,
-    CachePeriodInMinutes:
-      output.CachePeriodInMinutes !== undefined && output.CachePeriodInMinutes !== null
-        ? output.CachePeriodInMinutes
-        : undefined,
+    Address: __expectString(output.Address),
+    CachePeriodInMinutes: __expectNumber(output.CachePeriodInMinutes),
   } as any;
 };
 
@@ -566,7 +565,7 @@ const deserializeAws_json1_0InternalServerException = (
   context: __SerdeContext
 ): InternalServerException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -575,7 +574,7 @@ const deserializeAws_json1_0InvalidEndpointException = (
   context: __SerdeContext
 ): InvalidEndpointException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -584,7 +583,7 @@ const deserializeAws_json1_0QueryExecutionException = (
   context: __SerdeContext
 ): QueryExecutionException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -594,8 +593,8 @@ const deserializeAws_json1_0QueryResponse = (output: any, context: __SerdeContex
       output.ColumnInfo !== undefined && output.ColumnInfo !== null
         ? deserializeAws_json1_0ColumnInfoList(output.ColumnInfo, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
-    QueryId: output.QueryId !== undefined && output.QueryId !== null ? output.QueryId : undefined,
+    NextToken: __expectString(output.NextToken),
+    QueryId: __expectString(output.QueryId),
     QueryStatus:
       output.QueryStatus !== undefined && output.QueryStatus !== null
         ? deserializeAws_json1_0QueryStatus(output.QueryStatus, context)
@@ -609,18 +608,9 @@ const deserializeAws_json1_0QueryResponse = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_0QueryStatus = (output: any, context: __SerdeContext): QueryStatus => {
   return {
-    CumulativeBytesMetered:
-      output.CumulativeBytesMetered !== undefined && output.CumulativeBytesMetered !== null
-        ? output.CumulativeBytesMetered
-        : undefined,
-    CumulativeBytesScanned:
-      output.CumulativeBytesScanned !== undefined && output.CumulativeBytesScanned !== null
-        ? output.CumulativeBytesScanned
-        : undefined,
-    ProgressPercentage:
-      output.ProgressPercentage !== undefined && output.ProgressPercentage !== null
-        ? output.ProgressPercentage
-        : undefined,
+    CumulativeBytesMetered: __expectNumber(output.CumulativeBytesMetered),
+    CumulativeBytesScanned: __expectNumber(output.CumulativeBytesScanned),
+    ProgressPercentage: __expectNumber(output.ProgressPercentage),
   } as any;
 };
 
@@ -646,13 +636,13 @@ const deserializeAws_json1_0RowList = (output: any, context: __SerdeContext): Ro
 
 const deserializeAws_json1_0ThrottlingException = (output: any, context: __SerdeContext): ThrottlingException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_0TimeSeriesDataPoint = (output: any, context: __SerdeContext): TimeSeriesDataPoint => {
   return {
-    Time: output.Time !== undefined && output.Time !== null ? output.Time : undefined,
+    Time: __expectString(output.Time),
     Value:
       output.Value !== undefined && output.Value !== null
         ? deserializeAws_json1_0Datum(output.Value, context)
@@ -681,7 +671,7 @@ const deserializeAws_json1_0Type = (output: any, context: __SerdeContext): Type 
       output.RowColumnInfo !== undefined && output.RowColumnInfo !== null
         ? deserializeAws_json1_0ColumnInfoList(output.RowColumnInfo, context)
         : undefined,
-    ScalarType: output.ScalarType !== undefined && output.ScalarType !== null ? output.ScalarType : undefined,
+    ScalarType: __expectString(output.ScalarType),
     TimeSeriesMeasureValueColumnInfo:
       output.TimeSeriesMeasureValueColumnInfo !== undefined && output.TimeSeriesMeasureValueColumnInfo !== null
         ? deserializeAws_json1_0ColumnInfo(output.TimeSeriesMeasureValueColumnInfo, context)
@@ -691,7 +681,7 @@ const deserializeAws_json1_0Type = (output: any, context: __SerdeContext): Type 
 
 const deserializeAws_json1_0ValidationException = (output: any, context: __SerdeContext): ValidationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 

--- a/clients/client-timestream-write/protocols/Aws_json1_0.ts
+++ b/clients/client-timestream-write/protocols/Aws_json1_0.ts
@@ -63,7 +63,11 @@ import {
   _Record,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -1991,13 +1995,13 @@ const serializeAws_json1_0WriteRecordsRequest = (input: WriteRecordsRequest, con
 
 const deserializeAws_json1_0AccessDeniedException = (output: any, context: __SerdeContext): AccessDeniedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_0ConflictException = (output: any, context: __SerdeContext): ConflictException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2021,18 +2025,18 @@ const deserializeAws_json1_0CreateTableResponse = (output: any, context: __Serde
 
 const deserializeAws_json1_0Database = (output: any, context: __SerdeContext): Database => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    DatabaseName: output.DatabaseName !== undefined && output.DatabaseName !== null ? output.DatabaseName : undefined,
-    KmsKeyId: output.KmsKeyId !== undefined && output.KmsKeyId !== null ? output.KmsKeyId : undefined,
+    DatabaseName: __expectString(output.DatabaseName),
+    KmsKeyId: __expectString(output.KmsKeyId),
     LastUpdatedTime:
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
         ? new Date(Math.round(output.LastUpdatedTime * 1000))
         : undefined,
-    TableCount: output.TableCount !== undefined && output.TableCount !== null ? output.TableCount : undefined,
+    TableCount: __expectNumber(output.TableCount),
   } as any;
 };
 
@@ -2082,11 +2086,8 @@ const deserializeAws_json1_0DescribeTableResponse = (output: any, context: __Ser
 
 const deserializeAws_json1_0Endpoint = (output: any, context: __SerdeContext): Endpoint => {
   return {
-    Address: output.Address !== undefined && output.Address !== null ? output.Address : undefined,
-    CachePeriodInMinutes:
-      output.CachePeriodInMinutes !== undefined && output.CachePeriodInMinutes !== null
-        ? output.CachePeriodInMinutes
-        : undefined,
+    Address: __expectString(output.Address),
+    CachePeriodInMinutes: __expectNumber(output.CachePeriodInMinutes),
   } as any;
 };
 
@@ -2106,7 +2107,7 @@ const deserializeAws_json1_0InternalServerException = (
   context: __SerdeContext
 ): InternalServerException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2115,7 +2116,7 @@ const deserializeAws_json1_0InvalidEndpointException = (
   context: __SerdeContext
 ): InvalidEndpointException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2125,13 +2126,13 @@ const deserializeAws_json1_0ListDatabasesResponse = (output: any, context: __Ser
       output.Databases !== undefined && output.Databases !== null
         ? deserializeAws_json1_0DatabaseList(output.Databases, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
 const deserializeAws_json1_0ListTablesResponse = (output: any, context: __SerdeContext): ListTablesResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Tables:
       output.Tables !== undefined && output.Tables !== null
         ? deserializeAws_json1_0TableList(output.Tables, context)
@@ -2153,10 +2154,9 @@ const deserializeAws_json1_0ListTagsForResourceResponse = (
 
 const deserializeAws_json1_0RejectedRecord = (output: any, context: __SerdeContext): RejectedRecord => {
   return {
-    ExistingVersion:
-      output.ExistingVersion !== undefined && output.ExistingVersion !== null ? output.ExistingVersion : undefined,
-    Reason: output.Reason !== undefined && output.Reason !== null ? output.Reason : undefined,
-    RecordIndex: output.RecordIndex !== undefined && output.RecordIndex !== null ? output.RecordIndex : undefined,
+    ExistingVersion: __expectNumber(output.ExistingVersion),
+    Reason: __expectString(output.Reason),
+    RecordIndex: __expectNumber(output.RecordIndex),
   } as any;
 };
 
@@ -2176,7 +2176,7 @@ const deserializeAws_json1_0RejectedRecordsException = (
   context: __SerdeContext
 ): RejectedRecordsException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
     RejectedRecords:
       output.RejectedRecords !== undefined && output.RejectedRecords !== null
         ? deserializeAws_json1_0RejectedRecords(output.RejectedRecords, context)
@@ -2189,20 +2189,14 @@ const deserializeAws_json1_0ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_0RetentionProperties = (output: any, context: __SerdeContext): RetentionProperties => {
   return {
-    MagneticStoreRetentionPeriodInDays:
-      output.MagneticStoreRetentionPeriodInDays !== undefined && output.MagneticStoreRetentionPeriodInDays !== null
-        ? output.MagneticStoreRetentionPeriodInDays
-        : undefined,
-    MemoryStoreRetentionPeriodInHours:
-      output.MemoryStoreRetentionPeriodInHours !== undefined && output.MemoryStoreRetentionPeriodInHours !== null
-        ? output.MemoryStoreRetentionPeriodInHours
-        : undefined,
+    MagneticStoreRetentionPeriodInDays: __expectNumber(output.MagneticStoreRetentionPeriodInDays),
+    MemoryStoreRetentionPeriodInHours: __expectNumber(output.MemoryStoreRetentionPeriodInHours),
   } as any;
 };
 
@@ -2211,18 +2205,18 @@ const deserializeAws_json1_0ServiceQuotaExceededException = (
   context: __SerdeContext
 ): ServiceQuotaExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_0Table = (output: any, context: __SerdeContext): Table => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    DatabaseName: output.DatabaseName !== undefined && output.DatabaseName !== null ? output.DatabaseName : undefined,
+    DatabaseName: __expectString(output.DatabaseName),
     LastUpdatedTime:
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
         ? new Date(Math.round(output.LastUpdatedTime * 1000))
@@ -2231,8 +2225,8 @@ const deserializeAws_json1_0Table = (output: any, context: __SerdeContext): Tabl
       output.RetentionProperties !== undefined && output.RetentionProperties !== null
         ? deserializeAws_json1_0RetentionProperties(output.RetentionProperties, context)
         : undefined,
-    TableName: output.TableName !== undefined && output.TableName !== null ? output.TableName : undefined,
-    TableStatus: output.TableStatus !== undefined && output.TableStatus !== null ? output.TableStatus : undefined,
+    TableName: __expectString(output.TableName),
+    TableStatus: __expectString(output.TableStatus),
   } as any;
 };
 
@@ -2249,8 +2243,8 @@ const deserializeAws_json1_0TableList = (output: any, context: __SerdeContext): 
 
 const deserializeAws_json1_0Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -2271,7 +2265,7 @@ const deserializeAws_json1_0TagResourceResponse = (output: any, context: __Serde
 
 const deserializeAws_json1_0ThrottlingException = (output: any, context: __SerdeContext): ThrottlingException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2299,7 +2293,7 @@ const deserializeAws_json1_0UpdateTableResponse = (output: any, context: __Serde
 
 const deserializeAws_json1_0ValidationException = (output: any, context: __SerdeContext): ValidationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 

--- a/clients/client-transcribe-streaming/protocols/Aws_restJson1.ts
+++ b/clients/client-transcribe-streaming/protocols/Aws_restJson1.ts
@@ -29,7 +29,13 @@ import {
   TranscriptResultStream,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException, parseBoolean as __parseBoolean } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+  parseBoolean as __parseBoolean,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   EventStreamSerdeContext as __EventStreamSerdeContext,
@@ -645,7 +651,7 @@ const deserializeAws_restJson1BadRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -662,7 +668,7 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -679,7 +685,7 @@ const deserializeAws_restJson1InternalFailureExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -696,7 +702,7 @@ const deserializeAws_restJson1LimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -713,7 +719,7 @@ const deserializeAws_restJson1ServiceUnavailableExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -738,7 +744,7 @@ const deserializeAws_restJson1Alternative = (output: any, context: __SerdeContex
       output.Items !== undefined && output.Items !== null
         ? deserializeAws_restJson1ItemList(output.Items, context)
         : undefined,
-    Transcript: output.Transcript !== undefined && output.Transcript !== null ? output.Transcript : undefined,
+    Transcript: __expectString(output.Transcript),
   } as any;
 };
 
@@ -755,13 +761,13 @@ const deserializeAws_restJson1AlternativeList = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1BadRequestException = (output: any, context: __SerdeContext): BadRequestException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_restJson1ConflictException = (output: any, context: __SerdeContext): ConflictException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -770,23 +776,20 @@ const deserializeAws_restJson1InternalFailureException = (
   context: __SerdeContext
 ): InternalFailureException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_restJson1Item = (output: any, context: __SerdeContext): Item => {
   return {
-    Confidence: output.Confidence !== undefined && output.Confidence !== null ? output.Confidence : undefined,
-    Content: output.Content !== undefined && output.Content !== null ? output.Content : undefined,
-    EndTime: output.EndTime !== undefined && output.EndTime !== null ? output.EndTime : undefined,
-    Speaker: output.Speaker !== undefined && output.Speaker !== null ? output.Speaker : undefined,
-    Stable: output.Stable !== undefined && output.Stable !== null ? output.Stable : undefined,
-    StartTime: output.StartTime !== undefined && output.StartTime !== null ? output.StartTime : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    VocabularyFilterMatch:
-      output.VocabularyFilterMatch !== undefined && output.VocabularyFilterMatch !== null
-        ? output.VocabularyFilterMatch
-        : undefined,
+    Confidence: __expectNumber(output.Confidence),
+    Content: __expectString(output.Content),
+    EndTime: __expectNumber(output.EndTime),
+    Speaker: __expectString(output.Speaker),
+    Stable: __expectBoolean(output.Stable),
+    StartTime: __expectNumber(output.StartTime),
+    Type: __expectString(output.Type),
+    VocabularyFilterMatch: __expectBoolean(output.VocabularyFilterMatch),
   } as any;
 };
 
@@ -806,7 +809,7 @@ const deserializeAws_restJson1LimitExceededException = (
   context: __SerdeContext
 ): LimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -820,7 +823,7 @@ const deserializeAws_restJson1MedicalAlternative = (output: any, context: __Serd
       output.Items !== undefined && output.Items !== null
         ? deserializeAws_restJson1MedicalItemList(output.Items, context)
         : undefined,
-    Transcript: output.Transcript !== undefined && output.Transcript !== null ? output.Transcript : undefined,
+    Transcript: __expectString(output.Transcript),
   } as any;
 };
 
@@ -837,11 +840,11 @@ const deserializeAws_restJson1MedicalAlternativeList = (output: any, context: __
 
 const deserializeAws_restJson1MedicalEntity = (output: any, context: __SerdeContext): MedicalEntity => {
   return {
-    Category: output.Category !== undefined && output.Category !== null ? output.Category : undefined,
-    Confidence: output.Confidence !== undefined && output.Confidence !== null ? output.Confidence : undefined,
-    Content: output.Content !== undefined && output.Content !== null ? output.Content : undefined,
-    EndTime: output.EndTime !== undefined && output.EndTime !== null ? output.EndTime : undefined,
-    StartTime: output.StartTime !== undefined && output.StartTime !== null ? output.StartTime : undefined,
+    Category: __expectString(output.Category),
+    Confidence: __expectNumber(output.Confidence),
+    Content: __expectString(output.Content),
+    EndTime: __expectNumber(output.EndTime),
+    StartTime: __expectNumber(output.StartTime),
   } as any;
 };
 
@@ -858,12 +861,12 @@ const deserializeAws_restJson1MedicalEntityList = (output: any, context: __Serde
 
 const deserializeAws_restJson1MedicalItem = (output: any, context: __SerdeContext): MedicalItem => {
   return {
-    Confidence: output.Confidence !== undefined && output.Confidence !== null ? output.Confidence : undefined,
-    Content: output.Content !== undefined && output.Content !== null ? output.Content : undefined,
-    EndTime: output.EndTime !== undefined && output.EndTime !== null ? output.EndTime : undefined,
-    Speaker: output.Speaker !== undefined && output.Speaker !== null ? output.Speaker : undefined,
-    StartTime: output.StartTime !== undefined && output.StartTime !== null ? output.StartTime : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Confidence: __expectNumber(output.Confidence),
+    Content: __expectString(output.Content),
+    EndTime: __expectNumber(output.EndTime),
+    Speaker: __expectString(output.Speaker),
+    StartTime: __expectNumber(output.StartTime),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -884,11 +887,11 @@ const deserializeAws_restJson1MedicalResult = (output: any, context: __SerdeCont
       output.Alternatives !== undefined && output.Alternatives !== null
         ? deserializeAws_restJson1MedicalAlternativeList(output.Alternatives, context)
         : undefined,
-    ChannelId: output.ChannelId !== undefined && output.ChannelId !== null ? output.ChannelId : undefined,
-    EndTime: output.EndTime !== undefined && output.EndTime !== null ? output.EndTime : undefined,
-    IsPartial: output.IsPartial !== undefined && output.IsPartial !== null ? output.IsPartial : undefined,
-    ResultId: output.ResultId !== undefined && output.ResultId !== null ? output.ResultId : undefined,
-    StartTime: output.StartTime !== undefined && output.StartTime !== null ? output.StartTime : undefined,
+    ChannelId: __expectString(output.ChannelId),
+    EndTime: __expectNumber(output.EndTime),
+    IsPartial: __expectBoolean(output.IsPartial),
+    ResultId: __expectString(output.ResultId),
+    StartTime: __expectNumber(output.StartTime),
   } as any;
 };
 
@@ -973,11 +976,11 @@ const deserializeAws_restJson1Result = (output: any, context: __SerdeContext): R
       output.Alternatives !== undefined && output.Alternatives !== null
         ? deserializeAws_restJson1AlternativeList(output.Alternatives, context)
         : undefined,
-    ChannelId: output.ChannelId !== undefined && output.ChannelId !== null ? output.ChannelId : undefined,
-    EndTime: output.EndTime !== undefined && output.EndTime !== null ? output.EndTime : undefined,
-    IsPartial: output.IsPartial !== undefined && output.IsPartial !== null ? output.IsPartial : undefined,
-    ResultId: output.ResultId !== undefined && output.ResultId !== null ? output.ResultId : undefined,
-    StartTime: output.StartTime !== undefined && output.StartTime !== null ? output.StartTime : undefined,
+    ChannelId: __expectString(output.ChannelId),
+    EndTime: __expectNumber(output.EndTime),
+    IsPartial: __expectBoolean(output.IsPartial),
+    ResultId: __expectString(output.ResultId),
+    StartTime: __expectNumber(output.StartTime),
   } as any;
 };
 
@@ -997,7 +1000,7 @@ const deserializeAws_restJson1ServiceUnavailableException = (
   context: __SerdeContext
 ): ServiceUnavailableException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 

--- a/clients/client-transcribe/protocols/Aws_json1_1.ts
+++ b/clients/client-transcribe/protocols/Aws_json1_1.ts
@@ -161,7 +161,12 @@ import {
   VocabularyInfo,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -3090,22 +3095,20 @@ const serializeAws_json1_1Words = (input: string[], context: __SerdeContext): an
 
 const deserializeAws_json1_1BadRequestException = (output: any, context: __SerdeContext): BadRequestException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1ConflictException = (output: any, context: __SerdeContext): ConflictException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1ContentRedaction = (output: any, context: __SerdeContext): ContentRedaction => {
   return {
-    RedactionOutput:
-      output.RedactionOutput !== undefined && output.RedactionOutput !== null ? output.RedactionOutput : undefined,
-    RedactionType:
-      output.RedactionType !== undefined && output.RedactionType !== null ? output.RedactionType : undefined,
+    RedactionOutput: __expectString(output.RedactionOutput),
+    RedactionType: __expectString(output.RedactionType),
   } as any;
 };
 
@@ -3114,15 +3117,14 @@ const deserializeAws_json1_1CreateLanguageModelResponse = (
   context: __SerdeContext
 ): CreateLanguageModelResponse => {
   return {
-    BaseModelName:
-      output.BaseModelName !== undefined && output.BaseModelName !== null ? output.BaseModelName : undefined,
+    BaseModelName: __expectString(output.BaseModelName),
     InputDataConfig:
       output.InputDataConfig !== undefined && output.InputDataConfig !== null
         ? deserializeAws_json1_1InputDataConfig(output.InputDataConfig, context)
         : undefined,
-    LanguageCode: output.LanguageCode !== undefined && output.LanguageCode !== null ? output.LanguageCode : undefined,
-    ModelName: output.ModelName !== undefined && output.ModelName !== null ? output.ModelName : undefined,
-    ModelStatus: output.ModelStatus !== undefined && output.ModelStatus !== null ? output.ModelStatus : undefined,
+    LanguageCode: __expectString(output.LanguageCode),
+    ModelName: __expectString(output.ModelName),
+    ModelStatus: __expectString(output.ModelStatus),
   } as any;
 };
 
@@ -3131,17 +3133,14 @@ const deserializeAws_json1_1CreateMedicalVocabularyResponse = (
   context: __SerdeContext
 ): CreateMedicalVocabularyResponse => {
   return {
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
-    LanguageCode: output.LanguageCode !== undefined && output.LanguageCode !== null ? output.LanguageCode : undefined,
+    FailureReason: __expectString(output.FailureReason),
+    LanguageCode: __expectString(output.LanguageCode),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    VocabularyName:
-      output.VocabularyName !== undefined && output.VocabularyName !== null ? output.VocabularyName : undefined,
-    VocabularyState:
-      output.VocabularyState !== undefined && output.VocabularyState !== null ? output.VocabularyState : undefined,
+    VocabularyName: __expectString(output.VocabularyName),
+    VocabularyState: __expectString(output.VocabularyState),
   } as any;
 };
 
@@ -3150,15 +3149,12 @@ const deserializeAws_json1_1CreateVocabularyFilterResponse = (
   context: __SerdeContext
 ): CreateVocabularyFilterResponse => {
   return {
-    LanguageCode: output.LanguageCode !== undefined && output.LanguageCode !== null ? output.LanguageCode : undefined,
+    LanguageCode: __expectString(output.LanguageCode),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    VocabularyFilterName:
-      output.VocabularyFilterName !== undefined && output.VocabularyFilterName !== null
-        ? output.VocabularyFilterName
-        : undefined,
+    VocabularyFilterName: __expectString(output.VocabularyFilterName),
   } as any;
 };
 
@@ -3167,17 +3163,14 @@ const deserializeAws_json1_1CreateVocabularyResponse = (
   context: __SerdeContext
 ): CreateVocabularyResponse => {
   return {
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
-    LanguageCode: output.LanguageCode !== undefined && output.LanguageCode !== null ? output.LanguageCode : undefined,
+    FailureReason: __expectString(output.FailureReason),
+    LanguageCode: __expectString(output.LanguageCode),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    VocabularyName:
-      output.VocabularyName !== undefined && output.VocabularyName !== null ? output.VocabularyName : undefined,
-    VocabularyState:
-      output.VocabularyState !== undefined && output.VocabularyState !== null ? output.VocabularyState : undefined,
+    VocabularyName: __expectString(output.VocabularyName),
+    VocabularyState: __expectString(output.VocabularyState),
   } as any;
 };
 
@@ -3210,18 +3203,15 @@ const deserializeAws_json1_1GetMedicalVocabularyResponse = (
   context: __SerdeContext
 ): GetMedicalVocabularyResponse => {
   return {
-    DownloadUri: output.DownloadUri !== undefined && output.DownloadUri !== null ? output.DownloadUri : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
-    LanguageCode: output.LanguageCode !== undefined && output.LanguageCode !== null ? output.LanguageCode : undefined,
+    DownloadUri: __expectString(output.DownloadUri),
+    FailureReason: __expectString(output.FailureReason),
+    LanguageCode: __expectString(output.LanguageCode),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    VocabularyName:
-      output.VocabularyName !== undefined && output.VocabularyName !== null ? output.VocabularyName : undefined,
-    VocabularyState:
-      output.VocabularyState !== undefined && output.VocabularyState !== null ? output.VocabularyState : undefined,
+    VocabularyName: __expectString(output.VocabularyName),
+    VocabularyState: __expectString(output.VocabularyState),
   } as any;
 };
 
@@ -3242,45 +3232,35 @@ const deserializeAws_json1_1GetVocabularyFilterResponse = (
   context: __SerdeContext
 ): GetVocabularyFilterResponse => {
   return {
-    DownloadUri: output.DownloadUri !== undefined && output.DownloadUri !== null ? output.DownloadUri : undefined,
-    LanguageCode: output.LanguageCode !== undefined && output.LanguageCode !== null ? output.LanguageCode : undefined,
+    DownloadUri: __expectString(output.DownloadUri),
+    LanguageCode: __expectString(output.LanguageCode),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    VocabularyFilterName:
-      output.VocabularyFilterName !== undefined && output.VocabularyFilterName !== null
-        ? output.VocabularyFilterName
-        : undefined,
+    VocabularyFilterName: __expectString(output.VocabularyFilterName),
   } as any;
 };
 
 const deserializeAws_json1_1GetVocabularyResponse = (output: any, context: __SerdeContext): GetVocabularyResponse => {
   return {
-    DownloadUri: output.DownloadUri !== undefined && output.DownloadUri !== null ? output.DownloadUri : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
-    LanguageCode: output.LanguageCode !== undefined && output.LanguageCode !== null ? output.LanguageCode : undefined,
+    DownloadUri: __expectString(output.DownloadUri),
+    FailureReason: __expectString(output.FailureReason),
+    LanguageCode: __expectString(output.LanguageCode),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    VocabularyName:
-      output.VocabularyName !== undefined && output.VocabularyName !== null ? output.VocabularyName : undefined,
-    VocabularyState:
-      output.VocabularyState !== undefined && output.VocabularyState !== null ? output.VocabularyState : undefined,
+    VocabularyName: __expectString(output.VocabularyName),
+    VocabularyState: __expectString(output.VocabularyState),
   } as any;
 };
 
 const deserializeAws_json1_1InputDataConfig = (output: any, context: __SerdeContext): InputDataConfig => {
   return {
-    DataAccessRoleArn:
-      output.DataAccessRoleArn !== undefined && output.DataAccessRoleArn !== null
-        ? output.DataAccessRoleArn
-        : undefined,
-    S3Uri: output.S3Uri !== undefined && output.S3Uri !== null ? output.S3Uri : undefined,
-    TuningDataS3Uri:
-      output.TuningDataS3Uri !== undefined && output.TuningDataS3Uri !== null ? output.TuningDataS3Uri : undefined,
+    DataAccessRoleArn: __expectString(output.DataAccessRoleArn),
+    S3Uri: __expectString(output.S3Uri),
+    TuningDataS3Uri: __expectString(output.TuningDataS3Uri),
   } as any;
 };
 
@@ -3289,48 +3269,37 @@ const deserializeAws_json1_1InternalFailureException = (
   context: __SerdeContext
 ): InternalFailureException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1JobExecutionSettings = (output: any, context: __SerdeContext): JobExecutionSettings => {
   return {
-    AllowDeferredExecution:
-      output.AllowDeferredExecution !== undefined && output.AllowDeferredExecution !== null
-        ? output.AllowDeferredExecution
-        : undefined,
-    DataAccessRoleArn:
-      output.DataAccessRoleArn !== undefined && output.DataAccessRoleArn !== null
-        ? output.DataAccessRoleArn
-        : undefined,
+    AllowDeferredExecution: __expectBoolean(output.AllowDeferredExecution),
+    DataAccessRoleArn: __expectString(output.DataAccessRoleArn),
   } as any;
 };
 
 const deserializeAws_json1_1LanguageModel = (output: any, context: __SerdeContext): LanguageModel => {
   return {
-    BaseModelName:
-      output.BaseModelName !== undefined && output.BaseModelName !== null ? output.BaseModelName : undefined,
+    BaseModelName: __expectString(output.BaseModelName),
     CreateTime:
       output.CreateTime !== undefined && output.CreateTime !== null
         ? new Date(Math.round(output.CreateTime * 1000))
         : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
+    FailureReason: __expectString(output.FailureReason),
     InputDataConfig:
       output.InputDataConfig !== undefined && output.InputDataConfig !== null
         ? deserializeAws_json1_1InputDataConfig(output.InputDataConfig, context)
         : undefined,
-    LanguageCode: output.LanguageCode !== undefined && output.LanguageCode !== null ? output.LanguageCode : undefined,
+    LanguageCode: __expectString(output.LanguageCode),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    ModelName: output.ModelName !== undefined && output.ModelName !== null ? output.ModelName : undefined,
-    ModelStatus: output.ModelStatus !== undefined && output.ModelStatus !== null ? output.ModelStatus : undefined,
-    UpgradeAvailability:
-      output.UpgradeAvailability !== undefined && output.UpgradeAvailability !== null
-        ? output.UpgradeAvailability
-        : undefined,
+    ModelName: __expectString(output.ModelName),
+    ModelStatus: __expectString(output.ModelStatus),
+    UpgradeAvailability: __expectBoolean(output.UpgradeAvailability),
   } as any;
 };
 
@@ -3341,13 +3310,13 @@ const deserializeAws_json1_1LanguageOptions = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3360,7 +3329,7 @@ const deserializeAws_json1_1ListLanguageModelsResponse = (
       output.Models !== undefined && output.Models !== null
         ? deserializeAws_json1_1Models(output.Models, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -3373,8 +3342,8 @@ const deserializeAws_json1_1ListMedicalTranscriptionJobsResponse = (
       output.MedicalTranscriptionJobSummaries !== undefined && output.MedicalTranscriptionJobSummaries !== null
         ? deserializeAws_json1_1MedicalTranscriptionJobSummaries(output.MedicalTranscriptionJobSummaries, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    NextToken: __expectString(output.NextToken),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -3383,8 +3352,8 @@ const deserializeAws_json1_1ListMedicalVocabulariesResponse = (
   context: __SerdeContext
 ): ListMedicalVocabulariesResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    NextToken: __expectString(output.NextToken),
+    Status: __expectString(output.Status),
     Vocabularies:
       output.Vocabularies !== undefined && output.Vocabularies !== null
         ? deserializeAws_json1_1Vocabularies(output.Vocabularies, context)
@@ -3397,8 +3366,8 @@ const deserializeAws_json1_1ListTranscriptionJobsResponse = (
   context: __SerdeContext
 ): ListTranscriptionJobsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    NextToken: __expectString(output.NextToken),
+    Status: __expectString(output.Status),
     TranscriptionJobSummaries:
       output.TranscriptionJobSummaries !== undefined && output.TranscriptionJobSummaries !== null
         ? deserializeAws_json1_1TranscriptionJobSummaries(output.TranscriptionJobSummaries, context)
@@ -3411,8 +3380,8 @@ const deserializeAws_json1_1ListVocabulariesResponse = (
   context: __SerdeContext
 ): ListVocabulariesResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    NextToken: __expectString(output.NextToken),
+    Status: __expectString(output.Status),
     Vocabularies:
       output.Vocabularies !== undefined && output.Vocabularies !== null
         ? deserializeAws_json1_1Vocabularies(output.Vocabularies, context)
@@ -3425,7 +3394,7 @@ const deserializeAws_json1_1ListVocabularyFiltersResponse = (
   context: __SerdeContext
 ): ListVocabularyFiltersResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     VocabularyFilters:
       output.VocabularyFilters !== undefined && output.VocabularyFilters !== null
         ? deserializeAws_json1_1VocabularyFilters(output.VocabularyFilters, context)
@@ -3435,16 +3404,13 @@ const deserializeAws_json1_1ListVocabularyFiltersResponse = (
 
 const deserializeAws_json1_1Media = (output: any, context: __SerdeContext): Media => {
   return {
-    MediaFileUri: output.MediaFileUri !== undefined && output.MediaFileUri !== null ? output.MediaFileUri : undefined,
+    MediaFileUri: __expectString(output.MediaFileUri),
   } as any;
 };
 
 const deserializeAws_json1_1MedicalTranscript = (output: any, context: __SerdeContext): MedicalTranscript => {
   return {
-    TranscriptFileUri:
-      output.TranscriptFileUri !== undefined && output.TranscriptFileUri !== null
-        ? output.TranscriptFileUri
-        : undefined,
+    TranscriptFileUri: __expectString(output.TranscriptFileUri),
   } as any;
 };
 
@@ -3457,35 +3423,25 @@ const deserializeAws_json1_1MedicalTranscriptionJob = (
       output.CompletionTime !== undefined && output.CompletionTime !== null
         ? new Date(Math.round(output.CompletionTime * 1000))
         : undefined,
-    ContentIdentificationType:
-      output.ContentIdentificationType !== undefined && output.ContentIdentificationType !== null
-        ? output.ContentIdentificationType
-        : undefined,
+    ContentIdentificationType: __expectString(output.ContentIdentificationType),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
-    LanguageCode: output.LanguageCode !== undefined && output.LanguageCode !== null ? output.LanguageCode : undefined,
+    FailureReason: __expectString(output.FailureReason),
+    LanguageCode: __expectString(output.LanguageCode),
     Media:
       output.Media !== undefined && output.Media !== null
         ? deserializeAws_json1_1Media(output.Media, context)
         : undefined,
-    MediaFormat: output.MediaFormat !== undefined && output.MediaFormat !== null ? output.MediaFormat : undefined,
-    MediaSampleRateHertz:
-      output.MediaSampleRateHertz !== undefined && output.MediaSampleRateHertz !== null
-        ? output.MediaSampleRateHertz
-        : undefined,
-    MedicalTranscriptionJobName:
-      output.MedicalTranscriptionJobName !== undefined && output.MedicalTranscriptionJobName !== null
-        ? output.MedicalTranscriptionJobName
-        : undefined,
+    MediaFormat: __expectString(output.MediaFormat),
+    MediaSampleRateHertz: __expectNumber(output.MediaSampleRateHertz),
+    MedicalTranscriptionJobName: __expectString(output.MedicalTranscriptionJobName),
     Settings:
       output.Settings !== undefined && output.Settings !== null
         ? deserializeAws_json1_1MedicalTranscriptionSetting(output.Settings, context)
         : undefined,
-    Specialty: output.Specialty !== undefined && output.Specialty !== null ? output.Specialty : undefined,
+    Specialty: __expectString(output.Specialty),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
         ? new Date(Math.round(output.StartTime * 1000))
@@ -3494,11 +3450,8 @@ const deserializeAws_json1_1MedicalTranscriptionJob = (
       output.Transcript !== undefined && output.Transcript !== null
         ? deserializeAws_json1_1MedicalTranscript(output.Transcript, context)
         : undefined,
-    TranscriptionJobStatus:
-      output.TranscriptionJobStatus !== undefined && output.TranscriptionJobStatus !== null
-        ? output.TranscriptionJobStatus
-        : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    TranscriptionJobStatus: __expectString(output.TranscriptionJobStatus),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -3525,35 +3478,22 @@ const deserializeAws_json1_1MedicalTranscriptionJobSummary = (
       output.CompletionTime !== undefined && output.CompletionTime !== null
         ? new Date(Math.round(output.CompletionTime * 1000))
         : undefined,
-    ContentIdentificationType:
-      output.ContentIdentificationType !== undefined && output.ContentIdentificationType !== null
-        ? output.ContentIdentificationType
-        : undefined,
+    ContentIdentificationType: __expectString(output.ContentIdentificationType),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
-    LanguageCode: output.LanguageCode !== undefined && output.LanguageCode !== null ? output.LanguageCode : undefined,
-    MedicalTranscriptionJobName:
-      output.MedicalTranscriptionJobName !== undefined && output.MedicalTranscriptionJobName !== null
-        ? output.MedicalTranscriptionJobName
-        : undefined,
-    OutputLocationType:
-      output.OutputLocationType !== undefined && output.OutputLocationType !== null
-        ? output.OutputLocationType
-        : undefined,
-    Specialty: output.Specialty !== undefined && output.Specialty !== null ? output.Specialty : undefined,
+    FailureReason: __expectString(output.FailureReason),
+    LanguageCode: __expectString(output.LanguageCode),
+    MedicalTranscriptionJobName: __expectString(output.MedicalTranscriptionJobName),
+    OutputLocationType: __expectString(output.OutputLocationType),
+    Specialty: __expectString(output.Specialty),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
         ? new Date(Math.round(output.StartTime * 1000))
         : undefined,
-    TranscriptionJobStatus:
-      output.TranscriptionJobStatus !== undefined && output.TranscriptionJobStatus !== null
-        ? output.TranscriptionJobStatus
-        : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    TranscriptionJobStatus: __expectString(output.TranscriptionJobStatus),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -3562,22 +3502,12 @@ const deserializeAws_json1_1MedicalTranscriptionSetting = (
   context: __SerdeContext
 ): MedicalTranscriptionSetting => {
   return {
-    ChannelIdentification:
-      output.ChannelIdentification !== undefined && output.ChannelIdentification !== null
-        ? output.ChannelIdentification
-        : undefined,
-    MaxAlternatives:
-      output.MaxAlternatives !== undefined && output.MaxAlternatives !== null ? output.MaxAlternatives : undefined,
-    MaxSpeakerLabels:
-      output.MaxSpeakerLabels !== undefined && output.MaxSpeakerLabels !== null ? output.MaxSpeakerLabels : undefined,
-    ShowAlternatives:
-      output.ShowAlternatives !== undefined && output.ShowAlternatives !== null ? output.ShowAlternatives : undefined,
-    ShowSpeakerLabels:
-      output.ShowSpeakerLabels !== undefined && output.ShowSpeakerLabels !== null
-        ? output.ShowSpeakerLabels
-        : undefined,
-    VocabularyName:
-      output.VocabularyName !== undefined && output.VocabularyName !== null ? output.VocabularyName : undefined,
+    ChannelIdentification: __expectBoolean(output.ChannelIdentification),
+    MaxAlternatives: __expectNumber(output.MaxAlternatives),
+    MaxSpeakerLabels: __expectNumber(output.MaxSpeakerLabels),
+    ShowAlternatives: __expectBoolean(output.ShowAlternatives),
+    ShowSpeakerLabels: __expectBoolean(output.ShowSpeakerLabels),
+    VocabularyName: __expectString(output.VocabularyName),
   } as any;
 };
 
@@ -3594,45 +3524,26 @@ const deserializeAws_json1_1Models = (output: any, context: __SerdeContext): Lan
 
 const deserializeAws_json1_1ModelSettings = (output: any, context: __SerdeContext): ModelSettings => {
   return {
-    LanguageModelName:
-      output.LanguageModelName !== undefined && output.LanguageModelName !== null
-        ? output.LanguageModelName
-        : undefined,
+    LanguageModelName: __expectString(output.LanguageModelName),
   } as any;
 };
 
 const deserializeAws_json1_1NotFoundException = (output: any, context: __SerdeContext): NotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1Settings = (output: any, context: __SerdeContext): Settings => {
   return {
-    ChannelIdentification:
-      output.ChannelIdentification !== undefined && output.ChannelIdentification !== null
-        ? output.ChannelIdentification
-        : undefined,
-    MaxAlternatives:
-      output.MaxAlternatives !== undefined && output.MaxAlternatives !== null ? output.MaxAlternatives : undefined,
-    MaxSpeakerLabels:
-      output.MaxSpeakerLabels !== undefined && output.MaxSpeakerLabels !== null ? output.MaxSpeakerLabels : undefined,
-    ShowAlternatives:
-      output.ShowAlternatives !== undefined && output.ShowAlternatives !== null ? output.ShowAlternatives : undefined,
-    ShowSpeakerLabels:
-      output.ShowSpeakerLabels !== undefined && output.ShowSpeakerLabels !== null
-        ? output.ShowSpeakerLabels
-        : undefined,
-    VocabularyFilterMethod:
-      output.VocabularyFilterMethod !== undefined && output.VocabularyFilterMethod !== null
-        ? output.VocabularyFilterMethod
-        : undefined,
-    VocabularyFilterName:
-      output.VocabularyFilterName !== undefined && output.VocabularyFilterName !== null
-        ? output.VocabularyFilterName
-        : undefined,
-    VocabularyName:
-      output.VocabularyName !== undefined && output.VocabularyName !== null ? output.VocabularyName : undefined,
+    ChannelIdentification: __expectBoolean(output.ChannelIdentification),
+    MaxAlternatives: __expectNumber(output.MaxAlternatives),
+    MaxSpeakerLabels: __expectNumber(output.MaxSpeakerLabels),
+    ShowAlternatives: __expectBoolean(output.ShowAlternatives),
+    ShowSpeakerLabels: __expectBoolean(output.ShowSpeakerLabels),
+    VocabularyFilterMethod: __expectString(output.VocabularyFilterMethod),
+    VocabularyFilterName: __expectString(output.VocabularyFilterName),
+    VocabularyName: __expectString(output.VocabularyName),
   } as any;
 };
 
@@ -3662,14 +3573,8 @@ const deserializeAws_json1_1StartTranscriptionJobResponse = (
 
 const deserializeAws_json1_1Transcript = (output: any, context: __SerdeContext): Transcript => {
   return {
-    RedactedTranscriptFileUri:
-      output.RedactedTranscriptFileUri !== undefined && output.RedactedTranscriptFileUri !== null
-        ? output.RedactedTranscriptFileUri
-        : undefined,
-    TranscriptFileUri:
-      output.TranscriptFileUri !== undefined && output.TranscriptFileUri !== null
-        ? output.TranscriptFileUri
-        : undefined,
+    RedactedTranscriptFileUri: __expectString(output.RedactedTranscriptFileUri),
+    TranscriptFileUri: __expectString(output.TranscriptFileUri),
   } as any;
 };
 
@@ -3687,19 +3592,14 @@ const deserializeAws_json1_1TranscriptionJob = (output: any, context: __SerdeCon
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
-    IdentifiedLanguageScore:
-      output.IdentifiedLanguageScore !== undefined && output.IdentifiedLanguageScore !== null
-        ? output.IdentifiedLanguageScore
-        : undefined,
-    IdentifyLanguage:
-      output.IdentifyLanguage !== undefined && output.IdentifyLanguage !== null ? output.IdentifyLanguage : undefined,
+    FailureReason: __expectString(output.FailureReason),
+    IdentifiedLanguageScore: __expectNumber(output.IdentifiedLanguageScore),
+    IdentifyLanguage: __expectBoolean(output.IdentifyLanguage),
     JobExecutionSettings:
       output.JobExecutionSettings !== undefined && output.JobExecutionSettings !== null
         ? deserializeAws_json1_1JobExecutionSettings(output.JobExecutionSettings, context)
         : undefined,
-    LanguageCode: output.LanguageCode !== undefined && output.LanguageCode !== null ? output.LanguageCode : undefined,
+    LanguageCode: __expectString(output.LanguageCode),
     LanguageOptions:
       output.LanguageOptions !== undefined && output.LanguageOptions !== null
         ? deserializeAws_json1_1LanguageOptions(output.LanguageOptions, context)
@@ -3708,11 +3608,8 @@ const deserializeAws_json1_1TranscriptionJob = (output: any, context: __SerdeCon
       output.Media !== undefined && output.Media !== null
         ? deserializeAws_json1_1Media(output.Media, context)
         : undefined,
-    MediaFormat: output.MediaFormat !== undefined && output.MediaFormat !== null ? output.MediaFormat : undefined,
-    MediaSampleRateHertz:
-      output.MediaSampleRateHertz !== undefined && output.MediaSampleRateHertz !== null
-        ? output.MediaSampleRateHertz
-        : undefined,
+    MediaFormat: __expectString(output.MediaFormat),
+    MediaSampleRateHertz: __expectNumber(output.MediaSampleRateHertz),
     ModelSettings:
       output.ModelSettings !== undefined && output.ModelSettings !== null
         ? deserializeAws_json1_1ModelSettings(output.ModelSettings, context)
@@ -3729,14 +3626,8 @@ const deserializeAws_json1_1TranscriptionJob = (output: any, context: __SerdeCon
       output.Transcript !== undefined && output.Transcript !== null
         ? deserializeAws_json1_1Transcript(output.Transcript, context)
         : undefined,
-    TranscriptionJobName:
-      output.TranscriptionJobName !== undefined && output.TranscriptionJobName !== null
-        ? output.TranscriptionJobName
-        : undefined,
-    TranscriptionJobStatus:
-      output.TranscriptionJobStatus !== undefined && output.TranscriptionJobStatus !== null
-        ? output.TranscriptionJobStatus
-        : undefined,
+    TranscriptionJobName: __expectString(output.TranscriptionJobName),
+    TranscriptionJobStatus: __expectString(output.TranscriptionJobStatus),
   } as any;
 };
 
@@ -3771,35 +3662,21 @@ const deserializeAws_json1_1TranscriptionJobSummary = (
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    FailureReason:
-      output.FailureReason !== undefined && output.FailureReason !== null ? output.FailureReason : undefined,
-    IdentifiedLanguageScore:
-      output.IdentifiedLanguageScore !== undefined && output.IdentifiedLanguageScore !== null
-        ? output.IdentifiedLanguageScore
-        : undefined,
-    IdentifyLanguage:
-      output.IdentifyLanguage !== undefined && output.IdentifyLanguage !== null ? output.IdentifyLanguage : undefined,
-    LanguageCode: output.LanguageCode !== undefined && output.LanguageCode !== null ? output.LanguageCode : undefined,
+    FailureReason: __expectString(output.FailureReason),
+    IdentifiedLanguageScore: __expectNumber(output.IdentifiedLanguageScore),
+    IdentifyLanguage: __expectBoolean(output.IdentifyLanguage),
+    LanguageCode: __expectString(output.LanguageCode),
     ModelSettings:
       output.ModelSettings !== undefined && output.ModelSettings !== null
         ? deserializeAws_json1_1ModelSettings(output.ModelSettings, context)
         : undefined,
-    OutputLocationType:
-      output.OutputLocationType !== undefined && output.OutputLocationType !== null
-        ? output.OutputLocationType
-        : undefined,
+    OutputLocationType: __expectString(output.OutputLocationType),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
         ? new Date(Math.round(output.StartTime * 1000))
         : undefined,
-    TranscriptionJobName:
-      output.TranscriptionJobName !== undefined && output.TranscriptionJobName !== null
-        ? output.TranscriptionJobName
-        : undefined,
-    TranscriptionJobStatus:
-      output.TranscriptionJobStatus !== undefined && output.TranscriptionJobStatus !== null
-        ? output.TranscriptionJobStatus
-        : undefined,
+    TranscriptionJobName: __expectString(output.TranscriptionJobName),
+    TranscriptionJobStatus: __expectString(output.TranscriptionJobStatus),
   } as any;
 };
 
@@ -3808,15 +3685,13 @@ const deserializeAws_json1_1UpdateMedicalVocabularyResponse = (
   context: __SerdeContext
 ): UpdateMedicalVocabularyResponse => {
   return {
-    LanguageCode: output.LanguageCode !== undefined && output.LanguageCode !== null ? output.LanguageCode : undefined,
+    LanguageCode: __expectString(output.LanguageCode),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    VocabularyName:
-      output.VocabularyName !== undefined && output.VocabularyName !== null ? output.VocabularyName : undefined,
-    VocabularyState:
-      output.VocabularyState !== undefined && output.VocabularyState !== null ? output.VocabularyState : undefined,
+    VocabularyName: __expectString(output.VocabularyName),
+    VocabularyState: __expectString(output.VocabularyState),
   } as any;
 };
 
@@ -3825,15 +3700,12 @@ const deserializeAws_json1_1UpdateVocabularyFilterResponse = (
   context: __SerdeContext
 ): UpdateVocabularyFilterResponse => {
   return {
-    LanguageCode: output.LanguageCode !== undefined && output.LanguageCode !== null ? output.LanguageCode : undefined,
+    LanguageCode: __expectString(output.LanguageCode),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    VocabularyFilterName:
-      output.VocabularyFilterName !== undefined && output.VocabularyFilterName !== null
-        ? output.VocabularyFilterName
-        : undefined,
+    VocabularyFilterName: __expectString(output.VocabularyFilterName),
   } as any;
 };
 
@@ -3842,15 +3714,13 @@ const deserializeAws_json1_1UpdateVocabularyResponse = (
   context: __SerdeContext
 ): UpdateVocabularyResponse => {
   return {
-    LanguageCode: output.LanguageCode !== undefined && output.LanguageCode !== null ? output.LanguageCode : undefined,
+    LanguageCode: __expectString(output.LanguageCode),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    VocabularyName:
-      output.VocabularyName !== undefined && output.VocabularyName !== null ? output.VocabularyName : undefined,
-    VocabularyState:
-      output.VocabularyState !== undefined && output.VocabularyState !== null ? output.VocabularyState : undefined,
+    VocabularyName: __expectString(output.VocabularyName),
+    VocabularyState: __expectString(output.VocabularyState),
   } as any;
 };
 
@@ -3867,15 +3737,12 @@ const deserializeAws_json1_1Vocabularies = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_1VocabularyFilterInfo = (output: any, context: __SerdeContext): VocabularyFilterInfo => {
   return {
-    LanguageCode: output.LanguageCode !== undefined && output.LanguageCode !== null ? output.LanguageCode : undefined,
+    LanguageCode: __expectString(output.LanguageCode),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    VocabularyFilterName:
-      output.VocabularyFilterName !== undefined && output.VocabularyFilterName !== null
-        ? output.VocabularyFilterName
-        : undefined,
+    VocabularyFilterName: __expectString(output.VocabularyFilterName),
   } as any;
 };
 
@@ -3892,15 +3759,13 @@ const deserializeAws_json1_1VocabularyFilters = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1VocabularyInfo = (output: any, context: __SerdeContext): VocabularyInfo => {
   return {
-    LanguageCode: output.LanguageCode !== undefined && output.LanguageCode !== null ? output.LanguageCode : undefined,
+    LanguageCode: __expectString(output.LanguageCode),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
         ? new Date(Math.round(output.LastModifiedTime * 1000))
         : undefined,
-    VocabularyName:
-      output.VocabularyName !== undefined && output.VocabularyName !== null ? output.VocabularyName : undefined,
-    VocabularyState:
-      output.VocabularyState !== undefined && output.VocabularyState !== null ? output.VocabularyState : undefined,
+    VocabularyName: __expectString(output.VocabularyName),
+    VocabularyState: __expectString(output.VocabularyState),
   } as any;
 };
 

--- a/clients/client-transfer/protocols/Aws_json1_1.ts
+++ b/clients/client-transfer/protocols/Aws_json1_1.ts
@@ -103,7 +103,12 @@ import {
   UpdateUserResponse,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -3064,7 +3069,7 @@ const serializeAws_json1_1UpdateUserRequest = (input: UpdateUserRequest, context
 
 const deserializeAws_json1_1AccessDeniedException = (output: any, context: __SerdeContext): AccessDeniedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3075,33 +3080,33 @@ const deserializeAws_json1_1AddressAllocationIds = (output: any, context: __Serd
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1ConflictException = (output: any, context: __SerdeContext): ConflictException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1CreateAccessResponse = (output: any, context: __SerdeContext): CreateAccessResponse => {
   return {
-    ExternalId: output.ExternalId !== undefined && output.ExternalId !== null ? output.ExternalId : undefined,
-    ServerId: output.ServerId !== undefined && output.ServerId !== null ? output.ServerId : undefined,
+    ExternalId: __expectString(output.ExternalId),
+    ServerId: __expectString(output.ServerId),
   } as any;
 };
 
 const deserializeAws_json1_1CreateServerResponse = (output: any, context: __SerdeContext): CreateServerResponse => {
   return {
-    ServerId: output.ServerId !== undefined && output.ServerId !== null ? output.ServerId : undefined,
+    ServerId: __expectString(output.ServerId),
   } as any;
 };
 
 const deserializeAws_json1_1CreateUserResponse = (output: any, context: __SerdeContext): CreateUserResponse => {
   return {
-    ServerId: output.ServerId !== undefined && output.ServerId !== null ? output.ServerId : undefined,
-    UserName: output.UserName !== undefined && output.UserName !== null ? output.UserName : undefined,
+    ServerId: __expectString(output.ServerId),
+    UserName: __expectString(output.UserName),
   } as any;
 };
 
@@ -3111,29 +3116,25 @@ const deserializeAws_json1_1DescribeAccessResponse = (output: any, context: __Se
       output.Access !== undefined && output.Access !== null
         ? deserializeAws_json1_1DescribedAccess(output.Access, context)
         : undefined,
-    ServerId: output.ServerId !== undefined && output.ServerId !== null ? output.ServerId : undefined,
+    ServerId: __expectString(output.ServerId),
   } as any;
 };
 
 const deserializeAws_json1_1DescribedAccess = (output: any, context: __SerdeContext): DescribedAccess => {
   return {
-    ExternalId: output.ExternalId !== undefined && output.ExternalId !== null ? output.ExternalId : undefined,
-    HomeDirectory:
-      output.HomeDirectory !== undefined && output.HomeDirectory !== null ? output.HomeDirectory : undefined,
+    ExternalId: __expectString(output.ExternalId),
+    HomeDirectory: __expectString(output.HomeDirectory),
     HomeDirectoryMappings:
       output.HomeDirectoryMappings !== undefined && output.HomeDirectoryMappings !== null
         ? deserializeAws_json1_1HomeDirectoryMappings(output.HomeDirectoryMappings, context)
         : undefined,
-    HomeDirectoryType:
-      output.HomeDirectoryType !== undefined && output.HomeDirectoryType !== null
-        ? output.HomeDirectoryType
-        : undefined,
-    Policy: output.Policy !== undefined && output.Policy !== null ? output.Policy : undefined,
+    HomeDirectoryType: __expectString(output.HomeDirectoryType),
+    Policy: __expectString(output.Policy),
     PosixProfile:
       output.PosixProfile !== undefined && output.PosixProfile !== null
         ? deserializeAws_json1_1PosixProfile(output.PosixProfile, context)
         : undefined,
-    Role: output.Role !== undefined && output.Role !== null ? output.Role : undefined,
+    Role: __expectString(output.Role),
   } as any;
 };
 
@@ -3142,11 +3143,8 @@ const deserializeAws_json1_1DescribedSecurityPolicy = (
   context: __SerdeContext
 ): DescribedSecurityPolicy => {
   return {
-    Fips: output.Fips !== undefined && output.Fips !== null ? output.Fips : undefined,
-    SecurityPolicyName:
-      output.SecurityPolicyName !== undefined && output.SecurityPolicyName !== null
-        ? output.SecurityPolicyName
-        : undefined,
+    Fips: __expectBoolean(output.Fips),
+    SecurityPolicyName: __expectString(output.SecurityPolicyName),
     SshCiphers:
       output.SshCiphers !== undefined && output.SshCiphers !== null
         ? deserializeAws_json1_1SecurityPolicyOptions(output.SshCiphers, context)
@@ -3168,69 +3166,56 @@ const deserializeAws_json1_1DescribedSecurityPolicy = (
 
 const deserializeAws_json1_1DescribedServer = (output: any, context: __SerdeContext): DescribedServer => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Certificate: output.Certificate !== undefined && output.Certificate !== null ? output.Certificate : undefined,
-    Domain: output.Domain !== undefined && output.Domain !== null ? output.Domain : undefined,
+    Arn: __expectString(output.Arn),
+    Certificate: __expectString(output.Certificate),
+    Domain: __expectString(output.Domain),
     EndpointDetails:
       output.EndpointDetails !== undefined && output.EndpointDetails !== null
         ? deserializeAws_json1_1EndpointDetails(output.EndpointDetails, context)
         : undefined,
-    EndpointType: output.EndpointType !== undefined && output.EndpointType !== null ? output.EndpointType : undefined,
-    HostKeyFingerprint:
-      output.HostKeyFingerprint !== undefined && output.HostKeyFingerprint !== null
-        ? output.HostKeyFingerprint
-        : undefined,
+    EndpointType: __expectString(output.EndpointType),
+    HostKeyFingerprint: __expectString(output.HostKeyFingerprint),
     IdentityProviderDetails:
       output.IdentityProviderDetails !== undefined && output.IdentityProviderDetails !== null
         ? deserializeAws_json1_1IdentityProviderDetails(output.IdentityProviderDetails, context)
         : undefined,
-    IdentityProviderType:
-      output.IdentityProviderType !== undefined && output.IdentityProviderType !== null
-        ? output.IdentityProviderType
-        : undefined,
-    LoggingRole: output.LoggingRole !== undefined && output.LoggingRole !== null ? output.LoggingRole : undefined,
+    IdentityProviderType: __expectString(output.IdentityProviderType),
+    LoggingRole: __expectString(output.LoggingRole),
     Protocols:
       output.Protocols !== undefined && output.Protocols !== null
         ? deserializeAws_json1_1Protocols(output.Protocols, context)
         : undefined,
-    SecurityPolicyName:
-      output.SecurityPolicyName !== undefined && output.SecurityPolicyName !== null
-        ? output.SecurityPolicyName
-        : undefined,
-    ServerId: output.ServerId !== undefined && output.ServerId !== null ? output.ServerId : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    SecurityPolicyName: __expectString(output.SecurityPolicyName),
+    ServerId: __expectString(output.ServerId),
+    State: __expectString(output.State),
     Tags:
       output.Tags !== undefined && output.Tags !== null ? deserializeAws_json1_1Tags(output.Tags, context) : undefined,
-    UserCount: output.UserCount !== undefined && output.UserCount !== null ? output.UserCount : undefined,
+    UserCount: __expectNumber(output.UserCount),
   } as any;
 };
 
 const deserializeAws_json1_1DescribedUser = (output: any, context: __SerdeContext): DescribedUser => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    HomeDirectory:
-      output.HomeDirectory !== undefined && output.HomeDirectory !== null ? output.HomeDirectory : undefined,
+    Arn: __expectString(output.Arn),
+    HomeDirectory: __expectString(output.HomeDirectory),
     HomeDirectoryMappings:
       output.HomeDirectoryMappings !== undefined && output.HomeDirectoryMappings !== null
         ? deserializeAws_json1_1HomeDirectoryMappings(output.HomeDirectoryMappings, context)
         : undefined,
-    HomeDirectoryType:
-      output.HomeDirectoryType !== undefined && output.HomeDirectoryType !== null
-        ? output.HomeDirectoryType
-        : undefined,
-    Policy: output.Policy !== undefined && output.Policy !== null ? output.Policy : undefined,
+    HomeDirectoryType: __expectString(output.HomeDirectoryType),
+    Policy: __expectString(output.Policy),
     PosixProfile:
       output.PosixProfile !== undefined && output.PosixProfile !== null
         ? deserializeAws_json1_1PosixProfile(output.PosixProfile, context)
         : undefined,
-    Role: output.Role !== undefined && output.Role !== null ? output.Role : undefined,
+    Role: __expectString(output.Role),
     SshPublicKeys:
       output.SshPublicKeys !== undefined && output.SshPublicKeys !== null
         ? deserializeAws_json1_1SshPublicKeys(output.SshPublicKeys, context)
         : undefined,
     Tags:
       output.Tags !== undefined && output.Tags !== null ? deserializeAws_json1_1Tags(output.Tags, context) : undefined,
-    UserName: output.UserName !== undefined && output.UserName !== null ? output.UserName : undefined,
+    UserName: __expectString(output.UserName),
   } as any;
 };
 
@@ -3257,7 +3242,7 @@ const deserializeAws_json1_1DescribeServerResponse = (output: any, context: __Se
 
 const deserializeAws_json1_1DescribeUserResponse = (output: any, context: __SerdeContext): DescribeUserResponse => {
   return {
-    ServerId: output.ServerId !== undefined && output.ServerId !== null ? output.ServerId : undefined,
+    ServerId: __expectString(output.ServerId),
     User:
       output.User !== undefined && output.User !== null
         ? deserializeAws_json1_1DescribedUser(output.User, context)
@@ -3279,16 +3264,15 @@ const deserializeAws_json1_1EndpointDetails = (output: any, context: __SerdeCont
       output.SubnetIds !== undefined && output.SubnetIds !== null
         ? deserializeAws_json1_1SubnetIds(output.SubnetIds, context)
         : undefined,
-    VpcEndpointId:
-      output.VpcEndpointId !== undefined && output.VpcEndpointId !== null ? output.VpcEndpointId : undefined,
-    VpcId: output.VpcId !== undefined && output.VpcId !== null ? output.VpcId : undefined,
+    VpcEndpointId: __expectString(output.VpcEndpointId),
+    VpcId: __expectString(output.VpcId),
   } as any;
 };
 
 const deserializeAws_json1_1HomeDirectoryMapEntry = (output: any, context: __SerdeContext): HomeDirectoryMapEntry => {
   return {
-    Entry: output.Entry !== undefined && output.Entry !== null ? output.Entry : undefined,
-    Target: output.Target !== undefined && output.Target !== null ? output.Target : undefined,
+    Entry: __expectString(output.Entry),
+    Target: __expectString(output.Target),
   } as any;
 };
 
@@ -3308,10 +3292,9 @@ const deserializeAws_json1_1IdentityProviderDetails = (
   context: __SerdeContext
 ): IdentityProviderDetails => {
   return {
-    DirectoryId: output.DirectoryId !== undefined && output.DirectoryId !== null ? output.DirectoryId : undefined,
-    InvocationRole:
-      output.InvocationRole !== undefined && output.InvocationRole !== null ? output.InvocationRole : undefined,
-    Url: output.Url !== undefined && output.Url !== null ? output.Url : undefined,
+    DirectoryId: __expectString(output.DirectoryId),
+    InvocationRole: __expectString(output.InvocationRole),
+    Url: __expectString(output.Url),
   } as any;
 };
 
@@ -3320,16 +3303,15 @@ const deserializeAws_json1_1ImportSshPublicKeyResponse = (
   context: __SerdeContext
 ): ImportSshPublicKeyResponse => {
   return {
-    ServerId: output.ServerId !== undefined && output.ServerId !== null ? output.ServerId : undefined,
-    SshPublicKeyId:
-      output.SshPublicKeyId !== undefined && output.SshPublicKeyId !== null ? output.SshPublicKeyId : undefined,
-    UserName: output.UserName !== undefined && output.UserName !== null ? output.UserName : undefined,
+    ServerId: __expectString(output.ServerId),
+    SshPublicKeyId: __expectString(output.SshPublicKeyId),
+    UserName: __expectString(output.UserName),
   } as any;
 };
 
 const deserializeAws_json1_1InternalServiceError = (output: any, context: __SerdeContext): InternalServiceError => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3338,7 +3320,7 @@ const deserializeAws_json1_1InvalidNextTokenException = (
   context: __SerdeContext
 ): InvalidNextTokenException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3347,7 +3329,7 @@ const deserializeAws_json1_1InvalidRequestException = (
   context: __SerdeContext
 ): InvalidRequestException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3357,21 +3339,17 @@ const deserializeAws_json1_1ListAccessesResponse = (output: any, context: __Serd
       output.Accesses !== undefined && output.Accesses !== null
         ? deserializeAws_json1_1ListedAccesses(output.Accesses, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
-    ServerId: output.ServerId !== undefined && output.ServerId !== null ? output.ServerId : undefined,
+    NextToken: __expectString(output.NextToken),
+    ServerId: __expectString(output.ServerId),
   } as any;
 };
 
 const deserializeAws_json1_1ListedAccess = (output: any, context: __SerdeContext): ListedAccess => {
   return {
-    ExternalId: output.ExternalId !== undefined && output.ExternalId !== null ? output.ExternalId : undefined,
-    HomeDirectory:
-      output.HomeDirectory !== undefined && output.HomeDirectory !== null ? output.HomeDirectory : undefined,
-    HomeDirectoryType:
-      output.HomeDirectoryType !== undefined && output.HomeDirectoryType !== null
-        ? output.HomeDirectoryType
-        : undefined,
-    Role: output.Role !== undefined && output.Role !== null ? output.Role : undefined,
+    ExternalId: __expectString(output.ExternalId),
+    HomeDirectory: __expectString(output.HomeDirectory),
+    HomeDirectoryType: __expectString(output.HomeDirectoryType),
+    Role: __expectString(output.Role),
   } as any;
 };
 
@@ -3388,17 +3366,14 @@ const deserializeAws_json1_1ListedAccesses = (output: any, context: __SerdeConte
 
 const deserializeAws_json1_1ListedServer = (output: any, context: __SerdeContext): ListedServer => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    Domain: output.Domain !== undefined && output.Domain !== null ? output.Domain : undefined,
-    EndpointType: output.EndpointType !== undefined && output.EndpointType !== null ? output.EndpointType : undefined,
-    IdentityProviderType:
-      output.IdentityProviderType !== undefined && output.IdentityProviderType !== null
-        ? output.IdentityProviderType
-        : undefined,
-    LoggingRole: output.LoggingRole !== undefined && output.LoggingRole !== null ? output.LoggingRole : undefined,
-    ServerId: output.ServerId !== undefined && output.ServerId !== null ? output.ServerId : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    UserCount: output.UserCount !== undefined && output.UserCount !== null ? output.UserCount : undefined,
+    Arn: __expectString(output.Arn),
+    Domain: __expectString(output.Domain),
+    EndpointType: __expectString(output.EndpointType),
+    IdentityProviderType: __expectString(output.IdentityProviderType),
+    LoggingRole: __expectString(output.LoggingRole),
+    ServerId: __expectString(output.ServerId),
+    State: __expectString(output.State),
+    UserCount: __expectNumber(output.UserCount),
   } as any;
 };
 
@@ -3415,19 +3390,12 @@ const deserializeAws_json1_1ListedServers = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1ListedUser = (output: any, context: __SerdeContext): ListedUser => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    HomeDirectory:
-      output.HomeDirectory !== undefined && output.HomeDirectory !== null ? output.HomeDirectory : undefined,
-    HomeDirectoryType:
-      output.HomeDirectoryType !== undefined && output.HomeDirectoryType !== null
-        ? output.HomeDirectoryType
-        : undefined,
-    Role: output.Role !== undefined && output.Role !== null ? output.Role : undefined,
-    SshPublicKeyCount:
-      output.SshPublicKeyCount !== undefined && output.SshPublicKeyCount !== null
-        ? output.SshPublicKeyCount
-        : undefined,
-    UserName: output.UserName !== undefined && output.UserName !== null ? output.UserName : undefined,
+    Arn: __expectString(output.Arn),
+    HomeDirectory: __expectString(output.HomeDirectory),
+    HomeDirectoryType: __expectString(output.HomeDirectoryType),
+    Role: __expectString(output.Role),
+    SshPublicKeyCount: __expectNumber(output.SshPublicKeyCount),
+    UserName: __expectString(output.UserName),
   } as any;
 };
 
@@ -3447,7 +3415,7 @@ const deserializeAws_json1_1ListSecurityPoliciesResponse = (
   context: __SerdeContext
 ): ListSecurityPoliciesResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     SecurityPolicyNames:
       output.SecurityPolicyNames !== undefined && output.SecurityPolicyNames !== null
         ? deserializeAws_json1_1SecurityPolicyNames(output.SecurityPolicyNames, context)
@@ -3457,7 +3425,7 @@ const deserializeAws_json1_1ListSecurityPoliciesResponse = (
 
 const deserializeAws_json1_1ListServersResponse = (output: any, context: __SerdeContext): ListServersResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Servers:
       output.Servers !== undefined && output.Servers !== null
         ? deserializeAws_json1_1ListedServers(output.Servers, context)
@@ -3470,8 +3438,8 @@ const deserializeAws_json1_1ListTagsForResourceResponse = (
   context: __SerdeContext
 ): ListTagsForResourceResponse => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    Arn: __expectString(output.Arn),
+    NextToken: __expectString(output.NextToken),
     Tags:
       output.Tags !== undefined && output.Tags !== null ? deserializeAws_json1_1Tags(output.Tags, context) : undefined,
   } as any;
@@ -3479,8 +3447,8 @@ const deserializeAws_json1_1ListTagsForResourceResponse = (
 
 const deserializeAws_json1_1ListUsersResponse = (output: any, context: __SerdeContext): ListUsersResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
-    ServerId: output.ServerId !== undefined && output.ServerId !== null ? output.ServerId : undefined,
+    NextToken: __expectString(output.NextToken),
+    ServerId: __expectString(output.ServerId),
     Users:
       output.Users !== undefined && output.Users !== null
         ? deserializeAws_json1_1ListedUsers(output.Users, context)
@@ -3490,12 +3458,12 @@ const deserializeAws_json1_1ListUsersResponse = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1PosixProfile = (output: any, context: __SerdeContext): PosixProfile => {
   return {
-    Gid: output.Gid !== undefined && output.Gid !== null ? output.Gid : undefined,
+    Gid: __expectNumber(output.Gid),
     SecondaryGids:
       output.SecondaryGids !== undefined && output.SecondaryGids !== null
         ? deserializeAws_json1_1SecondaryGids(output.SecondaryGids, context)
         : undefined,
-    Uid: output.Uid !== undefined && output.Uid !== null ? output.Uid : undefined,
+    Uid: __expectNumber(output.Uid),
   } as any;
 };
 
@@ -3506,7 +3474,7 @@ const deserializeAws_json1_1Protocols = (output: any, context: __SerdeContext): 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3515,9 +3483,9 @@ const deserializeAws_json1_1ResourceExistsException = (
   context: __SerdeContext
 ): ResourceExistsException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Resource: output.Resource !== undefined && output.Resource !== null ? output.Resource : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
+    Message: __expectString(output.Message),
+    Resource: __expectString(output.Resource),
+    ResourceType: __expectString(output.ResourceType),
   } as any;
 };
 
@@ -3526,9 +3494,9 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Resource: output.Resource !== undefined && output.Resource !== null ? output.Resource : undefined,
-    ResourceType: output.ResourceType !== undefined && output.ResourceType !== null ? output.ResourceType : undefined,
+    Message: __expectString(output.Message),
+    Resource: __expectString(output.Resource),
+    ResourceType: __expectString(output.ResourceType),
   } as any;
 };
 
@@ -3539,7 +3507,7 @@ const deserializeAws_json1_1SecondaryGids = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectNumber(entry) as any;
     });
 };
 
@@ -3550,7 +3518,7 @@ const deserializeAws_json1_1SecurityGroupIds = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3561,7 +3529,7 @@ const deserializeAws_json1_1SecurityPolicyNames = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3572,7 +3540,7 @@ const deserializeAws_json1_1SecurityPolicyOptions = (output: any, context: __Ser
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3581,7 +3549,7 @@ const deserializeAws_json1_1ServiceUnavailableException = (
   context: __SerdeContext
 ): ServiceUnavailableException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -3591,10 +3559,8 @@ const deserializeAws_json1_1SshPublicKey = (output: any, context: __SerdeContext
       output.DateImported !== undefined && output.DateImported !== null
         ? new Date(Math.round(output.DateImported * 1000))
         : undefined,
-    SshPublicKeyBody:
-      output.SshPublicKeyBody !== undefined && output.SshPublicKeyBody !== null ? output.SshPublicKeyBody : undefined,
-    SshPublicKeyId:
-      output.SshPublicKeyId !== undefined && output.SshPublicKeyId !== null ? output.SshPublicKeyId : undefined,
+    SshPublicKeyBody: __expectString(output.SshPublicKeyBody),
+    SshPublicKeyId: __expectString(output.SshPublicKeyId),
   } as any;
 };
 
@@ -3616,14 +3582,14 @@ const deserializeAws_json1_1SubnetIds = (output: any, context: __SerdeContext): 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -3643,39 +3609,36 @@ const deserializeAws_json1_1TestIdentityProviderResponse = (
   context: __SerdeContext
 ): TestIdentityProviderResponse => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Response: output.Response !== undefined && output.Response !== null ? output.Response : undefined,
-    StatusCode: output.StatusCode !== undefined && output.StatusCode !== null ? output.StatusCode : undefined,
-    Url: output.Url !== undefined && output.Url !== null ? output.Url : undefined,
+    Message: __expectString(output.Message),
+    Response: __expectString(output.Response),
+    StatusCode: __expectNumber(output.StatusCode),
+    Url: __expectString(output.Url),
   } as any;
 };
 
 const deserializeAws_json1_1ThrottlingException = (output: any, context: __SerdeContext): ThrottlingException => {
   return {
-    RetryAfterSeconds:
-      output.RetryAfterSeconds !== undefined && output.RetryAfterSeconds !== null
-        ? output.RetryAfterSeconds
-        : undefined,
+    RetryAfterSeconds: __expectString(output.RetryAfterSeconds),
   } as any;
 };
 
 const deserializeAws_json1_1UpdateAccessResponse = (output: any, context: __SerdeContext): UpdateAccessResponse => {
   return {
-    ExternalId: output.ExternalId !== undefined && output.ExternalId !== null ? output.ExternalId : undefined,
-    ServerId: output.ServerId !== undefined && output.ServerId !== null ? output.ServerId : undefined,
+    ExternalId: __expectString(output.ExternalId),
+    ServerId: __expectString(output.ServerId),
   } as any;
 };
 
 const deserializeAws_json1_1UpdateServerResponse = (output: any, context: __SerdeContext): UpdateServerResponse => {
   return {
-    ServerId: output.ServerId !== undefined && output.ServerId !== null ? output.ServerId : undefined,
+    ServerId: __expectString(output.ServerId),
   } as any;
 };
 
 const deserializeAws_json1_1UpdateUserResponse = (output: any, context: __SerdeContext): UpdateUserResponse => {
   return {
-    ServerId: output.ServerId !== undefined && output.ServerId !== null ? output.ServerId : undefined,
-    UserName: output.UserName !== undefined && output.UserName !== null ? output.UserName : undefined,
+    ServerId: __expectString(output.ServerId),
+    UserName: __expectString(output.UserName),
   } as any;
 };
 

--- a/clients/client-translate/protocols/Aws_json1_1.ts
+++ b/clients/client-translate/protocols/Aws_json1_1.ts
@@ -81,7 +81,11 @@ import {
   UpdateParallelDataResponse,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -1869,7 +1873,7 @@ const serializeAws_json1_1UpdateParallelDataRequest = (
 
 const deserializeAws_json1_1AppliedTerminology = (output: any, context: __SerdeContext): AppliedTerminology => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     Terms:
       output.Terms !== undefined && output.Terms !== null
         ? deserializeAws_json1_1TermList(output.Terms, context)
@@ -1893,13 +1897,13 @@ const deserializeAws_json1_1ConcurrentModificationException = (
   context: __SerdeContext
 ): ConcurrentModificationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1ConflictException = (output: any, context: __SerdeContext): ConflictException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -1908,8 +1912,8 @@ const deserializeAws_json1_1CreateParallelDataResponse = (
   context: __SerdeContext
 ): CreateParallelDataResponse => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Name: __expectString(output.Name),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -1918,8 +1922,8 @@ const deserializeAws_json1_1DeleteParallelDataResponse = (
   context: __SerdeContext
 ): DeleteParallelDataResponse => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Name: __expectString(output.Name),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -1940,18 +1944,15 @@ const deserializeAws_json1_1DetectedLanguageLowConfidenceException = (
   context: __SerdeContext
 ): DetectedLanguageLowConfidenceException => {
   return {
-    DetectedLanguageCode:
-      output.DetectedLanguageCode !== undefined && output.DetectedLanguageCode !== null
-        ? output.DetectedLanguageCode
-        : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    DetectedLanguageCode: __expectString(output.DetectedLanguageCode),
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1EncryptionKey = (output: any, context: __SerdeContext): EncryptionKey => {
   return {
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Id: __expectString(output.Id),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -2007,8 +2008,8 @@ const deserializeAws_json1_1ImportTerminologyResponse = (
 
 const deserializeAws_json1_1InputDataConfig = (output: any, context: __SerdeContext): InputDataConfig => {
   return {
-    ContentType: output.ContentType !== undefined && output.ContentType !== null ? output.ContentType : undefined,
-    S3Uri: output.S3Uri !== undefined && output.S3Uri !== null ? output.S3Uri : undefined,
+    ContentType: __expectString(output.ContentType),
+    S3Uri: __expectString(output.S3Uri),
   } as any;
 };
 
@@ -2017,13 +2018,13 @@ const deserializeAws_json1_1InternalServerException = (
   context: __SerdeContext
 ): InternalServerException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidFilterException = (output: any, context: __SerdeContext): InvalidFilterException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2032,7 +2033,7 @@ const deserializeAws_json1_1InvalidParameterValueException = (
   context: __SerdeContext
 ): InvalidParameterValueException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2041,24 +2042,15 @@ const deserializeAws_json1_1InvalidRequestException = (
   context: __SerdeContext
 ): InvalidRequestException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1JobDetails = (output: any, context: __SerdeContext): JobDetails => {
   return {
-    DocumentsWithErrorsCount:
-      output.DocumentsWithErrorsCount !== undefined && output.DocumentsWithErrorsCount !== null
-        ? output.DocumentsWithErrorsCount
-        : undefined,
-    InputDocumentsCount:
-      output.InputDocumentsCount !== undefined && output.InputDocumentsCount !== null
-        ? output.InputDocumentsCount
-        : undefined,
-    TranslatedDocumentsCount:
-      output.TranslatedDocumentsCount !== undefined && output.TranslatedDocumentsCount !== null
-        ? output.TranslatedDocumentsCount
-        : undefined,
+    DocumentsWithErrorsCount: __expectNumber(output.DocumentsWithErrorsCount),
+    InputDocumentsCount: __expectNumber(output.InputDocumentsCount),
+    TranslatedDocumentsCount: __expectNumber(output.TranslatedDocumentsCount),
   } as any;
 };
 
@@ -2069,13 +2061,13 @@ const deserializeAws_json1_1LanguageCodeStringList = (output: any, context: __Se
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2084,7 +2076,7 @@ const deserializeAws_json1_1ListParallelDataResponse = (
   context: __SerdeContext
 ): ListParallelDataResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     ParallelDataPropertiesList:
       output.ParallelDataPropertiesList !== undefined && output.ParallelDataPropertiesList !== null
         ? deserializeAws_json1_1ParallelDataPropertiesList(output.ParallelDataPropertiesList, context)
@@ -2097,7 +2089,7 @@ const deserializeAws_json1_1ListTerminologiesResponse = (
   context: __SerdeContext
 ): ListTerminologiesResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     TerminologyPropertiesList:
       output.TerminologyPropertiesList !== undefined && output.TerminologyPropertiesList !== null
         ? deserializeAws_json1_1TerminologyPropertiesList(output.TerminologyPropertiesList, context)
@@ -2110,7 +2102,7 @@ const deserializeAws_json1_1ListTextTranslationJobsResponse = (
   context: __SerdeContext
 ): ListTextTranslationJobsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     TextTranslationJobPropertiesList:
       output.TextTranslationJobPropertiesList !== undefined && output.TextTranslationJobPropertiesList !== null
         ? deserializeAws_json1_1TextTranslationJobPropertiesList(output.TextTranslationJobPropertiesList, context)
@@ -2120,14 +2112,14 @@ const deserializeAws_json1_1ListTextTranslationJobsResponse = (
 
 const deserializeAws_json1_1OutputDataConfig = (output: any, context: __SerdeContext): OutputDataConfig => {
   return {
-    S3Uri: output.S3Uri !== undefined && output.S3Uri !== null ? output.S3Uri : undefined,
+    S3Uri: __expectString(output.S3Uri),
   } as any;
 };
 
 const deserializeAws_json1_1ParallelDataConfig = (output: any, context: __SerdeContext): ParallelDataConfig => {
   return {
-    Format: output.Format !== undefined && output.Format !== null ? output.Format : undefined,
-    S3Uri: output.S3Uri !== undefined && output.S3Uri !== null ? output.S3Uri : undefined,
+    Format: __expectString(output.Format),
+    S3Uri: __expectString(output.S3Uri),
   } as any;
 };
 
@@ -2136,34 +2128,26 @@ const deserializeAws_json1_1ParallelDataDataLocation = (
   context: __SerdeContext
 ): ParallelDataDataLocation => {
   return {
-    Location: output.Location !== undefined && output.Location !== null ? output.Location : undefined,
-    RepositoryType:
-      output.RepositoryType !== undefined && output.RepositoryType !== null ? output.RepositoryType : undefined,
+    Location: __expectString(output.Location),
+    RepositoryType: __expectString(output.RepositoryType),
   } as any;
 };
 
 const deserializeAws_json1_1ParallelDataProperties = (output: any, context: __SerdeContext): ParallelDataProperties => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     EncryptionKey:
       output.EncryptionKey !== undefined && output.EncryptionKey !== null
         ? deserializeAws_json1_1EncryptionKey(output.EncryptionKey, context)
         : undefined,
-    FailedRecordCount:
-      output.FailedRecordCount !== undefined && output.FailedRecordCount !== null
-        ? output.FailedRecordCount
-        : undefined,
-    ImportedDataSize:
-      output.ImportedDataSize !== undefined && output.ImportedDataSize !== null ? output.ImportedDataSize : undefined,
-    ImportedRecordCount:
-      output.ImportedRecordCount !== undefined && output.ImportedRecordCount !== null
-        ? output.ImportedRecordCount
-        : undefined,
+    FailedRecordCount: __expectNumber(output.FailedRecordCount),
+    ImportedDataSize: __expectNumber(output.ImportedDataSize),
+    ImportedRecordCount: __expectNumber(output.ImportedRecordCount),
     LastUpdatedAt:
       output.LastUpdatedAt !== undefined && output.LastUpdatedAt !== null
         ? new Date(Math.round(output.LastUpdatedAt * 1000))
@@ -2172,25 +2156,16 @@ const deserializeAws_json1_1ParallelDataProperties = (output: any, context: __Se
       output.LatestUpdateAttemptAt !== undefined && output.LatestUpdateAttemptAt !== null
         ? new Date(Math.round(output.LatestUpdateAttemptAt * 1000))
         : undefined,
-    LatestUpdateAttemptStatus:
-      output.LatestUpdateAttemptStatus !== undefined && output.LatestUpdateAttemptStatus !== null
-        ? output.LatestUpdateAttemptStatus
-        : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    LatestUpdateAttemptStatus: __expectString(output.LatestUpdateAttemptStatus),
+    Message: __expectString(output.Message),
+    Name: __expectString(output.Name),
     ParallelDataConfig:
       output.ParallelDataConfig !== undefined && output.ParallelDataConfig !== null
         ? deserializeAws_json1_1ParallelDataConfig(output.ParallelDataConfig, context)
         : undefined,
-    SkippedRecordCount:
-      output.SkippedRecordCount !== undefined && output.SkippedRecordCount !== null
-        ? output.SkippedRecordCount
-        : undefined,
-    SourceLanguageCode:
-      output.SourceLanguageCode !== undefined && output.SourceLanguageCode !== null
-        ? output.SourceLanguageCode
-        : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    SkippedRecordCount: __expectNumber(output.SkippedRecordCount),
+    SourceLanguageCode: __expectString(output.SourceLanguageCode),
+    Status: __expectString(output.Status),
     TargetLanguageCodes:
       output.TargetLanguageCodes !== undefined && output.TargetLanguageCodes !== null
         ? deserializeAws_json1_1LanguageCodeStringList(output.TargetLanguageCodes, context)
@@ -2219,7 +2194,7 @@ const deserializeAws_json1_1ResourceNameList = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2228,7 +2203,7 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2237,7 +2212,7 @@ const deserializeAws_json1_1ServiceUnavailableException = (
   context: __SerdeContext
 ): ServiceUnavailableException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2246,8 +2221,8 @@ const deserializeAws_json1_1StartTextTranslationJobResponse = (
   context: __SerdeContext
 ): StartTextTranslationJobResponse => {
   return {
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
-    JobStatus: output.JobStatus !== undefined && output.JobStatus !== null ? output.JobStatus : undefined,
+    JobId: __expectString(output.JobId),
+    JobStatus: __expectString(output.JobStatus),
   } as any;
 };
 
@@ -2256,8 +2231,8 @@ const deserializeAws_json1_1StopTextTranslationJobResponse = (
   context: __SerdeContext
 ): StopTextTranslationJobResponse => {
   return {
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
-    JobStatus: output.JobStatus !== undefined && output.JobStatus !== null ? output.JobStatus : undefined,
+    JobId: __expectString(output.JobId),
+    JobStatus: __expectString(output.JobStatus),
   } as any;
 };
 
@@ -2268,14 +2243,14 @@ const deserializeAws_json1_1TargetLanguageCodeStringList = (output: any, context
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1Term = (output: any, context: __SerdeContext): Term => {
   return {
-    SourceText: output.SourceText !== undefined && output.SourceText !== null ? output.SourceText : undefined,
-    TargetText: output.TargetText !== undefined && output.TargetText !== null ? output.TargetText : undefined,
+    SourceText: __expectString(output.SourceText),
+    TargetText: __expectString(output.TargetText),
   } as any;
 };
 
@@ -2284,20 +2259,19 @@ const deserializeAws_json1_1TerminologyDataLocation = (
   context: __SerdeContext
 ): TerminologyDataLocation => {
   return {
-    Location: output.Location !== undefined && output.Location !== null ? output.Location : undefined,
-    RepositoryType:
-      output.RepositoryType !== undefined && output.RepositoryType !== null ? output.RepositoryType : undefined,
+    Location: __expectString(output.Location),
+    RepositoryType: __expectString(output.RepositoryType),
   } as any;
 };
 
 const deserializeAws_json1_1TerminologyProperties = (output: any, context: __SerdeContext): TerminologyProperties => {
   return {
-    Arn: output.Arn !== undefined && output.Arn !== null ? output.Arn : undefined,
+    Arn: __expectString(output.Arn),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
         ? new Date(Math.round(output.CreatedAt * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     EncryptionKey:
       output.EncryptionKey !== undefined && output.EncryptionKey !== null
         ? deserializeAws_json1_1EncryptionKey(output.EncryptionKey, context)
@@ -2306,17 +2280,14 @@ const deserializeAws_json1_1TerminologyProperties = (output: any, context: __Ser
       output.LastUpdatedAt !== undefined && output.LastUpdatedAt !== null
         ? new Date(Math.round(output.LastUpdatedAt * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    SizeBytes: output.SizeBytes !== undefined && output.SizeBytes !== null ? output.SizeBytes : undefined,
-    SourceLanguageCode:
-      output.SourceLanguageCode !== undefined && output.SourceLanguageCode !== null
-        ? output.SourceLanguageCode
-        : undefined,
+    Name: __expectString(output.Name),
+    SizeBytes: __expectNumber(output.SizeBytes),
+    SourceLanguageCode: __expectString(output.SourceLanguageCode),
     TargetLanguageCodes:
       output.TargetLanguageCodes !== undefined && output.TargetLanguageCodes !== null
         ? deserializeAws_json1_1LanguageCodeStringList(output.TargetLanguageCodes, context)
         : undefined,
-    TermCount: output.TermCount !== undefined && output.TermCount !== null ? output.TermCount : undefined,
+    TermCount: __expectNumber(output.TermCount),
   } as any;
 };
 
@@ -2350,7 +2321,7 @@ const deserializeAws_json1_1TextSizeLimitExceededException = (
   context: __SerdeContext
 ): TextSizeLimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2359,10 +2330,7 @@ const deserializeAws_json1_1TextTranslationJobProperties = (
   context: __SerdeContext
 ): TextTranslationJobProperties => {
   return {
-    DataAccessRoleArn:
-      output.DataAccessRoleArn !== undefined && output.DataAccessRoleArn !== null
-        ? output.DataAccessRoleArn
-        : undefined,
+    DataAccessRoleArn: __expectString(output.DataAccessRoleArn),
     EndTime:
       output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
     InputDataConfig:
@@ -2373,10 +2341,10 @@ const deserializeAws_json1_1TextTranslationJobProperties = (
       output.JobDetails !== undefined && output.JobDetails !== null
         ? deserializeAws_json1_1JobDetails(output.JobDetails, context)
         : undefined,
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
-    JobName: output.JobName !== undefined && output.JobName !== null ? output.JobName : undefined,
-    JobStatus: output.JobStatus !== undefined && output.JobStatus !== null ? output.JobStatus : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    JobId: __expectString(output.JobId),
+    JobName: __expectString(output.JobName),
+    JobStatus: __expectString(output.JobStatus),
+    Message: __expectString(output.Message),
     OutputDataConfig:
       output.OutputDataConfig !== undefined && output.OutputDataConfig !== null
         ? deserializeAws_json1_1OutputDataConfig(output.OutputDataConfig, context)
@@ -2385,10 +2353,7 @@ const deserializeAws_json1_1TextTranslationJobProperties = (
       output.ParallelDataNames !== undefined && output.ParallelDataNames !== null
         ? deserializeAws_json1_1ResourceNameList(output.ParallelDataNames, context)
         : undefined,
-    SourceLanguageCode:
-      output.SourceLanguageCode !== undefined && output.SourceLanguageCode !== null
-        ? output.SourceLanguageCode
-        : undefined,
+    SourceLanguageCode: __expectString(output.SourceLanguageCode),
     SubmittedTime:
       output.SubmittedTime !== undefined && output.SubmittedTime !== null
         ? new Date(Math.round(output.SubmittedTime * 1000))
@@ -2423,7 +2388,7 @@ const deserializeAws_json1_1TooManyRequestsException = (
   context: __SerdeContext
 ): TooManyRequestsException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -2433,16 +2398,9 @@ const deserializeAws_json1_1TranslateTextResponse = (output: any, context: __Ser
       output.AppliedTerminologies !== undefined && output.AppliedTerminologies !== null
         ? deserializeAws_json1_1AppliedTerminologyList(output.AppliedTerminologies, context)
         : undefined,
-    SourceLanguageCode:
-      output.SourceLanguageCode !== undefined && output.SourceLanguageCode !== null
-        ? output.SourceLanguageCode
-        : undefined,
-    TargetLanguageCode:
-      output.TargetLanguageCode !== undefined && output.TargetLanguageCode !== null
-        ? output.TargetLanguageCode
-        : undefined,
-    TranslatedText:
-      output.TranslatedText !== undefined && output.TranslatedText !== null ? output.TranslatedText : undefined,
+    SourceLanguageCode: __expectString(output.SourceLanguageCode),
+    TargetLanguageCode: __expectString(output.TargetLanguageCode),
+    TranslatedText: __expectString(output.TranslatedText),
   } as any;
 };
 
@@ -2451,15 +2409,9 @@ const deserializeAws_json1_1UnsupportedLanguagePairException = (
   context: __SerdeContext
 ): UnsupportedLanguagePairException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    SourceLanguageCode:
-      output.SourceLanguageCode !== undefined && output.SourceLanguageCode !== null
-        ? output.SourceLanguageCode
-        : undefined,
-    TargetLanguageCode:
-      output.TargetLanguageCode !== undefined && output.TargetLanguageCode !== null
-        ? output.TargetLanguageCode
-        : undefined,
+    Message: __expectString(output.Message),
+    SourceLanguageCode: __expectString(output.SourceLanguageCode),
+    TargetLanguageCode: __expectString(output.TargetLanguageCode),
   } as any;
 };
 
@@ -2472,12 +2424,9 @@ const deserializeAws_json1_1UpdateParallelDataResponse = (
       output.LatestUpdateAttemptAt !== undefined && output.LatestUpdateAttemptAt !== null
         ? new Date(Math.round(output.LatestUpdateAttemptAt * 1000))
         : undefined,
-    LatestUpdateAttemptStatus:
-      output.LatestUpdateAttemptStatus !== undefined && output.LatestUpdateAttemptStatus !== null
-        ? output.LatestUpdateAttemptStatus
-        : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    LatestUpdateAttemptStatus: __expectString(output.LatestUpdateAttemptStatus),
+    Name: __expectString(output.Name),
+    Status: __expectString(output.Status),
   } as any;
 };
 

--- a/clients/client-waf-regional/protocols/Aws_json1_1.ts
+++ b/clients/client-waf-regional/protocols/Aws_json1_1.ts
@@ -424,7 +424,12 @@ import {
   XssMatchTuple,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -9869,9 +9874,9 @@ const deserializeAws_json1_1ActivatedRule = (output: any, context: __SerdeContex
       output.OverrideAction !== undefined && output.OverrideAction !== null
         ? deserializeAws_json1_1WafOverrideAction(output.OverrideAction, context)
         : undefined,
-    Priority: output.Priority !== undefined && output.Priority !== null ? output.Priority : undefined,
-    RuleId: output.RuleId !== undefined && output.RuleId !== null ? output.RuleId : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Priority: __expectNumber(output.Priority),
+    RuleId: __expectString(output.RuleId),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -9895,13 +9900,12 @@ const deserializeAws_json1_1AssociateWebACLResponse = (
 
 const deserializeAws_json1_1ByteMatchSet = (output: any, context: __SerdeContext): ByteMatchSet => {
   return {
-    ByteMatchSetId:
-      output.ByteMatchSetId !== undefined && output.ByteMatchSetId !== null ? output.ByteMatchSetId : undefined,
+    ByteMatchSetId: __expectString(output.ByteMatchSetId),
     ByteMatchTuples:
       output.ByteMatchTuples !== undefined && output.ByteMatchTuples !== null
         ? deserializeAws_json1_1ByteMatchTuples(output.ByteMatchTuples, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -9918,9 +9922,8 @@ const deserializeAws_json1_1ByteMatchSetSummaries = (output: any, context: __Ser
 
 const deserializeAws_json1_1ByteMatchSetSummary = (output: any, context: __SerdeContext): ByteMatchSetSummary => {
   return {
-    ByteMatchSetId:
-      output.ByteMatchSetId !== undefined && output.ByteMatchSetId !== null ? output.ByteMatchSetId : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    ByteMatchSetId: __expectString(output.ByteMatchSetId),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -9930,18 +9933,12 @@ const deserializeAws_json1_1ByteMatchTuple = (output: any, context: __SerdeConte
       output.FieldToMatch !== undefined && output.FieldToMatch !== null
         ? deserializeAws_json1_1FieldToMatch(output.FieldToMatch, context)
         : undefined,
-    PositionalConstraint:
-      output.PositionalConstraint !== undefined && output.PositionalConstraint !== null
-        ? output.PositionalConstraint
-        : undefined,
+    PositionalConstraint: __expectString(output.PositionalConstraint),
     TargetString:
       output.TargetString !== undefined && output.TargetString !== null
         ? context.base64Decoder(output.TargetString)
         : undefined,
-    TextTransformation:
-      output.TextTransformation !== undefined && output.TextTransformation !== null
-        ? output.TextTransformation
-        : undefined,
+    TextTransformation: __expectString(output.TextTransformation),
   } as any;
 };
 
@@ -9965,7 +9962,7 @@ const deserializeAws_json1_1CreateByteMatchSetResponse = (
       output.ByteMatchSet !== undefined && output.ByteMatchSet !== null
         ? deserializeAws_json1_1ByteMatchSet(output.ByteMatchSet, context)
         : undefined,
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
@@ -9974,7 +9971,7 @@ const deserializeAws_json1_1CreateGeoMatchSetResponse = (
   context: __SerdeContext
 ): CreateGeoMatchSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
     GeoMatchSet:
       output.GeoMatchSet !== undefined && output.GeoMatchSet !== null
         ? deserializeAws_json1_1GeoMatchSet(output.GeoMatchSet, context)
@@ -9984,7 +9981,7 @@ const deserializeAws_json1_1CreateGeoMatchSetResponse = (
 
 const deserializeAws_json1_1CreateIPSetResponse = (output: any, context: __SerdeContext): CreateIPSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
     IPSet:
       output.IPSet !== undefined && output.IPSet !== null
         ? deserializeAws_json1_1IPSet(output.IPSet, context)
@@ -9997,7 +9994,7 @@ const deserializeAws_json1_1CreateRateBasedRuleResponse = (
   context: __SerdeContext
 ): CreateRateBasedRuleResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
     Rule:
       output.Rule !== undefined && output.Rule !== null
         ? deserializeAws_json1_1RateBasedRule(output.Rule, context)
@@ -10010,7 +10007,7 @@ const deserializeAws_json1_1CreateRegexMatchSetResponse = (
   context: __SerdeContext
 ): CreateRegexMatchSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
     RegexMatchSet:
       output.RegexMatchSet !== undefined && output.RegexMatchSet !== null
         ? deserializeAws_json1_1RegexMatchSet(output.RegexMatchSet, context)
@@ -10023,7 +10020,7 @@ const deserializeAws_json1_1CreateRegexPatternSetResponse = (
   context: __SerdeContext
 ): CreateRegexPatternSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
     RegexPatternSet:
       output.RegexPatternSet !== undefined && output.RegexPatternSet !== null
         ? deserializeAws_json1_1RegexPatternSet(output.RegexPatternSet, context)
@@ -10036,7 +10033,7 @@ const deserializeAws_json1_1CreateRuleGroupResponse = (
   context: __SerdeContext
 ): CreateRuleGroupResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
     RuleGroup:
       output.RuleGroup !== undefined && output.RuleGroup !== null
         ? deserializeAws_json1_1RuleGroup(output.RuleGroup, context)
@@ -10046,7 +10043,7 @@ const deserializeAws_json1_1CreateRuleGroupResponse = (
 
 const deserializeAws_json1_1CreateRuleResponse = (output: any, context: __SerdeContext): CreateRuleResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
     Rule:
       output.Rule !== undefined && output.Rule !== null ? deserializeAws_json1_1Rule(output.Rule, context) : undefined,
   } as any;
@@ -10057,7 +10054,7 @@ const deserializeAws_json1_1CreateSizeConstraintSetResponse = (
   context: __SerdeContext
 ): CreateSizeConstraintSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
     SizeConstraintSet:
       output.SizeConstraintSet !== undefined && output.SizeConstraintSet !== null
         ? deserializeAws_json1_1SizeConstraintSet(output.SizeConstraintSet, context)
@@ -10070,7 +10067,7 @@ const deserializeAws_json1_1CreateSqlInjectionMatchSetResponse = (
   context: __SerdeContext
 ): CreateSqlInjectionMatchSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
     SqlInjectionMatchSet:
       output.SqlInjectionMatchSet !== undefined && output.SqlInjectionMatchSet !== null
         ? deserializeAws_json1_1SqlInjectionMatchSet(output.SqlInjectionMatchSet, context)
@@ -10083,13 +10080,13 @@ const deserializeAws_json1_1CreateWebACLMigrationStackResponse = (
   context: __SerdeContext
 ): CreateWebACLMigrationStackResponse => {
   return {
-    S3ObjectUrl: output.S3ObjectUrl !== undefined && output.S3ObjectUrl !== null ? output.S3ObjectUrl : undefined,
+    S3ObjectUrl: __expectString(output.S3ObjectUrl),
   } as any;
 };
 
 const deserializeAws_json1_1CreateWebACLResponse = (output: any, context: __SerdeContext): CreateWebACLResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
     WebACL:
       output.WebACL !== undefined && output.WebACL !== null
         ? deserializeAws_json1_1WebACL(output.WebACL, context)
@@ -10102,7 +10099,7 @@ const deserializeAws_json1_1CreateXssMatchSetResponse = (
   context: __SerdeContext
 ): CreateXssMatchSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
     XssMatchSet:
       output.XssMatchSet !== undefined && output.XssMatchSet !== null
         ? deserializeAws_json1_1XssMatchSet(output.XssMatchSet, context)
@@ -10115,7 +10112,7 @@ const deserializeAws_json1_1DeleteByteMatchSetResponse = (
   context: __SerdeContext
 ): DeleteByteMatchSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
@@ -10124,13 +10121,13 @@ const deserializeAws_json1_1DeleteGeoMatchSetResponse = (
   context: __SerdeContext
 ): DeleteGeoMatchSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
 const deserializeAws_json1_1DeleteIPSetResponse = (output: any, context: __SerdeContext): DeleteIPSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
@@ -10153,7 +10150,7 @@ const deserializeAws_json1_1DeleteRateBasedRuleResponse = (
   context: __SerdeContext
 ): DeleteRateBasedRuleResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
@@ -10162,7 +10159,7 @@ const deserializeAws_json1_1DeleteRegexMatchSetResponse = (
   context: __SerdeContext
 ): DeleteRegexMatchSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
@@ -10171,7 +10168,7 @@ const deserializeAws_json1_1DeleteRegexPatternSetResponse = (
   context: __SerdeContext
 ): DeleteRegexPatternSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
@@ -10180,13 +10177,13 @@ const deserializeAws_json1_1DeleteRuleGroupResponse = (
   context: __SerdeContext
 ): DeleteRuleGroupResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
 const deserializeAws_json1_1DeleteRuleResponse = (output: any, context: __SerdeContext): DeleteRuleResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
@@ -10195,7 +10192,7 @@ const deserializeAws_json1_1DeleteSizeConstraintSetResponse = (
   context: __SerdeContext
 ): DeleteSizeConstraintSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
@@ -10204,13 +10201,13 @@ const deserializeAws_json1_1DeleteSqlInjectionMatchSetResponse = (
   context: __SerdeContext
 ): DeleteSqlInjectionMatchSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
 const deserializeAws_json1_1DeleteWebACLResponse = (output: any, context: __SerdeContext): DeleteWebACLResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
@@ -10219,7 +10216,7 @@ const deserializeAws_json1_1DeleteXssMatchSetResponse = (
   context: __SerdeContext
 ): DeleteXssMatchSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
@@ -10232,7 +10229,7 @@ const deserializeAws_json1_1DisassociateWebACLResponse = (
 
 const deserializeAws_json1_1ExcludedRule = (output: any, context: __SerdeContext): ExcludedRule => {
   return {
-    RuleId: output.RuleId !== undefined && output.RuleId !== null ? output.RuleId : undefined,
+    RuleId: __expectString(output.RuleId),
   } as any;
 };
 
@@ -10249,15 +10246,15 @@ const deserializeAws_json1_1ExcludedRules = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1FieldToMatch = (output: any, context: __SerdeContext): FieldToMatch => {
   return {
-    Data: output.Data !== undefined && output.Data !== null ? output.Data : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Data: __expectString(output.Data),
+    Type: __expectString(output.Type),
   } as any;
 };
 
 const deserializeAws_json1_1GeoMatchConstraint = (output: any, context: __SerdeContext): GeoMatchConstraint => {
   return {
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Type: __expectString(output.Type),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -10278,9 +10275,8 @@ const deserializeAws_json1_1GeoMatchSet = (output: any, context: __SerdeContext)
       output.GeoMatchConstraints !== undefined && output.GeoMatchConstraints !== null
         ? deserializeAws_json1_1GeoMatchConstraints(output.GeoMatchConstraints, context)
         : undefined,
-    GeoMatchSetId:
-      output.GeoMatchSetId !== undefined && output.GeoMatchSetId !== null ? output.GeoMatchSetId : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    GeoMatchSetId: __expectString(output.GeoMatchSetId),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -10297,9 +10293,8 @@ const deserializeAws_json1_1GeoMatchSetSummaries = (output: any, context: __Serd
 
 const deserializeAws_json1_1GeoMatchSetSummary = (output: any, context: __SerdeContext): GeoMatchSetSummary => {
   return {
-    GeoMatchSetId:
-      output.GeoMatchSetId !== undefined && output.GeoMatchSetId !== null ? output.GeoMatchSetId : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    GeoMatchSetId: __expectString(output.GeoMatchSetId),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -10317,7 +10312,7 @@ const deserializeAws_json1_1GetByteMatchSetResponse = (
 
 const deserializeAws_json1_1GetChangeTokenResponse = (output: any, context: __SerdeContext): GetChangeTokenResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
@@ -10326,10 +10321,7 @@ const deserializeAws_json1_1GetChangeTokenStatusResponse = (
   context: __SerdeContext
 ): GetChangeTokenStatusResponse => {
   return {
-    ChangeTokenStatus:
-      output.ChangeTokenStatus !== undefined && output.ChangeTokenStatus !== null
-        ? output.ChangeTokenStatus
-        : undefined,
+    ChangeTokenStatus: __expectString(output.ChangeTokenStatus),
   } as any;
 };
 
@@ -10368,7 +10360,7 @@ const deserializeAws_json1_1GetPermissionPolicyResponse = (
   context: __SerdeContext
 ): GetPermissionPolicyResponse => {
   return {
-    Policy: output.Policy !== undefined && output.Policy !== null ? output.Policy : undefined,
+    Policy: __expectString(output.Policy),
   } as any;
 };
 
@@ -10381,7 +10373,7 @@ const deserializeAws_json1_1GetRateBasedRuleManagedKeysResponse = (
       output.ManagedKeys !== undefined && output.ManagedKeys !== null
         ? deserializeAws_json1_1ManagedKeys(output.ManagedKeys, context)
         : undefined,
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    NextMarker: __expectString(output.NextMarker),
   } as any;
 };
 
@@ -10442,8 +10434,7 @@ const deserializeAws_json1_1GetSampledRequestsResponse = (
   context: __SerdeContext
 ): GetSampledRequestsResponse => {
   return {
-    PopulationSize:
-      output.PopulationSize !== undefined && output.PopulationSize !== null ? output.PopulationSize : undefined,
+    PopulationSize: __expectNumber(output.PopulationSize),
     SampledRequests:
       output.SampledRequests !== undefined && output.SampledRequests !== null
         ? deserializeAws_json1_1SampledHTTPRequests(output.SampledRequests, context)
@@ -10511,8 +10502,8 @@ const deserializeAws_json1_1GetXssMatchSetResponse = (output: any, context: __Se
 
 const deserializeAws_json1_1HTTPHeader = (output: any, context: __SerdeContext): HTTPHeader => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Name: __expectString(output.Name),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -10529,15 +10520,15 @@ const deserializeAws_json1_1HTTPHeaders = (output: any, context: __SerdeContext)
 
 const deserializeAws_json1_1HTTPRequest = (output: any, context: __SerdeContext): HTTPRequest => {
   return {
-    ClientIP: output.ClientIP !== undefined && output.ClientIP !== null ? output.ClientIP : undefined,
-    Country: output.Country !== undefined && output.Country !== null ? output.Country : undefined,
-    HTTPVersion: output.HTTPVersion !== undefined && output.HTTPVersion !== null ? output.HTTPVersion : undefined,
+    ClientIP: __expectString(output.ClientIP),
+    Country: __expectString(output.Country),
+    HTTPVersion: __expectString(output.HTTPVersion),
     Headers:
       output.Headers !== undefined && output.Headers !== null
         ? deserializeAws_json1_1HTTPHeaders(output.Headers, context)
         : undefined,
-    Method: output.Method !== undefined && output.Method !== null ? output.Method : undefined,
-    URI: output.URI !== undefined && output.URI !== null ? output.URI : undefined,
+    Method: __expectString(output.Method),
+    URI: __expectString(output.URI),
   } as any;
 };
 
@@ -10547,15 +10538,15 @@ const deserializeAws_json1_1IPSet = (output: any, context: __SerdeContext): IPSe
       output.IPSetDescriptors !== undefined && output.IPSetDescriptors !== null
         ? deserializeAws_json1_1IPSetDescriptors(output.IPSetDescriptors, context)
         : undefined,
-    IPSetId: output.IPSetId !== undefined && output.IPSetId !== null ? output.IPSetId : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    IPSetId: __expectString(output.IPSetId),
+    Name: __expectString(output.Name),
   } as any;
 };
 
 const deserializeAws_json1_1IPSetDescriptor = (output: any, context: __SerdeContext): IPSetDescriptor => {
   return {
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Type: __expectString(output.Type),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -10583,8 +10574,8 @@ const deserializeAws_json1_1IPSetSummaries = (output: any, context: __SerdeConte
 
 const deserializeAws_json1_1IPSetSummary = (output: any, context: __SerdeContext): IPSetSummary => {
   return {
-    IPSetId: output.IPSetId !== undefined && output.IPSetId !== null ? output.IPSetId : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    IPSetId: __expectString(output.IPSetId),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -10597,7 +10588,7 @@ const deserializeAws_json1_1ListActivatedRulesInRuleGroupResponse = (
       output.ActivatedRules !== undefined && output.ActivatedRules !== null
         ? deserializeAws_json1_1ActivatedRules(output.ActivatedRules, context)
         : undefined,
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    NextMarker: __expectString(output.NextMarker),
   } as any;
 };
 
@@ -10610,7 +10601,7 @@ const deserializeAws_json1_1ListByteMatchSetsResponse = (
       output.ByteMatchSets !== undefined && output.ByteMatchSets !== null
         ? deserializeAws_json1_1ByteMatchSetSummaries(output.ByteMatchSets, context)
         : undefined,
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    NextMarker: __expectString(output.NextMarker),
   } as any;
 };
 
@@ -10623,7 +10614,7 @@ const deserializeAws_json1_1ListGeoMatchSetsResponse = (
       output.GeoMatchSets !== undefined && output.GeoMatchSets !== null
         ? deserializeAws_json1_1GeoMatchSetSummaries(output.GeoMatchSets, context)
         : undefined,
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    NextMarker: __expectString(output.NextMarker),
   } as any;
 };
 
@@ -10633,7 +10624,7 @@ const deserializeAws_json1_1ListIPSetsResponse = (output: any, context: __SerdeC
       output.IPSets !== undefined && output.IPSets !== null
         ? deserializeAws_json1_1IPSetSummaries(output.IPSets, context)
         : undefined,
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    NextMarker: __expectString(output.NextMarker),
   } as any;
 };
 
@@ -10646,7 +10637,7 @@ const deserializeAws_json1_1ListLoggingConfigurationsResponse = (
       output.LoggingConfigurations !== undefined && output.LoggingConfigurations !== null
         ? deserializeAws_json1_1LoggingConfigurations(output.LoggingConfigurations, context)
         : undefined,
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    NextMarker: __expectString(output.NextMarker),
   } as any;
 };
 
@@ -10655,7 +10646,7 @@ const deserializeAws_json1_1ListRateBasedRulesResponse = (
   context: __SerdeContext
 ): ListRateBasedRulesResponse => {
   return {
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    NextMarker: __expectString(output.NextMarker),
     Rules:
       output.Rules !== undefined && output.Rules !== null
         ? deserializeAws_json1_1RuleSummaries(output.Rules, context)
@@ -10668,7 +10659,7 @@ const deserializeAws_json1_1ListRegexMatchSetsResponse = (
   context: __SerdeContext
 ): ListRegexMatchSetsResponse => {
   return {
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    NextMarker: __expectString(output.NextMarker),
     RegexMatchSets:
       output.RegexMatchSets !== undefined && output.RegexMatchSets !== null
         ? deserializeAws_json1_1RegexMatchSetSummaries(output.RegexMatchSets, context)
@@ -10681,7 +10672,7 @@ const deserializeAws_json1_1ListRegexPatternSetsResponse = (
   context: __SerdeContext
 ): ListRegexPatternSetsResponse => {
   return {
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    NextMarker: __expectString(output.NextMarker),
     RegexPatternSets:
       output.RegexPatternSets !== undefined && output.RegexPatternSets !== null
         ? deserializeAws_json1_1RegexPatternSetSummaries(output.RegexPatternSets, context)
@@ -10703,7 +10694,7 @@ const deserializeAws_json1_1ListResourcesForWebACLResponse = (
 
 const deserializeAws_json1_1ListRuleGroupsResponse = (output: any, context: __SerdeContext): ListRuleGroupsResponse => {
   return {
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    NextMarker: __expectString(output.NextMarker),
     RuleGroups:
       output.RuleGroups !== undefined && output.RuleGroups !== null
         ? deserializeAws_json1_1RuleGroupSummaries(output.RuleGroups, context)
@@ -10713,7 +10704,7 @@ const deserializeAws_json1_1ListRuleGroupsResponse = (output: any, context: __Se
 
 const deserializeAws_json1_1ListRulesResponse = (output: any, context: __SerdeContext): ListRulesResponse => {
   return {
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    NextMarker: __expectString(output.NextMarker),
     Rules:
       output.Rules !== undefined && output.Rules !== null
         ? deserializeAws_json1_1RuleSummaries(output.Rules, context)
@@ -10726,7 +10717,7 @@ const deserializeAws_json1_1ListSizeConstraintSetsResponse = (
   context: __SerdeContext
 ): ListSizeConstraintSetsResponse => {
   return {
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    NextMarker: __expectString(output.NextMarker),
     SizeConstraintSets:
       output.SizeConstraintSets !== undefined && output.SizeConstraintSets !== null
         ? deserializeAws_json1_1SizeConstraintSetSummaries(output.SizeConstraintSets, context)
@@ -10739,7 +10730,7 @@ const deserializeAws_json1_1ListSqlInjectionMatchSetsResponse = (
   context: __SerdeContext
 ): ListSqlInjectionMatchSetsResponse => {
   return {
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    NextMarker: __expectString(output.NextMarker),
     SqlInjectionMatchSets:
       output.SqlInjectionMatchSets !== undefined && output.SqlInjectionMatchSets !== null
         ? deserializeAws_json1_1SqlInjectionMatchSetSummaries(output.SqlInjectionMatchSets, context)
@@ -10752,7 +10743,7 @@ const deserializeAws_json1_1ListSubscribedRuleGroupsResponse = (
   context: __SerdeContext
 ): ListSubscribedRuleGroupsResponse => {
   return {
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    NextMarker: __expectString(output.NextMarker),
     RuleGroups:
       output.RuleGroups !== undefined && output.RuleGroups !== null
         ? deserializeAws_json1_1SubscribedRuleGroupSummaries(output.RuleGroups, context)
@@ -10765,7 +10756,7 @@ const deserializeAws_json1_1ListTagsForResourceResponse = (
   context: __SerdeContext
 ): ListTagsForResourceResponse => {
   return {
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    NextMarker: __expectString(output.NextMarker),
     TagInfoForResource:
       output.TagInfoForResource !== undefined && output.TagInfoForResource !== null
         ? deserializeAws_json1_1TagInfoForResource(output.TagInfoForResource, context)
@@ -10775,7 +10766,7 @@ const deserializeAws_json1_1ListTagsForResourceResponse = (
 
 const deserializeAws_json1_1ListWebACLsResponse = (output: any, context: __SerdeContext): ListWebACLsResponse => {
   return {
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    NextMarker: __expectString(output.NextMarker),
     WebACLs:
       output.WebACLs !== undefined && output.WebACLs !== null
         ? deserializeAws_json1_1WebACLSummaries(output.WebACLs, context)
@@ -10788,7 +10779,7 @@ const deserializeAws_json1_1ListXssMatchSetsResponse = (
   context: __SerdeContext
 ): ListXssMatchSetsResponse => {
   return {
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    NextMarker: __expectString(output.NextMarker),
     XssMatchSets:
       output.XssMatchSets !== undefined && output.XssMatchSets !== null
         ? deserializeAws_json1_1XssMatchSetSummaries(output.XssMatchSets, context)
@@ -10803,7 +10794,7 @@ const deserializeAws_json1_1LogDestinationConfigs = (output: any, context: __Ser
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -10817,7 +10808,7 @@ const deserializeAws_json1_1LoggingConfiguration = (output: any, context: __Serd
       output.RedactedFields !== undefined && output.RedactedFields !== null
         ? deserializeAws_json1_1RedactedFields(output.RedactedFields, context)
         : undefined,
-    ResourceArn: output.ResourceArn !== undefined && output.ResourceArn !== null ? output.ResourceArn : undefined,
+    ResourceArn: __expectString(output.ResourceArn),
   } as any;
 };
 
@@ -10839,15 +10830,15 @@ const deserializeAws_json1_1ManagedKeys = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1Predicate = (output: any, context: __SerdeContext): Predicate => {
   return {
-    DataId: output.DataId !== undefined && output.DataId !== null ? output.DataId : undefined,
-    Negated: output.Negated !== undefined && output.Negated !== null ? output.Negated : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    DataId: __expectString(output.DataId),
+    Negated: __expectBoolean(output.Negated),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -10887,11 +10878,11 @@ const deserializeAws_json1_1RateBasedRule = (output: any, context: __SerdeContex
       output.MatchPredicates !== undefined && output.MatchPredicates !== null
         ? deserializeAws_json1_1Predicates(output.MatchPredicates, context)
         : undefined,
-    MetricName: output.MetricName !== undefined && output.MetricName !== null ? output.MetricName : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    RateKey: output.RateKey !== undefined && output.RateKey !== null ? output.RateKey : undefined,
-    RateLimit: output.RateLimit !== undefined && output.RateLimit !== null ? output.RateLimit : undefined,
-    RuleId: output.RuleId !== undefined && output.RuleId !== null ? output.RuleId : undefined,
+    MetricName: __expectString(output.MetricName),
+    Name: __expectString(output.Name),
+    RateKey: __expectString(output.RateKey),
+    RateLimit: __expectNumber(output.RateLimit),
+    RuleId: __expectString(output.RuleId),
   } as any;
 };
 
@@ -10908,9 +10899,8 @@ const deserializeAws_json1_1RedactedFields = (output: any, context: __SerdeConte
 
 const deserializeAws_json1_1RegexMatchSet = (output: any, context: __SerdeContext): RegexMatchSet => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    RegexMatchSetId:
-      output.RegexMatchSetId !== undefined && output.RegexMatchSetId !== null ? output.RegexMatchSetId : undefined,
+    Name: __expectString(output.Name),
+    RegexMatchSetId: __expectString(output.RegexMatchSetId),
     RegexMatchTuples:
       output.RegexMatchTuples !== undefined && output.RegexMatchTuples !== null
         ? deserializeAws_json1_1RegexMatchTuples(output.RegexMatchTuples, context)
@@ -10931,9 +10921,8 @@ const deserializeAws_json1_1RegexMatchSetSummaries = (output: any, context: __Se
 
 const deserializeAws_json1_1RegexMatchSetSummary = (output: any, context: __SerdeContext): RegexMatchSetSummary => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    RegexMatchSetId:
-      output.RegexMatchSetId !== undefined && output.RegexMatchSetId !== null ? output.RegexMatchSetId : undefined,
+    Name: __expectString(output.Name),
+    RegexMatchSetId: __expectString(output.RegexMatchSetId),
   } as any;
 };
 
@@ -10943,14 +10932,8 @@ const deserializeAws_json1_1RegexMatchTuple = (output: any, context: __SerdeCont
       output.FieldToMatch !== undefined && output.FieldToMatch !== null
         ? deserializeAws_json1_1FieldToMatch(output.FieldToMatch, context)
         : undefined,
-    RegexPatternSetId:
-      output.RegexPatternSetId !== undefined && output.RegexPatternSetId !== null
-        ? output.RegexPatternSetId
-        : undefined,
-    TextTransformation:
-      output.TextTransformation !== undefined && output.TextTransformation !== null
-        ? output.TextTransformation
-        : undefined,
+    RegexPatternSetId: __expectString(output.RegexPatternSetId),
+    TextTransformation: __expectString(output.TextTransformation),
   } as any;
 };
 
@@ -10967,11 +10950,8 @@ const deserializeAws_json1_1RegexMatchTuples = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1RegexPatternSet = (output: any, context: __SerdeContext): RegexPatternSet => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    RegexPatternSetId:
-      output.RegexPatternSetId !== undefined && output.RegexPatternSetId !== null
-        ? output.RegexPatternSetId
-        : undefined,
+    Name: __expectString(output.Name),
+    RegexPatternSetId: __expectString(output.RegexPatternSetId),
     RegexPatternStrings:
       output.RegexPatternStrings !== undefined && output.RegexPatternStrings !== null
         ? deserializeAws_json1_1RegexPatternStrings(output.RegexPatternStrings, context)
@@ -10995,11 +10975,8 @@ const deserializeAws_json1_1RegexPatternSetSummaries = (
 
 const deserializeAws_json1_1RegexPatternSetSummary = (output: any, context: __SerdeContext): RegexPatternSetSummary => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    RegexPatternSetId:
-      output.RegexPatternSetId !== undefined && output.RegexPatternSetId !== null
-        ? output.RegexPatternSetId
-        : undefined,
+    Name: __expectString(output.Name),
+    RegexPatternSetId: __expectString(output.RegexPatternSetId),
   } as any;
 };
 
@@ -11010,7 +10987,7 @@ const deserializeAws_json1_1RegexPatternStrings = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -11021,27 +10998,27 @@ const deserializeAws_json1_1ResourceArns = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1Rule = (output: any, context: __SerdeContext): Rule => {
   return {
-    MetricName: output.MetricName !== undefined && output.MetricName !== null ? output.MetricName : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    MetricName: __expectString(output.MetricName),
+    Name: __expectString(output.Name),
     Predicates:
       output.Predicates !== undefined && output.Predicates !== null
         ? deserializeAws_json1_1Predicates(output.Predicates, context)
         : undefined,
-    RuleId: output.RuleId !== undefined && output.RuleId !== null ? output.RuleId : undefined,
+    RuleId: __expectString(output.RuleId),
   } as any;
 };
 
 const deserializeAws_json1_1RuleGroup = (output: any, context: __SerdeContext): RuleGroup => {
   return {
-    MetricName: output.MetricName !== undefined && output.MetricName !== null ? output.MetricName : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    RuleGroupId: output.RuleGroupId !== undefined && output.RuleGroupId !== null ? output.RuleGroupId : undefined,
+    MetricName: __expectString(output.MetricName),
+    Name: __expectString(output.Name),
+    RuleGroupId: __expectString(output.RuleGroupId),
   } as any;
 };
 
@@ -11058,8 +11035,8 @@ const deserializeAws_json1_1RuleGroupSummaries = (output: any, context: __SerdeC
 
 const deserializeAws_json1_1RuleGroupSummary = (output: any, context: __SerdeContext): RuleGroupSummary => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    RuleGroupId: output.RuleGroupId !== undefined && output.RuleGroupId !== null ? output.RuleGroupId : undefined,
+    Name: __expectString(output.Name),
+    RuleGroupId: __expectString(output.RuleGroupId),
   } as any;
 };
 
@@ -11076,27 +11053,24 @@ const deserializeAws_json1_1RuleSummaries = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1RuleSummary = (output: any, context: __SerdeContext): RuleSummary => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    RuleId: output.RuleId !== undefined && output.RuleId !== null ? output.RuleId : undefined,
+    Name: __expectString(output.Name),
+    RuleId: __expectString(output.RuleId),
   } as any;
 };
 
 const deserializeAws_json1_1SampledHTTPRequest = (output: any, context: __SerdeContext): SampledHTTPRequest => {
   return {
-    Action: output.Action !== undefined && output.Action !== null ? output.Action : undefined,
+    Action: __expectString(output.Action),
     Request:
       output.Request !== undefined && output.Request !== null
         ? deserializeAws_json1_1HTTPRequest(output.Request, context)
         : undefined,
-    RuleWithinRuleGroup:
-      output.RuleWithinRuleGroup !== undefined && output.RuleWithinRuleGroup !== null
-        ? output.RuleWithinRuleGroup
-        : undefined,
+    RuleWithinRuleGroup: __expectString(output.RuleWithinRuleGroup),
     Timestamp:
       output.Timestamp !== undefined && output.Timestamp !== null
         ? new Date(Math.round(output.Timestamp * 1000))
         : undefined,
-    Weight: output.Weight !== undefined && output.Weight !== null ? output.Weight : undefined,
+    Weight: __expectNumber(output.Weight),
   } as any;
 };
 
@@ -11113,19 +11087,13 @@ const deserializeAws_json1_1SampledHTTPRequests = (output: any, context: __Serde
 
 const deserializeAws_json1_1SizeConstraint = (output: any, context: __SerdeContext): SizeConstraint => {
   return {
-    ComparisonOperator:
-      output.ComparisonOperator !== undefined && output.ComparisonOperator !== null
-        ? output.ComparisonOperator
-        : undefined,
+    ComparisonOperator: __expectString(output.ComparisonOperator),
     FieldToMatch:
       output.FieldToMatch !== undefined && output.FieldToMatch !== null
         ? deserializeAws_json1_1FieldToMatch(output.FieldToMatch, context)
         : undefined,
-    Size: output.Size !== undefined && output.Size !== null ? output.Size : undefined,
-    TextTransformation:
-      output.TextTransformation !== undefined && output.TextTransformation !== null
-        ? output.TextTransformation
-        : undefined,
+    Size: __expectNumber(output.Size),
+    TextTransformation: __expectString(output.TextTransformation),
   } as any;
 };
 
@@ -11142,11 +11110,8 @@ const deserializeAws_json1_1SizeConstraints = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_1SizeConstraintSet = (output: any, context: __SerdeContext): SizeConstraintSet => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    SizeConstraintSetId:
-      output.SizeConstraintSetId !== undefined && output.SizeConstraintSetId !== null
-        ? output.SizeConstraintSetId
-        : undefined,
+    Name: __expectString(output.Name),
+    SizeConstraintSetId: __expectString(output.SizeConstraintSetId),
     SizeConstraints:
       output.SizeConstraints !== undefined && output.SizeConstraints !== null
         ? deserializeAws_json1_1SizeConstraints(output.SizeConstraints, context)
@@ -11173,21 +11138,15 @@ const deserializeAws_json1_1SizeConstraintSetSummary = (
   context: __SerdeContext
 ): SizeConstraintSetSummary => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    SizeConstraintSetId:
-      output.SizeConstraintSetId !== undefined && output.SizeConstraintSetId !== null
-        ? output.SizeConstraintSetId
-        : undefined,
+    Name: __expectString(output.Name),
+    SizeConstraintSetId: __expectString(output.SizeConstraintSetId),
   } as any;
 };
 
 const deserializeAws_json1_1SqlInjectionMatchSet = (output: any, context: __SerdeContext): SqlInjectionMatchSet => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    SqlInjectionMatchSetId:
-      output.SqlInjectionMatchSetId !== undefined && output.SqlInjectionMatchSetId !== null
-        ? output.SqlInjectionMatchSetId
-        : undefined,
+    Name: __expectString(output.Name),
+    SqlInjectionMatchSetId: __expectString(output.SqlInjectionMatchSetId),
     SqlInjectionMatchTuples:
       output.SqlInjectionMatchTuples !== undefined && output.SqlInjectionMatchTuples !== null
         ? deserializeAws_json1_1SqlInjectionMatchTuples(output.SqlInjectionMatchTuples, context)
@@ -11214,11 +11173,8 @@ const deserializeAws_json1_1SqlInjectionMatchSetSummary = (
   context: __SerdeContext
 ): SqlInjectionMatchSetSummary => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    SqlInjectionMatchSetId:
-      output.SqlInjectionMatchSetId !== undefined && output.SqlInjectionMatchSetId !== null
-        ? output.SqlInjectionMatchSetId
-        : undefined,
+    Name: __expectString(output.Name),
+    SqlInjectionMatchSetId: __expectString(output.SqlInjectionMatchSetId),
   } as any;
 };
 
@@ -11228,10 +11184,7 @@ const deserializeAws_json1_1SqlInjectionMatchTuple = (output: any, context: __Se
       output.FieldToMatch !== undefined && output.FieldToMatch !== null
         ? deserializeAws_json1_1FieldToMatch(output.FieldToMatch, context)
         : undefined,
-    TextTransformation:
-      output.TextTransformation !== undefined && output.TextTransformation !== null
-        ? output.TextTransformation
-        : undefined,
+    TextTransformation: __expectString(output.TextTransformation),
   } as any;
 };
 
@@ -11268,22 +11221,22 @@ const deserializeAws_json1_1SubscribedRuleGroupSummary = (
   context: __SerdeContext
 ): SubscribedRuleGroupSummary => {
   return {
-    MetricName: output.MetricName !== undefined && output.MetricName !== null ? output.MetricName : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    RuleGroupId: output.RuleGroupId !== undefined && output.RuleGroupId !== null ? output.RuleGroupId : undefined,
+    MetricName: __expectString(output.MetricName),
+    Name: __expectString(output.Name),
+    RuleGroupId: __expectString(output.RuleGroupId),
   } as any;
 };
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
 const deserializeAws_json1_1TagInfoForResource = (output: any, context: __SerdeContext): TagInfoForResource => {
   return {
-    ResourceARN: output.ResourceARN !== undefined && output.ResourceARN !== null ? output.ResourceARN : undefined,
+    ResourceARN: __expectString(output.ResourceARN),
     TagList:
       output.TagList !== undefined && output.TagList !== null
         ? deserializeAws_json1_1TagList(output.TagList, context)
@@ -11326,7 +11279,7 @@ const deserializeAws_json1_1UpdateByteMatchSetResponse = (
   context: __SerdeContext
 ): UpdateByteMatchSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
@@ -11335,13 +11288,13 @@ const deserializeAws_json1_1UpdateGeoMatchSetResponse = (
   context: __SerdeContext
 ): UpdateGeoMatchSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
 const deserializeAws_json1_1UpdateIPSetResponse = (output: any, context: __SerdeContext): UpdateIPSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
@@ -11350,7 +11303,7 @@ const deserializeAws_json1_1UpdateRateBasedRuleResponse = (
   context: __SerdeContext
 ): UpdateRateBasedRuleResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
@@ -11359,7 +11312,7 @@ const deserializeAws_json1_1UpdateRegexMatchSetResponse = (
   context: __SerdeContext
 ): UpdateRegexMatchSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
@@ -11368,7 +11321,7 @@ const deserializeAws_json1_1UpdateRegexPatternSetResponse = (
   context: __SerdeContext
 ): UpdateRegexPatternSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
@@ -11377,13 +11330,13 @@ const deserializeAws_json1_1UpdateRuleGroupResponse = (
   context: __SerdeContext
 ): UpdateRuleGroupResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
 const deserializeAws_json1_1UpdateRuleResponse = (output: any, context: __SerdeContext): UpdateRuleResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
@@ -11392,7 +11345,7 @@ const deserializeAws_json1_1UpdateSizeConstraintSetResponse = (
   context: __SerdeContext
 ): UpdateSizeConstraintSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
@@ -11401,13 +11354,13 @@ const deserializeAws_json1_1UpdateSqlInjectionMatchSetResponse = (
   context: __SerdeContext
 ): UpdateSqlInjectionMatchSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
 const deserializeAws_json1_1UpdateWebACLResponse = (output: any, context: __SerdeContext): UpdateWebACLResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
@@ -11416,19 +11369,19 @@ const deserializeAws_json1_1UpdateXssMatchSetResponse = (
   context: __SerdeContext
 ): UpdateXssMatchSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
 const deserializeAws_json1_1WafAction = (output: any, context: __SerdeContext): WafAction => {
   return {
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
 const deserializeAws_json1_1WAFBadRequestException = (output: any, context: __SerdeContext): WAFBadRequestException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -11437,7 +11390,7 @@ const deserializeAws_json1_1WAFDisallowedNameException = (
   context: __SerdeContext
 ): WAFDisallowedNameException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -11446,15 +11399,9 @@ const deserializeAws_json1_1WAFEntityMigrationException = (
   context: __SerdeContext
 ): WAFEntityMigrationException => {
   return {
-    MigrationErrorReason:
-      output.MigrationErrorReason !== undefined && output.MigrationErrorReason !== null
-        ? output.MigrationErrorReason
-        : undefined,
-    MigrationErrorType:
-      output.MigrationErrorType !== undefined && output.MigrationErrorType !== null
-        ? output.MigrationErrorType
-        : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    MigrationErrorReason: __expectString(output.MigrationErrorReason),
+    MigrationErrorType: __expectString(output.MigrationErrorType),
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -11463,7 +11410,7 @@ const deserializeAws_json1_1WAFInternalErrorException = (
   context: __SerdeContext
 ): WAFInternalErrorException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -11479,7 +11426,7 @@ const deserializeAws_json1_1WAFInvalidOperationException = (
   context: __SerdeContext
 ): WAFInvalidOperationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -11488,9 +11435,9 @@ const deserializeAws_json1_1WAFInvalidParameterException = (
   context: __SerdeContext
 ): WAFInvalidParameterException => {
   return {
-    field: output.field !== undefined && output.field !== null ? output.field : undefined,
-    parameter: output.parameter !== undefined && output.parameter !== null ? output.parameter : undefined,
-    reason: output.reason !== undefined && output.reason !== null ? output.reason : undefined,
+    field: __expectString(output.field),
+    parameter: __expectString(output.parameter),
+    reason: __expectString(output.reason),
   } as any;
 };
 
@@ -11499,7 +11446,7 @@ const deserializeAws_json1_1WAFInvalidPermissionPolicyException = (
   context: __SerdeContext
 ): WAFInvalidPermissionPolicyException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -11508,7 +11455,7 @@ const deserializeAws_json1_1WAFInvalidRegexPatternException = (
   context: __SerdeContext
 ): WAFInvalidRegexPatternException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -11517,7 +11464,7 @@ const deserializeAws_json1_1WAFLimitsExceededException = (
   context: __SerdeContext
 ): WAFLimitsExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -11526,7 +11473,7 @@ const deserializeAws_json1_1WAFNonEmptyEntityException = (
   context: __SerdeContext
 ): WAFNonEmptyEntityException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -11535,7 +11482,7 @@ const deserializeAws_json1_1WAFNonexistentContainerException = (
   context: __SerdeContext
 ): WAFNonexistentContainerException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -11544,13 +11491,13 @@ const deserializeAws_json1_1WAFNonexistentItemException = (
   context: __SerdeContext
 ): WAFNonexistentItemException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1WafOverrideAction = (output: any, context: __SerdeContext): WafOverrideAction => {
   return {
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -11559,7 +11506,7 @@ const deserializeAws_json1_1WAFReferencedItemException = (
   context: __SerdeContext
 ): WAFReferencedItemException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -11568,13 +11515,13 @@ const deserializeAws_json1_1WAFServiceLinkedRoleErrorException = (
   context: __SerdeContext
 ): WAFServiceLinkedRoleErrorException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1WAFStaleDataException = (output: any, context: __SerdeContext): WAFStaleDataException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -11583,7 +11530,7 @@ const deserializeAws_json1_1WAFSubscriptionNotFoundException = (
   context: __SerdeContext
 ): WAFSubscriptionNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -11592,7 +11539,7 @@ const deserializeAws_json1_1WAFTagOperationException = (
   context: __SerdeContext
 ): WAFTagOperationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -11601,7 +11548,7 @@ const deserializeAws_json1_1WAFTagOperationInternalErrorException = (
   context: __SerdeContext
 ): WAFTagOperationInternalErrorException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -11610,7 +11557,7 @@ const deserializeAws_json1_1WAFUnavailableEntityException = (
   context: __SerdeContext
 ): WAFUnavailableEntityException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -11620,14 +11567,14 @@ const deserializeAws_json1_1WebACL = (output: any, context: __SerdeContext): Web
       output.DefaultAction !== undefined && output.DefaultAction !== null
         ? deserializeAws_json1_1WafAction(output.DefaultAction, context)
         : undefined,
-    MetricName: output.MetricName !== undefined && output.MetricName !== null ? output.MetricName : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    MetricName: __expectString(output.MetricName),
+    Name: __expectString(output.Name),
     Rules:
       output.Rules !== undefined && output.Rules !== null
         ? deserializeAws_json1_1ActivatedRules(output.Rules, context)
         : undefined,
-    WebACLArn: output.WebACLArn !== undefined && output.WebACLArn !== null ? output.WebACLArn : undefined,
-    WebACLId: output.WebACLId !== undefined && output.WebACLId !== null ? output.WebACLId : undefined,
+    WebACLArn: __expectString(output.WebACLArn),
+    WebACLId: __expectString(output.WebACLId),
   } as any;
 };
 
@@ -11644,16 +11591,15 @@ const deserializeAws_json1_1WebACLSummaries = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_1WebACLSummary = (output: any, context: __SerdeContext): WebACLSummary => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    WebACLId: output.WebACLId !== undefined && output.WebACLId !== null ? output.WebACLId : undefined,
+    Name: __expectString(output.Name),
+    WebACLId: __expectString(output.WebACLId),
   } as any;
 };
 
 const deserializeAws_json1_1XssMatchSet = (output: any, context: __SerdeContext): XssMatchSet => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    XssMatchSetId:
-      output.XssMatchSetId !== undefined && output.XssMatchSetId !== null ? output.XssMatchSetId : undefined,
+    Name: __expectString(output.Name),
+    XssMatchSetId: __expectString(output.XssMatchSetId),
     XssMatchTuples:
       output.XssMatchTuples !== undefined && output.XssMatchTuples !== null
         ? deserializeAws_json1_1XssMatchTuples(output.XssMatchTuples, context)
@@ -11674,9 +11620,8 @@ const deserializeAws_json1_1XssMatchSetSummaries = (output: any, context: __Serd
 
 const deserializeAws_json1_1XssMatchSetSummary = (output: any, context: __SerdeContext): XssMatchSetSummary => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    XssMatchSetId:
-      output.XssMatchSetId !== undefined && output.XssMatchSetId !== null ? output.XssMatchSetId : undefined,
+    Name: __expectString(output.Name),
+    XssMatchSetId: __expectString(output.XssMatchSetId),
   } as any;
 };
 
@@ -11686,10 +11631,7 @@ const deserializeAws_json1_1XssMatchTuple = (output: any, context: __SerdeContex
       output.FieldToMatch !== undefined && output.FieldToMatch !== null
         ? deserializeAws_json1_1FieldToMatch(output.FieldToMatch, context)
         : undefined,
-    TextTransformation:
-      output.TextTransformation !== undefined && output.TextTransformation !== null
-        ? output.TextTransformation
-        : undefined,
+    TextTransformation: __expectString(output.TextTransformation),
   } as any;
 };
 

--- a/clients/client-waf/protocols/Aws_json1_1.ts
+++ b/clients/client-waf/protocols/Aws_json1_1.ts
@@ -405,7 +405,12 @@ import {
   XssMatchTuple,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -9420,9 +9425,9 @@ const deserializeAws_json1_1ActivatedRule = (output: any, context: __SerdeContex
       output.OverrideAction !== undefined && output.OverrideAction !== null
         ? deserializeAws_json1_1WafOverrideAction(output.OverrideAction, context)
         : undefined,
-    Priority: output.Priority !== undefined && output.Priority !== null ? output.Priority : undefined,
-    RuleId: output.RuleId !== undefined && output.RuleId !== null ? output.RuleId : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Priority: __expectNumber(output.Priority),
+    RuleId: __expectString(output.RuleId),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -9439,13 +9444,12 @@ const deserializeAws_json1_1ActivatedRules = (output: any, context: __SerdeConte
 
 const deserializeAws_json1_1ByteMatchSet = (output: any, context: __SerdeContext): ByteMatchSet => {
   return {
-    ByteMatchSetId:
-      output.ByteMatchSetId !== undefined && output.ByteMatchSetId !== null ? output.ByteMatchSetId : undefined,
+    ByteMatchSetId: __expectString(output.ByteMatchSetId),
     ByteMatchTuples:
       output.ByteMatchTuples !== undefined && output.ByteMatchTuples !== null
         ? deserializeAws_json1_1ByteMatchTuples(output.ByteMatchTuples, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -9462,9 +9466,8 @@ const deserializeAws_json1_1ByteMatchSetSummaries = (output: any, context: __Ser
 
 const deserializeAws_json1_1ByteMatchSetSummary = (output: any, context: __SerdeContext): ByteMatchSetSummary => {
   return {
-    ByteMatchSetId:
-      output.ByteMatchSetId !== undefined && output.ByteMatchSetId !== null ? output.ByteMatchSetId : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    ByteMatchSetId: __expectString(output.ByteMatchSetId),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -9474,18 +9477,12 @@ const deserializeAws_json1_1ByteMatchTuple = (output: any, context: __SerdeConte
       output.FieldToMatch !== undefined && output.FieldToMatch !== null
         ? deserializeAws_json1_1FieldToMatch(output.FieldToMatch, context)
         : undefined,
-    PositionalConstraint:
-      output.PositionalConstraint !== undefined && output.PositionalConstraint !== null
-        ? output.PositionalConstraint
-        : undefined,
+    PositionalConstraint: __expectString(output.PositionalConstraint),
     TargetString:
       output.TargetString !== undefined && output.TargetString !== null
         ? context.base64Decoder(output.TargetString)
         : undefined,
-    TextTransformation:
-      output.TextTransformation !== undefined && output.TextTransformation !== null
-        ? output.TextTransformation
-        : undefined,
+    TextTransformation: __expectString(output.TextTransformation),
   } as any;
 };
 
@@ -9509,7 +9506,7 @@ const deserializeAws_json1_1CreateByteMatchSetResponse = (
       output.ByteMatchSet !== undefined && output.ByteMatchSet !== null
         ? deserializeAws_json1_1ByteMatchSet(output.ByteMatchSet, context)
         : undefined,
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
@@ -9518,7 +9515,7 @@ const deserializeAws_json1_1CreateGeoMatchSetResponse = (
   context: __SerdeContext
 ): CreateGeoMatchSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
     GeoMatchSet:
       output.GeoMatchSet !== undefined && output.GeoMatchSet !== null
         ? deserializeAws_json1_1GeoMatchSet(output.GeoMatchSet, context)
@@ -9528,7 +9525,7 @@ const deserializeAws_json1_1CreateGeoMatchSetResponse = (
 
 const deserializeAws_json1_1CreateIPSetResponse = (output: any, context: __SerdeContext): CreateIPSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
     IPSet:
       output.IPSet !== undefined && output.IPSet !== null
         ? deserializeAws_json1_1IPSet(output.IPSet, context)
@@ -9541,7 +9538,7 @@ const deserializeAws_json1_1CreateRateBasedRuleResponse = (
   context: __SerdeContext
 ): CreateRateBasedRuleResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
     Rule:
       output.Rule !== undefined && output.Rule !== null
         ? deserializeAws_json1_1RateBasedRule(output.Rule, context)
@@ -9554,7 +9551,7 @@ const deserializeAws_json1_1CreateRegexMatchSetResponse = (
   context: __SerdeContext
 ): CreateRegexMatchSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
     RegexMatchSet:
       output.RegexMatchSet !== undefined && output.RegexMatchSet !== null
         ? deserializeAws_json1_1RegexMatchSet(output.RegexMatchSet, context)
@@ -9567,7 +9564,7 @@ const deserializeAws_json1_1CreateRegexPatternSetResponse = (
   context: __SerdeContext
 ): CreateRegexPatternSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
     RegexPatternSet:
       output.RegexPatternSet !== undefined && output.RegexPatternSet !== null
         ? deserializeAws_json1_1RegexPatternSet(output.RegexPatternSet, context)
@@ -9580,7 +9577,7 @@ const deserializeAws_json1_1CreateRuleGroupResponse = (
   context: __SerdeContext
 ): CreateRuleGroupResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
     RuleGroup:
       output.RuleGroup !== undefined && output.RuleGroup !== null
         ? deserializeAws_json1_1RuleGroup(output.RuleGroup, context)
@@ -9590,7 +9587,7 @@ const deserializeAws_json1_1CreateRuleGroupResponse = (
 
 const deserializeAws_json1_1CreateRuleResponse = (output: any, context: __SerdeContext): CreateRuleResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
     Rule:
       output.Rule !== undefined && output.Rule !== null ? deserializeAws_json1_1Rule(output.Rule, context) : undefined,
   } as any;
@@ -9601,7 +9598,7 @@ const deserializeAws_json1_1CreateSizeConstraintSetResponse = (
   context: __SerdeContext
 ): CreateSizeConstraintSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
     SizeConstraintSet:
       output.SizeConstraintSet !== undefined && output.SizeConstraintSet !== null
         ? deserializeAws_json1_1SizeConstraintSet(output.SizeConstraintSet, context)
@@ -9614,7 +9611,7 @@ const deserializeAws_json1_1CreateSqlInjectionMatchSetResponse = (
   context: __SerdeContext
 ): CreateSqlInjectionMatchSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
     SqlInjectionMatchSet:
       output.SqlInjectionMatchSet !== undefined && output.SqlInjectionMatchSet !== null
         ? deserializeAws_json1_1SqlInjectionMatchSet(output.SqlInjectionMatchSet, context)
@@ -9627,13 +9624,13 @@ const deserializeAws_json1_1CreateWebACLMigrationStackResponse = (
   context: __SerdeContext
 ): CreateWebACLMigrationStackResponse => {
   return {
-    S3ObjectUrl: output.S3ObjectUrl !== undefined && output.S3ObjectUrl !== null ? output.S3ObjectUrl : undefined,
+    S3ObjectUrl: __expectString(output.S3ObjectUrl),
   } as any;
 };
 
 const deserializeAws_json1_1CreateWebACLResponse = (output: any, context: __SerdeContext): CreateWebACLResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
     WebACL:
       output.WebACL !== undefined && output.WebACL !== null
         ? deserializeAws_json1_1WebACL(output.WebACL, context)
@@ -9646,7 +9643,7 @@ const deserializeAws_json1_1CreateXssMatchSetResponse = (
   context: __SerdeContext
 ): CreateXssMatchSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
     XssMatchSet:
       output.XssMatchSet !== undefined && output.XssMatchSet !== null
         ? deserializeAws_json1_1XssMatchSet(output.XssMatchSet, context)
@@ -9659,7 +9656,7 @@ const deserializeAws_json1_1DeleteByteMatchSetResponse = (
   context: __SerdeContext
 ): DeleteByteMatchSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
@@ -9668,13 +9665,13 @@ const deserializeAws_json1_1DeleteGeoMatchSetResponse = (
   context: __SerdeContext
 ): DeleteGeoMatchSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
 const deserializeAws_json1_1DeleteIPSetResponse = (output: any, context: __SerdeContext): DeleteIPSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
@@ -9697,7 +9694,7 @@ const deserializeAws_json1_1DeleteRateBasedRuleResponse = (
   context: __SerdeContext
 ): DeleteRateBasedRuleResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
@@ -9706,7 +9703,7 @@ const deserializeAws_json1_1DeleteRegexMatchSetResponse = (
   context: __SerdeContext
 ): DeleteRegexMatchSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
@@ -9715,7 +9712,7 @@ const deserializeAws_json1_1DeleteRegexPatternSetResponse = (
   context: __SerdeContext
 ): DeleteRegexPatternSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
@@ -9724,13 +9721,13 @@ const deserializeAws_json1_1DeleteRuleGroupResponse = (
   context: __SerdeContext
 ): DeleteRuleGroupResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
 const deserializeAws_json1_1DeleteRuleResponse = (output: any, context: __SerdeContext): DeleteRuleResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
@@ -9739,7 +9736,7 @@ const deserializeAws_json1_1DeleteSizeConstraintSetResponse = (
   context: __SerdeContext
 ): DeleteSizeConstraintSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
@@ -9748,13 +9745,13 @@ const deserializeAws_json1_1DeleteSqlInjectionMatchSetResponse = (
   context: __SerdeContext
 ): DeleteSqlInjectionMatchSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
 const deserializeAws_json1_1DeleteWebACLResponse = (output: any, context: __SerdeContext): DeleteWebACLResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
@@ -9763,13 +9760,13 @@ const deserializeAws_json1_1DeleteXssMatchSetResponse = (
   context: __SerdeContext
 ): DeleteXssMatchSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
 const deserializeAws_json1_1ExcludedRule = (output: any, context: __SerdeContext): ExcludedRule => {
   return {
-    RuleId: output.RuleId !== undefined && output.RuleId !== null ? output.RuleId : undefined,
+    RuleId: __expectString(output.RuleId),
   } as any;
 };
 
@@ -9786,15 +9783,15 @@ const deserializeAws_json1_1ExcludedRules = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1FieldToMatch = (output: any, context: __SerdeContext): FieldToMatch => {
   return {
-    Data: output.Data !== undefined && output.Data !== null ? output.Data : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Data: __expectString(output.Data),
+    Type: __expectString(output.Type),
   } as any;
 };
 
 const deserializeAws_json1_1GeoMatchConstraint = (output: any, context: __SerdeContext): GeoMatchConstraint => {
   return {
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Type: __expectString(output.Type),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -9815,9 +9812,8 @@ const deserializeAws_json1_1GeoMatchSet = (output: any, context: __SerdeContext)
       output.GeoMatchConstraints !== undefined && output.GeoMatchConstraints !== null
         ? deserializeAws_json1_1GeoMatchConstraints(output.GeoMatchConstraints, context)
         : undefined,
-    GeoMatchSetId:
-      output.GeoMatchSetId !== undefined && output.GeoMatchSetId !== null ? output.GeoMatchSetId : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    GeoMatchSetId: __expectString(output.GeoMatchSetId),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -9834,9 +9830,8 @@ const deserializeAws_json1_1GeoMatchSetSummaries = (output: any, context: __Serd
 
 const deserializeAws_json1_1GeoMatchSetSummary = (output: any, context: __SerdeContext): GeoMatchSetSummary => {
   return {
-    GeoMatchSetId:
-      output.GeoMatchSetId !== undefined && output.GeoMatchSetId !== null ? output.GeoMatchSetId : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    GeoMatchSetId: __expectString(output.GeoMatchSetId),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -9854,7 +9849,7 @@ const deserializeAws_json1_1GetByteMatchSetResponse = (
 
 const deserializeAws_json1_1GetChangeTokenResponse = (output: any, context: __SerdeContext): GetChangeTokenResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
@@ -9863,10 +9858,7 @@ const deserializeAws_json1_1GetChangeTokenStatusResponse = (
   context: __SerdeContext
 ): GetChangeTokenStatusResponse => {
   return {
-    ChangeTokenStatus:
-      output.ChangeTokenStatus !== undefined && output.ChangeTokenStatus !== null
-        ? output.ChangeTokenStatus
-        : undefined,
+    ChangeTokenStatus: __expectString(output.ChangeTokenStatus),
   } as any;
 };
 
@@ -9905,7 +9897,7 @@ const deserializeAws_json1_1GetPermissionPolicyResponse = (
   context: __SerdeContext
 ): GetPermissionPolicyResponse => {
   return {
-    Policy: output.Policy !== undefined && output.Policy !== null ? output.Policy : undefined,
+    Policy: __expectString(output.Policy),
   } as any;
 };
 
@@ -9918,7 +9910,7 @@ const deserializeAws_json1_1GetRateBasedRuleManagedKeysResponse = (
       output.ManagedKeys !== undefined && output.ManagedKeys !== null
         ? deserializeAws_json1_1ManagedKeys(output.ManagedKeys, context)
         : undefined,
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    NextMarker: __expectString(output.NextMarker),
   } as any;
 };
 
@@ -9979,8 +9971,7 @@ const deserializeAws_json1_1GetSampledRequestsResponse = (
   context: __SerdeContext
 ): GetSampledRequestsResponse => {
   return {
-    PopulationSize:
-      output.PopulationSize !== undefined && output.PopulationSize !== null ? output.PopulationSize : undefined,
+    PopulationSize: __expectNumber(output.PopulationSize),
     SampledRequests:
       output.SampledRequests !== undefined && output.SampledRequests !== null
         ? deserializeAws_json1_1SampledHTTPRequests(output.SampledRequests, context)
@@ -10036,8 +10027,8 @@ const deserializeAws_json1_1GetXssMatchSetResponse = (output: any, context: __Se
 
 const deserializeAws_json1_1HTTPHeader = (output: any, context: __SerdeContext): HTTPHeader => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Name: __expectString(output.Name),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -10054,15 +10045,15 @@ const deserializeAws_json1_1HTTPHeaders = (output: any, context: __SerdeContext)
 
 const deserializeAws_json1_1HTTPRequest = (output: any, context: __SerdeContext): HTTPRequest => {
   return {
-    ClientIP: output.ClientIP !== undefined && output.ClientIP !== null ? output.ClientIP : undefined,
-    Country: output.Country !== undefined && output.Country !== null ? output.Country : undefined,
-    HTTPVersion: output.HTTPVersion !== undefined && output.HTTPVersion !== null ? output.HTTPVersion : undefined,
+    ClientIP: __expectString(output.ClientIP),
+    Country: __expectString(output.Country),
+    HTTPVersion: __expectString(output.HTTPVersion),
     Headers:
       output.Headers !== undefined && output.Headers !== null
         ? deserializeAws_json1_1HTTPHeaders(output.Headers, context)
         : undefined,
-    Method: output.Method !== undefined && output.Method !== null ? output.Method : undefined,
-    URI: output.URI !== undefined && output.URI !== null ? output.URI : undefined,
+    Method: __expectString(output.Method),
+    URI: __expectString(output.URI),
   } as any;
 };
 
@@ -10072,15 +10063,15 @@ const deserializeAws_json1_1IPSet = (output: any, context: __SerdeContext): IPSe
       output.IPSetDescriptors !== undefined && output.IPSetDescriptors !== null
         ? deserializeAws_json1_1IPSetDescriptors(output.IPSetDescriptors, context)
         : undefined,
-    IPSetId: output.IPSetId !== undefined && output.IPSetId !== null ? output.IPSetId : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    IPSetId: __expectString(output.IPSetId),
+    Name: __expectString(output.Name),
   } as any;
 };
 
 const deserializeAws_json1_1IPSetDescriptor = (output: any, context: __SerdeContext): IPSetDescriptor => {
   return {
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Type: __expectString(output.Type),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -10108,8 +10099,8 @@ const deserializeAws_json1_1IPSetSummaries = (output: any, context: __SerdeConte
 
 const deserializeAws_json1_1IPSetSummary = (output: any, context: __SerdeContext): IPSetSummary => {
   return {
-    IPSetId: output.IPSetId !== undefined && output.IPSetId !== null ? output.IPSetId : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    IPSetId: __expectString(output.IPSetId),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -10122,7 +10113,7 @@ const deserializeAws_json1_1ListActivatedRulesInRuleGroupResponse = (
       output.ActivatedRules !== undefined && output.ActivatedRules !== null
         ? deserializeAws_json1_1ActivatedRules(output.ActivatedRules, context)
         : undefined,
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    NextMarker: __expectString(output.NextMarker),
   } as any;
 };
 
@@ -10135,7 +10126,7 @@ const deserializeAws_json1_1ListByteMatchSetsResponse = (
       output.ByteMatchSets !== undefined && output.ByteMatchSets !== null
         ? deserializeAws_json1_1ByteMatchSetSummaries(output.ByteMatchSets, context)
         : undefined,
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    NextMarker: __expectString(output.NextMarker),
   } as any;
 };
 
@@ -10148,7 +10139,7 @@ const deserializeAws_json1_1ListGeoMatchSetsResponse = (
       output.GeoMatchSets !== undefined && output.GeoMatchSets !== null
         ? deserializeAws_json1_1GeoMatchSetSummaries(output.GeoMatchSets, context)
         : undefined,
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    NextMarker: __expectString(output.NextMarker),
   } as any;
 };
 
@@ -10158,7 +10149,7 @@ const deserializeAws_json1_1ListIPSetsResponse = (output: any, context: __SerdeC
       output.IPSets !== undefined && output.IPSets !== null
         ? deserializeAws_json1_1IPSetSummaries(output.IPSets, context)
         : undefined,
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    NextMarker: __expectString(output.NextMarker),
   } as any;
 };
 
@@ -10171,7 +10162,7 @@ const deserializeAws_json1_1ListLoggingConfigurationsResponse = (
       output.LoggingConfigurations !== undefined && output.LoggingConfigurations !== null
         ? deserializeAws_json1_1LoggingConfigurations(output.LoggingConfigurations, context)
         : undefined,
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    NextMarker: __expectString(output.NextMarker),
   } as any;
 };
 
@@ -10180,7 +10171,7 @@ const deserializeAws_json1_1ListRateBasedRulesResponse = (
   context: __SerdeContext
 ): ListRateBasedRulesResponse => {
   return {
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    NextMarker: __expectString(output.NextMarker),
     Rules:
       output.Rules !== undefined && output.Rules !== null
         ? deserializeAws_json1_1RuleSummaries(output.Rules, context)
@@ -10193,7 +10184,7 @@ const deserializeAws_json1_1ListRegexMatchSetsResponse = (
   context: __SerdeContext
 ): ListRegexMatchSetsResponse => {
   return {
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    NextMarker: __expectString(output.NextMarker),
     RegexMatchSets:
       output.RegexMatchSets !== undefined && output.RegexMatchSets !== null
         ? deserializeAws_json1_1RegexMatchSetSummaries(output.RegexMatchSets, context)
@@ -10206,7 +10197,7 @@ const deserializeAws_json1_1ListRegexPatternSetsResponse = (
   context: __SerdeContext
 ): ListRegexPatternSetsResponse => {
   return {
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    NextMarker: __expectString(output.NextMarker),
     RegexPatternSets:
       output.RegexPatternSets !== undefined && output.RegexPatternSets !== null
         ? deserializeAws_json1_1RegexPatternSetSummaries(output.RegexPatternSets, context)
@@ -10216,7 +10207,7 @@ const deserializeAws_json1_1ListRegexPatternSetsResponse = (
 
 const deserializeAws_json1_1ListRuleGroupsResponse = (output: any, context: __SerdeContext): ListRuleGroupsResponse => {
   return {
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    NextMarker: __expectString(output.NextMarker),
     RuleGroups:
       output.RuleGroups !== undefined && output.RuleGroups !== null
         ? deserializeAws_json1_1RuleGroupSummaries(output.RuleGroups, context)
@@ -10226,7 +10217,7 @@ const deserializeAws_json1_1ListRuleGroupsResponse = (output: any, context: __Se
 
 const deserializeAws_json1_1ListRulesResponse = (output: any, context: __SerdeContext): ListRulesResponse => {
   return {
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    NextMarker: __expectString(output.NextMarker),
     Rules:
       output.Rules !== undefined && output.Rules !== null
         ? deserializeAws_json1_1RuleSummaries(output.Rules, context)
@@ -10239,7 +10230,7 @@ const deserializeAws_json1_1ListSizeConstraintSetsResponse = (
   context: __SerdeContext
 ): ListSizeConstraintSetsResponse => {
   return {
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    NextMarker: __expectString(output.NextMarker),
     SizeConstraintSets:
       output.SizeConstraintSets !== undefined && output.SizeConstraintSets !== null
         ? deserializeAws_json1_1SizeConstraintSetSummaries(output.SizeConstraintSets, context)
@@ -10252,7 +10243,7 @@ const deserializeAws_json1_1ListSqlInjectionMatchSetsResponse = (
   context: __SerdeContext
 ): ListSqlInjectionMatchSetsResponse => {
   return {
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    NextMarker: __expectString(output.NextMarker),
     SqlInjectionMatchSets:
       output.SqlInjectionMatchSets !== undefined && output.SqlInjectionMatchSets !== null
         ? deserializeAws_json1_1SqlInjectionMatchSetSummaries(output.SqlInjectionMatchSets, context)
@@ -10265,7 +10256,7 @@ const deserializeAws_json1_1ListSubscribedRuleGroupsResponse = (
   context: __SerdeContext
 ): ListSubscribedRuleGroupsResponse => {
   return {
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    NextMarker: __expectString(output.NextMarker),
     RuleGroups:
       output.RuleGroups !== undefined && output.RuleGroups !== null
         ? deserializeAws_json1_1SubscribedRuleGroupSummaries(output.RuleGroups, context)
@@ -10278,7 +10269,7 @@ const deserializeAws_json1_1ListTagsForResourceResponse = (
   context: __SerdeContext
 ): ListTagsForResourceResponse => {
   return {
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    NextMarker: __expectString(output.NextMarker),
     TagInfoForResource:
       output.TagInfoForResource !== undefined && output.TagInfoForResource !== null
         ? deserializeAws_json1_1TagInfoForResource(output.TagInfoForResource, context)
@@ -10288,7 +10279,7 @@ const deserializeAws_json1_1ListTagsForResourceResponse = (
 
 const deserializeAws_json1_1ListWebACLsResponse = (output: any, context: __SerdeContext): ListWebACLsResponse => {
   return {
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    NextMarker: __expectString(output.NextMarker),
     WebACLs:
       output.WebACLs !== undefined && output.WebACLs !== null
         ? deserializeAws_json1_1WebACLSummaries(output.WebACLs, context)
@@ -10301,7 +10292,7 @@ const deserializeAws_json1_1ListXssMatchSetsResponse = (
   context: __SerdeContext
 ): ListXssMatchSetsResponse => {
   return {
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    NextMarker: __expectString(output.NextMarker),
     XssMatchSets:
       output.XssMatchSets !== undefined && output.XssMatchSets !== null
         ? deserializeAws_json1_1XssMatchSetSummaries(output.XssMatchSets, context)
@@ -10316,7 +10307,7 @@ const deserializeAws_json1_1LogDestinationConfigs = (output: any, context: __Ser
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -10330,7 +10321,7 @@ const deserializeAws_json1_1LoggingConfiguration = (output: any, context: __Serd
       output.RedactedFields !== undefined && output.RedactedFields !== null
         ? deserializeAws_json1_1RedactedFields(output.RedactedFields, context)
         : undefined,
-    ResourceArn: output.ResourceArn !== undefined && output.ResourceArn !== null ? output.ResourceArn : undefined,
+    ResourceArn: __expectString(output.ResourceArn),
   } as any;
 };
 
@@ -10352,15 +10343,15 @@ const deserializeAws_json1_1ManagedKeys = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1Predicate = (output: any, context: __SerdeContext): Predicate => {
   return {
-    DataId: output.DataId !== undefined && output.DataId !== null ? output.DataId : undefined,
-    Negated: output.Negated !== undefined && output.Negated !== null ? output.Negated : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    DataId: __expectString(output.DataId),
+    Negated: __expectBoolean(output.Negated),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -10400,11 +10391,11 @@ const deserializeAws_json1_1RateBasedRule = (output: any, context: __SerdeContex
       output.MatchPredicates !== undefined && output.MatchPredicates !== null
         ? deserializeAws_json1_1Predicates(output.MatchPredicates, context)
         : undefined,
-    MetricName: output.MetricName !== undefined && output.MetricName !== null ? output.MetricName : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    RateKey: output.RateKey !== undefined && output.RateKey !== null ? output.RateKey : undefined,
-    RateLimit: output.RateLimit !== undefined && output.RateLimit !== null ? output.RateLimit : undefined,
-    RuleId: output.RuleId !== undefined && output.RuleId !== null ? output.RuleId : undefined,
+    MetricName: __expectString(output.MetricName),
+    Name: __expectString(output.Name),
+    RateKey: __expectString(output.RateKey),
+    RateLimit: __expectNumber(output.RateLimit),
+    RuleId: __expectString(output.RuleId),
   } as any;
 };
 
@@ -10421,9 +10412,8 @@ const deserializeAws_json1_1RedactedFields = (output: any, context: __SerdeConte
 
 const deserializeAws_json1_1RegexMatchSet = (output: any, context: __SerdeContext): RegexMatchSet => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    RegexMatchSetId:
-      output.RegexMatchSetId !== undefined && output.RegexMatchSetId !== null ? output.RegexMatchSetId : undefined,
+    Name: __expectString(output.Name),
+    RegexMatchSetId: __expectString(output.RegexMatchSetId),
     RegexMatchTuples:
       output.RegexMatchTuples !== undefined && output.RegexMatchTuples !== null
         ? deserializeAws_json1_1RegexMatchTuples(output.RegexMatchTuples, context)
@@ -10444,9 +10434,8 @@ const deserializeAws_json1_1RegexMatchSetSummaries = (output: any, context: __Se
 
 const deserializeAws_json1_1RegexMatchSetSummary = (output: any, context: __SerdeContext): RegexMatchSetSummary => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    RegexMatchSetId:
-      output.RegexMatchSetId !== undefined && output.RegexMatchSetId !== null ? output.RegexMatchSetId : undefined,
+    Name: __expectString(output.Name),
+    RegexMatchSetId: __expectString(output.RegexMatchSetId),
   } as any;
 };
 
@@ -10456,14 +10445,8 @@ const deserializeAws_json1_1RegexMatchTuple = (output: any, context: __SerdeCont
       output.FieldToMatch !== undefined && output.FieldToMatch !== null
         ? deserializeAws_json1_1FieldToMatch(output.FieldToMatch, context)
         : undefined,
-    RegexPatternSetId:
-      output.RegexPatternSetId !== undefined && output.RegexPatternSetId !== null
-        ? output.RegexPatternSetId
-        : undefined,
-    TextTransformation:
-      output.TextTransformation !== undefined && output.TextTransformation !== null
-        ? output.TextTransformation
-        : undefined,
+    RegexPatternSetId: __expectString(output.RegexPatternSetId),
+    TextTransformation: __expectString(output.TextTransformation),
   } as any;
 };
 
@@ -10480,11 +10463,8 @@ const deserializeAws_json1_1RegexMatchTuples = (output: any, context: __SerdeCon
 
 const deserializeAws_json1_1RegexPatternSet = (output: any, context: __SerdeContext): RegexPatternSet => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    RegexPatternSetId:
-      output.RegexPatternSetId !== undefined && output.RegexPatternSetId !== null
-        ? output.RegexPatternSetId
-        : undefined,
+    Name: __expectString(output.Name),
+    RegexPatternSetId: __expectString(output.RegexPatternSetId),
     RegexPatternStrings:
       output.RegexPatternStrings !== undefined && output.RegexPatternStrings !== null
         ? deserializeAws_json1_1RegexPatternStrings(output.RegexPatternStrings, context)
@@ -10508,11 +10488,8 @@ const deserializeAws_json1_1RegexPatternSetSummaries = (
 
 const deserializeAws_json1_1RegexPatternSetSummary = (output: any, context: __SerdeContext): RegexPatternSetSummary => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    RegexPatternSetId:
-      output.RegexPatternSetId !== undefined && output.RegexPatternSetId !== null
-        ? output.RegexPatternSetId
-        : undefined,
+    Name: __expectString(output.Name),
+    RegexPatternSetId: __expectString(output.RegexPatternSetId),
   } as any;
 };
 
@@ -10523,27 +10500,27 @@ const deserializeAws_json1_1RegexPatternStrings = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1Rule = (output: any, context: __SerdeContext): Rule => {
   return {
-    MetricName: output.MetricName !== undefined && output.MetricName !== null ? output.MetricName : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    MetricName: __expectString(output.MetricName),
+    Name: __expectString(output.Name),
     Predicates:
       output.Predicates !== undefined && output.Predicates !== null
         ? deserializeAws_json1_1Predicates(output.Predicates, context)
         : undefined,
-    RuleId: output.RuleId !== undefined && output.RuleId !== null ? output.RuleId : undefined,
+    RuleId: __expectString(output.RuleId),
   } as any;
 };
 
 const deserializeAws_json1_1RuleGroup = (output: any, context: __SerdeContext): RuleGroup => {
   return {
-    MetricName: output.MetricName !== undefined && output.MetricName !== null ? output.MetricName : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    RuleGroupId: output.RuleGroupId !== undefined && output.RuleGroupId !== null ? output.RuleGroupId : undefined,
+    MetricName: __expectString(output.MetricName),
+    Name: __expectString(output.Name),
+    RuleGroupId: __expectString(output.RuleGroupId),
   } as any;
 };
 
@@ -10560,8 +10537,8 @@ const deserializeAws_json1_1RuleGroupSummaries = (output: any, context: __SerdeC
 
 const deserializeAws_json1_1RuleGroupSummary = (output: any, context: __SerdeContext): RuleGroupSummary => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    RuleGroupId: output.RuleGroupId !== undefined && output.RuleGroupId !== null ? output.RuleGroupId : undefined,
+    Name: __expectString(output.Name),
+    RuleGroupId: __expectString(output.RuleGroupId),
   } as any;
 };
 
@@ -10578,27 +10555,24 @@ const deserializeAws_json1_1RuleSummaries = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1RuleSummary = (output: any, context: __SerdeContext): RuleSummary => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    RuleId: output.RuleId !== undefined && output.RuleId !== null ? output.RuleId : undefined,
+    Name: __expectString(output.Name),
+    RuleId: __expectString(output.RuleId),
   } as any;
 };
 
 const deserializeAws_json1_1SampledHTTPRequest = (output: any, context: __SerdeContext): SampledHTTPRequest => {
   return {
-    Action: output.Action !== undefined && output.Action !== null ? output.Action : undefined,
+    Action: __expectString(output.Action),
     Request:
       output.Request !== undefined && output.Request !== null
         ? deserializeAws_json1_1HTTPRequest(output.Request, context)
         : undefined,
-    RuleWithinRuleGroup:
-      output.RuleWithinRuleGroup !== undefined && output.RuleWithinRuleGroup !== null
-        ? output.RuleWithinRuleGroup
-        : undefined,
+    RuleWithinRuleGroup: __expectString(output.RuleWithinRuleGroup),
     Timestamp:
       output.Timestamp !== undefined && output.Timestamp !== null
         ? new Date(Math.round(output.Timestamp * 1000))
         : undefined,
-    Weight: output.Weight !== undefined && output.Weight !== null ? output.Weight : undefined,
+    Weight: __expectNumber(output.Weight),
   } as any;
 };
 
@@ -10615,19 +10589,13 @@ const deserializeAws_json1_1SampledHTTPRequests = (output: any, context: __Serde
 
 const deserializeAws_json1_1SizeConstraint = (output: any, context: __SerdeContext): SizeConstraint => {
   return {
-    ComparisonOperator:
-      output.ComparisonOperator !== undefined && output.ComparisonOperator !== null
-        ? output.ComparisonOperator
-        : undefined,
+    ComparisonOperator: __expectString(output.ComparisonOperator),
     FieldToMatch:
       output.FieldToMatch !== undefined && output.FieldToMatch !== null
         ? deserializeAws_json1_1FieldToMatch(output.FieldToMatch, context)
         : undefined,
-    Size: output.Size !== undefined && output.Size !== null ? output.Size : undefined,
-    TextTransformation:
-      output.TextTransformation !== undefined && output.TextTransformation !== null
-        ? output.TextTransformation
-        : undefined,
+    Size: __expectNumber(output.Size),
+    TextTransformation: __expectString(output.TextTransformation),
   } as any;
 };
 
@@ -10644,11 +10612,8 @@ const deserializeAws_json1_1SizeConstraints = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_1SizeConstraintSet = (output: any, context: __SerdeContext): SizeConstraintSet => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    SizeConstraintSetId:
-      output.SizeConstraintSetId !== undefined && output.SizeConstraintSetId !== null
-        ? output.SizeConstraintSetId
-        : undefined,
+    Name: __expectString(output.Name),
+    SizeConstraintSetId: __expectString(output.SizeConstraintSetId),
     SizeConstraints:
       output.SizeConstraints !== undefined && output.SizeConstraints !== null
         ? deserializeAws_json1_1SizeConstraints(output.SizeConstraints, context)
@@ -10675,21 +10640,15 @@ const deserializeAws_json1_1SizeConstraintSetSummary = (
   context: __SerdeContext
 ): SizeConstraintSetSummary => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    SizeConstraintSetId:
-      output.SizeConstraintSetId !== undefined && output.SizeConstraintSetId !== null
-        ? output.SizeConstraintSetId
-        : undefined,
+    Name: __expectString(output.Name),
+    SizeConstraintSetId: __expectString(output.SizeConstraintSetId),
   } as any;
 };
 
 const deserializeAws_json1_1SqlInjectionMatchSet = (output: any, context: __SerdeContext): SqlInjectionMatchSet => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    SqlInjectionMatchSetId:
-      output.SqlInjectionMatchSetId !== undefined && output.SqlInjectionMatchSetId !== null
-        ? output.SqlInjectionMatchSetId
-        : undefined,
+    Name: __expectString(output.Name),
+    SqlInjectionMatchSetId: __expectString(output.SqlInjectionMatchSetId),
     SqlInjectionMatchTuples:
       output.SqlInjectionMatchTuples !== undefined && output.SqlInjectionMatchTuples !== null
         ? deserializeAws_json1_1SqlInjectionMatchTuples(output.SqlInjectionMatchTuples, context)
@@ -10716,11 +10675,8 @@ const deserializeAws_json1_1SqlInjectionMatchSetSummary = (
   context: __SerdeContext
 ): SqlInjectionMatchSetSummary => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    SqlInjectionMatchSetId:
-      output.SqlInjectionMatchSetId !== undefined && output.SqlInjectionMatchSetId !== null
-        ? output.SqlInjectionMatchSetId
-        : undefined,
+    Name: __expectString(output.Name),
+    SqlInjectionMatchSetId: __expectString(output.SqlInjectionMatchSetId),
   } as any;
 };
 
@@ -10730,10 +10686,7 @@ const deserializeAws_json1_1SqlInjectionMatchTuple = (output: any, context: __Se
       output.FieldToMatch !== undefined && output.FieldToMatch !== null
         ? deserializeAws_json1_1FieldToMatch(output.FieldToMatch, context)
         : undefined,
-    TextTransformation:
-      output.TextTransformation !== undefined && output.TextTransformation !== null
-        ? output.TextTransformation
-        : undefined,
+    TextTransformation: __expectString(output.TextTransformation),
   } as any;
 };
 
@@ -10770,22 +10723,22 @@ const deserializeAws_json1_1SubscribedRuleGroupSummary = (
   context: __SerdeContext
 ): SubscribedRuleGroupSummary => {
   return {
-    MetricName: output.MetricName !== undefined && output.MetricName !== null ? output.MetricName : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    RuleGroupId: output.RuleGroupId !== undefined && output.RuleGroupId !== null ? output.RuleGroupId : undefined,
+    MetricName: __expectString(output.MetricName),
+    Name: __expectString(output.Name),
+    RuleGroupId: __expectString(output.RuleGroupId),
   } as any;
 };
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
 const deserializeAws_json1_1TagInfoForResource = (output: any, context: __SerdeContext): TagInfoForResource => {
   return {
-    ResourceARN: output.ResourceARN !== undefined && output.ResourceARN !== null ? output.ResourceARN : undefined,
+    ResourceARN: __expectString(output.ResourceARN),
     TagList:
       output.TagList !== undefined && output.TagList !== null
         ? deserializeAws_json1_1TagList(output.TagList, context)
@@ -10828,7 +10781,7 @@ const deserializeAws_json1_1UpdateByteMatchSetResponse = (
   context: __SerdeContext
 ): UpdateByteMatchSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
@@ -10837,13 +10790,13 @@ const deserializeAws_json1_1UpdateGeoMatchSetResponse = (
   context: __SerdeContext
 ): UpdateGeoMatchSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
 const deserializeAws_json1_1UpdateIPSetResponse = (output: any, context: __SerdeContext): UpdateIPSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
@@ -10852,7 +10805,7 @@ const deserializeAws_json1_1UpdateRateBasedRuleResponse = (
   context: __SerdeContext
 ): UpdateRateBasedRuleResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
@@ -10861,7 +10814,7 @@ const deserializeAws_json1_1UpdateRegexMatchSetResponse = (
   context: __SerdeContext
 ): UpdateRegexMatchSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
@@ -10870,7 +10823,7 @@ const deserializeAws_json1_1UpdateRegexPatternSetResponse = (
   context: __SerdeContext
 ): UpdateRegexPatternSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
@@ -10879,13 +10832,13 @@ const deserializeAws_json1_1UpdateRuleGroupResponse = (
   context: __SerdeContext
 ): UpdateRuleGroupResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
 const deserializeAws_json1_1UpdateRuleResponse = (output: any, context: __SerdeContext): UpdateRuleResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
@@ -10894,7 +10847,7 @@ const deserializeAws_json1_1UpdateSizeConstraintSetResponse = (
   context: __SerdeContext
 ): UpdateSizeConstraintSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
@@ -10903,13 +10856,13 @@ const deserializeAws_json1_1UpdateSqlInjectionMatchSetResponse = (
   context: __SerdeContext
 ): UpdateSqlInjectionMatchSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
 const deserializeAws_json1_1UpdateWebACLResponse = (output: any, context: __SerdeContext): UpdateWebACLResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
@@ -10918,19 +10871,19 @@ const deserializeAws_json1_1UpdateXssMatchSetResponse = (
   context: __SerdeContext
 ): UpdateXssMatchSetResponse => {
   return {
-    ChangeToken: output.ChangeToken !== undefined && output.ChangeToken !== null ? output.ChangeToken : undefined,
+    ChangeToken: __expectString(output.ChangeToken),
   } as any;
 };
 
 const deserializeAws_json1_1WafAction = (output: any, context: __SerdeContext): WafAction => {
   return {
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
 const deserializeAws_json1_1WAFBadRequestException = (output: any, context: __SerdeContext): WAFBadRequestException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10939,7 +10892,7 @@ const deserializeAws_json1_1WAFDisallowedNameException = (
   context: __SerdeContext
 ): WAFDisallowedNameException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10948,15 +10901,9 @@ const deserializeAws_json1_1WAFEntityMigrationException = (
   context: __SerdeContext
 ): WAFEntityMigrationException => {
   return {
-    MigrationErrorReason:
-      output.MigrationErrorReason !== undefined && output.MigrationErrorReason !== null
-        ? output.MigrationErrorReason
-        : undefined,
-    MigrationErrorType:
-      output.MigrationErrorType !== undefined && output.MigrationErrorType !== null
-        ? output.MigrationErrorType
-        : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    MigrationErrorReason: __expectString(output.MigrationErrorReason),
+    MigrationErrorType: __expectString(output.MigrationErrorType),
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10965,7 +10912,7 @@ const deserializeAws_json1_1WAFInternalErrorException = (
   context: __SerdeContext
 ): WAFInternalErrorException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10981,7 +10928,7 @@ const deserializeAws_json1_1WAFInvalidOperationException = (
   context: __SerdeContext
 ): WAFInvalidOperationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -10990,9 +10937,9 @@ const deserializeAws_json1_1WAFInvalidParameterException = (
   context: __SerdeContext
 ): WAFInvalidParameterException => {
   return {
-    field: output.field !== undefined && output.field !== null ? output.field : undefined,
-    parameter: output.parameter !== undefined && output.parameter !== null ? output.parameter : undefined,
-    reason: output.reason !== undefined && output.reason !== null ? output.reason : undefined,
+    field: __expectString(output.field),
+    parameter: __expectString(output.parameter),
+    reason: __expectString(output.reason),
   } as any;
 };
 
@@ -11001,7 +10948,7 @@ const deserializeAws_json1_1WAFInvalidPermissionPolicyException = (
   context: __SerdeContext
 ): WAFInvalidPermissionPolicyException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -11010,7 +10957,7 @@ const deserializeAws_json1_1WAFInvalidRegexPatternException = (
   context: __SerdeContext
 ): WAFInvalidRegexPatternException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -11019,7 +10966,7 @@ const deserializeAws_json1_1WAFLimitsExceededException = (
   context: __SerdeContext
 ): WAFLimitsExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -11028,7 +10975,7 @@ const deserializeAws_json1_1WAFNonEmptyEntityException = (
   context: __SerdeContext
 ): WAFNonEmptyEntityException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -11037,7 +10984,7 @@ const deserializeAws_json1_1WAFNonexistentContainerException = (
   context: __SerdeContext
 ): WAFNonexistentContainerException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -11046,13 +10993,13 @@ const deserializeAws_json1_1WAFNonexistentItemException = (
   context: __SerdeContext
 ): WAFNonexistentItemException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1WafOverrideAction = (output: any, context: __SerdeContext): WafOverrideAction => {
   return {
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -11061,7 +11008,7 @@ const deserializeAws_json1_1WAFReferencedItemException = (
   context: __SerdeContext
 ): WAFReferencedItemException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -11070,13 +11017,13 @@ const deserializeAws_json1_1WAFServiceLinkedRoleErrorException = (
   context: __SerdeContext
 ): WAFServiceLinkedRoleErrorException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1WAFStaleDataException = (output: any, context: __SerdeContext): WAFStaleDataException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -11085,7 +11032,7 @@ const deserializeAws_json1_1WAFSubscriptionNotFoundException = (
   context: __SerdeContext
 ): WAFSubscriptionNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -11094,7 +11041,7 @@ const deserializeAws_json1_1WAFTagOperationException = (
   context: __SerdeContext
 ): WAFTagOperationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -11103,7 +11050,7 @@ const deserializeAws_json1_1WAFTagOperationInternalErrorException = (
   context: __SerdeContext
 ): WAFTagOperationInternalErrorException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -11113,14 +11060,14 @@ const deserializeAws_json1_1WebACL = (output: any, context: __SerdeContext): Web
       output.DefaultAction !== undefined && output.DefaultAction !== null
         ? deserializeAws_json1_1WafAction(output.DefaultAction, context)
         : undefined,
-    MetricName: output.MetricName !== undefined && output.MetricName !== null ? output.MetricName : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    MetricName: __expectString(output.MetricName),
+    Name: __expectString(output.Name),
     Rules:
       output.Rules !== undefined && output.Rules !== null
         ? deserializeAws_json1_1ActivatedRules(output.Rules, context)
         : undefined,
-    WebACLArn: output.WebACLArn !== undefined && output.WebACLArn !== null ? output.WebACLArn : undefined,
-    WebACLId: output.WebACLId !== undefined && output.WebACLId !== null ? output.WebACLId : undefined,
+    WebACLArn: __expectString(output.WebACLArn),
+    WebACLId: __expectString(output.WebACLId),
   } as any;
 };
 
@@ -11137,16 +11084,15 @@ const deserializeAws_json1_1WebACLSummaries = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_1WebACLSummary = (output: any, context: __SerdeContext): WebACLSummary => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    WebACLId: output.WebACLId !== undefined && output.WebACLId !== null ? output.WebACLId : undefined,
+    Name: __expectString(output.Name),
+    WebACLId: __expectString(output.WebACLId),
   } as any;
 };
 
 const deserializeAws_json1_1XssMatchSet = (output: any, context: __SerdeContext): XssMatchSet => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    XssMatchSetId:
-      output.XssMatchSetId !== undefined && output.XssMatchSetId !== null ? output.XssMatchSetId : undefined,
+    Name: __expectString(output.Name),
+    XssMatchSetId: __expectString(output.XssMatchSetId),
     XssMatchTuples:
       output.XssMatchTuples !== undefined && output.XssMatchTuples !== null
         ? deserializeAws_json1_1XssMatchTuples(output.XssMatchTuples, context)
@@ -11167,9 +11113,8 @@ const deserializeAws_json1_1XssMatchSetSummaries = (output: any, context: __Serd
 
 const deserializeAws_json1_1XssMatchSetSummary = (output: any, context: __SerdeContext): XssMatchSetSummary => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    XssMatchSetId:
-      output.XssMatchSetId !== undefined && output.XssMatchSetId !== null ? output.XssMatchSetId : undefined,
+    Name: __expectString(output.Name),
+    XssMatchSetId: __expectString(output.XssMatchSetId),
   } as any;
 };
 
@@ -11179,10 +11124,7 @@ const deserializeAws_json1_1XssMatchTuple = (output: any, context: __SerdeContex
       output.FieldToMatch !== undefined && output.FieldToMatch !== null
         ? deserializeAws_json1_1FieldToMatch(output.FieldToMatch, context)
         : undefined,
-    TextTransformation:
-      output.TextTransformation !== undefined && output.TextTransformation !== null
-        ? output.TextTransformation
-        : undefined,
+    TextTransformation: __expectString(output.TextTransformation),
   } as any;
 };
 

--- a/clients/client-wafv2/protocols/Aws_json1_1.ts
+++ b/clients/client-wafv2/protocols/Aws_json1_1.ts
@@ -262,7 +262,12 @@ import {
   XssMatchStatement,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -5856,7 +5861,7 @@ const serializeAws_json1_1XssMatchStatement = (input: XssMatchStatement, context
 
 const deserializeAws_json1_1ActionCondition = (output: any, context: __SerdeContext): ActionCondition => {
   return {
-    Action: output.Action !== undefined && output.Action !== null ? output.Action : undefined,
+    Action: __expectString(output.Action),
   } as any;
 };
 
@@ -5912,10 +5917,7 @@ const deserializeAws_json1_1ByteMatchStatement = (output: any, context: __SerdeC
       output.FieldToMatch !== undefined && output.FieldToMatch !== null
         ? deserializeAws_json1_1FieldToMatch(output.FieldToMatch, context)
         : undefined,
-    PositionalConstraint:
-      output.PositionalConstraint !== undefined && output.PositionalConstraint !== null
-        ? output.PositionalConstraint
-        : undefined,
+    PositionalConstraint: __expectString(output.PositionalConstraint),
     SearchString:
       output.SearchString !== undefined && output.SearchString !== null
         ? context.base64Decoder(output.SearchString)
@@ -5929,7 +5931,7 @@ const deserializeAws_json1_1ByteMatchStatement = (output: any, context: __SerdeC
 
 const deserializeAws_json1_1CheckCapacityResponse = (output: any, context: __SerdeContext): CheckCapacityResponse => {
   return {
-    Capacity: output.Capacity !== undefined && output.Capacity !== null ? output.Capacity : undefined,
+    Capacity: __expectNumber(output.Capacity),
   } as any;
 };
 
@@ -5973,7 +5975,7 @@ const deserializeAws_json1_1CountryCodes = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6021,8 +6023,8 @@ const deserializeAws_json1_1CreateWebACLResponse = (output: any, context: __Serd
 
 const deserializeAws_json1_1CustomHTTPHeader = (output: any, context: __SerdeContext): CustomHTTPHeader => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Name: __expectString(output.Name),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -6048,11 +6050,8 @@ const deserializeAws_json1_1CustomRequestHandling = (output: any, context: __Ser
 
 const deserializeAws_json1_1CustomResponse = (output: any, context: __SerdeContext): CustomResponse => {
   return {
-    CustomResponseBodyKey:
-      output.CustomResponseBodyKey !== undefined && output.CustomResponseBodyKey !== null
-        ? output.CustomResponseBodyKey
-        : undefined,
-    ResponseCode: output.ResponseCode !== undefined && output.ResponseCode !== null ? output.ResponseCode : undefined,
+    CustomResponseBodyKey: __expectString(output.CustomResponseBodyKey),
+    ResponseCode: __expectNumber(output.ResponseCode),
     ResponseHeaders:
       output.ResponseHeaders !== undefined && output.ResponseHeaders !== null
         ? deserializeAws_json1_1CustomHTTPHeaders(output.ResponseHeaders, context)
@@ -6077,8 +6076,8 @@ const deserializeAws_json1_1CustomResponseBodies = (
 
 const deserializeAws_json1_1CustomResponseBody = (output: any, context: __SerdeContext): CustomResponseBody => {
   return {
-    Content: output.Content !== undefined && output.Content !== null ? output.Content : undefined,
-    ContentType: output.ContentType !== undefined && output.ContentType !== null ? output.ContentType : undefined,
+    Content: __expectString(output.Content),
+    ContentType: __expectString(output.ContentType),
   } as any;
 };
 
@@ -6100,10 +6099,7 @@ const deserializeAws_json1_1DeleteFirewallManagerRuleGroupsResponse = (
   context: __SerdeContext
 ): DeleteFirewallManagerRuleGroupsResponse => {
   return {
-    NextWebACLLockToken:
-      output.NextWebACLLockToken !== undefined && output.NextWebACLLockToken !== null
-        ? output.NextWebACLLockToken
-        : undefined,
+    NextWebACLLockToken: __expectString(output.NextWebACLLockToken),
   } as any;
 };
 
@@ -6152,13 +6148,12 @@ const deserializeAws_json1_1DescribeManagedRuleGroupResponse = (
       output.AvailableLabels !== undefined && output.AvailableLabels !== null
         ? deserializeAws_json1_1LabelSummaries(output.AvailableLabels, context)
         : undefined,
-    Capacity: output.Capacity !== undefined && output.Capacity !== null ? output.Capacity : undefined,
+    Capacity: __expectNumber(output.Capacity),
     ConsumedLabels:
       output.ConsumedLabels !== undefined && output.ConsumedLabels !== null
         ? deserializeAws_json1_1LabelSummaries(output.ConsumedLabels, context)
         : undefined,
-    LabelNamespace:
-      output.LabelNamespace !== undefined && output.LabelNamespace !== null ? output.LabelNamespace : undefined,
+    LabelNamespace: __expectString(output.LabelNamespace),
     Rules:
       output.Rules !== undefined && output.Rules !== null
         ? deserializeAws_json1_1RuleSummaries(output.Rules, context)
@@ -6175,7 +6170,7 @@ const deserializeAws_json1_1DisassociateWebACLResponse = (
 
 const deserializeAws_json1_1ExcludedRule = (output: any, context: __SerdeContext): ExcludedRule => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -6227,12 +6222,12 @@ const deserializeAws_json1_1FieldToMatch = (output: any, context: __SerdeContext
 
 const deserializeAws_json1_1Filter = (output: any, context: __SerdeContext): Filter => {
   return {
-    Behavior: output.Behavior !== undefined && output.Behavior !== null ? output.Behavior : undefined,
+    Behavior: __expectString(output.Behavior),
     Conditions:
       output.Conditions !== undefined && output.Conditions !== null
         ? deserializeAws_json1_1Conditions(output.Conditions, context)
         : undefined,
-    Requirement: output.Requirement !== undefined && output.Requirement !== null ? output.Requirement : undefined,
+    Requirement: __expectString(output.Requirement),
   } as any;
 };
 
@@ -6256,12 +6251,12 @@ const deserializeAws_json1_1FirewallManagerRuleGroup = (
       output.FirewallManagerStatement !== undefined && output.FirewallManagerStatement !== null
         ? deserializeAws_json1_1FirewallManagerStatement(output.FirewallManagerStatement, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     OverrideAction:
       output.OverrideAction !== undefined && output.OverrideAction !== null
         ? deserializeAws_json1_1OverrideAction(output.OverrideAction, context)
         : undefined,
-    Priority: output.Priority !== undefined && output.Priority !== null ? output.Priority : undefined,
+    Priority: __expectNumber(output.Priority),
     VisibilityConfig:
       output.VisibilityConfig !== undefined && output.VisibilityConfig !== null
         ? deserializeAws_json1_1VisibilityConfig(output.VisibilityConfig, context)
@@ -6301,9 +6296,8 @@ const deserializeAws_json1_1FirewallManagerStatement = (
 
 const deserializeAws_json1_1ForwardedIPConfig = (output: any, context: __SerdeContext): ForwardedIPConfig => {
   return {
-    FallbackBehavior:
-      output.FallbackBehavior !== undefined && output.FallbackBehavior !== null ? output.FallbackBehavior : undefined,
-    HeaderName: output.HeaderName !== undefined && output.HeaderName !== null ? output.HeaderName : undefined,
+    FallbackBehavior: __expectString(output.FallbackBehavior),
+    HeaderName: __expectString(output.HeaderName),
   } as any;
 };
 
@@ -6326,7 +6320,7 @@ const deserializeAws_json1_1GetIPSetResponse = (output: any, context: __SerdeCon
       output.IPSet !== undefined && output.IPSet !== null
         ? deserializeAws_json1_1IPSet(output.IPSet, context)
         : undefined,
-    LockToken: output.LockToken !== undefined && output.LockToken !== null ? output.LockToken : undefined,
+    LockToken: __expectString(output.LockToken),
   } as any;
 };
 
@@ -6347,7 +6341,7 @@ const deserializeAws_json1_1GetPermissionPolicyResponse = (
   context: __SerdeContext
 ): GetPermissionPolicyResponse => {
   return {
-    Policy: output.Policy !== undefined && output.Policy !== null ? output.Policy : undefined,
+    Policy: __expectString(output.Policy),
   } as any;
 };
 
@@ -6372,7 +6366,7 @@ const deserializeAws_json1_1GetRegexPatternSetResponse = (
   context: __SerdeContext
 ): GetRegexPatternSetResponse => {
   return {
-    LockToken: output.LockToken !== undefined && output.LockToken !== null ? output.LockToken : undefined,
+    LockToken: __expectString(output.LockToken),
     RegexPatternSet:
       output.RegexPatternSet !== undefined && output.RegexPatternSet !== null
         ? deserializeAws_json1_1RegexPatternSet(output.RegexPatternSet, context)
@@ -6382,7 +6376,7 @@ const deserializeAws_json1_1GetRegexPatternSetResponse = (
 
 const deserializeAws_json1_1GetRuleGroupResponse = (output: any, context: __SerdeContext): GetRuleGroupResponse => {
   return {
-    LockToken: output.LockToken !== undefined && output.LockToken !== null ? output.LockToken : undefined,
+    LockToken: __expectString(output.LockToken),
     RuleGroup:
       output.RuleGroup !== undefined && output.RuleGroup !== null
         ? deserializeAws_json1_1RuleGroup(output.RuleGroup, context)
@@ -6395,8 +6389,7 @@ const deserializeAws_json1_1GetSampledRequestsResponse = (
   context: __SerdeContext
 ): GetSampledRequestsResponse => {
   return {
-    PopulationSize:
-      output.PopulationSize !== undefined && output.PopulationSize !== null ? output.PopulationSize : undefined,
+    PopulationSize: __expectNumber(output.PopulationSize),
     SampledRequests:
       output.SampledRequests !== undefined && output.SampledRequests !== null
         ? deserializeAws_json1_1SampledHTTPRequests(output.SampledRequests, context)
@@ -6422,7 +6415,7 @@ const deserializeAws_json1_1GetWebACLForResourceResponse = (
 
 const deserializeAws_json1_1GetWebACLResponse = (output: any, context: __SerdeContext): GetWebACLResponse => {
   return {
-    LockToken: output.LockToken !== undefined && output.LockToken !== null ? output.LockToken : undefined,
+    LockToken: __expectString(output.LockToken),
     WebACL:
       output.WebACL !== undefined && output.WebACL !== null
         ? deserializeAws_json1_1WebACL(output.WebACL, context)
@@ -6432,8 +6425,8 @@ const deserializeAws_json1_1GetWebACLResponse = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1HTTPHeader = (output: any, context: __SerdeContext): HTTPHeader => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Name: __expectString(output.Name),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -6450,15 +6443,15 @@ const deserializeAws_json1_1HTTPHeaders = (output: any, context: __SerdeContext)
 
 const deserializeAws_json1_1HTTPRequest = (output: any, context: __SerdeContext): HTTPRequest => {
   return {
-    ClientIP: output.ClientIP !== undefined && output.ClientIP !== null ? output.ClientIP : undefined,
-    Country: output.Country !== undefined && output.Country !== null ? output.Country : undefined,
-    HTTPVersion: output.HTTPVersion !== undefined && output.HTTPVersion !== null ? output.HTTPVersion : undefined,
+    ClientIP: __expectString(output.ClientIP),
+    Country: __expectString(output.Country),
+    HTTPVersion: __expectString(output.HTTPVersion),
     Headers:
       output.Headers !== undefined && output.Headers !== null
         ? deserializeAws_json1_1HTTPHeaders(output.Headers, context)
         : undefined,
-    Method: output.Method !== undefined && output.Method !== null ? output.Method : undefined,
-    URI: output.URI !== undefined && output.URI !== null ? output.URI : undefined,
+    Method: __expectString(output.Method),
+    URI: __expectString(output.URI),
   } as any;
 };
 
@@ -6469,31 +6462,29 @@ const deserializeAws_json1_1IPAddresses = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1IPSet = (output: any, context: __SerdeContext): IPSet => {
   return {
-    ARN: output.ARN !== undefined && output.ARN !== null ? output.ARN : undefined,
+    ARN: __expectString(output.ARN),
     Addresses:
       output.Addresses !== undefined && output.Addresses !== null
         ? deserializeAws_json1_1IPAddresses(output.Addresses, context)
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    IPAddressVersion:
-      output.IPAddressVersion !== undefined && output.IPAddressVersion !== null ? output.IPAddressVersion : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Description: __expectString(output.Description),
+    IPAddressVersion: __expectString(output.IPAddressVersion),
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
   } as any;
 };
 
 const deserializeAws_json1_1IPSetForwardedIPConfig = (output: any, context: __SerdeContext): IPSetForwardedIPConfig => {
   return {
-    FallbackBehavior:
-      output.FallbackBehavior !== undefined && output.FallbackBehavior !== null ? output.FallbackBehavior : undefined,
-    HeaderName: output.HeaderName !== undefined && output.HeaderName !== null ? output.HeaderName : undefined,
-    Position: output.Position !== undefined && output.Position !== null ? output.Position : undefined,
+    FallbackBehavior: __expectString(output.FallbackBehavior),
+    HeaderName: __expectString(output.HeaderName),
+    Position: __expectString(output.Position),
   } as any;
 };
 
@@ -6502,7 +6493,7 @@ const deserializeAws_json1_1IPSetReferenceStatement = (
   context: __SerdeContext
 ): IPSetReferenceStatement => {
   return {
-    ARN: output.ARN !== undefined && output.ARN !== null ? output.ARN : undefined,
+    ARN: __expectString(output.ARN),
     IPSetForwardedIPConfig:
       output.IPSetForwardedIPConfig !== undefined && output.IPSetForwardedIPConfig !== null
         ? deserializeAws_json1_1IPSetForwardedIPConfig(output.IPSetForwardedIPConfig, context)
@@ -6523,25 +6514,22 @@ const deserializeAws_json1_1IPSetSummaries = (output: any, context: __SerdeConte
 
 const deserializeAws_json1_1IPSetSummary = (output: any, context: __SerdeContext): IPSetSummary => {
   return {
-    ARN: output.ARN !== undefined && output.ARN !== null ? output.ARN : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    LockToken: output.LockToken !== undefined && output.LockToken !== null ? output.LockToken : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    ARN: __expectString(output.ARN),
+    Description: __expectString(output.Description),
+    Id: __expectString(output.Id),
+    LockToken: __expectString(output.LockToken),
+    Name: __expectString(output.Name),
   } as any;
 };
 
 const deserializeAws_json1_1JsonBody = (output: any, context: __SerdeContext): JsonBody => {
   return {
-    InvalidFallbackBehavior:
-      output.InvalidFallbackBehavior !== undefined && output.InvalidFallbackBehavior !== null
-        ? output.InvalidFallbackBehavior
-        : undefined,
+    InvalidFallbackBehavior: __expectString(output.InvalidFallbackBehavior),
     MatchPattern:
       output.MatchPattern !== undefined && output.MatchPattern !== null
         ? deserializeAws_json1_1JsonMatchPattern(output.MatchPattern, context)
         : undefined,
-    MatchScope: output.MatchScope !== undefined && output.MatchScope !== null ? output.MatchScope : undefined,
+    MatchScope: __expectString(output.MatchScope),
   } as any;
 };
 
@@ -6562,26 +6550,26 @@ const deserializeAws_json1_1JsonPointerPaths = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1Label = (output: any, context: __SerdeContext): Label => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
 const deserializeAws_json1_1LabelMatchStatement = (output: any, context: __SerdeContext): LabelMatchStatement => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Scope: output.Scope !== undefined && output.Scope !== null ? output.Scope : undefined,
+    Key: __expectString(output.Key),
+    Scope: __expectString(output.Scope),
   } as any;
 };
 
 const deserializeAws_json1_1LabelNameCondition = (output: any, context: __SerdeContext): LabelNameCondition => {
   return {
-    LabelName: output.LabelName !== undefined && output.LabelName !== null ? output.LabelName : undefined,
+    LabelName: __expectString(output.LabelName),
   } as any;
 };
 
@@ -6609,7 +6597,7 @@ const deserializeAws_json1_1LabelSummaries = (output: any, context: __SerdeConte
 
 const deserializeAws_json1_1LabelSummary = (output: any, context: __SerdeContext): LabelSummary => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -6622,7 +6610,7 @@ const deserializeAws_json1_1ListAvailableManagedRuleGroupsResponse = (
       output.ManagedRuleGroups !== undefined && output.ManagedRuleGroups !== null
         ? deserializeAws_json1_1ManagedRuleGroupSummaries(output.ManagedRuleGroups, context)
         : undefined,
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    NextMarker: __expectString(output.NextMarker),
   } as any;
 };
 
@@ -6632,7 +6620,7 @@ const deserializeAws_json1_1ListIPSetsResponse = (output: any, context: __SerdeC
       output.IPSets !== undefined && output.IPSets !== null
         ? deserializeAws_json1_1IPSetSummaries(output.IPSets, context)
         : undefined,
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    NextMarker: __expectString(output.NextMarker),
   } as any;
 };
 
@@ -6645,7 +6633,7 @@ const deserializeAws_json1_1ListLoggingConfigurationsResponse = (
       output.LoggingConfigurations !== undefined && output.LoggingConfigurations !== null
         ? deserializeAws_json1_1LoggingConfigurations(output.LoggingConfigurations, context)
         : undefined,
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    NextMarker: __expectString(output.NextMarker),
   } as any;
 };
 
@@ -6654,7 +6642,7 @@ const deserializeAws_json1_1ListRegexPatternSetsResponse = (
   context: __SerdeContext
 ): ListRegexPatternSetsResponse => {
   return {
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    NextMarker: __expectString(output.NextMarker),
     RegexPatternSets:
       output.RegexPatternSets !== undefined && output.RegexPatternSets !== null
         ? deserializeAws_json1_1RegexPatternSetSummaries(output.RegexPatternSets, context)
@@ -6676,7 +6664,7 @@ const deserializeAws_json1_1ListResourcesForWebACLResponse = (
 
 const deserializeAws_json1_1ListRuleGroupsResponse = (output: any, context: __SerdeContext): ListRuleGroupsResponse => {
   return {
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    NextMarker: __expectString(output.NextMarker),
     RuleGroups:
       output.RuleGroups !== undefined && output.RuleGroups !== null
         ? deserializeAws_json1_1RuleGroupSummaries(output.RuleGroups, context)
@@ -6689,7 +6677,7 @@ const deserializeAws_json1_1ListTagsForResourceResponse = (
   context: __SerdeContext
 ): ListTagsForResourceResponse => {
   return {
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    NextMarker: __expectString(output.NextMarker),
     TagInfoForResource:
       output.TagInfoForResource !== undefined && output.TagInfoForResource !== null
         ? deserializeAws_json1_1TagInfoForResource(output.TagInfoForResource, context)
@@ -6699,7 +6687,7 @@ const deserializeAws_json1_1ListTagsForResourceResponse = (
 
 const deserializeAws_json1_1ListWebACLsResponse = (output: any, context: __SerdeContext): ListWebACLsResponse => {
   return {
-    NextMarker: output.NextMarker !== undefined && output.NextMarker !== null ? output.NextMarker : undefined,
+    NextMarker: __expectString(output.NextMarker),
     WebACLs:
       output.WebACLs !== undefined && output.WebACLs !== null
         ? deserializeAws_json1_1WebACLSummaries(output.WebACLs, context)
@@ -6714,7 +6702,7 @@ const deserializeAws_json1_1LogDestinationConfigs = (output: any, context: __Ser
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6728,15 +6716,12 @@ const deserializeAws_json1_1LoggingConfiguration = (output: any, context: __Serd
       output.LoggingFilter !== undefined && output.LoggingFilter !== null
         ? deserializeAws_json1_1LoggingFilter(output.LoggingFilter, context)
         : undefined,
-    ManagedByFirewallManager:
-      output.ManagedByFirewallManager !== undefined && output.ManagedByFirewallManager !== null
-        ? output.ManagedByFirewallManager
-        : undefined,
+    ManagedByFirewallManager: __expectBoolean(output.ManagedByFirewallManager),
     RedactedFields:
       output.RedactedFields !== undefined && output.RedactedFields !== null
         ? deserializeAws_json1_1RedactedFields(output.RedactedFields, context)
         : undefined,
-    ResourceArn: output.ResourceArn !== undefined && output.ResourceArn !== null ? output.ResourceArn : undefined,
+    ResourceArn: __expectString(output.ResourceArn),
   } as any;
 };
 
@@ -6753,8 +6738,7 @@ const deserializeAws_json1_1LoggingConfigurations = (output: any, context: __Ser
 
 const deserializeAws_json1_1LoggingFilter = (output: any, context: __SerdeContext): LoggingFilter => {
   return {
-    DefaultBehavior:
-      output.DefaultBehavior !== undefined && output.DefaultBehavior !== null ? output.DefaultBehavior : undefined,
+    DefaultBehavior: __expectString(output.DefaultBehavior),
     Filters:
       output.Filters !== undefined && output.Filters !== null
         ? deserializeAws_json1_1Filters(output.Filters, context)
@@ -6771,12 +6755,12 @@ const deserializeAws_json1_1ManagedRuleGroupStatement = (
       output.ExcludedRules !== undefined && output.ExcludedRules !== null
         ? deserializeAws_json1_1ExcludedRules(output.ExcludedRules, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     ScopeDownStatement:
       output.ScopeDownStatement !== undefined && output.ScopeDownStatement !== null
         ? deserializeAws_json1_1Statement(output.ScopeDownStatement, context)
         : undefined,
-    VendorName: output.VendorName !== undefined && output.VendorName !== null ? output.VendorName : undefined,
+    VendorName: __expectString(output.VendorName),
   } as any;
 };
 
@@ -6799,9 +6783,9 @@ const deserializeAws_json1_1ManagedRuleGroupSummary = (
   context: __SerdeContext
 ): ManagedRuleGroupSummary => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    VendorName: output.VendorName !== undefined && output.VendorName !== null ? output.VendorName : undefined,
+    Description: __expectString(output.Description),
+    Name: __expectString(output.Name),
+    VendorName: __expectString(output.VendorName),
   } as any;
 };
 
@@ -6869,13 +6853,12 @@ const deserializeAws_json1_1QueryString = (output: any, context: __SerdeContext)
 
 const deserializeAws_json1_1RateBasedStatement = (output: any, context: __SerdeContext): RateBasedStatement => {
   return {
-    AggregateKeyType:
-      output.AggregateKeyType !== undefined && output.AggregateKeyType !== null ? output.AggregateKeyType : undefined,
+    AggregateKeyType: __expectString(output.AggregateKeyType),
     ForwardedIPConfig:
       output.ForwardedIPConfig !== undefined && output.ForwardedIPConfig !== null
         ? deserializeAws_json1_1ForwardedIPConfig(output.ForwardedIPConfig, context)
         : undefined,
-    Limit: output.Limit !== undefined && output.Limit !== null ? output.Limit : undefined,
+    Limit: __expectNumber(output.Limit),
     ScopeDownStatement:
       output.ScopeDownStatement !== undefined && output.ScopeDownStatement !== null
         ? deserializeAws_json1_1Statement(output.ScopeDownStatement, context)
@@ -6892,8 +6875,7 @@ const deserializeAws_json1_1RateBasedStatementManagedKeysIPSet = (
       output.Addresses !== undefined && output.Addresses !== null
         ? deserializeAws_json1_1IPAddresses(output.Addresses, context)
         : undefined,
-    IPAddressVersion:
-      output.IPAddressVersion !== undefined && output.IPAddressVersion !== null ? output.IPAddressVersion : undefined,
+    IPAddressVersion: __expectString(output.IPAddressVersion),
   } as any;
 };
 
@@ -6910,16 +6892,16 @@ const deserializeAws_json1_1RedactedFields = (output: any, context: __SerdeConte
 
 const deserializeAws_json1_1Regex = (output: any, context: __SerdeContext): Regex => {
   return {
-    RegexString: output.RegexString !== undefined && output.RegexString !== null ? output.RegexString : undefined,
+    RegexString: __expectString(output.RegexString),
   } as any;
 };
 
 const deserializeAws_json1_1RegexPatternSet = (output: any, context: __SerdeContext): RegexPatternSet => {
   return {
-    ARN: output.ARN !== undefined && output.ARN !== null ? output.ARN : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    ARN: __expectString(output.ARN),
+    Description: __expectString(output.Description),
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
     RegularExpressionList:
       output.RegularExpressionList !== undefined && output.RegularExpressionList !== null
         ? deserializeAws_json1_1RegularExpressionList(output.RegularExpressionList, context)
@@ -6932,7 +6914,7 @@ const deserializeAws_json1_1RegexPatternSetReferenceStatement = (
   context: __SerdeContext
 ): RegexPatternSetReferenceStatement => {
   return {
-    ARN: output.ARN !== undefined && output.ARN !== null ? output.ARN : undefined,
+    ARN: __expectString(output.ARN),
     FieldToMatch:
       output.FieldToMatch !== undefined && output.FieldToMatch !== null
         ? deserializeAws_json1_1FieldToMatch(output.FieldToMatch, context)
@@ -6960,11 +6942,11 @@ const deserializeAws_json1_1RegexPatternSetSummaries = (
 
 const deserializeAws_json1_1RegexPatternSetSummary = (output: any, context: __SerdeContext): RegexPatternSetSummary => {
   return {
-    ARN: output.ARN !== undefined && output.ARN !== null ? output.ARN : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    LockToken: output.LockToken !== undefined && output.LockToken !== null ? output.LockToken : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    ARN: __expectString(output.ARN),
+    Description: __expectString(output.Description),
+    Id: __expectString(output.Id),
+    LockToken: __expectString(output.LockToken),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -6986,7 +6968,7 @@ const deserializeAws_json1_1ResourceArns = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6996,12 +6978,12 @@ const deserializeAws_json1_1Rule = (output: any, context: __SerdeContext): Rule 
       output.Action !== undefined && output.Action !== null
         ? deserializeAws_json1_1RuleAction(output.Action, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     OverrideAction:
       output.OverrideAction !== undefined && output.OverrideAction !== null
         ? deserializeAws_json1_1OverrideAction(output.OverrideAction, context)
         : undefined,
-    Priority: output.Priority !== undefined && output.Priority !== null ? output.Priority : undefined,
+    Priority: __expectNumber(output.Priority),
     RuleLabels:
       output.RuleLabels !== undefined && output.RuleLabels !== null
         ? deserializeAws_json1_1Labels(output.RuleLabels, context)
@@ -7036,12 +7018,12 @@ const deserializeAws_json1_1RuleAction = (output: any, context: __SerdeContext):
 
 const deserializeAws_json1_1RuleGroup = (output: any, context: __SerdeContext): RuleGroup => {
   return {
-    ARN: output.ARN !== undefined && output.ARN !== null ? output.ARN : undefined,
+    ARN: __expectString(output.ARN),
     AvailableLabels:
       output.AvailableLabels !== undefined && output.AvailableLabels !== null
         ? deserializeAws_json1_1LabelSummaries(output.AvailableLabels, context)
         : undefined,
-    Capacity: output.Capacity !== undefined && output.Capacity !== null ? output.Capacity : undefined,
+    Capacity: __expectNumber(output.Capacity),
     ConsumedLabels:
       output.ConsumedLabels !== undefined && output.ConsumedLabels !== null
         ? deserializeAws_json1_1LabelSummaries(output.ConsumedLabels, context)
@@ -7050,11 +7032,10 @@ const deserializeAws_json1_1RuleGroup = (output: any, context: __SerdeContext): 
       output.CustomResponseBodies !== undefined && output.CustomResponseBodies !== null
         ? deserializeAws_json1_1CustomResponseBodies(output.CustomResponseBodies, context)
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    LabelNamespace:
-      output.LabelNamespace !== undefined && output.LabelNamespace !== null ? output.LabelNamespace : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Description: __expectString(output.Description),
+    Id: __expectString(output.Id),
+    LabelNamespace: __expectString(output.LabelNamespace),
+    Name: __expectString(output.Name),
     Rules:
       output.Rules !== undefined && output.Rules !== null
         ? deserializeAws_json1_1Rules(output.Rules, context)
@@ -7071,7 +7052,7 @@ const deserializeAws_json1_1RuleGroupReferenceStatement = (
   context: __SerdeContext
 ): RuleGroupReferenceStatement => {
   return {
-    ARN: output.ARN !== undefined && output.ARN !== null ? output.ARN : undefined,
+    ARN: __expectString(output.ARN),
     ExcludedRules:
       output.ExcludedRules !== undefined && output.ExcludedRules !== null
         ? deserializeAws_json1_1ExcludedRules(output.ExcludedRules, context)
@@ -7092,11 +7073,11 @@ const deserializeAws_json1_1RuleGroupSummaries = (output: any, context: __SerdeC
 
 const deserializeAws_json1_1RuleGroupSummary = (output: any, context: __SerdeContext): RuleGroupSummary => {
   return {
-    ARN: output.ARN !== undefined && output.ARN !== null ? output.ARN : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    LockToken: output.LockToken !== undefined && output.LockToken !== null ? output.LockToken : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    ARN: __expectString(output.ARN),
+    Description: __expectString(output.Description),
+    Id: __expectString(output.Id),
+    LockToken: __expectString(output.LockToken),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -7128,13 +7109,13 @@ const deserializeAws_json1_1RuleSummary = (output: any, context: __SerdeContext)
       output.Action !== undefined && output.Action !== null
         ? deserializeAws_json1_1RuleAction(output.Action, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
 const deserializeAws_json1_1SampledHTTPRequest = (output: any, context: __SerdeContext): SampledHTTPRequest => {
   return {
-    Action: output.Action !== undefined && output.Action !== null ? output.Action : undefined,
+    Action: __expectString(output.Action),
     Labels:
       output.Labels !== undefined && output.Labels !== null
         ? deserializeAws_json1_1Labels(output.Labels, context)
@@ -7147,17 +7128,13 @@ const deserializeAws_json1_1SampledHTTPRequest = (output: any, context: __SerdeC
       output.RequestHeadersInserted !== undefined && output.RequestHeadersInserted !== null
         ? deserializeAws_json1_1HTTPHeaders(output.RequestHeadersInserted, context)
         : undefined,
-    ResponseCodeSent:
-      output.ResponseCodeSent !== undefined && output.ResponseCodeSent !== null ? output.ResponseCodeSent : undefined,
-    RuleNameWithinRuleGroup:
-      output.RuleNameWithinRuleGroup !== undefined && output.RuleNameWithinRuleGroup !== null
-        ? output.RuleNameWithinRuleGroup
-        : undefined,
+    ResponseCodeSent: __expectNumber(output.ResponseCodeSent),
+    RuleNameWithinRuleGroup: __expectString(output.RuleNameWithinRuleGroup),
     Timestamp:
       output.Timestamp !== undefined && output.Timestamp !== null
         ? new Date(Math.round(output.Timestamp * 1000))
         : undefined,
-    Weight: output.Weight !== undefined && output.Weight !== null ? output.Weight : undefined,
+    Weight: __expectNumber(output.Weight),
   } as any;
 };
 
@@ -7174,13 +7151,13 @@ const deserializeAws_json1_1SampledHTTPRequests = (output: any, context: __Serde
 
 const deserializeAws_json1_1SingleHeader = (output: any, context: __SerdeContext): SingleHeader => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
 const deserializeAws_json1_1SingleQueryArgument = (output: any, context: __SerdeContext): SingleQueryArgument => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -7189,15 +7166,12 @@ const deserializeAws_json1_1SizeConstraintStatement = (
   context: __SerdeContext
 ): SizeConstraintStatement => {
   return {
-    ComparisonOperator:
-      output.ComparisonOperator !== undefined && output.ComparisonOperator !== null
-        ? output.ComparisonOperator
-        : undefined,
+    ComparisonOperator: __expectString(output.ComparisonOperator),
     FieldToMatch:
       output.FieldToMatch !== undefined && output.FieldToMatch !== null
         ? deserializeAws_json1_1FieldToMatch(output.FieldToMatch, context)
         : undefined,
-    Size: output.Size !== undefined && output.Size !== null ? output.Size : undefined,
+    Size: __expectNumber(output.Size),
     TextTransformations:
       output.TextTransformations !== undefined && output.TextTransformations !== null
         ? deserializeAws_json1_1TextTransformations(output.TextTransformations, context)
@@ -7292,14 +7266,14 @@ const deserializeAws_json1_1Statements = (output: any, context: __SerdeContext):
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
 const deserializeAws_json1_1TagInfoForResource = (output: any, context: __SerdeContext): TagInfoForResource => {
   return {
-    ResourceARN: output.ResourceARN !== undefined && output.ResourceARN !== null ? output.ResourceARN : undefined,
+    ResourceARN: __expectString(output.ResourceARN),
     TagList:
       output.TagList !== undefined && output.TagList !== null
         ? deserializeAws_json1_1TagList(output.TagList, context)
@@ -7324,8 +7298,8 @@ const deserializeAws_json1_1TagResourceResponse = (output: any, context: __Serde
 
 const deserializeAws_json1_1TextTransformation = (output: any, context: __SerdeContext): TextTransformation => {
   return {
-    Priority: output.Priority !== undefined && output.Priority !== null ? output.Priority : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Priority: __expectNumber(output.Priority),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -7357,8 +7331,7 @@ const deserializeAws_json1_1UntagResourceResponse = (output: any, context: __Ser
 
 const deserializeAws_json1_1UpdateIPSetResponse = (output: any, context: __SerdeContext): UpdateIPSetResponse => {
   return {
-    NextLockToken:
-      output.NextLockToken !== undefined && output.NextLockToken !== null ? output.NextLockToken : undefined,
+    NextLockToken: __expectString(output.NextLockToken),
   } as any;
 };
 
@@ -7367,8 +7340,7 @@ const deserializeAws_json1_1UpdateRegexPatternSetResponse = (
   context: __SerdeContext
 ): UpdateRegexPatternSetResponse => {
   return {
-    NextLockToken:
-      output.NextLockToken !== undefined && output.NextLockToken !== null ? output.NextLockToken : undefined,
+    NextLockToken: __expectString(output.NextLockToken),
   } as any;
 };
 
@@ -7377,15 +7349,13 @@ const deserializeAws_json1_1UpdateRuleGroupResponse = (
   context: __SerdeContext
 ): UpdateRuleGroupResponse => {
   return {
-    NextLockToken:
-      output.NextLockToken !== undefined && output.NextLockToken !== null ? output.NextLockToken : undefined,
+    NextLockToken: __expectString(output.NextLockToken),
   } as any;
 };
 
 const deserializeAws_json1_1UpdateWebACLResponse = (output: any, context: __SerdeContext): UpdateWebACLResponse => {
   return {
-    NextLockToken:
-      output.NextLockToken !== undefined && output.NextLockToken !== null ? output.NextLockToken : undefined,
+    NextLockToken: __expectString(output.NextLockToken),
   } as any;
 };
 
@@ -7395,15 +7365,9 @@ const deserializeAws_json1_1UriPath = (output: any, context: __SerdeContext): Ur
 
 const deserializeAws_json1_1VisibilityConfig = (output: any, context: __SerdeContext): VisibilityConfig => {
   return {
-    CloudWatchMetricsEnabled:
-      output.CloudWatchMetricsEnabled !== undefined && output.CloudWatchMetricsEnabled !== null
-        ? output.CloudWatchMetricsEnabled
-        : undefined,
-    MetricName: output.MetricName !== undefined && output.MetricName !== null ? output.MetricName : undefined,
-    SampledRequestsEnabled:
-      output.SampledRequestsEnabled !== undefined && output.SampledRequestsEnabled !== null
-        ? output.SampledRequestsEnabled
-        : undefined,
+    CloudWatchMetricsEnabled: __expectBoolean(output.CloudWatchMetricsEnabled),
+    MetricName: __expectString(output.MetricName),
+    SampledRequestsEnabled: __expectBoolean(output.SampledRequestsEnabled),
   } as any;
 };
 
@@ -7412,7 +7376,7 @@ const deserializeAws_json1_1WAFAssociatedItemException = (
   context: __SerdeContext
 ): WAFAssociatedItemException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7421,7 +7385,7 @@ const deserializeAws_json1_1WAFDuplicateItemException = (
   context: __SerdeContext
 ): WAFDuplicateItemException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7430,7 +7394,7 @@ const deserializeAws_json1_1WAFInternalErrorException = (
   context: __SerdeContext
 ): WAFInternalErrorException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7439,7 +7403,7 @@ const deserializeAws_json1_1WAFInvalidOperationException = (
   context: __SerdeContext
 ): WAFInvalidOperationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7448,10 +7412,10 @@ const deserializeAws_json1_1WAFInvalidParameterException = (
   context: __SerdeContext
 ): WAFInvalidParameterException => {
   return {
-    Field: output.Field !== undefined && output.Field !== null ? output.Field : undefined,
-    Parameter: output.Parameter !== undefined && output.Parameter !== null ? output.Parameter : undefined,
-    Reason: output.Reason !== undefined && output.Reason !== null ? output.Reason : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    Field: __expectString(output.Field),
+    Parameter: __expectString(output.Parameter),
+    Reason: __expectString(output.Reason),
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -7460,7 +7424,7 @@ const deserializeAws_json1_1WAFInvalidPermissionPolicyException = (
   context: __SerdeContext
 ): WAFInvalidPermissionPolicyException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7469,7 +7433,7 @@ const deserializeAws_json1_1WAFInvalidResourceException = (
   context: __SerdeContext
 ): WAFInvalidResourceException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7478,7 +7442,7 @@ const deserializeAws_json1_1WAFLimitsExceededException = (
   context: __SerdeContext
 ): WAFLimitsExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7487,7 +7451,7 @@ const deserializeAws_json1_1WAFNonexistentItemException = (
   context: __SerdeContext
 ): WAFNonexistentItemException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7496,7 +7460,7 @@ const deserializeAws_json1_1WAFOptimisticLockException = (
   context: __SerdeContext
 ): WAFOptimisticLockException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7505,7 +7469,7 @@ const deserializeAws_json1_1WAFServiceLinkedRoleErrorException = (
   context: __SerdeContext
 ): WAFServiceLinkedRoleErrorException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -7514,7 +7478,7 @@ const deserializeAws_json1_1WAFSubscriptionNotFoundException = (
   context: __SerdeContext
 ): WAFSubscriptionNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7523,7 +7487,7 @@ const deserializeAws_json1_1WAFTagOperationException = (
   context: __SerdeContext
 ): WAFTagOperationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7532,7 +7496,7 @@ const deserializeAws_json1_1WAFTagOperationInternalErrorException = (
   context: __SerdeContext
 ): WAFTagOperationInternalErrorException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7541,14 +7505,14 @@ const deserializeAws_json1_1WAFUnavailableEntityException = (
   context: __SerdeContext
 ): WAFUnavailableEntityException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1WebACL = (output: any, context: __SerdeContext): WebACL => {
   return {
-    ARN: output.ARN !== undefined && output.ARN !== null ? output.ARN : undefined,
-    Capacity: output.Capacity !== undefined && output.Capacity !== null ? output.Capacity : undefined,
+    ARN: __expectString(output.ARN),
+    Capacity: __expectNumber(output.Capacity),
     CustomResponseBodies:
       output.CustomResponseBodies !== undefined && output.CustomResponseBodies !== null
         ? deserializeAws_json1_1CustomResponseBodies(output.CustomResponseBodies, context)
@@ -7557,15 +7521,11 @@ const deserializeAws_json1_1WebACL = (output: any, context: __SerdeContext): Web
       output.DefaultAction !== undefined && output.DefaultAction !== null
         ? deserializeAws_json1_1DefaultAction(output.DefaultAction, context)
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    LabelNamespace:
-      output.LabelNamespace !== undefined && output.LabelNamespace !== null ? output.LabelNamespace : undefined,
-    ManagedByFirewallManager:
-      output.ManagedByFirewallManager !== undefined && output.ManagedByFirewallManager !== null
-        ? output.ManagedByFirewallManager
-        : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Description: __expectString(output.Description),
+    Id: __expectString(output.Id),
+    LabelNamespace: __expectString(output.LabelNamespace),
+    ManagedByFirewallManager: __expectBoolean(output.ManagedByFirewallManager),
+    Name: __expectString(output.Name),
     PostProcessFirewallManagerRuleGroups:
       output.PostProcessFirewallManagerRuleGroups !== undefined && output.PostProcessFirewallManagerRuleGroups !== null
         ? deserializeAws_json1_1FirewallManagerRuleGroups(output.PostProcessFirewallManagerRuleGroups, context)
@@ -7598,11 +7558,11 @@ const deserializeAws_json1_1WebACLSummaries = (output: any, context: __SerdeCont
 
 const deserializeAws_json1_1WebACLSummary = (output: any, context: __SerdeContext): WebACLSummary => {
   return {
-    ARN: output.ARN !== undefined && output.ARN !== null ? output.ARN : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    LockToken: output.LockToken !== undefined && output.LockToken !== null ? output.LockToken : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    ARN: __expectString(output.ARN),
+    Description: __expectString(output.Description),
+    Id: __expectString(output.Id),
+    LockToken: __expectString(output.LockToken),
+    Name: __expectString(output.Name),
   } as any;
 };
 

--- a/clients/client-wellarchitected/protocols/Aws_restJson1.ts
+++ b/clients/client-wellarchitected/protocols/Aws_restJson1.ts
@@ -92,6 +92,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -1360,10 +1363,10 @@ export const deserializeAws_restJson1CreateMilestoneCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.MilestoneNumber !== undefined && data.MilestoneNumber !== null) {
-    contents.MilestoneNumber = data.MilestoneNumber;
+    contents.MilestoneNumber = __expectNumber(data.MilestoneNumber);
   }
   if (data.WorkloadId !== undefined && data.WorkloadId !== null) {
-    contents.WorkloadId = data.WorkloadId;
+    contents.WorkloadId = __expectString(data.WorkloadId);
   }
   return Promise.resolve(contents);
 };
@@ -1467,10 +1470,10 @@ export const deserializeAws_restJson1CreateWorkloadCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.WorkloadArn !== undefined && data.WorkloadArn !== null) {
-    contents.WorkloadArn = data.WorkloadArn;
+    contents.WorkloadArn = __expectString(data.WorkloadArn);
   }
   if (data.WorkloadId !== undefined && data.WorkloadId !== null) {
-    contents.WorkloadId = data.WorkloadId;
+    contents.WorkloadId = __expectString(data.WorkloadId);
   }
   return Promise.resolve(contents);
 };
@@ -1566,10 +1569,10 @@ export const deserializeAws_restJson1CreateWorkloadShareCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ShareId !== undefined && data.ShareId !== null) {
-    contents.ShareId = data.ShareId;
+    contents.ShareId = __expectString(data.ShareId);
   }
   if (data.WorkloadId !== undefined && data.WorkloadId !== null) {
-    contents.WorkloadId = data.WorkloadId;
+    contents.WorkloadId = __expectString(data.WorkloadId);
   }
   return Promise.resolve(contents);
 };
@@ -1951,13 +1954,13 @@ export const deserializeAws_restJson1GetAnswerCommand = async (
     contents.Answer = deserializeAws_restJson1Answer(data.Answer, context);
   }
   if (data.LensAlias !== undefined && data.LensAlias !== null) {
-    contents.LensAlias = data.LensAlias;
+    contents.LensAlias = __expectString(data.LensAlias);
   }
   if (data.MilestoneNumber !== undefined && data.MilestoneNumber !== null) {
-    contents.MilestoneNumber = data.MilestoneNumber;
+    contents.MilestoneNumber = __expectNumber(data.MilestoneNumber);
   }
   if (data.WorkloadId !== undefined && data.WorkloadId !== null) {
-    contents.WorkloadId = data.WorkloadId;
+    contents.WorkloadId = __expectString(data.WorkloadId);
   }
   return Promise.resolve(contents);
 };
@@ -2049,10 +2052,10 @@ export const deserializeAws_restJson1GetLensReviewCommand = async (
     contents.LensReview = deserializeAws_restJson1LensReview(data.LensReview, context);
   }
   if (data.MilestoneNumber !== undefined && data.MilestoneNumber !== null) {
-    contents.MilestoneNumber = data.MilestoneNumber;
+    contents.MilestoneNumber = __expectNumber(data.MilestoneNumber);
   }
   if (data.WorkloadId !== undefined && data.WorkloadId !== null) {
-    contents.WorkloadId = data.WorkloadId;
+    contents.WorkloadId = __expectString(data.WorkloadId);
   }
   return Promise.resolve(contents);
 };
@@ -2144,10 +2147,10 @@ export const deserializeAws_restJson1GetLensReviewReportCommand = async (
     contents.LensReviewReport = deserializeAws_restJson1LensReviewReport(data.LensReviewReport, context);
   }
   if (data.MilestoneNumber !== undefined && data.MilestoneNumber !== null) {
-    contents.MilestoneNumber = data.MilestoneNumber;
+    contents.MilestoneNumber = __expectNumber(data.MilestoneNumber);
   }
   if (data.WorkloadId !== undefined && data.WorkloadId !== null) {
-    contents.WorkloadId = data.WorkloadId;
+    contents.WorkloadId = __expectString(data.WorkloadId);
   }
   return Promise.resolve(contents);
 };
@@ -2237,13 +2240,13 @@ export const deserializeAws_restJson1GetLensVersionDifferenceCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.BaseLensVersion !== undefined && data.BaseLensVersion !== null) {
-    contents.BaseLensVersion = data.BaseLensVersion;
+    contents.BaseLensVersion = __expectString(data.BaseLensVersion);
   }
   if (data.LatestLensVersion !== undefined && data.LatestLensVersion !== null) {
-    contents.LatestLensVersion = data.LatestLensVersion;
+    contents.LatestLensVersion = __expectString(data.LatestLensVersion);
   }
   if (data.LensAlias !== undefined && data.LensAlias !== null) {
-    contents.LensAlias = data.LensAlias;
+    contents.LensAlias = __expectString(data.LensAlias);
   }
   if (data.VersionDifferences !== undefined && data.VersionDifferences !== null) {
     contents.VersionDifferences = deserializeAws_restJson1VersionDifferences(data.VersionDifferences, context);
@@ -2337,7 +2340,7 @@ export const deserializeAws_restJson1GetMilestoneCommand = async (
     contents.Milestone = deserializeAws_restJson1Milestone(data.Milestone, context);
   }
   if (data.WorkloadId !== undefined && data.WorkloadId !== null) {
-    contents.WorkloadId = data.WorkloadId;
+    contents.WorkloadId = __expectString(data.WorkloadId);
   }
   return Promise.resolve(contents);
 };
@@ -2518,16 +2521,16 @@ export const deserializeAws_restJson1ListAnswersCommand = async (
     contents.AnswerSummaries = deserializeAws_restJson1AnswerSummaries(data.AnswerSummaries, context);
   }
   if (data.LensAlias !== undefined && data.LensAlias !== null) {
-    contents.LensAlias = data.LensAlias;
+    contents.LensAlias = __expectString(data.LensAlias);
   }
   if (data.MilestoneNumber !== undefined && data.MilestoneNumber !== null) {
-    contents.MilestoneNumber = data.MilestoneNumber;
+    contents.MilestoneNumber = __expectNumber(data.MilestoneNumber);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.WorkloadId !== undefined && data.WorkloadId !== null) {
-    contents.WorkloadId = data.WorkloadId;
+    contents.WorkloadId = __expectString(data.WorkloadId);
   }
   return Promise.resolve(contents);
 };
@@ -2618,7 +2621,7 @@ export const deserializeAws_restJson1ListLensesCommand = async (
     contents.LensSummaries = deserializeAws_restJson1LensSummaries(data.LensSummaries, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2704,16 +2707,16 @@ export const deserializeAws_restJson1ListLensReviewImprovementsCommand = async (
     contents.ImprovementSummaries = deserializeAws_restJson1ImprovementSummaries(data.ImprovementSummaries, context);
   }
   if (data.LensAlias !== undefined && data.LensAlias !== null) {
-    contents.LensAlias = data.LensAlias;
+    contents.LensAlias = __expectString(data.LensAlias);
   }
   if (data.MilestoneNumber !== undefined && data.MilestoneNumber !== null) {
-    contents.MilestoneNumber = data.MilestoneNumber;
+    contents.MilestoneNumber = __expectNumber(data.MilestoneNumber);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.WorkloadId !== undefined && data.WorkloadId !== null) {
-    contents.WorkloadId = data.WorkloadId;
+    contents.WorkloadId = __expectString(data.WorkloadId);
   }
   return Promise.resolve(contents);
 };
@@ -2806,13 +2809,13 @@ export const deserializeAws_restJson1ListLensReviewsCommand = async (
     contents.LensReviewSummaries = deserializeAws_restJson1LensReviewSummaries(data.LensReviewSummaries, context);
   }
   if (data.MilestoneNumber !== undefined && data.MilestoneNumber !== null) {
-    contents.MilestoneNumber = data.MilestoneNumber;
+    contents.MilestoneNumber = __expectNumber(data.MilestoneNumber);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.WorkloadId !== undefined && data.WorkloadId !== null) {
-    contents.WorkloadId = data.WorkloadId;
+    contents.WorkloadId = __expectString(data.WorkloadId);
   }
   return Promise.resolve(contents);
 };
@@ -2904,10 +2907,10 @@ export const deserializeAws_restJson1ListMilestonesCommand = async (
     contents.MilestoneSummaries = deserializeAws_restJson1MilestoneSummaries(data.MilestoneSummaries, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.WorkloadId !== undefined && data.WorkloadId !== null) {
-    contents.WorkloadId = data.WorkloadId;
+    contents.WorkloadId = __expectString(data.WorkloadId);
   }
   return Promise.resolve(contents);
 };
@@ -2995,7 +2998,7 @@ export const deserializeAws_restJson1ListNotificationsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.NotificationSummaries !== undefined && data.NotificationSummaries !== null) {
     contents.NotificationSummaries = deserializeAws_restJson1NotificationSummaries(data.NotificationSummaries, context);
@@ -3078,7 +3081,7 @@ export const deserializeAws_restJson1ListShareInvitationsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.ShareInvitationSummaries !== undefined && data.ShareInvitationSummaries !== null) {
     contents.ShareInvitationSummaries = deserializeAws_restJson1ShareInvitationSummaries(
@@ -3227,7 +3230,7 @@ export const deserializeAws_restJson1ListWorkloadsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.WorkloadSummaries !== undefined && data.WorkloadSummaries !== null) {
     contents.WorkloadSummaries = deserializeAws_restJson1WorkloadSummaries(data.WorkloadSummaries, context);
@@ -3311,10 +3314,10 @@ export const deserializeAws_restJson1ListWorkloadSharesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.WorkloadId !== undefined && data.WorkloadId !== null) {
-    contents.WorkloadId = data.WorkloadId;
+    contents.WorkloadId = __expectString(data.WorkloadId);
   }
   if (data.WorkloadShareSummaries !== undefined && data.WorkloadShareSummaries !== null) {
     contents.WorkloadShareSummaries = deserializeAws_restJson1WorkloadShareSummaries(
@@ -3530,10 +3533,10 @@ export const deserializeAws_restJson1UpdateAnswerCommand = async (
     contents.Answer = deserializeAws_restJson1Answer(data.Answer, context);
   }
   if (data.LensAlias !== undefined && data.LensAlias !== null) {
-    contents.LensAlias = data.LensAlias;
+    contents.LensAlias = __expectString(data.LensAlias);
   }
   if (data.WorkloadId !== undefined && data.WorkloadId !== null) {
-    contents.WorkloadId = data.WorkloadId;
+    contents.WorkloadId = __expectString(data.WorkloadId);
   }
   return Promise.resolve(contents);
 };
@@ -3632,7 +3635,7 @@ export const deserializeAws_restJson1UpdateLensReviewCommand = async (
     contents.LensReview = deserializeAws_restJson1LensReview(data.LensReview, context);
   }
   if (data.WorkloadId !== undefined && data.WorkloadId !== null) {
-    contents.WorkloadId = data.WorkloadId;
+    contents.WorkloadId = __expectString(data.WorkloadId);
   }
   return Promise.resolve(contents);
 };
@@ -3918,7 +3921,7 @@ export const deserializeAws_restJson1UpdateWorkloadShareCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.WorkloadId !== undefined && data.WorkloadId !== null) {
-    contents.WorkloadId = data.WorkloadId;
+    contents.WorkloadId = __expectString(data.WorkloadId);
   }
   if (data.WorkloadShare !== undefined && data.WorkloadShare !== null) {
     contents.WorkloadShare = deserializeAws_restJson1WorkloadShare(data.WorkloadShare, context);
@@ -4106,7 +4109,7 @@ const deserializeAws_restJson1AccessDeniedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -4125,13 +4128,13 @@ const deserializeAws_restJson1ConflictExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.ResourceId !== undefined && data.ResourceId !== null) {
-    contents.ResourceId = data.ResourceId;
+    contents.ResourceId = __expectString(data.ResourceId);
   }
   if (data.ResourceType !== undefined && data.ResourceType !== null) {
-    contents.ResourceType = data.ResourceType;
+    contents.ResourceType = __expectString(data.ResourceType);
   }
   return contents;
 };
@@ -4148,7 +4151,7 @@ const deserializeAws_restJson1InternalServerExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -4167,13 +4170,13 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.ResourceId !== undefined && data.ResourceId !== null) {
-    contents.ResourceId = data.ResourceId;
+    contents.ResourceId = __expectString(data.ResourceId);
   }
   if (data.ResourceType !== undefined && data.ResourceType !== null) {
-    contents.ResourceType = data.ResourceType;
+    contents.ResourceType = __expectString(data.ResourceType);
   }
   return contents;
 };
@@ -4194,19 +4197,19 @@ const deserializeAws_restJson1ServiceQuotaExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.QuotaCode !== undefined && data.QuotaCode !== null) {
-    contents.QuotaCode = data.QuotaCode;
+    contents.QuotaCode = __expectString(data.QuotaCode);
   }
   if (data.ResourceId !== undefined && data.ResourceId !== null) {
-    contents.ResourceId = data.ResourceId;
+    contents.ResourceId = __expectString(data.ResourceId);
   }
   if (data.ResourceType !== undefined && data.ResourceType !== null) {
-    contents.ResourceType = data.ResourceType;
+    contents.ResourceType = __expectString(data.ResourceType);
   }
   if (data.ServiceCode !== undefined && data.ServiceCode !== null) {
-    contents.ServiceCode = data.ServiceCode;
+    contents.ServiceCode = __expectString(data.ServiceCode);
   }
   return contents;
 };
@@ -4225,13 +4228,13 @@ const deserializeAws_restJson1ThrottlingExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.QuotaCode !== undefined && data.QuotaCode !== null) {
-    contents.QuotaCode = data.QuotaCode;
+    contents.QuotaCode = __expectString(data.QuotaCode);
   }
   if (data.ServiceCode !== undefined && data.ServiceCode !== null) {
-    contents.ServiceCode = data.ServiceCode;
+    contents.ServiceCode = __expectString(data.ServiceCode);
   }
   return contents;
 };
@@ -4253,10 +4256,10 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
     contents.Fields = deserializeAws_restJson1ValidationExceptionFieldList(data.Fields, context);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.Reason !== undefined && data.Reason !== null) {
-    contents.Reason = data.Reason;
+    contents.Reason = __expectString(data.Reason);
   }
   return contents;
 };
@@ -4368,25 +4371,15 @@ const deserializeAws_restJson1Answer = (output: any, context: __SerdeContext): A
       output.Choices !== undefined && output.Choices !== null
         ? deserializeAws_restJson1Choices(output.Choices, context)
         : undefined,
-    HelpfulResourceUrl:
-      output.HelpfulResourceUrl !== undefined && output.HelpfulResourceUrl !== null
-        ? output.HelpfulResourceUrl
-        : undefined,
-    ImprovementPlanUrl:
-      output.ImprovementPlanUrl !== undefined && output.ImprovementPlanUrl !== null
-        ? output.ImprovementPlanUrl
-        : undefined,
-    IsApplicable: output.IsApplicable !== undefined && output.IsApplicable !== null ? output.IsApplicable : undefined,
-    Notes: output.Notes !== undefined && output.Notes !== null ? output.Notes : undefined,
-    PillarId: output.PillarId !== undefined && output.PillarId !== null ? output.PillarId : undefined,
-    QuestionDescription:
-      output.QuestionDescription !== undefined && output.QuestionDescription !== null
-        ? output.QuestionDescription
-        : undefined,
-    QuestionId: output.QuestionId !== undefined && output.QuestionId !== null ? output.QuestionId : undefined,
-    QuestionTitle:
-      output.QuestionTitle !== undefined && output.QuestionTitle !== null ? output.QuestionTitle : undefined,
-    Risk: output.Risk !== undefined && output.Risk !== null ? output.Risk : undefined,
+    HelpfulResourceUrl: __expectString(output.HelpfulResourceUrl),
+    ImprovementPlanUrl: __expectString(output.ImprovementPlanUrl),
+    IsApplicable: __expectBoolean(output.IsApplicable),
+    Notes: __expectString(output.Notes),
+    PillarId: __expectString(output.PillarId),
+    QuestionDescription: __expectString(output.QuestionDescription),
+    QuestionId: __expectString(output.QuestionId),
+    QuestionTitle: __expectString(output.QuestionTitle),
+    Risk: __expectString(output.Risk),
     SelectedChoices:
       output.SelectedChoices !== undefined && output.SelectedChoices !== null
         ? deserializeAws_restJson1SelectedChoices(output.SelectedChoices, context)
@@ -4411,12 +4404,11 @@ const deserializeAws_restJson1AnswerSummary = (output: any, context: __SerdeCont
       output.Choices !== undefined && output.Choices !== null
         ? deserializeAws_restJson1Choices(output.Choices, context)
         : undefined,
-    IsApplicable: output.IsApplicable !== undefined && output.IsApplicable !== null ? output.IsApplicable : undefined,
-    PillarId: output.PillarId !== undefined && output.PillarId !== null ? output.PillarId : undefined,
-    QuestionId: output.QuestionId !== undefined && output.QuestionId !== null ? output.QuestionId : undefined,
-    QuestionTitle:
-      output.QuestionTitle !== undefined && output.QuestionTitle !== null ? output.QuestionTitle : undefined,
-    Risk: output.Risk !== undefined && output.Risk !== null ? output.Risk : undefined,
+    IsApplicable: __expectBoolean(output.IsApplicable),
+    PillarId: __expectString(output.PillarId),
+    QuestionId: __expectString(output.QuestionId),
+    QuestionTitle: __expectString(output.QuestionTitle),
+    Risk: __expectString(output.Risk),
     SelectedChoices:
       output.SelectedChoices !== undefined && output.SelectedChoices !== null
         ? deserializeAws_restJson1SelectedChoices(output.SelectedChoices, context)
@@ -4426,9 +4418,9 @@ const deserializeAws_restJson1AnswerSummary = (output: any, context: __SerdeCont
 
 const deserializeAws_restJson1Choice = (output: any, context: __SerdeContext): Choice => {
   return {
-    ChoiceId: output.ChoiceId !== undefined && output.ChoiceId !== null ? output.ChoiceId : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Title: output.Title !== undefined && output.Title !== null ? output.Title : undefined,
+    ChoiceId: __expectString(output.ChoiceId),
+    Description: __expectString(output.Description),
+    Title: __expectString(output.Title),
   } as any;
 };
 
@@ -4456,26 +4448,22 @@ const deserializeAws_restJson1ImprovementSummaries = (output: any, context: __Se
 
 const deserializeAws_restJson1ImprovementSummary = (output: any, context: __SerdeContext): ImprovementSummary => {
   return {
-    ImprovementPlanUrl:
-      output.ImprovementPlanUrl !== undefined && output.ImprovementPlanUrl !== null
-        ? output.ImprovementPlanUrl
-        : undefined,
-    PillarId: output.PillarId !== undefined && output.PillarId !== null ? output.PillarId : undefined,
-    QuestionId: output.QuestionId !== undefined && output.QuestionId !== null ? output.QuestionId : undefined,
-    QuestionTitle:
-      output.QuestionTitle !== undefined && output.QuestionTitle !== null ? output.QuestionTitle : undefined,
-    Risk: output.Risk !== undefined && output.Risk !== null ? output.Risk : undefined,
+    ImprovementPlanUrl: __expectString(output.ImprovementPlanUrl),
+    PillarId: __expectString(output.PillarId),
+    QuestionId: __expectString(output.QuestionId),
+    QuestionTitle: __expectString(output.QuestionTitle),
+    Risk: __expectString(output.Risk),
   } as any;
 };
 
 const deserializeAws_restJson1LensReview = (output: any, context: __SerdeContext): LensReview => {
   return {
-    LensAlias: output.LensAlias !== undefined && output.LensAlias !== null ? output.LensAlias : undefined,
-    LensName: output.LensName !== undefined && output.LensName !== null ? output.LensName : undefined,
-    LensStatus: output.LensStatus !== undefined && output.LensStatus !== null ? output.LensStatus : undefined,
-    LensVersion: output.LensVersion !== undefined && output.LensVersion !== null ? output.LensVersion : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
-    Notes: output.Notes !== undefined && output.Notes !== null ? output.Notes : undefined,
+    LensAlias: __expectString(output.LensAlias),
+    LensName: __expectString(output.LensName),
+    LensStatus: __expectString(output.LensStatus),
+    LensVersion: __expectString(output.LensVersion),
+    NextToken: __expectString(output.NextToken),
+    Notes: __expectString(output.Notes),
     PillarReviewSummaries:
       output.PillarReviewSummaries !== undefined && output.PillarReviewSummaries !== null
         ? deserializeAws_restJson1PillarReviewSummaries(output.PillarReviewSummaries, context)
@@ -4493,8 +4481,8 @@ const deserializeAws_restJson1LensReview = (output: any, context: __SerdeContext
 
 const deserializeAws_restJson1LensReviewReport = (output: any, context: __SerdeContext): LensReviewReport => {
   return {
-    Base64String: output.Base64String !== undefined && output.Base64String !== null ? output.Base64String : undefined,
-    LensAlias: output.LensAlias !== undefined && output.LensAlias !== null ? output.LensAlias : undefined,
+    Base64String: __expectString(output.Base64String),
+    LensAlias: __expectString(output.LensAlias),
   } as any;
 };
 
@@ -4511,10 +4499,10 @@ const deserializeAws_restJson1LensReviewSummaries = (output: any, context: __Ser
 
 const deserializeAws_restJson1LensReviewSummary = (output: any, context: __SerdeContext): LensReviewSummary => {
   return {
-    LensAlias: output.LensAlias !== undefined && output.LensAlias !== null ? output.LensAlias : undefined,
-    LensName: output.LensName !== undefined && output.LensName !== null ? output.LensName : undefined,
-    LensStatus: output.LensStatus !== undefined && output.LensStatus !== null ? output.LensStatus : undefined,
-    LensVersion: output.LensVersion !== undefined && output.LensVersion !== null ? output.LensVersion : undefined,
+    LensAlias: __expectString(output.LensAlias),
+    LensName: __expectString(output.LensName),
+    LensStatus: __expectString(output.LensStatus),
+    LensVersion: __expectString(output.LensVersion),
     RiskCounts:
       output.RiskCounts !== undefined && output.RiskCounts !== null
         ? deserializeAws_restJson1RiskCounts(output.RiskCounts, context)
@@ -4539,35 +4527,27 @@ const deserializeAws_restJson1LensSummaries = (output: any, context: __SerdeCont
 
 const deserializeAws_restJson1LensSummary = (output: any, context: __SerdeContext): LensSummary => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    LensAlias: output.LensAlias !== undefined && output.LensAlias !== null ? output.LensAlias : undefined,
-    LensName: output.LensName !== undefined && output.LensName !== null ? output.LensName : undefined,
-    LensVersion: output.LensVersion !== undefined && output.LensVersion !== null ? output.LensVersion : undefined,
+    Description: __expectString(output.Description),
+    LensAlias: __expectString(output.LensAlias),
+    LensName: __expectString(output.LensName),
+    LensVersion: __expectString(output.LensVersion),
   } as any;
 };
 
 const deserializeAws_restJson1LensUpgradeSummary = (output: any, context: __SerdeContext): LensUpgradeSummary => {
   return {
-    CurrentLensVersion:
-      output.CurrentLensVersion !== undefined && output.CurrentLensVersion !== null
-        ? output.CurrentLensVersion
-        : undefined,
-    LatestLensVersion:
-      output.LatestLensVersion !== undefined && output.LatestLensVersion !== null
-        ? output.LatestLensVersion
-        : undefined,
-    LensAlias: output.LensAlias !== undefined && output.LensAlias !== null ? output.LensAlias : undefined,
-    WorkloadId: output.WorkloadId !== undefined && output.WorkloadId !== null ? output.WorkloadId : undefined,
-    WorkloadName: output.WorkloadName !== undefined && output.WorkloadName !== null ? output.WorkloadName : undefined,
+    CurrentLensVersion: __expectString(output.CurrentLensVersion),
+    LatestLensVersion: __expectString(output.LatestLensVersion),
+    LensAlias: __expectString(output.LensAlias),
+    WorkloadId: __expectString(output.WorkloadId),
+    WorkloadName: __expectString(output.WorkloadName),
   } as any;
 };
 
 const deserializeAws_restJson1Milestone = (output: any, context: __SerdeContext): Milestone => {
   return {
-    MilestoneName:
-      output.MilestoneName !== undefined && output.MilestoneName !== null ? output.MilestoneName : undefined,
-    MilestoneNumber:
-      output.MilestoneNumber !== undefined && output.MilestoneNumber !== null ? output.MilestoneNumber : undefined,
+    MilestoneName: __expectString(output.MilestoneName),
+    MilestoneNumber: __expectNumber(output.MilestoneNumber),
     RecordedAt:
       output.RecordedAt !== undefined && output.RecordedAt !== null
         ? new Date(Math.round(output.RecordedAt * 1000))
@@ -4592,10 +4572,8 @@ const deserializeAws_restJson1MilestoneSummaries = (output: any, context: __Serd
 
 const deserializeAws_restJson1MilestoneSummary = (output: any, context: __SerdeContext): MilestoneSummary => {
   return {
-    MilestoneName:
-      output.MilestoneName !== undefined && output.MilestoneName !== null ? output.MilestoneName : undefined,
-    MilestoneNumber:
-      output.MilestoneNumber !== undefined && output.MilestoneNumber !== null ? output.MilestoneNumber : undefined,
+    MilestoneName: __expectString(output.MilestoneName),
+    MilestoneNumber: __expectNumber(output.MilestoneNumber),
     RecordedAt:
       output.RecordedAt !== undefined && output.RecordedAt !== null
         ? new Date(Math.round(output.RecordedAt * 1000))
@@ -4624,15 +4602,14 @@ const deserializeAws_restJson1NotificationSummary = (output: any, context: __Ser
       output.LensUpgradeSummary !== undefined && output.LensUpgradeSummary !== null
         ? deserializeAws_restJson1LensUpgradeSummary(output.LensUpgradeSummary, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
 const deserializeAws_restJson1PillarDifference = (output: any, context: __SerdeContext): PillarDifference => {
   return {
-    DifferenceStatus:
-      output.DifferenceStatus !== undefined && output.DifferenceStatus !== null ? output.DifferenceStatus : undefined,
-    PillarId: output.PillarId !== undefined && output.PillarId !== null ? output.PillarId : undefined,
+    DifferenceStatus: __expectString(output.DifferenceStatus),
+    PillarId: __expectString(output.PillarId),
     QuestionDifferences:
       output.QuestionDifferences !== undefined && output.QuestionDifferences !== null
         ? deserializeAws_restJson1QuestionDifferences(output.QuestionDifferences, context)
@@ -4664,9 +4641,9 @@ const deserializeAws_restJson1PillarReviewSummaries = (output: any, context: __S
 
 const deserializeAws_restJson1PillarReviewSummary = (output: any, context: __SerdeContext): PillarReviewSummary => {
   return {
-    Notes: output.Notes !== undefined && output.Notes !== null ? output.Notes : undefined,
-    PillarId: output.PillarId !== undefined && output.PillarId !== null ? output.PillarId : undefined,
-    PillarName: output.PillarName !== undefined && output.PillarName !== null ? output.PillarName : undefined,
+    Notes: __expectString(output.Notes),
+    PillarId: __expectString(output.PillarId),
+    PillarName: __expectString(output.PillarName),
     RiskCounts:
       output.RiskCounts !== undefined && output.RiskCounts !== null
         ? deserializeAws_restJson1RiskCounts(output.RiskCounts, context)
@@ -4676,11 +4653,9 @@ const deserializeAws_restJson1PillarReviewSummary = (output: any, context: __Ser
 
 const deserializeAws_restJson1QuestionDifference = (output: any, context: __SerdeContext): QuestionDifference => {
   return {
-    DifferenceStatus:
-      output.DifferenceStatus !== undefined && output.DifferenceStatus !== null ? output.DifferenceStatus : undefined,
-    QuestionId: output.QuestionId !== undefined && output.QuestionId !== null ? output.QuestionId : undefined,
-    QuestionTitle:
-      output.QuestionTitle !== undefined && output.QuestionTitle !== null ? output.QuestionTitle : undefined,
+    DifferenceStatus: __expectString(output.DifferenceStatus),
+    QuestionId: __expectString(output.QuestionId),
+    QuestionTitle: __expectString(output.QuestionTitle),
   } as any;
 };
 
@@ -4702,7 +4677,7 @@ const deserializeAws_restJson1RiskCounts = (output: any, context: __SerdeContext
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectNumber(value) as any,
     };
   }, {});
 };
@@ -4714,17 +4689,14 @@ const deserializeAws_restJson1SelectedChoices = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1ShareInvitation = (output: any, context: __SerdeContext): ShareInvitation => {
   return {
-    ShareInvitationId:
-      output.ShareInvitationId !== undefined && output.ShareInvitationId !== null
-        ? output.ShareInvitationId
-        : undefined,
-    WorkloadId: output.WorkloadId !== undefined && output.WorkloadId !== null ? output.WorkloadId : undefined,
+    ShareInvitationId: __expectString(output.ShareInvitationId),
+    WorkloadId: __expectString(output.WorkloadId),
   } as any;
 };
 
@@ -4747,16 +4719,12 @@ const deserializeAws_restJson1ShareInvitationSummary = (
   context: __SerdeContext
 ): ShareInvitationSummary => {
   return {
-    PermissionType:
-      output.PermissionType !== undefined && output.PermissionType !== null ? output.PermissionType : undefined,
-    ShareInvitationId:
-      output.ShareInvitationId !== undefined && output.ShareInvitationId !== null
-        ? output.ShareInvitationId
-        : undefined,
-    SharedBy: output.SharedBy !== undefined && output.SharedBy !== null ? output.SharedBy : undefined,
-    SharedWith: output.SharedWith !== undefined && output.SharedWith !== null ? output.SharedWith : undefined,
-    WorkloadId: output.WorkloadId !== undefined && output.WorkloadId !== null ? output.WorkloadId : undefined,
-    WorkloadName: output.WorkloadName !== undefined && output.WorkloadName !== null ? output.WorkloadName : undefined,
+    PermissionType: __expectString(output.PermissionType),
+    ShareInvitationId: __expectString(output.ShareInvitationId),
+    SharedBy: __expectString(output.SharedBy),
+    SharedWith: __expectString(output.SharedWith),
+    WorkloadId: __expectString(output.WorkloadId),
+    WorkloadName: __expectString(output.WorkloadName),
   } as any;
 };
 
@@ -4767,7 +4735,7 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -4777,8 +4745,8 @@ const deserializeAws_restJson1ValidationExceptionField = (
   context: __SerdeContext
 ): ValidationExceptionField => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Message: __expectString(output.Message),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -4811,26 +4779,17 @@ const deserializeAws_restJson1Workload = (output: any, context: __SerdeContext):
       output.AccountIds !== undefined && output.AccountIds !== null
         ? deserializeAws_restJson1WorkloadAccountIds(output.AccountIds, context)
         : undefined,
-    ArchitecturalDesign:
-      output.ArchitecturalDesign !== undefined && output.ArchitecturalDesign !== null
-        ? output.ArchitecturalDesign
-        : undefined,
+    ArchitecturalDesign: __expectString(output.ArchitecturalDesign),
     AwsRegions:
       output.AwsRegions !== undefined && output.AwsRegions !== null
         ? deserializeAws_restJson1WorkloadAwsRegions(output.AwsRegions, context)
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Environment: output.Environment !== undefined && output.Environment !== null ? output.Environment : undefined,
-    ImprovementStatus:
-      output.ImprovementStatus !== undefined && output.ImprovementStatus !== null
-        ? output.ImprovementStatus
-        : undefined,
-    Industry: output.Industry !== undefined && output.Industry !== null ? output.Industry : undefined,
-    IndustryType: output.IndustryType !== undefined && output.IndustryType !== null ? output.IndustryType : undefined,
-    IsReviewOwnerUpdateAcknowledged:
-      output.IsReviewOwnerUpdateAcknowledged !== undefined && output.IsReviewOwnerUpdateAcknowledged !== null
-        ? output.IsReviewOwnerUpdateAcknowledged
-        : undefined,
+    Description: __expectString(output.Description),
+    Environment: __expectString(output.Environment),
+    ImprovementStatus: __expectString(output.ImprovementStatus),
+    Industry: __expectString(output.Industry),
+    IndustryType: __expectString(output.IndustryType),
+    IsReviewOwnerUpdateAcknowledged: __expectBoolean(output.IsReviewOwnerUpdateAcknowledged),
     Lenses:
       output.Lenses !== undefined && output.Lenses !== null
         ? deserializeAws_restJson1WorkloadLenses(output.Lenses, context)
@@ -4839,13 +4798,13 @@ const deserializeAws_restJson1Workload = (output: any, context: __SerdeContext):
       output.NonAwsRegions !== undefined && output.NonAwsRegions !== null
         ? deserializeAws_restJson1WorkloadNonAwsRegions(output.NonAwsRegions, context)
         : undefined,
-    Notes: output.Notes !== undefined && output.Notes !== null ? output.Notes : undefined,
-    Owner: output.Owner !== undefined && output.Owner !== null ? output.Owner : undefined,
+    Notes: __expectString(output.Notes),
+    Owner: __expectString(output.Owner),
     PillarPriorities:
       output.PillarPriorities !== undefined && output.PillarPriorities !== null
         ? deserializeAws_restJson1WorkloadPillarPriorities(output.PillarPriorities, context)
         : undefined,
-    ReviewOwner: output.ReviewOwner !== undefined && output.ReviewOwner !== null ? output.ReviewOwner : undefined,
+    ReviewOwner: __expectString(output.ReviewOwner),
     ReviewRestrictionDate:
       output.ReviewRestrictionDate !== undefined && output.ReviewRestrictionDate !== null
         ? new Date(Math.round(output.ReviewRestrictionDate * 1000))
@@ -4854,10 +4813,7 @@ const deserializeAws_restJson1Workload = (output: any, context: __SerdeContext):
       output.RiskCounts !== undefined && output.RiskCounts !== null
         ? deserializeAws_restJson1RiskCounts(output.RiskCounts, context)
         : undefined,
-    ShareInvitationId:
-      output.ShareInvitationId !== undefined && output.ShareInvitationId !== null
-        ? output.ShareInvitationId
-        : undefined,
+    ShareInvitationId: __expectString(output.ShareInvitationId),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_restJson1TagMap(output.Tags, context)
@@ -4866,9 +4822,9 @@ const deserializeAws_restJson1Workload = (output: any, context: __SerdeContext):
       output.UpdatedAt !== undefined && output.UpdatedAt !== null
         ? new Date(Math.round(output.UpdatedAt * 1000))
         : undefined,
-    WorkloadArn: output.WorkloadArn !== undefined && output.WorkloadArn !== null ? output.WorkloadArn : undefined,
-    WorkloadId: output.WorkloadId !== undefined && output.WorkloadId !== null ? output.WorkloadId : undefined,
-    WorkloadName: output.WorkloadName !== undefined && output.WorkloadName !== null ? output.WorkloadName : undefined,
+    WorkloadArn: __expectString(output.WorkloadArn),
+    WorkloadId: __expectString(output.WorkloadId),
+    WorkloadName: __expectString(output.WorkloadName),
   } as any;
 };
 
@@ -4879,7 +4835,7 @@ const deserializeAws_restJson1WorkloadAccountIds = (output: any, context: __Serd
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4890,7 +4846,7 @@ const deserializeAws_restJson1WorkloadAwsRegions = (output: any, context: __Serd
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4901,7 +4857,7 @@ const deserializeAws_restJson1WorkloadLenses = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4912,7 +4868,7 @@ const deserializeAws_restJson1WorkloadNonAwsRegions = (output: any, context: __S
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4923,20 +4879,19 @@ const deserializeAws_restJson1WorkloadPillarPriorities = (output: any, context: 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1WorkloadShare = (output: any, context: __SerdeContext): WorkloadShare => {
   return {
-    PermissionType:
-      output.PermissionType !== undefined && output.PermissionType !== null ? output.PermissionType : undefined,
-    ShareId: output.ShareId !== undefined && output.ShareId !== null ? output.ShareId : undefined,
-    SharedBy: output.SharedBy !== undefined && output.SharedBy !== null ? output.SharedBy : undefined,
-    SharedWith: output.SharedWith !== undefined && output.SharedWith !== null ? output.SharedWith : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    WorkloadId: output.WorkloadId !== undefined && output.WorkloadId !== null ? output.WorkloadId : undefined,
-    WorkloadName: output.WorkloadName !== undefined && output.WorkloadName !== null ? output.WorkloadName : undefined,
+    PermissionType: __expectString(output.PermissionType),
+    ShareId: __expectString(output.ShareId),
+    SharedBy: __expectString(output.SharedBy),
+    SharedWith: __expectString(output.SharedWith),
+    Status: __expectString(output.Status),
+    WorkloadId: __expectString(output.WorkloadId),
+    WorkloadName: __expectString(output.WorkloadName),
   } as any;
 };
 
@@ -4956,11 +4911,10 @@ const deserializeAws_restJson1WorkloadShareSummaries = (
 
 const deserializeAws_restJson1WorkloadShareSummary = (output: any, context: __SerdeContext): WorkloadShareSummary => {
   return {
-    PermissionType:
-      output.PermissionType !== undefined && output.PermissionType !== null ? output.PermissionType : undefined,
-    ShareId: output.ShareId !== undefined && output.ShareId !== null ? output.ShareId : undefined,
-    SharedWith: output.SharedWith !== undefined && output.SharedWith !== null ? output.SharedWith : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    PermissionType: __expectString(output.PermissionType),
+    ShareId: __expectString(output.ShareId),
+    SharedWith: __expectString(output.SharedWith),
+    Status: __expectString(output.Status),
   } as any;
 };
 
@@ -4977,15 +4931,12 @@ const deserializeAws_restJson1WorkloadSummaries = (output: any, context: __Serde
 
 const deserializeAws_restJson1WorkloadSummary = (output: any, context: __SerdeContext): WorkloadSummary => {
   return {
-    ImprovementStatus:
-      output.ImprovementStatus !== undefined && output.ImprovementStatus !== null
-        ? output.ImprovementStatus
-        : undefined,
+    ImprovementStatus: __expectString(output.ImprovementStatus),
     Lenses:
       output.Lenses !== undefined && output.Lenses !== null
         ? deserializeAws_restJson1WorkloadLenses(output.Lenses, context)
         : undefined,
-    Owner: output.Owner !== undefined && output.Owner !== null ? output.Owner : undefined,
+    Owner: __expectString(output.Owner),
     RiskCounts:
       output.RiskCounts !== undefined && output.RiskCounts !== null
         ? deserializeAws_restJson1RiskCounts(output.RiskCounts, context)
@@ -4994,9 +4945,9 @@ const deserializeAws_restJson1WorkloadSummary = (output: any, context: __SerdeCo
       output.UpdatedAt !== undefined && output.UpdatedAt !== null
         ? new Date(Math.round(output.UpdatedAt * 1000))
         : undefined,
-    WorkloadArn: output.WorkloadArn !== undefined && output.WorkloadArn !== null ? output.WorkloadArn : undefined,
-    WorkloadId: output.WorkloadId !== undefined && output.WorkloadId !== null ? output.WorkloadId : undefined,
-    WorkloadName: output.WorkloadName !== undefined && output.WorkloadName !== null ? output.WorkloadName : undefined,
+    WorkloadArn: __expectString(output.WorkloadArn),
+    WorkloadId: __expectString(output.WorkloadId),
+    WorkloadName: __expectString(output.WorkloadName),
   } as any;
 };
 

--- a/clients/client-workdocs/protocols/Aws_restJson1.ts
+++ b/clients/client-workdocs/protocols/Aws_restJson1.ts
@@ -141,6 +141,9 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -3276,7 +3279,7 @@ export const deserializeAws_restJson1DescribeActivitiesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Marker !== undefined && data.Marker !== null) {
-    contents.Marker = data.Marker;
+    contents.Marker = __expectString(data.Marker);
   }
   if (data.UserActivities !== undefined && data.UserActivities !== null) {
     contents.UserActivities = deserializeAws_restJson1UserActivities(data.UserActivities, context);
@@ -3370,7 +3373,7 @@ export const deserializeAws_restJson1DescribeCommentsCommand = async (
     contents.Comments = deserializeAws_restJson1CommentList(data.Comments, context);
   }
   if (data.Marker !== undefined && data.Marker !== null) {
-    contents.Marker = data.Marker;
+    contents.Marker = __expectString(data.Marker);
   }
   return Promise.resolve(contents);
 };
@@ -3469,7 +3472,7 @@ export const deserializeAws_restJson1DescribeDocumentVersionsCommand = async (
     contents.DocumentVersions = deserializeAws_restJson1DocumentVersionMetadataList(data.DocumentVersions, context);
   }
   if (data.Marker !== undefined && data.Marker !== null) {
-    contents.Marker = data.Marker;
+    contents.Marker = __expectString(data.Marker);
   }
   return Promise.resolve(contents);
 };
@@ -3580,7 +3583,7 @@ export const deserializeAws_restJson1DescribeFolderContentsCommand = async (
     contents.Folders = deserializeAws_restJson1FolderMetadataList(data.Folders, context);
   }
   if (data.Marker !== undefined && data.Marker !== null) {
-    contents.Marker = data.Marker;
+    contents.Marker = __expectString(data.Marker);
   }
   return Promise.resolve(contents);
 };
@@ -3679,7 +3682,7 @@ export const deserializeAws_restJson1DescribeGroupsCommand = async (
     contents.Groups = deserializeAws_restJson1GroupMetadataList(data.Groups, context);
   }
   if (data.Marker !== undefined && data.Marker !== null) {
-    contents.Marker = data.Marker;
+    contents.Marker = __expectString(data.Marker);
   }
   return Promise.resolve(contents);
 };
@@ -3759,7 +3762,7 @@ export const deserializeAws_restJson1DescribeNotificationSubscriptionsCommand = 
   };
   const data: any = await parseBody(output.body, context);
   if (data.Marker !== undefined && data.Marker !== null) {
-    contents.Marker = data.Marker;
+    contents.Marker = __expectString(data.Marker);
   }
   if (data.Subscriptions !== undefined && data.Subscriptions !== null) {
     contents.Subscriptions = deserializeAws_restJson1SubscriptionList(data.Subscriptions, context);
@@ -3834,7 +3837,7 @@ export const deserializeAws_restJson1DescribeResourcePermissionsCommand = async 
   };
   const data: any = await parseBody(output.body, context);
   if (data.Marker !== undefined && data.Marker !== null) {
-    contents.Marker = data.Marker;
+    contents.Marker = __expectString(data.Marker);
   }
   if (data.Principals !== undefined && data.Principals !== null) {
     contents.Principals = deserializeAws_restJson1PrincipalList(data.Principals, context);
@@ -3920,7 +3923,7 @@ export const deserializeAws_restJson1DescribeRootFoldersCommand = async (
     contents.Folders = deserializeAws_restJson1FolderMetadataList(data.Folders, context);
   }
   if (data.Marker !== undefined && data.Marker !== null) {
-    contents.Marker = data.Marker;
+    contents.Marker = __expectString(data.Marker);
   }
   return Promise.resolve(contents);
 };
@@ -4009,10 +4012,10 @@ export const deserializeAws_restJson1DescribeUsersCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.Marker !== undefined && data.Marker !== null) {
-    contents.Marker = data.Marker;
+    contents.Marker = __expectString(data.Marker);
   }
   if (data.TotalNumberOfUsers !== undefined && data.TotalNumberOfUsers !== null) {
-    contents.TotalNumberOfUsers = data.TotalNumberOfUsers;
+    contents.TotalNumberOfUsers = __expectNumber(data.TotalNumberOfUsers);
   }
   if (data.Users !== undefined && data.Users !== null) {
     contents.Users = deserializeAws_restJson1OrganizationUserList(data.Users, context);
@@ -4708,7 +4711,7 @@ export const deserializeAws_restJson1GetResourcesCommand = async (
     contents.Folders = deserializeAws_restJson1FolderMetadataList(data.Folders, context);
   }
   if (data.Marker !== undefined && data.Marker !== null) {
-    contents.Marker = data.Marker;
+    contents.Marker = __expectString(data.Marker);
   }
   return Promise.resolve(contents);
 };
@@ -5547,7 +5550,7 @@ const deserializeAws_restJson1ConcurrentModificationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -5564,7 +5567,7 @@ const deserializeAws_restJson1ConflictingOperationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -5581,7 +5584,7 @@ const deserializeAws_restJson1CustomMetadataLimitExceededExceptionResponse = asy
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -5599,10 +5602,10 @@ const deserializeAws_restJson1DeactivatingLastSystemUserExceptionResponse = asyn
   };
   const data: any = parsedOutput.body;
   if (data.Code !== undefined && data.Code !== null) {
-    contents.Code = data.Code;
+    contents.Code = __expectString(data.Code);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -5619,7 +5622,7 @@ const deserializeAws_restJson1DocumentLockedForCommentsExceptionResponse = async
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -5636,7 +5639,7 @@ const deserializeAws_restJson1DraftUploadOutOfSyncExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -5653,7 +5656,7 @@ const deserializeAws_restJson1EntityAlreadyExistsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -5674,7 +5677,7 @@ const deserializeAws_restJson1EntityNotExistsExceptionResponse = async (
     contents.EntityIds = deserializeAws_restJson1EntityIdList(data.EntityIds, context);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -5691,7 +5694,7 @@ const deserializeAws_restJson1FailedDependencyExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -5708,7 +5711,7 @@ const deserializeAws_restJson1IllegalUserStateExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -5725,7 +5728,7 @@ const deserializeAws_restJson1InvalidArgumentExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -5742,7 +5745,7 @@ const deserializeAws_restJson1InvalidCommentOperationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -5759,7 +5762,7 @@ const deserializeAws_restJson1InvalidOperationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -5776,7 +5779,7 @@ const deserializeAws_restJson1InvalidPasswordExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -5793,7 +5796,7 @@ const deserializeAws_restJson1LimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -5810,7 +5813,7 @@ const deserializeAws_restJson1ProhibitedStateExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -5827,7 +5830,7 @@ const deserializeAws_restJson1RequestedEntityTooLargeExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -5844,7 +5847,7 @@ const deserializeAws_restJson1ResourceAlreadyCheckedOutExceptionResponse = async
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -5861,7 +5864,7 @@ const deserializeAws_restJson1ServiceUnavailableExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -5878,7 +5881,7 @@ const deserializeAws_restJson1StorageLimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -5895,7 +5898,7 @@ const deserializeAws_restJson1StorageLimitWillExceedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -5912,7 +5915,7 @@ const deserializeAws_restJson1TooManyLabelsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -5929,7 +5932,7 @@ const deserializeAws_restJson1TooManySubscriptionsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -5947,10 +5950,10 @@ const deserializeAws_restJson1UnauthorizedOperationExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Code !== undefined && data.Code !== null) {
-    contents.Code = data.Code;
+    contents.Code = __expectString(data.Code);
   }
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -5967,7 +5970,7 @@ const deserializeAws_restJson1UnauthorizedResourceAccessExceptionResponse = asyn
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -6039,12 +6042,8 @@ const deserializeAws_restJson1Activity = (output: any, context: __SerdeContext):
       output.Initiator !== undefined && output.Initiator !== null
         ? deserializeAws_restJson1UserMetadata(output.Initiator, context)
         : undefined,
-    IsIndirectActivity:
-      output.IsIndirectActivity !== undefined && output.IsIndirectActivity !== null
-        ? output.IsIndirectActivity
-        : undefined,
-    OrganizationId:
-      output.OrganizationId !== undefined && output.OrganizationId !== null ? output.OrganizationId : undefined,
+    IsIndirectActivity: __expectBoolean(output.IsIndirectActivity),
+    OrganizationId: __expectString(output.OrganizationId),
     OriginalParent:
       output.OriginalParent !== undefined && output.OriginalParent !== null
         ? deserializeAws_restJson1ResourceMetadata(output.OriginalParent, context)
@@ -6061,13 +6060,13 @@ const deserializeAws_restJson1Activity = (output: any, context: __SerdeContext):
       output.TimeStamp !== undefined && output.TimeStamp !== null
         ? new Date(Math.round(output.TimeStamp * 1000))
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
 const deserializeAws_restJson1Comment = (output: any, context: __SerdeContext): Comment => {
   return {
-    CommentId: output.CommentId !== undefined && output.CommentId !== null ? output.CommentId : undefined,
+    CommentId: __expectString(output.CommentId),
     Contributor:
       output.Contributor !== undefined && output.Contributor !== null
         ? deserializeAws_restJson1User(output.Contributor, context)
@@ -6076,12 +6075,12 @@ const deserializeAws_restJson1Comment = (output: any, context: __SerdeContext): 
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
         ? new Date(Math.round(output.CreatedTimestamp * 1000))
         : undefined,
-    ParentId: output.ParentId !== undefined && output.ParentId !== null ? output.ParentId : undefined,
-    RecipientId: output.RecipientId !== undefined && output.RecipientId !== null ? output.RecipientId : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    Text: output.Text !== undefined && output.Text !== null ? output.Text : undefined,
-    ThreadId: output.ThreadId !== undefined && output.ThreadId !== null ? output.ThreadId : undefined,
-    Visibility: output.Visibility !== undefined && output.Visibility !== null ? output.Visibility : undefined,
+    ParentId: __expectString(output.ParentId),
+    RecipientId: __expectString(output.RecipientId),
+    Status: __expectString(output.Status),
+    Text: __expectString(output.Text),
+    ThreadId: __expectString(output.ThreadId),
+    Visibility: __expectString(output.Visibility),
   } as any;
 };
 
@@ -6098,9 +6097,8 @@ const deserializeAws_restJson1CommentList = (output: any, context: __SerdeContex
 
 const deserializeAws_restJson1CommentMetadata = (output: any, context: __SerdeContext): CommentMetadata => {
   return {
-    CommentId: output.CommentId !== undefined && output.CommentId !== null ? output.CommentId : undefined,
-    CommentStatus:
-      output.CommentStatus !== undefined && output.CommentStatus !== null ? output.CommentStatus : undefined,
+    CommentId: __expectString(output.CommentId),
+    CommentStatus: __expectString(output.CommentStatus),
     Contributor:
       output.Contributor !== undefined && output.Contributor !== null
         ? deserializeAws_restJson1User(output.Contributor, context)
@@ -6109,7 +6107,7 @@ const deserializeAws_restJson1CommentMetadata = (output: any, context: __SerdeCo
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
         ? new Date(Math.round(output.CreatedTimestamp * 1000))
         : undefined,
-    RecipientId: output.RecipientId !== undefined && output.RecipientId !== null ? output.RecipientId : undefined,
+    RecipientId: __expectString(output.RecipientId),
   } as any;
 };
 
@@ -6120,7 +6118,7 @@ const deserializeAws_restJson1CustomMetadataMap = (output: any, context: __Serde
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -6131,8 +6129,8 @@ const deserializeAws_restJson1DocumentMetadata = (output: any, context: __SerdeC
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
         ? new Date(Math.round(output.CreatedTimestamp * 1000))
         : undefined,
-    CreatorId: output.CreatorId !== undefined && output.CreatorId !== null ? output.CreatorId : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    CreatorId: __expectString(output.CreatorId),
+    Id: __expectString(output.Id),
     Labels:
       output.Labels !== undefined && output.Labels !== null
         ? deserializeAws_restJson1SharedLabels(output.Labels, context)
@@ -6145,10 +6143,8 @@ const deserializeAws_restJson1DocumentMetadata = (output: any, context: __SerdeC
       output.ModifiedTimestamp !== undefined && output.ModifiedTimestamp !== null
         ? new Date(Math.round(output.ModifiedTimestamp * 1000))
         : undefined,
-    ParentFolderId:
-      output.ParentFolderId !== undefined && output.ParentFolderId !== null ? output.ParentFolderId : undefined,
-    ResourceState:
-      output.ResourceState !== undefined && output.ResourceState !== null ? output.ResourceState : undefined,
+    ParentFolderId: __expectString(output.ParentFolderId),
+    ResourceState: __expectString(output.ResourceState),
   } as any;
 };
 
@@ -6174,7 +6170,7 @@ const deserializeAws_restJson1DocumentSourceUrlMap = (
       }
       return {
         ...acc,
-        [key]: value,
+        [key]: __expectString(value) as any,
       };
     },
     {}
@@ -6192,7 +6188,7 @@ const deserializeAws_restJson1DocumentThumbnailUrlMap = (
       }
       return {
         ...acc,
-        [key]: value,
+        [key]: __expectString(value) as any,
       };
     },
     {}
@@ -6212,25 +6208,25 @@ const deserializeAws_restJson1DocumentVersionMetadata = (
       output.ContentModifiedTimestamp !== undefined && output.ContentModifiedTimestamp !== null
         ? new Date(Math.round(output.ContentModifiedTimestamp * 1000))
         : undefined,
-    ContentType: output.ContentType !== undefined && output.ContentType !== null ? output.ContentType : undefined,
+    ContentType: __expectString(output.ContentType),
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
         ? new Date(Math.round(output.CreatedTimestamp * 1000))
         : undefined,
-    CreatorId: output.CreatorId !== undefined && output.CreatorId !== null ? output.CreatorId : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    CreatorId: __expectString(output.CreatorId),
+    Id: __expectString(output.Id),
     ModifiedTimestamp:
       output.ModifiedTimestamp !== undefined && output.ModifiedTimestamp !== null
         ? new Date(Math.round(output.ModifiedTimestamp * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Signature: output.Signature !== undefined && output.Signature !== null ? output.Signature : undefined,
-    Size: output.Size !== undefined && output.Size !== null ? output.Size : undefined,
+    Name: __expectString(output.Name),
+    Signature: __expectString(output.Signature),
+    Size: __expectNumber(output.Size),
     Source:
       output.Source !== undefined && output.Source !== null
         ? deserializeAws_restJson1DocumentSourceUrlMap(output.Source, context)
         : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    Status: __expectString(output.Status),
     Thumbnail:
       output.Thumbnail !== undefined && output.Thumbnail !== null
         ? deserializeAws_restJson1DocumentThumbnailUrlMap(output.Thumbnail, context)
@@ -6259,7 +6255,7 @@ const deserializeAws_restJson1EntityIdList = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6269,27 +6265,22 @@ const deserializeAws_restJson1FolderMetadata = (output: any, context: __SerdeCon
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
         ? new Date(Math.round(output.CreatedTimestamp * 1000))
         : undefined,
-    CreatorId: output.CreatorId !== undefined && output.CreatorId !== null ? output.CreatorId : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    CreatorId: __expectString(output.CreatorId),
+    Id: __expectString(output.Id),
     Labels:
       output.Labels !== undefined && output.Labels !== null
         ? deserializeAws_restJson1SharedLabels(output.Labels, context)
         : undefined,
-    LatestVersionSize:
-      output.LatestVersionSize !== undefined && output.LatestVersionSize !== null
-        ? output.LatestVersionSize
-        : undefined,
+    LatestVersionSize: __expectNumber(output.LatestVersionSize),
     ModifiedTimestamp:
       output.ModifiedTimestamp !== undefined && output.ModifiedTimestamp !== null
         ? new Date(Math.round(output.ModifiedTimestamp * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    ParentFolderId:
-      output.ParentFolderId !== undefined && output.ParentFolderId !== null ? output.ParentFolderId : undefined,
-    ResourceState:
-      output.ResourceState !== undefined && output.ResourceState !== null ? output.ResourceState : undefined,
-    Signature: output.Signature !== undefined && output.Signature !== null ? output.Signature : undefined,
-    Size: output.Size !== undefined && output.Size !== null ? output.Size : undefined,
+    Name: __expectString(output.Name),
+    ParentFolderId: __expectString(output.ParentFolderId),
+    ResourceState: __expectString(output.ResourceState),
+    Signature: __expectString(output.Signature),
+    Size: __expectNumber(output.Size),
   } as any;
 };
 
@@ -6306,8 +6297,8 @@ const deserializeAws_restJson1FolderMetadataList = (output: any, context: __Serd
 
 const deserializeAws_restJson1GroupMetadata = (output: any, context: __SerdeContext): GroupMetadata => {
   return {
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -6348,8 +6339,8 @@ const deserializeAws_restJson1Participants = (output: any, context: __SerdeConte
 
 const deserializeAws_restJson1PermissionInfo = (output: any, context: __SerdeContext): PermissionInfo => {
   return {
-    Role: output.Role !== undefined && output.Role !== null ? output.Role : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Role: __expectString(output.Role),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -6366,12 +6357,12 @@ const deserializeAws_restJson1PermissionInfoList = (output: any, context: __Serd
 
 const deserializeAws_restJson1Principal = (output: any, context: __SerdeContext): Principal => {
   return {
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    Id: __expectString(output.Id),
     Roles:
       output.Roles !== undefined && output.Roles !== null
         ? deserializeAws_restJson1PermissionInfoList(output.Roles, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -6388,16 +6379,16 @@ const deserializeAws_restJson1PrincipalList = (output: any, context: __SerdeCont
 
 const deserializeAws_restJson1ResourceMetadata = (output: any, context: __SerdeContext): ResourceMetadata => {
   return {
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    OriginalName: output.OriginalName !== undefined && output.OriginalName !== null ? output.OriginalName : undefined,
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
+    OriginalName: __expectString(output.OriginalName),
     Owner:
       output.Owner !== undefined && output.Owner !== null
         ? deserializeAws_restJson1UserMetadata(output.Owner, context)
         : undefined,
-    ParentId: output.ParentId !== undefined && output.ParentId !== null ? output.ParentId : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    VersionId: output.VersionId !== undefined && output.VersionId !== null ? output.VersionId : undefined,
+    ParentId: __expectString(output.ParentId),
+    Type: __expectString(output.Type),
+    VersionId: __expectString(output.VersionId),
   } as any;
 };
 
@@ -6412,8 +6403,8 @@ const deserializeAws_restJson1ResourcePath = (output: any, context: __SerdeConte
 
 const deserializeAws_restJson1ResourcePathComponent = (output: any, context: __SerdeContext): ResourcePathComponent => {
   return {
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -6438,22 +6429,18 @@ const deserializeAws_restJson1SharedLabels = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1ShareResult = (output: any, context: __SerdeContext): ShareResult => {
   return {
-    InviteePrincipalId:
-      output.InviteePrincipalId !== undefined && output.InviteePrincipalId !== null
-        ? output.InviteePrincipalId
-        : undefined,
-    PrincipalId: output.PrincipalId !== undefined && output.PrincipalId !== null ? output.PrincipalId : undefined,
-    Role: output.Role !== undefined && output.Role !== null ? output.Role : undefined,
-    ShareId: output.ShareId !== undefined && output.ShareId !== null ? output.ShareId : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    StatusMessage:
-      output.StatusMessage !== undefined && output.StatusMessage !== null ? output.StatusMessage : undefined,
+    InviteePrincipalId: __expectString(output.InviteePrincipalId),
+    PrincipalId: __expectString(output.PrincipalId),
+    Role: __expectString(output.Role),
+    ShareId: __expectString(output.ShareId),
+    Status: __expectString(output.Status),
+    StatusMessage: __expectString(output.StatusMessage),
   } as any;
 };
 
@@ -6475,27 +6462,23 @@ const deserializeAws_restJson1SignedHeaderMap = (output: any, context: __SerdeCo
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
 
 const deserializeAws_restJson1StorageRuleType = (output: any, context: __SerdeContext): StorageRuleType => {
   return {
-    StorageAllocatedInBytes:
-      output.StorageAllocatedInBytes !== undefined && output.StorageAllocatedInBytes !== null
-        ? output.StorageAllocatedInBytes
-        : undefined,
-    StorageType: output.StorageType !== undefined && output.StorageType !== null ? output.StorageType : undefined,
+    StorageAllocatedInBytes: __expectNumber(output.StorageAllocatedInBytes),
+    StorageType: __expectString(output.StorageType),
   } as any;
 };
 
 const deserializeAws_restJson1Subscription = (output: any, context: __SerdeContext): Subscription => {
   return {
-    EndPoint: output.EndPoint !== undefined && output.EndPoint !== null ? output.EndPoint : undefined,
-    Protocol: output.Protocol !== undefined && output.Protocol !== null ? output.Protocol : undefined,
-    SubscriptionId:
-      output.SubscriptionId !== undefined && output.SubscriptionId !== null ? output.SubscriptionId : undefined,
+    EndPoint: __expectString(output.EndPoint),
+    Protocol: __expectString(output.Protocol),
+    SubscriptionId: __expectString(output.SubscriptionId),
   } as any;
 };
 
@@ -6516,7 +6499,7 @@ const deserializeAws_restJson1UploadMetadata = (output: any, context: __SerdeCon
       output.SignedHeaders !== undefined && output.SignedHeaders !== null
         ? deserializeAws_restJson1SignedHeaderMap(output.SignedHeaders, context)
         : undefined,
-    UploadUrl: output.UploadUrl !== undefined && output.UploadUrl !== null ? output.UploadUrl : undefined,
+    UploadUrl: __expectString(output.UploadUrl),
   } as any;
 };
 
@@ -6526,30 +6509,26 @@ const deserializeAws_restJson1User = (output: any, context: __SerdeContext): Use
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
         ? new Date(Math.round(output.CreatedTimestamp * 1000))
         : undefined,
-    EmailAddress: output.EmailAddress !== undefined && output.EmailAddress !== null ? output.EmailAddress : undefined,
-    GivenName: output.GivenName !== undefined && output.GivenName !== null ? output.GivenName : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Locale: output.Locale !== undefined && output.Locale !== null ? output.Locale : undefined,
+    EmailAddress: __expectString(output.EmailAddress),
+    GivenName: __expectString(output.GivenName),
+    Id: __expectString(output.Id),
+    Locale: __expectString(output.Locale),
     ModifiedTimestamp:
       output.ModifiedTimestamp !== undefined && output.ModifiedTimestamp !== null
         ? new Date(Math.round(output.ModifiedTimestamp * 1000))
         : undefined,
-    OrganizationId:
-      output.OrganizationId !== undefined && output.OrganizationId !== null ? output.OrganizationId : undefined,
-    RecycleBinFolderId:
-      output.RecycleBinFolderId !== undefined && output.RecycleBinFolderId !== null
-        ? output.RecycleBinFolderId
-        : undefined,
-    RootFolderId: output.RootFolderId !== undefined && output.RootFolderId !== null ? output.RootFolderId : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
+    OrganizationId: __expectString(output.OrganizationId),
+    RecycleBinFolderId: __expectString(output.RecycleBinFolderId),
+    RootFolderId: __expectString(output.RootFolderId),
+    Status: __expectString(output.Status),
     Storage:
       output.Storage !== undefined && output.Storage !== null
         ? deserializeAws_restJson1UserStorageMetadata(output.Storage, context)
         : undefined,
-    Surname: output.Surname !== undefined && output.Surname !== null ? output.Surname : undefined,
-    TimeZoneId: output.TimeZoneId !== undefined && output.TimeZoneId !== null ? output.TimeZoneId : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
-    Username: output.Username !== undefined && output.Username !== null ? output.Username : undefined,
+    Surname: __expectString(output.Surname),
+    TimeZoneId: __expectString(output.TimeZoneId),
+    Type: __expectString(output.Type),
+    Username: __expectString(output.Username),
   } as any;
 };
 
@@ -6566,11 +6545,11 @@ const deserializeAws_restJson1UserActivities = (output: any, context: __SerdeCon
 
 const deserializeAws_restJson1UserMetadata = (output: any, context: __SerdeContext): UserMetadata => {
   return {
-    EmailAddress: output.EmailAddress !== undefined && output.EmailAddress !== null ? output.EmailAddress : undefined,
-    GivenName: output.GivenName !== undefined && output.GivenName !== null ? output.GivenName : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Surname: output.Surname !== undefined && output.Surname !== null ? output.Surname : undefined,
-    Username: output.Username !== undefined && output.Username !== null ? output.Username : undefined,
+    EmailAddress: __expectString(output.EmailAddress),
+    GivenName: __expectString(output.GivenName),
+    Id: __expectString(output.Id),
+    Surname: __expectString(output.Surname),
+    Username: __expectString(output.Username),
   } as any;
 };
 
@@ -6591,10 +6570,7 @@ const deserializeAws_restJson1UserStorageMetadata = (output: any, context: __Ser
       output.StorageRule !== undefined && output.StorageRule !== null
         ? deserializeAws_restJson1StorageRuleType(output.StorageRule, context)
         : undefined,
-    StorageUtilizedInBytes:
-      output.StorageUtilizedInBytes !== undefined && output.StorageUtilizedInBytes !== null
-        ? output.StorageUtilizedInBytes
-        : undefined,
+    StorageUtilizedInBytes: __expectNumber(output.StorageUtilizedInBytes),
   } as any;
 };
 

--- a/clients/client-worklink/protocols/Aws_restJson1.ts
+++ b/clients/client-worklink/protocols/Aws_restJson1.ts
@@ -107,6 +107,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -1087,7 +1089,7 @@ export const deserializeAws_restJson1AssociateWebsiteAuthorizationProviderComman
   };
   const data: any = await parseBody(output.body, context);
   if (data.AuthorizationProviderId !== undefined && data.AuthorizationProviderId !== null) {
-    contents.AuthorizationProviderId = data.AuthorizationProviderId;
+    contents.AuthorizationProviderId = __expectString(data.AuthorizationProviderId);
   }
   return Promise.resolve(contents);
 };
@@ -1182,7 +1184,7 @@ export const deserializeAws_restJson1AssociateWebsiteCertificateAuthorityCommand
   };
   const data: any = await parseBody(output.body, context);
   if (data.WebsiteCaId !== undefined && data.WebsiteCaId !== null) {
-    contents.WebsiteCaId = data.WebsiteCaId;
+    contents.WebsiteCaId = __expectString(data.WebsiteCaId);
   }
   return Promise.resolve(contents);
 };
@@ -1277,7 +1279,7 @@ export const deserializeAws_restJson1CreateFleetCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.FleetArn !== undefined && data.FleetArn !== null) {
-    contents.FleetArn = data.FleetArn;
+    contents.FleetArn = __expectString(data.FleetArn);
   }
   return Promise.resolve(contents);
 };
@@ -1455,7 +1457,7 @@ export const deserializeAws_restJson1DescribeAuditStreamConfigurationCommand = a
   };
   const data: any = await parseBody(output.body, context);
   if (data.AuditStreamArn !== undefined && data.AuditStreamArn !== null) {
-    contents.AuditStreamArn = data.AuditStreamArn;
+    contents.AuditStreamArn = __expectString(data.AuditStreamArn);
   }
   return Promise.resolve(contents);
 };
@@ -1550,7 +1552,7 @@ export const deserializeAws_restJson1DescribeCompanyNetworkConfigurationCommand 
     contents.SubnetIds = deserializeAws_restJson1SubnetIds(data.SubnetIds, context);
   }
   if (data.VpcId !== undefined && data.VpcId !== null) {
-    contents.VpcId = data.VpcId;
+    contents.VpcId = __expectString(data.VpcId);
   }
   return Promise.resolve(contents);
 };
@@ -1651,25 +1653,25 @@ export const deserializeAws_restJson1DescribeDeviceCommand = async (
     contents.LastAccessedTime = new Date(Math.round(data.LastAccessedTime * 1000));
   }
   if (data.Manufacturer !== undefined && data.Manufacturer !== null) {
-    contents.Manufacturer = data.Manufacturer;
+    contents.Manufacturer = __expectString(data.Manufacturer);
   }
   if (data.Model !== undefined && data.Model !== null) {
-    contents.Model = data.Model;
+    contents.Model = __expectString(data.Model);
   }
   if (data.OperatingSystem !== undefined && data.OperatingSystem !== null) {
-    contents.OperatingSystem = data.OperatingSystem;
+    contents.OperatingSystem = __expectString(data.OperatingSystem);
   }
   if (data.OperatingSystemVersion !== undefined && data.OperatingSystemVersion !== null) {
-    contents.OperatingSystemVersion = data.OperatingSystemVersion;
+    contents.OperatingSystemVersion = __expectString(data.OperatingSystemVersion);
   }
   if (data.PatchLevel !== undefined && data.PatchLevel !== null) {
-    contents.PatchLevel = data.PatchLevel;
+    contents.PatchLevel = __expectString(data.PatchLevel);
   }
   if (data.Status !== undefined && data.Status !== null) {
-    contents.Status = data.Status;
+    contents.Status = __expectString(data.Status);
   }
   if (data.Username !== undefined && data.Username !== null) {
-    contents.Username = data.Username;
+    contents.Username = __expectString(data.Username);
   }
   return Promise.resolve(contents);
 };
@@ -1756,7 +1758,7 @@ export const deserializeAws_restJson1DescribeDevicePolicyConfigurationCommand = 
   };
   const data: any = await parseBody(output.body, context);
   if (data.DeviceCaCertificate !== undefined && data.DeviceCaCertificate !== null) {
-    contents.DeviceCaCertificate = data.DeviceCaCertificate;
+    contents.DeviceCaCertificate = __expectString(data.DeviceCaCertificate);
   }
   return Promise.resolve(contents);
 };
@@ -1847,19 +1849,19 @@ export const deserializeAws_restJson1DescribeDomainCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.AcmCertificateArn !== undefined && data.AcmCertificateArn !== null) {
-    contents.AcmCertificateArn = data.AcmCertificateArn;
+    contents.AcmCertificateArn = __expectString(data.AcmCertificateArn);
   }
   if (data.CreatedTime !== undefined && data.CreatedTime !== null) {
     contents.CreatedTime = new Date(Math.round(data.CreatedTime * 1000));
   }
   if (data.DisplayName !== undefined && data.DisplayName !== null) {
-    contents.DisplayName = data.DisplayName;
+    contents.DisplayName = __expectString(data.DisplayName);
   }
   if (data.DomainName !== undefined && data.DomainName !== null) {
-    contents.DomainName = data.DomainName;
+    contents.DomainName = __expectString(data.DomainName);
   }
   if (data.DomainStatus !== undefined && data.DomainStatus !== null) {
-    contents.DomainStatus = data.DomainStatus;
+    contents.DomainStatus = __expectString(data.DomainStatus);
   }
   return Promise.resolve(contents);
 };
@@ -1953,25 +1955,25 @@ export const deserializeAws_restJson1DescribeFleetMetadataCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.CompanyCode !== undefined && data.CompanyCode !== null) {
-    contents.CompanyCode = data.CompanyCode;
+    contents.CompanyCode = __expectString(data.CompanyCode);
   }
   if (data.CreatedTime !== undefined && data.CreatedTime !== null) {
     contents.CreatedTime = new Date(Math.round(data.CreatedTime * 1000));
   }
   if (data.DisplayName !== undefined && data.DisplayName !== null) {
-    contents.DisplayName = data.DisplayName;
+    contents.DisplayName = __expectString(data.DisplayName);
   }
   if (data.FleetName !== undefined && data.FleetName !== null) {
-    contents.FleetName = data.FleetName;
+    contents.FleetName = __expectString(data.FleetName);
   }
   if (data.FleetStatus !== undefined && data.FleetStatus !== null) {
-    contents.FleetStatus = data.FleetStatus;
+    contents.FleetStatus = __expectString(data.FleetStatus);
   }
   if (data.LastUpdatedTime !== undefined && data.LastUpdatedTime !== null) {
     contents.LastUpdatedTime = new Date(Math.round(data.LastUpdatedTime * 1000));
   }
   if (data.OptimizeForEndUserLocation !== undefined && data.OptimizeForEndUserLocation !== null) {
-    contents.OptimizeForEndUserLocation = data.OptimizeForEndUserLocation;
+    contents.OptimizeForEndUserLocation = __expectBoolean(data.OptimizeForEndUserLocation);
   }
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
@@ -2063,13 +2065,13 @@ export const deserializeAws_restJson1DescribeIdentityProviderConfigurationComman
   };
   const data: any = await parseBody(output.body, context);
   if (data.IdentityProviderSamlMetadata !== undefined && data.IdentityProviderSamlMetadata !== null) {
-    contents.IdentityProviderSamlMetadata = data.IdentityProviderSamlMetadata;
+    contents.IdentityProviderSamlMetadata = __expectString(data.IdentityProviderSamlMetadata);
   }
   if (data.IdentityProviderType !== undefined && data.IdentityProviderType !== null) {
-    contents.IdentityProviderType = data.IdentityProviderType;
+    contents.IdentityProviderType = __expectString(data.IdentityProviderType);
   }
   if (data.ServiceProviderSamlMetadata !== undefined && data.ServiceProviderSamlMetadata !== null) {
-    contents.ServiceProviderSamlMetadata = data.ServiceProviderSamlMetadata;
+    contents.ServiceProviderSamlMetadata = __expectString(data.ServiceProviderSamlMetadata);
   }
   return Promise.resolve(contents);
 };
@@ -2158,13 +2160,13 @@ export const deserializeAws_restJson1DescribeWebsiteCertificateAuthorityCommand 
   };
   const data: any = await parseBody(output.body, context);
   if (data.Certificate !== undefined && data.Certificate !== null) {
-    contents.Certificate = data.Certificate;
+    contents.Certificate = __expectString(data.Certificate);
   }
   if (data.CreatedTime !== undefined && data.CreatedTime !== null) {
     contents.CreatedTime = new Date(Math.round(data.CreatedTime * 1000));
   }
   if (data.DisplayName !== undefined && data.DisplayName !== null) {
-    contents.DisplayName = data.DisplayName;
+    contents.DisplayName = __expectString(data.DisplayName);
   }
   return Promise.resolve(contents);
 };
@@ -2512,7 +2514,7 @@ export const deserializeAws_restJson1ListDevicesCommand = async (
     contents.Devices = deserializeAws_restJson1DeviceSummaryList(data.Devices, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2603,7 +2605,7 @@ export const deserializeAws_restJson1ListDomainsCommand = async (
     contents.Domains = deserializeAws_restJson1DomainSummaryList(data.Domains, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2694,7 +2696,7 @@ export const deserializeAws_restJson1ListFleetsCommand = async (
     contents.FleetSummaryList = deserializeAws_restJson1FleetSummaryList(data.FleetSummaryList, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -2829,7 +2831,7 @@ export const deserializeAws_restJson1ListWebsiteAuthorizationProvidersCommand = 
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.WebsiteAuthorizationProviders !== undefined && data.WebsiteAuthorizationProviders !== null) {
     contents.WebsiteAuthorizationProviders = deserializeAws_restJson1WebsiteAuthorizationProvidersSummaryList(
@@ -2923,7 +2925,7 @@ export const deserializeAws_restJson1ListWebsiteCertificateAuthoritiesCommand = 
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.WebsiteCertificateAuthorities !== undefined && data.WebsiteCertificateAuthorities !== null) {
     contents.WebsiteCertificateAuthorities = deserializeAws_restJson1WebsiteCaSummaryList(
@@ -3856,7 +3858,7 @@ const deserializeAws_restJson1InternalServerErrorExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3873,7 +3875,7 @@ const deserializeAws_restJson1InvalidRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3890,7 +3892,7 @@ const deserializeAws_restJson1ResourceAlreadyExistsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3907,7 +3909,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3924,7 +3926,7 @@ const deserializeAws_restJson1TooManyRequestsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3941,7 +3943,7 @@ const deserializeAws_restJson1UnauthorizedExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -3982,8 +3984,8 @@ const serializeAws_restJson1TagMap = (input: { [key: string]: string }, context:
 
 const deserializeAws_restJson1DeviceSummary = (output: any, context: __SerdeContext): DeviceSummary => {
   return {
-    DeviceId: output.DeviceId !== undefined && output.DeviceId !== null ? output.DeviceId : undefined,
-    DeviceStatus: output.DeviceStatus !== undefined && output.DeviceStatus !== null ? output.DeviceStatus : undefined,
+    DeviceId: __expectString(output.DeviceId),
+    DeviceStatus: __expectString(output.DeviceStatus),
   } as any;
 };
 
@@ -4004,9 +4006,9 @@ const deserializeAws_restJson1DomainSummary = (output: any, context: __SerdeCont
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
         : undefined,
-    DisplayName: output.DisplayName !== undefined && output.DisplayName !== null ? output.DisplayName : undefined,
-    DomainName: output.DomainName !== undefined && output.DomainName !== null ? output.DomainName : undefined,
-    DomainStatus: output.DomainStatus !== undefined && output.DomainStatus !== null ? output.DomainStatus : undefined,
+    DisplayName: __expectString(output.DisplayName),
+    DomainName: __expectString(output.DomainName),
+    DomainStatus: __expectString(output.DomainStatus),
   } as any;
 };
 
@@ -4023,15 +4025,15 @@ const deserializeAws_restJson1DomainSummaryList = (output: any, context: __Serde
 
 const deserializeAws_restJson1FleetSummary = (output: any, context: __SerdeContext): FleetSummary => {
   return {
-    CompanyCode: output.CompanyCode !== undefined && output.CompanyCode !== null ? output.CompanyCode : undefined,
+    CompanyCode: __expectString(output.CompanyCode),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
         : undefined,
-    DisplayName: output.DisplayName !== undefined && output.DisplayName !== null ? output.DisplayName : undefined,
-    FleetArn: output.FleetArn !== undefined && output.FleetArn !== null ? output.FleetArn : undefined,
-    FleetName: output.FleetName !== undefined && output.FleetName !== null ? output.FleetName : undefined,
-    FleetStatus: output.FleetStatus !== undefined && output.FleetStatus !== null ? output.FleetStatus : undefined,
+    DisplayName: __expectString(output.DisplayName),
+    FleetArn: __expectString(output.FleetArn),
+    FleetName: __expectString(output.FleetName),
+    FleetStatus: __expectString(output.FleetStatus),
     LastUpdatedTime:
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
         ? new Date(Math.round(output.LastUpdatedTime * 1000))
@@ -4061,7 +4063,7 @@ const deserializeAws_restJson1SecurityGroupIds = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4072,7 +4074,7 @@ const deserializeAws_restJson1SubnetIds = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4083,7 +4085,7 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -4107,19 +4109,13 @@ const deserializeAws_restJson1WebsiteAuthorizationProviderSummary = (
   context: __SerdeContext
 ): WebsiteAuthorizationProviderSummary => {
   return {
-    AuthorizationProviderId:
-      output.AuthorizationProviderId !== undefined && output.AuthorizationProviderId !== null
-        ? output.AuthorizationProviderId
-        : undefined,
-    AuthorizationProviderType:
-      output.AuthorizationProviderType !== undefined && output.AuthorizationProviderType !== null
-        ? output.AuthorizationProviderType
-        : undefined,
+    AuthorizationProviderId: __expectString(output.AuthorizationProviderId),
+    AuthorizationProviderType: __expectString(output.AuthorizationProviderType),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
         : undefined,
-    DomainName: output.DomainName !== undefined && output.DomainName !== null ? output.DomainName : undefined,
+    DomainName: __expectString(output.DomainName),
   } as any;
 };
 
@@ -4129,8 +4125,8 @@ const deserializeAws_restJson1WebsiteCaSummary = (output: any, context: __SerdeC
       output.CreatedTime !== undefined && output.CreatedTime !== null
         ? new Date(Math.round(output.CreatedTime * 1000))
         : undefined,
-    DisplayName: output.DisplayName !== undefined && output.DisplayName !== null ? output.DisplayName : undefined,
-    WebsiteCaId: output.WebsiteCaId !== undefined && output.WebsiteCaId !== null ? output.WebsiteCaId : undefined,
+    DisplayName: __expectString(output.DisplayName),
+    WebsiteCaId: __expectString(output.WebsiteCaId),
   } as any;
 };
 

--- a/clients/client-workmail/protocols/Aws_json1_1.ts
+++ b/clients/client-workmail/protocols/Aws_json1_1.ts
@@ -280,7 +280,12 @@ import {
   User,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -6716,13 +6721,13 @@ const deserializeAws_json1_1AccessControlRule = (output: any, context: __SerdeCo
       output.DateModified !== undefined && output.DateModified !== null
         ? new Date(Math.round(output.DateModified * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    Effect: output.Effect !== undefined && output.Effect !== null ? output.Effect : undefined,
+    Description: __expectString(output.Description),
+    Effect: __expectString(output.Effect),
     IpRanges:
       output.IpRanges !== undefined && output.IpRanges !== null
         ? deserializeAws_json1_1IpRangeList(output.IpRanges, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     NotActions:
       output.NotActions !== undefined && output.NotActions !== null
         ? deserializeAws_json1_1ActionsList(output.NotActions, context)
@@ -6749,7 +6754,7 @@ const deserializeAws_json1_1AccessControlRuleNameList = (output: any, context: _
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6771,7 +6776,7 @@ const deserializeAws_json1_1ActionsList = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6782,7 +6787,7 @@ const deserializeAws_json1_1Aliases = (output: any, context: __SerdeContext): st
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6802,18 +6807,9 @@ const deserializeAws_json1_1AssociateMemberToGroupResponse = (
 
 const deserializeAws_json1_1BookingOptions = (output: any, context: __SerdeContext): BookingOptions => {
   return {
-    AutoAcceptRequests:
-      output.AutoAcceptRequests !== undefined && output.AutoAcceptRequests !== null
-        ? output.AutoAcceptRequests
-        : undefined,
-    AutoDeclineConflictingRequests:
-      output.AutoDeclineConflictingRequests !== undefined && output.AutoDeclineConflictingRequests !== null
-        ? output.AutoDeclineConflictingRequests
-        : undefined,
-    AutoDeclineRecurringRequests:
-      output.AutoDeclineRecurringRequests !== undefined && output.AutoDeclineRecurringRequests !== null
-        ? output.AutoDeclineRecurringRequests
-        : undefined,
+    AutoAcceptRequests: __expectBoolean(output.AutoAcceptRequests),
+    AutoDeclineConflictingRequests: __expectBoolean(output.AutoDeclineConflictingRequests),
+    AutoDeclineRecurringRequests: __expectBoolean(output.AutoDeclineRecurringRequests),
   } as any;
 };
 
@@ -6830,7 +6826,7 @@ const deserializeAws_json1_1CreateAliasResponse = (output: any, context: __Serde
 
 const deserializeAws_json1_1CreateGroupResponse = (output: any, context: __SerdeContext): CreateGroupResponse => {
   return {
-    GroupId: output.GroupId !== undefined && output.GroupId !== null ? output.GroupId : undefined,
+    GroupId: __expectString(output.GroupId),
   } as any;
 };
 
@@ -6839,10 +6835,7 @@ const deserializeAws_json1_1CreateMobileDeviceAccessRuleResponse = (
   context: __SerdeContext
 ): CreateMobileDeviceAccessRuleResponse => {
   return {
-    MobileDeviceAccessRuleId:
-      output.MobileDeviceAccessRuleId !== undefined && output.MobileDeviceAccessRuleId !== null
-        ? output.MobileDeviceAccessRuleId
-        : undefined,
+    MobileDeviceAccessRuleId: __expectString(output.MobileDeviceAccessRuleId),
   } as any;
 };
 
@@ -6851,27 +6844,26 @@ const deserializeAws_json1_1CreateOrganizationResponse = (
   context: __SerdeContext
 ): CreateOrganizationResponse => {
   return {
-    OrganizationId:
-      output.OrganizationId !== undefined && output.OrganizationId !== null ? output.OrganizationId : undefined,
+    OrganizationId: __expectString(output.OrganizationId),
   } as any;
 };
 
 const deserializeAws_json1_1CreateResourceResponse = (output: any, context: __SerdeContext): CreateResourceResponse => {
   return {
-    ResourceId: output.ResourceId !== undefined && output.ResourceId !== null ? output.ResourceId : undefined,
+    ResourceId: __expectString(output.ResourceId),
   } as any;
 };
 
 const deserializeAws_json1_1CreateUserResponse = (output: any, context: __SerdeContext): CreateUserResponse => {
   return {
-    UserId: output.UserId !== undefined && output.UserId !== null ? output.UserId : undefined,
+    UserId: __expectString(output.UserId),
   } as any;
 };
 
 const deserializeAws_json1_1Delegate = (output: any, context: __SerdeContext): Delegate => {
   return {
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Id: __expectString(output.Id),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -6909,9 +6901,8 @@ const deserializeAws_json1_1DeleteOrganizationResponse = (
   context: __SerdeContext
 ): DeleteOrganizationResponse => {
   return {
-    OrganizationId:
-      output.OrganizationId !== undefined && output.OrganizationId !== null ? output.OrganizationId : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    OrganizationId: __expectString(output.OrganizationId),
+    State: __expectString(output.State),
   } as any;
 };
 
@@ -6943,14 +6934,14 @@ const deserializeAws_json1_1DescribeGroupResponse = (output: any, context: __Ser
       output.DisabledDate !== undefined && output.DisabledDate !== null
         ? new Date(Math.round(output.DisabledDate * 1000))
         : undefined,
-    Email: output.Email !== undefined && output.Email !== null ? output.Email : undefined,
+    Email: __expectString(output.Email),
     EnabledDate:
       output.EnabledDate !== undefined && output.EnabledDate !== null
         ? new Date(Math.round(output.EnabledDate * 1000))
         : undefined,
-    GroupId: output.GroupId !== undefined && output.GroupId !== null ? output.GroupId : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    GroupId: __expectString(output.GroupId),
+    Name: __expectString(output.Name),
+    State: __expectString(output.State),
   } as any;
 };
 
@@ -6959,25 +6950,22 @@ const deserializeAws_json1_1DescribeMailboxExportJobResponse = (
   context: __SerdeContext
 ): DescribeMailboxExportJobResponse => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     EndTime:
       output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
-    EntityId: output.EntityId !== undefined && output.EntityId !== null ? output.EntityId : undefined,
-    ErrorInfo: output.ErrorInfo !== undefined && output.ErrorInfo !== null ? output.ErrorInfo : undefined,
-    EstimatedProgress:
-      output.EstimatedProgress !== undefined && output.EstimatedProgress !== null
-        ? output.EstimatedProgress
-        : undefined,
-    KmsKeyArn: output.KmsKeyArn !== undefined && output.KmsKeyArn !== null ? output.KmsKeyArn : undefined,
-    RoleArn: output.RoleArn !== undefined && output.RoleArn !== null ? output.RoleArn : undefined,
-    S3BucketName: output.S3BucketName !== undefined && output.S3BucketName !== null ? output.S3BucketName : undefined,
-    S3Path: output.S3Path !== undefined && output.S3Path !== null ? output.S3Path : undefined,
-    S3Prefix: output.S3Prefix !== undefined && output.S3Prefix !== null ? output.S3Prefix : undefined,
+    EntityId: __expectString(output.EntityId),
+    ErrorInfo: __expectString(output.ErrorInfo),
+    EstimatedProgress: __expectNumber(output.EstimatedProgress),
+    KmsKeyArn: __expectString(output.KmsKeyArn),
+    RoleArn: __expectString(output.RoleArn),
+    S3BucketName: __expectString(output.S3BucketName),
+    S3Path: __expectString(output.S3Path),
+    S3Prefix: __expectString(output.S3Prefix),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
         ? new Date(Math.round(output.StartTime * 1000))
         : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    State: __expectString(output.State),
   } as any;
 };
 
@@ -6986,23 +6974,18 @@ const deserializeAws_json1_1DescribeOrganizationResponse = (
   context: __SerdeContext
 ): DescribeOrganizationResponse => {
   return {
-    ARN: output.ARN !== undefined && output.ARN !== null ? output.ARN : undefined,
-    Alias: output.Alias !== undefined && output.Alias !== null ? output.Alias : undefined,
+    ARN: __expectString(output.ARN),
+    Alias: __expectString(output.Alias),
     CompletedDate:
       output.CompletedDate !== undefined && output.CompletedDate !== null
         ? new Date(Math.round(output.CompletedDate * 1000))
         : undefined,
-    DefaultMailDomain:
-      output.DefaultMailDomain !== undefined && output.DefaultMailDomain !== null
-        ? output.DefaultMailDomain
-        : undefined,
-    DirectoryId: output.DirectoryId !== undefined && output.DirectoryId !== null ? output.DirectoryId : undefined,
-    DirectoryType:
-      output.DirectoryType !== undefined && output.DirectoryType !== null ? output.DirectoryType : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    OrganizationId:
-      output.OrganizationId !== undefined && output.OrganizationId !== null ? output.OrganizationId : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    DefaultMailDomain: __expectString(output.DefaultMailDomain),
+    DirectoryId: __expectString(output.DirectoryId),
+    DirectoryType: __expectString(output.DirectoryType),
+    ErrorMessage: __expectString(output.ErrorMessage),
+    OrganizationId: __expectString(output.OrganizationId),
+    State: __expectString(output.State),
   } as any;
 };
 
@@ -7019,15 +7002,15 @@ const deserializeAws_json1_1DescribeResourceResponse = (
       output.DisabledDate !== undefined && output.DisabledDate !== null
         ? new Date(Math.round(output.DisabledDate * 1000))
         : undefined,
-    Email: output.Email !== undefined && output.Email !== null ? output.Email : undefined,
+    Email: __expectString(output.Email),
     EnabledDate:
       output.EnabledDate !== undefined && output.EnabledDate !== null
         ? new Date(Math.round(output.EnabledDate * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    ResourceId: output.ResourceId !== undefined && output.ResourceId !== null ? output.ResourceId : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Name: __expectString(output.Name),
+    ResourceId: __expectString(output.ResourceId),
+    State: __expectString(output.State),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -7037,16 +7020,16 @@ const deserializeAws_json1_1DescribeUserResponse = (output: any, context: __Serd
       output.DisabledDate !== undefined && output.DisabledDate !== null
         ? new Date(Math.round(output.DisabledDate * 1000))
         : undefined,
-    DisplayName: output.DisplayName !== undefined && output.DisplayName !== null ? output.DisplayName : undefined,
-    Email: output.Email !== undefined && output.Email !== null ? output.Email : undefined,
+    DisplayName: __expectString(output.DisplayName),
+    Email: __expectString(output.Email),
     EnabledDate:
       output.EnabledDate !== undefined && output.EnabledDate !== null
         ? new Date(Math.round(output.EnabledDate * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    UserId: output.UserId !== undefined && output.UserId !== null ? output.UserId : undefined,
-    UserRole: output.UserRole !== undefined && output.UserRole !== null ? output.UserRole : undefined,
+    Name: __expectString(output.Name),
+    State: __expectString(output.State),
+    UserId: __expectString(output.UserId),
+    UserRole: __expectString(output.UserRole),
   } as any;
 };
 
@@ -7057,7 +7040,7 @@ const deserializeAws_json1_1DeviceModelList = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7068,7 +7051,7 @@ const deserializeAws_json1_1DeviceOperatingSystemList = (output: any, context: _
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7079,7 +7062,7 @@ const deserializeAws_json1_1DeviceTypeList = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7090,7 +7073,7 @@ const deserializeAws_json1_1DeviceUserAgentList = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7099,7 +7082,7 @@ const deserializeAws_json1_1DirectoryInUseException = (
   context: __SerdeContext
 ): DirectoryInUseException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7108,7 +7091,7 @@ const deserializeAws_json1_1DirectoryServiceAuthenticationFailedException = (
   context: __SerdeContext
 ): DirectoryServiceAuthenticationFailedException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7117,7 +7100,7 @@ const deserializeAws_json1_1DirectoryUnavailableException = (
   context: __SerdeContext
 ): DirectoryUnavailableException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7140,7 +7123,7 @@ const deserializeAws_json1_1EmailAddressInUseException = (
   context: __SerdeContext
 ): EmailAddressInUseException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7149,7 +7132,7 @@ const deserializeAws_json1_1EntityAlreadyRegisteredException = (
   context: __SerdeContext
 ): EntityAlreadyRegisteredException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7158,21 +7141,21 @@ const deserializeAws_json1_1EntityNotFoundException = (
   context: __SerdeContext
 ): EntityNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1EntityStateException = (output: any, context: __SerdeContext): EntityStateException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1FolderConfiguration = (output: any, context: __SerdeContext): FolderConfiguration => {
   return {
-    Action: output.Action !== undefined && output.Action !== null ? output.Action : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Period: output.Period !== undefined && output.Period !== null ? output.Period : undefined,
+    Action: __expectString(output.Action),
+    Name: __expectString(output.Name),
+    Period: __expectNumber(output.Period),
   } as any;
 };
 
@@ -7192,7 +7175,7 @@ const deserializeAws_json1_1GetAccessControlEffectResponse = (
   context: __SerdeContext
 ): GetAccessControlEffectResponse => {
   return {
-    Effect: output.Effect !== undefined && output.Effect !== null ? output.Effect : undefined,
+    Effect: __expectString(output.Effect),
     MatchedRules:
       output.MatchedRules !== undefined && output.MatchedRules !== null
         ? deserializeAws_json1_1AccessControlRuleNameList(output.MatchedRules, context)
@@ -7205,13 +7188,13 @@ const deserializeAws_json1_1GetDefaultRetentionPolicyResponse = (
   context: __SerdeContext
 ): GetDefaultRetentionPolicyResponse => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     FolderConfigurations:
       output.FolderConfigurations !== undefined && output.FolderConfigurations !== null
         ? deserializeAws_json1_1FolderConfigurations(output.FolderConfigurations, context)
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -7220,8 +7203,8 @@ const deserializeAws_json1_1GetMailboxDetailsResponse = (
   context: __SerdeContext
 ): GetMailboxDetailsResponse => {
   return {
-    MailboxQuota: output.MailboxQuota !== undefined && output.MailboxQuota !== null ? output.MailboxQuota : undefined,
-    MailboxSize: output.MailboxSize !== undefined && output.MailboxSize !== null ? output.MailboxSize : undefined,
+    MailboxQuota: __expectNumber(output.MailboxQuota),
+    MailboxSize: __expectNumber(output.MailboxSize),
   } as any;
 };
 
@@ -7230,7 +7213,7 @@ const deserializeAws_json1_1GetMobileDeviceAccessEffectResponse = (
   context: __SerdeContext
 ): GetMobileDeviceAccessEffectResponse => {
   return {
-    Effect: output.Effect !== undefined && output.Effect !== null ? output.Effect : undefined,
+    Effect: __expectString(output.Effect),
     MatchedRules:
       output.MatchedRules !== undefined && output.MatchedRules !== null
         ? deserializeAws_json1_1MobileDeviceAccessMatchedRuleList(output.MatchedRules, context)
@@ -7244,14 +7227,14 @@ const deserializeAws_json1_1Group = (output: any, context: __SerdeContext): Grou
       output.DisabledDate !== undefined && output.DisabledDate !== null
         ? new Date(Math.round(output.DisabledDate * 1000))
         : undefined,
-    Email: output.Email !== undefined && output.Email !== null ? output.Email : undefined,
+    Email: __expectString(output.Email),
     EnabledDate:
       output.EnabledDate !== undefined && output.EnabledDate !== null
         ? new Date(Math.round(output.EnabledDate * 1000))
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
+    State: __expectString(output.State),
   } as any;
 };
 
@@ -7271,7 +7254,7 @@ const deserializeAws_json1_1InvalidConfigurationException = (
   context: __SerdeContext
 ): InvalidConfigurationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7280,7 +7263,7 @@ const deserializeAws_json1_1InvalidParameterException = (
   context: __SerdeContext
 ): InvalidParameterException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7289,7 +7272,7 @@ const deserializeAws_json1_1InvalidPasswordException = (
   context: __SerdeContext
 ): InvalidPasswordException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7300,7 +7283,7 @@ const deserializeAws_json1_1IpRangeList = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7317,7 +7300,7 @@ const deserializeAws_json1_1Jobs = (output: any, context: __SerdeContext): Mailb
 
 const deserializeAws_json1_1LimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7339,7 +7322,7 @@ const deserializeAws_json1_1ListAliasesResponse = (output: any, context: __Serde
       output.Aliases !== undefined && output.Aliases !== null
         ? deserializeAws_json1_1Aliases(output.Aliases, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -7352,7 +7335,7 @@ const deserializeAws_json1_1ListGroupMembersResponse = (
       output.Members !== undefined && output.Members !== null
         ? deserializeAws_json1_1Members(output.Members, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -7362,7 +7345,7 @@ const deserializeAws_json1_1ListGroupsResponse = (output: any, context: __SerdeC
       output.Groups !== undefined && output.Groups !== null
         ? deserializeAws_json1_1Groups(output.Groups, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -7373,7 +7356,7 @@ const deserializeAws_json1_1ListMailboxExportJobsResponse = (
   return {
     Jobs:
       output.Jobs !== undefined && output.Jobs !== null ? deserializeAws_json1_1Jobs(output.Jobs, context) : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -7382,7 +7365,7 @@ const deserializeAws_json1_1ListMailboxPermissionsResponse = (
   context: __SerdeContext
 ): ListMailboxPermissionsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Permissions:
       output.Permissions !== undefined && output.Permissions !== null
         ? deserializeAws_json1_1Permissions(output.Permissions, context)
@@ -7407,7 +7390,7 @@ const deserializeAws_json1_1ListOrganizationsResponse = (
   context: __SerdeContext
 ): ListOrganizationsResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     OrganizationSummaries:
       output.OrganizationSummaries !== undefined && output.OrganizationSummaries !== null
         ? deserializeAws_json1_1OrganizationSummaries(output.OrganizationSummaries, context)
@@ -7424,13 +7407,13 @@ const deserializeAws_json1_1ListResourceDelegatesResponse = (
       output.Delegates !== undefined && output.Delegates !== null
         ? deserializeAws_json1_1ResourceDelegates(output.Delegates, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
 const deserializeAws_json1_1ListResourcesResponse = (output: any, context: __SerdeContext): ListResourcesResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Resources:
       output.Resources !== undefined && output.Resources !== null
         ? deserializeAws_json1_1Resources(output.Resources, context)
@@ -7452,7 +7435,7 @@ const deserializeAws_json1_1ListTagsForResourceResponse = (
 
 const deserializeAws_json1_1ListUsersResponse = (output: any, context: __SerdeContext): ListUsersResponse => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Users:
       output.Users !== undefined && output.Users !== null
         ? deserializeAws_json1_1Users(output.Users, context)
@@ -7462,22 +7445,19 @@ const deserializeAws_json1_1ListUsersResponse = (output: any, context: __SerdeCo
 
 const deserializeAws_json1_1MailboxExportJob = (output: any, context: __SerdeContext): MailboxExportJob => {
   return {
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     EndTime:
       output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
-    EntityId: output.EntityId !== undefined && output.EntityId !== null ? output.EntityId : undefined,
-    EstimatedProgress:
-      output.EstimatedProgress !== undefined && output.EstimatedProgress !== null
-        ? output.EstimatedProgress
-        : undefined,
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
-    S3BucketName: output.S3BucketName !== undefined && output.S3BucketName !== null ? output.S3BucketName : undefined,
-    S3Path: output.S3Path !== undefined && output.S3Path !== null ? output.S3Path : undefined,
+    EntityId: __expectString(output.EntityId),
+    EstimatedProgress: __expectNumber(output.EstimatedProgress),
+    JobId: __expectString(output.JobId),
+    S3BucketName: __expectString(output.S3BucketName),
+    S3Path: __expectString(output.S3Path),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
         ? new Date(Math.round(output.StartTime * 1000))
         : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    State: __expectString(output.State),
   } as any;
 };
 
@@ -7486,7 +7466,7 @@ const deserializeAws_json1_1MailDomainNotFoundException = (
   context: __SerdeContext
 ): MailDomainNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7495,7 +7475,7 @@ const deserializeAws_json1_1MailDomainStateException = (
   context: __SerdeContext
 ): MailDomainStateException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7509,10 +7489,10 @@ const deserializeAws_json1_1Member = (output: any, context: __SerdeContext): Mem
       output.EnabledDate !== undefined && output.EnabledDate !== null
         ? new Date(Math.round(output.EnabledDate * 1000))
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
+    State: __expectString(output.State),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -7532,11 +7512,8 @@ const deserializeAws_json1_1MobileDeviceAccessMatchedRule = (
   context: __SerdeContext
 ): MobileDeviceAccessMatchedRule => {
   return {
-    MobileDeviceAccessRuleId:
-      output.MobileDeviceAccessRuleId !== undefined && output.MobileDeviceAccessRuleId !== null
-        ? output.MobileDeviceAccessRuleId
-        : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    MobileDeviceAccessRuleId: __expectString(output.MobileDeviceAccessRuleId),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -7564,7 +7541,7 @@ const deserializeAws_json1_1MobileDeviceAccessRule = (output: any, context: __Se
       output.DateModified !== undefined && output.DateModified !== null
         ? new Date(Math.round(output.DateModified * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
+    Description: __expectString(output.Description),
     DeviceModels:
       output.DeviceModels !== undefined && output.DeviceModels !== null
         ? deserializeAws_json1_1DeviceModelList(output.DeviceModels, context)
@@ -7581,12 +7558,9 @@ const deserializeAws_json1_1MobileDeviceAccessRule = (output: any, context: __Se
       output.DeviceUserAgents !== undefined && output.DeviceUserAgents !== null
         ? deserializeAws_json1_1DeviceUserAgentList(output.DeviceUserAgents, context)
         : undefined,
-    Effect: output.Effect !== undefined && output.Effect !== null ? output.Effect : undefined,
-    MobileDeviceAccessRuleId:
-      output.MobileDeviceAccessRuleId !== undefined && output.MobileDeviceAccessRuleId !== null
-        ? output.MobileDeviceAccessRuleId
-        : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Effect: __expectString(output.Effect),
+    MobileDeviceAccessRuleId: __expectString(output.MobileDeviceAccessRuleId),
+    Name: __expectString(output.Name),
     NotDeviceModels:
       output.NotDeviceModels !== undefined && output.NotDeviceModels !== null
         ? deserializeAws_json1_1DeviceModelList(output.NotDeviceModels, context)
@@ -7625,7 +7599,7 @@ const deserializeAws_json1_1NameAvailabilityException = (
   context: __SerdeContext
 ): NameAvailabilityException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7634,7 +7608,7 @@ const deserializeAws_json1_1OrganizationNotFoundException = (
   context: __SerdeContext
 ): OrganizationNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7643,7 +7617,7 @@ const deserializeAws_json1_1OrganizationStateException = (
   context: __SerdeContext
 ): OrganizationStateException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7660,22 +7634,18 @@ const deserializeAws_json1_1OrganizationSummaries = (output: any, context: __Ser
 
 const deserializeAws_json1_1OrganizationSummary = (output: any, context: __SerdeContext): OrganizationSummary => {
   return {
-    Alias: output.Alias !== undefined && output.Alias !== null ? output.Alias : undefined,
-    DefaultMailDomain:
-      output.DefaultMailDomain !== undefined && output.DefaultMailDomain !== null
-        ? output.DefaultMailDomain
-        : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    OrganizationId:
-      output.OrganizationId !== undefined && output.OrganizationId !== null ? output.OrganizationId : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    Alias: __expectString(output.Alias),
+    DefaultMailDomain: __expectString(output.DefaultMailDomain),
+    ErrorMessage: __expectString(output.ErrorMessage),
+    OrganizationId: __expectString(output.OrganizationId),
+    State: __expectString(output.State),
   } as any;
 };
 
 const deserializeAws_json1_1Permission = (output: any, context: __SerdeContext): Permission => {
   return {
-    GranteeId: output.GranteeId !== undefined && output.GranteeId !== null ? output.GranteeId : undefined,
-    GranteeType: output.GranteeType !== undefined && output.GranteeType !== null ? output.GranteeType : undefined,
+    GranteeId: __expectString(output.GranteeId),
+    GranteeType: __expectString(output.GranteeType),
     PermissionValues:
       output.PermissionValues !== undefined && output.PermissionValues !== null
         ? deserializeAws_json1_1PermissionValues(output.PermissionValues, context)
@@ -7701,7 +7671,7 @@ const deserializeAws_json1_1PermissionValues = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -7735,7 +7705,7 @@ const deserializeAws_json1_1RegisterToWorkMailResponse = (
 
 const deserializeAws_json1_1ReservedNameException = (output: any, context: __SerdeContext): ReservedNameException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7749,15 +7719,15 @@ const deserializeAws_json1_1Resource = (output: any, context: __SerdeContext): R
       output.DisabledDate !== undefined && output.DisabledDate !== null
         ? new Date(Math.round(output.DisabledDate * 1000))
         : undefined,
-    Email: output.Email !== undefined && output.Email !== null ? output.Email : undefined,
+    Email: __expectString(output.Email),
     EnabledDate:
       output.EnabledDate !== undefined && output.EnabledDate !== null
         ? new Date(Math.round(output.EnabledDate * 1000))
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
+    State: __expectString(output.State),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -7777,7 +7747,7 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7797,14 +7767,14 @@ const deserializeAws_json1_1StartMailboxExportJobResponse = (
   context: __SerdeContext
 ): StartMailboxExportJobResponse => {
   return {
-    JobId: output.JobId !== undefined && output.JobId !== null ? output.JobId : undefined,
+    JobId: __expectString(output.JobId),
   } as any;
 };
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -7825,7 +7795,7 @@ const deserializeAws_json1_1TagResourceResponse = (output: any, context: __Serde
 
 const deserializeAws_json1_1TooManyTagsException = (output: any, context: __SerdeContext): TooManyTagsException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7834,7 +7804,7 @@ const deserializeAws_json1_1UnsupportedOperationException = (
   context: __SerdeContext
 ): UnsupportedOperationException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
@@ -7873,16 +7843,16 @@ const deserializeAws_json1_1User = (output: any, context: __SerdeContext): User 
       output.DisabledDate !== undefined && output.DisabledDate !== null
         ? new Date(Math.round(output.DisabledDate * 1000))
         : undefined,
-    DisplayName: output.DisplayName !== undefined && output.DisplayName !== null ? output.DisplayName : undefined,
-    Email: output.Email !== undefined && output.Email !== null ? output.Email : undefined,
+    DisplayName: __expectString(output.DisplayName),
+    Email: __expectString(output.Email),
     EnabledDate:
       output.EnabledDate !== undefined && output.EnabledDate !== null
         ? new Date(Math.round(output.EnabledDate * 1000))
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    UserRole: output.UserRole !== undefined && output.UserRole !== null ? output.UserRole : undefined,
+    Id: __expectString(output.Id),
+    Name: __expectString(output.Name),
+    State: __expectString(output.State),
+    UserRole: __expectString(output.UserRole),
   } as any;
 };
 
@@ -7893,7 +7863,7 @@ const deserializeAws_json1_1UserIdList = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 

--- a/clients/client-workmailmessageflow/protocols/Aws_restJson1.ts
+++ b/clients/client-workmailmessageflow/protocols/Aws_restJson1.ts
@@ -17,6 +17,7 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
 import {
@@ -228,7 +229,7 @@ const deserializeAws_restJson1InvalidContentLocationResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -245,7 +246,7 @@ const deserializeAws_restJson1MessageFrozenResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -262,7 +263,7 @@ const deserializeAws_restJson1MessageRejectedResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };
@@ -279,7 +280,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.message !== undefined && data.message !== null) {
-    contents.message = data.message;
+    contents.message = __expectString(data.message);
   }
   return contents;
 };

--- a/clients/client-workspaces/protocols/Aws_json1_1.ts
+++ b/clients/client-workspaces/protocols/Aws_json1_1.ts
@@ -308,7 +308,12 @@ import {
   WorkspacesIpGroup,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -6088,26 +6093,17 @@ const serializeAws_json1_1WorkspaceRequestList = (input: WorkspaceRequest[], con
 
 const deserializeAws_json1_1AccessDeniedException = (output: any, context: __SerdeContext): AccessDeniedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1AccountModification = (output: any, context: __SerdeContext): AccountModification => {
   return {
-    DedicatedTenancyManagementCidrRange:
-      output.DedicatedTenancyManagementCidrRange !== undefined && output.DedicatedTenancyManagementCidrRange !== null
-        ? output.DedicatedTenancyManagementCidrRange
-        : undefined,
-    DedicatedTenancySupport:
-      output.DedicatedTenancySupport !== undefined && output.DedicatedTenancySupport !== null
-        ? output.DedicatedTenancySupport
-        : undefined,
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    ModificationState:
-      output.ModificationState !== undefined && output.ModificationState !== null
-        ? output.ModificationState
-        : undefined,
+    DedicatedTenancyManagementCidrRange: __expectString(output.DedicatedTenancyManagementCidrRange),
+    DedicatedTenancySupport: __expectString(output.DedicatedTenancySupport),
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
+    ModificationState: __expectString(output.ModificationState),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
         ? new Date(Math.round(output.StartTime * 1000))
@@ -6131,10 +6127,7 @@ const deserializeAws_json1_1AssociateConnectionAliasResult = (
   context: __SerdeContext
 ): AssociateConnectionAliasResult => {
   return {
-    ConnectionIdentifier:
-      output.ConnectionIdentifier !== undefined && output.ConnectionIdentifier !== null
-        ? output.ConnectionIdentifier
-        : undefined,
+    ConnectionIdentifier: __expectString(output.ConnectionIdentifier),
   } as any;
 };
 
@@ -6162,8 +6155,7 @@ const deserializeAws_json1_1BundleList = (output: any, context: __SerdeContext):
 
 const deserializeAws_json1_1ClientProperties = (output: any, context: __SerdeContext): ClientProperties => {
   return {
-    ReconnectEnabled:
-      output.ReconnectEnabled !== undefined && output.ReconnectEnabled !== null ? output.ReconnectEnabled : undefined,
+    ReconnectEnabled: __expectString(output.ReconnectEnabled),
   } as any;
 };
 
@@ -6184,28 +6176,26 @@ const deserializeAws_json1_1ClientPropertiesResult = (output: any, context: __Se
       output.ClientProperties !== undefined && output.ClientProperties !== null
         ? deserializeAws_json1_1ClientProperties(output.ClientProperties, context)
         : undefined,
-    ResourceId: output.ResourceId !== undefined && output.ResourceId !== null ? output.ResourceId : undefined,
+    ResourceId: __expectString(output.ResourceId),
   } as any;
 };
 
 const deserializeAws_json1_1ComputeType = (output: any, context: __SerdeContext): ComputeType => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
 const deserializeAws_json1_1ConnectionAlias = (output: any, context: __SerdeContext): ConnectionAlias => {
   return {
-    AliasId: output.AliasId !== undefined && output.AliasId !== null ? output.AliasId : undefined,
+    AliasId: __expectString(output.AliasId),
     Associations:
       output.Associations !== undefined && output.Associations !== null
         ? deserializeAws_json1_1ConnectionAliasAssociationList(output.Associations, context)
         : undefined,
-    ConnectionString:
-      output.ConnectionString !== undefined && output.ConnectionString !== null ? output.ConnectionString : undefined,
-    OwnerAccountId:
-      output.OwnerAccountId !== undefined && output.OwnerAccountId !== null ? output.OwnerAccountId : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    ConnectionString: __expectString(output.ConnectionString),
+    OwnerAccountId: __expectString(output.OwnerAccountId),
+    State: __expectString(output.State),
   } as any;
 };
 
@@ -6214,19 +6204,10 @@ const deserializeAws_json1_1ConnectionAliasAssociation = (
   context: __SerdeContext
 ): ConnectionAliasAssociation => {
   return {
-    AssociatedAccountId:
-      output.AssociatedAccountId !== undefined && output.AssociatedAccountId !== null
-        ? output.AssociatedAccountId
-        : undefined,
-    AssociationStatus:
-      output.AssociationStatus !== undefined && output.AssociationStatus !== null
-        ? output.AssociationStatus
-        : undefined,
-    ConnectionIdentifier:
-      output.ConnectionIdentifier !== undefined && output.ConnectionIdentifier !== null
-        ? output.ConnectionIdentifier
-        : undefined,
-    ResourceId: output.ResourceId !== undefined && output.ResourceId !== null ? output.ResourceId : undefined,
+    AssociatedAccountId: __expectString(output.AssociatedAccountId),
+    AssociationStatus: __expectString(output.AssociationStatus),
+    ConnectionIdentifier: __expectString(output.ConnectionIdentifier),
+    ResourceId: __expectString(output.ResourceId),
   } as any;
 };
 
@@ -6260,10 +6241,8 @@ const deserializeAws_json1_1ConnectionAliasPermission = (
   context: __SerdeContext
 ): ConnectionAliasPermission => {
   return {
-    AllowAssociation:
-      output.AllowAssociation !== undefined && output.AllowAssociation !== null ? output.AllowAssociation : undefined,
-    SharedAccountId:
-      output.SharedAccountId !== undefined && output.SharedAccountId !== null ? output.SharedAccountId : undefined,
+    AllowAssociation: __expectBoolean(output.AllowAssociation),
+    SharedAccountId: __expectString(output.SharedAccountId),
   } as any;
 };
 
@@ -6286,7 +6265,7 @@ const deserializeAws_json1_1CopyWorkspaceImageResult = (
   context: __SerdeContext
 ): CopyWorkspaceImageResult => {
   return {
-    ImageId: output.ImageId !== undefined && output.ImageId !== null ? output.ImageId : undefined,
+    ImageId: __expectString(output.ImageId),
   } as any;
 };
 
@@ -6295,13 +6274,13 @@ const deserializeAws_json1_1CreateConnectionAliasResult = (
   context: __SerdeContext
 ): CreateConnectionAliasResult => {
   return {
-    AliasId: output.AliasId !== undefined && output.AliasId !== null ? output.AliasId : undefined,
+    AliasId: __expectString(output.AliasId),
   } as any;
 };
 
 const deserializeAws_json1_1CreateIpGroupResult = (output: any, context: __SerdeContext): CreateIpGroupResult => {
   return {
-    GroupId: output.GroupId !== undefined && output.GroupId !== null ? output.GroupId : undefined,
+    GroupId: __expectString(output.GroupId),
   } as any;
 };
 
@@ -6341,7 +6320,7 @@ const deserializeAws_json1_1DedicatedTenancyCidrRangeList = (output: any, contex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6350,25 +6329,12 @@ const deserializeAws_json1_1DefaultWorkspaceCreationProperties = (
   context: __SerdeContext
 ): DefaultWorkspaceCreationProperties => {
   return {
-    CustomSecurityGroupId:
-      output.CustomSecurityGroupId !== undefined && output.CustomSecurityGroupId !== null
-        ? output.CustomSecurityGroupId
-        : undefined,
-    DefaultOu: output.DefaultOu !== undefined && output.DefaultOu !== null ? output.DefaultOu : undefined,
-    EnableInternetAccess:
-      output.EnableInternetAccess !== undefined && output.EnableInternetAccess !== null
-        ? output.EnableInternetAccess
-        : undefined,
-    EnableMaintenanceMode:
-      output.EnableMaintenanceMode !== undefined && output.EnableMaintenanceMode !== null
-        ? output.EnableMaintenanceMode
-        : undefined,
-    EnableWorkDocs:
-      output.EnableWorkDocs !== undefined && output.EnableWorkDocs !== null ? output.EnableWorkDocs : undefined,
-    UserEnabledAsLocalAdministrator:
-      output.UserEnabledAsLocalAdministrator !== undefined && output.UserEnabledAsLocalAdministrator !== null
-        ? output.UserEnabledAsLocalAdministrator
-        : undefined,
+    CustomSecurityGroupId: __expectString(output.CustomSecurityGroupId),
+    DefaultOu: __expectString(output.DefaultOu),
+    EnableInternetAccess: __expectBoolean(output.EnableInternetAccess),
+    EnableMaintenanceMode: __expectBoolean(output.EnableMaintenanceMode),
+    EnableWorkDocs: __expectBoolean(output.EnableWorkDocs),
+    UserEnabledAsLocalAdministrator: __expectBoolean(output.UserEnabledAsLocalAdministrator),
   } as any;
 };
 
@@ -6417,20 +6383,14 @@ const deserializeAws_json1_1DescribeAccountModificationsResult = (
       output.AccountModifications !== undefined && output.AccountModifications !== null
         ? deserializeAws_json1_1AccountModificationList(output.AccountModifications, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
 const deserializeAws_json1_1DescribeAccountResult = (output: any, context: __SerdeContext): DescribeAccountResult => {
   return {
-    DedicatedTenancyManagementCidrRange:
-      output.DedicatedTenancyManagementCidrRange !== undefined && output.DedicatedTenancyManagementCidrRange !== null
-        ? output.DedicatedTenancyManagementCidrRange
-        : undefined,
-    DedicatedTenancySupport:
-      output.DedicatedTenancySupport !== undefined && output.DedicatedTenancySupport !== null
-        ? output.DedicatedTenancySupport
-        : undefined,
+    DedicatedTenancyManagementCidrRange: __expectString(output.DedicatedTenancyManagementCidrRange),
+    DedicatedTenancySupport: __expectString(output.DedicatedTenancySupport),
   } as any;
 };
 
@@ -6455,7 +6415,7 @@ const deserializeAws_json1_1DescribeConnectionAliasesResult = (
       output.ConnectionAliases !== undefined && output.ConnectionAliases !== null
         ? deserializeAws_json1_1ConnectionAliasList(output.ConnectionAliases, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -6464,18 +6424,18 @@ const deserializeAws_json1_1DescribeConnectionAliasPermissionsResult = (
   context: __SerdeContext
 ): DescribeConnectionAliasPermissionsResult => {
   return {
-    AliasId: output.AliasId !== undefined && output.AliasId !== null ? output.AliasId : undefined,
+    AliasId: __expectString(output.AliasId),
     ConnectionAliasPermissions:
       output.ConnectionAliasPermissions !== undefined && output.ConnectionAliasPermissions !== null
         ? deserializeAws_json1_1ConnectionAliasPermissions(output.ConnectionAliasPermissions, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
 const deserializeAws_json1_1DescribeIpGroupsResult = (output: any, context: __SerdeContext): DescribeIpGroupsResult => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Result:
       output.Result !== undefined && output.Result !== null
         ? deserializeAws_json1_1WorkspacesIpGroupsList(output.Result, context)
@@ -6501,7 +6461,7 @@ const deserializeAws_json1_1DescribeWorkspaceBundlesResult = (
       output.Bundles !== undefined && output.Bundles !== null
         ? deserializeAws_json1_1BundleList(output.Bundles, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -6514,7 +6474,7 @@ const deserializeAws_json1_1DescribeWorkspaceDirectoriesResult = (
       output.Directories !== undefined && output.Directories !== null
         ? deserializeAws_json1_1DirectoryList(output.Directories, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -6523,12 +6483,12 @@ const deserializeAws_json1_1DescribeWorkspaceImagePermissionsResult = (
   context: __SerdeContext
 ): DescribeWorkspaceImagePermissionsResult => {
   return {
-    ImageId: output.ImageId !== undefined && output.ImageId !== null ? output.ImageId : undefined,
+    ImageId: __expectString(output.ImageId),
     ImagePermissions:
       output.ImagePermissions !== undefined && output.ImagePermissions !== null
         ? deserializeAws_json1_1ImagePermissions(output.ImagePermissions, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -6541,7 +6501,7 @@ const deserializeAws_json1_1DescribeWorkspaceImagesResult = (
       output.Images !== undefined && output.Images !== null
         ? deserializeAws_json1_1WorkspaceImageList(output.Images, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
@@ -6550,7 +6510,7 @@ const deserializeAws_json1_1DescribeWorkspacesConnectionStatusResult = (
   context: __SerdeContext
 ): DescribeWorkspacesConnectionStatusResult => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     WorkspacesConnectionStatus:
       output.WorkspacesConnectionStatus !== undefined && output.WorkspacesConnectionStatus !== null
         ? deserializeAws_json1_1WorkspaceConnectionStatusList(output.WorkspacesConnectionStatus, context)
@@ -6579,7 +6539,7 @@ const deserializeAws_json1_1DescribeWorkspacesResult = (
   context: __SerdeContext
 ): DescribeWorkspacesResult => {
   return {
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
     Workspaces:
       output.Workspaces !== undefined && output.Workspaces !== null
         ? deserializeAws_json1_1WorkspaceList(output.Workspaces, context)
@@ -6619,7 +6579,7 @@ const deserializeAws_json1_1DnsIpAddresses = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6628,8 +6588,8 @@ const deserializeAws_json1_1FailedCreateWorkspaceRequest = (
   context: __SerdeContext
 ): FailedCreateWorkspaceRequest => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
     WorkspaceRequest:
       output.WorkspaceRequest !== undefined && output.WorkspaceRequest !== null
         ? deserializeAws_json1_1WorkspaceRequest(output.WorkspaceRequest, context)
@@ -6726,16 +6686,15 @@ const deserializeAws_json1_1FailedWorkspaceChangeRequest = (
   context: __SerdeContext
 ): FailedWorkspaceChangeRequest => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    WorkspaceId: output.WorkspaceId !== undefined && output.WorkspaceId !== null ? output.WorkspaceId : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
+    WorkspaceId: __expectString(output.WorkspaceId),
   } as any;
 };
 
 const deserializeAws_json1_1ImagePermission = (output: any, context: __SerdeContext): ImagePermission => {
   return {
-    SharedAccountId:
-      output.SharedAccountId !== undefined && output.SharedAccountId !== null ? output.SharedAccountId : undefined,
+    SharedAccountId: __expectString(output.SharedAccountId),
   } as any;
 };
 
@@ -6755,7 +6714,7 @@ const deserializeAws_json1_1ImportWorkspaceImageResult = (
   context: __SerdeContext
 ): ImportWorkspaceImageResult => {
   return {
-    ImageId: output.ImageId !== undefined && output.ImageId !== null ? output.ImageId : undefined,
+    ImageId: __expectString(output.ImageId),
   } as any;
 };
 
@@ -6764,7 +6723,7 @@ const deserializeAws_json1_1InvalidParameterValuesException = (
   context: __SerdeContext
 ): InvalidParameterValuesException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6773,7 +6732,7 @@ const deserializeAws_json1_1InvalidResourceStateException = (
   context: __SerdeContext
 ): InvalidResourceStateException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6784,14 +6743,14 @@ const deserializeAws_json1_1IpGroupIdList = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1IpRuleItem = (output: any, context: __SerdeContext): IpRuleItem => {
   return {
-    ipRule: output.ipRule !== undefined && output.ipRule !== null ? output.ipRule : undefined,
-    ruleDesc: output.ruleDesc !== undefined && output.ruleDesc !== null ? output.ruleDesc : undefined,
+    ipRule: __expectString(output.ipRule),
+    ruleDesc: __expectString(output.ruleDesc),
   } as any;
 };
 
@@ -6815,27 +6774,21 @@ const deserializeAws_json1_1ListAvailableManagementCidrRangesResult = (
       output.ManagementCidrRanges !== undefined && output.ManagementCidrRanges !== null
         ? deserializeAws_json1_1DedicatedTenancyCidrRangeList(output.ManagementCidrRanges, context)
         : undefined,
-    NextToken: output.NextToken !== undefined && output.NextToken !== null ? output.NextToken : undefined,
+    NextToken: __expectString(output.NextToken),
   } as any;
 };
 
 const deserializeAws_json1_1MigrateWorkspaceResult = (output: any, context: __SerdeContext): MigrateWorkspaceResult => {
   return {
-    SourceWorkspaceId:
-      output.SourceWorkspaceId !== undefined && output.SourceWorkspaceId !== null
-        ? output.SourceWorkspaceId
-        : undefined,
-    TargetWorkspaceId:
-      output.TargetWorkspaceId !== undefined && output.TargetWorkspaceId !== null
-        ? output.TargetWorkspaceId
-        : undefined,
+    SourceWorkspaceId: __expectString(output.SourceWorkspaceId),
+    TargetWorkspaceId: __expectString(output.TargetWorkspaceId),
   } as any;
 };
 
 const deserializeAws_json1_1ModificationState = (output: any, context: __SerdeContext): ModificationState => {
   return {
-    Resource: output.Resource !== undefined && output.Resource !== null ? output.Resource : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    Resource: __expectString(output.Resource),
+    State: __expectString(output.State),
   } as any;
 };
 
@@ -6898,7 +6851,7 @@ const deserializeAws_json1_1ModifyWorkspaceStateResult = (
 
 const deserializeAws_json1_1OperatingSystem = (output: any, context: __SerdeContext): OperatingSystem => {
   return {
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -6907,7 +6860,7 @@ const deserializeAws_json1_1OperationInProgressException = (
   context: __SerdeContext
 ): OperationInProgressException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6916,7 +6869,7 @@ const deserializeAws_json1_1OperationNotSupportedException = (
   context: __SerdeContext
 ): OperationNotSupportedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6953,7 +6906,7 @@ const deserializeAws_json1_1ResourceAlreadyExistsException = (
   context: __SerdeContext
 ): ResourceAlreadyExistsException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6962,7 +6915,7 @@ const deserializeAws_json1_1ResourceAssociatedException = (
   context: __SerdeContext
 ): ResourceAssociatedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6971,7 +6924,7 @@ const deserializeAws_json1_1ResourceCreationFailedException = (
   context: __SerdeContext
 ): ResourceCreationFailedException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6980,7 +6933,7 @@ const deserializeAws_json1_1ResourceLimitExceededException = (
   context: __SerdeContext
 ): ResourceLimitExceededException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6989,8 +6942,8 @@ const deserializeAws_json1_1ResourceNotFoundException = (
   context: __SerdeContext
 ): ResourceNotFoundException => {
   return {
-    ResourceId: output.ResourceId !== undefined && output.ResourceId !== null ? output.ResourceId : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    ResourceId: __expectString(output.ResourceId),
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -6999,8 +6952,8 @@ const deserializeAws_json1_1ResourceUnavailableException = (
   context: __SerdeContext
 ): ResourceUnavailableException => {
   return {
-    ResourceId: output.ResourceId !== undefined && output.ResourceId !== null ? output.ResourceId : undefined,
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    ResourceId: __expectString(output.ResourceId),
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -7014,28 +6967,17 @@ const deserializeAws_json1_1RevokeIpRulesResult = (output: any, context: __Serde
 
 const deserializeAws_json1_1RootStorage = (output: any, context: __SerdeContext): RootStorage => {
   return {
-    Capacity: output.Capacity !== undefined && output.Capacity !== null ? output.Capacity : undefined,
+    Capacity: __expectString(output.Capacity),
   } as any;
 };
 
 const deserializeAws_json1_1SelfservicePermissions = (output: any, context: __SerdeContext): SelfservicePermissions => {
   return {
-    ChangeComputeType:
-      output.ChangeComputeType !== undefined && output.ChangeComputeType !== null
-        ? output.ChangeComputeType
-        : undefined,
-    IncreaseVolumeSize:
-      output.IncreaseVolumeSize !== undefined && output.IncreaseVolumeSize !== null
-        ? output.IncreaseVolumeSize
-        : undefined,
-    RebuildWorkspace:
-      output.RebuildWorkspace !== undefined && output.RebuildWorkspace !== null ? output.RebuildWorkspace : undefined,
-    RestartWorkspace:
-      output.RestartWorkspace !== undefined && output.RestartWorkspace !== null ? output.RestartWorkspace : undefined,
-    SwitchRunningMode:
-      output.SwitchRunningMode !== undefined && output.SwitchRunningMode !== null
-        ? output.SwitchRunningMode
-        : undefined,
+    ChangeComputeType: __expectString(output.ChangeComputeType),
+    IncreaseVolumeSize: __expectString(output.IncreaseVolumeSize),
+    RebuildWorkspace: __expectString(output.RebuildWorkspace),
+    RestartWorkspace: __expectString(output.RestartWorkspace),
+    SwitchRunningMode: __expectString(output.SwitchRunningMode),
   } as any;
 };
 
@@ -7084,14 +7026,14 @@ const deserializeAws_json1_1SubnetIds = (output: any, context: __SerdeContext): 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -7123,7 +7065,7 @@ const deserializeAws_json1_1UnsupportedNetworkConfigurationException = (
   context: __SerdeContext
 ): UnsupportedNetworkConfigurationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -7132,7 +7074,7 @@ const deserializeAws_json1_1UnsupportedWorkspaceConfigurationException = (
   context: __SerdeContext
 ): UnsupportedWorkspaceConfigurationException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
@@ -7166,38 +7108,29 @@ const deserializeAws_json1_1UpdateWorkspaceImagePermissionResult = (
 
 const deserializeAws_json1_1UserStorage = (output: any, context: __SerdeContext): UserStorage => {
   return {
-    Capacity: output.Capacity !== undefined && output.Capacity !== null ? output.Capacity : undefined,
+    Capacity: __expectString(output.Capacity),
   } as any;
 };
 
 const deserializeAws_json1_1Workspace = (output: any, context: __SerdeContext): Workspace => {
   return {
-    BundleId: output.BundleId !== undefined && output.BundleId !== null ? output.BundleId : undefined,
-    ComputerName: output.ComputerName !== undefined && output.ComputerName !== null ? output.ComputerName : undefined,
-    DirectoryId: output.DirectoryId !== undefined && output.DirectoryId !== null ? output.DirectoryId : undefined,
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    IpAddress: output.IpAddress !== undefined && output.IpAddress !== null ? output.IpAddress : undefined,
+    BundleId: __expectString(output.BundleId),
+    ComputerName: __expectString(output.ComputerName),
+    DirectoryId: __expectString(output.DirectoryId),
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
+    IpAddress: __expectString(output.IpAddress),
     ModificationStates:
       output.ModificationStates !== undefined && output.ModificationStates !== null
         ? deserializeAws_json1_1ModificationStateList(output.ModificationStates, context)
         : undefined,
-    RootVolumeEncryptionEnabled:
-      output.RootVolumeEncryptionEnabled !== undefined && output.RootVolumeEncryptionEnabled !== null
-        ? output.RootVolumeEncryptionEnabled
-        : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    SubnetId: output.SubnetId !== undefined && output.SubnetId !== null ? output.SubnetId : undefined,
-    UserName: output.UserName !== undefined && output.UserName !== null ? output.UserName : undefined,
-    UserVolumeEncryptionEnabled:
-      output.UserVolumeEncryptionEnabled !== undefined && output.UserVolumeEncryptionEnabled !== null
-        ? output.UserVolumeEncryptionEnabled
-        : undefined,
-    VolumeEncryptionKey:
-      output.VolumeEncryptionKey !== undefined && output.VolumeEncryptionKey !== null
-        ? output.VolumeEncryptionKey
-        : undefined,
-    WorkspaceId: output.WorkspaceId !== undefined && output.WorkspaceId !== null ? output.WorkspaceId : undefined,
+    RootVolumeEncryptionEnabled: __expectBoolean(output.RootVolumeEncryptionEnabled),
+    State: __expectString(output.State),
+    SubnetId: __expectString(output.SubnetId),
+    UserName: __expectString(output.UserName),
+    UserVolumeEncryptionEnabled: __expectBoolean(output.UserVolumeEncryptionEnabled),
+    VolumeEncryptionKey: __expectString(output.VolumeEncryptionKey),
+    WorkspaceId: __expectString(output.WorkspaceId),
     WorkspaceProperties:
       output.WorkspaceProperties !== undefined && output.WorkspaceProperties !== null
         ? deserializeAws_json1_1WorkspaceProperties(output.WorkspaceProperties, context)
@@ -7210,36 +7143,20 @@ const deserializeAws_json1_1WorkspaceAccessProperties = (
   context: __SerdeContext
 ): WorkspaceAccessProperties => {
   return {
-    DeviceTypeAndroid:
-      output.DeviceTypeAndroid !== undefined && output.DeviceTypeAndroid !== null
-        ? output.DeviceTypeAndroid
-        : undefined,
-    DeviceTypeChromeOs:
-      output.DeviceTypeChromeOs !== undefined && output.DeviceTypeChromeOs !== null
-        ? output.DeviceTypeChromeOs
-        : undefined,
-    DeviceTypeIos:
-      output.DeviceTypeIos !== undefined && output.DeviceTypeIos !== null ? output.DeviceTypeIos : undefined,
-    DeviceTypeLinux:
-      output.DeviceTypeLinux !== undefined && output.DeviceTypeLinux !== null ? output.DeviceTypeLinux : undefined,
-    DeviceTypeOsx:
-      output.DeviceTypeOsx !== undefined && output.DeviceTypeOsx !== null ? output.DeviceTypeOsx : undefined,
-    DeviceTypeWeb:
-      output.DeviceTypeWeb !== undefined && output.DeviceTypeWeb !== null ? output.DeviceTypeWeb : undefined,
-    DeviceTypeWindows:
-      output.DeviceTypeWindows !== undefined && output.DeviceTypeWindows !== null
-        ? output.DeviceTypeWindows
-        : undefined,
-    DeviceTypeZeroClient:
-      output.DeviceTypeZeroClient !== undefined && output.DeviceTypeZeroClient !== null
-        ? output.DeviceTypeZeroClient
-        : undefined,
+    DeviceTypeAndroid: __expectString(output.DeviceTypeAndroid),
+    DeviceTypeChromeOs: __expectString(output.DeviceTypeChromeOs),
+    DeviceTypeIos: __expectString(output.DeviceTypeIos),
+    DeviceTypeLinux: __expectString(output.DeviceTypeLinux),
+    DeviceTypeOsx: __expectString(output.DeviceTypeOsx),
+    DeviceTypeWeb: __expectString(output.DeviceTypeWeb),
+    DeviceTypeWindows: __expectString(output.DeviceTypeWindows),
+    DeviceTypeZeroClient: __expectString(output.DeviceTypeZeroClient),
   } as any;
 };
 
 const deserializeAws_json1_1WorkspaceBundle = (output: any, context: __SerdeContext): WorkspaceBundle => {
   return {
-    BundleId: output.BundleId !== undefined && output.BundleId !== null ? output.BundleId : undefined,
+    BundleId: __expectString(output.BundleId),
     ComputeType:
       output.ComputeType !== undefined && output.ComputeType !== null
         ? deserializeAws_json1_1ComputeType(output.ComputeType, context)
@@ -7248,14 +7165,14 @@ const deserializeAws_json1_1WorkspaceBundle = (output: any, context: __SerdeCont
       output.CreationTime !== undefined && output.CreationTime !== null
         ? new Date(Math.round(output.CreationTime * 1000))
         : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    ImageId: output.ImageId !== undefined && output.ImageId !== null ? output.ImageId : undefined,
+    Description: __expectString(output.Description),
+    ImageId: __expectString(output.ImageId),
     LastUpdatedTime:
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
         ? new Date(Math.round(output.LastUpdatedTime * 1000))
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Owner: output.Owner !== undefined && output.Owner !== null ? output.Owner : undefined,
+    Name: __expectString(output.Name),
+    Owner: __expectString(output.Owner),
     RootStorage:
       output.RootStorage !== undefined && output.RootStorage !== null
         ? deserializeAws_json1_1RootStorage(output.RootStorage, context)
@@ -7272,8 +7189,7 @@ const deserializeAws_json1_1WorkspaceConnectionStatus = (
   context: __SerdeContext
 ): WorkspaceConnectionStatus => {
   return {
-    ConnectionState:
-      output.ConnectionState !== undefined && output.ConnectionState !== null ? output.ConnectionState : undefined,
+    ConnectionState: __expectString(output.ConnectionState),
     ConnectionStateCheckTimestamp:
       output.ConnectionStateCheckTimestamp !== undefined && output.ConnectionStateCheckTimestamp !== null
         ? new Date(Math.round(output.ConnectionStateCheckTimestamp * 1000))
@@ -7282,7 +7198,7 @@ const deserializeAws_json1_1WorkspaceConnectionStatus = (
       output.LastKnownUserConnectionTimestamp !== undefined && output.LastKnownUserConnectionTimestamp !== null
         ? new Date(Math.round(output.LastKnownUserConnectionTimestamp * 1000))
         : undefined,
-    WorkspaceId: output.WorkspaceId !== undefined && output.WorkspaceId !== null ? output.WorkspaceId : undefined,
+    WorkspaceId: __expectString(output.WorkspaceId),
   } as any;
 };
 
@@ -7302,31 +7218,27 @@ const deserializeAws_json1_1WorkspaceConnectionStatusList = (
 
 const deserializeAws_json1_1WorkspaceDirectory = (output: any, context: __SerdeContext): WorkspaceDirectory => {
   return {
-    Alias: output.Alias !== undefined && output.Alias !== null ? output.Alias : undefined,
-    CustomerUserName:
-      output.CustomerUserName !== undefined && output.CustomerUserName !== null ? output.CustomerUserName : undefined,
-    DirectoryId: output.DirectoryId !== undefined && output.DirectoryId !== null ? output.DirectoryId : undefined,
-    DirectoryName:
-      output.DirectoryName !== undefined && output.DirectoryName !== null ? output.DirectoryName : undefined,
-    DirectoryType:
-      output.DirectoryType !== undefined && output.DirectoryType !== null ? output.DirectoryType : undefined,
+    Alias: __expectString(output.Alias),
+    CustomerUserName: __expectString(output.CustomerUserName),
+    DirectoryId: __expectString(output.DirectoryId),
+    DirectoryName: __expectString(output.DirectoryName),
+    DirectoryType: __expectString(output.DirectoryType),
     DnsIpAddresses:
       output.DnsIpAddresses !== undefined && output.DnsIpAddresses !== null
         ? deserializeAws_json1_1DnsIpAddresses(output.DnsIpAddresses, context)
         : undefined,
-    IamRoleId: output.IamRoleId !== undefined && output.IamRoleId !== null ? output.IamRoleId : undefined,
-    RegistrationCode:
-      output.RegistrationCode !== undefined && output.RegistrationCode !== null ? output.RegistrationCode : undefined,
+    IamRoleId: __expectString(output.IamRoleId),
+    RegistrationCode: __expectString(output.RegistrationCode),
     SelfservicePermissions:
       output.SelfservicePermissions !== undefined && output.SelfservicePermissions !== null
         ? deserializeAws_json1_1SelfservicePermissions(output.SelfservicePermissions, context)
         : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    State: __expectString(output.State),
     SubnetIds:
       output.SubnetIds !== undefined && output.SubnetIds !== null
         ? deserializeAws_json1_1SubnetIds(output.SubnetIds, context)
         : undefined,
-    Tenancy: output.Tenancy !== undefined && output.Tenancy !== null ? output.Tenancy : undefined,
+    Tenancy: __expectString(output.Tenancy),
     WorkspaceAccessProperties:
       output.WorkspaceAccessProperties !== undefined && output.WorkspaceAccessProperties !== null
         ? deserializeAws_json1_1WorkspaceAccessProperties(output.WorkspaceAccessProperties, context)
@@ -7335,10 +7247,7 @@ const deserializeAws_json1_1WorkspaceDirectory = (output: any, context: __SerdeC
       output.WorkspaceCreationProperties !== undefined && output.WorkspaceCreationProperties !== null
         ? deserializeAws_json1_1DefaultWorkspaceCreationProperties(output.WorkspaceCreationProperties, context)
         : undefined,
-    WorkspaceSecurityGroupId:
-      output.WorkspaceSecurityGroupId !== undefined && output.WorkspaceSecurityGroupId !== null
-        ? output.WorkspaceSecurityGroupId
-        : undefined,
+    WorkspaceSecurityGroupId: __expectString(output.WorkspaceSecurityGroupId),
     ipGroupIds:
       output.ipGroupIds !== undefined && output.ipGroupIds !== null
         ? deserializeAws_json1_1IpGroupIdList(output.ipGroupIds, context)
@@ -7350,20 +7259,18 @@ const deserializeAws_json1_1WorkspaceImage = (output: any, context: __SerdeConte
   return {
     Created:
       output.Created !== undefined && output.Created !== null ? new Date(Math.round(output.Created * 1000)) : undefined,
-    Description: output.Description !== undefined && output.Description !== null ? output.Description : undefined,
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    ErrorMessage: output.ErrorMessage !== undefined && output.ErrorMessage !== null ? output.ErrorMessage : undefined,
-    ImageId: output.ImageId !== undefined && output.ImageId !== null ? output.ImageId : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Description: __expectString(output.Description),
+    ErrorCode: __expectString(output.ErrorCode),
+    ErrorMessage: __expectString(output.ErrorMessage),
+    ImageId: __expectString(output.ImageId),
+    Name: __expectString(output.Name),
     OperatingSystem:
       output.OperatingSystem !== undefined && output.OperatingSystem !== null
         ? deserializeAws_json1_1OperatingSystem(output.OperatingSystem, context)
         : undefined,
-    OwnerAccountId:
-      output.OwnerAccountId !== undefined && output.OwnerAccountId !== null ? output.OwnerAccountId : undefined,
-    RequiredTenancy:
-      output.RequiredTenancy !== undefined && output.RequiredTenancy !== null ? output.RequiredTenancy : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    OwnerAccountId: __expectString(output.OwnerAccountId),
+    RequiredTenancy: __expectString(output.RequiredTenancy),
+    State: __expectString(output.State),
   } as any;
 };
 
@@ -7391,45 +7298,26 @@ const deserializeAws_json1_1WorkspaceList = (output: any, context: __SerdeContex
 
 const deserializeAws_json1_1WorkspaceProperties = (output: any, context: __SerdeContext): WorkspaceProperties => {
   return {
-    ComputeTypeName:
-      output.ComputeTypeName !== undefined && output.ComputeTypeName !== null ? output.ComputeTypeName : undefined,
-    RootVolumeSizeGib:
-      output.RootVolumeSizeGib !== undefined && output.RootVolumeSizeGib !== null
-        ? output.RootVolumeSizeGib
-        : undefined,
-    RunningMode: output.RunningMode !== undefined && output.RunningMode !== null ? output.RunningMode : undefined,
-    RunningModeAutoStopTimeoutInMinutes:
-      output.RunningModeAutoStopTimeoutInMinutes !== undefined && output.RunningModeAutoStopTimeoutInMinutes !== null
-        ? output.RunningModeAutoStopTimeoutInMinutes
-        : undefined,
-    UserVolumeSizeGib:
-      output.UserVolumeSizeGib !== undefined && output.UserVolumeSizeGib !== null
-        ? output.UserVolumeSizeGib
-        : undefined,
+    ComputeTypeName: __expectString(output.ComputeTypeName),
+    RootVolumeSizeGib: __expectNumber(output.RootVolumeSizeGib),
+    RunningMode: __expectString(output.RunningMode),
+    RunningModeAutoStopTimeoutInMinutes: __expectNumber(output.RunningModeAutoStopTimeoutInMinutes),
+    UserVolumeSizeGib: __expectNumber(output.UserVolumeSizeGib),
   } as any;
 };
 
 const deserializeAws_json1_1WorkspaceRequest = (output: any, context: __SerdeContext): WorkspaceRequest => {
   return {
-    BundleId: output.BundleId !== undefined && output.BundleId !== null ? output.BundleId : undefined,
-    DirectoryId: output.DirectoryId !== undefined && output.DirectoryId !== null ? output.DirectoryId : undefined,
-    RootVolumeEncryptionEnabled:
-      output.RootVolumeEncryptionEnabled !== undefined && output.RootVolumeEncryptionEnabled !== null
-        ? output.RootVolumeEncryptionEnabled
-        : undefined,
+    BundleId: __expectString(output.BundleId),
+    DirectoryId: __expectString(output.DirectoryId),
+    RootVolumeEncryptionEnabled: __expectBoolean(output.RootVolumeEncryptionEnabled),
     Tags:
       output.Tags !== undefined && output.Tags !== null
         ? deserializeAws_json1_1TagList(output.Tags, context)
         : undefined,
-    UserName: output.UserName !== undefined && output.UserName !== null ? output.UserName : undefined,
-    UserVolumeEncryptionEnabled:
-      output.UserVolumeEncryptionEnabled !== undefined && output.UserVolumeEncryptionEnabled !== null
-        ? output.UserVolumeEncryptionEnabled
-        : undefined,
-    VolumeEncryptionKey:
-      output.VolumeEncryptionKey !== undefined && output.VolumeEncryptionKey !== null
-        ? output.VolumeEncryptionKey
-        : undefined,
+    UserName: __expectString(output.UserName),
+    UserVolumeEncryptionEnabled: __expectBoolean(output.UserVolumeEncryptionEnabled),
+    VolumeEncryptionKey: __expectString(output.VolumeEncryptionKey),
     WorkspaceProperties:
       output.WorkspaceProperties !== undefined && output.WorkspaceProperties !== null
         ? deserializeAws_json1_1WorkspaceProperties(output.WorkspaceProperties, context)
@@ -7442,15 +7330,15 @@ const deserializeAws_json1_1WorkspacesDefaultRoleNotFoundException = (
   context: __SerdeContext
 ): WorkspacesDefaultRoleNotFoundException => {
   return {
-    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+    message: __expectString(output.message),
   } as any;
 };
 
 const deserializeAws_json1_1WorkspacesIpGroup = (output: any, context: __SerdeContext): WorkspacesIpGroup => {
   return {
-    groupDesc: output.groupDesc !== undefined && output.groupDesc !== null ? output.groupDesc : undefined,
-    groupId: output.groupId !== undefined && output.groupId !== null ? output.groupId : undefined,
-    groupName: output.groupName !== undefined && output.groupName !== null ? output.groupName : undefined,
+    groupDesc: __expectString(output.groupDesc),
+    groupId: __expectString(output.groupId),
+    groupName: __expectString(output.groupName),
     userRules:
       output.userRules !== undefined && output.userRules !== null
         ? deserializeAws_json1_1IpRuleList(output.userRules, context)

--- a/clients/client-xray/protocols/Aws_restJson1.ts
+++ b/clients/client-xray/protocols/Aws_restJson1.ts
@@ -113,7 +113,12 @@ import {
   ValueWithServiceIds,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -876,7 +881,7 @@ export const deserializeAws_restJson1BatchGetTracesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Traces !== undefined && data.Traces !== null) {
     contents.Traces = deserializeAws_restJson1TraceList(data.Traces, context);
@@ -1331,7 +1336,7 @@ export const deserializeAws_restJson1GetGroupsCommand = async (
     contents.Groups = deserializeAws_restJson1GroupSummaryList(data.Groups, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1461,7 +1466,7 @@ export const deserializeAws_restJson1GetInsightEventsCommand = async (
     contents.InsightEvents = deserializeAws_restJson1InsightEventList(data.InsightEvents, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1533,10 +1538,10 @@ export const deserializeAws_restJson1GetInsightImpactGraphCommand = async (
     contents.EndTime = new Date(Math.round(data.EndTime * 1000));
   }
   if (data.InsightId !== undefined && data.InsightId !== null) {
-    contents.InsightId = data.InsightId;
+    contents.InsightId = __expectString(data.InsightId);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.ServiceGraphEndTime !== undefined && data.ServiceGraphEndTime !== null) {
     contents.ServiceGraphEndTime = new Date(Math.round(data.ServiceGraphEndTime * 1000));
@@ -1615,7 +1620,7 @@ export const deserializeAws_restJson1GetInsightSummariesCommand = async (
     contents.InsightSummaries = deserializeAws_restJson1InsightSummaryList(data.InsightSummaries, context);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   return Promise.resolve(contents);
 };
@@ -1679,7 +1684,7 @@ export const deserializeAws_restJson1GetSamplingRulesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.SamplingRuleRecords !== undefined && data.SamplingRuleRecords !== null) {
     contents.SamplingRuleRecords = deserializeAws_restJson1SamplingRuleRecordList(data.SamplingRuleRecords, context);
@@ -1746,7 +1751,7 @@ export const deserializeAws_restJson1GetSamplingStatisticSummariesCommand = asyn
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.SamplingStatisticSummaries !== undefined && data.SamplingStatisticSummaries !== null) {
     contents.SamplingStatisticSummaries = deserializeAws_restJson1SamplingStatisticSummaryList(
@@ -1896,13 +1901,13 @@ export const deserializeAws_restJson1GetServiceGraphCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.ContainsOldGroupVersions !== undefined && data.ContainsOldGroupVersions !== null) {
-    contents.ContainsOldGroupVersions = data.ContainsOldGroupVersions;
+    contents.ContainsOldGroupVersions = __expectBoolean(data.ContainsOldGroupVersions);
   }
   if (data.EndTime !== undefined && data.EndTime !== null) {
     contents.EndTime = new Date(Math.round(data.EndTime * 1000));
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Services !== undefined && data.Services !== null) {
     contents.Services = deserializeAws_restJson1ServiceList(data.Services, context);
@@ -1973,10 +1978,10 @@ export const deserializeAws_restJson1GetTimeSeriesServiceStatisticsCommand = asy
   };
   const data: any = await parseBody(output.body, context);
   if (data.ContainsOldGroupVersions !== undefined && data.ContainsOldGroupVersions !== null) {
-    contents.ContainsOldGroupVersions = data.ContainsOldGroupVersions;
+    contents.ContainsOldGroupVersions = __expectBoolean(data.ContainsOldGroupVersions);
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.TimeSeriesServiceStatistics !== undefined && data.TimeSeriesServiceStatistics !== null) {
     contents.TimeSeriesServiceStatistics = deserializeAws_restJson1TimeSeriesServiceStatisticsList(
@@ -2046,7 +2051,7 @@ export const deserializeAws_restJson1GetTraceGraphCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Services !== undefined && data.Services !== null) {
     contents.Services = deserializeAws_restJson1ServiceList(data.Services, context);
@@ -2118,13 +2123,13 @@ export const deserializeAws_restJson1GetTraceSummariesCommand = async (
     contents.ApproximateTime = new Date(Math.round(data.ApproximateTime * 1000));
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.TraceSummaries !== undefined && data.TraceSummaries !== null) {
     contents.TraceSummaries = deserializeAws_restJson1TraceSummaryList(data.TraceSummaries, context);
   }
   if (data.TracesProcessedCount !== undefined && data.TracesProcessedCount !== null) {
-    contents.TracesProcessedCount = data.TracesProcessedCount;
+    contents.TracesProcessedCount = __expectNumber(data.TracesProcessedCount);
   }
   return Promise.resolve(contents);
 };
@@ -2188,7 +2193,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.NextToken !== undefined && data.NextToken !== null) {
-    contents.NextToken = data.NextToken;
+    contents.NextToken = __expectString(data.NextToken);
   }
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagList(data.Tags, context);
@@ -2717,7 +2722,7 @@ const deserializeAws_restJson1InvalidRequestExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -2735,10 +2740,10 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.ResourceName !== undefined && data.ResourceName !== null) {
-    contents.ResourceName = data.ResourceName;
+    contents.ResourceName = __expectString(data.ResourceName);
   }
   return contents;
 };
@@ -2755,7 +2760,7 @@ const deserializeAws_restJson1RuleLimitExceededExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -2772,7 +2777,7 @@ const deserializeAws_restJson1ThrottledExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -2790,10 +2795,10 @@ const deserializeAws_restJson1TooManyTagsExceptionResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   if (data.ResourceName !== undefined && data.ResourceName !== null) {
-    contents.ResourceName = data.ResourceName;
+    contents.ResourceName = __expectString(data.ResourceName);
   }
   return contents;
 };
@@ -3004,12 +3009,12 @@ const serializeAws_restJson1TraceSegmentDocumentList = (input: string[], context
 
 const deserializeAws_restJson1Alias = (output: any, context: __SerdeContext): Alias => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     Names:
       output.Names !== undefined && output.Names !== null
         ? deserializeAws_restJson1AliasNames(output.Names, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -3031,7 +3036,7 @@ const deserializeAws_restJson1AliasNames = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3051,20 +3056,14 @@ const deserializeAws_restJson1Annotations = (
 };
 
 const deserializeAws_restJson1AnnotationValue = (output: any, context: __SerdeContext): AnnotationValue => {
-  if (output.BooleanValue !== undefined && output.BooleanValue !== null) {
-    return {
-      BooleanValue: output.BooleanValue,
-    };
+  if (__expectBoolean(output.BooleanValue) !== undefined) {
+    return { BooleanValue: __expectBoolean(output.BooleanValue) as any };
   }
-  if (output.NumberValue !== undefined && output.NumberValue !== null) {
-    return {
-      NumberValue: output.NumberValue,
-    };
+  if (__expectNumber(output.NumberValue) !== undefined) {
+    return { NumberValue: __expectNumber(output.NumberValue) as any };
   }
-  if (output.StringValue !== undefined && output.StringValue !== null) {
-    return {
-      StringValue: output.StringValue,
-    };
+  if (__expectString(output.StringValue) !== undefined) {
+    return { StringValue: __expectString(output.StringValue) as any };
   }
   return { $unknown: Object.entries(output)[0] };
 };
@@ -3096,7 +3095,7 @@ const deserializeAws_restJson1AttributeMap = (output: any, context: __SerdeConte
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -3106,7 +3105,7 @@ const deserializeAws_restJson1AvailabilityZoneDetail = (
   context: __SerdeContext
 ): AvailabilityZoneDetail => {
   return {
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -3118,7 +3117,7 @@ const deserializeAws_restJson1Edge = (output: any, context: __SerdeContext): Edg
         : undefined,
     EndTime:
       output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
-    ReferenceId: output.ReferenceId !== undefined && output.ReferenceId !== null ? output.ReferenceId : undefined,
+    ReferenceId: __expectNumber(output.ReferenceId),
     ResponseTimeHistogram:
       output.ResponseTimeHistogram !== undefined && output.ResponseTimeHistogram !== null
         ? deserializeAws_restJson1Histogram(output.ResponseTimeHistogram, context)
@@ -3155,27 +3154,23 @@ const deserializeAws_restJson1EdgeStatistics = (output: any, context: __SerdeCon
       output.FaultStatistics !== undefined && output.FaultStatistics !== null
         ? deserializeAws_restJson1FaultStatistics(output.FaultStatistics, context)
         : undefined,
-    OkCount: output.OkCount !== undefined && output.OkCount !== null ? output.OkCount : undefined,
-    TotalCount: output.TotalCount !== undefined && output.TotalCount !== null ? output.TotalCount : undefined,
-    TotalResponseTime:
-      output.TotalResponseTime !== undefined && output.TotalResponseTime !== null
-        ? output.TotalResponseTime
-        : undefined,
+    OkCount: __expectNumber(output.OkCount),
+    TotalCount: __expectNumber(output.TotalCount),
+    TotalResponseTime: __expectNumber(output.TotalResponseTime),
   } as any;
 };
 
 const deserializeAws_restJson1EncryptionConfig = (output: any, context: __SerdeContext): EncryptionConfig => {
   return {
-    KeyId: output.KeyId !== undefined && output.KeyId !== null ? output.KeyId : undefined,
-    Status: output.Status !== undefined && output.Status !== null ? output.Status : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    KeyId: __expectString(output.KeyId),
+    Status: __expectString(output.Status),
+    Type: __expectString(output.Type),
   } as any;
 };
 
 const deserializeAws_restJson1ErrorRootCause = (output: any, context: __SerdeContext): ErrorRootCause => {
   return {
-    ClientImpacting:
-      output.ClientImpacting !== undefined && output.ClientImpacting !== null ? output.ClientImpacting : undefined,
+    ClientImpacting: __expectBoolean(output.ClientImpacting),
     Services:
       output.Services !== undefined && output.Services !== null
         ? deserializeAws_restJson1ErrorRootCauseServices(output.Services, context)
@@ -3189,8 +3184,8 @@ const deserializeAws_restJson1ErrorRootCauseEntity = (output: any, context: __Se
       output.Exceptions !== undefined && output.Exceptions !== null
         ? deserializeAws_restJson1RootCauseExceptions(output.Exceptions, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Remote: output.Remote !== undefined && output.Remote !== null ? output.Remote : undefined,
+    Name: __expectString(output.Name),
+    Remote: __expectBoolean(output.Remote),
   } as any;
 };
 
@@ -3221,18 +3216,18 @@ const deserializeAws_restJson1ErrorRootCauses = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1ErrorRootCauseService = (output: any, context: __SerdeContext): ErrorRootCauseService => {
   return {
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
+    AccountId: __expectString(output.AccountId),
     EntityPath:
       output.EntityPath !== undefined && output.EntityPath !== null
         ? deserializeAws_restJson1ErrorRootCauseEntityPath(output.EntityPath, context)
         : undefined,
-    Inferred: output.Inferred !== undefined && output.Inferred !== null ? output.Inferred : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Inferred: __expectBoolean(output.Inferred),
+    Name: __expectString(output.Name),
     Names:
       output.Names !== undefined && output.Names !== null
         ? deserializeAws_restJson1ServiceNames(output.Names, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -3252,17 +3247,15 @@ const deserializeAws_restJson1ErrorRootCauseServices = (
 
 const deserializeAws_restJson1ErrorStatistics = (output: any, context: __SerdeContext): ErrorStatistics => {
   return {
-    OtherCount: output.OtherCount !== undefined && output.OtherCount !== null ? output.OtherCount : undefined,
-    ThrottleCount:
-      output.ThrottleCount !== undefined && output.ThrottleCount !== null ? output.ThrottleCount : undefined,
-    TotalCount: output.TotalCount !== undefined && output.TotalCount !== null ? output.TotalCount : undefined,
+    OtherCount: __expectNumber(output.OtherCount),
+    ThrottleCount: __expectNumber(output.ThrottleCount),
+    TotalCount: __expectNumber(output.TotalCount),
   } as any;
 };
 
 const deserializeAws_restJson1FaultRootCause = (output: any, context: __SerdeContext): FaultRootCause => {
   return {
-    ClientImpacting:
-      output.ClientImpacting !== undefined && output.ClientImpacting !== null ? output.ClientImpacting : undefined,
+    ClientImpacting: __expectBoolean(output.ClientImpacting),
     Services:
       output.Services !== undefined && output.Services !== null
         ? deserializeAws_restJson1FaultRootCauseServices(output.Services, context)
@@ -3276,8 +3269,8 @@ const deserializeAws_restJson1FaultRootCauseEntity = (output: any, context: __Se
       output.Exceptions !== undefined && output.Exceptions !== null
         ? deserializeAws_restJson1RootCauseExceptions(output.Exceptions, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Remote: output.Remote !== undefined && output.Remote !== null ? output.Remote : undefined,
+    Name: __expectString(output.Name),
+    Remote: __expectBoolean(output.Remote),
   } as any;
 };
 
@@ -3308,18 +3301,18 @@ const deserializeAws_restJson1FaultRootCauses = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1FaultRootCauseService = (output: any, context: __SerdeContext): FaultRootCauseService => {
   return {
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
+    AccountId: __expectString(output.AccountId),
     EntityPath:
       output.EntityPath !== undefined && output.EntityPath !== null
         ? deserializeAws_restJson1FaultRootCauseEntityPath(output.EntityPath, context)
         : undefined,
-    Inferred: output.Inferred !== undefined && output.Inferred !== null ? output.Inferred : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Inferred: __expectBoolean(output.Inferred),
+    Name: __expectString(output.Name),
     Names:
       output.Names !== undefined && output.Names !== null
         ? deserializeAws_restJson1ServiceNames(output.Names, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -3339,26 +3332,23 @@ const deserializeAws_restJson1FaultRootCauseServices = (
 
 const deserializeAws_restJson1FaultStatistics = (output: any, context: __SerdeContext): FaultStatistics => {
   return {
-    OtherCount: output.OtherCount !== undefined && output.OtherCount !== null ? output.OtherCount : undefined,
-    TotalCount: output.TotalCount !== undefined && output.TotalCount !== null ? output.TotalCount : undefined,
+    OtherCount: __expectNumber(output.OtherCount),
+    TotalCount: __expectNumber(output.TotalCount),
   } as any;
 };
 
 const deserializeAws_restJson1ForecastStatistics = (output: any, context: __SerdeContext): ForecastStatistics => {
   return {
-    FaultCountHigh:
-      output.FaultCountHigh !== undefined && output.FaultCountHigh !== null ? output.FaultCountHigh : undefined,
-    FaultCountLow:
-      output.FaultCountLow !== undefined && output.FaultCountLow !== null ? output.FaultCountLow : undefined,
+    FaultCountHigh: __expectNumber(output.FaultCountHigh),
+    FaultCountLow: __expectNumber(output.FaultCountLow),
   } as any;
 };
 
 const deserializeAws_restJson1Group = (output: any, context: __SerdeContext): Group => {
   return {
-    FilterExpression:
-      output.FilterExpression !== undefined && output.FilterExpression !== null ? output.FilterExpression : undefined,
-    GroupARN: output.GroupARN !== undefined && output.GroupARN !== null ? output.GroupARN : undefined,
-    GroupName: output.GroupName !== undefined && output.GroupName !== null ? output.GroupName : undefined,
+    FilterExpression: __expectString(output.FilterExpression),
+    GroupARN: __expectString(output.GroupARN),
+    GroupName: __expectString(output.GroupName),
     InsightsConfiguration:
       output.InsightsConfiguration !== undefined && output.InsightsConfiguration !== null
         ? deserializeAws_restJson1InsightsConfiguration(output.InsightsConfiguration, context)
@@ -3368,10 +3358,9 @@ const deserializeAws_restJson1Group = (output: any, context: __SerdeContext): Gr
 
 const deserializeAws_restJson1GroupSummary = (output: any, context: __SerdeContext): GroupSummary => {
   return {
-    FilterExpression:
-      output.FilterExpression !== undefined && output.FilterExpression !== null ? output.FilterExpression : undefined,
-    GroupARN: output.GroupARN !== undefined && output.GroupARN !== null ? output.GroupARN : undefined,
-    GroupName: output.GroupName !== undefined && output.GroupName !== null ? output.GroupName : undefined,
+    FilterExpression: __expectString(output.FilterExpression),
+    GroupARN: __expectString(output.GroupARN),
+    GroupName: __expectString(output.GroupName),
     InsightsConfiguration:
       output.InsightsConfiguration !== undefined && output.InsightsConfiguration !== null
         ? deserializeAws_restJson1InsightsConfiguration(output.InsightsConfiguration, context)
@@ -3403,18 +3392,18 @@ const deserializeAws_restJson1Histogram = (output: any, context: __SerdeContext)
 
 const deserializeAws_restJson1HistogramEntry = (output: any, context: __SerdeContext): HistogramEntry => {
   return {
-    Count: output.Count !== undefined && output.Count !== null ? output.Count : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Count: __expectNumber(output.Count),
+    Value: __expectNumber(output.Value),
   } as any;
 };
 
 const deserializeAws_restJson1Http = (output: any, context: __SerdeContext): Http => {
   return {
-    ClientIp: output.ClientIp !== undefined && output.ClientIp !== null ? output.ClientIp : undefined,
-    HttpMethod: output.HttpMethod !== undefined && output.HttpMethod !== null ? output.HttpMethod : undefined,
-    HttpStatus: output.HttpStatus !== undefined && output.HttpStatus !== null ? output.HttpStatus : undefined,
-    HttpURL: output.HttpURL !== undefined && output.HttpURL !== null ? output.HttpURL : undefined,
-    UserAgent: output.UserAgent !== undefined && output.UserAgent !== null ? output.UserAgent : undefined,
+    ClientIp: __expectString(output.ClientIp),
+    HttpMethod: __expectString(output.HttpMethod),
+    HttpStatus: __expectNumber(output.HttpStatus),
+    HttpURL: __expectString(output.HttpURL),
+    UserAgent: __expectString(output.UserAgent),
   } as any;
 };
 
@@ -3430,9 +3419,9 @@ const deserializeAws_restJson1Insight = (output: any, context: __SerdeContext): 
         : undefined,
     EndTime:
       output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
-    GroupARN: output.GroupARN !== undefined && output.GroupARN !== null ? output.GroupARN : undefined,
-    GroupName: output.GroupName !== undefined && output.GroupName !== null ? output.GroupName : undefined,
-    InsightId: output.InsightId !== undefined && output.InsightId !== null ? output.InsightId : undefined,
+    GroupARN: __expectString(output.GroupARN),
+    GroupName: __expectString(output.GroupName),
+    InsightId: __expectString(output.InsightId),
     RootCauseServiceId:
       output.RootCauseServiceId !== undefined && output.RootCauseServiceId !== null
         ? deserializeAws_restJson1ServiceId(output.RootCauseServiceId, context)
@@ -3446,8 +3435,8 @@ const deserializeAws_restJson1Insight = (output: any, context: __SerdeContext): 
       output.StartTime !== undefined && output.StartTime !== null
         ? new Date(Math.round(output.StartTime * 1000))
         : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    Summary: output.Summary !== undefined && output.Summary !== null ? output.Summary : undefined,
+    State: __expectString(output.State),
+    Summary: __expectString(output.Summary),
     TopAnomalousServices:
       output.TopAnomalousServices !== undefined && output.TopAnomalousServices !== null
         ? deserializeAws_restJson1AnomalousServiceList(output.TopAnomalousServices, context)
@@ -3465,7 +3454,7 @@ const deserializeAws_restJson1InsightCategoryList = (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3484,7 +3473,7 @@ const deserializeAws_restJson1InsightEvent = (output: any, context: __SerdeConte
       output.RootCauseServiceRequestImpactStatistics !== null
         ? deserializeAws_restJson1RequestImpactStatistics(output.RootCauseServiceRequestImpactStatistics, context)
         : undefined,
-    Summary: output.Summary !== undefined && output.Summary !== null ? output.Summary : undefined,
+    Summary: __expectString(output.Summary),
     TopAnomalousServices:
       output.TopAnomalousServices !== undefined && output.TopAnomalousServices !== null
         ? deserializeAws_restJson1AnomalousServiceList(output.TopAnomalousServices, context)
@@ -3508,7 +3497,7 @@ const deserializeAws_restJson1InsightImpactGraphEdge = (
   context: __SerdeContext
 ): InsightImpactGraphEdge => {
   return {
-    ReferenceId: output.ReferenceId !== undefined && output.ReferenceId !== null ? output.ReferenceId : undefined,
+    ReferenceId: __expectNumber(output.ReferenceId),
   } as any;
 };
 
@@ -3531,18 +3520,18 @@ const deserializeAws_restJson1InsightImpactGraphService = (
   context: __SerdeContext
 ): InsightImpactGraphService => {
   return {
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
+    AccountId: __expectString(output.AccountId),
     Edges:
       output.Edges !== undefined && output.Edges !== null
         ? deserializeAws_restJson1InsightImpactGraphEdgeList(output.Edges, context)
         : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     Names:
       output.Names !== undefined && output.Names !== null
         ? deserializeAws_restJson1ServiceNames(output.Names, context)
         : undefined,
-    ReferenceId: output.ReferenceId !== undefined && output.ReferenceId !== null ? output.ReferenceId : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    ReferenceId: __expectNumber(output.ReferenceId),
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -3562,12 +3551,8 @@ const deserializeAws_restJson1InsightImpactGraphServiceList = (
 
 const deserializeAws_restJson1InsightsConfiguration = (output: any, context: __SerdeContext): InsightsConfiguration => {
   return {
-    InsightsEnabled:
-      output.InsightsEnabled !== undefined && output.InsightsEnabled !== null ? output.InsightsEnabled : undefined,
-    NotificationsEnabled:
-      output.NotificationsEnabled !== undefined && output.NotificationsEnabled !== null
-        ? output.NotificationsEnabled
-        : undefined,
+    InsightsEnabled: __expectBoolean(output.InsightsEnabled),
+    NotificationsEnabled: __expectBoolean(output.NotificationsEnabled),
   } as any;
 };
 
@@ -3583,9 +3568,9 @@ const deserializeAws_restJson1InsightSummary = (output: any, context: __SerdeCon
         : undefined,
     EndTime:
       output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
-    GroupARN: output.GroupARN !== undefined && output.GroupARN !== null ? output.GroupARN : undefined,
-    GroupName: output.GroupName !== undefined && output.GroupName !== null ? output.GroupName : undefined,
-    InsightId: output.InsightId !== undefined && output.InsightId !== null ? output.InsightId : undefined,
+    GroupARN: __expectString(output.GroupARN),
+    GroupName: __expectString(output.GroupName),
+    InsightId: __expectString(output.InsightId),
     LastUpdateTime:
       output.LastUpdateTime !== undefined && output.LastUpdateTime !== null
         ? new Date(Math.round(output.LastUpdateTime * 1000))
@@ -3603,8 +3588,8 @@ const deserializeAws_restJson1InsightSummary = (output: any, context: __SerdeCon
       output.StartTime !== undefined && output.StartTime !== null
         ? new Date(Math.round(output.StartTime * 1000))
         : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
-    Summary: output.Summary !== undefined && output.Summary !== null ? output.Summary : undefined,
+    State: __expectString(output.State),
+    Summary: __expectString(output.Summary),
     TopAnomalousServices:
       output.TopAnomalousServices !== undefined && output.TopAnomalousServices !== null
         ? deserializeAws_restJson1AnomalousServiceList(output.TopAnomalousServices, context)
@@ -3625,7 +3610,7 @@ const deserializeAws_restJson1InsightSummaryList = (output: any, context: __Serd
 
 const deserializeAws_restJson1InstanceIdDetail = (output: any, context: __SerdeContext): InstanceIdDetail => {
   return {
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    Id: __expectString(output.Id),
   } as any;
 };
 
@@ -3634,22 +3619,21 @@ const deserializeAws_restJson1RequestImpactStatistics = (
   context: __SerdeContext
 ): RequestImpactStatistics => {
   return {
-    FaultCount: output.FaultCount !== undefined && output.FaultCount !== null ? output.FaultCount : undefined,
-    OkCount: output.OkCount !== undefined && output.OkCount !== null ? output.OkCount : undefined,
-    TotalCount: output.TotalCount !== undefined && output.TotalCount !== null ? output.TotalCount : undefined,
+    FaultCount: __expectNumber(output.FaultCount),
+    OkCount: __expectNumber(output.OkCount),
+    TotalCount: __expectNumber(output.TotalCount),
   } as any;
 };
 
 const deserializeAws_restJson1ResourceARNDetail = (output: any, context: __SerdeContext): ResourceARNDetail => {
   return {
-    ARN: output.ARN !== undefined && output.ARN !== null ? output.ARN : undefined,
+    ARN: __expectString(output.ARN),
   } as any;
 };
 
 const deserializeAws_restJson1ResponseTimeRootCause = (output: any, context: __SerdeContext): ResponseTimeRootCause => {
   return {
-    ClientImpacting:
-      output.ClientImpacting !== undefined && output.ClientImpacting !== null ? output.ClientImpacting : undefined,
+    ClientImpacting: __expectBoolean(output.ClientImpacting),
     Services:
       output.Services !== undefined && output.Services !== null
         ? deserializeAws_restJson1ResponseTimeRootCauseServices(output.Services, context)
@@ -3662,9 +3646,9 @@ const deserializeAws_restJson1ResponseTimeRootCauseEntity = (
   context: __SerdeContext
 ): ResponseTimeRootCauseEntity => {
   return {
-    Coverage: output.Coverage !== undefined && output.Coverage !== null ? output.Coverage : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
-    Remote: output.Remote !== undefined && output.Remote !== null ? output.Remote : undefined,
+    Coverage: __expectNumber(output.Coverage),
+    Name: __expectString(output.Name),
+    Remote: __expectBoolean(output.Remote),
   } as any;
 };
 
@@ -3701,18 +3685,18 @@ const deserializeAws_restJson1ResponseTimeRootCauseService = (
   context: __SerdeContext
 ): ResponseTimeRootCauseService => {
   return {
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
+    AccountId: __expectString(output.AccountId),
     EntityPath:
       output.EntityPath !== undefined && output.EntityPath !== null
         ? deserializeAws_restJson1ResponseTimeRootCauseEntityPath(output.EntityPath, context)
         : undefined,
-    Inferred: output.Inferred !== undefined && output.Inferred !== null ? output.Inferred : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Inferred: __expectBoolean(output.Inferred),
+    Name: __expectString(output.Name),
     Names:
       output.Names !== undefined && output.Names !== null
         ? deserializeAws_restJson1ServiceNames(output.Names, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -3732,8 +3716,8 @@ const deserializeAws_restJson1ResponseTimeRootCauseServices = (
 
 const deserializeAws_restJson1RootCauseException = (output: any, context: __SerdeContext): RootCauseException => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Message: __expectString(output.Message),
+    Name: __expectString(output.Name),
   } as any;
 };
 
@@ -3754,19 +3738,18 @@ const deserializeAws_restJson1SamplingRule = (output: any, context: __SerdeConte
       output.Attributes !== undefined && output.Attributes !== null
         ? deserializeAws_restJson1AttributeMap(output.Attributes, context)
         : undefined,
-    FixedRate: output.FixedRate !== undefined && output.FixedRate !== null ? output.FixedRate : undefined,
-    HTTPMethod: output.HTTPMethod !== undefined && output.HTTPMethod !== null ? output.HTTPMethod : undefined,
-    Host: output.Host !== undefined && output.Host !== null ? output.Host : undefined,
-    Priority: output.Priority !== undefined && output.Priority !== null ? output.Priority : undefined,
-    ReservoirSize:
-      output.ReservoirSize !== undefined && output.ReservoirSize !== null ? output.ReservoirSize : undefined,
-    ResourceARN: output.ResourceARN !== undefined && output.ResourceARN !== null ? output.ResourceARN : undefined,
-    RuleARN: output.RuleARN !== undefined && output.RuleARN !== null ? output.RuleARN : undefined,
-    RuleName: output.RuleName !== undefined && output.RuleName !== null ? output.RuleName : undefined,
-    ServiceName: output.ServiceName !== undefined && output.ServiceName !== null ? output.ServiceName : undefined,
-    ServiceType: output.ServiceType !== undefined && output.ServiceType !== null ? output.ServiceType : undefined,
-    URLPath: output.URLPath !== undefined && output.URLPath !== null ? output.URLPath : undefined,
-    Version: output.Version !== undefined && output.Version !== null ? output.Version : undefined,
+    FixedRate: __expectNumber(output.FixedRate),
+    HTTPMethod: __expectString(output.HTTPMethod),
+    Host: __expectString(output.Host),
+    Priority: __expectNumber(output.Priority),
+    ReservoirSize: __expectNumber(output.ReservoirSize),
+    ResourceARN: __expectString(output.ResourceARN),
+    RuleARN: __expectString(output.RuleARN),
+    RuleName: __expectString(output.RuleName),
+    ServiceName: __expectString(output.ServiceName),
+    ServiceType: __expectString(output.ServiceType),
+    URLPath: __expectString(output.URLPath),
+    Version: __expectNumber(output.Version),
   } as any;
 };
 
@@ -3803,10 +3786,10 @@ const deserializeAws_restJson1SamplingStatisticSummary = (
   context: __SerdeContext
 ): SamplingStatisticSummary => {
   return {
-    BorrowCount: output.BorrowCount !== undefined && output.BorrowCount !== null ? output.BorrowCount : undefined,
-    RequestCount: output.RequestCount !== undefined && output.RequestCount !== null ? output.RequestCount : undefined,
-    RuleName: output.RuleName !== undefined && output.RuleName !== null ? output.RuleName : undefined,
-    SampledCount: output.SampledCount !== undefined && output.SampledCount !== null ? output.SampledCount : undefined,
+    BorrowCount: __expectNumber(output.BorrowCount),
+    RequestCount: __expectNumber(output.RequestCount),
+    RuleName: __expectString(output.RuleName),
+    SampledCount: __expectNumber(output.SampledCount),
     Timestamp:
       output.Timestamp !== undefined && output.Timestamp !== null
         ? new Date(Math.round(output.Timestamp * 1000))
@@ -3833,15 +3816,14 @@ const deserializeAws_restJson1SamplingTargetDocument = (
   context: __SerdeContext
 ): SamplingTargetDocument => {
   return {
-    FixedRate: output.FixedRate !== undefined && output.FixedRate !== null ? output.FixedRate : undefined,
-    Interval: output.Interval !== undefined && output.Interval !== null ? output.Interval : undefined,
-    ReservoirQuota:
-      output.ReservoirQuota !== undefined && output.ReservoirQuota !== null ? output.ReservoirQuota : undefined,
+    FixedRate: __expectNumber(output.FixedRate),
+    Interval: __expectNumber(output.Interval),
+    ReservoirQuota: __expectNumber(output.ReservoirQuota),
     ReservoirQuotaTTL:
       output.ReservoirQuotaTTL !== undefined && output.ReservoirQuotaTTL !== null
         ? new Date(Math.round(output.ReservoirQuotaTTL * 1000))
         : undefined,
-    RuleName: output.RuleName !== undefined && output.RuleName !== null ? output.RuleName : undefined,
+    RuleName: __expectString(output.RuleName),
   } as any;
 };
 
@@ -3861,8 +3843,8 @@ const deserializeAws_restJson1SamplingTargetDocumentList = (
 
 const deserializeAws_restJson1Segment = (output: any, context: __SerdeContext): Segment => {
   return {
-    Document: output.Document !== undefined && output.Document !== null ? output.Document : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    Document: __expectString(output.Document),
+    Id: __expectString(output.Id),
   } as any;
 };
 
@@ -3879,7 +3861,7 @@ const deserializeAws_restJson1SegmentList = (output: any, context: __SerdeContex
 
 const deserializeAws_restJson1Service = (output: any, context: __SerdeContext): Service => {
   return {
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
+    AccountId: __expectString(output.AccountId),
     DurationHistogram:
       output.DurationHistogram !== undefined && output.DurationHistogram !== null
         ? deserializeAws_restJson1Histogram(output.DurationHistogram, context)
@@ -3890,39 +3872,39 @@ const deserializeAws_restJson1Service = (output: any, context: __SerdeContext): 
         : undefined,
     EndTime:
       output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    Name: __expectString(output.Name),
     Names:
       output.Names !== undefined && output.Names !== null
         ? deserializeAws_restJson1ServiceNames(output.Names, context)
         : undefined,
-    ReferenceId: output.ReferenceId !== undefined && output.ReferenceId !== null ? output.ReferenceId : undefined,
+    ReferenceId: __expectNumber(output.ReferenceId),
     ResponseTimeHistogram:
       output.ResponseTimeHistogram !== undefined && output.ResponseTimeHistogram !== null
         ? deserializeAws_restJson1Histogram(output.ResponseTimeHistogram, context)
         : undefined,
-    Root: output.Root !== undefined && output.Root !== null ? output.Root : undefined,
+    Root: __expectBoolean(output.Root),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
         ? new Date(Math.round(output.StartTime * 1000))
         : undefined,
-    State: output.State !== undefined && output.State !== null ? output.State : undefined,
+    State: __expectString(output.State),
     SummaryStatistics:
       output.SummaryStatistics !== undefined && output.SummaryStatistics !== null
         ? deserializeAws_restJson1ServiceStatistics(output.SummaryStatistics, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
 const deserializeAws_restJson1ServiceId = (output: any, context: __SerdeContext): ServiceId => {
   return {
-    AccountId: output.AccountId !== undefined && output.AccountId !== null ? output.AccountId : undefined,
-    Name: output.Name !== undefined && output.Name !== null ? output.Name : undefined,
+    AccountId: __expectString(output.AccountId),
+    Name: __expectString(output.Name),
     Names:
       output.Names !== undefined && output.Names !== null
         ? deserializeAws_restJson1ServiceNames(output.Names, context)
         : undefined,
-    Type: output.Type !== undefined && output.Type !== null ? output.Type : undefined,
+    Type: __expectString(output.Type),
   } as any;
 };
 
@@ -3955,7 +3937,7 @@ const deserializeAws_restJson1ServiceNames = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -3969,19 +3951,16 @@ const deserializeAws_restJson1ServiceStatistics = (output: any, context: __Serde
       output.FaultStatistics !== undefined && output.FaultStatistics !== null
         ? deserializeAws_restJson1FaultStatistics(output.FaultStatistics, context)
         : undefined,
-    OkCount: output.OkCount !== undefined && output.OkCount !== null ? output.OkCount : undefined,
-    TotalCount: output.TotalCount !== undefined && output.TotalCount !== null ? output.TotalCount : undefined,
-    TotalResponseTime:
-      output.TotalResponseTime !== undefined && output.TotalResponseTime !== null
-        ? output.TotalResponseTime
-        : undefined,
+    OkCount: __expectNumber(output.OkCount),
+    TotalCount: __expectNumber(output.TotalCount),
+    TotalResponseTime: __expectNumber(output.TotalResponseTime),
   } as any;
 };
 
 const deserializeAws_restJson1Tag = (output: any, context: __SerdeContext): Tag => {
   return {
-    Key: output.Key !== undefined && output.Key !== null ? output.Key : undefined,
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Key: __expectString(output.Key),
+    Value: __expectString(output.Value),
   } as any;
 };
 
@@ -4040,10 +4019,9 @@ const deserializeAws_restJson1TimeSeriesServiceStatisticsList = (
 
 const deserializeAws_restJson1Trace = (output: any, context: __SerdeContext): Trace => {
   return {
-    Duration: output.Duration !== undefined && output.Duration !== null ? output.Duration : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    LimitExceeded:
-      output.LimitExceeded !== undefined && output.LimitExceeded !== null ? output.LimitExceeded : undefined,
+    Duration: __expectNumber(output.Duration),
+    Id: __expectString(output.Id),
+    LimitExceeded: __expectBoolean(output.LimitExceeded),
     Segments:
       output.Segments !== undefined && output.Segments !== null
         ? deserializeAws_restJson1SegmentList(output.Segments, context)
@@ -4108,7 +4086,7 @@ const deserializeAws_restJson1TraceSummary = (output: any, context: __SerdeConte
       output.AvailabilityZones !== undefined && output.AvailabilityZones !== null
         ? deserializeAws_restJson1TraceAvailabilityZones(output.AvailabilityZones, context)
         : undefined,
-    Duration: output.Duration !== undefined && output.Duration !== null ? output.Duration : undefined,
+    Duration: __expectNumber(output.Duration),
     EntryPoint:
       output.EntryPoint !== undefined && output.EntryPoint !== null
         ? deserializeAws_restJson1ServiceId(output.EntryPoint, context)
@@ -4121,19 +4099,19 @@ const deserializeAws_restJson1TraceSummary = (output: any, context: __SerdeConte
       output.FaultRootCauses !== undefined && output.FaultRootCauses !== null
         ? deserializeAws_restJson1FaultRootCauses(output.FaultRootCauses, context)
         : undefined,
-    HasError: output.HasError !== undefined && output.HasError !== null ? output.HasError : undefined,
-    HasFault: output.HasFault !== undefined && output.HasFault !== null ? output.HasFault : undefined,
-    HasThrottle: output.HasThrottle !== undefined && output.HasThrottle !== null ? output.HasThrottle : undefined,
+    HasError: __expectBoolean(output.HasError),
+    HasFault: __expectBoolean(output.HasFault),
+    HasThrottle: __expectBoolean(output.HasThrottle),
     Http:
       output.Http !== undefined && output.Http !== null
         ? deserializeAws_restJson1Http(output.Http, context)
         : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
+    Id: __expectString(output.Id),
     InstanceIds:
       output.InstanceIds !== undefined && output.InstanceIds !== null
         ? deserializeAws_restJson1TraceInstanceIds(output.InstanceIds, context)
         : undefined,
-    IsPartial: output.IsPartial !== undefined && output.IsPartial !== null ? output.IsPartial : undefined,
+    IsPartial: __expectBoolean(output.IsPartial),
     MatchedEventTime:
       output.MatchedEventTime !== undefined && output.MatchedEventTime !== null
         ? new Date(Math.round(output.MatchedEventTime * 1000))
@@ -4142,12 +4120,12 @@ const deserializeAws_restJson1TraceSummary = (output: any, context: __SerdeConte
       output.ResourceARNs !== undefined && output.ResourceARNs !== null
         ? deserializeAws_restJson1TraceResourceARNs(output.ResourceARNs, context)
         : undefined,
-    ResponseTime: output.ResponseTime !== undefined && output.ResponseTime !== null ? output.ResponseTime : undefined,
+    ResponseTime: __expectNumber(output.ResponseTime),
     ResponseTimeRootCauses:
       output.ResponseTimeRootCauses !== undefined && output.ResponseTimeRootCauses !== null
         ? deserializeAws_restJson1ResponseTimeRootCauses(output.ResponseTimeRootCauses, context)
         : undefined,
-    Revision: output.Revision !== undefined && output.Revision !== null ? output.Revision : undefined,
+    Revision: __expectNumber(output.Revision),
     ServiceIds:
       output.ServiceIds !== undefined && output.ServiceIds !== null
         ? deserializeAws_restJson1ServiceIds(output.ServiceIds, context)
@@ -4176,7 +4154,7 @@ const deserializeAws_restJson1TraceUser = (output: any, context: __SerdeContext)
       output.ServiceIds !== undefined && output.ServiceIds !== null
         ? deserializeAws_restJson1ServiceIds(output.ServiceIds, context)
         : undefined,
-    UserName: output.UserName !== undefined && output.UserName !== null ? output.UserName : undefined,
+    UserName: __expectString(output.UserName),
   } as any;
 };
 
@@ -4193,9 +4171,9 @@ const deserializeAws_restJson1TraceUsers = (output: any, context: __SerdeContext
 
 const deserializeAws_restJson1UnprocessedStatistics = (output: any, context: __SerdeContext): UnprocessedStatistics => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    RuleName: output.RuleName !== undefined && output.RuleName !== null ? output.RuleName : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    Message: __expectString(output.Message),
+    RuleName: __expectString(output.RuleName),
   } as any;
 };
 
@@ -4220,7 +4198,7 @@ const deserializeAws_restJson1UnprocessedTraceIdList = (output: any, context: __
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4229,9 +4207,9 @@ const deserializeAws_restJson1UnprocessedTraceSegment = (
   context: __SerdeContext
 ): UnprocessedTraceSegment => {
   return {
-    ErrorCode: output.ErrorCode !== undefined && output.ErrorCode !== null ? output.ErrorCode : undefined,
-    Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    ErrorCode: __expectString(output.ErrorCode),
+    Id: __expectString(output.Id),
+    Message: __expectString(output.Message),
   } as any;
 };
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonShapeDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonShapeDeserVisitor.java
@@ -74,7 +74,7 @@ final class JsonShapeDeserVisitor extends DocumentShapeDeserVisitor {
             writer.write("if (entry === null) { return null as any; }");
 
             // Dispatch to the output value provider for any additional handling.
-            writer.write("return $L;", target.accept(getMemberVisitor("entry")));
+            writer.write("return $L$L;", target.accept(getMemberVisitor("entry")), usesExpect(target) ? " as any" : "");
         });
     }
 
@@ -112,7 +112,8 @@ final class JsonShapeDeserVisitor extends DocumentShapeDeserVisitor {
                 writer.openBlock("return {", "};", () -> {
                     writer.write("...acc,");
                     // Dispatch to the output value provider for any additional handling.
-                    writer.write("[key]: $L", target.accept(getMemberVisitor("value")));
+                    writer.write("[key]: $L$L", target.accept(getMemberVisitor("value")),
+                            usesExpect(target) ? " as any" : "");
                 });
             }
         );
@@ -176,8 +177,8 @@ final class JsonShapeDeserVisitor extends DocumentShapeDeserVisitor {
             if (usesExpect(target)) {
                 // Booleans and numbers will call expectBoolean/expectNumber which will handle
                 // null/undefined properly.
-                writer.openBlock("if ((val = $L) !== undefined) {", "}", memberValue, () -> {
-                    writer.write("return { $L: val }", memberName);
+                writer.openBlock("if ($L !== undefined) {", "}", memberValue, () -> {
+                    writer.write("return { $L: $L as any }", memberName, memberValue);
                 });
             } else {
                 writer.openBlock("if (output.$L !== undefined && output.$L !== null) {", "}", locationName,

--- a/packages/smithy-client/src/parse-utils.spec.ts
+++ b/packages/smithy-client/src/parse-utils.spec.ts
@@ -51,6 +51,8 @@ describe("expectBoolean", () => {
   it("accepts booleans", () => {
     expect(expectBoolean(true)).toEqual(true);
     expect(expectBoolean(false)).toEqual(false);
+    expect(expectBoolean(null)).toEqual(undefined);
+    expect(expectBoolean(undefined)).toEqual(undefined);
   });
 
   it("rejects non-booleans", () => {
@@ -64,8 +66,6 @@ describe("expectBoolean", () => {
     expect(() => expectBoolean(NaN)).toThrowError();
     expect(() => expectBoolean({})).toThrowError();
     expect(() => expectBoolean([])).toThrowError();
-    expect(() => expectBoolean(null)).toThrowError();
-    expect(() => expectBoolean(undefined)).toThrowError();
   });
 });
 
@@ -76,6 +76,8 @@ describe("expectNumber", () => {
     expect(expectNumber(Infinity)).toEqual(Infinity);
     expect(expectNumber(-Infinity)).toEqual(-Infinity);
     expect(expectNumber(NaN)).toEqual(NaN);
+    expect(expectNumber(null)).toEqual(undefined);
+    expect(expectNumber(undefined)).toEqual(undefined);
   });
 
   it("rejects non-numbers", () => {
@@ -88,14 +90,14 @@ describe("expectNumber", () => {
     expect(() => expectNumber(false)).toThrowError();
     expect(() => expectNumber([])).toThrowError();
     expect(() => expectNumber({})).toThrowError();
-    expect(() => expectNumber(null)).toThrowError();
-    expect(() => expectNumber(undefined)).toThrowError();
   });
 });
 
 describe("expectString", () => {
   it("accepts strings", () => {
     expect(expectString("foo")).toEqual("foo");
+    expect(expectString(null)).toEqual(undefined);
+    expect(expectString(undefined)).toEqual(undefined);
   });
 
   it("rejects non-strings", () => {
@@ -107,7 +109,5 @@ describe("expectString", () => {
     expect(() => expectString(false)).toThrowError();
     expect(() => expectString([])).toThrowError();
     expect(() => expectString({})).toThrowError();
-    expect(() => expectString(null)).toThrowError();
-    expect(() => expectString(undefined)).toThrowError();
   });
 });

--- a/packages/smithy-client/src/parse-utils.spec.ts
+++ b/packages/smithy-client/src/parse-utils.spec.ts
@@ -1,4 +1,5 @@
 import { parseBoolean } from "./parse-utils";
+import { expectBoolean, expectNumber, expectString } from "./parse-utils";
 
 describe("parseBoolean", () => {
   it('Returns true for "true"', () => {
@@ -43,5 +44,70 @@ describe("parseBoolean", () => {
     expect(() => parseBoolean("Su Lin" as any)).toThrowError();
     expect(() => parseBoolean([] as any)).toThrowError();
     expect(() => parseBoolean({} as any)).toThrowError();
+  });
+});
+
+describe("expectBoolean", () => {
+  it("accepts booleans", () => {
+    expect(expectBoolean(true)).toEqual(true);
+    expect(expectBoolean(false)).toEqual(false);
+  });
+
+  it("rejects non-booleans", () => {
+    expect(() => expectBoolean("true")).toThrowError();
+    expect(() => expectBoolean("false")).toThrowError();
+    expect(() => expectBoolean(0)).toThrowError();
+    expect(() => expectBoolean(1)).toThrowError();
+    expect(() => expectBoolean(1.1)).toThrowError();
+    expect(() => expectBoolean(Infinity)).toThrowError();
+    expect(() => expectBoolean(-Infinity)).toThrowError();
+    expect(() => expectBoolean(NaN)).toThrowError();
+    expect(() => expectBoolean({})).toThrowError();
+    expect(() => expectBoolean([])).toThrowError();
+    expect(() => expectBoolean(null)).toThrowError();
+    expect(() => expectBoolean(undefined)).toThrowError();
+  });
+});
+
+describe("expectNumber", () => {
+  it("accepts numbers", () => {
+    expect(expectNumber(1)).toEqual(1);
+    expect(expectNumber(1.1)).toEqual(1.1);
+    expect(expectNumber(Infinity)).toEqual(Infinity);
+    expect(expectNumber(-Infinity)).toEqual(-Infinity);
+    expect(expectNumber(NaN)).toEqual(NaN);
+  });
+
+  it("rejects non-numbers", () => {
+    expect(() => expectNumber("1")).toThrowError();
+    expect(() => expectNumber("1.1")).toThrowError();
+    expect(() => expectNumber("Infinity")).toThrowError();
+    expect(() => expectNumber("-Infinity")).toThrowError();
+    expect(() => expectNumber("NaN")).toThrowError();
+    expect(() => expectNumber(true)).toThrowError();
+    expect(() => expectNumber(false)).toThrowError();
+    expect(() => expectNumber([])).toThrowError();
+    expect(() => expectNumber({})).toThrowError();
+    expect(() => expectNumber(null)).toThrowError();
+    expect(() => expectNumber(undefined)).toThrowError();
+  });
+});
+
+describe("expectString", () => {
+  it("accepts strings", () => {
+    expect(expectString("foo")).toEqual("foo");
+  });
+
+  it("rejects non-strings", () => {
+    expect(() => expectString(1)).toThrowError();
+    expect(() => expectString(NaN)).toThrowError();
+    expect(() => expectString(Infinity)).toThrowError();
+    expect(() => expectString(-Infinity)).toThrowError();
+    expect(() => expectString(true)).toThrowError();
+    expect(() => expectString(false)).toThrowError();
+    expect(() => expectString([])).toThrowError();
+    expect(() => expectString({})).toThrowError();
+    expect(() => expectString(null)).toThrowError();
+    expect(() => expectString(undefined)).toThrowError();
   });
 });

--- a/packages/smithy-client/src/parse-utils.ts
+++ b/packages/smithy-client/src/parse-utils.ts
@@ -22,7 +22,7 @@ export const parseBoolean = (value: string): boolean => {
  * @returns The value if it's a boolean, undefined if it's null/undefined,
  *   otherwise an error is thrown.
  */
-export function expectBoolean(value: any): boolean | undefined {
+export const expectBoolean = (value: any): boolean | undefined => {
   if (value === null || value === undefined) {
     return undefined;
   }
@@ -30,7 +30,7 @@ export function expectBoolean(value: any): boolean | undefined {
     return value;
   }
   throw new TypeError(`Expected boolean, got ${typeof value}`);
-}
+};
 
 /**
  * Asserts a value is a number and returns it.
@@ -39,7 +39,7 @@ export function expectBoolean(value: any): boolean | undefined {
  * @returns The value if it's a number, undefined if it's null/undefined,
  *   otherwise an error is thrown.
  */
-export function expectNumber(value: any): number | undefined {
+export const expectNumber = (value: any): number | undefined => {
   if (value === null || value === undefined) {
     return undefined;
   }
@@ -47,7 +47,7 @@ export function expectNumber(value: any): number | undefined {
     return value;
   }
   throw new TypeError(`Expected number, got ${typeof value}`);
-}
+};
 
 /**
  * Asserts a value is a string and returns it.
@@ -56,7 +56,7 @@ export function expectNumber(value: any): number | undefined {
  * @returns The value if it's a string, undefined if it's null/undefined,
  *   otherwise an error is thrown.
  */
-export function expectString(value: any): string | undefined {
+export const expectString = (value: any): string | undefined => {
   if (value === null || value === undefined) {
     return undefined;
   }
@@ -64,4 +64,4 @@ export function expectString(value: any): string | undefined {
     return value;
   }
   throw new TypeError(`Expected string, got ${typeof value}`);
-}
+};

--- a/packages/smithy-client/src/parse-utils.ts
+++ b/packages/smithy-client/src/parse-utils.ts
@@ -39,7 +39,7 @@ export function expectBoolean(value: any): boolean | undefined {
  * @returns The value if it's a number, undefined if it's null/undefined,
  *   otherwise an error is thrown.
  */
-export function expectNumber(value: any): number {
+export function expectNumber(value: any): number | undefined {
   if (value === null || value === undefined) {
     return undefined;
   }
@@ -56,7 +56,7 @@ export function expectNumber(value: any): number {
  * @returns The value if it's a string, undefined if it's null/undefined,
  *   otherwise an error is thrown.
  */
-export function expectString(value: any): string {
+export function expectString(value: any): string | undefined {
   if (value === null || value === undefined) {
     return undefined;
   }

--- a/packages/smithy-client/src/parse-utils.ts
+++ b/packages/smithy-client/src/parse-utils.ts
@@ -19,9 +19,13 @@ export const parseBoolean = (value: string): boolean => {
  * Asserts a value is a boolean and returns it.
  *
  * @param value A value that is expected to be a boolean.
- * @returns The value if it is a boolean, otherwise an error is thrown.
+ * @returns The value if it's a boolean, undefined if it's null/undefined,
+ *   otherwise an error is thrown.
  */
-export function expectBoolean(value: any): boolean {
+export function expectBoolean(value: any): boolean | undefined {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
   if (typeof value === "boolean") {
     return value;
   }
@@ -32,9 +36,13 @@ export function expectBoolean(value: any): boolean {
  * Asserts a value is a number and returns it.
  *
  * @param value A value that is expected to be a number.
- * @returns The value if it is a number, otherwise an error is thrown.
+ * @returns The value if it's a number, undefined if it's null/undefined,
+ *   otherwise an error is thrown.
  */
 export function expectNumber(value: any): number {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
   if (typeof value === "number") {
     return value;
   }
@@ -45,9 +53,13 @@ export function expectNumber(value: any): number {
  * Asserts a value is a string and returns it.
  *
  * @param value A value that is expected to be a string.
- * @returns The value if it is a string, otherwise an error is thrown.
+ * @returns The value if it's a string, undefined if it's null/undefined,
+ *   otherwise an error is thrown.
  */
 export function expectString(value: any): string {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
   if (typeof value === "string") {
     return value;
   }

--- a/packages/smithy-client/src/parse-utils.ts
+++ b/packages/smithy-client/src/parse-utils.ts
@@ -13,4 +13,43 @@ export const parseBoolean = (value: string): boolean => {
     default:
       throw new Error(`Unable to parse boolean value "${value}"`);
   }
+};
+
+/*
+ * Asserts a value is a boolean and returns it.
+ *
+ * @param value A value that is expected to be a boolean.
+ * @returns The value if it is a boolean, otherwise an error is thrown.
+ */
+export function expectBoolean(value: any): boolean {
+  if (typeof value === "boolean") {
+    return value;
+  }
+  throw new TypeError(`Expected boolean, got ${typeof value}`);
+}
+
+/**
+ * Asserts a value is a number and returns it.
+ *
+ * @param value A value that is expected to be a number.
+ * @returns The value if it is a number, otherwise an error is thrown.
+ */
+export function expectNumber(value: any): number {
+  if (typeof value === "number") {
+    return value;
+  }
+  throw new TypeError(`Expected number, got ${typeof value}`);
+}
+
+/**
+ * Asserts a value is a string and returns it.
+ *
+ * @param value A value that is expected to be a string.
+ * @returns The value if it is a string, otherwise an error is thrown.
+ */
+export function expectString(value: any): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  throw new TypeError(`Expected string, got ${typeof value}`);
 }

--- a/protocol_tests/aws-ec2/protocols/Aws_ec2.ts
+++ b/protocol_tests/aws-ec2/protocols/Aws_ec2.ts
@@ -70,6 +70,7 @@ import {
 } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
@@ -1541,7 +1542,7 @@ const deserializeAws_ec2ComplexError = (output: any, context: __SerdeContext): C
     Nested: undefined,
   };
   if (output["TopLevel"] !== undefined) {
-    contents.TopLevel = output["TopLevel"];
+    contents.TopLevel = __expectString(output["TopLevel"]);
   }
   if (output["Nested"] !== undefined) {
     contents.Nested = deserializeAws_ec2ComplexNestedErrorData(output["Nested"], context);
@@ -1554,7 +1555,7 @@ const deserializeAws_ec2ComplexNestedErrorData = (output: any, context: __SerdeC
     Foo: undefined,
   };
   if (output["Foo"] !== undefined) {
-    contents.Foo = output["Foo"];
+    contents.Foo = __expectString(output["Foo"]);
   }
   return contents;
 };
@@ -1572,7 +1573,7 @@ const deserializeAws_ec2GreetingWithErrorsOutput = (output: any, context: __Serd
     greeting: undefined,
   };
   if (output["greeting"] !== undefined) {
-    contents.greeting = output["greeting"];
+    contents.greeting = __expectString(output["greeting"]);
   }
   return contents;
 };
@@ -1585,7 +1586,7 @@ const deserializeAws_ec2IgnoresWrappingXmlNameOutput = (
     foo: undefined,
   };
   if (output["foo"] !== undefined) {
-    contents.foo = output["foo"];
+    contents.foo = __expectString(output["foo"]);
   }
   return contents;
 };
@@ -1595,7 +1596,7 @@ const deserializeAws_ec2InvalidGreeting = (output: any, context: __SerdeContext)
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -1607,7 +1608,7 @@ const deserializeAws_ec2ListWithMemberNamespace = (output: any, context: __Serde
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -1618,7 +1619,7 @@ const deserializeAws_ec2ListWithNamespace = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -1646,7 +1647,7 @@ const deserializeAws_ec2RecursiveXmlShapesOutputNested1 = (
     nested: undefined,
   };
   if (output["foo"] !== undefined) {
-    contents.foo = output["foo"];
+    contents.foo = __expectString(output["foo"]);
   }
   if (output["nested"] !== undefined) {
     contents.nested = deserializeAws_ec2RecursiveXmlShapesOutputNested2(output["nested"], context);
@@ -1663,7 +1664,7 @@ const deserializeAws_ec2RecursiveXmlShapesOutputNested2 = (
     recursiveMember: undefined,
   };
   if (output["bar"] !== undefined) {
-    contents.bar = output["bar"];
+    contents.bar = __expectString(output["bar"]);
   }
   if (output["recursiveMember"] !== undefined) {
     contents.recursiveMember = deserializeAws_ec2RecursiveXmlShapesOutputNested1(output["recursiveMember"], context);
@@ -1678,7 +1679,7 @@ const deserializeAws_ec2RenamedListMembers = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -1699,10 +1700,10 @@ const deserializeAws_ec2SimpleScalarXmlPropertiesOutput = (
     doubleValue: undefined,
   };
   if (output["stringValue"] !== undefined) {
-    contents.stringValue = output["stringValue"];
+    contents.stringValue = __expectString(output["stringValue"]);
   }
   if (output["emptyStringValue"] !== undefined) {
-    contents.emptyStringValue = output["emptyStringValue"];
+    contents.emptyStringValue = __expectString(output["emptyStringValue"]);
   }
   if (output["trueBooleanValue"] !== undefined) {
     contents.trueBooleanValue = __parseBoolean(output["trueBooleanValue"]);
@@ -1748,10 +1749,10 @@ const deserializeAws_ec2StructureListMember = (output: any, context: __SerdeCont
     b: undefined,
   };
   if (output["value"] !== undefined) {
-    contents.a = output["value"];
+    contents.a = __expectString(output["value"]);
   }
   if (output["other"] !== undefined) {
-    contents.b = output["other"];
+    contents.b = __expectString(output["other"]);
   }
   return contents;
 };
@@ -1776,13 +1777,13 @@ const deserializeAws_ec2XmlEnumsOutput = (output: any, context: __SerdeContext):
     fooEnumMap: undefined,
   };
   if (output["fooEnum1"] !== undefined) {
-    contents.fooEnum1 = output["fooEnum1"];
+    contents.fooEnum1 = __expectString(output["fooEnum1"]);
   }
   if (output["fooEnum2"] !== undefined) {
-    contents.fooEnum2 = output["fooEnum2"];
+    contents.fooEnum2 = __expectString(output["fooEnum2"]);
   }
   if (output["fooEnum3"] !== undefined) {
-    contents.fooEnum3 = output["fooEnum3"];
+    contents.fooEnum3 = __expectString(output["fooEnum3"]);
   }
   if (output.fooEnumList === "") {
     contents.fooEnumList = [];
@@ -1942,7 +1943,7 @@ const deserializeAws_ec2XmlNamespacedList = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -1952,7 +1953,7 @@ const deserializeAws_ec2XmlNamespaceNested = (output: any, context: __SerdeConte
     values: undefined,
   };
   if (output["foo"] !== undefined) {
-    contents.foo = output["foo"];
+    contents.foo = __expectString(output["foo"]);
   }
   if (output.values === "") {
     contents.values = [];
@@ -2013,7 +2014,7 @@ const deserializeAws_ec2FooEnumList = (output: any, context: __SerdeContext): (F
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2024,7 +2025,7 @@ const deserializeAws_ec2FooEnumMap = (output: any, context: __SerdeContext): { [
     }
     return {
       ...acc,
-      [pair["key"]]: pair["value"],
+      [pair["key"]]: __expectString(pair["value"]) as any,
     };
   }, {});
 };
@@ -2036,7 +2037,7 @@ const deserializeAws_ec2FooEnumSet = (output: any, context: __SerdeContext): (Fo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2069,7 +2070,7 @@ const deserializeAws_ec2StringList = (output: any, context: __SerdeContext): str
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2080,7 +2081,7 @@ const deserializeAws_ec2StringSet = (output: any, context: __SerdeContext): stri
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 

--- a/protocol_tests/aws-json/protocols/Aws_json1_1.ts
+++ b/protocol_tests/aws-json/protocols/Aws_json1_1.ts
@@ -51,6 +51,9 @@ import {
   LazyJsonString as __LazyJsonString,
   SmithyException as __SmithyException,
   dateToUtcString as __dateToUtcString,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -1142,13 +1145,13 @@ const deserializeAws_json1_1ComplexError = (output: any, context: __SerdeContext
       output.Nested !== undefined && output.Nested !== null
         ? deserializeAws_json1_1ComplexNestedErrorData(output.Nested, context)
         : undefined,
-    TopLevel: output.TopLevel !== undefined && output.TopLevel !== null ? output.TopLevel : undefined,
+    TopLevel: __expectString(output.TopLevel),
   } as any;
 };
 
 const deserializeAws_json1_1ComplexNestedErrorData = (output: any, context: __SerdeContext): ComplexNestedErrorData => {
   return {
-    Foo: output.Fooooo !== undefined && output.Fooooo !== null ? output.Fooooo : undefined,
+    Foo: __expectString(output.Fooooo),
   } as any;
 };
 
@@ -1162,12 +1165,12 @@ const deserializeAws_json1_1EmptyStruct = (output: any, context: __SerdeContext)
 
 const deserializeAws_json1_1ErrorWithMembers = (output: any, context: __SerdeContext): ErrorWithMembers => {
   return {
-    Code: output.Code !== undefined && output.Code !== null ? output.Code : undefined,
+    Code: __expectString(output.Code),
     ComplexData:
       output.ComplexData !== undefined && output.ComplexData !== null
         ? deserializeAws_json1_1KitchenSink(output.ComplexData, context)
         : undefined,
-    IntegerField: output.IntegerField !== undefined && output.IntegerField !== null ? output.IntegerField : undefined,
+    IntegerField: __expectNumber(output.IntegerField),
     ListField:
       output.ListField !== undefined && output.ListField !== null
         ? deserializeAws_json1_1ListOfStrings(output.ListField, context)
@@ -1176,8 +1179,8 @@ const deserializeAws_json1_1ErrorWithMembers = (output: any, context: __SerdeCon
       output.MapField !== undefined && output.MapField !== null
         ? deserializeAws_json1_1MapOfStrings(output.MapField, context)
         : undefined,
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
-    StringField: output.StringField !== undefined && output.StringField !== null ? output.StringField : undefined,
+    Message: __expectString(output.Message),
+    StringField: __expectString(output.StringField),
   } as any;
 };
 
@@ -1194,21 +1197,21 @@ const deserializeAws_json1_1GreetingWithErrorsOutput = (
   context: __SerdeContext
 ): GreetingWithErrorsOutput => {
   return {
-    greeting: output.greeting !== undefined && output.greeting !== null ? output.greeting : undefined,
+    greeting: __expectString(output.greeting),
   } as any;
 };
 
 const deserializeAws_json1_1InvalidGreeting = (output: any, context: __SerdeContext): InvalidGreeting => {
   return {
-    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+    Message: __expectString(output.Message),
   } as any;
 };
 
 const deserializeAws_json1_1JsonEnumsInputOutput = (output: any, context: __SerdeContext): JsonEnumsInputOutput => {
   return {
-    fooEnum1: output.fooEnum1 !== undefined && output.fooEnum1 !== null ? output.fooEnum1 : undefined,
-    fooEnum2: output.fooEnum2 !== undefined && output.fooEnum2 !== null ? output.fooEnum2 : undefined,
-    fooEnum3: output.fooEnum3 !== undefined && output.fooEnum3 !== null ? output.fooEnum3 : undefined,
+    fooEnum1: __expectString(output.fooEnum1),
+    fooEnum2: __expectString(output.fooEnum2),
+    fooEnum3: __expectString(output.fooEnum3),
     fooEnumList:
       output.fooEnumList !== undefined && output.fooEnumList !== null
         ? deserializeAws_json1_1FooEnumList(output.fooEnumList, context)
@@ -1227,18 +1230,18 @@ const deserializeAws_json1_1JsonEnumsInputOutput = (output: any, context: __Serd
 const deserializeAws_json1_1KitchenSink = (output: any, context: __SerdeContext): KitchenSink => {
   return {
     Blob: output.Blob !== undefined && output.Blob !== null ? context.base64Decoder(output.Blob) : undefined,
-    Boolean: output.Boolean !== undefined && output.Boolean !== null ? output.Boolean : undefined,
-    Double: output.Double !== undefined && output.Double !== null ? output.Double : undefined,
+    Boolean: __expectBoolean(output.Boolean),
+    Double: __expectNumber(output.Double),
     EmptyStruct:
       output.EmptyStruct !== undefined && output.EmptyStruct !== null
         ? deserializeAws_json1_1EmptyStruct(output.EmptyStruct, context)
         : undefined,
-    Float: output.Float !== undefined && output.Float !== null ? output.Float : undefined,
+    Float: __expectNumber(output.Float),
     HttpdateTimestamp:
       output.HttpdateTimestamp !== undefined && output.HttpdateTimestamp !== null
         ? new Date(Math.round(output.HttpdateTimestamp * 1000))
         : undefined,
-    Integer: output.Integer !== undefined && output.Integer !== null ? output.Integer : undefined,
+    Integer: __expectNumber(output.Integer),
     Iso8601Timestamp:
       output.Iso8601Timestamp !== undefined && output.Iso8601Timestamp !== null
         ? new Date(Math.round(output.Iso8601Timestamp * 1000))
@@ -1261,7 +1264,7 @@ const deserializeAws_json1_1KitchenSink = (output: any, context: __SerdeContext)
       output.ListOfStructs !== undefined && output.ListOfStructs !== null
         ? deserializeAws_json1_1ListOfStructs(output.ListOfStructs, context)
         : undefined,
-    Long: output.Long !== undefined && output.Long !== null ? output.Long : undefined,
+    Long: __expectNumber(output.Long),
     MapOfListsOfStrings:
       output.MapOfListsOfStrings !== undefined && output.MapOfListsOfStrings !== null
         ? deserializeAws_json1_1MapOfListsOfStrings(output.MapOfListsOfStrings, context)
@@ -1294,7 +1297,7 @@ const deserializeAws_json1_1KitchenSink = (output: any, context: __SerdeContext)
       output.SimpleStruct !== undefined && output.SimpleStruct !== null
         ? deserializeAws_json1_1SimpleStruct(output.SimpleStruct, context)
         : undefined,
-    String: output.String !== undefined && output.String !== null ? output.String : undefined,
+    String: __expectString(output.String),
     StructWithLocationName:
       output.StructWithLocationName !== undefined && output.StructWithLocationName !== null
         ? deserializeAws_json1_1StructWithLocationName(output.StructWithLocationName, context)
@@ -1353,7 +1356,7 @@ const deserializeAws_json1_1ListOfStrings = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -1423,7 +1426,7 @@ const deserializeAws_json1_1MapOfStrings = (output: any, context: __SerdeContext
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -1446,15 +1449,11 @@ const deserializeAws_json1_1MyUnion = (output: any, context: __SerdeContext): My
       blobValue: context.base64Decoder(output.blobValue),
     };
   }
-  if (output.booleanValue !== undefined && output.booleanValue !== null) {
-    return {
-      booleanValue: output.booleanValue,
-    };
+  if (__expectBoolean(output.booleanValue) !== undefined) {
+    return { booleanValue: __expectBoolean(output.booleanValue) as any };
   }
-  if (output.enumValue !== undefined && output.enumValue !== null) {
-    return {
-      enumValue: output.enumValue,
-    };
+  if (__expectString(output.enumValue) !== undefined) {
+    return { enumValue: __expectString(output.enumValue) as any };
   }
   if (output.listValue !== undefined && output.listValue !== null) {
     return {
@@ -1466,15 +1465,11 @@ const deserializeAws_json1_1MyUnion = (output: any, context: __SerdeContext): My
       mapValue: deserializeAws_json1_1StringMap(output.mapValue, context),
     };
   }
-  if (output.numberValue !== undefined && output.numberValue !== null) {
-    return {
-      numberValue: output.numberValue,
-    };
+  if (__expectNumber(output.numberValue) !== undefined) {
+    return { numberValue: __expectNumber(output.numberValue) as any };
   }
-  if (output.stringValue !== undefined && output.stringValue !== null) {
-    return {
-      stringValue: output.stringValue,
-    };
+  if (__expectString(output.stringValue) !== undefined) {
+    return { stringValue: __expectString(output.stringValue) as any };
   }
   if (output.structureValue !== undefined && output.structureValue !== null) {
     return {
@@ -1502,7 +1497,7 @@ const deserializeAws_json1_1NullOperationInputOutput = (
       output.sparseStringMap !== undefined && output.sparseStringMap !== null
         ? deserializeAws_json1_1SparseStringMap(output.sparseStringMap, context)
         : undefined,
-    string: output.string !== undefined && output.string !== null ? output.string : undefined,
+    string: __expectString(output.string),
   } as any;
 };
 
@@ -1520,13 +1515,13 @@ const deserializeAws_json1_1PutAndGetInlineDocumentsInputOutput = (
 
 const deserializeAws_json1_1SimpleStruct = (output: any, context: __SerdeContext): SimpleStruct => {
   return {
-    Value: output.Value !== undefined && output.Value !== null ? output.Value : undefined,
+    Value: __expectString(output.Value),
   } as any;
 };
 
 const deserializeAws_json1_1StructWithLocationName = (output: any, context: __SerdeContext): StructWithLocationName => {
   return {
-    Value: output.RenamedMember !== undefined && output.RenamedMember !== null ? output.RenamedMember : undefined,
+    Value: __expectString(output.RenamedMember),
   } as any;
 };
 
@@ -1546,7 +1541,7 @@ const deserializeAws_json1_1FooEnumList = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -1560,7 +1555,7 @@ const deserializeAws_json1_1FooEnumMap = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -1572,13 +1567,13 @@ const deserializeAws_json1_1FooEnumSet = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_json1_1GreetingStruct = (output: any, context: __SerdeContext): GreetingStruct => {
   return {
-    hi: output.hi !== undefined && output.hi !== null ? output.hi : undefined,
+    hi: __expectString(output.hi),
   } as any;
 };
 
@@ -1587,7 +1582,7 @@ const deserializeAws_json1_1SparseStringList = (output: any, context: __SerdeCon
     if (entry === null) {
       return null as any;
     }
-    return entry;
+    return __expectString(entry) as any;
   });
 };
 
@@ -1598,7 +1593,7 @@ const deserializeAws_json1_1SparseStringMap = (output: any, context: __SerdeCont
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -1610,7 +1605,7 @@ const deserializeAws_json1_1StringList = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -1621,7 +1616,7 @@ const deserializeAws_json1_1StringMap = (output: any, context: __SerdeContext): 
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };

--- a/protocol_tests/aws-query/protocols/Aws_query.ts
+++ b/protocol_tests/aws-query/protocols/Aws_query.ts
@@ -91,6 +91,7 @@ import {
 } from "@aws-sdk/protocol-http";
 import {
   SmithyException as __SmithyException,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
@@ -2178,7 +2179,7 @@ const deserializeAws_queryComplexError = (output: any, context: __SerdeContext):
     Nested: undefined,
   };
   if (output["TopLevel"] !== undefined) {
-    contents.TopLevel = output["TopLevel"];
+    contents.TopLevel = __expectString(output["TopLevel"]);
   }
   if (output["Nested"] !== undefined) {
     contents.Nested = deserializeAws_queryComplexNestedErrorData(output["Nested"], context);
@@ -2191,7 +2192,7 @@ const deserializeAws_queryComplexNestedErrorData = (output: any, context: __Serd
     Foo: undefined,
   };
   if (output["Foo"] !== undefined) {
-    contents.Foo = output["Foo"];
+    contents.Foo = __expectString(output["Foo"]);
   }
   return contents;
 };
@@ -2201,7 +2202,7 @@ const deserializeAws_queryCustomCodeError = (output: any, context: __SerdeContex
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -2256,7 +2257,7 @@ const deserializeAws_queryFlattenedXmlMapWithXmlNameOutputMap = (
     }
     return {
       ...acc,
-      [pair["K"]]: pair["V"],
+      [pair["K"]]: __expectString(pair["V"]) as any,
     };
   }, {});
 };
@@ -2290,7 +2291,7 @@ const deserializeAws_queryFlattenedXmlMapWithXmlNamespaceOutputMap = (
     }
     return {
       ...acc,
-      [pair["K"]]: pair["V"],
+      [pair["K"]]: __expectString(pair["V"]) as any,
     };
   }, {});
 };
@@ -2303,7 +2304,7 @@ const deserializeAws_queryGreetingWithErrorsOutput = (
     greeting: undefined,
   };
   if (output["greeting"] !== undefined) {
-    contents.greeting = output["greeting"];
+    contents.greeting = __expectString(output["greeting"]);
   }
   return contents;
 };
@@ -2316,7 +2317,7 @@ const deserializeAws_queryIgnoresWrappingXmlNameOutput = (
     foo: undefined,
   };
   if (output["foo"] !== undefined) {
-    contents.foo = output["foo"];
+    contents.foo = __expectString(output["foo"]);
   }
   return contents;
 };
@@ -2326,7 +2327,7 @@ const deserializeAws_queryInvalidGreeting = (output: any, context: __SerdeContex
     Message: undefined,
   };
   if (output["Message"] !== undefined) {
-    contents.Message = output["Message"];
+    contents.Message = __expectString(output["Message"]);
   }
   return contents;
 };
@@ -2338,7 +2339,7 @@ const deserializeAws_queryListWithMemberNamespace = (output: any, context: __Ser
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2349,7 +2350,7 @@ const deserializeAws_queryListWithNamespace = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2375,7 +2376,7 @@ const deserializeAws_queryRecursiveXmlShapesOutputNested1 = (
     nested: undefined,
   };
   if (output["foo"] !== undefined) {
-    contents.foo = output["foo"];
+    contents.foo = __expectString(output["foo"]);
   }
   if (output["nested"] !== undefined) {
     contents.nested = deserializeAws_queryRecursiveXmlShapesOutputNested2(output["nested"], context);
@@ -2392,7 +2393,7 @@ const deserializeAws_queryRecursiveXmlShapesOutputNested2 = (
     recursiveMember: undefined,
   };
   if (output["bar"] !== undefined) {
-    contents.bar = output["bar"];
+    contents.bar = __expectString(output["bar"]);
   }
   if (output["recursiveMember"] !== undefined) {
     contents.recursiveMember = deserializeAws_queryRecursiveXmlShapesOutputNested1(output["recursiveMember"], context);
@@ -2407,7 +2408,7 @@ const deserializeAws_queryRenamedListMembers = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2428,10 +2429,10 @@ const deserializeAws_querySimpleScalarXmlPropertiesOutput = (
     doubleValue: undefined,
   };
   if (output["stringValue"] !== undefined) {
-    contents.stringValue = output["stringValue"];
+    contents.stringValue = __expectString(output["stringValue"]);
   }
   if (output["emptyStringValue"] !== undefined) {
-    contents.emptyStringValue = output["emptyStringValue"];
+    contents.emptyStringValue = __expectString(output["emptyStringValue"]);
   }
   if (output["trueBooleanValue"] !== undefined) {
     contents.trueBooleanValue = __parseBoolean(output["trueBooleanValue"]);
@@ -2477,10 +2478,10 @@ const deserializeAws_queryStructureListMember = (output: any, context: __SerdeCo
     b: undefined,
   };
   if (output["value"] !== undefined) {
-    contents.a = output["value"];
+    contents.a = __expectString(output["value"]);
   }
   if (output["other"] !== undefined) {
-    contents.b = output["other"];
+    contents.b = __expectString(output["other"]);
   }
   return contents;
 };
@@ -2505,13 +2506,13 @@ const deserializeAws_queryXmlEnumsOutput = (output: any, context: __SerdeContext
     fooEnumMap: undefined,
   };
   if (output["fooEnum1"] !== undefined) {
-    contents.fooEnum1 = output["fooEnum1"];
+    contents.fooEnum1 = __expectString(output["fooEnum1"]);
   }
   if (output["fooEnum2"] !== undefined) {
-    contents.fooEnum2 = output["fooEnum2"];
+    contents.fooEnum2 = __expectString(output["fooEnum2"]);
   }
   if (output["fooEnum3"] !== undefined) {
-    contents.fooEnum3 = output["fooEnum3"];
+    contents.fooEnum3 = __expectString(output["fooEnum3"]);
   }
   if (output.fooEnumList === "") {
     contents.fooEnumList = [];
@@ -2739,7 +2740,7 @@ const deserializeAws_queryXmlNamespacedList = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2749,7 +2750,7 @@ const deserializeAws_queryXmlNamespaceNested = (output: any, context: __SerdeCon
     values: undefined,
   };
   if (output["foo"] !== undefined) {
-    contents.foo = output["foo"];
+    contents.foo = __expectString(output["foo"]);
   }
   if (output.values === "") {
     contents.values = [];
@@ -2813,7 +2814,7 @@ const deserializeAws_queryFooEnumList = (output: any, context: __SerdeContext): 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2824,7 +2825,7 @@ const deserializeAws_queryFooEnumMap = (output: any, context: __SerdeContext): {
     }
     return {
       ...acc,
-      [pair["key"]]: pair["value"],
+      [pair["key"]]: __expectString(pair["value"]) as any,
     };
   }, {});
 };
@@ -2836,7 +2837,7 @@ const deserializeAws_queryFooEnumSet = (output: any, context: __SerdeContext): (
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2845,7 +2846,7 @@ const deserializeAws_queryGreetingStruct = (output: any, context: __SerdeContext
     hi: undefined,
   };
   if (output["hi"] !== undefined) {
-    contents.hi = output["hi"];
+    contents.hi = __expectString(output["hi"]);
   }
   return contents;
 };
@@ -2879,7 +2880,7 @@ const deserializeAws_queryStringList = (output: any, context: __SerdeContext): s
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -2890,7 +2891,7 @@ const deserializeAws_queryStringSet = (output: any, context: __SerdeContext): st
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 

--- a/protocol_tests/aws-restjson/protocols/Aws_restJson1.ts
+++ b/protocol_tests/aws-restjson/protocols/Aws_restJson1.ts
@@ -134,6 +134,9 @@ import {
   LazyJsonString as __LazyJsonString,
   SmithyException as __SmithyException,
   dateToUtcString as __dateToUtcString,
+  expectBoolean as __expectBoolean,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   parseBoolean as __parseBoolean,
   splitEvery as __splitEvery,
@@ -1861,7 +1864,7 @@ export const deserializeAws_restJson1HttpEnumPayloadCommand = async (
     payload: undefined,
   };
   const data: any = await collectBodyString(output.body, context);
-  contents.payload = data;
+  contents.payload = __expectString(data);
   return Promise.resolve(contents);
 };
 
@@ -2333,7 +2336,7 @@ export const deserializeAws_restJson1HttpStringPayloadCommand = async (
     payload: undefined,
   };
   const data: any = await collectBodyString(output.body, context);
-  contents.payload = data;
+  contents.payload = __expectString(data);
   return Promise.resolve(contents);
 };
 
@@ -2379,7 +2382,7 @@ export const deserializeAws_restJson1IgnoreQueryParamsInResponseCommand = async 
   };
   const data: any = await parseBody(output.body, context);
   if (data.baz !== undefined && data.baz !== null) {
-    contents.baz = data.baz;
+    contents.baz = __expectString(data.baz);
   }
   return Promise.resolve(contents);
 };
@@ -2430,7 +2433,7 @@ export const deserializeAws_restJson1InlineDocumentCommand = async (
     contents.documentValue = deserializeAws_restJson1Document(data.documentValue, context);
   }
   if (data.stringValue !== undefined && data.stringValue !== null) {
-    contents.stringValue = data.stringValue;
+    contents.stringValue = __expectString(data.stringValue);
   }
   return Promise.resolve(contents);
 };
@@ -2688,13 +2691,13 @@ export const deserializeAws_restJson1JsonEnumsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data.fooEnum1 !== undefined && data.fooEnum1 !== null) {
-    contents.fooEnum1 = data.fooEnum1;
+    contents.fooEnum1 = __expectString(data.fooEnum1);
   }
   if (data.fooEnum2 !== undefined && data.fooEnum2 !== null) {
-    contents.fooEnum2 = data.fooEnum2;
+    contents.fooEnum2 = __expectString(data.fooEnum2);
   }
   if (data.fooEnum3 !== undefined && data.fooEnum3 !== null) {
-    contents.fooEnum3 = data.fooEnum3;
+    contents.fooEnum3 = __expectString(data.fooEnum3);
   }
   if (data.fooEnumList !== undefined && data.fooEnumList !== null) {
     contents.fooEnumList = deserializeAws_restJson1FooEnumList(data.fooEnumList, context);
@@ -3484,31 +3487,31 @@ export const deserializeAws_restJson1SimpleScalarPropertiesCommand = async (
   }
   const data: any = await parseBody(output.body, context);
   if (data.byteValue !== undefined && data.byteValue !== null) {
-    contents.byteValue = data.byteValue;
+    contents.byteValue = __expectNumber(data.byteValue);
   }
   if (data.DoubleDribble !== undefined && data.DoubleDribble !== null) {
-    contents.doubleValue = data.DoubleDribble;
+    contents.doubleValue = __expectNumber(data.DoubleDribble);
   }
   if (data.falseBooleanValue !== undefined && data.falseBooleanValue !== null) {
-    contents.falseBooleanValue = data.falseBooleanValue;
+    contents.falseBooleanValue = __expectBoolean(data.falseBooleanValue);
   }
   if (data.floatValue !== undefined && data.floatValue !== null) {
-    contents.floatValue = data.floatValue;
+    contents.floatValue = __expectNumber(data.floatValue);
   }
   if (data.integerValue !== undefined && data.integerValue !== null) {
-    contents.integerValue = data.integerValue;
+    contents.integerValue = __expectNumber(data.integerValue);
   }
   if (data.longValue !== undefined && data.longValue !== null) {
-    contents.longValue = data.longValue;
+    contents.longValue = __expectNumber(data.longValue);
   }
   if (data.shortValue !== undefined && data.shortValue !== null) {
-    contents.shortValue = data.shortValue;
+    contents.shortValue = __expectNumber(data.shortValue);
   }
   if (data.stringValue !== undefined && data.stringValue !== null) {
-    contents.stringValue = data.stringValue;
+    contents.stringValue = __expectString(data.stringValue);
   }
   if (data.trueBooleanValue !== undefined && data.trueBooleanValue !== null) {
-    contents.trueBooleanValue = data.trueBooleanValue;
+    contents.trueBooleanValue = __expectBoolean(data.trueBooleanValue);
   }
   return Promise.resolve(contents);
 };
@@ -3780,7 +3783,7 @@ const deserializeAws_restJson1ComplexErrorResponse = async (
     contents.Nested = deserializeAws_restJson1ComplexNestedErrorData(data.Nested, context);
   }
   if (data.TopLevel !== undefined && data.TopLevel !== null) {
-    contents.TopLevel = data.TopLevel;
+    contents.TopLevel = __expectString(data.TopLevel);
   }
   return contents;
 };
@@ -3810,7 +3813,7 @@ const deserializeAws_restJson1InvalidGreetingResponse = async (
   };
   const data: any = parsedOutput.body;
   if (data.Message !== undefined && data.Message !== null) {
-    contents.Message = data.Message;
+    contents.Message = __expectString(data.Message);
   }
   return contents;
 };
@@ -4128,7 +4131,7 @@ const deserializeAws_restJson1ComplexNestedErrorData = (
   context: __SerdeContext
 ): ComplexNestedErrorData => {
   return {
-    Foo: output.Fooooo !== undefined && output.Fooooo !== null ? output.Fooooo : undefined,
+    Foo: __expectString(output.Fooooo),
   } as any;
 };
 
@@ -4139,7 +4142,7 @@ const deserializeAws_restJson1DenseBooleanMap = (output: any, context: __SerdeCo
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectBoolean(value) as any,
     };
   }, {});
 };
@@ -4151,7 +4154,7 @@ const deserializeAws_restJson1DenseNumberMap = (output: any, context: __SerdeCon
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectNumber(value) as any,
     };
   }, {});
 };
@@ -4163,7 +4166,7 @@ const deserializeAws_restJson1DenseStringMap = (output: any, context: __SerdeCon
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -4193,15 +4196,11 @@ const deserializeAws_restJson1MyUnion = (output: any, context: __SerdeContext): 
       blobValue: context.base64Decoder(output.blobValue),
     };
   }
-  if (output.booleanValue !== undefined && output.booleanValue !== null) {
-    return {
-      booleanValue: output.booleanValue,
-    };
+  if (__expectBoolean(output.booleanValue) !== undefined) {
+    return { booleanValue: __expectBoolean(output.booleanValue) as any };
   }
-  if (output.enumValue !== undefined && output.enumValue !== null) {
-    return {
-      enumValue: output.enumValue,
-    };
+  if (__expectString(output.enumValue) !== undefined) {
+    return { enumValue: __expectString(output.enumValue) as any };
   }
   if (output.listValue !== undefined && output.listValue !== null) {
     return {
@@ -4213,20 +4212,16 @@ const deserializeAws_restJson1MyUnion = (output: any, context: __SerdeContext): 
       mapValue: deserializeAws_restJson1StringMap(output.mapValue, context),
     };
   }
-  if (output.numberValue !== undefined && output.numberValue !== null) {
-    return {
-      numberValue: output.numberValue,
-    };
+  if (__expectNumber(output.numberValue) !== undefined) {
+    return { numberValue: __expectNumber(output.numberValue) as any };
   }
   if (output.renamedStructureValue !== undefined && output.renamedStructureValue !== null) {
     return {
       renamedStructureValue: deserializeAws_restJson1RenamedGreeting(output.renamedStructureValue, context),
     };
   }
-  if (output.stringValue !== undefined && output.stringValue !== null) {
-    return {
-      stringValue: output.stringValue,
-    };
+  if (__expectString(output.stringValue) !== undefined) {
+    return { stringValue: __expectString(output.stringValue) as any };
   }
   if (output.structureValue !== undefined && output.structureValue !== null) {
     return {
@@ -4243,8 +4238,8 @@ const deserializeAws_restJson1MyUnion = (output: any, context: __SerdeContext): 
 
 const deserializeAws_restJson1NestedPayload = (output: any, context: __SerdeContext): NestedPayload => {
   return {
-    greeting: output.greeting !== undefined && output.greeting !== null ? output.greeting : undefined,
-    name: output.name !== undefined && output.name !== null ? output.name : undefined,
+    greeting: __expectString(output.greeting),
+    name: __expectString(output.name),
   } as any;
 };
 
@@ -4253,7 +4248,7 @@ const deserializeAws_restJson1RecursiveShapesInputOutputNested1 = (
   context: __SerdeContext
 ): RecursiveShapesInputOutputNested1 => {
   return {
-    foo: output.foo !== undefined && output.foo !== null ? output.foo : undefined,
+    foo: __expectString(output.foo),
     nested:
       output.nested !== undefined && output.nested !== null
         ? deserializeAws_restJson1RecursiveShapesInputOutputNested2(output.nested, context)
@@ -4266,7 +4261,7 @@ const deserializeAws_restJson1RecursiveShapesInputOutputNested2 = (
   context: __SerdeContext
 ): RecursiveShapesInputOutputNested2 => {
   return {
-    bar: output.bar !== undefined && output.bar !== null ? output.bar : undefined,
+    bar: __expectString(output.bar),
     recursiveMember:
       output.recursiveMember !== undefined && output.recursiveMember !== null
         ? deserializeAws_restJson1RecursiveShapesInputOutputNested1(output.recursiveMember, context)
@@ -4281,7 +4276,7 @@ const deserializeAws_restJson1SparseBooleanMap = (output: any, context: __SerdeC
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectBoolean(value) as any,
     };
   }, {});
 };
@@ -4293,7 +4288,7 @@ const deserializeAws_restJson1SparseNumberMap = (output: any, context: __SerdeCo
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectNumber(value) as any,
     };
   }, {});
 };
@@ -4326,14 +4321,14 @@ const deserializeAws_restJson1StructureList = (output: any, context: __SerdeCont
 
 const deserializeAws_restJson1StructureListMember = (output: any, context: __SerdeContext): StructureListMember => {
   return {
-    a: output.value !== undefined && output.value !== null ? output.value : undefined,
-    b: output.other !== undefined && output.other !== null ? output.other : undefined,
+    a: __expectString(output.value),
+    b: __expectString(output.other),
   } as any;
 };
 
 const deserializeAws_restJson1RenamedGreeting = (output: any, context: __SerdeContext): RenamedGreeting => {
   return {
-    salutation: output.salutation !== undefined && output.salutation !== null ? output.salutation : undefined,
+    salutation: __expectString(output.salutation),
   } as any;
 };
 
@@ -4344,7 +4339,7 @@ const deserializeAws_restJson1BooleanList = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectBoolean(entry) as any;
     });
 };
 
@@ -4355,7 +4350,7 @@ const deserializeAws_restJson1FooEnumList = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4369,7 +4364,7 @@ const deserializeAws_restJson1FooEnumMap = (
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -4381,13 +4376,13 @@ const deserializeAws_restJson1FooEnumSet = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
 const deserializeAws_restJson1GreetingStruct = (output: any, context: __SerdeContext): GreetingStruct => {
   return {
-    hi: output.hi !== undefined && output.hi !== null ? output.hi : undefined,
+    hi: __expectString(output.hi),
   } as any;
 };
 
@@ -4398,7 +4393,7 @@ const deserializeAws_restJson1IntegerList = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectNumber(entry) as any;
     });
 };
 
@@ -4418,7 +4413,7 @@ const deserializeAws_restJson1SparseStringList = (output: any, context: __SerdeC
     if (entry === null) {
       return null as any;
     }
-    return entry;
+    return __expectString(entry) as any;
   });
 };
 
@@ -4429,7 +4424,7 @@ const deserializeAws_restJson1SparseStringMap = (output: any, context: __SerdeCo
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -4441,7 +4436,7 @@ const deserializeAws_restJson1StringList = (output: any, context: __SerdeContext
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -4452,7 +4447,7 @@ const deserializeAws_restJson1StringMap = (output: any, context: __SerdeContext)
     }
     return {
       ...acc,
-      [key]: value,
+      [key]: __expectString(value) as any,
     };
   }, {});
 };
@@ -4464,7 +4459,7 @@ const deserializeAws_restJson1StringSet = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 

--- a/protocol_tests/aws-restxml/protocols/Aws_restXml.ts
+++ b/protocol_tests/aws-restxml/protocols/Aws_restXml.ts
@@ -157,6 +157,7 @@ import {
 import {
   SmithyException as __SmithyException,
   dateToUtcString as __dateToUtcString,
+  expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
@@ -3270,7 +3271,7 @@ export const deserializeAws_restXmlIgnoreQueryParamsInResponseCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data["baz"] !== undefined) {
-    contents.baz = data["baz"];
+    contents.baz = __expectString(data["baz"]);
   }
   return Promise.resolve(contents);
 };
@@ -3935,7 +3936,7 @@ export const deserializeAws_restXmlSimpleScalarPropertiesCommand = async (
     contents.shortValue = parseInt(data["shortValue"]);
   }
   if (data["stringValue"] !== undefined) {
-    contents.stringValue = data["stringValue"];
+    contents.stringValue = __expectString(data["stringValue"]);
   }
   if (data["trueBooleanValue"] !== undefined) {
     contents.trueBooleanValue = __parseBoolean(data["trueBooleanValue"]);
@@ -4057,10 +4058,10 @@ export const deserializeAws_restXmlXmlAttributesCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data["test"] !== undefined) {
-    contents.attr = data["test"];
+    contents.attr = __expectString(data["test"]);
   }
   if (data["foo"] !== undefined) {
-    contents.foo = data["foo"];
+    contents.foo = __expectString(data["foo"]);
   }
   return Promise.resolve(contents);
 };
@@ -4476,7 +4477,7 @@ export const deserializeAws_restXmlXmlEmptyStringsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data["emptyString"] !== undefined) {
-    contents.emptyString = data["emptyString"];
+    contents.emptyString = __expectString(data["emptyString"]);
   }
   return Promise.resolve(contents);
 };
@@ -4528,13 +4529,13 @@ export const deserializeAws_restXmlXmlEnumsCommand = async (
   };
   const data: any = await parseBody(output.body, context);
   if (data["fooEnum1"] !== undefined) {
-    contents.fooEnum1 = data["fooEnum1"];
+    contents.fooEnum1 = __expectString(data["fooEnum1"]);
   }
   if (data["fooEnum2"] !== undefined) {
-    contents.fooEnum2 = data["fooEnum2"];
+    contents.fooEnum2 = __expectString(data["fooEnum2"]);
   }
   if (data["fooEnum3"] !== undefined) {
-    contents.fooEnum3 = data["fooEnum3"];
+    contents.fooEnum3 = __expectString(data["fooEnum3"]);
   }
   if (data.fooEnumList === "") {
     contents.fooEnumList = [];
@@ -5051,7 +5052,7 @@ const deserializeAws_restXmlComplexErrorResponse = async (
     contents.Nested = deserializeAws_restXmlComplexNestedErrorData(data["Nested"], context);
   }
   if (data["TopLevel"] !== undefined) {
-    contents.TopLevel = data["TopLevel"];
+    contents.TopLevel = __expectString(data["TopLevel"]);
   }
   return contents;
 };
@@ -5068,7 +5069,7 @@ const deserializeAws_restXmlInvalidGreetingResponse = async (
   };
   const data: any = parsedOutput.body.Error;
   if (data["Message"] !== undefined) {
-    contents.Message = data["Message"];
+    contents.Message = __expectString(data["Message"]);
   }
   return contents;
 };
@@ -5551,7 +5552,7 @@ const deserializeAws_restXmlComplexNestedErrorData = (output: any, context: __Se
     Foo: undefined,
   };
   if (output["Foo"] !== undefined) {
-    contents.Foo = output["Foo"];
+    contents.Foo = __expectString(output["Foo"]);
   }
   return contents;
 };
@@ -5566,7 +5567,7 @@ const deserializeAws_restXmlFlattenedXmlMapWithXmlNameInputOutputMap = (
     }
     return {
       ...acc,
-      [pair["K"]]: pair["V"],
+      [pair["K"]]: __expectString(pair["V"]) as any,
     };
   }, {});
 };
@@ -5581,7 +5582,7 @@ const deserializeAws_restXmlFlattenedXmlMapWithXmlNamespaceOutputMap = (
     }
     return {
       ...acc,
-      [pair["K"]]: pair["V"],
+      [pair["K"]]: __expectString(pair["V"]) as any,
     };
   }, {});
 };
@@ -5593,7 +5594,7 @@ const deserializeAws_restXmlListWithMemberNamespace = (output: any, context: __S
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -5604,7 +5605,7 @@ const deserializeAws_restXmlListWithNamespace = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -5629,10 +5630,10 @@ const deserializeAws_restXmlNestedPayload = (output: any, context: __SerdeContex
     name: undefined,
   };
   if (output["greeting"] !== undefined) {
-    contents.greeting = output["greeting"];
+    contents.greeting = __expectString(output["greeting"]);
   }
   if (output["name"] !== undefined) {
-    contents.name = output["name"];
+    contents.name = __expectString(output["name"]);
   }
   return contents;
 };
@@ -5642,7 +5643,7 @@ const deserializeAws_restXmlPayloadWithXmlName = (output: any, context: __SerdeC
     name: undefined,
   };
   if (output["name"] !== undefined) {
-    contents.name = output["name"];
+    contents.name = __expectString(output["name"]);
   }
   return contents;
 };
@@ -5655,7 +5656,7 @@ const deserializeAws_restXmlPayloadWithXmlNamespace = (
     name: undefined,
   };
   if (output["name"] !== undefined) {
-    contents.name = output["name"];
+    contents.name = __expectString(output["name"]);
   }
   return contents;
 };
@@ -5668,7 +5669,7 @@ const deserializeAws_restXmlPayloadWithXmlNamespaceAndPrefix = (
     name: undefined,
   };
   if (output["name"] !== undefined) {
-    contents.name = output["name"];
+    contents.name = __expectString(output["name"]);
   }
   return contents;
 };
@@ -5682,7 +5683,7 @@ const deserializeAws_restXmlRecursiveShapesInputOutputNested1 = (
     nested: undefined,
   };
   if (output["foo"] !== undefined) {
-    contents.foo = output["foo"];
+    contents.foo = __expectString(output["foo"]);
   }
   if (output["nested"] !== undefined) {
     contents.nested = deserializeAws_restXmlRecursiveShapesInputOutputNested2(output["nested"], context);
@@ -5699,7 +5700,7 @@ const deserializeAws_restXmlRecursiveShapesInputOutputNested2 = (
     recursiveMember: undefined,
   };
   if (output["bar"] !== undefined) {
-    contents.bar = output["bar"];
+    contents.bar = __expectString(output["bar"]);
   }
   if (output["recursiveMember"] !== undefined) {
     contents.recursiveMember = deserializeAws_restXmlRecursiveShapesInputOutputNested1(
@@ -5717,7 +5718,7 @@ const deserializeAws_restXmlRenamedListMembers = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -5738,10 +5739,10 @@ const deserializeAws_restXmlStructureListMember = (output: any, context: __Serde
     b: undefined,
   };
   if (output["value"] !== undefined) {
-    contents.a = output["value"];
+    contents.a = __expectString(output["value"]);
   }
   if (output["other"] !== undefined) {
-    contents.b = output["other"];
+    contents.b = __expectString(output["other"]);
   }
   return contents;
 };
@@ -5755,10 +5756,10 @@ const deserializeAws_restXmlXmlAttributesInputOutput = (
     attr: undefined,
   };
   if (output["foo"] !== undefined) {
-    contents.foo = output["foo"];
+    contents.foo = __expectString(output["foo"]);
   }
   if (output["test"] !== undefined) {
-    contents.attr = output["test"];
+    contents.attr = __expectString(output["test"]);
   }
   return contents;
 };
@@ -5800,7 +5801,7 @@ const deserializeAws_restXmlXmlNamespacedList = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -5810,7 +5811,7 @@ const deserializeAws_restXmlXmlNamespaceNested = (output: any, context: __SerdeC
     values: undefined,
   };
   if (output["foo"] !== undefined) {
-    contents.foo = output["foo"];
+    contents.foo = __expectString(output["foo"]);
   }
   if (output.values === "") {
     contents.values = [];
@@ -5836,7 +5837,7 @@ const deserializeAws_restXmlXmlNestedUnionStruct = (output: any, context: __Serd
     doubleValue: undefined,
   };
   if (output["stringValue"] !== undefined) {
-    contents.stringValue = output["stringValue"];
+    contents.stringValue = __expectString(output["stringValue"]);
   }
   if (output["booleanValue"] !== undefined) {
     contents.booleanValue = __parseBoolean(output["booleanValue"]);
@@ -5865,7 +5866,7 @@ const deserializeAws_restXmlXmlNestedUnionStruct = (output: any, context: __Serd
 const deserializeAws_restXmlXmlUnionShape = (output: any, context: __SerdeContext): XmlUnionShape => {
   if (output["stringValue"] !== undefined) {
     return {
-      stringValue: output["stringValue"],
+      stringValue: __expectString(output["stringValue"]) as any,
     };
   }
   if (output["booleanValue"] !== undefined) {
@@ -5934,7 +5935,7 @@ const deserializeAws_restXmlFooEnumList = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -5948,7 +5949,7 @@ const deserializeAws_restXmlFooEnumMap = (
     }
     return {
       ...acc,
-      [pair["key"]]: pair["value"],
+      [pair["key"]]: __expectString(pair["value"]) as any,
     };
   }, {});
 };
@@ -5960,7 +5961,7 @@ const deserializeAws_restXmlFooEnumSet = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -5969,7 +5970,7 @@ const deserializeAws_restXmlGreetingStruct = (output: any, context: __SerdeConte
     hi: undefined,
   };
   if (output["hi"] !== undefined) {
-    contents.hi = output["hi"];
+    contents.hi = __expectString(output["hi"]);
   }
   return contents;
 };
@@ -6003,7 +6004,7 @@ const deserializeAws_restXmlStringList = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 
@@ -6014,7 +6015,7 @@ const deserializeAws_restXmlStringSet = (output: any, context: __SerdeContext): 
       if (entry === null) {
         return null as any;
       }
-      return entry;
+      return __expectString(entry) as any;
     });
 };
 


### PR DESCRIPTION
### Issue

n/a

### Description

This adds expectations for the default member deserialization so that an error will be thrown if the type being deserialized isn't correct.

### Testing

Tests were added.

### Additional context

See https://github.com/awslabs/smithy-typescript/pull/365 for the other half of this

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
